### PR TITLE
fix(issue-407): avoid pull in merge sync

### DIFF
--- a/skills/github/README.md
+++ b/skills/github/README.md
@@ -48,19 +48,19 @@ keeps the raw `gh`/`op` detail for logs.
 
 ## Git HTTPS Fallback
 
-Use `scripts/git-https-auth` for git network operations in workflows that
-should succeed with GitHub CLI auth even when project remotes are SSH-backed.
-The helper detects GitHub SSH remotes or explicit GitHub SSH URLs, validates
-the selected env token or `gh` keyring auth, and then runs the git command with
-temporary `credential.helper=!gh auth git-credential` and SSH-to-HTTPS rewrite
-config. It does not persist config and leaves non-GitHub or unauthenticated
-git commands on the normal path.
+Use `scripts/git-https-auth` for the GitHub network operations in workflows
+that should succeed with GitHub CLI auth even when project remotes are
+SSH-backed. The helper detects GitHub SSH remotes or explicit GitHub SSH URLs,
+validates the selected env token or `gh` keyring auth, and then runs the git
+command with temporary `credential.helper=!gh auth git-credential` and
+SSH-to-HTTPS rewrite config. It does not persist config and leaves non-GitHub
+or unauthenticated git commands on the normal path.
 
-Prefer targeted remotes in automation:
+Prefer targeted post-fetch sync commands in automation:
 
 ```bash
 ./scripts/git-https-auth -C "$repo" fetch --prune origin
-./scripts/git-https-auth -C "$repo" merge --ff-only "origin/$base_branch"
+git -C "$repo" merge --ff-only "origin/$base_branch"
 ```
 
 Avoid `git fetch --all` in PR closure workflows unless every remote is required;

--- a/skills/github/README.md
+++ b/skills/github/README.md
@@ -60,11 +60,13 @@ Prefer targeted remotes in automation:
 
 ```bash
 ./scripts/git-https-auth -C "$repo" fetch --prune origin
-./scripts/git-https-auth -C "$repo" pull --rebase origin "$base_branch"
+./scripts/git-https-auth -C "$repo" merge --ff-only "origin/$base_branch"
 ```
 
 Avoid `git fetch --all` in PR closure workflows unless every remote is required;
 optional secondary remotes should not block syncing `origin` after a merge.
+Use the explicit fetched `origin/$base_branch` ref for post-merge sync so
+automation avoids `git pull`'s branch/ref resolution ambiguity.
 
 ## Adding a Command
 

--- a/skills/github/README.md
+++ b/skills/github/README.md
@@ -59,14 +59,16 @@ or unauthenticated git commands on the normal path.
 Prefer targeted post-fetch sync commands in automation:
 
 ```bash
-./scripts/git-https-auth -C "$repo" fetch --prune origin
+./scripts/git-https-auth -C "$repo" fetch --prune origin "+refs/heads/$base_branch:refs/remotes/origin/$base_branch"
 git -C "$repo" merge --ff-only "origin/$base_branch"
 ```
 
 Avoid `git fetch --all` in PR closure workflows unless every remote is required;
 optional secondary remotes should not block syncing `origin` after a merge.
-Use the explicit fetched `origin/$base_branch` ref for post-merge sync so
-automation avoids `git pull`'s branch/ref resolution ambiguity.
+Fetch into the explicit `refs/remotes/origin/$base_branch` tracking ref and use
+that same `origin/$base_branch` ref for post-merge sync so automation avoids
+`git pull`'s branch/ref resolution ambiguity and does not depend on the
+repository's configured `remote.origin.fetch` refspec.
 
 ## Adding a Command
 

--- a/skills/orch/tests/workflow_helpers.sh
+++ b/skills/orch/tests/workflow_helpers.sh
@@ -128,9 +128,10 @@ for workflow in "$submit_workflow" "$comments_workflow"; do
 done
 
 assert_file_not_contains "$merge_workflow" "fetch --all --prune" "merge-pr avoids all-remote fetch during sync"
