### PR TITLE
Add ASCII-safe glyph style for Pi extension chrome

### DIFF
--- a/pi-extensions/pi-agents-tmux/README.md
+++ b/pi-extensions/pi-agents-tmux/README.md
@@ -99,6 +99,8 @@ See [`DEVELOPMENT.md`](./DEVELOPMENT.md) for the underlying tool surface (`subag
 
 Open `/extensions:settings`; settings appear under the **Agents (tmux)** tab.
 
+Glyph style: each package exposes `glyphStyle` (`unicode` default, `ascii` for terminal-safe chrome). `@vanillagreen/pi-tool-renderer.globalGlyphStyleOverride=ascii` forces ASCII chrome across vstack Pi extensions while leaving tool/model/user content unchanged.
+
 ### Execution
 
 | Setting | What it does |

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/dashboard.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/dashboard.ts
@@ -32,6 +32,7 @@ import {
 	type SubagentDashboardState,
 	type UsageStats,
 } from "./types.js";
+import { glyphs, glyphStyle } from "./glyphs.js";
 
 export function dashboardKindLabel(kind: DashboardKind): string {
 	return kind === "oneshot" ? "bg" : kind;
@@ -77,20 +78,22 @@ export function sortDashboardItems(items: SubagentDashboardItem[]): SubagentDash
 const WORKING_SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
 function workingSpinnerFrame(): string {
-	return WORKING_SPINNER_FRAMES[Math.floor(Date.now() / 120) % WORKING_SPINNER_FRAMES.length] ?? "•";
+	if (glyphStyle() === "ascii") return "*";
+	return WORKING_SPINNER_FRAMES[Math.floor(Date.now() / 120) % WORKING_SPINNER_FRAMES.length] ?? glyphs().emptyBullet.trim();
 }
 
 export function dashboardStatusIcon(status: SubagentDashboardItem["status"], theme: Theme, options: { animateSpinners?: boolean } = {}): string {
 	const animateSpinners = options.animateSpinners ?? true;
-	if (status === "completed") return theme.fg("success", ICONS.check);
-	if (status === "failed") return theme.fg("error", ICONS.times);
-	if (status === "blocked") return theme.fg("error", ICONS.times);
-	if (status === "needs_completion") return theme.fg("warning", ICONS.warning);
+	const ascii = glyphStyle() === "ascii";
+	if (status === "completed") return theme.fg("success", ascii ? glyphs().ok : ICONS.check);
+	if (status === "failed") return theme.fg("error", ascii ? glyphs().fail : ICONS.times);
+	if (status === "blocked") return theme.fg("error", ascii ? glyphs().fail : ICONS.times);
+	if (status === "needs_completion") return theme.fg("warning", ascii ? glyphs().warn : ICONS.warning);
 	if (status === "running") return theme.fg("warning", animateSpinners ? workingSpinnerFrame() : ICONS.cog);
 	if (status === "waiting") return theme.fg("warning", ICONS.clock);
 	if (status === "queued") return theme.fg("warning", ICONS.clock);
-	if (status === "unknown") return theme.fg("warning", ICONS.warning);
-	return theme.fg("accent", ICONS.circleFilled);
+	if (status === "unknown") return theme.fg("warning", ascii ? glyphs().warn : ICONS.warning);
+	return theme.fg("accent", ascii ? glyphs().bullet.trim() : ICONS.circleFilled);
 }
 
 export function dashboardStatusText(item: SubagentDashboardItem, theme: Theme): string {

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/format.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/format.ts
@@ -5,6 +5,7 @@ import type { Message } from "@earendil-works/pi-ai";
 import { type Theme } from "@earendil-works/pi-coding-agent";
 import { Container, Spacer, truncateToWidth, visibleWidth, wrapTextWithAnsi, type Component } from "@earendil-works/pi-tui";
 import { discoverAgents, type AgentConfig } from "./agents.js";
+import { frameGlyphs, glyphs } from "./glyphs.js";
 import { subagentTreeStyle } from "./settings.js";
 import {
 	AGENT_ASCII_COLOR_SEQUENCE,
@@ -213,15 +214,17 @@ export function simpleFrame(lines: string[], width: number, theme: Theme, title 
 	const border = (text: string) => theme.fg("borderAccent", text);
 	const innerWidth = Math.max(1, width - 4);
 	const top = () => {
-		if (!title) return `${border("┏")}${border("━".repeat(width - 2))}${border("┓")}`;
-		const titlePlain = ` ${truncateToWidth(title, Math.max(1, width - 4), "…")} `;
+		const frame = frameGlyphs();
+		if (!title) return `${border(frame.tl)}${border(frame.h.repeat(width - 2))}${border(frame.tr)}`;
+		const titlePlain = ` ${truncateToWidth(title, Math.max(1, width - 4), glyphs().ellipsis)} `;
 		const fill = Math.max(1, width - 2 - visibleWidth(titlePlain));
-		return `${border("┏")}${ansiGreen(titlePlain)}${border("━".repeat(fill))}${border("┓")}`;
+		return `${border(frame.tl)}${ansiGreen(titlePlain)}${border(frame.h.repeat(fill))}${border(frame.tr)}`;
 	};
+	const frame = frameGlyphs();
 	return [
 		top(),
-		...lines.map((line) => `${border("┃")} ${padAnsi(truncateToWidth(line, innerWidth, ""), innerWidth)} ${border("┃")}`),
-		`${border("┗")}${border("━".repeat(width - 2))}${border("┛")}`,
+		...lines.map((line) => `${border(frame.v)} ${padAnsi(truncateToWidth(line, innerWidth, ""), innerWidth)} ${border(frame.v)}`),
+		`${border(frame.bl)}${border(frame.h.repeat(width - 2))}${border(frame.br)}`,
 	].map((line) => truncateToWidth(line, width, ""));
 }
 
@@ -234,7 +237,7 @@ export function inactivePill(theme: Theme, label: string): string {
 }
 
 export function divider(width: number, theme: Theme): string {
-	return theme.fg("borderMuted", "─".repeat(Math.max(1, width)));
+	return theme.fg("borderMuted", glyphs().line.repeat(Math.max(1, width)));
 }
 
 export async function parseTranscriptUsage(transcriptPath: string | undefined): Promise<{ usage: UsageStats; model?: string } | undefined> {
@@ -640,7 +643,7 @@ export function formatToolCall(
 }
 
 export function toolChromeRule(theme: Theme, width: number): string {
-	const rule = "─".repeat(Math.max(1, width));
+	const rule = glyphs().line.repeat(Math.max(1, width));
 	for (const token of ["borderMuted", "muted", "dim"] as const) {
 		try {
 			const styled = theme.fg(token, rule);
@@ -693,7 +696,8 @@ export function framedMessage(content: string, theme: Theme): Component {
 }
 
 export function sectionHeading(theme: Theme, label: string): string {
-	return `${theme.fg("muted", "─── ")}${theme.fg("toolTitle", theme.bold(label))}${theme.fg("muted", " ───")}`;
+	const rule = glyphs().line.repeat(3);
+	return `${theme.fg("muted", `${rule} `)}${theme.fg("toolTitle", theme.bold(label))}${theme.fg("muted", ` ${rule}`)}`;
 }
 
 export function addSectionHeading(container: Container, theme: Theme, label: string): void {
@@ -712,7 +716,7 @@ export function addArtifactPathSection(container: Container, theme: Theme, label
 }
 
 export function agentsCommandBullet(theme: Theme): string {
-	return theme.fg("accent", "● ");
+	return theme.fg("accent", glyphs().bullet);
 }
 
 export function agentWord(theme: Theme): string {

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/glyphs.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/glyphs.ts
@@ -1,0 +1,122 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+export type GlyphStyle = "unicode" | "ascii";
+export type GlobalGlyphStyleOverride = "inherit" | GlyphStyle;
+
+const LOCAL_CONFIG_ID = "@vanillagreen/pi-agents-tmux";
+const GLOBAL_CONFIG_ID = "@vanillagreen/pi-tool-renderer";
+
+function expandHome(input: string): string {
+	if (input === "~") return homedir();
+	if (input.startsWith("~/")) return join(homedir(), input.slice(2));
+	return input;
+}
+
+function projectSettingsPath(cwd: string): string {
+	let current = resolve(cwd);
+	while (true) {
+		const candidate = join(current, ".pi", "settings.json");
+		if (existsSync(candidate)) return candidate;
+		if (existsSync(join(current, ".pi")) || existsSync(join(current, ".git")) || existsSync(join(current, ".vstack-lock.json"))) return candidate;
+		const parent = dirname(current);
+		if (parent === current) return join(resolve(cwd), ".pi", "settings.json");
+		current = parent;
+	}
+}
+
+function piSettingsPaths(cwd = process.cwd()): string[] {
+	const userDir = resolve(expandHome(process.env.PI_CODING_AGENT_DIR?.trim() || "~/.pi/agent"));
+	return [join(userDir, "settings.json"), projectSettingsPath(cwd)];
+}
+
+function readPackageConfig(packageId: string, cwd?: string): Record<string, unknown> {
+	const merged: Record<string, unknown> = {};
+	for (const settingsPath of piSettingsPaths(cwd)) {
+		if (!existsSync(settingsPath)) continue;
+		try {
+			const parsed = JSON.parse(readFileSync(settingsPath, "utf8"));
+			const config = parsed?.vstack?.extensionManager?.config?.[packageId];
+			if (config && typeof config === "object" && !Array.isArray(config)) Object.assign(merged, config);
+		} catch {
+			// Ignore malformed optional manager config.
+		}
+	}
+	return merged;
+}
+
+function asGlyphStyle(value: unknown): GlyphStyle | undefined {
+	return value === "unicode" || value === "ascii" ? value : undefined;
+}
+
+export function glyphStyle(cwd?: string): GlyphStyle {
+	const globalOverride = readPackageConfig(GLOBAL_CONFIG_ID, cwd).globalGlyphStyleOverride;
+	const forced = asGlyphStyle(globalOverride);
+	if (forced) return forced;
+	const local = readPackageConfig(LOCAL_CONFIG_ID, cwd);
+	return asGlyphStyle(local.glyphStyle) ?? asGlyphStyle(local.treeStyle) ?? "unicode";
+}
+
+export const GLYPHS = {
+	unicode: {
+		frame: { tl: "┏", tr: "┓", bl: "┗", br: "┛", h: "━", v: "┃" },
+		line: "─",
+		tree: { mid: "├─ ", last: "└─ ", stem: "│  ", blank: "   " },
+		bullet: "● ",
+		emptyBullet: "○ ",
+		dot: " · ",
+		ok: "✓",
+		fail: "✗",
+		warn: "▲",
+		diamond: "◆",
+		prompt: "π",
+		ellipsis: "…",
+		arrow: "→",
+		codeBar: "▌",
+	},
+	ascii: {
+		frame: { tl: "+", tr: "+", bl: "+", br: "+", h: "-", v: "|" },
+		line: "-",
+		tree: { mid: "|-- ", last: "`-- ", stem: "|  ", blank: "   " },
+		bullet: "* ",
+		emptyBullet: "o ",
+		dot: " - ",
+		ok: "+",
+		fail: "x",
+		warn: "!",
+		diamond: "*",
+		prompt: "pi",
+		ellipsis: "...",
+		arrow: "->",
+		codeBar: "|",
+	},
+} as const;
+
+export function glyphs(cwd?: string): (typeof GLYPHS)[GlyphStyle] {
+	return GLYPHS[glyphStyle(cwd)];
+}
+
+export function truncateIndicator(cwd?: string): string {
+	return glyphs(cwd).ellipsis;
+}
+
+export function truncateText(text: string, maxChars: number, cwd?: string): string {
+	if (text.length <= maxChars) return text;
+	const indicator = truncateIndicator(cwd);
+	return `${text.slice(0, Math.max(0, maxChars - indicator.length))}${indicator}`;
+}
+
+export function dot(cwd?: string): string {
+	return glyphs(cwd).dot;
+}
+
+export function treeGlyph(branch: "├" | "└" | "│", cwd?: string): string {
+	const tree = glyphs(cwd).tree;
+	if (branch === "│") return tree.stem;
+	return branch === "└" ? tree.last : tree.mid;
+}
+
+export function frameGlyphs(cwd?: string): (typeof GLYPHS)[GlyphStyle]["frame"] {
+	return glyphs(cwd).frame;
+}

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/settings.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/settings.ts
@@ -12,6 +12,7 @@ import {
 	type ResultLimits,
 	type VstackConfig,
 } from "./types.js";
