### PR TITLE
[codex] Handle pr-view no-PR and auth timeouts

### DIFF
--- a/skills/github/README.md
+++ b/skills/github/README.md
@@ -28,8 +28,18 @@ CLI wrapper for GitHub API operations used in PR workflows.
 | `GH_BOT_TOKEN` | Bot account GitHub token | Falls back to `gh` auth |
 | `GH_BOT_USERNAME` | Bot username for filtering | `review-bot[bot]` |
 | `GH_ISSUE_PATTERN` | Regex for branch issue extraction | `[A-Z]+-[0-9]+` |
+| `VSTACK_GITHUB_OP_TIMEOUT` | Seconds to wait for `op read` token resolution | `10` |
+| `VSTACK_GITHUB_AUTH_TIMEOUT` | Seconds to wait for `pr-view` auth preflight | `10` |
+| `VSTACK_GITHUB_PR_VIEW_TIMEOUT` | Seconds to wait for `gh pr view` | `30` |
 
 Keep tokens in `.env.local`. Shared non-secret defaults can live in `vstack.settings.toml` under `[env]`; `.env.local` still wins for local overrides.
+
+`pr-view --json ...` emits normal `gh pr view` JSON on success. On failure it
+emits structured JSON on stdout with `status` (`no_pr`, `auth_error`,
+`token_resolution_failed`, `token_resolution_timeout`,
+`token_resolution_unavailable`, `auth_timeout`, `gh_timeout`, or `gh_error`),
+`error`, `detail`, `exit_code`, and `number:null`, then exits nonzero. Stderr
+keeps the raw `gh`/`op` detail for logs.
 
 ## Adding a Command
 

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -22,7 +22,7 @@ CLI wrapper for GitHub API operations used in PR workflows. Provides structured 
 | Command | Purpose |
 |---------|---------|
 | `pr-data <N> [--actionable]` | Get PR with threads, comments, files. `--actionable`: unresolved non-outdated only. |
-| `pr-view [N] [--json FIELDS]` | View PR details (wraps gh pr view) |
+| `pr-view [N] [--json FIELDS]` | View PR details (wraps gh pr view with bounded auth/no-PR errors) |
 | `pr-threads <N> [--unresolved]` | Get thread list/count |
 | `pr-review-status <N> [--baseline-ts TS --baseline-threads N]` | Check review state, determine if action needed |
 | `pr-list-ready [--all] [--format=safe\|table]` | List PRs ready for merge |
@@ -121,14 +121,34 @@ Resolution rules:
 | `GH_BOT_TOKEN` | Bot account GitHub token (in `.env.local`) | Falls back to `gh` auth |
 | `GH_BOT_USERNAME` | Bot username for review/comment filtering | `review-bot[bot]` |
 | `GH_ISSUE_PATTERN` | Regex for issue ID extraction from branches | `[A-Z]+-[0-9]+` |
+| `VSTACK_GITHUB_OP_TIMEOUT` | Seconds to wait for `op read` when resolving `GH_BOT_TOKEN` | `10` |
+| `VSTACK_GITHUB_AUTH_TIMEOUT` | Seconds to wait for `gh auth status` in `pr-view` | `10` |
+| `VSTACK_GITHUB_PR_VIEW_TIMEOUT` | Seconds to wait for `gh pr view` in `pr-view` | `30` |
 
 Bot token supports direct tokens (`ghp_*`, `gho_*`, `ghs_*`, `ghr_*`, `github_pat_*`) and 1Password references (`op://vault/item/field`).
 
 Non-secret GitHub defaults can live in committed `vstack.settings.toml` under `[env]`. Keep tokens in `.env.local`.
 
