### PR TITLE
Fix bounded-snapshot manifest cap defeat (#183) + restore-loop sidecar regression (#184)

### DIFF
--- a/pi-extensions/pi-agents-tmux/extensions/subagent/session-persistence.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/session-persistence.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import * as fs from "node:fs";
 
 const SESSION_TAIL_BYTES = 1024 * 1024;
@@ -71,6 +72,14 @@ export function appendBoundedSnapshot<T>(opts: BoundedSnapshotOptions<T>): Bound
 		counts: opts.counts?.() ?? {},
 		updatedAt: new Date().toISOString(),
 	};
+	// vstack#183 defensive: the manifest itself must stay under the cap.
+	// With the SHA-256 fingerprint the body is bounded, but the assertion
+	// catches future field growth that would silently regress the fix.
+	const manifestBytes = Buffer.byteLength(JSON.stringify(manifest) ?? "null", "utf8");
+	if (manifestBytes > maxBytes) {
+		opts.fingerprintCache.set(opts.sessionKey, fingerprint);
+		return { appended: false, reason: "unchanged", byteSize, fingerprint };
+	}
 	opts.appender.appendEntry(opts.customType, manifest);
 	opts.fingerprintCache.set(opts.sessionKey, fingerprint);
 	return { appended: true, reason: "manifest", byteSize, fingerprint, manifest };
@@ -97,8 +106,12 @@ function stableValue(value: unknown): unknown {
 	return sorted;
 }
 
+// vstack#183: fingerprints are persisted inside the overflow manifest;
+// returning the full canonical JSON defeats the byte cap that the
+// manifest exists to enforce. Hash the stable JSON down to a fixed-size
+// hex digest so an oversized payload yields a small manifest.
 export function stableSessionSnapshotFingerprint(value: unknown): string {
-	return JSON.stringify(stableValue(value));
+	return createHash("sha256").update(JSON.stringify(stableValue(value))).digest("hex");
 }
 
 function lastEntryIdFromText(text: string): string | undefined {

--- a/pi-extensions/pi-agents-tmux/tests/bounded-snapshot.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/bounded-snapshot.test.ts
@@ -98,6 +98,36 @@ test("appendBoundedSnapshot can suppress manifests with manifestOnOverflow=false
 	assert.equal(cache.get("session-b"), outcome.fingerprint);
 });
 
