### PR TITLE
feat: auto-recover from Claude API rate-limits via exponential-backoff steer-retry (closes #108)

### DIFF
--- a/pi-extensions/pi-agents-tmux/.gitignore
+++ b/pi-extensions/pi-agents-tmux/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+bun.lock

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/activity.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/activity.ts
@@ -68,6 +68,10 @@ function activityType(eventName: string, status?: string, reason?: string): stri
 	if (eventName === "subagents:steered") return "agent.steered";
 	if (eventName === "subagents:needs_completion" && reason === "compact-then-empty") return "agent.empty_after_compact";
 	if (eventName === "subagents:needs_completion") return "agent.needs_completion";
+	if (eventName === "subagents:rate_limited") return "agent.rate_limited";
+	if (eventName === "subagents:rate_limit_retry") return "agent.rate_limit_retry";
+	if (eventName === "subagents:rate_limit_resolved") return "agent.rate_limit_resolved";
+	if (eventName === "subagents:rate_limit_exhausted") return "agent.rate_limit_exhausted";
 	if (eventName === "subagents:completed" || status === "completed") return "agent.task_completed";
 	if (status === "blocked") return "agent.task_blocked";
 	if (eventName === "subagents:failed" || status === "failed" || status === "aborted") return "agent.task_failed";
@@ -75,14 +79,25 @@ function activityType(eventName: string, status?: string, reason?: string): stri
 }
 
 function severityFor(type: string): PiActivitySeverity {
-	if (type === "agent.task_completed") return "success";
-	if (type === "agent.task_failed") return "error";
-	if (type === "agent.spawned" || type === "agent.task_started" || type === "agent.task_queued" || type === "agent.steered") return "info";
+	if (type === "agent.task_completed" || type === "agent.rate_limit_resolved") return "success";
+	if (type === "agent.task_failed" || type === "agent.rate_limit_exhausted") return "error";
+	if (
+		type === "agent.spawned"
+		|| type === "agent.task_started"
+		|| type === "agent.task_queued"
+		|| type === "agent.steered"
+		|| type === "agent.rate_limit_retry"
+	) return "info";
 	return "warning";
 }
 
 function importanceFor(type: string): PiActivityImportance {
-	if (type === "agent.task_completed" || type === "agent.task_started" || type === "agent.task_queued") return "normal";
+	if (
+		type === "agent.task_completed"
+		|| type === "agent.task_started"
+		|| type === "agent.task_queued"
+		|| type === "agent.rate_limit_resolved"
+	) return "normal";
 	if (type === "agent.spawned" || type === "agent.steered") return "noisy";
 	return "important";
 }
@@ -101,6 +116,10 @@ function summaryFor(type: string, agent?: string, taskId?: string, payload: Reco
 		case "agent.needs_completion": return payloadSummary || `${who} task${suffix} needs completion`;
 		case "agent.empty_after_compact": return payloadSummary || `${who} task${suffix} empty after compact`;
 		case "agent.steered": return `${who} task${suffix} steered`;
+		case "agent.rate_limited": return payloadSummary || `${who} rate-limited`;
+		case "agent.rate_limit_retry": return payloadSummary || `${who} rate-limit retry`;
+		case "agent.rate_limit_resolved": return payloadSummary || `${who} rate-limit resolved`;
+		case "agent.rate_limit_exhausted": return payloadSummary || `${who} rate-limit exhausted`;
 		default: return payloadSummary || `${who} activity`;
 	}
 }

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/index.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/index.ts
@@ -98,6 +98,13 @@ import {
 	watchdogGraceMsFromEnv,
 } from "./agent-end-watchdog.js";
 import {
+	backoffLadderSecFromEnv as rateLimitBackoffLadderSecFromEnv,
+	createSubagentRateLimitWatchdog,
+	defaultScheduleAfter as rateLimitDefaultScheduleAfter,
+	maxAttemptsFromEnv as rateLimitMaxAttemptsFromEnv,
+	watchdogEnabledFromEnv as rateLimitWatchdogEnabledFromEnv,
+} from "./rate-limit-watchdog.js";
+import {
 	createIdleStallWatchdog,
 	STALL_WATCHDOG_REASON,
 	stallWatchdogEnabledFromEnv,
@@ -403,9 +410,40 @@ export default function (pi: ExtensionAPI) {
 		},
 	});
 
+	// Rate-limit watchdog (vstack#108): rides on `pi.on("message_end")` for
+	// the canonical Claude / pi-coding-agent rate-limit error shape.
+	// Schedules a retry-with-backoff steer via pi.sendUserMessage and
+	// gates the agent-end watchdog so its synthetic needs_completion
+	// outbox does not race the recovery.
+	const rateLimitWatchdog = createSubagentRateLimitWatchdog({
+		now: () => Date.now(),
+		scheduleAfter: rateLimitDefaultScheduleAfter,
+		isEnabled: () => rateLimitWatchdogEnabledFromEnv(),
+		maxAttempts: () => rateLimitMaxAttemptsFromEnv(),
+		backoffLadderSec: () => rateLimitBackoffLadderSecFromEnv(),
+		sendUserMessage: (message) => {
+			try {
+				pi.sendUserMessage(message);
+			} catch (error) {
+				console.warn(`rate-limit-watchdog: pi.sendUserMessage failed (${(error as Error)?.message ?? error})`);
+			}
+		},
+		emitActivity: (eventName, payload) => {
+			emitSubagentEvent(pi, eventName, payload);
+		},
+		onExhausted: (_paneId, attempt, reason) => {
+			// Fall through to the existing agent-end watchdog: clearing the
+			// retry state lets the next agent_end handler run the synthetic
+			// needs_completion outbox flow without further interference.
+			console.warn(`rate-limit-watchdog: exhausted after ${attempt} attempt(s) — falling back to needs_completion (${reason})`);
+		},
+		logWarn: (message) => console.warn(message),
+	});
+
 	// Idle-stall watchdog (vstack#63 workaround): polls active tasks for
 	// pi-core post-compaction stalls where agent_end never fires. Reuses
 	// the W5 O_EXCL writer so a racing real complete_subagent always wins.
