### PR TITLE
fix(issue-369): avoid Codex-hostile workflow snippets

### DIFF
--- a/skills/dev/workflows/dev-fix.md
+++ b/skills/dev/workflows/dev-fix.md
@@ -74,7 +74,8 @@ Use visual QA skills to validate that the fix renders correctly. Focus on what t
 ### 4.2 Commit
 
 ```bash
-git add -A && git commit -m "[PREFIX]([ISSUE_ID]): [MESSAGE]"
+git add -A
+git commit -m "[PREFIX]([ISSUE_ID]): [MESSAGE]"
 ```
 
 | Source | Commit Message |

--- a/skills/dev/workflows/dev-implement.md
+++ b/skills/dev/workflows/dev-implement.md
@@ -75,7 +75,8 @@ Ad-hoc: use delegation text as source of truth, skip tracker writes.
 
 ```bash
 # Linear
-.agents/skills/linear/scripts/linear.sh cache issues get [ISSUE_ID] | jq -r '.description'
+.agents/skills/linear/scripts/linear.sh cache issues get [ISSUE_ID]
+# Read `.description` from the JSON output.
 
 # GitHub
 gh issue view [N] --repo [OWNER/REPO] --json body --jq .body
@@ -375,8 +376,9 @@ Then post it:
 
 Check blocking relations:
 ```bash
-.agents/skills/linear/scripts/linear.sh cache issues get [ISSUE_ID] | jq '.blocks'
+.agents/skills/linear/scripts/linear.sh cache issues get [ISSUE_ID]
 ```
+Read `.blocks` from the JSON output.
 
 Post a handoff comment to each downstream issue **only if** this work changed an API, interface, file, or contract the downstream issue depends on:
 ```bash

--- a/skills/orch/README.md
+++ b/skills/orch/README.md
@@ -64,7 +64,11 @@ GitHub auth helpers are env-first. If launch-time configuration already provides
 
 Use `skills/orch/scripts/resolve-base-branch [WORKTREE_PATH]` to print the base branch for a worktree. It honors `WORKTREE_DEFAULT_BRANCH`, then `origin/HEAD`, and falls back to `main`.
 
+Use `skills/orch/scripts/git-context branch|head|issue-from-branch|repo-root|common-root|timestamp [WORKTREE_PATH]` when workflow guidance needs git-derived values without inline command substitution, pipelines, or `cd && ...` chains.
+
 Use `skills/orch/scripts/workflow-state exists --json ISSUE_ID` when a workflow needs structured existence status without relying on shell exit-code capture.
+
+Use `skills/orch/scripts/workflow-state set-git-head ISSUE_ID FIELD [WORKTREE_PATH]` and `set-now ISSUE_ID FIELD` for common state writes that would otherwise require nested `$(git ...)` or `$(date ...)` snippets.
 
 Use `skills/orch/scripts/review-init` to initialize standalone review context and print branch, worktree, issue ID, state path, and whether state was created as JSON.
 

--- a/skills/orch/README.md
+++ b/skills/orch/README.md
@@ -70,6 +70,8 @@ Use `skills/orch/scripts/workflow-state exists --json ISSUE_ID` when a workflow 
 
 Use `skills/orch/scripts/workflow-state set-git-head ISSUE_ID FIELD [WORKTREE_PATH]` and `set-now ISSUE_ID FIELD` for common state writes that would otherwise require nested `$(git ...)` or `$(date ...)` snippets.
 
+Use `skills/orch/scripts/pr-view-json WORKTREE_PATH --json number,state` when a workflow needs to inspect the current branch's PR. It prints the structured `status=no_pr` JSON with exit code 0 so `submit-pr` can route to PR creation without shell fallback expressions.
+
 Use `skills/orch/scripts/review-init` to initialize standalone review context and print branch, worktree, issue ID, state path, and whether state was created as JSON.
 
 Use `skills/orch/scripts/tracker-for-issue ISSUE_ID` when workflow docs need tracker branching without inline shell conditionals.

--- a/skills/orch/SKILL.md
+++ b/skills/orch/SKILL.md
@@ -143,6 +143,7 @@ Follow ALL [Workflow Execution](#workflow-execution) rules for every command.
 | Script | Purpose |
 |--------|---------|
 | `workflow-state` | Persistent state read/write/append (survives compaction) |
+| `git-context` | Print git-derived workflow values such as branch, head SHA, issue id, repo root, and timestamps without inline shell plumbing |
 | `resolve-base-branch` | Print the worktree base branch (`WORKTREE_DEFAULT_BRANCH`, remote HEAD, or `main`) |
 | `review-init` | Initialize standalone review context and print branch/worktree/issue/state JSON |
 | `tracker-for-issue` | Print `github` for `issue-*` ids and `linear` otherwise |
@@ -169,6 +170,8 @@ Both `bot-review-wait` and `ci-wait` share `scripts/lib/gh-auth.sh` for a four-s
 | `path <ID>` | Print state file path |
 | `get <ID> <.field>` | Read state field |
 | `set <ID> <field> <value>` | Write state field |
+| `set-git-head <ID> <field> [worktree]` | Write current `HEAD` SHA to a field without command substitution |
+| `set-now <ID> <field>` | Write current epoch seconds to a field without command substitution |
 | `append <ID> <field> <value>` | Append to array field |
 | `increment <ID> <field>` | Increment counter |
 | `update <ID> <jq-expr>` | Arbitrary jq mutation (e.g. nested merges) |
@@ -365,7 +368,7 @@ Never edit or write code unless the user explicitly asks. Delegate to the domain
 
 #### Durable Workflow State Files
 
-Use workflow state files for data that must survive compaction: issue tracking, sub-issues, agent persistence, cycle counts, fix/escalation tracking, audit trails. Use the `workflow-state` CLI for all reads/writes.
+Use workflow state files for data that must survive compaction: issue tracking, sub-issues, agent persistence, cycle counts, fix/escalation tracking, audit trails. Use the `workflow-state` CLI for all reads/writes, including `set-git-head` and `set-now` instead of inline `$(git ...)` or `$(date ...)` state-write snippets.
 
 Location: `$ORCH_STATE_DIR/workflow-state-[ID].json` (default: `tmp/`)
 

--- a/skills/orch/SKILL.md
+++ b/skills/orch/SKILL.md
@@ -144,6 +144,7 @@ Follow ALL [Workflow Execution](#workflow-execution) rules for every command.
 |--------|---------|
 | `workflow-state` | Persistent state read/write/append (survives compaction) |
 | `git-context` | Print git-derived workflow values such as branch, head SHA, issue id, repo root, and timestamps without inline shell plumbing |
+| `pr-view-json` | Print PR view JSON and return success for expected `status=no_pr` so workflows can route to PR creation without shell fallback expressions |
 | `resolve-base-branch` | Print the worktree base branch (`WORKTREE_DEFAULT_BRANCH`, remote HEAD, or `main`) |
 | `review-init` | Initialize standalone review context and print branch/worktree/issue/state JSON |
 | `tracker-for-issue` | Print `github` for `issue-*` ids and `linear` otherwise |
@@ -241,10 +242,10 @@ Resolve once per workflow, store as `TRACKER`:
 3. Otherwise → `linear`.
 
 ```bash
-TRACKER=$(.agents/skills/orch/scripts/tracker-for-issue "[ISSUE_ID]")
+.agents/skills/orch/scripts/tracker-for-issue "[ISSUE_ID]"
 ```
 
-Assign `TRACKER` before any tracker test. Steps marked **Linear only** / **GitHub only** run only for that tracker. Never run `linear.sh` against a GitHub item — GitHub state lives in `gh issue`/PR linkage (`Closes #N`).
+Use the output as `TRACKER` before any tracker test. Steps marked **Linear only** / **GitHub only** run only for that tracker. Never run `linear.sh` against a GitHub item — GitHub state lives in `gh issue`/PR linkage (`Closes #N`).
 
 ---
 
@@ -368,7 +369,7 @@ Never edit or write code unless the user explicitly asks. Delegate to the domain
 
 #### Durable Workflow State Files
 
-Use workflow state files for data that must survive compaction: issue tracking, sub-issues, agent persistence, cycle counts, fix/escalation tracking, audit trails. Use the `workflow-state` CLI for all reads/writes, including `set-git-head` and `set-now` instead of inline `$(git ...)` or `$(date ...)` state-write snippets.
+Use workflow state files for data that must survive compaction: issue tracking, sub-issues, agent persistence, cycle counts, fix/escalation tracking, audit trails. Use the `workflow-state` CLI for all reads/writes, including `set-git-head` and `set-now` instead of inline command-substitution state-write snippets.
 
 Location: `$ORCH_STATE_DIR/workflow-state-[ID].json` (default: `tmp/`)
 

--- a/skills/orch/scripts/git-context
+++ b/skills/orch/scripts/git-context
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Print small git context values for workflow snippets without inline shell plumbing.
+
+set -euo pipefail
+
+cmd="${1:-help}"
+shift || true
+
+worktree_arg() {
+    printf '%s' "${1:-.}"
+}
+
+case "$cmd" in
+    branch)
+        worktree="$(worktree_arg "$@")"
+        git -C "$worktree" branch --show-current
+        ;;
+    head)
+        worktree="$(worktree_arg "$@")"
+        git -C "$worktree" rev-parse HEAD
+        ;;
+    issue-from-branch)
+        worktree="$(worktree_arg "$@")"
+        pattern="${2:-${GH_ISSUE_PATTERN:-([A-Z]+-[0-9]+|issue-[0-9]+)}}"
+        branch="$(git -C "$worktree" branch --show-current)"
+        if [[ "$branch" =~ $pattern ]]; then
+            printf '%s\n' "${BASH_REMATCH[0]}"
+        else
+            echo "Error: no issue id matched branch '$branch'" >&2
+            exit 1
+        fi
+        ;;
+    repo-root)
+        worktree="$(worktree_arg "$@")"
+        git -C "$worktree" rev-parse --show-toplevel
+        ;;
+    common-root)
+        worktree="$(worktree_arg "$@")"
+        git_common_dir="$(git -C "$worktree" rev-parse --git-common-dir)"
+        case "$git_common_dir" in
+            */.git) dirname "$git_common_dir" ;;
+            *) git -C "$worktree" rev-parse --show-toplevel ;;
+        esac
+        ;;
+    timestamp)
+        format="${1:-compact}"
+        case "$format" in
+            compact) date +%Y%m%d-%H%M%S ;;
+            epoch) date +%s ;;
+            *) echo "Error: unknown timestamp format '$format'" >&2; exit 2 ;;
+        esac
+        ;;
+    help|--help|-h)
+        cat << 'EOF'
+Usage: git-context <command> [worktree]
+
+Commands:
+  branch [worktree]               Print current branch
+  head [worktree]                 Print current HEAD SHA
+  issue-from-branch [worktree]    Print issue id matched from branch
+  repo-root [worktree]            Print git worktree root
+  common-root [worktree]          Print main checkout root for worktree sets
+  timestamp [compact|epoch]       Print workflow timestamp
+EOF
+        ;;
+    *)
+        echo "Unknown command: $cmd" >&2
+        exit 1
+        ;;
+esac

--- a/skills/orch/scripts/git-context
+++ b/skills/orch/scripts/git-context
@@ -23,8 +23,14 @@ case "$cmd" in
         worktree="$(worktree_arg "$@")"
         pattern="${2:-${GH_ISSUE_PATTERN:-([A-Z]+-[0-9]+|issue-[0-9]+)}}"
         branch="$(git -C "$worktree" branch --show-current)"
+        shopt -s nocasematch
         if [[ "$branch" =~ $pattern ]]; then
-            printf '%s\n' "${BASH_REMATCH[0]}"
+            issue_id="${BASH_REMATCH[0]}"
+            if [[ "$issue_id" == issue-* ]]; then
+                printf '%s\n' "${issue_id,,}"
+            else
+                printf '%s\n' "${issue_id^^}"
+            fi
         else
             echo "Error: no issue id matched branch '$branch'" >&2
             exit 1

--- a/skills/orch/scripts/pr-view-json
+++ b/skills/orch/scripts/pr-view-json
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Print PR view JSON while treating "no_pr" as a routable status, not a shell failure.
+
+set -euo pipefail
+
+worktree="${1:-.}"
+shift || true
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILLS_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+GITHUB="$SKILLS_DIR/github/scripts/github.sh"
+
+if [[ ! -x "$GITHUB" ]]; then
+    echo "Error: github helper not found: $GITHUB" >&2
+    exit 1
+fi
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+stdout_file="$tmp_dir/stdout.json"
+stderr_file="$tmp_dir/stderr.txt"
+rc=0
+"$GITHUB" -C "$worktree" pr-view "$@" >"$stdout_file" 2>"$stderr_file" || rc=$?
+
+if [[ "$rc" -eq 0 ]]; then
+    cat "$stdout_file"
+    exit 0
+fi
+
+if jq -e '.status == "no_pr"' "$stdout_file" >/dev/null 2>&1; then
+    cat "$stdout_file"
+    exit 0
+fi
+
+cat "$stdout_file"
+cat "$stderr_file" >&2
+exit "$rc"

--- a/skills/orch/scripts/workflow-state
+++ b/skills/orch/scripts/workflow-state
@@ -200,6 +200,25 @@ cmd_set() {
     fi
 }
 
