### PR TITLE
Fix pi-flightdeck stale pane standby hint

### DIFF
--- a/pi-extensions/pi-flightdeck/README.md
+++ b/pi-extensions/pi-flightdeck/README.md
@@ -13,6 +13,7 @@ Read-only, sessions-first dashboard for the [`flightdeck`](../../skills/flightde
 - **`/flightdeck` popup** — six tabs: Overview, Live feed, Conversations, Conflicts & merges, Decisions, Daemon.
 - **Session-complete view** — keeps the completed session visible until you dismiss the widget.
 - **Owner-scoped by default** — dashboard renders only in the flightdeck owner pane. Peer panes get a read-only observer popup. Child panes always suppressed. Visibility configurable.
+- **Stale-pane guard** — standby/watch hints ignore state files whose tracked entries only point at tmux pane ids that no longer exist.
 - Optional terminal bell and auto-popup when master pauses.
 - Participates in vstack's stable mini-dashboard stack order: Flightdeck → Tasks → Agents → BG tasks.
 

--- a/pi-extensions/pi-flightdeck/extensions/flightdeck.ts
+++ b/pi-extensions/pi-flightdeck/extensions/flightdeck.ts
@@ -29,6 +29,7 @@ import {
 	formatAge,
 	isPaneGone,
 	mostRecentPollMs,
+	readAwaitingWatchTrackedEntries,
 	readOwnerVisibilityProbe,
 	readTrackedEntries,
 	resolveProjectRoot,
@@ -286,7 +287,7 @@ export function renderAwaitingWatchHintLine(snapshot: FlightdeckSnapshot, theme:
 		everStarted: daemonEverStarted(snapshot),
 		heartbeatAgeSec: snapshot.daemon.heartbeatAgeSec,
 	});
-	const sessions = readTrackedEntries(snapshot.master);
+	const sessions = readAwaitingWatchTrackedEntries(snapshot);
 	const count = sessions.length;
 	const noun = count === 1 ? "session" : "sessions";
 	const line = `${daemon} ${theme.fg("dim", "·")} ${theme.fg("dim", `${count} tracked ${noun} — run /skill:flightdeck session watch to start supervising.`)}`;
@@ -1312,6 +1313,7 @@ export default function flightdeck(pi: ExtensionAPI): void {
 		const dashboardEnabled = dashboardPaneAllowed && settingBoolean("dashboard", true, ctx.cwd) && cache.state !== "hidden";
 		const staleAfterMin = Math.max(0, Math.floor(settingNumber("dashboardStaleAfterMin", 5, ctx.cwd)));
 		const status = flightdeckSessionStatus(snapshot, { staleAfterMin });
+		const awaitingWatchSessionCount = readAwaitingWatchTrackedEntries(snapshot).length;
 		if (status === "inactive" && !showBanner) {
 			if (cache.lastSyncKey !== "__off__") {
 				setMiniDashboardWidget(ctx, WIDGET_KEY, MINI_DASHBOARD_RANK.FLIGHTDECK, undefined);
@@ -1332,6 +1334,7 @@ export default function flightdeck(pi: ExtensionAPI): void {
 			dashboardVisibility: visibility,
 			currentPaneId: snapshot?.tmux.paneId ?? null,
 			status,
+			awaitingWatchSessionCount,
 			master: snapshot?.master ?? null,
 			daemonAlive: snapshot?.daemon?.pidAlive ?? null,
 			daemonHeartbeat: snapshot?.daemon?.heartbeatAgeSec ?? null,

--- a/pi-extensions/pi-flightdeck/extensions/state.ts
+++ b/pi-extensions/pi-flightdeck/extensions/state.ts
@@ -814,6 +814,19 @@ export function isPaneGone(session: TrackedSession | undefined, snapshot: Flight
 	return !live.has(paneId);
 }
 
+// Awaiting-watch should only count entries whose immutable tmux pane id is
+// still present. Empty `livePaneIds` means the probe is unavailable/unknown, so
+// keep legacy behavior and do not suppress the banner on lack of evidence.
+export function readAwaitingWatchTrackedEntries(snapshot: FlightdeckSnapshot | undefined): TrackedSession[] {
+	const entries = readTrackedEntries(snapshot?.master);
+	const live = snapshot?.livePaneIds;
+	if (!live || live.size === 0) return entries;
+	return entries.filter((entry) => {
+		const paneId = typeof entry.pane_id === "string" ? entry.pane_id.trim() : "";
+		return !paneId || live.has(paneId);
+	});
+}
+
 export function buildSnapshotFromInputs(inputs: BuildSnapshotInputs, settings: SettingsLike, options?: { logTailLines?: number; wakeEventsLines?: number }): FlightdeckSnapshot {
 	const { projectRoot, stateDir, tmux } = inputs;
 	const liveStatePath = masterStatePath(projectRoot, settings, tmux.sessionName);
@@ -978,8 +991,10 @@ export function flightdeckSessionStatus(
 	if (daemonAlive) return "live";
 	// Daemon never started for this tmux session — normal state between
 	// `session start` and `session watch`. Don't flag as stale; the user
-	// hasn't tried to supervise yet.
-	if (!daemonEverStarted(snapshot)) return "awaiting-watch";
+	// hasn't tried to supervise yet. But if tmux proves every tracked
+	// pane_id is dead, the leftover state is stale-only and should not
+	// render a misleading "start supervising" hint.
+	if (!daemonEverStarted(snapshot)) return readAwaitingWatchTrackedEntries(snapshot).length > 0 ? "awaiting-watch" : "inactive";
 	const staleAfterMin = options?.staleAfterMin ?? 5;
 	if (staleAfterMin <= 0) return "live";
 	const now = options?.now ?? Date.now();

--- a/pi-extensions/pi-flightdeck/package.json
+++ b/pi-extensions/pi-flightdeck/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vanillagreen/pi-flightdeck",
-  "version": "0.1.0",
-  "description": "Read-only sessions-first dashboard for the flightdeck skill: owner-scoped overview of tracked sessions, daemon health, decisions log, and a prominent pause banner when master is awaiting the user.",
+  "version": "0.1.1",
+  "description": "Read-only sessions-first dashboard for the flightdeck skill: owner-scoped overview of tracked sessions, daemon health, stale-pane filtering, decisions log, and a prominent pause banner when master is awaiting the user.",
   "license": "MIT",
   "keywords": [
     "pi-package",

--- a/pi-extensions/pi-flightdeck/tests/render-sessions.test.ts
+++ b/pi-extensions/pi-flightdeck/tests/render-sessions.test.ts
@@ -12,12 +12,13 @@ import { dashboardVisibleInPane, renderObserverHeader } from "../extensions/dash
 import {
 	makeInitialPopupState,
 	renderConflictsTab,
+	renderAwaitingWatchHintLine,
 	renderDashboardLines,
 	renderOverviewTab,
 	renderStaleHintLine,
 	type DashboardState,
 } from "../extensions/flightdeck.js";
-import { flightdeckSessionStatus, type FlightdeckSnapshot, type TrackedSession } from "../extensions/state.js";
+import { flightdeckSessionStatus, readAwaitingWatchTrackedEntries, type FlightdeckSnapshot, type TrackedSession } from "../extensions/state.js";
 
 type ThemeLike = {
 	fg(_color: string, text: string): string;
@@ -318,4 +319,24 @@ test("never-started daemon classifies as awaiting-watch, not stale", () => {
 		},
 	});
 	assert.equal(flightdeckSessionStatus(snap, { now: Date.parse("2026-05-13T00:30:00Z") }), "awaiting-watch");
+});
+
+test("awaiting-watch ignores tracked sessions whose pane ids are stale", () => {
+	const snap = snapshot([adhoc({ last_polled_at: "2026-05-13T00:00:00Z", pane_id: "%999" })], {
+		daemon: {
+			heartbeatExists: false,
+			pid: undefined,
+			pidAlive: false,
+			stateDir: "/tmp/pi-flightdeck-daemon",
+			subscriberCounts: { claude: 0, codex: 0, opencode: 0, pi: 0 },
+			subscribers: [],
+		},
+		livePaneIds: new Set(["%1", "%2"]),
+	});
+
+	assert.equal(readAwaitingWatchTrackedEntries(snap).length, 0);
+	assert.equal(flightdeckSessionStatus(snap, { now: Date.parse("2026-05-13T00:30:00Z") }), "inactive");
+	const text = joinRendered(renderAwaitingWatchHintLine(snap, plainTheme() as never, 120));
+	assert.match(text, /0 tracked sessions/);
+	assert.doesNotMatch(text, /1 tracked session/);
 });


### PR DESCRIPTION
## Summary
- Filter pi-flightdeck awaiting-watch tracked-session counts through live tmux pane ids.
- Treat never-started daemon state with only dead tracked pane ids as inactive, suppressing the misleading standby/watch hint.
- Document the stale-pane guard in the pi-flightdeck README.
- Bump `@vanillagreen/pi-flightdeck` package metadata to `0.1.1` and note stale-pane filtering in the package description.

Plan: `/mnt/Tertiary/dev/vstack/main/docs/plans/flightdeck-cleanup-and-dashboard-settings-handoff.md`
Item: `issue-140-stale-banner`
Reachability: `flightdeck.ts` refreshes snapshots, `flightdeckSessionStatus()` gates the awaiting-watch widget path, and `renderAwaitingWatchHintLine()` uses the same filtered count.

## Tests
- `cd pi-extensions/pi-flightdeck && npx tsx --test tests/*.test.ts`
- `git diff --check`
- `vstack refresh -g`
- `vstack refresh -g -v`
- `vstack verify -g @vanillagreen/pi-flightdeck`

## Pi extension refresh note
The global vstack source index for `@vanillagreen/pi-flightdeck` points at `/mnt/Tertiary/dev/vstack/main` (`1a1cac4b4d5feb689bb3a7c8e7910be56064d646`), not this worktree. `vstack refresh -g` therefore reported the global package unchanged; `vstack refresh -g -v` showed `@vanillagreen/pi-flightdeck 0f7f0b64 → 0f7f0b64 (unchanged)`. `vstack verify -g @vanillagreen/pi-flightdeck` passed for the currently installed global source.

Fixes #140
