### PR TITLE
Add Flightdeck permission migration command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 4.0.2
+
+- Flightdeck: add `vstack flightdeck migrate-permissions` to safely repair legacy run-store permissions after the vstack#227 strict-permissions upgrade. Use `--dry-run` first to review planned `0600` file and `0700` directory changes; unsafe paths such as symlinks, foreign-owned files, or group/other-writable paths are refused.
+- Flightdeck: strict run-store permission errors now point users at the migration command instead of leaving them with raw `mode=644 expected 600` failures.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,17 @@ nix run github:vanillagreencom/vstack -- add vanillagreencom/vstack
 
 That opens an interactive installer where you pick which agents, skills, hooks, and Pi extensions to bring in, and which tools to install them into.
 
+### Flightdeck upgrade note
+
+If Flightdeck reports a run-store permission error after upgrading, such as `mode=644 expected 600`, review and repair legacy permissions with:
+
+```bash
+vstack flightdeck migrate-permissions --dry-run
+vstack flightdeck migrate-permissions
+```
+
+The migration tightens Flightdeck run-store directories to `0700` and files to `0600`. It refuses symlinks, foreign-owned paths, and group/other-writable paths instead of silently masking possible tampering.
+
 ## How It Works
 
 A source repo is a package registry. vstack discovers what's there, asks which pieces you want, then writes the right files for each tool.

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1682,7 +1682,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vstack"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vstack"
-version = "4.0.1"
+version = "4.0.2"
 edition = "2024"
 description = "CLI tool for installing vstack skills and agents across AI coding harnesses"
 license = "MIT"

