### PR TITLE
fix(#397): Support documented Linear relation aliases

### DIFF
--- a/skills/linear/README.md
+++ b/skills/linear/README.md
@@ -38,6 +38,8 @@ Use `comments create ISSUE --body-file tmp/comment.md` for Markdown or multi-lin
 
 `issues bulk-update` applies each issue update independently. If one update fails after earlier items changed, the command emits a JSON summary with `partial: true`, per-issue success/error entries, and exits nonzero.
 
+Use explicit list actions for dependency reads: `issues list-relations ISSUE` and `projects list-dependencies PROJECT`. The older read-only aliases `issues relations` and `projects dependencies` remain accepted for compatibility, but new workflows should use the explicit names.
+
 ## Configuration
 
 | Variable | Purpose | Default |

--- a/skills/linear/SKILL.md
+++ b/skills/linear/SKILL.md
@@ -36,9 +36,9 @@ CLI wrapper for Linear's GraphQL API with local cache, bulk operations, and stru
 
 | Resource | Actions |
 |----------|---------|
-| `issues` | list, get, create, update, children, relations, bulk-get, bulk-update |
+| `issues` | list, get, create, update, children, list-relations, add-relation, remove-relation, bulk-get, bulk-update |
 | `comments` | list, create (`--body` or `--body-file`) |
-| `projects` | list, get, create, update, dependencies, updates |
+| `projects` | list, get, create, update, list-dependencies, add-dependency, remove-dependency, post-update, list-updates |
 | `initiatives` | list, get, create, add-project |
 | `milestones` | list, get, create |
 | `labels` | list, create |
@@ -51,6 +51,8 @@ CLI wrapper for Linear's GraphQL API with local cache, bulk operations, and stru
 | `sync` | Sync Linear data to local cache |
 | `cache` | Query local cache (issues, projects, cycles, initiatives, comments, labels, attachments) |
 | `auth-check` | Validate API key |
+
+Compatibility aliases: `issues relations` maps to `issues list-relations`, and `projects dependencies` maps to `projects list-dependencies`. Prefer the explicit action names in new workflows.
 
 ## Hierarchy
 

--- a/skills/linear/scripts/commands/cache-query.sh
+++ b/skills/linear/scripts/commands/cache-query.sh
@@ -1017,7 +1017,7 @@ main() {
         list) cache_list_issues "$@" ;;
         get) cache_get_issue "$@" ;;
         children) cache_list_children "$@" ;;
-        list-relations) cache_list_relations "${1:-}" ;;
+        list-relations | relations) cache_list_relations "${1:-}" ;;
         list-comments) cache_list_comments "$@" ;;
         validate-completion) cache_validate_completion "$@" ;;
         bulk-get) cache_bulk_get_issues "$@" ;;
@@ -1034,7 +1034,7 @@ main() {
         case "$action" in
         list) cache_list_projects "$@" ;;
         get) cache_get_project "$@" ;;
-        list-dependencies) cache_list_dependencies "${1:-}" ;;
+        list-dependencies | dependencies) cache_list_dependencies "${1:-}" ;;
         --help | -h) show_help ;;
         *)
             echo "{\"error\": \"Unknown projects action: $action\"}" >&2

