### PR TITLE
fix(orch): normalize Codex GitHub worktree starts

### DIFF
--- a/skills/orch/DEVELOPMENT.md
+++ b/skills/orch/DEVELOPMENT.md
@@ -37,3 +37,9 @@ Tests stage isolated repos/worktrees with parametrized CLI stubs on `PATH`. Each
 - `bot_review_wait.sh` — review-wait state machine + auth ladder.
 - `ci_wait.sh` — CI-wait state machine + auth ladder.
 - `session_init.sh` — worktree Linear auth diagnostic preservation.
+
+## Codex App Worktree Routing
+
+Codex Desktop handoff starts each child thread in an app-managed worktree, often on detached `HEAD`. `session-init --json github OWNER/REPO#N` is the normalization boundary: it converts the GitHub ref to `issue-N`, calls the worktree skill's `codex-branch` helper when the cwd is under `~/.codex/worktrees`, and returns the normalized issue context to `start-worktree.md`.
+
+The managed lifecycle relies on committed branch diffs. `dev-start.md`, `review-pr.md`, and `submit-pr.md` must reject dirty or detached worktrees before review/submission so uncommitted edits cannot be treated as "no changes".

--- a/skills/orch/README.md
+++ b/skills/orch/README.md
@@ -80,4 +80,6 @@ For app-visible handoff, use `handoff ... --harness codex-app` from the orch wor
 
 For multi-issue handoff, `handoff ISSUE_ID ISSUE_ID` defaults to Codex app threads when those tools are exposed. Create one Codex app thread per issue. Start each thread with exactly `$orch start ISSUE_ID` for Linear or `$orch start github OWNER/REPO#N` for GitHub. If the runtime separates thread creation from prompting, call `codex_app.send_message_to_thread` once for the returned thread ID with that same start prompt.
 
+Codex Desktop may create those child sessions as detached app worktrees under `~/.codex/worktrees`. The child `start` workflow still runs the normal worktree lifecycle: `session-init --json github OWNER/REPO#N` normalizes the branch to `issue-N`, then the session proceeds through implementation, review, PR submission, CI, and merge offer. A dirty or detached worktree is a hard preflight failure before review or PR submission.
+
 The Codex CLI does not expose these thread tools. Do not automate app-visible handoff with terminal launch helpers, `codex debug app-server`, raw `codex app-server`, or manual app-thread instructions.

--- a/skills/orch/SKILL.md
+++ b/skills/orch/SKILL.md
@@ -56,8 +56,11 @@ When invoked with `<command> [args]`, route to the corresponding workflow.
 | `initialize` | `[ISSUE_ID]` | `workflows/initialize.md` | Team setup, auth, cache, state (standalone) |
 
 **`start` routing logic:**
-1. Current directory is a worktree (git common dir differs from `.git`) → `workflows/start-worktree.md`
-2. Otherwise → `workflows/start.md`
+1. Parse explicit args first:
+   - `github OWNER/REPO#N` → `TRACKER=github`, `ISSUE_ID=issue-N`, `OWNER/REPO` retained for GitHub API calls.
+   - `[ISSUE_ID]` → Linear unless it already starts with `issue-`.
+2. Current directory is a worktree (git common dir differs from `.git`) → `workflows/start-worktree.md` with the parsed issue context.
+3. Otherwise → `workflows/start.md`
 
 ### Development
 
@@ -231,7 +234,7 @@ In a worktree, never create, switch to, or act on a different worktree or branch
 Resolve once per workflow, store as `TRACKER`:
 
 1. Caller `tracker` param wins.
