### PR TITLE
Fix project-management Linear label preflight

### DIFF
--- a/skills/linear/README.md
+++ b/skills/linear/README.md
@@ -32,6 +32,8 @@ skills/linear/
 
 Read-only cache queries (`./scripts/linear.sh cache ...` except `cache attachments fetch`) use existing `.cache/linear` data and do not require API auth.
 
+`cache labels list --format=safe` returns issue-label metadata (`id`, `name`, `team`, `parent`, `is_group`) so workflow callers can preflight labels and reject parent/group labels before issue mutation.
+
 ## Configuration
 
 | Variable | Purpose | Default |

--- a/skills/linear/SKILL.md
+++ b/skills/linear/SKILL.md
@@ -125,12 +125,14 @@ sortOrder → sort_order  # Manual sort position
 | `--project` | Name or UUID | Fail with "not found" |
 | `--state` | Exact name (case-sensitive) | Fail, lists available states |
 | `--milestone` | Name or UUID | Fail with "not found" |
-| `--labels` | Comma-separated names | Warn + skip invalid, continue |
+| `--labels` | Comma-separated issue-label names | Warn + skip invalid, continue (workflow callers must preflight strictly) |
 | `--assignee` | Name or `me` | Silent fail |
 
 - State names are case-sensitive and team-specific — verify with `linear.sh statuses list`
 - Available states: Backlog, Todo, In Progress, In Review, Done, Canceled (not "Cancelled")
 - `agent:*` labels are mutually exclusive (only one per issue)
+- `--labels` replaces the full issue-label set on update. Workflow callers must fetch current labels, compute the final set, validate against `cache labels list --format=safe`, then call update with the full final set.
+- `cache labels list --format=safe` returns issue labels with `id`, `name`, `team`, `parent`, and `is_group` so workflows can reject parent/group labels before mutation.
 
 ## Troubleshooting
 

--- a/skills/linear/patterns/workflow-actions.md
+++ b/skills/linear/patterns/workflow-actions.md
@@ -107,12 +107,27 @@ scripts/linear.sh issues update [ISSUE_ID] --priority 1
 scripts/linear.sh comments create [ISSUE_ID] --body "Priority updated: [REASON]"
 ```
 
+## Label Preflight
+
+Before any issue create or label update from a workflow:
+
+1. Refresh/load issue-label inventory: `scripts/linear.sh sync --reconcile` when the cache is missing or stale, then `scripts/linear.sh cache labels list --format=safe`.
+2. Load project taxonomy/application rules from the calling project.
+3. Build the full final issue-label set.
+4. Reject unknown labels, parent/group labels (`is_group: true` or names used as parents), missing required categories, and exclusive-category conflicts.
+5. Ask for explicit user authorization before creating any missing issue label; never create labels automatically.
+
+Project labels are separate resources and must not be used for issue-label preflight.
+
 ## Agent Label Updates
 
-Agent labels are exclusive. Replace the old `agent:*` label with the new one; do not stack them.
+Agent labels are exclusive. Replace the old taxonomy `agent` category label with the new one, preserve all unrelated labels, and update with the full validated final set.
 
 ```bash
-scripts/linear.sh issues update [ISSUE_ID] --labels "agent:[NAME]"
+scripts/linear.sh cache issues get [ISSUE_ID]
+# FINAL_LABELS = current labels - current agent-category labels + agent:[NAME]
+# Preflight FINAL_LABELS against live issue-label inventory + project taxonomy.
+scripts/linear.sh issues update [ISSUE_ID] --labels "[FINAL_LABELS]"
 scripts/linear.sh comments create [ISSUE_ID] --body "Agent label updated: [REASON]"
 ```
 
@@ -120,11 +135,13 @@ scripts/linear.sh comments create [ISSUE_ID] --body "Agent label updated: [REASO
 
 ```bash
 scripts/linear.sh cache issues get [ISSUE_ID]
-scripts/linear.sh issues update [ISSUE_ID] --labels "[EXISTING_LABELS],[MISSING_LABEL]"
+# FINAL_LABELS = current labels + [MISSING_LABEL]
+# Preflight FINAL_LABELS against live issue-label inventory + project taxonomy.
+scripts/linear.sh issues update [ISSUE_ID] --labels "[FINAL_LABELS]"
 scripts/linear.sh comments create [ISSUE_ID] --body "Added [MISSING_LABEL]: [REASON]"
 ```
 
-Remember that `--labels` replaces the full label set.
+Remember that `--labels` replaces the full label set. Never pass only the changed label unless the intended final label set is exactly that one label.
 
 ## Cycle Assignment
 
@@ -153,7 +170,8 @@ scripts/linear.sh issues update [PARENT_ID] --state "[CHILD_STATE]" --cycle [CYC
 
 ```bash
 scripts/linear.sh issues update [ISSUE_ID] --estimate 3
-scripts/linear.sh issues update [ISSUE_ID] --labels "agent:[NAME],blocked"
+# For labels: compute FINAL_LABELS from current labels + intended add/replace, preflight, then update.
+scripts/linear.sh issues update [ISSUE_ID] --labels "[FINAL_LABELS]"
 ```
 
 ## Create Gap Issues
@@ -170,17 +188,21 @@ scripts/linear.sh issues create \
 
 Then add any blocking relations that the new gap issue should impose.
 
+`[LABELS]` must be the full validated issue-label set, not a partial agent label.
+
 ## Create Research Gap
 
 ```bash
 scripts/linear.sh issues create \
   --title "Research: [TOPIC]" \
   --project "[TARGET_PROJECT]" \
-  --labels "research" \
+  --labels "[VALIDATED_RESEARCH_LABELS]" \
   --priority 3 \
   --estimate 1 \
   --description "[RESEARCH_BRIEF]"
 ```
+
+`[VALIDATED_RESEARCH_LABELS]` must include the project-required agent/domain/workflow categories and must pass issue-label preflight.
 
 ## Project State Changes
 

--- a/skills/linear/scripts/commands/labels.sh
+++ b/skills/linear/scripts/commands/labels.sh
@@ -83,6 +83,7 @@ list_labels() {
                 name
                 color
                 description
+                isGroup
                 team { name }
                 parent { name }
                 createdAt
@@ -184,6 +185,7 @@ create_label() {
                 id
                 name
                 color
+                isGroup
                 parent { name }
             }
         }
@@ -243,6 +245,8 @@ update_label() {
                 id
                 name
                 color
+                isGroup
+                parent { name }
             }
         }
     }'

--- a/skills/linear/scripts/commands/sync.sh
+++ b/skills/linear/scripts/commands/sync.sh
@@ -330,7 +330,7 @@ sync_labels() {
         issueLabels(first: 250, after: $after) {
             pageInfo { hasNextPage endCursor }
             nodes {
-                id name color description
+                id name color description isGroup
                 team { name }
                 parent { name }
             }

--- a/skills/linear/scripts/lib/formatters.sh
+++ b/skills/linear/scripts/lib/formatters.sh
@@ -396,6 +396,7 @@ format_labels_list() {
         name: (.name // ""),
         color: (.color // ""),
         description: (.description // ""),
+        is_group: (.isGroup // false),
         team: (.team.name // ""),
         parent: (.parent.name // "")
     }]'

--- a/skills/linear/tests/cache-no-auth.test.sh
+++ b/skills/linear/tests/cache-no-auth.test.sh
@@ -64,6 +64,29 @@ cat > "$tmp/.cache/linear/issues.json" <<'JSON'
 ]
 JSON
 
+cat > "$tmp/.cache/linear/labels.json" <<'JSON'
+[
+  {
+    "id": "label-group-1",
+    "name": "Agent",
+    "color": "#9C27B0",
+    "description": "Agent group",
+    "isGroup": true,
+    "team": {"name": "Claude"},
+    "parent": null
+  },
+  {
+    "id": "label-child-1",
+    "name": "agent:test",
+    "color": "#9C27B0",
+    "description": "Test agent",
+    "isGroup": false,
+    "team": {"name": "Claude"},
+    "parent": {"name": "Agent"}
+  }
+]
+JSON
+
 err="$tmp/stderr.txt"
 RUN_OUT=""
 
@@ -106,6 +129,17 @@ run_cache_read "cache issues list" cache issues list --state "Backlog,Todo,In Pr
 issues_out="$RUN_OUT"
 if ! echo "$issues_out" | jq -e '.[0].id == "AUTH-1"' >/dev/null; then
   echo "FAIL cache issues list returned unexpected output: $issues_out"
+  exit 1
+fi
+
+run_cache_read "cache labels list" cache labels list --format=safe
+labels_out="$RUN_OUT"
+if ! echo "$labels_out" | jq -e '.[] | select(.name == "Agent" and .is_group == true)' >/dev/null; then
+  echo "FAIL cache labels list did not expose is_group=true: $labels_out"
+  exit 1
+fi
+if ! echo "$labels_out" | jq -e '.[] | select(.name == "agent:test" and .parent == "Agent" and .is_group == false)' >/dev/null; then
+  echo "FAIL cache labels list returned unexpected child label output: $labels_out"
   exit 1
 fi
 

--- a/skills/project-management/README.md
+++ b/skills/project-management/README.md
@@ -15,7 +15,7 @@ skills/project-management/
 │   ├── initiatives-projects.md             # Initiative/project lifecycle, naming, breakdown
 │   ├── dependencies.md                     # Blocking rules, relation types, remediation
 │   ├── prioritization.md                   # Scoring formula, factor definitions, trade-offs
-│   └── labels.md                           # Label taxonomy, exclusivity, creation, lifecycle
+│   └── labels.md                           # Issue-label inventory preflight, taxonomy contract, exclusivity, lifecycle
 ├── workflows/
 │   ├── tpm-cycle-plan.md                   # Analyze backlog, compute architecture order for cycle
 │   ├── tpm-roadmap-plan.md                 # Cross-project analysis, architecture gaps
@@ -42,4 +42,5 @@ This skill requires an issue tracker CLI for all read/write operations. Configur
 - **Prioritization**: Weighted scoring formula (Critical Path x3, Dependencies x2, Risk x2, Value x1, Estimate x-0.5)
 - **Same-project rule**: Blocking relations and parent-child relations must be within the same project
 - **Blocking level rule**: Blocking relations go on bundle parents, not children
+- **Label preflight**: Issue creates/label updates load live issue-label inventory + project taxonomy, validate full final `labels[]`, and preserve unrelated labels on updates
 - **Workflows return JSON only**: No direct modifications to the issue tracker — recommendations are executed by the caller

--- a/skills/project-management/SKILL.md
+++ b/skills/project-management/SKILL.md
@@ -85,6 +85,7 @@ TPM workflows return JSON recommendations only.
 
 - Execute all workflow sections in order. The workflow decides what to skip via "**Skip if**" conditions — never skip based on your own scope assessment.
 - `<delegation_format>` and `<output_format>` tags are literal templates: fill `[PLACEHOLDERS]`, omit empty lines, add nothing else, do not paraphrase.
+- Before any issue create or label update, load the live issue-label inventory and project taxonomy, build the full final `labels[]` set, and run the label preflight in `references/labels.md`. Unknown labels, parent/group labels, missing required categories, or exclusivity violations stop the workflow before mutation.
 
 ## Hierarchy
 

--- a/skills/project-management/references/issues.md
+++ b/skills/project-management/references/issues.md
@@ -7,7 +7,7 @@
 | Field | Required | Format |
 |-------|----------|--------|
 | Title | Yes | `[Verb]: [outcome]` — e.g., "Implement: user authentication" |
-| Labels | Yes | Agent (one) + Stack (one+) + Workflow/Classification (if applicable) |
+| Labels | Yes | Full validated `labels[]`: required project categories (for example Agent + Domain/Stack) + Workflow/Classification when applicable |
 | Estimate | Yes | 1-5 points (1=hours, 3=day, 5=week) |
 | Project | Yes | Active project name or "Backlog" |
 | Description | Yes | Context, acceptance criteria, dependencies |
@@ -31,15 +31,21 @@ When finding potential duplicates, expand existing issues rather than creating o
 
 ## Labels
 
-See project label taxonomy for definitions. See project label application guide for when to apply.
+See the project's issue-label taxonomy for definitions and [labels.md](labels.md) for mandatory live-inventory preflight. Labels here are **issue labels**, not project labels.
 
 | Category | Exclusive? | Rule |
 |----------|------------|------|
-| Agent | YES | Exactly ONE per issue |
-| Platform | YES | ONE per issue |
-| Stack | NO | All that apply |
-| Workflow | NO | All applicable gates |
-| Classification | NO | Multiple allowed |
+| Agent | Project-configured | Usually exactly ONE per new issue |
+| Platform | Project-configured | Usually zero or one child label, never the parent/group label |
+| Domain/Stack | Project-configured | All that apply; required when taxonomy says so |
+| Workflow | Project-configured | All applicable gates |
+| Classification | Project-configured | Multiple allowed unless taxonomy says exclusive |
+
+Before create/update:
+1. Load issue-label inventory: `.agents/skills/linear/scripts/linear.sh cache labels list --format=safe` (refresh with `sync --reconcile` if missing/stale).
+2. Build the full final `labels[]` set.
+3. Validate against project taxonomy and live issue-label inventory.
+4. Halt on unknown, parent/group, missing required, or exclusivity violations. Ask for explicit authorization before creating any missing label.
 
 ## Estimates
 
@@ -105,10 +111,12 @@ Use `--parent [ISSUE_ID]` when:
 ## CLI Command
 
 ```bash