--- a/skills/linear/scripts/commands/issues.sh
+++ b/skills/linear/scripts/commands/issues.sh
@@ -2231,7 +2231,7 @@ main() {
         fi
         list_children "$@"
         ;;
-    list-relations)
+    list-relations | relations)
         if [ -z "${1:-}" ] || [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
             show_help
             exit 0

--- a/skills/linear/scripts/commands/projects.sh
+++ b/skills/linear/scripts/commands/projects.sh
@@ -92,7 +92,7 @@ Examples:
   projects.sh delete <id>
 
   # Project dependencies
-  projects.sh list-dependencies <project-id>
+  projects.sh list-dependencies <id-or-name>
   projects.sh add-dependency <project-id> --blocked-by <other-id>
   projects.sh add-dependency <project-id> --blocks <other-id>
   projects.sh remove-dependency <relation-id>

--- a/skills/linear/scripts/commands/projects.sh
+++ b/skills/linear/scripts/commands/projects.sh
@@ -610,7 +610,39 @@ delete_project() {
 }
 
 list_dependencies() {
-    local project_id="$1"
+    local project_id=""
+    FORMAT="raw"
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+        --format)
+            if [ -z "${2:-}" ]; then
+                echo '{"error": "Missing value for --format"}' >&2
+                return 1
+            fi
+            FORMAT="$2"
+            shift 2
+            ;;
+        --format=*)
+            FORMAT="${1#--format=}"
+            shift
+            ;;
+        *)
+            if [ -z "$project_id" ]; then
+                project_id="$1"
+                shift
+            else
+                echo "{\"error\": \"Unexpected argument: $1\"}" >&2
+                return 1
+            fi
+            ;;
+        esac
+    done
+
+    if [ -z "$project_id" ]; then
+        echo '{"error": "Project ID or name required"}' >&2
+        return 1
+    fi
 
     local query='
     query GetProjectDependencies($id: String!) {
@@ -639,7 +671,17 @@ list_dependencies() {
     }'
 
     local variables="{\"id\": \"$project_id\"}"
-    graphql_query "$query" "$variables"
+    local result
+    result=$(graphql_query "$query" "$variables")
+
+    case "$FORMAT" in
+    raw)
+        echo "$result"
+        ;;
+    safe | *)
+        format_project_dependencies "$result"
+        ;;
+    esac
 }
 
 add_dependency() {
@@ -1185,12 +1227,12 @@ delete)
     fi
     delete_project "$1"
     ;;
-list-dependencies)
+list-dependencies | dependencies)
     if [ -z "${1:-}" ]; then
         echo '{"error": "Usage: projects.sh list-dependencies <id>"}' >&2
         exit 1
     fi
-    list_dependencies "$1"
+    list_dependencies "$@"
     ;;
 add-dependency)
     if [ -z "${1:-}" ]; then