-2. `ISSUE_ID` starts with `issue-` → `github`. Issue number = `${ISSUE_ID#issue-}`; repo from `gh repo view --json nameWithOwner`.
+2. `ISSUE_ID` starts with `issue-` → `github`. Issue number = `${ISSUE_ID#issue-}`; repo from caller context when supplied, otherwise from `gh repo view --json nameWithOwner`.
 3. Otherwise → `linear`.
 
 ```bash

--- a/skills/orch/scripts/session-init
+++ b/skills/orch/scripts/session-init
@@ -1,20 +1,51 @@
 #!/usr/bin/env bash
 # session-init — Initialize development session and display dashboard
-# Usage: session-init         # formatted dashboard
-#        session-init --json  # raw JSON for workflows
+# Usage: session-init                         # formatted dashboard
+#        session-init --json [ISSUE_ID]       # raw JSON for workflows
+#        session-init --json github OWNER/REPO#N
 
 set -euo pipefail
 
 OUTPUT_FORMAT="dashboard"
 ISSUE_ID_ARG=""
+TRACKER_ARG=""
+GITHUB_REPO_ARG=""
+GITHUB_ISSUE_ARG=""
+POSITIONAL_ARGS=()
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --json) OUTPUT_FORMAT="json"; shift ;;
     --)     shift; break ;;
     -*)     shift ;;  # ignore unknown flags
-    *)      ISSUE_ID_ARG="$1"; shift ;;
+    *)      POSITIONAL_ARGS+=("$1"); shift ;;
   esac
 done
+
+if [[ ${#POSITIONAL_ARGS[@]} -gt 0 ]]; then
+  if [[ "${POSITIONAL_ARGS[0]}" == "github" ]]; then
+    if [[ ${#POSITIONAL_ARGS[@]} -lt 2 ]]; then
+      echo "Error: github start requires OWNER/REPO#N" >&2
+      exit 2
+    fi
+    GITHUB_REF="${POSITIONAL_ARGS[1]}"
+    if [[ "$GITHUB_REF" =~ ^([^#[:space:]]+/[^#[:space:]]+)#([0-9]+)$ ]]; then
+      TRACKER_ARG="github"
+      GITHUB_REPO_ARG="${BASH_REMATCH[1]}"
+      GITHUB_ISSUE_ARG="${BASH_REMATCH[2]}"
+      ISSUE_ID_ARG="issue-${GITHUB_ISSUE_ARG}"
+    else
+      echo "Error: expected GitHub issue ref OWNER/REPO#N, got '$GITHUB_REF'" >&2
+      exit 2
+    fi
+  elif [[ "${POSITIONAL_ARGS[0]}" =~ ^([^#[:space:]]+/[^#[:space:]]+)#([0-9]+)$ ]]; then
+    TRACKER_ARG="github"
+    GITHUB_REPO_ARG="${BASH_REMATCH[1]}"
+    GITHUB_ISSUE_ARG="${BASH_REMATCH[2]}"
+    ISSUE_ID_ARG="issue-${GITHUB_ISSUE_ARG}"
+  else
+    ISSUE_ID_ARG="${POSITIONAL_ARGS[0]}"
+  fi
+fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
@@ -202,6 +233,10 @@ else
   ISSUE_ID=$(printf '%s' "$BRANCH" | grep -oiE "$_ISSUE_PAT" | head -1 | tr '[:lower:]' '[:upper:]' || true)
 fi
 ISSUE_ID="${ISSUE_ID:-}"
+if [[ -z "$TRACKER_ARG" && -n "$ISSUE_ID" ]]; then
+  TRACKER_ARG="linear"
+  [[ "$ISSUE_ID" == issue-* ]] && TRACKER_ARG="github"
+fi
 
 # Worktree detection
 IS_WORKTREE="false"
@@ -212,7 +247,7 @@ if [[ -n "$GIT_COMMON_DIR" && "$GIT_COMMON_DIR" != ".git" && "$GIT_COMMON_DIR" !
   WORKTREE_NAME=$(basename "$(pwd)")
   if [[ -n "$ISSUE_ID_ARG" ]]; then
     normalize_codex_issue_branch "$ISSUE_ID"
-    source_project_env
+    vstack_load_project_env "$PROJECT_ROOT"
     BRANCH=$(git branch --show-current 2>/dev/null || echo "main")
     ISSUE_ID="$ISSUE_ID_ARG"
   fi
@@ -235,7 +270,10 @@ if [[ -n "$GIT_COMMON_DIR" && "$GIT_COMMON_DIR" != ".git" && "$GIT_COMMON_DIR" !
       --arg lang_version "$LANG_VERSION" \
       --arg branch "$BRANCH" \
       --arg issue_id "$ISSUE_ID" \
-      '{is_worktree: true, worktree_name: $worktree_name, platform: $platform, lang: $lang, lang_version: $lang_version, branch: $branch, issue_id: $issue_id, gh_auth: $gh, linear_auth: $linear, lsp: $lsp}'
+      --arg tracker "$TRACKER_ARG" \
+      --arg github_repo "$GITHUB_REPO_ARG" \
+      --arg github_issue "$GITHUB_ISSUE_ARG" \
+      '{is_worktree: true, worktree_name: $worktree_name, platform: $platform, lang: $lang, lang_version: $lang_version, branch: $branch, issue_id: $issue_id, tracker: $tracker, github_repo: $github_repo, github_issue: $github_issue, gh_auth: $gh, linear_auth: $linear, lsp: $lsp}'
   else
     GH_ICON=$([[ "$WT_GH_OK" == "true" ]] && echo "✓" || echo "✗")
     LINEAR_ICON=$([[ "$WT_LINEAR_OK" == "true" ]] && echo "✓" || echo "✗")
@@ -574,6 +612,9 @@ SESSION_JSON=$(jq -n \
   --arg lang_lsp "${LANG_LSP:-}" \
   --arg branch "$BRANCH" \
   --arg issue_id "$ISSUE_ID" \
+  --arg tracker "$TRACKER_ARG" \
+  --arg github_repo "$GITHUB_REPO_ARG" \
+  --arg github_issue "$GITHUB_ISSUE_ARG" \
   --arg build_status "$BUILD_STATUS" \
   --arg repo_owner "${REPO_OWNER:-}" \
   --arg repo_name "${REPO_NAME:-}" \
@@ -593,6 +634,9 @@ SESSION_JSON=$(jq -n \
   lang_lsp: $lang_lsp,
   branch: $branch,
   issue_id: $issue_id,
+  tracker: $tracker,
+  github_repo: $github_repo,
+  github_issue: $github_issue,
   build_status: $build_status,
   uncommitted: $uncommitted,
   worktrees: $worktrees,

--- a/skills/orch/tests/session_init.sh
+++ b/skills/orch/tests/session_init.sh
@@ -82,5 +82,19 @@ ok="$(jq -r '.linear_auth.ok // false' <<<"$out")"
 assert_eq "$ok" "false" "missing linear command reports ok=false"
 assert_eq "$err" "not installed" "missing linear command reports not installed"
 
+WT_GITHUB="$(make_worktree wt-github yes)"
+out="$(
+  cd "$WT_GITHUB"
+  TEST_PROJECT_ROOT="$WT_GITHUB" PATH="$STUB_BIN:$PATH" "$SCRIPT" --json github vanillagreencom/vstack#356
+)"
+issue="$(jq -r '.issue_id // empty' <<<"$out")"
+tracker="$(jq -r '.tracker // empty' <<<"$out")"
+repo="$(jq -r '.github_repo // empty' <<<"$out")"
+number="$(jq -r '.github_issue // empty' <<<"$out")"
+assert_eq "$issue" "issue-356" "GitHub refs normalize to issue-N in worktree init"
+assert_eq "$tracker" "github" "GitHub refs report github tracker"
+assert_eq "$repo" "vanillagreencom/vstack" "GitHub refs preserve owner/repo"
+assert_eq "$number" "356" "GitHub refs preserve issue number"
+
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/skills/orch/workflows/dev-start.md
+++ b/skills/orch/workflows/dev-start.md
@@ -84,6 +84,12 @@ gh issue view ${ISSUE_ID#issue-} --json labels --jq '.labels[].name'
 
 **Dev agents persist for the entire session.** Never shutdown dev agents — they stay alive for fix cycles, pending children, and PR review fixes. Only the caller's finalization step shuts them down.
 
+Before each implementation delegation, capture the current `HEAD`:
+
+```bash
+.agents/skills/orch/scripts/workflow-state set [ISSUE_ID] pre_delegate_sha "$(git -C [WORKTREE_PATH] rev-parse HEAD)"
+```
+
 **After each spawn**, persist the agent session:
 ```bash
 .agents/skills/orch/scripts/workflow-state update [ISSUE_ID] '.child_sessions["[AGENT_TYPE]"] = {"agent_id": "[AGENT_OR_TASK_ID]"}'
