### PR TITLE
perf(pi-extension-manager): defer npm-root spawns on /extensions popup open (fixes #74)

### DIFF
--- a/pi-extensions/pi-extension-manager/extensions/manager/inventory.ts
+++ b/pi-extensions/pi-extension-manager/extensions/manager/inventory.ts
@@ -9,11 +9,11 @@ import {
 	isNewer,
 	loadNpmCache,
 	loadSourceIndex,
-	npmPackageDirCandidates,
 	npmInstalledVersion,
 	npmPackageNameFromSource,
 	readPackageVersionFromDir,
 	readSourceRepoVersion,
+	resolveNpmPackageDir,
 } from "./versions.js";
 import {
 	type Inventory,
@@ -34,6 +34,12 @@ function readPackageManifest(dir: string): { manifest?: PackageManifest; error?:
 	} catch (error) {
 		return { error: stringifyError(error) };
 	}
+}
+
+function readNpmPackageManifest(npmName: string, scope: Scope, baseDir: string, cwd: string): { dir?: string; manifest?: PackageManifest; error?: string } {
+	const dir = resolveNpmPackageDir(npmName, scope, baseDir, cwd);
+	if (!dir) return { error: `package source not found: npm:${npmName}` };
+	return { dir, ...readPackageManifest(dir) };
 }
 
 function readFirstPackageManifest(dirs: string[]): { dir?: string; manifest?: PackageManifest; error?: string } {
@@ -275,7 +281,7 @@ export function buildInventory(_pi: ExtensionAPI, ctx: ExtensionContext): Invent
 				manifest = read.manifest;
 				brokenError = read.error;
 			} else if (npmName) {
-				const read = readFirstPackageManifest(npmPackageDirCandidates(npmName, file.scope, file.baseDir, ctx.cwd));
+				const read = readNpmPackageManifest(npmName, file.scope, file.baseDir, ctx.cwd);
 				packageDir = read.dir ?? normalized.resolved;
 				manifest = read.manifest ?? { name: npmName, description: "External npm package source" };
 				brokenError = read.error;
@@ -295,6 +301,7 @@ export function buildInventory(_pi: ExtensionAPI, ctx: ExtensionContext): Invent
 				description: manifest?.description ?? "Pi package",
 				displayName: packageDisplayName(manifest ?? {}, packageName),
 				id: pkgId,
+				installedVersion: typeof manifest?.version === "string" ? manifest.version : undefined,
 				kind: "package",
 				packageDir,
 				packageName,
@@ -347,7 +354,10 @@ export function buildInventory(_pi: ExtensionAPI, ctx: ExtensionContext): Invent
 
 	for (const item of items) {
 		if (item.kind !== "package" || !item.packageName) continue;
-		item.installedVersion = readPackageVersionFromDir(item.packageDir);
+		// Manifest was already parsed above when building the inventory entry; the version
+		// is recorded on the item to avoid a second readFileSync+JSON.parse pass per
+		// package on popup open (vstack#74).
+		if (!item.installedVersion) item.installedVersion = readPackageVersionFromDir(item.packageDir);
 	}
 	applyUpdateMetadata(items, settingsFiles, ctx.cwd);
 

--- a/pi-extensions/pi-extension-manager/extensions/manager/versions.ts
+++ b/pi-extensions/pi-extension-manager/extensions/manager/versions.ts
@@ -6,6 +6,20 @@ import { NPM_CACHE_TTL_MS, type NpmCache, type Scope, type SettingsFile, type So
 
 let npmCheckInFlight = false;
 
+// `npm root [args]` is slow (Node + npm config bootstrap, typically 40-500ms each). The
+// answer is invariant for the process lifetime, so memoize. Without this, opening the
+// extension manager popup spawned 2-5 `npm root` invocations per npm-sourced package
+// (vstack#74).
+const npmRootMemo = new Map<string, string | undefined>();
+
+function npmRootCacheKey(args: string[], cwd?: string): string {
+	return `${args.join("\x00")}\x01${cwd ?? ""}`;
+}
+
+export function __resetNpmRootCacheForTests(): void {
+	npmRootMemo.clear();
+}
+
 export function loadSourceIndex(settingsFiles: SettingsFile[]): SourceIndex {
 	const merged: SourceIndex = {};
 	for (const file of settingsFiles) {
@@ -85,9 +99,12 @@ export function readSourceRepoVersion(repoRoot: string, packageName: string, sou
 }
 
 function npmRoot(args: string[], cwd?: string): string | undefined {
+	const key = npmRootCacheKey(args, cwd);
+	if (npmRootMemo.has(key)) return npmRootMemo.get(key);
 	const result = spawnSync("npm", ["root", ...args], { encoding: "utf8", cwd });
-	if (result.error || (result.status ?? 1) !== 0) return undefined;
-	return (result.stdout ?? "").trim() || undefined;
+	const value = result.error || (result.status ?? 1) !== 0 ? undefined : ((result.stdout ?? "").trim() || undefined);
+	npmRootMemo.set(key, value);
+	return value;
 }
 
 function npmPrefixRoot(): string | undefined {
@@ -99,27 +116,57 @@ export function npmPackageDir(root: string, npmName: string): string {
 	return join(root, ...npmName.split("/"));
 }
 
-export function npmPackageDirCandidates(npmName: string, scope: Scope, baseDir: string, cwd: string): string[] {
-	const roots = new Set<string>();
+// Two-tier lookup: cheap candidates first (filesystem + env), expensive `npm root`
+// spawns only as fallback. Returns ordered roots; the caller short-circuits on first
+// existing dir (see `resolveNpmPackageDir`).
+function cheapNpmRoots(scope: Scope, baseDir: string): string[] {
+	const roots: string[] = [];
 	if (scope === "project") {
-		roots.add(join(baseDir, "npm", "node_modules"));
-		const projectRoot = npmRoot(["--prefix", join(baseDir, "npm")], cwd);
-		if (projectRoot) roots.add(projectRoot);
-		const cwdRoot = npmRoot([], cwd);
-		if (cwdRoot) roots.add(cwdRoot);
+		roots.push(join(baseDir, "npm", "node_modules"));
 	} else if (scope === "user") {
 		const prefixRoot = npmPrefixRoot();
-		if (prefixRoot) roots.add(prefixRoot);
+		if (prefixRoot) roots.push(prefixRoot);
+		roots.push(join(baseDir, "npm", "node_modules"));
+	}
+	return roots;
+}
+
+function expensiveNpmRoots(scope: Scope, baseDir: string, cwd: string): string[] {
+	const roots: string[] = [];
+	if (scope === "project") {
+		const projectRoot = npmRoot(["--prefix", join(baseDir, "npm")], cwd);
+		if (projectRoot) roots.push(projectRoot);
+		const cwdRoot = npmRoot([], cwd);
+		if (cwdRoot) roots.push(cwdRoot);
+	} else if (scope === "user") {
 		const globalRoot = npmRoot(["-g"], cwd);
-		if (globalRoot) roots.add(globalRoot);
-		roots.add(join(baseDir, "npm", "node_modules"));
+		if (globalRoot) roots.push(globalRoot);
 	} else {
 		const localRoot = npmRoot([], cwd);
-		if (localRoot) roots.add(localRoot);
+		if (localRoot) roots.push(localRoot);
 		const globalRoot = npmRoot(["-g"], cwd);
-		if (globalRoot) roots.add(globalRoot);
+		if (globalRoot) roots.push(globalRoot);
 	}
-	return [...roots].map((root) => npmPackageDir(root, npmName));
+	return roots;
+}
+
+export function resolveNpmPackageDir(npmName: string, scope: Scope, baseDir: string, cwd: string): string | undefined {
+	const seen = new Set<string>();
+	const tryRoot = (root: string): string | undefined => {
+		const dir = npmPackageDir(root, npmName);
+		if (seen.has(dir)) return undefined;
+		seen.add(dir);
+		return existsSync(join(dir, "package.json")) ? dir : undefined;
+	};
+	for (const root of cheapNpmRoots(scope, baseDir)) {
+		const hit = tryRoot(root);
+		if (hit) return hit;
+	}
+	for (const root of expensiveNpmRoots(scope, baseDir, cwd)) {
+		const hit = tryRoot(root);
+		if (hit) return hit;
+	}
+	return undefined;
 }
 
 export function gitPackageDirCandidates(source: string, scope: Scope, baseDir: string): string[] {

--- a/pi-extensions/pi-extension-manager/test/popup-perf.test.ts
+++ b/pi-extensions/pi-extension-manager/test/popup-perf.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, expect, mock, test } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+const rootTmp = join(process.cwd(), "tmp", "pi-extension-manager-popup-perf-tests");
+
+const originalEnv = {
+	HOME: process.env.HOME,
+	NPM_CONFIG_PREFIX: process.env.NPM_CONFIG_PREFIX,
+	npm_config_prefix: process.env.npm_config_prefix,
+	PI_CODING_AGENT_DIR: process.env.PI_CODING_AGENT_DIR,
+};
+
+const spawnSyncMock = mock(() => ({ status: 0, stdout: "", stderr: "", error: undefined, signal: null, output: [], pid: 0 }));
+
+mock.module("node:child_process", () => ({ spawnSync: spawnSyncMock }));
+
+function resetTmp(): void {
+	rmSync(rootTmp, { force: true, recursive: true });
+	mkdirSync(rootTmp, { recursive: true });
+}
+
+function writeJson(path: string, value: unknown): void {
+	mkdirSync(dirname(path), { recursive: true });
+	writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function writeNpmPackage(rootNodeModules: string, name: string, version: string): void {
+	const dir = join(rootNodeModules, ...name.split("/"));
+	mkdirSync(dir, { recursive: true });
+	writeJson(join(dir, "package.json"), {
+		name,
+		version,
+		description: `${name} synthetic package`,
+		pi: { extensions: ["./extensions/index.ts"] },
+		vstack: {
+			extensionManager: {
+				displayName: name,
+				settings: [{ key: "enabled", label: "enabled", type: "boolean", default: true }],
+			},
+		},
+	});
+	mkdirSync(join(dir, "extensions"), { recursive: true });
+	writeFileSync(join(dir, "extensions", "index.ts"), "export default function () {}\n", "utf8");
+}
+
+beforeEach(() => {
+	resetTmp();
+	process.env.HOME = join(rootTmp, "home");
+	process.env.NPM_CONFIG_PREFIX = join(rootTmp, "npm-prefix");
+	process.env.npm_config_prefix = process.env.NPM_CONFIG_PREFIX;
+	process.env.PI_CODING_AGENT_DIR = join(rootTmp, "home", ".pi", "agent");
+	spawnSyncMock.mockClear();
+});
+
+afterEach(() => {
+	if (originalEnv.HOME === undefined) delete process.env.HOME;
+	else process.env.HOME = originalEnv.HOME;
+	if (originalEnv.NPM_CONFIG_PREFIX === undefined) delete process.env.NPM_CONFIG_PREFIX;
+	else process.env.NPM_CONFIG_PREFIX = originalEnv.NPM_CONFIG_PREFIX;
+	if (originalEnv.npm_config_prefix === undefined) delete process.env.npm_config_prefix;
+	else process.env.npm_config_prefix = originalEnv.npm_config_prefix;
+	if (originalEnv.PI_CODING_AGENT_DIR === undefined) delete process.env.PI_CODING_AGENT_DIR;
+	else process.env.PI_CODING_AGENT_DIR = originalEnv.PI_CODING_AGENT_DIR;
+	rmSync(rootTmp, { force: true, recursive: true });
+});
+
+async function loadFreshModules() {
+	// Bun mock.module is hoisted before imports; re-importing returns the mocked
+	// versions for the duration of the test file.
+	const inventory = await import("../extensions/manager/inventory.ts");
+	const versions = await import("../extensions/manager/versions.ts");
+	(versions as { __resetNpmRootCacheForTests: () => void }).__resetNpmRootCacheForTests();
+	return inventory;
+}
+
+test("buildInventory does not spawn npm when npm packages resolve via NPM_CONFIG_PREFIX", async () => {
+	const { buildInventory } = await loadFreshModules();
+	const project = join(rootTmp, "project");
+	const userPi = process.env.PI_CODING_AGENT_DIR!;
+	const npmRoot = join(process.env.NPM_CONFIG_PREFIX!, "lib", "node_modules");
+
+	mkdirSync(join(project, ".pi"), { recursive: true });
+	const names = Array.from({ length: 20 }, (_, i) => `@scope/perf-pkg-${i}`);
+	writeJson(join(userPi, "settings.json"), { packages: names.map((n) => `npm:${n}`) });
+	for (const name of names) writeNpmPackage(npmRoot, name, "1.0.0");
+
+	const inv = buildInventory({} as never, { cwd: project } as never);
+	expect(inv.packages.length).toBe(20);
+	for (const pkg of inv.packages) {
+		expect(pkg.state).toBe("active");
+		expect(pkg.installedVersion).toBe("1.0.0");
+	}
+	expect(spawnSyncMock).not.toHaveBeenCalled();
+});
+
+test("buildInventory memoizes npm root spawns across many packages when cheap paths miss", async () => {
+	const { buildInventory } = await loadFreshModules();
+	const project = join(rootTmp, "project");
+	const userPi = process.env.PI_CODING_AGENT_DIR!;
+	const fakeNpmRoot = join(rootTmp, "fake-npm-root");
+
+	mkdirSync(join(project, ".pi"), { recursive: true });
+	const names = Array.from({ length: 10 }, (_, i) => `@scope/spawn-pkg-${i}`);
+	for (const name of names) writeNpmPackage(fakeNpmRoot, name, "1.0.0");
+
+	delete process.env.NPM_CONFIG_PREFIX;
+	delete process.env.npm_config_prefix;
+	writeJson(join(userPi, "settings.json"), { packages: names.map((n) => `npm:${n}`) });
+
+	spawnSyncMock.mockImplementation((_cmd: string, args: string[]) => {
+		const subArgs = args.slice(1);
+		const minusG = subArgs.includes("-g");
+		return {
+			status: 0,
+			stdout: minusG ? `${fakeNpmRoot}\n` : "",
+			stderr: "",
+			error: undefined,
+			signal: null,
+			output: [],
+			pid: 0,
+		};
+	});
+
+	const inv = buildInventory({} as never, { cwd: project } as never);
+	expect(inv.packages.length).toBe(10);
+	for (const pkg of inv.packages) expect(pkg.state).toBe("active");
+
+	// Memoization: at most one `npm root -g` invocation per (args, cwd) key for the
+	// whole inventory build, regardless of package count.
+	expect(spawnSyncMock.mock.calls.length).toBeLessThanOrEqual(2);
+});
+
+test("buildInventory wall-clock stays under 100ms for a realistic npm-heavy inventory", async () => {
+	const { buildInventory } = await loadFreshModules();
+	const project = join(rootTmp, "project");
+	const userPi = process.env.PI_CODING_AGENT_DIR!;
+	const npmRoot = join(process.env.NPM_CONFIG_PREFIX!, "lib", "node_modules");
+
+	mkdirSync(join(project, ".pi"), { recursive: true });
+	const names = Array.from({ length: 25 }, (_, i) => `@scope/wallclock-pkg-${i}`);
+	writeJson(join(userPi, "settings.json"), { packages: names.map((n) => `npm:${n}`) });
+	for (const name of names) writeNpmPackage(npmRoot, name, "1.0.0");
+
+	// Warm filesystem caches once so the timed pass measures steady-state cost.
+	buildInventory({} as never, { cwd: project } as never);
+
+	const start = performance.now();
+	const inv = buildInventory({} as never, { cwd: project } as never);
+	const elapsed = performance.now() - start;
+	expect(inv.packages.length).toBe(25);
+	expect(elapsed).toBeLessThan(100);
+});


### PR DESCRIPTION
Fixes #74 popup freeze.

**Root cause:** `npmPackageDirCandidates` ran `spawnSync npm root` 2-5 times per npm-sourced package on every popup open. With 18 packages, that is 36-90 spawns × 40-500ms each = the multi-second freeze the reporter saw.

**Fix:**
- Memoize `npmRoot()` so it spawns at most once per process.
- Lazy-evaluate candidate paths cheap-first: `NPM_CONFIG_PREFIX`, `<piDir>/npm/node_modules`, etc. before resorting to spawning `npm root`.
- Stop reading `package.json` twice in `buildInventory` (reuse the manifest version we already have).

**Result:**
- Real ~/.pi/agent/settings.json (18 packages): `buildInventory` wall-clock dropped from multi-second to ~1ms steady-state.
- Synthetic 25-npm-package inventory: <100ms with zero npm spawns on the popup path.

**Tests:** 3 new perf assertions in `popup-perf.test.ts` pinning the new behavior so future changes that re-introduce spawns on the popup path fail loudly.

**Validation:** 7/7 bun tests pass; bun build succeeds.