### PR TITLE
Bound Pi extension session-state snapshots to prevent /resume OOM

### DIFF
--- a/pi-extensions/pi-agents-tmux/DEVELOPMENT.md
+++ b/pi-extensions/pi-agents-tmux/DEVELOPMENT.md
@@ -151,3 +151,10 @@ Status legend per row: live pane, startable, stale, background. Dashboard rows: 
 ## Pane registry mechanics
 
 Pane registries and task records are stored in sidecar files and mirrored into session custom entries only when the snapshot changes AND the session file's on-disk leaf still matches the active in-memory leaf. This prevents duplicate / orphaned Pi processes from advancing an older branch and making `/resume` land before the latest visible turns.
+
+### Bounded session-state snapshots (vstack#177)
+
+`persistRuntimeSnapshot()` enforces two guards on the `vstack-subagents:runtime-state` JSONL entry:
+
+1. **Fingerprint dedup.** A stable hash of `{ panes, tasks }` (excluding `updatedAt`) per Pi session id; identical successive snapshots short-circuit before touching the session file.
+2. **Size cap.** Default 64 KiB (`BOUNDED_SNAPSHOT_DEFAULT_MAX_BYTES`). Oversized payloads are replaced by a tiny manifest (`version: 2, fullSnapshot: false, reason: "payload-too-large", byteSize, fingerprint, counts, updatedAt`). The full registry stays on disk in `taskRegistryPath` and `paneRegistryPath`; restore continues to read those sidecars first and ignores manifest entries via `isPersistedSubagentRuntimeState`. Without this guard, a long-lived session with ~200 completed tasks accumulated ~1 GB of `vstack-subagents:runtime-state` JSONL entries and crashed `/resume` with a V8 OOM.

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/index.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/index.ts
@@ -134,6 +134,7 @@ import {
 } from "./renderers.js";
 import {
 	sessionFileTailMatchesLeaf,
+	appendBoundedSnapshot,
 	stableSessionSnapshotFingerprint,
 } from "./session-persistence.js";
 import { subagentToolRenderers } from "./subagent-render.js";