@@ -161,20 +167,28 @@ Handoff from prior agents:
 
 1. **Run ALL checks** — do not proceed if ANY fails:
    ```bash
-   # Check commit exists
+   PRE_SHA=$(.agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.pre_delegate_sha // empty')
+   HEAD_SHA=$(git -C "[WORKTREE_PATH]" rev-parse HEAD)
+
+   # Check the implementation produced committed work.
    git -C "[WORKTREE_PATH]" log -1 --oneline
+   test -z "$PRE_SHA" || test "$HEAD_SHA" != "$PRE_SHA"
+
+   # Check no implemented files were left outside the commit.
+   test -z "$(git -C "[WORKTREE_PATH]" status --porcelain)"
 
    # Linear only: check state + summary (auto-includes pending children from bundle)
    .agents/skills/linear/scripts/linear.sh issues validate-completion [ISSUE_ID] --include-children-of [ISSUE_ID]
    ```
 
-   **GitHub/ad-hoc**: no tracker validation — require the commit plus a return message with Branch, Commit, QA Labels, and Summary content.
+   **GitHub/ad-hoc**: no tracker validation — require a new commit, a clean worktree, and a return message with Branch, Commit, QA Labels, and Summary content.
 
 2. **Evaluate results** (Linear):
 
    | Field | Expected | Failure Action |
    |-------|----------|----------------|