--- a/cli/src/commands/flightdeck.rs
+++ b/cli/src/commands/flightdeck.rs
@@ -1,0 +1,347 @@
+use anyhow::{Context, Result};
+use clap::ValueEnum;
+use std::collections::BTreeSet;
+use std::env;
+use std::path::{Path, PathBuf};
+use walkdir::WalkDir;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+pub enum PermissionScope {
+    /// Migrate the default user store at $HOME/.vstack/flightdeck/projects
+    User,
+    /// Migrate the FLIGHTDECK_RUN_STORE_ROOT override when set
+    Project,
+    /// Migrate both the user store and FLIGHTDECK_RUN_STORE_ROOT when distinct
+    All,
+}
+
+pub fn migrate_permissions(scope: PermissionScope, dry_run: bool) -> Result<()> {
+    #[cfg(unix)]
+    {
+        unix::migrate_permissions(scope, dry_run)
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (scope, dry_run);
+        anyhow::bail!("flightdeck permission migration is only supported on Unix-like systems")
+    }
+}
+
+#[cfg(unix)]
+mod unix {
+    use super::*;
+    use std::fs;
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+    const STORE_DIR_MODE: u32 = 0o700;
+    const STORE_FILE_MODE: u32 = 0o600;
+    const GROUP_OTHER_WRITE: u32 = 0o022;
+
+    #[derive(Debug, Default, PartialEq, Eq)]
+    struct MigrationReport {
+        roots: usize,
+        checked: usize,
+        changed: usize,
+        refused: Vec<String>,
+    }
+
+    pub(super) fn migrate_permissions(scope: PermissionScope, dry_run: bool) -> Result<()> {
+        let roots = migration_roots(scope)?;
+        if roots.is_empty() {
+            println!("No Flightdeck run-store roots found for scope {scope:?}.");
+            return Ok(());
+        }
+
+        let mut total = MigrationReport::default();
+        for root in roots {
+            let report = migrate_projects_dir(&root, dry_run)?;
+            total.roots += report.roots;
+            total.checked += report.checked;
+            total.changed += report.changed;
+            total.refused.extend(report.refused);
+        }
+
+        let action = if dry_run { "would change" } else { "changed" };
+        println!(
+            "Flightdeck permission migration: roots={} checked={} {action}={} refused={}",
+            total.roots,
+            total.checked,
+            total.changed,
+            total.refused.len()
+        );
+
+        if !total.refused.is_empty() {
+            eprintln!("Refused unsafe paths:");
+            for refusal in &total.refused {
+                eprintln!("  - {refusal}");
+            }
+            anyhow::bail!(
+                "Flightdeck permission migration refused {} unsafe path(s)",
+                total.refused.len()
+            );
+        }
+
+        Ok(())
+    }
+
+    fn migration_roots(scope: PermissionScope) -> Result<Vec<PathBuf>> {
+        let mut roots = Vec::new();
+        let mut seen = BTreeSet::new();
+        let include_user = matches!(scope, PermissionScope::User | PermissionScope::All);
+        let include_project = matches!(scope, PermissionScope::Project | PermissionScope::All);
+
+        if include_user {
+            let home = env::var_os("HOME")
+                .filter(|value| !value.is_empty())
+                .map(PathBuf::from)
+                .or_else(dirs::home_dir)
+                .context("HOME is not set and no home directory could be resolved")?;
+            push_existing_projects_root(&mut roots, &mut seen, home.join(".vstack/flightdeck"));
+        }
+
+        if include_project {
+            if let Some(root) =
+                env::var_os("FLIGHTDECK_RUN_STORE_ROOT").filter(|value| !value.is_empty())
+            {
+                let root = absolutize(PathBuf::from(root))?;
+                push_existing_projects_root(&mut roots, &mut seen, root);
+            } else if matches!(scope, PermissionScope::Project) {
+                println!(
+                    "FLIGHTDECK_RUN_STORE_ROOT is not set; no project-scoped run store to migrate."
+                );
+            }
+        }
+
+        Ok(roots)
+    }
+
+    fn push_existing_projects_root(
+        roots: &mut Vec<PathBuf>,
+        seen: &mut BTreeSet<PathBuf>,
+        store_root: PathBuf,
+    ) {
+        let projects = store_root.join("projects");
+        if !projects.exists() {
+            println!(
+                "Flightdeck run-store projects dir not found: {}",
+                projects.display()
+            );
+            return;
+        }
+        let key = fs::canonicalize(&projects).unwrap_or_else(|_| projects.clone());
+        if seen.insert(key) {
+            roots.push(projects);
+        }
+    }
+
+    fn absolutize(path: PathBuf) -> Result<PathBuf> {
+        if path.is_absolute() {
+            Ok(path)
+        } else {
+            Ok(env::current_dir()?.join(path))
+        }
+    }
+
+    fn migrate_projects_dir(projects: &Path, dry_run: bool) -> Result<MigrationReport> {
+        let mut report = MigrationReport {
+            roots: 1,
+            ..MigrationReport::default()
+        };
+        for entry in WalkDir::new(projects)
+            .follow_links(false)
+            .contents_first(false)
+        {
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(error) => {
+                    report.refused.push(format!(
+                        "{}: failed to walk path",
+                        error
+                            .path()
+                            .map(Path::display)
+                            .map(|p| p.to_string())
+                            .unwrap_or_else(|| "<unknown>".to_owned())
+                    ));
+                    continue;
+                }
+            };
+            report.checked += 1;
+            inspect_and_fix(entry.path(), dry_run, &mut report);
+        }
+        Ok(report)
+    }
+
+    fn inspect_and_fix(path: &Path, dry_run: bool, report: &mut MigrationReport) {
+        let metadata = match fs::symlink_metadata(path) {
+            Ok(metadata) => metadata,
+            Err(error) => {
+                report
+                    .refused
+                    .push(format!("{}: stat failed: {error}", path.display()));
+                return;
+            }
+        };
+        let mode = metadata.mode() & 0o777;
+        if metadata.file_type().is_symlink() {
+            report
+                .refused
+                .push(format!("{}: symlinks are not allowed", path.display()));
+            return;
+        }
+        let uid = current_uid();
+        if let Some(uid) = uid {
+            if metadata.uid() != uid {
+                report.refused.push(format!(
+                    "{}: owned by uid {}, not {}",
+                    path.display(),
+                    metadata.uid(),
+                    uid
+                ));
+                return;
+            }
+        }
+        if (mode & GROUP_OTHER_WRITE) != 0 {
+            report.refused.push(format!(
+                "{}: group/other write bits set (mode={mode:o})",
+                path.display()
+            ));
+            return;
+        }
+
+        let expected = if metadata.is_dir() {
+            STORE_DIR_MODE
+        } else if metadata.is_file() {
+            STORE_FILE_MODE
+        } else {
+            report.refused.push(format!(
+                "{}: expected regular file or directory",
+                path.display()
+            ));
+            return;
+        };
+
+        if mode == expected {
+            return;
+        }
+
+        if dry_run {
+            println!("would chmod {}: {mode:o}→{expected:o}", path.display());
+            report.changed += 1;
+            return;
+        }
+
+        match fs::set_permissions(path, fs::Permissions::from_mode(expected)) {
+            Ok(()) => {
+                println!("chmod {}: {mode:o}→{expected:o}", path.display());
+                report.changed += 1;
+            }
+            Err(error) => report.refused.push(format!(
+                "{}: chmod {mode:o}→{expected:o} failed: {error}",
+                path.display()
+            )),
+        }
+    }
+
+    fn current_uid() -> Option<u32> {
+        unsafe extern "C" {
+            fn getuid() -> u32;
+        }
+        Some(unsafe { getuid() })
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use std::fs::{self, File};
+        use std::os::unix::fs::PermissionsExt;
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        #[test]
+        fn dry_run_reports_without_changing_modes() {
+            let root = temp_dir("dry-run");
+            let projects = root.join("projects");
+            let run = projects.join("proj/runs/run-1");
+            fs::create_dir_all(&run).expect("dirs");
+            let state = run.join("state.json");
+            fs::write(&state, "{}").expect("state");
+            fs::set_permissions(&projects, fs::Permissions::from_mode(0o755))
+                .expect("projects perms");
+            fs::set_permissions(&state, fs::Permissions::from_mode(0o644)).expect("state perms");
+
+            let report = migrate_projects_dir(&projects, true).expect("dry run");
+
+            assert_eq!(report.changed, 5);
+            assert!(report.refused.is_empty());
+            assert_eq!(mode(&projects), 0o755);
+            assert_eq!(mode(&state), 0o644);
+            fs::remove_dir_all(root).ok();
+        }
+
+        #[test]
+        fn migrate_sets_dirs_0700_and_files_0600() {
+            let root = temp_dir("migrate");
+            let projects = root.join("projects");
+            let run = projects.join("proj/runs/run-1");
+            fs::create_dir_all(&run).expect("dirs");
+            let state = run.join("state.json");
+            fs::write(&state, "{}").expect("state");
+            for dir in [
+                &projects,
+                &projects.join("proj"),
+                &projects.join("proj/runs"),
+                &run,
+            ] {
+                fs::set_permissions(dir, fs::Permissions::from_mode(0o755)).expect("dir perms");
+            }
+            fs::set_permissions(&state, fs::Permissions::from_mode(0o644)).expect("state perms");
+
+            let report = migrate_projects_dir(&projects, false).expect("migrate");
+
+            assert_eq!(report.changed, 5);
+            assert!(report.refused.is_empty());
+            for dir in [
+                &projects,
+                &projects.join("proj"),
+                &projects.join("proj/runs"),
+                &run,
+            ] {
+                assert_eq!(mode(dir), 0o700, "{}", dir.display());
+            }
+            assert_eq!(mode(&state), 0o600);
+            fs::remove_dir_all(root).ok();
+        }
+
+        #[test]
+        fn refuses_group_writable_paths() {
+            let root = temp_dir("refuse");
+            let projects = root.join("projects");
+            fs::create_dir_all(&projects).expect("dirs");
+            let file = projects.join("state.json");
+            File::create(&file).expect("file");
+            fs::set_permissions(&file, fs::Permissions::from_mode(0o660)).expect("file perms");
+
+            let report = migrate_projects_dir(&projects, false).expect("migrate");
+
+            assert_eq!(mode(&file), 0o660);
+            assert_eq!(report.refused.len(), 1);
+            assert!(report.refused[0].contains("group/other write bits"));
+            fs::remove_dir_all(root).ok();
+        }
+
+        fn mode(path: &Path) -> u32 {
+            fs::symlink_metadata(path)
+                .expect("metadata")
+                .permissions()
+                .mode()
+                & 0o777
+        }
+
+        fn temp_dir(label: &str) -> PathBuf {
+            let nonce = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            env::temp_dir().join(format!("vstack-flightdeck-migrate-{label}-{nonce}"))
+        }
+    }
+}

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod add;
 pub mod check;
