### PR TITLE
Support Codex native worktree hooks

### DIFF
--- a/skills/linear-orch/README.md
+++ b/skills/linear-orch/README.md
@@ -63,3 +63,7 @@ Set in `.env` or `.env.local`, or export in the shell. Helper scripts source bot
 1. Install dependency skills: `linear`, `github`, `worktree`, `decider`, `project-management`.
 2. Set runtime config in `.env` or `.env.local` (`LINEAR_API_KEY`, `ORCH_STATE_DIR`, etc.).
 3. Verify each dependency skill works from the project root before invoking a workflow.
+
+## Codex Desktop Worktrees
+
+When Codex Desktop creates the worktree, configure the worktree skill's `codex-setup` and `codex-cleanup` hooks in the Codex environment. Then run `initialize [ISSUE_ID]` or `start [ISSUE_ID]` with the explicit issue ID; `session-init` will normalize the app-created branch before workflow state is initialized.

--- a/skills/linear-orch/scripts/session-init
+++ b/skills/linear-orch/scripts/session-init
@@ -5,23 +5,6 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-SKILLS_DIR="$PROJECT_ROOT/.agents/skills"
-
-# Source project config/secrets. .env.local overrides .env when both exist.
-for ENV_FILE in "$PROJECT_ROOT/.env" "$PROJECT_ROOT/.env.local"; do
-  if [[ -f "$ENV_FILE" ]]; then
-    # shellcheck source=/dev/null
-    source "$ENV_FILE"
-  fi
-done
-unset ENV_FILE
-
-# Sibling skill scripts (resolved from install location)
-LINEAR="$SKILLS_DIR/linear/scripts/linear.sh"
-GITHUB="$SKILLS_DIR/github/scripts/github.sh"
-
 OUTPUT_FORMAT="dashboard"
 ISSUE_ID_ARG=""
 while [[ $# -gt 0 ]]; do
@@ -32,6 +15,55 @@ while [[ $# -gt 0 ]]; do
     *)      ISSUE_ID_ARG="$1"; shift ;;
   esac
 done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+SKILLS_DIR="$PROJECT_ROOT/.agents/skills"
+
+source_project_env() {
+  local env_file
+  for env_file in "$PROJECT_ROOT/.env" "$PROJECT_ROOT/.env.local"; do
+    if [[ -f "$env_file" ]]; then
+      # shellcheck source=/dev/null
+      source "$env_file"
+    fi
+  done
+}
+
+is_codex_managed_worktree() {
+  local project_real codex_real
+  project_real="$(cd "$PROJECT_ROOT" 2>/dev/null && pwd -P)" || return 1
+
+  if [[ -n "${CODEX_WORKTREE_PATH:-}" ]]; then
+    codex_real="$(cd "$CODEX_WORKTREE_PATH" 2>/dev/null && pwd -P)" || codex_real=""
+    [[ -n "$codex_real" && "$project_real" == "$codex_real" ]] && return 0
+  fi
+
+  [[ -n "${HOME:-}" && "$project_real" == "$HOME/.codex/worktrees/"* ]]
+}
+
+normalize_codex_issue_branch() {
+  local issue_id="$1"
+  [[ -n "$issue_id" ]] || return 0
+  is_codex_managed_worktree || return 0
+
+  local worktree_script="$PROJECT_ROOT/.agents/skills/worktree/scripts/worktree"
+  [[ -x "$worktree_script" ]] || return 0
+
+  local target_branch current_branch
+  target_branch="$(printf '%s' "$issue_id" | tr '[:upper:]' '[:lower:]')"
+  current_branch="$(git -C "$PROJECT_ROOT" branch --show-current 2>/dev/null || true)"
+  [[ "$current_branch" == "$target_branch" ]] && return 0
+
+  "$worktree_script" codex-branch "$issue_id" "$PROJECT_ROOT" >/dev/null
+}
+
+# Source project config/secrets. .env.local overrides .env when both exist.
+source_project_env
+
+# Sibling skill scripts (resolved from install location)
+LINEAR="$SKILLS_DIR/linear/scripts/linear.sh"
+GITHUB="$SKILLS_DIR/github/scripts/github.sh"
 
 json_or_default() {
   local fallback="$1"
@@ -179,6 +211,12 @@ GIT_COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null || echo "")
 if [[ -n "$GIT_COMMON_DIR" && "$GIT_COMMON_DIR" != ".git" && "$GIT_COMMON_DIR" != "$(pwd)/.git" ]]; then
   IS_WORKTREE="true"
   WORKTREE_NAME=$(basename "$(pwd)")
+  if [[ -n "$ISSUE_ID_ARG" ]]; then
+    normalize_codex_issue_branch "$ISSUE_ID"
+    source_project_env
+    BRANCH=$(git branch --show-current 2>/dev/null || echo "main")
+    ISSUE_ID="$ISSUE_ID_ARG"
+  fi
   # Fast path: worktree sessions skip full dashboard, check only auth + LSP
   WT_GH_OK="false"
   WT_GH_TOKEN="${GH_BOT_TOKEN_RESOLVED:-$GH_MAIN_TOKEN}"

--- a/skills/linear-orch/workflows/initialize.md
+++ b/skills/linear-orch/workflows/initialize.md
@@ -23,6 +23,7 @@ Set up team, auth, cache, and workflow state for a worktree session.
 1. **Run**: `.agents/skills/linear-orch/scripts/session-init --json [ISSUE_ID]`
    - Pass `[ISSUE_ID]` as a positional argument if the caller provided one; otherwise omit it.
    - The script resolves `ISSUE_ID` from the argument or current branch (via `$GH_ISSUE_PATTERN`, case-insensitive) and returns it as `issue_id` in the JSON output (alongside `branch`).
+   - In Codex-managed worktrees with an explicit `[ISSUE_ID]`, the script normalizes the app-created branch to the lower-case issue branch before returning `branch`.
    - Read `issue_id` from the output and use it for subsequent steps. If empty (branch does not match the pattern), fall back to the sanitized branch name — replace `/` with `-` — so workflow-state and team naming still work for non-issue branches.
 
 2. **If `gh_auth` is false or `linear_auth.ok` is false** → report error and fix before proceeding.

--- a/skills/linear/scripts/commands/issues.sh
+++ b/skills/linear/scripts/commands/issues.sh
@@ -566,7 +566,7 @@ bulk_update_issues() {
             update_args+=("$_key" "$_val")
             shift
             ;;
-        --remove-parent)
+        --remove-parent | --clear-cycle)
             update_args+=("$1")
             shift
             ;;

--- a/skills/linear/scripts/commands/issues.sh
+++ b/skills/linear/scripts/commands/issues.sh
@@ -198,6 +198,7 @@ Update Options:
   --remove-parent       Remove parent (convert to top-level issue)
   --milestone <name|uuid> Set project milestone (name or UUID)
   --cycle <id>          Set cycle (sprint) ID
+  --clear-cycle         Remove cycle assignment
   --sort-order <float>  Manual sort position (lower = higher; parent/standalone only)
 
 Relation Options (add-relation):
@@ -231,6 +232,7 @@ Examples:
 
   # Cycle (sprint) assignment
   issues.sh update PROJ-42 --cycle 864d7ea0-2347-4048-80cd-5be977d904e4
+  issues.sh update PROJ-42 --clear-cycle
 
   # Bulk operations (reduces API calls)
   issues.sh list --project-id <uuid> --with-relations   # Single query with all relations
@@ -1037,6 +1039,7 @@ update_issue() {
     local remove_parent="false"
     local milestone=""
     local cycle=""
+    local clear_cycle="false"
     local estimate=""
     local sort_order=""
 
@@ -1132,6 +1135,10 @@ update_issue() {
             ;;
         --cycle=*)
             cycle="${1#*=}"
+            shift
+            ;;
+        --clear-cycle)
+            clear_cycle="true"
             shift
             ;;
         --sort-order)
@@ -1264,7 +1271,12 @@ update_issue() {
     fi
 
     # Handle cycle (sprint)
-    if [ -n "$cycle" ]; then
+    if [ "$clear_cycle" = "true" ] && [ -n "$cycle" ]; then
+        echo '{"error": "Use either --cycle or --clear-cycle, not both"}' >&2
+        return 1
+    elif [ "$clear_cycle" = "true" ]; then
+        input_parts+=("\"cycleId\": null")
+    elif [ -n "$cycle" ]; then
         input_parts+=("\"cycleId\": \"$cycle\"")
     fi
 

--- a/skills/worktree/README.md
+++ b/skills/worktree/README.md
@@ -25,6 +25,30 @@ Defaults: detects branch from `origin/HEAD` (fallback: `main`), creates worktree
 
 `remove` deletes the worktree first, then tries `git branch -d` for the associated local branch. If Git refuses the safe branch delete (for example, the branch is not merged into the current main checkout), the command exits non-zero and prints a diagnostic naming the remaining branch plus the manual `git branch -D` recovery command.
 
+## Codex Desktop
+
+When running inside Codex Desktop, let the app own worktree creation, branch metadata, and environment teardown. Use this script only as the project setup/cleanup hook for app-created worktrees.
+
+Setup script:
+
+```bash
+"$CODEX_SOURCE_TREE_PATH/.agents/skills/worktree/scripts/worktree" codex-setup "$CODEX_WORKTREE_PATH"
+```
+
+Cleanup script:
+
+```bash
+"$CODEX_SOURCE_TREE_PATH/.agents/skills/worktree/scripts/worktree" codex-cleanup "$CODEX_WORKTREE_PATH"
+```
+
+At the start of an issue thread, normalize the app-created branch before running issue orchestration:
+
+```bash
+"$CODEX_SOURCE_TREE_PATH/.agents/skills/worktree/scripts/worktree" codex-branch CC-123 "$CODEX_WORKTREE_PATH"
+```
+
+`codex-setup` applies the same env/config symlinks, copies, mkdirs, bot remote, bot git identity, and lightweight dependency bootstrap that `create` applies after creating a worktree. `codex-branch` renames or switches the app-created worktree branch to the lower-case issue branch expected by `linear-orch`. `codex-cleanup` is intentionally a no-op lifecycle hook for this script; Codex owns app-created worktree and branch deletion. Keep project-level teardown such as stopping containers or removing disposable caches in the Codex environment cleanup script after this command, but do not call `worktree remove` from the hook.
+
 ## Configuration
 
 Set in `.env` or `.env.local` — all optional. When both files exist, `.env.local` wins.

--- a/skills/worktree/SKILL.md
+++ b/skills/worktree/SKILL.md
@@ -31,10 +31,24 @@ Resolves project root via `git rev-parse`, detects default branch automatically,
 | `exists` | Check if worktree exists for issue ID |
 | `check` | Pre-create git state check (JSON: uncommitted, unpushed) |
 | `push` | Push worktree branch with auto-rebase |
+| `codex-setup` | Apply env/config setup to a Codex Desktop app-created worktree |
+| `codex-branch` | Normalize a Codex Desktop app-created branch to an issue branch |
+| `codex-cleanup` | Non-destructive Codex Desktop cleanup hook; app owns deletion |
 
 `remove` deletes the worktree before deleting the local branch. Branch deletion uses safe `git branch -d`; if that fails after worktree removal, the script exits non-zero with a diagnostic naming the remaining branch and manual `git branch -D` recovery command.
 
 When a configured symlink path is already tracked in the worktree branch, the script marks that path assume-unchanged before replacing it so `git status` stays clean.
+
+### Codex Desktop hooks
+
+Let Codex Desktop own app-created worktree creation and deletion. Configure project setup/cleanup hooks to run:
+
+```bash
+"$CODEX_SOURCE_TREE_PATH/.agents/skills/worktree/scripts/worktree" codex-setup "$CODEX_WORKTREE_PATH"
+"$CODEX_SOURCE_TREE_PATH/.agents/skills/worktree/scripts/worktree" codex-cleanup "$CODEX_WORKTREE_PATH"
+```
+
+For issue workflows, run `codex-branch ISSUE_ID "$CODEX_WORKTREE_PATH"` before orchestration if the harness did not already normalize the branch.
 
 ### `create` flags
 

--- a/skills/worktree/scripts/worktree
+++ b/skills/worktree/scripts/worktree
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Portable git worktree manager
-# Usage: worktree create|list|remove|cleanup|path|exists|check|push|fix-links [ID] [options]
+# Usage: worktree create|list|remove|cleanup|path|exists|check|push|fix-links|codex-setup|codex-branch|codex-cleanup [ID] [options]
 #   create options:
 #     --base BRANCH   Checkout an existing remote branch into the worktree
 #     --from REF      Create a new branch starting from REF (branch, tag, or commit)
@@ -112,6 +112,10 @@ worktree_path() {
   echo "$TREES_DIR/$(echo "$1" | tr '[:upper:]' '[:lower:]')"
 }
 
+issue_branch_name() {
+  echo "$1" | tr '[:upper:]' '[:lower:]'
+}
+
 # Symlink a path from main repo into worktree (handles tracked dirs with assume-unchanged)
 # Idempotently append a worktree-relative path to the COMMON git-dir's
 # info/exclude so git treats the symlink we lay down as ignored content.
@@ -202,7 +206,10 @@ setup_worktree_links() {
   # Project-configured mkdirs (run first so subsequent symlinks/copies can
   # land inside them if needed). Idempotent; ignores empty entries.
   for path in ${WORKTREE_MKDIRS:-}; do
-    [[ -n "$path" ]] && mkdir -p "$wt/$path"
+    if [[ -n "$path" ]]; then
+      mkdir -p "$wt/$path"
+      exclude_from_worktree_index "$wt" "$path"
+    fi
   done
 
   # Project-configured symlinks
@@ -213,6 +220,7 @@ setup_worktree_links() {
   # Project-configured copies
   for path in ${WORKTREE_COPIES:-}; do
     if [[ -f "$PROJECT_ROOT/$path" ]]; then
+      exclude_from_worktree_index "$wt" "$path"
       mkdir -p "$(dirname "$wt/$path")"
       cp "$PROJECT_ROOT/$path" "$wt/$path"
     fi
@@ -237,6 +245,54 @@ setup_worktree_links() {
     ln -sfn "$target" "$wt/$path"
     exclude_from_worktree_index "$wt" "$path"
   done
+}
+
+configure_worktree_git() {
+  local wt="$1"
+
+  # Required before writing per-worktree git config. Safe to repeat.
+  git -C "$PROJECT_ROOT" config extensions.worktreeConfig true 2>/dev/null || true
+
+  # Add bot remote for agent pushes (if configured).
+  if [[ -n "${BOT_REMOTE_NAME:-}" && -n "${BOT_REMOTE_URL:-}" ]]; then
+    git -C "$wt" remote add "$BOT_REMOTE_NAME" "$BOT_REMOTE_URL" 2>/dev/null || true
+  fi
+
+  # Set agent git identity (if configured).
+  if [[ -n "${BOT_NAME:-}" ]]; then
+    git -C "$wt" config --worktree user.name "$BOT_NAME"
+    git -C "$wt" config --worktree user.email "${BOT_EMAIL:-}"
+    if [[ -n "${BOT_SIGNING_KEY:-}" ]]; then
+      git -C "$wt" config --worktree gpg.format ssh
+      git -C "$wt" config --worktree user.signingkey "$BOT_SIGNING_KEY"
+      git -C "$wt" config --worktree commit.gpgsign true
+    fi
+  fi
+}
+
+install_worktree_dependencies() {
+  local wt="$1"
+
+  # Preserve the historical behavior for JS worktrees without blocking setup.
+  if [[ -f "$wt/package.json" ]] && command -v npm >/dev/null 2>&1; then
+    (
+      cd "$wt" || exit 0
+      npm install --no-audit --no-fund >/dev/null 2>&1
+    ) &
+  fi
+}
+
+setup_codex_worktree() {
+  local wt="$1"
+
+  setup_worktree_links "$wt"
+  configure_worktree_git "$wt"
+  install_worktree_dependencies "$wt"
+}
+
+is_git_worktree_path() {
+  local wt="$1"
+  [[ -f "$wt/.git" || -d "$wt/.git" ]]
 }
 
 case "${1:-}" in
@@ -272,8 +328,8 @@ case "${1:-}" in
           exit 1
         fi
       fi
-      # Refresh symlinks (rebase may have replaced symlinks with tracked content)
-      setup_worktree_links "$WT_PATH"
+      # Refresh setup (rebase may have replaced symlinks with tracked content)
+      setup_codex_worktree "$WT_PATH"
       echo "$WT_PATH"
       exit 0
     fi
@@ -305,7 +361,7 @@ case "${1:-}" in
         git -C "$WT_PATH" branch --set-upstream-to="$_REMOTE/$BRANCH" "$BRANCH" >/dev/null 2>&1 || true
         git -C "$WT_PATH" merge --ff-only "$_REMOTE/$BRANCH" >/dev/null 2>&1 || true
       fi
-      setup_worktree_links "$WT_PATH"
+      setup_codex_worktree "$WT_PATH"
       echo "$WT_PATH"
       exit 0
     fi
@@ -364,31 +420,7 @@ case "${1:-}" in
       fi
     fi
 
-    # Set up symlinks, copies, and bot config
-    setup_worktree_links "$WT_PATH"
-
-    # Add bot remote for agent pushes (if configured)
-    [[ -n "${BOT_REMOTE_NAME:-}" && -n "${BOT_REMOTE_URL:-}" ]] && \
-      git -C "$WT_PATH" remote add "$BOT_REMOTE_NAME" "$BOT_REMOTE_URL" 2>/dev/null || true
-
-    # Install dependencies if npm project detected.
-    if [[ -f "$WT_PATH/package.json" ]] && command -v npm >/dev/null 2>&1; then
-      (
-        cd "$WT_PATH" || exit 0
-        npm install --no-audit --no-fund >/dev/null 2>&1
-      ) &
-    fi
-
-    # Set agent git identity (if configured, requires extensions.worktreeConfig=true)
-    if [[ -n "${BOT_NAME:-}" ]]; then
-      git -C "$WT_PATH" config --worktree user.name "$BOT_NAME"
-      git -C "$WT_PATH" config --worktree user.email "${BOT_EMAIL:-}"
-      [[ -n "${BOT_SIGNING_KEY:-}" ]] && {
-        git -C "$WT_PATH" config --worktree gpg.format ssh
-        git -C "$WT_PATH" config --worktree user.signingkey "$BOT_SIGNING_KEY"
-        git -C "$WT_PATH" config --worktree commit.gpgsign true
-      }
-    fi
+    setup_codex_worktree "$WT_PATH"
     echo "$WT_PATH"
     ;;
 
@@ -517,7 +549,7 @@ case "${1:-}" in
       WT_PATH="$(worktree_path "$ARG")"
     fi
 
-    if [[ ! -d "$WT_PATH/.git" && ! -f "$WT_PATH/.git" ]]; then
+    if ! is_git_worktree_path "$WT_PATH"; then
       echo "Error: Not a git worktree: $WT_PATH" >&2
       exit 1
     fi
@@ -565,7 +597,7 @@ case "${1:-}" in
     else
       WT_PATH="$(worktree_path "$ARG")"
     fi
-    if [[ ! -f "$WT_PATH/.git" ]]; then
+    if ! is_git_worktree_path "$WT_PATH"; then
       echo "Error: Not a git worktree: $WT_PATH" >&2
       exit 1
     fi
@@ -573,8 +605,93 @@ case "${1:-}" in
     echo "Restored symlinks in $WT_PATH"
     ;;
 
+  codex-setup)
+    # Codex Desktop owns worktree creation. This command applies the same
+    # project-local setup that `create` applies after git has already created
+    # the worktree: env/config symlinks, configured copies/dirs, optional bot
+    # git config, optional bot remote, and lightweight dependency bootstrap.
+    ARG="${2:-}"
+    if [[ -z "$ARG" ]]; then
+      WT_PATH="$PWD"
+    elif [[ "$ARG" == */* ]]; then
+      WT_PATH="$ARG"
+    else
+      WT_PATH="$(worktree_path "$ARG")"
+    fi
+    if ! is_git_worktree_path "$WT_PATH"; then
+      echo "Error: Not a git worktree: $WT_PATH" >&2
+      exit 1
+    fi
+    setup_codex_worktree "$WT_PATH"
+    echo "Configured Codex worktree: $WT_PATH"
+    ;;
+
+  codex-branch)
+    # Codex Desktop may create an app-managed branch name. Normalize the
+    # current worktree to the issue branch expected by linear-orch before
+    # running `linear-orch start <ISSUE>`.
+    ISSUE="${2:?Error: codex-branch requires an issue ID or branch name}"
+    ARG="${3:-}"
+    if [[ -z "$ARG" ]]; then
+      WT_PATH="$PWD"
+    elif [[ "$ARG" == */* ]]; then
+      WT_PATH="$ARG"
+    else
+      WT_PATH="$(worktree_path "$ARG")"
+    fi
+    if ! is_git_worktree_path "$WT_PATH"; then
+      echo "Error: Not a git worktree: $WT_PATH" >&2
+      exit 1
+    fi
+
+    TARGET_BRANCH="$(issue_branch_name "$ISSUE")"
+    CURRENT_BRANCH="$(git -C "$WT_PATH" branch --show-current 2>/dev/null || true)"
+    if [[ "$CURRENT_BRANCH" == "$TARGET_BRANCH" ]]; then
+      echo "Codex worktree already on $TARGET_BRANCH: $WT_PATH"
+      exit 0
+    fi
+
+    fetch_origin
+    _REMOTE="${BOT_REMOTE_NAME:-origin}"
+    if git -C "$PROJECT_ROOT" show-ref --verify --quiet "refs/heads/$TARGET_BRANCH"; then
+      git -C "$WT_PATH" switch "$TARGET_BRANCH" >/dev/null 2>&1 || {
+        echo "Error: Branch '$TARGET_BRANCH' already exists and cannot be checked out in $WT_PATH" >&2
+        exit 1
+      }
+    elif git -C "$PROJECT_ROOT" rev-parse --verify "$_REMOTE/$TARGET_BRANCH" >/dev/null 2>&1; then
+      git -C "$WT_PATH" switch -c "$TARGET_BRANCH" --track "$_REMOTE/$TARGET_BRANCH" >/dev/null 2>&1
+    elif [[ -n "$CURRENT_BRANCH" ]]; then
+      git -C "$WT_PATH" branch -m "$TARGET_BRANCH"
+    else
+      git -C "$WT_PATH" switch -c "$TARGET_BRANCH" >/dev/null 2>&1
+    fi
+
+    if git -C "$WT_PATH" rev-parse --verify "$_REMOTE/$TARGET_BRANCH" >/dev/null 2>&1; then
+      git -C "$WT_PATH" branch --set-upstream-to="$_REMOTE/$TARGET_BRANCH" "$TARGET_BRANCH" >/dev/null 2>&1 || true
+    fi
+    setup_codex_worktree "$WT_PATH"
+    echo "Codex worktree branch ready: $TARGET_BRANCH ($WT_PATH)"
+    ;;
+
+  codex-cleanup)
+    # Codex Desktop owns worktree/branch deletion. This hook is intentionally
+    # non-destructive and does not remove symlinks: if the app fails to delete
+    # the worktree immediately after cleanup, mutating tracked symlink paths can
+    # leave the worktree dirty. Project-level teardown (containers, caches)
+    # belongs in the Codex environment cleanup script after this command.
+    ARG="${2:-}"
+    if [[ -z "$ARG" ]]; then
+      WT_PATH="$PWD"
+    elif [[ "$ARG" == */* ]]; then
+      WT_PATH="$ARG"
+    else
+      WT_PATH="$(worktree_path "$ARG")"
+    fi
+    echo "Codex cleanup hook complete; app owns worktree deletion: $WT_PATH"
+    ;;
+
   *)
-    echo "Usage: $0 create|list|remove|cleanup|path|exists|check|push|fix-links [ID|/path] [options]" >&2
+    echo "Usage: $0 create|list|remove|cleanup|path|exists|check|push|fix-links|codex-setup|codex-branch|codex-cleanup [ID|/path] [options]" >&2
     exit 1
     ;;
 esac

--- a/skills/worktree/tests/worktree_remove.sh
+++ b/skills/worktree/tests/worktree_remove.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKTREE_SCRIPT="$(cd "$TEST_DIR/.." && pwd)/scripts/worktree"
-TMP_ROOT="$(mktemp -d)"
+TMP_ROOT="$(cd "$(mktemp -d)" && pwd -P)"
 trap 'rm -rf "$TMP_ROOT"' EXIT
 
 PASS=0
@@ -40,6 +40,17 @@ assert_path_absent() {
   else
     FAIL=$((FAIL + 1))
     printf '  FAIL  %s\n        still exists: %s\n' "$name" "$path"
+  fi
+}
+
+assert_path_exists() {
+  local path="$1" name="$2"
+  if [[ -e "$path" ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        missing path: %s\n' "$name" "$path"
   fi
 }
 
@@ -163,6 +174,49 @@ assert_symlink_target "$LINK_ROOT/trees/issue-links/.claude/settings.json" "$LIN
 assert_git_status_clean_for_path "$LINK_ROOT/trees/issue-links" ".claude/settings.json" "configured tracked file symlink is hidden from git status"
 assert_symlink_target "$LINK_ROOT/trees/issue-links/.claude/agents" "$LINK_ROOT/main/.claude/agents" "configured dir symlink points to main checkout"
 assert_symlink_target "$LINK_ROOT/trees/issue-links/.claude/CLAUDE.md" "../AGENTS.md" "relative symlink keeps worktree-local AGENTS target"
+
+# Codex Desktop owns worktree lifecycle. codex-setup applies project setup to
+# an already-created app worktree; codex-cleanup is a non-destructive hook and
+# leaves worktree/branch deletion to the app.
+CODEX_ROOT="$TMP_ROOT/codex"
+make_repo "$CODEX_ROOT/main"
+mkdir -p "$CODEX_ROOT/main/config"
+printf 'local-config\n' > "$CODEX_ROOT/main/config/local.txt"
+printf 'copied-config\n' > "$CODEX_ROOT/main/copied.txt"
+cat > "$CODEX_ROOT/main/.env.local" <<'ENV'
+WORKTREE_SYMLINKS=".env.local config/local.txt"
+WORKTREE_COPIES="copied.txt"
+WORKTREE_MKDIRS="tmp/cache"
+BOT_NAME="Codex Bot"
+BOT_EMAIL="codex@example.com"
+ENV
+git -C "$CODEX_ROOT/main" worktree add -q -b issue-codex "$CODEX_ROOT/trees/issue-codex" main
+codex_setup_out=$(cd "$CODEX_ROOT/main" && "$WORKTREE_SCRIPT" codex-setup "$CODEX_ROOT/trees/issue-codex")
+assert_eq "$codex_setup_out" "Configured Codex worktree: $CODEX_ROOT/trees/issue-codex" "codex-setup reports configured worktree"
+assert_symlink_target "$CODEX_ROOT/trees/issue-codex/.env.local" "$CODEX_ROOT/main/.env.local" "codex-setup links .env.local"
+assert_symlink_target "$CODEX_ROOT/trees/issue-codex/config/local.txt" "$CODEX_ROOT/main/config/local.txt" "codex-setup links configured file"
+assert_path_exists "$CODEX_ROOT/trees/issue-codex/tmp/cache" "codex-setup creates configured mkdir"
+assert_eq "$(cat "$CODEX_ROOT/trees/issue-codex/copied.txt")" "copied-config" "codex-setup copies configured file"
+assert_eq "$(git -C "$CODEX_ROOT/trees/issue-codex" config --worktree user.name)" "Codex Bot" "codex-setup configures worktree user.name"
+assert_eq "$(git -C "$CODEX_ROOT/trees/issue-codex" config --worktree user.email)" "codex@example.com" "codex-setup configures worktree user.email"
+codex_cleanup_out=$(cd "$CODEX_ROOT/main" && "$WORKTREE_SCRIPT" codex-cleanup "$CODEX_ROOT/trees/issue-codex")
+assert_eq "$codex_cleanup_out" "Codex cleanup hook complete; app owns worktree deletion: $CODEX_ROOT/trees/issue-codex" "codex-cleanup reports app-owned deletion"
+assert_symlink_target "$CODEX_ROOT/trees/issue-codex/.env.local" "$CODEX_ROOT/main/.env.local" "codex-cleanup leaves configured symlink intact"
+assert_git_worktree "$CODEX_ROOT/trees/issue-codex" "codex-cleanup leaves worktree for app deletion"
+assert_branch_exists "$CODEX_ROOT/main" "issue-codex" "codex-cleanup leaves branch for app deletion"
+assert_eq "$(git -C "$CODEX_ROOT/trees/issue-codex" status --short)" "" "codex-cleanup leaves worktree clean"
+
+CODEX_BRANCH_ROOT="$TMP_ROOT/codex-branch"
+make_repo "$CODEX_BRANCH_ROOT/main"
+cat > "$CODEX_BRANCH_ROOT/main/.env.local" <<'ENV'
+WORKTREE_MKDIRS="tmp"
+ENV
+git -C "$CODEX_BRANCH_ROOT/main" worktree add -q -b app-managed-branch "$CODEX_BRANCH_ROOT/trees/app-managed" main
+codex_branch_out=$(cd "$CODEX_BRANCH_ROOT/main" && "$WORKTREE_SCRIPT" codex-branch CC-999 "$CODEX_BRANCH_ROOT/trees/app-managed")
+assert_eq "$codex_branch_out" "Codex worktree branch ready: cc-999 ($CODEX_BRANCH_ROOT/trees/app-managed)" "codex-branch reports normalized branch"
+assert_eq "$(git -C "$CODEX_BRANCH_ROOT/trees/app-managed" branch --show-current)" "cc-999" "codex-branch renames app branch to issue branch"
+assert_branch_absent "$CODEX_BRANCH_ROOT/main" "app-managed-branch" "codex-branch removes old app branch name"
+assert_path_exists "$CODEX_BRANCH_ROOT/trees/app-managed/tmp" "codex-branch reapplies setup after branch normalization"
 
 # .env.local is not special-cased. It is only linked when listed in
 # WORKTREE_SYMLINKS.


### PR DESCRIPTION
Summary: add Codex Desktop worktree setup/branch/cleanup commands, normalize Codex app branches in linear-orch session-init, add Linear --clear-cycle helper, and update skill docs/tests. Tests: bash -n touched scripts; git diff --check; bash skills/worktree/tests/worktree_remove.sh.