### PR TITLE
feat(flightdeck): Phase 0 owner gating + dashboard visibility (reframe plan)

### DIFF
--- a/docs/plans/flightdeck-session-management-reframe.md
+++ b/docs/plans/flightdeck-session-management-reframe.md
@@ -158,17 +158,18 @@ Status (2026-05-13): **REMAINING**. PR #23 / commit `1fbed75` explicitly deferre
 1. **[REMAINING]** Add short repo guidance to `AGENTS.md` after implementation is ready:
    - When user asks for a new tmux tab/window for testing, create a new tmux window in the existing session, never split the current pane.
    - Use Flightdeck session tools/skill for harness launch and IO; persist `%pane_id`/`#{window_id}`; do not rely on window names.
-2. **[REMAINING]** Add owner metadata to current Flightdeck state init/watch path before broad schema work:
+2. **[DONE]** Add owner metadata to current Flightdeck state init/watch path before broad schema work:
    - `owner.pane_id`
    - `owner.pane_target`
    - `owner.harness`
    - `owner.cwd`
+   - `owner.pid`
    - Pi owner bridge metadata when master harness is Pi.
-3. **[REMAINING]** Update `pi-flightdeck` to render the mini dashboard only for the owner by default.
+3. **[DONE]** Update `pi-flightdeck` to render the mini dashboard only for the owner by default.
    - New setting: `dashboardVisibility = owner | tmux-session | always`.
    - Default: `owner`.
    - Popup can show read-only observer info if opened manually, but persistent widget should not appear in peer Pi sessions.
-4. **[REMAINING]** Preserve child-pane suppression (`PI_SUBAGENT_CHILD_AGENT`, `FLIGHTDECK_CHILD_PANE`) as an additional guard.
+4. **[DONE]** Preserve child-pane suppression (`PI_SUBAGENT_CHILD_AGENT`, `FLIGHTDECK_CHILD_PANE`) as an additional guard.
 
 Validation:
 

--- a/docs/plans/flightdeck-session-management-reframe.md
+++ b/docs/plans/flightdeck-session-management-reframe.md
@@ -22,14 +22,14 @@ Merged baseline on `origin/main` now includes the following relevant work:
 
 ### Partially delivered
 
-- **Phase 1** has a Pi render-side `readTrackedEntries` seam from PR #23, but the core `skills/flightdeck/lib/flightdeck-core/src/state/` helpers, `entryIdForIssue`, dual-write/projection helpers, `.entries`, `schema_version`, and owner fields remain.
+- **Phase 1** has a Pi render-side `readTrackedEntries` seam from PR #23 and additive v1 `owner` metadata from PR #25, but the core `skills/flightdeck/lib/flightdeck-core/src/state/` helpers, `entryIdForIssue`, dual-write/projection helpers, `.entries`, and `schema_version` remain.
 - **Phase 2** has the `teardown-entry` alias from PR #22 and the `FLIGHTDECK_MANAGED=1`/`flightdeck-mode` managed-session signal from PR #21, but generic `init-entry`, `--kind adhoc`, `session-terminal`/`flightdeck-session`, and manual attach behavior remain.
 - **Phase 3** has canonical `pi-bg-task-exit` handling from PR #24 and stale cleanup tags from PR #21 in both daemon paths, but the `session-watch.md` vs issue `watch.md` split remains.
-- **Phase 5** has render normalization, terminated archive fallback, and extracted terminated render helpers from PR #23, but type renames, sessions-first UI copy, kind badges, and owner-aware dashboard behavior remain.
+- **Phase 5** has render normalization, terminated archive fallback, and extracted terminated render helpers from PR #23 plus owner-aware persistent-widget behavior from PR #25, but type renames, sessions-first UI copy, and kind badges remain.
 
 ### Remaining unchanged in scope
 
-- **Phase 0 remains first and unchanged**: owner metadata, owner-only persistent dashboard rendering, and dashboard visibility settings are not delivered.
+- **Phase 0 follow-up remains**: short repo guidance in `AGENTS.md` is still pending because the Phase 0 implementation change only touched `skills/flightdeck/`, `pi-extensions/pi-flightdeck/`, and this plan doc.
 - Official ad-hoc session start/attach, schema v2 generic entries, generic watch split, issue-mode isolation, and full docs refresh remain in this plan.
 
 ## Why this is needed
@@ -153,7 +153,7 @@ Compatibility requirement: read old `.issues` state as `kind: "issue"` entries. 
 
 Purpose: stop the exact class of mistakes seen in the ad-hoc test while the larger reframe is built.
 
-Status (2026-05-13): **REMAINING**. PR #23 / commit `1fbed75` explicitly deferred owner gating and dashboard owner-only behavior, so this phase is still required and unchanged. Keep Phase 0 first.
+Status (2026-05-13): **PARTIAL**. Owner metadata, owner-scoped `pi-flightdeck` rendering, `dashboardVisibility`, and child-pane suppression are done in PR #25. The only remaining Phase 0 item is the short `AGENTS.md` operational guidance, deferred because that file was outside this worker's edit scope.
 
 1. **[REMAINING]** Add short repo guidance to `AGENTS.md` after implementation is ready:
    - When user asks for a new tmux tab/window for testing, create a new tmux window in the existing session, never split the current pane.
@@ -163,8 +163,8 @@ Status (2026-05-13): **REMAINING**. PR #23 / commit `1fbed75` explicitly deferre
    - `owner.pane_target`
    - `owner.harness`
    - `owner.cwd`
-   - `owner.pid`
-   - Pi owner bridge metadata when master harness is Pi.
+   - `owner.pid` as the owner harness PID (`FLIGHTDECK_OWNER_PID`, fallback parent PID)
+   - Pi owner bridge metadata when master harness is Pi, plus `owner.discovery_error` on lookup failure.
 3. **[DONE]** Update `pi-flightdeck` to render the mini dashboard only for the owner by default.
    - New setting: `dashboardVisibility = owner | tmux-session | always`.
    - Default: `owner`.
@@ -188,7 +188,7 @@ Status (2026-05-13): **PARTIAL**. PR #23 / commit `1fbed75` delivered a Pi rende
    - **[PARTIAL]** `readTrackedEntries(state)` reads `.entries` if present, else maps `.issues` to entries. Delivered in PR #23 for the Pi extension render path only (`pi-extensions/pi-flightdeck/extensions/state.ts::readTrackedEntries`); remaining work is to add/own the core helper under `skills/flightdeck/lib/flightdeck-core/src/state/` for daemon/CLI/workflow consumers.
    - **[REMAINING]** `writeTrackedEntry(...)` writes `.entries[id]` and optionally updates `.issues[id]` for compatibility.
    - **[REMAINING]** `entryIdForIssue(issueId)` and `issueIdForEntry(entry)` helpers.
-2. **[REMAINING]** Add `schema_version` and `owner` to `flightdeck-state init`.
+2. **[PARTIAL]** Add `schema_version` and `owner` to `flightdeck-state init`. `owner` is delivered additively in PR #25; `schema_version` remains deferred until the schema-v2 entries migration needs it.
 3. **[REMAINING]** Keep existing `.issues`, `.merge_queue`, `.conflict_graph` in v1 compatibility path.
 4. **[PARTIAL]** Add tests for:
    - **[REMAINING]** v1 `.issues` read compatibility in the core state helpers.
@@ -313,7 +313,7 @@ Validation:
 
 Purpose: UI reflects sessions first, issue metadata second.
 
-Status (2026-05-13): **PARTIAL**. PR #23 / commit `1fbed75` delivered the render normalization seam (`pi-extensions/pi-flightdeck/extensions/state.ts::readTrackedEntries`), terminated archive fallback (`buildSnapshotFromInputs` + `readArchiveStrict`), and extracted `pi-extensions/pi-flightdeck/extensions/render-terminated.ts`. Sessions-first naming, kind badges, and owner-aware behavior remain.
+Status (2026-05-13): **PARTIAL**. PR #23 / commit `1fbed75` delivered the render normalization seam (`pi-extensions/pi-flightdeck/extensions/state.ts::readTrackedEntries`), terminated archive fallback (`buildSnapshotFromInputs` + `readArchiveStrict`), and extracted `pi-extensions/pi-flightdeck/extensions/render-terminated.ts`. PR #25 delivered owner-aware persistent-widget gating and observer popup header. Sessions-first naming and kind badges remain.
 
 1. **[PARTIAL]** Rename TypeScript UI types:
    - **[REMAINING]** `IssueRecord` → `TrackedSession` or `TrackedEntry`.
@@ -324,10 +324,10 @@ Status (2026-05-13): **PARTIAL**. PR #23 / commit `1fbed75` delivered the render
    - `Dashboard max issues` → `Dashboard max sessions`.
    - `Conflicts & merges` tab hides or renames when no issue-mode entries exist.
    - Rows render optional PR/worktree/scope metadata only when present.
-3. **[REMAINING]** Add owner-aware render behavior:
+3. **[DONE]** Add owner-aware render behavior:
    - Persistent widget shows only in owner by default.
    - Child panes remain suppressed.
-   - Observer popup can show `Owner: %pane · harness · cwd` and a setting-controlled read-only view.
+   - Observer popup shows `Observed Flightdeck owned by <owner.pane_id>` in peer panes.
 4. **[PARTIAL]** Update render details:
    - **[DONE]** Post-termination render fragments were extracted to `pi-extensions/pi-flightdeck/extensions/render-terminated.ts` and archive fallback now preserves completed-session context. Delivered in PR #23.
    - **[REMAINING]** Header counts: sessions by state, plus issue count when issue-mode entries exist.
@@ -388,15 +388,15 @@ Proposed short AGENTS.md wording once implementation supports it:
 
 ## Suggested execution order
 
-Some prerequisites are now satisfied by PRs #21-#24, but **Phase 0 still goes first** because owner gating and dashboard owner-only rendering remain undelivered.
+Some prerequisites are now satisfied by PRs #21-#25. Phase 0 implementation is functionally landed; finish the remaining `AGENTS.md` guidance before declaring Phase 0 fully closed, then continue with Phase 1.
 
-1. Finish Phase 0 owner gating in `pi-flightdeck` and state owner metadata.
+1. Finish the remaining Phase 0 `AGENTS.md` operational guidance.
 2. Complete Phase 1 core state normalization with v1 compatibility tests, reusing the PR #23 `readTrackedEntries` render seam instead of inventing a parallel read path.
 3. Extend the Phase 2 registry API from the delivered PR #22 `teardown-entry` alias to `init-entry`, normalized `list`, and entry-aware `find-by-pane`, leaving existing issue API intact.
 4. Add the official ad-hoc launch/attach path that uses `tmux new-window`, records immutable ids, and reuses the PR #21 `FLIGHTDECK_MANAGED=1` / `flightdeck-mode` managed-session signal.
 5. Split generic session watch/handler logic from issue workflow logic, reusing the PR #24 `pi-bg-task-exit` contract and PR #21 stale cleanup tags.
 6. Preserve and isolate issue/workflow management on top of the generic primitives.
-7. Reframe Pi dashboard language/types, kind badges, and owner-aware render behavior on top of the PR #23 archive/render seams.
+7. Reframe Pi dashboard language/types and kind badges on top of the PR #23 archive/render seams and PR #25 owner gating.
 8. Complete docs/guidance refresh once behavior lands.
 9. Only after all tests and live smoke pass, consider updating skill dependencies from hard required to mode-specific.
 

