### PR TITLE
[codex] Make GitHub token loaders env-first

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -9,6 +9,11 @@
 #
 # `.env.local` wins so existing projects keep working, but committed settings
 # should move to `vstack.settings.toml` whenever they are not secrets.
+#
+# Launch-time secret injection is supported: when GH_TOKEN, GITHUB_TOKEN,
+# GH_BOT_TOKEN, or LINEAR_API_KEY are already resolved in the process
+# environment, vstack helpers keep those values and do not resolve matching
+# `op://` references from local files.
 
 # LINEAR
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ Portable skill scripts load runtime settings in this order:
 
 Use `vstack.settings.toml` for non-sensitive project defaults that should be committed, such as worktree paths, issue regexes, bot usernames, default Linear team names, and second-opinion command defaults. Keep `.env.local` for secrets, tokens, API keys, private URLs, signing keys, and personal overrides. See [`vstack.settings.toml.example`](vstack.settings.toml.example) and [`.env.local.example`](.env.local.example).
 
+Secret values may also be injected by the parent process at launch time. GitHub and Linear helpers preserve already-resolved `GH_TOKEN`, `GITHUB_TOKEN`, `GH_BOT_TOKEN`, and `LINEAR_API_KEY` values before reading local files or resolving `op://` references.
+
 ## Supported Tools
 
 | Tool | Notes |

--- a/skills/github/README.md
+++ b/skills/github/README.md
@@ -25,14 +25,15 @@ CLI wrapper for GitHub API operations used in PR workflows.
 
 | Variable | Purpose | Default |
 |----------|---------|---------|
-| `GH_BOT_TOKEN` | Bot account GitHub token | Falls back to `gh` auth |
+| `GH_TOKEN` / `GITHUB_TOKEN` | Pre-resolved GitHub token from the parent process | Falls back to `gh` auth |
+| `GH_BOT_TOKEN` | Bot account GitHub token | Falls back to `GH_TOKEN` / `GITHUB_TOKEN` for helper auth, then `gh` auth |
 | `GH_BOT_USERNAME` | Bot username for filtering | `review-bot[bot]` |
 | `GH_ISSUE_PATTERN` | Regex for branch issue extraction | `[A-Z]+-[0-9]+` |
 | `VSTACK_GITHUB_OP_TIMEOUT` | Seconds to wait for `op read` token resolution | `10` |
 | `VSTACK_GITHUB_AUTH_TIMEOUT` | Seconds to wait for `pr-view` auth preflight | `10` |
 | `VSTACK_GITHUB_PR_VIEW_TIMEOUT` | Seconds to wait for `gh pr view` | `30` |
 
