### PR TITLE
Separate report output from Pi questions

### DIFF
--- a/skills/flightdeck/SKILL.md
+++ b/skills/flightdeck/SKILL.md
@@ -264,6 +264,8 @@ Nested workflows (marked with `⤵`) must be invoked through the harness's workf
 3. Add nothing else — no commentary, extra fields, rewording, or explanations before/after.
 4. Do not paraphrase — use exact structure, headings, and field names from the tag.
 
+If a user-visible tagged output/report block is followed by an `Ask user`, `AskUserQuestion`, or question-tool step, emit the filled output block first as a normal assistant message. Then call the question tool separately with only a concise question string and concise options. Keep report text out of `question.question`, option labels, and option descriptions unless the workflow explicitly asks for a short summary; this prevents Pi question popups from absorbing the preceding report.
+
 The user-visible output blocks at the end of `terminate.md` (`<generic_output_format>` / `<empty_output_format>` / `<issue_output_format>`) and `close-issue.md` (`<output_format>`) are tagged for this reason: emit them in full, not as summary lines.
 
 ## Implementation Constraints

--- a/skills/linear-orch/SKILL.md
+++ b/skills/linear-orch/SKILL.md
@@ -281,6 +281,8 @@ The delegation message (containing the `<delegation_format>` content) follows as
 4. **Do not paraphrase** — use the exact structure, headings, and field names from the tag
 5. **Placeholders hold structured data only** — fill only schema fields. Never embed workflow steps, commit/validate/push, or "let the orchestrator …" lines inside item records; the agent's `Follow workflow:` already owns process, and duplication triggers a second return on idle wake-up.
 
+If a user-visible tagged output/report block is immediately followed by `Ask user`, `AskUserQuestion`, or a question-tool step, present the filled block first as a normal assistant message. Then invoke the question tool separately with only a concise question and concise options. Do not copy the report into `question.question`, option labels, or option descriptions unless a short summary is explicitly requested; Pi renders those fields in the popup and should show only the next-step choice.
+
 #### Task Layers
 
 Work is organized in visually distinct layers: orchestrator workflow steps, nested sub-workflows, and agent tasks. Agents only act on their own assigned work — they never touch orchestrator or sub-workflow items.

--- a/skills/project-management/SKILL.md
+++ b/skills/project-management/SKILL.md
@@ -85,6 +85,7 @@ TPM workflows return JSON recommendations only.
 
 - Execute all workflow sections in order. The workflow decides what to skip via "**Skip if**" conditions — never skip based on your own scope assessment.
 - `<delegation_format>` and `<output_format>` tags are literal templates: fill `[PLACEHOLDERS]`, omit empty lines, add nothing else, do not paraphrase.
+- When a user-visible `<output_format>` report is followed by an `Ask user`, `AskUserQuestion`, or question-tool step, send the filled report as a normal assistant message first. Then invoke the question tool separately with only a concise question and concise options; do not paste the report into the question text, option labels, or option descriptions unless a short summary is explicitly requested. This keeps Pi question popups focused on the choice instead of the preceding report.
 - Before any issue create or label update, load the live issue-label inventory and project taxonomy, build the full final `labels[]` set, and run the label preflight in `references/labels.md`. Unknown labels, parent/group labels, missing required categories, or exclusivity violations stop the workflow before mutation.
 
 ## Hierarchy


### PR DESCRIPTION
## Summary
- Add shared guidance in Flightdeck format-tag rules to keep user-visible reports separate from question prompts.
- Add project-management execution guidance for adjacent `<output_format>` reports and question-tool steps.
- Add linear-orch format-tag guidance so orchestration prompts avoid embedding reports in Pi question popups.

## Validation
- `git diff --check`
- Grep/review of adjacent `<output_format>` / report blocks followed by `Ask user` or question-tool steps across `skills/flightdeck`, `skills/project-management`, and `skills/linear-orch`.

Fixes #298
