### PR TITLE
Improve Claude bridge spawn diagnostics

### DIFF
--- a/pi-extensions/pi-claude-bridge/README.md
+++ b/pi-extensions/pi-claude-bridge/README.md
@@ -79,3 +79,5 @@ Open `/extensions:settings`; settings appear under the **Claude Bridge** tab.
 ## Debugging
 
 Set `CLAUDE_BRIDGE_DEBUG=1` to write bridge logs to `~/.pi/agent/claude-bridge.log` and per-query Claude Code CLI logs under `~/.pi/agent/cc-cli-logs/`.
+
+Before starting Claude Code, the bridge preflights the resolved executable and working directory. Failures include the underlying `code`, `errno`, `syscall`, `path`, `cwd`, and detected executable file type so spawn issues point at the real failing path instead of the Claude Agent SDK's generic native-binary message. If Node still emits a spawn error after preflight, the bridge wraps that error with the same context before handing it back to the SDK.

--- a/pi-extensions/pi-claude-bridge/bundle/index.js
+++ b/pi-extensions/pi-claude-bridge/bundle/index.js
@@ -19184,8 +19184,9 @@ function readSession(jsonlPath, projectPath) {
 }
 
 // src/index.ts
+import { spawn as spawnProcess } from "child_process";
 import { createHash } from "crypto";
-import { accessSync, appendFileSync as appendFileSync3, constants as fsConstants, mkdirSync as mkdirSync3, realpathSync as realpathSync3, statSync as statSync3 } from "fs";
+import { accessSync, appendFileSync as appendFileSync3, constants as fsConstants, mkdirSync as mkdirSync3, readFileSync as readFileSync7, realpathSync as realpathSync3, statSync as statSync3 } from "fs";
 import { resolve as pathResolve } from "path";
 import { homedir as homedir5 } from "os";
 import { delimiter, dirname as dirname5, join as join5 } from "path";
@@ -34437,6 +34438,196 @@ function resolveClaudeExecutable(configured) {
   if (trimmed) return trimmed;
   return executableFromPath("claude") ?? executableFromPath("claude-code");
 }