+import { glyphStyle } from "./glyphs.js";
 
 export function expandHome(input: string): string {
 	if (input === "~") return os.homedir();
@@ -193,8 +194,7 @@ export function formatShortcutHint(shortcut: string): string {
 }
 
 export function subagentTreeStyle(cwd?: string): "unicode" | "ascii" {
-	const value = readVstackConfig(cwd).treeStyle;
-	return value === "ascii" || value === "unicode" ? value : "unicode";
+	return glyphStyle(cwd);
 }
 
 export function resultLimits(cwd?: string): ResultLimits {

--- a/pi-extensions/pi-agents-tmux/package.json
+++ b/pi-extensions/pi-agents-tmux/package.json
@@ -51,6 +51,19 @@
           "requiresReload": true
         },
         {
+          "key": "glyphStyle",
+          "label": "Glyph style",
+          "description": "Glyphs for vstack-owned UI chrome. Unicode is the default; ASCII uses plain box/status/separator characters for terminal compatibility. pi-tool-renderer's global override wins when set.",
+          "type": "enum",
+          "enumValues": [
+            "unicode",
+            "ascii"
+          ],
+          "default": "unicode",
+          "category": "Rendering",
+          "apply": "live"
+        },
+        {
           "key": "maxParallelTasks",
           "label": "Max parallel tasks",
           "description": "Internal batch size for parallel agent calls. Larger calls are automatically split into batches.",
@@ -167,8 +180,8 @@
         },
         {
           "key": "treeStyle",
-          "label": "Tree connector style",
-          "description": "Connector glyphs for agent result rows. Unicode is prettier; ASCII uses |--/`-- for maximum terminal compatibility.",
+          "label": "Legacy tree connector style",
+          "description": "Legacy fallback for tree connectors when glyphStyle is unset and pi-tool-renderer globalGlyphStyleOverride is inherit. Prefer Glyph style for all UI chrome.",
           "type": "enum",
           "enumValues": [
             "unicode",

--- a/pi-extensions/pi-background-tasks/README.md
+++ b/pi-extensions/pi-background-tasks/README.md
@@ -65,6 +65,8 @@ Use the arm-next-bash shortcut or `/bg:next` to force the next bash command into
 
 Open `/extensions:settings`; settings appear under the **Background Tasks** tab.
 
+Glyph style: each package exposes `glyphStyle` (`unicode` default, `ascii` for terminal-safe chrome). `@vanillagreen/pi-tool-renderer.globalGlyphStyleOverride=ascii` forces ASCII chrome across vstack Pi extensions while leaving tool/model/user content unchanged.
+
 ### Execution
 
 | Setting | What it does |

--- a/pi-extensions/pi-background-tasks/extensions/glyphs.ts
+++ b/pi-extensions/pi-background-tasks/extensions/glyphs.ts
@@ -1,0 +1,122 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+export type GlyphStyle = "unicode" | "ascii";
+export type GlobalGlyphStyleOverride = "inherit" | GlyphStyle;
+
+const LOCAL_CONFIG_ID = "@vanillagreen/pi-background-tasks";
+const GLOBAL_CONFIG_ID = "@vanillagreen/pi-tool-renderer";
+
+function expandHome(input: string): string {
+	if (input === "~") return homedir();
+	if (input.startsWith("~/")) return join(homedir(), input.slice(2));
+	return input;
+}
+
+function projectSettingsPath(cwd: string): string {
+	let current = resolve(cwd);
+	while (true) {
+		const candidate = join(current, ".pi", "settings.json");
+		if (existsSync(candidate)) return candidate;
+		if (existsSync(join(current, ".pi")) || existsSync(join(current, ".git")) || existsSync(join(current, ".vstack-lock.json"))) return candidate;
+		const parent = dirname(current);
+		if (parent === current) return join(resolve(cwd), ".pi", "settings.json");
+		current = parent;
+	}
+}
+
+function piSettingsPaths(cwd = process.cwd()): string[] {
+	const userDir = resolve(expandHome(process.env.PI_CODING_AGENT_DIR?.trim() || "~/.pi/agent"));
+	return [join(userDir, "settings.json"), projectSettingsPath(cwd)];
+}
+
+function readPackageConfig(packageId: string, cwd?: string): Record<string, unknown> {
+	const merged: Record<string, unknown> = {};
+	for (const settingsPath of piSettingsPaths(cwd)) {
+		if (!existsSync(settingsPath)) continue;
+		try {
+			const parsed = JSON.parse(readFileSync(settingsPath, "utf8"));
+			const config = parsed?.vstack?.extensionManager?.config?.[packageId];
+			if (config && typeof config === "object" && !Array.isArray(config)) Object.assign(merged, config);
+		} catch {
+			// Ignore malformed optional manager config.
+		}
+	}
+	return merged;
+}
+
+function asGlyphStyle(value: unknown): GlyphStyle | undefined {
+	return value === "unicode" || value === "ascii" ? value : undefined;
+}
+
+export function glyphStyle(cwd?: string): GlyphStyle {
+	const globalOverride = readPackageConfig(GLOBAL_CONFIG_ID, cwd).globalGlyphStyleOverride;
+	const forced = asGlyphStyle(globalOverride);
+	if (forced) return forced;
+	const local = readPackageConfig(LOCAL_CONFIG_ID, cwd);
+	return asGlyphStyle(local.glyphStyle) ?? asGlyphStyle(local.treeStyle) ?? "unicode";
+}
+
+export const GLYPHS = {
+	unicode: {
+		frame: { tl: "┏", tr: "┓", bl: "┗", br: "┛", h: "━", v: "┃" },
+		line: "─",
+		tree: { mid: "├─ ", last: "└─ ", stem: "│  ", blank: "   " },
+		bullet: "● ",
+		emptyBullet: "○ ",
+		dot: " · ",
+		ok: "✓",
+		fail: "✗",
+		warn: "▲",
+		diamond: "◆",
+		prompt: "π",
+		ellipsis: "…",
+		arrow: "→",
+		codeBar: "▌",
+	},
+	ascii: {
+		frame: { tl: "+", tr: "+", bl: "+", br: "+", h: "-", v: "|" },
+		line: "-",
+		tree: { mid: "|-- ", last: "`-- ", stem: "|  ", blank: "   " },
+		bullet: "* ",
+		emptyBullet: "o ",
+		dot: " - ",
+		ok: "+",
+		fail: "x",
+		warn: "!",
+		diamond: "*",
+		prompt: "pi",
+		ellipsis: "...",
+		arrow: "->",
+		codeBar: "|",
+	},
+} as const;
+
+export function glyphs(cwd?: string): (typeof GLYPHS)[GlyphStyle] {
+	return GLYPHS[glyphStyle(cwd)];
+}
+
+export function truncateIndicator(cwd?: string): string {
+	return glyphs(cwd).ellipsis;
+}
+
+export function truncateText(text: string, maxChars: number, cwd?: string): string {
+	if (text.length <= maxChars) return text;
+	const indicator = truncateIndicator(cwd);
+	return `${text.slice(0, Math.max(0, maxChars - indicator.length))}${indicator}`;
+}
+
+export function dot(cwd?: string): string {
+	return glyphs(cwd).dot;
+}
+
+export function treeGlyph(branch: "├" | "└" | "│", cwd?: string): string {
+	const tree = glyphs(cwd).tree;
+	if (branch === "│") return tree.stem;
+	return branch === "└" ? tree.last : tree.mid;
+}
+
+export function frameGlyphs(cwd?: string): (typeof GLYPHS)[GlyphStyle]["frame"] {
+	return glyphs(cwd).frame;
+}

--- a/pi-extensions/pi-background-tasks/extensions/render.ts
+++ b/pi-extensions/pi-background-tasks/extensions/render.ts
@@ -23,7 +23,8 @@ import {
 	taskDisplayName,
 } from "./format.js";
 import { latestSnapshot } from "./snapshot.js";
-import { readVstackConfig, settingEnum, settingNumber } from "./settings.js";
+import { frameGlyphs, glyphs, glyphStyle, treeGlyph } from "./glyphs.js";
+import { settingEnum, settingNumber } from "./settings.js";
 import type {
 	BackgroundTaskEventDetails,
 	BackgroundTaskSnapshot,
@@ -44,7 +45,7 @@ export function splitOutputLines(output: string): string[] {
 	const lines = text.split(/\r?\n/);
 	const maxLines = Math.max(20, Math.floor(settingNumber("dashboardOutputMaxLines", 800)));
 	if (lines.length <= maxLines) return lines;
-	return [`… ${lines.length - maxLines} older line(s) omitted from dashboard; use bg_task log or the Log file for full output`, ...lines.slice(-maxLines)];
+	return [`${glyphs().ellipsis} ${lines.length - maxLines} older line(s) omitted from dashboard; use bg_task log or the Log file for full output`, ...lines.slice(-maxLines)];
 }
 
 export function acquireVstackModalLock(): () => void {
@@ -69,27 +70,28 @@ export function frameDashboard(lines: string[], width: number, theme: Theme, tit
 	if (width < 8) return lines.map((line) => truncateToWidth(line, width, ""));
 
 	const border = (text: string) => theme.fg("borderAccent", text);
+	const frame = frameGlyphs();
 	const contentWidth = dashboardContentWidth(width);
-	const blank = `${border("┃")}${" ".repeat(width - 2)}${border("┃")}`;
+	const blank = `${border(frame.v)}${" ".repeat(width - 2)}${border(frame.v)}`;
 	const paddingTop = options.paddingTop ?? DASHBOARD_PADDING_Y;
 	const paddingBottom = options.paddingBottom ?? DASHBOARD_PADDING_Y;
 	const top = () => {
-		if (!title) return `${border("┏")}${border("━".repeat(width - 2))}${border("┓")}`;
+		if (!title) return `${border(frame.tl)}${border(frame.h.repeat(width - 2))}${border(frame.tr)}`;
 		const rightPlain = right ? ` ${right} ` : "";
 		const titleBudget = Math.max(1, width - 2 - visibleWidth(rightPlain) - 1);
-		const titlePlain = ` ${truncateToWidth(title, Math.max(1, titleBudget - 2), "…")} `;
+		const titlePlain = ` ${truncateToWidth(title, Math.max(1, titleBudget - 2), glyphs().ellipsis)} `;
 		const fill = Math.max(1, width - 2 - visibleWidth(titlePlain) - visibleWidth(rightPlain));
-		return `${border("┏")}${ansiGreen(titlePlain)}${border("━".repeat(fill))}${right ? theme.fg("dim", rightPlain) : ""}${border("┓")}`;
+		return `${border(frame.tl)}${ansiGreen(titlePlain)}${border(frame.h.repeat(fill))}${right ? theme.fg("dim", rightPlain) : ""}${border(frame.tr)}`;
 	};
 	const framed = [top()];
 
 	for (let i = 0; i < paddingTop; i += 1) framed.push(blank);
 	for (const line of lines) {
 		const content = padAnsi(line, contentWidth);
-		framed.push(`${border("┃")}${" ".repeat(DASHBOARD_PADDING_X)}${content}${" ".repeat(DASHBOARD_PADDING_X)}${border("┃")}`);
+		framed.push(`${border(frame.v)}${" ".repeat(DASHBOARD_PADDING_X)}${content}${" ".repeat(DASHBOARD_PADDING_X)}${border(frame.v)}`);
 	}
 	for (let i = 0; i < paddingBottom; i += 1) framed.push(blank);
-	framed.push(`${border("┗")}${border("━".repeat(width - 2))}${border("┛")}`);
+	framed.push(`${border(frame.bl)}${border(frame.h.repeat(width - 2))}${border(frame.br)}`);
 	return framed.map((line) => truncateToWidth(line, width, ""));
 }
 
@@ -97,11 +99,12 @@ export function frameWidget(lines: string[], width: number, theme: Theme): strin
 	const safeWidth = Math.max(1, width);
 	if (safeWidth < 8) return lines.map((line) => truncateToWidth(line, safeWidth, ""));
 	const border = (text: string) => theme.fg("borderAccent", text);
+	const frame = frameGlyphs();
 	const contentWidth = Math.max(1, safeWidth - 2 - WIDGET_PADDING_X * 2);
 	return [
-		`${border("┏")}${border("━".repeat(safeWidth - 2))}${border("┓")}`,
-		...lines.map((line) => `${border("┃")}${" ".repeat(WIDGET_PADDING_X)}${padAnsi(line, contentWidth)}${" ".repeat(WIDGET_PADDING_X)}${border("┃")}`),
-		`${border("┗")}${border("━".repeat(safeWidth - 2))}${border("┛")}`,
+		`${border(frame.tl)}${border(frame.h.repeat(safeWidth - 2))}${border(frame.tr)}`,
+		...lines.map((line) => `${border(frame.v)}${" ".repeat(WIDGET_PADDING_X)}${padAnsi(line, contentWidth)}${" ".repeat(WIDGET_PADDING_X)}${border(frame.v)}`),
+		`${border(frame.bl)}${border(frame.h.repeat(safeWidth - 2))}${border(frame.br)}`,
 	].map((line) => truncateToWidth(line, safeWidth, ""));
 }
 
@@ -141,13 +144,7 @@ export function renderEmpty() {
 }
 
 function bgTreeGlyph(branch: TreeBranch, cwd?: string): string {
-	const style = readVstackConfig(cwd).treeStyle === "ascii" ? "ascii" : "unicode";
-	if (style === "ascii") {
-		if (branch === "│") return "|  ";
-		return branch === "└" ? "`-- " : "|-- ";
-	}
-	if (branch === "│") return "│  ";
-	return `${branch}─ `;
+	return treeGlyph(branch, cwd);
 }
 
 export function bgTree(theme: Theme, branch: TreeBranch = "├", cwd?: string): string {
@@ -166,10 +163,11 @@ function bgStatusColor(status: BackgroundTaskStatus): "success" | "error" | "war
 }
 
 export function bgStatusIcon(status: BackgroundTaskStatus, theme: Theme): string {
-	if (status === "running") return theme.fg("warning", "●");
-	if (status === "completed") return theme.fg("success", ICONS.check);
-	if (status === "failed" || status === "timed_out") return theme.fg("error", ICONS.times);
-	return theme.fg("muted", "■");
+	const g = glyphs();
+	if (status === "running") return theme.fg("warning", g.bullet.trim());
+	if (status === "completed") return theme.fg("success", glyphStyle() === "ascii" ? g.ok : ICONS.check);
+	if (status === "failed" || status === "timed_out") return theme.fg("error", glyphStyle() === "ascii" ? g.fail : ICONS.times);
+	return theme.fg("muted", glyphStyle() === "ascii" ? "-" : "■");
 }
 
 export function bgStatusText(task: Pick<BackgroundTaskSnapshot, "status" | "exitCode">, theme: Theme): string {
@@ -210,7 +208,7 @@ export function makeToolResult(text: string, details: Record<string, unknown> = 
 }
 
 function backgroundRule(theme: Theme, width: number): string {
-	const rule = "─".repeat(Math.max(1, width));
+	const rule = glyphs().line.repeat(Math.max(1, width));
 	for (const token of ["borderMuted", "muted", "dim"] as const) {
 		try {
 			const styled = theme.fg(token, rule);

--- a/pi-extensions/pi-background-tasks/package.json
+++ b/pi-extensions/pi-background-tasks/package.json
@@ -51,6 +51,19 @@
           "requiresReload": true
         },
         {
+          "key": "glyphStyle",
+          "label": "Glyph style",
+          "description": "Glyphs for vstack-owned UI chrome. Unicode is the default; ASCII uses plain box/status/separator characters for terminal compatibility. pi-tool-renderer's global override wins when set.",
+          "type": "enum",
+          "enumValues": [
+            "unicode",
+            "ascii"
+          ],
+          "default": "unicode",
+          "category": "Rendering",
+          "apply": "live"
+        },
+        {
           "key": "defaultTimeoutSeconds",
           "label": "Default timeout",
           "description": "Default timeout for spawned background tasks. Default 0 disables timeouts so long-running work is not killed unexpectedly.",

--- a/pi-extensions/pi-codex-minimal-tools/README.md
+++ b/pi-extensions/pi-codex-minimal-tools/README.md
@@ -50,6 +50,8 @@ Restart Pi after installation.
 
 Open `/extensions:settings`; settings appear under the **Codex Minimal Tools** tab.
 
+Glyph style: each package exposes `glyphStyle` (`unicode` default, `ascii` for terminal-safe chrome). `@vanillagreen/pi-tool-renderer.globalGlyphStyleOverride=ascii` forces ASCII chrome across vstack Pi extensions while leaving tool/model/user content unchanged.
+
 ### General
 
 | Setting | What it does |

--- a/pi-extensions/pi-codex-minimal-tools/package.json
+++ b/pi-extensions/pi-codex-minimal-tools/package.json
@@ -34,6 +34,19 @@
           "requiresReload": true
         },
         {
+          "key": "glyphStyle",
+          "label": "Glyph style",
+          "description": "Glyphs for vstack-owned UI chrome. Unicode is the default; ASCII uses plain box/status/separator characters for terminal compatibility. pi-tool-renderer's global override wins when set.",
+          "type": "enum",
+          "enumValues": [
+            "unicode",
+            "ascii"
+          ],
+          "default": "unicode",
+          "category": "Rendering",
+          "apply": "live"
+        },
+        {
           "key": "autoEnable",
           "label": "Auto-add tools to active set",
           "description": "When a supported OpenAI/Codex model is selected, add this package's enabled tools to the model's active tool list. Off = activate manually.",

--- a/pi-extensions/pi-codex-minimal-tools/src/background-image-generation.ts
+++ b/pi-extensions/pi-codex-minimal-tools/src/background-image-generation.ts
@@ -4,6 +4,7 @@ import type { ExtensionAPI, ExtensionCommandContext, Theme } from "@earendil-wor
 import type { Api, Model } from "@earendil-works/pi-ai";
 import { type Component, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import { supportsImageInput, type ModelLike } from "./capabilities.js";
+import { frameGlyphs, glyphs, treeGlyph } from "./glyphs.js";
 import { loadSettings } from "./settings.js";
 import {
 	buildGeneratedImageDisplayText,
@@ -160,16 +161,16 @@ function panelFrame(lines: string[], width: number, theme: Theme): string[] {
 	const inner = Math.max(1, safeWidth - 2);
 	const contentWidth = panelFrameContentWidth(safeWidth);
 	const border = (text: string) => theme.fg(PANEL_BAR_COLOR, text);
+	const frame = frameGlyphs();
 	return [
-		`${border("┏")}${border("━".repeat(inner))}${border("┓")}`,
-		...lines.map((line) => `${border("┃")}${" ".repeat(PANEL_CARD_PADDING_X)}${padAnsi(line, contentWidth)}${" ".repeat(PANEL_CARD_PADDING_X)}${border("┃")}`),
-		`${border("┗")}${border("━".repeat(inner))}${border("┛")}`,
+		`${border(frame.tl)}${border(frame.h.repeat(inner))}${border(frame.tr)}`,
+		...lines.map((line) => `${border(frame.v)}${" ".repeat(PANEL_CARD_PADDING_X)}${padAnsi(line, contentWidth)}${" ".repeat(PANEL_CARD_PADDING_X)}${border(frame.v)}`),
+		`${border(frame.bl)}${border(frame.h.repeat(inner))}${border(frame.br)}`,
 	].map((line) => truncateToWidth(line, safeWidth, ""));
 }
 
 function panelBranch(theme: Theme, branch: "├" | "└" | "│"): string {
-	if (branch === "│") return theme.fg(PANEL_RULE_COLOR, "│  ");
-	return theme.fg(PANEL_RULE_COLOR, `${branch}─ `);
+	return theme.fg(PANEL_RULE_COLOR, treeGlyph(branch));
 }
 
 function renderStatusHeader(jobs: ActiveImageJob[], theme: Theme): string {
@@ -185,7 +186,7 @@ function renderStatusHeader(jobs: ActiveImageJob[], theme: Theme): string {
 function renderJobLines(theme: Theme, width: number): string[] {
 	const jobs = Array.from(activeImageJobs.values()).sort((a, b) => a.startedAt - b.startedAt);
 	if (jobs.length === 0) return [];
-	const dot = theme.fg("dim", " · ");
+	const dot = theme.fg("dim", glyphs().dot);
 	const lines = [renderStatusHeader(jobs, theme)];
 	const shown = jobs.slice(0, 4);
 	for (const [index, job] of shown.entries()) {
@@ -193,10 +194,10 @@ function renderJobLines(theme: Theme, width: number): string[] {
 		const isLast = index === shown.length - 1 && jobs.length <= shown.length;
 		const refs = job.referenceCount > 0 ? `${dot}${theme.fg("dim", `${job.referenceCount} ref${job.referenceCount === 1 ? "" : "s"}`)}` : "";
 		const promptWidth = Math.max(16, width - 36);
-		lines.push(`${panelBranch(theme, isLast ? "└" : "├")}${theme.fg("accent", "●")} ${theme.fg("accent", truncateToWidth(job.prompt, promptWidth, "…"))}${dot}${theme.fg("muted", job.imageModel)}${refs}${dot}${theme.fg("dim", `${ageSeconds}s`)}`);
+		lines.push(`${panelBranch(theme, isLast ? "└" : "├")}${theme.fg("accent", glyphs().bullet.trim())} ${theme.fg("accent", truncateToWidth(job.prompt, promptWidth, glyphs().ellipsis))}${dot}${theme.fg("muted", job.imageModel)}${refs}${dot}${theme.fg("dim", `${ageSeconds}s`)}`);
 	}
 	const hidden = jobs.length - shown.length;
-	if (hidden > 0) lines.push(`${panelBranch(theme, "└")}${theme.fg("muted", `… ${hidden} more`)}`);
+	if (hidden > 0) lines.push(`${panelBranch(theme, "└")}${theme.fg("muted", `${glyphs().ellipsis} ${hidden} more`)}`);
 	return panelFrame(lines, width, theme);
 }
 

--- a/pi-extensions/pi-codex-minimal-tools/src/glyphs.ts
+++ b/pi-extensions/pi-codex-minimal-tools/src/glyphs.ts
@@ -1,0 +1,122 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+export type GlyphStyle = "unicode" | "ascii";
+export type GlobalGlyphStyleOverride = "inherit" | GlyphStyle;
+
+const LOCAL_CONFIG_ID = "@vanillagreen/pi-codex-minimal-tools";
+const GLOBAL_CONFIG_ID = "@vanillagreen/pi-tool-renderer";
+
+function expandHome(input: string): string {
+	if (input === "~") return homedir();
+	if (input.startsWith("~/")) return join(homedir(), input.slice(2));
+	return input;
+}
+
+function projectSettingsPath(cwd: string): string {
+	let current = resolve(cwd);
+	while (true) {
+		const candidate = join(current, ".pi", "settings.json");
+		if (existsSync(candidate)) return candidate;
+		if (existsSync(join(current, ".pi")) || existsSync(join(current, ".git")) || existsSync(join(current, ".vstack-lock.json"))) return candidate;
+		const parent = dirname(current);
+		if (parent === current) return join(resolve(cwd), ".pi", "settings.json");
+		current = parent;
+	}
+}
+
+function piSettingsPaths(cwd = process.cwd()): string[] {
+	const userDir = resolve(expandHome(process.env.PI_CODING_AGENT_DIR?.trim() || "~/.pi/agent"));
+	return [join(userDir, "settings.json"), projectSettingsPath(cwd)];
+}
+
+function readPackageConfig(packageId: string, cwd?: string): Record<string, unknown> {
+	const merged: Record<string, unknown> = {};
+	for (const settingsPath of piSettingsPaths(cwd)) {
+		if (!existsSync(settingsPath)) continue;
+		try {
+			const parsed = JSON.parse(readFileSync(settingsPath, "utf8"));
+			const config = parsed?.vstack?.extensionManager?.config?.[packageId];
+			if (config && typeof config === "object" && !Array.isArray(config)) Object.assign(merged, config);
+		} catch {
+			// Ignore malformed optional manager config.
+		}
+	}
+	return merged;
+}
+
+function asGlyphStyle(value: unknown): GlyphStyle | undefined {
+	return value === "unicode" || value === "ascii" ? value : undefined;
+}
+
+export function glyphStyle(cwd?: string): GlyphStyle {
+	const globalOverride = readPackageConfig(GLOBAL_CONFIG_ID, cwd).globalGlyphStyleOverride;
+	const forced = asGlyphStyle(globalOverride);
+	if (forced) return forced;
+	const local = readPackageConfig(LOCAL_CONFIG_ID, cwd);
+	return asGlyphStyle(local.glyphStyle) ?? asGlyphStyle(local.treeStyle) ?? "unicode";
+}
+
+export const GLYPHS = {
+	unicode: {
+		frame: { tl: "┏", tr: "┓", bl: "┗", br: "┛", h: "━", v: "┃" },
+		line: "─",
+		tree: { mid: "├─ ", last: "└─ ", stem: "│  ", blank: "   " },
+		bullet: "● ",
+		emptyBullet: "○ ",
+		dot: " · ",
+		ok: "✓",
+		fail: "✗",
+		warn: "▲",
+		diamond: "◆",
+		prompt: "π",
+		ellipsis: "…",
+		arrow: "→",
+		codeBar: "▌",
+	},
+	ascii: {
+		frame: { tl: "+", tr: "+", bl: "+", br: "+", h: "-", v: "|" },
+		line: "-",
+		tree: { mid: "|-- ", last: "`-- ", stem: "|  ", blank: "   " },
+		bullet: "* ",
+		emptyBullet: "o ",
+		dot: " - ",
+		ok: "+",
+		fail: "x",
+		warn: "!",
+		diamond: "*",
+		prompt: "pi",
+		ellipsis: "...",
+		arrow: "->",
+		codeBar: "|",
+	},
+} as const;
+
+export function glyphs(cwd?: string): (typeof GLYPHS)[GlyphStyle] {
+	return GLYPHS[glyphStyle(cwd)];
+}
+
+export function truncateIndicator(cwd?: string): string {
+	return glyphs(cwd).ellipsis;
+}
+
+export function truncateText(text: string, maxChars: number, cwd?: string): string {
+	if (text.length <= maxChars) return text;
+	const indicator = truncateIndicator(cwd);
+	return `${text.slice(0, Math.max(0, maxChars - indicator.length))}${indicator}`;
+}
+
+export function dot(cwd?: string): string {
+	return glyphs(cwd).dot;
+}
+
+export function treeGlyph(branch: "├" | "└" | "│", cwd?: string): string {
+	const tree = glyphs(cwd).tree;
+	if (branch === "│") return tree.stem;
+	return branch === "└" ? tree.last : tree.mid;
+}
+
+export function frameGlyphs(cwd?: string): (typeof GLYPHS)[GlyphStyle]["frame"] {
+	return glyphs(cwd).frame;
+}

--- a/pi-extensions/pi-codex-minimal-tools/src/index.ts
+++ b/pi-extensions/pi-codex-minimal-tools/src/index.ts
@@ -9,6 +9,7 @@ import { loadSettings, settingsDiagnostics } from "./settings.js";
 import { createApplyPatchToolDefinition } from "./tools/apply-patch.js";
 import { createImageGenerationToolDefinition } from "./tools/image-generation.js";
 import { viewImage, viewImageToolSchema, type ValidatedImage, type ViewImageInput } from "./tools/view-image.js";
+import { glyphs } from "./glyphs.js";
 
 const INSTALL_SYMBOL = Symbol.for("vstack.pi-codex-minimal-tools.installed");
 
@@ -25,16 +26,16 @@ function formatBytes(bytes: number): string {
 
 function viewImageCallText(args: ViewImageInput | undefined, theme: any): string {
 	const path = typeof args?.path === "string" ? args.path : "image";
-	const detail = args?.detail && args.detail !== "auto" ? ` ${theme.fg("dim", `· ${args.detail}`)}` : "";
-	return `${theme.fg("accent", "● ")}${theme.fg("text", theme.bold("View Image "))}${theme.fg("accent", path)}${detail}`;
+	const detail = args?.detail && args.detail !== "auto" ? ` ${theme.fg("dim", `${glyphs().dot.trim()} ${args.detail}`)}` : "";
+	return `${theme.fg("accent", glyphs().bullet)}${theme.fg("text", theme.bold("View Image "))}${theme.fg("accent", path)}${detail}`;
 }
 
 function viewImageResultText(details: ValidatedImage | undefined, theme: any): string {
-	if (!details) return `${theme.fg("accent", "● ")}${theme.fg("text", theme.bold("View Image"))}${theme.fg("dim", " · image loaded")}`;
+	if (!details) return `${theme.fg("accent", glyphs().bullet)}${theme.fg("text", theme.bold("View Image"))}${theme.fg("dim", `${glyphs().dot}image loaded`)}`;
 	const type = details.mimeType.replace(/^image\//, "").toUpperCase();
 	const protocol = terminalImageProtocol();
 	const preview = protocol ? theme.fg("success", `inline ${protocol}`) : theme.fg("warning", "fallback");
-	return `${theme.fg("accent", "● ")}${theme.fg("text", theme.bold("View Image "))}${theme.fg("accent", details.displayPath)}${theme.fg("dim", " · ")}${theme.fg("success", type)}${theme.fg("dim", ` · ${formatBytes(details.sizeBytes)} · `)}${preview}`;
+	return `${theme.fg("accent", glyphs().bullet)}${theme.fg("text", theme.bold("View Image "))}${theme.fg("accent", details.displayPath)}${theme.fg("dim", glyphs().dot)}${theme.fg("success", type)}${theme.fg("dim", `${glyphs().dot}${formatBytes(details.sizeBytes)}${glyphs().dot}`)}${preview}`;
 }
 
 function emptyComponent(): Component {

--- a/pi-extensions/pi-codex-minimal-tools/src/provider-shim.ts
+++ b/pi-extensions/pi-codex-minimal-tools/src/provider-shim.ts
@@ -1,4 +1,5 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { glyphs, treeGlyph } from "./glyphs.js";
 import { loadSettings } from "./settings.js";
 import { saveBase64Image } from "./utils/images.js";
 import { Box, Container, getCapabilities, getImageDimensions, Image, Spacer, Text } from "@earendil-works/pi-tui";
@@ -1476,14 +1477,14 @@ function renderImageGenerationMessage(savedImage: SavedGeneratedImage | undefine
 	const dimensions = preview?.widthPx && preview?.heightPx ? `${preview.widthPx}x${preview.heightPx}` : undefined;
 	const size = formatImageBytes(preview?.bytes);
 	const imageModel = savedImage?.imageModel ? `model ${savedImage.imageModel}` : undefined;
-	const meta = [imageModel, type, dimensions, size].filter(Boolean).join(" · ");
-	const label = `${themeFg(theme, "accent", "● ")}${themeFg(theme, "text", themeBold(theme, "Image Generation "))}`;
+	const meta = [imageModel, type, dimensions, size].filter(Boolean).join(glyphs().dot);
+	const label = `${themeFg(theme, "accent", glyphs().bullet)}${themeFg(theme, "text", themeBold(theme, "Image Generation "))}`;
 	const pathText = savedImage?.relativePath ?? (typeof messageContent === "string" ? messageContent : "generated image");
-	const lines = [`${label}${themeFg(theme, "accent", pathText)}${meta ? themeFg(theme, "dim", ` · ${meta}`) : ""}`];
-	if (savedImage?.latestRelativePath) lines.push(`${themeFg(theme, "muted", "  ├─ ")}${themeFg(theme, "text", "Latest ")}${themeFg(theme, "accent", savedImage.latestRelativePath)}`);
-	if (options?.expanded && savedImage?.revisedPrompt) lines.push(`${themeFg(theme, "muted", "  ├─ ")}${themeFg(theme, "text", "Prompt ")}${themeFg(theme, "dim", savedImage.revisedPrompt)}`);
+	const lines = [`${label}${themeFg(theme, "accent", pathText)}${meta ? themeFg(theme, "dim", `${glyphs().dot}${meta}`) : ""}`];
+	if (savedImage?.latestRelativePath) lines.push(`${themeFg(theme, "muted", `  ${treeGlyph("├")}`)}${themeFg(theme, "text", "Latest ")}${themeFg(theme, "accent", savedImage.latestRelativePath)}`);
+	if (options?.expanded && savedImage?.revisedPrompt) lines.push(`${themeFg(theme, "muted", `  ${treeGlyph("├")}`)}${themeFg(theme, "text", "Prompt ")}${themeFg(theme, "dim", savedImage.revisedPrompt)}`);
 	const inline = shouldRenderInlineImage();
-	if (!inline.ok) lines.push(`${themeFg(theme, "muted", "  └─ ")}${themeFg(theme, "warning", inline.reason ?? "inline preview unavailable")}`);
+	if (!inline.ok) lines.push(`${themeFg(theme, "muted", `  ${treeGlyph("└")}`)}${themeFg(theme, "warning", inline.reason ?? "inline preview unavailable")}`);
 	container.addChild(new Text(lines.join("\n"), 0, 0));
 	if (savedImage && preview && inline.ok) {
 		container.addChild(new Spacer(1));

--- a/pi-extensions/pi-codex-minimal-tools/src/settings.ts
+++ b/pi-extensions/pi-codex-minimal-tools/src/settings.ts
@@ -6,6 +6,7 @@ export const PACKAGE_ID = "@vanillagreen/pi-codex-minimal-tools";
 
 export interface CodexMinimalToolsSettings {
 	enabled: boolean;
+	glyphStyle: "unicode" | "ascii";
 	autoEnable: boolean;
 	nativeProviderTools: boolean;
 	imageGeneration: boolean;
@@ -22,6 +23,7 @@ export interface CodexMinimalToolsSettings {
 
 export const DEFAULT_SETTINGS: CodexMinimalToolsSettings = {
 	enabled: true,
+	glyphStyle: "unicode",
 	autoEnable: true,
 	nativeProviderTools: true,
 	imageGeneration: true,
@@ -110,10 +112,16 @@ function imageModelSetting(raw: SettingsRecord): CodexMinimalToolsSettings["imag
 	return value === "gpt-image-2" || value === "gpt-image-1.5" || value === "gpt-image-1" ? value : DEFAULT_SETTINGS.imageModel;
 }
 
+function glyphStyleSetting(raw: SettingsRecord): CodexMinimalToolsSettings["glyphStyle"] {
+	const value = raw.glyphStyle;
+	return value === "ascii" || value === "unicode" ? value : DEFAULT_SETTINGS.glyphStyle;
+}
+
 export function loadSettings(cwd?: string): CodexMinimalToolsSettings {
 	const raw = readRawVstackConfig(cwd);
 	return {
 		enabled: boolSetting(raw, "enabled"),
+		glyphStyle: glyphStyleSetting(raw),
 		autoEnable: boolSetting(raw, "autoEnable"),
 		nativeProviderTools: boolSetting(raw, "nativeProviderTools"),
 		imageGeneration: boolSetting(raw, "imageGeneration"),

--- a/pi-extensions/pi-extension-manager/README.md
+++ b/pi-extensions/pi-extension-manager/README.md
@@ -50,6 +50,8 @@ Open `/extensions:settings`; settings appear under the **Extension Manager** tab
 | Default save scope | Where setting edits are written when scope is ambiguous (`project` or `user`). |
 | Notify on extension updates | Post a one-line notification at session start listing extensions with newer versions. |
 
+Glyph style: each package exposes `glyphStyle` (`unicode` default, `ascii` for terminal-safe chrome). `@vanillagreen/pi-tool-renderer.globalGlyphStyleOverride=ascii` forces ASCII chrome across vstack Pi extensions while leaving tool/model/user content unchanged.
+
 ## Notes
 
 Package enable/disable and updates take effect after `/reload` or restart — Pi doesn't currently support unloading already-loaded extensions. npm update/uninstall actions run inside Pi's scope-local npm directory (`<scope>/npm`), matching Pi 0.75+ user package installs under `~/.pi/agent/npm/`. Command execution resolves Windows npm-family shims without requiring external runtime dependencies.

--- a/pi-extensions/pi-extension-manager/extensions/manager/glyphs.ts
+++ b/pi-extensions/pi-extension-manager/extensions/manager/glyphs.ts
@@ -1,0 +1,122 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+export type GlyphStyle = "unicode" | "ascii";
+export type GlobalGlyphStyleOverride = "inherit" | GlyphStyle;
+
+const LOCAL_CONFIG_ID = "@vanillagreen/pi-extension-manager";
+const GLOBAL_CONFIG_ID = "@vanillagreen/pi-tool-renderer";
+
+function expandHome(input: string): string {
+	if (input === "~") return homedir();
+	if (input.startsWith("~/")) return join(homedir(), input.slice(2));
+	return input;
+}
+
+function projectSettingsPath(cwd: string): string {
+	let current = resolve(cwd);
+	while (true) {
+		const candidate = join(current, ".pi", "settings.json");
+		if (existsSync(candidate)) return candidate;
+		if (existsSync(join(current, ".pi")) || existsSync(join(current, ".git")) || existsSync(join(current, ".vstack-lock.json"))) return candidate;
+		const parent = dirname(current);
+		if (parent === current) return join(resolve(cwd), ".pi", "settings.json");
+		current = parent;
+	}
+}
+
+function piSettingsPaths(cwd = process.cwd()): string[] {
+	const userDir = resolve(expandHome(process.env.PI_CODING_AGENT_DIR?.trim() || "~/.pi/agent"));
+	return [join(userDir, "settings.json"), projectSettingsPath(cwd)];
+}
+
+function readPackageConfig(packageId: string, cwd?: string): Record<string, unknown> {
+	const merged: Record<string, unknown> = {};
+	for (const settingsPath of piSettingsPaths(cwd)) {
+		if (!existsSync(settingsPath)) continue;
+		try {
+			const parsed = JSON.parse(readFileSync(settingsPath, "utf8"));
+			const config = parsed?.vstack?.extensionManager?.config?.[packageId];
+			if (config && typeof config === "object" && !Array.isArray(config)) Object.assign(merged, config);
+		} catch {
+			// Ignore malformed optional manager config.
+		}
+	}
+	return merged;
+}
+
+function asGlyphStyle(value: unknown): GlyphStyle | undefined {
+	return value === "unicode" || value === "ascii" ? value : undefined;
+}
+
+export function glyphStyle(cwd?: string): GlyphStyle {
+	const globalOverride = readPackageConfig(GLOBAL_CONFIG_ID, cwd).globalGlyphStyleOverride;
+	const forced = asGlyphStyle(globalOverride);
+	if (forced) return forced;
+	const local = readPackageConfig(LOCAL_CONFIG_ID, cwd);
+	return asGlyphStyle(local.glyphStyle) ?? asGlyphStyle(local.treeStyle) ?? "unicode";
+}
+
+export const GLYPHS = {
+	unicode: {
+		frame: { tl: "┏", tr: "┓", bl: "┗", br: "┛", h: "━", v: "┃" },
+		line: "─",
+		tree: { mid: "├─ ", last: "└─ ", stem: "│  ", blank: "   " },
+		bullet: "● ",
+		emptyBullet: "○ ",
+		dot: " · ",
+		ok: "✓",
+		fail: "✗",
+		warn: "▲",
+		diamond: "◆",
+		prompt: "π",
+		ellipsis: "…",
+		arrow: "→",
+		codeBar: "▌",
+	},
+	ascii: {
+		frame: { tl: "+", tr: "+", bl: "+", br: "+", h: "-", v: "|" },
+		line: "-",
+		tree: { mid: "|-- ", last: "`-- ", stem: "|  ", blank: "   " },
+		bullet: "* ",
+		emptyBullet: "o ",
+		dot: " - ",
+		ok: "+",
+		fail: "x",
+		warn: "!",
+		diamond: "*",
+		prompt: "pi",
+		ellipsis: "...",
+		arrow: "->",
+		codeBar: "|",
+	},
+} as const;
+
+export function glyphs(cwd?: string): (typeof GLYPHS)[GlyphStyle] {
+	return GLYPHS[glyphStyle(cwd)];
+}
+
+export function truncateIndicator(cwd?: string): string {
+	return glyphs(cwd).ellipsis;
+}
+
+export function truncateText(text: string, maxChars: number, cwd?: string): string {
+	if (text.length <= maxChars) return text;
+	const indicator = truncateIndicator(cwd);
+	return `${text.slice(0, Math.max(0, maxChars - indicator.length))}${indicator}`;
+}
+
+export function dot(cwd?: string): string {
+	return glyphs(cwd).dot;
+}
+
+export function treeGlyph(branch: "├" | "└" | "│", cwd?: string): string {
+	const tree = glyphs(cwd).tree;
+	if (branch === "│") return tree.stem;
+	return branch === "└" ? tree.last : tree.mid;
+}
+
+export function frameGlyphs(cwd?: string): (typeof GLYPHS)[GlyphStyle]["frame"] {
+	return glyphs(cwd).frame;
+}

--- a/pi-extensions/pi-extension-manager/extensions/manager/manager-ui.ts
+++ b/pi-extensions/pi-extension-manager/extensions/manager/manager-ui.ts
@@ -5,6 +5,7 @@ import { filteredItems, packageExtensions } from "./filters.js";
 import { ansiGreen, ansiRed, ansiYellow, isPlainSearchInput, kindLabel, scopeFilterLabel } from "./format.js";
 import { applyUpdateMetadata, buildInventory, npmCandidatesFromInventory } from "./inventory.js";
 import { compactPath } from "./paths.js";
+import { glyphs } from "./glyphs.js";
 import {
 	countBy,
 	divider,
@@ -101,7 +102,7 @@ function renderDiagnosticsViewport(inventory: Inventory, ui: ManagerUiState, wid
 	const before = ui.diagnosticsScroll > 0 ? `↑ ${ui.diagnosticsScroll}` : "";
 	const afterCount = Math.max(0, all.length - ui.diagnosticsScroll - contentRows);
 	const after = afterCount > 0 ? `↓ ${afterCount}` : "";
-	return [...visible, theme.fg("dim", [before, after].filter(Boolean).join(" · "))];
+	return [...visible, theme.fg("dim", [before, after].filter(Boolean).join(glyphs().dot))];
 }
 
 function itemToggleHintLabel(item: InventoryItem | undefined): string | undefined {
@@ -113,9 +114,9 @@ function itemToggleHintLabel(item: InventoryItem | undefined): string | undefine
 }
 
 function stateToken(item: InventoryItem): string {
-	if (item.state === "active") return ansiGreen("●");
-	if (item.state === "broken") return ansiRed("×");
-	return ansiYellow("○");
+	if (item.state === "active") return ansiGreen(glyphs().bullet.trim());
+	if (item.state === "broken") return ansiRed(glyphs().fail);
+	return ansiYellow(glyphs().emptyBullet.trim());
 }
 
 function installSourceLabel(item: InventoryItem): string {
@@ -145,9 +146,9 @@ function renderList(items: InventoryItem[], ui: ManagerUiState, width: number, t
 		const scopeText = scopeFilterLabel(item.scope);
 		const meta = item.kind === "package"
 			? managerMutedForSelection(theme, ` ${scopeText}`, selected)
-			: managerMutedForSelection(theme, ` ${kindLabel(item.kind)} · ${scopeText}`, selected);
+			: managerMutedForSelection(theme, ` ${kindLabel(item.kind)}${glyphs().dot}${scopeText}`, selected);
 		const updateBadge = item.updateAvailable ? ` ${ansiRed("Update Needed")}` : "";
-		const row = truncateToWidth(`${marker}${stateIcon} ${name}${meta}${updateBadge}`, width, "…");
+		const row = truncateToWidth(`${marker}${stateIcon} ${name}${meta}${updateBadge}`, width, glyphs().ellipsis);
 		lines.push(selected ? managerSelectedLine(theme, row, width) : row);
 	}
 	const hidden = Math.max(0, items.length - (ui.scroll + listRows));

--- a/pi-extensions/pi-extension-manager/extensions/manager/render.ts
+++ b/pi-extensions/pi-extension-manager/extensions/manager/render.ts
@@ -1,6 +1,7 @@
 import type { Theme } from "@earendil-works/pi-coding-agent";
 import { truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
 import { ansiGreen } from "./format.js";
+import { frameGlyphs, glyphs } from "./glyphs.js";
 import { POPUP_PADDING_X, POPUP_PADDING_Y, type ManagerTab, type TopTab } from "./types.js";
 
 export function frameContentWidth(width: number): number {
@@ -8,7 +9,7 @@ export function frameContentWidth(width: number): number {
 }
 
 export function divider(width: number, theme: Theme): string {
-	return theme.fg("dim", "─".repeat(Math.max(1, width)));
+	return theme.fg("dim", glyphs().line.repeat(Math.max(1, width)));
 }
 
 export function pad(text: string, width: number): string {
@@ -47,18 +48,19 @@ export function frame(lines: string[], width: number, theme: Theme, fixedInnerRo
 		const hidden = body.length - fixedInnerRows + 1;
 		body = [...body.slice(0, Math.max(0, fixedInnerRows - 1)), theme.fg("dim", `↓ ${hidden} more line(s)`)].slice(0, fixedInnerRows);
 	}
-	const blank = `${border("┃")}${" ".repeat(inner)}${border("┃")}`;
+	const frameGlyph = frameGlyphs();
+	const blank = `${border(frameGlyph.v)}${" ".repeat(inner)}${border(frameGlyph.v)}`;
 	const top = () => {
-		if (!title) return `${border("┏")}${border("━".repeat(inner))}${border("┓")}`;
-		const titlePlain = ` ${truncateToWidth(title, Math.max(1, inner - 2), "…")} `;
+		if (!title) return `${border(frameGlyph.tl)}${border(frameGlyph.h.repeat(inner))}${border(frameGlyph.tr)}`;
+		const titlePlain = ` ${truncateToWidth(title, Math.max(1, inner - 2), glyphs().ellipsis)} `;
 		const fill = Math.max(1, inner - visibleWidth(titlePlain));
-		return `${border("┏")}${ansiGreen(titlePlain)}${border("━".repeat(fill))}${border("┓")}`;
+		return `${border(frameGlyph.tl)}${ansiGreen(titlePlain)}${border(frameGlyph.h.repeat(fill))}${border(frameGlyph.tr)}`;
 	};
 	const out = [top()];
 	for (let i = 0; i < POPUP_PADDING_Y; i += 1) out.push(blank);
-	for (const line of body) out.push(`${border("┃")}${" ".repeat(POPUP_PADDING_X)}${pad(line, contentWidth)}${" ".repeat(POPUP_PADDING_X)}${border("┃")}`);
+	for (const line of body) out.push(`${border(frameGlyph.v)}${" ".repeat(POPUP_PADDING_X)}${pad(line, contentWidth)}${" ".repeat(POPUP_PADDING_X)}${border(frameGlyph.v)}`);
 	for (let i = 0; i < POPUP_PADDING_Y; i += 1) out.push(blank);
-	out.push(`${border("┗")}${border("━".repeat(inner))}${border("┛")}`);
+	out.push(`${border(frameGlyph.bl)}${border(frameGlyph.h.repeat(inner))}${border(frameGlyph.br)}`);
 	return out.map((line) => truncateToWidth(line, width, ""));
 }
 

--- a/pi-extensions/pi-extension-manager/package.json
+++ b/pi-extensions/pi-extension-manager/package.json
@@ -31,6 +31,19 @@
           "requiresReload": true
         },
         {
+          "key": "glyphStyle",
+          "label": "Glyph style",
+          "description": "Glyphs for vstack-owned UI chrome. Unicode is the default; ASCII uses plain box/status/separator characters for terminal compatibility. pi-tool-renderer's global override wins when set.",
+          "type": "enum",
+          "enumValues": [
+            "unicode",
+            "ascii"
+          ],
+          "default": "unicode",
+          "category": "Rendering",
+          "apply": "live"
+        },
+        {
           "key": "defaultSaveScope",
           "label": "Default save scope",
           "description": "Where manager setting edits are written when the selected item scope is ambiguous.",

--- a/pi-extensions/pi-flightdeck/README.md
+++ b/pi-extensions/pi-flightdeck/README.md
@@ -47,6 +47,8 @@ Restart Pi after installation.
 
 Open `/extensions:settings`; settings appear under the **Flightdeck Status** tab.
 
+Glyph style: each package exposes `glyphStyle` (`unicode` default, `ascii` for terminal-safe chrome). `@vanillagreen/pi-tool-renderer.globalGlyphStyleOverride=ascii` forces ASCII chrome across vstack Pi extensions while leaving tool/model/user content unchanged.
+
 ### Dashboard
 
 | Setting | What it does |

--- a/pi-extensions/pi-flightdeck/extensions/flightdeck.ts
+++ b/pi-extensions/pi-flightdeck/extensions/flightdeck.ts
@@ -53,6 +53,7 @@ import {
 import { headerChipForSnapshot, renderArchiveErrorBanner } from "./render-terminated.js";
 import { formatSessionTotals, formatStateBreakdown, issueDomain, renderSessionDetailLines, renderSessionLine, sessionLabel } from "./session-ui.js";
 import { MINI_DASHBOARD_RANK, setMiniDashboardWidget } from "./stacked-widget.js";
+import { glyphs, glyphStyle } from "./glyphs.js";
 import {
 	createFlightdeckDashboardVisibility,
 	cycleFlightdeckDashboardVisibility,
@@ -254,15 +255,15 @@ export function renderAwaitingWatchHintLine(snapshot: FlightdeckSnapshot, theme:
 	const sessions = readAwaitingWatchTrackedEntries(snapshot);
 	const count = sessions.length;
 	const noun = count === 1 ? "session" : "sessions";
-	const line = `${daemon} ${theme.fg("dim", "·")} ${theme.fg("dim", `${count} tracked ${noun} — run /skill:flightdeck session watch to start supervising.`)}`;
-	return [truncateToWidth(line, Math.max(1, width), "…")];
+	const line = `${daemon} ${theme.fg("dim", glyphs().dot.trim())} ${theme.fg("dim", `${count} tracked ${noun} — run /skill:flightdeck session watch to start supervising.`)}`;
+	return [truncateToWidth(line, Math.max(1, width), glyphs().ellipsis)];
 }
 
 export function renderDashboardLines(snapshot: FlightdeckSnapshot, theme: Theme, width: number, state: DashboardState, cwd: string, paneMap: Map<string, string>): string[] {
 	if (state === "hidden") return [];
 	const sessions = readTrackedEntries(snapshot.master);
 	const max = Math.max(1, Math.floor(settingNumber("dashboardMaxItems", 8, cwd)));
-	const treeStyle = (settingString("treeStyle", "unicode", cwd) === "ascii" ? "ascii" : "unicode") as TreeStyle;
+	const treeStyle = glyphStyle(cwd) as TreeStyle;
 	const terminated = !!snapshot.master?.terminated;
 	const headerRight = headerChipForSnapshot(snapshot, theme);
 	const queueLen = snapshot.master?.merge_queue?.length ?? 0;
@@ -293,7 +294,7 @@ export function renderDashboardLines(snapshot: FlightdeckSnapshot, theme: Theme,
 			lines.push(`${panelBranch(theme, isLast ? "└" : "├", treeStyle)}${renderSessionLine(session, theme, stats, paneGone)}`);
 		}
 		const hidden = Math.max(0, sessions.length - visible.length);
-		if (hidden > 0) lines.push(`${panelBranch(theme, "└", treeStyle)}${theme.fg("muted", `… ${hidden} more`)}`);
+		if (hidden > 0) lines.push(`${panelBranch(theme, "└", treeStyle)}${theme.fg("muted", `${glyphs(cwd).ellipsis} ${hidden} more`)}`);
 		if (anyGone) {
 			lines.push(`${panelBranch(theme, "└", treeStyle)}${theme.fg("dim", "pane gone — run /flightdeck for full app context")}`);
 		}

--- a/pi-extensions/pi-flightdeck/extensions/glyphs.ts
+++ b/pi-extensions/pi-flightdeck/extensions/glyphs.ts
@@ -1,0 +1,122 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+export type GlyphStyle = "unicode" | "ascii";
+export type GlobalGlyphStyleOverride = "inherit" | GlyphStyle;
+
+const LOCAL_CONFIG_ID = "@vanillagreen/pi-flightdeck";
+const GLOBAL_CONFIG_ID = "@vanillagreen/pi-tool-renderer";
+
+function expandHome(input: string): string {
+	if (input === "~") return homedir();
+	if (input.startsWith("~/")) return join(homedir(), input.slice(2));
+	return input;
+}
+
+function projectSettingsPath(cwd: string): string {
+	let current = resolve(cwd);
+	while (true) {
+		const candidate = join(current, ".pi", "settings.json");
+		if (existsSync(candidate)) return candidate;
+		if (existsSync(join(current, ".pi")) || existsSync(join(current, ".git")) || existsSync(join(current, ".vstack-lock.json"))) return candidate;
+		const parent = dirname(current);
+		if (parent === current) return join(resolve(cwd), ".pi", "settings.json");
+		current = parent;
+	}
+}
+
+function piSettingsPaths(cwd = process.cwd()): string[] {
+	const userDir = resolve(expandHome(process.env.PI_CODING_AGENT_DIR?.trim() || "~/.pi/agent"));
+	return [join(userDir, "settings.json"), projectSettingsPath(cwd)];
+}
+
+function readPackageConfig(packageId: string, cwd?: string): Record<string, unknown> {
+	const merged: Record<string, unknown> = {};
+	for (const settingsPath of piSettingsPaths(cwd)) {
+		if (!existsSync(settingsPath)) continue;
+		try {
+			const parsed = JSON.parse(readFileSync(settingsPath, "utf8"));
+			const config = parsed?.vstack?.extensionManager?.config?.[packageId];
+			if (config && typeof config === "object" && !Array.isArray(config)) Object.assign(merged, config);
+		} catch {
+			// Ignore malformed optional manager config.
+		}
+	}
+	return merged;
+}
+
+function asGlyphStyle(value: unknown): GlyphStyle | undefined {
+	return value === "unicode" || value === "ascii" ? value : undefined;
+}
+
+export function glyphStyle(cwd?: string): GlyphStyle {
+	const globalOverride = readPackageConfig(GLOBAL_CONFIG_ID, cwd).globalGlyphStyleOverride;
+	const forced = asGlyphStyle(globalOverride);
+	if (forced) return forced;
+	const local = readPackageConfig(LOCAL_CONFIG_ID, cwd);
+	return asGlyphStyle(local.glyphStyle) ?? asGlyphStyle(local.treeStyle) ?? "unicode";
+}
+
+export const GLYPHS = {
+	unicode: {
+		frame: { tl: "┏", tr: "┓", bl: "┗", br: "┛", h: "━", v: "┃" },
+		line: "─",
+		tree: { mid: "├─ ", last: "└─ ", stem: "│  ", blank: "   " },
+		bullet: "● ",
+		emptyBullet: "○ ",
+		dot: " · ",
+		ok: "✓",
+		fail: "✗",
+		warn: "▲",
+		diamond: "◆",
+		prompt: "π",
+		ellipsis: "…",
+		arrow: "→",
+		codeBar: "▌",
+	},
+	ascii: {
+		frame: { tl: "+", tr: "+", bl: "+", br: "+", h: "-", v: "|" },
+		line: "-",
+		tree: { mid: "|-- ", last: "`-- ", stem: "|  ", blank: "   " },
+		bullet: "* ",
+		emptyBullet: "o ",
+		dot: " - ",
+		ok: "+",
+		fail: "x",
+		warn: "!",
+		diamond: "*",
+		prompt: "pi",
+		ellipsis: "...",
+		arrow: "->",
+		codeBar: "|",
+	},
+} as const;
+
+export function glyphs(cwd?: string): (typeof GLYPHS)[GlyphStyle] {
+	return GLYPHS[glyphStyle(cwd)];
+}
+
+export function truncateIndicator(cwd?: string): string {
+	return glyphs(cwd).ellipsis;
+}
+
+export function truncateText(text: string, maxChars: number, cwd?: string): string {
+	if (text.length <= maxChars) return text;
+	const indicator = truncateIndicator(cwd);
+	return `${text.slice(0, Math.max(0, maxChars - indicator.length))}${indicator}`;
+}
+
+export function dot(cwd?: string): string {
+	return glyphs(cwd).dot;
+}
+
+export function treeGlyph(branch: "├" | "└" | "│", cwd?: string): string {
+	const tree = glyphs(cwd).tree;
+	if (branch === "│") return tree.stem;
+	return branch === "└" ? tree.last : tree.mid;
+}
+
+export function frameGlyphs(cwd?: string): (typeof GLYPHS)[GlyphStyle]["frame"] {
+	return glyphs(cwd).frame;
+}

--- a/pi-extensions/pi-flightdeck/extensions/render.ts
+++ b/pi-extensions/pi-flightdeck/extensions/render.ts
@@ -10,6 +10,7 @@ import { truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@earendil-works
 type ThemeColor = Parameters<Theme["fg"]>[0];
 
 import type { TrackedState } from "./state.js";
+import { frameGlyphs, glyphs } from "./glyphs.js";
 
 export const ANSI_YELLOW_FG = "\x1b[33m";
 export const ANSI_RED_FG = "\x1b[31m";
@@ -45,7 +46,7 @@ export function wrapLine(line: string, width: number): string[] {
 }
 
 export function divider(width: number, theme: Theme): string {
-	return theme.fg("dim", "─".repeat(Math.max(1, width)));
+	return theme.fg("dim", glyphs().line.repeat(Math.max(1, width)));
 }
 
 export function frameContentWidth(width: number): number {
@@ -66,16 +67,17 @@ export function framePanel(lines: string[], width: number, theme: Theme, color: 
 	const inner = Math.max(1, safeWidth - 2);
 	const contentWidth = panelFrameContentWidth(safeWidth);
 	const border = (text: string): string => theme.fg(color, text);
+	const frame = frameGlyphs();
 	const top = (): string => {
-		if (!title) return `${border("┏")}${border("━".repeat(inner))}${border("┓")}`;
-		const titlePlain = ` ${truncateToWidth(title, Math.max(1, inner - 2), "…")} `;
+		if (!title) return `${border(frame.tl)}${border(frame.h.repeat(inner))}${border(frame.tr)}`;
+		const titlePlain = ` ${truncateToWidth(title, Math.max(1, inner - 2), glyphs().ellipsis)} `;
 		const fill = Math.max(1, inner - visibleWidth(titlePlain));
-		return `${border("┏")}${theme.fg(color, titlePlain)}${border("━".repeat(fill))}${border("┓")}`;
+		return `${border(frame.tl)}${theme.fg(color, titlePlain)}${border(frame.h.repeat(fill))}${border(frame.tr)}`;
 	};
 	return [
 		top(),
-		...lines.map((line) => `${border("┃")}${" ".repeat(PANEL_CARD_PADDING_X)}${pad(line, contentWidth)}${" ".repeat(PANEL_CARD_PADDING_X)}${border("┃")}`),
-		`${border("┗")}${border("━".repeat(inner))}${border("┛")}`,
+		...lines.map((line) => `${border(frame.v)}${" ".repeat(PANEL_CARD_PADDING_X)}${pad(line, contentWidth)}${" ".repeat(PANEL_CARD_PADDING_X)}${border(frame.v)}`),
+		`${border(frame.bl)}${border(frame.h.repeat(inner))}${border(frame.br)}`,
 	].map((line) => truncateToWidth(line, safeWidth, ""));
 }
 
@@ -118,17 +120,17 @@ export function stateColor(state: TrackedState | string | undefined | null): "su
 
 export function stateGlyph(state: TrackedState | string | undefined | null): string {
 	switch (state) {
-		case "complete": return "✓";
-		case "merged": return "✓";
-		case "ready": return "●";
-		case "merge-ready": return "▲";
-		case "submitting": return "◆";
+		case "complete": return glyphs().ok;
+		case "merged": return glyphs().ok;
+		case "ready": return glyphs().bullet.trim();
+		case "merge-ready": return glyphs().warn;
+		case "submitting": return glyphs().diamond;
 		case "prompting": return "?";
 		case "waiting": return COG_GLYPH;
-		case "cancelled": return "✗";
-		case "aborted": return "✗";
-		case "dead": return "×";
-		default: return "·";
+		case "cancelled": return glyphs().fail;
+		case "aborted": return glyphs().fail;
+		case "dead": return glyphs().fail;
+		default: return glyphs().dot.trim();
 	}
 }
 
@@ -185,7 +187,7 @@ export function bool(theme: Theme, value: boolean | undefined, ok = "yes", bad =
 }
 
 export function dotIndicator(theme: Theme, alive: boolean): string {
-	return alive ? theme.fg("success", "●") : theme.fg("error", "●");
+	return alive ? theme.fg("success", glyphs().bullet.trim()) : theme.fg("error", glyphs().bullet.trim());
 }
 
 // Combined daemon health chip. Five visual states, matching the
@@ -207,12 +209,13 @@ export interface DaemonChipInput {
 
 export function daemonHealthChip(theme: Theme, input: DaemonChipInput): string {
 	const { alive, heartbeatAgeSec, everStarted } = input;
-	if (!alive && !everStarted) return `${theme.fg("dim", "●")} ${theme.fg("dim", "daemon standby")}`;
-	if (!alive) return `${theme.fg("error", "●")} ${theme.fg("error", "daemon dead")}`;
-	if (heartbeatAgeSec === undefined) return `${theme.fg("warning", "●")} ${theme.fg("warning", "daemon no-pulse")}`;
-	if (heartbeatAgeSec >= 120) return `${theme.fg("error", "●")} ${theme.fg("error", `daemon stale ${formatAgeShort(heartbeatAgeSec)}`)}`;
-	if (heartbeatAgeSec >= 30) return `${theme.fg("warning", "●")} ${theme.fg("warning", `daemon stale ${formatAgeShort(heartbeatAgeSec)}`)}`;
-	return `${theme.fg("success", "●")} ${theme.fg("dim", "daemon")}`;
+	const bullet = glyphs().bullet.trim();
+	if (!alive && !everStarted) return `${theme.fg("dim", bullet)} ${theme.fg("dim", "daemon standby")}`;
+	if (!alive) return `${theme.fg("error", bullet)} ${theme.fg("error", "daemon dead")}`;
+	if (heartbeatAgeSec === undefined) return `${theme.fg("warning", bullet)} ${theme.fg("warning", "daemon no-pulse")}`;
+	if (heartbeatAgeSec >= 120) return `${theme.fg("error", bullet)} ${theme.fg("error", `daemon stale ${formatAgeShort(heartbeatAgeSec)}`)}`;
+	if (heartbeatAgeSec >= 30) return `${theme.fg("warning", bullet)} ${theme.fg("warning", `daemon stale ${formatAgeShort(heartbeatAgeSec)}`)}`;
+	return `${theme.fg("success", bullet)} ${theme.fg("dim", "daemon")}`;
 }
 
 // Header chip rendered in place of `daemonHealthChip` when the master
@@ -220,7 +223,7 @@ export function daemonHealthChip(theme: Theme, input: DaemonChipInput): string {
 // `terminate.md § 5`; the alarming red "daemon dead" badge was the
 // previous (wrong) signal in the post-completion view (issue #17).
 export function sessionCompleteChip(theme: Theme): string {
-	return `${theme.fg("success", "✔")} ${theme.fg("success", "session complete")}`;
+	return `${theme.fg("success", glyphs().ok)} ${theme.fg("success", "session complete")}`;
 }
 
 function formatAgeShort(sec: number): string {

--- a/pi-extensions/pi-flightdeck/package.json
+++ b/pi-extensions/pi-flightdeck/package.json
@@ -31,6 +31,19 @@
           "requiresReload": true
         },
         {
+          "key": "glyphStyle",
+          "label": "Glyph style",
+          "description": "Glyphs for vstack-owned UI chrome. Unicode is the default; ASCII uses plain box/status/separator characters for terminal compatibility. pi-tool-renderer's global override wins when set.",
+          "type": "enum",
+          "enumValues": [
+            "unicode",
+            "ascii"
+          ],
+          "default": "unicode",
+          "category": "Rendering",
+          "apply": "live"
+        },
+        {
           "key": "dashboardShortcut",
           "label": "Dashboard cycle shortcut",
           "description": "Keyboard shortcut that cycles the persistent mini-dashboard widget and restores the last visible mode when toggled back in. Use none to disable.",
@@ -125,8 +138,8 @@
         },
         {
           "key": "treeStyle",
-          "label": "Tree connector style",
-          "description": "Connector glyphs for the mini-dashboard widget. Unicode is prettier; ASCII uses |--/`-- for maximum terminal compatibility.",
+          "label": "Legacy tree connector style",
+          "description": "Legacy fallback for tree connectors when glyphStyle is unset and pi-tool-renderer globalGlyphStyleOverride is inherit. Prefer Glyph style for all UI chrome.",
           "type": "enum",
           "enumValues": [
             "unicode",

--- a/pi-extensions/pi-prompt-stash/README.md
+++ b/pi-extensions/pi-prompt-stash/README.md
@@ -38,6 +38,8 @@ The stash shortcut both stashes (when the editor has text) and opens the popup (
 
 ## Settings
 
+Glyph style: each package exposes `glyphStyle` (`unicode` default, `ascii` for terminal-safe chrome). `@vanillagreen/pi-tool-renderer.globalGlyphStyleOverride=ascii` forces ASCII chrome across vstack Pi extensions while leaving tool/model/user content unchanged.
+
 Open `/extensions:settings`; settings appear under the **Prompt Stash** tab.
 
 | Setting | What it does |

--- a/pi-extensions/pi-prompt-stash/extensions/glyphs.ts
+++ b/pi-extensions/pi-prompt-stash/extensions/glyphs.ts
@@ -1,0 +1,122 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+export type GlyphStyle = "unicode" | "ascii";
+export type GlobalGlyphStyleOverride = "inherit" | GlyphStyle;
+
+const LOCAL_CONFIG_ID = "@vanillagreen/pi-prompt-stash";
+const GLOBAL_CONFIG_ID = "@vanillagreen/pi-tool-renderer";
+
+function expandHome(input: string): string {
+	if (input === "~") return homedir();
+	if (input.startsWith("~/")) return join(homedir(), input.slice(2));
+	return input;
+}
+
+function projectSettingsPath(cwd: string): string {
+	let current = resolve(cwd);
+	while (true) {
+		const candidate = join(current, ".pi", "settings.json");
+		if (existsSync(candidate)) return candidate;
+		if (existsSync(join(current, ".pi")) || existsSync(join(current, ".git")) || existsSync(join(current, ".vstack-lock.json"))) return candidate;
+		const parent = dirname(current);
+		if (parent === current) return join(resolve(cwd), ".pi", "settings.json");
+		current = parent;
+	}
+}
+
+function piSettingsPaths(cwd = process.cwd()): string[] {
+	const userDir = resolve(expandHome(process.env.PI_CODING_AGENT_DIR?.trim() || "~/.pi/agent"));
+	return [join(userDir, "settings.json"), projectSettingsPath(cwd)];
+}
+
+function readPackageConfig(packageId: string, cwd?: string): Record<string, unknown> {
+	const merged: Record<string, unknown> = {};
+	for (const settingsPath of piSettingsPaths(cwd)) {
+		if (!existsSync(settingsPath)) continue;
+		try {
+			const parsed = JSON.parse(readFileSync(settingsPath, "utf8"));
+			const config = parsed?.vstack?.extensionManager?.config?.[packageId];
+			if (config && typeof config === "object" && !Array.isArray(config)) Object.assign(merged, config);
+		} catch {
+			// Ignore malformed optional manager config.
+		}
+	}
+	return merged;
+}
+
+function asGlyphStyle(value: unknown): GlyphStyle | undefined {
+	return value === "unicode" || value === "ascii" ? value : undefined;
+}
+
+export function glyphStyle(cwd?: string): GlyphStyle {
+	const globalOverride = readPackageConfig(GLOBAL_CONFIG_ID, cwd).globalGlyphStyleOverride;
+	const forced = asGlyphStyle(globalOverride);
+	if (forced) return forced;
+	const local = readPackageConfig(LOCAL_CONFIG_ID, cwd);
+	return asGlyphStyle(local.glyphStyle) ?? asGlyphStyle(local.treeStyle) ?? "unicode";
+}
+
+export const GLYPHS = {
+	unicode: {
+		frame: { tl: "┏", tr: "┓", bl: "┗", br: "┛", h: "━", v: "┃" },
+		line: "─",
+		tree: { mid: "├─ ", last: "└─ ", stem: "│  ", blank: "   " },
+		bullet: "● ",
+		emptyBullet: "○ ",
+		dot: " · ",
+		ok: "✓",
+		fail: "✗",
+		warn: "▲",
+		diamond: "◆",
+		prompt: "π",
+		ellipsis: "…",
+		arrow: "→",
+		codeBar: "▌",
+	},
+	ascii: {
+		frame: { tl: "+", tr: "+", bl: "+", br: "+", h: "-", v: "|" },
+		line: "-",
+		tree: { mid: "|-- ", last: "`-- ", stem: "|  ", blank: "   " },
+		bullet: "* ",
+		emptyBullet: "o ",
+		dot: " - ",
+		ok: "+",
+		fail: "x",
+		warn: "!",
+		diamond: "*",
+		prompt: "pi",
+		ellipsis: "...",
+		arrow: "->",
+		codeBar: "|",
+	},
+} as const;
+
+export function glyphs(cwd?: string): (typeof GLYPHS)[GlyphStyle] {
+	return GLYPHS[glyphStyle(cwd)];
+}
+
+export function truncateIndicator(cwd?: string): string {
+	return glyphs(cwd).ellipsis;
+}
+
+export function truncateText(text: string, maxChars: number, cwd?: string): string {
+	if (text.length <= maxChars) return text;
+	const indicator = truncateIndicator(cwd);
+	return `${text.slice(0, Math.max(0, maxChars - indicator.length))}${indicator}`;
+}
+
+export function dot(cwd?: string): string {
+	return glyphs(cwd).dot;
+}
+
+export function treeGlyph(branch: "├" | "└" | "│", cwd?: string): string {
+	const tree = glyphs(cwd).tree;
+	if (branch === "│") return tree.stem;
+	return branch === "└" ? tree.last : tree.mid;
+}
+
+export function frameGlyphs(cwd?: string): (typeof GLYPHS)[GlyphStyle]["frame"] {
+	return glyphs(cwd).frame;
+}

--- a/pi-extensions/pi-prompt-stash/extensions/prompt-stash.ts
+++ b/pi-extensions/pi-prompt-stash/extensions/prompt-stash.ts
@@ -7,6 +7,7 @@ import { Input, matchesKey, truncateToWidth, visibleWidth, type Focusable } from
 import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
+import { frameGlyphs, glyphs } from "./glyphs.js";
 
 const PACKAGE_ID = "@vanillagreen/pi-prompt-stash";
 const DEFAULT_STORE_FILE = "prompt-stash.json";
@@ -284,23 +285,24 @@ function framePopup(lines: string[], width: number, theme: Theme, title = "", ri
 
 	const border = (text: string) => theme.fg("borderAccent", text);
 	const contentWidth = popupContentWidth(width);
-	const blank = `${border("┃")}${" ".repeat(width - 2)}${border("┃")}`;
+	const frame = frameGlyphs();
+	const blank = `${border(frame.v)}${" ".repeat(width - 2)}${border(frame.v)}`;
 	const top = () => {
-		if (!title) return `${border("┏")}${border("━".repeat(width - 2))}${border("┓")}`;
+		if (!title) return `${border(frame.tl)}${border(frame.h.repeat(width - 2))}${border(frame.tr)}`;
 		const rightPlain = right ? ` ${right} ` : "";
 		const titleBudget = Math.max(1, width - 2 - visibleWidth(rightPlain) - 1);
-		const titlePlain = ` ${truncateToWidth(title, Math.max(1, titleBudget - 2), "…")} `;
+		const titlePlain = ` ${truncateToWidth(title, Math.max(1, titleBudget - 2), glyphs().ellipsis)} `;
 		const fill = Math.max(1, width - 2 - visibleWidth(titlePlain) - visibleWidth(rightPlain));
-		return `${border("┏")}${ansiGreen(titlePlain)}${border("━".repeat(fill))}${right ? theme.fg("dim", rightPlain) : ""}${border("┓")}`;
+		return `${border(frame.tl)}${ansiGreen(titlePlain)}${border(frame.h.repeat(fill))}${right ? theme.fg("dim", rightPlain) : ""}${border(frame.tr)}`;
 	};
 	const framed = [top()];
 
 	for (let i = 0; i < PADDING_Y; i += 1) framed.push(blank);
 	for (const line of lines) {
-		framed.push(`${border("┃")}${" ".repeat(PADDING_X)}${padAnsi(line, contentWidth)}${" ".repeat(PADDING_X)}${border("┃")}`);
+		framed.push(`${border(frame.v)}${" ".repeat(PADDING_X)}${padAnsi(line, contentWidth)}${" ".repeat(PADDING_X)}${border(frame.v)}`);
 	}
 	for (let i = 0; i < PADDING_Y; i += 1) framed.push(blank);
-	framed.push(`${border("┗")}${border("━".repeat(width - 2))}${border("┛")}`);
+	framed.push(`${border(frame.bl)}${border(frame.h.repeat(width - 2))}${border(frame.br)}`);
 	return framed.map((line) => truncateToWidth(line, width, ""));
 }
 

--- a/pi-extensions/pi-prompt-stash/package.json
+++ b/pi-extensions/pi-prompt-stash/package.json
@@ -42,6 +42,19 @@
           "requiresReload": true
         },
         {
+          "key": "glyphStyle",
+          "label": "Glyph style",
+          "description": "Glyphs for vstack-owned UI chrome. Unicode is the default; ASCII uses plain box/status/separator characters for terminal compatibility. pi-tool-renderer's global override wins when set.",
+          "type": "enum",
+          "enumValues": [
+            "unicode",
+            "ascii"
+          ],
+          "default": "unicode",
+          "category": "Rendering",
+          "apply": "live"
+        },
+        {
           "key": "storeFile",
           "label": "Store file",
           "description": "File name under the per-session global stash directory.",

--- a/pi-extensions/pi-qol/README.md
+++ b/pi-extensions/pi-qol/README.md
@@ -58,6 +58,8 @@ Arguments support autocomplete.
 
 Open `/extensions:settings`; settings appear under the **QOL** tab. Names below match the labels shown there.
 
+Glyph style: each package exposes `glyphStyle` (`unicode` default, `ascii` for terminal-safe chrome). `@vanillagreen/pi-tool-renderer.globalGlyphStyleOverride=ascii` forces ASCII chrome across vstack Pi extensions while leaving tool/model/user content unchanged.
+
 ### Statusline
 
 | Setting | What it does |

--- a/pi-extensions/pi-qol/extensions/qol/editor.ts
+++ b/pi-extensions/pi-qol/extensions/qol/editor.ts
@@ -3,6 +3,7 @@ import { matchesKey, truncateToWidth, visibleWidth, type AutocompleteItem, type 
 import { stripAnsi } from "./ansi.js";
 import { readCavemanBridge } from "./bridges.js";
 import { STATUS_KEY } from "./constants.js";
+import { glyphs } from "./glyphs.js";
 import { statusText, styleImageChips } from "./images.js";
 import { newlineFallbackKey, settingBoolean } from "./settings.js";
 
@@ -145,9 +146,10 @@ export class QolCompactPromptEditor extends CustomEditor {
 
 	render(width: number): string[] {
 		syncQolEditorStatus(this.ctx, this.getText(), this.statusCache);
-		const prompt = this.borderColor("π");
+		const promptGlyph = glyphs(this.ctx.cwd).prompt;
+		const prompt = this.borderColor(promptGlyph);
 		const prefix = `${prompt} `;
-		const prefixWidth = visibleWidth("π ");
+		const prefixWidth = visibleWidth(`${promptGlyph} `);
 		const continuationPrefix = " ".repeat(prefixWidth);
 		const innerWidth = Math.max(1, width - prefixWidth);
 		const rendered = super.render(innerWidth);

--- a/pi-extensions/pi-qol/extensions/qol/glyphs.ts
+++ b/pi-extensions/pi-qol/extensions/qol/glyphs.ts
@@ -1,0 +1,122 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+export type GlyphStyle = "unicode" | "ascii";
+export type GlobalGlyphStyleOverride = "inherit" | GlyphStyle;
+
+const LOCAL_CONFIG_ID = "@vanillagreen/pi-qol";
+const GLOBAL_CONFIG_ID = "@vanillagreen/pi-tool-renderer";
+
+function expandHome(input: string): string {
+	if (input === "~") return homedir();
+	if (input.startsWith("~/")) return join(homedir(), input.slice(2));
+	return input;
+}
+
+function projectSettingsPath(cwd: string): string {
+	let current = resolve(cwd);
+	while (true) {
+		const candidate = join(current, ".pi", "settings.json");
+		if (existsSync(candidate)) return candidate;
+		if (existsSync(join(current, ".pi")) || existsSync(join(current, ".git")) || existsSync(join(current, ".vstack-lock.json"))) return candidate;
+		const parent = dirname(current);
+		if (parent === current) return join(resolve(cwd), ".pi", "settings.json");
+		current = parent;
+	}
+}
+
+function piSettingsPaths(cwd = process.cwd()): string[] {
+	const userDir = resolve(expandHome(process.env.PI_CODING_AGENT_DIR?.trim() || "~/.pi/agent"));
+	return [join(userDir, "settings.json"), projectSettingsPath(cwd)];
+}
+
+function readPackageConfig(packageId: string, cwd?: string): Record<string, unknown> {
+	const merged: Record<string, unknown> = {};
+	for (const settingsPath of piSettingsPaths(cwd)) {
+		if (!existsSync(settingsPath)) continue;
+		try {
+			const parsed = JSON.parse(readFileSync(settingsPath, "utf8"));
+			const config = parsed?.vstack?.extensionManager?.config?.[packageId];
+			if (config && typeof config === "object" && !Array.isArray(config)) Object.assign(merged, config);
+		} catch {
+			// Ignore malformed optional manager config.
+		}
+	}
+	return merged;
+}
+
+function asGlyphStyle(value: unknown): GlyphStyle | undefined {
+	return value === "unicode" || value === "ascii" ? value : undefined;
+}
+
+export function glyphStyle(cwd?: string): GlyphStyle {
+	const globalOverride = readPackageConfig(GLOBAL_CONFIG_ID, cwd).globalGlyphStyleOverride;
+	const forced = asGlyphStyle(globalOverride);
+	if (forced) return forced;
+	const local = readPackageConfig(LOCAL_CONFIG_ID, cwd);
+	return asGlyphStyle(local.glyphStyle) ?? asGlyphStyle(local.treeStyle) ?? "unicode";
+}
+
+export const GLYPHS = {
+	unicode: {
+		frame: { tl: "┏", tr: "┓", bl: "┗", br: "┛", h: "━", v: "┃" },
+		line: "─",
+		tree: { mid: "├─ ", last: "└─ ", stem: "│  ", blank: "   " },
+		bullet: "● ",
+		emptyBullet: "○ ",
+		dot: " · ",
+		ok: "✓",
+		fail: "✗",
+		warn: "▲",
+		diamond: "◆",
+		prompt: "π",
+		ellipsis: "…",
+		arrow: "→",
+		codeBar: "▌",
+	},
+	ascii: {
+		frame: { tl: "+", tr: "+", bl: "+", br: "+", h: "-", v: "|" },
+		line: "-",
+		tree: { mid: "|-- ", last: "`-- ", stem: "|  ", blank: "   " },
+		bullet: "* ",
+		emptyBullet: "o ",
+		dot: " - ",
+		ok: "+",
+		fail: "x",
+		warn: "!",
+		diamond: "*",
+		prompt: "pi",
+		ellipsis: "...",
+		arrow: "->",
+		codeBar: "|",
+	},
+} as const;
+
+export function glyphs(cwd?: string): (typeof GLYPHS)[GlyphStyle] {
+	return GLYPHS[glyphStyle(cwd)];
+}
+
+export function truncateIndicator(cwd?: string): string {
+	return glyphs(cwd).ellipsis;
+}
+
+export function truncateText(text: string, maxChars: number, cwd?: string): string {
+	if (text.length <= maxChars) return text;
+	const indicator = truncateIndicator(cwd);
+	return `${text.slice(0, Math.max(0, maxChars - indicator.length))}${indicator}`;
+}
+
+export function dot(cwd?: string): string {
+	return glyphs(cwd).dot;
+}
+
+export function treeGlyph(branch: "├" | "└" | "│", cwd?: string): string {
+	const tree = glyphs(cwd).tree;
+	if (branch === "│") return tree.stem;
+	return branch === "└" ? tree.last : tree.mid;
+}
+
+export function frameGlyphs(cwd?: string): (typeof GLYPHS)[GlyphStyle]["frame"] {
+	return glyphs(cwd).frame;
+}

--- a/pi-extensions/pi-qol/extensions/qol/status-message.ts
+++ b/pi-extensions/pi-qol/extensions/qol/status-message.ts
@@ -8,6 +8,7 @@ import {
 	DEFAULT_PERMISSION_GATE_PREVIEW_LINES,
 } from "./constants.js";
 import { currentEditorText } from "./editor.js";
+import { glyphs } from "./glyphs.js";
 import { attachmentLabels } from "./images.js";
 import { permissionGateCommands } from "./permission-gate.js";
 import { autoRenameEnabled } from "./session-rename.js";
@@ -19,7 +20,7 @@ export function statusMessage(ctx: ExtensionContext): string {
 	const searchShortcut = sessionSearchShortcut(ctx.cwd);
 	return [
 		"Pi QOL status",
-		`Statusline: ${settingBoolean("replaceFooter", true, ctx.cwd) ? "replaces footer" : "footer preserved"}; prompt=${settingBoolean("compactPrompt", true, ctx.cwd) ? "π compact" : "default chrome"}`,
+		`Statusline: ${settingBoolean("replaceFooter", true, ctx.cwd) ? "replaces footer" : "footer preserved"}; prompt=${settingBoolean("compactPrompt", true, ctx.cwd) ? `${glyphs(ctx.cwd).prompt} compact` : "default chrome"}`,
 		`shift+enter newline: ${settingBoolean("newlineOnShiftEnter", true, ctx.cwd) ? "enabled" : "disabled"}`,
 		`Fallback newline key: ${newlineFallbackKey(ctx.cwd)}`,
 		`Pending queue preview: ${settingBoolean("pendingQueue.asciiGreen", true, ctx.cwd) ? "ANSI green" : "Pi default"}`,

--- a/pi-extensions/pi-qol/extensions/qol/statusline.ts
+++ b/pi-extensions/pi-qol/extensions/qol/statusline.ts
@@ -5,6 +5,7 @@ import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import { subagentStatuslineMarker } from "./agent-statusline.js";
 import { stripAnsi } from "./ansi.js";
 import { readCavemanBridge } from "./bridges.js";
+import { glyphs } from "./glyphs.js";
 import { CAVEMAN_ICON_ACTIVE, CAVEMAN_ICON_INACTIVE } from "./constants.js";
 import { settingBoolean, settingNumber } from "./settings.js";
 
@@ -136,14 +137,14 @@ export function sessionNameHeader(width: number, pi: ExtensionAPI, theme: Pick<T
 	const prefixPlain = "Session ";
 	const prefix = theme.fg("muted", prefixPlain);
 	const innerWidth = Math.max(1, width - visibleWidth(prefixPlain) - 2);
-	const inner = truncateToWidth(name, innerWidth, "…");
+	const inner = truncateToWidth(name, innerWidth, glyphs().ellipsis);
 	const plain = ` ${inner} `;
 	const badge = theme.bg("selectedBg", theme.fg("text", plain));
 	return [truncateToWidth(`${prefix}${badge}`, width, "")];
 }
 
 export function formatTmuxSessionTitle(sessionName: string): string {
-	return `π ${sessionName}`;
+	return `${glyphs().prompt} ${sessionName}`;
 }
 
 export function tmuxPaneTarget(): string | undefined {
@@ -201,7 +202,7 @@ export function renderStatusLine(width: number, ctx: ExtensionContext, git: GitS
 	const cavemanSegment = caveman ? `${statusSeparator}${cavemanGlyph}` : "";
 	const contextSeparator = caveman ? ` ${statusSeparator}` : "";
 	const leftPlain = `${projectChunk}${statusSeparator}${thinkingChunk}${cavemanSegment}${contextSeparator}${contextChunk.trimStart()}`;
-	const percentPlain = percent === null ? "…%" : `${percent}%`;
+	const percentPlain = percent === null ? `${glyphs(ctx.cwd).ellipsis}%` : `${percent}%`;
 	const subagentMarker = subagentStatuslineMarker(ctx.cwd);
 	const rightPlain = subagentMarker ? `${percentPlain} ${subagentMarker.plain}` : percentPlain;
 	const percentColor = percent === null ? "muted" : percent <= 15 ? "error" : percent <= 30 ? "warning" : "success";
@@ -214,6 +215,6 @@ export function renderStatusLine(width: number, ctx: ExtensionContext, git: GitS
 	const gapWidth = Math.max(minimumGap, width - visibleWidth(leftPlain) - visibleWidth(rightPlain) - 2);
 	const filled = percent === null ? 0 : Math.round(gapWidth * (percent / 100));
 	const empty = Math.max(0, gapWidth - filled);
-	const bar = " ".repeat(empty) + theme.fg("warning", "─".repeat(filled));
+	const bar = " ".repeat(empty) + theme.fg("warning", glyphs(ctx.cwd).line.repeat(filled));
 	return truncateToWidth(`${leftColored} ${bar} ${right}`, width, "");
 }

--- a/pi-extensions/pi-qol/package.json
+++ b/pi-extensions/pi-qol/package.json
@@ -31,6 +31,19 @@
           "requiresReload": true
         },
         {
+          "key": "glyphStyle",
+          "label": "Glyph style",
+          "description": "Glyphs for vstack-owned UI chrome. Unicode is the default; ASCII uses plain box/status/separator characters for terminal compatibility. pi-tool-renderer's global override wins when set.",
+          "type": "enum",
+          "enumValues": [
+            "unicode",
+            "ascii"
+          ],
+          "default": "unicode",
+          "category": "Rendering",
+          "apply": "live"
+        },
+        {
           "key": "replaceFooter",
           "label": "Replace built-in footer",
           "description": "Hide Pi default footer while the compact QOL statusline is active.",

--- a/pi-extensions/pi-questions/README.md
+++ b/pi-extensions/pi-questions/README.md
@@ -83,6 +83,8 @@ Open `/extensions:settings`; settings appear under the **Questions** tab.
 | Default question header | Fallback title when a request has no header. |
 | Bridge replies enabled | Allow `pi-session-bridge` to answer/reject pending questions. |
 
+Glyph style: each package exposes `glyphStyle` (`unicode` default, `ascii` for terminal-safe chrome). `@vanillagreen/pi-tool-renderer.globalGlyphStyleOverride=ascii` forces ASCII chrome across vstack Pi extensions while leaving tool/model/user content unchanged.
+
 ## Bridge control
 
 Requires `pi-session-bridge`. From any shell:

--- a/pi-extensions/pi-questions/extensions/glyphs.ts
+++ b/pi-extensions/pi-questions/extensions/glyphs.ts
@@ -1,0 +1,122 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+export type GlyphStyle = "unicode" | "ascii";
+export type GlobalGlyphStyleOverride = "inherit" | GlyphStyle;
+
+const LOCAL_CONFIG_ID = "@vanillagreen/pi-questions";
+const GLOBAL_CONFIG_ID = "@vanillagreen/pi-tool-renderer";
+
+function expandHome(input: string): string {
+	if (input === "~") return homedir();
+	if (input.startsWith("~/")) return join(homedir(), input.slice(2));
+	return input;
+}
+
+function projectSettingsPath(cwd: string): string {
+	let current = resolve(cwd);
+	while (true) {
+		const candidate = join(current, ".pi", "settings.json");
+		if (existsSync(candidate)) return candidate;
+		if (existsSync(join(current, ".pi")) || existsSync(join(current, ".git")) || existsSync(join(current, ".vstack-lock.json"))) return candidate;
+		const parent = dirname(current);
+		if (parent === current) return join(resolve(cwd), ".pi", "settings.json");
+		current = parent;
+	}
+}
+
+function piSettingsPaths(cwd = process.cwd()): string[] {
+	const userDir = resolve(expandHome(process.env.PI_CODING_AGENT_DIR?.trim() || "~/.pi/agent"));
+	return [join(userDir, "settings.json"), projectSettingsPath(cwd)];
+}
+
+function readPackageConfig(packageId: string, cwd?: string): Record<string, unknown> {
+	const merged: Record<string, unknown> = {};
+	for (const settingsPath of piSettingsPaths(cwd)) {
+		if (!existsSync(settingsPath)) continue;
+		try {
+			const parsed = JSON.parse(readFileSync(settingsPath, "utf8"));
+			const config = parsed?.vstack?.extensionManager?.config?.[packageId];
+			if (config && typeof config === "object" && !Array.isArray(config)) Object.assign(merged, config);
+		} catch {
+			// Ignore malformed optional manager config.
+		}
+	}
+	return merged;
+}
+
+function asGlyphStyle(value: unknown): GlyphStyle | undefined {
+	return value === "unicode" || value === "ascii" ? value : undefined;
+}
+
+export function glyphStyle(cwd?: string): GlyphStyle {
+	const globalOverride = readPackageConfig(GLOBAL_CONFIG_ID, cwd).globalGlyphStyleOverride;
+	const forced = asGlyphStyle(globalOverride);
+	if (forced) return forced;
+	const local = readPackageConfig(LOCAL_CONFIG_ID, cwd);
+	return asGlyphStyle(local.glyphStyle) ?? asGlyphStyle(local.treeStyle) ?? "unicode";
+}
+
+export const GLYPHS = {
+	unicode: {
+		frame: { tl: "┏", tr: "┓", bl: "┗", br: "┛", h: "━", v: "┃" },
+		line: "─",
+		tree: { mid: "├─ ", last: "└─ ", stem: "│  ", blank: "   " },
+		bullet: "● ",
+		emptyBullet: "○ ",
+		dot: " · ",
+		ok: "✓",
+		fail: "✗",
+		warn: "▲",
+		diamond: "◆",
+		prompt: "π",
+		ellipsis: "…",
+		arrow: "→",
+		codeBar: "▌",
+	},
+	ascii: {
+		frame: { tl: "+", tr: "+", bl: "+", br: "+", h: "-", v: "|" },
+		line: "-",
+		tree: { mid: "|-- ", last: "`-- ", stem: "|  ", blank: "   " },
+		bullet: "* ",
+		emptyBullet: "o ",
+		dot: " - ",
+		ok: "+",
+		fail: "x",
+		warn: "!",
+		diamond: "*",
+		prompt: "pi",
+		ellipsis: "...",
+		arrow: "->",
+		codeBar: "|",
+	},
+} as const;
+
+export function glyphs(cwd?: string): (typeof GLYPHS)[GlyphStyle] {
+	return GLYPHS[glyphStyle(cwd)];
+}
+
+export function truncateIndicator(cwd?: string): string {
+	return glyphs(cwd).ellipsis;
+}
+
+export function truncateText(text: string, maxChars: number, cwd?: string): string {
+	if (text.length <= maxChars) return text;
+	const indicator = truncateIndicator(cwd);
+	return `${text.slice(0, Math.max(0, maxChars - indicator.length))}${indicator}`;
+}
+
+export function dot(cwd?: string): string {
+	return glyphs(cwd).dot;
+}
+
+export function treeGlyph(branch: "├" | "└" | "│", cwd?: string): string {
+	const tree = glyphs(cwd).tree;
+	if (branch === "│") return tree.stem;
+	return branch === "└" ? tree.last : tree.mid;
+}
+
+export function frameGlyphs(cwd?: string): (typeof GLYPHS)[GlyphStyle]["frame"] {
+	return glyphs(cwd).frame;
+}

--- a/pi-extensions/pi-questions/extensions/questions.ts
+++ b/pi-extensions/pi-questions/extensions/questions.ts
@@ -17,6 +17,7 @@ import { homedir, tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 
 import { publishQuestionActivity } from "./activity.js";
+import { frameGlyphs, glyphs, treeGlyph } from "./glyphs.js";
 
 const INSTALL_SYMBOL = Symbol.for("vstack.pi-questions.installed");
 const CONFIG_ID = "@vanillagreen/pi-questions";
@@ -205,7 +206,7 @@ function formatQuestionTruncationNotice(truncation: TruncationResult, fullOutput
 function sanitizeDetailValue(value: unknown, depth = 0): unknown {
 	if (depth > 4) return "[Max detail depth reached]";
 	if (value == null || typeof value === "number" || typeof value === "boolean") return value;
-	if (typeof value === "string") return value.length > 8 * 1024 ? `${value.slice(0, 8 * 1024)}… [detail string truncated]` : value;
+	if (typeof value === "string") return value.length > 8 * 1024 ? `${value.slice(0, 8 * 1024)}${glyphs().ellipsis} [detail string truncated]` : value;
 	if (Array.isArray(value)) return value.slice(0, 50).map((item) => sanitizeDetailValue(item, depth + 1));
 	if (typeof value === "object") {
 		const out: Record<string, unknown> = {};
@@ -330,24 +331,25 @@ function framePopup(lines: string[], width: number, theme: Theme, title = "", ri
 	if (width < 8) return lines.map((line) => truncateToWidth(line, width, ""));
 
 	const border = (text: string) => theme.fg("borderAccent", text);
+	const frame = frameGlyphs();
 	const contentWidth = popupContentWidth(width);
-	const blank = `${border("┃")}${" ".repeat(width - 2)}${border("┃")}`;
+	const blank = `${border(frame.v)}${" ".repeat(width - 2)}${border(frame.v)}`;
 	const top = () => {
-		if (!title) return `${border("┏")}${border("━".repeat(width - 2))}${border("┓")}`;
+		if (!title) return `${border(frame.tl)}${border(frame.h.repeat(width - 2))}${border(frame.tr)}`;
 		const rightPlain = right ? ` ${right} ` : "";
 		const titleBudget = Math.max(1, width - 2 - visibleWidth(rightPlain) - 1);
-		const titlePlain = ` ${truncateToWidth(title, Math.max(1, titleBudget - 2), "…")} `;
+		const titlePlain = ` ${truncateToWidth(title, Math.max(1, titleBudget - 2), glyphs().ellipsis)} `;
 		const fill = Math.max(1, width - 2 - visibleWidth(titlePlain) - visibleWidth(rightPlain));
-		return `${border("┏")}${ansiGreen(titlePlain)}${border("━".repeat(fill))}${right ? theme.fg("dim", rightPlain) : ""}${border("┓")}`;
+		return `${border(frame.tl)}${ansiGreen(titlePlain)}${border(frame.h.repeat(fill))}${right ? theme.fg("dim", rightPlain) : ""}${border(frame.tr)}`;
 	};
 	const framed = [top()];
 
 	for (let i = 0; i < PADDING_Y; i += 1) framed.push(blank);
 	for (const line of lines) {
-		framed.push(`${border("┃")}${" ".repeat(PADDING_X)}${padAnsi(line, contentWidth)}${" ".repeat(PADDING_X)}${border("┃")}`);
+		framed.push(`${border(frame.v)}${" ".repeat(PADDING_X)}${padAnsi(line, contentWidth)}${" ".repeat(PADDING_X)}${border(frame.v)}`);
 	}
 	for (let i = 0; i < PADDING_Y; i += 1) framed.push(blank);
-	framed.push(`${border("┗")}${border("━".repeat(width - 2))}${border("┛")}`);
+	framed.push(`${border(frame.bl)}${border(frame.h.repeat(width - 2))}${border(frame.br)}`);
 	return framed.map((line) => truncateToWidth(line, width, ""));
 }
 
@@ -405,7 +407,7 @@ function wrapPlain(text: string, width: number, maxLines = 3): string[] {
 	}
 	if (current && lines.length < maxLines) lines.push(current);
 	if (lines.length === maxLines && words.join(" ").length > lines.join(" ").length) {
-		lines[maxLines - 1] = truncateToWidth(`${lines[maxLines - 1]}…`, width, "");
+		lines[maxLines - 1] = truncateToWidth(`${lines[maxLines - 1]}${glyphs().ellipsis}`, width, "");
 	}
 	return lines.length > 0 ? lines : [""];
 }
@@ -428,18 +430,18 @@ function renderCompactAnswerLines(request: QuestionRequest | undefined, answers:
 		const tab = request?.questions[index];
 		const labelText = tab?.header ?? `Q${index + 1}`;
 		const answerText = formatAnswers(answers[index]);
-		const label = `  ${theme.fg("muted", "•")} ${theme.fg("accent", `${labelText}: `)}`;
+		const label = `  ${theme.fg("muted", glyphs().bullet.trim())} ${theme.fg("accent", `${labelText}: `)}`;
 		lines.push(...wrapStyled(label, theme.fg("text", answerText), width));
 	}
 	return lines;
 }
 
 function answerBranch(theme: Theme, last: boolean): string {
-	return theme.fg("muted", last ? "  └─ " : "  ├─ ");
+	return theme.fg("muted", `  ${treeGlyph(last ? "└" : "├")}`);
 }
 
 function answerStem(theme: Theme, last: boolean): string {
-	return theme.fg("muted", last ? "     " : "  │  ");
+	return theme.fg("muted", last ? "     " : `  ${treeGlyph("│")}`);
 }
 
 function optionIcon(selected: boolean, theme: Theme): string {
@@ -900,7 +902,7 @@ async function openQuestionUi(ctx: ExtensionContext, pending: PendingQuestion): 
 				const lines = [panelLine(theme.fg("text", "Review answers, then press enter to submit."), width), panelLine("", width)];
 				for (const [index, question] of request.questions.entries()) {
 					const answerText = formatAnswers(currentAnswers[index]);
-					const label = `  ${theme.fg("muted", "•")} ${theme.fg("accent", `${question.header}: `)}`;
+					const label = `  ${theme.fg("muted", glyphs().bullet.trim())} ${theme.fg("accent", `${question.header}: `)}`;
 					lines.push(...wrapStyled(label, theme.fg("text", answerText), width, 4).map((line) => panelLine(line, width)));
 				}
 				return lines;
@@ -1113,9 +1115,9 @@ export default function questions(pi: ExtensionAPI): void {
 					catch { return undefined; }
 				})();
 				const title = request?.header ?? "Question";
-				const prefix = details && "answers" in details ? theme.fg("success", "● ") : theme.fg("warning", "● ");
+				const prefix = details && "answers" in details ? theme.fg("success", glyphs().bullet) : theme.fg("warning", glyphs().bullet);
 				const state = details && "answers" in details ? theme.fg("success", "answered") : theme.fg("warning", "cancelled");
-				const expandHint = details && "answers" in details && !options?.expanded ? theme.fg("dim", " · ctrl+o to expand") : "";
+				const expandHint = details && "answers" in details && !options?.expanded ? theme.fg("dim", `${glyphs().dot}ctrl+o to expand`) : "";
 				const head = `${prefix}${theme.fg("toolTitle", theme.bold("Question"))} ${state}${title ? ` ${theme.fg("muted", "—")} ${theme.fg("text", title)}` : ""}${expandHint}`;
 				if (!details || !("answers" in details)) return [head];
 

--- a/pi-extensions/pi-questions/package.json
+++ b/pi-extensions/pi-questions/package.json
@@ -48,6 +48,19 @@
           "requiresReload": true
         },
         {
+          "key": "glyphStyle",
+          "label": "Glyph style",
+          "description": "Glyphs for vstack-owned UI chrome. Unicode is the default; ASCII uses plain box/status/separator characters for terminal compatibility. pi-tool-renderer's global override wins when set.",
+          "type": "enum",
+          "enumValues": [
+            "unicode",
+            "ascii"
+          ],
+          "default": "unicode",
+          "category": "Rendering",
+          "apply": "live"
+        },
+        {
           "key": "renderMode",
           "label": "Question UI mode",
           "description": "Where interactive questions render: editor replaces the input area; overlay restores the floating popup.",

--- a/pi-extensions/pi-session-manager/README.md
+++ b/pi-extensions/pi-session-manager/README.md
@@ -53,6 +53,8 @@ Open `/extensions:settings`; settings appear under the **Session Manager** tab.
 | Overlay width | Preferred width in terminal columns. |
 | Use trash for delete | Try `trash` before permanent unlink. |
 
+Glyph style: each package exposes `glyphStyle` (`unicode` default, `ascii` for terminal-safe chrome). `@vanillagreen/pi-tool-renderer.globalGlyphStyleOverride=ascii` forces ASCII chrome across vstack Pi extensions while leaving tool/model/user content unchanged.
+
 ## Notes
 
 Pi's built-in `/resume`, `/tree`, `/fork`, `/clone`, and `/name` remain available.

--- a/pi-extensions/pi-session-manager/extensions/glyphs.ts
+++ b/pi-extensions/pi-session-manager/extensions/glyphs.ts
@@ -1,0 +1,122 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+export type GlyphStyle = "unicode" | "ascii";
+export type GlobalGlyphStyleOverride = "inherit" | GlyphStyle;
+
+const LOCAL_CONFIG_ID = "@vanillagreen/pi-session-manager";
+const GLOBAL_CONFIG_ID = "@vanillagreen/pi-tool-renderer";
+
+function expandHome(input: string): string {
+	if (input === "~") return homedir();
+	if (input.startsWith("~/")) return join(homedir(), input.slice(2));
+	return input;
+}
+
+function projectSettingsPath(cwd: string): string {
+	let current = resolve(cwd);
+	while (true) {
+		const candidate = join(current, ".pi", "settings.json");
+		if (existsSync(candidate)) return candidate;
+		if (existsSync(join(current, ".pi")) || existsSync(join(current, ".git")) || existsSync(join(current, ".vstack-lock.json"))) return candidate;
+		const parent = dirname(current);
+		if (parent === current) return join(resolve(cwd), ".pi", "settings.json");
+		current = parent;
+	}
+}
+
+function piSettingsPaths(cwd = process.cwd()): string[] {
+	const userDir = resolve(expandHome(process.env.PI_CODING_AGENT_DIR?.trim() || "~/.pi/agent"));
+	return [join(userDir, "settings.json"), projectSettingsPath(cwd)];
+}
+
+function readPackageConfig(packageId: string, cwd?: string): Record<string, unknown> {
+	const merged: Record<string, unknown> = {};
+	for (const settingsPath of piSettingsPaths(cwd)) {
+		if (!existsSync(settingsPath)) continue;
+		try {
+			const parsed = JSON.parse(readFileSync(settingsPath, "utf8"));
+			const config = parsed?.vstack?.extensionManager?.config?.[packageId];
+			if (config && typeof config === "object" && !Array.isArray(config)) Object.assign(merged, config);
+		} catch {
+			// Ignore malformed optional manager config.
+		}
+	}
+	return merged;
+}
+
+function asGlyphStyle(value: unknown): GlyphStyle | undefined {
+	return value === "unicode" || value === "ascii" ? value : undefined;
+}
+
+export function glyphStyle(cwd?: string): GlyphStyle {
+	const globalOverride = readPackageConfig(GLOBAL_CONFIG_ID, cwd).globalGlyphStyleOverride;
+	const forced = asGlyphStyle(globalOverride);
+	if (forced) return forced;
+	const local = readPackageConfig(LOCAL_CONFIG_ID, cwd);
+	return asGlyphStyle(local.glyphStyle) ?? asGlyphStyle(local.treeStyle) ?? "unicode";
+}
+
+export const GLYPHS = {
+	unicode: {
+		frame: { tl: "┏", tr: "┓", bl: "┗", br: "┛", h: "━", v: "┃" },
+		line: "─",
+		tree: { mid: "├─ ", last: "└─ ", stem: "│  ", blank: "   " },
+		bullet: "● ",
+		emptyBullet: "○ ",
+		dot: " · ",
+		ok: "✓",
+		fail: "✗",
+		warn: "▲",
+		diamond: "◆",
+		prompt: "π",
+		ellipsis: "…",
+		arrow: "→",
+		codeBar: "▌",
+	},
+	ascii: {
+		frame: { tl: "+", tr: "+", bl: "+", br: "+", h: "-", v: "|" },
+		line: "-",
+		tree: { mid: "|-- ", last: "`-- ", stem: "|  ", blank: "   " },
+		bullet: "* ",
+		emptyBullet: "o ",
+		dot: " - ",
+		ok: "+",
+		fail: "x",
+		warn: "!",
+		diamond: "*",
+		prompt: "pi",
+		ellipsis: "...",
+		arrow: "->",
+		codeBar: "|",
+	},
+} as const;
+
+export function glyphs(cwd?: string): (typeof GLYPHS)[GlyphStyle] {
+	return GLYPHS[glyphStyle(cwd)];
+}
+
+export function truncateIndicator(cwd?: string): string {
+	return glyphs(cwd).ellipsis;
+}
+
+export function truncateText(text: string, maxChars: number, cwd?: string): string {
+	if (text.length <= maxChars) return text;
+	const indicator = truncateIndicator(cwd);
+	return `${text.slice(0, Math.max(0, maxChars - indicator.length))}${indicator}`;
+}
+
+export function dot(cwd?: string): string {
+	return glyphs(cwd).dot;
+}
+
+export function treeGlyph(branch: "├" | "└" | "│", cwd?: string): string {
+	const tree = glyphs(cwd).tree;
+	if (branch === "│") return tree.stem;
+	return branch === "└" ? tree.last : tree.mid;
+}
+
+export function frameGlyphs(cwd?: string): (typeof GLYPHS)[GlyphStyle]["frame"] {
+	return glyphs(cwd).frame;
+}

--- a/pi-extensions/pi-session-manager/extensions/overlay.ts
+++ b/pi-extensions/pi-session-manager/extensions/overlay.ts
@@ -8,6 +8,7 @@ import { isNamed, sessionResumeTitle, sessionUserMessagesCache } from "./session
 import { settingNumber, settingScope, settingSort } from "./settings.js";
 import { ansiGreen, ansiRed, ansiYellow, centerAnsi, formatAge, oneLine, padAnsi, shortenPath } from "./text.js";
 import { buildSessionTree, flattenSessionTree, rowTreePrefix } from "./tree.js";
+import { frameGlyphs, glyphs } from "./glyphs.js";
 import {
 	DEFAULT_ROWS,
 	DEFAULT_WIDTH,
@@ -522,6 +523,7 @@ class SessionManagerOverlay implements Focusable {
 		const warning = (s: string) => th.fg("warning", s);
 		const error = (s: string) => th.fg("error", s);
 		const success = (s: string) => th.fg("success", s);
+		const frame = frameGlyphs();
 
 		const fixed = (content = "", rowWidth = bodyWidth): string => {
 			const safe = content.replace(/[\r\n\t]+/g, " ");
@@ -531,14 +533,14 @@ class SessionManagerOverlay implements Focusable {
 		const top = (title: string, right = "") => {
 			const rightPlain = right ? ` ${right} ` : "";
 			const titleBudget = Math.max(1, frameInner - visibleWidth(rightPlain) - 1);
-			const titlePlain = ` ${truncateToWidth(title, Math.max(1, titleBudget - 2), "…")} `;
+			const titlePlain = ` ${truncateToWidth(title, Math.max(1, titleBudget - 2), glyphs().ellipsis)} `;
 			const fill = Math.max(1, frameInner - visibleWidth(titlePlain) - visibleWidth(rightPlain));
-			return `${border("┏")}${ansiGreen(titlePlain)}${border("━".repeat(fill))}${right ? dim(rightPlain) : ""}${border("┓")}`;
+			return `${border(frame.tl)}${ansiGreen(titlePlain)}${border(frame.h.repeat(fill))}${right ? dim(rightPlain) : ""}${border(frame.tr)}`;
 		};
-		const blank = () => border("┃") + " ".repeat(frameInner) + border("┃");
-		const row = (content = "") => border("┃") + " ".repeat(POPUP_PADDING_X) + fixed(content) + " ".repeat(POPUP_PADDING_X) + border("┃");
-		const filledRow = (content = "") => border("┃") + " ".repeat(POPUP_PADDING_X) + th.bg("toolPendingBg", fixed(content)) + " ".repeat(POPUP_PADDING_X) + border("┃");
-		const divider = () => row(muted("━".repeat(bodyWidth)));
+		const blank = () => border(frame.v) + " ".repeat(frameInner) + border(frame.v);
+		const row = (content = "") => border(frame.v) + " ".repeat(POPUP_PADDING_X) + fixed(content) + " ".repeat(POPUP_PADDING_X) + border(frame.v);
+		const filledRow = (content = "") => border(frame.v) + " ".repeat(POPUP_PADDING_X) + th.bg("toolPendingBg", fixed(content)) + " ".repeat(POPUP_PADDING_X) + border(frame.v);
+		const divider = () => row(muted(frame.h.repeat(bodyWidth)));
 		const lines: string[] = [];
 
 		lines.push(top("Session Manager", `${this.filtered.length}/${this.sessions.length} shown`));
@@ -552,7 +554,7 @@ class SessionManagerOverlay implements Focusable {
 			const targetRows = Math.max(10, this.maxPopupRows() - rowsBeforeConfirmBody - rowsAfterConfirmBody);
 			lines.push(...this.renderDeleteConfirmationRows(bodyWidth, targetRows, { row, dim, muted, accent, warning, error, border }));
 			for (let i = 0; i < POPUP_PADDING_Y; i++) lines.push(blank());
-			lines.push(border(`┗${"━".repeat(frameInner)}┛`));
+			lines.push(border(`${frame.bl}${frame.h.repeat(frameInner)}${frame.br}`));
 			return lines.map((line) => truncateToWidth(line, renderWidth, ""));
 		}
 
@@ -562,7 +564,7 @@ class SessionManagerOverlay implements Focusable {
 			const targetRows = Math.max(12, this.maxPopupRows() - rowsBeforeConfirmBody - rowsAfterConfirmBody);
 			lines.push(...this.renderModelConfirmationRows(bodyWidth, targetRows, { row, dim, muted, accent, warning }));
 			for (let i = 0; i < POPUP_PADDING_Y; i++) lines.push(blank());
-			lines.push(border(`┗${"━".repeat(frameInner)}┛`));
+			lines.push(border(`${frame.bl}${frame.h.repeat(frameInner)}${frame.br}`));
 			return lines.map((line) => truncateToWidth(line, renderWidth, ""));
 		}
 
@@ -572,7 +574,7 @@ class SessionManagerOverlay implements Focusable {
 
 		if (this.mode === "loading") {
 			const progress = this.loadingProgress ? ` ${this.loadingProgress.loaded}/${this.loadingProgress.total}` : "";
-			lines.push(row(dim(`Loading sessions${progress}…`)));
+			lines.push(row(dim(`Loading sessions${progress}${glyphs().ellipsis}`)));
 			for (let i = 1; i < this.visibleRows; i++) lines.push(row(""));
 		} else {
 			lines.push(...this.renderListRows(bodyWidth, { row, fixed, dim, muted, accent, warning, error }));
@@ -583,7 +585,7 @@ class SessionManagerOverlay implements Focusable {
 		lines.push(row(""));
 		for (const footerLine of this.renderFooter(bodyWidth, dim, warning, error)) lines.push(row(footerLine));
 		for (let i = 0; i < POPUP_PADDING_Y; i++) lines.push(blank());
-		lines.push(border(`┗${"━".repeat(frameInner)}┛`));
+		lines.push(border(`${frame.bl}${frame.h.repeat(frameInner)}${frame.br}`));
 		return lines.map((line) => truncateToWidth(line, renderWidth, ""));
 	}
 

--- a/pi-extensions/pi-session-manager/package.json
+++ b/pi-extensions/pi-session-manager/package.json
@@ -31,6 +31,19 @@
           "requiresReload": true
         },
         {
+          "key": "glyphStyle",
+          "label": "Glyph style",
+          "description": "Glyphs for vstack-owned UI chrome. Unicode is the default; ASCII uses plain box/status/separator characters for terminal compatibility. pi-tool-renderer's global override wins when set.",
+          "type": "enum",
+          "enumValues": [
+            "unicode",
+            "ascii"
+          ],
+          "default": "unicode",
+          "category": "Rendering",
+          "apply": "live"
+        },
+        {
           "key": "shortcutKey",
           "label": "Manager shortcut",
           "description": "Keyboard shortcut that opens the session manager popup. Set to none to disable.",

--- a/pi-extensions/pi-skills-manager/README.md
+++ b/pi-extensions/pi-skills-manager/README.md
@@ -57,6 +57,8 @@ Open `/extensions:settings`; settings appear under the **Skills Manager** tab.
 | Popup max height | Number of rows or percentage. |
 | Visible list rows | Maximum rows shown before scrolling; short terminals shrink this so controls remain visible. |
 
+Glyph style: each package exposes `glyphStyle` (`unicode` default, `ascii` for terminal-safe chrome). `@vanillagreen/pi-tool-renderer.globalGlyphStyleOverride=ascii` forces ASCII chrome across vstack Pi extensions while leaving tool/model/user content unchanged.
+
 ## Notes
 
 Native `/skill:<name>` registration is controlled by Pi's `enableSkillCommands` setting (`/settings` → **Skill commands**). This manager doesn't change it.

--- a/pi-extensions/pi-skills-manager/extensions/skills-manager/components.ts
+++ b/pi-extensions/pi-skills-manager/extensions/skills-manager/components.ts
@@ -15,6 +15,7 @@ import {
 } from "@earendil-works/pi-tui";
 import { getMarkdownTheme, type Theme } from "@earendil-works/pi-coding-agent";
 import { buildFrontmatterBlock } from "./format.js";
+import { glyphs } from "./glyphs.js";
 import { isDeletableSkill } from "./registry.js";
 import {
 	getEditorTheme,
@@ -79,7 +80,7 @@ export class ScrollableSkillPreview implements Component {
 		const status = this.skill.enabled ? this.theme.fg("success", "enabled") : this.theme.fg("warning", "disabled");
 		const source = packageLabel(this.skill) ? `${packageLabel(this.skill)}` : this.skill.path;
 		content.addChild(new Text(skillEntityTitle(this.theme, this.skill.name), 0, 0));
-		content.addChild(new Text(`${this.theme.fg("muted", scopeLabel(this.skill))}${this.theme.fg("dim", " • ")}${this.theme.fg("muted", source)}${this.theme.fg("dim", " • ")}${status}`, 0, 0));
+		content.addChild(new Text(`${this.theme.fg("muted", scopeLabel(this.skill))}${this.theme.fg("dim", ` ${glyphs().bullet.trim()} `)}${this.theme.fg("muted", source)}${this.theme.fg("dim", ` ${glyphs().bullet.trim()} `)}${status}`, 0, 0));
 		content.addChild(new Spacer(1));
 		content.addChild(new Text(this.theme.fg("muted", this.theme.bold("Description")), 0, 0));
 		content.addChild(new Text(this.skill.description, 0, 0));
@@ -97,7 +98,7 @@ export class ScrollableSkillPreview implements Component {
 	}
 	private footer(innerWidth: number, visibleHeight: number, totalLines: number): string {
 		const maxScroll = Math.max(0, totalLines - visibleHeight);
-		const scroll = maxScroll > 0 ? this.theme.fg("dim", ` • ${this.scrollOffset + 1}-${Math.min(totalLines, this.scrollOffset + visibleHeight)}/${totalLines}`) : "";
+		const scroll = maxScroll > 0 ? this.theme.fg("dim", ` ${glyphs().bullet.trim()} ${this.scrollOffset + 1}-${Math.min(totalLines, this.scrollOffset + visibleHeight)}/${totalLines}`) : "";
 		const hints: Array<[string, string]> = [["-/=", "page"]];
 		hints.push(["alt+x", "enable/disable"]);
 		if (isDeletableSkill(this.skill)) hints.push(["alt+e", "edit"], ["alt+r", "rename"], ["backspace", "delete"]);

--- a/pi-extensions/pi-skills-manager/extensions/skills-manager/glyphs.ts
+++ b/pi-extensions/pi-skills-manager/extensions/skills-manager/glyphs.ts
@@ -1,0 +1,122 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+export type GlyphStyle = "unicode" | "ascii";
+export type GlobalGlyphStyleOverride = "inherit" | GlyphStyle;
+
+const LOCAL_CONFIG_ID = "@vanillagreen/pi-skills-manager";
+const GLOBAL_CONFIG_ID = "@vanillagreen/pi-tool-renderer";
+
+function expandHome(input: string): string {
+	if (input === "~") return homedir();
+	if (input.startsWith("~/")) return join(homedir(), input.slice(2));
+	return input;
+}
+
+function projectSettingsPath(cwd: string): string {
+	let current = resolve(cwd);
+	while (true) {
+		const candidate = join(current, ".pi", "settings.json");
+		if (existsSync(candidate)) return candidate;
+		if (existsSync(join(current, ".pi")) || existsSync(join(current, ".git")) || existsSync(join(current, ".vstack-lock.json"))) return candidate;
+		const parent = dirname(current);
+		if (parent === current) return join(resolve(cwd), ".pi", "settings.json");
+		current = parent;
+	}
+}
+
+function piSettingsPaths(cwd = process.cwd()): string[] {
+	const userDir = resolve(expandHome(process.env.PI_CODING_AGENT_DIR?.trim() || "~/.pi/agent"));
+	return [join(userDir, "settings.json"), projectSettingsPath(cwd)];
+}
+
+function readPackageConfig(packageId: string, cwd?: string): Record<string, unknown> {
+	const merged: Record<string, unknown> = {};
+	for (const settingsPath of piSettingsPaths(cwd)) {
+		if (!existsSync(settingsPath)) continue;
+		try {
+			const parsed = JSON.parse(readFileSync(settingsPath, "utf8"));
+			const config = parsed?.vstack?.extensionManager?.config?.[packageId];
+			if (config && typeof config === "object" && !Array.isArray(config)) Object.assign(merged, config);
+		} catch {
+			// Ignore malformed optional manager config.
+		}
+	}
+	return merged;
+}
+
+function asGlyphStyle(value: unknown): GlyphStyle | undefined {
+	return value === "unicode" || value === "ascii" ? value : undefined;
+}
+
+export function glyphStyle(cwd?: string): GlyphStyle {
+	const globalOverride = readPackageConfig(GLOBAL_CONFIG_ID, cwd).globalGlyphStyleOverride;
+	const forced = asGlyphStyle(globalOverride);
+	if (forced) return forced;
+	const local = readPackageConfig(LOCAL_CONFIG_ID, cwd);
+	return asGlyphStyle(local.glyphStyle) ?? asGlyphStyle(local.treeStyle) ?? "unicode";
+}
+
+export const GLYPHS = {
+	unicode: {
+		frame: { tl: "┏", tr: "┓", bl: "┗", br: "┛", h: "━", v: "┃" },
+		line: "─",
+		tree: { mid: "├─ ", last: "└─ ", stem: "│  ", blank: "   " },
+		bullet: "● ",
+		emptyBullet: "○ ",
+		dot: " · ",
+		ok: "✓",
+		fail: "✗",
+		warn: "▲",
+		diamond: "◆",
+		prompt: "π",
+		ellipsis: "…",
+		arrow: "→",
+		codeBar: "▌",
+	},
+	ascii: {
+		frame: { tl: "+", tr: "+", bl: "+", br: "+", h: "-", v: "|" },
+		line: "-",
+		tree: { mid: "|-- ", last: "`-- ", stem: "|  ", blank: "   " },
+		bullet: "* ",
+		emptyBullet: "o ",
+		dot: " - ",
+		ok: "+",
+		fail: "x",
+		warn: "!",
+		diamond: "*",
+		prompt: "pi",
+		ellipsis: "...",
+		arrow: "->",
+		codeBar: "|",
+	},
+} as const;
+
+export function glyphs(cwd?: string): (typeof GLYPHS)[GlyphStyle] {
+	return GLYPHS[glyphStyle(cwd)];
+}
+
+export function truncateIndicator(cwd?: string): string {
+	return glyphs(cwd).ellipsis;
+}
+
+export function truncateText(text: string, maxChars: number, cwd?: string): string {
+	if (text.length <= maxChars) return text;
+	const indicator = truncateIndicator(cwd);
+	return `${text.slice(0, Math.max(0, maxChars - indicator.length))}${indicator}`;
+}
+
+export function dot(cwd?: string): string {
+	return glyphs(cwd).dot;
+}
+
+export function treeGlyph(branch: "├" | "└" | "│", cwd?: string): string {
+	const tree = glyphs(cwd).tree;
+	if (branch === "│") return tree.stem;
+	return branch === "└" ? tree.last : tree.mid;
+}
+
+export function frameGlyphs(cwd?: string): (typeof GLYPHS)[GlyphStyle]["frame"] {
+	return glyphs(cwd).frame;
+}

--- a/pi-extensions/pi-skills-manager/extensions/skills-manager/ui.ts
+++ b/pi-extensions/pi-skills-manager/extensions/skills-manager/ui.ts
@@ -1,6 +1,7 @@
 import type { Theme } from "@earendil-works/pi-coding-agent";
 import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import { ansiGreen, ansiYellow, VSTACK_MODAL_LOCK_SYMBOL } from "./constants.js";
+import { frameGlyphs, glyphs } from "./glyphs.js";
 import type { MessageTone, SkillEntry, VstackModalLock } from "./types.js";
 
 export function inlineLine(text: string): string {
@@ -48,12 +49,13 @@ export function skillSelectedLine(theme: Theme, line: string, width: number): st
 export function skillKeyHints(theme: Theme, hints: Array<[key: string, description: string]>): string {
 	return hints
 		.map(([key, description]) => `${ansiYellow(key)} ${theme.fg("dim", description)}`)
-		.join(theme.fg("dim", " • "));
+		.join(theme.fg("dim", ` ${glyphs().bullet.trim()} `));
 }
 
 function frameLine(theme: Theme, line: string, innerWidth: number): string {
 	const clipped = truncateToWidth(inlineLine(line), innerWidth, theme.fg("dim", "..."));
-	return `${theme.fg("borderAccent", "┃ ")}${padAnsi(clipped, innerWidth)}${theme.fg("borderAccent", " ┃")}`;
+	const frame = frameGlyphs();
+	return `${theme.fg("borderAccent", `${frame.v} `)}${padAnsi(clipped, innerWidth)}${theme.fg("borderAccent", ` ${frame.v}`)}`;
 }
 
 function fitFrameBody(theme: Theme, lines: string[], fixedInnerRows?: number): string[] {
@@ -71,19 +73,20 @@ export function renderFrame(theme: Theme, width: number, lines: string[], fixedI
 	const body = fitFrameBody(theme, lines, fixedInnerRows);
 	if (width < 6) return body.map((line) => truncateToWidth(inlineLine(line), width, ""));
 	const innerWidth = Math.max(1, width - 4);
+	const frame = frameGlyphs();
 	const top = () => {
 		const contentWidth = innerWidth + 2;
-		if (!title && !right) return theme.fg("borderAccent", `┏${"━".repeat(contentWidth)}┓`);
+		if (!title && !right) return theme.fg("borderAccent", `${frame.tl}${frame.h.repeat(contentWidth)}${frame.tr}`);
 		const rightPlain = right ? ` ${right} ` : "";
 		const titleBudget = Math.max(1, contentWidth - visibleWidth(rightPlain) - 1);
-		const titlePlain = title ? ` ${truncateToWidth(title, Math.max(1, titleBudget - 2), "…")} ` : "";
+		const titlePlain = title ? ` ${truncateToWidth(title, Math.max(1, titleBudget - 2), glyphs().ellipsis)} ` : "";
 		const fill = Math.max(1, contentWidth - visibleWidth(titlePlain) - visibleWidth(rightPlain));
-		return `${theme.fg("borderAccent", "┏")}${titlePlain ? ansiGreen(titlePlain) : ""}${theme.fg("borderAccent", "━".repeat(fill))}${rightPlain ? theme.fg("dim", rightPlain) : ""}${theme.fg("borderAccent", "┓")}`;
+		return `${theme.fg("borderAccent", frame.tl)}${titlePlain ? ansiGreen(titlePlain) : ""}${theme.fg("borderAccent", frame.h.repeat(fill))}${rightPlain ? theme.fg("dim", rightPlain) : ""}${theme.fg("borderAccent", frame.tr)}`;
 	};
 	return [
 		top(),
 		...body.map((line) => frameLine(theme, line, innerWidth)),
-		theme.fg("borderAccent", `┗${"━".repeat(innerWidth + 2)}┛`),
+		theme.fg("borderAccent", `${frame.bl}${frame.h.repeat(innerWidth + 2)}${frame.br}`),
 	].map((line) => truncateToWidth(inlineLine(line), width, ""));
 }
 
@@ -96,10 +99,11 @@ function centerLines(lines: string[], width: number): string[] {
 export function renderCenteredDialog(theme: Theme, width: number, lines: string[], maxInnerWidth = 68): string[] {
 	if (width < 8) return lines.map((line) => truncateToWidth(line, width, ""));
 	const innerWidth = Math.max(1, Math.min(width - 4, maxInnerWidth));
+	const frame = frameGlyphs();
 	const framed = [
-		theme.fg("borderAccent", `┏${"━".repeat(innerWidth + 2)}┓`),
+		theme.fg("borderAccent", `${frame.tl}${frame.h.repeat(innerWidth + 2)}${frame.tr}`),
 		...lines.map((line) => frameLine(theme, line, innerWidth)),
-		theme.fg("borderAccent", `┗${"━".repeat(innerWidth + 2)}┛`),
+		theme.fg("borderAccent", `${frame.bl}${frame.h.repeat(innerWidth + 2)}${frame.br}`),
 	];
 	return centerLines(framed, width);
 }

--- a/pi-extensions/pi-skills-manager/package.json
+++ b/pi-extensions/pi-skills-manager/package.json
@@ -34,6 +34,19 @@
           "requiresReload": true
         },
         {
+          "key": "glyphStyle",
+          "label": "Glyph style",
+          "description": "Glyphs for vstack-owned UI chrome. Unicode is the default; ASCII uses plain box/status/separator characters for terminal compatibility. pi-tool-renderer's global override wins when set.",
+          "type": "enum",
+          "enumValues": [
+            "unicode",
+            "ascii"
+          ],
+          "default": "unicode",
+          "category": "Rendering",
+          "apply": "live"
+        },
+        {
           "key": "hideStartupSkillsBlock",
           "label": "Hide startup skills block",
           "description": "Hide Pi's built-in startup [Skills] list so skills are managed through the dedicated menu instead.",

--- a/pi-extensions/pi-task-panel/README.md
+++ b/pi-extensions/pi-task-panel/README.md
@@ -75,6 +75,8 @@ The panel toggle cycles visible modes and hides the panel; toggling back in rest
 
 Open `/extensions:settings`; settings appear under the **Task Panel** tab.
 
+Glyph style: each package exposes `glyphStyle` (`unicode` default, `ascii` for terminal-safe chrome). `@vanillagreen/pi-tool-renderer.globalGlyphStyleOverride=ascii` forces ASCII chrome across vstack Pi extensions while leaving tool/model/user content unchanged.
+
 ### Panel
 
 | Setting | What it does |

--- a/pi-extensions/pi-task-panel/extensions/glyphs.ts
+++ b/pi-extensions/pi-task-panel/extensions/glyphs.ts
@@ -1,0 +1,122 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+export type GlyphStyle = "unicode" | "ascii";
+export type GlobalGlyphStyleOverride = "inherit" | GlyphStyle;
+
+const LOCAL_CONFIG_ID = "@vanillagreen/pi-task-panel";
+const GLOBAL_CONFIG_ID = "@vanillagreen/pi-tool-renderer";
+
+function expandHome(input: string): string {
+	if (input === "~") return homedir();
+	if (input.startsWith("~/")) return join(homedir(), input.slice(2));
+	return input;
+}
+
+function projectSettingsPath(cwd: string): string {
+	let current = resolve(cwd);
+	while (true) {
+		const candidate = join(current, ".pi", "settings.json");
+		if (existsSync(candidate)) return candidate;
+		if (existsSync(join(current, ".pi")) || existsSync(join(current, ".git")) || existsSync(join(current, ".vstack-lock.json"))) return candidate;
+		const parent = dirname(current);
+		if (parent === current) return join(resolve(cwd), ".pi", "settings.json");
+		current = parent;
+	}
+}
+
+function piSettingsPaths(cwd = process.cwd()): string[] {
+	const userDir = resolve(expandHome(process.env.PI_CODING_AGENT_DIR?.trim() || "~/.pi/agent"));
+	return [join(userDir, "settings.json"), projectSettingsPath(cwd)];
+}
+
+function readPackageConfig(packageId: string, cwd?: string): Record<string, unknown> {
+	const merged: Record<string, unknown> = {};
+	for (const settingsPath of piSettingsPaths(cwd)) {
+		if (!existsSync(settingsPath)) continue;
+		try {
+			const parsed = JSON.parse(readFileSync(settingsPath, "utf8"));
+			const config = parsed?.vstack?.extensionManager?.config?.[packageId];
+			if (config && typeof config === "object" && !Array.isArray(config)) Object.assign(merged, config);
+		} catch {
+			// Ignore malformed optional manager config.
+		}
+	}
+	return merged;
+}
+
+function asGlyphStyle(value: unknown): GlyphStyle | undefined {
+	return value === "unicode" || value === "ascii" ? value : undefined;
+}
+
+export function glyphStyle(cwd?: string): GlyphStyle {
+	const globalOverride = readPackageConfig(GLOBAL_CONFIG_ID, cwd).globalGlyphStyleOverride;
+	const forced = asGlyphStyle(globalOverride);
+	if (forced) return forced;
+	const local = readPackageConfig(LOCAL_CONFIG_ID, cwd);
+	return asGlyphStyle(local.glyphStyle) ?? asGlyphStyle(local.treeStyle) ?? "unicode";
+}
+
+export const GLYPHS = {
+	unicode: {
+		frame: { tl: "┏", tr: "┓", bl: "┗", br: "┛", h: "━", v: "┃" },
+		line: "─",
+		tree: { mid: "├─ ", last: "└─ ", stem: "│  ", blank: "   " },
+		bullet: "● ",
+		emptyBullet: "○ ",
+		dot: " · ",
+		ok: "✓",
+		fail: "✗",
+		warn: "▲",
+		diamond: "◆",
+		prompt: "π",
+		ellipsis: "…",
+		arrow: "→",
+		codeBar: "▌",
+	},
+	ascii: {
+		frame: { tl: "+", tr: "+", bl: "+", br: "+", h: "-", v: "|" },
+		line: "-",
+		tree: { mid: "|-- ", last: "`-- ", stem: "|  ", blank: "   " },
+		bullet: "* ",
+		emptyBullet: "o ",
+		dot: " - ",
+		ok: "+",
+		fail: "x",
+		warn: "!",
+		diamond: "*",
+		prompt: "pi",
+		ellipsis: "...",
+		arrow: "->",
+		codeBar: "|",
+	},
+} as const;
+
+export function glyphs(cwd?: string): (typeof GLYPHS)[GlyphStyle] {
+	return GLYPHS[glyphStyle(cwd)];
+}
+
+export function truncateIndicator(cwd?: string): string {
+	return glyphs(cwd).ellipsis;
+}
+
+export function truncateText(text: string, maxChars: number, cwd?: string): string {
+	if (text.length <= maxChars) return text;
+	const indicator = truncateIndicator(cwd);
+	return `${text.slice(0, Math.max(0, maxChars - indicator.length))}${indicator}`;
+}
+
+export function dot(cwd?: string): string {
+	return glyphs(cwd).dot;
+}
+
+export function treeGlyph(branch: "├" | "└" | "│", cwd?: string): string {
+	const tree = glyphs(cwd).tree;
+	if (branch === "│") return tree.stem;
+	return branch === "└" ? tree.last : tree.mid;
+}
+
+export function frameGlyphs(cwd?: string): (typeof GLYPHS)[GlyphStyle]["frame"] {
+	return glyphs(cwd).frame;
+}

--- a/pi-extensions/pi-task-panel/extensions/task-panel.ts
+++ b/pi-extensions/pi-task-panel/extensions/task-panel.ts
@@ -5,6 +5,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { Type } from "typebox";
+import { frameGlyphs, glyphs, glyphStyle, treeGlyph } from "./glyphs.js";
 import { MINI_DASHBOARD_RANK, setMiniDashboardWidget } from "./stacked-widget.js";
 import {
 	applyTaskPanelContentVisibility,
@@ -172,35 +173,30 @@ function panelFrameContentWidth(width: number): number {
 	return Math.max(1, width - 2 - PANEL_CARD_PADDING_X * 2);
 }
 
-function panelFrame(lines: string[], width: number, theme: Theme): string[] {
+function panelFrame(lines: string[], width: number, theme: Theme, cwd?: string): string[] {
 	const safeWidth = Math.max(1, width);
 	if (safeWidth < 8) return lines.map((line) => truncateToWidth(line, safeWidth, ""));
 	const inner = Math.max(1, safeWidth - 2);
 	const contentWidth = panelFrameContentWidth(safeWidth);
+	const frame = frameGlyphs(cwd);
 	const border = (text: string) => theme.fg(PANEL_BAR_COLOR, text);
 	return [
-		`${border("┏")}${border("━".repeat(inner))}${border("┓")}`,
-		...lines.map((line) => `${border("┃")}${" ".repeat(PANEL_CARD_PADDING_X)}${padAnsi(line, contentWidth)}${" ".repeat(PANEL_CARD_PADDING_X)}${border("┃")}`),
-		`${border("┗")}${border("━".repeat(inner))}${border("┛")}`,
+		`${border(frame.tl)}${border(frame.h.repeat(inner))}${border(frame.tr)}`,
+		...lines.map((line) => `${border(frame.v)}${" ".repeat(PANEL_CARD_PADDING_X)}${padAnsi(line, contentWidth)}${" ".repeat(PANEL_CARD_PADDING_X)}${border(frame.v)}`),
+		`${border(frame.bl)}${border(frame.h.repeat(inner))}${border(frame.br)}`,
 	].map((line) => truncateToWidth(line, safeWidth, ""));
 }
 
 function panelTreeStyle(cwd?: string): "unicode" | "ascii" {
-	const value = readVstackConfig(cwd).treeStyle;
-	return value === "ascii" || value === "unicode" ? value : "unicode";
+	return glyphStyle(cwd);
 }
 
 function panelBranch(theme: Theme, branch: "├" | "└" | "│", cwd?: string): string {
-	if (panelTreeStyle(cwd) === "ascii") {
-		if (branch === "│") return theme.fg(PANEL_RULE_COLOR, "|  ");
-		return theme.fg(PANEL_RULE_COLOR, branch === "└" ? "`-- " : "|-- ");
-	}
-	if (branch === "│") return theme.fg(PANEL_RULE_COLOR, "│  ");
-	return theme.fg(PANEL_RULE_COLOR, `${branch}─ `);
+	return theme.fg(PANEL_RULE_COLOR, treeGlyph(branch, cwd));
 }
 
 function panelGroupRoot(theme: Theme, title: string, count: number, isLastGroup: boolean, cwd?: string): string {
-	const prefix = panelTreeStyle(cwd) === "ascii" ? (isLastGroup ? "`-- " : "|-- ") : (isLastGroup ? "└─ " : "├─ ");
+	const prefix = isLastGroup ? glyphs(cwd).tree.last : glyphs(cwd).tree.mid;
 	const titleText = theme.fg("mdHeading", theme.bold(title));
 	const countText = theme.fg("dim", ` ${count}`);
 	return `${theme.fg(PANEL_RULE_COLOR, prefix)}${titleText}${countText}`;
@@ -218,22 +214,23 @@ function panelGroupStem(theme: Theme, isLastTask: boolean, isLastGroup: boolean,
 
 function framePopup(lines: string[], width: number, theme: Theme, title = ""): string[] {
 	if (width < 8) return lines.map((line) => truncateToWidth(line, width, ""));
+	const frame = frameGlyphs();
 	const border = (text: string) => theme.fg("borderAccent", text);
 	const contentWidth = Math.max(1, width - 2 - POPUP_PADDING_X * 2);
-	const blank = `${border("┃")}${" ".repeat(width - 2)}${border("┃")}`;
+	const blank = `${border(frame.v)}${" ".repeat(width - 2)}${border(frame.v)}`;
 	const top = () => {
-		if (!title) return `${border("┏")}${border("━".repeat(width - 2))}${border("┓")}`;
-		const titlePlain = ` ${truncateToWidth(title, Math.max(1, width - 4), "…")} `;
+		if (!title) return `${border(frame.tl)}${border(frame.h.repeat(width - 2))}${border(frame.tr)}`;
+		const titlePlain = ` ${truncateToWidth(title, Math.max(1, width - 4), glyphs().ellipsis)} `;
 		const fill = Math.max(1, width - 2 - visibleWidth(titlePlain));
-		return `${border("┏")}${ansiGreen(titlePlain)}${border("━".repeat(fill))}${border("┓")}`;
+		return `${border(frame.tl)}${ansiGreen(titlePlain)}${border(frame.h.repeat(fill))}${border(frame.tr)}`;
 	};
 	const framed = [top()];
 	for (let i = 0; i < POPUP_PADDING_Y; i += 1) framed.push(blank);
 	for (const line of lines) {
-		framed.push(`${border("┃")}${" ".repeat(POPUP_PADDING_X)}${padAnsi(line, contentWidth)}${" ".repeat(POPUP_PADDING_X)}${border("┃")}`);
+		framed.push(`${border(frame.v)}${" ".repeat(POPUP_PADDING_X)}${padAnsi(line, contentWidth)}${" ".repeat(POPUP_PADDING_X)}${border(frame.v)}`);
 	}
 	for (let i = 0; i < POPUP_PADDING_Y; i += 1) framed.push(blank);
-	framed.push(`${border("┗")}${border("━".repeat(width - 2))}${border("┛")}`);
+	framed.push(`${border(frame.bl)}${border(frame.h.repeat(width - 2))}${border(frame.br)}`);
 	return framed.map((line) => truncateToWidth(line, width, ""));
 }
 
@@ -273,8 +270,8 @@ function normalizeState(value: unknown, cwd?: string): TaskPanelState {
 }
 
 function taskIcon(status: Status, active = false): string {
-	if (active || status === "in_progress" || status === "completed") return "●";
-	return "○";
+	if (active || status === "in_progress" || status === "completed") return glyphs().bullet.trim();
+	return glyphs().emptyBullet.trim();
 }
 
 function markerColor(status: Status, active = false): string {
@@ -298,7 +295,7 @@ function renderTaskLine(task: TaskItem, theme: Theme, active = false, prefix = "
 }
 
 function mutedRule(theme: Theme, width: number): string {
-	const rule = "─".repeat(Math.max(1, width));
+	const rule = glyphs().line.repeat(Math.max(1, width));
 	for (const token of ["borderMuted", "muted", "dim"] as const) {
 		try {
 			const styled = theme.fg(token, rule);
@@ -347,7 +344,7 @@ function panelToggleHint(cwd: string): string {
 	const parts: string[] = [];
 	if (toggle !== "none") parts.push(`${formatShortcutHint(toggle)} toggle`);
 	if (manager !== "none") parts.push(`${formatShortcutHint(manager)} manage`);
-	return parts.join(" · ");
+	return parts.join(glyphs(cwd).dot);
 }
 
 function activeTask(state: TaskPanelState): TaskItem | undefined {
@@ -540,7 +537,7 @@ function parseEditableText(text: string, cwd?: string, visibility = rememberTask
 function renderPanelWidgetLines(state: TaskPanelState, theme: Theme, cwd: string, width: number): string[] {
 	const lines = renderPanelLines(state, theme, cwd);
 	if (lines.length === 0) return [];
-	return panelFrame(lines, Math.max(1, width), theme);
+	return panelFrame(lines, Math.max(1, width), theme, cwd);
 }
 
 /**
@@ -556,7 +553,7 @@ function clampAboveEditorWidget(lines: string[], terminalRows: number, theme: Th
 	const maxLines = Math.max(4, terminalRows - reserveForOtherUi);
 	if (lines.length <= maxLines) return lines;
 	const hidden = lines.length - (maxLines - 1);
-	return [...lines.slice(0, maxLines - 1), theme.fg("muted", `… ${hidden} more (open task manager for full view)`)];
+	return [...lines.slice(0, maxLines - 1), theme.fg("muted", `${glyphs().ellipsis} ${hidden} more (open task manager for full view)`)];
 }
 
 function renderPanelHeader(state: TaskPanelState, theme: Theme, active?: TaskItem, hint = ""): string {
@@ -565,8 +562,8 @@ function renderPanelHeader(state: TaskPanelState, theme: Theme, active?: TaskIte
 	const phaseBadge = state.panel === "compact" && activePhase && activePhase !== "Tasks"
 		? ` ${theme.fg("dim", "›")} ${theme.fg("muted", activePhase)}`
 		: "";
-	const toggleHint = hint ? ` ${theme.fg("dim", `· ${hint}`)}` : "";
-	return `${theme.fg(PANEL_TITLE_COLOR, theme.bold("Tasks"))}${phaseBadge} ${theme.fg("muted", `${completedCount(state)}/${state.tasks.length} done · ${remaining} remaining`)}${toggleHint}`;
+	const toggleHint = hint ? ` ${theme.fg("dim", `${glyphs().dot.trim()} ${hint}`)}` : "";
+	return `${theme.fg(PANEL_TITLE_COLOR, theme.bold("Tasks"))}${phaseBadge} ${theme.fg("muted", `${completedCount(state)}/${state.tasks.length} done${glyphs().dot}${remaining} remaining`)}${toggleHint}`;
 }
 
 function pushTaskGroup(lines: string[], title: string, tasks: TaskItem[], theme: Theme, cwd: string, isLastGroup: boolean): void {
@@ -594,7 +591,7 @@ function renderPanelLines(state: TaskPanelState, theme: Theme, cwd: string): str
 		}
 		const shown = visible.length + (active ? 1 : 0);
 		const hidden = Math.max(0, remaining - shown);
-		if (hidden > 0) lines.push(`${panelBranch(theme, "└", cwd)}${theme.fg("muted", `… ${hidden} more`)}`);
+		if (hidden > 0) lines.push(`${panelBranch(theme, "└", cwd)}${theme.fg("muted", `${glyphs(cwd).ellipsis} ${hidden} more`)}`);
 		return lines;
 	}
 	const lines = [header];
@@ -674,7 +671,7 @@ function resultColor(action: string, summary: string): string {
 
 function renderTaskToolSummary(summary: string, action: string, theme: Theme): string {
 	const color = resultColor(action, summary);
-	const bullet = theme.fg(color, "● ");
+	const bullet = theme.fg(color, glyphs().bullet);
 	const taskMatch = summary.match(/^(Task )("[^"]+")( .+)$/);
 	if (taskMatch) {
 		return `${bullet}${theme.fg("text", taskMatch[1] ?? "Task ")}${theme.fg("accent", taskMatch[2] ?? "")}${theme.fg(color, taskMatch[3] ?? "")}`;
@@ -697,8 +694,9 @@ function taskContextMessage(state: TaskPanelState): string {
 }
 
 function toolResultContent(summary: string, state: TaskPanelState, cwd: string): string {
-	if (!settingBoolean("showWorkflowReminder", true, cwd) || remainingCount(state) === 0) return `• ${summary}`;
-	return `• ${summary}\n${workflowReminder(state)}`;
+	const bullet = glyphs(cwd).bullet.trimEnd();
+	if (!settingBoolean("showWorkflowReminder", true, cwd) || remainingCount(state) === 0) return `${bullet} ${summary}`;
+	return `${bullet} ${summary}\n${workflowReminder(state)}`;
 }
 
 const TaskToolParams = Type.Object({
@@ -1092,10 +1090,10 @@ export default function taskPanel(pi: ExtensionAPI): void {
 		},
 		renderResult(result, _options, theme) {
 			if (result.details?.deferDisplay) return singleLine("");
-			const summary = result.details?.summary ?? result.content?.find((part: any) => part?.type === "text")?.text?.replace(/^•\s*/, "") ?? "tasks updated";
+			const summary = result.details?.summary ?? result.content?.find((part: any) => part?.type === "text")?.text?.replace(/^[•*●]\s*/, "") ?? "tasks updated";
 			const action = result.details?.action ?? "";
 			if (compactToolOutput) return singleLine(renderTaskToolSummary(summary, action, theme));
-			return singleLine(theme.fg("text", `• ${summary}`));
+			return singleLine(theme.fg("text", `${glyphs(activeCtx?.cwd).bullet.trimEnd()} ${summary}`));
 		},
 	});
 

--- a/pi-extensions/pi-task-panel/package.json
+++ b/pi-extensions/pi-task-panel/package.json
@@ -35,6 +35,19 @@
           "requiresReload": true
         },
         {
+          "key": "glyphStyle",
+          "label": "Glyph style",
+          "description": "Glyphs for vstack-owned UI chrome. Unicode is the default; ASCII uses plain box/status/separator characters for terminal compatibility. pi-tool-renderer's global override wins when set.",
+          "type": "enum",
+          "enumValues": [
+            "unicode",
+            "ascii"
+          ],
+          "default": "unicode",
+          "category": "Rendering",
+          "apply": "live"
+        },
+        {
           "key": "panelDefaultState",
           "label": "Default panel state",
           "description": "Panel state when tasks first appear. User-hidden state is respected for the rest of the session.",

--- a/pi-extensions/pi-tool-renderer/README.md
+++ b/pi-extensions/pi-tool-renderer/README.md
@@ -56,6 +56,8 @@ If the combined output would exceed Pi's normal tool-result budget, child output
 
 Open `/extensions:settings`; settings appear under the **Tool Renderer** tab.
 
+Glyph style: each package exposes `glyphStyle` (`unicode` default, `ascii` for terminal-safe chrome). `@vanillagreen/pi-tool-renderer.globalGlyphStyleOverride=ascii` forces ASCII chrome across vstack Pi extensions while leaving tool/model/user content unchanged.
+
 ### General
 
 | Setting | What it does |

--- a/pi-extensions/pi-tool-renderer/extensions/__tests__/glyphs.test.ts
+++ b/pi-extensions/pi-tool-renderer/extensions/__tests__/glyphs.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { glyphs, glyphStyle } from "../tool-renderer/glyphs.js";
+
+const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+
+afterEach(() => {
+	if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+	else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+});
+
+function fixture(config: Record<string, unknown>): string {
+	const root = mkdtempSync(join(tmpdir(), "vstack-glyphs-"));
+	const user = join(root, "agent");
+	const project = join(root, "project");
+	mkdirSync(user, { recursive: true });
+	mkdirSync(join(project, ".pi"), { recursive: true });
+	writeFileSync(join(user, "settings.json"), JSON.stringify({ vstack: { extensionManager: { config } } }));
+	process.env.PI_CODING_AGENT_DIR = user;
+	return project;
+}
+
+describe("glyph style precedence", () => {
+	test("local glyphStyle=ascii selects ASCII chrome", () => {
+		const cwd = fixture({ "@vanillagreen/pi-tool-renderer": { glyphStyle: "ascii" } });
+		expect(glyphStyle(cwd)).toBe("ascii");
+		expect(glyphs(cwd).frame.tl).toBe("+");
+		expect(glyphs(cwd).bullet).toBe("* ");
+	});
+
+	test("global override wins over local unicode", () => {
+		const cwd = fixture({ "@vanillagreen/pi-tool-renderer": { glyphStyle: "unicode", globalGlyphStyleOverride: "ascii" } });
+		expect(glyphStyle(cwd)).toBe("ascii");
+	});
+
+	test("legacy treeStyle remains fallback", () => {
+		const cwd = fixture({ "@vanillagreen/pi-tool-renderer": { treeStyle: "ascii" } });
+		expect(glyphStyle(cwd)).toBe("ascii");
+	});
+});

--- a/pi-extensions/pi-tool-renderer/extensions/tool-renderer/chrome.ts
+++ b/pi-extensions/pi-tool-renderer/extensions/tool-renderer/chrome.ts
@@ -22,6 +22,7 @@ import {
 	componentDefinesRenderer,
 } from "./generic.js";
 import { settingBoolean, settingEnum, toolChromeMode } from "./settings.js";
+import { glyphs } from "./glyphs.js";
 import { subtleRule } from "./theme.js";
 
 const TOOL_EXECUTION_RENDERER_PATCH_SYMBOL = Symbol.for("vstack.pi-tool-renderer.tool-execution-renderer-patch.v2");
@@ -121,11 +122,11 @@ function prepareToolChromeTheme(theme: any, cwd?: string): void {
 let activeToolChromeCtx: ExtensionContext | undefined;
 
 function mutedHorizontalRule(theme: any, width: number, cwd?: string): string {
-	return subtleRule(theme, "─".repeat(stableRenderWidth(width, cwd)));
+	return subtleRule(theme, glyphs(cwd).line.repeat(stableRenderWidth(width, cwd)));
 }
 
 function shouldOmitBottomToolChromeRule(core: string[]): boolean {
-	return core.some((line) => /└─+(?:┴─+)?┘/.test(stripAnsi(line ?? "")));
+	return core.some((line) => /(?:└─+(?:┴─+)?┘|\+-+(?:\+-+)?\+)/.test(stripAnsi(line ?? "")));
 }
 
 export function installToolChromePatch(): void {
@@ -185,8 +186,9 @@ export function installWorkingIndicator(pi: ExtensionAPI): void {
 			ctx.ui.setWorkingIndicator({ frames: [] });
 			return;
 		}
+		const g = glyphs(ctx.cwd);
 		ctx.ui.setWorkingIndicator({
-			frames: [ctx.ui.theme.fg("dim", "·"), ctx.ui.theme.fg("muted", "•"), ctx.ui.theme.fg("accent", "●"), ctx.ui.theme.fg("muted", "•")],
+			frames: [ctx.ui.theme.fg("dim", g.dot.trim()), ctx.ui.theme.fg("muted", g.emptyBullet.trim()), ctx.ui.theme.fg("accent", g.bullet.trim()), ctx.ui.theme.fg("muted", g.emptyBullet.trim())],
 			intervalMs: 120,
 		});
 	});

--- a/pi-extensions/pi-tool-renderer/extensions/tool-renderer/diff.ts
+++ b/pi-extensions/pi-tool-renderer/extensions/tool-renderer/diff.ts
@@ -23,6 +23,7 @@ import {
 	settingBoolean,
 	settingNumber,
 } from "./settings.js";
+import { dot, glyphs } from "./glyphs.js";
 import { borderMuted, stackPrefix, toolLabel, treeConnector } from "./theme.js";
 import {
 	makeEmpty,
@@ -470,7 +471,7 @@ export function buildStructuredDiff(oldText: string, newText: string): Structure
 	return { additions, chars: oldText.length + newText.length, hunks: numbered.hunks, lines: numbered.lines, removals };
 }
 
-function diffStatBar(additions: number, removals: number, theme: any): string {
+function diffStatBar(additions: number, removals: number, theme: any, cwd?: string): string {
 	const total = additions + removals;
 	if (total <= 0) return "";
 	const slots = Math.max(6, Math.min(18, Math.ceil(total / 3)));
@@ -478,7 +479,8 @@ function diffStatBar(additions: number, removals: number, theme: any): string {
 	if (additions > 0 && addSlots === 0) addSlots = 1;
 	if (removals > 0 && addSlots === slots) addSlots = slots - 1;
 	const delSlots = slots - addSlots;
-	return `${theme.fg("dim", "[")}${theme.fg("toolDiffAdded", "━".repeat(addSlots))}${theme.fg("toolDiffRemoved", "━".repeat(delSlots))}${theme.fg("dim", "]")}`;
+	const bar = glyphs(cwd).line;
+	return `${theme.fg("dim", "[")}${theme.fg("toolDiffAdded", bar.repeat(addSlots))}${theme.fg("toolDiffRemoved", bar.repeat(delSlots))}${theme.fg("dim", "]")}`;
 }
 
 export function diffSummary(diff: StructuredDiff, theme: any, cwd?: string): string {
@@ -486,10 +488,10 @@ export function diffSummary(diff: StructuredDiff, theme: any, cwd?: string): str
 	if (diff.additions > 0) parts.push(theme.fg("success", `+${diff.additions}`));
 	if (diff.removals > 0) parts.push(theme.fg("error", `-${diff.removals}`));
 	if (parts.length === 0) return theme.fg("muted", "no changes");
-	const bar = diffStatBar(diff.additions, diff.removals, theme);
+	const bar = diffStatBar(diff.additions, diff.removals, theme, cwd);
 	const hunks = diff.hunks ?? countStructuredHunks(diff.lines);
 	let summary = `${parts.join(" ")}${bar ? ` ${bar}` : ""}`;
-	if (settingBoolean("showDiffHunkMeta", true, cwd) && hunks > 0) summary += theme.fg("dim", ` · ${hunks} hunk${hunks === 1 ? "" : "s"}`);
+	if (settingBoolean("showDiffHunkMeta", true, cwd) && hunks > 0) summary += theme.fg("dim", `${dot(cwd)}${hunks} hunk${hunks === 1 ? "" : "s"}`);
 	return summary;
 }
 
@@ -517,8 +519,13 @@ function lineWordRanges(line: StructuredDiffLine, mate: StructuredDiffLine | nul
 }
 
 function highlightedLineBody(line: StructuredDiffLine, theme: any, path: string | undefined, cwd?: string): string {
-	if (line.type === "sep") return line.content || " ";
+	if (line.type === "sep") return (line.content || " ").replaceAll("…", glyphs(cwd).ellipsis).replaceAll(" · ", glyphs(cwd).dot);
 	return highlightDiffContent(line.content, path, theme, cwd) || " ";
+}
+
+function diffFrame(cwd?: string): { bl: string; br: string; h: string; joint: string; tl: string; tm: string; tr: string; v: string } {
+	if (glyphs(cwd).line === "-") return { bl: "+", br: "+", h: "-", joint: "+", tl: "+", tm: "+", tr: "+", v: "|" };
+	return { bl: "└", br: "┘", h: "─", joint: "┴", tl: "┌", tm: "┬", tr: "┐", v: "│" };
 }
 
 function renderUnifiedLine(
@@ -542,12 +549,13 @@ function renderUnifiedDiff(diff: StructuredDiff, rows: StructuredDiffLine[], wid
 	const tableWidth = Math.max(40, width);
 	const maxNum = Math.max(1, ...diff.lines.map((line) => Math.max(line.oldNum ?? 0, line.newNum ?? 0)));
 	const numWidth = Math.max(2, String(maxNum).length);
-	const leftBorder = borderMuted(theme, "│");
-	const rightBorder = borderMuted(theme, "│");
+	const frame = diffFrame(cwd);
+	const leftBorder = borderMuted(theme, frame.v);
+	const rightBorder = borderMuted(theme, frame.v);
 	const cellWidth = Math.max(1, tableWidth - visibleLength(leftBorder) - visibleLength(rightBorder));
 	const contentWidth = Math.max(1, cellWidth - 2);
-	const ruleSegment = borderMuted(theme, "─".repeat(Math.max(1, cellWidth)));
-	const out: string[] = [`${borderMuted(theme, "┌")}${ruleSegment}${borderMuted(theme, "┐")}`];
+	const ruleSegment = borderMuted(theme, frame.h.repeat(Math.max(1, cellWidth)));
+	const out: string[] = [`${borderMuted(theme, frame.tl)}${ruleSegment}${borderMuted(theme, frame.tr)}`];
 	const pushLine = (line: StructuredDiffLine, renderedLine: string) => {
 		const cell = ` ${padVisible(renderedLine, contentWidth)} `;
 		const bgToken = diffLineBgToken(line);
@@ -573,7 +581,7 @@ function renderUnifiedDiff(diff: StructuredDiff, rows: StructuredDiffLine[], wid
 			if (add) pushLine(add, renderUnifiedLine(add, contentWidth, numWidth, theme, path ?? diff.path, cwd, lineWordRanges(add, del ?? null, cwd)));
 		}
 	}
-	out.push(`${borderMuted(theme, "└")}${ruleSegment}${borderMuted(theme, "┘")}`);
+	out.push(`${borderMuted(theme, frame.bl)}${ruleSegment}${borderMuted(theme, frame.br)}`);
 	return out;
 }
 
@@ -657,15 +665,16 @@ function renderSplitDiff(diff: StructuredDiff, rows: StructuredDiffLine[], width
 	const tableWidth = Math.max(DIFF_SPLIT_MIN_WIDTH, width);
 	const maxNum = Math.max(1, ...diff.lines.map((line) => Math.max(line.oldNum ?? 0, line.newNum ?? 0)));
 	const numWidth = Math.max(2, String(maxNum).length);
-	const leftBorder = borderMuted(theme, "│");
-	const divider = borderMuted(theme, "│");
-	const rightBorder = borderMuted(theme, "│");
+	const frame = diffFrame(cwd);
+	const leftBorder = borderMuted(theme, frame.v);
+	const divider = borderMuted(theme, frame.v);
+	const rightBorder = borderMuted(theme, frame.v);
 	const innerWidth = Math.max(2, tableWidth - visibleLength(leftBorder) - visibleLength(divider) - visibleLength(rightBorder));
 	const leftCellWidth = Math.max(1, Math.floor(innerWidth / 2));
 	const rightCellWidth = Math.max(1, innerWidth - leftCellWidth);
-	const ruleSegment = (width: number) => borderMuted(theme, "─".repeat(Math.max(1, width)));
-	const topRule = `${borderMuted(theme, "┌")}${ruleSegment(leftCellWidth)}${borderMuted(theme, "┬")}${ruleSegment(rightCellWidth)}${borderMuted(theme, "┐")}`;
-	const bottomRule = `${borderMuted(theme, "└")}${ruleSegment(leftCellWidth)}${borderMuted(theme, "┴")}${ruleSegment(rightCellWidth)}${borderMuted(theme, "┘")}`;
+	const ruleSegment = (width: number) => borderMuted(theme, frame.h.repeat(Math.max(1, width)));
+	const topRule = `${borderMuted(theme, frame.tl)}${ruleSegment(leftCellWidth)}${borderMuted(theme, frame.tm)}${ruleSegment(rightCellWidth)}${borderMuted(theme, frame.tr)}`;
+	const bottomRule = `${borderMuted(theme, frame.bl)}${ruleSegment(leftCellWidth)}${borderMuted(theme, frame.joint)}${ruleSegment(rightCellWidth)}${borderMuted(theme, frame.br)}`;
 	const out = [topRule];
 	for (const pair of pairDiffRows(rows)) {
 		const leftRanges = pair.left && pair.right ? lineWordRanges(pair.left, pair.right, cwd) : [];
@@ -682,22 +691,24 @@ function configuredDiffRowLimit(expanded: boolean, cwd?: string): number | null 
 	return expanded && configuredLimit <= 0 ? null : Math.max(4, configuredLimit);
 }
 
-function collapsedDiffHint(remainingLines: number, hiddenHunks: number, expanded: boolean, shown: number, total: number, width = terminalWidth()): string {
+
+function collapsedDiffHint(remainingLines: number, hiddenHunks: number, expanded: boolean, shown: number, total: number, width = terminalWidth(), cwd?: string): string {
+	const g = glyphs(cwd);
 	const candidates = expanded
 		? [
-			`… ${remainingLines} more diff lines${hiddenHunks > 0 ? ` · ${hiddenHunks} more hunks` : ""} · UI cap ${shown}/${total}`,
-			`… ${remainingLines} more lines${hiddenHunks > 0 ? ` · ${hiddenHunks} hunks` : ""}`,
-			`… +${remainingLines}${hiddenHunks > 0 ? ` · +${hiddenHunks}h` : ""}`,
-			"…",
+			`${g.ellipsis} ${remainingLines} more diff lines${hiddenHunks > 0 ? `${g.dot}${hiddenHunks} more hunks` : ""}${g.dot}UI cap ${shown}/${total}`,
+			`${g.ellipsis} ${remainingLines} more lines${hiddenHunks > 0 ? `${g.dot}${hiddenHunks} hunks` : ""}`,
+			`${g.ellipsis} +${remainingLines}${hiddenHunks > 0 ? `${g.dot}+${hiddenHunks}h` : ""}`,
+			g.ellipsis,
 		]
 		: [
-			`… ${remainingLines} more diff lines${hiddenHunks > 0 ? ` · ${hiddenHunks} more hunks` : ""} · ctrl+o to expand`,
-			`… ${remainingLines} more lines${hiddenHunks > 0 ? ` · ${hiddenHunks} hunks` : ""}`,
-			`… +${remainingLines}${hiddenHunks > 0 ? ` · +${hiddenHunks}h` : ""}`,
-			"…",
+			`${g.ellipsis} ${remainingLines} more diff lines${hiddenHunks > 0 ? `${g.dot}${hiddenHunks} more hunks` : ""}${g.dot}ctrl+o to expand`,
+			`${g.ellipsis} ${remainingLines} more lines${hiddenHunks > 0 ? `${g.dot}${hiddenHunks} hunks` : ""}`,
+			`${g.ellipsis} +${remainingLines}${hiddenHunks > 0 ? `${g.dot}+${hiddenHunks}h` : ""}`,
+			g.ellipsis,
 		];
 	for (const candidate of candidates) if (visibleWidth(candidate) <= width) return candidate;
-	return "…";
+	return g.ellipsis;
 }
 
 export function renderStructuredDiff(diff: StructuredDiff, theme: any, expanded: boolean, cwd?: string, rowLimit?: number | null, path?: string, widthOffset = 0): string {
@@ -709,7 +720,7 @@ export function renderStructuredDiff(diff: StructuredDiff, theme: any, expanded:
 	const useSplit = settingBoolean("splitDiffs", true, cwd) && shouldUseSplitDiff(diff, rows, width);
 	const rendered = useSplit ? renderSplitDiff(diff, rows, width, theme, path ?? diff.path, cwd) : renderUnifiedDiff(diff, rows, width, theme, path ?? diff.path, cwd);
 	const remaining = diff.lines.length - rows.length;
-	if (remaining > 0) rendered.push(theme.fg("dim", collapsedDiffHint(remaining, hiddenHunksAfter(diff.lines, rows), expanded, rows.length, diff.lines.length, width)));
+	if (remaining > 0) rendered.push(theme.fg("dim", collapsedDiffHint(remaining, hiddenHunksAfter(diff.lines, rows), expanded, rows.length, diff.lines.length, width, cwd)));
 	return rendered.join("\n");
 }
 

--- a/pi-extensions/pi-tool-renderer/extensions/tool-renderer/generic.ts
+++ b/pi-extensions/pi-tool-renderer/extensions/tool-renderer/generic.ts
@@ -10,6 +10,7 @@ import {
 	type StructuredDiffLine,
 } from "./diff.js";
 import { mcpOutputMode, settingBoolean, settingNumber } from "./settings.js";
+import { glyphs, truncateText } from "./glyphs.js";
 import { stackPrefix, toolLabel, treeConnector, treeStem } from "./theme.js";
 import {
 	clearBlink,
@@ -83,9 +84,9 @@ export function humanizeToolName(name: string): string {
 		.replace(/\b\w/g, (char) => char.toUpperCase());
 }
 
-export function oneLine(value: string, max = 72): string {
+export function oneLine(value: string, max = 72, cwd?: string): string {
 	const normalized = value.replace(/\s+/g, " ").trim();
-	return normalized.length > max ? `${normalized.slice(0, Math.max(0, max - 1))}…` : normalized;
+	return truncateText(normalized, max, cwd);
 }
 
 function stringArg(args: any, ...keys: string[]): string {
@@ -109,7 +110,7 @@ function stringArrayArg(args: any, ...keys: string[]): string[] {
 export function genericStatusPrefix(context: any, theme: any): string {
 	if (!context?.executionStarted || context?.isPartial) return pendingStatusPrefix(theme, context);
 	clearBlink(context);
-	return theme.fg(context?.isError ? "error" : "success", "● ");
+	return theme.fg(context?.isError ? "error" : "success", glyphs(context?.cwd).bullet);
 }
 
 function patchTextFromArgs(args: any): string {
@@ -223,7 +224,7 @@ function parseApplyPatchPreview(patchText: string): ApplyPatchChange[] {
 				? buildStructuredDiff(body.map((line) => line.startsWith("-") ? line.slice(1) : line).join("\n"), "")
 				: parseApplyPatchUpdateDiff(body);
 		diff.path = moveTo || path;
-		changes.push({ diff, displayPath: moveTo ? `${path} → ${moveTo}` : path, kind, line: firstChangedLine(diff), moveTo, path });
+		changes.push({ diff, displayPath: moveTo ? `${path} ${glyphs().arrow} ${moveTo}` : path, kind, line: firstChangedLine(diff), moveTo, path });
 	}
 	return changes;
 }

--- a/pi-extensions/pi-tool-renderer/extensions/tool-renderer/glyphs.ts
+++ b/pi-extensions/pi-tool-renderer/extensions/tool-renderer/glyphs.ts
@@ -1,0 +1,122 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+export type GlyphStyle = "unicode" | "ascii";
+export type GlobalGlyphStyleOverride = "inherit" | GlyphStyle;
+
+const LOCAL_CONFIG_ID = "@vanillagreen/pi-tool-renderer";
+const GLOBAL_CONFIG_ID = "@vanillagreen/pi-tool-renderer";
+
+function expandHome(input: string): string {
+	if (input === "~") return homedir();
+	if (input.startsWith("~/")) return join(homedir(), input.slice(2));
+	return input;
+}
+
+function projectSettingsPath(cwd: string): string {
+	let current = resolve(cwd);
+	while (true) {
+		const candidate = join(current, ".pi", "settings.json");
+		if (existsSync(candidate)) return candidate;
+		if (existsSync(join(current, ".pi")) || existsSync(join(current, ".git")) || existsSync(join(current, ".vstack-lock.json"))) return candidate;
+		const parent = dirname(current);
+		if (parent === current) return join(resolve(cwd), ".pi", "settings.json");
+		current = parent;
+	}
+}
+
+function piSettingsPaths(cwd = process.cwd()): string[] {
+	const userDir = resolve(expandHome(process.env.PI_CODING_AGENT_DIR?.trim() || "~/.pi/agent"));
+	return [join(userDir, "settings.json"), projectSettingsPath(cwd)];
+}
+
+function readPackageConfig(packageId: string, cwd?: string): Record<string, unknown> {
+	const merged: Record<string, unknown> = {};
+	for (const settingsPath of piSettingsPaths(cwd)) {
+		if (!existsSync(settingsPath)) continue;
+		try {
+			const parsed = JSON.parse(readFileSync(settingsPath, "utf8"));
+			const config = parsed?.vstack?.extensionManager?.config?.[packageId];
+			if (config && typeof config === "object" && !Array.isArray(config)) Object.assign(merged, config);
+		} catch {
+			// Ignore malformed optional manager config.
+		}
+	}
+	return merged;
+}
+
+function asGlyphStyle(value: unknown): GlyphStyle | undefined {
+	return value === "unicode" || value === "ascii" ? value : undefined;
+}
+
+export function glyphStyle(cwd?: string): GlyphStyle {
+	const globalOverride = readPackageConfig(GLOBAL_CONFIG_ID, cwd).globalGlyphStyleOverride;
+	const forced = asGlyphStyle(globalOverride);
+	if (forced) return forced;
+	const local = readPackageConfig(LOCAL_CONFIG_ID, cwd);
+	return asGlyphStyle(local.glyphStyle) ?? asGlyphStyle(local.treeStyle) ?? "unicode";
+}
+
+export const GLYPHS = {
+	unicode: {
+		frame: { tl: "┏", tr: "┓", bl: "┗", br: "┛", h: "━", v: "┃" },
+		line: "─",
+		tree: { mid: "├─ ", last: "└─ ", stem: "│  ", blank: "   " },
+		bullet: "● ",
+		emptyBullet: "○ ",
+		dot: " · ",
+		ok: "✓",
+		fail: "✗",
+		warn: "▲",
+		diamond: "◆",
+		prompt: "π",
+		ellipsis: "…",
+		arrow: "→",
+		codeBar: "▌",
+	},
+	ascii: {
+		frame: { tl: "+", tr: "+", bl: "+", br: "+", h: "-", v: "|" },
+		line: "-",
+		tree: { mid: "|-- ", last: "`-- ", stem: "|  ", blank: "   " },
+		bullet: "* ",
+		emptyBullet: "o ",
+		dot: " - ",
+		ok: "+",
+		fail: "x",
+		warn: "!",
+		diamond: "*",
+		prompt: "pi",
+		ellipsis: "...",
+		arrow: "->",
+		codeBar: "|",
+	},
+} as const;
+
+export function glyphs(cwd?: string): (typeof GLYPHS)[GlyphStyle] {
+	return GLYPHS[glyphStyle(cwd)];
+}
+
+export function truncateIndicator(cwd?: string): string {
+	return glyphs(cwd).ellipsis;
+}
+
+export function truncateText(text: string, maxChars: number, cwd?: string): string {
+	if (text.length <= maxChars) return text;
+	const indicator = truncateIndicator(cwd);
+	return `${text.slice(0, Math.max(0, maxChars - indicator.length))}${indicator}`;
+}
+
+export function dot(cwd?: string): string {
+	return glyphs(cwd).dot;
+}
+
+export function treeGlyph(branch: "├" | "└" | "│", cwd?: string): string {
+	const tree = glyphs(cwd).tree;
+	if (branch === "│") return tree.stem;
+	return branch === "└" ? tree.last : tree.mid;
+}
+
+export function frameGlyphs(cwd?: string): (typeof GLYPHS)[GlyphStyle]["frame"] {
+	return glyphs(cwd).frame;
+}

--- a/pi-extensions/pi-tool-renderer/extensions/tool-renderer/messages.ts
+++ b/pi-extensions/pi-tool-renderer/extensions/tool-renderer/messages.ts
@@ -17,6 +17,7 @@ import {
 	wrapTextWithAnsi,
 } from "./ansi.js";
 import { settingBoolean } from "./settings.js";
+import { frameGlyphs, glyphs } from "./glyphs.js";
 import { FALLBACK_THEME, stackPrefix, toolLabel, treeConnector } from "./theme.js";
 import { makeTruncatedLines } from "./text.js";
 
@@ -71,7 +72,7 @@ function applyPromptZoneMarkers(lines: string[], markers: PromptZoneMarkers): st
 	return marked;
 }
 
-function renderUserMessageBorder(lines: string[], width: number, theme: any): string[] {
+function renderUserMessageBorder(lines: string[], width: number, theme: any, cwd?: string): string[] {
 	if (lines.length === 0 || width < 4) return lines;
 	// Pi wraps user messages with OSC 133 prompt-zone markers. With compact
 	// padding, a single-line message can carry start/end/final markers on the
@@ -80,13 +81,15 @@ function renderUserMessageBorder(lines: string[], width: number, theme: any): st
 	// framed card so the terminal sees one stable prompt zone.
 	const unwrapped = stripPromptZoneMarkers(lines);
 	const innerWidth = Math.max(1, width - 2);
+	const frame = frameGlyphs(cwd);
+	const prompt = glyphs(cwd).prompt;
 	const border = (text: string) => ansiGreen(text);
 	const marker = (text: string) => ansiRed(text);
 	const topBorder = () => {
-		if (innerWidth < 5) return border("━".repeat(innerWidth));
-		const left = "━ ";
-		const right = ` ${"━".repeat(Math.max(0, innerWidth - visibleWidth(left) - 2))}`;
-		return `${border(left)}${marker("π")}${border(right)}`;
+		if (innerWidth < 5) return border(frame.h.repeat(innerWidth));
+		const left = `${frame.h} `;
+		const right = ` ${frame.h.repeat(Math.max(0, innerWidth - visibleWidth(left) - visibleWidth(prompt) - 1))}`;
+		return `${border(left)}${marker(prompt)}${border(right)}`;
 	};
 	const fitLine = (line: string) => {
 		const clipped = truncateAnsi(line, innerWidth);
@@ -94,9 +97,9 @@ function renderUserMessageBorder(lines: string[], width: number, theme: any): st
 	};
 
 	return applyPromptZoneMarkers([
-		`${border("┏")}${topBorder()}${border("┓")}`,
-		...unwrapped.lines.map((line) => `${border("┃")}${fitLine(line)}${border("┃")}`),
-		`${border("┗")}${border("━".repeat(innerWidth))}${border("┛")}`,
+		`${border(frame.tl)}${topBorder()}${border(frame.tr)}`,
+		...unwrapped.lines.map((line) => `${border(frame.v)}${fitLine(line)}${border(frame.v)}`),
+		`${border(frame.bl)}${border(frame.h.repeat(innerWidth))}${border(frame.br)}`,
 	], unwrapped.markers);
 }
 
@@ -158,7 +161,7 @@ export function installUserMessageRenderer(pi: ExtensionAPI, UserMessageComponen
 					const theme = ctx.ui?.theme ?? FALLBACK_THEME;
 					const frameWidth = stableRenderWidth(width, cwd);
 					const lines = state!.originalRender.call(this, Math.max(1, frameWidth - 2));
-					return appendUserMessageBreak(renderUserMessageBorder(lines, frameWidth, theme), width, cwd);
+					return appendUserMessageBreak(renderUserMessageBorder(lines, frameWidth, theme, cwd), width, cwd);
 				}
 			}
 
@@ -426,7 +429,8 @@ function renderStyledCodeBlock(token: any, width: number, markdownTheme: any, ct
 		highlightedLines = code.split("\n").map((line: string) => (markdownTheme?.codeBlock ? markdownTheme.codeBlock(line) : line));
 	}
 
-	const strip = markdownTheme?.codeBlockBorder ? markdownTheme.codeBlockBorder("▌") : "▌";
+	const bar = glyphs(ctx?.cwd).codeBar;
+	const strip = markdownTheme?.codeBlockBorder ? markdownTheme.codeBlockBorder(bar) : bar;
 	const stripWidth = Math.max(1, visibleWidth(strip));
 	const bodyWidth = Math.max(1, panelWidth - stripWidth);
 	const codeWidth = Math.max(1, bodyWidth - 2);

--- a/pi-extensions/pi-tool-renderer/extensions/tool-renderer/text.ts
+++ b/pi-extensions/pi-tool-renderer/extensions/tool-renderer/text.ts
@@ -2,6 +2,7 @@ import { wrapTextWithAnsi } from "@earendil-works/pi-tui";
 import { basename, extname } from "node:path";
 
 import { stableRenderWidth, stripAnsi } from "./ansi.js";
+import { glyphs, truncateText } from "./glyphs.js";
 import { pendingStatusAnimation, settingNumber, stackToolCalls } from "./settings.js";
 import { stackPrefix, toolLabel, treeConnector, type TreeBranch } from "./theme.js";
 
@@ -66,7 +67,7 @@ export function textContent(result: any): string {
 
 export function clipLine(line: string, cwd?: string): string {
 	const max = Math.max(40, Math.floor(settingNumber("maxLineWidth", 1000, cwd)));
-	return line.length > max ? `${line.slice(0, max - 1)}…` : line;
+	return truncateText(line, max, cwd);
 }
 
 export function preview(text: string, count: number, direction: "head" | "tail", cwd?: string): string {
@@ -162,16 +163,17 @@ export function clearBlink(context: any): void {
 	}
 }
 
-export function blinkingPrefix(theme: any, context: any): string {
+export function blinkingPrefix(theme: any, context: any, cwd?: string): string {
 	trackBlink(context);
 	const on = Math.floor(Date.now() / 450) % 2 === 0;
-	return theme.fg(on ? "success" : "muted", on ? "● " : "○ ");
+	const g = glyphs(context?.cwd ?? cwd);
+	return theme.fg(on ? "success" : "muted", on ? g.bullet : g.emptyBullet);
 }
 
 export function pendingStatusPrefix(theme: any, context: any, cwd?: string): string {
-	if (pendingStatusAnimation(context?.cwd ?? cwd)) return blinkingPrefix(theme, context);
+	if (pendingStatusAnimation(context?.cwd ?? cwd)) return blinkingPrefix(theme, context, cwd);
 	clearBlink(context);
-	return theme.fg("warning", "● ");
+	return theme.fg("warning", glyphs(context?.cwd ?? cwd).bullet);
 }
 
 export function renderPendingCall(call: string, theme: any, context: any, cwd?: string): TruncatedLines | ReturnType<typeof makeEmpty> {
@@ -179,8 +181,8 @@ export function renderPendingCall(call: string, theme: any, context: any, cwd?: 
 	return makeTruncatedLines(`${pendingStatusPrefix(theme, context, cwd)}${call}`);
 }
 
-export function renderPendingDetail(text: string, theme: any): TruncatedLines {
-	return makeTruncatedLines(`${treeConnector(theme, "└")}${theme.fg("warning", text)}`);
+export function renderPendingDetail(text: string, theme: any, cwd?: string): TruncatedLines {
+	return makeTruncatedLines(`${treeConnector(theme, "└", cwd)}${theme.fg("warning", text)}`);
 }
 
 const NF_DIR = "";
@@ -230,7 +232,9 @@ const ICON_BY_EXT: Record<string, string> = {
 	zsh: "",
 };
 
-export function nerdIcon(pathText: string, isDirectory = false, theme?: any): string {
+
+export function nerdIcon(pathText: string, isDirectory = false, theme?: any, cwd?: string): string {
+	if (glyphs(cwd).line === "-") return theme?.fg ? theme.fg(isDirectory ? "accent" : "muted", isDirectory ? "d" : "f") : (isDirectory ? "d" : "f");
 	if (isDirectory) return theme?.fg ? theme.fg("accent", NF_DIR) : NF_DIR;
 	const clean = stripAnsi(pathText).trim().replace(/\/$/, "");
 	const name = basename(clean).toLowerCase();
@@ -248,14 +252,14 @@ export function renderPathListPreview(output: string, toolName: "find" | "ls", t
 		const clean = stripAnsi(item).trim();
 		const isDir = clean.endsWith("/");
 		const branch = index === shown.length - 1 && shown.length === rawItems.length ? "└" : "├";
-		const icon = nerdIcon(clean, isDir, theme);
+		const icon = nerdIcon(clean, isDir, theme, cwd);
 		const label = isDir ? theme.fg("accent", theme.bold(clean)) : theme.fg("dim", clean);
 		return `${treeConnector(theme, branch as "├" | "└", cwd)}${icon} ${label}`;
 	});
 	const remaining = rawItems.length - shown.length;
 	if (remaining > 0) {
 		const noun = toolName === "ls" ? (remaining === 1 ? "entry" : "entries") : `file${remaining === 1 ? "" : "s"}`;
-		lines.push(`${treeConnector(theme, "└", cwd)}${theme.fg("muted", `… ${remaining} more ${noun}`)}`);
+		lines.push(`${treeConnector(theme, "└", cwd)}${theme.fg("muted", `${glyphs(cwd).ellipsis} ${remaining} more ${noun}`)}`);
 	}
 	return lines.join("\n");
 }
@@ -268,7 +272,7 @@ export function readCallText(args: any, theme: any): string {
 export function bashCallText(args: any, theme: any, cwd?: string): string {
 	const max = Math.max(20, Math.floor(settingNumber("commandPreviewChars", 96, cwd)));
 	const rawCommand = typeof args?.command === "string" ? args.command : "";
-	const command = rawCommand.length > max ? `${rawCommand.slice(0, max - 1)}…` : rawCommand;
+	const command = truncateText(rawCommand, max, cwd);
 	const commandLines = command.split(/\r?\n/);
 	const [firstLine = "", ...continuationLines] = commandLines;
 	const styledFirstLine = theme.fg("accent", firstLine);

--- a/pi-extensions/pi-tool-renderer/extensions/tool-renderer/theme.ts
+++ b/pi-extensions/pi-tool-renderer/extensions/tool-renderer/theme.ts
@@ -1,4 +1,4 @@
-import { settingEnum, treeStyle } from "./settings.js";
+import { glyphs, glyphStyle, treeGlyph as configuredTreeGlyph } from "./glyphs.js";
 
 export const FALLBACK_THEME = {
 	bg(_token: string, text: string) {
@@ -48,12 +48,8 @@ export function borderMuted(theme: any, text: string): string {
 export type TreeBranch = "├" | "└" | "│";
 
 export function treeGlyph(branch: TreeBranch, cwd?: string): string {
-	if (treeStyle(cwd) === "ascii") {
-		if (branch === "│") return "|  ";
-		return branch === "└" ? "`-- " : "|-- ";
-	}
-	if (branch === "│") return "  │ ";
-	return `  ${branch}─ `;
+	const glyph = configuredTreeGlyph(branch, cwd);
+	return glyphStyle(cwd) === "ascii" ? glyph : `  ${glyph}`;
 }
 
 export function treeConnector(theme: any, branch: TreeBranch = "├", cwd?: string): string {
@@ -61,7 +57,7 @@ export function treeConnector(theme: any, branch: TreeBranch = "├", cwd?: stri
 }
 
 export function treeStem(theme: any, branch: TreeBranch, cwd?: string): string {
-	if (branch === "└") return theme.fg("muted", treeStyle(cwd) === "ascii" ? "    " : "     ");
+	if (branch === "└") return theme.fg("muted", glyphStyle(cwd) === "ascii" ? "    " : "     ");
 	return treeConnector(theme, "│", cwd);
 }
 
@@ -69,6 +65,6 @@ export function toolLabel(theme: any, label: string): string {
 	return theme.fg("text", theme.bold(label));
 }
 
-export function stackPrefix(theme: any): string {
-	return theme.fg("accent", "● ");
+export function stackPrefix(theme: any, cwd?: string): string {
+	return theme.fg("accent", glyphs(cwd).bullet);
 }

--- a/pi-extensions/pi-tool-renderer/package.json
+++ b/pi-extensions/pi-tool-renderer/package.json
@@ -45,9 +45,36 @@
           "requiresReload": true
         },
         {
+          "key": "globalGlyphStyleOverride",
+          "label": "Global glyph style override",
+          "description": "Force glyph style for vstack-owned Pi extension UI chrome only. inherit leaves each extension's local glyphStyle/treeStyle setting in control.",
+          "type": "enum",
+          "enumValues": [
+            "inherit",
+            "unicode",
+            "ascii"
+          ],
+          "default": "inherit",
+          "category": "Rendering",
+          "apply": "live"
+        },
+        {
+          "key": "glyphStyle",
+          "label": "Glyph style",
+          "description": "Glyphs for vstack-owned UI chrome. Unicode is the default; ASCII uses plain box/status/separator characters for terminal compatibility. pi-tool-renderer's global override wins when set.",
+          "type": "enum",
+          "enumValues": [
+            "unicode",
+            "ascii"
+          ],
+          "default": "unicode",
+          "category": "Rendering",
+          "apply": "live"
+        },
+        {
           "key": "treeStyle",
-          "label": "Tree connector style",
-          "description": "Connector glyphs for compact nested tool rows. Unicode is prettier; ASCII uses |--/`-- for maximum terminal compatibility.",
+          "label": "Legacy tree connector style",
+          "description": "Legacy fallback for tree connectors when glyphStyle is unset and pi-tool-renderer globalGlyphStyleOverride is inherit. Prefer Glyph style for all UI chrome.",
           "type": "enum",
           "enumValues": [
             "unicode",

--- a/pi-extensions/pi-web-tools/README.md
+++ b/pi-extensions/pi-web-tools/README.md
@@ -82,6 +82,8 @@ Override per-mode defaults with the **Exa research mode overrides** setting (JSO
 
 Open `/extensions:settings`; settings appear under the **Web Tools** tab.
 
+Glyph style: each package exposes `glyphStyle` (`unicode` default, `ascii` for terminal-safe chrome). `@vanillagreen/pi-tool-renderer.globalGlyphStyleOverride=ascii` forces ASCII chrome across vstack Pi extensions while leaving tool/model/user content unchanged.
+
 ### General
 
 | Setting | What it does |

--- a/pi-extensions/pi-web-tools/package.json
+++ b/pi-extensions/pi-web-tools/package.json
@@ -36,6 +36,19 @@
           "requiresReload": true
         },
         {
+          "key": "glyphStyle",
+          "label": "Glyph style",
+          "description": "Glyphs for vstack-owned UI chrome. Unicode is the default; ASCII uses plain box/status/separator characters for terminal compatibility. pi-tool-renderer's global override wins when set.",
+          "type": "enum",
+          "enumValues": [
+            "unicode",
+            "ascii"
+          ],
+          "default": "unicode",
+          "category": "Rendering",
+          "apply": "live"
+        },
+        {
           "key": "autoEnable",
           "label": "Auto-enable web tools",
           "description": "Add supported web tools to the active tool set while preserving Pi native tools.",

--- a/pi-extensions/pi-web-tools/src/active-tools.ts
+++ b/pi-extensions/pi-web-tools/src/active-tools.ts
@@ -1,5 +1,6 @@
 import { exaDeepResearchAvailable, isOpenAiNativeModel, resolveWebProviderCandidates, type ModelLike } from "./provider-selection.js";
 import type { WebToolsSettings } from "./settings.js";
+import { glyphs } from "./glyphs.js";
 
 export const BASE_TOOL_NAMES = ["web_search", "web_fetch", "get_web_content"] as const;
 export const ADVANCED_TOOL_NAMES = ["web_answer", "web_find_similar", "code_search"] as const;
@@ -44,7 +45,7 @@ export function statusLines(model: ModelLike | undefined, settings: WebToolsSett
 		`autoEnable: ${settings.autoEnable}`,
 		`defaultProvider: ${settings.defaultProvider}`,
 		`enabledProviders: ${settings.enabledProviders.join(",")}`,
-		`auto provider order: ${resolveWebProviderCandidates("auto", settings, model).join(" → ") || "none"}`,
+		`auto provider order: ${resolveWebProviderCandidates("auto", settings, model).join(` ${glyphs().arrow} `) || "none"}`,
 		`OpenAI native available: ${settings.nativeOpenAiWebSearch && isOpenAiNativeModel(model)}`,
 		`Exa key: ${settings.apiKeys.exa ? "present" : "not set"}`,
 		`Exa deep research: ${exaDeepResearchAvailable(settings) ? "available" : "not available"}`,

--- a/pi-extensions/pi-web-tools/src/glyphs.ts
+++ b/pi-extensions/pi-web-tools/src/glyphs.ts
@@ -1,0 +1,122 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+export type GlyphStyle = "unicode" | "ascii";
+export type GlobalGlyphStyleOverride = "inherit" | GlyphStyle;
+
+const LOCAL_CONFIG_ID = "@vanillagreen/pi-web-tools";
+const GLOBAL_CONFIG_ID = "@vanillagreen/pi-tool-renderer";
+
+function expandHome(input: string): string {
+	if (input === "~") return homedir();
+	if (input.startsWith("~/")) return join(homedir(), input.slice(2));
+	return input;
+}
+
+function projectSettingsPath(cwd: string): string {
+	let current = resolve(cwd);
+	while (true) {
+		const candidate = join(current, ".pi", "settings.json");
+		if (existsSync(candidate)) return candidate;
+		if (existsSync(join(current, ".pi")) || existsSync(join(current, ".git")) || existsSync(join(current, ".vstack-lock.json"))) return candidate;
+		const parent = dirname(current);
+		if (parent === current) return join(resolve(cwd), ".pi", "settings.json");
+		current = parent;
+	}
+}
+
+function piSettingsPaths(cwd = process.cwd()): string[] {
+	const userDir = resolve(expandHome(process.env.PI_CODING_AGENT_DIR?.trim() || "~/.pi/agent"));
+	return [join(userDir, "settings.json"), projectSettingsPath(cwd)];
+}
+
+function readPackageConfig(packageId: string, cwd?: string): Record<string, unknown> {
+	const merged: Record<string, unknown> = {};
+	for (const settingsPath of piSettingsPaths(cwd)) {
+		if (!existsSync(settingsPath)) continue;
+		try {
+			const parsed = JSON.parse(readFileSync(settingsPath, "utf8"));
+			const config = parsed?.vstack?.extensionManager?.config?.[packageId];
+			if (config && typeof config === "object" && !Array.isArray(config)) Object.assign(merged, config);
+		} catch {
+			// Ignore malformed optional manager config.
+		}
+	}
+	return merged;
+}
+
+function asGlyphStyle(value: unknown): GlyphStyle | undefined {
+	return value === "unicode" || value === "ascii" ? value : undefined;
+}
+
+export function glyphStyle(cwd?: string): GlyphStyle {
+	const globalOverride = readPackageConfig(GLOBAL_CONFIG_ID, cwd).globalGlyphStyleOverride;
+	const forced = asGlyphStyle(globalOverride);
+	if (forced) return forced;
+	const local = readPackageConfig(LOCAL_CONFIG_ID, cwd);
+	return asGlyphStyle(local.glyphStyle) ?? asGlyphStyle(local.treeStyle) ?? "unicode";
+}
+
+export const GLYPHS = {
+	unicode: {
+		frame: { tl: "┏", tr: "┓", bl: "┗", br: "┛", h: "━", v: "┃" },
+		line: "─",
+		tree: { mid: "├─ ", last: "└─ ", stem: "│  ", blank: "   " },
+		bullet: "● ",
+		emptyBullet: "○ ",
+		dot: " · ",
+		ok: "✓",
+		fail: "✗",
+		warn: "▲",
+		diamond: "◆",
+		prompt: "π",
+		ellipsis: "…",
+		arrow: "→",
+		codeBar: "▌",
+	},
+	ascii: {
+		frame: { tl: "+", tr: "+", bl: "+", br: "+", h: "-", v: "|" },
+		line: "-",
+		tree: { mid: "|-- ", last: "`-- ", stem: "|  ", blank: "   " },
+		bullet: "* ",
+		emptyBullet: "o ",
+		dot: " - ",
+		ok: "+",
+		fail: "x",
+		warn: "!",
+		diamond: "*",
+		prompt: "pi",
+		ellipsis: "...",
+		arrow: "->",
+		codeBar: "|",
+	},
+} as const;
+
+export function glyphs(cwd?: string): (typeof GLYPHS)[GlyphStyle] {
+	return GLYPHS[glyphStyle(cwd)];
+}
+
+export function truncateIndicator(cwd?: string): string {
+	return glyphs(cwd).ellipsis;
+}
+
+export function truncateText(text: string, maxChars: number, cwd?: string): string {
+	if (text.length <= maxChars) return text;
+	const indicator = truncateIndicator(cwd);
+	return `${text.slice(0, Math.max(0, maxChars - indicator.length))}${indicator}`;
+}
+
+export function dot(cwd?: string): string {
+	return glyphs(cwd).dot;
+}
+
+export function treeGlyph(branch: "├" | "└" | "│", cwd?: string): string {
+	const tree = glyphs(cwd).tree;
+	if (branch === "│") return tree.stem;
+	return branch === "└" ? tree.last : tree.mid;
+}
+
+export function frameGlyphs(cwd?: string): (typeof GLYPHS)[GlyphStyle]["frame"] {
+	return glyphs(cwd).frame;
+}

--- a/pi-extensions/pi-web-tools/src/settings.ts
+++ b/pi-extensions/pi-web-tools/src/settings.ts
@@ -10,6 +10,7 @@ export type ResolvedWebProvider = Exclude<WebProvider, "auto">;
 
 export interface WebToolsSettings {
 	enabled: boolean;
+	glyphStyle: "unicode" | "ascii";
 	autoEnable: boolean;
 	defaultProvider: WebProvider;
 	enabledProviders: ResolvedWebProvider[];
@@ -32,6 +33,7 @@ export interface WebToolsSettings {
 
 export const DEFAULT_SETTINGS: Omit<WebToolsSettings, "apiKeys" | "warnings" | "privateConfigFile"> = {
 	enabled: true,
+	glyphStyle: "unicode",
 	autoEnable: true,
 	defaultProvider: "auto",
 	enabledProviders: ["exa", "perplexity", "gemini", "exa-mcp", "duckduckgo", "openai-native"],
@@ -136,6 +138,11 @@ function stringSetting(raw: SettingsRecord, key: string, fallback: string): stri
 function providerSetting(raw: SettingsRecord): WebProvider {
 	const value = raw.defaultProvider;
 	return WEB_PROVIDERS.includes(value as WebProvider) ? value as WebProvider : DEFAULT_SETTINGS.defaultProvider;
+}
+
+function glyphStyleSetting(raw: SettingsRecord): WebToolsSettings["glyphStyle"] {
+	const value = raw.glyphStyle;
+	return value === "ascii" || value === "unicode" ? value : DEFAULT_SETTINGS.glyphStyle;
 }
 
 function enabledProvidersSetting(raw: SettingsRecord): ResolvedWebProvider[] {
@@ -252,6 +259,7 @@ export function loadSettings(cwd = process.cwd()): WebToolsSettings {
 	const jinaKey = process.env.JINA_API_KEY || secretFrom(secrets, ["JINA_API_KEY", "jinaApiKey"]);
 	return {
 		enabled: boolSetting(raw, "enabled"),
+		glyphStyle: glyphStyleSetting(raw),
 		autoEnable: boolSetting(raw, "autoEnable"),
 		defaultProvider: providerSetting(raw),
 		enabledProviders: enabledProvidersSetting(raw),

--- a/pi-extensions/pi-web-tools/src/utils/render.ts
+++ b/pi-extensions/pi-web-tools/src/utils/render.ts
@@ -1,4 +1,5 @@
 import { Text, truncateToWidth, type Component } from "@earendil-works/pi-tui";
+import { glyphs, treeGlyph, truncateText } from "../glyphs.js";
 
 export function emptyComponent(): Component {
 	return { invalidate() {}, render: () => [] };
@@ -10,11 +11,11 @@ export function textComponent(text: string): Component {
 
 export function oneLine(value: unknown, max = 88): string {
 	const text = String(value ?? "").replace(/\s+/g, " ").trim();
-	return text.length > max ? `${text.slice(0, Math.max(0, max - 1))}…` : text;
+	return truncateText(text, max);
 }
 
 export function bullet(theme: any, tone: "accent" | "success" | "error" | "warning" = "accent"): string {
-	return theme.fg(tone, "● ");
+	return theme.fg(tone, glyphs().bullet);
 }
 
 export function toolLabel(theme: any, label: string): string {
@@ -34,8 +35,7 @@ export function accent(theme: any, text: string): string {
 }
 
 export function tree(theme: any, branch: "├" | "└" | "│" = "└"): string {
-	if (branch === "│") return theme.fg("muted", "  │ ");
-	return theme.fg("muted", `  ${branch}─ `);
+	return theme.fg("muted", `  ${treeGlyph(branch)}`);
 }
 
 export function firstText(result: any): string {
@@ -80,7 +80,7 @@ export function providerDisplayName(provider: unknown): string {
 	if (value === "mixed") return "Mixed";
 	if (value === "auto") return "Auto";
 	if (value === "session" || value === "stored") return "Session";
-	if (value === "resolving…" || value === "resolving...") return "Resolving…";
+	if (value === "resolving…" || value === "resolving...") return `Resolving${glyphs().ellipsis}`;
 	return value ? value.replace(/(^|-)([a-z])/g, (_match, sep, char) => `${sep === "-" ? " " : ""}${char.toUpperCase()}`) : "Provider";
 }
 


### PR DESCRIPTION
Fixes #168

## Summary
- add per-package glyphStyle settings and pi-tool-renderer globalGlyphStyleOverride
- centralize unicode/ascii chrome glyph tables across vstack Pi extensions
- update key renderers, package settings, docs, and glyph precedence tests

## Validation
- bun test pi-extensions/pi-tool-renderer/extensions/__tests__/glyphs.test.ts
- bun test pi-extensions/pi-codex-minimal-tools/tests/settings.test.ts
- bun test pi-extensions/pi-web-tools/tests/settings.test.ts --test-name-pattern "package settings"
- bun test pi-extensions/package-policy.test.mjs
- bun test pi-extensions/pi-extension-manager/test/popup-perf.test.ts
- bun test pi-extensions/pi-skills-manager/tests/layout.test.ts
- bun test pi-extensions/pi-agents-tmux/tests/dashboard-ux.test.ts
- vstack refresh -g
- vstack verify -g

Note: full Pi live UI testing was not run in this shell; several package tests that import Pi peer modules require host-provided @earendil-works dependencies.