### PR TITLE
fix(issue-406): show Linear cache subcommand help

### DIFF
--- a/skills/linear/scripts/commands/cache-query.sh
+++ b/skills/linear/scripts/commands/cache-query.sh
@@ -1001,6 +1001,29 @@ cache_list_cycles() {
 # =============================================================================
 
 main() {
+    for arg in "$@"; do
+        case "$arg" in
+        --help | -h)
+            show_help
+            return 0
+            ;;
+        esac
+    done
+
+    case "${1:-}" in
+    help)
+        show_help
+        return 0
+        ;;
+    esac
+
+    case "${2:-}" in
+    help)
+        show_help
+        return 0
+        ;;
+    esac
+
     if [[ ! -f "$CACHE_DIR/meta.json" ]]; then
         echo '{"error": "No cache found. Run: linear.sh sync"}' >&2
         return 1

--- a/skills/linear/tests/cache-no-auth.test.sh
+++ b/skills/linear/tests/cache-no-auth.test.sh
@@ -118,6 +118,17 @@ run_cache_read() {
   fi
 }
 
+run_cache_read "cache issues list help" cache issues list --help
+help_out="$RUN_OUT"
+if ! grep -q 'Linear Cache Query - Read from local cache' <<<"$help_out"; then
+  echo "FAIL cache issues list --help did not print cache help: $help_out"
+  exit 1
+fi
+if echo "$help_out" | jq -e . >/dev/null 2>&1; then
+  echo "FAIL cache issues list --help returned JSON query output instead of help: $help_out"
+  exit 1
+fi
+
 run_cache_read "cache projects list" cache projects list --format=safe
 projects_out="$RUN_OUT"
 if ! echo "$projects_out" | jq -e '.[0].name == "Authless Cache Project"' >/dev/null; then


### PR DESCRIPTION
Closes #406.

Summary:
- Handle cache subcommand help before cache validation and dispatch.
- Add no-auth regression coverage for cache issues list --help.

Tests:
- bash skills/linear/tests/cache-no-auth.test.sh
- bash skills/linear/scripts/linear.sh cache issues list --help
- Full Linear shell tests were verified in the delegated worktree before publish.
- git diff --check