### PR TITLE
feat(flightdeck): Phase 4 isolate issue mode dependencies (reframe plan)

### DIFF
--- a/docs/plans/flightdeck-session-management-reframe.md
+++ b/docs/plans/flightdeck-session-management-reframe.md
@@ -292,31 +292,34 @@ Validation:
 
 Purpose: no regression for current Flightdeck users.
 
-Status (2026-05-13): **REMAINING**. The new generic plumbing delivered in PRs #21, #22, and #24 makes isolation safer, but the issue/workflow preservation layer has not been reframed yet.
+Status (2026-05-13): **DONE in fd-reframe-p4**. Core/session dependency language is isolated from issue mode, issue commands remain grouped under `Issue workflows`, and termination now routes by tracked-entry kind so generic ad-hoc sessions do not require GitHub/Linear/worktree/project-management.
 
-1. **[REMAINING]** Keep `flightdeck start [ISSUE_ID]`, `start new`, `parallel-check`, merge planning, and termination summary as issue-mode workflows.
-2. **[REMAINING]** Move required dependency language:
+1. **[DONE]** Keep `flightdeck start [ISSUE_ID]`, `start new`, `parallel-check`, merge planning, and termination summary as issue-mode workflows. `SKILL.md` keeps these under `Issue workflows` and adds explicit `merge-plan`, `close-issue`, and `terminate` rows.
+2. **[DONE]** Move required dependency language:
    - Core Flightdeck requires tmux and harness adapters only.
    - Issue mode requires `github`, `linear`, `project-management`, and `worktree` as applicable.
-3. **[REMAINING]** In `SKILL.md`, change required setup:
+3. **[DONE]** In `SKILL.md`, change required setup:
    - Always verify `$TMUX`.
-   - Load GitHub/Linear/project-management only when entering issue workflow commands.
-4. **[REMAINING]** Keep issue commands in command table under `Issue workflows`.
-5. **[REMAINING]** Add new generic commands under `Session management`:
+   - Load GitHub/Linear/project-management/worktree only when entering issue workflow commands.
+   - Generic session commands explicitly skip those loads.
+4. **[DONE]** Keep issue commands in command table under `Issue workflows`.
+5. **[DONE]** Add new generic commands under `Session management`:
    - `session start`
    - `session attach`
    - `session watch`
    - `session status`
    - `session stop` / `session remove`
-6. **[REMAINING]** Update termination behavior:
+6. **[DONE]** Update termination behavior:
    - Generic sessions end with a session summary, not merge summary.
    - Issue sessions still produce the current issue/PR/new-issue recommendation summary.
-7. **[REMAINING]** Keep `pr-conflict-graph`, `parallel-groups`, and issue decision biases untouched except for namespacing/docs.
+   - Mixed sessions produce both.
+7. **[DONE]** Keep `pr-conflict-graph`, `parallel-groups`, and issue decision biases untouched except for namespacing/docs.
 
 Validation:
 
-- Run focused issue-mode tests and at least one live issue-mode smoke before any default flip.
-- Run generic ad-hoc smoke without Linear/GitHub credentials to prove core mode does not require them.
+- **[DONE]** Added `skills/flightdeck/lib/flightdeck-core/tests/parity/terminate-session.test.ts` covering issue-only, ad-hoc-only, and mixed termination summaries, including the no-credentials generic smoke.
+- **[DONE]** Run `cd skills/flightdeck/lib/flightdeck-core && bun test && bun run typecheck` in clean and polluted env before merging this phase.
+- **[PARTIAL]** Live issue-mode smoke is not part of this default-preserving change; still required before any future default flip.
 
 ### Phase 5 — Reframe Pi dashboard and UI language
 

--- a/skills/flightdeck/README.md
+++ b/skills/flightdeck/README.md
@@ -1,18 +1,18 @@
 # Flightdeck
 
-Hands-off orchestration for parallel AI dev sessions. When you spawn multiple coding agents to work on different issues at the same time, flightdeck supervises all of them, answers their prompts with sensible defaults, plans the merge order around file conflicts, and only interrupts you when something genuinely needs a human.
+Generic tmux session management for AI harness panes, plus optional issue-mode orchestration. In core session mode, Flightdeck launches or attaches tmux-window sessions, tracks stable panes, routes prompts, and summarizes completion. In issue mode, it adds GitHub/Linear/worktree decisions, merge planning, and next-cycle recommendations.
 
 > Agents reading this: you want `SKILL.md` instead. Hacking on flightdeck itself: see [`DEVELOPMENT.md`](./DEVELOPMENT.md).
 
 ## The problem
 
-Running one agent at a time is fine. Running five at once is chaos — each one keeps stopping to ask *"should I clean this up?"* or *"the bot review timed out, abort?"*, and the order you merge them in turns into a guessing game. Flightdeck handles the supervisory layer so you can spawn a whole cycle's worth of work and walk away.
+Running one agent at a time is fine. Running five at once is chaos — each one keeps stopping to ask questions, background tasks finish at odd times, and issue-mode merge order can turn into a guessing game. Flightdeck handles the supervisory layer so you can track generic sessions or spawn a whole issue cycle and walk away.
 
-Activates only inside tmux and only when you ask for it (`flightdeck start` from your harness). Outside tmux it's a no-op.
+Activates only inside tmux and only when you ask for it (`flightdeck session start|attach` for core sessions, `flightdeck start` for issue workflows). Outside tmux it's a no-op.
 
 ## How it works
 
-Flightdeck spawns each agent into its own tmux window via `open-terminal`, then watches all of them in parallel. For each agent it picks the cleanest available communication channel:
+Flightdeck launches generic sessions with `flightdeck-session` or issue agents with `open-terminal`, always into their own tmux windows, then watches them in parallel. For each tracked pane it picks the cleanest available communication channel:
 
 | Harness | How flightdeck talks to that agent |
 | --- | --- |
@@ -32,13 +32,13 @@ The watch layer is split into two modes:
 
 Issue-only prompt tags on ad-hoc sessions are guarded as `domain-mismatch`: Flightdeck logs a warning, takes no destructive action, and asks the master/user how to proceed. Missing kind now fails closed by default, and lookup misses should pass `--entry-kind-unknown`; legacy issue callers must explicitly opt in with `--allow-missing-kind` while they migrate.
 
-When every tracked issue is merged, aborted, or otherwise terminal, flightdeck writes a session summary — including any new issues the agents created along the way and a recommendation about what to tackle next — and hands control back.
+When tracked entries are terminal, Flightdeck writes a summary and hands control back. Generic-only sessions get a local session summary. Sessions with any issue entries keep the issue/PR/new-issue recommendation summary; mixed sessions include both.
 
 ## Activation and termination
 
-- **Activates** on `flightdeck start` from your harness inside tmux. Single issue or many — flightdeck supervises whatever you spawn.
-- **Pauses** for you on: scope creep that wants reverting, force-merging against a real content conflict, an issue abort, a `main` mutation that needs human OK, or a novel prompt shape no rule covers. Sets `paused_for_user` in state and stops polling. Resume by running `watch` again.
-- **Terminates** automatically when every tracked issue is in a terminal state for two consecutive poll cycles. Writes a summary, archives the state file, hands control back.
+- **Activates** on `flightdeck session start|attach` for generic tracked sessions, or `flightdeck start` for issue workflows, from inside tmux.
+- **Pauses** for you on: scope creep that wants reverting, force-merging against a real content conflict, an issue abort, a `main` mutation that needs human OK, domain mismatch, or a novel prompt shape no rule covers. Sets `paused_for_user` in state and stops polling. Resume by running `session watch` or issue `watch` again.
+- **Terminates** automatically when every tracked entry is terminal for the relevant mode. Generic-only sessions write a session summary with no GitHub/Linear/worktree calls. Issue sessions write the issue summary, archive the state file, and hand control back.
 
 ## Ad-hoc sessions
 
