### PR TITLE
feat: add flake.nix for Nix build support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,48 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777988971,
+        "narHash": "sha256-qIoWPDs+0/8JecyYgE3gpKQxW/4bLW/gp45vow9ioCQ=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "0678d8986be1661af6bb555f3489f2fdfc31f6ff",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1778672786,
+        "narHash": "sha256-Blg88K1jwG+P0Mr27+rKMFCufdrWkV3wWh9AdYtz0FQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "eef00dfd8a712b34af845f9350bac681b1228bd1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,58 @@
+{
+  description = "Cross-harness package manager for AI coding tools";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+    flake-parts = {
+      url = "github:hercules-ci/flake-parts";
+      inputs.nixpkgs-lib.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    inputs@{ self, flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "aarch64-darwin"
+        "x86_64-darwin"
+      ];
+
+      perSystem =
+        { pkgs, ... }:
+        let
+          version = (builtins.fromTOML (builtins.readFile ./cli/Cargo.toml)).package.version;
+        in
+        {
+          packages.default = pkgs.rustPlatform.buildRustPackage {
+            pname = "vstack";
+            inherit version;
+
+            src = self;
+
+            sourceRoot = "source/cli";
+
+            cargoHash = "sha256-ifmlOan4DTcxt5GbuYwNqFlPATNU5nul+E4wI9J/SPE=";
+
+            nativeBuildInputs = with pkgs; [
+              git
+            ];
+
+            meta = {
+              description = "Cross-harness package manager for AI coding tools";
+              homepage = "https://github.com/vanillagreencom/vstack";
+              license = pkgs.lib.licenses.mit;
+              mainProgram = "vstack";
+              maintainers = [ ];
+              platforms = pkgs.lib.platforms.linux ++ pkgs.lib.platforms.darwin;
+            };
+          };
+
+          devShells.default = pkgs.mkShell {
+            inputsFrom = [ self.packages.${pkgs.stdenv.hostPlatform.system}.default ];
+          };
+        };
+    };
+}


### PR DESCRIPTION
Adds a Nix flake using flake-parts that provides:

- packages.default: builds the vstack CLI via buildRustPackage
- devShells.default: development shell with cargo and build deps
- Supports x86_64-linux, aarch64-linux, x86_64-darwin, aarch64-darwin

The version is read from cli/Cargo.toml at eval time so it stays in sync automatically.