+LABELS="agent:[TYPE],[DOMAIN_LABEL],critical-path" # full validated issue-label set
+
 .agents/skills/linear/scripts/linear.sh issues create \
   --title "Implement user authentication service" \
   --project "Phase 1: Foundation" \
-  --labels "backend,agent:[TYPE],critical-path" \
+  --labels "$LABELS" \
   --estimate 3 \
   --description "## Summary
 Auth service for user login and session management.
@@ -144,8 +152,10 @@ See [prioritization.md](prioritization.md) for scoring formula and factor defini
 | Mistake | Fix |
 |---------|-----|
 | No project | Always add `--project` |
-| No/multiple agent labels | Exactly ONE `agent:*` |
-| Missing stack | Always add stack(s) |
+| Unknown label | Refresh issue-label inventory; do not rely on CLI warn-and-skip |
+| Parent/group label assigned | Use child label; never assign parent/group labels such as taxonomy group names |
+| No/multiple agent labels | Follow taxonomy; usually exactly ONE `agent:*` |
+| Missing domain/stack | Add required domain/stack labels from taxonomy |
 | Missing estimate | Always add `--estimate 1-5` |
 | Vague title | Use `[Verb] [outcome]` |
 | No acceptance criteria | Add testable outcomes |

--- a/skills/project-management/references/labels.md
+++ b/skills/project-management/references/labels.md
@@ -1,93 +1,248 @@
 # Label Management Reference
 
+Project-management workflows must treat issue labels as a validated contract, not free-form strings. Every issue create/update path uses two inputs:
+
+1. **Live issue-label inventory** from the issue tracker.
+2. **Project taxonomy/application rules** supplied by the project (for example in `vstack.toml` `[skill-instructions]`, project docs, or a project-specific reference file).
+
+Upstream workflows define the mechanism and schema. Projects define the actual label names, domains, colors, and required categories.
+
+## Issue Labels vs Project Labels
+
+| Resource | Used for | CLI/source |
+|----------|----------|------------|
+| Issue labels | Issue routing, ownership, workflow, classification, domain/stack tags | `.agents/skills/linear/scripts/linear.sh cache labels list` or `labels list` |
+| Project labels | Project/initiative categorization only | `.agents/skills/linear/scripts/linear.sh project-labels ...` |
+
+Issue creation/update preflight must use **issue labels only**. Never validate issue labels against project labels.
+
+## Mandatory Label Preflight
+
+Run this before any workflow creates an issue or updates issue labels (`roadmap-create`, `audit-issues`, `research-issue`, `research-complete`, `cycle-plan`, and any wrapper calling those paths):
+
+```bash
+# Refresh if cache missing, stale, or labels are empty.
+.agents/skills/linear/scripts/linear.sh sync --reconcile
+
+# Load live issue-label inventory.
+.agents/skills/linear/scripts/linear.sh cache labels list --format=safe
+```
+
+Safe inventory rows must provide enough metadata to reject parent/group labels:
+
+```json
+{
+  "id": "uuid",
+  "name": "agent:example",
+  "color": "#9C27B0",
+  "description": "...",
+  "team": "Team name or empty",
+  "parent": "Agent",
+  "is_group": false
+}
+```
+
+If `is_group` is missing from older caches, refresh the cache. If it remains unavailable, conservatively treat any label that is used as another label's `parent` as a parent/group label and do not assign it to issues.
+
+## Project Taxonomy Contract
+
+Projects supply taxonomy/application rules outside upstream workflow logic. This conceptual shape is portable; exact storage may be TOML, JSON, or prose if it maps unambiguously to these fields.
+
+```json
+{
+  "required_categories_for_new_issues": ["agent", "domain"],
+  "categories": {
+    "agent": {
+      "required": true,
+      "exclusive": true,
+      "match": {"prefix": "agent:"},
+      "forbid_group_labels": true
+    },
+    "platform": {
+      "required": false,
+      "exclusive": true,
+      "match": {"parent": "Platform"},
+      "forbid_group_labels": true
+    },
+    "domain": {
+      "required": true,
+      "exclusive": false,
+      "labels": ["project-specific-domain-labels"]
+    },
+    "workflow": {
+      "required": false,
+      "exclusive": false,
+      "labels": ["research", "blocked"]
+    },
+    "classification": {
+      "required": false,
+      "exclusive": false,
+      "labels": []
+    }
+  }
+}
+```
+
+Category matching order:
+
+1. Explicit `labels[]` list.
+2. `match.prefix`.
+3. `match.parent` from live inventory.
+4. Project-provided matcher/regex, if documented.
+
+If a label matches multiple categories, the project taxonomy must disambiguate before mutation.
+
+## Validation Rules
+
+Validate the **final label set** before every create/update:
+
+- Every label exists in live issue-label inventory.
+- No label has `is_group: true`.
+- No label name appears as a parent/group label for other labels.
+- Required categories for new issues are present.
+- Required exclusive categories have exactly one label.
+- Optional exclusive categories have at most one label.
+- Required non-exclusive categories have at least one label.
+- Labels not mapped by taxonomy are rejected unless the project taxonomy explicitly allows uncategorized labels.
+- Unknown labels stop the workflow and ask the user; workflows must not silently rely on CLI warn-and-skip behavior.
+- If a required taxonomy label is missing from the live inventory, report it and request explicit user authorization before creating it.
+
+Validation failure output should name:
+
+- requested label set
+- missing labels
+- parent/group labels attempted
+- category that failed required/exclusive rules
+- whether a missing label exists in taxonomy but not in issue tracker
+
+## Full Label Sets on Creates
+
+New issues must carry a full validated `labels[]` set. `agent` and `agent_label` may remain as derived/backward-compatible fields, but they are not enough to create an issue.
+
+Minimum create payload fields:
+
+```json
+{
+  "title": "Implement: example scope",
+  "labels": ["agent:example", "domain-example", "workflow-label"]
+}
+```
+
+Before calling `issues create --labels`, validate `labels[]` against the live inventory and project taxonomy.
+
+## Preserve Labels on Updates
+
+The Linear CLI `--labels` option replaces the full label set. Therefore update workflows must compute a final label set from current labels plus the intended change before calling `issues update --labels`.
+
+| Change intent | Algorithm |
+|---------------|-----------|
+| Replace `agent` | Fetch current labels, remove labels in taxonomy category `agent`, add new `agent:*`, preserve unrelated labels, preflight final set. |
+| Replace `platform` | Fetch current labels, remove labels in taxonomy category `platform`, add new platform child, preserve unrelated labels, preflight final set. |
+| Add workflow/classification/domain | Fetch current labels, union with new labels, preserve unrelated labels, preflight final set. |
+| Full replacement | Allowed only when workflow output explicitly says `replace_all_labels: true`; preflight full replacement set. |
+
+Never run snippets like:
+
+```bash
+.agents/skills/linear/scripts/linear.sh issues update [ISSUE_ID] --labels "agent:new"
+```
+
+unless the explicit intent is to remove every other label and the full replacement set has been validated.
+
 ## Exclusivity Rules
 
-See project label taxonomy for full taxonomy and colors.
+See the project's issue-label taxonomy for full taxonomy and colors.
 
-**Key rule**: Labels in a parent group (Agent, Platform) are exclusive — only ONE per issue. Labels without a parent (Stack, Workflow, Classification) allow multiples.
+**Key rule**: Labels in an exclusive parent/category group (for example Agent or Platform when configured that way) allow only one label per issue. Labels without an exclusive category (for example Stack, Workflow, Classification, depending on project policy) allow multiples.
 
-**"labelIds not exclusive child labels" error** = You tried to use multiple labels from Agent or Platform group.
+**"labelIds not exclusive child labels" error** = You tried to assign multiple labels from an exclusive group.
 
 ## When to Create Labels
 
 **Authorization rule**: Never create any label unprompted. All label creation requires explicit user authorization.
 
 **Create when**:
