### PR TITLE
Flightdeck v2 Phase 4+5: simplify SKILL.md + rewrite README; extract SCHEMA/SCRIPTS/ENV reference docs

### DIFF
--- a/skills/flightdeck/ENV.md
+++ b/skills/flightdeck/ENV.md
@@ -1,0 +1,83 @@
+# Flightdeck environment reference
+
+Reference doc extracted from `SKILL.md`. See [`SKILL.md`](./SKILL.md) for the load-bearing rules; this file holds detailed reference content for on-demand consultation.
+
+## Configuration
+
+Master-loop env vars consulted by workflows:
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `FLIGHTDECK_FORCE_MERGE_AFTER_SECS` | `240` | UNKNOWN-state wait threshold before considering force-merge (predicate also requires APPROVED + green + disjoint) |
+| `FLIGHTDECK_STATE_DIR` | `tmp` | Project-relative master-state file directory |
+| `FLIGHTDECK_ACTIVITY_FILE` | unset | Explicit activity JSONL target for wrapper/workflow emitters and `flightdeck-state activity append`; when unset, managed workflows use `activity_path` from master state. |
+| `FLIGHTDECK_DEBOUNCE_CYCLES` | `2` | Consecutive poll cycles required for "all-done" termination check |
+| `FLIGHTDECK_AUTO_MERGE` | `1` | When `0`, merge-now, force-merge-confirm, and UNKNOWN-timer force-merge transitions escalate instead of auto-answering. For sessions where the human gate is desired (compliance, big-blast-radius PRs) |
+| `FLIGHTDECK_AUTO_REBASE` | `0` | GitHub lane only: when `1`, a `BEHIND` PR prompt may answer Update Branch / auto-rebase if all other safety predicates hold. Default `0` escalates. |
+| `FLIGHTDECK_HIJACK_GRACE_SECS` | `90` | Seconds after spawn that master tolerates no orchestration `workflow-state-<ISSUE>.json` before escalating "orchestration-never-started". Catches hijacked panes / failed launches. |
+| `FLIGHTDECK_LAUNCH_MODEL` | unset | Default `open-terminal` / `flightdeck-session --prompt` model override when the workflow/user does not pass `--model`. |
+| `FLIGHTDECK_LAUNCH_EFFORT` | unset | Default `open-terminal` / `flightdeck-session --prompt` effort/thinking override when the workflow/user does not pass `--effort`. |
+| `FLIGHTDECK_OPENCODE_VALIDATE_MODEL` | `1` | When launching OpenCode, require `opencode models` to list the selected provider/model before passing `--model`. Set `0` only for local smoke tests with custom shims. |
+| `FLIGHTDECK_PI_ACTIVITY_BROKER` | `1` | Set to `0` to ignore `pi-session-bridge` `vstack_activity` broker rows and rely on legacy Pi wake messages only. |
+| `FLIGHTDECK_ENTRY_ID` | auto | Exported by `flightdeck-session start` into spawned panes (and inherited by their tool wrappers). When set, `github.sh` / `linear.sh` / `label-*` activity rows auto-bind `refs.entry_id` so cross-source activity ties back to the tracked entry. Do not set by hand. |
+
+Watchdog gates (operator-facing; see [`WATCHDOGS.md`](./WATCHDOGS.md) for behavior):
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `VSTACK_AGENT_END_WATCHDOG` | `1` | Toggle for the agent-end watchdog. |
+| `VSTACK_AGENT_END_WATCHDOG_GRACE_SEC` | `10` | Grace seconds before synthesizing a `needs_completion` outbox. |
+| `VSTACK_STALL_WATCHDOG` | `1` | Toggle for the idle-stall watchdog. |
+| `VSTACK_STALL_WATCHDOG_INTERVAL_SEC` | `60` | Poll cadence for idle-stall detection. |
+| `VSTACK_STALL_WATCHDOG_THRESHOLD_SEC` | `300` | Bridge-idle threshold before synthesizing a `blocked` outbox. |
+| `VSTACK_EDIT_LOOP_DETECTOR` | `1` | Toggle for the edit-loop detector. |
+| `VSTACK_EDIT_LOOP_THRESHOLD_N` | `5` | Edit-tool failure count within the window that trips the detector. |
+| `VSTACK_EDIT_LOOP_WINDOW_SEC` | `120` | Sliding window for edit-loop counting. |
+| `VSTACK_RATE_LIMIT_WATCHDOG` | `1` | Toggle for the rate-limit retry watchdog. |
+| `VSTACK_RATE_LIMIT_MAX_ATTEMPTS` | `5` | Maximum retry attempts before surfacing `agent.rate_limit_exhausted`. |
+| `VSTACK_RATE_LIMIT_BACKOFF_LADDER` | `60,120,300,600,1800` | Comma-separated seconds per attempt; clamped to `MAX_ATTEMPTS`. |
+
+Daemon hygiene env vars (operator-facing; details in `DEVELOPMENT.md`):
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `FD_BELL_WAKE_INTERVAL_SEC` | `60` | Per-pane-per-tag bell-wake rate-limit; suppresses storm-y duplicates within the window. |
+| `FD_RECONCILE_INTERVAL_SEC` | `5` | Mid-session reconcile cadence: spawn subscribers for newly tracked panes, reap subscribers for departed panes, drop dead `.entries` rows. |
+| `FD_HEARTBEAT_OWNER_CGROUP` | `1` | Set to `0` to skip the optional `MemoryCurrent` / `MemoryPeak` cgroup probe attached to heartbeat events. |
+
+
+Rust dashboard env vars:
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `FLIGHTDECK_DASHBOARD` | `1` | When `0`, `flightdeck-dashboard launch` exits `0` silently. |
+| `FLIGHTDECK_DASHBOARD_WINDOW` | `flightdeck` | Tmux window name used by the dashboard launch hook. |
+| `FLIGHTDECK_DASHBOARD_MOTION` | `full` | Animation intensity: `full`, `reduced`, or `off`. `NO_MOTION` / `NO_COLOR` force `off` regardless of this setting. CLI `--motion` overrides it. |
+| `FLIGHTDECK_DASHBOARD_THEME` | `moon` | Color theme: `moon`, `dawn`, `pantera`, or `system`. CLI `--theme` overrides it; the theme picker popup changes the live theme for the current run. |
+| `FLIGHTDECK_DAEMON_RUST` | `0` | Opt-in to the Rust daemon wake side / subscriber absorption. Default off keeps the canonical TypeScript daemon in charge of wake delivery. |
+| `FLIGHTDECK_DASHBOARD_BELL` | `1` | Set to `0` to suppress the terminal bell on a new pause-for-user edge. The dashboard never auto-focuses tmux windows. |
+| `FLIGHTDECK_DASHBOARD_COST_POLL_SECS` | `5` | Cost-source poll interval in seconds. |
+| `FLIGHTDECK_DASHBOARD_PRICING_FILE` | bundled table | Optional pricing TOML override for dashboard cost calculations; malformed files warn and fall back to bundled rates. |
+| `FLIGHTDECK_DASHBOARD_QUICK_FOCUS` | `0` | Set to `1` to let `g` focus the selected tmux window without a confirmation popup. |
+| `TMUX_PROBE_TTL` | `5` | Cached `tmux list-panes` TTL used to mark stale dashboard rows. |
+| `FLIGHTDECK_DASHBOARD_STALE_WARN_SECS` | `30` | Stale-chip warning threshold in seconds. |
+| `FLIGHTDECK_DASHBOARD_STALE_DEAD_SECS` | `300` | Stale/dead chip threshold in seconds. |
+| `FLIGHTDECK_DASHBOARD_STOP_GRACE_MS` | `5000` | Advanced daemon stop grace before SIGKILL escalation, in milliseconds. Tests may lower it. |
+| `FLIGHTDECK_DASHBOARD_READY_FD` | internal | Readiness pipe fd used by detached daemon startup; not user-configurable. |
+| `FLIGHTDECK_DASHBOARD_TEST_WEDGE_SIGNALS` | unset | Test-only hook that wedges signal handling. Do not set in normal sessions. |
+| `FLIGHTDECK_DASHBOARD_TEST_SUBSCRIBE_PAUSE_FILE` | unset | Test-only socket subscribe interleaving hook. Do not set in normal sessions. |
+| `FLIGHTDECK_DASHBOARD_TEST_SUBSCRIBE_RELEASE_FILE` | unset | Test-only release file for the subscribe interleaving hook. Do not set in normal sessions. |
+
+Daemon tuning (`FD_*`) is in DEVELOPMENT.md. Most `FD_*` knobs run inside the
+daemon and do not affect master operation directly, but two are
+consulted on the master poll path through the TS `pane-poll`:
+`FD_ADAPTER_READ_TIMEOUT_SEC` (default `2`, fractional values honored)
+caps each adapter read subprocess so one stale adapter cannot dominate
+a tick, and `FD_ADAPTER_FRESHNESS_TTL` (default `5`) gates freshness
+probe caching.
+
+Additional tuning:
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `FD_ADAPTER_READ_TIMEOUT_SEC` | `2` | Bounds per-adapter read subprocesses in `pane-poll` (fractional values honored). Stale adapters fall through to tmux capture rather than wedging the tick. |

--- a/skills/flightdeck/PROMPT-TAGS.md
+++ b/skills/flightdeck/PROMPT-TAGS.md
@@ -1,0 +1,49 @@
+# Flightdeck prompt tag reference
+
+Reference doc extracted from `SKILL.md`. See [`SKILL.md`](./SKILL.md) for the load-bearing rules; this file holds the detailed `prompt-classify` tag catalog for on-demand consultation.
+
+## Classifier contract
+
+`prompt-classify` is a regex/sentinel + computed-tag matcher. It maps pane state to a handler tag consumed by `pane-poll`, `session-watch.md`, `session-handle-prompt.md`, and issue-mode `handle-prompt.md` workflows.
+
+`--entry-kind` guards issue-only tags on non-issue entries. If kind is omitted or `--entry-kind-unknown` is passed, issue-only tags fail closed as `domain-mismatch`.
+
+## Pane-text tags
+
+| Tag | Handler domain | Purpose |
+|-----|----------------|---------|
+| `rendering` | generic | Pane still rendering; do not answer yet. |
+| `terminal-state-reached` | generic + issue | Pane reached a completion/terminal state; route to summary or close workflow. |
+| `bash-permission-prompt` | generic | Harness asks whether to allow a shell command. |
+| `force-merge-confirm` | issue | Prompt asks whether to force-merge. Apply conflict/UNKNOWN gate first. |
+| `merge-ready-but-unknown` | issue | GitHub merge state is `UNKNOWN`; apply timer and force-merge predicate before acting. |
+| `merge-now` | issue | Prompt asks to merge now; verify authoritative PR state before answering. |
+| `bot-review-wait-stuck` | issue | Bot/reviewer gate appears stuck; verify check/review state before skip/wait/escalate. |
+| `rebase-multi-choice` | issue | Rebase/update branch prompt that needs preserve / apply / verify guidance in the same response. |
+| `force-push-prompt` | issue | Prompt asks whether force-push is allowed; escalate unless workflow rules explicitly allow it. |
+| `cleanup-prompt` | issue | Prompt asks to remove worktree/files; compare prompt path to registered worktree before yes. |
+| `audit-relation-prompt` | issue | Prompt asks parent/related issue relationship; apply parent-vs-related rule. |
+| `descope-related` | issue | Prompt proposes descoping into a follow-up/related issue. |
+| `external-fix-suggestions` | issue | Prompt proposes fixes outside current issue scope. |
+| `cycle-fix-suggestions` | issue | Prompt proposes next-cycle fixes. |
+| `scope-creep-detected` | issue computed | Computed scope expansion guard; escalate rather than auto-revert. |
+| `multi-select-tabbed` | generic | Structured tabbed multi-select prompt. |
+| `awaiting-direction` | generic | Agent asks for free-form or novel direction. |
+| `generic-multi-choice` | generic | Bounded-choice prompt with no issue-only semantics. |
+| `domain-mismatch` | generic guard | Issue-only tag appeared on non-issue or unknown entry; skip issue handler and pause. |
+| `idle` | generic | No actionable prompt detected. |
+
+## Daemon/event-only tags
+
+These tags come from harness events, not normal assistant text classification.
+
+| Tag | Source | Purpose |
+|-----|--------|---------|
+| `oc-question` | OpenCode question event | Structured OpenCode question waiting for answer. |
+| `pi-question` | Pi question event | Structured Pi question waiting for answer. |
+| `pi-subagent-completion` | Pi subagent event | Inner Pi subagent completion surfaced to tracked pane. |
+| `pi-bg-task-exit` | Pi background task event | Background task exited; wake master through daemon path. |
+| `pi-activity-broker` | Pi activity broker | Activity-only broker row; copied to activity sidecar without waking master. |
+| `pi-rate-limit-retry` | Pi rate-limit watchdog | Rate limit detected and retry scheduled. |
+| `pi-rate-limit-exhausted` | Pi rate-limit watchdog | Retry ladder spent; normal completion/blocking flow resumes. |
+| `daemon-exited` | Flightdeck daemon lifecycle | Daemon exited for master-gone, signal, or recorded reason; route through respawn/recovery flow. |

--- a/skills/flightdeck/README.md
+++ b/skills/flightdeck/README.md
@@ -1,61 +1,19 @@
 # Flightdeck
 
-Flightdeck supervises AI harness sessions in tmux windows. In core session mode it launches or attaches panes, tracks stable ids, routes prompts, and summarizes completion. Issue orchestration is a built-in domain mode layered on top: GitHub/Linear/worktree decisions, merge planning, and next-cycle recommendations.
+Flightdeck supervises AI agent sessions in tmux windows. It can track generic panes, run Linear issue cycles, or run GitHub issue cycles while routing prompts, showing progress, and summarizing completion.
 
-> Agents reading this: you want `SKILL.md` instead. Hacking on flightdeck itself: see [`DEVELOPMENT.md`](./DEVELOPMENT.md).
+> AI agents using Flightdeck: read [`SKILL.md`](./SKILL.md). Contributors changing Flightdeck internals: read [`DEVELOPMENT.md`](./DEVELOPMENT.md).
 
-## The problem
+## Features
 
