### PR TITLE
fix(flightdeck): adhoc/generic session lifecycle gaps + AGENTS.md drift

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,42 +2,6 @@
 
 Cross-harness distribution system for AI coding skills, agents, hooks, and Pi extensions. Installs into Claude Code, Cursor, OpenCode, Codex, and Pi via a Rust CLI.
 
-## Active worktree: `flightdeck-ts-port`
-
-This worktree is the in-progress TypeScript port of the flightdeck skill
-scripts (`skills/flightdeck/lib/flightdeck-core/`). Context lives in
-`docs/work-in-progress/flightdeck-ts-port.md` and the review reports
-(`review-{perf,bugs,xharness,docs}.md`, `review-triage.md`,
-`CONTINUATION-HANDOFF.md`) under the same folder.
-
-Rules for any agent landing here:
-
-- **Default remains bash.** Every ported script ships behind
-  `FLIGHTDECK_USE_TS=1` (global) or `FLIGHTDECK_USE_TS_<SCRIPT>=1`
-  (per-script). Do NOT flip per-script defaults to TS without live
-  `tests/live-wake.sh` green under the same gate.
-- **`flightdeck-daemon start` always forwards to bash** until the
-  run-loop + subscriber lifecycle port lands.
-- **Parity tests are mandatory** for every TS port. Before any commit
-  that touches `lib/flightdeck-core/`, run
-  `cd skills/flightdeck/lib/flightdeck-core && bun test && bun run typecheck`.
-- **Do not delete the `.bash` siblings.** They are the canonical bodies
-  while the port stabilizes. Removal happens after one full production
-  cycle on TS defaults.
-- **Never touch harness mirrors.** Never search, read, or modify files in
-  `.agents/`, `.claude/`, `.opencode/`, or `.pi/`; they are installed
-  harness directories for repo use, not canonical packages. Work in
-  `agents/`, `skills/`, `hooks/`, and `pi-extensions/` only.
-- **New tmux tab/window requests.** Create a new tmux window in the current
-  session, never split the active pane. Use Flightdeck session tooling for
-  launch/attach and harness IO; persist `%pane_id`/`#{window_id}` and talk via
-  harness adapters (`pi-bridge`, OpenCode HTTP, Claude channels, Codex bridge)
-  before tmux fallback.
-- **flock semantics.** Use the helpers in
-  `lib/flightdeck-core/src/state/locking.ts`. The naive
-  `spawnSync("flock", ["-x", String(fd), "true"])` pattern is a no-op;
-  read the file header before adding new locked critical sections.
-
 ## Repo Layout
 
 ```
@@ -220,6 +184,10 @@ Each canonical agent declares its own `effort:` in frontmatter. Harnesses write 
 - **Verify after refresh.** `vstack refresh -v` prints per-item `old→new` hash. `vstack verify [-g] [name…]` confirms source matches lock and byte-matches install dir for Pi packages. Use both before claiming a change is live.
 - **Docs and instruction payloads ship with the code change.** Any change to a hook, skill, agent, or Pi extension must update — in the same commit — affected READMEs, AGENTS.md, `vstack.toml`, `.env.local.example`, `package.json`, agent instruction payloads (`appendSystem` files / before_agent_start hook prose), and any cross-referencing docs. A behavior change without its docs/instructions update is incomplete.
 - **Edit skills directly.** Edit `skills/<name>/SKILL.md` in place. No separate `rules/` directories or per-skill `AGENTS.md` files.
+- **Never touch harness mirror dirs.** `.agents/`, `.claude/`, `.opencode/`, `.pi/`, and `.codex/` are installed harness outputs, not canonical packages. Edit only `agents/`, `skills/`, `hooks/`, and `pi-extensions/`; harness mirrors regenerate on `vstack add` / `vstack refresh`.
+- **New tmux windows, never split the active pane.** Create a new tmux window in the current session for any spawned work. Use Flightdeck session tooling for launch/attach and harness adapters (`pi-bridge`, OpenCode HTTP, Claude channels, Codex bridge) before falling back to raw tmux.
+- **Parity tests mandatory for `lib/flightdeck-core/`.** Before any commit touching `skills/flightdeck/lib/flightdeck-core/`, run `cd skills/flightdeck/lib/flightdeck-core && bun test && bun run typecheck`. Bash and TS siblings must stay in lock-step until the bash siblings are formally retired.
+- **flock semantics in flightdeck.** Use the helpers in `skills/flightdeck/lib/flightdeck-core/src/state/locking.ts`. The naive `spawnSync("flock", ["-x", String(fd), "true"])` pattern is a no-op; read the file header before adding new locked critical sections.
 - **Always create vstack worktrees via the worktree skill.** Use `skills/worktree/scripts/worktree create <id>` (not raw `git worktree add`) so `.env.local`, harness mirror dirs, bot identity, and per-worktree config are wired in.
 - **READMEs are user-facing only.** Describe what the thing is, how to use it, features, settings/options, and install/setup. Technical/development detail goes in `DEVELOPMENT.md`; agent skill instructions live in the matching `SKILL.md`.
 - **Pi hook parity.** Pi gets its hooks via the `pi-extensions/pi-hooks` extension (native TS port of `hooks/*.sh` against Pi's `tool_call`/`tool_result`/`turn_end` events). Any change to a hook script must land in the same commit as the matching change in `pi-extensions/pi-hooks/extensions/hooks.ts` so all five harnesses stay behaviorally aligned.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,7 @@ skill-templates/         Templates for new skills
 - **Pi extensions are npm-shaped.** vstack copies them to `<scope>/packages/<name>` and registers the path in Pi's `settings.json` `packages` array.
 - **Skill/hook attribution is config-driven.** Source `vstack.toml` `[agent-skills]` is authoritative — explicit entries skip prefix matching. `[role-skills]` adds skills to all agents of a role. Project `vstack.toml` also has `[agent-skills]` populated at install; users add/remove and refresh. Agents get `skills:` frontmatter and a "Required Skills" body section.
 - **Reconciliation is automatic.** After every `vstack add`, all installed agents are regenerated with the current full set of installed skills and hooks.
-- **Project root walks up from CWD.** `config::project_root()` finds `.vstack-lock.json`, `.claude/`, `.cursor/`, `.codex/`, `.opencode/`, `.pi/`, or `.agents/` by walking parents. `$HOME` is rejected as a project root when only user-level harness dirs (`~/.claude`, `~/.pi`, etc.) exist there with no `.vstack-lock.json`, so project-scope writes never accidentally route into user state. `$HOME` is rejected as a project root when only user-level harness dirs (`~/.claude`, `~/.pi`, etc.) exist there with no `.vstack-lock.json`, so project-scope writes never accidentally route into user state.
+- **Project root walks up from CWD.** `config::project_root()` finds `.vstack-lock.json`, `.claude/`, `.cursor/`, `.codex/`, `.opencode/`, `.pi/`, or `.agents/` by walking parents. `$HOME` is rejected as a project root when only user-level harness dirs (`~/.claude`, `~/.pi`, etc.) exist there with no `.vstack-lock.json`, so project-scope writes never accidentally route into user state.
 
 ## Formats
 
@@ -106,7 +106,7 @@ dependencies:
 ```bash
 # ---
 # name: block-bare-cd
-# event: PreToolUse       # PreToolUse | PostToolUse | PostCompact | TaskCompleted | Stop | SessionStart | UserPromptSubmit | PermissionRequest
+# event: PreToolUse       # PreToolUse | PostToolUse | PreCompact | PostCompact | PermissionRequest | SessionStart | UserPromptSubmit | Stop | TaskCompleted
 # matcher: Bash           # Bash | Edit|Write | (empty for all)
 # description: ...
 # safety: ...

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,6 +221,7 @@ Each canonical agent declares its own `effort:` in frontmatter. Harnesses write 
 - **Docs and instruction payloads ship with the code change.** Any change to a hook, skill, agent, or Pi extension must update — in the same commit — affected READMEs, AGENTS.md, `vstack.toml`, `.env.local.example`, `package.json`, agent instruction payloads (`appendSystem` files / before_agent_start hook prose), and any cross-referencing docs. A behavior change without its docs/instructions update is incomplete.
 - **Edit skills directly.** Edit `skills/<name>/SKILL.md` in place. No separate `rules/` directories or per-skill `AGENTS.md` files.
 - **Always create vstack worktrees via the worktree skill.** Use `skills/worktree/scripts/worktree create <id>` (not raw `git worktree add`) so `.env.local`, harness mirror dirs, bot identity, and per-worktree config are wired in.
+- **READMEs are user-facing only.** Describe what the thing is, how to use it, features, settings/options, and install/setup. Technical/development detail goes in `DEVELOPMENT.md`; agent skill instructions live in the matching `SKILL.md`.
 - **Pi hook parity.** Pi gets its hooks via the `pi-extensions/pi-hooks` extension (native TS port of `hooks/*.sh` against Pi's `tool_call`/`tool_result`/`turn_end` events). Any change to a hook script must land in the same commit as the matching change in `pi-extensions/pi-hooks/extensions/hooks.ts` so all five harnesses stay behaviorally aligned.
 
 ## Updating Pi Extensions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -220,6 +220,7 @@ Each canonical agent declares its own `effort:` in frontmatter. Harnesses write 
 - **Verify after refresh.** `vstack refresh -v` prints per-item `old→new` hash. `vstack verify [-g] [name…]` confirms source matches lock and byte-matches install dir for Pi packages. Use both before claiming a change is live.
 - **Docs and instruction payloads ship with the code change.** Any change to a hook, skill, agent, or Pi extension must update — in the same commit — affected READMEs, AGENTS.md, `vstack.toml`, `.env.local.example`, `package.json`, agent instruction payloads (`appendSystem` files / before_agent_start hook prose), and any cross-referencing docs. A behavior change without its docs/instructions update is incomplete.
 - **Edit skills directly.** Edit `skills/<name>/SKILL.md` in place. No separate `rules/` directories or per-skill `AGENTS.md` files.
+- **Always create vstack worktrees via the worktree skill.** Use `skills/worktree/scripts/worktree create <id>` (not raw `git worktree add`) so `.env.local`, harness mirror dirs, bot identity, and per-worktree config are wired in.
 - **Pi hook parity.** Pi gets its hooks via the `pi-extensions/pi-hooks` extension (native TS port of `hooks/*.sh` against Pi's `tool_call`/`tool_result`/`turn_end` events). Any change to a hook script must land in the same commit as the matching change in `pi-extensions/pi-hooks/extensions/hooks.ts` so all five harnesses stay behaviorally aligned.
 
 ## Updating Pi Extensions

--- a/docs/work-in-progress/flightdeck-ts-port.md
+++ b/docs/work-in-progress/flightdeck-ts-port.md
@@ -19,7 +19,7 @@ Ran 106 tests across 14 files.
 
 ## Status (session 1, retained)
 
-81 parity tests pass across 9 files. All eight bash scripts targeted for porting now have a TS sibling under the trampoline gate; default remains bash for every script. Daemon's `start` action is the only piece still routed to bash (intentional — see below).
+81 parity tests pass across 9 files. All eight bash scripts targeted for porting now have a TS sibling under the trampoline gate; default remains bash for every script. The daemon `start` action has since landed as a parity-tested TS run-loop + subscriber lifecycle (see below); its **runtime default** still forwards to the bash sibling until one full production cycle on TS, gated by `FLIGHTDECK_USE_TS_DAEMON_START=1` (or global `FLIGHTDECK_USE_TS=1`).
 
 ## Ports landed (with commit + parity scope)
 
@@ -38,7 +38,7 @@ Adds up to ~6000 LOC bash → ~3500 LOC TS so far.
 
 ## Out of scope this session
 
-**Daemon `start` action — bash remains canonical.** The TS daemon's `start` action does `exec` to the bash sibling. The run_loop (~470 LOC), per-harness subscriber lifecycle (~600 LOC), wake delivery (~150 LOC), signal traps, heartbeat, and max-lifetime self-exec aren't ported yet. This is intentional: keeping the running production poller on bash leaves zero risk to live flightdeck sessions while the lightweight CLI surfaces (status/events/ack/find-window/health/stop) flip independently.
+**Daemon `start` action — TS port landed, bash still the runtime default.** Session 2 left the run-loop unported; subsequent sessions completed it. `src/daemon/loop.ts`, `src/daemon/lifecycle.ts`, and `src/daemon/subscribers/{spawn,drain,index}.ts` are on `main` with parity tests, and the TS `start` action runs end-to-end when `FLIGHTDECK_USE_TS_DAEMON_START=1` is set. The bash sibling remains the unflagged default until one full production cycle on TS validates the port — same opt-in / opt-out pattern every other script uses. See `SKILL.md` § Scripts for the current gating language.
 
 ## Infrastructure landed
 
@@ -75,14 +75,14 @@ Adds up to ~6000 LOC bash → ~3500 LOC TS so far.
 - `5239b22` — .env loader parity + project-root memoization. Shells out to `set -a; source ...; env -0` for true bash parity (\${VAR:-fallback}, \$VAR). Caches project root per-process.
 - `fe5b3eb` — dep preflight + SIGINT/SIGTERM/SIGHUP handlers + state-dir memoization. New `src/shared/preflight.ts` with `preflightDeps()` and `onShutdown()`; wired into flightdeck-daemon CLI startup.
 - `53e1256` — doc-audit punchlist (21 findings across SKILL.md, README.md, tests/README.md, two pattern docs, two workflow docs, pi-flightdeck README, AGENTS.md).
-- `<this>` — daemon helper foundation: `src/daemon/{log,gc,wake-payload}.ts` with unit tests. Not yet reachable from the running daemon (still forwards to bash); next session composes them into a TS run loop.
+- `<this>` — daemon helper foundation: `src/daemon/{log,gc,wake-payload}.ts` with unit tests. Not yet reachable from the running daemon (still forwards to bash); later sessions composed them into the TS run loop now living at `src/daemon/{loop,lifecycle}.ts` + `src/daemon/subscribers/{spawn,drain,index}.ts` (gated on `FLIGHTDECK_USE_TS_DAEMON_START=1`).
 
 ## Remaining work
 
 | Phase | Task | Notes |
 |---|---|---|
-| execute | Daemon run_loop + subscribers + wake delivery | The other ~1500 LOC of daemon. Highest risk port. The foundation modules under `src/daemon/` are now in place; next session composes them into `src/daemon/loop.ts` + four `subscribers/<harness>.ts` files. |
-| execute | Async pane-poll batch (review-perf critical) | Pair with the daemon run-loop port — needs `Bun.spawn` async refactor that the same session will write. |
+| landed | Daemon run_loop + subscribers + wake delivery | TS port lives at `src/daemon/{loop,lifecycle}.ts` + `src/daemon/subscribers/{spawn,drain,index}.ts` with parity tests. Subscribers delegate the long-running bodies to `scripts/lib/subscribers.bash` so bash and TS daemons share one canonical implementation. Runtime default still forwards to bash until one full production cycle on `FLIGHTDECK_USE_TS_DAEMON_START=1`. |
+| execute | Async pane-poll batch (review-perf critical) | Needs the `Bun.spawn` async refactor; the daemon run-loop port made the structural changes that unblock this. |
 | execute | Native jq replacement for `*_LAST_ASSISTANT_JQ` (review-perf important) | Pair with async refactor; keep jq constants exported for parity-test corpus. |
 | execute | Freshness probe fold into read (review-perf important) | Same async refactor. |
 | test | Integration smoke under `FLIGHTDECK_USE_TS=1` | Extend `tests/live-wake.sh` to assert against TS path. Needs a live pi + tmux session. |
@@ -93,18 +93,16 @@ Adds up to ~6000 LOC bash → ~3500 LOC TS so far.
 
 ```bash
 cd /mnt/Tertiary/dev/vstack/flightdeck-ts-port/skills/flightdeck/lib/flightdeck-core
-bun test          # confirm 81 tests still green
+bun test          # confirm parity suite still green
 bun run typecheck # confirm clean
 
-# Continue daemon port: pick up the run_loop. Start by reading the bash
-# run_loop body and the four subscriber loops; sketch the TS structure
-# (state machine + cooperative async over child processes) before
-# writing code.
-
-# When all ports done, flip defaults one-by-one and run the live
-# integration test under each flip:
+# The daemon run-loop port has landed; remaining work is the
+# async pane-poll refactor + flipping per-script defaults to TS.
+# Run the live integration test under each individual flip before
+# changing the trampoline default:
 FLIGHTDECK_USE_TS_PROMPT_CLASSIFY=1 ./tests/live-wake.sh
 FLIGHTDECK_USE_TS_FLIGHTDECK_STATE=1 FLIGHTDECK_USE_TS_PROMPT_CLASSIFY=1 ./tests/live-wake.sh
+FLIGHTDECK_USE_TS_DAEMON_START=1 ./tests/live-wake.sh
 # ... etc
 ```
 

--- a/skills/flightdeck/SKILL.md
+++ b/skills/flightdeck/SKILL.md
@@ -69,7 +69,7 @@ Generic tmux-window session tracking. These commands do not require a fake issue
 | `session watch` | `[ENTRY_ID...]` | `workflows/session-watch.md` | Generic daemon/poll/handler loop for tracked entries. Routes only generic handlers and guards issue-only tags as `domain-mismatch`; no GitHub/Linear/worktree dependency. |
 | `session prompt routing` | nested from `session watch` | `workflows/session-handle-prompt.md` | Generic prompt handlers for structured questions, bash permission prompts, safe bounded choices, terminal completion, `pi-bg-task-exit`, and `domain-mismatch`. |
 | `session status` | — | inline / `flightdeck-state tracked-entries` | Read-only normalized `.entries`/legacy `.issues` snapshot. |
-| `session stop` / `session remove` | `<ENTRY_ID>` | `pane-registry teardown-entry` / `pane-registry remove` | Teardown uses stable `pane_id`; issue remove remains the legacy cleanup path. Generic removal cleanup is still being expanded. |
+| `session stop` / `session remove` | `<ENTRY_ID>` | `pane-registry teardown-entry` / `pane-registry remove` | Teardown uses stable `pane_id` and accepts legacy (`merged|aborted|dead`) plus generic (`complete|cancelled`) terminal states. `remove` drops both legacy `.issues` and generic `.entries` rows in one call. |
 
 ### Issue workflows
 

--- a/skills/flightdeck/lib/flightdeck-core/src/bin/pane-registry.ts
+++ b/skills/flightdeck/lib/flightdeck-core/src/bin/pane-registry.ts
@@ -496,7 +496,12 @@ function cmdRemove(issue: string): void {
 	safeUnlink(piSpawnFile(issue));
 	// CX: drop spawn (server is per-session; terminate.md handles it)
 	safeUnlink(cxSpawnFile(issue));
+	// Issue #37(C): drop both the legacy .issues row AND the generic
+	// .entries row. Pre-fix, adhoc entries written only to .entries
+	// survived `remove` and required a manual flightdeck-state chase.
+	// Each `del` is idempotent on missing keys.
 	fdStateOrDie(["set", ".issues", `(.issues | del(.["${issue}"]))`]);
+	fdStateOrDie(["set", ".entries", `(.entries | del(.["${issue}"]))`]);
 }
 
 function readField(issue: string, field: string): string {

--- a/skills/flightdeck/lib/flightdeck-core/src/bin/pane-registry.ts
+++ b/skills/flightdeck/lib/flightdeck-core/src/bin/pane-registry.ts
@@ -701,7 +701,10 @@ function cmdReconcile(): void {
 //   5 - tmux kill failed: pane still alive after kill attempt
 //   6 - registry read failure
 
-const TERMINAL_STATES = new Set(["merged", "aborted", "dead"]);
+// Issue #37(B): legacy issue-flow terminal states (merged|aborted|dead)
+// plus generic session-lifecycle terminal states (complete|cancelled)
+// so adhoc entries can teardown without --force.
+const TERMINAL_STATES = new Set(["merged", "aborted", "dead", "complete", "cancelled"]);
 
 function cmdTeardownWindow(args: string[]): void {
 	let issue = "";
@@ -751,7 +754,7 @@ function cmdTeardownWindow(args: string[]): void {
 	if (paneAlive) {
 		if (!TERMINAL_STATES.has(state) && !force) {
 			process.stderr.write(
-				`teardown-window: policy refusal — pane_id '${paneId}' is alive but state is '${state}' (not merged|aborted|dead); set a terminal state first or rerun with --force\n`,
+				`teardown-window: policy refusal — pane_id '${paneId}' is alive but state is '${state}' (not merged|aborted|dead|complete|cancelled); set a terminal state first or rerun with --force\n`,
 			);
 			process.exit(4);
 		}
@@ -787,7 +790,7 @@ function cmdTeardownWindow(args: string[]): void {
 		return;
 	}
 	process.stderr.write(
-		`teardown-window: registry drift — pane_id '${paneId || "<none>"}' is gone but state is '${state}' (not merged|aborted|dead); refusing to derive kill target from pane_target (#16)\n`,
+		`teardown-window: registry drift — pane_id '${paneId || "<none>"}' is gone but state is '${state}' (not merged|aborted|dead|complete|cancelled); refusing to derive kill target from pane_target (#16)\n`,
 	);
 	process.exit(3);
 }

--- a/skills/flightdeck/lib/flightdeck-core/src/bin/pane-respond.ts
+++ b/skills/flightdeck/lib/flightdeck-core/src/bin/pane-respond.ts
@@ -146,7 +146,17 @@ function validate(args: Args): void {
 	}
 	if (/^%[0-9]+$/.test(args.target)) {
 		const resolved = resolvePaneTargetFromPaneId(args.target);
-		if (resolved) args.target = resolved;
+		switch (resolved.kind) {
+			case "ok":
+				args.target = resolved.target;
+				break;
+			case "registry_read":
+				die(`pane-respond: failed to look up pane '${args.target}' in registry (flightdeck-state exit=${resolved.rc})`);
+			case "not_registered":
+				die(`pane-respond: pane '${args.target}' is not registered as a flightdeck-tracked pane; pass the explicit pane target (e.g. <session>:<window>.<idx>) or register the pane first`);
+			case "missing_pane_target":
+				die(`pane-respond: registry entry for '${args.target}' is missing pane_target (registry drift); recover via pane-registry reconcile`);
+		}
 	}
 	if (!args.target.includes(".")) die("Error: target must include explicit pane index (e.g., HT:cc-463.0)");
 
@@ -196,14 +206,39 @@ function paneRegistry(args: string[]): string {
 // the SESSION:WINDOW.IDX pane_target. Resolve via the registry so the
 // downstream explicit-pane-index check (and every tmux/bridge call) sees
 // the canonical pane_target.
-function resolvePaneTargetFromPaneId(paneId: string): string {
-	const id = paneRegistry(["find-by-pane", paneId]);
-	if (!id) return "";
+//
+// Round-1 reviewer-error major (#37): distinguish three specific
+// failure modes so the caller can emit byte-identical error text to
+// the bash port instead of falling through to the generic
+// 'target must include explicit pane index' message.
+type PaneIdResolution =
+	| { kind: "ok"; target: string }
+	| { kind: "registry_read"; rc: number }
+	| { kind: "not_registered" }
+	| { kind: "missing_pane_target" };
+
+function resolvePaneTargetFromPaneId(paneId: string): PaneIdResolution {
+	const r = spawnSync(PANE_REGISTRY, ["find-by-pane", paneId], { encoding: "utf8" });
+	const status = typeof r.status === "number" ? r.status : 0;
+	if (status >= 2) return { kind: "registry_read", rc: status };
+	const raw = (r.stdout ?? "").trim();
+	let id = "";
+	if (raw.startsWith("{")) {
+		try {
+			const parsed = JSON.parse(raw) as { id?: unknown };
+			if (typeof parsed.id === "string") id = parsed.id;
+		} catch { /* malformed — treat as no id below */ }
+	} else {
+		id = raw;
+	}
+	if (!id) return { kind: "not_registered" };
 	const idJson = JSON.stringify(id);
 	const expr = `(.entries[${idJson}].pane_target // .issues[${idJson}].pane_target // empty)`;