-- New agent added (requires agent definition first)
-- New stack component introduced
-- New workflow state needed
+- Project taxonomy requires the label and the user authorizes issue-label creation.
+- New agent added (requires agent definition first).
+- New stack/domain component introduced and taxonomy owner approves.
+- New workflow/classification state needed and taxonomy owner approves.
 
 **Do NOT create when**:
-- Existing label covers the use case
-- One-off categorization (use description instead)
-- No clear owner or purpose defined
+- Existing label covers the use case.
+- One-off categorization (use description instead).
+- No clear owner or purpose defined.
+- The label belongs to project labels rather than issue labels.
 
 ## Label Ownership
 
 | Label Type | Owner | Approval | Notes |
 |------------|-------|----------|-------|
 | `agent:*` | tpm | Yes | Requires project agent definition |
-| Stack | tpm | Yes | Architectural change |
+| Domain/Stack | tpm | Yes | Architectural/taxonomy change |
 | Workflow | tpm | Yes | Operational, but still requires user authorization |
 | Classification | tpm | Yes | Operational, but still requires user authorization |
-| Platform | tpm | Yes | Architectural change |
+| Platform | tpm | Yes | Architectural/taxonomy change |
 
 ## Creating Agent Labels
 
-Agent labels are special — MUST have agent definition AND parent group.
+Agent labels are special — MUST have agent definition AND parent group/category in the project taxonomy.
 
-`agent:researcher` is reserved for research issues owned by the researcher agent. It requires the canonical `researcher` agent definition and should be used with the `research` workflow/classification label.
+`agent:researcher` is reserved for research issues owned by the researcher agent. It requires the canonical `researcher` agent definition and should be used with the project-configured research workflow/classification label.
 
 ### Process
 
-1. **Create the agent definition** in project agent definitions
-2. **Update** project label taxonomy
-3. **tpm** creates label:
+1. **Create the agent definition** in project agent definitions.
+2. **Update** the project's issue-label taxonomy.
+3. **Get explicit user authorization** to create the issue label.
+4. **tpm** creates issue label:
    ```bash
    .agents/skills/linear/scripts/linear.sh labels create --name "agent:[NAME]" --color "#9C27B0" --parent "Agent"
    ```
 
 **TPM should NOT create any labels unprompted** — even workflow or classification labels require explicit user authorization. `agent:*` labels additionally require the agent definition and taxonomy entry to exist first.
 
-## Creating Other Labels
+## Creating Other Issue Labels
 
 ```bash
-# Workflow labels (no parent - independent)
-.agents/skills/linear/scripts/linear.sh labels create --name "needs-[ACTION]" --color "#757575"
+# Workflow labels (usually no parent/group, project policy decides)
+.agents/skills/linear/scripts/linear.sh labels create --name "[WORKFLOW_LABEL]" --color "#757575"
 
-# Classification labels (no parent - independent)
+# Classification labels (usually no parent/group, project policy decides)
 .agents/skills/linear/scripts/linear.sh labels create --name "[TYPE]" --color "#E53935"
 
-# Stack labels (requires review)
-.agents/skills/linear/scripts/linear.sh labels create --name "[STACK_NAME]" --color "#FF6B35"
+# Domain/stack labels (requires taxonomy review)
+.agents/skills/linear/scripts/linear.sh labels create --name "[DOMAIN_LABEL]" --color "#FF6B35"
 ```
 
-After creating, update project label taxonomy.
+After creating, update the project's issue-label taxonomy and rerun label preflight before mutation.
 
 ## Label Lifecycle
 
 ### Deprecating
 
-1. Remove from active issues (reassign)
-2. Archive in issue tracker (don't delete — preserves history)
-3. Mark deprecated in taxonomy
+1. Remove from active issues (reassign).
+2. Archive in issue tracker (do not delete — preserves history).
+3. Mark deprecated in taxonomy.
 
 ### Renaming
 
 Avoid renaming — creates confusion. Instead:
-1. Create new label with correct name
-2. Migrate issues from old to new
-3. Archive old label
+1. Create new label with correct name.
+2. Migrate issues from old to new.
+3. Archive old label.
 
 ## Checklist: New Label
 
 Before:
-- [ ] No existing label covers this
-- [ ] Determined parent group (exclusive) or none (independent)
-- [ ] Color consistent with category
-- [ ] Explicit user authorization obtained
+- [ ] No existing issue label covers this.
+- [ ] Determined category and exclusivity.
+- [ ] Confirmed this is an issue label, not a project label.
+- [ ] Color consistent with category.
+- [ ] Explicit user authorization obtained.
 
 After:
-- [ ] Label created in issue tracker
-- [ ] Taxonomy updated
-- [ ] Announced in handoff/comment
+- [ ] Issue label created in issue tracker.
+- [ ] Taxonomy updated.
+- [ ] Label inventory refreshed.
+- [ ] Preflight passes.
+- [ ] Announced in handoff/comment.

--- a/skills/project-management/schemas/audit-issues-input.md
+++ b/skills/project-management/schemas/audit-issues-input.md
@@ -23,6 +23,7 @@ Input file for issue audit workflows — transforms review agent findings into t
       "recommendation": "* Bullet-list requirements, each actionable",
       "priority": 2,
       "estimate": 2,
+      "labels": ["agent:[TYPE]", "[DOMAIN_LABEL]", "[WORKFLOW_LABEL]"],
       "category": "issue",
       "found_by": "agent-name",
       "origin": "suggestion|escalated|planned|discovered",
@@ -58,6 +59,7 @@ Input file for issue audit workflows — transforms review agent findings into t
 | `recommendation` | Yes | Bullet-list requirements. Becomes requirements section. |
 | `priority` | Yes | 1-4 |
 | `estimate` | Yes | 1-5 points |
+| `labels` | No for legacy callers; required before create | Full issue-label set. Callers/workflows must complete and validate this against live issue-label inventory + project taxonomy before issue creation. |
 | `category` | Yes | Always `issue` (fix items don't reach audit) |
 | `found_by` | Yes | Agent that identified the item |
 | `origin` | Yes | `suggestion`, `escalated`, `planned`, or `discovered` |
@@ -77,6 +79,7 @@ suggestions[].description → description
 suggestions[].recommendation → recommendation
 suggestions[].priority → priority
 suggestions[].estimate → estimate
+suggestions[].labels → labels[] when provided; otherwise complete through project taxonomy before create
 category: "issue"
 found_by: agent (from parent JSON)
 origin: "suggestion"
@@ -99,6 +102,7 @@ From dev agent completion summaries:
 bullet text → title + description
 estimate: N → estimate (default 2 if absent)
 priority: infer from type (bug=2, tech-debt=3, enhancement=4)
+labels: infer from project taxonomy + source context before create
 origin: "discovered"
 ```
 

--- a/skills/project-management/schemas/audit-output.md
+++ b/skills/project-management/schemas/audit-output.md
@@ -14,6 +14,15 @@ Output path: `tmp/audit-project-YYYYMMDD-HHMMSS.json` or `tmp/audit-issues-YYYYM
 }
 ```
 
+## Label Contract
+
+Any output that can create an issue or update issue labels must carry full label intent:
+
+- New issues: `create_fields.labels[]` is the complete issue-label set to pass to `issues create --labels` after preflight.
+- Existing issue updates: label findings specify intended operation (`add`, `replace_category`, or explicit full replacement) so callers preserve unrelated labels.
+- `agent_label` and `agent` are derived/backward-compatible fields only; they are not sufficient for mutation.
+- All labels refer to **issue labels**, never project labels.
+
 ## PROJECT Mode Finding Arrays
 
 Located at `findings.*`:
@@ -23,8 +32,8 @@ Located at `findings.*`:
 | `add_relations[]` | `from`, `rel`, `to`, `reason` |
 | `remove_relations[]` | `from`, `rel`, `to`, `uuid`, `reason` |
 | `priority_misalignment[]` | `id`, `title`, `current`, `should_be`, `reason` |
-| `agent_mismatch[]` | `id`, `title`, `current`, `should_be`, `reason`, `signals[]` |
-| `label_cooccurrence[]` | `id`, `title`, `present`, `missing`, `reason` |
+| `agent_mismatch[]` | `id`, `title`, `current`, `should_be`, `reason`, `signals[]` (`replace_category: agent` implied) |
+| `label_cooccurrence[]` | `id`, `title`, `present`, `missing`, `reason` (`add` missing label implied) |
 | `duplicates[]` | `keep`, `remove`, `reason` |
 | `obsolete[]` | `issue`, `reason`, `evidence{}`, `confidence` |
 | `wrong_project[]` | `issue`, `title`, `from`, `to`, `to_id`, `reason` |
@@ -103,9 +112,11 @@ Located at `findings.*`:
     "rationale": "string",
     "requires_reopen": false
   },
-  "recommended_issue": {"title": "...", "agent": "...", "priority": "1-4", "estimate": "1-5", "blocks": [], "labels": []}
+  "recommended_issue": {"title": "...", "agent": "...", "priority": "1-4", "estimate": "1-5", "blocks": [], "labels": ["agent:[TYPE]", "[DOMAIN_LABEL]"]}
 }
 ```
+
+`recommended_issue.labels[]` must be the full issue-label set for the gap issue, not only an agent label.
 
 **`project_recommendations[]`**:
 
@@ -149,7 +160,21 @@ Located at `findings.*`:
       "priority_misalignment": {"current": 3, "should_be": 1, "reason": "..."},
       "agent_mismatch": {"current": "...", "should_be": "...", "signals": [], "reason": "..."},
       "label_cooccurrence": {"present": "[signals]", "missing": "design", "reason": "..."},
+      "label_updates": [
+        {"mode": "add", "category": "domain", "labels": ["design"], "reason": "..."}
+      ],
       "hierarchy": {"action": "none|make_child", "parent": "[ISSUE_ID]|#N|null"},
+      "create_fields": {
+        "description": "Issue body summary",
+        "recommendation": "* Requirements bullets",
+        "location": "path or component",
+        "estimate": 3,
+        "priority": 2,
+        "agent_label": "agent:[TYPE]",
+        "labels": ["agent:[TYPE]", "[DOMAIN_LABEL]", "[WORKFLOW_LABEL]"],
+        "is_bundle_parent": false,
+        "source_path": "docs/roadmaps/roadmap-feature.md"
+      },
       "supersedes": [
         {"identifier": "[ISSUE_ID]", "title": "Issue title", "reason": "Scope fully covered by this issue"}
       ],
@@ -159,6 +184,19 @@ Located at `findings.*`:
   ]
 }
 ```
+
+### ISSUE Mode Label Fields
+
+| Field | Meaning |
+|-------|---------|
+| `create_fields.labels[]` | Required for `action=create`; full validated issue-label set. |
+| `create_fields.agent_label` | Optional derived/backward-compatible agent label; do not use alone for create. |
+| `label_updates[].mode` | `add`, `replace_category`, or `replace_all`. |
+| `label_updates[].category` | Taxonomy category affected when `mode=replace_category` or category-aware add. |
+| `label_updates[].labels[]` | Labels being added/replaced. Caller computes final labels from current issue labels and preflights. |
+| `label_updates[].final_labels[]` | Optional explicit final full label set. Required when `mode=replace_all`. |
+
+When `label_cooccurrence.missing` is present without `label_updates[]`, callers treat it as `mode=add` for the taxonomy category that contains the missing label.
 
 ## Action Values
 

--- a/skills/project-management/schemas/cycle-plan-output.md
+++ b/skills/project-management/schemas/cycle-plan-output.md
@@ -106,13 +106,36 @@ Normal cycle planning output:
     "set_priorities": [{"id": "[ISSUE_ID]", "priority": 1}, {"id": "[OTHER_ISSUE_ID]", "priority": 2}],
     "set_sort_order": [{"id": "[ISSUE_ID]", "sort_order": 100}, {"id": "[OTHER_ISSUE_ID]", "sort_order": 200}],
     "set_estimates": [{"id": "[ISSUE_ID]", "estimate": 3}],
-    "set_labels": [{"id": "[ISSUE_ID]", "labels": ["agent:[TYPE]"]}],
+    "set_labels": [
+      {
+        "id": "[ISSUE_ID]",
+        "mode": "replace_category",
+        "category": "agent",
+        "labels": ["agent:[TYPE]"],
+        "preserve_existing": true
+      }
+    ],
     "update_initiative": {"id": "uuid", "status": "Active"},
     "update_project": {"id": "uuid", "state": "started"},
     "create_cycle": null
   }
 }
 ```