@@ -87,9 +87,11 @@ cd /path/to/your/project
 vstack add vanillagreencom/vstack --skill flightdeck -y
 ```
 
-Pulls in required dependencies (`github`, `linear`, `project-management`).
+Core mode requires tmux only at the workflow/skill-dependency layer, plus the harness adapter you choose for a tracked pane (`pi-bridge`, OpenCode HTTP, Claude Channels, Codex app-server, or tmux fallback). It does not require GitHub, Linear credentials, project-management, or worktree setup.
 
-System requirements: `bash` 4+, `tmux` 3.x, `jq`, `gh`, `flock`, and `bun` (https://bun.sh). Mac users: install GNU coreutils for `sha256sum` and GNU date.
+Issue mode adds the optional `github`, `linear`, `worktree`, and `project-management` skills on demand for `flightdeck start <ISSUE>`, `start new`, `parallel-check`, `merge-plan`, `close-issue`, and issue termination/recommendation workflows.
+
+Runtime requirements for the shipped core scripts remain `bash` 4+, `tmux` 3.x, `jq`, `flock`, and `bun` (https://bun.sh). Issue mode additionally needs the GitHub/Linear CLIs or auth wrappers used by those skills, plus normal git worktree support. Mac users: install GNU coreutils for `sha256sum` and GNU date.
 
 ## Pi dashboard (optional)
 
@@ -154,7 +156,7 @@ You don't run any of these by hand in normal use — the skill calls them.
 - `flightdeck-daemon` — background poller; wakes the master.
 - `pane-registry`, `pane-poll`, `pane-respond` — pane tracking and IO.
 - `prompt-classify` — pattern-matches agent output against known prompt shapes and guards issue-only tags on non-issue entries as `domain-mismatch`.
-- `pr-conflict-graph`, `parallel-groups` — merge-order planning.
+- `pr-conflict-graph`, `parallel-groups` — issue-mode merge-order planning.
 - `codex-app-server-spawn` / `-stop` — Codex bridge server lifecycle.
 
 See [`DEVELOPMENT.md`](./DEVELOPMENT.md) for the full script list with descriptions.

--- a/skills/flightdeck/SKILL.md
+++ b/skills/flightdeck/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: flightdeck
-description: "Master session lifecycle for multi-issue parallel dev work: dashboard, spawn, oversee tmux panes, answer prompts, plan merges, drive every tracked issue to merged or aborted."
+description: "Generic tmux session manager for AI harness panes; optional issue mode supervises issue/PR workflows, prompt handling, merge planning, and unwind."
 license: MIT
 user-invocable: true
 dependencies:
-  required: [github, linear, project-management]
-  optional: [decider, worktree]
+  required: []
+  optional: [decider, github, linear, project-management, worktree]
 metadata:
   author: vanillagreen
   version: "0.2.0"
@@ -17,10 +17,26 @@ metadata:
 
 ## STOP — Required Setup
 
-1. Verify `$TMUX` is set. If unset, **exit immediately with no-op**: print `Flightdeck requires tmux; skipping.` and return control to the caller. Flightdeck does nothing outside tmux.
-2. Load `github`, `linear`, and `project-management` skills if not already loaded. Redundant loads are no-ops.
+1. Verify `$TMUX` is set for every Flightdeck command. If unset, **exit immediately with no-op**: print `Flightdeck requires tmux; skipping.` and return control to the caller. Flightdeck does nothing outside tmux.
+2. Determine the command mode before loading dependencies:
+   - Generic session commands (`session start`, `session attach`, `session watch`, `session status`, `session stop`, `session remove`) require only tmux plus the selected harness adapter (`pi-bridge`, OpenCode HTTP, Claude Channels, Codex app-server, or tmux fallback). Do **not** load `github`, `linear`, `project-management`, or `worktree` for generic session commands.
+   - Issue workflow commands (`start [ISSUE_ID]`, `start new`, `parallel-check`, issue `watch`, `merge-plan`, `close-issue`, `terminate` when any tracked entry is `kind=issue`) load `github`, `linear`, `project-management`, and `worktree` on demand. Redundant loads are no-ops.
+3. If an issue workflow dependency cannot be loaded after entering issue mode, stop and tell the user. Do not proceed with issue/PR/worktree actions without it.
 
-If a required skill cannot be loaded, stop and tell the user. Do not proceed without them.
+---
+
+## Dependency modes
+
+Core Flightdeck is a generic session manager. It requires tmux and the harness adapters needed for the tracked panes only; it does not require GitHub, Linear, project-management, or worktree skills.
+
+### Issue-mode dependencies (load when entering issue workflows)
+
+- `github` — PR inspection, merge state, checks, review threads, file lists.
+- `linear` — issue metadata, created follow-ups, cycle/todo recommendation checks.
+- `worktree` — issue branch/worktree ownership and cleanup scope.
+- `project-management` — cycle planning, audits, roadmaps, research issue wrappers used by issue workflows.
+
+`decider` remains optional for agents that want an extra decision aid, but core session management does not require it.
 
 ---
 
@@ -51,16 +67,21 @@ Generic tmux-window session tracking. These commands do not require a fake issue
 
 ### Issue workflows
 
+Issue/PR/worktree workflows. Entering these commands loads the issue-mode dependencies on demand.
+
 | Command | Arguments | Workflow | Notes |
 |---------|-----------|----------|-------|
-| `start` | `[ISSUE_ID]` | `workflows/start.md` | From-main entry. Dashboard, issue selection, research evaluation, parallel-check, spawn (`open-terminal`), enter watch loop. |
-| `start new` | `[title]` | `workflows/start-new.md` | Create new issue + spawn. |
-| `start self` | — | inline | Initialize master session only, await further commands. |
-| `parallel-check` | `[ISSUE_IDS]` | `workflows/parallel-check.md` | Verify a candidate set is safe to spawn in parallel. |
-| `watch` | `[ISSUE_IDS]` | `workflows/watch.md` → `workflows/session-watch.md` | Issue-mode extension over the generic session loop. Loads issue skills, keeps legacy issue states, routes PR/Linear/worktree handlers, and resumes merge planning. |
+| `start` | `[ISSUE_ID]` | `workflows/start.md` | From-main issue entry. Dashboard, issue selection, research evaluation, parallel-check, spawn (`open-terminal`), enter issue watch loop. |
+| `start new` | `[title]` | `workflows/start-new.md` | Create new issue + spawn through the issue workflow path. |
+| `start self` | — | inline | Initialize master issue session only, await further issue commands. |
+| `parallel-check` | `[ISSUE_IDS]` | `workflows/parallel-check.md` | Verify a candidate issue set is safe to spawn in parallel. |
+| `watch` | `[ISSUE_IDS]` | `workflows/watch.md` → `workflows/session-watch.md` | Issue-mode extension over the generic loop. Keeps legacy issue states, routes PR/Linear/worktree handlers, and resumes merge planning. |
+| `merge-plan` | — | `workflows/merge-plan.md` | Build PR conflict graph and choose smallest-safe merge order for issue entries. |
+| `close-issue` | `<ISSUE_ID>` | `workflows/close-issue.md` | Verify terminal issue outcome, record issue fields, and tear down the issue window safely. |
+| `terminate` | — | `workflows/terminate.md` | If any tracked entry is `kind=issue`, produce the issue/PR/new-issue recommendation summary; mixed sessions also include generic session summary. |
 | `status` | — | inline | Print current pane registry + state machine snapshot from `tmp/flightdeck-state-<TMUX_SESSION>.json`. Read-only. |
 
-### Planning (cross-call to `project-management`)
+### Planning (cross-call to `project-management`, issue mode only)
 
 | Command | Workflow | Notes |
 |---------|----------|-------|
@@ -162,7 +183,7 @@ The daemon (`scripts/flightdeck-daemon.bash` + `lib/flightdeck-core/src/daemon/l
 
 ## Schema — master state
 
-Master state lives at `<project-root>/<FLIGHTDECK_STATE_DIR>/flightdeck-state-<TMUX_SESSION_NAME>.json` (default `tmp/`). Survives compaction; rotated to `*-<terminated_at>.json.archive` on terminate (see `terminate.md § 5`). The archive preserves the full `.issues` map (including merged-issue `decisions_log`, `pr_number`, `merge_commit`) so post-completion dashboards and post-mortem inspection have the whole session history — do not call `pane-registry remove-merged` between `set terminated true` and `archive`. pi-flightdeck's `buildSnapshot` falls back to the newest matching `*.json.archive` when the live file is gone, so the completed-session view in the dashboard / popup keeps rendering until a new `flightdeck start` rewrites the live file. Daemon-private files in `FD_STATE_DIR` are keyed by `SESSION_KEY=s<N>` instead (see `patterns/tmux-monitoring.md`).
+Master state lives at `<project-root>/<FLIGHTDECK_STATE_DIR>/flightdeck-state-<TMUX_SESSION_NAME>.json` (default `tmp/`). Survives compaction; rotated to `*-<terminated_at>.json.archive` on terminate (see `terminate.md § 6`). The archive preserves the full `.issues` map (including merged-issue `decisions_log`, `pr_number`, `merge_commit`) so post-completion dashboards and post-mortem inspection have the whole session history — do not call `pane-registry remove-merged` between `set terminated true` and `archive`. pi-flightdeck's `buildSnapshot` falls back to the newest matching `*.json.archive` when the live file is gone, so the completed-session view in the dashboard / popup keeps rendering until a new `flightdeck start` rewrites the live file. Daemon-private files in `FD_STATE_DIR` are keyed by `SESSION_KEY=s<N>` instead (see `patterns/tmux-monitoring.md`).
 
 Schema `1.1` is additive. `flightdeck-state init` writes `schema_version: 1.1`, keeps the v1 `.issues`, `.merge_queue`, and `.conflict_graph` fields, and adds `.entries` for the neutral `TrackedEntry` model. Older v1 readers ignore `schema_version` and `.entries`; issue-mode readers continue using `.issues`. New core readers must call `readTrackedEntries(state)` instead of touching `.issues` directly: it projects legacy `.issues` records first, then overlays valid `.entries` records by id so `.entries` wins on collisions but issue-only legacy updates remain visible. Malformed non-object `.entries` values are skipped with a stderr warning; malformed internal `entry.id` values warn and fall back to the map key. `writeTrackedEntry(state, id, entry)` validates non-empty ids, including `entry.domain.issue.id` when present, writes `.entries[id]`, and projects `kind: "issue"` entries back to `.issues[issueId]` for compatibility. Unknown future `schema_version` values warn on read (including `phase`) and refuse writes unless `FLIGHTDECK_ALLOW_FUTURE_SCHEMA=1` is set. This mirrors the pi-flightdeck render seam; do not fork renderer-only `.issues` reads back into core logic.
 
@@ -302,7 +323,7 @@ TS-port toggles:
 | `workflows/handle-prompt.md` | Nested invocation from issue `watch` for issue-only tags | PR/Linear/worktree prompt response surface only |
 | `workflows/close-issue.md` | Nested invocation from `watch` § 2 on `terminal-state-reached` | Verify two-signal terminal state, update master state, kill window, keep registry entry for terminate reporting/final cleanup |
 | `workflows/merge-plan.md` | Nested invocation from `watch` § 4 | Conflict-graph build + smallest-first merge ordering |
-| `workflows/terminate.md` | Nested invocation from `watch` § 6 | Final summary, new-issues report, next-cycle recommendation, master-state finalization |
+| `workflows/terminate.md` | Nested invocation from issue `watch` or generic session unwind | Generic session summary for ad-hoc/workflow entries; issue/PR/new-issues recommendation summary when any issue entry exists; master-state finalization |
 
 ## Workflow Execution
 
@@ -325,7 +346,7 @@ Nested workflows (marked with `⤵`) must be invoked through the harness's workf
 3. **Add nothing else** — no commentary, no extra fields, no rewording, no explanations before or after the content.
 4. **Do not paraphrase** — use the exact structure, headings, and field names from the tag.
 