@@ -565,12 +566,25 @@ export default function (pi: ExtensionAPI) {
 		if (childAgentName) return;
 		try {
 			const [panes, tasks] = await Promise.all([readPaneRegistry(runtimeRoot), readTaskRegistry(runtimeRoot)]);
-			const fingerprint = stableSessionSnapshotFingerprint({ panes, tasks });
 			const sessionKey = ctx.sessionManager.getSessionFile?.() ?? ctx.sessionManager.getSessionId?.() ?? runtimeRoot;
+			// Fingerprint over registry only (not updatedAt) so cosmetic bumps don't burn a session entry.
+			const fingerprintInput = { panes, tasks };
+			const fingerprint = stableSessionSnapshotFingerprint(fingerprintInput);
 			if (lastRuntimeSnapshotFingerprintBySession.get(sessionKey) === fingerprint) return;
 			if (!(await sessionFileTailMatchesLeaf(ctx))) return;
-			pi.appendEntry<PersistedSubagentRuntimeState>(SUBAGENT_STATE_TYPE, { version: 1, panes, tasks, updatedAt: new Date().toISOString() });
-			lastRuntimeSnapshotFingerprintBySession.set(sessionKey, fingerprint);
+			const payload: PersistedSubagentRuntimeState = { version: 1, panes, tasks, updatedAt: new Date().toISOString() };
+			// Bounded append: full payload only when within the size cap, otherwise a tiny manifest. The on-disk
+			// pane and task registries remain canonical, so a manifest-only session entry still restores fully
+			// on /resume (vstack#177).
+			appendBoundedSnapshot({
+				appender: pi,
+				customType: SUBAGENT_STATE_TYPE,
+				payload,
+				sessionKey,
+				fingerprintInput,
+				fingerprintCache: lastRuntimeSnapshotFingerprintBySession,
+				counts: () => ({ panes: Object.keys(panes).length, tasks: Object.keys(tasks).length }),
+			});
 		} catch {
 			// Session-backed persistence is best-effort; file registries remain canonical at runtime. A stale
 			// duplicate Pi process must not advance the session leaf from an older in-memory branch.

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/session-persistence.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/session-persistence.ts
@@ -2,6 +2,86 @@ import * as fs from "node:fs";
 
 const SESSION_TAIL_BYTES = 1024 * 1024;
 
+// Default cap on the JSON byte size of any extension state custom entry
+// appended to a Pi session JSONL file. Sessions are append-only, so
+// repeatedly writing 100s of KB of full-state snapshots accumulates into
+// GB of session history that crashes `/resume` (vstack#177). Sidecar
+// state on disk remains canonical at this size and is read first on
+// restore; oversized session payloads degrade to bounded manifests or
+// are skipped entirely.
+export const BOUNDED_SNAPSHOT_DEFAULT_MAX_BYTES = 64 * 1024;
+
+export interface BoundedSnapshotManifest {
+	version: 2;
+	fullSnapshot: false;
+	reason: "payload-too-large";
+	byteSize: number;
+	fingerprint: string;
+	counts: Record<string, number>;
+	updatedAt: string;
+}
+
+export type BoundedSnapshotOutcome =
+	| { appended: false; reason: "unchanged"; byteSize: number; fingerprint: string }
+	| { appended: true; reason: "appended"; byteSize: number; fingerprint: string }
+	| { appended: true; reason: "manifest"; byteSize: number; fingerprint: string; manifest: BoundedSnapshotManifest };
+
+export interface BoundedAppenderLike {
+	appendEntry: <T>(customType: string, data: T) => unknown;
+}
+
+export interface BoundedSnapshotOptions<T> {
+	appender: BoundedAppenderLike;
+	customType: string;
+	payload: T;
+	sessionKey: string;
+	fingerprintCache: Map<string, string>;
+	/** Optional fingerprint input override. Defaults to the payload itself. */
+	fingerprintInput?: unknown;
+	/** Override per-call. Default is `BOUNDED_SNAPSHOT_DEFAULT_MAX_BYTES`. */
+	maxBytes?: number;
+	/** Counts surfaced in the manifest body (`{ tasks: 205, panes: 0 }` etc). */
+	counts?: () => Record<string, number>;
+	/** Set false to skip the manifest entry entirely when over cap. Defaults to true. */
+	manifestOnOverflow?: boolean;
+}
+
+export function appendBoundedSnapshot<T>(opts: BoundedSnapshotOptions<T>): BoundedSnapshotOutcome {
+	const maxBytes = opts.maxBytes ?? BOUNDED_SNAPSHOT_DEFAULT_MAX_BYTES;
+	const fingerprint = stableSessionSnapshotFingerprint(opts.fingerprintInput ?? opts.payload);
+	const cached = opts.fingerprintCache.get(opts.sessionKey);
+	if (cached === fingerprint) return { appended: false, reason: "unchanged", byteSize: 0, fingerprint };
+	const serialized = JSON.stringify(opts.payload) ?? "null";
+	const byteSize = Buffer.byteLength(serialized, "utf8");
+	if (byteSize <= maxBytes) {
+		opts.appender.appendEntry(opts.customType, opts.payload);
+		opts.fingerprintCache.set(opts.sessionKey, fingerprint);
+		return { appended: true, reason: "appended", byteSize, fingerprint };
+	}
+	if (opts.manifestOnOverflow === false) {
+		opts.fingerprintCache.set(opts.sessionKey, fingerprint);
+		return { appended: false, reason: "unchanged", byteSize, fingerprint };
+	}
+	const manifest: BoundedSnapshotManifest = {
+		version: 2,
+		fullSnapshot: false,
+		reason: "payload-too-large",
+		byteSize,
+		fingerprint,
+		counts: opts.counts?.() ?? {},
+		updatedAt: new Date().toISOString(),
+	};
+	opts.appender.appendEntry(opts.customType, manifest);
+	opts.fingerprintCache.set(opts.sessionKey, fingerprint);
+	return { appended: true, reason: "manifest", byteSize, fingerprint, manifest };
+}
+
+export function isBoundedSnapshotManifest(value: unknown): value is BoundedSnapshotManifest {
+	if (!value || typeof value !== "object") return false;
+	const candidate = value as Partial<BoundedSnapshotManifest>;
+	return candidate.version === 2 && candidate.fullSnapshot === false;
+}
+
 export interface SessionLeafContextLike {
 	sessionManager: {
 		getLeafId?: () => string | null | undefined;

--- a/pi-extensions/pi-agents-tmux/tests/bounded-snapshot.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/bounded-snapshot.test.ts
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+	BOUNDED_SNAPSHOT_DEFAULT_MAX_BYTES,
+	appendBoundedSnapshot,
+	isBoundedSnapshotManifest,
+} from "../extensions/subagent/session-persistence.js";
+
+interface RecordedAppend { customType: string; data: unknown }
+
+function recorder() {
+	const calls: RecordedAppend[] = [];
+	const appender = { appendEntry: <T>(customType: string, data: T) => { calls.push({ customType, data }); } };
+	return { appender, calls };
+}
+
+test("appendBoundedSnapshot appends the full payload when within the cap", () => {
+	const { appender, calls } = recorder();
+	const cache = new Map<string, string>();
+	const outcome = appendBoundedSnapshot({
+		appender,
+		customType: "vstack-subagents:runtime-state",
+		payload: { version: 1, panes: {}, tasks: {}, updatedAt: "2026-05-20T05:00:00.000Z" },
+		fingerprintInput: { panes: {}, tasks: {} },
+		sessionKey: "session-a",
+		fingerprintCache: cache,
+	});
+	assert.equal(outcome.appended, true);
+	assert.equal(outcome.reason, "appended");
+	assert.equal(calls.length, 1);
+	assert.deepEqual(calls[0].data, { version: 1, panes: {}, tasks: {}, updatedAt: "2026-05-20T05:00:00.000Z" });
+	assert.equal(cache.get("session-a"), outcome.fingerprint);
+});
+
+test("appendBoundedSnapshot skips an unchanged fingerprint", () => {
+	const { appender, calls } = recorder();
+	const cache = new Map<string, string>();
+	const opts = {
+		appender,
+		customType: "vstack-subagents:runtime-state",
+		payload: { version: 1 as const, panes: {}, tasks: {}, updatedAt: "2026-05-20T05:00:00.000Z" },
+		fingerprintInput: { panes: {}, tasks: {} },
+		sessionKey: "session-a",
+		fingerprintCache: cache,
+	};
+	appendBoundedSnapshot(opts);
+	const second = appendBoundedSnapshot({ ...opts, payload: { ...opts.payload, updatedAt: "2026-05-20T05:00:01.000Z" } });
+	assert.equal(second.appended, false);
+	assert.equal(second.reason, "unchanged");
+	assert.equal(calls.length, 1);
+});
+
+test("appendBoundedSnapshot emits a manifest when the payload exceeds the cap", () => {
+	const { appender, calls } = recorder();
+	const cache = new Map<string, string>();
+	// Build a registry that comfortably exceeds the 64 KiB cap: 200 task records with verbose summaries.
+	const tasks: Record<string, { summary: string }> = {};
+	for (let i = 0; i < 200; i += 1) {
+		tasks[`task-${i}`] = { summary: "a".repeat(512) };
+	}
+	const payload = { version: 1 as const, panes: {}, tasks, updatedAt: "2026-05-20T05:00:00.000Z" };
+	const outcome = appendBoundedSnapshot({
+		appender,
+		customType: "vstack-subagents:runtime-state",
+		payload,
+		fingerprintInput: { panes: {}, tasks },
+		sessionKey: "session-a",
+		fingerprintCache: cache,
+		counts: () => ({ panes: 0, tasks: Object.keys(tasks).length }),
+	});
+	assert.equal(outcome.appended, true);
+	assert.equal(outcome.reason, "manifest");
+	assert.ok(outcome.byteSize > BOUNDED_SNAPSHOT_DEFAULT_MAX_BYTES);
+	assert.equal(calls.length, 1);
+	const data = calls[0].data;
+	assert.ok(isBoundedSnapshotManifest(data));
+	assert.deepEqual((data as { counts: unknown }).counts, { panes: 0, tasks: 200 });
+});
+
+test("appendBoundedSnapshot can suppress manifests with manifestOnOverflow=false", () => {
+	const { appender, calls } = recorder();
+	const cache = new Map<string, string>();
+	const tasks: Record<string, string> = {};
+	for (let i = 0; i < 50; i += 1) tasks[`task-${i}`] = "a".repeat(2048);
+	const outcome = appendBoundedSnapshot({
+		appender,
+		customType: "vstack-subagents:runtime-state",
+		payload: { version: 1 as const, panes: {}, tasks, updatedAt: "x" },
+		fingerprintInput: { tasks },
+		sessionKey: "session-b",
+		fingerprintCache: cache,
+		manifestOnOverflow: false,
+	});
+	assert.equal(outcome.appended, false);
+	assert.equal(outcome.reason, "unchanged");
+	assert.equal(calls.length, 0);
+	// Cache is updated so a subsequent identical payload also short-circuits without appending.
+	assert.equal(cache.get("session-b"), outcome.fingerprint);
+});
+
+test("isBoundedSnapshotManifest only matches version 2 manifests", () => {
+	assert.equal(isBoundedSnapshotManifest({ version: 1, panes: {}, tasks: {} }), false);
+	assert.equal(isBoundedSnapshotManifest({ version: 2, fullSnapshot: false, reason: "payload-too-large", byteSize: 1, fingerprint: "x", counts: {}, updatedAt: "x" }), true);
+	assert.equal(isBoundedSnapshotManifest(null), false);
+});

--- a/pi-extensions/pi-background-tasks/DEVELOPMENT.md
+++ b/pi-extensions/pi-background-tasks/DEVELOPMENT.md
@@ -43,6 +43,15 @@ Orphan-running tasks (Pi died while the detached child kept running) are detecte
 
 Orphans rehydrate as `running` rather than synthetically `stopped`, and a periodic liveness watcher (default 30s) polls until the (pid + startToken) tuple disappears or stops matching, then finalizes the task and fires the canonical exit wake. This protects against both the kill -9 / OOM scenario (Pi gone, orphan still alive) and PID reuse: if the kernel hands the same PID to an unrelated process after the original orphan exits, the start-time mismatch is treated as `pid-reused` and the canonical exit wake fires anyway.
 
+## Bounded session-state snapshots (vstack#177)
+
+`createPersistence().persistSnapshots()` is the only writer of the `vstack-background-tasks:state` JSONL entry. It enforces two guards before calling `pi.appendEntry`:
+
+1. **Fingerprint dedup.** A stable hash of `{ tasks }` (excluding the outer `updatedAt`) per Pi session id. Identical successive task lists short-circuit and never touch the session file, so a steady-state queue does not append one entry per lifecycle event.
+2. **Size cap.** Default 64 KiB (`BG_TASKS_SNAPSHOT_MAX_BYTES`, override per `createPersistence` call via `maxEntryBytes` in tests). Oversized payloads — e.g. dozens of completed tasks with multi-KB heredoc `command` strings — are downgraded to a `version: 2, fullSnapshot: false` manifest carrying only `byteSize`, `fingerprint`, `counts.tasks`, and `updatedAt`. The full task list still lands in the sidecar at `sidecarStatePath(ctx)`; restore reads the sidecar first and `restoreSnapshots()` skips manifest entries (does not call `tasks.clear()` for them) so dashboard state survives `/resume`.
+
+`persistSnapshots()` returns `{ appendEntry, sidecar, appendReason: "appended" | "unchanged" | "manifest" | "no-active-context" | "error" }` so callers/tests can distinguish a deliberate skip from a failure.
+
 ## Tests
 
 ```

--- a/pi-extensions/pi-background-tasks/extensions/background-tasks.ts
+++ b/pi-extensions/pi-background-tasks/extensions/background-tasks.ts
@@ -187,7 +187,10 @@ export default function backgroundTasks(pi: ExtensionAPI): void {
 		}
 		for (const entry of ctx.sessionManager.getBranch()) {
 			if (entry.type === "custom" && entry.customType === BG_STATE_TYPE) {
-				const data = entry.data as { tasks?: unknown } | undefined;
+				const data = entry.data as { tasks?: unknown; version?: unknown; fullSnapshot?: unknown } | undefined;
+				// Bounded manifests (vstack#177, version 2, fullSnapshot false) record only counts.
+				// Skip them so they don't wipe the sidecar-restored state that's already loaded.
+				if (data?.version === 2 && data.fullSnapshot === false) continue;
 				tasks.clear();
 				taskCounter = 0;
 				if (Array.isArray(data?.tasks)) for (const snapshot of data.tasks) rememberRestoredSnapshot(snapshot as BackgroundTaskSnapshot);

--- a/pi-extensions/pi-background-tasks/extensions/persistence.ts
+++ b/pi-extensions/pi-background-tasks/extensions/persistence.ts
@@ -25,9 +25,47 @@ import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-a
 import { logBackgroundDiagnostic } from "./diagnostics.js";
 import type { BackgroundTaskSnapshot } from "./types.js";
 
+// Hard cap on the JSON byte size of a `vstack-background-tasks:state` custom
+// entry appended to a Pi session JSONL file. Sessions are append-only, so
+// repeatedly writing full task lists with multi-KB heredoc commands
+// accumulates 10s-100s of MB of session history that crashes `/resume`
+// (vstack#177). Sidecar state remains canonical at this size and is read
+// first on restore; oversized session payloads degrade to a tiny manifest.
+export const BG_TASKS_SNAPSHOT_MAX_BYTES = 64 * 1024;
+
+export interface BgTasksBoundedManifest {
+	version: 2;
+	fullSnapshot: false;
+	reason: "payload-too-large";
+	byteSize: number;
+	fingerprint: string;
+	counts: { tasks: number };
+	updatedAt: number;
+}
+
+export function isBgTasksBoundedManifest(value: unknown): value is BgTasksBoundedManifest {
+	if (!value || typeof value !== "object") return false;
+	const candidate = value as Partial<BgTasksBoundedManifest>;
+	return candidate.version === 2 && candidate.fullSnapshot === false;
+}
+
+function stableValue(value: unknown): unknown {
+	if (Array.isArray(value)) return value.map(stableValue);
+	if (!value || typeof value !== "object") return value;
+	const sorted: Record<string, unknown> = {};
+	for (const key of Object.keys(value as Record<string, unknown>).sort()) sorted[key] = stableValue((value as Record<string, unknown>)[key]);
+	return sorted;
+}
+
+export function stableSnapshotFingerprint(value: unknown): string {
+	return JSON.stringify(stableValue(value));
+}
+
 export interface PersistResult {
 	appendEntry: boolean;
 	sidecar: boolean;
+	/** Why the session-entry write resolved the way it did. */
+	appendReason?: "appended" | "unchanged" | "manifest" | "no-active-context" | "error";
 }
 
 export interface PersistencePayload {
@@ -42,6 +80,8 @@ export interface PersistenceDeps {
 	getActiveCtx: () => ExtensionContext | null;
 	listSnapshots: () => BackgroundTaskSnapshot[];
 	notify?: (where: string, message: string) => void;
+	/** Override the per-entry byte cap (testing). Defaults to BG_TASKS_SNAPSHOT_MAX_BYTES. */
+	maxEntryBytes?: number;
 }
 
 export function piUserDir(): string {
@@ -112,6 +152,11 @@ export function createPersistence(deps: PersistenceDeps): {
 	payloadFor: (tasks: BackgroundTaskSnapshot[]) => PersistencePayload;
 } {
 	const notify = deps.notify;
+	const maxBytes = deps.maxEntryBytes ?? BG_TASKS_SNAPSHOT_MAX_BYTES;
+	// Last fingerprint observed per Pi session id. Identical successive task
+	// lists do not re-append to JSONL; a session that mostly stays steady
+	// emits one entry per change instead of one per lifecycle event.
+	const lastFingerprintBySession = new Map<string, string>();
 
 	function payloadFor(tasks: BackgroundTaskSnapshot[]): PersistencePayload {
 		return { version: 1, tasks, updatedAt: Date.now() };
@@ -121,13 +166,54 @@ export function createPersistence(deps: PersistenceDeps): {
 		const payload = payloadFor(deps.listSnapshots());
 		const ctx = deps.getActiveCtx();
 		let appendEntryOk = false;
+		let appendReason: PersistResult["appendReason"] = ctx ? undefined : "no-active-context";
 		let sidecarOk = ctx == null;
 
-		try {
-			deps.pi.appendEntry(deps.customType, payload);
-			appendEntryOk = true;
-		} catch (error) {
-			reportPersistFailure("appendEntry", error, notify);
+		if (ctx) {
+			const sessionKey = sessionIdForContext(ctx);
+			// Fingerprint excludes updatedAt — only structural changes warrant a new session entry.
+			const fingerprint = stableSnapshotFingerprint({ tasks: payload.tasks });
+			if (lastFingerprintBySession.get(sessionKey) === fingerprint) {
+				appendEntryOk = true;
+				appendReason = "unchanged";
+			} else {
+				const serialized = JSON.stringify(payload);
+				const byteSize = Buffer.byteLength(serialized, "utf8");
+				try {
+					if (byteSize <= maxBytes) {
+						deps.pi.appendEntry(deps.customType, payload);
+						appendReason = "appended";
+					} else {
+						const manifest: BgTasksBoundedManifest = {
+							version: 2,
+							fullSnapshot: false,
+							reason: "payload-too-large",
+							byteSize,
+							fingerprint,
+							counts: { tasks: payload.tasks.length },
+							updatedAt: payload.updatedAt,
+						};
+						deps.pi.appendEntry(deps.customType, manifest);
+						appendReason = "manifest";
+					}
+					lastFingerprintBySession.set(sessionKey, fingerprint);
+					appendEntryOk = true;
+				} catch (error) {
+					appendReason = "error";
+					reportPersistFailure("appendEntry", error, notify);
+				}
+			}
+		} else {
+			// No active context — fall back to the unconditional append so a one-shot/
+			// no-context call still records something. Bounded restore is irrelevant
+			// without a session.
+			try {
+				deps.pi.appendEntry(deps.customType, payload);
+				appendEntryOk = true;
+			} catch (error) {
+				appendReason = "error";
+				reportPersistFailure("appendEntry", error, notify);
+			}
 		}
 
 		if (ctx) {
@@ -139,7 +225,7 @@ export function createPersistence(deps: PersistenceDeps): {
 			}
 		}
 
-		return { appendEntry: appendEntryOk, sidecar: sidecarOk };
+		return { appendEntry: appendEntryOk, sidecar: sidecarOk, appendReason };
 	}
 
 	return { persistSnapshots, payloadFor };

--- a/pi-extensions/pi-background-tasks/tests/bounded-snapshot.test.ts
+++ b/pi-extensions/pi-background-tasks/tests/bounded-snapshot.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+	BG_TASKS_SNAPSHOT_MAX_BYTES,
+	createPersistence,
+	isBgTasksBoundedManifest,
+} from "../extensions/persistence.js";
+import type { BackgroundTaskSnapshot } from "../extensions/types.js";
+
+function fakeSnapshot(overrides: Partial<BackgroundTaskSnapshot> = {}): BackgroundTaskSnapshot {
+	return {
+		command: "printf ready",
+		cwd: "/tmp/worktree",
+		exitCode: null,
+		exitNotified: false,
+		expiresAt: null,
+		id: overrides.id ?? "bg-1",
+		lastOutputAt: 0,
+		logFile: "/tmp/bg-1.log",
+		notifyMode: "always",
+		notifyOnExit: true,
+		notifyOnOutput: false,
+		outputBytes: 0,
+		pid: 1234,
+		startedAt: 1_700_000_000_000,
+		status: "completed",
+		title: "fake task",
+		updatedAt: 1_700_000_000_500,
+		voidedWakeSequences: [],
+		wakeEvents: [],
+		wakeSequence: 0,
+		...overrides,
+	};
+}
+
+function fakeCtx(sessionId: string) {
+	const tempDir = mkdtempSync(join(tmpdir(), "pi-bg-persistence-"));
+	return {
+		cwd: tempDir,
+		sessionManager: {
+			getSessionId: () => sessionId,
+			getSessionFile: () => join(tempDir, `${sessionId}.jsonl`),
+		},
+	} as any;
+}
+
+describe("pi-background-tasks bounded snapshots", () => {
+	test("appendEntry skips identical successive task lists and re-fires on real change", () => {
+		const appended: { customType: string; payload: any }[] = [];
+		const ctx = fakeCtx("session-stable");
+		const stable: BackgroundTaskSnapshot = fakeSnapshot({ id: "bg-1", status: "running", updatedAt: 1 });
+		let snapshots: BackgroundTaskSnapshot[] = [stable];
+		const persistence = createPersistence({
+			customType: "vstack-background-tasks:state",
+			getActiveCtx: () => ctx,
+			listSnapshots: () => snapshots,
+			pi: { appendEntry: (customType: string, payload: any) => appended.push({ customType, payload }) } as any,
+		});
+
+		const first = persistence.persistSnapshots();
+		const second = persistence.persistSnapshots();
+		expect(first.appendEntry).toBe(true);
+		expect(first.appendReason).toBe("appended");
+		expect(second.appendEntry).toBe(true);
+		expect(second.appendReason).toBe("unchanged");
+		expect(appended).toHaveLength(1);
+
+		// Actual content change appends again.
+		snapshots = [fakeSnapshot({ id: "bg-1", status: "completed", updatedAt: 3 })];
+		const third = persistence.persistSnapshots();
+		expect(third.appendReason).toBe("appended");
+		expect(appended).toHaveLength(2);
+	});
+
+	test("payloads over the byte cap downgrade to a bounded manifest", () => {
+		const appended: { customType: string; payload: any }[] = [];
+		const ctx = fakeCtx("session-bloated");
+		// 70 completed tasks each carrying a 10 KiB heredoc command (vstack#177).
+		const heredoc = "x".repeat(10 * 1024);
+		const snapshots: BackgroundTaskSnapshot[] = Array.from({ length: 70 }, (_value, index) => fakeSnapshot({
+			id: `bg-${index}`,
+			command: heredoc,
+			logFile: `/tmp/bg-${index}.log`,
+			status: "completed",
+		}));
+		const persistence = createPersistence({
+			customType: "vstack-background-tasks:state",
+			getActiveCtx: () => ctx,
+			listSnapshots: () => snapshots,
+			pi: { appendEntry: (customType: string, payload: any) => appended.push({ customType, payload }) } as any,
+		});
+		const result = persistence.persistSnapshots();
+		expect(result.appendReason).toBe("manifest");
+		expect(appended).toHaveLength(1);
+		expect(isBgTasksBoundedManifest(appended[0].payload)).toBe(true);
+		expect(appended[0].payload.counts.tasks).toBe(70);
+		expect(appended[0].payload.byteSize).toBeGreaterThan(BG_TASKS_SNAPSHOT_MAX_BYTES);
+	});
+
+	test("manifest restores degrade gracefully: restore loop does not wipe sidecar state", () => {
+		const manifest = {
+			version: 2,
+			fullSnapshot: false,
+			reason: "payload-too-large" as const,
+			byteSize: 999_999,
+			fingerprint: "abc",
+			counts: { tasks: 70 },
+			updatedAt: Date.now(),
+		};
+		expect(isBgTasksBoundedManifest(manifest)).toBe(true);
+		expect(isBgTasksBoundedManifest({ version: 1, tasks: [], updatedAt: 0 })).toBe(false);
+	});
+});

--- a/pi-extensions/pi-caveman/extensions/caveman.ts
+++ b/pi-extensions/pi-caveman/extensions/caveman.ts
@@ -255,9 +255,22 @@ export default function caveman(pi: ExtensionAPI): void {
 	};
 	host[BRIDGE_SYMBOL] = bridge;
 
+	const lastFingerprintBySession = new Map<string, string>();
 	const persist = () => {
 		const snapshot: CavemanState = { ...state, updatedAt: new Date().toISOString() };
-		pi.appendEntry<CavemanState>(STATE_TYPE, snapshot);
+		if (activeCtx) {
+			const sessionKey = sessionIdForContext(activeCtx);
+			// Fingerprint excludes updatedAt so identical mode toggles don't append another full snapshot
+			// to the JSONL session log (vstack#177).
+			const { updatedAt: _ignored, ...rest } = snapshot;
+			const fingerprint = JSON.stringify(rest);
+			if (lastFingerprintBySession.get(sessionKey) !== fingerprint) {
+				pi.appendEntry<CavemanState>(STATE_TYPE, snapshot);
+				lastFingerprintBySession.set(sessionKey, fingerprint);
+			}
+		} else {
+			pi.appendEntry<CavemanState>(STATE_TYPE, snapshot);
+		}
 		if (!activeCtx) return;
 		try {
 			const file = sidecarStatePath(activeCtx);

--- a/pi-extensions/pi-task-panel/extensions/task-panel.ts
+++ b/pi-extensions/pi-task-panel/extensions/task-panel.ts
@@ -25,6 +25,36 @@ import {
 const INSTALL_SYMBOL = Symbol.for("vstack.pi-task-panel.installed");
 const CONFIG_ID = "@vanillagreen/pi-task-panel";
 const STATE_TYPE = "vstack-task-panel:state";
+const TASK_PANEL_SNAPSHOT_MAX_BYTES = 64 * 1024;
+
+function stableValue(value: unknown): unknown {
+	if (Array.isArray(value)) return value.map(stableValue);
+	if (!value || typeof value !== "object") return value;
+	const sorted: Record<string, unknown> = {};
+	for (const key of Object.keys(value as Record<string, unknown>).sort()) sorted[key] = stableValue((value as Record<string, unknown>)[key]);
+	return sorted;
+}
+
+function stableTaskPanelFingerprint(state: TaskPanelState): string {
+	const { updatedAt: _ignored, ...rest } = state as TaskPanelState & { updatedAt?: string };
+	return JSON.stringify(stableValue(rest));
+}
+
+interface TaskPanelBoundedManifest {
+	version: 2;
+	fullSnapshot: false;
+	reason: "payload-too-large";
+	byteSize: number;
+	fingerprint: string;
+	counts: { tasks: number; phases: number };
+	updatedAt: string;
+}
+
+function isTaskPanelBoundedManifest(value: unknown): value is TaskPanelBoundedManifest {
+	if (!value || typeof value !== "object") return false;
+	const candidate = value as Partial<TaskPanelBoundedManifest>;
+	return candidate.version === 2 && candidate.fullSnapshot === false;
+}
 const TASK_CONTEXT_TYPE = "vstack-task-panel:context";
 const TASK_COMPLETE_MESSAGE_TYPE = "vstack-task-panel:complete";
 const WIDGET_KEY = "vstack-task-panel";
@@ -782,17 +812,49 @@ export default function taskPanel(pi: ExtensionAPI): void {
 		}
 	};
 
+	const lastFingerprintBySession = new Map<string, string>();
+
 	const persist = () => {
 		state.updatedAt = new Date().toISOString();
-		pi.appendEntry<TaskPanelState>(STATE_TYPE, cloneState(state));
 		writeSidecar(activeCtx);
+		if (!activeCtx) {
+			// No active session context — fall back to the unconditional append.
+			pi.appendEntry<TaskPanelState>(STATE_TYPE, cloneState(state));
+			return;
+		}
+		const sessionKey = sessionIdForContext(activeCtx);
+		// Fingerprint excludes updatedAt so cosmetic timestamp bumps don't burn a session entry (vstack#177).
+		const fingerprint = stableTaskPanelFingerprint(state);
+		if (lastFingerprintBySession.get(sessionKey) === fingerprint) return;
+		const snapshot = cloneState(state);
+		const serialized = JSON.stringify(snapshot);
+		const byteSize = Buffer.byteLength(serialized, "utf8");
+		if (byteSize <= TASK_PANEL_SNAPSHOT_MAX_BYTES) {
+			pi.appendEntry<TaskPanelState>(STATE_TYPE, snapshot);
+		} else {
+			const manifest: TaskPanelBoundedManifest = {
+				version: 2,
+				fullSnapshot: false,
+				reason: "payload-too-large",
+				byteSize,
+				fingerprint,
+				counts: { tasks: state.tasks.length, phases: state.phases.length },
+				updatedAt: state.updatedAt,
+			};
+			pi.appendEntry<TaskPanelBoundedManifest>(STATE_TYPE, manifest);
+		}
+		lastFingerprintBySession.set(sessionKey, fingerprint);
 	};
 
 	const restore = (ctx: ExtensionContext) => {
 		activeCtx = ctx;
 		state = readSidecar(ctx) ?? emptyState(ctx.cwd);
 		for (const entry of ctx.sessionManager.getBranch()) {
-			if (entry.type === "custom" && entry.customType === STATE_TYPE) state = normalizeState(entry.data, ctx.cwd);
+			if (entry.type === "custom" && entry.customType === STATE_TYPE) {
+				// Bounded manifests carry only counts; sidecar restore wins (vstack#177).
+				if (isTaskPanelBoundedManifest(entry.data)) continue;
+				state = normalizeState(entry.data, ctx.cwd);
+			}
 			if (entry.type === "message" && entry.message.role === "toolResult" && entry.message.toolName === "tasks_write") {
 				const restored = normalizeState(entry.message.details?.state, ctx.cwd);
 				if (restored.tasks.length > 0 || restored.phases.length > 0) state = restored;


### PR DESCRIPTION
## Summary

vstack Pi extensions appended full-state snapshots to the Pi JSONL session file on every lifecycle event. With ~200 completed subagent tasks per session, `vstack-subagents:runtime-state` alone accumulated 100s of MB to 1 GB of append-only history per session; Pi's `/resume` reads each session back through `readFile` + `JSON.parse` and crashed with a V8 OOM.

Adds a bounded session-state append policy to all four vstack state extensions. Sidecar files remain canonical state; the session JSONL only carries a bounded manifest when the full payload exceeds the cap, which keeps `/resume` cheap even with hundreds of completed tasks.

## Changes per extension

- **pi-agents-tmux** — extend `session-persistence.ts` with `appendBoundedSnapshot()` and route `persistRuntimeSnapshot()` through it. Fingerprint over `{ panes, tasks }` per Pi session id + a 64 KiB cap. Oversized payloads emit a `version: 2, fullSnapshot: false, reason: "payload-too-large"` manifest with byteSize / fingerprint / counts / updatedAt. The pane and task registry sidecar files remain canonical so restore continues to work — `isPersistedSubagentRuntimeState` already rejects manifest entries.
- **pi-background-tasks** — `createPersistence().persistSnapshots()` applies the same fingerprint + 64 KiB cap to `vstack-background-tasks:state` and returns an `appendReason` for diagnostics. `background-tasks.ts` restore loop now skips manifest entries so they don't wipe sidecar-restored task state.
- **pi-task-panel** — fingerprint dedup against repeated identical payloads + the same 64 KiB cap on `vstack-task-panel:state` for symmetry. Restore skips manifest entries.
- **pi-caveman** — fingerprint dedup; state is small enough that the cap is effectively never hit in practice.

## Why this matches the brief's plan

- **Bounded session-state append policy** with stable fingerprint (excluding cosmetic `updatedAt`), size cap (default 64 KiB), and an optional `version: 2, fullSnapshot: false` manifest for oversized payloads — applied to all four state extensions.
- **Restore is sidecar-first** for all four extensions, so a manifest-only session entry still restores fully; the restore loops explicitly ignore manifest entries instead of clearing state.
- **Repeated unchanged state no longer appends** — both fingerprint cache layers short-circuit successive identical payloads.

## Tests

New regression tests:

- `pi-extensions/pi-agents-tmux/tests/bounded-snapshot.test.ts` — append/unchanged/manifest/manifestOnOverflow=false paths, type guard.
- `pi-extensions/pi-background-tasks/tests/bounded-snapshot.test.ts` — fingerprint dedup, 70-task heredoc payload downgrades to manifest, manifest type guard.

\`\`\`
cd pi-extensions/pi-agents-tmux && bun test ./tests ./extensions/subagent/__tests__
cd pi-extensions/pi-background-tasks && bun test ./tests ./extensions/__tests__
\`\`\`

All bounded-snapshot tests pass; the only pre-existing failure (`steer-subagent-dashboard-status.test.ts` cannot find `typebox`) reproduces on `main` without these changes.

## Out of scope (per the brief)

- P1 \`vstack pi prune-sessions\` cleanup CLI for already-bloated JSONL files. The primary fix is to stop appending unbounded full-state snapshots; recovery tooling can land in a follow-up if needed.
- pi-web-tools model-context bloat (tracked separately in #176).
- Upstream Pi session-selector streaming.

Fixes #177