+
+### Label Update Actions
+
+`actions.set_labels[]` describes intent, not a partial replacement. The caller must fetch current issue labels, compute the full final label set, preserve unrelated labels unless `mode=replace_all`, preflight, and then call `issues update --labels` with the full final set.
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `id` | Yes | Issue ID to update |
+| `mode` | Yes | `add`, `replace_category`, or `replace_all` |
+| `category` | When category-aware | Project taxonomy category affected (for example `agent`, `platform`, `domain`) |
+| `labels[]` | Yes | Labels to add or replace into the category |
+| `preserve_existing` | Yes unless `final_labels[]` present | Must be `true` for `add`/`replace_category` |
+| `final_labels[]` | Required for `replace_all` | Full final issue-label set |
+
+Unknown labels, parent/group labels, missing required categories, and exclusivity violations stop execution before mutation.
 
 ### Create Cycle Action
 

--- a/skills/project-management/schemas/roadmap-plan-input.md
+++ b/skills/project-management/schemas/roadmap-plan-input.md
@@ -28,6 +28,7 @@ Input file for roadmap analysis, created by orchestrator after specialist agent 
       "title": "Add dispose safety seam",
       "estimate": 2,
       "agent": "backend",
+      "labels": ["agent:[TYPE]", "[DOMAIN_LABEL]"],
       "depends_on_proposed": ["Add error propagation"],
       "depends_on_existing": ["PROJ-301"],
       "conflicts_with": ["Current dispose pattern"],
@@ -55,6 +56,7 @@ Input file for roadmap analysis, created by orchestrator after specialist agent 
 | `title` | Yes | Issue title in "Verb: outcome" format |
 | `estimate` | Yes | 1-5 points |
 | `agent` | Yes | Source agent type |
+| `labels` | No | Full issue-label set when known. Orchestrator/TPM must complete and validate required taxonomy categories before creation. |
 | `depends_on_proposed` | No | Title references to other proposed issues |
 | `depends_on_existing` | No | Issue ID references to existing issues |
 | `conflicts_with` | No | Existing code/patterns that would be replaced |
@@ -70,6 +72,7 @@ Agent response table row → proposed_issue entry
 - Title column → title
 - Estimate column → estimate
 - Agent source → agent
+- Labels column → labels[] (optional; full issue-label set if specialist knows project taxonomy)
 - "Depends on (proposed)" → depends_on_proposed
 - "Depends on (existing)" → depends_on_existing
 - "Conflicts with" → conflicts_with

--- a/skills/project-management/schemas/roadmap-plan-output.md
+++ b/skills/project-management/schemas/roadmap-plan-output.md
@@ -188,6 +188,7 @@ Output from TPM roadmap analysis, consumed by orchestrator for presentation and 
     "title": "Implement request router",
     "estimate": 3,
     "agent": "backend",
+    "labels": ["agent:[TYPE]", "[DOMAIN_LABEL]"],
     "priority": 1,
     "action": "create",
     "target": null,
@@ -210,6 +211,7 @@ Output from TPM roadmap analysis, consumed by orchestrator for presentation and 
     "estimate": null,
     "agent": "multi",
     "agent_label": "agent:multi",
+    "labels": ["agent:multi", "[DOMAIN_LABEL]"],
     "priority": 2,
     "action": "create",
     "target": null,
@@ -230,6 +232,7 @@ Output from TPM roadmap analysis, consumed by orchestrator for presentation and 
     "title": "Implement JWT validation middleware",
     "estimate": 2,
     "agent": "backend",
+    "labels": ["agent:[TYPE]", "[DOMAIN_LABEL]"],
     "priority": 2,
     "action": "create",
     "target": null,
@@ -284,7 +287,16 @@ Lower position = earlier in implementation order.
 - `is_bundle_parent: true` → aggregate issue, `estimate: null`
 - `parent_title` set → child of that bundle
 - Bundle when 2+ issues share: same agent + small estimates (1-2) + same work type
-- `agent_label`: If all children have same agent → parent gets that agent. If 2+ distinct agents → `agent:multi`
+- `labels[]`: Full issue-label set for creation. Required before `roadmap-create` mutates Linear.
+- `agent_label`: Backward-compatible derived field. If all children have same agent → parent gets that agent label. If 2+ distinct agents → parent gets the project-configured multi-agent label (for example `agent:multi` when present in taxonomy/inventory).
+
+### Label Rules
+
+- Labels are issue labels, not project labels.
+- `labels[]` must include all project-required categories for new issues.
+- Do not include parent/group labels.
+- If TPM cannot determine a required category, it should flag the gap in `reason` instead of inventing labels.
+- `agent`/`agent_label` are not enough for create; `roadmap-create` must preflight the full `labels[]` set against live inventory and project taxonomy.
 
 ### Action Assignment (from TPM 5.2)
 

--- a/skills/project-management/tests/label-preflight-contract.test.sh
+++ b/skills/project-management/tests/label-preflight-contract.test.sh
@@ -40,12 +40,16 @@ roadmap_plan="$SKILL_DIR/workflows/roadmap-plan.md"
 require_pattern "$roadmap_plan" 'RESEARCH_WORKFLOW_LABEL' 'taxonomy-derived research lookup label'
 require_pattern "$roadmap_plan" 'do not query a hard-coded fallback label' 'hard-coded research fallback guard'
 
+research_spike="$SKILL_DIR/workflows/research-spike.md"
+require_pattern "$research_spike" 'RESEARCH_WORKFLOW_LABEL' 'taxonomy-derived research spike lookup label'
+require_pattern "$research_spike" 'do not query a hard-coded fallback label' 'research spike hard-coded fallback guard'
+
 research_issue="$SKILL_DIR/workflows/research-issue.md"
 require_pattern "$research_issue" 'RESEARCH_WORKFLOW_LABEL' 'taxonomy-derived research create label'
 require_pattern "$research_issue" 'do not assume the literal name `research` exists' 'literal research label guard'
 
-if grep -R --line-number --fixed-strings -- '--label "research"' "$SKILL_DIR/workflows"; then
-  fail 'hard-coded --label "research" remains in project-management workflows'
+if grep -R --line-number -E -- '--label(=|[[:space:]]+)"?research"?([[:space:]]|$)' "$SKILL_DIR/workflows"; then
+  fail 'hard-coded --label research remains in project-management workflows'
 fi
 
 if grep -R --line-number --fixed-strings -- '["agent:researcher", "research", DOMAINS...]' "$SKILL_DIR/workflows"; then

--- a/skills/project-management/tests/label-preflight-contract.test.sh
+++ b/skills/project-management/tests/label-preflight-contract.test.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Regression test for project-management Linear issue-label contract.
+# These workflows are markdown contracts, so this test statically verifies that
+# create/update paths load issue-label inventory, require strict preflight, and
+# avoid hard-coded project-specific research labels.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+require_pattern() {
+  local file="$1" pattern="$2" desc="$3"
+  if ! grep -Eq -- "$pattern" "$file"; then
+    fail "$desc missing in ${file#$SKILL_DIR/}"
+  fi
+}
+
+mutation_workflows=(
+  workflows/roadmap-create.md
+  workflows/audit-issues.md
+  workflows/research-issue.md
+  workflows/research-complete.md
+  workflows/cycle-plan.md
+)
+
+for rel in "${mutation_workflows[@]}"; do
+  file="$SKILL_DIR/$rel"
+  [[ -f "$file" ]] || fail "workflow not found: $rel"
+  require_pattern "$file" 'cache labels list --format=safe' 'issue-label inventory load'
+  require_pattern "$file" 'labels\.md|Strict Label Preflight|Label Policy|label policy|preflight' 'label preflight reference'
+  require_pattern "$file" 'Unknown labels, parent/group labels, missing required categories, or exclusivity violations halt before mutation|unknown labels, parent/group labels, missing required categories, or exclusivity violations halt' 'strict halt behavior'
+done
+
+roadmap_plan="$SKILL_DIR/workflows/roadmap-plan.md"
+require_pattern "$roadmap_plan" 'RESEARCH_WORKFLOW_LABEL' 'taxonomy-derived research lookup label'
+require_pattern "$roadmap_plan" 'do not query a hard-coded fallback label' 'hard-coded research fallback guard'
+
+research_issue="$SKILL_DIR/workflows/research-issue.md"
+require_pattern "$research_issue" 'RESEARCH_WORKFLOW_LABEL' 'taxonomy-derived research create label'
+require_pattern "$research_issue" 'do not assume the literal name `research` exists' 'literal research label guard'
+
+if grep -R --line-number --fixed-strings -- '--label "research"' "$SKILL_DIR/workflows"; then
+  fail 'hard-coded --label "research" remains in project-management workflows'
+fi
+
+if grep -R --line-number --fixed-strings -- '["agent:researcher", "research", DOMAINS...]' "$SKILL_DIR/workflows"; then
+  fail 'hard-coded research create label remains in VALIDATED_LABELS'
+fi
+
+echo "all pass"

