### PR TITLE
Make skills manager browse rows responsive

### DIFF
--- a/pi-extensions/pi-skills-manager/README.md
+++ b/pi-extensions/pi-skills-manager/README.md
@@ -55,7 +55,7 @@ Open `/extensions:settings`; settings appear under the **Skills Manager** tab.
 | Default create location | `project` or `global`. |
 | Popup width | Number of columns or `82%`-style percentage. |
 | Popup max height | Number of rows or percentage. |
-| Visible list rows | Rows shown before scrolling. |
+| Visible list rows | Maximum rows shown before scrolling; short terminals shrink this so controls remain visible. |
 
 ## Notes
 

--- a/pi-extensions/pi-skills-manager/extensions/skills-manager/dialog.ts
+++ b/pi-extensions/pi-skills-manager/extensions/skills-manager/dialog.ts
@@ -29,7 +29,7 @@ import {
 	readSkillDocument,
 	toUpdatedSkill,
 } from "./format.js";
-import { normalizeListRows, responsiveBrowseListRows } from "./layout.js";
+import { normalizeListRows, responsiveBrowsePageSelection, responsiveBrowseWindow, sanitizePopupMaxHeight } from "./layout.js";
 import { isDeletableSkill, skillStorageTarget } from "./registry.js";
 import { settingNumber, settingOverlaySize, settingString } from "./settings.js";
 import {
@@ -99,7 +99,7 @@ class SkillsManagerDialog implements Focusable {
 		this.browseInput.setValue(initialQuery);
 		this.createLocation = settingString("defaultCreateLocation", "project", ctx.cwd) === "global" ? "global" : "project";
 		this.configuredListRows = normalizeListRows(settingNumber("listRows", DEFAULT_LIST_ROWS, ctx.cwd));
-		this.popupMaxHeight = settingOverlaySize("popupMaxHeight", DEFAULT_POPUP_MAX_HEIGHT, ctx.cwd);
+		this.popupMaxHeight = sanitizePopupMaxHeight(settingOverlaySize("popupMaxHeight", DEFAULT_POPUP_MAX_HEIGHT, ctx.cwd));
 		this.descriptionEditor = new Editor(tui, { borderColor: (text: string) => " ".repeat(text.length), selectList: getEditorTheme(theme).selectList });
 		this.descriptionEditor.onSubmit = (text: string) => { this.submittedDescriptionValue = text; void this.advanceCreate(); };
 		this.renameInput.onSubmit = (value) => { void this.submitRename(value); };
@@ -147,7 +147,6 @@ class SkillsManagerDialog implements Focusable {
 	private getSelectedSkill(): SkillEntry | undefined { return this.selectedIndex === 0 ? undefined : this.filteredSkills[this.selectedIndex - 1]; }
 	private getCurrentSkill(): SkillEntry | undefined { return this.previewSkillPath ? this.registry.allSkills.find((skill) => skill.path === this.previewSkillPath) : undefined; }
 	private get currentCreateStep(): CreateStep { return CREATE_STEPS[this.createStepIndex]!; }
-	private responsiveListRows(): number { return responsiveBrowseListRows(this.configuredListRows, this.tui.terminal.rows, this.popupMaxHeight); }
 
 	private enterCreateMode(): void { this.mode = "create"; this.createStepIndex = 0; this.createError = undefined; this.syncCreateInput(); this.syncFocus(); this.requestRender(); }
 	private exitToBrowse(preferredPath?: string): void {
@@ -303,9 +302,7 @@ class SkillsManagerDialog implements Focusable {
 				selectableIndex += 1;
 			}
 		}
-		const listRows = this.responsiveListRows();
-		const startIndex = Math.max(0, Math.min(selectedDisplayIndex - Math.floor(listRows / 2), Math.max(0, entries.length - listRows)));
-		const endIndex = Math.min(startIndex + listRows, entries.length);
+		const { startIndex, endIndex } = responsiveBrowseWindow(this.configuredListRows, this.tui.terminal.rows, entries.length, selectedDisplayIndex, this.popupMaxHeight);
 		selectableIndex = 0;
 		const ellipsis = this.theme.fg("dim", "...");
 		for (let i = 0; i < endIndex; i++) {
@@ -406,9 +403,8 @@ class SkillsManagerDialog implements Focusable {
 	private handleBrowseInput(data: string): void {
 		if (matchesKey(data, Key.up)) { this.selectedIndex = this.selectedIndex === 0 ? this.filteredSkills.length : this.selectedIndex - 1; return; }
 		if (matchesKey(data, Key.down)) { this.selectedIndex = this.selectedIndex === this.filteredSkills.length ? 0 : this.selectedIndex + 1; return; }
-		const listRows = this.responsiveListRows();
-		if (matchesKey(data, "-") || matchesKey(data, Key.pageUp)) { this.selectedIndex = Math.max(0, this.selectedIndex - listRows); return; }
-		if (matchesKey(data, "=") || matchesKey(data, Key.pageDown)) { this.selectedIndex = Math.min(this.filteredSkills.length, this.selectedIndex + listRows); return; }
+		if (matchesKey(data, "-") || matchesKey(data, Key.pageUp)) { this.selectedIndex = responsiveBrowsePageSelection(this.configuredListRows, this.tui.terminal.rows, this.selectedIndex, this.filteredSkills.length, -1, this.popupMaxHeight); return; }
+		if (matchesKey(data, "=") || matchesKey(data, Key.pageDown)) { this.selectedIndex = responsiveBrowsePageSelection(this.configuredListRows, this.tui.terminal.rows, this.selectedIndex, this.filteredSkills.length, 1, this.popupMaxHeight); return; }
 		if (matchesKey(data, Key.enter)) { if (this.selectedIndex === 0) { this.enterCreateMode(); return; } const skill = this.getSelectedSkill(); if (!skill) return; if (!skill.enabled) this.ctx.ui.notify("Enable this skill first with alt+x", "info"); else this.done(skill); return; }
 		if (matchesKey(data, Key.tab)) { const skill = this.getSelectedSkill(); if (skill) this.openPreview(skill); return; }
 		if (matchesKey(data, Key.alt("x")) || matchesKey(data, Key.ctrl("x"))) { const skill = this.getSelectedSkill(); if (skill) void this.toggleSkill(skill); return; }
@@ -446,7 +442,7 @@ export async function showSkillsManager(ctx: ExtensionContext, registry: SkillRe
 			overlayOptions: {
 				anchor: "center",
 				width: settingOverlaySize("popupWidth", DEFAULT_POPUP_WIDTH, ctx.cwd),
-				maxHeight: settingOverlaySize("popupMaxHeight", DEFAULT_POPUP_MAX_HEIGHT, ctx.cwd),
+				maxHeight: sanitizePopupMaxHeight(settingOverlaySize("popupMaxHeight", DEFAULT_POPUP_MAX_HEIGHT, ctx.cwd)),
 			},
 		});
 	} finally {

--- a/pi-extensions/pi-skills-manager/extensions/skills-manager/dialog.ts
+++ b/pi-extensions/pi-skills-manager/extensions/skills-manager/dialog.ts
@@ -29,6 +29,7 @@ import {
 	readSkillDocument,
 	toUpdatedSkill,
 } from "./format.js";
+import { normalizeListRows, responsiveBrowseListRows } from "./layout.js";
 import { isDeletableSkill, skillStorageTarget } from "./registry.js";
 import { settingNumber, settingOverlaySize, settingString } from "./settings.js";
 import {
@@ -48,6 +49,7 @@ import {
 	type CreateStep,
 	type CreateTextStepId,
 	type Mode,
+	type OverlaySize,
 	type SkillEntry,
 	type SkillLocation,
 	type SkillRegistry,
@@ -77,7 +79,8 @@ class SkillsManagerDialog implements Focusable {
 	private deleteReturnMode: "browse" | "preview" = "browse";
 	private generationAbortController: AbortController | undefined;
 	private generationRunId = 0;
-	private readonly listRows: number;
+	private readonly configuredListRows: number;
+	private readonly popupMaxHeight: OverlaySize;
 
 	constructor(
 		private readonly ctx: ExtensionContext,
@@ -95,7 +98,8 @@ class SkillsManagerDialog implements Focusable {
 		this.browseQuery = initialQuery;
 		this.browseInput.setValue(initialQuery);
 		this.createLocation = settingString("defaultCreateLocation", "project", ctx.cwd) === "global" ? "global" : "project";
-		this.listRows = Math.max(6, Math.floor(settingNumber("listRows", DEFAULT_LIST_ROWS, ctx.cwd)));
+		this.configuredListRows = normalizeListRows(settingNumber("listRows", DEFAULT_LIST_ROWS, ctx.cwd));
+		this.popupMaxHeight = settingOverlaySize("popupMaxHeight", DEFAULT_POPUP_MAX_HEIGHT, ctx.cwd);
 		this.descriptionEditor = new Editor(tui, { borderColor: (text: string) => " ".repeat(text.length), selectList: getEditorTheme(theme).selectList });
 		this.descriptionEditor.onSubmit = (text: string) => { this.submittedDescriptionValue = text; void this.advanceCreate(); };
 		this.renameInput.onSubmit = (value) => { void this.submitRename(value); };
@@ -143,6 +147,7 @@ class SkillsManagerDialog implements Focusable {
 	private getSelectedSkill(): SkillEntry | undefined { return this.selectedIndex === 0 ? undefined : this.filteredSkills[this.selectedIndex - 1]; }
 	private getCurrentSkill(): SkillEntry | undefined { return this.previewSkillPath ? this.registry.allSkills.find((skill) => skill.path === this.previewSkillPath) : undefined; }
 	private get currentCreateStep(): CreateStep { return CREATE_STEPS[this.createStepIndex]!; }
+	private responsiveListRows(): number { return responsiveBrowseListRows(this.configuredListRows, this.tui.terminal.rows, this.popupMaxHeight); }
 
 	private enterCreateMode(): void { this.mode = "create"; this.createStepIndex = 0; this.createError = undefined; this.syncCreateInput(); this.syncFocus(); this.requestRender(); }
 	private exitToBrowse(preferredPath?: string): void {
@@ -298,8 +303,9 @@ class SkillsManagerDialog implements Focusable {
 				selectableIndex += 1;
 			}
 		}
-		const startIndex = Math.max(0, Math.min(selectedDisplayIndex - Math.floor(this.listRows / 2), Math.max(0, entries.length - this.listRows)));
-		const endIndex = Math.min(startIndex + this.listRows, entries.length);
+		const listRows = this.responsiveListRows();
+		const startIndex = Math.max(0, Math.min(selectedDisplayIndex - Math.floor(listRows / 2), Math.max(0, entries.length - listRows)));
+		const endIndex = Math.min(startIndex + listRows, entries.length);
 		selectableIndex = 0;
 		const ellipsis = this.theme.fg("dim", "...");
 		for (let i = 0; i < endIndex; i++) {
@@ -400,8 +406,9 @@ class SkillsManagerDialog implements Focusable {
 	private handleBrowseInput(data: string): void {
 		if (matchesKey(data, Key.up)) { this.selectedIndex = this.selectedIndex === 0 ? this.filteredSkills.length : this.selectedIndex - 1; return; }
 		if (matchesKey(data, Key.down)) { this.selectedIndex = this.selectedIndex === this.filteredSkills.length ? 0 : this.selectedIndex + 1; return; }
-		if (matchesKey(data, "-") || matchesKey(data, Key.pageUp)) { this.selectedIndex = Math.max(0, this.selectedIndex - this.listRows); return; }
-		if (matchesKey(data, "=") || matchesKey(data, Key.pageDown)) { this.selectedIndex = Math.min(this.filteredSkills.length, this.selectedIndex + this.listRows); return; }
+		const listRows = this.responsiveListRows();
+		if (matchesKey(data, "-") || matchesKey(data, Key.pageUp)) { this.selectedIndex = Math.max(0, this.selectedIndex - listRows); return; }
+		if (matchesKey(data, "=") || matchesKey(data, Key.pageDown)) { this.selectedIndex = Math.min(this.filteredSkills.length, this.selectedIndex + listRows); return; }
 		if (matchesKey(data, Key.enter)) { if (this.selectedIndex === 0) { this.enterCreateMode(); return; } const skill = this.getSelectedSkill(); if (!skill) return; if (!skill.enabled) this.ctx.ui.notify("Enable this skill first with alt+x", "info"); else this.done(skill); return; }
 		if (matchesKey(data, Key.tab)) { const skill = this.getSelectedSkill(); if (skill) this.openPreview(skill); return; }
 		if (matchesKey(data, Key.alt("x")) || matchesKey(data, Key.ctrl("x"))) { const skill = this.getSelectedSkill(); if (skill) void this.toggleSkill(skill); return; }

--- a/pi-extensions/pi-skills-manager/extensions/skills-manager/layout.ts
+++ b/pi-extensions/pi-skills-manager/extensions/skills-manager/layout.ts
@@ -1,28 +1,129 @@
 import { DEFAULT_LIST_ROWS, DEFAULT_POPUP_MAX_HEIGHT } from "./constants.js";
 import type { OverlaySize } from "./types.js";
 
-const BROWSE_CHROME_ROWS = 8;
+export const BROWSE_FRAME_ROWS = 2;
+export const BROWSE_SEARCH_ROWS = 1;
+export const BROWSE_SEARCH_GAP_ROWS = 1;
+export const BROWSE_FOOTER_GAP_ROWS = 1;
+export const BROWSE_FOOTER_ROWS = 1;
+export const BROWSE_NON_LIST_ROWS = BROWSE_FRAME_ROWS + BROWSE_SEARCH_ROWS + BROWSE_SEARCH_GAP_ROWS + BROWSE_FOOTER_GAP_ROWS + BROWSE_FOOTER_ROWS;
 
-export function normalizeListRows(rows: number, fallback = DEFAULT_LIST_ROWS): number {
-	const value = Number.isFinite(rows) ? rows : fallback;
-	return Math.max(1, Math.floor(value));
+const DEFAULT_POPUP_MAX_HEIGHT_RATIO = 0.86;
+const FALLBACK_TERMINAL_ROWS = Math.ceil((DEFAULT_LIST_ROWS + BROWSE_NON_LIST_ROWS) / DEFAULT_POPUP_MAX_HEIGHT_RATIO);
+
+type ParsedPopupMaxHeight =
+	| { kind: "rows"; rows: number }
+	| { kind: "percent"; ratio: number; text: string };
+
+export interface BrowseWindow {
+	listRows: number;
+	startIndex: number;
+	endIndex: number;
 }
 
-export function resolveOverlayRows(terminalRows: number, maxHeight: OverlaySize = DEFAULT_POPUP_MAX_HEIGHT): number {
-	const terminal = Math.max(1, Math.floor(terminalRows));
-	if (typeof maxHeight === "number" && Number.isFinite(maxHeight)) return Math.max(1, Math.min(terminal, Math.floor(maxHeight)));
-	if (typeof maxHeight === "string") {
-		const trimmed = maxHeight.trim();
-		const percent = trimmed.match(/^(\d+(?:\.\d+)?)%$/);
-		if (percent) return Math.max(1, Math.min(terminal, Math.floor(terminal * (Number(percent[1]) / 100))));
-		if (/^\d+$/.test(trimmed)) return Math.max(1, Math.min(terminal, Number(trimmed)));
+function finiteFloor(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isFinite(value) ? Math.floor(value) : undefined;
+}
+
+function positiveFiniteFloor(value: unknown): number | undefined {
+	const floored = finiteFloor(value);
+	return floored !== undefined && floored >= 1 ? floored : undefined;
+}
+
+function clamp(value: number, min: number, max: number): number {
+	return Math.max(min, Math.min(max, value));
+}
+
+function parsePopupMaxHeight(maxHeight: OverlaySize | undefined): ParsedPopupMaxHeight | undefined {
+	const rows = positiveFiniteFloor(maxHeight);
+	if (rows !== undefined) return { kind: "rows", rows };
+	if (typeof maxHeight !== "string") return undefined;
+
+	const trimmed = maxHeight.trim();
+	const percent = trimmed.match(/^(\d+(?:\.\d+)?)%$/);
+	if (percent) {
+		const value = Number(percent[1]);
+		if (Number.isFinite(value) && value > 0) return { kind: "percent", ratio: value / 100, text: `${value}%` };
+		return undefined;
 	}
-	return terminal;
+
+	if (/^\d+$/.test(trimmed)) {
+		const value = Number(trimmed);
+		if (Number.isFinite(value) && value >= 1) return { kind: "rows", rows: value };
+	}
+
+	return undefined;
 }
 
-export function responsiveBrowseListRows(configuredRows: number, terminalRows: number, maxHeight: OverlaySize = DEFAULT_POPUP_MAX_HEIGHT): number {
+function safeTerminalRows(terminalRows: unknown): number {
+	return positiveFiniteFloor(terminalRows) ?? FALLBACK_TERMINAL_ROWS;
+}
+
+function resolvedPopupMaxHeight(maxHeight: OverlaySize | undefined): ParsedPopupMaxHeight {
+	return parsePopupMaxHeight(maxHeight) ?? parsePopupMaxHeight(DEFAULT_POPUP_MAX_HEIGHT) ?? { kind: "percent", ratio: DEFAULT_POPUP_MAX_HEIGHT_RATIO, text: "86%" };
+}
+
+export function sanitizePopupMaxHeight(maxHeight: OverlaySize | undefined): OverlaySize {
+	const parsed = parsePopupMaxHeight(maxHeight);
+	if (parsed?.kind === "rows") return parsed.rows;
+	if (parsed?.kind === "percent") return parsed.text;
+	return DEFAULT_POPUP_MAX_HEIGHT;
+}
+
+export function normalizeListRows(rows: number | undefined, fallback = DEFAULT_LIST_ROWS): number {
+	return positiveFiniteFloor(rows) ?? positiveFiniteFloor(fallback) ?? DEFAULT_LIST_ROWS;
+}
+
+export function resolveOverlayRows(terminalRows: number | undefined, maxHeight: OverlaySize | undefined = DEFAULT_POPUP_MAX_HEIGHT): number {
+	const terminal = safeTerminalRows(terminalRows);
+	const parsed = resolvedPopupMaxHeight(maxHeight);
+	if (parsed.kind === "rows") return Math.max(1, Math.min(terminal, parsed.rows));
+	return Math.max(1, Math.min(terminal, Math.floor(terminal * parsed.ratio)));
+}
+
+export function responsiveBrowseListRows(configuredRows: number | undefined, terminalRows: number | undefined, maxHeight: OverlaySize | undefined = DEFAULT_POPUP_MAX_HEIGHT): number {
 	const configured = normalizeListRows(configuredRows);
 	const overlayRows = resolveOverlayRows(terminalRows, maxHeight);
-	const availableListRows = Math.max(1, overlayRows - BROWSE_CHROME_ROWS);
+	const availableListRows = Math.max(1, overlayRows - BROWSE_NON_LIST_ROWS);
 	return Math.max(1, Math.min(configured, availableListRows));
+}
+
+export function browseWindow(entryCount: number | undefined, selectedDisplayIndex: number | undefined, listRows: number | undefined): BrowseWindow {
+	const rows = normalizeListRows(listRows);
+	const count = Math.max(0, finiteFloor(entryCount) ?? 0);
+	if (count === 0) return { listRows: rows, startIndex: 0, endIndex: 0 };
+
+	const selected = clamp(finiteFloor(selectedDisplayIndex) ?? 0, 0, count - 1);
+	const maxStartIndex = Math.max(0, count - rows);
+	const startIndex = clamp(selected - Math.floor(rows / 2), 0, maxStartIndex);
+	return { listRows: rows, startIndex, endIndex: Math.min(startIndex + rows, count) };
+}
+
+export function responsiveBrowseWindow(
+	configuredRows: number | undefined,
+	terminalRows: number | undefined,
+	entryCount: number | undefined,
+	selectedDisplayIndex: number | undefined,
+	maxHeight: OverlaySize | undefined = DEFAULT_POPUP_MAX_HEIGHT,
+): BrowseWindow {
+	const listRows = responsiveBrowseListRows(configuredRows, terminalRows, maxHeight);
+	return browseWindow(entryCount, selectedDisplayIndex, listRows);
+}
+
+export function pageBrowseSelection(selectedIndex: number | undefined, maxSelectedIndex: number | undefined, direction: -1 | 1, listRows: number | undefined): number {
+	const selected = Math.max(0, finiteFloor(selectedIndex) ?? 0);
+	const maxIndex = Math.max(0, finiteFloor(maxSelectedIndex) ?? 0);
+	const step = normalizeListRows(listRows);
+	return clamp(selected + direction * step, 0, maxIndex);
+}
+
+export function responsiveBrowsePageSelection(
+	configuredRows: number | undefined,
+	terminalRows: number | undefined,
+	selectedIndex: number | undefined,
+	maxSelectedIndex: number | undefined,
+	direction: -1 | 1,
+	maxHeight: OverlaySize | undefined = DEFAULT_POPUP_MAX_HEIGHT,
+): number {
+	return pageBrowseSelection(selectedIndex, maxSelectedIndex, direction, responsiveBrowseListRows(configuredRows, terminalRows, maxHeight));
 }

--- a/pi-extensions/pi-skills-manager/extensions/skills-manager/layout.ts
+++ b/pi-extensions/pi-skills-manager/extensions/skills-manager/layout.ts
@@ -1,0 +1,28 @@
+import { DEFAULT_LIST_ROWS, DEFAULT_POPUP_MAX_HEIGHT } from "./constants.js";
+import type { OverlaySize } from "./types.js";
+
+const BROWSE_CHROME_ROWS = 8;
+
+export function normalizeListRows(rows: number, fallback = DEFAULT_LIST_ROWS): number {
+	const value = Number.isFinite(rows) ? rows : fallback;
+	return Math.max(1, Math.floor(value));
+}
+
+export function resolveOverlayRows(terminalRows: number, maxHeight: OverlaySize = DEFAULT_POPUP_MAX_HEIGHT): number {
+	const terminal = Math.max(1, Math.floor(terminalRows));
+	if (typeof maxHeight === "number" && Number.isFinite(maxHeight)) return Math.max(1, Math.min(terminal, Math.floor(maxHeight)));
+	if (typeof maxHeight === "string") {
+		const trimmed = maxHeight.trim();
+		const percent = trimmed.match(/^(\d+(?:\.\d+)?)%$/);
+		if (percent) return Math.max(1, Math.min(terminal, Math.floor(terminal * (Number(percent[1]) / 100))));
+		if (/^\d+$/.test(trimmed)) return Math.max(1, Math.min(terminal, Number(trimmed)));
+	}
+	return terminal;
+}
+
+export function responsiveBrowseListRows(configuredRows: number, terminalRows: number, maxHeight: OverlaySize = DEFAULT_POPUP_MAX_HEIGHT): number {
+	const configured = normalizeListRows(configuredRows);
+	const overlayRows = resolveOverlayRows(terminalRows, maxHeight);
+	const availableListRows = Math.max(1, overlayRows - BROWSE_CHROME_ROWS);
+	return Math.max(1, Math.min(configured, availableListRows));
+}

--- a/pi-extensions/pi-skills-manager/package.json
+++ b/pi-extensions/pi-skills-manager/package.json
@@ -16,6 +16,9 @@
     ],
     "image": "https://raw.githubusercontent.com/vanillagreencom/vstack/main/pi-extensions/pi-skills-manager/assets/skills-manager.png"
   },
+  "scripts": {
+    "test": "bun test ./tests"
+  },
   "vstack": {
     "extensionManager": {
       "displayName": "Skills Manager",
@@ -83,7 +86,7 @@
         {
           "key": "listRows",
           "label": "Visible list rows",
-          "description": "Number of list rows shown before scrolling in browse mode.",
+          "description": "Maximum list rows shown before scrolling in browse mode. Short terminals shrink this to keep popup controls visible.",
           "type": "number",
           "default": 14,
           "category": "UI",

--- a/pi-extensions/pi-skills-manager/tests/layout.test.ts
+++ b/pi-extensions/pi-skills-manager/tests/layout.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import { normalizeListRows, resolveOverlayRows, responsiveBrowseListRows } from "../extensions/skills-manager/layout.ts";
+
+describe("normalizeListRows", () => {
+	test("floors configured rows and allows one-row lists", () => {
+		expect(normalizeListRows(7.9)).toBe(7);
+		expect(normalizeListRows(0)).toBe(1);
+		expect(normalizeListRows(-4)).toBe(1);
+	});
+
+	test("falls back for non-finite values", () => {
+		expect(normalizeListRows(Number.NaN, 14)).toBe(14);
+		expect(normalizeListRows(Number.POSITIVE_INFINITY, 14)).toBe(14);
+	});
+});
+
+describe("resolveOverlayRows", () => {
+	test("resolves percent max height against terminal rows", () => {
+		expect(resolveOverlayRows(40, "50%")).toBe(20);
+	});
+
+	test("clamps numeric max height to terminal rows", () => {
+		expect(resolveOverlayRows(20, 80)).toBe(20);
+		expect(resolveOverlayRows(80, 20)).toBe(20);
+	});
+});
+
+describe("responsiveBrowseListRows", () => {
+	test("keeps configured rows as upper bound on large terminals", () => {
+		expect(responsiveBrowseListRows(14, 80)).toBe(14);
+		expect(responsiveBrowseListRows(22, 80)).toBe(22);
+	});
+
+	test("shrinks rows on short terminals to leave popup chrome visible", () => {
+		const rows = responsiveBrowseListRows(14, 20);
+		expect(rows).toBeLessThan(14);
+		expect(rows).toBeGreaterThanOrEqual(1);
+	});
+
+	test("collapses to one row on tiny terminals", () => {
+		expect(responsiveBrowseListRows(14, 4)).toBe(1);
+	});
+
+	test("respects explicit popup max height", () => {
+		expect(responsiveBrowseListRows(14, 80, 12)).toBe(4);
+		expect(responsiveBrowseListRows(14, 80, "25%")).toBe(12);
+	});
+});

--- a/pi-extensions/pi-skills-manager/tests/layout.test.ts
+++ b/pi-extensions/pi-skills-manager/tests/layout.test.ts
@@ -1,20 +1,54 @@
 import { describe, expect, test } from "bun:test";
-import { normalizeListRows, resolveOverlayRows, responsiveBrowseListRows } from "../extensions/skills-manager/layout.ts";
+import { DEFAULT_POPUP_MAX_HEIGHT } from "../extensions/skills-manager/constants.ts";
+import {
+	BROWSE_NON_LIST_ROWS,
+	browseWindow,
+	normalizeListRows,
+	pageBrowseSelection,
+	resolveOverlayRows,
+	responsiveBrowseListRows,
+	responsiveBrowsePageSelection,
+	responsiveBrowseWindow,
+	sanitizePopupMaxHeight,
+} from "../extensions/skills-manager/layout.ts";
 
 describe("normalizeListRows", () => {
 	test("floors configured rows and allows one-row lists", () => {
 		expect(normalizeListRows(7.9)).toBe(7);
-		expect(normalizeListRows(0)).toBe(1);
-		expect(normalizeListRows(-4)).toBe(1);
+		expect(normalizeListRows(1)).toBe(1);
+		expect(normalizeListRows(0)).toBe(14);
+		expect(normalizeListRows(-4)).toBe(14);
 	});
 
-	test("falls back for non-finite values", () => {
+	test("falls back for missing or non-finite values", () => {
+		expect(normalizeListRows(undefined, 14)).toBe(14);
 		expect(normalizeListRows(Number.NaN, 14)).toBe(14);
 		expect(normalizeListRows(Number.POSITIVE_INFINITY, 14)).toBe(14);
 	});
 });
 
+describe("popup max height normalization", () => {
+	test("keeps valid row and percent values", () => {
+		expect(sanitizePopupMaxHeight(12.9)).toBe(12);
+		expect(sanitizePopupMaxHeight("12")).toBe(12);
+		expect(sanitizePopupMaxHeight("25%")).toBe("25%");
+	});
+
+	test("falls back for malformed, non-positive, and non-finite values", () => {
+		for (const value of ["abc", "-5", "0", "0%", 0, -5, Number.NaN, Number.POSITIVE_INFINITY] as const) {
+			expect(sanitizePopupMaxHeight(value)).toBe(DEFAULT_POPUP_MAX_HEIGHT);
+			expect(resolveOverlayRows(80, value)).toBe(68);
+		}
+	});
+});
+
 describe("resolveOverlayRows", () => {
+	test("guards missing or non-finite terminal rows with finite fallback", () => {
+		expect(resolveOverlayRows(undefined)).toBe(20);
+		expect(resolveOverlayRows(Number.NaN)).toBe(20);
+		expect(resolveOverlayRows(Number.POSITIVE_INFINITY)).toBe(20);
+	});
+
 	test("resolves percent max height against terminal rows", () => {
 		expect(resolveOverlayRows(40, "50%")).toBe(20);
 	});
@@ -26,15 +60,26 @@ describe("resolveOverlayRows", () => {
 });
 
 describe("responsiveBrowseListRows", () => {
+	test("documents browse chrome rows", () => {
+		expect(BROWSE_NON_LIST_ROWS).toBe(6);
+	});
+
+	test("always returns finite integer >= 1 for bad terminal rows", () => {
+		for (const terminalRows of [undefined, Number.NaN, Number.POSITIVE_INFINITY] as const) {
+			const rows = responsiveBrowseListRows(14, terminalRows);
+			expect(Number.isInteger(rows)).toBe(true);
+			expect(Number.isFinite(rows)).toBe(true);
+			expect(rows).toBe(14);
+		}
+	});
+
 	test("keeps configured rows as upper bound on large terminals", () => {
 		expect(responsiveBrowseListRows(14, 80)).toBe(14);
 		expect(responsiveBrowseListRows(22, 80)).toBe(22);
 	});
 
 	test("shrinks rows on short terminals to leave popup chrome visible", () => {
-		const rows = responsiveBrowseListRows(14, 20);
-		expect(rows).toBeLessThan(14);
-		expect(rows).toBeGreaterThanOrEqual(1);
+		expect(responsiveBrowseListRows(14, 20)).toBe(11);
 	});
 
 	test("collapses to one row on tiny terminals", () => {
@@ -42,7 +87,70 @@ describe("responsiveBrowseListRows", () => {
 	});
 
 	test("respects explicit popup max height", () => {
-		expect(responsiveBrowseListRows(14, 80, 12)).toBe(4);
-		expect(responsiveBrowseListRows(14, 80, "25%")).toBe(12);
+		expect(responsiveBrowseListRows(14, 80, 12)).toBe(6);
+		expect(responsiveBrowseListRows(14, 80, "25%")).toBe(14);
+	});
+});
+
+describe("browse window", () => {
+	function expectSelectedVisible(window: { startIndex: number; endIndex: number }, selectedDisplayIndex: number): void {
+		expect(selectedDisplayIndex).toBeGreaterThanOrEqual(window.startIndex);
+		expect(selectedDisplayIndex).toBeLessThan(window.endIndex);
+	}
+
+	test("centers selected item with exact representative rows", () => {
+		expect(browseWindow(30, 20, 11)).toEqual({ listRows: 11, startIndex: 15, endIndex: 26 });
+	});
+
+	test("tiny terminals render one selected row", () => {
+		const window = responsiveBrowseWindow(14, 4, 10, 6);
+		expect(window).toEqual({ listRows: 1, startIndex: 6, endIndex: 7 });
+		expectSelectedVisible(window, 6);
+	});
+
+	test("short terminals use responsive rows and keep selected item visible", () => {
+		const window = responsiveBrowseWindow(14, 20, 30, 20);
+		expect(window).toEqual({ listRows: 11, startIndex: 15, endIndex: 26 });
+		expectSelectedVisible(window, 20);
+	});
+
+	test("large terminals preserve configured default row count", () => {
+		const window = responsiveBrowseWindow(14, 80, 40, 20);
+		expect(window).toEqual({ listRows: 14, startIndex: 13, endIndex: 27 });
+		expectSelectedVisible(window, 20);
+	});
+
+	test("configured listRows remains upper bound on large terminals", () => {
+		const window = responsiveBrowseWindow(22, 80, 40, 20);
+		expect(window).toEqual({ listRows: 22, startIndex: 9, endIndex: 31 });
+		expectSelectedVisible(window, 20);
+	});
+
+	test("selected item near end remains visible", () => {
+		const window = responsiveBrowseWindow(14, 20, 30, 29);
+		expect(window).toEqual({ listRows: 11, startIndex: 19, endIndex: 30 });
+		expectSelectedVisible(window, 29);
+	});
+});
+
+describe("page movement", () => {
+	test("plain page movement clamps to selectable range", () => {
+		expect(pageBrowseSelection(5, 30, -1, 11)).toBe(0);
+		expect(pageBrowseSelection(25, 30, 1, 11)).toBe(30);
+	});
+
+	test("tiny terminal page step uses one responsive row", () => {
+		expect(responsiveBrowsePageSelection(14, 4, 5, 30, 1)).toBe(6);
+		expect(responsiveBrowsePageSelection(14, 4, 5, 30, -1)).toBe(4);
+	});
+
+	test("short terminal page step uses shortened responsive rows", () => {
+		expect(responsiveBrowsePageSelection(14, 20, 10, 30, 1)).toBe(21);
+		expect(responsiveBrowsePageSelection(14, 20, 10, 30, -1)).toBe(0);
+	});
+
+	test("large terminal page step uses configured upper-bound rows", () => {
+		expect(responsiveBrowsePageSelection(22, 80, 3, 30, 1)).toBe(25);
+		expect(responsiveBrowsePageSelection(22, 80, 20, 30, 1)).toBe(30);
 	});
 });


### PR DESCRIPTION
Summary:
- Added responsive browse row math for `/skill` so `listRows` remains an upper bound while short terminals shrink visible rows to preserve popup chrome/footer.
- Reused the responsive row count for browse render slicing and page up/down movement.
- Added focused Bun tests for row normalization, overlay height resolution, and responsive browse row limits.

Docs updates:
- Updated pi-skills-manager README and extension setting description to describe `listRows` as a maximum that shrinks on short terminals.

Validation:
- Inspected `pi-extensions/pi-skills-manager/package.json` and added a package test command because none existed.
- `cd pi-extensions/pi-skills-manager && bun run test` — pass (8 tests).
- `git diff --check -- pi-extensions/pi-skills-manager` — pass.

Known no-op / deferred:
- Live Pi smoke not run; no interactive Pi overlay session available from this implementation worktree.
- Global `vstack refresh -g` not run from this feature worktree to avoid refreshing global Pi packages from unmerged branch state; master should refresh after merge.
