### PR TITLE
Fix pi-bridge probe ENOENT toast

### DIFF
--- a/pi-extensions/pi-agents-tmux/README.md
+++ b/pi-extensions/pi-agents-tmux/README.md
@@ -20,7 +20,7 @@ Delegate work to specialized agents from a running Pi session. Agents run either
 - Bg agents get fresh sessions per call by default; opt into shared memory with an explicit `sessionKey`.
 - Inventory-aware launch guard rejects unknown agent names with the available list.
 - Large parallel calls are auto-batched. Pane idle waits use `wait_for_subagent_idle`.
-- Periodic pane idle-stall probes cache `pi-bridge` resolution at extension load; benign missing-binary races skip silently and write diagnostics to the session runtime instead of terminal warnings.
+- Periodic pane idle-stall probes cache `pi-bridge` resolution at extension load. A structured `spawn`/`ENOENT` for the expected `pi-bridge` binary is treated as genuinely missing and skips silently; other ENOENT/spawn failures are written to `subagent-diagnostics.jsonl`. If initial resolver setup fails, one `pi-bridge resolver failed: ...` diagnostic is written.
 
 ## Install
 

--- a/pi-extensions/pi-agents-tmux/README.md
+++ b/pi-extensions/pi-agents-tmux/README.md
@@ -20,6 +20,7 @@ Delegate work to specialized agents from a running Pi session. Agents run either
 - Bg agents get fresh sessions per call by default; opt into shared memory with an explicit `sessionKey`.
 - Inventory-aware launch guard rejects unknown agent names with the available list.
 - Large parallel calls are auto-batched. Pane idle waits use `wait_for_subagent_idle`.
+- Periodic pane idle-stall probes cache `pi-bridge` resolution at extension load; benign missing-binary races skip silently and write diagnostics to the session runtime instead of terminal warnings.
 
 ## Install
 

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/idle-stall-probe.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/idle-stall-probe.ts
@@ -21,7 +21,7 @@ export interface ProbePaneIdleDeps {
 		command: string,
 		args: string[],
 		options?: { cwd?: string; timeoutMs?: number },
-	) => Promise<{ code: number; stdout: string; stderr: string }>;
+	) => Promise<{ code: number; stdout: string; stderr: string; error?: unknown }>;
 	readPaneRegistryEntry: (agent: string) => Promise<PaneRegistryEntry | undefined>;
 	logWarn?: (msg: string) => void;
 	timeoutMs?: number;
@@ -56,8 +56,14 @@ function parseIsIdle(stdout: string): boolean | undefined {
 	}
 }
 
