### PR TITLE
Fix schedule composite durations

### DIFF
--- a/pi-extensions/pi-qol/README.md
+++ b/pi-extensions/pi-qol/README.md
@@ -15,7 +15,7 @@ Quality-of-life extension for Pi: compact statusline, multiline input, session n
 - `/search` browses previous sessions with snippet previews; the configured shortcut opens it instantly.
 - `/context` shows a Claude-style context-window breakdown.
 - `/handoff <goal>` drafts a focused prompt for a new session.
-- `/schedule 20m <message>` sends a delayed prompt without invoking the model until the timer fires.
+- `/schedule 20m <message>` or `/schedule 1h45m <message>` sends a delayed prompt without invoking the model until the timer fires.
 - Optional rate-limit auto-resume sends a configurable continuation after reset.
 - Permission gate prompts before risky `bash` commands. Default match: `rm -Rf`.
 - Notifications for ready, questions, blocked states, and task completion.
@@ -53,11 +53,11 @@ Restart Pi after installation.
 | `/search [query]` | Open previous-session search. |
 | `/search:refresh` | Refresh the session search cache. |
 | `/handoff <goal>` | Draft a handoff prompt for a new session. |
-| `/schedule <delay> <message>` | Send a user message after a timer without invoking the model now. Example: `/schedule 20m retry the previous request`. |
+| `/schedule <delay> <message>` | Send a user message after a timer without invoking the model now. Example: `/schedule 1h45m retry the previous request`. |
 
 Arguments support autocomplete.
 
-`/schedule` accepts `ms`, `s`, `m`, `h`, and `d` units; bare numbers mean minutes. Pending prompts render above the statusline like steering/follow-up previews until they are sent or cancelled. Manage pending prompts with `/schedule list` and `/schedule cancel <id|all>`. Schedules are stored in the Pi session and re-armed on reload/resume; if Pi is not running at the due time, an overdue prompt sends when that session is next loaded.
+`/schedule` accepts `ms`, `s`, `m`, `h`, and `d` units; bare numbers mean minutes. Compact composite durations are accepted in largest-to-smallest order, like `1h45m`, `45m10s`, or `1h45m30s`. Pending prompts render above the statusline like steering/follow-up previews until they are sent or cancelled. Manage pending prompts with `/schedule list` and `/schedule cancel <id|all>`. Schedules are stored in the Pi session and re-armed on reload/resume; if Pi is not running at the due time, an overdue prompt sends when that session is next loaded.
 
 ## Settings
 

--- a/pi-extensions/pi-qol/extensions/qol/schedule.ts
+++ b/pi-extensions/pi-qol/extensions/qol/schedule.ts
@@ -56,6 +56,7 @@ const SCHEDULE_COMPLETIONS: AutocompleteItem[] = [
 	{ value: "list", label: "list", description: "Show pending scheduled messages" },
 	{ value: "cancel ", label: "cancel <id|all>", description: "Cancel one scheduled message or all pending messages" },
 	{ value: "20m ", label: "20m <message>", description: "Send a message after 20 minutes" },
+	{ value: "1h30m ", label: "1h30m <message>", description: "Send a message after 1 hour 30 minutes" },
 	{ value: "1h ", label: "1h <message>", description: "Send a message after 1 hour" },
 ];
 
