### PR TITLE
fix(pi-tool-renderer): per-call timeout in tool_batch prevents indefinite hangs (closes #96)

### DIFF
--- a/pi-extensions/pi-tool-renderer/.gitignore
+++ b/pi-extensions/pi-tool-renderer/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+bun.lock

--- a/pi-extensions/pi-tool-renderer/extensions/__tests__/batch-timeout.test.ts
+++ b/pi-extensions/pi-tool-renderer/extensions/__tests__/batch-timeout.test.ts
@@ -1,0 +1,190 @@
+// Regression coverage for vstack#96: tool_batch hangs indefinitely when an
+// inner tool never resolves. The fix wraps each inner call in a
+// Promise.race against a per-call timeout and aborts the child signal so
+// cooperative tools can clean up subprocess handles.
+
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { registerToolBatch } from "../tool-renderer/batch.js";
+
+const RENDERER_CONFIG_ID = "@vanillagreen/pi-tool-renderer";
+
+function writeBatchSettings(cwd: string, overrides: Record<string, unknown>): void {
+	mkdirSync(join(cwd, ".pi"), { recursive: true });
+	writeFileSync(
+		join(cwd, ".pi", "settings.json"),
+		JSON.stringify({
+			vstack: {
+				extensionManager: {
+					config: { [RENDERER_CONFIG_ID]: overrides },
+				},
+			},
+		}),
+		"utf8",
+	);
+}
+
+interface CapturedDef {
+	execute: (
+		toolCallId: string,
+		params: unknown,
+		signal: AbortSignal | undefined,
+		onUpdate: unknown,
+		context: unknown,
+	) => Promise<{ details?: unknown; isError?: boolean; content?: Array<{ text: string; type: string }> }>;
+	[key: string]: unknown;
+}
+
+function makeFakePi(): { tools: CapturedDef[]; registerTool: (def: CapturedDef) => void } {
+	const tools: CapturedDef[] = [];
+	return {
+		registerTool(def: CapturedDef): void {
+			tools.push(def);
+		},
+		tools,
+	};
+}
+
+function fakeSuccessTool(text: string): { execute: (id: string, args: unknown) => Promise<unknown> } {
+	return {
+		execute: async () => ({
+			content: [{ text, type: "text" }],
+			details: { ok: true },
+			isError: false,
+		}),
+	};
+}
+
+function fakeHangingTool(onAbort: () => void): { execute: (id: string, args: unknown, signal: AbortSignal) => Promise<never> } {
+	return {
+		execute: (_id: string, _args: unknown, signal: AbortSignal) =>
+			new Promise<never>((_, reject) => {
+				const abortHandler = () => {
+					onAbort();
+					reject(new DOMException("aborted", "AbortError"));
+				};
+				if (signal.aborted) {
+					abortHandler();
+					return;
+				}
+				signal.addEventListener("abort", abortHandler, { once: true });
+			}),
+	};
+}
+
+function fakeAgent(opts: { hangingTool: ReturnType<typeof fakeHangingTool> }): Record<string, () => unknown> {
+	return {
+		createBashTool: () => fakeSuccessTool("ok-bash"),
+		createEditTool: () => null,
+		createFindTool: () => null,
+		createGrepTool: () => fakeSuccessTool("ok-grep"),
+		createLsTool: () => null,
+		createReadTool: () => opts.hangingTool,
+		createWriteTool: () => null,
+	};
+}
+
+describe("tool_batch per-call timeout (vstack#96)", () => {
+	test(
+		"inner tool that never resolves times out, siblings succeed, child signal is aborted",
+		async () => {
+			const cwd = mkdtempSync(join(tmpdir(), "tool-batch-timeout-"));
+			// Floor is 1000ms so anything below clamps up; pass that exact value so
+			// the asserted message and elapsed budget match without surprise.
+			writeBatchSettings(cwd, { batchCallTimeoutMs: 1000 });
+
+			let abortCount = 0;
+			const hangingTool = fakeHangingTool(() => {
+				abortCount += 1;
+			});
+			const agent = fakeAgent({ hangingTool });
+			const pi = makeFakePi();
+			registerToolBatch(pi as unknown as Parameters<typeof registerToolBatch>[0], agent, cwd);
+			expect(pi.tools.length).toBe(1);
+			const def = pi.tools[0]!;
+
+			const started = Date.now();
+			const result = await def.execute(
+				"toolcall-1",
+				{
+					calls: [
+						{ args: {}, tool: "bash" },
+						{ args: { path: "wedged.md" }, tool: "read" },
+						{ args: { pattern: "foo" }, tool: "grep" },
+					],
+				},
+				undefined,
+				undefined,
+				{ cwd },
+			);
+			const elapsedMs = Date.now() - started;
+
+			// Budget: the 1s timeout plus generous slack for slow CI hosts.
+			expect(elapsedMs).toBeLessThan(5_000);
+			const details = result.details as {
+				failed: number;
+				items: Array<{ isError: boolean; resultText: string; toolName: string }>;
+				succeeded: number;
+				total: number;
+			};
+			expect(details.total).toBe(3);
+			expect(details.succeeded).toBe(2);
+			expect(details.failed).toBe(1);
+			const readItem = details.items.find((item) => item.toolName === "read");
+			expect(readItem).toBeDefined();
+			expect(readItem!.isError).toBe(true);
+			expect(readItem!.resultText).toContain("timed out");
+			expect(readItem!.resultText).toContain("1000ms");
+			expect(readItem!.resultText).toContain("read");
+			const bashItem = details.items.find((item) => item.toolName === "bash");
+			expect(bashItem!.isError).toBe(false);
+			expect(bashItem!.resultText).toContain("ok-bash");
+			const grepItem = details.items.find((item) => item.toolName === "grep");
+			expect(grepItem!.isError).toBe(false);
+			// Cooperative cleanup: the child signal was aborted on timeout so
+			// long-running inners can release subprocess handles.
+			expect(abortCount).toBe(1);
+			expect(result.isError).toBe(true);
+		},
+		10_000,
+	);
+
+	test(
+		"explicit timeout below the floor clamps to the 1s minimum",
+		async () => {
+			const cwd = mkdtempSync(join(tmpdir(), "tool-batch-floor-"));
+			// Configure an absurdly low timeout — the floor must override it so
+			// quick happy-path callers still get a sane window on slow hosts.
+			writeBatchSettings(cwd, { batchCallTimeoutMs: 1 });
+
+			const hangingTool = fakeHangingTool(() => {});
+			const agent = fakeAgent({ hangingTool });
+			const pi = makeFakePi();
+			registerToolBatch(pi as unknown as Parameters<typeof registerToolBatch>[0], agent, cwd);
+			const def = pi.tools[0]!;
+
+			const started = Date.now();
+			const result = await def.execute(
+				"toolcall-2",
+				{ calls: [{ args: { path: "x" }, tool: "read" }] },
+				undefined,
+				undefined,
+				{ cwd },
+			);
+			const elapsedMs = Date.now() - started;
+
+			// Must wait at least the 1s floor before rejecting.
+			expect(elapsedMs).toBeGreaterThanOrEqual(900);
+			const details = result.details as {
+				failed: number;
+				items: Array<{ resultText: string }>;
+			};
+			expect(details.failed).toBe(1);
+			expect(details.items[0]!.resultText).toContain("1000ms");
+		},
+		10_000,
+	);
+});

--- a/pi-extensions/pi-tool-renderer/extensions/tool-renderer/batch.ts
+++ b/pi-extensions/pi-tool-renderer/extensions/tool-renderer/batch.ts
@@ -39,6 +39,8 @@ interface BatchToolDetails {
 
 const TOOL_BATCH_MAX_OUTPUT_BYTES = 50 * 1024;
 const TOOL_BATCH_MAX_OUTPUT_LINES = 2_000;
+const TOOL_BATCH_DEFAULT_CALL_TIMEOUT_MS = 120_000;
+const TOOL_BATCH_MIN_CALL_TIMEOUT_MS = 1_000;
 
 function utf8Length(text: string): number {
 	return Buffer.byteLength(text, "utf8");
@@ -268,11 +270,42 @@ export function registerToolBatch(pi: ExtensionAPI, agent: any, cwd: string): vo
 				};
 			}
 			const concurrency = Math.max(1, Math.min(calls.length, Math.floor(Number(params?.concurrency) || calls.length), maxCalls));
+			// vstack#96: per-call timeout so a single wedged inner tool can't block the
+			// aggregate forever. Default 120s, minimum 1s. Each inner gets its own
+			// AbortController so timeout aborts only that call (parent abort still
+			// propagates to all children via the addEventListener bridge).
+			const batchCallTimeoutMs = Math.max(
+				TOOL_BATCH_MIN_CALL_TIMEOUT_MS,
+				Math.floor(settingNumber("batchCallTimeoutMs", TOOL_BATCH_DEFAULT_CALL_TIMEOUT_MS, effectiveCwd)),
+			);
 			const items = await mapBatchWithConcurrency(calls, concurrency, async (call, index): Promise<BatchToolItem> => {
+				const childController = new AbortController();
+				const onParentAbort = () => childController.abort();
+				if (signal) {
+					if (signal.aborted) childController.abort();
+					else signal.addEventListener("abort", onParentAbort);
+				}
+				let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
 				try {
 					const original = getBuiltInTool(agent, effectiveCwd, call.tool);
 					if (!original?.execute) throw new Error(`Built-in tool unavailable: ${call.tool}`);
-					const result = await original.execute(`${toolCallId}:${index}`, call.args, signal, undefined);
+					const timeoutPromise = new Promise<never>((_, reject) => {
+						timeoutHandle = setTimeout(() => {
+							// Reject the race promise BEFORE aborting so the timeout
+							// error wins over any AbortError the inner tool may raise
+							// in response to childController.abort().
+							reject(
+								new Error(
+									`tool_batch inner call ${call.tool} timed out after ${batchCallTimeoutMs}ms`,
+								),
+							);
+							childController.abort();
+						}, batchCallTimeoutMs);
+					});
+					const result = await Promise.race([
+						original.execute(`${toolCallId}:${index}`, call.args, childController.signal, undefined),
+						timeoutPromise,
+					]);
 					return {
 						args: call.args,
 						details: result?.details,
@@ -291,6 +324,9 @@ export function registerToolBatch(pi: ExtensionAPI, agent: any, cwd: string): vo
 						toolName: call.tool,
 						truncated: false,
 					};
+				} finally {
+					if (timeoutHandle) clearTimeout(timeoutHandle);
+					signal?.removeEventListener("abort", onParentAbort);
 				}
 			});
 			const cappedItems = capBatchItemsForAggregate(items);

--- a/pi-extensions/pi-tool-renderer/package.json
+++ b/pi-extensions/pi-tool-renderer/package.json
@@ -100,6 +100,15 @@
           "apply": "live"
         },
         {
+          "key": "batchCallTimeoutMs",
+          "label": "Batch per-call timeout (ms)",
+          "description": "Maximum time tool_batch waits for any single inner tool call before timing it out as an error item. Prevents a never-resolving inner from hanging the whole batch. Minimum 1000ms.",
+          "type": "number",
+          "default": 120000,
+          "category": "Batch Tool",
+          "apply": "live"
+        },
+        {
           "key": "compactUserMessages",
           "label": "Compact user messages",
           "description": "Remove top/bottom padding from user message cards and render an ANSI green border with a red π marker near the top-left instead of a filled background. Disable to restore Pi defaults.",


### PR DESCRIPTION
Closes #96. `tool_batch` previously hung indefinitely when any single inner tool call never resolved.

Adds a `batchCallTimeoutMs` setting (default 120000ms, minimum 1000ms) via the existing `settingNumber` helper. Each inner call is raced against a setTimeout-driven rejection. On timeout: per-call AbortController fires so cooperative inner tools release subprocess handles. Parent abort propagates to all child controllers via an addEventListener bridge with proper finally-block cleanup to prevent listener leak.

Rejection ordering: setTimeout rejects the race promise BEFORE calling `childController.abort()` so the user-facing "timed out" message wins over any bubbled-up AbortError from cooperative tools.

2 bun tests: timeout+cooperative-abort path + 1s floor clamp.