--- a/skills/project-management/workflows/audit-issues.md
+++ b/skills/project-management/workflows/audit-issues.md
@@ -492,6 +492,8 @@ Before any approved mutation that creates an issue or changes labels:
 4. **Halt before mutation** on unknown labels, parent/group labels, missing required categories, or exclusivity violations. Report the failing label set and ask the user. If a required taxonomy label is missing from Linear, request explicit authorization before creating it; never create labels automatically.
 5. **Use only validated final labels** in `issues create --labels` or `issues update --labels`.
 
+Unknown labels, parent/group labels, missing required categories, or exclusivity violations halt before mutation.
+
 Do not run `issues update --labels "agent:new"` or any other partial label replacement unless the validated final label set really contains only that label.
 
 For each approved change:

--- a/skills/project-management/workflows/audit-issues.md
+++ b/skills/project-management/workflows/audit-issues.md
@@ -47,9 +47,10 @@ Set MODE and TARGET from input:
 ```bash
 .agents/skills/linear/scripts/linear.sh sync --reconcile
 .agents/skills/linear/scripts/linear.sh session-status
+.agents/skills/linear/scripts/linear.sh cache labels list --format=safe
 ```
 
-Extract `project` field for fallback resolution.
+Extract `project` field for fallback resolution. Store the issue-label inventory for all create/update preflights. Load project taxonomy/application rules from project configuration/docs (for example `vstack.toml` `[skill-instructions]`). Use issue labels only; never validate issue creates against project labels.
 
 ### 1.3 Route by Mode
 
@@ -370,9 +371,9 @@ Display findings table. Omit empty sections.
 
 ### ✨ CREATE
 
-| # | Title | Project | Agent | Relations | Structure | Reason |
-|---|-------|---------|-------|-----------|-----------|--------|
-| 1 | Add ring buffer tests | Phase 2.5 | [AGENT_TYPE] | — | — | New tests needed |
+| # | Title | Project | Labels | Relations | Structure | Reason |
+|---|-------|---------|--------|-----------|-----------|--------|
+| 1 | Add ring buffer tests | Phase 2.5 | agent:[TYPE], [domain] | — | — | New tests needed |
 
 ### 🔄 SUPERSEDE (via CREATE above)
 
@@ -473,6 +474,26 @@ Ask user with multi-select. Only show categories with findings.
 
 ## 7. Execute Approved Changes
 
+### 7.0 Strict Label Preflight
+
+Before any approved mutation that creates an issue or changes labels:
+
+1. **Build intended label operations** from approved findings:
+   - `create` and architecture/research gap issues: final `labels[]` from `create_fields.labels[]` or recommended issue labels.
+   - `agent_mismatch`: `replace_category` for taxonomy category `agent`.
+   - `label_cooccurrence`: `add` the missing label/category label.
+   - Any `set_labels[]`/metadata update: use its explicit mode (`add`, `replace_category`, or `replace_all`) and target category when present.
+2. **For existing issues**, fetch current labels and compute the full final set:
+   ```bash
+   .agents/skills/linear/scripts/linear.sh cache issues get [ISSUE_ID]
+   ```
+   Preserve unrelated labels. Replace only labels in the target taxonomy category unless the action explicitly says `replace_all_labels: true`.
+3. **Validate final labels** with the inventory/taxonomy loaded in § 1.2 per [labels.md](../references/labels.md).
+4. **Halt before mutation** on unknown labels, parent/group labels, missing required categories, or exclusivity violations. Report the failing label set and ask the user. If a required taxonomy label is missing from Linear, request explicit authorization before creating it; never create labels automatically.
+5. **Use only validated final labels** in `issues create --labels` or `issues update --labels`.
+
+Do not run `issues update --labels "agent:new"` or any other partial label replacement unless the validated final label set really contains only that label.
+
 For each approved change:
 
 1. **Read the referenced section** from the issue tracker CLI's workflow-actions patterns.
@@ -514,9 +535,9 @@ Process `create` actions first -- use created IDs to resolve `#N` references in 
 | supersede, combine | workflow-actions § Cancel / Merge / Combine |
 | cancel | workflow-actions § Cancel Obsolete Issues |
 
-**Create template**: Use project-level templates issue-description-template for `--description`. For parent/bundle issues, use project-level templates parent-issue-template. Always heredoc, never inline strings.
+**Create template**: Use project-level templates issue-description-template for `--description`. For parent/bundle issues, use project-level templates parent-issue-template. Always heredoc, never inline strings. Every create command must include `--labels "[VALIDATED_FINAL_LABELS]"` from § 7.0.
 
-**Analyzed mode**: When MODE = analyzed, issue creation fields (description, recommendation, location, estimate, priority, agent_label, source_path) come from `issues[].create_fields`. Use `source_path` for `[ORIGIN_CONTEXT]` in issue-description-template. For bundle parents (`create_fields.is_bundle_parent: true`), use parent-issue-template. Top-level `parent_issue` and `research_ref` available for hierarchy fallback and description refs.
+**Analyzed mode**: When MODE = analyzed, issue creation fields (description, recommendation, location, estimate, priority, agent_label, labels, source_path) come from `issues[].create_fields`. `create_fields.labels[]` is authoritative and required for create; `agent_label` is derived/backward-compatible only. Use `source_path` for `[ORIGIN_CONTEXT]` in issue-description-template. For bundle parents (`create_fields.is_bundle_parent: true`), use parent-issue-template. Top-level `parent_issue` and `research_ref` available for hierarchy fallback and description refs.
 
 **Inherit parent refs**: When creating a child issue (`hierarchy.action: "make_child"`), check parent's description for `**Research**:` and `**Decision**:` lines. Include them at the top of the child's description (before `**Source**:`). This ensures sub-issues inherit research/decision context even when `research_ref`/`decision_ref` are not in the audit input.
 

--- a/skills/project-management/workflows/cycle-plan.md
+++ b/skills/project-management/workflows/cycle-plan.md
@@ -140,6 +140,18 @@ JSON contains full plan with `velocity`, `planned_work`, `not_included`, `action
 
 ## 4. Execute Actions
 
+### 4.0 Load Label Policy for Label Updates
+
+Before executing any `actions.set_labels[]` entry:
+
+1. Load issue-label inventory and project taxonomy per [labels.md](../references/labels.md):
+   ```bash
+   .agents/skills/linear/scripts/linear.sh sync --reconcile
+   .agents/skills/linear/scripts/linear.sh cache labels list --format=safe
+   ```
+2. For each target issue, fetch current labels, compute the full final label set, preserve unrelated labels, and replace only the intended taxonomy category unless the action explicitly says `replace_all_labels: true`.
+3. Preflight the final label set. Unknown labels, parent/group labels, missing required categories, or exclusivity violations halt before mutation.
+
 ### 4.1 Create Cycle (if actions.create_cycle exists)
 
 **Skip if** `actions.create_cycle` is null.
@@ -161,7 +173,7 @@ JSON contains full plan with `velocity`, `planned_work`, `not_included`, `action
    | Assign to cycle | § Cycle Assignment | `actions.assign_to_cycle[]` (issue IDs) |
    | Set sort order | `.agents/skills/linear/scripts/linear.sh issues update [ID] --sort-order [VALUE]` | `actions.set_sort_order[]` (parent/standalone only, AFTER cycle assignment) |
    | Set estimates | § Estimate & Label Updates | `actions.set_estimates[]` |
-   | Set agent labels | § Estimate & Label Updates | `actions.set_labels[]` |
+   | Set labels | § Estimate & Label Updates | `actions.set_labels[]` with mode/category/final-label semantics from schema; run § 4.0 first |
    | Update initiative | § Initiative & Project Status | `actions.update_initiative` |
    | Update project | § Initiative & Project Status | `actions.update_project` |
 

--- a/skills/project-management/workflows/research-complete.md
+++ b/skills/project-management/workflows/research-complete.md
@@ -29,6 +29,15 @@ Link completed research to blocked issues, analyze impact, create follow-up work
 
 ## 2. Ensure Domain Labels
 
+Load issue-label inventory and project taxonomy before inspecting or updating labels:
+
+```bash
+.agents/skills/linear/scripts/linear.sh sync --reconcile
+.agents/skills/linear/scripts/linear.sh cache labels list --format=safe
+```
+
+Use issue labels only. Domain/stack labels, `agent:*`, and workflow/classification labels must be validated against [labels.md](../references/labels.md) before any update.
+
 **Two distinct concepts**:
 
 | Concept | Purpose | Example |
@@ -44,9 +53,9 @@ From § 1 response, check `.labels` array for domain/stack labels.
 
 1. **Analyze `findings.md`** content for domain indicators -- infer from component paths (project-configurable).
 
-2. **Update labels** (must include existing + new):
+2. **Update labels** (must include existing + new): compute `FINAL_LABELS = EXISTING_LABELS + INFERRED_LABELS`, preserve unrelated labels, preflight final labels, then update.
    ```bash
-   .agents/skills/linear/scripts/linear.sh issues update [ISSUE_ID] --labels "[EXISTING_LABELS],[INFERRED_LABELS]"
+   .agents/skills/linear/scripts/linear.sh issues update [ISSUE_ID] --labels "[FINAL_LABELS]"
    ```
 
 3. **If unclear or multi-domain** → add all likely domains; routing handles escalation
@@ -131,7 +140,7 @@ Execute ONE flow based on § 3 unless meets escalation criteria as defined.
 
 3. **Check for escalation**
    - If cross-domain impact reported:
-     - Add domain labels from agent report: `.agents/skills/linear/scripts/linear.sh issues update [ISSUE_ID] --labels "[EXISTING_LABELS],[NEW_DOMAINS]"`
+     - Add domain labels from agent report: compute `FINAL_LABELS = EXISTING_LABELS + NEW_DOMAINS`, preflight against § 2 inventory/taxonomy, then `.agents/skills/linear/scripts/linear.sh issues update [ISSUE_ID] --labels "[FINAL_LABELS]"`
      - Update issue description -- append `## Affected Domains` section with domains from agent report
      - **Switch to § 5.2**. Do not assess severity--let each affected domain analyze its own impact.
    - If initiative-level scope (10+ issues, needs phasing):
@@ -306,7 +315,7 @@ Count distinct domains across merged requirements from § 6.4. If 2+ domains, de
 
 1. **Group ALL requirements by domain** → one sub-issue per domain (including domains from original scope). Sub-issues must be in parent's project.
 2. **Title format**: `[Domain verb]: [scope] for [DECISION_ID]` (e.g., "Implement GBM tick generator for D012", "Add order panel view for D012")