-	const r = spawnSync(FLIGHTDECK_STATE, ["get", expr], { encoding: "utf8" });
-	if (r.status !== 0) return "";
-	return (r.stdout ?? "").trim().replace(/^"|"$/g, "");
+	const sr = spawnSync(FLIGHTDECK_STATE, ["get", expr], { encoding: "utf8" });
+	if (sr.status !== 0) return { kind: "missing_pane_target" };
+	const target = (sr.stdout ?? "").trim().replace(/^"|"$/g, "");
+	if (!target || target === "null") return { kind: "missing_pane_target" };
+	return { kind: "ok", target };
 }
 
 function extractFlag(s: string, flag: string): string {

--- a/skills/flightdeck/lib/flightdeck-core/src/bin/pane-respond.ts
+++ b/skills/flightdeck/lib/flightdeck-core/src/bin/pane-respond.ts
@@ -18,6 +18,7 @@ import { cxBridgeRun, cxSpawnFile } from "../paths/codex.ts";
 const HERE = dirname(fileURLToPath(import.meta.url));
 const PANE_REGISTRY = resolve(HERE, "../../../../scripts/pane-registry");
 const PANE_CLEAR_BELL = resolve(HERE, "../../../../scripts/pane-clear-bell");
+const FLIGHTDECK_STATE = resolve(HERE, "../../../../scripts/flightdeck-state");
 
 function die(msg: string, code = 2): never {
 	process.stderr.write(`${msg}\n`);
@@ -143,6 +144,10 @@ function validate(args: Args): void {
 			break;
 		}
 	}
+	if (/^%[0-9]+$/.test(args.target)) {
+		const resolved = resolvePaneTargetFromPaneId(args.target);
+		if (resolved) args.target = resolved;
+	}
 	if (!args.target.includes(".")) die("Error: target must include explicit pane index (e.g., HT:cc-463.0)");
 
 	if (args.mode === "payload" && args.tag === "rebase-multi-choice") {
@@ -185,6 +190,20 @@ function paneRegistry(args: string[]): string {
 	} catch {
 		return "";
 	}
+}
+
+// Issue #37(A): callers may pass a stable tmux pane_id (%NNN) instead of
+// the SESSION:WINDOW.IDX pane_target. Resolve via the registry so the
+// downstream explicit-pane-index check (and every tmux/bridge call) sees
+// the canonical pane_target.
+function resolvePaneTargetFromPaneId(paneId: string): string {
+	const id = paneRegistry(["find-by-pane", paneId]);
+	if (!id) return "";
+	const idJson = JSON.stringify(id);
+	const expr = `(.entries[${idJson}].pane_target // .issues[${idJson}].pane_target // empty)`;
+	const r = spawnSync(FLIGHTDECK_STATE, ["get", expr], { encoding: "utf8" });
+	if (r.status !== 0) return "";
+	return (r.stdout ?? "").trim().replace(/^"|"$/g, "");
 }
 
 function extractFlag(s: string, flag: string): string {

--- a/skills/flightdeck/lib/flightdeck-core/tests/parity/pane-registry.test.ts
+++ b/skills/flightdeck/lib/flightdeck-core/tests/parity/pane-registry.test.ts
@@ -476,14 +476,19 @@ describe("pane-registry teardown-window (#16, shim-driven)", () => {
 		}
 	});
 
-	for (const terminal of ["merged", "aborted", "dead"]) {
+	// Issue #37(B): generic adhoc terminal states (complete|cancelled)
+	// must teardown without --force, matching the legacy issue-flow
+	// vocabulary (merged|aborted|dead). Generic states are written via
+	// `set` (bypassing the legacy set-state enum) because the issue-mode
+	// state setter is intentionally legacy-only.
+	for (const terminal of ["merged", "aborted", "dead", "complete", "cancelled"]) {
 		test(`pane_id gone + state=${terminal} → no-op success`, () => {
 			for (const repo of [bashRepo, tsRepo]) {
 				const useTs = repo === tsRepo;
 				const statePath = makeShimState(repo, baseShim("test-session"));
 				runShim(useTs, repo, statePath, ["init", "TD-3", "--window", "issue-a", "--harness", "opencode", "--worktree", "/tmp/wt-a"]);
 				runShim(useTs, repo, statePath, ["set", "TD-3", "pane_id", JSON.stringify("%999999")]);
-				runShim(useTs, repo, statePath, ["set-state", "TD-3", terminal]);
+				runShim(useTs, repo, statePath, ["set", "TD-3", "state", JSON.stringify(terminal)]);
 				const r = runShim(useTs, repo, statePath, ["teardown-window", "TD-3"]);
 				expect(r.status).toBe(0);
 				expect(r.stdout).toContain("already closed");
@@ -504,6 +509,27 @@ describe("pane-registry teardown-window (#16, shim-driven)", () => {
 		}
 	});
 
+	// Issue #37(B): alive pane + generic terminal state (complete)
+	// kills without --force, mirroring the legacy 'merged' behavior.
+	test("pane_id alive + state=complete → kills without --force", () => {
+		for (const repo of [bashRepo, tsRepo]) {
+			const useTs = repo === tsRepo;
+			const statePath = makeShimState(repo, {
+				panes: {
+					"%200": { pane_index: 0, path: "/tmp/wt-a", window_id: "@20", window_index: 1, window_name: "adhoc-a" },
+				},
+				session: "test-session",
+				windows: { "@20": { index: 1, name: "adhoc-a" } },
+			});
+			runShim(useTs, repo, statePath, ["init", "TD-COMPLETE", "--window", "adhoc-a", "--harness", "pi", "--worktree", "/tmp/wt-a"]);
+			runShim(useTs, repo, statePath, ["set", "TD-COMPLETE", "pane_id", JSON.stringify("%200")]);
+			runShim(useTs, repo, statePath, ["set", "TD-COMPLETE", "state", JSON.stringify("complete")]);
+			const r = runShim(useTs, repo, statePath, ["teardown-entry", "TD-COMPLETE"]);
+			expect(r.status).toBe(0);
+			expect(readShimState(statePath).panes["%200"]).toBeUndefined();
+		}
+	});
+
 	test("pane_id alive + non-terminal state → exit 4 (policy refusal); --force kills", () => {
 		for (const repo of [bashRepo, tsRepo]) {
 			const useTs = repo === tsRepo;
@@ -520,6 +546,9 @@ describe("pane-registry teardown-window (#16, shim-driven)", () => {
 			const r1 = runShim(useTs, repo, statePath, ["teardown-window", "TD-FORCE"]);
 			expect(r1.status).toBe(4);
 			expect(r1.stderr).toContain("policy refusal");
+			// Issue #37(B): error must list both legacy and generic terminal
+			// vocab so callers learn the right state names.
+			expect(r1.stderr).toContain("complete|cancelled");
 			// Pane still alive after refusal.
 			expect(readShimState(statePath).panes["%100"]).toBeDefined();
 			const r2 = runShim(useTs, repo, statePath, ["teardown-window", "TD-FORCE", "--force"]);

--- a/skills/flightdeck/lib/flightdeck-core/tests/parity/pane-registry.test.ts
+++ b/skills/flightdeck/lib/flightdeck-core/tests/parity/pane-registry.test.ts
@@ -361,6 +361,33 @@ describe("pane-registry parity", () => {
 		expect(readIssues(tsRepo)).toEqual({});
 		expect(readIssues(bashRepo)).toEqual({});
 	});
+
+	// Issue #37(C): adhoc entries live only in .entries; pre-fix `remove`
+	// touched .issues only and silently left the .entries row behind.
+	test("remove drops adhoc entries from .entries too", () => {
+		for (const repo of [bashRepo, tsRepo]) {
+			const useTs = repo === tsRepo;
+			run(useTs, repo, ["init-entry", "RM-ADHOC", "--title", "Adhoc Rm", "--kind", "adhoc", "--cwd", "/tmp/a", "--window", "7", "--harness", "pi", "--pane-id", "%707"]);
+			const before = readEntries(repo) as Record<string, unknown>;
+			expect(before["RM-ADHOC"]).toBeDefined();
+			const r = run(useTs, repo, ["remove", "RM-ADHOC"]);
+			expect(r.status).toBe(0);
+			expect((readEntries(repo) as Record<string, unknown>)["RM-ADHOC"]).toBeUndefined();
+		}
+	});
+
+	// Issue #37(C): both deletes must be idempotent. Removing twice (or
+	// removing an id present in only one map) must not error.
+	test("remove is idempotent across .issues and .entries", () => {
+		for (const repo of [bashRepo, tsRepo]) {
+			const useTs = repo === tsRepo;
+			run(useTs, repo, ["init", "RM-IDEM", "--window", "wI", "--harness", "opencode", "--worktree", "/tmp/wt"]);
+			const r1 = run(useTs, repo, ["remove", "RM-IDEM"]);
+			expect(r1.status).toBe(0);
+			const r2 = run(useTs, repo, ["remove", "RM-IDEM"]);
+			expect(r2.status).toBe(0);
+		}
+	});
 });
 
 // --- teardown-window + reconcile (#16) ------------------------------------

--- a/skills/flightdeck/lib/flightdeck-core/tests/parity/pane-respond.test.ts
+++ b/skills/flightdeck/lib/flightdeck-core/tests/parity/pane-respond.test.ts
@@ -120,15 +120,72 @@ describe("pane-respond parity (validation)", () => {
 		expect(a.status).toBe(2);
 	});
 
-	// Issue #37(A): pane_id (%NNN) target with no registry match should
-	// still error with the explicit-pane-index message — confirms both
-	// implementations attempt resolution and fall through identically.
-	test("%pane_id with no registry match → pane-index error", () => {
+	// Issue #37(A) + round-1 reviewer-error major: pane_id resolution
+	// failures must emit specific, byte-identical error text in both
+	// implementations so the caller knows which recovery path applies.
+	test("%pane_id not registered → specific not-registered error", () => {
 		const a = run(false, ["%999999", "hi"]);
 		const b = run(true, ["%999999", "hi"]);
 		expect(b.status).toBe(a.status);
 		expect(a.status).toBe(2);
-		expect(a.stderr).toContain("target must include explicit pane index");
-		expect(b.stderr).toContain("target must include explicit pane index");
+		const expected = "pane-respond: pane '%999999' is not registered as a flightdeck-tracked pane; pass the explicit pane target (e.g. <session>:<window>.<idx>) or register the pane first";
+		expect(a.stderr).toContain(expected);
+		expect(b.stderr).toContain(expected);
+		// Generic 'explicit pane index' fallback must NOT fire for %-form.
+		expect(a.stderr).not.toContain("target must include explicit pane index");
+		expect(b.stderr).not.toContain("target must include explicit pane index");
 	});
+
+	test("%pane_id entry found but pane_target null → registry-drift error", () => {
+		// Drive the missing_pane_target branch: init-entry sets
+		// pane_target from the live pane, so we explicitly null it via
+		// `pane-registry set` to simulate registry drift. Both bash and
+		// TS implementations must surface the same drift recovery hint
+		// (pane-registry reconcile) rather than 'not registered'.
+		const tmuxPane = process.env.TMUX_PANE;
+		if (!tmuxPane) {
+			// Skip transparently when TMUX_PANE is unset (already gated by
+			// the file-level TMUX guard above; defensive fallback for
+			// nested tmux invocations that scrub the env).
+			return;
+		}
+		const fs = require("node:fs") as typeof import("node:fs");
+		const os = require("node:os") as typeof import("node:os");
+		const path = require("node:path") as typeof import("node:path");
+		const PANE_REGISTRY = resolve(HERE, "../../../../scripts/pane-registry");
+		const FLIGHTDECK_STATE = resolve(HERE, "../../../../scripts/flightdeck-state");
+		for (const useTs of [false, true]) {
+			const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "fd-pr-drift-"));
+			try {
+				const envBase: Record<string, string> = { ...(process.env as Record<string, string>), FLIGHTDECK_STATE_DIR: stateDir };
+				spawnSync(FLIGHTDECK_STATE, ["init"], { encoding: "utf8", env: envBase });
+				spawnSync(PANE_REGISTRY, ["init-entry", "DRIFT-PT", "--title", "T", "--kind", "adhoc", "--cwd", "/tmp", "--window", "1", "--harness", "pi", "--pane-id", tmuxPane], { encoding: "utf8", env: envBase });
+				// init-entry auto-derives pane_target from the live pane;
+				// stomp it to null to simulate registry drift.
+				spawnSync(PANE_REGISTRY, ["set", "DRIFT-PT", "pane_target", "null"], { encoding: "utf8", env: envBase });
+				const env: Record<string, string> = { ...envBase };
+				if (useTs) env.FLIGHTDECK_USE_TS_PANE_RESPOND = "1";
+				else delete env.FLIGHTDECK_USE_TS_PANE_RESPOND;
+				delete env.FLIGHTDECK_USE_TS;
+				const r = spawnSync(SCRIPT, [tmuxPane, "hi"], { encoding: "utf8", env });
+				expect(r.status).toBe(2);
+				const expected = `pane-respond: registry entry for '${tmuxPane}' is missing pane_target (registry drift); recover via pane-registry reconcile`;
+				expect((r.stderr ?? "")).toContain(expected);
+				// Generic 'explicit pane index' fallback must NOT fire.
+				expect((r.stderr ?? "")).not.toContain("target must include explicit pane index");
+			} finally {
+				fs.rmSync(stateDir, { recursive: true, force: true });
+			}
+		}
+	});
+
+	// Note on the registry_read (find-by-pane exit >= 2) branch: it is
+	// defensively wired in resolvePaneTargetFromPaneId / the bash helper
+	// but currently unreachable in normal operation — find-by-pane wraps
+	// state reads in `2>/dev/null` and downgrades any flightdeck-state
+	// failure to exit 1 (handled by the not_registered branch above), and
+	// the bun runtime exits 1 for uncaught state-dir errors. The error
+	// message and code path remain so a future find-by-pane that
+	// escalates state-read failures hits the registry_read branch in
+	// both bash and TS without further changes.
 });

--- a/skills/flightdeck/lib/flightdeck-core/tests/parity/pane-respond.test.ts
+++ b/skills/flightdeck/lib/flightdeck-core/tests/parity/pane-respond.test.ts
@@ -119,4 +119,16 @@ describe("pane-respond parity (validation)", () => {
 		expect(b.status).toBe(a.status);
 		expect(a.status).toBe(2);
 	});
+
+	// Issue #37(A): pane_id (%NNN) target with no registry match should
+	// still error with the explicit-pane-index message — confirms both
+	// implementations attempt resolution and fall through identically.
+	test("%pane_id with no registry match → pane-index error", () => {
+		const a = run(false, ["%999999", "hi"]);
+		const b = run(true, ["%999999", "hi"]);
+		expect(b.status).toBe(a.status);
+		expect(a.status).toBe(2);
+		expect(a.stderr).toContain("target must include explicit pane index");
+		expect(b.stderr).toContain("target must include explicit pane index");
+	});
 });

--- a/skills/flightdeck/lib/flightdeck-core/tests/parity/pi-subscriber-bg-task.test.ts
+++ b/skills/flightdeck/lib/flightdeck-core/tests/parity/pi-subscriber-bg-task.test.ts
@@ -289,6 +289,146 @@ exit 0
 		}
 	});
 
+	// Round-1 reviewer-error blocker (#37): drain must fail open with
+	// observable diagnostics when the bridge call errors, hangs, or
+	// returns malformed JSON. Each case writes a structured tag to the
+	// per-pane sub_log and never blocks the live stream branch.
+	test("non-zero pi-bridge questions exit → [pi-sub-drain-error], no wake row", async () => {
+		const stateDir = mkdtempSync(join(tmpdir(), "fd-pi-drain-err-"));
+		stateDirs.push(stateDir);
+		const wakeLog = join(stateDir, "wake-events.log");
+		const subLog = join(stateDir, "daemon.log.pi-sub-44");
+		const bridgeDir = join(stateDir, "bin");
+		mkdirSync(bridgeDir, { recursive: true });
+		const bridgeBin = join(bridgeDir, "pi-bridge");
+		const bridgeScript = `#!/usr/bin/env bash
+if [[ "\${1:-}" == "questions" ]]; then
+  echo "bridge unreachable: ECONNREFUSED" >&2
+  exit 2
+fi
+if [[ "\${1:-}" == "stream" ]]; then sleep 30; fi
+exit 0
+`;
+		writeFileSync(bridgeBin, bridgeScript);
+		chmodSync(bridgeBin, 0o755);
+		const fakeParent = spawn("sleep", ["30"], { stdio: "ignore" });
+		const parentPid = fakeParent.pid!;
+		try {
+			const env = subscriberEnv(bridgeDir, stateDir);
+			const sub = spawn("bash", [SUBSCRIBERS_BASH, "pi", "%44", "99999", "", String(parentPid)], {
+				env,
+				stdio: "ignore",
+				detached: true,
+			});
+			const subPid = sub.pid!;
+			const deadline = Date.now() + 3000;
+			while (Date.now() < deadline) {
+				if (existsSync(subLog) && readFileSync(subLog, "utf8").includes("[pi-sub-drain-error]")) break;
+				await sleep(50);
+			}
+			try { process.kill(-subPid, "SIGTERM"); } catch { /* */ }
+			try { process.kill(subPid, "SIGTERM"); } catch { /* */ }
+			const logBody = existsSync(subLog) ? readFileSync(subLog, "utf8") : "";
+			expect(logBody).toContain("[pi-sub-drain-error]");
+			expect(logBody).toContain("pane=%44");
+			expect(logBody).toContain("rc=2");
+			expect(logBody).toContain("ECONNREFUSED");
+			const wake = existsSync(wakeLog) ? readFileSync(wakeLog, "utf8").split("\n").filter(Boolean) : [];
+			expect(wake.length).toBe(0);
+		} finally {
+			try { fakeParent.kill("SIGKILL"); } catch { /* */ }
+			await sleep(50);
+		}
+	});
+
+	test("hanging pi-bridge questions → timeout, [pi-sub-drain-error] rc=124", async () => {
+		const stateDir = mkdtempSync(join(tmpdir(), "fd-pi-drain-hang-"));
+		stateDirs.push(stateDir);
+		const subLog = join(stateDir, "daemon.log.pi-sub-45");
+		const bridgeDir = join(stateDir, "bin");
+		mkdirSync(bridgeDir, { recursive: true });
+		const bridgeBin = join(bridgeDir, "pi-bridge");
+		const bridgeScript = `#!/usr/bin/env bash
+if [[ "\${1:-}" == "questions" ]]; then sleep 30; fi
+if [[ "\${1:-}" == "stream" ]]; then sleep 30; fi
+exit 0
+`;
+		writeFileSync(bridgeBin, bridgeScript);
+		chmodSync(bridgeBin, 0o755);
+		const fakeParent = spawn("sleep", ["30"], { stdio: "ignore" });
+		const parentPid = fakeParent.pid!;
+		try {
+			// Cap the drain timeout to 1s so the test completes quickly.
+			const env = subscriberEnv(bridgeDir, stateDir, { FD_ADAPTER_READ_TIMEOUT_SEC: "1" });
+			const sub = spawn("bash", [SUBSCRIBERS_BASH, "pi", "%45", "99999", "", String(parentPid)], {
+				env,
+				stdio: "ignore",
+				detached: true,
+			});
+			const subPid = sub.pid!;
+			const deadline = Date.now() + 4000;
+			while (Date.now() < deadline) {
+				if (existsSync(subLog) && readFileSync(subLog, "utf8").includes("[pi-sub-drain-error]")) break;
+				await sleep(50);
+			}
+			try { process.kill(-subPid, "SIGTERM"); } catch { /* */ }
+			try { process.kill(subPid, "SIGTERM"); } catch { /* */ }
+			const logBody = existsSync(subLog) ? readFileSync(subLog, "utf8") : "";
+			expect(logBody).toContain("[pi-sub-drain-error]");
+			expect(logBody).toContain("rc=124");
+		} finally {
+			try { fakeParent.kill("SIGKILL"); } catch { /* */ }
+			await sleep(50);
+		}
+	});
+
+	test("malformed JSON from pi-bridge questions → [pi-sub-drain-malformed], no wake row", async () => {
+		const stateDir = mkdtempSync(join(tmpdir(), "fd-pi-drain-malformed-"));
+		stateDirs.push(stateDir);
+		const wakeLog = join(stateDir, "wake-events.log");
+		const subLog = join(stateDir, "daemon.log.pi-sub-46");
+		const bridgeDir = join(stateDir, "bin");
+		mkdirSync(bridgeDir, { recursive: true });
+		const bridgeBin = join(bridgeDir, "pi-bridge");
+		const bridgeScript = `#!/usr/bin/env bash
+if [[ "\${1:-}" == "questions" ]]; then
+  # Valid JSON but wrong envelope: success=false, missing data.questions array.
+  echo '{"type":"response","success":false,"error":"no bridge"}'
+  exit 0
+fi
+if [[ "\${1:-}" == "stream" ]]; then sleep 30; fi
+exit 0
+`;
+		writeFileSync(bridgeBin, bridgeScript);
+		chmodSync(bridgeBin, 0o755);
+		const fakeParent = spawn("sleep", ["30"], { stdio: "ignore" });
+		const parentPid = fakeParent.pid!;
+		try {
+			const env = subscriberEnv(bridgeDir, stateDir);
+			const sub = spawn("bash", [SUBSCRIBERS_BASH, "pi", "%46", "99999", "", String(parentPid)], {
+				env,
+				stdio: "ignore",
+				detached: true,
+			});
+			const subPid = sub.pid!;
+			const deadline = Date.now() + 3000;
+			while (Date.now() < deadline) {
+				if (existsSync(subLog) && readFileSync(subLog, "utf8").includes("[pi-sub-drain-malformed]")) break;
+				await sleep(50);
+			}
+			try { process.kill(-subPid, "SIGTERM"); } catch { /* */ }
+			try { process.kill(subPid, "SIGTERM"); } catch { /* */ }
+			const logBody = existsSync(subLog) ? readFileSync(subLog, "utf8") : "";
+			expect(logBody).toContain("[pi-sub-drain-malformed]");
+			expect(logBody).toContain("no bridge");
+			const wake = existsSync(wakeLog) ? readFileSync(wakeLog, "utf8").split("\n").filter(Boolean) : [];
+			expect(wake.length).toBe(0);
+		} finally {
+			try { fakeParent.kill("SIGKILL"); } catch { /* */ }
+			await sleep(50);
+		}
+	});
+
 	test("empty questions response yields no wake row", async () => {
 		const stateDir = mkdtempSync(join(tmpdir(), "fd-pi-drain-empty-"));
 		stateDirs.push(stateDir);

--- a/skills/flightdeck/lib/flightdeck-core/tests/parity/pi-subscriber-bg-task.test.ts
+++ b/skills/flightdeck/lib/flightdeck-core/tests/parity/pi-subscriber-bg-task.test.ts
@@ -223,6 +223,116 @@ sleep 30
 	});
 });
 
