### PR TITLE
Cap multi-URL web_fetch preview to fit model input window

### DIFF
--- a/pi-extensions/pi-web-tools/EXA.md
+++ b/pi-extensions/pi-web-tools/EXA.md
@@ -8,7 +8,7 @@
 |---|---|---|---|
 | `web_search provider=exa` | `POST /search` with `type: auto` by default | General web search with optional text/highlights. | Stores Exa-returned text as a **stored excerpt** capped by `textMaxCharacters` (default 12k/result). |
 | `web_research` | `POST /search` with `type: deep-lite`, `deep`, or `deep-reasoning` | Evidence-backed research. Modes tune result count, text/highlight caps, summaries, structured output, and report sidecars. | Usually writes findings/raw files; source text is provider-capped evidence, not a local crawl. |
-| `web_fetch provider=exa` or URL fetch fallback | `POST /contents` | Extract known remote URLs when forced or when direct fetch fails. | Stores Exa-returned page contents; capped by `textMaxCharacters` (default 12k/url). |
+| `web_fetch provider=exa` or URL fetch fallback | `POST /contents` | Extract known remote URLs when forced or when direct fetch fails. | Stores Exa-returned page contents; capped by `textMaxCharacters` (default 6k/url — lower than search/findSimilar because `web_fetch` can pass dozens of URLs in one call). |
 | `web_answer` | `POST /answer` | Exa performs search + LLM synthesis for a direct answer. | Answer text is returned directly; any sources with text are stored as excerpts. |
 | `web_find_similar` | `POST /findSimilar` | Find pages similar to one URL. | Stores returned source text as excerpts capped by `textMaxCharacters` (default 12k/result). |
 | `code_search` | `POST /search` with code/docs domain hints | Search code and technical docs, currently biased to GitHub/docs/Stack Overflow. | Stores returned text as excerpts. |

--- a/pi-extensions/pi-web-tools/README.md
+++ b/pi-extensions/pi-web-tools/README.md
@@ -53,6 +53,18 @@ Restart Pi after installation.
 - `textMaxCharacters` caps the immediate preview (default 4k chars).
 - `get_web_content.maxCharacters` caps retrieval (default 50k chars).
 
+### Multi-URL preview caps
+
+A single `web_fetch` call accepts many URLs via `urls`/`filePaths`. To keep `content[0].text` from blowing past the model's input window, multi-URL calls cap the aggregate preview size and emit a manifest for large batches. Single-URL calls and explicit `textMaxCharacters` opt-ins are unaffected.
+
+| URLs in call | Per-URL preview | Aggregate cap | Format |
+| --- | --- | --- | --- |
+| 1 | `textMaxCharacters` (default 4k) | — | preview blocks |
+| 2–5 | `min(textMaxCharacters, floor(16 KB / count))` | 16 KB | preview blocks |
+| 6+ | 512 chars head | 25 KB | manifest of all URLs + short preview heads |
+
+The sidecar (`pi-web-tools.content` events + `get_web_content`) still stores the full extracted text per URL — the cap only applies to the inline preview returned to the model. Pass `textMaxCharacters` to opt back into larger inlined previews when the caller knows the context budget allows it.
+
 ## API keys
 
 Set via environment variables, project `.env.local`/`.env`, or a private config file. Process env wins over files.

--- a/pi-extensions/pi-web-tools/instructions.md
+++ b/pi-extensions/pi-web-tools/instructions.md
@@ -4,7 +4,7 @@ Tool selection (pick the cheapest option that answers the question):
 - `code_search` — code patterns, library APIs, developer documentation. Token-efficient via Exa Code; the default for "how do I use X library / what's the API for Y".
 - `web_search` — general web queries; the default for "find me…" when not code-specific.
 - `web_answer` — quick cited answer to a focused factual question (single short response, not a deep dive).
