### PR TITLE
Add display-only TUI extras tab

### DIFF
--- a/cli/src/tui/install_flow.rs
+++ b/cli/src/tui/install_flow.rs
@@ -75,8 +75,9 @@ pub fn run_install_flow(
         && items.skills.is_empty()
         && items.hooks.is_empty()
         && items.pi_extensions.is_empty()
+        && items.extras.is_empty()
     {
-        eprintln!("No agents, skills, hooks, or pi-packages found.");
+        eprintln!("No agents, skills, hooks, pi-packages, or extras found.");
         return Ok(InstallFlowResult::Cancelled);
     }
 
@@ -1006,6 +1007,7 @@ fn dispatch_action_button(
             state.select.help_overlay = true;
         }
         ActionButton::BatchInstall => open_install_confirm(state),
+        ActionButton::BatchApply => open_apply_stub(state),
         ActionButton::BatchUpdate => open_update_confirm(state, false)?,
         ActionButton::BatchRemove => open_remove_confirm(state),
         ActionButton::BatchMoveToGlobal => open_move_confirm(state, true),
@@ -1019,6 +1021,10 @@ fn dispatch_action_button(
         ActionButton::InspectorInstall => {
             mark_cursor_if_unmarked(state);
             open_install_confirm(state);
+        }
+        ActionButton::InspectorApply => {
+            mark_cursor_if_unmarked(state);
+            open_apply_stub(state);
         }
         ActionButton::InspectorUpdate => {
             mark_cursor_if_unmarked(state);
@@ -1134,6 +1140,28 @@ fn unlock_orphan_deps(select: &mut TabbedSelect, graph: &HashMap<String, Vec<Str
 
 // ── Confirm dialog construction ──────────────────────────────
 
+fn open_apply_stub(state: &mut FlowState) {
+    let mut names: Vec<String> = state
+        .select
+        .marked_items()
+        .into_iter()
+        .filter(|item| item.kind == Some(crate::config::ItemKind::Extra))
+        .map(|item| item.label.clone())
+        .collect();
+    names.sort();
+    names.dedup();
+
+    if names.is_empty() {
+        state.select.flash_message = Some("No extras selected to apply.".into());
+        return;
+    }
+
+    state.select.flash_message = Some(format!(
+        "Apply not implemented yet for {} extra(s); no files changed.",
+        names.len()
+    ));
+}
+
 fn open_install_confirm(state: &mut FlowState) {
     let to_install = marked_install_items(&state.select);
 
@@ -1215,7 +1243,7 @@ fn open_install_confirm(state: &mut FlowState) {
 fn is_install_candidate(item: &SelectItem) -> bool {
     // CLI update rows live in the Updates tab and use `kind = None`.
     // The install action is package-only; CLI updates stay on `u`.
-    item.kind.is_some()
+    item.kind.is_some() && item.kind != Some(crate::config::ItemKind::Extra)
 }
 
 fn marked_install_items(select: &TabbedSelect) -> Vec<&SelectItem> {

--- a/cli/src/tui/multiselect.rs
+++ b/cli/src/tui/multiselect.rs
@@ -357,6 +357,8 @@ pub enum ActionButton {
     OpenHelp,
     // Bottom action bar (operate on marked set)
     BatchInstall,
+    /// Apply selected extras. Display-only stub until the apply pathway lands.
+    BatchApply,
     BatchUpdate,
     BatchRemove,
     /// Move selected project-only items to global.
@@ -368,6 +370,8 @@ pub enum ActionButton {
     // Inspector panel (operate on cursor item)
     InspectorMarkToggle,
     InspectorInstall,
+    /// Apply the cursor extra. Display-only stub until the apply pathway lands.
+    InspectorApply,
     InspectorUpdate,
     InspectorRemove,
     InspectorDropProject,

--- a/cli/src/tui/render.rs
+++ b/cli/src/tui/render.rs
@@ -1239,6 +1239,15 @@ impl InspectorButton {
         }
     }
 
+    fn apply() -> Self {
+        Self {
+            label: "Apply (not implemented)".into(),
+            action: ActionButton::InspectorApply,
+            bg: theme::STATUS_OK,
+            fg: theme::ON_DARK,
+        }
+    }
+
     fn update() -> Self {
         // Update matches "outdated" badge color (STATUS_WARN / Yellow).
         Self {
@@ -1295,7 +1304,9 @@ impl InspectorButton {
 fn inspector_buttons(item: &SelectItem, scope_global: bool) -> Vec<InspectorButton> {
     let mut out = vec![InspectorButton::select(item.selected)];
 
-    if item.is_duplicate() {
+    if item.kind == Some(crate::config::ItemKind::Extra) && !item.installed {
+        out.push(InspectorButton::apply());
+    } else if item.is_duplicate() {
         out.push(InspectorButton::install(scope_global, true));
         out.push(InspectorButton::drop_project());
         out.push(InspectorButton::drop_global());
@@ -1342,6 +1353,7 @@ fn draw_action_bar(frame: &mut Frame, area: Rect, select: &mut TabbedSelect) {
     // of items the verb can act on; the user picks which verb to run.
     let mut install_n = 0usize;
     let mut reinstall_n = 0usize;
+    let mut apply_n = 0usize;
     let mut update_n = 0usize;
     let mut remove_n = 0usize;
     // Move counts are direction-specific. project-only selected items can
@@ -1351,7 +1363,9 @@ fn draw_action_bar(frame: &mut Frame, area: Rect, select: &mut TabbedSelect) {
     let mut move_to_global_n = 0usize;
     let mut move_to_project_n = 0usize;
     for item in select.marked_items() {
-        if item.kind.is_some() {
+        if item.kind == Some(crate::config::ItemKind::Extra) {
+            apply_n += 1;
+        } else if item.kind.is_some() {
             if item.installed {
                 reinstall_n += 1;
             } else {
@@ -1425,6 +1439,15 @@ fn draw_action_bar(frame: &mut Frame, area: Rect, select: &mut TabbedSelect) {
         buttons.push((
             label,
             ActionButton::BatchInstall,
+            theme::ON_DARK,
+            theme::STATUS_OK,
+            true,
+        ));
+    }
+    if apply_n > 0 {
+        buttons.push((
+            format!(" Apply ({apply_n}) "),
+            ActionButton::BatchApply,
             theme::ON_DARK,
             theme::STATUS_OK,
             true,
@@ -2775,6 +2798,81 @@ mod tests {
             .iter()
             .any(|b| b.action == ActionButton::BatchInstall && b.enabled);
         assert!(install_btn, "install button should be enabled with 1 mark");
+        let rendered = buffer_text(terminal.backend().buffer());
+        assert!(
+            rendered.contains("Install project (1)"),
+            "source package marks should keep Install label: {rendered}"
+        );
+        assert!(
+            !rendered.contains("Apply (1)"),
+            "non-extra tabs must not use Apply label: {rendered}"
+        );
+    }
+
+    #[test]
+    fn extras_tab_action_bar_renders_apply_instead_of_install() {
+        let mut item = item("vanillagreen-themes", "Matched themes");
+        item.selected = true;
+        item.kind = Some(crate::config::ItemKind::Extra);
+        let mut select = TabbedSelect::new("x", vec![source_tab("Extras", vec![item])]);
+
+        let backend = TestBackend::new(140, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| draw_tabbed_select(f, &mut select))
+            .unwrap();
+
+        assert!(
+            select
+                .button_hits
+                .iter()
+                .any(|b| b.action == ActionButton::BatchApply && b.enabled),
+            "apply button should be enabled for selected extras"
+        );
+        assert!(
+            !select
+                .button_hits
+                .iter()
+                .any(|b| b.action == ActionButton::BatchInstall),
+            "extras must not surface install action"
+        );
+        let rendered = buffer_text(terminal.backend().buffer());
+        assert!(
+            rendered.contains("Apply (1)"),
+            "missing Apply label: {rendered}"
+        );
+        assert!(
+            !rendered.contains("Install project") && !rendered.contains("Install packages"),
+            "extras action bar should not render install action: {rendered}"
+        );
+    }
+
+    #[test]
+    fn extras_row_renders_description_theme_count_and_targets() {
+        let mut item = item(
+            "vanillagreen-themes",
+            "Matched Ghostty + VS Code-family themes.",
+        );
+        item.kind = Some(crate::config::ItemKind::Extra);
+        item.suffix = Some(
+            "Matched Ghostty + VS Code-family themes. · 2 themes · targets: ghostty, vscode".into(),
+        );
+        let mut select = TabbedSelect::new("x", vec![source_tab("Extras", vec![item])]);
+
+        let backend = TestBackend::new(180, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| draw_tabbed_select(f, &mut select))
+            .unwrap();
+
+        let rendered = buffer_text(terminal.backend().buffer());
+        assert!(rendered.contains("vanillagreen-themes"), "{rendered}");
+        assert!(
+            rendered.contains("Matched Ghostty + VS Code-family themes."),
+            "{rendered}"
+        );
+        assert!(rendered.contains("2 themes"), "{rendered}");
+        assert!(rendered.contains("targets: ghostty, vscode"), "{rendered}");
     }
 
     #[test]

--- a/cli/src/tui/state.rs
+++ b/cli/src/tui/state.rs
@@ -285,6 +285,38 @@ pub(super) fn build_item_tabs(
         });
     }
 
+    if !items.extras.is_empty() {
+        let items_list: Vec<SelectItem> = items
+            .extras
+            .iter()
+            .map(|extra| {
+                let name = extra.name();
+                let info = installed.get(name);
+                SelectItem {
+                    label: name.to_string(),
+                    description: extra.description().to_string(),
+                    selected: false,
+                    suffix: Some(extra_row_suffix(extra)),
+                    locked: false,
+                    installed: info.is_some(),
+                    installed_scope: info.map(|i| i.scope),
+                    outdated: info.is_some_and(|i| i.outdated),
+                    kind: Some(crate::config::ItemKind::Extra),
+                    search_haystack: String::new(),
+                }
+            })
+            .collect();
+
+        tabs.push(Tab {
+            name: "Extras".into(),
+            kind: TabKind::Source,
+            groups: vec![ItemGroup {
+                label: String::new(),
+                items: items_list,
+            }],
+        });
+    }
+
     if let Some(installed_tab) = build_installed_tab(installed) {
         tabs.push(installed_tab);
     }
@@ -361,6 +393,20 @@ pub(super) fn build_item_tabs(
     }
 
     tabs
+}
+
+fn extra_row_suffix(extra: &crate::extra::Extra) -> String {
+    let theme_count = extra.theme_pack.themes.len();
+    let theme_label = if theme_count == 1 { "theme" } else { "themes" };
+    let target_summary = if extra.theme_pack.targets.is_empty() {
+        "—".to_string()
+    } else {
+        extra.theme_pack.targets.join(", ")
+    };
+    format!(
+        "{} · {theme_count} {theme_label} · targets: {target_summary}",
+        extra.description()
+    )
 }
 
 fn kind_bucket(kind: Option<crate::config::ItemKind>) -> &'static str {
@@ -556,4 +602,74 @@ pub(super) fn build_dep_display(
     }
 
     display
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::extra::{Extra, ExtraKind, ThemePack, ThemeSpec};
+
+    fn discovered(extras: Vec<Extra>) -> crate::tui::DiscoveredItems {
+        crate::tui::DiscoveredItems {
+            agents: Vec::new(),
+            skills: Vec::new(),
+            hooks: Vec::new(),
+            pi_extensions: Vec::new(),
+            extras,
+        }
+    }
+
+    fn extra_fixture() -> Extra {
+        Extra {
+            kind: ExtraKind::ThemePack,
+            theme_pack: ThemePack {
+                name: "vanillagreen-themes".into(),
+                description: "Matched Ghostty + VS Code-family themes.".into(),
+                default_theme: "forest".into(),
+                targets: vec!["ghostty".into(), "vscode".into(), "vscodium".into()],
+                themes: vec![
+                    ThemeSpec {
+                        id: "forest".into(),
+                        display: "Forest".into(),
+                        ghostty: None,
+                        vscode: None,
+                    },
+                    ThemeSpec {
+                        id: "meadow".into(),
+                        display: "Meadow".into(),
+                        ghostty: None,
+                        vscode: None,
+                    },
+                ],
+            },
+            source_dir: std::path::PathBuf::from("/tmp/vanillagreen-themes"),
+        }
+    }
+
+    #[test]
+    fn extras_tab_hidden_when_no_extras_discovered() {
+        let items = discovered(Vec::new());
+        let tabs = build_item_tabs(&items, &HashMap::new(), &InstalledState::new(), None);
+
+        assert!(!tabs.iter().any(|tab| tab.name == "Extras"));
+    }
+
+    #[test]
+    fn extras_tab_present_and_rows_include_manifest_summary() {
+        let items = discovered(vec![extra_fixture()]);
+        let tabs = build_item_tabs(&items, &HashMap::new(), &InstalledState::new(), None);
+        let extras_tab = tabs
+            .iter()
+            .find(|tab| tab.name == "Extras")
+            .expect("extras tab should be present");
+
+        let row = &extras_tab.groups[0].items[0];
+        assert_eq!(row.label, "vanillagreen-themes");
+        assert_eq!(row.description, "Matched Ghostty + VS Code-family themes.");
+        assert_eq!(row.kind, Some(crate::config::ItemKind::Extra));
+        let suffix = row.suffix.as_deref().unwrap_or_default();
+        assert!(suffix.contains("Matched Ghostty + VS Code-family themes."));
+        assert!(suffix.contains("2 themes"));
+        assert!(suffix.contains("targets: ghostty, vscode, vscodium"));
+    }
 }


### PR DESCRIPTION
Plan file: docs/plans/vstack-extras-theme-packs-plan.md
Item id: tui-extras-tab
Plan step: 3 (non-mutating TUI Extras tab display)

## Summary
- Add display-only Extras tab to the install wizard when extras are discovered.
- Render extra name, description, theme count, and target summary.
- Use Apply action label for selected extras without invoking any applier.

## Tests
- `cd cli && cargo test`
- `cd cli && cargo build`