-Keep tokens in `.env.local`. Shared non-secret defaults can live in `vstack.settings.toml` under `[env]`; `.env.local` still wins for local overrides.
+Keep tokens in `.env.local` unless the parent process injects already-resolved secrets at launch. Token loaders are env-first: resolved `GH_TOKEN`, `GITHUB_TOKEN`, or `GH_BOT_TOKEN` values are used before project files are read, and `op read` is only called when the final selected value is an `op://` reference. Bot-token operations still prefer an explicit `GH_BOT_TOKEN` over user-token variables. Shared non-secret defaults can live in `vstack.settings.toml` under `[env]`; `.env.local` still wins for local overrides.
 
 `pr-view --json ...` emits normal `gh pr view` JSON on success. On failure it
 emits structured JSON on stdout with `status` (`no_pr`, `auth_error`,

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -118,7 +118,8 @@ Resolution rules:
 
 | Variable | Purpose | Default |
 |----------|---------|---------|
-| `GH_BOT_TOKEN` | Bot account GitHub token (in `.env.local`) | Falls back to `gh` auth |
+| `GH_TOKEN` / `GITHUB_TOKEN` | Pre-resolved GitHub token from the parent process | Falls back to `gh` auth |
+| `GH_BOT_TOKEN` | Bot account GitHub token (in `.env.local` or parent env) | Falls back to `GH_TOKEN` / `GITHUB_TOKEN` for helper auth, then `gh` auth |
 | `GH_BOT_USERNAME` | Bot username for review/comment filtering | `review-bot[bot]` |
 | `GH_ISSUE_PATTERN` | Regex for issue ID extraction from branches | `[A-Z]+-[0-9]+` |
 | `VSTACK_GITHUB_OP_TIMEOUT` | Seconds to wait for `op read` when resolving `GH_BOT_TOKEN` | `10` |
@@ -127,7 +128,7 @@ Resolution rules:
 
 Bot token supports direct tokens (`ghp_*`, `gho_*`, `ghs_*`, `ghr_*`, `github_pat_*`) and 1Password references (`op://vault/item/field`).
 
-Non-secret GitHub defaults can live in committed `vstack.settings.toml` under `[env]`. Keep tokens in `.env.local`.
+Non-secret GitHub defaults can live in committed `vstack.settings.toml` under `[env]`. Keep tokens in `.env.local` unless the parent process injects already-resolved values. GitHub helpers are env-first: resolved `GH_TOKEN`, `GITHUB_TOKEN`, or `GH_BOT_TOKEN` values are used before project files are read, and `op read` runs only when the final selected value is still an `op://` reference. Bot-token operations still prefer an explicit `GH_BOT_TOKEN` over user-token variables.
 
 ### `pr-view` failure contract
 

--- a/skills/github/scripts/github.sh
+++ b/skills/github/scripts/github.sh
@@ -26,6 +26,8 @@ _CALLER_GH_TOKEN_SET="${GH_TOKEN+x}"
 _CALLER_GH_TOKEN="${GH_TOKEN:-}"
 _CALLER_GITHUB_TOKEN_SET="${GITHUB_TOKEN+x}"
 _CALLER_GITHUB_TOKEN="${GITHUB_TOKEN:-}"
+_CALLER_GH_BOT_TOKEN_SET="${GH_BOT_TOKEN+x}"
+_CALLER_GH_BOT_TOKEN="${GH_BOT_TOKEN:-}"
 
 _env_root=""
 if [ -n "$WORK_DIR" ]; then
@@ -43,6 +45,14 @@ if [ -n "$_CALLER_GH_TOKEN_SET" ]; then
 fi
 if [ -n "$_CALLER_GITHUB_TOKEN_SET" ]; then
     export GITHUB_TOKEN="$_CALLER_GITHUB_TOKEN"
+fi
+if [ -n "$_CALLER_GH_BOT_TOKEN_SET" ]; then
+    export GH_BOT_TOKEN="$_CALLER_GH_BOT_TOKEN"
+fi
+if [ -z "$_CALLER_GH_TOKEN" ] && [ -z "$_CALLER_GITHUB_TOKEN" ] && [ -n "$_CALLER_GH_BOT_TOKEN_SET" ]; then
+    if [[ "$_CALLER_GH_BOT_TOKEN" =~ ^gh[pors]_ ]] || [[ "$_CALLER_GH_BOT_TOKEN" =~ ^github_pat_ ]]; then
+        export GH_TOKEN="$_CALLER_GH_BOT_TOKEN"
+    fi
 fi
 if [ -z "${GH_TOKEN:-}" ] && [ -n "${GH_BOT_TOKEN:-}" ]; then
     _env_bot_token="$GH_BOT_TOKEN"
@@ -79,7 +89,7 @@ if [ -z "${GH_TOKEN:-}" ] && [ -n "${GH_BOT_TOKEN:-}" ]; then
         export GH_TOKEN="$_env_bot_token"
     fi
 fi
-unset _env_root _env_bot_token _resolved _op_timeout _op_status _CALLER_GH_TOKEN_SET _CALLER_GH_TOKEN _CALLER_GITHUB_TOKEN_SET _CALLER_GITHUB_TOKEN
+unset _env_root _env_bot_token _resolved _op_timeout _op_status _CALLER_GH_TOKEN_SET _CALLER_GH_TOKEN _CALLER_GITHUB_TOKEN_SET _CALLER_GITHUB_TOKEN _CALLER_GH_BOT_TOKEN_SET _CALLER_GH_BOT_TOKEN
 
 show_help() {
     cat << 'EOF'

--- a/skills/github/scripts/lib/github-api.sh
+++ b/skills/github/scripts/lib/github-api.sh
@@ -283,20 +283,58 @@ parse_format_arg() {
     echo "${remaining_args[@]:-}"
 }
 
-# Load and validate bot token from project config/env
+# Check whether a value is already a concrete GitHub token. `op://` references
+# are intentionally not considered resolved.
+is_resolved_github_token() {
+    local token="${1:-}"
+    [[ -n "$token" && "$token" != op://* ]] || return 1
+    [[ "$token" =~ ^gh[pors]_ ]] || [[ "$token" =~ ^github_pat_ ]]
+}
+
+select_github_auth_token() {
+    local token
+    for token in "${GH_BOT_TOKEN:-}" "${GH_TOKEN:-}" "${GITHUB_TOKEN:-}"; do
+        if is_resolved_github_token "$token"; then
+            printf '%s' "$token"
+            return 0
+        fi
+    done
+
+    for token in "${GH_BOT_TOKEN:-}" "${GH_TOKEN:-}" "${GITHUB_TOKEN:-}"; do
+        if [[ "$token" == op://* ]]; then
+            printf '%s' "$token"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+# Load and validate a GitHub auth token from process env or project config/env.
 # Supports direct tokens (ghp_*, gho_*, ghs_*, ghr_*) and 1Password references (op://...)
 # Returns: token string if valid, empty string if not configured/invalid
 # Outputs: diagnostic messages to stderr
 load_bot_token() {
     local token=""
 
-    # Load .env, public settings, then .env.local. .env.local still wins.
-    local lib_dir
-    lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-    # shellcheck source=vstack-env.sh
-    source "$lib_dir/vstack-env.sh"
-    vstack_load_project_env "$PROJECT_ROOT"
-    token="${GH_BOT_TOKEN:-}"
+    if ! token=$(select_github_auth_token); then
+        # Load .env, public settings, then .env.local only when the process env
+        # did not already carry a resolved GitHub token.
+        local lib_dir
+        lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+        # shellcheck source=vstack-env.sh
+        source "$lib_dir/vstack-env.sh"
+        vstack_load_project_env "$PROJECT_ROOT"
+        token=$(select_github_auth_token || true)
+    elif [[ "$token" == op://* ]]; then
+        # An unresolved inherited token can still be overridden by project env.
+        local lib_dir
+        lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+        # shellcheck source=vstack-env.sh
+        source "$lib_dir/vstack-env.sh"
+        vstack_load_project_env "$PROJECT_ROOT"
+        token=$(select_github_auth_token || true)
+    fi
 
     # Empty token - not configured
     if [ -z "$token" ]; then
@@ -323,14 +361,13 @@ load_bot_token() {
     # Validate GitHub token format
     # Classic: ghp_, gho_, ghs_, ghr_
     # Fine-grained: github_pat_
-    if [[ "$token" =~ ^gh[pors]_ ]] || [[ "$token" =~ ^github_pat_ ]]; then
+    if is_resolved_github_token "$token"; then
         echo "$token"
         return 0
     fi
 
     # Invalid format
     echo "Warning: GH_BOT_TOKEN has invalid format (expected ghp_*, gho_*, ghs_*, ghr_*, or github_pat_*)" >&2
-    echo "  Current value starts with: ${token:0:4}..." >&2
     echo "  Fix: Update .env.local with a valid GitHub token" >&2
     return 0
 }

--- a/skills/github/tests/env-first-auth.sh
+++ b/skills/github/tests/env-first-auth.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Regression tests for env-first GitHub token loading.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../.." && pwd)"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local got="$1" want="$2" name="$3"
+  if [[ "$got" == "$want" ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$name" "$want" "$got"
+  fi
+}
+
+assert_file_missing() {
+  local path="$1" name="$2"
+  if [[ ! -e "$path" ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        unexpected file: %s\n' "$name" "$path"
+  fi
+}
+
+mkdir -p "$TMP_ROOT/repo" "$TMP_ROOT/bin"
+git -C "$TMP_ROOT/repo" init -q
+
+cat > "$TMP_ROOT/bin/op" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'op called: %s\n' "\$*" >>"$TMP_ROOT/op.calls"
+if [[ "\${1:-}" == "read" && "\${2:-}" == "op://vault/github/bot" ]]; then
+  printf '%s\n' 'ghs_RESOLVED123'
+  exit 0
+fi
+exit 1
+EOF
+chmod +x "$TMP_ROOT/bin/op"
+
+cat > "$TMP_ROOT/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+_token_ok() {
+  [[ "${GH_TOKEN:-}" == "ghs_ROUTERBOT123" ]]
+}
+
+case "${1:-}" in
+  auth)
+    if [[ "${2:-}" == "status" ]]; then
+      _token_ok || { echo "auth failed" >&2; exit 1; }
+      echo "Logged in"
+      exit 0
+    fi
+    ;;
+  pr)
+    if [[ "${2:-}" == "view" ]]; then
+      _token_ok || { echo "HTTP 401: Bad credentials" >&2; exit 1; }
+      echo '{"number":42,"state":"OPEN"}'
+      exit 0
+    fi
+    ;;
+esac
+printf 'unexpected gh call: %s\n' "$*" >&2
+exit 1
+EOF
+chmod +x "$TMP_ROOT/bin/gh"
+
+load_token() {
+  (cd "$TMP_ROOT/repo" && PATH="$TMP_ROOT/bin:$PATH" env "$@" bash -c '
+    set -euo pipefail
+    source "'"$REPO_ROOT"'/skills/github/scripts/lib/github-api.sh"
+    load_bot_token
+  ')
+}
+
+echo "=== github env-first auth loading ==="
+
+cat > "$TMP_ROOT/repo/.env.local" <<'ENVEOF'
+GH_BOT_TOKEN=op://vault/github/bot
+ENVEOF
+rm -f "$TMP_ROOT/op.calls"
+output=$(load_token GH_TOKEN=ghp_ENV123)
+assert_eq "$output" "ghp_ENV123" "resolved GH_TOKEN wins over .env.local"
+assert_file_missing "$TMP_ROOT/op.calls" "resolved GH_TOKEN does not trigger op"
+
+rm -f "$TMP_ROOT/op.calls"
+output=$(load_token GITHUB_TOKEN=gho_ENV456)
+assert_eq "$output" "gho_ENV456" "resolved GITHUB_TOKEN wins over .env.local"
+assert_file_missing "$TMP_ROOT/op.calls" "resolved GITHUB_TOKEN does not trigger op"
+
+rm -f "$TMP_ROOT/op.calls"
+output=$(load_token GH_BOT_TOKEN=ghs_ENVBOT789)
+assert_eq "$output" "ghs_ENVBOT789" "resolved GH_BOT_TOKEN wins before project files"
+assert_file_missing "$TMP_ROOT/op.calls" "resolved GH_BOT_TOKEN does not trigger op"
+
+rm -f "$TMP_ROOT/op.calls"
+output=$(load_token GH_TOKEN=ghp_USER123 GH_BOT_TOKEN=ghs_BOT123)
+assert_eq "$output" "ghs_BOT123" "explicit GH_BOT_TOKEN wins for bot-token loader"
+assert_file_missing "$TMP_ROOT/op.calls" "explicit GH_BOT_TOKEN with GH_TOKEN does not trigger op"
+
+rm -f "$TMP_ROOT/op.calls"
+output=$(cd "$TMP_ROOT/repo" && PATH="$TMP_ROOT/bin:$PATH" GH_BOT_TOKEN=ghs_ROUTERBOT123 "$REPO_ROOT/skills/github/scripts/github.sh" -C "$TMP_ROOT/repo" bot-token --format=text)
+assert_eq "$output" "configured" "github.sh router preserves resolved GH_BOT_TOKEN"
+assert_file_missing "$TMP_ROOT/op.calls" "github.sh router does not trigger op for resolved GH_BOT_TOKEN"
+
+cat > "$TMP_ROOT/repo/.env.local" <<'ENVEOF'
+GH_TOKEN=op://vault/github/user
+GH_BOT_TOKEN=op://vault/github/bot
+ENVEOF
+rm -f "$TMP_ROOT/op.calls"
+output=$(cd "$TMP_ROOT/repo" && PATH="$TMP_ROOT/bin:$PATH" GH_BOT_TOKEN=ghs_ROUTERBOT123 "$REPO_ROOT/skills/github/scripts/github.sh" -C "$TMP_ROOT/repo" pr-view --json number,state)
+assert_eq "$(jq -r .number <<<"$output")" "42" "github.sh router uses inherited GH_BOT_TOKEN over local GH_TOKEN"
+assert_file_missing "$TMP_ROOT/op.calls" "github.sh router avoids op when inherited GH_BOT_TOKEN is resolved"
+
+rm -f "$TMP_ROOT/op.calls"
+output=$(load_token)
+assert_eq "$output" "ghs_RESOLVED123" "project op reference resolves when no env token exists"
+assert_eq "$(wc -l <"$TMP_ROOT/op.calls")" "1" "project op reference calls op once"
+
+cat > "$TMP_ROOT/repo/.env.local" <<'ENVEOF'
+GH_BOT_TOKEN=ghs_FILEBOT123
+ENVEOF
+rm -f "$TMP_ROOT/op.calls"
+output=$(load_token GH_TOKEN=op://vault/github/main)
+assert_eq "$output" "ghs_FILEBOT123" "unresolved env token allows direct project token"
+assert_file_missing "$TMP_ROOT/op.calls" "direct project token avoids op for inherited op reference"
+
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/skills/orch/DEVELOPMENT.md
+++ b/skills/orch/DEVELOPMENT.md
@@ -7,9 +7,11 @@ Implementation details and contributor notes. End-user setup: [`README.md`](./RE
 `bot-review-wait` and `ci-wait` share `scripts/lib/gh-auth.sh::orch_sanitize_gh_env`. Four-step ladder:
 
 1. **Sanitize.** Env tokens set but `gh auth status` fails → try `env -u GH_TOKEN -u GITHUB_TOKEN gh auth status`. If that succeeds, warn on stderr and unset.
-2. **Bot-token load.** `GH_TOKEN` empty → load `GH_BOT_TOKEN` from `.env`, `vstack.settings.toml`, then `.env.local`. `op://` references resolve via `op read`.
+2. **Bot-token load.** `GH_TOKEN` empty → first use already-resolved `GH_TOKEN`, `GITHUB_TOKEN`, or `GH_BOT_TOKEN` from process env. Only if those are missing or still `op://` references, load `.env`, `vstack.settings.toml`, then `.env.local`. `op://` references resolve via `op read` only after the final token source is selected.
 3. **Fallback retry.** Auth still fails → drop env tokens, retry bot-token load. Recovers when project config/secrets have a valid token despite broken keyring.
 4. **Hard fail.** No path works → exit `3` with diagnostic. Callers do not poll against empty output.
+
+The `op` CLI service-account/token setup is intentionally outside orch. Launchers may inject resolved secrets before starting Codex, Claude, or Pi; orch preserves those values instead of clobbering them with local `op://` references.
 
 ## Bot Review Terminal Fallback
 

--- a/skills/orch/README.md
+++ b/skills/orch/README.md
@@ -48,8 +48,8 @@ Set non-sensitive values in `vstack.settings.toml` under `[env]`. Existing `.env
 |----------|---------|---------|
 | `ORCH_STATE_DIR` | State file directory | `tmp` |
 | `ORCH_CACHE_DIR` | Parallel-group safety cache | `.cache/orch` |
-| `GH_TOKEN` | Main/user GitHub token | current `gh` auth |
-| `GH_BOT_TOKEN` | Bot GitHub token for worktree auth | current `gh` auth |
+| `GH_TOKEN` / `GITHUB_TOKEN` | Pre-resolved GitHub token from the parent process | current `gh` auth |
+| `GH_BOT_TOKEN` | Bot GitHub token for worktree auth | `GH_TOKEN` / `GITHUB_TOKEN`, then current `gh` auth |
 | `GH_ISSUE_PATTERN` | Issue ID regex for branch names | `[A-Z]+-[0-9]+` |
 | `BOT_REVIEWERS` | Comma-separated review bot usernames | auto-detect |
 | `BOT_CHECK_NAME` | CI check name for early review detection and PR-level approved fallback gating | — |
@@ -57,6 +57,8 @@ Set non-sensitive values in `vstack.settings.toml` under `[env]`. Existing `.env
 `bot-review-wait` also handles stale pending bot prose: when GitHub reports `reviewDecision=APPROVED`, the configured bot check has passed if one is set, and no unresolved review threads remain, it returns a terminal approved result instead of continuing to poll the stale status comment or checklist.
 
 See [`DEVELOPMENT.md`](./DEVELOPMENT.md) for GitHub auth fallback details and the test runner.
+
+GitHub auth helpers are env-first. If launch-time configuration already provides a resolved `GH_TOKEN`, `GITHUB_TOKEN`, or `GH_BOT_TOKEN`, orch keeps it and does not re-read `op://` references from `.env.local` for GitHub auth. Service-account setup for the `op` CLI remains local environment configuration.
 
 ## Helper Scripts
 

--- a/skills/orch/SKILL.md
+++ b/skills/orch/SKILL.md
@@ -153,7 +153,7 @@ Follow ALL [Workflow Execution](#workflow-execution) rules for every command.
 
 `session-init --json` reports worktree Linear auth as the structured `linear_auth` object from `linear auth-check`. `linear_auth.error = "not installed"` is reserved for a missing Linear skill command; API key, 1Password, and API failures keep their original auth-check diagnostic.
 
-Both `bot-review-wait` and `ci-wait` share `scripts/lib/gh-auth.sh` for a four-step auth-resolution ladder — see `DEVELOPMENT.md` for the full ladder description. Exit `3` on hard auth failure; callers treat both scripts consistently.
+Both `bot-review-wait` and `ci-wait` share `scripts/lib/gh-auth.sh` for a four-step auth-resolution ladder — see `DEVELOPMENT.md` for the full ladder description. GitHub auth is env-first: already-resolved `GH_TOKEN`, `GITHUB_TOKEN`, or `GH_BOT_TOKEN` values from the parent process win before local files are read, and `op read` is only used for the final selected `op://` reference. Exit `3` on hard auth failure; callers treat both scripts consistently.
 
 ### `workflow-state` actions
 

--- a/skills/orch/scripts/lib/gh-auth.sh
+++ b/skills/orch/scripts/lib/gh-auth.sh
@@ -16,12 +16,13 @@
 #      the current `gh auth status` already succeeds. Always returns 0.
 #
 #   2. orch_load_env_bot_token <project_root>
-#      Look for `GH_BOT_TOKEN` after loading `<project_root>/.env`,
+#      Prefer already-resolved GH_TOKEN, GITHUB_TOKEN, or GH_BOT_TOKEN from the
+#      process environment. Only when those are missing or still `op://`
+#      references, load `<project_root>/.env`,
 #      `<project_root>/vstack.settings.toml`, then `<project_root>/.env.local`.
-#      Resolve `op://`
-#      references via `op read` when available. If the resolved value
-#      looks like a GitHub token, export it as GH_TOKEN and return 0.
-#      Returns 1 if nothing valid was found.
+#      Resolve `op://` references via `op read` only for the final selected
+#      value. If the resolved value looks like a GitHub token, export it as
+#      GH_TOKEN and return 0. Returns 1 if nothing valid was found.
 #
 #      Implemented as a subshell `source` so unrelated `.env` variables
 #      do not leak into the caller. Mirrors skills/github/scripts/github.sh.
@@ -39,24 +40,52 @@ orch_sanitize_gh_env() {
   return 0
 }
 
+orch_is_resolved_github_token() {
+  local token="${1:-}"
+  [[ -n "$token" && "$token" != op://* ]] || return 1
+  [[ "$token" =~ ^gh[pors]_ ]] || [[ "$token" =~ ^github_pat_ ]]
+}
+
+orch_select_github_auth_token() {
+  local token
+  for token in "${GH_TOKEN:-}" "${GITHUB_TOKEN:-}" "${GH_BOT_TOKEN:-}"; do
+    if orch_is_resolved_github_token "$token"; then
+      printf '%s' "$token"
+      return 0
+    fi
+  done
+
+  for token in "${GH_TOKEN:-}" "${GITHUB_TOKEN:-}" "${GH_BOT_TOKEN:-}"; do
+    if [[ "$token" == op://* ]]; then
+      printf '%s' "$token"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
 orch_load_env_bot_token() {
   local project_root="${1:?orch_load_env_bot_token: project_root required}"
   local resolved bot_token
-  bot_token=$(
-    set +u
-    local lib_dir
-    lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-    # shellcheck disable=SC1091
-    source "$lib_dir/vstack-env.sh" >/dev/null 2>&1 || true
-    vstack_load_project_env "$project_root" >/dev/null 2>&1 || true
-    printf '%s' "${GH_BOT_TOKEN:-}"
-  )
+  bot_token="$(orch_select_github_auth_token || true)"
+  if [[ -z "$bot_token" || "$bot_token" == op://* ]]; then
+    bot_token=$(
+      set +u
+      local lib_dir
+      lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+      # shellcheck disable=SC1091
+      source "$lib_dir/vstack-env.sh" >/dev/null 2>&1 || true
+      vstack_load_project_env "$project_root" >/dev/null 2>&1 || true
+      orch_select_github_auth_token || true
+    )
+  fi
   [[ -n "$bot_token" ]] || return 1
   if [[ "$bot_token" == op://* ]] && command -v op >/dev/null 2>&1; then
     resolved=$(op read "$bot_token" 2>/dev/null || true)
     [[ -n "$resolved" ]] && bot_token="$resolved"
   fi
-  if [[ "$bot_token" =~ ^gh[pors]_ ]] || [[ "$bot_token" =~ ^github_pat_ ]]; then
+  if orch_is_resolved_github_token "$bot_token"; then
     export GH_TOKEN="$bot_token"
     return 0
   fi

--- a/skills/orch/tests/ci_wait.sh
+++ b/skills/orch/tests/ci_wait.sh
@@ -8,6 +8,8 @@
 #                                        -> exit 3 with "no working" diagnostic
 #   4. stale GH_TOKEN + broken keyring + valid .env.local GH_BOT_TOKEN
 #                                        -> bot-token fallback recovers
+#   5. broken keyring + inherited valid GH_BOT_TOKEN + .env.local op:// token
+#                                        -> inherited token wins, no op read
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -124,6 +126,14 @@ exit 1
 EOF
 chmod +x "$TMP_ROOT/bin/gh"
 
+cat > "$TMP_ROOT/bin/op" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'op called: %s\n' "\$*" >>"$TMP_ROOT/op.calls"
+exit 1
+EOF
+chmod +x "$TMP_ROOT/bin/op"
+
 # Run ci-wait via the .agents symlink, exactly how it's invoked in
 # production. `env "$@"` injects test-controlled env tokens / stub flags.
 run_wait() {
@@ -175,6 +185,26 @@ rc=$?
 set -e
 assert_eq "$rc" "0" "case4: .env.local GH_BOT_TOKEN recovers" "$stderr"
 assert_contains "$output" "CI passed" "case4: ci-wait reaches CI passed via bot-token fallback"
+rm -f "$TMP_ROOT/repo/.env.local"
+
+# Case 5: process env already has a resolved bot token; project op reference
+# should not be read.
+cat > "$TMP_ROOT/repo/.env.local" <<'ENVEOF'
+export GH_BOT_TOKEN=op://vault/github/bot
+ENVEOF
+rm -f "$TMP_ROOT/op.calls"
+stderr="$TMP_ROOT/case5.err"
+set +e
+output=$(run_wait GH_BOT_TOKEN=ghs_ENVBOT123 STUB_GH_DENY_KEYRING=1 STUB_GH_VALID_TOKEN=ghs_ENVBOT123 2>"$stderr")
+rc=$?
+set -e
+assert_eq "$rc" "0" "case5: inherited GH_BOT_TOKEN recovers without project secret load" "$stderr"
+assert_contains "$output" "CI passed" "case5: ci-wait reaches CI passed via inherited bot token"
+if [[ -e "$TMP_ROOT/op.calls" ]]; then
+  assert_eq "$(cat "$TMP_ROOT/op.calls")" "" "case5: inherited GH_BOT_TOKEN does not call op" "$stderr"
+else
+  assert_eq "missing" "missing" "case5: inherited GH_BOT_TOKEN does not call op"
+fi
 rm -f "$TMP_ROOT/repo/.env.local"
 
 echo


### PR DESCRIPTION
Closes #359

## Summary

- Make GitHub token resolution env-first for the shared GitHub helper and orch auth helper.
- Preserve already-injected `GH_BOT_TOKEN` in `github.sh` so local `op://` references do not clobber resolved launch-time secrets.
- Add regression coverage for `GH_TOKEN`, `GITHUB_TOKEN`, `GH_BOT_TOKEN`, router behavior, and project `op://` fallback.
- Document launch-time secret injection and the local nature of `op` service-account setup.

## Validation

- `bash skills/github/tests/env-first-auth.sh`
- `bash skills/orch/tests/run-all.sh`
- `bash skills/github/tests/bot_review_status.sh`
- `bash skills/github/tests/sticky-comment-cli.test.sh`
- `bash skills/github/tests/git-diff-summary-risk-flags.test.sh`
- `git diff --check`