+function errnoValue(err) {
+  return typeof err?.errno === "number" ? err.errno : void 0;
+}
+function syscallValue(err) {
+  return typeof err?.syscall === "string" ? err.syscall : void 0;
+}
+function pathValue(err) {
+  const value = err?.path;
+  return typeof value === "string" ? value : void 0;
+}
+function codeValue(err, fallback) {
+  const value = err?.code;
+  return typeof value === "string" ? value : fallback;
+}
+function displayValue(value) {
+  return value === void 0 || value === null || value === "" ? "<none>" : String(value);
+}
+function makeClaudePreflightError(summary, details) {
+  const detail = [
+    `code=${details.code}`,
+    `errno=${displayValue(details.errno)}`,
+    `syscall=${displayValue(details.syscall)}`,
+    `path=${details.path}`,
+    `cwd=${details.cwd}`,
+    ...details.fileType ? [`fileType=${details.fileType}`] : [],
+    ...details.realPath ? [`realPath=${details.realPath}`] : []
+  ].join(" ");
+  const error51 = new Error(`${summary} (${detail})`);
+  error51.name = "ClaudeExecutablePreflightError";
+  error51.code = details.code;
+  if (details.errno !== void 0) error51.errno = typeof details.errno === "number" ? details.errno : Number(details.errno);
+  if (details.syscall) error51.syscall = details.syscall;
+  error51.path = details.path;
+  error51.cwd = details.cwd;
+  if (details.fileType) error51.fileType = details.fileType;
+  if (details.realPath) error51.realPath = details.realPath;
+  if (details.cause !== void 0) error51.cause = details.cause;
+  return error51;
+}
+function classifyClaudeExecutableBytes(bytes) {
+  if (bytes.length === 0) return "empty";
+  if (bytes.length >= 2 && bytes[0] === 35 && bytes[1] === 33) return "shebang-script";
+  if (bytes.length >= 4 && bytes[0] === 127 && bytes[1] === 69 && bytes[2] === 76 && bytes[3] === 70) return "elf";
+  if (bytes.length >= 2 && bytes[0] === 77 && bytes[1] === 90) return "pe";
+  if (bytes.length >= 4) {
+    const magic = bytes[0] * 16777216 + bytes[1] * 65536 + bytes[2] * 256 + bytes[3];
+    if (magic === 4277009102 || magic === 4277009103 || magic === 3472551422 || magic === 3489328638 || magic === 3405691582 || magic === 3199925962) return "mach-o";
+  }
+  return "unknown";
+}
+function preflightClaudeExecutable(path, cwd) {
+  let realCwd = cwd;
+  try {
+    const cwdStat = statSync3(cwd);
+    if (!cwdStat.isDirectory()) {
+      throw makeClaudePreflightError("Claude Code spawn cwd preflight failed: cwd is not a directory.", {
+        code: "ENOTDIR",
+        syscall: "chdir",
+        path: cwd,
+        cwd
+      });
+    }
+    accessSync(cwd, fsConstants.X_OK);
+    realCwd = realpathSync3(cwd);
+  } catch (err) {
+    if (err.name === "ClaudeExecutablePreflightError") throw err;
+    throw makeClaudePreflightError("Claude Code spawn cwd preflight failed: cwd is not reachable before spawning Claude Code.", {
+      code: codeValue(err, "EACCES"),
+      errno: errnoValue(err),
+      syscall: syscallValue(err),
+      path: pathValue(err) ?? cwd,
+      cwd,
+      cause: err
+    });
+  }
+  let realPath = path;
+  try {
+    const stat = statSync3(path);
+    if (!stat.isFile()) {
+      throw makeClaudePreflightError("Claude Code executable preflight failed: resolved path is not a file.", {
+        code: "EACCES",
+        syscall: "exec",
+        path,
+        cwd
+      });
+    }
+    accessSync(path, fsConstants.X_OK);
+    realPath = realpathSync3(path);
+  } catch (err) {
+    if (err.name === "ClaudeExecutablePreflightError") throw err;
+    throw makeClaudePreflightError("Claude Code executable preflight failed: cannot access resolved executable before spawning Claude Code.", {
+      code: codeValue(err, "ENOENT"),
+      errno: errnoValue(err),
+      syscall: syscallValue(err),
+      path: pathValue(err) ?? path,
+      cwd,
+      cause: err
+    });
+  }
+  let fileType;
+  try {
+    fileType = classifyClaudeExecutableBytes(readFileSync7(realPath).subarray(0, 16));
+  } catch (err) {
+    throw makeClaudePreflightError("Claude Code executable preflight failed: cannot read executable header before spawning Claude Code.", {
+      code: codeValue(err, "EACCES"),
+      errno: errnoValue(err),
+      syscall: syscallValue(err),
+      path: pathValue(err) ?? realPath,
+      cwd,
+      realPath,
+      cause: err
+    });
+  }
+  if (!["elf", "mach-o", "pe", "shebang-script"].includes(fileType)) {
+    throw makeClaudePreflightError("Claude Code executable preflight failed: executable header is not an ELF, Mach-O, PE, or shebang script.", {
+      code: "ENOEXEC",
+      syscall: "exec",
+      path,
+      cwd,
+      fileType,
+      realPath
+    });
+  }
+  return { path, realPath, cwd, realCwd, fileType };
+}
+function envFlagEnabled(value) {
+  return value === "1" || value?.toLowerCase() === "true";
+}
+function wrapClaudeSpawnErrorForSdk(err, options) {
+  const originalCode = codeValue(err, "SPAWN_ERROR");
+  const spawnPath = pathValue(err) ?? options.command;
+  const cwd = options.cwd ?? process.cwd();
+  const detail = [
+    `code=${originalCode}`,
+    `errno=${displayValue(errnoValue(err))}`,
+    `syscall=${displayValue(syscallValue(err))}`,
+    `path=${spawnPath}`,
+    `cwd=${cwd}`,
+    `command=${options.command}`
+  ].join(" ");
+  const wrapped = new Error(`Claude Code spawn failed: ${err.message} (${detail})`);
+  wrapped.name = "ClaudeSpawnDiagnosticError";
+  wrapped.code = originalCode === "ENOENT" ? "CLAUDE_BRIDGE_SPAWN_FAILED" : originalCode;
+  wrapped.originalCode = originalCode;
+  const errno = errnoValue(err);
+  if (errno !== void 0) wrapped.errno = typeof errno === "number" ? errno : Number(errno);
+  const syscall = syscallValue(err);
+  if (syscall) wrapped.syscall = syscall;
+  wrapped.path = spawnPath;
+  wrapped.cwd = cwd;
+  wrapped.cause = err;
+  return wrapped;
+}
+function spawnClaudeCodeWithDiagnostics(options) {
+  const pipeStderr = DEBUG || envFlagEnabled(options.env.DEBUG_CLAUDE_AGENT_SDK);
+  const child = spawnProcess(options.command, options.args, {
+    cwd: options.cwd,
+    env: options.env,
+    signal: options.signal,
+    stdio: ["pipe", "pipe", pipeStderr ? "pipe" : "ignore"],
+    windowsHide: true
+  });
+  if (pipeStderr) {
+    child.stderr?.on("data", (data) => {
+      for (const line of data.toString().split(/\r?\n/)) {
+        if (line) debug(`[cli-stderr spawn] ${line}`);
+      }
+    });
+  }
+  child.prependListener("error", (err) => {
+    const wrapped = wrapClaudeSpawnErrorForSdk(err, options);
+    err.name = wrapped.name;
+    err.message = wrapped.message;
+    Object.assign(err, wrapped);
+  });
+  return {
+    stdin: child.stdin,
+    stdout: child.stdout,
+    get killed() {
+      return child.killed;
+    },
+    get exitCode() {
+      return child.exitCode;
+    },
+    kill: child.kill.bind(child),
+    on: child.on.bind(child),
+    once: child.once.bind(child),
+    off: child.off.bind(child)
+  };
+}
 var nextCliDebugSeq = 1;
 function makeCliDebugOptions(tag) {
   if (!DEBUG) return {};
@@ -35164,7 +35355,6 @@ function streamClaudeAgentSdk(model, context, options) {
   ctx().latestCursor = 0;
   const { mcpTools, customToolNameToSdk, customToolNameToPi } = resolveMcpTools(context);
   const cwd = options?.cwd ?? process.cwd();
-  const { sessionId: resumeSessionId } = syncSharedSession(context.messages, cwd, customToolNameToSdk, model.id);
   const promptBlocks = extractUserPromptBlocks(context.messages);
   let promptText = extractUserPrompt(context.messages) ?? "";
   if (!promptText && !promptBlocks) {
@@ -35192,6 +35382,8 @@ function streamClaudeAgentSdk(model, context, options) {
   const settingSources = appendSystemPrompt ? void 0 : providerSettings.settingSources ?? ["user", "project"];
   const strictMcpConfigEnabled = !appendSystemPrompt && providerSettings.strictMcpConfig !== false;
   const claudeExecutable = resolveClaudeExecutable(providerSettings.pathToClaudeCodeExecutable);
+  const claudeExecutablePreflight = claudeExecutable ? preflightClaudeExecutable(claudeExecutable, cwd) : void 0;
+  const { sessionId: resumeSessionId } = syncSharedSession(context.messages, cwd, customToolNameToSdk, model.id);
   const effort = options?.reasoning ? model.thinkingLevelMap?.[options.reasoning] ?? REASONING_TO_EFFORT[options.reasoning] : void 0;
   const extraArgs = { model: model.id };
   if (strictMcpConfigEnabled) extraArgs["strict-mcp-config"] = null;
@@ -35214,6 +35406,7 @@ function streamClaudeAgentSdk(model, context, options) {
     ...mcpServers ? { mcpServers } : {},
     ...resumeSessionId ? { resume: resumeSessionId } : {},
     ...claudeExecutable ? { pathToClaudeCodeExecutable: claudeExecutable } : {},
+    spawnClaudeCodeProcess: spawnClaudeCodeWithDiagnostics,
     ...makeCliDebugOptions("provider")
   };
   debug(
@@ -35221,6 +35414,7 @@ function streamClaudeAgentSdk(model, context, options) {
     `model=${model.id} msgs=${context.messages.length} tools=${mcpTools.length}`,
     `resume=${resumeSessionId?.slice(0, 8) ?? "none"} effort=${effort ?? "default"}`,
     `appendSys=${appendSystemPrompt} promptCtx=${promptContextAppend.labels.join(",") || "none"} strictMcp=${strictMcpConfigEnabled}`,
+    `claudeExec=${claudeExecutablePreflight ? `${claudeExecutablePreflight.fileType}:${claudeExecutablePreflight.path}` : "sdk-default"}`,
     `prompt=${promptText.slice(0, 60)}${promptBlocks ? " [+images]" : ""}`
   );
   let wasAborted = false;
@@ -35390,8 +35584,12 @@ function index_default(pi) {
 export {
   CLAUDE_BRIDGE_TOOL_ISOLATION,
   DISALLOWED_BUILTIN_TOOLS,
+  classifyClaudeExecutableBytes,
   index_default as default,
   mapToolName,
+  preflightClaudeExecutable,
   restoreSharedSessionFromPi,
-  shouldRestorePersistedBridgeEntry
+  shouldRestorePersistedBridgeEntry,
+  spawnClaudeCodeWithDiagnostics,
+  wrapClaudeSpawnErrorForSdk
 };

--- a/pi-extensions/pi-claude-bridge/bundle/index.js
+++ b/pi-extensions/pi-claude-bridge/bundle/index.js
@@ -34568,6 +34568,7 @@ function envFlagEnabled(value) {
 }
 function wrapClaudeSpawnErrorForSdk(err, options) {
   const originalCode = codeValue(err, "SPAWN_ERROR");
+  const originalMessage = err.message;
   const spawnPath = pathValue(err) ?? options.command;
   const cwd = options.cwd ?? process.cwd();
   const detail = [
@@ -34578,17 +34579,17 @@ function wrapClaudeSpawnErrorForSdk(err, options) {
     `cwd=${cwd}`,
     `command=${options.command}`
   ].join(" ");
-  const wrapped = new Error(`Claude Code spawn failed: ${err.message} (${detail})`);
+  const wrapped = new Error(`Claude Code spawn failed: ${originalMessage} (${detail})`);
   wrapped.name = "ClaudeSpawnDiagnosticError";
   wrapped.code = originalCode === "ENOENT" ? "CLAUDE_BRIDGE_SPAWN_FAILED" : originalCode;
   wrapped.originalCode = originalCode;
+  wrapped.originalMessage = originalMessage;
   const errno = errnoValue(err);
   if (errno !== void 0) wrapped.errno = typeof errno === "number" ? errno : Number(errno);
   const syscall = syscallValue(err);
   if (syscall) wrapped.syscall = syscall;
   wrapped.path = spawnPath;
   wrapped.cwd = cwd;
-  wrapped.cause = err;
   return wrapped;
 }
 function spawnClaudeCodeWithDiagnostics(options) {
@@ -34608,10 +34609,12 @@ function spawnClaudeCodeWithDiagnostics(options) {
     });
   }
   child.prependListener("error", (err) => {
+    const originalStack = err.stack;
     const wrapped = wrapClaudeSpawnErrorForSdk(err, options);
+    Object.assign(err, wrapped);
     err.name = wrapped.name;
     err.message = wrapped.message;
-    Object.assign(err, wrapped);
+    if (originalStack) err.stack = originalStack;
   });
   return {
     stdin: child.stdin,

--- a/pi-extensions/pi-claude-bridge/src/index.ts
+++ b/pi-extensions/pi-claude-bridge/src/index.ts
@@ -241,8 +241,9 @@ function envFlagEnabled(value: string | undefined): boolean {
 	return value === "1" || value?.toLowerCase() === "true";
 }
 
-export function wrapClaudeSpawnErrorForSdk(err: Error, options: SpawnOptions): Error & NodeJS.ErrnoException & { cwd: string; originalCode?: string } {
+export function wrapClaudeSpawnErrorForSdk(err: Error, options: SpawnOptions): Error & NodeJS.ErrnoException & { cwd: string; originalCode?: string; originalMessage?: string } {
 	const originalCode = codeValue(err, "SPAWN_ERROR");
+	const originalMessage = err.message;
 	const spawnPath = pathValue(err) ?? options.command;
 	const cwd = options.cwd ?? process.cwd();
 	const detail = [
@@ -253,20 +254,24 @@ export function wrapClaudeSpawnErrorForSdk(err: Error, options: SpawnOptions): E
 		`cwd=${cwd}`,
 		`command=${options.command}`,
 	].join(" ");
-	const wrapped = new Error(`Claude Code spawn failed: ${err.message} (${detail})`) as Error & NodeJS.ErrnoException & { cwd: string; originalCode?: string };
+	const wrapped = new Error(`Claude Code spawn failed: ${originalMessage} (${detail})`) as Error & NodeJS.ErrnoException & { cwd: string; originalCode?: string; originalMessage?: string };
 	wrapped.name = "ClaudeSpawnDiagnosticError";
 	// The SDK special-cases code === ENOENT and replaces the message with its
 	// generic "native binary not found" text. Preserve the original code in the
 	// message/originalCode while using a bridge code so the SDK surfaces context.
 	wrapped.code = originalCode === "ENOENT" ? "CLAUDE_BRIDGE_SPAWN_FAILED" : originalCode;
 	wrapped.originalCode = originalCode;
+	wrapped.originalMessage = originalMessage;
 	const errno = errnoValue(err);
 	if (errno !== undefined) wrapped.errno = typeof errno === "number" ? errno : Number(errno);
 	const syscall = syscallValue(err);
 	if (syscall) wrapped.syscall = syscall;
 	wrapped.path = spawnPath;
 	wrapped.cwd = cwd;
-	(wrapped as Error & { cause?: unknown }).cause = err;
+	// Do not set `cause` here: the listener copies these structured fields back
+	// onto the original Error. A cause reference to that same object would become
+	// `err.cause === err`, making JSON.stringify throw on a circular structure.
+	// originalMessage plus code/errno/syscall/path/cwd preserve the useful data.
 	return wrapped;
 }
 
@@ -287,10 +292,15 @@ export function spawnClaudeCodeWithDiagnostics(options: SpawnOptions): SpawnedPr
 		});
 	}
 	child.prependListener("error", (err) => {
+		const originalStack = err.stack;
 		const wrapped = wrapClaudeSpawnErrorForSdk(err, options);
+		Object.assign(err, wrapped);
 		err.name = wrapped.name;
 		err.message = wrapped.message;
-		Object.assign(err, wrapped);
+		// Keep V8's stack from the actual Node spawn failure, not the wrapper
+		// construction site. Diagnostic fields above remain enumerable and
+		// JSON-serializable; stack stays the spawn-time breadcrumb for operators.
+		if (originalStack) err.stack = originalStack;
 	});
 	return {
 		stdin: child.stdin,

--- a/pi-extensions/pi-claude-bridge/src/index.ts
+++ b/pi-extensions/pi-claude-bridge/src/index.ts
@@ -1,11 +1,12 @@
 import { calculateCost, getModels, type AssistantMessage, type AssistantMessageEventStream, type Context, type Model, type SimpleStreamOptions, type Tool } from "@earendil-works/pi-ai";
 import * as piAi from "@earendil-works/pi-ai";
 import { type ExtensionAPI, type ExtensionUIContext } from "@earendil-works/pi-coding-agent";
-import { createSdkMcpServer, query, type EffortLevel, type SDKMessage, type SDKUserMessage, type SettingSource } from "@anthropic-ai/claude-agent-sdk";
+import { createSdkMcpServer, query, type EffortLevel, type SDKMessage, type SDKUserMessage, type SettingSource, type SpawnOptions, type SpawnedProcess } from "@anthropic-ai/claude-agent-sdk";
 import type { Base64ImageSource, ContentBlockParam, MessageParam } from "@anthropic-ai/sdk/resources";
 import { createSession, deleteSession, openSession, repairToolPairing } from "cc-session-io";
+import { spawn as spawnProcess } from "child_process";
 import { createHash } from "crypto";
-import { accessSync, appendFileSync, constants as fsConstants, mkdirSync, realpathSync, statSync } from "fs";
+import { accessSync, appendFileSync, constants as fsConstants, mkdirSync, readFileSync, realpathSync, statSync } from "fs";
 import { resolve as pathResolve } from "path";
 import { homedir } from "os";
 import { delimiter, dirname, join } from "path";
@@ -77,6 +78,230 @@ function resolveClaudeExecutable(configured?: string): string | undefined {
 	const trimmed = configured?.trim();
 	if (trimmed) return trimmed;
 	return executableFromPath("claude") ?? executableFromPath("claude-code");
+}
+
+export type ClaudeExecutableFileType = "elf" | "mach-o" | "pe" | "shebang-script" | "empty" | "unknown";
+
+export interface ClaudeExecutablePreflightResult {
+	path: string;
+	realPath: string;
+	cwd: string;
+	realCwd: string;
+	fileType: ClaudeExecutableFileType;
+}
+
+function errnoValue(err: unknown): string | number | undefined {
+	return typeof (err as NodeJS.ErrnoException)?.errno === "number" ? (err as NodeJS.ErrnoException).errno : undefined;
+}
+
+function syscallValue(err: unknown): string | undefined {
+	return typeof (err as NodeJS.ErrnoException)?.syscall === "string" ? (err as NodeJS.ErrnoException).syscall : undefined;
+}
+
+function pathValue(err: unknown): string | undefined {
+	const value = (err as NodeJS.ErrnoException)?.path;
+	return typeof value === "string" ? value : undefined;
+}
+
+function codeValue(err: unknown, fallback: string): string {
+	const value = (err as NodeJS.ErrnoException)?.code;
+	return typeof value === "string" ? value : fallback;
+}
+
+function displayValue(value: unknown): string {
+	return value === undefined || value === null || value === "" ? "<none>" : String(value);
+}
+
+function makeClaudePreflightError(
+	summary: string,
+	details: { code: string; errno?: string | number; syscall?: string; path: string; cwd: string; fileType?: ClaudeExecutableFileType; realPath?: string; cause?: unknown },
+): Error & NodeJS.ErrnoException & { cwd: string; fileType?: ClaudeExecutableFileType; realPath?: string } {
+	const detail = [
+		`code=${details.code}`,
+		`errno=${displayValue(details.errno)}`,
+		`syscall=${displayValue(details.syscall)}`,
+		`path=${details.path}`,
+		`cwd=${details.cwd}`,
+		...(details.fileType ? [`fileType=${details.fileType}`] : []),
+		...(details.realPath ? [`realPath=${details.realPath}`] : []),
+	].join(" ");
+	const error = new Error(`${summary} (${detail})`) as Error & NodeJS.ErrnoException & { cwd: string; fileType?: ClaudeExecutableFileType; realPath?: string };
+	error.name = "ClaudeExecutablePreflightError";
+	error.code = details.code;
+	if (details.errno !== undefined) error.errno = typeof details.errno === "number" ? details.errno : Number(details.errno);
+	if (details.syscall) error.syscall = details.syscall;
+	error.path = details.path;
+	error.cwd = details.cwd;
+	if (details.fileType) error.fileType = details.fileType;
+	if (details.realPath) error.realPath = details.realPath;
+	if (details.cause !== undefined) (error as Error & { cause?: unknown }).cause = details.cause;
+	return error;
+}
+
+export function classifyClaudeExecutableBytes(bytes: Uint8Array): ClaudeExecutableFileType {
+	if (bytes.length === 0) return "empty";
+	if (bytes.length >= 2 && bytes[0] === 0x23 && bytes[1] === 0x21) return "shebang-script";
+	if (bytes.length >= 4 && bytes[0] === 0x7f && bytes[1] === 0x45 && bytes[2] === 0x4c && bytes[3] === 0x46) return "elf";
+	if (bytes.length >= 2 && bytes[0] === 0x4d && bytes[1] === 0x5a) return "pe";
+	if (bytes.length >= 4) {
+		const magic = bytes[0] * 0x1000000 + bytes[1] * 0x10000 + bytes[2] * 0x100 + bytes[3];
+		if (
+			magic === 0xfeedface ||
+			magic === 0xfeedfacf ||
+			magic === 0xcefaedfe ||
+			magic === 0xcffaedfe ||
+			magic === 0xcafebabe ||
+			magic === 0xbebafeca
+		) return "mach-o";
+	}
+	return "unknown";
+}
+
+export function preflightClaudeExecutable(path: string, cwd: string): ClaudeExecutablePreflightResult {
+	let realCwd = cwd;
+	try {
+		const cwdStat = statSync(cwd);
+		if (!cwdStat.isDirectory()) {
+			throw makeClaudePreflightError("Claude Code spawn cwd preflight failed: cwd is not a directory.", {
+				code: "ENOTDIR",
+				syscall: "chdir",
+				path: cwd,
+				cwd,
+			});
+		}
+		accessSync(cwd, fsConstants.X_OK);
+		realCwd = realpathSync(cwd);
+	} catch (err) {
+		if ((err as Error).name === "ClaudeExecutablePreflightError") throw err;
+		throw makeClaudePreflightError("Claude Code spawn cwd preflight failed: cwd is not reachable before spawning Claude Code.", {
+			code: codeValue(err, "EACCES"),
+			errno: errnoValue(err),
+			syscall: syscallValue(err),
+			path: pathValue(err) ?? cwd,
+			cwd,
+			cause: err,
+		});
+	}
+
+	let realPath = path;
+	try {
+		const stat = statSync(path);
+		if (!stat.isFile()) {
+			throw makeClaudePreflightError("Claude Code executable preflight failed: resolved path is not a file.", {
+				code: "EACCES",
+				syscall: "exec",
+				path,
+				cwd,
+			});
+		}
+		accessSync(path, fsConstants.X_OK);
+		realPath = realpathSync(path);
+	} catch (err) {
+		if ((err as Error).name === "ClaudeExecutablePreflightError") throw err;
+		throw makeClaudePreflightError("Claude Code executable preflight failed: cannot access resolved executable before spawning Claude Code.", {
+			code: codeValue(err, "ENOENT"),
+			errno: errnoValue(err),
+			syscall: syscallValue(err),
+			path: pathValue(err) ?? path,
+			cwd,
+			cause: err,
+		});
+	}
+
+	let fileType: ClaudeExecutableFileType;
+	try {
+		fileType = classifyClaudeExecutableBytes(readFileSync(realPath).subarray(0, 16));
+	} catch (err) {
+		throw makeClaudePreflightError("Claude Code executable preflight failed: cannot read executable header before spawning Claude Code.", {
+			code: codeValue(err, "EACCES"),
+			errno: errnoValue(err),
+			syscall: syscallValue(err),
+			path: pathValue(err) ?? realPath,
+			cwd,
+			realPath,
+			cause: err,
+		});
+	}
+
+	if (!["elf", "mach-o", "pe", "shebang-script"].includes(fileType)) {
+		throw makeClaudePreflightError("Claude Code executable preflight failed: executable header is not an ELF, Mach-O, PE, or shebang script.", {
+			code: "ENOEXEC",
+			syscall: "exec",
+			path,
+			cwd,
+			fileType,
+			realPath,
+		});
+	}
+
+	return { path, realPath, cwd, realCwd, fileType };
+}
+
+function envFlagEnabled(value: string | undefined): boolean {
+	return value === "1" || value?.toLowerCase() === "true";
+}
+
+export function wrapClaudeSpawnErrorForSdk(err: Error, options: SpawnOptions): Error & NodeJS.ErrnoException & { cwd: string; originalCode?: string } {
+	const originalCode = codeValue(err, "SPAWN_ERROR");
+	const spawnPath = pathValue(err) ?? options.command;
+	const cwd = options.cwd ?? process.cwd();
+	const detail = [
+		`code=${originalCode}`,
+		`errno=${displayValue(errnoValue(err))}`,
+		`syscall=${displayValue(syscallValue(err))}`,
+		`path=${spawnPath}`,
+		`cwd=${cwd}`,
+		`command=${options.command}`,
+	].join(" ");
+	const wrapped = new Error(`Claude Code spawn failed: ${err.message} (${detail})`) as Error & NodeJS.ErrnoException & { cwd: string; originalCode?: string };
+	wrapped.name = "ClaudeSpawnDiagnosticError";
+	// The SDK special-cases code === ENOENT and replaces the message with its
+	// generic "native binary not found" text. Preserve the original code in the
+	// message/originalCode while using a bridge code so the SDK surfaces context.
+	wrapped.code = originalCode === "ENOENT" ? "CLAUDE_BRIDGE_SPAWN_FAILED" : originalCode;
+	wrapped.originalCode = originalCode;
+	const errno = errnoValue(err);
+	if (errno !== undefined) wrapped.errno = typeof errno === "number" ? errno : Number(errno);
+	const syscall = syscallValue(err);
+	if (syscall) wrapped.syscall = syscall;
+	wrapped.path = spawnPath;
+	wrapped.cwd = cwd;
+	(wrapped as Error & { cause?: unknown }).cause = err;
+	return wrapped;
+}
+
+export function spawnClaudeCodeWithDiagnostics(options: SpawnOptions): SpawnedProcess {
+	const pipeStderr = DEBUG || envFlagEnabled(options.env.DEBUG_CLAUDE_AGENT_SDK);
+	const child = spawnProcess(options.command, options.args, {
+		cwd: options.cwd,
+		env: options.env,
+		signal: options.signal,
+		stdio: ["pipe", "pipe", pipeStderr ? "pipe" : "ignore"],
+		windowsHide: true,
+	});
+	if (pipeStderr) {
+		child.stderr?.on("data", (data) => {
+			for (const line of data.toString().split(/\r?\n/)) {
+				if (line) debug(`[cli-stderr spawn] ${line}`);
+			}
+		});
+	}
+	child.prependListener("error", (err) => {
+		const wrapped = wrapClaudeSpawnErrorForSdk(err, options);
+		err.name = wrapped.name;
+		err.message = wrapped.message;
+		Object.assign(err, wrapped);
+	});
+	return {
+		stdin: child.stdin,
+		stdout: child.stdout,
+		get killed() { return child.killed; },
+		get exitCode() { return child.exitCode; },
+		kill: child.kill.bind(child),
+		on: child.on.bind(child),
+		once: child.once.bind(child),
+		off: child.off.bind(child),
+	};
 }
 
 // Per-query CLI debug capture. When CLAUDE_BRIDGE_DEBUG=1, ask the Claude Code
@@ -1072,7 +1297,6 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 
 	const { mcpTools, customToolNameToSdk, customToolNameToPi } = resolveMcpTools(context);
 	const cwd = (options as { cwd?: string } | undefined)?.cwd ?? process.cwd();
-	const { sessionId: resumeSessionId } = syncSharedSession(context.messages, cwd, customToolNameToSdk, model.id);
 	const promptBlocks = extractUserPromptBlocks(context.messages);
 	let promptText = extractUserPrompt(context.messages) ?? "";
 
@@ -1114,6 +1338,8 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 		: providerSettings.settingSources ?? ["user", "project"];
 	const strictMcpConfigEnabled = !appendSystemPrompt && providerSettings.strictMcpConfig !== false;
 	const claudeExecutable = resolveClaudeExecutable(providerSettings.pathToClaudeCodeExecutable);
+	const claudeExecutablePreflight = claudeExecutable ? preflightClaudeExecutable(claudeExecutable, cwd) : undefined;
+	const { sessionId: resumeSessionId } = syncSharedSession(context.messages, cwd, customToolNameToSdk, model.id);
 
 	// Prefer the model's own thinkingLevelMap when present (pi-ai 0.72+ ships
 	// per-model overrides — e.g. opus-4-7 wants xhigh→xhigh, not xhigh→max).
@@ -1156,6 +1382,7 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 		...(mcpServers ? { mcpServers } : {}),
 		...(resumeSessionId ? { resume: resumeSessionId } : {}),
 		...(claudeExecutable ? { pathToClaudeCodeExecutable: claudeExecutable } : {}),
+		spawnClaudeCodeProcess: spawnClaudeCodeWithDiagnostics,
 		...makeCliDebugOptions("provider"),
 	};
 
@@ -1163,6 +1390,7 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 		`model=${model.id} msgs=${context.messages.length} tools=${mcpTools.length}`,
 		`resume=${resumeSessionId?.slice(0, 8) ?? "none"} effort=${effort ?? "default"}`,
 		`appendSys=${appendSystemPrompt} promptCtx=${promptContextAppend.labels.join(",") || "none"} strictMcp=${strictMcpConfigEnabled}`,
+		`claudeExec=${claudeExecutablePreflight ? `${claudeExecutablePreflight.fileType}:${claudeExecutablePreflight.path}` : "sdk-default"}`,
 		`prompt=${promptText.slice(0, 60)}${promptBlocks ? " [+images]" : ""}`);
 
 	// 3. Start SDK query and claim it for this context

--- a/pi-extensions/pi-claude-bridge/tests/unit-preflight.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-preflight.mjs
@@ -76,10 +76,14 @@ describe("preflightClaudeExecutable", () => {
 		assert.equal(error.name, "ClaudeSpawnDiagnosticError");
 		assert.equal(error.code, "CLAUDE_BRIDGE_SPAWN_FAILED");
 		assert.equal(error.originalCode, "ENOENT");
+		assert.match(error.originalMessage, /ENOENT/);
 		assert.equal(error.path, missing);
 		assert.equal(error.cwd, dir);
 		assert.match(error.message, /code=ENOENT/);
 		assert.match(error.message, /syscall=spawn/);
 		assert.doesNotMatch(error.message, /native binary not found/);
+		assert.notEqual(error.cause, error);
+		assert.doesNotThrow(() => JSON.stringify(error));
+		assert.doesNotMatch(error.stack ?? "", /wrapClaudeSpawnErrorForSdk/);
 	}));
 });

--- a/pi-extensions/pi-claude-bridge/tests/unit-preflight.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-preflight.mjs
@@ -1,0 +1,85 @@
+/**
+ * Tests for Claude executable preflight diagnostics.
+ * The checks do not require Claude Code to be installed; they use temp files
+ * and the current Node executable as a known platform binary.
+ */
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { preflightClaudeExecutable, spawnClaudeCodeWithDiagnostics } from "../src/index.ts";
+
+function withTempDir(fn) {
+	const dir = mkdtempSync(join(tmpdir(), "claude-bridge-preflight-"));
+	let cleanupNow = true;
+	const cleanup = () => rmSync(dir, { recursive: true, force: true });
+	try {
+		const result = fn(dir);
+		if (result && typeof result.then === "function") {
+			cleanupNow = false;
+			return result.finally(cleanup);
+		}
+		return result;
+	} finally {
+		if (cleanupNow) cleanup();
+	}
+}
+
+describe("preflightClaudeExecutable", () => {
+	it("accepts an existing executable shebang script", () => withTempDir((dir) => {
+		const script = join(dir, "claude-wrapper");
+		writeFileSync(script, "#!/bin/sh\nexit 0\n");
+		chmodSync(script, 0o755);
+
+		const result = preflightClaudeExecutable(script, dir);
+		assert.equal(result.path, script);
+		assert.equal(result.cwd, dir);
+		assert.equal(result.fileType, "shebang-script");
+	}));
+
+	it("accepts the current Node executable as an existing platform binary", () => withTempDir((dir) => {
+		const result = preflightClaudeExecutable(process.execPath, dir);
+		assert.equal(result.path, process.execPath);
+		assert.match(result.fileType, /^(elf|mach-o|pe)$/);
+	}));
+
+	it("reports errno details for a non-existent executable path", () => withTempDir((dir) => {
+		const missing = join(dir, "missing-claude");
+		assert.throws(
+			() => preflightClaudeExecutable(missing, dir),
+			(error) => {
+				assert.equal(error.name, "ClaudeExecutablePreflightError");
+				assert.equal(error.code, "ENOENT");
+				assert.equal(error.path, missing);
+				assert.equal(error.cwd, dir);
+				assert.equal(error.syscall, "stat");
+				assert.match(error.message, /code=ENOENT/);
+				assert.match(error.message, /errno=-?\d+/);
+				assert.match(error.message, /syscall=stat/);
+				assert.doesNotMatch(error.message, /native binary not found/);
+				return true;
+			},
+		);
+	}));
+
+	it("rewrites spawn ENOENT so SDK surfaces diagnostic context", async () => withTempDir(async (dir) => {
+		const missing = join(dir, "missing-claude");
+		const proc = spawnClaudeCodeWithDiagnostics({
+			command: missing,
+			args: [],
+			cwd: dir,
+			env: {},
+			signal: new AbortController().signal,
+		});
+		const error = await new Promise((resolve) => proc.once("error", resolve));
+		assert.equal(error.name, "ClaudeSpawnDiagnosticError");
+		assert.equal(error.code, "CLAUDE_BRIDGE_SPAWN_FAILED");
+		assert.equal(error.originalCode, "ENOENT");
+		assert.equal(error.path, missing);
+		assert.equal(error.cwd, dir);
+		assert.match(error.message, /code=ENOENT/);
+		assert.match(error.message, /syscall=spawn/);
+		assert.doesNotMatch(error.message, /native binary not found/);
+	}));
+});


### PR DESCRIPTION
Fixes #121

## Summary
- Add Claude executable preflight before invoking the Claude Agent SDK: cwd reachability, file existence, executable bit, realpath, and first-byte classification for ELF/Mach-O/PE/shebang scripts.
- Wrap post-preflight Node spawn errors through the SDK `spawnClaudeCodeProcess` hook so ENOENT includes original `code`, `errno`, `syscall`, `path`, `cwd`, and command context instead of being replaced by the SDK's generic native-binary message.
- Add unit coverage for executable shebang scripts, platform binaries, missing paths, and spawn ENOENT wrapping.
- Document the improved diagnostics in the Claude Bridge README.

## SDK hook note
The SDK exposes `spawnClaudeCodeProcess`, not a dedicated spawn-error callback. This PR uses that supported process factory to preserve the default local spawn behavior while wrapping spawn `error` events before the SDK's ENOENT classifier can replace the message.

## Validation
- `cd pi-extensions/pi-claude-bridge && npm run typecheck`
- `cd pi-extensions/pi-claude-bridge && npm run test:unit`
- `cd pi-extensions/pi-claude-bridge && npm run build`
- Bundle reachability smoke: imported `./bundle/index.js`, exercised script/binary/missing preflight and spawn ENOENT wrapping.
- `git diff --check`
- `vstack refresh -g` → `Processed 0 agent(s) (0 updated), 0 skill(s) (0 updated), 0 hook(s) (0 updated), 18 Pi package(s) (0 updated)`
- `vstack verify -g @vanillagreen/pi-claude-bridge` → `1 checked, 1 OK, 0 failed`

## Notes
- Commit: `8e18a69`.
- Unrelated dirty files: none.
- Package version unchanged.
- Generated `bundle/index.js` updated via `npm run build`; bundled SDK logic was not hand-edited.


## Follow-up: commit `ab52dca9` (post-review fix)

Reviewer-error flagged two correctness bugs in the spawn-error wrap. Both fixed:

1. **Self-referential `cause` cycle removed.** `wrapped.cause = err` is deleted; the original message is preserved on a dedicated `originalMessage` field instead. `Object.assign(err, wrapped)` no longer produces `err.cause === err`, so JSON.stringify of the spawn error no longer throws "circular structure".
2. **Original V8 spawn-site stack preserved.** Listener captures `originalStack` before `Object.assign` and restores `err.stack = originalStack` after, so operators retain the spawn frame that points into node:internal/errors.

New assertions in `tests/unit-preflight.mjs`: `assert.doesNotThrow(() => JSON.stringify(error))` (locks fix 1), `assert.doesNotMatch(error.stack, /wrapClaudeSpawnErrorForSdk/)` (locks fix 2). All 4 unit tests pass.

Known doc nits (follow-up): README does not enumerate the new wrapped-error fields (`originalCode`, `originalMessage`, synthetic `CLAUDE_BRIDGE_SPAWN_FAILED` code, preflight `realPath`/`realCwd`). Out of scope here; will file as a doc follow-up if you want one.