### PR TITLE
fix(pi-agents-tmux): dashboard summary persistence + chat dedupe + task UX (#45)

### DIFF
--- a/pi-extensions/pi-agents-tmux/DEVELOPMENT.md
+++ b/pi-extensions/pi-agents-tmux/DEVELOPMENT.md
@@ -68,7 +68,9 @@ Each row shows agent name, kind (`pane`/`bg`), turn count, input/output tokens, 
 
 Rows are bucketed for stability: queued/running/waiting agents stay above attention states; attention stays above completed. Within each bucket, rows preserve start-time order so token/usage updates do not reshuffle the list. The header always shows completed and working counts even when one side is zero. Missing pane artifacts render as `stale`; stale bg-only records are dropped (bg agents do not use pane handoff files).
 
-The popup has two top-level tabs: **Agents** (unified project/user/active list, sorted by current status, Live/Chat/Inspector subtabs) and **History** (completed task traces, Summary/Completion/Task subtabs; transcript paths in Summary). Chat is scoped to the selected dashboard row, usually `@orch` ↔ the selected agent. Repeated launches of the same agent render as stable session rows (`agent`, `agent 2`, …); resumed pane work in the same transcript stays on one row.
+The popup has two top-level tabs: **Agents** (unified project/user/active list, sorted by current status, Live/Chat/Inspector subtabs) and **History** (completed task traces, Summary/Completion/Task subtabs; transcript paths in Summary). Agents rows include recent task children keyed by `taskId`; selecting an agent defaults to its latest task, while selecting a child pins Live/Chat to that task. Chat is scoped to the selected task row, or to all recent rows for the selected agent row. Repeated launches of the same bg agent render as task children; resumed pane work can share one transcript row while still exposing individual task ids.
+
+Completed task records store the durable result summary in `PaneTaskRecord.summary`. On restore, completed records with a transcript but no summary backfill from the last assistant text in the transcript. Dashboard rows, History Summary, Chat completion rows, and `get_subagent_result` all read that same field; if no real summary exists they show `completion summary unavailable; see transcript` instead of echoing the original task prompt.
 
 ## Browser keys
 

--- a/pi-extensions/pi-agents-tmux/README.md
+++ b/pi-extensions/pi-agents-tmux/README.md
@@ -9,6 +9,9 @@ Delegate work to specialized agents from a running Pi session. Agents run either
 - `subagent` tool delegates one task, parallel tasks, or sequential chains.
 - Agents with `pane: true` open a visible tmux pane that persists across turns. Other agents run in the background.
 - `/agents` browser lists project and user agents with search, live detail, chat, history, and one-key launch.
+- History shows task numbers, short task IDs, times, summaries, usage, and transcript paths.
+- Chat completion rows show actual results, never a repeat of the original request.
+- Live transcript tails keep message line breaks and separate messages, tools, and exits.
 - Dashboard widget shows live state, model, turns, tokens, and cost for every spawned agent.
 - Dashboard participates in vstack's stable mini-dashboard stack order: Flightdeck → Tasks → Agents → BG tasks.
 - Grouped completion notifications batch multiple agents finishing together.

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/agents-command.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/agents-command.ts
@@ -8,6 +8,8 @@ import { pollPaneCompletions, readPaneRegistry, readTaskRegistry, emitSubagentEv
 import { runtimeSessionId, sessionRuntimeDir } from "./settings.js";
 import type { SubagentDashboardItem } from "./types.js";
 
+type AgentCommandCompletion = { value: string; label: string; description?: string; pane?: boolean };
+
 interface AgentsCommandDeps {
 	[key: string]: any;
 	pi: ExtensionAPI;
@@ -209,7 +211,7 @@ export function registerAgentsCommands(deps: AgentsCommandDeps): void {
 	const paneAgentNameCompletions = (subcommand: string) => (prefix: string) => {
 		const query = prefix.trimStart().toLowerCase();
 		const needsPane = subcommand !== "show";
-		const items = agentCommandCompletions
+		const items = (agentCommandCompletions as AgentCommandCompletion[])
 			.filter((agent) => (!needsPane || agent.pane) && (!query || agent.value.toLowerCase().startsWith(query)))
 			.slice(0, 20)
 			.map((agent) => ({ value: agent.value, label: agent.label, description: agent.description }));

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/browser.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/browser.ts
@@ -34,12 +34,17 @@ import {
 	ansiGreen,
 	ansiMagenta,
 	ansiYellow,
+	COMPLETION_SUMMARY_UNAVAILABLE,
 	compactPath,
+	completionBodyWithoutPromptEcho,
 	divider,
+	formatUsageStats,
 	formatUsageStatsForDashboard,
 	inactivePill,
 	oneLinePreview,
+	shortTaskSuffix,
 	simpleFrame,
+	textFromMessageContent,
 } from "./format.js";
 import {
 	ensurePersistentPane,
@@ -569,7 +574,12 @@ interface AgentBrowserRow {
 	agent: AgentConfig;
 	item?: SubagentDashboardItem;
 	label: string;
+	record?: PaneTaskRecord;
+	rowType: "agent" | "task";
+	taskNumber?: number;
 }
+
+const RECENT_TASK_CHILD_LIMIT = 5;
 
 function dashboardItemSearchText(item: SubagentDashboardItem, label: string): string {
 	return [
@@ -584,25 +594,71 @@ function dashboardItemSearchText(item: SubagentDashboardItem, label: string): st
 	].join(" ").toLowerCase();
 }
 
-function buildAgentRows(agents: AgentConfig[], query: string, statuses: Map<string, AgentPaneStatus>, activeItems: SubagentDashboardItem[]): AgentBrowserRow[] {
-	const tokens = query.trim().toLowerCase().split(/\s+/).filter(Boolean);
-	const agentByName = new Map(agents.map((agent) => [agent.name, agent]));
-	const labels = dashboardDisplayLabels(activeItems);
-	const rows: AgentBrowserRow[] = [];
-	const agentsWithActivity = new Set<string>();
-	for (const item of sortDashboardItems(activeItems)) {
-		const agent = agentByName.get(item.agent);
-		if (!agent) continue;
-		const label = labels.get(item.taskId) ?? item.agent;
-		const searchText = `${agentSearchText(agent, statuses.get(agent.name))} ${dashboardItemSearchText(item, label)}`;
-		if (tokens.length > 0 && !tokens.every((token) => searchText.includes(token))) continue;
-		agentsWithActivity.add(agent.name);
-		rows.push({ agent, item, label });
+function dashboardItemFromTaskRecord(record: PaneTaskRecord): SubagentDashboardItem {
+	const terminal = record.status === "completed" || record.status === "failed" || record.status === "blocked" || record.status === "needs_completion";
+	const message = record.summary?.trim()
+		? record.summary
+		: terminal
+			? COMPLETION_SUMMARY_UNAVAILABLE
+			: record.task || record.diagnostics?.at(-1);
+	return {
+		agent: record.agent,
+		artifacts: Boolean(record.transcriptPath || record.completionArchivePath || record.outboxFile || record.doneFile),
+		completedAt: record.completedAt,
+		kind: record.kind ?? (record.paneId || record.inboxFile || record.outboxFile || record.doneFile ? "pane" : "oneshot"),
+		message,
+		model: record.model,
+		paneId: record.paneId,
+		startedAt: record.createdAt,
+		status: record.status,
+		task: record.task,
+		taskId: record.taskId,
+		transcriptPath: record.transcriptPath,
+		updatedAt: record.updatedAt ?? record.completedAt ?? record.createdAt,
+		usage: record.usage,
+	};
+}
+
+function taskRecordsByAgent(taskRegistry: PaneTaskRegistry): Map<string, PaneTaskRecord[]> {
+	const out = new Map<string, PaneTaskRecord[]>();
+	for (const record of sortedHistoryRecords(taskRegistry)) {
+		const list = out.get(record.agent) ?? [];
+		list.push(record);
+		out.set(record.agent, list);
 	}
-	const catalogAgents = sortAgentsForUnifiedView(filterAgentsForBrowser(agents, query, statuses), statuses, activeItems);
+	return out;
+}
+
+export function buildAgentRows(agents: AgentConfig[], query: string, statuses: Map<string, AgentPaneStatus>, activeItems: SubagentDashboardItem[], taskRegistry: PaneTaskRegistry = {}): AgentBrowserRow[] {
+	const tokens = query.trim().toLowerCase().split(/\s+/).filter(Boolean);
+	const activeByTask = new Map(activeItems.map((item) => [item.taskId, item]));
+	const activeByAgent = activeItemsByAgent(activeItems);
+	const recordsByAgent = taskRecordsByAgent(taskRegistry);
+	const taskNumbers = taskNumberById(Object.values(taskRegistry));
+	const rows: AgentBrowserRow[] = [];
+	const catalogAgents = sortAgentsForUnifiedView(agents, statuses, activeItems);
 	for (const agent of catalogAgents) {
-		if (agentsWithActivity.has(agent.name)) continue;
-		rows.push({ agent, label: agent.name });
+		const records = recordsByAgent.get(agent.name) ?? [];
+		const latestRecord = records[0];
+		const activeItem = activeByAgent.get(agent.name);
+		const agentItem = activeItem ?? (latestRecord ? dashboardItemFromTaskRecord(latestRecord) : undefined);
+		const childRows = records.slice(0, RECENT_TASK_CHILD_LIMIT).map((record): AgentBrowserRow => ({
+			agent,
+			item: activeByTask.get(record.taskId) ?? dashboardItemFromTaskRecord(record),
+			label: `#${taskNumbers.get(record.taskId) ?? "?"} · ${recordClockTime(record)} · ${shortTaskSuffix(record.taskId)}`,
+			record,
+			rowType: "task",
+			taskNumber: taskNumbers.get(record.taskId),
+		}));
+		const agentSearch = `${agentSearchText(agent, statuses.get(agent.name))} ${agentItem ? dashboardItemSearchText(agentItem, agent.name) : ""}`.toLowerCase();
+		const matchingChildren = childRows.filter((row) => {
+			const text = `${row.label} ${row.record?.task ?? ""} ${row.record?.summary ?? ""} ${row.record?.taskId ?? ""} ${row.record?.transcriptPath ?? ""}`.toLowerCase();
+			return tokens.length === 0 || tokens.every((token) => text.includes(token) || agentSearch.includes(token));
+		});
+		const includeAgent = tokens.length === 0 || tokens.every((token) => agentSearch.includes(token)) || matchingChildren.length > 0;
+		if (!includeAgent) continue;
+		rows.push({ agent, item: agentItem, label: agent.name, record: latestRecord, rowType: "agent", taskNumber: latestRecord ? taskNumbers.get(latestRecord.taskId) : undefined });
+		rows.push(...matchingChildren);
 	}
 	return rows;
 }
@@ -651,10 +707,14 @@ function renderAgentList(rows: AgentBrowserRow[], statuses: Map<string, AgentPan
 		const selected = index === ui.selected;
 		const agent = rowInfo.agent;
 		const status = agentStatus(agent, statuses.get(agent.name));
-		const marker = " ";
-		const name = ansiMagenta(selected ? theme.bold(rowInfo.label) : rowInfo.label);
+		const marker = rowInfo.rowType === "task" ? theme.fg("dim", "  └ ") : " ";
+		const name = rowInfo.rowType === "task"
+			? theme.fg("muted", selected ? theme.bold(rowInfo.label) : rowInfo.label)
+			: ansiMagenta(selected ? theme.bold(rowInfo.label) : rowInfo.label);
 		const icon = rowInfo.item ? dashboardStatusIcon(rowInfo.item.status, theme) : agentStatusIcon(status, theme);
-		const meta = rowInfo.item ? `${theme.fg("dim", " · ")}${dashboardStatusText(rowInfo.item, theme)}` : "";
+		const meta = rowInfo.rowType === "task"
+			? rowInfo.item?.kind === "pane" && rowInfo.item.transcriptPath ? theme.fg("dim", " · shared transcript") : ""
+			: rowInfo.item ? `${theme.fg("dim", " · ")}${dashboardStatusText(rowInfo.item, theme)}` : "";
 		const row = truncateToWidth(`${marker}${icon} ${name}${meta}`, width, "…");
 		lines.push(selected ? theme.bg("selectedBg", agentPad(row, width)) : row);
 	}
@@ -715,7 +775,7 @@ export function activeDashboardItems(items: SubagentDashboardItem[]): SubagentDa
 	return sortDashboardItems(items);
 }
 
-function readTranscriptTail(transcriptPath: string | undefined, maxLines: number): string[] {
+export function readTranscriptTail(transcriptPath: string | undefined, maxLines: number): string[] {
 	if (!transcriptPath) return [];
 	// Pi's --mode json stream emits ~50-100x more streaming-delta events
 	// (message_update, tool_execution_update) than terminal ones, and the
@@ -741,10 +801,32 @@ function readTranscriptTail(transcriptPath: string | undefined, maxLines: number
 		const lines = raw.split(/\r?\n/);
 		const rendered: string[] = [];
 		let lastRendered: string | undefined;
-		const push = (text: string) => {
-			if (text === lastRendered) return;
-			lastRendered = text;
-			rendered.push(text);
+		const push = (text: string | undefined) => {
+			if (text === undefined) return;
+			const parts = String(text).replace(/\r\n/g, "\n").split("\n");
+			for (const part of parts) {
+				if (part === lastRendered) continue;
+				lastRendered = part;
+				rendered.push(part);
+			}
+		};
+		const pushSection = (label: string, ts?: string) => {
+			push(`── ${label}${ts ? ` · ${ts}` : ""} ──`);
+		};
+		const eventTime = (outer: any, inner: any): string | undefined => {
+			const rawTs = typeof outer?.ts === "string" ? outer.ts : typeof inner?.timestamp === "string" ? inner.timestamp : undefined;
+			if (!rawTs) return undefined;
+			const date = new Date(rawTs);
+			if (!Number.isFinite(date.getTime())) return rawTs;
+			return `${String(date.getHours()).padStart(2, "0")}:${String(date.getMinutes()).padStart(2, "0")}:${String(date.getSeconds()).padStart(2, "0")}`;
+		};
+		const pushJson = (value: unknown) => {
+			try {
+				const text = JSON.stringify(value ?? {}, null, 2);
+				for (const line of text.split(/\r?\n/)) push(line);
+			} catch {
+				push(String(value));
+			}
 		};
 		for (const line of lines) {
 			if (!line.trim()) continue;
@@ -753,20 +835,23 @@ function readTranscriptTail(transcriptPath: string | undefined, maxLines: number
 			const inner = event?.event && typeof event.event === "object" ? event.event : event;
 			const innerType = typeof inner?.type === "string" ? inner.type : undefined;
 			if (innerType && !INCLUDED_EVENT_TYPES.has(innerType)) continue;
+			const ts = eventTime(event, inner);
 			const msg = inner?.message;
 			if (msg && typeof msg === "object") {
 				const role = msg.role || innerType || "?";
 				const content = Array.isArray(msg.content) ? msg.content : [];
-				const textPart = content.find((c: any) => c?.type === "text");
 				const tool = content.find((c: any) => c?.type === "toolCall");
 				if (tool) {
 					const args = tool.arguments ?? tool.args ?? {};
-					const argText = JSON.stringify(args);
-					const argSuffix = argText && argText !== "{}" ? ` ${argText.slice(0, 120)}` : "";
-					push(`${role}: [tool] ${tool.name ?? "?"}${argSuffix}`);
-				} else if (textPart?.text) push(`${role}: ${oneLinePreview(String(textPart.text), 200)}`);
-				else if (typeof msg.content === "string") push(`${role}: ${oneLinePreview(msg.content, 200)}`);
-				else if (innerType) push(`${role}: (${innerType})`);
+					pushSection(`${role} tool call ${tool.name ?? "?"}`, ts);
+					if (Object.keys(args).length > 0) pushJson(args);
+				} else {
+					const text = textFromMessageContent(msg.content);
+					if (text.trim()) {
+						pushSection(String(role), ts);
+						push(text);
+					} else if (innerType) pushSection(`${role} (${innerType})`, ts);
+				}
 				continue;
 			}
 			// tool_execution_start/end carry identity in inner.toolName + inner.toolCallId
@@ -777,11 +862,16 @@ function readTranscriptTail(transcriptPath: string | undefined, maxLines: number
 				const rawId = typeof inner.toolCallId === "string" ? inner.toolCallId : "";
 				const id = rawId ? rawId.split("|").pop()?.slice(-8) : undefined;
 				const suffix = id ? ` · ${id}` : "";
-				push(`${innerType} ${inner.toolName}${suffix}`);
+				const phase = innerType === "tool_execution_start" ? "tool start" : innerType === "tool_execution_end" ? "tool end" : innerType;
+				pushSection(`${phase} ${inner.toolName}${suffix}`, ts);
+				const result = inner.result ?? inner.output ?? inner.content;
+				if (innerType === "tool_result_end" && result) push(typeof result === "string" ? result : JSON.stringify(result, null, 2));
 				continue;
 			}
 			if (innerType) {
-				push(innerType);
+				if (innerType === "turn_start" || innerType === "turn_end") pushSection(innerType.replace("_", " "), ts);
+				else if (innerType === "exit") pushSection(`exit${typeof inner?.code === "number" ? ` ${inner.code}` : ""}`, ts);
+				else pushSection(innerType, ts);
 				continue;
 			}
 			push(line);
@@ -847,6 +937,9 @@ function renderActiveAgentDetail(item: SubagentDashboardItem | undefined, displa
 	const titleLine = `${agentPaneTitle(theme, "Detail", ui.pane === "inspector")} ${ansiMagenta(theme.bold(nameForTitle))} ${dashboardStatusText(item, theme)} ${theme.fg("dim", dashboardKindLabel(item.kind))}`;
 	const body: string[] = [];
 	body.push(...wrap(`${theme.fg("muted", "Task ID")}: ${theme.fg("dim", item.taskId)}`));
+	if (item.kind === "pane" && item.transcriptPath) {
+		body.push(...wrap(`${theme.fg("muted", "Transcript")}: ${theme.fg("dim", "shared transcript for pane tasks")}`));
+	}
 	body.push("");
 	if (item.task) {
 		body.push(...wrap(theme.fg("accent", theme.bold("Task:"))));
@@ -926,6 +1019,40 @@ function sortedHistoryRecords(registry: PaneTaskRegistry): PaneTaskRecord[] {
 		.sort((a, b) => recordTimestampLocal(b) - recordTimestampLocal(a));
 }
 
+export function taskNumberById(records: PaneTaskRecord[]): Map<string, number> {
+	const byAgent = new Map<string, PaneTaskRecord[]>();
+	for (const record of records) {
+		if (!record.taskId || !record.agent) continue;
+		const list = byAgent.get(record.agent) ?? [];
+		list.push(record);
+		byAgent.set(record.agent, list);
+	}
+	const out = new Map<string, number>();
+	for (const list of byAgent.values()) {
+		list
+			.sort((a, b) => {
+				const delta = recordTimestampLocal(a) - recordTimestampLocal(b);
+				return delta !== 0 ? delta : a.taskId.localeCompare(b.taskId);
+			})
+			.forEach((record, index) => out.set(record.taskId, index + 1));
+	}
+	return out;
+}
+
+function recordClockTime(record: PaneTaskRecord): string {
+	const raw = record.completedAt ?? record.updatedAt ?? record.createdAt;
+	if (!raw) return "--:--";
+	const date = new Date(raw);
+	if (!Number.isFinite(date.getTime())) return "--:--";
+	return `${String(date.getHours()).padStart(2, "0")}:${String(date.getMinutes()).padStart(2, "0")}`;
+}
+
+export function historyRecordLabel(record: PaneTaskRecord, taskNumbers: Map<string, number>): string {
+	const number = taskNumbers.get(record.taskId);
+	const numberText = number ? ` #${number}` : "";
+	return `${record.agent}${numberText} · ${recordClockTime(record)} · ${shortTaskSuffix(record.taskId)}`;
+}
+
 function recordTimestampLocal(record: PaneTaskRecord): number {
 	const value = Date.parse(record.completedAt ?? record.createdAt ?? "");
 	return Number.isFinite(value) ? value : 0;
@@ -938,11 +1065,13 @@ function renderHistoryList(records: PaneTaskRecord[], ui: AgentBrowserUiState, w
 		return lines;
 	}
 	if (ui.historyScroll > 0) lines.push(theme.fg("dim", `↑ ${ui.historyScroll} earlier`));
+	const taskNumbers = taskNumberById(records);
 	for (const [visibleIndex, record] of records.slice(ui.historyScroll, ui.historyScroll + listRows).entries()) {
 		const index = ui.historyScroll + visibleIndex;
 		const selected = index === ui.historySelected;
 		const icon = historyStatusIcon(record.status, theme);
-		const name = ansiMagenta(selected ? theme.bold(record.agent) : record.agent);
+		const label = historyRecordLabel(record, taskNumbers);
+		const name = ansiMagenta(selected ? theme.bold(label) : label);
 		const row = truncateToWidth(`${icon} ${name}`, width, "…");
 		lines.push(selected ? theme.bg("selectedBg", agentPad(row, width)) : row);
 	}
@@ -987,13 +1116,14 @@ function renderTraceContentLine(raw: string, type: TraceViewerItem["type"] | und
 	const line = raw.replace(/\t/g, "  ");
 	const trimmed = line.trim();
 	if (!trimmed) return [""];
+	if (/^── .+ ──$/.test(trimmed)) return wrapTextWithAnsi(theme.fg("muted", trimmed.replace(/(assistant|user|tool call|tool start|tool end|turn start|turn end|exit)/i, (match) => theme.fg("accent", theme.bold(match)))), width);
 	if (/^-{3,}$/.test(trimmed)) return [];
-	if (/^(Overview|Summary|Files changed|Validation|Notes|Task|Artifacts)$/i.test(trimmed)) {
+	if (/^(Overview|Metadata|Summary|Files changed|Validation|Notes|Task|Artifacts)$/i.test(trimmed)) {
 		return wrapTextWithAnsi(theme.fg("accent", theme.bold(trimmed)), width);
 	}
-	const labelMatch = line.match(/^(Ref|Agent|Status|Task ID|Created|Done|Transcript)\s{2,}(.+)$/);
+	const labelMatch = line.match(/^(Ref|Agent|Task #|Status|Task ID|Created|Done|Model|Usage|Transcript|Completion|Archive|Source)\s{2,}(.+)$/);
 	if (labelMatch) return wrapTextWithAnsi(colorTraceValue(labelMatch[1], labelMatch[2], theme), width);
-	if (type === "completion") {
+	if (type === "completion" || type === "transcript") {
 		const jsonKey = line.match(/^(\s*)"([^"]+)"(\s*:\s*)(.*)$/);
 		if (jsonKey) return wrapTextWithAnsi(`${jsonKey[1]}${theme.fg("accent", `"${jsonKey[2]}"`)}${theme.fg("dim", jsonKey[3])}${theme.fg("toolOutput", jsonKey[4])}`, width);
 	}
@@ -1103,7 +1233,7 @@ function extractSteeringBody(raw: string): string {
 	return out.join("\n").trim();
 }
 
-function appendBgChatMessages(messages: ChatMessage[], items: SubagentDashboardItem[]): void {
+export function appendBgChatMessages(messages: ChatMessage[], items: SubagentDashboardItem[]): void {
 	// Bg/oneshot agents skip the file bus (no inbox/outbox/.md/.json), so the
 	// file-based scan never sees them. Synthesize delegation+completion records
 	// from the dashboard item itself; the data we need is already on it.
@@ -1134,7 +1264,7 @@ function appendBgChatMessages(messages: ChatMessage[], items: SubagentDashboardI
 			kind: "completion",
 			from: `@${label}`,
 			to: "@orch",
-			body: item.message || "(no summary)",
+			body: completionBodyWithoutPromptEcho(item.message, item.task),
 			status: item.status,
 		});
 	}
@@ -1274,8 +1404,10 @@ function renderChatRoomDetail(runtimeRoot: string, items: SubagentDashboardItem[
 			const sep = theme.fg("dim", "\u00b7");
 			const kindBadge = chatKindBadge(msg.kind, theme);
 			const statusIcon = chatStatusIcon(msg.status, theme);
+			const taskBadge = msg.taskId ? theme.fg("muted", `#${shortTaskSuffix(msg.taskId)}`) : undefined;
 			const headerParts = [time, fromLabel, arrow, toLabel, sep, kindBadge];
 			if (statusIcon) headerParts.push(sep, statusIcon);
+			if (taskBadge) headerParts.push(sep, taskBadge);
 			body.push(...wrapTextWithAnsi(headerParts.join(" "), safeWidth));
 			const indent = theme.fg("dim", "\u2502 ");
 			const bodyText = msg.body || theme.fg("dim", "(empty)");
@@ -1355,9 +1487,7 @@ function renderHistoryTabBody(
 }
 
 function renderUnifiedAgentDetail(
-	agent: AgentConfig | undefined,
-	activeItem: SubagentDashboardItem | undefined,
-	displayLabel: string | undefined,
+	row: AgentBrowserRow | undefined,
 	statuses: Map<string, AgentPaneStatus>,
 	activeItems: SubagentDashboardItem[],
 	runtimeRoot: string,
@@ -1366,7 +1496,9 @@ function renderUnifiedAgentDetail(
 	rows: number,
 	theme: Theme,
 ): string[] {
-	void activeItems;
+	const agent = row?.agent;
+	const activeItem = row?.item;
+	const displayLabel = row?.rowType === "task" && agent ? `${agent.name} ${row.label}` : row?.label;
 	if (!activeItem) {
 		ui.agentSubtab = 0;
 		return renderAgentInspector(agent, statuses, ui, width, rows, theme);
@@ -1377,10 +1509,12 @@ function renderUnifiedAgentDetail(
 		{ label: "Inspector", text: "", type: "summary" },
 	];
 	ui.agentSubtab = Math.max(0, Math.min(ui.agentSubtab, tabs.length - 1));
+	const agentChatItems = activeItems.filter((item) => item.agent === activeItem.agent);
+	const chatItems = row?.rowType === "agent" ? (agentChatItems.length > 0 ? agentChatItems : [activeItem]) : [activeItem];
 	const base = ui.agentSubtab === 0
 		? renderActiveAgentDetail(activeItem, displayLabel, ui, width, rows, theme)
 		: ui.agentSubtab === 1
-			? renderChatRoomDetail(runtimeRoot, [activeItem], ui, width, rows, theme)
+			? renderChatRoomDetail(runtimeRoot, chatItems, ui, width, rows, theme)
 			: renderAgentInspector(agent, statuses, ui, width, rows, theme);
 	const tabLine = renderTraceTabBar(tabs, ui.agentSubtab, Math.max(8, width), theme);
 	return [base[0] ?? "", "", tabLine, "", ...base.slice(2)].slice(0, rows);
@@ -1398,8 +1532,6 @@ function renderAgentsBody(
 	layout: AgentBrowserLayout,
 ): string[] {
 	const selectedRow = rowsForList[ui.selected];
-	const selected = selectedRow?.agent;
-	const activeItem = selectedRow?.item;
 	const maxLeftWidth = Math.max(10, width - 13);
 	const desiredLeftWidth = Math.min(AGENTS_LEFT_MAX_WIDTH, Math.floor(width * 0.38), maxLeftWidth);
 	const leftWidth = Math.max(10, Math.min(maxLeftWidth, Math.max(Math.min(AGENTS_LEFT_MIN_WIDTH, maxLeftWidth), desiredLeftWidth)));
@@ -1408,7 +1540,7 @@ function renderAgentsBody(
 	const liveCount = [...statuses.values()].filter((status) => status.live).length;
 	const paneCount = discovery.agents.filter((agent) => agent.pane).length;
 	const left = renderAgentList(rowsForList, statuses, ui, leftWidth, theme, layout.listRows);
-	const right = renderUnifiedAgentDetail(selected, activeItem, selectedRow?.label, statuses, activeItems, runtimeRoot, ui, rightWidth, bodyRows, theme);
+	const right = renderUnifiedAgentDetail(selectedRow, statuses, activeItems, runtimeRoot, ui, rightWidth, bodyRows, theme);
 	const rows = bodyRows;
 	const searchLine = theme.bg("toolPendingBg", agentPad(` > ${ui.search}${theme.inverse(" ")}`, width));
 	const workingCount = activeItems.filter((item) => isDashboardWorkingStatus(item.status)).length;
@@ -1463,7 +1595,7 @@ function createAgentsBrowserComponent(
 		done(action);
 	};
 	process.on("SIGWINCH", scheduleResizeRender);
-	const filtered = () => buildAgentRows(discovery.agents, ui.search, statuses, getActiveItems());
+	const filtered = () => buildAgentRows(discovery.agents, ui.search, statuses, getActiveItems(), taskRegistry);
 	const selectedRow = () => filtered()[ui.selected];
 	const selectedAgent = () => selectedRow()?.agent;
 	const clamp = () => {
@@ -1476,12 +1608,13 @@ function createAgentsBrowserComponent(
 	};
 	const historyRecords = sortedHistoryRecords(taskRegistry);
 	const historyCache = new Map<string, HistoryDetailEntry>();
+	const historyTaskNumbers = taskNumberById(historyRecords);
 	const loadHistoryRecord = (record: PaneTaskRecord | undefined) => {
 		if (!record) return;
 		const entry = historyCache.get(record.taskId);
 		if (entry?.items || entry?.loading) return;
 		historyCache.set(record.taskId, { loading: true });
-		void traceViewerItems(record).then((items) => {
+		void traceViewerItems(record, historyTaskNumbers.get(record.taskId)).then((items) => {
 			historyCache.set(record.taskId, { items });
 			requestRender();
 		}).catch((error) => {
@@ -2039,22 +2172,37 @@ export async function showAgentEditConfirmation(ctx: ExtensionContext, message: 
 	}), { overlay: true, overlayOptions: { anchor: "center", width: AGENT_EDIT_CONFIRM_WIDTH, maxHeight: "40%" } });
 }
 
-export async function traceViewerItems(record: PaneTaskRecord): Promise<TraceViewerItem[]> {
+export async function traceViewerItems(record: PaneTaskRecord, taskNumber?: number): Promise<TraceViewerItem[]> {
 	const ref = recordTraceRef(record);
+	const usage = record.usage ? formatUsageStats(record.usage, record.model) : "";
+	const completionPath = record.completionArchivePath ?? record.completionSourcePath;
+	const summaryText = record.summary?.trim()
+		? completionBodyWithoutPromptEcho(record.summary, record.task)
+		: record.status === "completed" || record.status === "failed" || record.status === "blocked"
+			? COMPLETION_SUMMARY_UNAVAILABLE
+			: "No summary yet.";
 	const metadata = [
 		"Overview",
 		"",
+		"Metadata",
+		"--------",
 		`Ref      ${ref}`,
 		`Agent    ${record.agent}`,
+		taskNumber ? `Task #   ${taskNumber}` : "",
 		`Status   ${record.status}`,
 		`Task ID  ${record.taskId}`,
+		record.model ? `Model    ${record.model}` : "",
+		usage ? `Usage    ${usage}` : "",
 		record.transcriptPath ? `Transcript  ${record.transcriptPath}` : "",
+		completionPath ? `Completion  ${completionPath}` : "",
+		record.completionArchivePath ? `Archive  ${record.completionArchivePath}` : "",
+		record.completionSourcePath ? `Source   ${record.completionSourcePath}` : "",
 		`Created  ${record.createdAt}`,
 		record.completedAt ? `Done     ${record.completedAt}` : "",
 		"",
 		"Summary",
 		"-------",
-		record.summary || "No summary yet.",
+		summaryText,
 		"",
 		"Files changed",
 		"-------------",
@@ -2066,10 +2214,19 @@ export async function traceViewerItems(record: PaneTaskRecord): Promise<TraceVie
 		record.notes ? `\nNotes\n-----\n${record.notes}` : "",
 	].filter(Boolean).join("\n");
 	const completion = await readTextFileIfExists(record.completionArchivePath ?? record.completionSourcePath, 24_000);
-	const common = { agent: record.agent, createdAt: record.completedAt ?? record.createdAt, ref, status: record.status, summary: record.summary || record.task };
+	const common = { agent: record.agent, createdAt: record.completedAt ?? record.createdAt, ref, status: record.status, summary: summaryText };
+	const taskText = [
+		`Task ID  ${record.taskId}`,
+		`Created  ${record.createdAt}`,
+		taskNumber ? `Task #   ${taskNumber}` : "",
+		"",
+		"Task",
+		"----",
+		record.task || "Task unavailable.",
+	].filter(Boolean).join("\n");
 	return [
 		{ ...common, label: "Summary", text: metadata, type: "summary" },
 		{ ...common, label: "Completion", path: record.completionArchivePath ?? record.completionSourcePath, text: completion || "Completion JSON unavailable.", type: "completion" },
-		{ ...common, label: "Task", path: record.inboxFile, text: record.task || "Task unavailable.", type: "task" },
+		{ ...common, label: "Task", path: record.inboxFile, text: taskText, type: "task" },
 	];
 }

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/browser.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/browser.ts
@@ -81,6 +81,7 @@ import {
 	type AgentFrontmatterEdit,
 	type AgentPaneStatus,
 	type ChatMessage,
+	type CompletionMessageProvenance,
 	type HistoryDetailEntry,
 	type PaneTaskRecord,
 	type PaneTaskRegistry,
@@ -597,17 +598,20 @@ function dashboardItemSearchText(item: SubagentDashboardItem, label: string): st
 
 function dashboardItemFromTaskRecord(record: PaneTaskRecord): SubagentDashboardItem {
 	const terminal = record.status === "completed" || record.status === "failed" || record.status === "blocked" || record.status === "needs_completion";
+	const hasSummary = Boolean(record.summary?.trim());
 	const message = record.summary?.trim()
 		? record.summary
 		: terminal
 			? COMPLETION_SUMMARY_UNAVAILABLE
 			: record.task || record.diagnostics?.at(-1);
+	const messageProvenance: CompletionMessageProvenance = hasSummary ? "persisted" : terminal ? "placeholder" : record.task ? "task-echo-fallback" : "diagnostic";
 	return {
 		agent: record.agent,
 		artifacts: Boolean(record.transcriptPath || record.completionArchivePath || record.outboxFile || record.doneFile),
 		completedAt: record.completedAt,
 		kind: record.kind ?? (record.paneId || record.inboxFile || record.outboxFile || record.doneFile ? "pane" : "oneshot"),
 		message,
+		messageProvenance,
 		model: record.model,
 		paneId: record.paneId,
 		startedAt: record.createdAt,
@@ -1213,9 +1217,9 @@ function loadTaskRegistrySync(runtimeRoot: string): PaneTaskRegistry {
 	}
 }
 
-function completionBodyFromRecord(record: PaneTaskRecord | undefined, fallback: string | undefined, task: string | undefined): string {
-	const persisted = record?.summary?.trim() ? record.summary : undefined;
-	return completionBodyWithoutPromptEcho(persisted ?? fallback, record?.task ?? task);
+function completionBodyFromRecord(record: PaneTaskRecord | undefined, fallback: string | undefined, task: string | undefined, fallbackProvenance: CompletionMessageProvenance = "fallback"): string {
+	if (record?.summary?.trim()) return completionBodyWithoutPromptEcho(record.summary, record.task ?? task, "persisted");
+	return completionBodyWithoutPromptEcho(fallback, record?.task ?? task, fallbackProvenance);
 }
 
 function extractDelegationBody(raw: string): string {
@@ -1283,7 +1287,7 @@ export function appendBgChatMessages(messages: ChatMessage[], items: SubagentDas
 			kind: "completion",
 			from: `@${label}`,
 			to: "@orch",
-			body: completionBodyFromRecord(taskRegistry[item.taskId], item.message, item.task),
+			body: completionBodyFromRecord(taskRegistry[item.taskId], item.message, item.task, item.messageProvenance ?? "task-echo-fallback"),
 			status: item.status,
 		});
 	}
@@ -1323,7 +1327,7 @@ function loadChatMessages(runtimeRoot: string, agentNames: string[], taskRegistr
 		try { parsed = JSON.parse(fs.readFileSync(filePath, "utf-8")) as Record<string, unknown>; } catch { return; }
 		const taskId = deriveTaskIdFromFile(filePath);
 		const record = taskId ? taskRegistry[taskId] : undefined;
-		const summary = completionBodyFromRecord(record, typeof parsed?.summary === "string" ? parsed.summary : undefined, record?.task);
+		const summary = completionBodyFromRecord(record, typeof parsed?.summary === "string" ? parsed.summary : undefined, record?.task, "fallback");
 		const status = typeof parsed?.status === "string" ? parsed.status : undefined;
 		const notes = typeof parsed?.notes === "string" ? parsed.notes : undefined;
 		const filesChanged = Array.isArray(parsed?.filesChanged)

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/browser.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/browser.ts
@@ -55,6 +55,7 @@ import {
 import { readPaneRegistry, readTaskRegistry } from "./tasks.js";
 import { paneCompletionTone, readTextFileIfExists } from "./renderers.js";
 import { recordTraceRef } from "./renderers.js";
+import { taskRegistryPath } from "./paths.js";
 import {
 	AGENTS_BROWSER_TAB,
 	AGENTS_BROWSER_HEIGHT_RATIO,
@@ -1199,6 +1200,24 @@ function trimChatBody(text: string, max = 4_000): string {
 	return `${compact.slice(0, max)}\n\u2026(truncated)`;
 }
 
+function normalizeTaskRegistryShape(parsed: unknown): PaneTaskRegistry {
+	if (Array.isArray(parsed)) return Object.fromEntries(parsed.filter((record) => record?.taskId).map((record) => [record.taskId, record])) as PaneTaskRegistry;
+	return parsed && typeof parsed === "object" ? parsed as PaneTaskRegistry : {};
+}
+
+function loadTaskRegistrySync(runtimeRoot: string): PaneTaskRegistry {
+	try {
+		return normalizeTaskRegistryShape(JSON.parse(fs.readFileSync(taskRegistryPath(runtimeRoot), "utf-8")));
+	} catch {
+		return {};
+	}
+}
+
+function completionBodyFromRecord(record: PaneTaskRecord | undefined, fallback: string | undefined, task: string | undefined): string {
+	const persisted = record?.summary?.trim() ? record.summary : undefined;
+	return completionBodyWithoutPromptEcho(persisted ?? fallback, record?.task ?? task);
+}
+
 function extractDelegationBody(raw: string): string {
 	const lines = raw.split(/\r?\n/);
 	const out: string[] = [];
@@ -1233,7 +1252,7 @@ function extractSteeringBody(raw: string): string {
 	return out.join("\n").trim();
 }
 
-export function appendBgChatMessages(messages: ChatMessage[], items: SubagentDashboardItem[]): void {
+export function appendBgChatMessages(messages: ChatMessage[], items: SubagentDashboardItem[], taskRegistry: PaneTaskRegistry = {}): void {
 	// Bg/oneshot agents skip the file bus (no inbox/outbox/.md/.json), so the
 	// file-based scan never sees them. Synthesize delegation+completion records
 	// from the dashboard item itself; the data we need is already on it.
@@ -1264,13 +1283,13 @@ export function appendBgChatMessages(messages: ChatMessage[], items: SubagentDas
 			kind: "completion",
 			from: `@${label}`,
 			to: "@orch",
-			body: completionBodyWithoutPromptEcho(item.message, item.task),
+			body: completionBodyFromRecord(taskRegistry[item.taskId], item.message, item.task),
 			status: item.status,
 		});
 	}
 }
 
-function loadChatMessages(runtimeRoot: string, agentNames: string[]): ChatMessage[] {
+function loadChatMessages(runtimeRoot: string, agentNames: string[], taskRegistry: PaneTaskRegistry): ChatMessage[] {
 	const messages: ChatMessage[] = [];
 	const seen = new Set<string>();
 	const pushMd = (filePath: string, agent: string): void => {
@@ -1302,7 +1321,9 @@ function loadChatMessages(runtimeRoot: string, agentNames: string[]): ChatMessag
 		try { stat = fs.statSync(filePath); } catch { return; }
 		let parsed: Record<string, unknown> | undefined;
 		try { parsed = JSON.parse(fs.readFileSync(filePath, "utf-8")) as Record<string, unknown>; } catch { return; }
-		const summary = typeof parsed?.summary === "string" ? parsed.summary : "(no summary)";
+		const taskId = deriveTaskIdFromFile(filePath);
+		const record = taskId ? taskRegistry[taskId] : undefined;
+		const summary = completionBodyFromRecord(record, typeof parsed?.summary === "string" ? parsed.summary : undefined, record?.task);
 		const status = typeof parsed?.status === "string" ? parsed.status : undefined;
 		const notes = typeof parsed?.notes === "string" ? parsed.notes : undefined;
 		const filesChanged = Array.isArray(parsed?.filesChanged)
@@ -1311,7 +1332,7 @@ function loadChatMessages(runtimeRoot: string, agentNames: string[]): ChatMessag
 		messages.push({
 			timestamp: stat.mtimeMs,
 			agent,
-			taskId: deriveTaskIdFromFile(filePath),
+			taskId,
 			kind: "completion",
 			from: `@${agent}`,
 			to: "@orch",
@@ -1388,8 +1409,9 @@ function renderChatRoomDetail(runtimeRoot: string, items: SubagentDashboardItem[
 	const taskIds = new Set(items.map((item) => item.taskId).filter(Boolean));
 	const scopeLabel = items.length === 1 ? `@${items[0]!.agent}` : `${agentNames.length} agent${agentNames.length === 1 ? "" : "s"}`;
 	const titleLine = `${agentPaneTitle(theme, "Chat", ui.pane === "inspector")} ${theme.fg("dim", `(${scopeLabel})`)}`;
-	const messages = loadChatMessages(runtimeRoot, agentNames).filter((message) => taskIds.size === 0 || !message.taskId || taskIds.has(message.taskId));
-	appendBgChatMessages(messages, items);
+	const taskRegistry = loadTaskRegistrySync(runtimeRoot);
+	const messages = loadChatMessages(runtimeRoot, agentNames, taskRegistry).filter((message) => taskIds.size === 0 || !message.taskId || taskIds.has(message.taskId));
+	appendBgChatMessages(messages, items, taskRegistry);
 	messages.sort((a, b) => a.timestamp - b.timestamp);
 	const body: string[] = [];
 	if (messages.length === 0) {

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/dispatch.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/dispatch.ts
@@ -1,6 +1,6 @@
 import type { AgentToolResult, ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { AgentConfig, AgentScope } from "./agents.js";
-import { getFinalOutput, oneLinePreview } from "./format.js";
+import { COMPLETION_SUMMARY_UNAVAILABLE, getFinalOutput, oneLinePreview } from "./format.js";
 import { runPersistentPaneAgent } from "./pane.js";
 import {
 	cloneMessagesForDetails,
@@ -152,6 +152,12 @@ function singleResultNeedsCompletion(result: SingleResult): boolean {
 	return singleResultStatus(result) === "needs_completion";
 }
 
+function dashboardMessageForOneShotResult(result: SingleResult): string {
+	const finalOutput = getFinalOutput(result.messages);
+	if (finalOutput.trim()) return oneLinePreview(finalOutput, 120);
+	return singleResultStatus(result) === "running" ? result.task : COMPLETION_SUMMARY_UNAVAILABLE;
+}
+
 function needsCompletionMessage(result: SingleResult): string {
 	const reason = result.needsCompletionReason ? ` (${result.needsCompletionReason})` : "";
 	return result.errorMessage || `Agent needs completion${reason}; inspect result details and worker cwd state.`;
@@ -230,7 +236,7 @@ export async function runChainDispatch(
 			flow.updateDashboard({
 				agent: result.agent,
 				kind: "oneshot",
-				message: oneLinePreview(getFinalOutput(result.messages), 120) || result.task,
+				message: dashboardMessageForOneShotResult(result),
 				model: result.model,
 				status: singleResultStatus(result),
 				task: result.task,
@@ -347,7 +353,7 @@ export async function runParallelDispatch(
 			flow.updateDashboard({
 				agent: item.agent,
 				kind: "oneshot",
-				message: oneLinePreview(getFinalOutput(item.messages), 120) || item.task,
+				message: dashboardMessageForOneShotResult(item),
 				model: item.model,
 				status: singleResultStatus(item),
 				task: item.task,
@@ -476,7 +482,7 @@ export async function runSingleDispatch(
 		flow.updateDashboard({
 			agent: result.agent,
 			kind: "oneshot",
-			message: oneLinePreview(getFinalOutput(result.messages), 120) || result.task,
+			message: dashboardMessageForOneShotResult(result),
 			model: result.model,
 			status: singleResultStatus(result),
 			task: result.task,

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/dispatch.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/dispatch.ts
@@ -161,6 +161,11 @@ function dashboardMessageForOneShotResult(result: SingleResult, persistedSummary
 	return singleResultStatus(result) === "running" ? result.task : COMPLETION_SUMMARY_UNAVAILABLE;
 }
 
+function dashboardMessageProvenanceForOneShotResult(result: SingleResult, persistedSummary?: string): SubagentDashboardItem["messageProvenance"] {
+	if (normalizeSummaryText(persistedSummary) || getFinalOutput(result.messages).trim()) return "persisted";
+	return singleResultStatus(result) === "running" ? "task-echo-fallback" : "placeholder";
+}
+
 async function persistedSummaryForOneShotResult(runtimeRoot: string, result: SingleResult): Promise<string | undefined> {
 	if (!result.taskId) return undefined;
 	try {
@@ -253,6 +258,7 @@ export async function runChainDispatch(
 				agent: result.agent,
 				kind: "oneshot",
 				message: await dashboardMessageForCompletedOneShotResult(flow.runtimeRoot, result),
+				messageProvenance: dashboardMessageProvenanceForOneShotResult(result, await persistedSummaryForOneShotResult(flow.runtimeRoot, result)),
 				model: result.model,
 				status: singleResultStatus(result),
 				task: result.task,
@@ -366,10 +372,12 @@ export async function runParallelDispatch(
 	const maxConcurrency = Math.max(1, Math.floor(settingNumber("maxConcurrency", MAX_CONCURRENCY, flow.cwd)));
 	const results = await mapInBatchesWithConcurrencyLimit(parallelTasks, parallelBatchSize, maxConcurrency, async (t, index) => {
 		const updateOneshotDashboard = async (item: SingleResult, usePersistedSummary = false) => {
+			const persistedSummary = usePersistedSummary ? await persistedSummaryForOneShotResult(flow.runtimeRoot, item) : undefined;
 			flow.updateDashboard({
 				agent: item.agent,
 				kind: "oneshot",
-				message: usePersistedSummary ? await dashboardMessageForCompletedOneShotResult(flow.runtimeRoot, item) : dashboardMessageForOneShotResult(item),
+				message: dashboardMessageForOneShotResult(item, persistedSummary),
+				messageProvenance: dashboardMessageProvenanceForOneShotResult(item, persistedSummary),
 				model: item.model,
 				status: singleResultStatus(item),
 				task: item.task,
@@ -499,6 +507,7 @@ export async function runSingleDispatch(
 			agent: result.agent,
 			kind: "oneshot",
 			message: await dashboardMessageForCompletedOneShotResult(flow.runtimeRoot, result),
+			messageProvenance: dashboardMessageProvenanceForOneShotResult(result, await persistedSummaryForOneShotResult(flow.runtimeRoot, result)),
 			model: result.model,
 			status: singleResultStatus(result),
 			task: result.task,

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/dispatch.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/dispatch.ts
@@ -1,6 +1,6 @@
 import type { AgentToolResult, ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { AgentConfig, AgentScope } from "./agents.js";
-import { COMPLETION_SUMMARY_UNAVAILABLE, getFinalOutput, oneLinePreview } from "./format.js";
+import { COMPLETION_SUMMARY_UNAVAILABLE, getFinalOutput, normalizeSummaryText } from "./format.js";
 import { runPersistentPaneAgent } from "./pane.js";
 import {
 	cloneMessagesForDetails,
@@ -12,6 +12,7 @@ import {
 } from "./runner.js";
 import { createOneShotSessionKey } from "./sessions.js";
 import { settingNumber } from "./settings.js";
+import { readTaskRegistry } from "./tasks.js";
 import {
 	DEFAULT_RESULT_MAX_BYTES,
 	DEFAULT_RESULT_MAX_LINES,
@@ -152,10 +153,25 @@ function singleResultNeedsCompletion(result: SingleResult): boolean {
 	return singleResultStatus(result) === "needs_completion";
 }
 
-function dashboardMessageForOneShotResult(result: SingleResult): string {
+function dashboardMessageForOneShotResult(result: SingleResult, persistedSummary?: string): string {
+	const persisted = normalizeSummaryText(persistedSummary);
+	if (persisted) return persisted;
 	const finalOutput = getFinalOutput(result.messages);
-	if (finalOutput.trim()) return oneLinePreview(finalOutput, 120);
+	if (finalOutput.trim()) return finalOutput;
 	return singleResultStatus(result) === "running" ? result.task : COMPLETION_SUMMARY_UNAVAILABLE;
+}
+
+async function persistedSummaryForOneShotResult(runtimeRoot: string, result: SingleResult): Promise<string | undefined> {
+	if (!result.taskId) return undefined;
+	try {
+		return (await readTaskRegistry(runtimeRoot))[result.taskId]?.summary;
+	} catch {
+		return undefined;
+	}
+}
+
+async function dashboardMessageForCompletedOneShotResult(runtimeRoot: string, result: SingleResult): Promise<string> {
+	return dashboardMessageForOneShotResult(result, await persistedSummaryForOneShotResult(runtimeRoot, result));
 }
 
 function needsCompletionMessage(result: SingleResult): string {
@@ -236,7 +252,7 @@ export async function runChainDispatch(
 			flow.updateDashboard({
 				agent: result.agent,
 				kind: "oneshot",
-				message: dashboardMessageForOneShotResult(result),
+				message: await dashboardMessageForCompletedOneShotResult(flow.runtimeRoot, result),
 				model: result.model,
 				status: singleResultStatus(result),
 				task: result.task,
@@ -349,11 +365,11 @@ export async function runParallelDispatch(
 
 	const maxConcurrency = Math.max(1, Math.floor(settingNumber("maxConcurrency", MAX_CONCURRENCY, flow.cwd)));
 	const results = await mapInBatchesWithConcurrencyLimit(parallelTasks, parallelBatchSize, maxConcurrency, async (t, index) => {
-		const updateOneshotDashboard = (item: SingleResult) => {
+		const updateOneshotDashboard = async (item: SingleResult, usePersistedSummary = false) => {
 			flow.updateDashboard({
 				agent: item.agent,
 				kind: "oneshot",
-				message: dashboardMessageForOneShotResult(item),
+				message: usePersistedSummary ? await dashboardMessageForCompletedOneShotResult(flow.runtimeRoot, item) : dashboardMessageForOneShotResult(item),
 				model: item.model,
 				status: singleResultStatus(item),
 				task: item.task,
@@ -396,7 +412,7 @@ export async function runParallelDispatch(
 					(partial) => {
 						if (partial.details?.results[0]) {
 							allResults[index] = partial.details.results[0];
-							updateOneshotDashboard(partial.details.results[0]);
+							void updateOneshotDashboard(partial.details.results[0]);
 							emitParallelUpdate();
 						}
 					},
@@ -404,7 +420,7 @@ export async function runParallelDispatch(
 					t.sessionKey,
 				);
 		allResults[index] = result;
-		if (!taskAgent?.pane) updateOneshotDashboard(result);
+		if (!taskAgent?.pane) await updateOneshotDashboard(result, true);
 		emitParallelUpdate();
 		return result;
 	});
@@ -482,7 +498,7 @@ export async function runSingleDispatch(
 		flow.updateDashboard({
 			agent: result.agent,
 			kind: "oneshot",
-			message: dashboardMessageForOneShotResult(result),
+			message: await dashboardMessageForCompletedOneShotResult(flow.runtimeRoot, result),
 			model: result.model,
 			status: singleResultStatus(result),
 			task: result.task,

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/format.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/format.ts
@@ -64,6 +64,40 @@ export function oneLinePreview(text: string | undefined, maxChars: number): stri
 	return compact.length > maxChars ? `${compact.slice(0, Math.max(0, maxChars - 1))}…` : compact;
 }
 
+export const COMPLETION_SUMMARY_UNAVAILABLE = "completion summary unavailable; see transcript";
+
+export function shortTaskSuffix(taskId: string | undefined, maxChars = 8): string {
+	const raw = taskId?.trim();
+	if (!raw) return "";
+	const parts = raw.split(/[-_/]+/).filter(Boolean);
+	const suffix = parts.at(-1) ?? raw;
+	return oneLinePreview(suffix, maxChars);
+}
+
+export function normalizeSummaryText(text: string | undefined): string | undefined {
+	const trimmed = text?.replace(/\r\n/g, "\n").trim();
+	return trimmed ? trimmed : undefined;
+}
+
+export function normalizeComparableText(value: string | undefined): string {
+	return (value ?? "")
+		.toLowerCase()
+		.replace(/\x1b\[[0-9;]*m/g, "")
+		.replace(/[`*_#>]/g, " ")
+		.replace(/\s+/g, " ")
+		.trim();
+}
+
+export function completionSummaryForDisplay(summary: string | undefined): string {
+	return normalizeSummaryText(summary) ?? COMPLETION_SUMMARY_UNAVAILABLE;
+}
+
+export function completionBodyWithoutPromptEcho(summary: string | undefined, task: string | undefined): string {
+	const body = completionSummaryForDisplay(summary);
+	if (normalizeComparableText(body) && normalizeComparableText(body) === normalizeComparableText(task)) return COMPLETION_SUMMARY_UNAVAILABLE;
+	return body;
+}
+
 export function compactPath(filePath: string | undefined, options?: { baseDir?: string; maxChars?: number }): string {
 	const raw = filePath?.trim();
 	if (!raw) return "";
@@ -254,12 +288,95 @@ export function getFinalOutput(messages: Message[]): string {
 	for (let i = messages.length - 1; i >= 0; i--) {
 		const msg = messages[i];
 		if (msg.role === "assistant") {
-			for (const part of msg.content) {
-				if (part.type === "text") return part.text;
-			}
+			const text = textFromMessageContent(msg.content);
+			if (text) return text;
 		}
 	}
 	return "";
+}
+
+export function textFromMessageContent(content: unknown): string {
+	if (typeof content === "string") return content;
+	if (!Array.isArray(content)) return "";
+	const parts = content
+		.map((part) => {
+			if (!part || typeof part !== "object") return "";
+			const candidate = part as Record<string, unknown>;
+			return candidate.type === "text" && typeof candidate.text === "string" ? candidate.text : "";
+		})
+		.filter((text) => text.trim());
+	return parts.join("\n\n");
+}
+
+function assistantTextFromTranscriptRecord(record: unknown): string | undefined {
+	if (!record || typeof record !== "object") return undefined;
+	const raw = record as Record<string, unknown>;
+	const event = raw.event && typeof raw.event === "object" ? raw.event as Record<string, unknown> : raw;
+	const message = event.message && typeof event.message === "object"
+		? event.message as Record<string, unknown>
+		: event.role === "assistant"
+			? event
+			: undefined;
+	if (!message || message.role !== "assistant") return undefined;
+	return normalizeSummaryText(textFromMessageContent(message.content));
+}
+
+export function extractLastAssistantTextFromTranscriptContent(content: string): string | undefined {
+	let finalText: string | undefined;
+	for (const line of content.split(/\r?\n/)) {
+		if (!line.trim()) continue;
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(line);
+		} catch {
+			continue;
+		}
+		const text = assistantTextFromTranscriptRecord(parsed);
+		if (text) finalText = text;
+	}
+	return finalText;
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	const timeout = new Promise<never>((_resolve, reject) => {
+		timer = setTimeout(() => reject(new Error(`${label} timed out after ${timeoutMs}ms`)), timeoutMs);
+		timer.unref?.();
+	});
+	try {
+		return await Promise.race([promise, timeout]);
+	} finally {
+		if (timer) clearTimeout(timer);
+	}
+}
+
+async function readFileTailBounded(filePath: string, maxBytes: number, timeoutMs: number): Promise<string> {
+	const read = (async () => {
+		const stat = await fs.promises.stat(filePath);
+		const size = Math.max(0, stat.size);
+		const start = Math.max(0, size - maxBytes);
+		const length = size - start;
+		const handle = await fs.promises.open(filePath, "r");
+		try {
+			const buffer = Buffer.alloc(length);
+			await handle.read(buffer, 0, length, start);
+			const text = buffer.toString("utf-8");
+			if (start === 0) return text;
+			return text.replace(/^[^\n]*(?:\n|$)/, "");
+		} finally {
+			await handle.close().catch(() => undefined);
+		}
+	})();
+	return withTimeout(read, timeoutMs, `read ${filePath}`);
+}
+
+export async function readLastAssistantTextFromTranscript(
+	transcriptPath: string | undefined,
+	options: { maxBytes?: number; timeoutMs?: number } = {},
+): Promise<string | undefined> {
+	if (!transcriptPath) return undefined;
+	const content = await readFileTailBounded(transcriptPath, options.maxBytes ?? 2 * 1024 * 1024, options.timeoutMs ?? 5_000);
+	return extractLastAssistantTextFromTranscriptContent(content);
 }
 
 export function getDisplayItems(messages: Message[]): DisplayItem[] {

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/format.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/format.ts
@@ -337,6 +337,19 @@ export function extractLastAssistantTextFromTranscriptContent(content: string): 
 	return finalText;
 }
 
+function assertTranscriptJsonlValid(content: string): void {
+	let lineNumber = 0;
+	for (const line of content.split(/\r?\n/)) {
+		lineNumber += 1;
+		if (!line.trim()) continue;
+		try {
+			JSON.parse(line);
+		} catch (error) {
+			throw new Error(`Invalid transcript JSONL at line ${lineNumber}: ${stringifyError(error)}`);
+		}
+	}
+}
+
 async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
 	let timer: ReturnType<typeof setTimeout> | undefined;
 	const timeout = new Promise<never>((_resolve, reject) => {
@@ -376,6 +389,7 @@ export async function readLastAssistantTextFromTranscript(
 ): Promise<string | undefined> {
 	if (!transcriptPath) return undefined;
 	const content = await readFileTailBounded(transcriptPath, options.maxBytes ?? 2 * 1024 * 1024, options.timeoutMs ?? 5_000);
+	assertTranscriptJsonlValid(content);
 	return extractLastAssistantTextFromTranscriptContent(content);
 }
 

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/format.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/format.ts
@@ -9,6 +9,7 @@ import { subagentTreeStyle } from "./settings.js";
 import {
 	AGENT_ASCII_COLOR_SEQUENCE,
 	type AgentAsciiColor,
+	type CompletionMessageProvenance,
 	type DisplayItem,
 	ICONS,
 	type SubagentStatuslineInfo,
@@ -92,9 +93,9 @@ export function completionSummaryForDisplay(summary: string | undefined): string
 	return normalizeSummaryText(summary) ?? COMPLETION_SUMMARY_UNAVAILABLE;
 }
 
-export function completionBodyWithoutPromptEcho(summary: string | undefined, task: string | undefined): string {
+export function completionBodyWithoutPromptEcho(summary: string | undefined, task: string | undefined, provenance: CompletionMessageProvenance = "persisted"): string {
 	const body = completionSummaryForDisplay(summary);
-	if (normalizeComparableText(body) && normalizeComparableText(body) === normalizeComparableText(task)) return COMPLETION_SUMMARY_UNAVAILABLE;
+	if (provenance === "task-echo-fallback" && normalizeComparableText(body) && normalizeComparableText(body) === normalizeComparableText(task)) return COMPLETION_SUMMARY_UNAVAILABLE;
 	return body;
 }
 

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/index.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/index.ts
@@ -569,6 +569,12 @@ export default function (pi: ExtensionAPI) {
 		if (isTerminalTaskStatus(record.status)) return COMPLETION_SUMMARY_UNAVAILABLE;
 		return record.diagnostics?.at(-1) ?? record.task;
 	};
+	const taskRecordDashboardMessageProvenance = (record: PaneTaskRecord): SubagentDashboardItem["messageProvenance"] => {
+		if (normalizeSummaryText(record.summary)) return "persisted";
+		if (record.status === "needs_completion") return record.diagnostics?.length ? "diagnostic" : "placeholder";
+		if (isTerminalTaskStatus(record.status)) return "placeholder";
+		return record.diagnostics?.length ? "diagnostic" : "task-echo-fallback";
+	};
 
 	const updateDashboardFromTaskRecord = (record: PaneTaskRecord, runtimeRoot: string) => {
 		const kind = inferTaskRecordKind(runtimeRoot, record);
@@ -592,6 +598,7 @@ export default function (pi: ExtensionAPI) {
 			completedAt: record.completedAt,
 			kind,
 			message: taskRecordDashboardMessage(record),
+			messageProvenance: taskRecordDashboardMessageProvenance(record),
 			model: record.model ?? existing?.model,
 			paneId: record.paneId,
 			startedAt: record.createdAt,

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/index.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/index.ts
@@ -35,7 +35,9 @@ import {
 	agentsCommandBullet,
 	agentWord,
 	ansiMagenta,
+	COMPLETION_SUMMARY_UNAVAILABLE,
 	compactPath,
+	completionBodyWithoutPromptEcho,
 	finalOutputLooksLikeToolEcho,
 	finalResponseSuppressedLine,
 	formatToolCall,
@@ -44,6 +46,7 @@ import {
 	framedMessage,
 	getDisplayItems,
 	getFinalOutput,
+	normalizeSummaryText,
 	oneLinePreview,
 	parseTranscriptUsage,
 	resolveSubagentStatuslineInfo,
@@ -120,6 +123,7 @@ import {
 } from "./settings.js";
 import {
 	appendUniqueDiagnostic,
+	backfillTaskSummaryFromTranscript,
 	completionParseErrorMessage,
 	createTaskId,
 	emitSubagentEvent,
@@ -134,6 +138,7 @@ import {
 	readPaneRegistry,
 	readTaskRegistry,
 	refreshTaskDiagnostics,
+	taskNeedsSummaryBackfill,
 	updateTaskRegistry,
 	upsertTaskRecord,
 	writePaneRegistry,
@@ -405,6 +410,7 @@ export default function (pi: ExtensionAPI) {
 			const kind: DashboardKind = event.mode === "oneshot" ? "oneshot" : event.mode === "pane" ? "pane" : existing?.kind ?? (typeof event.paneId === "string" ? "pane" : "oneshot");
 			const usage = normalizeUsageStats(event.usage) ?? existing?.usage;
 			const model = typeof event.model === "string" ? event.model : existing?.model;
+			const summary = normalizeSummaryText(typeof event.summary === "string" ? event.summary : typeof event.finalOutput === "string" ? event.finalOutput : typeof event.error === "string" ? event.error : undefined) ?? existing?.summary;
 			records[taskId] = {
 				...existing,
 				taskId,
@@ -422,7 +428,7 @@ export default function (pi: ExtensionAPI) {
 				transcriptPath: typeof event.transcriptPath === "string" ? event.transcriptPath : existing?.transcriptPath,
 				usage,
 				model,
-				summary: typeof event.summary === "string" ? event.summary : existing?.summary,
+				summary,
 				createdAt: existing?.createdAt ?? (typeof event.timestamp === "string" ? event.timestamp : now),
 				updatedAt: now,
 				...(isTerminalTaskStatus(status) ? { completedAt: now } : {}),
@@ -556,6 +562,14 @@ export default function (pi: ExtensionAPI) {
 		syncDashboard();
 	};
 
+	const taskRecordDashboardMessage = (record: PaneTaskRecord): string | undefined => {
+		const summary = normalizeSummaryText(record.summary);
+		if (summary) return summary;
+		if (record.status === "needs_completion") return record.diagnostics?.at(-1) ?? COMPLETION_SUMMARY_UNAVAILABLE;
+		if (isTerminalTaskStatus(record.status)) return COMPLETION_SUMMARY_UNAVAILABLE;
+		return record.diagnostics?.at(-1) ?? record.task;
+	};
+
 	const updateDashboardFromTaskRecord = (record: PaneTaskRecord, runtimeRoot: string) => {
 		const kind = inferTaskRecordKind(runtimeRoot, record);
 		const candidateKey = dashboardItemKey({ agent: record.agent, kind, taskId: record.taskId, transcriptPath: record.transcriptPath, paneId: record.paneId });
@@ -577,7 +591,7 @@ export default function (pi: ExtensionAPI) {
 			bridge: existing?.bridge,
 			completedAt: record.completedAt,
 			kind,
-			message: record.summary || record.diagnostics?.at(-1) || record.task,
+			message: taskRecordDashboardMessage(record),
 			model: record.model ?? existing?.model,
 			paneId: record.paneId,
 			startedAt: record.createdAt,
@@ -599,8 +613,11 @@ export default function (pi: ExtensionAPI) {
 				if (!record.taskId || !record.agent) continue;
 				if (inferTaskRecordKind(runtimeRoot, record) === "pane" && record.paneId && isTerminalTaskStatus(record.status) && !registry[record.agent]) continue;
 				const refreshed = await refreshTaskDiagnostics(runtimeRoot, record);
-				if (refreshed.record.status === "needs_completion") dashboardState.visible = true;
-				updateDashboardFromTaskRecord(refreshed.record, runtimeRoot);
+				const backfilled = taskNeedsSummaryBackfill(refreshed.record)
+					? await backfillTaskSummaryFromTranscript(runtimeRoot, refreshed.record)
+					: { record: refreshed.record, updated: false };
+				if (backfilled.record.status === "needs_completion") dashboardState.visible = true;
+				updateDashboardFromTaskRecord(backfilled.record, runtimeRoot);
 			}
 		});
 		await persistRuntimeSnapshot(ctx, runtimeRoot);
@@ -754,6 +771,7 @@ export default function (pi: ExtensionAPI) {
 		const transcriptPath = typeof event.transcriptPath === "string" ? event.transcriptPath : existing?.transcriptPath;
 		const eventUsage = normalizeUsageStats(event.usage);
 		const eventModel = typeof event.model === "string" ? event.model : undefined;
+		const eventSummary = normalizeSummaryText(typeof event.summary === "string" ? event.summary : typeof event.finalOutput === "string" ? event.finalOutput : typeof event.error === "string" ? event.error : undefined);
 		const kind = event.mode === "oneshot" ? "oneshot" : event.mode === "pane" ? "pane" : existing?.kind ?? "pane";
 		const payloadStatus = ((): PaneTaskStatus => {
 			const raw = event.status;
@@ -768,7 +786,7 @@ export default function (pi: ExtensionAPI) {
 			bridge: existing?.bridge,
 			completedAt: typeof event.timestamp === "string" ? event.timestamp : new Date().toISOString(),
 			kind,
-			message: typeof event.summary === "string" ? event.summary : existing?.message,
+			message: eventSummary ?? (isTerminalTaskStatus(eventStatus) || eventStatus === "needs_completion" ? completionBodyWithoutPromptEcho(existing?.message, existing?.task) : existing?.message),
 			paneId: kind === "pane" ? existing?.paneId ?? (typeof event.paneId === "string" ? event.paneId : undefined) : undefined,
 			startedAt: existing?.startedAt,
 			status: effectiveStatus,
@@ -972,10 +990,13 @@ export default function (pi: ExtensionAPI) {
 				for (const record of sortedRecords) {
 					if (!record.taskId || !record.agent) continue;
 					const refreshed = await refreshTaskDiagnostics(runtimeRoot, record);
-					updateDashboardFromTaskRecord(refreshed.record, runtimeRoot);
-					if (refreshed.record.transcriptPath && (refreshed.record.status === "completed" || refreshed.record.status === "failed" || refreshed.record.status === "blocked")) {
-						const capturedTaskId = refreshed.record.taskId;
-						parseTranscriptUsage(refreshed.record.transcriptPath)
+					const backfilled = taskNeedsSummaryBackfill(refreshed.record)
+						? await backfillTaskSummaryFromTranscript(runtimeRoot, refreshed.record)
+						: { record: refreshed.record, updated: false };
+					updateDashboardFromTaskRecord(backfilled.record, runtimeRoot);
+					if (backfilled.record.transcriptPath && (backfilled.record.status === "completed" || backfilled.record.status === "failed" || backfilled.record.status === "blocked")) {
+						const capturedTaskId = backfilled.record.taskId;
+						parseTranscriptUsage(backfilled.record.transcriptPath)
 							.then((parsed) => patchDashboardUsage(runtimeRoot, capturedTaskId, parsed))
 							.catch(() => undefined);
 					}
@@ -1221,6 +1242,7 @@ export default function (pi: ExtensionAPI) {
 	};
 
 	registerPaneSupportTools({
+		backfillTaskSummaryFromTranscript,
 		bridgeTargetArgs,
 		createFollowUpTask,
 		emitSubagentEvent,
@@ -1246,6 +1268,7 @@ export default function (pi: ExtensionAPI) {
 		sessionRuntimeDir,
 		steerDiagnostics,
 		stopPersistentPane,
+		taskNeedsSummaryBackfill,
 		updateDashboard,
 		updateDashboardFromTaskRecord,
 		persistRuntimeSnapshot,

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/pane-support-tools.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/pane-support-tools.ts
@@ -4,6 +4,7 @@ import {
 	addArtifactPathSection,
 	addWrappedSection,
 	agentStatusLine,
+	completionBodyWithoutPromptEcho,
 	wrappedText,
 } from "./format.js";
 import {
@@ -28,6 +29,7 @@ interface PaneSupportToolDeps {
 export function registerPaneSupportTools(deps: PaneSupportToolDeps): void {
 	const {
 		bridgeTargetArgs,
+		backfillTaskSummaryFromTranscript,
 		createFollowUpTask,
 		dashboardStatusFor,
 		emitSubagentEvent,
@@ -48,6 +50,7 @@ export function registerPaneSupportTools(deps: PaneSupportToolDeps): void {
 		readPaneRegistry,
 		readTaskRegistry,
 		refreshTaskDiagnostics,
+		taskNeedsSummaryBackfill,
 		removeDashboardAgent,
 		resolvePiBridgeBin,
 		runtimeSessionId,
@@ -116,12 +119,17 @@ export function registerPaneSupportTools(deps: PaneSupportToolDeps): void {
 				const selector = params.taskId ? `taskId ${params.taskId}` : `agent ${params.agent}`;
 				return { content: [{ type: "text", text: `No persistent agent task record found for ${selector}.` }], details: { agent: params.agent, taskId: params.taskId } satisfies GetSubagentResultDetails, isError: true };
 			}
-			updateDashboardFromTaskRecord({ ...record, updatedAt: new Date().toISOString() }, runtimeRoot);
+			if (typeof taskNeedsSummaryBackfill === "function" && typeof backfillTaskSummaryFromTranscript === "function" && taskNeedsSummaryBackfill(record)) {
+				const backfilled = await backfillTaskSummaryFromTranscript(runtimeRoot, record);
+				record = backfilled.record;
+			}
+			const finalRecord = record as PaneTaskRecord;
+			updateDashboardFromTaskRecord({ ...finalRecord, updatedAt: new Date().toISOString() }, runtimeRoot);
 			await persistRuntimeSnapshot(ctx, runtimeRoot);
 			const diagnosticBlock = params.verbose && diagnostics.length > 0 ? `\n\n### Artifact diagnostics\n${diagnostics.map((line) => `- ${line}`).join("\n")}` : "";
 			return {
-				content: [{ type: "text", text: `${formatTaskRecordResult(record, params.verbose ?? false)}${diagnosticBlock}` }],
-				details: { agent: record.agent, paneId: record.paneId, summary: record.summary, status: record.status, taskId: record.taskId, notes: record.notes, diagnostics: record.diagnostics, completionMessageEmitted } satisfies GetSubagentResultDetails,
+				content: [{ type: "text", text: `${formatTaskRecordResult(finalRecord, params.verbose ?? false)}${diagnosticBlock}` }],
+				details: { agent: finalRecord.agent, paneId: finalRecord.paneId, summary: finalRecord.summary, status: finalRecord.status, taskId: finalRecord.taskId, notes: finalRecord.notes, diagnostics: finalRecord.diagnostics, completionMessageEmitted } satisfies GetSubagentResultDetails,
 			};
 		},
 		renderCall(_args, _theme, _context) {
@@ -187,7 +195,7 @@ export function registerPaneSupportTools(deps: PaneSupportToolDeps): void {
 					artifacts: steerKind === "pane" ? Boolean(record.completionArchivePath || record.outboxFile || record.transcriptPath) : Boolean(record.transcriptPath),
 					completedAt: record.completedAt,
 					kind: steerKind,
-					message: record.summary || record.task,
+					message: completionBodyWithoutPromptEcho(record.summary, record.task),
 					model: record.model,
 					paneId: record.paneId,
 					startedAt: record.createdAt,

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/renderers.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/renderers.ts
@@ -8,6 +8,9 @@ import {
 	agentStatusLine,
 	agentsCommandBullet,
 	compactPath,
+	COMPLETION_SUMMARY_UNAVAILABLE,
+	completionBodyWithoutPromptEcho,
+	formatUsageStats,
 	framedComponent,
 	framedMessage,
 	oneLinePreview,
@@ -159,16 +162,27 @@ export function formatTaskRecordResult(record: PaneTaskRecord, verbose = false):
 	const files = record.filesChanged?.length ? record.filesChanged.map((file) => `- ${file}`).join("\n") : "None reported";
 	const validation = record.validation?.length ? record.validation.map((item) => `- ${item}`).join("\n") : "None reported";
 	const diagnostics = record.diagnostics?.length ? record.diagnostics.map((item) => `- ${item}`).join("\n") : "";
+	const terminal = record.status === "completed" || record.status === "failed" || record.status === "blocked";
+	const summary = record.summary?.trim()
+		? completionBodyWithoutPromptEcho(record.summary, record.task)
+		: record.status === "needs_completion"
+			? "Task turn ended without a valid completion record; see diagnostics."
+			: terminal
+				? COMPLETION_SUMMARY_UNAVAILABLE
+				: "No summary yet.";
+	const usage = record.usage ? formatUsageStats(record.usage, record.model) : "";
 	const metaParts = [
 		`Status: **${record.status}**`,
+		record.model ? `Model: ${record.model}` : "",
+		usage ? `Usage: ${usage}` : "",
 		record.completedAt ? `Completed: ${record.completedAt}` : record.updatedAt ? `Updated: ${record.updatedAt}` : `Created: ${record.createdAt}`,
-	];
+	].filter(Boolean);
 	const lines = [
 		`## ${record.agent} · ${record.taskId}`,
 		metaParts.join(" · "),
 		"",
 		"### Summary",
-		record.summary || (record.status === "needs_completion" ? "Task turn ended without a valid completion record; see diagnostics." : "No summary yet."),
+		summary,
 		"",
 		"### Files Changed",
 		files,

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/runner.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/runner.ts
@@ -780,12 +780,14 @@ async function runSingleAgentAttempt(
 			return currentResult;
 		}
 		const failed = exitCode !== 0 || currentResult.stopReason === "error" || currentResult.stopReason === "aborted";
+		const finalOutput = getFinalOutput(currentResult.messages);
 		emitSubagentEvent(pi, failed ? "subagents:failed" : "subagents:completed", {
 			mode: "oneshot",
 			agent: agent.name,
 			taskId: oneShotTaskId,
 			task,
 			status: failed ? "failed" : "completed",
+			...(finalOutput ? { summary: finalOutput, finalOutput } : {}),
 			runtimeRoot,
 			transcriptPath,
 			model: currentResult.model,

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/runner.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/runner.ts
@@ -725,16 +725,19 @@ async function runSingleAgentAttempt(
 		if (wasAborted) {
 			currentResult.stopReason = "aborted";
 			currentResult.errorMessage = "Agent was aborted";
+			const summary = "Agent was aborted before completion.";
 			emitSubagentEvent(pi, "subagents:failed", {
 				mode: "oneshot",
 				agent: agent.name,
 				taskId: oneShotTaskId,
 				task,
 				status: "aborted",
+				summary,
 				runtimeRoot,
 				transcriptPath,
 				model: currentResult.model,
 				usage: currentResult.usage,
+				error: currentResult.errorMessage || "Agent was aborted",
 				sessionKey: session.key,
 				sessionPath: session.path,
 				ephemeralSession: session.ephemeral,

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/subagent-render.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/subagent-render.ts
@@ -31,7 +31,7 @@ import {
 } from "./types.js";
 
 export const subagentToolRenderers = {
-	renderCall(args, theme, _context) {
+	renderCall(args: any, theme: any, _context: any) {
 		const scope: AgentScope = args.agentScope ?? "project";
 		if (args.chain && args.chain.length > 0) {
 			let text =
@@ -69,7 +69,7 @@ export const subagentToolRenderers = {
 		return wrappedText(text);
 	},
 
-	renderResult(result, { expanded }, theme, context) {
+	renderResult(result: any, { expanded }: { expanded?: boolean }, theme: any, context: any) {
 		const cwd = context?.cwd;
 		const collapsedItemCount = Math.max(1, Math.floor(settingNumber("collapsedItemCount", COLLAPSED_ITEM_COUNT, context?.cwd)));
 		const details = result.details as SubagentDetails | undefined;

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/tasks.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/tasks.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { atomicWriteFile, withCrossProcessFileLock } from "./file-lock.js";
-import { stringifyError } from "./format.js";
+import { readLastAssistantTextFromTranscript, stringifyError } from "./format.js";
 import { safeFileName } from "./names.js";
 import {
 	completionArchiveDir,
@@ -180,6 +180,51 @@ export function appendUniqueDiagnostic(existing: string[] | undefined, diagnosti
 	const diagnostics = [...(existing ?? [])];
 	if (!diagnostics.includes(compact)) diagnostics.push(compact);
 	return diagnostics.slice(-8);
+}
+
+export function taskNeedsSummaryBackfill(record: PaneTaskRecord): boolean {
+	return isTerminalTaskStatus(record.status) && !record.summary?.trim() && Boolean(record.transcriptPath);
+}
+
+export async function backfillTaskSummaryFromTranscript(
+	runtimeRoot: string,
+	record: PaneTaskRecord,
+	options: { timeoutMs?: number; maxBytes?: number } = {},
+): Promise<{ diagnostic?: string; record: PaneTaskRecord; updated: boolean }> {
+	if (!taskNeedsSummaryBackfill(record)) return { record, updated: false };
+	let summary: string | undefined;
+	try {
+		summary = await readLastAssistantTextFromTranscript(record.transcriptPath, { timeoutMs: options.timeoutMs ?? 5_000, maxBytes: options.maxBytes });
+	} catch (error) {
+		const diagnostic = `Summary backfill failed for ${record.taskId}: ${stringifyError(error)}`;
+		let updated = record;
+		await updateTaskRegistry(runtimeRoot, (records) => {
+			const existing = records[record.taskId] ?? record;
+			updated = {
+				...existing,
+				diagnostics: appendUniqueDiagnostic(existing.diagnostics, diagnostic),
+				updatedAt: new Date().toISOString(),
+			};
+			records[record.taskId] = updated;
+		});
+		return { diagnostic, record: updated, updated: true };
+	}
+	if (!summary) return { record, updated: false };
+	let updated = record;
+	await updateTaskRegistry(runtimeRoot, (records) => {
+		const existing = records[record.taskId] ?? record;
+		if (existing.summary?.trim()) {
+			updated = existing;
+			return;
+		}
+		updated = {
+			...existing,
+			summary,
+			updatedAt: new Date().toISOString(),
+		};
+		records[record.taskId] = updated;
+	});
+	return { record: updated, updated: updated.summary === summary };
 }
 
 export function completionParseErrorMessage(filePath: string, error: unknown): string {

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/tasks.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/tasks.ts
@@ -186,6 +186,17 @@ export function taskNeedsSummaryBackfill(record: PaneTaskRecord): boolean {
 	return isTerminalTaskStatus(record.status) && !record.summary?.trim() && Boolean(record.transcriptPath);
 }
 
+function hasBlankSummaryField(record: PaneTaskRecord): boolean {
+	if (!Object.prototype.hasOwnProperty.call(record, "summary")) return false;
+	const value = (record as { summary?: unknown }).summary;
+	return value === null || value === undefined || (typeof value === "string" && value.trim() === "");
+}
+
+function omitSummary(record: PaneTaskRecord): PaneTaskRecord {
+	const { summary: _summary, ...rest } = record;
+	return rest;
+}
+
 export async function backfillTaskSummaryFromTranscript(
 	runtimeRoot: string,
 	record: PaneTaskRecord,
@@ -195,21 +206,23 @@ export async function backfillTaskSummaryFromTranscript(
 	let summary: string | undefined;
 	try {
 		summary = await readLastAssistantTextFromTranscript(record.transcriptPath, { timeoutMs: options.timeoutMs ?? 5_000, maxBytes: options.maxBytes });
-	} catch (error) {
-		const diagnostic = `Summary backfill failed for ${record.taskId}: ${stringifyError(error)}`;
-		let updated = record;
+	} catch {
+		return { record, updated: false };
+	}
+	if (!summary) {
+		if (!hasBlankSummaryField(record)) return { record, updated: false };
+		let updated = omitSummary(record);
 		await updateTaskRegistry(runtimeRoot, (records) => {
 			const existing = records[record.taskId] ?? record;
-			updated = {
-				...existing,
-				diagnostics: appendUniqueDiagnostic(existing.diagnostics, diagnostic),
-				updatedAt: new Date().toISOString(),
-			};
+			if (!hasBlankSummaryField(existing)) {
+				updated = existing;
+				return;
+			}
+			updated = { ...omitSummary(existing), updatedAt: new Date().toISOString() };
 			records[record.taskId] = updated;
 		});
-		return { diagnostic, record: updated, updated: true };
+		return { record: updated, updated: updated.summary === undefined };
 	}
-	if (!summary) return { record, updated: false };
 	let updated = record;
 	await updateTaskRegistry(runtimeRoot, (records) => {
 		const existing = records[record.taskId] ?? record;

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/types.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/types.ts
@@ -340,6 +340,7 @@ export type PaneTaskRegistry = Record<string, PaneTaskRecord>;
 
 export type DashboardDisplayMode = "compact" | "normal" | "expanded";
 export type DashboardKind = "pane" | "oneshot";
+export type CompletionMessageProvenance = "persisted" | "task-echo-fallback" | "fallback" | "placeholder" | "diagnostic";
 
 export type SubagentDashboardStatus = PaneTaskStatus | "running" | "waiting";
 
@@ -350,6 +351,7 @@ export interface SubagentDashboardItem {
 	completedAt?: string;
 	kind: DashboardKind;
 	message?: string;
+	messageProvenance?: CompletionMessageProvenance;
 	paneId?: string;
 	startedAt?: string;
 	status: SubagentDashboardStatus;

--- a/pi-extensions/pi-agents-tmux/instructions.md
+++ b/pi-extensions/pi-agents-tmux/instructions.md
@@ -14,6 +14,7 @@ Calling rules:
 - Agent names are inventory-checked before launch for the selected `agentScope`. Missing names fail fast with available project/user agents; no similar-name redirect is attempted.
 - Persistent-pane (`pane: true`) dispatches return immediately with a `taskId` for follow-up collection. **End your turn after dispatching.** The completion arrives as a follow-up message that wakes you in a new turn — do not call `get_subagent_result` with `wait: true` to block, unless the user asked.
 - Save the `taskId`; use `get_subagent_result` only if you suspect a missed wake event. For pane-idle waits, use `wait_for_subagent_idle` (or `get_subagent_result` with `waitFor: "idle"`) instead of shell polling loops; it distinguishes `idle-after-busy` from `never-busy`.
+- Dashboard, chat, history, and `get_subagent_result` use persisted task summaries. If a summary is unavailable, inspect the transcript path shown with the task id instead of treating the original request as the result.
 - If a bg subagent hits `context_length_exceeded`, the extension retries once in a fresh one-shot lane and returns both attempt summaries if the retry also fails.
 - If a bg subagent returns `needs_completion` with `reason: "compact-then-empty"`, inspect `cwdSnapshot.head`, `cwdSnapshot.dirty`, and `cwdSnapshot.lastCommit.subject` before deciding whether the subagent's work completed.
 - Stopping kills the tmux process but preserves the session file; the next default `subagent` call resumes it. Pass `forceSpawn: true` only when the user wants a fresh session.

--- a/pi-extensions/pi-agents-tmux/tests/dashboard-ux.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/dashboard-ux.test.ts
@@ -62,6 +62,60 @@ test("completed one-shot record backfills summary from transcript final assistan
 	assert.equal((await readTaskRegistry(runtimeRoot))[taskId]?.summary, "Final summary\nwith details");
 });
 
+test("summary backfill skips corrupt transcript without changing record", async () => {
+	const runtimeRoot = tempRuntime();
+	const taskId = "reviewer-arch-corrupt";
+	const transcriptPath = join(runtimeRoot, "corrupt.jsonl");
+	writeFileSync(transcriptPath, "{not json\n");
+	const taskRecord = record("reviewer-arch", taskId, "2026-05-14T05:00:00.000Z", { transcriptPath });
+	await updateTaskRegistry(runtimeRoot, (records) => { records[taskId] = taskRecord; });
+
+	const result = await backfillTaskSummaryFromTranscript(runtimeRoot, taskRecord);
+	assert.equal(result.updated, false);
+	assert.deepEqual(result.record, taskRecord);
+	assert.deepEqual((await readTaskRegistry(runtimeRoot))[taskId], taskRecord);
+});
+
+test("summary backfill skips missing transcript without changing record", async () => {
+	const runtimeRoot = tempRuntime();
+	const taskId = "reviewer-arch-missing";
+	const taskRecord = record("reviewer-arch", taskId, "2026-05-14T05:00:00.000Z", { transcriptPath: join(runtimeRoot, "missing.jsonl") });
+	await updateTaskRegistry(runtimeRoot, (records) => { records[taskId] = taskRecord; });
+
+	const result = await backfillTaskSummaryFromTranscript(runtimeRoot, taskRecord);
+	assert.equal(result.updated, false);
+	assert.deepEqual(result.record, taskRecord);
+	assert.deepEqual((await readTaskRegistry(runtimeRoot))[taskId], taskRecord);
+});
+
+test("blank summary with valid transcript but no assistant text is removed", async () => {
+	const runtimeRoot = tempRuntime();
+	const taskId = "reviewer-arch-blank";
+	const transcriptPath = join(runtimeRoot, "no-assistant.jsonl");
+	writeFileSync(transcriptPath, JSON.stringify({ type: "message", message: { role: "user", content: "hello" } }));
+	const taskRecord = record("reviewer-arch", taskId, "2026-05-14T05:00:00.000Z", { summary: "   ", transcriptPath });
+	await updateTaskRegistry(runtimeRoot, (records) => { records[taskId] = taskRecord; });
+
+	const result = await backfillTaskSummaryFromTranscript(runtimeRoot, taskRecord);
+	assert.equal(result.updated, true);
+	assert.equal(Object.prototype.hasOwnProperty.call(result.record, "summary"), false);
+	assert.equal(Object.prototype.hasOwnProperty.call((await readTaskRegistry(runtimeRoot))[taskId]!, "summary"), false);
+});
+
+test("existing nonblank summary is not overwritten by transcript backfill", async () => {
+	const runtimeRoot = tempRuntime();
+	const taskId = "reviewer-arch-existing";
+	const transcriptPath = join(runtimeRoot, "assistant.jsonl");
+	writeFileSync(transcriptPath, JSON.stringify({ type: "message", message: { role: "assistant", content: [{ type: "text", text: "transcript text" }] } }));
+	const taskRecord = record("reviewer-arch", taskId, "2026-05-14T05:00:00.000Z", { summary: "some text", transcriptPath });
+	await updateTaskRegistry(runtimeRoot, (records) => { records[taskId] = taskRecord; });
+
+	const result = await backfillTaskSummaryFromTranscript(runtimeRoot, taskRecord);
+	assert.equal(result.updated, false);
+	assert.equal(result.record.summary, "some text");
+	assert.equal((await readTaskRegistry(runtimeRoot))[taskId]?.summary, "some text");
+});
+
 test("chat completion synthesis never echoes delegation prompt and annotates task id data", () => {
 	const taskId = "reviewer-test-1700000000-77abfc41";
 	const item: SubagentDashboardItem = {

--- a/pi-extensions/pi-agents-tmux/tests/dashboard-ux.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/dashboard-ux.test.ts
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import type { AgentConfig } from "../extensions/subagent/agents.js";
+import {
+	appendBgChatMessages,
+	buildAgentRows,
+	historyRecordLabel,
+	readTranscriptTail,
+	taskNumberById,
+} from "../extensions/subagent/browser.js";
+import { COMPLETION_SUMMARY_UNAVAILABLE, extractLastAssistantTextFromTranscriptContent } from "../extensions/subagent/format.js";
+import { oneShotTranscriptPath } from "../extensions/subagent/paths.js";
+import {
+	backfillTaskSummaryFromTranscript,
+	readTaskRegistry,
+	updateTaskRegistry,
+} from "../extensions/subagent/tasks.js";
+import type { ChatMessage, PaneTaskRecord, SubagentDashboardItem } from "../extensions/subagent/types.js";
+
+function tempRuntime(): string {
+	return mkdtempSync(join(tmpdir(), "pi-agents-dashboard-ux-"));
+}
+
+function record(agent: string, taskId: string, createdAt: string, patch: Partial<PaneTaskRecord> = {}): PaneTaskRecord {
+	return {
+		taskId,
+		agent,
+		task: `Task for ${agent}`,
+		status: "completed",
+		createdAt,
+		completedAt: createdAt,
+		updatedAt: createdAt,
+		...patch,
+	};
+}
+
+function agent(name: string, pane = false): AgentConfig {
+	return { name, pane, description: `${name} agent`, systemPrompt: "", source: "project", filePath: `${name}.md` };
+}
+
+test("completed one-shot record backfills summary from transcript final assistant text", async () => {
+	const runtimeRoot = tempRuntime();
+	const taskId = "reviewer-arch-1700000000-77abfc41";
+	const transcriptPath = oneShotTranscriptPath(runtimeRoot, "reviewer-arch", taskId);
+	mkdirSync(dirname(transcriptPath), { recursive: true });
+	writeFileSync(transcriptPath, [
+		JSON.stringify({ type: "message", message: { role: "assistant", content: [{ type: "text", text: "Early output" }] } }),
+		JSON.stringify({ ts: "2026-05-14T05:02:00.000Z", event: { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "Final summary\nwith details" }] } } }),
+	].join("\n"));
+	await updateTaskRegistry(runtimeRoot, (records) => {
+		records[taskId] = record("reviewer-arch", taskId, "2026-05-14T05:00:00.000Z", { transcriptPath });
+	});
+
+	const result = await backfillTaskSummaryFromTranscript(runtimeRoot, (await readTaskRegistry(runtimeRoot))[taskId]!);
+	assert.equal(result.updated, true);
+	assert.equal(result.record.summary, "Final summary\nwith details");
+	assert.equal((await readTaskRegistry(runtimeRoot))[taskId]?.summary, "Final summary\nwith details");
+});
+
+test("chat completion synthesis never echoes delegation prompt and annotates task id data", () => {
+	const taskId = "reviewer-test-1700000000-77abfc41";
+	const item: SubagentDashboardItem = {
+		agent: "reviewer-test",
+		kind: "oneshot",
+		message: "Check test coverage",
+		status: "completed",
+		task: "Check test coverage",
+		taskId,
+		startedAt: "2026-05-14T05:00:00.000Z",
+		completedAt: "2026-05-14T05:02:00.000Z",
+		updatedAt: "2026-05-14T05:02:00.000Z",
+	};
+	const messages: ChatMessage[] = [];
+	appendBgChatMessages(messages, [item]);
+
+	const completion = messages.find((message) => message.kind === "completion");
+	assert.equal(completion?.body, COMPLETION_SUMMARY_UNAVAILABLE);
+	assert.equal(completion?.taskId, taskId);
+});
+
+test("history labels number repeated same-agent tasks latest-first friendly", () => {
+	const first = record("reviewer-arch", "reviewer-arch-1700000000-11111111", "2026-05-14T05:00:00.000Z");
+	const second = record("reviewer-arch", "reviewer-arch-1700000120-77abfc41", "2026-05-14T05:02:00.000Z");
+	const numbers = taskNumberById([second, first]);
+
+	assert.equal(numbers.get(first.taskId), 1);
+	assert.equal(numbers.get(second.taskId), 2);
+	assert.match(historyRecordLabel(second, numbers), /reviewer-arch #2 · \d{2}:\d{2} · 77abfc41/);
+});
+
+test("agent rows include pane task children sharing one transcript", () => {
+	const sessionFile = join(tempRuntime(), "sessions", "planner.jsonl");
+	const first = record("planner", "planner-1700000000-aaaaaaaa", "2026-05-14T05:00:00.000Z", { kind: "pane", paneId: "%1", transcriptPath: sessionFile });
+	const second = record("planner", "planner-1700000120-bbbbbbbb", "2026-05-14T05:02:00.000Z", { kind: "pane", paneId: "%1", transcriptPath: sessionFile });
+	const rows = buildAgentRows([agent("planner", true)], "", new Map(), [], { [first.taskId]: first, [second.taskId]: second });
+
+	assert.equal(rows[0]?.rowType, "agent");
+	const taskRows = rows.filter((row) => row.rowType === "task");
+	assert.equal(taskRows.length, 2);
+	assert.deepEqual(taskRows.map((row) => row.item?.transcriptPath), [sessionFile, sessionFile]);
+	assert.match(taskRows[0]!.label, /#2/);
+	assert.match(taskRows[1]!.label, /#1/);
+});
+
+test("transcript tail preserves multiline assistant text and tool JSON structure", () => {
+	const runtimeRoot = tempRuntime();
+	const transcriptPath = join(runtimeRoot, "transcript.jsonl");
+	writeFileSync(transcriptPath, [
+		JSON.stringify({ ts: "2026-05-14T05:00:00.000Z", event: { type: "turn_start" } }),
+		JSON.stringify({ ts: "2026-05-14T05:00:01.000Z", event: { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "line one\nline two" }] } } }),
+		JSON.stringify({ ts: "2026-05-14T05:00:02.000Z", event: { type: "message_end", message: { role: "assistant", content: [{ type: "toolCall", name: "bash", arguments: { command: "echo hi" } }] } } }),
+	].join("\n"));
+
+	const tail = readTranscriptTail(transcriptPath, 40).join("\n");
+	assert.match(tail, /assistant/);
+	assert.match(tail, /line one\nline two/);
+	assert.match(tail, /tool call bash/);
+	assert.match(tail, /"command": "echo hi"/);
+	assert.equal(extractLastAssistantTextFromTranscriptContent(tail), undefined);
+});

--- a/pi-extensions/pi-agents-tmux/tests/dashboard-ux.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/dashboard-ux.test.ts
@@ -164,6 +164,51 @@ test("full persisted one-shot summary feeds chat history and result formatting",
 	assert.match(formatTaskRecordResult(taskRecord), new RegExp(longSummary.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
 });
 
+test("persisted summary equal to task text is not suppressed", () => {
+	const taskId = "reviewer-arch-echo";
+	const task = "repeat this exact sentence";
+	const taskRecord = record("reviewer-arch", taskId, "2026-05-14T05:00:00.000Z", { task, summary: task });
+	const item: SubagentDashboardItem = {
+		agent: "reviewer-arch",
+		kind: "oneshot",
+		message: task,
+		messageProvenance: "persisted",
+		status: "completed",
+		task,
+		taskId,
+		startedAt: taskRecord.createdAt,
+		completedAt: taskRecord.completedAt,
+		updatedAt: taskRecord.updatedAt!,
+	};
+	const messages: ChatMessage[] = [];
+	appendBgChatMessages(messages, [item], { [taskId]: taskRecord });
+
+	assert.equal(messages.find((message) => message.kind === "completion")?.body, task);
+});
+
+test("task echo fallback is suppressed but different fallback renders", () => {
+	const taskId = "reviewer-arch-fallback";
+	const task = "review this exact text";
+	const echoItem: SubagentDashboardItem = {
+		agent: "reviewer-arch",
+		kind: "oneshot",
+		message: task,
+		messageProvenance: "task-echo-fallback",
+		status: "completed",
+		task,
+		taskId,
+		startedAt: "2026-05-14T05:00:00.000Z",
+		completedAt: "2026-05-14T05:01:00.000Z",
+		updatedAt: "2026-05-14T05:01:00.000Z",
+	};
+	const differentItem = { ...echoItem, taskId: "reviewer-arch-different", message: "actual completion body" };
+	const messages: ChatMessage[] = [];
+	appendBgChatMessages(messages, [echoItem, differentItem]);
+
+	assert.equal(messages.find((message) => message.taskId === echoItem.taskId && message.kind === "completion")?.body, COMPLETION_SUMMARY_UNAVAILABLE);
+	assert.equal(messages.find((message) => message.taskId === differentItem.taskId && message.kind === "completion")?.body, "actual completion body");
+});
+
 test("history labels number repeated same-agent tasks latest-first friendly", () => {
 	const first = record("reviewer-arch", "reviewer-arch-1700000000-11111111", "2026-05-14T05:00:00.000Z");
 	const second = record("reviewer-arch", "reviewer-arch-1700000120-77abfc41", "2026-05-14T05:02:00.000Z");

--- a/pi-extensions/pi-agents-tmux/tests/dashboard-ux.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/dashboard-ux.test.ts
@@ -10,9 +10,11 @@ import {
 	historyRecordLabel,
 	readTranscriptTail,
 	taskNumberById,
+	traceViewerItems,
 } from "../extensions/subagent/browser.js";
-import { COMPLETION_SUMMARY_UNAVAILABLE, extractLastAssistantTextFromTranscriptContent } from "../extensions/subagent/format.js";
+import { COMPLETION_SUMMARY_UNAVAILABLE, extractLastAssistantTextFromTranscriptContent, oneLinePreview } from "../extensions/subagent/format.js";
 import { oneShotTranscriptPath } from "../extensions/subagent/paths.js";
+import { formatTaskRecordResult } from "../extensions/subagent/renderers.js";
 import {
 	backfillTaskSummaryFromTranscript,
 	readTaskRegistry,
@@ -79,6 +81,33 @@ test("chat completion synthesis never echoes delegation prompt and annotates tas
 	const completion = messages.find((message) => message.kind === "completion");
 	assert.equal(completion?.body, COMPLETION_SUMMARY_UNAVAILABLE);
 	assert.equal(completion?.taskId, taskId);
+});
+
+test("full persisted one-shot summary feeds chat history and result formatting", async () => {
+	const taskId = "reviewer-arch-1700000000-77abfc41";
+	const longSummary = Array.from({ length: 80 }, (_, index) => `finding-${index}`).join(" ");
+	assert.ok(longSummary.length > 600);
+	const taskRecord = record("reviewer-arch", taskId, "2026-05-14T05:00:00.000Z", {
+		summary: longSummary,
+		transcriptPath: "/tmp/reviewer-arch.jsonl",
+	});
+	const item: SubagentDashboardItem = {
+		agent: "reviewer-arch",
+		kind: "oneshot",
+		message: oneLinePreview(longSummary, 120),
+		status: "completed",
+		task: taskRecord.task,
+		taskId,
+		startedAt: taskRecord.createdAt,
+		completedAt: taskRecord.completedAt,
+		updatedAt: taskRecord.updatedAt!,
+	};
+	const messages: ChatMessage[] = [];
+	appendBgChatMessages(messages, [item], { [taskId]: taskRecord });
+
+	assert.equal(messages.find((message) => message.kind === "completion")?.body, longSummary);
+	assert.match((await traceViewerItems(taskRecord))[0]!.text, new RegExp(longSummary.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+	assert.match(formatTaskRecordResult(taskRecord), new RegExp(longSummary.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
 });
 
 test("history labels number repeated same-agent tasks latest-first friendly", () => {

--- a/pi-extensions/pi-agents-tmux/tests/preload.ts
+++ b/pi-extensions/pi-agents-tmux/tests/preload.ts
@@ -60,6 +60,9 @@ mock.module("@earendil-works/pi-tui", () => {
 	return {
 		Container,
 		Markdown: Container,
+		matchesKey() {
+			return false;
+		},
 		Spacer,
 		truncateToWidth(text: string, width: number, suffix = "") {
 			return text.length > width ? `${text.slice(0, Math.max(0, width - suffix.length))}${suffix}` : text;

--- a/pi-extensions/pi-agents-tmux/tests/session-lanes.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/session-lanes.test.ts
@@ -202,6 +202,40 @@ test("context_length_exceeded detection triggers one retry with fresh session", 
 	}
 });
 
+test("aborted oneshot emits failed event with summary", async () => {
+	const emitted: Array<{ name: string; payload: any }> = [];
+	const calls = installMockSpawn([{ code: 0 }]);
+	const controller = new AbortController();
+	controller.abort();
+	try {
+		await assert.rejects(
+			runSingleAgent(
+				process.cwd(),
+				tempRuntime(),
+				[testAgent()],
+				"reviewer-test",
+				"review code",
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				mockPiEvents(emitted),
+				controller.signal,
+				undefined,
+				makeDetails,
+			),
+			/Agent was aborted/,
+		);
+		assert.equal(calls.length, 1);
+		const failed = emitted.find((event) => event.name === "subagents:failed");
+		assert.ok(failed);
+		assert.equal(failed.payload.summary, "Agent was aborted before completion.");
+		assert.equal(failed.payload.error, "Agent was aborted");
+	} finally {
+		setSingleAgentSpawnForTests();
+	}
+});
+
 test("session_compact followed by empty agent_end emits synthetic needs_completion", async () => {
 	const cwd = tempGitRepo();
 	const emitted: Array<{ name: string; payload: any }> = [];


### PR DESCRIPTION
Closes #45.

`pi-agents-tmux` dashboard summary / chat / task UX overhaul. Addresses all six problem areas in the issue body: summary persistence, chat dedupe, history task numbering + metadata, multi-task UX with task children, transcript tail readability, single source of truth.

## What changed

- **Summary persistence** (`runner.ts`, `dispatch.ts`, `tasks.ts`, `index.ts`): one-shot/background completions persist `summary` (and structured fields where extractable) into `PaneTaskRecord` on every completion path. `get_subagent_result`, History Summary, Dashboard rows, and Chat completion all read from the same field. Fallback chain (`record.summary || record.diagnostics?.at(-1) || record.task`) no longer diverges per consumer.
- **Transcript backfill** (`pane-support-tools.ts`, `tasks.ts`): on `session_start` / `syncDashboardFromTaskRegistry` / `get_subagent_result`, completed records with `transcriptPath` but missing summary parse the last assistant text from the transcript and update the record + dashboard. Bounded (2 MB / 5 s per file), idempotent (skips records that already have summary), and tolerant of corrupt or truncated JSONL. Blank summaries are normalized so consumer fallback chains run correctly.
- **Chat dedupe with provenance** (`browser.ts`, `format.ts`): completion rows render the persisted summary or an explicit placeholder ("completion summary unavailable; see transcript"), never the delegation prompt as a fallback. Provenance-aware: a legitimate final response that happens to equal the task prompt is preserved (persisted summary wins); only fallback-derived task-text echoes are replaced. Every chat row is annotated with a short task id.
- **History UI** (`browser.ts`, `renderers.ts`): left list renders `✓ reviewer-arch #2 · 05:02 · 77abfc41` shape — status, task number, timestamp, short task id. Latest first. Detail Summary subtab leads with a compact metadata block (agent, task #, task id, status, created/completed, model, turns/tokens/cost, transcript path, completion/archive path).
- **Multi-task UX**: agent rows include recent task children keyed by `taskId`. Selecting agent defaults to latest task; selecting child pins Live/Chat/History to that task. Pane agents sharing one transcript expose task ids without losing the shared-transcript view.
- **Transcript tail readability** (`format.ts`): preserves multiline assistant text; adds visual separators for turn boundaries, user vs assistant, tool call groups, exit/error events. Uses existing `Markdown`/highlight helpers + `wrapTextWithAnsi()`. Malformed JSONL lines render as raw with a graceful JSON stringify fallback (no rendering throw).
- **Abort path observability**: aborted runs now emit `subagents:failed` with `error` and a "Agent was aborted before completion" summary so History detail and Chat render a real explanation.

## Review chain

- **Round 1** (4 commits) — reviewer-arch + reviewer-error in parallel:
  - 2 blockers (reviewer-error): full summaries clobbered by 120-char dashboard previews; backfill leaves `summary: ""` intact.
  - 2 majors (reviewer-arch): Chat not single-source-of-truth (pane chat reads completion JSON files, bg chat reads dashboard `item.message`); prompt-echo dedupe is overbroad (suppresses legitimate identical-to-prompt summaries).
  - 1 minor (reviewer-arch): abort path emits failed without summary/error.
  - All 5 folded into round-2 commits.
- **Round 2** (3 commits): `da811c4` preserves full summary at source + truncates only at render boundary; `bcdac69` normalizes blank summaries through transcript backfill; `6a26d76` adds provenance-aware task-echo dedupe + abort summary. Tests + typecheck green before every commit.
- **Round 3** (reviewer-doc final): no findings. README hygiene clean (3 user-facing feature bullets, no jargon); instructions.md gained one actionable bullet about persisted summaries + transcript-path fallback; DEVELOPMENT.md gained dashboard summary persistence + task children sections; `package.json` untouched; activity plan already references the `pi-agents-tmux` summary surface.

## Tests

`npx tsc --noEmit --target ES2022 --module NodeNext --moduleResolution NodeNext --types node --skipLibCheck extensions/subagent/*.ts && npm pack --dry-run && bun test --preload ./tests/preload.ts ./tests` — green before every commit and once more at the end. New coverage in `tests/dashboard-ux.test.ts` (251 lines) + extensions to `tests/session-lanes.test.ts` (34 lines):
- Summary persistence on one-shot/parallel/chain completion paths.
- Transcript backfill happy path + corrupt JSONL + missing transcript + already-has-summary skip + blank-summary normalize.
- Chat dedupe: persisted summary == task text → preserved; fallback == task text → placeholder.
- Repeated same-agent tasks rendering with stable task numbers.
- Pane agent with multiple task ids sharing one transcript.
- Transcript tail rendering preserves structure (markdown, tool calls, JSON, errors).

## Out of scope (intentional)

- Pi extension version bump. Per session convention, version bumps happen at deploy time.
- Activity plan cross-reference for `PaneTaskRecord.summary` provenance — the plan already references the field; provenance-aware dedupe is a producer detail that doesn't change the activity event shape.

## Notes

7 commits. Worktree created via `skills/worktree/scripts/worktree create fix-pi-agents-dashboard-ux`, scratch in `<worktree>/tmp/`. Engineer dispatched via `flightdeck-session start --harness pi --prompt`; reviews delivered via `pi-bridge follow-up`. `vstack refresh -g` to be run post-merge so the global Pi install picks up the new pi-agents-tmux source state.