-The user-visible output blocks at the end of `terminate.md` and `close-issue.md` are `<output_format>` tagged for this reason: the agent must emit them in full, not collapse to a summary line.
+The user-visible output blocks at the end of `terminate.md` (`<generic_output_format>` / `<issue_output_format>`) and `close-issue.md` (`<output_format>`) are tagged for this reason: the agent must emit them in full, not collapse to a summary line.
 
 ## Implementation Constraints
 

--- a/skills/flightdeck/SKILL.md
+++ b/skills/flightdeck/SKILL.md
@@ -42,10 +42,14 @@ Core Flightdeck is a generic session manager. It requires tmux and the harness a
 
 ## Mode
 
-You are in **master mode**. Observe-and-direct only:
+You are in **master mode**. Observe-and-direct only.
+
+Generic session mode is the core path: launch/attach with `flightdeck-session`, supervise with `session-watch.md`, answer generic prompts, and summarize sessions. It skips issue selection, research/plan evaluation, `open-terminal`, merge planning, GitHub/Linear/worktree actions, and project-management flows.
+
+Issue-mode global arc begins only after entering an Issue workflows command:
 
 - **You do NOT** write code in worktrees, run builds/tests, or invoke per-issue orchestration workflows (`bot-review-wait`, `ci-wait`, `merge-pr`, etc.). Per-issue work happens inside the spawned panes; you supervise.
-- **You DO** own the master arc end to end — dashboard → research/plan evaluation → spawn (`open-terminal`) → watch loop → merge planning → unwind — and answer prompts that surface from the spawned panes via `pane-respond`.
+- **You DO** own the issue-mode master arc end to end — dashboard → research/plan evaluation → spawn (`open-terminal`) → watch loop → merge planning → unwind — and answer prompts that surface from the spawned panes via `pane-respond`.
 - **You communicate with spawned agents through their native channels**: opencode via HTTP `/session/<id>/message`, claude via Channels MCP push + JSONL tail, pi via Unix-socket bridge, codex via JSON-RPC over WebSocket. `pane-respond` routes into the matching send path. Tmux `capture-pane` / `send-keys` is only the fallback when the channel is unavailable (see `patterns/tmux-monitoring.md`).
 - **You pause for the user only on**: scope creep that requires reverting agent work, force-merging against a real content conflict (not `UNKNOWN`), an issue abort, flightdeck mutating `main` directly when no orchestrator pane is alive, or a novel prompt shape no rule covers.
 - **You do NOT re-implement orchestration gates**. When the orchestrator surfaces a prompt (merge-now, audit-relation, fix-suggestions), its upstream conditions are already checked. Answer the prompt; don't re-validate CI / mergeable / thread state. The only checks master adds are cross-session conflict graph and multi-pane scope drift — things only master sees.
@@ -346,7 +350,7 @@ Nested workflows (marked with `⤵`) must be invoked through the harness's workf
 3. **Add nothing else** — no commentary, no extra fields, no rewording, no explanations before or after the content.
 4. **Do not paraphrase** — use the exact structure, headings, and field names from the tag.
 
-The user-visible output blocks at the end of `terminate.md` (`<generic_output_format>` / `<issue_output_format>`) and `close-issue.md` (`<output_format>`) are tagged for this reason: the agent must emit them in full, not collapse to a summary line.
+The user-visible output blocks at the end of `terminate.md` (`<generic_output_format>` / `<empty_output_format>` / `<issue_output_format>`) and `close-issue.md` (`<output_format>`) are tagged for this reason: the agent must emit them in full, not collapse to a summary line.
 
 ## Implementation Constraints
 