@@ -66,23 +67,45 @@ export function getScheduleArgumentCompletions(prefix: string): AutocompleteItem
 }
 
 export function parseDurationMs(input: string): number | undefined {
-	const match = input.trim().toLowerCase().match(/^(\d+(?:\.\d+)?)(ms|s|sec|secs|second|seconds|m|min|mins|minute|minutes|h|hr|hrs|hour|hours|d|day|days)?$/);
-	if (!match) return undefined;
-	const amount = Number(match[1]);
-	if (!Number.isFinite(amount) || amount <= 0) return undefined;
-	const unit = match[2] ?? "m";
-	const multiplier = unit === "ms"
-		? 1
-		: ["s", "sec", "secs", "second", "seconds"].includes(unit)
-			? 1000
-			: ["h", "hr", "hrs", "hour", "hours"].includes(unit)
-				? 60 * 60 * 1000
-				: ["d", "day", "days"].includes(unit)
-					? 24 * 60 * 60 * 1000
-					: 60 * 1000;
-	const delayMs = Math.round(amount * multiplier);
+	const text = input.trim().toLowerCase();
+	if (!text) return undefined;
+	if (/^\d+(?:\.\d+)?$/.test(text)) return clampScheduleDelay(Number(text) * 60 * 1000);
+
+	let totalMs = 0;
+	let matched = false;
+	let previousRank = Number.POSITIVE_INFINITY;
+	const seenUnits = new Set<string>();
+	const re = /(\d+(?:\.\d+)?)(ms|seconds?|secs?|s|minutes?|mins?|min|m|hours?|hrs?|hr|h|days?|d)/gy;
+
+	while (re.lastIndex < text.length) {
+		const match = re.exec(text);
+		if (!match) return undefined;
+		const amount = Number(match[1]);
+		const unit = scheduleUnit(match[2]);
+		if (!Number.isFinite(amount) || amount < 0 || !unit) return undefined;
+		if (seenUnits.has(unit.name) || unit.rank >= previousRank) return undefined;
+		seenUnits.add(unit.name);
+		previousRank = unit.rank;
+		totalMs += amount * unit.multiplier;
+		matched = true;
+	}
+
+	const delayMs = Math.round(totalMs);
+	return matched ? clampScheduleDelay(delayMs) : undefined;
+}
+
+function clampScheduleDelay(delayMs: number): number | undefined {
 	if (!Number.isFinite(delayMs) || delayMs <= 0 || delayMs > MAX_SCHEDULE_DELAY_MS) return undefined;
 	return delayMs;
+}
+
+function scheduleUnit(unit: string): { multiplier: number; name: string; rank: number } | undefined {
+	if (unit === "ms") return { multiplier: 1, name: "ms", rank: 0 };
+	if (["s", "sec", "secs", "second", "seconds"].includes(unit)) return { multiplier: 1000, name: "s", rank: 1 };
+	if (["m", "min", "mins", "minute", "minutes"].includes(unit)) return { multiplier: 60 * 1000, name: "m", rank: 2 };
+	if (["h", "hr", "hrs", "hour", "hours"].includes(unit)) return { multiplier: 60 * 60 * 1000, name: "h", rank: 3 };
+	if (["d", "day", "days"].includes(unit)) return { multiplier: 24 * 60 * 60 * 1000, name: "d", rank: 4 };
+	return undefined;
 }
 
 export function parseScheduleCommandArgs(args: string): ParsedScheduleCommand {
@@ -131,7 +154,8 @@ function usageText(): string {
 	return [
 		"Usage: /schedule <duration> <message>",
 		"Examples: /schedule 20m retry the previous request",
-		"          /schedule 1h retry after the rate limit reset",
+		"          /schedule 1h30m retry after the rate limit reset",
+		"Durations: 20, 20m, 90s, 500ms, 1h45m30s (bare numbers mean minutes)",
 		"Manage: /schedule list, /schedule cancel <id|all>",
 	].join("\n");
 }

--- a/pi-extensions/pi-qol/tests/schedule.test.ts
+++ b/pi-extensions/pi-qol/tests/schedule.test.ts
@@ -1,12 +1,14 @@
 import { expect, mock, test } from "bun:test";
+import "./preload.ts";
 
-import {
+import type { ScheduleClock } from "../extensions/qol/schedule.ts";
+
+const {
 	createScheduleController,
 	parseDurationMs,
 	parseScheduleCommandArgs,
 	SCHEDULE_ENTRY_TYPE,
-	type ScheduleClock,
-} from "../extensions/qol/schedule.ts";
+} = await import("../extensions/qol/schedule.ts");
 
 interface FakeTimer {
 	callback: () => void;
@@ -67,9 +69,24 @@ test("parseDurationMs supports default minutes and explicit units", () => {
 	expect(parseDurationMs("20")).toBe(20 * 60 * 1000);
 	expect(parseDurationMs("20m")).toBe(20 * 60 * 1000);
 	expect(parseDurationMs("90s")).toBe(90 * 1000);
+	expect(parseDurationMs("500ms")).toBe(500);
 	expect(parseDurationMs("1.5h")).toBe(90 * 60 * 1000);
 	expect(parseDurationMs("0m")).toBeUndefined();
 	expect(parseDurationMs("forever")).toBeUndefined();
+});
+
+test("parseDurationMs supports compact composite durations", () => {
+	expect(parseDurationMs("1h45m")).toBe(105 * 60 * 1000);
+	expect(parseDurationMs("1h30s")).toBe(3_630_000);
+	expect(parseDurationMs("45m10s")).toBe(2_710_000);
+	expect(parseDurationMs("1h45m30s")).toBe((105 * 60 + 30) * 1000);
+	expect(parseDurationMs("2d3h4m5s6ms")).toBe(2 * 24 * 60 * 60 * 1000 + 3 * 60 * 60 * 1000 + 4 * 60 * 1000 + 5 * 1000 + 6);
+
+	expect(parseDurationMs("1h2h")).toBeUndefined();
+	expect(parseDurationMs("30s1h")).toBeUndefined();
+	expect(parseDurationMs("1h30")).toBeUndefined();
+	expect(parseDurationMs("1h30xs")).toBeUndefined();
+	expect(parseDurationMs("31d")).toBeUndefined();
 });
 
 test("parseScheduleCommandArgs extracts delay and message", () => {
@@ -77,6 +94,21 @@ test("parseScheduleCommandArgs extracts delay and message", () => {
 		delayMs: 20 * 60 * 1000,
 		kind: "schedule",
 		message: "this is my message",
+	});
+	expect(parseScheduleCommandArgs("1h45m do thing later")).toEqual({
+		delayMs: 105 * 60 * 1000,
+		kind: "schedule",
+		message: "do thing later",
+	});
+	expect(parseScheduleCommandArgs("1h30s do thing later")).toEqual({
+		delayMs: 3_630_000,
+		kind: "schedule",
+		message: "do thing later",
+	});
+	expect(parseScheduleCommandArgs("45m10s do thing later")).toEqual({
+		delayMs: 2_710_000,
+		kind: "schedule",
+		message: "do thing later",
 	});
 	expect(parseScheduleCommandArgs("list")).toEqual({ kind: "list" });
 	expect(parseScheduleCommandArgs("cancel all")).toEqual({ all: true, kind: "cancel" });


### PR DESCRIPTION
## Summary
- Add compact composite duration parsing for /schedule, including values like 1h45m, 1h30s, and 45m10s.
- Preserve existing bare-minute and single-unit duration behavior.
- Update schedule help, autocomplete, README, and tests.

## Tests
- bun test pi-extensions/pi-qol/tests/schedule.test.ts
- cd pi-extensions/pi-qol && bun test ./tests

Fixes #279