+### `pr-view` failure contract
+
+`pr-view --json ...` returns normal `gh pr view` JSON on success. On failure it
+prints structured JSON to stdout and exits nonzero:
+
+```json
+{"status":"no_pr","error":"No pull request found for the current branch","detail":"...","exit_code":1,"number":null}
+```
+
+Known `status` values are `no_pr`, `auth_error`, `token_resolution_failed`,
+`token_resolution_timeout`, `token_resolution_unavailable`, `auth_timeout`,
+`gh_timeout`, and `gh_error`. Raw `gh`/`op` detail is also echoed to stderr so
+callers can distinguish no-PR, authentication, token resolution, and timeout
+cases without hanging.
+
 ## Error Handling
 
-- Returns `{"error": "message"}` on stderr with exit code 1
+- Most commands return `{"error": "message"}` on stderr with exit code 1
+- `pr-view --json ...` returns structured failure JSON on stdout so callers can
+  branch on `status` without losing raw stderr detail
 - Automatic retry on rate limiting (3 attempts with backoff)
 - NOT_FOUND errors return clean `{"error": "Not found"}`
 

--- a/skills/github/scripts/commands/pr-view.sh
+++ b/skills/github/scripts/commands/pr-view.sh
@@ -7,6 +7,63 @@ set -euo pipefail
 # shellcheck source=../lib/pr-branch.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib/pr-branch.sh"
 
+run_bounded_capture() {
+    local seconds="$1"
+    local stdout_file="$2"
+    local stderr_file="$3"
+    shift 3
+
+    if command -v timeout &>/dev/null; then
+        timeout "${seconds}s" "$@" >"$stdout_file" 2>"$stderr_file"
+    else
+        "$@" >"$stdout_file" 2>"$stderr_file"
+    fi
+}
+
+json_error() {
+    local status="$1"
+    local message="$2"
+    local detail="${3:-}"
+    local exit_code="${4:-1}"
+
+    jq -nc \
+        --arg status "$status" \
+        --arg error "$message" \
+        --arg detail "$detail" \
+        --argjson exit_code "$exit_code" \
+        '{status: $status, error: $error, detail: $detail, exit_code: $exit_code, number: null}'
+}
+
+emit_error_result() {
+    local status="$1"
+    local message="$2"
+    local detail="${3:-}"
+    local exit_code="${4:-1}"
+
+    printf 'pr-view: %s\n' "$message" >&2
+    if [ -n "$detail" ]; then
+        printf '%s\n' "$detail" >&2
+    fi
+    json_error "$status" "$message" "$detail" "$exit_code"
+}
+
+classify_gh_error() {
+    local detail_lc
+    detail_lc="$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')"
+
+    case "$detail_lc" in
+        *"no pull requests found"*|*"no pull request found"*|*"no open pull requests found"*|*"no pull requests"*found*)
+            printf '%s' "no_pr"
+            ;;
+        *"authentication"*|*"not logged in"*|*"bad credentials"*|*"http 401"*|*"unauthorized"*|*"gh auth login"*)
+            printf '%s' "auth_error"
+            ;;
+        *)
+            printf '%s' "gh_error"
+            ;;
+    esac
+}
+
 show_help() {
     cat << 'EOF'
 View PR details
@@ -19,6 +76,12 @@ Arguments:
 Options:
   --json FIELDS    Output specific fields as JSON (e.g., --json number,title)
   --help           Show this help
+
+Errors:
+  Emits structured JSON with status=no_pr, auth_error, token_resolution_failed,
+  token_resolution_timeout, token_resolution_unavailable, auth_timeout,
+  gh_timeout, or gh_error and exits nonzero. Raw gh/op detail is preserved in
+  stderr and the JSON detail field.
 
 Examples:
   github.sh pr-view              # View PR for current branch
@@ -38,6 +101,10 @@ main() {
             --json)
                 json_fields="$2"
                 shift 2
+                ;;
+            --json=*)
+                json_fields="${1#--json=}"
+                shift
                 ;;
             --help|-h)
                 show_help
