### PR TITLE
feat(pi-agents-tmux): stabilize subagent sessions (closes parts of #27)

### DIFF
--- a/pi-extensions/pi-agents-tmux/README.md
+++ b/pi-extensions/pi-agents-tmux/README.md
@@ -17,6 +17,18 @@ Delegate work to specialized agents from a running Pi session. Agents run either
 - Bg agents use fresh one-shot lanes by default; explicit `sessionKey` opts into memory reuse with a context-budget guard.
 - Large parallel calls are auto-batched internally, and pane idle waits are first-class via `wait_for_subagent_idle`.
 
+## Closes parts of issue #27
+
+This package implements the pi-agents-tmux portions of vanillagreencom/vstack#27:
+
+- #1 — fresh one-shot bg subagent sessions by default.
+- #2 — distinct ephemeral lanes for same-agent parallel and chain items.
+- #3 — one retry on `context_length_exceeded` with structured attempt details.
+- #6 — reused-session context-budget preflight guard.
+- #10 — inventory-aware launch guard for single, parallel, and chain dispatch.
+- #12 — first-class pane idle wait via `wait_for_subagent_idle` / `waitFor: "idle"`.
+- #13 — transparent auto-batching above the internal parallel cap.
+
 ## Install
 
 Via [npm](https://www.npmjs.com/package/@vanillagreen/pi-agents-tmux):
@@ -164,7 +176,7 @@ Wait for a pane agent to become idle without shell polling:
 { "agent": "iced", "timeoutMs": 30000 }
 ```
 
-Use the `wait_for_subagent_idle` tool for this. `get_subagent_result` also accepts `waitFor: "idle"` for compatibility with existing result lookups.
+Use the `wait_for_subagent_idle` tool for this. It reports `idle-after-busy` only after observing the pane leave idle first; if the pane never becomes busy it returns `never-busy` instead of a false completion. `get_subagent_result` also accepts `waitFor: "idle"` for compatibility with existing result lookups.
 
 Use `steer_subagent` for mid-run correction. It targets `pi-session-bridge` when available; otherwise it queues a steering note for the pane to read when idle.
 
@@ -188,7 +200,7 @@ All settings live in the extension manager under **Agents (tmux)**.
 | Subagent model source | Use the agent's `model:` or inherit the parent session model. |
 | Subagent thinking source | Use the model `:effort` suffix or inherit the parent thinking level. |
 | Reused session budget threshold | Fraction of model context allowed before an explicit `sessionKey` lane is considered too full. |
-| Reused session budget policy | `refuse` (default) blocks near-limit reused lanes; `warn` logs and continues. |
+| Reused session budget policy | `refuse-and-warn` (default) blocks near-limit reused lanes with a warning; `warn` logs and continues; `compact-then-resume` archives/truncates the lane before launch. |
 | Reused session context limit tokens | Context limit used by the session-file-size heuristic. |
 
 ### Rendering

--- a/pi-extensions/pi-agents-tmux/README.md
+++ b/pi-extensions/pi-agents-tmux/README.md
@@ -14,6 +14,8 @@ Delegate work to specialized agents from a running Pi session. Agents run either
 - Grouped completion notifications batch multiple agents finishing together.
 - `taskId` retrieval, mid-run steering, and pane stop without losing memory.
 - Stop kills the tmux process but preserves the session — next launch resumes it.
+- Bg agents use fresh one-shot lanes by default; explicit `sessionKey` opts into memory reuse with a context-budget guard.
+- Large parallel calls are auto-batched internally, and pane idle waits are first-class via `wait_for_subagent_idle`.
 
 ## Install
 
@@ -64,7 +66,13 @@ Useful options: `agentScope` (`project` default, `user`, `both`), `cwd` per task
 
 Persistent panes return a `taskId`. Keep it to retrieve or steer the task later.
 
-Bg agents resume per parent session by default. Pass `sessionKey: "<stable-id>"` for a separate named memory lane. Pane agents persist via their own session file and ignore `sessionKey`.
+Bg agents start in a fresh one-shot lane by default. Pass `sessionKey: "<stable-id>"` only when you want a named memory lane reused across calls. Pane agents persist via their own session file and ignore `sessionKey`.
+
+Parallel and chain items that omit `sessionKey` automatically receive distinct one-shot lanes, including same-agent parallel tasks. Calls above the internal batch size (default 8) are split into batches transparently.
+
+Explicit reused `sessionKey` lanes run a preflight context-budget heuristic before launch. Default policy refuses when estimated saved context exceeds 80% of the configured model limit; settings can raise/lower the threshold or warn instead.
+
+Agent names are validated against project/user inventory for the selected `agentScope` before any launch. Unknown names fail with structured details listing missing and available agents; no similar-name redirect is attempted.
 
 ## Commands
 
@@ -150,6 +158,14 @@ Dispatch and end your turn — the extension wakes the parent on completion. Use
 { "taskId": "iced-..." }
 ```
 
+Wait for a pane agent to become idle without shell polling:
+
+```json
+{ "agent": "iced", "timeoutMs": 30000 }
+```
+
+Use the `wait_for_subagent_idle` tool for this. `get_subagent_result` also accepts `waitFor: "idle"` for compatibility with existing result lookups.
+
 Use `steer_subagent` for mid-run correction. It targets `pi-session-bridge` when available; otherwise it queues a steering note for the pane to read when idle.
 
 ```json
@@ -167,10 +183,13 @@ All settings live in the extension manager under **Agents (tmux)**.
 | Setting | What it does |
 | --- | --- |
 | Enable agents | Master toggle for the subagent tools, dashboard, and pane helpers. |
-| Max parallel tasks | Cap on tasks in one parallel agent call. |
+| Max parallel tasks | Internal batch size for parallel calls; larger calls are auto-batched. |
 | Max concurrency | Cap on bg agent processes running simultaneously. |
 | Subagent model source | Use the agent's `model:` or inherit the parent session model. |
 | Subagent thinking source | Use the model `:effort` suffix or inherit the parent thinking level. |
+| Reused session budget threshold | Fraction of model context allowed before an explicit `sessionKey` lane is considered too full. |
+| Reused session budget policy | `refuse` (default) blocks near-limit reused lanes; `warn` logs and continues. |
+| Reused session context limit tokens | Context limit used by the session-file-size heuristic. |
 
 ### Rendering
 

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/agents-command.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/agents-command.ts
@@ -1,0 +1,261 @@
+import type { ExtensionCommandContext, ExtensionContext, ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { discoverAgents, formatAgentList, type AgentScope } from "./agents.js";
+import { activeDashboardItems, openAgentsBrowser, openTraceViewer, traceViewerItems } from "./browser.js";
+import { compactPath, oneLinePreview } from "./format.js";
+import { ensurePersistentPane, hasSavedPaneSession, paneExists, queuePersistentPaneTask, resetPersistentPaneSession, restoreArchivedPaneSession, stopPersistentPane, tmux } from "./pane.js";
+import { formatTraceView, recordTraceRef, resolveTraceRecord } from "./renderers.js";
+import { pollPaneCompletions, readPaneRegistry, readTaskRegistry, emitSubagentEvent } from "./tasks.js";
+import { runtimeSessionId, sessionRuntimeDir } from "./settings.js";
+
+interface AgentsCommandDeps {
+	[key: string]: any;
+	pi: ExtensionAPI;
+}
+
+export function registerAgentsCommands(deps: AgentsCommandDeps): void {
+	const {
+		agentCommandCompletions,
+		agentsArgumentCompletions,
+		dashboardState,
+		formatRelativeTime,
+		persistRuntimeSnapshot,
+		pi,
+		removeDashboardAgent,
+		syncDashboard,
+	} = deps;
+	const agentsHandler = async (args: string, ctx: ExtensionCommandContext) => {
+		const parts = args.trim().split(/\s+/).filter(Boolean);
+		const scopes = new Set<AgentScope>(["user", "project", "both"]);
+		const command = parts[0];
+		let scope: AgentScope = "project";
+		let content = "";
+		let messageDetails: Record<string, unknown> | undefined;
+
+		const parentModel = ctx.model ? `${ctx.model.provider}/${ctx.model.id}` : undefined;
+		const parentThinkingLevel = pi.getThinkingLevel();
+		const parentSessionId = runtimeSessionId(ctx);
+		const runtimeRoot = sessionRuntimeDir(parentSessionId);
+		const discovery = discoverAgents(ctx.cwd, scopes.has(parts.at(-1) as AgentScope) ? (parts.at(-1) as AgentScope) : scope);
+		const findAgent = (name: string | undefined) => discovery.agents.find((candidate) => candidate.name === name);
+		const sendMarkdown = (markdown: string) => {
+			pi.sendMessage({ customType: "subagent-trace", content: markdown, display: true });
+		};
+
+		try {
+			if (command === "start" || command === "new" || command === "resume") {
+				const agent = findAgent(parts[1]);
+				if (!agent) throw new Error(`Unknown agent: ${parts[1] ?? "(missing)"}`);
+				if (!agent.pane) throw new Error(`Agent ${agent.name} is not configured for persistent panes. Add \`pane: true\` to its frontmatter to enable.`);
+				const beforeRegistry = await readPaneRegistry(runtimeRoot);
+				const before = beforeRegistry[agent.name];
+				const hadLivePane = Boolean(before && (await paneExists(before.paneId)));
+				const hadSavedSessionFlag = hasSavedPaneSession(runtimeRoot, agent.name);
+				if (command === "new") {
+					if (hadLivePane) await stopPersistentPane(runtimeRoot, agent.name);
+					removeDashboardAgent(agent.name);
+					await resetPersistentPaneSession(runtimeRoot, agent.name);
+				} else if (command === "resume") {
+					if (hadLivePane) await stopPersistentPane(runtimeRoot, agent.name);
+					removeDashboardAgent(agent.name);
+					await restoreArchivedPaneSession(runtimeRoot, agent.name, parts[2] ?? "latest");
+				}
+				const pane = await ensurePersistentPane(runtimeRoot, parentSessionId, ctx.cwd, agent, parentModel, parentThinkingLevel, pi.getActiveTools());
+				if (!hadLivePane || command === "new") {
+					emitSubagentEvent(pi, "subagents:created", {
+						mode: "pane",
+						agent: agent.name,
+						paneId: pane.paneId,
+						runtimeRoot,
+						transcriptPath: pane.sessionFile,
+					});
+				}
+				const startLabel = command === "new" ? "Started new" : command === "resume" ? "Resumed archived" : hadLivePane ? "Reused live" : hadSavedSessionFlag ? "Resumed saved" : "Started new";
+				content = `${startLabel} ${agent.name} (${pane.windowName}).\nSession: ${pane.sessionFile}`;
+				messageDetails = { action: "start", agent: agent.name, sessionFile: pane.sessionFile, windowName: pane.windowName, status: startLabel };
+				await persistRuntimeSnapshot(ctx, runtimeRoot);
+			} else if (command === "send") {
+				const agent = findAgent(parts[1]);
+				if (!agent) throw new Error(`Unknown agent: ${parts[1] ?? "(missing)"}`);
+				if (!agent.pane) throw new Error(`Agent ${agent.name} is not configured for persistent panes. Add \`pane: true\` to its frontmatter to enable.`);
+				const task = parts.slice(2).join(" ").trim();
+				if (!task) throw new Error("Usage: /agents:send <name> <task>");
+				const queued = await queuePersistentPaneTask(runtimeRoot, parentSessionId, ctx.cwd, agent, task, undefined, parentModel, parentThinkingLevel, pi, pi.getActiveTools());
+				const sessionText = queued.sessionMode === "live" ? "reused live pane" : queued.sessionMode === "resumed" ? "resumed saved pane session" : "started new pane session";
+				content = `Queued task for ${agent.name} (${sessionText}).\nArtifacts: inbox=${compactPath(queued.taskFile)} completion=${compactPath(queued.outboxFile)} transcript=${compactPath(queued.pane.sessionFile)}`;
+				messageDetails = { action: "send", agent: agent.name, inboxFile: queued.taskFile, outboxFile: queued.outboxFile, taskId: queued.taskId, transcriptPath: queued.pane.sessionFile, status: sessionText };
+				await persistRuntimeSnapshot(ctx, runtimeRoot);
+			} else if (command === "attach") {
+				const registry = await readPaneRegistry(runtimeRoot);
+				const entry = registry[parts[1] ?? ""];
+				if (!entry || !(await paneExists(entry.paneId))) throw new Error(`No live pane for agent: ${parts[1] ?? "(missing)"}`);
+				const result = await tmux(["select-pane", "-t", entry.paneId]);
+				if (result.code !== 0) throw new Error(result.stderr || result.stdout || "tmux select-pane failed");
+				content = `Attached to ${entry.agent}.`;
+				messageDetails = { action: "attach", agent: entry.agent };
+			} else if (command === "stop") {
+				const stopped = await stopPersistentPane(runtimeRoot, parts[1] ?? "");
+				const stoppedAgent = stopped.agent;
+				removeDashboardAgent(stoppedAgent);
+				content = `Stopped ${stoppedAgent}.`;
+				messageDetails = { action: "stop", agent: stoppedAgent };
+				await persistRuntimeSnapshot(ctx, runtimeRoot);
+			} else if (command === "collect") {
+				const collected = await pollPaneCompletions(runtimeRoot, pi, false);
+				content = `Collected ${collected} agent completion file${collected === 1 ? "" : "s"}.`;
+				messageDetails = { action: "collect", count: collected };
+				await persistRuntimeSnapshot(ctx, runtimeRoot);
+			} else if (command === "status") {
+				const registry = await readPaneRegistry(runtimeRoot);
+				const lines = await Promise.all(
+					Object.values(registry).map(async (entry) => {
+						const live = await paneExists(entry.paneId);
+						return `- ${entry.agent}: ${live ? "live" : "dead"} ${entry.windowName} model=${entry.model ?? "default"} lastTask=${entry.lastTaskAt ?? "never"}`;
+					}),
+				);
+				content = [`# Persistent agent panes`, "", lines.join("\n") || "No persistent panes registered."].join("\n");
+				messageDetails = { action: "status", count: lines.length };
+			} else if (command === "trace") {
+				const ref = parts.slice(1).join(" ").trim();
+				if (!ref) throw new Error("Usage: /agents:trace <ref>");
+				const records = await readTaskRegistry(runtimeRoot);
+				const record = resolveTraceRecord(records, ref);
+				if (!record) throw new Error(`No agent trace matched: ${ref}`);
+				if (ctx.hasUI) {
+					await openTraceViewer(ctx as ExtensionContext, `Trace ${recordTraceRef(record)}`, await traceViewerItems(record));
+					return;
+				}
+				sendMarkdown(await formatTraceView(record, parts.includes("--verbose")));
+				return;
+			} else if (command === "toggle") {
+				dashboardState.visible = !dashboardState.visible;
+				syncDashboard(ctx as ExtensionContext);
+				content = `Agent dashboard ${dashboardState.visible ? `shown (${dashboardState.mode})` : "hidden"}.`;
+				messageDetails = { action: "toggle", status: dashboardState.visible ? `shown (${dashboardState.mode})` : "hidden" };
+			} else {
+				let showName: string | undefined;
+				if (command === "show") {
+					showName = parts[1];
+					if (scopes.has(parts[2] as AgentScope)) scope = parts[2] as AgentScope;
+				} else if (scopes.has(command as AgentScope)) {
+					scope = command as AgentScope;
+				} else if (command) {
+					throw new Error(`Unknown /agents action: ${command}`);
+				}
+
+				if (ctx.hasUI) {
+					await openAgentsBrowser(ctx, scope, showName, runtimeRoot, parentSessionId, parentModel, parentThinkingLevel, pi.getActiveTools(), () => activeDashboardItems(Object.values(dashboardState.items)), removeDashboardAgent);
+					return;
+				}
+
+				const scopedDiscovery = discoverAgents(ctx.cwd, scope);
+				if (showName) {
+					const agent = scopedDiscovery.agents.find((candidate) => candidate.name === showName);
+					content = agent
+						? [
+								`# Agent: ${agent.name}`,
+								`Source: ${agent.source}`,
+								`Path: ${agent.filePath}`,
+								`Model: ${agent.model ?? "default"}`,
+								`Deny tools: ${agent.denyTools && agent.denyTools.length > 0 ? agent.denyTools.join(", ") : "none"}`,
+								`Persistent pane: ${agent.pane ? "yes" : "no"}`,
+								"",
+								agent.description,
+								"",
+								"---",
+								"",
+								agent.systemPrompt.trim(),
+							]
+							.join("\n")
+						: `Unknown agent "${showName}" for scope "${scope}". Available: ${scopedDiscovery.agents
+								.map((agent) => agent.name)
+								.join(", ") || "none"}.`;
+					messageDetails = { action: "show", agent: showName };
+				} else {
+					const formatted = formatAgentList(scopedDiscovery.agents);
+					content = [
+						`# Available agents (${scope})`,
+						`Project agent dirs: ${scopedDiscovery.projectAgentsDir ?? "none"}`,
+						"",
+						formatted.text
+							.split("; ")
+							.map((line) => {
+								const name = line.match(/^-?\s*([^ ]+)/)?.[1];
+								const agent = scopedDiscovery.agents.find((candidate) => candidate.name === name);
+								return `- ${line}${agent?.pane ? " [pane]" : ""}`;
+							})
+							.join("\n"),
+						"",
+						"Commands: `/agents show <name>`, `/agents:start <name>` (resume/reuse), `/agents:new <name>` (fresh session), `/agents:send <name> <task>`, `/agents:attach <name>`, `/agents:stop <name>`, `/agents status`, `/agents:trace <ref>`, `/agents:toggle`. The popup's History tab browses past tasks visually.",
+					].join("\n");
+					messageDetails = { action: "list", count: scopedDiscovery.agents.length };
+				}
+			}
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			content = `Error: ${message}`;
+			messageDetails = { action: "error", error: message };
+		}
+
+		pi.sendMessage({ customType: "subagent-agents", content, details: messageDetails, display: true });
+	};
+
+	pi.registerCommand("agents", {
+		description: "Agent browser and persistent pane manager.",
+		getArgumentCompletions: agentsArgumentCompletions,
+		handler: agentsHandler,
+	});
+
+	const paneAgentNameCompletions = (subcommand: string) => (prefix: string) => {
+		const query = prefix.trimStart().toLowerCase();
+		const needsPane = subcommand !== "show";
+		const items = agentCommandCompletions
+			.filter((agent) => (!needsPane || agent.pane) && (!query || agent.value.toLowerCase().startsWith(query)))
+			.slice(0, 20)
+			.map((agent) => ({ value: agent.value, label: agent.label, description: agent.description }));
+		return items.length > 0 ? items : null;
+	};
+
+	const traceRefCompletions = (prefix: string) => {
+		const query = prefix.trimStart().toLowerCase();
+		const records = Object.values(dashboardState.items).sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+		const completions = records
+			.filter((item) => !query || item.taskId.toLowerCase().includes(query) || item.agent.toLowerCase().includes(query))
+			.slice(0, 20)
+			.map((item) => {
+				const when = formatRelativeTime(item.completedAt ?? item.startedAt ?? item.updatedAt);
+				const summary = oneLinePreview(item.message, 60);
+				return {
+					value: item.taskId,
+					label: `${item.agent} · ${when}`,
+					description: summary ? `${item.status} · ${summary}` : item.status,
+				};
+			});
+		return completions.length > 0 ? completions : null;
+	};
+
+	pi.registerCommand("agents:toggle", {
+		description: "Toggle the agent dashboard",
+		handler: async (_args, ctx) => agentsHandler("toggle", ctx),
+	});
+
+	for (const sub of ["start", "new", "send", "attach", "stop"] as const) {
+		const description =
+			sub === "start" ? "Start or reuse a persistent pane: /agents:start <name>" :
+			sub === "new" ? "Start a persistent pane with a fresh session: /agents:new <name>" :
+			sub === "send" ? "Queue a task for a persistent pane: /agents:send <name> <task>" :
+			sub === "attach" ? "Focus an existing agent pane: /agents:attach <name>" :
+			"Stop an agent pane: /agents:stop <name>";
+		pi.registerCommand(`agents:${sub}`, {
+			description,
+			getArgumentCompletions: paneAgentNameCompletions(sub),
+			handler: async (args, ctx) => agentsHandler(`${sub} ${args}`.trim(), ctx),
+		});
+	}
+
+	pi.registerCommand("agents:trace", {
+		description: "View an agent trace by ref/task id: /agents:trace <ref>",
+		getArgumentCompletions: traceRefCompletions,
+		handler: async (args, ctx) => agentsHandler(`trace ${args}`.trim(), ctx),
+	});
+
+}

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/dispatch.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/dispatch.ts
@@ -390,3 +390,74 @@ export async function runParallelDispatch(
 		details: flow.makeDetails("parallel")(preparedResults.map((prepared) => prepared.result)),
 	};
 }
