### PR TITLE
Fix bot review wait for Claude summary comments

### DIFF
--- a/skills/github/scripts/commands/find-comment.sh
+++ b/skills/github/scripts/commands/find-comment.sh
@@ -119,21 +119,19 @@ find_comment() {
     comments=$(gh_rest "repos/$owner/$repo/issues/$pr_num/comments") || exit 1
 
     if [ "$review_summary" = "true" ]; then
-        # Selection priority for a "review summary" comment:
-        #   1. Sticky bearing the "View job" marker (Claude-style sticky)
-        #   2. Comment with a review-section header
+        # Selection priority lives in github-api.sh so sticky-comment and
+        # find-comment stay aligned as review bot formats evolve:
+        #   1. Sticky bearing the "View job" / "Claude finished" marker
+        #   2. Comment with a shared review-signal marker
         #   3. The author's earliest comment (Codex-style submission comment)
         # Returns {} if no comment by author exists.
-        echo "$comments" | jq -c --arg author "$author" '
-            (if $author == "" then . else map(select(.user.login == $author)) end) as $candidates |
-            (
-                ($candidates | map(select(.body | test("View job"; "i"))) | first) //
-                ($candidates | map(select(.body | test("## Review|### Inline|### Recommendation|Recommendation:"; "i"))) | last) //
-                ($candidates | first) //
-                null
-            ) |
-            if . then {id: .id, author: .user.login, body: .body, created_at: .created_at, updated_at: .updated_at, url: .html_url} else {} end
-        '
+        local summary
+        summary=$(select_review_summary_comment_from_comments "$comments" "$author" false true)
+        if [[ -z "$summary" || "$summary" == "null" ]]; then
+            echo '{}'
+        else
+            echo "$summary" | jq -c '{id: .id, author: .user.login, body: .body, created_at: .created_at, updated_at: .updated_at, url: .html_url}'
+        fi
         return
     fi
 

--- a/skills/github/scripts/commands/sticky-comment.sh
+++ b/skills/github/scripts/commands/sticky-comment.sh
@@ -2,9 +2,10 @@
 # Get sticky/review-summary bot comment from a PR.
 # Usage: ./sticky-comment.sh <PR#> [--body|--updated-at|--verdict|--analysis] [--bot <login>]
 #
-# By default this targets the bot in $GH_BOT_USERNAME (Claude-style sticky).
-# Pass --bot to query a different reviewer — useful when multiple review bots
-# (e.g. Claude + Codex) are configured for a single PR.
+# By default this targets the bot in $GH_BOT_USERNAME (Claude-style sticky),
+# or falls back to any bot-authored Claude-style review-summary comment when no
+# bot is configured. Pass --bot to query a different reviewer — useful when
+# multiple review bots (e.g. Claude + Codex) are configured for a single PR.
 #
 # Returns JSON by default, or specific field with flags:
 #   --body         Just the comment body
@@ -50,7 +51,7 @@ Analysis Output:
   }
 
 Examples:
-  sticky-comment.sh 23                              # Full JSON for default bot
+  sticky-comment.sh 23                              # Full JSON for configured/default bot; auto-detects Claude-style if unset
   sticky-comment.sh 23 --body                       # Just comment body
   sticky-comment.sh 23 --verdict --bot 'codex[bot]' # Codex's verdict
 EOF
