### PR TITLE
fix(issue-395): skip duplicate terminal completion emits

### DIFF
--- a/pi-extensions/pi-agents-tmux/extensions/subagent/tasks.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/tasks.ts
@@ -732,6 +732,13 @@ function warnCompletionRetryableLock(filePath: string, error: unknown): void {
 	console.warn(`pi-agents-tmux completion collection could not persist task registry state while the registry lock was busy; leaving ${filePath} in place for retry: ${stringifyError(error)}`);
 }
 
+function isPersistedCompletionDuplicate(existing: PaneTaskRecord | undefined, agentName: string, status: PaneTaskStatus): boolean {
+	if (!existing || existing.agent !== agentName) return false;
+	if (!existing.completedAt && !existing.completionArchivePath) return false;
+	if (isTerminalTaskStatus(existing.status)) return true;
+	return existing.status === "needs_completion" && status === "needs_completion";
+}
+
 async function ensureCompletionOutboxRetrySource(filePath: string, archivePath: string, completion: PaneCompletion, error: unknown): Promise<void> {
 	if (await fileExists(filePath)) return;
 	try {
@@ -810,8 +817,9 @@ async function pollPaneCompletionsUnlocked(runtimeRoot: string, pi: ExtensionAPI
 				const taskId = completion.taskId || path.basename(filePath, path.extname(filePath));
 				const dedupKey = paneCompletionDedupKey(runtimeRoot, agentName, taskId);
 				const existing = tasks[taskId];
+				const completionStatus = normalizePaneTaskStatus(completion.status);
 				const alreadyEmitted = emittedPaneCompletionKeys.has(dedupKey)
-					|| Boolean(existing && existing.agent === agentName && (isTerminalTaskStatus(existing.status) || existing.status === "needs_completion") && (existing.completedAt || existing.completionArchivePath));
+					|| isPersistedCompletionDuplicate(existing, agentName, completionStatus);
 				if (alreadyEmitted) {
 					try {
 						const archivePath = await archiveCompletion(runtimeRoot, agentName, filePath);
@@ -833,7 +841,7 @@ async function pollPaneCompletionsUnlocked(runtimeRoot: string, pi: ExtensionAPI
 				let completionAlreadyPersisted = false;
 				tasks = await updateTaskRegistry(runtimeRoot, (records) => {
 					const existing = records[detail.taskId];
-					if (existing && existing.agent === agentName && (isTerminalTaskStatus(existing.status) || existing.status === "needs_completion") && (existing.completedAt || existing.completionArchivePath)) {
+					if (isPersistedCompletionDuplicate(existing, agentName, detail.status)) {
 						completionAlreadyPersisted = true;
 						return;
 					}

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/tasks.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/tasks.ts
@@ -830,8 +830,13 @@ async function pollPaneCompletionsUnlocked(runtimeRoot: string, pi: ExtensionAPI
 				}
 				let detail = paneCompletionDetailsFromCompletion(completion, agentDir.name, filePath, undefined, registry, tasks);
 				await beforeCompletionRegistryUpdateForTests?.({ filePath, runtimeRoot, taskId: detail.taskId });
+				let completionAlreadyPersisted = false;
 				tasks = await updateTaskRegistry(runtimeRoot, (records) => {
 					const existing = records[detail.taskId];
+					if (existing && existing.agent === agentName && (isTerminalTaskStatus(existing.status) || existing.status === "needs_completion") && (existing.completedAt || existing.completionArchivePath)) {
+						completionAlreadyPersisted = true;
+						return;
+					}
 					records[detail.taskId] = {
 						...existing,
 						taskId: detail.taskId,
@@ -854,6 +859,22 @@ async function pollPaneCompletionsUnlocked(runtimeRoot: string, pi: ExtensionAPI
 						completedAt: detail.completedAt,
 					};
 				});
+				if (completionAlreadyPersisted) {
+					try {
+						const archivePath = await archiveCompletion(runtimeRoot, agentName, filePath);
+						await afterCompletionArchiveForTests?.({ archivePath, filePath, runtimeRoot, taskId: detail.taskId });
+						try {
+							tasks = await persistCompletionArchivePath(runtimeRoot, detail.taskId, archivePath, new Date().toISOString());
+						} catch (error) {
+							await ensureCompletionOutboxRetrySource(filePath, archivePath, completion, error);
+							if (isFileLockTimeoutError(error)) warnCompletionRetryableLock(filePath, error);
+							else console.error(`pi-agents-tmux completion archive path persistence failed after terminal task state was saved; leaving ${filePath} in place for retry: ${stringifyError(error)}`);
+						}
+					} catch (error) {
+						console.warn(`pi-agents-tmux completion archive failed for already-persisted task state; leaving ${filePath} in place for retry: ${stringifyError(error)}`);
+					}
+					continue;
+				}
 				let archivePath: string | undefined;
 				try {
 					archivePath = await archiveCompletion(runtimeRoot, agentName, filePath);

--- a/pi-extensions/pi-agents-tmux/tests/needs-completion-cwd-snapshot.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/needs-completion-cwd-snapshot.test.ts
@@ -398,7 +398,6 @@ describe("needs_completion cwd snapshots", () => {
 	test("pollPaneCompletions preserves existing archive path when duplicate poll archive persistence fails", async () => {
 		const runtimeRoot = tempDir("needs-completion-runtime-");
 		const cwd = tempGitRepo();
-		let lockDir: string | undefined;
 		try {
 			const seeded = await seedPaneTask(runtimeRoot, cwd, "task-duplicate-archive");
 			const outboxFile = join(runtimeRoot, "outbox", "rust", "task-duplicate-archive.json");
@@ -432,12 +431,8 @@ describe("needs_completion cwd snapshots", () => {
 						updatedAt: "2026-05-20T00:00:02.000Z",
 					},
 				});
+				rmSync(outboxFile, { force: true });
 				setBeforeCompletionRegistryUpdateForTests();
-			});
-			setAfterCompletionArchiveForTests(({ runtimeRoot: hookRuntimeRoot }) => {
-				lockDir = holdTaskRegistryLock(hookRuntimeRoot);
-				forceFastRegistryLockTimeout();
-				setAfterCompletionArchiveForTests();
 			});
 
 			const count = await pollPaneCompletions(runtimeRoot, {
@@ -446,18 +441,17 @@ describe("needs_completion cwd snapshots", () => {
 			} as any);
 			const persisted = (await readTaskRegistry(runtimeRoot))["task-duplicate-archive"]!;
 
-			expect(count).toBe(1);
+			expect(count).toBe(0);
 			expect(persisted.status).toBe("completed");
 			expect(persisted.completionArchivePath).toBe(existingArchivePath);
 			expect(persisted.completionSourcePath).toBe(outboxFile);
 			expect(existsSync(existingArchivePath)).toBe(true);
-			expect(existsSync(outboxFile)).toBe(true);
-			expect(emitted.filter((event) => event.name === "subagents:completed")).toHaveLength(1);
+			expect(existsSync(outboxFile)).toBe(false);
+			expect(emitted.filter((event) => event.name === "subagents:completed")).toHaveLength(0);
 		} finally {
 			setAfterCompletionArchiveForTests();
 			setBeforeCompletionRegistryUpdateForTests();
 			setFileLockOptionsForTests();
-			if (lockDir) rmSync(lockDir, { force: true, recursive: true });
 			rmSync(`${taskRegistryPath(runtimeRoot)}.lock`, { force: true, recursive: true });
 			rmSync(runtimeRoot, { force: true, recursive: true });
 			rmSync(cwd, { force: true, recursive: true });

--- a/pi-extensions/pi-agents-tmux/tests/needs-completion-cwd-snapshot.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/needs-completion-cwd-snapshot.test.ts
@@ -458,6 +458,58 @@ describe("needs_completion cwd snapshots", () => {
 		}
 	});
 
+	test("pollPaneCompletions allows terminal completion after needs_completion was persisted", async () => {
+		const runtimeRoot = tempDir("needs-completion-runtime-");
+		const cwd = tempGitRepo();
+		try {
+			const seeded = await seedPaneTask(runtimeRoot, cwd, "task-late-terminal");
+			const outboxFile = join(runtimeRoot, "outbox", "rust", "task-late-terminal.json");
+			mkdirSync(dirname(outboxFile), { recursive: true });
+			writeFileSync(outboxFile, JSON.stringify({
+				agent: "rust",
+				filesChanged: ["x.ts"],
+				status: "completed",
+				summary: "late terminal completion",
+				taskId: "task-late-terminal",
+				validation: ["ok"],
+			}), "utf8");
+			const emitted: Array<{ name: string; payload: any }> = [];
+			setBeforeCompletionRegistryUpdateForTests(async () => {
+				await writeTaskRegistry(runtimeRoot, {
+					"task-late-terminal": {
+						...seeded,
+						completedAt: "2026-05-20T00:00:02.000Z",
+						completionSourcePath: outboxFile,
+						status: "needs_completion",
+						summary: "needs completion before late terminal",
+						updatedAt: "2026-05-20T00:00:02.000Z",
+					},
+				});
+				setBeforeCompletionRegistryUpdateForTests();
+			});
+
+			const count = await pollPaneCompletions(runtimeRoot, {
+				events: { emit: (name: string, payload: any) => emitted.push({ name, payload }) },
+				sendMessage: () => undefined,
+			} as any);
+			const persisted = (await readTaskRegistry(runtimeRoot))["task-late-terminal"]!;
+
+			expect(count).toBe(1);
+			expect(persisted.status).toBe("completed");
+			expect(persisted.summary).toBe("late terminal completion");
+			expect(persisted.completionArchivePath).toContain(join(runtimeRoot, "processed", "rust"));
+			expect(existsSync(outboxFile)).toBe(false);
+			expect(emitted.filter((event) => event.name === "subagents:completed")).toHaveLength(1);
+		} finally {
+			setAfterCompletionArchiveForTests();
+			setBeforeCompletionRegistryUpdateForTests();
+			setFileLockOptionsForTests();
+			rmSync(`${taskRegistryPath(runtimeRoot)}.lock`, { force: true, recursive: true });
+			rmSync(runtimeRoot, { force: true, recursive: true });
+			rmSync(cwd, { force: true, recursive: true });
+		}
+	});
+
 	test("pollPaneCompletions snapshots malformed completion outbox", async () => {
 		const runtimeRoot = tempDir("needs-completion-runtime-");
 		const cwd = tempGitRepo();


### PR DESCRIPTION
## Summary
- Re-check terminal task state inside the locked task-registry update before recording a completion from a possibly stale poller.
- Skip duplicate completion emission when another Pi process already persisted terminal state or an archive path for the task.
- Adjust duplicate-poll regression coverage so it fails if the slower poller emits a second completion after the faster poller archived the outbox.

## Context
- Follow-up for the post-merge Codex review thread on #405: `PRRT_kwDORvss6s6Msbvg`.

## Test Plan
- `npx --yes bun test ./tests/file-lock.test.ts ./tests/needs-completion-cwd-snapshot.test.ts ./tests/dashboard-kind.test.ts`
- `git diff --check`
