### PR TITLE
Fix duplicate bg subagent inline output

### DIFF
--- a/pi-extensions/pi-agents-tmux/README.md
+++ b/pi-extensions/pi-agents-tmux/README.md
@@ -153,7 +153,7 @@ There is one knob — `maxConcurrency` — and it caps the number of bg agent pr
 | Setting | What it does |
 | --- | --- |
 | Show agent dashboard | Render the activity card above the editor. The first agent activity may show it each session; user-hidden state blocks automatic re-open until an explicit toggle/show. |
-| Quiet inline output with dashboard | Keep inline tool output to short crumbs. |
+| Quiet inline output with dashboard | Keep inline tool output to short crumbs; single bg launches skip the initial task preview. |
 | Dashboard max items | Maximum agent rows shown. |
 | Dashboard collapsed by default | Start collapsed. |
 | Animate spinners | Animate running-agent spinner frames; disable for a static gear icon to reduce terminal flickering. |

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/subagent-render.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/subagent-render.ts
@@ -59,12 +59,14 @@ export const subagentToolRenderers = {
 			return new Container();
 		}
 		const agentName = args.agent || "...";
+		const cwd = _context?.cwd ?? process.cwd();
 		try {
-			const agent = discoverAgents(_context?.cwd ?? process.cwd(), scope).agents.find((candidate) => candidate.name === agentName);
+			const agent = discoverAgents(cwd, scope).agents.find((candidate) => candidate.name === agentName);
 			if (agent?.pane) return new Container();
 		} catch {
 			// Keep the generic call preview if discovery fails.
 		}
+		if (dashboardEnabled(cwd) && quietInline(cwd)) return new Container();
 		const preview = args.task ? oneLinePreview(args.task, 56) : "...";
 		let text = `${agentsCommandBullet(theme)}${agentWord(theme)} ${ansiMagenta(theme.bold(agentName))}`;
 		if (scope !== "project") text += theme.fg("dim", ` · ${scope}`);
@@ -233,7 +235,7 @@ export const subagentToolRenderers = {
 
 			if (queued) return queuedTaskPreviewComponent(r, quietDashboard);
 
-			if (quietDashboard && !queued && !isError && !needsCompletion) {
+			if (quietDashboard && !queued && !isRunning && !isError && !needsCompletion) {
 				const toolCalls = displayItems.filter((item) => item.type === "toolCall");
 				const preview = finalOutput && !finalOutputLooksLikeToolEcho(finalOutput, toolCalls)
 					? oneLinePreview(finalOutput, 180)

--- a/pi-extensions/pi-agents-tmux/package.json
+++ b/pi-extensions/pi-agents-tmux/package.json
@@ -125,7 +125,7 @@
         {
           "key": "quietInlineWhenDashboard",
           "label": "Quiet inline output with dashboard",
-          "description": "When the dashboard is enabled, keep chat/tool transcript rows to short event crumbs and move details into the persistent dashboard/ctrl+o to expand views.",
+          "description": "When the dashboard is enabled, keep chat/tool transcript rows to short event crumbs, skip single bg launch previews, and move details into the dashboard/ctrl+o views.",
           "type": "boolean",
           "default": true,
           "category": "Rendering",

--- a/pi-extensions/pi-agents-tmux/tests/dashboard-ux.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/dashboard-ux.test.ts
@@ -63,6 +63,11 @@ function writeManagerConfig(cwd: string, config: Record<string, unknown>): void 
 	}));
 }
 
+function writeProjectAgent(cwd: string, name: string, frontmatter: string[] = []): void {
+	mkdirSync(join(cwd, ".pi", "agents"), { recursive: true });
+	writeFileSync(join(cwd, ".pi", "agents", `${name}.md`), ["---", `name: ${name}`, `description: ${name} agent`, ...frontmatter, "---", ""].join("\n"));
+}
+
 function withTempPiUserDir<T>(fn: () => T): T {
 	const previous = process.env.PI_CODING_AGENT_DIR;
 	process.env.PI_CODING_AGENT_DIR = tempRuntime();
@@ -146,6 +151,15 @@ function renderSubagentSingle(result: SingleResult): string {
 	return subagentToolRenderers.renderResult({ content: [{ type: "text", text: "done" }], details }, {}, theme, { cwd: process.cwd() }).render(220).join("\n");
 }
 
+function renderSubagentSingleInCwd(result: SingleResult, cwd: string): string {
+	const details: SubagentDetails = { mode: "single", agentScope: "project", projectAgentsDir: null, results: [result] };
+	return subagentToolRenderers.renderResult({ content: [{ type: "text", text: "done" }], details }, {}, theme, { cwd }).render(220).join("\n");
+}
+
+function renderSubagentCall(args: Record<string, unknown>, cwd: string): string {
+	return subagentToolRenderers.renderCall(args, theme, { cwd }).render(220).join("\n");
+}
+
 function dashboardItem(patch: Partial<SubagentDashboardItem> = {}): SubagentDashboardItem {
 	return {
 		agent: "reviewer-arch",
@@ -162,6 +176,36 @@ test("subagent renderer shows session-mode chips", () => {
 	assert.match(renderSubagentSingle(singleResult({ sessionMode: "resumed", sessionKey: "very-long-session-key", sessionKeyExplicit: true })), /completed · bg · lane:very-l…-key/);
 	assert.match(renderSubagentSingle(singleResult({ paneId: "%1", paneSessionMode: "new", sessionMode: "new" })), /Queued task · pane · new/);
 	assert.match(renderSubagentSingle(singleResult({ paneId: "%1", paneSessionMode: "live", sessionMode: "resumed" })), /Queued task · pane · resumed/);
+});
+
+test("quiet dashboard suppresses single bg call preview", () => {
+	const cwd = tempRuntime();
+	writeManagerConfig(cwd, { dashboard: true, quietInlineWhenDashboard: true });
+	writeProjectAgent(cwd, "scout");
+
+	const rendered = renderSubagentCall({ agent: "scout", task: "Inspect duplicate output." }, cwd);
+
+	assert.equal(rendered, "");
+});
+
+test("single bg call preview remains when dashboard quiet mode is off", () => {
+	const cwd = tempRuntime();
+	writeManagerConfig(cwd, { dashboard: false, quietInlineWhenDashboard: true });
+	writeProjectAgent(cwd, "scout");
+
+	const rendered = renderSubagentCall({ agent: "scout", task: "Inspect duplicate output." }, cwd);
+
+	assert.match(stripAnsi(rendered), /Agent scout/);
+	assert.match(stripAnsi(rendered), /Inspect duplicate output\./);
+});
+
+test("quiet dashboard renders running bg updates as working", () => {
+	const cwd = tempRuntime();
+	writeManagerConfig(cwd, { dashboard: true, quietInlineWhenDashboard: true });
+	const rendered = renderSubagentSingleInCwd(singleResult({ agent: "scout", exitCode: -1, messages: [], task: "Inspect duplicate output." }), cwd);
+
+	assert.match(stripAnsi(rendered), /Agent scout working/);
+	assert.doesNotMatch(stripAnsi(rendered), /Agent scout completed/);
 });
 
 test("session-mode rendering ignores corrupt mode values", async () => {


### PR DESCRIPTION
## Summary
- suppress single bg subagent call previews when dashboard quiet mode is enabled
- keep running bg updates labeled `working` instead of `completed`
- document the quiet inline behavior

Fixes #230

## Validation
- `bun test tests/dashboard-ux.test.ts`
- `bun test ./tests ./extensions/subagent/__tests__` (with worktree `node_modules` symlinked to the main checkout for peer deps)
- `git diff --check`