@@ -91,6 +92,10 @@ if [[ -z "$FLAG" && "${POSITIONAL[1]:-}" =~ ^--(body|updated-at|verdict|analysis
 fi
 
 BOT_USER="${BOT_OVERRIDE:-${GH_BOT_USERNAME:-review-bot[bot]}}"
+BOT_EXPLICIT=false
+if [[ -n "$BOT_OVERRIDE" || -n "${GH_BOT_USERNAME:-}" ]]; then
+  BOT_EXPLICIT=true
+fi
 
 if [[ -z "$PR_NUM" ]]; then
   echo '{"error": "Usage: sticky-comment.sh <PR#> [--body|--updated-at|--verdict|--analysis]"}' >&2
@@ -110,27 +115,26 @@ if echo "$RESPONSE" | jq -e '.message' >/dev/null 2>&1; then
   exit 1
 fi
 
-# Find sticky comment: prefer "View job" (sticky marker), fall back to review headers
-STICKY=$(echo "$RESPONSE" | jq '
-  [.[] | select(.user.login == "'"$BOT_USER"'")] |
-  # First try: sticky with View job
-  (map(select(.body | test("View job"; "i"))) | first) //
-  # Fallback: any with review headers
-  (map(select(.body | test("## Review|### Inline"; "i"))) | last) //
-  empty
-')
+find_sticky_comment() {
+  local response="$1"
+  local allow_any="false"
+  if [[ "$BOT_EXPLICIT" == "false" ]]; then
+    allow_any="true"
+  fi
+  select_sticky_comment_from_comments "$response" "$BOT_USER" "$allow_any"
+}
+
+# Find sticky comment: prefer the configured/default bot, then (when no bot was
+# explicitly configured) fall back to any bot-authored Claude-style review
+# summary such as `**Claude finished ...** —— [View job](...)`.
+STICKY=$(find_sticky_comment "$RESPONSE")
 
 # Validate we got a comment object (has id and body)
 # Retry once after brief delay if not found (handles API sync delay)
 if [[ -z "$STICKY" || "$STICKY" == "null" ]] || ! echo "$STICKY" | jq -e '.id and .body' >/dev/null 2>&1; then
   sleep 2
   RESPONSE=$(gh api "repos/{owner}/{repo}/issues/$PR_NUM/comments" 2>&1) || true
-  STICKY=$(echo "$RESPONSE" | jq '
-    [.[] | select(.user.login == "'"$BOT_USER"'")] |
-    (map(select(.body | test("View job"; "i"))) | first) //
-    (map(select(.body | test("## Review|### Inline"; "i"))) | last) //
-    empty
-  ' 2>/dev/null || echo "")
+  STICKY=$(find_sticky_comment "$RESPONSE")
 
   if [[ -z "$STICKY" || "$STICKY" == "null" ]] || ! echo "$STICKY" | jq -e '.id and .body' >/dev/null 2>&1; then
     echo '{"error": "No sticky comment found"}' >&2
@@ -138,54 +142,11 @@ if [[ -z "$STICKY" || "$STICKY" == "null" ]] || ! echo "$STICKY" | jq -e '.id an
   fi
 fi
 
-# Helper: detect verdict from body text (emoji-based, legacy)
-#
-# Returns "pending" when the comment is purely a task checklist with unchecked
-# items and no final review section. The bot posts an in-progress checklist
-# before it finishes reviewing; treating that as a terminal verdict causes
-# bot-review-wait to exit before the bot has actually posted its findings.
-#
-# A comment is considered "review complete" (not just in-progress) when it
-# contains at least one of:
-#   - A review section header: ## Review, ### Inline, ### Recommendation
-#   - An explicit approval/changes statement
-# If none of those are present and unchecked items remain, return "pending".
+# Helper: detect verdict from body text. Delegates to github-api.sh so
+# sticky-comment, pr-review-status, and bot-review-wait share one parser.
 get_verdict() {
   local body="$1"
-
-  # Check if comment has a final review section (not just a task checklist)
-  local has_review_section
-  has_review_section=$(echo "$body" | grep -ciE '## Review|### Inline|### Recommendation|Recommendation:|View job' || true)
-
-  # If no review section present, check for unchecked checklist items.
-  # An in-progress checklist (unchecked items, no review section) = still processing.
-  if [[ $has_review_section -eq 0 ]]; then
-    local unchecked
-    unchecked=$(echo "$body" | grep -c '^\s*- \[ \]' || true)
-    if [[ $unchecked -gt 0 ]]; then
-      echo "pending"
-      return
-    fi
-  fi
-
-  # Standard emoji/keyword verdict detection
-  local has_check has_approv has_warn has_changes
-  has_check=$(echo "$body" | grep -c "✅" || true)
-  has_approv=$(echo "$body" | grep -ci "approv" || true)
-  has_warn=$(echo "$body" | grep -c "⚠️" || true)
-  has_changes=$(echo "$body" | grep -ci "changes" || true)
-
-  if [[ $has_check -gt 0 && $has_approv -gt 0 ]]; then
-    if [[ $has_warn -gt 0 || $has_changes -gt 0 ]]; then
-      echo "changes"  # Mixed signals = treat as changes
-    else
-      echo "approved"
-    fi
-  elif [[ $has_warn -gt 0 || $has_changes -gt 0 ]]; then
-    echo "changes"
-  else
-    echo "pending"
-  fi
+  compute_sticky_verdict_from_body "$body"
 }
 
 # Helper: deep analysis of bot recommendation
@@ -257,7 +218,8 @@ case "$FLAG" in
     ;;
   --verdict)
     # Primary: formal GitHub review state (structured, reliable)
-    FORMAL=$(get_formal_review_verdict "$PR_NUM" "$BOT_USER")
+    STICKY_BOT_USER=$(echo "$STICKY" | jq -r '.user.login // empty')
+    FORMAL=$(get_formal_review_verdict "$PR_NUM" "${STICKY_BOT_USER:-$BOT_USER}")
     if [[ -n "$FORMAL" ]]; then
       echo "$FORMAL"
     else
@@ -274,7 +236,8 @@ case "$FLAG" in
     # Return full JSON with computed verdict
     # Primary: formal review; fallback: sticky text parsing
     BODY=$(echo "$STICKY" | jq -r '.body')
-    FORMAL=$(get_formal_review_verdict "$PR_NUM" "$BOT_USER")
+    STICKY_BOT_USER=$(echo "$STICKY" | jq -r '.user.login // empty')
+    FORMAL=$(get_formal_review_verdict "$PR_NUM" "${STICKY_BOT_USER:-$BOT_USER}")
     VERDICT="${FORMAL:-$(get_verdict "$BODY")}"
     # Sanitize control characters in body to prevent jq parse errors
     echo "$STICKY" | jq --arg v "$VERDICT" '.body |= gsub("[[:cntrl:]]"; "") | . + {verdict: $v}'

--- a/skills/github/scripts/commands/sticky-comment.sh
+++ b/skills/github/scripts/commands/sticky-comment.sh
@@ -3,8 +3,8 @@
 # Usage: ./sticky-comment.sh <PR#> [--body|--updated-at|--verdict|--analysis] [--bot <login>]
 #
 # By default this targets the bot in $GH_BOT_USERNAME (Claude-style sticky),
-# or falls back to any bot-authored Claude-style review-summary comment when no
-# bot is configured. Pass --bot to query a different reviewer — useful when
+# or falls back to a known review-bot Claude-style review-summary comment when
+# no bot is configured. Pass --bot to query a different reviewer — useful when
 # multiple review bots (e.g. Claude + Codex) are configured for a single PR.
 #
 # Returns JSON by default, or specific field with flags:
@@ -51,7 +51,7 @@ Analysis Output:
   }
 
 Examples:
-  sticky-comment.sh 23                              # Full JSON for configured/default bot; auto-detects Claude-style if unset
+  sticky-comment.sh 23                              # Full JSON for configured/default bot; auto-detects known Claude-style if unset
   sticky-comment.sh 23 --body                       # Just comment body
   sticky-comment.sh 23 --verdict --bot 'codex[bot]' # Codex's verdict
 EOF
@@ -125,7 +125,7 @@ find_sticky_comment() {
 }
 
 # Find sticky comment: prefer the configured/default bot, then (when no bot was
-# explicitly configured) fall back to any bot-authored Claude-style review
+# explicitly configured) fall back to a known review-bot Claude-style review
 # summary such as `**Claude finished ...** —— [View job](...)`.
 STICKY=$(find_sticky_comment "$RESPONSE")
 

--- a/skills/github/scripts/lib/github-api.sh
+++ b/skills/github/scripts/lib/github-api.sh
@@ -452,9 +452,9 @@ compute_sticky_verdict_from_body() {
     local change_directives has_bare_directive_changes has_denied_approval has_pending_approval has_bare_directive_approval
     change_directives=$(printf '%s\n' "$verdict_directives" | sed -E 's/[Nn]o changes requested//g; s/0 changes requested//g; s/[Nn]o blocking changes//g')
     has_bare_directive_changes=$(printf '%s\n' "$change_directives" | grep -ciE '(^|[[:space:]])(Verdict|Status|Recommendation):[[:space:]]*(changes|change|needs changes|request changes|changes requested)\b' || true)
-    has_denied_approval=$(printf '%s\n' "$verdict_lines" | grep -ciE "\b(do not approve|don't approve|cannot approve|not approved|approval not recommended|not recommend approval|recommend against approval|approval denied|approval rejected|approval withheld|no approval|denied approval|rejected approval)\b" || true)
-    has_pending_approval=$(printf '%s\n' "$verdict_lines" | grep -ciE '\b(not ready for approval|pending approval|approval pending|awaiting approval|needs approval|requires approval|approval required|required approval)\b' || true)
-    has_bare_directive_approval=$(printf '%s\n' "$verdict_directives" | grep -ciE '(^|[[:space:]])(Verdict|Status|Recommendation):.*\b(approve|approved)\b' || true)
+    has_denied_approval=$(printf '%s\n' "$verdict_lines" | grep -ciE "\b(do not approve|don't approve|cannot approve|not approved|approval not recommended|not recommend approval|recommend against approval|approval denied|approval rejected|approval withheld|no approval|denied approval|rejected approval|denied|rejected|reject)\b" || true)
+    has_pending_approval=$(printf '%s\n' "$verdict_lines" | grep -ciE '\b(not ready for approval|not ready to approve|not yet approved|pending approval|approval pending|awaiting approval|needs approval|requires approval|approval required|required approval)\b' || true)
+    has_bare_directive_approval=$(printf '%s\n' "$verdict_directives" | grep -ciE '(^|[[:space:]])(Verdict|Status|Recommendation):[[:space:]]*(✅[[:space:]]*)?(approve|approved)\b' || true)
     has_warning=$(printf '%s\n' "$verdict_lines" | grep -cE '⚠️|❌' || true)
     has_explicit_approval=$(printf '%s\n' "$verdict_lines" | grep -ciE '✅.*approved|approved for merge|ready for merge|Review Complete ✅|\*\*Approved\*\*' || true)
 

--- a/skills/github/scripts/lib/github-api.sh
+++ b/skills/github/scripts/lib/github-api.sh
@@ -442,27 +442,28 @@ compute_sticky_verdict_from_body() {
         /([Cc]hanges requested|[Nn]eeds changes|[Rr]equest changes|[Aa]pproved for merge|[Rr]eady for merge|Review Complete ✅|\*\*[Aa]pproved\*\*)/ { print; next }
     ' || true)
 
-    local verdict_directives has_explicit_changes has_warning has_explicit_approval
+    local change_verdict_lines verdict_directives has_explicit_changes has_warning has_explicit_approval
+    # Strip only explicitly negated "changes requested" text before scanning
+    # for blockers. Keep the rest of the line so real blockers like
+    # "cannot merge" still win over nearby approval text.
+    change_verdict_lines=$(printf '%s\n' "$verdict_lines" | sed -E 's/[Nn]o changes requested//g; s/0 changes requested//g; s/[Nn]o blocking changes//g')
     verdict_directives=$(printf '%s\n' "$verdict_lines" | grep -iE '(^|[[:space:]])(Verdict|Status|Recommendation):' || true)
-    has_explicit_changes=$(printf '%s\n' "$verdict_lines" | grep -ciE '(^|[^[:alnum:]])(changes requested|needs changes|request changes|changes required|not approved|cannot merge|do not merge|blocks merge|blocked)([^[:alnum:]]|$)' || true)
-    # Do not let "no changes requested" negate an approval.
-    local negated_changes
-    negated_changes=$(printf '%s\n' "$verdict_lines" | grep -ciE 'no changes requested|0 changes requested|no blocking changes' || true)
-    if [[ $negated_changes -gt 0 && $has_explicit_changes -le $negated_changes ]]; then
-        has_explicit_changes=0
-    fi
-    local has_bare_directive_changes has_negated_directive_approval has_bare_directive_approval
-    has_bare_directive_changes=$(printf '%s\n' "$verdict_directives" | grep -ciE '(^|[[:space:]])(Verdict|Status|Recommendation):[[:space:]]*(changes|change|needs changes|request changes|changes requested)\b' || true)
-    if [[ $negated_changes -gt 0 && $has_bare_directive_changes -le $negated_changes ]]; then
-        has_bare_directive_changes=0
-    fi
+    has_explicit_changes=$(printf '%s\n' "$change_verdict_lines" | grep -ciE '(^|[^[:alnum:]])(changes requested|needs changes|request changes|changes required|not approved|cannot merge|do not merge|blocks merge|blocked)([^[:alnum:]]|$)' || true)
+    local change_directives has_bare_directive_changes has_negated_directive_approval has_pending_directive has_bare_directive_approval
+    change_directives=$(printf '%s\n' "$verdict_directives" | sed -E 's/[Nn]o changes requested//g; s/0 changes requested//g; s/[Nn]o blocking changes//g')
+    has_bare_directive_changes=$(printf '%s\n' "$change_directives" | grep -ciE '(^|[[:space:]])(Verdict|Status|Recommendation):[[:space:]]*(changes|change|needs changes|request changes|changes requested)\b' || true)
     has_negated_directive_approval=$(printf '%s\n' "$verdict_directives" | grep -ciE "(^|[[:space:]])(Verdict|Status|Recommendation):.*\b(do not approve|don't approve|cannot approve|not approved|approval not recommended|not recommend approval|recommend against approval)\b" || true)
-    has_bare_directive_approval=$(printf '%s\n' "$verdict_directives" | grep -ciE '(^|[[:space:]])(Verdict|Status|Recommendation):.*\b(approve|approved|approval)\b' || true)
+    has_pending_directive=$(printf '%s\n' "$verdict_directives" | grep -ciE '(^|[[:space:]])(Verdict|Status|Recommendation):.*\b(pending|reviewing|in progress|awaiting approval|needs approval|requires approval|approval required|required approval)\b' || true)
+    has_bare_directive_approval=$(printf '%s\n' "$verdict_directives" | grep -ciE '(^|[[:space:]])(Verdict|Status|Recommendation):.*\b(approve|approved)\b' || true)
     has_warning=$(printf '%s\n' "$verdict_lines" | grep -cE '⚠️|❌' || true)
     has_explicit_approval=$(printf '%s\n' "$verdict_lines" | grep -ciE '✅.*approv|approv(ed|al)|approved for merge|ready for merge|Review Complete ✅|\*\*Approved\*\*' || true)
 
     if [[ $has_explicit_changes -gt 0 || $has_bare_directive_changes -gt 0 || $has_negated_directive_approval -gt 0 || $has_warning -gt 0 ]]; then
         echo "changes"
+        return 0
+    fi
+    if [[ $has_pending_directive -gt 0 ]]; then
+        echo "pending"
         return 0
     fi
     if [[ $has_explicit_approval -gt 0 || $has_bare_directive_approval -gt 0 ]]; then

--- a/skills/github/scripts/lib/github-api.sh
+++ b/skills/github/scripts/lib/github-api.sh
@@ -451,16 +451,17 @@ compute_sticky_verdict_from_body() {
     if [[ $negated_changes -gt 0 && $has_explicit_changes -le $negated_changes ]]; then
         has_explicit_changes=0
     fi
-    local has_bare_directive_changes has_bare_directive_approval
+    local has_bare_directive_changes has_negated_directive_approval has_bare_directive_approval
     has_bare_directive_changes=$(printf '%s\n' "$verdict_directives" | grep -ciE '(^|[[:space:]])(Verdict|Status|Recommendation):[[:space:]]*(changes|change|needs changes|request changes|changes requested)\b' || true)
     if [[ $negated_changes -gt 0 && $has_bare_directive_changes -le $negated_changes ]]; then
         has_bare_directive_changes=0
     fi
+    has_negated_directive_approval=$(printf '%s\n' "$verdict_directives" | grep -ciE "(^|[[:space:]])(Verdict|Status|Recommendation):.*\b(do not approve|don't approve|cannot approve|not approved|approval not recommended|not recommend approval|recommend against approval)\b" || true)
     has_bare_directive_approval=$(printf '%s\n' "$verdict_directives" | grep -ciE '(^|[[:space:]])(Verdict|Status|Recommendation):.*\b(approve|approved|approval)\b' || true)
     has_warning=$(printf '%s\n' "$verdict_lines" | grep -cE '⚠️|❌' || true)
     has_explicit_approval=$(printf '%s\n' "$verdict_lines" | grep -ciE '✅.*approv|approv(ed|al)|approved for merge|ready for merge|Review Complete ✅|\*\*Approved\*\*' || true)
 
-    if [[ $has_explicit_changes -gt 0 || $has_bare_directive_changes -gt 0 || $has_warning -gt 0 ]]; then
+    if [[ $has_explicit_changes -gt 0 || $has_bare_directive_changes -gt 0 || $has_negated_directive_approval -gt 0 || $has_warning -gt 0 ]]; then
         echo "changes"
         return 0
     fi

--- a/skills/github/scripts/lib/github-api.sh
+++ b/skills/github/scripts/lib/github-api.sh
@@ -449,20 +449,20 @@ compute_sticky_verdict_from_body() {
     change_verdict_lines=$(printf '%s\n' "$verdict_lines" | sed -E 's/[Nn]o changes requested//g; s/0 changes requested//g; s/[Nn]o blocking changes//g')
     verdict_directives=$(printf '%s\n' "$verdict_lines" | grep -iE '(^|[[:space:]])(Verdict|Status|Recommendation):' || true)
     has_explicit_changes=$(printf '%s\n' "$change_verdict_lines" | grep -ciE '(^|[^[:alnum:]])(changes requested|needs changes|request changes|changes required|not approved|cannot merge|do not merge|blocks merge|blocked)([^[:alnum:]]|$)' || true)
-    local change_directives has_bare_directive_changes has_negated_directive_approval has_pending_directive has_bare_directive_approval
+    local change_directives has_bare_directive_changes has_denied_approval has_pending_approval has_bare_directive_approval
     change_directives=$(printf '%s\n' "$verdict_directives" | sed -E 's/[Nn]o changes requested//g; s/0 changes requested//g; s/[Nn]o blocking changes//g')
     has_bare_directive_changes=$(printf '%s\n' "$change_directives" | grep -ciE '(^|[[:space:]])(Verdict|Status|Recommendation):[[:space:]]*(changes|change|needs changes|request changes|changes requested)\b' || true)
-    has_negated_directive_approval=$(printf '%s\n' "$verdict_directives" | grep -ciE "(^|[[:space:]])(Verdict|Status|Recommendation):.*\b(do not approve|don't approve|cannot approve|not approved|approval not recommended|not recommend approval|recommend against approval)\b" || true)
-    has_pending_directive=$(printf '%s\n' "$verdict_directives" | grep -ciE '(^|[[:space:]])(Verdict|Status|Recommendation):.*\b(pending|reviewing|in progress|awaiting approval|needs approval|requires approval|approval required|required approval)\b' || true)
+    has_denied_approval=$(printf '%s\n' "$verdict_lines" | grep -ciE "\b(do not approve|don't approve|cannot approve|not approved|approval not recommended|not recommend approval|recommend against approval|approval denied|approval rejected|approval withheld|no approval|denied approval|rejected approval)\b" || true)
+    has_pending_approval=$(printf '%s\n' "$verdict_lines" | grep -ciE '\b(not ready for approval|pending approval|approval pending|awaiting approval|needs approval|requires approval|approval required|required approval)\b' || true)
     has_bare_directive_approval=$(printf '%s\n' "$verdict_directives" | grep -ciE '(^|[[:space:]])(Verdict|Status|Recommendation):.*\b(approve|approved)\b' || true)
     has_warning=$(printf '%s\n' "$verdict_lines" | grep -cE '⚠️|❌' || true)
-    has_explicit_approval=$(printf '%s\n' "$verdict_lines" | grep -ciE '✅.*approv|approv(ed|al)|approved for merge|ready for merge|Review Complete ✅|\*\*Approved\*\*' || true)
+    has_explicit_approval=$(printf '%s\n' "$verdict_lines" | grep -ciE '✅.*approved|approved for merge|ready for merge|Review Complete ✅|\*\*Approved\*\*' || true)
 
-    if [[ $has_explicit_changes -gt 0 || $has_bare_directive_changes -gt 0 || $has_negated_directive_approval -gt 0 || $has_warning -gt 0 ]]; then
+    if [[ $has_explicit_changes -gt 0 || $has_bare_directive_changes -gt 0 || $has_denied_approval -gt 0 || $has_warning -gt 0 ]]; then
         echo "changes"
         return 0
     fi
-    if [[ $has_pending_directive -gt 0 ]]; then
+    if [[ $has_pending_approval -gt 0 ]]; then
         echo "pending"
         return 0
     fi

--- a/skills/github/scripts/lib/github-api.sh
+++ b/skills/github/scripts/lib/github-api.sh
@@ -729,7 +729,11 @@ detect_bot_reviewers_from_inputs() {
             | select((.body // "") | test($marker_re; "i"))
             | .user.login
         ' <<<"$comments_json"
-        jq -r '.[].user.login | select(endswith("[bot]"))' <<<"$reactions_json"
+        jq -r --arg login_re "$login_re" '
+            .[]
+            | select((.user.login // "") | test($login_re))
+            | .user.login
+        ' <<<"$reactions_json"
     } | sort -u | grep -v '^$' || true
 }
 

--- a/skills/github/scripts/lib/github-api.sh
+++ b/skills/github/scripts/lib/github-api.sh
@@ -364,33 +364,58 @@ _review_signal_comment_regex() {
     printf '%s' 'Claude finished|View job|### PR Review|### Review Summary|## Review|### Inline|### Recommendation|Recommendation:|Verdict:|Status:'
 }
 
-# Select the sticky/review-summary comment for a bot from a preloaded issue
-# comments JSON array. When allow_any_bot is true, fall back to any bot-authored
-# review-signal comment if the requested/default bot did not post one.
-select_sticky_comment_from_comments() {
+# Review-summary comments can contain terminal verdicts, so no-config fallback
+# only accepts known review-bot identities. Custom bots remain supported by
+# explicit GH_BOT_USERNAME / --bot / BOT_REVIEWERS paths.
+_review_comment_bot_login_regex() {
+    printf '%s' '^(claude|claude-code|review-bot|chatgpt-codex-connector)\[bot\]$'
+}
+
+# Select a review-summary comment from a preloaded issue comments JSON array.
+# Reused by sticky-comment and find-comment so bot-format marker changes live in
+# one place. Selection order: View-job marker, review-signal marker, optional
+# first candidate fallback.
+select_review_summary_comment_from_comments() {
     local comments_json="${1:-[]}"
-    local bot_user="${2:-}"
-    local allow_any_bot="${3:-false}"
-    local marker_re
+    local author="${2:-}"
+    local allow_known_bot_fallback="${3:-false}"
+    local include_first_fallback="${4:-false}"
+    local marker_re login_re
     marker_re="$(_review_signal_comment_regex)"
+    login_re="$(_review_comment_bot_login_regex)"
 
     jq -c \
-        --arg u "$bot_user" \
+        --arg author "$author" \
         --arg marker_re "$marker_re" \
-        --arg allow_any_bot "$allow_any_bot" '
+        --arg login_re "$login_re" \
+        --arg allow_known_bot_fallback "$allow_known_bot_fallback" \
+        --arg include_first_fallback "$include_first_fallback" '
         def bot_login: (.user.login // "");
         def body_text: (.body // "");
         def is_view_job: (body_text | test("Claude finished|View job"; "i"));
         def is_review_signal($marker_re): (body_text | test($marker_re; "i"));
-        def pick($items; $marker_re):
+        def is_known_review_bot($login_re): (bot_login | test($login_re));
+        def pick($items; $marker_re; $include_first_fallback):
             (($items | map(select(is_view_job)) | last) //
              ($items | map(select(is_review_signal($marker_re))) | last) //
+             (if $include_first_fallback == "true" then ($items | first) else empty end) //
              empty);
-        ([.[] | select(bot_login == $u)] | pick(.; $marker_re)) //
-        (if $allow_any_bot == "true" then
-            ([.[] | select(bot_login | endswith("[bot]"))] | pick(.; $marker_re))
+        (if $author == "" then . else [.[] | select(bot_login == $author)] end) as $candidates |
+        ($candidates | pick(.; $marker_re; $include_first_fallback)) //
+        (if $allow_known_bot_fallback == "true" then
+            ([.[] | select(is_known_review_bot($login_re))] | pick(.; $marker_re; "false"))
          else empty end)
     ' <<<"$comments_json" 2>/dev/null || true
+}
+
+# Select the sticky/review-summary comment for a bot from a preloaded issue
+# comments JSON array. When allow_known_bot_fallback is true, fall back only to
+# known review-bot identities if the requested/default bot did not post one.
+select_sticky_comment_from_comments() {
+    local comments_json="${1:-[]}"
+    local bot_user="${2:-}"
+    local allow_known_bot_fallback="${3:-false}"
+    select_review_summary_comment_from_comments "$comments_json" "$bot_user" "$allow_known_bot_fallback" false
 }
 
 # Compute the verdict ("pending"|"approved"|"changes") from a sticky/review
@@ -417,7 +442,8 @@ compute_sticky_verdict_from_body() {
         /([Cc]hanges requested|[Nn]eeds changes|[Rr]equest changes|[Aa]pproved for merge|[Rr]eady for merge|Review Complete ✅|\*\*[Aa]pproved\*\*)/ { print; next }
     ' || true)
 
-    local has_explicit_changes has_warning has_explicit_approval
+    local verdict_directives has_explicit_changes has_warning has_explicit_approval
+    verdict_directives=$(printf '%s\n' "$verdict_lines" | grep -iE '(^|[[:space:]])(Verdict|Status|Recommendation):' || true)
     has_explicit_changes=$(printf '%s\n' "$verdict_lines" | grep -ciE '(^|[^[:alnum:]])(changes requested|needs changes|request changes|changes required|not approved|cannot merge|do not merge|blocks merge|blocked)([^[:alnum:]]|$)' || true)
     # Do not let "no changes requested" negate an approval.
     local negated_changes
@@ -425,14 +451,20 @@ compute_sticky_verdict_from_body() {
     if [[ $negated_changes -gt 0 && $has_explicit_changes -le $negated_changes ]]; then
         has_explicit_changes=0
     fi
+    local has_bare_directive_changes has_bare_directive_approval
+    has_bare_directive_changes=$(printf '%s\n' "$verdict_directives" | grep -ciE '(^|[[:space:]])(Verdict|Status|Recommendation):[[:space:]]*(changes|change|needs changes|request changes|changes requested)\b' || true)
+    if [[ $negated_changes -gt 0 && $has_bare_directive_changes -le $negated_changes ]]; then
+        has_bare_directive_changes=0
+    fi
+    has_bare_directive_approval=$(printf '%s\n' "$verdict_directives" | grep -ciE '(^|[[:space:]])(Verdict|Status|Recommendation):.*\b(approve|approved|approval)\b' || true)
     has_warning=$(printf '%s\n' "$verdict_lines" | grep -cE '⚠️|❌' || true)
     has_explicit_approval=$(printf '%s\n' "$verdict_lines" | grep -ciE '✅.*approv|approv(ed|al)|approved for merge|ready for merge|Review Complete ✅|\*\*Approved\*\*' || true)
 
-    if [[ $has_explicit_changes -gt 0 || $has_warning -gt 0 ]]; then
+    if [[ $has_explicit_changes -gt 0 || $has_bare_directive_changes -gt 0 || $has_warning -gt 0 ]]; then
         echo "changes"
         return 0
     fi
-    if [[ $has_explicit_approval -gt 0 ]]; then
+    if [[ $has_explicit_approval -gt 0 || $has_bare_directive_approval -gt 0 ]]; then
         echo "approved"
         return 0
     fi
@@ -683,14 +715,15 @@ detect_bot_reviewers_from_inputs() {
     local reviews_json="${1:-[]}"
     local comments_json="${2:-[]}"
     local reactions_json="${3:-[]}"
-    local marker_re
+    local marker_re login_re
     marker_re="$(_review_signal_comment_regex)"
+    login_re="$(_review_comment_bot_login_regex)"
 
     {
         jq -r '.[].user.login | select(endswith("[bot]"))' <<<"$reviews_json"
-        jq -r --arg marker_re "$marker_re" '
+        jq -r --arg marker_re "$marker_re" --arg login_re "$login_re" '
             .[]
-            | select((.user.login // "") | endswith("[bot]"))
+            | select((.user.login // "") | test($login_re))
             | select((.body // "") | test($marker_re; "i"))
             | .user.login
         ' <<<"$comments_json"
@@ -714,10 +747,11 @@ detect_bot_reviewers() {
     # Codex can signal via a reaction on its own first comment rather than on
     # the PR body. Include those reaction authors without treating every bot
     # comment author as a reviewer.
-    local comment_id comment_reactions reaction_reviewers
+    local comment_id comment_reactions reaction_reviewers login_re
+    login_re="$(_review_comment_bot_login_regex)"
     while IFS= read -r comment_id; do
         [[ -z "$comment_id" ]] && continue
-        comment_reactions=$(gh_rest "repos/{owner}/{repo}/issues/comments/$comment_id/reactions" 2>/dev/null || echo '[]')
+        comment_reactions=$(gh_rest "repos/{owner}/{repo}/issues/comments/$comment_id/reactions") || return 1
         reaction_reviewers=$(jq -r '
             .[]
             | select((.user.login // "") | endswith("[bot]"))
@@ -727,7 +761,7 @@ detect_bot_reviewers() {
         if [[ -n "$reaction_reviewers" ]]; then
             reviewers=$(printf '%s\n%s\n' "$reviewers" "$reaction_reviewers" | sort -u | grep -v '^$' || true)
         fi
-    done < <(jq -r '.[] | select((.user.login // "") | endswith("[bot]")) | .id // empty' <<<"$comments" 2>/dev/null || true)
+    done < <(jq -r --arg login_re "$login_re" '.[] | select((.user.login // "") | test($login_re)) | .id // empty' <<<"$comments" 2>/dev/null || true)
 
     printf '%s\n' "$reviewers" | sort -u | grep -v '^$' || true
 }

--- a/skills/github/scripts/lib/github-api.sh
+++ b/skills/github/scripts/lib/github-api.sh
@@ -748,21 +748,21 @@ detect_bot_reviewers() {
     # Codex can signal via a reaction on its own first comment rather than on
     # the PR body. Include those reaction authors without treating every bot
     # comment author as a reviewer.
-    local comment_id comment_reactions reaction_reviewers login_re
+    local comment_id comment_author comment_reactions reaction_reviewers login_re
     login_re="$(_review_comment_bot_login_regex)"
-    while IFS= read -r comment_id; do
-        [[ -z "$comment_id" ]] && continue
+    while IFS=$'\t' read -r comment_id comment_author; do
+        [[ -z "$comment_id" || -z "$comment_author" ]] && continue
         comment_reactions=$(gh_rest "repos/{owner}/{repo}/issues/comments/$comment_id/reactions") || return 1
-        reaction_reviewers=$(jq -r '
+        reaction_reviewers=$(jq -r --arg author "$comment_author" '
             .[]
-            | select((.user.login // "") | endswith("[bot]"))
+            | select((.user.login // "") == $author)
             | select((.content // "") == "+1" or (.content // "") == "eyes" or (.content // "") == "THUMBS_UP" or (.content // "") == "EYES")
             | .user.login
         ' <<<"$comment_reactions" 2>/dev/null || true)
         if [[ -n "$reaction_reviewers" ]]; then
             reviewers=$(printf '%s\n%s\n' "$reviewers" "$reaction_reviewers" | sort -u | grep -v '^$' || true)
         fi
-    done < <(jq -r --arg login_re "$login_re" '.[] | select((.user.login // "") | test($login_re)) | .id // empty' <<<"$comments" 2>/dev/null || true)
+    done < <(jq -r --arg login_re "$login_re" '.[] | select((.user.login // "") | test($login_re)) | [.id, .user.login] | @tsv' <<<"$comments" 2>/dev/null || true)
 
     printf '%s\n' "$reviewers" | sort -u | grep -v '^$' || true
 }

--- a/skills/github/scripts/lib/github-api.sh
+++ b/skills/github/scripts/lib/github-api.sh
@@ -356,37 +356,96 @@ get_formal_review_verdict() {
     esac
 }
 
+# Comment bodies that look like bot review/status output rather than generic
+# automation comments (for example Linear linkbacks). Keep this broad enough for
+# Claude sticky comments, but narrow enough that unrelated bot comments do not
+# become reviewers and block bot-review-wait.
+_review_signal_comment_regex() {
+    printf '%s' 'Claude finished|View job|### PR Review|### Review Summary|## Review|### Inline|### Recommendation|Recommendation:|Verdict:|Status:'
+}
+
+# Select the sticky/review-summary comment for a bot from a preloaded issue
+# comments JSON array. When allow_any_bot is true, fall back to any bot-authored
+# review-signal comment if the requested/default bot did not post one.
+select_sticky_comment_from_comments() {
+    local comments_json="${1:-[]}"
+    local bot_user="${2:-}"
+    local allow_any_bot="${3:-false}"
+    local marker_re
+    marker_re="$(_review_signal_comment_regex)"
+
+    jq -c \
+        --arg u "$bot_user" \
+        --arg marker_re "$marker_re" \
+        --arg allow_any_bot "$allow_any_bot" '
+        def bot_login: (.user.login // "");
+        def body_text: (.body // "");
+        def is_view_job: (body_text | test("Claude finished|View job"; "i"));
+        def is_review_signal($marker_re): (body_text | test($marker_re; "i"));
+        def pick($items; $marker_re):
+            (($items | map(select(is_view_job)) | last) //
+             ($items | map(select(is_review_signal($marker_re))) | last) //
+             empty);
+        ([.[] | select(bot_login == $u)] | pick(.; $marker_re)) //
+        (if $allow_any_bot == "true" then
+            ([.[] | select(bot_login | endswith("[bot]"))] | pick(.; $marker_re))
+         else empty end)
+    ' <<<"$comments_json" 2>/dev/null || true
+}
+
 # Compute the verdict ("pending"|"approved"|"changes") from a sticky/review
-# comment body. Mirrors the logic in commands/sticky-comment.sh — kept here so
-# bot_review_status_compute and tests do not need to shell out.
+# comment body. This intentionally reads verdict-like lines/sections instead of
+# grepping the entire body for "changes", since approved Claude summaries can
+# contain unrelated text like "Review CI workflow changes".
 compute_sticky_verdict_from_body() {
     local body="$1"
-    local has_review_section
-    has_review_section=$(printf '%s' "$body" | grep -ciE '## Review|### Inline|### Recommendation|Recommendation:|View job' || true)
-    if [[ $has_review_section -eq 0 ]]; then
-        local unchecked
+    local marker_re verdict_lines has_final_section unchecked
+    marker_re="$(_review_signal_comment_regex)"
+
+    # Pull out explicit verdict/status/recommendation lines plus review-summary
+    # bodies. Avoid generic checklist/body lines that can mention "changes" as a
+    # noun rather than a requested verdict.
+    verdict_lines=$(printf '%s\n' "$body" | awk '
+        BEGIN { in_summary=0; remaining=0 }
+        /^### Review Summary[[:space:]]*$/ { in_summary=1; remaining=8; print; next }
+        /^### Recommendation[[:space:]]*$/ { in_summary=1; remaining=8; print; next }
+        /^## Review[[:space:]]*$/ { in_summary=1; remaining=8; print; next }
+        /^### Inline/ { in_summary=1; remaining=8; print; next }
+        in_summary && remaining > 0 { print; remaining--; next }
+        /(^|[[:space:]])(Verdict|Status|Recommendation):/ { print; next }
+        /(✅|⚠️|❌)/ { print; next }
+        /([Cc]hanges requested|[Nn]eeds changes|[Rr]equest changes|[Aa]pproved for merge|[Rr]eady for merge|Review Complete ✅|\*\*[Aa]pproved\*\*)/ { print; next }
+    ' || true)
+
+    local has_explicit_changes has_warning has_explicit_approval
+    has_explicit_changes=$(printf '%s\n' "$verdict_lines" | grep -ciE '(^|[^[:alnum:]])(changes requested|needs changes|request changes|changes required|not approved|cannot merge|do not merge|blocks merge|blocked)([^[:alnum:]]|$)' || true)
+    # Do not let "no changes requested" negate an approval.
+    local negated_changes
+    negated_changes=$(printf '%s\n' "$verdict_lines" | grep -ciE 'no changes requested|0 changes requested|no blocking changes' || true)
+    if [[ $negated_changes -gt 0 && $has_explicit_changes -le $negated_changes ]]; then
+        has_explicit_changes=0
+    fi
+    has_warning=$(printf '%s\n' "$verdict_lines" | grep -cE '⚠️|❌' || true)
+    has_explicit_approval=$(printf '%s\n' "$verdict_lines" | grep -ciE '✅.*approv|approv(ed|al)|approved for merge|ready for merge|Review Complete ✅|\*\*Approved\*\*' || true)
+
+    if [[ $has_explicit_changes -gt 0 || $has_warning -gt 0 ]]; then
+        echo "changes"
+        return 0
+    fi
+    if [[ $has_explicit_approval -gt 0 ]]; then
+        echo "approved"
+        return 0
+    fi
+
+    has_final_section=$(printf '%s' "$body" | grep -ciE "$marker_re" || true)
+    if [[ $has_final_section -eq 0 ]]; then
         unchecked=$(printf '%s\n' "$body" | grep -c '^[[:space:]]*- \[ \]' || true)
         if [[ $unchecked -gt 0 ]]; then
             echo "pending"
             return 0
         fi
     fi
-    local has_check has_approv has_warn has_changes
-    has_check=$(printf '%s' "$body" | grep -c "✅" || true)
-    has_approv=$(printf '%s' "$body" | grep -ci "approv" || true)
-    has_warn=$(printf '%s' "$body" | grep -c "⚠️" || true)
-    has_changes=$(printf '%s' "$body" | grep -ci "changes" || true)
-    if [[ $has_check -gt 0 && $has_approv -gt 0 ]]; then
-        if [[ $has_warn -gt 0 || $has_changes -gt 0 ]]; then
-            echo "changes"
-        else
-            echo "approved"
-        fi
-    elif [[ $has_warn -gt 0 || $has_changes -gt 0 ]]; then
-        echo "changes"
-    else
-        echo "pending"
-    fi
+    echo "pending"
 }
 
 # ---------------------------------------------------------------------------
@@ -485,12 +544,7 @@ bot_review_status_compute() {
 
     # --- sticky / review summary comment ---
     local sticky_obj sticky_body sticky_at
-    sticky_obj=$(jq -c --arg u "$reviewer" '
-        [.[] | select(.user.login == $u)] |
-        ((map(select(.body | test("View job"; "i"))) | first) //
-         (map(select(.body | test("## Review|### Inline|### Recommendation"; "i"))) | last) //
-         empty)
-    ' <<<"$comments_json" 2>/dev/null || echo "null")
+    sticky_obj=$(select_sticky_comment_from_comments "$comments_json" "$reviewer" false)
     if [[ -n "$sticky_obj" && "$sticky_obj" != "null" ]]; then
         sticky_body=$(jq -r '.body // ""' <<<"$sticky_obj")
         sticky_at=$(jq -r '.updated_at // .created_at // ""' <<<"$sticky_obj")
@@ -622,20 +676,62 @@ query($owner: String!, $repo: String!, $pr: Int!) {
     bot_review_status_compute "$reviewer" "$reviews" "$comments" "$body_reactions" "$own_reactions" "$threads"
 }
 
-# Auto-detect bot reviewers — every "*[bot]" login that has signaled on the PR
-# in any way (formal review, issue comment, or reaction on the PR body).
+# Auto-detect bot reviewers that have emitted review-specific signals. Generic
+# automation comments (Linear linkbacks, release notes, etc.) are intentionally
+# excluded so they do not block bot-review-wait as unknown reviewers.
+detect_bot_reviewers_from_inputs() {
+    local reviews_json="${1:-[]}"
+    local comments_json="${2:-[]}"
+    local reactions_json="${3:-[]}"
+    local marker_re
+    marker_re="$(_review_signal_comment_regex)"
+
+    {
+        jq -r '.[].user.login | select(endswith("[bot]"))' <<<"$reviews_json"
+        jq -r --arg marker_re "$marker_re" '
+            .[]
+            | select((.user.login // "") | endswith("[bot]"))
+            | select((.body // "") | test($marker_re; "i"))
+            | .user.login
+        ' <<<"$comments_json"
+        jq -r '.[].user.login | select(endswith("[bot]"))' <<<"$reactions_json"
+    } | sort -u | grep -v '^$' || true
+}
+
+# Auto-detect bot reviewers — formal-review bots, bots with review-signal
+# comments, bots reacting on the PR body, and bots reacting on their own issue
+# comment (Codex-style fallback).
 detect_bot_reviewers() {
     local pr="$1"
     local reviews comments reactions
     reviews=$(gh_rest "repos/{owner}/{repo}/pulls/$pr/reviews") || return 1
     comments=$(gh_rest "repos/{owner}/{repo}/issues/$pr/comments") || return 1
     reactions=$(gh_rest "repos/{owner}/{repo}/issues/$pr/reactions") || return 1
-    {
-        jq -r '.[].user.login | select(endswith("[bot]"))' <<<"$reviews"
-        jq -r '.[].user.login | select(endswith("[bot]"))' <<<"$comments"
-        jq -r '.[].user.login | select(endswith("[bot]"))' <<<"$reactions"
-    } | sort -u | grep -v '^$' || true
+
+    local reviewers
+    reviewers=$(detect_bot_reviewers_from_inputs "$reviews" "$comments" "$reactions")
+
+    # Codex can signal via a reaction on its own first comment rather than on
+    # the PR body. Include those reaction authors without treating every bot
+    # comment author as a reviewer.
+    local comment_id comment_reactions reaction_reviewers
+    while IFS= read -r comment_id; do
+        [[ -z "$comment_id" ]] && continue
+        comment_reactions=$(gh_rest "repos/{owner}/{repo}/issues/comments/$comment_id/reactions" 2>/dev/null || echo '[]')
+        reaction_reviewers=$(jq -r '
+            .[]
+            | select((.user.login // "") | endswith("[bot]"))
+            | select((.content // "") == "+1" or (.content // "") == "eyes" or (.content // "") == "THUMBS_UP" or (.content // "") == "EYES")
+            | .user.login
+        ' <<<"$comment_reactions" 2>/dev/null || true)
+        if [[ -n "$reaction_reviewers" ]]; then
+            reviewers=$(printf '%s\n%s\n' "$reviewers" "$reaction_reviewers" | sort -u | grep -v '^$' || true)
+        fi
+    done < <(jq -r '.[] | select((.user.login // "") | endswith("[bot]")) | .id // empty' <<<"$comments" 2>/dev/null || true)
+
+    printf '%s\n' "$reviewers" | sort -u | grep -v '^$' || true
 }
+
 
 # Check if bot token is configured and valid
 # Usage: check_bot_token [format]

--- a/skills/github/tests/bot_review_status.sh
+++ b/skills/github/tests/bot_review_status.sh
@@ -240,6 +240,9 @@ assert_eq "$(compute_sticky_verdict_from_body "Status: changes")" "changes" "bar
 assert_eq "$(compute_sticky_verdict_from_body "Recommendation: approve")" "approved" "bare Recommendation: approve = approved"
 assert_eq "$(compute_sticky_verdict_from_body "Recommendation: do not approve")" "changes" "negated Recommendation approval = changes"
 assert_eq "$(compute_sticky_verdict_from_body "Verdict: approval not recommended")" "changes" "approval-not-recommended verdict = changes"
+assert_eq "$(compute_sticky_verdict_from_body "Status: pending approval")" "pending" "pending approval directive stays pending"
+assert_eq "$(compute_sticky_verdict_from_body "Status: approval required")" "pending" "approval required directive stays pending"
+assert_eq "$(compute_sticky_verdict_from_body "Verdict: approved; no changes requested but cannot merge")" "changes" "real blocker wins over approved plus no changes requested"
 
 echo
 echo "----"

--- a/skills/github/tests/bot_review_status.sh
+++ b/skills/github/tests/bot_review_status.sh
@@ -238,6 +238,8 @@ assert_eq "$(compute_sticky_verdict_from_body "$(jq -r '.[0].body' "$FIXTURES/cl
 assert_eq "$(compute_sticky_verdict_from_body "Verdict: changes")" "changes" "bare Verdict: changes = changes"
 assert_eq "$(compute_sticky_verdict_from_body "Status: changes")" "changes" "bare Status: changes = changes"
 assert_eq "$(compute_sticky_verdict_from_body "Recommendation: approve")" "approved" "bare Recommendation: approve = approved"
+assert_eq "$(compute_sticky_verdict_from_body "Recommendation: do not approve")" "changes" "negated Recommendation approval = changes"
+assert_eq "$(compute_sticky_verdict_from_body "Verdict: approval not recommended")" "changes" "approval-not-recommended verdict = changes"
 
 echo
 echo "----"

--- a/skills/github/tests/bot_review_status.sh
+++ b/skills/github/tests/bot_review_status.sh
@@ -244,8 +244,12 @@ assert_eq "$(compute_sticky_verdict_from_body "Status: pending approval")" "pend
 assert_eq "$(compute_sticky_verdict_from_body "Status: approval required")" "pending" "approval required directive stays pending"
 assert_eq "$(compute_sticky_verdict_from_body "Verdict: approved; no changes requested but cannot merge")" "changes" "real blocker wins over approved plus no changes requested"
 assert_eq "$(compute_sticky_verdict_from_body "Status: not ready for approval")" "pending" "not-ready-for-approval text stays pending"
+assert_eq "$(compute_sticky_verdict_from_body "Status: not yet approved")" "pending" "not-yet-approved text stays pending"
+assert_eq "$(compute_sticky_verdict_from_body "Status: not ready to approve")" "pending" "not-ready-to-approve text stays pending"
 assert_eq "$(compute_sticky_verdict_from_body "Verdict: approval denied")" "changes" "approval denied text = changes"
 assert_eq "$(compute_sticky_verdict_from_body "Verdict: approval withheld")" "changes" "approval withheld text = changes"
+assert_eq "$(compute_sticky_verdict_from_body "Verdict: rejected")" "changes" "rejected verdict = changes"
+assert_eq "$(compute_sticky_verdict_from_body "Verdict: denied")" "changes" "denied verdict = changes"
 assert_eq "$(compute_sticky_verdict_from_body "Recommendation: no approval")" "changes" "no approval text = changes"
 
 echo

--- a/skills/github/tests/bot_review_status.sh
+++ b/skills/github/tests/bot_review_status.sh
@@ -214,6 +214,10 @@ echo
 echo "=== detect_bot_reviewers_from_inputs ==="
 detected=$(detect_bot_reviewers_from_inputs "$(fx empty.json)" "$(fx mixed_bot_comments.json)" "$(fx empty.json)" | paste -sd, -)
 assert_eq "$detected" "claude[bot]" "detect excludes non-review bot linkback comments"
+detected=$(detect_bot_reviewers_from_inputs "$(fx empty.json)" "$(fx untrusted_status_comments.json)" "$(fx empty.json)" | paste -sd, -)
+assert_eq "$detected" "" "detect excludes untrusted non-review bot status comment"
+selected=$(select_sticky_comment_from_comments "$(fx untrusted_status_comments.json)" "review-bot[bot]" true)
+assert_eq "$selected" "" "sticky fallback ignores non-review bot status comment"
 
 # --- Reaction normalization (REST + GraphQL forms) ---
 echo
@@ -231,6 +235,9 @@ assert_eq "$(compute_sticky_verdict_from_body "## Review\n✅ Approved")" "appro
 assert_eq "$(compute_sticky_verdict_from_body "## Review\n⚠️ changes requested")" "changes" "review section + ⚠️ = changes"
 assert_eq "$(compute_sticky_verdict_from_body "## Review\n✅ Approved with ⚠️ caveats")" "changes" "mixed signals = changes"
 assert_eq "$(compute_sticky_verdict_from_body "$(jq -r '.[0].body' "$FIXTURES/claude_review_summary_comments.json")")" "approved" "Claude Review Summary approved despite unrelated changes prose"
+assert_eq "$(compute_sticky_verdict_from_body "Verdict: changes")" "changes" "bare Verdict: changes = changes"
+assert_eq "$(compute_sticky_verdict_from_body "Status: changes")" "changes" "bare Status: changes = changes"
+assert_eq "$(compute_sticky_verdict_from_body "Recommendation: approve")" "approved" "bare Recommendation: approve = approved"
 
 echo
 echo "----"

--- a/skills/github/tests/bot_review_status.sh
+++ b/skills/github/tests/bot_review_status.sh
@@ -72,6 +72,16 @@ assert_eq "$(echo "$out" | jq -r .status)" "approved" "1b status=approved (forma
 assert_contains "$(echo "$out" | jq -c .signals)" "formal_review:approved" "1b signals contain formal_review:approved"
 assert_contains "$(echo "$out" | jq -c .signals)" "sticky:approved" "1b signals contain sticky:approved"
 
+out=$(bot_review_status_compute \
+    "claude[bot]" \
+    "$(fx empty.json)" \
+    "$(fx claude_review_summary_comments.json)" \
+    "$(fx empty.json)" \
+    "$(fx empty.json)" \
+    "$(fx empty.json)")
+assert_eq "$(echo "$out" | jq -r .status)" "approved" "1c status=approved (Claude Review Summary comment only)"
+assert_contains "$(echo "$out" | jq -c .signals)" "sticky:approved" "1c signals contain sticky:approved"
+
 # --- 2. Codex 👀 only = pending ---
 echo "Test 2: Codex eyes-reaction only = pending"
 out=$(bot_review_status_compute \
@@ -199,6 +209,12 @@ fi
 echo "Test 7c: Empty reviewer set aggregates to pending (not approved)"
 assert_eq "$(agg '[]')" "pending" "7c agg([])=pending"
 
+# --- Review-signal auto-detection ---
+echo
+echo "=== detect_bot_reviewers_from_inputs ==="
+detected=$(detect_bot_reviewers_from_inputs "$(fx empty.json)" "$(fx mixed_bot_comments.json)" "$(fx empty.json)" | paste -sd, -)
+assert_eq "$detected" "claude[bot]" "detect excludes non-review bot linkback comments"
+
 # --- Reaction normalization (REST + GraphQL forms) ---
 echo
 echo "=== reaction normalization ==="
@@ -214,6 +230,7 @@ assert_eq "$(compute_sticky_verdict_from_body "View job\n- [ ] todo")" "pending"
 assert_eq "$(compute_sticky_verdict_from_body "## Review\n✅ Approved")" "approved" "review section + ✅ + approved = approved"
 assert_eq "$(compute_sticky_verdict_from_body "## Review\n⚠️ changes requested")" "changes" "review section + ⚠️ = changes"
 assert_eq "$(compute_sticky_verdict_from_body "## Review\n✅ Approved with ⚠️ caveats")" "changes" "mixed signals = changes"
+assert_eq "$(compute_sticky_verdict_from_body "$(jq -r '.[0].body' "$FIXTURES/claude_review_summary_comments.json")")" "approved" "Claude Review Summary approved despite unrelated changes prose"
 
 echo
 echo "----"

--- a/skills/github/tests/bot_review_status.sh
+++ b/skills/github/tests/bot_review_status.sh
@@ -243,6 +243,10 @@ assert_eq "$(compute_sticky_verdict_from_body "Verdict: approval not recommended
 assert_eq "$(compute_sticky_verdict_from_body "Status: pending approval")" "pending" "pending approval directive stays pending"
 assert_eq "$(compute_sticky_verdict_from_body "Status: approval required")" "pending" "approval required directive stays pending"
 assert_eq "$(compute_sticky_verdict_from_body "Verdict: approved; no changes requested but cannot merge")" "changes" "real blocker wins over approved plus no changes requested"
+assert_eq "$(compute_sticky_verdict_from_body "Status: not ready for approval")" "pending" "not-ready-for-approval text stays pending"
+assert_eq "$(compute_sticky_verdict_from_body "Verdict: approval denied")" "changes" "approval denied text = changes"
+assert_eq "$(compute_sticky_verdict_from_body "Verdict: approval withheld")" "changes" "approval withheld text = changes"
+assert_eq "$(compute_sticky_verdict_from_body "Recommendation: no approval")" "changes" "no approval text = changes"
 
 echo
 echo "----"

--- a/skills/github/tests/bot_review_status.sh
+++ b/skills/github/tests/bot_review_status.sh
@@ -218,6 +218,10 @@ detected=$(detect_bot_reviewers_from_inputs "$(fx empty.json)" "$(fx untrusted_s
 assert_eq "$detected" "" "detect excludes untrusted non-review bot status comment"
 selected=$(select_sticky_comment_from_comments "$(fx untrusted_status_comments.json)" "review-bot[bot]" true)
 assert_eq "$selected" "" "sticky fallback ignores non-review bot status comment"
+detected=$(detect_bot_reviewers_from_inputs "$(fx empty.json)" "$(fx empty.json)" "$(fx codex_eyes_body_reactions.json)" | paste -sd, -)
+assert_eq "$detected" "chatgpt-codex-connector[bot]" "detect includes known review bot PR-body reaction"
+detected=$(detect_bot_reviewers_from_inputs "$(fx empty.json)" "$(fx empty.json)" "$(fx untrusted_body_reactions.json)" | paste -sd, -)
+assert_eq "$detected" "" "detect excludes untrusted bot PR-body reaction"
 
 # --- Reaction normalization (REST + GraphQL forms) ---
 echo

--- a/skills/github/tests/fixtures/claude_review_summary_comments.json
+++ b/skills/github/tests/fixtures/claude_review_summary_comments.json
@@ -1,0 +1,9 @@
+[
+  {
+    "id": 2001,
+    "user": {"login": "claude[bot]"},
+    "body": "**Claude finished @vg-claude's task in 1m 44s** —— [View job](https://github.com/example/actions/runs/1)\n\n---\n### PR Review: sample fix\n\n- [x] Gather context\n- [x] Review CI workflow changes\n- [x] Post review summary\n\n---\n\n### Review Summary\n✅ Approved — 0 inline comments posted\n\n### Code Quality Assessment\nImplementation mentions changes in prose but requests none.",
+    "created_at": "2026-06-02T08:18:35Z",
+    "updated_at": "2026-06-02T08:20:33Z"
+  }
+]

--- a/skills/github/tests/fixtures/codex_own_comment.json
+++ b/skills/github/tests/fixtures/codex_own_comment.json
@@ -1,0 +1,9 @@
+[
+  {
+    "id": 4001,
+    "user": {"login": "chatgpt-codex-connector[bot]"},
+    "body": "Codex review started.",
+    "created_at": "2026-06-02T08:18:35Z",
+    "updated_at": "2026-06-02T08:18:35Z"
+  }
+]

--- a/skills/github/tests/fixtures/mixed_bot_comments.json
+++ b/skills/github/tests/fixtures/mixed_bot_comments.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": 3001,
+    "user": {"login": "linear-code[bot]"},
+    "body": "<!-- linear-linkback -->\n<details>\n<summary>CC-496</summary>\n\n## Summary\nIssue linkback only.",
+    "created_at": "2026-06-02T08:18:14Z",
+    "updated_at": "2026-06-02T08:18:31Z"
+  },
+  {
+    "id": 3002,
+    "user": {"login": "claude[bot]"},
+    "body": "**Claude finished @vg-claude's task in 1m 44s** —— [View job](https://github.com/example/actions/runs/1)\n\n---\n### Review Summary\n✅ Approved — 0 inline comments posted",
+    "created_at": "2026-06-02T08:18:35Z",
+    "updated_at": "2026-06-02T08:20:33Z"
+  }
+]

--- a/skills/github/tests/fixtures/untrusted_body_reactions.json
+++ b/skills/github/tests/fixtures/untrusted_body_reactions.json
@@ -1,0 +1,6 @@
+[
+  {
+    "user": {"login": "linear-code[bot]"},
+    "content": "+1"
+  }
+]

--- a/skills/github/tests/fixtures/untrusted_status_comments.json
+++ b/skills/github/tests/fixtures/untrusted_status_comments.json
@@ -1,0 +1,9 @@
+[
+  {
+    "id": 5001,
+    "user": {"login": "linear-code[bot]"},
+    "body": "Status: Approved\n\nThis is an issue linkback bot, not a review bot.",
+    "created_at": "2026-06-02T08:18:35Z",
+    "updated_at": "2026-06-02T08:18:35Z"
+  }
+]

--- a/skills/github/tests/sticky-comment-cli.test.sh
+++ b/skills/github/tests/sticky-comment-cli.test.sh
@@ -7,6 +7,7 @@ TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FIXTURES="$TEST_DIR/fixtures"
 REPO_ROOT="$(cd "$TEST_DIR/../../.." && pwd)"
 STICKY="$REPO_ROOT/skills/github/scripts/commands/sticky-comment.sh"
+FIND_COMMENT="$REPO_ROOT/skills/github/scripts/commands/find-comment.sh"
 LIB="$REPO_ROOT/skills/github/scripts/lib/github-api.sh"
 
 PASS=0
@@ -45,22 +46,43 @@ assert_fails_with() {
 cat >"$TMPDIR/gh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
-if [[ "${1:-}" != "api" ]]; then
-  echo "unexpected gh command: $*" >&2
-  exit 1
-fi
-endpoint="${2:-}"
-case "$endpoint" in
-  repos/{owner}/{repo}/issues/123/comments)
-    cat "$STUB_FIXTURES/mixed_bot_comments.json"
+case "${1:-}" in
+  auth)
+    if [[ "${2:-}" == "status" ]]; then
+      echo "Logged in"
+      exit 0
+    fi
     ;;
-  repos/{owner}/{repo}/pulls/123/reviews)
-    printf '[]\n'
+  repo)
+    if [[ "${2:-}" == "view" ]]; then
+      echo '{"owner":{"login":"owner"},"name":"repo"}'
+      exit 0
+    fi
     ;;
-  *)
-    printf '[]\n'
+  api)
+    endpoint="${2:-}"
+    case "$endpoint" in
+      repos/{owner}/{repo}/issues/123/comments|repos/owner/repo/issues/123/comments)
+        cat "$STUB_FIXTURES/mixed_bot_comments.json"
+        exit 0
+        ;;
+      repos/owner/repo/issues/124/comments)
+        cat "$STUB_FIXTURES/codex_own_comment.json"
+        exit 0
+        ;;
+      repos/{owner}/{repo}/pulls/123/reviews)
+        printf '[]\n'
+        exit 0
+        ;;
+      *)
+        printf '[]\n'
+        exit 0
+        ;;
+    esac
     ;;
 esac
+printf 'unexpected gh call: %s\n' "$*" >&2
+exit 1
 EOF
 chmod +x "$TMPDIR/gh"
 
@@ -76,6 +98,14 @@ assert_fails_with \
     "explicit --bot disables known-bot fallback" \
     "No sticky comment found" \
     "$STICKY" 123 --verdict --bot 'review-bot[bot]'
+
+echo
+echo "=== find-comment.sh review-summary ==="
+out=$("$FIND_COMMENT" 124 --author 'chatgpt-codex-connector[bot]' --review-summary)
+assert_eq "$(jq -r .id <<<"$out")" "4001" "find-comment review-summary returns Codex earliest comment"
+assert_eq "$(jq -r .author <<<"$out")" "chatgpt-codex-connector[bot]" "find-comment review-summary preserves Codex author"
+out=$("$FIND_COMMENT" 124 --author 'missing-reviewer[bot]' --review-summary)
+assert_eq "$out" "{}" "find-comment review-summary no-match returns empty object"
 
 echo
 echo "=== detect_bot_reviewers own-comment reactions ==="
@@ -105,6 +135,30 @@ gh_rest() {
 
 detected=$(detect_bot_reviewers 42 | paste -sd, -)
 assert_eq "$detected" "chatgpt-codex-connector[bot]" "detect includes Codex own-comment reaction reviewer"
+
+gh_rest() {
+    case "$1" in
+        repos/{owner}/{repo}/pulls/42/reviews)
+            printf '[]\n'
+            ;;
+        repos/{owner}/{repo}/issues/42/comments)
+            cat "$FIXTURES/codex_own_comment.json"
+            ;;
+        repos/{owner}/{repo}/issues/42/reactions)
+            printf '[]\n'
+            ;;
+        repos/{owner}/{repo}/issues/comments/4001/reactions)
+            printf '[{"user":{"login":"linear-code[bot]"},"content":"+1"}]\n'
+            ;;
+        *)
+            echo "unexpected endpoint: $1" >&2
+            return 1
+            ;;
+    esac
+}
+
+detected=$(detect_bot_reviewers 42 | paste -sd, -)
+assert_eq "$detected" "" "detect ignores unrelated bot reaction on review-bot comment"
 
 gh_rest() {
     case "$1" in

--- a/skills/github/tests/sticky-comment-cli.test.sh
+++ b/skills/github/tests/sticky-comment-cli.test.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# User-facing tests for sticky-comment.sh fallback behavior and live
+# detect_bot_reviewers own-comment reaction scanning.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FIXTURES="$TEST_DIR/fixtures"
+REPO_ROOT="$(cd "$TEST_DIR/../../.." && pwd)"
+STICKY="$REPO_ROOT/skills/github/scripts/commands/sticky-comment.sh"
+LIB="$REPO_ROOT/skills/github/scripts/lib/github-api.sh"
+
+PASS=0
+FAIL=0
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+assert_eq() {
+    local got="$1" want="$2" name="$3"
+    if [[ "$got" == "$want" ]]; then
+        PASS=$((PASS + 1))
+        printf '  ok    %s\n' "$name"
+    else
+        FAIL=$((FAIL + 1))
+        printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$name" "$want" "$got"
+    fi
+}
+
+assert_fails_with() {
+    local name="$1" needle="$2"
+    shift 2
+    local out status
+    set +e
+    out=$("$@" 2>&1)
+    status=$?
+    set -e
+    if [[ $status -ne 0 && "$out" == *"$needle"* ]]; then
+        PASS=$((PASS + 1))
+        printf '  ok    %s\n' "$name"
+    else
+        FAIL=$((FAIL + 1))
+        printf '  FAIL  %s\n        expected failure containing: %s\n        status: %s\n        output: %s\n' "$name" "$needle" "$status" "$out"
+    fi
+}
+
+cat >"$TMPDIR/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" != "api" ]]; then
+  echo "unexpected gh command: $*" >&2
+  exit 1
+fi
+endpoint="${2:-}"
+case "$endpoint" in
+  repos/{owner}/{repo}/issues/123/comments)
+    cat "$STUB_FIXTURES/mixed_bot_comments.json"
+    ;;
+  repos/{owner}/{repo}/pulls/123/reviews)
+    printf '[]\n'
+    ;;
+  *)
+    printf '[]\n'
+    ;;
+esac
+EOF
+chmod +x "$TMPDIR/gh"
+
+export PATH="$TMPDIR:$PATH"
+export STUB_FIXTURES="$FIXTURES"
+unset GH_BOT_USERNAME || true
+
+echo "=== sticky-comment.sh CLI fallback ==="
+out=$("$STICKY" 123 --verdict)
+assert_eq "$out" "approved" "default fallback selects known claude[bot] review summary"
+
+assert_fails_with \
+    "explicit --bot disables known-bot fallback" \
+    "No sticky comment found" \
+    "$STICKY" 123 --verdict --bot 'review-bot[bot]'
+
+echo
+echo "=== detect_bot_reviewers own-comment reactions ==="
+# shellcheck source=/dev/null
+source "$LIB"
+
+gh_rest() {
+    case "$1" in
+        repos/{owner}/{repo}/pulls/42/reviews)
+            printf '[]\n'
+            ;;
+        repos/{owner}/{repo}/issues/42/comments)
+            cat "$FIXTURES/codex_own_comment.json"
+            ;;
+        repos/{owner}/{repo}/issues/42/reactions)
+            printf '[]\n'
+            ;;
+        repos/{owner}/{repo}/issues/comments/4001/reactions)
+            cat "$FIXTURES/codex_eyes_body_reactions.json"
+            ;;
+        *)
+            echo "unexpected endpoint: $1" >&2
+            return 1
+            ;;
+    esac
+}
+
+detected=$(detect_bot_reviewers 42 | paste -sd, -)
+assert_eq "$detected" "chatgpt-codex-connector[bot]" "detect includes Codex own-comment reaction reviewer"
+
+gh_rest() {
+    case "$1" in
+        repos/{owner}/{repo}/pulls/42/reviews)
+            printf '[]\n'
+            ;;
+        repos/{owner}/{repo}/issues/42/comments)
+            cat "$FIXTURES/codex_own_comment.json"
+            ;;
+        repos/{owner}/{repo}/issues/42/reactions)
+            printf '[]\n'
+            ;;
+        repos/{owner}/{repo}/issues/comments/4001/reactions)
+            echo '{"error":"reaction fetch failed"}' >&2
+            return 1
+            ;;
+        *)
+            echo "unexpected endpoint: $1" >&2
+            return 1
+            ;;
+    esac
+}
+
+if detect_bot_reviewers 42 >/dev/null 2>"$TMPDIR/detect.err"; then
+    FAIL=$((FAIL + 1))
+    echo "  FAIL  detect propagates own-comment reaction fetch failures"
+else
+    PASS=$((PASS + 1))
+    echo "  ok    detect propagates own-comment reaction fetch failures"
+fi
+
+echo
+echo "----"
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/skills/linear-orch/tests/bot_review_wait.sh
+++ b/skills/linear-orch/tests/bot_review_wait.sh
@@ -86,7 +86,25 @@ case "${1:-}" in
         echo '[{"user":{"login":"review-bot[bot]"},"state":"APPROVED","submitted_at":"2026-01-01T00:00:00Z"}]'
         exit 0
         ;;
-      repos/*/issues/1/comments|repos/*/issues/1/reactions|repos/*/issues/comments/*/reactions)
+      repos/*/pulls/2/reviews)
+        echo '[]'
+        exit 0
+        ;;
+      repos/*/issues/2/comments)
+        cat <<'JSON'
+[
+  {
+    "id": 2001,
+    "user": {"login": "claude[bot]"},
+    "body": "**Claude finished @vg-claude's task in 1m 44s** —— [View job](https://github.com/example/actions/runs/1)\n\n---\n### Review Summary\n✅ Approved — 0 inline comments posted",
+    "created_at": "2026-06-02T08:18:35Z",
+    "updated_at": "2026-06-02T08:20:33Z"
+  }
+]
+JSON
+        exit 0
+        ;;
+      repos/*/issues/1/comments|repos/*/issues/1/reactions|repos/*/issues/2/reactions|repos/*/issues/comments/*/reactions)
         echo '[]'
         exit 0
         ;;
@@ -113,6 +131,14 @@ output=$(run_wait 1 1 5 --json --reviewers 'review-bot[bot]' 2>"$stderr")
 assert_eq "$(jq -r .status <<<"$output")" "complete" "bad GH_TOKEN falls back to gh keyring auth"
 assert_eq "$(jq -r .verdict <<<"$output")" "approved" "approved formal review returns terminal JSON"
 assert_contains "$(cat "$stderr")" "unsetting them" "fallback warning explains masked gh auth"
+
+cat > "$TMP_ROOT/repo/.env.local" <<EOF
+GIT_HOST_CLI="$FAKE_GITHUB_SH"
+EOF
+output=$(run_wait 2 1 5 --json)
+assert_eq "$(jq -r .status <<<"$output")" "complete" "Claude comment-only auto-detect completes without reviewers arg"
+assert_eq "$(jq -r .verdict <<<"$output")" "approved" "Claude comment-only auto-detect returns approved verdict"
+assert_eq "$(jq -r '.approved_reviewers | join(",")' <<<"$output")" "claude[bot]" "Claude comment-only auto-detect records reviewer"
 
 cat > "$TMP_ROOT/repo/.env.local" <<EOF
 GIT_HOST_CLI="$FAKE_GITHUB_SH"

--- a/skills/linear-orch/workflows/review-pr-comments.md
+++ b/skills/linear-orch/workflows/review-pr-comments.md
@@ -49,9 +49,9 @@ BOT_VERDICT=$(echo "$WAIT_RESULT" | jq -r '.verdict')
 PENDING_REVIEWERS=$(echo "$WAIT_RESULT" | jq -r '.pending_reviewers | join(", ")')
 ```
 
-`$BOT_REVIEWERS` is a comma-separated list of bot usernames to wait for (e.g., `review-bot-a[bot],chatgpt-codex-connector[bot]`). Default: wait for any bot with any signal (sticky, formal review, or reaction on the PR body).
+`$BOT_REVIEWERS` is a comma-separated list of bot usernames to wait for (e.g., `review-bot-a[bot],chatgpt-codex-connector[bot]`). Default: auto-detect review bots from formal reviews, known review-bot comment summaries (`View job` / `**Claude finished ...**` with `### Review Summary`), PR-body reactions, and known review-bot own-comment reactions. Custom comment-only review bots must be configured explicitly with `BOT_REVIEWERS` / `--reviewers`.
 
-**Polling behavior**: per reviewer, status is one of `pending|approved|changes|skipped|unknown`. The wrapper only returns `status=complete` when no reviewer is pending. If `status=timeout` and `pending_reviewers` is non-empty, ask the user `Wait` | `Skip pending bot` (configure via `BOT_SKIPPED_REVIEWERS`) | `Proceed without`. Late arrivals are still caught in § 6.3.
+**Polling behavior**: per reviewer, status is one of `pending|approved|changes|skipped|unknown`. Claude-style comments parse `✅ Approved` / `Changes requested`; Codex-style signals use 👀 = pending, 👍 = approved, and inline review threads = changes. The wrapper only returns `status=complete` when no reviewer is pending. If `status=timeout` and `pending_reviewers` is non-empty, ask the user `Wait` | `Skip pending bot` (configure via `BOT_SKIPPED_REVIEWERS`) | `Proceed without`. Late arrivals are still caught in § 6.3.
 
 ### 1.2 Fetch Actionable Data
 

--- a/skills/linear-orch/workflows/submit-pr.md
+++ b/skills/linear-orch/workflows/submit-pr.md
@@ -166,17 +166,15 @@ done
 
 **Extended poll** (timeout + pending only):
 ```bash
-# Poll sticky verdict every 30s for up to 300s more
-EXT_ELAPSED=0
-while [ $EXT_ELAPSED -lt 300 ]; do
-  BOT_VERDICT=$(.agents/skills/github/scripts/github.sh sticky-comment [PR_NUMBER] --verdict 2>/dev/null || echo "pending")
-  if [[ "$BOT_VERDICT" == "approved" || "$BOT_VERDICT" == "changes" ]]; then
-    break
-  fi
-  sleep 30
-  EXT_ELAPSED=$((EXT_ELAPSED + 30))
-done
-# Proceed to § 3 regardless (with note if still pending)
+# Re-run multi-reviewer wait every 30s for up to 300s more.
+BOT_WAIT_ARGS=([PR_NUMBER] 30 300 --json)
+[[ -n "${BOT_REVIEWERS:-}" ]] && BOT_WAIT_ARGS+=(--reviewers "$BOT_REVIEWERS")
+[[ -n "${BOT_SKIPPED_REVIEWERS:-}" ]] && BOT_WAIT_ARGS+=(--skip "$BOT_SKIPPED_REVIEWERS")
+WAIT_RESULT=$(.agents/skills/linear-orch/scripts/bot-review-wait "${BOT_WAIT_ARGS[@]}")
+BOT_STATUS=$(echo "$WAIT_RESULT"  | jq -r '.status')
+BOT_VERDICT=$(echo "$WAIT_RESULT" | jq -r '.verdict')
+PENDING_REVIEWERS=$(echo "$WAIT_RESULT" | jq -r '.pending_reviewers | join(", ")')
+# Proceed to § 3 if complete/terminal; otherwise ask with pending reviewers.
 ```
 
 ---
@@ -185,20 +183,16 @@ done
 
 ### 3.1 Initial Triage
 
-1. **Bot completion pre-check** — ensure sticky verdict is terminal before triaging:
+1. **Bot completion pre-check** — ensure all configured/detected bot reviewers have terminal status before triaging:
    ```bash
-   VERDICT=$(.agents/skills/github/scripts/github.sh sticky-comment [PR_NUMBER] --verdict 2>/dev/null || echo "pending")
-   if [[ "$VERDICT" == "pending" ]]; then
-     # Poll every 30s for up to 180s
-     PRE_ELAPSED=0
-     while [ $PRE_ELAPSED -lt 180 ]; do
-       sleep 30
-       PRE_ELAPSED=$((PRE_ELAPSED + 30))
-       VERDICT=$(.agents/skills/github/scripts/github.sh sticky-comment [PR_NUMBER] --verdict 2>/dev/null || echo "pending")
-       if [[ "$VERDICT" != "pending" ]]; then break; fi
-     done
-   fi
-   # Proceed regardless — terminal or timed out
+   BOT_WAIT_ARGS=([PR_NUMBER] 30 180 --json)
+   [[ -n "${BOT_REVIEWERS:-}" ]] && BOT_WAIT_ARGS+=(--reviewers "$BOT_REVIEWERS")
+   [[ -n "${BOT_SKIPPED_REVIEWERS:-}" ]] && BOT_WAIT_ARGS+=(--skip "$BOT_SKIPPED_REVIEWERS")
+   WAIT_RESULT=$(.agents/skills/linear-orch/scripts/bot-review-wait "${BOT_WAIT_ARGS[@]}")
+   BOT_STATUS=$(echo "$WAIT_RESULT"  | jq -r '.status')
+   BOT_VERDICT=$(echo "$WAIT_RESULT" | jq -r '.verdict')
+   PENDING_REVIEWERS=$(echo "$WAIT_RESULT" | jq -r '.pending_reviewers | join(", ")')
+   # Proceed if complete/terminal; if still pending, include PENDING_REVIEWERS in triage notes.
    ```
 
 2. **Run Workflow**: `⤵ workflows/review-pr-comments.md [PR_NUMBER] § 1-8 → § 3.1` with context:

--- a/skills/linear-orch/workflows/submit-pr.md
+++ b/skills/linear-orch/workflows/submit-pr.md
@@ -131,7 +131,7 @@ Waits for all configured bot reviewers (`$BOT_REVIEWERS` — e.g., `review-bot-a
 - **Claude-style** — formal review (APPROVED/CHANGES_REQUESTED) and/or sticky `View job` / `**Claude finished ...**` comment with `### Review Summary` verdict text (`✅ Approved`, `Changes requested`).
 - **Codex-style** — reactions on the PR body / earliest comment (👀 = pending, 👍 = approved) and inline review threads (= changes).
 
-Auto-detection only treats review-signal bot comments as reviewers; unrelated automation comments (for example issue linkbacks) do not block completion.
+Auto-detection only treats review-signal comments from known review bots as reviewers; unrelated automation comments (for example issue linkbacks) do not block completion. Configure custom comment-only review bots with `BOT_REVIEWERS` / `--reviewers`.
 
 `status=complete` is only emitted when **no reviewer is pending** (verdict will be `approved` or `changes`). If you need a reviewer to be ignored, pass `--skip "bot-login"` or set `BOT_SKIPPED_REVIEWERS`.
 

--- a/skills/linear-orch/workflows/submit-pr.md
+++ b/skills/linear-orch/workflows/submit-pr.md
@@ -128,8 +128,10 @@ PENDING_REVIEWERS=$(echo "$WAIT_RESULT" | jq -r '.pending_reviewers | join(", ")
 Waits for all configured bot reviewers (`$BOT_REVIEWERS` — e.g., `review-bot-a[bot],chatgpt-codex-connector[bot]`). Auto-detects if not configured. Max wait 600s.
 
 `bot-review-wait` understands per-reviewer signaling:
-- **Claude-style** — formal review (APPROVED/CHANGES_REQUESTED) and/or sticky "View job" comment.
+- **Claude-style** — formal review (APPROVED/CHANGES_REQUESTED) and/or sticky `View job` / `**Claude finished ...**` comment with `### Review Summary` verdict text (`✅ Approved`, `Changes requested`).
 - **Codex-style** — reactions on the PR body / earliest comment (👀 = pending, 👍 = approved) and inline review threads (= changes).
+
+Auto-detection only treats review-signal bot comments as reviewers; unrelated automation comments (for example issue linkbacks) do not block completion.
 
 `status=complete` is only emitted when **no reviewer is pending** (verdict will be `approved` or `changes`). If you need a reviewer to be ignored, pass `--skip "bot-login"` or set `BOT_SKIPPED_REVIEWERS`.
 


### PR DESCRIPTION
## Summary
- detect Claude `**Claude finished ...**` review-summary comments as terminal bot review verdicts
- harden sticky verdict parsing against pending/negated approval text and untrusted bot reactions
- add regression coverage for sticky comment, bot-review-wait, and reviewer detection paths

## Tests
- `bash skills/github/tests/bot_review_status.sh`
- `bash skills/github/tests/sticky-comment-cli.test.sh`
- `bash skills/linear-orch/tests/bot_review_wait.sh`

Fixes #327