### PR TITLE
Flightdeck v2 Phase 6: pi-session-bridge dedup skill expansion per session

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,6 +222,7 @@ Worktree/feature branch dev: test via local project Pi settings for that checkou
 ### Pi slash-command expansion
 
 - `sendUserMessage` still skips slash/skill expansion (`expandPromptTemplates: false`). `pi-bridge send` compensates with hybrid dispatch: client-side expansion for `/skill:<name>` and prompt templates, own-pane `tmux send-keys -l` for extension/TUI commands, raw `sendUserMessage` for plain text/fallback.
+- Repeated `/skill:<name>` sends in the same Pi session emit a short `Skill <name> (previously loaded). Invocation: ...` reminder instead of re-expanding the full SKILL.md body. The cache is keyed by `(session_id, skill_name, SKILL.md content hash)`; content-hash changes force a fresh full expansion; pi-bridge restart clears the in-memory cache.
 - From an extension, `ctx.ui.pasteToEditor("/skill:foo\n")` pastes text; newline is bracketed-paste content, not a guaranteed submit. Prefer `pi-bridge send "/skill:foo ..."` when controlling another session.
 
 ## Build & Test

--- a/pi-extensions/pi-session-bridge/README.md
+++ b/pi-extensions/pi-session-bridge/README.md
@@ -101,7 +101,8 @@ interface PiActivityBroker {
 `pi-bridge send` uses a hybrid slash dispatch path:
 
 - Plain text keeps the normal `sendUserMessage` path.
-- `/skill:<name> ...` expands client-side from the loaded skill's `sourceInfo.path`, inlining the same `<skill ...>` block Pi's editor would produce. Large user-message bodies are expected and match interactive `/skill:<name>` behavior.
+- `/skill:<name> ...` expands client-side from the loaded skill's `sourceInfo.path`, inlining the same `<skill ...>` block Pi's editor would produce the first time a skill is loaded in a Pi session.
+- Repeated `/skill:<name> ...` sends in the same Pi session skip the `SKILL.md` body and send `Skill <name> (previously loaded). Invocation: ...` instead. Changing the `SKILL.md` file content changes its hash and forces a fresh full expansion; restarting the bridge loses the in-memory cache, so the next send expands fully again.
 - Prompt templates (`/<name> ...` from loaded prompt paths) expand client-side with Pi-compatible `$1`, `$@`, `$ARGUMENTS`, and `${@:N[:L]}` substitution; unquoted spaces, tabs, and newlines split arguments, while quoted newlines stay inside the argument.
 - Extension/TUI commands (for example `/bridge:ping`, `/tasks:add`, `/flightdeck`) are pasted into Pi's own tmux pane with `send-keys -l` + enter after resolving the pane by walking parent processes from `process.pid`. This briefly shows text in the editor and always delivers immediately (`deliverAs` does not apply to this route).
 - If tmux pane resolution or paste fails, the bridge falls back to the old raw `sendUserMessage` behavior instead of failing the request.

--- a/pi-extensions/pi-session-bridge/extensions/session-bridge.ts
+++ b/pi-extensions/pi-session-bridge/extensions/session-bridge.ts
@@ -13,6 +13,7 @@
  */
 
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { createHash } from "node:crypto";
 import * as fs from "node:fs";
 import * as net from "node:net";
 import * as os from "node:os";
@@ -48,6 +49,13 @@ export interface SlashExpansion {
 	error?: string;
 }
 
+export type SkillExpansionCache = Map<string, Map<string, string>>;
+
+export interface SlashExpansionOptions {
+	sessionId?: string;
+	skillExpansionCache?: SkillExpansionCache;
+}
+
 interface ExecResultLike { stdout?: string; stderr?: string; code?: number | null; killed?: boolean }
 export type ExecLike = (command: string, args: string[], options?: { timeout?: number }) => Promise<ExecResultLike>;
 
@@ -56,6 +64,8 @@ interface BridgeClient {
 	buffer: string;
 	events: boolean;
 }
+
+const loadedSkillHashesBySession: SkillExpansionCache = new Map();
 
 interface InstanceInfo {
 	protocol: string;
@@ -485,7 +495,10 @@ export default function sessionBridge(pi: ExtensionAPI) {
 		// ancestry. Never use `tmux display-message -p '#{pane_id}'` here:
 		// it returns the active client pane and can misroute to another tab.
 		if (typeof content === "string" && content.startsWith("/")) {
-			const expanded = expandLoadedSlashContent(content, pi.getCommands() as SlashCommandInfoLike[]);
+			const expanded = expandLoadedSlashContent(content, pi.getCommands() as SlashCommandInfoLike[], fs.readFileSync, {
+				sessionId: currentInfo?.sessionId ?? getState("slash_expansion").sessionId ?? `pid:${process.pid}`,
+				skillExpansionCache: loadedSkillHashesBySession,
+			});
 			if (expanded.expanded) {
 				pi.sendUserMessage(expanded.text as never, options as never);
 				sendResponse(client, id, commandName, true, {
@@ -611,6 +624,7 @@ export function expandLoadedSlashContent(
 	text: string,
 	commands: SlashCommandInfoLike[],
 	readFile: (filePath: string, encoding: BufferEncoding) => string = fs.readFileSync,
+	options: SlashExpansionOptions = {},
 ): SlashExpansion {
 	const parsed = parseSlashCommand(text);
 	if (!parsed) return { expanded: false };
@@ -625,10 +639,33 @@ export function expandLoadedSlashContent(
 		const sourcePath = skill?.sourceInfo?.path;
 		if (!skill || typeof sourcePath !== "string" || sourcePath.length === 0) return { expanded: false };
 		try {
-			const body = stripFrontmatter(readFile(sourcePath, "utf8")).trim();
 			const skillName = parsed.commandName.slice("skill:".length);
+			const raw = readFile(sourcePath, "utf8");
+			const contentHash = shortSha256(raw);
+			const sessionId = options.sessionId?.trim();
+			const cache = options.skillExpansionCache;
+			if (sessionId && cache) {
+				const sessionCache = cache.get(sessionId);
+				const cachedHash = sessionCache?.get(skillName);
+				if (cachedHash === contentHash) {
+					const invocation = parsed.argsString.trim();
+					return {
+						expanded: true,
+						kind: "skill",
+						command: parsed.commandName,
+						text: invocation ? `Skill ${skillName} (previously loaded). Invocation: ${invocation}` : `Skill ${skillName} (previously loaded).`,
+					};
+				}
+			}
+
+			const body = stripFrontmatter(raw).trim();
 			const baseDir = skill.sourceInfo?.baseDir || path.dirname(sourcePath);
 			const block = `<skill name="${skillName}" location="${sourcePath}">\nReferences are relative to ${baseDir}.\n\n${body}\n</skill>`;
+			if (sessionId && cache) {
+				const sessionCache = cache.get(sessionId) ?? new Map<string, string>();
+				sessionCache.set(skillName, contentHash);
+				cache.set(sessionId, sessionCache);
+			}
 			return {
 				expanded: true,
 				kind: "skill",
@@ -654,6 +691,10 @@ export function expandLoadedSlashContent(
 	} catch (error) {
 		return { expanded: false, error: stringifyError(error) };
 	}
+}
+
+function shortSha256(content: string): string {
+	return createHash("sha256").update(content).digest("hex").slice(0, 16);
 }
 
 function parseSlashCommand(text: string): { commandName: string; argsString: string } | null {

--- a/pi-extensions/pi-session-bridge/instructions.md
+++ b/pi-extensions/pi-session-bridge/instructions.md
@@ -6,7 +6,7 @@ Discovery: `pi-bridge list` returns `(PID, IDLE, SESSION, NAME, CWD, SOCKET)`. F
 
 Commands:
 - `state` — structured snapshot (idle, model, cwd, session id, paths).
-- `send "msg"` — deliver a prompt; auto-queues if the target is busy. Slash dispatch is hybrid: `/skill:<name>` and prompt templates expand client-side, extension/TUI commands paste into the target Pi pane, and plain text uses normal `sendUserMessage`.
+- `send "msg"` — deliver a prompt; auto-queues if the target is busy. Slash dispatch is hybrid: `/skill:<name>` and prompt templates expand client-side, extension/TUI commands paste into the target Pi pane, and plain text uses normal `sendUserMessage`. Repeated `/skill:<name>` sends in one Pi session use a short previously-loaded reminder unless the `SKILL.md` content hash changes; bridge restart loses this in-memory cache.
 - `steer "msg"` / `follow-up "msg"` / `abort` — interrupt-and-redirect / queue-after-turn / cancel.
 - `history N` / `stream` — structured events (input, message_update, tool_call, agent_end, bridge_pong, question, `vstack_activity`). Activity rows are non-chat bridge events emitted by the local activity broker.
 - `questions` + `answer --request-id … --answers '[[...]]'` / `reject --request-id …` — drive `pi-questions` popups.

--- a/pi-extensions/pi-session-bridge/tests/slash-dispatch.test.ts
+++ b/pi-extensions/pi-session-bridge/tests/slash-dispatch.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
@@ -107,6 +107,73 @@ describe("slash expansion", () => {
 		const multiline = expandLoadedSlashContent("/template\nalpha beta", commands);
 		expect(multiline.expanded).toBe(true);
 		expect(multiline.text).toBe("alpha|beta|alpha beta|alpha beta|beta|beta");
+	});
+
+	test("dedups repeated skill expansion within the same session", () => {
+		const skillPath = p("skills/flightdeck/SKILL.md");
+		mkdirSync(dirname(skillPath), { recursive: true });
+		writeFileSync(skillPath, "---\nname: flightdeck\n---\n# Flightdeck\nWatch sessions.\n");
+		const commands = [{ name: "skill:flightdeck", source: "skill", sourceInfo: { path: skillPath } }] as SlashCommandInfoLike[];
+		const cache = new Map<string, Map<string, string>>();
+
+		const first = expandLoadedSlashContent("/skill:flightdeck watch --from-daemon", commands, readFileSync, {
+			sessionId: "session-a",
+			skillExpansionCache: cache,
+		});
+		expect(first.expanded).toBe(true);
+		expect(first.text).toContain(`<skill name="flightdeck" location="${skillPath}">`);
+		expect(first.text).toContain("# Flightdeck");
+
+		const second = expandLoadedSlashContent("/skill:flightdeck watch --from-daemon", commands, readFileSync, {
+			sessionId: "session-a",
+			skillExpansionCache: cache,
+		});
+		expect(second.expanded).toBe(true);
+		expect(second.kind).toBe("skill");
+		expect(second.text).toBe("Skill flightdeck (previously loaded). Invocation: watch --from-daemon");
+		expect(second.text).not.toContain("<skill");
+		expect(second.text).not.toContain("# Flightdeck");
+
+		const otherSession = expandLoadedSlashContent("/skill:flightdeck watch --from-daemon", commands, readFileSync, {
+			sessionId: "session-b",
+			skillExpansionCache: cache,
+		});
+		expect(otherSession.text).toContain(`<skill name="flightdeck" location="${skillPath}">`);
+	});
+
+	test("re-expands skill after SKILL.md content changes", () => {
+		const skillPath = p("skills/orchestration/SKILL.md");
+		mkdirSync(dirname(skillPath), { recursive: true });
+		writeFileSync(skillPath, "---\nname: orchestration\n---\n# Orchestration v1\n");
+		const commands = [{ name: "skill:orchestration", source: "skill", sourceInfo: { path: skillPath } }] as SlashCommandInfoLike[];
+		const cache = new Map<string, Map<string, string>>();
+
+		const first = expandLoadedSlashContent("/skill:orchestration run", commands, readFileSync, {
+			sessionId: "session-a",
+			skillExpansionCache: cache,
+		});
+		expect(first.text).toContain("# Orchestration v1");
+
+		const deduped = expandLoadedSlashContent("/skill:orchestration run", commands, readFileSync, {
+			sessionId: "session-a",
+			skillExpansionCache: cache,
+		});
+		expect(deduped.text).toBe("Skill orchestration (previously loaded). Invocation: run");
+
+		writeFileSync(skillPath, "---\nname: orchestration\n---\n# Orchestration v2\n");
+		const changed = expandLoadedSlashContent("/skill:orchestration run", commands, readFileSync, {
+			sessionId: "session-a",
+			skillExpansionCache: cache,
+		});
+		expect(changed.text).toContain(`<skill name="orchestration" location="${skillPath}">`);
+		expect(changed.text).toContain("# Orchestration v2");
+		expect(changed.text).not.toContain("# Orchestration v1");
+
+		const dedupedAgain = expandLoadedSlashContent("/skill:orchestration run", commands, readFileSync, {
+			sessionId: "session-a",
+			skillExpansionCache: cache,
+		});
+		expect(dedupedAgain.text).toBe("Skill orchestration (previously loaded). Invocation: run");
 	});
 });
 

--- a/pi-extensions/pi-session-bridge/tests/slash-dispatch.test.ts
+++ b/pi-extensions/pi-session-bridge/tests/slash-dispatch.test.ts
@@ -175,6 +175,38 @@ describe("slash expansion", () => {
 		});
 		expect(dedupedAgain.text).toBe("Skill orchestration (previously loaded). Invocation: run");
 	});
+
+	test("dedup is independent per skill within a session (pins Map<sessionId, Map<skillName, hash>>)", () => {
+		const alphaPath = p("skills/alpha/SKILL.md");
+		const betaPath = p("skills/beta/SKILL.md");
+		mkdirSync(dirname(alphaPath), { recursive: true });
+		mkdirSync(dirname(betaPath), { recursive: true });
+		writeFileSync(alphaPath, "---\nname: alpha\n---\n# Alpha Skill\nA body.\n");
+		writeFileSync(betaPath, "---\nname: beta\n---\n# Beta Skill\nB body.\n");
+		const commands = [
+			{ name: "skill:alpha", source: "skill", sourceInfo: { path: alphaPath } },
+			{ name: "skill:beta", source: "skill", sourceInfo: { path: betaPath } },
+		] as SlashCommandInfoLike[];
+		const cache = new Map<string, Map<string, string>>();
+		const options = { sessionId: "session-a", skillExpansionCache: cache };
+
+		const firstAlpha = expandLoadedSlashContent("/skill:alpha run-a", commands, readFileSync, options);
+		expect(firstAlpha.text).toContain(`<skill name="alpha" location="${alphaPath}">`);
+		expect(firstAlpha.text).toContain("# Alpha Skill");
+
+		// Skill B in the same session must still get the FULL body, not the dedup reminder.
+		const firstBeta = expandLoadedSlashContent("/skill:beta run-b", commands, readFileSync, options);
+		expect(firstBeta.text).toContain(`<skill name="beta" location="${betaPath}">`);
+		expect(firstBeta.text).toContain("# Beta Skill");
+		expect(firstBeta.text).not.toContain("previously loaded");
+
+		// Re-expanding each skill independently now hits the short reminder for each.
+		const secondAlpha = expandLoadedSlashContent("/skill:alpha run-a", commands, readFileSync, options);
+		expect(secondAlpha.text).toBe("Skill alpha (previously loaded). Invocation: run-a");
+
+		const secondBeta = expandLoadedSlashContent("/skill:beta run-b", commands, readFileSync, options);
+		expect(secondBeta.text).toBe("Skill beta (previously loaded). Invocation: run-b");
+	});
 });
 
 describe("tmux pane dispatch", () => {


### PR DESCRIPTION
## Summary

Implements Phase 6 from `docs/plans/flightdeck-v2-architecture-plan.md` § 3: pi-session-bridge now deduplicates client-side `/skill:<name>` expansion per Pi session.

Before: every `pi-bridge send "/skill:<name> ..."` inlined the full `SKILL.md` body into the user message, including repeated daemon wakes.

After: the first send for a `(session, skill name, SKILL.md content hash)` emits the full `<skill ...>` block. Later sends in the same Pi session with the same content hash emit only `Skill <name> (previously loaded). Invocation: ...`. If the `SKILL.md` content changes, the hash changes and the next invocation re-expands the full body. Bridge restart loses the in-memory cache and degrades to full expansion on the next send.

Applies to all skills, not just `flightdeck`.

## Tests

- `cd pi-extensions/pi-session-bridge && bun test` — 21 pass
- `cd pi-extensions/pi-session-bridge && bun run check` — 21 pass
- `cd pi-extensions/pi-session-bridge && bun run typecheck 2>/dev/null || true` — package has no `typecheck` script
- `cd pi-extensions/pi-session-bridge && node --check bin/pi-bridge.js` — pass

New test coverage:

- repeated same-session skill expansion returns the short reminder instead of a `<skill>` block
- a different session still receives a full expansion
- changed `SKILL.md` content hash forces a fresh full expansion, then dedups again

## vstack refresh / verify

`vstack refresh -g 2>&1`:

```text
─ refresh (GLOBAL) ─
  ! pi-package updated: @vanillagreen/pi-agents-tmux, @vanillagreen/pi-claude-bridge
Processed 0 agent(s) (0 updated), 0 skill(s) (0 updated), 0 hook(s) (0 updated), 18 Pi package(s) (2 updated)
```

Note: this machine's global source index points to `/mnt/Tertiary/dev/vstack/main`, so `@vanillagreen/pi-session-bridge` was not listed as updated from this feature worktree by global refresh.

`vstack verify -g @vanillagreen/pi-session-bridge 2>&1`:

```text
─ verify (GLOBAL) ─
  src:✓ install:✓  pi-package  @vanillagreen/pi-session-bridge

1 checked, 1 OK, 0 failed
```


## Follow-up: commit `c1a665c6` (post-review)

Reviewer-doc D1 + reviewer-test cross-skill gap addressed:

1. **Cross-doc dedup note added** to `AGENTS.md` (`.claude/CLAUDE.md` is a symlink to it, so both root-level docs are covered) under the existing "Pi slash-command expansion" section. The new bullet describes the per-session cache shape `(session_id, skill_name, SKILL.md content hash)`, the short-form reminder behavior, and the bridge-restart invalidation.
2. **Cross-skill independence test added** to `pi-extensions/pi-session-bridge/tests/slash-dispatch.test.ts` that pins the `Map<sessionId, Map<skillName, hash>>` cache key shape. Expands skill A → full body, skill B → full body (NOT a short reminder), then re-expands each → short reminder. Catches a regression to sessionId-only or skillName-only keying.

Test count: 8 → 9 in slash-dispatch.test.ts. `bun test` clean.

Applied by master directly (rather than via the spawned implementation pane) because that pane wedged after attempting an apply_patch with stale base text (session JSONL stopped writing at 05:56Z; pi-bridge reported isIdle=false but no activity for >2h). The intended doc + test changes are preserved unchanged.

Out of scope (will track as follow-up issues): #129 (cache eviction/bound) covers the per-session cleanup gap reviewer-safety flagged.