-function isBridgeSpawnMissing(message: string): boolean {
-	return /\bspawn\b/i.test(message) && /\bENOENT\b/i.test(message);
+function isBridgeSpawnMissing(error: unknown, expectedBin: string): boolean {
+	if (!error || typeof error !== "object") return false;
+	const candidate = error as { code?: unknown; syscall?: unknown; path?: unknown };
+	return candidate.code === "ENOENT" && candidate.syscall === "spawn" && candidate.path === expectedBin;
+}
+
+function errorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
 }
 
 export async function probePaneIdle(
@@ -74,19 +80,20 @@ export async function probePaneIdle(
 	if (!bin) return { idle: false, reason: "bridge-bin-not-found" };
 	const args = socket ? ["state", "--socket", socket] : ["state", "--pid", String(pid)];
 	const timeoutMs = deps.timeoutMs ?? BRIDGE_IDLE_PROBE_DEFAULT_TIMEOUT_MS;
-	let result: { code: number; stdout: string; stderr: string };
+	let result: { code: number; stdout: string; stderr: string; error?: unknown };
 	try {
 		result = await deps.execCapture(bin, args, { cwd: entry.cwd, timeoutMs });
 	} catch (err) {
-		const message = (err as Error)?.message ?? String(err);
-		if (isBridgeSpawnMissing(message)) return { idle: false, reason: "bridge-bin-not-found" };
+		const message = errorMessage(err);
+		if (isBridgeSpawnMissing(err, bin)) return { idle: false, reason: "bridge-bin-not-found" };
 		deps.logWarn?.(`probePaneIdle: ${record.agent} exec threw: ${message}`);
 		return { idle: false, reason: /timeout|timed out/i.test(message) ? "bridge-timeout" : "bridge-error" };
 	}
 	if (result.code !== 0) {
 		const stderr = (result.stderr || "").trim();
-		if (isBridgeSpawnMissing(stderr)) return { idle: false, reason: "bridge-bin-not-found" };
-		deps.logWarn?.(`probePaneIdle: ${record.agent} pi-bridge state exit ${result.code}: ${stderr.slice(0, 200)}`);
+		if (isBridgeSpawnMissing(result.error, bin)) return { idle: false, reason: "bridge-bin-not-found" };
+		const detail = stderr || (result.error ? errorMessage(result.error) : "non-zero exit");
+		deps.logWarn?.(`probePaneIdle: ${record.agent} pi-bridge state exit ${result.code}: ${detail.slice(0, 200)}`);
 		return { idle: false, reason: "bridge-error" };
 	}
 	const idle = parseIsIdle(result.stdout);

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/idle-stall-probe.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/idle-stall-probe.ts
@@ -56,6 +56,10 @@ function parseIsIdle(stdout: string): boolean | undefined {
 	}
 }
 
+function isBridgeSpawnMissing(message: string): boolean {
+	return /\bspawn\b/i.test(message) && /\bENOENT\b/i.test(message);
+}
+
 export async function probePaneIdle(
 	record: PaneTaskRecord,
 	deps: ProbePaneIdleDeps,
@@ -75,11 +79,14 @@ export async function probePaneIdle(
 		result = await deps.execCapture(bin, args, { cwd: entry.cwd, timeoutMs });
 	} catch (err) {
 		const message = (err as Error)?.message ?? String(err);
+		if (isBridgeSpawnMissing(message)) return { idle: false, reason: "bridge-bin-not-found" };
 		deps.logWarn?.(`probePaneIdle: ${record.agent} exec threw: ${message}`);
 		return { idle: false, reason: /timeout|timed out/i.test(message) ? "bridge-timeout" : "bridge-error" };
 	}
 	if (result.code !== 0) {
-		deps.logWarn?.(`probePaneIdle: ${record.agent} pi-bridge state exit ${result.code}: ${(result.stderr || "").trim().slice(0, 200)}`);
+		const stderr = (result.stderr || "").trim();
+		if (isBridgeSpawnMissing(stderr)) return { idle: false, reason: "bridge-bin-not-found" };
+		deps.logWarn?.(`probePaneIdle: ${record.agent} pi-bridge state exit ${result.code}: ${stderr.slice(0, 200)}`);
 		return { idle: false, reason: "bridge-error" };
 	}
 	const idle = parseIsIdle(result.stdout);

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/index.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/index.ts
@@ -367,7 +367,22 @@ export default function (pi: ExtensionAPI) {
 	if (guard[INSTALL_SYMBOL]) return;
 	guard[INSTALL_SYMBOL] = true;
 	if (!settingBoolean("enabled", true)) return;
-	const resolveIdleProbeBridgeBin = createCachedPiBridgeResolver(resolvePiBridgeBin);
+
+	let currentRuntimeRoot: string | undefined;
+	const pendingRuntimeDiagnostics: Array<{ source: string; message: string }> = [];
+	const logRuntimeDiagnostic = (source: string, message: string) => {
+		if (!currentRuntimeRoot) {
+			pendingRuntimeDiagnostics.push({ source, message });
+			return;
+		}
+		appendRuntimeDiagnostic(currentRuntimeRoot, source, message);
+	};
+	const flushRuntimeDiagnostics = () => {
+		if (!currentRuntimeRoot || pendingRuntimeDiagnostics.length === 0) return;
+		for (const pending of pendingRuntimeDiagnostics.splice(0)) appendRuntimeDiagnostic(currentRuntimeRoot, pending.source, pending.message);
+	};
+	const logIdleStallDiagnostic = (message: string) => logRuntimeDiagnostic("idle-stall-watchdog", message);
+	const resolveIdleProbeBridgeBin = createCachedPiBridgeResolver(resolvePiBridgeBin, logIdleStallDiagnostic);
 
 	const childAgentName = process.env.PI_SUBAGENT_CHILD_AGENT;
 	const statuslineBridge: SubagentStatuslineBridge = {
@@ -448,8 +463,6 @@ export default function (pi: ExtensionAPI) {
 	// pi-core post-compaction stalls where agent_end never fires. Reuses
 	// the W5 O_EXCL writer so a racing real complete_subagent always wins.
 
-	let currentRuntimeRoot: string | undefined;
-	const logIdleStallDiagnostic = (message: string) => appendRuntimeDiagnostic(currentRuntimeRoot, "idle-stall-watchdog", message);
 	const idleStallWatchdog = createIdleStallWatchdog({
 		intervalMs: stallWatchdogIntervalMsFromEnv(),
 		thresholdMs: stallWatchdogThresholdMsFromEnv(),
@@ -1267,6 +1280,7 @@ export default function (pi: ExtensionAPI) {
 		// vstack#63 workaround: idle-stall watchdog rides on the parent
 		// session and polls active tasks for post-compaction stalls.
 		currentRuntimeRoot = runtimeRoot;
+		flushRuntimeDiagnostics();
 		idleStallWatchdog.start();
 	});
 

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/index.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/index.ts
@@ -67,6 +67,7 @@ import {
 	ensurePaneBridgeMetadata,
 	ensurePersistentPane,
 	execCapture,
+	createCachedPiBridgeResolver,
 	migrateLegacyPackageRuntime,
 	migrateLegacyProjectRuntime,
 	paneExists,
@@ -354,11 +355,19 @@ function clampAboveEditorWidget(lines: string[], terminalRows: number, theme: Th
 	return [...lines.slice(0, maxLines - 1), theme.fg("muted", `… ${hidden} more (open agents browser for full view)`)];
 }
 
+function appendRuntimeDiagnostic(runtimeRoot: string | undefined, source: string, message: string): void {
+	if (!runtimeRoot) return;
+	const logFile = path.join(runtimeRoot, "subagent-diagnostics.jsonl");
+	const entry = { ts: new Date().toISOString(), source, message };
+	void fs.promises.appendFile(logFile, `${JSON.stringify(entry)}\n`, { encoding: "utf-8", mode: 0o600 }).catch(() => undefined);
+}
+
 export default function (pi: ExtensionAPI) {
 	const guard = pi as unknown as Record<PropertyKey, unknown>;
 	if (guard[INSTALL_SYMBOL]) return;
 	guard[INSTALL_SYMBOL] = true;
 	if (!settingBoolean("enabled", true)) return;
+	const resolveIdleProbeBridgeBin = createCachedPiBridgeResolver(resolvePiBridgeBin);
 
 	const childAgentName = process.env.PI_SUBAGENT_CHILD_AGENT;
 	const statuslineBridge: SubagentStatuslineBridge = {
@@ -440,6 +449,7 @@ export default function (pi: ExtensionAPI) {
 	// the W5 O_EXCL writer so a racing real complete_subagent always wins.
 
 	let currentRuntimeRoot: string | undefined;
+	const logIdleStallDiagnostic = (message: string) => appendRuntimeDiagnostic(currentRuntimeRoot, "idle-stall-watchdog", message);
 	const idleStallWatchdog = createIdleStallWatchdog({
 		intervalMs: stallWatchdogIntervalMsFromEnv(),
 		thresholdMs: stallWatchdogThresholdMsFromEnv(),
@@ -471,7 +481,7 @@ export default function (pi: ExtensionAPI) {
 			if (!currentRuntimeRoot) return false;
 			const registry = await readPaneRegistry(currentRuntimeRoot);
 			const probe = await probePaneIdle(record, {
-				resolveBridgeBin: resolvePiBridgeBin,
+				resolveBridgeBin: resolveIdleProbeBridgeBin,
 				execCapture: async (command, args, options) => {
 					const timeoutMs = options?.timeoutMs ?? BRIDGE_IDLE_PROBE_DEFAULT_TIMEOUT_MS;
 					return Promise.race([
@@ -482,7 +492,7 @@ export default function (pi: ExtensionAPI) {
 					]);
 				},
 				readPaneRegistryEntry: async (agent) => registry[agent],
-				logWarn: (msg) => console.warn(msg),
+				logWarn: logIdleStallDiagnostic,
 			});
 			return probe.idle;
 		},
@@ -502,9 +512,7 @@ export default function (pi: ExtensionAPI) {
 					completionPath(currentRuntimeRoot, record.agent, record.taskId),
 			});
 		},
-		logWarn: (msg) => {
-			console.warn(msg);
-		},
+		logWarn: logIdleStallDiagnostic,
 	});
 	let dashboardState: SubagentDashboardState = { collapsed: false, mode: "normal", visible: true, items: {} };
 	let dashboardCtx: ExtensionContext | undefined;

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/pane.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/pane.ts
@@ -67,7 +67,7 @@ import {
 	type SingleResult,
 } from "./types.js";
 
-export async function execCapture(command: string, args: string[], options?: { cwd?: string }): Promise<{ code: number; stdout: string; stderr: string }> {
+export async function execCapture(command: string, args: string[], options?: { cwd?: string }): Promise<{ code: number; stdout: string; stderr: string; error?: unknown }> {
 	return new Promise((resolve) => {
 		const proc = spawn(command, args, { cwd: options?.cwd, shell: false, stdio: ["ignore", "pipe", "pipe"] });
 		let stdout = "";
@@ -75,7 +75,7 @@ export async function execCapture(command: string, args: string[], options?: { c
 		proc.stdout.on("data", (data) => (stdout += data.toString()));
 		proc.stderr.on("data", (data) => (stderr += data.toString()));
 		proc.on("close", (code) => resolve({ code: code ?? 0, stdout, stderr }));
-		proc.on("error", (error) => resolve({ code: 1, stdout, stderr: String(error) }));
+		proc.on("error", (error) => resolve({ code: 1, stdout, stderr: String(error), error }));
 	});
 }
 
@@ -259,15 +259,45 @@ async function resolvePiBridgeBin(): Promise<string | undefined> {
 	return found || undefined;
 }
 
-export function createCachedPiBridgeResolver(resolve: () => Promise<string | undefined> = resolvePiBridgeBin): () => Promise<string | undefined> {
+type DiagnosticLogger = (message: string) => void;
+
+function formatResolverFailure(error: unknown): string {
+	if (!error || typeof error !== "object") return String(error);
+	const candidate = error as { code?: unknown; errno?: unknown; syscall?: unknown; path?: unknown; cwd?: unknown; message?: unknown };
+	const fields = ["code", "errno", "syscall", "path", "cwd"] as const;
+	const parts = fields.flatMap((field) => {
+		const value = candidate[field];
+		return value === undefined || value === null || value === "" ? [] : [`${field}=${String(value)}`];
+	});
+	if (typeof candidate.message === "string" && candidate.message.trim()) parts.push(`message=${candidate.message.trim()}`);
+	return parts.length ? parts.join(" ") : String(error);
+}
+
+export function createCachedPiBridgeResolver(
+	resolve: () => Promise<string | undefined> = resolvePiBridgeBin,
+	logDiagnostic?: DiagnosticLogger,
+): () => Promise<string | undefined> {
 	// vstack#122: interval probes must not re-run path discovery on every tick.
-	// Resolve once at extension-load; if the cached binary later disappears,
-	// probePaneIdle classifies spawn ENOENT as bridge-bin-not-found and skips
-	// silently instead of leaking a console.warn into the Pi TUI.
+	// Resolve once for the extension lifetime; if the initial lookup fails,
+	// emit one structured diagnostic before caching the missing result so later
+	// probes can short-circuit without spamming terminal warnings.
+	const report = (reason: string) => {
+		try { logDiagnostic?.(`pi-bridge resolver failed: ${reason}`); } catch { /* diagnostics are best-effort */ }
+	};
 	let cached: Promise<string | undefined>;
 	try {
-		cached = Promise.resolve(resolve()).catch(() => undefined);
-	} catch {
+		cached = Promise.resolve(resolve()).then(
+			(bin) => {
+				if (!bin) report("returned undefined");
+				return bin;
+			},
+			(error) => {
+				report(formatResolverFailure(error));
+				return undefined;
+			},
+		);
+	} catch (error) {
+		report(formatResolverFailure(error));
 		cached = Promise.resolve(undefined);
 	}
 	return () => cached;

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/pane.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/pane.ts
@@ -259,6 +259,20 @@ async function resolvePiBridgeBin(): Promise<string | undefined> {
 	return found || undefined;
 }
 
+export function createCachedPiBridgeResolver(resolve: () => Promise<string | undefined> = resolvePiBridgeBin): () => Promise<string | undefined> {
+	// vstack#122: interval probes must not re-run path discovery on every tick.
+	// Resolve once at extension-load; if the cached binary later disappears,
+	// probePaneIdle classifies spawn ENOENT as bridge-bin-not-found and skips
+	// silently instead of leaking a console.warn into the Pi TUI.
+	let cached: Promise<string | undefined>;
+	try {
+		cached = Promise.resolve(resolve()).catch(() => undefined);
+	} catch {
+		cached = Promise.resolve(undefined);
+	}
+	return () => cached;
+}
+
 export { resolvePiBridgeBin };
 
 async function discoverBridgeMetadataForPane(entry: PaneRegistryEntry, timeoutMs = 0): Promise<BridgeMetadata | undefined> {

--- a/pi-extensions/pi-agents-tmux/instructions.md
+++ b/pi-extensions/pi-agents-tmux/instructions.md
@@ -18,5 +18,6 @@ Calling rules:
 - If a bg subagent hits `context_length_exceeded`, the extension retries once in a fresh one-shot lane and returns both attempt summaries if the retry also fails.
 - If a bg subagent returns `needs_completion` with `reason: "compact-then-empty"`, inspect `cwdSnapshot.head`, `cwdSnapshot.dirty`, and `cwdSnapshot.lastCommit.subject` before deciding whether the subagent's work completed.
 - When `pi-session-bridge` is loaded, subagent lifecycle changes also publish structured `agent.*` activity broker events for external observers; these do not appear as chat messages.
+- Pane idle-stall probes cache `pi-bridge` resolution at extension load and suppress benign missing-binary races; inspect session runtime `subagent-diagnostics.jsonl` for probe diagnostics instead of expecting terminal warnings.
 - Stopping kills the tmux process but preserves the session file; the next default `subagent` call resumes it. Pass `forceSpawn: true` only when the user wants a fresh session.
 - `confirmProjectAgents: true` gates project-defined agents behind explicit user approval.

--- a/pi-extensions/pi-agents-tmux/instructions.md
+++ b/pi-extensions/pi-agents-tmux/instructions.md
@@ -18,6 +18,6 @@ Calling rules:
 - If a bg subagent hits `context_length_exceeded`, the extension retries once in a fresh one-shot lane and returns both attempt summaries if the retry also fails.
 - If a bg subagent returns `needs_completion` with `reason: "compact-then-empty"`, inspect `cwdSnapshot.head`, `cwdSnapshot.dirty`, and `cwdSnapshot.lastCommit.subject` before deciding whether the subagent's work completed.
 - When `pi-session-bridge` is loaded, subagent lifecycle changes also publish structured `agent.*` activity broker events for external observers; these do not appear as chat messages.
-- Pane idle-stall probes cache `pi-bridge` resolution at extension load and suppress benign missing-binary races; inspect session runtime `subagent-diagnostics.jsonl` for probe diagnostics instead of expecting terminal warnings.
+- Pane idle-stall probes cache `pi-bridge` resolution at extension load. A structured `spawn`/`ENOENT` for the expected `pi-bridge` binary is treated as genuinely missing and skips silently; other ENOENT/spawn failures are written to session runtime `subagent-diagnostics.jsonl`. If initial resolver setup fails, one `pi-bridge resolver failed: ...` diagnostic is written.
 - Stopping kills the tmux process but preserves the session file; the next default `subagent` call resumes it. Pass `forceSpawn: true` only when the user wants a fresh session.
 - `confirmProjectAgents: true` gates project-defined agents behind explicit user approval.

--- a/pi-extensions/pi-agents-tmux/tests/idle-stall-probe.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/idle-stall-probe.test.ts
@@ -40,11 +40,20 @@ function entry(overrides: Partial<PaneRegistryEntry> = {}): PaneRegistryEntry {
 	};
 }
 
+function spawnEnoent(path = "/usr/bin/pi-bridge", overrides: Record<string, unknown> = {}): Error {
+	return Object.assign(new Error(`spawn ${path} ENOENT`), {
+		code: "ENOENT",
+		syscall: "spawn",
+		path,
+		...overrides,
+	});
+}
+
 function deps(opts: {
 	bridgeBin?: string | null;
 	registry?: Partial<PaneRegistryEntry> | null;
-	execResult?: { code: number; stdout: string; stderr: string };
-	execError?: Error;
+	execResult?: { code: number; stdout: string; stderr: string; error?: unknown };
+	execError?: unknown;
 }): { d: ProbePaneIdleDeps; calls: { args: string[]; cwd?: string }[]; warnings: string[] } {
 	const calls: { args: string[]; cwd?: string }[] = [];
 	const warnings: string[] = [];
@@ -97,7 +106,7 @@ test("flat state shape (no .data wrapper) is also accepted", async () => {
 
 test("bridge spawn ENOENT (exec throws) -> default-busy without warning toast", async () => {
 	const { d, warnings } = deps({
-		execError: new Error("spawn /home/user/.pi/agent/bin/pi-bridge ENOENT"),
+		execError: spawnEnoent(),
 	});
 	const result = await probePaneIdle(record(), d);
 	assert.equal(result.idle, false);
@@ -107,12 +116,32 @@ test("bridge spawn ENOENT (exec throws) -> default-busy without warning toast", 
 
 test("bridge spawn ENOENT (non-zero result) -> default-busy without warning toast", async () => {
 	const { d, warnings } = deps({
-		execResult: { code: 1, stdout: "", stderr: "Error: spawn /home/user/.pi/agent/bin/pi-bridge ENOENT" },
+		execResult: { code: 1, stdout: "", stderr: "Error: spawn /usr/bin/pi-bridge ENOENT", error: spawnEnoent() },
 	});
 	const result = await probePaneIdle(record(), d);
 	assert.equal(result.idle, false);
 	assert.equal(result.reason, "bridge-bin-not-found");
 	assert.equal(warnings.length, 0);
+});
+
+test("text-only spawn ENOENT is not treated as expected bridge-bin missing", async () => {
+	const { d, warnings } = deps({
+		execError: new Error("spawn /usr/bin/pi-bridge ENOENT"),
+	});
+	const result = await probePaneIdle(record(), d);
+	assert.equal(result.idle, false);
+	assert.equal(result.reason, "bridge-error");
+	assert.ok(warnings.some((w) => w.includes("exec threw")));
+});
+
+test("structured ENOENT for a different path is logged as a real failure", async () => {
+	const { d, warnings } = deps({
+		execError: spawnEnoent("/tmp/not-pi-bridge"),
+	});
+	const result = await probePaneIdle(record(), d);
+	assert.equal(result.idle, false);
+	assert.equal(result.reason, "bridge-error");
+	assert.ok(warnings.some((w) => w.includes("exec threw")));
 });
 
 test("bridge unreachable (non-ENOENT exec throws) -> default-busy with bridge-error", async () => {

--- a/pi-extensions/pi-agents-tmux/tests/idle-stall-probe.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/idle-stall-probe.test.ts
@@ -95,9 +95,29 @@ test("flat state shape (no .data wrapper) is also accepted", async () => {
 	assert.equal(result.idle, true);
 });
 
-test("bridge unreachable (exec throws) -> default-busy with bridge-error", async () => {
+test("bridge spawn ENOENT (exec throws) -> default-busy without warning toast", async () => {
 	const { d, warnings } = deps({
-		execError: new Error("ENOENT spawn pi-bridge"),
+		execError: new Error("spawn /home/user/.pi/agent/bin/pi-bridge ENOENT"),
+	});
+	const result = await probePaneIdle(record(), d);
+	assert.equal(result.idle, false);
+	assert.equal(result.reason, "bridge-bin-not-found");
+	assert.equal(warnings.length, 0);
+});
+
+test("bridge spawn ENOENT (non-zero result) -> default-busy without warning toast", async () => {
+	const { d, warnings } = deps({
+		execResult: { code: 1, stdout: "", stderr: "Error: spawn /home/user/.pi/agent/bin/pi-bridge ENOENT" },
+	});
+	const result = await probePaneIdle(record(), d);
+	assert.equal(result.idle, false);
+	assert.equal(result.reason, "bridge-bin-not-found");
+	assert.equal(warnings.length, 0);
+});
+
+test("bridge unreachable (non-ENOENT exec throws) -> default-busy with bridge-error", async () => {
+	const { d, warnings } = deps({
+		execError: new Error("ECONNRESET"),
 	});
 	const result = await probePaneIdle(record(), d);
 	assert.equal(result.idle, false);

--- a/pi-extensions/pi-agents-tmux/tests/pi-bridge-resolver.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/pi-bridge-resolver.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createCachedPiBridgeResolver } from "../extensions/subagent/pane.js";
+
+test("cached pi-bridge resolver resolves once immediately and reuses the path", async () => {
+	let calls = 0;
+	const resolve = createCachedPiBridgeResolver(async () => {
+		calls += 1;
+		return `/tmp/pi-bridge-${calls}`;
+	});
+
+	assert.equal(calls, 1);
+	assert.equal(await resolve(), "/tmp/pi-bridge-1");
+	assert.equal(await resolve(), "/tmp/pi-bridge-1");
+	assert.equal(calls, 1);
+});
+
+test("cached pi-bridge resolver treats startup resolution failures as missing", async () => {
+	let calls = 0;
+	const resolve = createCachedPiBridgeResolver(async () => {
+		calls += 1;
+		throw new Error("resolver failed");
+	});
+
+	assert.equal(calls, 1);
+	assert.equal(await resolve(), undefined);
+	assert.equal(await resolve(), undefined);
+	assert.equal(calls, 1);
+});

--- a/pi-extensions/pi-agents-tmux/tests/pi-bridge-resolver.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/pi-bridge-resolver.test.ts
@@ -3,28 +3,62 @@ import test from "node:test";
 
 import { createCachedPiBridgeResolver } from "../extensions/subagent/pane.js";
 
+function resolverError(): Error {
+	return Object.assign(new Error("resolver failed"), {
+		code: "ENOENT",
+		errno: -2,
+		syscall: "spawn",
+		path: "/missing/pi-bridge",
+		cwd: "/tmp/cwd",
+	});
+}
+
 test("cached pi-bridge resolver resolves once immediately and reuses the path", async () => {
 	let calls = 0;
+	const warnings: string[] = [];
 	const resolve = createCachedPiBridgeResolver(async () => {
 		calls += 1;
 		return `/tmp/pi-bridge-${calls}`;
-	});
+	}, (message) => warnings.push(message));
 
 	assert.equal(calls, 1);
 	assert.equal(await resolve(), "/tmp/pi-bridge-1");
 	assert.equal(await resolve(), "/tmp/pi-bridge-1");
 	assert.equal(calls, 1);
+	assert.equal(warnings.length, 0);
 });
 
-test("cached pi-bridge resolver treats startup resolution failures as missing", async () => {
+test("cached pi-bridge resolver logs startup throw once and caches missing", async () => {
 	let calls = 0;
+	const warnings: string[] = [];
 	const resolve = createCachedPiBridgeResolver(async () => {
 		calls += 1;
-		throw new Error("resolver failed");
-	});
+		throw resolverError();
+	}, (message) => warnings.push(message));
 
 	assert.equal(calls, 1);
 	assert.equal(await resolve(), undefined);
 	assert.equal(await resolve(), undefined);
 	assert.equal(calls, 1);
+	assert.equal(warnings.length, 1);
+	assert.match(warnings[0]!, /code=ENOENT/);
+	assert.match(warnings[0]!, /errno=-2/);
+	assert.match(warnings[0]!, /syscall=spawn/);
+	assert.match(warnings[0]!, /path=\/missing\/pi-bridge/);
+	assert.match(warnings[0]!, /cwd=\/tmp\/cwd/);
+});
+
+test("cached pi-bridge resolver logs returned undefined once and caches missing", async () => {
+	let calls = 0;
+	const warnings: string[] = [];
+	const resolve = createCachedPiBridgeResolver(async () => {
+		calls += 1;
+		return undefined;
+	}, (message) => warnings.push(message));
+
+	assert.equal(calls, 1);
+	assert.equal(await resolve(), undefined);
+	assert.equal(await resolve(), undefined);
+	assert.equal(calls, 1);
+	assert.deepEqual(warnings, ["pi-bridge resolver failed: returned undefined"]);
 });


### PR DESCRIPTION
## Summary

Fixes #122.

- Cache the idle-stall watchdog's `pi-bridge` binary resolution at extension load instead of resolving on every periodic probe.
- Treat structured `spawn`/`ENOENT` for the expected `pi-bridge` binary as `bridge-bin-not-found` and skip without `console.warn`/terminal UI leakage.
- Route non-matching ENOENT/spawn failures and other idle-stall probe diagnostics to `subagent-diagnostics.jsonl` in the session runtime.
- Emit a one-shot `pi-bridge resolver failed: ...` diagnostic if the cached resolver's initial lookup throws or returns undefined.
- Document the probe invariant and add regression coverage for ENOENT suppression, mismatch logging, and cached resolution diagnostics.

## Follow-up: aaff37c0

- Hardened ENOENT discrimination so silent missing-binary handling requires `err.code === "ENOENT"`, `err.syscall === "spawn"`, and `err.path === <expected pi-bridge binary path>`.
- Added the one-shot resolver-failure diagnostic for initial cached resolver failures (`pi-bridge resolver failed: ...`).
- Focused regression test count increased from 16 to 19 for `idle-stall-probe.test.ts` + `pi-bridge-resolver.test.ts`.
- Doc-only follow-up commit `80e1f4d` refreshed the global Pi install: `vstack refresh -g` updated `@vanillagreen/pi-agents-tmux`; `vstack verify -g` reported 18 checked, 18 OK, 0 failed.

## Validation

- `grep -rn "pi-bridge" pi-extensions/ --include="*.ts" | grep -Ev "test|\.md"`
- `grep -rn "console\.warn\|console\.error" pi-extensions/ --include="*.ts" | grep -iE "enoent|bridge|spawn"`
- Pi TUI console surfacing checked in upstream Pi interactive mode/output guard (`showWarning`/`showError`, `core/output-guard.js`); fix stays on extension side.
- `bun test ./tests/idle-stall-probe.test.ts ./tests/pi-bridge-resolver.test.ts` — 19 pass after `aaff37c0`.
- `bun test ./tests ./extensions/subagent/__tests__` — targeted changes passed, but full package run hit existing environment dependency error: `Cannot find package 'typebox' from .../extensions/subagent/tools.ts`.
- `cd pi-extensions/pi-agents-tmux && (bun test 2>/dev/null || true) && (bun run typecheck 2>/dev/null || true)` — brief-required command completed.
- `git diff --check` — pass.
- `vstack refresh -g` after commit `267a8b1`: processed 18 Pi package(s), 0 updated.
- `vstack verify -g`: 18 checked, 18 OK, 0 failed.
- `vstack refresh -g` after doc commit `80e1f4d`: updated `@vanillagreen/pi-agents-tmux`; processed 18 Pi package(s), 1 updated.
- `vstack verify -g` after doc commit `80e1f4d`: 18 checked, 18 OK, 0 failed.

Live Pi TUI reproduction was not performed in this worktree; behavior is covered with the probe unit tests and global install verification.