-Running one agent at a time is fine. Running five at once is chaos — each one keeps stopping to ask questions, background tasks finish at odd times, and issue-mode merge order can turn into a guessing game. Flightdeck handles the supervisory layer so you can track generic sessions or spawn a whole issue cycle and walk away.
-
-Activates only inside tmux and only when you ask for it (`flightdeck session start|attach` for core sessions, `flightdeck linear start` for Linear issue workflows, `flightdeck github start` for GitHub issue workflows). Outside tmux it's a no-op.
-
-## How it works
-
-Flightdeck launches generic sessions with `flightdeck session start` (or `attach`) or issue agents with `flightdeck linear start` / `flightdeck github start`, always into their own tmux windows, then watches them in parallel. Each Flightdeck session launches/verifies the Rust dashboard by default; set `FLIGHTDECK_DASHBOARD=0` to opt out. Each agent talks to flightdeck through its native channel (Claude Code MCP, OpenCode HTTP, Pi bridge, Codex app-server) and falls back to tmux when a channel isn't available.
-
-A background daemon detects when an agent has a question, the master agent classifies the prompt, auto-answers when there's a learned default, and pauses for the human when there isn't.
-
-There are three modes: generic session, Linear issue, GitHub issue.
-
-- **Generic session mode** — structured questions, bash permission prompts, safe bounded choices, Pi background-task exits.
-- **Linear issue mode** — adds GitHub/Linear/worktree/project-management decisions: cleanup, rebase, force-push, bot-review/CI recovery, merge planning, scope creep, next-cycle recommendations.
-- **GitHub issue mode** — adds GitHub/worktree decisions for numeric GitHub issues: self-contained child prompts, PR/CI/review handling, authoritative merge/close verification, and GitHub summaries.
-
-When all tracked entries are terminal, flightdeck writes a summary and hands control back.
-
-## Reliability
-
-Four watchdogs sit between the daemon and the spawned agents and recover from the most common failure modes without waking you:
-
-- **agent-end watchdog** — if a subagent emits its end-of-turn event but never writes a completion outbox (an `agent_end` race), flightdeck synthesizes a `needs_completion` outbox after a short grace window so the parent agent is never left hanging on a phantom child.
-- **idle-stall watchdog** — if a subagent has been bridge-idle for several minutes without producing an outbox, flightdeck synthesizes a `blocked` outbox so the parent agent moves on instead of polling forever.
-- **edit-loop detector** — if a child agent fails the same edit tool repeatedly within a short window (default 5 failures in 120s), flightdeck synthesizes a `blocked` outbox so a stuck retry loop surfaces as an explicit failure.
-- **rate-limit watchdog** — if the upstream Claude API rate-limits a child agent, flightdeck steers it to retry with exponential backoff (default ladder `60s → 120s → 300s → 600s → 1800s`, up to 5 attempts). Each retry surfaces as a `rate_limit_retry` activity row; an exhausted retry budget shows as `rate_limit_exhausted`.
-
-Each watchdog is independently toggleable via its `VSTACK_*` env var. Daemon hygiene knobs (`FD_BELL_WAKE_INTERVAL_SEC`, `FD_RECONCILE_INTERVAL_SEC`, `FD_HEARTBEAT_OWNER_CGROUP`) similarly default to safe values and only need tuning in unusual setups. See `SKILL.md` for the full table and `DEVELOPMENT.md` for canonical decision modules and parity rules.
-
-If the daemon's master pane disappears (master agent crash, accidental window kill), the daemon writes a structured `fd-daemon-recovery-<session>.json` breadcrumb under `FD_STATE_DIR` before exiting. Re-launch the master from the same cwd and run `flightdeck session watch` to resume; `flightdeck-state archive` rolls the state file if you want to abandon the session instead.
-
-## Activation and termination
-
-- **Activates** on `flightdeck session start|attach` for generic tracked sessions, `flightdeck linear start` for Linear issue workflows, or `flightdeck github start` for GitHub issue workflows, from inside tmux.
-- **Pauses** for you on: scope creep that wants reverting, force-merging against a real content conflict, an issue abort, a `main` mutation that needs human OK, domain mismatch, or a novel prompt shape no rule covers. Sets `paused_for_user` in state and stops polling. Resume by running `session watch`, `linear watch`, or `github watch` again.
-- **Terminates** automatically when every tracked entry is terminal for the relevant mode. Generic-only sessions write a session summary with no GitHub/Linear/worktree calls. Issue sessions write the issue summary, archive the state file, and hand control back.
-
-## Ad-hoc sessions
-
-Ask the agent to track an ad-hoc tmux window (a scratch Pi pane, a log tail, an extra worker) and it will call `flightdeck session start` or `flightdeck session attach` for you. Useful when you want supervision and a dashboard row but no issue/worktree wiring. See [`DEVELOPMENT.md`](./DEVELOPMENT.md) for the script flag reference.
-
-Fresh LLM panes need an explicit launch profile. `flightdeck session start --prompt` accepts `--model` plus `--effort`/`--thinking` and translates them per harness: Pi uses `--model` + `--thinking`, Claude uses `--model` + `--effort`, Codex uses `-m` + `model_reasoning_effort`, and OpenCode validates `--model` with `opencode models` but records effort as unsupported because top-level `opencode` has no validated effort flag. If a custom command or attached pane cannot expose model/effort, the tracked entry records `launch.reasoning_status` and `launch.unsupported_reason` instead of pretending defaults were known.
-
-## Issue workflows
-
-Issue orchestration remains first-class when the session is tied to a Linear or GitHub issue domain. Ask the agent to start a Linear issue (`flightdeck linear start <ISSUE>`), check a Linear parallel group for safety (`flightdeck linear parallel-check`), launch the group, watch the session (`flightdeck linear watch`), recompute merge order (`flightdeck linear merge-plan`), or close out the session (`flightdeck linear close-issue` / `flightdeck linear terminate`). For plain GitHub issues, ask for `flightdeck github start <N>` / `flightdeck github watch` / `flightdeck github close-issue` / `flightdeck github terminate`; GitHub mode uses a self-contained child prompt and tracks GitHub issue session metadata separately from Linear sessions.
-
-The `github` skill ships `label-add` and `label-remove` wrappers around `gh pr edit` / `gh issue edit`. When flightdeck spawns a managed pane, those wrappers emit `pr.labeled` / `pr.unlabeled` / `issue.labeled` / `issue.unlabeled` activity rows alongside the existing `pr.*` events, so label-driven gates (`defer-ci`, custom workflow labels) show up in the activity sidecar and Rust dashboard.
-
-The spawn path also auto-exports `FLIGHTDECK_ENTRY_ID` into every child pane and captures the worktree's current git branch as `entry.branch` (via `git rev-parse --abbrev-ref HEAD`). The Rust dashboard renders branch info in the right rail and Sessions table PR/path column (`<branch> · PR #N` for non-default branches), and `pr.*` activity rows are enriched with `refs.branch` via `gh pr view --json headRefName`. Child Pi sessions also advertise a unique `<parent>:c<pid>` session id (via `PI_BRIDGE_PARENT_SESSION_ID`) so cross-session activity does not collide with the parent.
+- Start or attach tracked agent panes in their own tmux windows.
+- Watch multiple sessions at once and route prompts back to the right pane.
+- Run generic sessions with no issue tracker.
+- Run Linear issue workflows with planning, PR checks, merge ordering, and closeout summaries.
+- Run GitHub issue workflows with PR/CI/review handling and verified issue closeout.
+- Pause for humans on risky choices: scope creep, force-merge, issue aborts, domain mismatch, or novel prompt shapes.
+- Launch a terminal dashboard by default so sessions, prompts, PRs, activity, and costs stay visible.
+- Recover from common stalls with watchdogs for missing child completions, idle panes, edit loops, and rate limits.
 
 ## Install
 
@@ -64,87 +22,119 @@ cd /path/to/your/project
 vstack add vanillagreencom/vstack --skill flightdeck -y
 ```
 
-Core mode requires tmux only at the workflow/skill-dependency layer, plus the harness adapter you choose for a tracked pane (`pi-bridge`, OpenCode HTTP, Claude Channels, Codex app-server, or tmux fallback). It does not require GitHub, Linear credentials, project-management, or worktree setup.
+Requirements:
 
-Linear issue mode requires Linear MCP/CLI auth plus the optional `github`, `linear`, `worktree`, and `project-management` skills on demand for `flightdeck linear start <ISSUE>`, `linear start new`, `linear parallel-check`, `linear merge-plan`, `linear close-issue`, and `linear terminate`. GitHub issue mode requires `gh` CLI authenticated against the target repo plus the optional `github` and `worktree` skills for `flightdeck github start <N>`, `github watch`, `github close-issue`, and `github terminate`. Generic session mode requires neither Linear nor GitHub issue auth.
+- tmux 3.x; Flightdeck no-ops outside tmux.
+- bash 4+, jq, flock, bun.
+- One supported harness adapter for each tracked pane: Pi bridge, OpenCode HTTP, Claude Channels, Codex app-server, or tmux fallback.
+- Linear issue mode: Linear auth plus GitHub auth for PR helpers.
+- GitHub issue mode: `gh` authenticated against the target repo.
+- macOS: GNU coreutils for `sha256sum` and GNU date.
 
-Runtime requirements for the shipped core scripts remain `bash` 4+, `tmux` 3.x, `jq`, `flock`, and `bun` (https://bun.sh). Linear issue mode additionally needs Linear MCP/CLI auth and the GitHub auth used by PR helpers; GitHub issue mode needs `gh` auth for the target repo; both issue modes need normal git worktree support. Mac users: install GNU coreutils for `sha256sum` and GNU date.
+## Commands quick reference
+
+Run commands by asking your agent for `flightdeck <command>`.
+
+### Session lane
+
+| Command | Use when | Main args |
+|---------|----------|-----------|
+| `flightdeck session start` | Launch a new tracked pane. | `--session-id <ID> --title <T> --cwd <path> --harness <H> (--cmd <cmd> \| --prompt <text>)` |
+| `flightdeck session attach` | Track an existing pane. | `--pane <%PANE_ID> --harness <H> --title <T>` |
+| `flightdeck session watch` | Resume supervision for generic sessions. | `[ENTRY_ID...]` |
+| `flightdeck session status` | Print tracked session state. | none |
+| `flightdeck session stop` | Teardown a tracked entry. | `<ENTRY_ID>` |
+| `flightdeck session remove` | Remove a tracked entry from state. | `<ENTRY_ID>` |
+
+### Linear lane
+
+| Command | Use when | Main args |
+|---------|----------|-----------|
+| `flightdeck linear start` | Start one Linear issue or choose one from main. | `[ISSUE_ID]` |
+| `flightdeck linear start new` | Create a Linear issue, then start it. | `[title]` |
+| `flightdeck linear start self` | Initialize master Linear issue session only. | none |
+| `flightdeck linear parallel-check` | Check whether issues are safe to run together. | `[ISSUE_IDS]` |
+| `flightdeck linear watch` | Resume Linear issue supervision. | `[ISSUE_IDS]` |
+| `flightdeck linear merge-plan` | Recompute PR merge order. | none |
+| `flightdeck linear close-issue` | Verify and close one issue workflow. | `<ISSUE_ID>` |
+| `flightdeck linear terminate` | Summarize and unwind the Linear session. | none |
+
+### GitHub lane
+
+| Command | Use when | Main args |
+|---------|----------|-----------|
+| `flightdeck github start` | Start a numeric GitHub issue. | `<N> [--repo OWNER/REPO]` |
+| `flightdeck github start new` | Create a GitHub issue, then start it. | `[title] [--repo OWNER/REPO]` |
+| `flightdeck github watch` | Resume GitHub issue supervision. | `[N...]` |
+| `flightdeck github close-issue` | Verify merged PR state, then close/no-op issue. | `<N>` |
+| `flightdeck github terminate` | Summarize and unwind the GitHub session. | none |
+
+## Settings users actually set
+
+Most sessions work with defaults. These are the knobs users most often change.
+
+| Variable | Default | Use when |
+|----------|---------|----------|
+| `FLIGHTDECK_AUTO_MERGE` | `1` | Set `0` to require human approval before merge or force-merge actions. |
+| `FLIGHTDECK_AUTO_REBASE` | `0` | Set `1` in GitHub mode to allow safe auto-rebase/update-branch prompts. |
+| `FLIGHTDECK_FORCE_MERGE_AFTER_SECS` | `240` | Change how long Flightdeck waits before considering force-merge for approved, green PRs stuck in GitHub `UNKNOWN` merge state. |
+| `FLIGHTDECK_LAUNCH_MODEL` | unset | Default model for panes launched from `open-terminal` or `flightdeck-session --prompt`. |
+| `FLIGHTDECK_LAUNCH_EFFORT` | unset | Default effort/thinking level for launched panes. |
+| `FLIGHTDECK_OPENCODE_VALIDATE_MODEL` | `1` | Set `0` only when using local OpenCode shims that are not listed by `opencode models`. |
+| `FLIGHTDECK_STATE_DIR` | `tmp` | Change where Flightdeck writes session state inside the project. |
+| `FLIGHTDECK_DASHBOARD` | `1` | Set `0` to disable automatic dashboard launch. |
+| `FLIGHTDECK_DASHBOARD_WINDOW` | `flightdeck` | Change the tmux window name used for the dashboard. |
+| `FLIGHTDECK_DASHBOARD_THEME` | `moon` | Pick `moon`, `dawn`, `pantera`, or `system`. |
+| `FLIGHTDECK_DASHBOARD_MOTION` | `full` | Pick `full`, `reduced`, or `off`; `NO_MOTION` and `NO_COLOR` also disable motion. |
+| `FLIGHTDECK_DASHBOARD_BELL` | `1` | Set `0` to suppress terminal bell on pause-for-user. |
+| `FLIGHTDECK_DASHBOARD_QUICK_FOCUS` | `0` | Set `1` to let dashboard `g` focus a tmux window without confirmation. |
+| `FLIGHTDECK_DASHBOARD_PRICING_FILE` | bundled table | Point dashboard cost calculations at a custom pricing TOML. |
+| `VSTACK_AGENT_END_WATCHDOG` / `VSTACK_STALL_WATCHDOG` / `VSTACK_EDIT_LOOP_DETECTOR` / `VSTACK_RATE_LIMIT_WATCHDOG` | `1` | Set any to `0` to disable that recovery watchdog. |
+
+Full env reference: [`ENV.md`](./ENV.md).
 
 ## Dashboard
 
-Flightdeck ships a ratatui terminal dashboard that opens automatically in its own tmux window when you run `flightdeck linear start` or `flightdeck github start`. It shows:
+The terminal dashboard opens automatically when `FLIGHTDECK_DASHBOARD=1` (default). It shows tracked sessions, state, harness, PR/path, branch, age, last decision, activity, conversations, merge planning, daemon health, token/cost totals, and pause-for-user banners.
 
-- Tracked sessions with state, kind (adhoc / issue / workflow), harness, title, PR/path, branch, age, last decision.
-- Pause-for-user banner above the table when flightdeck is waiting on you.
-- Cross-harness cost and token totals, with a per-source breakdown popup.
-- Activity feed, conversations, decisions log, conflict/merge planning, and daemon health, each on its own tab.
-- Themes (`moon`, `dawn`, `pantera`, `system`) selectable from the picker (`T`) or `--theme`.
-
-`flightdeck-dashboard launch` is the startup hook used by Flightdeck. It opens one tracked tmux window through `flightdeck-session start --kind workflow --harness shell`, registers `.entries.flightdeck-dashboard`, and skips cleanly outside tmux or when disabled. Idempotency is based on the live tracked dashboard pane; stale same-name windows no longer satisfy the launch check. Use `launch --theme moon|dawn|pantera|system` to forward a theme to the child TUI.
-
-Most actions are read-only. The only writes are confirmation-gated: prune a stale registry entry (`D`), or focus a tmux window (`g`).
-
-`flightdeck-dashboard tui --demo[=NAME]` runs compiled demo fixtures (`empty`, `one-adhoc`, `one-issue`, `mixed`, `terminated`, `paused`, `observer`, `conversations`, `no-issue`, `decisions`, `stale-mixed`). `tui --state-file <path>` reads a concrete master-state JSON file, and `tui --session <name>` resolves `<project-root>/<FLIGHTDECK_STATE_DIR>/flightdeck-state-<name>.json` (default state dir `tmp/`) with terminated-archive fallback. With neither flag inside tmux, the dashboard uses the current tmux session. Use `--theme moon|dawn|pantera|system` to select Rose Pine Moon, Rose Pine Dawn, Pantera neon, or terminal-system colors. `?` opens Help with the legend, `T` opens the theme picker (with `█bg █surface █accent █error` swatch slot labels), `/` opens the filter popup, `Enter` opens the selected session/decision/event detail popup, `p` opens the pricing-source detail popup from the Costs tab, `g` confirms focus for the selected pane, `D` confirms prune for stale rows, and `Alt+M` toggles compact mode. The tabs row collapses responsively at 140- and 110-column thresholds (full → shortened → narrow labels), and the base header drops `kind counts → uptime → cwd → daemon → master` in priority order before any mid-text clip. Stale rows render with a `(stale)` annotation when tmux reports the pane id is gone, and the right rail adds a `branch <name>` row plus a "Recent activity" panel for adhoc/workflow entries. File-mode (no live tmux session) populates the Conversations tab from activity events instead of leaving dead space, and Unicode display-width is honored across every view module so CJK and emoji rows align.
-
-`flightdeck-state activity export --session <name> [--state-file <path>]` mirrors the existing `path` / `tail` / `append` source-of-truth resolution so post-mortem exports work without an active tmux session.
-
-The legacy in-Pi dashboard extension remains documented in [`pi-extensions/pi-flightdeck/README.md`](../../pi-extensions/pi-flightdeck/README.md), but it is deprecated for new sessions. Prefer the Rust dashboard for new Flightdeck runs.
-
-After `vstack add`, build the release binary with:
+Useful commands:
 
 ```bash
