### PR TITLE
Implement VS Code theme apply

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -3,6 +3,23 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,6 +112,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,12 +166,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bzip2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "cc"
+version = "1.2.62"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+dependencies = [
+ "find-msvc-tools",
+ "jobserver",
+ "libc",
+ "shlex",
 ]
 
 [[package]]
@@ -162,6 +223,16 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
 
 [[package]]
 name = "clap"
@@ -224,6 +295,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -240,6 +317,21 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
@@ -383,6 +475,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -468,6 +561,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "finl_unicode"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -478,6 +577,16 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -576,6 +685,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -606,6 +724,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -641,6 +768,16 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -785,6 +922,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -905,6 +1052,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
+dependencies = [
+ "base64ct",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+dependencies = [
+ "digest",
+ "hmac",
+ "password-hash",
+ "sha2",
+]
+
+[[package]]
 name = "pest"
 version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -998,6 +1168,12 @@ checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
  "siphasher",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "portable-atomic"
@@ -1330,6 +1506,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1339,6 +1526,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"
@@ -1370,6 +1563,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "siphasher"
@@ -1415,6 +1614,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1696,6 +1901,7 @@ dependencies = [
  "thiserror 2.0.18",
  "toml",
  "walkdir",
+ "zip",
 ]
 
 [[package]]
@@ -2109,7 +2315,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "aes",
+ "byteorder",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
+ "hmac",
+ "pbkdf2",
+ "sha1",
+ "time",
+ "zstd",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.11.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "5.0.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -24,6 +24,7 @@ regex-lite = "0.1"
 
 # Filesystem
 walkdir = "2"
+zip = "0.6"
 
 # Error handling
 anyhow = "1"

--- a/cli/src/commands/apply.rs
+++ b/cli/src/commands/apply.rs
@@ -1,13 +1,14 @@
 use crate::config;
 use crate::extra::{Extra, ExtraKind, ThemeSpec};
 use crate::ghostty_apply::{self, GhosttyPathContext, GhosttyPlatform};
+use crate::vscode_apply::VscodeEditor;
 use anyhow::{Context, Result, bail};
 use std::collections::BTreeSet;
 use std::ffi::OsString;
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Output};
 
 const GHOSTTY_TARGET: &str = "ghostty";
 const VSCODE_TARGET: &str = "vscode";