+pub mod flightdeck;
 pub mod init;
 pub mod list;
 pub mod refresh;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -222,6 +222,12 @@ enum Commands {
         scope: Option<String>,
     },
 
+    /// Flightdeck maintenance helpers.
+    Flightdeck {
+        #[command(subcommand)]
+        command: FlightdeckCommands,
+    },
+
     /// Scaffold a new agent, skill, or hook template in a vstack source repo.
     /// Run from the repo root; writes to ./agents/, ./skills/, or ./hooks/.
     Init {
@@ -229,6 +235,19 @@ enum Commands {
         /// What to scaffold: agent | skill | hook
         #[arg(long)]
         kind: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
+enum FlightdeckCommands {
+    /// Safely tighten legacy run-store permissions after the vstack#227 upgrade.
+    MigratePermissions {
+        /// Which run store to migrate: user, project (FLIGHTDECK_RUN_STORE_ROOT), or all.
+        #[arg(long, value_enum, default_value_t = commands::flightdeck::PermissionScope::All)]
+        scope: commands::flightdeck::PermissionScope,
+        /// Print planned chmod operations without changing files.
+        #[arg(long)]
+        dry_run: bool,
     },
 }
 
@@ -306,6 +325,11 @@ fn main() -> Result<()> {
             commands::verify::run(scope, &names)
         }
         Some(Commands::UpdatePi { check, scope }) => commands::update_pi::run(check, scope),
+        Some(Commands::Flightdeck { command }) => match command {
+            FlightdeckCommands::MigratePermissions { scope, dry_run } => {
+                commands::flightdeck::migrate_permissions(scope, dry_run)
+            }
+        },
         Some(Commands::Init { name, kind }) => {
             commands::init::run(name.as_deref(), kind.as_deref())
         }

--- a/skills/flightdeck/DEVELOPMENT.md
+++ b/skills/flightdeck/DEVELOPMENT.md
@@ -140,6 +140,8 @@ Each run directory contains `metadata.json`, `state.json`, `activity.jsonl`, opt
 
 `flightdeck-state run import-legacy [--state-dir <dir>]` scans `flightdeck-state-*.json.archive`, copies matching state/activity archives into durable run directories, and never deletes the legacy files. Imported run ids are deterministic from project id, session id, termination time, and archive filename so repeat imports skip existing runs. Legacy activity archives are accepted only from the same state directory with the expected basename, regular-file type, and size cap; malformed legacy state archives are skipped with diagnostics while corrupt durable project/run JSON fails loud with the path. No retention process deletes durable run directories by default.
 
+`vstack flightdeck migrate-permissions [--scope user|project|all] [--dry-run]` is the one-time post-vstack#227 repair path for legacy run stores. It walks `projects/` under `$HOME/.vstack/flightdeck` and/or `FLIGHTDECK_RUN_STORE_ROOT`, changes safe directories to `0700` and safe files to `0600`, and refuses symlinks, foreign uid ownership, group/other write bits, or non-file/non-directory paths. The strict read path must continue to fail closed; do not add auto-chmod-on-read.
+
 ## Daemon tuning (`FD_*` env vars)
 
 The background daemon (`flightdeck-daemon`) is configurable but defaults are fine for normal use. Listed for advanced setups:

--- a/skills/flightdeck/README.md
+++ b/skills/flightdeck/README.md
@@ -37,6 +37,19 @@ Requirements:
 - Plan lane: `gh` authenticated plus worktree creation configured; see [`PLAN-FILE.md`](./PLAN-FILE.md) for plan format.
 - macOS: GNU coreutils for `sha256sum` and GNU date.
 
+### Upgrade note: run-store permissions
+
+vstack#227 tightened durable run-store permissions under `~/.vstack/flightdeck/projects`. Existing installs may still have legacy `0644` files or `0755` directories and then fail with errors such as `mode=644 expected 600`.
+
+Review and repair safe legacy paths with:
+
+```bash
+vstack flightdeck migrate-permissions --dry-run
+vstack flightdeck migrate-permissions
+```
+
+The command sets directories to `0700` and files to `0600`, logs each old→new mode, and refuses symlinks, foreign-owned paths, or group/other-writable paths.
+
 ## Commands quick reference
 
 Run commands by asking your agent for `flightdeck <command>`.

--- a/skills/flightdeck/SKILL.md
+++ b/skills/flightdeck/SKILL.md
@@ -129,6 +129,8 @@ Plan file format reference: [`PLAN-FILE.md`](./PLAN-FILE.md).
 
 Durable run commands are read/write state helpers only. They do not start dashboard UI or spawn panes. `flightdeck-session start` / `attach` call `run ensure`; terminate/archive workflows call `run terminate-active` through `flightdeck-state archive`. If a start/attach path creates a fresh active run and aborts before registration, `flightdeck-session` terminates that new run while preserving reused active runs.
 
+If a strict permission error mentions `mode=644 expected 600`, tell the user to run `vstack flightdeck migrate-permissions --dry-run` and then `vstack flightdeck migrate-permissions`. Do not recommend blind `chmod -R`: directories must become `0700`, files must become `0600`, and the migration command refuses symlinks, foreign-owned paths, or group/other-writable paths.
+
 | Command | Arguments | Script | Notes |
 |---------|-----------|--------|-------|
 | `state run create` | `--project-root <path> --tmux-session <name> [--state-dir <dir>]` | `flightdeck-state run create` | Creates a durable run under `~/.vstack/flightdeck/projects/<project-id>/runs/<run-id>/`, writes `metadata.json`, `state.json`, `activity.jsonl`, and sets `active-run.json`. Honors `FLIGHTDECK_STATE_DIR` / `.env.local` unless `--state-dir` is supplied. |

--- a/skills/flightdeck/lib/flightdeck-core/src/state/run-store.ts
+++ b/skills/flightdeck/lib/flightdeck-core/src/state/run-store.ts
@@ -221,6 +221,10 @@ export function flightdeckRunStoreRoot(): string {
 // outside the intended root by way of a symlinked ancestor.
 const STORE_DIR_MODE = 0o700;
 const STORE_FILE_MODE = 0o600;
+const RUN_STORE_PERMISSION_MIGRATION_HINT =
+	"\nThis can happen after upgrading legacy Flightdeck run-store data. Review and fix safe legacy permissions with:\n" +
+	"  vstack flightdeck migrate-permissions --dry-run\n" +
+	"  vstack flightdeck migrate-permissions";
 
 function currentUidOrNull(): number | null {
 	const fn = (process as unknown as { getuid?: () => number }).getuid;
@@ -260,7 +264,7 @@ function assertStoreOwnership(stat: { uid?: number; mode: number; isFile?: () =>
 	// state.json or activity.jsonl would expose cc_channel_token,
 	// transcripts, and other sensitive payloads.
 	if (masked !== STORE_FILE_MODE) {
-		throw new Error(`invalid ${label} ${path}: mode=${masked.toString(8)} expected ${STORE_FILE_MODE.toString(8)}`);
+		throw new Error(`invalid ${label} ${path}: mode=${masked.toString(8)} expected ${STORE_FILE_MODE.toString(8)}${RUN_STORE_PERMISSION_MIGRATION_HINT}`);
 	}
 }
 

--- a/skills/flightdeck/lib/flightdeck-core/tests/parity/unified-state-location.test.ts
+++ b/skills/flightdeck/lib/flightdeck-core/tests/parity/unified-state-location.test.ts
@@ -185,6 +185,7 @@ describe("unified state location (vstack#227)", () => {
 			const tracked = runState(repo, ["tracked-entries"]);
 			expect(tracked.status).not.toBe(0);
 			expect(tracked.stderr).toMatch(/mode=644 expected 600|group\/other write/);
+			expect(tracked.stderr).toContain("vstack flightdeck migrate-permissions --dry-run");
 		} finally {
 			rmSync(repo, { force: true, recursive: true });
 		}
@@ -204,6 +205,7 @@ describe("unified state location (vstack#227)", () => {
 			const r = runState(repo, ["set", "terminated", "true"]);
 			expect(r.status).not.toBe(0);
 			expect(r.stderr).toMatch(/mode=644 expected 600|group\/other write/);
+			expect(r.stderr).toContain("vstack flightdeck migrate-permissions --dry-run");
 		} finally {
 			rmSync(repo, { force: true, recursive: true });
 		}


### PR DESCRIPTION
## Summary

- add `vstack flightdeck migrate-permissions` with `--scope user|project|all` and `--dry-run`
- safely migrates legacy Flightdeck run-store dirs to `0700` and files to `0600`, refusing symlinks, foreign-owned paths, group/other-writable paths, and non-file/dir entries
- add strict run-store error guidance pointing users at the migration command
- document the upgrade path and bump CLI to 4.0.2

Fixes #233.

## Validation

- `cd cli && cargo test`
- `cd cli && cargo test commands::flightdeck`
- `cd skills/flightdeck/lib/flightdeck-core && bun test tests/parity/unified-state-location.test.ts`
- `cd skills/flightdeck/lib/flightdeck-core && bun run typecheck`
- `cd skills/flightdeck/lib/flightdeck-core && bun test`
- manual temp run-store dry-run + migration via `cargo run -- flightdeck migrate-permissions --scope project`
