### PR TITLE
fix(pi-agents-tmux): treat Claude home agents as user scope

### DIFF
--- a/pi-extensions/pi-agents-tmux/extensions/subagent/agents.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/agents.ts
@@ -2,14 +2,16 @@
  * Agent discovery and configuration for the project-local Pi subagent extension.
  *
  * Supported locations:
- * - ~/.pi/agent/agents/*.md       user-level agents
- * - .pi/agents/*.md               project-level Pi agents
+ * - ~/.claude/agents/*.md         user-level Claude agents
+ * - ~/.pi/agent/agents/*.md       user-level Pi agents
  * - .claude/agents/*.md           project-level compatibility import
+ * - .pi/agents/*.md               project-level Pi agents
  *
- * When duplicate names exist, precedence is: user < .claude < .pi.
+ * When duplicate names exist, precedence is: Claude user < Pi user < project .claude < project .pi.
  */
 
 import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 import { getAgentDir, parseFrontmatter } from "@earendil-works/pi-coding-agent";
 import { effortFromModelId, normalizeReasoningEffort } from "./settings.js";
@@ -172,9 +174,20 @@ function isDirectory(p: string): boolean {
 	}
 }
 
+function homeAgentRoot(): string {
+	return path.resolve(process.env.HOME || os.homedir());
+}
+
+function userAgentDirs(): string[] {
+	return [path.join(homeAgentRoot(), ".claude", "agents"), path.join(getAgentDir(), "agents")];
+}
+
 function findNearestProjectAgentDirs(cwd: string): string[] {
-	let currentDir = cwd;
+	let currentDir = path.resolve(cwd);
+	const homeDir = homeAgentRoot();
 	while (true) {
+		if (currentDir === homeDir) return [];
+
 		const claudeDir = path.join(currentDir, ".claude", "agents");
 		const piDir = path.join(currentDir, ".pi", "agents");
 		const dirs = [claudeDir, piDir].filter(isDirectory);
@@ -187,10 +200,9 @@ function findNearestProjectAgentDirs(cwd: string): string[] {
 }
 
 export function discoverAgents(cwd: string, scope: AgentScope): AgentDiscoveryResult {
-	const userDir = path.join(getAgentDir(), "agents");
 	const projectAgentDirs = findNearestProjectAgentDirs(cwd);
 
-	const userAgents = scope === "project" ? [] : loadAgentsFromDir(userDir, "user");
+	const userAgents = scope === "project" ? [] : userAgentDirs().flatMap((dir) => loadAgentsFromDir(dir, "user"));
 	const projectAgents =
 		scope === "user" ? [] : projectAgentDirs.flatMap((dir) => loadAgentsFromDir(dir, "project"));
 

--- a/pi-extensions/pi-agents-tmux/instructions.md
+++ b/pi-extensions/pi-agents-tmux/instructions.md
@@ -10,7 +10,7 @@ Do not use for: trivial work the parent can do directly with read/grep/find; any
 
 Calling rules:
 - One self-contained `task` string per delegation — the subagent cannot ask follow-ups.
-- Default `agentScope` is `"project"`. Pass `"both"` only when user-level agents at `~/.pi/agent/agents` are explicitly needed.
+- Default `agentScope` is `"project"`. Pass `"both"` only when user-level agents at `~/.claude/agents` or `~/.pi/agent/agents` are explicitly needed.
 - Bg (`pane: false`) agents start in a fresh one-shot session when `sessionKey` is omitted. Pass a stable `sessionKey` only when you intentionally want to reuse memory across calls; reused lanes are preflight-guarded near context limit and default to refuse-and-warn.
 - Bg children and pane children both carry `PI_SUBAGENT_CHILD_AGENT` for identity/authorization; only visible pane children carry `PI_SUBAGENT_CHILD_PANE=1` and may update tmux pane title or poll pane inboxes.
 - Bg completions are captured from the child process's final assistant output. `complete_subagent` is reserved for persistent pane/follow-up tasks and is not exposed to bg children.

--- a/pi-extensions/pi-agents-tmux/tests/discovery-scope.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/discovery-scope.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { discoverAgents } from "../extensions/subagent/agents.js";
+
+function writeAgent(dir: string, name: string, description: string): void {
+	mkdirSync(dir, { recursive: true });
+	writeFileSync(join(dir, `${name}.md`), `---\nname: ${name}\ndescription: ${description}\n---\n\n${name} body\n`, "utf8");
+}
+
+function withTempDiscoveryEnv<T>(fn: (env: { home: string; piDir: string; cwd: string }) => T): T {
+	const root = mkdtempSync(join(tmpdir(), "pi-agents-discovery-"));
+	const home = join(root, "home");
+	const piDir = join(root, "pi-user");
+	const cwd = join(home, "workspace", "repo", "src");
+	mkdirSync(cwd, { recursive: true });
+
+	const previousHome = process.env.HOME;
+	const previousPiDir = process.env.PI_CODING_AGENT_DIR;
+	process.env.HOME = home;
+	process.env.PI_CODING_AGENT_DIR = piDir;
+	try {
+		return fn({ home, piDir, cwd });
+	} finally {
+		if (previousHome === undefined) delete process.env.HOME;
+		else process.env.HOME = previousHome;
+		if (previousPiDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousPiDir;
+		rmSync(root, { force: true, recursive: true });
+	}
+}
+
+describe("agent discovery scope", () => {
+	test("does not classify HOME .claude agents as project agents", () => {
+		withTempDiscoveryEnv(({ home, cwd }) => {
+			writeAgent(join(home, ".claude", "agents"), "claude-user", "Claude user agent");
+
+			const { agents, projectAgentsDir } = discoverAgents(cwd, "project");
+
+			expect(agents.map((agent) => agent.name)).not.toContain("claude-user");
+			expect(projectAgentsDir).toBeNull();
+		});
+	});
+
+	test("loads HOME .claude agents as user agents and keeps Pi user precedence", () => {
+		withTempDiscoveryEnv(({ home, piDir, cwd }) => {
+			writeAgent(join(home, ".claude", "agents"), "claude-only", "Claude user agent");
+			writeAgent(join(home, ".claude", "agents"), "shared", "Claude shared user agent");
+			writeAgent(join(piDir, "agents"), "shared", "Pi shared user agent");
+
+			const { agents } = discoverAgents(cwd, "user");
+			const byName = new Map(agents.map((agent) => [agent.name, agent]));
+
+			expect(byName.get("claude-only")?.source).toBe("user");
+			expect(byName.get("shared")?.source).toBe("user");
+			expect(byName.get("shared")?.description).toBe("Pi shared user agent");
+		});
+	});
+
+	test("preserves project-local .claude agents as project agents", () => {
+		withTempDiscoveryEnv(({ home, cwd }) => {
+			const repo = join(home, "workspace", "repo");
+			writeAgent(join(repo, ".claude", "agents"), "project-claude", "Project Claude agent");
+
+			const { agents, projectAgentsDir } = discoverAgents(cwd, "project");
+			const agent = agents.find((candidate) => candidate.name === "project-claude");
+
+			expect(agent?.source).toBe("project");
+			expect(projectAgentsDir).toBe(join(repo, ".claude", "agents"));
+		});
+	});
+});


### PR DESCRIPTION
Fixes #339

## Summary

- Treat `~/.claude/agents` as user-level agent inventory.
- Stop project-agent discovery before checking `$HOME`.
- Preserve project-local `.claude/agents` as project-level compatibility inventory.
- Add discovery-scope coverage for Claude user agents, Pi user precedence, and project-local Claude agents.

## Validation

- `cd pi-extensions/pi-agents-tmux && bun test ./tests/discovery-scope.test.ts`

Note: `node scripts/verify-vstack-migration.mjs` is unavailable on the upstream `vstack-upstream/main` branch in this checkout.
