### PR TITLE
fix(orchestration): ci-wait sanitizes stale GH_TOKEN like bot-review-wait (closes #19)

### DIFF
--- a/skills/orchestration/README.md
+++ b/skills/orchestration/README.md
@@ -51,7 +51,7 @@ Set in `.env` or `.env.local`, or export in the shell. Helper scripts source bot
 | `BOT_REVIEWERS` | Comma-separated review bot usernames | auto-detect |
 | `BOT_CHECK_NAME` | CI check name for early review detection | — |
 
-`bot-review-wait --json` fails fast with JSON `status: "error"` when GitHub auth/API reads are not reliable. If an invalid `GH_TOKEN`/`GITHUB_TOKEN` masks working `gh` keyring auth, it unsets those variables for the wait process and continues with a warning.
+`bot-review-wait --json` fails fast with JSON `status: "error"` when GitHub auth/API reads are not reliable. Both `bot-review-wait` and `ci-wait` source `scripts/lib/gh-auth.sh`: if an invalid `GH_TOKEN`/`GITHUB_TOKEN` masks working `gh` keyring auth, the wait process unsets those variables and continues with a warning so a stale inherited token does not 401 every API call.
 
 ## System Dependencies
 

--- a/skills/orchestration/README.md
+++ b/skills/orchestration/README.md
@@ -51,7 +51,15 @@ Set in `.env` or `.env.local`, or export in the shell. Helper scripts source bot
 | `BOT_REVIEWERS` | Comma-separated review bot usernames | auto-detect |
 | `BOT_CHECK_NAME` | CI check name for early review detection | — |
 
-`bot-review-wait --json` fails fast with JSON `status: "error"` when GitHub auth/API reads are not reliable. Both `bot-review-wait` and `ci-wait` source `scripts/lib/gh-auth.sh`: if an invalid `GH_TOKEN`/`GITHUB_TOKEN` masks working `gh` keyring auth, the wait process unsets those variables and continues with a warning so a stale inherited token does not 401 every API call.
+`bot-review-wait --json` fails fast with JSON `status: "error"` when GitHub auth/API reads are not reliable. Both `bot-review-wait` and `ci-wait` source `scripts/lib/gh-auth.sh` for a four-step auth ladder: (1) sanitize stale `GH_TOKEN`/`GITHUB_TOKEN` that mask working `gh` keyring auth (warns on stderr and unsets); (2) if `GH_TOKEN` ends up empty, load a valid `GH_BOT_TOKEN` from `.env.local`/`.env` (`op://` references resolved via `op read`); (3) on remaining auth failure, drop env tokens and retry the bot-token load so a stale env token plus broken keyring still recovers if `.env.local` provides a valid bot token; (4) if no auth path works, exit `3` with a clear diagnostic.
+
+## Tests
+
+```
+bash skills/orchestration/tests/run-all.sh
+```
+
+Runs every script-level regression test (`bot_review_wait.sh`, `ci_wait.sh`). Each test stages a temp repo with a parametrized `gh` stub on `PATH` and exercises every rung of the auth ladder — stale-token sanitize, keyring fallback, `.env.local` `GH_BOT_TOKEN` fallback, and the hard “no working auth path” exit (code `3`).
 
 ## System Dependencies
 

--- a/skills/orchestration/SKILL.md
+++ b/skills/orchestration/SKILL.md
@@ -165,7 +165,7 @@ When executing a command's workflow, follow ALL [Workflow Execution](#workflow-e
 | `ci-wait` | Block until CI completes on a PR — same |
 | `session-init` | Initialize session state for a new worktree (called by `initialize.md`) |
 
-`bot-review-wait --json` returns `status: "error"` and exits non-zero on GitHub auth/API failures instead of polling until timeout with empty output. When a bad `GH_TOKEN`/`GITHUB_TOKEN` masks working `gh` keyring auth, it unsets those variables for the wait process and continues with a warning.
+`bot-review-wait --json` returns `status: "error"` and exits non-zero on GitHub auth/API failures instead of polling until timeout with empty output. Both `bot-review-wait` and `ci-wait` share the `scripts/lib/gh-auth.sh` guard: when a bad `GH_TOKEN`/`GITHUB_TOKEN` masks working `gh` keyring auth, they unset those variables for the wait process and continue with a warning.
 
 ### `workflow-state` actions
 

--- a/skills/orchestration/SKILL.md
+++ b/skills/orchestration/SKILL.md
@@ -165,7 +165,13 @@ When executing a command's workflow, follow ALL [Workflow Execution](#workflow-e
 | `ci-wait` | Block until CI completes on a PR — same |
 | `session-init` | Initialize session state for a new worktree (called by `initialize.md`) |
 
-`bot-review-wait --json` returns `status: "error"` and exits non-zero on GitHub auth/API failures instead of polling until timeout with empty output. Both `bot-review-wait` and `ci-wait` share the `scripts/lib/gh-auth.sh` guard: when a bad `GH_TOKEN`/`GITHUB_TOKEN` masks working `gh` keyring auth, they unset those variables for the wait process and continue with a warning.
+`bot-review-wait --json` returns `status: "error"` and exits non-zero on GitHub auth/API failures instead of polling until timeout with empty output.
+
+Both `bot-review-wait` and `ci-wait` share `scripts/lib/gh-auth.sh` for a four-step auth-resolution ladder: (1) sanitize stale `GH_TOKEN`/`GITHUB_TOKEN` that mask working `gh` keyring auth and continue with a warning; (2) when `GH_TOKEN` ends up empty, load a valid `GH_BOT_TOKEN` from `.env.local`/`.env` (`op://` references resolved via `op read`); (3) on a remaining auth failure, drop env tokens and retry the bot-token load so a stale env token plus broken keyring still recovers if `.env.local` provides a valid bot token; (4) if no auth path works, exit `3` with a clear diagnostic. Exit `3` matches `bot-review-wait`'s auth-error exit so callers can treat the two consistently.
+
+### Tests
+
+`bash skills/orchestration/tests/run-all.sh` runs every script-level regression test (`bot_review_wait.sh`, `ci_wait.sh`). Each test stages a temp repo with a parametrized `gh` stub on `PATH` and exercises every rung of the auth ladder: stale-token sanitize, keyring fallback, `.env.local` `GH_BOT_TOKEN` fallback, and the hard “no working auth path” exit.
 
 ### `workflow-state` actions
 

--- a/skills/orchestration/scripts/bot-review-wait
+++ b/skills/orchestration/scripts/bot-review-wait
@@ -131,6 +131,15 @@ ensure_gh_ready() {
     return 0
   fi
 
+  # Final fallback: a stale env token plus broken keyring may still recover
+  # if .env.local/.env carries a valid GH_BOT_TOKEN. Drop any remaining
+  # stale env token first so we are not just retrying the bad one.
+  unset GH_TOKEN GITHUB_TOKEN
+  if orchestration_load_env_bot_token "$PROJECT_ROOT" && \
+     gh auth status >/dev/null 2>&1; then
+    return 0
+  fi
+
   printf '%s\n' "$auth_output" >&2
   return 1
 }

--- a/skills/orchestration/scripts/bot-review-wait
+++ b/skills/orchestration/scripts/bot-review-wait
@@ -64,6 +64,10 @@ fi
 # shellcheck source=/dev/null
 source "$GH_LIB"
 
+# Shared GH_TOKEN/GITHUB_TOKEN sanitizer (see lib/gh-auth.sh).
+# shellcheck source=lib/gh-auth.sh
+source "$SCRIPT_DIR/lib/gh-auth.sh"
+
 # --- arg parse ---
 JSON_OUTPUT=false
 REVIEWERS_ARG=""
@@ -122,10 +126,8 @@ ensure_gh_ready() {
   # A bad GH_TOKEN/GITHUB_TOKEN masks gh keyring auth. If keyring auth works
   # with those variables removed, prefer the working auth source instead of
   # polling until timeout with every API read degraded to "unknown".
-  if [[ -n "${GH_TOKEN:-}${GITHUB_TOKEN:-}" ]] && \
-     env -u GH_TOKEN -u GITHUB_TOKEN gh auth status >/dev/null 2>&1; then
-    echo "Warning: GH_TOKEN/GITHUB_TOKEN failed gh auth; unsetting them and using gh keyring auth." >&2
-    unset GH_TOKEN GITHUB_TOKEN
+  orchestration_sanitize_gh_env
+  if gh auth status >/dev/null 2>&1; then
     return 0
   fi
 

--- a/skills/orchestration/scripts/ci-wait
+++ b/skills/orchestration/scripts/ci-wait
@@ -7,11 +7,24 @@
 #
 # Usage: ci-wait <PR#> [poll_interval] [max_wait]
 #
+# Auth: stale GH_TOKEN/GITHUB_TOKEN env vars that mask working `gh` keyring
+# auth are detected and unset before any `gh` call (see vstack#19). After
+# that, .env / .env.local GH_BOT_TOKEN is loaded only when GH_TOKEN is empty,
+# matching skills/github/scripts/github.sh.
+#
 # Environment:
 #   GIT_HOST_CLI  - (optional) Path to git host CLI script for enriched output
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+# Sanitize stale GH_TOKEN/GITHUB_TOKEN that mask working `gh` keyring auth.
+# Must run before any `gh` call so a bad inherited token does not 401 every
+# request. Mirrors the guard in bot-review-wait.
+# shellcheck source=lib/gh-auth.sh
+source "$SCRIPT_DIR/lib/gh-auth.sh"
+orchestration_sanitize_gh_env
 
 # --- Auth: mirror skills/github/scripts/github.sh — only override when GH_TOKEN unset ---
 if [ -z "${GH_TOKEN:-}" ]; then

--- a/skills/orchestration/scripts/ci-wait
+++ b/skills/orchestration/scripts/ci-wait
@@ -7,10 +7,18 @@
 #
 # Usage: ci-wait <PR#> [poll_interval] [max_wait]
 #
-# Auth: stale GH_TOKEN/GITHUB_TOKEN env vars that mask working `gh` keyring
-# auth are detected and unset before any `gh` call (see vstack#19). After
-# that, .env / .env.local GH_BOT_TOKEN is loaded only when GH_TOKEN is empty,
-# matching skills/github/scripts/github.sh.
+# Auth resolution ladder (see vstack#19):
+#   1. orchestration_sanitize_gh_env — drop stale GH_TOKEN/GITHUB_TOKEN
+#      env vars that mask working `gh` keyring auth.
+#   2. If GH_TOKEN ended up empty (never set, or step 1 cleared it), match
+#      skills/github/scripts/github.sh and load a .env.local/.env
+#      GH_BOT_TOKEN if one is present.
+#   3. If the current `gh auth status` still fails, drop any remaining
+#      stale env token and retry the GH_BOT_TOKEN load — covers the
+#      stale-env-token + bad-keyring + valid-bot-token combination.
+#   4. If no auth path works after that, exit 3 with a clear diagnostic.
+#      Exit 3 matches bot-review-wait's auth-error exit so callers can
+#      treat the two consistently.
 #
 # Environment:
 #   GIT_HOST_CLI  - (optional) Path to git host CLI script for enriched output
@@ -19,36 +27,32 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 
-# Sanitize stale GH_TOKEN/GITHUB_TOKEN that mask working `gh` keyring auth.
-# Must run before any `gh` call so a bad inherited token does not 401 every
-# request. Mirrors the guard in bot-review-wait.
 # shellcheck source=lib/gh-auth.sh
 source "$SCRIPT_DIR/lib/gh-auth.sh"
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "ci-wait: gh CLI not found on PATH" >&2
+  exit 3
+fi
+
 orchestration_sanitize_gh_env
 
-# --- Auth: mirror skills/github/scripts/github.sh — only override when GH_TOKEN unset ---
-if [ -z "${GH_TOKEN:-}" ]; then
-  for _env_file in "$PROJECT_ROOT/.env.local" "$PROJECT_ROOT/.env"; do
-    if [ -f "$_env_file" ]; then
-      _env_bot_token=$(
-        set +u
-        # shellcheck disable=SC1090
-        source "$_env_file" >/dev/null 2>&1 || true
-        printf '%s' "${GH_BOT_TOKEN:-}"
-      )
-      if [ -n "$_env_bot_token" ]; then
-        if [[ "$_env_bot_token" == op://* ]] && command -v op &>/dev/null; then
-          _resolved=$(op read "$_env_bot_token" 2>/dev/null || true)
-          [ -n "$_resolved" ] && _env_bot_token="$_resolved"
-        fi
-        if [[ "$_env_bot_token" =~ ^gh[pors]_ ]] || [[ "$_env_bot_token" =~ ^github_pat_ ]]; then
-          export GH_TOKEN="$_env_bot_token"
-        fi
-        break
-      fi
-    fi
-  done
-  unset _env_file _env_bot_token _resolved
+if [[ -z "${GH_TOKEN:-}" ]]; then
+  orchestration_load_env_bot_token "$PROJECT_ROOT" || true
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+  unset GH_TOKEN GITHUB_TOKEN
+  orchestration_load_env_bot_token "$PROJECT_ROOT" || true
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+  {
+    echo "ci-wait: no working GitHub auth path."
+    echo "Tried: env GH_TOKEN/GITHUB_TOKEN, gh keyring, .env.local/.env GH_BOT_TOKEN."
+    echo "Run: gh auth login   (or set a valid GH_BOT_TOKEN in .env.local)."
+  } >&2
+  exit 3
 fi
 
 PR_NUM="${1:?Usage: ci-wait <PR#> [poll_interval] [max_wait]}"

--- a/skills/orchestration/scripts/lib/gh-auth.sh
+++ b/skills/orchestration/scripts/lib/gh-auth.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Shared auth helper for orchestration scripts that shell out to `gh`.
+#
+# Source this file; do not execute it directly.
+#
+# orchestration_sanitize_gh_env
+#   Detect when GH_TOKEN/GITHUB_TOKEN are set but cause `gh` to fail auth,
+#   while `gh` keyring auth would succeed with those variables unset. In
+#   that case, emit a warning and unset both so subsequent `gh` calls in
+#   the same shell fall back to the keyring.
+#
+#   No-op when:
+#     - `gh` is not on PATH
+#     - Neither GH_TOKEN nor GITHUB_TOKEN is set
+#     - The current `gh auth status` already succeeds
+#
+#   Always returns 0. Callers that need a hard auth gate should re-check
+#   `gh auth status` afterward and handle failure themselves.
+
+orchestration_sanitize_gh_env() {
+  command -v gh >/dev/null 2>&1 || return 0
+  [[ -z "${GH_TOKEN:-}${GITHUB_TOKEN:-}" ]] && return 0
+  if gh auth status >/dev/null 2>&1; then
+    return 0
+  fi
+  if env -u GH_TOKEN -u GITHUB_TOKEN gh auth status >/dev/null 2>&1; then
+    echo "Warning: GH_TOKEN/GITHUB_TOKEN failed gh auth; unsetting them and using gh keyring auth." >&2
+    unset GH_TOKEN GITHUB_TOKEN
+  fi
+  return 0
+}

--- a/skills/orchestration/scripts/lib/gh-auth.sh
+++ b/skills/orchestration/scripts/lib/gh-auth.sh
@@ -1,21 +1,29 @@
 #!/usr/bin/env bash
-# Shared auth helper for orchestration scripts that shell out to `gh`.
+# Shared auth helpers for orchestration scripts that shell out to `gh`.
 #
 # Source this file; do not execute it directly.
 #
-# orchestration_sanitize_gh_env
-#   Detect when GH_TOKEN/GITHUB_TOKEN are set but cause `gh` to fail auth,
-#   while `gh` keyring auth would succeed with those variables unset. In
-#   that case, emit a warning and unset both so subsequent `gh` calls in
-#   the same shell fall back to the keyring.
+# Two functions are exposed. Together they form the auth-resolution ladder
+# used by ci-wait and bot-review-wait:
 #
-#   No-op when:
-#     - `gh` is not on PATH
-#     - Neither GH_TOKEN nor GITHUB_TOKEN is set
-#     - The current `gh auth status` already succeeds
+#   1. orchestration_sanitize_gh_env
+#      Detect when GH_TOKEN/GITHUB_TOKEN are set but cause `gh` to fail
+#      auth, while `gh` keyring auth would succeed with those variables
+#      unset. In that case, emit a warning and unset both so subsequent
+#      `gh` calls in the same shell fall back to the keyring.
 #
-#   Always returns 0. Callers that need a hard auth gate should re-check
-#   `gh auth status` afterward and handle failure themselves.
+#      No-op when `gh` is missing, when no env tokens are set, or when
+#      the current `gh auth status` already succeeds. Always returns 0.
+#
+#   2. orchestration_load_env_bot_token <project_root>
+#      Look for `GH_BOT_TOKEN` in `<project_root>/.env.local` then
+#      `<project_root>/.env` (`.env.local` wins). Resolve `op://`
+#      references via `op read` when available. If the resolved value
+#      looks like a GitHub token, export it as GH_TOKEN and return 0.
+#      Returns 1 if nothing valid was found.
+#
+#      Implemented as a subshell `source` so unrelated `.env` variables
+#      do not leak into the caller. Mirrors skills/github/scripts/github.sh.
 
 orchestration_sanitize_gh_env() {
   command -v gh >/dev/null 2>&1 || return 0
@@ -28,4 +36,28 @@ orchestration_sanitize_gh_env() {
     unset GH_TOKEN GITHUB_TOKEN
   fi
   return 0
+}
+
+orchestration_load_env_bot_token() {
+  local project_root="${1:?orchestration_load_env_bot_token: project_root required}"
+  local env_file resolved bot_token
+  for env_file in "$project_root/.env.local" "$project_root/.env"; do
+    [[ -f "$env_file" ]] || continue
+    bot_token=$(
+      set +u
+      # shellcheck disable=SC1090
+      source "$env_file" >/dev/null 2>&1 || true
+      printf '%s' "${GH_BOT_TOKEN:-}"
+    )
+    [[ -n "$bot_token" ]] || continue
+    if [[ "$bot_token" == op://* ]] && command -v op >/dev/null 2>&1; then
+      resolved=$(op read "$bot_token" 2>/dev/null || true)
+      [[ -n "$resolved" ]] && bot_token="$resolved"
+    fi
+    if [[ "$bot_token" =~ ^gh[pors]_ ]] || [[ "$bot_token" =~ ^github_pat_ ]]; then
+      export GH_TOKEN="$bot_token"
+      return 0
+    fi
+  done
+  return 1
 }

--- a/skills/orchestration/tests/ci_wait.sh
+++ b/skills/orchestration/tests/ci_wait.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
-# Regression tests for orchestration/scripts/ci-wait.
-# Verifies the stale-GH_TOKEN sanitizer from lib/gh-auth.sh kicks in before
-# the first `gh` call (vstack#19).
+# Regression tests for orchestration/scripts/ci-wait auth ladder.
+#
+# Covers vstack#19 plus the follow-up review:
+#   1. stale GH_TOKEN + working keyring  -> sanitizer unsets, ci-wait passes
+#   2. no env tokens + working keyring   -> no warning, ci-wait passes
+#   3. stale GH_TOKEN + broken keyring + no .env.local bot token
+#                                        -> exit 3 with "no working" diagnostic
+#   4. stale GH_TOKEN + broken keyring + valid .env.local GH_BOT_TOKEN
+#                                        -> bot-token fallback recovers
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -12,33 +18,43 @@ trap 'rm -rf "$TMP_ROOT"' EXIT
 PASS=0
 FAIL=0
 
+dump_stderr() {
+  local file="$1"
+  [[ -n "$file" && -f "$file" ]] || return 0
+  printf '        stderr:\n'
+  sed 's/^/          /' "$file"
+}
+
 assert_eq() {
-  local got="$1" want="$2" name="$3"
+  local got="$1" want="$2" name="$3" stderr_file="${4:-}"
   if [[ "$got" == "$want" ]]; then
     PASS=$((PASS + 1))
     printf '  ok    %s\n' "$name"
   else
     FAIL=$((FAIL + 1))
     printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$name" "$want" "$got"
+    dump_stderr "$stderr_file"
   fi
 }
 
 assert_contains() {
-  local haystack="$1" needle="$2" name="$3"
+  local haystack="$1" needle="$2" name="$3" stderr_file="${4:-}"
   if grep -qF -- "$needle" <<<"$haystack"; then
     PASS=$((PASS + 1))
     printf '  ok    %s\n' "$name"
   else
     FAIL=$((FAIL + 1))
     printf '  FAIL  %s\n        wanted substring: %s\n        in: %s\n' "$name" "$needle" "$haystack"
+    dump_stderr "$stderr_file"
   fi
 }
 
 assert_not_contains() {
-  local haystack="$1" needle="$2" name="$3"
+  local haystack="$1" needle="$2" name="$3" stderr_file="${4:-}"
   if grep -qF -- "$needle" <<<"$haystack"; then
     FAIL=$((FAIL + 1))
     printf '  FAIL  %s\n        unwanted substring: %s\n        in: %s\n' "$name" "$needle" "$haystack"
+    dump_stderr "$stderr_file"
   else
     PASS=$((PASS + 1))
     printf '  ok    %s\n' "$name"
@@ -51,41 +67,53 @@ git -C "$TMP_ROOT/repo" init -q
 git -C "$TMP_ROOT/repo" config user.email test@example.com
 git -C "$TMP_ROOT/repo" config user.name Test
 
-# Fake gh: succeeds for auth status only when no env tokens are present;
-# the same gate is applied to `pr checks` so a stale GH_TOKEN that the
-# sanitizer fails to clear would surface as an HTTP 401 like the real bug.
+# Parametrized `gh` stub.
+#   _stub_auth_ok returns 0 iff the current invocation should succeed.
+#     GH_TOKEN/GITHUB_TOKEN set    -> ok iff value matches STUB_GH_VALID_TOKEN
+#     no env tokens                 -> ok iff STUB_GH_DENY_KEYRING != 1
+#   All API endpoints (auth status, repo view, pr view, pr checks) gate on
+#   _stub_auth_ok so a stale token surfaces as HTTP 401 the same way the
+#   real `gh` does.
 cat > "$TMP_ROOT/bin/gh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
+
+_stub_auth_ok() {
+  local tok="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+  if [[ -n "$tok" ]]; then
+    [[ -n "${STUB_GH_VALID_TOKEN:-}" && "$tok" == "$STUB_GH_VALID_TOKEN" ]] && return 0
+    return 1
+  fi
+  [[ "${STUB_GH_DENY_KEYRING:-0}" == "1" ]] && return 1
+  return 0
+}
+
 case "${1:-}" in
   auth)
     if [[ "${2:-}" == "status" ]]; then
-      if [[ -n "${GH_TOKEN:-}${GITHUB_TOKEN:-}" ]]; then
-        echo "GH_TOKEN invalid" >&2
-        exit 1
+      if _stub_auth_ok; then
+        echo "Logged in"
+        exit 0
       fi
-      echo "Logged in"
-      exit 0
+      echo "auth failed" >&2
+      exit 1
     fi
     ;;
   repo)
     if [[ "${2:-}" == "view" ]]; then
-      # ci-wait calls: gh repo view --json nameWithOwner -q .nameWithOwner
+      _stub_auth_ok || { echo "HTTP 401: Bad credentials" >&2; exit 1; }
       echo "owner/repo"
       exit 0
     fi
     ;;
   pr)
     if [[ "${2:-}" == "view" ]]; then
-      # ci-wait calls: gh pr view N --repo R --json mergeStateStatus --jq '.mergeStateStatus'
+      _stub_auth_ok || { echo "HTTP 401: Bad credentials" >&2; exit 1; }
       echo "CLEAN"
       exit 0
     fi
     if [[ "${2:-}" == "checks" ]]; then
-      if [[ -n "${GH_TOKEN:-}${GITHUB_TOKEN:-}" ]]; then
-        echo "HTTP 401: Bad credentials" >&2
-        exit 1
-      fi
+      _stub_auth_ok || { echo "HTTP 401: Bad credentials" >&2; exit 1; }
       echo '[{"name":"build","state":"SUCCESS"}]'
       exit 0
     fi
@@ -96,23 +124,58 @@ exit 1
 EOF
 chmod +x "$TMP_ROOT/bin/gh"
 
+# Run ci-wait via the .agents symlink, exactly how it's invoked in
+# production. `env "$@"` injects test-controlled env tokens / stub flags.
 run_wait() {
-  (cd "$TMP_ROOT/repo" && PATH="$TMP_ROOT/bin:$PATH" "$@" .agents/skills/orchestration/scripts/ci-wait 1 1 30)
+  (cd "$TMP_ROOT/repo" \
+    && PATH="$TMP_ROOT/bin:$PATH" \
+       env "$@" .agents/skills/orchestration/scripts/ci-wait 1 1 30)
 }
 
 echo "=== ci-wait auth handling ==="
 
-# Case 1: bad GH_TOKEN inherited from caller, keyring works once unset.
+# Case 1: stale GH_TOKEN inherited from caller; keyring works once unset.
 stderr="$TMP_ROOT/case1.err"
-output=$(run_wait env GH_TOKEN=bad-token 2>"$stderr")
-assert_contains "$output" "CI passed" "bad GH_TOKEN sanitized; ci-wait reaches CI passed"
-assert_contains "$(cat "$stderr")" "unsetting them" "stale-token warning emitted to stderr"
+set +e
+output=$(run_wait GH_TOKEN=bad-token 2>"$stderr")
+rc=$?
+set -e
+assert_eq "$rc" "0" "case1: stale GH_TOKEN sanitized, ci-wait exits 0" "$stderr"
+assert_contains "$output" "CI passed" "case1: ci-wait reaches CI passed"
+assert_contains "$(cat "$stderr")" "unsetting them" "case1: stale-token warning on stderr"
 
-# Case 2: no env tokens — sanitizer must stay silent.
+# Case 2: no env tokens; keyring works directly.
 stderr="$TMP_ROOT/case2.err"
-output=$(run_wait env -u GH_TOKEN -u GITHUB_TOKEN 2>"$stderr")
-assert_contains "$output" "CI passed" "keyring auth works without env tokens"
-assert_not_contains "$(cat "$stderr")" "unsetting them" "sanitizer silent when no env tokens set"
+set +e
+output=$(run_wait 2>"$stderr")
+rc=$?
+set -e
+assert_eq "$rc" "0" "case2: keyring works without env tokens" "$stderr"
+assert_contains "$output" "CI passed" "case2: ci-wait reaches CI passed"
+assert_not_contains "$(cat "$stderr")" "unsetting them" "case2: sanitizer silent when no env tokens" "$stderr"
+
+# Case 3: stale GH_TOKEN + keyring denied + no .env.local bot token.
+rm -f "$TMP_ROOT/repo/.env.local"
+stderr="$TMP_ROOT/case3.err"
+set +e
+output=$(run_wait GH_TOKEN=bad-token STUB_GH_DENY_KEYRING=1 2>"$stderr")
+rc=$?
+set -e
+assert_eq "$rc" "3" "case3: no working auth path -> exit 3" "$stderr"
+assert_contains "$(cat "$stderr")" "no working GitHub auth path" "case3: clear diagnostic on stderr"
+
+# Case 4: stale GH_TOKEN + keyring denied + valid .env.local GH_BOT_TOKEN.
+cat > "$TMP_ROOT/repo/.env.local" <<'ENVEOF'
+export GH_BOT_TOKEN=ghs_VALIDBOT123
+ENVEOF
+stderr="$TMP_ROOT/case4.err"
+set +e
+output=$(run_wait GH_TOKEN=bad-token STUB_GH_DENY_KEYRING=1 STUB_GH_VALID_TOKEN=ghs_VALIDBOT123 2>"$stderr")
+rc=$?
+set -e
+assert_eq "$rc" "0" "case4: .env.local GH_BOT_TOKEN recovers" "$stderr"
+assert_contains "$output" "CI passed" "case4: ci-wait reaches CI passed via bot-token fallback"
+rm -f "$TMP_ROOT/repo/.env.local"
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/skills/orchestration/tests/ci_wait.sh
+++ b/skills/orchestration/tests/ci_wait.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Regression tests for orchestration/scripts/ci-wait.
+# Verifies the stale-GH_TOKEN sanitizer from lib/gh-auth.sh kicks in before
+# the first `gh` call (vstack#19).
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../.." && pwd)"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local got="$1" want="$2" name="$3"
+  if [[ "$got" == "$want" ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$name" "$want" "$got"
+  fi
+}
+
+assert_contains() {
+  local haystack="$1" needle="$2" name="$3"
+  if grep -qF -- "$needle" <<<"$haystack"; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        wanted substring: %s\n        in: %s\n' "$name" "$needle" "$haystack"
+  fi
+}
+
+assert_not_contains() {
+  local haystack="$1" needle="$2" name="$3"
+  if grep -qF -- "$needle" <<<"$haystack"; then
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        unwanted substring: %s\n        in: %s\n' "$name" "$needle" "$haystack"
+  else
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  fi
+}
+
+mkdir -p "$TMP_ROOT/repo/.agents/skills" "$TMP_ROOT/bin"
+ln -s "$REPO_ROOT/skills/orchestration" "$TMP_ROOT/repo/.agents/skills/orchestration"
+git -C "$TMP_ROOT/repo" init -q
+git -C "$TMP_ROOT/repo" config user.email test@example.com
+git -C "$TMP_ROOT/repo" config user.name Test
+
+# Fake gh: succeeds for auth status only when no env tokens are present;
+# the same gate is applied to `pr checks` so a stale GH_TOKEN that the
+# sanitizer fails to clear would surface as an HTTP 401 like the real bug.
+cat > "$TMP_ROOT/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}" in
+  auth)
+    if [[ "${2:-}" == "status" ]]; then
+      if [[ -n "${GH_TOKEN:-}${GITHUB_TOKEN:-}" ]]; then
+        echo "GH_TOKEN invalid" >&2
+        exit 1
+      fi
+      echo "Logged in"
+      exit 0
+    fi
+    ;;
+  repo)
+    if [[ "${2:-}" == "view" ]]; then
+      # ci-wait calls: gh repo view --json nameWithOwner -q .nameWithOwner
+      echo "owner/repo"
+      exit 0
+    fi
+    ;;
+  pr)
+    if [[ "${2:-}" == "view" ]]; then
+      # ci-wait calls: gh pr view N --repo R --json mergeStateStatus --jq '.mergeStateStatus'
+      echo "CLEAN"
+      exit 0
+    fi
+    if [[ "${2:-}" == "checks" ]]; then
+      if [[ -n "${GH_TOKEN:-}${GITHUB_TOKEN:-}" ]]; then
+        echo "HTTP 401: Bad credentials" >&2
+        exit 1
+      fi
+      echo '[{"name":"build","state":"SUCCESS"}]'
+      exit 0
+    fi
+    ;;
+esac
+printf 'unexpected gh call: %s\n' "$*" >&2
+exit 1
+EOF
+chmod +x "$TMP_ROOT/bin/gh"
+
+run_wait() {
+  (cd "$TMP_ROOT/repo" && PATH="$TMP_ROOT/bin:$PATH" "$@" .agents/skills/orchestration/scripts/ci-wait 1 1 30)
+}
+
+echo "=== ci-wait auth handling ==="
+
+# Case 1: bad GH_TOKEN inherited from caller, keyring works once unset.
+stderr="$TMP_ROOT/case1.err"
+output=$(run_wait env GH_TOKEN=bad-token 2>"$stderr")
+assert_contains "$output" "CI passed" "bad GH_TOKEN sanitized; ci-wait reaches CI passed"
+assert_contains "$(cat "$stderr")" "unsetting them" "stale-token warning emitted to stderr"
+
+# Case 2: no env tokens — sanitizer must stay silent.
+stderr="$TMP_ROOT/case2.err"
+output=$(run_wait env -u GH_TOKEN -u GITHUB_TOKEN 2>"$stderr")
+assert_contains "$output" "CI passed" "keyring auth works without env tokens"
+assert_not_contains "$(cat "$stderr")" "unsetting them" "sanitizer silent when no env tokens set"
+
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/skills/orchestration/tests/run-all.sh
+++ b/skills/orchestration/tests/run-all.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Run every orchestration regression test script in this directory.
+# Exits 0 if all pass, 1 if any fails. Output is per-script so a failure
+# in one file does not hide failures in another.
+set -uo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+overall=0
+ran=0
+for t in "$TEST_DIR"/*.sh; do
+  [[ -f "$t" ]] || continue
+  name=$(basename "$t")
+  [[ "$name" == "run-all.sh" ]] && continue
+  ran=$((ran + 1))
+  printf '\n### %s ###\n' "$name"
+  if ! bash "$t"; then
+    overall=1
+  fi
+done
+
+if [[ "$ran" -eq 0 ]]; then
+  echo "run-all.sh: no test scripts found under $TEST_DIR" >&2
+  exit 1
+fi
+
+if [[ "$overall" -eq 0 ]]; then
+  printf '\nrun-all: all %d test script(s) passed\n' "$ran"
+else
+  printf '\nrun-all: one or more test scripts failed\n' >&2
+fi
+
+exit "$overall"


### PR DESCRIPTION
Closes #19.

## Summary

`skills/orchestration/scripts/ci-wait` used to fail immediately with `HTTP 401: Bad credentials` against `gh`'s GraphQL endpoint when a stale `GH_TOKEN` / `GITHUB_TOKEN` was inherited from the parent shell, even though `gh auth status` worked once those env vars were unset. `bot-review-wait` already had a guard for this; `ci-wait` did not.

This PR factors the guard out of `bot-review-wait` into a small shared helper and applies it to both scripts.

## Changes

- **New helper** `skills/orchestration/scripts/lib/gh-auth.sh` exposing `orchestration_sanitize_gh_env`. No-op when `gh` is missing, when no env tokens are set, or when current `gh auth status` already succeeds. Only when env tokens are present **and** current auth fails **and** keyring auth works after `env -u GH_TOKEN -u GITHUB_TOKEN` does it warn and unset.
- **`ci-wait`** sources the helper and calls the sanitizer **before** any `gh` call (and before the existing `.env` GH_BOT_TOKEN loader, so a sanitized GH_TOKEN can still be replaced by a valid `.env.local` bot token).
- **`bot-review-wait`** `ensure_gh_ready` now calls the shared helper instead of an inline duplicate. Externally-observable behavior is preserved — same warning text, same exit codes.
- **Docs**: `SKILL.md` and `README.md` updated to describe the shared guard covering both scripts.
- **`session-init` intentionally untouched.** Its `gh_with_token` flow resolves `op://` 1Password references via `resolve_secret_ref` before passing tokens to `gh`. A naive unset on the literal `op://...` value would regress users whose GH_TOKEN points at a vault reference. A targeted fix there is a follow-up if needed; the runtime scenario in the linked incident was `ci-wait` only.

## Verification

```
bash skills/orchestration/tests/ci_wait.sh
bash skills/orchestration/tests/bot_review_wait.sh
```

`ci_wait.sh` (new) covers two cases against a stub `gh` that fails when env tokens are present:

1. `GH_TOKEN=bad-token` inherited from the caller — sanitizer detects keyring auth would work, warns on stderr, unsets, and `ci-wait` reaches `CI passed`.
2. No env tokens — sanitizer stays silent, `ci-wait` reaches `CI passed` via keyring.

Both existing `bot_review_wait.sh` assertions (including the stale-token warning) still pass after the refactor.

## Out of scope

- No CLI / Rust changes.
- No vstack version bump or release.
- Harness mirrors under `.agents/` / `.claude/` / `.opencode/` / `.pi/` are not touched; `vstack refresh` will pick up the canonical changes on next install.