### PR TITLE
fix(issue-392): make benchmark QA guidance Codex-safe

### DIFF
--- a/skills/orch/tests/workflow_helpers.sh
+++ b/skills/orch/tests/workflow_helpers.sh
@@ -113,6 +113,7 @@ orch_skill="$REPO_ROOT/skills/orch/SKILL.md"
 submit_workflow="$REPO_ROOT/skills/orch/workflows/submit-pr.md"
 comments_workflow="$REPO_ROOT/skills/orch/workflows/review-pr-comments.md"
 merge_workflow="$REPO_ROOT/skills/orch/workflows/merge-pr.md"
+qa_workflow="$REPO_ROOT/skills/reviewer/workflows/qa-review.md"
 
 assert_file_contains "$orch_skill" "#### Harness-Safe Shell" "orch skill documents Harness-Safe Shell section"
 assert_file_contains "$orch_skill" 'Avoid inline `$(...)`, shell `for`/`while` loops' "Harness-Safe Shell section bans unsafe shell helper shapes"
@@ -129,6 +130,12 @@ done
 assert_file_not_contains "$merge_workflow" "fetch --all --prune" "merge-pr avoids all-remote fetch during sync"
 assert_file_contains "$merge_workflow" "git-https-auth -C [MAIN_REPO_ROOT] fetch --prune origin" "merge-pr sync fetches origin through HTTPS auth helper"
 assert_file_contains "$merge_workflow" "git-https-auth -C [MAIN_REPO_ROOT] pull --rebase origin [BASE_BRANCH]" "merge-pr sync pulls origin base branch through HTTPS auth helper"
+
+assert_file_not_contains "$qa_workflow" "Pipe benchmark output" "qa-review avoids pipe-based benchmark recording"
+assert_file_not_contains "$qa_workflow" "pipe results" "qa-review avoids pipe-based perf capture guidance"
+assert_file_contains "$qa_workflow" "Do not use shell pipelines" "qa-review bans Codex-unsafe benchmark shell plumbing"
+assert_file_contains "$qa_workflow" "benchmark recorder fails closed on all-zero counters" "qa-review documents all-zero recorder fallback"
+assert_file_contains "$qa_workflow" "targeted regression command reports numeric regressions" "qa-review reports targeted numeric regressions"
 
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/skills/reviewer/workflows/qa-review.md
+++ b/skills/reviewer/workflows/qa-review.md
@@ -55,9 +55,16 @@ When the benchmarking skill's regression check exits with code 1, classify every
 
 **Skip if** not the performance QA agent.
 
-- **Backend changes**: Pipe benchmark output through the benchmarking skill's parser for automatic recording
-- **Frontend/UI changes**: Run a project-specific perf capture tool and pipe results to the benchmarking skill's record command
-- **Manual entry**: Run the benchmarking skill's record command with the component name and JSON data
+- Use the project's benchmarking skill's direct runner or recorder commands when
+  they are documented as standalone commands.
+- Do not use shell pipelines, redirection, heredocs, `tee`, `cat >`, inline
+  environment assignment, command substitution, or shell plumbing to capture or
+  record benchmark output under Codex `approval=never`.
+- If the only documented recording path requires shell plumbing, stop and report
+  the harness gap instead of inventing an alternate command shape.
+- If manual entry is supported, pass the component name and JSON data only by a
+  documented direct argument or body-file option. Do not create the body file
+  with shell redirection.
 
 See the project's benchmarking skill for full recording details if available.
 
@@ -70,6 +77,16 @@ If the parser records zero results, stop and report the harness gap instead of
 counting the run as benchmark coverage. Common causes are missing required
 features, parser prefix drift after bench refactors, or tool output format
 changes.
+
+If the benchmark recorder fails closed on all-zero counters, report a benchmark
+environment/tooling failure. Include the command, commit, and error evidence in
+the QA report, set `benchmark_commit` to `"none"`, and do not bypass the failure
+with manual benchmark data.
+
+If a targeted regression command reports numeric regressions but an aggregate
+validation command passes, classify and report the targeted numeric regressions.
+The aggregate validation result is supporting context, not a substitute for the
+targeted regression output.
 
 **Note**: Benchmark results may be symlinked to the main repo in worktrees. Results are written directly to main's directory — no commit needed. Record the latest commit SHA from your worktree branch as the benchmark commit in your return output (§ 3).
 


### PR DESCRIPTION
## Summary
- replace pipe-based performance QA benchmark recording guidance with Codex-safe direct-command guidance
- document all-zero benchmark recorder failure handling and targeted regression reporting
- add regression checks to the orch workflow helper test

Fixes #392

## Tests
- bash skills/orch/tests/workflow_helpers.sh
- bash skills/orch/tests/run-all.sh
- git diff --check