### PR TITLE
docs(flightdeck): catch-up sweep for post-W4 Phase 7 features (closes #112)

### DIFF
--- a/pi-extensions/pi-flightdeck/README.md
+++ b/pi-extensions/pi-flightdeck/README.md
@@ -1,10 +1,10 @@
 # pi-flightdeck
 
-> **DEPRECATED for new sessions.** A first-class Rust dashboard ships with the flightdeck skill at `skills/flightdeck/lib/flightdeck-dashboard/`. Run `flightdeck-dashboard tui` (auto-launched by `workflows/start.md`) for the same surfaces with native motion, file-watched live updates, and a daemon read-shim. This extension remains supported for sessions that prefer in-pi mission control until parity is verified across all installs.
+> **DEPRECATED for new sessions.** The Rust dashboard at `skills/flightdeck/lib/flightdeck-dashboard/` now has feature parity for everything this extension renders — structured activity rendering, rate-limit recovery surfacing, branch/entry binding, watchdog activity rows, the `(stale)` row annotation, responsive tabs, the Costs detail popup (`p`), Alt+M compact mode, theme picker swatch slots, conversations file-mode, and Unicode display-width — with native motion, file-watched live updates, and a daemon read-shim. Run `flightdeck-dashboard tui` (auto-launched by `workflows/start.md`) instead. This extension remains supported for sessions that prefer in-pi mission control until parity is verified across all installs.
 
 > ⚠️ **WIP — not production ready.** APIs, settings, and UI may change without notice.
 
-Read-only, sessions-first dashboard for the [`flightdeck`](../../skills/flightdeck) skill. When Pi runs as the Flightdeck master agent in a tmux session, this extension surfaces the same owner-scoped on-disk tracked-session state the daemon and master maintain — without ever mutating it. The Live feed tab still tails the daemon log; the structured `flightdeck-activity-<session>.jsonl` sidecar is consumed by the Rust dashboard, which new sessions should prefer.
+Read-only, sessions-first dashboard for the [`flightdeck`](../../skills/flightdeck) skill. When Pi runs as the Flightdeck master agent in a tmux session, this extension surfaces the same owner-scoped on-disk tracked-session state the daemon and master maintain — without ever mutating it. The Live feed tab still tails the daemon log; the structured `flightdeck-activity-<session>.jsonl` sidecar is consumed by the Rust dashboard, which new sessions should prefer for the watchdog/branch/entry/recovery surfaces.
 
 ## Highlights
 

--- a/skills/flightdeck/DEVELOPMENT.md
+++ b/skills/flightdeck/DEVELOPMENT.md
@@ -6,6 +6,53 @@ This file is for agents and humans hacking on flightdeck itself. End users shoul
 
 Most scripts under `scripts/` are bash trampolines that exec the TypeScript implementation under `lib/flightdeck-core/src/bin/`. `flightdeck-dashboard` is the Rust/ratatui trampoline under `lib/flightdeck-dashboard/`: it prefers a prebuilt release binary and falls back to `cargo run --release`. `bun` is a hard runtime dependency for the TypeScript scripts. Functional + integration tests live under `lib/flightdeck-core/tests/`. The live-wake suite (`tests/live-wake.sh`) is the smoke test for the daemon `start` run-loop.
 
+## Reliability watchdogs
+
+Four watchdogs sit between the daemon, the canonical TS subscriber, and the `pi-agents-tmux` extension. SKILL.md and README.md describe behavior and env vars; this section is the parity contract.
+
+| Watchdog | Canonical decision module | Activity types | Parity rule |
+| --- | --- | --- | --- |
+| agent-end | `pi-extensions/pi-agents-tmux/extensions/subagent/agent-end-watchdog.ts` | `agent.needs_completion` | Synthesizes a `needs_completion` outbox when `agent_end` fires without `complete_subagent` within `VSTACK_AGENT_END_WATCHDOG_GRACE_SEC`. The synthetic outbox is byte-equivalent to a legitimate outbox so parents cannot tell them apart. |
+| idle-stall | `pi-extensions/pi-agents-tmux/extensions/subagent/idle-stall-watchdog.ts` | `agent.idle_stalled` | Polls bridge-idle subagent panes on `VSTACK_STALL_WATCHDOG_INTERVAL_SEC` and synthesizes a `blocked` outbox after `VSTACK_STALL_WATCHDOG_THRESHOLD_SEC`. Bridge-idle is the canonical signal; never substitute pane bell or tmux capture. |
+| edit-loop | `skills/flightdeck/lib/flightdeck-core/src/daemon/edit-loop-detector.ts` | `agent.edit_loop_blocked` | Counts edit-tool failures within `VSTACK_EDIT_LOOP_WINDOW_SEC`; trips on `VSTACK_EDIT_LOOP_THRESHOLD_N`. Failure classification uses the tool-renderer's structured error path — never substring matches against assistant text. |
+| rate-limit | `skills/flightdeck/lib/flightdeck-core/src/daemon/rate-limit-watchdog.ts` plus `pi-extensions/pi-agents-tmux/extensions/subagent/rate-limit-decision.ts` + `rate-limit-watchdog.ts` | `agent.rate_limit_detected`, `agent.rate_limit_retry`, `agent.rate_limit_exhausted` | Decision module is the source of truth. The Pi subscriber routes rate-limit events through it (`flightdeck-core/src/daemon/rate-limit-watchdog.ts` for the in-daemon path; the `subagent/` siblings for the inline subagent path). Backoff ladder is `VSTACK_RATE_LIMIT_BACKOFF_LADDER`, clamped to `VSTACK_RATE_LIMIT_MAX_ATTEMPTS`. Any change to the decision module must keep both sides in lock-step. |
+
+All four emit activity-only rows for soft signals (detection, retry) and wake master only when they synthesize a terminal outbox or exhaust their budget.
+
+## Daemon hygiene
+
+- **Bell wake per-tag rate-limit** (`FD_BELL_WAKE_INTERVAL_SEC`, default `60`). Implemented in `src/daemon/wake-filter.ts`. Suppresses successive bell wakes for the same `(pane_id, classifier_tag)` within the window. Storms on a single tag therefore collapse to one wake; multiple distinct tags still wake independently.
+- **Mid-session reconcile** (`FD_RECONCILE_INTERVAL_SEC`, default `5`). Implemented in `src/daemon/reconcile.ts` (called from `src/daemon/loop.ts`). Each tick: spawn subscribers for tracked entries whose pane is alive but missing a subscriber, reap subscribers whose pane is gone, and drop stale `.entries` rows whose pane id is no longer in `tmux list-panes`. The reap is conservative — it never removes a tracked entry while its pane is alive even if the subscriber is dead, since master may still want to receive a follow-up wake.
+- **Heartbeat cgroup memory probe** (`FD_HEARTBEAT_OWNER_CGROUP`, default `1`). Implemented in `src/daemon/owner-cgroup-mem.ts`. Reads `MemoryCurrent` and `MemoryPeak` from the owner harness's cgroup when available; failures are silent so the probe never blocks a heartbeat. Set the env var to `0` to skip the probe entirely (containers / non-systemd hosts).
+- **Master-gone recovery hint**. Implemented in `src/daemon/recovery-hint.ts`. On `master-gone` exit the daemon writes `fd-daemon-recovery-<SESSION_KEY>.json` under `FD_STATE_DIR` with `{reason, session_id, owner_pid, owner_pane_id, exited_at, next_steps[], state_file, events_file}`. Write failure is warn-logged and must NEVER block the master-gone exit — the file is a breadcrumb, not a barrier.
+
+## Cross-source activity binding
+
+The spawn path and tool wrappers cooperate to thread a stable identity through every activity row originated by a tracked pane.
+
+- `flightdeck-session start` exports `FLIGHTDECK_ENTRY_ID=<id>` into the child environment so subsequent `github.sh` / `linear.sh` / `label-*` wrappers can attach `refs.entry_id` without further plumbing. The wrappers fall back to legacy `FLIGHTDECK_ISSUE_ID` for issue-mode panes when the entry id is not available.
+- `entry.branch` is captured at spawn via `git rev-parse --abbrev-ref HEAD` against the worktree cwd. Stored on `entries[id].branch` and surfaced in the Rust dashboard right rail and the Sessions table PR/worktree column (`<branch> · PR #N` for non-default branches).
+- `refs.branch` is enriched on `pr.*` activity rows by querying `gh pr view --json headRefName` in `workflow-emit.ts`. Failures degrade silently — the row still emits without `refs.branch`.
+- Child Pi sessions advertise a unique `<parent>:c<pid>` session id (see `pi-extensions/pi-session-bridge/extensions/child-session-id.ts`) by exporting `PI_BRIDGE_PARENT_SESSION_ID` and `PI_BRIDGE_CHILD_ROLE` into the child environment before spawn. Activity rows from the child therefore disambiguate from the parent in dashboards and post-mortems.
+
+## bg-task lifecycle accounting
+
+`BackgroundTaskSnapshot.terminationReason` is the canonical post-mortem hint for any terminated bg-task. The enum is defined in `pi-extensions/pi-background-tasks/extensions/types.ts`:
+
+- `self-exit` — child exited under its own steam.
+- `extension-stop` — `bg_task action: "stop"`.
+- `session-shutdown` — Pi session unloaded.
+- `timeout` — `timeoutSeconds` elapsed.
+- `external` — unexpected exit (OOM, external SIGKILL, etc.).
+- `reconcile-on-restart` — task finalized at session restore because the recorded pid was gone or recycled.
+- `orphaned-pid-gone` / `orphaned-pid-reused` — the orphan-watcher polled a previously-restored alive task and found the pid gone or recycled (kernel start-time mismatch).
+
+The reason flows through `lifecycle.ts` into the snapshot consumed by `bg_status list`, the dashboard widget, and wake payloads. Wake suppression honors `notifyOnExit: false` and `notifyMode: "first-match-only"` against the same enum; suppressed wakes carry a `WakeDropReason` so post-mortems can tell genuine drops from races.
+
+## tool_batch hardening
+
+`pi-extensions/pi-tool-renderer/extensions/tool-renderer/batch.ts` exposes the `batchCallTimeoutMs` setting (default `120000`). Each inner tool call inside a `tool_batch` is wrapped in a per-call timeout; on timeout the inner result reports `tool_batch inner call <tool> timed out after <ms>ms` instead of hanging the outer batch. Set the value in extension settings to tune for long-running inner tools.
+
 ## Session model and schema boundary
 
 Flightdeck core is the generic tmux-session manager. It owns `TrackedEntry` lifecycle, owner metadata, daemon wake routing, generic prompt handling, and stable pane/window ids for any harness session. Issue orchestration is a domain layer on top: it adds GitHub/Linear/worktree metadata under `entry.domain.issue`, issue-specific lifecycle states (`merge-ready` / `merged` / `aborted`), PR conflict graphs, merge queues, and next-cycle recommendations.
@@ -26,6 +73,8 @@ Pi broker contract: `pi-session-bridge` installs `globalThis[Symbol.for("vstack.
 
 Dashboard activity: the Rust dashboard reads structured JSONL through `JsonlActivitySource`, not the legacy daemon/wake sources. It validates `schema_version: 1`, skips malformed lines with diagnostics, tracks device/inode for same-path rotation, falls back to newest archive filename when the live file is gone, and file-watches the activity sidecar for debounced reloads.
 
+Conversations file-mode rendering: when the dashboard runs without a live tmux session (`tui --state-file` / `tui --session <name>` from a foreign shell), the Conversations tab is populated from activity events instead of from live tmux capture. The render path joins `entry.message_appended` and `entry.tool_call` rows by `entry_id`, formats them through the same view module as live mode, and trims each pane's history to `dashboardConversationTurns`-equivalent depth so file-mode output stays comparable to live captures.
+
 Workflow emitter table:
 
 | Seam | Event types |
@@ -36,6 +85,7 @@ Workflow emitter table:
 | `pane-registry set-state merge-ready/merged/aborted` | `pr.merge_queued`, `pr.merged`, `pr.merge_blocked` |
 | `pane-registry teardown-entry` | `entry.completed`, `entry.cancelled`, `entry.dead` |
 | `github.sh` wrappers | `pr.comments_left`, `pr.merged`, `pr.merge_queued`, `pr.merge_blocked`, `pr.checks_passed`, `pr.checks_failed` |
+| `label-add` / `label-remove` wrappers | `pr.labeled`, `pr.unlabeled`, `issue.labeled`, `issue.unlabeled` |
 | `linear.sh` wrappers | `linear.issue_created`, `linear.issue_updated`, `linear.issue_finished`, `linear.issue_cancelled`, `linear.relation_created` |
 
 `workflow-emit.ts` resolves `FLIGHTDECK_ACTIVITY_FILE` first. Without it, it emits only when `FLIGHTDECK_MANAGED=1` and a state or explicit activity path resolves. Appends use `nonblocking: true`; failures warn once per `(file,type,reason)` and never fail the workflow mutation.
@@ -123,6 +173,8 @@ Snapshot tests use `ratatui::backend::TestBackend::new(200, 60)`. The shared con
 When adding a tab, wire the enum/state in `app/model.rs`, key handling in `app/keymap.rs`, update logic in `app/update.rs`, and render code under `app/view/<tab>.rs` plus `app/view/mod.rs`. Keep view modules render-only: write paths must become `Cmd::Spawn` effects that shell to existing Flightdeck helpers, not direct mutations from the TUI. Mouse targets come from the per-frame `app/hitmap.rs` registry; never store absolute coordinates in `Model`.
 
 Popup chrome lives in `app/view/popup.rs`; individual popups live in `app/view/modals.rs`. Keep popups one-at-a-time and closeable via Esc, `[ ✕ ]`, or the backdrop. Confirm popups are the only write affordance; the pending action must be data (`actions::WriteAction`), not a closure hidden inside view code. Base-layer click zones must remain masked while a popup is open.
+
+Display-width helpers live in `src/util/display_width.rs`. Every view module that lays out tabular content (Sessions table, right rail, popups, conversations) routes through these helpers so CJK and emoji rows align correctly. Never call `.chars().count()` or `len()` for visible width; use the helper and let it consult `unicode-width` for the right answer.
 
 `app/theme.rs` is the single source of truth for colors and styles. Views must consume `Palette` style helpers (`theme.ok()`, `theme.warning()`, `theme.error()`, etc.) and never hard-code raw colors. The frame renderer paints `Palette::bg` once for non-system themes, panels use `Palette::surface`, and popups use `Palette::overlay`; keep System background reset so terminal palettes still win. Motion effects live in `app/view/fx.rs` and `app/motion.rs`; add new effects to the catalog, respect `MotionLevel::Off`, and keep semantic information visible without animation.
 

--- a/skills/flightdeck/README.md
+++ b/skills/flightdeck/README.md
@@ -23,6 +23,19 @@ There are two modes per tracked entry:
 
 When all tracked entries are terminal, flightdeck writes a summary and hands control back.
 
+## Reliability
+
+Four watchdogs sit between the daemon and the spawned agents and recover from the most common failure modes without waking you:
+
+- **agent-end watchdog** — if a subagent emits its end-of-turn event but never writes a completion outbox (an `agent_end` race), flightdeck synthesizes a `needs_completion` outbox after a short grace window so the parent agent is never left hanging on a phantom child.
+- **idle-stall watchdog** — if a subagent has been bridge-idle for several minutes without producing an outbox, flightdeck synthesizes a `blocked` outbox so the parent agent moves on instead of polling forever.
+- **edit-loop detector** — if a child agent fails the same edit tool repeatedly within a short window (default 5 failures in 120s), flightdeck synthesizes a `blocked` outbox so a stuck retry loop surfaces as an explicit failure.
+- **rate-limit watchdog** — if the upstream Claude API rate-limits a child agent, flightdeck steers it to retry with exponential backoff (default ladder `60s → 120s → 300s → 600s → 1800s`, up to 5 attempts). Each retry surfaces as a `rate_limit_retry` activity row; an exhausted retry budget shows as `rate_limit_exhausted`.
+
+Each watchdog is independently toggleable via its `VSTACK_*` env var. Daemon hygiene knobs (`FD_BELL_WAKE_INTERVAL_SEC`, `FD_RECONCILE_INTERVAL_SEC`, `FD_HEARTBEAT_OWNER_CGROUP`) similarly default to safe values and only need tuning in unusual setups. See `SKILL.md` for the full table and `DEVELOPMENT.md` for canonical decision modules and parity rules.
+
+If the daemon's master pane disappears (master agent crash, accidental window kill), the daemon writes a structured `fd-daemon-recovery-<session>.json` breadcrumb under `FD_STATE_DIR` before exiting. Re-launch the master from the same cwd and run `flightdeck session watch` to resume; `flightdeck-state archive` rolls the state file if you want to abandon the session instead.
+
 ## Activation and termination
 
 - **Activates** on `flightdeck session start|attach` for generic tracked sessions, or `flightdeck start` for issue workflows, from inside tmux.
@@ -36,6 +49,10 @@ Ask the agent to track an ad-hoc tmux window (a scratch Pi pane, a log tail, an 
 ## Issue workflows
 
 Issue orchestration remains first-class when the session is tied to a Linear/GitHub/worktree domain. Ask the agent to start an issue, check a parallel group for safety, launch the group, watch the session, recompute merge order, or close out the session — it routes to the right flightdeck command for you.
+
+The `github` skill ships `label-add` and `label-remove` wrappers around `gh pr edit` / `gh issue edit`. When flightdeck spawns a managed pane, those wrappers emit `pr.labeled` / `pr.unlabeled` / `issue.labeled` / `issue.unlabeled` activity rows alongside the existing `pr.*` events, so label-driven gates (`defer-ci`, custom workflow labels) show up in the activity sidecar and Rust dashboard.
+
+The spawn path also auto-exports `FLIGHTDECK_ENTRY_ID` into every child pane and captures the worktree's current git branch as `entry.branch` (via `git rev-parse --abbrev-ref HEAD`). The Rust dashboard renders branch info in the right rail and Sessions table PR/worktree column (`<branch> · PR #N` for non-default branches), and `pr.*` activity rows are enriched with `refs.branch` via `gh pr view --json headRefName`. Child Pi sessions also advertise a unique `<parent>:c<pid>` session id (via `PI_BRIDGE_PARENT_SESSION_ID`) so cross-session activity does not collide with the parent.
 
 ## Install
 
@@ -70,7 +87,9 @@ The Rust dashboard binary lives at `skills/flightdeck/lib/flightdeck-dashboard/`
 | `TMUX_PROBE_TTL` | Cached `tmux list-panes` stale-row probe TTL, default `5` seconds. |
 | `FLIGHTDECK_DASHBOARD_STALE_WARN_SECS` / `FLIGHTDECK_DASHBOARD_STALE_DEAD_SECS` | Tune stale-chip thresholds. |
 
-`flightdeck-dashboard tui --demo[=NAME]` runs compiled demo fixtures (`empty`, `one-adhoc`, `one-issue`, `mixed`, `terminated`, `paused`, `observer`, `conversations`, `no-issue`, `decisions`). `tui --state-file <path>` reads a concrete master-state JSON file, and `tui --session <name>` resolves `<project-root>/<FLIGHTDECK_STATE_DIR>/flightdeck-state-<name>.json` (default state dir `tmp/`) with terminated-archive fallback. With neither flag inside tmux, the dashboard uses the current tmux session. Use `--theme moon|dawn|pantera|system` to select Rose Pine Moon, Rose Pine Dawn, Pantera neon, or terminal-system colors. `?` opens Help with the legend, `T` opens the theme picker, `/` opens the filter popup, `Enter` opens the selected session/decision/event detail popup, `g` confirms focus for the selected pane, and `D` confirms prune for stale rows.
+`flightdeck-dashboard tui --demo[=NAME]` runs compiled demo fixtures (`empty`, `one-adhoc`, `one-issue`, `mixed`, `terminated`, `paused`, `observer`, `conversations`, `no-issue`, `decisions`, `stale-mixed`). `tui --state-file <path>` reads a concrete master-state JSON file, and `tui --session <name>` resolves `<project-root>/<FLIGHTDECK_STATE_DIR>/flightdeck-state-<name>.json` (default state dir `tmp/`) with terminated-archive fallback. With neither flag inside tmux, the dashboard uses the current tmux session. Use `--theme moon|dawn|pantera|system` to select Rose Pine Moon, Rose Pine Dawn, Pantera neon, or terminal-system colors. `?` opens Help with the legend, `T` opens the theme picker (with `█bg █surface █accent █error` swatch slot labels), `/` opens the filter popup, `Enter` opens the selected session/decision/event detail popup, `p` opens the pricing-source detail popup from the Costs tab, `g` confirms focus for the selected pane, `D` confirms prune for stale rows, and `Alt+M` toggles compact mode. The tabs row collapses responsively at 140- and 110-column thresholds (full → shortened → narrow labels), and the base header drops `kind counts → uptime → cwd → daemon → master` in priority order before any mid-text clip. Stale rows render with a `(stale)` annotation when tmux reports the pane id is gone, and the right rail adds a `branch <name>` row plus a "Recent activity" panel for adhoc/workflow entries. File-mode (no live tmux session) populates the Conversations tab from activity events instead of leaving dead space, and Unicode display-width is honored across every view module so CJK and emoji rows align.
+
+`flightdeck-state activity export --session <name> [--state-file <path>]` mirrors the existing `path` / `tail` / `append` source-of-truth resolution so post-mortem exports work without an active tmux session.
 
 The legacy in-Pi dashboard extension remains documented in [`pi-extensions/pi-flightdeck/README.md`](../../pi-extensions/pi-flightdeck/README.md), but it is deprecated for new sessions. Prefer the Rust dashboard for new Flightdeck runs.
 
@@ -115,6 +134,11 @@ Most users never touch these. The ones that occasionally matter:
 | `FLIGHTDECK_DASHBOARD_STALE_WARN_SECS` | Rust dashboard stale-warning threshold in seconds (default `30`). |
 | `FLIGHTDECK_DASHBOARD_STALE_DEAD_SECS` | Rust dashboard stale/dead threshold in seconds (default `300`). |
 | `FLIGHTDECK_PI_ACTIVITY_BROKER` | Set to `0` to disable `pi-session-bridge` `vstack_activity` broker consumption and rely on legacy Pi wake messages only. Default `1`. |
+| `VSTACK_AGENT_END_WATCHDOG` / `VSTACK_STALL_WATCHDOG` / `VSTACK_EDIT_LOOP_DETECTOR` / `VSTACK_RATE_LIMIT_WATCHDOG` | Set any to `0` to disable that watchdog. Defaults are `1`. Tuning knobs (`*_GRACE_SEC`, `*_THRESHOLD_SEC`, `*_THRESHOLD_N`, `*_WINDOW_SEC`, `*_MAX_ATTEMPTS`, `*_BACKOFF_LADDER`) live in `SKILL.md`. |
+| `FD_BELL_WAKE_INTERVAL_SEC` | Per-pane-per-tag bell-wake rate-limit window (default `60`). Lower it only if you genuinely want more bells per minute. |
+| `FD_RECONCILE_INTERVAL_SEC` | Mid-session reconcile cadence in seconds (default `5`). The daemon spawns subscribers for newly tracked panes and reaps subscribers for departed panes on this interval. |
+| `FD_HEARTBEAT_OWNER_CGROUP` | Set to `0` to skip the optional `MemoryCurrent`/`MemoryPeak` cgroup probe in heartbeat events. Default `1`. |
+| `FLIGHTDECK_ENTRY_ID` | Auto-exported by `flightdeck-session start` to spawned panes; binds `refs.entry_id` on github/linear/label activity rows. Do not set by hand. |
 
 Activity history lives beside the master state as `<FLIGHTDECK_STATE_DIR>/flightdeck-activity-<session>.jsonl`. `flightdeck-state activity path|append|tail|export` exposes the path, writes normalized activity rows, tails recent rows, or exports JSONL/Markdown. Event families include tracked entries (`entry.*`), agents (`agent.*`), background tasks (`bg_task.*`), PRs (`pr.*`), Linear writes (`linear.*`), questions, and daemon/subscriber lifecycle rows. Pi sessions also append activity-only rows from the `pi-session-bridge` activity broker (`vstack_activity`) when enabled. `flightdeck-state archive` archives the activity JSONL next to the master-state archive.
 

--- a/skills/flightdeck/SKILL.md
+++ b/skills/flightdeck/SKILL.md
@@ -166,6 +166,7 @@ Functional + integration tests live under `lib/flightdeck-core/tests/`.
 | `pane-respond` | Send response to a pane. Modes: free-text payload, `--option N`, `--option-multi`, `--keys` (rejected without `--keys-allow-tmux`), `--question <reqID> --answer\|--answer-multi\|--answer-text\|--answers-json\|--reject`. Validates rebase-multi-choice payloads for the preserve/apply/verify triplet. See `patterns/prompt-handlers.md` for mode selection and `patterns/opencode-questions.md` / `patterns/pi-questions.md` for question routing. |
 | `pane-clear-bell` | Atomic chained-command bell clear (no flicker). |
 | `pr-conflict-graph` | File-intersection adjacency for a list of PR numbers via `gh pr view --json files`. |
+| `label-add` / `label-remove` (in `skills/github/scripts/commands/`) | Add/remove GitHub labels via `gh pr edit` / `gh issue edit`. Emit `pr.labeled` / `pr.unlabeled` / `issue.labeled` / `issue.unlabeled` activity rows when `FLIGHTDECK_MANAGED=1`; silent otherwise. Wrapped by the `github` skill — flightdeck issue workflows call them indirectly. |
 | `prompt-classify` | Regex/sentinel + computed-tag matcher mapping pane state to a handler tag: `rendering`, `terminal-state-reached`, `bash-permission-prompt`, `force-merge-confirm`, `merge-ready-but-unknown`, `merge-now`, `bot-review-wait-stuck`, `rebase-multi-choice`, `force-push-prompt`, `cleanup-prompt`, `audit-relation-prompt`, `descope-related`, `external-fix-suggestions`, `cycle-fix-suggestions`, `scope-creep-detected` [computed], `multi-select-tabbed`, `awaiting-direction`, `generic-multi-choice`, `domain-mismatch`, `idle`. `--entry-kind` guards issue-only tags on non-issue entries; omitted kind and `--entry-kind-unknown` fail closed as `domain-mismatch`. Daemon/event-only tags: `oc-question`, `pi-question`, `pi-subagent-completion`, `pi-bg-task-exit`, `pi-activity-broker`, `daemon-exited`.
 
 `pi-bg-task-exit` (vstack#15): the Pi subscriber matches `pi-bridge stream` events of shape `{ type: "event", event: "message_end", data.message.customType: "vstack-background-tasks:event", data.message.details.eventType: "exit" }` and appends a canonical wake row to `WAKE_EVENTS_LOG`:
@@ -178,7 +179,7 @@ The daemon (`lib/flightdeck-core/src/daemon/loop.ts`) treats the tag as canonica
 
 `pi-activity-broker`: Pi extensions publish through `globalThis[Symbol.for("vstack.pi.activity")]`; `pi-session-bridge` streams each publication as `{type:"event", event:"vstack_activity", data:{...}}`. The Pi subscriber appends an activity-only `pi-activity-broker` row to `WAKE_EVENTS_LOG`. The TS daemon copies the subset payload into `flightdeck-activity-<session>.jsonl` with the tracked pane id and never wakes master. Set `FLIGHTDECK_PI_ACTIVITY_BROKER=0` to disable this broker drain and rely on legacy custom-message wake paths only.
 
-Activity sidecar: `flightdeck-state init` records `activity_path` beside the master state as `flightdeck-activity-<TMUX_SESSION>.jsonl`. `flightdeck-state activity path|append|tail|export` exposes the path, appends a normalized event, tails recent rows, or exports JSONL/Markdown. Retention caps are 5,000 events and 10 MiB per live sidecar; oversized `details` are truncated to a 16 KiB budget. Daemon emission is curated: daemon/subscriber lifecycle, wake-delivery failures, subagent completions, bg-task exit/output rows, questions, and Pi broker rows. Workflow/github/linear helper emission is gated by `FLIGHTDECK_MANAGED=1 || FLIGHTDECK_ACTIVITY_FILE` so standalone wrapper use stays silent.
+Activity sidecar: `flightdeck-state init` records `activity_path` beside the master state as `flightdeck-activity-<TMUX_SESSION>.jsonl`. `flightdeck-state activity path|append|tail|export` exposes the path, appends a normalized event, tails recent rows, or exports JSONL/Markdown. `activity export` accepts `--session <name>` and `--state-file <path>` for parity with `path` / `tail` / `append`, so dashboards and post-mortems can resolve sidecars without an active tmux session. Retention caps are 5,000 events and 10 MiB per live sidecar; oversized `details` are truncated to a 16 KiB budget. Daemon emission is curated: daemon/subscriber lifecycle, wake-delivery failures, subagent completions, bg-task exit/output rows, questions, and Pi broker rows. Workflow/github/linear helper emission is gated by `FLIGHTDECK_MANAGED=1 || FLIGHTDECK_ACTIVITY_FILE` so standalone wrapper use stays silent.
 
 `daemon-exited`: the daemon emits this lifecycle row during cleanup when it exits for `master-gone`, `signal-term`, `signal-int`, or another recorded reason. It writes directly to the per-session `EVENTS_FILE` under `SESSION_LOCK` (not `WAKE_EVENTS_LOG`), with `pane_id` set to the master pane id so pane-keyed drains include it:
 
@@ -261,6 +262,17 @@ Readers call `readTrackedEntries(state)` to get the canonical `TrackedEntry` map
 
 Tracked entry state enum: `state ∈ {waiting, prompting, submitting, ready, complete, cancelled, dead}`. Issue-mode workflows additionally use `{merge-ready, merged, aborted}` for issue-specific lifecycle states; these still map onto the generic enum via `domain.issue.phase` / `domain.issue.outcome` (e.g. `merged → complete + outcome="merged"`). `entryIdForIssue(issueId)` returns the issue id unchanged after validation (empty/invalid ids return null); `issueIdForEntry(entry)` reads `entry.domain.issue.id` or, for `kind: "issue"`, `entry.id`. `owner` is metadata written by `flightdeck-state init`; `owner.pid` is the owner harness PID supplied by `FLIGHTDECK_OWNER_PID` (falling back to parent PID), and `owner.discovery_error` records Pi bridge metadata lookup failures when the owner harness is Pi. pi-flightdeck uses `owner.pane_id` to keep the persistent dashboard owner-scoped by default. `paused_for_user` carries `{entry_id|issue_id, reason, prompt_text}` when a guard or issue-mode pause fires.
 
+## Reliability watchdogs
+
+Four operator-facing watchdogs run inside the daemon and the `pi-agents-tmux` extension. Agents do not interact with them; they emit activity rows and synthetic outbox payloads when child sessions misbehave.
+
+- **agent-end** (`VSTACK_AGENT_END_WATCHDOG`, default on; grace `VSTACK_AGENT_END_WATCHDOG_GRACE_SEC`=10s) — if a child agent emits `agent_end` without writing a `complete_subagent` outbox within the grace window, the watchdog synthesizes a `needs_completion` outbox so the parent never silently stalls. Emits `agent.needs_completion` activity.
+- **idle-stall** (`VSTACK_STALL_WATCHDOG`, default on; `VSTACK_STALL_WATCHDOG_INTERVAL_SEC`=60s, `VSTACK_STALL_WATCHDOG_THRESHOLD_SEC`=300s) — polls bridge-idle subagent panes whose outbox has not landed and fires a synthetic `blocked` outbox after the threshold. Emits `agent.idle_stalled`.
+- **edit-loop** (`VSTACK_EDIT_LOOP_DETECTOR`, default on; `VSTACK_EDIT_LOOP_THRESHOLD_N`=5, `VSTACK_EDIT_LOOP_WINDOW_SEC`=120) — counts edit-tool failures inside a child agent's window; on threshold breach synthesizes a `blocked` outbox + `agent.edit_loop_blocked` activity row.
+- **rate-limit** (`VSTACK_RATE_LIMIT_WATCHDOG`, default on; `VSTACK_RATE_LIMIT_MAX_ATTEMPTS`=5, `VSTACK_RATE_LIMIT_BACKOFF_LADDER`=`60,120,300,600,1800` seconds) — on a detected Claude API rate-limit error, schedules an exponential-backoff steer-retry. Emits `agent.rate_limit_detected` / `agent.rate_limit_retry` / `agent.rate_limit_exhausted` and short-circuits the canonical wake path while a retry is pending.
+
+All four can be hard-disabled by setting the gate env var to `0`. The canonical decision modules and parity rules live in `DEVELOPMENT.md`.
+
 ## Configuration
 
 Master-loop env vars consulted by workflows:
@@ -276,6 +288,32 @@ Master-loop env vars consulted by workflows:
 | `FLIGHTDECK_LAUNCH_MODEL` | unset | Default `open-terminal --model` override when the workflow/user does not pass `--model`. |
 | `FLIGHTDECK_LAUNCH_EFFORT` | unset | Default `open-terminal --effort` / thinking override when the workflow/user does not pass `--effort`. |
 | `FLIGHTDECK_PI_ACTIVITY_BROKER` | `1` | Set to `0` to ignore `pi-session-bridge` `vstack_activity` broker rows and rely on legacy Pi wake messages only. |
+| `FLIGHTDECK_ENTRY_ID` | auto | Exported by `flightdeck-session start` into spawned panes (and inherited by their tool wrappers). When set, `github.sh` / `linear.sh` / `label-*` activity rows auto-bind `refs.entry_id` so cross-source activity ties back to the tracked entry. Do not set by hand. |
+
+Watchdog gates (operator-facing; see § Reliability watchdogs for behavior):
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `VSTACK_AGENT_END_WATCHDOG` | `1` | Toggle for the agent-end watchdog. |
+| `VSTACK_AGENT_END_WATCHDOG_GRACE_SEC` | `10` | Grace seconds before synthesizing a `needs_completion` outbox. |
+| `VSTACK_STALL_WATCHDOG` | `1` | Toggle for the idle-stall watchdog. |
+| `VSTACK_STALL_WATCHDOG_INTERVAL_SEC` | `60` | Poll cadence for idle-stall detection. |
+| `VSTACK_STALL_WATCHDOG_THRESHOLD_SEC` | `300` | Bridge-idle threshold before synthesizing a `blocked` outbox. |
+| `VSTACK_EDIT_LOOP_DETECTOR` | `1` | Toggle for the edit-loop detector. |
+| `VSTACK_EDIT_LOOP_THRESHOLD_N` | `5` | Edit-tool failure count within the window that trips the detector. |
+| `VSTACK_EDIT_LOOP_WINDOW_SEC` | `120` | Sliding window for edit-loop counting. |
+| `VSTACK_RATE_LIMIT_WATCHDOG` | `1` | Toggle for the rate-limit retry watchdog. |
+| `VSTACK_RATE_LIMIT_MAX_ATTEMPTS` | `5` | Maximum retry attempts before surfacing `agent.rate_limit_exhausted`. |
+| `VSTACK_RATE_LIMIT_BACKOFF_LADDER` | `60,120,300,600,1800` | Comma-separated seconds per attempt; clamped to `MAX_ATTEMPTS`. |
+
+Daemon hygiene env vars (operator-facing; details in `DEVELOPMENT.md`):
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `FD_BELL_WAKE_INTERVAL_SEC` | `60` | Per-pane-per-tag bell-wake rate-limit; suppresses storm-y duplicates within the window. |
+| `FD_RECONCILE_INTERVAL_SEC` | `5` | Mid-session reconcile cadence: spawn subscribers for newly tracked panes, reap subscribers for departed panes, drop dead `.entries` rows. |
+| `FD_HEARTBEAT_OWNER_CGROUP` | `1` | Set to `0` to skip the optional `MemoryCurrent` / `MemoryPeak` cgroup probe attached to heartbeat events. |
+
 
 Rust dashboard env vars:
 


### PR DESCRIPTION
Closes #112. Markdown-only sweep updating `SKILL.md`, `README.md`, `DEVELOPMENT.md`, and `pi-extensions/pi-flightdeck/README.md` to cover 26 features that shipped without doc updates after W4 Phase 7.

Coverage:
- 4 reliability watchdogs (agent-end, idle-stall, edit-loop, rate-limit) + their `VSTACK_*` env vars
- 4 daemon hygiene knobs (`FD_BELL_WAKE_INTERVAL_SEC`, `FD_RECONCILE_INTERVAL_SEC`, `FD_HEARTBEAT_OWNER_CGROUP`, master-gone recovery hint)
- 4 cross-source binding items (`FLIGHTDECK_ENTRY_ID`, `entry.branch`, `refs.branch`, `PI_BRIDGE_PARENT_SESSION_ID`)
- 2 bg-task lifecycle items (`BackgroundTaskTerminationReason`, notifyOnExit/notifyMode wake suppression)
- GitHub label wrappers + new `pr.labeled`/`issue.labeled` activity types
- 9 dashboard surfaces (pricing popup, theme swatch labels, responsive tabs, header truncation guard, Alt+M, stale annotation, Conversations file-mode, unicode display-width, right-rail branch + recent-activity)
- Activity export `--session` parity
- `tool_batch` `batchCallTimeoutMs`

All file sizes within 1.5x budget caps:
- SKILL.md 364→402 (cap 540)
- README.md 130→154 (cap 195)
- DEVELOPMENT.md 242→294 (cap 360)
- pi-flightdeck/README.md 113→113 (cap 170; unchanged content, deprecation pointer already covered prior catch-up gaps)