+cmd_set_git_head() {
+    local issue_id="$1"
+    local field="$2"
+    local worktree="${3:-.}"
+    local value
+
+    value="$(git -C "$worktree" rev-parse HEAD)"
+    cmd_set "$issue_id" "$field" "$value"
+}
+
+cmd_set_now() {
+    local issue_id="$1"
+    local field="$2"
+    local value
+
+    value="$(date +%s)"
+    cmd_set "$issue_id" "$field" "$value"
+}
+
 cmd_path() {
     local issue_id="$1"
     get_state_file "$issue_id"
@@ -254,6 +273,8 @@ Commands:
   append <issue_id> <field> <value>   Append to array field
   increment <issue_id> <field>  Increment numeric field
   set <issue_id> <field> <value>  Set field value
+  set-git-head <issue_id> <field> [worktree]  Set field to current HEAD SHA
+  set-now <issue_id> <field>     Set field to current epoch seconds
   path <issue_id>               Print state file path
   exists [--json] <issue_id>    Exit 0 if exists, 1 if not; --json prints status and exits 0
 
@@ -266,6 +287,8 @@ Examples:
   workflow-state append PROJ-123 json_paths "review.json"
   workflow-state append PROJ-123 fixed_items '{"description":"Fix","commit":"abc"}'
   workflow-state set PROJ-123 pr_review_baseline '{"last_ts":"2026-01-28","last_threads":2}'
+  workflow-state set-git-head PROJ-123 pre_delegate_sha /tmp/wt
+  workflow-state set-now PROJ-123 review_delegated_at
   workflow-state update PROJ-123 '.fixed_items | map(select(.source == "qa-review"))'
 
 Environment:
@@ -285,6 +308,8 @@ case "${1:-help}" in
     append)    shift; cmd_append "$@" ;;
     increment) shift; cmd_increment "$@" ;;
     set)       shift; cmd_set "$@" ;;
+    set-git-head) shift; cmd_set_git_head "$@" ;;
+    set-now)   shift; cmd_set_now "$@" ;;
     path)      shift; cmd_path "$@" ;;
     exists)    shift; cmd_exists "$@" ;;
     help|--help|-h) cmd_help ;;

--- a/skills/orch/tests/workflow_helpers.sh
+++ b/skills/orch/tests/workflow_helpers.sh
@@ -43,5 +43,13 @@ assert_eq "$fallback_branch" "main" "resolve-base-branch falls back to main"
 assert_eq "$("$REPO_ROOT/skills/orch/scripts/tracker-for-issue" issue-353)" "github" "tracker-for-issue detects GitHub ids"
 assert_eq "$("$REPO_ROOT/skills/orch/scripts/tracker-for-issue" CC-353)" "linear" "tracker-for-issue detects Linear ids"
 
+issue_repo="$TMP_ROOT/issue-repo"
+git init -q "$issue_repo"
+git -C "$issue_repo" checkout -q -b cc-536
+assert_eq "$("$REPO_ROOT/skills/orch/scripts/git-context" issue-from-branch "$issue_repo")" "CC-536" "git-context uppercases lower-case Linear branch ids"
+
+git -C "$issue_repo" checkout -q --orphan issue-369
+assert_eq "$("$REPO_ROOT/skills/orch/scripts/git-context" issue-from-branch "$issue_repo")" "issue-369" "git-context keeps GitHub issue branch ids lowercase"
+
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/skills/orch/workflows/ci-fix.md
+++ b/skills/orch/workflows/ci-fix.md
@@ -70,9 +70,11 @@ Classify error and route to appropriate flow:
 
 1. **Get or create worktree**:
    ```bash
-   ISSUE=$(.agents/skills/github/scripts/github.sh pr-issue [PR_NUMBER] --format=text)
-   WT_PATH=$(.agents/skills/worktree/scripts/worktree path $ISSUE 2>/dev/null || .agents/skills/worktree/scripts/worktree create $ISSUE --pr [PR_NUMBER])
+   .agents/skills/github/scripts/github.sh pr-issue [PR_NUMBER] --format=text
+   .agents/skills/worktree/scripts/worktree exists [ISSUE_FROM_PREVIOUS_COMMAND]
+   .agents/skills/worktree/scripts/worktree path [ISSUE_FROM_PREVIOUS_COMMAND]
    ```
+   Use the first output as `ISSUE`. If the worktree is missing, run `.agents/skills/worktree/scripts/worktree create [ISSUE] --pr [PR_NUMBER]`; otherwise use the path output as `WT_PATH`.
 
 2. **Apply fix**.
 
@@ -157,8 +159,9 @@ For `queue` argument (merge queue failures). May need to dequeue PR while fixing
 
 4. **Create worktree from draft branch** (integration issues only):
    ```bash
-   WT_PATH=$(.agents/skills/worktree/scripts/worktree create [ISSUE_ID] "[DRAFT_BRANCH]" --pr [DRAFT_PR_NUMBER])
+   .agents/skills/worktree/scripts/worktree create [ISSUE_ID] "[DRAFT_BRANCH]" --pr [DRAFT_PR_NUMBER]
    ```
+   Use the output as `WT_PATH`.
 
 5. **Delegate to architecture review agent**: Fill placeholders, omit empty lines/sections.
 
@@ -190,14 +193,16 @@ After fix is pushed:
 
 **Post to issue tracker** — **Linear only** (GitHub items: the PR conversation already records the fix):
 ```bash
-ISSUE=$(.agents/skills/github/scripts/github.sh pr-issue [PR_NUMBER] --format=text)
+.agents/skills/github/scripts/github.sh pr-issue [PR_NUMBER] --format=text
 ```
+Use the output as `ISSUE`.
 
 If `ISSUE` is non-empty, determine tracker:
 
 ```bash
-TRACKER=$(.agents/skills/orch/scripts/tracker-for-issue "$ISSUE")
+.agents/skills/orch/scripts/tracker-for-issue "$ISSUE"
 ```
+Use the output as `TRACKER`.
 
 If `TRACKER` is `linear`, post the short status:
 

