### PR TITLE
Fix pi-session-bridge skill cache eviction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,7 +222,7 @@ Worktree/feature branch dev: test via local project Pi settings for that checkou
 ### Pi slash-command expansion
 
 - `sendUserMessage` still skips slash/skill expansion (`expandPromptTemplates: false`). `pi-bridge send` compensates with hybrid dispatch: client-side expansion for `/skill:<name>` and prompt templates, own-pane `tmux send-keys -l` for extension/TUI commands, raw `sendUserMessage` for plain text/fallback.
-- Repeated `/skill:<name>` sends in the same Pi session emit a short `Skill <name> (previously loaded). Invocation: ...` reminder instead of re-expanding the full SKILL.md body. The cache is keyed by `(session_id, skill_name, SKILL.md content hash)`; content-hash changes force a fresh full expansion; pi-bridge restart clears the in-memory cache.
+- Repeated `/skill:<name>` sends in the same Pi session emit a short `Skill <name> (previously loaded). Invocation: ...` reminder instead of re-expanding the full SKILL.md body. The cache is keyed by `(session_id, skill_name, SKILL.md content hash)`; content-hash changes force a fresh full expansion; `session_shutdown` evicts that session; pi-bridge restart clears the in-memory cache; and the bridge bounds the cache to the 100 most recent sessions.
 - From an extension, `ctx.ui.pasteToEditor("/skill:foo\n")` pastes text; newline is bracketed-paste content, not a guaranteed submit. Prefer `pi-bridge send "/skill:foo ..."` when controlling another session.
 
 ## Build & Test