+describe("Pi subscriber question drain on attach (#37 D)", () => {
+	// The bridge stub returns one already-open question from
+	// `pi-bridge questions` and a stream that never emits, so the
+	// only path that can land a pi-question wake row is the new
+	// on-attach drain.
+	test("emits pi-question wake row for questions opened before subscribe", async () => {
+		const stateDir = mkdtempSync(join(tmpdir(), "fd-pi-drain-"));
+		stateDirs.push(stateDir);
+		const wakeLog = join(stateDir, "wake-events.log");
+		const bridgeDir = join(stateDir, "bin");
+		mkdirSync(bridgeDir, { recursive: true });
+		const bridgeBin = join(bridgeDir, "pi-bridge");
+		const bridgeScript = `#!/usr/bin/env bash
+if [[ "\${1:-}" == "questions" ]]; then
+  cat <<'JSON'
+{"type":"response","id":1,"command":"questions","success":true,"data":{"available":true,"questions":[{"requestId":"que_drain_1","openedAt":"2026-05-13T00:00:00Z","request":{"id":"que_drain_1","header":"H","questions":[{"header":"H","question":"Q?","options":[{"label":"yes"},{"label":"no"}]}]}}]}}
+JSON
+  exit 0
+fi
+if [[ "\${1:-}" == "stream" ]]; then
+  sleep 30
+fi
+exit 0
+`;
+		writeFileSync(bridgeBin, bridgeScript);
+		chmodSync(bridgeBin, 0o755);
+
+		const fakeParent = spawn("sleep", ["30"], { stdio: "ignore" });
+		const parentPid = fakeParent.pid!;
+		try {
+			const env = subscriberEnv(bridgeDir, stateDir);
+			const sub = spawn("bash", [SUBSCRIBERS_BASH, "pi", "%42", "99999", "", String(parentPid)], {
+				env,
+				stdio: "ignore",
+				detached: true,
+			});
+			const subPid = sub.pid!;
+
+			const deadline = Date.now() + 5000;
+			let lines: string[] = [];
+			while (Date.now() < deadline) {
+				if (existsSync(wakeLog)) {
+					lines = readFileSync(wakeLog, "utf8").split("\n").filter(Boolean);
+					if (lines.length > 0) break;
+				}
+				await sleep(100);
+			}
+
+			try { process.kill(-subPid, "SIGTERM"); } catch { /* */ }
+			try { process.kill(subPid, "SIGTERM"); } catch { /* */ }
+
+			expect(lines.length).toBeGreaterThan(0);
+			const ev = JSON.parse(lines[0]!);
+			expect(ev.pane_id).toBe("%42");
+			expect(ev.harness).toBe("pi");
+			expect(ev.event_type).toBe("question");
+			expect(ev.classifier_tag).toBe("pi-question");
+			expect(ev.request_id).toBe("que_drain_1");
+			expect(ev.question?.id).toBe("que_drain_1");
+			expect(ev.hash).toMatch(/^[0-9a-f]{12}$/);
+		} finally {
+			try { fakeParent.kill("SIGKILL"); } catch { /* */ }
+			await sleep(50);
+		}
+	});
+
+	test("empty questions response yields no wake row", async () => {
+		const stateDir = mkdtempSync(join(tmpdir(), "fd-pi-drain-empty-"));
+		stateDirs.push(stateDir);
+		const wakeLog = join(stateDir, "wake-events.log");
+		const bridgeDir = join(stateDir, "bin");
+		mkdirSync(bridgeDir, { recursive: true });
+		const bridgeBin = join(bridgeDir, "pi-bridge");
+		const bridgeScript = `#!/usr/bin/env bash
+if [[ "\${1:-}" == "questions" ]]; then
+  echo '{"type":"response","id":1,"command":"questions","success":true,"data":{"available":true,"questions":[]}}'
+  exit 0
+fi
+if [[ "\${1:-}" == "stream" ]]; then
+  sleep 30
+fi
+exit 0
+`;
+		writeFileSync(bridgeBin, bridgeScript);
+		chmodSync(bridgeBin, 0o755);
+
+		const fakeParent = spawn("sleep", ["30"], { stdio: "ignore" });
+		const parentPid = fakeParent.pid!;
+		try {
+			const env = subscriberEnv(bridgeDir, stateDir);
+			const sub = spawn("bash", [SUBSCRIBERS_BASH, "pi", "%43", "99999", "", String(parentPid)], {
+				env,
+				stdio: "ignore",
+				detached: true,
+			});
+			const subPid = sub.pid!;
+			await sleep(800);
+			try { process.kill(-subPid, "SIGTERM"); } catch { /* */ }
+			try { process.kill(subPid, "SIGTERM"); } catch { /* */ }
+			const lines = existsSync(wakeLog)
+				? readFileSync(wakeLog, "utf8").split("\n").filter(Boolean)
+				: [];
+			expect(lines.length).toBe(0);
+		} finally {
+			try { fakeParent.kill("SIGKILL"); } catch { /* */ }
+			await sleep(50);
+		}
+	});
+});
+
 // Compile-time use of pidAlive helper to avoid unused-import warnings in
 // future refactors. The runtime tests above intentionally don't poll the
 // fake parent's liveness since the watchdog isn't under test here.