-assert_file_not_contains "$merge_workflow" "pull --rebase origin [BASE_BRANCH]" "merge-pr avoids rebase pull during post-merge sync"
+assert_file_not_contains "$merge_workflow" "git-https-auth -C [MAIN_REPO_ROOT] pull" "merge-pr avoids pull during post-merge sync"
+assert_file_not_contains "$merge_workflow" "git-https-auth -C [MAIN_REPO_ROOT] merge" "merge-pr keeps local merge outside HTTPS credential wrapper"
 assert_file_contains "$merge_workflow" "git-https-auth -C [MAIN_REPO_ROOT] fetch --prune origin" "merge-pr sync fetches origin through HTTPS auth helper"
-assert_file_contains "$merge_workflow" "git-https-auth -C [MAIN_REPO_ROOT] merge --ff-only origin/[BASE_BRANCH]" "merge-pr sync fast-forwards to fetched origin base branch through HTTPS auth helper"
+assert_file_contains "$merge_workflow" 'git -C [MAIN_REPO_ROOT] merge --ff-only "origin/[BASE_BRANCH]"' "merge-pr sync fast-forwards to quoted fetched origin base branch with plain git"
 
 assert_file_not_contains "$qa_workflow" "Pipe benchmark output" "qa-review avoids pipe-based benchmark recording"
 assert_file_not_contains "$qa_workflow" "pipe results" "qa-review avoids pipe-based perf capture guidance"

--- a/skills/orch/tests/workflow_helpers.sh
+++ b/skills/orch/tests/workflow_helpers.sh
@@ -129,6 +129,7 @@ done
 
 assert_file_not_contains "$merge_workflow" "fetch --all --prune" "merge-pr avoids all-remote fetch during sync"
 assert_file_not_contains "$merge_workflow" "git-https-auth -C [MAIN_REPO_ROOT] pull" "merge-pr avoids pull during post-merge sync"
+assert_file_not_contains "$merge_workflow" "git -C [MAIN_REPO_ROOT] pull" "merge-pr avoids plain git pull during post-merge sync"
 assert_file_not_contains "$merge_workflow" "git-https-auth -C [MAIN_REPO_ROOT] merge" "merge-pr keeps local merge outside HTTPS credential wrapper"
 assert_file_contains "$merge_workflow" "git-https-auth -C [MAIN_REPO_ROOT] fetch --prune origin" "merge-pr sync fetches origin through HTTPS auth helper"
 assert_file_contains "$merge_workflow" 'git -C [MAIN_REPO_ROOT] merge --ff-only "origin/[BASE_BRANCH]"' "merge-pr sync fast-forwards to quoted fetched origin base branch with plain git"

--- a/skills/orch/tests/workflow_helpers.sh
+++ b/skills/orch/tests/workflow_helpers.sh
@@ -131,7 +131,7 @@ assert_file_not_contains "$merge_workflow" "fetch --all --prune" "merge-pr avoid
 assert_file_not_contains "$merge_workflow" "git-https-auth -C [MAIN_REPO_ROOT] pull" "merge-pr avoids pull during post-merge sync"
 assert_file_not_contains "$merge_workflow" "git -C [MAIN_REPO_ROOT] pull" "merge-pr avoids plain git pull during post-merge sync"
 assert_file_not_contains "$merge_workflow" "git-https-auth -C [MAIN_REPO_ROOT] merge" "merge-pr keeps local merge outside HTTPS credential wrapper"
-assert_file_contains "$merge_workflow" "git-https-auth -C [MAIN_REPO_ROOT] fetch --prune origin" "merge-pr sync fetches origin through HTTPS auth helper"
+assert_file_contains "$merge_workflow" 'git-https-auth -C [MAIN_REPO_ROOT] fetch --prune origin "+refs/heads/[BASE_BRANCH]:refs/remotes/origin/[BASE_BRANCH]"' "merge-pr sync fetches explicit origin base branch through HTTPS auth helper"
 assert_file_contains "$merge_workflow" 'git -C [MAIN_REPO_ROOT] merge --ff-only "origin/[BASE_BRANCH]"' "merge-pr sync fast-forwards to quoted fetched origin base branch with plain git"
 
 assert_file_not_contains "$qa_workflow" "Pipe benchmark output" "qa-review avoids pipe-based benchmark recording"

--- a/skills/orch/tests/workflow_helpers.sh
+++ b/skills/orch/tests/workflow_helpers.sh
@@ -128,8 +128,9 @@ for workflow in "$submit_workflow" "$comments_workflow"; do
 done
 
 assert_file_not_contains "$merge_workflow" "fetch --all --prune" "merge-pr avoids all-remote fetch during sync"