--- a/skills/linear/scripts/commands/projects.sh
+++ b/skills/linear/scripts/commands/projects.sh
@@ -644,6 +644,11 @@ list_dependencies() {
         return 1
     fi
 
+    local resolved_project_id
+    if ! resolved_project_id=$(resolve_project_id "$project_id"); then
+        return 1
+    fi
+
     local query='
     query GetProjectDependencies($id: String!) {
         project(id: $id) {
@@ -670,7 +675,7 @@ list_dependencies() {
         }
     }'
 
-    local variables="{\"id\": \"$project_id\"}"
+    local variables="{\"id\": \"$resolved_project_id\"}"
     local result
     result=$(graphql_query "$query" "$variables")
 

--- a/skills/linear/scripts/lib/common.sh
+++ b/skills/linear/scripts/lib/common.sh
@@ -440,13 +440,15 @@ resolve_project_id() {
 
     # Look up by name
     local query='query GetProject($name: String!) { projects(filter: {name: {eq: $name}}) { nodes { id } } }'
+    local variables
+    variables=$(jq -nc --arg name "$project_ref" '{name: $name}')
     local result
-    result=$(graphql_query "$query" "{\"name\": \"$project_ref\"}")
+    result=$(graphql_query "$query" "$variables")
     local project_id
     project_id=$(echo "$result" | jq -r '.projects.nodes[0].id // empty')
 
     if [ -z "$project_id" ]; then
-        echo "{\"error\": \"Project not found: $project_ref\"}" >&2
+        jq -nc --arg message "Project not found: $project_ref" '{error: $message}' >&2
         return 1
     fi
 

--- a/skills/linear/scripts/lib/formatters.sh
+++ b/skills/linear/scripts/lib/formatters.sh
@@ -290,6 +290,28 @@ format_project_single() {
     }'
 }
 
+format_project_dependencies() {
+    local raw="$1"
+    echo "$raw" | jq '.project | {
+        id: .id,
+        name: (.name // ""),
+        blocked_by: [(.relations.nodes // [])[] | select(.type == "dependency") | {
+            relation_id: .id,
+            id: .relatedProject.id,
+            name: .relatedProject.name,
+            state: (.relatedProject.state // ""),
+            progress: (.relatedProject.progress // 0)
+        }],
+        blocks: [(.inverseRelations.nodes // [])[] | select(.type == "dependency") | {
+            relation_id: .id,
+            id: .project.id,
+            name: .project.name,
+            state: (.project.state // ""),
+            progress: (.project.progress // 0)
+        }]
+    }'
+}
+
 # Format projects list to IDs only
 format_projects_ids() {
     local raw="$1"

--- a/skills/linear/scripts/linear.sh
+++ b/skills/linear/scripts/linear.sh
@@ -13,9 +13,9 @@ Linear GraphQL API CLI
 Usage: ./linear.sh <resource> <action> [options]
 
 Resources:
-  issues          Issue operations (list, get, create, update, children, relations)
+  issues          Issue operations (list, get, create, update, children, list-relations, add-relation)
   comments        Comment operations (list, create/update; supports --body-file)
-  projects        Project operations (list, get, create, update, dependencies, updates)
+  projects        Project operations (list, get, create, update, list-dependencies, add-dependency, updates)
   initiatives     Initiative operations (list, get, create, add-project)
   milestones      Project milestone operations (list, get, create)
   labels          Issue label operations (list, create)
@@ -34,12 +34,14 @@ Examples:
   # Issues with parent/sub-issues and relations
   ./linear.sh issues list --label "backend" --state "Todo,In Progress"
   ./linear.sh issues create --title "Task" --parent PROJ-42
+  ./linear.sh issues list-relations PROJ-42
   ./linear.sh issues add-relation PROJ-42 --blocks PROJ-43
   ./linear.sh issues children PROJ-42              # Direct children
   ./linear.sh issues children PROJ-42 --recursive  # All descendants (3 levels)
 
   # Projects with dependencies and health updates
   ./linear.sh projects list --state started
+  ./linear.sh projects list-dependencies <id>
   ./linear.sh projects add-dependency <id> --blocked-by <other-id>
   ./linear.sh projects post-update <id> --health on-track --body "Progressing well"
 

--- a/skills/linear/scripts/linear.sh
+++ b/skills/linear/scripts/linear.sh
@@ -15,7 +15,7 @@ Usage: ./linear.sh <resource> <action> [options]
 Resources:
   issues          Issue operations (list, get, create, update, children, list-relations, add-relation)
   comments        Comment operations (list, create/update; supports --body-file)
-  projects        Project operations (list, get, create, update, list-dependencies, add-dependency, updates)
+  projects        Project operations (list, get, create, update, list-dependencies, add-dependency, post-update, list-updates)
   initiatives     Initiative operations (list, get, create, add-project)
   milestones      Project milestone operations (list, get, create)
   labels          Issue label operations (list, create)

--- a/skills/linear/tests/action-aliases.test.sh
+++ b/skills/linear/tests/action-aliases.test.sh
@@ -17,12 +17,24 @@ cat >"$TMP_ROOT/bin/curl" <<'SH'
 config="$(cat)"
 payload="$(sed -n 's/^data = //p' <<<"$config" | jq -r)"
 query="$(jq -r '.query' <<<"$payload")"
+variables="$(jq -c '.variables' <<<"$payload")"
 
 case "$query" in
 *"GetRelations"*)
   printf '%s' '{"data":{"issue":{"identifier":"PROJ-42","title":"Current","relations":{"nodes":[{"id":"rel-1","type":"blocks","relatedIssue":{"id":"issue-43","identifier":"PROJ-43","title":"Downstream","state":{"name":"Todo"}}}]},"inverseRelations":{"nodes":[{"id":"rel-2","type":"blocks","issue":{"id":"issue-41","identifier":"PROJ-41","title":"Upstream","state":{"name":"In Progress"}}}]}}}}___HTTP_CODE___200'
   ;;
+*"projects(filter: {name: {eq: \$name}}"*)
+  if [[ "$(jq -r '.name' <<<"$variables")" != "Tech Debt & Bugs" ]]; then
+    printf '%s' '{"errors":[{"message":"unexpected project name"}]}___HTTP_CODE___200'
+    exit 0
+  fi
+  printf '%s' '{"data":{"projects":{"nodes":[{"id":"project-1"}]}}}___HTTP_CODE___200'
+  ;;
 *"GetProjectDependencies"*)
+  if [[ "$(jq -r '.id' <<<"$variables")" != "project-1" ]]; then
+    printf '%s' '{"errors":[{"message":"dependencies query did not use resolved project id"}]}___HTTP_CODE___200'
+    exit 0
+  fi
   printf '%s' '{"data":{"project":{"id":"project-1","name":"Tech Debt & Bugs","relations":{"nodes":[{"id":"dep-1","type":"dependency","anchorType":"project","relatedAnchorType":"project","relatedProject":{"id":"project-0","name":"Foundation","state":"started","progress":0.5}}]},"inverseRelations":{"nodes":[{"id":"dep-2","type":"dependency","anchorType":"project","relatedAnchorType":"project","project":{"id":"project-2","name":"Followup","state":"planned","progress":0}}]}}}}___HTTP_CODE___200'
   ;;
 *)

--- a/skills/linear/tests/action-aliases.test.sh
+++ b/skills/linear/tests/action-aliases.test.sh
@@ -24,7 +24,7 @@ case "$query" in
   printf '%s' '{"data":{"issue":{"identifier":"PROJ-42","title":"Current","relations":{"nodes":[{"id":"rel-1","type":"blocks","relatedIssue":{"id":"issue-43","identifier":"PROJ-43","title":"Downstream","state":{"name":"Todo"}}}]},"inverseRelations":{"nodes":[{"id":"rel-2","type":"blocks","issue":{"id":"issue-41","identifier":"PROJ-41","title":"Upstream","state":{"name":"In Progress"}}}]}}}}___HTTP_CODE___200'
   ;;
 *"projects(filter: {name: {eq: \$name}}"*)
-  if [[ "$(jq -r '.name' <<<"$variables")" != "Tech Debt & Bugs" ]]; then
+  if [[ "$(jq -r '.name' <<<"$variables")" != 'Project "Quoted"' ]]; then
     printf '%s' '{"errors":[{"message":"unexpected project name"}]}___HTTP_CODE___200'
     exit 0
   fi
@@ -35,7 +35,7 @@ case "$query" in
     printf '%s' '{"errors":[{"message":"dependencies query did not use resolved project id"}]}___HTTP_CODE___200'
     exit 0
   fi
-  printf '%s' '{"data":{"project":{"id":"project-1","name":"Tech Debt & Bugs","relations":{"nodes":[{"id":"dep-1","type":"dependency","anchorType":"project","relatedAnchorType":"project","relatedProject":{"id":"project-0","name":"Foundation","state":"started","progress":0.5}}]},"inverseRelations":{"nodes":[{"id":"dep-2","type":"dependency","anchorType":"project","relatedAnchorType":"project","project":{"id":"project-2","name":"Followup","state":"planned","progress":0}}]}}}}___HTTP_CODE___200'
+  printf '%s' '{"data":{"project":{"id":"project-1","name":"Project \"Quoted\"","relations":{"nodes":[{"id":"dep-1","type":"dependency","anchorType":"project","relatedAnchorType":"project","relatedProject":{"id":"project-0","name":"Foundation","state":"started","progress":0.5}}]},"inverseRelations":{"nodes":[{"id":"dep-2","type":"dependency","anchorType":"project","relatedAnchorType":"project","project":{"id":"project-2","name":"Followup","state":"planned","progress":0}}]}}}}___HTTP_CODE___200'
   ;;
 *)
   printf '%s' '{"errors":[{"message":"unexpected query"}]}___HTTP_CODE___200'
@@ -56,10 +56,10 @@ fi
 
 projects_out="$(
   PATH="$TMP_ROOT/bin:$PATH" LINEAR_API_KEY=test-token \
-    bash "$TMP_ROOT/.agents/skills/linear/scripts/linear.sh" projects dependencies "Tech Debt & Bugs" --format=safe
+    bash "$TMP_ROOT/.agents/skills/linear/scripts/linear.sh" projects dependencies 'Project "Quoted"' --format=safe
 )"
 
