### PR TITLE
extras: tmux readability + reliable live-reload (theme pack v1.0.4)

### DIFF
--- a/cli/src/commands/apply.rs
+++ b/cli/src/commands/apply.rs
@@ -1032,6 +1032,26 @@ fn reload_running_tmux_servers(cli_path: &Path, config_file: &Path) {
     }
 
     for socket in sockets {
+        // Clear `window-style` first so a stale fg from a prior theme cannot
+        // outlive the re-source (the new theme conf deliberately omits a
+        // `window-style` set to keep inactive panes readable on dark themes).
+        let unset = Command::new(cli_path)
+            .arg("-S")
+            .arg(&socket)
+            .arg("set")
+            .arg("-gu")
+            .arg("window-style")
+            .output();
+        if let Ok(out) = &unset
+            && !out.status.success()
+        {
+            eprintln!(
+                "warning: failed to unset window-style on tmux server at {} ({})",
+                socket.display(),
+                String::from_utf8_lossy(&out.stderr).trim_end()
+            );
+        }
+
         let output = Command::new(cli_path)
             .arg("-S")
             .arg(&socket)

--- a/extras/vanillagreen-themes/tmux/themes/anthropic-dark.conf
+++ b/extras/vanillagreen-themes/tmux/themes/anthropic-dark.conf
@@ -1,13 +1,13 @@
 # Anthropic Dark -- vanillagreen tmux theme (colors only).
-# Source-this from your tmux.conf to apply just the palette;
-# `vstack apply` auto-injects a `source-file` line into your tmux.conf.
+# `set -gu window-style` first nukes any stale window-style override left
+# behind by a prior theme (otherwise inactive panes flash correct then revert).
 
+set -gu window-style
 set -g status-style "bg=#141413,fg=#3D3D3A"
 set -g message-style "bg=#D8A76D,fg=#141413"
 set -g message-command-style "bg=#D8A76D,fg=#141413"
 set -g pane-border-style "fg=#3D3D3A"
 set -g pane-active-border-style "fg=#D8A76D"
-set -g window-style "fg=#3D3D3A"
 set -g window-active-style "fg=#F0EEE6"
 set -g mode-style "bg=#4F3228,fg=#F0EEE6"
 set -g copy-mode-selection-style "bg=#4F3228,fg=#F0EEE6"

--- a/extras/vanillagreen-themes/tmux/themes/anthropic-slate.conf
+++ b/extras/vanillagreen-themes/tmux/themes/anthropic-slate.conf
@@ -1,13 +1,13 @@
 # Anthropic Slate -- vanillagreen tmux theme (colors only).
-# Source-this from your tmux.conf to apply just the palette;
-# `vstack apply` auto-injects a `source-file` line into your tmux.conf.
+# `set -gu window-style` first nukes any stale window-style override left
+# behind by a prior theme (otherwise inactive panes flash correct then revert).
 
+set -gu window-style
 set -g status-style "bg=#191919,fg=#40403E"
 set -g message-style "bg=#D4A27F,fg=#191919"
 set -g message-command-style "bg=#D4A27F,fg=#191919"
 set -g pane-border-style "fg=#40403E"
 set -g pane-active-border-style "fg=#D4A27F"
-set -g window-style "fg=#40403E"
 set -g window-active-style "fg=#F0F0EB"
 set -g mode-style "bg=#4F362D,fg=#F0F0EB"
 set -g copy-mode-selection-style "bg=#4F362D,fg=#F0F0EB"

--- a/extras/vanillagreen-themes/tmux/themes/anthropic.conf
+++ b/extras/vanillagreen-themes/tmux/themes/anthropic.conf
@@ -1,13 +1,13 @@
 # Anthropic -- vanillagreen tmux theme (colors only).
-# Source-this from your tmux.conf to apply just the palette;
-# `vstack apply` auto-injects a `source-file` line into your tmux.conf.
+# `set -gu window-style` first nukes any stale window-style override left
+# behind by a prior theme (otherwise inactive panes flash correct then revert).
 
+set -gu window-style
 set -g status-style "bg=#F0EEE6,fg=#87867F"
 set -g message-style "bg=#C6613F,fg=#FFFEFC"
 set -g message-command-style "bg=#C6613F,fg=#FFFEFC"
 set -g pane-border-style "fg=#5E5D59"
 set -g pane-active-border-style "fg=#C6613F"
-set -g window-style "fg=#5E5D59"
 set -g window-active-style "fg=#141413"
 set -g mode-style "bg=#E7B8A2,fg=#000000"
 set -g copy-mode-selection-style "bg=#E7B8A2,fg=#000000"

--- a/extras/vanillagreen-themes/tmux/themes/aura-dark.conf
+++ b/extras/vanillagreen-themes/tmux/themes/aura-dark.conf
@@ -1,13 +1,13 @@
 # Aura Dark -- vanillagreen tmux theme (colors only).
-# Source-this from your tmux.conf to apply just the palette;
-# `vstack apply` auto-injects a `source-file` line into your tmux.conf.
+# `set -gu window-style` first nukes any stale window-style override left
+# behind by a prior theme (otherwise inactive panes flash correct then revert).
 
+set -gu window-style
 set -g status-style "bg=#1c1b22,fg=#6d6d6d"
 set -g message-style "bg=#ffca85,fg=#15141b"
 set -g message-command-style "bg=#ffca85,fg=#15141b"
 set -g pane-border-style "fg=#6d6d6d"
 set -g pane-active-border-style "fg=#ffca85"
-set -g window-style "fg=#6d6d6d"
 set -g window-active-style "fg=#edecee"
 set -g mode-style "bg=#382D54,fg=#edecee"
 set -g copy-mode-selection-style "bg=#382D54,fg=#edecee"

--- a/extras/vanillagreen-themes/tmux/themes/bearded-theme-monokai-black.conf
+++ b/extras/vanillagreen-themes/tmux/themes/bearded-theme-monokai-black.conf
@@ -1,13 +1,13 @@
 # Bearded Theme Monokai Black -- vanillagreen tmux theme (colors only).
-# Source-this from your tmux.conf to apply just the palette;
-# `vstack apply` auto-injects a `source-file` line into your tmux.conf.
+# `set -gu window-style` first nukes any stale window-style override left
+# behind by a prior theme (otherwise inactive panes flash correct then revert).
 
+set -gu window-style
 set -g status-style "bg=#141414,fg=#444444"
 set -g message-style "bg=#ffd866,fg=#141414"
 set -g message-command-style "bg=#ffd866,fg=#141414"
 set -g pane-border-style "fg=#444444"
 set -g pane-active-border-style "fg=#ffd866"
-set -g window-style "fg=#444444"
 set -g window-active-style "fg=#c7c7c7"
 set -g mode-style "bg=#444444"
 set -g copy-mode-selection-style "bg=#444444"

--- a/extras/vanillagreen-themes/tmux/themes/catppuccin-frappe.conf
+++ b/extras/vanillagreen-themes/tmux/themes/catppuccin-frappe.conf
@@ -1,13 +1,13 @@
 # Catppuccin Frappé -- vanillagreen tmux theme (colors only).
-# Source-this from your tmux.conf to apply just the palette;
-# `vstack apply` auto-injects a `source-file` line into your tmux.conf.
+# `set -gu window-style` first nukes any stale window-style override left
+# behind by a prior theme (otherwise inactive panes flash correct then revert).
 
+set -gu window-style
 set -g status-style "bg=#51576d,fg=#626880"
 set -g message-style "bg=#e5c890,fg=#303446"
 set -g message-command-style "bg=#e5c890,fg=#303446"
 set -g pane-border-style "fg=#626880"
 set -g pane-active-border-style "fg=#e5c890"
-set -g window-style "fg=#626880"
 set -g window-active-style "fg=#c6d0f5"
 set -g mode-style "bg=#626880"
 set -g copy-mode-selection-style "bg=#626880"

--- a/extras/vanillagreen-themes/tmux/themes/catppuccin-latte.conf
+++ b/extras/vanillagreen-themes/tmux/themes/catppuccin-latte.conf
@@ -1,13 +1,13 @@
 # Catppuccin Latte -- vanillagreen tmux theme (colors only).
-# Source-this from your tmux.conf to apply just the palette;
-# `vstack apply` auto-injects a `source-file` line into your tmux.conf.
+# `set -gu window-style` first nukes any stale window-style override left
+# behind by a prior theme (otherwise inactive panes flash correct then revert).
 
+set -gu window-style
 set -g status-style "bg=#eff1f5,fg=#4c4f69"
 set -g message-style "bg=#df8e1d,fg=#eff1f5"
 set -g message-command-style "bg=#df8e1d,fg=#eff1f5"
 set -g pane-border-style "fg=#6c6f85"
 set -g pane-active-border-style "fg=#df8e1d"
-set -g window-style "fg=#6c6f85"
 set -g window-active-style "fg=#4c4f69"
 set -g mode-style "bg=#6c6f85"
 set -g copy-mode-selection-style "bg=#6c6f85"

--- a/extras/vanillagreen-themes/tmux/themes/catppuccin-macchiato.conf
+++ b/extras/vanillagreen-themes/tmux/themes/catppuccin-macchiato.conf
@@ -1,13 +1,13 @@
 # Catppuccin Macchiato -- vanillagreen tmux theme (colors only).
-# Source-this from your tmux.conf to apply just the palette;
-# `vstack apply` auto-injects a `source-file` line into your tmux.conf.
+# `set -gu window-style` first nukes any stale window-style override left
+# behind by a prior theme (otherwise inactive panes flash correct then revert).
 
+set -gu window-style
 set -g status-style "bg=#494d64,fg=#5b6078"
 set -g message-style "bg=#eed49f,fg=#24273a"
 set -g message-command-style "bg=#eed49f,fg=#24273a"
 set -g pane-border-style "fg=#5b6078"
 set -g pane-active-border-style "fg=#eed49f"
-set -g window-style "fg=#5b6078"
 set -g window-active-style "fg=#cad3f5"
 set -g mode-style "bg=#5b6078"
 set -g copy-mode-selection-style "bg=#5b6078"

--- a/extras/vanillagreen-themes/tmux/themes/catppuccin-mocha.conf
+++ b/extras/vanillagreen-themes/tmux/themes/catppuccin-mocha.conf
@@ -1,13 +1,13 @@
 # Catppuccin Mocha -- vanillagreen tmux theme (colors only).
-# Source-this from your tmux.conf to apply just the palette;
-# `vstack apply` auto-injects a `source-file` line into your tmux.conf.
+# `set -gu window-style` first nukes any stale window-style override left
+# behind by a prior theme (otherwise inactive panes flash correct then revert).
 
+set -gu window-style
 set -g status-style "bg=#45475a,fg=#585b70"
 set -g message-style "bg=#f9e2af,fg=#1e1e2e"
 set -g message-command-style "bg=#f9e2af,fg=#1e1e2e"
 set -g pane-border-style "fg=#585b70"
 set -g pane-active-border-style "fg=#f9e2af"
-set -g window-style "fg=#585b70"
 set -g window-active-style "fg=#cdd6f4"
 set -g mode-style "bg=#585b70"
 set -g copy-mode-selection-style "bg=#585b70"

--- a/extras/vanillagreen-themes/tmux/themes/citrus.conf
+++ b/extras/vanillagreen-themes/tmux/themes/citrus.conf
@@ -1,13 +1,13 @@
 # Citrus -- vanillagreen tmux theme (colors only).
-# Source-this from your tmux.conf to apply just the palette;
-# `vstack apply` auto-injects a `source-file` line into your tmux.conf.
+# `set -gu window-style` first nukes any stale window-style override left
+# behind by a prior theme (otherwise inactive panes flash correct then revert).
 
+set -gu window-style
 set -g status-style "bg=#101413,fg=#b64c00"
 set -g message-style "bg=#aacec4,fg=#101413"
 set -g message-command-style "bg=#aacec4,fg=#101413"
 set -g pane-border-style "fg=#b64c00"
 set -g pane-active-border-style "fg=#aacec4"
-set -g window-style "fg=#b64c00"
 set -g window-active-style "fg=#dfe3e1"
 set -g mode-style "bg=#35544D,fg=#dfe3e1"
 set -g copy-mode-selection-style "bg=#35544D,fg=#dfe3e1"

--- a/extras/vanillagreen-themes/tmux/themes/dracula.conf
+++ b/extras/vanillagreen-themes/tmux/themes/dracula.conf
@@ -1,13 +1,13 @@
 # Dracula -- vanillagreen tmux theme (colors only).
-# Source-this from your tmux.conf to apply just the palette;
-# `vstack apply` auto-injects a `source-file` line into your tmux.conf.
+# `set -gu window-style` first nukes any stale window-style override left
+# behind by a prior theme (otherwise inactive panes flash correct then revert).
 
+set -gu window-style
 set -g status-style "bg=#21222c,fg=#6272a4"
 set -g message-style "bg=#f1fa8c,fg=#282a36"
 set -g message-command-style "bg=#f1fa8c,fg=#282a36"
 set -g pane-border-style "fg=#6272a4"
 set -g pane-active-border-style "fg=#f1fa8c"
-set -g window-style "fg=#6272a4"
 set -g window-active-style "fg=#f8f8f2"
 set -g mode-style "bg=#6272a4"
 set -g copy-mode-selection-style "bg=#6272a4"

--- a/extras/vanillagreen-themes/tmux/themes/flowers.conf
+++ b/extras/vanillagreen-themes/tmux/themes/flowers.conf
@@ -1,13 +1,13 @@
 # Flowers -- vanillagreen tmux theme (colors only).
-# Source-this from your tmux.conf to apply just the palette;
-# `vstack apply` auto-injects a `source-file` line into your tmux.conf.
+# `set -gu window-style` first nukes any stale window-style override left
+# behind by a prior theme (otherwise inactive panes flash correct then revert).
 
+set -gu window-style
 set -g status-style "bg=#2F4447,fg=#BF8F75"
 set -g message-style "bg=#FFDEB2,fg=#2F4447"
 set -g message-command-style "bg=#FFDEB2,fg=#2F4447"
 set -g pane-border-style "fg=#527378"
 set -g pane-active-border-style "fg=#FFDEB2"
-set -g window-style "fg=#527378"
 set -g window-active-style "fg=#FFDEB2"
 set -g mode-style "bg=#857163,fg=#FFDEB2"
 set -g copy-mode-selection-style "bg=#857163,fg=#FFDEB2"

--- a/extras/vanillagreen-themes/tmux/themes/ghibli-serene-nature.conf
+++ b/extras/vanillagreen-themes/tmux/themes/ghibli-serene-nature.conf
@@ -1,13 +1,13 @@
 # Ghibli Serene Nature -- vanillagreen tmux theme (colors only).
-# Source-this from your tmux.conf to apply just the palette;
-# `vstack apply` auto-injects a `source-file` line into your tmux.conf.
+# `set -gu window-style` first nukes any stale window-style override left
+# behind by a prior theme (otherwise inactive panes flash correct then revert).
 
+set -gu window-style
 set -g status-style "bg=default,fg=#344D3B"
 set -g message-style "bg=#8B5A42,fg=#FFF8DC"
 set -g message-command-style "bg=#8B5A42,fg=#FFF8DC"
 set -g pane-border-style "fg=#6D9C6B"
 set -g pane-active-border-style "fg=#8B5A42"
-set -g window-style "fg=#6D9C6B"
 set -g window-active-style "fg=#2A3A2E"
 set -g mode-style "bg=#EDEFD2,fg=#2A3A2E"
 set -g copy-mode-selection-style "bg=#EDEFD2,fg=#2A3A2E"

--- a/extras/vanillagreen-themes/tmux/themes/iceberg.conf
+++ b/extras/vanillagreen-themes/tmux/themes/iceberg.conf
@@ -1,13 +1,13 @@
 # Iceberg -- vanillagreen tmux theme (colors only).
-# Source-this from your tmux.conf to apply just the palette;
-# `vstack apply` auto-injects a `source-file` line into your tmux.conf.
+# `set -gu window-style` first nukes any stale window-style override left
+# behind by a prior theme (otherwise inactive panes flash correct then revert).
 
+set -gu window-style
 set -g status-style "bg=#1e2132,fg=#6b7089"
 set -g message-style "bg=#e2a478,fg=#161821"
 set -g message-command-style "bg=#e2a478,fg=#161821"
 set -g pane-border-style "fg=#6b7089"
 set -g pane-active-border-style "fg=#e2a478"
-set -g window-style "fg=#6b7089"
 set -g window-active-style "fg=#c6c8d1"
 set -g mode-style "bg=#6b7089"
 set -g copy-mode-selection-style "bg=#6b7089"

--- a/extras/vanillagreen-themes/tmux/themes/kawaii-pixel.conf
+++ b/extras/vanillagreen-themes/tmux/themes/kawaii-pixel.conf
@@ -1,13 +1,13 @@
 # Kawaii Pixel -- vanillagreen tmux theme (colors only).
-# Source-this from your tmux.conf to apply just the palette;
-# `vstack apply` auto-injects a `source-file` line into your tmux.conf.
+# `set -gu window-style` first nukes any stale window-style override left
+# behind by a prior theme (otherwise inactive panes flash correct then revert).
 
+set -gu window-style
 set -g status-style "bg=#FBE6F2,fg=#563A8A"
 set -g message-style "bg=#8C5F24,fg=#D7EEF9"
 set -g message-command-style "bg=#8C5F24,fg=#D7EEF9"
 set -g pane-border-style "fg=#844EA7"
 set -g pane-active-border-style "fg=#8C5F24"
-set -g window-style "fg=#844EA7"
 set -g window-active-style "fg=#563A8A"
 set -g mode-style "bg=#C7D4EB,fg=#563A8A"
 set -g copy-mode-selection-style "bg=#C7D4EB,fg=#563A8A"

--- a/extras/vanillagreen-themes/tmux/themes/method-dark.conf
+++ b/extras/vanillagreen-themes/tmux/themes/method-dark.conf
@@ -1,13 +1,13 @@
 # Method Dark -- vanillagreen tmux theme (colors only).
-# Source-this from your tmux.conf to apply just the palette;
-# `vstack apply` auto-injects a `source-file` line into your tmux.conf.
+# `set -gu window-style` first nukes any stale window-style override left
+# behind by a prior theme (otherwise inactive panes flash correct then revert).
 
+set -gu window-style
 set -g status-style "bg=default,fg=#7A7A7A"
 set -g message-style "bg=#565656,fg=#FFFFFF"
 set -g message-command-style "bg=#565656,fg=#FFFFFF"
 set -g pane-border-style "fg=#3A3A3A"
 set -g pane-active-border-style "fg=#7A7A7A"
-set -g window-style "fg=#5A5A5A"
 set -g window-active-style "fg=#FFFFFF"
 set -g mode-style "bg=#3A3A3A,fg=#FFFFFF"
 set -g copy-mode-selection-style "bg=#3A3A3A,fg=#FFFFFF"

--- a/extras/vanillagreen-themes/tmux/themes/pixel-corsair.conf
+++ b/extras/vanillagreen-themes/tmux/themes/pixel-corsair.conf
@@ -1,13 +1,13 @@
 # Pixel Corsair -- vanillagreen tmux theme (colors only).
-# Source-this from your tmux.conf to apply just the palette;
-# `vstack apply` auto-injects a `source-file` line into your tmux.conf.
+# `set -gu window-style` first nukes any stale window-style override left
+# behind by a prior theme (otherwise inactive panes flash correct then revert).
 
+set -gu window-style
 set -g status-style "bg=#332B28,fg=#F6E8C1"
 set -g message-style "bg=#E2B18F,fg=#332B28"
 set -g message-command-style "bg=#E2B18F,fg=#332B28"
 set -g pane-border-style "fg=#B58E72"
 set -g pane-active-border-style "fg=#E2B18F"
-set -g window-style "fg=#B58E72"
 set -g window-active-style "fg=#F6E8C1"
 set -g mode-style "bg=#5E867B,fg=#F6E8C1"
 set -g copy-mode-selection-style "bg=#5E867B,fg=#F6E8C1"

--- a/extras/vanillagreen-themes/tmux/themes/retro-city-console.conf
+++ b/extras/vanillagreen-themes/tmux/themes/retro-city-console.conf
@@ -1,13 +1,13 @@
 # Retro City Console -- vanillagreen tmux theme (colors only).
-# Source-this from your tmux.conf to apply just the palette;
-# `vstack apply` auto-injects a `source-file` line into your tmux.conf.
+# `set -gu window-style` first nukes any stale window-style override left
+# behind by a prior theme (otherwise inactive panes flash correct then revert).
 
+set -gu window-style
 set -g status-style "bg=#101B2E,fg=#75AFAE"
 set -g message-style "bg=#FADAAF,fg=#101B2E"
 set -g message-command-style "bg=#FADAAF,fg=#101B2E"
 set -g pane-border-style "fg=#354651"
 set -g pane-active-border-style "fg=#FADAAF"
-set -g window-style "fg=#354651"
 set -g window-active-style "fg=#FBE1B7"
 set -g mode-style "bg=#123244,fg=#FBE1B7"
 set -g copy-mode-selection-style "bg=#123244,fg=#FBE1B7"

--- a/extras/vanillagreen-themes/tmux/themes/rose-pine-black.conf
+++ b/extras/vanillagreen-themes/tmux/themes/rose-pine-black.conf
@@ -1,13 +1,13 @@
 # Rosé Pine Black -- vanillagreen tmux theme (colors only).
-# Source-this from your tmux.conf to apply just the palette;
-# `vstack apply` auto-injects a `source-file` line into your tmux.conf.
+# `set -gu window-style` first nukes any stale window-style override left
+# behind by a prior theme (otherwise inactive panes flash correct then revert).
 
+set -gu window-style
 set -g status-style "bg=#141414,fg=#524f67"
 set -g message-style "bg=#f6c177,fg=#0d0d0d"
 set -g message-command-style "bg=#f6c177,fg=#0d0d0d"
 set -g pane-border-style "fg=#524f67"
 set -g pane-active-border-style "fg=#f6c177"
-set -g window-style "fg=#524f67"
 set -g window-active-style "fg=#e0def4"
 set -g mode-style "bg=#3B3246,fg=#e0def4"
 set -g copy-mode-selection-style "bg=#3B3246,fg=#e0def4"

--- a/extras/vanillagreen-themes/tmux/themes/rose-pine-dawn.conf
+++ b/extras/vanillagreen-themes/tmux/themes/rose-pine-dawn.conf
@@ -1,13 +1,13 @@
 # Rosé Pine Dawn -- vanillagreen tmux theme (colors only).
-# Source-this from your tmux.conf to apply just the palette;
-# `vstack apply` auto-injects a `source-file` line into your tmux.conf.
+# `set -gu window-style` first nukes any stale window-style override left
+# behind by a prior theme (otherwise inactive panes flash correct then revert).
 
+set -gu window-style
 set -g status-style "bg=#faf4ed,fg=#575279"
 set -g message-style "bg=#A96512,fg=#faf4ed"
 set -g message-command-style "bg=#A96512,fg=#faf4ed"
 set -g pane-border-style "fg=#9893a5"
 set -g pane-active-border-style "fg=#A96512"
-set -g window-style "fg=#9893a5"
 set -g window-active-style "fg=#575279"
 set -g mode-style "bg=#EAE2E3,fg=#575279"
 set -g copy-mode-selection-style "bg=#EAE2E3,fg=#575279"

--- a/extras/vanillagreen-themes/tmux/themes/rose-pine-extra-black.conf
+++ b/extras/vanillagreen-themes/tmux/themes/rose-pine-extra-black.conf
@@ -1,13 +1,13 @@
 # Rosé Pine Extra Black -- vanillagreen tmux theme (colors only).
-# Source-this from your tmux.conf to apply just the palette;
-# `vstack apply` auto-injects a `source-file` line into your tmux.conf.
+# `set -gu window-style` first nukes any stale window-style override left
+# behind by a prior theme (otherwise inactive panes flash correct then revert).
 
+set -gu window-style
 set -g status-style "bg=#0d0d0d,fg=#4d476f"
 set -g message-style "bg=#ffc36e,fg=#000000"
 set -g message-command-style "bg=#ffc36e,fg=#000000"
 set -g pane-border-style "fg=#4d476f"
 set -g pane-active-border-style "fg=#ffc36e"
-set -g window-style "fg=#4d476f"
 set -g window-active-style "fg=#ffffff"
 set -g mode-style "bg=#4d476f"
 set -g copy-mode-selection-style "bg=#4d476f"

--- a/extras/vanillagreen-themes/tmux/themes/rose-pine-moon.conf
+++ b/extras/vanillagreen-themes/tmux/themes/rose-pine-moon.conf
@@ -1,13 +1,13 @@
 # Rosé Pine Moon -- vanillagreen tmux theme (colors only).
-# Source-this from your tmux.conf to apply just the palette;
-# `vstack apply` auto-injects a `source-file` line into your tmux.conf.
+# `set -gu window-style` first nukes any stale window-style override left
+# behind by a prior theme (otherwise inactive panes flash correct then revert).
 
+set -gu window-style
 set -g status-style "bg=#393552,fg=#6e6a86"
 set -g message-style "bg=#f6c177,fg=#232136"
 set -g message-command-style "bg=#f6c177,fg=#232136"
 set -g pane-border-style "fg=#6e6a86"
 set -g pane-active-border-style "fg=#f6c177"
-set -g window-style "fg=#6e6a86"
 set -g window-active-style "fg=#e0def4"
 set -g mode-style "bg=#6e6a86"
 set -g copy-mode-selection-style "bg=#6e6a86"

--- a/extras/vanillagreen-themes/tmux/themes/rose-pine.conf
+++ b/extras/vanillagreen-themes/tmux/themes/rose-pine.conf
@@ -1,13 +1,13 @@
 # Rosé Pine -- vanillagreen tmux theme (colors only).
-# Source-this from your tmux.conf to apply just the palette;
-# `vstack apply` auto-injects a `source-file` line into your tmux.conf.
+# `set -gu window-style` first nukes any stale window-style override left
+# behind by a prior theme (otherwise inactive panes flash correct then revert).
 
+set -gu window-style
 set -g status-style "bg=#26233a,fg=#6e6a86"
 set -g message-style "bg=#f6c177,fg=#191724"
 set -g message-command-style "bg=#f6c177,fg=#191724"
 set -g pane-border-style "fg=#6e6a86"
 set -g pane-active-border-style "fg=#f6c177"
-set -g window-style "fg=#6e6a86"
 set -g window-active-style "fg=#e0def4"
 set -g mode-style "bg=#6e6a86"
 set -g copy-mode-selection-style "bg=#6e6a86"

--- a/extras/vanillagreen-themes/tmux/themes/tokyo-night.conf
+++ b/extras/vanillagreen-themes/tmux/themes/tokyo-night.conf
@@ -1,13 +1,13 @@
 # Tokyo Night -- vanillagreen tmux theme (colors only).
-# Source-this from your tmux.conf to apply just the palette;
-# `vstack apply` auto-injects a `source-file` line into your tmux.conf.
+# `set -gu window-style` first nukes any stale window-style override left
+# behind by a prior theme (otherwise inactive panes flash correct then revert).
 
+set -gu window-style
 set -g status-style "bg=#15161e,fg=#414868"
 set -g message-style "bg=#e0af68,fg=#1a1b26"
 set -g message-command-style "bg=#e0af68,fg=#1a1b26"
 set -g pane-border-style "fg=#414868"
 set -g pane-active-border-style "fg=#e0af68"
-set -g window-style "fg=#414868"
 set -g window-active-style "fg=#c0caf5"
 set -g mode-style "bg=#414868"
 set -g copy-mode-selection-style "bg=#414868"

--- a/extras/vanillagreen-themes/tmux/themes/warp.conf
+++ b/extras/vanillagreen-themes/tmux/themes/warp.conf
@@ -1,13 +1,13 @@
 # Warp -- vanillagreen tmux theme (colors only).
-# Source-this from your tmux.conf to apply just the palette;
-# `vstack apply` auto-injects a `source-file` line into your tmux.conf.
+# `set -gu window-style` first nukes any stale window-style override left
+# behind by a prior theme (otherwise inactive panes flash correct then revert).
 
+set -gu window-style
 set -g status-style "bg=#000000,fg=#D0D1FE"
 set -g message-style "bg=#FEFDC2,fg=#000000"
 set -g message-command-style "bg=#FEFDC2,fg=#000000"
 set -g pane-border-style "fg=#8E8E8E"
 set -g pane-active-border-style "fg=#FEFDC2"
-set -g window-style "fg=#8E8E8E"
 set -g window-active-style "fg=#FFFFFF"
 set -g mode-style "bg=#062B36,fg=#FFFFFF"
 set -g copy-mode-selection-style "bg=#062B36,fg=#FFFFFF"

--- a/extras/vanillagreen-themes/vscode/package.json
+++ b/extras/vanillagreen-themes/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "vstack-themes",
   "displayName": "vstack themes",
   "description": "Matched Ghostty + VS Code-family theme pack. 25 color themes + Ros\u00e9 Pine icon theme, curated by vanillagreen and distributed with vstack.",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "publisher": "vanillagreen",
   "icon": "icon.png",
   "engines": {


### PR DESCRIPTION
Three concrete fixes for the tmux target. Each surfaced as a real user-visible bug in 1.0.3.

### 1. Drop `window-style fg` from generated confs
Inactive panes on dark themes were unreadable because `color8` sits within a few units of the background. Active-pane brightening via `window-active-style` is enough to indicate focus.

### 2. Always emit `copy-mode-selection-style` explicitly
tmux 3.6's documented `#{E:mode-style}` default doesn't reliably inherit -- selection paints nothing in many cells. Both `mode-style` and `copy-mode-selection-style` are now emitted with the same value, with a comment explaining why.

### 3. Re-source no longer leaks stale `window-style`
`tmux source-file` runs the new conf but doesn't clear server options the new conf no longer sets. Removing `window-style` from generation alone made apply "flash correct then stay wrong". Fixed two ways:
- Every generated conf starts with `set -gu window-style`.
- `vstack apply --target tmux` runs `tmux -S <socket> set -gu window-style` against each live socket before `source-file`.

Theme pack 1.0.3 -> 1.0.4 published to both registries. Dotfiles generator (`tmux/.local/bin/tmux-apply-theme`) mirrored in the same edit for consistency.