### PR TITLE
pi-output-policy: transcript-budget defaults via policyMode

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ If a Pi extension declares production dependencies (`dependencies` or `optionalD
 | [`pi-extension-manager`](pi-extensions/pi-extension-manager/README.md) | Pi-styled package manager and inline settings editor. |
 | [`pi-flightdeck`](pi-extensions/pi-flightdeck/README.md) | Optional Pi UI support for Flightdeck: inline mini-dashboard, pause banner, notifications, and `/flightdeck` focus/open integration for the Rust app. |
 | [`pi-hooks`](pi-extensions/pi-hooks/README.md) | First-class Pi port of the vstack safety hooks: bare-cd blocking, pre-commit fmt+clippy, post-edit clippy, end-of-turn lint. |
-| [`pi-output-policy`](pi-extensions/pi-output-policy/README.md) | Large-output policy with truncation and spill-file preservation. |
+| [`pi-output-policy`](pi-extensions/pi-output-policy/README.md) | Large-output policy with transcript-budget-aware truncation, spill-file preservation, and balanced/compact/compat modes. |
 | [`pi-prompt-stash`](pi-extensions/pi-prompt-stash/README.md) | Per-session prompt stash history with stash/pop editor. |
 | [`pi-qol`](pi-extensions/pi-qol/README.md) | Compact statusline, multiline input, image chips, session naming and search. |
 | [`pi-questions`](pi-extensions/pi-questions/README.md) | Structured multi-tab popup questions with bridge-driven replies. |

--- a/pi-extensions/pi-output-policy/README.md
+++ b/pi-extensions/pi-output-policy/README.md
@@ -138,4 +138,4 @@ Pi's built-in tools may truncate before reaching this extension. Custom tools th
 
 For truncated file reads, continue reading the original file with `offset`/`limit`. For truncated command output, the inline notice points at the artifact file on disk and reports per-turn and per-session bytes saved so users can see the transcript impact at a glance.
 
-Extension-produced custom messages (`pi.sendMessage`) are not currently policed by this extension — Pi's event hooks for custom-message content land in a separate planned follow-up. Add per-package caps in extensions that emit large custom messages.
+Extension-produced custom messages (`pi.sendMessage`) are not policed by this extension; add per-package caps in extensions that emit large custom messages.

--- a/pi-extensions/pi-output-policy/README.md
+++ b/pi-extensions/pi-output-policy/README.md
@@ -11,7 +11,7 @@ Output policy enforces two related but distinct budgets:
 - **Compact renderer UI** — how big a tool block can be without breaking Pi's TUI. Caps line width, hard line count, and absolute block size.
 - **Model transcript / session JSONL** — how much each tool result adds to the request body that gets resent on every turn. Long runs with many "fine" 50–200 KB results have crashed with `HTTP 507: exceeded request buffer limit while retrying upstream` even when no individual block was UI-pathological.
 
-Before 1.1 only the first budget had teeth. The default `balanced` policy mode now also constrains the second, while leaving the full text on disk via per-session artifacts.
+Earlier defaults only had teeth on the first budget. The default `balanced` policy mode now also constrains the second, while leaving the full text on disk via per-session artifacts.
 
 ## Policy modes
 
@@ -23,7 +23,7 @@ Pick the trade-off via `Policy mode` (or `policyMode` in JSON):
 | `compact` | 16 | 6 / 200 | 8 | 200 | 2 000 | on (with allowlist) |
 | `compat` | 200 | 100 / 2 000 | 200 | 8 000 | 20 000 | off |
 
-`balanced` keeps any single non-read/non-mutation tool result under ~24 KB inline while preserving the full output to disk. `compact` is for very long autonomous runs that need to stretch the request buffer further. `compat` restores pre-1.1 behavior — UI safety only, no transcript-size protection. Switch to `compat` when you need every byte inline and can fit the full transcript yourself.
+`balanced` keeps any single non-read/non-mutation tool result under ~24 KB inline while preserving the full output to disk. `compact` is for very long autonomous runs that need to stretch the request buffer further. `compat` is the legacy UI-safety-only profile — no transcript-size protection, but it still applies the old caps (200 KB block / 8 000 lines / 20 000-char lines). For truly untruncated inline output, set `enabled: false` instead.
 
 Any per-knob value you set in `vstack.extensionManager.config["@vanillagreen/pi-output-policy"]` overrides the mode default; unset knobs follow the mode.
 
@@ -32,8 +32,9 @@ Any per-knob value you set in `vstack.extensionManager.config["@vanillagreen/pi-
 - Preserves oversized tool output to disk and includes the artifact path in results.
 - Head truncation for search/listing tools; tail truncation for command/log tools.
 - Explicit truncation notices show size, line count, direction, artifact path, per-turn/session bytes saved, and continuation guidance.
-- File reads, edit/write results, and detail payloads pass through unmodified by default — opt in per category.
-- State-bearing tool details (`tasks_write`, `bg_task`, `subagent`, …) bypass sanitization so sidecar restore semantics stay safe.
+- File reads and edit/write results pass through unmodified by default — opt in per category.
+- Tool-result `details` are sanitized by default in `balanced`/`compact` (off in `compat`); state-bearing tools (`tasks_write`, `bg_task`, `subagent`, …) bypass sanitization so sidecar restore semantics stay safe.
+- When `details` are sanitized, the result carries a `vstackOutputPolicySanitized` marker (and capped arrays/objects include a sentinel string) so consumers can detect the truncation.
 - Shell output minimizer compresses noisy git/npm/cargo/test output before truncation while preserving warnings, errors, and summaries.
 
 ## Install
@@ -101,7 +102,7 @@ Open `/extensions:settings`; settings appear under the **Output Policy** tab.
 
 ## Switching back to verbatim behavior
 
-Need the full inline output for a specific run? Set:
+`compat` mode restores the legacy generous UI-safety caps (200 KB block, 8 000 lines, 20 000-char lines) and turns off `sanitizeDetails`, but it is **not** "fully untruncated" — anything above those caps still spills. Pick it when those caps are wide enough for your workflow:
 
 ```json
 {
@@ -117,7 +118,19 @@ Need the full inline output for a specific run? Set:
 }
 ```
 
-(or pick `compat` from the Policy mode dropdown). Disabling truncation entirely is `"enabled": false`, which also skips the minimizer.
+For truly untruncated inline output (no spill, no minimizer, no sanitization), disable the policy entirely:
+
+```json
+{
+  "vstack": {
+    "extensionManager": {
+      "config": {
+        "@vanillagreen/pi-output-policy": { "enabled": false }
+      }
+    }
+  }
+}
+```
 
 ## Notes
 

--- a/pi-extensions/pi-output-policy/README.md
+++ b/pi-extensions/pi-output-policy/README.md
@@ -2,14 +2,38 @@
 
 ![Output Policy settings panel](https://raw.githubusercontent.com/vanillagreencom/vstack/main/pi-extensions/pi-output-policy/assets/settings-panel.png)
 
-Large-output policy for Pi tool results: minimization, bounded truncation, and full-output preservation.
+Large-output policy for Pi tool results: minimization, bounded truncation, and full-output preservation. Tuned to keep long autonomous runs under provider request-buffer limits without losing the full tool output (it lands on disk).
+
+## Two budgets, one policy
+
+Output policy enforces two related but distinct budgets:
+
+- **Compact renderer UI** — how big a tool block can be without breaking Pi's TUI. Caps line width, hard line count, and absolute block size.
+- **Model transcript / session JSONL** — how much each tool result adds to the request body that gets resent on every turn. Long runs with many "fine" 50–200 KB results have crashed with `HTTP 507: exceeded request buffer limit while retrying upstream` even when no individual block was UI-pathological.
+
+Before 1.1 only the first budget had teeth. The default `balanced` policy mode now also constrains the second, while leaving the full text on disk via per-session artifacts.
+
+## Policy modes
+
+Pick the trade-off via `Policy mode` (or `policyMode` in JSON):
+
+| Mode | Spill (KB) | Inline tail (KB / lines) | Max block (KB) | Max lines | Max line width | sanitizeDetails |
+| --- | --- | --- | --- | --- | --- | --- |
+| `balanced` (default) | 48 | 16 / 400 | 24 | 400 | 3 000 | on (with allowlist) |
+| `compact` | 16 | 6 / 200 | 8 | 200 | 2 000 | on (with allowlist) |
+| `compat` | 200 | 100 / 2 000 | 200 | 8 000 | 20 000 | off |
+
+`balanced` keeps any single non-read/non-mutation tool result under ~24 KB inline while preserving the full output to disk. `compact` is for very long autonomous runs that need to stretch the request buffer further. `compat` restores pre-1.1 behavior — UI safety only, no transcript-size protection. Switch to `compat` when you need every byte inline and can fit the full transcript yourself.
+
+Any per-knob value you set in `vstack.extensionManager.config["@vanillagreen/pi-output-policy"]` overrides the mode default; unset knobs follow the mode.
 
 ## Highlights
 
 - Preserves oversized tool output to disk and includes the artifact path in results.
 - Head truncation for search/listing tools; tail truncation for command/log tools.
-- Explicit truncation notices show size, line count, direction, and artifact path.
+- Explicit truncation notices show size, line count, direction, artifact path, per-turn/session bytes saved, and continuation guidance.
 - File reads, edit/write results, and detail payloads pass through unmodified by default — opt in per category.
+- State-bearing tool details (`tasks_write`, `bg_task`, `subagent`, …) bypass sanitization so sidecar restore semantics stay safe.
 - Shell output minimizer compresses noisy git/npm/cargo/test output before truncation while preserving warnings, errors, and summaries.
 
 ## Install
@@ -33,24 +57,32 @@ Restart Pi after installation.
 
 Open `/extensions:settings`; settings appear under the **Output Policy** tab.
 
+### General
+
+| Setting | What it does |
+| --- | --- |
+| Enable output policy | Master toggle. |
+| Policy mode | `balanced` (default), `compact`, or `compat`. See [Policy modes](#policy-modes). |
+
 ### Truncation
 
 | Setting | What it does |
 | --- | --- |
 | Truncate file reads | Apply spill/truncation to `read` results. |
 | Truncate edits/writes | Apply spill/truncation to `edit`/`write` results. |
-| Output spill threshold (KB) | Preserve full output externally above this size. |
-| Inline tail size (KB) | Bytes kept inline for tail-truncated command/log output. |
-| Inline tail lines | Lines kept inline for tail-truncated command/log output. |
+| Output spill threshold (KB) | Preserve full output externally above this size. Unset = mode default. |
+| Inline tail size (KB) | Bytes kept inline for tail-truncated command/log output. Unset = mode default. |
+| Inline tail lines | Lines kept inline for tail-truncated command/log output. Unset = mode default. |
 
 ### UI safety
 
 | Setting | What it does |
 | --- | --- |
-| Max UI-safe text block (KB) | Hard cap on text blocks even when spill is off. |
-| Max UI-safe line count | Hard line cap for rendered text. |
-| Max UI-safe line width | Truncate pathological wide lines. |
-| Sanitize details payloads | Cap nested tool-result details. Off by default. |
+| Max UI-safe text block (KB) | Hard cap on text blocks even when spill is off. Unset = mode default. |
+| Max UI-safe line count | Hard line cap for rendered text. Unset = mode default. |
+| Max UI-safe line width | Truncate pathological wide lines. Unset = mode default. |
+| Sanitize details payloads | Cap nested tool-result details. Unset = mode default (`balanced`/`compact` on, `compat` off). |
+| Sanitize details allowlist | Comma-separated tool names whose details bypass sanitization. Empty = built-in list (`tasks_write`, `tasks_read`, `bg_task`, `bg_status`, `subagent`, `subagent_run`, `stop_subagent`, `steer_subagent`, `get_subagent_result`). |
 
 ### Storage
 
@@ -67,8 +99,30 @@ Open `/extensions:settings`; settings appear under the **Output Policy** tab.
 | Denylist | Comma-separated command families to leave alone. |
 | Max capture bytes | Skip minimizer on output larger than this; truncate directly. |
 
+## Switching back to verbatim behavior
+
+Need the full inline output for a specific run? Set:
+
+```json
+{
+  "vstack": {
+    "extensionManager": {
+      "config": {
+        "@vanillagreen/pi-output-policy": {
+          "policyMode": "compat"
+        }
+      }
+    }
+  }
+}
+```
+
+(or pick `compat` from the Policy mode dropdown). Disabling truncation entirely is `"enabled": false`, which also skips the minimizer.
+
 ## Notes
 
 Pi's built-in tools may truncate before reaching this extension. Custom tools that return full large text benefit most from spill preservation.
 
-For truncated file reads, continue reading the original file with `offset`/`limit`. Session `tool-results/*.json` artifacts are wrappers, not full-content recovery.
+For truncated file reads, continue reading the original file with `offset`/`limit`. For truncated command output, the inline notice points at the artifact file on disk and reports per-turn and per-session bytes saved so users can see the transcript impact at a glance.
+
+Extension-produced custom messages (`pi.sendMessage`) are not currently policed by this extension — Pi's event hooks for custom-message content land in a separate planned follow-up. Add per-package caps in extensions that emit large custom messages.

--- a/pi-extensions/pi-output-policy/extensions/output-policy.ts
+++ b/pi-extensions/pi-output-policy/extensions/output-policy.ts
@@ -477,6 +477,9 @@ export function processText(event: any, ctx: ExtensionContext, text: string): { 
 	return { meta, text: `${truncated.content}\n\n${notice(meta)}` };
 }
 
+const SANITIZE_ARRAY_CAP = 50;
+const SANITIZE_OBJECT_CAP = 80;
+
 export function sanitizeDetails(value: unknown, depth = 0): { value: unknown; changed: boolean } {
 	if (depth > 4) return { changed: true, value: "[Max detail depth reached]" };
 	if (value == null || typeof value === "number" || typeof value === "boolean") return { changed: false, value };
@@ -485,26 +488,39 @@ export function sanitizeDetails(value: unknown, depth = 0): { value: unknown; ch
 		return value.length > max ? { changed: true, value: `${value.slice(0, max)}… [detail string truncated]` } : { changed: false, value };
 	}
 	if (Array.isArray(value)) {
-		let changed = value.length > 50;
-		const sanitized = value.slice(0, 50).map((item) => {
-			const nested = sanitizeDetails(item, depth + 1);
+		const overflow = value.length > SANITIZE_ARRAY_CAP;
+		const limit = overflow ? SANITIZE_ARRAY_CAP - 1 : value.length;
+		const sanitized: unknown[] = [];
+		let changed = overflow;
+		for (let i = 0; i < limit; i += 1) {
+			const nested = sanitizeDetails(value[i], depth + 1);
 			changed ||= nested.changed;
-			return nested.value;
-		});
+			sanitized.push(nested.value);
+		}
+		if (overflow) {
+			sanitized.push(`[output-policy: array truncated, dropped ${value.length - limit} item(s)]`);
+		}
 		return { changed, value: sanitized };
 	}
 	if (typeof value === "object") {
+		// Iterate own keys with an early break instead of materializing the full
+		// Object.entries(...) array, so a wide untrusted `details` object cannot
+		// exhaust memory or CPU before the cap engages.
 		let changed = false;
 		const out: Record<string, unknown> = {};
-		for (const [index, [key, nested]] of Object.entries(value as Record<string, unknown>).entries()) {
-			if (index >= 80) {
-				out["[truncated]"] = "detail object field cap reached";
+		const source = value as Record<string, unknown>;
+		let kept = 0;
+		for (const key in source) {
+			if (!Object.hasOwn(source, key)) continue;
+			if (kept >= SANITIZE_OBJECT_CAP) {
+				out["[output-policy:truncated]"] = `object truncated past cap of ${SANITIZE_OBJECT_CAP} field(s)`;
 				changed = true;
 				break;
 			}
-			const sanitized = sanitizeDetails(nested, depth + 1);
+			const sanitized = sanitizeDetails(source[key], depth + 1);
 			changed ||= sanitized.changed;
 			out[key] = sanitized.value;
+			kept += 1;
 		}
 		return { changed, value: out };
 	}
@@ -551,12 +567,19 @@ export default function outputPolicy(pi: ExtensionAPI): void {
 		const exemptByTool = isSanitizeExceptTool(toolName, ctx.cwd);
 		const sanitizedDetails = sanitizeOn && !exemptByTool ? sanitizeDetails(event.details) : { changed: false, value: event.details };
 		let details = sanitizedDetails.value;
-		if (metas.length > 0) {
+		if (metas.length > 0 || sanitizedDetails.changed) {
 			details = details && typeof details === "object" && !Array.isArray(details) ? { ...(details as Record<string, unknown>) } : {};
-			(details as Record<string, unknown>).vstackOutputPolicy = metas;
 			changed = true;
 		}
-		if (sanitizedDetails.changed) changed = true;
+		if (metas.length > 0) {
+			(details as Record<string, unknown>).vstackOutputPolicy = metas;
+		}
+		if (sanitizedDetails.changed) {
+			(details as Record<string, unknown>).vstackOutputPolicySanitized = {
+				policyMode: resolvePolicyMode(ctx.cwd),
+				reason: "details payload exceeded inline budget; capped per policyMode (set policyMode=compat or sanitizeDetails=false to disable)",
+			};
+		}
 		return changed ? { content, details } : undefined;
 	});
 }

--- a/pi-extensions/pi-output-policy/extensions/output-policy.ts
+++ b/pi-extensions/pi-output-policy/extensions/output-policy.ts
@@ -6,14 +6,72 @@ import { basename, dirname, join, resolve } from "node:path";
 
 const INSTALL_SYMBOL = Symbol.for("vstack.pi-output-policy.installed");
 const CONFIG_ID = "@vanillagreen/pi-output-policy";
-const DEFAULT_SPILL_THRESHOLD_KB = 200;
-const DEFAULT_INLINE_TAIL_KB = 100;
-const DEFAULT_INLINE_TAIL_LINES = 2_000;
-const DEFAULT_MAX_TEXT_BLOCK_KB = 200;
-const DEFAULT_MAX_LINE_COUNT = 8_000;
-const DEFAULT_MAX_LINE_WIDTH = 20_000;
 const DEFAULT_MINIMIZER_MAX_CAPTURE_BYTES = 1024 * 1024;
 const DEFAULT_SHELL_MINIMIZER_ENABLED = true;
+
+// Tools whose `details` carry state-bearing data (task lists, background-task
+// snapshots, subagent run records). Sanitization would corrupt restore
+// semantics, so balanced/compact modes skip these by default. Sidecars/state
+// files are the canonical store; the inline details just point at them.
+const DEFAULT_SANITIZE_EXCEPT_TOOLS = [
+	"tasks_write",
+	"tasks_read",
+	"bg_task",
+	"bg_status",
+	"subagent",
+	"subagent_run",
+	"stop_subagent",
+	"steer_subagent",
+	"get_subagent_result",
+];
+
+export type PolicyMode = "compat" | "balanced" | "compact";
+
+interface ModeDefaults {
+	spillThresholdKb: number;
+	inlineTailKb: number;
+	inlineTailLines: number;
+	maxTextBlockKb: number;
+	maxLineCount: number;
+	maxLineWidth: number;
+	sanitizeDetails: boolean;
+}
+
+// `compat` is the pre-1.1 behavior — UI-safety sized only. `balanced` (default)
+// is sized so a single non-read/non-mutation tool result cannot push more than
+// ~24 KB into the model transcript / session JSONL. `compact` is for very long
+// runs that need to stretch the request buffer further.
+const MODE_DEFAULTS: Record<PolicyMode, ModeDefaults> = {
+	compat: {
+		spillThresholdKb: 200,
+		inlineTailKb: 100,
+		inlineTailLines: 2_000,
+		maxTextBlockKb: 200,
+		maxLineCount: 8_000,
+		maxLineWidth: 20_000,
+		sanitizeDetails: false,
+	},
+	balanced: {
+		spillThresholdKb: 48,
+		inlineTailKb: 16,
+		inlineTailLines: 400,
+		maxTextBlockKb: 24,
+		maxLineCount: 400,
+		maxLineWidth: 3_000,
+		sanitizeDetails: true,
+	},
+	compact: {
+		spillThresholdKb: 16,
+		inlineTailKb: 6,
+		inlineTailLines: 200,
+		maxTextBlockKb: 8,
+		maxLineCount: 200,
+		maxLineWidth: 2_000,
+		sanitizeDetails: true,
+	},
+};
+
+const DEFAULT_POLICY_MODE: PolicyMode = "balanced";
 
 type VstackConfig = Record<string, unknown>;
 type Direction = "head" | "tail";
@@ -31,6 +89,26 @@ interface TruncationMeta {
 	artifactError?: string;
 	minimized?: boolean;
 	minimizedDroppedLines?: number;
+	policyMode?: PolicyMode;
+	savedBytes?: number;
+	turnSavedBytes?: number;
+	sessionSavedBytes?: number;
+}
+
+interface SessionCounters {
+	turnSavedBytes: number;
+	sessionSavedBytes: number;
+}
+
+const SESSION_COUNTERS = new Map<string, SessionCounters>();
+
+function counters(sessionId: string): SessionCounters {
+	let entry = SESSION_COUNTERS.get(sessionId);
+	if (!entry) {
+		entry = { sessionSavedBytes: 0, turnSavedBytes: 0 };
+		SESSION_COUNTERS.set(sessionId, entry);
+	}
+	return entry;
 }
 
 function expandHome(input: string): string {
@@ -159,6 +237,31 @@ function settingBoolean(key: string, fallback: boolean, cwd?: string): boolean {
 function settingString(key: string, fallback: string, cwd?: string): string {
 	const value = readVstackConfig(cwd)[key];
 	return typeof value === "string" ? value : fallback;
+}
+
+export function resolvePolicyMode(cwd?: string): PolicyMode {
+	const raw = settingString("policyMode", DEFAULT_POLICY_MODE, cwd).toLowerCase().trim();
+	if (raw === "compat" || raw === "balanced" || raw === "compact") return raw;
+	return DEFAULT_POLICY_MODE;
+}
+
+function modeDefault<K extends keyof ModeDefaults>(key: K, cwd?: string): ModeDefaults[K] {
+	return MODE_DEFAULTS[resolvePolicyMode(cwd)][key];
+}
+
+function sanitizeExceptTools(cwd?: string): string[] {
+	const configured = listSetting("sanitizeDetails.exceptTools", cwd);
+	return configured.length > 0 ? configured : DEFAULT_SANITIZE_EXCEPT_TOOLS;
+}
+
+export function isSanitizeExceptTool(toolName: string, cwd?: string): boolean {
+	const name = toolName.toLowerCase();
+	const allowlist = sanitizeExceptTools(cwd);
+	return allowlist.includes(name) || allowlist.some((entry) => entry && name.endsWith(`.${entry}`));
+}
+
+export function __resetSessionCountersForTests(): void {
+	SESSION_COUNTERS.clear();
 }
 
 function byteLength(text: string): number {
@@ -312,20 +415,23 @@ function notice(meta: TruncationMeta): string {
 	const target = meta.direction === "tail" ? `Showing last ${meta.shownLines} lines / ${formatSize(meta.shownBytes)}` : `Showing ${meta.shownRange} of ${meta.totalLines} / ${formatSize(meta.shownBytes)}`;
 	const artifact = meta.artifactPath ? ` Full output: ${meta.artifactPath}` : meta.artifactError ? ` Full output preservation unavailable: ${meta.artifactError}` : "";
 	const minimized = meta.minimized ? ` Minimized ${meta.minimizedDroppedLines} noisy line(s) before truncation.` : "";
-	return `[Output truncated (${meta.direction}). ${target}. Total: ${meta.totalLines} lines / ${formatSize(meta.totalBytes)}.${minimized}${artifact}]`;
+	const saved = typeof meta.savedBytes === "number" && meta.savedBytes > 0 ? ` Saved ${formatSize(meta.savedBytes)} from transcript (turn total: ${formatSize(meta.turnSavedBytes ?? 0)}, session: ${formatSize(meta.sessionSavedBytes ?? 0)}).` : "";
+	const continuation = meta.direction === "head" && meta.totalLines > meta.shownLines ? ` Continue with the same tool using an offset past line ${meta.shownLines} to read more.` : "";
+	return `[Output truncated (${meta.direction}). ${target}. Total: ${meta.totalLines} lines / ${formatSize(meta.totalBytes)}.${minimized}${saved}${artifact}${continuation}]`;
 }
 
-function processText(event: any, ctx: ExtensionContext, text: string): { text: string; meta?: TruncationMeta } {
+export function processText(event: any, ctx: ExtensionContext, text: string): { text: string; meta?: TruncationMeta } {
 	const cwd = ctx.cwd;
 	const toolName = String(event.toolName ?? "tool");
 	if (shouldBypassTool(toolName, cwd)) return { text };
+	const mode = resolvePolicyMode(cwd);
 	const direction = directionForTool(toolName);
-	const maxLineWidth = Math.max(80, Math.floor(settingNumber("maxLineWidth", DEFAULT_MAX_LINE_WIDTH, cwd)));
-	const maxLineCount = Math.max(1, Math.floor(settingNumber("maxLineCount", DEFAULT_MAX_LINE_COUNT, cwd)));
-	const spillThresholdBytes = Math.max(1, Math.floor(settingNumber("spillThresholdKb", DEFAULT_SPILL_THRESHOLD_KB, cwd) * 1024));
-	const maxTextBytes = Math.max(1, Math.floor(settingNumber("maxTextBlockKb", DEFAULT_MAX_TEXT_BLOCK_KB, cwd) * 1024));
-	const inlineTailBytes = Math.max(1, Math.floor(settingNumber("inlineTailKb", DEFAULT_INLINE_TAIL_KB, cwd) * 1024));
-	const inlineTailLines = Math.max(1, Math.floor(settingNumber("inlineTailLines", DEFAULT_INLINE_TAIL_LINES, cwd)));
+	const maxLineWidth = Math.max(80, Math.floor(settingNumber("maxLineWidth", modeDefault("maxLineWidth", cwd), cwd)));
+	const maxLineCount = Math.max(1, Math.floor(settingNumber("maxLineCount", modeDefault("maxLineCount", cwd), cwd)));
+	const spillThresholdBytes = Math.max(1, Math.floor(settingNumber("spillThresholdKb", modeDefault("spillThresholdKb", cwd), cwd) * 1024));
+	const maxTextBytes = Math.max(1, Math.floor(settingNumber("maxTextBlockKb", modeDefault("maxTextBlockKb", cwd), cwd) * 1024));
+	const inlineTailBytes = Math.max(1, Math.floor(settingNumber("inlineTailKb", modeDefault("inlineTailKb", cwd), cwd) * 1024));
+	const inlineTailLines = Math.max(1, Math.floor(settingNumber("inlineTailLines", modeDefault("inlineTailLines", cwd), cwd)));
 
 	const original = text;
 	let working = text;
@@ -349,6 +455,11 @@ function processText(event: any, ctx: ExtensionContext, text: string): { text: s
 	const bytes = direction === "tail" ? inlineTailBytes : maxTextBytes;
 	const lineLimit = direction === "tail" ? inlineTailLines : maxLineCount;
 	const truncated = truncateText(working, direction, bytes, lineLimit, maxLineWidth);
+	const originalBytes = byteLength(original);
+	const savedBytes = Math.max(0, originalBytes - truncated.meta.shownBytes);
+	const session = counters(sessionIdForContext(ctx));
+	session.turnSavedBytes += savedBytes;
+	session.sessionSavedBytes += savedBytes;
 	const meta: TruncationMeta = {
 		...truncated.meta,
 		artifactError: artifact.error,
@@ -356,13 +467,17 @@ function processText(event: any, ctx: ExtensionContext, text: string): { text: s
 		direction,
 		minimized,
 		minimizedDroppedLines,
+		policyMode: mode,
 		reason: byteLength(working) > spillThresholdBytes ? "spill-threshold" : "ui-safety",
+		savedBytes,
+		sessionSavedBytes: session.sessionSavedBytes,
 		truncated: true,
+		turnSavedBytes: session.turnSavedBytes,
 	};
 	return { meta, text: `${truncated.content}\n\n${notice(meta)}` };
 }
 
-function sanitizeDetails(value: unknown, depth = 0): { value: unknown; changed: boolean } {
+export function sanitizeDetails(value: unknown, depth = 0): { value: unknown; changed: boolean } {
 	if (depth > 4) return { changed: true, value: "[Max detail depth reached]" };
 	if (value == null || typeof value === "number" || typeof value === "boolean") return { changed: false, value };
 	if (typeof value === "string") {
@@ -407,7 +522,16 @@ export default function outputPolicy(pi: ExtensionAPI): void {
 	guard[INSTALL_SYMBOL] = true;
 
 	pi.on("session_start", async (_event, ctx: ExtensionContext) => {
+		SESSION_COUNTERS.delete(sessionIdForContext(ctx));
 		if (settingBoolean("enabled", true, ctx.cwd)) migrateLegacyProjectArtifacts(ctx);
+	});
+
+	pi.on("turn_start", async (_event, ctx: ExtensionContext) => {
+		counters(sessionIdForContext(ctx)).turnSavedBytes = 0;
+	});
+
+	pi.on("session_shutdown", async (_event, ctx: ExtensionContext) => {
+		SESSION_COUNTERS.delete(sessionIdForContext(ctx));
 	});
 
 	pi.on("tool_result", async (event: any, ctx: ExtensionContext) => {
@@ -423,8 +547,9 @@ export default function outputPolicy(pi: ExtensionAPI): void {
 			if (processed.meta) metas.push(processed.meta);
 			return { ...part, text: processed.text };
 		});
-		const shouldSanitizeDetails = settingBoolean("sanitizeDetails", false, ctx.cwd);
-		const sanitizedDetails = shouldSanitizeDetails ? sanitizeDetails(event.details) : { changed: false, value: event.details };
+		const sanitizeOn = settingBoolean("sanitizeDetails", modeDefault("sanitizeDetails", ctx.cwd), ctx.cwd);
+		const exemptByTool = isSanitizeExceptTool(toolName, ctx.cwd);
+		const sanitizedDetails = sanitizeOn && !exemptByTool ? sanitizeDetails(event.details) : { changed: false, value: event.details };
 		let details = sanitizedDetails.value;
 		if (metas.length > 0) {
 			details = details && typeof details === "object" && !Array.isArray(details) ? { ...(details as Record<string, unknown>) } : {};

--- a/pi-extensions/pi-output-policy/extensions/output-policy.ts
+++ b/pi-extensions/pi-output-policy/extensions/output-policy.ts
@@ -445,7 +445,12 @@ export function processText(event: any, ctx: ExtensionContext, text: string): { 
 	}
 
 	const lines = working.split(/\r?\n/);
-	const tooLarge = byteLength(working) > spillThresholdBytes || lines.length > maxLineCount || lines.some((line) => line.length > maxLineWidth);
+	const workingBytes = byteLength(working);
+	const overSpill = workingBytes > spillThresholdBytes;
+	const overTextBlock = workingBytes > maxTextBytes;
+	const overLineCount = lines.length > maxLineCount;
+	const overLineWidth = lines.some((line) => line.length > maxLineWidth);
+	const tooLarge = overSpill || overTextBlock || overLineCount || overLineWidth;
 	if (!tooLarge) {
 		const widthSafe = lines.map((line) => truncateLine(line, maxLineWidth)).join("\n");
 		return minimized ? { text: `${widthSafe}\n\n[Output minimized: removed ${minimizedDroppedLines} repetitive/noisy line(s).]` } : { text: widthSafe };
@@ -460,6 +465,7 @@ export function processText(event: any, ctx: ExtensionContext, text: string): { 
 	const session = counters(sessionIdForContext(ctx));
 	session.turnSavedBytes += savedBytes;
 	session.sessionSavedBytes += savedBytes;
+	const reason = overSpill ? "spill-threshold" : overTextBlock ? "max-text-block" : "ui-safety";
 	const meta: TruncationMeta = {
 		...truncated.meta,
 		artifactError: artifact.error,
@@ -468,7 +474,7 @@ export function processText(event: any, ctx: ExtensionContext, text: string): { 
 		minimized,
 		minimizedDroppedLines,
 		policyMode: mode,
-		reason: byteLength(working) > spillThresholdBytes ? "spill-threshold" : "ui-safety",
+		reason,
 		savedBytes,
 		sessionSavedBytes: session.sessionSavedBytes,
 		truncated: true,

--- a/pi-extensions/pi-output-policy/package.json
+++ b/pi-extensions/pi-output-policy/package.json
@@ -30,6 +30,20 @@
           "apply": "live"
         },
         {
+          "key": "policyMode",
+          "label": "Policy mode",
+          "description": "Budget profile for inline truncation. balanced (default) caps non-read/non-mutation tool results at ~24 KB inline so long sessions stay under provider request buffers. compact halves those caps for very long runs. compat restores pre-1.1 UI-safety-only defaults (200 KB inline) when you need full output and aren't worried about transcript size. Explicit per-knob values override the mode default.",
+          "type": "enum",
+          "default": "balanced",
+          "enumValues": [
+            "balanced",
+            "compact",
+            "compat"
+          ],
+          "category": "General",
+          "apply": "live"
+        },
+        {
           "key": "truncateReadOutputs",
           "label": "Truncate file reads",
           "description": "Apply output-policy spill/truncation to read tool file contents. Disabled by default so file reads are returned unmodified.",
@@ -50,54 +64,48 @@
         {
           "key": "spillThresholdKb",
           "label": "Output spill threshold (KB)",
-          "description": "Preserve full output externally when text exceeds this size.",
+          "description": "Preserve full output externally when text exceeds this size. When unset, policyMode picks: balanced 48, compact 16, compat 200.",
           "type": "number",
-          "default": 200,
           "category": "Truncation",
           "apply": "live"
         },
         {
           "key": "inlineTailKb",
           "label": "Inline tail size (KB)",
-          "description": "Bytes retained inline for tail-truncated command/log output after spill.",
+          "description": "Bytes retained inline for tail-truncated command/log output after spill. When unset, policyMode picks: balanced 16, compact 6, compat 100.",
           "type": "number",
-          "default": 100,
           "category": "Truncation",
           "apply": "live"
         },
         {
           "key": "inlineTailLines",
           "label": "Inline tail lines",
-          "description": "Lines retained inline for tail-truncated command/log output after spill.",
+          "description": "Lines retained inline for tail-truncated command/log output after spill. When unset, policyMode picks: balanced 400, compact 200, compat 2000.",
           "type": "number",
-          "default": 2000,
           "category": "Truncation",
           "apply": "live"
         },
         {
           "key": "maxTextBlockKb",
           "label": "Max UI-safe text block (KB)",
-          "description": "Hard cap for text blocks even when spill is disabled or fails.",
+          "description": "Hard cap for text blocks even when spill is disabled or fails. When unset, policyMode picks: balanced 24, compact 8, compat 200.",
           "type": "number",
-          "default": 200,
           "category": "UI Safety",
           "apply": "live"
         },
         {
           "key": "maxLineCount",
           "label": "Max UI-safe line count",
-          "description": "Hard line cap for rendered/result text.",
+          "description": "Hard line cap for rendered/result text. When unset, policyMode picks: balanced 400, compact 200, compat 8000.",
           "type": "number",
-          "default": 8000,
           "category": "UI Safety",
           "apply": "live"
         },
         {
           "key": "maxLineWidth",
           "label": "Max UI-safe line width",
-          "description": "Truncate individual pathological lines to this character width.",
+          "description": "Truncate individual pathological lines to this character width. When unset, policyMode picks: balanced 3000, compact 2000, compat 20000.",
           "type": "number",
-          "default": 20000,
           "category": "UI Safety",
           "apply": "live"
         },
@@ -113,9 +121,17 @@
         {
           "key": "sanitizeDetails",
           "label": "Sanitize details payloads",
-          "description": "Cap nested tool-result details for UI safety. Disabled by default so extension state, subagent details, and diffs are preserved.",
+          "description": "Cap nested tool-result details. When unset, policyMode picks: balanced/compact on, compat off. State-bearing tools listed in 'Sanitize details allowlist' bypass this and pass through untouched.",
           "type": "boolean",
-          "default": false,
+          "category": "UI Safety",
+          "apply": "live"
+        },
+        {
+          "key": "sanitizeDetails.exceptTools",
+          "label": "Sanitize details allowlist",
+          "description": "Comma-separated tool names whose details bypass sanitization (their inline details point at sidecars/state files that must not be capped). Empty means the built-in list: tasks_write, tasks_read, bg_task, bg_status, subagent, subagent_run, stop_subagent, steer_subagent, get_subagent_result.",
+          "type": "string",
+          "default": "",
           "category": "UI Safety",
           "apply": "live"
         },

--- a/pi-extensions/pi-output-policy/tests/output-policy.test.ts
+++ b/pi-extensions/pi-output-policy/tests/output-policy.test.ts
@@ -1,9 +1,16 @@
-import { describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { describe, expect, test, beforeEach } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { minimizeShellOutput } from "../extensions/output-policy.ts";
+import {
+	__resetSessionCountersForTests,
+	isSanitizeExceptTool,
+	minimizeShellOutput,
+	processText,
+	resolvePolicyMode,
+	sanitizeDetails,
+} from "../extensions/output-policy.ts";
 
 const CONFIG_ID = "@vanillagreen/pi-output-policy";
 
@@ -19,6 +26,23 @@ function withConfig(config: Record<string, unknown>, run: (cwd: string) => void)
 		rmSync(dir, { force: true, recursive: true });
 	}
 }
+
+let testSeq = 0;
+function fakeCtx(cwd: string): any {
+	testSeq += 1;
+	const sessionId = `test-${testSeq}-${process.hrtime.bigint().toString(36)}`;
+	return {
+		cwd,
+		sessionManager: {
+			getSessionId: () => sessionId,
+			getSessionFile: () => null,
+		},
+	};
+}
+
+beforeEach(() => {
+	__resetSessionCountersForTests();
+});
 
 describe("shell minimizer", () => {
 	test("minimizes noisy successful cargo output by default", () => {
@@ -39,6 +63,187 @@ describe("shell minimizer", () => {
 			const result = minimizeShellOutput(text, "cargo test", cwd);
 			expect(result.dropped).toBe(0);
 			expect(result.text).toBe(text);
+		});
+	});
+});
+
+describe("policy mode resolution", () => {
+	test("defaults to balanced when unset", () => {
+		withConfig({}, (cwd) => {
+			expect(resolvePolicyMode(cwd)).toBe("balanced");
+		});
+	});
+
+	test("accepts compact and compat", () => {
+		withConfig({ policyMode: "compact" }, (cwd) => {
+			expect(resolvePolicyMode(cwd)).toBe("compact");
+		});
+		withConfig({ policyMode: "compat" }, (cwd) => {
+			expect(resolvePolicyMode(cwd)).toBe("compat");
+		});
+	});
+
+	test("falls back to balanced for unknown values", () => {
+		withConfig({ policyMode: "ludicrous" }, (cwd) => {
+			expect(resolvePolicyMode(cwd)).toBe("balanced");
+		});
+	});
+});
+
+describe("balanced policy caps inline text", () => {
+	test("non-read text >25 KB is truncated below the cap", () => {
+		withConfig({}, (cwd) => {
+			const ctx = fakeCtx(cwd);
+			const text = Array.from({ length: 4000 }, (_, i) => `payload line ${i.toString().padStart(6, "0")} ${"x".repeat(40)}`).join("\n");
+			expect(text.length).toBeGreaterThan(150_000);
+			const result = processText({ toolName: "grep", toolCallId: "t1", input: {} }, ctx, text);
+			expect(result.meta?.truncated).toBe(true);
+			expect(result.meta?.policyMode).toBe("balanced");
+			expect(result.meta?.shownBytes).toBeLessThanOrEqual(25 * 1024);
+			expect(result.text).toContain("[Output truncated");
+			expect(result.text).toContain("Continue with the same tool");
+		});
+	});
+
+	test("artifact path is preserved on the result and the file holds full content", () => {
+		withConfig({}, (cwd) => {
+			const ctx = fakeCtx(cwd);
+			const text = Array.from({ length: 4000 }, (_, i) => `line ${i} ${"q".repeat(60)}`).join("\n");
+			const result = processText({ toolName: "bash", toolCallId: "art1", input: { command: "echo hello" } }, ctx, text);
+			expect(result.meta?.artifactPath).toBeTruthy();
+			const artifactPath = result.meta!.artifactPath!;
+			expect(existsSync(artifactPath)).toBe(true);
+			expect(readFileSync(artifactPath, "utf8")).toBe(text);
+			expect(result.text).toContain(`Full output: ${artifactPath}`);
+		});
+	});
+
+	test("compat mode allows the old 200 KB block size", () => {
+		withConfig({ policyMode: "compat" }, (cwd) => {
+			const ctx = fakeCtx(cwd);
+			const text = Array.from({ length: 1000 }, (_, i) => `compat line ${i}`).join("\n");
+			const result = processText({ toolName: "grep", toolCallId: "compat1", input: {} }, ctx, text);
+			expect(result.meta?.truncated).toBeFalsy();
+			expect(result.text).toBe(text);
+		});
+	});
+
+	test("explicit knob overrides mode default", () => {
+		// compact spill threshold is 16 KB; explicitly lifting it to 80 plus lifting
+		// the line/width caps should let a ~26 KB text pass through untruncated.
+		withConfig({ policyMode: "compact", spillThresholdKb: 80, maxLineCount: 2000, maxLineWidth: 4000 }, (cwd) => {
+			const ctx = fakeCtx(cwd);
+			const text = Array.from({ length: 600 }, (_, i) => `line ${i} ${"y".repeat(30)}`).join("\n");
+			const result = processText({ toolName: "grep", toolCallId: "ov1", input: {} }, ctx, text);
+			expect(result.meta?.truncated).toBeFalsy();
+		});
+	});
+});
+
+describe("shell minimizer + truncation interaction", () => {
+	test("minimizer-only path emits inline minimized marker without meta", () => {
+		withConfig({}, (cwd) => {
+			const ctx = fakeCtx(cwd);
+			const noisy = Array.from({ length: 500 }, (_, i) => `   Compiling noisy_crate_${i} v0.1.0`).join("\n");
+			const tail = "    Finished release\ntest result: ok. 999 passed; 0 failed";
+			const text = `${noisy}\n${tail}`;
+			const result = processText({ toolName: "bash", toolCallId: "sm-min", input: { command: "cargo test" } }, ctx, text);
+			expect(result.text).toContain("Output minimized: removed");
+			expect(result.text).toContain("test result: ok");
+			expect(result.meta).toBeUndefined();
+		});
+	});
+
+	test("minimizer + truncation: meta reports minimization and artifact holds original full text", () => {
+		// Force truncation by tightening the spill threshold below post-minimizer
+		// size, so we exercise minimizer → truncate → artifact persistence in order.
+		withConfig({ spillThresholdKb: 2 }, (cwd) => {
+			const ctx = fakeCtx(cwd);
+			const noisy = Array.from({ length: 4000 }, (_, i) => `   Compiling noisy_crate_${i} v0.1.0`).join("\n");
+			const tail = "    Finished release\ntest result: ok. 999 passed; 0 failed";
+			const text = `${noisy}\n${tail}`;
+			const result = processText({ toolName: "bash", toolCallId: "sm-trunc", input: { command: "cargo test --release" } }, ctx, text);
+			expect(result.meta?.truncated).toBe(true);
+			expect(result.meta?.minimized).toBe(true);
+			expect(result.meta?.minimizedDroppedLines ?? 0).toBeGreaterThan(0);
+			expect(result.text).toContain("Minimized");
+			expect(result.text).toContain("test result: ok");
+			expect(result.meta?.artifactPath).toBeTruthy();
+			// Artifact retains the ORIGINAL pre-minimizer text so the model can recover full context.
+			expect(readFileSync(result.meta!.artifactPath!, "utf8")).toBe(text);
+		});
+	});
+});
+
+describe("sanitize details", () => {
+	test("nested strings are truncated", () => {
+		const big = "a".repeat(20_000);
+		const result = sanitizeDetails({ note: big });
+		expect(result.changed).toBe(true);
+		expect((result.value as { note: string }).note.length).toBeLessThanOrEqual(8 * 1024 + 64);
+		expect((result.value as { note: string }).note).toContain("[detail string truncated]");
+	});
+
+	test("oversized arrays are capped at 50 entries", () => {
+		const huge = Array.from({ length: 200 }, (_, i) => ({ i }));
+		const result = sanitizeDetails(huge);
+		expect(result.changed).toBe(true);
+		expect(Array.isArray(result.value)).toBe(true);
+		expect((result.value as unknown[]).length).toBe(50);
+	});
+
+	test("deeply nested objects are bounded", () => {
+		let nested: any = { leaf: true };
+		for (let i = 0; i < 10; i += 1) nested = { child: nested };
+		const result = sanitizeDetails(nested);
+		expect(result.changed).toBe(true);
+		const serialized = JSON.stringify(result.value);
+		expect(serialized).toContain("[Max detail depth reached]");
+	});
+
+	test("small objects pass through unchanged", () => {
+		const value = { ok: true, count: 3, label: "x" };
+		const result = sanitizeDetails(value);
+		expect(result.changed).toBe(false);
+		expect(result.value).toEqual(value);
+	});
+});
+
+describe("state-bearing details allowlist", () => {
+	test("default allowlist covers tasks_write, bg_task, subagent", () => {
+		withConfig({}, (cwd) => {
+			expect(isSanitizeExceptTool("tasks_write", cwd)).toBe(true);
+			expect(isSanitizeExceptTool("bg_task", cwd)).toBe(true);
+			expect(isSanitizeExceptTool("subagent", cwd)).toBe(true);
+			expect(isSanitizeExceptTool("grep", cwd)).toBe(false);
+		});
+	});
+
+	test("custom allowlist replaces the default", () => {
+		withConfig({ "sanitizeDetails.exceptTools": "my_state_tool,other" }, (cwd) => {
+			expect(isSanitizeExceptTool("my_state_tool", cwd)).toBe(true);
+			expect(isSanitizeExceptTool("tasks_write", cwd)).toBe(false);
+		});
+	});
+
+	test("dotted suffix matching covers namespaced tools", () => {
+		withConfig({}, (cwd) => {
+			expect(isSanitizeExceptTool("ext.tasks_write", cwd)).toBe(true);
+		});
+	});
+});
+
+describe("saved-bytes counter", () => {
+	test("accumulates across multiple truncations within a turn", () => {
+		withConfig({}, (cwd) => {
+			const ctx = fakeCtx(cwd);
+			const text = Array.from({ length: 4000 }, (_, i) => `payload ${i} ${"z".repeat(40)}`).join("\n");
+			const first = processText({ toolName: "grep", toolCallId: "a", input: {} }, ctx, text);
+			const second = processText({ toolName: "grep", toolCallId: "b", input: {} }, ctx, text);
+			expect(first.meta?.savedBytes).toBeGreaterThan(0);
+			expect(second.meta?.savedBytes).toBeGreaterThan(0);
+			expect(second.meta!.turnSavedBytes!).toBeGreaterThan(first.meta!.turnSavedBytes!);
+			expect(second.meta!.sessionSavedBytes!).toBe(second.meta!.turnSavedBytes!);
 		});
 	});
 });

--- a/pi-extensions/pi-output-policy/tests/output-policy.test.ts
+++ b/pi-extensions/pi-output-policy/tests/output-policy.test.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import {
+import outputPolicy, {
 	__resetSessionCountersForTests,
 	isSanitizeExceptTool,
 	minimizeShellOutput,
@@ -244,6 +244,254 @@ describe("saved-bytes counter", () => {
 			expect(second.meta?.savedBytes).toBeGreaterThan(0);
 			expect(second.meta!.turnSavedBytes!).toBeGreaterThan(first.meta!.turnSavedBytes!);
 			expect(second.meta!.sessionSavedBytes!).toBe(second.meta!.turnSavedBytes!);
+		});
+	});
+});
+
+interface FakePi {
+	pi: any;
+	fire: (event: string, payload: any, ctx: any) => Promise<any>;
+}
+
+function createFakePi(): FakePi {
+	const handlers = new Map<string, (event: any, ctx: any) => any>();
+	const pi = {
+		on(event: string, handler: any) {
+			handlers.set(event, handler);
+		},
+	};
+	return {
+		pi,
+		fire: async (event, payload, ctx) => {
+			const handler = handlers.get(event);
+			if (!handler) return undefined;
+			return await handler(payload, ctx);
+		},
+	};
+}
+
+describe("tool_result handler (default-on sanitization & metadata)", () => {
+	test("oversized non-allowlisted details are sanitized and carry a marker", async () => {
+		await new Promise<void>((resolveTest) => {
+			withConfig({}, (cwd) => {
+				const fake = createFakePi();
+				outputPolicy(fake.pi);
+				const ctx = fakeCtx(cwd);
+				const details: Record<string, unknown> = { big: "x".repeat(20_000) };
+				for (let i = 0; i < 200; i += 1) details[`field_${i}`] = i;
+				fake.fire("tool_result", {
+					toolName: "grep",
+					toolCallId: "h1",
+					input: {},
+					content: [{ type: "text", text: "hello" }],
+					details,
+					isError: false,
+				}, ctx).then((result: any) => {
+					expect(result).toBeTruthy();
+					expect(Object.keys(result.details).length).toBeLessThanOrEqual(81 + 1);
+					expect(result.details["[output-policy:truncated]"]).toMatch(/object truncated/);
+					expect(result.details.vstackOutputPolicySanitized).toBeTruthy();
+					expect(result.details.vstackOutputPolicySanitized.policyMode).toBe("balanced");
+					expect(typeof result.details.big).toBe("string");
+					expect(result.details.big.length).toBeLessThanOrEqual(8 * 1024 + 64);
+					expect(result.details.big).toContain("[detail string truncated]");
+					resolveTest();
+				});
+			});
+		});
+	});
+
+	test("tasks_write details pass through untouched (state-bearing allowlist)", async () => {
+		await new Promise<void>((resolveTest) => {
+			withConfig({}, (cwd) => {
+				const fake = createFakePi();
+				outputPolicy(fake.pi);
+				const ctx = fakeCtx(cwd);
+				const details: Record<string, unknown> = {};
+				for (let i = 0; i < 200; i += 1) details[`task_${i}`] = { id: i, title: "x".repeat(20_000) };
+				fake.fire("tool_result", {
+					toolName: "tasks_write",
+					toolCallId: "h2",
+					input: {},
+					content: [{ type: "text", text: "ok" }],
+					details,
+					isError: false,
+				}, ctx).then((result: any) => {
+					// `tasks_write` text isn't oversized and details are exempt → handler returns undefined (no changes).
+					expect(result).toBeUndefined();
+					resolveTest();
+				});
+			});
+		});
+	});
+
+	test("vstackOutputPolicy meta is attached when text is truncated", async () => {
+		await new Promise<void>((resolveTest) => {
+			withConfig({}, (cwd) => {
+				const fake = createFakePi();
+				outputPolicy(fake.pi);
+				const ctx = fakeCtx(cwd);
+				const huge = Array.from({ length: 4000 }, (_, i) => `match ${i} ${"q".repeat(40)}`).join("\n");
+				fake.fire("tool_result", {
+					toolName: "grep",
+					toolCallId: "h3",
+					input: {},
+					content: [{ type: "text", text: huge }],
+					details: { ok: true },
+					isError: false,
+				}, ctx).then((result: any) => {
+					expect(result.details.vstackOutputPolicy).toBeInstanceOf(Array);
+					expect(result.details.vstackOutputPolicy[0].truncated).toBe(true);
+					expect(result.details.vstackOutputPolicy[0].artifactPath).toBeTruthy();
+					expect(result.content[0].text).toContain("[Output truncated");
+					resolveTest();
+				});
+			});
+		});
+	});
+
+	test("compat mode skips default sanitization", async () => {
+		await new Promise<void>((resolveTest) => {
+			withConfig({ policyMode: "compat" }, (cwd) => {
+				const fake = createFakePi();
+				outputPolicy(fake.pi);
+				const ctx = fakeCtx(cwd);
+				const details: Record<string, unknown> = {};
+				for (let i = 0; i < 200; i += 1) details[`field_${i}`] = i;
+				fake.fire("tool_result", {
+					toolName: "grep",
+					toolCallId: "h4",
+					input: {},
+					content: [{ type: "text", text: "ok" }],
+					details,
+					isError: false,
+				}, ctx).then((result: any) => {
+					// compat: no sanitization, no text truncation → no change.
+					expect(result).toBeUndefined();
+					resolveTest();
+				});
+			});
+		});
+	});
+
+	test("array details get a sentinel when capped", () => {
+		const huge = Array.from({ length: 300 }, (_, i) => ({ i }));
+		const result = sanitizeDetails(huge);
+		expect(result.changed).toBe(true);
+		const arr = result.value as unknown[];
+		expect(arr.length).toBe(50);
+		expect(typeof arr[arr.length - 1]).toBe("string");
+		expect(arr[arr.length - 1]).toMatch(/array truncated, dropped/);
+	});
+});
+
+describe("handler-level counter lifecycle", () => {
+	async function runWithHandlers(
+		cwd: string,
+		fn: (fake: FakePi, ctx: any, oversized: string) => Promise<void>,
+	): Promise<void> {
+		const fake = createFakePi();
+		outputPolicy(fake.pi);
+		const ctx = fakeCtx(cwd);
+		const oversized = Array.from({ length: 4000 }, (_, i) => `line ${i} ${"w".repeat(40)}`).join("\n");
+		await fn(fake, ctx, oversized);
+	}
+
+	test("turn_start resets turnSavedBytes, sessionSavedBytes persists", async () => {
+		await new Promise<void>((resolveTest) => {
+			withConfig({}, (cwd) => {
+				runWithHandlers(cwd, async (fake, ctx, oversized) => {
+					const r1: any = await fake.fire("tool_result", {
+						toolName: "grep",
+						toolCallId: "t1",
+						input: {},
+						content: [{ type: "text", text: oversized }],
+						details: {},
+						isError: false,
+					}, ctx);
+					const meta1 = r1.details.vstackOutputPolicy[0];
+					expect(meta1.turnSavedBytes).toBeGreaterThan(0);
+					expect(meta1.sessionSavedBytes).toBe(meta1.turnSavedBytes);
+
+					await fake.fire("turn_start", { type: "turn_start", turnIndex: 1, timestamp: 0 }, ctx);
+
+					const r2: any = await fake.fire("tool_result", {
+						toolName: "grep",
+						toolCallId: "t2",
+						input: {},
+						content: [{ type: "text", text: oversized }],
+						details: {},
+						isError: false,
+					}, ctx);
+					const meta2 = r2.details.vstackOutputPolicy[0];
+					// Turn counter restarted from 0, then this call added saved bytes.
+					expect(meta2.turnSavedBytes).toBe(meta2.savedBytes);
+					expect(meta2.turnSavedBytes).toBeLessThan(meta1.sessionSavedBytes + meta2.savedBytes);
+					expect(meta2.sessionSavedBytes).toBe(meta1.sessionSavedBytes + meta2.savedBytes);
+					resolveTest();
+				});
+			});
+		});
+	});
+
+	test("session_start clears all counters", async () => {
+		await new Promise<void>((resolveTest) => {
+			withConfig({}, (cwd) => {
+				runWithHandlers(cwd, async (fake, ctx, oversized) => {
+					await fake.fire("tool_result", {
+						toolName: "grep",
+						toolCallId: "s1",
+						input: {},
+						content: [{ type: "text", text: oversized }],
+						details: {},
+						isError: false,
+					}, ctx);
+					await fake.fire("session_start", { type: "session_start" }, ctx);
+					const r2: any = await fake.fire("tool_result", {
+						toolName: "grep",
+						toolCallId: "s2",
+						input: {},
+						content: [{ type: "text", text: oversized }],
+						details: {},
+						isError: false,
+					}, ctx);
+					const meta2 = r2.details.vstackOutputPolicy[0];
+					// Session reset means sessionSavedBytes equals what this single call added.
+					expect(meta2.sessionSavedBytes).toBe(meta2.savedBytes);
+					expect(meta2.turnSavedBytes).toBe(meta2.savedBytes);
+					resolveTest();
+				});
+			});
+		});
+	});
+
+	test("session_shutdown clears counters", async () => {
+		await new Promise<void>((resolveTest) => {
+			withConfig({}, (cwd) => {
+				runWithHandlers(cwd, async (fake, ctx, oversized) => {
+					await fake.fire("tool_result", {
+						toolName: "grep",
+						toolCallId: "sh1",
+						input: {},
+						content: [{ type: "text", text: oversized }],
+						details: {},
+						isError: false,
+					}, ctx);
+					await fake.fire("session_shutdown", { type: "session_shutdown" }, ctx);
+					const r2: any = await fake.fire("tool_result", {
+						toolName: "grep",
+						toolCallId: "sh2",
+						input: {},
+						content: [{ type: "text", text: oversized }],
+						details: {},
+						isError: false,
+					}, ctx);
+					const meta2 = r2.details.vstackOutputPolicy[0];
+					expect(meta2.sessionSavedBytes).toBe(meta2.savedBytes);
+					expect(meta2.turnSavedBytes).toBe(meta2.savedBytes);
+					resolveTest();
+				});
+			});
 		});
 	});
 });

--- a/pi-extensions/pi-output-policy/tests/output-policy.test.ts
+++ b/pi-extensions/pi-output-policy/tests/output-policy.test.ts
@@ -129,13 +129,21 @@ describe("balanced policy caps inline text", () => {
 	});
 
 	test("payload between maxTextBlockKb and spillThresholdKb still truncates in balanced", () => {
-		// balanced: spill 48 KB, maxTextBlockKb 24 KB. A ~32 KB payload sits in the
-		// gap and must trigger truncation via the maxTextBlock cap.
+		// balanced caps: spill 48 KB, maxTextBlockKb 24 KB, maxLineCount 400,
+		// maxLineWidth 3000. Construct ~32 KB with every other cap comfortably
+		// under threshold so ONLY the per-block byte cap can fire — that proves
+		// the round-2 trigger and is not satisfied by line-width/line-count
+		// fallback if maxTextBlockKb were removed from the predicate.
 		withConfig({}, (cwd) => {
 			const ctx = fakeCtx(cwd);
-			const text = "x".repeat(32 * 1024);
+			const lineCount = 100;
+			const lineWidth = 320;
+			const lines = Array.from({ length: lineCount }, (_, i) => `${String(i).padStart(4, "0")} ${"a".repeat(lineWidth - 5)}`);
+			const text = lines.join("\n");
 			expect(text.length).toBeGreaterThan(24 * 1024);
 			expect(text.length).toBeLessThan(48 * 1024);
+			expect(lineCount).toBeLessThanOrEqual(400);
+			expect(lines.every((line) => line.length <= 3000)).toBe(true);
 			const result = processText({ toolName: "grep", toolCallId: "gap1", input: {} }, ctx, text);
 			expect(result.meta?.truncated).toBe(true);
 			expect(result.meta?.reason).toBe("max-text-block");
@@ -145,13 +153,18 @@ describe("balanced policy caps inline text", () => {
 	});
 
 	test("payload between maxTextBlockKb and spillThresholdKb still truncates in compact", () => {
-		// compact: spill 16 KB, maxTextBlockKb 8 KB. A ~12 KB payload sits in
-		// the gap.
+		// compact caps: spill 16 KB, maxTextBlockKb 8 KB, maxLineCount 200,
+		// maxLineWidth 2000. Same isolation discipline as the balanced case.
 		withConfig({ policyMode: "compact" }, (cwd) => {
 			const ctx = fakeCtx(cwd);
-			const text = "y".repeat(12 * 1024);
+			const lineCount = 60;
+			const lineWidth = 200;
+			const lines = Array.from({ length: lineCount }, (_, i) => `${String(i).padStart(4, "0")} ${"b".repeat(lineWidth - 5)}`);
+			const text = lines.join("\n");
 			expect(text.length).toBeGreaterThan(8 * 1024);
 			expect(text.length).toBeLessThan(16 * 1024);
+			expect(lineCount).toBeLessThanOrEqual(200);
+			expect(lines.every((line) => line.length <= 2000)).toBe(true);
 			const result = processText({ toolName: "grep", toolCallId: "gap2", input: {} }, ctx, text);
 			expect(result.meta?.truncated).toBe(true);
 			expect(result.meta?.reason).toBe("max-text-block");

--- a/pi-extensions/pi-output-policy/tests/output-policy.test.ts
+++ b/pi-extensions/pi-output-policy/tests/output-policy.test.ts
@@ -128,10 +128,42 @@ describe("balanced policy caps inline text", () => {
 		});
 	});
 
+	test("payload between maxTextBlockKb and spillThresholdKb still truncates in balanced", () => {
+		// balanced: spill 48 KB, maxTextBlockKb 24 KB. A ~32 KB payload sits in the
+		// gap and must trigger truncation via the maxTextBlock cap.
+		withConfig({}, (cwd) => {
+			const ctx = fakeCtx(cwd);
+			const text = "x".repeat(32 * 1024);
+			expect(text.length).toBeGreaterThan(24 * 1024);
+			expect(text.length).toBeLessThan(48 * 1024);
+			const result = processText({ toolName: "grep", toolCallId: "gap1", input: {} }, ctx, text);
+			expect(result.meta?.truncated).toBe(true);
+			expect(result.meta?.reason).toBe("max-text-block");
+			expect(result.meta?.artifactPath).toBeTruthy();
+			expect(result.meta?.shownBytes).toBeLessThanOrEqual(24 * 1024);
+		});
+	});
+
+	test("payload between maxTextBlockKb and spillThresholdKb still truncates in compact", () => {
+		// compact: spill 16 KB, maxTextBlockKb 8 KB. A ~12 KB payload sits in
+		// the gap.
+		withConfig({ policyMode: "compact" }, (cwd) => {
+			const ctx = fakeCtx(cwd);
+			const text = "y".repeat(12 * 1024);
+			expect(text.length).toBeGreaterThan(8 * 1024);
+			expect(text.length).toBeLessThan(16 * 1024);
+			const result = processText({ toolName: "grep", toolCallId: "gap2", input: {} }, ctx, text);
+			expect(result.meta?.truncated).toBe(true);
+			expect(result.meta?.reason).toBe("max-text-block");
+			expect(result.meta?.artifactPath).toBeTruthy();
+			expect(result.meta?.shownBytes).toBeLessThanOrEqual(8 * 1024);
+		});
+	});
+
 	test("explicit knob overrides mode default", () => {
-		// compact spill threshold is 16 KB; explicitly lifting it to 80 plus lifting
-		// the line/width caps should let a ~26 KB text pass through untruncated.
-		withConfig({ policyMode: "compact", spillThresholdKb: 80, maxLineCount: 2000, maxLineWidth: 4000 }, (cwd) => {
+		// compact caps: spill 16 KB / maxTextBlockKb 8 KB. Lift every triggering
+		// cap explicitly and verify a ~26 KB text passes through untruncated.
+		withConfig({ policyMode: "compact", spillThresholdKb: 80, maxTextBlockKb: 80, maxLineCount: 2000, maxLineWidth: 4000 }, (cwd) => {
 			const ctx = fakeCtx(cwd);
 			const text = Array.from({ length: 600 }, (_, i) => `line ${i} ${"y".repeat(30)}`).join("\n");
 			const result = processText({ toolName: "grep", toolCallId: "ov1", input: {} }, ctx, text);


### PR DESCRIPTION
## Summary
- Add a `policyMode` setting (`balanced` default / `compact` / `compat`) so pi-output-policy enforces a model-transcript / session-JSONL budget alongside the existing UI-safety caps. `balanced` keeps any single non-read/non-mutation tool result under ~24 KB inline while preserving the full output on disk.
- Default `sanitizeDetails` on in `balanced`/`compact` with a state-bearing allowlist (`tasks_write`, `bg_task`, `subagent`, …) so sidecar restore semantics stay safe. Sanitization carries an explicit `vstackOutputPolicySanitized` marker, capped arrays/objects emit inline sentinels, and the `Object.entries` allocation path was replaced with a `for…in` + early-break loop (CWE-400 mitigation on wide untrusted details objects).
- Track per-turn and per-session bytes saved; surface counters in `TruncationMeta` and inline notice, with proper reset on `turn_start` / `session_start` / `session_shutdown`.
- Per-block byte cap (`maxTextBlockKb`) is now an independent truncation trigger, so payloads in the gap between `maxTextBlockKb` and `spillThresholdKb` are truncated with `reason="max-text-block"` and the artifact path preserved.
- README: two-budgets framing (UI vs transcript), policy-modes table, allowlist docs, accurate compat description (legacy UI-safety caps, not "untruncated"), and explicit `enabled: false` opt-out for verbatim inline output.

## Test plan
- [x] `bun test` in `pi-extensions/pi-output-policy` — 29 pass, 0 fail (97 expectations). Covers policyMode resolution, balanced cap on non-read/non-mutation text, compat passthrough, explicit-knob override, gap-payload truncation (balanced 32 KB / compact 12 KB) pinned to `max-text-block` reason via multi-line payloads under every other cap, shell minimizer + truncation interaction, artifact path preservation, sanitizeDetails (strings, arrays with sentinel, deep nesting, object cap with field sentinel), state-bearing allowlist, handler-level default-on sanitization metadata, and counter lifecycle (`turn_start` resets `turnSavedBytes` while `sessionSavedBytes` carries over; `session_start` / `session_shutdown` clear both).
- [x] `node --test pi-extensions/package-policy.test.mjs` — 2 pass (Pi 0.75 manifest policy still satisfied for the updated `package.json`).
- [x] `cargo test --quiet` in `cli/` — 205 pass, 0 failed, 2 ignored.

Fixes #209