### PR TITLE
feat(flightdeck): Phase 2 generic registry + flightdeck-session launch (reframe plan)

### DIFF
--- a/docs/plans/flightdeck-session-management-reframe.md
+++ b/docs/plans/flightdeck-session-management-reframe.md
@@ -212,31 +212,31 @@ bun run typecheck
 
 Purpose: make official ad-hoc session management possible without fake issue IDs.
 
-Status (2026-05-13): **PARTIAL**. PR #22 / commit `7045946` delivered the `teardown-entry` alias and safe pane-id teardown; PR #21 / commit `6a10e4d` delivered the `FLIGHTDECK_MANAGED=1` signal and `skills/orchestration/scripts/flightdeck-mode` basis for managed detection. Generic registry init/list, `--kind adhoc`, and launch/attach APIs remain.
+Status (2026-05-13): **PARTIAL**. PR #22 / commit `7045946` delivered the `teardown-entry` alias and safe pane-id teardown; PR #21 / commit `6a10e4d` delivered the `FLIGHTDECK_MANAGED=1` signal and `skills/orchestration/scripts/flightdeck-mode` basis for managed detection. Phase 2 worker branch `fd-reframe-p2` adds generic registry init/list/find, `flightdeck-session start`, and Pi attach. Remaining work is mostly adapter spawn-file generalization, broader non-Pi adapter launch metadata, and Phase 3 watch split.
 
-1. **[PARTIAL]** Evolve `pane-registry` CLI:
+1. **[DONE]** Evolve `pane-registry` CLI:
    - **[DONE]** `pane-registry teardown-entry <ENTRY_ID>` is available as a TrackedEntry-aligned alias for `teardown-window` in `skills/flightdeck/scripts/pane-registry.bash` and `skills/flightdeck/lib/flightdeck-core/src/bin/pane-registry.ts::cmdTeardownWindow`. Delivered in PR #22.
-   - **[REMAINING]** Add aliases or new commands using `entry` terminology:
-     - `pane-registry init-entry <ENTRY_ID> --title ... --kind ... --cwd ... --window ... --harness ...`
-     - `pane-registry list --format json` returns normalized entries while preserving legacy fields for issue entries.
-     - `pane-registry find-by-pane` returns entry id, not necessarily issue id.
-   - **[REMAINING]** Keep current commands (`init <ISSUE>`, `set-state <ISSUE>`, etc.) as issue-mode aliases.
-2. **[REMAINING]** Rename internal variable names from `issue` to `entryId` where code is generic.
+   - **[DONE]** Add aliases or new commands using `entry` terminology:
+     - **[DONE]** `pane-registry init-entry <ENTRY_ID> --title ... --kind ... --cwd ... --window ... --harness ...` writes through `flightdeck-state write-entry` / `writeTrackedEntry` and dual-writes `.issues[id]` for `kind=issue`.
+     - **[DONE]** `pane-registry list --format json` returns normalized entries from `tracked-entries` while preserving legacy top-level issue fields for issue entries.
+     - **[DONE]** `pane-registry find-by-pane` returns stable JSON `{id, kind}` and resolves both `.entries[*]` and legacy `.issues[*]` pane ids/targets.
+   - **[DONE]** Keep current commands (`init <ISSUE>`, `set-state <ISSUE>`, etc.) as issue-mode aliases.
+2. **[PARTIAL]** Rename internal variable names from `issue` to `entryId` where code is generic. New `init-entry` paths use entry terminology, but legacy issue-mode commands and compatibility adapters intentionally keep `issue` names until Phase 3/4 split the watch and issue layers.
 3. **[REMAINING]** Split adapter spawn metadata paths away from issue IDs:
    - New `adapter-spawn-<entryId>.json` helpers, or preserve per-harness files but pass `entryId` not issue id.
    - Old files still read for compatibility.
-4. **[REMAINING]** Add first-class ad-hoc launch script/API:
+4. **[DONE]** Add first-class ad-hoc launch script/API:
    - Option A: extend `open-terminal` with `--session-id`, `--title`, `--cwd`, `--prompt`, and `--cmd` so it can launch without worktree creation.
-   - Option B: add `session-terminal` or `flightdeck-session` script and keep `open-terminal` as issue preset.
-   - Preferred: add a new script for clarity, then let `open-terminal` call it in issue mode.
+   - **[DONE]** Option B: add `flightdeck-session` script and keep `open-terminal` as issue preset.
+   - **[DONE]** Preferred: add a new script for clarity, then let `open-terminal` call it in issue mode for the tmux fallback path.
 5. **[PARTIAL]** New launch behavior:
-   - **[REMAINING]** Always use `tmux new-window`, not split panes, in the new generic launch path.
-   - **[REMAINING]** Capture `#{window_id}`, `#{pane_id}`, `#{window_index}`, and pane cwd immediately for generic entries.
-   - **[PARTIAL]** Set `FLIGHTDECK_CHILD_PANE=1` in launched child sessions so pi-flightdeck does not render full owner dashboard inside children. Existing Pi child panes already carry it; PR #21 added the cross-harness `FLIGHTDECK_MANAGED=1` signal in `skills/flightdeck/scripts/open-terminal`. Remaining work is to reuse both signals in the generic launcher.
-   - **[REMAINING]** Prefer harness adapters (`pi-bridge`, OpenCode HTTP attach, Claude channels, Codex bridge) over tmux fallback in the generic launch/attach path.
-6. **[REMAINING]** Add attach behavior for sessions launched manually:
-   - `flightdeck session attach --pane %33 --harness pi --title "..."`
-   - Discovers adapter metadata where possible.
+   - **[DONE]** Always use `tmux new-window`, not split panes, in the new generic launch path.
+   - **[DONE]** Capture `#{window_id}`, `#{pane_id}`, `#{window_index}`, and pane cwd immediately for generic entries.
+   - **[DONE]** Set `FLIGHTDECK_CHILD_PANE=1` and `FLIGHTDECK_MANAGED=1` in launched child sessions through the shared pane env helper.
+   - **[PARTIAL]** Prefer harness adapters (`pi-bridge`, OpenCode HTTP attach, Claude channels, Codex bridge) over tmux fallback in the generic launch/attach path. Pi launch/attach bridge discovery is implemented; OpenCode/Claude/Codex generic adapter metadata remains tied to issue spawn files.
+6. **[DONE]** Add attach behavior for sessions launched manually:
+   - **[DONE]** `flightdeck-session attach --pane %33 --harness pi --title "..."`
+   - **[DONE]** Discovers Pi adapter metadata via `pi-bridge list --pid` where possible.
 
 Validation:
 

--- a/skills/flightdeck/README.md
+++ b/skills/flightdeck/README.md
@@ -33,6 +33,44 @@ When every tracked issue is merged, aborted, or otherwise terminal, flightdeck w
 - **Pauses** for you on: scope creep that wants reverting, force-merging against a real content conflict, an issue abort, a `main` mutation that needs human OK, or a novel prompt shape no rule covers. Sets `paused_for_user` in state and stops polling. Resume by running `watch` again.
 - **Terminates** automatically when every tracked issue is in a terminal state for two consecutive poll cycles. Writes a summary, archives the state file, hands control back.
 
+## Ad-hoc sessions
+
+Use `flightdeck-session` when you need Flightdeck to track a tmux window that is not tied to an issue/worktree workflow.
+
+Launch a managed ad-hoc Pi session:
+
+```bash
+skills/flightdeck/scripts/flightdeck-session start \
+  --session-id scratch-pi \
+  --title "Scratch Pi" \
+  --cwd "$PWD" \
+  --harness pi \
+  --prompt "Investigate this repo and report risks" \
+  --kind adhoc
+```
+
+Launch any command in a new tracked tmux window:
+
+```bash
+skills/flightdeck/scripts/flightdeck-session start \
+  --session-id logs-1 \
+  --title "Log watcher" \
+  --cwd "$PWD" \
+  --harness shell \
+  --cmd "tail -f tmp/app.log"
+```
+
+Attach an existing Pi pane without launching a new window:
+
+```bash
+skills/flightdeck/scripts/flightdeck-session attach \
+  --pane %33 \
+  --harness pi \
+  --title "Manual Pi"
+```
+
+All starts use `tmux new-window` (never split panes), set `FLIGHTDECK_MANAGED=1` and `FLIGHTDECK_CHILD_PANE=1` in the launched command environment, capture stable `pane_id`/`window_id` metadata, and register through `pane-registry init-entry`. `pane-registry list --format json` returns normalized entries for both ad-hoc sessions and legacy issue rows.
+
 ## Install
 
 ```bash
@@ -101,7 +139,8 @@ The `patterns/` directory documents the decisions the master agent makes — *wh
 
 You don't run any of these by hand in normal use — the skill calls them.
 
-- `open-terminal` — launches a tmux window with the chosen harness on the chosen worktree.
+- `open-terminal` — launches issue worktree tmux windows with the chosen harness.
+- `flightdeck-session` — launches or attaches generic tracked tmux sessions without fake issue ids.
 - `flightdeck-state` — reads/writes the session's master state file, including schema `1.1` tracked-entry normalization (`tracked-entries`, `write-entry`).
 - `flightdeck-daemon` — background poller; wakes the master.
 - `pane-registry`, `pane-poll`, `pane-respond` — pane tracking and IO.

--- a/skills/flightdeck/README.md
+++ b/skills/flightdeck/README.md
@@ -35,6 +35,8 @@ When every tracked issue is merged, aborted, or otherwise terminal, flightdeck w
 
 ## Ad-hoc sessions
 
+Existing issue workflows (`start`, `start new`, `parallel-check`) are unchanged; ad-hoc sessions are additive.
+
 Use `flightdeck-session` when you need Flightdeck to track a tmux window that is not tied to an issue/worktree workflow.
 
 Launch a managed ad-hoc Pi session:

--- a/skills/flightdeck/SKILL.md
+++ b/skills/flightdeck/SKILL.md
@@ -36,7 +36,19 @@ You are in **master mode**. Observe-and-direct only:
 
 ## Commands
 
-### Session
+### Session management
+
+Generic tmux-window session tracking. These commands do not require a fake issue id.
+
+| Command | Arguments | Workflow / Script | Notes |
+|---------|-----------|-------------------|-------|
+| `session start` | `--session-id <ID> --title <T> --cwd <path> --harness <H> (--cmd <cmd> \| --prompt <text>) [--kind adhoc\|workflow]` | `scripts/flightdeck-session start` | Creates a new tmux window (never a split), launches the command/harness, sets `FLIGHTDECK_MANAGED=1` + `FLIGHTDECK_CHILD_PANE=1`, and records a generic `.entries[ID]` row. Pi `--prompt` launch starts `pi` directly and records bridge metadata when discovery succeeds. |
+| `session attach` | `--pane <%PANE_ID> --harness pi --title <T> [--session-id <ID>] [--kind adhoc]` | `scripts/flightdeck-session attach` | Attaches an existing pane without launching a new window. For Pi, probes `pi-bridge` by pane pid and records `pi_session_id`/socket metadata when available. |
+| `session watch` | `[ENTRY_ID...]` | Phase 3 pending | Generic watch split is not landed yet; current daemon/watch paths still share issue-mode prompt handling. |
+| `session status` | — | inline / `flightdeck-state tracked-entries` | Read-only normalized `.entries`/legacy `.issues` snapshot. |
+| `session stop` / `session remove` | `<ENTRY_ID>` | `pane-registry teardown-entry` / `pane-registry remove` | Teardown uses stable `pane_id`; issue remove remains the legacy cleanup path. Generic removal cleanup is still being expanded. |
+
+### Issue workflows
 
 | Command | Arguments | Workflow | Notes |
 |---------|-----------|----------|-------|
@@ -126,12 +138,13 @@ complete. Parity tests for every port live under
 
 | Script | Purpose |
 |--------|---------|
-| `open-terminal` | Spawn issue worktree(s) with selected harness + optional `--model`/`--effort`. **Never hand-roll tmux/terminal commands — use this for every spawn.** |
+| `open-terminal` | Spawn issue worktree(s) with selected harness + optional `--model`/`--effort`. **Never hand-roll issue tmux/terminal commands — use this for issue workflow spawns.** Tmux fallback now delegates to `flightdeck-session` in issue mode. |
+| `flightdeck-session` | Generic session launcher/attacher. `start` creates a tmux window and registers `.entries[id]`; `attach` records an existing Pi pane by stable pane id. |
 | `parallel-groups` | Read/manage parallel issue groups. |
 | `flightdeck-state` | Atomic CRUD on `tmp/flightdeck-state-<TMUX_SESSION>.json` (`init`/`get`/`set`/`append`/`increment`/`tracked-entries`/`write-entry`/`archive`) and master-busy lock (`master-busy lock\|unlock\|check`). See `workflows/watch.md` § 1 for lock semantics. |
 | `flightdeck-daemon` | External wake driver. Polls inner panes, normalizes turn-end events, wakes master with a per-harness payload. Actions: `start \| stop \| status \| health \| events \| ack`. See `patterns/tmux-monitoring.md` for adapter freshness + tmux-fallback semantics; the script's own header comment for daemon internals. |
 | `codex-app-server-spawn` / `-stop` | Idempotent bring-up/teardown of the per-session codex `app-server --listen ws://...` shared by all `codex --remote` panes. |
-| `pane-registry` | Issue↔pane mapping CRUD. `init` stores immutable `pane_id` (`%N`) alongside `pane_target`. `list --format json\|inner-panes\|inner-harnesses` feeds `pane-poll --batch -` and `flightdeck-daemon start`. |
+| `pane-registry` | TrackedEntry↔pane mapping CRUD. `init-entry` writes `.entries[id]` and dual-writes `.issues[id]` for `kind=issue`; legacy `init <ISSUE>` remains an issue-mode alias. `find-by-pane` emits `{id,kind}` JSON. `list --format json\|inner-panes\|inner-harnesses` feeds `pane-poll --batch -` and `flightdeck-daemon start`. |
 | `pane-poll` | Pane state read. Preferred: `--batch -` from `pane-registry list --format json` (one JSONL object per issue). Legacy single-pane mode for drift re-polls / manual debug. See `patterns/tmux-monitoring.md` for per-harness adapter routes. |
 | `pane-respond` | Send response to a pane. Modes: free-text payload, `--option N`, `--option-multi`, `--keys` (rejected without `--keys-allow-tmux`), `--question <reqID> --answer\|--answer-multi\|--answer-text\|--answers-json\|--reject`. Validates rebase-multi-choice payloads for the preserve/apply/verify triplet. See `patterns/prompt-handlers.md` for mode selection and `patterns/opencode-questions.md` / `patterns/pi-questions.md` for question routing. |
 | `pane-clear-bell` | Atomic chained-command bell clear (no flicker). |