@@ -48,6 +49,7 @@ struct ApplyPlan {
 #[derive(Debug, Clone)]
 struct TargetPlan {
     name: String,
+    kind: TargetKind,
     cli_name: String,
     cli_path: Option<PathBuf>,
     config_dir: PathBuf,
@@ -57,6 +59,7 @@ struct TargetPlan {
     managed_block: Option<String>,
     json_change: Option<JsonChangePlan>,
     vsix_path: Option<PathBuf>,
+    vscode: Option<VscodeThemePlan>,
     commands: Vec<Vec<String>>,
 }
 
@@ -70,6 +73,13 @@ struct FileCopyPlan {
 struct JsonChangePlan {
     key: String,
     value: String,
+}
+
+#[derive(Debug, Clone)]
+struct VscodeThemePlan {
+    extension_root: PathBuf,
+    package_json: PathBuf,
+    theme_name: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -149,6 +159,15 @@ impl TargetKind {
     }
 }
 
+fn vscode_editor(kind: TargetKind) -> Option<VscodeEditor> {
+    match kind {
+        TargetKind::Vscode => Some(VscodeEditor::Vscode),
+        TargetKind::Vscodium => Some(VscodeEditor::Vscodium),
+        TargetKind::Cursor => Some(VscodeEditor::Cursor),
+        TargetKind::Ghostty => None,
+    }
+}
+
 pub fn run(
     extra_name: String,
     theme_id: Option<String>,
@@ -189,20 +208,16 @@ pub fn run(
 }
 
 fn apply_plan(plan: &ApplyPlan) -> Result<()> {
-    if let Some(unsupported) = plan
-        .targets
-        .iter()
-        .find(|target| target.name != GHOSTTY_TARGET)
-    {
-        bail!(
-            "target `{}` apply is not implemented yet; use --target ghostty or --dry-run",
-            unsupported.name
-        );
-    }
-
     for target in &plan.targets {
-        apply_ghostty_target(&plan.extra_name, target)?;
-        println!("Ghostty config updated. Reload Ghostty to apply the new theme.");
+        match target.kind {
+            TargetKind::Ghostty => {
+                apply_ghostty_target(&plan.extra_name, target)?;
+                println!("Ghostty config updated. Reload Ghostty to apply the new theme.");
+            }
+            TargetKind::Vscode | TargetKind::Vscodium | TargetKind::Cursor => {
+                apply_vscode_family_target(target)?;
+            }
+        }
     }
     Ok(())
 }
@@ -274,6 +289,144 @@ fn validate_ghostty_config(cli_path: &Path, config_file: &Path, backup_file: &Pa
         stdout.trim_end(),
         stderr.trim_end()
     )
+}
+
+fn apply_vscode_family_target(target: &TargetPlan) -> Result<()> {
+    let cli_path = target
+        .cli_path
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("target `{}` has no CLI path", target.name))?;
+    let vscode = target.vscode.as_ref().ok_or_else(|| {
+        anyhow::anyhow!(
+            "target `{}` has no VS Code-family package plan",
+            target.name
+        )
+    })?;
+    let vsix_path = target
+        .vsix_path
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("target `{}` has no VSIX path", target.name))?;
+
+    let cleanup = TempDirCleanup::from_child_path(vsix_path);
+    let vsix = crate::vsix::write_vsix(&vscode.extension_root, &vscode.package_json, vsix_path)
+        .with_context(|| format!("building VSIX for target `{}`", target.name))?;
+
+    run_checked_command(
+        cli_path,
+        &[
+            "--install-extension".to_string(),
+            vsix_path.display().to_string(),
+            "--force".to_string(),
+        ],
+    )
+    .with_context(|| format!("installing VSIX for target `{}`", target.name))?;
+
+    let settings_existed = target.config_file.exists();
+    let original_settings = if settings_existed {
+        fs::read_to_string(&target.config_file)
+            .with_context(|| format!("reading {}", target.config_file.display()))?
+    } else {
+        "{}\n".to_string()
+    };
+    let patched_settings =
+        crate::vscode_apply::patch_settings_text(&original_settings, &vscode.theme_name)
+            .with_context(|| format!("patching {}", target.config_file.display()))?;
+
+    if !settings_existed || patched_settings != original_settings {
+        backup_settings_file(&target.config_file, &target.backup_file, settings_existed)?;
+        if let Some(parent) = target.config_file.parent() {
+            fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
+        }
+        fs::write(&target.config_file, patched_settings)
+            .with_context(|| format!("writing {}", target.config_file.display()))?;
+    }
+
+    let listed = run_checked_command(cli_path, &["--list-extensions".to_string()])
+        .with_context(|| format!("listing extensions for target `{}`", target.name))?;
+    let stdout = String::from_utf8_lossy(&listed.stdout);
+    if !extension_list_contains(&stdout, &vsix.extension_id) {
+        bail!(
+            "target `{}` did not list installed extension `{}` after VSIX install",
+            target.name,
+            vsix.extension_id
+        );
+    }
+
+    drop(cleanup);
+    Ok(())
+}
+
+fn backup_settings_file(settings_file: &Path, backup_file: &Path, existed: bool) -> Result<()> {
+    if let Some(parent) = settings_file.parent() {
+        fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
+    }
+    if existed {
+        fs::copy(settings_file, backup_file).with_context(|| {
+            format!(
+                "backing up {} to {}",
+                settings_file.display(),
+                backup_file.display()
+            )
+        })?;
+    } else {
+        fs::write(backup_file, b"").with_context(|| {
+            format!(
+                "creating empty backup for missing settings file {} at {}",
+                settings_file.display(),
+                backup_file.display()
+            )
+        })?;
+    }
+    Ok(())
+}
+
+fn run_checked_command(program: &Path, args: &[String]) -> Result<Output> {
+    let output = Command::new(program)
+        .args(args)
+        .output()
+        .with_context(|| format!("running {}", render_command_for_program(program, args)))?;
+    if !output.status.success() {
+        bail!(
+            "command failed ({}):\nstdout:\n{}\nstderr:\n{}",
+            render_command_for_program(program, args),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    Ok(output)
+}
+
+fn render_command_for_program(program: &Path, args: &[String]) -> String {
+    let mut command = Vec::with_capacity(args.len() + 1);
+    command.push(program.display().to_string());
+    command.extend(args.iter().cloned());
+    render_command(&command)
+}
+
+fn extension_list_contains(list_output: &str, extension_id: &str) -> bool {
+    list_output
+        .lines()
+        .any(|line| line.trim().eq_ignore_ascii_case(extension_id))
+}
+
+struct TempDirCleanup {
+    path: Option<PathBuf>,
+}
+
+impl TempDirCleanup {
+    fn from_child_path(path: &Path) -> Self {
+        Self {
+            path: path.parent().map(Path::to_path_buf),
+        }
+    }
+}
+
+impl Drop for TempDirCleanup {
+    fn drop(&mut self) {
+        if let Some(path) = self.path.take() {
+            let _ = fs::remove_dir_all(path);
+        }
+    }
 }
 
 fn parse_target_list(raw: Option<&str>) -> Result<Option<Vec<String>>> {
@@ -569,6 +722,7 @@ fn build_ghostty_plan(
 
     Ok(TargetPlan {
         name: target.name.clone(),
+        kind: target.kind,
         cli_name: target.cli_name.clone(),
         cli_path: target.cli_path.clone(),
         config_dir,
@@ -578,6 +732,7 @@ fn build_ghostty_plan(
         managed_block: Some(managed_block),
         json_change: None,
         vsix_path: None,
+        vscode: None,
         commands,
     })
 }
@@ -596,12 +751,23 @@ fn build_vscode_family_plan(
         )
     })?;
 
-    let user_dir = vscode_user_dir(target.kind, env);
+    let editor = vscode_editor(target.kind).ok_or_else(|| {
+        anyhow::anyhow!("target `{}` is not a VS Code-family target", target.name)
+    })?;
+    let user_dir =
+        crate::vscode_apply::user_dir_for_current_os(editor, &env.home_dir, &env.config_dir);
     let settings_file = user_dir.join("settings.json");
     let backup_file = ghostty_apply::backup_path(&settings_file, &env.timestamp);
-    let vsix_path = env
-        .temp_dir
-        .join(format!("vstack-{}-{}.vsix", extra.name(), theme.id));
+    let vsix_dir = env.temp_dir.join(format!(
+        "vstack-{}-{}-{}-{}",
+        extra.name(),
+        theme.id,
+        target.name,
+        env.timestamp
+    ));
+    let vsix_path = vsix_dir.join(format!("{}-{}.vsix", extra.name(), theme.id));
+    let extension_root = extra.source_dir.join("vscode");
+    let package_json = extension_root.join("package.json");
     let cli_path = target
         .cli_path
         .as_ref()
@@ -621,6 +787,7 @@ fn build_vscode_family_plan(
 
     Ok(TargetPlan {
         name: target.name.clone(),
+        kind: target.kind,
         cli_name: target.cli_name.clone(),
         cli_path: Some(cli_path.clone()),
         config_dir: user_dir,
@@ -633,6 +800,11 @@ fn build_vscode_family_plan(
             value: vscode.theme_name.clone(),
         }),
         vsix_path: Some(vsix_path),
+        vscode: Some(VscodeThemePlan {
+            extension_root,
+            package_json,
+            theme_name: vscode.theme_name.clone(),
+        }),
         commands,
     })
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -18,6 +18,8 @@ mod skill;
 #[cfg(test)]
 mod test_util;
 mod tui;
+mod vscode_apply;
+mod vsix;
 
 use anyhow::Result;
 use clap::{Parser, Subcommand};

--- a/cli/src/vscode_apply.rs
+++ b/cli/src/vscode_apply.rs
@@ -1,0 +1,491 @@
+use anyhow::{Context, Result, bail};
+use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+pub const COLOR_THEME_KEY: &str = "workbench.colorTheme";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VscodeEditor {
+    Vscode,
+    Vscodium,
+    Cursor,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HostOs {
+    Linux,
+    Macos,
+}
+
+impl VscodeEditor {
+    fn app_dir(self) -> &'static str {
+        match self {
+            Self::Vscode => "Code",
+            Self::Vscodium => "VSCodium",
+            Self::Cursor => "Cursor",
+        }
+    }
+}
+
+pub fn current_host_os() -> HostOs {
+    if cfg!(target_os = "macos") {
+        HostOs::Macos
+    } else {
+        HostOs::Linux
+    }
+}
+
+pub fn user_dir_for_os(
+    editor: VscodeEditor,
+    home_dir: &Path,
+    config_dir: &Path,
+    host_os: HostOs,
+) -> PathBuf {
+    match host_os {
+        HostOs::Linux => config_dir.join(editor.app_dir()).join("User"),
+        HostOs::Macos => home_dir
+            .join("Library")
+            .join("Application Support")
+            .join(editor.app_dir())
+            .join("User"),
+    }
+}
+
+pub fn user_dir_for_current_os(
+    editor: VscodeEditor,
+    home_dir: &Path,
+    config_dir: &Path,
+) -> PathBuf {
+    user_dir_for_os(editor, home_dir, config_dir, current_host_os())
+}
+
+pub fn settings_path_for_os(
+    editor: VscodeEditor,
+    home_dir: &Path,
+    config_dir: &Path,
+    host_os: HostOs,
+) -> PathBuf {
+    user_dir_for_os(editor, home_dir, config_dir, host_os).join("settings.json")
+}
+
+pub fn patch_settings_file(path: &Path, theme_name: &str) -> Result<bool> {
+    let original = if path.exists() {
+        fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?
+    } else {
+        "{}\n".to_string()
+    };
+    let patched = patch_settings_text(&original, theme_name)
+        .with_context(|| format!("patching {}", path.display()))?;
+    if patched == original && path.exists() {
+        return Ok(false);
+    }
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
+    }
+    fs::write(path, patched).with_context(|| format!("writing {}", path.display()))?;
+    Ok(true)
+}
+
+pub fn patch_settings_text(original: &str, theme_name: &str) -> Result<String> {
+    let text = if original.trim().is_empty() {
+        "{}\n"
+    } else {
+        original
+    };
+
+    if has_comment_outside_string(text) {
+        bail!(
+            "settings.json appears to be JSONC with comments; vstack will not rewrite it because comment preservation is not implemented"
+        );
+    }
+
+    let parsed: Value = serde_json::from_str(text).context(
+        "settings.json must be valid JSON; JSONC/trailing commas are not rewritten to avoid destructive formatting loss",
+    )?;
+    let object = parsed
+        .as_object()
+        .ok_or_else(|| anyhow::anyhow!("settings.json root must be a JSON object"))?;
+
+    let replacement = serde_json::to_string(theme_name)?;
+    if let Some((start, end)) = find_top_level_key_value_span(text, COLOR_THEME_KEY)? {
+        if text[start..end].trim() == replacement {
+            return Ok(text.to_string());
+        }
+        let mut patched = text.to_string();
+        patched.replace_range(start..end, &replacement);
+        return Ok(patched);
+    }
+
+    insert_color_theme_key(text, object.is_empty(), &replacement)
+}
+
+fn insert_color_theme_key(text: &str, object_is_empty: bool, replacement: &str) -> Result<String> {
+    let (open, close) = root_object_bounds(text)?;
+    let newline = if text.contains("\r\n") { "\r\n" } else { "\n" };
+    let closing_indent = line_indent_at(text, close);
+    let key_indent = first_property_indent(text).unwrap_or_else(|| format!("{closing_indent}  "));
+    let quoted_key = serde_json::to_string(COLOR_THEME_KEY)?;
+
+    if object_is_empty {
+        let mut patched = String::new();
+        patched.push_str(&text[..open + 1]);
+        patched.push_str(newline);
+        patched.push_str(&key_indent);
+        patched.push_str(&quoted_key);
+        patched.push_str(": ");
+        patched.push_str(replacement);
+        patched.push_str(newline);
+        patched.push_str(&closing_indent);
+        patched.push_str(&text[close..]);
+        return Ok(patched);
+    }
+
+    let mut insert_pos = close;
+    while insert_pos > open + 1 && is_json_ws(text.as_bytes()[insert_pos - 1]) {
+        insert_pos -= 1;
+    }
+
+    let mut patched = String::new();
+    patched.push_str(&text[..insert_pos]);
+    patched.push(',');
+    patched.push_str(newline);
+    patched.push_str(&key_indent);
+    patched.push_str(&quoted_key);
+    patched.push_str(": ");
+    patched.push_str(replacement);
+    patched.push_str(newline);
+    patched.push_str(&closing_indent);
+    patched.push_str(&text[close..]);
+    Ok(patched)
+}
+
+fn find_top_level_key_value_span(text: &str, key: &str) -> Result<Option<(usize, usize)>> {
+    let bytes = text.as_bytes();
+    let mut index = skip_ws(bytes, 0);
+    if index >= bytes.len() || bytes[index] != b'{' {
+        bail!("settings.json root must be a JSON object");
+    }
+    index += 1;
+
+    loop {
+        index = skip_ws(bytes, index);
+        if index >= bytes.len() {
+            bail!("unexpected end while scanning settings.json object");
+        }
+        if bytes[index] == b'}' {
+            return Ok(None);
+        }
+        if bytes[index] != b'"' {
+            bail!("expected JSON object key while scanning settings.json");
+        }
+
+        let key_end = string_span_end(text, index)?;
+        let decoded_key: String = serde_json::from_str(&text[index..key_end])?;
+        index = skip_ws(bytes, key_end);
+        if index >= bytes.len() || bytes[index] != b':' {
+            bail!("expected ':' after JSON object key while scanning settings.json");
+        }
+        index += 1;
+        let value_start = skip_ws(bytes, index);
+        let value_end = json_value_end(text, value_start)?;
+        if decoded_key == key {
+            return Ok(Some((value_start, value_end)));
+        }
+
+        index = skip_ws(bytes, value_end);
+        if index >= bytes.len() {
+            bail!("unexpected end after JSON object value while scanning settings.json");
+        }
+        match bytes[index] {
+            b',' => index += 1,
+            b'}' => return Ok(None),
+            _ => bail!("expected ',' or '}}' after JSON object value while scanning settings.json"),
+        }
+    }
+}
+
+fn json_value_end(text: &str, start: usize) -> Result<usize> {
+    let bytes = text.as_bytes();
+    let mut index = start;
+    let mut depth = 0usize;
+
+    while index < bytes.len() {
+        match bytes[index] {
+            b'"' => index = string_span_end(text, index)?,
+            b'{' | b'[' => {
+                depth += 1;
+                index += 1;
+            }
+            b'}' if depth == 0 => return Ok(trim_json_ws_end(bytes, start, index)),
+            b',' if depth == 0 => return Ok(trim_json_ws_end(bytes, start, index)),
+            b'}' | b']' => {
+                if depth == 0 {
+                    bail!("unexpected closing delimiter while scanning JSON value");
+                }
+                depth -= 1;
+                index += 1;
+            }
+            _ => index += 1,
+        }
+    }
+
+    bail!("unexpected end while scanning JSON value")
+}
+
+fn root_object_bounds(text: &str) -> Result<(usize, usize)> {
+    let bytes = text.as_bytes();
+    let open = skip_ws(bytes, 0);
+    if open >= bytes.len() || bytes[open] != b'{' {
+        bail!("settings.json root must be a JSON object");
+    }
+
+    let mut index = open;
+    let mut depth = 0usize;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'"' => index = string_span_end(text, index)?,
+            b'{' => {
+                depth += 1;
+                index += 1;
+            }
+            b'}' => {
+                depth -= 1;
+                if depth == 0 {
+                    let tail = skip_ws(bytes, index + 1);
+                    if tail != bytes.len() {
+                        bail!("settings.json has non-whitespace content after root object");
+                    }
+                    return Ok((open, index));
+                }
+                index += 1;
+            }
+            _ => index += 1,
+        }
+    }
+
+    bail!("settings.json root object is not closed")
+}
+
+fn first_property_indent(text: &str) -> Option<String> {
+    let bytes = text.as_bytes();
+    let mut index = skip_ws(bytes, 0);
+    if index >= bytes.len() || bytes[index] != b'{' {
+        return None;
+    }
+    index = skip_ws(bytes, index + 1);
+    if index >= bytes.len() || bytes[index] != b'"' {
+        return None;
+    }
+    let line_start = text[..index].rfind('\n').map(|pos| pos + 1)?;
+    if text[line_start..index]
+        .bytes()
+        .all(|byte| matches!(byte, b' ' | b'\t'))
+    {
+        Some(text[line_start..index].to_string())
+    } else {
+        None
+    }
+}
+
+fn line_indent_at(text: &str, index: usize) -> String {
+    let line_start = text[..index].rfind('\n').map(|pos| pos + 1).unwrap_or(0);
+    let mut end = line_start;
+    let bytes = text.as_bytes();
+    while end < index && matches!(bytes[end], b' ' | b'\t') {
+        end += 1;
+    }
+    text[line_start..end].to_string()
+}
+
+fn has_comment_outside_string(text: &str) -> bool {
+    let bytes = text.as_bytes();
+    let mut index = 0usize;
+    let mut in_string = false;
+    let mut escape = false;
+    while index < bytes.len() {
+        let byte = bytes[index];
+        if in_string {
+            if escape {
+                escape = false;
+            } else if byte == b'\\' {
+                escape = true;
+            } else if byte == b'"' {
+                in_string = false;
+            }
+            index += 1;
+            continue;
+        }
+
+        if byte == b'"' {
+            in_string = true;
+            index += 1;
+            continue;
+        }
+        if byte == b'/' && index + 1 < bytes.len() {
+            let next = bytes[index + 1];
+            if next == b'/' || next == b'*' {
+                return true;
+            }
+        }
+        index += 1;
+    }
+    false
+}
+
+fn string_span_end(text: &str, start: usize) -> Result<usize> {
+    let bytes = text.as_bytes();
+    if start >= bytes.len() || bytes[start] != b'"' {
+        bail!("expected JSON string");
+    }
+    let mut index = start + 1;
+    let mut escape = false;
+    while index < bytes.len() {
+        let byte = bytes[index];
+        if escape {
+            escape = false;
+        } else if byte == b'\\' {
+            escape = true;
+        } else if byte == b'"' {
+            return Ok(index + 1);
+        }
+        index += 1;
+    }
+    bail!("unterminated JSON string")
+}
+
+fn skip_ws(bytes: &[u8], mut index: usize) -> usize {
+    while index < bytes.len() && is_json_ws(bytes[index]) {
+        index += 1;
+    }
+    index
+}
+
+fn trim_json_ws_end(bytes: &[u8], start: usize, mut end: usize) -> usize {
+    while end > start && is_json_ws(bytes[end - 1]) {
+        end -= 1;
+    }
+    end
+}
+
+fn is_json_ws(byte: u8) -> bool {
+    matches!(byte, b' ' | b'\n' | b'\r' | b'\t')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn sandbox(label: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "vstack_vscode_apply_{label}_{}_{}",
+            std::process::id(),
+            unique
+        ));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn settings_path_resolver_returns_linux_paths() {
+        let home = Path::new("/home/alice");
+        let config = Path::new("/home/alice/.config");
+
+        assert_eq!(
+            settings_path_for_os(VscodeEditor::Vscode, home, config, HostOs::Linux),
+            PathBuf::from("/home/alice/.config/Code/User/settings.json")
+        );
+        assert_eq!(
+            settings_path_for_os(VscodeEditor::Vscodium, home, config, HostOs::Linux),
+            PathBuf::from("/home/alice/.config/VSCodium/User/settings.json")
+        );
+        assert_eq!(
+            settings_path_for_os(VscodeEditor::Cursor, home, config, HostOs::Linux),
+            PathBuf::from("/home/alice/.config/Cursor/User/settings.json")
+        );
+    }
+
+    #[test]
+    fn settings_path_resolver_returns_macos_paths() {
+        let home = Path::new("/Users/alice");
+        let config = Path::new("/Users/alice/.config");
+
+        assert_eq!(
+            settings_path_for_os(VscodeEditor::Vscode, home, config, HostOs::Macos),
+            PathBuf::from("/Users/alice/Library/Application Support/Code/User/settings.json")
+        );
+        assert_eq!(
+            settings_path_for_os(VscodeEditor::Vscodium, home, config, HostOs::Macos),
+            PathBuf::from("/Users/alice/Library/Application Support/VSCodium/User/settings.json")
+        );
+        assert_eq!(
+            settings_path_for_os(VscodeEditor::Cursor, home, config, HostOs::Macos),
+            PathBuf::from("/Users/alice/Library/Application Support/Cursor/User/settings.json")
+        );
+    }
+
+    #[test]
+    fn settings_patcher_changes_only_workbench_color_theme_value() {
+        let input = r#"{
+  "editor.fontFamily": "JetBrains Mono",
+  "workbench.colorTheme": "Old Theme",
+  "terminal.integrated.fontFamily": "CommitMono",
+  "nested": { "keep": true },
+  "array": [1, 2, 3]
+}
+"#;
+
+        let patched = patch_settings_text(input, "Ghibli Serene Nature").unwrap();
+        let mut expected: Value = serde_json::from_str(input).unwrap();
+        expected[COLOR_THEME_KEY] = Value::String("Ghibli Serene Nature".to_string());
+        let actual: Value = serde_json::from_str(&patched).unwrap();
+
+        assert_eq!(actual, expected);
+        assert!(patched.contains("\"workbench.colorTheme\": \"Ghibli Serene Nature\""));
+        assert!(patched.contains("\"editor.fontFamily\": \"JetBrains Mono\""));
+        assert!(patched.contains("\"terminal.integrated.fontFamily\": \"CommitMono\""));
+        assert!(patched.contains("\"nested\": { \"keep\": true }"));
+        assert!(patched.contains("\"array\": [1, 2, 3]"));
+        assert!(!patched.contains("Old Theme"));
+    }
+
+    #[test]
+    fn settings_patcher_inserts_color_theme_when_missing() {
+        let input = r#"{
+  "editor.fontFamily": "JetBrains Mono"
+}
+"#;
+
+        let patched = patch_settings_text(input, "Forest").unwrap();
+        let parsed: Value = serde_json::from_str(&patched).unwrap();
+
+        assert_eq!(parsed["editor.fontFamily"], "JetBrains Mono");
+        assert_eq!(parsed[COLOR_THEME_KEY], "Forest");
+        assert!(patched.contains("\"editor.fontFamily\": \"JetBrains Mono\","));
+    }
+
+    #[test]
+    fn settings_patcher_on_jsonc_comments_fails_without_writing() {
+        let root = sandbox("jsonc");
+        let settings = root.join("settings.json");
+        let original = r#"{
+  // keep this comment
+  "editor.fontFamily": "JetBrains Mono"
+}
+"#;
+        fs::write(&settings, original).unwrap();
+
+        let err = patch_settings_file(&settings, "Forest").unwrap_err();
+        let msg = format!("{err:#}");
+
+        assert!(msg.contains("JSONC with comments"), "{msg}");
+        assert_eq!(fs::read_to_string(&settings).unwrap(), original);
+        let _ = fs::remove_dir_all(root);
+    }
+}

