### PR TITLE
fix(flightdeck-core): adhoc shell terminal-state + teardown --force override (closes #85)

### DIFF
--- a/skills/flightdeck/lib/flightdeck-core/src/bin/pane-registry.ts
+++ b/skills/flightdeck/lib/flightdeck-core/src/bin/pane-registry.ts
@@ -73,14 +73,34 @@ function tmuxPaneExists(target: string): boolean {
 	return r.status === 0;
 }
 
-function tmuxLivePaneIds(): Set<string> {
+// vstack#85 F1: tmux probes return a tagged Result so callers that
+// drive destructive transitions (cmdReconcile, cmdRemoveMerged,
+// cmdTeardownWindow) can distinguish "verified empty" from "probe
+// failed" instead of silently treating a momentary tmux hiccup as
+// "every pane is gone".
+type TmuxLivePaneIdsResult =
+	| { ok: true; panes: Set<string> }
+	| { ok: false; error: string };
+
+function tmuxLivePaneIdsResult(): TmuxLivePaneIdsResult {
 	const r = spawnSync("tmux", ["list-panes", "-a", "-F", "#{pane_id}"], { encoding: "utf8" });
+	if (r.status !== 0) {
+		const stderr = (r.stderr ?? "").trim();
+		return { ok: false, error: `tmux list-panes -a failed (status=${r.status})${stderr ? `: ${stderr}` : ""}` };
+	}
 	const panes = new Set<string>();
-	if (r.status !== 0) return panes;
 	for (const line of (r.stdout ?? "").split("\n")) {
 		if (line) panes.add(line);
 	}
-	return panes;
+	return { ok: true, panes };
+}
+
+// Legacy adapter — preserves the historical empty-on-failure shape for
+// non-destructive callers (find-by-pane, list --format inner-panes-live).
+// Destructive callers must use tmuxLivePaneIdsResult() directly.
+function tmuxLivePaneIds(): Set<string> {
+	const r = tmuxLivePaneIdsResult();
+	return r.ok ? r.panes : new Set<string>();
 }
 
 function paneMatchIsLive(paneId: string, paneTarget: string): boolean {
@@ -839,19 +859,42 @@ function readEntriesJson(): Record<string, IssueRec> {
 	return out;
 }
 
-function livePanesAndWindows(): { panes: Set<string>; windows: Set<string> } {
-	const panes = new Set<string>();
-	const windows = new Set<string>();
+// vstack#85 F1: see tmuxLivePaneIdsResult above. cmdReconcile and
+// cmdRemoveMerged must bail on probe failure instead of mass-
+// transitioning every entry as "pane gone".
+type LivePanesAndWindowsResult =
+	| { ok: true; panes: Set<string>; windows: Set<string> }
+	| { ok: false; error: string };
+
+function livePanesAndWindowsResult(): LivePanesAndWindowsResult {
 	const session = tmuxCurrentSession();
 	const pp = spawnSync("tmux", ["list-panes", "-a", "-F", "#{pane_id}"], { encoding: "utf8" });
-	if (pp.status === 0) for (const line of (pp.stdout ?? "").split("\n")) { if (line) panes.add(line); }
+	if (pp.status !== 0) {
+		const stderr = (pp.stderr ?? "").trim();
+		return { ok: false, error: `tmux list-panes -a failed (status=${pp.status})${stderr ? `: ${stderr}` : ""}` };
+	}
 	const ww = spawnSync("tmux", ["list-windows", "-t", session, "-F", "#{window_name}"], { encoding: "utf8" });
-	if (ww.status === 0) for (const line of (ww.stdout ?? "").split("\n")) { if (line) windows.add(line); }
-	return { panes, windows };
+	if (ww.status !== 0) {
+		const stderr = (ww.stderr ?? "").trim();
+		return { ok: false, error: `tmux list-windows -t ${session} failed (status=${ww.status})${stderr ? `: ${stderr}` : ""}` };
+	}
+	const panes = new Set<string>();
+	const windows = new Set<string>();
+	for (const line of (pp.stdout ?? "").split("\n")) if (line) panes.add(line);
+	for (const line of (ww.stdout ?? "").split("\n")) if (line) windows.add(line);
+	return { ok: true, panes, windows };
 }
 
 function cmdRemoveMerged(): void {
-	const live = livePanesAndWindows();
+	const probe = livePanesAndWindowsResult();
+	if (!probe.ok) {
+		// vstack#85 F1: transient tmux probe failure must not mass-drop
+		// terminal-state entries (a hiccup would otherwise wipe every
+		// pane-gone row from the registry on a single tick).
+		process.stderr.write(`remove-merged: tmux probe failed; skipping tick (${probe.error})\n`);
+		return;
+	}
+	const live = { panes: probe.panes, windows: probe.windows };
 	const entries = readEntriesJson();
 	const dropped: string[] = [];
 	for (const [issue, rec] of Object.entries(entries)) {
@@ -871,7 +914,18 @@ function cmdRemoveMerged(): void {
 }
 
 function cmdReconcile(): void {
-	const live = livePanesAndWindows();
+	const probe = livePanesAndWindowsResult();
+	if (!probe.ok) {
+		// vstack#85 F1: transient tmux probe failure (SIGSTOP, SIGPIPE,
+		// EAGAIN, mid-session restart, momentary socket loss) must not
+		// be treated as "every pane is gone". A silent empty-set would
+		// mass-transition adhoc-shell rows to `complete` AND drop every
+		// other entry as `entry.dead` in a single tick. Bail early so
+		// the next tick can reconcile against a healthy probe.
+		process.stderr.write(`reconcile: tmux probe failed; skipping tick (${probe.error})\n`);
+		return;
+	}
+	const live = { panes: probe.panes, windows: probe.windows };
 	const entries = readEntriesJson();
 	const dropped: string[] = [];
 	const completed: string[] = [];
@@ -1026,11 +1080,17 @@ function cmdTeardownWindow(args: string[]): void {
 	const state = String(rec.state ?? "");
 	const paneId = String(rec.pane_id ?? "");
 	const windowName = String(rec.window ?? "");
-	let paneAlive = false;
-	if (paneId) {
-		const live = tmuxLivePaneIds();
-		paneAlive = live.has(paneId);
+	// vstack#85 F1: probe panes AND windows in one shot so the F2 empty-
+	// paneId window fallback shares the same atomic snapshot. Probe
+	// failure aborts before any destructive branch.
+	const probe = livePanesAndWindowsResult();
+	if (!probe.ok) {
+		process.stderr.write(
+			`teardown-window: tmux probe failed; refusing to act (state of pane_id '${paneId || "<none>"}' / window '${windowName || "<none>"}' unknown): ${probe.error}\n`,
+		);
+		process.exit(5);
 	}
+	const paneAlive = paneId ? probe.panes.has(paneId) : false;
 	if (paneAlive) {
 		if (!TERMINAL_STATES.has(state) && !force) {
 			process.stderr.write(
@@ -1052,8 +1112,14 @@ function cmdTeardownWindow(args: string[]): void {
 		// Post-kill liveness check is authoritative — not the exit code
 		// (BLOCK #1). tmux can return non-zero for benign reasons such as
 		// the pane vanishing between the alive-check and the kill.
-		const stillAlive = tmuxLivePaneIds().has(paneId);
-		if (stillAlive) {
+		const stillProbe = tmuxLivePaneIdsResult();
+		if (!stillProbe.ok) {
+			process.stderr.write(
+				`teardown-window: post-kill tmux probe failed (status of pane_id '${paneId}' unknown after kill of ${kind}): ${stillProbe.error}\n`,
+			);
+			process.exit(5);
+		}
+		if (stillProbe.panes.has(paneId)) {
 			process.stderr.write(
 				`teardown-window: kill of ${kind} failed (status=${killResult.status}, pane_id=${paneId} still alive): ${killResult.stderr ?? ""}`,
 			);
@@ -1065,6 +1131,18 @@ function cmdTeardownWindow(args: string[]): void {
 			`teardown-window: killed ${kind} (pane_id=${paneId}, window=${windowName}, force=${force ? 1 : 0})\n`,
 		);
 		return;
+	}
+	// vstack#85 F2: when paneId is empty, fall back to the recorded
+	// window name. If tmux still lists the window, the pane state is
+	// unverifiable — refuse even with --force so the operator can
+	// reconcile/backfill instead of dropping a row whose pane may be
+	// alive. Empty paneId + empty/gone window is the operator's call
+	// (no way to verify; --force proceeds, non-force still hits drift).
+	if (!paneId && windowName && probe.windows.has(windowName)) {
+		process.stderr.write(
+			`teardown-window: refusing to drop '${issue}' — pane_id is empty but recorded window '${windowName}' is still alive in tmux; cannot verify pane state. Run \`pane-registry reconcile\` to backfill pane_id, then retry${force ? " (--force refused for safety)" : ""}\n`,
+		);
+		process.exit(3);
 	}
 	if (TERMINAL_STATES.has(state)) {
 		emitTerminalEntry(rec, state, { pane_id: paneId || null, teardown: "already-closed" });

--- a/skills/flightdeck/lib/flightdeck-core/src/bin/pane-registry.ts
+++ b/skills/flightdeck/lib/flightdeck-core/src/bin/pane-registry.ts
@@ -16,6 +16,7 @@ import { emitCloseIssue, emitMergeAction, emitWorkflowDecision } from "../activi
 import type { ActivityEventInput } from "../activity/types.ts";
 import type { CloseIssueOutcome } from "../activity/workflow-emit.ts";
 import { cxAdapterIsFresh, cxSpawnFile } from "../paths/codex.ts";
+import { decideShellAdhocWake } from "../daemon/shell-adhoc-wake.ts";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const FD_STATE_SCRIPT = resolve(HERE, "../../../../scripts/flightdeck-state");
@@ -555,6 +556,13 @@ function emitReconcileDrop(entry: EntryRecord): void {
 	}, id);
 }
 
+function emitReconcileShellComplete(entry: EntryRecord): void {
+	emitCloseIssue(registryWorkflowContext(entry), "complete", {
+		details: { reason: "reconcile-pane-gone", teardown: "shell-pane-gone" },
+		severity: "success",
+	});
+}
+
 // Issue-mode metadata lives under `entry.domain.issue`. If a caller
 // passes one of those field names as a top-level set, redirect into the
 // nested object so downstream readers (`pane-registry list --format json`,
@@ -866,6 +874,7 @@ function cmdReconcile(): void {
 	const live = livePanesAndWindows();
 	const entries = readEntriesJson();
 	const dropped: string[] = [];
+	const completed: string[] = [];
 	const backfilled: string[] = [];
 	const drift: string[] = [];
 	for (const [issue, rec] of Object.entries(entries)) {
@@ -913,10 +922,37 @@ function cmdReconcile(): void {
 		const alive = paneId ? live.panes.has(paneId) : !win || live.windows.has(win);
 		if (!alive) {
 			const droppedEntry = rec;
+			const stateStr = String(rec.state ?? "");
+			// vstack#85: adhoc shell entries have no idle subscriber, so
+			// pane-gone IS their terminal signal. Transition state to
+			// `complete` and emit `entry.completed` instead of dropping +
+			// `entry.dead`. Non-shell-adhoc entries keep the legacy drop.
+			const wake = decideShellAdhocWake({
+				kind: String(rec.kind ?? ""),
+				harness: String(rec.harness ?? ""),
+				state: stateStr,
+				paneAlive: false,
+			});
+			if (wake.transition) {
+				const idJson = JSON.stringify(issue);
+				fdStateOrDie(["set", `.entries[${idJson}].state`, JSON.stringify(wake.nextState)]);
+				emitReconcileShellComplete(droppedEntry);
+				completed.push(issue);
+				continue;
+			}
 			fdStateOrDie(["set", ".entries", `(.entries | del(.["${issue}"]))`]);
-			emitReconcileDrop(droppedEntry);
+			// Already-terminal entries (e.g. an adhoc-shell row that was
+			// transitioned to `complete` on a prior reconcile tick, then
+			// observed pane-gone again on the next sweep) drop silently
+			// — the terminal-event was emitted at the original
+			// transition and re-emitting `entry.dead` would lie about the
+			// outcome.
+			if (!TERMINAL_STATES.has(stateStr.toLowerCase())) emitReconcileDrop(droppedEntry);
 			dropped.push(issue);
 		}
+	}
+	if (completed.length > 0) {
+		process.stdout.write(`reconciled: completed ${completed.length} adhoc shell entr${completed.length === 1 ? "y" : "ies"} (${completed.join(",")})\n`);
 	}
 	if (dropped.length > 0) {
 		process.stdout.write(`reconciled: dropped ${dropped.length} stale entr${dropped.length === 1 ? "y" : "ies"} (${dropped.join(",")})\n`);
@@ -1035,8 +1071,24 @@ function cmdTeardownWindow(args: string[]): void {
 		process.stdout.write(`teardown-window: window already closed (pane_id=${paneId || "<none>"} gone, state=${state})\n`);
 		return;
 	}
+	if (force) {
+		// vstack#85: --force is the operator explicitly saying "I know this
+		// entry is stuck and the pane is verifiably gone — drop it". The
+		// non-force path keeps the #16 drift refusal intact.
+		const outcome: "cancelled" | "dead" = state === "waiting" || state === "" ? "cancelled" : "dead";
+		fdStateOrDie(["set", ".entries", `(.entries | del(.["${issue}"]))`]);
+		emitTerminalEntry(rec, outcome, {
+			force: true,
+			pane_id: paneId || null,
+			prior_state: state || null,
+			reason: "force-gone-pane",
+			teardown: "force-gone-pane",
+		});
+		process.stdout.write(`teardown-window: removed stale entry '${issue}' (pane_id=${paneId || "<none>"} gone, prior_state=${state || "<none>"}, force=1, outcome=${outcome})\n`);
+		return;
+	}
 	process.stderr.write(
-		`teardown-window: registry drift — pane_id '${paneId || "<none>"}' is gone but state is '${state}' (not merged|aborted|dead|complete|cancelled); refusing to derive kill target from pane_target (#16)\n`,
+		`teardown-window: registry drift — pane_id '${paneId || "<none>"}' is gone but state is '${state}' (not merged|aborted|dead|complete|cancelled); refusing to derive kill target from pane_target (#16); rerun with --force to drop the stale entry\n`,
 	);
 	process.exit(3);
 }

--- a/skills/flightdeck/lib/flightdeck-core/src/daemon/shell-adhoc-wake.ts
+++ b/skills/flightdeck/lib/flightdeck-core/src/daemon/shell-adhoc-wake.ts
@@ -1,0 +1,79 @@
+// Adhoc shell pane-gone → terminal-state-reached decision (vstack#85).
+//
+// Shell harnesses have NO idle subscriber (unlike pi/claude/opencode/codex),
+// so the W5 G1 pattern in pi-adhoc-wake.ts (which gates on
+// `isIdle: true && hasPendingMessages: false`) does not apply. For adhoc
+// shell entries the only meaningful terminal signal is "the user's tmux
+// pane is gone" — once the pane is destroyed the session is, by
+// definition, done. Without this gate adhoc-shell entries stay stuck in
+// `waiting` forever and the dashboard/session-watch never advance them
+// to `complete`.
+//
+// This module owns the pure decision so:
+//   - The runtime caller (`bin/pane-registry.ts::cmdReconcile`) stays a
+//     thin shell-out + state writer; the gating logic and exhaustive
+//     cases live in unit tests against this function.
+//   - The decision composes with the existing reconcile drop-on-gone
+//     path: shell-adhoc gets a success transition + `entry.completed`,
+//     while non-shell-adhoc entries keep the legacy drop + `entry.dead`
+//     warning emit.
+
+/** Terminal lifecycle states across both adhoc and issue-mode wires. */
+export const TERMINAL_STATES = new Set([
+	"merged",
+	"aborted",
+	"dead",
+	"complete",
+	"cancelled",
+]);
+
+export interface ShellAdhocWakeInput {
+	/** `.entries[].kind` — adhoc | issue | workflow */
+	kind: string;
+	/** `.entries[].harness` — pi | claude | opencode | codex | shell */
+	harness: string;
+	/** `.entries[].state` — waiting | prompting | ... | complete | cancelled | dead */
+	state: string;
+	/** True iff the registered `pane_id` is still in `tmux list-panes -a`. */
+	paneAlive: boolean;
+}
+
+export interface ShellAdhocWakeSkip {
+	transition: false;
+	reason:
+		| "pane-alive"
+		| "not-adhoc"
+		| "not-shell"
+		| "already-terminal";
+}
+
+export interface ShellAdhocWakeTransition {
+	transition: true;
+	nextState: "complete";
+}
+
+export type ShellAdhocWakeOutcome = ShellAdhocWakeSkip | ShellAdhocWakeTransition;
+
+/**
+ * Decide whether an adhoc shell entry whose pane has vanished should be
+ * transitioned to `complete` (and have `entry.completed` emitted).
+ *
+ * Returns `transition: true` only when:
+ *   - pane is gone (`paneAlive === false`)
+ *   - kind is exactly "adhoc" (case-insensitive)
+ *   - harness is exactly "shell" (case-insensitive)
+ *   - current state is not already terminal (idempotency — don't re-emit
+ *     entry.completed every reconcile tick for the same entry)
+ *
+ * All other cases skip with a reason string for diagnostics.
+ */
+export function decideShellAdhocWake(input: ShellAdhocWakeInput): ShellAdhocWakeOutcome {
+	if (input.paneAlive) return { transition: false, reason: "pane-alive" };
+	const kind = (input.kind ?? "").trim().toLowerCase();
+	const harness = (input.harness ?? "").trim().toLowerCase();
+	const state = (input.state ?? "").trim().toLowerCase();
+	if (kind !== "adhoc") return { transition: false, reason: "not-adhoc" };
+	if (harness !== "shell") return { transition: false, reason: "not-shell" };
+	if (TERMINAL_STATES.has(state)) return { transition: false, reason: "already-terminal" };
+	return { transition: true, nextState: "complete" };
+}

--- a/skills/flightdeck/lib/flightdeck-core/tests/activity/instrumentation.test.ts
+++ b/skills/flightdeck/lib/flightdeck-core/tests/activity/instrumentation.test.ts
@@ -196,6 +196,74 @@ describe("pane-registry activity instrumentation", () => {
 		expect(dead[0]?.details).toMatchObject({ reason: "reconcile-stale-pane" });
 	});
 
+	// vstack#85 Fix A: shell adhoc has no idle subscriber, so pane-gone
+	// IS the terminal signal. Reconcile transitions state to `complete`
+	// and emits `entry.completed` (success) instead of dropping the row
+	// with `entry.dead` (warning).
+	test("reconcile adhoc shell with gone pane transitions to complete and emits entry.completed", () => {
+		expect(run(["init-entry", "SHELL-1", "--title", "Adhoc Shell", "--kind", "adhoc", "--cwd", "/tmp/shell", "--window", "shell-win", "--harness", "shell", "--pane-id", "%999"]).status).toBe(0);
+		expect(run(["reconcile"]).status).toBe(0);
+		const completed = eventsOf("entry.completed").filter((event) => event.entry_id === "SHELL-1");
+		expect(completed).toHaveLength(1);
+		expect(completed[0]).toMatchObject({ importance: "important", severity: "success" });
+		expect(completed[0]?.details).toMatchObject({ reason: "reconcile-pane-gone", teardown: "shell-pane-gone" });
+		expect(eventsOf("entry.dead").filter((event) => event.entry_id === "SHELL-1")).toHaveLength(0);
+		const entry = JSON.parse(run(["get", "SHELL-1"]).stdout) as Record<string, unknown>;
+		expect(entry.state).toBe("complete");
+	});
+
+	test("reconcile adhoc shell is idempotent: second pass on terminal state does not re-emit", () => {
+		expect(run(["init-entry", "SHELL-IDEM", "--title", "Idempotent", "--kind", "adhoc", "--cwd", "/tmp/shell", "--window", "shell-win", "--harness", "shell", "--pane-id", "%998"]).status).toBe(0);
+		expect(run(["reconcile"]).status).toBe(0);
+		expect(run(["reconcile"]).status).toBe(0);
+		const completed = eventsOf("entry.completed").filter((event) => event.entry_id === "SHELL-IDEM");
+		expect(completed).toHaveLength(1);
+		expect(eventsOf("entry.dead").filter((event) => event.entry_id === "SHELL-IDEM")).toHaveLength(0);
+	});
+
+	test("reconcile adhoc pi with gone pane keeps legacy entry.dead drop (not-shell skip)", () => {
+		initEntry("PI-STALE", ["--pane-id", "%997"]);
+		expect(run(["reconcile"]).status).toBe(0);
+		const dead = eventsOf("entry.dead").filter((event) => event.entry_id === "PI-STALE");
+		expect(dead).toHaveLength(1);
+		expect(eventsOf("entry.completed").filter((event) => event.entry_id === "PI-STALE")).toHaveLength(0);
+	});
+
+	// vstack#85 Fix B: teardown-entry --force on a gone-pane waiting
+	// entry must drop the stale row and emit entry.cancelled. Without
+	// --force the existing #16 drift refusal (exit 3) must stand.
+	test("teardown-entry --force on gone-pane waiting entry drops row and emits entry.cancelled", () => {
+		expect(run(["init-entry", "FORCE-WAIT", "--title", "Stuck Waiting", "--kind", "adhoc", "--cwd", "/tmp/force", "--window", "force-win", "--harness", "shell", "--pane-id", "%996"]).status).toBe(0);
+		// Non-force path: existing drift refusal still applies.
+		const refused = run(["teardown-entry", "FORCE-WAIT"]);
+		expect(refused.status).toBe(3);
+		expect(refused.stderr).toContain("registry drift");
+		expect(refused.stderr).toContain("--force");
+		// --force path: drops row + emits entry.cancelled.
+		const forced = run(["teardown-entry", "FORCE-WAIT", "--force"]);
+		expect(forced.status).toBe(0);
+		expect(forced.stdout).toContain("removed stale entry 'FORCE-WAIT'");
+		const cancelled = eventsOf("entry.cancelled").filter((event) => event.entry_id === "FORCE-WAIT");
+		expect(cancelled).toHaveLength(1);
+		expect(cancelled[0]).toMatchObject({ importance: "important", severity: "warning" });
+		expect(cancelled[0]?.details).toMatchObject({ force: true, reason: "force-gone-pane", teardown: "force-gone-pane", prior_state: "waiting" });
+		// Entry is gone from the registry.
+		expect(run(["get", "FORCE-WAIT"]).status).toBe(1);
+	});
+
+	test("teardown-entry --force on gone-pane non-waiting entry emits entry.dead", () => {
+		expect(run(["init-entry", "FORCE-PROMPT", "--title", "Stuck Prompting", "--kind", "adhoc", "--cwd", "/tmp/force", "--window", "force-win", "--harness", "shell", "--pane-id", "%995"]).status).toBe(0);
+		expect(run(["set-state", "FORCE-PROMPT", "prompting"]).status).toBe(0);
+		const forced = run(["teardown-entry", "FORCE-PROMPT", "--force"]);
+		expect(forced.status).toBe(0);
+		const dead = eventsOf("entry.dead").filter((event) => event.entry_id === "FORCE-PROMPT");
+		expect(dead).toHaveLength(1);
+		expect(dead[0]).toMatchObject({ importance: "important", severity: "error" });
+		expect(dead[0]?.details).toMatchObject({ force: true, prior_state: "prompting", reason: "force-gone-pane" });
+		expect(eventsOf("entry.cancelled").filter((event) => event.entry_id === "FORCE-PROMPT")).toHaveLength(0);
+		expect(run(["get", "FORCE-PROMPT"]).status).toBe(1);
+	});
+
 	test("reconcile drift emits daemon.warning without dropping row", () => {
 		shimState = writeShimState({
 			panes: { "%500": { pane_index: 0, path: "/tmp/other", window_id: "@50", window_index: 1, window_name: "other-window" } },

--- a/skills/flightdeck/lib/flightdeck-core/tests/activity/instrumentation.test.ts
+++ b/skills/flightdeck/lib/flightdeck-core/tests/activity/instrumentation.test.ts
@@ -78,6 +78,12 @@ function run(args: string[]): { stdout: string; stderr: string; status: number |
 	return { status: r.status, stderr: r.stderr ?? "", stdout: r.stdout ?? "" };
 }
 
+function runWithEnv(args: string[], extraEnv: Record<string, string>): { stdout: string; stderr: string; status: number | null } {
+	const env = { ...registryEnv(), ...extraEnv };
+	const r = spawnSync(SCRIPT, args, { cwd: repo, encoding: "utf8", env });
+	return { status: r.status, stderr: r.stderr ?? "", stdout: r.stdout ?? "" };
+}
+
 function runFlightdeckState(args: string[]): { stdout: string; stderr: string; status: number | null } {
 	const env = registryEnv();
 	const r = spawnSync(FLIGHTDECK_STATE, [args[0]!, "--session", SESSION, ...args.slice(1)], { cwd: repo, encoding: "utf8", env });
@@ -262,6 +268,100 @@ describe("pane-registry activity instrumentation", () => {
 		expect(dead[0]?.details).toMatchObject({ force: true, prior_state: "prompting", reason: "force-gone-pane" });
 		expect(eventsOf("entry.cancelled").filter((event) => event.entry_id === "FORCE-PROMPT")).toHaveLength(0);
 		expect(run(["get", "FORCE-PROMPT"]).status).toBe(1);
+	});
+
+	// vstack#85 F1 (round-2 follow-up): a transient `tmux list-panes -a`
+	// failure (SIGPIPE, EAGAIN, mid-session restart) must NOT mass-
+	// transition every adhoc-shell row to `complete` or mass-drop every
+	// other entry as `entry.dead`. Reconcile bails with a structured
+	// warn line and exit 0 so the next healthy probe can drive the
+	// actual reconciliation.
+	test("reconcile bails on tmux probe failure: no transitions, no drops, single warn line", () => {
+		for (let i = 0; i < 5; i += 1) {
+			const id = `PROBE-SHELL-${i}`;
+			expect(run(["init-entry", id, "--title", `Shell ${i}`, "--kind", "adhoc", "--cwd", "/tmp/shell", "--window", `shell-${i}`, "--harness", "shell", "--pane-id", `%${900 + i}`]).status).toBe(0);
+		}
+		for (let i = 0; i < 3; i += 1) {
+			const id = `PROBE-PI-${i}`;
+			expect(run(["init-entry", id, "--title", `Pi ${i}`, "--kind", "adhoc", "--cwd", "/tmp/pi", "--window", `pi-${i}`, "--harness", "pi", "--pane-id", `%${950 + i}`]).status).toBe(0);
+		}
+		// Baseline activity snapshot: drop all the entry.registered events
+		// emitted during init; only post-baseline rows matter for the
+		// assertion below.
+		const registeredBefore = eventsOf("entry.registered").length;
+		const completedBefore = eventsOf("entry.completed").length;
+		const deadBefore = eventsOf("entry.dead").length;
+		const stateChangedBefore = eventsOf("entry.state_changed").length;
+		const result = runWithEnv(["reconcile"], { TMUX_SHIM_FAIL_LIST_PANES_A: "1" });
+		expect(result.status).toBe(0);
+		expect(result.stderr).toContain("reconcile: tmux probe failed");
+		expect(result.stderr).toContain("skipping tick");
+		// Exactly one warn line — no per-entry chatter.
+		expect(result.stderr.split("\n").filter((line) => line.includes("tmux probe failed"))).toHaveLength(1);
+		// No new transition / drop emits.
+		expect(eventsOf("entry.completed").length).toBe(completedBefore);
+		expect(eventsOf("entry.dead").length).toBe(deadBefore);
+		expect(eventsOf("entry.state_changed").length).toBe(stateChangedBefore);
+		expect(eventsOf("entry.registered").length).toBe(registeredBefore);
+		// Every entry still in the registry, state unchanged.
+		for (let i = 0; i < 5; i += 1) {
+			const entry = JSON.parse(run(["get", `PROBE-SHELL-${i}`]).stdout) as Record<string, unknown>;
+			expect(entry.state).toBe("waiting");
+		}
+		for (let i = 0; i < 3; i += 1) {
+			const entry = JSON.parse(run(["get", `PROBE-PI-${i}`]).stdout) as Record<string, unknown>;
+			expect(entry.state).toBe("waiting");
+		}
+	});
+
+	test("teardown-entry --force bails on tmux probe failure (refuses, exit 5)", () => {
+		expect(run(["init-entry", "PROBE-TD", "--title", "Probe Teardown", "--kind", "adhoc", "--cwd", "/tmp/probe", "--window", "probe-win", "--harness", "shell", "--pane-id", "%994"]).status).toBe(0);
+		const result = runWithEnv(["teardown-entry", "PROBE-TD", "--force"], { TMUX_SHIM_FAIL_LIST_PANES_A: "1" });
+		expect(result.status).toBe(5);
+		expect(result.stderr).toContain("tmux probe failed");
+		// Entry still in registry, no terminal emit.
+		expect(run(["get", "PROBE-TD"]).status).toBe(0);
+		expect(eventsOf("entry.cancelled").filter((event) => event.entry_id === "PROBE-TD")).toHaveLength(0);
+		expect(eventsOf("entry.dead").filter((event) => event.entry_id === "PROBE-TD")).toHaveLength(0);
+	});
+
+	// vstack#85 F2 (round-2 follow-up): teardown --force must refuse to
+	// drop an entry whose pane_id is empty when the recorded window is
+	// still alive in tmux — there's no way to verify the pane is
+	// actually gone, and a force-drop would lose state for a
+	// possibly-live session.
+	test("teardown-entry --force refuses when pane_id empty but recorded window is still alive", () => {
+		// Stage a live window in the shim that the registry entry will
+		// reference. No pane is associated with the entry (pane_id null).
+		shimState = writeShimState({
+			panes: { "%993": { pane_index: 0, path: "/tmp/other", window_id: "@93", window_index: 9, window_name: "stuck-win" } },
+			session: SESSION,
+			windows: { "@93": { index: 9, name: "stuck-win" } },
+		});
+		expect(run(["init-entry", "WIN-ALIVE", "--title", "Window Alive", "--kind", "adhoc", "--cwd", "/tmp/stuck", "--window", "stuck-win", "--harness", "shell"]).status).toBe(0);
+		expect(run(["set", "WIN-ALIVE", "pane_id", "null"]).status).toBe(0);
+		const result = run(["teardown-entry", "WIN-ALIVE", "--force"]);
+		expect(result.status).toBe(3);
+		expect(result.stderr).toContain("pane_id is empty");
+		expect(result.stderr).toContain("stuck-win");
+		expect(result.stderr).toContain("still alive");
+		expect(result.stderr).toContain("--force refused");
+		// Entry still in registry, no terminal emit.
+		expect(run(["get", "WIN-ALIVE"]).status).toBe(0);
+		expect(eventsOf("entry.cancelled").filter((event) => event.entry_id === "WIN-ALIVE")).toHaveLength(0);
+		expect(eventsOf("entry.dead").filter((event) => event.entry_id === "WIN-ALIVE")).toHaveLength(0);
+	});
+
+	test("teardown-entry --force proceeds when pane_id empty AND recorded window is also gone", () => {
+		// No matching window in the shim — the recorded window vanished.
+		expect(run(["init-entry", "WIN-GONE", "--title", "Window Gone", "--kind", "adhoc", "--cwd", "/tmp/gone", "--window", "never-existed-win", "--harness", "shell"]).status).toBe(0);
+		expect(run(["set", "WIN-GONE", "pane_id", "null"]).status).toBe(0);
+		const result = run(["teardown-entry", "WIN-GONE", "--force"]);
+		expect(result.status).toBe(0);
+		expect(result.stdout).toContain("removed stale entry 'WIN-GONE'");
+		const cancelled = eventsOf("entry.cancelled").filter((event) => event.entry_id === "WIN-GONE");
+		expect(cancelled).toHaveLength(1);
+		expect(run(["get", "WIN-GONE"]).status).toBe(1);
 	});
 
 	test("reconcile drift emits daemon.warning without dropping row", () => {

--- a/skills/flightdeck/lib/flightdeck-core/tests/parity/adhoc-shell-wake.test.ts
+++ b/skills/flightdeck/lib/flightdeck-core/tests/parity/adhoc-shell-wake.test.ts
@@ -1,0 +1,143 @@
+// Regression coverage for vstack#85 (Fix A): adhoc shell entries whose
+// tmux pane has vanished must transition to `complete` and emit
+// `entry.completed` during reconcile. Shell harnesses have no idle
+// subscriber, so pane-gone is the only meaningful terminal signal.
+
+import { describe, expect, test } from "bun:test";
+
+import {
+	TERMINAL_STATES,
+	decideShellAdhocWake,
+} from "../../src/daemon/shell-adhoc-wake.ts";
+
+describe("decideShellAdhocWake (vstack#85 Fix A)", () => {
+	test("adhoc shell entry with gone pane -> transition to complete", () => {
+		const outcome = decideShellAdhocWake({
+			kind: "adhoc",
+			harness: "shell",
+			state: "waiting",
+			paneAlive: false,
+		});
+		expect(outcome.transition).toBe(true);
+		if (!outcome.transition) throw new Error("expected transition=true");
+		expect(outcome.nextState).toBe("complete");
+	});
+
+	test("adhoc shell entry with live pane -> no transition (pane-alive)", () => {
+		const outcome = decideShellAdhocWake({
+			kind: "adhoc",
+			harness: "shell",
+			state: "waiting",
+			paneAlive: true,
+		});
+		expect(outcome.transition).toBe(false);
+		if (outcome.transition) throw new Error("expected transition=false");
+		expect(outcome.reason).toBe("pane-alive");
+	});
+
+	test("issue-kind shell entry with gone pane -> no transition (not-adhoc)", () => {
+		const outcome = decideShellAdhocWake({
+			kind: "issue",
+			harness: "shell",
+			state: "waiting",
+			paneAlive: false,
+		});
+		expect(outcome.transition).toBe(false);
+		if (outcome.transition) throw new Error("expected transition=false");
+		expect(outcome.reason).toBe("not-adhoc");
+	});
+
+	test("workflow-kind shell entry with gone pane -> no transition (not-adhoc)", () => {
+		const outcome = decideShellAdhocWake({
+			kind: "workflow",
+			harness: "shell",
+			state: "waiting",
+			paneAlive: false,
+		});
+		expect(outcome.transition).toBe(false);
+		if (outcome.transition) throw new Error("expected transition=false");
+		expect(outcome.reason).toBe("not-adhoc");
+	});
+
+	test("adhoc pi entry with gone pane -> no transition (not-shell, pi has its own wake path)", () => {
+		const outcome = decideShellAdhocWake({
+			kind: "adhoc",
+			harness: "pi",
+			state: "waiting",
+			paneAlive: false,
+		});
+		expect(outcome.transition).toBe(false);
+		if (outcome.transition) throw new Error("expected transition=false");
+		expect(outcome.reason).toBe("not-shell");
+	});
+
+	test("adhoc claude/opencode/codex with gone pane -> no transition (not-shell)", () => {
+		for (const harness of ["claude", "opencode", "codex"]) {
+			const outcome = decideShellAdhocWake({
+				kind: "adhoc",
+				harness,
+				state: "waiting",
+				paneAlive: false,
+			});
+			expect(outcome.transition).toBe(false);
+			if (outcome.transition) throw new Error("expected transition=false");
+			expect(outcome.reason).toBe("not-shell");
+		}
+	});
+
+	test("idempotency: already-terminal state -> no transition", () => {
+		for (const terminal of TERMINAL_STATES) {
+			const outcome = decideShellAdhocWake({
+				kind: "adhoc",
+				harness: "shell",
+				state: terminal,
+				paneAlive: false,
+			});
+			expect(outcome.transition).toBe(false);
+			if (outcome.transition) throw new Error(`expected transition=false for state=${terminal}`);
+			expect(outcome.reason).toBe("already-terminal");
+		}
+	});
+
+	test("case-insensitive kind/harness matching", () => {
+		const outcome = decideShellAdhocWake({
+			kind: "ADHOC",
+			harness: "Shell",
+			state: "WAITING",
+			paneAlive: false,
+		});
+		expect(outcome.transition).toBe(true);
+		if (!outcome.transition) throw new Error("expected transition=true");
+		expect(outcome.nextState).toBe("complete");
+	});
+
+	test("non-waiting non-terminal states still transition (e.g. prompting / ready)", () => {
+		for (const state of ["prompting", "submitting", "ready", "merge-ready"]) {
+			const outcome = decideShellAdhocWake({
+				kind: "adhoc",
+				harness: "shell",
+				state,
+				paneAlive: false,
+			});
+			expect(outcome.transition).toBe(true);
+			if (!outcome.transition) throw new Error(`expected transition=true for state=${state}`);
+			expect(outcome.nextState).toBe("complete");
+		}
+	});
+
+	test("empty/missing state with gone pane -> transition (treat empty as non-terminal)", () => {
+		const outcome = decideShellAdhocWake({
+			kind: "adhoc",
+			harness: "shell",
+			state: "",
+			paneAlive: false,
+		});
+		expect(outcome.transition).toBe(true);
+		if (!outcome.transition) throw new Error("expected transition=true");
+		expect(outcome.nextState).toBe("complete");
+	});
+
+	test("TERMINAL_STATES export matches the documented vocabulary", () => {
+		expect([...TERMINAL_STATES].sort()).toEqual(["aborted", "cancelled", "complete", "dead", "merged"]);
+	});
+});

--- a/skills/flightdeck/lib/flightdeck-core/tests/parity/tmux-shim/tmux
+++ b/skills/flightdeck/lib/flightdeck-core/tests/parity/tmux-shim/tmux
@@ -142,6 +142,15 @@ case "$subcmd" in
       esac
     done
     if (( all == 1 )); then
+      # vstack#85 F1 regression hook: simulate a transient tmux probe
+      # failure (SIGPIPE, EAGAIN, mid-session restart) by returning
+      # non-zero. The destructive callers (reconcile, remove-merged,
+      # teardown --force) must bail instead of treating an empty set
+      # as "every pane is gone".
+      if [[ "${TMUX_SHIM_FAIL_LIST_PANES_A:-0}" == "1" ]]; then
+        echo "shim: list-panes -a refused (TMUX_SHIM_FAIL_LIST_PANES_A=1)" >&2
+        exit 1
+      fi
       jq -r '.panes | keys[]' "$STATE_FILE"
       exit 0
     fi


### PR DESCRIPTION
Closes #85.

Two complementary fixes:

**A. Adhoc shell terminal-state classification.** Mirrors W5 G1 #57 (which was pi-only). New `src/daemon/shell-adhoc-wake.ts` pure decision module: when the reconcile loop observes that an `kind=adhoc && harness=shell` entry's `pane_id` is no longer in `tmux list-panes -a`, transition state to `complete` and emit `entry.completed` (severity=success, importance=important). Idempotent — re-emit suppressed for already-terminal pane-gone entries.

**B. `teardown-entry --force` overrides the gone-pane drift refusal.** The pre-fix script refused to clean up a stale entry even with `--force`, leaving operators with only `pane-registry remove` (which skips lifecycle accounting). Now `--force` + verified-gone-pane drops the stale entry and emits `entry.cancelled` (when prior state was `waiting`) or `entry.dead` (any later non-terminal state) with `force=true` + `reason=force-gone-pane` in details. The non-force path keeps the existing safety check and points callers at `--force`.

Both discovered via the live UI/UX audit (2026-05-16) running real adhoc shell sessions through `flightdeck-session start --harness shell --kind adhoc`.

## Validation

```
cd skills/flightdeck/lib/flightdeck-core && bun test && bun run typecheck
```

510/510 tests pass; typecheck clean.

## Architecture

`shell-adhoc-wake.ts` mirrors `pi-adhoc-wake.ts` pure-decision shape so the future bash port can stay in lock-step under the parity rule.