### PR TITLE
feat(flightdeck-core): activity export filter parity + polish trio (closes #92, #95)

### DIFF
--- a/skills/flightdeck/lib/flightdeck-core/src/bin/flightdeck-state.ts
+++ b/skills/flightdeck/lib/flightdeck-core/src/bin/flightdeck-state.ts
@@ -9,7 +9,7 @@ import { join } from "node:path";
 import { appendActivityEvent } from "../activity/append.ts";
 import { emitActivity } from "../activity/emit.ts";
 import { formatActivityJsonl, formatActivityLine, formatActivityMarkdown } from "../activity/format.ts";
-import { activityPathForSession } from "../activity/paths.ts";
+import { activityPathForSession, activityPathFromStatePath } from "../activity/paths.ts";
 import { emitMergePlanUpdated, emitSessionCompleted, emitSessionStarted } from "../activity/workflow-emit.ts";
 import { ActivityFilterError, readActivityEvents, readActivityJsonlLines, tailActivityEvents } from "../activity/read.ts";
 import {
@@ -246,7 +246,9 @@ function dieActivityError(error: unknown): never {
 	die(`Error: ${String(error)}`, 1);
 }
 
-function activityFile(): string {
+function activityFile(overrides: { session?: string; stateFile?: string } = {}): string {
+	if (overrides.stateFile) return activityPathFromStatePath(overrides.stateFile);
+	if (overrides.session) return activityPathForSession(overrides.session, resolveStateBase());
 	const envActivity = process.env.FLIGHTDECK_ACTIVITY_FILE;
 	if (typeof envActivity === "string" && envActivity.trim()) return envActivity.trim();
 	return activityPathForSession(session, resolveStateBase());
@@ -255,14 +257,15 @@ function activityFile(): string {
 function runActivity(args: string[]): void {
 	const sub = args[0];
 	if (!sub) die("Usage: activity <path|append|tail|export> [args]");
-	const activity = activityFile();
 	switch (sub) {
 		case "path": {
-			process.stdout.write(`${activity}\n`);
+			const opts = parseActivityReadFlags(args.slice(1), { defaultFormat: "text" });
+			process.stdout.write(`${activityFile({ session: opts.session, stateFile: opts.stateFile })}\n`);
 			break;
 		}
 		case "append": {
-			const jsonText = args.length >= 2 ? args[1]! : readStdinOrDie("Usage: activity append <json-event>");
+			const { session: sessionOverride, stateFile: stateFileOverride, positionals } = parseActivityAppendArgs(args.slice(1));
+			const jsonText = positionals.length >= 1 ? positionals[0]! : readStdinOrDie("Usage: activity append <json-event>");
 			let payload: unknown;
 			try {
 				payload = JSON.parse(jsonText);
@@ -270,8 +273,9 @@ function runActivity(args: string[]): void {
 				die("Error: invalid json-event");
 			}
 			if (!payload || typeof payload !== "object" || Array.isArray(payload)) die("Error: json-event must be an object");
+			const activity = activityFile({ session: sessionOverride, stateFile: stateFileOverride });
 			try {
-				const result = appendActivityEvent(activity, payload, { sessionId: session });
+				const result = appendActivityEvent(activity, payload, { sessionId: sessionOverride || session });
 				const output: { id: string; deduped: boolean; archived?: true } = {
 					id: result.event.id,
 					deduped: !result.appended && !result.archived,
@@ -285,6 +289,7 @@ function runActivity(args: string[]): void {
 		}
 		case "tail": {
 			const opts = parseActivityReadFlags(args.slice(1), { defaultFormat: "text", defaultLimit: 300 });
+			const activity = activityFile({ session: opts.session, stateFile: opts.stateFile });
 			try {
 				const events = tailActivityEvents(activity, opts.limit, { filter: opts.filter, warn: warnLine });
 				if (opts.format === "json") process.stdout.write(formatActivityJsonl(events));
@@ -296,6 +301,7 @@ function runActivity(args: string[]): void {
 		}
 		case "export": {
 			const opts = parseActivityReadFlags(args.slice(1), { defaultFormat: "jsonl" });
+			const activity = activityFile({ session: opts.session, stateFile: opts.stateFile });
 			try {
 				if (opts.format === "markdown") {
 					const events = readActivityEvents(activity, { filter: opts.filter, warn: warnLine });
@@ -316,10 +322,27 @@ function runActivity(args: string[]): void {
 	}
 }
 
-function parseActivityReadFlags(args: string[], defaults: { defaultFormat: "text" | "json" | "jsonl" | "markdown"; defaultLimit?: number }): { filter?: string; format: "text" | "json" | "jsonl" | "markdown"; limit: number } {
+function parseActivityAppendArgs(args: string[]): { session?: string; stateFile?: string; positionals: string[] } {
+	let session: string | undefined;
+	let stateFile: string | undefined;
+	const positionals: string[] = [];
+	for (let i = 0; i < args.length; i += 1) {
+		const arg = args[i]!;
+		if (arg === "--session") { session = args[++i] ?? ""; continue; }
+		if (arg.startsWith("--session=")) { session = arg.slice("--session=".length); continue; }
+		if (arg === "--state-file") { stateFile = args[++i] ?? ""; continue; }
+		if (arg.startsWith("--state-file=")) { stateFile = arg.slice("--state-file=".length); continue; }
+		positionals.push(arg);
+	}
+	return { positionals, session: session || undefined, stateFile: stateFile || undefined };
+}
+
+function parseActivityReadFlags(args: string[], defaults: { defaultFormat: "text" | "json" | "jsonl" | "markdown"; defaultLimit?: number }): { filter?: string; format: "text" | "json" | "jsonl" | "markdown"; limit: number; session?: string; stateFile?: string } {
 	let format = defaults.defaultFormat;
 	let limit = defaults.defaultLimit ?? Number.MAX_SAFE_INTEGER;
 	let filter: string | undefined;
+	let session: string | undefined;
+	let stateFile: string | undefined;
 	for (let i = 0; i < args.length; i += 1) {
 		const arg = args[i]!;
 		if (arg === "--json") { format = "json"; continue; }
@@ -329,9 +352,13 @@ function parseActivityReadFlags(args: string[], defaults: { defaultFormat: "text
 		if (arg.startsWith("--format=")) { format = parseActivityFormat(arg.slice("--format=".length)); continue; }
 		if (arg === "--filter") { filter = args[++i] ?? ""; continue; }
 		if (arg.startsWith("--filter=")) { filter = arg.slice("--filter=".length); continue; }
+		if (arg === "--session") { session = args[++i] ?? ""; continue; }
+		if (arg.startsWith("--session=")) { session = arg.slice("--session=".length); continue; }
+		if (arg === "--state-file") { stateFile = args[++i] ?? ""; continue; }
+		if (arg.startsWith("--state-file=")) { stateFile = arg.slice("--state-file=".length); continue; }
 		die(`Unknown activity flag: ${arg}`);
 	}
-	return { filter, format, limit };
+	return { filter, format, limit, session: session || undefined, stateFile: stateFile || undefined };
 }
 
 function parseActivityFormat(value: string | undefined): "jsonl" | "markdown" {

--- a/skills/flightdeck/lib/flightdeck-core/src/bin/pane-registry.ts
+++ b/skills/flightdeck/lib/flightdeck-core/src/bin/pane-registry.ts
@@ -981,15 +981,25 @@ function cmdReconcile(): void {
 			// pane-gone IS their terminal signal. Transition state to
 			// `complete` and emit `entry.completed` instead of dropping +
 			// `entry.dead`. Non-shell-adhoc entries keep the legacy drop.
+			const terminalEmittedAt = typeof rec.terminal_emitted_at === "string"
+				? rec.terminal_emitted_at
+				: null;
 			const wake = decideShellAdhocWake({
 				kind: String(rec.kind ?? ""),
 				harness: String(rec.harness ?? ""),
 				state: stateStr,
 				paneAlive: false,
+				terminalEmittedAt,
 			});
 			if (wake.transition) {
 				const idJson = JSON.stringify(issue);
 				fdStateOrDie(["set", `.entries[${idJson}].state`, JSON.stringify(wake.nextState)]);
+				const emittedAt = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+				fdStateOrDie([
+					"set",
+					`.entries[${idJson}].terminal_emitted_at`,
+					JSON.stringify(emittedAt),
+				]);
 				emitReconcileShellComplete(droppedEntry);
 				completed.push(issue);
 				continue;

--- a/skills/flightdeck/lib/flightdeck-core/src/daemon/edit-loop-detector.ts
+++ b/skills/flightdeck/lib/flightdeck-core/src/daemon/edit-loop-detector.ts
@@ -14,15 +14,11 @@
 // caller can emit a synthetic `blocked` outbox row. The state Map is
 // trimmed to the last N entries so memory stays bounded.
 //
-// Production wiring (subscribers.bash pi_subscriber_loop) currently
-// emits a `pi-edit-tool-loop` wake-event row to WAKE_EVENTS_LOG when
-// the bash mirror crosses the threshold; the daemon's canonical-tag
-// path then wakes master. `buildEditLoopSyntheticOutbox` below is
-// reserved for a future TS-side caller that wants to write a real
-// synthetic outbox JSON (via the W5 defaultWriteSyntheticOutbox
-// helper) the way pi-agents-tmux's agent-end + idle-stall watchdogs
-// do. Kept exported because the wiring is a likely follow-up; the
-// shape is locked by tests so a future caller can rely on it.
+// Production wiring (subscribers.bash pi_subscriber_loop) emits a
+// `pi-edit-tool-loop` wake-event row to WAKE_EVENTS_LOG when the bash
+// mirror crosses the threshold; the daemon's canonical-tag path then
+// wakes master. There is no TS-side synthetic outbox writer; the bash
+// emit IS the production path.
 //
 // Configuration via env vars (read by the caller, not by this module):
 //   VSTACK_EDIT_LOOP_DETECTOR=0     disables the detector entirely.
@@ -104,51 +100,6 @@ export function evaluateEditLoop(
 export function resetEditLoopPane(state: EditLoopState, paneId: string): void {
 	state.timestamps.delete(paneId);
 	state.fired.delete(paneId);
-}
-
-export interface EditLoopSyntheticOutbox {
-	agent: string;
-	taskId: string;
-	status: "blocked";
-	summary: string;
-	filesChanged: string[];
-	validation: string[];
-	reason: typeof EDIT_LOOP_REASON;
-	synthetic: true;
-	consecutive_failures: number;
-	window_sec: number;
-	notes: string;
-}
-
-/**
- * Build a synthetic `blocked` outbox payload for a pane that crossed
- * the edit-loop threshold. NOT called by the current production wiring
- * (the bash subscriber emits a wake-event row, not an outbox). Kept
- * exported for a future TS-side caller that wants to write a real
- * outbox JSON via the W5 defaultWriteSyntheticOutbox helper; the
- * shape + tests are locked here so a follow-up wiring can rely on it.
- */
-export function buildEditLoopSyntheticOutbox(input: {
-	agent: string;
-	taskId: string;
-	consecutiveFailures: number;
-	windowMs: number;
-}): EditLoopSyntheticOutbox {
-	const windowSec = Math.max(1, Math.floor(input.windowMs / 1000));
-	return {
-		agent: input.agent,
-		taskId: input.taskId,
-		status: "blocked",
-		summary: `Agent is in a post-compaction edit-loop: ${input.consecutiveFailures} consecutive edit-tool failures inside ${windowSec}s. Master should kill the pane and re-dispatch.`,
-		filesChanged: [],
-		validation: [],
-		reason: EDIT_LOOP_REASON,
-		synthetic: true,
-		consecutive_failures: input.consecutiveFailures,
-		window_sec: windowSec,
-		notes:
-			"Synthesized by edit-loop detector (vstack#67 workaround). status=blocked because the agent is actively erroring, not idle; master should kill the pane and re-dispatch with a resume brief.",
-	};
 }
 
 export function editLoopDetectorEnabledFromEnv(env: NodeJS.ProcessEnv = process.env): boolean {

--- a/skills/flightdeck/lib/flightdeck-core/src/daemon/loop.ts
+++ b/skills/flightdeck/lib/flightdeck-core/src/daemon/loop.ts
@@ -659,7 +659,7 @@ export async function runLoop(opts: RunLoopOpts): Promise<void> {
 					sessionLock, eventsFile, wakePending, lastEventKey,
 				});
 				if (appended) {
-					recordBellWake(bellWakeState, innerId, now);
+					recordBellWake(bellWakeState, innerId, tag, now);
 					tickActivity.push({ classifier_tag: tag, event_type: tag, hash, harness, pane_id: innerId });
 					tickReasons.push(`bell:${innerId}:${tag}`);
 					tickPending.push({ paneId: innerId, hash, tag, isBell: true });

--- a/skills/flightdeck/lib/flightdeck-core/src/daemon/shell-adhoc-wake.ts
+++ b/skills/flightdeck/lib/flightdeck-core/src/daemon/shell-adhoc-wake.ts
@@ -36,6 +36,14 @@ export interface ShellAdhocWakeInput {
 	state: string;
 	/** True iff the registered `pane_id` is still in `tmux list-panes -a`. */
 	paneAlive: boolean;
+	/**
+	 * `.entries[].terminal_emitted_at` — ISO8601 marker recorded on the
+	 * first synthetic terminal-state transition. Suppresses re-emission
+	 * when an operator resets state back from a terminal value
+	 * (vstack#95C); operators wanting a fresh emit must clear the marker
+	 * explicitly.
+	 */
+	terminalEmittedAt?: string | null;
 }
 
 export interface ShellAdhocWakeSkip {
@@ -44,7 +52,8 @@ export interface ShellAdhocWakeSkip {
 		| "pane-alive"
 		| "not-adhoc"
 		| "not-shell"
-		| "already-terminal";
+		| "already-terminal"
+		| "marker-present";
 }
 
 export interface ShellAdhocWakeTransition {
@@ -62,8 +71,13 @@ export type ShellAdhocWakeOutcome = ShellAdhocWakeSkip | ShellAdhocWakeTransitio
  *   - pane is gone (`paneAlive === false`)
  *   - kind is exactly "adhoc" (case-insensitive)
  *   - harness is exactly "shell" (case-insensitive)
- *   - current state is not already terminal (idempotency — don't re-emit
- *     entry.completed every reconcile tick for the same entry)
+ *   - current state is not already terminal (idempotency for the
+ *     normal terminal-state path)
+ *   - `terminal_emitted_at` marker is absent (vstack#95C idempotency:
+ *     if a prior tick already emitted entry.completed for this entry,
+ *     a manual reset to a non-terminal state must NOT re-trigger the
+ *     synthetic emit. Operator surgery wanting a fresh emit can clear
+ *     the marker explicitly.)
  *
  * All other cases skip with a reason string for diagnostics.
  */
@@ -75,5 +89,8 @@ export function decideShellAdhocWake(input: ShellAdhocWakeInput): ShellAdhocWake
 	if (kind !== "adhoc") return { transition: false, reason: "not-adhoc" };
 	if (harness !== "shell") return { transition: false, reason: "not-shell" };
 	if (TERMINAL_STATES.has(state)) return { transition: false, reason: "already-terminal" };
+	if (typeof input.terminalEmittedAt === "string" && input.terminalEmittedAt.trim()) {
+		return { transition: false, reason: "marker-present" };
+	}
 	return { transition: true, nextState: "complete" };
 }

--- a/skills/flightdeck/lib/flightdeck-core/src/daemon/wake-filter.ts
+++ b/skills/flightdeck/lib/flightdeck-core/src/daemon/wake-filter.ts
@@ -36,7 +36,7 @@ export type BellWakeDecision =
 	| { emit: false; reason: string; suppressedUntil?: number };
 
 export interface BellWakeState {
-	/** Map of paneId -> epoch seconds of most recent bell wake. */
+	/** Map of `${paneId}:${tag}` -> epoch seconds of most recent bell wake. */
 	lastBellWakeAt: Map<string, number>;
 }
 
@@ -44,18 +44,18 @@ export function makeBellWakeState(): BellWakeState {
 	return { lastBellWakeAt: new Map() };
 }
 
-// Rate-limit is keyed per-pane, not per-tag. Two distinct canonical bell-tagged
-// events on the same pane inside FD_BELL_WAKE_INTERVAL_SEC collapse to one wake.
-// The stable-age classifier still picks up new state on the next tick within
-// `stab` seconds, so events are delayed rather than lost. If per-tag granularity
-// becomes important, key lastBellWakeAt by `${paneId}:${tag}` instead.
+// Rate-limit is keyed by `${paneId}:${tag}` so distinct canonical bell-tagged
+// events on the same pane (e.g. merge-now vs question.opened) get independent
+// windows and both fire within FD_BELL_WAKE_INTERVAL_SEC. Storms on a single
+// tag are still capped at one wake per interval; the stable-age classifier
+// picks up the next observation on the next tick within `stab` seconds.
 export function shouldEmitBellWake(state: BellWakeState, opts: BellWakeOptions): BellWakeDecision {
 	if (!opts.isCanonical) {
 		return { emit: false, reason: BELL_NON_CANONICAL_DROP_REASON };
 	}
 	const interval = Math.max(0, Math.floor(opts.intervalSec ?? BELL_WAKE_INTERVAL_DEFAULT_SEC));
 	if (interval > 0) {
-		const last = state.lastBellWakeAt.get(opts.paneId);
+		const last = state.lastBellWakeAt.get(bellWakeKey(opts.paneId, opts.tag));
 		if (last !== undefined && opts.nowSec - last < interval) {
 			return {
 				emit: false,
@@ -67,8 +67,12 @@ export function shouldEmitBellWake(state: BellWakeState, opts: BellWakeOptions):
 	return { emit: true };
 }
 
-export function recordBellWake(state: BellWakeState, paneId: string, nowSec: number): void {
-	state.lastBellWakeAt.set(paneId, nowSec);
+export function recordBellWake(state: BellWakeState, paneId: string, tag: string, nowSec: number): void {
+	state.lastBellWakeAt.set(bellWakeKey(paneId, tag), nowSec);
+}
+
+function bellWakeKey(paneId: string, tag: string): string {
+	return `${paneId}:${tag}`;
 }
 
 export function bellWakeIntervalFromEnv(env: NodeJS.ProcessEnv = process.env): number {

--- a/skills/flightdeck/lib/flightdeck-core/src/state/types.ts
+++ b/skills/flightdeck/lib/flightdeck-core/src/state/types.ts
@@ -82,6 +82,13 @@ export interface TrackedEntry {
 	decisions_log?: DecisionLogEntry[];
 	unknown_since?: string | null;
 	merge_commit?: string | null;
+	/**
+	 * ISO8601 timestamp recorded when a synthetic terminal-state
+	 * transition fires (vstack#95C). Suppresses re-emission when an
+	 * operator manually resets state back from a terminal value;
+	 * clearing the marker explicitly re-enables a fresh emit.
+	 */
+	terminal_emitted_at?: string | null;
 	[key: string]: unknown;
 }
 

--- a/skills/flightdeck/lib/flightdeck-core/tests/parity/adhoc-shell-wake.test.ts
+++ b/skills/flightdeck/lib/flightdeck-core/tests/parity/adhoc-shell-wake.test.ts
@@ -140,4 +140,45 @@ describe("decideShellAdhocWake (vstack#85 Fix A)", () => {
 	test("TERMINAL_STATES export matches the documented vocabulary", () => {
 		expect([...TERMINAL_STATES].sort()).toEqual(["aborted", "cancelled", "complete", "dead", "merged"]);
 	});
+
+	test("vstack#95C: terminal_emitted_at marker suppresses re-emit after manual state reset", () => {
+		const outcome = decideShellAdhocWake({
+			kind: "adhoc",
+			harness: "shell",
+			state: "waiting",
+			paneAlive: false,
+			terminalEmittedAt: "2026-05-15T10:10:00Z",
+		});
+		expect(outcome.transition).toBe(false);
+		if (outcome.transition) throw new Error("expected transition=false");
+		expect(outcome.reason).toBe("marker-present");
+	});
+
+	test("vstack#95C: cleared marker re-enables a fresh emit (operator override path)", () => {
+		for (const marker of [null, undefined, "", "   "]) {
+			const outcome = decideShellAdhocWake({
+				kind: "adhoc",
+				harness: "shell",
+				state: "waiting",
+				paneAlive: false,
+				terminalEmittedAt: marker,
+			});
+			expect(outcome.transition).toBe(true);
+			if (!outcome.transition) throw new Error(`expected transition=true for marker=${String(marker)}`);
+			expect(outcome.nextState).toBe("complete");
+		}
+	});
+
+	test("vstack#95C: marker on already-terminal state still skips with already-terminal precedence", () => {
+		const outcome = decideShellAdhocWake({
+			kind: "adhoc",
+			harness: "shell",
+			state: "complete",
+			paneAlive: false,
+			terminalEmittedAt: "2026-05-15T10:10:00Z",
+		});
+		expect(outcome.transition).toBe(false);
+		if (outcome.transition) throw new Error("expected transition=false");
+		expect(outcome.reason).toBe("already-terminal");
+	});
 });

--- a/skills/flightdeck/lib/flightdeck-core/tests/parity/bell-wake-rate-limit.test.ts
+++ b/skills/flightdeck/lib/flightdeck-core/tests/parity/bell-wake-rate-limit.test.ts
@@ -59,7 +59,7 @@ describe("shouldEmitBellWake (vstack#68)", () => {
 		const state = makeBellWakeState();
 		const t1 = shouldEmitBellWake(state, { paneId: "%1", tag: "merge-now", isCanonical: true, intervalSec: 60, nowSec: 0 });
 		expect(t1.emit).toBe(true);
-		recordBellWake(state, "%1", 0);
+		recordBellWake(state, "%1", "merge-now", 0);
 
 		const t2 = shouldEmitBellWake(state, { paneId: "%1", tag: "merge-now", isCanonical: true, intervalSec: 60, nowSec: 5 });
 		expect(t2.emit).toBe(false);
@@ -74,14 +74,32 @@ describe("shouldEmitBellWake (vstack#68)", () => {
 
 	test("rate limit is per-pane (a different pane's bell at 5s still fires)", () => {
 		const state = makeBellWakeState();
-		recordBellWake(state, "%1", 0);
+		recordBellWake(state, "%1", "merge-now", 0);
 		const otherPane = shouldEmitBellWake(state, { paneId: "%2", tag: "merge-now", isCanonical: true, intervalSec: 60, nowSec: 5 });
 		expect(otherPane.emit).toBe(true);
 	});
 
+	test("rate limit is per-tag (two distinct canonical tags on the same pane both fire inside the window)", () => {
+		const state = makeBellWakeState();
+		const mergeNow = shouldEmitBellWake(state, { paneId: "%1", tag: "merge-now", isCanonical: true, intervalSec: 60, nowSec: 0 });
+		expect(mergeNow.emit).toBe(true);
+		recordBellWake(state, "%1", "merge-now", 0);
+
+		const questionOpened = shouldEmitBellWake(state, { paneId: "%1", tag: "question.opened", isCanonical: true, intervalSec: 60, nowSec: 5 });
+		expect(questionOpened.emit).toBe(true);
+		recordBellWake(state, "%1", "question.opened", 5);
+
+		const mergeAgain = shouldEmitBellWake(state, { paneId: "%1", tag: "merge-now", isCanonical: true, intervalSec: 60, nowSec: 10 });
+		expect(mergeAgain.emit).toBe(false);
+		if (!mergeAgain.emit) expect(mergeAgain.reason).toBe(BELL_RATE_LIMIT_DROP_REASON);
+
+		const questionAgain = shouldEmitBellWake(state, { paneId: "%1", tag: "question.opened", isCanonical: true, intervalSec: 60, nowSec: 10 });
+		expect(questionAgain.emit).toBe(false);
+	});
+
 	test("interval=0 disables rate limiting", () => {
 		const state = makeBellWakeState();
-		recordBellWake(state, "%1", 0);
+		recordBellWake(state, "%1", "merge-now", 0);
 		const decision = shouldEmitBellWake(state, { paneId: "%1", tag: "merge-now", isCanonical: true, intervalSec: 0, nowSec: 1 });
 		expect(decision.emit).toBe(true);
 	});

--- a/skills/flightdeck/lib/flightdeck-core/tests/parity/edit-loop-detector.test.ts
+++ b/skills/flightdeck/lib/flightdeck-core/tests/parity/edit-loop-detector.test.ts
@@ -10,8 +10,6 @@ import {
 	DEFAULT_EDIT_LOOP_CONFIG,
 	EDIT_LOOP_DEFAULT_THRESHOLD_N,
 	EDIT_LOOP_DEFAULT_WINDOW_SEC,
-	EDIT_LOOP_REASON,
-	buildEditLoopSyntheticOutbox,
 	editLoopConfigFromEnv,
 	editLoopDetectorEnabledFromEnv,
 	editLoopThresholdFromEnv,
@@ -133,27 +131,6 @@ describe("evaluateEditLoop (vstack#67)", () => {
 		// Once fired, the pane is in `fired` so the entry list freezes —
 		// but the most recent N entries must still be exactly thresholdN.
 		expect(entries.length).toBeLessThanOrEqual(EDIT_LOOP_DEFAULT_THRESHOLD_N);
-	});
-});
-
-describe("buildEditLoopSyntheticOutbox (vstack#67)", () => {
-	test("status is blocked (not needs_completion); carries reason + window + count", () => {
-		const outbox = buildEditLoopSyntheticOutbox({ agent: "rust", taskId: "task-1", consecutiveFailures: 5, windowMs: 120_000 });
-		expect(outbox.status).toBe("blocked");
-		expect(outbox.reason).toBe(EDIT_LOOP_REASON);
-		expect(outbox.synthetic).toBe(true);
-		expect(outbox.consecutive_failures).toBe(5);
-		expect(outbox.window_sec).toBe(120);
-		expect(outbox.summary).toMatch(/post-compaction edit-loop/);
-		expect(outbox.summary).toMatch(/5 consecutive edit-tool failures/);
-		expect(outbox.notes).toMatch(/master should kill the pane and re-dispatch/);
-	});
-
-	test("windowMs floors to seconds (>=1)", () => {
-		expect(
-			buildEditLoopSyntheticOutbox({ agent: "x", taskId: "y", consecutiveFailures: 5, windowMs: 500 })
-				.window_sec,
-		).toBe(1);
 	});
 });
 

--- a/skills/flightdeck/lib/flightdeck-core/tests/parity/edit-loop-wiring.test.ts
+++ b/skills/flightdeck/lib/flightdeck-core/tests/parity/edit-loop-wiring.test.ts
@@ -12,12 +12,9 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import {
-	buildEditLoopSyntheticOutbox,
-	DEFAULT_EDIT_LOOP_CONFIG,
 	EDIT_LOOP_CLASSIFIER_TAG,
 	EDIT_LOOP_DEFAULT_THRESHOLD_N,
 	EDIT_LOOP_DEFAULT_WINDOW_SEC,
-	EDIT_LOOP_REASON,
 	evaluateEditLoop,
 	makeEditLoopState,
 } from "../../src/daemon/edit-loop-detector.ts";
@@ -87,21 +84,6 @@ describe("edit-loop wiring: 5-in-window scenario (vstack#67)", () => {
 		}
 		expect(decisions).toEqual(["track", "track", "track", "track", "fire"]);
 		expect(state.fired.has("%42")).toBe(true);
-	});
-
-	test("synthetic outbox shape on fire matches reason=post-compaction-edit-loop", () => {
-		const outbox = buildEditLoopSyntheticOutbox({
-			agent: "rust",
-			taskId: "task-edit-loop",
-			consecutiveFailures: DEFAULT_EDIT_LOOP_CONFIG.thresholdN,
-			windowMs: DEFAULT_EDIT_LOOP_CONFIG.windowMs,
-		});
-		expect(outbox.status).toBe("blocked");
-		expect(outbox.reason).toBe(EDIT_LOOP_REASON);
-		expect(outbox.synthetic).toBe(true);
-		expect(outbox.consecutive_failures).toBe(5);
-		expect(outbox.window_sec).toBe(120);
-		expect(outbox.summary).toMatch(/post-compaction edit-loop/);
 	});
 
 	test("4-in-window then 1 outside window -> no fire", () => {

--- a/skills/flightdeck/lib/flightdeck-core/tests/parity/flightdeck-state.test.ts
+++ b/skills/flightdeck/lib/flightdeck-core/tests/parity/flightdeck-state.test.ts
@@ -383,6 +383,48 @@ describe("flightdeck-state CLI", () => {
 		expect(markdown.stdout).toContain("A1 registered");
 	});
 
+	test("activity export honors --session and --state-file overrides", () => {
+		run(repo, ["init"]);
+		run(repo, ["activity", "append", JSON.stringify({
+			entry_id: "PRIMARY",
+			natural_key: "PRIMARY:start",
+			source: "flightdeck",
+			summary: "primary session line",
+			type: "entry.registered",
+		})]);
+		const stateDir = join(repo, "tmp");
+		mkdirSync(stateDir, { recursive: true });
+		const altSession = "ALT";
+		const altActivity = join(stateDir, `flightdeck-activity-${altSession}.jsonl`);
+		const altEvent = {
+			entry_id: "ALT1",
+			id: "alt-1",
+			natural_key: "ALT1:start",
+			schema_version: 1,
+			session_id: altSession,
+			source: "flightdeck",
+			summary: "alt session line",
+			ts: "2026-05-15T10:00:00Z",
+			type: "entry.registered",
+		};
+		writeFileSync(altActivity, `${JSON.stringify(altEvent)}\n`, "utf8");
+
+		const exportedBySession = run(repo, ["activity", "export", "--session", altSession]);
+		expect(exportedBySession.status).toBe(0);
+		expect(exportedBySession.stdout).toBe(`${JSON.stringify(altEvent)}\n`);
+		expect(exportedBySession.stdout).not.toContain("primary session line");
+
+		const altStateFile = join(stateDir, `flightdeck-state-${altSession}.json`);
+		writeFileSync(altStateFile, JSON.stringify({ session_id: altSession }), "utf8");
+		const exportedByStateFile = run(repo, ["activity", "export", "--state-file", altStateFile]);
+		expect(exportedByStateFile.status).toBe(0);
+		expect(exportedByStateFile.stdout).toBe(`${JSON.stringify(altEvent)}\n`);
+
+		const defaultExport = run(repo, ["activity", "export", "--format", "jsonl"]);
+		expect(defaultExport.status).toBe(0);
+		expect(defaultExport.stdout).toContain("primary session line");
+	});
+
 	test("activity append and filters reject invalid input", () => {
 		const invalidSeverity = run(repo, ["activity", "append", JSON.stringify({
 			severity: "bad",


### PR DESCRIPTION
Two commits.

`ab0f09ec` (#92): `flightdeck-state activity` subcommands now all accept `--session <name>` and `--state-file <path>` uniformly (previously only `path`/`tail`/`append` did; `export` did not). Precedence: explicit `--state-file` > explicit `--session` > `FLIGHTDECK_ACTIVITY_FILE` > global `--session`.

`7322b5e0` (#95): three flightdeck-core polish items bundled —
- Bell wake rate-limit keys on `${paneId}:${tag}` (was `${paneId}` only). Distinct canonical tags on the same pane now both fire within `FD_BELL_WAKE_INTERVAL_SEC`.
- `buildEditLoopSyntheticOutbox` + interface + tests deleted (dead code per CLAUDE.md rule; bash subscriber owns the emit).
- Adhoc-shell synthetic terminal transition writes `terminal_emitted_at` marker; `decideShellAdhocWake` reads it to suppress re-emission after manual state resets (closes the F3 edge case from #87 round-1 review).

516 tests pass; typecheck clean.