### PR TITLE
Prefix Codex provider HTTP errors

### DIFF
--- a/pi-extensions/pi-codex-minimal-tools/README.md
+++ b/pi-extensions/pi-codex-minimal-tools/README.md
@@ -15,6 +15,7 @@ Minimal Codex/OpenAI tools for Pi. Adds Codex-style tools without replacing Pi n
 - Generated images saved with timestamp filenames, `latest.<ext>` mirrors, metadata, and inline previews.
 - Tools only activate on OpenAI/Codex-like models; hidden on Anthropic/Claude-bridge sessions.
 - Optional direct OpenAI Images API fallback when `OPENAI_API_KEY` is set.
+- Codex provider failures keep HTTP status prefixes such as `HTTP 429:` or `HTTP 503:` so Pi can classify retries and limits.
 
 `web_search` moved to `pi-web-tools`. Install both packages together if you use search.
 

--- a/pi-extensions/pi-codex-minimal-tools/src/provider-shim.ts
+++ b/pi-extensions/pi-codex-minimal-tools/src/provider-shim.ts
@@ -174,6 +174,8 @@ const websocketSessionCache = new Map<string, SessionWebSocketCacheEntry>();
 
 class NonRetryableProviderError extends Error {}
 
+const HTTP_STATUS_MESSAGE_PREFIX = /^HTTP\s+\d{3}(?::|\b)/i;
+
 interface StreamEventShape {
 	type?: string;
 	response?: ResponseEnvelope;
@@ -580,6 +582,12 @@ function isRetryableError(status: number, errorText: string): boolean {
 		return true;
 	}
 	return /rate.?limit|overloaded|service.?unavailable|upstream.?connect|connection.?refused/i.test(errorText);
+}
+
+export function withHttpStatusPrefix(status: number, message: string): string {
+	const trimmed = message.trim() || "Request failed";
+	if (HTTP_STATUS_MESSAGE_PREFIX.test(trimmed)) return trimmed;
+	return `HTTP ${status}: ${trimmed}`;
 }
 
 function sleep(ms: number, signal: AbortSignal | undefined): Promise<void> {
@@ -1666,7 +1674,7 @@ function createCodexStream<TApi extends Api>(
 						statusText: response.statusText,
 					});
 					const info = await parseErrorResponse(fakeResponse);
