### PR TITLE
[codex] Clarify TPM audit relation cache lookup

### DIFF
--- a/skills/project-management/tests/label-preflight-contract.test.sh
+++ b/skills/project-management/tests/label-preflight-contract.test.sh
@@ -56,4 +56,13 @@ if grep -R --line-number --fixed-strings -- '["agent:researcher", "research", DO
   fail 'hard-coded research create label remains in VALIDATED_LABELS'
 fi
 
+unsupported_relations_cmd="cache issues relation""s"
+if grep -R --line-number --fixed-strings -- "$unsupported_relations_cmd" "$SKILL_DIR/workflows" "$SKILL_DIR/README.md" "$SKILL_DIR/SKILL.md" "$SKILL_DIR/references" "$SKILL_DIR/schemas"; then
+  fail 'unsupported Linear cache relation lookup subcommand remains in project-management docs'
+fi
+
+tpm_audit="$SKILL_DIR/workflows/tpm-audit.md"
+require_pattern "$tpm_audit" 'cache issues get \[ISSUE_ID\]' 'supported cached issue fetch for relation analysis'
+require_pattern "$tpm_audit" 'blocks`, `blocked_by`, and `related`' 'relation fields from cached issue JSON'
+
 echo "all pass"

--- a/skills/project-management/workflows/tpm-audit.md
+++ b/skills/project-management/workflows/tpm-audit.md
@@ -72,6 +72,8 @@ Store project IDs and metadata for cross-project analysis.
 ```bash
 .agents/skills/linear/scripts/linear.sh cache issues get [ISSUE_ID]
 ```
+Use the returned issue JSON for relation analysis. The supported cache payload includes `blocks`, `blocked_by`, and `related`; do not call a separate relation cache subcommand.
+
 For proposed issues, use provided fields directly.
 
 ### 1.5 Fetch Comparison Set


### PR DESCRIPTION
## Summary

- Clarifies TPM audit issue-mode guidance to use `cache issues get [ISSUE_ID]` output for relation analysis.
- Adds a project-management contract regression that rejects the stale unsupported relation lookup wording and requires the supported cache fetch/fields in `tpm-audit.md`.

## Root Cause

The TPM audit workflow did not explicitly tell delegated agents where relation data should come from in issue mode, which allowed a stale unsupported cache relation lookup shape to appear during an audit run.

## Validation

- `bash skills/project-management/tests/label-preflight-contract.test.sh`
- `bash skills/linear/tests/cache-no-auth.test.sh`
- `git diff --check HEAD~1 HEAD`

Closes #398