+
+export async function runSingleDispatch(
+	flow: DispatchFlowContext & { agent: string; task: string; cwdOverride?: string; sessionKey?: string },
+): Promise<ToolTextResult> {
+	const agent = flow.agents.find((candidate) => candidate.name === flow.agent);
+	const result = agent?.pane
+		? await runPersistentPaneAgent(
+				flow.cwd,
+				flow.runtimeRoot,
+				flow.parentSessionId,
+				flow.agents,
+				flow.agent,
+				flow.task,
+				flow.cwdOverride,
+				flow.parentModel,
+				flow.parentThinkingLevel,
+				undefined,
+				flow.pi,
+				flow.forceSpawn ?? false,
+				flow.resumeSession,
+				flow.removeDashboardAgent,
+			)
+		: await runSingleAgent(
+				flow.cwd,
+				flow.runtimeRoot,
+				flow.agents,
+				flow.agent,
+				flow.task,
+				flow.cwdOverride,
+				flow.parentModel,
+				flow.parentThinkingLevel,
+				undefined,
+				flow.pi,
+				flow.signal,
+				flow.onUpdate,
+				flow.makeDetails("single"),
+				flow.sessionKey,
+			);
+	if (!agent?.pane) {
+		flow.updateDashboard({
+			agent: result.agent,
+			kind: "oneshot",
+			message: oneLinePreview(getFinalOutput(result.messages), 120) || result.task,
+			model: result.model,
+			status: result.exitCode === 0 ? "completed" : "failed",
+			task: result.task,
+			taskId: result.taskId ?? result.agent,
+			transcriptPath: result.transcriptPath,
+			updatedAt: new Date().toISOString(),
+			usage: result.usage,
+		});
+	}
+	const isError = result.exitCode !== 0 || result.stopReason === "error" || result.stopReason === "aborted";
+	if (isError) {
+		const errorMsg = result.errorMessage || result.stderr || getFinalOutput(result.messages) || "(no output)";
+		const prepared = await prepareSingleResultForReturn(result, flow.runtimeRoot, flow.cwd, "single-error", errorMsg);
+		prepared.result.errorMessage = prepared.text || errorMsg;
+		const details = flow.makeDetails("single")([prepared.result]);
+		return {
+			content: [{ type: "text", text: `Agent ${result.stopReason || "failed"}: ${prepared.text || "(no output)"}` }],
+			details: detailsWithTruncation(details, prepared),
+			isError: true,
+		};
+	}
+	const prepared = await prepareSingleResultForReturn(result, flow.runtimeRoot, flow.cwd, "single");
+	const details = flow.makeDetails("single")([prepared.result]);
+	return {
+		content: [{ type: "text", text: prepared.text || "(no output)" }],
+		details: detailsWithTruncation(details, prepared),
+	};
+}

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/dispatch.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/dispatch.ts
@@ -1,11 +1,59 @@
+import type { AgentToolResult, ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { AgentConfig, AgentScope } from "./agents.js";
+import { getFinalOutput, oneLinePreview } from "./format.js";
+import { runPersistentPaneAgent } from "./pane.js";
+import {
+	cloneMessagesForDetails,
+	detailsWithTruncation,
+	prepareSingleResultForReturn,
+	runSingleAgent,
+	truncateForDetails,
+	type OnUpdateCallback,
+} from "./runner.js";
 import { createOneShotSessionKey } from "./sessions.js";
+import { settingNumber } from "./settings.js";
+import {
+	DEFAULT_RESULT_MAX_BYTES,
+	DEFAULT_RESULT_MAX_LINES,
+	MAX_CONCURRENCY,
+	MAX_PARALLEL_TASKS,
+	type SingleResult,
+	type SubagentDashboardItem,
+	type SubagentDetails,
+} from "./types.js";
 
 export interface DispatchItem {
 	agent: string;
 	cwd?: string;
 	sessionKey?: string;
 	task?: string;
+}
+
+export interface DispatchTask extends DispatchItem {
+	task: string;
+}
+
+type ToolTextResult = {
+	content: Array<{ type: "text"; text: string }>;
+	details: SubagentDetails;
+	isError?: boolean;
+};
+
+interface DispatchFlowContext {
+	agents: AgentConfig[];
+	cwd: string;
+	forceSpawn?: boolean;
+	makeDetails: (mode: "single" | "parallel" | "chain") => (results: SingleResult[]) => SubagentDetails;
+	onUpdate?: OnUpdateCallback;
+	parentModel?: string;
+	parentSessionId: string;
+	parentThinkingLevel?: string;
+	pi: ExtensionAPI;
+	removeDashboardAgent: (agentName: string) => void;
+	resumeSession?: string;
+	runtimeRoot: string;
+	signal?: AbortSignal;
+	updateDashboard: (item: SubagentDashboardItem) => void;
 }
 
 export interface AgentInventory {
@@ -87,4 +135,258 @@ export function formatInventoryValidationError(validation: InventoryValidationRe
 		`Project agents: ${availableProject}.`,
 		`User agents: ${availableUser}.`,
 	].join("\n");
+}
+
+export async function runChainDispatch(
+	flow: DispatchFlowContext & { chain: DispatchTask[] },
+): Promise<ToolTextResult> {
+	const chainSteps = assignEphemeralSessionKeys(flow.chain);
+	const results: SingleResult[] = [];
+	let previousOutput = "";
+
+	for (let i = 0; i < chainSteps.length; i++) {
+		const step = chainSteps[i];
+		const taskWithContext = step.task.replace(/\{previous\}/g, previousOutput);
+
+		const chainUpdate: OnUpdateCallback | undefined = flow.onUpdate
+			? (partial: AgentToolResult<SubagentDetails>) => {
+					const currentResult = partial.details?.results[0];
+					if (currentResult) {
+						const allResults = [...results, currentResult].map((result) => {
+							const rawOutput = getFinalOutput(result.messages);
+							return {
+								...result,
+								messages: cloneMessagesForDetails(
+									result.messages,
+									rawOutput ? truncateForDetails(rawOutput, flow.cwd) : undefined,
+									flow.cwd,
+								),
+							};
+						});
+						flow.onUpdate?.({
+							content: partial.content,
+							details: flow.makeDetails("chain")(allResults),
+						});
+					}
+				}
+			: undefined;
+
+		const stepAgent = flow.agents.find((agent) => agent.name === step.agent);
+		const result = stepAgent?.pane
+			? await runPersistentPaneAgent(
+					flow.cwd,
+					flow.runtimeRoot,
+					flow.parentSessionId,
+					flow.agents,
+					step.agent,
+					taskWithContext,
+					step.cwd,
+					flow.parentModel,
+					flow.parentThinkingLevel,
+					i + 1,
+					flow.pi,
+					flow.forceSpawn ?? false,
+					flow.resumeSession,
+					flow.removeDashboardAgent,
+				)
+			: await runSingleAgent(
+					flow.cwd,
+					flow.runtimeRoot,
+					flow.agents,
+					step.agent,
+					taskWithContext,
+					step.cwd,
+					flow.parentModel,
+					flow.parentThinkingLevel,
+					i + 1,
+					flow.pi,
+					flow.signal,
+					chainUpdate,
+					flow.makeDetails("chain"),
+					step.sessionKey,
+				);
+		results.push(result);
+		if (!stepAgent?.pane) {
+			flow.updateDashboard({
+				agent: result.agent,
+				kind: "oneshot",
+				message: oneLinePreview(getFinalOutput(result.messages), 120) || result.task,
+				model: result.model,
+				status: result.exitCode === 0 ? "completed" : "failed",
+				task: result.task,
+				taskId: result.taskId ?? `${result.agent}-step-${i + 1}`,
+				transcriptPath: result.transcriptPath,
+				updatedAt: new Date().toISOString(),
+				usage: result.usage,
+			});
+		}
+
+		const isError = result.exitCode !== 0 || result.stopReason === "error" || result.stopReason === "aborted";
+		if (isError) {
+			const errorMsg = result.errorMessage || result.stderr || getFinalOutput(result.messages) || "(no output)";
+			const preparedResults = await Promise.all(
+				results.map((candidate, index) =>
+					prepareSingleResultForReturn(
+						candidate,
+						flow.runtimeRoot,
+						flow.cwd,
+						`chain-step-${candidate.step ?? index + 1}`,
+						candidate === result ? errorMsg : undefined,
+					),
+				),
+			);
+			const failed = preparedResults[preparedResults.length - 1];
+			failed.result.errorMessage = failed.text || errorMsg;
+			const details = flow.makeDetails("chain")(preparedResults.map((prepared) => prepared.result));
+			return {
+				content: [{ type: "text", text: `Chain stopped at step ${i + 1} (${step.agent}): ${failed.text || "(no output)"}` }],
+				details: detailsWithTruncation(details, failed),
+				isError: true,
+			};
+		}
+		previousOutput = getFinalOutput(result.messages);
+	}
+	const preparedResults = await Promise.all(
+		results.map((result, index) =>
+			prepareSingleResultForReturn(result, flow.runtimeRoot, flow.cwd, `chain-step-${result.step ?? index + 1}`),
+		),
+	);
+	const last = preparedResults[preparedResults.length - 1];
+	const details = flow.makeDetails("chain")(preparedResults.map((prepared) => prepared.result));
+	return {
+		content: [{ type: "text", text: last.text || "(no output)" }],
+		details: detailsWithTruncation(details, last),
+	};
+}
+
+export async function runParallelDispatch(
+	flow: DispatchFlowContext & { tasks: DispatchTask[] },
+): Promise<ToolTextResult> {
+	const parallelTasks = assignEphemeralSessionKeys(flow.tasks);
+	const parallelBatchSize = Math.max(1, Math.floor(settingNumber("maxParallelTasks", MAX_PARALLEL_TASKS, flow.cwd)));
+
+	const allResults: SingleResult[] = new Array(flow.tasks.length);
+	for (let i = 0; i < flow.tasks.length; i++) {
+		allResults[i] = {
+			agent: parallelTasks[i].agent,
+			agentSource: "unknown",
+			task: parallelTasks[i].task,
+			exitCode: -1,
+			messages: [],
+			stderr: "",
+			usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, contextTokens: 0, turns: 0 },
+		};
+	}
+
+	const emitParallelUpdate = () => {
+		if (flow.onUpdate) {
+			const running = allResults.filter((r) => r.exitCode === -1).length;
+			const done = allResults.filter((r) => r.exitCode !== -1).length;
+			const updateResults = allResults.map((result) => {
+				const rawOutput = getFinalOutput(result.messages);
+				return {
+					...result,
+					messages: cloneMessagesForDetails(
+						result.messages,
+						rawOutput ? truncateForDetails(rawOutput, flow.cwd) : undefined,
+						flow.cwd,
+					),
+				};
+			});
+			flow.onUpdate({
+				content: [{ type: "text", text: `Parallel: ${done}/${allResults.length} done, ${running} running...` }],
+				details: flow.makeDetails("parallel")(updateResults),
+			});
+		}
+	};
+
+	const maxConcurrency = Math.max(1, Math.floor(settingNumber("maxConcurrency", MAX_CONCURRENCY, flow.cwd)));
+	const results = await mapInBatchesWithConcurrencyLimit(parallelTasks, parallelBatchSize, maxConcurrency, async (t, index) => {
+		const updateOneshotDashboard = (item: SingleResult) => {
+			flow.updateDashboard({
+				agent: item.agent,
+				kind: "oneshot",
+				message: oneLinePreview(getFinalOutput(item.messages), 120) || item.task,
+				model: item.model,
+				status: item.exitCode === -1 ? "running" : item.exitCode === 0 ? "completed" : "failed",
+				task: item.task,
+				taskId: item.taskId ?? `${item.agent}-${index}`,
+				transcriptPath: item.transcriptPath,
+				updatedAt: new Date().toISOString(),
+				usage: item.usage,
+			});
+		};
+		const taskAgent = flow.agents.find((agent) => agent.name === t.agent);
+		const result = taskAgent?.pane
+			? await runPersistentPaneAgent(
+					flow.cwd,
+					flow.runtimeRoot,
+					flow.parentSessionId,
+					flow.agents,
+					t.agent,
+					t.task,
+					t.cwd,
+					flow.parentModel,
+					flow.parentThinkingLevel,
+					undefined,
+					flow.pi,
+					flow.forceSpawn ?? false,
+					flow.resumeSession,
+					flow.removeDashboardAgent,
+				)
+			: await runSingleAgent(
+					flow.cwd,
+					flow.runtimeRoot,
+					flow.agents,
+					t.agent,
+					t.task,
+					t.cwd,
+					flow.parentModel,
+					flow.parentThinkingLevel,
+					undefined,
+					flow.pi,
+					flow.signal,
+					(partial) => {
+						if (partial.details?.results[0]) {
+							allResults[index] = partial.details.results[0];
+							updateOneshotDashboard(partial.details.results[0]);
+							emitParallelUpdate();
+						}
+					},
+					flow.makeDetails("parallel"),
+					t.sessionKey,
+				);
+		allResults[index] = result;
+		if (!taskAgent?.pane) updateOneshotDashboard(result);
+		emitParallelUpdate();
+		return result;
+	});
+
+	const successCount = results.filter((r) => r.exitCode === 0).length;
+	const perResultLimits = (() => {
+		const total = { maxBytes: Math.max(1, Math.floor(settingNumber("resultMaxBytes", DEFAULT_RESULT_MAX_BYTES, flow.cwd))), maxLines: Math.max(1, Math.floor(settingNumber("resultMaxLines", DEFAULT_RESULT_MAX_LINES, flow.cwd))) };
+		const count = Math.max(1, results.length);
+		return { maxBytes: Math.max(1024, Math.floor(total.maxBytes / count)), maxLines: Math.max(40, Math.floor(total.maxLines / count)) };
+	})();
+	const preparedResults = await Promise.all(
+		results.map((result, index) =>
+			prepareSingleResultForReturn(
+				result,
+				flow.runtimeRoot,
+				flow.cwd,
+				`parallel-${index + 1}-${result.agent}`,
+				undefined,
+				perResultLimits,
+			),
+		),
+	);
+	const sections = preparedResults.map((prepared) => {
+		const r = prepared.result;
+		const status = r.exitCode === 0 ? "completed" : r.exitCode === -1 ? "running" : "failed";
+		return `## ${r.agent} (${status})\n${prepared.text || "(no output)"}`;
+	});
+	return {
+		content: [{ type: "text", text: `Parallel: ${successCount}/${results.length} succeeded\n\n${sections.join("\n\n")}` }],
+		details: flow.makeDetails("parallel")(preparedResults.map((prepared) => prepared.result)),
+	};
 }

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/dispatch.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/dispatch.ts
@@ -1,0 +1,90 @@
+import type { AgentConfig, AgentScope } from "./agents.js";
+import { createOneShotSessionKey } from "./sessions.js";
+
+export interface DispatchItem {
+	agent: string;
+	cwd?: string;
+	sessionKey?: string;
+	task?: string;
+}
+
+export interface AgentInventory {
+	allowed: AgentConfig[];
+	project: AgentConfig[];
+	user: AgentConfig[];
+}
+
+export interface InventoryValidationResult {
+	available: {
+		allowed: string[];
+		project: string[];
+		user: string[];
+	};
+	missing: string[];
+	scope: AgentScope;
+}
+
+export function assignEphemeralSessionKeys<T extends DispatchItem>(items: readonly T[]): Array<T & { sessionKey: string }> {
+	return items.map((item) => {
+		if (item.sessionKey?.trim()) return { ...item, sessionKey: item.sessionKey.trim() };
+		return { ...item, sessionKey: createOneShotSessionKey() };
+	});
+}
+
+export async function mapInBatchesWithConcurrencyLimit<TIn, TOut>(
+	items: readonly TIn[],
+	batchSize: number,
+	concurrency: number,
+	fn: (item: TIn, index: number) => Promise<TOut>,
+): Promise<TOut[]> {
+	if (items.length === 0) return [];
+	const normalizedBatchSize = Math.max(1, Math.floor(batchSize));
+	const normalizedConcurrency = Math.max(1, Math.floor(concurrency));
+	const results: TOut[] = new Array(items.length);
+	for (let start = 0; start < items.length; start += normalizedBatchSize) {
+		const batch = items.slice(start, start + normalizedBatchSize);
+		let nextIndex = 0;
+		const workerCount = Math.min(normalizedConcurrency, batch.length);
+		const workers = new Array(workerCount).fill(null).map(async () => {
+			while (true) {
+				const batchIndex = nextIndex++;
+				if (batchIndex >= batch.length) return;
+				const absoluteIndex = start + batchIndex;
+				results[absoluteIndex] = await fn(batch[batchIndex], absoluteIndex);
+			}
+		});
+		await Promise.all(workers);
+	}
+	return results;
+}
+
+export function validateAgentInventory(
+	requestedNames: Iterable<string>,
+	inventory: AgentInventory,
+	scope: AgentScope,
+): InventoryValidationResult | undefined {
+	const allowed = new Set(inventory.allowed.map((agent) => agent.name));
+	const missing = [...new Set(Array.from(requestedNames).filter((name) => !allowed.has(name)))].sort((a, b) => a.localeCompare(b));
+	if (missing.length === 0) return undefined;
+	return {
+		available: {
+			allowed: [...allowed].sort((a, b) => a.localeCompare(b)),
+			project: inventory.project.map((agent) => agent.name).sort((a, b) => a.localeCompare(b)),
+			user: inventory.user.map((agent) => agent.name).sort((a, b) => a.localeCompare(b)),
+		},
+		missing,
+		scope,
+	};
+}
+
+export function formatInventoryValidationError(validation: InventoryValidationResult): string {
+	const availableAllowed = validation.available.allowed.length > 0 ? validation.available.allowed.join(", ") : "none";
+	const availableProject = validation.available.project.length > 0 ? validation.available.project.join(", ") : "none";
+	const availableUser = validation.available.user.length > 0 ? validation.available.user.join(", ") : "none";
+	return [
+		`Unknown subagent(s) for agentScope=${validation.scope}: ${validation.missing.join(", ")}.`,
+		`Available in selected scope: ${availableAllowed}.`,
+		`Project agents: ${availableProject}.`,
+		`User agents: ${availableUser}.`,
+	].join("\n");
+}

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/file-lock.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/file-lock.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { withFileMutationQueue } from "@earendil-works/pi-coding-agent";
+import { randomHex, randomJitter } from "./random.js";
 
 interface LockOptions {
 	staleMs?: number;
@@ -102,7 +103,7 @@ export async function acquireFileLock(filePath: string, opts: LockOptions = {}):
 		if (Date.now() - start > timeoutMs) {
 			throw new Error(`Timed out acquiring file lock for ${filePath} after ${timeoutMs}ms`);
 		}
-		const jitter = Math.floor(Math.random() * retryMs);
+		const jitter = randomJitter(retryMs);
 		await new Promise((resolve) => setTimeout(resolve, retryMs + jitter));
 	}
 }
