### PR TITLE
Fix worktree push for Codex app worktrees

### DIFF
--- a/skills/worktree/README.md
+++ b/skills/worktree/README.md
@@ -47,6 +47,8 @@ Cleanup script:
 "$CODEX_SOURCE_TREE_PATH/.agents/skills/worktree/scripts/worktree" codex-branch CC-123 "$CODEX_WORKTREE_PATH"
 ```
 
+From a Codex Desktop app-created worktree, `worktree push CC-123` pushes the active checkout when its current branch matches `cc-123`. It does not require the app-created worktree to live under the configured `WORKTREE_BASE_DIR` registry.
+
 `codex-setup` applies the same env/config symlinks, copies, mkdirs, bot remote, bot git identity, and lightweight dependency bootstrap that `create` applies after creating a worktree. `codex-branch` renames or switches the app-created worktree branch to the lower-case issue branch expected by `orch`. `codex-cleanup` is intentionally a no-op lifecycle hook for this script; Codex owns app-created worktree and branch deletion. Keep project-level teardown such as stopping containers or removing disposable caches in the Codex environment cleanup script after this command, but do not call `worktree remove` from the hook.
 
 ## Configuration

--- a/skills/worktree/SKILL.md
+++ b/skills/worktree/SKILL.md
@@ -35,6 +35,8 @@ Resolves project root via `git rev-parse`, detects default branch automatically,
 | `codex-branch` | Normalize a Codex Desktop app-created branch to an issue branch |
 | `codex-cleanup` | Non-destructive Codex Desktop cleanup hook; app owns deletion |
 
+`push ISSUE_ID` normally resolves through the configured worktree registry. When run from a checkout whose current branch already matches the normalized issue branch, it pushes that active checkout instead. This supports Codex Desktop app-created worktrees that are valid git worktrees but are not registered under `WORKTREE_BASE_DIR`.
+
 `remove` deletes the worktree before deleting the local branch. Branch deletion uses safe `git branch -d`; if that fails after worktree removal, the script exits non-zero with a diagnostic naming the remaining branch and manual `git branch -D` recovery command.
 
 When a configured symlink path is already tracked in the worktree branch, the script marks that path assume-unchanged before replacing it so `git status` stays clean.

--- a/skills/worktree/scripts/worktree
+++ b/skills/worktree/scripts/worktree
@@ -113,6 +113,17 @@ issue_branch_name() {
   echo "$1" | tr '[:upper:]' '[:lower:]'
 }
 
+current_checkout_path_for_issue() {
+  local issue="$1"
+  local expected_branch current_root current_branch
+  expected_branch="$(issue_branch_name "$issue")"
+  current_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+  [[ -n "$current_root" ]] || return 1
+  current_branch="$(git -C "$current_root" branch --show-current 2>/dev/null || true)"
+  [[ -n "$current_branch" && "$current_branch" == "$expected_branch" ]] || return 1
+  printf '%s\n' "$current_root"
+}
+
 # Symlink a path from main repo into worktree (handles tracked dirs with assume-unchanged)
 # Idempotently append a worktree-relative path to the COMMON git-dir's
 # info/exclude so git treats the symlink we lay down as ignored content.
@@ -542,6 +553,8 @@ case "${1:-}" in
       WT_PATH="$PWD"
     elif [[ "$ARG" == */* ]]; then
       WT_PATH="$ARG"
+    elif WT_PATH="$(current_checkout_path_for_issue "$ARG")"; then
+      :
     else
       WT_PATH="$(worktree_path "$ARG")"
     fi

--- a/skills/worktree/tests/worktree_remove.sh
+++ b/skills/worktree/tests/worktree_remove.sh
@@ -113,6 +113,17 @@ assert_branch_absent() {
   fi
 }
 
+assert_remote_branch_exists() {
+  local repo="$1" branch="$2" name="$3"
+  if git -C "$repo" ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        missing remote branch: %s\n' "$name" "$branch"
+  fi
+}
+
 make_repo() {
   local repo="$1"
   mkdir -p "$repo"
@@ -217,6 +228,29 @@ assert_eq "$codex_branch_out" "Codex worktree branch ready: cc-999 ($CODEX_BRANC
 assert_eq "$(git -C "$CODEX_BRANCH_ROOT/trees/app-managed" branch --show-current)" "cc-999" "codex-branch renames app branch to issue branch"
 assert_branch_absent "$CODEX_BRANCH_ROOT/main" "app-managed-branch" "codex-branch removes old app branch name"
 assert_path_exists "$CODEX_BRANCH_ROOT/trees/app-managed/tmp" "codex-branch reapplies setup after branch normalization"
+
+CODEX_PUSH_ROOT="$TMP_ROOT/codex-push"
+make_repo "$CODEX_PUSH_ROOT/main"
+git init -q --bare "$CODEX_PUSH_ROOT/origin.git"
+git -C "$CODEX_PUSH_ROOT/main" remote add origin "$CODEX_PUSH_ROOT/origin.git"
+git -C "$CODEX_PUSH_ROOT/main" push -q -u origin main
+cat > "$CODEX_PUSH_ROOT/main/.env.local" <<'ENV'
+WORKTREE_BASE_DIR="../registry-trees"
+ENV
+git -C "$CODEX_PUSH_ROOT/main" worktree add -q -b issue-codex-push "$CODEX_PUSH_ROOT/app-worktrees/issue-codex-push" main
+printf 'codex-change\n' >> "$CODEX_PUSH_ROOT/app-worktrees/issue-codex-push/file.txt"
+git -C "$CODEX_PUSH_ROOT/app-worktrees/issue-codex-push" add file.txt
+git -C "$CODEX_PUSH_ROOT/app-worktrees/issue-codex-push" commit -q -m 'codex push change'
+set +e
+(
+  cd "$CODEX_PUSH_ROOT/app-worktrees/issue-codex-push" && \
+    "$WORKTREE_SCRIPT" push ISSUE-CODEX-PUSH --no-rebase >"$CODEX_PUSH_ROOT/codex-push.out" 2>"$CODEX_PUSH_ROOT/codex-push.err"
+)
+codex_push_code=$?
+set -e
+assert_eq "$codex_push_code" "0" "push issue ID uses current Codex worktree outside configured registry"
+assert_remote_branch_exists "$CODEX_PUSH_ROOT/main" "issue-codex-push" "push issue ID publishes current Codex worktree branch"
+assert_path_absent "$CODEX_PUSH_ROOT/registry-trees/issue-codex-push" "push issue ID does not require configured registry path"
 
 # .env.local is not special-cased. It is only linked when listed in
 # WORKTREE_SYMLINKS.


### PR DESCRIPTION
## Summary
- Resolve `worktree push ISSUE_ID` to the active checkout when the current branch matches the normalized issue branch.
- Add a regression for a Codex Desktop-style worktree outside the configured `WORKTREE_BASE_DIR` registry.
- Document the Codex Desktop push behavior in the worktree skill docs.

## Root Cause
`worktree push CC-536` treated an issue ID argument as a registry lookup under `WORKTREE_BASE_DIR`, even when the caller was already inside a valid Codex Desktop-created worktree on branch `cc-536`.

## Test Plan
- `git diff --check HEAD~1..HEAD`
- `bash -n skills/worktree/scripts/worktree skills/worktree/tests/worktree_remove.sh`
- `bash skills/worktree/tests/worktree_remove.sh`

Closes #357