### PR TITLE
[codex] Fix bot review wait terminal approval fallback

### DIFF
--- a/skills/orch/DEVELOPMENT.md
+++ b/skills/orch/DEVELOPMENT.md
@@ -11,6 +11,17 @@ Implementation details and contributor notes. End-user setup: [`README.md`](./RE
 3. **Fallback retry.** Auth still fails → drop env tokens, retry bot-token load. Recovers when project config/secrets have a valid token despite broken keyring.
 4. **Hard fail.** No path works → exit `3` with diagnostic. Callers do not poll against empty output.
 
+## Bot Review Terminal Fallback
+
+`bot-review-wait` primarily trusts per-reviewer signals from formal reviews, sticky comments, reactions, and unresolved threads. Some bot runs can leave a sticky comment looking pending after GitHub has already moved the PR to `reviewDecision=APPROVED`. In that case the waiter promotes pending/unknown reviewers to approved only when:
+
+- no reviewer has an explicit `changes` status,
+- `gh pr view --json reviewDecision` reports `APPROVED`,
+- `BOT_CHECK_NAME` is unset or the matching check line is `pass`, and
+- the PR has zero unresolved review threads.
+
+The emitted reviewer signals include `pr_review_decision:approved` and `pr_threads:clear` so callers can distinguish this fallback from a direct sticky/comment verdict. Entries with this signal skip the later sticky-checklist drain wait because the fallback already verified that thread propagation is clear.
+
 ## Tests
 
 ```bash

--- a/skills/orch/README.md
+++ b/skills/orch/README.md
@@ -52,7 +52,9 @@ Set non-sensitive values in `vstack.settings.toml` under `[env]`. Existing `.env
 | `GH_BOT_TOKEN` | Bot GitHub token for worktree auth | current `gh` auth |
 | `GH_ISSUE_PATTERN` | Issue ID regex for branch names | `[A-Z]+-[0-9]+` |
 | `BOT_REVIEWERS` | Comma-separated review bot usernames | auto-detect |
-| `BOT_CHECK_NAME` | CI check name for early review detection | — |
+| `BOT_CHECK_NAME` | CI check name for early review detection and PR-level approved fallback gating | — |
+
+`bot-review-wait` also handles stale pending bot prose: when GitHub reports `reviewDecision=APPROVED`, the configured bot check has passed if one is set, and no unresolved review threads remain, it returns a terminal approved result instead of continuing to poll the stale status comment or checklist.
 
 See [`DEVELOPMENT.md`](./DEVELOPMENT.md) for GitHub auth fallback details and the test runner.
 

--- a/skills/orch/SKILL.md
+++ b/skills/orch/SKILL.md
@@ -146,7 +146,7 @@ Follow ALL [Workflow Execution](#workflow-execution) rules for every command.
 | `open-terminal` | Launch-only handoff helper for Linear/GitHub worktrees |
 | `parallel-groups` | Local cache for safe parallel handoff analysis |
 
-`bot-review-wait --json` returns `status: "error"` and exits non-zero on GitHub auth/API failures instead of polling until timeout with empty output.
+`bot-review-wait --json` returns `status: "error"` and exits non-zero on GitHub auth/API failures instead of polling until timeout with empty output. If a bot's direct signal remains pending after GitHub reports `reviewDecision=APPROVED`, the waiter treats the reviewer as approved only when any configured `BOT_CHECK_NAME` has passed and there are no unresolved review threads, then skips stale sticky-checklist waiting.
 
 `session-init --json` reports worktree Linear auth as the structured `linear_auth` object from `linear auth-check`. `linear_auth.error = "not installed"` is reserved for a missing Linear skill command; API key, 1Password, and API failures keep their original auth-check diagnostic.
 

--- a/skills/orch/scripts/bot-review-wait
+++ b/skills/orch/scripts/bot-review-wait
@@ -19,6 +19,9 @@
 #                          completion. Combined with --skip.
 #   BOT_CHECK_NAME         Optional CI check name treated as an early review
 #                          completion signal (legacy fast-path for Claude).
+#                          When unset, PR-level approved reviewDecision can
+#                          still resolve stale pending bot signals if no
+#                          unresolved review threads remain.
 #
 # Exit codes:
 #   0 - All configured reviewers reached a terminal state (approved/changes/skipped)
@@ -198,12 +201,89 @@ collect_reviewers() {
   printf '%s' "$arr"
 }
 
+pr_review_decision_approved() {
+  local pr_json
+  if ! pr_json=$(gh pr view "$PR_NUM" --json reviewDecision 2>/dev/null); then
+    return 1
+  fi
+  [[ "$(jq -r '.reviewDecision // ""' <<<"$pr_json")" == "APPROVED" ]]
+}
+
+bot_check_name_passed() {
+  [[ -z "${BOT_CHECK_NAME:-}" ]] && return 0
+
+  local check_lines
+  check_lines=$(gh pr checks "$PR_NUM" 2>&1 | grep -E "^\s*${BOT_CHECK_NAME}\s" || true)
+  [[ -n "$check_lines" ]] && echo "$check_lines" | grep -qE '\bpass\b'
+}
+
+unresolved_pr_threads_count() {
+  local repo_info owner repo threads
+  repo_info=$(get_repo_info) || return 1
+  owner=$(get_owner "$repo_info")
+  repo=$(get_repo "$repo_info")
+
+  local query='
+query($owner: String!, $repo: String!, $pr: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $pr) {
+      reviewThreads(first: 100) {
+        nodes { isResolved }
+      }
+    }
+  }
+}'
+  threads=$(gh_graphql "$query" -F owner="$owner" -F repo="$repo" -F pr="$PR_NUM") || return 1
+  jq '[.repository.pullRequest.reviewThreads.nodes[]? | select((.isResolved // false) == false)] | length' <<<"$threads"
+}
+
+apply_pr_terminal_fallback() {
+  local entries="$1"
+
+  # Do not turn an explicit changes request into approval.
+  if jq -e 'any(.status == "changes")' >/dev/null <<<"$entries"; then
+    printf '%s' "$entries"
+    return 0
+  fi
+
+  # GitHub's PR-level reviewDecision can become terminal while a bot's sticky
+  # status comment still looks pending. Trust it only when the configured bot
+  # check has passed (if one is configured) and no unresolved review threads
+  # remain, so comment triage can proceed instead of polling stale prose.
+  if ! pr_review_decision_approved || ! bot_check_name_passed; then
+    printf '%s' "$entries"
+    return 0
+  fi
+
+  local unresolved
+  if ! unresolved=$(unresolved_pr_threads_count); then
+    printf '%s' "$entries"
+    return 0
+  fi
+  if [[ "$unresolved" -gt 0 ]]; then
+    printf '%s' "$entries"
+    return 0
+  fi
+
+  jq -c '
+    map(
+      if .status == "pending" or .status == "unknown" then
+        .status = "approved"
+        | .signals += ["pr_review_decision:approved", "pr_threads:clear"]
+      else
+        .
+      end
+    )
+  ' <<<"$entries"
+}
+
 collect_reviewers_or_exit() {
   local entries
   if ! entries=$(collect_reviewers); then
     emit_error "GitHub API failure while reading bot review status for PR #$PR_NUM"
     exit 3
   fi
+  entries=$(apply_pr_terminal_fallback "$entries")
   printf '%s' "$entries"
 }
 