--- a/skills/flightdeck/lib/flightdeck-core/src/bin/pane-poll.ts
+++ b/skills/flightdeck/lib/flightdeck-core/src/bin/pane-poll.ts
@@ -140,7 +140,14 @@ function registryIssueForPane(issue: string, paneLookup: string): string {
 	if (issue) return issue;
 	const r = spawnSync(PANE_REGISTRY_SCRIPT, ["find-by-pane", paneLookup], { encoding: "utf8" });
 	if (r.status !== 0) return "";
-	return (r.stdout ?? "").trim();
+	const raw = (r.stdout ?? "").trim();
+	if (!raw.startsWith("{")) return raw;
+	try {
+		const parsed = JSON.parse(raw) as { id?: unknown };
+		return typeof parsed.id === "string" ? parsed.id : "";
+	} catch {
+		return "";
+	}
 }
 
 function paneRegistryArgs(action: string, issue: string): string {

--- a/skills/flightdeck/lib/flightdeck-core/src/bin/pane-registry.ts
+++ b/skills/flightdeck/lib/flightdeck-core/src/bin/pane-registry.ts
@@ -69,6 +69,16 @@ function tmuxLivePaneIds(): Set<string> {
 	return panes;
 }
 
+function paneMatchIsLive(paneId: string, paneTarget: string): boolean {
+	if (paneId) return tmuxLivePaneIds().has(paneId);
+	return !!paneTarget && tmuxPaneExists(paneTarget);
+}
+
+function warnStalePaneMatch(paneId: string, paneTarget: string): void {
+	const lookup = paneId || paneTarget || "<none>";
+	process.stderr.write(`Warning: find-by-pane match ${lookup} is stale (pane no longer exists); use pane-registry reconcile.\n`);
+}
+
 function tmuxPaneCountInWindow(windowId: string): number {
 	const r = spawnSync("tmux", ["list-panes", "-t", windowId, "-F", "#{pane_id}"], { encoding: "utf8" });
 	if (r.status !== 0) return 0;
@@ -110,6 +120,7 @@ interface InitFields {
 	cwd: string;
 	cx_thread_id: string;
 	cx_ws: string;
+	discovery_error: string;
 	harness: string;
 	kind: string;
 	launch_cmd: string;
@@ -137,6 +148,7 @@ function defaultInitFields(entryId: string, kind = "adhoc"): InitFields {
 		cc_port: "", cc_session_uuid: "", cc_transcript: "", cc_url: "",
 		cwd: "",
 		cx_thread_id: "", cx_ws: "",
+		discovery_error: "",
 		harness: "",
 		kind,
 		launch_cmd: "", launch_effort: "", launch_model: "",
@@ -158,6 +170,7 @@ const INIT_FLAG_MAP: Record<string, keyof InitFields> = {
 	"--cwd": "cwd",
 	"--cx-thread-id": "cx_thread_id",
 	"--cx-ws": "cx_ws",
+	"--discovery-error": "discovery_error",
 	"--harness": "harness",
 	"--kind": "kind",
 	"--launch-cmd": "launch_cmd",
@@ -285,6 +298,7 @@ function cmdInitEntry(entryId: string, args: string[], mode: "entry" | "issue" =
 		adapter,
 		cwd: fields.cwd,
 		decisions_log: [],
+		discovery_error: strOrNull(fields.discovery_error),
 		domain: issueDomain ? { issue: issueDomain } : null,
 		harness: fields.harness,
 		id: entryId,
@@ -529,6 +543,12 @@ function cmdFindByPane(target: string): void {
 	const hit = Object.entries(trackedEntries()).find(([, entry]) => entry.pane_target === target || entry.pane_id === target);
 	if (!hit) process.exit(1);
 	const [key, entry] = hit;
+	const paneId = typeof entry.pane_id === "string" ? entry.pane_id : "";
+	const paneTarget = typeof entry.pane_target === "string" ? entry.pane_target : "";
+	if (!paneMatchIsLive(paneId, paneTarget)) {
+		warnStalePaneMatch(paneId, paneTarget);
+		process.exit(1);
+	}
 	process.stdout.write(`${JSON.stringify({ id: typeof entry.id === "string" ? entry.id : key, kind: typeof entry.kind === "string" ? entry.kind : "issue" })}\n`);
 }
 

--- a/skills/flightdeck/lib/flightdeck-core/src/bin/pane-registry.ts
+++ b/skills/flightdeck/lib/flightdeck-core/src/bin/pane-registry.ts
@@ -88,145 +88,231 @@ function readJsonIfExists<T>(path: string): T | null {
 	catch { return null; }
 }
 
-// ----- init ----------------------------------------------------------------
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return !!value && typeof value === "object" && !Array.isArray(value);
+}
 
-function cmdInit(issue: string, args: string[]): void {
-	if (!issue) die("Usage: pane-registry init <ISSUE> [flags]");
-	const defaultIdx = tmuxBasePaneIndex() || "0";
-	const fields: Record<string, string> = {
+function lookupId(raw: string): string {
+	if (!raw.trim().startsWith("{")) return raw;
+	try {
+		const obj = JSON.parse(raw) as unknown;
+		return isRecord(obj) && typeof obj.id === "string" ? obj.id : raw;
+	} catch {
+		return raw;
+	}
+}
+
+interface InitFields {
+	cc_port: string;
+	cc_session_uuid: string;
+	cc_transcript: string;
+	cc_url: string;
+	cwd: string;
+	cx_thread_id: string;
+	cx_ws: string;
+	harness: string;
+	kind: string;
+	launch_cmd: string;
+	launch_effort: string;
+	launch_model: string;
+	oc_port: string;
+	oc_session_id: string;
+	oc_url: string;
+	pane_id: string;
+	pane_index: string;
+	pane_target: string;
+	pi_bridge_pid: string;
+	pi_bridge_socket: string;
+	pi_session_id: string;
+	pr: string;
+	title: string;
+	window: string;
+	window_id: string;
+	window_index: string;
+	worktree: string;
+}
+
+function defaultInitFields(entryId: string, kind = "adhoc"): InitFields {
+	return {
 		cc_port: "", cc_session_uuid: "", cc_transcript: "", cc_url: "",
+		cwd: "",
 		cx_thread_id: "", cx_ws: "",
 		harness: "",
-		launch_effort: "", launch_model: "",
+		kind,
+		launch_cmd: "", launch_effort: "", launch_model: "",
 		oc_port: "", oc_session_id: "", oc_url: "",
-		pane_index: defaultIdx,
+		pane_id: "", pane_index: tmuxBasePaneIndex() || "0", pane_target: "",
 		pi_bridge_pid: "", pi_bridge_socket: "", pi_session_id: "",
 		pr: "",
-		window: "",
+		title: entryId,
+		window: "", window_id: "", window_index: "",
 		worktree: "",
 	};
-	const flagMap: Record<string, keyof typeof fields> = {
-		"--cc-port": "cc_port",
-		"--cc-session-uuid": "cc_session_uuid",
-		"--cc-transcript": "cc_transcript",
-		"--cc-url": "cc_url",
-		"--cx-thread-id": "cx_thread_id",
-		"--cx-ws": "cx_ws",
-		"--harness": "harness",
-		"--oc-port": "oc_port",
-		"--oc-session-id": "oc_session_id",
-		"--oc-url": "oc_url",
-		"--pane-index": "pane_index",
-		"--pi-bridge-pid": "pi_bridge_pid",
-		"--pi-bridge-socket": "pi_bridge_socket",
-		"--pi-session-id": "pi_session_id",
-		"--pr": "pr",
-		"--window": "window",
-		"--worktree": "worktree",
-	};
+}
+
+const INIT_FLAG_MAP: Record<string, keyof InitFields> = {
+	"--cc-port": "cc_port",
+	"--cc-session-uuid": "cc_session_uuid",
+	"--cc-transcript": "cc_transcript",
+	"--cc-url": "cc_url",
+	"--cwd": "cwd",
+	"--cx-thread-id": "cx_thread_id",
+	"--cx-ws": "cx_ws",
+	"--harness": "harness",
+	"--kind": "kind",
+	"--launch-cmd": "launch_cmd",
+	"--launch-effort": "launch_effort",
+	"--launch-model": "launch_model",
+	"--oc-port": "oc_port",
+	"--oc-session-id": "oc_session_id",
+	"--oc-url": "oc_url",
+	"--pane-id": "pane_id",
+	"--pane-index": "pane_index",
+	"--pane-target": "pane_target",
+	"--pi-bridge-pid": "pi_bridge_pid",
+	"--pi-bridge-socket": "pi_bridge_socket",
+	"--pi-session-id": "pi_session_id",
+	"--pr": "pr",
+	"--title": "title",
+	"--window": "window",
+	"--window-id": "window_id",
+	"--window-index": "window_index",
+	"--worktree": "worktree",
+};
+
+function parseInitFlags(fields: InitFields, args: string[]): void {
 	for (let i = 0; i < args.length; i += 1) {
-		const key = flagMap[args[i] ?? ""];
+		const key = INIT_FLAG_MAP[args[i] ?? ""];
 		if (!key) die(`Unknown flag: ${args[i]}`);
 		fields[key] = args[++i] ?? "";
 	}
-	if (!fields.window || !fields.harness || !fields.worktree) die("init requires --window, --harness, --worktree");
+}
 
-	// Auto-hydrate spawn discovery files.
+function hydrateSpawnMetadata(entryId: string, fields: InitFields): void {
 	const harness = fields.harness;
-	const issueId = issue;
 	if (harness === "opencode" && !fields.oc_url) {
-		const rec = readJsonIfExists<Record<string, unknown>>(ocSpawnFile(issueId));
+		const rec = readJsonIfExists<Record<string, unknown>>(ocSpawnFile(entryId));
 		if (rec) {
 			fields.oc_url = String(rec.url ?? "");
 			fields.oc_session_id = String(rec.session_id ?? "");
 			fields.oc_port = String(rec.port ?? "");
 			const launch = rec.launch as Record<string, unknown> | undefined;
-			fields.launch_model = String(launch?.model ?? "");
-			fields.launch_effort = String(launch?.effort ?? "");
+			if (!fields.launch_model) fields.launch_model = String(launch?.model ?? "");
+			if (!fields.launch_effort) fields.launch_effort = String(launch?.effort ?? "");
 		}
 	}
 	if (harness === "claude" && !fields.cc_url) {
-		const rec = readJsonIfExists<Record<string, unknown>>(ccSpawnFile(issueId));
+		const rec = readJsonIfExists<Record<string, unknown>>(ccSpawnFile(entryId));
 		if (rec) {
 			fields.cc_url = String(rec.url ?? "");
 			fields.cc_session_uuid = String(rec.session_uuid ?? "");
 			fields.cc_port = String(rec.port ?? "");
 			fields.cc_transcript = String(rec.transcript ?? "");
 			const launch = rec.launch as Record<string, unknown> | undefined;
-			fields.launch_model = String(launch?.model ?? "");
-			fields.launch_effort = String(launch?.effort ?? "");
+			if (!fields.launch_model) fields.launch_model = String(launch?.model ?? "");
+			if (!fields.launch_effort) fields.launch_effort = String(launch?.effort ?? "");
 		}
 	}
 	if (harness === "pi" && !fields.pi_bridge_pid) {
-		const rec = readJsonIfExists<Record<string, unknown>>(piSpawnFile(issueId));
+		const rec = readJsonIfExists<Record<string, unknown>>(piSpawnFile(entryId));
 		if (rec) {
 			fields.pi_bridge_pid = String(rec.pid ?? "");
 			fields.pi_bridge_socket = String(rec.socket ?? "");
 			fields.pi_session_id = String(rec.session_id ?? "");
 			const launch = rec.launch as Record<string, unknown> | undefined;
-			fields.launch_model = String(launch?.model ?? "");
-			fields.launch_effort = String(launch?.effort ?? "");
+			if (!fields.launch_model) fields.launch_model = String(launch?.model ?? "");
+			if (!fields.launch_effort) fields.launch_effort = String(launch?.effort ?? "");
 		}
 	}
 	if (harness === "codex" && !fields.cx_ws) {
-		const rec = readJsonIfExists<Record<string, unknown>>(cxSpawnFile(issueId));
+		const rec = readJsonIfExists<Record<string, unknown>>(cxSpawnFile(entryId));
 		if (rec) {
 			fields.cx_ws = String(rec.url ?? "");
 			fields.cx_thread_id = String(rec.thread_id ?? "");
 			const launch = rec.launch as Record<string, unknown> | undefined;
-			fields.launch_model = String(launch?.model ?? "");
-			fields.launch_effort = String(launch?.effort ?? "");
+			if (!fields.launch_model) fields.launch_model = String(launch?.model ?? "");
+			if (!fields.launch_effort) fields.launch_effort = String(launch?.effort ?? "");
 		}
 	}
+}
 
+function cmdInitEntry(entryId: string, args: string[], mode: "entry" | "issue" = "entry"): void {
+	if (!entryId) die(mode === "issue" ? "Usage: pane-registry init <ISSUE> [flags]" : "Usage: pane-registry init-entry <ENTRY_ID> [flags]");
+	const fields = defaultInitFields(entryId, mode === "issue" ? "issue" : "adhoc");
+	parseInitFlags(fields, args);
+	if (!fields.title) fields.title = entryId;
+	if (mode === "issue") fields.kind = "issue";
+	if (!["adhoc", "issue", "workflow"].includes(fields.kind)) die("init-entry requires --kind adhoc|issue|workflow");
+	if (mode === "issue" && !fields.worktree) die("init requires --window, --harness, --worktree");
+	if (fields.kind === "issue" && !fields.worktree) fields.worktree = fields.cwd;
+	if (!fields.cwd) fields.cwd = fields.worktree;
+	if (!fields.window || !fields.harness || !fields.cwd) die(mode === "issue" ? "init requires --window, --harness, --worktree" : "init-entry requires --title, --kind, --cwd, --window, --harness");
+
+	hydrateSpawnMetadata(entryId, fields);
 	fdStateOrDie(["init"]);
 	const session = tmuxCurrentSession();
-	const paneTarget = `${session}:${fields.window}.${fields.pane_index}`;
-	let paneId = "";
-	if (tmuxPaneExists(paneTarget)) {
-		paneId = tmuxField(paneTarget, "#{pane_id}");
-	}
+	const paneTarget = fields.pane_target || `${session}:${fields.window}.${fields.pane_index}`;
+	let paneId = fields.pane_id;
+	if (!paneId && tmuxPaneExists(paneTarget)) paneId = tmuxField(paneTarget, "#{pane_id}");
 
-	const launch = (fields.launch_model || fields.launch_effort)
-		? { effort: fields.launch_effort || null, model: fields.launch_model || null }
+	const launch = (fields.launch_model || fields.launch_effort || fields.launch_cmd)
+		? { cmd: fields.launch_cmd || null, effort: fields.launch_effort || null, model: fields.launch_model || null }
 		: null;
-
-	const issueObj = {
+	const adapter = {
 		cc_port: numOrNull(fields.cc_port),
 		cc_session_uuid: strOrNull(fields.cc_session_uuid),
 		cc_transcript: strOrNull(fields.cc_transcript),
 		cc_url: strOrNull(fields.cc_url),
 		cx_thread_id: strOrNull(fields.cx_thread_id),
 		cx_ws: strOrNull(fields.cx_ws),
-		decisions_log: [],
-		harness: fields.harness,
-		last_capture_hash: null,
-		last_polled_at: nowIso(),
-		last_response_at: null,
-		launch,
 		oc_port: numOrNull(fields.oc_port),
 		oc_session_id: strOrNull(fields.oc_session_id),
 		oc_url: strOrNull(fields.oc_url),
-		orchestration_started: false,
-		pane_id: paneId || null,
-		pane_target: paneTarget,
 		pi_bridge_pid: numOrNull(fields.pi_bridge_pid),
 		pi_bridge_socket: strOrNull(fields.pi_bridge_socket),
 		pi_session_id: strOrNull(fields.pi_session_id),
+	};
+	const issueDomain = fields.kind === "issue" ? {
+		id: entryId,
+		orchestration_started: false,
 		pr_number: numOrNull(fields.pr),
 		scope_files_actual: null,
 		scope_files_declared: null,
-		spawned_at: nowIso(),
+		worktree: strOrNull(fields.worktree),
+	} : undefined;
+	const ts = nowIso();
+	const entry = {
+		adapter,
+		cwd: fields.cwd,
+		decisions_log: [],
+		domain: issueDomain ? { issue: issueDomain } : null,
+		harness: fields.harness,
+		id: entryId,
+		kind: fields.kind,
+		last_capture_hash: null,
+		last_polled_at: ts,
+		last_response_at: null,
+		launch,
+		pane_id: paneId || null,
+		pane_target: paneTarget || null,
+		spawned_at: ts,
 		state: "waiting",
 		substate: null,
+		title: fields.title,
 		unknown_since: null,
 		window: fields.window,
-		worktree: fields.worktree,
+		window_id: strOrNull(fields.window_id),
+		window_index: numOrNull(fields.window_index),
 	};
 
-	fdStateOrDie(["set", `.issues["${issueId}"]`, JSON.stringify(issueObj)]);
+	fdStateOrDie(["write-entry", entryId, JSON.stringify(entry)]);
 }
 
+// ----- init ----------------------------------------------------------------
+
+function cmdInit(issue: string, args: string[]): void {
+	cmdInitEntry(issue, args, "issue");
+}
 function strOrNull(s: string): string | null {
 	return s ? s : null;
 }
@@ -235,6 +321,57 @@ function numOrNull(s: string): number | null {
 	if (!s) return null;
 	const n = Number(s);
 	return Number.isFinite(n) ? n : null;
+}
+
+function trackedEntries(): Record<string, Record<string, unknown>> {
+	const out = fdStateOrDie(["tracked-entries"]);
+	try {
+		const parsed = JSON.parse(out || "{}") as unknown;
+		if (!isRecord(parsed)) return {};
+		const entries: Record<string, Record<string, unknown>> = {};
+		for (const [key, value] of Object.entries(parsed)) if (isRecord(value)) entries[key] = value;
+		return entries;
+	} catch {
+		return {};
+	}
+}
+
+function nestedRecord(obj: Record<string, unknown>, key: string): Record<string, unknown> {
+	const value = obj[key];
+	return isRecord(value) ? value : {};
+}
+
+function entryRows(): Record<string, unknown>[] {
+	const entries = trackedEntries();
+	return Object.entries(entries).map(([key, entry]) => {
+		const adapter = nestedRecord(entry, "adapter");
+		const domain = nestedRecord(entry, "domain");
+		const issue = nestedRecord(domain, "issue");
+		const id = typeof entry.id === "string" ? entry.id : key;
+		const kind = typeof entry.kind === "string" ? entry.kind : "issue";
+		return {
+			...entry,
+			cc_port: adapter.cc_port ?? null,
+			cc_session_uuid: adapter.cc_session_uuid ?? null,
+			cc_transcript: adapter.cc_transcript ?? null,
+			cc_url: adapter.cc_url ?? null,
+			cx_thread_id: adapter.cx_thread_id ?? null,
+			cx_ws: adapter.cx_ws ?? null,
+			id,
+			issue: kind === "issue" ? (issue.id ?? id) : null,
+			oc_port: adapter.oc_port ?? null,
+			oc_session_id: adapter.oc_session_id ?? null,
+			oc_url: adapter.oc_url ?? null,
+			orchestration_started: issue.orchestration_started ?? null,
+			pi_bridge_pid: adapter.pi_bridge_pid ?? null,
+			pi_bridge_socket: adapter.pi_bridge_socket ?? null,
+			pi_session_id: adapter.pi_session_id ?? null,
+			pr_number: issue.pr_number ?? null,
+			scope_files_actual: issue.scope_files_actual ?? null,
+			scope_files_declared: issue.scope_files_declared ?? null,
+			worktree: issue.worktree ?? entry.cwd ?? null,
+		};
+	});
 }
 
 // ----- list ----------------------------------------------------------------
@@ -247,13 +384,13 @@ function cmdList(args: string[]): void {
 	}
 	switch (format) {
 		case "json":
-			process.stdout.write(fdStateOrDie(["get", ".issues // {} | to_entries | map({issue: .key} + .value)"]));
+			process.stdout.write(`${JSON.stringify(entryRows())}\n`);
 			break;
 		case "inner-panes":
-			process.stdout.write(fdStateOrDie(["get", ".issues // {} | to_entries | map(.value.pane_id // .value.pane_target // empty) | join(\",\")"]));
+			process.stdout.write(`${entryRows().map((row) => row.pane_id ?? row.pane_target ?? "").filter(Boolean).join(",")}\n`);
 			break;
 		case "inner-harnesses":
-			process.stdout.write(fdStateOrDie(["get", ".issues // {} | to_entries | map(.value.harness // \"\") | join(\",\")"]));
+			process.stdout.write(`${entryRows().map((row) => String(row.harness ?? "")).join(",")}\n`);
 			break;
 		default:
 			die(`Unknown format: ${format} (supported: json, inner-panes, inner-harnesses)`);
@@ -327,7 +464,9 @@ function cmdRemove(issue: string): void {
 }
 
 function readField(issue: string, field: string): string {
-	const r = fdState(["get", `.issues["${issue}"].${field} // empty`]);
+	const id = lookupId(issue);
+	const idJson = JSON.stringify(id);
+	const r = fdState(["get", `(.issues[${idJson}].${field} // .entries[${idJson}].adapter.${field} // .entries[${idJson}].${field} // empty)`]);
 	return r.stdout.replace(/\n$/, "").replace(/^"|"$/g, "");
 }
 
@@ -345,6 +484,7 @@ function safeUnlink(p: string): void {
 
 function cmdOcAttachArgs(issue: string): void {
 	if (!issue) die("Usage: oc-attach-args <ISSUE>");
+	issue = lookupId(issue);
 	const url = readField(issue, "oc_url");
 	const sid = readField(issue, "oc_session_id");
 	if (url && sid && url !== "null" && sid !== "null") {
@@ -354,6 +494,7 @@ function cmdOcAttachArgs(issue: string): void {
 
 function cmdCcChannelArgs(issue: string): void {
 	if (!issue) die("Usage: cc-channel-args <ISSUE>");
+	issue = lookupId(issue);
 	const url = readField(issue, "cc_url");
 	const transcript = readField(issue, "cc_transcript");
 	if (url && transcript && url !== "null" && transcript !== "null") {
@@ -363,6 +504,7 @@ function cmdCcChannelArgs(issue: string): void {
 
 function cmdPiBridgeArgs(issue: string): void {
 	if (!issue) die("Usage: pi-bridge-args <ISSUE>");
+	issue = lookupId(issue);
 	const pid = readField(issue, "pi_bridge_pid");
 	const socket = readField(issue, "pi_bridge_socket");
 	if (pid && socket && pid !== "null" && socket !== "null") {
@@ -372,6 +514,7 @@ function cmdPiBridgeArgs(issue: string): void {
 
 function cmdCxBridgeArgs(issue: string): void {
 	if (!issue) die("Usage: cx-bridge-args <ISSUE>");
+	issue = lookupId(issue);
 	const url = readField(issue, "cx_ws");
 	const thread = readField(issue, "cx_thread_id");
 	if (url && thread && url !== "null" && thread !== "null") {
@@ -383,12 +526,10 @@ function cmdCxBridgeArgs(issue: string): void {
 
 function cmdFindByPane(target: string): void {
 	if (!target) die("Usage: find-by-pane <pane-target-or-pane-id>");
-	const out = fdStateOrDie([
-		"get",
-		`.issues // {} | to_entries[] | select(.value.pane_target == "${target}" or .value.pane_id == "${target}") | .key`,
-	]).trim().split("\n").filter(Boolean)[0] ?? "";
-	if (!out) process.exit(1);
-	process.stdout.write(`${out}\n`);
+	const hit = Object.entries(trackedEntries()).find(([, entry]) => entry.pane_target === target || entry.pane_id === target);
+	if (!hit) process.exit(1);
+	const [key, entry] = hit;
+	process.stdout.write(`${JSON.stringify({ id: typeof entry.id === "string" ? entry.id : key, kind: typeof entry.kind === "string" ? entry.kind : "issue" })}\n`);
 }
 
 // ----- reconcile / remove-merged -------------------------------------------
@@ -537,7 +678,7 @@ function cmdTeardownWindow(args: string[]): void {
 	//   exit >= 2             — usage error or genuine read failure
 	// Treat 0+empty and 1 as "not found" (exit 1); only exit >= 2 escalates
 	// to exit 6 (registry read failure) per BLOCK #2.
-	const r = fdState(["get", `.issues["${issue}"] // empty`]);
+	const r = fdState(["get", `.issues["${issue}"] // .entries["${issue}"] // empty`]);
 	const status = r.status ?? 0;
 	if (status >= 2) {
 		process.stderr.write(
@@ -616,6 +757,7 @@ const action = argv.shift();
 if (!action) die("Usage: pane-registry <action> [args]");
 switch (action) {
 	case "init":          cmdInit(argv.shift() ?? "", argv); break;
+	case "init-entry":    cmdInitEntry(argv.shift() ?? "", argv); break;
 	case "list":          cmdList(argv); break;
 	case "get":           cmdGet(argv[0] ?? ""); break;
 	case "set-state":     cmdSetState(argv[0] ?? "", argv[1] ?? ""); break;
@@ -633,5 +775,5 @@ switch (action) {
 	case "teardown-window":
 	case "teardown-entry":  cmdTeardownWindow(argv); break;
 	default:
-		die(`Unknown action: ${action}\nActions: init | list | get | set-state | set-substate | set | log-decision | remove | remove-merged | reconcile | teardown-window | teardown-entry | oc-attach-args | cc-channel-args | pi-bridge-args | cx-bridge-args | find-by-pane`);
+		die(`Unknown action: ${action}\nActions: init-entry | init | list | get | set-state | set-substate | set | log-decision | remove | remove-merged | reconcile | teardown-window | teardown-entry | oc-attach-args | cc-channel-args | pi-bridge-args | cx-bridge-args | find-by-pane`);
 }

--- a/skills/flightdeck/lib/flightdeck-core/src/bin/pane-respond.ts
+++ b/skills/flightdeck/lib/flightdeck-core/src/bin/pane-respond.ts
@@ -177,7 +177,14 @@ function tmuxRun(args: string[], opts: { input?: string } = {}): void {
 function paneRegistry(args: string[]): string {
 	const r = spawnSync(PANE_REGISTRY, args, { encoding: "utf8" });
 	if (r.status !== 0) return "";
-	return (r.stdout ?? "").trim();
+	const raw = (r.stdout ?? "").trim();
+	if (args[0] !== "find-by-pane" || !raw.startsWith("{")) return raw;
+	try {
+		const parsed = JSON.parse(raw) as { id?: unknown };
+		return typeof parsed.id === "string" ? parsed.id : "";
+	} catch {
+		return "";
+	}
 }
 
 function extractFlag(s: string, flag: string): string {

--- a/skills/flightdeck/lib/flightdeck-core/src/daemon/loop.ts
+++ b/skills/flightdeck/lib/flightdeck-core/src/daemon/loop.ts
@@ -100,7 +100,14 @@ function paneRegistryArgs(bin: string, action: string, issue: string): string {
 function paneRegistryIssueForPane(bin: string, paneTarget: string): string {
 	const r = spawnSync(bin, ["find-by-pane", paneTarget], { encoding: "utf8" });
 	if (r.status !== 0) return "";
-	return (r.stdout ?? "").trim();
+	const raw = (r.stdout ?? "").trim();
+	if (!raw.startsWith("{")) return raw;
+	try {
+		const parsed = JSON.parse(raw) as { id?: unknown };
+		return typeof parsed.id === "string" ? parsed.id : "";
+	} catch {
+		return "";
+	}
 }
 
 function extractFlag(args: string, flag: string): string {

--- a/skills/flightdeck/lib/flightdeck-core/tests/parity/flightdeck-session.test.ts
+++ b/skills/flightdeck/lib/flightdeck-core/tests/parity/flightdeck-session.test.ts
@@ -279,6 +279,26 @@ for arg in "$@"; do printf '<%s>\n' "$arg"; done
 			expect(state.entries["pi-snapshot-failed"].adapter.pi_bridge_socket).toBe("/tmp/pi-snapshot.sock");
 		});
 
+		test(`start --strict-discovery refuses pre-launch snapshot failure (${useTs ? "ts registry" : "bash registry"})`, () => {
+			const repo = makeRepo();
+			repos.push(repo);
+			const shim = writeShimState(repo, { panes: {}, session: "test-session", windows: {} });
+			const r = run(repo, shim, [
+				"start",
+				"--session-id", "pi-strict-snapshot-failed",
+				"--title", "Pi strict snapshot failed",
+				"--cwd", repo,
+				"--harness", "pi",
+				"--prompt", "say hi",
+				"--strict-discovery",
+			], useTs, { PI_BRIDGE_BIN: makeFailingPiBridgeShim(repo) });
+			expect(r.status).not.toBe(0);
+			expect(r.stderr).toContain("Warning: pre-launch pi snapshot failed");
+			expect(r.stderr).toContain("--strict-discovery refusing Pi launch");
+			expect(Object.keys(readShimState(shim).panes)).toHaveLength(0);
+			expect(existsSync(stateFile(repo))).toBe(false);
+		});
+
 		test(`attach records existing pi pane metadata (${useTs ? "ts registry" : "bash registry"})`, () => {
 			const repo = makeRepo();
 			repos.push(repo);

--- a/skills/flightdeck/lib/flightdeck-core/tests/parity/flightdeck-session.test.ts
+++ b/skills/flightdeck/lib/flightdeck-core/tests/parity/flightdeck-session.test.ts
@@ -1,0 +1,155 @@
+// Smoke tests for skills/flightdeck/scripts/flightdeck-session.
+// Uses the tmux shim; no real windows or Pi processes are created.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync, chmodSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SCRIPT = resolve(HERE, "../../../../scripts/flightdeck-session");
+const SHIM_DIR = resolve(HERE, "./tmux-shim");
+
+interface ShimPane {
+	window_id: string;
+	window_name: string;
+	path: string;
+	window_index: number;
+	pane_index: number;
+	pane_pid?: number;
+	sent_keys?: string[];
+}
+
+interface ShimState {
+	session: string;
+	panes: Record<string, ShimPane>;
+	windows: Record<string, { name: string; index: number }>;
+}
+
+function makeRepo(): string {
+	const dir = mkdtempSync(join(tmpdir(), "fdsession-"));
+	spawnSync("git", ["init", "-q", "-b", "main"], { cwd: dir });
+	spawnSync("git", ["-C", dir, "commit", "-q", "--allow-empty", "-m", "init"], {
+		env: { ...process.env, GIT_AUTHOR_NAME: "t", GIT_AUTHOR_EMAIL: "t@t", GIT_COMMITTER_NAME: "t", GIT_COMMITTER_EMAIL: "t@t" },
+	});
+	return dir;
+}
+
+function writeShimState(repo: string, state: ShimState): string {
+	const path = join(repo, "shim-state.json");
+	writeFileSync(path, JSON.stringify(state, null, 2));
+	return path;
+}
+
+function readShimState(path: string): ShimState {
+	return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function stateFile(repo: string): string {
+	return join(repo, "tmp", "flightdeck-state-test-session.json");
+}
+
+function run(repo: string, statePath: string, args: string[], useTs: boolean, extraEnv: Record<string, string> = {}): { stdout: string; stderr: string; status: number | null } {
+	const env: Record<string, string> = { ...(process.env as Record<string, string>) };
+	env.TMUX = "/tmp/tmux-test";
+	env.TMUX_SHIM_STATE = statePath;
+	env.TMUX_PARITY_SESSION = "test-session";
+	env.PATH = `${SHIM_DIR}:${env.PATH ?? ""}`;
+	env.FLIGHTDECK_STATE_DIR = "tmp";
+	if (useTs) {
+		env.FLIGHTDECK_USE_TS_PANE_REGISTRY = "1";
+		env.FLIGHTDECK_USE_TS_FLIGHTDECK_STATE = "1";
+	} else {
+		env.FLIGHTDECK_USE_TS_PANE_REGISTRY = "0";
+		env.FLIGHTDECK_USE_TS_FLIGHTDECK_STATE = "0";
+	}
+	delete env.FLIGHTDECK_USE_TS;
+	Object.assign(env, extraEnv);
+	const r = spawnSync(SCRIPT, args, { cwd: repo, encoding: "utf8", env });
+	return { status: r.status, stderr: r.stderr ?? "", stdout: r.stdout ?? "" };
+}
+
+function makePiBridgeShim(repo: string): string {
+	const bin = join(repo, "pi-bridge-shim");
+	writeFileSync(bin, `#!/usr/bin/env bash
+case "$1" in
+  list)
+    echo '[{"pid":4242,"socketPath":"/tmp/pi-77.sock","sessionId":"pi-session-77","cwd":"/tmp/attach"}]'
+    ;;
+  state)
+    echo '{"data":{"protocol":"pi-session-bridge.v1","socketPath":"/tmp/pi-77.sock","sessionId":"pi-session-77"}}'
+    ;;
+  *) echo '{}' ;;
+esac
+`);
+	chmodSync(bin, 0o755);
+	return bin;
+}
+
+let repos: string[] = [];
+
+beforeEach(() => {
+	repos = [];
+});
+
+afterEach(() => {
+	for (const repo of repos) if (existsSync(repo)) rmSync(repo, { recursive: true, force: true });
+});
+
+describe("flightdeck-session smoke", () => {
+	for (const useTs of [false, true]) {
+		test(`start creates tmux window and registers entry (${useTs ? "ts registry" : "bash registry"})`, () => {
+			const repo = makeRepo();
+			repos.push(repo);
+			const shim = writeShimState(repo, { panes: {}, session: "test-session", windows: {} });
+			const r = run(repo, shim, [
+				"start",
+				"--session-id", "adhoc-start",
+				"--title", "Scratch",
+				"--kind", "adhoc",
+				"--cwd", repo,
+				"--harness", "pi",
+				"--cmd", "printf ok",
+			], useTs);
+			expect(r.status).toBe(0);
+			const shimState = readShimState(shim);
+			const pane = shimState.panes["%1"]!;
+			expect(pane.window_name).toBe("Scratch");
+			expect(pane.sent_keys).toContain("clear Enter");
+			const launchLine = pane.sent_keys!.find((line) => line.includes("printf ok"))!;
+			expect(launchLine).toContain("FLIGHTDECK_MANAGED=1");
+			expect(launchLine).toContain("FLIGHTDECK_CHILD_PANE=1");
+			const state = JSON.parse(readFileSync(stateFile(repo), "utf8"));
+			expect(state.entries["adhoc-start"].pane_id).toBe("%1");
+			expect(state.entries["adhoc-start"].kind).toBe("adhoc");
+			expect(state.entries["adhoc-start"].cwd).toBe(repo);
+		});
+
+		test(`attach records existing pi pane metadata (${useTs ? "ts registry" : "bash registry"})`, () => {
+			const repo = makeRepo();
+			repos.push(repo);
+			const shim = writeShimState(repo, {
+				panes: {
+					"%77": { pane_index: 0, pane_pid: 4242, path: "/tmp/attach", window_id: "@7", window_index: 7, window_name: "manual-pi" },
+				},
+				session: "test-session",
+				windows: { "@7": { index: 7, name: "manual-pi" } },
+			});
+			const bridge = makePiBridgeShim(repo);
+			const r = run(repo, shim, [
+				"attach",
+				"--pane", "%77",
+				"--harness", "pi",
+				"--title", "Manual Pi",
+			], useTs, { PI_BRIDGE_BIN: bridge });
+			expect(r.status).toBe(0);
+			const state = JSON.parse(readFileSync(stateFile(repo), "utf8"));
+			expect(state.entries["pi-session-77"].pane_id).toBe("%77");
+			expect(state.entries["pi-session-77"].adapter.pi_bridge_pid).toBe(4242);
+			expect(state.entries["pi-session-77"].adapter.pi_bridge_socket).toBe("/tmp/pi-77.sock");
+			expect(state.entries["pi-session-77"].adapter.pi_session_id).toBe("pi-session-77");
+		});
+	}
+});

--- a/skills/flightdeck/lib/flightdeck-core/tests/parity/flightdeck-session.test.ts
+++ b/skills/flightdeck/lib/flightdeck-core/tests/parity/flightdeck-session.test.ts
@@ -98,6 +98,60 @@ exit 1
 	return bin;
 }
 
+function makeHangingPiBridgeShim(repo: string): string {
+	const bin = join(repo, "pi-bridge-hang-shim");
+	writeFileSync(bin, `#!/usr/bin/env bash
+sleep 10
+`);
+	chmodSync(bin, 0o755);
+	return bin;
+}
+
+function makeStartListTimeoutPiBridgeShim(repo: string): string {
+	const bin = join(repo, "pi-bridge-start-timeout-shim");
+	const countFile = join(repo, "pi-bridge-start-timeout.count");
+	writeFileSync(bin, `#!/usr/bin/env bash
+count_file=${JSON.stringify(countFile)}
+count=0
+[[ -f "$count_file" ]] && count=$(cat "$count_file")
+count=$((count + 1))
+printf '%s' "$count" > "$count_file"
+if [[ "$1" == "list" && "$count" == "1" ]]; then
+  echo '[]'
+  exit 0
+fi
+sleep 10
+`);
+	chmodSync(bin, 0o755);
+	return bin;
+}
+
+function makeSnapshotFailThenSuccessPiBridgeShim(repo: string): string {
+	const bin = join(repo, "pi-bridge-snapshot-fail-shim");
+	const countFile = join(repo, "pi-bridge-snapshot-fail.count");
+	writeFileSync(bin, `#!/usr/bin/env bash
+count_file=${JSON.stringify(countFile)}
+count=0
+[[ -f "$count_file" ]] && count=$(cat "$count_file")
+count=$((count + 1))
+printf '%s' "$count" > "$count_file"
+case "$1" in
+  list)
+    if [[ "$count" == "1" ]]; then
+      exit 7
+    fi
+    printf '[{"pid":5151,"socketPath":"/tmp/pi-snapshot.sock","sessionId":"pi-snapshot-session","cwd":%s}]\\n' ${JSON.stringify(JSON.stringify(repo))}
+    ;;
+  state)
+    echo '{"data":{"protocol":"pi-session-bridge.v1","socketPath":"/tmp/pi-snapshot.sock","sessionId":"pi-snapshot-session"}}'
+    ;;
+  *) echo '{}' ;;
+esac
+`);
+	chmodSync(bin, 0o755);
+	return bin;
+}
+
 function makePiBinShim(repo: string): string {
 	const bin = join(repo, "pi-shim");
 	writeFileSync(bin, `#!/usr/bin/env bash
@@ -185,23 +239,44 @@ for arg in "$@"; do printf '<%s>\n' "$arg"; done
 			expect(Object.keys(readShimState(shim).panes)).toHaveLength(0);
 		});
 
-		test(`start records Pi discovery_error when bridge discovery fails (${useTs ? "ts registry" : "bash registry"})`, () => {
+		test(`start records Pi discovery_error when bridge discovery times out (${useTs ? "ts registry" : "bash registry"})`, () => {
+			const repo = makeRepo();
+			repos.push(repo);
+			const shim = writeShimState(repo, { panes: {}, session: "test-session", windows: {} });
+			const started = Date.now();
+			const r = run(repo, shim, [
+				"start",
+				"--session-id", "pi-timeout",
+				"--title", "Pi timeout",
+				"--cwd", repo,
+				"--harness", "pi",
+				"--prompt", "say hi",
+			], useTs, { PI_BIN: makePiBinShim(repo), PI_BRIDGE_BIN: makeStartListTimeoutPiBridgeShim(repo), PI_BRIDGE_CALL_TIMEOUT_SEC: "1", PI_BRIDGE_DISCOVERY_TIMEOUT: "5" });
+			expect(Date.now() - started).toBeLessThan(4000);
+			expect(r.status).toBe(0);
+			expect(r.stderr).toContain("Warning: pi-bridge metadata discovery failed during start");
+			const state = JSON.parse(readFileSync(stateFile(repo), "utf8"));
+			expect(state.entries["pi-timeout"].discovery_error).toBe("pi_bridge_timeout");
+			expect(state.entries["pi-timeout"].adapter.pi_bridge_socket).toBeNull();
+		});
+
+		test(`start surfaces pre-launch snapshot failure (${useTs ? "ts registry" : "bash registry"})`, () => {
 			const repo = makeRepo();
 			repos.push(repo);
 			const shim = writeShimState(repo, { panes: {}, session: "test-session", windows: {} });
 			const r = run(repo, shim, [
 				"start",
-				"--session-id", "pi-degraded",
-				"--title", "Pi degraded",
+				"--session-id", "pi-snapshot-failed",
+				"--title", "Pi snapshot failed",
 				"--cwd", repo,
 				"--harness", "pi",
 				"--prompt", "say hi",
-			], useTs, { PI_BIN: makePiBinShim(repo), PI_BRIDGE_BIN: makeFailingPiBridgeShim(repo), PI_BRIDGE_DISCOVERY_TIMEOUT: "0" });
+			], useTs, { PI_BIN: makePiBinShim(repo), PI_BRIDGE_BIN: makeSnapshotFailThenSuccessPiBridgeShim(repo), PI_BRIDGE_CALL_TIMEOUT_SEC: "1", PI_BRIDGE_DISCOVERY_TIMEOUT: "2" });
 			expect(r.status).toBe(0);
-			expect(r.stderr).toContain("Warning: pi-bridge metadata discovery failed during start");
+			expect(r.stderr).toContain("Warning: pre-launch pi snapshot failed");
 			const state = JSON.parse(readFileSync(stateFile(repo), "utf8"));
-			expect(state.entries["pi-degraded"].discovery_error).toBe("pi_bridge_discovery_timeout");
-			expect(state.entries["pi-degraded"].adapter.pi_bridge_socket).toBeNull();
+			expect(state.entries["pi-snapshot-failed"].discovery_error).toBe("pi_snapshot_failed");
+			expect(state.entries["pi-snapshot-failed"].adapter.pi_bridge_socket).toBe("/tmp/pi-snapshot.sock");
 		});
 
 		test(`attach records existing pi pane metadata (${useTs ? "ts registry" : "bash registry"})`, () => {
@@ -249,7 +324,32 @@ for arg in "$@"; do printf '<%s>\n' "$arg"; done
 			expect(r.stderr).toContain("Warning: pi-bridge metadata discovery failed during attach");
 			const state = JSON.parse(readFileSync(stateFile(repo), "utf8"));
 			expect(state.entries["pane-88"].pane_id).toBe("%88");
-			expect(state.entries["pane-88"].discovery_error).toBe("pi_bridge_no_instance_for_pane_pid");
+			expect(state.entries["pane-88"].discovery_error).toBe("pi_bridge_list_failed");
+		});
+
+		test(`attach records Pi discovery_error when bridge call times out (${useTs ? "ts registry" : "bash registry"})`, () => {
+			const repo = makeRepo();
+			repos.push(repo);
+			const shim = writeShimState(repo, {
+				panes: {
+					"%89": { pane_index: 0, pane_pid: 8989, path: "/tmp/attach-timeout", window_id: "@9", window_index: 9, window_name: "manual-pi-timeout" },
+				},
+				session: "test-session",
+				windows: { "@9": { index: 9, name: "manual-pi-timeout" } },
+			});
+			const started = Date.now();
+			const r = run(repo, shim, [
+				"attach",
+				"--pane", "%89",
+				"--harness", "pi",
+				"--title", "Manual Timeout Pi",
+			], useTs, { PI_BRIDGE_BIN: makeHangingPiBridgeShim(repo), PI_BRIDGE_CALL_TIMEOUT_SEC: "1" });
+			expect(Date.now() - started).toBeLessThan(4000);
+			expect(r.status).toBe(0);
+			expect(r.stderr).toContain("Warning: pi-bridge metadata discovery failed during attach");
+			const state = JSON.parse(readFileSync(stateFile(repo), "utf8"));
+			expect(state.entries["pane-89"].pane_id).toBe("%89");
+			expect(state.entries["pane-89"].discovery_error).toBe("pi_bridge_timeout");
 		});
 	}
 });

--- a/skills/flightdeck/lib/flightdeck-core/tests/parity/flightdeck-session.test.ts
+++ b/skills/flightdeck/lib/flightdeck-core/tests/parity/flightdeck-session.test.ts
@@ -10,6 +10,7 @@ import { fileURLToPath } from "node:url";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const SCRIPT = resolve(HERE, "../../../../scripts/flightdeck-session");
+const PANE_ENV_SCRIPT = resolve(HERE, "../../../../scripts/lib/pane-env.sh");
 const SHIM_DIR = resolve(HERE, "./tmux-shim");
 
 interface ShimPane {
@@ -88,6 +89,24 @@ esac
 	return bin;
 }
 
+function makeFailingPiBridgeShim(repo: string): string {
+	const bin = join(repo, "pi-bridge-fail-shim");
+	writeFileSync(bin, `#!/usr/bin/env bash
+exit 1
+`);
+	chmodSync(bin, 0o755);
+	return bin;
+}
+
+function makePiBinShim(repo: string): string {
+	const bin = join(repo, "pi-shim");
+	writeFileSync(bin, `#!/usr/bin/env bash
+echo pi-shim "$@"
+`);
+	chmodSync(bin, 0o755);
+	return bin;
+}
+
 let repos: string[] = [];
 
 beforeEach(() => {
@@ -99,6 +118,27 @@ afterEach(() => {
 });
 
 describe("flightdeck-session smoke", () => {
+	test("pane env string helpers shell-escape metacharacters", () => {
+		const script = `
+source ${JSON.stringify(PANE_ENV_SCRIPT)}
+FLIGHTDECK_CHILD_PANE_ENV=(env "A=space value" "B=single'quote" 'C=\`ticks\`' 'D=$dollar')
+quoted=$(flightdeck_child_pane_env_str)
+eval "set -- $quoted"
+printf '%s\n' "$#"
+for arg in "$@"; do printf '<%s>\n' "$arg"; done
+`;
+		const r = spawnSync("bash", ["-lc", script], { encoding: "utf8" });
+		expect(r.status).toBe(0);
+		expect(r.stdout.trim().split("\n")).toEqual([
+			"5",
+			"<env>",
+			"<A=space value>",
+			"<B=single'quote>",
+			"<C=`ticks`>",
+			"<D=$dollar>",
+		]);
+	});
+
 	for (const useTs of [false, true]) {
 		test(`start creates tmux window and registers entry (${useTs ? "ts registry" : "bash registry"})`, () => {
 			const repo = makeRepo();
@@ -127,6 +167,43 @@ describe("flightdeck-session smoke", () => {
 			expect(state.entries["adhoc-start"].cwd).toBe(repo);
 		});
 
+		test(`start reports tmux new-window failure without registering entry (${useTs ? "ts registry" : "bash registry"})`, () => {
+			const repo = makeRepo();
+			repos.push(repo);
+			const shim = writeShimState(repo, { panes: {}, session: "test-session", windows: {} });
+			const r = run(repo, shim, [
+				"start",
+				"--session-id", "fail-start",
+				"--title", "Fail",
+				"--cwd", repo,
+				"--harness", "pi",
+				"--cmd", "printf ok",
+			], useTs, { TMUX_SHIM_FAIL_NEW_WINDOW: "1" });
+			expect(r.status).not.toBe(0);
+			expect(r.stderr).toContain("tmux new-window failed");
+			expect(existsSync(stateFile(repo))).toBe(false);
+			expect(Object.keys(readShimState(shim).panes)).toHaveLength(0);
+		});
+
+		test(`start records Pi discovery_error when bridge discovery fails (${useTs ? "ts registry" : "bash registry"})`, () => {
+			const repo = makeRepo();
+			repos.push(repo);
+			const shim = writeShimState(repo, { panes: {}, session: "test-session", windows: {} });
+			const r = run(repo, shim, [
+				"start",
+				"--session-id", "pi-degraded",
+				"--title", "Pi degraded",
+				"--cwd", repo,
+				"--harness", "pi",
+				"--prompt", "say hi",
+			], useTs, { PI_BIN: makePiBinShim(repo), PI_BRIDGE_BIN: makeFailingPiBridgeShim(repo), PI_BRIDGE_DISCOVERY_TIMEOUT: "0" });
+			expect(r.status).toBe(0);
+			expect(r.stderr).toContain("Warning: pi-bridge metadata discovery failed during start");
+			const state = JSON.parse(readFileSync(stateFile(repo), "utf8"));
+			expect(state.entries["pi-degraded"].discovery_error).toBe("pi_bridge_discovery_timeout");
+			expect(state.entries["pi-degraded"].adapter.pi_bridge_socket).toBeNull();
+		});
+
 		test(`attach records existing pi pane metadata (${useTs ? "ts registry" : "bash registry"})`, () => {
 			const repo = makeRepo();
 			repos.push(repo);
@@ -150,6 +227,29 @@ describe("flightdeck-session smoke", () => {
 			expect(state.entries["pi-session-77"].adapter.pi_bridge_pid).toBe(4242);
 			expect(state.entries["pi-session-77"].adapter.pi_bridge_socket).toBe("/tmp/pi-77.sock");
 			expect(state.entries["pi-session-77"].adapter.pi_session_id).toBe("pi-session-77");
+		});
+
+		test(`attach records Pi discovery_error when bridge metadata is unavailable (${useTs ? "ts registry" : "bash registry"})`, () => {
+			const repo = makeRepo();
+			repos.push(repo);
+			const shim = writeShimState(repo, {
+				panes: {
+					"%88": { pane_index: 0, pane_pid: 8888, path: "/tmp/attach-missing", window_id: "@8", window_index: 8, window_name: "manual-pi-missing" },
+				},
+				session: "test-session",
+				windows: { "@8": { index: 8, name: "manual-pi-missing" } },
+			});
+			const r = run(repo, shim, [
+				"attach",
+				"--pane", "%88",
+				"--harness", "pi",
+				"--title", "Manual Missing Pi",
+			], useTs, { PI_BRIDGE_BIN: makeFailingPiBridgeShim(repo) });
+			expect(r.status).toBe(0);
+			expect(r.stderr).toContain("Warning: pi-bridge metadata discovery failed during attach");
+			const state = JSON.parse(readFileSync(stateFile(repo), "utf8"));
+			expect(state.entries["pane-88"].pane_id).toBe("%88");
+			expect(state.entries["pane-88"].discovery_error).toBe("pi_bridge_no_instance_for_pane_pid");
 		});
 	}
 });

--- a/skills/flightdeck/lib/flightdeck-core/tests/parity/pane-registry.test.ts
+++ b/skills/flightdeck/lib/flightdeck-core/tests/parity/pane-registry.test.ts
@@ -46,6 +46,11 @@ function readIssues(repo: string, session = process.env.TMUX_PARITY_SESSION ?? s
 	return JSON.parse(readFileSync(file, "utf8")).issues;
 }
 
+function readEntries(repo: string, session = process.env.TMUX_PARITY_SESSION ?? sessionName()): unknown {
+	const file = join(repo, "tmp", `flightdeck-state-${session}.json`);
+	return JSON.parse(readFileSync(file, "utf8")).entries;
+}
+
 function sessionName(): string {
 	const r = spawnSync("tmux", ["display-message", "-p", "#S"], { encoding: "utf8" });
 	return (r.stdout ?? "").trim();
@@ -154,6 +159,74 @@ describe("pane-registry parity", () => {
 		expect(b.stdout.trim().split(",").sort()).toEqual(a.stdout.trim().split(",").sort());
 	});
 
+	test("init-entry writes normalized adhoc entry without legacy issue projection", () => {
+		for (const repo of [bashRepo, tsRepo]) {
+			const useTs = repo === tsRepo;
+			const r = run(useTs, repo, [
+				"init-entry", "adhoc.one",
+				"--title", "Scratch Session",
+				"--kind", "adhoc",
+				"--cwd", "/tmp/scratch",
+				"--window", "7",
+				"--harness", "pi",
+				"--pane-target", "test:7.0",
+				"--pane-id", "%777",
+			]);
+			expect(r.status).toBe(0);
+		}
+		const bEntries = readEntries(bashRepo) as Record<string, Record<string, unknown>>;
+		const tEntries = readEntries(tsRepo) as Record<string, Record<string, unknown>>;
+		expect(tEntries["adhoc.one"]!.kind).toBe("adhoc");
+		expect(tEntries["adhoc.one"]!.pane_id).toBe("%777");
+		expect(normalize(tEntries)).toEqual(normalize(bEntries));
+		expect(readIssues(tsRepo)).toEqual({});
+		expect(readIssues(bashRepo)).toEqual({});
+	});
+
+	test("init-entry kind=issue dual-writes .entries and .issues", () => {
+		for (const repo of [bashRepo, tsRepo]) {
+			const useTs = repo === tsRepo;
+			const r = run(useTs, repo, [
+				"init-entry", "ISSUE-42",
+				"--title", "Issue 42",
+				"--kind", "issue",
+				"--cwd", "/tmp/wt42",
+				"--window", "issue-42",
+				"--harness", "opencode",
+				"--worktree", "/tmp/wt42",
+				"--pr", "42",
+			]);
+			expect(r.status).toBe(0);
+		}
+		const bIssues = readIssues(bashRepo) as Record<string, Record<string, unknown>>;
+		const tIssues = readIssues(tsRepo) as Record<string, Record<string, unknown>>;
+		const tEntries = readEntries(tsRepo) as Record<string, Record<string, unknown>>;
+		expect(tEntries["ISSUE-42"]!.kind).toBe("issue");
+		expect(tIssues["ISSUE-42"]!.pr_number).toBe(42);
+		expect(normalize(tIssues)).toEqual(normalize(bIssues));
+	});
+
+	test("list --format json returns normalized entries with legacy issue fields", () => {
+		for (const repo of [bashRepo, tsRepo]) {
+			const useTs = repo === tsRepo;
+			run(useTs, repo, ["init-entry", "adhoc-json", "--title", "Adhoc", "--kind", "adhoc", "--cwd", "/tmp/a", "--window", "10", "--harness", "pi", "--pane-id", "%10"]);
+			run(useTs, repo, ["init", "JSON-9", "--window", "json-9", "--harness", "codex", "--worktree", "/tmp/json-9", "--pr", "9"]);
+		}
+		const a = JSON.parse(run(false, bashRepo, ["list", "--format", "json"]).stdout) as Array<Record<string, unknown>>;
+		const b = JSON.parse(run(true, tsRepo, ["list", "--format", "json"]).stdout) as Array<Record<string, unknown>>;
+		const normRows = (rows: Array<Record<string, unknown>>) => rows.map((row) => ({
+			id: row.id,
+			issue: row.issue,
+			kind: row.kind,
+			pane_id: row.pane_id,
+			pr_number: row.pr_number,
+			worktree: row.worktree,
+		})).sort((x, y) => String(x.id).localeCompare(String(y.id)));
+		expect(normRows(b)).toEqual(normRows(a));
+		expect(normRows(b)).toContainEqual({ id: "JSON-9", issue: "JSON-9", kind: "issue", pane_id: null, pr_number: 9, worktree: "/tmp/json-9" });
+		expect(normRows(b)).toContainEqual({ id: "adhoc-json", issue: null, kind: "adhoc", pane_id: "%10", pr_number: null, worktree: "/tmp/a" });
+	});
+
 	test("find-by-pane resolves an issue", () => {
 		for (const repo of [bashRepo, tsRepo]) {
 			const useTs = repo === tsRepo;
@@ -165,8 +238,21 @@ describe("pane-registry parity", () => {
 		const target = `${session}:wF.0`;
 		const a = run(false, bashRepo, ["find-by-pane", target]);
 		const b = run(true, tsRepo, ["find-by-pane", target]);
-		expect(b.stdout.trim()).toBe("FBP-001");
-		expect(a.stdout.trim()).toBe("FBP-001");
+		expect(JSON.parse(b.stdout)).toEqual({ id: "FBP-001", kind: "issue" });
+		expect(JSON.parse(a.stdout)).toEqual({ id: "FBP-001", kind: "issue" });
+	});
+
+	test("find-by-pane resolves entry rows and legacy issue rows", () => {
+		for (const repo of [bashRepo, tsRepo]) {
+			const useTs = repo === tsRepo;
+			run(useTs, repo, ["init-entry", "adhoc-fbp", "--title", "Adhoc FBP", "--kind", "adhoc", "--cwd", "/tmp/a", "--window", "11", "--harness", "pi", "--pane-id", "%110"]);
+			run(useTs, repo, ["init", "LEGACY-1", "--window", "legacy-win", "--harness", "pi", "--worktree", "/tmp/l", "--pane-index", "0"]);
+		}
+		const session = sessionName();
+		expect(JSON.parse(run(false, bashRepo, ["find-by-pane", "%110"]).stdout)).toEqual({ id: "adhoc-fbp", kind: "adhoc" });
+		expect(JSON.parse(run(true, tsRepo, ["find-by-pane", "%110"]).stdout)).toEqual({ id: "adhoc-fbp", kind: "adhoc" });
+		expect(JSON.parse(run(false, bashRepo, ["find-by-pane", `${session}:legacy-win.0`]).stdout)).toEqual({ id: "LEGACY-1", kind: "issue" });
+		expect(JSON.parse(run(true, tsRepo, ["find-by-pane", `${session}:legacy-win.0`]).stdout)).toEqual({ id: "LEGACY-1", kind: "issue" });
 	});
 
 	test("remove drops the issue from .issues", () => {

--- a/skills/flightdeck/lib/flightdeck-core/tests/parity/pane-registry.test.ts
+++ b/skills/flightdeck/lib/flightdeck-core/tests/parity/pane-registry.test.ts
@@ -227,17 +227,38 @@ describe("pane-registry parity", () => {
 		expect(normRows(b)).toContainEqual({ id: "adhoc-json", issue: null, kind: "adhoc", pane_id: "%10", pr_number: null, worktree: "/tmp/a" });
 	});
 
+	test("init-entry rejects bad input with parity", () => {
+		const cases = [
+			{ args: ["init-entry"], stderr: "Usage: pane-registry init-entry" },
+			{ args: ["init-entry", "BAD-KIND", "--title", "Bad", "--kind", "bogus", "--cwd", "/tmp/bad", "--window", "1", "--harness", "pi"], stderr: "init-entry requires --kind" },
+			{ args: ["init-entry", "NO-CWD", "--title", "Missing", "--kind", "adhoc", "--window", "1", "--harness", "pi"], stderr: "init-entry requires --title" },
+			{ args: ["init-entry", "NO-HARNESS", "--title", "Missing", "--kind", "adhoc", "--cwd", "/tmp/missing", "--window", "1"], stderr: "init-entry requires --title" },
+		];
+		for (const c of cases) {
+			const bash = run(false, bashRepo, c.args);
+			const ts = run(true, tsRepo, c.args);
+			expect(ts.status).toBe(2);
+			expect(bash.status).toBe(2);
+			expect(ts.stderr).toContain(c.stderr);
+			expect(bash.stderr).toContain(c.stderr);
+		}
+	});
+
 	test("find-by-pane resolves an issue", () => {
 		for (const repo of [bashRepo, tsRepo]) {
 			const useTs = repo === tsRepo;
-			// Pin --pane-index 0 so the test target is deterministic across
-			// tmux configs that set pane-base-index to 1.
-			run(useTs, repo, ["init", "FBP-001", "--window", "wF", "--harness", "pi", "--worktree", "/tmp/wt", "--pane-index", "0"]);
+			const statePath = makeShimState(repo, {
+				panes: {
+					"%210": { pane_index: 0, path: "/tmp/wt", window_id: "@21", window_index: 21, window_name: "wF" },
+				},
+				session: "test-session",
+				windows: { "@21": { index: 21, name: "wF" } },
+			});
+			runShim(useTs, repo, statePath, ["init", "FBP-001", "--window", "21", "--harness", "pi", "--worktree", "/tmp/wt", "--pane-index", "0"]);
 		}
-		const session = sessionName();
-		const target = `${session}:wF.0`;
-		const a = run(false, bashRepo, ["find-by-pane", target]);
-		const b = run(true, tsRepo, ["find-by-pane", target]);
+		const target = "test-session:21.0";
+		const a = runShim(false, bashRepo, join(bashRepo, "shim-state.json"), ["find-by-pane", target]);
+		const b = runShim(true, tsRepo, join(tsRepo, "shim-state.json"), ["find-by-pane", target]);
 		expect(JSON.parse(b.stdout)).toEqual({ id: "FBP-001", kind: "issue" });
 		expect(JSON.parse(a.stdout)).toEqual({ id: "FBP-001", kind: "issue" });
 	});
@@ -245,14 +266,33 @@ describe("pane-registry parity", () => {
 	test("find-by-pane resolves entry rows and legacy issue rows", () => {
 		for (const repo of [bashRepo, tsRepo]) {
 			const useTs = repo === tsRepo;
-			run(useTs, repo, ["init-entry", "adhoc-fbp", "--title", "Adhoc FBP", "--kind", "adhoc", "--cwd", "/tmp/a", "--window", "11", "--harness", "pi", "--pane-id", "%110"]);
-			run(useTs, repo, ["init", "LEGACY-1", "--window", "legacy-win", "--harness", "pi", "--worktree", "/tmp/l", "--pane-index", "0"]);
+			const statePath = makeShimState(repo, {
+				panes: {
+					"%110": { pane_index: 0, path: "/tmp/a", window_id: "@11", window_index: 11, window_name: "adhoc" },
+					"%120": { pane_index: 0, path: "/tmp/l", window_id: "@12", window_index: 12, window_name: "legacy" },
+				},
+				session: "test-session",
+				windows: { "@11": { index: 11, name: "adhoc" }, "@12": { index: 12, name: "legacy" } },
+			});
+			runShim(useTs, repo, statePath, ["init-entry", "adhoc-fbp", "--title", "Adhoc FBP", "--kind", "adhoc", "--cwd", "/tmp/a", "--window", "11", "--harness", "pi", "--pane-id", "%110", "--pane-target", "test-session:11.0"]);
+			runShim(useTs, repo, statePath, ["init", "LEGACY-1", "--window", "12", "--harness", "pi", "--worktree", "/tmp/l", "--pane-index", "0"]);
 		}
-		const session = sessionName();
-		expect(JSON.parse(run(false, bashRepo, ["find-by-pane", "%110"]).stdout)).toEqual({ id: "adhoc-fbp", kind: "adhoc" });
-		expect(JSON.parse(run(true, tsRepo, ["find-by-pane", "%110"]).stdout)).toEqual({ id: "adhoc-fbp", kind: "adhoc" });
-		expect(JSON.parse(run(false, bashRepo, ["find-by-pane", `${session}:legacy-win.0`]).stdout)).toEqual({ id: "LEGACY-1", kind: "issue" });
-		expect(JSON.parse(run(true, tsRepo, ["find-by-pane", `${session}:legacy-win.0`]).stdout)).toEqual({ id: "LEGACY-1", kind: "issue" });
+		expect(JSON.parse(runShim(false, bashRepo, join(bashRepo, "shim-state.json"), ["find-by-pane", "%110"]).stdout)).toEqual({ id: "adhoc-fbp", kind: "adhoc" });
+		expect(JSON.parse(runShim(true, tsRepo, join(tsRepo, "shim-state.json"), ["find-by-pane", "%110"]).stdout)).toEqual({ id: "adhoc-fbp", kind: "adhoc" });
+		expect(JSON.parse(runShim(false, bashRepo, join(bashRepo, "shim-state.json"), ["find-by-pane", "test-session:12.0"]).stdout)).toEqual({ id: "LEGACY-1", kind: "issue" });
+		expect(JSON.parse(runShim(true, tsRepo, join(tsRepo, "shim-state.json"), ["find-by-pane", "test-session:12.0"]).stdout)).toEqual({ id: "LEGACY-1", kind: "issue" });
+	});
+
+	test("find-by-pane treats stale pane_id as no match and warns", () => {
+		for (const repo of [bashRepo, tsRepo]) {
+			const useTs = repo === tsRepo;
+			const statePath = makeShimState(repo, baseShim("test-session"));
+			runShim(useTs, repo, statePath, ["init-entry", "stale-fbp", "--title", "Stale", "--kind", "adhoc", "--cwd", "/tmp/stale", "--window", "99", "--harness", "pi", "--pane-id", "%999", "--pane-target", "test-session:99.0"]);
+			const r = runShim(useTs, repo, statePath, ["find-by-pane", "%999"]);
+			expect(r.status).toBe(1);
+			expect(r.stdout).toBe("");
+			expect(r.stderr).toContain("Warning: find-by-pane match %999 is stale");
+		}
 	});
 
 	test("remove drops the issue from .issues", () => {

--- a/skills/flightdeck/lib/flightdeck-core/tests/parity/tmux-shim/tmux
+++ b/skills/flightdeck/lib/flightdeck-core/tests/parity/tmux-shim/tmux
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Test-only tmux shim. Reads/writes state from $TMUX_SHIM_STATE (JSON).
-# Implements only the tmux subcommands the pane-registry helper invokes:
-#   display-message, list-panes, list-windows, kill-window, kill-pane,
-#   show-options.
+# Implements only the tmux subcommands the pane-registry / flightdeck-session helpers invoke:
+#   display-message, list-panes, list-windows, new-window, send-keys,
+#   kill-window, kill-pane, show-options.
 #
 # State shape:
 #   {
@@ -55,6 +55,33 @@ write_state() {
   mv "$tmp" "$STATE_FILE"
 }
 
+next_numeric_suffix() {
+  local path="$1" prefix="$2"
+  jq -r --arg p "$prefix" "$path | keys | map(sub(\"^\" + \$p; \"\") | tonumber? // 0) | max // 0 | . + 1" "$STATE_FILE"
+}
+
+max_window_index() {
+  jq -r '.windows | to_entries | map(.value.index // 0) | max // 0' "$STATE_FILE"
+}
+
+format_new_window() {
+  local fmt="$1" pane_id="$2" window_id="$3" window_index="$4" pane_index="$5" cwd="$6" out
+  case "$fmt" in
+    '#{pane_id}') echo "$pane_id"; return ;;
+    '#{window_id}') echo "$window_id"; return ;;
+    '#{window_index}') echo "$window_index"; return ;;
+    '#{pane_index}') echo "$pane_index"; return ;;
+    '#{pane_current_path}') echo "$cwd"; return ;;
+  esac
+  out="$fmt"
+  out="${out//'#{pane_id}'/$pane_id}"
+  out="${out//'#{window_id}'/$window_id}"
+  out="${out//'#{window_index}'/$window_index}"
+  out="${out//'#{pane_index}'/$pane_index}"
+  out="${out//'#{pane_current_path}'/$cwd}"
+  printf '%s\n' "$out"
+}
+
 subcmd="${1:-}"
 shift || true
 
@@ -88,6 +115,9 @@ case "$subcmd" in
     case "$format" in
       "#{window_id}")         jq -r '.window_id // empty' <<< "$pane" ;;
       "#{window_name}")       jq -r '.window_name // empty' <<< "$pane" ;;
+      "#{window_index}")      jq -r '.window_index // empty' <<< "$pane" ;;
+      "#{pane_index}")        jq -r '.pane_index // empty' <<< "$pane" ;;
+      "#{pane_pid}")          jq -r '.pane_pid // empty' <<< "$pane" ;;
       "#{pane_id}")           jq -r --arg t "$target" --arg session "$(jq -r '.session' "$STATE_FILE")" '
                                  def to_pt: "\($session):\(.value.window_index).\(.value.pane_index)";
                                  .panes | to_entries[] |
@@ -153,6 +183,71 @@ case "$subcmd" in
       esac
     done
     jq -r '.windows | to_entries[] | .value.name' "$STATE_FILE"
+    ;;
+  new-window)
+    name=""
+    cwd=""
+    format=""
+    print=0
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        -n) name="$2"; shift 2 ;;
+        -c) cwd="$2"; shift 2 ;;
+        -F) format="$2"; shift 2 ;;
+        -P) print=1; shift ;;
+        -d|-a) shift ;;
+        -t) shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    [[ -n "$name" ]] || name="window-$(($(max_window_index) + 1))"
+    [[ -n "$cwd" ]] || cwd="/tmp"
+    win_num=$(next_numeric_suffix '.windows' '@')
+    pane_num=$(next_numeric_suffix '.panes' '%')
+    window_id="@$win_num"
+    pane_id="%$pane_num"
+    window_index=$(($(max_window_index) + 1))
+    pane_index=0
+    pane_pid=$((10000 + pane_num))
+    tmp=$(mktemp -t fd-shim-new-window.XXXXXX)
+    jq \
+      --arg window_id "$window_id" \
+      --arg pane_id "$pane_id" \
+      --arg name "$name" \
+      --arg cwd "$cwd" \
+      --argjson window_index "$window_index" \
+      --argjson pane_index "$pane_index" \
+      --argjson pane_pid "$pane_pid" \
+      '.windows[$window_id] = {name: $name, index: $window_index}
+       | .panes[$pane_id] = {window_id: $window_id, window_name: $name, path: $cwd, window_index: $window_index, pane_index: $pane_index, pane_pid: $pane_pid, sent_keys: []}' \
+      "$STATE_FILE" > "$tmp"
+    mv "$tmp" "$STATE_FILE"
+    if (( print == 1 )); then
+      fmt="$format"
+      [[ -n "$fmt" ]] || fmt='#{pane_id}'
+      format_new_window "$fmt" "$pane_id" "$window_id" "$window_index" "$pane_index" "$cwd"
+    fi
+    ;;
+  send-keys)
+    target=""
+    keys=()
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        -t) target="$2"; shift 2 ;;
+        -l) shift ;;
+        *) keys+=("$1"); shift ;;
+      esac
+    done
+    if [[ -z "$target" ]]; then
+      target=$(jq -r '.panes | keys | last // empty' "$STATE_FILE")
+    fi
+    [[ -n "$target" ]] || exit 1
+    pane_id=$(resolve_pane_id "$target")
+    [[ -n "$pane_id" ]] || exit 1
+    payload="${keys[*]}"
+    tmp=$(mktemp -t fd-shim-send-keys.XXXXXX)
+    jq --arg pane_id "$pane_id" --arg payload "$payload" '.panes[$pane_id].sent_keys += [$payload]' "$STATE_FILE" > "$tmp"
+    mv "$tmp" "$STATE_FILE"
     ;;
   kill-window)
     target=""

--- a/skills/flightdeck/lib/flightdeck-core/tests/parity/tmux-shim/tmux
+++ b/skills/flightdeck/lib/flightdeck-core/tests/parity/tmux-shim/tmux
@@ -185,6 +185,10 @@ case "$subcmd" in
     jq -r '.windows | to_entries[] | .value.name' "$STATE_FILE"
     ;;
   new-window)
+    if [[ "${TMUX_SHIM_FAIL_NEW_WINDOW:-0}" == "1" ]]; then
+      echo "shim: new-window refused (TMUX_SHIM_FAIL_NEW_WINDOW=1)" >&2
+      exit 1
+    fi
     name=""
     cwd=""
     format=""

--- a/skills/flightdeck/scripts/flightdeck-daemon.bash
+++ b/skills/flightdeck/scripts/flightdeck-daemon.bash
@@ -1007,6 +1007,16 @@ clear_bell_for_window() {
 PANE_REGISTRY="$_daemon_script_dir/pane-registry"
 WAKE_EVENTS_LOG=$(oc_wake_events_log "$SESSION_KEY")
 
+pane_registry_find_id() {
+  local target="$1" raw
+  raw=$("$PANE_REGISTRY" find-by-pane "$target" 2>/dev/null || true)
+  if [[ "$raw" == \{* ]]; then
+    jq -r '.id // empty' <<< "$raw" 2>/dev/null || true
+  else
+    printf '%s' "$raw"
+  fi
+}
+
 oc_bell_marker_file() {
   local pane_id="$1"
   printf '%s/oc-bell-%s' "$STATE_DIR" "$(oc_pane_id_safe "$pane_id")"
@@ -1274,7 +1284,7 @@ spawn_cc_subscriber() {
 resolve_cc_meta() {
   local pane_target="$1"
   local issue
-  issue=$("$PANE_REGISTRY" find-by-pane "$pane_target" 2>/dev/null || echo "")
+  issue=$(pane_registry_find_id "$pane_target")
   [[ -z "$issue" ]] && return 1
   local args
   args=$("$PANE_REGISTRY" cc-channel-args "$issue" 2>/dev/null || echo "")
@@ -1472,7 +1482,7 @@ spawn_pi_subscriber() {
 resolve_pi_meta() {
   local pane_target="$1"
   local issue
-  issue=$("$PANE_REGISTRY" find-by-pane "$pane_target" 2>/dev/null || echo "")
+  issue=$(pane_registry_find_id "$pane_target")
   [[ -z "$issue" ]] && return 1
   local args
   args=$("$PANE_REGISTRY" pi-bridge-args "$issue" 2>/dev/null || echo "")
@@ -1572,7 +1582,7 @@ spawn_cx_subscriber() {
 resolve_cx_meta() {
   local pane_target="$1"
   local issue
-  issue=$("$PANE_REGISTRY" find-by-pane "$pane_target" 2>/dev/null || echo "")
+  issue=$(pane_registry_find_id "$pane_target")
   [[ -z "$issue" ]] && return 1
   local args
   args=$("$PANE_REGISTRY" cx-bridge-args "$issue" 2>/dev/null || echo "")
@@ -1687,7 +1697,7 @@ drain_oc_wake_events() {
 resolve_oc_meta() {
   local pane_target="$1"
   local issue
-  issue=$("$PANE_REGISTRY" find-by-pane "$pane_target" 2>/dev/null || echo "")
+  issue=$(pane_registry_find_id "$pane_target")
   [[ -z "$issue" ]] && return 1
   local args
   args=$("$PANE_REGISTRY" oc-attach-args "$issue" 2>/dev/null || echo "")

--- a/skills/flightdeck/scripts/flightdeck-session
+++ b/skills/flightdeck/scripts/flightdeck-session
@@ -54,30 +54,41 @@ capture_pane_meta() {
 
 pi_state_for_pid() {
   local pid="$1" bridge_bin state
-  bridge_bin=$(pi_resolve_bridge_bin 2>/dev/null) || return 1
+  bridge_bin=$(pi_resolve_bridge_bin 2>/dev/null) || { PI_DISCOVERY_ERROR="pi_bridge_not_found"; return 1; }
   state=$("$bridge_bin" state --pid "$pid" 2>/dev/null || true)
-  [[ -n "$state" ]] || return 1
+  [[ -n "$state" ]] || { PI_DISCOVERY_ERROR="pi_bridge_state_unavailable"; return 1; }
   PI_BRIDGE_PID="$pid"
   PI_BRIDGE_SOCKET=$(jq -r '.data.socketPath // .data.socket // ""' <<< "$state" 2>/dev/null || echo "")
   PI_SESSION_ID=$(jq -r '.data.sessionId // .data.session_id // ""' <<< "$state" 2>/dev/null || echo "")
+  if [[ -z "$PI_BRIDGE_SOCKET" || -z "$PI_SESSION_ID" ]]; then
+    PI_DISCOVERY_ERROR="pi_bridge_partial_metadata"
+  fi
   [[ -n "$PI_BRIDGE_SOCKET" || -n "$PI_SESSION_ID" ]]
 }
 
 pi_discover_after_launch() {
   local cwd="$1" pre_pids="$2" timeout_secs="${PI_BRIDGE_DISCOVERY_TIMEOUT:-30}" pid
-  PI_BRIDGE_PID=""; PI_BRIDGE_SOCKET=""; PI_SESSION_ID=""
+  PI_BRIDGE_PID=""; PI_BRIDGE_SOCKET=""; PI_SESSION_ID=""; PI_DISCOVERY_ERROR=""
+  if ! pi_resolve_bridge_bin >/dev/null 2>&1; then
+    PI_DISCOVERY_ERROR="pi_bridge_not_found"
+    return 1
+  fi
   if pid=$(pi_discover_pid "$cwd" "$timeout_secs" "$pre_pids" 2>/dev/null); then
-    pi_state_for_pid "$pid" || true
+    pi_state_for_pid "$pid" || return 1
+  else
+    PI_DISCOVERY_ERROR="pi_bridge_discovery_timeout"
+    return 1
   fi
 }
 
 pi_discover_for_pane() {
   local pane="$1" pane_pid bridge_bin out line
-  PI_BRIDGE_PID=""; PI_BRIDGE_SOCKET=""; PI_SESSION_ID=""
+  PI_BRIDGE_PID=""; PI_BRIDGE_SOCKET=""; PI_SESSION_ID=""; PI_DISCOVERY_ERROR=""
   pane_pid=$(tmux display-message -t "$pane" -p '#{pane_pid}' 2>/dev/null || true)
-  [[ -n "$pane_pid" ]] || return 1
-  bridge_bin=$(pi_resolve_bridge_bin 2>/dev/null) || return 1
+  [[ -n "$pane_pid" ]] || { PI_DISCOVERY_ERROR="pi_pane_pid_unavailable"; return 1; }
+  bridge_bin=$(pi_resolve_bridge_bin 2>/dev/null) || { PI_DISCOVERY_ERROR="pi_bridge_not_found"; return 1; }
   out=$("$bridge_bin" list --json --pid "$pane_pid" 2>/dev/null || "$bridge_bin" list --json 2>/dev/null || echo "[]")
+  [[ -n "${out//[[:space:]]/}" ]] || { PI_DISCOVERY_ERROR="pi_bridge_empty_output"; return 1; }
   line=$(jq -r --arg pid "$pane_pid" '
     (if type == "array" then . else (.data.instances // .instances // []) end)
     | map(select((.pid | tostring) == $pid))
@@ -88,7 +99,20 @@ pi_discover_for_pane() {
   PI_BRIDGE_PID=$(awk -F'\t' '{print $1}' <<< "$line")
   PI_BRIDGE_SOCKET=$(awk -F'\t' '{print $2}' <<< "$line")
   PI_SESSION_ID=$(awk -F'\t' '{print $3}' <<< "$line")
+  if [[ -z "$PI_BRIDGE_PID" && -z "$PI_BRIDGE_SOCKET" && -z "$PI_SESSION_ID" ]]; then
+    PI_DISCOVERY_ERROR="pi_bridge_no_instance_for_pane_pid"
+    return 1
+  fi
+  if [[ -z "$PI_BRIDGE_SOCKET" || -z "$PI_SESSION_ID" ]]; then
+    PI_DISCOVERY_ERROR="pi_bridge_partial_metadata"
+  fi
   [[ -n "$PI_BRIDGE_PID" || -n "$PI_BRIDGE_SOCKET" || -n "$PI_SESSION_ID" ]]
+}
+
+warn_pi_discovery_error() {
+  local context="$1"
+  [[ -n "${PI_DISCOVERY_ERROR:-}" ]] || return 0
+  printf 'Warning: pi-bridge metadata discovery failed during %s (%s); registering degraded entry.\n' "$context" "$PI_DISCOVERY_ERROR" >&2
 }
 
 build_pi_prompt_cmd() {
@@ -108,6 +132,7 @@ register_entry() {
   [[ -n "${PI_BRIDGE_PID:-}" ]] && args+=(--pi-bridge-pid "$PI_BRIDGE_PID")
   [[ -n "${PI_BRIDGE_SOCKET:-}" ]] && args+=(--pi-bridge-socket "$PI_BRIDGE_SOCKET")
   [[ -n "${PI_SESSION_ID:-}" ]] && args+=(--pi-session-id "$PI_SESSION_ID")
+  [[ -n "${PI_DISCOVERY_ERROR:-}" ]] && args+=(--discovery-error "$PI_DISCOVERY_ERROR")
   "$PANE_REGISTRY" "${args[@]}"
 }
 
@@ -158,7 +183,10 @@ cmd_start() {
   fi
 
   local pane_id
-  pane_id=$(tmux new-window -d -P -F '#{pane_id}' -n "$title" -c "$abs_cwd" 2>/dev/null)
+  if ! pane_id=$(tmux new-window -d -P -F '#{pane_id}' -n "$title" -c "$abs_cwd" 2>/dev/null); then
+    echo "Error: tmux new-window failed" >&2
+    exit 2
+  fi
   [[ -n "$pane_id" ]] || { echo "Error: tmux new-window failed" >&2; exit 2; }
   capture_pane_meta "$pane_id"
   tmux send-keys -t "$pane_id" "clear" Enter
@@ -167,8 +195,9 @@ cmd_start() {
 
   if [[ -n "$prompt" && "$harness" == "pi" ]]; then
     pi_discover_after_launch "$abs_cwd" "$pre_pids" || true
+    warn_pi_discovery_error "start"
   else
-    PI_BRIDGE_PID=""; PI_BRIDGE_SOCKET=""; PI_SESSION_ID=""
+    PI_BRIDGE_PID=""; PI_BRIDGE_SOCKET=""; PI_SESSION_ID=""; PI_DISCOVERY_ERROR=""
   fi
 
   [[ -n "$worktree" ]] || [[ "$kind" != "issue" ]] || worktree="$abs_cwd"
@@ -201,8 +230,9 @@ cmd_attach() {
   capture_pane_meta "$pane"
   if [[ "$harness" == "pi" ]]; then
     pi_discover_for_pane "$CAPTURE_PANE_ID" || true
+    warn_pi_discovery_error "attach"
   else
-    PI_BRIDGE_PID=""; PI_BRIDGE_SOCKET=""; PI_SESSION_ID=""
+    PI_BRIDGE_PID=""; PI_BRIDGE_SOCKET=""; PI_SESSION_ID=""; PI_DISCOVERY_ERROR=""
   fi
   if [[ -z "$session_id" ]]; then
     if [[ -n "${PI_SESSION_ID:-}" ]]; then

--- a/skills/flightdeck/scripts/flightdeck-session
+++ b/skills/flightdeck/scripts/flightdeck-session
@@ -15,7 +15,7 @@ source "$SCRIPT_DIR/lib/pi-bridge-paths.sh"
 usage() {
   cat >&2 <<'USAGE'
 Usage:
-  flightdeck-session start --session-id <ID> --title <T> --cwd <path> --harness <H> (--cmd <cmd> | --prompt <text>) [--kind adhoc|workflow|issue]
+  flightdeck-session start --session-id <ID> --title <T> --cwd <path> --harness <H> (--cmd <cmd> | --prompt <text>) [--kind adhoc|workflow|issue] [--strict-discovery]
   flightdeck-session attach --pane <%PANE_ID> --harness pi --title <T> [--session-id <ID>] [--kind adhoc|workflow]
 USAGE
   exit 2
@@ -30,6 +30,35 @@ shell_join() {
     if [[ -z "$out" ]]; then out="$quoted"; else out+=" $quoted"; fi
   done
   printf '%s\n' "$out"
+}
+
+set_pi_discovery_error() {
+  local reason="$1" mode="${2:-preserve}"
+  if [[ "$mode" == "force" || -z "${PI_DISCOVERY_ERROR:-}" ]]; then
+    PI_DISCOVERY_ERROR="$reason"
+  fi
+}
+
+pi_bridge_call_timeout_secs() {
+  printf '%s' "${PI_BRIDGE_CALL_TIMEOUT_SEC:-5}"
+}
+
+pi_bridge_call() {
+  local timeout_secs out status
+  PI_BRIDGE_CALL_OUTPUT=""
+  timeout_secs="$(pi_bridge_call_timeout_secs)"
+  set +e
+  out=$(timeout --kill-after=1 "${timeout_secs}s" "$@" 2>/dev/null)
+  status=$?
+  set -e
+  if (( status == 124 || status == 137 )); then
+    set_pi_discovery_error "pi_bridge_timeout" force
+    return 124
+  fi
+  if (( status != 0 )); then
+    return "$status"
+  fi
+  PI_BRIDGE_CALL_OUTPUT="$out"
 }
 
 require_tmux() {
@@ -54,29 +83,103 @@ capture_pane_meta() {
 
 pi_state_for_pid() {
   local pid="$1" bridge_bin state
-  bridge_bin=$(pi_resolve_bridge_bin 2>/dev/null) || { PI_DISCOVERY_ERROR="pi_bridge_not_found"; return 1; }
-  state=$("$bridge_bin" state --pid "$pid" 2>/dev/null || true)
-  [[ -n "$state" ]] || { PI_DISCOVERY_ERROR="pi_bridge_state_unavailable"; return 1; }
+  bridge_bin=$(pi_resolve_bridge_bin 2>/dev/null) || { set_pi_discovery_error "pi_bridge_not_found"; return 1; }
+  if ! pi_bridge_call "$bridge_bin" state --pid "$pid"; then
+    [[ "${PI_DISCOVERY_ERROR:-}" == "pi_bridge_timeout" ]] || set_pi_discovery_error "pi_bridge_state_unavailable"
+    return 1
+  fi
+  state="$PI_BRIDGE_CALL_OUTPUT"
+  [[ -n "$state" ]] || { set_pi_discovery_error "pi_bridge_state_unavailable"; return 1; }
   PI_BRIDGE_PID="$pid"
   PI_BRIDGE_SOCKET=$(jq -r '.data.socketPath // .data.socket // ""' <<< "$state" 2>/dev/null || echo "")
   PI_SESSION_ID=$(jq -r '.data.sessionId // .data.session_id // ""' <<< "$state" 2>/dev/null || echo "")
   if [[ -z "$PI_BRIDGE_SOCKET" || -z "$PI_SESSION_ID" ]]; then
-    PI_DISCOVERY_ERROR="pi_bridge_partial_metadata"
+    set_pi_discovery_error "pi_bridge_partial_metadata"
   fi
   [[ -n "$PI_BRIDGE_SOCKET" || -n "$PI_SESSION_ID" ]]
 }
 
-pi_discover_after_launch() {
-  local cwd="$1" pre_pids="$2" timeout_secs="${PI_BRIDGE_DISCOVERY_TIMEOUT:-30}" pid
-  PI_BRIDGE_PID=""; PI_BRIDGE_SOCKET=""; PI_SESSION_ID=""; PI_DISCOVERY_ERROR=""
-  if ! pi_resolve_bridge_bin >/dev/null 2>&1; then
-    PI_DISCOVERY_ERROR="pi_bridge_not_found"
+pi_snapshot_pids_checked() {
+  local bridge_bin out pids jq_status
+  PI_SNAPSHOT_PIDS="[]"
+  bridge_bin=$(pi_resolve_bridge_bin 2>/dev/null) || {
+    set_pi_discovery_error "pi_snapshot_failed" force
+    PI_SNAPSHOT_ERROR="pi_bridge_not_found"
+    return 1
+  }
+  if ! pi_bridge_call "$bridge_bin" list --json; then
+    PI_SNAPSHOT_ERROR="${PI_DISCOVERY_ERROR:-pi_bridge_list_failed}"
+    set_pi_discovery_error "pi_snapshot_failed" force
     return 1
   fi
-  if pid=$(pi_discover_pid "$cwd" "$timeout_secs" "$pre_pids" 2>/dev/null); then
+  out="$PI_BRIDGE_CALL_OUTPUT"
+  set +e
+  pids=$(jq -c 'if type == "array" then map(.pid) | map(select(. != null)) else error("not array") end' <<< "$out" 2>/dev/null)
+  jq_status=$?
+  set -e
+  if (( jq_status != 0 )); then
+    PI_SNAPSHOT_ERROR="pi_bridge_malformed_json"
+    set_pi_discovery_error "pi_snapshot_failed" force
+    return 1
+  fi
+  PI_SNAPSHOT_PIDS="$pids"
+}
+
+warn_pi_snapshot_failure() {
+  local reason="${PI_SNAPSHOT_ERROR:-unknown}"
+  printf 'Warning: pre-launch pi snapshot failed (%s); cwd-only discovery is unreliable.\n' "$reason" >&2
+}
+
+pi_discover_pid_bounded() {
+  local wt_path="$1" timeout_secs="${2:-30}" pre_pids_json="${3:-[]}" bridge_bin abs_wt deadline out pid jq_status
+  PI_DISCOVERED_PID=""
+  bridge_bin=$(pi_resolve_bridge_bin 2>/dev/null) || { set_pi_discovery_error "pi_bridge_not_found"; return 1; }
+  abs_wt=$(cd "$wt_path" && pwd)
+  deadline=$((SECONDS + timeout_secs))
+  while (( SECONDS < deadline )); do
+    if ! pi_bridge_call "$bridge_bin" list --json; then
+      [[ "${PI_DISCOVERY_ERROR:-}" == "pi_bridge_timeout" ]] || set_pi_discovery_error "pi_bridge_list_failed"
+      return 1
+    fi
+    out="$PI_BRIDGE_CALL_OUTPUT"
+    set +e
+    pid=$(jq -r --arg dir "$abs_wt" --argjson pre "$pre_pids_json" '
+      (if type == "array" then . else [] end)
+      | map(select((.cwd // "") == $dir))
+      | map(select(.pid as $p | ($pre // []) | index($p) | not))
+      | sort_by(.startedAt // .started_at // 0)
+      | last
+      | (.pid // empty)
+    ' <<< "$out" 2>/dev/null)
+    jq_status=$?
+    set -e
+    if (( jq_status != 0 )); then
+      set_pi_discovery_error "pi_bridge_malformed_json"
+      return 1
+    fi
+    if [[ -n "$pid" && "$pid" != "null" ]]; then
+      PI_DISCOVERED_PID="$pid"
+      return 0
+    fi
+    sleep 0.2
+  done
+  set_pi_discovery_error "pi_bridge_discovery_timeout"
+  return 1
+}
+
+pi_discover_after_launch() {
+  local cwd="$1" pre_pids="$2" timeout_secs="${PI_BRIDGE_DISCOVERY_TIMEOUT:-30}" pid existing_error
+  existing_error="${PI_DISCOVERY_ERROR:-}"
+  PI_BRIDGE_PID=""; PI_BRIDGE_SOCKET=""; PI_SESSION_ID=""; PI_DISCOVERY_ERROR="$existing_error"
+  if ! pi_resolve_bridge_bin >/dev/null 2>&1; then
+    set_pi_discovery_error "pi_bridge_not_found"
+    return 1
+  fi
+  if pi_discover_pid_bounded "$cwd" "$timeout_secs" "$pre_pids"; then
+    pid="$PI_DISCOVERED_PID"
     pi_state_for_pid "$pid" || return 1
   else
-    PI_DISCOVERY_ERROR="pi_bridge_discovery_timeout"
+    set_pi_discovery_error "pi_bridge_discovery_timeout"
     return 1
   fi
 }
@@ -85,10 +188,19 @@ pi_discover_for_pane() {
   local pane="$1" pane_pid bridge_bin out line
   PI_BRIDGE_PID=""; PI_BRIDGE_SOCKET=""; PI_SESSION_ID=""; PI_DISCOVERY_ERROR=""
   pane_pid=$(tmux display-message -t "$pane" -p '#{pane_pid}' 2>/dev/null || true)
-  [[ -n "$pane_pid" ]] || { PI_DISCOVERY_ERROR="pi_pane_pid_unavailable"; return 1; }
-  bridge_bin=$(pi_resolve_bridge_bin 2>/dev/null) || { PI_DISCOVERY_ERROR="pi_bridge_not_found"; return 1; }
-  out=$("$bridge_bin" list --json --pid "$pane_pid" 2>/dev/null || "$bridge_bin" list --json 2>/dev/null || echo "[]")
-  [[ -n "${out//[[:space:]]/}" ]] || { PI_DISCOVERY_ERROR="pi_bridge_empty_output"; return 1; }
+  [[ -n "$pane_pid" ]] || { set_pi_discovery_error "pi_pane_pid_unavailable"; return 1; }
+  bridge_bin=$(pi_resolve_bridge_bin 2>/dev/null) || { set_pi_discovery_error "pi_bridge_not_found"; return 1; }
+  if ! pi_bridge_call "$bridge_bin" list --json --pid "$pane_pid"; then
+    if [[ "${PI_DISCOVERY_ERROR:-}" == "pi_bridge_timeout" ]]; then
+      return 1
+    fi
+    if ! pi_bridge_call "$bridge_bin" list --json; then
+      [[ "${PI_DISCOVERY_ERROR:-}" == "pi_bridge_timeout" ]] || set_pi_discovery_error "pi_bridge_list_failed"
+      return 1
+    fi
+  fi
+  out="$PI_BRIDGE_CALL_OUTPUT"
+  [[ -n "${out//[[:space:]]/}" ]] || { set_pi_discovery_error "pi_bridge_empty_output"; return 1; }
   line=$(jq -r --arg pid "$pane_pid" '
     (if type == "array" then . else (.data.instances // .instances // []) end)
     | map(select((.pid | tostring) == $pid))
@@ -100,11 +212,11 @@ pi_discover_for_pane() {
   PI_BRIDGE_SOCKET=$(awk -F'\t' '{print $2}' <<< "$line")
   PI_SESSION_ID=$(awk -F'\t' '{print $3}' <<< "$line")
   if [[ -z "$PI_BRIDGE_PID" && -z "$PI_BRIDGE_SOCKET" && -z "$PI_SESSION_ID" ]]; then
-    PI_DISCOVERY_ERROR="pi_bridge_no_instance_for_pane_pid"
+    set_pi_discovery_error "pi_bridge_no_instance_for_pane_pid"
     return 1
   fi
   if [[ -z "$PI_BRIDGE_SOCKET" || -z "$PI_SESSION_ID" ]]; then
-    PI_DISCOVERY_ERROR="pi_bridge_partial_metadata"
+    set_pi_discovery_error "pi_bridge_partial_metadata"
   fi
   [[ -n "$PI_BRIDGE_PID" || -n "$PI_BRIDGE_SOCKET" || -n "$PI_SESSION_ID" ]]
 }
@@ -138,7 +250,7 @@ register_entry() {
 
 cmd_start() {
   require_tmux
-  local session_id="" title="" cwd="" harness="" cmd="" prompt="" kind="adhoc" worktree="" pr=""
+  local session_id="" title="" cwd="" harness="" cmd="" prompt="" kind="adhoc" worktree="" pr="" strict_discovery=0
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --session-id) session_id="$2"; shift 2 ;;
@@ -159,6 +271,7 @@ cmd_start() {
       --worktree=*) worktree="${1#--worktree=}"; shift ;;
       --pr) pr="$2"; shift 2 ;;
       --pr=*) pr="${1#--pr=}"; shift ;;
+      --strict-discovery) strict_discovery=1; shift ;;
       --help|-h) usage ;;
       *) echo "Unknown flag: $1" >&2; usage ;;
     esac
@@ -169,11 +282,21 @@ cmd_start() {
   [[ -z "$cmd" || -z "$prompt" ]] || { echo "Error: --cmd and --prompt are mutually exclusive" >&2; exit 2; }
 
   local abs_cwd launch_cmd pre_pids="[]"
+  PI_DISCOVERY_ERROR=""
+  PI_SNAPSHOT_ERROR=""
+  PI_SNAPSHOT_PIDS="[]"
   abs_cwd=$(cd "$cwd" && pwd)
   if [[ -n "$prompt" ]]; then
     case "$harness" in
       pi)
-        pre_pids=$(pi_snapshot_pids 2>/dev/null || echo "[]")
+        if ! pi_snapshot_pids_checked; then
+          warn_pi_snapshot_failure
+          if (( strict_discovery == 1 )); then
+            echo "Error: --strict-discovery refusing Pi launch after pre-launch snapshot failure" >&2
+            exit 2
+          fi
+        fi
+        pre_pids="$PI_SNAPSHOT_PIDS"
         launch_cmd=$(build_pi_prompt_cmd "$prompt")
         ;;
       *) echo "Error: --prompt launch currently supports --harness pi; use --cmd for $harness" >&2; exit 2 ;;

--- a/skills/flightdeck/scripts/flightdeck-session
+++ b/skills/flightdeck/scripts/flightdeck-session
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+# First-class Flightdeck session launcher/attacher for non-issue panes.
+# Uses tmux windows only (never split panes) and records TrackedEntry rows
+# through pane-registry init-entry.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PANE_REGISTRY="$SCRIPT_DIR/pane-registry"
+
+# shellcheck source=lib/pane-env.sh
+source "$SCRIPT_DIR/lib/pane-env.sh"
+# shellcheck source=lib/pi-bridge-paths.sh
+source "$SCRIPT_DIR/lib/pi-bridge-paths.sh"
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage:
+  flightdeck-session start --session-id <ID> --title <T> --cwd <path> --harness <H> (--cmd <cmd> | --prompt <text>) [--kind adhoc|workflow|issue]
+  flightdeck-session attach --pane <%PANE_ID> --harness pi --title <T> [--session-id <ID>] [--kind adhoc|workflow]
+USAGE
+  exit 2
+}
+
+now() { date -u +"%Y-%m-%dT%H:%M:%SZ"; }
+
+shell_join() {
+  local out="" arg quoted
+  for arg in "$@"; do
+    printf -v quoted '%q' "$arg"
+    if [[ -z "$out" ]]; then out="$quoted"; else out+=" $quoted"; fi
+  done
+  printf '%s\n' "$out"
+}
+
+require_tmux() {
+  [[ -n "${TMUX:-}" ]] || { echo "Error: flightdeck-session requires an active tmux session" >&2; exit 2; }
+}
+
+valid_kind() {
+  case "$1" in adhoc|workflow|issue) return 0 ;; *) return 1 ;; esac
+}
+
+capture_pane_meta() {
+  local target="$1"
+  CAPTURE_PANE_ID=$(tmux display-message -t "$target" -p '#{pane_id}' 2>/dev/null || true)
+  [[ -n "$CAPTURE_PANE_ID" ]] || { echo "Error: unable to resolve pane id for $target" >&2; exit 2; }
+  CAPTURE_WINDOW_ID=$(tmux display-message -t "$CAPTURE_PANE_ID" -p '#{window_id}' 2>/dev/null || true)
+  CAPTURE_WINDOW_INDEX=$(tmux display-message -t "$CAPTURE_PANE_ID" -p '#{window_index}' 2>/dev/null || true)
+  CAPTURE_PANE_INDEX=$(tmux display-message -t "$CAPTURE_PANE_ID" -p '#{pane_index}' 2>/dev/null || true)
+  CAPTURE_PANE_CWD=$(tmux display-message -t "$CAPTURE_PANE_ID" -p '#{pane_current_path}' 2>/dev/null || true)
+  CAPTURE_SESSION=$(tmux display-message -p '#S' 2>/dev/null || echo unknown)
+  CAPTURE_PANE_TARGET="${CAPTURE_SESSION}:${CAPTURE_WINDOW_INDEX}.${CAPTURE_PANE_INDEX}"
+}
+
+pi_state_for_pid() {
+  local pid="$1" bridge_bin state
+  bridge_bin=$(pi_resolve_bridge_bin 2>/dev/null) || return 1
+  state=$("$bridge_bin" state --pid "$pid" 2>/dev/null || true)
+  [[ -n "$state" ]] || return 1
+  PI_BRIDGE_PID="$pid"
+  PI_BRIDGE_SOCKET=$(jq -r '.data.socketPath // .data.socket // ""' <<< "$state" 2>/dev/null || echo "")
+  PI_SESSION_ID=$(jq -r '.data.sessionId // .data.session_id // ""' <<< "$state" 2>/dev/null || echo "")
+  [[ -n "$PI_BRIDGE_SOCKET" || -n "$PI_SESSION_ID" ]]
+}
+
+pi_discover_after_launch() {
+  local cwd="$1" pre_pids="$2" timeout_secs="${PI_BRIDGE_DISCOVERY_TIMEOUT:-30}" pid
+  PI_BRIDGE_PID=""; PI_BRIDGE_SOCKET=""; PI_SESSION_ID=""
+  if pid=$(pi_discover_pid "$cwd" "$timeout_secs" "$pre_pids" 2>/dev/null); then
+    pi_state_for_pid "$pid" || true
+  fi
+}
+
+pi_discover_for_pane() {
+  local pane="$1" pane_pid bridge_bin out line
+  PI_BRIDGE_PID=""; PI_BRIDGE_SOCKET=""; PI_SESSION_ID=""
+  pane_pid=$(tmux display-message -t "$pane" -p '#{pane_pid}' 2>/dev/null || true)
+  [[ -n "$pane_pid" ]] || return 1
+  bridge_bin=$(pi_resolve_bridge_bin 2>/dev/null) || return 1
+  out=$("$bridge_bin" list --json --pid "$pane_pid" 2>/dev/null || "$bridge_bin" list --json 2>/dev/null || echo "[]")
+  line=$(jq -r --arg pid "$pane_pid" '
+    (if type == "array" then . else (.data.instances // .instances // []) end)
+    | map(select((.pid | tostring) == $pid))
+    | .[0] // {}
+    | [(.pid // ""), (.socketPath // .socket // ""), (.sessionId // .session_id // "")]
+    | @tsv
+  ' <<< "$out" 2>/dev/null || echo "")
+  PI_BRIDGE_PID=$(awk -F'\t' '{print $1}' <<< "$line")
+  PI_BRIDGE_SOCKET=$(awk -F'\t' '{print $2}' <<< "$line")
+  PI_SESSION_ID=$(awk -F'\t' '{print $3}' <<< "$line")
+  [[ -n "$PI_BRIDGE_PID" || -n "$PI_BRIDGE_SOCKET" || -n "$PI_SESSION_ID" ]]
+}
+
+build_pi_prompt_cmd() {
+  local prompt="$1" pi_bin ext_path bridge_args=()
+  pi_bin=$(pi_resolve_pi_bin) || { echo "Error: pi binary not found" >&2; exit 2; }
+  ext_path=$(pi_resolve_bridge_extension 2>/dev/null || echo "")
+  [[ -n "$ext_path" ]] && bridge_args=(-e "$ext_path")
+  shell_join "${FLIGHTDECK_CHILD_PANE_ENV[@]}" "$pi_bin" "${bridge_args[@]}" "$prompt"
+}
+
+register_entry() {
+  local entry_id="$1" title="$2" kind="$3" cwd="$4" window_index="$5" harness="$6" pane_id="$7" pane_target="$8" window_id="$9" launch_cmd="${10}" worktree="${11:-}" pr="${12:-}"
+  local args=(init-entry "$entry_id" --title "$title" --kind "$kind" --cwd "$cwd" --window "$window_index" --harness "$harness" --pane-id "$pane_id" --pane-target "$pane_target" --window-id "$window_id" --window-index "$window_index")
+  [[ -n "$worktree" ]] && args+=(--worktree "$worktree")
+  [[ -n "$pr" ]] && args+=(--pr "$pr")
+  [[ -n "$launch_cmd" ]] && args+=(--launch-cmd "$launch_cmd")
+  [[ -n "${PI_BRIDGE_PID:-}" ]] && args+=(--pi-bridge-pid "$PI_BRIDGE_PID")
+  [[ -n "${PI_BRIDGE_SOCKET:-}" ]] && args+=(--pi-bridge-socket "$PI_BRIDGE_SOCKET")
+  [[ -n "${PI_SESSION_ID:-}" ]] && args+=(--pi-session-id "$PI_SESSION_ID")
+  "$PANE_REGISTRY" "${args[@]}"
+}
+
+cmd_start() {
+  require_tmux
+  local session_id="" title="" cwd="" harness="" cmd="" prompt="" kind="adhoc" worktree="" pr=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --session-id) session_id="$2"; shift 2 ;;
+      --session-id=*) session_id="${1#--session-id=}"; shift ;;
+      --title) title="$2"; shift 2 ;;
+      --title=*) title="${1#--title=}"; shift ;;
+      --cwd) cwd="$2"; shift 2 ;;
+      --cwd=*) cwd="${1#--cwd=}"; shift ;;
+      --harness) harness="$2"; shift 2 ;;
+      --harness=*) harness="${1#--harness=}"; shift ;;
+      --cmd) cmd="$2"; shift 2 ;;
+      --cmd=*) cmd="${1#--cmd=}"; shift ;;
+      --prompt) prompt="$2"; shift 2 ;;
+      --prompt=*) prompt="${1#--prompt=}"; shift ;;
+      --kind) kind="$2"; shift 2 ;;
+      --kind=*) kind="${1#--kind=}"; shift ;;
+      --worktree) worktree="$2"; shift 2 ;;
+      --worktree=*) worktree="${1#--worktree=}"; shift ;;
+      --pr) pr="$2"; shift 2 ;;
+      --pr=*) pr="${1#--pr=}"; shift ;;
+      --help|-h) usage ;;
+      *) echo "Unknown flag: $1" >&2; usage ;;
+    esac
+  done
+  [[ -n "$session_id" && -n "$title" && -n "$cwd" && -n "$harness" ]] || usage
+  valid_kind "$kind" || { echo "Error: invalid --kind: $kind" >&2; exit 2; }
+  [[ -n "$cmd" || -n "$prompt" ]] || { echo "Error: start requires --cmd or --prompt" >&2; exit 2; }
+  [[ -z "$cmd" || -z "$prompt" ]] || { echo "Error: --cmd and --prompt are mutually exclusive" >&2; exit 2; }
+
+  local abs_cwd launch_cmd pre_pids="[]"
+  abs_cwd=$(cd "$cwd" && pwd)
+  if [[ -n "$prompt" ]]; then
+    case "$harness" in
+      pi)
+        pre_pids=$(pi_snapshot_pids 2>/dev/null || echo "[]")
+        launch_cmd=$(build_pi_prompt_cmd "$prompt")
+        ;;
+      *) echo "Error: --prompt launch currently supports --harness pi; use --cmd for $harness" >&2; exit 2 ;;
+    esac
+  else
+    launch_cmd="$(flightdeck_child_pane_env_str) $cmd"
+  fi
+
+  local pane_id
+  pane_id=$(tmux new-window -d -P -F '#{pane_id}' -n "$title" -c "$abs_cwd" 2>/dev/null)
+  [[ -n "$pane_id" ]] || { echo "Error: tmux new-window failed" >&2; exit 2; }
+  capture_pane_meta "$pane_id"
+  tmux send-keys -t "$pane_id" "clear" Enter
+  tmux send-keys -t "$pane_id" -l "$launch_cmd"
+  tmux send-keys -t "$pane_id" Enter
+
+  if [[ -n "$prompt" && "$harness" == "pi" ]]; then
+    pi_discover_after_launch "$abs_cwd" "$pre_pids" || true
+  else
+    PI_BRIDGE_PID=""; PI_BRIDGE_SOCKET=""; PI_SESSION_ID=""
+  fi
+
+  [[ -n "$worktree" ]] || [[ "$kind" != "issue" ]] || worktree="$abs_cwd"
+  register_entry "$session_id" "$title" "$kind" "${CAPTURE_PANE_CWD:-$abs_cwd}" "$CAPTURE_WINDOW_INDEX" "$harness" "$CAPTURE_PANE_ID" "$CAPTURE_PANE_TARGET" "$CAPTURE_WINDOW_ID" "$launch_cmd" "$worktree" "$pr"
+  printf 'flightdeck-session: started %s kind=%s pane_id=%s target=%s\n' "$session_id" "$kind" "$CAPTURE_PANE_ID" "$CAPTURE_PANE_TARGET"
+}
+
+cmd_attach() {
+  require_tmux
+  local pane="" harness="" title="" kind="adhoc" session_id=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --pane) pane="$2"; shift 2 ;;
+      --pane=*) pane="${1#--pane=}"; shift ;;
+      --harness) harness="$2"; shift 2 ;;
+      --harness=*) harness="${1#--harness=}"; shift ;;
+      --title) title="$2"; shift 2 ;;
+      --title=*) title="${1#--title=}"; shift ;;
+      --kind) kind="$2"; shift 2 ;;
+      --kind=*) kind="${1#--kind=}"; shift ;;
+      --session-id) session_id="$2"; shift 2 ;;
+      --session-id=*) session_id="${1#--session-id=}"; shift ;;
+      --help|-h) usage ;;
+      *) echo "Unknown flag: $1" >&2; usage ;;
+    esac
+  done
+  [[ -n "$pane" && -n "$harness" && -n "$title" ]] || usage
+  valid_kind "$kind" || { echo "Error: invalid --kind: $kind" >&2; exit 2; }
+  tmux list-panes -t "$pane" >/dev/null 2>&1 || { echo "Error: pane not found: $pane" >&2; exit 1; }
+  capture_pane_meta "$pane"
+  if [[ "$harness" == "pi" ]]; then
+    pi_discover_for_pane "$CAPTURE_PANE_ID" || true
+  else
+    PI_BRIDGE_PID=""; PI_BRIDGE_SOCKET=""; PI_SESSION_ID=""
+  fi
+  if [[ -z "$session_id" ]]; then
+    if [[ -n "${PI_SESSION_ID:-}" ]]; then
+      session_id="$PI_SESSION_ID"
+    else
+      session_id="pane-${CAPTURE_PANE_ID#%}"
+    fi
+  fi
+  register_entry "$session_id" "$title" "$kind" "$CAPTURE_PANE_CWD" "$CAPTURE_WINDOW_INDEX" "$harness" "$CAPTURE_PANE_ID" "$CAPTURE_PANE_TARGET" "$CAPTURE_WINDOW_ID" "" "" ""
+  printf 'flightdeck-session: attached %s kind=%s pane_id=%s target=%s\n' "$session_id" "$kind" "$CAPTURE_PANE_ID" "$CAPTURE_PANE_TARGET"
+}
+
+ACTION="${1:-start}"
+case "$ACTION" in
+  start) shift || true; cmd_start "$@" ;;
+  attach) shift || true; cmd_attach "$@" ;;
+  --help|-h|help) usage ;;
+  *) cmd_start "$@" ;;
+esac

--- a/skills/flightdeck/scripts/lib/pane-env.sh
+++ b/skills/flightdeck/scripts/lib/pane-env.sh
@@ -9,17 +9,30 @@ FLIGHTDECK_PANE_ENV=(env FLIGHTDECK_MANAGED=1)
 FLIGHTDECK_PI_PANE_ENV=(env FLIGHTDECK_MANAGED=1 FLIGHTDECK_CHILD_PANE=1)
 FLIGHTDECK_CHILD_PANE_ENV=(env FLIGHTDECK_MANAGED=1 FLIGHTDECK_CHILD_PANE=1)
 
+flightdeck_shell_join() {
+  local out="" arg quoted
+  for arg in "$@"; do
+    printf -v quoted '%q' "$arg"
+    if [[ -z "$out" ]]; then
+      out="$quoted"
+    else
+      out+=" $quoted"
+    fi
+  done
+  printf '%s' "$out"
+}
+
 flightdeck_pane_env_str() {
-  # Space-joined string form of FLIGHTDECK_PANE_ENV, suitable for
+  # Shell-escaped string form of FLIGHTDECK_PANE_ENV, suitable for
   # prefixing tmux send-keys / printf command lines.
-  printf '%s' "${FLIGHTDECK_PANE_ENV[*]}"
+  flightdeck_shell_join "${FLIGHTDECK_PANE_ENV[@]}"
 }
 
 flightdeck_child_pane_env_str() {
   # Generic child-pane prefix for first-class Flightdeck sessions.
-  printf '%s' "${FLIGHTDECK_CHILD_PANE_ENV[*]}"
+  flightdeck_shell_join "${FLIGHTDECK_CHILD_PANE_ENV[@]}"
 }
 
 flightdeck_pi_pane_env_str() {
-  printf '%s' "${FLIGHTDECK_PI_PANE_ENV[*]}"
+  flightdeck_shell_join "${FLIGHTDECK_PI_PANE_ENV[@]}"
 }

--- a/skills/flightdeck/scripts/lib/pane-env.sh
+++ b/skills/flightdeck/scripts/lib/pane-env.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Shared environment prefixes for panes launched by Flightdeck.
+# Source from launchers; do not execute directly.
+
+# Canonical cross-harness managed-mode signal. The Pi variant retains the
+# legacy child-pane signal consumed by pi-flightdeck to suppress owner UI in
+# child sessions.
+FLIGHTDECK_PANE_ENV=(env FLIGHTDECK_MANAGED=1)
+FLIGHTDECK_PI_PANE_ENV=(env FLIGHTDECK_MANAGED=1 FLIGHTDECK_CHILD_PANE=1)
+FLIGHTDECK_CHILD_PANE_ENV=(env FLIGHTDECK_MANAGED=1 FLIGHTDECK_CHILD_PANE=1)
+
+flightdeck_pane_env_str() {
+  # Space-joined string form of FLIGHTDECK_PANE_ENV, suitable for
+  # prefixing tmux send-keys / printf command lines.
+  printf '%s' "${FLIGHTDECK_PANE_ENV[*]}"
+}
+
+flightdeck_child_pane_env_str() {
+  # Generic child-pane prefix for first-class Flightdeck sessions.
+  printf '%s' "${FLIGHTDECK_CHILD_PANE_ENV[*]}"
+}
+
+flightdeck_pi_pane_env_str() {
+  printf '%s' "${FLIGHTDECK_PI_PANE_ENV[*]}"
+}

--- a/skills/flightdeck/scripts/open-terminal
+++ b/skills/flightdeck/scripts/open-terminal
@@ -39,6 +39,8 @@ source "$SCRIPT_DIR/lib/cc-channel-paths.sh"
 source "$SCRIPT_DIR/lib/pi-bridge-paths.sh"
 # shellcheck source=lib/codex-paths.sh
 source "$SCRIPT_DIR/lib/codex-paths.sh"
+# shellcheck source=lib/pane-env.sh
+source "$SCRIPT_DIR/lib/pane-env.sh"
 
 # Resolve project root (works in worktrees and main repos)
 PROJECT_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null)"
@@ -299,23 +301,9 @@ launch_metadata_json_args() {
   jq -nc --arg model "$model" --arg effort "$effort" '{model:$model, effort:$effort}'
 }
 
-# Env-prefix tokens that mark every flightdeck-spawned pane as managed.
-# `FLIGHTDECK_MANAGED=1` is the canonical cross-harness signal consumed
-# by orchestration's `flightdeck-mode` helper to scope destructive
-# cleanup. Expand with "${FLIGHTDECK_PANE_ENV[@]}" inside `cmd=(...)`
-# arrays, or call `flightdeck_pane_env_str` for the printf / send-keys
-# path. The Pi variant additionally sets `FLIGHTDECK_CHILD_PANE=1` for
-# backwards compatibility with the pi-flightdeck dashboard extension's
-# child-pane widget suppression (issue #8).
-FLIGHTDECK_PANE_ENV=(env FLIGHTDECK_MANAGED=1)
-FLIGHTDECK_PI_PANE_ENV=(env FLIGHTDECK_MANAGED=1 FLIGHTDECK_CHILD_PANE=1)
-
-flightdeck_pane_env_str() {
-  # Space-joined string form of FLIGHTDECK_PANE_ENV, suitable for
-  # prefixing tmux send-keys / printf command lines.
-  printf '%s' "${FLIGHTDECK_PANE_ENV[*]}"
-}
-
+# Env-prefix tokens that mark every flightdeck-spawned pane as managed live
+# in lib/pane-env.sh. Use "${FLIGHTDECK_PANE_ENV[@]}" inside arrays or
+# `flightdeck_pane_env_str` for string-form tmux send-keys paths.
 detect_start_cmd() {
   local issue="$1"
   if [[ -n "$CMD_TEMPLATE" ]]; then
@@ -1034,6 +1022,21 @@ open_tmux() {
   if [[ -z "${TMUX:-}" ]]; then
     echo "Error: not inside a tmux session" >&2
     return 1
+  fi
+  # Phase 2 generic launcher path. Preserve legacy issue behavior while
+  # registering through pane-registry init-entry immediately. Adapter-specific
+  # spawners still write their spawn files after this call; watch/init can
+  # refresh metadata as before.
+  if [[ -n "$cmd" && -x "$SCRIPT_DIR/flightdeck-session" ]]; then
+    "$SCRIPT_DIR/flightdeck-session" start \
+      --session-id "$name" \
+      --title "$name" \
+      --kind issue \
+      --cwd "$dir" \
+      --worktree "$dir" \
+      --harness "${HARNESS:-unknown}" \
+      --cmd "$cmd"
+    return $?
   fi
   local last_idx
   last_idx=$(tmux list-windows -F '#{window_index}' | tail -1)

--- a/skills/flightdeck/scripts/open-terminal
+++ b/skills/flightdeck/scripts/open-terminal
@@ -27,6 +27,9 @@
 #   PI_BRIDGE_DISCOVERY_TIMEOUT - Seconds to wait for pi-session-bridge metadata after
 #                               opening a Pi pane (default: 30). Test/operator override.
 
+# TODO(structure, phase-3+): keep generic launch behavior in flightdeck-session;
+# open-terminal should shrink to issue-mode compatibility and adapter presets.
+
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/skills/flightdeck/scripts/pane-poll.bash
+++ b/skills/flightdeck/scripts/pane-poll.bash
@@ -166,12 +166,17 @@ split_target_and_index() {
 }
 
 registry_issue_for_pane() {
-  local issue="$1" pane_lookup="$2"
+  local issue="$1" pane_lookup="$2" raw
   if [[ -n "$issue" ]]; then
     printf '%s' "$issue"
     return 0
   fi
-  "$PANE_REGISTRY" find-by-pane "$pane_lookup" 2>/dev/null || true
+  raw=$("$PANE_REGISTRY" find-by-pane "$pane_lookup" 2>/dev/null || true)
+  if [[ "$raw" == \{* ]]; then
+    jq -r '.id // empty' <<< "$raw" 2>/dev/null || true
+  else
+    printf '%s' "$raw"
+  fi
 }
 
 resolve_oc_args() {

--- a/skills/flightdeck/scripts/pane-registry.bash
+++ b/skills/flightdeck/scripts/pane-registry.bash
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
-# Issue↔pane registry CRUD. Wraps flightdeck-state for the .issues map.
+# TrackedEntry↔pane registry CRUD. Wraps flightdeck-state for .entries and
+# dual-writes issue entries to the legacy .issues map.
 #
 # Usage:
+#   pane-registry init-entry <ENTRY_ID> --title <T> --kind adhoc|issue|workflow --cwd <path> --window <N> --harness <h> [--worktree <path>] [--pr <N>]
 #   pane-registry init <ISSUE> --window <name> --harness <h> --worktree <path> [--pane-index <N>] [--pr <N>]
 #                                  [--oc-url <URL> --oc-session-id <ID> [--oc-port <N>]]
 #   pane-registry list [--format json|inner-panes|inner-harnesses]
@@ -16,7 +18,7 @@
 #   pane-registry teardown-window <ISSUE> [--force]      # safely kill the issue's window/pane using stable pane_id
 #   pane-registry teardown-entry <ENTRY_ID> [--force]    # alias for teardown-window (TrackedEntry alignment)
 #   pane-registry oc-attach-args <ISSUE>                # prints '--url U --session S' or empty
-#   pane-registry find-by-pane <pane-target>             # prints issue id matching pane_target
+#   pane-registry find-by-pane <pane-target>             # prints {id,kind} JSON matching pane target/id
 #
 # When --harness is opencode and --oc-url is omitted, init auto-loads from
 # the spawn-discovery file written by open-terminal at oc_spawn_file(<ISSUE>).
@@ -48,178 +50,245 @@ shift
 
 now() { date -u +"%Y-%m-%dT%H:%M:%SZ"; }
 
+entry_list_filter() {
+  cat <<'JQ'
+to_entries | map(
+  .value as $e
+  | ($e.adapter // {}) as $a
+  | ($e.domain.issue // {}) as $i
+  | $e + {
+      id: ($e.id // .key),
+      issue: (if ($e.kind // "issue") == "issue" then ($i.id // $e.id // .key) else null end),
+      worktree: ($i.worktree // $e.cwd // null),
+      pr_number: ($i.pr_number // null),
+      oc_url: ($a.oc_url // null),
+      oc_session_id: ($a.oc_session_id // null),
+      oc_port: ($a.oc_port // null),
+      cc_url: ($a.cc_url // null),
+      cc_session_uuid: ($a.cc_session_uuid // null),
+      cc_port: ($a.cc_port // null),
+      cc_transcript: ($a.cc_transcript // null),
+      pi_bridge_pid: ($a.pi_bridge_pid // null),
+      pi_bridge_socket: ($a.pi_bridge_socket // null),
+      pi_session_id: ($a.pi_session_id // null),
+      cx_ws: ($a.cx_ws // null),
+      cx_thread_id: ($a.cx_thread_id // null),
+      orchestration_started: ($i.orchestration_started // null),
+      scope_files_declared: ($i.scope_files_declared // null),
+      scope_files_actual: ($i.scope_files_actual // null)
+    }
+)
+JQ
+}
+
+lookup_id() {
+  local raw="$1"
+  if [[ "$raw" == \{* ]]; then
+    jq -r '.id // empty' <<< "$raw" 2>/dev/null || true
+  else
+    printf '%s' "$raw"
+  fi
+}
+
+read_registry_field() {
+  local raw_id="$1" field="$2" id id_json
+  id=$(lookup_id "$raw_id")
+  [[ -n "$id" ]] || return 1
+  id_json=$(jq -Rn --arg v "$id" '$v')
+  "$FD_STATE" get "(.issues[$id_json].$field // .entries[$id_json].adapter.$field // .entries[$id_json].$field // empty)" 2>/dev/null | tr -d '"'
+}
+
+cmd_init_entry() {
+  local ENTRY_ID="$1" MODE="${2:-entry}"
+  shift 2 || true
+  [[ -n "$ENTRY_ID" ]] || { echo "Usage: pane-registry init-entry <ENTRY_ID> [flags]" >&2; exit 2; }
+
+  DEFAULT_PANE_INDEX="$(tmux show-options -g pane-base-index 2>/dev/null | awk '{print $2}')"
+  DEFAULT_PANE_INDEX="${DEFAULT_PANE_INDEX:-0}"
+  TITLE="$ENTRY_ID"; KIND="adhoc"; CWD=""; WINDOW=""; HARNESS=""; WORKTREE=""; PANE_INDEX="$DEFAULT_PANE_INDEX"; PR=""
+  PANE_ID=""; PANE_TARGET=""; WINDOW_ID=""; WINDOW_INDEX=""
+  OC_URL=""; OC_SESSION_ID=""; OC_PORT=""
+  CC_URL=""; CC_SESSION_UUID=""; CC_PORT=""; CC_TRANSCRIPT=""
+  PI_BRIDGE_PID=""; PI_BRIDGE_SOCKET=""; PI_SESSION_ID=""
+  CX_WS=""; CX_THREAD_ID=""
+  LAUNCH_MODEL=""; LAUNCH_EFFORT=""; LAUNCH_CMD=""
+
+  if [[ "$MODE" == "issue" ]]; then
+    KIND="issue"
+  fi
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --title) TITLE="$2"; shift 2 ;;
+      --kind) KIND="$2"; shift 2 ;;
+      --cwd) CWD="$2"; shift 2 ;;
+      --window) WINDOW="$2"; shift 2 ;;
+      --harness) HARNESS="$2"; shift 2 ;;
+      --worktree) WORKTREE="$2"; shift 2 ;;
+      --pane-index) PANE_INDEX="$2"; shift 2 ;;
+      --pane-id) PANE_ID="$2"; shift 2 ;;
+      --pane-target) PANE_TARGET="$2"; shift 2 ;;
+      --window-id) WINDOW_ID="$2"; shift 2 ;;
+      --window-index) WINDOW_INDEX="$2"; shift 2 ;;
+      --pr) PR="$2"; shift 2 ;;
+      --oc-url) OC_URL="$2"; shift 2 ;;
+      --oc-session-id) OC_SESSION_ID="$2"; shift 2 ;;
+      --oc-port) OC_PORT="$2"; shift 2 ;;
+      --cc-url) CC_URL="$2"; shift 2 ;;
+      --cc-session-uuid) CC_SESSION_UUID="$2"; shift 2 ;;
+      --cc-port) CC_PORT="$2"; shift 2 ;;
+      --cc-transcript) CC_TRANSCRIPT="$2"; shift 2 ;;
+      --pi-bridge-pid) PI_BRIDGE_PID="$2"; shift 2 ;;
+      --pi-bridge-socket) PI_BRIDGE_SOCKET="$2"; shift 2 ;;
+      --pi-session-id) PI_SESSION_ID="$2"; shift 2 ;;
+      --cx-ws) CX_WS="$2"; shift 2 ;;
+      --cx-thread-id) CX_THREAD_ID="$2"; shift 2 ;;
+      --launch-model) LAUNCH_MODEL="$2"; shift 2 ;;
+      --launch-effort) LAUNCH_EFFORT="$2"; shift 2 ;;
+      --launch-cmd) LAUNCH_CMD="$2"; shift 2 ;;
+      *) echo "Unknown flag: $1" >&2; exit 2 ;;
+    esac
+  done
+
+  case "$KIND" in adhoc|issue|workflow) ;; *) echo "init-entry requires --kind adhoc|issue|workflow" >&2; exit 2 ;; esac
+  if [[ "$MODE" == "issue" ]]; then
+    [[ -z "$CWD" ]] && CWD="$WORKTREE"
+    [[ -z "$TITLE" ]] && TITLE="$ENTRY_ID"
+    [[ -z "$WORKTREE" ]] && { echo "init requires --window, --harness, --worktree" >&2; exit 2; }
+  fi
+  [[ -z "$WORKTREE" && "$KIND" == "issue" ]] && WORKTREE="$CWD"
+  [[ -z "$CWD" ]] && CWD="$WORKTREE"
+  [[ -z "$TITLE" ]] && TITLE="$ENTRY_ID"
+  [[ -z "$WINDOW" || -z "$HARNESS" || -z "$CWD" ]] && {
+    echo "init-entry requires --title, --kind, --cwd, --window, --harness" >&2; exit 2; }
+
+  # Auto-hydrate bridge metadata from legacy issue-keyed spawn files when
+  # callers do not pass adapter fields explicitly. This preserves init alias
+  # behavior and lets issue-mode init-entry share the same code path.
+  if [[ "$HARNESS" == "opencode" && -z "$OC_URL" ]]; then
+    _spawn_file="$(oc_spawn_file "$ENTRY_ID")"
+    if [[ -f "$_spawn_file" ]]; then
+      OC_URL=$(jq -r '.url // ""' "$_spawn_file" 2>/dev/null || echo "")
+      OC_SESSION_ID=$(jq -r '.session_id // ""' "$_spawn_file" 2>/dev/null || echo "")
+      OC_PORT=$(jq -r '.port // ""' "$_spawn_file" 2>/dev/null || echo "")
+      LAUNCH_MODEL=${LAUNCH_MODEL:-$(jq -r '.launch.model // ""' "$_spawn_file" 2>/dev/null || echo "")}
+      LAUNCH_EFFORT=${LAUNCH_EFFORT:-$(jq -r '.launch.effort // ""' "$_spawn_file" 2>/dev/null || echo "")}
+    fi
+  fi
+  if [[ "$HARNESS" == "claude" && -z "$CC_URL" ]]; then
+    _cc_spawn_file="$(cc_spawn_file "$ENTRY_ID")"
+    if [[ -f "$_cc_spawn_file" ]]; then
+      CC_URL=$(jq -r '.url // ""' "$_cc_spawn_file" 2>/dev/null || echo "")
+      CC_SESSION_UUID=$(jq -r '.session_uuid // ""' "$_cc_spawn_file" 2>/dev/null || echo "")
+      CC_PORT=$(jq -r '.port // ""' "$_cc_spawn_file" 2>/dev/null || echo "")
+      CC_TRANSCRIPT=$(jq -r '.transcript // ""' "$_cc_spawn_file" 2>/dev/null || echo "")
+      LAUNCH_MODEL=${LAUNCH_MODEL:-$(jq -r '.launch.model // ""' "$_cc_spawn_file" 2>/dev/null || echo "")}
+      LAUNCH_EFFORT=${LAUNCH_EFFORT:-$(jq -r '.launch.effort // ""' "$_cc_spawn_file" 2>/dev/null || echo "")}
+    fi
+  fi
+  if [[ "$HARNESS" == "pi" && -z "$PI_BRIDGE_PID" ]]; then
+    _pi_spawn_file="$(pi_spawn_file "$ENTRY_ID")"
+    if [[ -f "$_pi_spawn_file" ]]; then
+      PI_BRIDGE_PID=$(jq -r '.pid // ""' "$_pi_spawn_file" 2>/dev/null || echo "")
+      PI_BRIDGE_SOCKET=$(jq -r '.socket // ""' "$_pi_spawn_file" 2>/dev/null || echo "")
+      PI_SESSION_ID=$(jq -r '.session_id // ""' "$_pi_spawn_file" 2>/dev/null || echo "")
+      LAUNCH_MODEL=${LAUNCH_MODEL:-$(jq -r '.launch.model // ""' "$_pi_spawn_file" 2>/dev/null || echo "")}
+      LAUNCH_EFFORT=${LAUNCH_EFFORT:-$(jq -r '.launch.effort // ""' "$_pi_spawn_file" 2>/dev/null || echo "")}
+    fi
+  fi
+  if [[ "$HARNESS" == "codex" && -z "$CX_WS" ]]; then
+    _cx_spawn_file="$(cx_spawn_file "$ENTRY_ID")"
+    if [[ -f "$_cx_spawn_file" ]]; then
+      CX_WS=$(jq -r '.url // ""' "$_cx_spawn_file" 2>/dev/null || echo "")
+      CX_THREAD_ID=$(jq -r '.thread_id // ""' "$_cx_spawn_file" 2>/dev/null || echo "")
+      LAUNCH_MODEL=${LAUNCH_MODEL:-$(jq -r '.launch.model // ""' "$_cx_spawn_file" 2>/dev/null || echo "")}
+      LAUNCH_EFFORT=${LAUNCH_EFFORT:-$(jq -r '.launch.effort // ""' "$_cx_spawn_file" 2>/dev/null || echo "")}
+    fi
+  fi
+
+  "$FD_STATE" init >/dev/null
+  SESSION=$(tmux display-message -p '#S' 2>/dev/null || echo unknown)
+  if [[ -z "$PANE_TARGET" ]]; then
+    PANE_TARGET="${SESSION}:${WINDOW}.${PANE_INDEX}"
+  fi
+  if [[ -z "$PANE_ID" ]] && tmux list-panes -t "$PANE_TARGET" >/dev/null 2>&1; then
+    PANE_ID=$(tmux display-message -t "$PANE_TARGET" -p '#{pane_id}' 2>/dev/null || echo "")
+  fi
+
+  entry_obj=$(jq -n \
+    --arg id "$ENTRY_ID" \
+    --arg title "$TITLE" \
+    --arg kind "$KIND" \
+    --arg cwd "$CWD" \
+    --arg window "$WINDOW" \
+    --arg window_id "$WINDOW_ID" \
+    --arg window_index "$WINDOW_INDEX" \
+    --arg pane_target "$PANE_TARGET" \
+    --arg pane_id "$PANE_ID" \
+    --arg harness "$HARNESS" \
+    --arg worktree "$WORKTREE" \
+    --arg pr "$PR" \
+    --arg oc_url "$OC_URL" \
+    --arg oc_session_id "$OC_SESSION_ID" \
+    --arg oc_port "$OC_PORT" \
+    --arg cc_url "$CC_URL" \
+    --arg cc_session_uuid "$CC_SESSION_UUID" \
+    --arg cc_port "$CC_PORT" \
+    --arg cc_transcript "$CC_TRANSCRIPT" \
+    --arg pi_bridge_pid "$PI_BRIDGE_PID" \
+    --arg pi_bridge_socket "$PI_BRIDGE_SOCKET" \
+    --arg pi_session_id "$PI_SESSION_ID" \
+    --arg cx_ws "$CX_WS" \
+    --arg cx_thread_id "$CX_THREAD_ID" \
+    --arg launch_model "$LAUNCH_MODEL" \
+    --arg launch_effort "$LAUNCH_EFFORT" \
+    --arg launch_cmd "$LAUNCH_CMD" \
+    --arg now "$(now)" \
+    'def s($v): if $v == "" then null else $v end;
+     def n($v): if $v == "" then null else ($v | tonumber) end;
+     {
+       id: $id,
+       title: $title,
+       kind: $kind,
+       state: "waiting",
+       substate: null,
+       harness: $harness,
+       cwd: $cwd,
+       window: $window,
+       window_id: s($window_id),
+       window_index: n($window_index),
+       pane_target: s($pane_target),
+       pane_id: s($pane_id),
+       launch: (if $launch_model == "" and $launch_effort == "" and $launch_cmd == "" then null else {model: s($launch_model), effort: s($launch_effort), cmd: s($launch_cmd)} end),
+       adapter: {
+         oc_url: s($oc_url), oc_session_id: s($oc_session_id), oc_port: n($oc_port),
+         cc_url: s($cc_url), cc_session_uuid: s($cc_session_uuid), cc_port: n($cc_port), cc_transcript: s($cc_transcript),
+         pi_bridge_pid: n($pi_bridge_pid), pi_bridge_socket: s($pi_bridge_socket), pi_session_id: s($pi_session_id),
+         cx_ws: s($cx_ws), cx_thread_id: s($cx_thread_id)
+       },
+       domain: (if $kind == "issue" then {issue: {id: $id, worktree: s($worktree), pr_number: n($pr), orchestration_started: false, scope_files_declared: null, scope_files_actual: null}} else null end),
+       last_capture_hash: null,
+       last_response_at: null,
+       spawned_at: $now,
+       last_polled_at: $now,
+       decisions_log: [],
+       unknown_since: null
+     }')
+
+  "$FD_STATE" write-entry "$ENTRY_ID" "$entry_obj"
+}
+
 case "$ACTION" in
   init)
     ISSUE="${1:-}"; shift || true
     [[ -z "$ISSUE" ]] && { echo "Usage: pane-registry init <ISSUE> [flags]" >&2; exit 2; }
-
-    # Default pane index follows tmux's pane-base-index (commonly 0; some
-    # configs set 1). Fingerprinting in the watch loop still resolves the
-    # actual orchestrator pane when a TUI lays out differently — this just
-    # avoids a wasted round-trip when the default-index is correct.
-    DEFAULT_PANE_INDEX="$(tmux show-options -g pane-base-index 2>/dev/null | awk '{print $2}')"
-    DEFAULT_PANE_INDEX="${DEFAULT_PANE_INDEX:-0}"
-    WINDOW=""; HARNESS=""; WORKTREE=""; PANE_INDEX="$DEFAULT_PANE_INDEX"; PR=""
-    OC_URL=""; OC_SESSION_ID=""; OC_PORT=""
-    CC_URL=""; CC_SESSION_UUID=""; CC_PORT=""; CC_TRANSCRIPT=""
-    PI_BRIDGE_PID=""; PI_BRIDGE_SOCKET=""; PI_SESSION_ID=""
-    CX_WS=""; CX_THREAD_ID=""
-    LAUNCH_MODEL=""; LAUNCH_EFFORT=""
-    while [[ $# -gt 0 ]]; do
-      case "$1" in
-        --window) WINDOW="$2"; shift 2 ;;
-        --harness) HARNESS="$2"; shift 2 ;;
-        --worktree) WORKTREE="$2"; shift 2 ;;
-        --pane-index) PANE_INDEX="$2"; shift 2 ;;
-        --pr) PR="$2"; shift 2 ;;
-        --oc-url) OC_URL="$2"; shift 2 ;;
-        --oc-session-id) OC_SESSION_ID="$2"; shift 2 ;;
-        --oc-port) OC_PORT="$2"; shift 2 ;;
-        --cc-url) CC_URL="$2"; shift 2 ;;
-        --cc-session-uuid) CC_SESSION_UUID="$2"; shift 2 ;;
-        --cc-port) CC_PORT="$2"; shift 2 ;;
-        --cc-transcript) CC_TRANSCRIPT="$2"; shift 2 ;;
-        --pi-bridge-pid) PI_BRIDGE_PID="$2"; shift 2 ;;
-        --pi-bridge-socket) PI_BRIDGE_SOCKET="$2"; shift 2 ;;
-        --pi-session-id) PI_SESSION_ID="$2"; shift 2 ;;
-        --cx-ws) CX_WS="$2"; shift 2 ;;
-        --cx-thread-id) CX_THREAD_ID="$2"; shift 2 ;;
-        *) echo "Unknown flag: $1" >&2; exit 2 ;;
-      esac
-    done
-    [[ -z "$WINDOW" || -z "$HARNESS" || -z "$WORKTREE" ]] && {
-      echo "init requires --window, --harness, --worktree" >&2; exit 2; }
-
-    # Auto-hydrate opencode bridge metadata from the spawn-discovery file
-    # written by open-terminal, when caller didn't pass it explicitly.
-    if [[ "$HARNESS" == "opencode" && -z "$OC_URL" ]]; then
-      _spawn_file="$(oc_spawn_file "$ISSUE")"
-      if [[ -f "$_spawn_file" ]]; then
-        OC_URL=$(jq -r '.url // ""' "$_spawn_file" 2>/dev/null || echo "")
-        OC_SESSION_ID=$(jq -r '.session_id // ""' "$_spawn_file" 2>/dev/null || echo "")
-        OC_PORT=$(jq -r '.port // ""' "$_spawn_file" 2>/dev/null || echo "")
-        LAUNCH_MODEL=$(jq -r '.launch.model // ""' "$_spawn_file" 2>/dev/null || echo "")
-        LAUNCH_EFFORT=$(jq -r '.launch.effort // ""' "$_spawn_file" 2>/dev/null || echo "")
-      fi
-    fi
-    # Auto-hydrate claude channel metadata.
-    if [[ "$HARNESS" == "claude" && -z "$CC_URL" ]]; then
-      _cc_spawn_file="$(cc_spawn_file "$ISSUE")"
-      if [[ -f "$_cc_spawn_file" ]]; then
-        CC_URL=$(jq -r '.url // ""' "$_cc_spawn_file" 2>/dev/null || echo "")
-        CC_SESSION_UUID=$(jq -r '.session_uuid // ""' "$_cc_spawn_file" 2>/dev/null || echo "")
-        CC_PORT=$(jq -r '.port // ""' "$_cc_spawn_file" 2>/dev/null || echo "")
-        CC_TRANSCRIPT=$(jq -r '.transcript // ""' "$_cc_spawn_file" 2>/dev/null || echo "")
-        LAUNCH_MODEL=$(jq -r '.launch.model // ""' "$_cc_spawn_file" 2>/dev/null || echo "")
-        LAUNCH_EFFORT=$(jq -r '.launch.effort // ""' "$_cc_spawn_file" 2>/dev/null || echo "")
-      fi
-    fi
-    # Auto-hydrate pi bridge metadata.
-    if [[ "$HARNESS" == "pi" && -z "$PI_BRIDGE_PID" ]]; then
-      _pi_spawn_file="$(pi_spawn_file "$ISSUE")"
-      if [[ -f "$_pi_spawn_file" ]]; then
-        PI_BRIDGE_PID=$(jq -r '.pid // ""' "$_pi_spawn_file" 2>/dev/null || echo "")
-        PI_BRIDGE_SOCKET=$(jq -r '.socket // ""' "$_pi_spawn_file" 2>/dev/null || echo "")
-        PI_SESSION_ID=$(jq -r '.session_id // ""' "$_pi_spawn_file" 2>/dev/null || echo "")
-        LAUNCH_MODEL=$(jq -r '.launch.model // ""' "$_pi_spawn_file" 2>/dev/null || echo "")
-        LAUNCH_EFFORT=$(jq -r '.launch.effort // ""' "$_pi_spawn_file" 2>/dev/null || echo "")
-      fi
-    fi
-    # Auto-hydrate codex bridge metadata.
-    if [[ "$HARNESS" == "codex" && -z "$CX_WS" ]]; then
-      _cx_spawn_file="$(cx_spawn_file "$ISSUE")"
-      if [[ -f "$_cx_spawn_file" ]]; then
-        CX_WS=$(jq -r '.url // ""' "$_cx_spawn_file" 2>/dev/null || echo "")
-        CX_THREAD_ID=$(jq -r '.thread_id // ""' "$_cx_spawn_file" 2>/dev/null || echo "")
-        LAUNCH_MODEL=$(jq -r '.launch.model // ""' "$_cx_spawn_file" 2>/dev/null || echo "")
-        LAUNCH_EFFORT=$(jq -r '.launch.effort // ""' "$_cx_spawn_file" 2>/dev/null || echo "")
-      fi
-    fi
-
-    "$FD_STATE" init >/dev/null
-    SESSION=$(tmux display-message -p '#S' 2>/dev/null || echo unknown)
-    PANE_TARGET="${SESSION}:${WINDOW}.${PANE_INDEX}"
-
-    # Resolve the immutable tmux pane id (`%N`) at init time and store it
-    # alongside the human-readable pane_target. Window names are mutable —
-    # pi/codex auto-rename their window once the TUI starts, which broke
-    # the previous window_name-keyed reconcile path and caused live entries
-    # to be silently dropped (#3 finding 3 + #4 finding 4). `allow-rename
-    # off` doesn't help: pi invokes `tmux rename-window` directly via IPC,
-    # bypassing the OSC-2 gate. pane_id is stable for the life of the
-    # pane, regardless of rename / split / harness restart.
-    #
-    # Validate the target exists before resolving the id. `tmux
-    # display-message -t <bogus>` silently returns the active pane's id
-    # (footgun: an init call with a typoed window name would store the
-    # caller's own pane id and reconcile would never drop it). list-panes
-    # exits non-zero for a missing target, so use it as the gate.
-    PANE_ID=""
-    if tmux list-panes -t "$PANE_TARGET" >/dev/null 2>&1; then
-      PANE_ID=$(tmux display-message -t "$PANE_TARGET" -p '#{pane_id}' 2>/dev/null || echo "")
-    fi
-
-    issue_obj=$(jq -n \
-      --arg window "$WINDOW" \
-      --arg pane_target "$PANE_TARGET" \
-      --arg pane_id "$PANE_ID" \
-      --arg harness "$HARNESS" \
-      --arg worktree "$WORKTREE" \
-      --arg pr "$PR" \
-      --arg oc_url "$OC_URL" \
-      --arg oc_session_id "$OC_SESSION_ID" \
-      --arg oc_port "$OC_PORT" \
-      --arg cc_url "$CC_URL" \
-      --arg cc_session_uuid "$CC_SESSION_UUID" \
-      --arg cc_port "$CC_PORT" \
-      --arg cc_transcript "$CC_TRANSCRIPT" \
-      --arg pi_bridge_pid "$PI_BRIDGE_PID" \
-      --arg pi_bridge_socket "$PI_BRIDGE_SOCKET" \
-      --arg pi_session_id "$PI_SESSION_ID" \
-      --arg cx_ws "$CX_WS" \
-      --arg cx_thread_id "$CX_THREAD_ID" \
-      --arg launch_model "$LAUNCH_MODEL" \
-      --arg launch_effort "$LAUNCH_EFFORT" \
-      --arg now "$(now)" \
-      '{
-        window: $window,
-        pane_target: $pane_target,
-        pane_id: ($pane_id | if . == "" then null else . end),
-        harness: $harness,
-        worktree: $worktree,
-        pr_number: ($pr | if . == "" then null else (. | tonumber) end),
-        oc_url: ($oc_url | if . == "" then null else . end),
-        oc_session_id: ($oc_session_id | if . == "" then null else . end),
-        oc_port: ($oc_port | if . == "" then null else (. | tonumber) end),
-        cc_url: ($cc_url | if . == "" then null else . end),
-        cc_session_uuid: ($cc_session_uuid | if . == "" then null else . end),
-        cc_port: ($cc_port | if . == "" then null else (. | tonumber) end),
-        cc_transcript: ($cc_transcript | if . == "" then null else . end),
-        pi_bridge_pid: ($pi_bridge_pid | if . == "" then null else (. | tonumber) end),
-        pi_bridge_socket: ($pi_bridge_socket | if . == "" then null else . end),
-        pi_session_id: ($pi_session_id | if . == "" then null else . end),
-        cx_ws: ($cx_ws | if . == "" then null else . end),
-        cx_thread_id: ($cx_thread_id | if . == "" then null else . end),
-        launch: (if $launch_model == "" and $launch_effort == "" then null else {
-          model: ($launch_model | if . == "" then null else . end),
-          effort: ($launch_effort | if . == "" then null else . end)
-        } end),
-        state: "waiting",
-        substate: null,
-        unknown_since: null,
-        last_capture_hash: null,
-        last_response_at: null,
-        spawned_at: $now,
-        last_polled_at: $now,
-        orchestration_started: false,
-        scope_files_declared: null,
-        scope_files_actual: null,
-        decisions_log: []
-      }')
-
-    "$FD_STATE" set ".issues[\"$ISSUE\"]" "$issue_obj"
+    cmd_init_entry "$ISSUE" issue --title "$ISSUE" "$@"
     ;;
 
+  init-entry)
+    ENTRY_ID="${1:-}"; shift || true
+    cmd_init_entry "$ENTRY_ID" entry "$@"
+    ;;
   list)
     FORMAT="json"
     while [[ $# -gt 0 ]]; do
@@ -230,24 +299,16 @@ case "$ACTION" in
     done
     case "$FORMAT" in
       json)
-        "$FD_STATE" get '.issues // {} | to_entries | map({issue: .key} + .value)'
+        "$FD_STATE" tracked-entries | jq -c "$(entry_list_filter)"
         ;;
       inner-panes)
-        # Comma-separated target list, one per issue, suitable for
-        # `flightdeck-daemon start --inner`. Prefer the immutable
-        # `pane_id` (`%N`) when the registry recorded one; fall back to
-        # `pane_target` for legacy entries that haven't been re-init'd
-        # or whose pane_id resolution failed at init. Without preferring
-        # pane_id here, daemon start would resolve targets through the
-        # current window name and could fail on pi/codex auto-renamed
-        # windows even though reconcile keeps the entries alive
-        # (cross-harness review finding #4).
-        "$FD_STATE" get '.issues // {} | to_entries | map(.value.pane_id // .value.pane_target // empty) | join(",")'
+        # Comma-separated target list, one per tracked entry, suitable for
+        # `flightdeck-daemon start --inner`. Prefer immutable pane_id.
+        "$FD_STATE" tracked-entries | jq -r 'to_entries | map(.value.pane_id // .value.pane_target // empty) | join(",")'
         ;;
       inner-harnesses)
-        # Comma-separated harness list in the same issue order as
-        # `inner-panes`, suitable for `flightdeck-daemon --inner-harnesses`.
-        "$FD_STATE" get '.issues // {} | to_entries | map(.value.harness // "") | join(",")'
+        # Comma-separated harness list in the same order as `inner-panes`.
+        "$FD_STATE" tracked-entries | jq -r 'to_entries | map(.value.harness // "") | join(",")'
         ;;
       *)
         echo "Unknown format: $FORMAT (supported: json, inner-panes, inner-harnesses)" >&2
@@ -357,9 +418,9 @@ case "$ACTION" in
     # (cross-harness review finding #2).
     ISSUE="${1:-}"
     [[ -z "$ISSUE" ]] && { echo "Usage: oc-attach-args <ISSUE>" >&2; exit 2; }
-    line=$("$FD_STATE" get ".issues[\"$ISSUE\"] // {} | [(.oc_url // \"\"), (.oc_session_id // \"\")] | @tsv" 2>/dev/null | tr -d '"')
-    url=$(awk -F'\t' '{print $1}' <<< "$line")
-    sid=$(awk -F'\t' '{print $2}' <<< "$line")
+    ISSUE=$(lookup_id "$ISSUE")
+    url=$(read_registry_field "$ISSUE" oc_url || true)
+    sid=$(read_registry_field "$ISSUE" oc_session_id || true)
     if [[ -n "$url" && -n "$sid" && "$url" != "null" && "$sid" != "null" ]]; then
       if oc_adapter_is_fresh "$ISSUE" 2>/dev/null; then
         printf -- "--url %s --session %s\n" "$url" "$sid"
@@ -373,9 +434,9 @@ case "$ACTION" in
     # file exists. Same fallback contract as `oc-attach-args`.
     ISSUE="${1:-}"
     [[ -z "$ISSUE" ]] && { echo "Usage: cc-channel-args <ISSUE>" >&2; exit 2; }
-    line=$("$FD_STATE" get ".issues[\"$ISSUE\"] // {} | [(.cc_url // \"\"), (.cc_transcript // \"\")] | @tsv" 2>/dev/null | tr -d '"')
-    url=$(awk -F'\t' '{print $1}' <<< "$line")
-    transcript=$(awk -F'\t' '{print $2}' <<< "$line")
+    ISSUE=$(lookup_id "$ISSUE")
+    url=$(read_registry_field "$ISSUE" cc_url || true)
+    transcript=$(read_registry_field "$ISSUE" cc_transcript || true)
     if [[ -n "$url" && -n "$transcript" && "$url" != "null" && "$transcript" != "null" ]]; then
       if cc_adapter_is_fresh "$ISSUE" 2>/dev/null; then
         printf -- "--url %s --transcript %s\n" "$url" "$transcript"
@@ -389,9 +450,9 @@ case "$ACTION" in
     # stdout when stale or missing — caller falls back to tmux.
     ISSUE="${1:-}"
     [[ -z "$ISSUE" ]] && { echo "Usage: pi-bridge-args <ISSUE>" >&2; exit 2; }
-    line=$("$FD_STATE" get ".issues[\"$ISSUE\"] // {} | [(.pi_bridge_pid // \"\"), (.pi_bridge_socket // \"\")] | @tsv" 2>/dev/null | tr -d '"')
-    pid=$(awk -F'\t' '{print $1}' <<< "$line")
-    socket=$(awk -F'\t' '{print $2}' <<< "$line")
+    ISSUE=$(lookup_id "$ISSUE")
+    pid=$(read_registry_field "$ISSUE" pi_bridge_pid || true)
+    socket=$(read_registry_field "$ISSUE" pi_bridge_socket || true)
     if [[ -n "$pid" && -n "$socket" && "$pid" != "null" && "$socket" != "null" ]]; then
       if pi_bridge_is_fresh "$pid" "$socket" 2>/dev/null; then
         printf -- "--pid %s --socket %s\n" "$pid" "$socket"
@@ -405,9 +466,9 @@ case "$ACTION" in
     # adapter args (cross-harness review finding #2).
     ISSUE="${1:-}"
     [[ -z "$ISSUE" ]] && { echo "Usage: cx-bridge-args <ISSUE>" >&2; exit 2; }
-    line=$("$FD_STATE" get ".issues[\"$ISSUE\"] // {} | [(.cx_ws // \"\"), (.cx_thread_id // \"\")] | @tsv" 2>/dev/null | tr -d '"')
-    url=$(awk -F'\t' '{print $1}' <<< "$line")
-    thread=$(awk -F'\t' '{print $2}' <<< "$line")
+    ISSUE=$(lookup_id "$ISSUE")
+    url=$(read_registry_field "$ISSUE" cx_ws || true)
+    thread=$(read_registry_field "$ISSUE" cx_thread_id || true)
     if [[ -n "$url" && -n "$thread" && "$url" != "null" && "$thread" != "null" ]]; then
       if cx_adapter_is_fresh "$ISSUE" 2>/dev/null; then
         printf -- "--url %s --thread %s\n" "$url" "$thread"
@@ -416,19 +477,20 @@ case "$ACTION" in
     ;;
 
   find-by-pane)
-    # Print the issue id whose registry entry matches the given target.
-    # Accepts either `pane_target` (session:window.pane) or `pane_id`
-    # (%N) — needed because `list --format inner-panes` now emits the
-    # immutable pane_id when present, so daemon callers pass `%N` to
-    # `find-by-pane` and must still resolve back to the issue id. Empty
-    # stdout (exit 1) when no match (cross-harness verify follow-up).
+    # Print stable JSON for the tracked entry matching pane_target or pane_id.
+    # The normalized read path covers both .entries and legacy .issues rows.
     PANE_TARGET="${1:-}"
     [[ -z "$PANE_TARGET" ]] && { echo "Usage: find-by-pane <pane-target-or-pane-id>" >&2; exit 2; }
-    issue=$("$FD_STATE" get ".issues // {} | to_entries[] | select(.value.pane_target == \"$PANE_TARGET\" or .value.pane_id == \"$PANE_TARGET\") | .key" 2>/dev/null | tr -d '"' | head -n1)
-    if [[ -z "$issue" ]]; then
+    match=$("$FD_STATE" tracked-entries 2>/dev/null | jq -c --arg target "$PANE_TARGET" '
+      to_entries
+      | map(select(.value.pane_target == $target or .value.pane_id == $target))
+      | .[0] // empty
+      | {id: (.value.id // .key), kind: (.value.kind // "issue")}
+    ' 2>/dev/null | head -n1)
+    if [[ -z "$match" ]]; then
       exit 1
     fi
-    echo "$issue"
+    echo "$match"
     ;;
 
   remove-merged)
@@ -684,7 +746,7 @@ case "$ACTION" in
     #   exit >= 2             — usage error or genuine read failure
     # Treat 0+empty and 1 as "not found"; only exit >= 2 escalates to
     # exit 6 (registry read failure) per BLOCK #2.
-    entry=$("$FD_STATE" get ".issues[\"$ISSUE\"] // empty" 2>"$fd_stderr_file")
+    entry=$("$FD_STATE" get ".issues[\"$ISSUE\"] // .entries[\"$ISSUE\"] // empty" 2>"$fd_stderr_file")
     fd_status=$?
     if (( fd_status >= 2 )); then
       printf 'teardown-window: registry read failed (flightdeck-state exit=%s): ' "$fd_status" >&2
@@ -762,7 +824,7 @@ case "$ACTION" in
 
   *)
     echo "Unknown action: $ACTION" >&2
-    echo "Actions: init | list | get | set-state | set-substate | set | log-decision | remove | remove-merged | reconcile | teardown-window | teardown-entry | oc-attach-args | cc-channel-args | pi-bridge-args | cx-bridge-args | find-by-pane" >&2
+    echo "Actions: init-entry | init | list | get | set-state | set-substate | set | log-decision | remove | remove-merged | reconcile | teardown-window | teardown-entry | oc-attach-args | cc-channel-args | pi-bridge-args | cx-bridge-args | find-by-pane" >&2
     exit 2
     ;;
 esac

--- a/skills/flightdeck/scripts/pane-registry.bash
+++ b/skills/flightdeck/scripts/pane-registry.bash
@@ -98,6 +98,21 @@ read_registry_field() {
   "$FD_STATE" get "(.issues[$id_json].$field // .entries[$id_json].adapter.$field // .entries[$id_json].$field // empty)" 2>/dev/null | tr -d '"'
 }
 
+pane_match_is_live() {
+  local pane_id="$1" pane_target="$2" lookup="${pane_id:-$pane_target}"
+  [[ -n "$lookup" ]] || return 1
+  if [[ -n "$pane_id" ]]; then
+    tmux list-panes -a -F '#{pane_id}' 2>/dev/null | grep -qFx "$pane_id"
+    return $?
+  fi
+  tmux list-panes -t "$pane_target" >/dev/null 2>&1
+}
+
+warn_stale_pane_match() {
+  local pane_id="$1" pane_target="$2" lookup="${pane_id:-$pane_target}"
+  printf 'Warning: find-by-pane match %s is stale (pane no longer exists); use pane-registry reconcile.\n' "${lookup:-<none>}" >&2
+}
+
 cmd_init_entry() {
   local ENTRY_ID="$1" MODE="${2:-entry}"
   shift 2 || true
@@ -111,7 +126,7 @@ cmd_init_entry() {
   CC_URL=""; CC_SESSION_UUID=""; CC_PORT=""; CC_TRANSCRIPT=""
   PI_BRIDGE_PID=""; PI_BRIDGE_SOCKET=""; PI_SESSION_ID=""
   CX_WS=""; CX_THREAD_ID=""
-  LAUNCH_MODEL=""; LAUNCH_EFFORT=""; LAUNCH_CMD=""
+  LAUNCH_MODEL=""; LAUNCH_EFFORT=""; LAUNCH_CMD=""; DISCOVERY_ERROR=""
 
   if [[ "$MODE" == "issue" ]]; then
     KIND="issue"
@@ -146,6 +161,7 @@ cmd_init_entry() {
       --launch-model) LAUNCH_MODEL="$2"; shift 2 ;;
       --launch-effort) LAUNCH_EFFORT="$2"; shift 2 ;;
       --launch-cmd) LAUNCH_CMD="$2"; shift 2 ;;
+      --discovery-error) DISCOVERY_ERROR="$2"; shift 2 ;;
       *) echo "Unknown flag: $1" >&2; exit 2 ;;
     esac
   done
@@ -243,6 +259,7 @@ cmd_init_entry() {
     --arg launch_model "$LAUNCH_MODEL" \
     --arg launch_effort "$LAUNCH_EFFORT" \
     --arg launch_cmd "$LAUNCH_CMD" \
+    --arg discovery_error "$DISCOVERY_ERROR" \
     --arg now "$(now)" \
     'def s($v): if $v == "" then null else $v end;
      def n($v): if $v == "" then null else ($v | tonumber) end;
@@ -259,6 +276,7 @@ cmd_init_entry() {
        window_index: n($window_index),
        pane_target: s($pane_target),
        pane_id: s($pane_id),
+       discovery_error: s($discovery_error),
        launch: (if $launch_model == "" and $launch_effort == "" and $launch_cmd == "" then null else {model: s($launch_model), effort: s($launch_effort), cmd: s($launch_cmd)} end),
        adapter: {
          oc_url: s($oc_url), oc_session_id: s($oc_session_id), oc_port: n($oc_port),
@@ -485,12 +503,18 @@ case "$ACTION" in
       to_entries
       | map(select(.value.pane_target == $target or .value.pane_id == $target))
       | .[0] // empty
-      | {id: (.value.id // .key), kind: (.value.kind // "issue")}
+      | {id: (.value.id // .key), kind: (.value.kind // "issue"), pane_id: (.value.pane_id // null), pane_target: (.value.pane_target // null)}
     ' 2>/dev/null | head -n1)
     if [[ -z "$match" ]]; then
       exit 1
     fi
-    echo "$match"
+    match_pane_id=$(jq -r '.pane_id // ""' <<< "$match")
+    match_pane_target=$(jq -r '.pane_target // ""' <<< "$match")
+    if ! pane_match_is_live "$match_pane_id" "$match_pane_target"; then
+      warn_stale_pane_match "$match_pane_id" "$match_pane_target"
+      exit 1
+    fi
+    jq -c '{id, kind}' <<< "$match"
     ;;
 
   remove-merged)

--- a/skills/flightdeck/scripts/pane-respond.bash
+++ b/skills/flightdeck/scripts/pane-respond.bash
@@ -97,6 +97,16 @@ source "$SCRIPT_DIR/lib/pi-bridge-paths.sh"
 # shellcheck source=lib/codex-paths.sh
 source "$SCRIPT_DIR/lib/codex-paths.sh"
 
+pane_registry_find_id() {
+  local target="$1" raw
+  raw=$("$SCRIPT_DIR/pane-registry" find-by-pane "$target" 2>/dev/null || true)
+  if [[ "$raw" == \{* ]]; then
+    jq -r '.id // empty' <<< "$raw" 2>/dev/null || true
+  else
+    printf '%s' "$raw"
+  fi
+}
+
 TARGET="${1:-}"
 if [[ -z "$TARGET" ]]; then
   echo "Usage: pane-respond <pane-target> <payload>|--option N|--keys k1,k2,... [flags]" >&2
@@ -489,7 +499,7 @@ CX_ADAPTER_USED=0
 #   pi-bridge reject --pid <PID> --request-id <id>
 # The request_id disambiguates the pending prompt.
 if [[ "$MODE" == "question" && "$HARNESS" == "opencode" ]]; then
-  oc_issue=$("$SCRIPT_DIR/pane-registry" find-by-pane "$TARGET" 2>/dev/null || echo "")
+  oc_issue=$(pane_registry_find_id "$TARGET")
   oc_attach_args=""
   if [[ -n "$oc_issue" ]]; then
     oc_attach_args=$("$SCRIPT_DIR/pane-registry" oc-attach-args "$oc_issue" 2>/dev/null || echo "")
@@ -533,7 +543,7 @@ if [[ "$MODE" == "question" && "$HARNESS" == "opencode" ]]; then
 fi
 
 if [[ "$MODE" == "question" && "$HARNESS" == "pi" ]]; then
-  pi_issue=$("$SCRIPT_DIR/pane-registry" find-by-pane "$TARGET" 2>/dev/null || echo "")
+  pi_issue=$(pane_registry_find_id "$TARGET")
   pi_args=""
   if [[ -n "$pi_issue" ]]; then
     pi_args=$("$SCRIPT_DIR/pane-registry" pi-bridge-args "$pi_issue" 2>/dev/null || echo "")
@@ -603,7 +613,7 @@ if [[ "$MODE" == "question" && "$HARNESS" == "pi" ]]; then
 fi
 
 if [[ "$HARNESS" == "opencode" && $OC_ADAPTER_USED -eq 0 ]]; then
-  oc_issue=$("$SCRIPT_DIR/pane-registry" find-by-pane "$TARGET" 2>/dev/null || echo "")
+  oc_issue=$(pane_registry_find_id "$TARGET")
   oc_attach_args=""
   if [[ -n "$oc_issue" ]]; then
     oc_attach_args=$("$SCRIPT_DIR/pane-registry" oc-attach-args "$oc_issue" 2>/dev/null || echo "")
@@ -646,7 +656,7 @@ fi
 # All non-tmux modes route through the channel; --keys is rejected
 # unless --keys-allow-tmux. Symmetric with the opencode block above.
 if [[ "$HARNESS" == "claude" && $OC_ADAPTER_USED -eq 0 ]]; then
-  cc_issue=$("$SCRIPT_DIR/pane-registry" find-by-pane "$TARGET" 2>/dev/null || echo "")
+  cc_issue=$(pane_registry_find_id "$TARGET")
   cc_args=""
   if [[ -n "$cc_issue" ]]; then
     cc_args=$("$SCRIPT_DIR/pane-registry" cc-channel-args "$cc_issue" 2>/dev/null || echo "")
@@ -703,7 +713,7 @@ fi
 # over the per-process Unix socket. Symmetric with claude/opencode
 # blocks above.
 if [[ "$HARNESS" == "pi" && $OC_ADAPTER_USED -eq 0 && $CC_ADAPTER_USED -eq 0 && $PI_ADAPTER_USED -eq 0 ]]; then
-  pi_issue=$("$SCRIPT_DIR/pane-registry" find-by-pane "$TARGET" 2>/dev/null || echo "")
+  pi_issue=$(pane_registry_find_id "$TARGET")
   pi_args=""
   if [[ -n "$pi_issue" ]]; then
     pi_args=$("$SCRIPT_DIR/pane-registry" pi-bridge-args "$pi_issue" 2>/dev/null || echo "")
@@ -764,7 +774,7 @@ fi
 # Codex bridge adapter (Phase 4). Routes via the vendored bun
 # codex-bridge over JSON-RPC/WS to the per-session app-server.
 if [[ "$HARNESS" == "codex" && $OC_ADAPTER_USED -eq 0 && $CC_ADAPTER_USED -eq 0 && $PI_ADAPTER_USED -eq 0 ]]; then
-  cx_issue=$("$SCRIPT_DIR/pane-registry" find-by-pane "$TARGET" 2>/dev/null || echo "")
+  cx_issue=$(pane_registry_find_id "$TARGET")
   cx_args=""
   if [[ -n "$cx_issue" ]]; then
     cx_args=$("$SCRIPT_DIR/pane-registry" cx-bridge-args "$cx_issue" 2>/dev/null || echo "")


### PR DESCRIPTION
## Summary

Implements Phase 2 of `docs/plans/flightdeck-session-management-reframe.md`: generic tracked-entry registry APIs plus first-class ad-hoc session launch/attach.

## New commands

- `pane-registry init-entry <ENTRY_ID> --title <T> --kind adhoc|issue|workflow --cwd <path> --window <N> --harness <H> [--worktree <p>] [--pr <N>]`
- `pane-registry list --format json` now returns normalized tracked entries while preserving legacy issue fields for issue entries.
- `pane-registry find-by-pane <pane>` now returns stable JSON `{id, kind}` and resolves both `.entries[*]` and legacy `.issues[*]` rows.
- `flightdeck-session start --session-id <ID> --title <T> --cwd <path> --harness <H> (--cmd <cmd> | --prompt <text>) [--kind adhoc|workflow]`
- `flightdeck-session attach --pane <%PANE_ID> --harness pi --title <T> [--session-id <ID>] [--kind adhoc]`

## Test recipe

```bash
cd skills/flightdeck/lib/flightdeck-core
bun test
bun run typecheck
FLIGHTDECK_MANAGED=1 ORCH_STATE_DIR=other bun test
FLIGHTDECK_MANAGED=1 ORCH_STATE_DIR=other bun run typecheck
```

## Compatibility

Legacy issue workflow commands remain available: `pane-registry init <ISSUE>` calls the same write path in issue mode, issue entries continue to dual-write `.issues`, and internal callers now parse the new `find-by-pane` JSON before invoking existing adapter helpers. `.bash` siblings remain in place and TS defaults are unchanged.
