### PR TITLE
Add Fable 5 to Claude bridge models

### DIFF
--- a/pi-extensions/pi-claude-bridge/README.md
+++ b/pi-extensions/pi-claude-bridge/README.md
@@ -9,7 +9,7 @@ Forked from [`elidickinson/pi-claude-bridge`](https://github.com/elidickinson/pi
 
 ## Highlights
 
-- `claude-bridge/claude-opus-4-8`, Opus 4-7, Sonnet, and Haiku in `/model`.
+- `claude-bridge/claude-fable-5`, Opus 4.8, Opus 4.7, Sonnet, and Haiku in `/model`.
 - Pi tool calls run on Pi; Claude Code handles reasoning.
 - Tool-use turns block until Pi-delivered tool results reach Claude Code, including persistent subagent panes.
 - Session continuity across normal turns, `/compact`, tree navigation, and abort recovery.
@@ -89,6 +89,10 @@ Pi does not have a native `max` thinking level; it exposes up to `xhigh`, and ea
 ```
 
 Keys may be bare model IDs (`claude-opus-4-8`), `claude-bridge/<id>`, or `*` for all bridge models. Values are `low`, `medium`, `high`, `xhigh`, or `max`.
+
+### Fable 5 caveat
+
+The bridge registers `claude-bridge/claude-fable-5` and `claude-bridge/claude-opus-4-8` even when Pi's Anthropic model registry has not shipped those entries yet. Claude can route Fable 5 prompts flagged by its cyber/bio safety classifiers to Opus 4.8 in Claude Code or API surfaces. This bridge does not add its own fallback layer, so flagged Fable 5 requests may be less reliable in Pi if the underlying Claude Code SDK does not handle the reroute transparently for that turn.
 
 ## Extra usage and rate limits
 

--- a/pi-extensions/pi-claude-bridge/bundle/index.js
+++ b/pi-extensions/pi-claude-bridge/bundle/index.js
@@ -22237,9 +22237,36 @@ function convertPiMessages(messages, customToolNameToSdk) {
 }
 
 // src/models.ts
-var MODEL_IDS_IN_ORDER = ["claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5"];
+var MODEL_IDS_IN_ORDER = [
+  "claude-fable-5",
+  "claude-opus-4-8",
+  "claude-opus-4-7",
+  "claude-opus-4-6",
+  "claude-sonnet-4-6",
+  "claude-haiku-4-5"
+];
+var FALLBACK_MODELS = {
+  "claude-fable-5": {
+    id: "claude-fable-5",
+    name: "Claude Fable 5",
+    reasoning: true,
+    thinkingLevelMap: { xhigh: "xhigh" },
+    input: ["text", "image"],
+    contextWindow: 1e6,
+    maxTokens: 128e3
+  },
+  "claude-opus-4-8": {
+    id: "claude-opus-4-8",
+    name: "Claude Opus 4.8",
+    reasoning: true,
+    thinkingLevelMap: { xhigh: "xhigh" },
+    input: ["text", "image"],
+    contextWindow: 1e6,
+    maxTokens: 128e3
+  }
+};
 function buildModels(piAiModels) {
-  return MODEL_IDS_IN_ORDER.map((id) => piAiModels.find((m4) => m4.id === id)).filter((m4) => m4 != null).map(({ id, name, reasoning, input, contextWindow, maxTokens, thinkingLevelMap }) => ({
+  return MODEL_IDS_IN_ORDER.map((id) => piAiModels.find((m4) => m4.id === id) ?? FALLBACK_MODELS[id]).filter((m4) => m4 != null).map(({ id, name, reasoning, input, contextWindow, maxTokens, thinkingLevelMap }) => ({
     id,
     name,
     reasoning,

--- a/pi-extensions/pi-claude-bridge/src/models.ts
+++ b/pi-extensions/pi-claude-bridge/src/models.ts
@@ -2,13 +2,52 @@
 // `resolveModelId` returns the first partial match, so `opus` resolves to the first-listed opus entry.
 // Extracted from index.ts so tests can import without activating the extension.
 
-export const MODEL_IDS_IN_ORDER = ["claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5"];
+export const MODEL_IDS_IN_ORDER = [
+	"claude-fable-5",
+	"claude-opus-4-8",
+	"claude-opus-4-7",
+	"claude-opus-4-6",
+	"claude-sonnet-4-6",
+	"claude-haiku-4-5",
+];
+
+type BridgeModelMetadata = {
+	id: string;
+	name: string;
+	reasoning: boolean;
+	thinkingLevelMap?: Record<string, string | null>;
+	input: ("text" | "image")[];
+	contextWindow: number;
+	maxTokens: number;
+};
+
+const FALLBACK_MODELS: Record<string, BridgeModelMetadata> = {
+	"claude-fable-5": {
+		id: "claude-fable-5",
+		name: "Claude Fable 5",
+		reasoning: true,
+		thinkingLevelMap: { xhigh: "xhigh" },
+		input: ["text", "image"],
+		contextWindow: 1000000,
+		maxTokens: 128000,
+	},
+	"claude-opus-4-8": {
+		id: "claude-opus-4-8",
+		name: "Claude Opus 4.8",
+		reasoning: true,
+		thinkingLevelMap: { xhigh: "xhigh" },
+		input: ["text", "image"],
+		contextWindow: 1000000,
+		maxTokens: 128000,
+	},
+};
 
 // Project pi-ai's model entries down to the fields pi's registerProvider expects,
-// and keep MODEL_IDS_IN_ORDER ordering. IDs missing from pi-ai are silently dropped.
+// keep MODEL_IDS_IN_ORDER ordering, and fill bridge-owned future IDs when pi-ai
+// has not shipped metadata for them yet. Unknown missing IDs are still dropped.
 export function buildModels<T extends { id: string; [key: string]: any }>(piAiModels: T[]) {
 	return MODEL_IDS_IN_ORDER
-		.map((id) => piAiModels.find((m) => m.id === id))
+		.map((id) => piAiModels.find((m) => m.id === id) ?? FALLBACK_MODELS[id])
 		.filter((m) => m != null)
 		// Forward thinkingLevelMap so per-model overrides (e.g. opus-4-7 mapping
 		// xhigh→xhigh instead of xhigh→max) are visible to the effort lookup.

--- a/pi-extensions/pi-claude-bridge/tests/unit-models.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-models.mjs
@@ -34,10 +34,32 @@ describe("MODELS projection", () => {
 		assert.deepEqual(models.map((m) => m.id), MODEL_IDS_IN_ORDER);
 	});
 
-	it("silently drops IDs missing from pi-ai (no fallback)", () => {
-		// Only haiku present — opus/sonnet vanish from picker.
+	it("lists Fable 5 before Opus models", () => {
+		const models = buildModels(MODEL_IDS_IN_ORDER.map(mockPiAiModel));
+		assert.equal(models[0]?.id, "claude-fable-5");
+	});
+
+	it("fills bridge-owned future IDs missing from pi-ai and drops unknown missing IDs", () => {
 		const models = buildModels([mockPiAiModel("claude-haiku-4-5")]);
-		assert.deepEqual(models.map((m) => m.id), ["claude-haiku-4-5"]);
+		assert.deepEqual(models.map((m) => m.id), ["claude-fable-5", "claude-opus-4-8", "claude-haiku-4-5"]);
+		assert.equal(models.find((m) => m.id === "claude-fable-5")?.name, "Claude Fable 5");
+		assert.equal(models.find((m) => m.id === "claude-fable-5")?.contextWindow, 1000000);
+		assert.equal(models.find((m) => m.id === "claude-opus-4-8")?.maxTokens, 128000);
+	});
+
+	it("prefers pi-ai metadata over bridge fallback metadata", () => {
+		const models = buildModels([{
+			...mockPiAiModel("claude-fable-5"),
+			name: "Registry Fable",
+			contextWindow: 123,
+			maxTokens: 456,
+			thinkingLevelMap: { xhigh: "max" },
+		}]);
+		const fable = models.find((m) => m.id === "claude-fable-5");
+		assert.equal(fable?.name, "Registry Fable");
+		assert.equal(fable?.contextWindow, 123);
+		assert.equal(fable?.maxTokens, 456);
+		assert.deepEqual(fable?.thinkingLevelMap, { xhigh: "max" });
 	});
 
 	it("zeros out cost regardless of pi-ai pricing", () => {
@@ -58,6 +80,10 @@ describe("resolveModelId", () => {
 
 	it("opus shortcut resolves to claude-opus-4-8 (first opus in order)", () => {
 		assert.equal(resolveModelId(models, "opus"), "claude-opus-4-8");
+	});
+
+	it("fable shortcut resolves to claude-fable-5", () => {
+		assert.equal(resolveModelId(models, "fable"), "claude-fable-5");
 	});
 
 	it("haiku shortcut resolves to claude-haiku-4-5", () => {

--- a/pi-extensions/pi-claude-bridge/tests/usage-test.sh
+++ b/pi-extensions/pi-claude-bridge/tests/usage-test.sh
@@ -8,7 +8,8 @@
 # Rate limit: the usage endpoint is aggressively limited — don't run repeatedly.
 #
 # Usage: tests/usage-test.sh [model] [turns]
-#   model: claude-haiku-4-5 (default), claude-sonnet-4-6, claude-opus-4-6
+#   model: claude-haiku-4-5 (default), claude-fable-5, claude-opus-4-8,
+#          claude-opus-4-7, claude-opus-4-6, claude-sonnet-4-6
 #   turns: number of conversation turns (default: 10)
 
 source "$(dirname "$0")/lib/bash-setup.sh"
@@ -38,7 +39,10 @@ get_usage() {
 # --- Map model to Claude Code model ID ---
 # Claude Code uses different model IDs than the bridge.
 case "$MODEL" in
+  claude-fable-5)     CC_MODEL="claude-fable-5" ;;
   claude-haiku-4-5)   CC_MODEL="claude-haiku-4-5" ;;
+  claude-opus-4-8)    CC_MODEL="claude-opus-4-8" ;;
+  claude-opus-4-7)    CC_MODEL="claude-opus-4-7" ;;
   claude-sonnet-4-6)  CC_MODEL="claude-sonnet-4-6" ;;
   claude-opus-4-6)    CC_MODEL="claude-opus-4-6" ;;
   *)                  CC_MODEL="$MODEL" ;;


### PR DESCRIPTION
## Summary

- Adds `claude-fable-5` to the pi-claude-bridge model picker ahead of Opus models.
- Adds fallback metadata for `claude-fable-5` and `claude-opus-4-8` so the bridge exposes them even when Pi's Anthropic registry lags.
- Documents the Fable 5 safety-reroute caveat and updates model tests/usage diagnostics.

Closes #346.

## Caveat

Anthropic documents that Fable 5 can route prompts flagged by its cyber/bio safeguards to Opus 4.8, and that routed requests are not billed at Fable pricing. The bridge now exposes Fable 5, but it does not add an independent fallback layer; if the underlying Claude Code SDK does not transparently reroute a Pi turn, flagged Fable 5 requests may behave less reliably in Pi than in direct Claude Code.

References:
- https://www.anthropic.com/claude/fable
- https://platform.claude.com/docs/en/build-with-claude/context-windows
- https://platform.claude.com/docs/en/about-claude/models/overview

## Validation

- `npm run build`
- `npm run typecheck`
- `npm run test:unit`
- `node --import tsx --input-type=module -e 'import { getModels } from "@earendil-works/pi-ai"; import { buildModels } from "./src/models.ts"; console.log(buildModels(getModels("anthropic")).map(m=>m.id).join("\n"))'`
- `git diff --check`