+
 	let currentRuntimeRoot: string | undefined;
 	const idleStallWatchdog = createIdleStallWatchdog({
 		intervalMs: stallWatchdogIntervalMsFromEnv(),
@@ -1221,9 +1259,32 @@ export default function (pi: ExtensionAPI) {
 		idleStallWatchdog.start();
 	});
 
+	// vstack#108: rate-limit-watchdog rides on message_end so it can
+	// observe the canonical Claude rate-limit signature (assistant turn
+	// with stopReason==="error" + "temporarily limiting requests" prose)
+	// before agent_end fires its existing missing-completion path. The
+	// pane id passed downstream is the child agent name — each subagent
+	// pane runs its own Pi instance with a single in-pane child so a
+	// per-agent counter is the right granularity.
+	pi.on("message_end", async (event: any) => {
+		if (!childAgentName) return;
+		try {
+			const taskId = childCurrentTaskFile
+				? path.basename(childCurrentTaskFile, path.extname(childCurrentTaskFile))
+				: undefined;
+			rateLimitWatchdog.onMessageEnd(event, childAgentName, childAgentName, taskId);
+		} catch (error) {
+			console.warn(`rate-limit-watchdog: message_end handler failed (${(error as Error)?.message ?? error})`);
+		}
+	});
+
 	pi.on("agent_end", async (_event, ctx) => {
 		if (!childAgentName) return;
 		lastChildAgentEndCtx = ctx;
+		// vstack#108: when the rate-limit watchdog has a retry scheduled for
+		// this pane, skip the agent-end-watchdog's needs_completion path so
+		// the steer can race the synthetic outbox.
+		const rateLimitAwaitingRetry = rateLimitWatchdog.isAwaitingRetry(childAgentName);
 		if (childCurrentTaskFile) {
 			const runtimeRoot = runtimeDirForContext(ctx);
 			const activeTaskFile = childCurrentTaskFile;
@@ -1242,6 +1303,13 @@ export default function (pi: ExtensionAPI) {
 					const records = await readTaskRegistry(runtimeRoot);
 					if (isTerminalTaskStatus(records[taskId]?.status)) manualCompletionOk = true;
 				}
+			}
+
+			if (!pendingMatches && !manualCompletionOk && rateLimitAwaitingRetry) {
+				// vstack#108: rate-limit retry will reissue the steer; defer
+				// the immediate needs_completion mark + UI status until the
+				// retry either succeeds (rate_limit_resolved) or exhausts.
+				return;
 			}
 
 			if (!pendingMatches && !manualCompletionOk) {
@@ -1306,6 +1374,11 @@ export default function (pi: ExtensionAPI) {
 		// follow-ups, sessionless steers, etc.). If any task record for this
 		// agent is still active and has no outbox after the grace window, write
 		// a synthetic needs_completion outbox so the parent's wake handler runs.
+		//
+		// vstack#108: skip this scan when the rate-limit watchdog has a retry
+		// in flight for this pane — otherwise the synthetic outbox races the
+		// scheduled steer and the parent gets a misleading 'needs completion'.
+		if (rateLimitAwaitingRetry) return;
 		try {
 			const runtimeRoot = runtimeDirForContext(ctx);
 			const records = await readTaskRegistry(runtimeRoot);

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/rate-limit-decision.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/rate-limit-decision.ts
@@ -1,0 +1,179 @@
+/**
+ * Vendored mirror of skills/flightdeck/lib/flightdeck-core/src/daemon/
+ * rate-limit-watchdog.ts (vstack#108). The canonical reference lives in
+ * flightdeck-core and is parity-tested there; pi-extensions ship as
+ * standalone npm-style packages so a relative import outside the
+ * package boundary will not resolve post-install. Keep this file in
+ * lock-step with the canonical module — parity tests in both packages
+ * exercise the same decision shape so drift surfaces quickly.
+ *
+ * Functional copy: identical inputs must produce identical decisions.
+ */
+
+export const RATE_LIMIT_STEER_MESSAGE =
+	"API rate limit was detected. Try to continue from where you left off." as const;
+
+export const RATE_LIMIT_DEFAULT_MAX_ATTEMPTS = 5;
+export const RATE_LIMIT_DEFAULT_BACKOFF_LADDER_SEC = [60, 120, 300, 600, 1800] as const;
+
+export const RATE_LIMIT_ERROR_REGEX =
+	/(temporarily limiting requests|rate[\s_-]?limit(?:ed)?|429|too many requests)/i;
+
+export interface RateLimitWatchdogInput {
+	event: unknown;
+	paneId: string;
+	attempt: number;
+	lastRetryAt: number | null;
+	now: number;
+}
+
+export type RateLimitWatchdogDecision =
+	| { kind: "not-rate-limited" }
+	| {
+		kind: "retry-at";
+		at: number;
+		attempt: number;
+		hash: string;
+		steerMessage: typeof RATE_LIMIT_STEER_MESSAGE;
+	}
+	| { kind: "exhausted"; attempt: number; reason: string };
+
+export interface RateLimitWatchdogEnv {
+	maxAttempts?: number;
+	backoffLadderSec?: readonly number[];
+	enabled?: boolean;
+}
+
+export function rateLimitWatchdogEnabledFromEnv(env: NodeJS.ProcessEnv = process.env): boolean {
+	const raw = env.VSTACK_RATE_LIMIT_WATCHDOG?.trim();
+	if (raw === undefined || raw === "") return true;
+	return raw !== "0" && raw.toLowerCase() !== "false" && raw.toLowerCase() !== "off";
+}
+
+export function rateLimitMaxAttemptsFromEnv(env: NodeJS.ProcessEnv = process.env): number {
+	const raw = env.VSTACK_RATE_LIMIT_MAX_ATTEMPTS?.trim();
+	const parsed = raw ? Number(raw) : Number.NaN;
+	if (!Number.isFinite(parsed) || parsed < 1) return RATE_LIMIT_DEFAULT_MAX_ATTEMPTS;
+	return Math.floor(parsed);
+}
+
+export function rateLimitBackoffLadderFromEnv(env: NodeJS.ProcessEnv = process.env): number[] {
+	const raw = env.VSTACK_RATE_LIMIT_BACKOFF_LADDER?.trim();
+	if (!raw) return [...RATE_LIMIT_DEFAULT_BACKOFF_LADDER_SEC];
+	const parts = raw
+		.split(",")
+		.map((part) => part.trim())
+		.filter(Boolean)
+		.map((part) => Number(part))
+		.filter((value) => Number.isFinite(value) && value > 0)
+		.map((value) => Math.floor(value));
+	return parts.length > 0 ? parts : [...RATE_LIMIT_DEFAULT_BACKOFF_LADDER_SEC];
+}
+
+export function isRateLimitEvent(event: unknown): boolean {
+	const text = extractErrorText(event);
+	if (!text) return false;
+	if (!RATE_LIMIT_ERROR_REGEX.test(text)) return false;
+	const stopReason = readStopReason(event);
+	if (stopReason && stopReason !== "error") return false;
+	return true;
+}
+
+export function extractRetryAfterMs(event: unknown): number | null {
+	const seen = new Set<unknown>();
+	const stack: unknown[] = [event];
+	while (stack.length > 0) {
+		const node = stack.pop();
+		if (!node || typeof node !== "object" || seen.has(node)) continue;
+		seen.add(node);
+		const record = node as Record<string, unknown>;
+		for (const key of ["retry_after_ms", "retryAfterMs", "retryAfter", "retry_after"]) {
+			const value = record[key];
+			if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+				if (key === "retry_after_ms" || key === "retryAfterMs") return Math.floor(value);
+				return Math.floor(value * 1000);
+			}
+			if (typeof value === "string" && /^[0-9]+(?:\.[0-9]+)?$/.test(value)) {
+				const parsed = Number(value);
+				if (key === "retry_after_ms" || key === "retryAfterMs") return Math.floor(parsed);
+				return Math.floor(parsed * 1000);
+			}
+		}
+		for (const child of Object.values(record)) {
+			if (child && typeof child === "object") stack.push(child);
+		}
+	}
+	return null;
+}
+
+export function decideRateLimitRetry(
+	input: RateLimitWatchdogInput,
+	envOverride: RateLimitWatchdogEnv = {},
+): RateLimitWatchdogDecision {
+	if (!isRateLimitEvent(input.event)) return { kind: "not-rate-limited" };
+
+	const maxAttempts = envOverride.maxAttempts ?? rateLimitMaxAttemptsFromEnv();
+	if (input.attempt >= maxAttempts) {
+		return {
+			attempt: input.attempt,
+			kind: "exhausted",
+			reason: `rate-limit retries exhausted after ${input.attempt} attempt${input.attempt === 1 ? "" : "s"}`,
+		};
+	}
+
+	const ladder = envOverride.backoffLadderSec ?? rateLimitBackoffLadderFromEnv();
+	const ladderIndex = Math.min(input.attempt, ladder.length - 1);
+	const ladderMs = Math.max(0, Math.floor(ladder[ladderIndex]! * 1000));
+	const explicitMs = extractRetryAfterMs(input.event);
+	const delayMs = explicitMs !== null ? Math.max(ladderMs, explicitMs) : ladderMs;
+	const at = input.now + delayMs;
+	const nextAttempt = input.attempt + 1;
+	const hash = `${input.paneId}:${nextAttempt}:${at}`;
+	return { at, attempt: nextAttempt, hash, kind: "retry-at", steerMessage: RATE_LIMIT_STEER_MESSAGE };
+}
+
+function extractErrorText(event: unknown): string {
+	const parts: string[] = [];
+	const seen = new Set<unknown>();
+	const stack: unknown[] = [event];
+	while (stack.length > 0) {
+		const node = stack.pop();
+		if (!node || typeof node !== "object" || seen.has(node)) continue;
+		seen.add(node);
+		const record = node as Record<string, unknown>;
+		for (const key of ["errorMessage", "error_message", "message", "text", "error"]) {
+			const value = record[key];
+			if (typeof value === "string" && value) parts.push(value);
+		}
+		const content = record.content;
+		if (Array.isArray(content)) {
+			for (const item of content) {
+				if (item && typeof item === "object") {
+					const text = (item as Record<string, unknown>).text;
+					if (typeof text === "string" && text) parts.push(text);
+				}
+			}
+		}
+		for (const child of Object.values(record)) {
+			if (child && typeof child === "object") stack.push(child);
+		}
+	}
+	return parts.join("\n");
+}
+
+function readStopReason(event: unknown): string | null {
+	const seen = new Set<unknown>();
+	const stack: unknown[] = [event];
+	while (stack.length > 0) {
+		const node = stack.pop();
+		if (!node || typeof node !== "object" || seen.has(node)) continue;
+		seen.add(node);
+		const record = node as Record<string, unknown>;
+		const value = record.stopReason;
+		if (typeof value === "string" && value) return value;
+		for (const child of Object.values(record)) {
+			if (child && typeof child === "object") stack.push(child);
+		}
+	}
+	return null;
+}

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/rate-limit-watchdog.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/rate-limit-watchdog.ts
@@ -1,0 +1,236 @@
+/**
+ * Subagent rate-limit watchdog (vstack#108).
+ *
+ * Rides on `pi.on("message_end")` inside a persistent subagent pane.
+ * When the canonical rate-limit signature appears (assistant message_end
+ * with `stopReason==="error"` and a Claude-side "temporarily limiting
+ * requests" / "Rate limited" / 429 error payload), this watchdog:
+ *
+ *   1. Picks a retry-at delay from the shared decideRateLimitRetry
+ *      decision module in flightdeck-core (so the bash subscriber and
+ *      this layer share the same backoff ladder + canonical detection).
+ *   2. Schedules a `pi.sendUserMessage(STEER_MESSAGE)` for that retry
+ *      time. The fixed steer prose is mandated by the issue body so the
+ *      child agent has a deterministic recovery signal.
+ *   3. Emits agent.rate_limited (first detection per pane) and
+ *      agent.rate_limit_retry (each scheduled attempt) broker events so
+ *      the dashboard Activity tab shows the recovery timeline.
+ *   4. On every subsequent non-error assistant message_end, treats the
+ *      pane as recovered: emits agent.rate_limit_resolved and resets
+ *      the per-pane counter.
+ *   5. After VSTACK_RATE_LIMIT_MAX_ATTEMPTS scheduled retries, emits
+ *      agent.rate_limit_exhausted and calls onExhausted so the existing
+ *      agent-end-watchdog can fall back to its synthetic
+ *      needs_completion outbox path.
+ *
+ * The watchdog also exposes isAwaitingRetry(paneId) so the agent-end
+ * handler in subagent/index.ts can skip its grace-timeout schedule
+ * while a pane is mid-recovery — without that gate the synthetic
+ * needs_completion outbox would race the steer.
+ *
+ * All side effects are injectable. Failures inside scheduleAfter /
+ * sendUserMessage / emitActivity / onExhausted are swallowed so the
+ * rate-limit recovery can never throw out of the parent pane.
+ */
+
+import {
+	RATE_LIMIT_STEER_MESSAGE,
+	decideRateLimitRetry,
+	rateLimitBackoffLadderFromEnv,
+	rateLimitMaxAttemptsFromEnv,
+	rateLimitWatchdogEnabledFromEnv,
+} from "./rate-limit-decision.js";
+
+export type RateLimitOutcome =
+	| { kind: "scheduled-retry"; at: number; attempt: number }
+	| { kind: "exhausted"; attempt: number; reason: string }
+	| { kind: "not-rate-limited" }
+	| { kind: "resolved"; previousAttempt: number }
+	| { kind: "skipped-disabled" };
+
+export interface SubagentRateLimitWatchdogDeps {
+	now: () => number;
+	scheduleAfter: (delayMs: number, fn: () => void) => { cancel: () => void };
+	isEnabled: () => boolean;
+	maxAttempts: () => number;
+	backoffLadderSec: () => readonly number[];
+	sendUserMessage: (message: string) => void;
+	emitActivity: (eventName: string, payload: Record<string, unknown>) => void;
+	onExhausted: (paneId: string, attempt: number, reason: string) => void;
+	logWarn: (message: string) => void;
+}
+
+export interface SubagentRateLimitWatchdog {
+	onMessageEnd(event: unknown, paneId: string, agentName?: string, taskId?: string): RateLimitOutcome;
+	isAwaitingRetry(paneId: string): boolean;
+	cancel(paneId: string): boolean;
+	/** Test helper: synchronously fire the pending steer for a pane. */
+	fireRetryNow(paneId: string): boolean;
+}
+
+interface PaneState {
+	attempt: number;
+	pendingTimer: { cancel: () => void } | null;
+	pendingRetry: { at: number; attempt: number; fire: () => void } | null;
+	agentName?: string;
+	taskId?: string;
+}
+
+export function watchdogEnabledFromEnv(env: NodeJS.ProcessEnv = process.env): boolean {
+	return rateLimitWatchdogEnabledFromEnv(env);
+}
+
+export function maxAttemptsFromEnv(env: NodeJS.ProcessEnv = process.env): number {
+	return rateLimitMaxAttemptsFromEnv(env);
+}
+
+export function backoffLadderSecFromEnv(env: NodeJS.ProcessEnv = process.env): readonly number[] {
+	return rateLimitBackoffLadderFromEnv(env);
+}
+
+export function defaultScheduleAfter(delayMs: number, fn: () => void): { cancel: () => void } {
+	const handle = setTimeout(fn, Math.max(0, delayMs));
+	handle.unref?.();
+	return {
+		cancel: () => clearTimeout(handle),
+	};
+}
+
+export function createSubagentRateLimitWatchdog(
+	deps: SubagentRateLimitWatchdogDeps,
+): SubagentRateLimitWatchdog {
+	const panes = new Map<string, PaneState>();
+
+	function paneState(paneId: string): PaneState {
+		let state = panes.get(paneId);
+		if (!state) {
+			state = { attempt: 0, pendingRetry: null, pendingTimer: null };
+			panes.set(paneId, state);
+		}
+		return state;
+	}
+
+	function clearPending(state: PaneState): void {
+		if (state.pendingTimer) {
+			try {
+				state.pendingTimer.cancel();
+			} catch {
+				// best-effort
+			}
+			state.pendingTimer = null;
+		}
+		state.pendingRetry = null;
+	}
+
+	function emit(eventName: string, payload: Record<string, unknown>): void {
+		try {
+			deps.emitActivity(eventName, payload);
+		} catch (error) {
+			deps.logWarn(`rate-limit-watchdog: activity emit failed (${(error as Error)?.message ?? error})`);
+		}
+	}
+
+	return {
+		onMessageEnd(event, paneId, agentName, taskId): RateLimitOutcome {
+			if (!deps.isEnabled()) return { kind: "skipped-disabled" };
+			const state = paneState(paneId);
+			if (agentName) state.agentName = agentName;
+			if (taskId) state.taskId = taskId;
+
+			const decision = decideRateLimitRetry(
+				{
+					attempt: state.attempt,
+					event,
+					lastRetryAt: state.pendingRetry?.at ?? null,
+					now: deps.now(),
+					paneId,
+				},
+				{ backoffLadderSec: deps.backoffLadderSec(), maxAttempts: deps.maxAttempts() },
+			);
+
+			if (decision.kind === "not-rate-limited") {
+				// Recovery branch: if the pane had been mid-rate-limit and just
+				// produced a healthy assistant turn, emit resolved + reset state.
+				if (state.pendingRetry === null && state.attempt > 0) {
+					const previousAttempt = state.attempt;
+					state.attempt = 0;
+					emit("subagents:rate_limit_resolved", {
+						agent: state.agentName,
+						attempt: previousAttempt,
+						paneId,
+						taskId: state.taskId,
+					});
+					return { kind: "resolved", previousAttempt };
+				}
+				return { kind: "not-rate-limited" };
+			}
+
+			if (decision.kind === "exhausted") {
+				clearPending(state);
+				const exhaustedAttempt = decision.attempt;
+				state.attempt = exhaustedAttempt;
+				emit("subagents:rate_limit_exhausted", {
+					agent: state.agentName,
+					attempt: exhaustedAttempt,
+					paneId,
+					reason: decision.reason,
+					taskId: state.taskId,
+				});
+				try {
+					deps.onExhausted(paneId, exhaustedAttempt, decision.reason);
+				} catch (error) {
+					deps.logWarn(`rate-limit-watchdog: onExhausted handler failed (${(error as Error)?.message ?? error})`);
+				}
+				return { kind: "exhausted", attempt: exhaustedAttempt, reason: decision.reason };
+			}
+
+			// retry-at: cancel any pre-existing timer for the same pane (a
+			// follow-up rate-limit before the first retry has fired) so the
+			// schedule reflects the latest decision, then arm the retry.
+			clearPending(state);
+			const firstDetection = state.attempt === 0;
+			const delayMs = Math.max(0, decision.at - deps.now());
+			const eventName = firstDetection ? "subagents:rate_limited" : "subagents:rate_limit_retry";
+			emit(eventName, {
+				agent: state.agentName,
+				attempt: decision.attempt,
+				next_retry_at: decision.at,
+				paneId,
+				taskId: state.taskId,
+			});
+			state.attempt = decision.attempt;
+			const fire = () => {
+				const current = panes.get(paneId);
+				if (!current || current.pendingRetry?.at !== decision.at) return;
+				current.pendingTimer = null;
+				current.pendingRetry = null;
+				try {
+					deps.sendUserMessage(RATE_LIMIT_STEER_MESSAGE);
+				} catch (error) {
+					deps.logWarn(`rate-limit-watchdog: steer dispatch failed (${(error as Error)?.message ?? error})`);
+				}
+			};
+			state.pendingTimer = deps.scheduleAfter(delayMs, fire);
+			state.pendingRetry = { at: decision.at, attempt: decision.attempt, fire };
+			return { kind: "scheduled-retry", at: decision.at, attempt: decision.attempt };
+		},
+		isAwaitingRetry(paneId: string): boolean {
+			return panes.get(paneId)?.pendingRetry !== null && panes.get(paneId)?.pendingRetry !== undefined;
+		},
+		cancel(paneId: string): boolean {
+			const state = panes.get(paneId);
+			if (!state) return false;
+			const had = state.pendingRetry !== null;
+			clearPending(state);
+			state.attempt = 0;
+			return had;
+		},
+		fireRetryNow(paneId: string): boolean {
+			const state = panes.get(paneId);
+			if (!state?.pendingRetry) return false;
+			const { fire } = state.pendingRetry;
+			fire();
+			return true;
+		},
+	};
+}

--- a/pi-extensions/pi-agents-tmux/tests/rate-limit-watchdog.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/rate-limit-watchdog.test.ts
@@ -1,0 +1,214 @@
+// vstack#108: rate-limit retry-with-backoff watchdog for subagent panes.
+// The integration test injects deterministic clock + scheduler so the
+// per-pane attempt counter, retry-at scheduling, steer dispatch, and
+// exhaustion fallback all surface synchronously.
+
+import { describe, expect, test } from "bun:test";
+
+import {
+	createSubagentRateLimitWatchdog,
+	type RateLimitOutcome,
+	type SubagentRateLimitWatchdogDeps,
+} from "../extensions/subagent/rate-limit-watchdog.js";
+
+const CANONICAL_RATE_LIMIT_MESSAGE_END = {
+	message: {
+		api: "claude-bridge",
+		content: [
+			{
+				text: "API Error: Server is temporarily limiting requests (not your usage limit) · Rate limited",
+				type: "text",
+			},
+		],
+		errorMessage:
+			"Claude Code returned an error result: API Error: Server is temporarily limiting requests (not your usage limit) · Rate limited",
+		role: "assistant",
+		stopReason: "error",
+	},
+	type: "message_end",
+};
+
+const HEALTHY_MESSAGE_END = {
+	message: {
+		content: [{ text: "Done.", type: "text" }],
+		role: "assistant",
+		stopReason: "stop",
+	},
+	type: "message_end",
+};
+
+function makeDeps(overrides: Partial<SubagentRateLimitWatchdogDeps> = {}): {
+	deps: SubagentRateLimitWatchdogDeps;
+	scheduled: Array<{ delayMs: number; fn: () => void; cancelled: boolean }>;
+	steerCalls: string[];
+	activity: Array<{ event: string; payload: Record<string, unknown> }>;
+	exhausted: Array<{ paneId: string; attempt: number; reason: string }>;
+	warnings: string[];
+	clockMs: { value: number };
+} {
+	const scheduled: Array<{ delayMs: number; fn: () => void; cancelled: boolean }> = [];
+	const steerCalls: string[] = [];
+	const activity: Array<{ event: string; payload: Record<string, unknown> }> = [];
+	const exhausted: Array<{ paneId: string; attempt: number; reason: string }> = [];
+	const warnings: string[] = [];
+	const clockMs = { value: 0 };
+	const deps: SubagentRateLimitWatchdogDeps = {
+		backoffLadderSec: () => [1, 2, 4],
+		emitActivity: (event, payload) => activity.push({ event, payload }),
+		isEnabled: () => true,
+		logWarn: (message) => warnings.push(message),
+		maxAttempts: () => 3,
+		now: () => clockMs.value,
+		onExhausted: (paneId, attempt, reason) => exhausted.push({ attempt, paneId, reason }),
+		scheduleAfter: (delayMs, fn) => {
+			const entry = { cancelled: false, delayMs, fn };
+			scheduled.push(entry);
+			return { cancel: () => { entry.cancelled = true; } };
+		},
+		sendUserMessage: (message) => steerCalls.push(message),
+		...overrides,
+	};
+	return { activity, clockMs, deps, exhausted, scheduled, steerCalls, warnings };
+}
+
+describe("subagent rate-limit watchdog (vstack#108)", () => {
+	test("first rate-limit detection schedules a retry and emits agent.rate_limited", () => {
+		const ctx = makeDeps();
+		const watchdog = createSubagentRateLimitWatchdog(ctx.deps);
+		ctx.clockMs.value = 1_000;
+
+		const outcome = watchdog.onMessageEnd(CANONICAL_RATE_LIMIT_MESSAGE_END, "rust", "rust", "task-1");
+		expect(outcome.kind).toBe("scheduled-retry");
+		if (outcome.kind !== "scheduled-retry") throw new Error("expected scheduled-retry");
+		expect(outcome.attempt).toBe(1);
+		// First ladder step is 1s.
+		expect(outcome.at).toBe(1_000 + 1_000);
+		expect(watchdog.isAwaitingRetry("rust")).toBe(true);
+		expect(ctx.scheduled).toHaveLength(1);
+		expect(ctx.scheduled[0]!.delayMs).toBe(1_000);
+		expect(ctx.activity[0]?.event).toBe("subagents:rate_limited");
+		expect(ctx.activity[0]?.payload.attempt).toBe(1);
+		expect(ctx.activity[0]?.payload.next_retry_at).toBe(2_000);
+	});
+
+	test("scheduled steer fires the canonical recovery prose", () => {
+		const ctx = makeDeps();
+		const watchdog = createSubagentRateLimitWatchdog(ctx.deps);
+		watchdog.onMessageEnd(CANONICAL_RATE_LIMIT_MESSAGE_END, "rust");
+		expect(watchdog.fireRetryNow("rust")).toBe(true);
+		expect(ctx.steerCalls).toEqual([
+			"API rate limit was detected. Try to continue from where you left off.",
+		]);
+		expect(watchdog.isAwaitingRetry("rust")).toBe(false);
+	});
+
+	test("counter advances and second detection emits agent.rate_limit_retry", () => {
+		const ctx = makeDeps();
+		const watchdog = createSubagentRateLimitWatchdog(ctx.deps);
+		watchdog.onMessageEnd(CANONICAL_RATE_LIMIT_MESSAGE_END, "rust");
+		watchdog.fireRetryNow("rust");
+		ctx.clockMs.value = 5_000;
+		const second = watchdog.onMessageEnd(CANONICAL_RATE_LIMIT_MESSAGE_END, "rust");
+		expect(second.kind).toBe("scheduled-retry");
+		if (second.kind !== "scheduled-retry") throw new Error("expected scheduled-retry");
+		expect(second.attempt).toBe(2);
+		// Ladder[1]=2s
+		expect(second.at).toBe(5_000 + 2_000);
+		const events = ctx.activity.map((entry) => entry.event);
+		expect(events).toContain("subagents:rate_limited");
+		expect(events).toContain("subagents:rate_limit_retry");
+	});
+
+	test("exhaustion fires agent.rate_limit_exhausted and onExhausted handler", () => {
+		const ctx = makeDeps();
+		const watchdog = createSubagentRateLimitWatchdog(ctx.deps);
+		// Burn through all three retries.
+		for (let i = 0; i < 3; i += 1) {
+			watchdog.onMessageEnd(CANONICAL_RATE_LIMIT_MESSAGE_END, "rust");
+			watchdog.fireRetryNow("rust");
+		}
+		// 4th detection exhausts.
+		const outcome = watchdog.onMessageEnd(CANONICAL_RATE_LIMIT_MESSAGE_END, "rust", "rust", "task-1");
+		expect(outcome.kind).toBe("exhausted");
+		if (outcome.kind !== "exhausted") throw new Error("expected exhausted");
+		expect(outcome.attempt).toBe(3);
+		expect(ctx.exhausted).toEqual([{ attempt: 3, paneId: "rust", reason: outcome.reason }]);
+		const exhaustedEvent = ctx.activity.find((entry) => entry.event === "subagents:rate_limit_exhausted");
+		expect(exhaustedEvent).toBeDefined();
+		expect(exhaustedEvent!.payload.attempt).toBe(3);
+		expect(watchdog.isAwaitingRetry("rust")).toBe(false);
+	});
+
+	test("healthy turn after rate-limit emits agent.rate_limit_resolved and resets counter", () => {
+		const ctx = makeDeps();
+		const watchdog = createSubagentRateLimitWatchdog(ctx.deps);
+		watchdog.onMessageEnd(CANONICAL_RATE_LIMIT_MESSAGE_END, "rust");
+		watchdog.fireRetryNow("rust"); // pending cleared
+		ctx.activity.length = 0;
+		const outcome: RateLimitOutcome = watchdog.onMessageEnd(HEALTHY_MESSAGE_END, "rust");
+		expect(outcome.kind).toBe("resolved");
+		if (outcome.kind !== "resolved") throw new Error("expected resolved");
+		expect(outcome.previousAttempt).toBe(1);
+		expect(ctx.activity[0]?.event).toBe("subagents:rate_limit_resolved");
+		// Counter reset → a subsequent rate-limit starts at attempt 1 again.
+		const second = watchdog.onMessageEnd(CANONICAL_RATE_LIMIT_MESSAGE_END, "rust");
+		if (second.kind !== "scheduled-retry") throw new Error("expected scheduled-retry");
+		expect(second.attempt).toBe(1);
+	});
+
+	test("non-rate-limit message_end leaves state untouched", () => {
+		const ctx = makeDeps();
+		const watchdog = createSubagentRateLimitWatchdog(ctx.deps);
+		const outcome = watchdog.onMessageEnd(HEALTHY_MESSAGE_END, "rust");
+		expect(outcome.kind).toBe("not-rate-limited");
+		expect(ctx.scheduled).toHaveLength(0);
+		expect(ctx.activity).toHaveLength(0);
+		expect(watchdog.isAwaitingRetry("rust")).toBe(false);
+	});
+
+	test("disabled watchdog short-circuits with skipped-disabled", () => {
+		const ctx = makeDeps({ isEnabled: () => false });
+		const watchdog = createSubagentRateLimitWatchdog(ctx.deps);
+		const outcome = watchdog.onMessageEnd(CANONICAL_RATE_LIMIT_MESSAGE_END, "rust");
+		expect(outcome.kind).toBe("skipped-disabled");
+		expect(ctx.scheduled).toHaveLength(0);
+		expect(ctx.activity).toHaveLength(0);
+	});
+
+	test("cancel clears the pending retry and resets the counter", () => {
+		const ctx = makeDeps();
+		const watchdog = createSubagentRateLimitWatchdog(ctx.deps);
+		watchdog.onMessageEnd(CANONICAL_RATE_LIMIT_MESSAGE_END, "rust");
+		expect(watchdog.isAwaitingRetry("rust")).toBe(true);
+		expect(watchdog.cancel("rust")).toBe(true);
+		expect(watchdog.isAwaitingRetry("rust")).toBe(false);
+		expect(ctx.scheduled[0]!.cancelled).toBe(true);
+		// Subsequent detection restarts at attempt 1.
+		const outcome = watchdog.onMessageEnd(CANONICAL_RATE_LIMIT_MESSAGE_END, "rust");
+		if (outcome.kind !== "scheduled-retry") throw new Error("expected scheduled-retry");
+		expect(outcome.attempt).toBe(1);
+	});
+
+	test("steer dispatch errors are swallowed (best-effort recovery)", () => {
+		const ctx = makeDeps({
+			sendUserMessage: () => {
+				throw new Error("bridge socket gone");
+			},
+		});
+		const watchdog = createSubagentRateLimitWatchdog(ctx.deps);
+		watchdog.onMessageEnd(CANONICAL_RATE_LIMIT_MESSAGE_END, "rust");
+		expect(() => watchdog.fireRetryNow("rust")).not.toThrow();
+		expect(ctx.warnings.some((line) => line.includes("steer dispatch failed"))).toBe(true);
+	});
+
+	test("activity emit errors are swallowed (best-effort recovery)", () => {
+		const ctx = makeDeps({
+			emitActivity: () => {
+				throw new Error("broker offline");
+			},
+		});
+		const watchdog = createSubagentRateLimitWatchdog(ctx.deps);
+		expect(() => watchdog.onMessageEnd(CANONICAL_RATE_LIMIT_MESSAGE_END, "rust")).not.toThrow();
+		expect(ctx.warnings.some((line) => line.includes("activity emit failed"))).toBe(true);
+	});
+});

--- a/skills/flightdeck/lib/flightdeck-core/src/daemon/rate-limit-watchdog.ts
+++ b/skills/flightdeck/lib/flightdeck-core/src/daemon/rate-limit-watchdog.ts
@@ -1,0 +1,203 @@
+// vstack#108: detect Claude / pi-coding-agent rate-limit errors and
+// schedule a retry with exponential backoff instead of falling through
+// to the agent-end-watchdog's needs_completion synthetic outbox.
+//
+// Canonical event shape (confirmed from a real rate-limited session
+// transcript under
+// ~/.pi/agent/vstack/sessions/<id>/pi-agents-tmux/sessions/<agent>.jsonl):
+//
+//   { "type": "message", "message": {
+//        "role": "assistant",
+//        "stopReason": "error",
+//        "api": "claude-bridge" | ...,
+//        "errorMessage": "...API Error: Server is temporarily limiting requests..."
+//   }}
+//
+// The watchdog also accepts:
+//   - any payload whose `.message.errorMessage` or `.message.content[].text`
+//     matches the canonical prose AND whose stopReason is "error";
+//   - top-level `data.error` shapes (some bridges emit through agent_end
+//     with a flatter error object) carrying the same prose;
+//   - explicit `retry_after_ms` / `retryAfterMs` fields (Anthropic API
+//     occasionally provides one) — those win over the env-ladder backoff.
+//
+// Pure decision; the layered consumers (pi-agents-tmux subagent watchdog
+// and the bash subscriber wake-event branch) do the actual setTimeout +
+// pi-bridge steer side effects.
+
+export const RATE_LIMIT_STEER_MESSAGE =
+	"API rate limit was detected. Try to continue from where you left off." as const;
+
+export const RATE_LIMIT_DEFAULT_MAX_ATTEMPTS = 5;
+export const RATE_LIMIT_DEFAULT_BACKOFF_LADDER_SEC = [60, 120, 300, 600, 1800] as const;
+
+export const RATE_LIMIT_ERROR_REGEX =
+	/(temporarily limiting requests|rate[\s_-]?limit(?:ed)?|429|too many requests)/i;
+
+export interface RateLimitWatchdogInput {
+	event: unknown;
+	paneId: string;
+	attempt: number;
+	lastRetryAt: number | null;
+	now: number;
+}
+
+export type RateLimitWatchdogDecision =
+	| { kind: "not-rate-limited" }
+	| {
+		kind: "retry-at";
+		at: number;
+		attempt: number;
+		hash: string;
+		steerMessage: typeof RATE_LIMIT_STEER_MESSAGE;
+	}
+	| { kind: "exhausted"; attempt: number; reason: string };
+
+export interface RateLimitWatchdogEnv {
+	maxAttempts?: number;
+	backoffLadderSec?: readonly number[];
+	enabled?: boolean;
+}
+
+export function rateLimitWatchdogEnabledFromEnv(env: NodeJS.ProcessEnv = process.env): boolean {
+	const raw = env.VSTACK_RATE_LIMIT_WATCHDOG?.trim();
+	if (raw === undefined || raw === "") return true;
+	return raw !== "0" && raw.toLowerCase() !== "false" && raw.toLowerCase() !== "off";
+}
+
+export function rateLimitMaxAttemptsFromEnv(env: NodeJS.ProcessEnv = process.env): number {
+	const raw = env.VSTACK_RATE_LIMIT_MAX_ATTEMPTS?.trim();
+	const parsed = raw ? Number(raw) : Number.NaN;
+	if (!Number.isFinite(parsed) || parsed < 1) return RATE_LIMIT_DEFAULT_MAX_ATTEMPTS;
+	return Math.floor(parsed);
+}
+
+export function rateLimitBackoffLadderFromEnv(env: NodeJS.ProcessEnv = process.env): number[] {
+	const raw = env.VSTACK_RATE_LIMIT_BACKOFF_LADDER?.trim();
+	if (!raw) return [...RATE_LIMIT_DEFAULT_BACKOFF_LADDER_SEC];
+	const parts = raw
+		.split(",")
+		.map((part) => part.trim())
+		.filter(Boolean)
+		.map((part) => Number(part))
+		.filter((value) => Number.isFinite(value) && value > 0)
+		.map((value) => Math.floor(value));
+	return parts.length > 0 ? parts : [...RATE_LIMIT_DEFAULT_BACKOFF_LADDER_SEC];
+}
+
+export function isRateLimitEvent(event: unknown): boolean {
+	const text = extractErrorText(event);
+	if (!text) return false;
+	if (!RATE_LIMIT_ERROR_REGEX.test(text)) return false;
+	// Belt-and-braces: only count assistant turns that explicitly errored.
+	// A normal assistant message mentioning "rate limit" in prose must NOT
+	// trigger recovery. stopReason==="error" gates the canonical path.
+	const stopReason = readStopReason(event);
+	if (stopReason && stopReason !== "error") return false;
+	return true;
+}
+
+export function extractRetryAfterMs(event: unknown): number | null {
+	const seen = new Set<unknown>();
+	const stack: unknown[] = [event];
+	while (stack.length > 0) {
+		const node = stack.pop();
+		if (!node || typeof node !== "object" || seen.has(node)) continue;
+		seen.add(node);
+		const record = node as Record<string, unknown>;
+		for (const key of ["retry_after_ms", "retryAfterMs", "retryAfter", "retry_after"]) {
+			const value = record[key];
+			if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+				// `retry_after` / `retryAfter` are conventionally seconds on
+				// HTTP 429 responses; everything ending in `_ms` / `Ms` is
+				// milliseconds. Normalise to ms.
+				if (key === "retry_after_ms" || key === "retryAfterMs") return Math.floor(value);
+				return Math.floor(value * 1000);
+			}
+			if (typeof value === "string" && /^[0-9]+(?:\.[0-9]+)?$/.test(value)) {
+				const parsed = Number(value);
+				if (key === "retry_after_ms" || key === "retryAfterMs") return Math.floor(parsed);
+				return Math.floor(parsed * 1000);
+			}
+		}
+		for (const child of Object.values(record)) {
+			if (child && typeof child === "object") stack.push(child);
+		}
+	}
+	return null;
+}
+
+export function decideRateLimitRetry(
+	input: RateLimitWatchdogInput,
+	envOverride: RateLimitWatchdogEnv = {},
+): RateLimitWatchdogDecision {
+	if (!isRateLimitEvent(input.event)) return { kind: "not-rate-limited" };
+
+	const maxAttempts = envOverride.maxAttempts ?? rateLimitMaxAttemptsFromEnv();
+	if (input.attempt >= maxAttempts) {
+		return {
+			attempt: input.attempt,
+			kind: "exhausted",
+			reason: `rate-limit retries exhausted after ${input.attempt} attempt${input.attempt === 1 ? "" : "s"}`,
+		};
+	}
+
+	const ladder = envOverride.backoffLadderSec ?? rateLimitBackoffLadderFromEnv();
+	const ladderIndex = Math.min(input.attempt, ladder.length - 1);
+	const ladderMs = Math.max(0, Math.floor(ladder[ladderIndex]! * 1000));
+	const explicitMs = extractRetryAfterMs(input.event);
+	// Anthropic-provided retry_after wins over the ladder when it requests
+	// a longer wait (we don't want to retry before the API window resets);
+	// otherwise the ladder governs.
+	const delayMs = explicitMs !== null ? Math.max(ladderMs, explicitMs) : ladderMs;
+	const at = input.now + delayMs;
+	const nextAttempt = input.attempt + 1;
+	const hash = `${input.paneId}:${nextAttempt}:${at}`;
+	return { at, attempt: nextAttempt, hash, kind: "retry-at", steerMessage: RATE_LIMIT_STEER_MESSAGE };
+}
+
+function extractErrorText(event: unknown): string {
+	const parts: string[] = [];
+	const seen = new Set<unknown>();
+	const stack: unknown[] = [event];
+	while (stack.length > 0) {
+		const node = stack.pop();
+		if (!node || typeof node !== "object" || seen.has(node)) continue;
+		seen.add(node);
+		const record = node as Record<string, unknown>;
+		for (const key of ["errorMessage", "error_message", "message", "text", "error"]) {
+			const value = record[key];
+			if (typeof value === "string" && value) parts.push(value);
+		}
+		const content = record.content;
+		if (Array.isArray(content)) {
+			for (const item of content) {
+				if (item && typeof item === "object") {
+					const text = (item as Record<string, unknown>).text;
+					if (typeof text === "string" && text) parts.push(text);
+				}
+			}
+		}
+		for (const child of Object.values(record)) {
+			if (child && typeof child === "object") stack.push(child);
+		}
+	}
+	return parts.join("\n");
+}
+
+function readStopReason(event: unknown): string | null {
+	const seen = new Set<unknown>();
+	const stack: unknown[] = [event];
+	while (stack.length > 0) {
+		const node = stack.pop();
+		if (!node || typeof node !== "object" || seen.has(node)) continue;
+		seen.add(node);
+		const record = node as Record<string, unknown>;
+		const value = record.stopReason;
+		if (typeof value === "string" && value) return value;
+		for (const child of Object.values(record)) {
+			if (child && typeof child === "object") stack.push(child);
+		}
+	}
+	return null;
+}

--- a/skills/flightdeck/lib/flightdeck-core/src/daemon/rate-limit-watchdog.ts
+++ b/skills/flightdeck/lib/flightdeck-core/src/daemon/rate-limit-watchdog.ts
@@ -201,3 +201,47 @@ function readStopReason(event: unknown): string | null {
 	}
 	return null;
 }
+
+// CLI entry: `bun rate-limit-watchdog.ts decide --event <json> --pane <id> --attempt <n> [--now <ms>]`
+// Used by the bash pi subscriber (Layer B) so it can route rate-limit
+// events through the same decision module without re-implementing the
+// ladder math. Outputs the decision as JSON on stdout, exits 0.
+// `--event` accepts a JSON-encoded event payload; if omitted, the event
+// is read from stdin.
+if (import.meta.main) {
+	const args = process.argv.slice(2);
+	const action = args.shift();
+	if (action !== "decide") {
+		process.stderr.write("Usage: rate-limit-watchdog.ts decide --event <json> --pane <id> --attempt <n> [--now <ms>]\n");
+		process.exit(2);
+	}
+	let eventJson = "";
+	let paneId = "";
+	let attempt = 0;
+	let now = Date.now();
+	for (let i = 0; i < args.length; i += 1) {
+		const flag = args[i];
+		switch (flag) {
+			case "--event": eventJson = args[++i] ?? ""; break;
+			case "--pane": paneId = args[++i] ?? ""; break;
+			case "--attempt": attempt = Number(args[++i] ?? "0") || 0; break;
+			case "--now": now = Number(args[++i] ?? `${Date.now()}`) || Date.now(); break;
+			default:
+				process.stderr.write(`Unknown flag: ${flag}\n`);
+				process.exit(2);
+		}
+	}
+	if (!eventJson) {
+		eventJson = await Bun.stdin.text();
+	}
+	let event: unknown;
+	try {
+		event = JSON.parse(eventJson);
+	} catch (error) {
+		process.stderr.write(`invalid --event JSON: ${(error as Error).message}\n`);
+		process.exit(2);
+	}
+	const decision = decideRateLimitRetry({ attempt, event, lastRetryAt: null, now, paneId });
+	process.stdout.write(`${JSON.stringify(decision)}\n`);
+	process.exit(0);
+}

--- a/skills/flightdeck/lib/flightdeck-core/tests/parity/rate-limit-watchdog.test.ts
+++ b/skills/flightdeck/lib/flightdeck-core/tests/parity/rate-limit-watchdog.test.ts
@@ -1,0 +1,288 @@
+// vstack#108: pure-function regression coverage for the rate-limit
+// watchdog decision module. Same decision module is consumed by Layer A
+// (pi-agents-tmux subagent watchdog) and Layer B (bash subscriber wake
+// branch); both layers must observe identical transitions for identical
+// inputs.
+
+import { describe, expect, test } from "bun:test";
+
+import {
+	RATE_LIMIT_DEFAULT_BACKOFF_LADDER_SEC,
+	RATE_LIMIT_DEFAULT_MAX_ATTEMPTS,
+	RATE_LIMIT_ERROR_REGEX,
+	RATE_LIMIT_STEER_MESSAGE,
+	decideRateLimitRetry,
+	extractRetryAfterMs,
+	isRateLimitEvent,
+	rateLimitBackoffLadderFromEnv,
+	rateLimitMaxAttemptsFromEnv,
+	rateLimitWatchdogEnabledFromEnv,
+} from "../../src/daemon/rate-limit-watchdog.ts";
+
+// Canonical message_end-style envelope produced by pi-coding-agent for a
+// rate-limited assistant turn. Snapshot taken from a real session under
+// ~/.pi/agent/vstack/sessions/<id>/pi-agents-tmux/sessions/rust.jsonl.
+const CANONICAL_RATE_LIMIT_EVENT = {
+	message: {
+		api: "claude-bridge",
+		content: [
+			{
+				text: "API Error: Server is temporarily limiting requests (not your usage limit) · Rate limited",
+				type: "text",
+			},
+		],
+		errorMessage:
+			"Claude Code returned an error result: API Error: Server is temporarily limiting requests (not your usage limit) · Rate limited",
+		model: "claude-opus-4-7",
+		provider: "claude-bridge",
+		role: "assistant",
+		stopReason: "error",
+		timestamp: 1_778_998_215_269,
+	},
+	type: "message",
+};
+
+describe("decideRateLimitRetry — canonical detection (vstack#108)", () => {
+	test("returns not-rate-limited for an unrelated assistant turn", () => {
+		const decision = decideRateLimitRetry({
+			attempt: 0,
+			event: { message: { role: "assistant", stopReason: "stop" }, type: "message" },
+			lastRetryAt: null,
+			now: 1_000_000,
+			paneId: "%41",
+		});
+		expect(decision).toEqual({ kind: "not-rate-limited" });
+	});
+
+	test("returns not-rate-limited when prose mentions 'rate' but stopReason is not 'error'", () => {
+		// A normal turn whose assistant text legitimately discusses rate
+		// limiting must NOT trigger recovery. stopReason==='error' gates it.
+		const decision = decideRateLimitRetry({
+			attempt: 0,
+			event: {
+				message: {
+					content: [{ text: "rate-limited inputs need throttling", type: "text" }],
+					role: "assistant",
+					stopReason: "stop",
+				},
+				type: "message",
+			},
+			lastRetryAt: null,
+			now: 1_000_000,
+			paneId: "%41",
+		});
+		expect(decision.kind).toBe("not-rate-limited");
+	});
+
+	test("schedules a retry-at on first detection using the default ladder", () => {
+		const decision = decideRateLimitRetry({
+			attempt: 0,
+			event: CANONICAL_RATE_LIMIT_EVENT,
+			lastRetryAt: null,
+			now: 1_000_000,
+			paneId: "%41",
+		});
+		expect(decision.kind).toBe("retry-at");
+		if (decision.kind !== "retry-at") throw new Error("expected retry-at");
+		expect(decision.attempt).toBe(1);
+		// First step of the ladder is 60s.
+		expect(decision.at).toBe(1_000_000 + 60_000);
+		expect(decision.steerMessage).toBe(RATE_LIMIT_STEER_MESSAGE);
+		expect(decision.hash).toContain("%41");
+	});
+
+	test("ladder advances with the attempt counter", () => {
+		const base = {
+			event: CANONICAL_RATE_LIMIT_EVENT,
+			lastRetryAt: null,
+			now: 2_000_000,
+			paneId: "%41",
+		} as const;
+		const ladderMs = RATE_LIMIT_DEFAULT_BACKOFF_LADDER_SEC.map((s) => s * 1_000);
+		for (let attempt = 0; attempt < RATE_LIMIT_DEFAULT_MAX_ATTEMPTS; attempt += 1) {
+			const decision = decideRateLimitRetry({ ...base, attempt });
+			expect(decision.kind).toBe("retry-at");
+			if (decision.kind !== "retry-at") throw new Error("expected retry-at");
+			expect(decision.attempt).toBe(attempt + 1);
+			const expectedDelay = ladderMs[Math.min(attempt, ladderMs.length - 1)]!;
+			expect(decision.at).toBe(base.now + expectedDelay);
+		}
+	});
+
+	test("returns exhausted once attempt reaches the configured max", () => {
+		const decision = decideRateLimitRetry({
+			attempt: RATE_LIMIT_DEFAULT_MAX_ATTEMPTS,
+			event: CANONICAL_RATE_LIMIT_EVENT,
+			lastRetryAt: 0,
+			now: 5_000_000,
+			paneId: "%41",
+		});
+		expect(decision.kind).toBe("exhausted");
+		if (decision.kind !== "exhausted") throw new Error("expected exhausted");
+		expect(decision.attempt).toBe(RATE_LIMIT_DEFAULT_MAX_ATTEMPTS);
+		expect(decision.reason).toMatch(/exhausted/i);
+	});
+
+	test("explicit retry_after_ms in the event wins over the ladder when larger", () => {
+		const withRetryAfter = {
+			...CANONICAL_RATE_LIMIT_EVENT,
+			message: { ...CANONICAL_RATE_LIMIT_EVENT.message, retry_after_ms: 90_000 },
+		};
+		const decision = decideRateLimitRetry({
+			attempt: 0,
+			event: withRetryAfter,
+			lastRetryAt: null,
+			now: 10_000,
+			paneId: "%99",
+		});
+		expect(decision.kind).toBe("retry-at");
+		if (decision.kind !== "retry-at") throw new Error("expected retry-at");
+		// Ladder[0]=60s ⇒ 60_000ms; explicit=90_000ms ⇒ wins.
+		expect(decision.at).toBe(10_000 + 90_000);
+	});
+
+	test("explicit retry_after in seconds wins over a smaller ladder step", () => {
+		const withRetryAfter = {
+			...CANONICAL_RATE_LIMIT_EVENT,
+			message: { ...CANONICAL_RATE_LIMIT_EVENT.message, retry_after: 180 },
+		};
+		const decision = decideRateLimitRetry({
+			attempt: 0,
+			event: withRetryAfter,
+			lastRetryAt: null,
+			now: 0,
+			paneId: "%1",
+		});
+		if (decision.kind !== "retry-at") throw new Error("expected retry-at");
+		expect(decision.at).toBe(180_000);
+	});
+
+	test("ladder still wins when explicit retry_after is smaller (don't retry too early)", () => {
+		const withRetryAfter = {
+			...CANONICAL_RATE_LIMIT_EVENT,
+			message: { ...CANONICAL_RATE_LIMIT_EVENT.message, retryAfterMs: 1_000 },
+		};
+		const decision = decideRateLimitRetry({
+			attempt: 0,
+			event: withRetryAfter,
+			lastRetryAt: null,
+			now: 0,
+			paneId: "%1",
+		});
+		if (decision.kind !== "retry-at") throw new Error("expected retry-at");
+		// Ladder[0]=60_000ms, explicit=1_000ms ⇒ ladder wins (Math.max).
+		expect(decision.at).toBe(60_000);
+	});
+
+	test("environment overrides shorten the ladder", () => {
+		const decision = decideRateLimitRetry(
+			{
+				attempt: 0,
+				event: CANONICAL_RATE_LIMIT_EVENT,
+				lastRetryAt: null,
+				now: 1_000,
+				paneId: "%1",
+			},
+			{ backoffLadderSec: [5], maxAttempts: 2 },
+		);
+		if (decision.kind !== "retry-at") throw new Error("expected retry-at");
+		expect(decision.at).toBe(1_000 + 5_000);
+	});
+
+	test("environment override caps max attempts", () => {
+		const decision = decideRateLimitRetry(
+			{
+				attempt: 2,
+				event: CANONICAL_RATE_LIMIT_EVENT,
+				lastRetryAt: 0,
+				now: 5_000,
+				paneId: "%1",
+			},
+			{ backoffLadderSec: [5], maxAttempts: 2 },
+		);
+		expect(decision.kind).toBe("exhausted");
+	});
+});
+
+describe("isRateLimitEvent — defensive shape matching", () => {
+	test("accepts agent_end shapes with top-level data.error prose", () => {
+		expect(
+			isRateLimitEvent({
+				data: {
+					error: {
+						message: "API Error: Server is temporarily limiting requests · Rate limited",
+					},
+				},
+				stopReason: "error",
+				type: "agent_end",
+			}),
+		).toBe(true);
+	});
+
+	test("matches the canonical regex with several phrasings", () => {
+		for (const text of [
+			"API Error: Server is temporarily limiting requests",
+			"Rate limited (try again later)",
+			"HTTP 429 too many requests",
+			"rate_limit_exceeded",
+		]) {
+			expect(RATE_LIMIT_ERROR_REGEX.test(text)).toBe(true);
+		}
+	});
+
+	test("rejects empty / object-only events", () => {
+		expect(isRateLimitEvent(null)).toBe(false);
+		expect(isRateLimitEvent({})).toBe(false);
+		expect(isRateLimitEvent({ type: "message", message: { role: "assistant" } })).toBe(false);
+	});
+});
+
+describe("extractRetryAfterMs — recursive payload walk", () => {
+	test("returns null when no retry-after hint is present", () => {
+		expect(extractRetryAfterMs({ message: { role: "assistant" }, type: "message" })).toBeNull();
+	});
+
+	test("finds retry_after seconds nested under data.error", () => {
+		expect(
+			extractRetryAfterMs({
+				data: { error: { retry_after: 30 } },
+				type: "agent_end",
+			}),
+		).toBe(30_000);
+	});
+
+	test("finds retryAfterMs at top level", () => {
+		expect(extractRetryAfterMs({ retryAfterMs: 12_345 })).toBe(12_345);
+	});
+});
+
+describe("env parsers", () => {
+	test("watchdog enabled defaults to true; honors 0/false/off", () => {
+		expect(rateLimitWatchdogEnabledFromEnv({} as NodeJS.ProcessEnv)).toBe(true);
+		expect(rateLimitWatchdogEnabledFromEnv({ VSTACK_RATE_LIMIT_WATCHDOG: "0" } as any)).toBe(false);
+		expect(rateLimitWatchdogEnabledFromEnv({ VSTACK_RATE_LIMIT_WATCHDOG: "false" } as any)).toBe(false);
+		expect(rateLimitWatchdogEnabledFromEnv({ VSTACK_RATE_LIMIT_WATCHDOG: "off" } as any)).toBe(false);
+		expect(rateLimitWatchdogEnabledFromEnv({ VSTACK_RATE_LIMIT_WATCHDOG: "1" } as any)).toBe(true);
+	});
+
+	test("max attempts defaults to 5 and clamps garbage", () => {
+		expect(rateLimitMaxAttemptsFromEnv({} as NodeJS.ProcessEnv)).toBe(RATE_LIMIT_DEFAULT_MAX_ATTEMPTS);
+		expect(rateLimitMaxAttemptsFromEnv({ VSTACK_RATE_LIMIT_MAX_ATTEMPTS: "3" } as any)).toBe(3);
+		expect(rateLimitMaxAttemptsFromEnv({ VSTACK_RATE_LIMIT_MAX_ATTEMPTS: "garbage" } as any)).toBe(
+			RATE_LIMIT_DEFAULT_MAX_ATTEMPTS,
+		);
+		expect(rateLimitMaxAttemptsFromEnv({ VSTACK_RATE_LIMIT_MAX_ATTEMPTS: "0" } as any)).toBe(
+			RATE_LIMIT_DEFAULT_MAX_ATTEMPTS,
+		);
+	});
+
+	test("backoff ladder defaults to 60,120,300,600,1800 and parses overrides", () => {
+		expect(rateLimitBackoffLadderFromEnv({} as NodeJS.ProcessEnv)).toEqual([60, 120, 300, 600, 1800]);
+		expect(
+			rateLimitBackoffLadderFromEnv({ VSTACK_RATE_LIMIT_BACKOFF_LADDER: "5,10" } as any),
+		).toEqual([5, 10]);
+		expect(
+			rateLimitBackoffLadderFromEnv({ VSTACK_RATE_LIMIT_BACKOFF_LADDER: "garbage" } as any),
+		).toEqual([60, 120, 300, 600, 1800]);
+	});
+});

--- a/skills/flightdeck/lib/flightdeck-core/tests/parity/rate-limit-wiring.test.ts
+++ b/skills/flightdeck/lib/flightdeck-core/tests/parity/rate-limit-wiring.test.ts
@@ -1,0 +1,126 @@
+// vstack#108 wiring test: the bash pi subscriber must stay in lock-step
+// with the canonical decideRateLimitRetry decision module. Two halves:
+//
+//   1. The bash subscriber source contains the jq filter that picks up
+//      the canonical rate-limit shape, plus both wake-event classifier
+//      tags (pi-rate-limit-retry / pi-rate-limit-exhausted) and a steer
+//      dispatch path. Source-level guards catch any future refactor that
+//      removes one of the contracts.
+//   2. The TS decision module's CLI (`bun rate-limit-watchdog.ts decide
+//      ...`) emits the exact JSON shape the bash branch consumes. Drives
+//      the CLI for a canonical event + a healthy event and asserts the
+//      decision-kind round-trip.
+
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SUBSCRIBERS_BASH = resolve(HERE, "../../../../scripts/lib/subscribers.bash");
+const DECIDER_TS = resolve(HERE, "../../src/daemon/rate-limit-watchdog.ts");
+
+const bashSrc = readFileSync(SUBSCRIBERS_BASH, "utf8");
+
+const CANONICAL_DATA = {
+	message: {
+		api: "claude-bridge",
+		content: [
+			{
+				text: "API Error: Server is temporarily limiting requests (not your usage limit) · Rate limited",
+				type: "text",
+			},
+		],
+		errorMessage:
+			"Claude Code returned an error result: API Error: Server is temporarily limiting requests (not your usage limit) · Rate limited",
+		role: "assistant",
+		stopReason: "error",
+	},
+};
+
+const HEALTHY_DATA = {
+	message: {
+		content: [{ text: "Done.", type: "text" }],
+		role: "assistant",
+		stopReason: "stop",
+	},
+};
+
+function runDecider(event: unknown, attempt: number, paneId = "%41", now = 0): { kind: string; raw: any } {
+	const r = spawnSync(
+		"bun",
+		[
+			DECIDER_TS,
+			"decide",
+			"--event",
+			JSON.stringify(event),
+			"--pane",
+			paneId,
+			"--attempt",
+			String(attempt),
+			"--now",
+			String(now),
+		],
+		{ encoding: "utf8" },
+	);
+	if (r.status !== 0) throw new Error(`decider CLI exit ${r.status}: ${r.stderr}`);
+	const parsed = JSON.parse(r.stdout);
+	return { kind: parsed.kind, raw: parsed };
+}
+
+describe("rate-limit wiring: bash subscriber mirror (vstack#108)", () => {
+	test("subscribers.bash honors VSTACK_RATE_LIMIT_WATCHDOG=0 disable", () => {
+		expect(bashSrc).toMatch(/VSTACK_RATE_LIMIT_WATCHDOG/);
+		expect(bashSrc).toMatch(/case "\$rate_limit_enabled" in 0\|false\|FALSE\|off\|OFF/);
+	});
+
+	test("bash defaults match TS decider defaults", () => {
+		// Max attempts default 5.
+		expect(bashSrc).toMatch(/VSTACK_RATE_LIMIT_MAX_ATTEMPTS:-5/);
+	});
+
+	test("jq filter matches message_end + assistant + stopReason=error + rate-limit prose", () => {
+		expect(bashSrc).toMatch(/\.event == "message_end"/);
+		expect(bashSrc).toMatch(/\.data\.message\.role/);
+		expect(bashSrc).toMatch(/\.data\.message\.stopReason/);
+		expect(bashSrc).toMatch(/temporarily limiting requests/);
+		expect(bashSrc).toMatch(/too many requests/);
+	});
+
+	test("bash emits both retry and exhausted classifier tags", () => {
+		expect(bashSrc).toContain('--arg tag "pi-rate-limit-retry"');
+		expect(bashSrc).toContain('--arg tag "pi-rate-limit-exhausted"');
+	});
+
+	test("bash references the canonical TS module name for parity", () => {
+		expect(bashSrc).toContain("rate-limit-watchdog.ts");
+		expect(bashSrc).toMatch(/decideRateLimitRetry/);
+	});
+
+	test("bash dispatches a pi-bridge --steer after the backoff delay", () => {
+		expect(bashSrc).toContain("--steer");
+		// Steer prose is mandated by the issue body.
+		expect(bashSrc).toContain("API rate limit was detected. Try to continue from where you left off.");
+	});
+});
+
+describe("rate-limit decider CLI (vstack#108)", () => {
+	test("canonical event + attempt 0 returns retry-at with attempt=1", () => {
+		const { kind, raw } = runDecider({ data: CANONICAL_DATA, event: "message_end", type: "event" }, 0);
+		expect(kind).toBe("retry-at");
+		expect(raw.attempt).toBe(1);
+		expect(raw.at).toBeGreaterThan(0);
+	});
+
+	test("canonical event + attempt at max returns exhausted", () => {
+		const { kind, raw } = runDecider({ data: CANONICAL_DATA, event: "message_end", type: "event" }, 5);
+		expect(kind).toBe("exhausted");
+		expect(raw.attempt).toBe(5);
+	});
+
+	test("healthy event returns not-rate-limited", () => {
+		const { kind } = runDecider({ data: HEALTHY_DATA, event: "message_end", type: "event" }, 0);
+		expect(kind).toBe("not-rate-limited");
+	});
+});

--- a/skills/flightdeck/lib/flightdeck-core/tests/unit/activity.test.ts
+++ b/skills/flightdeck/lib/flightdeck-core/tests/unit/activity.test.ts
@@ -96,6 +96,29 @@ describe("activity event normalization", () => {
 		expect(emptyBranch.refs?.branch).toBeUndefined();
 	});
 
+	test("accepts new agent.rate_limit_* types (vstack#108)", () => {
+		for (const type of [
+			"agent.rate_limited",
+			"agent.rate_limit_retry",
+			"agent.rate_limit_resolved",
+			"agent.rate_limit_exhausted",
+		]) {
+			const event = normalizeActivityEvent(
+				{
+					details: { attempt: 2, next_retry_at: 1_700_000_000_000 },
+					refs: { agent: "rust" },
+					source: "pi-agents-tmux",
+					summary: `rust ${type}`,
+					type,
+				},
+				{ naturalKey: `pane:%41:${type}`, sessionId: "S1" },
+			);
+			expect(event.type).toBe(type);
+			expect(event.refs?.agent).toBe("rust");
+			expect(event.details?.attempt).toBe(2);
+		}
+	});
+
 	test("accepts new pr/issue labeled and unlabeled types", () => {
 		for (const type of ["pr.labeled", "pr.unlabeled", "issue.labeled", "issue.unlabeled"]) {
 			const event = normalizeActivityEvent(

--- a/skills/flightdeck/scripts/lib/subscribers.bash
+++ b/skills/flightdeck/scripts/lib/subscribers.bash
@@ -298,6 +298,21 @@ pi_subscriber_loop() {
   local edit_loop_fired=0
   local -a edit_loop_ts=()
 
+  # vstack#108: rate-limit watchdog state. Mirrors the canonical decision
+  # in src/daemon/rate-limit-watchdog.ts decideRateLimitRetry(); the TS
+  # function is the source of truth and parity tests assert this bash
+  # stays in lock step. Per-pane attempt counter is tracked in this
+  # process; daemon restart resets the budget (acceptable per the brief).
+  local rate_limit_enabled="${VSTACK_RATE_LIMIT_WATCHDOG:-1}"
+  case "$rate_limit_enabled" in 0|false|FALSE|off|OFF) rate_limit_enabled=0 ;; *) rate_limit_enabled=1 ;; esac
+  local rate_limit_attempt=0
+  local rate_limit_max="${VSTACK_RATE_LIMIT_MAX_ATTEMPTS:-5}"
+  [[ "$rate_limit_max" =~ ^[1-9][0-9]*$ ]] || rate_limit_max=5
+  local rate_limit_decider="${VSTACK_RATE_LIMIT_DECIDER_BIN:-}"
+  if [[ -z "$rate_limit_decider" ]]; then
+    rate_limit_decider="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../lib/flightdeck-core/src/daemon" 2>/dev/null && pwd)/rate-limit-watchdog.ts"
+  fi
+
   "$pi_bin" stream "${pi_target_args[@]}" 2>/dev/null \
     | jq --unbuffered -c 'select(
         (.type == "bridge_hello")
@@ -313,6 +328,8 @@ pi_subscriber_loop() {
         (.type == "event" and .event == "tool_execution_end" and ((.data.toolName // "") == "edit") and (.data.isError == true))
         or
         (.type == "event" and .data.message.role == "assistant" and (.data.message.stopReason // "") != "")
+        or
+        (.type == "event" and .event == "message_end" and (.data.message.role // "") == "assistant" and (.data.message.stopReason // "") == "error" and ((.data.message.errorMessage // "") | test("temporarily limiting requests|[Rr]ate.{0,5}[Ll]imit|429|too many requests")))
       )' \
     | while IFS= read -r line; do
       if ! kill -0 "$parent_pid" 2>/dev/null; then exit 0; fi
@@ -384,6 +401,92 @@ pi_subscriber_loop() {
           fi
         fi
         continue
+      fi
+
+      # vstack#108: rate-limit watchdog. The jq filter above keeps only
+      # message_end events whose assistant payload errored with a
+      # canonical rate-limit prose. Per-pane attempt counter advances
+      # through the env-driven backoff ladder; on retry-at we both
+      # write a wake-event row (so the daemon wakes master) and fork a
+      # detached background sleeper that delivers `pi-bridge send
+      # --steer` once the API window has plausibly reset. On exhausted
+      # we emit a distinct classifier_tag so master can operator-
+      # intervene without further mistaken retries.
+      if [[ "$event_name" == "message_end" && "$rate_limit_enabled" == "1" ]]; then
+        local rl_error rl_role rl_stop
+        rl_role=$(jq -r '.data.message.role // ""' <<< "$line" 2>/dev/null)
+        rl_stop=$(jq -r '.data.message.stopReason // ""' <<< "$line" 2>/dev/null)
+        rl_error=$(jq -r '.data.message.errorMessage // ""' <<< "$line" 2>/dev/null)
+        if [[ "$rl_role" == "assistant" && "$rl_stop" == "error" ]] \
+          && [[ "$rl_error" =~ (temporarily\ limiting\ requests|[Rr]ate.{0,5}[Ll]imit|429|too\ many\ requests) ]]; then
+          local rl_event_json rl_decision rl_kind rl_at rl_attempt_next
+          rl_event_json=$(jq -c '.data // {}' <<< "$line" 2>/dev/null)
+          if [[ -n "$rl_event_json" && -x "$(command -v bun 2>/dev/null)" && -f "$rate_limit_decider" ]]; then
+            rl_decision=$(bun "$rate_limit_decider" decide \
+              --event "$rl_event_json" \
+              --pane "$pane_id" \
+              --attempt "$rate_limit_attempt" \
+              --now "$(date +%s%3N)" 2>/dev/null || true)
+          fi
+          if [[ -z "$rl_decision" ]]; then
+            # Defensive fallback when bun / the decider script is missing:
+            # still emit a single wake-event row so master gets the signal,
+            # but do not schedule a steer (no decision module to compute the
+            # backoff).
+            rl_decision='{"kind":"not-rate-limited"}'
+          fi
+          rl_kind=$(jq -r '.kind // ""' <<< "$rl_decision" 2>/dev/null)
+          if [[ "$rl_kind" == "retry-at" ]]; then
+            rl_at=$(jq -r '.at // 0' <<< "$rl_decision" 2>/dev/null)
+            rl_attempt_next=$(jq -r '.attempt // 0' <<< "$rl_decision" 2>/dev/null)
+            rate_limit_attempt="$rl_attempt_next"
+            local rl_hash rl_now_ms rl_delay_ms
+            rl_now_ms=$(date +%s%3N)
+            rl_delay_ms=$(( rl_at - rl_now_ms ))
+            (( rl_delay_ms < 0 )) && rl_delay_ms=0
+            rl_hash=$(printf '%s|rate-limit|%s|%s' "$pane_id" "$rl_attempt_next" "$rl_at" | sha256sum | awk '{print substr($1,1,12)}')
+            ( exec 219>"$SESSION_LOCK"
+              flock 219
+              jq -nc --arg ts "$(date -Iseconds)" \
+                     --arg pid "$pane_id" \
+                     --arg harness "pi" \
+                     --arg tag "pi-rate-limit-retry" \
+                     --arg h "$rl_hash" \
+                     --argjson attempt "$rl_attempt_next" \
+                     --argjson next_retry_at "$rl_at" \
+                     '{ts:$ts, pane_id:$pid, harness:$harness, event_type:"rate_limited", attempt:$attempt, next_retry_at:$next_retry_at, classifier_tag:$tag, hash:$h}' \
+                     >> "$WAKE_EVENTS_LOG"
+            )
+            # Detached steer dispatcher: sleep then deliver via pi-bridge.
+            # nohup + disown so the sleeper survives the loop body.
+            local rl_delay_sec=$(( rl_delay_ms / 1000 ))
+            (( rl_delay_sec < 1 )) && rl_delay_sec=1
+            ( nohup bash -c "sleep $rl_delay_sec; '$pi_bin' send ${pi_target_args[*]} --steer 'API rate limit was detected. Try to continue from where you left off.' >/dev/null 2>&1" >/dev/null 2>&1 & ) >/dev/null 2>&1
+            printf '%s [pi-rate-limit-scheduled] pane=%s attempt=%s delay_sec=%s\n' \
+              "$(date -Iseconds)" "$pane_id" "$rl_attempt_next" "$rl_delay_sec" \
+              >> "$sub_log" 2>/dev/null || true
+            continue
+          elif [[ "$rl_kind" == "exhausted" ]]; then
+            rl_attempt_next=$(jq -r '.attempt // 0' <<< "$rl_decision" 2>/dev/null)
+            local rl_hash
+            rl_hash=$(printf '%s|rate-limit-exhausted|%s' "$pane_id" "$rl_attempt_next" | sha256sum | awk '{print substr($1,1,12)}')
+            ( exec 219>"$SESSION_LOCK"
+              flock 219
+              jq -nc --arg ts "$(date -Iseconds)" \
+                     --arg pid "$pane_id" \
+                     --arg harness "pi" \
+                     --arg tag "pi-rate-limit-exhausted" \
+                     --arg h "$rl_hash" \
+                     --argjson attempt "$rl_attempt_next" \
+                     '{ts:$ts, pane_id:$pid, harness:$harness, event_type:"rate_limit_exhausted", attempt:$attempt, classifier_tag:$tag, hash:$h}' \
+                     >> "$WAKE_EVENTS_LOG"
+            )
+            printf '%s [pi-rate-limit-exhausted] pane=%s attempt=%s\n' \
+              "$(date -Iseconds)" "$pane_id" "$rl_attempt_next" \
+              >> "$sub_log" 2>/dev/null || true
+            continue
+          fi
+        fi
       fi
 
       if [[ "$event_name" == "vstack_activity" ]]; then


### PR DESCRIPTION
Closes #108.

Three commits across flightdeck-core + pi-agents-tmux + bash subscriber implement a two-layer rate-limit recovery system.

## Investigation

Confirmed canonical Claude rate-limit event shape from a real transcript: pi-bridge `message_end` event with `data.message.role:"assistant"` + `data.message.stopReason:"error"` + `data.message.errorMessage` (and/or `content[0].text`) matching `/temporarily limiting requests|rate[\s_-]?limit(?:ed)?|429|too many requests/i`. The `stopReason==="error"` gate prevents prose-mentioning-rate-limit from triggering false recovery.

## Architecture

`406e0570` — Canonical decision module + activity types in flightdeck-core.
- Pure `decideRateLimitRetry()` with env-driven `VSTACK_RATE_LIMIT_MAX_ATTEMPTS` (5) + `VSTACK_RATE_LIMIT_BACKOFF_LADDER` (60,120,300,600,1800s).
- Explicit `retry_after_ms` extraction (wins over ladder when API provides it).
- Fixed steer prose: `"API rate limit was detected. Try to continue from where you left off."`
- 4 new activity types: `agent.rate_limited`, `agent.rate_limit_retry`, `agent.rate_limit_resolved`, `agent.rate_limit_exhausted`.
- 25 parity tests + 4 activity-type assertions.

`8c48b4a0` — Layer A: pi-agents-tmux subagent panes.
- Per-pane stateful watchdog hooked on `pi.on("message_end")`.
- Schedules retries via `pi.sendUserMessage(steer)` at the computed time.
- Gates the existing #66 agent-end-watchdog so synthetic `needs_completion` doesn't race the scheduled steer.
- Vendors the decision module locally (cross-repo imports don't resolve post-install for standalone npm-shaped extensions); parity tests in both packages exercise identical shapes so drift surfaces in CI.

`6a241897` — Layer B: flightdeck-daemon pi subscriber (closes #108).
- New `bun rate-limit-watchdog.ts decide` CLI on the canonical module for bash callers.
- Bash subscriber branch detects the canonical shape via jq (cheap; no per-event bun launch for detection), calls TS decider for ladder math.
- Forks detached `nohup bash -c "sleep N; pi-bridge send --steer ..."` so the sleeper survives subscriber-loop iterations.
- Writes `pi-rate-limit-retry` / `pi-rate-limit-exhausted` classifier tags to `WAKE_EVENTS_LOG` consumed by the daemon canonical-tag path.

## Validation

- flightdeck-core: bun test 549/0; typecheck clean.
- pi-agents-tmux: bun test 127/0.
- flightdeck-dashboard: cargo fmt/clippy/test all pass (no source change needed — `event_chip` already maps `agent.*` prefix).
- Decider CLI smoke: `bun rate-limit-watchdog.ts decide --event {...} --attempt 0 --now 1000` returns `{kind:"retry-at", attempt:1, at:61000, steerMessage:"API rate limit..."}`.

## Env switches

- `VSTACK_RATE_LIMIT_WATCHDOG=0` disables (default on).
- `VSTACK_RATE_LIMIT_MAX_ATTEMPTS` (default 5).
- `VSTACK_RATE_LIMIT_BACKOFF_LADDER` CSV seconds (default `60,120,300,600,1800`).

Per-pane counter persists for the daemon/extension process lifetime; restart resets the budget.