### PR TITLE
fix(#353): make workflow shell snippets codex-safe

### DIFF
--- a/skills/dev/workflows/dev-implement.md
+++ b/skills/dev/workflows/dev-implement.md
@@ -32,9 +32,8 @@ Respect blocking order: complete blockers before blocked issues.
 - Read/Write/Edit/Grep/Glob: `[WORKTREE_PATH]/...`
 
 ```bash
-BASE_BRANCH=${WORKTREE_DEFAULT_BRANCH:-$(git -C [WORKTREE_PATH] symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')}
-[ -n "$BASE_BRANCH" ] || BASE_BRANCH=main
-git -C [WORKTREE_PATH] fetch origin "$BASE_BRANCH"
+.agents/skills/orch/scripts/resolve-base-branch [WORKTREE_PATH]
+git -C [WORKTREE_PATH] fetch origin [BASE_BRANCH_FROM_PREVIOUS_COMMAND]
 ```
 
 ---
@@ -323,21 +322,23 @@ Development-only feature exception: do not apply `needs-perf-test` for work isol
 
 **Target issue**: Linear posts to the issue you just implemented. GitHub/ad-hoc returns the same content to the orchestrator instead of posting a tracker comment.
 
-```bash
-.agents/skills/linear/scripts/linear.sh comments create [ISSUE_ID] --body "## Completion Summary
+Create `tmp/completion-summary-[ISSUE_ID].md` with:
+
+```markdown
+## Completion Summary
 
 **Agent**: [AGENT_NAME]
-**Branch**: \`[BRANCH]\`
+**Branch**: `[BRANCH]`
 
 ### Files Created/Modified
-- \`path/to/file\` - Description
+- `path/to/file` - Description
 
 ### Key Decisions
 1. Decision and rationale
 2. DXXX recorded (if research-informed)
 
 ### Skills/Docs/Rules Updated
-- \`skill-name\`: Updated X
+- `skill-name`: Updated X
 (Skip if none)
 
 ### Domain Metrics
@@ -360,8 +361,12 @@ Bullets without a marker prefix are treated as genuine new backlog work and rout
 ### Handoff Notes
 Context the next agent in this bundle needs to complete its current-scope work (e.g., struct changes, API contracts, file locations). Do NOT put aspirational suggestions or future work here — those belong in Discovered Work.
 (Skip if none)
+```
 
-"
+Then post it:
+
+```bash
+.agents/skills/linear/scripts/linear.sh comments create [ISSUE_ID] --body-file tmp/completion-summary-[ISSUE_ID].md
 ```
 
 ### 9.2 Downstream Handoff (selective)

--- a/skills/linear/README.md
+++ b/skills/linear/README.md
@@ -34,6 +34,8 @@ Read-only cache queries (`./scripts/linear.sh cache ...` except `cache attachmen
 
 `cache labels list --format=safe` returns issue-label metadata (`id`, `name`, `team`, `parent`, `is_group`) so workflow callers can preflight labels and reject parent/group labels before issue mutation.
 
+Use `comments create ISSUE --body-file tmp/comment.md` for Markdown or multi-line comments. Inline `--body` is intended for short plain strings.
+
 ## Configuration
 
 | Variable | Purpose | Default |

--- a/skills/linear/SKILL.md
+++ b/skills/linear/SKILL.md
@@ -37,7 +37,7 @@ CLI wrapper for Linear's GraphQL API with local cache, bulk operations, and stru
 | Resource | Actions |
 |----------|---------|
 | `issues` | list, get, create, update, children, relations, bulk-get |
-| `comments` | list, create |
+| `comments` | list, create (`--body` or `--body-file`) |
 | `projects` | list, get, create, update, dependencies, updates |
 | `initiatives` | list, get, create, add-project |
 | `milestones` | list, get, create |

--- a/skills/linear/scripts/commands/comments.sh
+++ b/skills/linear/scripts/commands/comments.sh
@@ -25,18 +25,34 @@ List:
   comments.sh list <issue-id>
 
 Create Options:
-  --body <text>         Comment body (required, supports markdown)
+  --body <text>         Comment body (required unless --body-file is set)
+  --body-file <path>    Read comment body from file (preferred for markdown)
   --parent <id>         Parent comment ID for replies
 
 Update Options:
-  --body <text>         New comment body
+  --body <text>         New comment body (required unless --body-file is set)
+  --body-file <path>    Read new comment body from file
 
 Examples:
   comments.sh list PROJ-42
   comments.sh create PROJ-42 --body "Starting work on this task"
+  comments.sh create PROJ-42 --body-file tmp/comment.md
   comments.sh update <comment-id> --body "Updated comment text"
   comments.sh delete <comment-id>
 EOF
+}
+
+read_body_file() {
+    local body_file="$1"
+    if [[ -z "$body_file" ]]; then
+        echo '{"error": "--body-file requires a non-empty path argument"}' >&2
+        return 1
+    fi
+    if [[ ! -r "$body_file" ]]; then
+        echo "{\"error\": \"--body-file path not readable: $body_file\"}" >&2
+        return 1
+    fi
+    body=$(<"$body_file")
 }
 
 list_comments() {
@@ -97,11 +113,13 @@ create_comment() {
     shift
 
     local body=""
+    local body_file=""
     local parent_id=""
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
             --body) body="$2"; shift 2 ;;
+            --body-file) body_file="$2"; shift 2 ;;
             --parent) parent_id="$2"; shift 2 ;;
             --) shift; break ;;
             -*) echo "{\"error\": \"Unknown option: $1. Run --help for valid options.\"}" >&2; return 1 ;;
@@ -109,8 +127,16 @@ create_comment() {
         esac
     done
 
+    if [[ -n "$body" && -n "$body_file" ]]; then
+        echo '{"error": "--body and --body-file are mutually exclusive"}' >&2
+        return 1
+    fi
+    if [[ -n "$body_file" ]]; then
+        read_body_file "$body_file"
+    fi
+
     if [ -z "$body" ]; then
-        echo '{"error": "Required: --body"}' >&2
+        echo '{"error": "Required: --body or --body-file"}' >&2
         return 1
     fi
 
@@ -167,18 +193,28 @@ update_comment() {
     shift
 
     local body=""
+    local body_file=""
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
             --body) body="$2"; shift 2 ;;
+            --body-file) body_file="$2"; shift 2 ;;
             --) shift; break ;;
             -*) echo "{\"error\": \"Unknown option: $1. Run --help for valid options.\"}" >&2; return 1 ;;
             *) break ;;
         esac
     done
 
+    if [[ -n "$body" && -n "$body_file" ]]; then
+        echo '{"error": "--body and --body-file are mutually exclusive"}' >&2
+        return 1
+    fi
+    if [[ -n "$body_file" ]]; then
+        read_body_file "$body_file"
+    fi
+
     if [ -z "$body" ]; then
-        echo '{"error": "Required: --body"}' >&2
+        echo '{"error": "Required: --body or --body-file"}' >&2
         return 1
     fi
 

--- a/skills/linear/scripts/linear.sh
+++ b/skills/linear/scripts/linear.sh
@@ -14,7 +14,7 @@ Usage: ./linear.sh <resource> <action> [options]
 
 Resources:
   issues          Issue operations (list, get, create, update, children, relations)
-  comments        Comment operations (list, create)
+  comments        Comment operations (list, create/update; supports --body-file)
   projects        Project operations (list, get, create, update, dependencies, updates)
   initiatives     Initiative operations (list, get, create, add-project)
   milestones      Project milestone operations (list, get, create)

--- a/skills/linear/tests/comments-body-file.test.sh
+++ b/skills/linear/tests/comments-body-file.test.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Regression test for comments --body-file parsing without invoking the real API.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+mkdir -p "$TMP_ROOT/.agents/skills" "$TMP_ROOT/bin"
+cp -R "$SKILL_DIR" "$TMP_ROOT/.agents/skills/linear"
+
+cat >"$TMP_ROOT/bin/curl" <<'SH'
+#!/usr/bin/env bash
+config="$(cat)"
+printf '%s\n' "$config" > "${CURL_CONFIG_CAPTURE:?}"
+printf '{"data":{"commentCreate":{"success":true,"comment":{"id":"comment-1","body":"ok","createdAt":"2026-06-13T00:00:00Z","updatedAt":"2026-06-13T00:00:00Z","user":{"name":"Test"},"issue":{"identifier":"PROJ-1","updatedAt":"2026-06-13T00:00:00Z"}}}}}___HTTP_CODE___200'
+SH
+chmod +x "$TMP_ROOT/bin/curl"
+
+body_file="$TMP_ROOT/comment.md"
+cat >"$body_file" <<'MD'
+## Completion Summary
+
+`code` and multi-line markdown.
+MD
+
+export CURL_CONFIG_CAPTURE="$TMP_ROOT/curl-config.txt"
+out="$(PATH="$TMP_ROOT/bin:$PATH" LINEAR_API_KEY=test-token bash "$TMP_ROOT/.agents/skills/linear/scripts/linear.sh" comments create PROJ-1 --body-file "$body_file")"
+
+if ! jq -e '.success == true and .data.comment.id == "comment-1"' >/dev/null <<<"$out"; then
+  echo "FAIL comments create --body-file returned unexpected output: $out"
+  exit 1
+fi
+
+payload="$(sed -n 's/^data = //p' "$CURL_CONFIG_CAPTURE" | jq -r)"
+body="$(jq -r '.variables.input.body' <<<"$payload")"
+if [[ "$body" != *"Completion Summary"* || "$body" != *'`code` and multi-line markdown.'* ]]; then
+  echo "FAIL --body-file payload did not include markdown body: $body"
+  exit 1
+fi
+
+set +e
+PATH="$TMP_ROOT/bin:$PATH" LINEAR_API_KEY=test-token bash "$TMP_ROOT/.agents/skills/linear/scripts/linear.sh" comments create PROJ-1 --body inline --body-file "$body_file" >"$TMP_ROOT/conflict.out" 2>&1
+rc=$?
+set -e
+if [[ "$rc" -eq 0 ]]; then
+  echo "FAIL comments create accepted both --body and --body-file"
+  exit 1
+fi
+
+echo "all pass"

--- a/skills/orch/README.md
+++ b/skills/orch/README.md
@@ -56,6 +56,16 @@ Set non-sensitive values in `vstack.settings.toml` under `[env]`. Existing `.env
 
 See [`DEVELOPMENT.md`](./DEVELOPMENT.md) for GitHub auth fallback details and the test runner.
 
+## Helper Scripts
+
+Use `skills/orch/scripts/resolve-base-branch [WORKTREE_PATH]` to print the base branch for a worktree. It honors `WORKTREE_DEFAULT_BRANCH`, then `origin/HEAD`, and falls back to `main`.
+
+Use `skills/orch/scripts/workflow-state exists --json ISSUE_ID` when a workflow needs structured existence status without relying on shell exit-code capture.
+
+Use `skills/orch/scripts/review-init` to initialize standalone review context and print branch, worktree, issue ID, state path, and whether state was created as JSON.
+
+Use `skills/orch/scripts/tracker-for-issue ISSUE_ID` when workflow docs need tracker branching without inline shell conditionals.
+
 ## System Dependencies
 
 - `jq`, `bash` 4+, `flock` (util-linux)

--- a/skills/orch/SKILL.md
+++ b/skills/orch/SKILL.md
@@ -140,6 +140,9 @@ Follow ALL [Workflow Execution](#workflow-execution) rules for every command.
 | Script | Purpose |
 |--------|---------|
 | `workflow-state` | Persistent state read/write/append (survives compaction) |
+| `resolve-base-branch` | Print the worktree base branch (`WORKTREE_DEFAULT_BRANCH`, remote HEAD, or `main`) |
+| `review-init` | Initialize standalone review context and print branch/worktree/issue/state JSON |
+| `tracker-for-issue` | Print `github` for `issue-*` ids and `linear` otherwise |
 | `bot-review-wait` | Block until bot review posts on a PR — invoked by per-issue agents inside their submit-pr flow |
 | `ci-wait` | Block until CI completes on a PR — same |
 | `session-init` | Initialize session state for a new worktree (called by `initialize.md`) |
@@ -159,7 +162,7 @@ Both `bot-review-wait` and `ci-wait` share `scripts/lib/gh-auth.sh` for a four-s
 | Action | Purpose |
 |--------|---------|
 | `init <ID> --agent <name> --worktree <path> [--branch <b>] [--team <t>]` | Initialize state file |
-| `exists <ID>` | Check state file exists (exit code) |
+| `exists [--json] <ID>` | Check state file exists; `--json` prints `{issue_id,path,exists}` and exits 0 |
 | `path <ID>` | Print state file path |
 | `get <ID> <.field>` | Read state field |
 | `set <ID> <field> <value>` | Write state field |
@@ -232,10 +235,10 @@ Resolve once per workflow, store as `TRACKER`:
 3. Otherwise → `linear`.
 
 ```bash
-TRACKER=linear; [[ "$ISSUE_ID" == issue-* ]] && TRACKER=github
+TRACKER=$(.agents/skills/orch/scripts/tracker-for-issue "[ISSUE_ID]")
 ```
 
-Assign before any `$TRACKER` test. Steps marked **Linear only** / **GitHub only** run only for that tracker. Never run `linear.sh` against a GitHub item — GitHub state lives in `gh issue`/PR linkage (`Closes #N`).
+Assign `TRACKER` before any tracker test. Steps marked **Linear only** / **GitHub only** run only for that tracker. Never run `linear.sh` against a GitHub item — GitHub state lives in `gh issue`/PR linkage (`Closes #N`).
 
 ---
 

--- a/skills/orch/scripts/resolve-base-branch
+++ b/skills/orch/scripts/resolve-base-branch
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Print the default base branch for a worktree, falling back to main.
+
+set -euo pipefail
+
+worktree="${1:-.}"
+remote_head=""
+
+if [[ -n "${WORKTREE_DEFAULT_BRANCH:-}" ]]; then
+    base_branch="$WORKTREE_DEFAULT_BRANCH"
+else
+    remote_head="$(git -C "$worktree" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null || true)"
+    base_branch="${remote_head#refs/remotes/origin/}"
+fi
+
+base_branch="${base_branch#origin/}"
+base_branch="${base_branch#refs/heads/}"
+
+if [[ -z "${base_branch:-}" || "$base_branch" == "$remote_head" ]]; then
+    base_branch="main"
+fi
+
+printf '%s\n' "$base_branch"

--- a/skills/orch/scripts/review-init
+++ b/skills/orch/scripts/review-init
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Initialize standalone review context and print it as JSON.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+branch="$(git rev-parse --abbrev-ref HEAD)"
+worktree="$(pwd)"
+pattern="${GH_ISSUE_PATTERN:-[A-Z]+-[0-9]+}"
+issue_id=""
+state_path=""
+initialized=false
+
+if issue_id="$(printf '%s\n' "$branch" | grep -oiP "$pattern" | head -1)"; then
+    :
+else
+    issue_id=""
+fi
+
+if [[ -n "$issue_id" ]]; then
+    exists_json="$("$SCRIPT_DIR/workflow-state" exists --json "$issue_id")"
+    state_path="$(printf '%s\n' "$exists_json" | jq -r '.path')"
+    if [[ "$(printf '%s\n' "$exists_json" | jq -r '.exists')" == "false" ]]; then
+        state_path="$("$SCRIPT_DIR/workflow-state" init "$issue_id" --worktree "$worktree" --branch "$branch")"
+        initialized=true
+    fi
+fi
+
+jq -n \
+  --arg branch "$branch" \
+  --arg worktree "$worktree" \
+  --arg issue_id "$issue_id" \
+  --arg state_path "$state_path" \
+  --argjson initialized "$initialized" \
+  '{
+    branch: $branch,
+    worktree: $worktree,
+    issue_id: $issue_id,
+    state_path: $state_path,
+    initialized: $initialized
+  }'

--- a/skills/orch/scripts/tracker-for-issue
+++ b/skills/orch/scripts/tracker-for-issue
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Print the tracker name for an orch issue id.
+
+set -euo pipefail
+
+issue_id="${1:-}"
+if [[ -z "$issue_id" ]]; then
+    echo "Usage: tracker-for-issue <issue-id>" >&2
+    exit 2
+fi
+
+if [[ "$issue_id" == issue-* ]]; then
+    printf 'github\n'
+else
+    printf 'linear\n'
+fi

--- a/skills/orch/scripts/workflow-state
+++ b/skills/orch/scripts/workflow-state
@@ -206,9 +206,33 @@ cmd_path() {
 }
 
 cmd_exists() {
-    local issue_id="$1"
+    local json=false
+
+    if [[ "${1:-}" == "--json" ]]; then
+        json=true
+        shift
+    fi
+
+    local issue_id="${1:-}"
+    if [[ -z "$issue_id" ]]; then
+        echo "Error: exists requires an issue_id" >&2
+        exit 2
+    fi
+
     local state_file
     state_file=$(get_state_file "$issue_id")
+
+    if [[ "$json" == true ]]; then
+        local exists=false
+        [[ -f "$state_file" ]] && exists=true
+        jq -n \
+          --arg issue_id "$issue_id" \
+          --arg path "$state_file" \
+          --argjson exists "$exists" \
+          '{issue_id: $issue_id, path: $path, exists: $exists}'
+        return 0
+    fi
+
     [[ -f "$state_file" ]]
 }
 
@@ -231,10 +255,11 @@ Commands:
   increment <issue_id> <field>  Increment numeric field
   set <issue_id> <field> <value>  Set field value
   path <issue_id>               Print state file path
-  exists <issue_id>             Exit 0 if exists, 1 if not
+  exists [--json] <issue_id>    Exit 0 if exists, 1 if not; --json prints status and exits 0
 
 Examples:
   workflow-state init PROJ-123 --agent rust --worktree /tmp/wt
+  workflow-state exists --json PROJ-123
   workflow-state get PROJ-123 .cycles
   workflow-state increment PROJ-123 cycles
   workflow-state increment PROJ-123 pr_comment_review.iterations

--- a/skills/orch/tests/workflow_helpers.sh
+++ b/skills/orch/tests/workflow_helpers.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Regression tests for Codex-safe orch helper commands.
+
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../.." && pwd)"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local got="$1" want="$2" name="$3"
+  if [[ "$got" == "$want" ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$name" "$want" "$got"
+  fi
+}
+
+echo "=== orch Codex-safe helper commands ==="
+
+state_dir="$TMP_ROOT/state"
+ORCH_STATE_DIR="$state_dir" "$REPO_ROOT/skills/orch/scripts/workflow-state" init issue-353 --worktree "$REPO_ROOT" --branch issue-353 >/dev/null
+
+exists_json="$(ORCH_STATE_DIR="$state_dir" "$REPO_ROOT/skills/orch/scripts/workflow-state" exists --json issue-353)"
+assert_eq "$(jq -r '.exists' <<<"$exists_json")" "true" "workflow-state exists --json reports existing state"
+assert_eq "$(jq -r '.issue_id' <<<"$exists_json")" "issue-353" "workflow-state exists --json includes issue id"
+
+missing_json="$(ORCH_STATE_DIR="$state_dir" "$REPO_ROOT/skills/orch/scripts/workflow-state" exists --json issue-404)"
+assert_eq "$(jq -r '.exists' <<<"$missing_json")" "false" "workflow-state exists --json reports missing state"
+
+default_branch="$(WORKTREE_DEFAULT_BRANCH=trunk "$REPO_ROOT/skills/orch/scripts/resolve-base-branch" "$REPO_ROOT")"
+assert_eq "$default_branch" "trunk" "resolve-base-branch honors WORKTREE_DEFAULT_BRANCH"
+
+fallback_branch="$("$REPO_ROOT/skills/orch/scripts/resolve-base-branch" "$TMP_ROOT/not-a-git-repo")"
+assert_eq "$fallback_branch" "main" "resolve-base-branch falls back to main"
+
+assert_eq "$("$REPO_ROOT/skills/orch/scripts/tracker-for-issue" issue-353)" "github" "tracker-for-issue detects GitHub ids"
+assert_eq "$("$REPO_ROOT/skills/orch/scripts/tracker-for-issue" CC-353)" "linear" "tracker-for-issue detects Linear ids"
+
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/skills/orch/workflows/ci-fix.md
+++ b/skills/orch/workflows/ci-fix.md
@@ -96,7 +96,17 @@ Infer agent type from component paths or issue labels.
 
 **Flaky test detection**: If test failure involves concurrent/threading code and passes locally, check project testing conventions for common patterns (missing barriers, iteration-based waits, static mutable state).
 
-**Detect team context**: `.agents/skills/orch/scripts/workflow-state exists [ISSUE_ID] && TEAM=$(.agents/skills/orch/scripts/workflow-state get [ISSUE_ID] .team_name)`
+**Detect team context**:
+
+```bash
+.agents/skills/orch/scripts/workflow-state exists --json [ISSUE_ID]
+```
+
+If `.exists` is `true`, read `.team_name`:
+
+```bash
+.agents/skills/orch/scripts/workflow-state get [ISSUE_ID] .team_name
+```
 
 Delegate to `[AGENT]`. Wait for completion. Fill placeholders, omit empty lines/sections.
 
@@ -181,8 +191,18 @@ After fix is pushed:
 **Post to issue tracker** — **Linear only** (GitHub items: the PR conversation already records the fix):
 ```bash
 ISSUE=$(.agents/skills/github/scripts/github.sh pr-issue [PR_NUMBER] --format=text)
-TRACKER=linear; [[ "$ISSUE" == issue-* ]] && TRACKER=github
-[[ -n "$ISSUE" && "$TRACKER" == "linear" ]] && .agents/skills/linear/scripts/linear.sh comments create "$ISSUE" --body "CI Fix: [ERROR_TYPE] → [FIX_DESCRIPTION]"
+```
+
+If `ISSUE` is non-empty, determine tracker:
+
+```bash
+TRACKER=$(.agents/skills/orch/scripts/tracker-for-issue "$ISSUE")
+```
+
+If `TRACKER` is `linear`, post the short status:
+
+```bash
+.agents/skills/linear/scripts/linear.sh comments create "$ISSUE" --body "CI Fix: [ERROR_TYPE] → [FIX_DESCRIPTION]"
 ```
 
 ## 6. Present Results

--- a/skills/orch/workflows/dev-fix.md
+++ b/skills/orch/workflows/dev-fix.md
@@ -72,10 +72,16 @@ Apply [Worktree Scope](../SKILL.md#worktree-scope): if in a worktree and `ISSUE_
    - Otherwise: from workflow state or issue labels
      ```bash
      AGENT=$(.agents/skills/orch/scripts/workflow-state get $ISSUE_ID '.agent // empty' 2>/dev/null)
-     TRACKER=linear; [[ "$ISSUE_ID" == issue-* ]] && TRACKER=github
-     # Linear only — GitHub items: gh issue view ${ISSUE_ID#issue-} --json labels, or infer from component paths
-     [[ -z "$AGENT" && "$TRACKER" == "linear" ]] && AGENT=$(.agents/skills/linear/scripts/linear.sh cache issues get $ISSUE_ID --format=compact | jq -r '[.labels[] | select(startswith("agent:"))] | first | split(":")[1] // empty')
+     TRACKER=$(.agents/skills/orch/scripts/tracker-for-issue "$ISSUE_ID")
      ```
+
+     If `AGENT` is empty and `TRACKER` is `linear`, look up the Linear agent label:
+
+     ```bash
+     AGENT=$(.agents/skills/linear/scripts/linear.sh cache issues get $ISSUE_ID --format=compact | jq -r '[.labels[] | select(startswith("agent:"))] | first | split(":")[1] // empty')
+     ```
+
+     GitHub items: use `gh issue view ${ISSUE_ID#issue-} --json labels`, or infer from component paths.
 
 2. **Group items by agent domain** if multi-domain. Order per [agent-sequencing.md](agent-sequencing.md).
 

--- a/skills/orch/workflows/dev-start.md
+++ b/skills/orch/workflows/dev-start.md
@@ -26,20 +26,44 @@ Apply [Worktree Scope](../SKILL.md#worktree-scope): if in a worktree and `ISSUE_
 - Main repo, worktree missing → ask the user before creating
 
 ```bash
-TRACKER=linear; [[ "$ISSUE_ID" == issue-* ]] && TRACKER=github
-# Init workflow state if not exists
-if ! .agents/skills/orch/scripts/workflow-state exists $ISSUE_ID; then
-  # Linear only: check for parent context (start-new flow: sub-issue in parent's worktree)
-  PARENT_ID=""
-  [[ "$TRACKER" == "linear" ]] && PARENT_ID=$(.agents/skills/linear/scripts/linear.sh cache issues get $ISSUE_ID --format=compact | jq -r '.parent.identifier // empty')
-  if [[ -n "$PARENT_ID" ]] && .agents/skills/orch/scripts/workflow-state exists $PARENT_ID; then
-    TEAM=$(.agents/skills/orch/scripts/workflow-state get $PARENT_ID '.team_name // empty')
-    WT_PATH=$(.agents/skills/orch/scripts/workflow-state get $PARENT_ID '.worktree // empty')
-    .agents/skills/orch/scripts/workflow-state init $ISSUE_ID --worktree "$WT_PATH" --branch "$(git rev-parse --abbrev-ref HEAD)" --team "$TEAM"
-  else
-    .agents/skills/orch/scripts/workflow-state init $ISSUE_ID --worktree "$WT_PATH" --branch "$(git rev-parse --abbrev-ref HEAD)"
-  fi
-fi
+TRACKER=$(.agents/skills/orch/scripts/tracker-for-issue "$ISSUE_ID")
+```
+
+If workflow state already exists, skip initialization:
+
+```bash
+.agents/skills/orch/scripts/workflow-state exists --json "$ISSUE_ID"
+```
+
+If `.exists` is `false`, initialize workflow state. Linear only: first check for parent context from a start-new sub-issue:
+
+```bash
+PARENT_ID=$(.agents/skills/linear/scripts/linear.sh cache issues get $ISSUE_ID --format=compact | jq -r '.parent.identifier // empty')
+```
+
+If `PARENT_ID` is non-empty, check whether the parent workflow state exists:
+
+```bash
+.agents/skills/orch/scripts/workflow-state exists --json "$PARENT_ID"
+```
+
+If `.exists` is `true`, read the parent team and worktree:
+
+```bash
+TEAM=$(.agents/skills/orch/scripts/workflow-state get $PARENT_ID '.team_name // empty')
+WT_PATH=$(.agents/skills/orch/scripts/workflow-state get $PARENT_ID '.worktree // empty')
+```
+
+Then initialize child state with the inherited context:
+
+```bash
+.agents/skills/orch/scripts/workflow-state init $ISSUE_ID --worktree "$WT_PATH" --branch "$(git rev-parse --abbrev-ref HEAD)" --team "$TEAM"
+```
+
+Otherwise, initialize state with the current worktree:
+
+```bash
+.agents/skills/orch/scripts/workflow-state init $ISSUE_ID --worktree "$WT_PATH" --branch "$(git rev-parse --abbrev-ref HEAD)"
 ```
 
 ## 1. Determine Agent

--- a/skills/orch/workflows/merge-pr.md
+++ b/skills/orch/workflows/merge-pr.md
@@ -102,8 +102,12 @@ PR #N ready with warnings:
 
 ```bash
 ISSUE=$(.agents/skills/github/scripts/github.sh pr-issue [PR_NUMBER] --format=text)
-TRACKER=linear; [[ "$ISSUE" == issue-* ]] && TRACKER=github
-[ -n "$ISSUE" ] && .agents/skills/worktree/scripts/worktree exists "$ISSUE"
+```
+
+If `ISSUE` is non-empty, check whether its worktree exists:
+
+```bash
+.agents/skills/worktree/scripts/worktree exists "$ISSUE"
 ```
 
 If worktree exists: Ask user `"Cleanup worktree for [ISSUE_ID]?"` → store for § 5.

--- a/skills/orch/workflows/post-summary.md
+++ b/skills/orch/workflows/post-summary.md
@@ -20,7 +20,7 @@ Post summary comments to git host and issue tracker, and selective handoff comme
 ```bash
 # Extract issue from branch if not provided
 ISSUE_ID=$(git rev-parse --abbrev-ref HEAD | grep -oiP "$GH_ISSUE_PATTERN")
-TRACKER=linear; [[ "$ISSUE_ID" == issue-* ]] && TRACKER=github
+TRACKER=$(.agents/skills/orch/scripts/tracker-for-issue "$ISSUE_ID")
 WT_PATH=$(.agents/skills/worktree/scripts/worktree path $ISSUE_ID 2>/dev/null || echo ".")
 PR_NUMBER=$(.agents/skills/github/scripts/github.sh -C "$WT_PATH" pr-view --json number 2>/dev/null | jq -r .number)
 # Init workflow state if not exists
@@ -52,10 +52,13 @@ fi
    [filled SUMMARY_CONTENT — see template below]
    SUMMARY_EOF
    .agents/skills/github/scripts/github.sh post-comment [PR_NUMBER] --body-file "$SUMMARY_FILE"
-   # Linear only — GitHub items get linkage via `Closes #N` in the PR body
-   [[ "$TRACKER" == "linear" ]] && .agents/skills/linear/scripts/linear.sh comments create [ISSUE_ID] --body "$(cat "$SUMMARY_FILE")"
    ```
-   The Linear path uses `--body "$(cat ...)"` because `linear.sh` lacks `--body-file`; safe here because the heredoc is already on disk.
+
+   Linear only — GitHub items get linkage via `Closes #N` in the PR body:
+
+   ```bash
+   .agents/skills/linear/scripts/linear.sh comments create [ISSUE_ID] --body-file "$SUMMARY_FILE"
+   ```
 
    **Summary content template** (omit empty sections):
 

--- a/skills/orch/workflows/review-pr-comments.md
+++ b/skills/orch/workflows/review-pr-comments.md
@@ -504,9 +504,18 @@ If user requests fixes for skipped items → delegate via § 6.1 (single item), 
    [filled SUMMARY_CONTENT — see template below]
    SUMMARY_EOF
    .agents/skills/github/scripts/github.sh post-comment [PR_NUMBER] --body-file "$SUMMARY_FILE"
-   # Linear only — GitHub items get linkage via `Closes #N` in the PR body
-   TRACKER=linear; [[ "$ISSUE_ID" == issue-* ]] && TRACKER=github
-   [[ "$TRACKER" == "linear" ]] && .agents/skills/linear/scripts/linear.sh comments create [ISSUE_ID] --body "$(cat "$SUMMARY_FILE")"
+   ```
+
+   Determine tracker:
+
+   ```bash
+   TRACKER=$(.agents/skills/orch/scripts/tracker-for-issue "[ISSUE_ID]")
+   ```
+
+   If `TRACKER` is `linear`, post to Linear. GitHub items get linkage via `Closes #N` in the PR body:
+
+   ```bash
+   .agents/skills/linear/scripts/linear.sh comments create [ISSUE_ID] --body-file "$SUMMARY_FILE"
    ```
 
    ```markdown

--- a/skills/orch/workflows/review-pr.md
+++ b/skills/orch/workflows/review-pr.md
@@ -31,7 +31,7 @@ ISSUE_ID=$(git rev-parse --abbrev-ref HEAD | grep -oiP "$GH_ISSUE_PATTERN")
 # Init workflow state if not exists
 if ! .agents/skills/orch/scripts/workflow-state exists $ISSUE_ID; then
   .agents/skills/orch/scripts/workflow-state init $ISSUE_ID --worktree "$WT_PATH" --branch "$(git -C $WT_PATH rev-parse --abbrev-ref HEAD)"
-  TRACKER=linear; [[ "$ISSUE_ID" == issue-* ]] && TRACKER=github
+  TRACKER=$(.agents/skills/orch/scripts/tracker-for-issue "$ISSUE_ID")
   if [[ "$TRACKER" == "github" ]]; then
     QA_LABELS=$(gh issue view ${ISSUE_ID#issue-} --json labels --jq '[.labels[].name | select(startswith("needs-"))]')
   else
@@ -46,9 +46,8 @@ fi
 ## 1. Identify Changes
 
 ```bash
-BASE_BRANCH=${WORKTREE_DEFAULT_BRANCH:-$(git -C [WORKTREE_PATH] symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')}
-[ -n "$BASE_BRANCH" ] || BASE_BRANCH=main
-git -C [WORKTREE_PATH] diff "origin/$BASE_BRANCH"...HEAD --stat
+.agents/skills/orch/scripts/resolve-base-branch [WORKTREE_PATH]
+git -C [WORKTREE_PATH] diff "origin/[BASE_BRANCH_FROM_PREVIOUS_COMMAND]"...HEAD --stat
 ```
 
 **If no changes**: Report "No changes to review" and **END**.

--- a/skills/orch/workflows/review.md
+++ b/skills/orch/workflows/review.md
@@ -15,29 +15,27 @@ On-demand code review for the current session. Reviews recent commits, presents 
 
 **Init:**
 ```bash
-ISSUE_ID=$(git rev-parse --abbrev-ref HEAD | grep -oiP "$GH_ISSUE_PATTERN") || true
-WT_PATH=$(pwd)
-
-if [[ -n "$ISSUE_ID" ]] && ! .agents/skills/orch/scripts/workflow-state exists $ISSUE_ID; then
-  .agents/skills/orch/scripts/workflow-state init $ISSUE_ID --worktree "$WT_PATH" --branch "$(git rev-parse --abbrev-ref HEAD)"
-fi
+.agents/skills/orch/scripts/review-init
 ```
+
+Use the JSON fields as `BRANCH`, `WT_PATH`, and `ISSUE_ID`. If `issue_id` is empty, skip workflow-state steps.
 
 ---
 
 ## 1. Determine Review Scope
 
 ```bash
-BASE_BRANCH=${WORKTREE_DEFAULT_BRANCH:-$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')}
-[ -n "$BASE_BRANCH" ] || BASE_BRANCH=main
+.agents/skills/orch/scripts/resolve-base-branch .
 ```
+
+Use the output as `BASE_BRANCH`.
 
 **Diff range by argument:**
 
 | Argument | `DIFF_RANGE` | Description |
 |----------|-------------|-------------|
 | (none) | `HEAD` | Uncommitted changes (staged + unstaged) vs last commit |
-| `all` | `origin/$BASE_BRANCH..` | All branch changes including uncommitted work |
+| `all` | `origin/[BASE_BRANCH]..` | All branch changes including uncommitted work |
 | `last [N]` | `HEAD~[N]..HEAD` | Last N commits (committed only) |
 | `[HASH]` | `[HASH]~1..[HASH]` | Single commit |
 

--- a/skills/orch/workflows/submit-pr.md
+++ b/skills/orch/workflows/submit-pr.md
@@ -402,8 +402,12 @@ All bot review comments resolved (or max iterations). Verify no late-arriving th
    [filled SUMMARY_CONTENT — see template below]
    SUMMARY_EOF
    .agents/skills/github/scripts/github.sh post-comment [PR_NUMBER] --body-file "$SUMMARY_FILE"
-   # Linear only — GitHub items get linkage via `Closes #N` in the PR body
-   .agents/skills/linear/scripts/linear.sh comments create [ISSUE_ID] --body "$(cat "$SUMMARY_FILE")"
+   ```
+
+   Linear only — GitHub items get linkage via `Closes #N` in the PR body:
+
+   ```bash
+   .agents/skills/linear/scripts/linear.sh comments create [ISSUE_ID] --body-file "$SUMMARY_FILE"
    ```
 
    **Summary content template** (omit empty sections):


### PR DESCRIPTION
## Summary
- Move Codex-fragile workflow snippets into helper scripts for base branch, review init, tracker detection, and structured workflow-state existence.
- Update dev/orch workflow docs to use one-purpose commands and body-file based Markdown posting.
- Add Linear comment --body-file support plus regression coverage for the new helpers.

## Test Plan
- bash skills/orch/tests/run-all.sh
- bash skills/linear/tests/comments-body-file.test.sh && bash skills/linear/tests/cache-no-auth.test.sh && bash skills/linear/tests/update-emit-newline.test.sh
- bash -n skills/orch/scripts/resolve-base-branch && bash -n skills/orch/scripts/review-init && bash -n skills/orch/scripts/tracker-for-issue && bash -n skills/orch/scripts/workflow-state && bash -n skills/linear/scripts/commands/comments.sh && bash -n skills/linear/scripts/linear.sh
- git diff --check

Closes #353