--- a/skills/orch/workflows/dev-fix.md
+++ b/skills/orch/workflows/dev-fix.md
@@ -27,8 +27,8 @@ Delegate fix items to a specialist dev agent. Works standalone (user-initiated) 
 Use the output as `ISSUE_ID`.
 
 Apply [Worktree Scope](../SKILL.md#worktree-scope): if in a worktree and `ISSUE_ID` ≠ the current branch's issue, ask the user before proceeding. Resolve `WT_PATH`:
-- Inside a worktree → `WT_PATH=$(pwd)`
-- Main repo, worktree exists → `WT_PATH=$(.agents/skills/worktree/scripts/worktree path $ISSUE_ID)`
+- Inside a worktree → use current directory as `WT_PATH`
+- Main repo, worktree exists → run `.agents/skills/worktree/scripts/worktree path [ISSUE_ID]` and use the output as `WT_PATH`
 - Main repo, worktree missing → ask the user before creating
 
 ## 1. Build Fix Items
@@ -73,15 +73,19 @@ Apply [Worktree Scope](../SKILL.md#worktree-scope): if in a worktree and `ISSUE_
    - If `dev_agent` provided → use it (already alive)
    - Otherwise: from workflow state or issue labels
      ```bash
-     AGENT=$(.agents/skills/orch/scripts/workflow-state get $ISSUE_ID '.agent // empty' 2>/dev/null)
-     TRACKER=$(.agents/skills/orch/scripts/tracker-for-issue "$ISSUE_ID")
+     .agents/skills/orch/scripts/workflow-state exists --json [ISSUE_ID]
+     .agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.agent // empty'
+     .agents/skills/orch/scripts/tracker-for-issue [ISSUE_ID]
      ```
+     If state exists, use the second output as `AGENT`; otherwise leave `AGENT` empty. Use the tracker output as `TRACKER`.
 
      If `AGENT` is empty and `TRACKER` is `linear`, look up the Linear agent label:
 
      ```bash
-     AGENT=$(.agents/skills/linear/scripts/linear.sh cache issues get $ISSUE_ID --format=compact | jq -r '[.labels[] | select(startswith("agent:"))] | first | split(":")[1] // empty')
+     .agents/skills/linear/scripts/linear.sh cache issues get [ISSUE_ID] --format=compact
+     jq -r '[.labels[] | select(startswith("agent:"))] | first | split(":")[1] // empty' [ISSUE_JSON_FROM_PREVIOUS_COMMAND]
      ```
+     Use the `jq` output as `AGENT`.
 
      GitHub items: use `gh issue view ${ISSUE_ID#issue-} --json labels`, or infer from component paths.
 
@@ -89,8 +93,9 @@ Apply [Worktree Scope](../SKILL.md#worktree-scope): if in a worktree and `ISSUE_
 
 3. **Detect team context**:
    ```bash
-   TEAM=$(.agents/skills/orch/scripts/workflow-state get $ISSUE_ID '.team_name // empty')
+   .agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.team_name // empty'
    ```
+   Use the output as `TEAM`.
 
 4. **Delegate** to `[AGENT_TYPE]` agent (reuse existing dev agent if available).
 

--- a/skills/orch/workflows/dev-fix.md
+++ b/skills/orch/workflows/dev-fix.md
@@ -21,8 +21,10 @@ Delegate fix items to a specialist dev agent. Works standalone (user-initiated) 
 
 **Standalone init** (`lifecycle: "self"` only):
 ```bash
-ISSUE_ID=${ARG:-$(git rev-parse --abbrev-ref HEAD | grep -oiP "$GH_ISSUE_PATTERN")}
+# If ARG was provided, use it as ISSUE_ID. Otherwise:
+.agents/skills/orch/scripts/git-context issue-from-branch .
 ```
+Use the output as `ISSUE_ID`.
 
 Apply [Worktree Scope](../SKILL.md#worktree-scope): if in a worktree and `ISSUE_ID` ≠ the current branch's issue, ask the user before proceeding. Resolve `WT_PATH`:
 - Inside a worktree → `WT_PATH=$(pwd)`

--- a/skills/orch/workflows/dev-fix.md
+++ b/skills/orch/workflows/dev-fix.md
@@ -83,9 +83,8 @@ Apply [Worktree Scope](../SKILL.md#worktree-scope): if in a worktree and `ISSUE_
 
      ```bash
      .agents/skills/linear/scripts/linear.sh cache issues get [ISSUE_ID] --format=compact
-     jq -r '[.labels[] | select(startswith("agent:"))] | first | split(":")[1] // empty' [ISSUE_JSON_FROM_PREVIOUS_COMMAND]
      ```
-     Use the `jq` output as `AGENT`.
+     Read the first `agent:*` label from the JSON output and use the suffix as `AGENT`.
 
      GitHub items: use `gh issue view ${ISSUE_ID#issue-} --json labels`, or infer from component paths.
 

--- a/skills/orch/workflows/dev-start.md
+++ b/skills/orch/workflows/dev-start.md
@@ -17,8 +17,10 @@ Delegate development work to specialist agent(s). Handles single issues and bund
 
 **Standalone init** (`lifecycle: "self"` only):
 ```bash
-ISSUE_ID=${ARG:-$(git rev-parse --abbrev-ref HEAD | grep -oiP "$GH_ISSUE_PATTERN")}
+# If ARG was provided, use it as ISSUE_ID. Otherwise:
+.agents/skills/orch/scripts/git-context issue-from-branch .
 ```
+Use the output as `ISSUE_ID`.
 
 Apply [Worktree Scope](../SKILL.md#worktree-scope): if in a worktree and `ISSUE_ID` ≠ the current branch's issue, ask the user before proceeding. Resolve `WT_PATH`:
 - Inside a worktree → `WT_PATH=$(pwd)`
@@ -57,13 +59,15 @@ WT_PATH=$(.agents/skills/orch/scripts/workflow-state get $PARENT_ID '.worktree /
 Then initialize child state with the inherited context:
 
 ```bash
-.agents/skills/orch/scripts/workflow-state init $ISSUE_ID --worktree "$WT_PATH" --branch "$(git rev-parse --abbrev-ref HEAD)" --team "$TEAM"
+.agents/skills/orch/scripts/git-context branch "$WT_PATH"
+.agents/skills/orch/scripts/workflow-state init $ISSUE_ID --worktree "$WT_PATH" --branch "[BRANCH_FROM_PREVIOUS_COMMAND]" --team "$TEAM"
 ```
 
 Otherwise, initialize state with the current worktree:
 
 ```bash
-.agents/skills/orch/scripts/workflow-state init $ISSUE_ID --worktree "$WT_PATH" --branch "$(git rev-parse --abbrev-ref HEAD)"
+.agents/skills/orch/scripts/git-context branch "$WT_PATH"
+.agents/skills/orch/scripts/workflow-state init $ISSUE_ID --worktree "$WT_PATH" --branch "[BRANCH_FROM_PREVIOUS_COMMAND]"
 ```
 
 ## 1. Determine Agent
@@ -87,7 +91,7 @@ gh issue view ${ISSUE_ID#issue-} --json labels --jq '.labels[].name'
 Before each implementation delegation, capture the current `HEAD`:
 
 ```bash
-.agents/skills/orch/scripts/workflow-state set [ISSUE_ID] pre_delegate_sha "$(git -C [WORKTREE_PATH] rev-parse HEAD)"
+.agents/skills/orch/scripts/workflow-state set-git-head [ISSUE_ID] pre_delegate_sha [WORKTREE_PATH]
 ```
 
 **After each spawn**, persist the agent session:
@@ -167,15 +171,16 @@ Handoff from prior agents:
 
 1. **Run ALL checks** — do not proceed if ANY fails:
    ```bash
-   PRE_SHA=$(.agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.pre_delegate_sha // empty')
-   HEAD_SHA=$(git -C "[WORKTREE_PATH]" rev-parse HEAD)
+   .agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.pre_delegate_sha // empty'
+   .agents/skills/orch/scripts/git-context head [WORKTREE_PATH]
 
    # Check the implementation produced committed work.
    git -C "[WORKTREE_PATH]" log -1 --oneline
-   test -z "$PRE_SHA" || test "$HEAD_SHA" != "$PRE_SHA"
+   # The previous two SHA outputs must differ unless pre_delegate_sha was empty.
 
    # Check no implemented files were left outside the commit.
-   test -z "$(git -C "[WORKTREE_PATH]" status --porcelain)"
+   git -C "[WORKTREE_PATH]" status --porcelain
+   # The status output must be empty.
 
    # Linear only: check state + summary (auto-includes pending children from bundle)
    .agents/skills/linear/scripts/linear.sh issues validate-completion [ISSUE_ID] --include-children-of [ISSUE_ID]

--- a/skills/orch/workflows/dev-start.md
+++ b/skills/orch/workflows/dev-start.md
@@ -23,13 +23,14 @@ Delegate development work to specialist agent(s). Handles single issues and bund
 Use the output as `ISSUE_ID`.
 
 Apply [Worktree Scope](../SKILL.md#worktree-scope): if in a worktree and `ISSUE_ID` ≠ the current branch's issue, ask the user before proceeding. Resolve `WT_PATH`:
-- Inside a worktree → `WT_PATH=$(pwd)`
-- Main repo, worktree exists → `WT_PATH=$(.agents/skills/worktree/scripts/worktree path $ISSUE_ID)`
+- Inside a worktree → use current directory as `WT_PATH`
+- Main repo, worktree exists → run `.agents/skills/worktree/scripts/worktree path [ISSUE_ID]` and use the output as `WT_PATH`
 - Main repo, worktree missing → ask the user before creating
 
 ```bash
-TRACKER=$(.agents/skills/orch/scripts/tracker-for-issue "$ISSUE_ID")
+.agents/skills/orch/scripts/tracker-for-issue [ISSUE_ID]
 ```
+Use the output as `TRACKER`.
 
 If workflow state already exists, skip initialization:
 
@@ -40,8 +41,9 @@ If workflow state already exists, skip initialization:
 If `.exists` is `false`, initialize workflow state. Linear only: first check for parent context from a start-new sub-issue:
 
 ```bash
-PARENT_ID=$(.agents/skills/linear/scripts/linear.sh cache issues get $ISSUE_ID --format=compact | jq -r '.parent.identifier // empty')
+.agents/skills/linear/scripts/linear.sh cache issues get [ISSUE_ID] --format=compact
 ```
+Read `.parent.identifier // empty` from the JSON output and use it as `PARENT_ID`.
 
 If `PARENT_ID` is non-empty, check whether the parent workflow state exists:
 
@@ -52,9 +54,10 @@ If `PARENT_ID` is non-empty, check whether the parent workflow state exists:
 If `.exists` is `true`, read the parent team and worktree:
 
 ```bash
-TEAM=$(.agents/skills/orch/scripts/workflow-state get $PARENT_ID '.team_name // empty')
-WT_PATH=$(.agents/skills/orch/scripts/workflow-state get $PARENT_ID '.worktree // empty')
+.agents/skills/orch/scripts/workflow-state get [PARENT_ID] '.team_name // empty'
+.agents/skills/orch/scripts/workflow-state get [PARENT_ID] '.worktree // empty'
 ```
+Use the outputs as `TEAM` and `WT_PATH`.
 
 Then initialize child state with the inherited context:
 
@@ -76,7 +79,8 @@ Otherwise, initialize state with the current worktree:
 
 ```bash
 # Linear
-.agents/skills/linear/scripts/linear.sh cache issues get [ISSUE_ID] --format=compact | jq -r '.labels[]'
+.agents/skills/linear/scripts/linear.sh cache issues get [ISSUE_ID] --format=compact
+# Read `.labels[]` from the JSON output.
 
 # GitHub
 gh issue view ${ISSUE_ID#issue-} --json labels --jq '.labels[].name'
@@ -126,8 +130,9 @@ Blocks: [BLOCKED_ISSUE_IDS or "none"]
 
 a. For each sub-issue completed by any prior agent group (cumulative):
    ```bash
-   .agents/skills/linear/scripts/linear.sh cache comments list [COMPLETED_ISSUE_ID] | jq -r '.[] | select(.body | contains("Handoff Notes")) | .body'
+   .agents/skills/linear/scripts/linear.sh cache comments list [COMPLETED_ISSUE_ID]
    ```
+   Read bodies containing `Handoff Notes` from the JSON output.
 b. Extract "Handoff Notes" sections. Combine into a single block.
 c. Include in next delegation as `Handoff from prior agents:` (see below). Omit if none found.
 

--- a/skills/orch/workflows/fix-reconcile.md
+++ b/skills/orch/workflows/fix-reconcile.md
@@ -21,9 +21,10 @@ Batch workflow — checks if applied fixes address existing open issues. Process
 
 1. **Read state**:
    ```bash
-   REVIEW_FIXES=$(.agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.fixed_items // []')
-   PR_FIXES=$(.agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.pr_comment_review.fixes // []')
+   .agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.fixed_items // []'
+   .agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.pr_comment_review.fixes // []'
    ```
+   Use the outputs as `REVIEW_FIXES` and `PR_FIXES`.
 
 2. **Merge** both arrays into `fixes`. Deduplicate by description.
 

--- a/skills/orch/workflows/merge-pr.md
+++ b/skills/orch/workflows/merge-pr.md
@@ -194,34 +194,35 @@ merge. Detach them first.
 
 ## 5. Execute Merge
 
-**Note**: Some harnesses reset cwd per shell call — use `cd && ...` chains or absolute paths.
+**Note**: Some harnesses reset cwd per shell call. Prefer helper scripts and `-C`/absolute-path options over `cd && ...` chains in generated commands.
 
 1. **Resolve main repo root** (needed when running from a worktree):
    ```bash
-   MAIN_REPO_ROOT=$(git rev-parse --git-common-dir | sed 's|/\.git$||')
-   [[ "$MAIN_REPO_ROOT" == ".git" ]] && MAIN_REPO_ROOT="$PWD"
-   echo "$MAIN_REPO_ROOT"
+   .agents/skills/orch/scripts/git-context common-root .
    ```
+   Use the output as `MAIN_REPO_ROOT`.
 
 2. **Merge** (before cleanup — worktree survives if merge fails):
    ```bash
-   (cd [MAIN_REPO_ROOT] && .agents/skills/github/scripts/github.sh pr-merge [PR_NUMBER] [--force])
+   [MAIN_REPO_ROOT]/.agents/skills/github/scripts/github.sh -C [MAIN_REPO_ROOT] pr-merge [PR_NUMBER] [--force]
    ```
 
    Exit `75` = queued for auto-merge (fires when CI + branch protection clear). Wait before sync:
    ```bash
-   (cd [MAIN_REPO_ROOT] && .agents/skills/github/scripts/github.sh await-mergeable [PR_NUMBER])
+   [MAIN_REPO_ROOT]/.agents/skills/github/scripts/github.sh -C [MAIN_REPO_ROOT] await-mergeable [PR_NUMBER]
    ```
    Never poll `gh pr view --json mergeable` — stays UNKNOWN after merge, loops forever.
 
 3. **Sync issue tracker cache** — **Linear only** (merged PRs close issues via magic words; cache must reflect done states):
    ```bash
-   (cd [MAIN_REPO_ROOT] && .agents/skills/linear/scripts/linear.sh sync --reconcile)
+   [MAIN_REPO_ROOT]/.agents/skills/linear/scripts/linear.sh sync --reconcile
    ```
 
 4. **Sync main repo** (ALWAYS runs after merge):
    ```bash
-   (cd [MAIN_REPO_ROOT] && for remote in $(git remote); do git fetch "$remote" --prune || true; done && git pull --rebase && git worktree prune)
+   git -C [MAIN_REPO_ROOT] fetch --all --prune
+   git -C [MAIN_REPO_ROOT] pull --rebase
+   git -C [MAIN_REPO_ROOT] worktree prune
    ```
    `--rebase` prevents merge-bubble commits when local main diverged.
 
@@ -235,7 +236,7 @@ merge. Detach them first.
       ```
    2. If `[PR_BRANCH]` exists locally and is not the current branch, delete it:
       ```bash
-      (cd [MAIN_REPO_ROOT] && git branch -D "$PR_BRANCH")
+      git -C [MAIN_REPO_ROOT] branch -D "$PR_BRANCH"
       ```
    3. Worktree removal is handled by step 6 when § 4.1 captured a cleanup request.
 
@@ -243,8 +244,9 @@ merge. Detach them first.
 
    Run only for `merge-pr all` or explicit user request. Find local branches whose remote PRs are merged/closed:
    ```bash
-   (cd [MAIN_REPO_ROOT] && git branch --format='%(refname:short)' | grep -v '^main$')
+   git -C [MAIN_REPO_ROOT] branch --format='%(refname:short)'
    ```
+   Ignore the default branch from this output.
 
    For each branch, check PR status:
    ```bash
@@ -252,7 +254,7 @@ merge. Detach them first.
    ```
 
    - **MERGED/CLOSED with no worktree**: Auto-delete (`git branch -D [BRANCH]`). Report in § 7.
-   - **MERGED/CLOSED with worktree**: Ask user `"Stale worktree for [BRANCH] (PR already merged). Remove?"`. If yes: `(cd [MAIN_REPO_ROOT] && .agents/skills/worktree/scripts/worktree remove [ISSUE_ID])` then `git branch -D [BRANCH]`.
+   - **MERGED/CLOSED with worktree**: Ask user `"Stale worktree for [BRANCH] (PR already merged). Remove?"`. If yes: `[MAIN_REPO_ROOT]/.agents/skills/worktree/scripts/worktree remove [ISSUE_ID]` then `git -C [MAIN_REPO_ROOT] branch -D [BRANCH]`.
    - **OPEN**: Leave alone (active work).
    - **No PR found**: Ask user `"Local branch [BRANCH] has no associated PR. Delete?"`. Show last commit for context.
 
@@ -266,7 +268,7 @@ merge. Detach them first.
 
 6. **Cleanup current worktree** (if requested in § 4.1 — **must be last**, destroys session cwd):
    ```bash
-   (cd [MAIN_REPO_ROOT] && .agents/skills/worktree/scripts/worktree remove "[ISSUE_ID]")
+   [MAIN_REPO_ROOT]/.agents/skills/worktree/scripts/worktree remove "[ISSUE_ID]"
    ```
    If this prints `SESSION CWD DESTROYED`: present § 7 immediately, tell user to end the session — no further shell calls will succeed. Skip if cleanup not requested.
 
@@ -324,7 +326,7 @@ For each file flagged as overlapping in § 2.1:
 | ⏭️ | #[P] | [ISSUE_ID] - [TITLE] | Review threads |
 | ❌ | #[Q] | [ISSUE_ID] - [TITLE] | Merge conflicts |
 
-Total: [N] PRs merged | Synced: git fetch --prune && git pull
+Total: [N] PRs merged | Synced: git fetch --all --prune; git pull --rebase
 
 ### 🧹 STALE CLEANUP
 

--- a/skills/orch/workflows/merge-pr.md
+++ b/skills/orch/workflows/merge-pr.md
@@ -27,16 +27,18 @@ When `all` or 2+ PRs requested:
 ### 2.1 Run Quick Pre-Check
 
 ```bash
-QUICK=$(.agents/skills/github/scripts/github.sh pr-cross-check [PR_NUMBERS] --quick --json)
+.agents/skills/github/scripts/github.sh pr-cross-check [PR_NUMBERS] --quick --json
 ```
+Use the output as `QUICK`.
 
 If quick check finds high-severity issues (conflicts): Show issues, abort early.
 
 ### 2.2 Run Full Verification (if quick check passes)
 
 ```bash
-VERIFY=$(.agents/skills/github/scripts/github.sh pr-cross-check [PR_NUMBERS] --verify --json)
+.agents/skills/github/scripts/github.sh pr-cross-check [PR_NUMBERS] --verify --json
 ```
+Use the output as `VERIFY`.
 
 Creates temp worktree from main, merges PRs sequentially, runs build + test, reports + cleans up.
 
@@ -59,8 +61,9 @@ Verification failed:
 For each PR:
 
 ```bash
-CHECK=$(.agents/skills/github/scripts/github.sh pr-merge [PR_NUMBER] --check)
+.agents/skills/github/scripts/github.sh pr-merge [PR_NUMBER] --check
 ```
+Use the output as `CHECK`.
 
 ### 3.1 Resolve transient "unknown" before prompting
 
@@ -68,8 +71,9 @@ If `issues` contains an entry starting with `unknown:` (GitHub still computing m
 
 ```bash
 .agents/skills/github/scripts/github.sh await-mergeable [PR_NUMBER]
-CHECK=$(.agents/skills/github/scripts/github.sh pr-merge [PR_NUMBER] --check)
+.agents/skills/github/scripts/github.sh pr-merge [PR_NUMBER] --check
 ```
+Use the second command output as `CHECK`.
 
 `await-mergeable` polls `state` + `mergeStateStatus` (never `mergeable` — stays UNKNOWN after merge, hangs forever). Exit 124 on timeout → surface to user.
 
@@ -101,8 +105,9 @@ PR #N ready with warnings:
 ### 4.1 Check Worktree Cleanup
 
 ```bash
-ISSUE=$(.agents/skills/github/scripts/github.sh pr-issue [PR_NUMBER] --format=text)
+.agents/skills/github/scripts/github.sh pr-issue [PR_NUMBER] --format=text
 ```
+Use the output as `ISSUE`.
 
 If `ISSUE` is non-empty, check whether its worktree exists:
 
@@ -115,8 +120,9 @@ If worktree exists: Ask user `"Cleanup worktree for [ISSUE_ID]?"` → store for 
 ### 4.2 Verify Bot Token
 
 ```bash
-.agents/skills/github/scripts/github.sh bot-token | jq -r '.configured'
+.agents/skills/github/scripts/github.sh bot-token
 ```
+Read `.configured` from the JSON output.
 
 If `false`: Ask user: `Merge as current user` | `Abort`
 
@@ -155,15 +161,15 @@ merge. Detach them first.
 
    a. Read parent metadata. Capture `.title` → `[PARENT_TITLE]`, `.project.id` → `[PARENT_PROJECT]`, joined labels → `[PARENT_LABELS]`:
       ```bash
-      .agents/skills/linear/scripts/linear.sh cache issues get [ISSUE] \
-          | jq -r '"title=\(.title)\nproject=\(.project.id // .project.name // "")\nlabels=\([.labels.nodes[].name] | join(","))"'
+      .agents/skills/linear/scripts/linear.sh cache issues get [ISSUE]
       ```
+      Read `.title`, `.project.id // .project.name // ""`, and joined `.labels.nodes[].name` from the JSON output.
 
    b. Compute `[BUNDLE_PRIORITY]` (highest-priority across `[SAFE_IDS]`; Linear: `1`=Urgent…`4`=Low, lower=higher; default `3`):
       ```bash
-      .agents/skills/linear/scripts/linear.sh cache issues children [ISSUE] --pending --recursive \
-          | jq '[.[] | select(.priority > 0) | .priority] | (min // 3)'
+      .agents/skills/linear/scripts/linear.sh cache issues children [ISSUE] --pending --recursive
       ```
+      Read priorities from the JSON output and use the minimum positive priority, or `3` when none exists.
 
    c. Build `[BUNDLE_DESC]` per `.agents/skills/project-management/templates/parent-issue-template.md` — 1-2 sentence summary synthesized from orphan titles, `## Sub-Issues` listing each safe ID, `## Context` line: `Detached from [ISSUE] before merge to prevent cascade-Done.`
 
@@ -232,8 +238,9 @@ merge. Detach them first.
 
    1. Resolve the merged PR branch:
       ```bash
-      PR_BRANCH=$(gh pr view [PR_NUMBER] --json headRefName --jq .headRefName)
+      gh pr view [PR_NUMBER] --json headRefName --jq .headRefName
       ```
+      Use the output as `PR_BRANCH`.
    2. If `[PR_BRANCH]` exists locally and is not the current branch, delete it:
       ```bash
       git -C [MAIN_REPO_ROOT] branch -D "$PR_BRANCH"
@@ -260,10 +267,10 @@ merge. Detach them first.
 
    Also check for orphan worktree directories:
    ```bash
-   ls [TREES_DIR]/ | while read d; do
-       git worktree list --porcelain | grep -q "$d" || echo "orphan: $d"
-   done
+   ls [TREES_DIR]/
+   git -C [MAIN_REPO_ROOT] worktree list --porcelain
    ```
+   Compare the two outputs; any tree directory absent from `git worktree list --porcelain` is an orphan.
    If orphans found: Ask user before `rm -rf`.
 
 6. **Cleanup current worktree** (if requested in § 4.1 — **must be last**, destroys session cwd):

--- a/skills/orch/workflows/post-summary.md
+++ b/skills/orch/workflows/post-summary.md
@@ -19,15 +19,14 @@ Post summary comments to git host and issue tracker, and selective handoff comme
 **Standalone init** (`lifecycle: "self"` only):
 ```bash
 # Extract issue from branch if not provided
-ISSUE_ID=$(git rev-parse --abbrev-ref HEAD | grep -oiP "$GH_ISSUE_PATTERN")
-TRACKER=$(.agents/skills/orch/scripts/tracker-for-issue "$ISSUE_ID")
-WT_PATH=$(.agents/skills/worktree/scripts/worktree path $ISSUE_ID 2>/dev/null || echo ".")
-PR_NUMBER=$(.agents/skills/github/scripts/github.sh -C "$WT_PATH" pr-view --json number 2>/dev/null | jq -r .number)
+.agents/skills/orch/scripts/git-context issue-from-branch .
+.agents/skills/orch/scripts/tracker-for-issue [ISSUE_ID_FROM_PREVIOUS_COMMAND]
+.agents/skills/worktree/scripts/worktree path [ISSUE_ID_FROM_PREVIOUS_COMMAND]
+.agents/skills/github/scripts/github.sh -C [WORKTREE_PATH_FROM_PREVIOUS_COMMAND] pr-view --json number
 # Init workflow state if not exists
-if ! .agents/skills/orch/scripts/workflow-state exists $ISSUE_ID; then
-  .agents/skills/orch/scripts/workflow-state init $ISSUE_ID --worktree "$WT_PATH" --branch "$(git rev-parse --abbrev-ref HEAD)"
-fi
+.agents/skills/orch/scripts/workflow-state exists --json [ISSUE_ID]
 ```
+Use the outputs as `ISSUE_ID`, `TRACKER`, `WT_PATH`, and `PR_NUMBER`. If `.exists` is `false`, initialize with `git-context branch [WT_PATH]` and `workflow-state init`.
 
 ---
 
@@ -46,13 +45,12 @@ fi
 
 3. **Post to git host and issue tracker** — consolidate all review cycle results from state. Write to a file first (same backtick hazard as submit-pr PR body):
    ```bash
-   SUMMARY_FILE="[WORKTREE_PATH]/tmp/post-summary-[ISSUE_ID]-$(date +%Y%m%d-%H%M%S).md"
-   mkdir -p "$(dirname "$SUMMARY_FILE")"
-   cat > "$SUMMARY_FILE" <<'SUMMARY_EOF'
-   [filled SUMMARY_CONTENT — see template below]
-   SUMMARY_EOF
+   mkdir -p [WORKTREE_PATH]/tmp
+   .agents/skills/orch/scripts/git-context timestamp compact
+   # Write SUMMARY_CONTENT to [WORKTREE_PATH]/tmp/post-summary-[ISSUE_ID]-[TIMESTAMP_FROM_PREVIOUS_COMMAND].md
    .agents/skills/github/scripts/github.sh post-comment [PR_NUMBER] --body-file "$SUMMARY_FILE"
    ```
+   Use the summary file path as `SUMMARY_FILE`.
 
    Linear only — GitHub items get linkage via `Closes #N` in the PR body:
 

--- a/skills/orch/workflows/post-summary.md
+++ b/skills/orch/workflows/post-summary.md
@@ -34,12 +34,13 @@ Use the outputs as `ISSUE_ID`, `TRACKER`, `WT_PATH`, and `PR_NUMBER`. If `.exist
 
 1. **Read state**:
    ```bash
-   FIXED_COUNT=$(.agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.fixed_items | length')
-   ESCALATED_COUNT=$(.agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.escalated_items | length')
-   AUDIT_ISSUES=$(.agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.audit_issues_created | length')
-   PR_ISSUES=$(.agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.pr_comment_review.issues_created | length')
-   CYCLES=$(.agents/skills/orch/scripts/workflow-state get [ISSUE_ID] .cycles)
+   .agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.fixed_items | length'
+   .agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.escalated_items | length'
+   .agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.audit_issues_created | length'
+   .agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.pr_comment_review.issues_created | length'
+   .agents/skills/orch/scripts/workflow-state get [ISSUE_ID] .cycles
    ```
+   Use the outputs as `FIXED_COUNT`, `ESCALATED_COUNT`, `AUDIT_ISSUES`, `PR_ISSUES`, and `CYCLES`.
 
 2. **Skip if** `FIXED_COUNT == 0` AND `AUDIT_ISSUES == 0` AND `PR_ISSUES == 0` AND `ESCALATED_COUNT == 0`. → § 2
 
@@ -95,7 +96,7 @@ Use the outputs as `ISSUE_ID`, `TRACKER`, `WT_PATH`, and `PR_NUMBER`. If `.exist
 
 **Skip if** `TRACKER=github` (dependencies live in issue bodies, not tracked relations). → § 3
 
-1. **Check unblocked issues**: `.agents/skills/linear/scripts/linear.sh cache issues get [ISSUE_ID] | jq '.blocks'`
+1. **Check unblocked issues**: run `.agents/skills/linear/scripts/linear.sh cache issues get [ISSUE_ID]`, then read `.blocks` from the JSON output.
 
 2. **Evaluate conditions** — post handoff only if:
    - Downstream description references files touched in this PR

--- a/skills/orch/workflows/post-summary.md
+++ b/skills/orch/workflows/post-summary.md
@@ -20,13 +20,14 @@ Post summary comments to git host and issue tracker, and selective handoff comme
 ```bash
 # Extract issue from branch if not provided
 .agents/skills/orch/scripts/git-context issue-from-branch .
-.agents/skills/orch/scripts/tracker-for-issue [ISSUE_ID_FROM_PREVIOUS_COMMAND]
-.agents/skills/worktree/scripts/worktree path [ISSUE_ID_FROM_PREVIOUS_COMMAND]
-.agents/skills/github/scripts/github.sh -C [WORKTREE_PATH_FROM_PREVIOUS_COMMAND] pr-view --json number
+.agents/skills/orch/scripts/tracker-for-issue [ISSUE_ID]
+.agents/skills/worktree/scripts/worktree exists [ISSUE_ID]
+.agents/skills/worktree/scripts/worktree path [ISSUE_ID]
+.agents/skills/orch/scripts/pr-view-json [WT_PATH] --json number
 # Init workflow state if not exists
 .agents/skills/orch/scripts/workflow-state exists --json [ISSUE_ID]
 ```
-Use the outputs as `ISSUE_ID`, `TRACKER`, `WT_PATH`, and `PR_NUMBER`. If `.exists` is `false`, initialize with `git-context branch [WT_PATH]` and `workflow-state init`.
+Use the first output as `ISSUE_ID` and the tracker output as `TRACKER`. Use current directory as `WT_PATH` unless `worktree exists` confirms a different path. Read `PR_NUMBER` from the PR JSON output. If `.exists` is `false`, initialize with `git-context branch [WT_PATH]` and `workflow-state init`.
 
 ---
 

--- a/skills/orch/workflows/review-codebase.md
+++ b/skills/orch/workflows/review-codebase.md
@@ -37,8 +37,9 @@ mkdir -p "$WT_PATH/tmp"
 Enumerate every installed `reviewer-*` agent from active harness registries:
 
 ```bash
-AGENTS=$(.agents/skills/orch/scripts/list-review-agents)
+.agents/skills/orch/scripts/list-review-agents
 ```
+Use the output as `AGENTS`.
 
 If no agents are found, report `No reviewer-* agents installed; cannot run codebase review` and **END**. Use the full list — do not path-filter.
 

--- a/skills/orch/workflows/review-codebase.md
+++ b/skills/orch/workflows/review-codebase.md
@@ -18,8 +18,9 @@ Ad-hoc full-codebase reviewer fanout. No PR, no issue, no diff, no fix delegatio
 If `[PATH]` is provided, use it. Otherwise use current directory.
 
 ```bash
-WT_PATH=$(git -C [PATH_OR_PWD] rev-parse --show-toplevel 2>/dev/null)
+.agents/skills/orch/scripts/git-context repo-root [PATH_OR_PWD]
 ```
+Use the output as `WT_PATH`.
 
 **If not a git worktree**: report `review-codebase requires a git worktree` and **END**.
 

--- a/skills/orch/workflows/review-pr-comments.md
+++ b/skills/orch/workflows/review-pr-comments.md
@@ -39,11 +39,9 @@ On any `gh` or `.agents/skills/github/scripts/github.sh` failure: halt, report e
 Multiple bots may review on different timelines. Wait for all configured reviewers before triaging.
 
 ```bash
-WAIT_RESULT=$(.agents/skills/orch/scripts/bot-review-wait [PR_NUMBER] 15 600 --json --reviewers "$BOT_REVIEWERS")
-BOT_STATUS=$(echo  "$WAIT_RESULT" | jq -r '.status')
-BOT_VERDICT=$(echo "$WAIT_RESULT" | jq -r '.verdict')
-PENDING_REVIEWERS=$(echo "$WAIT_RESULT" | jq -r '.pending_reviewers | join(", ")')
+.agents/skills/orch/scripts/bot-review-wait [PR_NUMBER] 15 600 --json --reviewers "$BOT_REVIEWERS"
 ```
+Use the returned JSON fields as `BOT_STATUS`, `BOT_VERDICT`, and `PENDING_REVIEWERS`.
 
 `$BOT_REVIEWERS`: comma-separated bot usernames. Default: auto-detected from formal reviews, known review-bot comment summaries, PR-body reactions, and own-comment reactions. Custom comment-only bots must be configured explicitly via `BOT_REVIEWERS` / `--reviewers`.
 
@@ -52,8 +50,9 @@ PENDING_REVIEWERS=$(echo "$WAIT_RESULT" | jq -r '.pending_reviewers | join(", ")
 ### 1.2 Fetch Actionable Data
 
 ```bash
-PR_DATA=$(.agents/skills/github/scripts/github.sh pr-data "[PR_NUMBER]" --actionable)
+.agents/skills/github/scripts/github.sh pr-data "[PR_NUMBER]" --actionable
 ```
+Use the JSON output as `PR_DATA`.
 
 Output: `threads` (inline) + `comments` (PR-level).
 
@@ -132,8 +131,10 @@ Output: `threads` (inline) + `comments` (PR-level).
 
 2. **Get worktree**:
    ```bash
-   WT_PATH=$(.agents/skills/worktree/scripts/worktree path [ISSUE_ID] 2>/dev/null || echo ".")
+   .agents/skills/worktree/scripts/worktree exists [ISSUE_ID]
+   .agents/skills/worktree/scripts/worktree path [ISSUE_ID]
    ```
+   If the worktree does not exist, use `.` for `WT_PATH`; otherwise use the path output.
 
 3. **Decision context**: `.agents/skills/decider/scripts/decisions search --issue [ISSUE_ID]`. Collect matching IDs and summaries for § 3 delegation prompt.
 
@@ -310,7 +311,16 @@ Issue suggestions: [N] items → § 6.2 audit
 
 **Skip if** no items marked "Fixing" in § 5. → § 6.2
 
-1. **Ensure worktree**: `WT_PATH=$(.agents/skills/worktree/scripts/worktree path [ISSUE_ID] 2>/dev/null || .agents/skills/worktree/scripts/worktree create [ISSUE_ID] --pr [PR_NUMBER])`
+1. **Ensure worktree**:
+   ```bash
+   .agents/skills/worktree/scripts/worktree exists [ISSUE_ID]
+   .agents/skills/worktree/scripts/worktree path [ISSUE_ID]
+   ```
+   If the worktree is missing, run:
+   ```bash
+   .agents/skills/worktree/scripts/worktree create [ISSUE_ID] --pr [PR_NUMBER]
+   ```
+   Use the existing path output or create output as `WT_PATH`.
 
 2. **Group items** by `agent` field.
 
@@ -385,8 +395,9 @@ After fixes are pushed, bots re-review. Wait for new comments, then loop.
 
 2. **Check iteration limit**:
    ```bash
-   ITERATIONS=$(.agents/skills/orch/scripts/workflow-state get [ISSUE_ID] .pr_comment_review.iterations)
+   .agents/skills/orch/scripts/workflow-state get [ISSUE_ID] .pr_comment_review.iterations
    ```
+   Use the output as `ITERATIONS`.
    **If** `ITERATIONS >= 5` → § 7.
 
 3. **Wait 5 minutes** for bot re-reviews:
@@ -397,9 +408,10 @@ After fixes are pushed, bots re-review. Wait for new comments, then loop.
 4. **Check for new comments**:
    ```bash
    # Count unresolved threads + new PR-level comments since last triage
-   LAST_TS=$(.agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.pr_review_baseline.last_ts // empty')
-   NEW_THREADS=$(.agents/skills/github/scripts/github.sh pr-threads [PR_NUMBER] --unresolved --since "$LAST_TS" | jq '.count')
+   .agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.pr_review_baseline.last_ts // empty'
+   .agents/skills/github/scripts/github.sh pr-threads [PR_NUMBER] --unresolved --since "$LAST_TS"
    ```
+   Use the workflow-state output as `LAST_TS`. Read `.count` from the threads JSON output as `NEW_THREADS`.
 
 5. **Route**:
 
@@ -410,9 +422,10 @@ After fixes are pushed, bots re-review. Wait for new comments, then loop.
 
 6. **Update baseline** (before looping):
    ```bash
-   NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+   date -u +%Y-%m-%dT%H:%M:%SZ
    .agents/skills/orch/scripts/workflow-state set [ISSUE_ID] pr_review_baseline "{\"last_ts\":\"$NOW\",\"last_threads\":$NEW_THREADS}"
    ```
+   Use the date output as `NOW`.
 
 7. **Loop**: Return to § 1.2 (skip § 1.1 bot-wait on re-triage — comments already arrived).
 
@@ -508,8 +521,9 @@ If user requests fixes for skipped items → delegate via § 6.1 (single item), 
    Determine tracker:
 
    ```bash
-   TRACKER=$(.agents/skills/orch/scripts/tracker-for-issue "[ISSUE_ID]")
+   .agents/skills/orch/scripts/tracker-for-issue "[ISSUE_ID]"
    ```
+   Use the output as `TRACKER`.
 
    If `TRACKER` is `linear`, post to Linear. GitHub items get linkage via `Closes #N` in the PR body:
 

--- a/skills/orch/workflows/review-pr-comments.md
+++ b/skills/orch/workflows/review-pr-comments.md
@@ -22,13 +22,11 @@ Route PR review comments to domain agents, auto-fix valid items, loop until stab
 
 **Standalone init** (`lifecycle: "self"` only):
 ```bash
-ISSUE_ID=$(git rev-parse --abbrev-ref HEAD | grep -oiP "$GH_ISSUE_PATTERN")
-PR_NUMBER=$(gh pr view --json number -q .number 2>/dev/null)
-if ! .agents/skills/orch/scripts/workflow-state exists $ISSUE_ID; then
-  WT_PATH=$(.agents/skills/worktree/scripts/worktree path $ISSUE_ID 2>/dev/null || echo ".")
-  .agents/skills/orch/scripts/workflow-state init $ISSUE_ID --worktree "$WT_PATH" --branch "$(git rev-parse --abbrev-ref HEAD)"
-fi
+.agents/skills/orch/scripts/git-context issue-from-branch .
+gh pr view --json number -q .number
+.agents/skills/orch/scripts/workflow-state exists --json [ISSUE_ID_FROM_PREVIOUS_COMMAND]
 ```
+Use the outputs as `ISSUE_ID` and `PR_NUMBER`. If `.exists` is `false`, resolve `WT_PATH`, read the current branch with `git-context branch`, and run `workflow-state init`.
 
 ## API Error Handling
 
@@ -64,10 +62,12 @@ Output: `threads` (inline) + `comments` (PR-level).
 1. **Get baseline timestamp** for re-run filtering:
    ```bash
    mkdir -p tmp
-   GH_USER=$(gh api user -q .login)
-   .agents/skills/github/scripts/github.sh find-comment [PR_NUMBER] --pattern "Recommendations.*Processed" --author "$GH_USER" > tmp/summary_comment_[PR_NUMBER].json
-   SUMMARY_TS=$(jq -r '.updated_at // empty' tmp/summary_comment_[PR_NUMBER].json)
+   gh api user -q .login
+   .agents/skills/github/scripts/github.sh find-comment [PR_NUMBER] --pattern "Recommendations.*Processed" --author "[GH_USER_FROM_PREVIOUS_COMMAND]"
+   # Save output to tmp/summary_comment_[PR_NUMBER].json with the harness file-write tool.
+   jq -r '.updated_at // empty' tmp/summary_comment_[PR_NUMBER].json
    ```
+   Use the `jq` output as `SUMMARY_TS`.
 
 2. **Filter comments**. When `$SUMMARY_TS` is set, filter PR-level comments with `select(.created_at > $SUMMARY_TS)`.
 
@@ -498,13 +498,12 @@ If user requests fixes for skipped items → delegate via § 6.1 (single item), 
 
 2. **Post summary** — skip if no fixes AND no issues created. Write the summary to a file first so Markdown is shell-safe:
    ```bash
-   SUMMARY_FILE="[WORKTREE_PATH]/tmp/pr-comments-summary-[ISSUE_ID]-$(date +%Y%m%d-%H%M%S).md"
-   mkdir -p "$(dirname "$SUMMARY_FILE")"
-   cat > "$SUMMARY_FILE" <<'SUMMARY_EOF'
-   [filled SUMMARY_CONTENT — see template below]
-   SUMMARY_EOF
+   mkdir -p [WORKTREE_PATH]/tmp
+   .agents/skills/orch/scripts/git-context timestamp compact
+   # Write SUMMARY_CONTENT to [WORKTREE_PATH]/tmp/pr-comments-summary-[ISSUE_ID]-[TIMESTAMP_FROM_PREVIOUS_COMMAND].md
    .agents/skills/github/scripts/github.sh post-comment [PR_NUMBER] --body-file "$SUMMARY_FILE"
    ```
+   Use the summary file path as `SUMMARY_FILE`.
 
    Determine tracker:
 

--- a/skills/orch/workflows/review-pr-comments.md
+++ b/skills/orch/workflows/review-pr-comments.md
@@ -24,7 +24,7 @@ Route PR review comments to domain agents, auto-fix valid items, loop until stab
 ```bash
 .agents/skills/orch/scripts/git-context issue-from-branch .
 gh pr view --json number -q .number
-.agents/skills/orch/scripts/workflow-state exists --json [ISSUE_ID_FROM_PREVIOUS_COMMAND]
+.agents/skills/orch/scripts/workflow-state exists --json [ISSUE_ID]
 ```
 Use the outputs as `ISSUE_ID` and `PR_NUMBER`. If `.exists` is `false`, resolve `WT_PATH`, read the current branch with `git-context branch`, and run `workflow-state init`.
 

--- a/skills/orch/workflows/review-pr.md
+++ b/skills/orch/workflows/review-pr.md
@@ -27,19 +27,11 @@ Apply [Worktree Scope](../SKILL.md#worktree-scope). If no worktree exists for `$
 **Standalone init** (`lifecycle: "self"` only):
 ```bash
 # Extract issue from branch if not provided
-ISSUE_ID=$(git rev-parse --abbrev-ref HEAD | grep -oiP "$GH_ISSUE_PATTERN")
+.agents/skills/orch/scripts/git-context issue-from-branch .
 # Init workflow state if not exists
-if ! .agents/skills/orch/scripts/workflow-state exists $ISSUE_ID; then
-  .agents/skills/orch/scripts/workflow-state init $ISSUE_ID --worktree "$WT_PATH" --branch "$(git -C $WT_PATH rev-parse --abbrev-ref HEAD)"
-  TRACKER=$(.agents/skills/orch/scripts/tracker-for-issue "$ISSUE_ID")
-  if [[ "$TRACKER" == "github" ]]; then
-    QA_LABELS=$(gh issue view ${ISSUE_ID#issue-} --json labels --jq '[.labels[].name | select(startswith("needs-"))]')
-  else
-    QA_LABELS=$(.agents/skills/linear/scripts/linear.sh cache issues get $ISSUE_ID | jq '[.labels[] | select(startswith("needs-"))]')
-  fi
-  .agents/skills/orch/scripts/workflow-state set $ISSUE_ID qa_labels "$QA_LABELS"
-fi
+.agents/skills/orch/scripts/workflow-state exists --json [ISSUE_ID_FROM_PREVIOUS_COMMAND]
 ```
+Use the output as `ISSUE_ID`. If `.exists` is `false`, initialize with `git-context branch "$WT_PATH"` and `workflow-state init`, then resolve `TRACKER` and set `qa_labels` from the issue labels.
 
 ---
 
@@ -128,7 +120,7 @@ EXTERNAL_TARGET=$(.agents/skills/second-opinion/scripts/second-opinion detect 2>
 
 **Record delegation timestamp** before delegating — gates the § 3 watchdog filesystem fallback against stale JSONs from earlier cycles:
 ```bash
-.agents/skills/orch/scripts/workflow-state set [ISSUE_ID] review_delegated_at "$(date +%s)"
+.agents/skills/orch/scripts/workflow-state set-now [ISSUE_ID] review_delegated_at
 ```
 
 Delegate to each active reviewer in `[AGENTS]` in parallel. **If `EXTERNAL_REVIEW_REQUESTED=true`**, launch the external review in the *same parallel batch*.
@@ -158,8 +150,9 @@ Re-review cycle [N]. Already resolved — do NOT re-report:
 **External review execution** (only if `EXTERNAL_REVIEW_REQUESTED=true`; default timeout: `SECOND_OPINION_TIMEOUT` env var or 300s):
 
 ```bash
-TIMESTAMP=$(date +%Y%m%d-%H%M%S)
-EXTERNAL_OUTPUT="[WORKTREE_PATH]/tmp/review-external-${TIMESTAMP}.json"
+mkdir -p [WORKTREE_PATH]/tmp
+.agents/skills/orch/scripts/git-context timestamp compact
+# Use [WORKTREE_PATH]/tmp/review-external-[TIMESTAMP_FROM_PREVIOUS_COMMAND].json as EXTERNAL_OUTPUT.
 .agents/skills/second-opinion/scripts/second-opinion review \
   --cwd [WORKTREE_PATH] \
   --output "$EXTERNAL_OUTPUT"
@@ -285,7 +278,7 @@ If >4 suggestion items: show first 3 + `All N fixes`. Refine via "Other".
 
 1. **Capture pre-fix state**:
    ```bash
-   .agents/skills/orch/scripts/workflow-state set [ISSUE_ID] pre_delegate_sha "$(git -C [WORKTREE_PATH] rev-parse HEAD)"
+   .agents/skills/orch/scripts/workflow-state set-git-head [ISSUE_ID] pre_delegate_sha [WORKTREE_PATH]
    ```
 
 2. **Run Workflow**: `⤵ workflows/dev-fix.md § 1-3 → § 4 step 3` with context:
@@ -554,7 +547,7 @@ Issue suggestions: [N] items → § 9 audit
 
 3. **Capture pre-delegate state**:
    ```bash
-   .agents/skills/orch/scripts/workflow-state set [ISSUE_ID] pre_delegate_sha "$(git -C [WORKTREE_PATH] rev-parse HEAD)"
+   .agents/skills/orch/scripts/workflow-state set-git-head [ISSUE_ID] pre_delegate_sha [WORKTREE_PATH]
    ```
 
 4. **Delegate immediately.** Do **not** surface a Defer/Skip prompt — § 10 is mandatory once § 9 created `make_child` issues under `[ISSUE_ID]`.

--- a/skills/orch/workflows/review-pr.md
+++ b/skills/orch/workflows/review-pr.md
@@ -30,7 +30,7 @@ Apply [Worktree Scope](../SKILL.md#worktree-scope). If no worktree exists for `$
 # Extract issue from branch if not provided
 .agents/skills/orch/scripts/git-context issue-from-branch .
 # Init workflow state if not exists
-.agents/skills/orch/scripts/workflow-state exists --json [ISSUE_ID_FROM_PREVIOUS_COMMAND]
+.agents/skills/orch/scripts/workflow-state exists --json [ISSUE_ID]
 ```
 Use the output as `ISSUE_ID`. If `.exists` is `false`, initialize with `git-context branch "$WT_PATH"` and `workflow-state init`, then resolve `TRACKER` and set `qa_labels` from the issue labels.
 

--- a/skills/orch/workflows/review-pr.md
+++ b/skills/orch/workflows/review-pr.md
@@ -19,8 +19,9 @@ Pre-submission code review: fix handling, QA checks, and issue audit.
 
 **If PR# provided:**
 ```bash
-ISSUE=$(.agents/skills/github/scripts/github.sh pr-issue [PR_NUMBER] --format=text)
+.agents/skills/github/scripts/github.sh pr-issue [PR_NUMBER] --format=text
 ```
+Use the output as `ISSUE`.
 
 Apply [Worktree Scope](../SKILL.md#worktree-scope). If no worktree exists for `$ISSUE`, ask the user before running `worktree create $ISSUE --pr [PR_NUMBER]`. If no argument: set `WT_PATH` to current directory.
 
@@ -62,10 +63,11 @@ Collect decision IDs and summaries from the JSON output. If decisions found: inc
 ### 1.2 Check for Re-Review Context
 
 ```bash
-CYCLES=$(.agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.cycles // 0')
-FIXED=$(.agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.fixed_items // []')
-ESCALATED=$(.agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.escalated_items // []')
+.agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.cycles // 0'
+.agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.fixed_items // []'
+.agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.escalated_items // []'
 ```
+Use the outputs as `CYCLES`, `FIXED`, and `ESCALATED`.
 
 If `CYCLES > 0`: include the "Previous review cycle context" section in the delegation prompt, populated from `FIXED` and `ESCALATED`.
 
@@ -73,26 +75,25 @@ If `CYCLES > 0`: include the "Previous review cycle context" section in the dele
 
 **Detect team context**:
 ```bash
-TEAM=$(.agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.team_name // empty')
+.agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.team_name // empty'
 ```
+Use the output as `TEAM`.
 
 **Determine agent list**: If `agents` context provided, use only those. Otherwise enumerate every `reviewer-*` agent from active harness registries (do not hardcode a count):
 
 ```bash
-AGENTS=$(.agents/skills/orch/scripts/list-review-agents)
-if [ $? -ne 0 ] || [ -z "$AGENTS" ]; then
-  echo "No reviewer-* agents installed in any harness registry; skipping review delegation" >&2
-  # → § 5 (verdict pass, no items to handle)
-fi
+.agents/skills/orch/scripts/list-review-agents
 ```
+Use the output as `AGENTS`. If the command fails or prints no agents, skip review delegation and go to § 5 with verdict pass.
 
 `list-review-agents` scans `.pi/agents`, `.claude/agents`, `.agents`, `.codex/agents`, and `.opencode/agents` for `reviewer-*` files, dedupes, and exits non-zero if none found. Output: one agent name per line.
 
 Before any spawn, read existing reviewer state:
 ```bash
-EXISTING_REVIEW_AGENTS=$(.agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.review_agents // []')
-EXISTING_REVIEW_AGENT_IDS=$(.agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.review_agent_ids // {}')
+.agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.review_agents // []'
+.agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.review_agent_ids // {}'
 ```
+Use the outputs as `EXISTING_REVIEW_AGENTS` and `EXISTING_REVIEW_AGENT_IDS`.
 
 For each reviewer in `[AGENTS]`: reuse by exact name when `review_agent_ids` points to a live/recoverable session. If only `review_agents` exists, attempt one recovery/resume, then treat as missing. Spawn only the missing, closed, or confirmed-stuck reviewer. Do not respawn already-live reviewers.
 
@@ -111,8 +112,9 @@ External review runs automatically alongside internal reviewers when the second-
 **Skip if** `.agents/skills/second-opinion/scripts/second-opinion` does not exist. Set `EXTERNAL_REVIEW_REQUESTED=false` → § 2.2.
 
 ```bash
-EXTERNAL_TARGET=$(.agents/skills/second-opinion/scripts/second-opinion detect 2>/dev/null) || true
+.agents/skills/second-opinion/scripts/second-opinion detect
 ```
+If the command fails or prints `none`, set `EXTERNAL_REVIEW_REQUESTED=false`. Otherwise use the output as `EXTERNAL_TARGET`.
 
 **Skip if** `EXTERNAL_TARGET` is empty or `"none"`. Set `EXTERNAL_REVIEW_REQUESTED=false` → § 2.2. Otherwise `EXTERNAL_REVIEW_REQUESTED=true` → § 2.2.
 
@@ -291,9 +293,10 @@ If >4 suggestion items: show first 3 + `All N fixes`. Refine via "Other".
 
 3. **Route based on fix scope**:
    ```bash
-   PRE_SHA=$(.agents/skills/orch/scripts/workflow-state get [ISSUE_ID] .pre_delegate_sha)
+   .agents/skills/orch/scripts/workflow-state get [ISSUE_ID] .pre_delegate_sha
    .agents/skills/github/scripts/git-diff-summary -C [WORKTREE_PATH] $PRE_SHA
    ```
+   Use the workflow-state output as `PRE_SHA`.
 
    | `files_changed` | `risk_flags` | `scope` | Route |
    |-----------------|--------------|---------|-------|
@@ -317,8 +320,9 @@ If >4 suggestion items: show first 3 + `All N fixes`. Refine via "Other".
 
 2. **Check skip_qa flag**:
    ```bash
-   SKIP_QA=$(.agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.skip_qa // false')
+   .agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.skip_qa // false'
    ```
+   Use the output as `SKIP_QA`.
    If `true`: `.agents/skills/orch/scripts/workflow-state set [ISSUE_ID] skip_qa false` → § 8
 
 3. **Read state**: `.agents/skills/orch/scripts/workflow-state get [ISSUE_ID] .qa_labels`
@@ -502,9 +506,10 @@ Issue suggestions: [N] items → § 9 audit
 
 2. **Extract discovered work** from completion summaries — **Linear only**; GitHub/ad-hoc: parse the dev agent's return message for a "Discovered Work" section instead:
    ```bash
-   .agents/skills/linear/scripts/linear.sh cache comments list [ISSUE_ID] | jq -r '.[] | select(.body | contains("Discovered Work")) | .body'
+   .agents/skills/linear/scripts/linear.sh cache comments list [ISSUE_ID]
    ```
-   If bundled: also check sub-issues via `.agents/skills/linear/scripts/linear.sh cache issues get [ISSUE_ID] --with-bundle | jq -r '.children[].id'`.
+   Read matching comments from the JSON output with the filter `.[] | select(.body | contains("Discovered Work")) | .body`.
+   If bundled: also run `.agents/skills/linear/scripts/linear.sh cache issues get [ISSUE_ID] --with-bundle` and read `.children[].id` from the JSON output.
    Parse "Discovered Work" bullets into audit items with `origin: "discovered"`, `found_by: [agent]`. Skip if section absent or "(Skip if none)".
 
    **Filter out workflow-internal handoffs.** Skip any Discovered Work bullet whose leading token after `- ` is one of the markers below. The marker MUST be the first token — anything before it (such as `[Type]`) prevents the match. The canonical bullet form is documented in `dev/workflows/dev-implement.md` § 9:
@@ -555,9 +560,9 @@ Issue suggestions: [N] items → § 9 audit
    If delegation is skipped (user override, escalation), § 10 must FIRST detach every `audit_issues_created` entry from `[ISSUE_ID]` before returning to § 11 — otherwise `merge-pr.md` will cascade-Done them.
 
    ```bash
-   .agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.audit_issues_created // []' | jq -r '.[]'
+   .agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.audit_issues_created // []'
    ```
-   Capture each line as `[CHILD_ID]`, then for each:
+   Read each array item as `[CHILD_ID]`, then for each:
    ```bash
    .agents/skills/linear/scripts/linear.sh issues update [CHILD_ID] --remove-parent
    .agents/skills/linear/scripts/linear.sh issues add-relation [CHILD_ID] --related [ISSUE_ID]
@@ -572,9 +577,10 @@ Issue suggestions: [N] items → § 9 audit
 
 5. **Assess re-review scope**:
    ```bash
-   PRE_SHA=$(.agents/skills/orch/scripts/workflow-state get [ISSUE_ID] .pre_delegate_sha)
+   .agents/skills/orch/scripts/workflow-state get [ISSUE_ID] .pre_delegate_sha
    .agents/skills/github/scripts/git-diff-summary -C [WORKTREE_PATH] $PRE_SHA
    ```
+   Use the workflow-state output as `PRE_SHA`.
 
    | `risk_flags` | `scope` | Action | Route |
    |--------------|---------|--------|-------|

--- a/skills/orch/workflows/review.md
+++ b/skills/orch/workflows/review.md
@@ -174,7 +174,7 @@ Ask user (omit categories with no items):
 
 1. **Capture pre-fix state** (if `ISSUE_ID` exists):
    ```bash
-   .agents/skills/orch/scripts/workflow-state set [ISSUE_ID] pre_delegate_sha "$(git rev-parse HEAD)"
+   .agents/skills/orch/scripts/workflow-state set-git-head [ISSUE_ID] pre_delegate_sha [WORKTREE_PATH]
    ```
 
 2. **Run Workflow**: `⤵ workflows/dev-fix.md § 1-3 → § 4.1 step 3` with context:

--- a/skills/orch/workflows/review.md
+++ b/skills/orch/workflows/review.md
@@ -59,13 +59,16 @@ Collect decision IDs and summaries from JSON output.
 
 **Detect team context:**
 ```bash
-TEAM=$(.agents/skills/orch/scripts/workflow-state get $ISSUE_ID '.team_name // empty' 2>/dev/null) || true
+.agents/skills/orch/scripts/workflow-state exists --json [ISSUE_ID]
+.agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.team_name // empty'
 ```
+If state does not exist, use an empty `TEAM`.
 
 **Determine agent list**:
 ```bash
-AGENTS=$(.agents/skills/orch/scripts/list-review-agents)
+.agents/skills/orch/scripts/list-review-agents
 ```
+Use the output as `AGENTS`.
 
 Delegate to each review agent in parallel:
 

--- a/skills/orch/workflows/start-worktree.md
+++ b/skills/orch/workflows/start-worktree.md
@@ -90,8 +90,9 @@ If invoked as `start github OWNER/REPO#N`, parse it before initialization:
 
 1. **Resolve tracker**:
    ```bash
-   TRACKER=$(.agents/skills/orch/scripts/tracker-for-issue "[ISSUE_ID]")
+   .agents/skills/orch/scripts/tracker-for-issue "[ISSUE_ID]"
    ```
+   Use the output as `TRACKER`.
 
 2. **Skip if** `TRACKER=github` (GitHub issues close via PR merge keywords). → § 5.4
 
@@ -106,14 +107,15 @@ If invoked as `start github OWNER/REPO#N`, parse it before initialization:
 
 1. **Read final state**:
    ```bash
-   CYCLES=$(.agents/skills/orch/scripts/workflow-state get [ISSUE_ID] .cycles)
-   FIXED_COUNT=$(.agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.fixed_items | length')
-   ESCALATED_COUNT=$(.agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.escalated_items | length')
-   PR_ITERATIONS=$(.agents/skills/orch/scripts/workflow-state get [ISSUE_ID] .pr_comment_review.iterations)
-   PR_FIXES=$(.agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.pr_comment_review.fixes | length')
-   PR_ISSUES=$(.agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.pr_comment_review.issues_created | length')
-   AUDIT_ISSUES=$(.agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.audit_issues_created | length')
+   .agents/skills/orch/scripts/workflow-state get [ISSUE_ID] .cycles
+   .agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.fixed_items | length'
+   .agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.escalated_items | length'
+   .agents/skills/orch/scripts/workflow-state get [ISSUE_ID] .pr_comment_review.iterations
+   .agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.pr_comment_review.fixes | length'
+   .agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.pr_comment_review.issues_created | length'
+   .agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.audit_issues_created | length'
    ```
+   Use the outputs as `CYCLES`, `FIXED_COUNT`, `ESCALATED_COUNT`, `PR_ITERATIONS`, `PR_FIXES`, `PR_ISSUES`, and `AUDIT_ISSUES`.
 
 2. **Output session summary**:
 

--- a/skills/orch/workflows/start.md
+++ b/skills/orch/workflows/start.md
@@ -70,11 +70,12 @@ If the issue is not open, stop and ask for a different item.
 3. Create/reuse worktree:
    ```bash
    # Linear
-   WT_PATH=$(.agents/skills/worktree/scripts/worktree create [ISSUE_ID])
+   .agents/skills/worktree/scripts/worktree create [ISSUE_ID]
 
    # GitHub
-   WT_PATH=$(.agents/skills/worktree/scripts/worktree create issue-[N])
+   .agents/skills/worktree/scripts/worktree create issue-[N]
    ```
+   Use the create output as `WT_PATH`.
 
 ## 5. Handoff Or Continue
 

--- a/skills/orch/workflows/submit-pr.md
+++ b/skills/orch/workflows/submit-pr.md
@@ -111,9 +111,11 @@ Use the first output as `ISSUE_ID`. Use the worktree output as `WT_PATH`; if no 
    **No existing PR** → create with `defer-ci` label. Always pass the body via `--body-file`:
    ```bash
    # Linear
-   ISSUE_TITLE=$(.agents/skills/linear/scripts/linear.sh cache issues get [ISSUE_ID] | jq -r '.title')
+   .agents/skills/linear/scripts/linear.sh cache issues get [ISSUE_ID]
+   # Read `.title` from the JSON output and use it as ISSUE_TITLE.
    # GitHub
-   ISSUE_TITLE=$(gh issue view ${ISSUE_ID#issue-} --json title --jq '.title')
+   gh issue view [N] --json title --jq '.title'
+   # Use the output as ISSUE_TITLE.
 
    .agents/skills/github/scripts/github.sh -C "[WORKTREE_PATH]" pr-create \
      --title "[PREFIX]([ISSUE_ID]): $ISSUE_TITLE" \
@@ -123,9 +125,10 @@ Use the first output as `ISSUE_ID`. Use the worktree output as `WT_PATH`; if no 
 
    **Existing PR** (`$PR_NUM` set) → update body and ensure label:
    ```bash
-   gh pr edit "$PR_NUM" --body-file "$BODY_FILE" 2>/dev/null || true
-   .agents/skills/github/scripts/commands/label-add.sh "$PR_NUM" defer-ci --reason "queue for bot review before CI" 2>/dev/null || true
+   gh pr edit "$PR_NUM" --body-file "$BODY_FILE"
+   .agents/skills/github/scripts/commands/label-add.sh "$PR_NUM" defer-ci --reason "queue for bot review before CI"
    ```
+   If either command fails because the PR no longer exists or the label is already present, report the failure and continue only when the state is understood.
 
 ---
 
@@ -134,11 +137,9 @@ Use the first output as `ISSUE_ID`. Use the worktree output as `WT_PATH`; if no 
 Wait for bot review to complete (sticky comment with verdict). CI is deferred via label.
 
 ```bash
-WAIT_RESULT=$(.agents/skills/orch/scripts/bot-review-wait [PR_NUMBER] 15 600 --json --reviewers "$BOT_REVIEWERS")
-BOT_STATUS=$(echo "$WAIT_RESULT"  | jq -r '.status')
-BOT_VERDICT=$(echo "$WAIT_RESULT" | jq -r '.verdict')
-PENDING_REVIEWERS=$(echo "$WAIT_RESULT" | jq -r '.pending_reviewers | join(", ")')
+.agents/skills/orch/scripts/bot-review-wait [PR_NUMBER] 15 600 --json --reviewers "$BOT_REVIEWERS"
 ```
+Use the returned JSON fields as `BOT_STATUS`, `BOT_VERDICT`, and `PENDING_REVIEWERS`.
 
 Waits for all configured bot reviewers (`$BOT_REVIEWERS`). Auto-detects if not configured. Max wait 600s. Understands Claude-style (formal review + sticky verdict comment) and Codex-style (reactions + inline threads) signaling. Unrelated automation comments do not block. `status=complete` only when no reviewer is pending. If sticky prose is stale but GitHub reports `reviewDecision=APPROVED`, any configured `BOT_CHECK_NAME` has passed, and no unresolved review threads remain, `bot-review-wait` returns approved with `pr_review_decision:approved` and `pr_threads:clear` signals without waiting on the stale checklist. To ignore a reviewer: `--skip "bot-login"` or `BOT_SKIPPED_REVIEWERS`.
 
@@ -160,16 +161,9 @@ Waits for all configured bot reviewers (`$BOT_REVIEWERS`). Auto-detects if not c
 
 ```bash
 # "Wait 5 min" path: extend checklist wait
-EXT_ELAPSED=0
-while [ $EXT_ELAPSED -lt 300 ]; do
-  CHECKLIST_DONE=$(.agents/skills/github/scripts/github.sh sticky-comment [PR_NUMBER] --body 2>/dev/null \
-    | grep -c '^\s*- \[ \]' || true)
-  if [ "$CHECKLIST_DONE" -eq 0 ]; then break; fi
-  sleep 30
-  EXT_ELAPSED=$((EXT_ELAPSED + 30))
-done
-# → § 3 regardless
+.agents/skills/orch/scripts/bot-review-wait [PR_NUMBER] 30 300 --json --reviewers "$BOT_REVIEWERS"
 ```
+Use the returned JSON status and pending reviewer fields to re-route. If it still reports checklist timeout or pending reviewers, ask the user `Wait` | `Skip pending bot` | `Abort`; otherwise continue to § 3.
 
 **Extended poll** (timeout + pending only):
 ```bash
@@ -181,12 +175,10 @@ fi
 if [[ -n "${BOT_SKIPPED_REVIEWERS:-}" ]]; then
   BOT_WAIT_ARGS+=(--skip "$BOT_SKIPPED_REVIEWERS")
 fi
-WAIT_RESULT=$(.agents/skills/orch/scripts/bot-review-wait "${BOT_WAIT_ARGS[@]}")
-BOT_STATUS=$(echo "$WAIT_RESULT"  | jq -r '.status')
-BOT_VERDICT=$(echo "$WAIT_RESULT" | jq -r '.verdict')
-PENDING_REVIEWERS=$(echo "$WAIT_RESULT" | jq -r '.pending_reviewers | join(", ")')
+.agents/skills/orch/scripts/bot-review-wait "${BOT_WAIT_ARGS[@]}"
 # Proceed to § 3 if complete/terminal; otherwise ask with pending reviewers.
 ```
+Use the returned JSON fields as `BOT_STATUS`, `BOT_VERDICT`, and `PENDING_REVIEWERS`.
 
 ---
 
@@ -203,12 +195,10 @@ PENDING_REVIEWERS=$(echo "$WAIT_RESULT" | jq -r '.pending_reviewers | join(", ")
    if [[ -n "${BOT_SKIPPED_REVIEWERS:-}" ]]; then
      BOT_WAIT_ARGS+=(--skip "$BOT_SKIPPED_REVIEWERS")
    fi
-   WAIT_RESULT=$(.agents/skills/orch/scripts/bot-review-wait "${BOT_WAIT_ARGS[@]}")
-   BOT_STATUS=$(echo "$WAIT_RESULT"  | jq -r '.status')
-   BOT_VERDICT=$(echo "$WAIT_RESULT" | jq -r '.verdict')
-   PENDING_REVIEWERS=$(echo "$WAIT_RESULT" | jq -r '.pending_reviewers | join(", ")')
+   .agents/skills/orch/scripts/bot-review-wait "${BOT_WAIT_ARGS[@]}"
    # Proceed if complete/terminal; if still pending, include PENDING_REVIEWERS in triage notes.
    ```
+   Use the returned JSON fields as `BOT_STATUS`, `BOT_VERDICT`, and `PENDING_REVIEWERS`.
 
 2. **Run Workflow**: `⤵ workflows/review-pr-comments.md [PR_NUMBER] § 1-8 → § 3.1` with context:
    - `lifecycle`: `"managed"`
@@ -244,12 +234,10 @@ After fixes pushed, wait for bot re-review (CI still deferred). Re-run `workflow
 
 1. **Check iteration count**:
    ```bash
-   ITERATIONS=$(.agents/skills/orch/scripts/workflow-state get [ISSUE_ID] .pr_comment_review.iterations)
+   .agents/skills/orch/scripts/workflow-state get [ISSUE_ID] .pr_comment_review.iterations
    # Max 3 iterations
-   if [ "$ITERATIONS" -ge 3 ]; then
-     # → Max iterations exceeded → § 4
-   fi
    ```
+   Use the output as `ITERATIONS`. If `ITERATIONS >= 3`, go to § 4.
 
 2. **Wait for bot re-review** after fixes pushed:
    ```bash
@@ -257,8 +245,9 @@ After fixes pushed, wait for bot re-review (CI still deferred). Re-run `workflow
    .agents/skills/orch/scripts/bot-review-wait [PR_NUMBER]
 
    # 2. Read baseline from state
-   LAST_TS=$(.agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.pr_review_baseline.last_ts // empty')
-   LAST_THREADS=$(.agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.pr_review_baseline.last_threads // 0')
+   .agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.pr_review_baseline.last_ts // empty'
+   .agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.pr_review_baseline.last_threads // 0'
+   # Use the outputs as LAST_TS and LAST_THREADS.
 
    # 3. Check status against baseline
    .agents/skills/github/scripts/github.sh pr-review-status [PR_NUMBER] --baseline-ts "$LAST_TS" --baseline-threads "$LAST_THREADS"
@@ -297,8 +286,9 @@ Sub-issues created during comment triage need implementation before CI.
 
 1. **Check cycle count**:
    ```bash
-   SUBMIT_CYCLES=$(.agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.submit_cycles // 0')
+   .agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.submit_cycles // 0'
    ```
+   Use the output as `SUBMIT_CYCLES`.
    **If** `SUBMIT_CYCLES >= 2` → § 4 with note: "Max re-submit cycles reached, created issues may need manual implementation."
 
 2. **Increment**:
@@ -326,8 +316,10 @@ Sub-issues created during comment triage need implementation before CI.
 **Skip if** the issue does not have the `design` label.
 
 ```bash
-LABELS=$(.agents/skills/linear/scripts/linear.sh cache issues get "$ISSUE_ID" --format=compact 2>/dev/null | jq -r '.labels[]' 2>/dev/null)
+.agents/skills/linear/scripts/linear.sh cache issues get "[ISSUE_ID]" --format=compact
+jq -r '.labels[]' [ISSUE_JSON_FROM_PREVIOUS_COMMAND]
 ```
+Use the `jq` output as `LABELS`. For GitHub items, read labels with `gh issue view [N] --json labels --jq '.labels[].name'`.
 
 If `design` label present:
 
@@ -352,14 +344,12 @@ All bot review comments resolved (or max iterations). Verify no late-arriving th
    ```bash
    # Wait for late-arriving threads (bot posts inline comments after sticky update)
    sleep 15
-   UNRESOLVED=$(.agents/skills/github/scripts/github.sh pr-threads [PR_NUMBER] --unresolved | jq '.unresolved_count')
-   if [ "$UNRESOLVED" -eq 0 ]; then
-     # Double-check after additional delay to catch very late threads
-     sleep 15
-     UNRESOLVED=$(.agents/skills/github/scripts/github.sh pr-threads [PR_NUMBER] --unresolved | jq '.unresolved_count')
-   fi
-   CI_GATE_REROUTED=$(.agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.pr_comment_review.ci_gate_rerouted // false')
+   .agents/skills/github/scripts/github.sh pr-threads [PR_NUMBER] --unresolved
+   # Read `.unresolved_count` from the JSON output and use it as UNRESOLVED.
+   # If UNRESOLVED is 0, sleep 15 and run the same command again to double-check.
+   .agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.pr_comment_review.ci_gate_rerouted // false'
    ```
+   Use the workflow-state output as `CI_GATE_REROUTED`.
 
    | `UNRESOLVED` | `CI_GATE_REROUTED` | Action |
    |--------------|---------------------|--------|

--- a/skills/orch/workflows/submit-pr.md
+++ b/skills/orch/workflows/submit-pr.md
@@ -15,9 +15,10 @@ Push changes, create/update PR, handle bot review, triage PR comments, and trigg
 **If PR# provided:**
 ```bash
 .agents/skills/github/scripts/github.sh pr-issue [PR_NUMBER] --format=text
-.agents/skills/worktree/scripts/worktree path [ISSUE_ID_FROM_PREVIOUS_COMMAND]
+.agents/skills/worktree/scripts/worktree exists [ISSUE_ID]
+.agents/skills/worktree/scripts/worktree path [ISSUE_ID]
 ```
-Use the first output as `ISSUE_ID`. Use the second output as `WT_PATH`; if no worktree exists, use `.`.
+Use the first output as `ISSUE_ID`. If the worktree exists, use the path output as `WT_PATH`; otherwise ask before creating or use the current directory when already inside the PR checkout.
 
 Resolve `TRACKER` per [Tracker Resolution](../SKILL.md#tracker-resolution).
 
@@ -26,10 +27,11 @@ Resolve `TRACKER` per [Tracker Resolution](../SKILL.md#tracker-resolution).
 **Standalone init** (`lifecycle: "self"` only):
 ```bash
 .agents/skills/orch/scripts/git-context issue-from-branch .
-.agents/skills/worktree/scripts/worktree path [ISSUE_ID_FROM_PREVIOUS_COMMAND]
+.agents/skills/worktree/scripts/worktree exists [ISSUE_ID]
+.agents/skills/worktree/scripts/worktree path [ISSUE_ID]
 .agents/skills/orch/scripts/workflow-state exists --json [ISSUE_ID]
 ```
-Use the first output as `ISSUE_ID`. Use the worktree output as `WT_PATH`; if no worktree exists, use `.`. If `.exists` is `false`, initialize:
+Use the first output as `ISSUE_ID`. For no-arg standalone flow, prefer the current directory as `WT_PATH`; use the worktree path output only when `worktree exists` confirms it. If `.exists` is `false`, initialize:
 
 ```bash
 .agents/skills/orch/scripts/git-context branch "$WT_PATH"
@@ -63,9 +65,9 @@ Use the first output as `ISSUE_ID`. Use the worktree output as `WT_PATH`; if no 
 
 3. **Check for existing PR**:
    ```bash
-   .agents/skills/github/scripts/github.sh -C "[WORKTREE_PATH]" pr-view --json number,state
+   .agents/skills/orch/scripts/pr-view-json "[WORKTREE_PATH]" --json number,state
    ```
-   If status is `no_pr`, create a new PR in step 5. For auth, token, timeout, or unparseable errors, stop and report the JSON error.
+   Use the JSON output as `PR_VIEW`. If `status` is `no_pr`, create a new PR in step 5. For auth, token, timeout, or unparseable errors, stop and report the JSON error.
 
 4. **Build PR body** from current workflow state using the template below (omit empty sections).
 
@@ -317,9 +319,8 @@ Sub-issues created during comment triage need implementation before CI.
 
 ```bash
 .agents/skills/linear/scripts/linear.sh cache issues get "[ISSUE_ID]" --format=compact
-jq -r '.labels[]' [ISSUE_JSON_FROM_PREVIOUS_COMMAND]
 ```
-Use the `jq` output as `LABELS`. For GitHub items, read labels with `gh issue view [N] --json labels --jq '.labels[].name'`.
+Read `.labels[]` from the JSON output and use it as `LABELS`. For GitHub items, read labels with `gh issue view [N] --json labels --jq '.labels[].name'`.
 
 If `design` label present:
 

--- a/skills/orch/workflows/submit-pr.md
+++ b/skills/orch/workflows/submit-pr.md
@@ -14,9 +14,10 @@ Push changes, create/update PR, handle bot review, triage PR comments, and trigg
 
 **If PR# provided:**
 ```bash
-ISSUE_ID=$(.agents/skills/github/scripts/github.sh pr-issue [PR_NUMBER] --format=text)
-WT_PATH=$(.agents/skills/worktree/scripts/worktree path $ISSUE_ID 2>/dev/null || echo ".")
+.agents/skills/github/scripts/github.sh pr-issue [PR_NUMBER] --format=text
+.agents/skills/worktree/scripts/worktree path [ISSUE_ID_FROM_PREVIOUS_COMMAND]
 ```
+Use the first output as `ISSUE_ID`. Use the second output as `WT_PATH`; if no worktree exists, use `.`.
 
 Resolve `TRACKER` per [Tracker Resolution](../SKILL.md#tracker-resolution).
 
@@ -24,11 +25,15 @@ Resolve `TRACKER` per [Tracker Resolution](../SKILL.md#tracker-resolution).
 
 **Standalone init** (`lifecycle: "self"` only):
 ```bash
-ISSUE_ID=$(git rev-parse --abbrev-ref HEAD | grep -oiP "$GH_ISSUE_PATTERN")
-WT_PATH=$(.agents/skills/worktree/scripts/worktree path $ISSUE_ID 2>/dev/null || echo ".")
-if ! .agents/skills/orch/scripts/workflow-state exists $ISSUE_ID; then
-  .agents/skills/orch/scripts/workflow-state init $ISSUE_ID --worktree "$WT_PATH" --branch "$(git rev-parse --abbrev-ref HEAD)"
-fi
+.agents/skills/orch/scripts/git-context issue-from-branch .
+.agents/skills/worktree/scripts/worktree path [ISSUE_ID_FROM_PREVIOUS_COMMAND]
+.agents/skills/orch/scripts/workflow-state exists --json [ISSUE_ID]
+```
+Use the first output as `ISSUE_ID`. Use the worktree output as `WT_PATH`; if no worktree exists, use `.`. If `.exists` is `false`, initialize:
+
+```bash
+.agents/skills/orch/scripts/git-context branch "$WT_PATH"
+.agents/skills/orch/scripts/workflow-state init [ISSUE_ID] --worktree "$WT_PATH" --branch "[BRANCH_FROM_PREVIOUS_COMMAND]"
 ```
 
 ---
@@ -37,17 +42,17 @@ fi
 
 1. **Preflight committed work**:
    ```bash
-   BASE_BRANCH=$(.agents/skills/orch/scripts/resolve-base-branch "[WORKTREE_PATH]")
-   CURRENT_BRANCH=$(git -C "[WORKTREE_PATH]" branch --show-current)
+   .agents/skills/orch/scripts/resolve-base-branch "[WORKTREE_PATH]"
+   .agents/skills/orch/scripts/git-context branch "[WORKTREE_PATH]"
    git -C "[WORKTREE_PATH]" status --porcelain
-   git -C "[WORKTREE_PATH]" diff "origin/$BASE_BRANCH"...HEAD --stat
+   git -C "[WORKTREE_PATH]" diff "origin/[BASE_BRANCH_FROM_PREVIOUS_COMMAND]"...HEAD --stat
    ```
 
    Stop before pushing if any condition is true:
-   - `CURRENT_BRANCH` is empty (detached HEAD).
-   - `CURRENT_BRANCH` equals `$BASE_BRANCH`.
+   - The current branch output is empty (detached HEAD).
+   - The current branch output equals the base branch output.
    - `git status --porcelain` is not empty.
-   - The committed diff against `origin/$BASE_BRANCH` is empty.
+   - The committed diff against the base branch output is empty.
 
    In managed lifecycle, return to the caller with the failed preflight so the dev agent can normalize the branch and commit or clean the worktree. Do not create a PR from dirty or detached state.
 
@@ -58,43 +63,19 @@ fi
 
 3. **Check for existing PR**:
    ```bash
-   mkdir -p tmp
-   PR_VIEW_RC=0
-   PR_VIEW_JSON=$(.agents/skills/github/scripts/github.sh -C "[WORKTREE_PATH]" pr-view --json number,state 2>tmp/pr-view.err) || PR_VIEW_RC=$?
-   if [ "$PR_VIEW_RC" -eq 0 ]; then
-     PR_NUM=$(echo "$PR_VIEW_JSON" | jq -r '.number // empty')
-   else
-     PR_VIEW_STATUS=$(echo "$PR_VIEW_JSON" | jq -r '.status // "error"' 2>/dev/null || echo "error")
-     case "$PR_VIEW_STATUS" in
-       no_pr)
-         PR_NUM=""
-         ;;
-       auth_error|token_resolution_failed|token_resolution_timeout|token_resolution_unavailable|auth_timeout|gh_timeout|gh_error)
-         echo "PR lookup failed ($PR_VIEW_STATUS): $(echo "$PR_VIEW_JSON" | jq -r '.error // empty')" >&2
-         cat tmp/pr-view.err >&2
-         exit "$PR_VIEW_RC"
-         ;;
-       *)
-         echo "PR lookup failed with unparseable output" >&2
-         cat tmp/pr-view.err >&2
-         exit "$PR_VIEW_RC"
-         ;;
-     esac
-   fi
+   .agents/skills/github/scripts/github.sh -C "[WORKTREE_PATH]" pr-view --json number,state
    ```
+   If status is `no_pr`, create a new PR in step 5. For auth, token, timeout, or unparseable errors, stop and report the JSON error.
 
 4. **Build PR body** from current workflow state using the template below (omit empty sections).
 
-   **PR body MUST be written to a file** — inline bodies with backticks or fenced code blocks corrupt under shell command substitution. Use a quoted heredoc (disables interpolation) or your harness's `Write` tool:
+   **PR body MUST be written to a file** — inline bodies with backticks or fenced code blocks corrupt under shell command substitution. Prefer your harness's file-write tool:
 
    ```bash
-   BODY_FILE="[WORKTREE_PATH]/tmp/pr-body-[ISSUE_ID]-$(date +%Y%m%d-%H%M%S).md"
-   mkdir -p "$(dirname "$BODY_FILE")"
-   cat > "$BODY_FILE" <<'PR_BODY_EOF'
-   ## Summary
-   - ...
-   PR_BODY_EOF
+   mkdir -p [WORKTREE_PATH]/tmp
+   .agents/skills/orch/scripts/git-context timestamp compact
    ```
+   Write the PR body to `[WORKTREE_PATH]/tmp/pr-body-[ISSUE_ID]-[TIMESTAMP_FROM_PREVIOUS_COMMAND].md` and use that path as `BODY_FILE`.
 
    ```markdown
    ## Summary
@@ -194,8 +175,12 @@ done
 ```bash
 # Re-run multi-reviewer wait every 30s for up to 300s more.
 BOT_WAIT_ARGS=([PR_NUMBER] 30 300 --json)
-[[ -n "${BOT_REVIEWERS:-}" ]] && BOT_WAIT_ARGS+=(--reviewers "$BOT_REVIEWERS")
-[[ -n "${BOT_SKIPPED_REVIEWERS:-}" ]] && BOT_WAIT_ARGS+=(--skip "$BOT_SKIPPED_REVIEWERS")
+if [[ -n "${BOT_REVIEWERS:-}" ]]; then
+  BOT_WAIT_ARGS+=(--reviewers "$BOT_REVIEWERS")
+fi
+if [[ -n "${BOT_SKIPPED_REVIEWERS:-}" ]]; then
+  BOT_WAIT_ARGS+=(--skip "$BOT_SKIPPED_REVIEWERS")
+fi
 WAIT_RESULT=$(.agents/skills/orch/scripts/bot-review-wait "${BOT_WAIT_ARGS[@]}")
 BOT_STATUS=$(echo "$WAIT_RESULT"  | jq -r '.status')
 BOT_VERDICT=$(echo "$WAIT_RESULT" | jq -r '.verdict')
@@ -212,8 +197,12 @@ PENDING_REVIEWERS=$(echo "$WAIT_RESULT" | jq -r '.pending_reviewers | join(", ")
 1. **Bot completion pre-check** — ensure all configured/detected bot reviewers have terminal status before triaging:
    ```bash
    BOT_WAIT_ARGS=([PR_NUMBER] 30 180 --json)
-   [[ -n "${BOT_REVIEWERS:-}" ]] && BOT_WAIT_ARGS+=(--reviewers "$BOT_REVIEWERS")
-   [[ -n "${BOT_SKIPPED_REVIEWERS:-}" ]] && BOT_WAIT_ARGS+=(--skip "$BOT_SKIPPED_REVIEWERS")
+   if [[ -n "${BOT_REVIEWERS:-}" ]]; then
+     BOT_WAIT_ARGS+=(--reviewers "$BOT_REVIEWERS")
+   fi
+   if [[ -n "${BOT_SKIPPED_REVIEWERS:-}" ]]; then
+     BOT_WAIT_ARGS+=(--skip "$BOT_SKIPPED_REVIEWERS")
+   fi
    WAIT_RESULT=$(.agents/skills/orch/scripts/bot-review-wait "${BOT_WAIT_ARGS[@]}")
    BOT_STATUS=$(echo "$WAIT_RESULT"  | jq -r '.status')
    BOT_VERDICT=$(echo "$WAIT_RESULT" | jq -r '.verdict')
@@ -272,7 +261,8 @@ After fixes pushed, wait for bot re-review (CI still deferred). Re-run `workflow
    LAST_THREADS=$(.agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.pr_review_baseline.last_threads // 0')
 
    # 3. Check status against baseline
-   .agents/skills/github/scripts/github.sh pr-review-status [PR_NUMBER] --baseline-ts "$LAST_TS" --baseline-threads "$LAST_THREADS" > tmp/pr_status_[PR_NUMBER].json
+   .agents/skills/github/scripts/github.sh pr-review-status [PR_NUMBER] --baseline-ts "$LAST_TS" --baseline-threads "$LAST_THREADS"
+   # Save output to tmp/pr_status_[PR_NUMBER].json with the harness file-write tool.
    ```
 
 3. **Route based on status**:
@@ -293,10 +283,11 @@ After fixes pushed, wait for bot re-review (CI still deferred). Re-run `workflow
    # Add fixes/issues/skipped (same as § 3.1 step 3)
 
    # Update baseline
-   NEW_TS=$(jq -r '.sticky_updated_at' tmp/pr_status_[PR_NUMBER].json)
-   NEW_THREADS=$(jq -r '.unresolved_threads' tmp/pr_status_[PR_NUMBER].json)
+   jq -r '.sticky_updated_at' tmp/pr_status_[PR_NUMBER].json
+   jq -r '.unresolved_threads' tmp/pr_status_[PR_NUMBER].json
    .agents/skills/orch/scripts/workflow-state set [ISSUE_ID] pr_review_baseline "{\"last_ts\":\"$NEW_TS\",\"last_threads\":$NEW_THREADS}"
    ```
+   Use the two `jq` outputs as `NEW_TS` and `NEW_THREADS`.
 
 5. **Max iterations exceeded**: Report to user with status, recommendation, and proceed to § 4.
 
@@ -434,13 +425,12 @@ All bot review comments resolved (or max iterations). Verify no late-arriving th
 
 2. **Post summary** — skip if no fixes AND no issues created. Write to a file first (same backtick hazard as PR body):
    ```bash
-   SUMMARY_FILE="[WORKTREE_PATH]/tmp/submit-summary-[ISSUE_ID]-$(date +%Y%m%d-%H%M%S).md"
-   mkdir -p "$(dirname "$SUMMARY_FILE")"
-   cat > "$SUMMARY_FILE" <<'SUMMARY_EOF'
-   [filled SUMMARY_CONTENT — see template below]
-   SUMMARY_EOF
+   mkdir -p [WORKTREE_PATH]/tmp
+   .agents/skills/orch/scripts/git-context timestamp compact
+   # Write SUMMARY_CONTENT to [WORKTREE_PATH]/tmp/submit-summary-[ISSUE_ID]-[TIMESTAMP_FROM_PREVIOUS_COMMAND].md
    .agents/skills/github/scripts/github.sh post-comment [PR_NUMBER] --body-file "$SUMMARY_FILE"
    ```
+   Use the summary file path as `SUMMARY_FILE`.
 
    Linear only — GitHub items get linkage via `Closes #N` in the PR body:
 

--- a/skills/reviewer/workflows/review.md
+++ b/skills/reviewer/workflows/review.md
@@ -24,9 +24,8 @@ Extract from delegation message:
 if [[ -n "$DIFF_RANGE" ]]; then
   git -C [WORKTREE_PATH] diff $DIFF_RANGE
 else
-  BASE_BRANCH=${WORKTREE_DEFAULT_BRANCH:-$(git -C [WORKTREE_PATH] symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')}
-  [ -n "$BASE_BRANCH" ] || BASE_BRANCH=main
-  git -C [WORKTREE_PATH] diff "origin/$BASE_BRANCH"...HEAD
+  .agents/skills/orch/scripts/resolve-base-branch [WORKTREE_PATH]
+  git -C [WORKTREE_PATH] diff "origin/[BASE_BRANCH_FROM_PREVIOUS_COMMAND]"...HEAD
 fi
 ```
 


### PR DESCRIPTION
## Summary
- Added Codex-safe orch helpers for git context, workflow-state writes, and no-PR PR lookup routing.
- Reworked orch/dev/reviewer workflow snippets to avoid command substitution, redirection-heavy fallback commands, and chained shell expressions in generated guidance.
- Preserved lower-case worktree issue extraction behavior and documented the new helper usage.

## Completed Issues
- Closes #369 - Codex harness rejects workflow shell helper shapes with command substitution/redirection

## QA Metrics
- Review cycle: 1
- Review fixes applied: 1
- Focused re-review: correctness, quality, and docs all passed
- `defer-ci` label not applied because the repository does not define it.

## Test Plan
- `bash skills/orch/tests/run-all.sh`
- `bash -n skills/orch/scripts/git-context skills/orch/scripts/workflow-state skills/orch/scripts/pr-view-json`
- `git diff --check origin/main...HEAD`
- `skills/orch/scripts/git-context issue-from-branch .`
- `rg -n "\$\(|>\s*tmp/|cat >|&&|\|\||2>/dev/null|sed 's@|symbolic-ref" skills/orch/workflows skills/reviewer/workflows skills/dev/workflows -g '*.md'`
