### PR TITLE
fix(linear): linear.issue_updated/_finished/_cancelled never emit (printf missing newline) — caught by hyprtrade live validation

### DIFF
--- a/skills/linear/scripts/commands/issues.sh
+++ b/skills/linear/scripts/commands/issues.sh
@@ -103,9 +103,9 @@ linear_update_activity_type() {
     state=$(echo "$normalized" | jq -r '.data.issue.state.name // empty' 2>/dev/null || true)
     state_type=$(echo "$normalized" | jq -r '.data.issue.state.type // empty' 2>/dev/null || true)
     case "$(printf '%s' "$state_type:$state" | tr '[:upper:]' '[:lower:]')" in
-        completed:*|*:done|*:complete|*:completed) printf 'linear.issue_finished success' ;;
-        canceled:*|cancelled:*|*:canceled|*:cancelled|*:canceled*|*:cancelled*) printf 'linear.issue_cancelled warning' ;;
-        *) printf 'linear.issue_updated info' ;;
+        completed:*|*:done|*:complete|*:completed) printf 'linear.issue_finished success\n' ;;
+        canceled:*|cancelled:*|*:canceled|*:cancelled|*:canceled*|*:cancelled*) printf 'linear.issue_cancelled warning\n' ;;
+        *) printf 'linear.issue_updated info\n' ;;
     esac
 }
 

--- a/skills/linear/tests/update-emit-newline.test.sh
+++ b/skills/linear/tests/update-emit-newline.test.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Regression test for vstack hotfix: linear_update_activity_type must terminate
+# its output with a newline so `read -r ...` returns 0 under `set -e`.
+# Before the hotfix, the lack of a trailing newline made `read` return 1 at
+# EOF, which aborted the update path via set -e BEFORE emit_linear_issue_activity
+# could fire. As a result, linear.issue_updated / _finished / _cancelled events
+# never landed in the activity sidecar.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ISSUES_SH="$SCRIPT_DIR/../scripts/commands/issues.sh"
+
+# Source only the function under test so we don't trigger the script's main
+# dispatch.
+# shellcheck disable=SC1090
+source <(awk '/^linear_update_activity_type\(\)/,/^}$/' "$ISSUES_SH")
+
+assert_pair() {
+    local label="$1" normalized="$2" expect_type="$3" expect_sev="$4"
+    local out_t out_s
+    set +e
+    read -r out_t out_s < <(linear_update_activity_type "$normalized")
+    local rc=$?
+    set -e
+    if [ "$rc" -ne 0 ]; then
+        echo "FAIL $label: read returned non-zero ($rc) — function missed terminating newline"
+        exit 1
+    fi
+    if [ "$out_t" != "$expect_type" ] || [ "$out_s" != "$expect_sev" ]; then
+        echo "FAIL $label: got '$out_t $out_s', expected '$expect_type $expect_sev'"
+        exit 1
+    fi
+    echo "PASS $label"
+}
+
+assert_pair "completed state -> issue_finished success" \
+    '{"data":{"issue":{"state":{"name":"Done","type":"completed"}}}}' \
+    "linear.issue_finished" "success"
+
+assert_pair "canceled state -> issue_cancelled warning" \
+    '{"data":{"issue":{"state":{"name":"Canceled","type":"canceled"}}}}' \
+    "linear.issue_cancelled" "warning"
+
+assert_pair "in_progress state -> issue_updated info" \
+    '{"data":{"issue":{"state":{"name":"In Progress","type":"started"}}}}' \
+    "linear.issue_updated" "info"
+
+echo "all pass"


### PR DESCRIPTION
Hotfix for a bug introduced in PR #75 (W5 deferred items, B1 fix). Caught by end-to-end live validation against Linear API in /mnt/Tertiary/dev/hyprtrade/main.

## Root cause

`linear_update_activity_type` in `skills/linear/scripts/commands/issues.sh` uses `printf` WITHOUT a trailing newline:

```bash
printf 'linear.issue_finished success'
```

The caller does:
```bash
read -r activity_type activity_severity < <(linear_update_activity_type "$normalized")
```

Without a newline, `read` parses the two tokens correctly but returns 1 at EOF. With `set -e` enabled at the top of the script, this aborts the whole `update_issue` function BEFORE `emit_linear_issue_activity` is reached. The Linear API mutation succeeds (the issue state moves correctly), the calling script exits with code 1, and no activity row lands in the sidecar.

## Live evidence (pre-fix)

```
CC-515 created via linear.sh issues create → activity row appears (`linear.issue_created`)
CC-515 updated to In Progress → no activity row, exit=1
CC-515 updated to Done → no activity row, exit=1
```

The state changes were real (visible in Linear UI), but the activity stream missed them entirely.

## Fix

Add `\n` to the three `printf` branches. Done.

## Regression test

`skills/linear/tests/update-emit-newline.test.sh` asserts `read` succeeds and the type/severity pair parses correctly for all three branches (completed → finished/success, canceled → cancelled/warning, default → updated/info). Verified the test catches the bug if the newline is removed.

## Live evidence (post-fix)

```
CC-516 created → linear.issue_created (severity=info)
CC-516 → In Progress → linear.issue_updated (severity=info)
CC-516 → Canceled → linear.issue_cancelled (severity=warning)
```

All three activity rows land in the sidecar with correct types, severities, and refs.linear_id.

## Why this slipped past the W5 review chain

PR #75 round-1 reviewer-error flagged the analogous "wrong jq event-field path" bug in #67 wiring (subscribers.bash). The fix for that was to feed a real upstream payload through the actual jq selector. The same depth of integration testing was not applied to the Linear update path — the test suite asserted the helper FUNCTION was called and the gate worked, but never end-to-end through the real read+set-e interaction. The hyprtrade live validation surfaced it immediately.

## Follow-up

This is the only `printf-without-newline-into-read` in skills/linear and skills/github — verified via grep. No analogous bug in the github wrappers.