-3. **Set labels**: `agent:[TYPE]` per domain, appropriate stack labels
+3. **Set labels**: full validated `labels[]` per sub-issue (`agent:[TYPE]` per domain plus required domain/stack/workflow/classification labels). Validate with § 2 inventory/taxonomy before writing the audit-input file.
 4. **Determine blocking order**: Read [agent-sequencing.md](../../linear-orch/workflows/agent-sequencing.md). Record as `blocks_items`/`blocked_by_items` for step 6.
 5. **Include supplementary findings** from agent reports as requirements in the appropriate domain sub-issue -- don't create separate issues for small supplementary items that belong to the same domain
 6. **Build audit-input file** with formatted titles:
@@ -318,6 +327,7 @@ Count distinct domains across merged requirements from § 6.4. If 2+ domains, de
    - `research_issue`: `[ISSUE_ID]` (the research issue being completed)
    - `research_ref`: `[RESEARCH_DOCS_PATH]/[ISSUE_ID]/findings.md`
    - `decision_ref`: `[DECISION_ID]`
+   - Each `items[]` entry includes `labels[]` with the full validated issue-label set.
 7. **Include refactors**: Add agent-reported refactors as additional items with `origin: "discovered"`, no `blocks_items`/`blocked_by_items`. TPM routes to appropriate project (typically Tech Debt) via § 6.3.
 8. **Write file**: `tmp/audit-research-YYYYMMDD-HHMMSS.json`
 9. **Run Workflow**: `⤵ workflows/audit-issues.md --issues [FILE_PATH] § 1-9 → § 6.6`
@@ -339,10 +349,10 @@ Update each blocked issue (from § 1 `.blocks` array) to reflect research outcom
    - **Add `## Requirements`**: One bullet per deliverable from decision
    - **Add `## Context`**: Key constraints, cross-references
 
-4. **Set parent label** to `agent:multi` if children span 2+ distinct `agent:[TYPE]` domains (per project-level templates parent-issue-template)
+4. **Set parent label** to the project-configured multi-agent label (for example `agent:multi` when present) if children span 2+ distinct taxonomy `agent` domains. Compute final parent labels from current labels, replace only the `agent` category, preserve unrelated labels, preflight, then update.
 
 5. **Update metadata** if research changed scope:
-   - **Labels**: Add domain labels if cross-domain work discovered
+   - **Labels**: Add domain labels if cross-domain work discovered. Compute final labels from current labels + additions, preserve unrelated labels, preflight, then update.
    - **Estimate**: Adjust if research revealed significantly more/less work
 
 6. **Invalidate parallel groups**: Description rewrites change issue scope, invalidating cached parallel-check results.

--- a/skills/project-management/workflows/research-complete.md
+++ b/skills/project-management/workflows/research-complete.md
@@ -38,6 +38,8 @@ Load issue-label inventory and project taxonomy before inspecting or updating la
 
 Use issue labels only. Domain/stack labels, `agent:*`, and workflow/classification labels must be validated against [labels.md](../references/labels.md) before any update.
 
+Unknown labels, parent/group labels, missing required categories, or exclusivity violations halt before mutation.
+
 **Two distinct concepts**:
 
 | Concept | Purpose | Example |

--- a/skills/project-management/workflows/research-issue.md
+++ b/skills/project-management/workflows/research-issue.md
@@ -48,13 +48,17 @@ Load issue-label inventory and project taxonomy per [labels.md](../references/la
 .agents/skills/linear/scripts/linear.sh cache labels list --format=safe
 ```
 
-Build `VALIDATED_LABELS = ["agent:researcher", "research", DOMAINS...]` using issue labels only. Validate that:
+Resolve `RESEARCH_WORKFLOW_LABEL` from the project taxonomy/application rules and live issue-label inventory. It is the project-configured workflow/classification label for research issues; do not assume the literal name `research` exists.
+
+Build `VALIDATED_LABELS = ["agent:researcher", RESEARCH_WORKFLOW_LABEL, DOMAINS...]` using issue labels only. Validate that:
 - `agent:researcher` exists in live issue-label inventory and is not a parent/group label.
-- The project-configured research workflow/classification label exists.
+- `RESEARCH_WORKFLOW_LABEL` exists in live issue-label inventory, is assignable to issues, and satisfies the project-configured research workflow/classification category.
 - Every `[DOMAINS]` entry exists as an issue label and satisfies the taxonomy domain/category rules.
 - Required categories and exclusivity rules pass.
 
 If any label is missing or invalid, halt before create. If a required taxonomy label is missing from Linear, report it and ask for explicit user authorization before creating it; do not create labels automatically.
+
+Unknown labels, parent/group labels, missing required categories, or exclusivity violations halt before mutation.
 
 ### 1.3 Create Issue
 

--- a/skills/project-management/workflows/research-issue.md
+++ b/skills/project-management/workflows/research-issue.md
@@ -41,6 +41,21 @@ Confirm all required variables are set. If [TYPE] not provided, determine from [
 
 Strategic requires explicit caller designation (initiative-level scope).
 
+Load issue-label inventory and project taxonomy per [labels.md](../references/labels.md):
+
+```bash
+.agents/skills/linear/scripts/linear.sh sync --reconcile
+.agents/skills/linear/scripts/linear.sh cache labels list --format=safe
+```
+
+Build `VALIDATED_LABELS = ["agent:researcher", "research", DOMAINS...]` using issue labels only. Validate that:
+- `agent:researcher` exists in live issue-label inventory and is not a parent/group label.
+- The project-configured research workflow/classification label exists.
+- Every `[DOMAINS]` entry exists as an issue label and satisfies the taxonomy domain/category rules.
+- Required categories and exclusivity rules pass.
+
+If any label is missing or invalid, halt before create. If a required taxonomy label is missing from Linear, report it and ask for explicit user authorization before creating it; do not create labels automatically.
+
 ### 1.3 Create Issue
 
 Create issue using input variables.
@@ -49,7 +64,7 @@ Create issue using input variables.
 .agents/skills/linear/scripts/linear.sh issues create \
   --title "Research: [TOPIC]" \
   --project "[PROJECT]" \
-  --labels "agent:researcher,research,[DOMAINS]" \
+  --labels "[VALIDATED_LABELS]" \
   --priority 2 \
   --estimate 1 \
   --description "[DESCRIPTION]"

--- a/skills/project-management/workflows/research-spike.md
+++ b/skills/project-management/workflows/research-spike.md
@@ -57,17 +57,23 @@ Ask any additional clarifying questions needed before proceeding, based on topic
 
 ### 2.2 Check Related Research
 
-1. **Search for related research**:
+1. **Resolve research issue label**:
+   - Load issue-label inventory: `.agents/skills/linear/scripts/linear.sh cache labels list --format=safe`.
+   - Load project taxonomy/application rules.
+   - Resolve `RESEARCH_WORKFLOW_LABEL` to the project-configured issue label for completed research artifacts.
+   - If no unambiguous assignable issue label exists, skip related-research lookup and continue to § 3 (do not query a hard-coded fallback label).
+
+2. **Search for related research**:
    ```bash
-   .agents/skills/linear/scripts/linear.sh cache issues list --label research --max --search "[TOPIC_KEYWORDS]"
+   .agents/skills/linear/scripts/linear.sh cache issues list --label "[RESEARCH_WORKFLOW_LABEL]" --max --search "[TOPIC_KEYWORDS]"
    ```
 
-2. **If matches found**:
+3. **If matches found**:
    1. **Read the findings file** - project research docs `[ISSUE_ID]/findings.md`
    2. **Extract ALL key findings** - summary paragraph, bullet lists, Go/No-Go sections
    3. **Set [PRIOR_RESEARCH]** - extracted findings for handoff in § 3.3
 
-3. **Notify user**:
+4. **Notify user**:
    ```
    Prior Research: [ISSUE_ID] - [TITLE]
    ```

--- a/skills/project-management/workflows/roadmap-create.md
+++ b/skills/project-management/workflows/roadmap-create.md
@@ -301,6 +301,7 @@ For bundle parents: use parent-issue-template format (`is_bundle_parent: true`, 
 - If `labels[]` is missing but legacy `agent`/`agent_label` exists, complete `labels[]` from project taxonomy and issue context before mutation.
 - Validate every `labels[]` set against § 6.0 inventory/taxonomy before writing the audit file.
 - Unknown labels, parent/group labels, missing required categories, or exclusivity violations halt the workflow and ask the user. Do not let the Linear CLI warn-and-skip invalid labels.
+- Unknown labels, parent/group labels, missing required categories, or exclusivity violations halt before mutation.
 
 **Top-level metadata**:
 

--- a/skills/project-management/workflows/roadmap-create.md
+++ b/skills/project-management/workflows/roadmap-create.md
@@ -39,6 +39,7 @@ Extract `PLAN_PATH` from `@[path]` argument.
 | `PROJECT_DESC` | Description field |
 | `PROJECT_RELATIONS[]` | "Project Relations" table |
 | `ISSUES[]` | "Issues" table |
+| `ISSUES[].labels[]` | "Labels" column, comma-separated (legacy plans may omit; must be completed before create) |
 | `GAPS[]` | "Architecture Gaps" table |
 | `BREAKING_CHANGES[]` | "Breaking Changes" table |
 
@@ -219,6 +220,19 @@ Project ordering handled when `workflows/audit-issues.md` runs with `project-ord
 
 ## 6. Create Issues
 
+### 6.0 Load Label Policy
+
+Before converting or creating any issue payload:
+
+1. **Load live issue-label inventory** per [labels.md](../references/labels.md):
+   ```bash
+   .agents/skills/linear/scripts/linear.sh sync --reconcile
+   .agents/skills/linear/scripts/linear.sh cache labels list --format=safe
+   ```
+2. **Load project taxonomy/application rules** from project configuration/docs (for example `vstack.toml` `[skill-instructions]`).
+3. **Use issue labels only**. Do not validate against project labels.
+4. **Halt before § 6.1** if taxonomy is missing and labels cannot be validated.
+
 ### 6.1 Create Issues via Audit
 
 **If `TPM_OUTPUT` is not null** → JSON conversion below (skip tpm-audit).
@@ -274,12 +288,19 @@ Bundle children always reference their bundle parent as `#N`.
   "estimate": 3,
   "priority": 1,
   "agent_label": "agent:[TYPE]",
+  "labels": ["agent:[TYPE]", "[DOMAIN_LABEL]", "[WORKFLOW_LABEL]"],
   "is_bundle_parent": false,
   "source_path": "docs/roadmaps/roadmap-[FEATURE].md"
 }
 ```
 
-For bundle parents: use parent-issue-template format (`is_bundle_parent: true`, no description/recommendation -- populated after children created via § Sync Parent Description).
+For bundle parents: use parent-issue-template format (`is_bundle_parent: true`, no description/recommendation -- populated after children created via § Sync Parent Description). Keep `agent_label` for backward compatibility, but `labels[]` is authoritative for create.
+
+**Label mapping and preflight**:
+- Source labels from `organized_issues[i].labels[]`.
+- If `labels[]` is missing but legacy `agent`/`agent_label` exists, complete `labels[]` from project taxonomy and issue context before mutation.
+- Validate every `labels[]` set against § 6.0 inventory/taxonomy before writing the audit file.
+- Unknown labels, parent/group labels, missing required categories, or exclusivity violations halt the workflow and ask the user. Do not let the Linear CLI warn-and-skip invalid labels.
 
 **Top-level metadata**:
 
@@ -309,6 +330,7 @@ Build audit-input file from markdown plan per [audit-issues-input.md](../schemas
 | "From roadmap" | `recommendation` |
 | TPM-computed `priority` | `priority` (from `organized_issues[].priority` -- do NOT default to P2) |
 | Estimate | `estimate` |
+| Labels column | `labels[]` (full issue-label set; if absent, complete from taxonomy before create) |
 | `"issue"` | `category` |
 | `"tpm"` | `found_by` |
 | `"planned"` | `origin` |
@@ -326,6 +348,8 @@ Source: `"roadmap-create"` | Parent issue: from `hierarchy_recommendation` in ma
 **Dependency conversion**: Preserve TPM's parent-level relation assignments for bundled issues (per [agent-sequencing.md](../../linear-orch/workflows/agent-sequencing.md) rule 5). For non-bundled issues, convert plan's `#N` references to `blocked_by_items: [N]` and existing refs to `blocked_by_issues: ["[ISSUE_ID]"]`.
 
 **Source path**: Format as file path, not markdown link: `docs/roadmaps/roadmap-[FEATURE].md`
