### PR TITLE
Pi agents: restricted nested delegation via allowed-subagents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,7 +143,7 @@ rust = { color = "#f97316", model = "openai/gpt-5.5", model-reasoning-effort = "
 rust = { model = "gpt-5.5", model-reasoning-effort = "xhigh", sandbox-mode = "danger-full-access" }
 
 [agent-frontmatter.pi]
-rust = { color = "orange", model = "openai-codex/gpt-5.5:xhigh", deny-tools = ["subagent", "get_subagent_result", "steer_subagent", "stop_subagent", "question"], pane = true }
+rust = { color = "orange", model = "openai-codex/gpt-5.5:xhigh", deny-tools = ["subagent", "get_subagent_result", "steer_subagent", "stop_subagent", "question"], allowed-subagents = ["scout"], pane = true }
 
 # Project instructions prepended to a skill's SKILL.md.
 [skill-instructions]
@@ -165,6 +165,7 @@ Each canonical agent declares its own `effort:` in frontmatter. Harnesses write 
 - Prefer `deny-tools`. Claude Code writes it as native `disallowedTools`, seeds `background` from Pi `pane` on first install (`pane = true` → `background = false`, `pane = false` → `background = true`) and preserves later edits, and omits `isolation`/`memory` unless configured. Pi emits `deny-tools` for `pi-agents-tmux` (default = active parent tools minus denials); generated Pi reviewer agents additionally deny `tasks_write` so isolated review fan-outs do not mutate task panels. OpenCode defaults generated agents to `mode: subagent`, still exposes `mode` for rare primary-agent overrides, emits `permission: <tool>: deny` entries from the same deny list, maps `color` to hex values, and writes reasoning under `options.reasoningEffort` with summary/verbosity defaults.
 - Cursor and Codex don't use the same per-agent tool-deny frontmatter; Codex subagents use sandbox/approval configuration instead.
 - Per-harness frontmatter overrides live under `[agent-frontmatter.<harness>]`; use `deny-tools` rather than allowlists so harness defaults remain available while unsafe tools are blocked.
+- Pi `allowed-subagents` is the restricted delegation allowlist for `delegate_subagent`. Engineer agents default to `["scout"]` so dev agents can dispatch read-only reconnaissance into a fresh bg lane without gaining full `subagent` orchestration. Non-engineer roles default to empty (no delegation) and gain `delegate_subagent` in `deny-tools`. Set `allowed-subagents = []` in `[agent-frontmatter.pi]` to disable the engineer default. Accepted aliases: `allowedSubagents`, `subagent-agents`, `subagent_agents`. Pane targets are rejected at runtime by `delegate_subagent`.
 
 ## Rules
 

--- a/README.md
+++ b/README.md
@@ -92,12 +92,13 @@ rust = { color = "#f97316", model = "openai/gpt-5.5", model-reasoning-effort = "
 rust = { model = "gpt-5.5", model-reasoning-effort = "xhigh", sandbox-mode = "danger-full-access" }
 
 [agent-frontmatter.pi]
-rust = { color = "orange", model = "openai-codex/gpt-5.5:xhigh", deny-tools = ["subagent", "question"], pane = true }
+rust = { color = "orange", model = "openai-codex/gpt-5.5:xhigh", deny-tools = ["subagent", "question"], allowed-subagents = ["scout"], pane = true }
 ```
 
 Key rules:
 
 - **Prefer `deny-tools` over allowlists.** Each harness inherits its normal tool set and blocks only what you list. Claude Code writes it as native `disallowedTools`; OpenCode emits `permission: <tool>: deny`; Pi enforces it via `pi-agents-tmux`. Cursor and Codex don't use per-agent deny lists — Codex subagents use `sandbox-mode`/approval instead.
+- **Pi `allowed-subagents` enables `delegate_subagent`.** vstack engineer agents default to `allowed-subagents = ["scout"]` so dev agents can dispatch read-only reconnaissance without gaining full orchestration controls. Set `[]` to disable; non-engineer roles default to disabled (and gain `delegate_subagent` in their `deny-tools`). Aliases: `allowedSubagents`, `subagent-agents`, `subagent_agents`.
 - **`effort` is written verbatim** by each harness. Valid: `low`, `medium`, `high`, `xhigh` (Claude also accepts `max`). Pi appends it to its model id as `:<effort>`.
 - **OpenCode agents default to `mode: subagent`.** Set `mode = "primary"` only when you want an OpenCode primary agent. OpenCode `color` must be hex.
 - **Claude `background` seeds from Pi `pane`** on first install (`pane = true` → `background = false`), then your edits are preserved on refresh.

--- a/cli/src/agent.rs
+++ b/cli/src/agent.rs
@@ -246,6 +246,19 @@ pub struct AgentFrontmatterOverrides {
     /// `disallowedTools`) or preserve the denylist for the harness extension.
     #[serde(default, deserialize_with = "deserialize_optional_tools")]
     pub deny_tools: Option<Vec<String>>,
+    /// Pi restricted-delegation allowlist for `delegate_subagent`. Names must
+    /// match a discovered agent (no fuzzy matching). An explicit empty list
+    /// disables the engineer-role default. Accepts the canonical kebab key
+    /// plus camelCase / snake_case / `subagent-agents` aliases for
+    /// compatibility with the upstream `pi-subagents` convention.
+    #[serde(
+        default,
+        alias = "allowedSubagents",
+        alias = "subagent-agents",
+        alias = "subagent_agents",
+        deserialize_with = "deserialize_optional_tools"
+    )]
+    pub allowed_subagents: Option<Vec<String>>,
     /// Pi persistent pane flag.
     pub pane: Option<bool>,
     /// Claude Code background subagent flag.
@@ -299,6 +312,10 @@ impl AgentFrontmatterOverrides {
             model: harness.model.clone().or_else(|| self.model.clone()),
             tools: harness.tools.clone().or_else(|| self.tools.clone()),
             deny_tools: merge_optional_tool_lists(&self.deny_tools, &harness.deny_tools),
+            allowed_subagents: harness
+                .allowed_subagents
+                .clone()
+                .or_else(|| self.allowed_subagents.clone()),
             pane: harness.pane.or(self.pane),
             background: harness.background.or(self.background),
             effort: harness.effort.clone().or_else(|| self.effort.clone()),
@@ -722,6 +739,77 @@ Always run clippy.
         let extras = extract_user_sections(content);
         assert!(extras.guidance.is_none());
         assert!(extras.instructions.is_none());
+    }
+
+    #[test]
+    fn frontmatter_overrides_merge_allowed_subagents_with_harness_winning() {
+        let base = AgentFrontmatterOverrides {
+            allowed_subagents: Some(vec!["base-target".into()]),
+            ..Default::default()
+        };
+        let harness = AgentFrontmatterOverrides {
+            allowed_subagents: Some(vec!["harness-target".into()]),
+            ..Default::default()
+        };
+        let merged = base.merge(&harness);
+        assert_eq!(
+            merged.allowed_subagents,
+            Some(vec!["harness-target".to_string()]),
+            "harness override should win, including its full list"
+        );
+    }
+
+    #[test]
+    fn frontmatter_overrides_merge_preserves_explicit_empty_allowed_subagents() {
+        // An explicit empty list at either layer must survive — that's how
+        // users opt out of engineer-role defaults.
+        let base = AgentFrontmatterOverrides::default();
+        let harness = AgentFrontmatterOverrides {
+            allowed_subagents: Some(Vec::new()),
+            ..Default::default()
+        };
+        let merged = base.merge(&harness);
+        assert_eq!(
+            merged.allowed_subagents,
+            Some(Vec::new()),
+            "explicit empty list must override unset/default state"
+        );
+    }
+
+    #[test]
+    fn frontmatter_overrides_merge_falls_through_when_harness_unset() {
+        let base = AgentFrontmatterOverrides {
+            allowed_subagents: Some(vec!["scout".into()]),
+            ..Default::default()
+        };
+        let harness = AgentFrontmatterOverrides::default();
+        let merged = base.merge(&harness);
+        assert_eq!(merged.allowed_subagents, Some(vec!["scout".to_string()]));
+    }
+
+    #[test]
+    fn frontmatter_overrides_parses_allowed_subagents_aliases() {
+        let canonical: AgentFrontmatterOverrides =
+            serde_yaml::from_str("allowed-subagents: scout, researcher").unwrap();
+        assert_eq!(
+            canonical.allowed_subagents,
+            Some(vec!["scout".to_string(), "researcher".to_string()])
+        );
+
+        let camel: AgentFrontmatterOverrides =
+            serde_yaml::from_str("allowedSubagents:\n  - scout\n  - researcher").unwrap();
+        assert_eq!(
+            camel.allowed_subagents,
+            Some(vec!["scout".to_string(), "researcher".to_string()])
+        );
+
+        let snake: AgentFrontmatterOverrides =
+            serde_yaml::from_str("subagent_agents: scout").unwrap();
+        assert_eq!(snake.allowed_subagents, Some(vec!["scout".to_string()]));
+
+        let dashed: AgentFrontmatterOverrides =
+            serde_yaml::from_str("subagent-agents: scout").unwrap();
+        assert_eq!(dashed.allowed_subagents, Some(vec!["scout".to_string()]));
     }
 
     #[test]

--- a/cli/src/commands/add.rs
+++ b/cli/src/commands/add.rs
@@ -286,10 +286,7 @@ mod auto_include_agent_skills_tests {
         let agents = vec![agent("reviewer-error", AgentRole::Engineer)];
         let mut selected = Vec::<Skill>::new();
         let added = auto_include_agent_skills(&agents, &mapping, &all, &mut selected);
-        assert_eq!(
-            added,
-            vec!["github".to_string(), "linear-dev".to_string()]
-        );
+        assert_eq!(added, vec!["github".to_string(), "linear-dev".to_string()]);
         let names: Vec<&str> = selected.iter().map(|s| s.name.as_str()).collect();
         assert!(names.contains(&"linear-dev"));
         assert!(names.contains(&"github"));

--- a/cli/src/commands/check.rs
+++ b/cli/src/commands/check.rs
@@ -285,10 +285,7 @@ mod parse_skills_field_tests {
         // Real-world shape from .claude/agents/<name>.md.
         let fm = "name: reviewer-error\nskills: linear-dev, linear\nrole: engineer";
         let skills = parse_skills_field(fm);
-        assert_eq!(
-            skills,
-            vec!["linear-dev".to_string(), "linear".to_string()]
-        );
+        assert_eq!(skills, vec!["linear-dev".to_string(), "linear".to_string()]);
     }
 
     #[test]

--- a/cli/src/commands/refresh.rs
+++ b/cli/src/commands/refresh.rs
@@ -172,13 +172,8 @@ pub fn refresh_items_in_scope(
 
         for harness_id in &entry.harnesses {
             if let Some(harness) = Harness::from_id(harness_id) {
-                let _ = harness.generate_agent(
-                    agent,
-                    global,
-                    &skill_pairs,
-                    &matched_hooks,
-                    &extras,
-                );
+                let _ =
+                    harness.generate_agent(agent, global, &skill_pairs, &matched_hooks, &extras);
             }
         }
         stats.agents_refreshed += 1;

--- a/cli/src/harness/claude.rs
+++ b/cli/src/harness/claude.rs
@@ -282,8 +282,8 @@ mod tests {
 
         let mut agent = agent_fixture("reviewer-arch", AgentRole::Reviewer);
         agent.effort = Some("high".into());
-        let path = generate_agent(&agent, &dir, &[], &[], &AgentExtras::default())
-            .expect("generate ok");
+        let path =
+            generate_agent(&agent, &dir, &[], &[], &AgentExtras::default()).expect("generate ok");
         let content = std::fs::read_to_string(&path).unwrap();
         assert!(!content.contains("\ntools:"));
         assert!(content.contains("effort: high"));

--- a/cli/src/harness/codex.rs
+++ b/cli/src/harness/codex.rs
@@ -129,8 +129,8 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
 
         let agent = agent_fixture("tpm", AgentRole::Manager);
-        let path = generate_agent(&agent, &dir, &[], &[], &AgentExtras::default())
-            .expect("generate ok");
+        let path =
+            generate_agent(&agent, &dir, &[], &[], &AgentExtras::default()).expect("generate ok");
         let content = std::fs::read_to_string(&path).unwrap();
         assert!(content.contains("sandbox_mode = \"workspace-write\""));
 
@@ -166,8 +166,8 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
 
         let agent = agent_fixture("scout", AgentRole::Analyst);
-        let path = generate_agent(&agent, &dir, &[], &[], &AgentExtras::default())
-            .expect("generate ok");
+        let path =
+            generate_agent(&agent, &dir, &[], &[], &AgentExtras::default()).expect("generate ok");
         let content = std::fs::read_to_string(&path).unwrap();
         assert!(!content.contains("model_reasoning_effort"));
 

--- a/cli/src/harness/mod.rs
+++ b/cli/src/harness/mod.rs
@@ -260,13 +260,9 @@ impl Harness {
         }
         let dir = self.agents_dir(global);
         match self {
-            Harness::ClaudeCode => {
-                claude::generate_agent(agent, &dir, skills, hooks, extras)
-            }
+            Harness::ClaudeCode => claude::generate_agent(agent, &dir, skills, hooks, extras),
             Harness::Cursor => cursor::generate_agent(agent, &dir, skills, hooks, extras),
-            Harness::OpenCode => {
-                opencode::generate_agent(agent, &dir, skills, hooks, extras)
-            }
+            Harness::OpenCode => opencode::generate_agent(agent, &dir, skills, hooks, extras),
             Harness::Codex => codex::generate_agent(agent, &dir, skills, hooks, extras),
             Harness::Pi => pi::generate_agent(agent, &dir, skills, hooks, extras),
         }

--- a/cli/src/harness/pi.rs
+++ b/cli/src/harness/pi.rs
@@ -294,8 +294,8 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
 
         let agent = agent_fixture("scout", AgentRole::Analyst, "opus");
-        let path = generate_agent(&agent, &dir, &[], &[], &AgentExtras::default())
-            .expect("generate ok");
+        let path =
+            generate_agent(&agent, &dir, &[], &[], &AgentExtras::default()).expect("generate ok");
 
         let content = std::fs::read_to_string(&path).unwrap();
         assert!(content.contains("model: openai-codex/gpt-5.5\n"));

--- a/cli/src/harness/pi.rs
+++ b/cli/src/harness/pi.rs
@@ -134,15 +134,26 @@ fn pi_deny_tools_for(
     frontmatter: &agent::AgentFrontmatterOverrides,
     allowed_subagents: &[String],
 ) -> Vec<String> {
+    let user_denies_delegate = frontmatter
+        .deny_tools
+        .as_deref()
+        .is_some_and(|denies| {
+            denies
+                .iter()
+                .any(|tool| normalize_pi_tool_name(tool) == "delegate_subagent")
+        });
     let mut tools = pi_default_deny_tools_for(agent, allowed_subagents);
     if let Some(deny_tools) = &frontmatter.deny_tools {
         tools.extend(deny_tools.clone());
     }
     let mut tools = dedupe_pi_tool_names(tools);
-    if !allowed_subagents.is_empty() {
-        // The agent has an explicit allowlist, so it must see the restricted
-        // delegation tool. Strip any stale `delegate_subagent` deny so the
-        // child process actually inherits the active tool.
+    if !allowed_subagents.is_empty() && !user_denies_delegate {
+        // Engineer agents ship with the scout-style allowlist by default,
+        // which implies the default `delegate_subagent` deny is no longer
+        // appropriate. Strip it so the child process actually inherits the
+        // active tool. If the user *explicitly* listed `delegate_subagent`
+        // in `deny-tools`, the explicit policy wins — keep the deny and
+        // accept that the allowlist will never resolve targets at runtime.
         tools.retain(|tool| normalize_pi_tool_name(tool) != "delegate_subagent");
     }
     tools
@@ -570,6 +581,90 @@ mod tests {
                 .any(|line| line.starts_with("allowed-subagents:"))
         );
         assert!(!content.contains("pane: true"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn explicit_delegate_subagent_deny_wins_over_engineer_default_allowlist() {
+        // Pre-PR review round-1 blocker 2: an engineer's default
+        // `allowed-subagents: scout` must not silently override an explicit
+        // user policy that denies `delegate_subagent`. The user's intent is
+        // authoritative — keep the deny even though the allowlist is
+        // non-empty, and accept that runtime delegation will refuse.
+        let dir = std::env::temp_dir().join(format!(
+            "vstack_pi_agent_explicit_delegate_deny_{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let agent = agent_fixture("rust", AgentRole::Engineer, "opus");
+        let extras = AgentExtras {
+            frontmatter_by_harness: {
+                let mut map = std::collections::HashMap::new();
+                map.insert(
+                    "pi".into(),
+                    agent::AgentFrontmatterOverrides {
+                        deny_tools: Some(vec!["delegate_subagent".into()]),
+                        ..Default::default()
+                    },
+                );
+                map
+            },
+            ..AgentExtras::default()
+        };
+        let path = generate_agent(&agent, &dir, &[], &[], &extras).expect("generate ok");
+        let content = std::fs::read_to_string(&path).unwrap();
+        let deny_line = content
+            .lines()
+            .find(|line| line.starts_with("deny-tools:"))
+            .expect("deny-tools line");
+        assert!(
+            deny_line.contains("delegate_subagent"),
+            "explicit user deny must survive the allowlist strip: {deny_line}"
+        );
+        // Engineer default allowlist still emitted so users see what the
+        // allowlist looks like, even though deny-tools makes it inert.
+        assert!(content.contains("allowed-subagents: scout"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn explicit_delegate_subagent_deny_with_dash_alias_wins() {
+        // Same as above, exercising the normalize_pi_tool_name path that
+        // collapses dashes — `delegate-subagent` from the user must be
+        // detected as the same deny token.
+        let dir = std::env::temp_dir().join(format!(
+            "vstack_pi_agent_explicit_delegate_deny_alias_{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let agent = agent_fixture("rust", AgentRole::Engineer, "opus");
+        let extras = AgentExtras {
+            frontmatter_by_harness: {
+                let mut map = std::collections::HashMap::new();
+                map.insert(
+                    "pi".into(),
+                    agent::AgentFrontmatterOverrides {
+                        deny_tools: Some(vec!["delegate-subagent".into()]),
+                        ..Default::default()
+                    },
+                );
+                map
+            },
+            ..AgentExtras::default()
+        };
+        let path = generate_agent(&agent, &dir, &[], &[], &extras).expect("generate ok");
+        let content = std::fs::read_to_string(&path).unwrap();
+        let deny_line = content
+            .lines()
+            .find(|line| line.starts_with("deny-tools:"))
+            .expect("deny-tools line");
+        assert!(deny_line.contains("delegate-subagent"), "{deny_line}");
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/cli/src/harness/pi.rs
+++ b/cli/src/harness/pi.rs
@@ -17,6 +17,7 @@ use std::path::{Path, PathBuf};
 /// name: rust
 /// description: "..."
 /// deny-tools: subagent, get_subagent_result, steer_subagent, stop_subagent, question
+/// allowed-subagents: scout
 /// model: claude-opus-4-5
 /// color: green
 /// pane: true
@@ -41,7 +42,8 @@ pub fn generate_agent(
         .unwrap_or_else(|| {
             pi_model_for_with_effort(&agent.model, pi_effort_for(agent, &frontmatter))
         });
-    let deny_tools = pi_deny_tools_for(agent, &frontmatter);
+    let allowed_subagents = pi_allowed_subagents_for(agent, &frontmatter);
+    let deny_tools = pi_deny_tools_for(agent, &frontmatter, &allowed_subagents);
 
     let mut output = String::new();
     output.push_str("---\n");
@@ -51,6 +53,12 @@ pub fn generate_agent(
     output.push_str(&format!("description: \"{}\"\n", desc));
     if !deny_tools.is_empty() {
         output.push_str(&format!("deny-tools: {}\n", deny_tools.join(", ")));
+    }
+    if !allowed_subagents.is_empty() {
+        output.push_str(&format!(
+            "allowed-subagents: {}\n",
+            allowed_subagents.join(", ")
+        ));
     }
     output.push_str(&format!("model: {}\n", model));
     if let Some(color) = frontmatter
@@ -121,21 +129,38 @@ fn is_none_value(value: &str) -> bool {
     )
 }
 
-fn pi_deny_tools_for(agent: &Agent, frontmatter: &agent::AgentFrontmatterOverrides) -> Vec<String> {
-    let mut tools = pi_default_deny_tools_for(agent);
+fn pi_deny_tools_for(
+    agent: &Agent,
+    frontmatter: &agent::AgentFrontmatterOverrides,
+    allowed_subagents: &[String],
+) -> Vec<String> {
+    let mut tools = pi_default_deny_tools_for(agent, allowed_subagents);
     if let Some(deny_tools) = &frontmatter.deny_tools {
         tools.extend(deny_tools.clone());
     }
-    dedupe_pi_tool_names(tools)
+    let mut tools = dedupe_pi_tool_names(tools);
+    if !allowed_subagents.is_empty() {
+        // The agent has an explicit allowlist, so it must see the restricted
+        // delegation tool. Strip any stale `delegate_subagent` deny so the
+        // child process actually inherits the active tool.
+        tools.retain(|tool| normalize_pi_tool_name(tool) != "delegate_subagent");
+    }
+    tools
 }
 
-fn pi_default_deny_tools_for(agent: &Agent) -> Vec<String> {
+fn pi_default_deny_tools_for(agent: &Agent, allowed_subagents: &[String]) -> Vec<String> {
     let mut tools = vec![
         "subagent".into(),
         "get_subagent_result".into(),
         "steer_subagent".into(),
         "stop_subagent".into(),
     ];
+    if allowed_subagents.is_empty() {
+        // Agents without an allowlist must not see the restricted delegation
+        // tool either; deny it at install time so the child LLM never even
+        // sees the description.
+        tools.push("delegate_subagent".into());
+    }
     if !agent.name.eq_ignore_ascii_case("planner") {
         tools.push("question".into());
     }
@@ -143,6 +168,41 @@ fn pi_default_deny_tools_for(agent: &Agent) -> Vec<String> {
         tools.push("tasks_write".into());
     }
     tools
+}
+
+/// Resolve the effective `allowed-subagents` list for an agent.
+///
+/// Order: explicit override (including empty list) wins; otherwise the
+/// engineer-role default is `["scout"]`. Non-engineer roles default to an
+/// empty list so reviewers/analysts/managers cannot delegate further.
+fn pi_allowed_subagents_for(
+    agent: &Agent,
+    frontmatter: &agent::AgentFrontmatterOverrides,
+) -> Vec<String> {
+    if let Some(list) = &frontmatter.allowed_subagents {
+        return dedupe_allowed_subagent_names(list.clone());
+    }
+    pi_default_allowed_subagents_for(agent)
+}
+
+pub(crate) fn pi_default_allowed_subagents_for(agent: &Agent) -> Vec<String> {
+    if !matches!(agent.role, AgentRole::Engineer) {
+        return Vec::new();
+    }
+    // Engineer agents get scout-style exploratory delegation by default so
+    // dev agents can shed reconnaissance work without absorbing the context
+    // hit. Other potential targets stay opt-in via vstack.toml overrides.
+    vec!["scout".into()]
+}
+
+fn dedupe_allowed_subagent_names(names: Vec<String>) -> Vec<String> {
+    let mut seen = std::collections::HashSet::new();
+    names
+        .into_iter()
+        .map(|name| name.trim().to_string())
+        .filter(|name| !name.is_empty())
+        .filter(|name| seen.insert(name.to_ascii_lowercase()))
+        .collect()
 }
 
 fn dedupe_pi_tool_names(tools: Vec<String>) -> Vec<String> {
@@ -222,9 +282,20 @@ mod tests {
         assert!(content.contains("model: openai-codex/gpt-5.5:xhigh"));
         assert!(content.contains("color: magenta"));
         assert!(!content.lines().any(|line| line.starts_with("tools:")));
+        // Engineer default: subagent-family stays denied, but delegate_subagent
+        // does NOT appear in deny-tools because the engineer ships with an
+        // allowed-subagents list (scout).
         assert!(content.contains(
             "deny-tools: subagent, get_subagent_result, steer_subagent, stop_subagent, question"
         ));
+        assert!(
+            !content
+                .lines()
+                .find(|line| line.starts_with("deny-tools:"))
+                .unwrap()
+                .contains("delegate_subagent")
+        );
+        assert!(content.contains("allowed-subagents: scout"));
         assert!(content.contains("pane: true"));
         assert!(content.contains("## Launch Instructions"));
         assert!(content.contains("Read open issues and start."));
@@ -259,6 +330,141 @@ mod tests {
         assert!(deny_line.contains("steer_subagent"));
         assert!(deny_line.contains("stop_subagent"));
         assert!(!deny_line.contains("question"));
+        // Planner is engineer-role, so it gets the default scout allowlist
+        // and delegate_subagent stays available.
+        assert!(!deny_line.contains("delegate_subagent"));
+        assert!(content.contains("allowed-subagents: scout"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn generate_engineer_default_allows_scout_delegation() {
+        let dir = std::env::temp_dir().join(format!(
+            "vstack_pi_agent_engineer_default_{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let agent = agent_fixture("generalist", AgentRole::Engineer, "sonnet");
+        let path =
+            generate_agent(&agent, &dir, &[], &[], &AgentExtras::default()).expect("generate ok");
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("allowed-subagents: scout"));
+        let deny_line = content
+            .lines()
+            .find(|line| line.starts_with("deny-tools:"))
+            .expect("deny-tools line");
+        assert!(deny_line.contains("subagent"));
+        assert!(!deny_line.contains("delegate_subagent"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn generate_engineer_with_empty_allowed_disables_delegation() {
+        let dir = std::env::temp_dir().join(format!(
+            "vstack_pi_agent_engineer_disabled_{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let agent = agent_fixture("rust", AgentRole::Engineer, "opus");
+        let extras = AgentExtras {
+            frontmatter_by_harness: {
+                let mut map = std::collections::HashMap::new();
+                map.insert(
+                    "pi".into(),
+                    agent::AgentFrontmatterOverrides {
+                        allowed_subagents: Some(vec![]),
+                        ..Default::default()
+                    },
+                );
+                map
+            },
+            ..AgentExtras::default()
+        };
+        let path = generate_agent(&agent, &dir, &[], &[], &extras).expect("generate ok");
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            !content
+                .lines()
+                .any(|line| line.starts_with("allowed-subagents:"))
+        );
+        let deny_line = content
+            .lines()
+            .find(|line| line.starts_with("deny-tools:"))
+            .expect("deny-tools line");
+        assert!(deny_line.contains("delegate_subagent"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn generate_engineer_with_custom_allowed_list_emits_comma_separated() {
+        let dir = std::env::temp_dir().join(format!(
+            "vstack_pi_agent_engineer_custom_{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let agent = agent_fixture("iced", AgentRole::Engineer, "opus");
+        let extras = AgentExtras {
+            frontmatter_by_harness: {
+                let mut map = std::collections::HashMap::new();
+                map.insert(
+                    "pi".into(),
+                    agent::AgentFrontmatterOverrides {
+                        allowed_subagents: Some(vec!["scout".into(), "researcher".into()]),
+                        ..Default::default()
+                    },
+                );
+                map
+            },
+            ..AgentExtras::default()
+        };
+        let path = generate_agent(&agent, &dir, &[], &[], &extras).expect("generate ok");
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("allowed-subagents: scout, researcher"));
+        let deny_line = content
+            .lines()
+            .find(|line| line.starts_with("deny-tools:"))
+            .expect("deny-tools line");
+        assert!(!deny_line.contains("delegate_subagent"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn generate_non_engineer_default_denies_delegation() {
+        let dir = std::env::temp_dir().join(format!(
+            "vstack_pi_agent_non_engineer_{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let agent = agent_fixture("scout", AgentRole::Analyst, "haiku");
+        let path =
+            generate_agent(&agent, &dir, &[], &[], &AgentExtras::default()).expect("generate ok");
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            !content
+                .lines()
+                .any(|line| line.starts_with("allowed-subagents:"))
+        );
+        let deny_line = content
+            .lines()
+            .find(|line| line.starts_with("deny-tools:"))
+            .expect("deny-tools line");
+        assert!(deny_line.contains("delegate_subagent"));
 
         let _ = std::fs::remove_dir_all(&dir);
     }
@@ -328,9 +534,12 @@ mod tests {
         let path = generate_agent(&agent, &dir, &[], &[], &extras).expect("generate ok");
         let content = std::fs::read_to_string(&path).unwrap();
         assert!(!content.lines().any(|line| line.starts_with("tools:")));
+        // Engineer keeps the default scout allowlist, so delegate_subagent is
+        // not denied alongside the orchestration tools.
         assert!(content.contains(
             "deny-tools: subagent, get_subagent_result, steer_subagent, stop_subagent, question, bash, apply-patch"
         ));
+        assert!(content.contains("allowed-subagents: scout"));
 
         let _ = std::fs::remove_dir_all(&dir);
     }
@@ -350,11 +559,35 @@ mod tests {
         let content = std::fs::read_to_string(&path).unwrap();
         assert!(content.contains("model: openai-codex/gpt-5.5:high"));
         assert!(!content.lines().any(|line| line.starts_with("tools:")));
+        // Reviewer role keeps the empty allowlist default, so
+        // delegate_subagent is denied and not exposed at all.
         assert!(content.contains(
-            "deny-tools: subagent, get_subagent_result, steer_subagent, stop_subagent, question, tasks_write"
+            "deny-tools: subagent, get_subagent_result, steer_subagent, stop_subagent, delegate_subagent, question, tasks_write"
         ));
+        assert!(
+            !content
+                .lines()
+                .any(|line| line.starts_with("allowed-subagents:"))
+        );
         assert!(!content.contains("pane: true"));
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn pi_default_allowed_subagents_engineer_is_scout() {
+        let agent = agent_fixture("rust", AgentRole::Engineer, "opus");
+        assert_eq!(
+            pi_default_allowed_subagents_for(&agent),
+            vec!["scout".to_string()]
+        );
+    }
+
+    #[test]
+    fn pi_default_allowed_subagents_non_engineer_is_empty() {
+        for role in [AgentRole::Analyst, AgentRole::Reviewer, AgentRole::Manager] {
+            let agent = agent_fixture("any", role, "sonnet");
+            assert!(pi_default_allowed_subagents_for(&agent).is_empty());
+        }
     }
 }

--- a/cli/src/mapping.rs
+++ b/cli/src/mapping.rs
@@ -324,9 +324,10 @@ mod tests {
         let mut config = MappingConfig::default();
         // Agent "rust" has explicit entry — prefix matching should NOT run.
         // Only the listed skills (plus role-skills) should be attached.
-        config
-            .agent_skills
-            .insert("rust".into(), vec!["rust-tooling".into(), "rust-runtime".into()]);
+        config.agent_skills.insert(
+            "rust".into(),
+            vec!["rust-tooling".into(), "rust-runtime".into()],
+        );
         let available = vec![
             "rust-tooling".into(),
             "rust-runtime".into(),

--- a/cli/src/project_config.rs
+++ b/cli/src/project_config.rs
@@ -100,6 +100,10 @@ fn is_agent_frontmatter_override(value: &toml::Value) -> bool {
         "color",
         "model",
         "deny-tools",
+        "allowed-subagents",
+        "allowedSubagents",
+        "subagent-agents",
+        "subagent_agents",
         "tools",
         "pane",
         "background",
@@ -582,6 +586,7 @@ fn render_inline_table_fields(fields: &[(String, String)]) -> String {
         "model",
         "effort",
         "deny-tools",
+        "allowed-subagents",
         "pane",
         "background",
         "isolation",
@@ -1105,6 +1110,7 @@ fn pi_frontmatter_defaults(
     agent: &crate::agent::Agent,
     frontmatter: &crate::agent::AgentFrontmatterOverrides,
 ) -> Vec<(String, String)> {
+    let allowed_subagents = pi_default_allowed_subagents_with_override(agent, frontmatter);
     let mut fields = Vec::new();
     push_color_field(&mut fields, agent, frontmatter, false);
     fields.push((
@@ -1113,10 +1119,28 @@ fn pi_frontmatter_defaults(
     ));
     fields.push((
         "deny-tools".into(),
-        toml_inline_array(&pi_default_deny_tools(agent)),
+        toml_inline_array(&pi_default_deny_tools(agent, &allowed_subagents)),
+    ));
+    fields.push((
+        "allowed-subagents".into(),
+        toml_inline_array(&allowed_subagents),
     ));
     fields.push(("pane".into(), default_pi_pane(agent).to_string()));
     fields
+}
+
+fn pi_default_allowed_subagents_with_override(
+    agent: &crate::agent::Agent,
+    frontmatter: &crate::agent::AgentFrontmatterOverrides,
+) -> Vec<String> {
+    if let Some(list) = &frontmatter.allowed_subagents {
+        return list
+            .iter()
+            .map(|name| name.trim().to_string())
+            .filter(|name| !name.is_empty())
+            .collect();
+    }
+    crate::harness::pi::pi_default_allowed_subagents_for(agent)
 }
 
 fn pi_extra_default_deny_tools() -> Vec<String> {
@@ -1184,13 +1208,16 @@ fn opencode_default_deny_tools(agent: &crate::agent::Agent) -> Vec<String> {
     tools
 }
 
-fn pi_default_deny_tools(agent: &crate::agent::Agent) -> Vec<String> {
+fn pi_default_deny_tools(agent: &crate::agent::Agent, allowed_subagents: &[String]) -> Vec<String> {
     let mut tools = vec![
         "subagent".into(),
         "get_subagent_result".into(),
         "steer_subagent".into(),
         "stop_subagent".into(),
     ];
+    if allowed_subagents.is_empty() {
+        tools.push("delegate_subagent".into());
+    }
     if !agent.name.eq_ignore_ascii_case("planner") {
         tools.push("question".into());
     }
@@ -1896,9 +1923,11 @@ fn agent_frontmatter_heading() -> String {
     out.push_str("# vstack writes active defaults here for every installed agent.\n");
     out.push_str("# Edit fields, then run `vstack refresh` to regenerate harness files.\n");
     out.push_str("# Harness-specific entries apply only to that harness.\n");
-    out.push_str("# Fields: color, model, effort, deny-tools, pane, background,\n");
-    out.push_str("# isolation, memory, mode, sandbox-mode, model-reasoning-effort.\n");
+    out.push_str("# Fields: color, model, effort, deny-tools, allowed-subagents,\n");
+    out.push_str("# pane, background, isolation, memory, mode, sandbox-mode,\n");
+    out.push_str("# model-reasoning-effort.\n");
     out.push_str("# Claude background is seeded from Pi pane on first install (pane=true -> false, pane=false -> true), then preserved on refresh.\n");
+    out.push_str("# Pi allowed-subagents is the restricted delegation allowlist for delegate_subagent (engineer default ['scout']; set [] to disable).\n");
     out.push_str(
         "# OpenCode maps colors to hex. Effort values are written verbatim per harness.\n",
     );
@@ -2669,6 +2698,202 @@ planner = { background = true }
         assert!(
             planner_line.contains("background = true"),
             "planner background should stay true: {planner_line}"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn write_agent_frontmatter_defaults_pi_engineer_seeds_allowed_subagents_scout() {
+        let dir = std::env::temp_dir().join(format!(
+            "vstack_test_agent_frontmatter_pi_allowed_engineer_{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("vstack.toml");
+        std::fs::write(&path, "[agent-frontmatter.pi]\n").unwrap();
+
+        let rust = crate::agent::Agent {
+            name: "rust".into(),
+            description: "Rust agent".into(),
+            model: "opus".into(),
+            role: crate::agent::AgentRole::Engineer,
+            color: None,
+            effort: Some("xhigh".into()),
+            body: String::new(),
+            source_path: std::path::PathBuf::new(),
+        };
+        let mut harnesses = HashMap::new();
+        harnesses.insert("rust".into(), vec![crate::harness::Harness::Pi]);
+
+        write_agent_frontmatter_defaults(
+            &dir,
+            &[rust],
+            &harnesses,
+            &crate::mapping::MappingConfig::default(),
+        );
+
+        let updated = std::fs::read_to_string(&path).unwrap();
+        let rust_line = updated
+            .lines()
+            .find(|line| line.starts_with("rust =") && line.contains("allowed-subagents"))
+            .expect("rust pi frontmatter line missing allowed-subagents");
+        assert!(
+            rust_line.contains("allowed-subagents = [\"scout\"]"),
+            "{rust_line}"
+        );
+        assert!(
+            !rust_line.contains("delegate_subagent"),
+            "engineer with allowed-subagents must not deny delegate_subagent: {rust_line}"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn write_agent_frontmatter_defaults_pi_engineer_explicit_empty_disables_default() {
+        let dir = std::env::temp_dir().join(format!(
+            "vstack_test_agent_frontmatter_pi_allowed_empty_{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("vstack.toml");
+        // User explicitly opts out by setting allowed-subagents = [].
+        std::fs::write(
+            &path,
+            "[agent-frontmatter.pi]\nrust = { allowed-subagents = [] }\n",
+        )
+        .unwrap();
+
+        let rust = crate::agent::Agent {
+            name: "rust".into(),
+            description: "Rust agent".into(),
+            model: "opus".into(),
+            role: crate::agent::AgentRole::Engineer,
+            color: None,
+            effort: Some("xhigh".into()),
+            body: String::new(),
+            source_path: std::path::PathBuf::new(),
+        };
+        let mut harnesses = HashMap::new();
+        harnesses.insert("rust".into(), vec![crate::harness::Harness::Pi]);
+
+        write_agent_frontmatter_defaults(
+            &dir,
+            &[rust],
+            &harnesses,
+            &crate::mapping::MappingConfig::default(),
+        );
+
+        let updated = std::fs::read_to_string(&path).unwrap();
+        let rust_line = updated
+            .lines()
+            .find(|line| line.starts_with("rust =") && line.contains("allowed-subagents"))
+            .expect("rust pi frontmatter line");
+        // User's empty list is preserved.
+        assert!(rust_line.contains("allowed-subagents = []"), "{rust_line}");
+        // And the seeded deny-tools must include delegate_subagent so the
+        // engineer with explicit empty allowlist cannot delegate.
+        assert!(
+            rust_line.contains("delegate_subagent"),
+            "engineer with empty allowed list must deny delegate_subagent: {rust_line}"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn write_agent_frontmatter_defaults_pi_analyst_skips_allowed_subagents() {
+        let dir = std::env::temp_dir().join(format!(
+            "vstack_test_agent_frontmatter_pi_allowed_analyst_{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("vstack.toml");
+        std::fs::write(&path, "[agent-frontmatter.pi]\n").unwrap();
+
+        let scout = crate::agent::Agent {
+            name: "scout".into(),
+            description: "Scout agent".into(),
+            model: "haiku".into(),
+            role: crate::agent::AgentRole::Analyst,
+            color: None,
+            effort: Some("medium".into()),
+            body: String::new(),
+            source_path: std::path::PathBuf::new(),
+        };
+        let mut harnesses = HashMap::new();
+        harnesses.insert("scout".into(), vec![crate::harness::Harness::Pi]);
+
+        write_agent_frontmatter_defaults(
+            &dir,
+            &[scout],
+            &harnesses,
+            &crate::mapping::MappingConfig::default(),
+        );
+
+        let updated = std::fs::read_to_string(&path).unwrap();
+        let scout_line = updated
+            .lines()
+            .find(|line| line.starts_with("scout ="))
+            .expect("scout pi frontmatter line");
+        // Analyst gets allowed-subagents = [] (engineer-only default), and
+        // delegate_subagent shows up in deny-tools.
+        assert!(
+            scout_line.contains("allowed-subagents = []"),
+            "scout should record empty allowed-subagents: {scout_line}"
+        );
+        assert!(
+            scout_line.contains("delegate_subagent"),
+            "non-engineer must deny delegate_subagent: {scout_line}"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn project_config_parses_allowed_subagents_aliases() {
+        let dir = std::env::temp_dir().join(format!(
+            "vstack_test_agent_frontmatter_allowed_aliases_{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("vstack.toml"),
+            r#"
+[agent-frontmatter.pi]
+rust = { allowed-subagents = ["scout", "researcher"] }
+iced = { allowedSubagents = ["scout"] }
+generalist = { subagent-agents = ["scout"] }
+tpm = { subagent_agents = ["scout"] }
+"#,
+        )
+        .unwrap();
+
+        let config = ProjectConfig::load(&dir);
+        let rust_pi = config.frontmatter_for("rust", "pi");
+        assert_eq!(
+            rust_pi.allowed_subagents.as_deref(),
+            Some(&["scout".to_string(), "researcher".to_string()][..])
+        );
+        let iced_pi = config.frontmatter_for("iced", "pi");
+        assert_eq!(
+            iced_pi.allowed_subagents.as_deref(),
+            Some(&["scout".to_string()][..])
+        );
+        let generalist_pi = config.frontmatter_for("generalist", "pi");
+        assert_eq!(
+            generalist_pi.allowed_subagents.as_deref(),
+            Some(&["scout".to_string()][..])
+        );
+        let tpm_pi = config.frontmatter_for("tpm", "pi");
+        assert_eq!(
+            tpm_pi.allowed_subagents.as_deref(),
+            Some(&["scout".to_string()][..])
         );
 
         let _ = std::fs::remove_dir_all(&dir);

--- a/cli/src/project_config.rs
+++ b/cli/src/project_config.rs
@@ -2467,10 +2467,8 @@ mod tests {
         // header inline; after `repair_project_config_structure` runs (which
         // calls `normalize_attached_section_headers`), the file must still
         // parse as valid TOML and `[agent-skills]` entries must survive.
-        let dir = std::env::temp_dir().join(format!(
-            "vstack_norm_comment_header_{}",
-            std::process::id()
-        ));
+        let dir =
+            std::env::temp_dir().join(format!("vstack_norm_comment_header_{}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
         let path = dir.join("vstack.toml");
         let content = concat!(

--- a/cli/src/tui/install_flow.rs
+++ b/cli/src/tui/install_flow.rs
@@ -1847,10 +1847,7 @@ where
 
 /// Apply a finished worker's outcome on the main thread. Owns every
 /// mutation that touches TUI state, the terminal, or process lifetime.
-fn apply_post_work(
-    state: &mut FlowState<'_>,
-    post: PostWork,
-) -> Result<Option<InstallFlowResult>> {
+fn apply_post_work(state: &mut FlowState<'_>, post: PostWork) -> Result<Option<InstallFlowResult>> {
     match post {
         PostWork::Done(flash) => {
             rebuild_tabs(state);
@@ -2090,13 +2087,7 @@ fn perform_move_plans(items: &DiscoveredItems, plans: &[MovePlan], to_global: bo
                 );
                 for harness in &target_harnesses {
                     if harness
-                        .generate_agent(
-                            agent,
-                            to_global,
-                            &skill_pairs,
-                            &matched_hooks,
-                            &extras,
-                        )
+                        .generate_agent(agent, to_global, &skill_pairs, &matched_hooks, &extras)
                         .is_ok()
                     {
                         succeeded.push(*harness);

--- a/cli/src/tui/render.rs
+++ b/cli/src/tui/render.rs
@@ -1753,12 +1753,12 @@ fn draw_confirm_dialog(frame: &mut Frame, select: &mut TabbedSelect, d: &Confirm
 // ── Help overlay ──────────────────────────────────────────
 
 /// Braille-dot spinner frames; ~10 fps when advanced every 80–100ms.
-const SPINNER_FRAMES: &[&str] = &[
-    "⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏",
-];
+const SPINNER_FRAMES: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
 fn draw_progress_overlay(frame: &mut Frame, select: &mut TabbedSelect) {
-    let Some(progress) = select.progress.as_ref() else { return };
+    let Some(progress) = select.progress.as_ref() else {
+        return;
+    };
     let elapsed = progress.started.elapsed();
     let frame_idx = (elapsed.as_millis() / 100) as usize % SPINNER_FRAMES.len();
     let spinner = SPINNER_FRAMES[frame_idx];
@@ -1774,7 +1774,10 @@ fn draw_progress_overlay(frame: &mut Frame, select: &mut TabbedSelect) {
     let (inner, _outer) = draw_dialog_chrome(frame, "Working", theme::ACCENT, 3, dialog_w);
 
     let line = Line::from(vec![
-        Span::styled(format!("{spinner} "), Style::default().fg(theme::ACCENT).bold()),
+        Span::styled(
+            format!("{spinner} "),
+            Style::default().fg(theme::ACCENT).bold(),
+        ),
         Span::styled(label, Style::default().fg(theme::TEXT_PRIMARY).bold()),
         Span::styled(
             format!("  ({elapsed_label})"),
@@ -1786,8 +1789,7 @@ fn draw_progress_overlay(frame: &mut Frame, select: &mut TabbedSelect) {
         Style::default().fg(theme::TEXT_MUTED).italic(),
     ));
     frame.render_widget(
-        Paragraph::new(vec![line, Line::from(""), hint])
-            .style(Style::default().bg(Color::Reset)),
+        Paragraph::new(vec![line, Line::from(""), hint]).style(Style::default().bg(Color::Reset)),
         inner,
     );
 }
@@ -2623,10 +2625,7 @@ mod tests {
 
     #[test]
     fn progress_overlay_renders_label_and_spinner_frame() {
-        let mut select = TabbedSelect::new(
-            "x",
-            vec![source_tab("Agents", vec![item("a", "")])],
-        );
+        let mut select = TabbedSelect::new("x", vec![source_tab("Agents", vec![item("a", "")])]);
         select.progress = Some(crate::tui::multiselect::ProgressOverlay {
             label: "Updating 3 item(s)…".into(),
             started: std::time::Instant::now(),

--- a/hooks/pre-commit-check.sh
+++ b/hooks/pre-commit-check.sh
@@ -26,16 +26,18 @@ fi
 # Check for Rust files
 if echo "$STAGED" | grep -qE '\.rs$'; then
   # Locate Cargo.toml so the hook works in repos that nest the manifest
-  # (vstack's own `cli/Cargo.toml` is the canonical example). Earlier
-  # versions ran `cargo fmt --check` from the repo root unconditionally
-  # and misreported "could not find Cargo.toml" as a fmt failure.
+  # (vstack's own `cli/Cargo.toml` is the canonical example) and when
+  # the hook is invoked from a subdirectory. Earlier versions ran
+  # `cargo fmt --check` from cwd unconditionally and misreported "could
+  # not find Cargo.toml" as a fmt failure.
   MANIFEST_ARGS=()
-  if [ ! -f Cargo.toml ]; then
+  REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || true)
+  if [ -n "$REPO_ROOT" ] && [ ! -f "$REPO_ROOT/Cargo.toml" ]; then
     MANIFEST=$(echo "$STAGED" | grep -E '\.rs$' | while IFS= read -r path; do
       dir=$(dirname "$path")
       while [ -n "$dir" ] && [ "$dir" != "." ] && [ "$dir" != "/" ]; do
-        if [ -f "$dir/Cargo.toml" ]; then
-          echo "$dir/Cargo.toml"
+        if [ -f "$REPO_ROOT/$dir/Cargo.toml" ]; then
+          echo "$REPO_ROOT/$dir/Cargo.toml"
           break
         fi
         dir=$(dirname "$dir")

--- a/hooks/pre-commit-check.sh
+++ b/hooks/pre-commit-check.sh
@@ -25,14 +25,35 @@ fi
 
 # Check for Rust files
 if echo "$STAGED" | grep -qE '\.rs$'; then
+  # Locate Cargo.toml so the hook works in repos that nest the manifest
+  # (vstack's own `cli/Cargo.toml` is the canonical example). Earlier
+  # versions ran `cargo fmt --check` from the repo root unconditionally
+  # and misreported "could not find Cargo.toml" as a fmt failure.
+  MANIFEST_ARGS=()
+  if [ ! -f Cargo.toml ]; then
+    MANIFEST=$(echo "$STAGED" | grep -E '\.rs$' | while IFS= read -r path; do
+      dir=$(dirname "$path")
+      while [ -n "$dir" ] && [ "$dir" != "." ] && [ "$dir" != "/" ]; do
+        if [ -f "$dir/Cargo.toml" ]; then
+          echo "$dir/Cargo.toml"
+          break
+        fi
+        dir=$(dirname "$dir")
+      done
+    done | head -1)
+    if [ -n "$MANIFEST" ]; then
+      MANIFEST_ARGS=(--manifest-path "$MANIFEST")
+    fi
+  fi
+
   # Format check
-  if ! cargo fmt --check 2>/dev/null; then
+  if ! cargo fmt "${MANIFEST_ARGS[@]}" --check 2>/dev/null; then
     echo "cargo fmt --check failed. Run 'cargo fmt' first." >&2
     exit 2
   fi
 
   # Clippy check
-  if ! cargo clippy --workspace --all-targets -- -D warnings 2>/dev/null; then
+  if ! cargo clippy "${MANIFEST_ARGS[@]}" --workspace --all-targets -- -D warnings 2>/dev/null; then
     echo "cargo clippy found warnings. Fix them before committing." >&2
     exit 2
   fi

--- a/hooks/task-completed-check.sh
+++ b/hooks/task-completed-check.sh
@@ -25,7 +25,30 @@ fi
 
 # Check for Rust files
 if echo "$ALL_CHANGED" | grep -qE '\.rs$'; then
-  OUTPUT=$(cargo clippy --workspace --all-targets -- -D warnings 2>&1 || true)
+  # Locate Cargo.toml so the hook works when the manifest is nested
+  # (vstack's own `cli/Cargo.toml` is the canonical case) and when the
+  # hook is invoked from a subdirectory. Earlier versions ran `cargo
+  # clippy` from cwd unconditionally and surfaced "could not find
+  # Cargo.toml" as a clippy error.
+  MANIFEST_ARGS=()
+  REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || true)
+  if [ -n "$REPO_ROOT" ] && [ ! -f "$REPO_ROOT/Cargo.toml" ]; then
+    MANIFEST=$(echo "$ALL_CHANGED" | grep -E '\.rs$' | while IFS= read -r path; do
+      dir=$(dirname "$path")
+      while [ -n "$dir" ] && [ "$dir" != "." ] && [ "$dir" != "/" ]; do
+        if [ -f "$REPO_ROOT/$dir/Cargo.toml" ]; then
+          echo "$REPO_ROOT/$dir/Cargo.toml"
+          break
+        fi
+        dir=$(dirname "$dir")
+      done
+    done | head -1)
+    if [ -n "$MANIFEST" ]; then
+      MANIFEST_ARGS=(--manifest-path "$MANIFEST")
+    fi
+  fi
+
+  OUTPUT=$(cargo clippy "${MANIFEST_ARGS[@]}" --workspace --all-targets -- -D warnings 2>&1 || true)
   # grep no-match exits 1 — swallow under pipefail so an empty result is success.
   ISSUES=$(echo "$OUTPUT" | grep -E '^error' | head -15 || true)
 

--- a/pi-extensions/pi-agents-tmux/AGENTS.md
+++ b/pi-extensions/pi-agents-tmux/AGENTS.md
@@ -3,3 +3,4 @@
 - Activity broker publication lives in `extensions/subagent/activity.ts` and uses `globalThis[Symbol.for("vstack.pi.activity")]` when `pi-session-bridge` is loaded.
 - Keep broker emission fail-open: subagent dispatch, steering, completion, and result retrieval must not depend on activity publish success.
 - Lifecycle mapping is `subagents:*` → `agent.*`; update README and DEVELOPMENT.md when adding or renaming activity event types.
+- `delegate_subagent` (issue #228) is intentionally narrow: single-mode only, authorized via `PI_SUBAGENT_CHILD_AGENT`, allowlist comes from the caller agent's `allowed-subagents:` frontmatter, pane targets rejected. Do not silently grow its schema or short-circuit the allowlist — that defeats the dev-agent-without-orchestration design. Bg one-shot runner exports `PI_SUBAGENT_CHILD_AGENT` (and `PI_SUBAGENT_CHILD_COLOR`) for authorization; keep bridge env vars pane-only unless tested against `pi-session-bridge`.

--- a/pi-extensions/pi-agents-tmux/DEVELOPMENT.md
+++ b/pi-extensions/pi-agents-tmux/DEVELOPMENT.md
@@ -73,9 +73,11 @@ Parallel dispatch runs through a flat worker pool capped by `maxConcurrency` (de
 `delegate_subagent` is a single-mode wrapper around the same dispatch helpers `subagent` uses (`runSingleDispatch` → `runSingleAgent`). Differences from `subagent`:
 
 ```json
-// Only shape accepted.
-{ "agent": "scout", "task": "Map the cwd-snapshot module." }
+// Only shape accepted. `cwd` is the sole optional field.
+{ "agent": "scout", "task": "Map the cwd-snapshot module.", "cwd": "/optional/working/dir" }
 ```
+
+`cwd` defaults to the caller's cwd when omitted; when present it is threaded to `runSingleDispatch` as `cwdOverride`, identical to the single-mode path of full `subagent`.
 
 - **Authorization.** `PI_SUBAGENT_CHILD_AGENT` must be set in the calling Pi process. Pane launchers already export it; the bg one-shot runner exports it for issue #228. Without it the tool refuses immediately. The caller agent's discovered `AgentConfig.allowedSubagents` (parsed from `allowed-subagents:` frontmatter and aliases `allowedSubagents` / `subagent-agents` / `subagent_agents`) is the canonical allowlist. Unlisted targets, undiscovered targets, and pane targets are all rejected before launch.
 - **No orchestration knobs.** No `tasks`, `chain`, `agentScope`, `sessionKey`, `forceSpawn`, `resumeSession`, or `confirmProjectAgents`. The schema literally does not expose them; the resolver defaults `agentScope` to `"project"` and `sessionKey`/`forceSpawn`/`resumeSession` to undefined.

--- a/pi-extensions/pi-agents-tmux/DEVELOPMENT.md
+++ b/pi-extensions/pi-agents-tmux/DEVELOPMENT.md
@@ -68,6 +68,23 @@ Live pane reuse runs a Linux cwd preflight before returning an existing pane or 
 
 Parallel dispatch runs through a flat worker pool capped by `maxConcurrency` (default 4); the whole task array shares one queue. The earlier `maxParallelTasks` setting is a deprecated no-op kept for setting-file compatibility.
 
+## Restricted delegation (`delegate_subagent`) — issue #228
+
+`delegate_subagent` is a single-mode wrapper around the same dispatch helpers `subagent` uses (`runSingleDispatch` → `runSingleAgent`). Differences from `subagent`:
+
+```json
+// Only shape accepted.
+{ "agent": "scout", "task": "Map the cwd-snapshot module." }
+```
+
+- **Authorization.** `PI_SUBAGENT_CHILD_AGENT` must be set in the calling Pi process. Pane launchers already export it; the bg one-shot runner exports it for issue #228. Without it the tool refuses immediately. The caller agent's discovered `AgentConfig.allowedSubagents` (parsed from `allowed-subagents:` frontmatter and aliases `allowedSubagents` / `subagent-agents` / `subagent_agents`) is the canonical allowlist. Unlisted targets, undiscovered targets, and pane targets are all rejected before launch.
+- **No orchestration knobs.** No `tasks`, `chain`, `agentScope`, `sessionKey`, `forceSpawn`, `resumeSession`, or `confirmProjectAgents`. The schema literally does not expose them; the resolver defaults `agentScope` to `"project"` and `sessionKey`/`forceSpawn`/`resumeSession` to undefined.
+- **Tool inheritance.** Child tools start from the parent active tools then drop the target agent's `deny-tools`. vstack-generated reviewer/analyst/manager agents already deny `delegate_subagent` so a chain like `rust → scout → researcher` is impossible by default — scout's `allowed-subagents` is empty, and `delegate_subagent` is in scout's `deny-tools`. Both layers fail closed.
+- **Bg-only.** Pane targets reject with a clear error; engineer-style delegation is intentionally disposable.
+- **System prompt.** When the only active subagent surface is `delegate_subagent`, `before_agent_start` emits a short "Restricted Subagent Delegation" section listing the caller's allowlist (with model / pane warning) instead of the full Project Agents list. When `subagent` is also active (parent orchestrator), the full list is emitted unchanged.
+
+vstack CLI defaults: engineer-role agents emit `allowed-subagents: scout` and omit `delegate_subagent` from `deny-tools`. Analyst/reviewer/manager agents omit `allowed-subagents` and add `delegate_subagent` to `deny-tools` so the child LLM never sees it. An explicit `allowed-subagents = []` in `vstack.toml` overrides the engineer default and re-denies the tool.
+
 ## One-shot transcript capture
 
 Bg one-shot agents run Pi in JSON stream mode and write a sidecar transcript under `transcripts/<agent>/<taskId>.jsonl`. The writer records `start`, `exit`, `message_start`, `message_end`, tool execution events, stderr, parse errors, and diagnostics. It drops successful `message_update` events by default because those events are full message-so-far snapshots and duplicate the final `message_end` content. If the process exits nonzero or emits a process error after an unfinalized update, the latest filtered update is flushed as a `buffered: true` diagnostic record. Set `PI_AGENTS_TMUX_TRANSCRIPT_FULL=1` in the parent environment before launching Pi to keep the full stream for debugging.

--- a/pi-extensions/pi-agents-tmux/README.md
+++ b/pi-extensions/pi-agents-tmux/README.md
@@ -7,6 +7,7 @@ Delegate work to specialized agents from a running Pi session. Agents run either
 ## Highlights
 
 - `subagent` tool delegates one task, parallel tasks, or sequential chains.
+- `delegate_subagent` is a restricted, single-mode variant child agents can call without gaining full orchestration controls. Engineer agents installed by vstack default to `allowed-subagents: scout` so they can dispatch read-only reconnaissance into a fresh bg lane.
 - Agents with `pane: true` open a visible tmux pane that persists across turns. Other agents run in the background.
 - `/agents` browser lists agents for the selected scope with static detail, Monitor task traces, and one-key launch.
 - Monitor groups tasks by session (pane, bg lane, bg one-shot) under expandable Active and Completed sections; repeated same-agent launches get session numbers and task numbers reset per session.
@@ -87,6 +88,7 @@ Frontmatter fields:
 | `name` | yes | Unique agent name. |
 | `description` | yes | Short description shown in `/agents` and completions. |
 | `deny-tools` | no | Comma-separated Pi tools to deny. Future parent tools are inherited unless explicitly denied. |
+| `allowed-subagents` | no | Comma-separated or array of agent names this agent may call via `delegate_subagent`. Engineer agents installed by vstack default to `scout`. Set `[]` to disable delegation. Aliases: `allowedSubagents`, `subagent-agents`, `subagent_agents`. |
 | `model` | no | Pi model id; shorthands: `sonnet`, `opus*`, `haiku`. Other ids pass through. |
 | `pane` | no | `true` for a visible persistent pane; omit for bg. |
 | `color` | no | Pane badge color: `red`, `green`, `yellow`, `blue`, `magenta`, `cyan`. Aliases: `orange`, `purple`/`violet`, `teal`. |
@@ -95,7 +97,35 @@ Everything after the frontmatter is the agent's system prompt.
 
 Pane tasks move through queued → running → completed | blocked | failed. On Linux, before reusing a live pane, `subagent` verifies the pane process cwd is still present and matches the requested task `cwd`; stale or mismatched panes return a structured `pane-cwd-stale` error, publish `agent.pane_cwd_stale`, and should be recovered with `stop_subagent` plus a retry using `forceSpawn: true`. Stop kills the tmux process; the session file is preserved so the next launch resumes memory.
 
-See [`DEVELOPMENT.md`](./DEVELOPMENT.md) for the underlying tool surface (`subagent`, `get_subagent_result`, `steer_subagent`, `stop_subagent`, `wait_for_subagent_idle`) and activity broker mapping.
+See [`DEVELOPMENT.md`](./DEVELOPMENT.md) for the underlying tool surface (`subagent`, `delegate_subagent`, `get_subagent_result`, `steer_subagent`, `stop_subagent`, `wait_for_subagent_idle`) and activity broker mapping.
+
+## Restricted delegation (`delegate_subagent`)
+
+vstack-installed engineer agents default to denying `subagent` so they cannot orchestrate fleets, but they still need to spend a fresh context window on reconnaissance work. `delegate_subagent` is the bridge:
+
+- Only visible to child Pi processes whose `PI_SUBAGENT_CHILD_AGENT` is set (panes export this automatically; the bg one-shot runner sets it for issue #228).
+- Only the targets listed in the caller agent's `allowed-subagents:` frontmatter are accepted; missing or unlisted targets fail with an inventory error.
+- Single-dispatch only — no `tasks`, `chain`, `agentScope`, `sessionKey`, `forceSpawn`, or `resumeSession` exposure.
+- Targets with `pane: true` are rejected — restricted delegation is bg-only.
+- The child receives its own append-system prompt, skills, and a fresh one-shot session; parent conversation is not shared.
+
+vstack defaults for `allowed-subagents`:
+
+| Role | Default |
+| --- | --- |
+| `engineer` | `scout` |
+| `analyst` / `reviewer` / `manager` | empty (delegation denied) |
+
+Customize per agent in `vstack.toml`:
+
+```toml
+[agent-frontmatter.pi]
+rust = { allowed-subagents = ["scout"] }
+iced = { allowed-subagents = ["scout", "researcher"] }
+generalist = { allowed-subagents = [] }   # disable delegation entirely
+```
+
+An explicit empty list overrides the engineer default; the matching agent file is regenerated without `allowed-subagents:` and gains `delegate_subagent` back in `deny-tools` so the child never sees the tool.
 
 ## Settings
 

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/agents.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/agents.ts
@@ -21,6 +21,12 @@ export interface AgentConfig {
 	description: string;
 	color?: string;
 	denyTools?: string[];
+	/**
+	 * Allowlist for the restricted delegation tool. When non-empty the agent
+	 * can call `delegate_subagent` targeting any of the listed agents; when
+	 * empty/undefined the tool refuses and is denied at install time.
+	 */
+	allowedSubagents?: string[];
 	model?: string;
 	effort?: string;
 	pane: boolean;
@@ -55,6 +61,36 @@ function parseToolList(value: unknown): string[] | undefined {
 			.map((tool) => (typeof tool === "string" ? tool.trim() : ""))
 			.filter(Boolean);
 		return tools.length > 0 ? tools : undefined;
+	}
+	return undefined;
+}
+
+/**
+ * Parse the `allowed-subagents` frontmatter (and its aliases) into a
+ * normalized array. Unlike `parseToolList`, an explicit empty list is
+ * preserved as `[]` so callers can distinguish "user disabled delegation"
+ * from "user did not set this field". Returns undefined only when no key
+ * was present at all.
+ */
+function parseAllowedSubagents(frontmatter: Record<string, unknown>): string[] | undefined {
+	const keys = ["allowed-subagents", "allowedSubagents", "subagent-agents", "subagent_agents"];
+	for (const key of keys) {
+		if (!(key in frontmatter)) continue;
+		const value = frontmatter[key];
+		if (typeof value === "string") {
+			const names = value
+				.split(",")
+				.map((name) => name.trim())
+				.filter(Boolean);
+			return names;
+		}
+		if (Array.isArray(value)) {
+			const names = value
+				.map((name) => (typeof name === "string" ? name.trim() : ""))
+				.filter(Boolean);
+			return names;
+		}
+		return [];
 	}
 	return undefined;
 }
@@ -112,6 +148,7 @@ function loadAgentsFromDir(dir: string, source: "user" | "project"): AgentConfig
 			description,
 			color: asString(frontmatter.color),
 			denyTools: parseToolList(frontmatter["deny-tools"] ?? frontmatter.denyTools ?? frontmatter.disallowedTools),
+			allowedSubagents: parseAllowedSubagents(frontmatter),
 			model,
 			// Reasoning effort lives under different keys depending on harness
 			// (Claude `effort`, OpenCode/Codex `model-reasoning-effort`). Both

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/index.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/index.ts
@@ -186,6 +186,7 @@ import {
 } from "./tasks.js";
 import {
 	CompleteSubagentParams,
+	DelegateSubagentParams,
 	GetSubagentResultParams,
 	SteerSubagentParams,
 	StopSubagentParams,
@@ -1614,23 +1615,187 @@ export default function (pi: ExtensionAPI) {
 	});
 
 	pi.on("before_agent_start", (event, ctx) => {
-		if (!pi.getActiveTools().includes("subagent")) return;
+		const activeTools = pi.getActiveTools();
+		const hasSubagent = activeTools.includes("subagent");
+		const hasDelegate = activeTools.includes("delegate_subagent");
+		if (!hasSubagent && !hasDelegate) return;
 
 		const discovery = discoverAgents(ctx.cwd, "project");
 		if (discovery.agents.length === 0) return;
 
-		const agentLines = discovery.agents
-			.map((agent) => {
-				const model = agent.model ? ` model=${agent.model}` : "";
-				const denyTools = agent.denyTools && agent.denyTools.length > 0 ? ` deny-tools=${agent.denyTools.join(",")}` : "";
-				const pane = agent.pane ? " pane=true" : "";
-				return `- ${agent.name}: ${agent.description} (${agent.source}${model}${denyTools}${pane})`;
+		// Full orchestrator tool: emit the complete project agent list so the
+		// orchestrator can pick targets directly.
+		if (hasSubagent) {
+			const agentLines = discovery.agents
+				.map((agent) => {
+					const model = agent.model ? ` model=${agent.model}` : "";
+					const denyTools = agent.denyTools && agent.denyTools.length > 0 ? ` deny-tools=${agent.denyTools.join(",")}` : "";
+					const pane = agent.pane ? " pane=true" : "";
+					return `- ${agent.name}: ${agent.description} (${agent.source}${model}${denyTools}${pane})`;
+				})
+				.join("\n");
+
+			return {
+				systemPrompt: `${event.systemPrompt}\n\n## Project Agents\nProject-local agents available to \`subagent\` (default \`agentScope: "project"\`; pass \`"both"\` only for user-level agents at \`~/.pi/agent/agents\`):\n${agentLines}`,
+			};
+		}
+
+		// Restricted delegation only: emit a compact list of the caller's
+		// allowed targets. Falls back to a hint when the caller identity is
+		// missing (parent session without PI_SUBAGENT_CHILD_AGENT).
+		const callerName = childAgentName?.trim();
+		if (!callerName) {
+			return {
+				systemPrompt: `${event.systemPrompt}\n\n## Restricted Subagent Delegation\n\`delegate_subagent\` is only usable from a child agent process with PI_SUBAGENT_CHILD_AGENT set; it is unavailable from the root session.`,
+			};
+		}
+		const caller = discovery.agents.find((agent) => agent.name === callerName);
+		const allowedList = (caller?.allowedSubagents ?? []).filter((name) => name && name.trim().length > 0);
+		if (allowedList.length === 0) {
+			return {
+				systemPrompt: `${event.systemPrompt}\n\n## Restricted Subagent Delegation\n\`delegate_subagent\` is registered but ${callerName} has no \`allowed-subagents\` configured; the tool will refuse every call.`,
+			};
+		}
+		const targetMap = new Map<string, typeof discovery.agents[number]>();
+		for (const agent of discovery.agents) targetMap.set(agent.name, agent);
+		const targetLines = allowedList
+			.map((name) => {
+				const target = targetMap.get(name);
+				if (!target) return `- ${name}: (not discovered)`;
+				const model = target.model ? ` model=${target.model}` : "";
+				const pane = target.pane ? " pane=true (delegate_subagent will refuse)" : "";
+				return `- ${target.name}: ${target.description} (${target.source}${model}${pane})`;
 			})
 			.join("\n");
 
 		return {
-			systemPrompt: `${event.systemPrompt}\n\n## Project Agents\nProject-local agents available to \`subagent\` (default \`agentScope: "project"\`; pass \`"both"\` only for user-level agents at \`~/.pi/agent/agents\`):\n${agentLines}`,
+			systemPrompt: `${event.systemPrompt}\n\n## Restricted Subagent Delegation\nUse \`delegate_subagent\` only for context-protecting exploratory or reconnaissance work — read exact files yourself before editing. Include all needed context in the task; parent conversation is not shared with the child. The child returns a single text summary.\n\nAllowed targets for ${callerName}:\n${targetLines}`,
 		};
+	});
+
+	pi.registerTool({
+		renderShell: "self",
+		name: "delegate_subagent",
+		label: "Delegate",
+		description: [
+			"Restricted exploratory delegation. Spawn a single child agent in its own context window and return its summary.",
+			"Only callable from a child Pi process whose PI_SUBAGENT_CHILD_AGENT is set; targets must appear in the caller agent's `allowed-subagents` frontmatter.",
+			"Single dispatch only — no parallel `tasks`, no `chain`, no session reuse, no pane control. Pane targets are rejected.",
+			"Include every fact and constraint in `task`; parent conversation is not shared.",
+			"Intended for context-protecting reconnaissance and research (for example, an engineer agent dispatching `scout` to map an unknown area). Read exact files yourself before editing.",
+		].join(" "),
+		parameters: DelegateSubagentParams,
+
+		async execute(_toolCallId, params, signal, onUpdate, ctx) {
+			const callerName = childAgentName?.trim();
+			const agentScope: AgentScope = "project";
+			const discovery = discoverAgents(ctx.cwd, agentScope);
+			const agents = discovery.agents;
+			const parentModel = ctx.model ? `${ctx.model.provider}/${ctx.model.id}` : undefined;
+			const parentThinkingLevel = pi.getThinkingLevel();
+			const parentSessionId = runtimeSessionId(ctx);
+			const runtimeRoot = sessionRuntimeDir(parentSessionId);
+			const makeDetails =
+				(_mode: "single" | "parallel" | "chain") =>
+				(results: SingleResult[]): SubagentDetails => ({
+					mode: "single",
+					agentScope,
+					projectAgentsDir: discovery.projectAgentsDir,
+					results,
+				});
+
+			if (!callerName) {
+				return {
+					content: [{ type: "text", text: "delegate_subagent is only callable from a child agent process (PI_SUBAGENT_CHILD_AGENT must be set). Use `subagent` from a root session instead." }],
+					details: makeDetails("single")([]),
+					isError: true,
+				};
+			}
+
+			const caller = agents.find((agent) => agent.name === callerName);
+			const allowedList = (caller?.allowedSubagents ?? [])
+				.map((name) => name.trim())
+				.filter((name) => name.length > 0);
+			if (!caller) {
+				return {
+					content: [{ type: "text", text: `delegate_subagent: caller agent '${callerName}' is not in the discovered project inventory; cannot authorize delegation.` }],
+					details: makeDetails("single")([]),
+					isError: true,
+				};
+			}
+			if (allowedList.length === 0) {
+				return {
+					content: [{ type: "text", text: `delegate_subagent: ${callerName} has no allowed-subagents configured. Add a list to the agent frontmatter (vstack.toml [agent-frontmatter.pi]) or use the full subagent tool from a parent session.` }],
+					details: makeDetails("single")([]),
+					isError: true,
+				};
+			}
+
+			const requestedTarget = (params.agent ?? "").trim();
+			if (!requestedTarget) {
+				return {
+					content: [{ type: "text", text: "delegate_subagent: 'agent' parameter is required." }],
+					details: makeDetails("single")([]),
+					isError: true,
+				};
+			}
+			if (!allowedList.includes(requestedTarget)) {
+				return {
+					content: [{ type: "text", text: `delegate_subagent: '${requestedTarget}' is not in ${callerName}'s allowed-subagents list. Allowed: ${allowedList.join(", ")}.` }],
+					details: makeDetails("single")([]),
+					isError: true,
+				};
+			}
+
+			const target = agents.find((agent) => agent.name === requestedTarget);
+			if (!target) {
+				const available = agents.map((a) => a.name).join(", ") || "none";
+				return {
+					content: [{ type: "text", text: `delegate_subagent: target '${requestedTarget}' is not discovered in project agents. Discovered: ${available}.` }],
+					details: makeDetails("single")([]),
+					isError: true,
+				};
+			}
+			if (target.pane) {
+				return {
+					content: [{ type: "text", text: `delegate_subagent: target '${requestedTarget}' is a persistent pane agent; restricted delegation is bg-only. Configure a non-pane agent or use the full subagent tool.` }],
+					details: makeDetails("single")([]),
+					isError: true,
+				};
+			}
+
+			const task = (params.task ?? "").trim();
+			if (!task) {
+				return {
+					content: [{ type: "text", text: "delegate_subagent: 'task' parameter is required." }],
+					details: makeDetails("single")([]),
+					isError: true,
+				};
+			}
+
+			return runSingleDispatch({
+				agent: requestedTarget,
+				agents,
+				cwd: ctx.cwd,
+				cwdOverride: params.cwd,
+				forceSpawn: false,
+				makeDetails,
+				onUpdate,
+				parentModel,
+				parentSessionId,
+				parentThinkingLevel,
+				pi,
+				removeDashboardAgent,
+				resumeSession: undefined,
+				runtimeRoot,
+				sessionKey: undefined,
+				signal,
+				task,
+				updateDashboard,
+			});
+		},
+
+		...subagentToolRenderers,
 	});
 
 	pi.registerTool({

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/runner.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/runner.ts
@@ -574,8 +574,18 @@ async function runSingleAgentAttempt(
 
 		const exitCode = await new Promise<number>((resolve) => {
 			const invocation = getPiInvocation(args);
+			// Child identity env mirrors the pane launcher's PI_SUBAGENT_*
+			// variables for bg one-shot lanes (issue #228). Restricted
+			// delegation reads PI_SUBAGENT_CHILD_AGENT to authorize the
+			// caller. Intentionally omit PI_BRIDGE_* and
+			// PI_SUBAGENT_PARENT_SESSION_ID here so bg lanes don't inherit
+			// pane-only session/bridge scope.
+			const childEnv: NodeJS.ProcessEnv = { ...process.env, PI_SUBAGENT_CHILD_AGENT: agent.name };
+			if (agent.color) childEnv.PI_SUBAGENT_CHILD_COLOR = agent.color;
+			else delete childEnv.PI_SUBAGENT_CHILD_COLOR;
 			const proc = spawnProcess(invocation.command, invocation.args, {
 				cwd: cwd ?? defaultCwd,
+				env: childEnv,
 				shell: false,
 				stdio: ["ignore", "pipe", "pipe"],
 			});

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/runner.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/runner.ts
@@ -577,12 +577,20 @@ async function runSingleAgentAttempt(
 			// Child identity env mirrors the pane launcher's PI_SUBAGENT_*
 			// variables for bg one-shot lanes (issue #228). Restricted
 			// delegation reads PI_SUBAGENT_CHILD_AGENT to authorize the
-			// caller. Intentionally omit PI_BRIDGE_* and
-			// PI_SUBAGENT_PARENT_SESSION_ID here so bg lanes don't inherit
-			// pane-only session/bridge scope.
+			// caller. Strip PI_BRIDGE_* and PI_SUBAGENT_PARENT_SESSION_ID
+			// so bg lanes never inherit pane-only session/bridge scope —
+			// without an explicit delete a parent process that already has
+			// those vars set (for example, this Pi running inside a pane
+			// itself) would leak them into the bg child and
+			// `runtimeSessionId()` would attach the child to the wrong
+			// runtime root.
 			const childEnv: NodeJS.ProcessEnv = { ...process.env, PI_SUBAGENT_CHILD_AGENT: agent.name };
 			if (agent.color) childEnv.PI_SUBAGENT_CHILD_COLOR = agent.color;
 			else delete childEnv.PI_SUBAGENT_CHILD_COLOR;
+			delete childEnv.PI_SUBAGENT_PARENT_SESSION_ID;
+			for (const key of Object.keys(childEnv)) {
+				if (key.startsWith("PI_BRIDGE_")) delete childEnv[key];
+			}
 			const proc = spawnProcess(invocation.command, invocation.args, {
 				cwd: cwd ?? defaultCwd,
 				env: childEnv,

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/tools.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/tools.ts
@@ -83,3 +83,25 @@ export const CompleteSubagentParams = Type.Object({
 	validation: Type.Optional(Type.Array(Type.String(), { description: "Validation performed, or empty if none" })),
 	notes: Type.Optional(Type.String({ description: "Optional concise notes" })),
 });
+
+/**
+ * Restricted exploratory delegation. Mirrors the single-mode shape of
+ * `subagent` but deliberately omits `tasks`, `chain`, `agentScope`,
+ * `sessionKey`, `forceSpawn`, and `resumeSession` — child dev agents should
+ * think "ask scout to map an unknown area", not "manage an agent fleet".
+ */
+export const DelegateSubagentParams = Type.Object({
+	agent: Type.String({
+		description:
+			"Name of the child agent to delegate to. Must be listed in the caller's allowed-subagents frontmatter; unknown or unlisted targets fail with an explicit inventory error.",
+	}),
+	task: Type.String({
+		description:
+			"Standalone task for the child. Include every fact and constraint the child needs — parent conversation context is not shared. Use only for context-protecting exploratory or reconnaissance work; read exact files yourself before editing.",
+	}),
+	cwd: Type.Optional(
+		Type.String({
+			description: "Optional working directory for the child process. Defaults to the caller's cwd.",
+		}),
+	),
+});

--- a/pi-extensions/pi-agents-tmux/instructions.md
+++ b/pi-extensions/pi-agents-tmux/instructions.md
@@ -1,6 +1,8 @@
-## pi-agents-tmux — `subagent`, `steer_subagent`, `get_subagent_result`, `wait_for_subagent_idle`, `stop_subagent`
+## pi-agents-tmux — `subagent`, `delegate_subagent`, `steer_subagent`, `get_subagent_result`, `wait_for_subagent_idle`, `stop_subagent`
 
 `subagent` delegates work to a project-defined agent (loaded from `.pi/agents`, with `.claude/agents` as a compatibility source). Agents with `pane: true` run in visible persistent tmux panes and survive across turns; others run as resumable bg agents. Child tools default to the parent's active tools minus the agent's `deny-tools:`.
+
+`delegate_subagent` is the restricted variant that child agents (engineer-role agents in particular) can call without gaining full orchestration controls. It only runs in child Pi processes (those launched with `PI_SUBAGENT_CHILD_AGENT` set), only accepts a single `{ agent, task, cwd? }`, and only targets agents listed in the caller's `allowed-subagents:` frontmatter. Engineer agents installed by vstack default to `allowed-subagents: scout` so they can dispatch read-only reconnaissance without absorbing the context. Pane targets, parallel/chain modes, session reuse, and the `agentScope` knob are all rejected.
 
 Use when: isolated context for a focused task; specialist review (security, performance, design); reconnaissance/planning/read-only investigation that can run in parallel; multiple independent investigations via `tasks: [...]` (parallel) or `chain: [...]` (sequential, with `{previous}` placeholder).
 

--- a/pi-extensions/pi-agents-tmux/package.json
+++ b/pi-extensions/pi-agents-tmux/package.json
@@ -303,6 +303,11 @@
         },
         {
           "kind": "tool",
+          "name": "delegate_subagent",
+          "description": "Restricted exploratory delegation for child agents. Single-mode only; targets must appear in the caller agent's allowed-subagents frontmatter (engineer agents default to ['scout']). Pane targets and session reuse are rejected."
+        },
+        {
+          "kind": "tool",
           "name": "get_subagent_result",
           "description": "Retrieve persistent pane agent task results by taskId or latest agent task; can also wait for pane idle."
         },

--- a/pi-extensions/pi-agents-tmux/tests/allowed-subagents.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/allowed-subagents.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { discoverAgents } from "../extensions/subagent/agents.js";
+
+function tempProject(): string {
+	const root = mkdtempSync(join(tmpdir(), "pi-agents-allowed-"));
+	mkdirSync(join(root, ".pi", "agents"), { recursive: true });
+	return root;
+}
+
+function writeAgent(root: string, name: string, frontmatterLines: string[]): void {
+	const lines = ["---", `name: ${name}`, `description: ${name} test agent`, ...frontmatterLines, "---", ""];
+	writeFileSync(join(root, ".pi", "agents", `${name}.md`), `${lines.join("\n")}\n`, "utf8");
+}
+
+describe("allowed-subagents parsing", () => {
+	test("comma-separated string is split into a list", () => {
+		const root = tempProject();
+		writeAgent(root, "rust", ["allowed-subagents: scout, researcher"]);
+		const { agents } = discoverAgents(root, "project");
+		const rust = agents.find((agent) => agent.name === "rust");
+		expect(rust?.allowedSubagents).toEqual(["scout", "researcher"]);
+	});
+
+	test("single name is preserved", () => {
+		const root = tempProject();
+		writeAgent(root, "rust", ["allowed-subagents: scout"]);
+		const { agents } = discoverAgents(root, "project");
+		const rust = agents.find((agent) => agent.name === "rust");
+		expect(rust?.allowedSubagents).toEqual(["scout"]);
+	});
+
+	test("missing field leaves allowedSubagents undefined", () => {
+		const root = tempProject();
+		writeAgent(root, "rust", []);
+		const { agents } = discoverAgents(root, "project");
+		const rust = agents.find((agent) => agent.name === "rust");
+		expect(rust?.allowedSubagents).toBeUndefined();
+	});
+
+	test("empty string yields empty list (preserves explicit opt-out)", () => {
+		const root = tempProject();
+		writeAgent(root, "rust", ["allowed-subagents: "]);
+		const { agents } = discoverAgents(root, "project");
+		const rust = agents.find((agent) => agent.name === "rust");
+		expect(rust?.allowedSubagents).toEqual([]);
+	});
+
+	test("aliases (allowedSubagents / subagent-agents / subagent_agents) all parse", () => {
+		const root = tempProject();
+		writeAgent(root, "alpha", ["allowedSubagents: scout"]);
+		writeAgent(root, "beta", ["subagent-agents: scout"]);
+		writeAgent(root, "gamma", ["subagent_agents: scout"]);
+		const { agents } = discoverAgents(root, "project");
+		const get = (name: string) => agents.find((agent) => agent.name === name);
+		expect(get("alpha")?.allowedSubagents).toEqual(["scout"]);
+		expect(get("beta")?.allowedSubagents).toEqual(["scout"]);
+		expect(get("gamma")?.allowedSubagents).toEqual(["scout"]);
+	});
+});

--- a/pi-extensions/pi-agents-tmux/tests/delegate-subagent-runtime.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/delegate-subagent-runtime.test.ts
@@ -1,0 +1,334 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { EventEmitter } from "node:events";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { setSingleAgentSpawnForTests } from "../extensions/subagent/runner.js";
+
+interface RegisteredTool {
+	name: string;
+	execute: (
+		toolCallId: string,
+		params: Record<string, any>,
+		signal: AbortSignal | undefined,
+		onUpdate: undefined,
+		ctx: any,
+	) => Promise<any>;
+}
+
+interface Harness {
+	cwd: string;
+	piUserDir: string;
+	tools: Map<string, RegisteredTool>;
+	previousEnv: {
+		child?: string;
+		dir?: string;
+		bridgeParent?: string;
+		bridgeRole?: string;
+		parentSession?: string;
+	};
+}
+
+function createTempProject(): { cwd: string; piUserDir: string } {
+	const cwd = mkdtempSync(join(tmpdir(), "delegate-subagent-runtime-"));
+	mkdirSync(join(cwd, ".pi", "agents"), { recursive: true });
+	const piUserDir = join(cwd, ".pi-agent-home");
+	mkdirSync(piUserDir, { recursive: true });
+	return { cwd, piUserDir };
+}
+
+function writeAgent(cwd: string, name: string, frontmatter: string[]): void {
+	const lines = ["---", `name: ${name}`, `description: ${name} test agent`, ...frontmatter, "---", ""];
+	writeFileSync(join(cwd, ".pi", "agents", `${name}.md`), `${lines.join("\n")}\n`, "utf8");
+}
+
+function makeFakeCtx(cwd: string): any {
+	return {
+		cwd,
+		hasUI: false,
+		isIdle: () => true,
+		model: undefined,
+		sessionManager: {
+			getSessionFile: () => undefined,
+			getSessionId: () => "test-session-id",
+			getBranch: () => [],
+		},
+		ui: {
+			confirm: async () => true,
+			setStatus: () => undefined,
+			setTitle: () => undefined,
+			setWidget: () => undefined,
+		},
+	};
+}
+
+function setup(callerEnv: string | undefined): Harness {
+	const { cwd, piUserDir } = createTempProject();
+	const previousEnv = {
+		child: process.env.PI_SUBAGENT_CHILD_AGENT,
+		dir: process.env.PI_CODING_AGENT_DIR,
+		bridgeParent: process.env.PI_BRIDGE_PARENT_SESSION_ID,
+		bridgeRole: process.env.PI_BRIDGE_CHILD_ROLE,
+		parentSession: process.env.PI_SUBAGENT_PARENT_SESSION_ID,
+	};
+	if (callerEnv === undefined) delete process.env.PI_SUBAGENT_CHILD_AGENT;
+	else process.env.PI_SUBAGENT_CHILD_AGENT = callerEnv;
+	process.env.PI_CODING_AGENT_DIR = piUserDir;
+	delete process.env.PI_BRIDGE_PARENT_SESSION_ID;
+	delete process.env.PI_BRIDGE_CHILD_ROLE;
+	delete process.env.PI_SUBAGENT_PARENT_SESSION_ID;
+	return { cwd, piUserDir, tools: new Map(), previousEnv };
+}
+
+function teardown(harness: Harness): void {
+	const { previousEnv, cwd } = harness;
+	setSingleAgentSpawnForTests();
+	if (previousEnv.child === undefined) delete process.env.PI_SUBAGENT_CHILD_AGENT;
+	else process.env.PI_SUBAGENT_CHILD_AGENT = previousEnv.child;
+	if (previousEnv.dir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+	else process.env.PI_CODING_AGENT_DIR = previousEnv.dir;
+	if (previousEnv.bridgeParent === undefined) delete process.env.PI_BRIDGE_PARENT_SESSION_ID;
+	else process.env.PI_BRIDGE_PARENT_SESSION_ID = previousEnv.bridgeParent;
+	if (previousEnv.bridgeRole === undefined) delete process.env.PI_BRIDGE_CHILD_ROLE;
+	else process.env.PI_BRIDGE_CHILD_ROLE = previousEnv.bridgeRole;
+	if (previousEnv.parentSession === undefined) delete process.env.PI_SUBAGENT_PARENT_SESSION_ID;
+	else process.env.PI_SUBAGENT_PARENT_SESSION_ID = previousEnv.parentSession;
+	rmSync(cwd, { force: true, recursive: true });
+}
+
+async function installExtension(harness: Harness): Promise<void> {
+	// Re-import so module-level `childAgentName` snapshot reflects the
+	// per-test PI_SUBAGENT_CHILD_AGENT env we set in setup(). bun's import
+	// cache is keyed by URL; a query parameter forces a fresh evaluation.
+	const url = new URL("../extensions/subagent/index.ts", import.meta.url);
+	url.searchParams.set("t", String(Date.now()) + Math.random().toString(36).slice(2));
+	const mod = await import(url.href);
+	const subagentExtension = mod.default;
+	const bus = new EventEmitter();
+	const pi = {
+		appendEntry: () => undefined,
+		events: { emit: bus.emit.bind(bus), on: bus.on.bind(bus) },
+		getActiveTools: () => ["delegate_subagent"],
+		getThinkingLevel: () => undefined,
+		on: () => undefined,
+		registerCommand: () => undefined,
+		registerMessageRenderer: () => undefined,
+		registerShortcut: () => undefined,
+		registerTool: (def: any) => {
+			if (def.name && typeof def.execute === "function") {
+				harness.tools.set(def.name, { name: def.name, execute: def.execute });
+			}
+		},
+		sendMessage: () => undefined,
+		sendUserMessage: async () => undefined,
+	} as any;
+	subagentExtension(pi);
+}
+
+function installSpawnSuccess(): Array<{ args: string[]; env: NodeJS.ProcessEnv | undefined }> {
+	const calls: Array<{ args: string[]; env: NodeJS.ProcessEnv | undefined }> = [];
+	setSingleAgentSpawnForTests(((command: string, args: string[], options?: { env?: NodeJS.ProcessEnv }) => {
+		void command;
+		calls.push({ args, env: options?.env });
+		const proc = new EventEmitter() as any;
+		proc.stdout = new EventEmitter();
+		proc.stderr = new EventEmitter();
+		proc.killed = false;
+		proc.kill = () => {
+			proc.killed = true;
+			return true;
+		};
+		queueMicrotask(() => {
+			const events = [
+				JSON.stringify({ type: "event", event: "agent_start", data: {} }),
+				JSON.stringify({
+					type: "event",
+					event: "message_end",
+					data: {
+						message: {
+							role: "assistant",
+							content: [{ type: "text", text: "scout report" }],
+							usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, totalTokens: 2 },
+						},
+					},
+				}),
+			];
+			proc.stdout.emit("data", Buffer.from(`${events.join("\n")}\n`));
+			proc.emit("close", 0, null);
+		});
+		return proc;
+	}) as any);
+	return calls;
+}
+
+describe("delegate_subagent runtime behavior (issue #228)", () => {
+	let harness: Harness | undefined;
+
+	afterEach(() => {
+		if (harness) {
+			teardown(harness);
+			harness = undefined;
+		}
+	});
+
+	test("registers when imported and is callable via the captured execute fn", async () => {
+		harness = setup("rust");
+		writeAgent(harness.cwd, "rust", ["allowed-subagents: scout"]);
+		writeAgent(harness.cwd, "scout", []);
+		await installExtension(harness);
+		expect(harness.tools.has("delegate_subagent")).toBe(true);
+	});
+
+	test("allowed target spawns the child via single-mode dispatch", async () => {
+		harness = setup("rust");
+		writeAgent(harness.cwd, "rust", ["allowed-subagents: scout"]);
+		writeAgent(harness.cwd, "scout", []);
+		await installExtension(harness);
+		const calls = installSpawnSuccess();
+		const tool = harness.tools.get("delegate_subagent")!;
+		const result = await tool.execute(
+			"call-1",
+			{ agent: "scout", task: "Map the unknown area." },
+			undefined,
+			undefined,
+			makeFakeCtx(harness.cwd),
+		);
+		expect(result.isError).toBeFalsy();
+		expect(calls).toHaveLength(1);
+		// Child identity env (issue #228) is set, bridge env is stripped.
+		expect(calls[0]?.env?.PI_SUBAGENT_CHILD_AGENT).toBe("scout");
+		expect(calls[0]?.env?.PI_BRIDGE_PARENT_SESSION_ID).toBeUndefined();
+	});
+
+	test("refuses when caller identity is missing (no PI_SUBAGENT_CHILD_AGENT)", async () => {
+		harness = setup(undefined);
+		writeAgent(harness.cwd, "rust", ["allowed-subagents: scout"]);
+		writeAgent(harness.cwd, "scout", []);
+		await installExtension(harness);
+		const tool = harness.tools.get("delegate_subagent")!;
+		const result = await tool.execute(
+			"call-1",
+			{ agent: "scout", task: "Map." },
+			undefined,
+			undefined,
+			makeFakeCtx(harness.cwd),
+		);
+		expect(result.isError).toBe(true);
+		expect(result.content[0]?.text).toContain("PI_SUBAGENT_CHILD_AGENT");
+	});
+
+	test("refuses when caller has no allowed-subagents configured", async () => {
+		harness = setup("scout");
+		writeAgent(harness.cwd, "scout", []);
+		writeAgent(harness.cwd, "researcher", []);
+		await installExtension(harness);
+		const tool = harness.tools.get("delegate_subagent")!;
+		const result = await tool.execute(
+			"call-1",
+			{ agent: "researcher", task: "Recurse." },
+			undefined,
+			undefined,
+			makeFakeCtx(harness.cwd),
+		);
+		expect(result.isError).toBe(true);
+		expect(result.content[0]?.text).toMatch(/no allowed-subagents/);
+	});
+
+	test("refuses target not in caller's allowlist", async () => {
+		harness = setup("rust");
+		writeAgent(harness.cwd, "rust", ["allowed-subagents: scout"]);
+		writeAgent(harness.cwd, "scout", []);
+		writeAgent(harness.cwd, "researcher", []);
+		await installExtension(harness);
+		const tool = harness.tools.get("delegate_subagent")!;
+		const result = await tool.execute(
+			"call-1",
+			{ agent: "researcher", task: "Do research." },
+			undefined,
+			undefined,
+			makeFakeCtx(harness.cwd),
+		);
+		expect(result.isError).toBe(true);
+		expect(result.content[0]?.text).toMatch(/not in rust's allowed-subagents/);
+	});
+
+	test("refuses target that is not in discovered project inventory", async () => {
+		harness = setup("rust");
+		writeAgent(harness.cwd, "rust", ["allowed-subagents: ghost"]);
+		// Note: no ghost agent on disk.
+		await installExtension(harness);
+		const tool = harness.tools.get("delegate_subagent")!;
+		const result = await tool.execute(
+			"call-1",
+			{ agent: "ghost", task: "Ghostly task." },
+			undefined,
+			undefined,
+			makeFakeCtx(harness.cwd),
+		);
+		expect(result.isError).toBe(true);
+		expect(result.content[0]?.text).toMatch(/not discovered in project agents/);
+	});
+
+	test("refuses pane target even when allowlisted", async () => {
+		harness = setup("rust");
+		writeAgent(harness.cwd, "rust", ["allowed-subagents: planner"]);
+		writeAgent(harness.cwd, "planner", ["pane: true"]);
+		await installExtension(harness);
+		const tool = harness.tools.get("delegate_subagent")!;
+		const result = await tool.execute(
+			"call-1",
+			{ agent: "planner", task: "Plan a thing." },
+			undefined,
+			undefined,
+			makeFakeCtx(harness.cwd),
+		);
+		expect(result.isError).toBe(true);
+		expect(result.content[0]?.text).toMatch(/persistent pane agent/);
+	});
+
+	test("refuses when caller agent itself is not in project inventory", async () => {
+		// Pane launches set PI_SUBAGENT_CHILD_AGENT to an agent name, but a
+		// stale env (or local repo override missing the agent file) must not
+		// auto-authorize.
+		harness = setup("ghost-caller");
+		writeAgent(harness.cwd, "scout", []);
+		await installExtension(harness);
+		const tool = harness.tools.get("delegate_subagent")!;
+		const result = await tool.execute(
+			"call-1",
+			{ agent: "scout", task: "Recon." },
+			undefined,
+			undefined,
+			makeFakeCtx(harness.cwd),
+		);
+		expect(result.isError).toBe(true);
+		expect(result.content[0]?.text).toMatch(/not in the discovered project inventory/);
+	});
+
+	test("refuses empty task / empty agent params", async () => {
+		harness = setup("rust");
+		writeAgent(harness.cwd, "rust", ["allowed-subagents: scout"]);
+		writeAgent(harness.cwd, "scout", []);
+		await installExtension(harness);
+		const tool = harness.tools.get("delegate_subagent")!;
+		const noTask = await tool.execute(
+			"call-1",
+			{ agent: "scout", task: "  " },
+			undefined,
+			undefined,
+			makeFakeCtx(harness.cwd),
+		);
+		expect(noTask.isError).toBe(true);
+		expect(noTask.content[0]?.text).toMatch(/'task' parameter is required/);
+
+		const noAgent = await tool.execute(
+			"call-2",
+			{ agent: "  ", task: "Real task." },
+			undefined,
+			undefined,
+			makeFakeCtx(harness.cwd),
+		);
+		expect(noAgent.isError).toBe(true);
+		expect(noAgent.content[0]?.text).toMatch(/'agent' parameter is required/);
+	});
+});

--- a/pi-extensions/pi-agents-tmux/tests/runner-child-identity.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/runner-child-identity.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, test } from "bun:test";
+import { EventEmitter } from "node:events";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AgentConfig } from "../extensions/subagent/agents.js";
+import {
+	runSingleAgent,
+	setSingleAgentSpawnForTests,
+} from "../extensions/subagent/runner.js";
+import type { SingleResult, SubagentDetails } from "../extensions/subagent/types.js";
+
+function tempRuntime(): string {
+	return mkdtempSync(join(tmpdir(), "pi-agents-runner-env-"));
+}
+
+function makeDetails(results: SingleResult[]): SubagentDetails {
+	return { mode: "single", agentScope: "project", projectAgentsDir: null, results };
+}
+
+function mockPiEvents() {
+	return {
+		getActiveTools: () => [],
+		events: { emit: () => undefined },
+	} as any;
+}
+
+function captureSpawnedEnv(scenarios: Array<{ code: number; stdout?: string }>): Array<NodeJS.ProcessEnv | undefined> {
+	const envs: Array<NodeJS.ProcessEnv | undefined> = [];
+	setSingleAgentSpawnForTests(((command: string, args: string[], options?: { env?: NodeJS.ProcessEnv }) => {
+		void command;
+		void args;
+		envs.push(options?.env);
+		const proc = new EventEmitter() as any;
+		proc.stdout = new EventEmitter();
+		proc.stderr = new EventEmitter();
+		proc.killed = false;
+		proc.kill = () => { proc.killed = true; return true; };
+		const scenario = scenarios.shift() ?? { code: 0 };
+		queueMicrotask(() => {
+			if (scenario.stdout) proc.stdout.emit("data", Buffer.from(scenario.stdout));
+			proc.emit("close", scenario.code, null);
+		});
+		return proc;
+	}) as any);
+	return envs;
+}
+
+function agent(name: string, color?: string): AgentConfig {
+	return {
+		name,
+		description: `${name} test agent`,
+		pane: false,
+		systemPrompt: "",
+		source: "project",
+		filePath: `${name}.md`,
+		color,
+	};
+}
+
+describe("bg one-shot runner exports child identity env (issue #228)", () => {
+	test("PI_SUBAGENT_CHILD_AGENT is set to the target agent name", async () => {
+		const envs = captureSpawnedEnv([{ code: 0 }]);
+		try {
+			await runSingleAgent(
+				tempRuntime(),
+				tempRuntime(),
+				[agent("scout")],
+				"scout",
+				"map the unknown",
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				mockPiEvents(),
+				undefined,
+				undefined,
+				makeDetails,
+			);
+			expect(envs).toHaveLength(1);
+			expect(envs[0]?.PI_SUBAGENT_CHILD_AGENT).toBe("scout");
+		} finally {
+			setSingleAgentSpawnForTests();
+		}
+	});
+
+	test("PI_SUBAGENT_CHILD_COLOR is exported when the agent has a color", async () => {
+		const envs = captureSpawnedEnv([{ code: 0 }]);
+		try {
+			await runSingleAgent(
+				tempRuntime(),
+				tempRuntime(),
+				[agent("scout", "cyan")],
+				"scout",
+				"recon",
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				mockPiEvents(),
+				undefined,
+				undefined,
+				makeDetails,
+			);
+			expect(envs[0]?.PI_SUBAGENT_CHILD_COLOR).toBe("cyan");
+		} finally {
+			setSingleAgentSpawnForTests();
+		}
+	});
+
+	test("bridge env vars (PI_BRIDGE_*) are NOT forwarded to bg children", async () => {
+		// Issue #228 post-verification: bridge workaround is pane-oriented; bg
+		// children should not bleed bridge session/role.
+		const envs = captureSpawnedEnv([{ code: 0 }]);
+		const previousParent = process.env.PI_BRIDGE_PARENT_SESSION_ID;
+		const previousChild = process.env.PI_BRIDGE_CHILD_ROLE;
+		const previousSession = process.env.PI_SUBAGENT_PARENT_SESSION_ID;
+		try {
+			delete process.env.PI_BRIDGE_PARENT_SESSION_ID;
+			delete process.env.PI_BRIDGE_CHILD_ROLE;
+			delete process.env.PI_SUBAGENT_PARENT_SESSION_ID;
+			await runSingleAgent(
+				tempRuntime(),
+				tempRuntime(),
+				[agent("scout")],
+				"scout",
+				"recon",
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				mockPiEvents(),
+				undefined,
+				undefined,
+				makeDetails,
+			);
+			expect(envs[0]?.PI_BRIDGE_PARENT_SESSION_ID).toBeUndefined();
+			expect(envs[0]?.PI_BRIDGE_CHILD_ROLE).toBeUndefined();
+			expect(envs[0]?.PI_SUBAGENT_PARENT_SESSION_ID).toBeUndefined();
+		} finally {
+			setSingleAgentSpawnForTests();
+			if (previousParent === undefined) delete process.env.PI_BRIDGE_PARENT_SESSION_ID;
+			else process.env.PI_BRIDGE_PARENT_SESSION_ID = previousParent;
+			if (previousChild === undefined) delete process.env.PI_BRIDGE_CHILD_ROLE;
+			else process.env.PI_BRIDGE_CHILD_ROLE = previousChild;
+			if (previousSession === undefined) delete process.env.PI_SUBAGENT_PARENT_SESSION_ID;
+			else process.env.PI_SUBAGENT_PARENT_SESSION_ID = previousSession;
+		}
+	});
+
+	test("PI_SUBAGENT_CHILD_COLOR is cleared when the parent had it set but the agent has no color", async () => {
+		const envs = captureSpawnedEnv([{ code: 0 }]);
+		const previous = process.env.PI_SUBAGENT_CHILD_COLOR;
+		try {
+			process.env.PI_SUBAGENT_CHILD_COLOR = "magenta";
+			await runSingleAgent(
+				tempRuntime(),
+				tempRuntime(),
+				[agent("scout")],
+				"scout",
+				"recon",
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				mockPiEvents(),
+				undefined,
+				undefined,
+				makeDetails,
+			);
+			expect(envs[0]?.PI_SUBAGENT_CHILD_COLOR).toBeUndefined();
+		} finally {
+			setSingleAgentSpawnForTests();
+			if (previous === undefined) delete process.env.PI_SUBAGENT_CHILD_COLOR;
+			else process.env.PI_SUBAGENT_CHILD_COLOR = previous;
+		}
+	});
+});

--- a/pi-extensions/pi-agents-tmux/tests/runner-child-identity.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/runner-child-identity.test.ts
@@ -108,17 +108,25 @@ describe("bg one-shot runner exports child identity env (issue #228)", () => {
 		}
 	});
 
-	test("bridge env vars (PI_BRIDGE_*) are NOT forwarded to bg children", async () => {
+	test("bridge env vars (PI_BRIDGE_*) and PI_SUBAGENT_PARENT_SESSION_ID are stripped even when set in parent", async () => {
 		// Issue #228 post-verification: bridge workaround is pane-oriented; bg
-		// children should not bleed bridge session/role.
+		// children must not bleed bridge session/role. Regression guard against
+		// the pre-PR review round-1 finding — the earlier test pre-cleared
+		// these vars, so a `{...process.env, PI_SUBAGENT_CHILD_AGENT: ...}`
+		// spread that *didn't* delete them was still passing.
 		const envs = captureSpawnedEnv([{ code: 0 }]);
 		const previousParent = process.env.PI_BRIDGE_PARENT_SESSION_ID;
 		const previousChild = process.env.PI_BRIDGE_CHILD_ROLE;
 		const previousSession = process.env.PI_SUBAGENT_PARENT_SESSION_ID;
+		const previousExtraBridge = process.env.PI_BRIDGE_SOCKET_PATH;
 		try {
-			delete process.env.PI_BRIDGE_PARENT_SESSION_ID;
-			delete process.env.PI_BRIDGE_CHILD_ROLE;
-			delete process.env.PI_SUBAGENT_PARENT_SESSION_ID;
+			// Set sentinel values BEFORE spawn so the test actually exercises
+			// the strip path. If runner.ts ever drops the explicit deletes,
+			// these sentinels would otherwise leak through.
+			process.env.PI_BRIDGE_PARENT_SESSION_ID = "sentinel-parent";
+			process.env.PI_BRIDGE_CHILD_ROLE = "sentinel-role";
+			process.env.PI_SUBAGENT_PARENT_SESSION_ID = "sentinel-session";
+			process.env.PI_BRIDGE_SOCKET_PATH = "/tmp/sentinel-socket";
 			await runSingleAgent(
 				tempRuntime(),
 				tempRuntime(),
@@ -137,6 +145,9 @@ describe("bg one-shot runner exports child identity env (issue #228)", () => {
 			expect(envs[0]?.PI_BRIDGE_PARENT_SESSION_ID).toBeUndefined();
 			expect(envs[0]?.PI_BRIDGE_CHILD_ROLE).toBeUndefined();
 			expect(envs[0]?.PI_SUBAGENT_PARENT_SESSION_ID).toBeUndefined();
+			// Any other PI_BRIDGE_* var must also be stripped, not just the
+			// two named ones.
+			expect(envs[0]?.PI_BRIDGE_SOCKET_PATH).toBeUndefined();
 		} finally {
 			setSingleAgentSpawnForTests();
 			if (previousParent === undefined) delete process.env.PI_BRIDGE_PARENT_SESSION_ID;
@@ -145,6 +156,8 @@ describe("bg one-shot runner exports child identity env (issue #228)", () => {
 			else process.env.PI_BRIDGE_CHILD_ROLE = previousChild;
 			if (previousSession === undefined) delete process.env.PI_SUBAGENT_PARENT_SESSION_ID;
 			else process.env.PI_SUBAGENT_PARENT_SESSION_ID = previousSession;
+			if (previousExtraBridge === undefined) delete process.env.PI_BRIDGE_SOCKET_PATH;
+			else process.env.PI_BRIDGE_SOCKET_PATH = previousExtraBridge;
 		}
 	});
 

--- a/vstack.toml
+++ b/vstack.toml
@@ -32,7 +32,12 @@ is_source_catalog = true
 # planner = { model = "gpt-5.5", model-reasoning-effort = "xhigh", sandbox-mode = "workspace-write" }
 #
 # [agent-frontmatter.pi]
-# planner = { color = "blue", model = "openai-codex/gpt-5.5:xhigh", deny-tools = ["subagent", "get_subagent_result", "steer_subagent", "stop_subagent"], pane = true }
+# planner = { color = "blue", model = "openai-codex/gpt-5.5:xhigh", deny-tools = ["subagent", "get_subagent_result", "steer_subagent", "stop_subagent"], allowed-subagents = ["scout"], pane = true }
+#
+# `allowed-subagents` is the Pi restricted-delegation allowlist for the
+# `delegate_subagent` tool. Engineer agents default to `["scout"]`; set
+# `allowed-subagents = []` to disable. Non-engineer roles default to empty.
+# Accepted aliases: `allowedSubagents`, `subagent-agents`, `subagent_agents`.
 #
 # The Pi `/agents` popup can edit model/deny-tools/color for vstack-managed project
 # agents and writes those changes into `[agent-frontmatter.pi]` automatically.


### PR DESCRIPTION
## Summary

- Add `allowed-subagents` Pi agent frontmatter (canonical kebab key plus `allowedSubagents` / `subagent-agents` / `subagent_agents` aliases) and a new `delegate_subagent` Pi tool so vstack-generated engineer agents can dispatch read-only reconnaissance (for example `rust → scout`) without gaining full `subagent` orchestration controls.
- Engineer agents default to `allowed-subagents: scout`; reviewer/analyst/manager roles default to empty (`delegate_subagent` added to `deny-tools`). User overrides via `[agent-frontmatter.pi]` win; `allowed-subagents = []` disables the engineer default. An explicit `deny-tools` entry containing `delegate_subagent` overrides the allowlist strip — user policy is authoritative.
- `delegate_subagent` is single-mode only (`{ agent, task, cwd? }`), authorizes the caller via `PI_SUBAGENT_CHILD_AGENT`, rejects pane targets / unlisted targets / unknown callers, and reuses `runSingleDispatch` so session isolation, skills, model/effort, transcripts, dashboard, activity broker, rate-limit handling, and context-length retry all carry over unchanged. The bg one-shot runner exports `PI_SUBAGENT_CHILD_AGENT` (and `PI_SUBAGENT_CHILD_COLOR`) and strips `PI_BRIDGE_*` / `PI_SUBAGENT_PARENT_SESSION_ID` so bg lanes don't inherit pane-only session/bridge scope.
- Side-effect: fixed the canonical `hooks/pre-commit-check.sh` and `hooks/task-completed-check.sh` so they locate nested `Cargo.toml` (vstack's `cli/Cargo.toml`) via `git rev-parse --show-toplevel` walks instead of running `cargo fmt`/`cargo clippy` blindly from cwd.

## Test plan

- [x] `cd cli && cargo test` — 222 passed, 2 ignored
- [x] `cd cli && cargo clippy --all-targets -- -D warnings` — clean
- [x] `cd pi-extensions/pi-agents-tmux && bun test ./tests ./extensions/subagent/__tests__` — 210 passed
- [x] Integration: `vstack add .. --all --copy -y` into a temp project — engineer agents (`rust`, `iced`, `generalist`) generated with `allowed-subagents: scout` and `delegate_subagent` absent from `deny-tools`; non-engineer agents (`scout`, `planner`, `researcher`, reviewers) generated with no `allowed-subagents:` line and `delegate_subagent` present in `deny-tools`.
- [x] Round-1 reviewer feedback addressed (env strip, explicit deny precedence, runtime tests, doc accuracy).

Fixes #228