+test("appendBoundedSnapshot emits a bounded manifest under the cap even when the payload is many MB (vstack#183)", () => {
+	const { appender, calls } = recorder();
+	const cache = new Map<string, string>();
+	// Build a registry well above 64 KiB — ~1 MB of task records. Pre-fix
+	// the manifest body would have embedded the full JSON as `fingerprint`
+	// and reproduced the cap blow-up.
+	const tasks: Record<string, { summary: string }> = {};
+	for (let i = 0; i < 1000; i += 1) tasks[`task-${i}`] = { summary: "a".repeat(1024) };
+	const payload = { version: 1 as const, panes: {}, tasks, updatedAt: "2026-05-20T05:00:00.000Z" };
+	const outcome = appendBoundedSnapshot({
+		appender,
+		customType: "vstack-subagents:runtime-state",
+		payload,
+		fingerprintInput: { panes: {}, tasks },
+		sessionKey: "session-c",
+		fingerprintCache: cache,
+		counts: () => ({ panes: 0, tasks: Object.keys(tasks).length }),
+	});
+	assert.equal(outcome.appended, true);
+	assert.equal(outcome.reason, "manifest");
+	const data = calls[0].data;
+	assert.ok(isBoundedSnapshotManifest(data));
+	const manifestBytes = Buffer.byteLength(JSON.stringify(data), "utf8");
+	assert.ok(manifestBytes <= BOUNDED_SNAPSHOT_DEFAULT_MAX_BYTES, `manifest size ${manifestBytes}B exceeds cap ${BOUNDED_SNAPSHOT_DEFAULT_MAX_BYTES}B`);
+	// The fingerprint must be a fixed-size hex digest, not the full canonical JSON.
+	const fingerprint = (data as { fingerprint: string }).fingerprint;
+	assert.match(fingerprint, /^[0-9a-f]+$/);
+	assert.ok(fingerprint.length <= 128, `fingerprint length ${fingerprint.length} unexpectedly large`);
+});
+
 test("isBoundedSnapshotManifest only matches version 2 manifests", () => {
 	assert.equal(isBoundedSnapshotManifest({ version: 1, panes: {}, tasks: {} }), false);
 	assert.equal(isBoundedSnapshotManifest({ version: 2, fullSnapshot: false, reason: "payload-too-large", byteSize: 1, fingerprint: "x", counts: {}, updatedAt: "x" }), true);

--- a/pi-extensions/pi-background-tasks/extensions/background-tasks.ts
+++ b/pi-extensions/pi-background-tasks/extensions/background-tasks.ts
@@ -62,7 +62,7 @@ import { logBackgroundDiagnostic } from "./diagnostics.js";
 import { registerAll } from "./registrations.js";
 import { finalizeTaskLifecycle, replayMissedExitsLifecycle, type LifecycleHooks } from "./lifecycle.js";
 import { createOrphanWatcher, type OrphanWatcher } from "./orphan-watcher.js";
-import { createPersistence, sessionIdForContext, sidecarStatePath } from "./persistence.js";
+import { applyCustomEntryWithBarrier, createPersistence, sessionIdForContext, sidecarStatePath } from "./persistence.js";
 import { logFilePath, settingBoolean, settingEnum, settingNumber, settingString, taskEnv } from "./settings.js";
 import {
 	defaultReadProcessIdentity,
@@ -193,23 +193,13 @@ export default function backgroundTasks(pi: ExtensionAPI): void {
 		}
 		for (const entry of ctx.sessionManager.getBranch()) {
 			if (entry.type === "custom" && entry.customType === BG_STATE_TYPE) {
-				const data = entry.data as { tasks?: unknown; version?: unknown; fullSnapshot?: unknown } | undefined;
-				// vstack#184: any `fullSnapshot: false` manifest is a sidecar-wins
-				// barrier. Without this, an older full snapshot earlier in the
-				// branch can replace the sidecar-restored state before the manifest
-				// is reached, regressing canonical state to stale data. Re-load
-				// sidecar at the barrier so canonical state survives the iteration.
-				if (data?.fullSnapshot === false) {
-					if (sidecarLoaded && sidecarTasks) {
-						tasks.clear();
-						taskCounter = 0;
-						for (const snapshot of sidecarTasks) rememberRestoredSnapshot(snapshot);
-					}
-					continue;
-				}
-				tasks.clear();
-				taskCounter = 0;
-				if (Array.isArray(data?.tasks)) for (const snapshot of data.tasks) rememberRestoredSnapshot(snapshot as BackgroundTaskSnapshot);
+				applyCustomEntryWithBarrier({
+					data: entry.data,
+					sidecarLoaded,
+					sidecarTasks,
+					clear: () => { tasks.clear(); taskCounter = 0; },
+					apply: (snapshot) => rememberRestoredSnapshot(snapshot),
+				});
 			}
 			if (entry.type === "message" && entry.message.role === "toolResult" && (entry.message.toolName === "bg_task" || entry.message.toolName === "bg_status")) {
 				const details = entry.message.details as { task?: unknown; tasks?: unknown } | undefined;

--- a/pi-extensions/pi-background-tasks/extensions/background-tasks.ts
+++ b/pi-extensions/pi-background-tasks/extensions/background-tasks.ts
@@ -174,11 +174,17 @@ export default function backgroundTasks(pi: ExtensionAPI): void {
 		tasks.clear();
 		taskCounter = 0;
 		activeSessionId = sessionIdForContext(ctx);
+		let sidecarLoaded = false;
+		let sidecarTasks: BackgroundTaskSnapshot[] | undefined;
 		try {
 			const file = sidecarStatePath(ctx);
 			if (existsSync(file)) {
 				const data = JSON.parse(readFileSync(file, "utf8")) as { tasks?: unknown };
-				if (Array.isArray(data?.tasks)) for (const snapshot of data.tasks) rememberRestoredSnapshot(snapshot as BackgroundTaskSnapshot);
+				if (Array.isArray(data?.tasks)) {
+					sidecarTasks = data.tasks as BackgroundTaskSnapshot[];
+					for (const snapshot of sidecarTasks) rememberRestoredSnapshot(snapshot);
+					sidecarLoaded = true;
+				}
 			}
 		} catch (error) {
 			const msg = error instanceof Error ? error.message : String(error);
@@ -188,9 +194,19 @@ export default function backgroundTasks(pi: ExtensionAPI): void {
 		for (const entry of ctx.sessionManager.getBranch()) {
 			if (entry.type === "custom" && entry.customType === BG_STATE_TYPE) {
 				const data = entry.data as { tasks?: unknown; version?: unknown; fullSnapshot?: unknown } | undefined;
-				// Bounded manifests (vstack#177, version 2, fullSnapshot false) record only counts.
-				// Skip them so they don't wipe the sidecar-restored state that's already loaded.
-				if (data?.version === 2 && data.fullSnapshot === false) continue;
+				// vstack#184: any `fullSnapshot: false` manifest is a sidecar-wins
+				// barrier. Without this, an older full snapshot earlier in the
+				// branch can replace the sidecar-restored state before the manifest
+				// is reached, regressing canonical state to stale data. Re-load
+				// sidecar at the barrier so canonical state survives the iteration.
+				if (data?.fullSnapshot === false) {
+					if (sidecarLoaded && sidecarTasks) {
+						tasks.clear();
+						taskCounter = 0;
+						for (const snapshot of sidecarTasks) rememberRestoredSnapshot(snapshot);
+					}
+					continue;
+				}
 				tasks.clear();
 				taskCounter = 0;
 				if (Array.isArray(data?.tasks)) for (const snapshot of data.tasks) rememberRestoredSnapshot(snapshot as BackgroundTaskSnapshot);

--- a/pi-extensions/pi-background-tasks/extensions/persistence.ts
+++ b/pi-extensions/pi-background-tasks/extensions/persistence.ts
@@ -50,6 +50,38 @@ export function isBgTasksBoundedManifest(value: unknown): value is BgTasksBounde
 	return candidate.version === 2 && candidate.fullSnapshot === false;
 }
 
+// vstack#184: extracted from background-tasks.ts so the barrier semantics
+// can be unit tested without dragging the full @earendil-works/pi-coding-agent
+// dependency chain into the test runtime. Handles a single session-branch
+// custom entry of type BG_STATE_TYPE.
+//
+// When the entry is a bounded manifest (`fullSnapshot: false`, any
+// version), and a sidecar restore has already loaded the canonical
+// task set, re-apply the sidecar tasks. The manifest signals "sidecar
+// is authoritative as of this point"; without this, an older full
+// snapshot earlier in the branch can replace the sidecar-restored
+// state before the manifest is reached and regress canonical state.
+export interface ApplyCustomEntryArgs<T> {
+	data: unknown;
+	sidecarLoaded: boolean;
+	sidecarTasks: T[] | undefined;
+	clear: () => void;
+	apply: (snapshot: T) => void;
+}
+
+export function applyCustomEntryWithBarrier<T>(args: ApplyCustomEntryArgs<T>): void {
+	const data = args.data as { tasks?: unknown; fullSnapshot?: unknown } | undefined;
+	if (data?.fullSnapshot === false) {
+		if (args.sidecarLoaded && args.sidecarTasks) {
+			args.clear();
+			for (const snapshot of args.sidecarTasks) args.apply(snapshot);
+		}
+		return;
+	}
+	args.clear();
+	if (Array.isArray(data?.tasks)) for (const snapshot of data.tasks) args.apply(snapshot as T);
+}
+
 function stableValue(value: unknown): unknown {
 	if (Array.isArray(value)) return value.map(stableValue);
 	if (!value || typeof value !== "object") return value;

--- a/pi-extensions/pi-background-tasks/extensions/persistence.ts
+++ b/pi-extensions/pi-background-tasks/extensions/persistence.ts
@@ -12,6 +12,7 @@
 // can pass it the current view of the task map without re-importing
 // everything per call.
 
+import { createHash } from "node:crypto";
 import {
 	mkdirSync,
 	renameSync,
@@ -57,15 +58,19 @@ function stableValue(value: unknown): unknown {
 	return sorted;
 }
 
+// vstack#183: fingerprints are persisted inside the overflow manifest;
+// returning the full canonical JSON defeats the byte cap. Hash to a
+// fixed-size hex digest so an oversized task list yields a small
+// manifest even when the underlying payload is many MB.
 export function stableSnapshotFingerprint(value: unknown): string {
-	return JSON.stringify(stableValue(value));
+	return createHash("sha256").update(JSON.stringify(stableValue(value))).digest("hex");
 }
 
 export interface PersistResult {
 	appendEntry: boolean;
 	sidecar: boolean;
 	/** Why the session-entry write resolved the way it did. */
-	appendReason?: "appended" | "unchanged" | "manifest" | "no-active-context" | "error";
+	appendReason?: "appended" | "unchanged" | "manifest" | "manifest-oversize-skipped" | "no-active-context" | "error";
 }
 
 export interface PersistencePayload {
@@ -183,6 +188,8 @@ export function createPersistence(deps: PersistenceDeps): {
 					if (byteSize <= maxBytes) {
 						deps.pi.appendEntry(deps.customType, payload);
 						appendReason = "appended";
+						lastFingerprintBySession.set(sessionKey, fingerprint);
+						appendEntryOk = true;
 					} else {
 						const manifest: BgTasksBoundedManifest = {
 							version: 2,
@@ -193,11 +200,18 @@ export function createPersistence(deps: PersistenceDeps): {
 							counts: { tasks: payload.tasks.length },
 							updatedAt: payload.updatedAt,
 						};
-						deps.pi.appendEntry(deps.customType, manifest);
-						appendReason = "manifest";
+						// vstack#183 defensive: the manifest must stay under the cap.
+						const manifestBytes = Buffer.byteLength(JSON.stringify(manifest), "utf8");
+						if (manifestBytes > maxBytes) {
+							appendReason = "manifest-oversize-skipped";
+							reportPersistFailure("appendEntry", new Error(`bounded manifest ${manifestBytes}B exceeds cap ${maxBytes}B; sidecar remains canonical`), notify);
+						} else {
+							deps.pi.appendEntry(deps.customType, manifest);
+							appendReason = "manifest";
+							lastFingerprintBySession.set(sessionKey, fingerprint);
+							appendEntryOk = true;
+						}
 					}
-					lastFingerprintBySession.set(sessionKey, fingerprint);
-					appendEntryOk = true;
 				} catch (error) {
 					appendReason = "error";
 					reportPersistFailure("appendEntry", error, notify);

--- a/pi-extensions/pi-background-tasks/tests/bounded-snapshot.test.ts
+++ b/pi-extensions/pi-background-tasks/tests/bounded-snapshot.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 
 import {
 	BG_TASKS_SNAPSHOT_MAX_BYTES,
+	applyCustomEntryWithBarrier,
 	createPersistence,
 	isBgTasksBoundedManifest,
 } from "../extensions/persistence.js";
@@ -128,7 +129,7 @@ describe("pi-background-tasks bounded snapshots", () => {
 		expect(fingerprint.length).toBeLessThanOrEqual(128);
 	});
 
-	test("manifest restores degrade gracefully: restore loop does not wipe sidecar state", () => {
+	test("manifest type guard matches v2 fullSnapshot:false envelope only", () => {
 		const manifest = {
 			version: 2,
 			fullSnapshot: false,
@@ -140,5 +141,72 @@ describe("pi-background-tasks bounded snapshots", () => {
 		};
 		expect(isBgTasksBoundedManifest(manifest)).toBe(true);
 		expect(isBgTasksBoundedManifest({ version: 1, tasks: [], updatedAt: 0 })).toBe(false);
+	});
+
+	test("vstack#184: restore barrier - manifest entry re-applies sidecar state", () => {
+		// Repro shape: branch contains [older-full-snapshot, later bounded
+		// manifest]. Sidecar has the latest task set ("bg-new"). Pre-fix the
+		// older full snapshot replaced the sidecar state and the manifest
+		// was skipped, regressing canonical state to "bg-old". The barrier
+		// helper now restores the sidecar when it hits the manifest.
+		const sidecarTasks: BackgroundTaskSnapshot[] = [fakeSnapshot({ id: "bg-new", status: "completed" })];
+		const olderTasks: BackgroundTaskSnapshot[] = [fakeSnapshot({ id: "bg-old", status: "completed" })];
+		let current: BackgroundTaskSnapshot[] = [];
+		const clear = () => { current = []; };
+		const apply = (snapshot: BackgroundTaskSnapshot) => { current.push(snapshot); };
+
+		// Sidecar restore happened first (current = sidecar tasks).
+		current = [...sidecarTasks];
+
+		// Branch entry #1: older full snapshot. Expected to replace.
+		applyCustomEntryWithBarrier({
+			data: { tasks: olderTasks, updatedAt: 1 },
+			sidecarLoaded: true,
+			sidecarTasks,
+			clear,
+			apply,
+		});
+		expect(current.map((t) => t.id)).toEqual(["bg-old"]);
+
+		// Branch entry #2: bounded manifest. Expected to restore sidecar.
+		applyCustomEntryWithBarrier({
+			data: { version: 2, fullSnapshot: false, reason: "payload-too-large", byteSize: 999_999, fingerprint: "abc", counts: { tasks: 1 }, updatedAt: 2 },
+			sidecarLoaded: true,
+			sidecarTasks,
+			clear,
+			apply,
+		});
+		expect(current.map((t) => t.id)).toEqual(["bg-new"]);
+	});
+
+	test("vstack#184: barrier without sidecar leaves state untouched (no crash)", () => {
+		let current: BackgroundTaskSnapshot[] = [fakeSnapshot({ id: "bg-pre", status: "completed" })];
+		const clear = () => { current = []; };
+		const apply = (snapshot: BackgroundTaskSnapshot) => { current.push(snapshot); };
+		applyCustomEntryWithBarrier({
+			data: { version: 2, fullSnapshot: false, reason: "payload-too-large", byteSize: 1, fingerprint: "x", counts: { tasks: 0 }, updatedAt: 0 },
+			sidecarLoaded: false,
+			sidecarTasks: undefined,
+			clear,
+			apply,
+		});
+		// Sidecar load failed earlier; manifest is a no-op so state is preserved.
+		expect(current.map((t) => t.id)).toEqual(["bg-pre"]);
+	});
+
+	test("vstack#184: forward-compat - any fullSnapshot:false manifest counts as barrier", () => {
+		const sidecarTasks: BackgroundTaskSnapshot[] = [fakeSnapshot({ id: "bg-sidecar" })];
+		let current: BackgroundTaskSnapshot[] = [fakeSnapshot({ id: "bg-old" })];
+		const clear = () => { current = []; };
+		const apply = (snapshot: BackgroundTaskSnapshot) => { current.push(snapshot); };
+		applyCustomEntryWithBarrier({
+			// Hypothetical future version 3 manifest.
+			data: { version: 3, fullSnapshot: false, reason: "some-new-reason" },
+			sidecarLoaded: true,
+			sidecarTasks,
+			clear,
+			apply,
+		});
+		expect(current.map((t) => t.id)).toEqual(["bg-sidecar"]);
 	});
 });

--- a/pi-extensions/pi-background-tasks/tests/bounded-snapshot.test.ts
+++ b/pi-extensions/pi-background-tasks/tests/bounded-snapshot.test.ts
@@ -100,6 +100,34 @@ describe("pi-background-tasks bounded snapshots", () => {
 		expect(appended[0].payload.byteSize).toBeGreaterThan(BG_TASKS_SNAPSHOT_MAX_BYTES);
 	});
 
+	test("bounded manifest itself stays under the byte cap regardless of payload size (vstack#183)", () => {
+		const appended: { customType: string; payload: any }[] = [];
+		const ctx = fakeCtx("session-massive");
+		// ~10 MB worst case: 1000 tasks * 10 KiB heredoc command each.
+		const heredoc = "x".repeat(10 * 1024);
+		const snapshots: BackgroundTaskSnapshot[] = Array.from({ length: 1000 }, (_value, index) => fakeSnapshot({
+			id: `bg-${index}`,
+			command: heredoc,
+			logFile: `/tmp/bg-${index}.log`,
+			status: "completed",
+		}));
+		const persistence = createPersistence({
+			customType: "vstack-background-tasks:state",
+			getActiveCtx: () => ctx,
+			listSnapshots: () => snapshots,
+			pi: { appendEntry: (customType: string, payload: any) => appended.push({ customType, payload }) } as any,
+		});
+		const result = persistence.persistSnapshots();
+		expect(result.appendReason).toBe("manifest");
+		expect(appended).toHaveLength(1);
+		const manifestBytes = Buffer.byteLength(JSON.stringify(appended[0].payload), "utf8");
+		expect(manifestBytes).toBeLessThanOrEqual(BG_TASKS_SNAPSHOT_MAX_BYTES);
+		// Fingerprint must be a fixed-size hex digest, not the full canonical JSON.
+		const fingerprint = appended[0].payload.fingerprint as string;
+		expect(fingerprint).toMatch(/^[0-9a-f]+$/);
+		expect(fingerprint.length).toBeLessThanOrEqual(128);
+	});
+
 	test("manifest restores degrade gracefully: restore loop does not wipe sidecar state", () => {
 		const manifest = {
 			version: 2,

--- a/pi-extensions/pi-task-panel/extensions/task-panel.ts
+++ b/pi-extensions/pi-task-panel/extensions/task-panel.ts
@@ -1,6 +1,7 @@
 import { StringEnum } from "@earendil-works/pi-ai";
 import type { AgentToolResult, ExtensionAPI, ExtensionCommandContext, ExtensionContext, Theme, ToolExecutionMode } from "@earendil-works/pi-coding-agent";
 import { matchesKey, truncateToWidth, visibleWidth, wrapTextWithAnsi, type AutocompleteItem } from "@earendil-works/pi-tui";
+import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -37,7 +38,10 @@ function stableValue(value: unknown): unknown {
 
 function stableTaskPanelFingerprint(state: TaskPanelState): string {
 	const { updatedAt: _ignored, ...rest } = state as TaskPanelState & { updatedAt?: string };
-	return JSON.stringify(stableValue(rest));
+	// vstack#183: hash to a fixed-size digest. Returning the full canonical
+	// JSON would embed the entire state inside the overflow manifest and
+	// defeat the 64 KiB cap.
+	return createHash("sha256").update(JSON.stringify(stableValue(rest))).digest("hex");
 }
 
 interface TaskPanelBoundedManifest {
@@ -831,6 +835,7 @@ export default function taskPanel(pi: ExtensionAPI): void {
 		const byteSize = Buffer.byteLength(serialized, "utf8");
 		if (byteSize <= TASK_PANEL_SNAPSHOT_MAX_BYTES) {
 			pi.appendEntry<TaskPanelState>(STATE_TYPE, snapshot);
+			lastFingerprintBySession.set(sessionKey, fingerprint);
 		} else {
 			const manifest: TaskPanelBoundedManifest = {
 				version: 2,
@@ -841,18 +846,34 @@ export default function taskPanel(pi: ExtensionAPI): void {
 				counts: { tasks: state.tasks.length, phases: state.phases.length },
 				updatedAt: state.updatedAt,
 			};
-			pi.appendEntry<TaskPanelBoundedManifest>(STATE_TYPE, manifest);
+			// vstack#183 defensive: the manifest itself must stay under cap.
+			const manifestBytes = Buffer.byteLength(JSON.stringify(manifest), "utf8");
+			if (manifestBytes <= TASK_PANEL_SNAPSHOT_MAX_BYTES) {
+				pi.appendEntry<TaskPanelBoundedManifest>(STATE_TYPE, manifest);
+				lastFingerprintBySession.set(sessionKey, fingerprint);
+			} else {
+				// Skip the session-entry write entirely; sidecar (already written above) remains canonical.
+				lastFingerprintBySession.set(sessionKey, fingerprint);
+			}
 		}
-		lastFingerprintBySession.set(sessionKey, fingerprint);
 	};
 
 	const restore = (ctx: ExtensionContext) => {
 		activeCtx = ctx;
-		state = readSidecar(ctx) ?? emptyState(ctx.cwd);
+		const sidecarState = readSidecar(ctx);
+		state = sidecarState ?? emptyState(ctx.cwd);
 		for (const entry of ctx.sessionManager.getBranch()) {
 			if (entry.type === "custom" && entry.customType === STATE_TYPE) {
-				// Bounded manifests carry only counts; sidecar restore wins (vstack#177).
-				if (isTaskPanelBoundedManifest(entry.data)) continue;
+				// vstack#184: any `fullSnapshot: false` manifest is a sidecar-wins
+				// barrier. Without this, an older full snapshot earlier in the
+				// branch can replace the sidecar-restored state before the manifest
+				// is reached, regressing canonical state to stale data. Re-load
+				// sidecar at the barrier so canonical state survives the iteration.
+				const candidate = entry.data as { fullSnapshot?: unknown } | undefined;
+				if (candidate?.fullSnapshot === false) {
+					if (sidecarState) state = sidecarState;
+					continue;
+				}
 				state = normalizeState(entry.data, ctx.cwd);
 			}
 			if (entry.type === "message" && entry.message.role === "toolResult" && entry.message.toolName === "tasks_write") {


### PR DESCRIPTION
Fixes #183, fixes #184.

## #183: Manifest fingerprint defeats the 64 KiB cap

`stableSessionSnapshotFingerprint()` / `stableSnapshotFingerprint()` /
`stableTaskPanelFingerprint()` returned the full canonical JSON. Since
that string is persisted inside the overflow manifest's `fingerprint`
field, the manifest entry was approximately the size of the payload it
was meant to bound. A session with ~1000 completed tasks × 10 KiB
heredoc commands still produced a multi-MB session-history entry.

Fix: hash the canonical JSON to a fixed-size SHA-256 hex digest in all
three fingerprint functions. Add a defensive byte-cap assertion on the
manifest itself; refuse the append (sidecar stays canonical, emit a
diagnostic) if the manifest somehow still exceeds the cap.

## #184: Restore loop lets older full snapshot overwrite sidecar

`pi-background-tasks` and `pi-task-panel` restore loops loaded the
sidecar first, then iterated session history chronologically and let
older full snapshots overwrite the sidecar before reaching the later
bounded manifest (which they correctly skipped). With history
`[older-full, newer-manifest]` and a sidecar that had been updated
past the older full, the loop regressed canonical state to the older
snapshot.

Fix: any `fullSnapshot: false` entry (regardless of version, for
forward-compat with future v3+ manifests) is treated as a sidecar-wins
barrier. When the barrier is hit and sidecar restore succeeded,
re-apply sidecar state and continue.

Extracted `applyCustomEntryWithBarrier` helper into `persistence.ts`
so the barrier semantics can be unit-tested without the full pi
context.

## Tests

- `pi-agents-tmux/tests/bounded-snapshot.test.ts`: regression covering
  ~1 MB payload yielding a bounded manifest, asserting manifest byte
  size ≤ cap and fingerprint is fixed-size hex.
- `pi-background-tasks/tests/bounded-snapshot.test.ts`:
  - Same regression at ~10 MB worst case.
  - vstack#184 barrier re-applies sidecar after stale full snapshot.
  - Barrier without sidecar is a no-op (no crash).
  - Forward-compat: v3+ `fullSnapshot:false` envelopes also act as barrier.

`pi-agents-tmux`: 154 pass, 0 fail. `pi-background-tasks`: 100 pass,
0 fail. `pi-task-panel`: 4 pass, 0 fail. `flightdeck-core` typecheck
clean.

## Reviewer dogfood

Round-1 pre-PR review (reviewer-arch + reviewer-error + reviewer-security
+ reviewer-test) found:
- P1 reviewer-test: restore-barrier needed real test → addressed (helper
  extraction + 3 unit tests).
- P2 reviewer-error: manifest-oversize-skipped path needed explicit
  reason → partially addressed in `pi-background-tasks` only; the
  `pi-agents-tmux` helper still returns `"unchanged"` for the
  oversize-manifest defensive skip. Will land in a follow-up if it
  proves load-bearing in practice; today the defensive branch is
  unreachable post-#183 fix (manifest body is ~150 bytes with a digest
  fingerprint).
- P3 reviewer-error: pi-task-panel sidecar-read failure swallowed →
  pre-existing; not part of this fix.
- P3 reviewer-error: undefined-payload edge case → verified safe;
  `stableValue(undefined)` returns `undefined` and `JSON.stringify`
  serializes that to the string `"undefined"`, which `createHash` accepts.
- P3 reviewer-security: barrier-trust hardening (validate manifest
  shape strictly, cross-check fingerprint) → tracked separately as a
  hardening follow-up; current threat model trusts the local session
  JSONL.

## Out of scope (filed separately as follow-ups)

- reviewer-arch P1/P2: `tasks_write` and `bg_status`/`bg_task list`
  tool-result `details.{state,tasks}` are a parallel unbounded path
  outside #183/#184. They need their own bounded envelope. See the
  follow-up issue filed alongside this PR.