@@ -63,13 +130,64 @@ main() {
     [ -n "$json_fields" ] && cmd+=(--json "$json_fields")
     [ ${#extra_args[@]} -gt 0 ] && cmd+=("${extra_args[@]}")
 
+    local auth_out auth_err pr_out pr_err
+    PR_VIEW_TMP_DIR="$(mktemp -d)"
+    trap 'rm -rf "${PR_VIEW_TMP_DIR:-}"' EXIT
+    auth_out="$PR_VIEW_TMP_DIR/auth.out"
+    auth_err="$PR_VIEW_TMP_DIR/auth.err"
+    pr_out="$PR_VIEW_TMP_DIR/pr.out"
+    pr_err="$PR_VIEW_TMP_DIR/pr.err"
+
+    local auth_timeout="${VSTACK_GITHUB_AUTH_TIMEOUT:-10}"
+    local auth_status=0
+    run_bounded_capture "$auth_timeout" "$auth_out" "$auth_err" gh auth status || auth_status=$?
+    if [ "$auth_status" -ne 0 ]; then
+        local auth_detail
+        auth_detail="$(cat "$auth_out" "$auth_err" 2>/dev/null | head -c 1000)"
+        if [ "$auth_status" -eq 124 ]; then
+            emit_error_result "auth_timeout" "GitHub auth preflight timed out after ${auth_timeout}s" "$auth_detail" 124
+            exit 124
+        fi
+        if [ -n "${VSTACK_GITHUB_TOKEN_ERROR_TYPE:-}" ]; then
+            local token_detail="${VSTACK_GITHUB_TOKEN_ERROR_DETAIL:-$auth_detail}"
+            emit_error_result "$VSTACK_GITHUB_TOKEN_ERROR_TYPE" "${VSTACK_GITHUB_TOKEN_ERROR:-GitHub token resolution failed}" "$token_detail" 3
+            exit 3
+        fi
+        emit_error_result "auth_error" "GitHub auth preflight failed" "$auth_detail" 3
+        exit 3
+    fi
+
+    local pr_timeout="${VSTACK_GITHUB_PR_VIEW_TIMEOUT:-30}"
     local output status=0
-    output=$("${cmd[@]}") || status=$?
+    run_bounded_capture "$pr_timeout" "$pr_out" "$pr_err" "${cmd[@]}" || status=$?
+    output="$(cat "$pr_out")"
+    if [ "$status" -ne 0 ]; then
+        local detail error_status message exit_status
+        detail="$(cat "$pr_err" "$pr_out" 2>/dev/null | head -c 1000)"
+        if [ "$status" -eq 124 ]; then
+            emit_error_result "gh_timeout" "gh pr view timed out after ${pr_timeout}s" "$detail" 124
+            exit 124
+        fi
+        error_status="$(classify_gh_error "$detail")"
+        case "$error_status" in
+            no_pr)
+                message="No pull request found for the current branch"
+                exit_status=1
+                ;;
+            auth_error)
+                message="GitHub auth failed during gh pr view"
+                exit_status=3
+                ;;
+            *)
+                message="gh pr view failed"
+                exit_status="$status"
+                ;;
+        esac
+        emit_error_result "$error_status" "$message" "$detail" "$exit_status"
+        exit "$exit_status"
+    fi
     if [ -n "$output" ]; then
         printf '%s\n' "$output"
-    fi
-    if [ "$status" -ne 0 ]; then
-        exit "$status"
     fi
     emit_checks_activity "$json_fields" "$pr_num" "$output"
 }