+assert_file_not_contains "$merge_workflow" "pull --rebase origin [BASE_BRANCH]" "merge-pr avoids rebase pull during post-merge sync"
 assert_file_contains "$merge_workflow" "git-https-auth -C [MAIN_REPO_ROOT] fetch --prune origin" "merge-pr sync fetches origin through HTTPS auth helper"
-assert_file_contains "$merge_workflow" "git-https-auth -C [MAIN_REPO_ROOT] pull --rebase origin [BASE_BRANCH]" "merge-pr sync pulls origin base branch through HTTPS auth helper"
+assert_file_contains "$merge_workflow" "git-https-auth -C [MAIN_REPO_ROOT] merge --ff-only origin/[BASE_BRANCH]" "merge-pr sync fast-forwards to fetched origin base branch through HTTPS auth helper"
 
 assert_file_not_contains "$qa_workflow" "Pipe benchmark output" "qa-review avoids pipe-based benchmark recording"
 assert_file_not_contains "$qa_workflow" "pipe results" "qa-review avoids pipe-based perf capture guidance"

--- a/skills/orch/workflows/merge-pr.md
+++ b/skills/orch/workflows/merge-pr.md
@@ -231,16 +231,18 @@ merge. Detach them first.
    Use the output as `BASE_BRANCH`.
 
    ```bash
-   [MAIN_REPO_ROOT]/.agents/skills/github/scripts/git-https-auth -C [MAIN_REPO_ROOT] fetch --prune origin
+   [MAIN_REPO_ROOT]/.agents/skills/github/scripts/git-https-auth -C [MAIN_REPO_ROOT] fetch --prune origin "+refs/heads/[BASE_BRANCH]:refs/remotes/origin/[BASE_BRANCH]"
    git -C [MAIN_REPO_ROOT] merge --ff-only "origin/[BASE_BRANCH]"
    git -C [MAIN_REPO_ROOT] worktree prune
    ```
    Target `origin` only. Optional secondary remotes must not block closure of
    the current PR. The fetch uses `git-https-auth`, which preserves normal SSH
    behavior unless a GitHub SSH remote is present and `gh` auth is valid; then
-   it applies a per-command HTTPS/`gh auth git-credential` fallback. Keep the
-   local fast-forward merge on plain `git` so credential helper config is not
-   exposed to merge-time repository hooks. Sync to the explicit fetched
+   it applies a per-command HTTPS/`gh auth git-credential` fallback. Fetch the
+   base branch with an explicit refspec so narrowed `remote.origin.fetch`
+   config cannot leave `origin/[BASE_BRANCH]` stale or missing. Keep the local
+   fast-forward merge on plain `git` so credential helper config is not exposed
+   to merge-time repository hooks. Sync to the explicit fetched
    `origin/[BASE_BRANCH]` ref with `--ff-only` so local main never gains
    merge-bubble commits; if the fast-forward fails, stop and surface the
    divergence for manual handling.

--- a/skills/orch/workflows/merge-pr.md
+++ b/skills/orch/workflows/merge-pr.md
@@ -232,16 +232,18 @@ merge. Detach them first.
 
    ```bash
    [MAIN_REPO_ROOT]/.agents/skills/github/scripts/git-https-auth -C [MAIN_REPO_ROOT] fetch --prune origin
-   [MAIN_REPO_ROOT]/.agents/skills/github/scripts/git-https-auth -C [MAIN_REPO_ROOT] merge --ff-only origin/[BASE_BRANCH]
+   git -C [MAIN_REPO_ROOT] merge --ff-only "origin/[BASE_BRANCH]"
    git -C [MAIN_REPO_ROOT] worktree prune
    ```
    Target `origin` only. Optional secondary remotes must not block closure of
-   the current PR. `git-https-auth` preserves normal SSH behavior unless a
-   GitHub SSH remote is present and `gh` auth is valid, in which case it
-   applies a per-command HTTPS/`gh auth git-credential` fallback. Sync to the
-   explicit fetched `origin/[BASE_BRANCH]` ref with `--ff-only` so local main
-   never gains merge-bubble commits; if the fast-forward fails, stop and
-   surface the divergence for manual handling.
+   the current PR. The fetch uses `git-https-auth`, which preserves normal SSH
+   behavior unless a GitHub SSH remote is present and `gh` auth is valid; then
+   it applies a per-command HTTPS/`gh auth git-credential` fallback. Keep the
+   local fast-forward merge on plain `git` so credential helper config is not
+   exposed to merge-time repository hooks. Sync to the explicit fetched
+   `origin/[BASE_BRANCH]` ref with `--ff-only` so local main never gains
+   merge-bubble commits; if the fast-forward fails, stop and surface the
+   divergence for manual handling.
 
 5. **Sweep stale branches & worktrees** (after all PRs merged and synced). Default: scoped to current PR only — do not enumerate unrelated branches or sibling worktrees.
 

