### PR TITLE
fix(pi-tool-renderer): trim ANSI-padded tool rows

### DIFF
--- a/pi-extensions/pi-tool-renderer/extensions/tool-renderer/ansi.ts
+++ b/pi-extensions/pi-tool-renderer/extensions/tool-renderer/ansi.ts
@@ -73,6 +73,20 @@ export function trimOuterBlankLines(lines: string[]): string[] {
 	return start > end ? [] : lines.slice(start, end + 1);
 }
 
+export function trimTrailingWhitespaceBeforeAnsi(text: string): string {
+	let body = text;
+	let suffix = "";
+	const trailingAnsiRe = /(?:\x1b(?:\[[0-9;:]*m|\]133;[ABC]\x07))+$/;
+	while (body.length > 0) {
+		const match = body.match(trailingAnsiRe);
+		if (!match) break;
+		const ansi = match[0];
+		suffix = `${ansi}${suffix}`;
+		body = body.slice(0, -ansi.length);
+	}
+	return `${body.trimEnd()}${suffix}`;
+}
+
 export function isHorizontalRuleLine(line: string | undefined): boolean {
 	const stripped = stripAnsi(line ?? "").trim();
 	return stripped.length > 0 && /^[─━-]+$/.test(stripped);

--- a/pi-extensions/pi-tool-renderer/extensions/tool-renderer/chrome.ts
+++ b/pi-extensions/pi-tool-renderer/extensions/tool-renderer/chrome.ts
@@ -6,6 +6,7 @@ import {
 	stripAnsi,
 	stripLeadingBackgroundLayer,
 	trimOuterBlankLines,
+	trimTrailingWhitespaceBeforeAnsi,
 	wrapTextWithAnsi,
 } from "./ansi.js";
 import { captureDiffBackgroundTheme } from "./diff.js";
@@ -146,10 +147,11 @@ export function installToolChromePatch(): void {
 		const effectiveCwd = this?.cwd ?? process.cwd();
 		const renderWidth = stableRenderWidth(width, effectiveCwd);
 		const core = rendered.slice(start, end + 1).flatMap((line) => {
-			// Pi's Text component pads rows to the full render width. The right-margin
-			// guard intentionally wraps at width - 1, so padded rows otherwise spill a
-			// trailing space onto a blank continuation line after every row.
-			const wrapped = wrapTextWithAnsi(stripLeadingBackgroundLayer(line).trimEnd(), renderWidth);
+			// Pi's Text/Box components pad rows before trailing SGR reset codes.
+			// Plain trimEnd() cannot see those spaces when ANSI comes after them;
+			// if they survive, the right-margin guard wraps each padded row into a
+			// blank continuation line. Trim visually trailing spaces before wrapping.
+			const wrapped = wrapTextWithAnsi(trimTrailingWhitespaceBeforeAnsi(stripLeadingBackgroundLayer(line)), renderWidth);
 			return wrapped.length > 0 ? wrapped : [""];
 		});
 		if (mode === "transparent") return core;


### PR DESCRIPTION
## Problem
Some custom/native tool outputs, notably `agent_browser eval`, were rendering with a blank-looking line after every real line when Tool Renderer chrome was enabled with the right-margin guard.

The visible output looked like double-spaced JSON/text, even though the underlying tool result did not contain those blank lines. Built-in compact-rendered tools were mostly unaffected, which made the issue appear specific to agent-browser and a few similar tools.

## Cause
Tool chrome post-processes rendered rows and wraps them one column short to avoid terminal right-margin auto-wrap. Pi's `Text`/`Box` rendering can pad rows with spaces before trailing ANSI reset sequences. Plain `.trimEnd()` does not remove those spaces because the string technically ends with ANSI bytes, not whitespace.

Those leftover padding spaces then wrap into whitespace-only continuation rows, producing the apparent blank line after each output line.

## Fix
Add an ANSI-aware trailing trim helper and use it before tool chrome re-wraps rows. This removes visually trailing padding while preserving trailing ANSI control sequences.

## Verification
- Ran `git diff --check`
- Manually verified in Pi with `agent_browser eval --stdin`: multi-line JSON now renders without blank spacer lines between every line