-- `web_fetch` — a URL or local PDF you already have. Stores the full extracted text so later `get_web_content` calls retrieve without refetching.
+- `web_fetch` — a URL or local PDF you already have. Stores the full extracted text so later `get_web_content` calls retrieve without refetching. Multi-URL calls (2–5 URLs) shrink each per-URL preview to fit a 16 KB aggregate cap; 6+ URLs return a manifest plus short 512-char preview heads under a 25 KB aggregate cap. Pass `textMaxCharacters` to opt back into larger inlined previews; the sidecar always stores the full text.
 - `web_find_similar` — expand from a known good URL.
 - `web_research` — multi-source deep-dive findings report. Expensive; only when the user wants a researched recommendation, not a quick lookup.
 - `get_web_content` — re-read content already fetched/searched in this session by id. Never refetch what you already have.

--- a/pi-extensions/pi-web-tools/src/providers/exa.ts
+++ b/pi-extensions/pi-web-tools/src/providers/exa.ts
@@ -148,7 +148,11 @@ export class ExaClient {
 	}
 
 	async contents(params: ExaContentsParams, signal?: AbortSignal): Promise<NormalizedExaResponse> {
-		const raw = await this.post("/contents", { urls: params.urls, text: { maxCharacters: params.textMaxCharacters ?? 12000 } }, signal);
+		// Default contents text cap is intentionally lower than search/findSimilar:
+		// `web_fetch` callers can pass dozens of URLs in one call, and the previously-12k
+		// default produced hundreds of KB of inlined preview that blew the model input window.
+		// Callers can opt back into larger payloads with `textMaxCharacters`.
+		const raw = await this.post("/contents", { urls: params.urls, text: { maxCharacters: params.textMaxCharacters ?? 6000 } }, signal);
 		return { answer: synthesized(raw), results: normalizeResults(raw), raw, metadata: { urls: params.urls } };
 	}
 

--- a/pi-extensions/pi-web-tools/src/tools/web-fetch.ts
+++ b/pi-extensions/pi-web-tools/src/tools/web-fetch.ts
@@ -20,13 +20,20 @@ export const webFetchSchema = Type.Object({
 	urls: Type.Optional(Type.Array(Type.String())),
 	filePath: Type.Optional(Type.String({ description: "Local file path to extract. Currently supports PDFs. Relative paths resolve against ctx.cwd; leading @ is stripped." })),
 	filePaths: Type.Optional(Type.Array(Type.String({ description: "Local file paths to extract. Currently supports PDFs." }))),
-	textMaxCharacters: Type.Optional(Type.Number({ description: "Preview character cap for direct/GitHub/PDF fetches and provider extraction cap for Exa fallback/override. Direct fetches still store the full extracted text in session storage before preview truncation." })),
+	textMaxCharacters: Type.Optional(Type.Number({ description: "Preview character cap for direct/GitHub/PDF fetches and provider extraction cap for Exa fallback/override. Direct fetches still store the full extracted text in session storage before preview truncation. Multi-URL calls otherwise cap the aggregate `content[0].text` (16 KB for 2–5 URLs, 25 KB for 6+ URLs with a manifest); passing this flag opts back into larger per-URL previews." })),
 	provider: Type.Optional(Type.Union([Type.Literal("auto"), Type.Literal("http"), Type.Literal("exa")])),
 	prompt: Type.Optional(Type.String({ description: "Optional prompt for video/YouTube understanding (passed to Gemini Web/API). Ignored for non-video URLs." })),
 });
 export type WebFetchInput = Static<typeof webFetchSchema>;
 
 export const DEFAULT_WEB_FETCH_PREVIEW_CHARACTERS = 4000;
