### PR TITLE
feat(pi-claude-bridge): allowlist claude-opus-4-8 in model picker

### DIFF
--- a/pi-extensions/pi-claude-bridge/README.md
+++ b/pi-extensions/pi-claude-bridge/README.md
@@ -9,7 +9,7 @@ Forked from [`elidickinson/pi-claude-bridge`](https://github.com/elidickinson/pi
 
 ## Highlights
 
-- `claude-bridge/claude-opus-4-7`, Sonnet, and Haiku in `/model`.
+- `claude-bridge/claude-opus-4-8`, Opus 4-7, Sonnet, and Haiku in `/model`.
 - Pi tool calls run on Pi; Claude Code handles reasoning.
 - Session continuity across normal turns, `/compact`, tree navigation, and abort recovery.
 - Thinking-level forwarding with summarized Opus thinking display.

--- a/pi-extensions/pi-claude-bridge/bundle/index.js
+++ b/pi-extensions/pi-claude-bridge/bundle/index.js
@@ -21953,7 +21953,7 @@ function convertPiMessages(messages, customToolNameToSdk) {
 }
 
 // src/models.ts
-var MODEL_IDS_IN_ORDER = ["claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5"];
+var MODEL_IDS_IN_ORDER = ["claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5"];
 function buildModels(piAiModels) {
   return MODEL_IDS_IN_ORDER.map((id) => piAiModels.find((m2) => m2.id === id)).filter((m2) => m2 != null).map(({ id, name, reasoning, input, contextWindow, maxTokens, thinkingLevelMap }) => ({
     id,

--- a/pi-extensions/pi-claude-bridge/src/models.ts
+++ b/pi-extensions/pi-claude-bridge/src/models.ts
@@ -2,7 +2,7 @@
 // `resolveModelId` returns the first partial match, so `opus` resolves to the first-listed opus entry.
 // Extracted from index.ts so tests can import without activating the extension.
 
-export const MODEL_IDS_IN_ORDER = ["claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5"];
+export const MODEL_IDS_IN_ORDER = ["claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5"];
 
 // Project pi-ai's model entries down to the fields pi's registerProvider expects,
 // and keep MODEL_IDS_IN_ORDER ordering. IDs missing from pi-ai are silently dropped.

--- a/pi-extensions/pi-claude-bridge/tests/unit-models.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-models.mjs
@@ -50,8 +50,8 @@ describe("MODELS projection", () => {
 describe("resolveModelId", () => {
 	const models = buildModels(MODEL_IDS_IN_ORDER.map(mockPiAiModel));
 
-	it("opus shortcut resolves to claude-opus-4-7 (first opus in order)", () => {
-		assert.equal(resolveModelId(models, "opus"), "claude-opus-4-7");
+	it("opus shortcut resolves to claude-opus-4-8 (first opus in order)", () => {
+		assert.equal(resolveModelId(models, "opus"), "claude-opus-4-8");
 	});
 
 	it("haiku shortcut resolves to claude-haiku-4-5", () => {


### PR DESCRIPTION
## Summary

Add `claude-opus-4-8` (released 2026-05-29) to the bridge's model allowlist. Surfaces as `claude-bridge/claude-opus-4-8` in `/model`. The `opus` shortcut resolves to it.

## Changes

- `src/models.ts` — prepend `claude-opus-4-8` to `MODEL_IDS_IN_ORDER`. Position matches prior precedent: `opus` resolves to the first-listed (newest) Opus.
- `tests/unit-models.mjs` — update the `opus` shortcut assertion to pin `claude-opus-4-8`.
- `README.md` — refresh Highlights bullet to mention 4-8.
- `bundle/index.js` — regenerated via `npm run build`. Follows `build(pi-claude-bridge): refresh bundled provider`.

No `package.json` version bump. Version bumps look batched under `chore(pi-extensions): bump npm package versions`.

## Verification

- `npm run test:unit`: 112 pass.
- `pi-extensions/package-policy.test.mjs`: 3 pass.
- Local smoke test: rebuilt `bundle/index.js` dropped into an installed `@vanillagreen/pi-claude-bridge`, `claude-bridge/claude-opus-4-8` added to `enabledModels`, Pi restarted, model selected via `/model`, turn routed through Claude Code without error.

## SDK caveat

`@anthropic-ai/claude-agent-sdk@0.2.141` TS model union still lists only `claude-opus-4-7`. At runtime the SDK passes the model id as a string, so 4-8 works. You may want to pair this with an SDK bump once a release that includes 4-8 in the union ships. SDK dependency left untouched to keep the patch minimal.

## Notes

Patch drafted with AI assistance (Claude).