--- a/skills/flightdeck/lib/flightdeck-core/tests/parity/pi-subscriber-bg-task.test.ts
+++ b/skills/flightdeck/lib/flightdeck-core/tests/parity/pi-subscriber-bg-task.test.ts
@@ -429,6 +429,133 @@ exit 0
 		}
 	});
 
+	// Round-1 reviewer-arch major (#37): race fix. A question opened
+	// between the initial drain and the moment the stream connection
+	// registers with the bridge must still land. Stub `pi-bridge
+	// questions` so the first call (initial drain) returns empty and
+	// the second call (re-drain triggered by bridge_hello) returns
+	// Q; stream emits bridge_hello only, never the live `opened`
+	// event.
+	test("question opened between drain and stream connect → re-drain catches it", async () => {
+		const stateDir = mkdtempSync(join(tmpdir(), "fd-pi-race-"));
+		stateDirs.push(stateDir);
+		const wakeLog = join(stateDir, "wake-events.log");
+		const subLog = join(stateDir, "daemon.log.pi-sub-47");
+		const bridgeDir = join(stateDir, "bin");
+		mkdirSync(bridgeDir, { recursive: true });
+		const bridgeBin = join(bridgeDir, "pi-bridge");
+		const counter = join(stateDir, "q-call-count");
+		const bridgeScript = `#!/usr/bin/env bash
+if [[ "\${1:-}" == "questions" ]]; then
+  n=0
+  if [[ -f "${counter}" ]]; then n=\$(cat "${counter}"); fi
+  printf '%s' "\$((n+1))" > "${counter}"
+  if (( n == 0 )); then
+    echo '{"type":"response","id":1,"command":"questions","success":true,"data":{"available":true,"questions":[]}}'
+  else
+    cat <<'JSON'
+{"type":"response","id":1,"command":"questions","success":true,"data":{"available":true,"questions":[{"requestId":"que_race_1","openedAt":"2026-05-13T00:00:00Z","request":{"id":"que_race_1","header":"H","questions":[{"header":"H","question":"Q?","options":[{"label":"yes"}]}]}}]}}
+JSON
+  fi
+  exit 0
+fi
+if [[ "\${1:-}" == "stream" ]]; then
+  echo '{"type":"bridge_hello","protocol":"pi-session-bridge.v1"}'
+  sleep 30
+fi
+exit 0
+`;
+		writeFileSync(bridgeBin, bridgeScript);
+		chmodSync(bridgeBin, 0o755);
+		const fakeParent = spawn("sleep", ["30"], { stdio: "ignore" });
+		const parentPid = fakeParent.pid!;
+		try {
+			const env = subscriberEnv(bridgeDir, stateDir);
+			const sub = spawn("bash", [SUBSCRIBERS_BASH, "pi", "%47", "99999", "", String(parentPid)], {
+				env,
+				stdio: "ignore",
+				detached: true,
+			});
+			const subPid = sub.pid!;
+			const deadline = Date.now() + 5000;
+			let lines: string[] = [];
+			while (Date.now() < deadline) {
+				if (existsSync(wakeLog)) {
+					lines = readFileSync(wakeLog, "utf8").split("\n").filter(Boolean);
+					if (lines.length > 0) break;
+				}
+				await sleep(100);
+			}
+			try { process.kill(-subPid, "SIGTERM"); } catch { /* */ }
+			try { process.kill(subPid, "SIGTERM"); } catch { /* */ }
+			expect(lines.length).toBe(1);
+			const ev = JSON.parse(lines[0]!);
+			expect(ev.request_id).toBe("que_race_1");
+			expect(ev.classifier_tag).toBe("pi-question");
+			const logBody = existsSync(subLog) ? readFileSync(subLog, "utf8") : "";
+			expect(logBody).toContain("[pi-sub-stream-connected]");
+			// Initial drain (n=0) emitted no row; re-drain (n=1) did.
+			expect(readFileSync(counter, "utf8")).toBe("2");
+		} finally {
+			try { fakeParent.kill("SIGKILL"); } catch { /* */ }
+			await sleep(50);
+		}
+	});
+
+	// Dedupe guarantee: re-drain and the live `question opened` event
+	// both see the same id; only one wake row is written.
+	test("re-drain and live stream both see the same question → single wake row", async () => {
+		const stateDir = mkdtempSync(join(tmpdir(), "fd-pi-race-dedupe-"));
+		stateDirs.push(stateDir);
+		const wakeLog = join(stateDir, "wake-events.log");
+		const bridgeDir = join(stateDir, "bin");
+		mkdirSync(bridgeDir, { recursive: true });
+		const bridgeBin = join(bridgeDir, "pi-bridge");
+		const bridgeScript = `#!/usr/bin/env bash
+if [[ "\${1:-}" == "questions" ]]; then
+  # Both drain calls return the same open question, so the re-drain
+  # would attempt to re-emit it without dedup. seen_qids must skip.
+  cat <<'JSON'
+{"type":"response","id":1,"command":"questions","success":true,"data":{"available":true,"questions":[{"requestId":"que_dedupe_1","openedAt":"2026-05-13T00:00:00Z","request":{"id":"que_dedupe_1","header":"H","questions":[{"header":"H","question":"Q?","options":[{"label":"y"}]}]}}]}}
+JSON
+  exit 0
+fi
+if [[ "\${1:-}" == "stream" ]]; then
+  echo '{"type":"bridge_hello","protocol":"pi-session-bridge.v1"}'
+  # Live event for the same id; must be deduped by seen_qids.
+  echo '{"type":"event","event":"question","data":{"action":"opened","requestId":"que_dedupe_1","request":{"id":"que_dedupe_1","header":"H","questions":[]}}}'
+  sleep 30
+fi
+exit 0
+`;
+		writeFileSync(bridgeBin, bridgeScript);
+		chmodSync(bridgeBin, 0o755);
+		const fakeParent = spawn("sleep", ["30"], { stdio: "ignore" });
+		const parentPid = fakeParent.pid!;
+		try {
+			const env = subscriberEnv(bridgeDir, stateDir);
+			const sub = spawn("bash", [SUBSCRIBERS_BASH, "pi", "%48", "99999", "", String(parentPid)], {
+				env,
+				stdio: "ignore",
+				detached: true,
+			});
+			const subPid = sub.pid!;
+			// Wait long enough for any duplicate emission to land.
+			await sleep(1500);
+			try { process.kill(-subPid, "SIGTERM"); } catch { /* */ }
+			try { process.kill(subPid, "SIGTERM"); } catch { /* */ }
+			const lines = existsSync(wakeLog)
+				? readFileSync(wakeLog, "utf8").split("\n").filter(Boolean)
+				: [];
+			expect(lines.length).toBe(1);
+			const ev = JSON.parse(lines[0]!);
+			expect(ev.request_id).toBe("que_dedupe_1");
+		} finally {
+			try { fakeParent.kill("SIGKILL"); } catch { /* */ }
+			await sleep(50);
+		}
+	});
+
 	test("empty questions response yields no wake row", async () => {
 		const stateDir = mkdtempSync(join(tmpdir(), "fd-pi-drain-empty-"));
 		stateDirs.push(stateDir);

--- a/skills/flightdeck/patterns/pi-questions.md
+++ b/skills/flightdeck/patterns/pi-questions.md
@@ -33,6 +33,27 @@ Pi's `pi-questions` extension renders questions inline in the editor area and ex
 
 The daemon normalizes this to a canonical `pi-question` wake event with `question` set to the request payload.
 
+## Subscriber attach: drain + re-drain
+
+`pi-bridge stream` only delivers **future** events, and `pane-poll` can't see questions (they live in bridge state, not the tmux pane buffer). To avoid wake-starvation when a question is already open at attach time, the daemon's pi subscriber drains pending questions twice on startup:
+
+1. **Initial drain** — immediately before opening the stream, the subscriber calls `pi-bridge questions` and synthesizes a `pi-question` wake row for every entry in `data.questions[]`, seeding a per-pane `seen_qids` dedup string.
+2. **Re-drain on `bridge_hello`** — `pi-session-bridge` sends `{"type":"bridge_hello","protocol":"pi-session-bridge.v1"}` the instant the stream socket is accepted. The subscriber treats that line as the deterministic "stream connected" signal and runs the same drain again, closing the race window between the initial snapshot and the stream subscription registering with the bridge. `seen_qids` carries forward, so a question seen by both drains (or by a drain and the live `event:"question" action:"opened"`) wakes master exactly once.
+
+The drain is **fail-open**: a broken bridge must never block the live-stream branch from running. `pi-bridge questions` is wrapped in `timeout` bounded by `FD_ADAPTER_READ_TIMEOUT_SEC` (default 2s, matching `pane-poll`); rc and stderr are captured and classified, and the subscriber proceeds to the stream regardless. Operators can grep the per-pane `daemon.log.pi-sub-<paneid>` sub-log for these tags:
+
+| Tag | Meaning |
+| --- | --- |
+| `[pi-sub-stream-connected]` | `bridge_hello` arrived; re-drain about to fire. |
+| `[pi-question-emit] ... drain=1` | Drain (initial or re-drain) wrote a `pi-question` wake row for the listed `request_id`. |
+| `[pi-sub-drain-empty]` | Bridge returned an empty response body — distinguishes drain-quiet from drain-broken. |
+| `[pi-sub-drain-error]` | `pi-bridge questions` exited non-zero (or hit `rc=124` from the timeout). Line carries `rc=` and a `stderr=` tail (200 chars). |
+| `[pi-sub-drain-malformed]` | Response failed the `.success == true` / `.data.questions \| type == "array"` shape probe. Line carries a 200-char `excerpt=` of the body. |
+
+A drain failure is not a daemon failure: master still sees subsequent live `event:"question"` opens through the stream. The tags exist so operators can distinguish "the bridge is fine, no questions were pending" from "the bridge call kept failing and we relied on the live stream alone".
+
+## Inner-pane subagent completions
+
 `pi-agents-tmux` may also emit `subagent-completion` custom messages from inner persistent panes. The daemon treats blocked/failed/needs-completion completions as `pi-subagent-completion` advisory wake events and logs successful completions without waking. Flightdeck must re-poll the outer orchestration pane and let that orchestrator consume the inner result. Do not call `subagent`, `steer_subagent`, or `get_subagent_result` for the orchestrator's inner panes from Flightdeck, and never target them by shared cwd/session metadata. If the orchestrator needs a decision about an inner result, it will surface a normal outer `pi-question` or prompt; answer that outer prompt only.
 
 ## Answering

--- a/skills/flightdeck/scripts/flightdeck-daemon.bash
+++ b/skills/flightdeck/scripts/flightdeck-daemon.bash
@@ -1338,8 +1338,19 @@ pi_subscriber_loop() {
   #     directly so a bg_task terminal state lands even if the agent's follow-up
   #     turn never fires (vstack#15).
   #   - normal assistant turn-end text events, classified through prompt-classify.
+  #
+  # Issue #37 round-1 reviewer-arch major: re-drain after stream
+  # connect closes the race where a question opens between the
+  # initial drain (above) and the stream subscription registering
+  # with the bridge. pi-bridge sends `{type:"bridge_hello",...}`
+  # the instant the socket is accepted; passing that line through
+  # the jq filter lets the while loop fire one re-drain on the
+  # very first emitted message. seen_qids is shared into the pipe
+  # subshell so prior drain ids dedupe automatically.
   "$pi_bin" stream "${pi_target_args[@]}" 2>/dev/null \
     | jq --unbuffered -c 'select(
+        (.type == "bridge_hello")
+        or
         (.type == "event" and .event == "question" and (.data.action // "") == "opened")
         or
         (.type == "event" and .event == "message_end" and ((.data.message.customType // "") == "subagent-completion"))
@@ -1351,6 +1362,16 @@ pi_subscriber_loop() {
     | while IFS= read -r line; do
       if ! kill -0 "$parent_pid" 2>/dev/null; then exit 0; fi
       [[ -z "$line" ]] && continue
+
+      local msg_type
+      msg_type=$(jq -r '.type // ""' <<< "$line" 2>/dev/null)
+      if [[ "$msg_type" == "bridge_hello" ]]; then
+        printf '%s [pi-sub-stream-connected] pane=%s\n' \
+          "$(date -Iseconds)" "$pane_id" \
+          >> "$sub_log" 2>/dev/null || true
+        pi_subscriber_drain_questions "$pane_id" "$pi_bin" "$sub_log" pi_target_args seen_qids
+        continue
+      fi
 
       local event_name
       event_name=$(jq -r '.event // ""' <<< "$line" 2>/dev/null)

--- a/skills/flightdeck/scripts/flightdeck-daemon.bash
+++ b/skills/flightdeck/scripts/flightdeck-daemon.bash
@@ -1321,6 +1321,16 @@ pi_subscriber_loop() {
     pi_target_args=(--pid "$pi_pid")
   fi
 
+  # Issue #37(D): drain pi-questions that were opened before the
+  # subscriber attached. `pi-bridge stream` only delivers future
+  # events, so a question opened before the daemon subscribed would
+  # be invisible to master and pane-poll alike (questions live in
+  # the bridge state, not the tmux pane buffer). The helper emits
+  # the same pi-question-emit log + WAKE_EVENTS_LOG row that the
+  # live-stream branch below emits, then seeds seen_qids so the
+  # future stream event for the same id dedupes.
+  pi_subscriber_drain_questions "$pane_id" "$pi_bin" "$sub_log" pi_target_args seen_qids
+
   # Stream bridge events. We emit four classes:
   #   - pi-question: structured pi-questions prompts opened by the child pane.
   #   - pi-subagent-completion: blocked/failed/needs-completion inner persistent-subagent completions.

--- a/skills/flightdeck/scripts/lib/pi-bridge-paths.sh
+++ b/skills/flightdeck/scripts/lib/pi-bridge-paths.sh
@@ -155,6 +155,59 @@ pi_bridge_is_fresh() {
   [[ "$proto" == "pi-session-bridge.v1" ]]
 }
 
+# Issue #37(D): drain pi-questions that are already open in the bridge
+# when a subscriber attaches. The live `pi-bridge stream` only emits
+# future events; a question opened before the daemon subscribed would
+# otherwise be invisible to master (the classifier can't see it either,
+# since questions live in bridge state, not the tmux pane buffer).
+#
+# Synthesizes the same `pi-question-emit` sub_log line and
+# WAKE_EVENTS_LOG row that the live-stream branch emits, then seeds
+# the caller's seen_qids dedup string so the future stream event is
+# treated as already-handled.
+#
+# Usage:
+#   pi_subscriber_drain_questions <pane_id> <pi_bin> <sub_log> \
+#                                 <pi_target_args_arrayname> \
+#                                 <seen_qids_varname>
+# Requires WAKE_EVENTS_LOG and SESSION_LOCK in env.
+pi_subscriber_drain_questions() {
+  local pane_id="$1" pi_bin="$2" sub_log="$3"
+  local -n _pi_drain_target_args="$4"
+  local -n _pi_drain_seen="$5"
+  local resp pending
+  resp=$("$pi_bin" questions "${_pi_drain_target_args[@]}" 2>/dev/null || true)
+  [[ -z "$resp" ]] && return 0
+  pending=$(jq -c '.data.questions // []' <<< "$resp" 2>/dev/null || echo '[]')
+  [[ -z "$pending" || "$pending" == "null" || "$pending" == "[]" ]] && return 0
+  local item qid payload qhash
+  while IFS= read -r item; do
+    [[ -z "$item" || "$item" == "null" ]] && continue
+    qid=$(jq -r '.requestId // .request.id // ""' <<< "$item" 2>/dev/null)
+    [[ -z "$qid" || "$qid" == "null" ]] && continue
+    if [[ "$_pi_drain_seen" == *",$qid,"* ]]; then continue; fi
+    payload=$(jq -c '.request // .' <<< "$item" 2>/dev/null)
+    [[ -z "$payload" || "$payload" == "null" ]] && continue
+    qhash=$(printf '%s' "$qid" | sha256sum | awk '{print substr($1,1,12)}')
+    printf '%s [pi-question-emit] pane=%s request_id=%s drain=1\n' \
+      "$(date -Iseconds)" "$pane_id" "$qid" \
+      >> "$sub_log" 2>/dev/null || true
+    ( exec 218>"$SESSION_LOCK"
+      flock 218
+      jq -nc --arg ts "$(date -Iseconds)" \
+             --arg pid "$pane_id" \
+             --arg harness "pi" \
+             --arg req "$qid" \
+             --arg tag "pi-question" \
+             --arg h "$qhash" \
+             --argjson q "$payload" \
+             '{ts:$ts, pane_id:$pid, harness:$harness, event_type:"question", request_id:$req, question:$q, classifier_tag:$tag, hash:$h}' \
+             >> "$WAKE_EVENTS_LOG"
+    )
+    _pi_drain_seen+="$qid,"
+  done < <(jq -c '.[]' <<< "$pending" 2>/dev/null || true)
+}
+
 # jq filter that extracts the last assistant message text from
 # `pi-bridge history` output. Pi events shape:
 #   {type:"event", event:"message_update", data:{message:{role:"assistant",

--- a/skills/flightdeck/scripts/lib/pi-bridge-paths.sh
+++ b/skills/flightdeck/scripts/lib/pi-bridge-paths.sh
@@ -166,19 +166,59 @@ pi_bridge_is_fresh() {
 # the caller's seen_qids dedup string so the future stream event is
 # treated as already-handled.
 #
+# Round-1 reviewer-error blocker (#37): fail open with explicit
+# diagnostics. Timeout the bridge call so a hung pi-bridge cannot
+# block the subscriber before it reaches `pi-bridge stream`; capture
+# exit code + stderr; validate the JSON envelope before iterating;
+# log structured tags on every failure mode so the operator can tell
+# drain-quiet from drain-broken.
+#
 # Usage:
 #   pi_subscriber_drain_questions <pane_id> <pi_bin> <sub_log> \
 #                                 <pi_target_args_arrayname> \
 #                                 <seen_qids_varname>
+#
+# Honors FD_ADAPTER_READ_TIMEOUT_SEC (default 2, matching pane-poll).
 # Requires WAKE_EVENTS_LOG and SESSION_LOCK in env.
 pi_subscriber_drain_questions() {
   local pane_id="$1" pi_bin="$2" sub_log="$3"
   local -n _pi_drain_target_args="$4"
   local -n _pi_drain_seen="$5"
-  local resp pending
-  resp=$("$pi_bin" questions "${_pi_drain_target_args[@]}" 2>/dev/null || true)
-  [[ -z "$resp" ]] && return 0
-  pending=$(jq -c '.data.questions // []' <<< "$resp" 2>/dev/null || echo '[]')
+  local drain_timeout="${FD_ADAPTER_READ_TIMEOUT_SEC:-2}"
+  local err_file resp rc stderr_tail excerpt pending
+  err_file=$(mktemp -t fd-pi-drain-err.XXXXXX)
+  # `timeout(1)` SIGTERMs the bridge after the deadline (exit 124),
+  # bounding the worst-case attach delay so even a hung pi-bridge
+  # falls through to the live stream. stderr is captured separately
+  # so a non-zero rc has actionable diagnostics.
+  resp=$(timeout "${drain_timeout}s" "$pi_bin" questions "${_pi_drain_target_args[@]}" 2>"$err_file")
+  rc=$?
+  if (( rc != 0 )); then
+    stderr_tail=$(tail -c 200 "$err_file" 2>/dev/null | tr '\n' ' ' || true)
+    rm -f "$err_file"
+    printf '%s [pi-sub-drain-error] pane=%s rc=%s stderr=%s\n' \
+      "$(date -Iseconds)" "$pane_id" "$rc" "${stderr_tail:-<empty>}" \
+      >> "$sub_log" 2>/dev/null || true
+    return 0
+  fi
+  rm -f "$err_file"
+  if [[ -z "$resp" ]]; then
+    printf '%s [pi-sub-drain-empty] pane=%s\n' \
+      "$(date -Iseconds)" "$pane_id" \
+      >> "$sub_log" 2>/dev/null || true
+    return 0
+  fi
+  # Validate JSON envelope shape before walking it. A malformed body
+  # would otherwise be silently swallowed by the inner `jq -c`.
+  if ! jq -e '.success == true' <<< "$resp" >/dev/null 2>&1 \
+     || ! jq -e '.data.questions | type == "array"' <<< "$resp" >/dev/null 2>&1; then
+    excerpt=$(printf '%s' "$resp" | head -c 200 | tr '\n' ' ')
+    printf '%s [pi-sub-drain-malformed] pane=%s excerpt=%s\n' \
+      "$(date -Iseconds)" "$pane_id" "${excerpt:-<empty>}" \
+      >> "$sub_log" 2>/dev/null || true
+    return 0
+  fi
+  pending=$(jq -c '.data.questions' <<< "$resp" 2>/dev/null || echo '[]')
   [[ -z "$pending" || "$pending" == "null" || "$pending" == "[]" ]] && return 0
   local item qid payload qhash
   while IFS= read -r item; do

--- a/skills/flightdeck/scripts/lib/subscribers.bash
+++ b/skills/flightdeck/scripts/lib/subscribers.bash
@@ -267,6 +267,16 @@ pi_subscriber_loop() {
     pi_target_args=(--pid "$pi_pid")
   fi
 
+  # Issue #37(D): drain pi-questions that were opened before the
+  # subscriber attached. `pi-bridge stream` only delivers future
+  # events, so a question opened before daemon startup is invisible
+  # to master and pane-poll can't see it either (questions live in
+  # the bridge state, not the tmux buffer). Synthesize the same
+  # pi-question-emit log + WAKE_EVENTS_LOG append the live-stream
+  # path emits, then seed seen_qids so the future stream event
+  # dedupes.
+  pi_subscriber_drain_questions "$pane_id" "$pi_bin" "$sub_log" pi_target_args seen_qids
+
   "$pi_bin" stream "${pi_target_args[@]}" 2>/dev/null \
     | jq --unbuffered -c 'select(
         (.type == "event" and .event == "question" and (.data.action // "") == "opened")

--- a/skills/flightdeck/scripts/lib/subscribers.bash
+++ b/skills/flightdeck/scripts/lib/subscribers.bash
@@ -277,8 +277,18 @@ pi_subscriber_loop() {
   # dedupes.
   pi_subscriber_drain_questions "$pane_id" "$pi_bin" "$sub_log" pi_target_args seen_qids
 
+  # Issue #37 round-1 reviewer-arch major: re-drain after stream
+  # connect closes the race where a question opens between the
+  # initial drain (above) and the stream subscription registering
+  # with the bridge. pi-bridge sends `{type:"bridge_hello",...}`
+  # the instant the socket is accepted; passing that line through
+  # the jq filter lets the while loop fire one re-drain on the very
+  # first emitted message. seen_qids is shared into the pipe
+  # subshell, so prior drain ids dedupe automatically.
   "$pi_bin" stream "${pi_target_args[@]}" 2>/dev/null \
     | jq --unbuffered -c 'select(
+        (.type == "bridge_hello")
+        or
         (.type == "event" and .event == "question" and (.data.action // "") == "opened")
         or
         (.type == "event" and .event == "message_end" and ((.data.message.customType // "") == "subagent-completion"))
@@ -290,6 +300,16 @@ pi_subscriber_loop() {
     | while IFS= read -r line; do
       if ! kill -0 "$parent_pid" 2>/dev/null; then exit 0; fi
       [[ -z "$line" ]] && continue
+
+      local msg_type
+      msg_type=$(jq -r '.type // ""' <<< "$line" 2>/dev/null)
+      if [[ "$msg_type" == "bridge_hello" ]]; then
+        printf '%s [pi-sub-stream-connected] pane=%s\n' \
+          "$(date -Iseconds)" "$pane_id" \
+          >> "$sub_log" 2>/dev/null || true
+        pi_subscriber_drain_questions "$pane_id" "$pi_bin" "$sub_log" pi_target_args seen_qids
+        continue
+      fi
 
       local event_name
       event_name=$(jq -r '.event // ""' <<< "$line" 2>/dev/null)

--- a/skills/flightdeck/scripts/pane-registry.bash
+++ b/skills/flightdeck/scripts/pane-registry.bash
@@ -457,7 +457,14 @@ case "$ACTION" in
     # pane); kept alive via codex-app-server-spawn idempotency until
     # terminate.md § 5 calls codex-app-server-stop.
     rm -f "$(cx_spawn_file "$ISSUE")" 2>/dev/null || true
+    # Issue #37(C): drop both the legacy .issues row AND the generic
+    # .entries row. Pre-fix, adhoc entries written only to .entries
+    # survived `remove` forever and required a manual
+    # `flightdeck-state set .entries '(.entries | del(...))'` chase.
+    # Each `del` is idempotent on missing keys, so calling both in
+    # sequence is safe regardless of which map the id lives in.
     "$FD_STATE" set ".issues" "(.issues | del(.[\"$ISSUE\"]))"
+    "$FD_STATE" set ".entries" "(.entries | del(.[\"$ISSUE\"]))"
     ;;
 
   oc-attach-args)

--- a/skills/flightdeck/scripts/pane-registry.bash
+++ b/skills/flightdeck/scripts/pane-registry.bash
@@ -828,10 +828,14 @@ case "$ACTION" in
     fi
     if (( pane_alive == 1 )); then
       case "$state" in
-        merged|aborted|dead) ;;
+        # Issue #37(B): accept legacy issue-flow terminal states
+        # (merged|aborted|dead) and the generic session-lifecycle
+        # terminal states (complete|cancelled) so adhoc entries can
+        # clean up without --force.
+        merged|aborted|dead|complete|cancelled) ;;
         *)
           if (( FORCE != 1 )); then
-            echo "teardown-window: policy refusal — pane_id '$pane_id' is alive but state is '$state' (not merged|aborted|dead); set a terminal state first or rerun with --force" >&2
+            echo "teardown-window: policy refusal — pane_id '$pane_id' is alive but state is '$state' (not merged|aborted|dead|complete|cancelled); set a terminal state first or rerun with --force" >&2
             exit 4
           fi
           ;;
@@ -867,13 +871,14 @@ case "$ACTION" in
       exit 0
     fi
     # pane_id missing or already dead — gate teardown on terminal state.
+    # Issue #37(B): accept legacy + generic terminal vocabularies.
     case "$state" in
-      merged|aborted|dead)
+      merged|aborted|dead|complete|cancelled)
         printf 'teardown-window: window already closed (pane_id=%s gone, state=%s)\n' "${pane_id:-<none>}" "$state"
         exit 0
         ;;
       *)
-        echo "teardown-window: registry drift — pane_id '${pane_id:-<none>}' is gone but state is '${state}' (not merged|aborted|dead); refusing to derive kill target from pane_target (#16)" >&2
+        echo "teardown-window: registry drift — pane_id '${pane_id:-<none>}' is gone but state is '${state}' (not merged|aborted|dead|complete|cancelled); refusing to derive kill target from pane_target (#16)" >&2
         exit 3
         ;;
     esac

--- a/skills/flightdeck/scripts/pane-respond.bash
+++ b/skills/flightdeck/scripts/pane-respond.bash
@@ -107,6 +107,20 @@ pane_registry_find_id() {
   fi
 }
 
+# Issue #37(A): callers may pass a stable tmux pane_id (%NNN) instead of
+# the human SESSION:WINDOW.IDX pane_target. Resolve via the registry so
+# every downstream tmux/bridge call still gets an explicit pane index.
+resolve_pane_target_from_pane_id() {
+  local pane_id="$1" id id_json target
+  id=$(pane_registry_find_id "$pane_id")
+  [[ -n "$id" ]] || return 1
+  id_json=$(jq -Rn --arg v "$id" '$v')
+  target=$("$SCRIPT_DIR/flightdeck-state" get \
+    "(.entries[$id_json].pane_target // .issues[$id_json].pane_target // empty)" 2>/dev/null | tr -d '"')
+  [[ -n "$target" ]] || return 1
+  printf '%s' "$target"
+}
+
 TARGET="${1:-}"
 if [[ -z "$TARGET" ]]; then
   echo "Usage: pane-respond <pane-target> <payload>|--option N|--keys k1,k2,... [flags]" >&2
@@ -235,6 +249,14 @@ case "$MODE" in
     fi
     ;;
 esac
+
+# Issue #37(A): accept stable pane_id (%NNN) by resolving to pane_target
+# via the registry before enforcing the explicit-pane-index check.
+if [[ "$TARGET" =~ ^%[0-9]+$ ]]; then
+  if resolved=$(resolve_pane_target_from_pane_id "$TARGET"); then
+    TARGET="$resolved"
+  fi
+fi
 
 # Enforce explicit pane index.
 if [[ "$TARGET" != *"."* ]]; then

--- a/skills/flightdeck/scripts/pane-respond.bash
+++ b/skills/flightdeck/scripts/pane-respond.bash
@@ -107,17 +107,61 @@ pane_registry_find_id() {
   fi
 }
 
-# Issue #37(A): callers may pass a stable tmux pane_id (%NNN) instead of
-# the human SESSION:WINDOW.IDX pane_target. Resolve via the registry so
-# every downstream tmux/bridge call still gets an explicit pane index.
+# Issue #37(A): callers may pass a stable tmux pane_id (%NNN) instead
+# of the human SESSION:WINDOW.IDX pane_target. Resolve via the registry
+# so every downstream tmux/bridge call still gets an explicit pane
+# index.
+#
+# Round-1 reviewer-error major (#37): the previous helper returned 1
+# for every failure mode, so the caller fell through to the generic
+# 'target must include explicit pane index' error. Distinguish three
+# specific failure shapes and emit byte-identical error text to the
+# TS port:
+#   1 = registry read failure (find-by-pane exit >= 2)
+#   2 = no tracked entry matches the pane id (find-by-pane exit 1
+#       OR exit 0 but missing id)
+#   3 = entry found but pane_target field is empty/null (registry
+#       drift; recover via pane-registry reconcile)
+# On success the resolved pane_target is printed to stdout, exit 0.
 resolve_pane_target_from_pane_id() {
-  local pane_id="$1" id id_json target
-  id=$(pane_registry_find_id "$pane_id")
-  [[ -n "$id" ]] || return 1
+  local pane_id="$1"
+  local raw fb_rc id id_json target sr_rc
+  # set -e is in effect for the script body; explicitly suspend it so
+  # find-by-pane and flightdeck-state can return non-zero (legitimate
+  # 'no match' or 'state read failure' signals) without aborting the
+  # caller before we can classify the failure.
+  set +e
+  raw=$("$SCRIPT_DIR/pane-registry" find-by-pane "$pane_id" 2>/dev/null)
+  fb_rc=$?
+  set -e
+  if (( fb_rc >= 2 )); then
+    printf '__PANE_RESPOND_ERR__:registry_read:%s' "$fb_rc"
+    return 1
+  fi
+  id=""
+  if [[ "$raw" == \{* ]]; then
+    id=$(jq -r '.id // empty' <<< "$raw" 2>/dev/null || true)
+  else
+    id="$raw"
+  fi
+  if [[ -z "$id" ]]; then
+    printf '__PANE_RESPOND_ERR__:not_registered'
+    return 2
+  fi
   id_json=$(jq -Rn --arg v "$id" '$v')
+  set +e
   target=$("$SCRIPT_DIR/flightdeck-state" get \
     "(.entries[$id_json].pane_target // .issues[$id_json].pane_target // empty)" 2>/dev/null | tr -d '"')
-  [[ -n "$target" ]] || return 1
+  sr_rc=$?
+  set -e
+  if (( sr_rc >= 2 )); then
+    printf '__PANE_RESPOND_ERR__:registry_read:%s' "$sr_rc"
+    return 1
+  fi
+  if [[ -z "$target" || "$target" == "null" ]]; then
+    printf '__PANE_RESPOND_ERR__:missing_pane_target'
+    return 3
+  fi
   printf '%s' "$target"
 }
 
@@ -250,12 +294,31 @@ case "$MODE" in
     ;;
 esac
 
-# Issue #37(A): accept stable pane_id (%NNN) by resolving to pane_target
-# via the registry before enforcing the explicit-pane-index check.
+# Issue #37(A): accept stable pane_id (%NNN) by resolving to
+# pane_target via the registry before enforcing the explicit-pane-
+# index check. Round-1 reviewer-error major: surface the specific
+# resolution failure rather than falling through to the generic
+# 'target must include explicit pane index' error.
 if [[ "$TARGET" =~ ^%[0-9]+$ ]]; then
-  if resolved=$(resolve_pane_target_from_pane_id "$TARGET"); then
-    TARGET="$resolved"
-  fi
+  resolved=$(resolve_pane_target_from_pane_id "$TARGET")
+  case "$resolved" in
+    __PANE_RESPOND_ERR__:registry_read:*)
+      _rc="${resolved#__PANE_RESPOND_ERR__:registry_read:}"
+      echo "pane-respond: failed to look up pane '$TARGET' in registry (flightdeck-state exit=$_rc)" >&2
+      exit 2
+      ;;
+    __PANE_RESPOND_ERR__:not_registered)
+      echo "pane-respond: pane '$TARGET' is not registered as a flightdeck-tracked pane; pass the explicit pane target (e.g. <session>:<window>.<idx>) or register the pane first" >&2
+      exit 2
+      ;;
+    __PANE_RESPOND_ERR__:missing_pane_target)
+      echo "pane-respond: registry entry for '$TARGET' is missing pane_target (registry drift); recover via pane-registry reconcile" >&2
+      exit 2
+      ;;
+    *)
+      TARGET="$resolved"
+      ;;
+  esac
 fi
 
 # Enforce explicit pane index.


### PR DESCRIPTION
Closes #37.

Fixes a cluster of generic/adhoc-session lifecycle gaps found while live-testing the `session start` / `session watch` / teardown flow with three Pi panes, plus the two AGENTS.md doc-drift findings from the same test pass.

## What changed

### Behavior
- `pane-respond` now accepts the stable `%pane_id` form and resolves it through the registry. When resolution fails, it surfaces one of three specific error shapes (`registry_read` / `not_registered` / `missing_pane_target`) instead of the old "must include explicit pane index" passthrough. Bash + TS in parity. (`4a3c218`, `5d8992d`)
- `pane-registry teardown-entry` now accepts the generic terminal states `complete` and `cancelled` in addition to the legacy `merged | aborted | dead`. The drift error message lists both vocabularies. (`bb34292`)
- `pane-registry remove <id>` now drops the matching `.entries[]` row as well as the legacy `.issues[]` row, making adhoc/workflow cleanup symmetric with issue cleanup. (`306a45a`)
- Daemon Pi subscriber drains existing open `pi-questions` on attach via `pi-bridge questions`, so a question opened before subscriber start no longer gets stuck in pre-history. (`1548876`)
- Drain fails open with bounded timeout (`FD_ADAPTER_READ_TIMEOUT_SEC`), captures rc + stderr + malformed JSON shape, and logs structured `[pi-sub-drain-error|drain-malformed|drain-empty]` sub_log tags so operators can grep failures. (`999bc22`)
- Drain is re-run on `bridge_hello` after stream subscribe to close the snapshot→subscribe race; `seen_qids` deduplicates between both drains and live stream events. (`12cbeb8`)

### Docs
- `AGENTS.md`: dedupe the duplicated `$HOME is rejected as a project root` sentence; add `PreCompact` to the hook header `event:` enum in the README-matching Codex order. (`feac21c`)
- `AGENTS.md`: new rule that vstack worktrees must be created via `skills/worktree/scripts/worktree create <id>`, not raw `git worktree add`. (`59c11f8`)
- `AGENTS.md`: new rule that READMEs are user-facing only — technical/development detail goes in `DEVELOPMENT.md`; agent skill instructions live in `SKILL.md`. (`950fad1`)
- `skills/flightdeck/patterns/pi-questions.md`: documents the new subscriber attach drain + bridge_hello re-drain + fail-open diagnostics + sub_log tag vocabulary. (`09a6ab1`)
- `docs/work-in-progress/flightdeck-ts-port.md`: surgical refresh of the stale "daemon start bash remains canonical" claims to reflect the landed TS daemon path behind `FLIGHTDECK_USE_TS_DAEMON_START=1`. (`3bd512b`)
- `skills/flightdeck/SKILL.md`: Scripts table session-stop/remove row updated to reflect generic-removal cleanup now working.

### Out of scope (intentional)
- Issue #37 §E (`pane-poll` consulting `pi-bridge questions` as a fallback) — covered by the drain + re-drain instead.
- Daemon master-pane silent-exit + recovery — filed separately as #40.
- `flightdeck-session --prompt` fish quoting — filed separately as #39.
- Any README content. User rule: READMEs are user-facing only.

## Tests

`cd skills/flightdeck/lib/flightdeck-core && bun test && bun run typecheck` — 303/303 bun tests pass, `tsc --noEmit` clean. Added parity coverage for every behavior change:
- 3 cases in `tests/parity/pi-subscriber-bg-task.test.ts` for drain fail-open (timeout, malformed JSON, empty response).
- 2 cases for drain → bridge_hello → re-drain race with `seen_qids` dedupe.
- 2 cases in `tests/parity/pane-respond.test.ts` for `not_registered` + `missing_pane_target`.
- Extended `pane-registry.test.ts` for `teardown-entry` accepting `complete|cancelled` and `remove` clearing `.entries[]`.

## Review

- Architecture (reviewer-arch): 1 major (drain race) — addressed in `12cbeb8`.
- Error-handling (reviewer-error): 1 blocker (drain swallows failures) + 1 major (vague pane_id error) — addressed in `999bc22` and `5d8992d`.
- Docs (reviewer-doc, final stage): 2 majors (pattern doc drift, ts-port WIP drift) — addressed in `09a6ab1` and `3bd512b`.

Master pane orchestration done from a single flightdeck-managed Pi engineer pane; review rounds delivered via `pi-bridge follow-up`.