+
+**Label preflight**: For every fallback issue, build and validate full `labels[]` using § 6.0 before invoking `audit-issues`. Legacy plans without labels must be completed through project taxonomy; if required labels cannot be determined, halt and ask the user.
 
 1. **Write file** to `tmp/audit-roadmap-YYYYMMDD-HHMMSS.json`.
 

--- a/skills/project-management/workflows/roadmap-plan.md
+++ b/skills/project-management/workflows/roadmap-plan.md
@@ -105,15 +105,16 @@ List implementation issues for your domain:
 | Conflicts with | Existing code/patterns that would be replaced |
 | Breaking changes | APIs or contracts affected |
 | Skills/docs updates | Files needing updates |
+| Labels | Optional full issue-label set if known; include agent/domain/workflow labels from project taxonomy, otherwise leave blank for orchestrator/TPM completion |
 
 Reply with structured table. Include ONLY issues for your domain.
 </delegation_format>
 
 ### 3.2 Collect Responses
 
-1. **Store all proposed issues** with source agent label.
+1. **Store all proposed issues** with source agent label and any proposed `labels[]`.
 
-2. **Build initial `PROPOSED_ISSUES[]`** per [roadmap-plan-input.md](../schemas/roadmap-plan-input.md).
+2. **Build initial `PROPOSED_ISSUES[]`** per [roadmap-plan-input.md](../schemas/roadmap-plan-input.md). Keep `agent` as a derived/source field, but also carry `labels[]` when available so TPM can output a full validated label set.
 
 ---
 
@@ -287,7 +288,7 @@ Legend: Parent = bundle parent #, Deps = blocking dependencies, Pri = priority, 
 |-----------|-------------|
 | Remove issue | Set `action: "skip"`, recompute dependent priorities |
 | Change priority | Update `priority` field |
-| Change agent | Update `agent`, recompute bundle parent `agent_label` |
+| Change agent | Update `agent`, recompute bundle parent `agent_label`, recompute affected `labels[]` through taxonomy before creation |
 | Change estimate | Update `estimate` field |
 | Add issue | Re-run `roadmap plan` (cannot add without specialist input) |
 
@@ -342,11 +343,11 @@ Write markdown to `docs/roadmaps/roadmap-[FEATURE].md` and JSON to `docs/roadmap
 
 ### Issues
 
-| Title | Est | Agent | Pri | Parent | Dependencies | Critical |
-|-------|-----|-------|-----|--------|--------------|----------|
-| [Bundle: Name] | — | multi | P2 | — | — | — |
-| [Child issue] | 2 | [AGENT_TYPE] | P2 | [parent title] | — | — |
-| [Standalone] | 3 | [AGENT_TYPE] | P1 | — | [ISSUE_ID] | Y |
+| Title | Est | Agent | Labels | Pri | Parent | Dependencies | Critical |
+|-------|-----|-------|--------|-----|--------|--------------|----------|
+| [Bundle: Name] | — | multi | agent:multi,[domain] | P2 | — | — | — |
+| [Child issue] | 2 | [AGENT_TYPE] | agent:[TYPE],[domain] | P2 | [parent title] | — | — |
+| [Standalone] | 3 | [AGENT_TYPE] | agent:[TYPE],[domain] | P1 | — | [ISSUE_ID] | Y |
 
 ## Architecture Gaps
 

--- a/skills/project-management/workflows/roadmap-plan.md
+++ b/skills/project-management/workflows/roadmap-plan.md
@@ -43,14 +43,20 @@ If no planner handoff is provided, set `PLANNER_HANDOFF` = null. Do not run `pla
 
 ### 1.3 Search Existing Research
 
-1. **Search for research**:
+1. **Resolve research issue label**:
+   - Load issue-label inventory: `.agents/skills/linear/scripts/linear.sh cache labels list --format=safe`.
+   - Load project taxonomy/application rules.
+   - Resolve `RESEARCH_WORKFLOW_LABEL` to the project-configured issue label for completed research artifacts.
+   - If no unambiguous assignable issue label exists, skip existing-research lookup and continue to § 2 (do not query a hard-coded fallback label).
+
+2. **Search for research**:
    ```bash
-   .agents/skills/linear/scripts/linear.sh cache issues list --label "research" --state "Done" --max
+   .agents/skills/linear/scripts/linear.sh cache issues list --label "[RESEARCH_WORKFLOW_LABEL]" --state "Done" --max
    ```
 
-2. **Filter results** for `FEATURE` keywords in title/description.
+3. **Filter results** for `FEATURE` keywords in title/description.
 
-3. **Route based on results**:
+4. **Route based on results**:
 
    | Result | Action |
    |--------|--------|

--- a/skills/project-management/workflows/tpm-audit.md
+++ b/skills/project-management/workflows/tpm-audit.md
@@ -38,7 +38,17 @@ Parse arguments → set `MODE` (project | issues).
 - `RESEARCH_REF` from `research_ref` field (optional, research-complete only)
 - `DECISION_REF` from `decision_ref` field (optional, research-complete only)
 
-### 1.2 Fetch All Projects
+### 1.2 Load Issue Label Policy
+
+Load live issue-label inventory and project taxonomy/application rules before validating agent/domain/workflow labels or recommending label changes:
+
+```bash
+.agents/skills/linear/scripts/linear.sh cache labels list --format=safe
+```
+
+If the label cache is missing/stale, report that the caller must run `sync --reconcile` before mutation. TPM does not mutate labels, but all `agent_mismatch`, `label_cooccurrence`, `recommended_issue.labels[]`, and `create_fields.labels[]` recommendations must be expressible against live issue labels and project taxonomy. Use issue labels only; project labels are separate.
+
+### 1.3 Fetch All Projects
 
 Query ALL project states:
 ```bash
@@ -51,7 +61,7 @@ Query ALL project states:
 
 Store project IDs and metadata for cross-project analysis.
 
-### 1.3 Fetch Input Issues
+### 1.4 Fetch Input Issues
 
 **PROJECT**: Fetch all issues in target project (all states):
 ```bash
@@ -64,9 +74,9 @@ Store project IDs and metadata for cross-project analysis.
 ```
 For proposed issues, use provided fields directly.
 
-### 1.4 Fetch Comparison Set
+### 1.5 Fetch Comparison Set
 
-Fetch issues from ALL projects (from 1.2) for duplicate/obsolete/fit checking:
+Fetch issues from ALL projects (from 1.3) for duplicate/obsolete/fit checking:
 ```bash
 .agents/skills/linear/scripts/linear.sh cache issues list --project "[PROJECT_NAME]" --state "Backlog,Todo,In Progress,In Review,Done" --max
 ```
@@ -75,9 +85,9 @@ Run for each project. Store all issues for comparison in 6.
 
 **Why all projects**: Cross-project duplicate detection, obsolete checking against completed work, and project fit evaluation all require visibility into the full backlog.
 
-### 1.5 Extract Project Definitions
+### 1.6 Extract Project Definitions
 
-For EACH project from 1.2, extract from name + description + content:
+For EACH project from 1.3, extract from name + description + content:
 
 | Field | Question |
 |-------|----------|
@@ -118,7 +128,7 @@ For each INPUT issue, extract from title + description:
 
 ### 3.1 Validate Issue Fit
 
-For each issue, verify it matches the target project definition from 1.5.
+For each issue, verify it matches the target project definition from 1.6.
 
 | Mismatch | Example | Action |
 |----------|---------|--------|
@@ -174,7 +184,7 @@ Scan for Creates-Consumes matches across different targets:
 
 ### 4.3 Include Comparison Set Matches
 
-Compare input issues against comparison set (1.4) for:
+Compare input issues against comparison set (1.5) for:
 - Same target component
 - Same file path in location field — issues modifying the same file are always candidates
 - Creates-Consumes overlap
@@ -207,7 +217,7 @@ For input issues with existing relations, add to candidate pairs for verificatio
 1. **Cross-project blocking**:
    - If issue-level blocking aligns with project ordering (3.2) → skip (redundant specificity)
    - Otherwise → move one issue to the other's project
-   - **Check** 1.5 scope definitions to determine which issue to move
+   - **Check** 1.6 scope definitions to determine which issue to move
    - If issue is a child, it must move with its parent (or be detached first)
    - **Add** to `wrong_project[]` with target project and reason referencing the blocking relation
    - **Do NOT create project-level dependencies from individual issue relations** — project deps come from project-order audit scope analysis, not bottom-up from 1-2 issue crossings
@@ -282,7 +292,7 @@ For each blocking relationship (A blocks B) where both are active:
 
 **Skip** Done/Cancelled issues — their labels are historical.
 
-**Check** each active issue's `agent:X` label against its content.
+**Check** each active issue's taxonomy `agent` category label against its content. Validate recommended replacement labels against § 1.2 inventory/taxonomy before adding `agent_mismatch[]`; if the desired `agent:*` label does not exist or is a parent/group label, report the validation failure in `reason` and do not recommend a mutating fix without user/taxonomy action.
 
 **Code verification** (when target exists):
 ```bash
