### PR TITLE
Handle GitHub activity emit load failures

### DIFF
--- a/skills/github/README.md
+++ b/skills/github/README.md
@@ -43,6 +43,14 @@ CLI wrapper for GitHub API operations used in PR workflows.
 2. `verify.sh` in project root
 3. Auto-detect from `Cargo.toml`, `package.json`, `go.mod`, `pyproject.toml`, `Makefile`
 
+## Flightdeck Activity
+
+GitHub wrappers emit Flightdeck activity rows only when `FLIGHTDECK_MANAGED=1`
+or `FLIGHTDECK_ACTIVITY_FILE` is set. Emission is best-effort: if the shared
+Flightdeck helper is unavailable, wrappers continue and print one clear
+non-blocking warning instead of raw shell diagnostics. Standalone use outside
+Flightdeck stays silent.
+
 ## Dependencies
 
 - `gh` CLI authenticated

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -119,6 +119,10 @@ Bot token supports direct tokens (`ghp_*`, `gho_*`, `ghs_*`, `ghr_*`, `github_pa
 - Returns `{"error": "message"}` on stderr with exit code 1
 - Automatic retry on rate limiting (3 attempts with backoff)
 - NOT_FOUND errors return clean `{"error": "Not found"}`
+- Flightdeck activity emission is best-effort. If the shared Flightdeck helper
+  is unavailable in a managed context, wrappers continue and print one clear
+  non-blocking warning instead of raw shell diagnostics. Standalone use outside
+  Flightdeck stays silent.
 
 ## Troubleshooting
 

--- a/skills/github/scripts/_activity-emit.sh
+++ b/skills/github/scripts/_activity-emit.sh
@@ -4,8 +4,30 @@
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=/dev/null
-source "$SCRIPT_DIR/../../flightdeck/scripts/_activity-emit.sh"
 
-flightdeck_activity_emit github "$@" || true
+# Nothing should be emitted outside Flightdeck-managed contexts. Return before
+# touching the shared helper so a missing/unreadable Flightdeck install never
+# affects standalone GitHub wrapper usage.
+if [ "${FLIGHTDECK_MANAGED:-}" != "1" ] && [ -z "${FLIGHTDECK_ACTIVITY_FILE:-}" ]; then
+    exit 0
+fi
+
+ACTIVITY_EMIT_SH="$SCRIPT_DIR/../../flightdeck/scripts/_activity-emit.sh"
+
+warn_activity_unavailable() {
+    printf 'Warning: Flightdeck activity emit unavailable; continuing without activity: %s\n' "$ACTIVITY_EMIT_SH" >&2
+}
+
+# shellcheck source=/dev/null
+if ! source "$ACTIVITY_EMIT_SH" >/dev/null 2>&1; then
+    warn_activity_unavailable
+    exit 0
+fi
+
+if ! declare -F flightdeck_activity_emit >/dev/null 2>&1; then
+    warn_activity_unavailable
+    exit 0
+fi
+
+flightdeck_activity_emit github "$@" >/dev/null 2>&1 || true
 exit 0

--- a/skills/github/tests/activity-emit-failure.test.sh
+++ b/skills/github/tests/activity-emit-failure.test.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# vstack#261: GitHub activity emission is best-effort. If the shared
+# Flightdeck activity helper cannot be loaded after a successful wrapper
+# operation, emit only a clear non-blocking warning and never leak raw shell
+# diagnostics such as `source: ...` or `flightdeck_activity_emit: command not found`.
+#
+# Run: bash skills/github/tests/activity-emit-failure.test.sh
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../.." && pwd)"
+WRAPPER="$REPO_ROOT/skills/github/scripts/_activity-emit.sh"
+
+SANDBOX="$(mktemp -d -t gh-activity-emit-XXXXXX)"
+PASS=0
+FAIL=0
+
+cleanup() { rm -rf "$SANDBOX" 2>/dev/null || true; }
+trap cleanup EXIT
+
+assert_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if [ "$expected" = "$actual" ]; then
+        printf '  PASS: %s\n' "$label"
+        PASS=$((PASS + 1))
+    else
+        printf '  FAIL: %s\n    expected: %s\n    actual:   %s\n' "$label" "$expected" "$actual" >&2
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_contains() {
+    local label="$1" needle="$2" haystack="$3"
+    if [[ "$haystack" == *"$needle"* ]]; then
+        printf '  PASS: %s\n' "$label"
+        PASS=$((PASS + 1))
+    else
+        printf '  FAIL: %s\n    missing: %s\n    actual:  %s\n' "$label" "$needle" "$haystack" >&2
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_not_contains() {
+    local label="$1" needle="$2" haystack="$3"
+    if [[ "$haystack" != *"$needle"* ]]; then
+        printf '  PASS: %s\n' "$label"
+        PASS=$((PASS + 1))
+    else
+        printf '  FAIL: %s\n    unexpected: %s\n    actual:     %s\n' "$label" "$needle" "$haystack" >&2
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Copy the GitHub trampoline into a sandbox without the sibling Flightdeck
+# helper. The relative source path will fail exactly like an unavailable or
+# unreadable Flightdeck install, without mutating the real repository files.
+mkdir -p "$SANDBOX/github/scripts"
+cp "$WRAPPER" "$SANDBOX/github/scripts/_activity-emit.sh"
+SANDBOX_WRAPPER="$SANDBOX/github/scripts/_activity-emit.sh"
+
+# Managed context: failure to load the Flightdeck helper returns success and
+# prints one actionable warning, not bash source/function diagnostics.
+export FLIGHTDECK_MANAGED=1
+export FLIGHTDECK_ACTIVITY_FILE="$SANDBOX/activity.jsonl"
+managed_stdout="$SANDBOX/managed.stdout"
+managed_stderr="$SANDBOX/managed.stderr"
+managed_status=0
+bash "$SANDBOX_WRAPPER" pr.merged --summary "PR merged" >"$managed_stdout" 2>"$managed_stderr" || managed_status=$?
+managed_err="$(cat "$managed_stderr")"
+assert_eq "managed helper-load failure exits 0" "0" "$managed_status"
+assert_eq "managed helper-load failure has no stdout" "" "$(cat "$managed_stdout")"
+assert_contains "managed helper-load failure warns clearly" "Warning: Flightdeck activity emit unavailable; continuing without activity:" "$managed_err"
+assert_not_contains "managed helper-load failure hides shell source error" "No such file or directory" "$managed_err"
+assert_not_contains "managed helper-load failure hides missing function error" "command not found" "$managed_err"
+assert_not_contains "managed helper-load failure hides raw script line diagnostics" "line " "$managed_err"
+
+# Unmanaged context: GitHub wrapper usage should remain silent and should not
+# attempt to load Flightdeck at all.
+unset FLIGHTDECK_MANAGED FLIGHTDECK_ACTIVITY_FILE
+unmanaged_stdout="$SANDBOX/unmanaged.stdout"
+unmanaged_stderr="$SANDBOX/unmanaged.stderr"
+unmanaged_status=0
+bash "$SANDBOX_WRAPPER" pr.merged --summary "PR merged" >"$unmanaged_stdout" 2>"$unmanaged_stderr" || unmanaged_status=$?
+assert_eq "unmanaged helper-load failure exits 0" "0" "$unmanaged_status"
+assert_eq "unmanaged helper-load failure has no stdout" "" "$(cat "$unmanaged_stdout")"
+assert_eq "unmanaged helper-load failure has no stderr" "" "$(cat "$unmanaged_stderr")"
+
+printf '\nPASS=%d FAIL=%d\n' "$PASS" "$FAIL"
+if [ "$FAIL" -ne 0 ]; then exit 1; fi


### PR DESCRIPTION
## Summary
- Harden `skills/github/scripts/_activity-emit.sh` so standalone GitHub wrapper use stays silent outside Flightdeck.
- Convert managed Flightdeck helper-load failures into one clear non-blocking warning instead of raw shell diagnostics.
- Add regression coverage and update GitHub skill docs.

## Tests
- `bash skills/github/tests/activity-emit-failure.test.sh`
- `bash skills/github/tests/wrapper-entry-id-branch.test.sh`
- `for test in skills/github/tests/*.test.sh; do bash "$test"; done`
- `bash -n skills/github/scripts/_activity-emit.sh`
- `bash -n skills/github/tests/activity-emit-failure.test.sh`

## Non-blocking review notes
- Follow-up candidate: `skills/linear/scripts/_activity-emit.sh` appears to have the same unguarded-source pattern.
- Future hardening could cover IO-erroring source/stale helper branches and shared loader dedupe.

Fixes #261
