### PR TITLE
fix(issue-415): clarify review-pr reviewer launch ordering

### DIFF
--- a/skills/orch/tests/codex_agent_type_guidance.sh
+++ b/skills/orch/tests/codex_agent_type_guidance.sh
@@ -33,6 +33,20 @@ assert_not_contains() {
   fi
 }
 
+assert_order() {
+  local file="$1" first="$2" second="$3" name="$4"
+  local first_line second_line
+  first_line=$(grep -nF "$first" "$file" | head -n 1 | cut -d: -f1 || true)
+  second_line=$(grep -nF "$second" "$file" | head -n 1 | cut -d: -f1 || true)
+  if [[ -n "$first_line" && -n "$second_line" && "$first_line" -lt "$second_line" ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        order: %s before %s\n        file:  %s\n' "$name" "$first" "$second" "$file"
+  fi
+}
+
 echo "=== Codex orch runtime agent type guidance ==="
 
 skill="$REPO_ROOT/skills/orch/SKILL.md"
@@ -61,6 +75,11 @@ assert_contains "$review_pr" "carry forward any \`EXISTING_REVIEW_AGENT_RUNTIME_
 assert_contains "$review_pr" "When writing \`review_agent_runtime_types\`, include preserved entries for reused reviewers and new/updated entries for reviewers launched in this step." "review-pr writes preserved and new runtime metadata"
 assert_contains "$review_pr" "**Do NOT spawn or delegate yet.** Continue to § 2.1 to resolve external review availability before launching reviewers." "review-pr resolves external availability before reviewer launch"
 assert_contains "$review_pr" "For each reviewer in \`REVIEWERS_TO_LAUNCH\`, spawn it now." "review-pr launches missing reviewers in section 2.2"
+assert_contains "$review_pr" "**Record delegation timestamp immediately before the actual delegation batch**" "review-pr timestamp is tied to actual delegation"
+assert_contains "$review_pr" "output produced during reviewer spawn/bootstrap" "review-pr timestamp excludes spawn/bootstrap output"
+assert_contains "$review_pr" "Start the coordinated delegation batch:" "review-pr labels actual delegation batch"
+assert_order "$review_pr" ".agents/skills/orch/scripts/workflow-state set [ISSUE_ID] review_agent_runtime_types '[AGENT_RUNTIME_TYPE_MAP_JSON]'" ".agents/skills/orch/scripts/workflow-state set-now [ISSUE_ID] review_delegated_at" "review-pr records timestamp after reviewer state writes"
+assert_order "$review_pr" ".agents/skills/orch/scripts/workflow-state set-now [ISSUE_ID] review_delegated_at" "Delegate to each active reviewer in \`[AGENTS]\` in parallel." "review-pr records timestamp before reviewer delegation"
 
 assert_contains "$review" "first call the harness spawn API with \`agent_type\` equal to that reviewer name" "review requires reviewer runtime agent_type first"
 assert_contains "$review" "unless the generated-agent spawn was attempted and the spawn API rejects or does not expose that generated \`agent_type\`" "review permits generated-agent unavailable fallback"

--- a/skills/orch/tests/codex_agent_type_guidance.sh
+++ b/skills/orch/tests/codex_agent_type_guidance.sh
@@ -55,6 +55,10 @@ assert_contains "$review_pr" "first call the harness spawn API with \`agent_type
 assert_contains "$review_pr" "unless the generated-agent spawn was attempted and the spawn API rejects or does not expose that generated \`agent_type\`" "review-pr permits generated-agent unavailable fallback"
 assert_contains "$review_pr" "persist the returned id under \`review_agent_ids[reviewer-name]\`" "review-pr keeps id keyed by reviewer name"
 assert_contains "$review_pr" "record runtime metadata under \`review_agent_runtime_types[reviewer-name]\`" "review-pr records reviewer fallback metadata"
+assert_contains "$review_pr" ".agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.review_agent_runtime_types // {}'" "review-pr loads existing reviewer runtime metadata"
+assert_contains "$review_pr" "Use the outputs as \`EXISTING_REVIEW_AGENTS\`, \`EXISTING_REVIEW_AGENT_IDS\`, and \`EXISTING_REVIEW_AGENT_RUNTIME_TYPES\`." "review-pr names existing runtime metadata state"
+assert_contains "$review_pr" "carry forward any \`EXISTING_REVIEW_AGENT_RUNTIME_TYPES[reviewer-name]\` entry into \`AGENT_RUNTIME_TYPE_MAP_JSON\`" "review-pr preserves reusable reviewer runtime metadata"
+assert_contains "$review_pr" "When writing \`review_agent_runtime_types\`, include preserved entries for reused reviewers and new/updated entries for reviewers launched in this step." "review-pr writes preserved and new runtime metadata"
 assert_contains "$review_pr" "**Do NOT spawn or delegate yet.** Continue to § 2.1 to resolve external review availability before launching reviewers." "review-pr resolves external availability before reviewer launch"
 assert_contains "$review_pr" "For each reviewer in \`REVIEWERS_TO_LAUNCH\`, spawn it now." "review-pr launches missing reviewers in section 2.2"
 

--- a/skills/orch/tests/codex_agent_type_guidance.sh
+++ b/skills/orch/tests/codex_agent_type_guidance.sh
@@ -55,6 +55,8 @@ assert_contains "$review_pr" "first call the harness spawn API with \`agent_type
 assert_contains "$review_pr" "unless the generated-agent spawn was attempted and the spawn API rejects or does not expose that generated \`agent_type\`" "review-pr permits generated-agent unavailable fallback"
 assert_contains "$review_pr" "persist the returned id under \`review_agent_ids[reviewer-name]\`" "review-pr keeps id keyed by reviewer name"
 assert_contains "$review_pr" "record runtime metadata under \`review_agent_runtime_types[reviewer-name]\`" "review-pr records reviewer fallback metadata"
+assert_contains "$review_pr" "**Do NOT spawn or delegate yet.** Continue to § 2.1 to resolve external review availability before launching reviewers." "review-pr resolves external availability before reviewer launch"
+assert_contains "$review_pr" "For each reviewer in \`REVIEWERS_TO_LAUNCH\`, spawn it now." "review-pr launches missing reviewers in section 2.2"
 
 assert_contains "$review" "first call the harness spawn API with \`agent_type\` equal to that reviewer name" "review requires reviewer runtime agent_type first"
 assert_contains "$review" "unless the generated-agent spawn was attempted and the spawn API rejects or does not expose that generated \`agent_type\`" "review permits generated-agent unavailable fallback"

--- a/skills/orch/workflows/review-pr.md
+++ b/skills/orch/workflows/review-pr.md
@@ -117,12 +117,7 @@ If the command fails or prints `none`, set `EXTERNAL_REVIEW_REQUESTED=false`. Ot
 
 ## 2.2 Launch Review Agents
 
-**Record delegation timestamp** before delegating — gates the § 3 watchdog filesystem fallback against stale JSONs from earlier cycles:
-```bash
-.agents/skills/orch/scripts/workflow-state set-now [ISSUE_ID] review_delegated_at
-```
-
-Launch internal reviewer work and optional external review in one coordinated step:
+Prepare internal reviewer sessions before the coordinated delegation step:
 - For each reusable reviewer, keep the existing session id and preserve its carried-forward `EXISTING_REVIEW_AGENT_RUNTIME_TYPES[reviewer-name]` entry in `AGENT_RUNTIME_TYPE_MAP_JSON`.
 - For each reviewer in `REVIEWERS_TO_LAUNCH`, spawn it now. Follow the Codex runtime agent type rule above when running in Codex.
 - When writing `review_agent_runtime_types`, include preserved entries for reused reviewers and new/updated entries for reviewers launched in this step.
@@ -134,6 +129,12 @@ After launch/reuse, store the active reviewer set:
 .agents/skills/orch/scripts/workflow-state set [ISSUE_ID] review_agent_runtime_types '[AGENT_RUNTIME_TYPE_MAP_JSON]'
 ```
 
+**Record delegation timestamp immediately before the actual delegation batch** — gates the § 3 watchdog filesystem fallback against stale JSONs from earlier cycles and output produced during reviewer spawn/bootstrap:
+```bash
+.agents/skills/orch/scripts/workflow-state set-now [ISSUE_ID] review_delegated_at
+```
+
+Start the coordinated delegation batch:
 - Delegate to each active reviewer in `[AGENTS]` in parallel.
 - **If `EXTERNAL_REVIEW_REQUESTED=true`**, launch the external review in the same parallel batch.
 

--- a/skills/orch/workflows/review-pr.md
+++ b/skills/orch/workflows/review-pr.md
@@ -94,10 +94,11 @@ Before any spawn, read existing reviewer state:
 ```bash
 .agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.review_agents // []'
 .agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.review_agent_ids // {}'
+.agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.review_agent_runtime_types // {}'
 ```
-Use the outputs as `EXISTING_REVIEW_AGENTS` and `EXISTING_REVIEW_AGENT_IDS`.
+Use the outputs as `EXISTING_REVIEW_AGENTS`, `EXISTING_REVIEW_AGENT_IDS`, and `EXISTING_REVIEW_AGENT_RUNTIME_TYPES`.
 
-For each reviewer in `[AGENTS]`: classify it as reusable, missing, closed, or confirmed-stuck. Reuse by exact name when `review_agent_ids` points to a live/recoverable session. If only `review_agents` exists, attempt one recovery/resume, then treat as missing. Add only missing, closed, or confirmed-stuck reviewers to `REVIEWERS_TO_LAUNCH`. Do not respawn already-live reviewers.
+For each reviewer in `[AGENTS]`: classify it as reusable, missing, closed, or confirmed-stuck. Reuse by exact name when `review_agent_ids` points to a live/recoverable session. If only `review_agents` exists, attempt one recovery/resume, then treat as missing. Add only missing, closed, or confirmed-stuck reviewers to `REVIEWERS_TO_LAUNCH`. Do not respawn already-live reviewers. When a reviewer is reusable, carry forward any `EXISTING_REVIEW_AGENT_RUNTIME_TYPES[reviewer-name]` entry into `AGENT_RUNTIME_TYPE_MAP_JSON` instead of rebuilding runtime metadata only from newly spawned reviewers.
 
 **Do NOT spawn or delegate yet.** Continue to § 2.1 to resolve external review availability before launching reviewers.
 
@@ -122,8 +123,9 @@ If the command fails or prints `none`, set `EXTERNAL_REVIEW_REQUESTED=false`. Ot
 ```
 
 Launch internal reviewer work and optional external review in one coordinated step:
-- For each reusable reviewer, keep the existing session id and runtime metadata.
+- For each reusable reviewer, keep the existing session id and preserve its carried-forward `EXISTING_REVIEW_AGENT_RUNTIME_TYPES[reviewer-name]` entry in `AGENT_RUNTIME_TYPE_MAP_JSON`.
 - For each reviewer in `REVIEWERS_TO_LAUNCH`, spawn it now. Follow the Codex runtime agent type rule above when running in Codex.
+- When writing `review_agent_runtime_types`, include preserved entries for reused reviewers and new/updated entries for reviewers launched in this step.
 
 After launch/reuse, store the active reviewer set:
 ```bash

--- a/skills/orch/workflows/review-pr.md
+++ b/skills/orch/workflows/review-pr.md
@@ -71,7 +71,7 @@ Use the outputs as `CYCLES`, `FIXED`, and `ESCALATED`.
 
 If `CYCLES > 0`: include the "Previous review cycle context" section in the delegation prompt, populated from `FIXED` and `ESCALATED`.
 
-## 2. Launch Review Agents
+## 2. Prepare Review Agents
 
 **Detect team context**:
 ```bash
@@ -88,7 +88,7 @@ Use the output as `AGENTS`. If the command fails or prints no agents, skip revie
 
 `list-review-agents` scans `.pi/agents`, `.claude/agents`, `.agents`, `.codex/agents`, and `.opencode/agents` for `reviewer-*` files, dedupes, and exits non-zero if none found. Output: one agent name per line.
 
-**Codex runtime agent type rule**: For each reviewer in `AGENTS`, first call the harness spawn API with `agent_type` equal to that reviewer name. Do not launch `worker` and simulate reviewer identity in the prompt unless the generated-agent spawn was attempted and the spawn API rejects or does not expose that generated `agent_type`. In that fallback, spawn `agent_type=worker` but keep the logical reviewer name in bootstrap/delegation text, reports, and workflow-state keys: persist the returned id under `review_agent_ids[reviewer-name]`, and record runtime metadata under `review_agent_runtime_types[reviewer-name]` with `agent_type="worker"` and a fallback reason.
+**Codex runtime agent type rule**: When § 2.2 launches a reviewer, first call the harness spawn API with `agent_type` equal to that reviewer name. Do not launch `worker` and simulate reviewer identity in the prompt unless the generated-agent spawn was attempted and the spawn API rejects or does not expose that generated `agent_type`. In that fallback, spawn `agent_type=worker` but keep the logical reviewer name in bootstrap/delegation text, reports, and workflow-state keys: persist the returned id under `review_agent_ids[reviewer-name]`, and record runtime metadata under `review_agent_runtime_types[reviewer-name]` with `agent_type="worker"` and a fallback reason.
 
 Before any spawn, read existing reviewer state:
 ```bash
@@ -97,16 +97,9 @@ Before any spawn, read existing reviewer state:
 ```
 Use the outputs as `EXISTING_REVIEW_AGENTS` and `EXISTING_REVIEW_AGENT_IDS`.
 
-For each reviewer in `[AGENTS]`: reuse by exact name when `review_agent_ids` points to a live/recoverable session. If only `review_agents` exists, attempt one recovery/resume, then treat as missing. Spawn only the missing, closed, or confirmed-stuck reviewer. Do not respawn already-live reviewers.
+For each reviewer in `[AGENTS]`: classify it as reusable, missing, closed, or confirmed-stuck. Reuse by exact name when `review_agent_ids` points to a live/recoverable session. If only `review_agents` exists, attempt one recovery/resume, then treat as missing. Add only missing, closed, or confirmed-stuck reviewers to `REVIEWERS_TO_LAUNCH`. Do not respawn already-live reviewers.
 
-After reconciliation, store the active reviewer set:
-  ```bash
-  .agents/skills/orch/scripts/workflow-state set [ISSUE_ID] review_agents '[AGENT_LIST_JSON]'
-  .agents/skills/orch/scripts/workflow-state set [ISSUE_ID] review_agent_ids '[AGENT_ID_MAP_JSON]'
-  .agents/skills/orch/scripts/workflow-state set [ISSUE_ID] review_agent_runtime_types '[AGENT_RUNTIME_TYPE_MAP_JSON]'
-  ```
-
-**Do NOT delegate yet.** Continue to § 2.1 to resolve external review availability *before* spawning.
+**Do NOT spawn or delegate yet.** Continue to § 2.1 to resolve external review availability before launching reviewers.
 
 ## 2.1 External Review Availability
 
@@ -121,14 +114,26 @@ If the command fails or prints `none`, set `EXTERNAL_REVIEW_REQUESTED=false`. Ot
 
 **Skip if** `EXTERNAL_TARGET` is empty or `"none"`. Set `EXTERNAL_REVIEW_REQUESTED=false` → § 2.2. Otherwise `EXTERNAL_REVIEW_REQUESTED=true` → § 2.2.
 
-## 2.2 Delegate Review Agents
+## 2.2 Launch Review Agents
 
 **Record delegation timestamp** before delegating — gates the § 3 watchdog filesystem fallback against stale JSONs from earlier cycles:
 ```bash
 .agents/skills/orch/scripts/workflow-state set-now [ISSUE_ID] review_delegated_at
 ```
 
-Delegate to each active reviewer in `[AGENTS]` in parallel. **If `EXTERNAL_REVIEW_REQUESTED=true`**, launch the external review in the *same parallel batch*.
+Launch internal reviewer work and optional external review in one coordinated step:
+- For each reusable reviewer, keep the existing session id and runtime metadata.
+- For each reviewer in `REVIEWERS_TO_LAUNCH`, spawn it now. Follow the Codex runtime agent type rule above when running in Codex.
+
+After launch/reuse, store the active reviewer set:
+```bash
+.agents/skills/orch/scripts/workflow-state set [ISSUE_ID] review_agents '[AGENT_LIST_JSON]'
+.agents/skills/orch/scripts/workflow-state set [ISSUE_ID] review_agent_ids '[AGENT_ID_MAP_JSON]'
+.agents/skills/orch/scripts/workflow-state set [ISSUE_ID] review_agent_runtime_types '[AGENT_RUNTIME_TYPE_MAP_JSON]'
+```
+
+- Delegate to each active reviewer in `[AGENTS]` in parallel.
+- **If `EXTERNAL_REVIEW_REQUESTED=true`**, launch the external review in the same parallel batch.
 
 **Harness-specific batching:**
 - **Claude Code / Codex / OpenCode**: spawn reviewers via the harness sub-agent task API; run the external review shell command in the same delegation step.


### PR DESCRIPTION
## Summary
- Clarifies `review-pr.md` so reviewer preparation happens before external availability detection, while actual reviewer spawning/delegation happens in section 2.2.
- Renames the section from "Launch Review Agents" to "Prepare Review Agents" and introduces `REVIEWERS_TO_LAUNCH` to remove the contradictory ordering.
- Adds regression assertions to the orch Codex guidance test for the corrected launch sequencing.

## Context
- No linked decisions found.

## Completed Issues
- Closes #415 - orch review-pr workflow has contradictory reviewer spawn ordering

## Test Plan
- `bash skills/orch/tests/run-all.sh codex_agent_type_guidance`
- `bash skills/orch/tests/run-all.sh`
- `git diff --check origin/main...HEAD`
- Internal review pool: reviewer-arch, reviewer-correctness, reviewer-doc, reviewer-error, reviewer-perf, reviewer-quality, reviewer-safety, reviewer-security, reviewer-structure, reviewer-test
- External review: Claude second opinion