@@ -143,7 +144,7 @@ export async function atomicWriteFile(
 	mode: number = 0o600,
 ): Promise<void> {
 	await fs.promises.mkdir(path.dirname(filePath), { recursive: true, mode: 0o700 });
-	const tmpPath = `${filePath}.tmp.${process.pid}.${Math.random().toString(16).slice(2)}`;
+	const tmpPath = `${filePath}.tmp.${process.pid}.${randomHex(8)}`;
 	await fs.promises.writeFile(tmpPath, content, { encoding: typeof content === "string" ? "utf-8" : undefined, mode });
 	try {
 		await fs.promises.rename(tmpPath, filePath);

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/index.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/index.ts
@@ -51,10 +51,16 @@ import {
 	wrappedText,
 } from "./format.js";
 import {
+	assignEphemeralSessionKeys,
+	formatInventoryValidationError,
+	mapInBatchesWithConcurrencyLimit,
+	validateAgentInventory,
+	type AgentInventory,
+} from "./dispatch.js";
+import {
 	ensurePaneBridgeMetadata,
 	ensurePersistentPane,
 	execCapture,
-	mapWithConcurrencyLimit,
 	migrateLegacyPackageRuntime,
 	migrateLegacyProjectRuntime,
 	paneExists,
@@ -137,6 +143,7 @@ import {
 	SteerSubagentParams,
 	StopSubagentParams,
 	SubagentParams,
+	WaitForSubagentIdleParams,
 } from "./tools.js";
 import {
 	COLLAPSED_ITEM_COUNT,
@@ -165,14 +172,31 @@ import {
 	type SubagentStatsBridge,
 	type SubagentStatsItem,
 	type SubagentStatuslineBridge,
+	type WaitForSubagentIdleDetails,
 	SUBAGENT_WIDGET_KEY,
 	type UsageStats,
 } from "./types.js";
+import { extractBridgeState, waitForIdleTransition } from "./wait.js";
 
 function bridgeTargetArgs(metadata: { socket?: string; pid?: string }): string[] {
 	if (metadata.socket) return ["--socket", metadata.socket];
 	if (metadata.pid) return ["--pid", metadata.pid];
 	return [];
+}
+
+function launchInventory(cwd: string, scope: AgentScope, allowed: AgentConfig[]): AgentInventory {
+	void scope;
+	const project = discoverAgents(cwd, "project").agents;
+	const user = discoverAgents(cwd, "user").agents;
+	return { allowed, project, user };
+}
+
+function collectRequestedAgentNames(params: Record<string, any>): Set<string> {
+	const requested = new Set<string>();
+	if (Array.isArray(params.chain)) for (const step of params.chain) if (typeof step?.agent === "string") requested.add(step.agent);
+	if (Array.isArray(params.tasks)) for (const task of params.tasks) if (typeof task?.agent === "string") requested.add(task.agent);
+	if (typeof params.agent === "string") requested.add(params.agent);
+	return requested;
 }
 
 type FollowUpTask = { taskId: string; outboxFile: string; taskFile?: string };
@@ -1355,11 +1379,72 @@ export default function (pi: ExtensionAPI) {
 		});
 	}
 
+	const waitForPaneIdle = async (ctx: ExtensionCommandContext | ExtensionContext, agentName: string, timeoutMs = 30000): Promise<{ text: string; details: WaitForSubagentIdleDetails; isError?: boolean }> => {
+		const runtimeRoot = sessionRuntimeDir(runtimeSessionId(ctx as ExtensionContext));
+		const registry = await readPaneRegistry(runtimeRoot);
+		const entry = registry[agentName];
+		if (!entry) {
+			return {
+				text: `No persistent pane registry entry for ${agentName} in runtime ${runtimeRoot}.`,
+				details: { agent: agentName, runtimeRoot, samples: 0, timedOut: false, transitioned: false },
+				isError: true,
+			};
+		}
+		if (!paneSessionBelongsToRuntime(runtimeRoot, entry)) {
+			return {
+				text: `Refusing to wait for ${agentName}: pane session file is outside this runtime. Session: ${entry.sessionFile}. Runtime: ${runtimeRoot}`,
+				details: { agent: agentName, paneId: entry.paneId, runtimeRoot, samples: 0, sessionFile: entry.sessionFile, timedOut: false, transitioned: false },
+				isError: true,
+			};
+		}
+		if (!(await paneExists(entry.paneId))) {
+			return {
+				text: `Agent ${agentName} is not live.`,
+				details: { agent: agentName, paneId: entry.paneId, runtimeRoot, samples: 0, sessionFile: entry.sessionFile, timedOut: false, transitioned: false },
+				isError: true,
+			};
+		}
+		const metadata = await ensurePaneBridgeMetadata(runtimeRoot, entry);
+		const bridgeBin = metadata ? await resolvePiBridgeBin() : undefined;
+		const targetArgs = metadata ? bridgeTargetArgs(metadata) : [];
+		if (!bridgeBin || targetArgs.length === 0) {
+			return {
+				text: `No live pi-bridge target for ${agentName}; cannot wait for isIdle transition.`,
+				details: { agent: agentName, paneId: entry.paneId, runtimeRoot, samples: 0, sessionFile: entry.sessionFile, timedOut: false, transitioned: false },
+				isError: true,
+			};
+		}
+		const wait = await waitForIdleTransition(async () => {
+			const result = await execCapture(bridgeBin, ["state", ...targetArgs], { cwd: entry.cwd });
+			if (result.code !== 0) return undefined;
+			return extractBridgeState(result.stdout);
+		}, timeoutMs, 500);
+		const details: WaitForSubagentIdleDetails = {
+			agent: agentName,
+			bridgePid: metadata?.pid,
+			bridgeSocket: metadata?.socket,
+			isIdle: wait.lastState?.isIdle,
+			paneId: entry.paneId,
+			runtimeRoot,
+			samples: wait.samples,
+			sessionFile: entry.sessionFile,
+			timedOut: wait.timedOut,
+			transitioned: wait.transitioned,
+		};
+		return {
+			text: wait.transitioned
+				? `${agentName} is idle (pane ${entry.paneId}).`
+				: `Timed out waiting for ${agentName} idle transition after ${timeoutMs}ms.`,
+			details,
+			isError: !wait.transitioned,
+		};
+	};
+
 	pi.registerTool({
 		renderShell: "self",
 		name: "get_subagent_result",
 		label: "Get Agent Result",
-		description: "Retrieve status/results for persistent pane agent tasks by taskId or latest agent task. This is a recovery/status tool for pane tasks and does not change Flightdeck or Orchestration ownership.",
+		description: "Retrieve status/results for persistent pane agent tasks by taskId or latest agent task. Use waitFor: \"idle\" to wait for pane isIdle transition without shell polling. This is a recovery/status tool for pane tasks and does not change Flightdeck or Orchestration ownership.",
 		parameters: GetSubagentResultParams,
 		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
 			if (!params.taskId && !params.agent) {
@@ -1370,6 +1455,26 @@ export default function (pi: ExtensionAPI) {
 				};
 			}
 			const runtimeRoot = sessionRuntimeDir(runtimeSessionId(ctx));
+			if ((params.waitFor ?? "completion") === "idle") {
+				let agentName = params.agent;
+				if (!agentName && params.taskId) {
+					const records = await readTaskRegistry(runtimeRoot);
+					agentName = records[params.taskId]?.agent;
+				}
+				if (!agentName) {
+					return {
+						content: [{ type: "text", text: `No task record found for ${params.taskId}; provide agent to wait for pane idle.` }],
+						details: { taskId: params.taskId, waitFor: "idle" } satisfies GetSubagentResultDetails,
+						isError: true,
+					};
+				}
+				const waited = await waitForPaneIdle(ctx, agentName, params.timeoutMs ?? 30000);
+				return {
+					content: [{ type: "text", text: waited.text }],
+					details: { agent: agentName, paneId: waited.details.paneId, taskId: params.taskId, waitFor: "idle", waitTimedOut: waited.details.timedOut } satisfies GetSubagentResultDetails,
+					isError: waited.isError,
+				};
+			}
 			const deadline = Date.now() + Math.max(0, Math.floor(params.timeoutMs ?? 30000));
 			let record: PaneTaskRecord | undefined;
 			let diagnostics: string[] = [];
@@ -1411,6 +1516,31 @@ export default function (pi: ExtensionAPI) {
 			const target = details?.agent ? details.agent : "unknown";
 			const tone = details?.status === "completed" ? "success" : details?.status === "failed" ? "error" : "warning";
 			return wrappedText(agentStatusLine(theme, target, details?.status ?? "result", tone));
+		},
+	});
+
+	pi.registerTool({
+		renderShell: "self",
+		name: "wait_for_subagent_idle",
+		label: "Wait Agent Idle",
+		description: "Wait for a persistent pane agent's pi-bridge state to transition to isIdle=true. Use this instead of polling pi-bridge state in shell loops.",
+		parameters: WaitForSubagentIdleParams,
+		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+			const waited = await waitForPaneIdle(ctx, params.agent, params.timeoutMs ?? 30000);
+			return {
+				content: [{ type: "text", text: waited.text }],
+				details: waited.details,
+				isError: waited.isError,
+			};
+		},
+		renderCall(_args, _theme, _context) {
+			return new Container();
+		},
+		renderResult(result, _options, theme, context) {
+			const raw = (result.content as any[] | undefined)?.find?.((part: any) => part?.type === "text" && typeof part.text === "string")?.text ?? "";
+			const details = result.details as WaitForSubagentIdleDetails | undefined;
+			if (context?.isError) return wrappedText(`${theme.fg("error", ICONS.times)} ${theme.fg("toolTitle", "Agent idle wait failed")}\n${theme.fg("muted", raw)}`);
+			return wrappedText(agentStatusLine(theme, details?.agent ?? "agent", "idle", "success"));
 		},
 	});
 
@@ -1628,6 +1758,8 @@ export default function (pi: ExtensionAPI) {
 		description: [
 			"Delegate tasks to specialized agents with isolated context.",
 			"Modes: single (agent + task), parallel (tasks array), chain (sequential with {previous} placeholder).",
+			"Bg agents use fresh one-shot sessions by default; pass sessionKey only when you want continuity.",
+			`Parallel calls above ${MAX_PARALLEL_TASKS} items are internally batched; callers do not need to split requests.`,
 			`Results are truncated by default to ${DEFAULT_RESULT_MAX_LINES} lines or ${formatSize(DEFAULT_RESULT_MAX_BYTES)}; full oversized output is saved under the session runtime when enabled.`,
 			'Default agent scope is "project" (.pi/agents plus .claude/agents compatibility).',
 			'Use agentScope: "both" to include user-level agents from ~/.pi/agent/agents.',
@@ -1666,12 +1798,18 @@ export default function (pi: ExtensionAPI) {
 				};
 			}
 
-			if ((agentScope === "project" || agentScope === "both") && confirmProjectAgents && ctx.hasUI) {
-				const requestedAgentNames = new Set<string>();
-				if (params.chain) for (const step of params.chain) requestedAgentNames.add(step.agent);
-				if (params.tasks) for (const t of params.tasks) requestedAgentNames.add(t.agent);
-				if (params.agent) requestedAgentNames.add(params.agent);
+			const requestedAgentNames = collectRequestedAgentNames(params as Record<string, any>);
+			const inventoryError = validateAgentInventory(requestedAgentNames, launchInventory(ctx.cwd, agentScope, agents), agentScope);
+			if (inventoryError) {
+				const mode = hasChain ? "chain" : hasTasks ? "parallel" : "single";
+				return {
+					content: [{ type: "text", text: formatInventoryValidationError(inventoryError) }],
+					details: { ...makeDetails(mode)([]), inventoryError },
+					isError: true,
+				};
+			}
 
+			if ((agentScope === "project" || agentScope === "both") && confirmProjectAgents && ctx.hasUI) {
 				const projectAgentsRequested = Array.from(requestedAgentNames)
 					.map((name) => agents.find((a) => a.name === name))
 					.filter((a): a is AgentConfig => a?.source === "project");
@@ -1692,11 +1830,12 @@ export default function (pi: ExtensionAPI) {
 			}
 
 			if (params.chain && params.chain.length > 0) {
+				const chainSteps = assignEphemeralSessionKeys(params.chain as Array<{ agent: string; task: string; cwd?: string; sessionKey?: string }>);
 				const results: SingleResult[] = [];
 				let previousOutput = "";
 
-				for (let i = 0; i < params.chain.length; i++) {
-					const step = params.chain[i];
+				for (let i = 0; i < chainSteps.length; i++) {
+					const step = chainSteps[i];
 					const taskWithContext = step.task.replace(/\{previous\}/g, previousOutput);
 
 					const chainUpdate: OnUpdateCallback | undefined = onUpdate
@@ -1811,19 +1950,15 @@ export default function (pi: ExtensionAPI) {
 			}
 
 			if (params.tasks && params.tasks.length > 0) {
-				const maxParallelTasks = Math.max(1, Math.floor(settingNumber("maxParallelTasks", MAX_PARALLEL_TASKS, ctx.cwd)));
-				if (params.tasks.length > maxParallelTasks)
-					return {
-						content: [{ type: "text", text: `Too many parallel tasks (${params.tasks.length}). Max is ${maxParallelTasks}.` }],
-						details: makeDetails("parallel")([]),
-					};
+				const parallelTasks = assignEphemeralSessionKeys(params.tasks as Array<{ agent: string; task: string; cwd?: string; sessionKey?: string }>);
+				const parallelBatchSize = Math.max(1, Math.floor(settingNumber("maxParallelTasks", MAX_PARALLEL_TASKS, ctx.cwd)));
 
 				const allResults: SingleResult[] = new Array(params.tasks.length);
 				for (let i = 0; i < params.tasks.length; i++) {
 					allResults[i] = {
-						agent: params.tasks[i].agent,
+						agent: parallelTasks[i].agent,
 						agentSource: "unknown",
-						task: params.tasks[i].task,
+						task: parallelTasks[i].task,
 						exitCode: -1,
 						messages: [],
 						stderr: "",
@@ -1854,7 +1989,7 @@ export default function (pi: ExtensionAPI) {
 				};
 
 				const maxConcurrency = Math.max(1, Math.floor(settingNumber("maxConcurrency", MAX_CONCURRENCY, ctx.cwd)));
-				const results = await mapWithConcurrencyLimit(params.tasks, maxConcurrency, async (t: { agent: string; task: string; cwd?: string; sessionKey?: string }, index) => {
+				const results = await mapInBatchesWithConcurrencyLimit(parallelTasks, parallelBatchSize, maxConcurrency, async (t: { agent: string; task: string; cwd?: string; sessionKey?: string }, index) => {
 					const updateOneshotDashboard = (item: SingleResult) => {
 						updateDashboard({
 							agent: item.agent,

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/index.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/index.ts
@@ -11,6 +11,7 @@ import * as path from "node:path";
 import { formatSize, getMarkdownTheme, type ExtensionAPI, type ExtensionCommandContext, type ExtensionContext, type Theme } from "@earendil-works/pi-coding-agent";
 import { Container, Markdown, Spacer, truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
 import { discoverAgents, formatAgentList, type AgentConfig, type AgentScope } from "./agents.js";
+import { registerAgentsCommands } from "./agents-command.js";
 import {
 	activeDashboardItems,
 	editAgentFrontmatterOverrides,
@@ -54,6 +55,7 @@ import {
 	formatInventoryValidationError,
 	runChainDispatch,
 	runParallelDispatch,
+	runSingleDispatch,
 	validateAgentInventory,
 	type AgentInventory,
 } from "./dispatch.js";
@@ -81,6 +83,7 @@ import {
 	inboxDir,
 	processingDir,
 } from "./paths.js";
+import { registerPaneSupportTools } from "./pane-support-tools.js";
 import { MINI_DASHBOARD_RANK, setMiniDashboardWidget } from "./stacked-widget.js";
 import {
 	formatTaskRecordResult,
@@ -95,6 +98,7 @@ import {
 	sessionFileTailMatchesLeaf,
 	stableSessionSnapshotFingerprint,
 } from "./session-persistence.js";
+import { subagentToolRenderers } from "./subagent-render.js";
 import {
 	prepareSingleResultForReturn,
 	runSingleAgent,
@@ -1098,239 +1102,15 @@ export default function (pi: ExtensionAPI) {
 		dashboardCtx = undefined;
 	});
 
-	const agentsHandler = async (args: string, ctx: ExtensionCommandContext) => {
-		const parts = args.trim().split(/\s+/).filter(Boolean);
-		const scopes = new Set<AgentScope>(["user", "project", "both"]);
-		const command = parts[0];
-		let scope: AgentScope = "project";
-		let content = "";
-		let messageDetails: Record<string, unknown> | undefined;
-
-		const parentModel = ctx.model ? `${ctx.model.provider}/${ctx.model.id}` : undefined;
-		const parentThinkingLevel = pi.getThinkingLevel();
-		const parentSessionId = runtimeSessionId(ctx);
-		const runtimeRoot = sessionRuntimeDir(parentSessionId);
-		const discovery = discoverAgents(ctx.cwd, scopes.has(parts.at(-1) as AgentScope) ? (parts.at(-1) as AgentScope) : scope);
-		const findAgent = (name: string | undefined) => discovery.agents.find((candidate) => candidate.name === name);
-		const sendMarkdown = (markdown: string) => {
-			pi.sendMessage({ customType: "subagent-trace", content: markdown, display: true });
-		};
-
-		try {
-			if (command === "start" || command === "new" || command === "resume") {
-				const agent = findAgent(parts[1]);
-				if (!agent) throw new Error(`Unknown agent: ${parts[1] ?? "(missing)"}`);
-				if (!agent.pane) throw new Error(`Agent ${agent.name} is not configured for persistent panes. Add \`pane: true\` to its frontmatter to enable.`);
-				const beforeRegistry = await readPaneRegistry(runtimeRoot);
-				const before = beforeRegistry[agent.name];
-				const hadLivePane = Boolean(before && (await paneExists(before.paneId)));
-				const hadSavedSessionFlag = hasSavedPaneSession(runtimeRoot, agent.name);
-				if (command === "new") {
-					if (hadLivePane) await stopPersistentPane(runtimeRoot, agent.name);
-					removeDashboardAgent(agent.name);
-					await resetPersistentPaneSession(runtimeRoot, agent.name);
-				} else if (command === "resume") {
-					if (hadLivePane) await stopPersistentPane(runtimeRoot, agent.name);
-					removeDashboardAgent(agent.name);
-					await restoreArchivedPaneSession(runtimeRoot, agent.name, parts[2] ?? "latest");
-				}
-				const pane = await ensurePersistentPane(runtimeRoot, parentSessionId, ctx.cwd, agent, parentModel, parentThinkingLevel, pi.getActiveTools());
-				if (!hadLivePane || command === "new") {
-					emitSubagentEvent(pi, "subagents:created", {
-						mode: "pane",
-						agent: agent.name,
-						paneId: pane.paneId,
-						runtimeRoot,
-						transcriptPath: pane.sessionFile,
-					});
-				}
-				const startLabel = command === "new" ? "Started new" : command === "resume" ? "Resumed archived" : hadLivePane ? "Reused live" : hadSavedSessionFlag ? "Resumed saved" : "Started new";
-				content = `${startLabel} ${agent.name} (${pane.windowName}).\nSession: ${pane.sessionFile}`;
-				messageDetails = { action: "start", agent: agent.name, sessionFile: pane.sessionFile, windowName: pane.windowName, status: startLabel };
-				await persistRuntimeSnapshot(ctx, runtimeRoot);
-			} else if (command === "send") {
-				const agent = findAgent(parts[1]);
-				if (!agent) throw new Error(`Unknown agent: ${parts[1] ?? "(missing)"}`);
-				if (!agent.pane) throw new Error(`Agent ${agent.name} is not configured for persistent panes. Add \`pane: true\` to its frontmatter to enable.`);
-				const task = parts.slice(2).join(" ").trim();
-				if (!task) throw new Error("Usage: /agents:send <name> <task>");
-				const queued = await queuePersistentPaneTask(runtimeRoot, parentSessionId, ctx.cwd, agent, task, undefined, parentModel, parentThinkingLevel, pi, pi.getActiveTools());
-				const sessionText = queued.sessionMode === "live" ? "reused live pane" : queued.sessionMode === "resumed" ? "resumed saved pane session" : "started new pane session";
-				content = `Queued task for ${agent.name} (${sessionText}).\nArtifacts: inbox=${compactPath(queued.taskFile)} completion=${compactPath(queued.outboxFile)} transcript=${compactPath(queued.pane.sessionFile)}`;
-				messageDetails = { action: "send", agent: agent.name, inboxFile: queued.taskFile, outboxFile: queued.outboxFile, taskId: queued.taskId, transcriptPath: queued.pane.sessionFile, status: sessionText };
-				await persistRuntimeSnapshot(ctx, runtimeRoot);
-			} else if (command === "attach") {
-				const registry = await readPaneRegistry(runtimeRoot);
-				const entry = registry[parts[1] ?? ""];
-				if (!entry || !(await paneExists(entry.paneId))) throw new Error(`No live pane for agent: ${parts[1] ?? "(missing)"}`);
-				const result = await tmux(["select-pane", "-t", entry.paneId]);
-				if (result.code !== 0) throw new Error(result.stderr || result.stdout || "tmux select-pane failed");
-				content = `Attached to ${entry.agent}.`;
-				messageDetails = { action: "attach", agent: entry.agent };
-			} else if (command === "stop") {
-				const stopped = await stopPersistentPane(runtimeRoot, parts[1] ?? "");
-				const stoppedAgent = stopped.agent;
-				removeDashboardAgent(stoppedAgent);
-				content = `Stopped ${stoppedAgent}.`;
-				messageDetails = { action: "stop", agent: stoppedAgent };
-				await persistRuntimeSnapshot(ctx, runtimeRoot);
-			} else if (command === "collect") {
-				const collected = await pollPaneCompletions(runtimeRoot, pi, false);
-				content = `Collected ${collected} agent completion file${collected === 1 ? "" : "s"}.`;
-				messageDetails = { action: "collect", count: collected };
-				await persistRuntimeSnapshot(ctx, runtimeRoot);
-			} else if (command === "status") {
-				const registry = await readPaneRegistry(runtimeRoot);
-				const lines = await Promise.all(
-					Object.values(registry).map(async (entry) => {
-						const live = await paneExists(entry.paneId);
-						return `- ${entry.agent}: ${live ? "live" : "dead"} ${entry.windowName} model=${entry.model ?? "default"} lastTask=${entry.lastTaskAt ?? "never"}`;
-					}),
-				);
-				content = [`# Persistent agent panes`, "", lines.join("\n") || "No persistent panes registered."].join("\n");
-				messageDetails = { action: "status", count: lines.length };
-			} else if (command === "trace") {
-				const ref = parts.slice(1).join(" ").trim();
-				if (!ref) throw new Error("Usage: /agents:trace <ref>");
-				const records = await readTaskRegistry(runtimeRoot);
-				const record = resolveTraceRecord(records, ref);
-				if (!record) throw new Error(`No agent trace matched: ${ref}`);
-				if (ctx.hasUI) {
-					await openTraceViewer(ctx as ExtensionContext, `Trace ${recordTraceRef(record)}`, await traceViewerItems(record));
-					return;
-				}
-				sendMarkdown(await formatTraceView(record, parts.includes("--verbose")));
-				return;
-			} else if (command === "toggle") {
-				dashboardState.visible = !dashboardState.visible;
-				syncDashboard(ctx as ExtensionContext);
-				content = `Agent dashboard ${dashboardState.visible ? `shown (${dashboardState.mode})` : "hidden"}.`;
-				messageDetails = { action: "toggle", status: dashboardState.visible ? `shown (${dashboardState.mode})` : "hidden" };
-			} else {
-				let showName: string | undefined;
-				if (command === "show") {
-					showName = parts[1];
-					if (scopes.has(parts[2] as AgentScope)) scope = parts[2] as AgentScope;
-				} else if (scopes.has(command as AgentScope)) {
-					scope = command as AgentScope;
-				} else if (command) {
-					throw new Error(`Unknown /agents action: ${command}`);
-				}
-
-				if (ctx.hasUI) {
-					await openAgentsBrowser(ctx, scope, showName, runtimeRoot, parentSessionId, parentModel, parentThinkingLevel, pi.getActiveTools(), () => activeDashboardItems(Object.values(dashboardState.items)), removeDashboardAgent);
-					return;
-				}
-
-				const scopedDiscovery = discoverAgents(ctx.cwd, scope);
-				if (showName) {
-					const agent = scopedDiscovery.agents.find((candidate) => candidate.name === showName);
-					content = agent
-						? [
-								`# Agent: ${agent.name}`,
-								`Source: ${agent.source}`,
-								`Path: ${agent.filePath}`,
-								`Model: ${agent.model ?? "default"}`,
-								`Deny tools: ${agent.denyTools && agent.denyTools.length > 0 ? agent.denyTools.join(", ") : "none"}`,
-								`Persistent pane: ${agent.pane ? "yes" : "no"}`,
-								"",
-								agent.description,
-								"",
-								"---",
-								"",
-								agent.systemPrompt.trim(),
-							]
-							.join("\n")
-						: `Unknown agent "${showName}" for scope "${scope}". Available: ${scopedDiscovery.agents
-								.map((agent) => agent.name)
-								.join(", ") || "none"}.`;
-					messageDetails = { action: "show", agent: showName };
-				} else {
-					const formatted = formatAgentList(scopedDiscovery.agents);
-					content = [
-						`# Available agents (${scope})`,
-						`Project agent dirs: ${scopedDiscovery.projectAgentsDir ?? "none"}`,
-						"",
-						formatted.text
-							.split("; ")
-							.map((line) => {
-								const name = line.match(/^-?\s*([^ ]+)/)?.[1];
-								const agent = scopedDiscovery.agents.find((candidate) => candidate.name === name);
-								return `- ${line}${agent?.pane ? " [pane]" : ""}`;
-							})
-							.join("\n"),
-						"",
-						"Commands: `/agents show <name>`, `/agents:start <name>` (resume/reuse), `/agents:new <name>` (fresh session), `/agents:send <name> <task>`, `/agents:attach <name>`, `/agents:stop <name>`, `/agents status`, `/agents:trace <ref>`, `/agents:toggle`. The popup's History tab browses past tasks visually.",
-					].join("\n");
-					messageDetails = { action: "list", count: scopedDiscovery.agents.length };
-				}
-			}
-		} catch (error) {
-			const message = error instanceof Error ? error.message : String(error);
-			content = `Error: ${message}`;
-			messageDetails = { action: "error", error: message };
-		}
-
-		pi.sendMessage({ customType: "subagent-agents", content, details: messageDetails, display: true });
-	};
-
-	pi.registerCommand("agents", {
-		description: "Agent browser and persistent pane manager.",
-		getArgumentCompletions: agentsArgumentCompletions,
-		handler: agentsHandler,
-	});
-
-	const paneAgentNameCompletions = (subcommand: string) => (prefix: string) => {
-		const query = prefix.trimStart().toLowerCase();
-		const needsPane = subcommand !== "show";
-		const items = agentCommandCompletions
-			.filter((agent) => (!needsPane || agent.pane) && (!query || agent.value.toLowerCase().startsWith(query)))
-			.slice(0, 20)
-			.map((agent) => ({ value: agent.value, label: agent.label, description: agent.description }));
-		return items.length > 0 ? items : null;
-	};
-
-	const traceRefCompletions = (prefix: string) => {
-		const query = prefix.trimStart().toLowerCase();
-		const records = Object.values(dashboardState.items).sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
-		const completions = records
-			.filter((item) => !query || item.taskId.toLowerCase().includes(query) || item.agent.toLowerCase().includes(query))
-			.slice(0, 20)
-			.map((item) => {
-				const when = formatRelativeTime(item.completedAt ?? item.startedAt ?? item.updatedAt);
-				const summary = oneLinePreview(item.message, 60);
-				return {
-					value: item.taskId,
-					label: `${item.agent} · ${when}`,
-					description: summary ? `${item.status} · ${summary}` : item.status,
-				};
-			});
-		return completions.length > 0 ? completions : null;
-	};
-
-	pi.registerCommand("agents:toggle", {
-		description: "Toggle the agent dashboard",
-		handler: async (_args, ctx) => agentsHandler("toggle", ctx),
-	});
-
-	for (const sub of ["start", "new", "send", "attach", "stop"] as const) {
-		const description =
-			sub === "start" ? "Start or reuse a persistent pane: /agents:start <name>" :
-			sub === "new" ? "Start a persistent pane with a fresh session: /agents:new <name>" :
-			sub === "send" ? "Queue a task for a persistent pane: /agents:send <name> <task>" :
-			sub === "attach" ? "Focus an existing agent pane: /agents:attach <name>" :
-			"Stop an agent pane: /agents:stop <name>";
-		pi.registerCommand(`agents:${sub}`, {
-			description,
-			getArgumentCompletions: paneAgentNameCompletions(sub),
-			handler: async (args, ctx) => agentsHandler(`${sub} ${args}`.trim(), ctx),
-		});
-	}
-
-	pi.registerCommand("agents:trace", {
-		description: "View an agent trace by ref/task id: /agents:trace <ref>",
-		getArgumentCompletions: traceRefCompletions,
-		handler: async (args, ctx) => agentsHandler(`trace ${args}`.trim(), ctx),
+	registerAgentsCommands({
+		agentCommandCompletions,
+		agentsArgumentCompletions,
+		dashboardState,
+		formatRelativeTime,
+		persistRuntimeSnapshot,
+		pi,
+		removeDashboardAgent,
+		syncDashboard,
 	});
 
 	const toggleDashboardMode = async (ctx: ExtensionContext) => {
@@ -1439,295 +1219,36 @@ export default function (pi: ExtensionAPI) {
 		};
 	};
 
-	pi.registerTool({
-		renderShell: "self",
-		name: "get_subagent_result",
-		label: "Get Agent Result",
-		description: "Retrieve status/results for persistent pane agent tasks by taskId or latest agent task. Use waitFor: \"idle\" to wait for pane isIdle transition without shell polling. This is a recovery/status tool for pane tasks and does not change Flightdeck or Orchestration ownership.",
-		parameters: GetSubagentResultParams,
-		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-			if (!params.taskId && !params.agent) {
-				return {
-					content: [{ type: "text", text: "Provide either taskId or agent." }],
-					details: {} satisfies GetSubagentResultDetails,
-					isError: true,
-				};
-			}
-			const runtimeRoot = sessionRuntimeDir(runtimeSessionId(ctx));
-			if ((params.waitFor ?? "completion") === "idle") {
-				let agentName = params.agent;
-				if (!agentName && params.taskId) {
-					const records = await readTaskRegistry(runtimeRoot);
-					agentName = records[params.taskId]?.agent;
-				}
-				if (!agentName) {
-					return {
-						content: [{ type: "text", text: `No task record found for ${params.taskId}; provide agent to wait for pane idle.` }],
-						details: { taskId: params.taskId, waitFor: "idle" } satisfies GetSubagentResultDetails,
-						isError: true,
-					};
-				}
-				const waited = await waitForPaneIdle(ctx, agentName, params.timeoutMs ?? 30000);
-				return {
-					content: [{ type: "text", text: waited.text }],
-					details: { agent: agentName, paneId: waited.details.paneId, taskId: params.taskId, waitFor: "idle", waitTimedOut: waited.details.timedOut } satisfies GetSubagentResultDetails,
-					isError: waited.isError,
-				};
-			}
-			const deadline = Date.now() + Math.max(0, Math.floor(params.timeoutMs ?? 30000));
-			let record: PaneTaskRecord | undefined;
-			let diagnostics: string[] = [];
-			let completionMessageEmitted = false;
-			do {
-				completionMessageEmitted = (await pollPaneCompletions(runtimeRoot, pi, false)) > 0 || completionMessageEmitted;
-				const records = await readTaskRegistry(runtimeRoot);
-				record = params.taskId ? records[params.taskId] : latestTaskRecord(records, params.agent);
-				if (record) {
-					const refreshed = await refreshTaskDiagnostics(runtimeRoot, record);
-					record = refreshed.record;
-					diagnostics = refreshed.diagnostics;
-				}
-				if (!params.wait || (record && (isTerminalTaskStatus(record.status) || record.status === "needs_completion"))) break;
-				if (Date.now() >= deadline) break;
-				await new Promise((resolve) => setTimeout(resolve, 500));
-			} while (true);
-
-			if (!record) {
-				const selector = params.taskId ? `taskId ${params.taskId}` : `agent ${params.agent}`;
-				return { content: [{ type: "text", text: `No persistent agent task record found for ${selector}.` }], details: { agent: params.agent, taskId: params.taskId } satisfies GetSubagentResultDetails, isError: true };
-			}
-			updateDashboardFromTaskRecord({ ...record, updatedAt: new Date().toISOString() }, runtimeRoot);
-			await persistRuntimeSnapshot(ctx, runtimeRoot);
-			const diagnosticBlock = params.verbose && diagnostics.length > 0 ? `\n\n### Artifact diagnostics\n${diagnostics.map((line) => `- ${line}`).join("\n")}` : "";
-			return {
-				content: [{ type: "text", text: `${formatTaskRecordResult(record, params.verbose ?? false)}${diagnosticBlock}` }],
-				details: { agent: record.agent, paneId: record.paneId, summary: record.summary, status: record.status, taskId: record.taskId, notes: record.notes, diagnostics: record.diagnostics, completionMessageEmitted } satisfies GetSubagentResultDetails,
-			};
-		},
-		renderCall(_args, _theme, _context) {
-			return new Container();
-		},
-		renderResult(result, _options, theme, context) {
-			const raw = (result.content as any[] | undefined)?.find?.((part: any) => part?.type === "text" && typeof part.text === "string")?.text ?? "";
-			const details = result.details as GetSubagentResultDetails | undefined;
-			if (context?.isError) return wrappedText(`${theme.fg("error", ICONS.times)} ${theme.fg("toolTitle", "Agent result lookup failed")}\n${theme.fg("muted", raw)}`);
-			if (details?.completionMessageEmitted) return new Container();
-			const target = details?.agent ? details.agent : "unknown";
-			const tone = details?.status === "completed" ? "success" : details?.status === "failed" ? "error" : "warning";
-			return wrappedText(agentStatusLine(theme, target, details?.status ?? "result", tone));
-		},
-	});
-
-	pi.registerTool({
-		renderShell: "self",
-		name: "wait_for_subagent_idle",
-		label: "Wait Agent Idle",
-		description: "Wait for a persistent pane agent's pi-bridge state to transition to isIdle=true. Use this instead of polling pi-bridge state in shell loops.",
-		parameters: WaitForSubagentIdleParams,
-		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-			const waited = await waitForPaneIdle(ctx, params.agent, params.timeoutMs ?? 30000);
-			return {
-				content: [{ type: "text", text: waited.text }],
-				details: waited.details,
-				isError: waited.isError,
-			};
-		},
-		renderCall(_args, _theme, _context) {
-			return new Container();
-		},
-		renderResult(result, _options, theme, context) {
-			const raw = (result.content as any[] | undefined)?.find?.((part: any) => part?.type === "text" && typeof part.text === "string")?.text ?? "";
-			const details = result.details as WaitForSubagentIdleDetails | undefined;
-			if (context?.isError) return wrappedText(`${theme.fg("error", ICONS.times)} ${theme.fg("toolTitle", "Agent idle wait failed")}\n${theme.fg("muted", raw)}`);
-			return wrappedText(agentStatusLine(theme, details?.agent ?? "agent", "idle", "success"));
-		},
-	});
-
-	pi.registerTool({
-		renderShell: "self",
-		name: "steer_subagent",
-		label: "Steer Agent",
-		description: "Send a steering message to a persistent pane agent via pi-session-bridge. Bridge targeting requires the agent's child session to live under this parent session's runtime; otherwise an inbox-file fallback is queued instead.",
-		parameters: SteerSubagentParams,
-		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-			const runtimeRoot = sessionRuntimeDir(runtimeSessionId(ctx));
-			const records = await readTaskRegistry(runtimeRoot);
-			let agentName = params.agent;
-			let record: PaneTaskRecord | undefined;
-			if (params.taskId) {
-				record = records[params.taskId];
-				if (!record && !agentName) return { content: [{ type: "text", text: `No task record found for ${params.taskId}; provide agent to steer directly.` }], details: {}, isError: true };
-				agentName = agentName ?? record?.agent;
-			}
-			if (!agentName) return { content: [{ type: "text", text: "Provide either agent or taskId." }], details: {}, isError: true };
-			if (params.taskId && record) {
-				const steerKind = inferTaskRecordKind(runtimeRoot, record);
-				updateDashboard({
-					agent: record.agent,
-					artifacts: steerKind === "pane" ? Boolean(record.completionArchivePath || record.outboxFile || record.transcriptPath) : Boolean(record.transcriptPath),
-					completedAt: record.completedAt,
-					kind: steerKind,
-					message: record.summary || record.task,
-					model: record.model,
-					paneId: record.paneId,
-					startedAt: record.createdAt,
-					status: dashboardStatusFor(record.status, steerKind),
-					task: record.task,
-					taskId: record.taskId,
-					transcriptPath: record.transcriptPath,
-					updatedAt: new Date().toISOString(),
-					usage: record.usage,
-				});
-			}
-
-			const registry = await readPaneRegistry(runtimeRoot);
-			const entry = registry[agentName];
-			if (!entry) return { content: [{ type: "text", text: `No persistent pane registry entry for ${agentName} in runtime ${runtimeRoot}.` }], details: {}, isError: true };
-			if (!paneSessionBelongsToRuntime(runtimeRoot, entry)) return { content: [{ type: "text", text: `Refusing to steer ${agentName}: pane session file is outside this runtime. Session: ${entry.sessionFile}. Runtime: ${runtimeRoot}` }], details: {}, isError: true };
-			if (!(await paneExists(entry.paneId))) return { content: [{ type: "text", text: `Agent ${agentName} is not live.` }], details: {}, isError: true };
-
-			const deliverAs = params.deliverAs ?? "steer";
-			const followUpTask = isFollowUpDelivery(deliverAs) ? await createFollowUpTask(runtimeRoot, agentName, entry, params.message) : undefined;
-			const metadata = await ensurePaneBridgeMetadata(runtimeRoot, entry);
-			const bridgeBin = metadata ? await resolvePiBridgeBin() : undefined;
-			const targetArgs = metadata ? bridgeTargetArgs(metadata) : [];
-			const baseDetails = {
-				agent: agentName,
-				bridge: Boolean(bridgeBin && targetArgs.length > 0),
-				bridgePid: metadata?.pid,
-				bridgeSocket: metadata?.socket,
-				deliverAs,
-				paneId: entry.paneId,
-				runtimeRoot,
-				sessionFile: entry.sessionFile,
-				taskId: followUpTask?.taskId ?? params.taskId ?? record?.taskId,
-				outboxFile: followUpTask?.outboxFile,
-			} satisfies SteerSubagentDetails;
-
-			if (bridgeBin && targetArgs.length > 0) {
-				const command = deliverAs === "follow-up" ? "follow-up" : deliverAs === "send" ? "send" : "steer";
-				const args = [command, ...targetArgs];
-				if (command === "send") args.push("--auto");
-				args.push(formatSteeringForChild(agentName, params.message, true, deliverAs, followUpTask));
-				const result = await execCapture(bridgeBin, args, { cwd: entry.cwd });
-				if (result.code === 0) {
-					patchDashboard(followUpTask?.taskId ?? params.taskId ?? record?.taskId, { bridge: true, paneId: entry.paneId });
-					emitSubagentEvent(pi, "subagents:steered", {
-						mode: "pane",
-						agent: agentName,
-						taskId: followUpTask?.taskId ?? params.taskId ?? record?.taskId,
-						paneId: entry.paneId,
-						bridge: true,
-						bridgePid: metadata?.pid,
-						bridgeSocket: metadata?.socket,
-						deliverAs,
-						runtimeRoot,
-						transcriptPath: entry.sessionFile,
-					});
-					await persistRuntimeSnapshot(ctx, runtimeRoot);
-					return {
-						content: [{ type: "text", text: [`Steered ${agentName} via bridge (${deliverAs}).`, ...steerDiagnostics(baseDetails)].join("\n") }],
-						details: baseDetails,
-					};
-				}
-				const fallbackFile = await queueSteeringFallback(runtimeRoot, agentName, params.message, deliverAs, followUpTask);
-				const details = { ...baseDetails, bridge: false, fallbackFile } satisfies SteerSubagentDetails;
-				patchDashboard(followUpTask?.taskId ?? params.taskId ?? record?.taskId, { bridge: false, paneId: entry.paneId });
-				emitSubagentEvent(pi, "subagents:steered", {
-					mode: "pane",
-					agent: agentName,
-					taskId: followUpTask?.taskId ?? params.taskId ?? record?.taskId,
-					paneId: entry.paneId,
-					bridge: false,
-					deliverAs,
-					runtimeRoot,
-					transcriptPath: entry.sessionFile,
-				});
-				await persistRuntimeSnapshot(ctx, runtimeRoot);
-				return {
-					content: [{ type: "text", text: [`Bridge for ${agentName} found, but pi-bridge ${command} failed (exit ${result.code}); queued inbox fallback instead.`, result.stderr || result.stdout ? `Bridge output: ${(result.stderr || result.stdout).trim()}` : "", ...steerDiagnostics(details)].filter(Boolean).join("\n") }],
-					details,
-				};
-			}
-
-			const fallbackFile = await queueSteeringFallback(runtimeRoot, agentName, params.message, deliverAs, followUpTask);
-			const details = { ...baseDetails, bridge: false, fallbackFile } satisfies SteerSubagentDetails;
-			patchDashboard(followUpTask?.taskId ?? params.taskId ?? record?.taskId, { bridge: false, paneId: entry.paneId });
-			emitSubagentEvent(pi, "subagents:steered", {
-				mode: "pane",
-				agent: agentName,
-				taskId: followUpTask?.taskId ?? params.taskId ?? record?.taskId,
-				paneId: entry.paneId,
-				bridge: false,
-				deliverAs,
-				runtimeRoot,
-				transcriptPath: entry.sessionFile,
-			});
-			await persistRuntimeSnapshot(ctx, runtimeRoot);
-			return {
-				content: [
-					{
-						type: "text",
-						text: [`No live bridge for ${agentName}; no bridge message was sent. Queued inbox fallback instead, which is not true mid-run steering and will be read when the pane is idle.`, ...steerDiagnostics(details)].join("\n"),
-					},
-				],
-				details,
-			};
-		},
-		renderCall(_args, _theme, _context) {
-			return new Container();
-		},
-		renderResult(result, { expanded }, theme, context) {
-			const raw = (result.content as any[] | undefined)?.find?.((part: any) => part?.type === "text" && typeof part.text === "string")?.text ?? "";
-			const details = result.details as SteerSubagentDetails | undefined;
-			if (context?.isError) return wrappedText(`${theme.fg("error", ICONS.times)} ${theme.fg("toolTitle", "Steer agent failed")}\n${theme.fg("muted", raw)}`);
-			if (!details) return wrappedText(raw);
-			const status = details.bridge ? "steered" : "queued steering";
-			const via = details.bridge ? theme.fg("success", "bridge") : theme.fg("warning", "inbox fallback");
-			if (expanded) {
-				const container = new Container();
-				container.addChild(wrappedText(`${agentStatusLine(theme, details.agent, status, details.bridge ? "success" : "warning")} ${theme.fg("dim", "via")} ${via}`));
-				addWrappedSection(container, theme, "Delivery", details.deliverAs, "toolOutput");
-				if (details.taskId) addWrappedSection(container, theme, "Task ID", details.taskId, "dim");
-				addWrappedSection(container, theme, "Bridge", details.bridge ? "active" : "not used", details.bridge ? "toolOutput" : "muted");
-				if (details.bridgePid) addWrappedSection(container, theme, "Bridge PID", details.bridgePid, "dim");
-				addWrappedSection(container, theme, "Pane ID", details.paneId, "dim");
-				addArtifactPathSection(container, theme, "Bridge socket", details.bridgeSocket);
-				addArtifactPathSection(container, theme, "Child session", details.sessionFile);
-				addArtifactPathSection(container, theme, "Runtime root", details.runtimeRoot);
-				addArtifactPathSection(container, theme, "Inbox fallback", details.fallbackFile);
-				addArtifactPathSection(container, theme, "Expected outbox", details.outboxFile);
-				return container;
-			}
-			return wrappedText(`${agentStatusLine(theme, details.agent, status, details.bridge ? "success" : "warning")} ${theme.fg("dim", "via")} ${via}`);
-		},
-	});
-
-	pi.registerTool({
-		renderShell: "self",
-		name: "stop_subagent",
-		label: "Stop Agent",
-		description: "Stop a persistent pane agent, kill its tmux pane, remove it from the live pane registry/dashboard, and mark any non-terminal active task as blocked. The pane session file is preserved; a later subagent call or /agents start resumes it unless forceSpawn or /agents new is used.",
-		parameters: StopSubagentParams,
-		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-			const runtimeRoot = sessionRuntimeDir(runtimeSessionId(ctx));
-			const stopped = await stopPersistentPane(runtimeRoot, params.agent);
-			removeDashboardAgent(stopped.agent);
-			await persistRuntimeSnapshot(ctx, runtimeRoot);
-			return {
-				content: [{ type: "text", text: `Stopped ${stopped.agent}. Pane ${stopped.paneId} was killed and removed from the active registry. Session preserved at ${stopped.sessionFile}; default start/subagent will resume it. Use forceSpawn or /agents new for a fresh session.` }],
-				details: { agent: stopped.agent, paneId: stopped.paneId, sessionFile: stopped.sessionFile },
-			};
-		},
-		renderCall(_args, _theme, _context) {
-			return new Container();
-		},
-		renderResult(result, _options, theme, context) {
-			const raw = (result.content as any[] | undefined)?.find?.((part: any) => part?.type === "text" && typeof part.text === "string")?.text ?? "";
-			const details = result.details as { agent?: string } | undefined;
-			if (context?.isError) return wrappedText(`${theme.fg("error", ICONS.times)} ${theme.fg("toolTitle", "Stop agent failed")}\n${theme.fg("muted", raw)}`);
-			return wrappedText(agentStatusLine(theme, details?.agent ?? "agent", "stopped", "success"));
-		},
+	registerPaneSupportTools({
+		bridgeTargetArgs,
+		createFollowUpTask,
+		emitSubagentEvent,
+		execCapture,
+		formatSteeringForChild,
+		formatTaskRecordResult,
+		inferTaskRecordKind,
+		isFollowUpDelivery,
+		isTerminalTaskStatus,
+		latestTaskRecord,
+		paneExists,
+		paneSessionBelongsToRuntime,
+		patchDashboard,
+		pi,
+		pollPaneCompletions,
+		queueSteeringFallback,
+		readPaneRegistry,
+		readTaskRegistry,
+		refreshTaskDiagnostics,
+		removeDashboardAgent,
+		resolvePiBridgeBin,
+		runtimeSessionId,
+		sessionRuntimeDir,
+		steerDiagnostics,
+		stopPersistentPane,
+		updateDashboard,
+		updateDashboardFromTaskRecord,
+		persistRuntimeSnapshot,
+		waitForPaneIdle,
 	});
 
 	pi.on("before_agent_start", (event, ctx) => {
@@ -1869,75 +1390,27 @@ export default function (pi: ExtensionAPI) {
 				});
 			}
 
-			// TODO(structure): move single-dispatch into dispatch.ts next.
-
 			if (params.agent && params.task) {
-				const agent = agents.find((candidate) => candidate.name === params.agent);
-				const result = agent?.pane
-					? await runPersistentPaneAgent(
-							ctx.cwd,
-							runtimeRoot,
-							parentSessionId,
-							agents,
-							params.agent,
-							params.task,
-							params.cwd,
-							parentModel,
-							parentThinkingLevel,
-							undefined,
-							pi,
-							params.forceSpawn ?? false,
-							params.resumeSession,
-							removeDashboardAgent,
-						)
-					: await runSingleAgent(
-							ctx.cwd,
-							runtimeRoot,
-							agents,
-							params.agent,
-							params.task,
-							params.cwd,
-							parentModel,
-							parentThinkingLevel,
-							undefined,
-							pi,
-							signal,
-							onUpdate,
-							makeDetails("single"),
-							params.sessionKey,
-						);
-				if (!agent?.pane) {
-					updateDashboard({
-						agent: result.agent,
-						kind: "oneshot",
-						message: oneLinePreview(getFinalOutput(result.messages), 120) || result.task,
-						model: result.model,
-						status: result.exitCode === 0 ? "completed" : "failed",
-						task: result.task,
-						taskId: result.taskId ?? result.agent,
-						transcriptPath: result.transcriptPath,
-						updatedAt: new Date().toISOString(),
-						usage: result.usage,
-					});
-				}
-				const isError = result.exitCode !== 0 || result.stopReason === "error" || result.stopReason === "aborted";
-				if (isError) {
-					const errorMsg = result.errorMessage || result.stderr || getFinalOutput(result.messages) || "(no output)";
-					const prepared = await prepareSingleResultForReturn(result, runtimeRoot, ctx.cwd, "single-error", errorMsg);
-					prepared.result.errorMessage = prepared.text || errorMsg;
-					const details = makeDetails("single")([prepared.result]);
-					return {
-						content: [{ type: "text", text: `Agent ${result.stopReason || "failed"}: ${prepared.text || "(no output)"}` }],
-						details: detailsWithTruncation(details, prepared),
-						isError: true,
-					};
-				}
-				const prepared = await prepareSingleResultForReturn(result, runtimeRoot, ctx.cwd, "single");
-				const details = makeDetails("single")([prepared.result]);
-				return {
-					content: [{ type: "text", text: prepared.text || "(no output)" }],
-					details: detailsWithTruncation(details, prepared),
-				};
+				return runSingleDispatch({
+					agent: params.agent,
+					agents,
+					cwd: ctx.cwd,
+					cwdOverride: params.cwd,
+					forceSpawn: params.forceSpawn ?? false,
+					makeDetails,
+					onUpdate,
+					parentModel,
+					parentSessionId,
+					parentThinkingLevel,
+					pi,
+					removeDashboardAgent,
+					resumeSession: params.resumeSession,
+					runtimeRoot,
+					sessionKey: params.sessionKey,
+					signal,
+					task: params.task,
+					updateDashboard,
+				});
 			}
 
 			const available = agents.map((a) => `${a.name} (${a.source})`).join(", ") || "none";
@@ -1947,373 +1420,7 @@ export default function (pi: ExtensionAPI) {
 			};
 		},
 
-		renderCall(args, theme, _context) {
-			const scope: AgentScope = args.agentScope ?? "project";
-			if (args.chain && args.chain.length > 0) {
-				let text =
-					theme.fg("toolTitle", theme.bold("agents ")) +
-					theme.fg("accent", `chain (${args.chain.length} steps)`) +
-					theme.fg("muted", ` [${scope}]`);
-				for (let i = 0; i < Math.min(args.chain.length, 3); i++) {
-					const step = args.chain[i];
-					const cleanTask = step.task.replace(/\{previous\}/g, "").trim();
-					const preview = cleanTask.length > 40 ? `${cleanTask.slice(0, 40)}...` : cleanTask;
-					text +=
-						"\n  " +
-						theme.fg("muted", `${i + 1}.`) +
-						" " +
-						theme.fg("accent", step.agent) +
-						theme.fg("dim", ` ${preview}`);
-				}
-				if (args.chain.length > 3) text += `\n  ${theme.fg("muted", `... +${args.chain.length - 3} more`)}`;
-				return wrappedText(text);
-			}
-			if (args.tasks && args.tasks.length > 0) {
-				return new Container();
-			}
-			const agentName = args.agent || "...";
-			try {
-				const agent = discoverAgents(_context?.cwd ?? process.cwd(), scope).agents.find((candidate) => candidate.name === agentName);
-				if (agent?.pane) return new Container();
-			} catch {
-				// Keep the generic call preview if discovery fails.
-			}
-			const preview = args.task ? oneLinePreview(args.task, 56) : "...";
-			let text = `${agentsCommandBullet(theme)}${agentWord(theme)} ${ansiMagenta(theme.bold(agentName))}`;
-			if (scope !== "project") text += theme.fg("dim", ` · ${scope}`);
-			text += `\n${subagentBranch(theme, "└", _context?.cwd)}${theme.fg("dim", preview)}`;
-			return wrappedText(text);
-		},
-
-		renderResult(result, { expanded }, theme, context) {
-			const cwd = context?.cwd;
-			const collapsedItemCount = Math.max(1, Math.floor(settingNumber("collapsedItemCount", COLLAPSED_ITEM_COUNT, context?.cwd)));
-			const details = result.details as SubagentDetails | undefined;
-			if (!details || details.results.length === 0) {
-				const text = result.content[0];
-				return wrappedText(text?.type === "text" ? text.text : "(no output)");
-			}
-
-			const mdTheme = getMarkdownTheme();
-			const truncationBadge = (r: SingleResult) => (r.truncation?.truncated ? theme.fg("warning", " · truncated") : "");
-			const fullOutputLine = (r: SingleResult) =>
-				r.fullOutputPath
-					? theme.fg("dim", `Full output: ${compactPath(r.fullOutputPath)}`)
-					: r.fullOutputError
-						? theme.fg("warning", `Full output unavailable: ${r.fullOutputError}`)
-						: "";
-			const transcriptLine = (r: SingleResult) => (r.transcriptPath ? theme.fg("dim", `Transcript: ${compactPath(r.transcriptPath)}`) : "");
-			const queuedPaneLine = (r: SingleResult, _dashboard = false) => {
-				if (!r.taskId || !r.paneId) return "";
-				const mode = r.paneSessionMode === "live" ? "reused live pane" : r.paneSessionMode === "resumed" ? "resumed pane" : "new pane";
-				const suffix = `${theme.fg("dim", ` · ${mode}`)}${theme.fg("dim", " · ctrl+o expand")}`;
-				return agentStatusLine(theme, r.agent, "Queued task", "warning", suffix);
-			};
-			const queuedTaskPreviewComponent = (r: SingleResult, dashboard = false) => ({
-				invalidate() {},
-				render(width: number): string[] {
-					const header = queuedPaneLine(r, dashboard);
-					const task = r.task.replace(/\s+/g, " ").trim() || "queued task";
-					const firstPrefix = subagentBranch(theme, "└", cwd);
-					const nextPrefix = " ".repeat(Math.max(0, visibleWidth(firstPrefix)));
-					const textWidth = Math.max(20, width - Math.max(visibleWidth(firstPrefix), visibleWidth(nextPrefix)));
-					const wrapped = wrapTextWithAnsi(task, textWidth);
-					const shown = wrapped.slice(0, 2);
-					if (wrapped.length > shown.length && shown.length > 0) shown[shown.length - 1] = truncateToWidth(`${shown[shown.length - 1]}…`, textWidth, "…");
-					return [
-						header,
-						`${firstPrefix}${theme.fg("dim", shown[0] ?? "queued task")}`,
-						...(shown[1] ? [`${nextPrefix}${theme.fg("dim", shown[1])}`] : []),
-					];
-				},
-			});
-			const expandedQueuedTaskComponent = (r: SingleResult) => {
-				const container = new Container();
-				container.addChild(wrappedText(queuedPaneLine(r)));
-				addSectionHeading(container, theme, "Queued task");
-				container.addChild(new Markdown(r.task.trim() || "(empty task)", 0, 0, mdTheme));
-				if (r.taskId || r.queuedTaskFile || r.queuedOutboxFile || r.transcriptPath) {
-					if (r.paneSessionMode) addWrappedSection(container, theme, "Pane session", r.paneSessionMode === "live" ? "Reused live pane" : r.paneSessionMode === "resumed" ? "Resumed saved pane session" : "Started new pane session", "dim");
-					if (r.taskId) addWrappedSection(container, theme, "Task ID", r.taskId, "dim");
-					addArtifactPathSection(container, theme, "Inbox", r.queuedTaskFile);
-					addArtifactPathSection(container, theme, "Completion", r.queuedOutboxFile);
-					addArtifactPathSection(container, theme, "Transcript", r.transcriptPath);
-				}
-				return container;
-			};
-			const addFinalResponseMarkdown = (container: Container, finalOutput: string, toolCalls: DisplayItem[]) => {
-				if (!finalOutput.trim()) {
-					container.addChild(wrappedText(theme.fg("muted", "(no final response)")));
-					return;
-				}
-				if (finalOutputLooksLikeToolEcho(finalOutput, toolCalls)) {
-					container.addChild(wrappedText(finalResponseSuppressedLine(theme)));
-					return;
-				}
-				container.addChild(new Markdown(finalOutput.trim(), 0, 0, mdTheme));
-			};
-
-			const renderDisplayItems = (items: DisplayItem[], limit?: number) => {
-				const toShow = limit ? items.slice(-limit) : items;
-				const skipped = limit && items.length > limit ? items.length - limit : 0;
-				let text = "";
-				if (skipped > 0) text += theme.fg("muted", `... ${skipped} earlier items\n`);
-				for (const [index, item] of toShow.entries()) {
-					const branch = subagentBranch(theme, index === toShow.length - 1 ? "└" : "├", cwd);
-					if (item.type === "text") {
-						const preview = expanded ? item.text : item.text.split("\n").slice(0, 3).join("\n");
-						const lines = preview.split(/\r?\n/);
-						text += `${branch}${theme.fg("toolOutput", lines[0] ?? "")}\n`;
-						for (const line of lines.slice(1)) text += `${subagentBranch(theme, "│", cwd)}${theme.fg("toolOutput", line)}\n`;
-					} else {
-						text += `${branch}${formatToolCall(item.name, item.args, theme.fg.bind(theme))}\n`;
-					}
-				}
-				return text.trimEnd();
-			};
-
-			if (details.mode === "single" && details.results.length === 1) {
-				const r = details.results[0];
-				if (r.duplicateQueued) return new Container();
-				// runSingleAgent uses exitCode -1 as the still-running sentinel while
-				// emitting streaming partials; only a positive exitCode (or a terminal
-				// stopReason) is a real failure.
-				const isRunning = r.exitCode === -1;
-				const isError = !isRunning && (r.exitCode > 0 || r.stopReason === "error" || r.stopReason === "aborted");
-				const isQueued = !isError && !isRunning && Boolean(r.taskId && r.paneId);
-				const displayItems = getDisplayItems(r.messages);
-				const finalOutput = getFinalOutput(r.messages);
-				const queued = queuedPaneLine(r);
-				const quietDashboard = !expanded && dashboardEnabled(cwd) && quietInline(cwd);
-
-				if (expanded) {
-					if (isQueued) return expandedQueuedTaskComponent(r);
-					const container = new Container();
-					const statusLabel = isQueued ? "Queued task" : isRunning ? "working" : isError ? "failed" : "completed";
-					const statusTone = isQueued || isRunning ? "warning" : isError ? "error" : "success";
-					let header = agentStatusLine(theme, r.agent, statusLabel, statusTone, theme.fg("dim", ` · ${isQueued ? "pane" : "bg"}`));
-					if (isError && r.stopReason) header += ` ${theme.fg("error", `[${r.stopReason}]`)}`;
-					header += truncationBadge(r);
-					container.addChild(wrappedText(header));
-					if (isError && r.errorMessage) container.addChild(wrappedText(theme.fg("error", `Error: ${r.errorMessage}`)));
-					container.addChild(new Spacer(1));
-					container.addChild(wrappedText(theme.fg("muted", "─── Task ───")));
-					container.addChild(wrappedText(theme.fg("dim", r.task)));
-					container.addChild(new Spacer(1));
-					const toolCalls = displayItems.filter((item) => item.type === "toolCall");
-					container.addChild(wrappedText(theme.fg("muted", "─── Tools used ───")));
-					if (toolCalls.length === 0) container.addChild(wrappedText(theme.fg("muted", "(none)")));
-					else {
-						for (const item of toolCalls) {
-							container.addChild(
-								wrappedText(theme.fg("muted", "→ ") + formatToolCall(item.name, item.args, theme.fg.bind(theme))),
-							);
-						}
-					}
-					container.addChild(new Spacer(1));
-					container.addChild(wrappedText(theme.fg("muted", "─── Final response ───")));
-					addFinalResponseMarkdown(container, finalOutput, toolCalls);
-					const outputPath = fullOutputLine(r);
-					if (outputPath) container.addChild(wrappedText(outputPath));
-					const transcript = transcriptLine(r);
-					if (transcript) container.addChild(wrappedText(transcript));
-					const usageStr = queued ? "" : formatUsageStats(r.usage, r.model);
-					if (usageStr) {
-						container.addChild(new Spacer(1));
-						container.addChild(wrappedText(theme.fg("dim", usageStr)));
-					}
-					return container;
-				}
-
-
-				if (queued) return queuedTaskPreviewComponent(r, quietDashboard);
-
-				if (quietDashboard && !queued && !isError) {
-					const toolCalls = displayItems.filter((item) => item.type === "toolCall");
-					const preview = finalOutput && !finalOutputLooksLikeToolEcho(finalOutput, toolCalls)
-						? oneLinePreview(finalOutput, 180)
-						: r.task
-							? oneLinePreview(r.task, 140)
-							: "completed";
-					let text = `${theme.fg("toolTitle", theme.bold("Result from"))} ${ansiMagenta(theme.bold(r.agent))}${theme.fg("dim", " · bg · ctrl+o")}${truncationBadge(r)}`;
-					if (preview) text += `\n${subagentBranch(theme, "└", cwd)}${theme.fg("toolOutput", preview)}`;
-					const outputPath = fullOutputLine(r);
-					if (outputPath) text += `\n${outputPath}`;
-					return wrappedText(text);
-				}
-
-				const compactStatusLabel = isRunning ? "working" : isError ? "failed" : "completed";
-				const compactStatusTone = isRunning ? "warning" : isError ? "error" : "success";
-				let text = queued || agentStatusLine(theme, r.agent, compactStatusLabel, compactStatusTone, `${theme.fg("dim", " · bg")}${theme.fg("dim", " · ctrl+o")}`);
-				if (isError && r.stopReason) text += ` ${theme.fg("error", `[${r.stopReason}]`)}`;
-				text += truncationBadge(r);
-				if (queued) text += `\n${subagentBranch(theme, "└", cwd)}${theme.fg("dim", r.task ? oneLinePreview(r.task, 120) : "queued task")}`;
-				else if (isError && r.errorMessage) text += `\n${theme.fg("error", `Error: ${r.errorMessage}`)}`;
-				else if (displayItems.length === 0) text += `\n${subagentBranch(theme, "└", cwd)}${theme.fg("dim", r.task ? oneLinePreview(r.task, 120) : "(no output)")}`;
-				else {
-					if (r.task) text += `\n${subagentBranch(theme, "├", cwd)}${theme.fg("dim", oneLinePreview(r.task, 120))}`;
-					text += `\n${renderDisplayItems(displayItems, collapsedItemCount)}`;
-					if (displayItems.length > collapsedItemCount) text += `\n${theme.fg("muted", "… more in ctrl+o")}`;
-				}
-				const outputPath = queued ? "" : fullOutputLine(r);
-				if (outputPath) text += `\n${outputPath}`;
-				const usageStr = formatUsageStats(r.usage, r.model);
-				if (usageStr) text += `\n${theme.fg("dim", usageStr)}`;
-				return wrappedText(text);
-			}
-
-			const aggregateUsage = (results: SingleResult[]) => {
-				const total: UsageStats = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, contextTokens: 0, turns: 0 };
-				for (const r of results) {
-					total.input += r.usage.input;
-					total.output += r.usage.output;
-					total.cacheRead += r.usage.cacheRead;
-					total.cacheWrite += r.usage.cacheWrite;
-					total.cost += r.usage.cost;
-					total.contextTokens = Math.max(total.contextTokens, r.usage.contextTokens || 0);
-					total.turns += r.usage.turns;
-				}
-				return total;
-			};
-
-			if (details.mode === "chain") {
-				const successCount = details.results.filter((r) => r.exitCode === 0).length;
-				const runningCount = details.results.filter((r) => r.exitCode === -1).length;
-				const chainStepIcon = (r: SingleResult) =>
-					r.exitCode === -1
-						? theme.fg("warning", ICONS.cog)
-						: r.exitCode === 0
-							? theme.fg("success", ICONS.check)
-							: theme.fg("error", ICONS.times);
-				const icon = runningCount > 0
-					? theme.fg("warning", ICONS.cog)
-					: successCount === details.results.length
-						? theme.fg("success", ICONS.check)
-						: theme.fg("error", ICONS.times);
-
-				if (expanded) {
-					const container = new Container();
-					container.addChild(
-						wrappedText(
-							icon +
-								" " +
-								theme.fg("toolTitle", theme.bold("chain ")) +
-								theme.fg("accent", `${successCount}/${details.results.length} steps`),
-						),
-					);
-
-					for (const r of details.results) {
-						const rIcon = chainStepIcon(r);
-						const displayItems = getDisplayItems(r.messages);
-						const finalOutput = getFinalOutput(r.messages);
-
-						container.addChild(new Spacer(1));
-						container.addChild(
-							wrappedText(
-								`${theme.fg("muted", `─── Step ${r.step}: `) + theme.fg("accent", r.agent)} ${rIcon}${truncationBadge(r)}`,
-							),
-						);
-						container.addChild(wrappedText(theme.fg("muted", "Task: ") + theme.fg("dim", r.task)));
-						const toolCalls = displayItems.filter((item) => item.type === "toolCall");
-						container.addChild(wrappedText(theme.fg("muted", "Tools used:")));
-						if (toolCalls.length === 0) container.addChild(wrappedText(theme.fg("muted", "(none)")));
-						else {
-							for (const item of toolCalls) {
-								container.addChild(
-									wrappedText(theme.fg("muted", "→ ") + formatToolCall(item.name, item.args, theme.fg.bind(theme))),
-								);
-							}
-						}
-
-						container.addChild(wrappedText(theme.fg("muted", "Final response:")));
-						addFinalResponseMarkdown(container, finalOutput, toolCalls);
-
-						const outputPath = fullOutputLine(r);
-						if (outputPath) container.addChild(wrappedText(outputPath));
-						const transcript = transcriptLine(r);
-						if (transcript) container.addChild(wrappedText(transcript));
-						const stepUsage = formatUsageStats(r.usage, r.model);
-						if (stepUsage) container.addChild(wrappedText(theme.fg("dim", stepUsage)));
-					}
-
-					const usageStr = formatUsageStats(aggregateUsage(details.results));
-					if (usageStr) {
-						container.addChild(new Spacer(1));
-						container.addChild(wrappedText(theme.fg("dim", `Total: ${usageStr}`)));
-					}
-					return container;
-				}
-
-				let text =
-					icon +
-					" " +
-					theme.fg("toolTitle", theme.bold("chain ")) +
-					theme.fg("accent", `${successCount}/${details.results.length} steps`);
-				for (const r of details.results) {
-					const rIcon = chainStepIcon(r);
-					const displayItems = getDisplayItems(r.messages);
-					text += `\n\n${theme.fg("muted", `─── Step ${r.step}: `)}${theme.fg("accent", r.agent)} ${rIcon}${truncationBadge(r)}`;
-					if (displayItems.length === 0) text += `\n${theme.fg("muted", "(no output)")}`;
-					else text += `\n${renderDisplayItems(displayItems, 5)}`;
-					const outputPath = fullOutputLine(r);
-					if (outputPath) text += `\n${outputPath}`;
-					const transcript = transcriptLine(r);
-					if (transcript) text += `\n${transcript}`;
-				}
-				const usageStr = formatUsageStats(aggregateUsage(details.results));
-				if (usageStr) text += `\n\n${theme.fg("dim", `Total: ${usageStr}`)}`;
-				text += `\n${theme.fg("muted", "(ctrl+o to expand)")}`;
-				return wrappedText(text);
-			}
-
-			if (details.mode === "parallel") {
-				const running = details.results.filter((r) => r.exitCode === -1).length;
-				const successCount = details.results.filter((r) => r.exitCode === 0).length;
-				const failCount = details.results.filter((r) => r.exitCode > 0).length;
-				const queuedPaneCount = details.results.filter((r) => r.exitCode === 0 && r.taskId && r.paneId).length;
-				const oneshotCompletedCount = successCount - queuedPaneCount;
-				const isRunning = running > 0;
-				const total = details.results.length;
-				const pluralN = (n: number) => (n === 1 ? "" : "s");
-				const headerLabel = isRunning
-					? `${total} agent${pluralN(total)} running`
-					: failCount > 0
-						? `${successCount}/${total} agent${pluralN(total)} completed`
-						: queuedPaneCount === total
-							? `${total} agent${pluralN(total)} launched`
-							: queuedPaneCount > 0
-								? `${total} agents launched (${oneshotCompletedCount} bg, ${queuedPaneCount} pane)`
-								: `${total} agent${pluralN(total)} completed`;
-				const hint = isRunning
-					? ""
-					: queuedPaneCount > 0
-						? theme.fg("muted", " · see dashboard for live status")
-						: dashboardEnabled(cwd) && quietInline(cwd) && !expanded
-							? theme.fg("muted", " · lifecycle in dashboard")
-						: expanded
-							? ""
-							: theme.fg("muted", " (ctrl+o to inspect)");
-				const headerText =
-					theme.fg("accent", "● ") +
-					theme.fg("toolTitle", theme.bold(headerLabel)) +
-					hint;
-				const nameWidth = Math.min(28, Math.max(0, ...details.results.map((r) => visibleWidth(r.agent))));
-				const rowTaskPreview = (r: SingleResult, maxChars: number) =>
-					r.task ? theme.fg("dim", ` · ${oneLinePreview(r.task, maxChars)}`) : "";
-				const treeText = details.results
-					.map((r, index) => {
-						const prefix = index === details.results.length - 1 ? "└" : "├";
-						const name = ((text: string, width: number) => `${text}${" ".repeat(Math.max(0, width - visibleWidth(text)))}`)(ansiMagenta(theme.bold(r.agent)), nameWidth);
-						return `${subagentBranch(theme, prefix, cwd)}${name}${rowTaskPreview(r, 100)}${truncationBadge(r)}`;
-					})
-					.join("\n");
-
-				return wrappedText(`${headerText}\n${treeText}`);
-			}
-
-			const text = result.content[0];
-			return wrappedText(text?.type === "text" ? text.text : "(no output)");
-		},
+		...subagentToolRenderers,
 	});
 
 	emitSubagentEvent(pi, "subagents:ready", { mode: "extension" });

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/index.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/index.ts
@@ -83,6 +83,7 @@ import {
 	inboxDir,
 	processingDir,
 } from "./paths.js";
+import { randomHex } from "./random.js";
 import { registerPaneSupportTools } from "./pane-support-tools.js";
 import { MINI_DASHBOARD_RANK, setMiniDashboardWidget } from "./stacked-widget.js";
 import {
@@ -267,7 +268,7 @@ async function createFollowUpTask(runtimeRoot: string, agentName: string, entry:
 }
 
 async function queueSteeringFallback(runtimeRoot: string, agentName: string, message: string, deliverAs: string = "steer", followUpTask?: FollowUpTask): Promise<string> {
-	const steeringId = followUpTask?.taskId ?? `${safeFileName(`${agentName}-steer`)}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+	const steeringId = followUpTask?.taskId ?? `${safeFileName(`${agentName}-steer`)}-${Date.now()}-${randomHex(8)}`;
 	const filePath = path.join(inboxDir(runtimeRoot, agentName), `${safeFileName(steeringId)}.md`);
 	const content = formatSteeringForChild(agentName, message, false, deliverAs, followUpTask);
 	await fs.promises.mkdir(path.dirname(filePath), { recursive: true, mode: 0o700 });

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/index.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/index.ts
@@ -51,9 +51,9 @@ import {
 	wrappedText,
 } from "./format.js";
 import {
-	assignEphemeralSessionKeys,
 	formatInventoryValidationError,
-	mapInBatchesWithConcurrencyLimit,
+	runChainDispatch,
+	runParallelDispatch,
 	validateAgentInventory,
 	type AgentInventory,
 } from "./dispatch.js";
@@ -96,12 +96,9 @@ import {
 	stableSessionSnapshotFingerprint,
 } from "./session-persistence.js";
 import {
-	cloneMessagesForDetails,
 	prepareSingleResultForReturn,
 	runSingleAgent,
-	truncateForDetails,
 	detailsWithTruncation,
-	type OnUpdateCallback,
 } from "./runner.js";
 import {
 	dashboardDefaultCollapsed,
@@ -154,7 +151,6 @@ import {
 	type GetSubagentResultDetails,
 	ICONS,
 	INSTALL_SYMBOL,
-	MAX_CONCURRENCY,
 	MAX_PARALLEL_TASKS,
 	type PaneCompletionMessageDetails,
 	type PaneRegistry,
@@ -1386,21 +1382,21 @@ export default function (pi: ExtensionAPI) {
 		if (!entry) {
 			return {
 				text: `No persistent pane registry entry for ${agentName} in runtime ${runtimeRoot}.`,
-				details: { agent: agentName, runtimeRoot, samples: 0, timedOut: false, transitioned: false },
+				details: { agent: agentName, runtimeRoot, samples: 0, status: "timeout", timedOut: false, transitioned: false },
 				isError: true,
 			};
 		}
 		if (!paneSessionBelongsToRuntime(runtimeRoot, entry)) {
 			return {
 				text: `Refusing to wait for ${agentName}: pane session file is outside this runtime. Session: ${entry.sessionFile}. Runtime: ${runtimeRoot}`,
-				details: { agent: agentName, paneId: entry.paneId, runtimeRoot, samples: 0, sessionFile: entry.sessionFile, timedOut: false, transitioned: false },
+				details: { agent: agentName, paneId: entry.paneId, runtimeRoot, samples: 0, sessionFile: entry.sessionFile, status: "timeout", timedOut: false, transitioned: false },
 				isError: true,
 			};
 		}
 		if (!(await paneExists(entry.paneId))) {
 			return {
 				text: `Agent ${agentName} is not live.`,
-				details: { agent: agentName, paneId: entry.paneId, runtimeRoot, samples: 0, sessionFile: entry.sessionFile, timedOut: false, transitioned: false },
+				details: { agent: agentName, paneId: entry.paneId, runtimeRoot, samples: 0, sessionFile: entry.sessionFile, status: "timeout", timedOut: false, transitioned: false },
 				isError: true,
 			};
 		}
@@ -1410,7 +1406,7 @@ export default function (pi: ExtensionAPI) {
 		if (!bridgeBin || targetArgs.length === 0) {
 			return {
 				text: `No live pi-bridge target for ${agentName}; cannot wait for isIdle transition.`,
-				details: { agent: agentName, paneId: entry.paneId, runtimeRoot, samples: 0, sessionFile: entry.sessionFile, timedOut: false, transitioned: false },
+				details: { agent: agentName, paneId: entry.paneId, runtimeRoot, samples: 0, sessionFile: entry.sessionFile, status: "timeout", timedOut: false, transitioned: false },
 				isError: true,
 			};
 		}
@@ -1428,13 +1424,16 @@ export default function (pi: ExtensionAPI) {
 			runtimeRoot,
 			samples: wait.samples,
 			sessionFile: entry.sessionFile,
+			status: wait.status,
 			timedOut: wait.timedOut,
 			transitioned: wait.transitioned,
 		};
 		return {
-			text: wait.transitioned
-				? `${agentName} is idle (pane ${entry.paneId}).`
-				: `Timed out waiting for ${agentName} idle transition after ${timeoutMs}ms.`,
+			text: wait.status === "idle-after-busy"
+				? `${agentName} is idle after busy transition (pane ${entry.paneId}).`
+				: wait.status === "never-busy"
+					? `${agentName} never became busy before idle wait timeout (${timeoutMs}ms).`
+					: `Timed out waiting for ${agentName} idle transition after it became busy (${timeoutMs}ms).`,
 			details,
 			isError: !wait.transitioned,
 		};
@@ -1759,6 +1758,7 @@ export default function (pi: ExtensionAPI) {
 			"Delegate tasks to specialized agents with isolated context.",
 			"Modes: single (agent + task), parallel (tasks array), chain (sequential with {previous} placeholder).",
 			"Bg agents use fresh one-shot sessions by default; pass sessionKey only when you want continuity.",
+			"Agent names are checked against selected inventory before launch; unknown names fail with available agents.",
 			`Parallel calls above ${MAX_PARALLEL_TASKS} items are internally batched; callers do not need to split requests.`,
 			`Results are truncated by default to ${DEFAULT_RESULT_MAX_LINES} lines or ${formatSize(DEFAULT_RESULT_MAX_BYTES)}; full oversized output is saved under the session runtime when enabled.`,
 			'Default agent scope is "project" (.pi/agents plus .claude/agents compatibility).',
@@ -1830,254 +1830,46 @@ export default function (pi: ExtensionAPI) {
 			}
 
 			if (params.chain && params.chain.length > 0) {
-				const chainSteps = assignEphemeralSessionKeys(params.chain as Array<{ agent: string; task: string; cwd?: string; sessionKey?: string }>);
-				const results: SingleResult[] = [];
-				let previousOutput = "";
-
-				for (let i = 0; i < chainSteps.length; i++) {
-					const step = chainSteps[i];
-					const taskWithContext = step.task.replace(/\{previous\}/g, previousOutput);
-
-					const chainUpdate: OnUpdateCallback | undefined = onUpdate
-						? (partial) => {
-								const currentResult = partial.details?.results[0];
-								if (currentResult) {
-									const allResults = [...results, currentResult].map((result) => {
-										const rawOutput = getFinalOutput(result.messages);
-										return {
-											...result,
-											messages: cloneMessagesForDetails(
-												result.messages,
-												rawOutput ? truncateForDetails(rawOutput, ctx.cwd) : undefined,
-												ctx.cwd,
-											),
-										};
-									});
-									onUpdate({
-										content: partial.content,
-										details: makeDetails("chain")(allResults),
-									});
-								}
-							}
-						: undefined;
-
-					const stepAgent = agents.find((agent) => agent.name === step.agent);
-					const result = stepAgent?.pane
-						? await runPersistentPaneAgent(
-								ctx.cwd,
-								runtimeRoot,
-								parentSessionId,
-								agents,
-								step.agent,
-								taskWithContext,
-								step.cwd,
-								parentModel,
-								parentThinkingLevel,
-								i + 1,
-								pi,
-								params.forceSpawn ?? false,
-								params.resumeSession,
-								removeDashboardAgent,
-							)
-						: await runSingleAgent(
-								ctx.cwd,
-								runtimeRoot,
-								agents,
-								step.agent,
-								taskWithContext,
-								step.cwd,
-								parentModel,
-								parentThinkingLevel,
-								i + 1,
-								pi,
-								signal,
-								chainUpdate,
-								makeDetails("chain"),
-								step.sessionKey,
-							);
-					results.push(result);
-					if (!stepAgent?.pane) {
-						updateDashboard({
-							agent: result.agent,
-							kind: "oneshot",
-							message: oneLinePreview(getFinalOutput(result.messages), 120) || result.task,
-							model: result.model,
-							status: result.exitCode === 0 ? "completed" : "failed",
-							task: result.task,
-							taskId: result.taskId ?? `${result.agent}-step-${i + 1}`,
-							transcriptPath: result.transcriptPath,
-							updatedAt: new Date().toISOString(),
-							usage: result.usage,
-						});
-					}
-
-					const isError = result.exitCode !== 0 || result.stopReason === "error" || result.stopReason === "aborted";
-					if (isError) {
-						const errorMsg = result.errorMessage || result.stderr || getFinalOutput(result.messages) || "(no output)";
-						const preparedResults = await Promise.all(
-							results.map((candidate, index) =>
-								prepareSingleResultForReturn(
-									candidate,
-									runtimeRoot,
-									ctx.cwd,
-									`chain-step-${candidate.step ?? index + 1}`,
-									candidate === result ? errorMsg : undefined,
-								),
-							),
-						);
-						const failed = preparedResults[preparedResults.length - 1];
-						failed.result.errorMessage = failed.text || errorMsg;
-						const details = makeDetails("chain")(preparedResults.map((prepared) => prepared.result));
-						return {
-							content: [{ type: "text", text: `Chain stopped at step ${i + 1} (${step.agent}): ${failed.text || "(no output)"}` }],
-							details: detailsWithTruncation(details, failed),
-							isError: true,
-						};
-					}
-					previousOutput = getFinalOutput(result.messages);
-				}
-				const preparedResults = await Promise.all(
-					results.map((result, index) =>
-						prepareSingleResultForReturn(result, runtimeRoot, ctx.cwd, `chain-step-${result.step ?? index + 1}`),
-					),
-				);
-				const last = preparedResults[preparedResults.length - 1];
-				const details = makeDetails("chain")(preparedResults.map((prepared) => prepared.result));
-				return {
-					content: [{ type: "text", text: last.text || "(no output)" }],
-					details: detailsWithTruncation(details, last),
-				};
+				return runChainDispatch({
+					agents,
+					chain: params.chain as Array<{ agent: string; task: string; cwd?: string; sessionKey?: string }>,
+					cwd: ctx.cwd,
+					forceSpawn: params.forceSpawn ?? false,
+					makeDetails,
+					onUpdate,
+					parentModel,
+					parentSessionId,
+					parentThinkingLevel,
+					pi,
+					removeDashboardAgent,
+					resumeSession: params.resumeSession,
+					runtimeRoot,
+					signal,
+					updateDashboard,
+				});
 			}
 
 			if (params.tasks && params.tasks.length > 0) {
-				const parallelTasks = assignEphemeralSessionKeys(params.tasks as Array<{ agent: string; task: string; cwd?: string; sessionKey?: string }>);
-				const parallelBatchSize = Math.max(1, Math.floor(settingNumber("maxParallelTasks", MAX_PARALLEL_TASKS, ctx.cwd)));
-
-				const allResults: SingleResult[] = new Array(params.tasks.length);
-				for (let i = 0; i < params.tasks.length; i++) {
-					allResults[i] = {
-						agent: parallelTasks[i].agent,
-						agentSource: "unknown",
-						task: parallelTasks[i].task,
-						exitCode: -1,
-						messages: [],
-						stderr: "",
-						usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, contextTokens: 0, turns: 0 },
-					};
-				}
-
-				const emitParallelUpdate = () => {
-					if (onUpdate) {
-						const running = allResults.filter((r) => r.exitCode === -1).length;
-						const done = allResults.filter((r) => r.exitCode !== -1).length;
-						const updateResults = allResults.map((result) => {
-							const rawOutput = getFinalOutput(result.messages);
-							return {
-								...result,
-								messages: cloneMessagesForDetails(
-									result.messages,
-									rawOutput ? truncateForDetails(rawOutput, ctx.cwd) : undefined,
-									ctx.cwd,
-								),
-							};
-						});
-						onUpdate({
-							content: [{ type: "text", text: `Parallel: ${done}/${allResults.length} done, ${running} running...` }],
-							details: makeDetails("parallel")(updateResults),
-						});
-					}
-				};
-
-				const maxConcurrency = Math.max(1, Math.floor(settingNumber("maxConcurrency", MAX_CONCURRENCY, ctx.cwd)));
-				const results = await mapInBatchesWithConcurrencyLimit(parallelTasks, parallelBatchSize, maxConcurrency, async (t: { agent: string; task: string; cwd?: string; sessionKey?: string }, index) => {
-					const updateOneshotDashboard = (item: SingleResult) => {
-						updateDashboard({
-							agent: item.agent,
-							kind: "oneshot",
-							message: oneLinePreview(getFinalOutput(item.messages), 120) || item.task,
-							model: item.model,
-							status: item.exitCode === -1 ? "running" : item.exitCode === 0 ? "completed" : "failed",
-							task: item.task,
-							taskId: item.taskId ?? `${item.agent}-${index}`,
-							transcriptPath: item.transcriptPath,
-							updatedAt: new Date().toISOString(),
-							usage: item.usage,
-						});
-					};
-					const taskAgent = agents.find((agent) => agent.name === t.agent);
-					const result = taskAgent?.pane
-						? await runPersistentPaneAgent(
-								ctx.cwd,
-								runtimeRoot,
-								parentSessionId,
-								agents,
-								t.agent,
-								t.task,
-								t.cwd,
-								parentModel,
-								parentThinkingLevel,
-								undefined,
-								pi,
-								params.forceSpawn ?? false,
-								params.resumeSession,
-								removeDashboardAgent,
-							)
-						: await runSingleAgent(
-								ctx.cwd,
-								runtimeRoot,
-								agents,
-								t.agent,
-								t.task,
-								t.cwd,
-								parentModel,
-								parentThinkingLevel,
-								undefined,
-								pi,
-								signal,
-								(partial) => {
-									if (partial.details?.results[0]) {
-										allResults[index] = partial.details.results[0];
-										updateOneshotDashboard(partial.details.results[0]);
-										emitParallelUpdate();
-									}
-								},
-								makeDetails("parallel"),
-								t.sessionKey,
-							);
-					allResults[index] = result;
-					if (!taskAgent?.pane) updateOneshotDashboard(result);
-					emitParallelUpdate();
-					return result;
+				return runParallelDispatch({
+					agents,
+					cwd: ctx.cwd,
+					forceSpawn: params.forceSpawn ?? false,
+					makeDetails,
+					onUpdate,
+					parentModel,
+					parentSessionId,
+					parentThinkingLevel,
+					pi,
+					removeDashboardAgent,
+					resumeSession: params.resumeSession,
+					runtimeRoot,
+					signal,
+					tasks: params.tasks as Array<{ agent: string; task: string; cwd?: string; sessionKey?: string }>,
+					updateDashboard,
 				});
-
-				const successCount = results.filter((r) => r.exitCode === 0).length;
-				const perResultLimits = (() => {
-					const total = { maxBytes: Math.max(1, Math.floor(settingNumber("resultMaxBytes", DEFAULT_RESULT_MAX_BYTES, ctx.cwd))), maxLines: Math.max(1, Math.floor(settingNumber("resultMaxLines", DEFAULT_RESULT_MAX_LINES, ctx.cwd))) };
-					const count = Math.max(1, results.length);
-					return { maxBytes: Math.max(1024, Math.floor(total.maxBytes / count)), maxLines: Math.max(40, Math.floor(total.maxLines / count)) };
-				})();
-				const preparedResults = await Promise.all(
-					results.map((result, index) =>
-						prepareSingleResultForReturn(
-							result,
-							runtimeRoot,
-							ctx.cwd,
-							`parallel-${index + 1}-${result.agent}`,
-							undefined,
-							perResultLimits,
-						),
-					),
-				);
-				const sections = preparedResults.map((prepared) => {
-					const r = prepared.result;
-					const status = r.exitCode === 0 ? "completed" : r.exitCode === -1 ? "running" : "failed";
-					return `## ${r.agent} (${status})\n${prepared.text || "(no output)"}`;
-				});
-				return {
-					content: [{ type: "text", text: `Parallel: ${successCount}/${results.length} succeeded\n\n${sections.join("\n\n")}` }],
-					details: makeDetails("parallel")(preparedResults.map((prepared) => prepared.result)),
-				};
 			}
+
+			// TODO(structure): move single-dispatch into dispatch.ts next.
 
 			if (params.agent && params.task) {
 				const agent = agents.find((candidate) => candidate.name === params.agent);

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/pane-support-tools.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/pane-support-tools.ts
@@ -1,0 +1,350 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Container } from "@earendil-works/pi-tui";
+import {
+	addArtifactPathSection,
+	addWrappedSection,
+	agentStatusLine,
+	wrappedText,
+} from "./format.js";
+import {
+	GetSubagentResultParams,
+	SteerSubagentParams,
+	StopSubagentParams,
+	WaitForSubagentIdleParams,
+} from "./tools.js";
+import {
+	ICONS,
+	type GetSubagentResultDetails,
+	type SteerSubagentDetails,
+	type WaitForSubagentIdleDetails,
+} from "./types.js";
+
+interface PaneSupportToolDeps {
+	[key: string]: any;
+	pi: ExtensionAPI;
+}
+
+export function registerPaneSupportTools(deps: PaneSupportToolDeps): void {
+	const {
+		bridgeTargetArgs,
+		createFollowUpTask,
+		emitSubagentEvent,
+		execCapture,
+		formatSteeringForChild,
+		formatTaskRecordResult,
+		inferTaskRecordKind,
+		isFollowUpDelivery,
+		isTerminalTaskStatus,
+		latestTaskRecord,
+		paneExists,
+		paneSessionBelongsToRuntime,
+		patchDashboard,
+		pi,
+		pollPaneCompletions,
+		queueSteeringFallback,
+		readPaneRegistry,
+		readTaskRegistry,
+		refreshTaskDiagnostics,
+		removeDashboardAgent,
+		resolvePiBridgeBin,
+		runtimeSessionId,
+		sessionRuntimeDir,
+		steerDiagnostics,
+		stopPersistentPane,
+		updateDashboard,
+		updateDashboardFromTaskRecord,
+		persistRuntimeSnapshot,
+		waitForPaneIdle,
+	} = deps;
+	pi.registerTool({
+		renderShell: "self",
+		name: "get_subagent_result",
+		label: "Get Agent Result",
+		description: "Retrieve status/results for persistent pane agent tasks by taskId or latest agent task. Use waitFor: \"idle\" to wait for pane isIdle transition without shell polling. This is a recovery/status tool for pane tasks and does not change Flightdeck or Orchestration ownership.",
+		parameters: GetSubagentResultParams,
+		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+			if (!params.taskId && !params.agent) {
+				return {
+					content: [{ type: "text", text: "Provide either taskId or agent." }],
+					details: {} satisfies GetSubagentResultDetails,
+					isError: true,
+				};
+			}
+			const runtimeRoot = sessionRuntimeDir(runtimeSessionId(ctx));
+			if ((params.waitFor ?? "completion") === "idle") {
+				let agentName = params.agent;
+				if (!agentName && params.taskId) {
+					const records = await readTaskRegistry(runtimeRoot);
+					agentName = records[params.taskId]?.agent;
+				}
+				if (!agentName) {
+					return {
+						content: [{ type: "text", text: `No task record found for ${params.taskId}; provide agent to wait for pane idle.` }],
+						details: { taskId: params.taskId, waitFor: "idle" } satisfies GetSubagentResultDetails,
+						isError: true,
+					};
+				}
+				const waited = await waitForPaneIdle(ctx, agentName, params.timeoutMs ?? 30000);
+				return {
+					content: [{ type: "text", text: waited.text }],
+					details: { agent: agentName, paneId: waited.details.paneId, taskId: params.taskId, waitFor: "idle", waitTimedOut: waited.details.timedOut } satisfies GetSubagentResultDetails,
+					isError: waited.isError,
+				};
+			}
+			const deadline = Date.now() + Math.max(0, Math.floor(params.timeoutMs ?? 30000));
+			let record: PaneTaskRecord | undefined;
+			let diagnostics: string[] = [];
+			let completionMessageEmitted = false;
+			do {
+				completionMessageEmitted = (await pollPaneCompletions(runtimeRoot, pi, false)) > 0 || completionMessageEmitted;
+				const records = await readTaskRegistry(runtimeRoot);
+				record = params.taskId ? records[params.taskId] : latestTaskRecord(records, params.agent);
+				if (record) {
+					const refreshed = await refreshTaskDiagnostics(runtimeRoot, record);
+					record = refreshed.record;
+					diagnostics = refreshed.diagnostics;
+				}
+				if (!params.wait || (record && (isTerminalTaskStatus(record.status) || record.status === "needs_completion"))) break;
+				if (Date.now() >= deadline) break;
+				await new Promise((resolve) => setTimeout(resolve, 500));
+			} while (true);
+
+			if (!record) {
+				const selector = params.taskId ? `taskId ${params.taskId}` : `agent ${params.agent}`;
+				return { content: [{ type: "text", text: `No persistent agent task record found for ${selector}.` }], details: { agent: params.agent, taskId: params.taskId } satisfies GetSubagentResultDetails, isError: true };
+			}
+			updateDashboardFromTaskRecord({ ...record, updatedAt: new Date().toISOString() }, runtimeRoot);
+			await persistRuntimeSnapshot(ctx, runtimeRoot);
+			const diagnosticBlock = params.verbose && diagnostics.length > 0 ? `\n\n### Artifact diagnostics\n${diagnostics.map((line) => `- ${line}`).join("\n")}` : "";
+			return {
+				content: [{ type: "text", text: `${formatTaskRecordResult(record, params.verbose ?? false)}${diagnosticBlock}` }],
+				details: { agent: record.agent, paneId: record.paneId, summary: record.summary, status: record.status, taskId: record.taskId, notes: record.notes, diagnostics: record.diagnostics, completionMessageEmitted } satisfies GetSubagentResultDetails,
+			};
+		},
+		renderCall(_args, _theme, _context) {
+			return new Container();
+		},
+		renderResult(result, _options, theme, context) {
+			const raw = (result.content as any[] | undefined)?.find?.((part: any) => part?.type === "text" && typeof part.text === "string")?.text ?? "";
+			const details = result.details as GetSubagentResultDetails | undefined;
+			if (context?.isError) return wrappedText(`${theme.fg("error", ICONS.times)} ${theme.fg("toolTitle", "Agent result lookup failed")}\n${theme.fg("muted", raw)}`);
+			if (details?.completionMessageEmitted) return new Container();
+			const target = details?.agent ? details.agent : "unknown";
+			const tone = details?.status === "completed" ? "success" : details?.status === "failed" ? "error" : "warning";
+			return wrappedText(agentStatusLine(theme, target, details?.status ?? "result", tone));
+		},
+	});
+
+	pi.registerTool({
+		renderShell: "self",
+		name: "wait_for_subagent_idle",
+		label: "Wait Agent Idle",
+		description: "Wait for a persistent pane agent's pi-bridge state to transition to isIdle=true. Use this instead of polling pi-bridge state in shell loops.",
+		parameters: WaitForSubagentIdleParams,
+		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+			const waited = await waitForPaneIdle(ctx, params.agent, params.timeoutMs ?? 30000);
+			return {
+				content: [{ type: "text", text: waited.text }],
+				details: waited.details,
+				isError: waited.isError,
+			};
+		},
+		renderCall(_args, _theme, _context) {
+			return new Container();
+		},
+		renderResult(result, _options, theme, context) {
+			const raw = (result.content as any[] | undefined)?.find?.((part: any) => part?.type === "text" && typeof part.text === "string")?.text ?? "";
+			const details = result.details as WaitForSubagentIdleDetails | undefined;
+			if (context?.isError) return wrappedText(`${theme.fg("error", ICONS.times)} ${theme.fg("toolTitle", "Agent idle wait failed")}\n${theme.fg("muted", raw)}`);
+			return wrappedText(agentStatusLine(theme, details?.agent ?? "agent", "idle", "success"));
+		},
+	});
+
+	pi.registerTool({
+		renderShell: "self",
+		name: "steer_subagent",
+		label: "Steer Agent",
+		description: "Send a steering message to a persistent pane agent via pi-session-bridge. Bridge targeting requires the agent's child session to live under this parent session's runtime; otherwise an inbox-file fallback is queued instead.",
+		parameters: SteerSubagentParams,
+		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+			const runtimeRoot = sessionRuntimeDir(runtimeSessionId(ctx));
+			const records = await readTaskRegistry(runtimeRoot);
+			let agentName = params.agent;
+			let record: PaneTaskRecord | undefined;
+			if (params.taskId) {
+				record = records[params.taskId];
+				if (!record && !agentName) return { content: [{ type: "text", text: `No task record found for ${params.taskId}; provide agent to steer directly.` }], details: {}, isError: true };
+				agentName = agentName ?? record?.agent;
+			}
+			if (!agentName) return { content: [{ type: "text", text: "Provide either agent or taskId." }], details: {}, isError: true };
+			if (params.taskId && record) {
+				const steerKind = inferTaskRecordKind(runtimeRoot, record);
+				updateDashboard({
+					agent: record.agent,
+					artifacts: steerKind === "pane" ? Boolean(record.completionArchivePath || record.outboxFile || record.transcriptPath) : Boolean(record.transcriptPath),
+					completedAt: record.completedAt,
+					kind: steerKind,
+					message: record.summary || record.task,
+					model: record.model,
+					paneId: record.paneId,
+					startedAt: record.createdAt,
+					status: dashboardStatusFor(record.status, steerKind),
+					task: record.task,
+					taskId: record.taskId,
+					transcriptPath: record.transcriptPath,
+					updatedAt: new Date().toISOString(),
+					usage: record.usage,
+				});
+			}
+
+			const registry = await readPaneRegistry(runtimeRoot);
+			const entry = registry[agentName];
+			if (!entry) return { content: [{ type: "text", text: `No persistent pane registry entry for ${agentName} in runtime ${runtimeRoot}.` }], details: {}, isError: true };
+			if (!paneSessionBelongsToRuntime(runtimeRoot, entry)) return { content: [{ type: "text", text: `Refusing to steer ${agentName}: pane session file is outside this runtime. Session: ${entry.sessionFile}. Runtime: ${runtimeRoot}` }], details: {}, isError: true };
+			if (!(await paneExists(entry.paneId))) return { content: [{ type: "text", text: `Agent ${agentName} is not live.` }], details: {}, isError: true };
+
+			const deliverAs = params.deliverAs ?? "steer";
+			const followUpTask = isFollowUpDelivery(deliverAs) ? await createFollowUpTask(runtimeRoot, agentName, entry, params.message) : undefined;
+			const metadata = await ensurePaneBridgeMetadata(runtimeRoot, entry);
+			const bridgeBin = metadata ? await resolvePiBridgeBin() : undefined;
+			const targetArgs = metadata ? bridgeTargetArgs(metadata) : [];
+			const baseDetails = {
+				agent: agentName,
+				bridge: Boolean(bridgeBin && targetArgs.length > 0),
+				bridgePid: metadata?.pid,
+				bridgeSocket: metadata?.socket,
+				deliverAs,
+				paneId: entry.paneId,
+				runtimeRoot,
+				sessionFile: entry.sessionFile,
+				taskId: followUpTask?.taskId ?? params.taskId ?? record?.taskId,
+				outboxFile: followUpTask?.outboxFile,
+			} satisfies SteerSubagentDetails;
+
+			if (bridgeBin && targetArgs.length > 0) {
+				const command = deliverAs === "follow-up" ? "follow-up" : deliverAs === "send" ? "send" : "steer";
+				const args = [command, ...targetArgs];
+				if (command === "send") args.push("--auto");
+				args.push(formatSteeringForChild(agentName, params.message, true, deliverAs, followUpTask));
+				const result = await execCapture(bridgeBin, args, { cwd: entry.cwd });
+				if (result.code === 0) {
+					patchDashboard(followUpTask?.taskId ?? params.taskId ?? record?.taskId, { bridge: true, paneId: entry.paneId });
+					emitSubagentEvent(pi, "subagents:steered", {
+						mode: "pane",
+						agent: agentName,
+						taskId: followUpTask?.taskId ?? params.taskId ?? record?.taskId,
+						paneId: entry.paneId,
+						bridge: true,
+						bridgePid: metadata?.pid,
+						bridgeSocket: metadata?.socket,
+						deliverAs,
+						runtimeRoot,
+						transcriptPath: entry.sessionFile,
+					});
+					await persistRuntimeSnapshot(ctx, runtimeRoot);
+					return {
+						content: [{ type: "text", text: [`Steered ${agentName} via bridge (${deliverAs}).`, ...steerDiagnostics(baseDetails)].join("\n") }],
+						details: baseDetails,
+					};
+				}
+				const fallbackFile = await queueSteeringFallback(runtimeRoot, agentName, params.message, deliverAs, followUpTask);
+				const details = { ...baseDetails, bridge: false, fallbackFile } satisfies SteerSubagentDetails;
+				patchDashboard(followUpTask?.taskId ?? params.taskId ?? record?.taskId, { bridge: false, paneId: entry.paneId });
+				emitSubagentEvent(pi, "subagents:steered", {
+					mode: "pane",
+					agent: agentName,
+					taskId: followUpTask?.taskId ?? params.taskId ?? record?.taskId,
+					paneId: entry.paneId,
+					bridge: false,
+					deliverAs,
+					runtimeRoot,
+					transcriptPath: entry.sessionFile,
+				});
+				await persistRuntimeSnapshot(ctx, runtimeRoot);
+				return {
+					content: [{ type: "text", text: [`Bridge for ${agentName} found, but pi-bridge ${command} failed (exit ${result.code}); queued inbox fallback instead.`, result.stderr || result.stdout ? `Bridge output: ${(result.stderr || result.stdout).trim()}` : "", ...steerDiagnostics(details)].filter(Boolean).join("\n") }],
+					details,
+				};
+			}
+
+			const fallbackFile = await queueSteeringFallback(runtimeRoot, agentName, params.message, deliverAs, followUpTask);
+			const details = { ...baseDetails, bridge: false, fallbackFile } satisfies SteerSubagentDetails;
+			patchDashboard(followUpTask?.taskId ?? params.taskId ?? record?.taskId, { bridge: false, paneId: entry.paneId });
+			emitSubagentEvent(pi, "subagents:steered", {
+				mode: "pane",
+				agent: agentName,
+				taskId: followUpTask?.taskId ?? params.taskId ?? record?.taskId,
+				paneId: entry.paneId,
+				bridge: false,
+				deliverAs,
+				runtimeRoot,
+				transcriptPath: entry.sessionFile,
+			});
+			await persistRuntimeSnapshot(ctx, runtimeRoot);
+			return {
+				content: [
+					{
+						type: "text",
+						text: [`No live bridge for ${agentName}; no bridge message was sent. Queued inbox fallback instead, which is not true mid-run steering and will be read when the pane is idle.`, ...steerDiagnostics(details)].join("\n"),
+					},
+				],
+				details,
+			};
+		},
+		renderCall(_args, _theme, _context) {
+			return new Container();
+		},
+		renderResult(result, { expanded }, theme, context) {
+			const raw = (result.content as any[] | undefined)?.find?.((part: any) => part?.type === "text" && typeof part.text === "string")?.text ?? "";
+			const details = result.details as SteerSubagentDetails | undefined;
+			if (context?.isError) return wrappedText(`${theme.fg("error", ICONS.times)} ${theme.fg("toolTitle", "Steer agent failed")}\n${theme.fg("muted", raw)}`);
+			if (!details) return wrappedText(raw);
+			const status = details.bridge ? "steered" : "queued steering";
+			const via = details.bridge ? theme.fg("success", "bridge") : theme.fg("warning", "inbox fallback");
+			if (expanded) {
+				const container = new Container();
+				container.addChild(wrappedText(`${agentStatusLine(theme, details.agent, status, details.bridge ? "success" : "warning")} ${theme.fg("dim", "via")} ${via}`));
+				addWrappedSection(container, theme, "Delivery", details.deliverAs, "toolOutput");
+				if (details.taskId) addWrappedSection(container, theme, "Task ID", details.taskId, "dim");
+				addWrappedSection(container, theme, "Bridge", details.bridge ? "active" : "not used", details.bridge ? "toolOutput" : "muted");
+				if (details.bridgePid) addWrappedSection(container, theme, "Bridge PID", details.bridgePid, "dim");
+				addWrappedSection(container, theme, "Pane ID", details.paneId, "dim");
+				addArtifactPathSection(container, theme, "Bridge socket", details.bridgeSocket);
+				addArtifactPathSection(container, theme, "Child session", details.sessionFile);
+				addArtifactPathSection(container, theme, "Runtime root", details.runtimeRoot);
+				addArtifactPathSection(container, theme, "Inbox fallback", details.fallbackFile);
+				addArtifactPathSection(container, theme, "Expected outbox", details.outboxFile);
+				return container;
+			}
+			return wrappedText(`${agentStatusLine(theme, details.agent, status, details.bridge ? "success" : "warning")} ${theme.fg("dim", "via")} ${via}`);
+		},
+	});
+
+	pi.registerTool({
+		renderShell: "self",
+		name: "stop_subagent",
+		label: "Stop Agent",
+		description: "Stop a persistent pane agent, kill its tmux pane, remove it from the live pane registry/dashboard, and mark any non-terminal active task as blocked. The pane session file is preserved; a later subagent call or /agents start resumes it unless forceSpawn or /agents new is used.",
+		parameters: StopSubagentParams,
+		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+			const runtimeRoot = sessionRuntimeDir(runtimeSessionId(ctx));
+			const stopped = await stopPersistentPane(runtimeRoot, params.agent);
+			removeDashboardAgent(stopped.agent);
+			await persistRuntimeSnapshot(ctx, runtimeRoot);
+			return {
+				content: [{ type: "text", text: `Stopped ${stopped.agent}. Pane ${stopped.paneId} was killed and removed from the active registry. Session preserved at ${stopped.sessionFile}; default start/subagent will resume it. Use forceSpawn or /agents new for a fresh session.` }],
+				details: { agent: stopped.agent, paneId: stopped.paneId, sessionFile: stopped.sessionFile },
+			};
+		},
+		renderCall(_args, _theme, _context) {
+			return new Container();
+		},
+		renderResult(result, _options, theme, context) {
+			const raw = (result.content as any[] | undefined)?.find?.((part: any) => part?.type === "text" && typeof part.text === "string")?.text ?? "";
+			const details = result.details as { agent?: string } | undefined;
+			if (context?.isError) return wrappedText(`${theme.fg("error", ICONS.times)} ${theme.fg("toolTitle", "Stop agent failed")}\n${theme.fg("muted", raw)}`);
+			return wrappedText(agentStatusLine(theme, details?.agent ?? "agent", "stopped", "success"));
+		},
+	});
+
+}

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/pane.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/pane.ts
@@ -17,6 +17,7 @@ import {
 	legacyProjectRuntimeDirs,
 	paneSessionPath,
 } from "./paths.js";
+import { randomHex } from "./random.js";
 import {
 	legacyPackageSessionRuntimeDir,
 	piUserDir,
@@ -673,7 +674,7 @@ export async function migrateLegacyProjectRuntime(cwd: string, runtimeRoot: stri
 		if (legacyRoot === path.resolve(runtimeRoot) || !fs.existsSync(legacyRoot)) continue;
 		await stopLegacyPanes(legacyRoot);
 		await fs.promises.mkdir(runtimeRoot, { recursive: true, mode: 0o700 });
-		const target = path.join(runtimeRoot, `legacy-project-runtime-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+		const target = path.join(runtimeRoot, `legacy-project-runtime-${Date.now()}-${randomHex(8)}`);
 		try {
 			await fs.promises.rename(legacyRoot, target);
 		} catch {

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/random.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/random.ts
@@ -1,0 +1,10 @@
+import { randomBytes, randomInt } from "node:crypto";
+
+export function randomHex(bytes: number = 8): string {
+	return randomBytes(Math.max(1, Math.floor(bytes))).toString("hex");
+}
+
+export function randomJitter(maxExclusive: number): number {
+	if (!Number.isFinite(maxExclusive) || maxExclusive <= 0) return 0;
+	return randomInt(Math.max(1, Math.floor(maxExclusive)));
+}

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/runner.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/runner.ts
@@ -28,6 +28,13 @@ import {
 	selectedToolsForAgent,
 	settingBoolean,
 } from "./settings.js";
+import {
+	guardReusedSessionBudget,
+	resolveBgSession,
+	resultHasContextLengthExceeded,
+	summarizeAttempt,
+	type BgSessionSelection,
+} from "./sessions.js";
 import { createTaskId, emitSubagentEvent } from "./tasks.js";
 import {
 	DETAIL_STRING_MAX_CHARS,
@@ -38,6 +45,13 @@ import {
 } from "./types.js";
 
 export type OnUpdateCallback = (partial: AgentToolResult<SubagentDetails>) => void;
+
+type SpawnProcess = typeof spawn;
+let spawnProcess: SpawnProcess = spawn;
+
+export function setSingleAgentSpawnForTests(spawner?: SpawnProcess): void {
+	spawnProcess = spawner ?? spawn;
+}
 
 export function formatTruncationNotice(
 	truncation: TruncationResult,
@@ -242,19 +256,132 @@ export async function runSingleAgent(
 		};
 	}
 
-	// Bg agents are resumable by default. A caller-provided sessionKey selects a
-	// named lane; otherwise each agent uses its default lane.
-	const args: string[] = ["--mode", "json", "-p"];
-	const effectiveSessionKey = sessionKey?.trim() || "default";
-	const sessionsDir = path.join(runtimeRoot, "sessions");
-	await fs.promises.mkdir(sessionsDir, { recursive: true, mode: 0o700 }).catch(() => undefined);
-	const resumedSessionPath = path.join(sessionsDir, `bg-${safeFileName(agent.name)}-${safeFileName(effectiveSessionKey)}.jsonl`);
-	args.push("--session", resumedSessionPath);
 	const selectedModel = selectedModelForAgent(agent, parentModel, defaultCwd);
-	if (selectedModel) args.push("--model", selectedModel);
 	const selectedThinking = selectedThinkingLevelForAgent(parentThinkingLevel, defaultCwd);
+	const firstSession = resolveBgSession(runtimeRoot, agent.name, sessionKey);
+	await fs.promises.mkdir(path.dirname(firstSession.path), { recursive: true, mode: 0o700 }).catch(() => undefined);
+
+	const budgetGuard = firstSession.explicit
+		? await guardReusedSessionBudget(firstSession.path, agent.name, selectedModel, cwd ?? defaultCwd)
+		: undefined;
+	if (budgetGuard && !budgetGuard.ok) {
+		const errorMessage = budgetGuard.warning ?? `Refusing reused session for ${agent.name}: estimated context budget exceeded.`;
+		return {
+			agent: agentName,
+			agentSource: agent.source,
+			task,
+			exitCode: 1,
+			messages: [],
+			stderr: errorMessage,
+			usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, contextTokens: budgetGuard.estimate.tokens, turns: 0 },
+			model: selectedModel,
+			sessionKey: firstSession.key,
+			sessionKeyExplicit: true,
+			sessionPath: firstSession.path,
+			ephemeralSession: false,
+			stopReason: "session_budget_exceeded",
+			errorMessage,
+			step,
+		};
+	}
+
+	const first = await runSingleAgentAttempt(
+		defaultCwd,
+		runtimeRoot,
+		agent,
+		agentName,
+		task,
+		cwd,
+		selectedModel,
+		selectedThinking,
+		step,
+		pi,
+		signal,
+		onUpdate,
+		makeDetails,
+		firstSession,
+		1,
+	);
+	if (budgetGuard?.warning) first.stderr = [budgetGuard.warning, first.stderr].filter(Boolean).join("\n");
+
+	if (!resultHasContextLengthExceeded(first)) return first;
+
+	const retrySession = resolveBgSession(runtimeRoot, agent.name);
+	const warning = `Context length exceeded for ${agent.name} session ${firstSession.key}; retrying once with fresh session ${retrySession.key}.`;
+	first.stderr = [first.stderr, warning].filter(Boolean).join("\n");
+	first.errorMessage = first.errorMessage ?? warning;
+	emitSubagentEvent(pi, "subagents:retrying", {
+		mode: "oneshot",
+		agent: agent.name,
+		taskId: first.taskId,
+		task,
+		runtimeRoot,
+		transcriptPath: first.transcriptPath,
+		model: first.model,
+		usage: first.usage,
+		reason: "context_length_exceeded",
+		retrySessionKey: retrySession.key,
+	});
+
+	const retry = await runSingleAgentAttempt(
+		defaultCwd,
+		runtimeRoot,
+		agent,
+		agentName,
+		task,
+		cwd,
+		selectedModel,
+		selectedThinking,
+		step,
+		pi,
+		signal,
+		onUpdate,
+		makeDetails,
+		retrySession,
+		2,
+	);
+	const attempts = [summarizeAttempt(first), summarizeAttempt(retry)];
+	retry.attempts = attempts;
+	const retryFailed = retry.exitCode !== 0 || retry.stopReason === "error" || retry.stopReason === "aborted" || resultHasContextLengthExceeded(retry);
+	if (!retryFailed) {
+		retry.stderr = [warning, retry.stderr].filter(Boolean).join("\n");
+		return retry;
+	}
+
+	const retryError = retry.errorMessage || retry.stderr || "retry failed without output";
+	const firstError = first.errorMessage || first.stderr || "first attempt failed without output";
+	const combinedError = [
+		`Context length exceeded for ${agent.name}; retry with fresh session also failed.`,
+		`First attempt (${first.sessionKey ?? firstSession.key}) exit ${first.exitCode}: ${firstError}`,
+		`Retry attempt (${retry.sessionKey ?? retrySession.key}) exit ${retry.exitCode}: ${retryError}`,
+	].join("\n");
+	retry.exitCode = retry.exitCode === 0 ? 1 : retry.exitCode;
+	retry.errorMessage = combinedError;
+	retry.stderr = [warning, combinedError, retry.stderr].filter(Boolean).join("\n");
+	return retry;
+}
+
+async function runSingleAgentAttempt(
+	defaultCwd: string,
+	runtimeRoot: string,
+	agent: AgentConfig,
+	agentName: string,
+	task: string,
+	cwd: string | undefined,
+	selectedModel: string | undefined,
+	selectedThinking: string | undefined,
+	step: number | undefined,
+	pi: ExtensionAPI,
+	signal: AbortSignal | undefined,
+	onUpdate: OnUpdateCallback | undefined,
+	makeDetails: (results: SingleResult[]) => SubagentDetails,
+	session: BgSessionSelection,
+	attempt: number,
+): Promise<SingleResult> {
+	const args: string[] = ["--mode", "json", "-p", "--session", session.path];
+	if (selectedModel) args.push("--model", selectedModel);
 	if (selectedThinking && selectedThinking !== "off") args.push("--thinking", selectedThinking);
-	const selectedTools = selectedToolsForAgent(agent, defaultCwd, [], pi.getActiveTools());
+	const selectedTools = selectedToolsForAgent(agent, defaultCwd, [], pi.getActiveTools?.() ?? []);
 	if (selectedTools && selectedTools.length > 0) args.push("--tools", selectedTools.join(","));
 
 	let tmpPromptDir: string | null = null;
@@ -278,10 +405,15 @@ export async function runSingleAgent(
 		// -1 = still running. Real exit code is set after proc.close; streaming
 		// partials must not look completed to callers that key on exitCode.
 		exitCode: -1,
+		attempt,
 		messages: [],
 		stderr: "",
 		usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, contextTokens: 0, turns: 0 },
 		model: selectedModel,
+		sessionKey: session.key,
+		sessionKeyExplicit: session.explicit,
+		sessionPath: session.path,
+		ephemeralSession: session.ephemeral,
 		taskId: oneShotTaskId,
 		transcriptPath,
 		step,
@@ -313,8 +445,12 @@ export async function runSingleAgent(
 			runtimeRoot,
 			transcriptPath,
 			model: selectedModel,
+			sessionKey: session.key,
+			sessionPath: session.path,
+			ephemeralSession: session.ephemeral,
+			attempt,
 		});
-		appendTranscript({ type: "start", agent: agent.name, taskId: oneShotTaskId, task, cwd: cwd ?? defaultCwd });
+		appendTranscript({ type: "start", agent: agent.name, taskId: oneShotTaskId, task, cwd: cwd ?? defaultCwd, sessionKey: session.key, sessionPath: session.path, ephemeralSession: session.ephemeral, attempt });
 
 		if (agent.systemPrompt.trim()) {
 			const tmp = await writePromptToTempFile(agent.name, agent.systemPrompt);
@@ -328,7 +464,7 @@ export async function runSingleAgent(
 
 		const exitCode = await new Promise<number>((resolve) => {
 			const invocation = getPiInvocation(args);
-			const proc = spawn(invocation.command, invocation.args, {
+			const proc = spawnProcess(invocation.command, invocation.args, {
 				cwd: cwd ?? defaultCwd,
 				shell: false,
 				stdio: ["ignore", "pipe", "pipe"],
@@ -368,6 +504,13 @@ export async function runSingleAgent(
 					emitUpdate();
 				}
 
+				if (event.type === "error") {
+					const errorText = typeof event.error === "string" ? event.error : JSON.stringify(event.error ?? event);
+					currentResult.errorMessage = errorText;
+					currentResult.stderr += `${errorText}\n`;
+					emitUpdate();
+				}
+
 				if (event.type === "tool_result_end") {
 					emitUpdate();
 				}
@@ -388,13 +531,13 @@ export async function runSingleAgent(
 
 			proc.on("close", (code) => {
 				if (buffer.trim()) processLine(buffer);
-				appendTranscript({ type: "exit", code: code ?? 0 });
+				appendTranscript({ type: "exit", code: code ?? 0, attempt });
 				Promise.allSettled(transcriptWrites).finally(() => resolve(code ?? 0));
 			});
 
 			proc.on("error", (error) => {
 				currentResult.errorMessage = stringifyError(error);
-				appendTranscript({ type: "process_error", error: stringifyError(error) });
+				appendTranscript({ type: "process_error", error: stringifyError(error), attempt });
 				Promise.allSettled(transcriptWrites).finally(() => resolve(1));
 			});
 
@@ -425,6 +568,10 @@ export async function runSingleAgent(
 				transcriptPath,
 				model: currentResult.model,
 				usage: currentResult.usage,
+				sessionKey: session.key,
+				sessionPath: session.path,
+				ephemeralSession: session.ephemeral,
+				attempt,
 			});
 			throw new Error("Agent was aborted");
 		}
@@ -440,6 +587,10 @@ export async function runSingleAgent(
 			model: currentResult.model,
 			usage: currentResult.usage,
 			error: failed ? currentResult.errorMessage || currentResult.stderr || undefined : undefined,
+			sessionKey: session.key,
+			sessionPath: session.path,
+			ephemeralSession: session.ephemeral,
+			attempt,
 		});
 		return currentResult;
 	} finally {

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/runner.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/runner.ts
@@ -21,6 +21,7 @@ import {
 import {
 	oneShotTranscriptPath,
 } from "./paths.js";
+import { randomHex } from "./random.js";
 import {
 	resultLimits,
 	selectedModelForAgent,
@@ -83,7 +84,7 @@ export async function writeFullOutputArtifact(
 	const dir = path.join(runtimeRoot, "outputs", safeFileName(agentName || "subagent"));
 	const filePath = path.join(
 		dir,
-		`${Date.now()}-${Math.random().toString(16).slice(2)}-${safeFileName(label || "output")}.txt`,
+		`${Date.now()}-${randomHex(8)}-${safeFileName(label || "output")}.txt`,
 	);
 	try {
 		await withFileMutationQueue(filePath, async () => {

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/runner.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/runner.ts
@@ -30,6 +30,8 @@ import {
 } from "./settings.js";
 import {
 	guardReusedSessionBudget,
+	isContextLengthExceededEnvelope,
+	isContextLengthExceededText,
 	resolveBgSession,
 	resultHasContextLengthExceeded,
 	summarizeAttempt,
@@ -352,9 +354,11 @@ export async function runSingleAgent(
 	const firstError = first.errorMessage || first.stderr || "first attempt failed without output";
 	const combinedError = [
 		`Context length exceeded for ${agent.name}; retry with fresh session also failed.`,
+		first.errorEnvelope ? `First raw error envelope: ${first.errorEnvelope}` : "",
+		retry.errorEnvelope ? `Retry raw error envelope: ${retry.errorEnvelope}` : "",
 		`First attempt (${first.sessionKey ?? firstSession.key}) exit ${first.exitCode}: ${firstError}`,
 		`Retry attempt (${retry.sessionKey ?? retrySession.key}) exit ${retry.exitCode}: ${retryError}`,
-	].join("\n");
+	].filter(Boolean).join("\n");
 	retry.exitCode = retry.exitCode === 0 ? 1 : retry.exitCode;
 	retry.errorMessage = combinedError;
 	retry.stderr = [warning, combinedError, retry.stderr].filter(Boolean).join("\n");
@@ -504,10 +508,13 @@ async function runSingleAgentAttempt(
 					emitUpdate();
 				}
 
-				if (event.type === "error") {
+				const hasContextOverflowEnvelope = isContextLengthExceededEnvelope(event) || isContextLengthExceededText(line);
+				if (event.type === "error" || hasContextOverflowEnvelope) {
+					const rawEnvelope = line;
 					const errorText = typeof event.error === "string" ? event.error : JSON.stringify(event.error ?? event);
+					currentResult.errorEnvelope = rawEnvelope;
 					currentResult.errorMessage = errorText;
-					currentResult.stderr += `${errorText}\n`;
+					currentResult.stderr += `${rawEnvelope}\n`;
 					emitUpdate();
 				}
 

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/sessions.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/sessions.ts
@@ -8,7 +8,7 @@ export const ONESHOT_SESSION_PREFIX = "oneshot-";
 export const DEFAULT_REUSED_SESSION_BUDGET_THRESHOLD = 0.8;
 export const DEFAULT_MODEL_CONTEXT_LIMIT_TOKENS = 200_000;
 
-type ReusedSessionBudgetPolicy = "refuse" | "warn";
+type ReusedSessionBudgetPolicy = "compact-then-resume" | "refuse-and-warn" | "warn";
 
 export interface BgSessionSelection {
 	ephemeral: boolean;
@@ -28,10 +28,44 @@ export interface SessionBudgetEstimate {
 }
 
 export interface SessionBudgetGuard {
+	compacted?: boolean;
+	compactionPath?: string;
 	estimate: SessionBudgetEstimate;
 	ok: boolean;
 	policy: ReusedSessionBudgetPolicy;
 	warning?: string;
+}
+
+export interface SessionCompactionRequest {
+	agentName: string;
+	estimate: SessionBudgetEstimate;
+	model?: string;
+	sessionPath: string;
+}
+
+export interface SessionCompactionResult {
+	archivePath?: string;
+}
+
+type SessionCompactor = (request: SessionCompactionRequest) => Promise<SessionCompactionResult>;
+
+const defaultSessionCompactor: SessionCompactor = async (request) => {
+	let archivePath: string | undefined;
+	try {
+		const dir = path.dirname(request.sessionPath);
+		archivePath = path.join(dir, `${path.basename(request.sessionPath)}.precompact-${Date.now()}`);
+		await fs.promises.copyFile(request.sessionPath, archivePath);
+		await fs.promises.truncate(request.sessionPath, 0);
+	} catch (error) {
+		throw new Error(`Failed to compact reused session ${request.sessionPath}: ${error instanceof Error ? error.message : String(error)}`);
+	}
+	return { archivePath };
+};
+
+let sessionCompactor: SessionCompactor = defaultSessionCompactor;
+
+export function setSessionCompactorForTests(compactor?: SessionCompactor): void {
+	sessionCompactor = compactor ?? defaultSessionCompactor;
 }
 
 export function createOneShotSessionKey(): string {
@@ -65,7 +99,9 @@ export function reusedSessionBudgetThreshold(cwd?: string): number {
 }
 
 export function reusedSessionBudgetPolicy(cwd?: string): ReusedSessionBudgetPolicy {
-	return settingString("reusedSessionBudgetPolicy", "refuse", cwd) === "warn" ? "warn" : "refuse";
+	const value = settingString("reusedSessionBudgetPolicy", "refuse-and-warn", cwd);
+	if (value === "warn" || value === "compact-then-resume") return value;
+	return "refuse-and-warn";
 }
 
 export function modelContextLimitTokens(model: string | undefined, cwd?: string): number {
@@ -110,8 +146,39 @@ export async function guardReusedSessionBudget(sessionPath: string, agentName: s
 	const pct = Math.round(estimate.ratio * 100);
 	const thresholdPct = Math.round(estimate.threshold * 100);
 	const base = `reused session for ${agentName}: estimated context ${estimate.tokens}/${estimate.contextLimitTokens} tokens (${pct}%) exceeds ${thresholdPct}% guard threshold. Use a fresh call without sessionKey, a smaller task, or raise reusedSessionBudgetThreshold/reusedSessionContextLimitTokens if intentional.`;
+	if (policy === "compact-then-resume") {
+		let compacted: SessionCompactionResult;
+		try {
+			compacted = await sessionCompactor({ agentName, estimate, model, sessionPath });
+		} catch (error) {
+			return {
+				estimate,
+				ok: false,
+				policy,
+				warning: `Compaction failed for ${base} ${error instanceof Error ? error.message : String(error)}`,
+			};
+		}
+		return {
+			compacted: true,
+			compactionPath: compacted.archivePath,
+			estimate,
+			ok: true,
+			policy,
+			warning: `Compacted ${base}${compacted.archivePath ? ` Archived previous session at ${compacted.archivePath}.` : ""}`,
+		};
+	}
 	const warning = policy === "warn" ? `Warning for ${base}` : `Refusing ${base}`;
 	return { estimate, ok: policy === "warn", policy, warning };
+}
+
+export function isContextLengthExceededEnvelope(value: unknown): boolean {
+	if (!value || typeof value !== "object") return false;
+	const candidate = value as Record<string, unknown>;
+	const error = candidate.error && typeof candidate.error === "object" ? candidate.error as Record<string, unknown> : undefined;
+	return error?.code === "context_length_exceeded"
+		|| error?.type === "context_length_exceeded"
+		|| candidate.code === "context_length_exceeded"
+		|| candidate.type === "context_length_exceeded";
 }
 
 export function isContextLengthExceededText(text: string | undefined): boolean {
@@ -134,6 +201,7 @@ function messageText(result: SingleResult): string {
 export function resultHasContextLengthExceeded(result: SingleResult): boolean {
 	return isContextLengthExceededText([
 		result.stderr,
+		result.errorEnvelope,
 		result.errorMessage,
 		result.stopReason,
 		messageText(result),
@@ -143,6 +211,7 @@ export function resultHasContextLengthExceeded(result: SingleResult): boolean {
 export function summarizeAttempt(result: SingleResult): AttemptSummary {
 	return {
 		attempt: result.attempt ?? 1,
+		errorEnvelope: result.errorEnvelope,
 		errorMessage: result.errorMessage,
 		exitCode: result.exitCode,
 		sessionKey: result.sessionKey,

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/sessions.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/sessions.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { safeFileName } from "./names.js";
+import { randomHex } from "./random.js";
 import { settingNumber, settingString } from "./settings.js";
 import type { AttemptSummary, SingleResult } from "./types.js";
 
@@ -69,7 +70,7 @@ export function setSessionCompactorForTests(compactor?: SessionCompactor): void 
 }
 
 export function createOneShotSessionKey(): string {
-	return `${ONESHOT_SESSION_PREFIX}${Date.now().toString(36)}-${Math.random().toString(16).slice(2, 10)}`;
+	return `${ONESHOT_SESSION_PREFIX}${Date.now().toString(36)}-${randomHex(4)}`;
 }
 
 export function bgSessionPath(runtimeRoot: string, agentName: string, sessionKey: string): string {

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/sessions.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/sessions.ts
@@ -1,0 +1,155 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { safeFileName } from "./names.js";
+import { settingNumber, settingString } from "./settings.js";
+import type { AttemptSummary, SingleResult } from "./types.js";
+
+export const ONESHOT_SESSION_PREFIX = "oneshot-";
+export const DEFAULT_REUSED_SESSION_BUDGET_THRESHOLD = 0.8;
+export const DEFAULT_MODEL_CONTEXT_LIMIT_TOKENS = 200_000;
+
+type ReusedSessionBudgetPolicy = "refuse" | "warn";
+
+export interface BgSessionSelection {
+	ephemeral: boolean;
+	explicit: boolean;
+	key: string;
+	path: string;
+}
+
+export interface SessionBudgetEstimate {
+	bytes: number;
+	contextLimitTokens: number;
+	exists: boolean;
+	path: string;
+	ratio: number;
+	threshold: number;
+	tokens: number;
+}
+
+export interface SessionBudgetGuard {
+	estimate: SessionBudgetEstimate;
+	ok: boolean;
+	policy: ReusedSessionBudgetPolicy;
+	warning?: string;
+}
+
+export function createOneShotSessionKey(): string {
+	return `${ONESHOT_SESSION_PREFIX}${Date.now().toString(36)}-${Math.random().toString(16).slice(2, 10)}`;
+}
+
+export function bgSessionPath(runtimeRoot: string, agentName: string, sessionKey: string): string {
+	return path.join(runtimeRoot, "sessions", `bg-${safeFileName(agentName)}-${safeFileName(sessionKey)}.jsonl`);
+}
+
+export function resolveBgSession(runtimeRoot: string, agentName: string, sessionKey?: string): BgSessionSelection {
+	const trimmed = sessionKey?.trim();
+	const explicit = Boolean(trimmed && !trimmed.startsWith(ONESHOT_SESSION_PREFIX));
+	const key = trimmed || createOneShotSessionKey();
+	return {
+		ephemeral: !explicit,
+		explicit,
+		key,
+		path: bgSessionPath(runtimeRoot, agentName, key),
+	};
+}
+
+export function normalizeBudgetThreshold(value: number): number {
+	if (!Number.isFinite(value) || value <= 0) return DEFAULT_REUSED_SESSION_BUDGET_THRESHOLD;
+	const normalized = value > 1 ? value / 100 : value;
+	return Math.min(1, Math.max(0.01, normalized));
+}
+
+export function reusedSessionBudgetThreshold(cwd?: string): number {
+	return normalizeBudgetThreshold(settingNumber("reusedSessionBudgetThreshold", DEFAULT_REUSED_SESSION_BUDGET_THRESHOLD, cwd));
+}
+
+export function reusedSessionBudgetPolicy(cwd?: string): ReusedSessionBudgetPolicy {
+	return settingString("reusedSessionBudgetPolicy", "refuse", cwd) === "warn" ? "warn" : "refuse";
+}
+
+export function modelContextLimitTokens(model: string | undefined, cwd?: string): number {
+	const configured = Math.floor(settingNumber("reusedSessionContextLimitTokens", DEFAULT_MODEL_CONTEXT_LIMIT_TOKENS, cwd));
+	if (Number.isFinite(configured) && configured > 0) return configured;
+	void model;
+	return DEFAULT_MODEL_CONTEXT_LIMIT_TOKENS;
+}
+
+export function estimateTokensFromBytes(bytes: number): number {
+	return Math.ceil(Math.max(0, bytes) / 4);
+}
+
+export async function estimateSessionBudget(sessionPath: string, model: string | undefined, cwd?: string): Promise<SessionBudgetEstimate> {
+	let bytes = 0;
+	let exists = false;
+	try {
+		const stat = await fs.promises.stat(sessionPath);
+		bytes = stat.isFile() ? stat.size : 0;
+		exists = stat.isFile();
+	} catch {
+		// Missing session files are empty reused lanes.
+	}
+	const contextLimitTokens = modelContextLimitTokens(model, cwd);
+	const tokens = estimateTokensFromBytes(bytes);
+	const threshold = reusedSessionBudgetThreshold(cwd);
+	return {
+		bytes,
+		contextLimitTokens,
+		exists,
+		path: sessionPath,
+		ratio: contextLimitTokens > 0 ? tokens / contextLimitTokens : 0,
+		threshold,
+		tokens,
+	};
+}
+
+export async function guardReusedSessionBudget(sessionPath: string, agentName: string, model: string | undefined, cwd?: string): Promise<SessionBudgetGuard> {
+	const estimate = await estimateSessionBudget(sessionPath, model, cwd);
+	const policy = reusedSessionBudgetPolicy(cwd);
+	if (!estimate.exists || estimate.ratio <= estimate.threshold) return { estimate, ok: true, policy };
+	const pct = Math.round(estimate.ratio * 100);
+	const thresholdPct = Math.round(estimate.threshold * 100);
+	const base = `reused session for ${agentName}: estimated context ${estimate.tokens}/${estimate.contextLimitTokens} tokens (${pct}%) exceeds ${thresholdPct}% guard threshold. Use a fresh call without sessionKey, a smaller task, or raise reusedSessionBudgetThreshold/reusedSessionContextLimitTokens if intentional.`;
+	const warning = policy === "warn" ? `Warning for ${base}` : `Refusing ${base}`;
+	return { estimate, ok: policy === "warn", policy, warning };
+}
+
+export function isContextLengthExceededText(text: string | undefined): boolean {
+	if (!text) return false;
+	return /context[_-]length[_-]exceeded/i.test(text)
+		|| /"code"\s*:\s*"context_length_exceeded"/i.test(text)
+		|| /"type"\s*:\s*"context_length_exceeded"/i.test(text);
+}
+
+function messageText(result: SingleResult): string {
+	const parts: string[] = [];
+	for (const message of result.messages ?? []) {
+		for (const part of message.content ?? []) {
+			if (part.type === "text") parts.push(part.text);
+		}
+	}
+	return parts.join("\n");
+}
+
+export function resultHasContextLengthExceeded(result: SingleResult): boolean {
+	return isContextLengthExceededText([
+		result.stderr,
+		result.errorMessage,
+		result.stopReason,
+		messageText(result),
+	].filter(Boolean).join("\n"));
+}
+
+export function summarizeAttempt(result: SingleResult): AttemptSummary {
+	return {
+		attempt: result.attempt ?? 1,
+		errorMessage: result.errorMessage,
+		exitCode: result.exitCode,
+		sessionKey: result.sessionKey,
+		sessionPath: result.sessionPath,
+		stderr: result.stderr,
+		stopReason: result.stopReason,
+		taskId: result.taskId,
+		transcriptPath: result.transcriptPath,
+	};
+}

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/subagent-render.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/subagent-render.ts
@@ -1,0 +1,401 @@
+import { getMarkdownTheme } from "@earendil-works/pi-coding-agent";
+import { Container, Markdown, Spacer, truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
+import { discoverAgents, type AgentScope } from "./agents.js";
+import {
+	addArtifactPathSection,
+	addSectionHeading,
+	addWrappedSection,
+	agentStatusLine,
+	agentsCommandBullet,
+	agentWord,
+	ansiMagenta,
+	compactPath,
+	finalOutputLooksLikeToolEcho,
+	finalResponseSuppressedLine,
+	formatToolCall,
+	formatUsageStats,
+	getDisplayItems,
+	getFinalOutput,
+	oneLinePreview,
+	subagentBranch,
+	wrappedText,
+} from "./format.js";
+import { dashboardEnabled, quietInline, settingNumber } from "./settings.js";
+import {
+	COLLAPSED_ITEM_COUNT,
+	ICONS,
+	type DisplayItem,
+	type SingleResult,
+	type SubagentDetails,
+	type UsageStats,
+} from "./types.js";
+
+export const subagentToolRenderers = {
+	renderCall(args, theme, _context) {
+		const scope: AgentScope = args.agentScope ?? "project";
+		if (args.chain && args.chain.length > 0) {
+			let text =
+				theme.fg("toolTitle", theme.bold("agents ")) +
+				theme.fg("accent", `chain (${args.chain.length} steps)`) +
+				theme.fg("muted", ` [${scope}]`);
+			for (let i = 0; i < Math.min(args.chain.length, 3); i++) {
+				const step = args.chain[i];
+				const cleanTask = step.task.replace(/\{previous\}/g, "").trim();
+				const preview = cleanTask.length > 40 ? `${cleanTask.slice(0, 40)}...` : cleanTask;
+				text +=
+					"\n  " +
+					theme.fg("muted", `${i + 1}.`) +
+					" " +
+					theme.fg("accent", step.agent) +
+					theme.fg("dim", ` ${preview}`);
+			}
+			if (args.chain.length > 3) text += `\n  ${theme.fg("muted", `... +${args.chain.length - 3} more`)}`;
+			return wrappedText(text);
+		}
+		if (args.tasks && args.tasks.length > 0) {
+			return new Container();
+		}
+		const agentName = args.agent || "...";
+		try {
+			const agent = discoverAgents(_context?.cwd ?? process.cwd(), scope).agents.find((candidate) => candidate.name === agentName);
+			if (agent?.pane) return new Container();
+		} catch {
+			// Keep the generic call preview if discovery fails.
+		}
+		const preview = args.task ? oneLinePreview(args.task, 56) : "...";
+		let text = `${agentsCommandBullet(theme)}${agentWord(theme)} ${ansiMagenta(theme.bold(agentName))}`;
+		if (scope !== "project") text += theme.fg("dim", ` · ${scope}`);
+		text += `\n${subagentBranch(theme, "└", _context?.cwd)}${theme.fg("dim", preview)}`;
+		return wrappedText(text);
+	},
+
+	renderResult(result, { expanded }, theme, context) {
+		const cwd = context?.cwd;
+		const collapsedItemCount = Math.max(1, Math.floor(settingNumber("collapsedItemCount", COLLAPSED_ITEM_COUNT, context?.cwd)));
+		const details = result.details as SubagentDetails | undefined;
+		if (!details || details.results.length === 0) {
+			const text = result.content[0];
+			return wrappedText(text?.type === "text" ? text.text : "(no output)");
+		}
+
+		const mdTheme = getMarkdownTheme();
+		const truncationBadge = (r: SingleResult) => (r.truncation?.truncated ? theme.fg("warning", " · truncated") : "");
+		const fullOutputLine = (r: SingleResult) =>
+			r.fullOutputPath
+				? theme.fg("dim", `Full output: ${compactPath(r.fullOutputPath)}`)
+				: r.fullOutputError
+					? theme.fg("warning", `Full output unavailable: ${r.fullOutputError}`)
+					: "";
+		const transcriptLine = (r: SingleResult) => (r.transcriptPath ? theme.fg("dim", `Transcript: ${compactPath(r.transcriptPath)}`) : "");
+		const queuedPaneLine = (r: SingleResult, _dashboard = false) => {
+			if (!r.taskId || !r.paneId) return "";
+			const mode = r.paneSessionMode === "live" ? "reused live pane" : r.paneSessionMode === "resumed" ? "resumed pane" : "new pane";
+			const suffix = `${theme.fg("dim", ` · ${mode}`)}${theme.fg("dim", " · ctrl+o expand")}`;
+			return agentStatusLine(theme, r.agent, "Queued task", "warning", suffix);
+		};
+		const queuedTaskPreviewComponent = (r: SingleResult, dashboard = false) => ({
+			invalidate() {},
+			render(width: number): string[] {
+				const header = queuedPaneLine(r, dashboard);
+				const task = r.task.replace(/\s+/g, " ").trim() || "queued task";
+				const firstPrefix = subagentBranch(theme, "└", cwd);
+				const nextPrefix = " ".repeat(Math.max(0, visibleWidth(firstPrefix)));
+				const textWidth = Math.max(20, width - Math.max(visibleWidth(firstPrefix), visibleWidth(nextPrefix)));
+				const wrapped = wrapTextWithAnsi(task, textWidth);
+				const shown = wrapped.slice(0, 2);
+				if (wrapped.length > shown.length && shown.length > 0) shown[shown.length - 1] = truncateToWidth(`${shown[shown.length - 1]}…`, textWidth, "…");
+				return [
+					header,
+					`${firstPrefix}${theme.fg("dim", shown[0] ?? "queued task")}`,
+					...(shown[1] ? [`${nextPrefix}${theme.fg("dim", shown[1])}`] : []),
+				];
+			},
+		});
+		const expandedQueuedTaskComponent = (r: SingleResult) => {
+			const container = new Container();
+			container.addChild(wrappedText(queuedPaneLine(r)));
+			addSectionHeading(container, theme, "Queued task");
+			container.addChild(new Markdown(r.task.trim() || "(empty task)", 0, 0, mdTheme));
+			if (r.taskId || r.queuedTaskFile || r.queuedOutboxFile || r.transcriptPath) {
+				if (r.paneSessionMode) addWrappedSection(container, theme, "Pane session", r.paneSessionMode === "live" ? "Reused live pane" : r.paneSessionMode === "resumed" ? "Resumed saved pane session" : "Started new pane session", "dim");
+				if (r.taskId) addWrappedSection(container, theme, "Task ID", r.taskId, "dim");
+				addArtifactPathSection(container, theme, "Inbox", r.queuedTaskFile);
+				addArtifactPathSection(container, theme, "Completion", r.queuedOutboxFile);
+				addArtifactPathSection(container, theme, "Transcript", r.transcriptPath);
+			}
+			return container;
+		};
+		const addFinalResponseMarkdown = (container: Container, finalOutput: string, toolCalls: DisplayItem[]) => {
+			if (!finalOutput.trim()) {
+				container.addChild(wrappedText(theme.fg("muted", "(no final response)")));
+				return;
+			}
+			if (finalOutputLooksLikeToolEcho(finalOutput, toolCalls)) {
+				container.addChild(wrappedText(finalResponseSuppressedLine(theme)));
+				return;
+			}
+			container.addChild(new Markdown(finalOutput.trim(), 0, 0, mdTheme));
+		};
+
+		const renderDisplayItems = (items: DisplayItem[], limit?: number) => {
+			const toShow = limit ? items.slice(-limit) : items;
+			const skipped = limit && items.length > limit ? items.length - limit : 0;
+			let text = "";
+			if (skipped > 0) text += theme.fg("muted", `... ${skipped} earlier items\n`);
+			for (const [index, item] of toShow.entries()) {
+				const branch = subagentBranch(theme, index === toShow.length - 1 ? "└" : "├", cwd);
+				if (item.type === "text") {
+					const preview = expanded ? item.text : item.text.split("\n").slice(0, 3).join("\n");
+					const lines = preview.split(/\r?\n/);
+					text += `${branch}${theme.fg("toolOutput", lines[0] ?? "")}\n`;
+					for (const line of lines.slice(1)) text += `${subagentBranch(theme, "│", cwd)}${theme.fg("toolOutput", line)}\n`;
+				} else {
+					text += `${branch}${formatToolCall(item.name, item.args, theme.fg.bind(theme))}\n`;
+				}
+			}
+			return text.trimEnd();
+		};
+
+		if (details.mode === "single" && details.results.length === 1) {
+			const r = details.results[0];
+			if (r.duplicateQueued) return new Container();
+			// runSingleAgent uses exitCode -1 as the still-running sentinel while
+			// emitting streaming partials; only a positive exitCode (or a terminal
+			// stopReason) is a real failure.
+			const isRunning = r.exitCode === -1;
+			const isError = !isRunning && (r.exitCode > 0 || r.stopReason === "error" || r.stopReason === "aborted");
+			const isQueued = !isError && !isRunning && Boolean(r.taskId && r.paneId);
+			const displayItems = getDisplayItems(r.messages);
+			const finalOutput = getFinalOutput(r.messages);
+			const queued = queuedPaneLine(r);
+			const quietDashboard = !expanded && dashboardEnabled(cwd) && quietInline(cwd);
+
+			if (expanded) {
+				if (isQueued) return expandedQueuedTaskComponent(r);
+				const container = new Container();
+				const statusLabel = isQueued ? "Queued task" : isRunning ? "working" : isError ? "failed" : "completed";
+				const statusTone = isQueued || isRunning ? "warning" : isError ? "error" : "success";
+				let header = agentStatusLine(theme, r.agent, statusLabel, statusTone, theme.fg("dim", ` · ${isQueued ? "pane" : "bg"}`));
+				if (isError && r.stopReason) header += ` ${theme.fg("error", `[${r.stopReason}]`)}`;
+				header += truncationBadge(r);
+				container.addChild(wrappedText(header));
+				if (isError && r.errorMessage) container.addChild(wrappedText(theme.fg("error", `Error: ${r.errorMessage}`)));
+				container.addChild(new Spacer(1));
+				container.addChild(wrappedText(theme.fg("muted", "─── Task ───")));
+				container.addChild(wrappedText(theme.fg("dim", r.task)));
+				container.addChild(new Spacer(1));
+				const toolCalls = displayItems.filter((item) => item.type === "toolCall");
+				container.addChild(wrappedText(theme.fg("muted", "─── Tools used ───")));
+				if (toolCalls.length === 0) container.addChild(wrappedText(theme.fg("muted", "(none)")));
+				else {
+					for (const item of toolCalls) {
+						container.addChild(
+							wrappedText(theme.fg("muted", "→ ") + formatToolCall(item.name, item.args, theme.fg.bind(theme))),
+						);
+					}
+				}
+				container.addChild(new Spacer(1));
+				container.addChild(wrappedText(theme.fg("muted", "─── Final response ───")));
+				addFinalResponseMarkdown(container, finalOutput, toolCalls);
+				const outputPath = fullOutputLine(r);
+				if (outputPath) container.addChild(wrappedText(outputPath));
+				const transcript = transcriptLine(r);
+				if (transcript) container.addChild(wrappedText(transcript));
+				const usageStr = queued ? "" : formatUsageStats(r.usage, r.model);
+				if (usageStr) {
+					container.addChild(new Spacer(1));
+					container.addChild(wrappedText(theme.fg("dim", usageStr)));
+				}
+				return container;
+			}
+
+
+			if (queued) return queuedTaskPreviewComponent(r, quietDashboard);
+
+			if (quietDashboard && !queued && !isError) {
+				const toolCalls = displayItems.filter((item) => item.type === "toolCall");
+				const preview = finalOutput && !finalOutputLooksLikeToolEcho(finalOutput, toolCalls)
+					? oneLinePreview(finalOutput, 180)
+					: r.task
+						? oneLinePreview(r.task, 140)
+						: "completed";
+				let text = `${theme.fg("toolTitle", theme.bold("Result from"))} ${ansiMagenta(theme.bold(r.agent))}${theme.fg("dim", " · bg · ctrl+o")}${truncationBadge(r)}`;
+				if (preview) text += `\n${subagentBranch(theme, "└", cwd)}${theme.fg("toolOutput", preview)}`;
+				const outputPath = fullOutputLine(r);
+				if (outputPath) text += `\n${outputPath}`;
+				return wrappedText(text);
+			}
+
+			const compactStatusLabel = isRunning ? "working" : isError ? "failed" : "completed";
+			const compactStatusTone = isRunning ? "warning" : isError ? "error" : "success";
+			let text = queued || agentStatusLine(theme, r.agent, compactStatusLabel, compactStatusTone, `${theme.fg("dim", " · bg")}${theme.fg("dim", " · ctrl+o")}`);
+			if (isError && r.stopReason) text += ` ${theme.fg("error", `[${r.stopReason}]`)}`;
+			text += truncationBadge(r);
+			if (queued) text += `\n${subagentBranch(theme, "└", cwd)}${theme.fg("dim", r.task ? oneLinePreview(r.task, 120) : "queued task")}`;
+			else if (isError && r.errorMessage) text += `\n${theme.fg("error", `Error: ${r.errorMessage}`)}`;
+			else if (displayItems.length === 0) text += `\n${subagentBranch(theme, "└", cwd)}${theme.fg("dim", r.task ? oneLinePreview(r.task, 120) : "(no output)")}`;
+			else {
+				if (r.task) text += `\n${subagentBranch(theme, "├", cwd)}${theme.fg("dim", oneLinePreview(r.task, 120))}`;
+				text += `\n${renderDisplayItems(displayItems, collapsedItemCount)}`;
+				if (displayItems.length > collapsedItemCount) text += `\n${theme.fg("muted", "… more in ctrl+o")}`;
+			}
+			const outputPath = queued ? "" : fullOutputLine(r);
+			if (outputPath) text += `\n${outputPath}`;
+			const usageStr = formatUsageStats(r.usage, r.model);
+			if (usageStr) text += `\n${theme.fg("dim", usageStr)}`;
+			return wrappedText(text);
+		}
+
+		const aggregateUsage = (results: SingleResult[]) => {
+			const total: UsageStats = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, contextTokens: 0, turns: 0 };
+			for (const r of results) {
+				total.input += r.usage.input;
+				total.output += r.usage.output;
+				total.cacheRead += r.usage.cacheRead;
+				total.cacheWrite += r.usage.cacheWrite;
+				total.cost += r.usage.cost;
+				total.contextTokens = Math.max(total.contextTokens, r.usage.contextTokens || 0);
+				total.turns += r.usage.turns;
+			}
+			return total;
+		};
+
+		if (details.mode === "chain") {
+			const successCount = details.results.filter((r) => r.exitCode === 0).length;
+			const runningCount = details.results.filter((r) => r.exitCode === -1).length;
+			const chainStepIcon = (r: SingleResult) =>
+				r.exitCode === -1
+					? theme.fg("warning", ICONS.cog)
+					: r.exitCode === 0
+						? theme.fg("success", ICONS.check)
+						: theme.fg("error", ICONS.times);
+			const icon = runningCount > 0
+				? theme.fg("warning", ICONS.cog)
+				: successCount === details.results.length
+					? theme.fg("success", ICONS.check)
+					: theme.fg("error", ICONS.times);
+
+			if (expanded) {
+				const container = new Container();
+				container.addChild(
+					wrappedText(
+						icon +
+							" " +
+							theme.fg("toolTitle", theme.bold("chain ")) +
+							theme.fg("accent", `${successCount}/${details.results.length} steps`),
+					),
+				);
+
+				for (const r of details.results) {
+					const rIcon = chainStepIcon(r);
+					const displayItems = getDisplayItems(r.messages);
+					const finalOutput = getFinalOutput(r.messages);
+
+					container.addChild(new Spacer(1));
+					container.addChild(
+						wrappedText(
+							`${theme.fg("muted", `─── Step ${r.step}: `) + theme.fg("accent", r.agent)} ${rIcon}${truncationBadge(r)}`,
+						),
+					);
+					container.addChild(wrappedText(theme.fg("muted", "Task: ") + theme.fg("dim", r.task)));
+					const toolCalls = displayItems.filter((item) => item.type === "toolCall");
+					container.addChild(wrappedText(theme.fg("muted", "Tools used:")));
+					if (toolCalls.length === 0) container.addChild(wrappedText(theme.fg("muted", "(none)")));
+					else {
+						for (const item of toolCalls) {
+							container.addChild(
+								wrappedText(theme.fg("muted", "→ ") + formatToolCall(item.name, item.args, theme.fg.bind(theme))),
+							);
+						}
+					}
+
+					container.addChild(wrappedText(theme.fg("muted", "Final response:")));
+					addFinalResponseMarkdown(container, finalOutput, toolCalls);
+
+					const outputPath = fullOutputLine(r);
+					if (outputPath) container.addChild(wrappedText(outputPath));
+					const transcript = transcriptLine(r);
+					if (transcript) container.addChild(wrappedText(transcript));
+					const stepUsage = formatUsageStats(r.usage, r.model);
+					if (stepUsage) container.addChild(wrappedText(theme.fg("dim", stepUsage)));
+				}
+
+				const usageStr = formatUsageStats(aggregateUsage(details.results));
+				if (usageStr) {
+					container.addChild(new Spacer(1));
+					container.addChild(wrappedText(theme.fg("dim", `Total: ${usageStr}`)));
+				}
+				return container;
+			}
+
+			let text =
+				icon +
+				" " +
+				theme.fg("toolTitle", theme.bold("chain ")) +
+				theme.fg("accent", `${successCount}/${details.results.length} steps`);
+			for (const r of details.results) {
+				const rIcon = chainStepIcon(r);
+				const displayItems = getDisplayItems(r.messages);
+				text += `\n\n${theme.fg("muted", `─── Step ${r.step}: `)}${theme.fg("accent", r.agent)} ${rIcon}${truncationBadge(r)}`;
+				if (displayItems.length === 0) text += `\n${theme.fg("muted", "(no output)")}`;
+				else text += `\n${renderDisplayItems(displayItems, 5)}`;
+				const outputPath = fullOutputLine(r);
+				if (outputPath) text += `\n${outputPath}`;
+				const transcript = transcriptLine(r);
+				if (transcript) text += `\n${transcript}`;
+			}
+			const usageStr = formatUsageStats(aggregateUsage(details.results));
+			if (usageStr) text += `\n\n${theme.fg("dim", `Total: ${usageStr}`)}`;
+			text += `\n${theme.fg("muted", "(ctrl+o to expand)")}`;
+			return wrappedText(text);
+		}
+
+		if (details.mode === "parallel") {
+			const running = details.results.filter((r) => r.exitCode === -1).length;
+			const successCount = details.results.filter((r) => r.exitCode === 0).length;
+			const failCount = details.results.filter((r) => r.exitCode > 0).length;
+			const queuedPaneCount = details.results.filter((r) => r.exitCode === 0 && r.taskId && r.paneId).length;
+			const oneshotCompletedCount = successCount - queuedPaneCount;
+			const isRunning = running > 0;
+			const total = details.results.length;
+			const pluralN = (n: number) => (n === 1 ? "" : "s");
+			const headerLabel = isRunning
+				? `${total} agent${pluralN(total)} running`
+				: failCount > 0
+					? `${successCount}/${total} agent${pluralN(total)} completed`
+					: queuedPaneCount === total
+						? `${total} agent${pluralN(total)} launched`
+						: queuedPaneCount > 0
+							? `${total} agents launched (${oneshotCompletedCount} bg, ${queuedPaneCount} pane)`
+							: `${total} agent${pluralN(total)} completed`;
+			const hint = isRunning
+				? ""
+				: queuedPaneCount > 0
+					? theme.fg("muted", " · see dashboard for live status")
+					: dashboardEnabled(cwd) && quietInline(cwd) && !expanded
+						? theme.fg("muted", " · lifecycle in dashboard")
+					: expanded
+						? ""
+						: theme.fg("muted", " (ctrl+o to inspect)");
+			const headerText =
+				theme.fg("accent", "● ") +
+				theme.fg("toolTitle", theme.bold(headerLabel)) +
+				hint;
+			const nameWidth = Math.min(28, Math.max(0, ...details.results.map((r) => visibleWidth(r.agent))));
+			const rowTaskPreview = (r: SingleResult, maxChars: number) =>
+				r.task ? theme.fg("dim", ` · ${oneLinePreview(r.task, maxChars)}`) : "";
+			const treeText = details.results
+				.map((r, index) => {
+					const prefix = index === details.results.length - 1 ? "└" : "├";
+					const name = ((text: string, width: number) => `${text}${" ".repeat(Math.max(0, width - visibleWidth(text)))}`)(ansiMagenta(theme.bold(r.agent)), nameWidth);
+					return `${subagentBranch(theme, prefix, cwd)}${name}${rowTaskPreview(r, 100)}${truncationBadge(r)}`;
+				})
+				.join("\n");
+
+			return wrappedText(`${headerText}\n${treeText}`);
+		}
+
+		const text = result.content[0];
+		return wrappedText(text?.type === "text" ? text.text : "(no output)");
+	},
+};

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/tasks.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/tasks.ts
@@ -13,6 +13,7 @@ import {
 	taskRegistryPath,
 	transcriptDir,
 } from "./paths.js";
+import { randomHex } from "./random.js";
 import {
 	type DashboardKind,
 	MALFORMED_COMPLETION_GRACE_MS,
@@ -579,7 +580,7 @@ async function pollPaneCompletionsUnlocked(runtimeRoot: string, pi: ExtensionAPI
 }
 
 export function createTaskId(agentName: string): string {
-	return `${safeFileName(agentName)}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+	return `${safeFileName(agentName)}-${Date.now()}-${randomHex(8)}`;
 }
 
 export function normalizedTaskForDedup(task: string): string {

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/tools.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/tools.ts
@@ -55,14 +55,14 @@ export const GetSubagentResultParams = Type.Object({
 	taskId: Type.Optional(Type.String({ description: "Persistent pane task ID to retrieve" })),
 	agent: Type.Optional(Type.String({ description: "Persistent pane agent name; selects that agent's latest task when taskId is omitted" })),
 	wait: Type.Optional(Type.Boolean({ description: "Poll for completion until timeout before returning", default: false })),
-	waitFor: Type.Optional(StringEnum(["completion", "idle"] as const, { description: "Wait target when wait=true. completion polls task status; idle waits for pane bridge isIdle=true transition.", default: "completion" })),
+	waitFor: Type.Optional(StringEnum(["completion", "idle"] as const, { description: "Wait target when wait=true. completion polls task status; idle waits for pane bridge isIdle=true after an observed busy state and reports never-busy distinctly.", default: "completion" })),
 	timeoutMs: Type.Optional(Type.Number({ description: "Maximum wait time when wait=true", default: 30000 })),
 	verbose: Type.Optional(Type.Boolean({ description: "Include registry and artifact paths", default: false })),
 });
 
 export const WaitForSubagentIdleParams = Type.Object({
 	agent: Type.String({ description: "Persistent pane agent name to wait for" }),
-	timeoutMs: Type.Optional(Type.Number({ description: "Maximum wait time for an isIdle=true transition", default: 30000 })),
+	timeoutMs: Type.Optional(Type.Number({ description: "Maximum wait time for isIdle=true after an observed busy state; returns never-busy if pane never leaves idle", default: 30000 })),
 });
 
 export const SteerSubagentParams = Type.Object({

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/tools.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/tools.ts
@@ -5,14 +5,14 @@ const TaskItem = Type.Object({
 	agent: Type.String({ description: "Name of the agent to invoke" }),
 	task: Type.String({ description: "Task to delegate to the agent" }),
 	cwd: Type.Optional(Type.String({ description: "Working directory for the agent process" })),
-	sessionKey: Type.Optional(Type.String({ description: "Optional lane id for resuming a bg (non-pane) agent across calls. Omit to use that agent's default resumable lane; same key + agent => same persisted pi session. Ignored for pane agents." })),
+	sessionKey: Type.Optional(Type.String({ description: "Optional lane id for resuming a bg (non-pane) agent across calls. Omit for a fresh one-shot lane; same key + agent => same persisted pi session. Ignored for pane agents." })),
 });
 
 const ChainItem = Type.Object({
 	agent: Type.String({ description: "Name of the agent to invoke" }),
 	task: Type.String({ description: "Task with optional {previous} placeholder for prior output" }),
 	cwd: Type.Optional(Type.String({ description: "Working directory for the agent process" })),
-	sessionKey: Type.Optional(Type.String({ description: "Optional lane id for resuming a bg (non-pane) agent across calls. Omit to use that agent's default resumable lane; same key + agent => same persisted pi session. Ignored for pane agents." })),
+	sessionKey: Type.Optional(Type.String({ description: "Optional lane id for resuming a bg (non-pane) agent across calls. Omit for a fresh one-shot lane; same key + agent => same persisted pi session. Ignored for pane agents." })),
 });
 
 const AgentScopeSchema = StringEnum(["user", "project", "both"] as const, {
@@ -23,7 +23,7 @@ const AgentScopeSchema = StringEnum(["user", "project", "both"] as const, {
 export const SubagentParams = Type.Object({
 	agent: Type.Optional(Type.String({ description: "Name of the agent to invoke (for single mode)" })),
 	task: Type.Optional(Type.String({ description: "Task to delegate (for single mode)" })),
-	tasks: Type.Optional(Type.Array(TaskItem, { description: "Array of {agent, task} for parallel execution" })),
+	tasks: Type.Optional(Type.Array(TaskItem, { description: "Array of {agent, task} for parallel execution. Larger batches are internally chunked; caller does not need to split." })),
 	chain: Type.Optional(Type.Array(ChainItem, { description: "Array of {agent, task} for sequential execution" })),
 	agentScope: Type.Optional(AgentScopeSchema),
 	confirmProjectAgents: Type.Optional(
@@ -33,7 +33,7 @@ export const SubagentParams = Type.Object({
 	sessionKey: Type.Optional(
 		Type.String({
 			description:
-				"For bg (non-pane) agents only, single mode. Optional lane id used as the resumed pi session file name; omit to use that agent's default resumable lane. Use a stable workflow-scoped id like 'review-issue-123' when you want separate memories. Ignored for pane agents (panes already persist via their own session file).",
+				"For bg (non-pane) agents only, single mode. Optional lane id used as the resumed pi session file name; omit for a fresh one-shot lane. Use a stable workflow-scoped id like 'review-issue-123' when you want continuity. Ignored for pane agents (panes already persist via their own session file).",
 		}),
 	),
 	forceSpawn: Type.Optional(
@@ -55,8 +55,14 @@ export const GetSubagentResultParams = Type.Object({
 	taskId: Type.Optional(Type.String({ description: "Persistent pane task ID to retrieve" })),
 	agent: Type.Optional(Type.String({ description: "Persistent pane agent name; selects that agent's latest task when taskId is omitted" })),
 	wait: Type.Optional(Type.Boolean({ description: "Poll for completion until timeout before returning", default: false })),
+	waitFor: Type.Optional(StringEnum(["completion", "idle"] as const, { description: "Wait target when wait=true. completion polls task status; idle waits for pane bridge isIdle=true transition.", default: "completion" })),
 	timeoutMs: Type.Optional(Type.Number({ description: "Maximum wait time when wait=true", default: 30000 })),
 	verbose: Type.Optional(Type.Boolean({ description: "Include registry and artifact paths", default: false })),
+});
+
+export const WaitForSubagentIdleParams = Type.Object({
+	agent: Type.String({ description: "Persistent pane agent name to wait for" }),
+	timeoutMs: Type.Optional(Type.Number({ description: "Maximum wait time for an isIdle=true transition", default: 30000 })),
 });
 
 export const SteerSubagentParams = Type.Object({

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/types.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/types.ts
@@ -162,6 +162,7 @@ export interface UsageStats {
 
 export interface AttemptSummary {
 	attempt: number;
+	errorEnvelope?: string;
 	errorMessage?: string;
 	exitCode: number;
 	sessionKey?: string;
@@ -179,6 +180,7 @@ export interface SingleResult {
 	exitCode: number;
 	attempt?: number;
 	attempts?: AttemptSummary[];
+	errorEnvelope?: string;
 	messages: Message[];
 	stderr: string;
 	usage: UsageStats;
@@ -404,6 +406,7 @@ export interface WaitForSubagentIdleDetails {
 	runtimeRoot: string;
 	samples: number;
 	sessionFile?: string;
+	status: "idle-after-busy" | "never-busy" | "timeout";
 	timedOut: boolean;
 	transitioned: boolean;
 }

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/types.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/types.ts
@@ -160,15 +160,33 @@ export interface UsageStats {
 	turns: number;
 }
 
+export interface AttemptSummary {
+	attempt: number;
+	errorMessage?: string;
+	exitCode: number;
+	sessionKey?: string;
+	sessionPath?: string;
+	stderr?: string;
+	stopReason?: string;
+	taskId?: string;
+	transcriptPath?: string;
+}
+
 export interface SingleResult {
 	agent: string;
 	agentSource: "user" | "project" | "unknown";
 	task: string;
 	exitCode: number;
+	attempt?: number;
+	attempts?: AttemptSummary[];
 	messages: Message[];
 	stderr: string;
 	usage: UsageStats;
 	model?: string;
+	sessionKey?: string;
+	sessionKeyExplicit?: boolean;
+	sessionPath?: string;
+	ephemeralSession?: boolean;
 	taskId?: string;
 	paneId?: string;
 	queuedTaskFile?: string;
@@ -189,6 +207,15 @@ export interface SubagentDetails {
 	agentScope: AgentScope;
 	projectAgentsDir: string | null;
 	results: SingleResult[];
+	inventoryError?: {
+		available: {
+			allowed: string[];
+			project: string[];
+			user: string[];
+		};
+		missing: string[];
+		scope: AgentScope;
+	};
 	fullOutputError?: string;
 	fullOutputPath?: string;
 	truncation?: TruncationResult;
@@ -364,6 +391,21 @@ export interface GetSubagentResultDetails {
 	notes?: string;
 	diagnostics?: string[];
 	completionMessageEmitted?: boolean;
+	waitFor?: "completion" | "idle";
+	waitTimedOut?: boolean;
+}
+
+export interface WaitForSubagentIdleDetails {
+	agent: string;
+	bridgePid?: string;
+	bridgeSocket?: string;
+	isIdle?: boolean;
+	paneId?: string;
+	runtimeRoot: string;
+	samples: number;
+	sessionFile?: string;
+	timedOut: boolean;
+	transitioned: boolean;
 }
 
 export interface SteerSubagentDetails {

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/wait.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/wait.ts
@@ -1,0 +1,45 @@
+export interface BridgeStateSnapshot {
+	isIdle?: boolean;
+	[key: string]: unknown;
+}
+
+export interface IdleTransitionResult {
+	lastState?: BridgeStateSnapshot;
+	samples: number;
+	timedOut: boolean;
+	transitioned: boolean;
+}
+
+export function extractBridgeState(stdout: string): BridgeStateSnapshot | undefined {
+	if (!stdout.trim()) return undefined;
+	try {
+		const parsed = JSON.parse(stdout);
+		const data = parsed?.data && typeof parsed.data === "object" ? parsed.data : parsed;
+		return data && typeof data === "object" && !Array.isArray(data) ? data as BridgeStateSnapshot : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+export async function waitForIdleTransition(
+	readState: () => Promise<BridgeStateSnapshot | undefined>,
+	timeoutMs = 30_000,
+	pollMs = 500,
+): Promise<IdleTransitionResult> {
+	const deadline = Date.now() + Math.max(0, Math.floor(timeoutMs));
+	const interval = Math.max(50, Math.floor(pollMs));
+	let previousIdle = false;
+	let samples = 0;
+	let lastState: BridgeStateSnapshot | undefined;
+	while (true) {
+		lastState = await readState();
+		samples += 1;
+		const currentIdle = lastState?.isIdle === true;
+		if (currentIdle && previousIdle !== true) {
+			return { lastState, samples, timedOut: false, transitioned: true };
+		}
+		if (typeof lastState?.isIdle === "boolean") previousIdle = lastState.isIdle;
+		if (Date.now() >= deadline) return { lastState, samples, timedOut: true, transitioned: false };
+		await new Promise((resolve) => setTimeout(resolve, Math.min(interval, Math.max(0, deadline - Date.now()))));
+	}
+}

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/wait.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/wait.ts
@@ -6,6 +6,7 @@ export interface BridgeStateSnapshot {
 export interface IdleTransitionResult {
 	lastState?: BridgeStateSnapshot;
 	samples: number;
+	status: "idle-after-busy" | "never-busy" | "timeout";
 	timedOut: boolean;
 	transitioned: boolean;
 }
@@ -28,18 +29,20 @@ export async function waitForIdleTransition(
 ): Promise<IdleTransitionResult> {
 	const deadline = Date.now() + Math.max(0, Math.floor(timeoutMs));
 	const interval = Math.max(50, Math.floor(pollMs));
-	let previousIdle = false;
+	let observedBusy = false;
 	let samples = 0;
 	let lastState: BridgeStateSnapshot | undefined;
 	while (true) {
 		lastState = await readState();
 		samples += 1;
 		const currentIdle = lastState?.isIdle === true;
-		if (currentIdle && previousIdle !== true) {
-			return { lastState, samples, timedOut: false, transitioned: true };
+		if (currentIdle && observedBusy) {
+			return { lastState, samples, status: "idle-after-busy", timedOut: false, transitioned: true };
 		}
-		if (typeof lastState?.isIdle === "boolean") previousIdle = lastState.isIdle;
-		if (Date.now() >= deadline) return { lastState, samples, timedOut: true, transitioned: false };
+		if (lastState?.isIdle === false) observedBusy = true;
+		if (Date.now() >= deadline) {
+			return { lastState, samples, status: observedBusy ? "timeout" : "never-busy", timedOut: true, transitioned: false };
+		}
 		await new Promise((resolve) => setTimeout(resolve, Math.min(interval, Math.max(0, deadline - Date.now()))));
 	}
 }

--- a/pi-extensions/pi-agents-tmux/instructions.md
+++ b/pi-extensions/pi-agents-tmux/instructions.md
@@ -9,11 +9,11 @@ Do not use for: trivial work the parent can do directly with read/grep/find; any
 Calling rules:
 - One self-contained `task` string per delegation — the subagent cannot ask follow-ups.
 - Default `agentScope` is `"project"`. Pass `"both"` only when user-level agents at `~/.pi/agent/agents` are explicitly needed.
-- Bg (`pane: false`) agents start in a fresh one-shot session when `sessionKey` is omitted. Pass a stable `sessionKey` only when you intentionally want to reuse memory across calls; reused lanes are preflight-guarded near context limit and may refuse with a warning.
+- Bg (`pane: false`) agents start in a fresh one-shot session when `sessionKey` is omitted. Pass a stable `sessionKey` only when you intentionally want to reuse memory across calls; reused lanes are preflight-guarded near context limit and default to refuse-and-warn.
 - Parallel and chain bg items without `sessionKey` receive distinct one-shot lanes automatically, so same-agent tasks do not collide. Parallel calls larger than the internal batch size are auto-batched; do not split manually just for the old cap.
 - Agent names are inventory-checked before launch for the selected `agentScope`. Missing names fail fast with available project/user agents; no similar-name redirect is attempted.
 - Persistent-pane (`pane: true`) dispatches return immediately with a `taskId` for follow-up collection. **End your turn after dispatching.** The completion arrives as a follow-up message that wakes you in a new turn — do not call `get_subagent_result` with `wait: true` to block, unless the user asked.
-- Save the `taskId`; use `get_subagent_result` only if you suspect a missed wake event. For pane-idle waits, use `wait_for_subagent_idle` (or `get_subagent_result` with `waitFor: "idle"`) instead of shell polling loops.
+- Save the `taskId`; use `get_subagent_result` only if you suspect a missed wake event. For pane-idle waits, use `wait_for_subagent_idle` (or `get_subagent_result` with `waitFor: "idle"`) instead of shell polling loops; it distinguishes `idle-after-busy` from `never-busy`.
 - If a bg subagent hits `context_length_exceeded`, the extension retries once in a fresh one-shot lane and returns both attempt summaries if the retry also fails.
 - Stopping kills the tmux process but preserves the session file; the next default `subagent` call resumes it. Pass `forceSpawn: true` only when the user wants a fresh session.
 - `confirmProjectAgents: true` gates project-defined agents behind explicit user approval.

--- a/pi-extensions/pi-agents-tmux/instructions.md
+++ b/pi-extensions/pi-agents-tmux/instructions.md
@@ -1,4 +1,4 @@
-## pi-agents-tmux — `subagent`, `steer_subagent`, `get_subagent_result`, `stop_subagent`
+## pi-agents-tmux — `subagent`, `steer_subagent`, `get_subagent_result`, `wait_for_subagent_idle`, `stop_subagent`
 
 `subagent` delegates work to a project-defined agent (loaded from `.pi/agents`, with `.claude/agents` as a compatibility source). Agents with `pane: true` run in visible persistent tmux panes and survive across turns; others run as resumable bg agents. Child tools default to the parent's active tools minus the agent's `deny-tools:`.
 
@@ -9,7 +9,11 @@ Do not use for: trivial work the parent can do directly with read/grep/find; any
 Calling rules:
 - One self-contained `task` string per delegation — the subagent cannot ask follow-ups.
 - Default `agentScope` is `"project"`. Pass `"both"` only when user-level agents at `~/.pi/agent/agents` are explicitly needed.
+- Bg (`pane: false`) agents start in a fresh one-shot session when `sessionKey` is omitted. Pass a stable `sessionKey` only when you intentionally want to reuse memory across calls; reused lanes are preflight-guarded near context limit and may refuse with a warning.
+- Parallel and chain bg items without `sessionKey` receive distinct one-shot lanes automatically, so same-agent tasks do not collide. Parallel calls larger than the internal batch size are auto-batched; do not split manually just for the old cap.
+- Agent names are inventory-checked before launch for the selected `agentScope`. Missing names fail fast with available project/user agents; no similar-name redirect is attempted.
 - Persistent-pane (`pane: true`) dispatches return immediately with a `taskId` for follow-up collection. **End your turn after dispatching.** The completion arrives as a follow-up message that wakes you in a new turn — do not call `get_subagent_result` with `wait: true` to block, unless the user asked.
-- Save the `taskId`; use `get_subagent_result` only if you suspect a missed wake event. Use `steer_subagent` for mid-run correction, `stop_subagent` to kill/close a pane.
+- Save the `taskId`; use `get_subagent_result` only if you suspect a missed wake event. For pane-idle waits, use `wait_for_subagent_idle` (or `get_subagent_result` with `waitFor: "idle"`) instead of shell polling loops.
+- If a bg subagent hits `context_length_exceeded`, the extension retries once in a fresh one-shot lane and returns both attempt summaries if the retry also fails.
 - Stopping kills the tmux process but preserves the session file; the next default `subagent` call resumes it. Pass `forceSpawn: true` only when the user wants a fresh session.
 - `confirmProjectAgents: true` gates project-defined agents behind explicit user approval.

--- a/pi-extensions/pi-agents-tmux/package.json
+++ b/pi-extensions/pi-agents-tmux/package.json
@@ -19,6 +19,7 @@
     "appendSystem": "./instructions.md"
   },
   "scripts": {
+    "test": "bun test --preload ./tests/preload.ts ./tests",
     "postinstall": "node scripts/append-system.mjs install",
     "preuninstall": "node scripts/append-system.mjs remove"
   },
@@ -52,7 +53,7 @@
         {
           "key": "maxParallelTasks",
           "label": "Max parallel tasks",
-          "description": "Maximum number of tasks accepted in one parallel agent call.",
+          "description": "Internal batch size for parallel agent calls. Larger calls are automatically split into batches.",
           "type": "number",
           "default": 8,
           "category": "Execution",
@@ -64,6 +65,37 @@
           "description": "Maximum number of bg agent processes to run at the same time.",
           "type": "number",
           "default": 4,
+          "category": "Execution",
+          "apply": "live"
+        },
+        {
+          "key": "reusedSessionBudgetThreshold",
+          "label": "Reused session budget threshold",
+          "description": "Refuse or warn before launching an explicit bg sessionKey when the saved session estimate exceeds this fraction of model context.",
+          "type": "number",
+          "default": 0.8,
+          "category": "Execution",
+          "apply": "live"
+        },
+        {
+          "key": "reusedSessionBudgetPolicy",
+          "label": "Reused session budget policy",
+          "description": "Behavior when an explicit bg sessionKey is near context limit. refuse blocks launch; warn allows launch with a warning.",
+          "type": "enum",
+          "enumValues": [
+            "refuse",
+            "warn"
+          ],
+          "default": "refuse",
+          "category": "Execution",
+          "apply": "live"
+        },
+        {
+          "key": "reusedSessionContextLimitTokens",
+          "label": "Reused session context limit tokens",
+          "description": "Model context limit used by the reused-session file-size heuristic.",
+          "type": "number",
+          "default": 200000,
           "category": "Execution",
           "apply": "live"
         },
@@ -249,7 +281,12 @@
         {
           "kind": "tool",
           "name": "get_subagent_result",
-          "description": "Retrieve persistent pane agent task results by taskId or latest agent task."
+          "description": "Retrieve persistent pane agent task results by taskId or latest agent task; can also wait for pane idle."
+        },
+        {
+          "kind": "tool",
+          "name": "wait_for_subagent_idle",
+          "description": "Wait for a persistent pane agent to transition to pi-bridge isIdle=true."
         },
         {
           "kind": "tool",

--- a/pi-extensions/pi-agents-tmux/package.json
+++ b/pi-extensions/pi-agents-tmux/package.json
@@ -80,13 +80,14 @@
         {
           "key": "reusedSessionBudgetPolicy",
           "label": "Reused session budget policy",
-          "description": "Behavior when an explicit bg sessionKey is near context limit. refuse blocks launch; warn allows launch with a warning.",
+          "description": "Behavior when an explicit bg sessionKey is near context limit. refuse-and-warn blocks launch with a warning; warn allows launch with a warning; compact-then-resume archives/truncates the lane before launch.",
           "type": "enum",
           "enumValues": [
-            "refuse",
-            "warn"
+            "refuse-and-warn",
+            "warn",
+            "compact-then-resume"
           ],
-          "default": "refuse",
+          "default": "refuse-and-warn",
           "category": "Execution",
           "apply": "live"
         },
@@ -276,7 +277,7 @@
         {
           "kind": "tool",
           "name": "subagent",
-          "description": "Delegate tasks to isolated Pi agents."
+          "description": "Delegate tasks to isolated Pi agents. Bg calls use fresh one-shot sessions unless sessionKey is explicit; unknown agent names are rejected with available inventory; parallel calls above the internal cap are auto-batched."
         },
         {
           "kind": "tool",

--- a/pi-extensions/pi-agents-tmux/tests/preload.ts
+++ b/pi-extensions/pi-agents-tmux/tests/preload.ts
@@ -1,0 +1,80 @@
+import { mock } from "bun:test";
+
+mock.module("@earendil-works/pi-coding-agent", () => {
+	const truncate = (text: string, limits: { maxBytes: number; maxLines: number }, fromTail = false) => {
+		const lines = text.split(/\r?\n/);
+		const selectedLines = fromTail ? lines.slice(-limits.maxLines) : lines.slice(0, limits.maxLines);
+		let content = selectedLines.join("\n");
+		if (Buffer.byteLength(content) > limits.maxBytes) content = content.slice(0, limits.maxBytes);
+		return {
+			content,
+			outputBytes: Buffer.byteLength(content),
+			outputLines: selectedLines.length,
+			totalBytes: Buffer.byteLength(text),
+			totalLines: lines.length,
+			truncated: content !== text,
+		};
+	};
+	return {
+		formatSize(bytes: number) {
+			return `${bytes} B`;
+		},
+		getAgentDir() {
+			return process.env.PI_CODING_AGENT_DIR ?? "/tmp/pi-agent-test";
+		},
+		getMarkdownTheme() {
+			return {};
+		},
+		parseFrontmatter(content: string) {
+			const match = content.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+			if (!match) return { frontmatter: {}, body: content };
+			const frontmatter: Record<string, unknown> = {};
+			for (const line of match[1].split(/\r?\n/)) {
+				const separator = line.indexOf(":");
+				if (separator < 0) continue;
+				frontmatter[line.slice(0, separator).trim()] = line.slice(separator + 1).trim();
+			}
+			return { frontmatter, body: match[2] };
+		},
+		truncateHead(text: string, limits: { maxBytes: number; maxLines: number }) {
+			return truncate(text, limits, false);
+		},
+		truncateTail(text: string, limits: { maxBytes: number; maxLines: number }) {
+			return truncate(text, limits, true);
+		},
+		async withFileMutationQueue<T>(_filePath: string, fn: () => Promise<T>): Promise<T> {
+			return fn();
+		},
+	};
+});
+
+mock.module("@earendil-works/pi-tui", () => {
+	class Container {
+		children: unknown[] = [];
+		addChild(child: unknown) { this.children.push(child); }
+		render() { return []; }
+	}
+	class Spacer {
+		render() { return [""]; }
+	}
+	return {
+		Container,
+		Markdown: Container,
+		Spacer,
+		truncateToWidth(text: string, width: number, suffix = "") {
+			return text.length > width ? `${text.slice(0, Math.max(0, width - suffix.length))}${suffix}` : text;
+		},
+		visibleWidth(text: string) {
+			return text.replace(/\x1b\[[0-9;]*m/g, "").length;
+		},
+		wrapTextWithAnsi(text: string, _width: number) {
+			return text.split(/\r?\n/);
+		},
+	};
+});
+
+mock.module("@earendil-works/pi-ai", () => ({
+	StringEnum(values: readonly string[], options?: Record<string, unknown>) {
+		return { ...options, enum: values, type: "string" };
+	},
+}));

--- a/pi-extensions/pi-agents-tmux/tests/session-lanes.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/session-lanes.test.ts
@@ -1,0 +1,190 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import type { AgentConfig } from "../extensions/subagent/agents.js";
+import {
+	assignEphemeralSessionKeys,
+	formatInventoryValidationError,
+	mapInBatchesWithConcurrencyLimit,
+	validateAgentInventory,
+} from "../extensions/subagent/dispatch.js";
+import {
+	isContextLengthExceededText,
+	ONESHOT_SESSION_PREFIX,
+	resolveBgSession,
+} from "../extensions/subagent/sessions.js";
+import {
+	runSingleAgent,
+	setSingleAgentSpawnForTests,
+} from "../extensions/subagent/runner.js";
+import { waitForIdleTransition } from "../extensions/subagent/wait.js";
+import type { SubagentDetails } from "../extensions/subagent/types.js";
+
+function tempRuntime(): string {
+	return mkdtempSync(join(tmpdir(), "pi-agents-lanes-"));
+}
+
+function withPollutedEnv(fn: () => void) {
+	const previousParent = process.env.PI_SUBAGENT_PARENT_SESSION_ID;
+	const previousChild = process.env.PI_SUBAGENT_CHILD_AGENT;
+	const previousDir = process.env.PI_CODING_AGENT_DIR;
+	try {
+		process.env.PI_SUBAGENT_PARENT_SESSION_ID = "polluted-parent";
+		process.env.PI_SUBAGENT_CHILD_AGENT = "polluted-child";
+		process.env.PI_CODING_AGENT_DIR = join(tempRuntime(), "agent-dir");
+		fn();
+	} finally {
+		if (previousParent === undefined) delete process.env.PI_SUBAGENT_PARENT_SESSION_ID;
+		else process.env.PI_SUBAGENT_PARENT_SESSION_ID = previousParent;
+		if (previousChild === undefined) delete process.env.PI_SUBAGENT_CHILD_AGENT;
+		else process.env.PI_SUBAGENT_CHILD_AGENT = previousChild;
+		if (previousDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousDir;
+	}
+}
+
+test("oneshot default mints unique lane per call in clean and polluted env", () => {
+	const cleanRuntime = tempRuntime();
+	const first = resolveBgSession(cleanRuntime, "reviewer-test");
+	const second = resolveBgSession(cleanRuntime, "reviewer-test");
+	assert.equal(first.explicit, false);
+	assert.equal(second.explicit, false);
+	assert.match(first.key, new RegExp(`^${ONESHOT_SESSION_PREFIX}`));
+	assert.match(second.key, new RegExp(`^${ONESHOT_SESSION_PREFIX}`));
+	assert.notEqual(first.key, second.key);
+	assert.notEqual(first.path, second.path);
+	const forwardedOneShot = resolveBgSession(cleanRuntime, "reviewer-test", first.key);
+	assert.equal(forwardedOneShot.explicit, false);
+	assert.equal(forwardedOneShot.ephemeral, true);
+	assert.equal(forwardedOneShot.key, first.key);
+
+	withPollutedEnv(() => {
+		const pollutedRuntime = tempRuntime();
+		const pollutedFirst = resolveBgSession(pollutedRuntime, "reviewer-test");
+		const pollutedSecond = resolveBgSession(pollutedRuntime, "reviewer-test");
+		assert.notEqual(pollutedFirst.key, pollutedSecond.key);
+		assert.match(pollutedFirst.key, new RegExp(`^${ONESHOT_SESSION_PREFIX}`));
+	});
+});
+
+test("parallel tasks for same agent get distinct ephemeral lanes", () => {
+	const tasks = assignEphemeralSessionKeys([
+		{ agent: "reviewer-test", task: "one" },
+		{ agent: "reviewer-test", task: "two" },
+		{ agent: "reviewer-test", task: "three" },
+	]);
+	assert.equal(new Set(tasks.map((item) => item.sessionKey)).size, 3);
+	for (const task of tasks) assert.match(task.sessionKey ?? "", new RegExp(`^${ONESHOT_SESSION_PREFIX}`));
+});
+
+test("explicit sessionKey reuses same lane", () => {
+	const runtimeRoot = tempRuntime();
+	const first = resolveBgSession(runtimeRoot, "reviewer-test", "issue-27");
+	const second = resolveBgSession(runtimeRoot, "reviewer-test", "issue-27");
+	assert.equal(first.explicit, true);
+	assert.equal(first.ephemeral, false);
+	assert.equal(first.key, "issue-27");
+	assert.equal(second.key, "issue-27");
+	assert.equal(first.path, second.path);
+});
+
+test("context_length_exceeded detection triggers one retry with fresh session", async () => {
+	assert.equal(isContextLengthExceededText('Codex error: {"type":"error","error":{"type":"invalid_request_error","code":"context_length_exceeded"}}'), true);
+	const calls: Array<{ args: string[] }> = [];
+	const scenarios = [
+		{ code: 1, stderr: 'Codex error: {"type":"error","error":{"type":"invalid_request_error","code":"context_length_exceeded"}}\n' },
+		{ code: 0, stdout: `${JSON.stringify({ type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "ok after retry" }], usage: { input: 1, output: 1, totalTokens: 2 } } })}\n` },
+	];
+	setSingleAgentSpawnForTests(((command: string, args: string[]) => {
+		void command;
+		calls.push({ args });
+		const proc = new EventEmitter() as any;
+		proc.stdout = new EventEmitter();
+		proc.stderr = new EventEmitter();
+		proc.killed = false;
+		proc.kill = () => {
+			proc.killed = true;
+			return true;
+		};
+		const scenario = scenarios.shift();
+		queueMicrotask(() => {
+			if (scenario?.stdout) proc.stdout.emit("data", Buffer.from(scenario.stdout));
+			if (scenario?.stderr) proc.stderr.emit("data", Buffer.from(scenario.stderr));
+			proc.emit("close", scenario?.code ?? 0);
+		});
+		return proc;
+	}) as any);
+	try {
+		const agent: AgentConfig = {
+			name: "reviewer-test",
+			description: "test reviewer",
+			pane: false,
+			systemPrompt: "",
+			source: "project",
+			filePath: "reviewer-test.md",
+		};
+		const result = await runSingleAgent(
+			process.cwd(),
+			tempRuntime(),
+			[agent],
+			"reviewer-test",
+			"review code",
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			{ getActiveTools: () => [], events: { emit: () => undefined } } as any,
+			undefined,
+			undefined,
+			(results): SubagentDetails => ({ mode: "single", agentScope: "project", projectAgentsDir: null, results }),
+		);
+		assert.equal(calls.length, 2);
+		assert.equal(result.exitCode, 0);
+		assert.equal(result.attempt, 2);
+		assert.equal(result.attempts?.length, 2);
+		assert.notEqual(result.attempts?.[0]?.sessionKey, result.attempts?.[1]?.sessionKey);
+		assert.match(result.stderr, /retrying once with fresh session/);
+	} finally {
+		setSingleAgentSpawnForTests();
+	}
+});
+
+test("inventory guard rejects unknown agent with structured available lists", () => {
+	const projectAgent: AgentConfig = { name: "planner", description: "plan", pane: true, systemPrompt: "", source: "project", filePath: "planner.md" };
+	const userAgent: AgentConfig = { name: "personal", description: "user", pane: false, systemPrompt: "", source: "user", filePath: "personal.md" };
+	const validation = validateAgentInventory(["missing"], { allowed: [projectAgent], project: [projectAgent], user: [userAgent] }, "project");
+	assert.ok(validation);
+	assert.deepEqual(validation?.missing, ["missing"]);
+	assert.deepEqual(validation?.available.project, ["planner"]);
+	assert.deepEqual(validation?.available.user, ["personal"]);
+	assert.match(formatInventoryValidationError(validation!), /Unknown subagent\(s\).*missing/);
+	assert.match(formatInventoryValidationError(validation!), /Project agents: planner/);
+	assert.match(formatInventoryValidationError(validation!), /User agents: personal/);
+});
+
+test("parallel cap of 10 tasks dispatches with auto-batching", async () => {
+	const items = Array.from({ length: 10 }, (_, index) => index);
+	let active = 0;
+	let maxActive = 0;
+	const results = await mapInBatchesWithConcurrencyLimit(items, 8, 8, async (item) => {
+		active += 1;
+		maxActive = Math.max(maxActive, active);
+		await new Promise((resolve) => setTimeout(resolve, 5));
+		active -= 1;
+		return item * 2;
+	});
+	assert.deepEqual(results, items.map((item) => item * 2));
+	assert.equal(maxActive, 8);
+});
+
+test("wait_for_subagent_idle helper resolves on idle transition", async () => {
+	const states = [{ isIdle: false }, { isIdle: false }, { isIdle: true }];
+	const result = await waitForIdleTransition(async () => states.shift(), 1_000, 1);
+	assert.equal(result.transitioned, true);
+	assert.equal(result.timedOut, false);
+	assert.equal(result.samples, 3);
+	assert.equal(result.lastState?.isIdle, true);
+});

--- a/pi-extensions/pi-agents-tmux/tests/session-lanes.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/session-lanes.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
 import { EventEmitter } from "node:events";
-import { mkdtempSync } from "node:fs";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import test from "node:test";
 import type { AgentConfig } from "../extensions/subagent/agents.js";
 import {
@@ -15,6 +15,7 @@ import {
 	isContextLengthExceededText,
 	ONESHOT_SESSION_PREFIX,
 	resolveBgSession,
+	setSessionCompactorForTests,
 } from "../extensions/subagent/sessions.js";
 import {
 	runSingleAgent,
@@ -25,6 +26,52 @@ import type { SubagentDetails } from "../extensions/subagent/types.js";
 
 function tempRuntime(): string {
 	return mkdtempSync(join(tmpdir(), "pi-agents-lanes-"));
+}
+
+function writeSettings(cwd: string, config: Record<string, unknown>) {
+	mkdirSync(join(cwd, ".pi"), { recursive: true });
+	writeFileSync(join(cwd, ".pi", "settings.json"), JSON.stringify({
+		vstack: { extensionManager: { config: { "@vanillagreen/pi-agents-tmux": config } } },
+	}), "utf8");
+}
+
+function testAgent(): AgentConfig {
+	return {
+		name: "reviewer-test",
+		description: "test reviewer",
+		pane: false,
+		systemPrompt: "",
+		source: "project",
+		filePath: "reviewer-test.md",
+	};
+}
+
+function installMockSpawn(scenarios: Array<{ code?: number; stderr?: string; stdout?: string }>) {
+	const calls: Array<{ args: string[] }> = [];
+	setSingleAgentSpawnForTests(((command: string, args: string[]) => {
+		void command;
+		calls.push({ args });
+		const proc = new EventEmitter() as any;
+		proc.stdout = new EventEmitter();
+		proc.stderr = new EventEmitter();
+		proc.killed = false;
+		proc.kill = () => {
+			proc.killed = true;
+			return true;
+		};
+		const scenario = scenarios.shift();
+		queueMicrotask(() => {
+			if (scenario?.stdout) proc.stdout.emit("data", Buffer.from(scenario.stdout));
+			if (scenario?.stderr) proc.stderr.emit("data", Buffer.from(scenario.stderr));
+			proc.emit("close", scenario?.code ?? 0);
+		});
+		return proc;
+	}) as any);
+	return calls;
+}
+
+function makeDetails(results: any[]): SubagentDetails {
+	return { mode: "single", agentScope: "project", projectAgentsDir: null, results };
 }
 
 function withPollutedEnv(fn: () => void) {
@@ -93,39 +140,12 @@ test("explicit sessionKey reuses same lane", () => {
 
 test("context_length_exceeded detection triggers one retry with fresh session", async () => {
 	assert.equal(isContextLengthExceededText('Codex error: {"type":"error","error":{"type":"invalid_request_error","code":"context_length_exceeded"}}'), true);
-	const calls: Array<{ args: string[] }> = [];
-	const scenarios = [
-		{ code: 1, stderr: 'Codex error: {"type":"error","error":{"type":"invalid_request_error","code":"context_length_exceeded"}}\n' },
+	const calls = installMockSpawn([
+		{ code: 1, stdout: `${JSON.stringify({ error: { type: "invalid_request_error", code: "context_length_exceeded" } })}\n` },
 		{ code: 0, stdout: `${JSON.stringify({ type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "ok after retry" }], usage: { input: 1, output: 1, totalTokens: 2 } } })}\n` },
-	];
-	setSingleAgentSpawnForTests(((command: string, args: string[]) => {
-		void command;
-		calls.push({ args });
-		const proc = new EventEmitter() as any;
-		proc.stdout = new EventEmitter();
-		proc.stderr = new EventEmitter();
-		proc.killed = false;
-		proc.kill = () => {
-			proc.killed = true;
-			return true;
-		};
-		const scenario = scenarios.shift();
-		queueMicrotask(() => {
-			if (scenario?.stdout) proc.stdout.emit("data", Buffer.from(scenario.stdout));
-			if (scenario?.stderr) proc.stderr.emit("data", Buffer.from(scenario.stderr));
-			proc.emit("close", scenario?.code ?? 0);
-		});
-		return proc;
-	}) as any);
+	]);
 	try {
-		const agent: AgentConfig = {
-			name: "reviewer-test",
-			description: "test reviewer",
-			pane: false,
-			systemPrompt: "",
-			source: "project",
-			filePath: "reviewer-test.md",
-		};
+		const agent = testAgent();
 		const result = await runSingleAgent(
 			process.cwd(),
 			tempRuntime(),
@@ -146,8 +166,123 @@ test("context_length_exceeded detection triggers one retry with fresh session", 
 		assert.equal(result.attempt, 2);
 		assert.equal(result.attempts?.length, 2);
 		assert.notEqual(result.attempts?.[0]?.sessionKey, result.attempts?.[1]?.sessionKey);
+		assert.match(result.attempts?.[0]?.errorEnvelope ?? "", /context_length_exceeded/);
 		assert.match(result.stderr, /retrying once with fresh session/);
 	} finally {
+		setSingleAgentSpawnForTests();
+	}
+});
+
+test("reused session budget guard refuses over-threshold explicit session by default without spawning", async () => {
+	const runtimeRoot = tempRuntime();
+	const cwd = tempRuntime();
+	const session = resolveBgSession(runtimeRoot, "reviewer-test", "reuse");
+	mkdirSync(dirname(session.path), { recursive: true });
+	writeFileSync(session.path, "x".repeat(700_000), "utf8");
+	const calls = installMockSpawn([{ code: 0 }]);
+	try {
+		const result = await runSingleAgent(
+			cwd,
+			runtimeRoot,
+			[testAgent()],
+			"reviewer-test",
+			"reuse old context",
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			{ getActiveTools: () => [], events: { emit: () => undefined } } as any,
+			undefined,
+			undefined,
+			makeDetails,
+			"reuse",
+		);
+		assert.equal(calls.length, 0);
+		assert.equal(result.exitCode, 1);
+		assert.equal(result.stopReason, "session_budget_exceeded");
+		assert.match(result.errorMessage ?? "", /Refusing reused session/);
+		assert.match(result.errorMessage ?? "", /exceeds 80% guard threshold/);
+	} finally {
+		setSingleAgentSpawnForTests();
+	}
+});
+
+test("reused session budget guard allows below-threshold explicit session", async () => {
+	const runtimeRoot = tempRuntime();
+	const cwd = tempRuntime();
+	const session = resolveBgSession(runtimeRoot, "reviewer-test", "reuse-small");
+	mkdirSync(dirname(session.path), { recursive: true });
+	writeFileSync(session.path, "small", "utf8");
+	const calls = installMockSpawn([
+		{ code: 0, stdout: `${JSON.stringify({ type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "ok" }], usage: { input: 1, output: 1, totalTokens: 2 } } })}\n` },
+	]);
+	try {
+		const result = await runSingleAgent(
+			cwd,
+			runtimeRoot,
+			[testAgent()],
+			"reviewer-test",
+			"reuse small context",
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			{ getActiveTools: () => [], events: { emit: () => undefined } } as any,
+			undefined,
+			undefined,
+			makeDetails,
+			"reuse-small",
+		);
+		assert.equal(calls.length, 1);
+		assert.equal(result.exitCode, 0);
+	} finally {
+		setSingleAgentSpawnForTests();
+	}
+});
+
+test("reused session compact-then-resume policy compacts then launches", async () => {
+	const runtimeRoot = tempRuntime();
+	const cwd = tempRuntime();
+	writeSettings(cwd, {
+		reusedSessionBudgetPolicy: "compact-then-resume",
+		reusedSessionBudgetThreshold: 0.5,
+		reusedSessionContextLimitTokens: 100,
+	});
+	const session = resolveBgSession(runtimeRoot, "reviewer-test", "reuse-compact");
+	mkdirSync(dirname(session.path), { recursive: true });
+	writeFileSync(session.path, "x".repeat(1_000), "utf8");
+	let compactCalls = 0;
+	setSessionCompactorForTests(async (request) => {
+		compactCalls += 1;
+		writeFileSync(request.sessionPath, "", "utf8");
+		return { archivePath: `${request.sessionPath}.archive` };
+	});
+	const calls = installMockSpawn([
+		{ code: 0, stdout: `${JSON.stringify({ type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "ok" }], usage: { input: 1, output: 1, totalTokens: 2 } } })}\n` },
+	]);
+	try {
+		const result = await runSingleAgent(
+			cwd,
+			runtimeRoot,
+			[testAgent()],
+			"reviewer-test",
+			"compact old context",
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			{ getActiveTools: () => [], events: { emit: () => undefined } } as any,
+			undefined,
+			undefined,
+			makeDetails,
+			"reuse-compact",
+		);
+		assert.equal(compactCalls, 1);
+		assert.equal(calls.length, 1);
+		assert.equal(result.exitCode, 0);
+		assert.match(result.stderr, /Compacted reused session/);
+	} finally {
+		setSessionCompactorForTests();
 		setSingleAgentSpawnForTests();
 	}
 });
@@ -185,6 +320,14 @@ test("wait_for_subagent_idle helper resolves on idle transition", async () => {
 	const result = await waitForIdleTransition(async () => states.shift(), 1_000, 1);
 	assert.equal(result.transitioned, true);
 	assert.equal(result.timedOut, false);
+	assert.equal(result.status, "idle-after-busy");
 	assert.equal(result.samples, 3);
 	assert.equal(result.lastState?.isIdle, true);
+});
+
+test("wait_for_subagent_idle distinguishes never-busy from idle-after-busy", async () => {
+	const result = await waitForIdleTransition(async () => ({ isIdle: true }), 5, 1);
+	assert.equal(result.transitioned, false);
+	assert.equal(result.status, "never-busy");
+	assert.equal(result.timedOut, true);
 });


### PR DESCRIPTION
## Summary
- Addresses issue #27 pi-agents-tmux items #1, #2, #3, #6, #10, #12, and #13.
- Fresh bg subagent calls now use one-shot lanes unless `sessionKey` is explicit, with same-agent parallel/chain lanes auto-distinct.
- Adds context-overflow retry, reused-session budget guard, inventory preflight, pane idle wait, and transparent parallel batching.

## Tests
- `cd pi-extensions/pi-agents-tmux && bun run test`
- `bun build pi-extensions/pi-agents-tmux/extensions/subagent/index.ts --target node --external @earendil-works/pi-ai --external @earendil-works/pi-coding-agent --external @earendil-works/pi-tui --external typebox --outfile /tmp/pi-agents-tmux-index.js`
- `vstack refresh -g`
- `vstack verify -g @vanillagreen/pi-agents-tmux`