--- a/skills/github/scripts/github.sh
+++ b/skills/github/scripts/github.sh
@@ -47,14 +47,39 @@ fi
 if [ -z "${GH_TOKEN:-}" ] && [ -n "${GH_BOT_TOKEN:-}" ]; then
     _env_bot_token="$GH_BOT_TOKEN"
     if [[ "$_env_bot_token" == op://* ]] && command -v op &>/dev/null; then
-        _resolved=$(op read "$_env_bot_token" 2>/dev/null || true)
-        [ -n "$_resolved" ] && _env_bot_token="$_resolved"
+        _op_timeout="${VSTACK_GITHUB_OP_TIMEOUT:-10}"
+        _op_status=0
+        if command -v timeout &>/dev/null; then
+            _resolved=$(timeout "${_op_timeout}s" op read "$_env_bot_token" 2>&1) || _op_status=$?
+        else
+            _resolved=$(op read "$_env_bot_token" 2>&1) || _op_status=$?
+        fi
+        if [ "$_op_status" -eq 0 ] && [ -n "$_resolved" ]; then
+            _env_bot_token="$_resolved"
+        else
+            case "$_op_status" in
+                124)
+                    export VSTACK_GITHUB_TOKEN_ERROR_TYPE="token_resolution_timeout"
+                    export VSTACK_GITHUB_TOKEN_ERROR="Timed out resolving GH_BOT_TOKEN 1Password reference after ${_op_timeout}s"
+                    ;;
+                *)
+                    export VSTACK_GITHUB_TOKEN_ERROR_TYPE="token_resolution_failed"
+                    export VSTACK_GITHUB_TOKEN_ERROR="Failed to resolve GH_BOT_TOKEN 1Password reference"
+                    ;;
+            esac
+            if [ -n "$_resolved" ]; then
+                export VSTACK_GITHUB_TOKEN_ERROR_DETAIL="$(printf '%s' "$_resolved" | head -c 500 | tr '\n' ' ')"
+            fi
+        fi
+    elif [[ "$_env_bot_token" == op://* ]]; then
+        export VSTACK_GITHUB_TOKEN_ERROR_TYPE="token_resolution_unavailable"
+        export VSTACK_GITHUB_TOKEN_ERROR="GH_BOT_TOKEN is a 1Password reference but 'op' CLI is not available"
     fi
     if [[ "$_env_bot_token" =~ ^gh[pors]_ ]] || [[ "$_env_bot_token" =~ ^github_pat_ ]]; then
         export GH_TOKEN="$_env_bot_token"
     fi
 fi
-unset _env_root _env_bot_token _resolved _CALLER_GH_TOKEN_SET _CALLER_GH_TOKEN _CALLER_GITHUB_TOKEN_SET _CALLER_GITHUB_TOKEN
+unset _env_root _env_bot_token _resolved _op_timeout _op_status _CALLER_GH_TOKEN_SET _CALLER_GH_TOKEN _CALLER_GITHUB_TOKEN_SET _CALLER_GITHUB_TOKEN
 
 show_help() {
     cat << 'EOF'

--- a/skills/github/tests/pr-view.sh
+++ b/skills/github/tests/pr-view.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# Regression tests for github.sh pr-view bounded auth and no-PR behavior.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../.." && pwd)"
+GITHUB_SH="$REPO_ROOT/skills/github/scripts/github.sh"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local got="$1" want="$2" name="$3" stderr_file="${4:-}"
+  if [[ "$got" == "$want" ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$name" "$want" "$got"
+    if [[ -n "$stderr_file" && -f "$stderr_file" ]]; then
+      sed 's/^/        stderr: /' "$stderr_file"
+    fi
+  fi
+}
+
+assert_contains() {
+  local haystack="$1" needle="$2" name="$3"
+  if grep -qF -- "$needle" <<<"$haystack"; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        wanted substring: %s\n        in: %s\n' "$name" "$needle" "$haystack"
+  fi
+}
+
+mkdir -p "$TMP_ROOT/repo" "$TMP_ROOT/bin"
+git -C "$TMP_ROOT/repo" init -q
+git -C "$TMP_ROOT/repo" config user.email test@example.com
+git -C "$TMP_ROOT/repo" config user.name Test
+
+cat > "$TMP_ROOT/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+  auth)
+    if [[ "${2:-}" == "status" ]]; then
+      if [[ "${STUB_AUTH_SLEEP:-0}" == "1" ]]; then
+        sleep 5
+      fi
+      if [[ "${STUB_AUTH_OK:-1}" == "1" ]]; then
+        echo "Logged in"
+        exit 0
+      fi
+      echo "gh auth failed" >&2
+      exit 1
+    fi
+    ;;
+  pr)
+    if [[ "${2:-}" == "view" ]]; then
+      case "${STUB_PR_MODE:-ok}" in
+        no_pr)
+          echo 'no pull requests found for branch "feature/no-pr"' >&2
+          exit 1
+          ;;
+        auth)
+          echo "HTTP 401: Bad credentials" >&2
+          exit 1
+          ;;
+        hang)
+          sleep 5
+          ;;
+        *)
+          echo '{"number":42,"state":"OPEN"}'
+          exit 0
+          ;;
+      esac
+    fi
+    ;;
+esac
+printf 'unexpected gh call: %s\n' "$*" >&2
+exit 1
+EOF
+chmod +x "$TMP_ROOT/bin/gh"
+
+cat > "$TMP_ROOT/bin/op" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${STUB_OP_MODE:-fail}" in
+  slow)
+    sleep 5
+    ;;
+  ok)
+    echo "ghs_VALIDBOT123"
+    exit 0
+    ;;
+  *)
+    echo "1Password item not available" >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "$TMP_ROOT/bin/op"
+
+run_pr_view() {
+  (cd "$TMP_ROOT/repo" \
+    && PATH="$TMP_ROOT/bin:$PATH" \
+       env -u GH_TOKEN -u GITHUB_TOKEN "$@" "$GITHUB_SH" -C "$TMP_ROOT/repo" pr-view --json number,state)
+}
+
+echo "=== github.sh pr-view ==="
+
+stderr="$TMP_ROOT/no-pr.err"
+set +e
+output=$(run_pr_view STUB_PR_MODE=no_pr 2>"$stderr")
+rc=$?
+set -e
+assert_eq "$rc" "1" "no PR exits nonzero like gh" "$stderr"
+assert_eq "$(jq -r .status <<<"$output")" "no_pr" "no PR emits structured status" "$stderr"
+assert_contains "$(jq -r .detail <<<"$output")" "no pull requests found" "no PR preserves gh detail"
+
+stderr="$TMP_ROOT/auth-timeout.err"
+set +e
+output=$(run_pr_view STUB_AUTH_SLEEP=1 VSTACK_GITHUB_AUTH_TIMEOUT=1 2>"$stderr")
+rc=$?
+set -e
+assert_eq "$rc" "124" "auth preflight timeout exits 124" "$stderr"
+assert_eq "$(jq -r .status <<<"$output")" "auth_timeout" "auth timeout emits structured status" "$stderr"
+
+stderr="$TMP_ROOT/pr-view-timeout.err"
+set +e
+output=$(run_pr_view STUB_PR_MODE=hang VSTACK_GITHUB_PR_VIEW_TIMEOUT=1 2>"$stderr")
+rc=$?
+set -e
+assert_eq "$rc" "124" "gh pr view timeout exits 124" "$stderr"
+assert_eq "$(jq -r .status <<<"$output")" "gh_timeout" "gh timeout emits structured status" "$stderr"
+
+cat > "$TMP_ROOT/repo/.env.local" <<'ENVEOF'
+GH_BOT_TOKEN=op://vault/item/field
+ENVEOF
+
+stderr="$TMP_ROOT/op-fail.err"
+set +e
+output=$(run_pr_view STUB_AUTH_OK=0 STUB_OP_MODE=fail 2>"$stderr")
+rc=$?
+set -e
+assert_eq "$rc" "3" "token resolution failure exits auth code" "$stderr"
+assert_eq "$(jq -r .status <<<"$output")" "token_resolution_failed" "token failure emits structured status" "$stderr"
+
+stderr="$TMP_ROOT/op-timeout.err"
+set +e
+output=$(run_pr_view STUB_AUTH_OK=0 STUB_OP_MODE=slow VSTACK_GITHUB_OP_TIMEOUT=1 2>"$stderr")
+rc=$?
+set -e
+assert_eq "$rc" "3" "token resolution timeout exits auth code" "$stderr"
+assert_eq "$(jq -r .status <<<"$output")" "token_resolution_timeout" "token timeout emits structured status" "$stderr"
+
+rm -f "$TMP_ROOT/repo/.env.local"
+
+stderr="$TMP_ROOT/success.err"
+set +e
+output=$(run_pr_view 2>"$stderr")
+rc=$?
+set -e
+assert_eq "$rc" "0" "successful pr-view exits 0" "$stderr"
+assert_eq "$(jq -r .number <<<"$output")" "42" "successful pr-view preserves gh JSON" "$stderr"
+
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/skills/orch/workflows/submit-pr.md
+++ b/skills/orch/workflows/submit-pr.md
@@ -42,7 +42,29 @@ fi
 
 2. **Check for existing PR**:
    ```bash
-   PR_NUM=$(.agents/skills/github/scripts/github.sh -C "[WORKTREE_PATH]" pr-view --json number,state 2>/dev/null | jq -r .number)
+   mkdir -p tmp
+   PR_VIEW_RC=0
+   PR_VIEW_JSON=$(.agents/skills/github/scripts/github.sh -C "[WORKTREE_PATH]" pr-view --json number,state 2>tmp/pr-view.err) || PR_VIEW_RC=$?
+   if [ "$PR_VIEW_RC" -eq 0 ]; then
+     PR_NUM=$(echo "$PR_VIEW_JSON" | jq -r '.number // empty')
+   else
+     PR_VIEW_STATUS=$(echo "$PR_VIEW_JSON" | jq -r '.status // "error"' 2>/dev/null || echo "error")
+     case "$PR_VIEW_STATUS" in
+       no_pr)
+         PR_NUM=""
+         ;;
+       auth_error|token_resolution_failed|token_resolution_timeout|token_resolution_unavailable|auth_timeout|gh_timeout|gh_error)
+         echo "PR lookup failed ($PR_VIEW_STATUS): $(echo "$PR_VIEW_JSON" | jq -r '.error // empty')" >&2
+         cat tmp/pr-view.err >&2
+         exit "$PR_VIEW_RC"
+         ;;
+       *)
+         echo "PR lookup failed with unparseable output" >&2
+         cat tmp/pr-view.err >&2
+         exit "$PR_VIEW_RC"
+         ;;
+     esac
+   fi
    ```
 
 3. **Build PR body** from current workflow state using the template below (omit empty sections).

