### PR TITLE
fix(flightdeck-repo-sync): cap diagnostic stdout/stderr to 2 KiB

### DIFF
--- a/skills/flightdeck/lib/flightdeck-core/src/bin/flightdeck-repo-sync.ts
+++ b/skills/flightdeck/lib/flightdeck-core/src/bin/flightdeck-repo-sync.ts
@@ -130,6 +130,15 @@ function reasonWithDiagnostics(reason: string, diagnostics: RepoMainSyncDiagnost
 	return suffix ? `${reason}: ${suffix}` : reason;
 }
 
+const DIAGNOSTIC_STREAM_CAP_BYTES = 2048;
+
+function capDiagnosticStream(value: string): string {
+	const trimmed = value.trim();
+	if (trimmed.length <= DIAGNOSTIC_STREAM_CAP_BYTES) return trimmed;
+	const keep = DIAGNOSTIC_STREAM_CAP_BYTES;
+	return `${trimmed.slice(0, keep)}…[truncated ${trimmed.length - keep} bytes]`;
+}
+
 function gitDiagnostic(run: GitRun): RepoMainSyncDiagnostic {
 	const diagnostic: RepoMainSyncDiagnostic = {
 		args: run.args,
@@ -137,8 +146,8 @@ function gitDiagnostic(run: GitRun): RepoMainSyncDiagnostic {
 		exit_status: run.status,
 		signal: run.signal,
 	};
-	if (run.stderr.trim()) diagnostic.stderr = run.stderr.trim();
-	if (run.stdout.trim()) diagnostic.stdout = run.stdout.trim();
+	if (run.stderr.trim()) diagnostic.stderr = capDiagnosticStream(run.stderr);
+	if (run.stdout.trim()) diagnostic.stdout = capDiagnosticStream(run.stdout);
 	if (run.error) {
 		if (run.error.code) diagnostic.error_code = run.error.code;
 		diagnostic.error_message = run.error.message;

--- a/skills/flightdeck/lib/flightdeck-core/tests/parity/repo-sync.test.ts
+++ b/skills/flightdeck/lib/flightdeck-core/tests/parity/repo-sync.test.ts
@@ -79,6 +79,14 @@ function failStatusShim(): Record<string, string> {
 	return gitShim(`  *" status --porcelain=v1 --untracked-files=all "*) echo "status exploded" >&2; exit 44 ;;`);
 }
 
+function failStatusOversizedStdoutShim(): Record<string, string> {
+	// Emit > 4 KiB of NUL-separated path-like junk on stdout plus a short stderr,
+	// then exit non-zero. Mirrors the real-world failure mode where a `git ls-files
+	// -z` or `git diff --name-only -z` run produces huge stdout and a downstream
+	// failure ends up dumping that stdout into the diagnostic JSON.
+	return gitShim(`  *" status --porcelain=v1 --untracked-files=all "*) python3 -c 'import sys; sys.stdout.write("path/" + "\\x00".join("file" + str(i) + ".rs" for i in range(800)))' ; echo "status exploded" >&2; exit 44 ;;`);
+}
+
 function failFetchShim(): Record<string, string> {
 	return gitShim(`  *" fetch --prune --no-tags --refmap= origin +refs/heads/main:refs/remotes/origin/main "*) echo "fetch exploded" >&2; exit 47 ;;`);
 }
@@ -333,6 +341,19 @@ describe("flightdeck-repo-sync main", () => {
 		expect(result.json.dirty_paths).toEqual([]);
 		expect(result.json.diagnostics?.[0]).toMatchObject({ exit_status: 44, stderr: "status exploded" });
 		expect(result.json.diagnostics?.[0]?.command).toContain("status --porcelain=v1 --untracked-files=all");
+	});
+
+	test("diagnostic stdout/stderr are capped on oversized output", () => {
+		const result = runSync(failStatusOversizedStdoutShim());
+		expect(result.status).toBe(1);
+		expect(result.json.status).toBe("failed");
+		const diag = result.json.diagnostics?.[0];
+		expect(diag).toBeDefined();
+		const stdout = (diag?.stdout ?? "") as string;
+		// Cap is 2048 bytes; allow some headroom for the truncation marker (“ellipsis + [truncated N bytes]”).
+		expect(stdout.length).toBeGreaterThan(0);
+		expect(stdout.length).toBeLessThan(2200);
+		expect(stdout).toContain("truncated");
 	});
 
 	test("symbolic-ref failure fails before updating checked-out main ref", () => {


### PR DESCRIPTION
## Problem

`gitDiagnostic` in `flightdeck-repo-sync.ts` embedded `run.stdout` / `run.stderr` verbatim into the `RepoMainSyncDiagnostic` JSON. When a downstream failure attached a diagnostic for a command with large output (e.g. `git ls-files -z -o -i --exclude-standard` on a repo with thousands of ignored paths under `target/release/`, `node_modules/`, etc), the resulting JSON line contained kilobytes of NUL-separated paths encoded as `\u0000` literals — visible during the 8-issue Flightdeck batch (PRs #217-#224) when calling `flightdeck-repo-sync main` between rapid merges.

## Fix

Cap each stream at 2048 bytes with a `…[truncated N bytes]` marker via a small `capDiagnosticStream` helper. Preserves all useful diagnostic info while bounding pathological cases.

## Tests

- New parity regression: `diagnostic stdout/stderr are capped on oversized output` — seeds a failing `git status` shim that emits >4 KiB of NUL-separated stdout, asserts `diag.stdout` length stays under 2200 chars and contains `truncated`.
- Existing `flightdeck-repo-sync main` parity tests: 19/19 pass (was 18 before this test was added).
- Full `flightdeck-core` suite: 838 pass / 0 fail (53 files, 4275 expect calls).

No-issue fix — surfaced and resolved during session cleanup after #213/#216/#220 merges.