--- a/skills/flightdeck/lib/flightdeck-core/src/terminate/session-summary.ts
+++ b/skills/flightdeck/lib/flightdeck-core/src/terminate/session-summary.ts
@@ -1,0 +1,124 @@
+import { readTrackedEntries } from "../state/tracked-entry.ts";
+import type { FlightdeckStateLike, TrackedEntry } from "../state/types.ts";
+
+export interface TerminationPartition {
+	genericEntries: TrackedEntry[];
+	issueEntries: TrackedEntry[];
+}
+
+export interface TerminationSummaryOptions {
+	session?: string;
+	timestamp?: string;
+	summaryPath?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function issueDomain(entry: TrackedEntry): Record<string, unknown> | undefined {
+	const domain = isRecord(entry.domain) ? entry.domain : undefined;
+	const issue = domain && isRecord(domain.issue) ? domain.issue : undefined;
+	return issue;
+}
+
+function isIssueEntry(entry: TrackedEntry): boolean {
+	return entry.kind === "issue" || typeof issueDomain(entry)?.id === "string";
+}
+
+export function partitionTerminationEntries(state: FlightdeckStateLike): TerminationPartition {
+	const entries = Object.values(readTrackedEntries(state));
+	const issueEntries = entries.filter(isIssueEntry);
+	const genericEntries = entries.filter((entry) => !isIssueEntry(entry));
+	return { genericEntries, issueEntries };
+}
+
+function decisionCount(entry: TrackedEntry): number {
+	return Array.isArray(entry.decisions_log) ? entry.decisions_log.length : 0;
+}
+
+function stringField(value: unknown, fallback = "—"): string {
+	return typeof value === "string" && value.trim() ? value.trim() : fallback;
+}
+
+function issueId(entry: TrackedEntry): string {
+	const issue = issueDomain(entry);
+	return stringField(issue?.id, entry.id);
+}
+
+function issuePr(entry: TrackedEntry): string {
+	const issue = issueDomain(entry);
+	const pr = typeof issue?.pr_number === "number" ? issue.pr_number : (typeof entry.pr_number === "number" ? entry.pr_number : null);
+	return pr === null ? "—" : `#${pr}`;
+}
+
+function issueMergeCommit(entry: TrackedEntry): string {
+	const issue = issueDomain(entry);
+	const raw = typeof entry.merge_commit === "string" ? entry.merge_commit : typeof issue?.merge_commit === "string" ? issue.merge_commit : "";
+	return raw ? raw.slice(0, 12) : "—";
+}
+
+function issueState(entry: TrackedEntry): string {
+	const issue = issueDomain(entry);
+	const outcome = issue && typeof issue.outcome === "string" ? issue.outcome : "";
+	if (outcome) return outcome;
+	return stringField(entry.state, "unknown");
+}
+
+function summaryPath(opts: TerminationSummaryOptions): string {
+	if (opts.summaryPath) return opts.summaryPath;
+	const session = opts.session ?? "SESSION";
+	const ts = (opts.timestamp ?? "TS").replace(/:/g, "");
+	return `tmp/flightdeck-summary-${session}-${ts}.md`;
+}
+
+export function renderGenericTerminationSummary(entries: TrackedEntry[], opts: TerminationSummaryOptions = {}): string {
+	const rows = entries.map((entry) => `| ${entry.id} | ${stringField(entry.kind)} | ${stringField(entry.state, "unknown")} | ${stringField(entry.harness)} | ${decisionCount(entry)} |`);
+	const complete = entries.filter((entry) => entry.state === "complete").length;
+	const cancelled = entries.filter((entry) => entry.state === "cancelled").length;
+	const dead = entries.filter((entry) => entry.state === "dead").length;
+	return [
+		"### ✈️ Flightdeck sessions complete",
+		"",
+		"**Tracked sessions**",
+		"",
+		"| Entry | Kind | State | Harness | Decisions |",
+		"|-------|------|-------|---------|-----------|",
+		...(rows.length ? rows : ["| — | — | — | — | 0 |"]),
+		"",
+		`**Counts**: ${entries.length} sessions · ${complete} complete · ${cancelled} cancelled · ${dead} dead`,
+		"",
+		`Summary file: \`${summaryPath(opts)}\``,
+	].join("\n");
+}
+
+export function renderIssueTerminationSummary(entries: TrackedEntry[], opts: TerminationSummaryOptions = {}): string {
+	const rows = entries.map((entry) => `| ${issueId(entry)} | ${issueState(entry)} | ${issuePr(entry)} | ${issueMergeCommit(entry)} | ${decisionCount(entry)} |`);
+	const merged = entries.filter((entry) => issueState(entry) === "merged").length;
+	const aborted = entries.filter((entry) => issueState(entry) === "aborted").length;
+	return [
+		"### ✈️ Flightdeck session complete",
+		"",
+		"**Outcomes**",
+		"",
+		"| Issue | State | PR | Merge commit | Decisions |",
+		"|-------|-------|----|--------------|-----------|",
+		...(rows.length ? rows : ["| — | — | — | — | 0 |"]),
+		"",
+		"**Next-cycle recommendation**",
+		"",
+		"- Stick with planned cycle — no created issues warrant precedence.",
+		"",
+		`**Counts**: ${merged} merged · ${aborted} aborted · 0 children · 0 follow-ups · 0 recommended next`,
+		"",
+		`Summary file: \`${summaryPath(opts)}\``,
+	].join("\n");
+}
+
+export function renderTerminationSummary(state: FlightdeckStateLike, opts: TerminationSummaryOptions = {}): string {
+	const { genericEntries, issueEntries } = partitionTerminationEntries(state);
+	const sections: string[] = [];
+	if (genericEntries.length > 0) sections.push(renderGenericTerminationSummary(genericEntries, opts));
+	if (issueEntries.length > 0) sections.push(renderIssueTerminationSummary(issueEntries, opts));
+	return sections.join("\n\n");
+}

--- a/skills/flightdeck/lib/flightdeck-core/src/terminate/session-summary.ts
+++ b/skills/flightdeck/lib/flightdeck-core/src/terminate/session-summary.ts
@@ -2,15 +2,39 @@ import { readTrackedEntries } from "../state/tracked-entry.ts";
 import type { FlightdeckStateLike, TrackedEntry } from "../state/types.ts";
 
 export interface TerminationPartition {
+	entryCount: number;
 	genericEntries: TrackedEntry[];
 	issueEntries: TrackedEntry[];
+	warnings: string[];
 }
 
-export interface TerminationSummaryOptions {
+export interface TerminationPartitionOptions {
+	warn?: (message: string) => void;
+}
+
+export interface TerminationSummaryOptions extends TerminationPartitionOptions {
 	session?: string;
 	timestamp?: string;
 	summaryPath?: string;
 }
+
+const ISSUE_STATES = new Set(["merge-ready", "merged", "aborted"]);
+const ISSUE_SUBSTATES = new Set([
+	"audit-relation-prompt",
+	"bot-review-wait-stuck",
+	"cleanup-prompt",
+	"cycle-fix-suggestions",
+	"descope-related",
+	"external-fix-suggestions",
+	"force-merge-confirm",
+	"force-push-prompt",
+	"merge-now",
+	"merge-ready-but-unknown",
+	"rebase-multi-choice",
+	"scope-creep-detected",
+	"stale-no-pr-branch",
+	"stale-orphan-worktree",
+]);
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return !!value && typeof value === "object" && !Array.isArray(value);
@@ -22,15 +46,55 @@ function issueDomain(entry: TrackedEntry): Record<string, unknown> | undefined {
 	return issue;
 }
 
-function isIssueEntry(entry: TrackedEntry): boolean {
-	return entry.kind === "issue" || typeof issueDomain(entry)?.id === "string";
+function hasNonEmptyString(value: unknown): boolean {
+	return typeof value === "string" && value.trim().length > 0;
 }
 
-export function partitionTerminationEntries(state: FlightdeckStateLike): TerminationPartition {
-	const entries = Object.values(readTrackedEntries(state));
-	const issueEntries = entries.filter(isIssueEntry);
-	const genericEntries = entries.filter((entry) => !isIssueEntry(entry));
-	return { genericEntries, issueEntries };
+function hasFiniteNumber(value: unknown): boolean {
+	return typeof value === "number" && Number.isFinite(value);
+}
+
+function issueMarkers(entry: TrackedEntry): string[] {
+	const markers: string[] = [];
+	const issue = issueDomain(entry);
+	if (hasNonEmptyString(issue?.id)) markers.push("domain.issue.id");
+	if (hasFiniteNumber(issue?.pr_number) || hasFiniteNumber(entry.pr_number)) markers.push("pr_number");
+	if (hasNonEmptyString(issue?.worktree) || hasNonEmptyString(entry.worktree)) markers.push("worktree");
+	if (hasNonEmptyString(issue?.merge_commit) || hasNonEmptyString(entry.merge_commit)) markers.push("merge_commit");
+	if (hasFiniteNumber(issue?.scope_files_declared) || hasFiniteNumber(issue?.scope_files_actual)) markers.push("scope_files");
+	if (typeof issue?.orchestration_started === "boolean" || typeof entry.orchestration_started === "boolean") markers.push("orchestration_started");
+	if (typeof entry.state === "string" && ISSUE_STATES.has(entry.state)) markers.push(`state:${entry.state}`);
+	if (typeof entry.substate === "string" && ISSUE_SUBSTATES.has(entry.substate)) markers.push(`substate:${entry.substate}`);
+	return [...new Set(markers)];
+}
+
+function warn(message: string, opts: TerminationPartitionOptions, warnings: string[]): void {
+	warnings.push(message);
+	if (opts.warn) opts.warn(message);
+	else process.stderr.write(`${message}\n`);
+}
+
+function classifyEntry(entry: TrackedEntry, opts: TerminationPartitionOptions, warnings: string[]): "generic" | "issue" {
+	if (entry.kind === "issue") return "issue";
+	if (hasNonEmptyString(issueDomain(entry)?.id)) return "issue";
+	const markers = issueMarkers(entry).filter((marker) => marker !== "domain.issue.id");
+	if (markers.length > 0) {
+		warn(`Warning: issue-shaped tracked entry ${JSON.stringify(entry.id)} missing kind=issue/domain.issue.id; routing through issue termination path (${markers.join(", ")}).`, opts, warnings);
+		return "issue";
+	}
+	return "generic";
+}
+
+export function partitionTerminationEntries(state: FlightdeckStateLike, opts: TerminationPartitionOptions = {}): TerminationPartition {
+	const warnings: string[] = [];
+	const entries = Object.values(readTrackedEntries(state, { warn: (message) => warn(message, opts, warnings) }));
+	const issueEntries: TrackedEntry[] = [];
+	const genericEntries: TrackedEntry[] = [];
+	for (const entry of entries) {
+		if (classifyEntry(entry, opts, warnings) === "issue") issueEntries.push(entry);
+		else genericEntries.push(entry);
+	}
+	return { entryCount: entries.length, genericEntries, issueEntries, warnings };
 }
 
 function decisionCount(entry: TrackedEntry): number {
@@ -41,30 +105,6 @@ function stringField(value: unknown, fallback = "—"): string {
 	return typeof value === "string" && value.trim() ? value.trim() : fallback;
 }
 
-function issueId(entry: TrackedEntry): string {
-	const issue = issueDomain(entry);
-	return stringField(issue?.id, entry.id);
-}
-
-function issuePr(entry: TrackedEntry): string {
-	const issue = issueDomain(entry);
-	const pr = typeof issue?.pr_number === "number" ? issue.pr_number : (typeof entry.pr_number === "number" ? entry.pr_number : null);
-	return pr === null ? "—" : `#${pr}`;
-}
-
-function issueMergeCommit(entry: TrackedEntry): string {
-	const issue = issueDomain(entry);
-	const raw = typeof entry.merge_commit === "string" ? entry.merge_commit : typeof issue?.merge_commit === "string" ? issue.merge_commit : "";
-	return raw ? raw.slice(0, 12) : "—";
-}
-
-function issueState(entry: TrackedEntry): string {
-	const issue = issueDomain(entry);
-	const outcome = issue && typeof issue.outcome === "string" ? issue.outcome : "";
-	if (outcome) return outcome;
-	return stringField(entry.state, "unknown");
-}
-
 function summaryPath(opts: TerminationSummaryOptions): string {
 	if (opts.summaryPath) return opts.summaryPath;
 	const session = opts.session ?? "SESSION";
@@ -72,7 +112,20 @@ function summaryPath(opts: TerminationSummaryOptions): string {
 	return `tmp/flightdeck-summary-${session}-${ts}.md`;
 }
 
+export function renderEmptyTerminationSummary(opts: TerminationSummaryOptions = {}): string {
+	return [
+		"### ✈️ Flightdeck session complete",
+		"",
+		"Session terminated with no tracked entries.",
+		"",
+		"**Counts**: 0 sessions · 0 complete · 0 cancelled · 0 dead",
+		"",
+		`Summary file: \`${summaryPath(opts)}\``,
+	].join("\n");
+}
+
 export function renderGenericTerminationSummary(entries: TrackedEntry[], opts: TerminationSummaryOptions = {}): string {
+	if (entries.length === 0) return renderEmptyTerminationSummary(opts);
 	const rows = entries.map((entry) => `| ${entry.id} | ${stringField(entry.kind)} | ${stringField(entry.state, "unknown")} | ${stringField(entry.harness)} | ${decisionCount(entry)} |`);
 	const complete = entries.filter((entry) => entry.state === "complete").length;
 	const cancelled = entries.filter((entry) => entry.state === "cancelled").length;
@@ -84,7 +137,7 @@ export function renderGenericTerminationSummary(entries: TrackedEntry[], opts: T
 		"",
 		"| Entry | Kind | State | Harness | Decisions |",
 		"|-------|------|-------|---------|-----------|",
-		...(rows.length ? rows : ["| — | — | — | — | 0 |"]),
+		...rows,
 		"",
 		`**Counts**: ${entries.length} sessions · ${complete} complete · ${cancelled} cancelled · ${dead} dead`,
 		"",
@@ -92,33 +145,9 @@ export function renderGenericTerminationSummary(entries: TrackedEntry[], opts: T
 	].join("\n");
 }
 
-export function renderIssueTerminationSummary(entries: TrackedEntry[], opts: TerminationSummaryOptions = {}): string {
-	const rows = entries.map((entry) => `| ${issueId(entry)} | ${issueState(entry)} | ${issuePr(entry)} | ${issueMergeCommit(entry)} | ${decisionCount(entry)} |`);
-	const merged = entries.filter((entry) => issueState(entry) === "merged").length;
-	const aborted = entries.filter((entry) => issueState(entry) === "aborted").length;
-	return [
-		"### ✈️ Flightdeck session complete",
-		"",
-		"**Outcomes**",
-		"",
-		"| Issue | State | PR | Merge commit | Decisions |",
-		"|-------|-------|----|--------------|-----------|",
-		...(rows.length ? rows : ["| — | — | — | — | 0 |"]),
-		"",
-		"**Next-cycle recommendation**",
-		"",
-		"- Stick with planned cycle — no created issues warrant precedence.",
-		"",
-		`**Counts**: ${merged} merged · ${aborted} aborted · 0 children · 0 follow-ups · 0 recommended next`,
-		"",
-		`Summary file: \`${summaryPath(opts)}\``,
-	].join("\n");
-}
-
-export function renderTerminationSummary(state: FlightdeckStateLike, opts: TerminationSummaryOptions = {}): string {
-	const { genericEntries, issueEntries } = partitionTerminationEntries(state);
-	const sections: string[] = [];
-	if (genericEntries.length > 0) sections.push(renderGenericTerminationSummary(genericEntries, opts));
-	if (issueEntries.length > 0) sections.push(renderIssueTerminationSummary(issueEntries, opts));
-	return sections.join("\n\n");
+export function renderGenericTerminationSummaryFromState(state: FlightdeckStateLike, opts: TerminationSummaryOptions = {}): string {
+	const { entryCount, genericEntries } = partitionTerminationEntries(state, opts);
+	if (entryCount === 0) return renderEmptyTerminationSummary(opts);
+	if (genericEntries.length === 0) return "";
+	return renderGenericTerminationSummary(genericEntries, opts);
 }

--- a/skills/flightdeck/lib/flightdeck-core/tests/parity/terminate-session.test.ts
+++ b/skills/flightdeck/lib/flightdeck-core/tests/parity/terminate-session.test.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 
 import {
 	partitionTerminationEntries,
-	renderTerminationSummary,
+	renderGenericTerminationSummaryFromState,
 } from "../../src/terminate/session-summary.ts";
 import type { FlightdeckStateLike } from "../../src/state/types.ts";
 
@@ -52,6 +52,22 @@ function issueEntry(id = "FD-401"): Record<string, unknown> {
 	};
 }
 
+function legacyIssueShapedEntry(id = "FD-402"): Record<string, unknown> {
+	return {
+		id,
+		title: "Issue-shaped malformed entry",
+		kind: "adhoc",
+		state: "merged",
+		harness: "pi",
+		pr_number: 402,
+		worktree: "/repo/trees/fd-402",
+		merge_commit: "fedcba6543210000",
+		decisions_log: [
+			{ ts: "2026-05-13T00:12:00Z", prompt_tag: "terminal-state-reached", answer: "merged" },
+		],
+	};
+}
+
 function adhocEntry(id = "scratch-pi"): Record<string, unknown> {
 	return {
 		id,
@@ -75,18 +91,20 @@ describe("terminate session summary split", () => {
 		timestamp: "2026-05-13T00:15:00Z",
 	};
 
-	test("issue-only session produces the issue merge summary", () => {
+	test("issue-only session routes to the existing issue markdown path, not the generic TS renderer", () => {
 		const state = baseState({ "FD-401": issueEntry() });
 		const partition = partitionTerminationEntries(state);
 		expect(partition.issueEntries.map((entry) => entry.id)).toEqual(["FD-401"]);
 		expect(partition.genericEntries).toEqual([]);
 
-		const output = renderTerminationSummary(state, opts);
-		expect(output).toContain("### ✈️ Flightdeck session complete");
-		expect(output).toContain("**Outcomes**");
-		expect(output).toContain("| FD-401 | merged | #401 | abcdef123456 | 2 |");
-		expect(output).toContain("**Next-cycle recommendation**");
-		expect(output).not.toContain("### ✈️ Flightdeck sessions complete");
+		const output = renderGenericTerminationSummaryFromState(state, opts);
+		expect(output).toBe("");
+
+		const doc = readFileSync(TERMINATE_MD, "utf8");
+		expect(doc).toContain("For issue entries, emit the existing issue summary block");
+		expect(doc).toContain("**Issues created this session**");
+		expect(doc).toContain("**Next-cycle recommendation**");
+		expect(doc).toContain("[For each recommended issue from § 4:]");
 	});
 
 	test("adhoc-only session produces generic session summary without issue dependencies", () => {
@@ -102,7 +120,7 @@ describe("terminate session summary split", () => {
 			expect(partition.issueEntries).toEqual([]);
 			expect(partition.genericEntries.map((entry) => entry.id)).toEqual(["scratch-pi"]);
 
-			const output = renderTerminationSummary(state, opts);
+			const output = renderGenericTerminationSummaryFromState(state, opts);
 			expect(output).toContain("### ✈️ Flightdeck sessions complete");
 			expect(output).toContain("**Tracked sessions**");
 			expect(output).toContain("| scratch-pi | adhoc | complete | pi | 1 |");
@@ -116,7 +134,7 @@ describe("terminate session summary split", () => {
 		}
 	});
 
-	test("mixed session produces generic and issue summaries", () => {
+	test("mixed session produces generic TS summary and leaves issue entries for markdown path", () => {
 		const state = baseState({
 			"FD-401": issueEntry(),
 			"scratch-pi": adhocEntry(),
@@ -125,18 +143,46 @@ describe("terminate session summary split", () => {
 		expect(partition.issueEntries.map((entry) => entry.id)).toEqual(["FD-401"]);
 		expect(partition.genericEntries.map((entry) => entry.id)).toEqual(["scratch-pi"]);
 
-		const output = renderTerminationSummary(state, opts);
+		const output = renderGenericTerminationSummaryFromState(state, opts);
 		expect(output).toContain("### ✈️ Flightdeck sessions complete");
 		expect(output).toContain("| scratch-pi | adhoc | complete | pi | 1 |");
-		expect(output).toContain("### ✈️ Flightdeck session complete");
-		expect(output).toContain("| FD-401 | merged | #401 | abcdef123456 | 2 |");
+		expect(output).not.toContain("| FD-401 |");
 	});
 
-	test("workflow doc routes termination by tracked-entry kind", () => {
+	test("issue-shaped entries without issue kind/domain fail closed into issue path with warning", () => {
+		const warnings: string[] = [];
+		const state = baseState({ "FD-402": legacyIssueShapedEntry() });
+		const partition = partitionTerminationEntries(state, { warn: (message) => warnings.push(message) });
+		expect(partition.issueEntries.map((entry) => entry.id)).toEqual(["FD-402"]);
+		expect(partition.genericEntries).toEqual([]);
+		expect(warnings).toHaveLength(1);
+		expect(warnings[0]).toContain("issue-shaped tracked entry");
+		expect(warnings[0]).toContain("routing through issue termination path");
+		expect(warnings[0]).toContain("pr_number");
+
+		const output = renderGenericTerminationSummaryFromState(state, { ...opts, warn: () => undefined });
+		expect(output).toBe("");
+	});
+
+	test("empty tracked entries produce explicit empty-session diagnostic", () => {
+		const state = baseState({});
+		const partition = partitionTerminationEntries(state);
+		expect(partition.entryCount).toBe(0);
+		expect(partition.issueEntries).toEqual([]);
+		expect(partition.genericEntries).toEqual([]);
+
+		const output = renderGenericTerminationSummaryFromState(state, opts);
+		expect(output).toContain("### ✈️ Flightdeck session complete");
+		expect(output).toContain("Session terminated with no tracked entries.");
+		expect(output).toContain("**Counts**: 0 sessions · 0 complete · 0 cancelled · 0 dead");
+	});
+
+	test("workflow doc routes termination by tracked-entry kind and documents empty sessions", () => {
 		const doc = readFileSync(TERMINATE_MD, "utf8");
 		expect(doc).toContain("Partition tracked entries by kind");
 		expect(doc).toContain("If `ISSUE_ENTRIES` is non-empty");
 		expect(doc).toContain("If `ISSUE_ENTRIES` is empty and `GENERIC_ENTRIES` is non-empty");
+		expect(doc).toContain("If both partitions are empty");
 		expect(doc).toContain("For mixed sessions");
 		expect(doc).toContain("Do not call `gh`, `linear`, worktree helpers, merge planning, or `project-management`");
 	});

--- a/skills/flightdeck/lib/flightdeck-core/tests/parity/terminate-session.test.ts
+++ b/skills/flightdeck/lib/flightdeck-core/tests/parity/terminate-session.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+	partitionTerminationEntries,
+	renderTerminationSummary,
+} from "../../src/terminate/session-summary.ts";
+import type { FlightdeckStateLike } from "../../src/state/types.ts";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const TERMINATE_MD = resolve(HERE, "../../../../workflows/terminate.md");
+
+function baseState(entries: Record<string, unknown>, issues: Record<string, unknown> = {}): FlightdeckStateLike {
+	return {
+		conflict_graph: { computed_at: null, edges: [] },
+		entries,
+		issues,
+		merge_queue: [],
+		paused_for_user: null,
+		schema_version: 1.1,
+		session_id: "TERM",
+		started_at: "2026-05-13T00:00:00Z",
+		terminated: false,
+	};
+}
+
+function issueEntry(id = "FD-401"): Record<string, unknown> {
+	return {
+		id,
+		title: "Issue workflow",
+		kind: "issue",
+		state: "merged",
+		harness: "pi",
+		cwd: "/repo/trees/fd-401",
+		pane_id: "%401",
+		pane_target: "TERM:4.0",
+		domain: {
+			issue: {
+				id,
+				worktree: "/repo/trees/fd-401",
+				pr_number: 401,
+				merge_commit: "abcdef1234567890",
+			},
+		},
+		decisions_log: [
+			{ ts: "2026-05-13T00:10:00Z", prompt_tag: "merge-now", answer: "Merge" },
+			{ ts: "2026-05-13T00:12:00Z", prompt_tag: "terminal-state-reached", answer: "merged" },
+		],
+		merge_commit: "abcdef1234567890",
+	};
+}
+
+function adhocEntry(id = "scratch-pi"): Record<string, unknown> {
+	return {
+		id,
+		title: "Scratch Pi",
+		kind: "adhoc",
+		state: "complete",
+		harness: "pi",
+		cwd: "/repo",
+		pane_id: "%77",
+		pane_target: "TERM:7.0",
+		decisions_log: [
+			{ ts: "2026-05-13T00:05:00Z", prompt_tag: "terminal-state-reached", answer: "complete" },
+		],
+	};
+}
+
+describe("terminate session summary split", () => {
+	const opts = {
+		session: "TERM",
+		summaryPath: "tmp/flightdeck-summary-TERM-2026-05-13T001500Z.md",
+		timestamp: "2026-05-13T00:15:00Z",
+	};
+
+	test("issue-only session produces the issue merge summary", () => {
+		const state = baseState({ "FD-401": issueEntry() });
+		const partition = partitionTerminationEntries(state);
+		expect(partition.issueEntries.map((entry) => entry.id)).toEqual(["FD-401"]);
+		expect(partition.genericEntries).toEqual([]);
+
+		const output = renderTerminationSummary(state, opts);
+		expect(output).toContain("### ✈️ Flightdeck session complete");
+		expect(output).toContain("**Outcomes**");
+		expect(output).toContain("| FD-401 | merged | #401 | abcdef123456 | 2 |");
+		expect(output).toContain("**Next-cycle recommendation**");
+		expect(output).not.toContain("### ✈️ Flightdeck sessions complete");
+	});
+
+	test("adhoc-only session produces generic session summary without issue dependencies", () => {
+		const oldGh = process.env.GH_TOKEN;
+		const oldGithub = process.env.GITHUB_TOKEN;
+		const oldLinear = process.env.LINEAR_API_KEY;
+		delete process.env.GH_TOKEN;
+		delete process.env.GITHUB_TOKEN;
+		delete process.env.LINEAR_API_KEY;
+		try {
+			const state = baseState({ "scratch-pi": adhocEntry() });
+			const partition = partitionTerminationEntries(state);
+			expect(partition.issueEntries).toEqual([]);
+			expect(partition.genericEntries.map((entry) => entry.id)).toEqual(["scratch-pi"]);
+
+			const output = renderTerminationSummary(state, opts);
+			expect(output).toContain("### ✈️ Flightdeck sessions complete");
+			expect(output).toContain("**Tracked sessions**");
+			expect(output).toContain("| scratch-pi | adhoc | complete | pi | 1 |");
+			expect(output).toContain("**Counts**: 1 sessions · 1 complete · 0 cancelled · 0 dead");
+			expect(output).not.toContain("**Outcomes**");
+			expect(output).not.toContain("Next-cycle recommendation");
+		} finally {
+			if (oldGh === undefined) delete process.env.GH_TOKEN; else process.env.GH_TOKEN = oldGh;
+			if (oldGithub === undefined) delete process.env.GITHUB_TOKEN; else process.env.GITHUB_TOKEN = oldGithub;
+			if (oldLinear === undefined) delete process.env.LINEAR_API_KEY; else process.env.LINEAR_API_KEY = oldLinear;
+		}
+	});
+
+	test("mixed session produces generic and issue summaries", () => {
+		const state = baseState({
+			"FD-401": issueEntry(),
+			"scratch-pi": adhocEntry(),
+		});
+		const partition = partitionTerminationEntries(state);
+		expect(partition.issueEntries.map((entry) => entry.id)).toEqual(["FD-401"]);
+		expect(partition.genericEntries.map((entry) => entry.id)).toEqual(["scratch-pi"]);
+
+		const output = renderTerminationSummary(state, opts);
+		expect(output).toContain("### ✈️ Flightdeck sessions complete");
+		expect(output).toContain("| scratch-pi | adhoc | complete | pi | 1 |");
+		expect(output).toContain("### ✈️ Flightdeck session complete");
+		expect(output).toContain("| FD-401 | merged | #401 | abcdef123456 | 2 |");
+	});
+
+	test("workflow doc routes termination by tracked-entry kind", () => {
+		const doc = readFileSync(TERMINATE_MD, "utf8");
+		expect(doc).toContain("Partition tracked entries by kind");
+		expect(doc).toContain("If `ISSUE_ENTRIES` is non-empty");
+		expect(doc).toContain("If `ISSUE_ENTRIES` is empty and `GENERIC_ENTRIES` is non-empty");
+		expect(doc).toContain("For mixed sessions");
+		expect(doc).toContain("Do not call `gh`, `linear`, worktree helpers, merge planning, or `project-management`");
+	});
+});

--- a/skills/flightdeck/workflows/close-issue.md
+++ b/skills/flightdeck/workflows/close-issue.md
@@ -49,7 +49,7 @@ Map signals to terminal state:
 - PR state `CLOSED` without merge AND issue tracker state cancelled → `state = aborted`.
 - Pane signals end-of-session but PR state is still `OPEN` and no other signal contradicts → return without teardown; the orchestrator may have ended its turn but the merge hasn't actually landed yet. Re-poll.
 
-Capture the outcome's summary fields from the buffer if present (PR number, merge commit, branch deleted-on-remote, etc.) — these go into the end-of-session report (`terminate.md` § 1).
+Capture the outcome's summary fields from the buffer if present (PR number, merge commit, branch deleted-on-remote, etc.) — these go into the issue end-of-session report (`terminate.md` § 2).
 
 ---
 
@@ -88,7 +88,7 @@ This step runs AFTER § 3 has already written the terminal state (`merged|aborte
 
 3. Verify the window is gone (defensive, skipped on exit 3/4/5/6): `tmux list-panes -a -F '#{pane_id}' | grep -qFx "<pane_id>"` — if the recorded `pane_id` is still alive after a `0` exit, log a warning (don't escalate; the helper's own post-kill check already escalates to exit 5 in that case, so a positive match here is a tmux-state race the user can sort out).
 
-Pane registry entry is left in place for the end-of-session report (see `terminate.md` § 1). It carries the issue's history. Do NOT call `pane-registry remove` here — terminate is responsible for the final cleanup.
+Pane registry entry is left in place for the issue end-of-session report (see `terminate.md` § 2). It carries the issue's history. Do NOT call `pane-registry remove` here — terminate is responsible for the final cleanup.
 
 ---
 

--- a/skills/flightdeck/workflows/terminate.md
+++ b/skills/flightdeck/workflows/terminate.md
@@ -1,35 +1,87 @@
-# Workflow: `terminate` — Final Summary + Next-Cycle Recommendation
+# Workflow: `terminate` — Final Summary + Mode-Aware Unwind
 
-End-of-session unwind. Composes a per-issue summary, the new-issues report, and a next-cycle recommendation. Marks master state terminated. Returns control to flightdeck's dashboard.
+End-of-session unwind. Routes by tracked-entry kind, writes the summary file, marks master state terminated, archives state, and returns control to flightdeck's dashboard. Issue entries keep the existing issue/PR/new-issue recommendation behavior; ad-hoc/workflow entries get a generic session summary with no issue-system side effects.
 
-**Inputs**: master state (every tracked issue is `merged | aborted | dead`; debounce satisfied).
+**Inputs**: master state after debounce confirms every tracked entry is terminal enough to end the session.
 
-**Pre-conditions**: `watch.md` § 6 confirmed all-done across consecutive poll cycles.
+**Pre-conditions**:
+- `session-watch.md` confirmed generic entries are `complete | cancelled | dead` (or intentionally removed from active watch).
+- When issue entries exist, `watch.md` § 7 confirmed every tracked issue is terminal (`merged | aborted | dead`) across consecutive poll cycles.
 
-**Post-condition**: `tmp/flightdeck-summary-<SESSION>-<TS>.md` written; `master_state.terminated = true`; user-visible summary line emitted; control returned to flightdeck's dashboard loop (`workflows/start.md` § 1).
+**Post-condition**: `tmp/flightdeck-summary-<SESSION>-<TS>.md` written; `master_state.terminated = true`; user-visible summary block(s) emitted; live state archived.
 
 ---
 
-## § 1: Compose Per-Issue Outcomes
+## § 0: Partition tracked entries by kind
 
-For each tracked issue, gather:
+Read through the normalized TrackedEntry seam:
+
+```bash
+ENTRIES_JSON=$(flightdeck-state tracked-entries)
+```
+
+Partition tracked entries by kind:
+
+- `ISSUE_ENTRIES`: entries with `kind == "issue"` or `domain.issue.id`.
+- `GENERIC_ENTRIES`: entries with `kind == "adhoc"`, `kind == "workflow"`, or any non-issue kind.
+
+Routing rules:
+
+1. If `ISSUE_ENTRIES` is non-empty, run the issue summary path (§§ 2-4) and preserve the current issue/PR/new-issue recommendation summary behavior.
+2. If `ISSUE_ENTRIES` is empty and `GENERIC_ENTRIES` is non-empty, run only the generic session summary path (§ 1). Do not call `gh`, `linear`, worktree helpers, merge planning, or `project-management`.
+3. For mixed sessions, run both paths: generic session summary for `GENERIC_ENTRIES`, then issue/PR/new-issue recommendation summary for `ISSUE_ENTRIES`.
+4. Unknown or malformed kinds fail safe as generic unless `domain.issue.id` is present.
+
+---
+
+## § 1: Compose Generic Session Outcomes
+
+**Skip this section** when `GENERIC_ENTRIES` is empty.
+
+For each generic entry, gather only local state:
 
 | Field | Source |
 |-------|--------|
-| `id` | registry key |
-| `state` | `merged | aborted | dead` |
-| `pr_number` | registry |
-| `merge_commit` | `gh pr view <PR> --json mergeCommit` (when `state == merged`) |
-| `time_elapsed` | `now - master_state.started_at` per-issue if tracked, else session-level |
+| `id` | entry id |
+| `title` | entry title, fallback id |
+| `kind` | entry kind (`adhoc`, `workflow`, or future non-issue kind) |
+| `state` | `complete | cancelled | dead | ready | ...` |
+| `harness` | entry harness |
+| `time_elapsed` | `now - entry.spawned_at`, fallback session elapsed |
 | `decisions_count` | length of `decisions_log` |
-| `scope_files_declared` | registry |
-| `scope_files_actual` | registry (or fetch from `gh pr view --json files`) |
+| `last_prompt` | latest `decisions_log[-1].prompt_tag`, if any |
+| `last_answer` | latest `decisions_log[-1].answer`, if any |
+
+Generic sessions must not query GitHub, Linear, PR state, worktree metadata, or project-management workflows. They do not produce merge ordering, issue cleanup, new issue reports, or next-cycle recommendations.
 
 ---
 
-## § 2: Compose New-Issues Report
+## § 2: Compose Per-Issue Outcomes
 
-Walk every issue's `decisions_log` for `audit-relation-prompt` entries. For each created issue captured during the session, gather:
+**Skip this section** when `ISSUE_ENTRIES` is empty.
+
+For each issue entry, gather:
+
+| Field | Source |
+|-------|--------|
+| `id` | `domain.issue.id` or legacy registry key |
+| `state` | `merged | aborted | dead` |
+| `pr_number` | `domain.issue.pr_number` / legacy registry |
+| `merge_commit` | cached `domain.issue.merge_commit` / legacy `merge_commit`; if missing and `state == merged`, `gh pr view <PR> --json mergeCommit` |
+| `time_elapsed` | `now - spawned_at` per issue, fallback session elapsed |
+| `decisions_count` | length of `decisions_log` |
+| `scope_files_declared` | `domain.issue.scope_files_declared` / legacy registry |
+| `scope_files_actual` | `domain.issue.scope_files_actual` / legacy registry; if missing and PR exists, fetch from `gh pr view --json files` |
+
+Issue-mode lookups may use `github`, `linear`, `worktree`, and `project-management` because § 0 already proved at least one tracked issue exists.
+
+---
+
+## § 3: Compose New-Issues Report
+
+**Skip this section** when `ISSUE_ENTRIES` is empty.
+
+Walk every issue entry's `decisions_log` for `audit-relation-prompt` entries. For each created issue captured during the session, gather:
 
 | Field | Source |
 |-------|--------|
@@ -47,7 +99,9 @@ Group by `relation_kind`:
 
 ---
 
-## § 3: Compose Next-Cycle Recommendation
+## § 4: Compose Next-Cycle Recommendation
+
+**Skip this section** when `ISSUE_ENTRIES` is empty.
 
 For each standalone follow-up (the `relation_kind: follow-up` set):
 
@@ -66,13 +120,30 @@ If no follow-ups warrant precedence, the recommendation is "stick with planned c
 
 ---
 
-## § 4: Write Summary File
+## § 5: Write Summary File
 
-Emit to `tmp/flightdeck-summary-<SESSION>-<TS>.md` (TS = ISO8601, no colons):
+Emit to `tmp/flightdeck-summary-<SESSION>-<TS>.md` (TS = ISO8601, no colons).
+
+For generic-only sessions, write:
 
 ```markdown
 # Flightdeck Session Summary — <SESSION> — <ISO8601>
 
+## Tracked Sessions
+| Entry | Kind | State | Harness | Elapsed | Decisions | Last prompt | Answer |
+|-------|------|-------|---------|---------|-----------|-------------|--------|
+| ...
+
+## Counts
+- Sessions: <N>
+- Complete: <N>
+- Cancelled: <N>
+- Dead: <N>
+```
+
+When issue entries exist, append the existing issue-mode sections after any generic section:
+
+```markdown
 ## Outcomes
 | Issue | State | PR | Merge Commit | Elapsed | Decisions |
 |-------|-------|----|--------------|---------|-----------|
@@ -94,7 +165,7 @@ Emit to `tmp/flightdeck-summary-<SESSION>-<TS>.md` (TS = ISO8601, no colons):
 - **Pick up next**: <ISSUE> — <one-line rationale>
 ... or "Stick with planned cycle — no created issues warrant precedence."
 
-## Counts
+## Issue Counts
 - Merged: <N>
 - Aborted: <N>
 - New issues (children): <N>
@@ -104,7 +175,7 @@ Emit to `tmp/flightdeck-summary-<SESSION>-<TS>.md` (TS = ISO8601, no colons):
 
 ---
 
-## § 5: Finalize Master State
+## § 6: Finalize Master State
 
 ```
 flightdeck-state set terminated true
@@ -116,15 +187,33 @@ flightdeck-state archive
 
 Do NOT call `pane-registry remove-merged` here. Earlier revisions did, but `close-issue.md § 4` has already killed every terminal-state issue's tmux window by the time terminate runs, so `remove-merged` would unconditionally delete every `merged|aborted|dead` issue's history — including `decisions_log`, `pr_number`, and `merge_commit` — from the file that is about to be archived. The pi-flightdeck dashboard depends on those records to render the post-completion `Overview`, `Decisions`, and `Conflicts & merges` tabs; deleting them collapses the dashboard to an empty `0 issues` state immediately after a successful session. The archive's value is precisely the full session history (see [[issue-17]]).
 
-`flightdeck-daemon stop` terminates the external wake daemon (validates PID + flock holder before killing; refuses on stale PID file). `archive` rotates the live state file to `tmp/flightdeck-state-<SESSION>-<terminated_at>.json.archive` so the next session in the same tmux name (e.g. `HT`) starts clean instead of inheriting this session's `issues` map, `merge_queue`, and `terminated` flag. The archive preserves the full `.issues` map (including merged-issue `decisions_log`, `pr_number`, `merge_commit`) for post-mortem inspection and dashboard rendering.
+`flightdeck-daemon stop` terminates the external wake daemon (validates PID + flock holder before killing; refuses on stale PID file). `archive` rotates the live state file to `tmp/flightdeck-state-<SESSION>-<terminated_at>.json.archive` so the next session in the same tmux name (e.g. `HT`) starts clean instead of inheriting this session's entries, issue map, merge queue, and `terminated` flag. The archive preserves the full `.entries` map and full `.issues` map for post-mortem inspection and dashboard rendering.
 
 ---
 
-## § 6: User-Visible Output
+## § 7: User-Visible Output
 
-Emit the full session summary inline using the `<output_format>` block below. Do not collapse to a single line. Do not skip the new-issues table when issues were created. Do not skip the next-cycle recommendation when § 3 produced one. Per SKILL.md "Format Tags Are Literal": fill placeholders, omit empty sections, add nothing else.
+Emit the full applicable summary block(s) inline. Do not collapse to a single line. Per SKILL.md "Format Tags Are Literal": fill placeholders, omit empty sections, add nothing else.
 
-<output_format>
+For generic entries, emit this block only when `GENERIC_ENTRIES` is non-empty:
+
+<generic_output_format>
+### ✈️ Flightdeck sessions complete
+
+**Tracked sessions**
+
+| Entry | Kind | State | Harness | Decisions |
+|-------|------|-------|---------|-----------|
+| [ENTRY_ID] | [adhoc|workflow|other] | [complete|cancelled|dead|ready|...] | [HARNESS] | [N] |
+
+**Counts**: [N] sessions · [N] complete · [N] cancelled · [N] dead
+
+Summary file: `tmp/flightdeck-summary-<SESSION>-<TS>.md`
+</generic_output_format>
+
+For issue entries, emit the existing issue summary block only when `ISSUE_ENTRIES` is non-empty:
+
+<issue_output_format>
 ### ✈️ Flightdeck session complete
 
 **Outcomes**
@@ -147,7 +236,7 @@ Standalone follow-ups:
 
 **Next-cycle recommendation**
 
-[For each recommended issue from § 3:]
+[For each recommended issue from § 4:]
 - **[ISSUE_ID]** ([PRIORITY], [PROJECT]) — [ONE_LINE_RATIONALE]
 
 [Or, if no follow-ups warrant precedence:]
@@ -156,19 +245,19 @@ Standalone follow-ups:
 **Counts**: [N] merged · [N] aborted · [N] children · [N] follow-ups · [N] recommended next
 
 Summary file: `tmp/flightdeck-summary-<SESSION>-<TS>.md`
-</output_format>
+</issue_output_format>
 
-Sections with no data (e.g., no children created, no standalone follow-ups, no recommendations) are omitted entirely per the format-tags rule. Never substitute a one-liner.
+For mixed sessions, emit `<generic_output_format>` first, then `<issue_output_format>`. Sections with no data (e.g., no children created, no standalone follow-ups, no recommendations) are omitted entirely per the format-tags rule. Never substitute a one-liner.
 
 ---
 
-## § 7: Launch Recommended Follow-ups
+## § 8: Launch Recommended Follow-ups
 
-**Skip if** § 3 produced an empty recommendation list.
+**Skip if** `ISSUE_ENTRIES` is empty or § 4 produced an empty recommendation list.
 
-Ask the user whether to launch any of the recommended follow-ups now and continue the flightdeck session. The new issue(s) are spawned via `start.md`'s spawn path; the watch loop resumes with the new pane(s) added to the registry.
+Ask the user whether to launch any of the recommended follow-ups now and continue the flightdeck issue session. The new issue(s) are spawned via `start.md`'s spawn path; the watch loop resumes with the new pane(s) added to the registry.
 
-Use the harness's user-question primitive (Claude Code: `AskUserQuestion`) with options derived from § 3's recommendation list:
+Use the harness's user-question primitive (Claude Code: `AskUserQuestion`) with options derived from § 4's recommendation list:
 
 <launch_now_format>
 **Launch follow-ups now?**
@@ -190,20 +279,20 @@ On launch:
    ```
 2. Invoke the spawn path: `⤵ workflows/start.md § 1.4 → § 5` (or equivalent — same flow `flightdeck start <ISSUE_ID>` would take).
 3. The new pane is added to the registry; the watch loop's next cycle picks it up.
-4. Re-enter `watch.md § 2`. Do NOT proceed to § 8 (Pane Lifecycle) — session continues.
+4. Re-enter `watch.md § 2`. Do NOT proceed to § 9 (Pane Lifecycle) — session continues.
 
-On "Stick with planned cycle / Done": proceed to § 8.
+On "Stick with planned cycle / Done": proceed to § 9.
 
 ---
 
-## § 8: Pane Lifecycle
+## § 9: Pane Lifecycle
 
-Do **not** close any additional panes here. Terminal issue windows were already closed by `close-issue.md` after the two-signal check; any remaining paused/non-terminal panes stay with the user so they can inspect transcripts or resume manually.
+Do **not** close any additional panes here. Terminal issue windows were already closed by `close-issue.md` after the two-signal check; generic/ad-hoc windows remain available for transcript inspection or manual resume unless the user explicitly runs `session stop` / `session remove`.
 
-§ 5's `flightdeck-state archive` rotated the live state away, so a subsequent `flightdeck start` (or bare `watch`) in the same tmux session creates a fresh master-state file — no stale `issues` / `merge_queue` carryover. Past sessions remain inspectable via `tmp/flightdeck-state-<SESSION>-<TS>.json.archive` (full `.issues` history, including merged-issue `decisions_log` / `pr_number` / `merge_commit`) and the summary file. pi-flightdeck's `buildSnapshot` falls back to the newest `flightdeck-state-<SESSION>-*.json.archive` with `terminated: true` whenever the live file is missing for the current `$TMUX` session name, so the dashboard, Overview, Decisions, and Conflicts & merges tabs keep rendering the completed session until the user dismisses the widget via `Alt+M` or a new `flightdeck start` writes a fresh live file.
+§ 6's `flightdeck-state archive` rotated the live state away, so a subsequent `flightdeck start` (or bare `watch`) in the same tmux session creates a fresh master-state file — no stale entries, issue map, merge queue, or `terminated` flag carryover. Past sessions remain inspectable via `tmp/flightdeck-state-<SESSION>-<TS>.json.archive` and the summary file. pi-flightdeck's `buildSnapshot` falls back to the newest `flightdeck-state-<SESSION>-*.json.archive` with `terminated: true` whenever the live file is missing for the current `$TMUX` session name, so the dashboard keeps rendering the completed session until the user dismisses the widget via `Alt+M` or a new `flightdeck start` writes a fresh live file.
 
 ---
 
 ## Returns
 
-To flightdeck's dashboard loop (`workflows/start.md` § 1).
+To flightdeck's dashboard loop (`workflows/start.md` or `workflows/session-watch.md`), after summary emission and state archive.

--- a/skills/flightdeck/workflows/terminate.md
+++ b/skills/flightdeck/workflows/terminate.md
@@ -1,6 +1,6 @@
 # Workflow: `terminate` — Final Summary + Mode-Aware Unwind
 
-End-of-session unwind. Routes by tracked-entry kind, writes the summary file, marks master state terminated, archives state, and returns control to flightdeck's dashboard. Issue entries keep the existing issue/PR/new-issue recommendation behavior; ad-hoc/workflow entries get a generic session summary with no issue-system side effects.
+End-of-session unwind. Routes by tracked-entry kind, writes the summary file, marks master state terminated, archives state, and returns control to flightdeck's dashboard. Issue entries keep the existing issue/PR/new-issue recommendation behavior from this markdown workflow; ad-hoc/workflow entries get a generic session summary with no issue-system side effects. Any TS helper under `lib/flightdeck-core/src/terminate/` owns the generic/empty summary path only — never replace the issue/PR/new-issue recommendation path with hard-coded TS output.
 
 **Inputs**: master state after debounce confirms every tracked entry is terminal enough to end the session.
 
@@ -22,21 +22,23 @@ ENTRIES_JSON=$(flightdeck-state tracked-entries)
 
 Partition tracked entries by kind:
 
-- `ISSUE_ENTRIES`: entries with `kind == "issue"` or `domain.issue.id`.
-- `GENERIC_ENTRIES`: entries with `kind == "adhoc"`, `kind == "workflow"`, or any non-issue kind.
+- `ISSUE_ENTRIES`: entries with `kind == "issue"`, `domain.issue.id`, or issue-shaped markers.
+- `GENERIC_ENTRIES`: entries with `kind == "adhoc"`, `kind == "workflow"`, or a future non-issue kind and **no** issue-shaped markers.
+
+Issue-shaped markers are: legacy/top-level `pr_number`, `worktree`, `merge_commit`, issue-domain `pr_number`, `worktree`, `merge_commit`, `scope_files_declared`, `scope_files_actual`, `orchestration_started`, issue-only states (`merge-ready`, `merged`, `aborted`), or issue-only substates (`merge-now`, `audit-relation-prompt`, `bot-review-wait-stuck`, `rebase-multi-choice`, `force-push-prompt`, `cleanup-prompt`, `stale-no-pr-branch`, `stale-orphan-worktree`, `descope-related`, `scope-creep-detected`, fix-suggestion tags). If any marker appears without `kind == "issue"` / `domain.issue.id`, emit a warning naming the entry id and markers, then route through `ISSUE_ENTRIES`. This fails closed so malformed issue-shaped entries cannot silently skip merge/new-issue history.
 
 Routing rules:
 
 1. If `ISSUE_ENTRIES` is non-empty, run the issue summary path (§§ 2-4) and preserve the current issue/PR/new-issue recommendation summary behavior.
 2. If `ISSUE_ENTRIES` is empty and `GENERIC_ENTRIES` is non-empty, run only the generic session summary path (§ 1). Do not call `gh`, `linear`, worktree helpers, merge planning, or `project-management`.
-3. For mixed sessions, run both paths: generic session summary for `GENERIC_ENTRIES`, then issue/PR/new-issue recommendation summary for `ISSUE_ENTRIES`.
-4. Unknown or malformed kinds fail safe as generic unless `domain.issue.id` is present.
+3. If both partitions are empty, write the empty-session summary in § 1 and continue finalization. This is an explicit diagnostic, not a silent success.
+4. For mixed sessions, run both paths: generic session summary for `GENERIC_ENTRIES`, then issue/PR/new-issue recommendation summary for `ISSUE_ENTRIES`.
 
 ---
 
 ## § 1: Compose Generic Session Outcomes
 
-**Skip this section** when `GENERIC_ENTRIES` is empty.
+**Skip this section** when `GENERIC_ENTRIES` is empty and `ISSUE_ENTRIES` is non-empty. **Run this section** for an empty tracked-entry set to emit the explicit empty-session diagnostic.
 
 For each generic entry, gather only local state:
 
@@ -52,7 +54,7 @@ For each generic entry, gather only local state:
 | `last_prompt` | latest `decisions_log[-1].prompt_tag`, if any |
 | `last_answer` | latest `decisions_log[-1].answer`, if any |
 
-Generic sessions must not query GitHub, Linear, PR state, worktree metadata, or project-management workflows. They do not produce merge ordering, issue cleanup, new issue reports, or next-cycle recommendations.
+Generic sessions must not query GitHub, Linear, PR state, worktree metadata, or project-management workflows. They do not produce merge ordering, issue cleanup, new issue reports, or next-cycle recommendations. If there are zero tracked entries, write `Session terminated with no tracked entries.` plus zero counts.
 
 ---
 
@@ -124,7 +126,7 @@ If no follow-ups warrant precedence, the recommendation is "stick with planned c
 
 Emit to `tmp/flightdeck-summary-<SESSION>-<TS>.md` (TS = ISO8601, no colons).
 
-For generic-only sessions, write:
+For generic-only sessions or empty sessions, write:
 
 ```markdown
 # Flightdeck Session Summary — <SESSION> — <ISO8601>
@@ -133,6 +135,10 @@ For generic-only sessions, write:
 | Entry | Kind | State | Harness | Elapsed | Decisions | Last prompt | Answer |
 |-------|------|-------|---------|---------|-----------|-------------|--------|
 | ...
+
+If no tracked entries exist, write this instead of the table rows:
+
+Session terminated with no tracked entries.
 
 ## Counts
 - Sessions: <N>
@@ -195,7 +201,7 @@ Do NOT call `pane-registry remove-merged` here. Earlier revisions did, but `clos
 
 Emit the full applicable summary block(s) inline. Do not collapse to a single line. Per SKILL.md "Format Tags Are Literal": fill placeholders, omit empty sections, add nothing else.
 
-For generic entries, emit this block only when `GENERIC_ENTRIES` is non-empty:
+For generic entries, emit this block when `GENERIC_ENTRIES` is non-empty:
 
 <generic_output_format>
 ### ✈️ Flightdeck sessions complete
@@ -210,6 +216,18 @@ For generic entries, emit this block only when `GENERIC_ENTRIES` is non-empty:
 
 Summary file: `tmp/flightdeck-summary-<SESSION>-<TS>.md`
 </generic_output_format>
+
+If no tracked entries exist, emit this explicit diagnostic block:
+
+<empty_output_format>
+### ✈️ Flightdeck session complete
+
+Session terminated with no tracked entries.
+
+**Counts**: 0 sessions · 0 complete · 0 cancelled · 0 dead
+
+Summary file: `tmp/flightdeck-summary-<SESSION>-<TS>.md`
+</empty_output_format>
 
 For issue entries, emit the existing issue summary block only when `ISSUE_ENTRIES` is non-empty:
 
@@ -247,7 +265,7 @@ Standalone follow-ups:
 Summary file: `tmp/flightdeck-summary-<SESSION>-<TS>.md`
 </issue_output_format>
 
-For mixed sessions, emit `<generic_output_format>` first, then `<issue_output_format>`. Sections with no data (e.g., no children created, no standalone follow-ups, no recommendations) are omitted entirely per the format-tags rule. Never substitute a one-liner.
+For mixed sessions, emit `<generic_output_format>` first, then `<issue_output_format>`. For empty sessions, emit only `<empty_output_format>`. Sections with no data (e.g., no children created, no standalone follow-ups, no recommendations) are omitted entirely per the format-tags rule. Never substitute a one-liner.
 
 ---
 


### PR DESCRIPTION
## Summary
- Move Flightdeck issue dependencies to optional/on-demand and document core session mode as tmux/harness-only.
- Split termination workflow output by tracked-entry kind: generic session summary for ad-hoc/workflow entries, issue summary when issue entries exist, both for mixed sessions.
- Add terminate-session parity coverage for issue-only, ad-hoc-only, and mixed summary routing.

## Validation
- cd skills/flightdeck/lib/flightdeck-core && env -u GH_TOKEN -u GITHUB_TOKEN -u LINEAR_API_KEY -u LINEAR_TOKEN bun test && env -u GH_TOKEN -u GITHUB_TOKEN -u LINEAR_API_KEY -u LINEAR_TOKEN bun run typecheck
- cd skills/flightdeck/lib/flightdeck-core && env GH_TOKEN=polluted GITHUB_TOKEN=polluted LINEAR_API_KEY=polluted LINEAR_TOKEN=polluted FLIGHTDECK_USE_TS=1 FLIGHTDECK_STATE_DIR=tmp bun test && env GH_TOKEN=polluted GITHUB_TOKEN=polluted LINEAR_API_KEY=polluted LINEAR_TOKEN=polluted FLIGHTDECK_USE_TS=1 FLIGHTDECK_STATE_DIR=tmp bun run typecheck
- cd skills/flightdeck/lib/flightdeck-core && bun run typecheck && bun test tests/parity/terminate-session.test.ts