--- a/vstack.settings.toml.example
+++ b/vstack.settings.toml.example
@@ -78,6 +78,15 @@ GH_ISSUE_PATTERN = "[A-Z]+-[0-9]+"
 GH_VERIFY_CMD = "make verify"
 # Used by: github (`pr-cross-check --verify`).
 
+VSTACK_GITHUB_OP_TIMEOUT = "10"
+# Used by: github (`pr-view` / bot token 1Password resolution).
+
+VSTACK_GITHUB_AUTH_TIMEOUT = "10"
+# Used by: github (`pr-view` auth preflight).
+
+VSTACK_GITHUB_PR_VIEW_TIMEOUT = "30"
+# Used by: github (`pr-view`).
+
 # SECOND OPINION
 
 SECOND_OPINION_TARGET = "codex"


### PR DESCRIPTION
## Summary
- Add bounded token, auth, and `gh pr view` execution for `github.sh pr-view`.
- Return structured failure JSON for no-PR, auth, token-resolution, and timeout cases while preserving raw detail on stderr.
- Update the submit workflow to branch safely on `no_pr` before PR creation.

Closes #355

## Tests
- `bash skills/github/tests/pr-view.sh`
- `bash skills/github/tests/sticky-comment-cli.test.sh`
- `bash skills/github/tests/bot_review_status.sh`
- `bash skills/github/tests/git-diff-summary-risk-flags.test.sh`
- `cd cli && cargo test`
- `git diff --check`
- `git diff --cached --check`