-					throw new NonRetryableProviderError(info.friendlyMessage || info.message);
+					throw new NonRetryableProviderError(withHttpStatusPrefix(response.status, info.friendlyMessage || info.message));
 				} catch (error) {
 					if (error instanceof NonRetryableProviderError) {
 						throw error;

--- a/pi-extensions/pi-codex-minimal-tools/tests/capabilities.test.ts
+++ b/pi-extensions/pi-codex-minimal-tools/tests/capabilities.test.ts
@@ -4,7 +4,7 @@ import { computeNextActiveTools, computeToolCapabilities } from "../src/capabili
 import { DEFAULT_SETTINGS } from "../src/settings.js";
 
 const codex55 = { provider: "openai-codex", id: "gpt-5.5", input: ["text", "image"] };
-const spark = { provider: "openai-codex", id: "gpt-5.3-codex-spark", input: ["text"] };
+const textOnlyCodex = { provider: "openai-codex", id: "text-only-codex", input: ["text"] };
 const openai = { provider: "openai", id: "gpt-5.5", input: ["text", "image"] };
 
 test("capability gating follows provider and image support", () => {
@@ -15,10 +15,10 @@ test("capability gating follows provider and image support", () => {
 	assert.equal(codex.view_image.enabled, true);
 	assert.equal(codex.apply_patch.enabled, true);
 
-	const sparkCaps = computeToolCapabilities(spark, withViewImage);
-	assert.equal(sparkCaps.image_generation.enabled, false);
-	assert.equal(sparkCaps.view_image.enabled, false);
-	assert.equal(sparkCaps.apply_patch.enabled, true);
+	const textOnlyCodexCaps = computeToolCapabilities(textOnlyCodex, withViewImage);
+	assert.equal(textOnlyCodexCaps.image_generation.enabled, false);
+	assert.equal(textOnlyCodexCaps.view_image.enabled, false);
+	assert.equal(textOnlyCodexCaps.apply_patch.enabled, true);
 
 	const openaiCaps = computeToolCapabilities(openai, withViewImage);
 	assert.equal(openaiCaps.image_generation.enabled, false);

--- a/pi-extensions/pi-codex-minimal-tools/tests/provider-shim-http-status.test.ts
+++ b/pi-extensions/pi-codex-minimal-tools/tests/provider-shim-http-status.test.ts
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+import test, { afterEach } from "node:test";
+import { registerOpenAICodexCustomProvider, withHttpStatusPrefix } from "../src/provider-shim.js";
+
+const originalFetch = globalThis.fetch;
+const originalSetTimeout = globalThis.setTimeout;
+
+interface FetchFactory {
+	(): Response;
+}
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+	globalThis.setTimeout = originalSetTimeout;
+});
+
+function installImmediateRetryTimers(): void {
+	globalThis.setTimeout = ((callback: TimerHandler, _delay?: number, ...args: unknown[]) => {
+		queueMicrotask(() => {
+			if (typeof callback === "function") {
+				callback(...args);
+			}
+		});
+		return 0 as unknown as ReturnType<typeof setTimeout>;
+	}) as unknown as typeof setTimeout;
+}
+
+function codexJwt(): string {
+	const payload = Buffer.from(JSON.stringify({ "https://api.openai.com/auth": { chatgpt_account_id: "acct_test" } })).toString("base64");
+	return `header.${payload}.signature`;
+}
+
+function createCodexProvider(): any {
+	let provider: any;
+	const pi = {
+		registerProvider(name: string, value: any) {
+			assert.equal(name, "openai-codex");
+			provider = value;
+		},
+		on() {},
+		registerMessageRenderer() {},
+	};
+	registerOpenAICodexCustomProvider(pi as any, { getCurrentCwd: () => process.cwd() });
+	assert.ok(provider);
+	return provider;
+}
+
+function mockFetch(factories: FetchFactory[]): () => number {
+	let calls = 0;
+	globalThis.fetch = (async () => {
+		const factory = factories[Math.min(calls, factories.length - 1)];
+		calls++;
+		return factory();
+	}) as typeof fetch;
+	return () => calls;
+}
+
+async function runCodexProvider(): Promise<any> {
+	const provider = createCodexProvider();
+	const stream = provider.streamSimple(
+		{
+			provider: "openai-codex",
+			api: "openai-codex-responses",
+			id: "gpt-5.5",
+			baseUrl: "https://example.test/backend-api",
+			headers: {},
+			input: ["text"],
+			reasoning: false,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		},
+		{
+			systemPrompt: "",
+			messages: [{ role: "user", content: "hello" }],
+			tools: [],
+		},
+		{ apiKey: codexJwt(), transport: "sse" },
+	);
+	return stream.result();
+}
+
+function errorResponse(status: number, body: unknown, statusText = "Error"): Response {
+	return new Response(typeof body === "string" ? body : JSON.stringify(body), { status, statusText });
+}
+
+function successSseResponse(): Response {
+	const event = {
+		type: "response.completed",
+		response: {
+			id: "resp_ok",
+			status: "completed",
+			usage: { input_tokens: 0, output_tokens: 0, total_tokens: 0, input_tokens_details: { cached_tokens: 0 } },
+		},
+	};
+	return new Response(`data: ${JSON.stringify(event)}\n\n`, { status: 200, headers: { "content-type": "text/event-stream" } });
+}
+
+test("withHttpStatusPrefix adds status once", () => {
+	assert.equal(withHttpStatusPrefix(503, "Service unavailable"), "HTTP 503: Service unavailable");
+	assert.equal(withHttpStatusPrefix(429, "HTTP 429: Too many requests"), "HTTP 429: Too many requests");
+	assert.equal(withHttpStatusPrefix(503, "HTTP 503 upstream unavailable"), "HTTP 503 upstream unavailable");
+});
+
+test("final HTTP 429 provider failure preserves friendly usage-limit text after status prefix", async () => {
+	installImmediateRetryTimers();
+	const fetchCalls = mockFetch([
+		() => errorResponse(429, { error: { code: "usage_limit_reached", plan_type: "PLUS", message: "Upstream quota body" } }, "Too Many Requests"),
+	]);
+
+	const result = await runCodexProvider();
+
+	assert.equal(fetchCalls(), 4);
+	assert.equal(result.stopReason, "error");
+	assert.equal(result.errorMessage, "HTTP 429: You have hit your ChatGPT usage limit (plus plan).");
+});
+
+test("final HTTP 503 provider failure preserves HTTP status prefix", async () => {
+	installImmediateRetryTimers();
+	const fetchCalls = mockFetch([
+		() => errorResponse(503, { error: { code: "server_error", message: "Service unavailable" } }, "Service Unavailable"),
+	]);
+
+	const result = await runCodexProvider();
+
+	assert.equal(fetchCalls(), 4);
+	assert.equal(result.stopReason, "error");
+	assert.equal(result.errorMessage, "HTTP 503: Service unavailable");
+});
+
+test("successful SSE retry hides intermediate HTTP failure", async () => {
+	installImmediateRetryTimers();
+	const fetchCalls = mockFetch([
+		() => errorResponse(503, { error: { code: "server_error", message: "Service unavailable" } }, "Service Unavailable"),
+		() => successSseResponse(),
+	]);
+
+	const result = await runCodexProvider();
+
+	assert.equal(fetchCalls(), 2);
+	assert.equal(result.stopReason, "stop");
+	assert.equal(result.errorMessage, undefined);
+});


### PR DESCRIPTION
## Summary
- Prefix terminal Codex SSE/Responses HTTP failures with `HTTP <status>:` before surfacing `NonRetryableProviderError` messages.
- Preserve friendly ChatGPT usage-limit messaging after the new status prefix and avoid double-prefixing messages that already start with `HTTP <status>`.
- Add provider-shim coverage for final HTTP 429, final HTTP 503, and successful retry behavior hiding intermediate failures.
- Rename stale text-only Codex test fixture identifiers from `spark` to neutral names; runtime behavior unchanged.

## Docs updates
- Updated `pi-extensions/pi-codex-minimal-tools/README.md` to note HTTP status prefixes on Codex provider failures.

## Validation
- `cd pi-extensions/pi-codex-minimal-tools && npm test`
- `cd pi-extensions/pi-codex-minimal-tools && npm run typecheck`
- `cd pi-extensions/pi-codex-minimal-tools && npm run check`

## Known no-op / deferred
- Global `vstack refresh -g` not run from this feature worktree to avoid editing global Pi install state before merge; master should refresh after merge if needed.
