### PR TITLE
fix(flightdeck): TrackedEntry-aware set-state + teardown-entry (post-reframe smoke)

### DIFF
--- a/skills/flightdeck/lib/flightdeck-core/src/bin/pane-registry.ts
+++ b/skills/flightdeck/lib/flightdeck-core/src/bin/pane-registry.ts
@@ -350,6 +350,22 @@ function trackedEntries(): Record<string, Record<string, unknown>> {
 	}
 }
 
+function registryMapHas(map: "entries" | "issues", id: string): boolean {
+	const idJson = JSON.stringify(id);
+	const r = fdState(["get", `has(${JSON.stringify(map)}) and .${map}[${idJson}] != null`]);
+	return r.status === 0 && r.stdout.trim() === "true";
+}
+
+function setRegistryFieldBoth(id: string, field: string, value: string): void {
+	const hasEntry = registryMapHas("entries", id);
+	const hasIssue = registryMapHas("issues", id);
+	if (!hasEntry && !hasIssue) {
+		die(`pane-registry: entry '${id}' not found in .entries or .issues`);
+	}
+	if (hasEntry) fdStateOrDie(["set", `.entries[${JSON.stringify(id)}].${field}`, value]);
+	if (hasIssue) fdStateOrDie(["set", `.issues[${JSON.stringify(id)}].${field}`, value]);
+}
+
 function nestedRecord(obj: Record<string, unknown>, key: string): Record<string, unknown> {
 	const value = obj[key];
 	return isRecord(value) ? value : {};
@@ -425,17 +441,17 @@ const VALID_STATES = new Set(["waiting", "prompting", "submitting", "merge-ready
 function cmdSetState(issue: string, state: string): void {
 	if (!issue || !state) die("Usage: set-state <ISSUE> <state>");
 	if (!VALID_STATES.has(state)) die(`Unknown state: ${state}`);
-	fdStateOrDie(["set", `.issues["${issue}"].state`, JSON.stringify(state)]);
+	setRegistryFieldBoth(issue, "state", JSON.stringify(state));
 }
 
 function cmdSetSubstate(issue: string, sub: string): void {
 	if (!issue || !sub) die("Usage: set-substate <ISSUE> <substate>");
-	fdStateOrDie(["set", `.issues["${issue}"].substate`, JSON.stringify(sub)]);
+	setRegistryFieldBoth(issue, "substate", JSON.stringify(sub));
 }
 
 function cmdSetField(issue: string, field: string, value: string): void {
 	if (!issue || !field || !value) die("Usage: set <ISSUE> <field> <json-value>");
-	fdStateOrDie(["set", `.issues["${issue}"].${field}`, value]);
+	setRegistryFieldBoth(issue, field, value);
 }
 
 function cmdLogDecision(issue: string, tag: string, answer: string): void {
@@ -698,7 +714,7 @@ function cmdTeardownWindow(args: string[]): void {
 	//   exit >= 2             — usage error or genuine read failure
 	// Treat 0+empty and 1 as "not found" (exit 1); only exit >= 2 escalates
 	// to exit 6 (registry read failure) per BLOCK #2.
-	const r = fdState(["get", `.issues["${issue}"] // .entries["${issue}"] // empty`]);
+	const r = fdState(["get", `.entries["${issue}"] // .issues["${issue}"] // empty`]);
 	const status = r.status ?? 0;
 	if (status >= 2) {
 		process.stderr.write(

--- a/skills/flightdeck/lib/flightdeck-core/src/bin/pane-registry.ts
+++ b/skills/flightdeck/lib/flightdeck-core/src/bin/pane-registry.ts
@@ -353,6 +353,12 @@ function trackedEntries(): Record<string, Record<string, unknown>> {
 function registryMapHas(map: "entries" | "issues", id: string): boolean {
 	const idJson = JSON.stringify(id);
 	const r = fdState(["get", `has(${JSON.stringify(map)}) and .${map}[${idJson}] != null`]);
+	const status = r.status ?? 0;
+	if (status >= 2 || r.stderr.trim()) {
+		process.stderr.write(`pane-registry: registry read failed (flightdeck-state exit=${status}): ${r.stderr}`);
+		if (!r.stderr.endsWith("\n")) process.stderr.write("\n");
+		process.exit(6);
+	}
 	return r.status === 0 && r.stdout.trim() === "true";
 }
 

--- a/skills/flightdeck/lib/flightdeck-core/tests/parity/pane-registry.test.ts
+++ b/skills/flightdeck/lib/flightdeck-core/tests/parity/pane-registry.test.ts
@@ -157,6 +157,23 @@ describe("pane-registry parity", () => {
 		}
 	});
 
+	test("set-state corrupt registry state → exit 6 without touching state file", () => {
+		const fs = require("node:fs") as typeof import("node:fs");
+		for (const repo of [bashRepo, tsRepo]) {
+			const useTs = repo === tsRepo;
+			const statePath = makeShimState(repo, baseShim("test-session"));
+			runShim(useTs, repo, statePath, ["init-entry", "CORRUPT-SET", "--title", "Corrupt", "--kind", "adhoc", "--cwd", "/tmp/c", "--window", "1", "--harness", "pi"]);
+			const registryPath = stateFilePath(repo, "test-session");
+			const corrupt = "{not valid json at all,,,";
+			fs.writeFileSync(registryPath, corrupt);
+			const r = runShim(useTs, repo, statePath, ["set-state", "CORRUPT-SET", "dead"]);
+			expect(r.status).toBe(6);
+			expect(r.stderr).toContain("registry read failed");
+			expect(r.stderr).not.toContain("not found in .entries or .issues");
+			expect(fs.readFileSync(registryPath, "utf8")).toBe(corrupt);
+		}
+	});
+
 	test("log-decision appends to decisions_log", () => {
 		for (const repo of [bashRepo, tsRepo]) {
 			const useTs = repo === tsRepo;

--- a/skills/flightdeck/lib/flightdeck-core/tests/parity/pane-registry.test.ts
+++ b/skills/flightdeck/lib/flightdeck-core/tests/parity/pane-registry.test.ts
@@ -109,6 +109,45 @@ describe("pane-registry parity", () => {
 		expect(normalize(readIssues(tsRepo))).toEqual(normalize(readIssues(bashRepo)));
 	});
 
+	test("set-state updates adhoc-only .entries row", () => {
+		for (const repo of [bashRepo, tsRepo]) {
+			const useTs = repo === tsRepo;
+			run(useTs, repo, ["init-entry", "adhoc-state", "--title", "Adhoc", "--kind", "adhoc", "--cwd", "/tmp/a", "--window", "1", "--harness", "pi", "--pane-id", "%301"]);
+			const r = run(useTs, repo, ["set-state", "adhoc-state", "dead"]);
+			expect(r.status).toBe(0);
+		}
+		const bEntries = readEntries(bashRepo) as Record<string, Record<string, unknown>>;
+		const tEntries = readEntries(tsRepo) as Record<string, Record<string, unknown>>;
+		expect(tEntries["adhoc-state"]!.state).toBe("dead");
+		expect(tEntries["adhoc-state"]!.pane_id).toBe("%301");
+		expect(normalize(tEntries)).toEqual(normalize(bEntries));
+		expect(readIssues(tsRepo)).toEqual({});
+	});
+
+	test("set-state, set-substate, and set update both .entries and .issues for issue rows", () => {
+		for (const repo of [bashRepo, tsRepo]) {
+			const useTs = repo === tsRepo;
+			run(useTs, repo, ["init-entry", "ISSUE-DUAL", "--title", "Issue Dual", "--kind", "issue", "--cwd", "/tmp/wt", "--window", "2", "--harness", "pi", "--pane-id", "%302", "--worktree", "/tmp/wt"]);
+			expect(run(useTs, repo, ["set-state", "ISSUE-DUAL", "prompting"]).status).toBe(0);
+			expect(run(useTs, repo, ["set-substate", "ISSUE-DUAL", "needs-human"]).status).toBe(0);
+			expect(run(useTs, repo, ["set", "ISSUE-DUAL", "pane_target", JSON.stringify("test:2.0")]).status).toBe(0);
+		}
+		const tEntries = readEntries(tsRepo) as Record<string, Record<string, unknown>>;
+		const tIssues = readIssues(tsRepo) as Record<string, Record<string, unknown>>;
+		const bEntries = readEntries(bashRepo) as Record<string, Record<string, unknown>>;
+		const bIssues = readIssues(bashRepo) as Record<string, Record<string, unknown>>;
+		expect(tEntries["ISSUE-DUAL"]!.state).toBe("prompting");
+		expect(tIssues["ISSUE-DUAL"]!.state).toBe("prompting");
+		expect(tEntries["ISSUE-DUAL"]!.substate).toBe("needs-human");
+		expect(tIssues["ISSUE-DUAL"]!.substate).toBe("needs-human");
+		expect(tEntries["ISSUE-DUAL"]!.pane_id).toBe("%302");
+		expect(tIssues["ISSUE-DUAL"]!.pane_id).toBe("%302");
+		expect(tEntries["ISSUE-DUAL"]!.pane_target).toBe("test:2.0");
+		expect(tIssues["ISSUE-DUAL"]!.pane_target).toBe("test:2.0");
+		expect(normalize(tEntries)).toEqual(normalize(bEntries));
+		expect(normalize(tIssues)).toEqual(normalize(bIssues));
+	});
+
 	test("set-state rejects invalid state", () => {
 		for (const repo of [bashRepo, tsRepo]) {
 			const useTs = repo === tsRepo;
@@ -492,6 +531,31 @@ describe("pane-registry teardown-window (#16, shim-driven)", () => {
 			const r = runShim(useTs, repo, statePath, ["teardown-entry", "TD-ALIAS"]);
 			expect(r.status).toBe(0);
 			expect(r.stdout).toContain("already closed");
+		}
+	});
+
+	test("teardown-entry prefers .entries pane_id when legacy .issues row is nulled", () => {
+		for (const repo of [bashRepo, tsRepo]) {
+			const useTs = repo === tsRepo;
+			const statePath = makeShimState(repo, {
+				panes: {
+					"%310": { pane_index: 0, path: "/tmp/wt-a", window_id: "@31", window_index: 31, window_name: "issue-entry" },
+				},
+				session: "test-session",
+				windows: { "@31": { index: 31, name: "issue-entry" } },
+			});
+			runShim(useTs, repo, statePath, ["init-entry", "TD-ENTRY-FIRST", "--title", "Entry First", "--kind", "issue", "--cwd", "/tmp/wt-a", "--window", "31", "--harness", "pi", "--worktree", "/tmp/wt-a", "--pane-id", "%310", "--pane-target", "test-session:31.0"]);
+			// Simulate stale legacy projection damage from pre-fix set-state.
+			runShim(useTs, repo, statePath, ["set", "TD-ENTRY-FIRST", "state", JSON.stringify("dead")]);
+			const fs = require("node:fs") as typeof import("node:fs");
+			const registryPath = stateFilePath(repo, "test-session");
+			const stateJson = JSON.parse(fs.readFileSync(registryPath, "utf8")) as { issues: Record<string, Record<string, unknown>> };
+			stateJson.issues["TD-ENTRY-FIRST"]!.pane_id = null;
+			stateJson.issues["TD-ENTRY-FIRST"]!.pane_target = null;
+			fs.writeFileSync(registryPath, JSON.stringify(stateJson, null, 2));
+			const r = runShim(useTs, repo, statePath, ["teardown-entry", "TD-ENTRY-FIRST"]);
+			expect(r.status).toBe(0);
+			expect(readShimState(statePath).panes["%310"]).toBeUndefined();
 		}
 	});
 

--- a/skills/flightdeck/scripts/pane-registry.bash
+++ b/skills/flightdeck/scripts/pane-registry.bash
@@ -98,6 +98,29 @@ read_registry_field() {
   "$FD_STATE" get "(.issues[$id_json].$field // .entries[$id_json].adapter.$field // .entries[$id_json].$field // empty)" 2>/dev/null | tr -d '"'
 }
 
+registry_map_has() {
+  local map="$1" id="$2" id_json out
+  id_json=$(jq -Rn --arg v "$id" '$v')
+  out=$("$FD_STATE" get "has(\"$map\") and .$map[$id_json] != null" 2>/dev/null || echo "false")
+  [[ "$out" == "true" ]]
+}
+
+set_registry_field_both() {
+  local id="$1" field="$2" value="$3" entry_has=0 issue_has=0
+  registry_map_has entries "$id" && entry_has=1
+  registry_map_has issues "$id" && issue_has=1
+  if (( entry_has == 0 && issue_has == 0 )); then
+    echo "pane-registry: entry '$id' not found in .entries or .issues" >&2
+    exit 2
+  fi
+  if (( entry_has == 1 )); then
+    "$FD_STATE" set ".entries[\"$id\"].$field" "$value"
+  fi
+  if (( issue_has == 1 )); then
+    "$FD_STATE" set ".issues[\"$id\"].$field" "$value"
+  fi
+}
+
 pane_match_is_live() {
   local pane_id="$1" pane_target="$2" lookup="${pane_id:-$pane_target}"
   [[ -n "$lookup" ]] || return 1
@@ -350,20 +373,20 @@ case "$ACTION" in
       waiting|prompting|submitting|merge-ready|merged|aborted|dead) ;;
       *) echo "Unknown state: $STATE" >&2; exit 2 ;;
     esac
-    "$FD_STATE" set ".issues[\"$ISSUE\"].state" "\"$STATE\""
+    set_registry_field_both "$ISSUE" state "\"$STATE\""
     ;;
 
   set-substate)
     ISSUE="${1:-}"; SUB="${2:-}"
     [[ -z "$ISSUE" || -z "$SUB" ]] && { echo "Usage: set-substate <ISSUE> <substate>" >&2; exit 2; }
-    "$FD_STATE" set ".issues[\"$ISSUE\"].substate" "\"$SUB\""
+    set_registry_field_both "$ISSUE" substate "\"$SUB\""
     ;;
 
   set)
     ISSUE="${1:-}"; FIELD="${2:-}"; VALUE="${3:-}"
     [[ -z "$ISSUE" || -z "$FIELD" || -z "$VALUE" ]] && {
       echo "Usage: set <ISSUE> <field> <json-value>" >&2; exit 2; }
-    "$FD_STATE" set ".issues[\"$ISSUE\"].$FIELD" "$VALUE"
+    set_registry_field_both "$ISSUE" "$FIELD" "$VALUE"
     ;;
 
   log-decision)
@@ -770,7 +793,7 @@ case "$ACTION" in
     #   exit >= 2             — usage error or genuine read failure
     # Treat 0+empty and 1 as "not found"; only exit >= 2 escalates to
     # exit 6 (registry read failure) per BLOCK #2.
-    entry=$("$FD_STATE" get ".issues[\"$ISSUE\"] // .entries[\"$ISSUE\"] // empty" 2>"$fd_stderr_file")
+    entry=$("$FD_STATE" get ".entries[\"$ISSUE\"] // .issues[\"$ISSUE\"] // empty" 2>"$fd_stderr_file")
     fd_status=$?
     if (( fd_status >= 2 )); then
       printf 'teardown-window: registry read failed (flightdeck-state exit=%s): ' "$fd_status" >&2

--- a/skills/flightdeck/scripts/pane-registry.bash
+++ b/skills/flightdeck/scripts/pane-registry.bash
@@ -99,9 +99,19 @@ read_registry_field() {
 }
 
 registry_map_has() {
-  local map="$1" id="$2" id_json out
+  local map="$1" id="$2" id_json out status stderr_file
   id_json=$(jq -Rn --arg v "$id" '$v')
-  out=$("$FD_STATE" get "has(\"$map\") and .$map[$id_json] != null" 2>/dev/null || echo "false")
+  stderr_file=$(mktemp -t fd-registry-read-stderr.XXXXXX)
+  out=$("$FD_STATE" get "has(\"$map\") and .$map[$id_json] != null" 2>"$stderr_file")
+  status=$?
+  if (( status >= 2 )) || [[ -s "$stderr_file" ]]; then
+    printf 'pane-registry: registry read failed (flightdeck-state exit=%s): ' "$status" >&2
+    cat "$stderr_file" >&2
+    echo >&2
+    rm -f "$stderr_file"
+    exit 6
+  fi
+  rm -f "$stderr_file"
   [[ "$out" == "true" ]]
 }
 


### PR DESCRIPTION
## Summary
- update pane-registry set-state/set-substate/set to mutate .entries and legacy .issues when present
- preserve pane_id during state transitions so teardown owns pane cleanup
- make teardown-entry/window read .entries first and only fall back to .issues for legacy-only rows
- add bash/TS parity coverage for adhoc entries, dual issue rows, pane_id preservation, and nulled legacy teardown

## Live smoke reproducer documented
1. flightdeck-state init creates schema 1.1 state.
2. flightdeck-session start --session-id smoke --title "X" --cwd $PWD --harness pi --kind adhoc --prompt "stay idle" registers .entries[smoke] with state=waiting and pane_id=%N.
3. pane-registry set-state smoke dead now updates .entries[smoke].state and preserves .entries[smoke].pane_id.
4. pane-registry teardown-entry smoke now reads pane identity from .entries first and kills the live terminal-state pane/window instead of trusting nulled legacy .issues fields.

Manual smoke run in this branch: init → flightdeck-session start adhoc → set-state dead → teardown-entry killed window @706 (pane_id=%721).

## Validation
- cd skills/flightdeck/lib/flightdeck-core && bun test && bun run typecheck
- manual smoke above
- vstack refresh -g after commit: Processed 0 agent(s), 0 skill(s), 0 hook(s), 18 Pi package(s), 0 updated