-   | commit | exists | Re-delegate § 2 with retry instructions |
+   | commit | `HEAD` advanced from `pre_delegate_sha` | Re-delegate § 2 with retry instructions |
+   | worktree | `git status --porcelain` empty | Re-delegate § 2: commit or revert leftover files |
    | `.all_ok` | `true` | Check `.results[]` below |
    | `.results[].state_ok` | `true` | Re-delegate § 2 |
    | `.results[].has_summary` | `true` | Re-delegate § 2 with retry instructions |

--- a/skills/orch/workflows/handoff.md
+++ b/skills/orch/workflows/handoff.md
@@ -53,6 +53,7 @@ For each item:
 2. Create exactly one Codex app thread for that item with `codex_app.create_thread`.
    - The prompt must be exactly the start prompt from step 1.
    - Target the current saved project with a separate worktree environment for that issue. Do not run all issues in the controller thread, do not launch all issues in one child thread, and do not pass multiple issue IDs to a child thread.
+   - The child thread may start in a detached Codex app worktree. Its first `start`/`initialize` step must parse `github OWNER/REPO#N` into `ISSUE_ID=issue-N` and run `session-init --json github OWNER/REPO#N`, which normalizes the branch before dev/review/submit.
    - Use the current model and thinking settings unless the user explicitly requested overrides.
 3. If the runtime creates the thread before accepting the prompt, immediately call `codex_app.send_message_to_thread` for the returned `threadId` with the exact start prompt from step 1.
 4. If `codex_app.set_thread_title` is exposed, title the thread with the item identifier, such as `orch [ISSUE_ID]` or `orch github #[N]`.

--- a/skills/orch/workflows/initialize.md
+++ b/skills/orch/workflows/initialize.md
@@ -8,11 +8,14 @@ Set up team, auth, cache, and workflow state for a worktree session.
 |---------|------|
 | `initialize` | § 1 → § 2 |
 | `initialize [ISSUE_ID]` | § 1 → § 2 |
+| `initialize github OWNER/REPO#N` | normalize to `issue-N`, then § 1 → § 2 |
 | (from start-worktree.md) | Managed lifecycle with caller context |
 
 **Caller context parameters** (via `⤵`):
 - `lifecycle` (optional): `"managed"` (return to caller at § 2) | `"self"` (default, standalone).
 - `issue_id` (optional): Issue ID. If absent, extracted from branch.
+- `tracker` (optional): `linear` or `github`.
+- `github_repo` (optional): `OWNER/REPO` for GitHub work items.
 
 ---
 
@@ -22,7 +25,12 @@ Set up team, auth, cache, and workflow state for a worktree session.
 
 1. **Run**: `.agents/skills/orch/scripts/session-init --json [ISSUE_ID]`
    - Pass `[ISSUE_ID]` as a positional argument if provided; otherwise omit it.