-flightdeck-dashboard tui                            # current tmux session, live
-flightdeck-dashboard tui --session <name>           # any past or current session
-flightdeck-dashboard tui --demo                     # try it without a live session
+flightdeck-dashboard tui                  # current tmux session, live
+flightdeck-dashboard tui --session <name> # past or current session
+flightdeck-dashboard tui --demo           # demo data
 ```
 
-Rebuild the release binary after pulling changes:
+Useful keys:
 
-```bash
-cd skills/flightdeck/lib/flightdeck-dashboard && cargo build --release
+- `?` — help.
+- `T` — theme picker.
+- `/` — filter.
+- `Enter` — detail popup for selected row.
+- `p` — pricing-source detail.
+- `g` — focus selected pane, with confirmation unless quick focus is enabled.
+- `D` — prune stale row, with confirmation.
+- `Alt+M` — compact mode.
+
+## High-level architecture
+
+Flightdeck always runs inside one tmux session. The master agent owns the Flightdeck workflow and records tracked entries in a project-local state file. Each child agent runs in its own tmux window, never as a split of the active pane. Flightdeck talks to child panes through the best available native channel for that harness, with tmux as fallback. A daemon watches child panes and wakes the master only when there is work to do. The master classifies prompts, answers known safe shapes, pauses for risky or novel shapes, and updates state. Issue lanes add GitHub/Linear/worktree checks on top of the same session loop. The dashboard reads the same state and activity data the workflows already write; it does not replace the workflows.
+
+```
+user request
+  -> master agent
+  -> Flightdeck workflow
+  -> tmux child windows
+  -> daemon wake + prompt routing
+  -> dashboard + final summary
 ```
 
-The trampoline falls back to `cargo run --release` if no release binary is present.
+## More docs
 
-## Settings worth knowing
-
-Most users never touch these. The ones that occasionally matter:
-
-| Variable | What it does |
-| --- | --- |
-| `FLIGHTDECK_AUTO_MERGE` | Set to `0` to require a human OK on every merge, including UNKNOWN-state force-merge prompts. Useful for compliance-sensitive repos or big-blast-radius PRs. |
-| `FLIGHTDECK_AUTO_REBASE` | GitHub issue mode defaults this to `0`; set `1` only when you want Flightdeck to answer safe Update Branch / auto-rebase prompts for `BEHIND` PRs. |
-| `FLIGHTDECK_FORCE_MERGE_AFTER_SECS` | How long flightdeck waits before considering force-merge for a PR that's approved + green but stuck in GitHub's `UNKNOWN` merge state (default 4 minutes). |
-| `FLIGHTDECK_LAUNCH_MODEL` / `FLIGHTDECK_LAUNCH_EFFORT` | Default model + thinking level for spawned agents / `flightdeck-session --prompt` when the user doesn't pass them explicitly. |
-| `FLIGHTDECK_OPENCODE_VALIDATE_MODEL` | Keep `1` to require `opencode models` to list the selected OpenCode provider/model before launch; set `0` only for local smoke shims. |
-| `FLIGHTDECK_STATE_DIR` | Where flightdeck writes its session state file inside the project. Defaults to `tmp/`. |
-| `FLIGHTDECK_ACTIVITY_FILE` | Override the activity JSONL sidecar path for wrapper/workflow emitters and `flightdeck-state activity append`. |
-| `FLIGHTDECK_DASHBOARD` | Set to `0` to disable the dashboard launch hook silently. |
-| `FLIGHTDECK_DASHBOARD_WINDOW` | Tmux window name for the dashboard launch hook. Defaults to `flightdeck`. |
-| `FLIGHTDECK_DASHBOARD_THEME` | Dashboard theme: `moon` (default), `dawn`, `pantera`, or `system`. |
-| `FLIGHTDECK_DASHBOARD_MOTION` | Dashboard motion level: `full`, `reduced`, or `off`. `NO_MOTION` and `NO_COLOR` also disable motion. |
-| `FLIGHTDECK_DASHBOARD_BELL` | Set to `0` to suppress the terminal bell when flightdeck pauses for you. |
-| `FLIGHTDECK_DASHBOARD_QUICK_FOCUS` | Set to `1` to make `g` focus a tmux window without the confirmation popup. Prune always confirms. |
-| `FLIGHTDECK_DASHBOARD_PRICING_FILE` | Path to a pricing TOML override for dashboard cost calculations. |
-| `TMUX_PROBE_TTL` | Stale-pane probe cache TTL in seconds (default `5`). |
-| `FLIGHTDECK_DASHBOARD_STALE_WARN_SECS` | Rust dashboard stale-warning threshold in seconds (default `30`). |
-| `FLIGHTDECK_DASHBOARD_STALE_DEAD_SECS` | Rust dashboard stale/dead threshold in seconds (default `300`). |
-| `FLIGHTDECK_PI_ACTIVITY_BROKER` | Set to `0` to disable `pi-session-bridge` `vstack_activity` broker consumption and rely on legacy Pi wake messages only. Default `1`. |
-| `VSTACK_AGENT_END_WATCHDOG` / `VSTACK_STALL_WATCHDOG` / `VSTACK_EDIT_LOOP_DETECTOR` / `VSTACK_RATE_LIMIT_WATCHDOG` | Set any to `0` to disable that watchdog. Defaults are `1`. Tuning knobs (`*_GRACE_SEC`, `*_THRESHOLD_SEC`, `*_THRESHOLD_N`, `*_WINDOW_SEC`, `*_MAX_ATTEMPTS`, `*_BACKOFF_LADDER`) live in `SKILL.md`. |
-| `FD_BELL_WAKE_INTERVAL_SEC` | Per-pane-per-tag bell-wake rate-limit window (default `60`). Lower it only if you genuinely want more bells per minute. |
-| `FD_RECONCILE_INTERVAL_SEC` | Mid-session reconcile cadence in seconds (default `5`). The daemon spawns subscribers for newly tracked panes and reaps subscribers for departed panes on this interval. |
-| `FD_HEARTBEAT_OWNER_CGROUP` | Set to `0` to skip the optional `MemoryCurrent`/`MemoryPeak` cgroup probe in heartbeat events. Default `1`. |
-| `FLIGHTDECK_ENTRY_ID` | Auto-exported by `flightdeck-session start` to spawned panes; binds `refs.entry_id` on github/linear/label activity rows. Do not set by hand. |
-
-Activity history lives beside the master state as `<FLIGHTDECK_STATE_DIR>/flightdeck-activity-<session>.jsonl`. The dashboard's Activity tab reads it; you can also tail or export it with `flightdeck-state activity tail|export`.
-
-Daemon-private files live outside your project under `$XDG_RUNTIME_DIR/flightdeck` (fallback `/tmp/flightdeck-$UID`) so they don't show up in commits.
-
-Daemon tuning (`FD_*` env vars) and contributor-only knobs are documented in [`DEVELOPMENT.md`](./DEVELOPMENT.md). Defaults work for normal use.
-
-## Out of scope
-
-- Flightdeck does not abort issues for you — only you can.
-- Flightdeck does not respawn dead panes.
-- Flightdeck operates within one tmux session at a time. Multiple sessions are independent.
-- Flightdeck does not bypass the parallel-safety check that orchestration runs before spawn. If that check says no, flightdeck doesn't override.
+- AI agent operating rules: [`SKILL.md`](./SKILL.md)
+- Full script reference: [`SCRIPTS.md`](./SCRIPTS.md)
+- State and activity schema: [`SCHEMA.md`](./SCHEMA.md)
+- Env reference: [`ENV.md`](./ENV.md)
+- Watchdog reference: [`WATCHDOGS.md`](./WATCHDOGS.md)
+- Prompt tag reference: [`PROMPT-TAGS.md`](./PROMPT-TAGS.md)
+- Development and testing: [`DEVELOPMENT.md`](./DEVELOPMENT.md)

--- a/skills/flightdeck/SCHEMA.md
+++ b/skills/flightdeck/SCHEMA.md
@@ -1,0 +1,100 @@
+# Flightdeck schema reference
+
+Reference doc extracted from `SKILL.md`. See [`SKILL.md`](./SKILL.md) for the load-bearing rules; this file holds detailed reference content for on-demand consultation.
+
+## Schema — master state
+
+Master state lives at `<project-root>/<FLIGHTDECK_STATE_DIR>/flightdeck-state-<TMUX_SESSION_NAME>.json` (default `tmp/`). Activity history lives beside it as `flightdeck-activity-<TMUX_SESSION_NAME>.jsonl` and is exposed through `flightdeck-state activity path|append|tail|export`. Both survive compaction; terminate rotates state to `*-<terminated_at>.json.archive` and activity to `*-<terminated_at>.jsonl.archive` in the same `flightdeck-state archive` flow (see `terminate.md § 6`). The archive preserves the full session history (including merged-issue `decisions_log`, `pr_number`, `merge_commit`) so post-completion dashboards and post-mortem inspection have the whole session history — do not call `pane-registry remove-merged` between `set terminated true` and `archive`. Dashboard snapshot loaders fall back to the newest matching `*.json.archive` when the live file is gone, so the completed-session view keeps rendering until a new `flightdeck linear start` rewrites the live file. Daemon-private files in `FD_STATE_DIR` are keyed by `SESSION_KEY=s<N>` instead (see `patterns/tmux-monitoring.md`).
+
+Auto-archive on session start: `flightdeck-session start` rolls the live file to a `.json.archive` sibling before fresh init when (a) `terminated == true` or (b) the file has tracked entries but ZERO `pane_id` is currently alive in tmux. Removes the need to manually prune leftover state from prior tmux sessions or crashed masters. `flightdeck-session start` also exports `FLIGHTDECK_ENTRY_ID` into the launched child environment (consumed by `github.sh` / `linear.sh` wrappers to auto-bind activity events to the right entry) and captures the current `git rev-parse --abbrev-ref HEAD` of the entry's cwd into `entry.branch` (informational; not refreshed when the agent switches branches mid-session) and onto every `pr.*` activity row's `refs.branch`.
+
+Readers call `readTrackedEntries(state)` to get the canonical `TrackedEntry` map. Malformed non-object entry values are skipped with a stderr warning; malformed internal `entry.id` values warn and fall back to the map key. `writeTrackedEntry(state, id, entry)` validates non-empty ids (including `entry.domain.issue.id` when present), accepts the optional `entry.domain.github_issue` shape, rejects unknown `entry.domain.*` sub-keys, rejects entries that set both `domain.issue` and `domain.github_issue`, and writes `.entries[id]`. Linear issue-mode metadata lives under `entry.domain.issue` (`pr_number`, `worktree`, `merge_commit`, etc.). GitHub issue-mode metadata lives under `entry.domain.github_issue` (`number`, `url`, `worktree`, `pr_number`, `merge_commit`, `scope_files_actual`). Generic `adhoc`/`workflow` rows may also carry top-level `pr_number` and `worktree` for traceability without becoming issue-mode entries; readers must keep those separate from issue-domain routing. Dashboard renderers surface the nested issue views and generic top-level traceability fields without changing issue-domain routing.
+
+```json
+{
+  "session_id": "<TMUX_SESSION_NAME>",
+  "started_at": "<ISO8601>",
+  "activity_path": "<project-root>/tmp/flightdeck-activity-<TMUX_SESSION_NAME>.jsonl",
+  "activity_archive_path": null,
+  "activity_schema_version": 1,
+  "terminated": false,
+  "owner": {
+    "harness": "claude|opencode|codex|pi|unknown",
+    "pane_id": "%25",
+    "pane_target": "<TMUX_SESSION>:<window>.<pane>",
+    "cwd": "<absolute cwd>",
+    "pid": 1752875,
+    "pi_session_id": "<pi-session-id-or-null>",
+    "pi_bridge_socket": "<pi-bridge-socket-or-null>",
+    "discovery_error": "<warning-or-null>"
+  },
+  "entries": {
+    "<ENTRY_ID>": {
+      "id": "<ENTRY_ID>",
+      "title": "<human label>",
+      "kind": "adhoc|issue|workflow",
+      "state": "waiting|prompting|submitting|ready|complete|cancelled|dead",
+      "substate": null,
+      "harness": "claude|opencode|codex|pi|unknown",
+      "cwd": "<absolute cwd>",
+      "window": "<window-name-or-index>",
+      "pane_target": "<TMUX_SESSION>:<window>.<pane>",
+      "pane_id": "%403",
+      "pr_number": null,
+      "worktree": null,
+      "launch": {
+        "model": "<resolved-model-or-null>",
+        "effort": "<resolved-effort-or-thinking-or-null>",
+        "requested_model": "<explicit-or-env-model-or-null>",
+        "requested_effort": "<explicit-or-env-effort-or-null>",
+        "resolved_model": "<resolved-model-or-null>",
+        "resolved_effort": "<resolved-effort-or-thinking-or-null>",
+        "model_source": "explicit|env|auto|null",
+        "effort_source": "explicit|env|auto|null",
+        "argv": ["<resolved>", "<harness>", "argv>"],
+        "reasoning_status": "configured|recorded|unsupported|not-applicable",
+        "unsupported_reason": "<reason-or-null>",
+        "cmd": "<command-or-null>"
+      },
+      "adapter": {
+        "pi_bridge_pid": 0, "pi_bridge_socket": "<path-or-null>", "pi_session_id": "<id-or-null>",
+        "oc_url": "<server-url-or-null>", "oc_session_id": "<id-or-null>",
+        "cc_url": "<server-url-or-null>", "cc_transcript": "<path-or-null>",
+        "cx_ws": "<ws-url-or-null>", "cx_thread_id": "<id-or-null>"
+      },
+      "domain": {
+        "issue": {
+          "id": "<ISSUE_ID>",
+          "worktree": "<absolute path>",
+          "pr_number": 0,
+          "scope_files_declared": 5,
+          "scope_files_actual": 27,
+          "orchestration_started": true
+        },
+        "github_issue": {
+          "number": 120,
+          "url": "https://github.com/OWNER/REPO/issues/120",
+          "worktree": "<absolute path>",
+          "pr_number": 0,
+          "merge_commit": null,
+          "scope_files_actual": 27
+        }
+      },
+      "branch": "<git-branch-or-null>",
+      "last_capture_hash": "sha256:...",
+      "last_response_at": "<ISO8601>",
+      "spawned_at": "<ISO8601>",
+      "last_polled_at": "<ISO8601>",
+      "decisions_log": []
+    }
+  },
+  "merge_queue": ["<ISSUE_ID>", "<ISSUE_ID>"],
+  "conflict_graph": {
+    "edges": [["<ISSUE_A>", "<ISSUE_B>"]],
+    "computed_at": "<ISO8601>"
+  },
+  "paused_for_user": null
+}
+```
+
+Tracked entry state enum: `state ∈ {waiting, prompting, submitting, ready, complete, cancelled, dead}`. Issue-mode workflows additionally use `{merge-ready, merged, aborted}` for issue-specific lifecycle states; these map onto the generic enum via `domain.issue.phase` / `domain.issue.outcome` for Linear or `domain.github_issue.phase` / `domain.github_issue.outcome` for GitHub (e.g. `merged → complete + outcome="merged"`). `entryIdForIssue(issueId)` returns the issue id unchanged after validation (empty/invalid ids return null); `issueIdForEntry(entry)` reads `entry.domain.issue.id` or, for `kind: "issue"`, `entry.id`. GitHub entries use numeric `domain.github_issue.number` for lane-specific routing. `owner` is metadata written by `flightdeck-state init`; `owner.pid` is the owner harness PID supplied by `FLIGHTDECK_OWNER_PID` (falling back to parent PID), and `owner.discovery_error` records Pi bridge metadata lookup failures when the owner harness is Pi. Dashboard renderers use `owner.pane_id` to keep the persistent dashboard owner-scoped by default. `paused_for_user` carries `{entry_id|issue_id, reason, prompt_text}` when a guard or issue-mode pause fires.