@@ -285,6 +365,23 @@ wait_for_checklist() {
   sticky_checklist_done
 }
 
+pr_terminal_fallback_applied() {
+  local entries="$1"
+  jq -e 'any(.signals[]? == "pr_review_decision:approved")' >/dev/null <<<"$entries"
+}
+
+terminal_posting_done() {
+  local entries="$1"
+
+  # The PR-level fallback already verified that no unresolved review threads
+  # remain. Do not wait on stale sticky checklist prose after that point.
+  if pr_terminal_fallback_applied "$entries"; then
+    return 0
+  fi
+
+  wait_for_checklist
+}
+
 emit_result() {
   local status="$1"
   local entries="$2"
@@ -354,7 +451,7 @@ while [ $elapsed -lt $phase1_end ] && [[ -n "$BOT_CHECK_NAME" ]]; do
     if echo "$check_lines" | grep -qE '\b(pass|fail)\b'; then
       entries=$(collect_reviewers_or_exit)
       if ! any_blocking "$entries"; then
-        if wait_for_checklist; then
+        if terminal_posting_done "$entries"; then
           emit_result "complete" "$entries"
           exit 0
         else
@@ -376,7 +473,7 @@ done
 while [ $elapsed -lt $MAX_WAIT ]; do
   entries=$(collect_reviewers_or_exit)
   if ! any_blocking "$entries"; then
-    if wait_for_checklist; then
+    if terminal_posting_done "$entries"; then
       emit_result "complete" "$entries"
       exit 0
     else
@@ -400,7 +497,7 @@ done
 entries=$(collect_reviewers_or_exit)
 if ! any_blocking "$entries"; then
   # Crossed the line right at the bell.
-  if wait_for_checklist; then
+  if terminal_posting_done "$entries"; then
     emit_result "complete" "$entries"
     exit 0
   fi

--- a/skills/orch/tests/bot_review_wait.sh
+++ b/skills/orch/tests/bot_review_wait.sh
@@ -44,6 +44,9 @@ cat > "$FAKE_GITHUB_SH" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 if [[ "${1:-}" == "sticky-comment" && "${3:-}" == "--body" ]]; then
+  if [[ "${2:-}" == "3" ]]; then
+    printf '%s\n' '- [ ] stale checklist item'
+  fi
   exit 0
 fi
 printf 'unexpected github.sh call: %s\n' "$*" >&2
@@ -79,7 +82,11 @@ case "${1:-}" in
     endpoint="${2:-}"
     case "$endpoint" in
       graphql)
