### PR TITLE
Update project docs for new reviewer skill (README + AGENTS)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,7 +106,7 @@ iced = ["iced-rs", "iced-shadcn", ...]
 [role-skills]
 analyst = ["linear", "github"]
 engineer = ["issue-lifecycle", "github", "worktree", "decider", "linear"]
-reviewer = ["issue-lifecycle", "linear"]
+reviewer = ["reviewer"]
 
 [hook-events]
 "PreToolUse:Bash" = "all"

--- a/README.md
+++ b/README.md
@@ -191,7 +191,8 @@ Windows: CLI runs natively; symlink mode falls back to copy.
 | [`deep-research`](skills/deep-research/) | Exa-powered deep research and portable findings report generation. |
 | [`html-artifact`](skills/html-artifact/) | Standalone HTML artifacts for plans, reports, reviews, explainers, prototypes, and custom editors. |
 | [`github`](skills/github/)* | GitHub PR, thread, review, CI, and merge workflows. |
-| [`issue-lifecycle`](skills/issue-lifecycle/)* | Delegated implementation, review, and QA issue workflows. |
+| [`issue-lifecycle`](skills/issue-lifecycle/)* | Delegated implementation and review-fix issue workflows for dev agents. |
+| [`reviewer`](skills/reviewer/)* | Code-review and QA-review workflows + the canonical finding/verdict JSON schema. Loaded by any `reviewer-*` agent. |
 | [`linear`](skills/linear/)* | Linear issue, cycle, milestone, and project workflows. |
 | [`flightdeck`](skills/flightdeck/)* | Master session lifecycle for multi-issue parallel dev work; tmux-only, with structured activity JSONL for dashboard/live inspection. |
 | [`orchestration`](skills/orchestration/)* | Per-issue lifecycle inside a worktree: dev → review → submit → merge. |


### PR DESCRIPTION
Follow-up to #192. Updates two project-root docs that still referenced the pre-move state:

- `README.md` skills table: added a `reviewer` skill row (Code-review and QA-review workflows + finding/verdict JSON schema, loaded by any `reviewer-*` agent). Narrowed the `issue-lifecycle` description to dev workflows only since review.md and qa-review.md moved.
- `AGENTS.md` `[role-skills]` example: `reviewer = ["issue-lifecycle", "linear"]` \u2192 `reviewer = ["reviewer"]` to match the current default mapping.
- `.claude/CLAUDE.md` is a symlink to `../AGENTS.md` so it picks up the change automatically (verified).

Audit pass for stale references found no other live config or skill cross-link issues: all moved file paths (`workflows/review.md`, `workflows/qa-review.md`, `schemas/review-finding.md`) are correctly pointed at `skills/reviewer/` everywhere. Test fixtures in `cli/src/commands/check.rs` and explanatory comments in `cli/src/commands/add.rs` that mention `issue-lifecycle` are illustrative parser/example data, not stale config.