--- a/pi-extensions/pi-flightdeck/README.md
+++ b/pi-extensions/pi-flightdeck/README.md
@@ -11,7 +11,7 @@ Read-only mission-control dashboard for the [`flightdeck`](../../skills/flightde
 - **Expanded dashboard tree** — issue details render as proper child rows, with ASCII or Unicode connectors matching the Tree connector style setting.
 - **`/flightdeck` popup** (F6) — mission-control view with six tabs: Overview, Live feed, Conversations, Conflicts & merges, Decisions, Daemon. Conversations render as a newest-first stream keyed by issue/session names, hide raw pane ids from normal view, and collapse Pi streaming partials into one finalized turn. Decisions are selectable; press Enter to open the full wrapped answer, then Esc or Backspace to return.
 - **Session-complete view** — once `terminate.md` flips master state to `terminated: true`, the dashboard and popup keep rendering the completed session. `buildSnapshot` falls back to the newest `flightdeck-state-<SESSION>-*.json.archive` whenever the live file is missing (it's renamed by `flightdeck-state archive`), so Overview shows the terminated banner + summary file path, Decisions retains the full log, and Conflicts & merges adds a `Merge history` panel (PR + merge commit + age) that outlives the now-drained `merge_queue`. The daemon-health chip is swapped for a green `✔ session complete` so the user does not read the intentional shutdown as an alarming `daemon dead`. Dismiss with `Alt+M`.
-- Dashboard suppresses in child panes so the same state doesn't echo inside every agent.
+- Dashboard defaults to the Flightdeck owner pane only, using `owner.pane_id` from master state. Child panes remain suppressed, and `dashboardVisibility` can opt back into same-tmux-session or always-on rendering for observer workflows.
 - Participates in vstack's stable mini-dashboard stack order: Flightdeck → Tasks → Agents → BG tasks.
 - Optional terminal bell and auto-popup when master pauses.
 
@@ -45,6 +45,8 @@ Restart Pi after installation.
 
 Inside the popup, use Tab / Shift+Tab to switch tabs, arrows to move or scroll, `-/=` to page, and type to filter. Selected rows brighten muted metadata for contrast. Conversations and Live feed use compact streams with a wrapped selected-item preview; Enter opens the full retained turn/event with scroll. Live feed labels each row by managed issue/session and defaults to important events; Ctrl+N toggles noisy info/heartbeat rows. In Decisions, Enter opens a detail popup for the selected decision; the detail view wraps the full answer and scrolls with arrows/page keys. Esc or Backspace returns to the main Flightdeck popup. In Daemon, heartbeat runs are folded into one summary row so real daemon events stay visible while the log remains scrollable.
 
+The popup is always openable from peer panes in the same tmux session. When the current pane is not `owner.pane_id`, the header says `Observed Flightdeck owned by <pane>` and the popup acts as a read-only observer view.
+
 ## Settings
 
 All settings live in the extension manager under **Flightdeck Dashboard**.
@@ -54,6 +56,7 @@ All settings live in the extension manager under **Flightdeck Dashboard**.
 | Setting | What it does |
 | --- | --- |
 | Show dashboard widget | Render the persistent dashboard above the editor. |
+| Dashboard visibility | Where the persistent dashboard may render: `owner` (default), `tmux-session` (legacy same-session behavior), or `always`. Child panes remain suppressed in all modes. |
 | Dashboard default state | Initial state: `hidden`, `compact`, or `expanded`. |
 | Dashboard max issues | Max issue rows shown. |
 | Dashboard stale-after (min) | Suppress the issue tree with a one-line hint when the daemon is dead and the last poll is older than N minutes. `0` disables. |

--- a/pi-extensions/pi-flightdeck/extensions/dashboard-visibility.ts
+++ b/pi-extensions/pi-flightdeck/extensions/dashboard-visibility.ts
@@ -1,0 +1,49 @@
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { truncateToWidth } from "@earendil-works/pi-tui";
+
+import type { FlightdeckSnapshot } from "./state.js";
+
+export type DashboardVisibility = "owner" | "tmux-session" | "always";
+
+export function normalizeDashboardVisibility(value: unknown): DashboardVisibility {
+	return value === "tmux-session" || value === "always" ? value : "owner";
+}
+
+export function isInFlightdeckChildPane(env: NodeJS.ProcessEnv = process.env): boolean {
+	return Boolean(env.PI_SUBAGENT_CHILD_AGENT || env.FLIGHTDECK_CHILD_PANE);
+}
+
+export function dashboardVisibleInPane(options: { visibility: DashboardVisibility; currentPaneId?: string | null; ownerPaneId?: string | null; inChildPane?: boolean }): boolean {
+	if (options.inChildPane) return false;
+	if (options.visibility === "always") return true;
+	if (options.visibility === "tmux-session") return true;
+	return Boolean(options.currentPaneId && options.ownerPaneId && options.currentPaneId === options.ownerPaneId);
+}
+
+export function dashboardVisibleForSnapshot(snapshot: FlightdeckSnapshot | undefined, visibility: DashboardVisibility, env: NodeJS.ProcessEnv = process.env): boolean {
+	return dashboardVisibleInPane({
+		currentPaneId: snapshot?.tmux.paneId,
+		inChildPane: isInFlightdeckChildPane(env),
+		ownerPaneId: snapshot?.master?.owner?.pane_id,
+		visibility,
+	});
+}
+
+export function isFlightdeckOwnerPane(snapshot: FlightdeckSnapshot | undefined): boolean {
+	return Boolean(snapshot?.tmux.paneId && snapshot.master?.owner?.pane_id && snapshot.tmux.paneId === snapshot.master.owner.pane_id);
+}
+
+export function isFlightdeckObserverPane(snapshot: FlightdeckSnapshot | undefined): boolean {
+	return Boolean(snapshot?.tmux.paneId && snapshot.master?.owner?.pane_id && snapshot.tmux.paneId !== snapshot.master.owner.pane_id);
+}
+
+export function renderObserverHeader(snapshot: FlightdeckSnapshot, theme: Theme, width: number): string | undefined {
+	if (!isFlightdeckObserverPane(snapshot)) return undefined;
+	const ownerPane = snapshot.master?.owner?.pane_id;
+	if (!ownerPane) return undefined;
+	const current = snapshot.tmux.paneId ? ` ${theme.fg("dim", `(current ${snapshot.tmux.paneId})`)}` : "";
+	const discovery = typeof snapshot.master?.owner?.discovery_error === "string" && snapshot.master.owner.discovery_error.trim()
+		? ` ${theme.fg("dim", "·")} ${theme.fg("warning", "owner metadata warning")}`
+		: "";
+	return truncateToWidth(`${theme.fg("warning", "Observed Flightdeck")} ${theme.fg("dim", "owned by")} ${theme.fg("accent", ownerPane)}${current}${discovery}`, width, "");
+}

--- a/pi-extensions/pi-flightdeck/extensions/flightdeck.ts
+++ b/pi-extensions/pi-flightdeck/extensions/flightdeck.ts
@@ -77,6 +77,7 @@ const POPUP_WIDTH_PERCENT = "92%";
 const POPUP_MAX_HEIGHT = "85%";
 
 export type DashboardState = "hidden" | "compact" | "expanded";
+export type DashboardVisibility = "owner" | "tmux-session" | "always";
 
 interface VstackModalLock { depth: number }
 
@@ -235,6 +236,26 @@ function usageForIssue(issue: IssueRecord, paneMap: Map<string, string>, bridge:
 function defaultDashboardState(cwd?: string): DashboardState {
 	const value = settingString("dashboardDefaultState", "compact", cwd);
 	return value === "hidden" || value === "expanded" ? value : "compact";
+}
+
+function dashboardVisibility(cwd?: string): DashboardVisibility {
+	const value = settingString("dashboardVisibility", "owner", cwd);
+	return value === "tmux-session" || value === "always" ? value : "owner";
+}
+
+export function dashboardVisibleInPane(options: { visibility: DashboardVisibility; currentPaneId?: string | null; ownerPaneId?: string | null; inChildPane?: boolean }): boolean {
+	if (options.inChildPane) return false;
+	if (options.visibility === "always") return true;
+	if (options.visibility === "tmux-session") return true;
+	return Boolean(options.currentPaneId && options.ownerPaneId && options.currentPaneId === options.ownerPaneId);
+}
+
+export function isFlightdeckOwnerPane(snapshot: FlightdeckSnapshot | undefined): boolean {
+	return Boolean(snapshot?.tmux.paneId && snapshot.master?.owner?.pane_id && snapshot.tmux.paneId === snapshot.master.owner.pane_id);
+}
+
+export function isFlightdeckObserverPane(snapshot: FlightdeckSnapshot | undefined): boolean {
+	return Boolean(snapshot?.tmux.paneId && snapshot.master?.owner?.pane_id && snapshot.tmux.paneId !== snapshot.master.owner.pane_id);
 }
 
 function pollIntervalMs(cwd?: string): number {
@@ -454,6 +475,14 @@ function isPlainSearchInput(data: string): boolean {
 
 function activePopupCwd(ctx: ExtensionContext | ExtensionCommandContext): string {
 	return (ctx as { cwd?: string }).cwd ?? process.cwd();
+}
+
+export function renderObserverHeader(snapshot: FlightdeckSnapshot, theme: Theme, width: number): string | undefined {
+	if (!isFlightdeckObserverPane(snapshot)) return undefined;
+	const ownerPane = snapshot.master?.owner?.pane_id;
+	if (!ownerPane) return undefined;
+	const current = snapshot.tmux.paneId ? ` ${theme.fg("dim", `(current ${snapshot.tmux.paneId})`)}` : "";
+	return truncateToWidth(`${theme.fg("warning", "Observed Flightdeck")} ${theme.fg("dim", "owned by")} ${theme.fg("accent", ownerPane)}${current}`, width, "");
 }
 
 // ----- Tab renderers --------------------------------------------------------
@@ -1323,6 +1352,14 @@ export default function flightdeck(pi: ExtensionAPI): void {
 		if (cache.pauseSeenIssue === issueId) return;
 		cache.pauseSeenIssue = issueId;
 		cache.pauseSeenAt = Date.now();
+		const inChildPane = Boolean(process.env.PI_SUBAGENT_CHILD_AGENT || process.env.FLIGHTDECK_CHILD_PANE);
+		const paneAllowed = dashboardVisibleInPane({
+			currentPaneId: snapshot?.tmux.paneId,
+			inChildPane,
+			ownerPaneId: snapshot?.master?.owner?.pane_id,
+			visibility: dashboardVisibility(ctx.cwd),
+		});
+		if (!paneAllowed) return;
 		if (settingBoolean("pauseBeep", true, ctx.cwd)) process.stdout.write(ANSI_BELL);
 		if (settingBoolean("autoOpenOnPause", false, ctx.cwd)) {
 			openPopup(pi, ctx).catch(() => undefined);
@@ -1339,16 +1376,22 @@ export default function flightdeck(pi: ExtensionAPI): void {
 		const snapshot = cache.lastSnapshot;
 		// Child panes (spawned via pi-agents-tmux as subagents OR via
 		// flightdeck's open-terminal as orchestrated workers) read the
-		// same project state as the master coordinator pane, so the
-		// dashboard would otherwise render inside every child. Suppress
-		// it there; keep the pause banner since a parent pause is still
-		// actionable context. (issue #8)
+		// same project state as the master coordinator pane. Preserve that
+		// suppression as a separate hard gate, then apply owner/tmux/always
+		// visibility for the persistent widget.
 		const inChildPane = Boolean(
 			process.env.PI_SUBAGENT_CHILD_AGENT ||
 			process.env.FLIGHTDECK_CHILD_PANE,
 		);
-		const showBanner = settingBoolean("pauseBanner", true, ctx.cwd) && Boolean(snapshot?.master?.paused_for_user);
-		const dashboardEnabled = !inChildPane && settingBoolean("dashboard", true, ctx.cwd) && cache.state !== "hidden";
+		const visibility = dashboardVisibility(ctx.cwd);
+		const dashboardPaneAllowed = dashboardVisibleInPane({
+			currentPaneId: snapshot?.tmux.paneId,
+			inChildPane,
+			ownerPaneId: snapshot?.master?.owner?.pane_id,
+			visibility,
+		});
+		const showBanner = dashboardPaneAllowed && settingBoolean("pauseBanner", true, ctx.cwd) && Boolean(snapshot?.master?.paused_for_user);
+		const dashboardEnabled = dashboardPaneAllowed && settingBoolean("dashboard", true, ctx.cwd) && cache.state !== "hidden";
 		const staleAfterMin = Math.max(0, Math.floor(settingNumber("dashboardStaleAfterMin", 5, ctx.cwd)));
 		const status = flightdeckSessionStatus(snapshot, { staleAfterMin });
 		if (status === "inactive" && !showBanner) {
@@ -1368,6 +1411,9 @@ export default function flightdeck(pi: ExtensionAPI): void {
 			state: cache.state,
 			showBanner,
 			dashboardEnabled,
+			dashboardVisibility: visibility,
+			currentPaneId: snapshot?.tmux.paneId ?? null,
+			inChildPane,
 			status,
 			master: snapshot?.master ?? null,
 			daemonAlive: snapshot?.daemon?.pidAlive ?? null,
@@ -1706,6 +1752,11 @@ export default function flightdeck(pi: ExtensionAPI): void {
 						}
 						lines.push(renderTabBar(ui.tab, innerWidth, theme));
 						lines.push("");
+						const observerHeader = renderObserverHeader(snapshot, theme, innerWidth);
+						if (observerHeader) {
+							lines.push(observerHeader);
+							lines.push(divider(innerWidth, theme));
+						}
 						const headerSummary = renderPopupHeader(snapshot, theme, innerWidth);
 						lines.push(headerSummary);
 						lines.push(divider(innerWidth, theme));

--- a/pi-extensions/pi-flightdeck/extensions/flightdeck.ts
+++ b/pi-extensions/pi-flightdeck/extensions/flightdeck.ts
@@ -2,13 +2,7 @@
  * pi-flightdeck — read-only mission control for the flightdeck skill.
  *
  * Reads on-disk artifacts produced by skills/flightdeck/scripts/* — never
- * mutates them. Renders three surfaces:
- *   1. A persistent dashboard widget above the editor with one row per
- *      tracked issue.
- *   2. A high-contrast pause banner above the editor whenever master
- *      sets paused_for_user. This is the primary attention surface.
- *   3. A /flightdeck popup with six tabs (Overview / Live feed /
- *      Conversations / Conflicts & merges / Decisions / Daemon).
+ * mutates them. Renders persistent dashboard, pause banner, and /flightdeck popup.
  *
  * Pi extension only — the underlying flightdeck skill works without this
  * extension via the same on-disk files.
@@ -32,9 +26,11 @@ import {
 	foldWakeEventsIntoConversations,
 	formatAge,
 	mostRecentPollMs,
+	readOwnerVisibilityProbe,
 	readTrackedEntries,
 	type SettingsLike,
 } from "./state.js";
+import { dashboardVisibleForSnapshot, dashboardVisibleInPane, isInFlightdeckChildPane, normalizeDashboardVisibility, renderObserverHeader, type DashboardVisibility } from "./dashboard-visibility.js";
 import {
 	buildPaneTargetToIdMap,
 	formatUsageCompact,
@@ -67,7 +63,6 @@ import {
 } from "./render.js";
 import { headerChipForSnapshot, renderArchiveErrorBanner, renderIssueMergeCommitLine, renderTerminatedConflictsSection, renderTerminatedOverviewBanner } from "./render-terminated.js";
 import { MINI_DASHBOARD_RANK, setMiniDashboardWidget } from "./stacked-widget.js";
-
 const INSTALL_SYMBOL = Symbol.for("vstack.pi-flightdeck.installed");
 const CONFIG_ID = "@vanillagreen/pi-flightdeck";
 const SETTINGS_EVENT = "vstack:extension-settings-changed";
@@ -75,12 +70,8 @@ const VSTACK_MODAL_LOCK_SYMBOL = Symbol.for("vstack.pi.modal-lock");
 const WIDGET_KEY = "vstack-flightdeck-widget";
 const POPUP_WIDTH_PERCENT = "92%";
 const POPUP_MAX_HEIGHT = "85%";
-
 export type DashboardState = "hidden" | "compact" | "expanded";
-export type DashboardVisibility = "owner" | "tmux-session" | "always";
-
 interface VstackModalLock { depth: number }
-
 function expandHome(input: string): string {
 	if (!input) return input;
 	if (input === "~") return homedir();
@@ -233,35 +224,11 @@ function usageForIssue(issue: IssueRecord, paneMap: Map<string, string>, bridge:
 	return bridge.getByPaneId(paneId);
 }
 
-function defaultDashboardState(cwd?: string): DashboardState {
-	const value = settingString("dashboardDefaultState", "compact", cwd);
-	return value === "hidden" || value === "expanded" ? value : "compact";
-}
+function defaultDashboardState(cwd?: string): DashboardState { const value = settingString("dashboardDefaultState", "compact", cwd); return value === "hidden" || value === "expanded" ? value : "compact"; }
 
-function dashboardVisibility(cwd?: string): DashboardVisibility {
-	const value = settingString("dashboardVisibility", "owner", cwd);
-	return value === "tmux-session" || value === "always" ? value : "owner";
-}
+function dashboardVisibility(cwd?: string): DashboardVisibility { return normalizeDashboardVisibility(settingString("dashboardVisibility", "owner", cwd)); }
 
-export function dashboardVisibleInPane(options: { visibility: DashboardVisibility; currentPaneId?: string | null; ownerPaneId?: string | null; inChildPane?: boolean }): boolean {
-	if (options.inChildPane) return false;
-	if (options.visibility === "always") return true;
-	if (options.visibility === "tmux-session") return true;
-	return Boolean(options.currentPaneId && options.ownerPaneId && options.currentPaneId === options.ownerPaneId);
-}
-
-export function isFlightdeckOwnerPane(snapshot: FlightdeckSnapshot | undefined): boolean {
-	return Boolean(snapshot?.tmux.paneId && snapshot.master?.owner?.pane_id && snapshot.tmux.paneId === snapshot.master.owner.pane_id);
-}
-
-export function isFlightdeckObserverPane(snapshot: FlightdeckSnapshot | undefined): boolean {
-	return Boolean(snapshot?.tmux.paneId && snapshot.master?.owner?.pane_id && snapshot.tmux.paneId !== snapshot.master.owner.pane_id);
-}
-
-function pollIntervalMs(cwd?: string): number {
-	const raw = Math.floor(settingNumber("pollIntervalMs", 1500, cwd));
-	return Math.max(500, raw);
-}
+function pollIntervalMs(cwd?: string): number { return Math.max(500, Math.floor(settingNumber("pollIntervalMs", 1500, cwd))); }
 
 // ============================================================================
 // Widget render — pause banner + persistent dashboard
@@ -475,14 +442,6 @@ function isPlainSearchInput(data: string): boolean {
 
 function activePopupCwd(ctx: ExtensionContext | ExtensionCommandContext): string {
 	return (ctx as { cwd?: string }).cwd ?? process.cwd();
-}
-
-export function renderObserverHeader(snapshot: FlightdeckSnapshot, theme: Theme, width: number): string | undefined {
-	if (!isFlightdeckObserverPane(snapshot)) return undefined;
-	const ownerPane = snapshot.master?.owner?.pane_id;
-	if (!ownerPane) return undefined;
-	const current = snapshot.tmux.paneId ? ` ${theme.fg("dim", `(current ${snapshot.tmux.paneId})`)}` : "";
-	return truncateToWidth(`${theme.fg("warning", "Observed Flightdeck")} ${theme.fg("dim", "owned by")} ${theme.fg("accent", ownerPane)}${current}`, width, "");
 }
 
 // ----- Tab renderers --------------------------------------------------------
@@ -1352,13 +1311,7 @@ export default function flightdeck(pi: ExtensionAPI): void {
 		if (cache.pauseSeenIssue === issueId) return;
 		cache.pauseSeenIssue = issueId;
 		cache.pauseSeenAt = Date.now();
-		const inChildPane = Boolean(process.env.PI_SUBAGENT_CHILD_AGENT || process.env.FLIGHTDECK_CHILD_PANE);
-		const paneAllowed = dashboardVisibleInPane({
-			currentPaneId: snapshot?.tmux.paneId,
-			inChildPane,
-			ownerPaneId: snapshot?.master?.owner?.pane_id,
-			visibility: dashboardVisibility(ctx.cwd),
-		});
+		const paneAllowed = dashboardVisibleForSnapshot(snapshot, dashboardVisibility(ctx.cwd));
 		if (!paneAllowed) return;
 		if (settingBoolean("pauseBeep", true, ctx.cwd)) process.stdout.write(ANSI_BELL);
 		if (settingBoolean("autoOpenOnPause", false, ctx.cwd)) {
@@ -1374,22 +1327,8 @@ export default function flightdeck(pi: ExtensionAPI): void {
 			return;
 		}
 		const snapshot = cache.lastSnapshot;
-		// Child panes (spawned via pi-agents-tmux as subagents OR via
-		// flightdeck's open-terminal as orchestrated workers) read the
-		// same project state as the master coordinator pane. Preserve that
-		// suppression as a separate hard gate, then apply owner/tmux/always
-		// visibility for the persistent widget.
-		const inChildPane = Boolean(
-			process.env.PI_SUBAGENT_CHILD_AGENT ||
-			process.env.FLIGHTDECK_CHILD_PANE,
-		);
 		const visibility = dashboardVisibility(ctx.cwd);
-		const dashboardPaneAllowed = dashboardVisibleInPane({
-			currentPaneId: snapshot?.tmux.paneId,
-			inChildPane,
-			ownerPaneId: snapshot?.master?.owner?.pane_id,
-			visibility,
-		});
+		const dashboardPaneAllowed = dashboardVisibleForSnapshot(snapshot, visibility);
 		const showBanner = dashboardPaneAllowed && settingBoolean("pauseBanner", true, ctx.cwd) && Boolean(snapshot?.master?.paused_for_user);
 		const dashboardEnabled = dashboardPaneAllowed && settingBoolean("dashboard", true, ctx.cwd) && cache.state !== "hidden";
 		const staleAfterMin = Math.max(0, Math.floor(settingNumber("dashboardStaleAfterMin", 5, ctx.cwd)));
@@ -1413,7 +1352,6 @@ export default function flightdeck(pi: ExtensionAPI): void {
 			dashboardEnabled,
 			dashboardVisibility: visibility,
 			currentPaneId: snapshot?.tmux.paneId ?? null,
-			inChildPane,
 			status,
 			master: snapshot?.master ?? null,
 			daemonAlive: snapshot?.daemon?.pidAlive ?? null,
@@ -1444,7 +1382,18 @@ export default function flightdeck(pi: ExtensionAPI): void {
 		}), { placement: "aboveEditor" });
 	};
 
+	const shouldSkipOwnerWidgetSnapshot = (ctx: ExtensionContext): boolean => {
+		const visibility = dashboardVisibility(ctx.cwd); if (popupTui || visibility !== "owner") return false;
+		const probe = readOwnerVisibilityProbe(ctx.cwd, settingsLike(ctx.cwd));
+		if (!probe) return false; const inChildPane = isInFlightdeckChildPane(); if (inChildPane) return true; if (!probe.ownerPaneId) return false;
+		return !dashboardVisibleInPane({ currentPaneId: probe.tmux.paneId, inChildPane, ownerPaneId: probe.ownerPaneId, visibility });
+	};
+
 	const tick = (ctx: ExtensionContext) => {
+		if (shouldSkipOwnerWidgetSnapshot(ctx)) {
+			cache.lastSnapshot = undefined; cache.paneTargetToId = new Map(); syncWidget(ctx);
+			return;
+		}
 		const snapshot = refreshSnapshot(ctx.cwd);
 		handlePauseTransition(ctx, snapshot);
 		syncWidget(ctx);

--- a/pi-extensions/pi-flightdeck/extensions/state-normalizers.ts
+++ b/pi-extensions/pi-flightdeck/extensions/state-normalizers.ts
@@ -6,7 +6,7 @@
 // filter the two nested fields the renderers iterate without guarding:
 // `conflict_graph.edges` and per-issue `decisions_log`.
 
-import type { IssueRecord } from "./state.js";
+import type { IssueRecord, MasterOwner } from "./state.js";
 
 export function normalizeConflictGraph(raw: unknown): { edges: Array<[string, string]>; computed_at: string | null } {
 	const empty = { computed_at: null, edges: [] as Array<[string, string]> };
@@ -34,4 +34,23 @@ export function normalizeDecisionsLog(raw: unknown): IssueRecord["decisions_log"
 		out.push({ answer: e.answer, prompt_tag: e.prompt_tag, ts: e.ts });
 	}
 	return out;
+}
+
+export function normalizeOwner(owner: unknown): MasterOwner | undefined {
+	if (!owner || typeof owner !== "object" || Array.isArray(owner)) return undefined;
+	const raw = owner as Record<string, unknown>;
+	const pid = typeof raw.pid === "number" && Number.isFinite(raw.pid)
+		? Math.floor(raw.pid)
+		: typeof raw.pid === "string" && /^[1-9][0-9]*$/.test(raw.pid) ? Number.parseInt(raw.pid, 10) : undefined;
+	return {
+		...raw,
+		cwd: typeof raw.cwd === "string" ? raw.cwd : undefined,
+		harness: typeof raw.harness === "string" ? raw.harness : undefined,
+		pane_id: typeof raw.pane_id === "string" ? raw.pane_id : raw.pane_id === null ? null : undefined,
+		pane_target: typeof raw.pane_target === "string" ? raw.pane_target : raw.pane_target === null ? null : undefined,
+		pid,
+		pi_bridge_socket: typeof raw.pi_bridge_socket === "string" ? raw.pi_bridge_socket : raw.pi_bridge_socket === null ? null : undefined,
+		pi_session_id: typeof raw.pi_session_id === "string" ? raw.pi_session_id : raw.pi_session_id === null ? null : undefined,
+		discovery_error: typeof raw.discovery_error === "string" ? raw.discovery_error : raw.discovery_error === null ? null : undefined,
+	};
 }

--- a/pi-extensions/pi-flightdeck/extensions/state.ts
+++ b/pi-extensions/pi-flightdeck/extensions/state.ts
@@ -54,6 +54,17 @@ export interface PausedForUser {
 	[key: string]: unknown;
 }
 
+export interface MasterOwner {
+	harness?: string;
+	pane_id?: string | null;
+	pane_target?: string | null;
+	cwd?: string;
+	pid?: number;
+	pi_session_id?: string | null;
+	pi_bridge_socket?: string | null;
+	[key: string]: unknown;
+}
+
 export interface MasterState {
 	session_id?: string;
 	started_at?: string;
@@ -63,6 +74,7 @@ export interface MasterState {
 	// session summary markdown. Used by the dashboard to point users at the
 	// post-mortem file without re-reading the disk.
 	summary_path?: string;
+	owner?: MasterOwner;
 	issues: Record<string, IssueRecord>;
 	merge_queue: string[];
 	conflict_graph?: { edges?: Array<[string, string]>; computed_at?: string | null };
@@ -307,6 +319,24 @@ function readJsonFile<T>(path: string): T | undefined {
 	}
 }
 
+function normalizeOwner(owner: unknown): MasterOwner | undefined {
+	if (!owner || typeof owner !== "object" || Array.isArray(owner)) return undefined;
+	const raw = owner as Record<string, unknown>;
+	const pid = typeof raw.pid === "number" && Number.isFinite(raw.pid)
+		? Math.floor(raw.pid)
+		: typeof raw.pid === "string" && /^[1-9][0-9]*$/.test(raw.pid) ? Number.parseInt(raw.pid, 10) : undefined;
+	return {
+		...raw,
+		cwd: typeof raw.cwd === "string" ? raw.cwd : undefined,
+		harness: typeof raw.harness === "string" ? raw.harness : undefined,
+		pane_id: typeof raw.pane_id === "string" ? raw.pane_id : raw.pane_id === null ? null : undefined,
+		pane_target: typeof raw.pane_target === "string" ? raw.pane_target : raw.pane_target === null ? null : undefined,
+		pid,
+		pi_bridge_socket: typeof raw.pi_bridge_socket === "string" ? raw.pi_bridge_socket : raw.pi_bridge_socket === null ? null : undefined,
+		pi_session_id: typeof raw.pi_session_id === "string" ? raw.pi_session_id : raw.pi_session_id === null ? null : undefined,
+	};
+}
+
 export function readMasterState(path: string): { state?: MasterState; error?: string } {
 	if (!existsSync(path)) return {};
 	try {
@@ -334,6 +364,7 @@ export function readMasterState(path: string): { state?: MasterState; error?: st
 				conflict_graph: normalizeConflictGraph(raw.conflict_graph),
 				issues,
 				merge_queue: Array.isArray(raw.merge_queue) ? raw.merge_queue.filter((v): v is string => typeof v === "string") : [],
+				owner: normalizeOwner(raw.owner),
 				paused_for_user: raw.paused_for_user ?? null,
 				session_id: raw.session_id,
 				started_at: raw.started_at,

--- a/pi-extensions/pi-flightdeck/extensions/state.ts
+++ b/pi-extensions/pi-flightdeck/extensions/state.ts
@@ -62,6 +62,7 @@ export interface MasterOwner {
 	pid?: number;
 	pi_session_id?: string | null;
 	pi_bridge_socket?: string | null;
+	discovery_error?: string | null;
 	[key: string]: unknown;
 }
 
@@ -319,6 +320,7 @@ function readJsonFile<T>(path: string): T | undefined {
 	}
 }
 
+// TODO(structure): move to state-normalizers.ts if owner normalization grows.
 function normalizeOwner(owner: unknown): MasterOwner | undefined {
 	if (!owner || typeof owner !== "object" || Array.isArray(owner)) return undefined;
 	const raw = owner as Record<string, unknown>;
@@ -334,6 +336,7 @@ function normalizeOwner(owner: unknown): MasterOwner | undefined {
 		pid,
 		pi_bridge_socket: typeof raw.pi_bridge_socket === "string" ? raw.pi_bridge_socket : raw.pi_bridge_socket === null ? null : undefined,
 		pi_session_id: typeof raw.pi_session_id === "string" ? raw.pi_session_id : raw.pi_session_id === null ? null : undefined,
+		discovery_error: typeof raw.discovery_error === "string" ? raw.discovery_error : raw.discovery_error === null ? null : undefined,
 	};
 }
 
@@ -612,6 +615,23 @@ export interface BuildSnapshotInputs {
 	projectRoot: string;
 	stateDir: string;
 	tmux: TmuxContext;
+}
+
+export interface OwnerVisibilityProbe {
+	tmux: TmuxContext;
+	ownerPaneId?: string | null;
+}
+
+// Cheap preflight for non-owner widget suppression. Reads only tmux context
+// + the live master state's owner pane before `buildSnapshot` tails daemon
+// logs, wake events, subscribers, and terminated archives.
+export function readOwnerVisibilityProbe(cwd: string, settings: SettingsLike): OwnerVisibilityProbe | undefined {
+	const tmux = resolveTmuxContext();
+	if (!tmux) return undefined;
+	const projectRoot = resolveProjectRoot(cwd);
+	const path = masterStatePath(projectRoot, settings, tmux.sessionName);
+	const { state } = readMasterState(path);
+	return { ownerPaneId: state?.owner?.pane_id, tmux };
 }
 
 export function buildSnapshotFromInputs(inputs: BuildSnapshotInputs, settings: SettingsLike, options?: { logTailLines?: number; wakeEventsLines?: number }): FlightdeckSnapshot {

--- a/pi-extensions/pi-flightdeck/extensions/state.ts
+++ b/pi-extensions/pi-flightdeck/extensions/state.ts
@@ -11,7 +11,7 @@ import { closeSync, existsSync, openSync, readdirSync, readFileSync, readSync, s
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { findNewestTerminatedArchive, listTerminatedArchives } from "./state-archive.js";
-import { normalizeConflictGraph, normalizeDecisionsLog } from "./state-normalizers.js";
+import { normalizeConflictGraph, normalizeDecisionsLog, normalizeOwner } from "./state-normalizers.js";
 
 export { findNewestTerminatedArchive, listTerminatedArchives } from "./state-archive.js";
 
@@ -318,26 +318,6 @@ function readJsonFile<T>(path: string): T | undefined {
 	} catch {
 		return undefined;
 	}
-}
-
-// TODO(structure): move to state-normalizers.ts if owner normalization grows.
-function normalizeOwner(owner: unknown): MasterOwner | undefined {
-	if (!owner || typeof owner !== "object" || Array.isArray(owner)) return undefined;
-	const raw = owner as Record<string, unknown>;
-	const pid = typeof raw.pid === "number" && Number.isFinite(raw.pid)
-		? Math.floor(raw.pid)
-		: typeof raw.pid === "string" && /^[1-9][0-9]*$/.test(raw.pid) ? Number.parseInt(raw.pid, 10) : undefined;
-	return {
-		...raw,
-		cwd: typeof raw.cwd === "string" ? raw.cwd : undefined,
-		harness: typeof raw.harness === "string" ? raw.harness : undefined,
-		pane_id: typeof raw.pane_id === "string" ? raw.pane_id : raw.pane_id === null ? null : undefined,
-		pane_target: typeof raw.pane_target === "string" ? raw.pane_target : raw.pane_target === null ? null : undefined,
-		pid,
-		pi_bridge_socket: typeof raw.pi_bridge_socket === "string" ? raw.pi_bridge_socket : raw.pi_bridge_socket === null ? null : undefined,
-		pi_session_id: typeof raw.pi_session_id === "string" ? raw.pi_session_id : raw.pi_session_id === null ? null : undefined,
-		discovery_error: typeof raw.discovery_error === "string" ? raw.discovery_error : raw.discovery_error === null ? null : undefined,
-	};
 }
 
 export function readMasterState(path: string): { state?: MasterState; error?: string } {

--- a/pi-extensions/pi-flightdeck/package.json
+++ b/pi-extensions/pi-flightdeck/package.json
@@ -60,6 +60,20 @@
           "apply": "live"
         },
         {
+          "key": "dashboardVisibility",
+          "label": "Dashboard visibility",
+          "description": "Where the persistent dashboard widget may render: owner pane only (default), any pane in the same tmux session, or always when state is readable. Child panes remain suppressed.",
+          "type": "enum",
+          "enumValues": [
+            "owner",
+            "tmux-session",
+            "always"
+          ],
+          "default": "owner",
+          "category": "Dashboard",
+          "apply": "live"
+        },
+        {
           "key": "dashboardDefaultState",
           "label": "Dashboard default state",
           "description": "Initial dashboard state when a flightdeck session first appears.",

--- a/pi-extensions/pi-flightdeck/tests/dashboard-visibility.test.ts
+++ b/pi-extensions/pi-flightdeck/tests/dashboard-visibility.test.ts
@@ -148,8 +148,20 @@ test("dashboardVisibility=tmux-session renders in a non-owner pane", () => {
 	assert.match(text, /CC-001/);
 });
 
+test("dashboardVisibility=tmux-session renders in owner pane", () => {
+	const text = joinRendered(renderIfVisible("tmux-session", "%42", "%42"));
+	assert.match(text, /Flightdeck/);
+	assert.match(text, /CC-001/);
+});
+
 test("dashboardVisibility=always renders in a non-owner pane", () => {
 	const text = joinRendered(renderIfVisible("always", "%99", "%42"));
+	assert.match(text, /Flightdeck/);
+	assert.match(text, /CC-001/);
+});
+
+test("dashboardVisibility=always renders in owner pane", () => {
+	const text = joinRendered(renderIfVisible("always", "%42", "%42"));
 	assert.match(text, /Flightdeck/);
 	assert.match(text, /CC-001/);
 });

--- a/pi-extensions/pi-flightdeck/tests/dashboard-visibility.test.ts
+++ b/pi-extensions/pi-flightdeck/tests/dashboard-visibility.test.ts
@@ -1,0 +1,158 @@
+// Phase 0 owner-gating coverage. These tests mock the current tmux pane id
+// through the snapshot (same source `resolveTmuxContext` uses in production)
+// and prove the persistent dashboard renders only under the configured
+// dashboardVisibility policy. Child-pane suppression remains a separate hard
+// gate even when visibility is set to `always`.
+
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test, { afterEach, beforeEach } from "node:test";
+import {
+	dashboardVisibleInPane,
+	type DashboardVisibility,
+	isFlightdeckObserverPane,
+	renderDashboardLines,
+	renderObserverHeader,
+} from "../extensions/flightdeck.js";
+import type { FlightdeckSnapshot } from "../extensions/state.js";
+
+type ThemeLike = {
+	fg(_color: string, text: string): string;
+	bg(_color: string, text: string): string;
+	bold(text: string): string;
+	italic(text: string): string;
+	underline(text: string): string;
+	inverse(text: string): string;
+	strikethrough(text: string): string;
+};
+
+function plainTheme(): ThemeLike {
+	const passthrough = (_c: string, t: string) => t;
+	const wrap = (t: string) => t;
+	return {
+		bg: passthrough,
+		bold: wrap,
+		fg: passthrough,
+		inverse: wrap,
+		italic: wrap,
+		strikethrough: wrap,
+		underline: wrap,
+	};
+}
+
+function stripAnsi(s: string): string {
+	return s.replace(/\x1b\[[0-9;]*[A-Za-z]/g, "").replace(/\x07/g, "");
+}
+
+function joinRendered(lines: string[]): string {
+	return lines.map(stripAnsi).join("\n");
+}
+
+const SAVED_ENV: Record<string, string | undefined> = {};
+let ENV_HOME = "";
+let ENV_PI_DIR = "";
+let ENV_CWD = "";
+
+beforeEach(() => {
+	for (const key of ["PI_CODING_AGENT_DIR", "HOME", "XDG_CONFIG_HOME", "USERPROFILE"]) {
+		SAVED_ENV[key] = process.env[key];
+	}
+	ENV_HOME = mkdtempSync(join(tmpdir(), "pi-flightdeck-visibility-home-"));
+	ENV_PI_DIR = mkdtempSync(join(tmpdir(), "pi-flightdeck-visibility-piconf-"));
+	ENV_CWD = mkdtempSync(join(ENV_HOME, "isolated-cwd-"));
+	process.env.HOME = ENV_HOME;
+	process.env.PI_CODING_AGENT_DIR = ENV_PI_DIR;
+	process.env.XDG_CONFIG_HOME = ENV_HOME;
+	process.env.USERPROFILE = ENV_HOME;
+});
+
+afterEach(() => {
+	for (const [key, value] of Object.entries(SAVED_ENV)) {
+		if (value === undefined) delete process.env[key];
+		else process.env[key] = value;
+	}
+	if (ENV_HOME) rmSync(ENV_HOME, { force: true, recursive: true });
+	if (ENV_PI_DIR) rmSync(ENV_PI_DIR, { force: true, recursive: true });
+});
+
+function snapshot(currentPaneId: string, ownerPaneId: string): FlightdeckSnapshot {
+	return {
+		daemon: {
+			heartbeatExists: false,
+			pidAlive: true,
+			stateDir: "/tmp/pi-flightdeck-daemon",
+			subscriberCounts: { claude: 0, codex: 0, opencode: 0, pi: 0 },
+			subscribers: [],
+		},
+		master: {
+			conflict_graph: { computed_at: null, edges: [] },
+			issues: {
+				"CC-001": {
+					harness: "pi",
+					issue: "CC-001",
+					last_polled_at: "2026-05-13T00:00:00Z",
+					pane_id: "%33",
+					pr_number: 101,
+					spawned_at: "2026-05-13T00:00:00Z",
+					state: "waiting",
+				},
+			},
+			merge_queue: [],
+			owner: {
+				cwd: "/repo",
+				harness: "pi",
+				pane_id: ownerPaneId,
+				pane_target: "HT:1.0",
+				pid: 4242,
+				pi_bridge_socket: "/tmp/pi.sock",
+				pi_session_id: "pi-session-owner",
+			},
+			paused_for_user: null,
+			session_id: "HT",
+			started_at: "2026-05-13T00:00:00Z",
+			terminated: false,
+		},
+		pendingEvents: [],
+		stateDir: "/tmp/pi-flightdeck-daemon",
+		tmux: { paneId: currentPaneId, sessionId: "$1", sessionKey: "s1", sessionName: "HT" },
+		wakeEvents: [],
+	};
+}
+
+function renderIfVisible(visibility: DashboardVisibility, currentPaneId: string, ownerPaneId: string, inChildPane = false): string[] {
+	const snap = snapshot(currentPaneId, ownerPaneId);
+	if (!dashboardVisibleInPane({ currentPaneId: snap.tmux.paneId, inChildPane, ownerPaneId: snap.master?.owner?.pane_id, visibility })) return [];
+	return renderDashboardLines(snap, plainTheme() as never, 120, "compact", ENV_CWD, new Map());
+}
+
+test("dashboardVisibility=owner renders when current pane matches owner pane", () => {
+	const text = joinRendered(renderIfVisible("owner", "%42", "%42"));
+	assert.match(text, /Flightdeck/);
+	assert.match(text, /CC-001/);
+});
+
+test("dashboardVisibility=owner suppresses when current pane differs from owner pane", () => {
+	const lines = renderIfVisible("owner", "%99", "%42");
+	assert.deepEqual(lines, []);
+	assert.equal(isFlightdeckObserverPane(snapshot("%99", "%42")), true);
+	assert.match(renderObserverHeader(snapshot("%99", "%42"), plainTheme() as never, 120) ?? "", /Observed Flightdeck owned by %42/);
+});
+
+test("dashboardVisibility=tmux-session renders in a non-owner pane", () => {
+	const text = joinRendered(renderIfVisible("tmux-session", "%99", "%42"));
+	assert.match(text, /Flightdeck/);
+	assert.match(text, /CC-001/);
+});
+
+test("dashboardVisibility=always renders in a non-owner pane", () => {
+	const text = joinRendered(renderIfVisible("always", "%99", "%42"));
+	assert.match(text, /Flightdeck/);
+	assert.match(text, /CC-001/);
+});
+
+test("child-pane suppression remains a separate hard gate", () => {
+	const lines = renderIfVisible("always", "%99", "%42", true);
+	assert.deepEqual(lines, []);
+});

--- a/pi-extensions/pi-flightdeck/tests/dashboard-visibility.test.ts
+++ b/pi-extensions/pi-flightdeck/tests/dashboard-visibility.test.ts
@@ -10,12 +10,14 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test, { afterEach, beforeEach } from "node:test";
 import {
+	dashboardVisibleForSnapshot,
 	dashboardVisibleInPane,
 	type DashboardVisibility,
+	isInFlightdeckChildPane,
 	isFlightdeckObserverPane,
-	renderDashboardLines,
 	renderObserverHeader,
-} from "../extensions/flightdeck.js";
+} from "../extensions/dashboard-visibility.js";
+import { renderDashboardLines } from "../extensions/flightdeck.js";
 import type { FlightdeckSnapshot } from "../extensions/state.js";
 
 type ThemeLike = {
@@ -56,7 +58,7 @@ let ENV_PI_DIR = "";
 let ENV_CWD = "";
 
 beforeEach(() => {
-	for (const key of ["PI_CODING_AGENT_DIR", "HOME", "XDG_CONFIG_HOME", "USERPROFILE"]) {
+	for (const key of ["PI_CODING_AGENT_DIR", "HOME", "XDG_CONFIG_HOME", "USERPROFILE", "FLIGHTDECK_CHILD_PANE", "PI_SUBAGENT_CHILD_AGENT"]) {
 		SAVED_ENV[key] = process.env[key];
 	}
 	ENV_HOME = mkdtempSync(join(tmpdir(), "pi-flightdeck-visibility-home-"));
@@ -155,4 +157,18 @@ test("dashboardVisibility=always renders in a non-owner pane", () => {
 test("child-pane suppression remains a separate hard gate", () => {
 	const lines = renderIfVisible("always", "%99", "%42", true);
 	assert.deepEqual(lines, []);
+});
+
+test("FLIGHTDECK_CHILD_PANE env var suppresses through production child-pane detection", () => {
+	process.env.FLIGHTDECK_CHILD_PANE = "1";
+	const snap = snapshot("%99", "%42");
+	assert.equal(isInFlightdeckChildPane(), true);
+	assert.equal(dashboardVisibleForSnapshot(snap, "always"), false);
+});
+
+test("PI_SUBAGENT_CHILD_AGENT env var suppresses through production child-pane detection", () => {
+	process.env.PI_SUBAGENT_CHILD_AGENT = "1";
+	const snap = snapshot("%99", "%42");
+	assert.equal(isInFlightdeckChildPane(), true);
+	assert.equal(dashboardVisibleForSnapshot(snap, "always"), false);
 });

--- a/skills/flightdeck/SKILL.md
+++ b/skills/flightdeck/SKILL.md
@@ -155,6 +155,15 @@ Master state lives at `<project-root>/<FLIGHTDECK_STATE_DIR>/flightdeck-state-<T
   "session_id": "<TMUX_SESSION_NAME>",
   "started_at": "<ISO8601>",
   "terminated": false,
+  "owner": {
+    "harness": "claude|opencode|codex|pi|unknown",
+    "pane_id": "%25",
+    "pane_target": "<TMUX_SESSION>:<window>.<pane>",
+    "cwd": "<absolute cwd>",
+    "pid": 1752875,
+    "pi_session_id": "<pi-session-id-or-null>",
+    "pi_bridge_socket": "<pi-bridge-socket-or-null>"
+  },
   "issues": {
     "<ISSUE_ID>": {
       "window": "<window-name>",
@@ -193,7 +202,7 @@ Master state lives at `<project-root>/<FLIGHTDECK_STATE_DIR>/flightdeck-state-<T
 }
 ```
 
-State enum: `state ∈ {waiting, prompting, submitting, merge-ready, merged, aborted, dead}`. `paused_for_user` carries `{issue_id, reason, prompt_text}` when an aggressive-mode pause fires.
+State enum: `state ∈ {waiting, prompting, submitting, merge-ready, merged, aborted, dead}`. `owner` is additive v1 metadata written by `flightdeck-state init`; pi-flightdeck uses `owner.pane_id` to keep the persistent dashboard owner-scoped by default, while older readers ignore the field. `paused_for_user` carries `{issue_id, reason, prompt_text}` when an aggressive-mode pause fires.
 
 ## Configuration
 

--- a/skills/flightdeck/SKILL.md
+++ b/skills/flightdeck/SKILL.md
@@ -162,7 +162,8 @@ Master state lives at `<project-root>/<FLIGHTDECK_STATE_DIR>/flightdeck-state-<T
     "cwd": "<absolute cwd>",
     "pid": 1752875,
     "pi_session_id": "<pi-session-id-or-null>",
-    "pi_bridge_socket": "<pi-bridge-socket-or-null>"
+    "pi_bridge_socket": "<pi-bridge-socket-or-null>",
+    "discovery_error": "<warning-or-null>"
   },
   "issues": {
     "<ISSUE_ID>": {
@@ -202,7 +203,7 @@ Master state lives at `<project-root>/<FLIGHTDECK_STATE_DIR>/flightdeck-state-<T
 }
 ```
 
-State enum: `state ∈ {waiting, prompting, submitting, merge-ready, merged, aborted, dead}`. `owner` is additive v1 metadata written by `flightdeck-state init`; pi-flightdeck uses `owner.pane_id` to keep the persistent dashboard owner-scoped by default, while older readers ignore the field. `paused_for_user` carries `{issue_id, reason, prompt_text}` when an aggressive-mode pause fires.
+State enum: `state ∈ {waiting, prompting, submitting, merge-ready, merged, aborted, dead}`. `owner` is additive v1 metadata written by `flightdeck-state init`; `owner.pid` is the owner harness PID supplied by `FLIGHTDECK_OWNER_PID` (falling back to parent PID), and `owner.discovery_error` records Pi bridge metadata lookup failures when the owner harness is Pi. pi-flightdeck uses `owner.pane_id` to keep the persistent dashboard owner-scoped by default, while older readers ignore the field. `paused_for_user` carries `{issue_id, reason, prompt_text}` when an aggressive-mode pause fires.
 
 ## Configuration
 

--- a/skills/flightdeck/lib/flightdeck-core/src/state/master-state.ts
+++ b/skills/flightdeck/lib/flightdeck-core/src/state/master-state.ts
@@ -24,6 +24,7 @@ export interface FlightdeckOwner {
 	pid: number;
 	pi_session_id: string | null;
 	pi_bridge_socket: string | null;
+	discovery_error: string | null;
 }
 
 export function resolveStateBase(): string {
@@ -98,17 +99,26 @@ function tmuxDisplay(format: string): string {
 function ownerPid(): number {
 	const raw = nonEmptyEnv("FLIGHTDECK_OWNER_PID");
 	if (/^[1-9][0-9]*$/.test(raw)) return Number.parseInt(raw, 10);
+	if (Number.isFinite(process.ppid) && process.ppid > 0) return process.ppid;
+	process.stderr.write("Warning: FLIGHTDECK_OWNER_PID unset and parent pid unavailable; using helper pid as owner.pid.\n");
 	return process.pid;
 }
 
-function piBridgeMetadata(pid: number): { sessionId: string; socketPath: string } {
+function piBridgeMetadata(pid: number): { sessionId: string; socketPath: string; discoveryError: string } {
 	const envSession = nonEmptyEnv("FLIGHTDECK_OWNER_PI_SESSION_ID") || nonEmptyEnv("PI_SESSION_ID");
 	const envSocket = nonEmptyEnv("FLIGHTDECK_OWNER_PI_BRIDGE_SOCKET") || nonEmptyEnv("PI_BRIDGE_SOCKET_PATH");
-	if (envSession && envSocket) return { sessionId: envSession, socketPath: envSocket };
+	if (envSession && envSocket) return { discoveryError: "", sessionId: envSession, socketPath: envSocket };
 	let foundSession = "";
 	let foundSocket = "";
+	let discoveryError = "";
 	const r = spawnSync("pi-bridge", ["list", "--json", "--pid", String(pid)], { encoding: "utf8", timeout: 1000 });
-	if (r.status === 0 && r.stdout) {
+	if (r.error) {
+		discoveryError = (r.error as NodeJS.ErrnoException).code === "ENOENT" ? "pi-bridge not found" : r.error.message;
+	} else if (r.status !== 0) {
+		discoveryError = `pi-bridge list exited ${r.status ?? "unknown"}${r.stderr ? `: ${r.stderr.trim()}` : ""}`;
+	} else if (!r.stdout.trim()) {
+		discoveryError = "pi-bridge list returned empty output";
+	} else {
 		try {
 			const parsed = JSON.parse(r.stdout) as unknown;
 			if (Array.isArray(parsed)) {
@@ -120,12 +130,15 @@ function piBridgeMetadata(pid: number): { sessionId: string; socketPath: string 
 					foundSession = typeof match.sessionId === "string" ? match.sessionId : typeof match.session_id === "string" ? match.session_id : "";
 					foundSocket = typeof match.socketPath === "string" ? match.socketPath : typeof match.socket === "string" ? match.socket : "";
 				}
+				if (!match) discoveryError = `no pi-bridge instance found for pid ${pid}`;
+			} else {
+				discoveryError = "pi-bridge list JSON was not an array";
 			}
-		} catch {
-			// Optional discovery only; env values still win below.
+		} catch (e) {
+			discoveryError = `malformed pi-bridge JSON: ${e instanceof Error ? e.message : String(e)}`;
 		}
 	}
-	return { sessionId: envSession || foundSession, socketPath: envSocket || foundSocket };
+	return { discoveryError, sessionId: envSession || foundSession, socketPath: envSocket || foundSocket };
 }
 
 function detectOwnerHarness(piMeta: { sessionId: string; socketPath: string }): string {
@@ -141,16 +154,24 @@ function detectOwnerHarness(piMeta: { sessionId: string; socketPath: string }): 
 export function resolveOwnerMetadata(): FlightdeckOwner {
 	const pid = ownerPid();
 	const piMeta = piBridgeMetadata(pid);
+	const harness = detectOwnerHarness(piMeta);
+	const discoveryError = harness === "pi" && piMeta.discoveryError && (!piMeta.sessionId || !piMeta.socketPath)
+		? piMeta.discoveryError
+		: "";
+	if (discoveryError) {
+		process.stderr.write(`Warning: pi-bridge metadata discovery failed (${discoveryError}); proceeding with null pi_session_id/pi_bridge_socket.\n`);
+	}
 	const paneId = nonEmptyEnv("FLIGHTDECK_OWNER_PANE_ID") || tmuxDisplay("#{pane_id}");
 	const paneTarget = nonEmptyEnv("FLIGHTDECK_OWNER_PANE_TARGET") || tmuxDisplay("#S:#{window_index}.#{pane_index}");
 	return {
-		cwd: nonEmptyEnv("FLIGHTDECK_OWNER_CWD") || process.cwd(),
-		harness: detectOwnerHarness(piMeta),
+		harness,
 		pane_id: paneId || null,
 		pane_target: paneTarget || null,
+		cwd: nonEmptyEnv("FLIGHTDECK_OWNER_CWD") || process.cwd(),
 		pid,
-		pi_bridge_socket: piMeta.socketPath || null,
 		pi_session_id: piMeta.sessionId || null,
+		pi_bridge_socket: piMeta.socketPath || null,
+		discovery_error: discoveryError || null,
 	};
 }
 

--- a/skills/flightdeck/lib/flightdeck-core/src/state/master-state.ts
+++ b/skills/flightdeck/lib/flightdeck-core/src/state/master-state.ts
@@ -16,6 +16,16 @@ import { basename, dirname, join, resolve } from "node:path";
 import { resolveProjectRoot, loadDotEnvIntoProcess } from "../shared/project.ts";
 import { lockedJqUpdate, lockedRename } from "./locking.ts";
 
+export interface FlightdeckOwner {
+	harness: string;
+	pane_id: string | null;
+	pane_target: string | null;
+	cwd: string;
+	pid: number;
+	pi_session_id: string | null;
+	pi_bridge_socket: string | null;
+}
+
 export function resolveStateBase(): string {
 	const root = resolveProjectRoot();
 	loadDotEnvIntoProcess(root);
@@ -74,6 +84,76 @@ export function updateState(file: string, filter: string): void {
 	}
 }
 
+function nonEmptyEnv(name: string): string {
+	const value = process.env[name];
+	return typeof value === "string" && value.trim() ? value.trim() : "";
+}
+
+function tmuxDisplay(format: string): string {
+	if (!process.env.TMUX) return "";
+	const r = spawnSync("tmux", ["display-message", "-p", format], { encoding: "utf8" });
+	return r.status === 0 ? (r.stdout ?? "").trim() : "";
+}
+
+function ownerPid(): number {
+	const raw = nonEmptyEnv("FLIGHTDECK_OWNER_PID");
+	if (/^[1-9][0-9]*$/.test(raw)) return Number.parseInt(raw, 10);
+	return process.pid;
+}
+
+function piBridgeMetadata(pid: number): { sessionId: string; socketPath: string } {
+	const envSession = nonEmptyEnv("FLIGHTDECK_OWNER_PI_SESSION_ID") || nonEmptyEnv("PI_SESSION_ID");
+	const envSocket = nonEmptyEnv("FLIGHTDECK_OWNER_PI_BRIDGE_SOCKET") || nonEmptyEnv("PI_BRIDGE_SOCKET_PATH");
+	if (envSession && envSocket) return { sessionId: envSession, socketPath: envSocket };
+	let foundSession = "";
+	let foundSocket = "";
+	const r = spawnSync("pi-bridge", ["list", "--json", "--pid", String(pid)], { encoding: "utf8", timeout: 1000 });
+	if (r.status === 0 && r.stdout) {
+		try {
+			const parsed = JSON.parse(r.stdout) as unknown;
+			if (Array.isArray(parsed)) {
+				const match = parsed.find((item) => {
+					if (!item || typeof item !== "object") return false;
+					return String((item as { pid?: unknown }).pid ?? "") === String(pid);
+				}) as Record<string, unknown> | undefined;
+				if (match) {
+					foundSession = typeof match.sessionId === "string" ? match.sessionId : typeof match.session_id === "string" ? match.session_id : "";
+					foundSocket = typeof match.socketPath === "string" ? match.socketPath : typeof match.socket === "string" ? match.socket : "";
+				}
+			}
+		} catch {
+			// Optional discovery only; env values still win below.
+		}
+	}
+	return { sessionId: envSession || foundSession, socketPath: envSocket || foundSocket };
+}
+
+function detectOwnerHarness(piMeta: { sessionId: string; socketPath: string }): string {
+	const explicit = nonEmptyEnv("FLIGHTDECK_OWNER_HARNESS");
+	if (explicit) return explicit;
+	if (piMeta.sessionId || piMeta.socketPath) return "pi";
+	if (nonEmptyEnv("CLAUDE_SESSION_ID") || nonEmptyEnv("CLAUDE_CODE_SESSION_ID")) return "claude";
+	if (nonEmptyEnv("OPENCODE_SESSION_ID") || nonEmptyEnv("OPENCODE_APP_INFO")) return "opencode";
+	if (nonEmptyEnv("CODEX_SESSION_ID") || nonEmptyEnv("CODEX_SANDBOX")) return "codex";
+	return "unknown";
+}
+
+export function resolveOwnerMetadata(): FlightdeckOwner {
+	const pid = ownerPid();
+	const piMeta = piBridgeMetadata(pid);
+	const paneId = nonEmptyEnv("FLIGHTDECK_OWNER_PANE_ID") || tmuxDisplay("#{pane_id}");
+	const paneTarget = nonEmptyEnv("FLIGHTDECK_OWNER_PANE_TARGET") || tmuxDisplay("#S:#{window_index}.#{pane_index}");
+	return {
+		cwd: nonEmptyEnv("FLIGHTDECK_OWNER_CWD") || process.cwd(),
+		harness: detectOwnerHarness(piMeta),
+		pane_id: paneId || null,
+		pane_target: paneTarget || null,
+		pid,
+		pi_bridge_socket: piMeta.socketPath || null,
+		pi_session_id: piMeta.sessionId || null,
+	};
+}
+
 export function initState(file: string): void {
 	gcTmpOrphans(file);
 	const lock = `${file}.lock`;
@@ -84,9 +164,41 @@ export function initState(file: string): void {
 	// set are serialized correctly.
 	const session = basename(file).replace(/^flightdeck-state-/, "").replace(/\.json$/, "");
 	const startedAt = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+	const owner = resolveOwnerMetadata();
+	const ownerJson = JSON.stringify(owner);
+	const initJson = JSON.stringify({
+		conflict_graph: { computed_at: null, edges: [] },
+		issues: {},
+		merge_queue: [],
+		owner,
+		paused_for_user: null,
+		session_id: session,
+		started_at: startedAt,
+		terminated: false,
+	});
+	if (existsSync(file)) {
+		try {
+			const parsed = JSON.parse(readFileSync(file, "utf8")) as unknown;
+			if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+				const raw = parsed as Record<string, unknown>;
+				if (raw.owner !== null && raw.owner !== undefined) return;
+			}
+		} catch {
+			// Preserve legacy idempotence for corrupt/partial existing files:
+			// init must not clobber them.
+			return;
+		}
+		const backfillFilter = `if ((. // {}) | type == "object") then (if .owner? == null then . + {owner: ${ownerJson}} else . end) else . end`;
+		const backfill = lockedJqUpdate(lock, file, backfillFilter);
+		if (backfill.status !== 0) {
+			process.stderr.write(backfill.stderr || "");
+			process.exit(backfill.status ?? 1);
+		}
+		return;
+	}
 	// jq filter that prefers an existing object over the synthesized init.
-	const initFilter = `if (. // {}) | type == "object" and (.issues // null) != null then . else { session_id: "${session}", started_at: "${startedAt}", terminated: false, issues: {}, merge_queue: [], conflict_graph: { edges: [], computed_at: null }, paused_for_user: null } end`;
-	if (existsSync(file)) return;
+	// Existing pre-owner state is preserved and backfilled with the additive owner block.
+	const initFilter = `if ((. // {}) | type == "object" and (.issues // null) != null) then (if .owner? == null then . + {owner: ${ownerJson}} else . end) else ${initJson} end`;
 	const r = lockedJqUpdate(lock, file, initFilter);
 	if (r.status !== 0) {
 		process.stderr.write(r.stderr || "");

--- a/skills/flightdeck/lib/flightdeck-core/src/state/master-state.ts
+++ b/skills/flightdeck/lib/flightdeck-core/src/state/master-state.ts
@@ -111,13 +111,15 @@ function piBridgeMetadata(pid: number): { sessionId: string; socketPath: string;
 	let foundSession = "";
 	let foundSocket = "";
 	let discoveryError = "";
-	const r = spawnSync("pi-bridge", ["list", "--json", "--pid", String(pid)], { encoding: "utf8", timeout: 1000 });
+	const timeoutMs = Number.parseInt(nonEmptyEnv("FLIGHTDECK_PI_BRIDGE_DISCOVERY_TIMEOUT_MS") || "1000", 10);
+	const r = spawnSync("pi-bridge", ["list", "--json", "--pid", String(pid)], { encoding: "utf8", timeout: Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : 1000 });
 	if (r.error) {
-		discoveryError = (r.error as NodeJS.ErrnoException).code === "ENOENT" ? "pi-bridge not found" : r.error.message;
+		const code = (r.error as NodeJS.ErrnoException).code;
+		discoveryError = code === "ENOENT" ? "pi_bridge_not_found" : code === "ETIMEDOUT" ? "pi_bridge_timeout" : `pi_bridge_error_${code ?? "unknown"}`;
 	} else if (r.status !== 0) {
-		discoveryError = `pi-bridge list exited ${r.status ?? "unknown"}${r.stderr ? `: ${r.stderr.trim()}` : ""}`;
+		discoveryError = `pi_bridge_exit_${r.status ?? "unknown"}`;
 	} else if (!r.stdout.trim()) {
-		discoveryError = "pi-bridge list returned empty output";
+		discoveryError = "pi_bridge_empty_output";
 	} else {
 		try {
 			const parsed = JSON.parse(r.stdout) as unknown;
@@ -129,13 +131,14 @@ function piBridgeMetadata(pid: number): { sessionId: string; socketPath: string;
 				if (match) {
 					foundSession = typeof match.sessionId === "string" ? match.sessionId : typeof match.session_id === "string" ? match.session_id : "";
 					foundSocket = typeof match.socketPath === "string" ? match.socketPath : typeof match.socket === "string" ? match.socket : "";
+					if (!foundSession || !foundSocket) discoveryError = "pi_bridge_partial_metadata";
 				}
-				if (!match) discoveryError = `no pi-bridge instance found for pid ${pid}`;
+				if (!match) discoveryError = "pi_bridge_no_instance_for_pid";
 			} else {
-				discoveryError = "pi-bridge list JSON was not an array";
+				discoveryError = "pi_bridge_json_not_array";
 			}
 		} catch (e) {
-			discoveryError = `malformed pi-bridge JSON: ${e instanceof Error ? e.message : String(e)}`;
+			discoveryError = "pi_bridge_malformed_json";
 		}
 	}
 	return { discoveryError, sessionId: envSession || foundSession, socketPath: envSocket || foundSocket };
@@ -155,8 +158,8 @@ export function resolveOwnerMetadata(): FlightdeckOwner {
 	const pid = ownerPid();
 	const piMeta = piBridgeMetadata(pid);
 	const harness = detectOwnerHarness(piMeta);
-	const discoveryError = harness === "pi" && piMeta.discoveryError && (!piMeta.sessionId || !piMeta.socketPath)
-		? piMeta.discoveryError
+	const discoveryError = harness === "pi" && (!piMeta.sessionId || !piMeta.socketPath)
+		? (piMeta.discoveryError || "pi_bridge_partial_metadata")
 		: "";
 	if (discoveryError) {
 		process.stderr.write(`Warning: pi-bridge metadata discovery failed (${discoveryError}); proceeding with null pi_session_id/pi_bridge_socket.\n`);

--- a/skills/flightdeck/lib/flightdeck-core/tests/parity/flightdeck-state.test.ts
+++ b/skills/flightdeck/lib/flightdeck-core/tests/parity/flightdeck-state.test.ts
@@ -21,7 +21,7 @@ function makeRepo(): string {
 	return dir;
 }
 
-function run(useTs: boolean, cwd: string, args: string[]): { stdout: string; stderr: string; status: number | null } {
+function run(useTs: boolean, cwd: string, args: string[], extraEnv: Record<string, string | undefined> = {}): { stdout: string; stderr: string; status: number | null } {
 	const env: Record<string, string> = { ...(process.env as Record<string, string>) };
 	env.FLIGHTDECK_STATE_DIR = "tmp";
 	if (useTs) env.FLIGHTDECK_USE_TS_FLIGHTDECK_STATE = "1";
@@ -34,6 +34,10 @@ function run(useTs: boolean, cwd: string, args: string[]): { stdout: string; std
 	env.FLIGHTDECK_OWNER_PID = "4242";
 	env.FLIGHTDECK_OWNER_PI_SESSION_ID = "pi-session-parity";
 	env.FLIGHTDECK_OWNER_PI_BRIDGE_SOCKET = "/tmp/pi-session-bridge/parity.sock";
+	for (const [key, value] of Object.entries(extraEnv)) {
+		if (value === undefined) delete env[key];
+		else env[key] = value;
+	}
 	// Bash parses <action> first, then --session — preserve that order.
 	const [action, ...rest] = args;
 	const full = action ? [action, "--session", SESSION, ...rest] : ["--session", SESSION];
@@ -44,6 +48,14 @@ function run(useTs: boolean, cwd: string, args: string[]): { stdout: string; std
 function readState(repoRoot: string): unknown {
 	const path = join(repoRoot, "tmp", `flightdeck-state-${SESSION}.json`);
 	return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function readOwnerViaJq(repoRoot: string, sortKeys = false): string {
+	const path = join(repoRoot, "tmp", `flightdeck-state-${SESSION}.json`);
+	const args = sortKeys ? ["-S", ".owner", path] : [".owner", path];
+	const r = spawnSync("jq", args, { encoding: "utf8" });
+	expect(r.status).toBe(0);
+	return r.stdout;
 }
 
 function writeState(repoRoot: string, state: unknown): void {
@@ -92,11 +104,14 @@ describe("flightdeck-state parity", () => {
 			pane_id: "%42",
 			pane_target: "PARITY:7.0",
 			pid: 4242,
-			pi_bridge_socket: "/tmp/pi-session-bridge/parity.sock",
 			pi_session_id: "pi-session-parity",
+			pi_bridge_socket: "/tmp/pi-session-bridge/parity.sock",
+			discovery_error: null,
 		};
 		expect((readState(bashRepo) as { owner?: unknown }).owner).toEqual(expectedOwner);
 		expect((readState(tsRepo) as { owner?: unknown }).owner).toEqual(expectedOwner);
+		expect(readOwnerViaJq(tsRepo)).toBe(readOwnerViaJq(bashRepo));
+		expect(readOwnerViaJq(tsRepo, true)).toBe(readOwnerViaJq(bashRepo, true));
 	});
 
 	test("init backfills owner metadata on legacy state without clobbering fields", () => {
@@ -118,6 +133,25 @@ describe("flightdeck-state parity", () => {
 		expect(Object.keys(state.issues ?? {})).toEqual(["CC-LEGACY"]);
 		expect(state.merge_queue).toEqual(["CC-LEGACY"]);
 		expect(state.owner?.pane_id).toBe("%42");
+	});
+
+	test("pi owner discovery failure warns and persists discovery_error identically", () => {
+		const overrides: Record<string, string | undefined> = {
+			FLIGHTDECK_OWNER_HARNESS: "pi",
+			FLIGHTDECK_OWNER_PI_BRIDGE_SOCKET: undefined,
+			FLIGHTDECK_OWNER_PI_SESSION_ID: undefined,
+			PI_BRIDGE_SOCKET_PATH: undefined,
+			PI_SESSION_ID: undefined,
+			PATH: "/usr/bin:/bin",
+		};
+		const a = run(false, bashRepo, ["init"], overrides);
+		const b = run(true, tsRepo, ["init"], overrides);
+		expect(a.status).toBe(0);
+		expect(b.status).toBe(0);
+		expect(a.stderr).toContain("Warning: pi-bridge metadata discovery failed (pi-bridge not found); proceeding with null pi_session_id/pi_bridge_socket.");
+		expect(b.stderr).toContain("Warning: pi-bridge metadata discovery failed (pi-bridge not found); proceeding with null pi_session_id/pi_bridge_socket.");
+		expect(normalize(readState(bashRepo))).toEqual(normalize(readState(tsRepo)));
+		expect(readOwnerViaJq(tsRepo)).toBe(readOwnerViaJq(bashRepo));
 	});
 
 	test("init is idempotent", () => {

--- a/skills/flightdeck/lib/flightdeck-core/tests/parity/flightdeck-state.test.ts
+++ b/skills/flightdeck/lib/flightdeck-core/tests/parity/flightdeck-state.test.ts
@@ -5,7 +5,7 @@
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -62,6 +62,15 @@ function writeState(repoRoot: string, state: unknown): void {
 	const dir = join(repoRoot, "tmp");
 	mkdirSync(dir, { recursive: true });
 	writeFileSync(join(dir, `flightdeck-state-${SESSION}.json`), JSON.stringify(state), "utf8");
+}
+
+function writePiBridgeStub(repoRoot: string, body: string): string {
+	const dir = join(repoRoot, "stub-bin");
+	mkdirSync(dir, { recursive: true });
+	const bin = join(dir, "pi-bridge");
+	writeFileSync(bin, `#!/usr/bin/env bash\n${body}\n`, "utf8");
+	chmodSync(bin, 0o755);
+	return dir;
 }
 
 function normalize(state: unknown): unknown {
@@ -148,9 +157,57 @@ describe("flightdeck-state parity", () => {
 		const b = run(true, tsRepo, ["init"], overrides);
 		expect(a.status).toBe(0);
 		expect(b.status).toBe(0);
-		expect(a.stderr).toContain("Warning: pi-bridge metadata discovery failed (pi-bridge not found); proceeding with null pi_session_id/pi_bridge_socket.");
-		expect(b.stderr).toContain("Warning: pi-bridge metadata discovery failed (pi-bridge not found); proceeding with null pi_session_id/pi_bridge_socket.");
+		expect(a.stderr).toContain("Warning: pi-bridge metadata discovery failed (pi_bridge_not_found); proceeding with null pi_session_id/pi_bridge_socket.");
+		expect(b.stderr).toContain("Warning: pi-bridge metadata discovery failed (pi_bridge_not_found); proceeding with null pi_session_id/pi_bridge_socket.");
 		expect(normalize(readState(bashRepo))).toEqual(normalize(readState(tsRepo)));
+		expect(readOwnerViaJq(tsRepo)).toBe(readOwnerViaJq(bashRepo));
+	});
+
+	test("pi owner discovery timeout warns and persists discovery_error identically", () => {
+		const stub = writePiBridgeStub(bashRepo, "sleep 10");
+		const overrides: Record<string, string | undefined> = {
+			FLIGHTDECK_OWNER_HARNESS: "pi",
+			FLIGHTDECK_OWNER_PI_BRIDGE_SOCKET: undefined,
+			FLIGHTDECK_OWNER_PI_SESSION_ID: undefined,
+			FLIGHTDECK_PI_BRIDGE_DISCOVERY_TIMEOUT_MS: "1000",
+			FLIGHTDECK_PI_BRIDGE_DISCOVERY_TIMEOUT_SEC: "1",
+			PI_BRIDGE_SOCKET_PATH: undefined,
+			PI_SESSION_ID: undefined,
+			PATH: `${stub}:/usr/bin:/bin`,
+		};
+		const start = Date.now();
+		const a = run(false, bashRepo, ["init"], overrides);
+		const b = run(true, tsRepo, ["init"], overrides);
+		expect(Date.now() - start).toBeLessThan(3500);
+		expect(a.status).toBe(0);
+		expect(b.status).toBe(0);
+		expect(a.stderr).toContain("Warning: pi-bridge metadata discovery failed (pi_bridge_timeout); proceeding with null pi_session_id/pi_bridge_socket.");
+		expect(b.stderr).toContain("Warning: pi-bridge metadata discovery failed (pi_bridge_timeout); proceeding with null pi_session_id/pi_bridge_socket.");
+		expect((readState(tsRepo) as { owner?: { discovery_error?: string } }).owner?.discovery_error).toBe("pi_bridge_timeout");
+		expect(readOwnerViaJq(tsRepo)).toBe(readOwnerViaJq(bashRepo));
+	});
+
+	test("pi owner partial bridge metadata warns and persists discovery_error identically", () => {
+		const stub = writePiBridgeStub(bashRepo, "printf '%s\\n' '[{\"pid\":4242,\"sessionId\":\"pi-session-only\"}]'");
+		const overrides: Record<string, string | undefined> = {
+			FLIGHTDECK_OWNER_HARNESS: "pi",
+			FLIGHTDECK_OWNER_PI_BRIDGE_SOCKET: undefined,
+			FLIGHTDECK_OWNER_PI_SESSION_ID: undefined,
+			PI_BRIDGE_SOCKET_PATH: undefined,
+			PI_SESSION_ID: undefined,
+			PATH: `${stub}:/usr/bin:/bin`,
+		};
+		const a = run(false, bashRepo, ["init"], overrides);
+		const b = run(true, tsRepo, ["init"], overrides);
+		expect(a.status).toBe(0);
+		expect(b.status).toBe(0);
+		expect(a.stderr).toContain("Warning: pi-bridge metadata discovery failed (pi_bridge_partial_metadata); proceeding with null pi_session_id/pi_bridge_socket.");
+		expect(b.stderr).toContain("Warning: pi-bridge metadata discovery failed (pi_bridge_partial_metadata); proceeding with null pi_session_id/pi_bridge_socket.");
+		expect((readState(tsRepo) as { owner?: { discovery_error?: string; pi_session_id?: string; pi_bridge_socket?: string | null } }).owner).toMatchObject({
+			discovery_error: "pi_bridge_partial_metadata",
+			pi_bridge_socket: null,
+			pi_session_id: "pi-session-only",
+		});
 		expect(readOwnerViaJq(tsRepo)).toBe(readOwnerViaJq(bashRepo));
 	});
 

--- a/skills/flightdeck/lib/flightdeck-core/tests/parity/flightdeck-state.test.ts
+++ b/skills/flightdeck/lib/flightdeck-core/tests/parity/flightdeck-state.test.ts
@@ -5,7 +5,7 @@
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -25,8 +25,15 @@ function run(useTs: boolean, cwd: string, args: string[]): { stdout: string; std
 	const env: Record<string, string> = { ...(process.env as Record<string, string>) };
 	env.FLIGHTDECK_STATE_DIR = "tmp";
 	if (useTs) env.FLIGHTDECK_USE_TS_FLIGHTDECK_STATE = "1";
-	else delete env.FLIGHTDECK_USE_TS_FLIGHTDECK_STATE;
+	else env.FLIGHTDECK_USE_TS_FLIGHTDECK_STATE = "0";
 	delete env.FLIGHTDECK_USE_TS;
+	env.FLIGHTDECK_OWNER_HARNESS = "pi";
+	env.FLIGHTDECK_OWNER_PANE_ID = "%42";
+	env.FLIGHTDECK_OWNER_PANE_TARGET = "PARITY:7.0";
+	env.FLIGHTDECK_OWNER_CWD = "/tmp/flightdeck-owner-parity";
+	env.FLIGHTDECK_OWNER_PID = "4242";
+	env.FLIGHTDECK_OWNER_PI_SESSION_ID = "pi-session-parity";
+	env.FLIGHTDECK_OWNER_PI_BRIDGE_SOCKET = "/tmp/pi-session-bridge/parity.sock";
 	// Bash parses <action> first, then --session — preserve that order.
 	const [action, ...rest] = args;
 	const full = action ? [action, "--session", SESSION, ...rest] : ["--session", SESSION];
@@ -37,6 +44,12 @@ function run(useTs: boolean, cwd: string, args: string[]): { stdout: string; std
 function readState(repoRoot: string): unknown {
 	const path = join(repoRoot, "tmp", `flightdeck-state-${SESSION}.json`);
 	return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function writeState(repoRoot: string, state: unknown): void {
+	const dir = join(repoRoot, "tmp");
+	mkdirSync(dir, { recursive: true });
+	writeFileSync(join(dir, `flightdeck-state-${SESSION}.json`), JSON.stringify(state), "utf8");
 }
 
 function normalize(state: unknown): unknown {
@@ -68,6 +81,43 @@ describe("flightdeck-state parity", () => {
 		expect(a.status).toBe(0);
 		expect(b.status).toBe(0);
 		expect(normalize(readState(bashRepo))).toEqual(normalize(readState(tsRepo)));
+	});
+
+	test("init records owner metadata identically", () => {
+		run(false, bashRepo, ["init"]);
+		run(true, tsRepo, ["init"]);
+		const expectedOwner = {
+			cwd: "/tmp/flightdeck-owner-parity",
+			harness: "pi",
+			pane_id: "%42",
+			pane_target: "PARITY:7.0",
+			pid: 4242,
+			pi_bridge_socket: "/tmp/pi-session-bridge/parity.sock",
+			pi_session_id: "pi-session-parity",
+		};
+		expect((readState(bashRepo) as { owner?: unknown }).owner).toEqual(expectedOwner);
+		expect((readState(tsRepo) as { owner?: unknown }).owner).toEqual(expectedOwner);
+	});
+
+	test("init backfills owner metadata on legacy state without clobbering fields", () => {
+		const legacy = {
+			conflict_graph: { computed_at: null, edges: [] },
+			issues: { "CC-LEGACY": { state: "waiting" } },
+			merge_queue: ["CC-LEGACY"],
+			paused_for_user: null,
+			session_id: SESSION,
+			started_at: "2026-05-13T00:00:00Z",
+			terminated: false,
+		};
+		writeState(bashRepo, legacy);
+		writeState(tsRepo, legacy);
+		run(false, bashRepo, ["init"]);
+		run(true, tsRepo, ["init"]);
+		expect(normalize(readState(bashRepo))).toEqual(normalize(readState(tsRepo)));
+		const state = readState(tsRepo) as { issues?: Record<string, unknown>; merge_queue?: string[]; owner?: { pane_id?: string } };
+		expect(Object.keys(state.issues ?? {})).toEqual(["CC-LEGACY"]);
+		expect(state.merge_queue).toEqual(["CC-LEGACY"]);
+		expect(state.owner?.pane_id).toBe("%42");
 	});
 
 	test("init is idempotent", () => {

--- a/skills/flightdeck/scripts/flightdeck-state.bash
+++ b/skills/flightdeck/scripts/flightdeck-state.bash
@@ -127,13 +127,19 @@ gc_tmp_orphans() {
 
 # Owner metadata is additive state written at init time. Test paths can pin
 # every value with FLIGHTDECK_OWNER_* env vars; production falls back to the
-# current tmux pane + process context and Pi bridge discovery when present.
+# current tmux pane + owner process context and Pi bridge discovery when present.
 resolve_owner_pid() {
-  local pid="${FLIGHTDECK_OWNER_PID:-$$}"
-  if [[ ! "$pid" =~ ^[1-9][0-9]*$ ]]; then
-    pid="$$"
+  local pid="${FLIGHTDECK_OWNER_PID:-}"
+  if [[ "$pid" =~ ^[1-9][0-9]*$ ]]; then
+    echo "$pid"
+    return
   fi
-  echo "$pid"
+  if [[ "${PPID:-}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "$PPID"
+    return
+  fi
+  echo "Warning: FLIGHTDECK_OWNER_PID unset and parent pid unavailable; using helper pid as owner.pid." >&2
+  echo "$$"
 }
 
 resolve_owner_pane_id() {
@@ -161,26 +167,39 @@ resolve_pi_bridge_metadata() {
   local env_session="${FLIGHTDECK_OWNER_PI_SESSION_ID:-${PI_SESSION_ID:-}}"
   local env_socket="${FLIGHTDECK_OWNER_PI_BRIDGE_SOCKET:-${PI_BRIDGE_SOCKET_PATH:-}}"
   if [[ -n "$env_session" && -n "$env_socket" ]]; then
-    printf '%s\t%s\n' "$env_session" "$env_socket"
+    printf '%s\t%s\t%s\n' "$env_session" "$env_socket" ""
     return
   fi
-  local found_session="" found_socket=""
-  if command -v pi-bridge >/dev/null 2>&1; then
+  local found_session="" found_socket="" discovery_error=""
+  if ! command -v pi-bridge >/dev/null 2>&1; then
+    discovery_error="pi-bridge not found"
+  else
     local json
-    json=$(pi-bridge list --json --pid "$owner_pid" 2>/dev/null || true)
-    if [[ -n "$json" ]]; then
+    local status=0
+    json=$(pi-bridge list --json --pid "$owner_pid" 2>&1) || status=$?
+    if (( status != 0 )); then
+      discovery_error="pi-bridge list exited $status: ${json//$'\n'/ }"
+    elif [[ -z "${json//[[:space:]]/}" ]]; then
+      discovery_error="pi-bridge list returned empty output"
+    else
       local line
+      local jq_status=0
       line=$(jq -r --arg pid "$owner_pid" '
         if type == "array" then
           map(select((.pid | tostring) == $pid)) | .[0] // {}
         else {} end
-        | [(.sessionId // .session_id // ""), (.socketPath // .socket // "")] | @tsv
-      ' <<< "$json" 2>/dev/null || true)
-      found_session=$(awk -F'\t' '{print $1}' <<< "$line")
-      found_socket=$(awk -F'\t' '{print $2}' <<< "$line")
+        | [(.sessionId // .session_id // ""), (.socketPath // .socket // ""), (if . == {} then "no pi-bridge instance found for pid " + $pid else "" end)] | @tsv
+      ' <<< "$json" 2>&1) || jq_status=$?
+      if (( jq_status != 0 )); then
+        discovery_error="malformed pi-bridge JSON: ${line//$'\n'/ }"
+      else
+        found_session=$(awk -F'\t' '{print $1}' <<< "$line")
+        found_socket=$(awk -F'\t' '{print $2}' <<< "$line")
+        discovery_error=$(awk -F'\t' '{print $3}' <<< "$line")
+      fi
     fi
   fi
-  printf '%s\t%s\n' "${env_session:-$found_session}" "${env_socket:-$found_socket}"
+  printf '%s\t%s\t%s\n' "${env_session:-$found_session}" "${env_socket:-$found_socket}" "$discovery_error"
 }
 
 resolve_owner_harness() {
@@ -242,7 +261,13 @@ case "$ACTION" in
     pi_meta=$(resolve_pi_bridge_metadata "$owner_pid")
     owner_pi_session_id=$(awk -F'\t' '{print $1}' <<< "$pi_meta")
     owner_pi_bridge_socket=$(awk -F'\t' '{print $2}' <<< "$pi_meta")
+    owner_discovery_error=$(awk -F'\t' '{print $3}' <<< "$pi_meta")
     owner_harness=$(resolve_owner_harness "$owner_pi_session_id" "$owner_pi_bridge_socket")
+    if [[ "$owner_harness" == "pi" && -n "$owner_discovery_error" && ( -z "$owner_pi_session_id" || -z "$owner_pi_bridge_socket" ) ]]; then
+      echo "Warning: pi-bridge metadata discovery failed ($owner_discovery_error); proceeding with null pi_session_id/pi_bridge_socket." >&2
+    else
+      owner_discovery_error=""
+    fi
     # Acquire the same lock the update_state helper uses so concurrent
     # `pane-registry init` paths don't race here (bugs review finding #5):
     # one path could pass the `-f $FILE` existence check while another is
@@ -266,6 +291,7 @@ case "$ACTION" in
           --argjson owner_pid "$owner_pid" \
           --arg owner_pi_session_id "$owner_pi_session_id" \
           --arg owner_pi_bridge_socket "$owner_pi_bridge_socket" \
+          --arg owner_discovery_error "$owner_discovery_error" \
           'def owner: {
              harness: $owner_harness,
              pane_id: ($owner_pane_id | if . == "" then null else . end),
@@ -273,7 +299,8 @@ case "$ACTION" in
              cwd: $owner_cwd,
              pid: $owner_pid,
              pi_session_id: ($owner_pi_session_id | if . == "" then null else . end),
-             pi_bridge_socket: ($owner_pi_bridge_socket | if . == "" then null else . end)
+             pi_bridge_socket: ($owner_pi_bridge_socket | if . == "" then null else . end),
+             discovery_error: ($owner_discovery_error | if . == "" then null else . end)
            };
            . + {owner: owner}' "$FILE" > "$init_tmp"
         mv "$init_tmp" "$FILE"
@@ -292,6 +319,7 @@ case "$ACTION" in
       --argjson owner_pid "$owner_pid" \
       --arg owner_pi_session_id "$owner_pi_session_id" \
       --arg owner_pi_bridge_socket "$owner_pi_bridge_socket" \
+      --arg owner_discovery_error "$owner_discovery_error" \
       '{
         session_id: $session_id,
         started_at: $started_at,
@@ -303,7 +331,8 @@ case "$ACTION" in
           cwd: $owner_cwd,
           pid: $owner_pid,
           pi_session_id: ($owner_pi_session_id | if . == "" then null else . end),
-          pi_bridge_socket: ($owner_pi_bridge_socket | if . == "" then null else . end)
+          pi_bridge_socket: ($owner_pi_bridge_socket | if . == "" then null else . end),
+          discovery_error: ($owner_discovery_error | if . == "" then null else . end)
         },
         issues: {},
         merge_queue: [],

--- a/skills/flightdeck/scripts/flightdeck-state.bash
+++ b/skills/flightdeck/scripts/flightdeck-state.bash
@@ -125,6 +125,90 @@ gc_tmp_orphans() {
   shopt -u nullglob
 }
 
+# Owner metadata is additive state written at init time. Test paths can pin
+# every value with FLIGHTDECK_OWNER_* env vars; production falls back to the
+# current tmux pane + process context and Pi bridge discovery when present.
+resolve_owner_pid() {
+  local pid="${FLIGHTDECK_OWNER_PID:-$$}"
+  if [[ ! "$pid" =~ ^[1-9][0-9]*$ ]]; then
+    pid="$$"
+  fi
+  echo "$pid"
+}
+
+resolve_owner_pane_id() {
+  if [[ -n "${FLIGHTDECK_OWNER_PANE_ID:-}" ]]; then
+    echo "$FLIGHTDECK_OWNER_PANE_ID"
+    return
+  fi
+  if [[ -n "${TMUX:-}" ]]; then
+    tmux display-message -p '#{pane_id}' 2>/dev/null || true
+  fi
+}
+
+resolve_owner_pane_target() {
+  if [[ -n "${FLIGHTDECK_OWNER_PANE_TARGET:-}" ]]; then
+    echo "$FLIGHTDECK_OWNER_PANE_TARGET"
+    return
+  fi
+  if [[ -n "${TMUX:-}" ]]; then
+    tmux display-message -p '#S:#{window_index}.#{pane_index}' 2>/dev/null || true
+  fi
+}
+
+resolve_pi_bridge_metadata() {
+  local owner_pid="$1"
+  local env_session="${FLIGHTDECK_OWNER_PI_SESSION_ID:-${PI_SESSION_ID:-}}"
+  local env_socket="${FLIGHTDECK_OWNER_PI_BRIDGE_SOCKET:-${PI_BRIDGE_SOCKET_PATH:-}}"
+  if [[ -n "$env_session" && -n "$env_socket" ]]; then
+    printf '%s\t%s\n' "$env_session" "$env_socket"
+    return
+  fi
+  local found_session="" found_socket=""
+  if command -v pi-bridge >/dev/null 2>&1; then
+    local json
+    json=$(pi-bridge list --json --pid "$owner_pid" 2>/dev/null || true)
+    if [[ -n "$json" ]]; then
+      local line
+      line=$(jq -r --arg pid "$owner_pid" '
+        if type == "array" then
+          map(select((.pid | tostring) == $pid)) | .[0] // {}
+        else {} end
+        | [(.sessionId // .session_id // ""), (.socketPath // .socket // "")] | @tsv
+      ' <<< "$json" 2>/dev/null || true)
+      found_session=$(awk -F'\t' '{print $1}' <<< "$line")
+      found_socket=$(awk -F'\t' '{print $2}' <<< "$line")
+    fi
+  fi
+  printf '%s\t%s\n' "${env_session:-$found_session}" "${env_socket:-$found_socket}"
+}
+
+resolve_owner_harness() {
+  local pi_session="$1"
+  local pi_socket="$2"
+  if [[ -n "${FLIGHTDECK_OWNER_HARNESS:-}" ]]; then
+    echo "$FLIGHTDECK_OWNER_HARNESS"
+    return
+  fi
+  if [[ -n "$pi_session" || -n "$pi_socket" ]]; then
+    echo "pi"
+    return
+  fi
+  if [[ -n "${CLAUDE_SESSION_ID:-${CLAUDE_CODE_SESSION_ID:-}}" ]]; then
+    echo "claude"
+    return
+  fi
+  if [[ -n "${OPENCODE_SESSION_ID:-${OPENCODE_APP_INFO:-}}" ]]; then
+    echo "opencode"
+    return
+  fi
+  if [[ -n "${CODEX_SESSION_ID:-${CODEX_SANDBOX:-}}" ]]; then
+    echo "codex"
+    return
+  fi
+  echo "unknown"
+}
+
 # --- Argument parsing -----------------------------------------------------
 
 ACTION="${1:-}"
@@ -151,6 +235,14 @@ case "$ACTION" in
 
   init)
     gc_tmp_orphans "$FILE"
+    owner_pid=$(resolve_owner_pid)
+    owner_pane_id=$(resolve_owner_pane_id)
+    owner_pane_target=$(resolve_owner_pane_target)
+    owner_cwd="${FLIGHTDECK_OWNER_CWD:-$PWD}"
+    pi_meta=$(resolve_pi_bridge_metadata "$owner_pid")
+    owner_pi_session_id=$(awk -F'\t' '{print $1}' <<< "$pi_meta")
+    owner_pi_bridge_socket=$(awk -F'\t' '{print $2}' <<< "$pi_meta")
+    owner_harness=$(resolve_owner_harness "$owner_pi_session_id" "$owner_pi_bridge_socket")
     # Acquire the same lock the update_state helper uses so concurrent
     # `pane-registry init` paths don't race here (bugs review finding #5):
     # one path could pass the `-f $FILE` existence check while another is
@@ -161,9 +253,31 @@ case "$ACTION" in
     exec 9>"$init_lock"
     flock 9
     if [[ -f "$FILE" ]]; then
-      # Idempotent — don't clobber existing state (compaction-recovery path).
+      # Idempotent — don't clobber existing state (compaction-recovery path),
+      # but backfill the additive owner block on pre-owner live state files.
       # Stale `terminated: true` files are rotated by `terminate.md § 5` via
       # the `archive` action, so a present file here is always a live session.
+      if jq -e '.owner? == null' "$FILE" >/dev/null 2>&1; then
+        jq \
+          --arg owner_harness "$owner_harness" \
+          --arg owner_pane_id "$owner_pane_id" \
+          --arg owner_pane_target "$owner_pane_target" \
+          --arg owner_cwd "$owner_cwd" \
+          --argjson owner_pid "$owner_pid" \
+          --arg owner_pi_session_id "$owner_pi_session_id" \
+          --arg owner_pi_bridge_socket "$owner_pi_bridge_socket" \
+          'def owner: {
+             harness: $owner_harness,
+             pane_id: ($owner_pane_id | if . == "" then null else . end),
+             pane_target: ($owner_pane_target | if . == "" then null else . end),
+             cwd: $owner_cwd,
+             pid: $owner_pid,
+             pi_session_id: ($owner_pi_session_id | if . == "" then null else . end),
+             pi_bridge_socket: ($owner_pi_bridge_socket | if . == "" then null else . end)
+           };
+           . + {owner: owner}' "$FILE" > "$init_tmp"
+        mv "$init_tmp" "$FILE"
+      fi
       exec 9>&-
       exit 0
     fi
@@ -171,10 +285,26 @@ case "$ACTION" in
     jq -n \
       --arg session_id "$SESSION" \
       --arg started_at "$started_at" \
+      --arg owner_harness "$owner_harness" \
+      --arg owner_pane_id "$owner_pane_id" \
+      --arg owner_pane_target "$owner_pane_target" \
+      --arg owner_cwd "$owner_cwd" \
+      --argjson owner_pid "$owner_pid" \
+      --arg owner_pi_session_id "$owner_pi_session_id" \
+      --arg owner_pi_bridge_socket "$owner_pi_bridge_socket" \
       '{
         session_id: $session_id,
         started_at: $started_at,
         terminated: false,
+        owner: {
+          harness: $owner_harness,
+          pane_id: ($owner_pane_id | if . == "" then null else . end),
+          pane_target: ($owner_pane_target | if . == "" then null else . end),
+          cwd: $owner_cwd,
+          pid: $owner_pid,
+          pi_session_id: ($owner_pi_session_id | if . == "" then null else . end),
+          pi_bridge_socket: ($owner_pi_bridge_socket | if . == "" then null else . end)
+        },
         issues: {},
         merge_queue: [],
         conflict_graph: {edges: [], computed_at: null},

--- a/skills/flightdeck/scripts/flightdeck-state.bash
+++ b/skills/flightdeck/scripts/flightdeck-state.bash
@@ -172,26 +172,38 @@ resolve_pi_bridge_metadata() {
   fi
   local found_session="" found_socket="" discovery_error=""
   if ! command -v pi-bridge >/dev/null 2>&1; then
-    discovery_error="pi-bridge not found"
+    discovery_error="pi_bridge_not_found"
   else
     local json
     local status=0
-    json=$(pi-bridge list --json --pid "$owner_pid" 2>&1) || status=$?
+    local timeout_sec="${FLIGHTDECK_PI_BRIDGE_DISCOVERY_TIMEOUT_SEC:-1}"
+    json=$(timeout "${timeout_sec}s" pi-bridge list --json --pid "$owner_pid" 2>&1) || status=$?
     if (( status != 0 )); then
-      discovery_error="pi-bridge list exited $status: ${json//$'\n'/ }"
+      if (( status == 124 )); then
+        discovery_error="pi_bridge_timeout"
+      else
+        discovery_error="pi_bridge_exit_$status"
+      fi
     elif [[ -z "${json//[[:space:]]/}" ]]; then
-      discovery_error="pi-bridge list returned empty output"
+      discovery_error="pi_bridge_empty_output"
     else
       local line
       local jq_status=0
       line=$(jq -r --arg pid "$owner_pid" '
-        if type == "array" then
-          map(select((.pid | tostring) == $pid)) | .[0] // {}
-        else {} end
-        | [(.sessionId // .session_id // ""), (.socketPath // .socket // ""), (if . == {} then "no pi-bridge instance found for pid " + $pid else "" end)] | @tsv
+        if type != "array" then
+          ["", "", "pi_bridge_json_not_array"]
+        else
+          (map(select((.pid | tostring) == $pid)) | .[0] // {}) as $m
+          | if $m == {} then
+              ["", "", "pi_bridge_no_instance_for_pid"]
+            else
+              [($m.sessionId // $m.session_id // ""), ($m.socketPath // $m.socket // ""), (if (($m.sessionId // $m.session_id // "") == "" or ($m.socketPath // $m.socket // "") == "") then "pi_bridge_partial_metadata" else "" end)]
+            end
+        end
+        | @tsv
       ' <<< "$json" 2>&1) || jq_status=$?
       if (( jq_status != 0 )); then
-        discovery_error="malformed pi-bridge JSON: ${line//$'\n'/ }"
+        discovery_error="pi_bridge_malformed_json"
       else
         found_session=$(awk -F'\t' '{print $1}' <<< "$line")
         found_socket=$(awk -F'\t' '{print $2}' <<< "$line")
@@ -263,7 +275,8 @@ case "$ACTION" in
     owner_pi_bridge_socket=$(awk -F'\t' '{print $2}' <<< "$pi_meta")
     owner_discovery_error=$(awk -F'\t' '{print $3}' <<< "$pi_meta")
     owner_harness=$(resolve_owner_harness "$owner_pi_session_id" "$owner_pi_bridge_socket")
-    if [[ "$owner_harness" == "pi" && -n "$owner_discovery_error" && ( -z "$owner_pi_session_id" || -z "$owner_pi_bridge_socket" ) ]]; then
+    if [[ "$owner_harness" == "pi" && ( -z "$owner_pi_session_id" || -z "$owner_pi_bridge_socket" ) ]]; then
+      [[ -n "$owner_discovery_error" ]] || owner_discovery_error="pi_bridge_partial_metadata"
       echo "Warning: pi-bridge metadata discovery failed ($owner_discovery_error); proceeding with null pi_session_id/pi_bridge_socket." >&2
     else
       owner_discovery_error=""

--- a/skills/flightdeck/workflows/watch.md
+++ b/skills/flightdeck/workflows/watch.md
@@ -19,9 +19,12 @@ Master mode entry point. Polls every spawned issue pane, classifies their prompt
 1. Resolve session: `SESSION=$(tmux display-message -p '#S')`, `SESSION_ID=$(tmux display-message -p '#{session_id}')`.
 2. Init / resume master state:
    ```
-   .agents/skills/flightdeck/scripts/flightdeck-state init
+   # Prefer a long-lived harness PID; fall back to this watch caller's parent.
+   MASTER_OWNER_PID="${MASTER_OWNER_PID:-${PPID:-}}"
+   FLIGHTDECK_OWNER_PID="$MASTER_OWNER_PID" \
+     .agents/skills/flightdeck/scripts/flightdeck-state init
    ```
-   Idempotent — preserves an existing state file if one exists (compaction-recovery path).
+   Idempotent — preserves an existing state file if one exists (compaction-recovery path). `owner.pid` is the owner harness PID; do not pass the short-lived `flightdeck-state` helper PID.
 3. Reconcile registry against live tmux windows (drops stale entries from prior sessions whose windows are gone):
    ```
    .agents/skills/flightdeck/scripts/pane-registry reconcile


### PR DESCRIPTION
References `docs/plans/flightdeck-session-management-reframe.md` Phase 0.

Behavior change:
- `flightdeck-state init` now writes additive `owner` metadata in bash and TS paths: harness, pane id/target, cwd, pid, and Pi bridge session/socket metadata when discoverable.
- `pi-flightdeck` reads `owner.pane_id` and defaults the persistent widget to owner-only rendering via `dashboardVisibility=owner`.
- New `dashboardVisibility` setting supports `owner | tmux-session | always`; child-pane suppression remains a separate hard gate.
- `/flightdeck` remains openable from peer panes and shows `Observed Flightdeck owned by <pane>` for read-only observer view.

Tests:
- `cd skills/flightdeck/lib/flightdeck-core && bun test && bun run typecheck`
- `cd skills/flightdeck/lib/flightdeck-core && FLIGHTDECK_CHILD_PANE=1 bun test && FLIGHTDECK_CHILD_PANE=1 bun run typecheck`
- `cd pi-extensions/pi-flightdeck && bun test`
- `cd pi-extensions/pi-flightdeck && FLIGHTDECK_CHILD_PANE=1 bun test`
- `cd pi-extensions/pi-flightdeck && node -e 'const fs=require("fs"); const p=require("./package.json"); console.log(`typecheck-script=${p.scripts?.typecheck?"yes":"no"}`); console.log(`tsconfig=${fs.existsSync("tsconfig.json")?"yes":"no"}`)'` → no typecheck script and no tsconfig.

Install verification:
- `vstack refresh -g`
- `vstack verify -g @vanillagreen/pi-flightdeck`

Deferred work:
- Phase 0 repo guidance in `AGENTS.md` remains marked `[REMAINING]` because this worker scope allowed only `skills/flightdeck/`, `pi-extensions/pi-flightdeck/`, and `docs/plans/` edits.
- Phase 1+ schema v2 entries/session reframe remains out of scope.