-        echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}'
+        if [[ "$*" == *"pr=4"* ]]; then
+          echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"isResolved":false,"isOutdated":false,"comments":{"nodes":[{"author":{"login":"vg-claude"}}]}}]}}}}}'
+        else
+          echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}'
+        fi
         exit 0
         ;;
       repos/*/pulls/1/reviews)
@@ -87,6 +94,14 @@ case "${1:-}" in
         exit 0
         ;;
       repos/*/pulls/2/reviews)
+        echo '[]'
+        exit 0
+        ;;
+      repos/*/pulls/3/reviews)
+        echo '[]'
+        exit 0
+        ;;
+      repos/*/pulls/4/reviews)
         echo '[]'
         exit 0
         ;;
@@ -104,9 +119,61 @@ case "${1:-}" in
 JSON
         exit 0
         ;;
+      repos/*/issues/3/comments)
+        cat <<'JSON'
+[
+  {
+    "id": 3001,
+    "user": {"login": "vg-claude"},
+    "body": "**Claude is working** —— [View job](https://github.com/example/actions/runs/3)\n\n- [ ] Analyze changes\n- [ ] Post review",
+    "created_at": "2026-06-02T08:18:35Z",
+    "updated_at": "2026-06-02T08:20:33Z"
+  }
+]
+JSON
+        exit 0
+        ;;
+      repos/*/issues/4/comments)
+        cat <<'JSON'
+[
+  {
+    "id": 4001,
+    "user": {"login": "vg-claude"},
+    "body": "**Claude is working** —— [View job](https://github.com/example/actions/runs/4)\n\n- [ ] Post review",
+    "created_at": "2026-06-02T08:18:35Z",
+    "updated_at": "2026-06-02T08:20:33Z"
+  }
+]
+JSON
+        exit 0
+        ;;
       repos/*/issues/1/comments|repos/*/issues/1/reactions|repos/*/issues/2/reactions|repos/*/issues/comments/*/reactions)
         echo '[]'
         exit 0
+        ;;
+      repos/*/issues/3/reactions|repos/*/issues/comments/3001/reactions)
+        echo '[]'
+        exit 0
+        ;;
+      repos/*/issues/4/reactions|repos/*/issues/comments/4001/reactions)
+        echo '[]'
+        exit 0
+        ;;
+    esac
+    ;;
+  pr)
+    case "${2:-}" in
+      view)
+        if [[ "${3:-}" == "3" || "${3:-}" == "4" ]]; then
+          echo '{"reviewDecision":"APPROVED"}'
+          exit 0
+        fi
+        ;;
+      checks)
+        if [[ "${3:-}" == "3" || "${3:-}" == "4" ]]; then
+          echo 'Claude Code	pass	0	https://github.com/example/actions/runs/3'
+          exit 0
+        fi
         ;;
     esac
     ;;
@@ -139,6 +206,24 @@ output=$(run_wait 2 1 5 --json)
 assert_eq "$(jq -r .status <<<"$output")" "complete" "Claude comment-only auto-detect completes without reviewers arg"
 assert_eq "$(jq -r .verdict <<<"$output")" "approved" "Claude comment-only auto-detect returns approved verdict"
 assert_eq "$(jq -r '.approved_reviewers | join(",")' <<<"$output")" "claude[bot]" "Claude comment-only auto-detect records reviewer"
+
+cat > "$TMP_ROOT/repo/.env.local" <<EOF
+GIT_HOST_CLI="$FAKE_GITHUB_SH"
+BOT_CHECK_NAME="Claude Code"
+EOF
+output=$(run_wait 3 1 5 --json --reviewers 'vg-claude')
+assert_eq "$(jq -r .status <<<"$output")" "complete" "PR-level approved reviewDecision resolves stale pending sticky"
+assert_eq "$(jq -r .verdict <<<"$output")" "approved" "PR-level approved fallback returns approved verdict"
+assert_eq "$(jq -r .elapsed_seconds <<<"$output")" "0" "PR-level approved fallback skips stale sticky checklist wait"
+assert_contains "$(jq -c '.reviewers[0].signals' <<<"$output")" "pr_review_decision:approved" "PR-level approved fallback records signal"
+
+set +e
+output=$(run_wait 4 1 1 --json --reviewers 'vg-claude')
+code=$?
+set -e
+assert_eq "$code" "0" "PR-level approved fallback does not fail on unresolved terminal threads"
+assert_eq "$(jq -r .status <<<"$output")" "complete" "unresolved threads are terminal"
+assert_eq "$(jq -r .verdict <<<"$output")" "changes" "unresolved threads retain changes verdict"
 
 cat > "$TMP_ROOT/repo/.env.local" <<EOF
 GIT_HOST_CLI="$FAKE_GITHUB_SH"

--- a/skills/orch/workflows/submit-pr.md
+++ b/skills/orch/workflows/submit-pr.md
@@ -121,7 +121,7 @@ BOT_VERDICT=$(echo "$WAIT_RESULT" | jq -r '.verdict')
 PENDING_REVIEWERS=$(echo "$WAIT_RESULT" | jq -r '.pending_reviewers | join(", ")')
 ```
 
-Waits for all configured bot reviewers (`$BOT_REVIEWERS`). Auto-detects if not configured. Max wait 600s. Understands Claude-style (formal review + sticky verdict comment) and Codex-style (reactions + inline threads) signaling. Unrelated automation comments do not block. `status=complete` only when no reviewer is pending. To ignore a reviewer: `--skip "bot-login"` or `BOT_SKIPPED_REVIEWERS`.
+Waits for all configured bot reviewers (`$BOT_REVIEWERS`). Auto-detects if not configured. Max wait 600s. Understands Claude-style (formal review + sticky verdict comment) and Codex-style (reactions + inline threads) signaling. Unrelated automation comments do not block. `status=complete` only when no reviewer is pending. If sticky prose is stale but GitHub reports `reviewDecision=APPROVED`, any configured `BOT_CHECK_NAME` has passed, and no unresolved review threads remain, `bot-review-wait` returns approved with `pr_review_decision:approved` and `pr_threads:clear` signals without waiting on the stale checklist. To ignore a reviewer: `--skip "bot-login"` or `BOT_SKIPPED_REVIEWERS`.
 
 **Route result**:
 


### PR DESCRIPTION
## Summary

- Add a PR-level terminal fallback to `bot-review-wait` for stale pending bot signals after GitHub reports `reviewDecision=APPROVED`.
- Require any configured `BOT_CHECK_NAME` to have passed and require zero unresolved review threads before promoting pending/unknown reviewers to approved.
- Skip stale sticky-checklist waiting after that fallback, and document the behavior for orch workflows.

Closes #356

## Validation

- `bash skills/orch/tests/bot_review_wait.sh`
- `bash skills/orch/tests/run-all.sh`
- `bash skills/github/tests/bot_review_status.sh`
- `bash -n skills/orch/scripts/bot-review-wait skills/orch/tests/bot_review_wait.sh`
- `git diff --check`