@@ -302,7 +312,9 @@ grep -rn "pub fn\|export function\|def " ${WORKTREE:-.}/src/[TARGET_MODULE]/
 
 **Skip** Done/Cancelled issues — their labels are historical.
 
-**Step 1 — Heuristic**: For each active issue, if it lacks a required label, check title/description against detection signals. If 2+ signals match → add finding with `present: "[signals]"`.
+**Step 1 — Heuristic**: For each active issue, if it lacks a required taxonomy label/category, check title/description against detection signals. If 2+ signals match → add finding with `present: "[signals]"`.
+
+Only recommend `missing` labels that exist in live issue-label inventory and are assignable issue labels. If taxonomy requires a label that is absent from Linear, record that the label is missing from inventory and requires explicit user authorization to create; do not silently substitute another label.
 
 **Add** to `label_cooccurrence[]`:
 ```json
@@ -315,7 +327,7 @@ grep -rn "pub fn\|export function\|def " ${WORKTREE:-.}/src/[TARGET_MODULE]/
 
 ### 6.1 Check for Duplicates
 
-**Compare** input issues against ALL issues from comparison set (1.4):
+**Compare** input issues against ALL issues from comparison set (1.5):
 
 **Same-project duplicates**:
 - Same problem + same approach = duplicate → add to `duplicates[]`
@@ -369,7 +381,7 @@ Detect issues that should be canceled because work is complete.
 
 ### 6.3 Check Project Fit
 
-For each input issue, compare against ALL project definitions from 1.5:
+For each input issue, compare against ALL project definitions from 1.6:
 
 | Check | Action |
 |-------|--------|
@@ -443,7 +455,7 @@ For each parent issue with children:
 
 2. **If parent has implementation scope** not mapped to children → add to `analysis[]`: "Parent [ISSUE_ID] has `## Requirements` not decomposed into sub-issues."
 
-3. **Check agent labels**: if children have 2+ distinct `agent:X` but parent lacks `agent:multi` → add to `agent_mismatch[]`
+3. **Check agent labels**: if children have 2+ distinct taxonomy `agent` labels but parent lacks the project-configured multi-agent label (for example `agent:multi` when present in inventory/taxonomy) → add to `agent_mismatch[]` only after validating that replacement label exists and is assignable.
 
 4. **Check `## Sub-Issues` list matches actual children**: Compare issue IDs listed in parent description vs actual `children[]` from API. If mismatched (missing or extra entries), add to `hierarchy[]` with action `update_parent_desc` and reason noting the stale entries.
 
@@ -510,7 +522,7 @@ Classify:
 
 For each architecture component:
 
-1. **Search ALL project backlogs** (from 1.4) for matching issues
+1. **Search ALL project backlogs** (from 1.5) for matching issues
 
 2. **Check implementation state** from 9.2
 
@@ -591,6 +603,8 @@ For each input issue, assign action based on analysis:
 
 **Research traceability**: If `SOURCE == "research-complete"` and `RESEARCH_ISSUE` is set, add `RESEARCH_ISSUE` to `add_relations.related[]` for all `create` actions. This ensures created issues link back to the research that spawned them.
 
+**Create fields**: For every `create` action, populate `create_fields` per [audit-output.md](../schemas/audit-output.md). Include full `create_fields.labels[]` from input `items[].labels[]` when present or complete it from § 1.2 taxonomy/inventory. If required labels cannot be determined or do not exist in live issue-label inventory, leave the action blocked with a clear `reason`; do not emit a create action that relies only on `agent`/`agent_label`.
+
 ---
 
 ## 11. Pre-Output Verification
@@ -605,6 +619,7 @@ For each input issue, assign action based on analysis:
 - [ ] 5.3: Priority alignment checked (skip if proposed without priority)
 - [ ] 5.4: Agent label verified
 - [ ] 5.5: Label co-occurrence checked
+- [ ] 10.2: Create actions include full `create_fields.labels[]`; label update recommendations have mode/category semantics
 - [ ] 6.1: Duplicates and supersession checked (same-project AND cross-project)
 - [ ] 6.2: Obsolete checked with deep verification
 - [ ] 6.3: Project fit evaluated against ALL projects

--- a/skills/project-management/workflows/tpm-cycle-plan.md
+++ b/skills/project-management/workflows/tpm-cycle-plan.md
@@ -38,6 +38,12 @@ Analyze backlog, compute architecture order, and generate cycle plan recommendat
       ```
       </output_format>
 
+4. **Load label policy context** if any label recommendations may be produced:
+   ```bash
+   .agents/skills/linear/scripts/linear.sh cache labels list --format=safe
+   ```
+   Use project taxonomy/application rules to classify label categories. TPM does not mutate labels, but any `actions.set_labels[]` recommendation must specify the intended update mode/category and enough data for the caller to preflight a full final label set.
+
 ### 1.2 Calculate Velocity
 
 Uses cycle scope history (estimation points per day), not issue counts.
@@ -211,7 +217,7 @@ Architecture order determines new priority for cycle assignment:
      - `set_sort_order[]` — sort order from 1.4.4 position (`{id, sort_order}`, spacing of 100, parent/standalone only)
      - `assign_to_cycle[]` — issue IDs to assign
      - `set_estimates[]` — estimate updates if needed
-     - `set_labels[]` — label updates if needed
+     - `set_labels[]` — label updates if needed; each entry must specify `mode` (`add`, `replace_category`, or `replace_all`), `category` when applicable, `labels[]` being added/replaced, and either `preserve_existing: true` or explicit `final_labels[]`
      - `create_cycle` — cycle creation if needed (from 1.5)
 
 2. **Return the JSON** in your response (the calling agent writes the file):

--- a/skills/project-management/workflows/tpm-roadmap-plan.md
+++ b/skills/project-management/workflows/tpm-roadmap-plan.md
@@ -22,7 +22,23 @@ Read input file with Read tool. Extract `FEATURE`, `RESEARCH_PATH`, `ORIGIN_ISSU
 
 If `PLANNER_HANDOFF` is present, treat it as high-signal technical context from the scout → planner chain, not as a project-management decision. Preserve its plan path, proposed phases/issues, and explicit TPM questions through analysis. Use it to inform project placement, issue grouping, dependency ordering, and roadmap-vs-child-issue recommendations, but still verify against current issue/project state.
 
-### 1.2 Analyze Origin Issue
+### 1.2 Load Issue Label Policy
+
+Load live issue-label inventory and project taxonomy/application rules before organizing issue output:
+
+```bash
+.agents/skills/linear/scripts/linear.sh cache labels list --format=safe
+```
+
+If label cache is missing/stale, ask the caller/orchestrator to refresh via `sync --reconcile` before mutation. TPM does not mutate labels, but it must output full `labels[]` sets that are valid against the loaded issue-label inventory and project taxonomy where possible. Use issue labels only; project labels are separate.
+
+For each proposed issue:
+- Preserve input `labels[]` when present.
+- If input has only `agent`, derive the agent label and complete other required labels from project taxonomy and issue context.
+- If required category labels cannot be determined, mark the issue as needing taxonomy/user input in `reason` and do not invent labels.
+- Reject parent/group labels from output.
+
+### 1.3 Analyze Origin Issue
 
 **Skip if** `origin_issue` is null in input.
 
@@ -42,7 +58,7 @@ If `PLANNER_HANDOFF` is present, treat it as high-signal technical context from 
 
 3. **Store** `hierarchy_recommendation` with `type`, `origin_issue`, and `rationale`.
 
-### 1.3 Fetch All Projects
+### 1.4 Fetch All Projects
 
 1. **Query ALL project states** for cross-project analysis:
    ```bash
@@ -54,16 +70,16 @@ If `PLANNER_HANDOFF` is present, treat it as high-signal technical context from 
 
 2. **Store** project metadata: `id`, `name`, `state`, `description`, `content`.
 
-### 1.4 Fetch All Issues
+### 1.5 Fetch All Issues
 
 1. **Fetch issues** for each project:
    ```bash
    .agents/skills/linear/scripts/linear.sh cache issues list --project "[PROJECT_NAME]" --state "Backlog,Todo,In Progress,In Review,Done" --max
    ```
 
-2. **Store** for comparison: `id`, `title`, `description`, `project`, `state`, `agent`, `blocked_by[]`, `blocks[]`.
+2. **Store** for comparison: `id`, `title`, `description`, `project`, `state`, `agent`, `labels[]`, `blocked_by[]`, `blocks[]`.
 
-### 1.5 Read Research Context
+### 1.6 Read Research Context
 
 **Skip if** `RESEARCH_PATH` is null.
 
@@ -191,7 +207,7 @@ Build dependency graph from `depends_on_proposed`:
 2. **For each bundle**:
    - Create parent title describing the deliverable
    - Mark component issues as children
-   - **Compute agent label**: If all children have same agent → parent gets that agent. If 2+ distinct agents → `agent:multi`. Store as `agent_label` on the bundle parent.
+   - **Compute labels**: If all children have same agent → parent gets that agent label. If 2+ distinct agents → parent gets the project-configured multi-agent label (for example `agent:multi`, if present in taxonomy/inventory). Store as `agent_label` for backward compatibility and include the full parent `labels[]` set. Parent labels must also pass label policy; do not assign parent/group labels.
 
 3. **Lift inter-bundle relations**: Move `blocks`/`blocked_by` between bundled issues up to their respective bundle parents. Children within a bundle retain no external blocking relations — only the parent carries cross-bundle dependencies.
 
@@ -231,7 +247,7 @@ Assign priority (1-4) to each issue based on layer and impact:
 
 ### 4.6 Build Organized List
 
-Store in `organized_issues[]` per schema. Sort by `position`. Include `priority` and `agent_label` (for bundle parents) per schema.
+Store in `organized_issues[]` per schema. Sort by `position`. Include `priority`, full `labels[]`, and `agent_label` (for bundle parents/backward compatibility) per schema.
 
 ---
 


### PR DESCRIPTION
## Summary
- add portable project-management issue-label taxonomy/inventory preflight docs
- require full validated labels[] for roadmap/audit/research/cycle create and update flows
- expose issue-label is_group metadata in Linear safe label output and add regression coverage

Fixes #293