+
+// Multi-URL aggregate caps for `content[0].text` so a single tool call can't blow the model's input window.
+// Single-URL fetches and callers passing `textMaxCharacters` explicitly bypass these caps.
+export const MULTI_URL_AGGREGATE_CAP_SMALL_BATCH = 16 * 1024;
+export const MULTI_URL_AGGREGATE_CAP_LARGE_BATCH = 25 * 1024;
+export const MULTI_URL_LARGE_BATCH_THRESHOLD = 6;
+export const MULTI_URL_LARGE_BATCH_PER_URL_HEAD = 512;
 
 interface WebFetchPreviewItem {
 	id: string;
@@ -41,6 +48,16 @@ interface WebFetchPreviewDetails {
 	fullCharacters: number;
 	truncated: boolean;
 	items: WebFetchPreviewItem[];
+	perUrlMaxCharacters?: number;
+	aggregateCap?: number;
+	manifest?: boolean;
+	explicitMaxCharacters?: boolean;
+}
+
+export interface BuildWebFetchToolResultOptions {
+	maxCharacters?: number;
+	explicit?: boolean;
+	pageImages?: Array<{ type: "image"; mimeType: string; data: string; pageNumber?: number }>;
 }
 
 function fallbackTitle(url: string | undefined, fallback = "content"): string {
@@ -108,9 +125,58 @@ function storedProvider(stored: any[]): string {
 	return labels.length === 1 ? labels[0]! : "mixed";
 }
 
-function previewLimit(params: WebFetchInput): number {
-	const raw = params.textMaxCharacters ?? DEFAULT_WEB_FETCH_PREVIEW_CHARACTERS;
-	return Number.isFinite(raw) ? Math.max(0, Math.floor(raw)) : DEFAULT_WEB_FETCH_PREVIEW_CHARACTERS;
+function previewLimit(params: WebFetchInput): { maxCharacters: number; explicit: boolean } {
+	const raw = params.textMaxCharacters;
+	const explicit = raw != null && Number.isFinite(raw);
+	const max = explicit ? Math.max(0, Math.floor(raw as number)) : DEFAULT_WEB_FETCH_PREVIEW_CHARACTERS;
+	return { maxCharacters: max, explicit };
+}
+
+function formatBytesApprox(chars: number): string {
+	if (chars < 1024) return `${chars} chars`;
+	return `${(chars / 1024).toFixed(1)} KB`;
+}
+
+function urlExtension(url: string | undefined): string {
+	if (!url) return "";
+	try {
+		const leaf = new URL(url).pathname.split("/").filter(Boolean).pop() ?? "";
+		const dot = leaf.lastIndexOf(".");
+		return dot > 0 ? leaf.slice(dot) : "";
+	} catch {
+		const leaf = url.split("/").filter(Boolean).pop() ?? "";
+		const dot = leaf.lastIndexOf(".");
+		return dot > 0 ? leaf.slice(dot) : "";
+	}
+}
+
+function manifestRow(item: StoredWebContent): string {
+	const target = item.url || displayTitle(item);
+	const ext = urlExtension(item.url);
+	const extPart = ext ? `, ${ext}` : "";
+	return `- ${item.id}  ${target} (${formatBytesApprox(item.content.length)}${extPart})`;
+}
+
+interface AggregatePolicy {
+	perUrlMax: number;
+	aggregateCap?: number;
+	useManifest: boolean;
+}
+
+function aggregatePolicy(count: number, requested: number, explicit: boolean): AggregatePolicy {
+	if (explicit || count <= 1) return { perUrlMax: requested, aggregateCap: undefined, useManifest: false };
+	if (count < MULTI_URL_LARGE_BATCH_THRESHOLD) {
+		return {
+			perUrlMax: Math.min(requested, Math.max(0, Math.floor(MULTI_URL_AGGREGATE_CAP_SMALL_BATCH / count))),
+			aggregateCap: MULTI_URL_AGGREGATE_CAP_SMALL_BATCH,
+			useManifest: false,
+		};
+	}
+	return {
+		perUrlMax: Math.min(requested, MULTI_URL_LARGE_BATCH_PER_URL_HEAD),
+		aggregateCap: MULTI_URL_AGGREGATE_CAP_LARGE_BATCH,
+		useManifest: true,
+	};
 }
 
 function previewStats(content: string, maxCharacters: number): WebFetchPreviewItem {
@@ -123,29 +189,82 @@ function previewStats(content: string, maxCharacters: number): WebFetchPreviewIt
 	};
 }
 
-export function buildWebFetchToolResult(stored: StoredWebContent[], provider: string, maxCharacters = DEFAULT_WEB_FETCH_PREVIEW_CHARACTERS, pageImages: Array<{ type: "image"; mimeType: string; data: string; pageNumber?: number }> = []) {
+export function buildWebFetchToolResult(
+	stored: StoredWebContent[],
+	provider: string,
+	optionsOrMaxCharacters: BuildWebFetchToolResultOptions | number = {},
+	legacyPageImages: Array<{ type: "image"; mimeType: string; data: string; pageNumber?: number }> = []
+) {
+	const options: BuildWebFetchToolResultOptions = typeof optionsOrMaxCharacters === "number"
+		? { maxCharacters: optionsOrMaxCharacters, pageImages: legacyPageImages }
+		: optionsOrMaxCharacters;
+	const requestedMax = options.maxCharacters ?? DEFAULT_WEB_FETCH_PREVIEW_CHARACTERS;
+	const explicit = options.explicit ?? false;
+	const pageImages = options.pageImages ?? legacyPageImages ?? [];
+
+	const policy = aggregatePolicy(stored.length, requestedMax, explicit);
+
 	const previewItems = stored.map((item) => {
-		const stats = previewStats(item.content, maxCharacters);
-		const { text } = truncateText(item.content, maxCharacters);
+		const stats = previewStats(item.content, policy.perUrlMax);
+		const { text } = truncateText(item.content, policy.perUrlMax);
 		return { item, text, stats: { ...stats, id: item.id } };
 	});
 	const preview: WebFetchPreviewDetails = {
-		maxCharacters,
+		maxCharacters: policy.perUrlMax,
 		shownCharacters: previewItems.reduce((sum, item) => sum + item.stats.shownCharacters, 0),
 		fullCharacters: previewItems.reduce((sum, item) => sum + item.stats.fullCharacters, 0),
 		truncated: previewItems.some((item) => item.stats.truncated),
 		items: previewItems.map((item) => item.stats),
+		perUrlMaxCharacters: policy.perUrlMax,
+		aggregateCap: policy.aggregateCap,
+		manifest: policy.useManifest,
+		explicitMaxCharacters: explicit,
 	};
 	const ids = stored.map((item) => item.id).join(", ");
-	const previewText = previewItems.map(({ item, text, stats }) => {
+	const previewBlocks = previewItems.map(({ item, text, stats }) => {
 		const label = displayTitle(item);
 		const meta = `preview ${stats.shownCharacters}/${stats.fullCharacters} chars${stats.truncated ? "; full text stored" : ""}`;
 		return `- ${item.id}: ${label}\n[${meta}]\n${text}`;
 	}).join("\n\n");
 	const previewMeta = preview.truncated ? ` (${preview.shownCharacters}/${preview.fullCharacters} chars shown)` : "";
+	const totalFull = stored.reduce((sum, item) => sum + item.content.length, 0);
+
+	let head: string;
+	let body: string;
+	let tail: string;
+	if (policy.useManifest) {
+		const manifestHeader = `Fetched ${stored.length} URLs (${formatBytesApprox(totalFull)} total, stored as ${stored.length} content ids):`;
+		const manifestRows = stored.map(manifestRow).join("\n");
+		head = `${manifestHeader}\n${manifestRows}`;
+		const capNote = `Per-URL preview heads capped at ${policy.perUrlMax} chars to fit the multi-URL aggregate cap. Pass textMaxCharacters to opt back into larger inlined previews.`;
+		body = previewBlocks ? `\n\n${capNote}\n\n${previewBlocks}` : `\n\n${capNote}`;
+		tail = `\n\nCall get_web_content <id> [offset] [maxCharacters] to load full stored text per id.`;
+	} else {
+		head = `Fetched ${stored.length} URL(s). Preview returned${previewMeta}. Full extracted text is stored under content id(s): ${ids || "none"}.`;
+		body = previewBlocks ? `\n\n${previewBlocks}` : "";
+		tail = `\n\nUse get_web_content with the content id for stored full text.`;
+	}
+
+	let combined: string;
+	if (policy.aggregateCap !== undefined) {
+		const truncationMarker = `\n\n[multi-URL preview truncated to fit aggregate cap; use get_web_content with content ids for full stored text]`;
+		const bodyBudget = Math.max(0, policy.aggregateCap - head.length - tail.length - truncationMarker.length);
+		if (body.length > bodyBudget) {
+			body = body.slice(0, bodyBudget) + truncationMarker;
+		}
+		combined = head + body + tail;
+		if (combined.length > policy.aggregateCap) {
+			const fallbackBudget = Math.max(0, policy.aggregateCap - truncationMarker.length);
+			combined = combined.slice(0, fallbackBudget) + truncationMarker;
+		}
+	} else {
+		combined = head + body + tail;
+	}
+
 	const imagesNote = pageImages.length ? `\n\n[${pageImages.length} scanned PDF page image${pageImages.length === 1 ? "" : "s"} attached for vision OCR]` : "";
+	const finalText = combined + imagesNote;
 	const content: Array<{ type: "text"; text: string } | { type: "image"; mimeType: string; data: string }> = [
-		{ type: "text", text: `Fetched ${stored.length} URL(s). Preview returned${previewMeta}. Full extracted text is stored under content id(s): ${ids || "none"}.\n\n${previewText}${imagesNote}\n\nUse get_web_content with the content id for stored full text.` },
+		{ type: "text", text: finalText },
 	];
 	for (const image of pageImages) content.push({ type: "image", mimeType: image.mimeType, data: image.data });
 	return {
@@ -276,10 +395,12 @@ export function createWebFetchToolDefinition(pi: ExtensionAPI, getSettings: (cwd
 					stored.push(...await fetchWithExa(failed.map((item) => item.url)));
 				}
 				const actualProvider = storedProvider(stored);
-				return buildWebFetchToolResult(stored, params.provider === "http" ? "http" : actualProvider, previewLimit(params), pageImages);
+				const { maxCharacters, explicit } = previewLimit(params);
+				return buildWebFetchToolResult(stored, params.provider === "http" ? "http" : actualProvider, { maxCharacters, explicit, pageImages });
 			}
 			const stored = await fetchWithExa(list);
-			return buildWebFetchToolResult(stored, "exa", previewLimit(params));
+			const { maxCharacters, explicit } = previewLimit(params);
+			return buildWebFetchToolResult(stored, "exa", { maxCharacters, explicit });
 		},
 	};
 }

--- a/pi-extensions/pi-web-tools/tests/storage.test.ts
+++ b/pi-extensions/pi-web-tools/tests/storage.test.ts
@@ -6,7 +6,7 @@ import test from "node:test";
 import { clearMemoryForTests, getWebContent, restoreStoredContent, storeWebContent } from "../src/storage.js";
 import { createCodeSearchToolDefinition } from "../src/tools/code-search.js";
 import { createGetWebContentToolDefinition } from "../src/tools/get-web-content.js";
-import { buildWebFetchToolResult, createWebFetchToolDefinition, DEFAULT_WEB_FETCH_PREVIEW_CHARACTERS } from "../src/tools/web-fetch.js";
+import { buildWebFetchToolResult, createWebFetchToolDefinition, DEFAULT_WEB_FETCH_PREVIEW_CHARACTERS, MULTI_URL_AGGREGATE_CAP_LARGE_BATCH, MULTI_URL_AGGREGATE_CAP_SMALL_BATCH, MULTI_URL_LARGE_BATCH_PER_URL_HEAD, MULTI_URL_LARGE_BATCH_THRESHOLD } from "../src/tools/web-fetch.js";
 import { createWebAnswerToolDefinition } from "../src/tools/web-answer.js";
 import { createWebFindSimilarToolDefinition } from "../src/tools/web-find-similar.js";
 import { createWebSearchToolDefinition } from "../src/tools/web-search.js";
@@ -204,6 +204,91 @@ test("advanced Exa tools render compact provider-labeled summaries", () => {
 	assert.ok(expandedAnswerResult.length > answerResult.length);
 	assert.match(similarResult, /Web Find Similar \(Exa\) https:\/\/ghostty.org · 2 results/);
 	assert.match(similarResult, /Docs · https:\/\/ghostty.org\/docs/);
+});
+
+function makeStored(count: number, perItemChars: number, urlPrefix = "https://example.com/file"): Array<{ id: string; title: string; url: string; content: string; createdAt: string }> {
+	const items = [];
+	for (let index = 0; index < count; index++) {
+		items.push({
+			id: `web-${index.toString(36)}`,
+			title: `Item ${index}`,
+			url: `${urlPrefix}-${index}.rs`,
+			content: "y".repeat(perItemChars),
+			createdAt: "2026-01-01T00:00:00.000Z",
+		});
+	}
+	return items;
+}
+
+function textOfResult(result: ReturnType<typeof buildWebFetchToolResult>): string {
+	const block = result.content[0]!;
+	return block.type === "text" ? block.text : "";
+}
+
+test("web_fetch caps aggregate content[0].text for small multi-URL batches (2-5 URLs)", () => {
+	const stored = makeStored(5, 50000);
+	const result = buildWebFetchToolResult(stored, "http");
+	const text = textOfResult(result);
+	assert.ok(text.length <= MULTI_URL_AGGREGATE_CAP_SMALL_BATCH, `expected <= ${MULTI_URL_AGGREGATE_CAP_SMALL_BATCH} chars, got ${text.length}`);
+	const expectedPerUrl = Math.min(DEFAULT_WEB_FETCH_PREVIEW_CHARACTERS, Math.floor(MULTI_URL_AGGREGATE_CAP_SMALL_BATCH / 5));
+	assert.equal(result.details.preview.perUrlMaxCharacters, expectedPerUrl);
+	assert.ok(expectedPerUrl < DEFAULT_WEB_FETCH_PREVIEW_CHARACTERS, "5 URLs should shrink per-URL preview below the default cap");
+	assert.equal(result.details.preview.aggregateCap, MULTI_URL_AGGREGATE_CAP_SMALL_BATCH);
+	assert.equal(result.details.preview.manifest, false);
+	assert.equal(result.details.preview.explicitMaxCharacters, false);
+	assert.match(text, /Fetched 5 URL\(s\)/);
+	assert.match(text, /Use get_web_content with the content id for stored full text/);
+});
+
+test("web_fetch emits a manifest for large multi-URL batches (6+ URLs) and stays under 25 KB", () => {
+	const stored = makeStored(30, 50000);
+	const result = buildWebFetchToolResult(stored, "exa");
+	const text = textOfResult(result);
+	assert.ok(text.length <= MULTI_URL_AGGREGATE_CAP_LARGE_BATCH, `expected <= ${MULTI_URL_AGGREGATE_CAP_LARGE_BATCH} chars, got ${text.length}`);
+	assert.equal(result.details.preview.manifest, true);
+	assert.equal(result.details.preview.perUrlMaxCharacters, MULTI_URL_LARGE_BATCH_PER_URL_HEAD);
+	assert.match(text, /Fetched 30 URLs/);
+	assert.match(text, /stored as 30 content ids/);
+	assert.match(text, /Per-URL preview heads capped at 512 chars/);
+	assert.match(text, /Call get_web_content <id>/);
+	// Every content id should appear in the manifest section.
+	for (const item of stored) assert.ok(text.includes(item.id), `manifest missing ${item.id}`);
+});
+
+test("web_fetch threshold for large-batch manifest matches the constant", () => {
+	assert.equal(MULTI_URL_LARGE_BATCH_THRESHOLD, 6);
+	const smallBatch = buildWebFetchToolResult(makeStored(MULTI_URL_LARGE_BATCH_THRESHOLD - 1, 8000), "http");
+	const largeBatch = buildWebFetchToolResult(makeStored(MULTI_URL_LARGE_BATCH_THRESHOLD, 8000), "http");
+	assert.equal(smallBatch.details.preview.manifest, false);
+	assert.equal(largeBatch.details.preview.manifest, true);
+});
+
+test("web_fetch honors explicit textMaxCharacters and bypasses aggregate cap", () => {
+	const stored = makeStored(30, 50000);
+	const result = buildWebFetchToolResult(stored, "exa", { maxCharacters: 8000, explicit: true });
+	const text = textOfResult(result);
+	assert.equal(result.details.preview.manifest, false);
+	assert.equal(result.details.preview.perUrlMaxCharacters, 8000);
+	assert.equal(result.details.preview.aggregateCap, undefined);
+	assert.equal(result.details.preview.explicitMaxCharacters, true);
+	assert.ok(text.length > MULTI_URL_AGGREGATE_CAP_LARGE_BATCH, `expected > ${MULTI_URL_AGGREGATE_CAP_LARGE_BATCH} chars when caller opts in, got ${text.length}`);
+});
+
+test("web_fetch single-URL behavior is unchanged when textMaxCharacters omitted", () => {
+	const stored = makeStored(1, DEFAULT_WEB_FETCH_PREVIEW_CHARACTERS + 5);
+	const result = buildWebFetchToolResult(stored, "http");
+	const text = textOfResult(result);
+	assert.equal(result.details.preview.perUrlMaxCharacters, DEFAULT_WEB_FETCH_PREVIEW_CHARACTERS);
+	assert.equal(result.details.preview.manifest, false);
+	assert.match(text, /Fetched 1 URL\(s\)/);
+	assert.match(text, /Preview returned \(4000\/4005 chars shown\)/);
+});
+
+test("web_fetch backwards-compatible positional maxCharacters argument still works", () => {
+	const stored = makeStored(1, 4005);
+	const result = buildWebFetchToolResult(stored, "http", 4000);
+	const text = textOfResult(result);
+	assert.match(text, /Preview returned \(4000\/4005 chars shown\)/);
 });
 
 test("web_fetch extracts local PDF file paths into session storage", async () => {


### PR DESCRIPTION
Closes #176.

A single `web_fetch` call with many URLs returned a `toolResult` whose
`content[0].text` could be 100\u2013200+ KB. Providers serialize
`content[*].text` verbatim into the API request body, so a few multi-URL
fetches reliably exceeded the model's hard input limit
(`context_length_exceeded` against `gpt-5.5`, 272k window).

## Fix

`buildWebFetchToolResult` now applies an aggregate cap on
`content[0].text` for multi-URL calls. The per-URL sidecar
(`pi-web-tools.content` events + `get_web_content`) still stores the
full extracted text per id, so the manifest path stays fully recoverable.

| URLs in call | Per-URL preview | Aggregate cap | Format |
| --- | --- | --- | --- |
| 1 | `textMaxCharacters` (default 4k) | \u2014 | preview blocks |
| 2\u20135 | `min(textMaxCharacters, floor(16 KB / count))` | 16 KB | preview blocks |
| 6+ | 512 chars head | 25 KB | manifest of all URLs + short preview heads |

Callers that pass `textMaxCharacters` explicitly still get their requested
per-URL preview size (opt-in for large inlined previews).

Also reduces the default per-URL `contents()` text cap in the Exa client
from 12k to 6k chars, since `web_fetch` can pass dozens of URLs in one
call and the previous 12k default contributed to the same wire-payload
blow-up. Other Exa endpoints (`search`/`findSimilar`) keep their 12k
default.

## Files

- `pi-extensions/pi-web-tools/src/tools/web-fetch.ts` \u2014 aggregate cap +
  manifest path; explicit `textMaxCharacters` opt-in tracked separately
  from the default; `buildWebFetchToolResult` accepts an options bag
  (positional `maxCharacters` argument still supported for callers).
- `pi-extensions/pi-web-tools/src/providers/exa.ts` \u2014 contents default
  6k chars.
- `pi-extensions/pi-web-tools/tests/storage.test.ts` \u2014 multi-URL coverage
  (2\u20135 URL cap, 6+ URL manifest, explicit opt-in bypass, single-URL
  unchanged, positional-arg back-compat).
- `pi-extensions/pi-web-tools/README.md`, `instructions.md`, `EXA.md` \u2014
  document the new caps.

## Validation

```
cd pi-extensions/pi-web-tools && npm run check
# 94 tests passing (88 prior + 6 new)
```