-if ! jq -e '.name == "Tech Debt & Bugs" and .blocked_by[0].name == "Foundation" and .blocks[0].name == "Followup"' >/dev/null <<<"$projects_out"; then
+if ! jq -e '.name == "Project \"Quoted\"" and .blocked_by[0].name == "Foundation" and .blocks[0].name == "Followup"' >/dev/null <<<"$projects_out"; then
   echo "FAIL projects dependencies alias returned unexpected output: $projects_out"
   exit 1
 fi

--- a/skills/linear/tests/action-aliases.test.sh
+++ b/skills/linear/tests/action-aliases.test.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Regression test: documented legacy action aliases should route to the
+# canonical relation/dependency list commands.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+mkdir -p "$TMP_ROOT/.agents/skills" "$TMP_ROOT/bin"
+cp -R "$SKILL_DIR" "$TMP_ROOT/.agents/skills/linear"
+
+cat >"$TMP_ROOT/bin/curl" <<'SH'
+#!/usr/bin/env bash
+config="$(cat)"
+payload="$(sed -n 's/^data = //p' <<<"$config" | jq -r)"
+query="$(jq -r '.query' <<<"$payload")"
+
+case "$query" in
+*"GetRelations"*)
+  printf '%s' '{"data":{"issue":{"identifier":"PROJ-42","title":"Current","relations":{"nodes":[{"id":"rel-1","type":"blocks","relatedIssue":{"id":"issue-43","identifier":"PROJ-43","title":"Downstream","state":{"name":"Todo"}}}]},"inverseRelations":{"nodes":[{"id":"rel-2","type":"blocks","issue":{"id":"issue-41","identifier":"PROJ-41","title":"Upstream","state":{"name":"In Progress"}}}]}}}}___HTTP_CODE___200'
+  ;;
+*"GetProjectDependencies"*)
+  printf '%s' '{"data":{"project":{"id":"project-1","name":"Tech Debt & Bugs","relations":{"nodes":[{"id":"dep-1","type":"dependency","anchorType":"project","relatedAnchorType":"project","relatedProject":{"id":"project-0","name":"Foundation","state":"started","progress":0.5}}]},"inverseRelations":{"nodes":[{"id":"dep-2","type":"dependency","anchorType":"project","relatedAnchorType":"project","project":{"id":"project-2","name":"Followup","state":"planned","progress":0}}]}}}}___HTTP_CODE___200'
+  ;;
+*)
+  printf '%s' '{"errors":[{"message":"unexpected query"}]}___HTTP_CODE___200'
+  ;;
+esac
+SH
+chmod +x "$TMP_ROOT/bin/curl"
+
+issues_out="$(
+  PATH="$TMP_ROOT/bin:$PATH" LINEAR_API_KEY=test-token \
+    bash "$TMP_ROOT/.agents/skills/linear/scripts/linear.sh" issues relations PROJ-42 --format=safe
+)"
+
+if ! jq -e '.blocks[0].id == "PROJ-43" and .blocked_by[0].id == "PROJ-41"' >/dev/null <<<"$issues_out"; then
+  echo "FAIL issues relations alias returned unexpected output: $issues_out"
+  exit 1
+fi
+
+projects_out="$(
+  PATH="$TMP_ROOT/bin:$PATH" LINEAR_API_KEY=test-token \
+    bash "$TMP_ROOT/.agents/skills/linear/scripts/linear.sh" projects dependencies "Tech Debt & Bugs" --format=safe
+)"
+
+if ! jq -e '.name == "Tech Debt & Bugs" and .blocked_by[0].name == "Foundation" and .blocks[0].name == "Followup"' >/dev/null <<<"$projects_out"; then
+  echo "FAIL projects dependencies alias returned unexpected output: $projects_out"
+  exit 1
+fi
+
+echo "all pass"


### PR DESCRIPTION
## Summary
- Added compatibility aliases for documented Linear read actions: `issues relations` and `projects dependencies`.
- Added safe project dependency formatting and project-name resolution for `projects dependencies/list-dependencies`.
- Updated Linear skill docs/help to prefer explicit actions while documenting legacy aliases.

## Completed Issues
- Closes #397 - Linear skill documents unsupported dependencies/relations actions

## QA Metrics
- Internal review: arch, correctness, doc, error, perf, quality, safety, security, structure, and test reviewers passed after fix cycles.
- Review fixes applied:
  - `9e5fc7c7` resolved project-name dependency lookup and top-level help wording.
  - `995b6475` clarified `list-dependencies <id-or-name>` help.
  - `94602f0` escaped project-name lookup variables for quoted names.

## Test Plan
- `bash skills/linear/tests/action-aliases.test.sh`
- `bash skills/linear/tests/bulk-update-diagnostics.test.sh`
- `bash skills/linear/tests/cache-no-auth.test.sh`
- `bash skills/linear/tests/comments-body-file.test.sh`
- `bash skills/linear/tests/update-emit-newline.test.sh`
- `cd cli && cargo test`
