### PR TITLE
pi-claude-bridge: add cwd-deleted regression test for preflight (follow-up to #124)

### DIFF
--- a/pi-extensions/pi-claude-bridge/tests/unit-preflight.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-preflight.mjs
@@ -63,6 +63,42 @@ describe("preflightClaudeExecutable", () => {
 		);
 	}));
 
+	it("reports errno details for a deleted cwd before checking the executable", () => withTempDir((dir) => {
+		rmSync(dir, { recursive: true, force: true });
+		assert.throws(
+			() => preflightClaudeExecutable(process.execPath, dir),
+			(error) => {
+				assert.equal(error.name, "ClaudeExecutablePreflightError");
+				assert.equal(error.code, "ENOENT");
+				assert.equal(error.path, dir);
+				assert.equal(error.cwd, dir);
+				assert.equal(error.syscall, "stat");
+				assert.match(error.message, /cwd is not reachable/);
+				assert.ok(error.message.includes(`cwd=${dir}`));
+				assert.doesNotMatch(error.message, /native binary not found/);
+				return true;
+			},
+		);
+	}));
+
+	it("reports structured details when cwd is a file", () => withTempDir((dir) => {
+		const fileCwd = join(dir, "not-a-directory");
+		writeFileSync(fileCwd, "not a directory\n");
+		assert.throws(
+			() => preflightClaudeExecutable(process.execPath, fileCwd),
+			(error) => {
+				assert.equal(error.name, "ClaudeExecutablePreflightError");
+				assert.equal(error.code, "ENOTDIR");
+				assert.equal(error.path, fileCwd);
+				assert.equal(error.cwd, fileCwd);
+				assert.equal(error.syscall, "chdir");
+				assert.match(error.message, /cwd is not a directory/);
+				assert.ok(error.message.includes(`cwd=${fileCwd}`));
+				return true;
+			},
+		);
+	}));
+
 	it("rewrites spawn ENOENT so SDK surfaces diagnostic context", async () => withTempDir(async (dir) => {
 		const missing = join(dir, "missing-claude");
 		const proc = spawnClaudeCodeWithDiagnostics({


### PR DESCRIPTION
TEST-ONLY PR, zero source changes.

References #130 (pi-agents-tmux deleted-cwd follow-up) and follows up #124 (Claude bridge spawn diagnostic preflight fix).

Adds regression coverage for `preflightClaudeExecutable(path, cwd)` cwd preflight failures:
- deleted cwd directory: asserts `ClaudeExecutablePreflightError`, `ENOENT`, `stat`, preserved `cwd`, `cwd=` detail, and no misleading `native binary not found` wording
- cwd path is a file, not a directory: asserts `ClaudeExecutablePreflightError`, `ENOTDIR`, `chdir`, preserved structured fields, and `cwd is not a directory` wording

Closes original #124 reviewer-test gap: cwd unreachable/missing/not-a-dir path was untested even though it matches the real deleted-worktree failure class.

Validation:
- `cd pi-extensions/pi-claude-bridge && npm run test:unit`
- `cd pi-extensions/pi-claude-bridge && npm run typecheck`
