### PR TITLE
Flightdeck v2 Phase 2: add github-issue lane (workflows/github/*, --tracker github)

### DIFF
--- a/skills/flightdeck/README.md
+++ b/skills/flightdeck/README.md
@@ -1,6 +1,6 @@
 # Flightdeck
 
-Flightdeck supervises AI harness sessions in tmux windows. In core session mode it launches or attaches panes, tracks stable ids, routes prompts, and summarizes completion. Issue orchestration is a built-in domain mode layered on top: GitHub/Linear/worktree decisions, merge planning, and next-cycle recommendations.
+Flightdeck supervises AI harness sessions in tmux windows. In core session mode it launches or attaches panes, tracks stable ids, routes prompts, and summarizes completion. Issue orchestration is a built-in domain mode layered on top: Linear issue flows add merge planning and next-cycle recommendations; GitHub issue flows add PR/CI/review gates without Linear/project-management dependencies.
 
 > Agents reading this: you want `SKILL.md` instead. Hacking on flightdeck itself: see [`DEVELOPMENT.md`](./DEVELOPMENT.md).
 
@@ -8,18 +8,19 @@ Flightdeck supervises AI harness sessions in tmux windows. In core session mode 
 
 Running one agent at a time is fine. Running five at once is chaos — each one keeps stopping to ask questions, background tasks finish at odd times, and issue-mode merge order can turn into a guessing game. Flightdeck handles the supervisory layer so you can track generic sessions or spawn a whole issue cycle and walk away.
 
-Activates only inside tmux and only when you ask for it (`flightdeck session start|attach` for core sessions, `flightdeck start` for issue workflows). Outside tmux it's a no-op.
+Activates only inside tmux and only when you ask for it (`flightdeck session start|attach` for core sessions, `flightdeck start` for Linear issue workflows, or `flightdeck github start <N>` for GitHub issue workflows). Outside tmux it's a no-op.
 
 ## How it works
 
-Flightdeck launches generic sessions with `flightdeck session start` (or `attach`) or issue agents with `flightdeck start`, always into their own tmux windows, then watches them in parallel. Each Flightdeck session launches/verifies the Rust dashboard by default; set `FLIGHTDECK_DASHBOARD=0` to opt out. Each agent talks to flightdeck through its native channel (Claude Code MCP, OpenCode HTTP, Pi bridge, Codex app-server) and falls back to tmux when a channel isn't available.
+Flightdeck launches generic sessions with `flightdeck session start` (or `attach`), Linear issue agents with `flightdeck start`, or GitHub issue agents with `flightdeck github start <N>`, always into their own tmux windows, then watches them in parallel. Each Flightdeck session launches/verifies the Rust dashboard by default; set `FLIGHTDECK_DASHBOARD=0` to opt out. Each agent talks to flightdeck through its native channel (Claude Code MCP, OpenCode HTTP, Pi bridge, Codex app-server) and falls back to tmux when a channel isn't available.
 
 A background daemon detects when an agent has a question, the master agent classifies the prompt, auto-answers when there's a learned default, and pauses for the human when there isn't.
 
 There are two modes per tracked entry:
 
 - **Generic session mode** — structured questions, bash permission prompts, safe bounded choices, Pi background-task exits.
-- **Issue mode** — adds GitHub/Linear/worktree decisions: cleanup, rebase, force-push, bot-review/CI recovery, merge planning, scope creep.
+- **Linear issue mode** — adds GitHub/Linear/worktree decisions: cleanup, rebase, force-push, bot-review/CI recovery, merge planning, scope creep, and next-cycle recommendations.
+- **GitHub issue mode** — adds GitHub/worktree decisions: cleanup, rebase, force-push, bot-review/CI recovery, merge gating, issue-close fallback, and session summary.
 
 When all tracked entries are terminal, flightdeck writes a summary and hands control back.
 
@@ -38,7 +39,7 @@ If the daemon's master pane disappears (master agent crash, accidental window ki
 
 ## Activation and termination
 
-- **Activates** on `flightdeck session start|attach` for generic tracked sessions, or `flightdeck start` for issue workflows, from inside tmux.
+- **Activates** on `flightdeck session start|attach` for generic tracked sessions, `flightdeck start` for Linear issue workflows, or `flightdeck github start <N>` for GitHub issue workflows, from inside tmux.
 - **Pauses** for you on: scope creep that wants reverting, force-merging against a real content conflict, an issue abort, a `main` mutation that needs human OK, domain mismatch, or a novel prompt shape no rule covers. Sets `paused_for_user` in state and stops polling. Resume by running `session watch` or issue `watch` again.
 - **Terminates** automatically when every tracked entry is terminal for the relevant mode. Generic-only sessions write a session summary with no GitHub/Linear/worktree calls. Issue sessions write the issue summary, archive the state file, and hand control back.
 
@@ -50,7 +51,7 @@ Fresh LLM panes need an explicit launch profile. `flightdeck session start --pro
 
 ## Issue workflows
 
-Issue orchestration remains first-class when the session is tied to a Linear/GitHub/worktree domain. Ask the agent to start an issue, check a parallel group for safety, launch the group, watch the session, recompute merge order, or close out the session — it routes to the right flightdeck command for you.
+Issue orchestration remains first-class when the session is tied to an issue/worktree domain. Ask the agent to start a Linear issue, check a parallel group for safety, launch the group, watch the session, recompute merge order, or close out the session. For GitHub-only repos, use `flightdeck github start <N>`, `github start new`, `github watch`, `github close-issue`, and `github terminate`; this lane is intentionally smaller and covers PR/CI/review handling without merge-order planning.
 
 The `github` skill ships `label-add` and `label-remove` wrappers around `gh pr edit` / `gh issue edit`. When flightdeck spawns a managed pane, those wrappers emit `pr.labeled` / `pr.unlabeled` / `issue.labeled` / `issue.unlabeled` activity rows alongside the existing `pr.*` events, so label-driven gates (`defer-ci`, custom workflow labels) show up in the activity sidecar and Rust dashboard.
 
@@ -65,7 +66,7 @@ vstack add vanillagreencom/vstack --skill flightdeck -y
 
 Core mode requires tmux only at the workflow/skill-dependency layer, plus the harness adapter you choose for a tracked pane (`pi-bridge`, OpenCode HTTP, Claude Channels, Codex app-server, or tmux fallback). It does not require GitHub, Linear credentials, project-management, or worktree setup.
 
-Issue mode adds the optional `github`, `linear`, `worktree`, and `project-management` skills on demand for `flightdeck start <ISSUE>`, `start new`, `parallel-check`, `merge-plan`, `close-issue`, and issue termination/recommendation workflows.
+Linear issue mode adds the optional `github`, `linear`, `worktree`, and `project-management` skills on demand for `flightdeck start <ISSUE>`, `start new`, `parallel-check`, `merge-plan`, `close-issue`, and issue termination/recommendation workflows. GitHub issue mode loads only `github` and `worktree` for `flightdeck github start <N>`, `github start new`, `github watch`, `github close-issue`, and `github terminate`.
 
 Runtime requirements for the shipped core scripts remain `bash` 4+, `tmux` 3.x, `jq`, `flock`, and `bun` (https://bun.sh). Issue mode additionally needs the GitHub/Linear CLIs or auth wrappers used by those skills, plus normal git worktree support. Mac users: install GNU coreutils for `sha256sum` and GNU date.
 
@@ -145,4 +146,4 @@ Daemon tuning (`FD_*` env vars) and contributor-only knobs are documented in [`D
 - Flightdeck does not abort issues for you — only you can.
 - Flightdeck does not respawn dead panes.
 - Flightdeck operates within one tmux session at a time. Multiple sessions are independent.
-- Flightdeck does not bypass the parallel-safety check that orchestration runs before spawn. If that check says no, flightdeck doesn't override.
+- Flightdeck does not bypass the Linear parallel-safety check before spawn. If that check says no, flightdeck doesn't override. GitHub mode has no parallel-check lane.

--- a/skills/flightdeck/SKILL.md
+++ b/skills/flightdeck/SKILL.md
@@ -20,7 +20,8 @@ metadata:
 1. Verify `$TMUX` is set for every Flightdeck command. If unset, **exit immediately with no-op**: print `Flightdeck requires tmux; skipping.` and return control to the caller. Flightdeck does nothing outside tmux.
 2. Determine the command mode before loading dependencies:
    - Generic session commands (`session start`, `session attach`, `session watch`, `session status`, `session stop`, `session remove`) require only tmux plus the selected harness adapter (`pi-bridge`, OpenCode HTTP, Claude Channels, Codex app-server, or tmux fallback). Do **not** load `github`, `linear`, `project-management`, or `worktree` for generic session commands.
-   - Issue workflow commands (`start [ISSUE_ID]`, `start new`, `parallel-check`, issue `watch`, `merge-plan`, `close-issue`, `terminate` when any tracked entry is `kind=issue`) load `github`, `linear`, `project-management`, and `worktree` on demand. Redundant loads are no-ops.
+   - Linear issue workflow commands (`start [ISSUE_ID]`, `start new`, `parallel-check`, issue `watch`, `merge-plan`, `close-issue`, `terminate` when any tracked entry is `kind=issue`) load `github`, `linear`, `project-management`, and `worktree` on demand. Redundant loads are no-ops.
+   - GitHub issue workflow commands (`github start <N>`, `github start new`, `github watch`, `github close-issue`, `github terminate`) load only `github` and `worktree` on demand. Do **not** load `linear` or `project-management` for GitHub mode.
 3. If an issue workflow dependency cannot be loaded after entering issue mode, stop and tell the user. Do not proceed with issue/PR/worktree actions without it.
 
 ---
@@ -29,12 +30,19 @@ metadata:
 
 Core Flightdeck is a generic session manager. It requires tmux and the harness adapters needed for the tracked panes only; it does not require GitHub, Linear, project-management, or worktree skills.
 
-### Issue-mode dependencies (load when entering issue workflows)
+### Linear issue-mode dependencies (load when entering Linear issue workflows)
 
 - `github` — PR inspection, merge state, checks, review threads, file lists.
 - `linear` — issue metadata, created follow-ups, cycle/todo recommendation checks.
 - `worktree` — issue branch/worktree ownership and cleanup scope.
 - `project-management` — cycle planning, audits, roadmaps, research issue wrappers used by issue workflows.
+
+### GitHub-mode dependencies (load when entering GitHub issue workflows)
+
+- `github` — issue lookup/closure plus PR inspection, merge state, checks, review threads, file lists.
+- `worktree` — issue branch/worktree ownership and cleanup scope.
+
+Do **not** load `linear` or `project-management` for GitHub mode.
 
 `decider` remains optional for agents that want an extra decision aid, but core session management does not require it.
 
@@ -46,7 +54,7 @@ You are in **master mode**. Master supervises: it routes prompts, updates state/
 
 Generic session mode is the core path: launch/attach with `flightdeck-session`, supervise with `session-watch.md`, answer generic prompts, and summarize sessions. It skips issue selection, research/plan evaluation, `open-terminal`, merge planning, GitHub/Linear/worktree actions, and project-management flows.
 
-Issue-mode global arc begins only after entering an Issue workflows command: dashboard verification → research/plan evaluation → spawn (`open-terminal`) → watch loop → merge planning → unwind. Communicate with spawned agents through native channels (`pane-respond`): opencode HTTP, Claude Channels MCP/JSONL, Pi bridge, Codex JSON-RPC, with tmux capture/send-keys only as fallback (see `patterns/tmux-monitoring.md`). Pause for the user only on scope creep that requires reverting agent work, force-merging against a real content conflict, issue abort, direct `main` mutation when no orchestrator pane is alive, or a novel prompt shape no rule covers. Do not re-implement orchestration gates; answer surfaced prompts and add only cross-session conflict/scope facts.
+Linear issue-mode global arc begins only after entering a Linear issue workflow command: dashboard verification → research/plan evaluation → spawn (`open-terminal`) → watch loop → merge planning → unwind. GitHub issue-mode arc begins after `github *`: dashboard verification → `gh issue view` / `gh issue create` → spawn (`open-terminal --tracker github`) → watch loop → PR/CI/review gates → unwind. Communicate with spawned agents through native channels (`pane-respond`): opencode HTTP, Claude Channels MCP/JSONL, Pi bridge, Codex JSON-RPC, with tmux capture/send-keys only as fallback (see `patterns/tmux-monitoring.md`). Pause for the user only on scope creep that requires reverting agent work, force-merging against a real content conflict, issue abort, direct `main` mutation when no orchestrator pane is alive, or a novel prompt shape no rule covers. Do not re-implement orchestration gates; answer surfaced prompts and add only cross-session conflict/scope facts.
 
 ## Commands
 
@@ -67,7 +75,7 @@ Generic tmux-window session tracking. These commands do not require a fake issue
 
 ### Issue workflows
 
-Issue/PR/worktree workflows. Entering these commands loads the issue-mode dependencies on demand.
+Linear issue/PR/worktree workflows. Entering these commands loads the Linear issue-mode dependencies on demand.
 
 | Command | Arguments | Workflow | Notes |
 |---------|-----------|----------|-------|
@@ -81,7 +89,19 @@ Issue/PR/worktree workflows. Entering these commands loads the issue-mode depend
 | `terminate` | — | `workflows/linear/terminate.md` | If any tracked entry is `kind=issue`, produce the issue/PR/new-issue recommendation summary; mixed sessions also include generic session summary. |
 | `status` | — | inline | Print current pane registry + state machine snapshot from `tmp/flightdeck-state-<TMUX_SESSION>.json`. Read-only. |
 
-### Planning (cross-call to `project-management`, issue mode only)
+### GitHub workflows
+
+GitHub issue/PR/worktree workflows. Entering these commands loads only `github` and `worktree` on demand.
+
+| Command | Arguments | Workflow | Notes |
+|---------|-----------|----------|-------|
+| `github start` | `<N>` | `workflows/github/start.md` | Entry: spawn worktree + pane for GitHub issue, enter watch. |
+| `github start new` | `[title]` | `workflows/github/start-new.md` | Create + spawn. |
+| `github watch` | `[Ns...]` | `workflows/github/watch.md` → `workflows/shared/session-watch.md` | Github-mode extension over the generic loop. |
+| `github close-issue` | `<N>` | `workflows/github/close-issue.md` | Terminal validation + teardown. |
+| `github terminate` | — | `workflows/github/terminate.md` | Session summary for github entries. |
+
+### Planning (cross-call to `project-management`, Linear issue mode only)
 
 | Command | Workflow | Notes |
 |---------|----------|-------|
@@ -383,6 +403,12 @@ Additional tuning:
 | `workflows/linear/close-issue.md` | Nested invocation from `watch` § 2 on `terminal-state-reached` | Verify two-signal terminal state, update master state, kill window, keep registry entry for terminate reporting/final cleanup |
 | `workflows/linear/merge-plan.md` | Nested invocation from `watch` § 4 | Conflict-graph build + smallest-first merge ordering |
 | `workflows/linear/terminate.md` | Nested invocation from issue `watch` or generic session unwind | Generic session summary for ad-hoc/workflow entries; issue/PR/new-issues recommendation summary when any issue entry exists; master-state finalization |
+| `workflows/github/start.md` | `github start <N>` | Entry: dashboard, GitHub issue lookup, worktree spawn, enter GitHub watch |
+| `workflows/github/start-new.md` | `github start new` | Create GitHub issue, then run GitHub start |
+| `workflows/github/watch.md` | `github watch` | GitHub issue-mode extension over `session-watch`: PR/CI/review handlers, close issue, terminate |
+| `workflows/github/handle-prompt.md` | Nested invocation from GitHub watch for GitHub issue-only tags | PR/CI/review prompt response surface only |
+| `workflows/github/close-issue.md` | Nested invocation from GitHub watch on `terminal-state-reached` | Verify terminal state, close issue fallback, update master state, kill window |
+| `workflows/github/terminate.md` | Nested invocation from GitHub watch or generic session unwind | Generic session summary for ad-hoc/workflow entries; GitHub issue/PR/worktree summary when GitHub entries exist; master-state finalization |
 
 ## Workflow Execution
 
@@ -418,4 +444,4 @@ The user-visible output blocks at the end of `terminate.md` (`<generic_output_fo
 
 ## Compaction Recovery
 
-Master state is persisted on every state mutation and rehydrated on watch re-entry. Generic entry reconciliation and daemon recovery live in `workflows/shared/session-watch.md` § 6; issue-specific recovery (pane fingerprinting, `unknown_since`, conflict graph, and paused issue re-evaluation) lives in `workflows/linear/watch.md` § 8.
+Master state is persisted on every state mutation and rehydrated on watch re-entry. Generic entry reconciliation and daemon recovery live in `workflows/shared/session-watch.md` § 6; issue-specific recovery lives in `workflows/linear/watch.md` § 8 and `workflows/github/watch.md` § 8.

--- a/skills/flightdeck/lib/flightdeck-core/tests/parity/open-terminal.test.ts
+++ b/skills/flightdeck/lib/flightdeck-core/tests/parity/open-terminal.test.ts
@@ -187,6 +187,35 @@ describe("open-terminal smoke", () => {
 		expect(state.entries["CC-6"].launch.requested_effort).toBe("high");
 	});
 
+	test("default tracker keeps linear issue IDs on orchestration start prompt", () => {
+		const repo = makeRepo();
+		repos.push(repo);
+		const shim = writeShimState(repo, { panes: {}, session: "test-session", windows: {} });
+		const r = runOpenTerminal(repo, shim, ["cc-7", "--tmux", "--harness", "pi"]);
+		expect(r.status).toBe(0);
+		const pane = readShimState(shim).panes["%1"]!;
+		expect(pane.window_name).toBe("CC-7");
+		const launchLine = pane.sent_keys!.find((line) => line.includes("pi"))!.replaceAll("\\ ", " ");
+		expect(launchLine).toContain("/skill:orchestration start CC-7");
+		expect(launchLine).not.toContain("/skill:flightdeck github start");
+	});
+
+	test("github tracker accepts numeric issue IDs and starts github lane", () => {
+		const repo = makeRepo();
+		repos.push(repo);
+		const shim = writeShimState(repo, { panes: {}, session: "test-session", windows: {} });
+		const r = runOpenTerminal(repo, shim, ["120", "--tracker", "github", "--tmux", "--harness", "pi"]);
+		expect(r.status).toBe(0);
+		const pane = readShimState(shim).panes["%1"]!;
+		expect(pane.window_name).toBe("120");
+		const launchLine = pane.sent_keys!.find((line) => line.includes("pi"))!.replaceAll("\\ ", " ");
+		expect(launchLine).toContain("/skill:flightdeck github start 120");
+		expect(launchLine).not.toContain("/skill:orchestration start");
+		const state = JSON.parse(readFileSync(stateFile(repo), "utf8"));
+		expect(state.entries["120"].kind).toBe("issue");
+		expect(state.entries["120"].domain.issue.id).toBe("120");
+	});
+
 	test("claude minimal effort fails before worktree or tmux mutation", () => {
 		const repo = makeRepo();
 		repos.push(repo);

--- a/skills/flightdeck/scripts/open-terminal
+++ b/skills/flightdeck/scripts/open-terminal
@@ -2,11 +2,12 @@
 # Launch worktree(s) for one or more issues with selected harness, model/effort overrides, and terminal.
 #
 # Usage:
-#   open-terminal ISSUE-1 [--tmux | --ghostty] [--harness claude] [--model MODEL] [--effort LEVEL]
-#   open-terminal ISSUE-1 ISSUE-2 ... [--tmux | --ghostty] [--harness codex] [--model MODEL] [--effort LEVEL]
+#   open-terminal ISSUE-1 [--tracker linear|github] [--tmux | --ghostty] [--harness claude] [--model MODEL] [--effort LEVEL]
+#   open-terminal ISSUE-1 ISSUE-2 ... [--tracker linear|github] [--tmux | --ghostty] [--harness codex] [--model MODEL] [--effort LEVEL]
 #   open-terminal <group_id> [--tmux | --ghostty] [--cmd "command {issue}"]
 #
 # Options:
+#   --tracker NAME  Issue tracker lane: linear (default, JIRA-style IDs) or github (numeric IDs)
 #   --harness NAME  Harness to launch: claude, codex, opencode, pi, omp
 #   --model MODEL   Model for this launch/session (defaults per harness)
 #   --effort LEVEL  Effort/thinking for this launch/session (defaults per harness)
@@ -17,7 +18,7 @@
 #   (default)       Auto-detect: tmux if $TMUX set, else ghostty/GUI terminal
 #
 # Environment:
-#   GH_ISSUE_PATTERN          - Regex pattern matching issue IDs (default: "[A-Z]+-[0-9]+")
+#   GH_ISSUE_PATTERN          - Regex pattern matching Linear issue IDs (default: "[A-Z]+-[0-9]+")
 #   FLIGHTDECK_LAUNCH_MODEL   - Default model when --model is omitted
 #   FLIGHTDECK_LAUNCH_EFFORT  - Default effort/thinking when --effort is omitted
 #   OPEN_TERMINAL_NO_BYPASS=1 - Do not pass per-harness permission-bypass flags to spawned
@@ -60,8 +61,9 @@ fi
 # Resolve WORKTREE_CLI from sibling skill
 WORKTREE_CLI="${WORKTREE_CLI:-$SKILLS_DIR/worktree/scripts/worktree}"
 
-# Configurable issue pattern (default: JIRA-style ABC-123)
+# Configurable issue pattern (default: JIRA-style ABC-123 for linear tracker)
 GH_ISSUE_PATTERN="${GH_ISSUE_PATTERN:-[A-Z]+-[0-9]+}"
+TRACKER="linear"
 
 TERMINAL_MODE=""
 HARNESS=""
@@ -72,12 +74,35 @@ CMD_TEMPLATE=""
 MODEL_OVERRIDE=""
 EFFORT_OVERRIDE=""
 
+# Pre-scan tracker so positional numeric args can be interpreted correctly even
+# when callers put `--tracker github` after the issue number.
+SCAN_ARGS=("$@")
+for ((i = 0; i < ${#SCAN_ARGS[@]}; i++)); do
+  case "${SCAN_ARGS[$i]}" in
+    --tracker)
+      if (( i + 1 >= ${#SCAN_ARGS[@]} )); then
+        echo "Error: --tracker requires a value (linear|github)" >&2
+        exit 1
+      fi
+      TRACKER="${SCAN_ARGS[$((i + 1))]}"
+      ;;
+    --tracker=*) TRACKER="${SCAN_ARGS[$i]#--tracker=}" ;;
+  esac
+done
+
+case "$TRACKER" in
+  linear|github) ;;
+  *) echo "Error: invalid --tracker: $TRACKER (expected linear|github)" >&2; exit 1 ;;
+esac
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --tmux) TERMINAL_MODE="tmux"; shift ;;
     --ghostty) TERMINAL_MODE="ghostty"; shift ;;
     --harness) HARNESS="$2"; shift 2 ;;
     --harness=*) HARNESS="${1#--harness=}"; shift ;;
+    --tracker) TRACKER="$2"; shift 2 ;;
+    --tracker=*) TRACKER="${1#--tracker=}"; shift ;;
     --model) MODEL_OVERRIDE="$2"; shift 2 ;;
     --model=*) MODEL_OVERRIDE="${1#--model=}"; shift ;;
     --effort|--thinking) EFFORT_OVERRIDE="$2"; shift 2 ;;
@@ -89,6 +114,7 @@ while [[ $# -gt 0 ]]; do
       echo "Usage: open-terminal ISSUE-1 [ISSUE-2 ...] [options]"
       echo ""
       echo "Options:"
+      echo "  --tracker <name>   Issue tracker lane: linear (default) or github"
       echo "  --harness <name>    Harness to launch: claude, codex, opencode, pi, omp"
       echo "  --model <model>     Model for this launch/session (defaults per harness)"
       echo "  --effort <level>    Effort/thinking level (defaults per harness): minimal, low, medium, high, xhigh, max"
@@ -98,11 +124,13 @@ while [[ $# -gt 0 ]]; do
       echo "  (default terminal)  Auto-detect: tmux if \$TMUX set, else GUI terminal"
       echo ""
       echo "Harness launch commands (with permission bypass enabled by default):"
-      echo "  claude   → claude -n ISSUE --dangerously-skip-permissions --model 'opus[1m]' --effort max '/orchestration start ISSUE'"
-      echo "  codex    → codex -m MODEL -c model_reasoning_effort=EFFORT '\$orchestration start ISSUE'"
-      echo "  opencode → opencode --model MODEL --prompt '/orchestration start ISSUE' (effort unsupported by top-level opencode)"
-      echo "  omp      → omp '/skill:orchestration start ISSUE'"
-      echo "  pi       → pi --model MODEL --thinking EFFORT '/skill:orchestration start ISSUE'"
+      echo "  linear tracker (default) spawns orchestration:"
+      echo "    claude   → claude -n ISSUE --dangerously-skip-permissions --model 'opus[1m]' --effort max '/orchestration start ISSUE'"
+      echo "    codex    → codex -m MODEL -c model_reasoning_effort=EFFORT '\$orchestration start ISSUE'"
+      echo "    opencode → opencode --model MODEL --prompt '/orchestration start ISSUE' (effort unsupported by top-level opencode)"
+      echo "    omp      → omp '/skill:orchestration start ISSUE'"
+      echo "    pi       → pi --model MODEL --thinking EFFORT '/skill:orchestration start ISSUE'"
+      echo "  github tracker spawns Flightdeck github lane: /flightdeck github start N (Pi/OMP: /skill:flightdeck github start N; Codex: \$flightdeck github start N)"
       echo ""
       echo "Recommended defaults for implementation panes:"
       echo "  claude:   --model 'opus[1m]' --effort max"
@@ -111,16 +139,22 @@ while [[ $# -gt 0 ]]; do
       echo "  pi:       --model openai-codex/gpt-5.5 --effort xhigh"
       echo ""
       echo "Environment:"
-      echo "  GH_ISSUE_PATTERN          Regex for issue IDs (default: [A-Z]+-[0-9]+)"
+      echo "  GH_ISSUE_PATTERN          Regex for Linear issue IDs (default: [A-Z]+-[0-9]+)"
       echo "  FLIGHTDECK_LAUNCH_MODEL   Default model when --model is omitted"
       echo "  FLIGHTDECK_LAUNCH_EFFORT  Default effort/thinking when --effort is omitted"
       echo "  OPEN_TERMINAL_NO_BYPASS=1 Disable per-harness permission-bypass flags (default: off)"
       exit 0
       ;;
-    [0-9]*) GROUP_ID="$1"; shift ;;
     *)
-      # Match against configurable issue pattern
-      if echo "$1" | grep -qiE "^${GH_ISSUE_PATTERN}$"; then
+      if [[ "$TRACKER" == "github" ]]; then
+        if [[ "$1" =~ ^[0-9]+$ ]]; then
+          ISSUES+=("$1"); shift
+        else
+          echo "Error: github tracker expects numeric issue IDs: $1" >&2; exit 1
+        fi
+      elif [[ "$1" =~ ^[0-9]+$ ]]; then
+        GROUP_ID="$1"; shift
+      elif echo "$1" | grep -qiE "^${GH_ISSUE_PATTERN}$"; then
         ISSUES+=("$(echo "$1" | tr '[:lower:]' '[:upper:]')"); shift
       else
         echo "Error: unexpected argument: $1" >&2; exit 1
@@ -391,36 +425,55 @@ launch_metadata_json_args() {
 # Env-prefix tokens that mark every flightdeck-spawned pane as managed live
 # in lib/pane-env.sh. Use "${FLIGHTDECK_PANE_ENV[@]}" inside arrays or
 # `flightdeck_pane_env_str` for string-form tmux send-keys paths.
+start_prompt_for_harness() {
+  local issue="$1" harness="$2"
+  if [[ "$TRACKER" == "github" ]]; then
+    case "$harness" in
+      codex) echo "\$flightdeck github start $issue" ;;
+      pi|omp) echo "/skill:flightdeck github start $issue" ;;
+      *) echo "/flightdeck github start $issue" ;;
+    esac
+    return
+  fi
+
+  case "$harness" in
+    codex) echo "\$orchestration start $issue" ;;
+    pi|omp) echo "/skill:orchestration start $issue" ;;
+    *) echo "/orchestration start $issue" ;;
+  esac
+}
+
 detect_start_cmd() {
   local issue="$1"
   if [[ -n "$CMD_TEMPLATE" ]]; then
     echo "${CMD_TEMPLATE//\{issue\}/$issue}"
     return
   fi
-  local cmd=() launch_args=() bypass
+  local cmd=() launch_args=() bypass prompt
   add_launch_args "$HARNESS" launch_args || return 1
   bypass="$(bypass_flag_for_harness "$HARNESS")"
+  prompt="$(start_prompt_for_harness "$issue" "$HARNESS")"
   case "$HARNESS" in
     claude)
       cmd=("${FLIGHTDECK_PANE_ENV[@]}" claude -n "$issue")
       [[ -n "$bypass" ]] && cmd+=("$bypass")
-      cmd+=("${launch_args[@]}" "/orchestration start $issue")
+      cmd+=("${launch_args[@]}" "$prompt")
       shell_join "${cmd[@]}"
       ;;
     codex)
-      cmd=("${FLIGHTDECK_PANE_ENV[@]}" codex "${launch_args[@]}" "\$orchestration start $issue")
+      cmd=("${FLIGHTDECK_PANE_ENV[@]}" codex "${launch_args[@]}" "$prompt")
       shell_join "${cmd[@]}"
       ;;
     opencode)
-      cmd=("${FLIGHTDECK_PANE_ENV[@]}" opencode "${launch_args[@]}" --prompt "/orchestration start $issue")
+      cmd=("${FLIGHTDECK_PANE_ENV[@]}" opencode "${launch_args[@]}" --prompt "$prompt")
       shell_join "${cmd[@]}"
       ;;
     omp)
-      cmd=("${FLIGHTDECK_PANE_ENV[@]}" omp "/skill:orchestration start $issue")
+      cmd=("${FLIGHTDECK_PANE_ENV[@]}" omp "$prompt")
       shell_join "${cmd[@]}"
       ;;
     pi)
-      cmd=("${FLIGHTDECK_PANE_ENV[@]}" pi "${launch_args[@]}" "/skill:orchestration start $issue")
+      cmd=("${FLIGHTDECK_PANE_ENV[@]}" pi "${launch_args[@]}" "$prompt")
       shell_join "${cmd[@]}"
       ;;
     *)        echo "" ;;
@@ -531,9 +584,9 @@ start_oc_server() {
 
 # Step 1: create a session via run --attach with a minimal bootstrap
 # prompt. The bootstrap MUST complete quickly (single short reply) —
-# previously this was `/orchestration start $issue` which triggers the
-# full workflow and blocks past the 60s timeout, hanging the spawn.
-# Orchestration is fired as a backgrounded follow-up after the spawn
+# previously this was the full start prompt, which triggers the
+# workflow and blocks past the 60s timeout, hanging the spawn.
+# The tracker start prompt is fired as a backgrounded follow-up after the spawn
 # completes (see fire_orchestration_async below). Run from the worktree
 # so the session's cwd field reflects the worktree.
 create_oc_session() {
@@ -561,7 +614,7 @@ create_oc_session() {
   echo "$sid"
 }
 
-# Fire `/orchestration start <issue>` as a backgrounded follow-up. This
+# Fire the tracker-specific start prompt as a backgrounded follow-up. This
 # is what actually starts the per-issue agent's work; it can run for
 # minutes and is fire-and-forget from open-terminal's perspective. The
 # user-visible `opencode attach` TUI in step 2 will display the turn
@@ -569,8 +622,8 @@ create_oc_session() {
 # exit and doesn't pollute the launcher's stdio.
 #
 # Env overrides (intended for tests / alt workflows):
-#   FLIGHTDECK_OC_FOLLOWUP_PROMPT — replace the default `/orchestration
-#       start <ISSUE>` prompt entirely. Use literal `__ISSUE__` in the
+#   FLIGHTDECK_OC_FOLLOWUP_PROMPT — replace the default tracker prompt
+#       entirely. Use literal `__ISSUE__` in the
 #       value to substitute the issue id at fire time (multi-issue
 #       spawns share one env, but each issue gets its own substitution).
 #   FLIGHTDECK_OC_SKIP_FOLLOWUP=1 — skip the followup fire entirely;
@@ -586,12 +639,12 @@ fire_orchestration_async() {
   if [[ -n "${FLIGHTDECK_OC_FOLLOWUP_PROMPT:-}" ]]; then
     prompt="${FLIGHTDECK_OC_FOLLOWUP_PROMPT//__ISSUE__/$issue}"
   else
-    prompt="/orchestration start $issue"
+    prompt="$(start_prompt_for_harness "$issue" opencode)"
   fi
   local launch_args=()
   add_launch_args opencode launch_args || return 1
   # FLIGHTDECK_MANAGED=1 also exports into the fire-and-forget
-  # `/orchestration start` invocation so any tool calls (e.g.
+  # tracker start invocation so any tool calls (e.g.
   # merge-pr.md § 5 running flightdeck-mode) see the canonical signal.
   # Outer redirect detaches the subshell's FDs from anything the caller
   # might be capturing — same hazard as start_oc_server.
@@ -714,9 +767,9 @@ spawn_oc_attach_tmux() {
     return 1
   fi
 
-  # Fire the actual orchestration workflow as a backgrounded follow-up.
+  # Fire the actual tracker workflow as a backgrounded follow-up.
   # The bootstrap above only created the session (with a "READY" reply);
-  # this is what kicks off /orchestration start <issue>. Logs to
+  # this is what kicks off the tracker start prompt. Logs to
   # oc-serve-<port>.log.orch so the master can tail if needed.
   fire_orchestration_async "$bin" "http://127.0.0.1:$port" "$sid" "$issue" "$wt_path"
 
@@ -819,11 +872,13 @@ build_claude_channel_cmd() {
   # Canonical flightdeck managed-pane env prefix (see FLIGHTDECK_PANE_ENV
   # near the top of this file).
   local cmd=("${FLIGHTDECK_PANE_ENV[@]}" "$bin" -n "$issue")
+  local prompt
+  prompt="$(start_prompt_for_harness "$issue" claude)"
   local launch_args=()
   [[ -n "$bypass" ]] && cmd+=("$bypass")
   add_launch_args claude launch_args || return 1
   cmd+=("${launch_args[@]}" --session-id "$uuid" --mcp-config "$mcp_path" \
-    --dangerously-load-development-channels server:webhook -- "/orchestration start $issue")
+    --dangerously-load-development-channels server:webhook -- "$prompt")
   shell_join "${cmd[@]}"
 }
 
@@ -961,7 +1016,9 @@ spawn_pi_bridge_tmux() {
   # signal plus the legacy FLIGHTDECK_CHILD_PANE=1 retained for the
   # pi-flightdeck dashboard extension's child-pane widget suppression
   # (issue #8). See FLIGHTDECK_PANE_ENV near the top of this file.
-  cmd=$(shell_join "${FLIGHTDECK_PI_PANE_ENV[@]}" "$pi_bin" "${launch_args[@]}" "${bridge_args[@]}" "/skill:orchestration start $issue")
+  local prompt
+  prompt="$(start_prompt_for_harness "$issue" pi)"
+  cmd=$(shell_join "${FLIGHTDECK_PI_PANE_ENV[@]}" "$pi_bin" "${launch_args[@]}" "${bridge_args[@]}" "$prompt")
 
   # Snapshot existing pi-bridge pids BEFORE spawning so discovery can
   # exclude already-running pi processes in the same worktree (bugs

--- a/skills/flightdeck/workflows/github/close-issue.md
+++ b/skills/flightdeck/workflows/github/close-issue.md
@@ -1,0 +1,144 @@
+# Workflow: `github close-issue` — Recognize Terminal State + Tear Down Pane
+
+Inner pane has signaled it's done. Verify the signal, mark the GitHub issue terminal in master state, close the GitHub issue if the PR merge did not auto-close it, kill the window, leave the registry entry in place for the final report, and let the watch loop's termination check fire.
+
+GitHub issue-mode workflow only. Generic/ad-hoc terminal signals stay in `workflows/shared/session-handle-prompt.md`; `github/watch.md` layers this two-signal verification and safe teardown on top of the generic `workflows/shared/session-watch.md` underlay.
+
+**Inputs**: `<ISSUE_ID>`. Caller (`github/watch.md` § 3) routes here when `pane-poll` returns the `terminal-state-reached` tag.
+
+**Pre-conditions**: issue is registered; pane is alive but signaling completion; the issue agent's own PR / cleanup steps already ran (their output is what we're reading).
+
+**Post-condition**: issue's `state` = `merged` or `aborted` in master state; GitHub issue is closed with reason `completed` if needed; tmux window for the issue is gone; pane registry entry remains for `terminate.md` reporting and final cleanup; completion line emitted.
+
+---
+
+## § 1: Verify Terminal State (Two-Signal Rule)
+
+A single sentinel match is not sufficient — pane output can include words like "MERGED" mid-session (for example, quoting a commit message). Require **at least two independent signals** before tearing down.
+
+**Fast-path — orphaned (worktree gone + PR merged)**: when the registry's `worktree` directory does not exist on disk AND `gh pr view <pr_number>` returns `state: MERGED`, the issue is observably done regardless of pane content. The two-signal rule is satisfied by the worktree-gone + PR-merged pair; skip the buffer-signal accumulation and proceed directly to § 3 with `state = merged`.
+
+Signals (any two):
+
+| Signal | Source |
+|--------|--------|
+| Pane buffer contains `MERGED` banner with a PR reference (`PR #123`) | `tmux capture-pane` |
+| Pane buffer contains explicit "Please end the session" / "session complete" | `tmux capture-pane` |
+| Pane buffer contains destroyed-CWD failure pattern | `tmux capture-pane` (harness-specific — see adapter below) |
+| Pane is idle (harness-specific quiescent indicator) | `tmux capture-pane` (harness-specific) |
+| PR for this issue is `state == MERGED` (or PR was closed without merge) | `gh pr view <PR> --json state` |
+| GitHub issue state is `CLOSED` for this issue | `gh issue view <ISSUE_ID> --json state` |
+
+Implementation:
+
+1. Read pane: `tmux capture-pane -t "${pane_id:-$pane_target}" -p -S -200`. Prefer the stable `pane_id` (`%N`) from the registry over the human-readable `pane_target` — tmux reuses window indices after windows are destroyed, so a stale `pane_target` can after-the-fact point to an unrelated window.
+2. Apply portable buffer signals (banner, end-session text).
+3. Apply harness-specific signals via the adapter for the registered harness:
+   - **Claude Code**: idle indicator `* Idle` on its own line near buffer end; destroyed-CWD pattern includes `Path does not exist` and a path matching the worktree.
+   - Other harnesses: add an adapter in `patterns/tmux-monitoring.md` § Per-harness signals; do not blanket-apply Claude Code's patterns.
+4. Apply external signals: query PR state if `pr_number` is set; query GitHub issue state.
+5. Count matched signals. If `< 2`, return to caller without tearing down — re-poll next cycle. False positive risk is not zero; favor an extra poll over a wrong teardown.
+
+---
+
+## § 2: Determine Outcome
+
+Map signals to terminal state:
+
+- PR state `MERGED` (or buffer banner says `MERGED`) → `state = merged`.
+- PR state `CLOSED` without merge AND GitHub issue state `CLOSED` → `state = aborted`.
+- Pane signals end-of-session but PR state is still `OPEN` and no other signal contradicts → return without teardown; the issue agent may have ended its turn but the merge hasn't actually landed yet. Re-poll.
+
+Capture the outcome's summary fields from the buffer if present (PR number, merge commit, branch deleted-on-remote, etc.) — these go into the GitHub issue end-of-session report (`terminate.md` § 2).
+
+---
+
+## § 3: Close GitHub Issue If Needed
+
+**Skip if** `state != merged`.
+
+1. Query issue state:
+   ```bash
+   gh issue view "$ISSUE_ID" --json state,url
+   ```
+2. If `state == CLOSED`, do nothing; the PR's `Fixes #N` linkage or a user action already closed it.
+3. If `state == OPEN`, close it with completed reason:
+   ```bash
+   gh issue close "$ISSUE_ID" --reason completed
+   ```
+4. If close fails because the issue is already closed or cannot be found after a successful merge, log a warning and continue. If close fails for auth/rate-limit, set `paused_for_user` with the stderr and do not tear down yet.
+
+---
+
+## § 4: Update Master State
+
+```
+.agents/skills/flightdeck/scripts/pane-registry set-state <ISSUE_ID> <merged|aborted>
+.agents/skills/flightdeck/scripts/pane-registry log-decision <ISSUE_ID> terminal-state-reached "<outcome-summary>"
+```
+
+Persist any captured summary fields via `pane-registry set <ISSUE_ID> <field> <value>`.
+
+---
+
+## § 5: Tear Down Window
+
+Delegate the destructive teardown to the registry. **Never** derive a kill target from `pane_target` (`session:window.index`) — tmux reuses window indices after windows are destroyed, so the stored `pane_target` can after-the-fact point to an unrelated window. The registry stores a stable `pane_id` (`%N`) at init time; the helper uses it as the only correct destructive target.
+
+This step runs AFTER § 4 has already written the terminal state (`merged|aborted|dead`). The helper enforces that contract — it will refuse to kill an alive pane whose registry state is non-terminal unless `--force` is passed.
+
+1. Run the safe teardown:
+   ```
+   .agents/skills/flightdeck/scripts/pane-registry teardown-window <ISSUE_ID>
+   ```
+2. Branch on the helper's exit code:
+
+   | Exit | Meaning | Action |
+   |------|---------|--------|
+   | `0` | window/pane killed, OR already closed (terminal + dead pane) | proceed to § 6 |
+   | `1` | issue not registered — already removed by terminate or earlier cleanup | idempotent no-op; proceed to § 6 |
+   | `3` | registry drift: `pane_id` gone but state is non-terminal | log a warning and continue; state from § 4 preserves outcome |
+   | `4` | policy refusal: pane is alive but state is non-terminal | log stderr and abort; do NOT silently rerun with `--force` |
+   | `5` | tmux kill failed: pane is still alive after the kill attempt | forward stderr; user may need to kill manually |
+   | `6` | registry read failure | forward stderr; abort |
+
+3. Verify the window is gone (defensive, skipped on exit 3/4/5/6): `tmux list-panes -a -F '#{pane_id}' | grep -qFx "<pane_id>"` — if the recorded `pane_id` is still alive after a `0` exit, log a warning.
+
+Pane registry entry is left in place for the GitHub issue end-of-session report. Do NOT call `pane-registry remove` here — terminate is responsible for final cleanup.
+
+---
+
+## § 6: Emit Completion Line
+
+Per SKILL.md "Format Tags Are Literal": fill placeholders, omit empty fields, add nothing else.
+
+<output_format>
+[For merged:]
+#[ISSUE_ID] ✅ merged — PR #[N] ([MERGE_COMMIT_SHORT]) — GitHub issue closed — window closed
+
+[For aborted:]
+#[ISSUE_ID] ⨯ aborted — window closed
+</output_format>
+
+Goes through the same channel as the watch loop's other status output.
+
+---
+
+## § 7: Advance Queue
+
+If no panes remain alive (every tracked GitHub issue is in `merged | aborted | dead`):
+
+1. The watch loop's termination check will fire after `FLIGHTDECK_DEBOUNCE_CYCLES` consecutive cycles confirm all-done.
+
+Otherwise, continue normally — the watch loop's § 3 poll will pick up the next active pane on its next pass.
+
+---
+
+## Skip-If
+
+- The two-signal rule was not satisfied → return to `github/watch.md` § 3 without teardown; re-poll next cycle.
+- The issue is already terminal and its window is already gone (or terminate's final cleanup already removed the registry entry) → idempotent; just log and return.
+
+## Returns
+
+To `github/watch.md` § 3 (continue polling remaining panes).

--- a/skills/flightdeck/workflows/github/handle-prompt.md
+++ b/skills/flightdeck/workflows/github/handle-prompt.md
@@ -1,0 +1,153 @@
+# Workflow: `github handle-prompt` — GitHub Issue Prompt Handler
+
+Routes GitHub issue-specific prompt tags for a `kind="issue"` entry. Generic prompt/event tags live in `workflows/shared/session-handle-prompt.md`; `github/watch.md` calls that file first for `oc-question`, `pi-question`, `bash-permission-prompt`, `awaiting-direction`, safe `generic-multi-choice`, `terminal-state-reached`, `pi-bg-task-exit`, and `domain-mismatch` guard handling.
+
+**Inputs**: `<ISSUE_ID>`, `<TAG>` (GitHub issue-only substate from `prompt-classify` or computed by the issue workflow), captured buffer or structured event details.
+
+**Pre-conditions**: master state initialized; `<ISSUE_ID>` is registered as `kind="issue"`; state is `prompting`; GitHub-mode skills (`github`, `worktree`) are available.
+
+**Post-condition**: a response was sent and decision logged, issue state/domain fields were updated, or `master_state.paused_for_user` is set and the watch loop yields.
+
+---
+
+## § 1: Domain guard and lookup
+
+Read the normalized issue entry:
+
+```bash
+ENTRY_JSON=$(.agents/skills/flightdeck/scripts/pane-registry list --format json \
+  | jq -c --arg id "<ISSUE_ID>" '.[] | select((.id // .issue) == $id)')
+```
+
+Require `kind == "issue"`. If this handler is invoked for `kind=adhoc` or `kind=workflow`, treat it as a bug in the caller: log `domain-mismatch`, take no destructive action, set `paused_for_user`, and return.
+
+Use `pane_target`, `pane_id`, `worktree`, `domain.issue.pr_number`, and adapter metadata from `ENTRY_JSON`. Legacy `pane-registry get <ISSUE_ID>` remains a compatibility read, but new logic should prefer normalized entries.
+
+---
+
+## § 2: Handler — `cleanup-prompt`
+
+Some agents propose cleanup of multiple worktrees. GitHub issue mode may clean only the asking issue's own worktree.
+
+1. Extract the target worktree path from the prompt buffer.
+2. Compare it to `domain.issue.worktree` from the registry.
+3. Equal → answer the affirmative option (usually `--option 1`).
+4. Not equal → answer the negative/keep option or send a scope-to-self payload.
+5. Log `cleanup-prompt <answer>`.
+
+---
+
+## § 3: Handler — `bot-review-wait-stuck` and issue `pi-bg-task-exit` continuation
+
+Master does not re-invoke long-running waiters inside the pane. It observes PR state and nudges the issue agent.
+
+1. Query:
+   ```bash
+   gh pr view <PR> --json statusCheckRollup,reviewDecision,latestReviews,labels,mergeStateStatus,state
+   ```
+2. Parse bot check conclusion, review decision, status checks, and latest human reviews.
+3. Decision matrix:
+   - Bot check `SUCCESS`, all required CI checks green, and `reviewDecision == APPROVED` (or no reviewers required) → answer `Skip` / continue.
+   - `CHANGES_REQUESTED` → instruct the pane to address review feedback.
+   - CI failed → instruct the pane to inspect failing jobs and fix.
+   - Bot or CI still pending but elapsed beyond threshold → escalate with observed state.
+   - Real human reviewer pending → escalate.
+4. Log decision.
+
+When `session-handle-prompt.md` handles `pi-bg-task-exit` for an issue entry and the task command is `bot-review-wait`, `ci-wait`, or another PR waiter, resume here to recover downstream PR/CI/review state before deciding whether to nudge or escalate.
+
+---
+
+## § 4: Handler — `rebase-multi-choice`
+
+The issue agent is asking how to resolve conflicts.
+
+1. Identify the upstream merged PR or default-branch change whose code must be preserved.
+2. Gather **PRESERVE** details from the upstream diff: signatures, wrappers, parameters, and behavior that must not be reverted.
+3. Gather **APPLY** details from the current issue's PR/branch: field renames, type updates, and intended local refactors.
+4. Choose **VERIFY** commands that prove both sides are intact.
+5. Compose a single payload containing the selected option plus the preserve/apply/verify triplet.
+6. Send via `pane-respond <pane_target> "<payload>" --tag rebase-multi-choice`.
+7. Log decision.
+
+---
+
+## § 5: Handler — `force-push-prompt`
+
+Auto-approve only bounded force-pushes.
+
+All must be true:
+
+1. The command uses `--force-with-lease`, not raw `--force`.
+2. No other in-flight session depends on this branch/ref.
+3. The remote tip belongs to the current issue agent identity; no foreign commits would be dropped.
+
+If satisfied, answer the affirmative option. Otherwise set `paused_for_user` with the failing predicate.
+
+---
+
+## § 6: Handler — `merge-now`
+
+The issue agent has already checked review, CI, branch protection, and thread gates. Master adds cross-session awareness and one final PR state read.
+
+1. Re-fetch current PR state:
+   ```bash
+   gh pr view <PR> --json state,mergeStateStatus,reviewDecision,statusCheckRollup,files,labels
+   ```
+2. Compare this PR's files against other live unmerged PRs from tracked GitHub issue entries. If files overlap, escalate.
+3. If no overlap and the PR is approved with all required checks green, answer `Merge`.
+4. If the prompt asks for a force/admin merge while merge state is still `UNKNOWN`, defer to § 7.
+5. If checks failed, review requested changes, or merge state is dirty/behind, answer the safe wait/fix option when present; otherwise escalate.
+6. Log decision.
+
+`FLIGHTDECK_AUTO_MERGE=0` escalates this prompt unconditionally.
+
+---
+
+## § 7: Handler — `force-merge-confirm`
+
+See `patterns/conflict-detection.md`.
+
+1. Record or read `unknown_since`.
+2. Re-fetch PR state immediately before deciding.
+3. Force-merge predicate:
+   - review decision approved;
+   - all checks are `SUCCESS` or `SKIPPED`, none failed;
+   - `unknown_since` elapsed ≥ `FLIGHTDECK_FORCE_MERGE_AFTER_SECS`;
+   - PR files are disjoint from recent default-branch changes and other live tracked PRs.
+4. Predicate true → answer the force-merge option.
+5. Predicate false and elapsed below threshold → answer wait.
+6. Predicate false after threshold or state flips to dirty/behind with overlap → escalate.
+7. Log decision.
+
+---
+
+## § 8: Handler — `multi-select-tabbed`
+
+Tabbed checkbox prompts are GitHub issue-specific only when their choices reference PR review fixes, CI actions, rebase choices, force-push choices, cleanup scope, or merge actions.
+
+1. Parse visible checkbox rows and tabs.
+2. Apply the matching GitHub policy above (review/CI continuation, cleanup, rebase, force-push, or merge gating).
+3. Send through `pane-respond --option-multi` / `--keys` as required by the harness.
+4. Log selected rows.
+
+If the checkbox prompt is generic and safe, it should be reclassified/handled as a generic prompt in `session-handle-prompt.md`; otherwise escalate.
+
+---
+
+## § 9: GitHub-mode extension for `bash-permission-prompt`
+
+Generic permission handling lives in `session-handle-prompt.md`. If the only reason generic handling would escalate is a GitHub-domain read-only command, GitHub mode may extend the allowlist with:
+
+| Pattern | Why safe in GitHub issue mode |
+|---------|-------------------------------|
+| `^gh (pr (view|list|files|diff|checks)|issue view|run (list|view))` | Read-only GitHub inspection. |
+| `^\.agents/skills/github/scripts/github\.sh (pr-data|pr-view|pr-threads|pr-review-status|pr-list-ready|pr-list-failing|pr-issue|await-mergeable|ci-logs|sticky-comment)` | Read-only GitHub wrapper inspection. |
+
+Do not approve writes to the default branch, destructive git operations, force pushes, branch deletion, worktree removal, issue closure, or merge commands through a bash permission prompt. Those must surface as their specific GitHub issue tags.
+
+---
+
+## Returns
+
+To `github/watch.md` § 4 for sequential GitHub issue routing, then back to the generic ack/yield path in `session-watch.md`.

--- a/skills/flightdeck/workflows/github/start-new.md
+++ b/skills/flightdeck/workflows/github/start-new.md
@@ -1,0 +1,87 @@
+# Workflow: `github start new` — Create GitHub Issue + Launch
+
+Create a new GitHub issue, set up a worktree, and launch a GitHub issue session.
+
+## Inputs
+
+| Command | Flow |
+|---------|------|
+| `github start new` | § 1 → § 2 → § 3 |
+| `github start new [TITLE]` | Skip title prompt → § 1 step 2 → § 2 → § 3 |
+
+---
+
+## 1. Gather Intent
+
+1. **If title provided** as argument → set `TITLE`, skip to step 2.
+
+   **Otherwise** → Ask user: "What do you want to work on?" (free text).
+
+   Parse response: first line = `TITLE`, rest = `DESCRIPTION_NOTES`.
+
+2. **Ask user**: "Brief description? (or press enter to skip)".
+
+   If response provided → append to `DESCRIPTION_NOTES`.
+
+3. **Ask user** for optional labels if the repo uses them: `No labels` | `Add labels`.
+
+   If `Add labels`, capture comma-separated label names for `gh issue create --label`.
+
+---
+
+## 2. Create Issue
+
+### 2.1 Build Body
+
+Create a concise body from `DESCRIPTION_NOTES`:
+
+```markdown
+## Summary
+
+[DESCRIPTION_NOTES or "Scope TBD."]
+
+## Acceptance Criteria
+
+- [ ] Implementation complete
+- [ ] Tests/validation complete
+- [ ] PR links this issue with `Fixes #[ISSUE_NUMBER]`
+```
+
+### 2.2 Create GitHub Issue
+
+Run:
+
+```bash
+gh issue create --title "$TITLE" --body-file "$BODY_FILE" [--label "LABELS"]
+```
+
+Capture the returned URL, then resolve the issue number:
+
+```bash
+ISSUE_ID=$(printf '%s\n' "$ISSUE_URL" | sed -E 's#.*/issues/([0-9]+).*#\1#')
+gh issue view "$ISSUE_ID" --json number,title,state,url,labels
+```
+
+If `gh issue create` fails, stop and surface stderr.
+
+### 2.3 Output
+
+<output_format>
+GitHub issue created: #[ISSUE_ID] — [TITLE]
+URL: [URL]
+Labels: [LABELS or none]
+</output_format>
+
+---
+
+## 3. Create Worktree & Launch
+
+Invoke `⤵ workflows/github/start.md [ISSUE_ID] § 1-4 → end`.
+
+The nested start workflow owns worktree checks, launch-profile selection, `open-terminal --tracker github`, and entry into `workflows/github/watch.md`.
+
+---
+
+## Returns
+
+To the GitHub issue watch loop if launched, or to the user if manual launch was selected.

--- a/skills/flightdeck/workflows/github/start.md
+++ b/skills/flightdeck/workflows/github/start.md
@@ -1,0 +1,161 @@
+# Workflow: `github start` — GitHub Issue Session Entry
+
+Initialize a GitHub issue session, verify status, create/reuse the issue worktree, spawn the selected harness, and enter the GitHub issue watch loop.
+
+This is the GitHub issue-mode start workflow. For ad-hoc or workflow sessions that are not tied to a GitHub issue/worktree, use `scripts/flightdeck-session start` or `flightdeck session start`, then supervise with `workflows/shared/session-watch.md` and `workflows/shared/session-handle-prompt.md`.
+
+## Inputs
+
+| Command | Flow |
+|---------|------|
+| `github start <N>` | § 1 → § 2 → § 3 → § 4 |
+
+**Required**: `<N>` is a numeric GitHub issue number.
+
+---
+
+## 1. Initialize Session
+
+### 1.1 Validate Issue Argument
+
+1. Require a single numeric GitHub issue number.
+2. If missing or non-numeric, ask the user for the issue number or stop with a concise error.
+3. Set `ISSUE_ID=<N>`.
+
+### 1.2 Present Preflight Status
+
+1. **Run**: `FLIGHTDECK_PREFLIGHT=1 .agents/skills/flightdeck/scripts/flightdeck-dashboard launch`
+
+   This verifies a live tracked `flightdeck-dashboard` entry/pane and ignores stale same-name windows. `FLIGHTDECK_DASHBOARD=0` is the only explicit opt-out.
+
+2. **If dashboard launch fails**, surface stderr and stop. Do not spawn an issue pane when the dashboard invariant is not satisfied.
+
+3. **Check GitHub CLI auth**:
+   ```bash
+   gh auth status
+   ```
+   If auth fails, stop and tell the user to authenticate `gh` before continuing.
+
+### 1.3 Fetch Issue
+
+Fetch authoritative issue data:
+
+```bash
+gh issue view "$ISSUE_ID" --json number,title,state,body,url,labels,assignees,milestone,closed,closedAt
+```
+
+1. If the issue does not exist, stop.
+2. If `state == CLOSED`, present:
+
+   <output_format>
+   GitHub issue #[ISSUE_ID] is already closed: [TITLE]
+   URL: [URL]
+   </output_format>
+
+   Ask: `Watch existing PR/session anyway` | `Stop`. Only continue on explicit watch/spawn confirmation.
+3. Store the issue title, URL, labels, and body excerpt for the launch summary.
+
+---
+
+## 2. Prepare Worktree
+
+### 2.1 Check Main Worktree Cleanliness
+
+1. **Run check**:
+   ```bash
+   .agents/skills/worktree/scripts/worktree check
+   ```
+
+2. **If uncommitted** → Ask user: `Stash` | `Commit` | `Continue anyway`.
+
+3. **If unpushed** → Ask user: `Push unpushed commits to the default branch?` (show commits), then:
+   ```bash
+   DEFAULT_BRANCH=${WORKTREE_DEFAULT_BRANCH:-$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')}
+   [ -n "$DEFAULT_BRANCH" ] || DEFAULT_BRANCH=main
+   git push origin "$DEFAULT_BRANCH"
+   ```
+
+### 2.2 Active Work Conflict Scan
+
+1. List active worktrees:
+   ```bash
+   .agents/skills/worktree/scripts/worktree list
+   ```
+2. If another live Flightdeck entry is working on the same issue number, stop and point to the existing entry.
+3. If another live entry has an open PR touching the same files, do not block here; the `github watch` prompt handlers re-check PR state before merge/force-push decisions.
+
+### 2.3 Create Worktree
+
+Worktree creation is idempotent: existing worktrees are reused and rebased onto the default branch.
+
+```bash
+WT_PATH=$(.agents/skills/worktree/scripts/worktree create "$ISSUE_ID")
+```
+
+If the helper reports rebase conflicts, stop and tell the user to resolve or remove the worktree before retrying.
+
+---
+
+## 3. Select Launch Profile
+
+Use this whenever § 4 launches a pane through `open-terminal`.
+
+1. **Recommend a default profile** by issue complexity:
+
+   | Work type | Recommended profile | Command flags |
+   |-----------|---------------------|---------------|
+   | Normal/complex implementation | Claude Code, strongest reasoning | `--harness claude --model 'opus[1m]' --effort max` |
+   | OpenAI/Codex-preferred implementation | Codex, strongest reasoning | `--harness codex --model gpt-5.5 --effort xhigh` |
+   | Pi-native work | Pi, strongest OpenAI reasoning | `--harness pi --model openai-codex/gpt-5.5 --effort xhigh` |
+   | OpenCode-preferred implementation | OpenCode, strong model (effort recorded unsupported) | `--harness opencode --model openai/gpt-5.5 --effort xhigh` |
+
+   Notes:
+   - `open-terminal` maps effort per harness: Claude → `--effort`, Codex → `-c model_reasoning_effort=...`, Pi → `--thinking`. OpenCode validates the model via `opencode models`, passes `--model`, and records effort as unsupported because no validated top-level effort flag exists.
+   - If the user chooses a model/effort different from the recommendation, pass exactly their values.
+   - Do not choose bare harness defaults for a fresh LLM pane; subagents generated with model/effort definitions are exempt.
+
+2. **Ask user** for launch profile. Include the recommendation first, then: `Claude max` | `Codex xhigh` | `Pi xhigh` | `OpenCode xhigh` | `I'll launch it myself` | custom model/effort.
+
+3. **Capture** `[HARNESS]`, optional `[MODEL]`, optional `[EFFORT]`. Build `[LAUNCH_FLAGS]` as:
+   ```bash
+   --harness [HARNESS] [--model MODEL] [--effort EFFORT]
+   ```
+
+---
+
+## 4. Launch and Watch
+
+### 4.1 Present Launch Summary
+
+<output_format>
+GitHub issue #[ISSUE_ID] — [TITLE]
+URL: [URL]
+Worktree: [WT_PATH]
+Harness: [HARNESS]
+Model: [MODEL or default]
+Effort: [EFFORT or default]
+</output_format>
+
+### 4.2 Spawn
+
+- **Profile selected**:
+  ```bash
+  .agents/skills/flightdeck/scripts/open-terminal --tracker github "$ISSUE_ID" [LAUNCH_FLAGS]
+  ```
+  Then invoke `⤵ workflows/github/watch.md [ISSUE_ID] § 1-8 → § 1`.
+
+- **Manual**: Show the recommended command and worktree path so the user can run it themselves:
+  ```bash
+  .agents/skills/flightdeck/scripts/open-terminal --tracker github "$ISSUE_ID" [LAUNCH_FLAGS]
+  ```
+  Then return to the user.
+
+### 4.3 Watch Loop Entry
+
+`workflows/github/watch.md § 1` registers or refreshes the numeric issue entry, then runs `workflows/shared/session-watch.md` for daemon spawn/ack/yield. Do not duplicate the generic loop here.
+
+---
+
+## Returns
+
+To the GitHub issue watch loop. The watch loop handles prompts, terminal verification, teardown, and final summary.

--- a/skills/flightdeck/workflows/github/terminate.md
+++ b/skills/flightdeck/workflows/github/terminate.md
@@ -1,0 +1,268 @@
+# Workflow: `github terminate` — Final Summary + GitHub Issue Unwind
+
+End-of-session unwind for GitHub issue sessions. Routes by tracked-entry kind, writes the summary file, marks master state terminated, archives state, and returns control to flightdeck's session loop. GitHub issue entries produce PR/issue/worktree outcomes; ad-hoc/workflow entries get a generic session summary with no issue-system side effects.
+
+Mode-aware boundary workflow. Generic-only sessions arrive from `workflows/shared/session-watch.md` / `workflows/shared/session-handle-prompt.md`; GitHub issue sessions arrive through `workflows/github/watch.md`, which adds PR state, GitHub issue closure, and worktree cleanup recommendations.
+
+**Inputs**: master state after debounce confirms every tracked entry is terminal enough to end the session.
+
+**Pre-conditions**:
+- `session-watch.md` confirmed generic entries are `complete | cancelled | dead` (or intentionally removed from active watch).
+- When GitHub issue entries exist, `github/watch.md` § 7 confirmed every tracked issue is terminal (`merged | aborted | dead`) across consecutive poll cycles.
+
+**Post-condition**: `tmp/flightdeck-summary-<SESSION>-<TS>.md` written; `master_state.terminated = true`; user-visible summary block(s) emitted; live state archived.
+
+---
+
+## § 0: Partition tracked entries by kind
+
+Read through the normalized TrackedEntry seam:
+
+```bash
+ENTRIES_JSON=$(flightdeck-state tracked-entries)
+```
+
+Partition tracked entries by kind:
+
+- `ISSUE_ENTRIES`: entries with `kind == "issue"`, `domain.issue.id`, or issue-shaped markers.
+- `GENERIC_ENTRIES`: entries with `kind == "adhoc"`, `kind == "workflow"`, or a future non-issue kind and **no** issue-shaped markers.
+
+Issue-shaped markers are: issue-domain `pr_number`, `worktree`, `merge_commit`, `scope_files_declared`, `scope_files_actual`; issue-only states (`merge-ready`, `merged`, `aborted`); or GitHub issue-only substates (`merge-now`, `bot-review-wait-stuck`, `rebase-multi-choice`, `force-push-prompt`, `cleanup-prompt`, `force-merge-confirm`). If any marker appears without `kind == "issue"` / `domain.issue.id`, emit a warning naming the entry id and markers, then route through `ISSUE_ENTRIES`. This fails closed so malformed issue-shaped entries cannot silently skip PR/issue history.
+
+Routing rules:
+
+1. If `ISSUE_ENTRIES` is non-empty, run the GitHub issue summary path (§§ 2-4).
+2. If `ISSUE_ENTRIES` is empty and `GENERIC_ENTRIES` is non-empty, run only the generic session summary path (§ 1). Do not call `gh` or worktree helpers.
+3. If both partitions are empty, write the empty-session summary in § 1 and continue finalization. This is an explicit diagnostic, not a silent success.
+4. For mixed sessions, run both paths: generic session summary for `GENERIC_ENTRIES`, then GitHub issue summary for `ISSUE_ENTRIES`.
+
+---
+
+## § 1: Compose Generic Session Outcomes
+
+**Skip this section** when `GENERIC_ENTRIES` is empty and `ISSUE_ENTRIES` is non-empty. **Run this section** for an empty tracked-entry set to emit the explicit empty-session diagnostic.
+
+For each generic entry, gather only local state:
+
+| Field | Source |
+|-------|--------|
+| `id` | entry id |
+| `title` | entry title, fallback id |
+| `kind` | entry kind (`adhoc`, `workflow`, or future non-issue kind) |
+| `state` | `complete | cancelled | dead | ready | ...` |
+| `harness` | entry harness |
+| `time_elapsed` | `now - entry.spawned_at`, fallback session elapsed |
+| `decisions_count` | length of `decisions_log` |
+| `last_prompt` | latest `decisions_log[-1].prompt_tag`, if any |
+| `last_answer` | latest `decisions_log[-1].answer`, if any |
+
+Generic sessions must not query GitHub, PR state, or worktree metadata. They do not produce issue closure, PR outcomes, or cleanup recommendations. If there are zero tracked entries, write `Session terminated with no tracked entries.` plus zero counts.
+
+---
+
+## § 2: Compose Per-Issue Outcomes
+
+**Skip this section** when `ISSUE_ENTRIES` is empty.
+
+For each GitHub issue entry, gather:
+
+| Field | Source |
+|-------|--------|
+| `id` | `domain.issue.id` or entry id |
+| `title` | `gh issue view <N> --json title`, fallback entry title |
+| `issue_state` | `gh issue view <N> --json state` |
+| `state` | `merged | aborted | dead` |
+| `pr_number` | `domain.issue.pr_number` |
+| `pr_state` | `gh pr view <PR> --json state` when PR exists |
+| `merge_commit` | cached `domain.issue.merge_commit`; if missing and `state == merged`, `gh pr view <PR> --json mergeCommit` |
+| `time_elapsed` | `now - spawned_at` per issue, fallback session elapsed |
+| `decisions_count` | length of `decisions_log` |
+| `scope_files_actual` | `domain.issue.scope_files_actual`; if missing and PR exists, fetch from `gh pr view --json files` |
+
+GitHub-mode lookups may use `github` wrappers, `gh`, and `worktree` because § 0 already proved at least one tracked issue exists.
+
+---
+
+## § 3: Compose Follow-Up Issue Report
+
+**Skip this section** when `ISSUE_ENTRIES` is empty.
+
+Walk every issue entry's `decisions_log` for entries that captured created GitHub issue numbers during the session. For each captured issue, gather:
+
+| Field | Source |
+|-------|--------|
+| `id` | created GitHub issue number |
+| `title` | `gh issue view <N> --json title` |
+| `state` | `gh issue view <N> --json state` |
+| `url` | `gh issue view <N> --json url` |
+| `creating_session_issue` | which tracked issue caused the follow-up |
+| `reason` | captured one-line reason from decision log |
+
+If no follow-up issues were captured, omit the follow-up issue table from user-visible output.
+
+---
+
+## § 4: Compose Worktree Cleanup Recommendations
+
+**Skip this section** when `ISSUE_ENTRIES` is empty.
+
+For each GitHub issue entry, gather:
+
+| Field | Source |
+|-------|--------|
+| `worktree` | `domain.issue.worktree` |
+| `branch` | `entry.branch` or `git -C <worktree> branch --show-current` if worktree exists |
+| `remote_branch` | PR head ref from `gh pr view <PR> --json headRefName` |
+| `safe_to_remove` | `state == merged` and PR state is `MERGED` and issue state is `CLOSED` |
+
+Recommendations:
+
+1. `safe_to_remove == true` → recommend normal worktree cleanup through the worktree helper.
+2. `state == aborted` → recommend manual inspection before cleanup.
+3. `state == dead` → recommend inspecting the pane/worktree before cleanup.
+4. Do not run destructive cleanup here; this workflow reports only.
+
+---
+
+## § 5: Write Summary File
+
+Emit to `tmp/flightdeck-summary-<SESSION>-<TS>.md` (TS = ISO8601, no colons).
+
+For generic-only sessions or empty sessions, write:
+
+```markdown
+# Flightdeck Session Summary — <SESSION> — <ISO8601>
+
+## Tracked Sessions
+| Entry | Kind | State | Harness | Elapsed | Decisions | Last prompt | Answer |
+|-------|------|-------|---------|---------|-----------|-------------|--------|
+| ...
+
+If no tracked entries exist, write this instead of the table rows:
+
+Session terminated with no tracked entries.
+
+## Counts
+- Sessions: <N>
+- Complete: <N>
+- Cancelled: <N>
+- Dead: <N>
+```
+
+When GitHub issue entries exist, append the GitHub issue sections after any generic section:
+
+```markdown
+## GitHub Issue Outcomes
+| Issue | Title | State | GitHub State | PR | PR State | Merge Commit | Elapsed | Decisions |
+|-------|-------|-------|--------------|----|----------|--------------|---------|-----------|
+| ...
+
+## Follow-Up Issues Created
+| Issue | Title | State | Created From | Reason |
+|-------|-------|-------|--------------|--------|
+| ...
+
+## Worktree Cleanup Recommendations
+| Issue | Worktree | Branch | Recommendation |
+|-------|----------|--------|----------------|
+| ...
+
+## GitHub Issue Counts
+- Merged: <N>
+- Aborted: <N>
+- Dead: <N>
+- Follow-ups: <N>
+- Cleanup ready: <N>
+```
+
+---
+
+## § 6: Finalize Master State
+
+```
+flightdeck-state set terminated true
+flightdeck-state set terminated_at "\"<ISO8601>\""
+flightdeck-state set summary_path "\"<tmp/flightdeck-summary-<SESSION>-<TS>.md>\""
+flightdeck-daemon stop --session "$SESSION"
+flightdeck-state archive
+```
+
+Do NOT remove terminal entries before archive. The archive preserves the full `.entries` map for post-mortem inspection and dashboard rendering.
+
+---
+
+## § 7: User-Visible Output
+
+Emit the full applicable summary block(s) inline. Do not collapse to a single line. Per SKILL.md "Format Tags Are Literal": fill placeholders, omit empty sections, add nothing else.
+
+For generic entries, emit this block when `GENERIC_ENTRIES` is non-empty:
+
+<generic_output_format>
+### ✈️ Flightdeck sessions complete
+
+**Tracked sessions**
+
+| Entry | Kind | State | Harness | Decisions |
+|-------|------|-------|---------|-----------|
+| [ENTRY_ID] | [adhoc|workflow|other] | [complete|cancelled|dead|ready|...] | [HARNESS] | [N] |
+
+**Counts**: [N] sessions · [N] complete · [N] cancelled · [N] dead
+
+Summary file: `tmp/flightdeck-summary-<SESSION>-<TS>.md`
+</generic_output_format>
+
+If no tracked entries exist, emit this explicit diagnostic block:
+
+<empty_output_format>
+### ✈️ Flightdeck session complete
+
+Session terminated with no tracked entries.
+
+**Counts**: 0 sessions · 0 complete · 0 cancelled · 0 dead
+
+Summary file: `tmp/flightdeck-summary-<SESSION>-<TS>.md`
+</empty_output_format>
+
+For GitHub issue entries, emit this block only when `ISSUE_ENTRIES` is non-empty:
+
+<github_issue_output_format>
+### ✈️ Flightdeck GitHub session complete
+
+**Outcomes**
+
+| Issue | Title | State | GitHub state | PR | PR state | Merge commit | Decisions |
+|-------|-------|-------|--------------|----|----------|--------------|-----------|
+| #[ISSUE_ID] | [TITLE] | [merged | aborted | dead] | [OPEN|CLOSED|—] | #[N] | [MERGED|CLOSED|OPEN|—] | [SHORT_SHA] | [N] |
+
+**Follow-up issues created this session**
+
+| Issue | Title | State | Created from | Reason |
+|-------|-------|-------|--------------|--------|
+| #[ISSUE_ID] | [TITLE] | [OPEN|CLOSED] | #[SOURCE_ISSUE] | [REASON] |
+
+**Worktree cleanup recommendations**
+
+| Issue | Worktree | Branch | Recommendation |
+|-------|----------|--------|----------------|
+| #[ISSUE_ID] | [PATH] | [BRANCH] | [SAFE_TO_REMOVE or INSPECT_FIRST] |
+
+**Counts**: [N] merged · [N] aborted · [N] dead · [N] follow-ups · [N] cleanup ready
+
+Summary file: `tmp/flightdeck-summary-<SESSION>-<TS>.md`
+</github_issue_output_format>
+
+For mixed sessions, emit `<generic_output_format>` first, then `<github_issue_output_format>`. For empty sessions, emit only `<empty_output_format>`. Sections with no data (for example, no follow-up issues) are omitted entirely per the format-tags rule. Never substitute a one-liner.
+
+---
+
+## § 8: Pane Lifecycle
+
+Do **not** close any additional panes here. Terminal GitHub issue windows were already closed by `close-issue.md` after the two-signal check; generic/ad-hoc windows remain available for transcript inspection or manual resume unless the user explicitly runs `session stop` / `session remove`.
+
+§ 6's `flightdeck-state archive` rotated the live state away, so a subsequent `github start` (or `github watch`) in the same tmux session creates a fresh master-state file — no stale entries or `terminated` flag carryover. Past sessions remain inspectable via `tmp/flightdeck-state-<SESSION>-<TS>.json.archive` and the summary file.
+
+---
+
+## Returns
+
+To flightdeck's session loop (`workflows/github/start.md` or `workflows/shared/session-watch.md`), after summary emission and state archive.

--- a/skills/flightdeck/workflows/github/watch.md
+++ b/skills/flightdeck/workflows/github/watch.md
@@ -1,0 +1,186 @@
+# Workflow: `github watch` — GitHub Issue-Mode Extension
+
+GitHub issue-mode master loop. It extends the generic `workflows/shared/session-watch.md` loop with PR/CI/review decisions and the GitHub issue lifecycle states.
+
+**Inputs**: `[ISSUE_NUMBERS]` from `github start`, or an existing Flightdeck state file on compaction recovery.
+
+**Pre-conditions**:
+- `$TMUX` set.
+- `workflows/shared/session-watch.md` is the core loop for state init, entry reconciliation, daemon startup, polling, generic prompt routing, and ack/yield.
+- GitHub-mode skills are loaded now: `github` and `worktree`. Generic `session-watch.md` does not load or require them.
+- `[ISSUE_NUMBERS]` non-empty or `tmp/flightdeck-state-<SESSION>.json` exists.
+
+**Post-condition**: GitHub issue entries reach a terminal issue outcome (`merged`, `aborted`, or `dead`), `terminate.md` writes the GitHub summary, and control returns to the watch loop.
+
+---
+
+## § 0: Enter through the generic loop
+
+Run `⤵ workflows/shared/session-watch.md` for the common mechanics:
+
+1. Initialize/resume master state.
+2. Reconcile entries through `flightdeck-state tracked-entries` / `pane-registry list --format json`.
+3. Spawn/attach `flightdeck-daemon`.
+4. Poll each non-terminal entry with `pane-poll --batch -`.
+5. Route generic prompts to `session-handle-prompt.md`.
+6. Ack and yield.
+
+GitHub mode adds the sections below before/after those generic steps. Do not duplicate generic daemon or prompt-loop logic here.
+
+---
+
+## § 1: Register / refresh GitHub issue entries
+
+For each `ISSUE_ID` in the spawn batch, ensure a `kind="issue"` entry exists. Numeric issue ids are used as entry ids.
+
+1. Require `ISSUE_ID` to match `^[0-9]+$`.
+2. Look up the spawned window by issue id (window name from `open-terminal --tracker github`).
+3. Determine harness, worktree, pane index, stable `%pane_id`, and adapter metadata.
+4. Fetch issue metadata for display and validation:
+   ```bash
+   gh issue view "$ISSUE_ID" --json number,title,state,url,labels,closed,closedAt
+   ```
+5. Register through the issue alias or explicit entry path:
+   ```bash
+   .agents/skills/flightdeck/scripts/pane-registry init "$ISSUE_ID" \
+     --window <window-name> --harness <h> --worktree <path> --pane-index <N>
+   ```
+   This writes `.entries[ISSUE_ID]` with `kind="issue"` and GitHub issue metadata under `domain.issue`.
+6. If resuming, do not overwrite existing decisions or domain fields; reconcile only liveness and pane metadata.
+
+---
+
+## § 2: GitHub issue state mapping
+
+The generic state enum is canonical. GitHub issue-mode entries may carry one of the issue-specific lifecycle states directly in `state`; renderers treat them as terminal/near-terminal alongside the generic enum.
+
+| GitHub issue-mode state | Generic equivalent | Domain fields |
+|-------------------------|--------------------|---------------|
+| `waiting` | `waiting` | unchanged |
+| `prompting` | `prompting` | `substate=<tag>` |
+| `submitting` | `submitting` | issue agent is working |
+| `merge-ready` | `ready` | `domain.issue.phase = "merge-ready"` |
+| `merged` | `complete` | `domain.issue.outcome = "merged"` |
+| `aborted` | `cancelled` | `domain.issue.outcome = "aborted"` |
+| `dead` | `dead` | pane/window lost |
+
+GitHub workflows write `state` as `merge-ready` / `merged` / `aborted` and set the matching `domain.issue.phase` or `domain.issue.outcome`. Generic readers treat `domain.issue.phase / outcome` as the issue-specific extension.
+
+---
+
+## § 3: GitHub poll additions
+
+During `session-watch.md` § 2, GitHub issue entries add these checks after generic structured events and before GitHub handler routing:
+
+GitHub mode extends the generic `POLL_INPUT` with issue-domain metadata for `pane-poll` orphan terminal cross-checks and PR/worktree-aware handlers:
+
+```bash
+POLL_INPUT=$(jq '[.[]
+  | select((.state // "waiting") as $s | ["waiting","prompting","submitting","ready","merge-ready"] | index($s))
+  | {id, kind, issue, pane_id, pane_target, harness, cwd, worktree, pr_number,
+      oc_url, oc_session_id, cc_url, cc_transcript,
+      pi_bridge_pid, pi_bridge_socket, cx_ws, cx_thread_id}
+]' <<< "$REGISTRY_JSON")
+```
+
+1. **Start check** — if `domain.issue.orchestration_started` is false, look for `tmp/workflow-state-<ISSUE>.json`. If absent beyond `FLIGHTDECK_HIJACK_GRACE_SECS` (default 90), set `paused_for_user = {issue_id, reason: "issue-agent-never-started", prompt_text: ...}`.
+2. **GitHub issue-only tags** — route only when `kind == "issue"`. Tags include:
+   - `cleanup-prompt`
+   - `bot-review-wait-stuck`
+   - `rebase-multi-choice`
+   - `force-push-prompt`
+   - `merge-now`
+   - `force-merge-confirm`
+   - `multi-select-tabbed`
+3. **Domain guard** — if an issue-only tag appears on `kind=adhoc` or any non-issue entry, `prompt-classify --entry-kind` / `pane-poll` reports `domain-mismatch`. Log a warning, do not run GitHub handlers, and surface a master question through `paused_for_user`.
+4. **Generic tags on issue entries** — `oc-question`, `pi-question`, `bash-permission-prompt`, `awaiting-direction`, safe `generic-multi-choice`, `terminal-state-reached`, and `pi-bg-task-exit` first route through `session-handle-prompt.md`. After it returns, resume this GitHub issue loop with domain state intact.
+
+`terminal-state-reached` on a GitHub issue entry invokes `⤵ workflows/github/close-issue.md <ISSUE_ID>` after the generic completion signal. `close-issue.md` performs the two-signal verification, closes the GitHub issue if the PR merge did not auto-close it, records the outcome, and tears down the window when safe.
+
+---
+
+## § 4: GitHub issue decision routing
+
+Process prompting GitHub issues sequentially. For each issue in `state == "prompting"` and not debounced:
+
+1. If `<SUBSTATE_TAG>` is generic, call:
+   ```
+   ⤵ workflows/shared/session-handle-prompt.md <ISSUE_ID> <SUBSTATE_TAG>
+   ```
+   Then re-poll and continue issue flow.
+2. If `<SUBSTATE_TAG>` is GitHub issue-only, call:
+   ```
+   ⤵ workflows/github/handle-prompt.md <ISSUE_ID> <SUBSTATE_TAG>
+   ```
+3. If either handler sets `paused_for_user`, stop the cycle and yield to the user.
+4. After a confirmed response, re-poll the same issue before moving to the next prompting issue.
+
+The GitHub handler surface is limited to PR/CI/review workflow logic: cleanup worktree, bot-review/CI continuation, rebase, force-push, merge, force-merge confirmation, and tabbed selections that reference PR review or merge/rebase actions.
+
+---
+
+## § 5: PR readiness checks
+
+When a GitHub issue reaches `merge-ready` (`state = "merge-ready"` plus `domain.issue.phase = "merge-ready"`):
+
+1. Re-fetch PR state for `domain.issue.pr_number`:
+   ```bash
+   gh pr view <PR> --json state,mergeStateStatus,reviewDecision,statusCheckRollup,files,labels
+   ```
+2. If review is approved, all required checks are `SUCCESS` or `SKIPPED`, and merge state is clean, direct the per-issue pane through the `merge-now` prompt path.
+3. If merge state is `UNKNOWN`, record/read `unknown_since` and let `handle-prompt.md` apply the bounded force-merge predicate only when `force-merge-confirm` appears.
+4. If checks failed, reviews requested changes, or conflicts are present, transition back to `submitting` so the issue pane can fix and re-prompt.
+5. Do not build a cross-issue merge queue in GitHub mode. Each GitHub issue is gated independently at prompt time.
+
+---
+
+## § 6: GitHub issue cycle summary
+
+After generic session status, emit the GitHub issue summary expected by current users. This chat table is not the Rust dashboard.
+
+For each tracked GitHub issue, gather:
+
+- **Phase** — `flightdeck-state phase <ISSUE>` from workflow state, falling back to `fd:<state>`.
+- **Last prompt** — most recent `decisions_log[-1].prompt_tag` plus a short prompt excerpt.
+- **Answer** — most recent `decisions_log[-1].answer`.
+- **PR** — `domain.issue.pr_number`.
+- **Issue state** — `gh issue view <ISSUE> --json state` when cheap.
+
+<output_format>
+### ✈️ Flightdeck GitHub cycle [N] · [SESSION] · [ISO8601]
+
+| Issue | Phase | Last prompt | Answer | PR | GitHub state |
+|-------|-------|-------------|--------|----|--------------|
+| #[ISSUE_ID] | [PHASE] | [PROMPT_EXCERPT or —] | [ANSWER_EXCERPT or —] | [#N or —] | [OPEN|CLOSED|—] |
+
+Paused: [issue_id and reason, or —]
+</output_format>
+
+---
+
+## § 7: Termination
+
+At the end of each GitHub issue cycle:
+
+1. Count GitHub issue entries by state/outcome. Terminal issue outcomes are `merged`, `aborted`, and `dead` (generic `complete`, `cancelled`, `dead`).
+2. If every tracked GitHub issue is terminal and no issue is `prompting`, increment the debounce counter.
+3. At `FLIGHTDECK_DEBOUNCE_CYCLES` consecutive terminal cycles (default 2), invoke `⤵ workflows/github/terminate.md`.
+4. Otherwise return to `session-watch.md` § 5 for ack/yield.
+
+---
+
+## § 8: Compaction recovery
+
+On re-entry, run the generic recovery in `session-watch.md` first, then GitHub issue-specific recovery:
+
+1. Re-fingerprint registered issue panes.
+2. Recompute issue state from fresh `pane-poll --batch -` output and workflow state.
+3. Preserve `unknown_since` so force-merge timers do not reset.
+4. Re-fetch PR and GitHub issue state for active issue entries.
+5. Re-evaluate `paused_for_user`; if the user acted in the pane, reclassify and proceed.
+
+---
+
+## Returns
+
+To flightdeck's GitHub issue loop (`workflows/github/start.md` § 4), after `terminate.md` writes the GitHub issue summary and archives state.


### PR DESCRIPTION
Implements Flightdeck v2 Phase 2 from `docs/plans/flightdeck-v2-architecture-plan.md` § 2 (GitHub lane).

Changes:
- Adds 6 GitHub workflow files:
  - `skills/flightdeck/workflows/github/start.md`
  - `skills/flightdeck/workflows/github/start-new.md`
  - `skills/flightdeck/workflows/github/watch.md`
  - `skills/flightdeck/workflows/github/handle-prompt.md`
  - `skills/flightdeck/workflows/github/close-issue.md`
  - `skills/flightdeck/workflows/github/terminate.md`
- Extends `skills/flightdeck/scripts/open-terminal` with `--tracker github` so numeric GitHub issue ids spawn GitHub-lane prompts (`/skill:flightdeck github start <N>` for Pi, `$flightdeck github start <N>` for Codex, `/flightdeck github start <N>` elsewhere).
- Updates `skills/flightdeck/SKILL.md` dependency modes and command/workflow tables for GitHub mode (`github` + `worktree` only; no `linear`, no `project-management`).
- Updates `skills/flightdeck/README.md` user-facing mode/dependency notes.

Tests:
- `cd skills/flightdeck/lib/flightdeck-core && bun test && bun run typecheck`
- Result: 595 pass, 0 fail; typecheck clean.
- Test count delta: open-terminal parity tests 6 → 8 (+2), full suite +2.

Scope:
- ZERO change to Linear-mode behavior; scope is strictly additive.