--- a/cli/src/vsix.rs
+++ b/cli/src/vsix.rs
@@ -1,0 +1,501 @@
+use anyhow::{Context, Result, bail};
+use serde_json::Value;
+use std::collections::BTreeSet;
+use std::fs::File;
+use std::io::{Read, Write};
+use std::path::{Component, Path, PathBuf};
+use zip::CompressionMethod;
+use zip::write::FileOptions;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VsixInfo {
+    pub extension_id: String,
+    pub package_name: String,
+    pub publisher: String,
+    pub version: String,
+    pub included_theme_files: Vec<PathBuf>,
+}
+
+#[derive(Debug, Clone)]
+struct PackageInfo {
+    name: String,
+    publisher: String,
+    version: String,
+    display_name: String,
+    description: String,
+    categories: Vec<String>,
+    vscode_engine: Option<String>,
+    theme_paths: Vec<PathBuf>,
+}
+
+impl PackageInfo {
+    fn extension_id(&self) -> String {
+        format!("{}.{}", self.publisher, self.name)
+    }
+}
+
+pub fn write_vsix(
+    extension_root: &Path,
+    package_json_path: &Path,
+    output_path: &Path,
+) -> Result<VsixInfo> {
+    let package_json = std::fs::read_to_string(package_json_path).with_context(|| {
+        format!(
+            "reading VS Code package manifest {}",
+            package_json_path.display()
+        )
+    })?;
+    let package = parse_package_info(&package_json).with_context(|| {
+        format!(
+            "parsing VS Code package manifest {}",
+            package_json_path.display()
+        )
+    })?;
+
+    if let Some(parent) = output_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating VSIX output directory {}", parent.display()))?;
+    }
+
+    let file = File::create(output_path)
+        .with_context(|| format!("creating VSIX {}", output_path.display()))?;
+    let mut zip = zip::ZipWriter::new(file);
+    let options = FileOptions::default()
+        .compression_method(CompressionMethod::Stored)
+        .unix_permissions(0o644);
+
+    write_zip_entry(
+        &mut zip,
+        "[Content_Types].xml",
+        content_types_xml().as_bytes(),
+        options,
+    )?;
+    write_zip_entry(
+        &mut zip,
+        "extension.vsixmanifest",
+        vsix_manifest_xml(&package).as_bytes(),
+        options,
+    )?;
+    write_zip_entry(
+        &mut zip,
+        "extension/package.json",
+        package_json.as_bytes(),
+        options,
+    )?;
+
+    let mut seen_theme_basenames = BTreeSet::new();
+    let mut included_theme_files = Vec::new();
+    for theme_path in &package.theme_paths {
+        let source = extension_root.join(theme_path);
+        let basename = theme_path.file_name().ok_or_else(|| {
+            anyhow::anyhow!(
+                "theme path `{}` in {} has no file name",
+                theme_path.display(),
+                package_json_path.display()
+            )
+        })?;
+        let basename_string = basename.to_string_lossy().to_string();
+        if !seen_theme_basenames.insert(basename_string.clone()) {
+            bail!(
+                "multiple VS Code themes in {} resolve to basename `{basename_string}`; VSIX writer keeps themes under extension/themes/",
+                package_json_path.display()
+            );
+        }
+
+        let mut contents = Vec::new();
+        File::open(&source)
+            .with_context(|| format!("opening VS Code theme file {}", source.display()))?
+            .read_to_end(&mut contents)
+            .with_context(|| format!("reading VS Code theme file {}", source.display()))?;
+        let entry = format!("extension/themes/{basename_string}");
+        write_zip_entry(&mut zip, &entry, &contents, options)?;
+        included_theme_files.push(source);
+    }
+
+    zip.finish()
+        .with_context(|| format!("finalizing VSIX {}", output_path.display()))?;
+
+    Ok(VsixInfo {
+        extension_id: package.extension_id(),
+        package_name: package.name,
+        publisher: package.publisher,
+        version: package.version,
+        included_theme_files,
+    })
+}
+
+fn write_zip_entry<W: Write + std::io::Seek>(
+    zip: &mut zip::ZipWriter<W>,
+    name: &str,
+    contents: &[u8],
+    options: FileOptions,
+) -> Result<()> {
+    zip.start_file(name, options)
+        .with_context(|| format!("starting VSIX entry {name}"))?;
+    zip.write_all(contents)
+        .with_context(|| format!("writing VSIX entry {name}"))?;
+    Ok(())
+}
+
+fn parse_package_info(package_json: &str) -> Result<PackageInfo> {
+    let value: Value =
+        serde_json::from_str(package_json).context("package.json is not valid JSON")?;
+    let name = required_string(&value, "name")?.to_string();
+    let publisher = required_string(&value, "publisher")?.to_string();
+    let version = required_string(&value, "version")?.to_string();
+    let display_name = optional_string(&value, "displayName")
+        .unwrap_or(&name)
+        .to_string();
+    let description = optional_string(&value, "description")
+        .unwrap_or("")
+        .to_string();
+    let vscode_engine = value
+        .get("engines")
+        .and_then(|engines| engines.get("vscode"))
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let categories = value
+        .get("categories")
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::to_string)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    let themes = value
+        .get("contributes")
+        .and_then(|contributes| contributes.get("themes"))
+        .and_then(Value::as_array)
+        .ok_or_else(|| anyhow::anyhow!("package.json must contain contributes.themes[]"))?;
+    if themes.is_empty() {
+        bail!("package.json contributes.themes[] must contain at least one theme");
+    }
+
+    let mut theme_paths = Vec::new();
+    for theme in themes {
+        let raw = theme.get("path").and_then(Value::as_str).ok_or_else(|| {
+            anyhow::anyhow!("each contributes.themes[] item must contain a string path")
+        })?;
+        theme_paths.push(validate_relative_manifest_path(
+            raw,
+            "contributes.themes[].path",
+        )?);
+    }
+
+    Ok(PackageInfo {
+        name,
+        publisher,
+        version,
+        display_name,
+        description,
+        categories,
+        vscode_engine,
+        theme_paths,
+    })
+}
+
+fn required_string<'a>(value: &'a Value, key: &str) -> Result<&'a str> {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| anyhow::anyhow!("package.json must contain a non-empty string `{key}`"))
+}
+
+fn optional_string<'a>(value: &'a Value, key: &str) -> Option<&'a str> {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+}
+
+fn validate_relative_manifest_path(raw: &str, field: &str) -> Result<PathBuf> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        bail!("{field} must not be empty");
+    }
+    let without_dot = trimmed.strip_prefix("./").unwrap_or(trimmed);
+    let path = Path::new(without_dot);
+    if path.is_absolute() {
+        bail!("{field} `{raw}` must be relative");
+    }
+    for component in path.components() {
+        match component {
+            Component::ParentDir => bail!("{field} `{raw}` must not contain `..`"),
+            Component::Prefix(_) | Component::RootDir => bail!("{field} `{raw}` must be relative"),
+            Component::CurDir | Component::Normal(_) => {}
+        }
+    }
+    Ok(path.to_path_buf())
+}
+
+fn content_types_xml() -> &'static str {
+    r#"<?xml version="1.0" encoding="utf-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="json" ContentType="application/json" />
+  <Default Extension="vsixmanifest" ContentType="text/xml" />
+</Types>
+"#
+}
+
+fn vsix_manifest_xml(package: &PackageInfo) -> String {
+    let categories = if package.categories.is_empty() {
+        "Themes".to_string()
+    } else {
+        package.categories.join(",")
+    };
+    let engine = package.vscode_engine.as_deref().unwrap_or("*");
+    format!(
+        r#"<?xml version="1.0" encoding="utf-8"?>
+<PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011">
+  <Metadata>
+    <Identity Language="en-US" Id="{}" Version="{}" Publisher="{}" />
+    <DisplayName>{}</DisplayName>
+    <Description xml:space="preserve">{}</Description>
+    <Categories>{}</Categories>
+    <Tags>theme,color-theme</Tags>
+    <Properties>
+      <Property Id="Microsoft.VisualStudio.Code.Engine" Value="{}" />
+    </Properties>
+  </Metadata>
+  <Installation>
+    <InstallationTarget Id="Microsoft.VisualStudio.Code" />
+  </Installation>
+  <Dependencies />
+  <Assets>
+    <Asset Type="Microsoft.VisualStudio.Code.Manifest" Path="extension/package.json" Addressable="true" />
+  </Assets>
+</PackageManifest>
+"#,
+        xml_escape(&package.name),
+        xml_escape(&package.version),
+        xml_escape(&package.publisher),
+        xml_escape(&package.display_name),
+        xml_escape(&package.description),
+        xml_escape(&categories),
+        xml_escape(engine),
+    )
+}
+
+fn xml_escape(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&apos;")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::io::Read;
+    use std::process::Command;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn sandbox(label: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "vstack_vsix_{label}_{}_{}",
+            std::process::id(),
+            unique
+        ));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn write_fixture(root: &Path) -> (PathBuf, PathBuf) {
+        let extension_root = root.join("vscode");
+        fs::create_dir_all(extension_root.join("themes")).unwrap();
+        let package_json = extension_root.join("package.json");
+        fs::write(
+            &package_json,
+            r#"{
+  "name": "vanillagreen-themes",
+  "displayName": "Vanillagreen Themes",
+  "description": "Matched themes & colors.",
+  "version": "0.1.0",
+  "publisher": "vanillagreen",
+  "engines": { "vscode": "^1.85.0" },
+  "categories": ["Themes"],
+  "contributes": {
+    "themes": [
+      { "label": "Forest", "uiTheme": "vs", "path": "./themes/forest-color-theme.json" }
+    ]
+  }
+}
+"#,
+        )
+        .unwrap();
+        fs::write(
+            extension_root.join("themes/forest-color-theme.json"),
+            r#"{"name":"Forest","type":"light","colors":{}}"#,
+        )
+        .unwrap();
+        (extension_root, package_json)
+    }
+
+    fn find_cli(name: &str) -> Option<PathBuf> {
+        std::env::split_paths(&std::env::var_os("PATH")?)
+            .map(|dir| dir.join(name))
+            .find(|candidate| candidate.is_file())
+    }
+
+    #[test]
+    fn vsix_writer_produces_required_entries_and_manifest() {
+        let root = sandbox("entries");
+        let (extension_root, package_json) = write_fixture(&root);
+        let vsix_path = root.join("out/theme.vsix");
+
+        let info = write_vsix(&extension_root, &package_json, &vsix_path).unwrap();
+
+        assert_eq!(info.extension_id, "vanillagreen.vanillagreen-themes");
+        assert_eq!(info.included_theme_files.len(), 1);
+
+        let file = File::open(&vsix_path).unwrap();
+        let mut archive = zip::ZipArchive::new(file).unwrap();
+        let mut names = Vec::new();
+        for index in 0..archive.len() {
+            names.push(archive.by_index(index).unwrap().name().to_string());
+        }
+        names.sort();
+        assert_eq!(
+            names,
+            vec![
+                "[Content_Types].xml",
+                "extension.vsixmanifest",
+                "extension/package.json",
+                "extension/themes/forest-color-theme.json",
+            ]
+        );
+
+        let mut manifest = String::new();
+        archive
+            .by_name("extension.vsixmanifest")
+            .unwrap()
+            .read_to_string(&mut manifest)
+            .unwrap();
+        assert!(manifest.contains("<PackageManifest"), "{manifest}");
+        assert!(
+            manifest.contains("Id=\"vanillagreen-themes\""),
+            "{manifest}"
+        );
+        assert!(
+            manifest.contains("Publisher=\"vanillagreen\""),
+            "{manifest}"
+        );
+        assert!(
+            manifest.contains("Microsoft.VisualStudio.Code.Manifest"),
+            "{manifest}"
+        );
+        assert!(manifest.ends_with("</PackageManifest>\n"), "{manifest}");
+
+        let mut package = String::new();
+        archive
+            .by_name("extension/package.json")
+            .unwrap()
+            .read_to_string(&mut package)
+            .unwrap();
+        let parsed: Value = serde_json::from_str(&package).unwrap();
+        assert_eq!(parsed["name"], "vanillagreen-themes");
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn vsix_writer_rejects_escaping_theme_path() {
+        let root = sandbox("escape");
+        let extension_root = root.join("vscode");
+        fs::create_dir_all(&extension_root).unwrap();
+        let package_json = extension_root.join("package.json");
+        fs::write(
+            &package_json,
+            r#"{
+  "name": "bad",
+  "version": "0.1.0",
+  "publisher": "example",
+  "contributes": { "themes": [{ "path": "../bad.json" }] }
+}
+"#,
+        )
+        .unwrap();
+
+        let err = write_vsix(&extension_root, &package_json, &root.join("bad.vsix")).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("must not contain `..`"), "{msg}");
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn detected_editor_clis_install_vsix_in_sandbox() {
+        let editors = ["code", "codium", "cursor"];
+        let available: Vec<(&str, PathBuf)> = editors
+            .iter()
+            .filter_map(|name| find_cli(name).map(|path| (*name, path)))
+            .collect();
+        if available.is_empty() {
+            eprintln!("skipping VS Code-family VSIX install integration test: no editor CLI found");
+            return;
+        }
+
+        for (name, cli) in available {
+            let root = sandbox(&format!("install_{name}"));
+            let (extension_root, package_json) = write_fixture(&root);
+            let vsix_path = root.join("theme.vsix");
+            let info = write_vsix(&extension_root, &package_json, &vsix_path).unwrap();
+            let user_data = root.join("user-data");
+            let extensions_dir = root.join("extensions");
+
+            let install = Command::new(&cli)
+                .arg("--user-data-dir")
+                .arg(&user_data)
+                .arg("--extensions-dir")
+                .arg(&extensions_dir)
+                .arg("--install-extension")
+                .arg(&vsix_path)
+                .arg("--force")
+                .output()
+                .unwrap_or_else(|err| panic!("failed to run {name}: {err}"));
+            assert!(
+                install.status.success(),
+                "{name} install failed\nstdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&install.stdout),
+                String::from_utf8_lossy(&install.stderr)
+            );
+
+            let listed = Command::new(&cli)
+                .arg("--user-data-dir")
+                .arg(&user_data)
+                .arg("--extensions-dir")
+                .arg(&extensions_dir)
+                .arg("--list-extensions")
+                .output()
+                .unwrap_or_else(|err| panic!("failed to list {name} extensions: {err}"));
+            assert!(
+                listed.status.success(),
+                "{name} list failed\nstdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&listed.stdout),
+                String::from_utf8_lossy(&listed.stderr)
+            );
+            let stdout = String::from_utf8_lossy(&listed.stdout);
+            assert!(
+                stdout
+                    .lines()
+                    .any(|line| line.trim().eq_ignore_ascii_case(&info.extension_id)),
+                "{name} did not list {} in:\n{stdout}",
+                info.extension_id
+            );
+
+            let _ = fs::remove_dir_all(root);
+        }
+    }
+}


### PR DESCRIPTION
Plan file: docs/plans/vstack-extras-theme-packs-plan.md
Item id: vscode-applier
Plan step: 6 (VSIX builder + VS Code-family applier)

Summary:
- Adds a small Rust VSIX writer for bundled VS Code theme packages.
- Implements VS Code, VSCodium, and Cursor apply flow behind `vstack apply`.
- Backs up `settings.json`, patches only `workbench.colorTheme`, rejects JSONC comments instead of stripping them, and validates extension install via `--list-extensions`.

Validation:
- `cd cli && cargo test`
- `cd cli && cargo build`
- Manual local apply verified for detected `code`, `codium`, and `cursor`; live settings restored afterward.
