### PR TITLE
Make pi-web-tools op secrets fail fast

### DIFF
--- a/pi-extensions/pi-web-tools/README.md
+++ b/pi-extensions/pi-web-tools/README.md
@@ -77,7 +77,7 @@ Set via environment variables, project `.env.local`/`.env`, or a private config 
 - `JINA_API_KEY` (optional; anonymous Jina Reader works without it)
 - `PI_WEB_TOOLS_CONFIG_FILE=/path/to/private.json`
 
-Values may be 1Password references such as `op://Private/Exa API Key/credential` when the `op` CLI is installed and signed in.
+Values may be 1Password references such as `op://Private/Exa API Key/credential` when the `op` CLI is installed and signed in. References resolve best-effort with a short startup timeout (default 1500 ms, override with `PI_WEB_TOOLS_OP_READ_TIMEOUT_MS`); unresolved references are treated as unset so Pi startup does not block.
 
 ## Deep research modes
 

--- a/pi-extensions/pi-web-tools/src/settings.ts
+++ b/pi-extensions/pi-web-tools/src/settings.ts
@@ -1,10 +1,12 @@
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { execFileSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import { dirname, isAbsolute, join, resolve } from "node:path";
 
 export const PACKAGE_ID = "@vanillagreen/pi-web-tools";
 export const WEB_PROVIDERS = ["auto", "exa", "perplexity", "gemini", "exa-mcp", "duckduckgo", "openai-native"] as const;
+const DEFAULT_OP_READ_TIMEOUT_MS = 1500;
+const OP_READ_TIMEOUT_ENV = "PI_WEB_TOOLS_OP_READ_TIMEOUT_MS";
 export type WebProvider = (typeof WEB_PROVIDERS)[number];
 export type ResolvedWebProvider = Exclude<WebProvider, "auto">;
 
@@ -224,14 +226,44 @@ function secretFrom(raw: SettingsRecord, keys: string[]): string | undefined {
 	return undefined;
 }
 
+function opReadTimeoutMs(): number {
+	const raw = process.env[OP_READ_TIMEOUT_ENV];
+	const parsed = raw && raw.trim() ? Number(raw) : NaN;
+	return Number.isFinite(parsed) && parsed > 0 ? Math.min(Math.max(Math.trunc(parsed), 100), 10000) : DEFAULT_OP_READ_TIMEOUT_MS;
+}
+
+function addSecretWarning(warnings: string[], name: string, reason: string): void {
+	warnings.push(`${name} is a 1Password reference but could not be resolved ${reason}; treating it as unset.`);
+}
+
 function resolveSecretRef(value: string | undefined, name: string, warnings: string[]): string | undefined {
 	if (!value || !value.startsWith("op://")) return value;
-	try {
-		return execFileSync("op", ["read", value], { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim();
-	} catch {
-		warnings.push(`${name} is a 1Password reference but could not be resolved. Install/sign in to the op CLI and run: op read '${value}'`);
-		return value;
+	const timeout = opReadTimeoutMs();
+	const result = spawnSync("op", ["read", value], {
+		encoding: "utf8",
+		stdio: ["ignore", "pipe", "ignore"],
+		timeout,
+		killSignal: "SIGTERM",
+	});
+	const errorCode = result.error && "code" in result.error ? String(result.error.code) : undefined;
+	if (errorCode === "ETIMEDOUT") {
+		addSecretWarning(warnings, name, `within ${timeout}ms`);
+		return undefined;
 	}
+	if (result.error) {
+		addSecretWarning(warnings, name, "because the op CLI is unavailable or failed to start");
+		return undefined;
+	}
+	if (result.status !== 0 || result.signal) {
+		addSecretWarning(warnings, name, "because op read exited unsuccessfully");
+		return undefined;
+	}
+	const resolved = result.stdout.trim();
+	if (!resolved) {
+		addSecretWarning(warnings, name, "because op read returned an empty value");
+		return undefined;
+	}
+	return resolved;
 }
 
 export function loadSettings(cwd = process.cwd()): WebToolsSettings {

--- a/pi-extensions/pi-web-tools/tests/settings.test.ts
+++ b/pi-extensions/pi-web-tools/tests/settings.test.ts
@@ -115,6 +115,40 @@ test("loadSettings reads project .env.local without overriding process env", () 
 	}
 });
 
+test("loadSettings treats slow op:// API key references as unset", () => {
+	const root = tempDir();
+	const user = join(root, "agent");
+	const project = join(root, "project");
+	const bin = join(root, "bin");
+	mkdirSync(user, { recursive: true });
+	mkdirSync(join(project, ".pi"), { recursive: true });
+	mkdirSync(bin, { recursive: true });
+	writeFileSync(join(bin, "op"), "#!/usr/bin/env bash\n[ \"$1\" = read ] && { sleep 5; printf late-secret; exit 0; }\nexit 1\n");
+	chmodSync(join(bin, "op"), 0o755);
+	writeFileSync(join(user, "settings.json"), JSON.stringify({ vstack: { extensionManager: { config: { "@vanillagreen/pi-web-tools": { exaApiKey: "op://vault/exa/key" } } } } }));
+	const previousDir = process.env.PI_CODING_AGENT_DIR;
+	const previousPath = process.env.PATH;
+	const previousExa = process.env.EXA_API_KEY;
+	const previousTimeout = process.env.PI_WEB_TOOLS_OP_READ_TIMEOUT_MS;
+	process.env.PI_CODING_AGENT_DIR = user;
+	process.env.PATH = `${bin}:${previousPath}`;
+	process.env.PI_WEB_TOOLS_OP_READ_TIMEOUT_MS = "100";
+	delete process.env.EXA_API_KEY;
+	try {
+		const started = Date.now();
+		const settings = loadSettings(project);
+		assert.equal(settings.apiKeys.exa, undefined);
+		assert.ok(Date.now() - started < 1500);
+		assert.match(settings.warnings.join("\n"), /EXA_API_KEY.*within 100ms.*unset/);
+		assert.doesNotMatch(settings.warnings.join("\n"), /op:\/\//);
+	} finally {
+		if (previousDir === undefined) delete process.env.PI_CODING_AGENT_DIR; else process.env.PI_CODING_AGENT_DIR = previousDir;
+		process.env.PATH = previousPath;
+		if (previousExa === undefined) delete process.env.EXA_API_KEY; else process.env.EXA_API_KEY = previousExa;
+		if (previousTimeout === undefined) delete process.env.PI_WEB_TOOLS_OP_READ_TIMEOUT_MS; else process.env.PI_WEB_TOOLS_OP_READ_TIMEOUT_MS = previousTimeout;
+	}
+});
+
 test("loadSettings resolves op:// API key references with op CLI", () => {
 	const root = tempDir();
 	const user = join(root, "agent");


### PR DESCRIPTION
## Summary

- add a bounded timeout for `op read` when pi-web-tools resolves `op://` API key refs
- treat unresolved 1Password refs as unset with sanitized warnings instead of passing the ref downstream
- document the timeout behavior and add regression coverage for a hung `op` CLI

Fixes #348.

## Validation

- `cd pi-extensions/pi-web-tools && npm install --package-lock=false --legacy-peer-deps --no-audit --no-fund && npm run check`
- `PI_OFFLINE=1 PI_TIMING=1 timeout 5s pi --no-session --no-extensions --extension ./pi-extensions/pi-web-tools/src/index.ts --list-models`
