### PR TITLE
chore(pi-tool-renderer): hoist trailing-ansi regex and drop redundant loop

### DIFF
--- a/pi-extensions/pi-tool-renderer/extensions/tool-renderer/ansi.ts
+++ b/pi-extensions/pi-tool-renderer/extensions/tool-renderer/ansi.ts
@@ -73,18 +73,12 @@ export function trimOuterBlankLines(lines: string[]): string[] {
 	return start > end ? [] : lines.slice(start, end + 1);
 }
 
+const TRAILING_ANSI_RE = /(?:\x1b(?:\[[0-9;:]*m|\]133;[ABC]\x07))+$/;
+
 export function trimTrailingWhitespaceBeforeAnsi(text: string): string {
-	let body = text;
-	let suffix = "";
-	const trailingAnsiRe = /(?:\x1b(?:\[[0-9;:]*m|\]133;[ABC]\x07))+$/;
-	while (body.length > 0) {
-		const match = body.match(trailingAnsiRe);
-		if (!match) break;
-		const ansi = match[0];
-		suffix = `${ansi}${suffix}`;
-		body = body.slice(0, -ansi.length);
-	}
-	return `${body.trimEnd()}${suffix}`;
+	const match = text.match(TRAILING_ANSI_RE);
+	if (!match) return text.trimEnd();
+	return `${text.slice(0, -match[0].length).trimEnd()}${match[0]}`;
 }
 
 export function isHorizontalRuleLine(line: string | undefined): boolean {


### PR DESCRIPTION
Follow-up to #89 addressing both Copilot review nits.

## Changes

- Hoist `trailingAnsiRe` to module-level `TRAILING_ANSI_RE` so the `RegExp` is not re-allocated per call. The helper runs from tool chrome's `core.flatMap` on every rendered row, so this is a real (if small) per-row allocation win.
- Drop the `while` loop. The regex is anchored with `+$` and is greedy, so the first match already grabs all consecutive trailing ANSI sequences in a single pass; the loop iterated at most once.

## Verification

Behavior unchanged — verified against the same 8 fixtures used on #89:

| Case | Input | Output |
| --- | --- | --- |
| trailing spaces before reset | `hello world   \x1b[0m` | `hello world\x1b[0m` |
| no ANSI suffix | `hello world   ` | `hello world` |
| mixed FG+RESET | `foo    \x1b[39m\x1b[0m` | `foo\x1b[39m\x1b[0m` |
| spaces between ANSI | `foo\x1b[39m   \x1b[0m` | `foo\x1b[39m\x1b[0m` |
| just ANSI | `\x1b[39m\x1b[0m` | `\x1b[39m\x1b[0m` |
| OSC 133 trailing | `bar   \x1b]133;C\x07` | `bar\x1b]133;C\x07` |
| empty | `` | `` |
| extended SGR colon | `baz   \x1b[38:2:255:0:0m\x1b[0m` | `baz\x1b[38:2:255:0:0m\x1b[0m` |

Pure cosmetic refactor — same call site in `chrome.ts`, same observable rendering.

Refs #89.