-   - Script resolves `ISSUE_ID` from the argument or current branch and returns it as `issue_id` in JSON output. In Codex-managed worktrees with an explicit `[ISSUE_ID]`, normalizes the app-created branch to the lower-case issue branch.
+   - For GitHub work items, pass the original form when available:
+     ```bash
+     .agents/skills/orch/scripts/session-init --json github [OWNER/REPO]#[N]
+     ```
+   - Script resolves `ISSUE_ID` from the argument or current branch and returns it as `issue_id` in JSON output. `github OWNER/REPO#N` returns `issue-N`.
+   - In Codex-managed worktrees with an explicit issue, the script normalizes the app-created detached branch to the lower-case issue branch before workflow-state initialization.
    - Read `issue_id` from output; if empty, fall back to the sanitized branch name (replace `/` with `-`) for workflow-state and team naming.
    - Resolve `TRACKER` per [Tracker Resolution](../SKILL.md#tracker-resolution).
 

--- a/skills/orch/workflows/review-pr.md
+++ b/skills/orch/workflows/review-pr.md
@@ -47,10 +47,15 @@ fi
 
 ```bash
 .agents/skills/orch/scripts/resolve-base-branch [WORKTREE_PATH]
+git -C [WORKTREE_PATH] status --porcelain
 git -C [WORKTREE_PATH] diff "origin/[BASE_BRANCH_FROM_PREVIOUS_COMMAND]"...HEAD --stat
 ```
 
-**If no changes**: Report "No changes to review" and **END**.
+**If `git status --porcelain` is not empty**:
+- Managed lifecycle with `dev_agent`: stop review and re-delegate to the dev agent to commit or revert the leftover files, then re-enter § 1. Do not run review against a dirty pre-submission worktree.
+- Standalone lifecycle: report the dirty files and ask the user to commit, revert, or run `orch review all` for an ad-hoc uncommitted review. Do not continue through `review-pr`.
+
+**If no committed diff after the dirty check**: Report "No committed changes to review" and **END**.
 
 **Tiny/docs-only skip path**: Review is the default gate. If the full diff is docs/comments-only (`*.md`, comments, typo fixes) or tiny (≤10 changed lines, no logic change), present the diff stat and ask the user: `Run full review` | `Skip review (tiny/docs-only)`. On skip: `workflow-state set [ISSUE_ID] review_skipped "tiny-docs"` → § 11 with verdict `pass`. Never auto-skip without asking.
 

--- a/skills/orch/workflows/start-worktree.md
+++ b/skills/orch/workflows/start-worktree.md
@@ -8,14 +8,22 @@ Expedited session start for worktree contexts. Skips issue selection, preparatio
 |---------|------|
 | `start` (from worktree) | § 1 → § 2 → § 3 → § 4 → § 5 |
 | `start [ISSUE_ID]` (from worktree) | § 1 → § 2 → § 3 → § 4 → § 5 |
+| `start github OWNER/REPO#N` (from worktree) | normalize to `ISSUE_ID=issue-N`, then § 1 → § 2 → § 3 → § 4 → § 5 |
 
 ---
 
 ## 1. Initialize Worktree Session
 
+If invoked as `start github OWNER/REPO#N`, parse it before initialization:
+- `TRACKER=github`
+- `ISSUE_ID=issue-N`
+- `GITHUB_REPO=OWNER/REPO`
+
 **Invoke workflow**: `⤵ workflows/initialize.md § 1-2 → § 2` with context:
 - `lifecycle`: `"managed"`
-- `issue_id`: from argument or branch
+- `issue_id`: normalized issue ID from argument or branch
+- `tracker`: `[TRACKER]` when parsed
+- `github_repo`: `[GITHUB_REPO]` when parsed
 
 ---
 
@@ -28,7 +36,14 @@ Expedited session start for worktree contexts. Skips issue selection, preparatio
 
 2. **Parse return**: Branch, Commit, QA Labels, Summary.
 
-3. **Do NOT shutdown dev agent.** Persists for § 3 fix cycles and re-delegation. Only § 5.5 shuts it down.
+3. **Require committed clean work before review.** Do not proceed to § 3 unless § 2 validation confirms:
+   - `HEAD` advanced from the pre-dev SHA captured by `dev-start.md`.
+   - The returned commit exists in `HEAD` history.
+   - `git status --porcelain` is empty.
+
+   If any check fails, re-delegate to the same dev agent with the exact missing step: commit the implemented changes, report the commit SHA, and leave the worktree clean. Never review or submit a dirty worktree.
+
+4. **Do NOT shutdown dev agent.** Persists for § 3 fix cycles and re-delegation. Only § 5.5 shuts it down.
 
 → § 3
 
@@ -75,7 +90,7 @@ Expedited session start for worktree contexts. Skips issue selection, preparatio
 
 1. **Resolve tracker**:
    ```bash
-   TRACKER=linear; [[ "[ISSUE_ID]" == issue-* ]] && TRACKER=github
+   TRACKER=$(.agents/skills/orch/scripts/tracker-for-issue "[ISSUE_ID]")
    ```
 
 2. **Skip if** `TRACKER=github` (GitHub issues close via PR merge keywords). → § 5.4

--- a/skills/orch/workflows/start.md
+++ b/skills/orch/workflows/start.md
@@ -14,9 +14,11 @@ Start one work item. Never watches or manages other sessions.
 ## 1. Route
 
 1. If args start with `new`, invoke `workflows/start-new.md`.
-2. If cwd is a worktree, invoke `workflows/start-worktree.md` and stop.
-3. If args start with `github`, set `tracker=github`, parse `[OWNER/REPO]` and `[N]`.
-4. Else set `tracker=linear`, parse `[ISSUE_ID]` if present.
+2. Parse explicit work item args before checking cwd:
+   - If args start with `github`, set `tracker=github`, parse `[OWNER/REPO]` and `[N]`, and set `ISSUE_ID=issue-[N]`.
+   - Else set `tracker=linear`, parse `[ISSUE_ID]` if present.
+   - If parsed `ISSUE_ID` starts with `issue-`, set `tracker=github`.
+3. If cwd is a worktree, invoke `workflows/start-worktree.md` with the parsed context and stop.
 
 ## 2. Main Repo Dashboard
 
@@ -83,7 +85,7 @@ Ask one action:
 | Continue here | Execute `workflows/start-worktree.md` using `[WT_PATH]` as the worktree context |
 | Launch handoff | Invoke `workflows/handoff.md` |
 | Launch Codex app | Invoke `workflows/handoff.md` with `harness=codex-app`; Codex Desktop creates one app thread per issue via `codex_app` thread tools |
-| Manual | Print worktree path and exact `/orch start ...` command |
+| Manual | Print worktree path and exact `/orch start ...` command. For GitHub, use `/orch start github [OWNER/REPO]#[N]`; the worktree workflow normalizes it to `issue-[N]`. |
 
 <output_format>
 ### Milestone: Worktree Ready

--- a/skills/orch/workflows/submit-pr.md
+++ b/skills/orch/workflows/submit-pr.md
@@ -35,12 +35,28 @@ fi
 
 ## 1. Push and Submit PR
 
-1. **Push branch**:
+1. **Preflight committed work**:
+   ```bash
+   BASE_BRANCH=$(.agents/skills/orch/scripts/resolve-base-branch "[WORKTREE_PATH]")
+   CURRENT_BRANCH=$(git -C "[WORKTREE_PATH]" branch --show-current)
+   git -C "[WORKTREE_PATH]" status --porcelain
+   git -C "[WORKTREE_PATH]" diff "origin/$BASE_BRANCH"...HEAD --stat
+   ```
+
+   Stop before pushing if any condition is true:
+   - `CURRENT_BRANCH` is empty (detached HEAD).
+   - `CURRENT_BRANCH` equals `$BASE_BRANCH`.
+   - `git status --porcelain` is not empty.
+   - The committed diff against `origin/$BASE_BRANCH` is empty.
+
+   In managed lifecycle, return to the caller with the failed preflight so the dev agent can normalize the branch and commit or clean the worktree. Do not create a PR from dirty or detached state.
+
+2. **Push branch**:
    ```bash
    .agents/skills/worktree/scripts/worktree push "[WORKTREE_PATH]" --set-upstream
    ```
 
-2. **Check for existing PR**:
+3. **Check for existing PR**:
    ```bash
    mkdir -p tmp
    PR_VIEW_RC=0
@@ -67,7 +83,7 @@ fi
    fi
    ```
 
-3. **Build PR body** from current workflow state using the template below (omit empty sections).
+4. **Build PR body** from current workflow state using the template below (omit empty sections).
 
    **PR body MUST be written to a file** — inline bodies with backticks or fenced code blocks corrupt under shell command substitution. Use a quoted heredoc (disables interpolation) or your harness's `Write` tool:
 
@@ -109,7 +125,7 @@ fi
    - **Created Issues**: Include if issues created during review.
    - **QA Metrics**: Include if QA agents ran. Format is project-configurable based on which QA agent types are active.
 
-4. **Create or update PR**:
+5. **Create or update PR**:
 
    **No existing PR** → create with `defer-ci` label. Always pass the body via `--body-file`:
    ```bash


### PR DESCRIPTION
## Summary
- Normalize `start github OWNER/REPO#N` before worktree routing so Codex Desktop child threads run the normal worktree lifecycle as `issue-N`.
- Make `session-init` parse GitHub refs, normalize Codex app detached branches, and return tracker/repo metadata.
- Add clean committed-work preflights before review/PR submission so uncommitted implementation edits cannot be treated as no changes.

## Test Plan
- `bash -n skills/orch/scripts/session-init skills/orch/tests/session_init.sh`
- `bash skills/orch/tests/session_init.sh`
- `bash skills/orch/tests/run-all.sh`
- `git diff --check`
- `cargo run -- refresh --scope project -v`
- `cargo run -- verify --scope project orch`