--- a/pi-extensions/pi-session-bridge/README.md
+++ b/pi-extensions/pi-session-bridge/README.md
@@ -102,7 +102,7 @@ interface PiActivityBroker {
 
 - Plain text keeps the normal `sendUserMessage` path.
 - `/skill:<name> ...` expands client-side from the loaded skill's `sourceInfo.path`, inlining the same `<skill ...>` block Pi's editor would produce the first time a skill is loaded in a Pi session.
-- Repeated `/skill:<name> ...` sends in the same Pi session skip the `SKILL.md` body and send `Skill <name> (previously loaded). Invocation: ...` instead. Changing the `SKILL.md` file content changes its hash and forces a fresh full expansion; restarting the bridge loses the in-memory cache, so the next send expands fully again.
+- Repeated `/skill:<name> ...` sends in the same Pi session skip the `SKILL.md` body and send `Skill <name> (previously loaded). Invocation: ...` instead. Changing the `SKILL.md` file content changes its hash and forces a fresh full expansion; session shutdown evicts that session, bridge restart loses the in-memory cache, and the bridge keeps only the 100 most recent sessions.
 - Prompt templates (`/<name> ...` from loaded prompt paths) expand client-side with Pi-compatible `$1`, `$@`, `$ARGUMENTS`, and `${@:N[:L]}` substitution; unquoted spaces, tabs, and newlines split arguments, while quoted newlines stay inside the argument.
 - Extension/TUI commands (for example `/bridge:ping`, `/tasks:add`, `/flightdeck`) are pasted into Pi's own tmux pane with `send-keys -l` + enter after resolving the pane by walking parent processes from `process.pid`. This briefly shows text in the editor and always delivers immediately (`deliverAs` does not apply to this route).
 - If tmux pane resolution or paste fails, the bridge falls back to the old raw `sendUserMessage` behavior instead of failing the request.

--- a/pi-extensions/pi-session-bridge/extensions/session-bridge.ts
+++ b/pi-extensions/pi-session-bridge/extensions/session-bridge.ts
@@ -29,6 +29,7 @@ const QUESTION_SERVICE_SYMBOL = Symbol.for("vstack.pi-questions.service");
 const CONFIG_ID = "@vanillagreen/pi-session-bridge";
 const DEFAULT_HISTORY_LIMIT = 500;
 const DEFAULT_MAX_LINE_BYTES = 1024 * 1024;
+const MAX_SKILL_EXPANSION_CACHE_SESSIONS = 100;
 
 type JsonObject = Record<string, unknown>;
 type VstackConfig = Record<string, unknown>;
@@ -65,7 +66,7 @@ interface BridgeClient {
 	events: boolean;
 }
 
-const loadedSkillHashesBySession: SkillExpansionCache = new Map();
+export const loadedSkillHashesBySession: SkillExpansionCache = new Map();
 
 interface InstanceInfo {
 	protocol: string;
@@ -578,7 +579,11 @@ export default function sessionBridge(pi: ExtensionAPI) {
 		await start(ctx, event.reason ?? "session_start");
 	});
 
-	pi.on("session_shutdown", async (event) => {
+	pi.on("session_shutdown", async (event, ctx) => {
+		evictLoadedSkillExpansionSession(
+			loadedSkillHashesBySession,
+			readStringProperty(event, "sessionId") ?? sessionIdFromContext(ctx) ?? currentInfo?.sessionId,
+		);
 		await stop(event.reason ?? "session_shutdown");
 	});
 
@@ -645,7 +650,7 @@ export function expandLoadedSlashContent(
 			const sessionId = options.sessionId?.trim();
 			const cache = options.skillExpansionCache;
 			if (sessionId && cache) {
-				const sessionCache = cache.get(sessionId);
+				const sessionCache = touchLoadedSkillExpansionSession(cache, sessionId);
 				const cachedHash = sessionCache?.get(skillName);
 				if (cachedHash === contentHash) {
 					const invocation = parsed.argsString.trim();
@@ -661,11 +666,7 @@ export function expandLoadedSlashContent(
 			const body = stripFrontmatter(raw).trim();
 			const baseDir = skill.sourceInfo?.baseDir || path.dirname(sourcePath);
 			const block = `<skill name="${skillName}" location="${sourcePath}">\nReferences are relative to ${baseDir}.\n\n${body}\n</skill>`;
-			if (sessionId && cache) {
-				const sessionCache = cache.get(sessionId) ?? new Map<string, string>();
-				sessionCache.set(skillName, contentHash);
-				cache.set(sessionId, sessionCache);
-			}
+			if (sessionId && cache) rememberLoadedSkillExpansion(cache, sessionId, skillName, contentHash);
 			return {
 				expanded: true,
 				kind: "skill",
@@ -691,6 +692,57 @@ export function expandLoadedSlashContent(
 	} catch (error) {
 		return { expanded: false, error: stringifyError(error) };
 	}
+}
+
+export function evictLoadedSkillExpansionSession(cache: SkillExpansionCache, sessionId?: string): boolean {
+	const normalized = sessionId?.trim();
+	return normalized ? cache.delete(normalized) : false;
+}
+
+export function rememberLoadedSkillExpansion(
+	cache: SkillExpansionCache,
+	sessionId: string,
+	skillName: string,
+	contentHash: string,
+	maxSessions = MAX_SKILL_EXPANSION_CACHE_SESSIONS,
+): void {
+	const normalized = sessionId.trim();
+	if (!normalized) return;
+	const sessionCache = cache.get(normalized) ?? new Map<string, string>();
+	cache.delete(normalized);
+	sessionCache.set(skillName, contentHash);
+	cache.set(normalized, sessionCache);
+	trimLoadedSkillExpansionSessions(cache, maxSessions);
+}
+
+function touchLoadedSkillExpansionSession(cache: SkillExpansionCache, sessionId: string): Map<string, string> | undefined {
+	const normalized = sessionId.trim();
+	if (!normalized) return undefined;
+	const sessionCache = cache.get(normalized);
+	if (!sessionCache) return undefined;
+	cache.delete(normalized);
+	cache.set(normalized, sessionCache);
+	return sessionCache;
+}
+
+function trimLoadedSkillExpansionSessions(cache: SkillExpansionCache, maxSessions: number): void {
+	const limit = Math.max(0, Math.floor(maxSessions));
+	while (cache.size > limit) {
+		const oldest = cache.keys().next().value;
+		if (typeof oldest !== "string") return;
+		cache.delete(oldest);
+	}
+}
+
+function sessionIdFromContext(ctx?: ExtensionContext): string | undefined {
+	const defaultId = callOptional(ctx?.sessionManager, "getSessionId");
+	return resolveSessionId({ defaultId, pid: process.pid }).sessionId;
+}
+
+function readStringProperty(value: unknown, key: string): string | undefined {
+	if (!value || typeof value !== "object") return undefined;
+	const nested = (value as Record<string, unknown>)[key];
+	return typeof nested === "string" && nested.trim().length > 0 ? nested.trim() : undefined;
 }
 
 function shortSha256(content: string): string {

--- a/pi-extensions/pi-session-bridge/instructions.md
+++ b/pi-extensions/pi-session-bridge/instructions.md
@@ -6,7 +6,7 @@ Discovery: `pi-bridge list` returns `(PID, IDLE, SESSION, NAME, CWD, SOCKET)`. F
 
 Commands:
 - `state` — structured snapshot (idle, model, cwd, session id, paths).
-- `send "msg"` — deliver a prompt; auto-queues if the target is busy. Slash dispatch is hybrid: `/skill:<name>` and prompt templates expand client-side, extension/TUI commands paste into the target Pi pane, and plain text uses normal `sendUserMessage`. Repeated `/skill:<name>` sends in one Pi session use a short previously-loaded reminder unless the `SKILL.md` content hash changes; bridge restart loses this in-memory cache.
+- `send "msg"` — deliver a prompt; auto-queues if the target is busy. Slash dispatch is hybrid: `/skill:<name>` and prompt templates expand client-side, extension/TUI commands paste into the target Pi pane, and plain text uses normal `sendUserMessage`. Repeated `/skill:<name>` sends in one Pi session use a short previously-loaded reminder unless the `SKILL.md` content hash changes; session shutdown evicts that session, bridge restart loses the in-memory cache, and the bridge keeps only the 100 most recent sessions.
 - `steer "msg"` / `follow-up "msg"` / `abort` — interrupt-and-redirect / queue-after-turn / cancel.
 - `history N` / `stream` — structured events (input, message_update, tool_call, agent_end, bridge_pong, question, `vstack_activity`). Activity rows are non-chat bridge events emitted by the local activity broker.
 - `questions` + `answer --request-id … --answers '[[...]]'` / `reject --request-id …` — drive `pi-questions` popups.

--- a/pi-extensions/pi-session-bridge/package.json
+++ b/pi-extensions/pi-session-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vanillagreen/pi-session-bridge",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Pi extension and CLI for controlling visible interactive Pi sessions over a structured Unix-socket side channel.",
   "license": "MIT",
   "keywords": [

--- a/pi-extensions/pi-session-bridge/tests/slash-dispatch.test.ts
+++ b/pi-extensions/pi-session-bridge/tests/slash-dispatch.test.ts
@@ -3,8 +3,9 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "nod
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
-import {
+import sessionBridge, {
 	expandLoadedSlashContent,
+	loadedSkillHashesBySession,
 	parseCommandArgs,
 	pasteAndSubmitToPane,
 	resolveOwnTmuxPaneByParentChain,
@@ -12,18 +13,63 @@ import {
 	type SlashCommandInfoLike,
 } from "../extensions/session-bridge.ts";
 
+type EventHandler = (event: any, ctx?: any) => unknown | Promise<unknown>;
+
+interface FakePi {
+	handlers: Map<string, EventHandler>;
+	pi: any;
+}
+
+function fakePi(): FakePi {
+	const handlers = new Map<string, EventHandler>();
+	return {
+		handlers,
+		pi: {
+			exec: async () => ({ code: 0, stdout: "" }),
+			getCommands: () => [],
+			getSessionName: () => undefined,
+			getThinkingLevel: () => undefined,
+			on: (eventName: string, handler: EventHandler) => handlers.set(eventName, handler),
+			registerCommand: () => undefined,
+			sendUserMessage: () => undefined,
+		},
+	};
+}
+
+function writeEnabledProjectSettings(root: string): void {
+	const settingsPath = join(root, ".pi/settings.json");
+	mkdirSync(dirname(settingsPath), { recursive: true });
+	writeFileSync(settingsPath, JSON.stringify({
+		vstack: {
+			extensionManager: {
+				config: {
+					"@vanillagreen/pi-session-bridge": { enabled: true },
+				},
+			},
+		},
+	}));
+}
+
 let dir = "";
 let oldTmux: string | undefined;
+let oldBridgeDir: string | undefined;
+let oldCwd = "";
 function p(name: string): string { return join(dir, name); }
 
 beforeEach(() => {
 	dir = mkdtempSync(join(tmpdir(), "pi-session-bridge-slash-"));
 	oldTmux = process.env.TMUX;
+	oldBridgeDir = process.env.PI_BRIDGE_DIR;
+	oldCwd = process.cwd();
 });
 
 afterEach(() => {
 	if (oldTmux === undefined) delete process.env.TMUX;
 	else process.env.TMUX = oldTmux;
+	if (oldBridgeDir === undefined) delete process.env.PI_BRIDGE_DIR;
+	else process.env.PI_BRIDGE_DIR = oldBridgeDir;
+	process.chdir(oldCwd);
+	loadedSkillHashesBySession.clear();
 	if (dir) rmSync(dir, { recursive: true, force: true });
 });
 
@@ -139,6 +185,44 @@ describe("slash expansion", () => {
 			skillExpansionCache: cache,
 		});
 		expect(otherSession.text).toContain(`<skill name="flightdeck" location="${skillPath}">`);
+	});
+
+	test("evicts only the shutting-down session from the skill expansion cache", async () => {
+		writeEnabledProjectSettings(dir);
+		process.chdir(dir);
+		process.env.PI_BRIDGE_DIR = p("bridge-dir");
+		loadedSkillHashesBySession.set("session-a", new Map([["alpha", "hash-a"]]));
+		loadedSkillHashesBySession.set("session-b", new Map([["beta", "hash-b"]]));
+
+		const { pi, handlers } = fakePi();
+		sessionBridge(pi);
+		const shutdown = handlers.get("session_shutdown");
+		expect(typeof shutdown).toBe("function");
+
+		await shutdown?.({ reason: "quit" }, { sessionManager: { getSessionId: () => "session-a" } });
+
+		expect(loadedSkillHashesBySession.has("session-a")).toBe(false);
+		expect(loadedSkillHashesBySession.get("session-b")?.get("beta")).toBe("hash-b");
+	});
+
+	test("bounds skill expansion cache to the 100 most recent sessions", () => {
+		const skillPath = p("skills/flightdeck/SKILL.md");
+		mkdirSync(dirname(skillPath), { recursive: true });
+		writeFileSync(skillPath, "---\nname: flightdeck\n---\n# Flightdeck\nWatch sessions.\n");
+		const commands = [{ name: "skill:flightdeck", source: "skill", sourceInfo: { path: skillPath } }] as SlashCommandInfoLike[];
+		const cache = new Map<string, Map<string, string>>();
+
+		for (let index = 0; index < 101; index++) {
+			expandLoadedSlashContent("/skill:flightdeck watch", commands, readFileSync, {
+				sessionId: `session-${index}`,
+				skillExpansionCache: cache,
+			});
+		}
+
+		expect(cache.size).toBe(100);
+		expect(cache.has("session-0")).toBe(false);
+		expect(cache.has("session-1")).toBe(true);
+		expect(cache.has("session-100")).toBe(true);
 	});
 
 	test("re-expands skill after SKILL.md content changes", () => {


### PR DESCRIPTION
## Summary
- Evict the per-session skill expansion cache entry during `session_shutdown` using the active session id.
- Bound the skill expansion cache to the 100 most recent sessions with Map-order LRU behavior.
- Document the session-shutdown/cache-bound behavior in the Session Bridge README, append-system instructions, and root `AGENTS.md`.
- Bump `@vanillagreen/pi-session-bridge` package metadata from `1.0.6` to `1.0.7` for the behavior change.

## Plan reference
- Plan file: `/mnt/Tertiary/dev/vstack/main/docs/plans/flightdeck-cleanup-and-dashboard-settings-handoff.md`
- Plan item id: `issue-129-cache-eviction`

## Tests / validation
- `cd pi-extensions/pi-session-bridge && bun run check`
- `vstack refresh -g` — Processed 18 Pi package(s), 0 updated
- `vstack verify -g @vanillagreen/pi-session-bridge` — `src:✓ install:✓`

Fixes #129
