### PR TITLE
fix(flightdeck): close-issue teardown uses stable pane_id, not reusable index (closes #16)

### DIFF
--- a/skills/flightdeck/lib/flightdeck-core/src/bin/pane-registry.ts
+++ b/skills/flightdeck/lib/flightdeck-core/src/bin/pane-registry.ts
@@ -442,23 +442,39 @@ function cmdReconcile(): void {
 	const issues = readIssuesJson();
 	const dropped: string[] = [];
 	const backfilled: string[] = [];
+	const drift: string[] = [];
 	for (const [issue, rec] of Object.entries(issues)) {
 		let paneId = String(rec.pane_id ?? "");
 		const paneTarget = String(rec.pane_target ?? "");
 		const win = String(rec.window ?? "");
+		const worktree = String((rec as { worktree?: string }).worktree ?? "");
+		let driftedThis = false;
 		if (!paneId && paneTarget) {
 			if (tmuxPaneExists(paneTarget)) {
-				// Guard against index reuse (#16): tmux reassigns destroyed
-				// window indices to new windows. A stale pane_target like
-				// `HT:2.1` may now point to an unrelated window (the daemon,
-				// the user's editor, ...). Backfilling pane_id from that
-				// target would adopt the WRONG pane id and turn the next
-				// teardown into a kill of the unrelated workload. Reject
-				// the backfill whenever the window name at the recorded
-				// pane_target no longer matches the issue's window.
+				// #16 backfill guard. tmux reassigns destroyed window indices,
+				// so a stale pane_target may now point at an unrelated window
+				// (daemon, editor, ...). Window-name alone is mutable and can
+				// collide; require AND of:
+				//   (a) #{window_name} == registered window
+				//   (b) #{pane_current_path} prefix-matches registered worktree
+				// If either has hard evidence of mismatch → emit drift and
+				// LEAVE the entry untouched (no adopt, no drop). Strong
+				// invariant per reviewer BLOCK #3.
 				const currentWindow = tmuxField(paneTarget, "#{window_name}");
-				const mismatched = win && currentWindow && currentWindow !== win;
-				if (!mismatched) {
+				const currentPath = tmuxField(paneTarget, "#{pane_current_path}");
+				const windowMismatch = !!(win && currentWindow && currentWindow !== win);
+				const pathMismatch = !!(
+					worktree &&
+					currentPath &&
+					currentPath !== worktree &&
+					!currentPath.startsWith(`${worktree}/`)
+				);
+				if (windowMismatch || pathMismatch) {
+					drift.push(
+						`${issue} (window:'${win}'→'${currentWindow}' worktree:'${worktree}'→'${currentPath}')`,
+					);
+					driftedThis = true;
+				} else {
 					const resolved = tmuxField(paneTarget, "#{pane_id}");
 					if (resolved) {
 						fdStateOrDie(["set", `.issues["${issue}"].pane_id`, JSON.stringify(resolved)]);
@@ -468,6 +484,7 @@ function cmdReconcile(): void {
 				}
 			}
 		}
+		if (driftedThis) continue;
 		const alive = paneId ? live.panes.has(paneId) : !win || live.windows.has(win);
 		if (!alive) {
 			fdStateOrDie(["set", ".issues", `(.issues | del(.["${issue}"]))`]);
@@ -480,17 +497,54 @@ function cmdReconcile(): void {
 	if (backfilled.length > 0) {
 		process.stdout.write(`reconciled: backfilled pane_id for ${backfilled.length} entr${backfilled.length === 1 ? "y" : "ies"} (${backfilled.join(",")})\n`);
 	}
+	if (drift.length > 0) {
+		process.stderr.write(
+			`reconciled: drift detected for ${drift.length} entr${drift.length === 1 ? "y" : "ies"}, left untouched (${drift.join("|")})\n`,
+		);
+	}
 }
 
 // ----- teardown-window -----------------------------------------------------
+//
+// Exit codes (mirror the bash sibling):
+//   0 - window/pane killed, or already closed (terminal + dead pane)
+//   1 - issue not registered (caller may treat as idempotent no-op)
+//   2 - bad arguments
+//   3 - registry drift: pane_id gone but state not terminal
+//   4 - policy: pane_id alive but state non-terminal (rerun with --force)
+//   5 - tmux kill failed: pane still alive after kill attempt
+//   6 - registry read failure
 
 const TERMINAL_STATES = new Set(["merged", "aborted", "dead"]);
 
-function cmdTeardownWindow(issue: string): void {
-	if (!issue) die("Usage: teardown-window <ISSUE>");
+function cmdTeardownWindow(args: string[]): void {
+	let issue = "";
+	let force = false;
+	for (const a of args) {
+		if (a === "--force") force = true;
+		else if (a === "--") continue;
+		else if (a.startsWith("-")) die(`teardown-window: unknown flag: ${a}`);
+		else if (!issue) issue = a;
+		else die(`teardown-window: extra argument: ${a}`);
+	}
+	if (!issue) die("Usage: teardown-window <ISSUE> [--force]");
+	// Read registry through flightdeck-state. The script returns:
+	//   exit 0 + empty stdout — state file present, lookup miss (idempotent)
+	//   exit 1                — state file does not exist (registry never initialized; idempotent)
+	//   exit >= 2             — usage error or genuine read failure
+	// Treat 0+empty and 1 as "not found" (exit 1); only exit >= 2 escalates
+	// to exit 6 (registry read failure) per BLOCK #2.
 	const r = fdState(["get", `.issues["${issue}"] // empty`]);
+	const status = r.status ?? 0;
+	if (status >= 2) {
+		process.stderr.write(
+			`teardown-window: registry read failed (flightdeck-state exit=${status}): ${r.stderr}`,
+		);
+		if (!r.stderr.endsWith("\n")) process.stderr.write("\n");
+		process.exit(6);
+	}
 	const raw = (r.stdout ?? "").trim();
-	if (!raw || raw === "null") {
+	if (status === 1 || !raw || raw === "null") {
 		process.stderr.write(`teardown-window: issue '${issue}' not found in registry\n`);
 		process.exit(1);
 	}
@@ -498,7 +552,7 @@ function cmdTeardownWindow(issue: string): void {
 	try { rec = JSON.parse(raw) as IssueRec; }
 	catch {
 		process.stderr.write(`teardown-window: malformed registry entry for '${issue}'\n`);
-		process.exit(1);
+		process.exit(6);
 	}
 	const state = String(rec.state ?? "");
 	const paneId = String(rec.pane_id ?? "");
@@ -509,15 +563,37 @@ function cmdTeardownWindow(issue: string): void {
 		paneAlive = live.has(paneId);
 	}
 	if (paneAlive) {
+		if (!TERMINAL_STATES.has(state) && !force) {
+			process.stderr.write(
+				`teardown-window: policy refusal — pane_id '${paneId}' is alive but state is '${state}' (not merged|aborted|dead); set a terminal state first or rerun with --force\n`,
+			);
+			process.exit(4);
+		}
 		const windowId = tmuxField(paneId, "#{window_id}");
 		const paneCount = windowId ? tmuxPaneCountInWindow(windowId) : 0;
+		let kind: string;
+		let killResult;
 		if (windowId && paneCount === 1) {
-			spawnSync("tmux", ["kill-window", "-t", windowId], { encoding: "utf8" });
-			process.stdout.write(`teardown-window: killed window ${windowId} (pane_id=${paneId}, window=${windowName})\n`);
+			killResult = spawnSync("tmux", ["kill-window", "-t", windowId], { encoding: "utf8" });
+			kind = `window ${windowId}`;
 		} else {
-			spawnSync("tmux", ["kill-pane", "-t", paneId], { encoding: "utf8" });
-			process.stdout.write(`teardown-window: killed pane ${paneId} (window has ${paneCount} panes, window=${windowName})\n`);
+			killResult = spawnSync("tmux", ["kill-pane", "-t", paneId], { encoding: "utf8" });
+			kind = `pane ${paneId}`;
 		}
+		// Post-kill liveness check is authoritative — not the exit code
+		// (BLOCK #1). tmux can return non-zero for benign reasons such as
+		// the pane vanishing between the alive-check and the kill.
+		const stillAlive = tmuxLivePaneIds().has(paneId);
+		if (stillAlive) {
+			process.stderr.write(
+				`teardown-window: kill of ${kind} failed (status=${killResult.status}, pane_id=${paneId} still alive): ${killResult.stderr ?? ""}`,
+			);
+			if (!(killResult.stderr ?? "").endsWith("\n")) process.stderr.write("\n");
+			process.exit(5);
+		}
+		process.stdout.write(
+			`teardown-window: killed ${kind} (pane_id=${paneId}, window=${windowName}, force=${force ? 1 : 0})\n`,
+		);
 		return;
 	}
 	if (TERMINAL_STATES.has(state)) {
@@ -551,7 +627,8 @@ switch (action) {
 	case "pi-bridge-args":  cmdPiBridgeArgs(argv[0] ?? ""); break;
 	case "cx-bridge-args":  cmdCxBridgeArgs(argv[0] ?? ""); break;
 	case "find-by-pane":    cmdFindByPane(argv[0] ?? ""); break;
-	case "teardown-window": cmdTeardownWindow(argv[0] ?? ""); break;
+	case "teardown-window":
+	case "teardown-entry":  cmdTeardownWindow(argv); break;
 	default:
-		die(`Unknown action: ${action}\nActions: init | list | get | set-state | set-substate | set | log-decision | remove | remove-merged | reconcile | teardown-window | oc-attach-args | cc-channel-args | pi-bridge-args | cx-bridge-args | find-by-pane`);
+		die(`Unknown action: ${action}\nActions: init | list | get | set-state | set-substate | set | log-decision | remove | remove-merged | reconcile | teardown-window | teardown-entry | oc-attach-args | cc-channel-args | pi-bridge-args | cx-bridge-args | find-by-pane`);
 }

--- a/skills/flightdeck/lib/flightdeck-core/src/bin/pane-registry.ts
+++ b/skills/flightdeck/lib/flightdeck-core/src/bin/pane-registry.ts
@@ -506,6 +506,9 @@ function cmdReconcile(): void {
 
 // ----- teardown-window -----------------------------------------------------
 //
+// Parity: scripts/pane-registry.bash cmd_teardown_window
+// (see tests/parity/pane-registry.test.ts).
+//
 // Exit codes (mirror the bash sibling):
 //   0 - window/pane killed, or already closed (terminal + dead pane)
 //   1 - issue not registered (caller may treat as idempotent no-op)

--- a/skills/flightdeck/lib/flightdeck-core/src/bin/pane-registry.ts
+++ b/skills/flightdeck/lib/flightdeck-core/src/bin/pane-registry.ts
@@ -59,6 +59,22 @@ function tmuxPaneExists(target: string): boolean {
 	return r.status === 0;
 }
 
+function tmuxLivePaneIds(): Set<string> {
+	const r = spawnSync("tmux", ["list-panes", "-a", "-F", "#{pane_id}"], { encoding: "utf8" });
+	const panes = new Set<string>();
+	if (r.status !== 0) return panes;
+	for (const line of (r.stdout ?? "").split("\n")) {
+		if (line) panes.add(line);
+	}
+	return panes;
+}
+
+function tmuxPaneCountInWindow(windowId: string): number {
+	const r = spawnSync("tmux", ["list-panes", "-t", windowId, "-F", "#{pane_id}"], { encoding: "utf8" });
+	if (r.status !== 0) return 0;
+	return (r.stdout ?? "").split("\n").filter(Boolean).length;
+}
+
 function tmuxBasePaneIndex(): string {
 	const r = spawnSync("tmux", ["show-options", "-g", "pane-base-index"], { encoding: "utf8" });
 	const out = (r.stdout ?? "").trim();
@@ -432,11 +448,23 @@ function cmdReconcile(): void {
 		const win = String(rec.window ?? "");
 		if (!paneId && paneTarget) {
 			if (tmuxPaneExists(paneTarget)) {
-				const resolved = tmuxField(paneTarget, "#{pane_id}");
-				if (resolved) {
-					fdStateOrDie(["set", `.issues["${issue}"].pane_id`, JSON.stringify(resolved)]);
-					paneId = resolved;
-					backfilled.push(issue);
+				// Guard against index reuse (#16): tmux reassigns destroyed
+				// window indices to new windows. A stale pane_target like
+				// `HT:2.1` may now point to an unrelated window (the daemon,
+				// the user's editor, ...). Backfilling pane_id from that
+				// target would adopt the WRONG pane id and turn the next
+				// teardown into a kill of the unrelated workload. Reject
+				// the backfill whenever the window name at the recorded
+				// pane_target no longer matches the issue's window.
+				const currentWindow = tmuxField(paneTarget, "#{window_name}");
+				const mismatched = win && currentWindow && currentWindow !== win;
+				if (!mismatched) {
+					const resolved = tmuxField(paneTarget, "#{pane_id}");
+					if (resolved) {
+						fdStateOrDie(["set", `.issues["${issue}"].pane_id`, JSON.stringify(resolved)]);
+						paneId = resolved;
+						backfilled.push(issue);
+					}
 				}
 			}
 		}
@@ -452,6 +480,54 @@ function cmdReconcile(): void {
 	if (backfilled.length > 0) {
 		process.stdout.write(`reconciled: backfilled pane_id for ${backfilled.length} entr${backfilled.length === 1 ? "y" : "ies"} (${backfilled.join(",")})\n`);
 	}
+}
+
+// ----- teardown-window -----------------------------------------------------
+
+const TERMINAL_STATES = new Set(["merged", "aborted", "dead"]);
+
+function cmdTeardownWindow(issue: string): void {
+	if (!issue) die("Usage: teardown-window <ISSUE>");
+	const r = fdState(["get", `.issues["${issue}"] // empty`]);
+	const raw = (r.stdout ?? "").trim();
+	if (!raw || raw === "null") {
+		process.stderr.write(`teardown-window: issue '${issue}' not found in registry\n`);
+		process.exit(1);
+	}
+	let rec: IssueRec;
+	try { rec = JSON.parse(raw) as IssueRec; }
+	catch {
+		process.stderr.write(`teardown-window: malformed registry entry for '${issue}'\n`);
+		process.exit(1);
+	}
+	const state = String(rec.state ?? "");
+	const paneId = String(rec.pane_id ?? "");
+	const windowName = String(rec.window ?? "");
+	let paneAlive = false;
+	if (paneId) {
+		const live = tmuxLivePaneIds();
+		paneAlive = live.has(paneId);
+	}
+	if (paneAlive) {
+		const windowId = tmuxField(paneId, "#{window_id}");
+		const paneCount = windowId ? tmuxPaneCountInWindow(windowId) : 0;
+		if (windowId && paneCount === 1) {
+			spawnSync("tmux", ["kill-window", "-t", windowId], { encoding: "utf8" });
+			process.stdout.write(`teardown-window: killed window ${windowId} (pane_id=${paneId}, window=${windowName})\n`);
+		} else {
+			spawnSync("tmux", ["kill-pane", "-t", paneId], { encoding: "utf8" });
+			process.stdout.write(`teardown-window: killed pane ${paneId} (window has ${paneCount} panes, window=${windowName})\n`);
+		}
+		return;
+	}
+	if (TERMINAL_STATES.has(state)) {
+		process.stdout.write(`teardown-window: window already closed (pane_id=${paneId || "<none>"} gone, state=${state})\n`);
+		return;
+	}
+	process.stderr.write(
+		`teardown-window: registry drift — pane_id '${paneId || "<none>"}' is gone but state is '${state}' (not merged|aborted|dead); refusing to derive kill target from pane_target (#16)\n`,
+	);
+	process.exit(3);
 }
 
 // ----- main ----------------------------------------------------------------
@@ -475,6 +551,7 @@ switch (action) {
 	case "pi-bridge-args":  cmdPiBridgeArgs(argv[0] ?? ""); break;
 	case "cx-bridge-args":  cmdCxBridgeArgs(argv[0] ?? ""); break;
 	case "find-by-pane":    cmdFindByPane(argv[0] ?? ""); break;
+	case "teardown-window": cmdTeardownWindow(argv[0] ?? ""); break;
 	default:
-		die(`Unknown action: ${action}\nActions: init | list | get | set-state | set-substate | set | log-decision | remove | remove-merged | reconcile | oc-attach-args | cc-channel-args | pi-bridge-args | cx-bridge-args | find-by-pane`);
+		die(`Unknown action: ${action}\nActions: init | list | get | set-state | set-substate | set | log-decision | remove | remove-merged | reconcile | teardown-window | oc-attach-args | cc-channel-args | pi-bridge-args | cx-bridge-args | find-by-pane`);
 }

--- a/skills/flightdeck/lib/flightdeck-core/tests/parity/pane-registry.test.ts
+++ b/skills/flightdeck/lib/flightdeck-core/tests/parity/pane-registry.test.ts
@@ -180,3 +180,157 @@ describe("pane-registry parity", () => {
 		expect(readIssues(bashRepo)).toEqual({});
 	});
 });
+
+// --- teardown-window (#16) -------------------------------------------------
+//
+// teardown-window is the destructive cleanup helper called from
+// workflows/close-issue.md § 4. The point of #16 is that the old
+// `WINDOW_TARGET="${pane_target%.*}"; tmux kill-window` path could destroy
+// an unrelated window after tmux reused the recorded window index. These
+// tests cover the three branches of the new helper:
+//
+//   1. pane_id alive, single-pane window  → kill the window
+//   2. pane_id alive, multi-pane window   → kill only the pane
+//   3. pane_id gone + terminal state       → no-op success (already closed)
+//   4. pane_id gone + non-terminal state   → exit 3 (registry drift)
+//   5. pane_target reused by another window (#16) → helper must NOT kill it
+//
+// All branches are exercised against both bash and TS implementations.
+
+function sessionId(): string {
+	return spawnSync("tmux", ["display-message", "-p", "#S"], { encoding: "utf8" }).stdout.trim();
+}
+
+function makeWindow(name: string): { paneId: string; windowId: string } {
+	const r = spawnSync(
+		"tmux",
+		["new-window", "-d", "-P", "-n", name, "-F", "#{pane_id}\t#{window_id}"],
+		{ encoding: "utf8" },
+	);
+	const [paneId, windowId] = (r.stdout ?? "").trim().split("\t");
+	if (!paneId || !windowId) throw new Error(`failed to create window ${name}: ${r.stderr}`);
+	return { paneId, windowId };
+}
+
+function killWindowIfExists(windowId: string): void {
+	spawnSync("tmux", ["kill-window", "-t", windowId], { stdio: "ignore" });
+}
+
+function paneStillExists(paneId: string): boolean {
+	const r = spawnSync("tmux", ["list-panes", "-a", "-F", "#{pane_id}"], { encoding: "utf8" });
+	return (r.stdout ?? "").split("\n").includes(paneId);
+}
+
+function setIssueField(useTs: boolean, repo: string, issue: string, field: string, jsonValue: string): void {
+	run(useTs, repo, ["set", issue, field, jsonValue]);
+}
+
+describe("pane-registry teardown-window (#16)", () => {
+	test("pane_id alive + single-pane window → kills the window", () => {
+		for (const repo of [bashRepo, tsRepo]) {
+			const useTs = repo === tsRepo;
+			const name = `td-single-${useTs ? "ts" : "bash"}-${process.pid}`;
+			const { paneId, windowId } = makeWindow(name);
+			try {
+				run(useTs, repo, ["init", "TD-1", "--window", name, "--harness", "opencode", "--worktree", "/tmp/wt"]);
+				setIssueField(useTs, repo, "TD-1", "pane_id", JSON.stringify(paneId));
+				const r = run(useTs, repo, ["teardown-window", "TD-1"]);
+				expect(r.status).toBe(0);
+				expect(paneStillExists(paneId)).toBe(false);
+			} finally {
+				killWindowIfExists(windowId);
+			}
+		}
+	});
+
+	test("pane_id alive + multi-pane window → kills only the pane", () => {
+		for (const repo of [bashRepo, tsRepo]) {
+			const useTs = repo === tsRepo;
+			const name = `td-multi-${useTs ? "ts" : "bash"}-${process.pid}`;
+			const { paneId, windowId } = makeWindow(name);
+			// Split the window so it has two panes; we'll target the first.
+			const split = spawnSync(
+				"tmux",
+				["split-window", "-d", "-t", paneId, "-P", "-F", "#{pane_id}"],
+				{ encoding: "utf8" },
+			);
+			const siblingId = split.stdout.trim();
+			try {
+				run(useTs, repo, ["init", "TD-2", "--window", name, "--harness", "opencode", "--worktree", "/tmp/wt"]);
+				setIssueField(useTs, repo, "TD-2", "pane_id", JSON.stringify(paneId));
+				const r = run(useTs, repo, ["teardown-window", "TD-2"]);
+				expect(r.status).toBe(0);
+				expect(paneStillExists(paneId)).toBe(false);
+				// Sibling pane (and therefore the window) must still exist.
+				expect(paneStillExists(siblingId)).toBe(true);
+			} finally {
+				killWindowIfExists(windowId);
+			}
+		}
+	});
+
+	test("pane_id gone + terminal state → no-op success", () => {
+		for (const repo of [bashRepo, tsRepo]) {
+			const useTs = repo === tsRepo;
+			run(useTs, repo, ["init", "TD-3", "--window", "td-fake", "--harness", "opencode", "--worktree", "/tmp/wt"]);
+			setIssueField(useTs, repo, "TD-3", "pane_id", JSON.stringify("%999999"));
+			run(useTs, repo, ["set-state", "TD-3", "merged"]);
+			const r = run(useTs, repo, ["teardown-window", "TD-3"]);
+			expect(r.status).toBe(0);
+			expect(r.stdout).toContain("already closed");
+		}
+	});
+
+	test("pane_id gone + non-terminal state → exit 3 (registry drift)", () => {
+		for (const repo of [bashRepo, tsRepo]) {
+			const useTs = repo === tsRepo;
+			run(useTs, repo, ["init", "TD-4", "--window", "td-fake", "--harness", "opencode", "--worktree", "/tmp/wt"]);
+			setIssueField(useTs, repo, "TD-4", "pane_id", JSON.stringify("%999998"));
+			// state remains "waiting" (default from init).
+			const r = run(useTs, repo, ["teardown-window", "TD-4"]);
+			expect(r.status).toBe(3);
+			expect(r.stderr).toContain("registry drift");
+		}
+	});
+
+	test("#16 scenario: stale pane_target reused by unrelated window is NOT killed", () => {
+		// Reproduce the issue: registry has a stale pane_target whose index
+		// has been reassigned to a different window. The helper must rely
+		// on the stable pane_id only; the unrelated window must survive.
+		for (const repo of [bashRepo, tsRepo]) {
+			const useTs = repo === tsRepo;
+			const victimName = `td-victim-${useTs ? "ts" : "bash"}-${process.pid}`;
+			const victim = makeWindow(victimName);
+			try {
+				const session = sessionId();
+				// Compute the victim's `session:window-index.pane-index`.
+				const meta = spawnSync(
+					"tmux",
+					["display-message", "-t", victim.paneId, "-p", "#{window_index}.#{pane_index}"],
+					{ encoding: "utf8" },
+				).stdout.trim();
+				const stalePaneTarget = `${session}:${meta}`;
+				run(useTs, repo, ["init", "TD-5", "--window", "orig-window-name", "--harness", "opencode", "--worktree", "/tmp/wt"]);
+				// Simulate the recorded state from issue #16: pane_id is the
+				// original (now-dead) one; pane_target now points at an
+				// unrelated live window via tmux index reuse.
+				setIssueField(useTs, repo, "TD-5", "pane_id", JSON.stringify("%999997"));
+				setIssueField(useTs, repo, "TD-5", "pane_target", JSON.stringify(stalePaneTarget));
+				run(useTs, repo, ["set-state", "TD-5", "merged"]);
+				const r = run(useTs, repo, ["teardown-window", "TD-5"]);
+				expect(r.status).toBe(0);
+				expect(paneStillExists(victim.paneId)).toBe(true);
+			} finally {
+				killWindowIfExists(victim.windowId);
+			}
+		}
+	});
+
+	test("unknown issue → exit 1", () => {
+		for (const repo of [bashRepo, tsRepo]) {
+			const useTs = repo === tsRepo;
+			const r = run(useTs, repo, ["teardown-window", "DOES-NOT-EXIST"]);
+			expect(r.status).toBe(1);
+		}
+	});
+});

--- a/skills/flightdeck/lib/flightdeck-core/tests/parity/pane-registry.test.ts
+++ b/skills/flightdeck/lib/flightdeck-core/tests/parity/pane-registry.test.ts
@@ -181,156 +181,283 @@ describe("pane-registry parity", () => {
 	});
 });
 
-// --- teardown-window (#16) -------------------------------------------------
+// --- teardown-window + reconcile (#16) ------------------------------------
 //
-// teardown-window is the destructive cleanup helper called from
-// workflows/close-issue.md § 4. The point of #16 is that the old
-// `WINDOW_TARGET="${pane_target%.*}"; tmux kill-window` path could destroy
-// an unrelated window after tmux reused the recorded window index. These
-// tests cover the three branches of the new helper:
-//
-//   1. pane_id alive, single-pane window  → kill the window
-//   2. pane_id alive, multi-pane window   → kill only the pane
-//   3. pane_id gone + terminal state       → no-op success (already closed)
-//   4. pane_id gone + non-terminal state   → exit 3 (registry drift)
-//   5. pane_target reused by another window (#16) → helper must NOT kill it
-//
-// All branches are exercised against both bash and TS implementations.
+// These tests run pane-registry against a deterministic tmux shim instead
+// of the live tmux server (reviewer BLOCKER #4: don't create/split/kill
+// real windows in CI). The shim is a bash script that reads/writes a JSON
+// state file; PATH-prepending its directory makes both the bash and TS
+// implementations resolve `tmux` to the shim. Each test owns its own
+// state file, so runs are isolated.
 
-function sessionId(): string {
-	return spawnSync("tmux", ["display-message", "-p", "#S"], { encoding: "utf8" }).stdout.trim();
+const SHIM_DIR = resolve(HERE, "./tmux-shim");
+
+interface ShimPane {
+	window_id: string;
+	window_name: string;
+	path: string;
+	window_index: number;
+	pane_index: number;
 }
 
-function makeWindow(name: string): { paneId: string; windowId: string } {
-	const r = spawnSync(
-		"tmux",
-		["new-window", "-d", "-P", "-n", name, "-F", "#{pane_id}\t#{window_id}"],
-		{ encoding: "utf8" },
-	);
-	const [paneId, windowId] = (r.stdout ?? "").trim().split("\t");
-	if (!paneId || !windowId) throw new Error(`failed to create window ${name}: ${r.stderr}`);
-	return { paneId, windowId };
+interface ShimState {
+	session: string;
+	panes: Record<string, ShimPane>;
+	windows: Record<string, { name: string; index: number }>;
 }
 
-function killWindowIfExists(windowId: string): void {
-	spawnSync("tmux", ["kill-window", "-t", windowId], { stdio: "ignore" });
+function makeShimState(repo: string, state: ShimState): string {
+	const path = join(repo, "shim-state.json");
+	spawnSync("mkdir", ["-p", repo]);
+	require("node:fs").writeFileSync(path, JSON.stringify(state, null, 2));
+	return path;
 }
 
-function paneStillExists(paneId: string): boolean {
-	const r = spawnSync("tmux", ["list-panes", "-a", "-F", "#{pane_id}"], { encoding: "utf8" });
-	return (r.stdout ?? "").split("\n").includes(paneId);
+function readShimState(path: string): ShimState {
+	return JSON.parse(require("node:fs").readFileSync(path, "utf8"));
 }
 
-function setIssueField(useTs: boolean, repo: string, issue: string, field: string, jsonValue: string): void {
-	run(useTs, repo, ["set", issue, field, jsonValue]);
+function runShim(useTs: boolean, repo: string, statePath: string, args: string[]): { stdout: string; stderr: string; status: number | null } {
+	const env: Record<string, string> = { ...(process.env as Record<string, string>) };
+	if (useTs) {
+		env.FLIGHTDECK_USE_TS_PANE_REGISTRY = "1";
+		env.FLIGHTDECK_USE_TS_FLIGHTDECK_STATE = "1";
+	} else {
+		delete env.FLIGHTDECK_USE_TS_PANE_REGISTRY;
+		delete env.FLIGHTDECK_USE_TS_FLIGHTDECK_STATE;
+	}
+	delete env.FLIGHTDECK_USE_TS;
+	env.FLIGHTDECK_STATE_DIR = "tmp";
+	env.PATH = `${SHIM_DIR}:${env.PATH ?? ""}`;
+	env.TMUX_SHIM_STATE = statePath;
+	env.TMUX_PARITY_SESSION = readShimState(statePath).session;
+	const r = spawnSync(SCRIPT, args, { cwd: repo, encoding: "utf8", env });
+	return { status: r.status, stderr: r.stderr ?? "", stdout: r.stdout ?? "" };
 }
 
-describe("pane-registry teardown-window (#16)", () => {
-	test("pane_id alive + single-pane window → kills the window", () => {
+function baseShim(session: string, extras: Partial<ShimState> = {}): ShimState {
+	return {
+		panes: {},
+		session,
+		windows: {},
+		...extras,
+	};
+}
+
+describe("pane-registry teardown-window (#16, shim-driven)", () => {
+	test("pane_id alive + terminal + single-pane window → kills the window", () => {
 		for (const repo of [bashRepo, tsRepo]) {
 			const useTs = repo === tsRepo;
-			const name = `td-single-${useTs ? "ts" : "bash"}-${process.pid}`;
-			const { paneId, windowId } = makeWindow(name);
-			try {
-				run(useTs, repo, ["init", "TD-1", "--window", name, "--harness", "opencode", "--worktree", "/tmp/wt"]);
-				setIssueField(useTs, repo, "TD-1", "pane_id", JSON.stringify(paneId));
-				const r = run(useTs, repo, ["teardown-window", "TD-1"]);
-				expect(r.status).toBe(0);
-				expect(paneStillExists(paneId)).toBe(false);
-			} finally {
-				killWindowIfExists(windowId);
-			}
-		}
-	});
-
-	test("pane_id alive + multi-pane window → kills only the pane", () => {
-		for (const repo of [bashRepo, tsRepo]) {
-			const useTs = repo === tsRepo;
-			const name = `td-multi-${useTs ? "ts" : "bash"}-${process.pid}`;
-			const { paneId, windowId } = makeWindow(name);
-			// Split the window so it has two panes; we'll target the first.
-			const split = spawnSync(
-				"tmux",
-				["split-window", "-d", "-t", paneId, "-P", "-F", "#{pane_id}"],
-				{ encoding: "utf8" },
-			);
-			const siblingId = split.stdout.trim();
-			try {
-				run(useTs, repo, ["init", "TD-2", "--window", name, "--harness", "opencode", "--worktree", "/tmp/wt"]);
-				setIssueField(useTs, repo, "TD-2", "pane_id", JSON.stringify(paneId));
-				const r = run(useTs, repo, ["teardown-window", "TD-2"]);
-				expect(r.status).toBe(0);
-				expect(paneStillExists(paneId)).toBe(false);
-				// Sibling pane (and therefore the window) must still exist.
-				expect(paneStillExists(siblingId)).toBe(true);
-			} finally {
-				killWindowIfExists(windowId);
-			}
-		}
-	});
-
-	test("pane_id gone + terminal state → no-op success", () => {
-		for (const repo of [bashRepo, tsRepo]) {
-			const useTs = repo === tsRepo;
-			run(useTs, repo, ["init", "TD-3", "--window", "td-fake", "--harness", "opencode", "--worktree", "/tmp/wt"]);
-			setIssueField(useTs, repo, "TD-3", "pane_id", JSON.stringify("%999999"));
-			run(useTs, repo, ["set-state", "TD-3", "merged"]);
-			const r = run(useTs, repo, ["teardown-window", "TD-3"]);
+			const statePath = makeShimState(repo, {
+				panes: {
+					"%100": { pane_index: 0, path: "/tmp/wt-a", window_id: "@10", window_index: 1, window_name: "issue-a" },
+				},
+				session: "test-session",
+				windows: { "@10": { index: 1, name: "issue-a" } },
+			});
+			runShim(useTs, repo, statePath, ["init", "TD-1", "--window", "issue-a", "--harness", "opencode", "--worktree", "/tmp/wt-a"]);
+			runShim(useTs, repo, statePath, ["set", "TD-1", "pane_id", JSON.stringify("%100")]);
+			runShim(useTs, repo, statePath, ["set-state", "TD-1", "merged"]);
+			const r = runShim(useTs, repo, statePath, ["teardown-window", "TD-1"]);
 			expect(r.status).toBe(0);
-			expect(r.stdout).toContain("already closed");
+			const state = readShimState(statePath);
+			expect(state.panes["%100"]).toBeUndefined();
+			expect(state.windows["@10"]).toBeUndefined();
 		}
 	});
+
+	test("pane_id alive + terminal + multi-pane window → kills only the pane", () => {
+		for (const repo of [bashRepo, tsRepo]) {
+			const useTs = repo === tsRepo;
+			const statePath = makeShimState(repo, {
+				panes: {
+					"%100": { pane_index: 0, path: "/tmp/wt-a", window_id: "@10", window_index: 1, window_name: "issue-a" },
+					"%101": { pane_index: 1, path: "/tmp/wt-a", window_id: "@10", window_index: 1, window_name: "issue-a" },
+				},
+				session: "test-session",
+				windows: { "@10": { index: 1, name: "issue-a" } },
+			});
+			runShim(useTs, repo, statePath, ["init", "TD-2", "--window", "issue-a", "--harness", "opencode", "--worktree", "/tmp/wt-a"]);
+			runShim(useTs, repo, statePath, ["set", "TD-2", "pane_id", JSON.stringify("%100")]);
+			runShim(useTs, repo, statePath, ["set-state", "TD-2", "merged"]);
+			const r = runShim(useTs, repo, statePath, ["teardown-window", "TD-2"]);
+			expect(r.status).toBe(0);
+			const state = readShimState(statePath);
+			expect(state.panes["%100"]).toBeUndefined();
+			expect(state.panes["%101"]).toBeDefined();
+			expect(state.windows["@10"]).toBeDefined();
+		}
+	});
+
+	for (const terminal of ["merged", "aborted", "dead"]) {
+		test(`pane_id gone + state=${terminal} → no-op success`, () => {
+			for (const repo of [bashRepo, tsRepo]) {
+				const useTs = repo === tsRepo;
+				const statePath = makeShimState(repo, baseShim("test-session"));
+				runShim(useTs, repo, statePath, ["init", "TD-3", "--window", "issue-a", "--harness", "opencode", "--worktree", "/tmp/wt-a"]);
+				runShim(useTs, repo, statePath, ["set", "TD-3", "pane_id", JSON.stringify("%999999")]);
+				runShim(useTs, repo, statePath, ["set-state", "TD-3", terminal]);
+				const r = runShim(useTs, repo, statePath, ["teardown-window", "TD-3"]);
+				expect(r.status).toBe(0);
+				expect(r.stdout).toContain("already closed");
+			}
+		});
+	}
 
 	test("pane_id gone + non-terminal state → exit 3 (registry drift)", () => {
 		for (const repo of [bashRepo, tsRepo]) {
 			const useTs = repo === tsRepo;
-			run(useTs, repo, ["init", "TD-4", "--window", "td-fake", "--harness", "opencode", "--worktree", "/tmp/wt"]);
-			setIssueField(useTs, repo, "TD-4", "pane_id", JSON.stringify("%999998"));
-			// state remains "waiting" (default from init).
-			const r = run(useTs, repo, ["teardown-window", "TD-4"]);
+			const statePath = makeShimState(repo, baseShim("test-session"));
+			runShim(useTs, repo, statePath, ["init", "TD-4", "--window", "issue-a", "--harness", "opencode", "--worktree", "/tmp/wt-a"]);
+			runShim(useTs, repo, statePath, ["set", "TD-4", "pane_id", JSON.stringify("%999998")]);
+			// state remains "waiting".
+			const r = runShim(useTs, repo, statePath, ["teardown-window", "TD-4"]);
 			expect(r.status).toBe(3);
 			expect(r.stderr).toContain("registry drift");
 		}
 	});
 
-	test("#16 scenario: stale pane_target reused by unrelated window is NOT killed", () => {
-		// Reproduce the issue: registry has a stale pane_target whose index
-		// has been reassigned to a different window. The helper must rely
-		// on the stable pane_id only; the unrelated window must survive.
+	test("pane_id alive + non-terminal state → exit 4 (policy refusal); --force kills", () => {
 		for (const repo of [bashRepo, tsRepo]) {
 			const useTs = repo === tsRepo;
-			const victimName = `td-victim-${useTs ? "ts" : "bash"}-${process.pid}`;
-			const victim = makeWindow(victimName);
-			try {
-				const session = sessionId();
-				// Compute the victim's `session:window-index.pane-index`.
-				const meta = spawnSync(
-					"tmux",
-					["display-message", "-t", victim.paneId, "-p", "#{window_index}.#{pane_index}"],
-					{ encoding: "utf8" },
-				).stdout.trim();
-				const stalePaneTarget = `${session}:${meta}`;
-				run(useTs, repo, ["init", "TD-5", "--window", "orig-window-name", "--harness", "opencode", "--worktree", "/tmp/wt"]);
-				// Simulate the recorded state from issue #16: pane_id is the
-				// original (now-dead) one; pane_target now points at an
-				// unrelated live window via tmux index reuse.
-				setIssueField(useTs, repo, "TD-5", "pane_id", JSON.stringify("%999997"));
-				setIssueField(useTs, repo, "TD-5", "pane_target", JSON.stringify(stalePaneTarget));
-				run(useTs, repo, ["set-state", "TD-5", "merged"]);
-				const r = run(useTs, repo, ["teardown-window", "TD-5"]);
-				expect(r.status).toBe(0);
-				expect(paneStillExists(victim.paneId)).toBe(true);
-			} finally {
-				killWindowIfExists(victim.windowId);
-			}
+			const statePath = makeShimState(repo, {
+				panes: {
+					"%100": { pane_index: 0, path: "/tmp/wt-a", window_id: "@10", window_index: 1, window_name: "issue-a" },
+				},
+				session: "test-session",
+				windows: { "@10": { index: 1, name: "issue-a" } },
+			});
+			runShim(useTs, repo, statePath, ["init", "TD-FORCE", "--window", "issue-a", "--harness", "opencode", "--worktree", "/tmp/wt-a"]);
+			runShim(useTs, repo, statePath, ["set", "TD-FORCE", "pane_id", JSON.stringify("%100")]);
+			// state stays "waiting".
+			const r1 = runShim(useTs, repo, statePath, ["teardown-window", "TD-FORCE"]);
+			expect(r1.status).toBe(4);
+			expect(r1.stderr).toContain("policy refusal");
+			// Pane still alive after refusal.
+			expect(readShimState(statePath).panes["%100"]).toBeDefined();
+			const r2 = runShim(useTs, repo, statePath, ["teardown-window", "TD-FORCE", "--force"]);
+			expect(r2.status).toBe(0);
+			expect(readShimState(statePath).panes["%100"]).toBeUndefined();
 		}
 	});
 
-	test("unknown issue → exit 1", () => {
+	test("unknown issue → exit 1 (idempotent, distinct from read-failure)", () => {
 		for (const repo of [bashRepo, tsRepo]) {
 			const useTs = repo === tsRepo;
-			const r = run(useTs, repo, ["teardown-window", "DOES-NOT-EXIST"]);
+			const statePath = makeShimState(repo, baseShim("test-session"));
+			const r = runShim(useTs, repo, statePath, ["teardown-window", "DOES-NOT-EXIST"]);
 			expect(r.status).toBe(1);
+			expect(r.stderr).toContain("not found in registry");
+		}
+	});
+
+	test("teardown-entry is an alias for teardown-window", () => {
+		for (const repo of [bashRepo, tsRepo]) {
+			const useTs = repo === tsRepo;
+			const statePath = makeShimState(repo, baseShim("test-session"));
+			runShim(useTs, repo, statePath, ["init", "TD-ALIAS", "--window", "issue-a", "--harness", "opencode", "--worktree", "/tmp/wt-a"]);
+			runShim(useTs, repo, statePath, ["set", "TD-ALIAS", "pane_id", JSON.stringify("%999990")]);
+			runShim(useTs, repo, statePath, ["set-state", "TD-ALIAS", "aborted"]);
+			const r = runShim(useTs, repo, statePath, ["teardown-entry", "TD-ALIAS"]);
+			expect(r.status).toBe(0);
+			expect(r.stdout).toContain("already closed");
+		}
+	});
+});
+
+describe("pane-registry reconcile backfill safety (#16, shim-driven)", () => {
+	test("index reuse: window_name mismatch → drift, no adoption, victim survives", () => {
+		for (const repo of [bashRepo, tsRepo]) {
+			const useTs = repo === tsRepo;
+			// Reproduce the original #16 wire: the registry has a NUMERIC
+			// pane_target (`HT:2.1` in the issue evidence) because the issue
+			// was previously persisted with a session:window-index.pane-index
+			// form. After the original window was destroyed and tmux reused
+			// the index, that target now resolves to an unrelated live pane
+			// (the daemon).
+			const statePath = makeShimState(repo, {
+				panes: {
+					"%500": { pane_index: 0, path: "/some/daemon/cwd", window_id: "@50", window_index: 1, window_name: "flightdeck-daemon-s1" },
+				},
+				session: "test-session",
+				windows: { "@50": { index: 1, name: "flightdeck-daemon-s1" } },
+			});
+			runShim(useTs, repo, statePath, [
+				"init", "REUSE-1",
+				"--window", "orig-issue",
+				"--harness", "opencode",
+				"--worktree", "/tmp/wt-issue",
+			]);
+			// Force the legacy wire: numeric pane_target pointing at the
+			// victim's address, pane_id cleared.
+			runShim(useTs, repo, statePath, ["set", "REUSE-1", "pane_target", JSON.stringify("test-session:1.0")]);
+			runShim(useTs, repo, statePath, ["set", "REUSE-1", "pane_id", "null"]);
+			const r = runShim(useTs, repo, statePath, ["reconcile"]);
+			// Reconcile must not adopt the victim's pane_id; must emit drift;
+			// must not destroy the victim.
+			expect(r.stderr).toContain("drift detected");
+			expect(readShimState(statePath).panes["%500"]).toBeDefined();
+			const entry = JSON.parse(runShim(useTs, repo, statePath, ["get", "REUSE-1"]).stdout) as Record<string, unknown>;
+			expect(entry.pane_id).toBeNull();
+		}
+	});
+
+	test("index reuse: worktree (cwd) mismatch alone → drift, no adoption", () => {
+		for (const repo of [bashRepo, tsRepo]) {
+			const useTs = repo === tsRepo;
+			// Pathological window-name collision: the new occupant happens to
+			// have the same window name (e.g. user reused a friendly name),
+			// but its cwd is a different worktree. The cwd-anchor invariant
+			// must catch this and emit drift.
+			const statePath = makeShimState(repo, {
+				panes: {
+					"%600": { pane_index: 0, path: "/tmp/wt-other", window_id: "@60", window_index: 2, window_name: "orig-issue" },
+				},
+				session: "test-session",
+				windows: { "@60": { index: 2, name: "orig-issue" } },
+			});
+			runShim(useTs, repo, statePath, [
+				"init", "REUSE-2",
+				"--window", "orig-issue",
+				"--harness", "opencode",
+				"--worktree", "/tmp/wt-issue",
+				"--pane-index", "0",
+			]);
+			// Force pane_target to the victim's address and clear pane_id.
+			runShim(useTs, repo, statePath, ["set", "REUSE-2", "pane_target", JSON.stringify("test-session:2.0")]);
+			runShim(useTs, repo, statePath, ["set", "REUSE-2", "pane_id", "null"]);
+			const r = runShim(useTs, repo, statePath, ["reconcile"]);
+			expect(r.stderr).toContain("drift detected");
+			const entry = JSON.parse(runShim(useTs, repo, statePath, ["get", "REUSE-2"]).stdout) as Record<string, unknown>;
+			expect(entry.pane_id).toBeNull();
+			expect(readShimState(statePath).panes["%600"]).toBeDefined();
+		}
+	});
+
+	test("matching window_name + worktree → backfill adopts pane_id", () => {
+		for (const repo of [bashRepo, tsRepo]) {
+			const useTs = repo === tsRepo;
+			const statePath = makeShimState(repo, {
+				panes: {
+					"%700": { pane_index: 0, path: "/tmp/wt-good/subdir", window_id: "@70", window_index: 3, window_name: "good-issue" },
+				},
+				session: "test-session",
+				windows: { "@70": { index: 3, name: "good-issue" } },
+			});
+			runShim(useTs, repo, statePath, [
+				"init", "GOOD-1",
+				"--window", "good-issue",
+				"--harness", "opencode",
+				"--worktree", "/tmp/wt-good",
+				"--pane-index", "0",
+			]);
+			runShim(useTs, repo, statePath, ["set", "GOOD-1", "pane_target", JSON.stringify("test-session:3.0")]);
+			runShim(useTs, repo, statePath, ["set", "GOOD-1", "pane_id", "null"]);
+			const r = runShim(useTs, repo, statePath, ["reconcile"]);
+			expect(r.stderr).not.toContain("drift detected");
+			expect(r.stdout).toContain("backfilled pane_id");
+			const entry = JSON.parse(runShim(useTs, repo, statePath, ["get", "GOOD-1"]).stdout) as Record<string, unknown>;
+			expect(entry.pane_id).toBe("%700");
 		}
 	});
 });

--- a/skills/flightdeck/lib/flightdeck-core/tests/parity/pane-registry.test.ts
+++ b/skills/flightdeck/lib/flightdeck-core/tests/parity/pane-registry.test.ts
@@ -217,7 +217,7 @@ function readShimState(path: string): ShimState {
 	return JSON.parse(require("node:fs").readFileSync(path, "utf8"));
 }
 
-function runShim(useTs: boolean, repo: string, statePath: string, args: string[]): { stdout: string; stderr: string; status: number | null } {
+function runShim(useTs: boolean, repo: string, statePath: string, args: string[], extraEnv: Record<string, string> = {}): { stdout: string; stderr: string; status: number | null } {
 	const env: Record<string, string> = { ...(process.env as Record<string, string>) };
 	if (useTs) {
 		env.FLIGHTDECK_USE_TS_PANE_REGISTRY = "1";
@@ -231,8 +231,13 @@ function runShim(useTs: boolean, repo: string, statePath: string, args: string[]
 	env.PATH = `${SHIM_DIR}:${env.PATH ?? ""}`;
 	env.TMUX_SHIM_STATE = statePath;
 	env.TMUX_PARITY_SESSION = readShimState(statePath).session;
+	for (const [k, v] of Object.entries(extraEnv)) env[k] = v;
 	const r = spawnSync(SCRIPT, args, { cwd: repo, encoding: "utf8", env });
 	return { status: r.status, stderr: r.stderr ?? "", stdout: r.stdout ?? "" };
+}
+
+function stateFilePath(repo: string, session: string): string {
+	return join(repo, "tmp", `flightdeck-state-${session}.json`);
 }
 
 function baseShim(session: string, extras: Partial<ShimState> = {}): ShimState {
@@ -361,6 +366,57 @@ describe("pane-registry teardown-window (#16, shim-driven)", () => {
 			const r = runShim(useTs, repo, statePath, ["teardown-entry", "TD-ALIAS"]);
 			expect(r.status).toBe(0);
 			expect(r.stdout).toContain("already closed");
+		}
+	});
+
+	test("tmux kill fails and pane stays alive → exit 5", () => {
+		// Reviewer BLOCKER: drive the shim to refuse kill-window/kill-pane
+		// (non-zero exit + state unchanged). Post-kill liveness check sees
+		// the pane is still listed and escalates instead of falsely
+		// returning success.
+		for (const repo of [bashRepo, tsRepo]) {
+			const useTs = repo === tsRepo;
+			const statePath = makeShimState(repo, {
+				panes: {
+					"%900": { pane_index: 0, path: "/tmp/wt-a", window_id: "@90", window_index: 1, window_name: "issue-a" },
+				},
+				session: "test-session",
+				windows: { "@90": { index: 1, name: "issue-a" } },
+			});
+			runShim(useTs, repo, statePath, ["init", "TD-KILLFAIL", "--window", "issue-a", "--harness", "opencode", "--worktree", "/tmp/wt-a"]);
+			runShim(useTs, repo, statePath, ["set", "TD-KILLFAIL", "pane_id", JSON.stringify("%900")]);
+			runShim(useTs, repo, statePath, ["set-state", "TD-KILLFAIL", "merged"]);
+			const r = runShim(useTs, repo, statePath, ["teardown-window", "TD-KILLFAIL"], { TMUX_SHIM_REFUSE_KILL: "1" });
+			expect(r.status).toBe(5);
+			expect(r.stderr).toContain("kill of");
+			expect(r.stderr).toContain("%900 still alive");
+			// Pane and window unchanged in shim state.
+			const state = readShimState(statePath);
+			expect(state.panes["%900"]).toBeDefined();
+			expect(state.windows["@90"]).toBeDefined();
+		}
+	});
+
+	test("corrupt registry state file → exit 6 (distinct from issue-not-found)", () => {
+		// Reviewer BLOCKER: a flightdeck-state get failure (corrupt JSON
+		// here — jq exits 5) must NOT be conflated with "issue not in
+		// registry" (exit 1). close-issue.md treats exit 1 as idempotent;
+		// exit 6 must surface so the operator sees state corruption.
+		const fs = require("node:fs") as typeof import("node:fs");
+		for (const repo of [bashRepo, tsRepo]) {
+			const useTs = repo === tsRepo;
+			const statePath = makeShimState(repo, baseShim("test-session"));
+			// Initialise the registry once so the state file exists, then
+			// corrupt it. (Without an init step flightdeck-state would
+			// return the normal exit-1 "file missing" path which IS the
+			// idempotent case and correctly maps to teardown exit 1.)
+			runShim(useTs, repo, statePath, ["init", "TD-CORRUPT", "--window", "issue-a", "--harness", "opencode", "--worktree", "/tmp/wt-a"]);
+			const registryPath = stateFilePath(repo, "test-session");
+			fs.writeFileSync(registryPath, "{not valid json at all,,,");
+			const r = runShim(useTs, repo, statePath, ["teardown-window", "TD-CORRUPT"]);
+			expect(r.status).toBe(6);
+			expect(r.stderr).toContain("registry read failed");
+			expect(r.stderr).not.toContain("not found in registry");
 		}
 	});
 });

--- a/skills/flightdeck/lib/flightdeck-core/tests/parity/tmux-shim/tmux
+++ b/skills/flightdeck/lib/flightdeck-core/tests/parity/tmux-shim/tmux
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# Test-only tmux shim. Reads/writes state from $TMUX_SHIM_STATE (JSON).
+# Implements only the tmux subcommands the pane-registry helper invokes:
+#   display-message, list-panes, list-windows, kill-window, kill-pane,
+#   show-options.
+#
+# State shape:
+#   {
+#     "session": "test-session",
+#     "panes": {
+#       "%100": {"window_id": "@10", "window_name": "issue-1",
+#                "path": "/tmp/wt-1", "window_index": 1, "pane_index": 0}
+#     },
+#     "windows": {
+#       "@10": {"name": "issue-1", "index": 1}
+#     }
+#   }
+#
+# Killing a pane removes it from .panes. Killing a window removes both
+# the window and every pane attached to it. Lookups by `pane_target`
+# (session:window_idx.pane_idx) walk .panes to find a match.
+set -euo pipefail
+
+STATE_FILE="${TMUX_SHIM_STATE:?TMUX_SHIM_STATE not set}"
+[[ -f "$STATE_FILE" ]] || { echo "shim: state file missing: $STATE_FILE" >&2; exit 1; }
+
+resolve_pane() {
+  # $1 = target, prints the pane object (or empty).
+  local target="$1"
+  jq --arg t "$target" --arg session "$(jq -r '.session' "$STATE_FILE")" '
+    def to_pt: "\($session):\(.value.window_index).\(.value.pane_index)";
+    .panes | to_entries[] |
+    select(.key == $t or (to_pt) == $t) |
+    .value
+  ' "$STATE_FILE"
+}
+
+resolve_pane_id() {
+  # $1 = target, prints the pane_id key (or empty).
+  local target="$1"
+  jq -r --arg t "$target" --arg session "$(jq -r '.session' "$STATE_FILE")" '
+    def to_pt: "\($session):\(.value.window_index).\(.value.pane_index)";
+    .panes | to_entries[] |
+    select(.key == $t or (to_pt) == $t) |
+    .key
+  ' "$STATE_FILE"
+}
+
+write_state() {
+  # $1 = jq filter
+  local filter="$1"
+  local tmp
+  tmp=$(mktemp -t fd-shim.XXXXXX)
+  jq "$filter" "$STATE_FILE" > "$tmp"
+  mv "$tmp" "$STATE_FILE"
+}
+
+subcmd="${1:-}"
+shift || true
+
+case "$subcmd" in
+  display-message)
+    target=""
+    format=""
+    print=0
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        -t) target="$2"; shift 2 ;;
+        -p) print=1; shift ;;
+        *)
+          if (( print == 1 )) && [[ -z "$format" ]]; then format="$1"; fi
+          shift
+          ;;
+      esac
+    done
+    if [[ -z "$target" && -z "$format" ]]; then
+      jq -r '.session' "$STATE_FILE"
+      exit 0
+    fi
+    if [[ -z "$target" && "$format" == "#S" ]]; then
+      jq -r '.session' "$STATE_FILE"
+      exit 0
+    fi
+    pane=$(resolve_pane "$target")
+    if [[ -z "$pane" || "$pane" == "null" ]]; then
+      exit 1
+    fi
+    case "$format" in
+      "#{window_id}")         jq -r '.window_id // empty' <<< "$pane" ;;
+      "#{window_name}")       jq -r '.window_name // empty' <<< "$pane" ;;
+      "#{pane_id}")           jq -r --arg t "$target" --arg session "$(jq -r '.session' "$STATE_FILE")" '
+                                 def to_pt: "\($session):\(.value.window_index).\(.value.pane_index)";
+                                 .panes | to_entries[] |
+                                 select(.key == $t or (to_pt) == $t) |
+                                 .key
+                               ' "$STATE_FILE" ;;
+      "#{pane_current_path}") jq -r '.path // empty' <<< "$pane" ;;
+      "#S")                   jq -r '.session' "$STATE_FILE" ;;
+      *) echo "shim: unsupported display-message format: $format" >&2; exit 2 ;;
+    esac
+    ;;
+  list-panes)
+    all=0
+    target=""
+    format=""
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        -a) all=1; shift ;;
+        -t) target="$2"; shift 2 ;;
+        -F) format="$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    if (( all == 1 )); then
+      jq -r '.panes | keys[]' "$STATE_FILE"
+      exit 0
+    fi
+    if [[ -n "$target" ]]; then
+      if [[ "$target" == @* ]]; then
+        # list-panes -t <window_id>
+        matches=$(jq -r --arg w "$target" '
+          .panes | to_entries[] |
+          select(.value.window_id == $w) | .key
+        ' "$STATE_FILE")
+        # Existence: exit 0 only if there is at least one pane.
+        if [[ -z "$matches" ]]; then
+          echo "shim: no panes in window $target" >&2
+          exit 1
+        fi
+        [[ -n "$format" ]] && echo "$matches"
+        exit 0
+      fi
+      # Target by pane_id or pane_target string.
+      pane=$(resolve_pane "$target")
+      if [[ -z "$pane" || "$pane" == "null" ]]; then
+        echo "shim: pane $target not found" >&2
+        exit 1
+      fi
+      [[ -n "$format" ]] && resolve_pane_id "$target"
+      exit 0
+    fi
+    echo "shim: list-panes requires -a or -t" >&2
+    exit 2
+    ;;
+  list-windows)
+    target=""
+    format=""
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        -t) target="$2"; shift 2 ;;
+        -F) format="$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    jq -r '.windows | to_entries[] | .value.name' "$STATE_FILE"
+    ;;
+  kill-window)
+    target=""
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        -t) target="$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    if [[ -z "$target" ]]; then exit 2; fi
+    # If target is @N, drop window and its panes.
+    if [[ "$target" == @* ]]; then
+      write_state "
+        .panes |= with_entries(select(.value.window_id != \"$target\"))
+        | .windows |= with_entries(select(.key != \"$target\"))
+      "
+      exit 0
+    fi
+    # Otherwise treat as session:window_idx — drop matching windows by index.
+    idx="${target##*:}"
+    write_state "
+      .panes |= with_entries(select((.value.window_index | tostring) != \"$idx\"))
+      | .windows |= with_entries(select((.value.index | tostring) != \"$idx\"))
+    "
+    ;;
+  kill-pane)
+    target=""
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        -t) target="$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    if [[ -z "$target" ]]; then exit 2; fi
+    write_state ".panes |= with_entries(select(.key != \"$target\"))"
+    ;;
+  show-options)
+    # Only `-g pane-base-index` is consulted by pane-registry.
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        -g) shift ;;
+        *) name="$1"; shift ;;
+      esac
+    done
+    case "${name:-pane-base-index}" in
+      pane-base-index) echo "pane-base-index 0" ;;
+      *) echo "${name:-} 0" ;;
+    esac
+    ;;
+  *)
+    echo "shim: unsupported tmux subcmd: $subcmd $*" >&2
+    exit 2
+    ;;
+esac

--- a/skills/flightdeck/lib/flightdeck-core/tests/parity/tmux-shim/tmux
+++ b/skills/flightdeck/lib/flightdeck-core/tests/parity/tmux-shim/tmux
@@ -163,6 +163,12 @@ case "$subcmd" in
       esac
     done
     if [[ -z "$target" ]]; then exit 2; fi
+    # TMUX_SHIM_REFUSE_KILL=1 simulates a tmux that returns non-zero
+    # AND leaves the target alive — used by the exit-5 teardown test.
+    if [[ "${TMUX_SHIM_REFUSE_KILL:-0}" == "1" ]]; then
+      echo "shim: kill-window refused (TMUX_SHIM_REFUSE_KILL=1)" >&2
+      exit 1
+    fi
     # If target is @N, drop window and its panes.
     if [[ "$target" == @* ]]; then
       write_state "
@@ -187,6 +193,10 @@ case "$subcmd" in
       esac
     done
     if [[ -z "$target" ]]; then exit 2; fi
+    if [[ "${TMUX_SHIM_REFUSE_KILL:-0}" == "1" ]]; then
+      echo "shim: kill-pane refused (TMUX_SHIM_REFUSE_KILL=1)" >&2
+      exit 1
+    fi
     write_state ".panes |= with_entries(select(.key != \"$target\"))"
     ;;
   show-options)

--- a/skills/flightdeck/patterns/tmux-monitoring.md
+++ b/skills/flightdeck/patterns/tmux-monitoring.md
@@ -63,7 +63,7 @@ if tmux list-panes -a -F '#{pane_id}' | grep -qFx "$pane_id"; then
 fi
 ```
 
-When `pane_id` is gone, the original pane is already destroyed; do NOT fall back to `pane_target` to "clean up". Either the issue is already terminal (`merged|aborted|dead`) and the window is already closed (no-op), or the registry has drifted and the caller must escalate. The shared implementation lives at `scripts/pane-registry teardown-window <ISSUE>` and is what `workflows/close-issue.md` § 4 calls; do not reimplement the kill path inline.
+When `pane_id` is gone, the original pane is already destroyed; do NOT fall back to `pane_target` to "clean up". Either the issue is already terminal (`merged|aborted|dead`) and the window is already closed (no-op), or the registry has drifted and the caller must escalate. The shared implementation lives at `scripts/pane-registry teardown-window <ISSUE>` (alias `teardown-entry <ENTRY_ID>` for the TrackedEntry schema) and is what `workflows/close-issue.md` § 4 calls; do not reimplement the kill path inline. The helper distinguishes every outcome via exit code: `0` success/already-closed, `1` issue-not-registered, `3` registry-drift (pane gone + non-terminal), `4` policy-refusal (pane alive + non-terminal; pass `--force` to override), `5` kill-failed (post-kill liveness check still finds the pane), `6` registry-read-failure. Callers must distinguish `1` from `6` — the former is idempotent, the latter is state corruption.
 
 The same rule applies to capture-pane reads during the close-issue two-signal check: prefer `pane_id`. A stale `pane_target` would feed an unrelated window's text into the signal accumulator and could either mask a real termination or trip a false positive on the wrong content.
 
@@ -71,7 +71,16 @@ The same rule applies to capture-pane reads during the close-issue two-signal ch
 
 ### Reconcile-time backfill guard (#16)
 
-`pane-registry reconcile` opportunistically backfills `pane_id` for legacy entries that recorded only `pane_target`. The backfill MUST reject any `pane_target` whose current `window_name` no longer matches the registered `window` — a mismatch means the original window was destroyed and the index has been reassigned. Adopting that pane id into the registry would silently graft an unrelated window onto the issue, and the next `teardown-window` call would then kill it. When the window-name guard rejects a backfill, leave `pane_id` empty so the liveness check drops the entry on the same pass.
+`pane-registry reconcile` opportunistically backfills `pane_id` for legacy entries that recorded only `pane_target`. tmux reuses window indices after a window is destroyed, so a stale `pane_target` may now resolve to an unrelated window; adopting its `pane_id` into the registry would silently graft that window onto the issue, and the next `teardown-window` call would then kill it. Window names are mutable (pi/codex auto-rename their windows; users can rename arbitrarily; duplicate names are allowed), so a single window-name comparison is too weak.
+
+The backfill requires the AND of two independent invariants:
+
+1. `#{window_name}` at the recorded `pane_target` == registered `window`.
+2. `#{pane_current_path}` at the recorded `pane_target` is `worktree` or starts with `worktree/`. The cwd-anchor is harder to spoof: agents launch with cwd pinned to their worktree, and a window-index collision with an identical-worktree-prefix is vanishingly unlikely.
+
+If either check has hard evidence of mismatch — a non-empty observed value that disagrees — reconcile MUST NOT adopt the pane id AND MUST NOT silently drop the entry. Instead it emits a single `reconciled: drift detected for N entr...` line on stderr and leaves the entry untouched so the operator can investigate. The drift gate covers both the index-reuse case from #16 and the rarer case of a user reusing a window name across workspaces.
+
+When neither check has enough data to disprove identity (e.g. either field empty), reconcile falls through to adoption — a benign cwd-changed-by-user pane would still get caught by `teardown-window`'s separate liveness check against the adopted `pane_id`.
 
 If fingerprinting fails (no sentinel matches on any pane), default to pane 0 and log a warning. Pane 0 is right for opencode and claude code in standard layouts.
 

--- a/skills/flightdeck/patterns/tmux-monitoring.md
+++ b/skills/flightdeck/patterns/tmux-monitoring.md
@@ -40,6 +40,39 @@ done
 
 Persist BOTH `pane_target` (`"HT:cc-463.0"`) and the immutable `pane_id` (`"%403"`) in master state. `pane-registry init` resolves and stores both at spawn time; reconcile / drift recovery keep them in sync. The daemon and pane-poll prefer `pane_id` because pi/codex auto-rename their tmux window once the TUI starts, which breaks any `pane_target`-only lookup once the window name changes.
 
+### Stable-id rule for destructive ops (#16)
+
+**Never derive a destructive tmux target from `pane_target`.** tmux reuses window indices after a window is destroyed, so the recorded `pane_target` (`session:window-index.pane-index`) is only valid for the lifetime of the original pane. A stripped `WINDOW_TARGET="${pane_target%.*}"` produces a session:window-index string that may now point to a completely different window — e.g. the long-running `flightdeck-daemon` window, or the user's editor window. Calling `tmux kill-window` against that derived target destroys the unrelated workload.
+
+Destructive teardown (`kill-window`, `kill-pane`, anything that removes panes/windows) MUST use the stable `pane_id` (`%N`) recorded at init time:
+
+```bash
+# WRONG — derives a reusable index; can kill the daemon after window reuse (#16)
+WINDOW_TARGET="${pane_target%.*}"
+tmux kill-window -t "$WINDOW_TARGET"
+
+# RIGHT — stable id; only ever targets the originally-registered pane
+if tmux list-panes -a -F '#{pane_id}' | grep -qFx "$pane_id"; then
+  window_id=$(tmux display-message -t "$pane_id" -p '#{window_id}')
+  pane_count=$(tmux list-panes -t "$window_id" -F '#{pane_id}' | wc -l)
+  if [[ "$pane_count" == "1" ]]; then
+    tmux kill-window -t "$window_id"
+  else
+    tmux kill-pane -t "$pane_id"
+  fi
+fi
+```
+
+When `pane_id` is gone, the original pane is already destroyed; do NOT fall back to `pane_target` to "clean up". Either the issue is already terminal (`merged|aborted|dead`) and the window is already closed (no-op), or the registry has drifted and the caller must escalate. The shared implementation lives at `scripts/pane-registry teardown-window <ISSUE>` and is what `workflows/close-issue.md` § 4 calls; do not reimplement the kill path inline.
+
+The same rule applies to capture-pane reads during the close-issue two-signal check: prefer `pane_id`. A stale `pane_target` would feed an unrelated window's text into the signal accumulator and could either mask a real termination or trip a false positive on the wrong content.
+
+**Bell-clear is not destructive.** `pane-respond` derives `WINDOW_TARGET="${TARGET%.*}"` to call `pane-clear-bell`, which only performs a paired `tmux select-window` (focus flip back to origin). Even against a recycled target this is at worst a brief UI flicker on an unrelated window; nothing is killed. The stable-id rule above applies specifically to destructive ops — `kill-window`, `kill-pane`, and anything else that removes panes or windows. The `pane-respond` send itself targets whatever the caller passed (callers should pass `pane_id` whenever possible; the registry's `list --format inner-panes` already prefers `pane_id`).
+
+### Reconcile-time backfill guard (#16)
+
+`pane-registry reconcile` opportunistically backfills `pane_id` for legacy entries that recorded only `pane_target`. The backfill MUST reject any `pane_target` whose current `window_name` no longer matches the registered `window` — a mismatch means the original window was destroyed and the index has been reassigned. Adopting that pane id into the registry would silently graft an unrelated window onto the issue, and the next `teardown-window` call would then kill it. When the window-name guard rejects a backfill, leave `pane_id` empty so the liveness check drops the entry on the same pass.
+
 If fingerprinting fails (no sentinel matches on any pane), default to pane 0 and log a warning. Pane 0 is right for opencode and claude code in standard layouts.
 
 ### Capture-pane scrollback depth

--- a/skills/flightdeck/scripts/pane-registry.bash
+++ b/skills/flightdeck/scripts/pane-registry.bash
@@ -13,7 +13,8 @@
 #   pane-registry remove <ISSUE>                         # also releases oc port + deletes spawn file
 #   pane-registry remove-merged                          # drop terminal-state issues with closed windows
 #   pane-registry reconcile                              # drop entries whose windows no longer exist
-#   pane-registry teardown-window <ISSUE>                # safely kill the issue's window/pane using stable pane_id
+#   pane-registry teardown-window <ISSUE> [--force]      # safely kill the issue's window/pane using stable pane_id
+#   pane-registry teardown-entry <ENTRY_ID> [--force]    # alias for teardown-window (TrackedEntry alignment)
 #   pane-registry oc-attach-args <ISSUE>                # prints '--url U --session S' or empty
 #   pane-registry find-by-pane <pane-target>             # prints issue id matching pane_target
 #
@@ -480,24 +481,44 @@ case "$ACTION" in
     ;;
 
   reconcile)
-    # Drop entries whose tmux panes no longer exist. Called by watch.md § 1
-    # at startup to clean up stale registry state from prior sessions.
-    # Same pane_id-first logic as remove-merged: the previous
-    # window_name-only check silently dropped live entries when pi/codex
-    # auto-renamed their window post-spawn (#3 finding 3).
+    # Reconcile registry against live tmux. Three things happen per entry:
     #
-    # Opportunistic backfill: for legacy entries with a pane_target but
-    # no pane_id, try to resolve it now so future reconciles use the
-    # stable key. CRITICAL (#16): tmux reuses window indices after
-    # windows are destroyed, so a stale pane_target like `HT:2.1` may
-    # now point to a completely different window (e.g. the daemon).
-    # Resolving pane_id from such a stale target would adopt the
-    # WRONG pane id into the registry and turn future teardowns into
-    # a kill of the unrelated window. The window-name guard rejects
-    # any pane_target whose current window name no longer matches the
-    # registered window — that mismatch means the original window was
-    # destroyed and the index recycled. Such entries get dropped
-    # outright (no backfill, no pane_target fallback).
+    #   1. Liveness check. If `pane_id` is recorded and tmux still lists
+    #      it, the entry survives. If `pane_id` is recorded but tmux no
+    #      longer lists it, the original pane is definitively gone and
+    #      the entry is dropped — this is the only deterministic case.
+    #
+    #   2. Opportunistic backfill (legacy entries: pane_target but no
+    #      pane_id). Backfilling from a stale pane_target is the #16
+    #      footgun: tmux reuses indices after windows are destroyed, so
+    #      session:idx.pidx may now point to an unrelated window. The
+    #      backfill needs a proof-of-identity strong enough to survive
+    #      window-name collisions (tmux allows duplicate names) and
+    #      rename races (pi/codex auto-rename their window post-spawn).
+    #
+    #      The invariant is the AND of two checks:
+    #        a. `#{window_name}` at the current pane_target == recorded
+    #           `window`.
+    #        b. `#{pane_current_path}` at the current pane_target is
+    #           prefixed by the recorded `worktree` (cwd-anchor proof).
+    #
+    #      If both checks pass with non-empty data: adopt pane_id.
+    #      If either check fails with non-empty data: emit drift and
+    #      LEAVE the entry untouched (no backfill, no drop) so a human
+    #      can investigate. The previous round-1 fix used window_name
+    #      alone and could (i) be defeated by name collision and (ii)
+    #      drop live entries silently when only the name mismatched.
+    #      If neither check has enough data to disprove identity, fall
+    #      through to backfill (conservative — a window-name collision
+    #      with an identical worktree path is vanishingly unlikely; a
+    #      cwd-changed-by-user pane will fail check (b) and route to
+    #      drift instead of adoption).
+    #
+    #   3. pane_target-only entries that survived (2): the window_name
+    #      liveness fallback used to drop them on rename mismatch. With
+    #      the drift gate in place that pathway is no longer reachable
+    #      without explicit operator intent; we keep the entry untouched
+    #      and let a future reconcile try again once pane_id is resolved.
     LIVE_PANES=$(tmux list-panes -a -F '#{pane_id}' 2>/dev/null | sort -u || true)
     SESSION=$(tmux display-message -p '#S' 2>/dev/null || echo unknown)
     LIVE_WINDOWS=$(tmux list-windows -t "$SESSION" -F '#{window_name}' 2>/dev/null | sort -u || true)
@@ -507,26 +528,38 @@ case "$ACTION" in
     REGISTERED=$(jq -r 'keys[]?' <<< "$ISSUES_JSON")
     DROPPED=()
     BACKFILLED=()
+    DRIFT=()
     while IFS= read -r issue; do
       [[ -z "$issue" ]] && continue
       fields=$(jq -r --arg k "$issue" '
-        .[$k] // {} | [(.pane_id // ""), (.pane_target // ""), (.window // "")] | @tsv
+        .[$k] // {} | [(.pane_id // ""), (.pane_target // ""), (.window // ""), (.worktree // "")] | @tsv
       ' <<< "$ISSUES_JSON")
       pane_id=$(awk -F'\t' '{print $1}' <<< "$fields")
       pane_target=$(awk -F'\t' '{print $2}' <<< "$fields")
       window=$(awk -F'\t' '{print $3}' <<< "$fields")
+      worktree=$(awk -F'\t' '{print $4}' <<< "$fields")
+      drift_this=0
       if [[ -z "$pane_id" && -n "$pane_target" ]]; then
-        # Same list-panes gate as init: avoid tmux's silent fallback to
-        # the active pane when the recorded pane_target no longer exists.
         if tmux list-panes -t "$pane_target" >/dev/null 2>&1; then
           current_window=$(tmux display-message -t "$pane_target" -p '#{window_name}' 2>/dev/null || echo "")
-          # Guard against index reuse (#16): if the window name at the
-          # recorded pane_target no longer matches the issue's window,
-          # the original window was destroyed and tmux has reassigned
-          # the index to an unrelated window. Do not backfill — the
-          # original pane is gone.
+          current_path=$(tmux display-message -t "$pane_target" -p '#{pane_current_path}' 2>/dev/null || echo "")
+          window_mismatch=0
+          path_mismatch=0
           if [[ -n "$window" && -n "$current_window" && "$current_window" != "$window" ]]; then
-            : # mismatched window name → leave pane_id empty so liveness check below drops this entry
+            window_mismatch=1
+          fi
+          if [[ -n "$worktree" && -n "$current_path" ]]; then
+            case "$current_path" in
+              "$worktree"|"$worktree"/*) ;;
+              *) path_mismatch=1 ;;
+            esac
+          fi
+          if (( window_mismatch == 1 || path_mismatch == 1 )); then
+            # Strong evidence of identity mismatch. Do NOT adopt; do NOT
+            # drop. Leave the entry untouched and emit drift so a human
+            # can decide. This is the #16 safety net.
+            DRIFT+=("$issue (window:'$window'→'$current_window' worktree:'$worktree'→'$current_path')")
+            drift_this=1
           else
             resolved=$(tmux display-message -t "$pane_target" -p '#{pane_id}' 2>/dev/null || echo "")
             if [[ -n "$resolved" ]]; then
@@ -536,6 +569,9 @@ case "$ACTION" in
             fi
           fi
         fi
+      fi
+      if (( drift_this == 1 )); then
+        continue
       fi
       alive=1
       if [[ -n "$pane_id" ]]; then
@@ -565,9 +601,15 @@ case "$ACTION" in
         "$([ ${#BACKFILLED[@]} -eq 1 ] && echo y || echo ies)" \
         "$(IFS=,; echo "${BACKFILLED[*]}")"
     fi
+    if [[ ${#DRIFT[@]} -gt 0 ]]; then
+      printf 'reconciled: drift detected for %d entr%s, left untouched (%s)\n' \
+        "${#DRIFT[@]}" \
+        "$([ ${#DRIFT[@]} -eq 1 ] && echo y || echo ies)" \
+        "$(IFS='|'; echo "${DRIFT[*]}")" >&2
+    fi
     ;;
 
-  teardown-window)
+  teardown-window|teardown-entry)
     # Safely tear down the tmux window/pane for an issue using the
     # stable `pane_id` (`%N`) recorded at init time. Never derives a
     # kill target from the human-readable `pane_target`
@@ -576,28 +618,76 @@ case "$ACTION" in
     # point to an unrelated window (the daemon, the user's editor,
     # etc.). Killing that would destroy the wrong workload (#16).
     #
+    # `teardown-entry` is an alias anticipating the TrackedEntry schema
+    # in docs/plans/flightdeck-session-management-reframe.md; both names
+    # call the same code path so callers can migrate gradually.
+    #
     # Behavior:
-    #   1. If `pane_id` is alive in `tmux list-panes -a`, kill the
-    #      window when it has exactly one pane, otherwise kill only
-    #      the pane. Single-pane-window kill matches the historical
+    #   1. pane_id alive + state ∈ {merged,aborted,dead}: kill the
+    #      window when it has exactly one pane, otherwise kill only the
+    #      pane. Single-pane-window kill matches the historical
     #      contract from close-issue.md § 4.
-    #   2. If `pane_id` is gone AND the issue is already in a terminal
-    #      state (`merged|aborted|dead`), treat the window as already
-    #      closed and exit success. No fallback to `pane_target`.
-    #   3. If `pane_id` is gone AND the issue is NOT terminal, exit 3
-    #      with an error: the registry has drifted from tmux reality
-    #      and the caller must escalate. Silently deriving a kill
-    #      target from `pane_target` is exactly the #16 footgun.
+    #   2. pane_id alive + state NOT terminal:
+    #        - default: refuse with exit 4 (policy guard — callers must
+    #          set the issue to a terminal state before tearing down).
+    #        - with --force: kill anyway. close-issue.md's normal path
+    #          sets state before invoking, so --force is the explicit
+    #          escape hatch for operator-driven cleanup.
+    #   3. pane_id gone + state terminal: treat as already closed and
+    #      exit success. No fallback to pane_target.
+    #   4. pane_id gone + state non-terminal: exit 3 (registry drift).
+    #
+    # Every destructive tmux call captures exit status and stderr; if
+    # the kill exits non-zero AND the pane is still listed afterwards,
+    # the helper exits 5 with the captured diagnostic instead of
+    # falsely reporting success.
+    #
+    # Registry-read errors (flightdeck-state failure) propagate as exit
+    # 6 with stderr forwarded — close-issue.md must not confuse them
+    # with an idempotent "already removed" outcome (exit 1).
     #
     # Exit codes:
     #   0 - window/pane killed, or already closed (terminal + dead pane)
-    #   1 - issue not found in registry
+    #   1 - issue not registered (caller may treat as idempotent no-op)
     #   2 - bad arguments
-    #   3 - registry drift: pane_id is gone but state is not terminal
-    ISSUE="${1:-}"
-    [[ -z "$ISSUE" ]] && { echo "Usage: teardown-window <ISSUE>" >&2; exit 2; }
-    entry=$("$FD_STATE" get ".issues[\"$ISSUE\"] // empty" 2>/dev/null || echo "")
-    if [[ -z "$entry" || "$entry" == "null" ]]; then
+    #   3 - registry drift: pane_id gone but state not terminal
+    #   4 - policy: pane_id alive but state non-terminal (rerun with --force)
+    #   5 - tmux kill failed: pane still alive after kill attempt
+    #   6 - registry read failure
+    ISSUE=""
+    FORCE=0
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --force) FORCE=1; shift ;;
+        --) shift; break ;;
+        -*) echo "teardown-window: unknown flag: $1" >&2; exit 2 ;;
+        *) [[ -z "$ISSUE" ]] && ISSUE="$1" || { echo "teardown-window: extra argument: $1" >&2; exit 2; }; shift ;;
+      esac
+    done
+    [[ -z "$ISSUE" ]] && { echo "Usage: $ACTION <ISSUE> [--force]" >&2; exit 2; }
+    # Separate stdout / stderr / status from flightdeck-state so we can
+    # distinguish read-failures (→ exit 6) from a successful empty
+    # lookup (→ exit 1). The previous body collapsed both with
+    # `2>/dev/null || echo ""`, which is exactly the failure mode
+    # called out as BLOCK #2.
+    fd_stderr_file=$(mktemp -t fd-teardown-stderr.XXXXXX)
+    trap 'rm -f "$fd_stderr_file"' EXIT
+    # `flightdeck-state get` returns:
+    #   exit 0 + empty stdout — state file present, lookup miss (idempotent)
+    #   exit 1                — state file does not exist (registry never initialized; idempotent)
+    #   exit >= 2             — usage error or genuine read failure
+    # Treat 0+empty and 1 as "not found"; only exit >= 2 escalates to
+    # exit 6 (registry read failure) per BLOCK #2.
+    entry=$("$FD_STATE" get ".issues[\"$ISSUE\"] // empty" 2>"$fd_stderr_file")
+    fd_status=$?
+    if (( fd_status >= 2 )); then
+      printf 'teardown-window: registry read failed (flightdeck-state exit=%s): ' "$fd_status" >&2
+      cat "$fd_stderr_file" >&2
+      echo >&2
+      exit 6
+    fi
+    entry_trim="${entry//[[:space:]]/}"
+    if (( fd_status == 1 )) || [[ -z "$entry_trim" || "$entry_trim" == "null" ]]; then
       echo "teardown-window: issue '$ISSUE' not found in registry" >&2
       exit 1
     fi
@@ -612,18 +702,43 @@ case "$ACTION" in
       fi
     fi
     if (( pane_alive == 1 )); then
+      case "$state" in
+        merged|aborted|dead) ;;
+        *)
+          if (( FORCE != 1 )); then
+            echo "teardown-window: policy refusal — pane_id '$pane_id' is alive but state is '$state' (not merged|aborted|dead); set a terminal state first or rerun with --force" >&2
+            exit 4
+          fi
+          ;;
+      esac
       window_id=$(tmux display-message -t "$pane_id" -p '#{window_id}' 2>/dev/null || echo "")
       pane_count=0
       if [[ -n "$window_id" ]]; then
         pane_count=$(tmux list-panes -t "$window_id" -F '#{pane_id}' 2>/dev/null | wc -l | tr -d ' ')
       fi
+      kill_stderr=$(mktemp -t fd-teardown-kill-stderr.XXXXXX)
       if [[ -n "$window_id" && "$pane_count" == "1" ]]; then
-        tmux kill-window -t "$window_id" 2>/dev/null || true
-        printf 'teardown-window: killed window %s (pane_id=%s, window=%s)\n' "$window_id" "$pane_id" "$window"
+        tmux kill-window -t "$window_id" 2>"$kill_stderr"
+        kill_status=$?
+        kind="window $window_id"
       else
-        tmux kill-pane -t "$pane_id" 2>/dev/null || true
-        printf 'teardown-window: killed pane %s (window has %s panes, window=%s)\n' "$pane_id" "$pane_count" "$window"
+        tmux kill-pane -t "$pane_id" 2>"$kill_stderr"
+        kill_status=$?
+        kind="pane $pane_id"
       fi
+      # Verify by re-checking the live pane list. tmux can return
+      # non-zero for benign reasons (e.g. the pane vanished between
+      # the alive-check and the kill), so the post-kill liveness
+      # check is authoritative — not the exit code.
+      if tmux list-panes -a -F '#{pane_id}' 2>/dev/null | grep -qFx "$pane_id"; then
+        printf 'teardown-window: kill of %s failed (status=%s, pane_id=%s still alive): ' "$kind" "$kill_status" "$pane_id" >&2
+        cat "$kill_stderr" >&2
+        echo >&2
+        rm -f "$kill_stderr"
+        exit 5
+      fi
+      rm -f "$kill_stderr"
+      printf 'teardown-window: killed %s (pane_id=%s, window=%s, force=%s)\n' "$kind" "$pane_id" "$window" "$FORCE"
       exit 0
     fi
     # pane_id missing or already dead — gate teardown on terminal state.
@@ -641,7 +756,7 @@ case "$ACTION" in
 
   *)
     echo "Unknown action: $ACTION" >&2
-    echo "Actions: init | list | get | set-state | set-substate | set | log-decision | remove | remove-merged | reconcile | teardown-window | oc-attach-args | cc-channel-args | pi-bridge-args | cx-bridge-args | find-by-pane" >&2
+    echo "Actions: init | list | get | set-state | set-substate | set | log-decision | remove | remove-merged | reconcile | teardown-window | teardown-entry | oc-attach-args | cc-channel-args | pi-bridge-args | cx-bridge-args | find-by-pane" >&2
     exit 2
     ;;
 esac

--- a/skills/flightdeck/scripts/pane-registry.bash
+++ b/skills/flightdeck/scripts/pane-registry.bash
@@ -610,6 +610,9 @@ case "$ACTION" in
     ;;
 
   teardown-window|teardown-entry)
+    # Parity: lib/flightdeck-core/src/bin/pane-registry.ts cmdTeardownWindow
+    # (see tests/parity/pane-registry.test.ts).
+    #
     # Safely tear down the tmux window/pane for an issue using the
     # stable `pane_id` (`%N`) recorded at init time. Never derives a
     # kill target from the human-readable `pane_target`

--- a/skills/flightdeck/scripts/pane-registry.bash
+++ b/skills/flightdeck/scripts/pane-registry.bash
@@ -13,6 +13,7 @@
 #   pane-registry remove <ISSUE>                         # also releases oc port + deletes spawn file
 #   pane-registry remove-merged                          # drop terminal-state issues with closed windows
 #   pane-registry reconcile                              # drop entries whose windows no longer exist
+#   pane-registry teardown-window <ISSUE>                # safely kill the issue's window/pane using stable pane_id
 #   pane-registry oc-attach-args <ISSUE>                # prints '--url U --session S' or empty
 #   pane-registry find-by-pane <pane-target>             # prints issue id matching pane_target
 #
@@ -483,9 +484,20 @@ case "$ACTION" in
     # at startup to clean up stale registry state from prior sessions.
     # Same pane_id-first logic as remove-merged: the previous
     # window_name-only check silently dropped live entries when pi/codex
-    # auto-renamed their window post-spawn (#3 finding 3). Opportunistic
-    # backfill: for legacy entries with a pane_target but no pane_id, try
-    # to resolve it now so future reconciles use the stable key.
+    # auto-renamed their window post-spawn (#3 finding 3).
+    #
+    # Opportunistic backfill: for legacy entries with a pane_target but
+    # no pane_id, try to resolve it now so future reconciles use the
+    # stable key. CRITICAL (#16): tmux reuses window indices after
+    # windows are destroyed, so a stale pane_target like `HT:2.1` may
+    # now point to a completely different window (e.g. the daemon).
+    # Resolving pane_id from such a stale target would adopt the
+    # WRONG pane id into the registry and turn future teardowns into
+    # a kill of the unrelated window. The window-name guard rejects
+    # any pane_target whose current window name no longer matches the
+    # registered window — that mismatch means the original window was
+    # destroyed and the index recycled. Such entries get dropped
+    # outright (no backfill, no pane_target fallback).
     LIVE_PANES=$(tmux list-panes -a -F '#{pane_id}' 2>/dev/null | sort -u || true)
     SESSION=$(tmux display-message -p '#S' 2>/dev/null || echo unknown)
     LIVE_WINDOWS=$(tmux list-windows -t "$SESSION" -F '#{window_name}' 2>/dev/null | sort -u || true)
@@ -507,11 +519,21 @@ case "$ACTION" in
         # Same list-panes gate as init: avoid tmux's silent fallback to
         # the active pane when the recorded pane_target no longer exists.
         if tmux list-panes -t "$pane_target" >/dev/null 2>&1; then
-          resolved=$(tmux display-message -t "$pane_target" -p '#{pane_id}' 2>/dev/null || echo "")
-          if [[ -n "$resolved" ]]; then
-            "$FD_STATE" set ".issues[\"$issue\"].pane_id" "\"$resolved\""
-            pane_id="$resolved"
-            BACKFILLED+=("$issue")
+          current_window=$(tmux display-message -t "$pane_target" -p '#{window_name}' 2>/dev/null || echo "")
+          # Guard against index reuse (#16): if the window name at the
+          # recorded pane_target no longer matches the issue's window,
+          # the original window was destroyed and tmux has reassigned
+          # the index to an unrelated window. Do not backfill — the
+          # original pane is gone.
+          if [[ -n "$window" && -n "$current_window" && "$current_window" != "$window" ]]; then
+            : # mismatched window name → leave pane_id empty so liveness check below drops this entry
+          else
+            resolved=$(tmux display-message -t "$pane_target" -p '#{pane_id}' 2>/dev/null || echo "")
+            if [[ -n "$resolved" ]]; then
+              "$FD_STATE" set ".issues[\"$issue\"].pane_id" "\"$resolved\""
+              pane_id="$resolved"
+              BACKFILLED+=("$issue")
+            fi
           fi
         fi
       fi
@@ -519,6 +541,11 @@ case "$ACTION" in
       if [[ -n "$pane_id" ]]; then
         grep -qx "$pane_id" <<< "$LIVE_PANES" || alive=0
       else
+        # No stable pane_id — pane_target alone is not trustworthy
+        # (#16 index reuse), so use window_name liveness as the only
+        # fallback. If the window name is gone the entry is dropped;
+        # if it happens to still exist, the entry survives this pass
+        # and a future reconcile will retry pane_id resolution.
         if [[ -n "$window" ]] && ! grep -qx "$window" <<< "$LIVE_WINDOWS"; then alive=0; fi
       fi
       if (( alive == 0 )); then
@@ -540,9 +567,81 @@ case "$ACTION" in
     fi
     ;;
 
+  teardown-window)
+    # Safely tear down the tmux window/pane for an issue using the
+    # stable `pane_id` (`%N`) recorded at init time. Never derives a
+    # kill target from the human-readable `pane_target`
+    # (`session:window.index`) — tmux reuses window indices after the
+    # original window is destroyed, so a stale `pane_target` may now
+    # point to an unrelated window (the daemon, the user's editor,
+    # etc.). Killing that would destroy the wrong workload (#16).
+    #
+    # Behavior:
+    #   1. If `pane_id` is alive in `tmux list-panes -a`, kill the
+    #      window when it has exactly one pane, otherwise kill only
+    #      the pane. Single-pane-window kill matches the historical
+    #      contract from close-issue.md § 4.
+    #   2. If `pane_id` is gone AND the issue is already in a terminal
+    #      state (`merged|aborted|dead`), treat the window as already
+    #      closed and exit success. No fallback to `pane_target`.
+    #   3. If `pane_id` is gone AND the issue is NOT terminal, exit 3
+    #      with an error: the registry has drifted from tmux reality
+    #      and the caller must escalate. Silently deriving a kill
+    #      target from `pane_target` is exactly the #16 footgun.
+    #
+    # Exit codes:
+    #   0 - window/pane killed, or already closed (terminal + dead pane)
+    #   1 - issue not found in registry
+    #   2 - bad arguments
+    #   3 - registry drift: pane_id is gone but state is not terminal
+    ISSUE="${1:-}"
+    [[ -z "$ISSUE" ]] && { echo "Usage: teardown-window <ISSUE>" >&2; exit 2; }
+    entry=$("$FD_STATE" get ".issues[\"$ISSUE\"] // empty" 2>/dev/null || echo "")
+    if [[ -z "$entry" || "$entry" == "null" ]]; then
+      echo "teardown-window: issue '$ISSUE' not found in registry" >&2
+      exit 1
+    fi
+    fields=$(jq -r '[(.state // ""), (.pane_id // ""), (.window // "")] | @tsv' <<< "$entry")
+    state=$(awk -F'\t' '{print $1}' <<< "$fields")
+    pane_id=$(awk -F'\t' '{print $2}' <<< "$fields")
+    window=$(awk -F'\t' '{print $3}' <<< "$fields")
+    pane_alive=0
+    if [[ -n "$pane_id" ]]; then
+      if tmux list-panes -a -F '#{pane_id}' 2>/dev/null | grep -qFx "$pane_id"; then
+        pane_alive=1
+      fi
+    fi
+    if (( pane_alive == 1 )); then
+      window_id=$(tmux display-message -t "$pane_id" -p '#{window_id}' 2>/dev/null || echo "")
+      pane_count=0
+      if [[ -n "$window_id" ]]; then
+        pane_count=$(tmux list-panes -t "$window_id" -F '#{pane_id}' 2>/dev/null | wc -l | tr -d ' ')
+      fi
+      if [[ -n "$window_id" && "$pane_count" == "1" ]]; then
+        tmux kill-window -t "$window_id" 2>/dev/null || true
+        printf 'teardown-window: killed window %s (pane_id=%s, window=%s)\n' "$window_id" "$pane_id" "$window"
+      else
+        tmux kill-pane -t "$pane_id" 2>/dev/null || true
+        printf 'teardown-window: killed pane %s (window has %s panes, window=%s)\n' "$pane_id" "$pane_count" "$window"
+      fi
+      exit 0
+    fi
+    # pane_id missing or already dead — gate teardown on terminal state.
+    case "$state" in
+      merged|aborted|dead)
+        printf 'teardown-window: window already closed (pane_id=%s gone, state=%s)\n' "${pane_id:-<none>}" "$state"
+        exit 0
+        ;;
+      *)
+        echo "teardown-window: registry drift — pane_id '${pane_id:-<none>}' is gone but state is '${state}' (not merged|aborted|dead); refusing to derive kill target from pane_target (#16)" >&2
+        exit 3
+        ;;
+    esac
+    ;;
+
   *)
     echo "Unknown action: $ACTION" >&2
-    echo "Actions: init | list | get | set-state | set-substate | set | log-decision | remove | remove-merged | reconcile | oc-attach-args | find-by-pane" >&2
+    echo "Actions: init | list | get | set-state | set-substate | set | log-decision | remove | remove-merged | reconcile | teardown-window | oc-attach-args | cc-channel-args | pi-bridge-args | cx-bridge-args | find-by-pane" >&2
     exit 2
     ;;
 esac

--- a/skills/flightdeck/workflows/close-issue.md
+++ b/skills/flightdeck/workflows/close-issue.md
@@ -29,7 +29,7 @@ Signals (any two):
 
 Implementation:
 
-1. Read pane: `tmux capture-pane -t <pane_target> -p -S -200`.
+1. Read pane: `tmux capture-pane -t "${pane_id:-$pane_target}" -p -S -200`. Prefer the stable `pane_id` (`%N`) from the registry over the human-readable `pane_target` — tmux reuses window indices after windows are destroyed, so a stale `pane_target` can after-the-fact point to an unrelated window (the daemon, the user's editor, etc.) and feed that window's text into the two-signal check. See `patterns/tmux-monitoring.md` § Stable-id rule.
 2. Apply portable buffer signals (banner, end-session text).
 3. Apply harness-specific signals via the adapter for the registered harness:
    - **Claude Code**: idle indicator `* Idle` on its own line near buffer end; destroyed-CWD pattern includes `Path does not exist` and a path matching the worktree.
@@ -64,9 +64,21 @@ Persist any captured summary fields via `pane-registry set <ISSUE_ID> <field> <v
 
 ## § 4: Tear Down Window
 
-1. Resolve the window: `WINDOW_TARGET="${pane_target%.*}"` (strip the pane index suffix).
-2. Kill the window: `tmux kill-window -t "$WINDOW_TARGET"`.
-3. Verify it's gone: `tmux list-windows -F '#{window_name}' | grep -qx "<window-name>"` — if still present, log a warning and continue (don't escalate; the user can clean up manually).
+Delegate the destructive teardown to the registry. **Never** derive a kill target from `pane_target` (`session:window.index`) — tmux reuses window indices after windows are destroyed, so the stored `pane_target` can after-the-fact point to an unrelated window (the daemon, the user's editor, ...), and a naive `tmux kill-window -t "${pane_target%.*}"` would destroy that unrelated workload (#16). The registry stores a stable `pane_id` (`%N`) at init time; the helper uses it as the only correct destructive target.
+
+1. Run the safe teardown:
+   ```
+   .agents/skills/flightdeck/scripts/pane-registry teardown-window <ISSUE_ID>
+   ```
+   The helper:
+   - **`pane_id` alive** → resolves the pane's `window_id` (`@N`). If that window has a single pane, runs `tmux kill-window -t "@N"`; otherwise runs `tmux kill-pane -t "%N"` (so we don't accidentally close another pane sharing the window).
+   - **`pane_id` gone AND `state ∈ {merged, aborted, dead}`** → treats the window as already closed; no fallback to `pane_target`. Exits success.
+   - **`pane_id` gone AND state is NOT terminal** → exits non-zero (registry drift). Do NOT retry by stripping `pane_target` — that's the original #16 footgun.
+2. Handle the exit:
+   - Exit `0` → done; proceed to § 5.
+   - Exit `1` (issue not registered) → already cleaned up; idempotent no-op; proceed to § 5.
+   - Exit `3` (registry drift) → log a warning with the issue id and continue. Skip § 5's destructive verify; let the user clean up manually. State has already been updated in § 3, so terminate's archive captures the outcome.
+3. Verify the window is gone (defensive): `tmux list-panes -a -F '#{pane_id}' | grep -qFx "<pane_id>"` — if the recorded `pane_id` is still alive, log a warning and continue (don't escalate; the user can clean up manually).
 
 Pane registry entry is left in place for the end-of-session report (see `terminate.md` § 1). It carries the issue's history. Do NOT call `pane-registry remove` here — terminate is responsible for the final cleanup.
 

--- a/skills/flightdeck/workflows/close-issue.md
+++ b/skills/flightdeck/workflows/close-issue.md
@@ -66,19 +66,25 @@ Persist any captured summary fields via `pane-registry set <ISSUE_ID> <field> <v
 
 Delegate the destructive teardown to the registry. **Never** derive a kill target from `pane_target` (`session:window.index`) — tmux reuses window indices after windows are destroyed, so the stored `pane_target` can after-the-fact point to an unrelated window (the daemon, the user's editor, ...), and a naive `tmux kill-window -t "${pane_target%.*}"` would destroy that unrelated workload (#16). The registry stores a stable `pane_id` (`%N`) at init time; the helper uses it as the only correct destructive target.
 
+This step runs AFTER § 3 has already written the terminal state (`merged|aborted|dead`). The helper enforces that contract — it will refuse to kill an alive pane whose registry state is non-terminal unless `--force` is passed.
+
 1. Run the safe teardown:
    ```
    .agents/skills/flightdeck/scripts/pane-registry teardown-window <ISSUE_ID>
    ```
-   The helper:
-   - **`pane_id` alive** → resolves the pane's `window_id` (`@N`). If that window has a single pane, runs `tmux kill-window -t "@N"`; otherwise runs `tmux kill-pane -t "%N"` (so we don't accidentally close another pane sharing the window).
-   - **`pane_id` gone AND `state ∈ {merged, aborted, dead}`** → treats the window as already closed; no fallback to `pane_target`. Exits success.
-   - **`pane_id` gone AND state is NOT terminal** → exits non-zero (registry drift). Do NOT retry by stripping `pane_target` — that's the original #16 footgun.
-2. Handle the exit:
-   - Exit `0` → done; proceed to § 5.
-   - Exit `1` (issue not registered) → already cleaned up; idempotent no-op; proceed to § 5.
-   - Exit `3` (registry drift) → log a warning with the issue id and continue. Skip § 5's destructive verify; let the user clean up manually. State has already been updated in § 3, so terminate's archive captures the outcome.
-3. Verify the window is gone (defensive): `tmux list-panes -a -F '#{pane_id}' | grep -qFx "<pane_id>"` — if the recorded `pane_id` is still alive, log a warning and continue (don't escalate; the user can clean up manually).
+   The helper performs the kill, verifies the pane is actually gone via a post-kill liveness check, and exits with a status that distinguishes every outcome below. `pane-registry teardown-entry <ENTRY_ID>` is an alias of the same code path anticipating the TrackedEntry schema.
+
+2. Branch on the helper's exit code:
+   | Exit | Meaning | Action |
+   |------|---------|--------|
+   | `0`  | window/pane killed, OR already closed (terminal + dead pane) | proceed to § 5 |
+   | `1`  | issue not registered — already removed by terminate or earlier cleanup | idempotent no-op; proceed to § 5 |
+   | `3`  | registry drift: `pane_id` gone but state is non-terminal. The registry says we should still be running. Do NOT derive a kill target from `pane_target` (#16). | log a warning with the issue id, skip the destructive verify in step 3, continue. The state recorded in § 3 means terminate's archive still captures the outcome. |
+   | `4`  | policy refusal: pane is alive but state is non-terminal. § 3 should have set a terminal state already — this signals an ordering bug in the caller. | log the helper's stderr and abort the workflow; the user must investigate. Do NOT silently rerun with `--force`. |
+   | `5`  | tmux kill failed: pane is still alive after the kill attempt. The helper has already captured the kill's stderr. | forward the helper's stderr to the user; the user may need to kill the window manually. |
+   | `6`  | registry read failure (flightdeck-state broken). | forward the helper's stderr; abort the workflow. Treating this as an idempotent no-op would mask state corruption. |
+
+3. Verify the window is gone (defensive, skipped on exit 3/4/5/6): `tmux list-panes -a -F '#{pane_id}' | grep -qFx "<pane_id>"` — if the recorded `pane_id` is still alive after a `0` exit, log a warning (don't escalate; the helper's own post-kill check already escalates to exit 5 in that case, so a positive match here is a tmux-state race the user can sort out).
 
 Pane registry entry is left in place for the end-of-session report (see `terminate.md` § 1). It carries the issue's history. Do NOT call `pane-registry remove` here — terminate is responsible for the final cleanup.
 


### PR DESCRIPTION
Fixes #16.

## Problem

`workflows/close-issue.md` § 4 derived a destructive tmux target by stripping the pane index off the recorded `pane_target`:

```bash
WINDOW_TARGET="${pane_target%.*}"
tmux kill-window -t "$WINDOW_TARGET"
```

tmux reuses window indices after a window is destroyed. Once the original issue window was gone, a stale registry entry like `HT:2.1` could now point at the running `flightdeck-daemon-s1` window or the user's editor — and the cleanup would kill *that* window instead. The registry already stores the immutable `pane_id` (`%N`) at init time, which correctly reflects whether the original pane is still alive.

## Fix

1. **New `pane-registry teardown-window <ISSUE>` action** (bash + TS) encapsulates safe teardown:
   - `pane_id` alive → kill `window_id` (`@N`) if it has a single pane, else kill only `pane_id`.
   - `pane_id` gone AND state ∈ {merged, aborted, dead} → exit 0, "already closed". No fallback to `pane_target`.
   - `pane_id` gone AND state is non-terminal → exit 3 (registry drift). Caller logs and continues; no destructive op.

2. **`close-issue.md` § 4** rewritten to delegate to the helper and handle its exit codes. § 1 capture-pane prefers `pane_id` over `pane_target` to avoid feeding an unrelated window's text into the two-signal accumulator.

3. **`pane-registry reconcile`** backfill is now guarded by a `window_name` match. The old backfill resolved `pane_id` from any pane_target whose `list-panes` succeeded — after index reuse that would adopt an unrelated window's pane id and weaponize the next teardown. Now a window-name mismatch leaves `pane_id` empty and the entry gets dropped on the same pass.

4. **`patterns/tmux-monitoring.md`** gets a new "Stable-id rule for destructive ops" section with the wrong/right example, the reconcile-time backfill guard, and a note that `pane-respond`'s `WINDOW_TARGET="${TARGET%.*}"` bell-clear is non-destructive (just a `select-window` focus flip) and stays as-is.

## Tests

Parity test (`tests/parity/pane-registry.test.ts`) covers all five teardown branches against both implementations:
- pane_id alive + single-pane window → window killed
- pane_id alive + multi-pane window → only the pane killed, siblings survive
- pane_id gone + terminal state → no-op success
- pane_id gone + non-terminal state → exit 3 (registry drift)
- **#16 scenario**: creates a real victim window, plants a stale `pane_target` pointing at it, asserts the victim survives
- unknown issue → exit 1

```
cd skills/flightdeck/lib/flightdeck-core
bun test         # 189 pass, 0 fail
bun run typecheck  # clean
```

## Notes for reviewers

- The `.bash` sibling stays per the worktree rule (TS port is default, bash is fallback).
- No CLI version bump.
- No harness mirrors touched.