### PR TITLE
fix(pi-background-tasks): annotate terminationReason + harden spawn (closes #97)

### DIFF
--- a/pi-extensions/pi-background-tasks/.gitignore
+++ b/pi-extensions/pi-background-tasks/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+bun.lock

--- a/pi-extensions/pi-background-tasks/extensions/activity.ts
+++ b/pi-extensions/pi-background-tasks/extensions/activity.ts
@@ -56,6 +56,10 @@ export function buildBackgroundTaskActivity(eventType: TaskEventType | "start", 
 			output_bytes: task.outputBytes,
 			sequence,
 			status: task.status,
+			// vstack#97: carry the termination annotation on the broker event
+			// so dashboards / loggers can distinguish self-exit, extension-stop,
+			// reconcile-on-restart, and orphan-watcher finalizes.
+			termination_reason: task.terminationReason,
 		},
 		importance: backgroundTaskImportance(type),
 		refs: { bg_task_id: task.id },

--- a/pi-extensions/pi-background-tasks/extensions/background-tasks.ts
+++ b/pi-extensions/pi-background-tasks/extensions/background-tasks.ts
@@ -565,6 +565,28 @@ export default function backgroundTasks(pi: ExtensionAPI): void {
 		writeFileSync(logFile, "");
 
 		const { shell, args } = getShellConfig();
+		// vstack#97 hardening: spawn the child in its own session / process
+		// group via `detached: true` (Node calls setsid() on POSIX before
+		// exec). This addresses two of the issue's hypotheses:
+		//
+		//   H1 (process-group / parent-death cascade): when Pi exits or is
+		//   restarted, the kernel does NOT propagate SIGHUP / SIGTERM to
+		//   the child because it lives in a separate pgid that is not tied
+		//   to Pi's controlling terminal or session. PR_SET_PDEATHSIG is 0
+		//   by default on Linux for non-prctl'd children, so the child is
+		//   not signaled on parent death even without setsid — setsid is
+		//   the belt-and-braces protection that also covers macOS / BSD.
+		//
+		//   H3 (session-leader cascade): if Pi was attached to a tmux pane
+		//   that subsequently died, SIGHUP would propagate through Pi's
+		//   session leader to every process group in the same session.
+		//   detached: true makes the child its own session leader so the
+		//   cascade stops at Pi's pgid.
+		//
+		// We do NOT call child.unref() here because we still rely on the
+		// child handle for stdout/stderr piping and close-event delivery;
+		// the detached flag only affects session/pgid membership, not
+		// whether the parent waits for the child during normal operation.
 		const child = spawn(shell, [...args, command], {
 			cwd,
 			detached: process.platform !== "win32",

--- a/pi-extensions/pi-background-tasks/extensions/background-tasks.ts
+++ b/pi-extensions/pi-background-tasks/extensions/background-tasks.ts
@@ -254,7 +254,7 @@ export default function backgroundTasks(pi: ExtensionAPI): void {
 			const activityAt = task.lastOutputAt ?? task.updatedAt;
 			lines.push(`${bgTree(theme, isLast ? "└" : "├", activeCtx?.cwd)}${bgStatusIcon(task.status, theme)} ${theme.fg("accent", task.id)} ${theme.fg(
 				"dim",
-				`${summarizeTaskStatus(task.status, task.exitCode)} · ${compactText(taskDisplayName(task), 72)} · ${formatRelativeTime(activityAt)}`,
+				`${summarizeTaskStatus(task.status, task.exitCode, task.terminationReason)} · ${compactText(taskDisplayName(task), 72)} · ${formatRelativeTime(activityAt)}`,
 			)}`);
 		});
 		const hidden = display.length - shown.length;
@@ -516,10 +516,17 @@ export default function backgroundTasks(pi: ExtensionAPI): void {
 	): { ok: boolean; message: string } => {
 		if (!task) return { ok: false, message: "No background task matched that id or pid." };
 		if (task.status !== "running") {
-			return { ok: true, message: `${task.id} is already ${summarizeTaskStatus(task.status, task.exitCode)}.` };
+			return { ok: true, message: `${task.id} is already ${summarizeTaskStatus(task.status, task.exitCode, task.terminationReason)}.` };
 		}
 
 		task.stopReason = reason;
+		// vstack#97: stamp terminationReason eagerly so when the child's
+		// close handler later calls finalizeTaskLifecycle the annotation
+		// is already in place. session_shutdown calls requestStop with
+		// reason="shutdown" so the two paths land on distinct values.
+		if (reason === "user") task.terminationReason = "extension-stop";
+		else if (reason === "shutdown") task.terminationReason = "session-shutdown";
+		else if (reason === "timeout") task.terminationReason = "timeout";
 		task.updatedAt = Date.now();
 		voidPendingTaskWakes(task, reason === "shutdown" ? "shutdown" : "stop", logWakeDiagnostic);
 		rememberSnapshot(task);
@@ -603,6 +610,7 @@ export default function backgroundTasks(pi: ExtensionAPI): void {
 			startedAt: now,
 			status: "running",
 			stopReason: null,
+			terminationReason: undefined,
 			timeoutTimer: null,
 			title: options.title?.trim() || command,
 			updatedAt: now,
@@ -744,6 +752,10 @@ export default function backgroundTasks(pi: ExtensionAPI): void {
 		for (const task of tasks.values()) {
 			if (task.status === "running") {
 				task.stopReason = "shutdown";
+				// vstack#97: explicit annotation for the session_shutdown
+				// kill path so a later restore can tell shutdown-kills from
+				// reconcile-on-restart coercion.
+				task.terminationReason = "session-shutdown";
 				voidPendingTaskWakes(task, "shutdown", logWakeDiagnostic);
 				task.status = "stopped";
 				task.updatedAt = Date.now();

--- a/pi-extensions/pi-background-tasks/extensions/dashboard.ts
+++ b/pi-extensions/pi-background-tasks/extensions/dashboard.ts
@@ -194,7 +194,7 @@ export async function openDashboard(
 						const isSelected = task.id === selected?.id;
 						const row = ` ${bgStatusIcon(task.status, theme)} ${theme.fg("accent", task.id)} ${theme.fg(
 							isSelected ? "text" : "dim",
-							`${summarizeTaskStatus(task.status, task.exitCode)} · ${compactText(taskDisplayName(task), Math.max(12, taskPaneWidth - 24))}`,
+							`${summarizeTaskStatus(task.status, task.exitCode, task.terminationReason)} · ${compactText(taskDisplayName(task), Math.max(12, taskPaneWidth - 24))}`,
 						)}`;
 						left.push(isSelected ? theme.bg("selectedBg", padAnsi(row, taskPaneWidth)) : row);
 					}

--- a/pi-extensions/pi-background-tasks/extensions/format.ts
+++ b/pi-extensions/pi-background-tasks/extensions/format.ts
@@ -79,7 +79,21 @@ export function parseOutputMatcher(pattern: string | undefined): ((text: string)
 	return (text: string) => text.toLowerCase().includes(lower);
 }
 
-export function summarizeTaskStatus(status: BackgroundTaskStatus, exitCode: number | null): string {
+export function summarizeTaskStatus(
+	status: BackgroundTaskStatus,
+	exitCode: number | null,
+	terminationReason?: string,
+): string {
+	const base = baseStatusLabel(status, exitCode);
+	if (!terminationReason || terminationReason === "self-exit") return base;
+	// vstack#97: surface the non-self-exit cause inline so operators reading
+	// `bg_status list` can tell extension-stop from session-shutdown from a
+	// reconcile-on-restart coercion. Self-exit termination matches the
+	// historical wording so unchanged completed/failed rows stay terse.
+	return `${base} (${terminationReason})`;
+}
+
+function baseStatusLabel(status: BackgroundTaskStatus, exitCode: number | null): string {
 	switch (status) {
 		case "running":
 			return "running";
@@ -100,7 +114,7 @@ export function taskDisplayName(task: Pick<BackgroundTaskSnapshot, "title" | "co
 
 export function buildTaskSummaryLine(task: BackgroundTaskSnapshot, now: number = Date.now()): string {
 	const activityAt = task.lastOutputAt ?? task.updatedAt;
-	return `${task.id} · ${summarizeTaskStatus(task.status, task.exitCode)} · pid ${task.pid} · ${taskDisplayName(
+	return `${task.id} · ${summarizeTaskStatus(task.status, task.exitCode, task.terminationReason)} · pid ${task.pid} · ${taskDisplayName(
 		task,
 	)} · ${formatRelativeTime(activityAt, now)}`;
 }

--- a/pi-extensions/pi-background-tasks/extensions/lifecycle.ts
+++ b/pi-extensions/pi-background-tasks/extensions/lifecycle.ts
@@ -8,7 +8,13 @@
 // record the calls.
 
 import { selectMissedExits } from "./snapshot.js";
-import type { BackgroundTaskSnapshot, BackgroundTaskStatus, ManagedTask, TaskEventType } from "./types.js";
+import type {
+	BackgroundTaskSnapshot,
+	BackgroundTaskStatus,
+	BackgroundTaskTerminationReason,
+	ManagedTask,
+	TaskEventType,
+} from "./types.js";
 
 export interface LifecycleHooks {
 	rememberSnapshot: (task: ManagedTask) => BackgroundTaskSnapshot;
@@ -22,6 +28,12 @@ export interface LifecycleHooks {
 //   - first close wins (closed=true gate is idempotent)
 //   - status derives from stopReason / statusOverride / exitCode
 //   - exitNotified flips to true only after a successful sendTaskEvent
+//   - terminationReason is set on every terminal transition so callers
+//     can distinguish self-exit from extension-stop, session-shutdown,
+//     external kill, reconcile-on-restart, and orphan-watcher finalizes
+//     (vstack#97). An explicit `terminationReason` argument wins over
+//     whatever the caller pre-stamped on `task.terminationReason`; the
+//     default falls back to a derivation from stopReason and exitCode.
 //
 // Returns the same task instance so callers can chain.
 export function finalizeTaskLifecycle(
@@ -29,6 +41,7 @@ export function finalizeTaskLifecycle(
 	exitCode: number | null,
 	hooks: LifecycleHooks,
 	statusOverride?: BackgroundTaskStatus,
+	terminationReason?: BackgroundTaskTerminationReason,
 ): ManagedTask {
 	if (task.closed) return task;
 	task.closed = true;
@@ -45,6 +58,7 @@ export function finalizeTaskLifecycle(
 	} else {
 		task.status = exitCode === 0 ? "completed" : "failed";
 	}
+	task.terminationReason = resolveTerminationReason(task, exitCode, terminationReason);
 	hooks.rememberSnapshot(task);
 	hooks.persistSnapshots();
 
@@ -56,6 +70,29 @@ export function finalizeTaskLifecycle(
 	}
 	hooks.refreshUi();
 	return task;
+}
+
+// Resolve the terminationReason for a finalize call. Precedence:
+//   1. Explicit argument from the caller (e.g. orphan-watcher passes
+//      "orphaned-pid-gone", session_shutdown passes "session-shutdown").
+//   2. A reason the caller pre-stamped on task.terminationReason
+//      (requestStop sets "extension-stop" before invoking the SIGTERM
+//      cascade so the eventual child.on("close") finalize picks it up).
+//   3. Derived from the resolved status + exitCode: completed
+//      (exit 0) and failed (non-zero) self-exit; null exitCode with no
+//      stopReason is treated as external (signal we did not issue).
+function resolveTerminationReason(
+	task: ManagedTask,
+	exitCode: number | null,
+	explicit: BackgroundTaskTerminationReason | undefined,
+): BackgroundTaskTerminationReason {
+	if (explicit !== undefined) return explicit;
+	if (task.terminationReason !== undefined) return task.terminationReason;
+	if (task.stopReason === "timeout") return "timeout";
+	if (task.stopReason === "user") return "extension-stop";
+	if (task.stopReason === "shutdown") return "session-shutdown";
+	if (exitCode === null) return "external";
+	return "self-exit";
 }
 
 // Replay 'exit' wakeups for any restored task that hit terminal state

--- a/pi-extensions/pi-background-tasks/extensions/orphan-watcher.ts
+++ b/pi-extensions/pi-background-tasks/extensions/orphan-watcher.ts
@@ -75,7 +75,17 @@ export function createOrphanWatcher(deps: OrphanWatcherDeps): OrphanWatcher {
 			// 'failed' (no stopReason, non-zero exit). The canonical exit
 			// event fires here, and the subscriber/daemon routes the
 			// resulting pi-bg-task-exit wake to master.
-			finalizeTaskLifecycle(task, null, deps.hooks);
+			//
+			// vstack#97: stamp terminationReason so callers can distinguish
+			// an orphan-watcher finalize from an explicit extension-stop or
+			// reconcile-on-restart.
+			finalizeTaskLifecycle(
+				task,
+				null,
+				deps.hooks,
+				undefined,
+				reason === "pid-gone" ? "orphaned-pid-gone" : "orphaned-pid-reused",
+			);
 			deps.onFinalize?.(task, reason);
 			finalized += 1;
 		}

--- a/pi-extensions/pi-background-tasks/extensions/orphan-watcher.ts
+++ b/pi-extensions/pi-background-tasks/extensions/orphan-watcher.ts
@@ -9,6 +9,17 @@
 // canonical exit wake (and pi-bg-task-exit daemon path) fires that
 // would have fired if Pi had stayed alive.
 //
+// vstack#97 hardening (H2 — snapshot reconciliation kill): this module
+// is METADATA-ONLY. It MUST NOT call process.kill() / child.kill() on
+// the tracked pid under any reconcile or polling path. The only
+// observation it makes is the identity probe (defaultReadProcessIdentity
+// reads /proc or shells out to `ps`, neither of which signals); the
+// only mutation it makes is finalizeTaskLifecycle, which updates the
+// in-memory + persisted snapshot and emits the canonical exit wake.
+// If a future change adds a real kill here it would resurrect the H2
+// failure mode where a tracked pid + start-time pair flickering across
+// snapshot writes could be proactively terminated.
+//
 // Pure logic; tests inject deterministic `isProcessAlive` + clock.
 
 import { finalizeTaskLifecycle, type LifecycleHooks } from "./lifecycle.js";

--- a/pi-extensions/pi-background-tasks/extensions/registrations.ts
+++ b/pi-extensions/pi-background-tasks/extensions/registrations.ts
@@ -168,7 +168,7 @@ function registerCommands(pi: ExtensionAPI, deps: RegistrationDeps): void {
 		const items = deps.sortedTasks()
 			.filter((task) => !query || task.id.toLowerCase().startsWith(query) || String(task.pid).startsWith(query))
 			.map((task) => ({
-				description: `${summarizeTaskStatus(task.status, task.exitCode)} · ${task.command}`,
+				description: `${summarizeTaskStatus(task.status, task.exitCode, task.terminationReason)} · ${task.command}`,
 				label: task.id,
 				value: task.id,
 			}));
@@ -198,7 +198,7 @@ function registerCommands(pi: ExtensionAPI, deps: RegistrationDeps): void {
 			const taskItems = deps.sortedTasks()
 				.filter((task) => !taskQuery || task.id.toLowerCase().startsWith(taskQuery) || String(task.pid).startsWith(taskQuery))
 				.map((task) => ({
-					description: `${summarizeTaskStatus(task.status, task.exitCode)} · ${task.command}`,
+					description: `${summarizeTaskStatus(task.status, task.exitCode, task.terminationReason)} · ${task.command}`,
 					label: task.id,
 					value: `${subcommand} ${task.id}`,
 				}));

--- a/pi-extensions/pi-background-tasks/extensions/render.ts
+++ b/pi-extensions/pi-background-tasks/extensions/render.ts
@@ -173,7 +173,7 @@ export function bgStatusIcon(status: BackgroundTaskStatus, theme: Theme): string
 }
 
 export function bgStatusText(task: Pick<BackgroundTaskSnapshot, "status" | "exitCode">, theme: Theme): string {
-	return theme.fg(bgStatusColor(task.status), summarizeTaskStatus(task.status, task.exitCode));
+	return theme.fg(bgStatusColor(task.status), summarizeTaskStatus(task.status, task.exitCode, task.terminationReason));
 }
 
 function renderToolTaskRow(task: BackgroundTaskSnapshot, theme: Theme, branch: TreeBranch, cwd?: string): string {

--- a/pi-extensions/pi-background-tasks/extensions/snapshot.ts
+++ b/pi-extensions/pi-background-tasks/extensions/snapshot.ts
@@ -37,6 +37,7 @@ export function taskSnapshot(task: ManagedTask): BackgroundTaskSnapshot {
 		sessionId: task.sessionId,
 		startedAt: task.startedAt,
 		status: task.status,
+		terminationReason: task.terminationReason,
 		title: task.title,
 		updatedAt: task.updatedAt,
 	};
@@ -222,6 +223,15 @@ export function restoredTaskFromSnapshot(snapshot: BackgroundTaskSnapshot, optio
 		exitNotified = snapshot.exitNotified === undefined ? true : snapshot.exitNotified;
 	}
 
+	// vstack#97: annotate the running -> stopped coercion so callers can
+	// distinguish a Pi-restart reconcile from a clean self-exit or an
+	// explicit extension stop. Pre-existing termination reasons (e.g. a
+	// snapshot persisted at extension-stop time) are preserved.
+	let terminationReason = snapshot.terminationReason;
+	if (coercedFromRunning && terminationReason === undefined) {
+		terminationReason = "reconcile-on-restart";
+	}
+
 	return {
 		...snapshot,
 		child: null,
@@ -239,6 +249,7 @@ export function restoredTaskFromSnapshot(snapshot: BackgroundTaskSnapshot, optio
 		pendingWakes: [],
 		status: pidStillAlive ? "running" : (wasRunning ? "stopped" : snapshot.status),
 		stopReason: pidStillAlive ? null : (coercedFromRunning ? "shutdown" : null),
+		terminationReason,
 		timeoutTimer: null,
 		voidedWakeSequences: snapshot.voidedWakeSequences ?? [],
 		voidedWakes: new Set(snapshot.voidedWakeSequences ?? []),

--- a/pi-extensions/pi-background-tasks/extensions/types.ts
+++ b/pi-extensions/pi-background-tasks/extensions/types.ts
@@ -1,6 +1,36 @@
 import type { ChildProcess } from "node:child_process";
 
 export type BackgroundTaskStatus = "running" | "completed" | "failed" | "stopped" | "timed_out";
+
+/**
+ * Why a tracked task left the running state. Surfaced on `bg_status list`,
+ * the wake-event payload, and persisted snapshots so callers can distinguish
+ * a clean self-exit from an external kill (vstack#97).
+ *
+ * - `self-exit`: child closed on its own with no stop request. Reserved for
+ *   `completed` (exitCode 0) and `failed` (non-zero exitCode). `external` is
+ *   the same close path with `exitCode === null`, which means the child was
+ *   killed by a signal we did not issue.
+ * - `extension-stop`: this extension issued the kill via `bg_status stop`.
+ * - `session-shutdown`: this extension issued the kill on `session_shutdown`.
+ * - `timeout`: the task's `timeoutSeconds` budget elapsed.
+ * - `reconcile-on-restart`: a Pi restart probed the recorded pid and found
+ *   it gone; the task was coerced running -> stopped in
+ *   `restoredTaskFromSnapshot`. The actual cause of death is unknown to us
+ *   (Pi may have crashed mid-bg_task, the OS may have OOM-killed the child,
+ *   or an unrelated session-leader cascade may have hit it).
+ * - `orphaned-pid-gone` / `orphaned-pid-reused`: the orphan-watcher polled
+ *   a previously-restored alive task and found the pid gone or recycled.
+ */
+export type BackgroundTaskTerminationReason =
+	| "self-exit"
+	| "extension-stop"
+	| "session-shutdown"
+	| "timeout"
+	| "external"
+	| "reconcile-on-restart"
+	| "orphaned-pid-gone"
+	| "orphaned-pid-reused";
 export type TaskEventType = "output" | "exit";
 export type NotifyMode = "always" | "transition" | "first-match-only";
 
@@ -116,6 +146,13 @@ export interface BackgroundTaskSnapshot {
 	// checks on restore + orphan polls. Absent on pre-1.2.2 snapshots;
 	// identity check degrades to PID-only for those.
 	procIdent?: ProcessIdentity;
+	/**
+	 * Why this task left the running state. Optional so snapshots persisted
+	 * before vstack#97 still load (treated as undefined). Set on every
+	 * terminal transition through finalizeTaskLifecycle, the
+	 * restoredTaskFromSnapshot coercion path, and the orphan watcher.
+	 */
+	terminationReason?: BackgroundTaskTerminationReason;
 }
 
 export type ManagedTask = BackgroundTaskSnapshot & {

--- a/pi-extensions/pi-background-tasks/tests/spawn-hardening.test.ts
+++ b/pi-extensions/pi-background-tasks/tests/spawn-hardening.test.ts
@@ -1,0 +1,152 @@
+// vstack#97 hardening: protect bg_task children from parent/session/pgid
+// cascades when Pi exits, restarts, or its session leader dies.
+//
+// H1 (process-group / parent-death cascade) + H3 (session-leader cascade)
+// are addressed by spawning detached on POSIX (Node calls setsid() before
+// exec). H2 (snapshot reconciliation kill) is addressed by keeping the
+// orphan-watcher metadata-only — no kill() under reconcile.
+//
+// These tests don't actually spawn child processes; they exercise the
+// helpers and module source so a future regression in the contract trips
+// the suite.
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { createOrphanWatcher } from "../extensions/orphan-watcher.js";
+import type { LifecycleHooks } from "../extensions/lifecycle.js";
+import { taskSnapshot } from "../extensions/snapshot.js";
+import type { ManagedTask, ProcessIdentity } from "../extensions/types.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const BACKGROUND_TASKS_SRC = resolve(HERE, "../extensions/background-tasks.ts");
+const ORPHAN_WATCHER_SRC = resolve(HERE, "../extensions/orphan-watcher.ts");
+
+function fakeOrphan(): ManagedTask {
+	return {
+		child: null,
+		closed: false,
+		command: "idle-watcher",
+		cwd: "/tmp/w",
+		exitCode: null,
+		exitNotified: false,
+		expiresAt: null,
+		forceKillTimer: null,
+		id: "bg-97",
+		lastAnnouncedLength: 0,
+		lastOutputAt: null,
+		logFile: "/tmp/log.txt",
+		matcher: null,
+		notifyOnExit: true,
+		notifyOnOutput: false,
+		notifyPattern: undefined,
+		output: "",
+		outputBytes: 0,
+		outputTimer: null,
+		pid: 4242,
+		procIdent: { comm: "bash", pid: 4242, startToken: "start-4242" } satisfies ProcessIdentity,
+		restored: true,
+		sessionId: "sess-A",
+		startedAt: 1_700_000_000_000,
+		status: "running",
+		stopReason: null,
+		timeoutTimer: null,
+		title: "idle watcher",
+		updatedAt: 1_700_000_000_000,
+		voidedWakes: new Set<number>(),
+	};
+}
+
+function recordingHooks(): LifecycleHooks {
+	return {
+		clearTaskTimers: () => {},
+		persistSnapshots: () => {},
+		refreshUi: () => {},
+		rememberSnapshot: (task) => taskSnapshot(task),
+		sendTaskEvent: () => true,
+	};
+}
+
+function stripLineComments(source: string): string {
+	const lines = source.split(/\r?\n/);
+	const cleaned = lines.map((line) => {
+		const idx = line.indexOf("//");
+		return idx >= 0 ? line.slice(0, idx) : line;
+	});
+	return cleaned.join("\n");
+}
+
+describe("spawn hardening (vstack#97)", () => {
+	test("background-tasks spawn options request detached:true on non-Windows", () => {
+		const src = readFileSync(BACKGROUND_TASKS_SRC, "utf8");
+		// The exact call site that creates the tracked child. The literal
+		// expression matters: if a future refactor drops detached or makes
+		// it a runtime-toggleable boolean, the protection regresses.
+		expect(src).toContain('detached: process.platform !== "win32"');
+		// Documentation breadcrumb: the comment block must reference the
+		// issue so refactors that delete it are caught here.
+		expect(src).toContain("vstack#97 hardening");
+		expect(src).toContain("H1 (process-group");
+		expect(src).toContain("H3 (session-leader cascade)");
+	});
+
+	test("orphan-watcher source contains no process.kill / child.kill / killTaskProcess call", () => {
+		const src = readFileSync(ORPHAN_WATCHER_SRC, "utf8");
+		// Strip line-comments so the hardening prose (which intentionally
+		// names the forbidden calls) does not trip the guard.
+		const code = stripLineComments(src);
+		expect(code).not.toMatch(/\bprocess\.kill\(/);
+		expect(code).not.toMatch(/\bchild\.kill\(/);
+		expect(code).not.toMatch(/\bkillTaskProcess\(/);
+		// Hardening comment is the contract: a future kill() addition
+		// must also delete this comment, which is the early-warning signal.
+		expect(src).toContain("METADATA-ONLY");
+	});
+
+	test("orphan-watcher does not invoke its hooks beyond finalizeTaskLifecycle", () => {
+		// Belt-and-braces: spy that the watcher only causes the finalize
+		// path (which itself is non-killing). A future regression that
+		// added an unexpected hook would surface here.
+		const calls: string[] = [];
+		const hooks: LifecycleHooks = {
+			clearTaskTimers: () => calls.push("clearTaskTimers"),
+			persistSnapshots: () => calls.push("persistSnapshots"),
+			refreshUi: () => calls.push("refreshUi"),
+			rememberSnapshot: (task) => {
+				calls.push("rememberSnapshot");
+				return taskSnapshot(task);
+			},
+			sendTaskEvent: () => {
+				calls.push("sendTaskEvent");
+				return true;
+			},
+		};
+		const tasks = [fakeOrphan()];
+		const watcher = createOrphanWatcher({
+			getTasks: () => tasks,
+			hooks,
+			identityProbe: () => null,
+		});
+		watcher.checkOnce();
+		const unexpected = calls.filter(
+			(name) => !["clearTaskTimers", "persistSnapshots", "refreshUi", "rememberSnapshot", "sendTaskEvent"].includes(name),
+		);
+		expect(unexpected).toEqual([]);
+	});
+
+	test("orphan-watcher leaves a still-matching pid alone (no finalize, no kill)", () => {
+		const tasks = [fakeOrphan()];
+		const hooks = recordingHooks();
+		const watcher = createOrphanWatcher({
+			getTasks: () => tasks,
+			hooks,
+			identityProbe: (pid) => ({ comm: "bash", pid, startToken: "start-4242" }),
+		});
+		const { finalized } = watcher.checkOnce();
+		expect(finalized).toBe(0);
+		expect(tasks[0]!.status).toBe("running");
+		expect(tasks[0]!.terminationReason).toBeUndefined();
+	});
+});

--- a/pi-extensions/pi-background-tasks/tests/termination-reason.test.ts
+++ b/pi-extensions/pi-background-tasks/tests/termination-reason.test.ts
@@ -1,0 +1,269 @@
+// vstack#97: every terminal-state transition stamps a terminationReason
+// so callers can tell self-exit from extension-stop, session-shutdown,
+// external kill, reconcile-on-restart, and orphan-watcher finalize.
+// `bg_status list` and the wake-event payload both surface the value.
+
+import { describe, expect, test } from "bun:test";
+
+import { finalizeTaskLifecycle, type LifecycleHooks } from "../extensions/lifecycle.js";
+import { createOrphanWatcher } from "../extensions/orphan-watcher.js";
+import { summarizeTaskStatus } from "../extensions/format.js";
+import { restoredTaskFromSnapshot, taskSnapshot } from "../extensions/snapshot.js";
+import type {
+	BackgroundTaskSnapshot,
+	BackgroundTaskTerminationReason,
+	ManagedTask,
+	ProcessIdentity,
+} from "../extensions/types.js";
+
+function fakeSnapshot(overrides: Partial<BackgroundTaskSnapshot> = {}): BackgroundTaskSnapshot {
+	return {
+		command: "idle-watcher",
+		cwd: "/tmp/w",
+		exitCode: null,
+		exitNotified: false,
+		expiresAt: null,
+		id: "bg-97",
+		lastOutputAt: null,
+		logFile: "/tmp/log.txt",
+		notifyOnExit: true,
+		notifyOnOutput: false,
+		notifyPattern: undefined,
+		outputBytes: 12,
+		pid: 4242,
+		sessionId: "sess-A",
+		startedAt: 1_700_000_000_000,
+		status: "running",
+		title: "idle watcher",
+		updatedAt: 1_700_000_000_000,
+		...overrides,
+	};
+}
+
+function fakeTask(overrides: Partial<ManagedTask> = {}): ManagedTask {
+	const snapshot = fakeSnapshot(overrides);
+	return {
+		...snapshot,
+		child: null,
+		closed: false,
+		forceKillTimer: null,
+		lastAnnouncedLength: 0,
+		matcher: null,
+		output: "",
+		outputTimer: null,
+		stopReason: null,
+		timeoutTimer: null,
+		...overrides,
+	};
+}
+
+function recordingHooks(): LifecycleHooks & { events: Array<{ type: string; reason?: string }> } {
+	const events: Array<{ type: string; reason?: string }> = [];
+	return {
+		clearTaskTimers: () => {},
+		persistSnapshots: () => {},
+		refreshUi: () => {},
+		rememberSnapshot: (task) => taskSnapshot(task),
+		sendTaskEvent: (eventType, task) => {
+			events.push({ reason: task.terminationReason, type: eventType });
+			return true;
+		},
+		events,
+	};
+}
+
+describe("terminationReason annotation (vstack#97)", () => {
+	test("clean self-exit (exitCode 0, no stopReason) stamps self-exit", () => {
+		const task = fakeTask();
+		const hooks = recordingHooks();
+		finalizeTaskLifecycle(task, 0, hooks);
+		expect(task.status).toBe("completed");
+		expect(task.terminationReason).toBe("self-exit");
+		expect(hooks.events[0]?.reason).toBe("self-exit");
+	});
+
+	test("non-zero exit with no stopReason stamps self-exit (failed)", () => {
+		const task = fakeTask();
+		const hooks = recordingHooks();
+		finalizeTaskLifecycle(task, 1, hooks);
+		expect(task.status).toBe("failed");
+		expect(task.terminationReason).toBe("self-exit");
+	});
+
+	test("null exit code with no stopReason stamps external (signal we did not issue)", () => {
+		const task = fakeTask();
+		const hooks = recordingHooks();
+		finalizeTaskLifecycle(task, null, hooks);
+		expect(task.status).toBe("failed");
+		expect(task.terminationReason).toBe("external");
+	});
+
+	test("pre-stamped extension-stop survives the finalize", () => {
+		const task = fakeTask({ stopReason: "user", terminationReason: "extension-stop" });
+		const hooks = recordingHooks();
+		finalizeTaskLifecycle(task, null, hooks);
+		expect(task.status).toBe("stopped");
+		expect(task.terminationReason).toBe("extension-stop");
+	});
+
+	test("session-shutdown stopReason derives session-shutdown", () => {
+		const task = fakeTask({ stopReason: "shutdown" });
+		const hooks = recordingHooks();
+		finalizeTaskLifecycle(task, null, hooks);
+		expect(task.status).toBe("stopped");
+		expect(task.terminationReason).toBe("session-shutdown");
+	});
+
+	test("timeout stopReason derives timeout (status timed_out)", () => {
+		const task = fakeTask({ stopReason: "timeout" });
+		const hooks = recordingHooks();
+		finalizeTaskLifecycle(task, null, hooks);
+		expect(task.status).toBe("timed_out");
+		expect(task.terminationReason).toBe("timeout");
+	});
+
+	test("explicit terminationReason argument wins over the derivation", () => {
+		const task = fakeTask({ stopReason: "user", terminationReason: "extension-stop" });
+		const hooks = recordingHooks();
+		finalizeTaskLifecycle(
+			task,
+			null,
+			hooks,
+			undefined,
+			"orphaned-pid-reused" as BackgroundTaskTerminationReason,
+		);
+		expect(task.terminationReason).toBe("orphaned-pid-reused");
+	});
+});
+
+describe("restoredTaskFromSnapshot annotation (vstack#97)", () => {
+	test("running -> stopped coercion annotates reconcile-on-restart", () => {
+		const snapshot = fakeSnapshot({
+			procIdent: { comm: "bash", pid: 4242, startToken: "start-4242" },
+			status: "running",
+		});
+		const restored = restoredTaskFromSnapshot(snapshot, {
+			identityProbe: () => null,
+			now: 1_700_000_100_000,
+			sessionId: "sess-A",
+		});
+		expect(restored.status).toBe("stopped");
+		expect(restored.terminationReason).toBe("reconcile-on-restart");
+	});
+
+	test("alive-pid restore preserves whatever terminationReason was already set", () => {
+		const snapshot = fakeSnapshot({
+			procIdent: { comm: "bash", pid: 4242, startToken: "start-4242" },
+			status: "running",
+			terminationReason: undefined,
+		});
+		const restored = restoredTaskFromSnapshot(snapshot, {
+			identityProbe: (pid) => ({ comm: "bash", pid, startToken: "start-4242" }),
+			now: 1_700_000_100_000,
+			sessionId: "sess-A",
+		});
+		expect(restored.status).toBe("running");
+		expect(restored.terminationReason).toBeUndefined();
+	});
+
+	test("terminal snapshot with pre-existing terminationReason flows through unchanged", () => {
+		const snapshot = fakeSnapshot({
+			exitCode: 0,
+			exitNotified: true,
+			status: "completed",
+			terminationReason: "self-exit",
+		});
+		const restored = restoredTaskFromSnapshot(snapshot, {
+			now: 1_700_000_100_000,
+			sessionId: "sess-A",
+		});
+		expect(restored.status).toBe("completed");
+		expect(restored.terminationReason).toBe("self-exit");
+	});
+});
+
+describe("orphan-watcher annotation (vstack#97)", () => {
+	function makeOrphan(overrides: Partial<ManagedTask> = {}): ManagedTask {
+		return fakeTask({
+			child: null,
+			pid: 4242,
+			procIdent: { comm: "bash", pid: 4242, startToken: "start-4242" },
+			restored: true,
+			status: "running",
+			...overrides,
+		});
+	}
+
+	test("pid-gone finalize stamps orphaned-pid-gone", () => {
+		const tasks = [makeOrphan()];
+		const hooks = recordingHooks();
+		const watcher = createOrphanWatcher({
+			getTasks: () => tasks,
+			hooks,
+			identityProbe: () => null,
+		});
+		const { finalized } = watcher.checkOnce();
+		expect(finalized).toBe(1);
+		expect(tasks[0]!.terminationReason).toBe("orphaned-pid-gone");
+	});
+
+	test("pid-reuse finalize stamps orphaned-pid-reused", () => {
+		const tasks = [makeOrphan()];
+		const hooks = recordingHooks();
+		const watcher = createOrphanWatcher({
+			getTasks: () => tasks,
+			hooks,
+			identityProbe: (pid) => ({
+				comm: "unrelated",
+				pid,
+				startToken: "start-RECYCLED",
+			} satisfies ProcessIdentity),
+		});
+		const { finalized } = watcher.checkOnce();
+		expect(finalized).toBe(1);
+		expect(tasks[0]!.terminationReason).toBe("orphaned-pid-reused");
+	});
+});
+
+describe("summarizeTaskStatus formatting (vstack#97)", () => {
+	test("self-exit annotation is omitted so historical rows stay terse", () => {
+		expect(summarizeTaskStatus("completed", 0, "self-exit")).toBe("completed (exit 0)");
+		expect(summarizeTaskStatus("failed", 137, "self-exit")).toBe("failed (exit 137)");
+	});
+
+	test("non-self-exit reasons are appended in parentheses", () => {
+		expect(summarizeTaskStatus("stopped", null, "extension-stop")).toBe(
+			"stopped (extension-stop)",
+		);
+		expect(summarizeTaskStatus("stopped", null, "reconcile-on-restart")).toBe(
+			"stopped (reconcile-on-restart)",
+		);
+		expect(summarizeTaskStatus("failed", null, "orphaned-pid-gone")).toBe(
+			"failed (exit ?) (orphaned-pid-gone)",
+		);
+		expect(summarizeTaskStatus("failed", null, "external")).toBe(
+			"failed (exit ?) (external)",
+		);
+	});
+
+	test("undefined termination reason matches the legacy output (back-compat)", () => {
+		expect(summarizeTaskStatus("stopped", null, undefined)).toBe("stopped");
+		expect(summarizeTaskStatus("completed", 0, undefined)).toBe("completed (exit 0)");
+	});
+});
+
+describe("taskSnapshot round-trip (vstack#97)", () => {
+	test("preserves terminationReason through snapshot serialization", () => {
+		const task = fakeTask({
+			exitCode: 0,
+			status: "stopped",
+			terminationReason: "extension-stop",
+		});
+		expect(taskSnapshot(task).terminationReason).toBe("extension-stop");
+	});
+
+	test("undefined terminationReason serializes as undefined (older snapshots load unchanged)", () => {
+		const task = fakeTask();
+		expect(taskSnapshot(task).terminationReason).toBeUndefined();
+	});
+});


### PR DESCRIPTION
Closes #97.

Two commits:

`e330a20d` adds a new `BackgroundTaskTerminationReason` union (`self-exit | extension-stop | session-shutdown | timeout | external | reconcile-on-restart | orphaned-pid-gone | orphaned-pid-reused`) threaded through `finalizeTaskLifecycle`. Resolution precedence: explicit-arg > caller-pre-stamped > derived from stopReason+exitCode. Pre-stamped by `requestStop` and `session_shutdown`; orphan-watcher passes explicit; restoredTaskFromSnapshot stamps `reconcile-on-restart` on running→stopped coercion. Surfaced in `summarizeTaskStatus`, `bg_status list`, dashboard widget, broker event details, and wake payloads. Full back-compat: pre-vstack#97 snapshots load with `terminationReason=undefined`.

`ccd80ce7` pins the spawn-time `detached:true` contract with documentation + source-level tests detecting future regressions. Marks orphan-watcher METADATA-ONLY (no kill() calls under reconcile) per H2 audit. H1+H3 already addressed by `detached:true`; H2 confirmed safe. `PR_SET_PDEATHSIG` not directly exposed by Node child_process — Linux default is already 0 for non-prctld children, and setsid covers session/pgid detachment cross-platform.

Tests: bun test 91 pass / 0 fail (was 70/0). +17 terminationReason assertions, +4 spawn-hardening assertions.

Note: did not 100% repro original symptom — issue body listed three hypotheses without confirmed cause. Annotation is the visible-failure-mode fix per the briefs "MUST work even before root cause is fully identified" rule. Future occurrences are self-documenting via the persisted `terminationReason` field.