--- a/skills/flightdeck/SCRIPTS.md
+++ b/skills/flightdeck/SCRIPTS.md
@@ -1,0 +1,55 @@
+# Flightdeck scripts reference
+
+Reference doc extracted from `SKILL.md`. See [`SKILL.md`](./SKILL.md) for the load-bearing rules; this file holds detailed reference content for on-demand consultation.
+
+## Scripts
+
+```bash
+.agents/skills/flightdeck/scripts/<script> [args]
+```
+
+**Implementation:** Most scripts are TypeScript under
+`skills/flightdeck/lib/flightdeck-core/`. Trampolines under `scripts/`
+exec `bun .../src/bin/<script>.ts`; `flightdeck-dashboard` is the Rust dashboard trampoline under `lib/flightdeck-dashboard/`. `bun` remains a hard runtime dependency for the TypeScript scripts.
+Functional + integration tests live under `lib/flightdeck-core/tests/`.
+
+| Script | Purpose |
+|--------|---------|
+| `open-terminal` | Spawn issue worktree(s) with selected harness + optional `--model`/`--effort`. **Never hand-roll issue tmux/terminal commands — use this for issue workflow spawns.** Linear is default; `--tracker github` accepts numeric issues, creates branch `issue-<N>`, fetches `gh issue view`, and emits a self-contained child prompt (no supervisor slash-command recursion). Tmux fallback delegates to `flightdeck-session` in issue mode. |
+| `flightdeck-session` | Generic session launcher/attacher. `start` creates a tmux window and registers `.entries[id]`; `attach` records an existing Pi pane by stable pane id. |
+| `parallel-groups` | Read/manage parallel issue groups. |
+| `flightdeck-state` | Atomic CRUD on `tmp/flightdeck-state-<TMUX_SESSION>.json` (`init`/`get`/`set`/`append`/`increment`/`tracked-entries`/`write-entry`/`archive`), activity JSONL sidecar commands (`activity path\|append\|tail\|export`), and master-busy lock (`master-busy lock\|unlock\|check`). See `workflows/shared/session-watch.md` § 1 for lock semantics. |
+| `flightdeck-daemon` | External wake driver. Polls inner panes, normalizes turn-end events, wakes master with a per-harness payload. Actions: `start \| stop \| status \| health \| events \| ack`. `start` exits `4` for stale `--master` (distinct from usage/missing dependency exit `2`). Master respawn trigger: `status --session <S>` says `no daemon` while live entries exist; source panes via `pane-registry list --format inner-panes-live` / `inner-harnesses-live`, re-resolve `$TMUX_PANE` and retry once on exit `4`, and do not yield on unresolved start failure. Full contract: `workflows/shared/session-watch.md` § 1 / § 6; adapter freshness: `patterns/tmux-monitoring.md`. |
+| `flightdeck-dashboard` | Rust TUI dashboard binary. Subcommands: `tui`, `daemon {start,stop,status,health,tail}`, `launch`, `supervise`. The TUI has keyboard/mouse navigation, help/theme/filter/detail/confirm popups, dashboard badge/chip legend, cost/token totals, and two confirmation-gated writes that shell to canonical helpers (`pane-registry remove` for stale entries, `tmux select-window` for focus). Lives in `skills/flightdeck/lib/flightdeck-dashboard/`. See `DEVELOPMENT.md` for the build + test workflow. |
+| `codex-app-server-spawn` / `-stop` | Idempotent bring-up/teardown of the per-session codex `app-server --listen ws://...` shared by all `codex --remote` panes. |
+| `pane-registry` | TrackedEntry↔pane mapping CRUD. `init-entry` writes `.entries[id]`; `init <ISSUE>` is an alias for `init-entry --kind issue`. `find-by-pane` emits `{id,kind}` JSON. `list --format json\|inner-panes\|inner-harnesses\|inner-panes-live\|inner-harnesses-live` feeds `pane-poll --batch -` and `flightdeck-daemon start`; use the `*-live` pair for daemon respawn. |
+| `pane-poll` | Pane state read. Preferred: `--batch -` from `pane-registry list --format json` (one JSONL object per tracked entry). Passes `kind` to `prompt-classify` so issue-only tags on ad-hoc entries become `domain-mismatch`. Legacy single-pane mode for drift re-polls / manual debug. See `patterns/tmux-monitoring.md` for per-harness adapter routes. |
+| `pane-respond` | Send response to a pane. Modes: free-text payload, `--option N`, `--option-multi`, `--keys` (rejected without `--keys-allow-tmux`), `--question <reqID> --answer\|--answer-multi\|--answer-text\|--answers-json\|--reject`. Validates rebase-multi-choice payloads for the preserve/apply/verify triplet. See `patterns/prompt-handlers.md` for mode selection and `patterns/opencode-questions.md` / `patterns/pi-questions.md` for question routing. |
+| `pane-clear-bell` | Atomic chained-command bell clear (no flicker). |
+| `pr-conflict-graph` | File-intersection adjacency for a list of PR numbers via `gh pr view --json files`. |
+| `label-add` / `label-remove` (in `skills/github/scripts/commands/`) | Add/remove GitHub labels via `gh pr edit` / `gh issue edit`. Emit `pr.labeled` / `pr.unlabeled` / `issue.labeled` / `issue.unlabeled` activity rows when `FLIGHTDECK_MANAGED=1`; silent otherwise. Wrapped by the `github` skill — flightdeck issue workflows call them indirectly. |
+| `prompt-classify` | Regex/sentinel + computed-tag matcher that maps pane state to handler tags. `--entry-kind` guards issue-only tags on non-issue entries; omitted kind and `--entry-kind-unknown` fail closed as `domain-mismatch`. See [`PROMPT-TAGS.md`](./PROMPT-TAGS.md) for the full tag catalog, including `merge-ready-but-unknown`, `pi-bg-task-exit`, `pi-activity-broker`, and `daemon-exited`. |
+
+`pi-bg-task-exit` (vstack#15): the Pi subscriber matches `pi-bridge stream` events of shape `{ type: "event", event: "message_end", data.message.customType: "vstack-background-tasks:event", data.message.details.eventType: "exit" }` and appends a canonical wake row to `WAKE_EVENTS_LOG`:
+
+```
+{"ts":"<iso>","pane_id":"%18","harness":"pi","event_type":"bg-task-exit","sequence":17,"task":{"id":"bg-3","status":"failed","exitCode":null,"command":"...","outputBytes":89},"classifier_tag":"pi-bg-task-exit","hash":"<12hex>"}
+```
+
+The daemon (`lib/flightdeck-core/src/daemon/loop.ts`) treats the tag as canonical, appends to the per-session events file via `appendEvent`, extends `WAKE_PENDING.in_flight`, and wakes master before emitting structured activity. Non-exit bg-task subscriber signals (for example `details.eventType: "output"`) append activity-only `pi-bg-task-activity` rows with `activity_event_type` and `sequence`; the daemon records them as `bg_task.output_matched` activity without waking master. Master routes terminal rows through `workflows/shared/session-watch.md` § 2 → `workflows/shared/session-handle-prompt.md` § 7; issue mode may then resume `workflows/linear/handle-prompt.md` § 4 for PR/CI/bot-review recovery. The classifier never sees these messages — they are system-role customType messages, not assistant text — so `prompt-classify` has no matching tag and only the daemon path produces them.
+
+`pi-activity-broker`: Pi extensions publish through `globalThis[Symbol.for("vstack.pi.activity")]`; `pi-session-bridge` streams each publication as `{type:"event", event:"vstack_activity", data:{...}}`. The Pi subscriber appends an activity-only `pi-activity-broker` row to `WAKE_EVENTS_LOG`. The TS daemon copies the subset payload into `flightdeck-activity-<session>.jsonl` with the tracked pane id and never wakes master. Set `FLIGHTDECK_PI_ACTIVITY_BROKER=0` to disable this broker drain and rely on legacy custom-message wake paths only.
+
+Activity sidecar: `flightdeck-state init` records `activity_path` beside the master state as `flightdeck-activity-<TMUX_SESSION>.jsonl`. `flightdeck-state activity path|append|tail|export` exposes the path, appends a normalized event, tails recent rows, or exports JSONL/Markdown. `activity export` accepts `--session <name>` and `--state-file <path>` for parity with `path` / `tail` / `append`, so dashboards and post-mortems can resolve sidecars without an active tmux session. Retention caps are 5,000 events and 10 MiB per live sidecar; oversized `details` are truncated to a 16 KiB budget. Daemon emission is curated: daemon/subscriber lifecycle, wake-delivery failures, subagent completions, bg-task exit/output rows, questions, and Pi broker rows. Workflow/github/linear helper emission is gated by `FLIGHTDECK_MANAGED=1 || FLIGHTDECK_ACTIVITY_FILE` so standalone wrapper use stays silent.
+
+`daemon-exited`: the daemon emits this lifecycle row during cleanup when it exits for `master-gone`, `signal-term`, `signal-int`, or another recorded reason. It writes directly to the per-session `EVENTS_FILE` under `SESSION_LOCK` (not `WAKE_EVENTS_LOG`), with `pane_id` set to the master pane id so pane-keyed drains include it:
+
+```
+{"ts":"<iso>","pane_id":"%25","event_type":"daemon-exited","reason":"master-gone","master_id":"%25","pid":12345,"hash":"<12hex>","tag":"daemon-exited","stable_age_sec":0,"details":{"event_type":"daemon-exited","reason":"master-gone","master_id":"%25","pid":12345}}
+```
+
+`session-watch.md` routes `daemon-exited` as a daemon-lifecycle signal, not a pane-prompt classification. It records the reason and follows the master respawn flow in `workflows/shared/session-watch.md` § 1 / § 6 before yielding.
+
+## Prompt tag catalog
+
+See [`PROMPT-TAGS.md`](./PROMPT-TAGS.md).

--- a/skills/flightdeck/SKILL.md
+++ b/skills/flightdeck/SKILL.md
@@ -18,35 +18,23 @@ metadata:
 ## STOP — Required Setup
 
 1. Verify `$TMUX` is set for every Flightdeck command. If unset, **exit immediately with no-op**: print `Flightdeck requires tmux; skipping.` and return control to the caller. Flightdeck does nothing outside tmux.
-2. Determine the command mode before loading dependencies:
-   - Generic session commands (`session start`, `session attach`, `session watch`, `session status`, `session stop`, `session remove`) require only tmux plus the selected harness adapter (`pi-bridge`, OpenCode HTTP, Claude Channels, Codex app-server, or tmux fallback). Do **not** load `github`, `linear`, `project-management`, or `worktree` for generic session commands.
-   - Linear issue workflow commands (`linear start [ISSUE_ID]`, `linear start new`, `linear start self`, `linear parallel-check`, `linear watch`, `linear merge-plan`, `linear close-issue`, `linear terminate` when entries use `domain.issue`) load `github`, `linear`, `project-management`, and `worktree` on demand. Redundant loads are no-ops.
-   - GitHub issue workflow commands (`github start <N>`, `github start new`, `github watch`, `github close-issue`, `github terminate` when entries use `domain.github_issue`) load `github` and `worktree` only. Do **not** load `linear` or `project-management` for GitHub mode.
-3. If an issue workflow dependency cannot be loaded after entering issue mode, stop and tell the user. Do not proceed with issue/PR/worktree actions without it.
-
----
+2. Determine the lane before loading dependencies:
+   - Generic session commands (`session start`, `session attach`, `session watch`, `session status`, `session stop`, `session remove`) require only tmux plus the selected harness adapter (`pi-bridge`, OpenCode HTTP, Claude Channels, Codex app-server, or tmux fallback). Do **not** load `github`, `linear`, `project-management`, or `worktree`.
+   - Linear issue commands (`linear start [ISSUE_ID]`, `linear start new`, `linear start self`, `linear parallel-check`, `linear watch`, `linear merge-plan`, `linear close-issue`, `linear terminate` when entries use `domain.issue`) load `github`, `linear`, `project-management`, and `worktree` on demand.
+   - GitHub issue commands (`github start <N>`, `github start new`, `github watch`, `github close-issue`, `github terminate` when entries use `domain.github_issue`) load `github` and `worktree` only. Do **not** load `linear` or `project-management`.
+3. If an issue-workflow dependency cannot be loaded after entering issue mode, stop and tell the user. Do not proceed with issue/PR/worktree actions without it.
 
 ## Dependency modes
 
-Core Flightdeck is a generic session manager. It requires tmux and the harness adapters needed for the tracked panes only; it does not require GitHub, Linear, project-management, or worktree skills.
+Core Flightdeck is a generic session manager. It needs tmux and the harness adapter for each tracked pane; GitHub, Linear, project-management, and worktree skills are issue-mode dependencies only.
 
-### Linear issue-mode dependencies (load when entering Linear issue workflows)
+| Lane | Load | Do not load |
+|------|------|-------------|
+| Session | tmux + selected harness adapter | `github`, `linear`, `project-management`, `worktree` |
+| Linear issue | `github`, `linear`, `project-management`, `worktree` | only skip redundant loads |
+| GitHub issue | `github`, `worktree` | `linear`, `project-management` |
 
-- `github` — PR inspection, merge state, checks, review threads, file lists.
-- `linear` — issue metadata, created follow-ups, cycle/todo recommendation checks.
-- `worktree` — issue branch/worktree ownership and cleanup scope.
-- `project-management` — Linear issue workflow planning/research context and follow-up recommendation support.
-
-### GitHub issue-mode dependencies (load when entering GitHub issue workflows)
-
-- `github` — issue/PR inspection, merge state, checks, reviews, issue close.
-- `worktree` — issue branch/worktree ownership and cleanup scope.
-
-GitHub mode intentionally does **not** load `linear` or `project-management`.
-
-`decider` remains optional for agents that want an extra decision aid, but core session management does not require it.
-
----
+`decider` remains optional for agents that want an extra decision aid.
 
 ## Mode
 
@@ -54,11 +42,26 @@ You are in **master mode**. Master supervises: it routes prompts, updates state/
 
 Generic session mode is the core path: launch/attach with `flightdeck-session`, supervise with `session-watch.md`, answer generic prompts, and summarize sessions. It skips issue selection, research/plan evaluation, `open-terminal`, merge planning, GitHub/Linear/worktree actions, and project-management flows.
 
-Issue-mode global arc begins only after entering a Linear or GitHub issue workflow command. Linear mode keeps the existing research/plan evaluation → spawn (`open-terminal`) → watch loop → merge planning → unwind path. GitHub mode resolves issue context with `gh`, spawns a child with a self-contained prompt through `open-terminal --tracker github`, watches PR/CI/review state, then verifies close/termination from authoritative GitHub state. Communicate with spawned agents through native channels (`pane-respond`): opencode HTTP, Claude Channels MCP/JSONL, Pi bridge, Codex JSON-RPC, with tmux capture/send-keys only as fallback (see `patterns/tmux-monitoring.md`). Pause for the user only on scope creep that requires reverting agent work, force-merging against a real content conflict, issue abort, direct `main` mutation when no orchestrator pane is alive, or a novel prompt shape no rule covers. Do not re-implement orchestration gates; answer surfaced prompts and add only cross-session conflict/scope facts.
+Issue-mode begins only after a Linear or GitHub issue command. Linear mode keeps the research/plan evaluation → spawn (`open-terminal`) → watch loop → merge planning → unwind path. GitHub mode resolves issue context with `gh`, spawns a child with a self-contained prompt through `open-terminal --tracker github`, watches PR/CI/review state, then verifies close/termination from authoritative GitHub state.
+
+Communicate with spawned agents through native channels (`pane-respond`): OpenCode HTTP, Claude Channels MCP/JSONL, Pi bridge, Codex JSON-RPC, with tmux capture/send-keys only as fallback (see `patterns/tmux-monitoring.md`). Pause for the user only on scope creep that requires reverting agent work, force-merging against a real content conflict, issue abort, direct `main` mutation when no orchestrator pane is alive, or a novel prompt shape no rule covers. Do not re-implement orchestration gates; answer surfaced prompts and add only cross-session conflict/scope facts.
+
+## Reference docs
+
+Load these on demand; keep this file as the operational quick path.
+
+| Need | Read |
+|------|------|
+| Master-state JSON, activity sidecar, registry shape, `readTrackedEntries` / `writeTrackedEntry` contract | [`SCHEMA.md`](./SCHEMA.md) |
+| Full scripts table, script arguments, Pi bg-task exit, Pi activity broker, activity sidecar, `daemon-exited` details | [`SCRIPTS.md`](./SCRIPTS.md) |
+| Full `prompt-classify` tag catalog, including daemon/event-only tags | [`PROMPT-TAGS.md`](./PROMPT-TAGS.md) |
+| Env var tables: master loop, watchdog gates, daemon hygiene, dashboard, adapter tuning | [`ENV.md`](./ENV.md) |
+| Watchdog behavior: agent-end, idle-stall, edit-loop, rate-limit | [`WATCHDOGS.md`](./WATCHDOGS.md) |
+| Development workflow, parity tests, daemon internals | [`DEVELOPMENT.md`](./DEVELOPMENT.md) |
 
 ## Commands
 
-Use the session-management table for the core Flightdeck product: tracked tmux-window sessions, harness IO, generic prompts, and summaries. Dashboard terms are distinct: TrackedEntry row = source-of-truth state; Rust dashboard/TUI = persistent visibility launched by default; cycle summary = chat-visible tick report, not a dashboard replacement. Use a lane-specific issue-workflow table only after the user enters the issue/PR/worktree domain; those workflows layer on `session-watch.md` / `session-handle-prompt.md` rather than replacing them.
+Use the session table for core Flightdeck: tracked tmux-window sessions, harness IO, generic prompts, and summaries. Use Linear/GitHub tables only after the user enters an issue/PR/worktree domain. Dashboard terms: TrackedEntry row = source-of-truth state; Rust dashboard/TUI = persistent visibility; cycle summary = chat-visible tick report.
 
 ### Session management
 
@@ -66,49 +69,49 @@ Generic tmux-window session tracking. These commands do not require a fake issue
 
 | Command | Arguments | Workflow / Script | Notes |
 |---------|-----------|-------------------|-------|
-| `session start` | `--session-id <ID> --title <T> --cwd <path> --harness <H> (--cmd <cmd> \| --prompt <text>) [--kind adhoc\|workflow] [--model <id>] [--effort <level>\|--thinking <level>]` | `scripts/flightdeck-session start` | Creates a new tmux window (never a split), launches the command/harness, sets `FLIGHTDECK_MANAGED=1` + `FLIGHTDECK_CHILD_PANE=1`, records launch model/effort metadata, and records a generic `.entries[ID]` row. Prompt LLM launches pass harness-aware model/effort argv (Pi `--model` + `--thinking`, Claude `--model` + `--effort`, Codex `-m` + `model_reasoning_effort`; OpenCode validates `--model` via `opencode models` and records effort unsupported). Launches/verifies the Rust dashboard by default unless `FLIGHTDECK_DASHBOARD=0`. |
-| `session attach` | `--pane <%PANE_ID> --harness <H> --title <T> [--session-id <ID>] [--kind adhoc] [--model <id>] [--effort <level>\|--thinking <level>]` | `scripts/flightdeck-session attach` | Attaches an existing pane without launching a new window, records supplied or unsupported model/effort metadata, and launches/verifies the Rust dashboard unless disabled. Pi attach also probes `pi-bridge` by pane pid and records `pi_session_id`/socket metadata when available. |
-| `session watch` | `[ENTRY_ID...]` | `workflows/shared/session-watch.md` | Generic daemon/poll/handler loop for tracked entries. Verifies dashboard presence on re-entry before daemon yield. Routes only generic handlers and guards issue-only tags as `domain-mismatch`; no GitHub/Linear/worktree dependency. |
+| `session start` | `--session-id <ID> --title <T> --cwd <path> --harness <H> (--cmd <cmd> \| --prompt <text>) [--kind adhoc\|workflow] [--model <id>] [--effort <level>\|--thinking <level>]` | `scripts/flightdeck-session start` | Creates a new tmux window (never a split), launches command/harness, records a generic `.entries[ID]` row, records launch model/effort metadata, exports Flightdeck child env, and launches/verifies the Rust dashboard unless `FLIGHTDECK_DASHBOARD=0`. Prompt launches pass harness-aware model/effort argv. |
+| `session attach` | `--pane <%PANE_ID> --harness <H> --title <T> [--session-id <ID>] [--kind adhoc] [--model <id>] [--effort <level>\|--thinking <level>]` | `scripts/flightdeck-session attach` | Attaches an existing pane by stable pane id, records supplied or unsupported launch metadata, and launches/verifies the dashboard unless disabled. Pi attach probes `pi-bridge` when available. |
+| `session watch` | `[ENTRY_ID...]` | `workflows/shared/session-watch.md` | Generic daemon/poll/handler loop. Verifies dashboard presence on re-entry before daemon yield. Routes only generic handlers and guards issue-only tags as `domain-mismatch`; no GitHub/Linear/worktree dependency. |
 | `session prompt routing` | nested from `session watch` | `workflows/shared/session-handle-prompt.md` | Generic prompt handlers for structured questions, bash permission prompts, safe bounded choices, terminal completion, `pi-bg-task-exit`, and `domain-mismatch`. |
 | `session status` | — | inline / `flightdeck-state tracked-entries` | Read-only normalized `.entries` snapshot. |
-| `session stop` / `session remove` | `<ENTRY_ID>` | `pane-registry teardown-entry` / `pane-registry remove` | Teardown uses stable `pane_id` and accepts the issue-mode lifecycle (`merged|aborted|dead`) plus the generic lifecycle (`complete|cancelled`) as terminal states. `remove` drops the `.entries` row. |
+| `session stop` / `session remove` | `<ENTRY_ID>` | `pane-registry teardown-entry` / `pane-registry remove` | Teardown uses stable `pane_id` and accepts issue-mode plus generic terminal states. `remove` drops the `.entries` row. |
 
 ### Linear issue workflows
 
-Linear issue/PR/worktree workflows. Entering these commands loads Linear issue-mode dependencies on demand. Use the GitHub table below for GitHub-tracked issues; use the session table for non-issue work.
+Entering these commands loads Linear issue-mode dependencies on demand. Use GitHub commands for numeric GitHub issues and session commands for non-issue work.
 
 | Command | Arguments | Workflow | Notes |
 |---------|-----------|----------|-------|
-| `linear start` | `[ISSUE_ID]` | `workflows/linear/start.md` | From-main issue entry. Dashboard, issue selection, research evaluation, parallel-check, spawn (`open-terminal`), enter Linear watch loop. |
+| `linear start` | `[ISSUE_ID]` | `workflows/linear/start.md` | From-main issue entry: dashboard, issue selection, research evaluation, parallel-check, spawn (`open-terminal`), enter Linear watch loop. |
 | `linear start new` | `[title]` | `workflows/linear/start-new.md` | Create new issue + spawn through the Linear issue workflow path. |
-| `linear start self` | — | inline | Initialize master Linear issue session only, await further issue commands. |
-| `linear parallel-check` | `[ISSUE_IDS]` | `workflows/linear/parallel-check.md` | Verify a candidate issue set is safe to spawn in parallel. |
+| `linear start self` | — | inline | Initialize master Linear issue session only; await further issue commands. |
+| `linear parallel-check` | `[ISSUE_IDS]` | `workflows/linear/parallel-check.md` | Verify candidate issue set is safe to spawn in parallel. |
 | `linear watch` | `[ISSUE_IDS]` | `workflows/linear/watch.md` → `workflows/shared/session-watch.md` | Linear issue-mode extension over the generic loop. Tracks issue-specific lifecycle states, routes PR/Linear/worktree handlers, and resumes merge planning. |
 | `linear merge-plan` | — | `workflows/linear/merge-plan.md` | Build PR conflict graph and choose smallest-safe merge order for Linear issue entries. |
-| `linear close-issue` | `<ISSUE_ID>` | `workflows/linear/close-issue.md` | Verify terminal issue outcome, record issue fields, and tear down the issue window safely. |
-| `linear terminate` | — | `workflows/linear/terminate.md` | If any tracked entry is `kind=issue`, produce the issue/PR/new-issue recommendation summary; mixed sessions also include generic session summary. |
-
-### Lane-agnostic status
-
-| Command | Arguments | Workflow | Notes |
-|---------|-----------|----------|-------|
-| `status` | — | inline | Print current pane registry + state machine snapshot from `tmp/flightdeck-state-<TMUX_SESSION>.json`. Read-only. |
+| `linear close-issue` | `<ISSUE_ID>` | `workflows/linear/close-issue.md` | Verify terminal issue outcome, record issue fields, and tear down issue window safely. |
+| `linear terminate` | — | `workflows/linear/terminate.md` | Produce issue/PR/new-issue recommendation summary when issue entries exist; mixed sessions also include generic session summary. |
 
 ### GitHub issue workflows
 
-Plain GitHub issue/PR/worktree workflows. Entering these commands loads `github` + `worktree` only. The child pane receives a self-contained prompt; do not invoke a master-side flightdeck supervisor workflow inside the child.
+Entering these commands loads `github` + `worktree` only. Child panes receive self-contained prompts; do not invoke a master-side Flightdeck supervisor workflow inside the child.
 
 | Command | Arguments | Workflow | Notes |
 |---------|-----------|----------|-------|
 | `github start` | `<N> [--repo OWNER/REPO]` | `workflows/github/start.md` | Resolve `gh issue view`, create/reuse worktree branch `issue-<N>`, launch with `open-terminal --tracker github`, register `domain.github_issue`, enter GitHub watch. |
 | `github start new` | `[title] [--repo OWNER/REPO]` | `workflows/github/start-new.md` | Create a GitHub issue, then run `github start <N>`. |
 | `github watch` | `[N...]` | `workflows/github/watch.md` → `workflows/shared/session-watch.md` | GitHub extension over the generic loop. Handles PR/CI/review prompts, `UNKNOWN` merge timers, and gh failure escalation. |
-| `github close-issue` | `<N>` | `workflows/github/close-issue.md` | Requires recorded PR number plus authoritative `gh pr view` `state === MERGED` and non-null merge commit before closing/no-oping issue. Missing merge commit pauses visibly. Pane text alone is never enough. |
+| `github close-issue` | `<N>` | `workflows/github/close-issue.md` | Requires recorded PR plus authoritative `gh pr view` `state === MERGED` and non-null merge commit before closing/no-oping issue. Pane text alone is never enough. |
 | `github terminate` | — | `workflows/github/terminate.md` | Summarizes GitHub entries partitioned by `domain.github_issue`; mixed sessions also include generic and Linear summaries. |
+
+### Lane-agnostic status
+
+| Command | Arguments | Workflow | Notes |
+|---------|-----------|----------|-------|
+| `status` | — | inline | Print current pane registry + state machine snapshot from `<FLIGHTDECK_STATE_DIR>/flightdeck-state-<TMUX_SESSION>.json`. Read-only. |
 
 ## Skill Rules
 
-Decision rules grouped by domain. Each pattern doc under `patterns/` has the full context, examples, and edge cases — the bullets below are the quick-reference rules. Read the matching pattern doc whenever its prompt class appears.
+Decision rules grouped by domain. Pattern docs under `patterns/` hold examples and edge cases. Read the matching pattern doc whenever its prompt class appears.
 
 ### Tmux monitoring (`patterns/tmux-monitoring.md`)
 
@@ -121,279 +124,60 @@ Decision rules grouped by domain. Each pattern doc under `patterns/` has the ful
 
 ### Prompt handlers (`patterns/prompt-handlers.md`)
 
-- **Cleanup scope** — answer YES iff the target path equals the asking pane's registered worktree. NEVER for sibling worktrees (parallel sessions still using them). Extract the path from the prompt text and compare to the registry entry. Some agents propose batch cleanup; that's wrong.
-- **Combine guidance with the option pick** — when picking an option triggers immediate sub-agent delegation (rebase, fix), the sub-agent guidance must ride in the SAME input. `pane-respond` rejects rebase-multi-choice payloads missing the preserve/apply/verify triplet.
-- **Bot-review prompt response** — on a Skip/Wait/Abort prompt, decide from `gh pr view <PR> --json statusCheckRollup,reviewDecision,labels`. Skip if the bot check is `SUCCESS` and `reviewDecision == APPROVED` (or unset with no pending reviewers). Real pending reviewer → escalate. Master never re-invokes `bot-review-wait` itself.
+- **Cleanup scope** — answer YES iff the target path equals the asking pane's registered worktree. NEVER for sibling worktrees. Extract the path from prompt text and compare to the registry entry. Some agents propose batch cleanup; that's wrong.
+- **Combine guidance with option pick** — when picking an option triggers immediate sub-agent delegation (rebase, fix), sub-agent guidance must ride in the SAME input. `pane-respond` rejects `rebase-multi-choice` payloads missing the preserve / apply / verify triplet.
+- **Bot-review prompt response** — on a Skip/Wait/Abort prompt, decide from `gh pr view <PR> --json statusCheckRollup,reviewDecision,labels`. Skip if bot check is `SUCCESS` and `reviewDecision == APPROVED` (or unset with no pending reviewers). Real pending reviewer → escalate. Master never re-invokes `bot-review-wait` itself.
 - **GitHub merge-now gate** — before answering Merge in GitHub mode, run `gh pr view <PR> --json mergeStateStatus,reviewDecision,statusCheckRollup`. Auto-Merge only when `mergeStateStatus === "CLEAN"`, review is approved (or no pending reviewers), and every required check is `SUCCESS` or `SKIPPED`. `UNKNOWN`, `BEHIND`, `DIRTY`, `BLOCKED`, `HAS_HOOKS`, missing fields, and `FLIGHTDECK_AUTO_MERGE=0` all escalate or route to the documented UNKNOWN/auto-rebase path; never merge from pane text alone. `FLIGHTDECK_AUTO_MERGE=0` also blocks force-merge confirmation and UNKNOWN-timer transitions to force-merge.
-- **Rebase-multi-choice guidance** — payload must follow the **preserve / apply / verify** triplet:
-  - **Preserve**: function signatures / parameter splits / new wrappers from the upstream merge that must NOT be reverted.
+- **Rebase-multi-choice guidance** — payload must follow the preserve / apply / verify triplet:
+  - **Preserve**: function signatures / parameter splits / new wrappers from upstream merge that must NOT be reverted.
   - **Apply**: field renames / type updates / local refactors that go ON TOP of the preserved shape.
-  - **Verify**: the exact test invocation proving both sides intact.
-- **Parent vs related** (audit prompts) — accept `child of <current-PR-issue>` when scopes don't intersect another live worktree's PR files (expansion bias). Reject → use `related` or pick a different parent. Capture each new issue's proposed parent/project/scope at decision time for the end-of-session report.
-- **Verify-don't-trust** — never advance an issue's state on an agent's claim alone. After any structural change (rebase done, conflicts resolved, fields renamed), run a verification grep against the worktree. For rebases: check function signatures and rename counts in every conflict file.
+  - **Verify**: exact test invocation proving both sides intact.
+- **Parent vs related** — accept `child of <current-PR-issue>` when scopes don't intersect another live worktree's PR files (expansion bias). Reject → use `related` or pick a different parent. Capture each new issue's proposed parent/project/scope at decision time for end-of-session report.
+- **Verify-don't-trust** — never advance issue state on an agent claim alone. After structural change (rebase done, conflicts resolved, fields renamed), run verification grep against the worktree. For rebases: check function signatures and rename counts in every conflict file.
 
 ### Conflict detection (`patterns/conflict-detection.md`)
 
-- **`defer-ci`** label blocks heavy CI lanes (Lint, Cross-Platform, Linux Integration, Bench, Fixture Sync) but NOT bot reviews. Bot review runs with `defer-ci`; CI runs after the label drops.
+- **`defer-ci`** label blocks heavy CI lanes (Lint, Cross-Platform, Linux Integration, Bench, Fixture Sync) but NOT bot reviews. Bot review runs with `defer-ci`; CI runs after label drops.
 - **File-level conflict graph** — build edges from `gh pr view <N> --json files`. Two PRs with file-set intersection conflict; merge order is topological + smallest-scope-first.
-- **UNKNOWN-state timer** — GitHub's `mergeStateStatus` stays `UNKNOWN` for minutes after upstream `main` moves. Force-merge predicate: `APPROVED ∧ all_checks_in {SUCCESS, SKIPPED} ∧ disjoint(PR_files, main_files_recently_changed) ∧ unknown_since > FLIGHTDECK_FORCE_MERGE_AFTER_SECS ∧ FLIGHTDECK_AUTO_MERGE != 0`.
+- **UNKNOWN-state timer** — GitHub `mergeStateStatus` can stay `UNKNOWN` for minutes after upstream `main` moves. Force-merge predicate: `APPROVED ∧ all_checks_in {SUCCESS, SKIPPED} ∧ disjoint(PR_files, main_files_recently_changed) ∧ unknown_since > FLIGHTDECK_FORCE_MERGE_AFTER_SECS ∧ FLIGHTDECK_AUTO_MERGE != 0`.
 - **GitHub issue close** — `github close-issue` requires `domain.github_issue.pr_number` plus authoritative `gh pr view <PR> --json state,mergeStateStatus,mergeCommit` with `state === "MERGED"` and non-null `mergeCommit` before `gh issue close`. If `state === "MERGED"` but `mergeCommit` is null, pause with `reason="gh-pr-merge-commit-missing"`. If `gh issue view <N> --json state` says already `CLOSED`, no-op and log; pane-buffer `MERGED` text is never sufficient.
 
 ### Decision biases (`patterns/decision-biases.md`)
 
 - **Scope-creep detector** — `scope_files_actual` (from `gh pr view --json files`) vs `scope_files_declared` (parsed from issue description). `actual > 2× declared` → escalate. Don't auto-revert.
-- **Smaller-PR-first** — when two PRs overlap, the smaller one merges first; the bigger absorbs the rebase. Reverse order forces the smaller PR to rebase against a bigger restructure.
-- **Rule of three** — don't extract a shared helper across <3 sibling files. At 2 sites the abstraction shape isn't visible; at 3 the rule is satisfied.
-- **Expansion bias** — prefer inline fixes in the current PR over new issues, UNLESS the reason is concrete (different scope, different agent, requires measurement, blocked dep, architectural decision). "Tidiness" is not a reason.
+- **Smaller-PR-first** — when two PRs overlap, smaller merges first; bigger absorbs the rebase. Reverse order forces smaller PR to rebase against bigger restructure.
+- **Rule of three** — don't extract a shared helper across <3 sibling files. At 2 sites abstraction shape isn't visible; at 3 rule is satisfied.
+- **Expansion bias** — prefer inline fixes in current PR over new issues, UNLESS reason is concrete (different scope, different agent, requires measurement, blocked dep, architectural decision). "Tidiness" is not a reason.
 - **Merge-order tiebreakers**: (1) smallest scope first, (2) overlapping files: smaller first, (3) else: any order.
 
 ### Structured questions (`patterns/opencode-questions.md`, `patterns/pi-questions.md`)
 
-- **Never pass off-list labels.** Pick `--answer` / `--answer-multi` values from `question.questions[i].options[].label`. Pi `--answer-text` only when the matching tab has `allowCustom=true`; opencode free-form requires `--reject` + a follow-up `opencode run --attach --session <SID> "<text>"`.
-- **Pi inner agent completions** are advisory. Re-poll the outer orchestrator only; never call `subagent`/`steer_subagent`/`get_subagent_result` against an orchestrator's inner panes.
+- **Never pass off-list labels.** Pick `--answer` / `--answer-multi` values from `question.questions[i].options[].label`. Pi `--answer-text` only when matching tab has `allowCustom=true`; OpenCode free-form requires `--reject` + follow-up `opencode run --attach --session <SID> "<text>"`.
+- **Pi inner agent completions** are advisory. Re-poll the outer orchestrator only; never call `subagent` / `steer_subagent` / `get_subagent_result` against an orchestrator's inner panes.
 
-### Rate-limit recovery (`lib/flightdeck-core/src/daemon/rate-limit-watchdog.ts`)
+### Rate-limit recovery (`WATCHDOGS.md`, `lib/flightdeck-core/src/daemon/rate-limit-watchdog.ts`)
 
-- **Do not escalate rate-limited panes as "stuck".** When a tracked Pi pane (master or child) emits an assistant `message_end` with `role: "assistant"`, `stopReason: "error"`, and canonical rate-limit prose in the assistant envelope (`errorMessage` or `content[].text`: `temporarily limiting requests`, `Rate limited`, `429`, `too many requests`), the daemon's Pi subscriber routes the event through the rate-limit watchdog instead of the normal wake path. User/toolResult messages, missing stop reasons, and prose outside the assistant envelope are ignored. The watchdog suppresses the `needs_completion` synthetic outbox that the agent-end-watchdog would otherwise fire and schedules a `pi-bridge steer "API rate limit was detected. Try to continue from where you left off."` at the computed retry time.
-- **Backoff ladder** — default `60s, 120s, 300s, 600s, 1800s`, max `5` attempts per pane. An Anthropic-provided `retry_after_ms` wins over the env ladder. After exhaustion the watchdog stops retrying and the pane falls through to the normal `needs_completion` path. Env tuning: `VSTACK_RATE_LIMIT_WATCHDOG=0` disables; `VSTACK_RATE_LIMIT_MAX_ATTEMPTS` overrides the attempt cap; `VSTACK_RATE_LIMIT_BACKOFF_LADDER` overrides the ladder.
-- **Classifier + activity signals** — the Pi wake-event classifier tags rate-limit decisions as `pi-rate-limit-retry` (scheduled) and `pi-rate-limit-exhausted` (ladder spent). Subagent panes additionally publish `subagents:rate_limited`, `subagents:rate_limit_retry`, `subagents:rate_limit_resolved`, and `subagents:rate_limit_exhausted` through the Pi activity broker, which the daemon mirrors into the activity sidecar. Treat these as advisory; do not pause master or prompt the user unless the exhausted tag fires.
-- **Layer A vs B** — subagent panes (`pi-agents-tmux`) carry their own vendored watchdog; flightdeck-managed tracked panes are covered by the daemon’s Pi subscriber wake branch. Both consume the same pure decision module (parity-tested), so the contract above applies regardless of which layer owns the pane.
+- **Do not escalate rate-limited panes as "stuck".** A tracked Pi pane rate-limit envelope routes through the rate-limit watchdog instead of the normal wake path. User/toolResult messages, missing stop reasons, and prose outside the assistant envelope are ignored.
+- **Backoff ladder** — default `60s, 120s, 300s, 600s, 1800s`, max `5` attempts per pane. Anthropic `retry_after_ms` wins over env ladder. After exhaustion the watchdog stops retrying and the pane falls through to normal `needs_completion` handling. Env tuning lives in [`ENV.md`](./ENV.md): `VSTACK_RATE_LIMIT_WATCHDOG=0`, `VSTACK_RATE_LIMIT_MAX_ATTEMPTS`, `VSTACK_RATE_LIMIT_BACKOFF_LADDER`.
+- **Classifier + activity signals** — rate-limit decisions tag as `pi-rate-limit-retry` (scheduled) and `pi-rate-limit-exhausted` (ladder spent). Treat these as advisory; do not pause master or prompt user unless exhausted tag fires.
+- **Layer A vs B** — subagent panes (`pi-agents-tmux`) carry their own vendored watchdog; Flightdeck-managed tracked panes are covered by the daemon's Pi subscriber wake branch. Both consume the same pure decision module.
 
 ## Scripts
 
-```bash
-.agents/skills/flightdeck/scripts/<script> [args]
-```
+Full script table and event details live in [`SCRIPTS.md`](./SCRIPTS.md). Required quick rules:
 
-**Implementation:** Most scripts are TypeScript under
-`skills/flightdeck/lib/flightdeck-core/`. Trampolines under `scripts/`
-exec `bun .../src/bin/<script>.ts`; `flightdeck-dashboard` is the Rust dashboard trampoline under `lib/flightdeck-dashboard/`. `bun` remains a hard runtime dependency for the TypeScript scripts.
-Functional + integration tests live under `lib/flightdeck-core/tests/`.
+- Invoke scripts as `.agents/skills/flightdeck/scripts/<script> [args]` when using installed skill paths.
+- Most scripts trampoline into TypeScript under `lib/flightdeck-core/`; `flightdeck-dashboard` is the Rust dashboard trampoline.
+- Use `open-terminal` for issue workflow spawns. Never hand-roll issue tmux/terminal commands.
+- Use `flightdeck-session` for generic session `start` / `attach`.
+- Use `pane-poll` and `pane-respond` for pane IO; do not bypass adapter routes except as documented fallback.
+- Use `prompt-classify` tag names exactly. Full tag catalog lives in [`PROMPT-TAGS.md`](./PROMPT-TAGS.md).
 
-| Script | Purpose |
-|--------|---------|
-| `open-terminal` | Spawn issue worktree(s) with selected harness + optional `--model`/`--effort`. **Never hand-roll issue tmux/terminal commands — use this for issue workflow spawns.** Linear is default; `--tracker github` accepts numeric issues, creates branch `issue-<N>`, fetches `gh issue view`, and emits a self-contained child prompt (no supervisor slash-command recursion). Tmux fallback delegates to `flightdeck-session` in issue mode. |
-| `flightdeck-session` | Generic session launcher/attacher. `start` creates a tmux window and registers `.entries[id]`; `attach` records an existing Pi pane by stable pane id. |
-| `parallel-groups` | Read/manage parallel issue groups. |
-| `flightdeck-state` | Atomic CRUD on `tmp/flightdeck-state-<TMUX_SESSION>.json` (`init`/`get`/`set`/`append`/`increment`/`tracked-entries`/`write-entry`/`archive`), activity JSONL sidecar commands (`activity path\|append\|tail\|export`), and master-busy lock (`master-busy lock\|unlock\|check`). See `workflows/shared/session-watch.md` § 1 for lock semantics. |
-| `flightdeck-daemon` | External wake driver. Polls inner panes, normalizes turn-end events, wakes master with a per-harness payload. Actions: `start \| stop \| status \| health \| events \| ack`. `start` exits `4` for stale `--master` (distinct from usage/missing dependency exit `2`). Master respawn trigger: `status --session <S>` says `no daemon` while live entries exist; source panes via `pane-registry list --format inner-panes-live` / `inner-harnesses-live`, re-resolve `$TMUX_PANE` and retry once on exit `4`, and do not yield on unresolved start failure. Full contract: `workflows/shared/session-watch.md` § 1 / § 6; adapter freshness: `patterns/tmux-monitoring.md`. |
-| `flightdeck-dashboard` | Rust TUI dashboard binary. Subcommands: `tui`, `daemon {start,stop,status,health,tail}`, `launch`, `supervise`. The TUI has keyboard/mouse navigation, help/theme/filter/detail/confirm popups, dashboard badge/chip legend, cost/token totals, and two confirmation-gated writes that shell to canonical helpers (`pane-registry remove` for stale entries, `tmux select-window` for focus). Lives in `skills/flightdeck/lib/flightdeck-dashboard/`. See `DEVELOPMENT.md` for the build + test workflow. |
-| `codex-app-server-spawn` / `-stop` | Idempotent bring-up/teardown of the per-session codex `app-server --listen ws://...` shared by all `codex --remote` panes. |
-| `pane-registry` | TrackedEntry↔pane mapping CRUD. `init-entry` writes `.entries[id]`; `init <ISSUE>` is an alias for `init-entry --kind issue`. `find-by-pane` emits `{id,kind}` JSON. `list --format json\|inner-panes\|inner-harnesses\|inner-panes-live\|inner-harnesses-live` feeds `pane-poll --batch -` and `flightdeck-daemon start`; use the `*-live` pair for daemon respawn. |
-| `pane-poll` | Pane state read. Preferred: `--batch -` from `pane-registry list --format json` (one JSONL object per tracked entry). Passes `kind` to `prompt-classify` so issue-only tags on ad-hoc entries become `domain-mismatch`. Legacy single-pane mode for drift re-polls / manual debug. See `patterns/tmux-monitoring.md` for per-harness adapter routes. |
-| `pane-respond` | Send response to a pane. Modes: free-text payload, `--option N`, `--option-multi`, `--keys` (rejected without `--keys-allow-tmux`), `--question <reqID> --answer\|--answer-multi\|--answer-text\|--answers-json\|--reject`. Validates rebase-multi-choice payloads for the preserve/apply/verify triplet. See `patterns/prompt-handlers.md` for mode selection and `patterns/opencode-questions.md` / `patterns/pi-questions.md` for question routing. |
-| `pane-clear-bell` | Atomic chained-command bell clear (no flicker). |
-| `pr-conflict-graph` | File-intersection adjacency for a list of PR numbers via `gh pr view --json files`. |
-| `label-add` / `label-remove` (in `skills/github/scripts/commands/`) | Add/remove GitHub labels via `gh pr edit` / `gh issue edit`. Emit `pr.labeled` / `pr.unlabeled` / `issue.labeled` / `issue.unlabeled` activity rows when `FLIGHTDECK_MANAGED=1`; silent otherwise. Wrapped by the `github` skill — flightdeck issue workflows call them indirectly. |
-| `prompt-classify` | Regex/sentinel + computed-tag matcher mapping pane state to a handler tag: `rendering`, `terminal-state-reached`, `bash-permission-prompt`, `force-merge-confirm`, `merge-ready-but-unknown`, `merge-now`, `bot-review-wait-stuck`, `rebase-multi-choice`, `force-push-prompt`, `cleanup-prompt`, `audit-relation-prompt`, `descope-related`, `external-fix-suggestions`, `cycle-fix-suggestions`, `scope-creep-detected` [computed], `multi-select-tabbed`, `awaiting-direction`, `generic-multi-choice`, `domain-mismatch`, `idle`. `--entry-kind` guards issue-only tags on non-issue entries; omitted kind and `--entry-kind-unknown` fail closed as `domain-mismatch`. Daemon/event-only tags: `oc-question`, `pi-question`, `pi-subagent-completion`, `pi-bg-task-exit`, `pi-activity-broker`, `pi-rate-limit-retry`, `pi-rate-limit-exhausted`, `daemon-exited`. |
+## Schema, watchdogs, and configuration
 
-`pi-bg-task-exit` (vstack#15): the Pi subscriber matches `pi-bridge stream` events of shape `{ type: "event", event: "message_end", data.message.customType: "vstack-background-tasks:event", data.message.details.eventType: "exit" }` and appends a canonical wake row to `WAKE_EVENTS_LOG`:
-
-```
-{"ts":"<iso>","pane_id":"%18","harness":"pi","event_type":"bg-task-exit","sequence":17,"task":{"id":"bg-3","status":"failed","exitCode":null,"command":"...","outputBytes":89},"classifier_tag":"pi-bg-task-exit","hash":"<12hex>"}
-```
-
-The daemon (`lib/flightdeck-core/src/daemon/loop.ts`) treats the tag as canonical, appends to the per-session events file via `appendEvent`, extends `WAKE_PENDING.in_flight`, and wakes master before emitting structured activity. Non-exit bg-task subscriber signals (for example `details.eventType: "output"`) append activity-only `pi-bg-task-activity` rows with `activity_event_type` and `sequence`; the daemon records them as `bg_task.output_matched` activity without waking master. Master routes terminal rows through `workflows/shared/session-watch.md` § 2 → `workflows/shared/session-handle-prompt.md` § 7; issue mode may then resume `workflows/linear/handle-prompt.md` § 4 for PR/CI/bot-review recovery. The classifier never sees these messages — they are system-role customType messages, not assistant text — so `prompt-classify` has no matching tag and only the daemon path produces them.
-
-`pi-activity-broker`: Pi extensions publish through `globalThis[Symbol.for("vstack.pi.activity")]`; `pi-session-bridge` streams each publication as `{type:"event", event:"vstack_activity", data:{...}}`. The Pi subscriber appends an activity-only `pi-activity-broker` row to `WAKE_EVENTS_LOG`. The TS daemon copies the subset payload into `flightdeck-activity-<session>.jsonl` with the tracked pane id and never wakes master. Set `FLIGHTDECK_PI_ACTIVITY_BROKER=0` to disable this broker drain and rely on legacy custom-message wake paths only.
-
-Activity sidecar: `flightdeck-state init` records `activity_path` beside the master state as `flightdeck-activity-<TMUX_SESSION>.jsonl`. `flightdeck-state activity path|append|tail|export` exposes the path, appends a normalized event, tails recent rows, or exports JSONL/Markdown. `activity export` accepts `--session <name>` and `--state-file <path>` for parity with `path` / `tail` / `append`, so dashboards and post-mortems can resolve sidecars without an active tmux session. Retention caps are 5,000 events and 10 MiB per live sidecar; oversized `details` are truncated to a 16 KiB budget. Daemon emission is curated: daemon/subscriber lifecycle, wake-delivery failures, subagent completions, bg-task exit/output rows, questions, and Pi broker rows. Workflow/github/linear helper emission is gated by `FLIGHTDECK_MANAGED=1 || FLIGHTDECK_ACTIVITY_FILE` so standalone wrapper use stays silent.
-
-`daemon-exited`: the daemon emits this lifecycle row during cleanup when it exits for `master-gone`, `signal-term`, `signal-int`, or another recorded reason. It writes directly to the per-session `EVENTS_FILE` under `SESSION_LOCK` (not `WAKE_EVENTS_LOG`), with `pane_id` set to the master pane id so pane-keyed drains include it:
-
-```
-{"ts":"<iso>","pane_id":"%25","event_type":"daemon-exited","reason":"master-gone","master_id":"%25","pid":12345,"hash":"<12hex>","tag":"daemon-exited","stable_age_sec":0,"details":{"event_type":"daemon-exited","reason":"master-gone","master_id":"%25","pid":12345}}
-```
-
-`session-watch.md` routes `daemon-exited` as a daemon-lifecycle signal, not a pane-prompt classification. It records the reason and follows the master respawn flow in `workflows/shared/session-watch.md` § 1 / § 6 before yielding.
-
-## Schema — master state
-
-Master state lives at `<project-root>/<FLIGHTDECK_STATE_DIR>/flightdeck-state-<TMUX_SESSION_NAME>.json` (default `tmp/`). Activity history lives beside it as `flightdeck-activity-<TMUX_SESSION_NAME>.jsonl` and is exposed through `flightdeck-state activity path|append|tail|export`. Both survive compaction; terminate rotates state to `*-<terminated_at>.json.archive` and activity to `*-<terminated_at>.jsonl.archive` in the same `flightdeck-state archive` flow (see `terminate.md § 6`). The archive preserves the full session history (including merged-issue `decisions_log`, `pr_number`, `merge_commit`) so post-completion dashboards and post-mortem inspection have the whole session history — do not call `pane-registry remove-merged` between `set terminated true` and `archive`. Dashboard snapshot loaders fall back to the newest matching `*.json.archive` when the live file is gone, so the completed-session view keeps rendering until a new `flightdeck linear start` rewrites the live file. Daemon-private files in `FD_STATE_DIR` are keyed by `SESSION_KEY=s<N>` instead (see `patterns/tmux-monitoring.md`).
-
-Auto-archive on session start: `flightdeck-session start` rolls the live file to a `.json.archive` sibling before fresh init when (a) `terminated == true` or (b) the file has tracked entries but ZERO `pane_id` is currently alive in tmux. Removes the need to manually prune leftover state from prior tmux sessions or crashed masters. `flightdeck-session start` also exports `FLIGHTDECK_ENTRY_ID` into the launched child environment (consumed by `github.sh` / `linear.sh` wrappers to auto-bind activity events to the right entry) and captures the current `git rev-parse --abbrev-ref HEAD` of the entry's cwd into `entry.branch` (informational; not refreshed when the agent switches branches mid-session) and onto every `pr.*` activity row's `refs.branch`.
-
-Readers call `readTrackedEntries(state)` to get the canonical `TrackedEntry` map. Malformed non-object entry values are skipped with a stderr warning; malformed internal `entry.id` values warn and fall back to the map key. `writeTrackedEntry(state, id, entry)` validates non-empty ids (including `entry.domain.issue.id` when present), accepts the optional `entry.domain.github_issue` shape, rejects unknown `entry.domain.*` sub-keys, rejects entries that set both `domain.issue` and `domain.github_issue`, and writes `.entries[id]`. Linear issue-mode metadata lives under `entry.domain.issue` (`pr_number`, `worktree`, `merge_commit`, etc.). GitHub issue-mode metadata lives under `entry.domain.github_issue` (`number`, `url`, `worktree`, `pr_number`, `merge_commit`, `scope_files_actual`). Generic `adhoc`/`workflow` rows may also carry top-level `pr_number` and `worktree` for traceability without becoming issue-mode entries; readers must keep those separate from issue-domain routing. Dashboard renderers surface the nested issue views and generic top-level traceability fields without changing issue-domain routing.
-
-```json
-{
-  "session_id": "<TMUX_SESSION_NAME>",
-  "started_at": "<ISO8601>",
-  "activity_path": "<project-root>/tmp/flightdeck-activity-<TMUX_SESSION_NAME>.jsonl",
-  "activity_archive_path": null,
-  "activity_schema_version": 1,
-  "terminated": false,
-  "owner": {
-    "harness": "claude|opencode|codex|pi|unknown",
-    "pane_id": "%25",
-    "pane_target": "<TMUX_SESSION>:<window>.<pane>",
-    "cwd": "<absolute cwd>",
-    "pid": 1752875,
-    "pi_session_id": "<pi-session-id-or-null>",
-    "pi_bridge_socket": "<pi-bridge-socket-or-null>",
-    "discovery_error": "<warning-or-null>"
-  },
-  "entries": {
-    "<ENTRY_ID>": {
-      "id": "<ENTRY_ID>",
-      "title": "<human label>",
-      "kind": "adhoc|issue|workflow",
-      "state": "waiting|prompting|submitting|ready|complete|cancelled|dead",
-      "substate": null,
-      "harness": "claude|opencode|codex|pi|unknown",
-      "cwd": "<absolute cwd>",
-      "window": "<window-name-or-index>",
-      "pane_target": "<TMUX_SESSION>:<window>.<pane>",
-      "pane_id": "%403",
-      "pr_number": null,
-      "worktree": null,
-      "launch": {
-        "model": "<resolved-model-or-null>",
-        "effort": "<resolved-effort-or-thinking-or-null>",
-        "requested_model": "<explicit-or-env-model-or-null>",
-        "requested_effort": "<explicit-or-env-effort-or-null>",
-        "resolved_model": "<resolved-model-or-null>",
-        "resolved_effort": "<resolved-effort-or-thinking-or-null>",
-        "model_source": "explicit|env|auto|null",
-        "effort_source": "explicit|env|auto|null",
-        "argv": ["<resolved>", "<harness>", "argv>"],
-        "reasoning_status": "configured|recorded|unsupported|not-applicable",
-        "unsupported_reason": "<reason-or-null>",
-        "cmd": "<command-or-null>"
-      },
-      "adapter": {
-        "pi_bridge_pid": 0, "pi_bridge_socket": "<path-or-null>", "pi_session_id": "<id-or-null>",
-        "oc_url": "<server-url-or-null>", "oc_session_id": "<id-or-null>",
-        "cc_url": "<server-url-or-null>", "cc_transcript": "<path-or-null>",
-        "cx_ws": "<ws-url-or-null>", "cx_thread_id": "<id-or-null>"
-      },
-      "domain": {
-        "issue": {
-          "id": "<ISSUE_ID>",
-          "worktree": "<absolute path>",
-          "pr_number": 0,
-          "scope_files_declared": 5,
-          "scope_files_actual": 27,
-          "orchestration_started": true
-        },
-        "github_issue": {
-          "number": 120,
-          "url": "https://github.com/OWNER/REPO/issues/120",
-          "worktree": "<absolute path>",
-          "pr_number": 0,
-          "merge_commit": null,
-          "scope_files_actual": 27
-        }
-      },
-      "branch": "<git-branch-or-null>",
-      "last_capture_hash": "sha256:...",
-      "last_response_at": "<ISO8601>",
-      "spawned_at": "<ISO8601>",
-      "last_polled_at": "<ISO8601>",
-      "decisions_log": []
-    }
-  },
-  "merge_queue": ["<ISSUE_ID>", "<ISSUE_ID>"],
-  "conflict_graph": {
-    "edges": [["<ISSUE_A>", "<ISSUE_B>"]],
-    "computed_at": "<ISO8601>"
-  },
-  "paused_for_user": null
-}
-```
-
-Tracked entry state enum: `state ∈ {waiting, prompting, submitting, ready, complete, cancelled, dead}`. Issue-mode workflows additionally use `{merge-ready, merged, aborted}` for issue-specific lifecycle states; these map onto the generic enum via `domain.issue.phase` / `domain.issue.outcome` for Linear or `domain.github_issue.phase` / `domain.github_issue.outcome` for GitHub (e.g. `merged → complete + outcome="merged"`). `entryIdForIssue(issueId)` returns the issue id unchanged after validation (empty/invalid ids return null); `issueIdForEntry(entry)` reads `entry.domain.issue.id` or, for `kind: "issue"`, `entry.id`. GitHub entries use numeric `domain.github_issue.number` for lane-specific routing. `owner` is metadata written by `flightdeck-state init`; `owner.pid` is the owner harness PID supplied by `FLIGHTDECK_OWNER_PID` (falling back to parent PID), and `owner.discovery_error` records Pi bridge metadata lookup failures when the owner harness is Pi. Dashboard renderers use `owner.pane_id` to keep the persistent dashboard owner-scoped by default. `paused_for_user` carries `{entry_id|issue_id, reason, prompt_text}` when a guard or issue-mode pause fires.
-
-## Reliability watchdogs
-
-Four operator-facing watchdogs run inside the daemon and the `pi-agents-tmux` extension. Agents do not interact with them; they emit activity rows and synthetic outbox payloads when child sessions misbehave.
-
-- **agent-end** (`VSTACK_AGENT_END_WATCHDOG`, default on; grace `VSTACK_AGENT_END_WATCHDOG_GRACE_SEC`=10s) — if a child agent emits `agent_end` without writing a `complete_subagent` outbox within the grace window, the watchdog synthesizes a `needs_completion` outbox so the parent never silently stalls. Emits `agent.needs_completion` activity.
-- **idle-stall** (`VSTACK_STALL_WATCHDOG`, default on; `VSTACK_STALL_WATCHDOG_INTERVAL_SEC`=60s, `VSTACK_STALL_WATCHDOG_THRESHOLD_SEC`=300s) — polls bridge-idle subagent panes whose outbox has not landed and fires a synthetic `blocked` outbox after the threshold. Emits `agent.idle_stalled`.
-- **edit-loop** (`VSTACK_EDIT_LOOP_DETECTOR`, default on; `VSTACK_EDIT_LOOP_THRESHOLD_N`=5, `VSTACK_EDIT_LOOP_WINDOW_SEC`=120) — counts edit-tool failures inside a child agent's window; on threshold breach synthesizes a `blocked` outbox + `agent.edit_loop_blocked` activity row.
-- **rate-limit** (`VSTACK_RATE_LIMIT_WATCHDOG`, default on; `VSTACK_RATE_LIMIT_MAX_ATTEMPTS`=5, `VSTACK_RATE_LIMIT_BACKOFF_LADDER`=`60,120,300,600,1800` seconds) — on a detected Claude API rate-limit error, schedules an exponential-backoff steer-retry. Emits `agent.rate_limit_detected` / `agent.rate_limit_retry` / `agent.rate_limit_exhausted` and short-circuits the canonical wake path while a retry is pending.
-
-All four can be hard-disabled by setting the gate env var to `0`. The canonical decision modules and parity rules live in `DEVELOPMENT.md`.
-
-## Configuration
-
-Master-loop env vars consulted by workflows:
-
-| Variable | Default | Purpose |
-|----------|---------|---------|
-| `FLIGHTDECK_FORCE_MERGE_AFTER_SECS` | `240` | UNKNOWN-state wait threshold before considering force-merge (predicate also requires APPROVED + green + disjoint) |
-| `FLIGHTDECK_STATE_DIR` | `tmp` | Project-relative master-state file directory |
-| `FLIGHTDECK_ACTIVITY_FILE` | unset | Explicit activity JSONL target for wrapper/workflow emitters and `flightdeck-state activity append`; when unset, managed workflows use `activity_path` from master state. |
-| `FLIGHTDECK_DEBOUNCE_CYCLES` | `2` | Consecutive poll cycles required for "all-done" termination check |
-| `FLIGHTDECK_AUTO_MERGE` | `1` | When `0`, merge-now, force-merge-confirm, and UNKNOWN-timer force-merge transitions escalate instead of auto-answering. For sessions where the human gate is desired (compliance, big-blast-radius PRs) |
-| `FLIGHTDECK_AUTO_REBASE` | `0` | GitHub lane only: when `1`, a `BEHIND` PR prompt may answer Update Branch / auto-rebase if all other safety predicates hold. Default `0` escalates. |
-| `FLIGHTDECK_HIJACK_GRACE_SECS` | `90` | Seconds after spawn that master tolerates no orchestration `workflow-state-<ISSUE>.json` before escalating "orchestration-never-started". Catches hijacked panes / failed launches. |
-| `FLIGHTDECK_LAUNCH_MODEL` | unset | Default `open-terminal` / `flightdeck-session --prompt` model override when the workflow/user does not pass `--model`. |
-| `FLIGHTDECK_LAUNCH_EFFORT` | unset | Default `open-terminal` / `flightdeck-session --prompt` effort/thinking override when the workflow/user does not pass `--effort`. |
-| `FLIGHTDECK_OPENCODE_VALIDATE_MODEL` | `1` | When launching OpenCode, require `opencode models` to list the selected provider/model before passing `--model`. Set `0` only for local smoke tests with custom shims. |
-| `FLIGHTDECK_PI_ACTIVITY_BROKER` | `1` | Set to `0` to ignore `pi-session-bridge` `vstack_activity` broker rows and rely on legacy Pi wake messages only. |
-| `FLIGHTDECK_ENTRY_ID` | auto | Exported by `flightdeck-session start` into spawned panes (and inherited by their tool wrappers). When set, `github.sh` / `linear.sh` / `label-*` activity rows auto-bind `refs.entry_id` so cross-source activity ties back to the tracked entry. Do not set by hand. |
-
-Watchdog gates (operator-facing; see § Reliability watchdogs for behavior):
-
-| Variable | Default | Purpose |
-|----------|---------|---------|
-| `VSTACK_AGENT_END_WATCHDOG` | `1` | Toggle for the agent-end watchdog. |
-| `VSTACK_AGENT_END_WATCHDOG_GRACE_SEC` | `10` | Grace seconds before synthesizing a `needs_completion` outbox. |
-| `VSTACK_STALL_WATCHDOG` | `1` | Toggle for the idle-stall watchdog. |
-| `VSTACK_STALL_WATCHDOG_INTERVAL_SEC` | `60` | Poll cadence for idle-stall detection. |
-| `VSTACK_STALL_WATCHDOG_THRESHOLD_SEC` | `300` | Bridge-idle threshold before synthesizing a `blocked` outbox. |
-| `VSTACK_EDIT_LOOP_DETECTOR` | `1` | Toggle for the edit-loop detector. |
-| `VSTACK_EDIT_LOOP_THRESHOLD_N` | `5` | Edit-tool failure count within the window that trips the detector. |
-| `VSTACK_EDIT_LOOP_WINDOW_SEC` | `120` | Sliding window for edit-loop counting. |
-| `VSTACK_RATE_LIMIT_WATCHDOG` | `1` | Toggle for the rate-limit retry watchdog. |
-| `VSTACK_RATE_LIMIT_MAX_ATTEMPTS` | `5` | Maximum retry attempts before surfacing `agent.rate_limit_exhausted`. |
-| `VSTACK_RATE_LIMIT_BACKOFF_LADDER` | `60,120,300,600,1800` | Comma-separated seconds per attempt; clamped to `MAX_ATTEMPTS`. |
-
-Daemon hygiene env vars (operator-facing; details in `DEVELOPMENT.md`):
-
-| Variable | Default | Purpose |
-|----------|---------|---------|
-| `FD_BELL_WAKE_INTERVAL_SEC` | `60` | Per-pane-per-tag bell-wake rate-limit; suppresses storm-y duplicates within the window. |
-| `FD_RECONCILE_INTERVAL_SEC` | `5` | Mid-session reconcile cadence: spawn subscribers for newly tracked panes, reap subscribers for departed panes, drop dead `.entries` rows. |
-| `FD_HEARTBEAT_OWNER_CGROUP` | `1` | Set to `0` to skip the optional `MemoryCurrent` / `MemoryPeak` cgroup probe attached to heartbeat events. |
-
-
-Rust dashboard env vars:
-
-| Variable | Default | Purpose |
-|----------|---------|---------|
-| `FLIGHTDECK_DASHBOARD` | `1` | When `0`, `flightdeck-dashboard launch` exits `0` silently. |
-| `FLIGHTDECK_DASHBOARD_WINDOW` | `flightdeck` | Tmux window name used by the dashboard launch hook. |
-| `FLIGHTDECK_DASHBOARD_MOTION` | `full` | Animation intensity: `full`, `reduced`, or `off`. `NO_MOTION` / `NO_COLOR` force `off` regardless of this setting. CLI `--motion` overrides it. |
-| `FLIGHTDECK_DASHBOARD_THEME` | `moon` | Color theme: `moon`, `dawn`, `pantera`, or `system`. CLI `--theme` overrides it; the theme picker popup changes the live theme for the current run. |
-| `FLIGHTDECK_DAEMON_RUST` | `0` | Opt-in to the Rust daemon wake side / subscriber absorption. Default off keeps the canonical TypeScript daemon in charge of wake delivery. |
-| `FLIGHTDECK_DASHBOARD_BELL` | `1` | Set to `0` to suppress the terminal bell on a new pause-for-user edge. The dashboard never auto-focuses tmux windows. |
-| `FLIGHTDECK_DASHBOARD_COST_POLL_SECS` | `5` | Cost-source poll interval in seconds. |
-| `FLIGHTDECK_DASHBOARD_PRICING_FILE` | bundled table | Optional pricing TOML override for dashboard cost calculations; malformed files warn and fall back to bundled rates. |
-| `FLIGHTDECK_DASHBOARD_QUICK_FOCUS` | `0` | Set to `1` to let `g` focus the selected tmux window without a confirmation popup. |
-| `TMUX_PROBE_TTL` | `5` | Cached `tmux list-panes` TTL used to mark stale dashboard rows. |
-| `FLIGHTDECK_DASHBOARD_STALE_WARN_SECS` | `30` | Stale-chip warning threshold in seconds. |
-| `FLIGHTDECK_DASHBOARD_STALE_DEAD_SECS` | `300` | Stale/dead chip threshold in seconds. |
-| `FLIGHTDECK_DASHBOARD_STOP_GRACE_MS` | `5000` | Advanced daemon stop grace before SIGKILL escalation, in milliseconds. Tests may lower it. |
-| `FLIGHTDECK_DASHBOARD_READY_FD` | internal | Readiness pipe fd used by detached daemon startup; not user-configurable. |
-| `FLIGHTDECK_DASHBOARD_TEST_WEDGE_SIGNALS` | unset | Test-only hook that wedges signal handling. Do not set in normal sessions. |
-| `FLIGHTDECK_DASHBOARD_TEST_SUBSCRIBE_PAUSE_FILE` | unset | Test-only socket subscribe interleaving hook. Do not set in normal sessions. |
-| `FLIGHTDECK_DASHBOARD_TEST_SUBSCRIBE_RELEASE_FILE` | unset | Test-only release file for the subscribe interleaving hook. Do not set in normal sessions. |
-
-Daemon tuning (`FD_*`) is in DEVELOPMENT.md. Most `FD_*` knobs run inside the
-daemon and do not affect master operation directly, but two are
-consulted on the master poll path through the TS `pane-poll`:
-`FD_ADAPTER_READ_TIMEOUT_SEC` (default `2`, fractional values honored)
-caps each adapter read subprocess so one stale adapter cannot dominate
-a tick, and `FD_ADAPTER_FRESHNESS_TTL` (default `5`) gates freshness
-probe caching.
-
-Additional tuning:
-
-| Variable | Default | Purpose |
-|----------|---------|---------|
-| `FD_ADAPTER_READ_TIMEOUT_SEC` | `2` | Bounds per-adapter read subprocesses in `pane-poll` (fractional values honored). Stale adapters fall through to tmux capture rather than wedging the tick. |
+- Master state + activity sidecar contract lives in [`SCHEMA.md`](./SCHEMA.md). `readTrackedEntries(state)` is the canonical reader; `writeTrackedEntry(state, id, entry)` is the canonical writer and rejects malformed domain combinations.
+- Reliability watchdog details live in [`WATCHDOGS.md`](./WATCHDOGS.md).
+- Env var tables live in [`ENV.md`](./ENV.md). Operator-facing gates include `FLIGHTDECK_AUTO_MERGE`, `FLIGHTDECK_FORCE_MERGE_AFTER_SECS`, `FLIGHTDECK_AUTO_REBASE`, dashboard controls, and the `VSTACK_*` watchdog toggles.
 
 ## Workflows
 
@@ -418,35 +202,35 @@ Additional tuning:
 
 ## Workflow Execution
 
-These rules apply to flightdeck's boundary workflows (`start.md`, `start-new.md`, `terminate.md`, `close-issue.md`, and per-tag handlers in `session-handle-prompt.md` / `handle-prompt.md`). The `session-watch.md` generic loop and `watch.md` issue extension are reactive by nature — their inner decisions are judgment calls and not subject to these rules.
+These rules apply to boundary workflows (`start.md`, `start-new.md`, `terminate.md`, `close-issue.md`, and per-tag handlers in `session-handle-prompt.md` / `handle-prompt.md`). The `session-watch.md` generic loop and `watch.md` issue extension are reactive; their inner decisions are judgment calls subject to their workflow text.
 
 ### Sequential Section Execution
 
-Process sections sequentially. Execute all sub-sections within a section before proceeding to the next. Never skip steps because the outcome seems predictable, or rationalize skipping based on visible state ("nothing changed since last poll", "the summary is obvious", "the user can see this"). The workflow text is the decision authority, not the agent's assessment.
+Process sections sequentially. Execute all sub-sections within a section before proceeding. Never skip steps because outcome seems predictable, visible state looks unchanged, or summary seems obvious. Workflow text is the decision authority.
 
 ### Nested Workflow Invocation
 
-Nested workflows (marked with `⤵`) must be invoked through the harness's workflow invocation mechanism — never inlined or substituted with ad-hoc commands. If the marker includes a return point (`→ § X`), record it before invoking.
+Nested workflows (marked with `⤵`) must be invoked through the harness's workflow invocation mechanism — never inlined or substituted with ad-hoc commands. If marker includes a return point (`→ § X`), record it before invoking.
 
 ### Format Tags Are Literal
 
-`<output_format>`, `<recommendation_format>`, `<launch_now_format>`, and any other XML-tagged content blocks define exact content for emission. When emitting tagged content:
+`<output_format>`, `<recommendation_format>`, `<launch_now_format>`, and other XML-tagged content blocks define exact emitted content:
 
-1. **Fill `[PLACEHOLDERS]`** with actual values.
-2. **Omit lines/sections** where the placeholder value is empty or not applicable.
-3. **Add nothing else** — no commentary, no extra fields, no rewording, no explanations before or after the content.
-4. **Do not paraphrase** — use the exact structure, headings, and field names from the tag.
+1. Fill `[PLACEHOLDERS]` with actual values.
+2. Omit lines/sections where placeholder value is empty or not applicable.
+3. Add nothing else — no commentary, extra fields, rewording, or explanations before/after.
+4. Do not paraphrase — use exact structure, headings, and field names from the tag.
 
-The user-visible output blocks at the end of `terminate.md` (`<generic_output_format>` / `<empty_output_format>` / `<issue_output_format>`) and `close-issue.md` (`<output_format>`) are tagged for this reason: the agent must emit them in full, not collapse to a summary line.
+The user-visible output blocks at the end of `terminate.md` (`<generic_output_format>` / `<empty_output_format>` / `<issue_output_format>`) and `close-issue.md` (`<output_format>`) are tagged for this reason: emit them in full, not as summary lines.
 
 ## Implementation Constraints
 
-1. **Aggressive autonomy on known shapes; escalate on novel shapes.** The classifier returns a tag for known prompt shapes. Generic `generic-multi-choice` uses the bounded safe policy in `session-handle-prompt.md`; issue-only prompts use `handle-prompt.md`. Both escalate when options are destructive, ambiguous, or genuinely novel. They do NOT blindly pick the first option.
-2. **Daemon-driven wake; no blocking sleeps.** `flightdeck-daemon` (spawned by `session-watch.md` § 1; issue `watch.md` reuses that core loop) owns wake delivery for every harness. Master ends each turn after `flightdeck-daemon ack` + `flightdeck-state master-busy unlock`. Never `sleep`. Wake payload reference: `/flightdeck` (claude/opencode/default), `$flightdeck` (codex), `/skill:flightdeck` (pi). Claude Code MAY optionally arm `ScheduleWakeup({delaySeconds: 1800})` as a defensive fallback.
-3. **Dashboards are read-only and additive.** The Rust `flightdeck-dashboard` renders mission-control UX from the on-disk artifacts master and the daemon already write; it never bypasses the schema. The only write affordances are confirmation-gated shells to canonical helpers (`pane-registry remove` for stale entries, `tmux select-window` for focus). No harness-specific shortcut paths that bypass the on-disk schema in any other renderer.
-4. **One daemon per tmux session.** Concurrent flightdecks within the same tmux session are refused via flock. Run separate sessions for parallel flightdeck instances.
-5. **Explicit LLM launch profile.** Every fresh LLM pane Flightdeck creates must have a selected model and effort/thinking level, or an explicit `launch.reasoning_status`/`unsupported_reason` explaining why that harness/session cannot report it. Subagents with generated model/effort definitions are exempt.
-6. **All scripts must appear in this SKILL.md's Scripts table.** No "hidden" scripts. README.md mirrors the table for human readers.
+1. **Aggressive autonomy on known shapes; escalate on novel shapes.** The classifier returns a tag for known prompt shapes. Generic `generic-multi-choice` uses bounded safe policy in `session-handle-prompt.md`; issue-only prompts use `handle-prompt.md`. Both escalate when options are destructive, ambiguous, or novel. They do NOT blindly pick the first option.
+2. **Daemon-driven wake; no blocking sleeps.** `flightdeck-daemon` owns wake delivery for every harness. Master ends each turn after `flightdeck-daemon ack` + `flightdeck-state master-busy unlock`. Never `sleep`. Wake payload reference: `/flightdeck` (claude/opencode/default), `$flightdeck` (codex), `/skill:flightdeck` (pi). Claude Code MAY arm `ScheduleWakeup({delaySeconds: 1800})` as defensive fallback.
+3. **Dashboards are read-only and additive.** Rust dashboard renders from on-disk artifacts master and daemon already write; it never bypasses schema. Only write affordances are confirmation-gated shells to canonical helpers (`pane-registry remove` for stale entries, `tmux select-window` for focus).
+4. **One daemon per tmux session.** Concurrent Flightdecks within same tmux session are refused via flock. Run separate tmux sessions for parallel Flightdeck instances.
+5. **Explicit LLM launch profile.** Every fresh LLM pane Flightdeck creates must have selected model and effort/thinking level, or explicit `launch.reasoning_status` / `unsupported_reason` explaining why harness/session cannot report it. Subagents with generated model/effort definitions are exempt.
+6. **No hidden scripts or tags.** All scripts must appear in [`SCRIPTS.md`](./SCRIPTS.md). All `prompt-classify` tags must appear in [`PROMPT-TAGS.md`](./PROMPT-TAGS.md).
 
 ## Compaction Recovery
 

--- a/skills/flightdeck/WATCHDOGS.md
+++ b/skills/flightdeck/WATCHDOGS.md
@@ -1,0 +1,14 @@
+# Flightdeck watchdog reference
+
+Reference doc extracted from `SKILL.md`. See [`SKILL.md`](./SKILL.md) for the load-bearing rules; this file holds detailed reference content for on-demand consultation.
+
+## Reliability watchdogs
+
+Four operator-facing watchdogs run inside the daemon and the `pi-agents-tmux` extension. Agents do not interact with them; they emit activity rows and synthetic outbox payloads when child sessions misbehave.
+
+- **agent-end** (`VSTACK_AGENT_END_WATCHDOG`, default on; grace `VSTACK_AGENT_END_WATCHDOG_GRACE_SEC`=10s) — if a child agent emits `agent_end` without writing a `complete_subagent` outbox within the grace window, the watchdog synthesizes a `needs_completion` outbox so the parent never silently stalls. Emits `agent.needs_completion` activity.
+- **idle-stall** (`VSTACK_STALL_WATCHDOG`, default on; `VSTACK_STALL_WATCHDOG_INTERVAL_SEC`=60s, `VSTACK_STALL_WATCHDOG_THRESHOLD_SEC`=300s) — polls bridge-idle subagent panes whose outbox has not landed and fires a synthetic `blocked` outbox after the threshold. Emits `agent.idle_stalled`.
+- **edit-loop** (`VSTACK_EDIT_LOOP_DETECTOR`, default on; `VSTACK_EDIT_LOOP_THRESHOLD_N`=5, `VSTACK_EDIT_LOOP_WINDOW_SEC`=120) — counts edit-tool failures inside a child agent's window; on threshold breach synthesizes a `blocked` outbox + `agent.edit_loop_blocked` activity row.
+- **rate-limit** (`VSTACK_RATE_LIMIT_WATCHDOG`, default on; `VSTACK_RATE_LIMIT_MAX_ATTEMPTS`=5, `VSTACK_RATE_LIMIT_BACKOFF_LADDER`=`60,120,300,600,1800` seconds) — on a detected Claude API rate-limit error, schedules an exponential-backoff steer-retry. Emits `agent.rate_limit_detected` / `agent.rate_limit_retry` / `agent.rate_limit_exhausted` and short-circuits the canonical wake path while a retry is pending.
+
+All four can be hard-disabled by setting the gate env var to `0`. The canonical decision modules and parity rules live in `DEVELOPMENT.md`.

--- a/skills/flightdeck/patterns/tmux-monitoring.md
+++ b/skills/flightdeck/patterns/tmux-monitoring.md
@@ -197,4 +197,4 @@ To add an adapter for a new harness:
 4. Update both tables above with the mechanic.
 5. Add a functional test under `lib/flightdeck-core/tests/parity/`.
 6. Add a smoke test under `skills/flightdeck/tests/<harness>-smoke` and update `tests/live-wake.sh` if the wake path is affected.
-7. Reflect any new env var in `skills/flightdeck/README.md` (operator-facing table) and `skills/flightdeck/SKILL.md` (Configuration section).
+7. Reflect any new user-facing env var in `skills/flightdeck/README.md` and every env var in `skills/flightdeck/ENV.md`.


### PR DESCRIPTION
References `docs/plans/flightdeck-v2-architecture-plan.md` §§ 4 + 5.

## Scope

- ZERO behavior change.
- ZERO code changes.
- ZERO test changes.
- Docs-only extraction/rewrite for `skills/flightdeck/`.

## Changes

- Rewrote `skills/flightdeck/SKILL.md` as the load-bearing AI-agent quick path.
- Rewrote `skills/flightdeck/README.md` as a human-facing overview: what it is, features, commands, user settings, dashboard, high-level architecture.
- Added reference docs:
  - `skills/flightdeck/SCHEMA.md` — 100 lines
  - `skills/flightdeck/SCRIPTS.md` — 55 lines
  - `skills/flightdeck/ENV.md` — 83 lines
  - `skills/flightdeck/WATCHDOGS.md` — 14 lines
  - `skills/flightdeck/PROMPT-TAGS.md` — 49 lines
- Updated one stale cross-reference in `skills/flightdeck/patterns/tmux-monitoring.md` from the removed SKILL configuration section to `ENV.md`.

## Line-count deltas

- `skills/flightdeck/SKILL.md`: 453 → 237 (-216)
- `skills/flightdeck/README.md`: 150 → 140 (-10)

## Validation

- `cd skills/flightdeck/lib/flightdeck-core && bun test` — PASS (610 pass, 0 fail)
- `cd skills/flightdeck/lib/flightdeck-core && bun run typecheck` — PASS
- `git diff --check` — PASS
- Docs-only changed paths check — PASS
- Load-bearing phrase grep — PASS for:
  - `FLIGHTDECK_FORCE_MERGE_AFTER_SECS`
  - `FLIGHTDECK_AUTO_MERGE`
  - `VSTACK_RATE_LIMIT_WATCHDOG`
  - `pi-bg-task-exit`
  - `daemon-exited`
  - `writeTrackedEntry`
  - `merge-ready-but-unknown`
  - `preserve / apply / verify`
  - `Pane-0 rule`
- reviewer-doc subagent — PASS; no required fixes.