--- a/skills/orch/workflows/merge-pr.md
+++ b/skills/orch/workflows/merge-pr.md
@@ -346,7 +346,7 @@ For each file flagged as overlapping in § 2.1:
 | ⏭️ | #[P] | [ISSUE_ID] - [TITLE] | Review threads |
 | ❌ | #[Q] | [ISSUE_ID] - [TITLE] | Merge conflicts |
 
-Total: [N] PRs merged | Synced: origin fetch/ff-only merge via git-https-auth
+Total: [N] PRs merged | Synced: origin fetch via git-https-auth + local ff-only merge
 
 ### 🧹 STALE CLEANUP
 

--- a/skills/orch/workflows/merge-pr.md
+++ b/skills/orch/workflows/merge-pr.md
@@ -232,14 +232,16 @@ merge. Detach them first.
 
    ```bash
    [MAIN_REPO_ROOT]/.agents/skills/github/scripts/git-https-auth -C [MAIN_REPO_ROOT] fetch --prune origin
-   [MAIN_REPO_ROOT]/.agents/skills/github/scripts/git-https-auth -C [MAIN_REPO_ROOT] pull --rebase origin [BASE_BRANCH]
+   [MAIN_REPO_ROOT]/.agents/skills/github/scripts/git-https-auth -C [MAIN_REPO_ROOT] merge --ff-only origin/[BASE_BRANCH]
    git -C [MAIN_REPO_ROOT] worktree prune
    ```
    Target `origin` only. Optional secondary remotes must not block closure of
    the current PR. `git-https-auth` preserves normal SSH behavior unless a
    GitHub SSH remote is present and `gh` auth is valid, in which case it
-   applies a per-command HTTPS/`gh auth git-credential` fallback. `--rebase`
-   prevents merge-bubble commits when local main diverged.
+   applies a per-command HTTPS/`gh auth git-credential` fallback. Sync to the
+   explicit fetched `origin/[BASE_BRANCH]` ref with `--ff-only` so local main
+   never gains merge-bubble commits; if the fast-forward fails, stop and
+   surface the divergence for manual handling.
 
 5. **Sweep stale branches & worktrees** (after all PRs merged and synced). Default: scoped to current PR only — do not enumerate unrelated branches or sibling worktrees.
 
@@ -342,7 +344,7 @@ For each file flagged as overlapping in § 2.1:
 | ⏭️ | #[P] | [ISSUE_ID] - [TITLE] | Review threads |
 | ❌ | #[Q] | [ISSUE_ID] - [TITLE] | Merge conflicts |
 
-Total: [N] PRs merged | Synced: origin fetch/pull via git-https-auth
+Total: [N] PRs merged | Synced: origin fetch/ff-only merge via git-https-auth
 
 ### 🧹 STALE CLEANUP
 


### PR DESCRIPTION
## Summary
- Replace the post-merge `git pull --rebase origin <base>` sync guidance with an explicit `origin` fetch followed by a local fast-forward merge from the fetched ref.
- Keep `git-https-auth` scoped to the network fetch step, and document that the local merge uses plain `git` with a quoted `origin/<base>` ref.
- Add workflow-helper regressions that reject all-remote fetches, wrapped or plain pull-based sync, wrapped local merges, and unquoted/non-ff-only merge guidance.

## Context
- No linked decisions found.

## Completed Issues
- Closes #407 - Merge workflow main sync can fail with pull --rebase origin main

## QA Metrics
- Internal review: reviewer-arch, correctness, doc, error, perf, quality, safety, security, structure, and test lanes completed; final focused doc/test re-review passed.
- External second-opinion review passed after final fixes.

## Test Plan
- `bash skills/orch/tests/run-all.sh workflow_helpers`
- `bash skills/orch/tests/run-all.sh`
