### PR TITLE
fix(issue-416): persist TPM audit inline JSON

### DIFF
--- a/skills/project-management/tests/label-preflight-contract.test.sh
+++ b/skills/project-management/tests/label-preflight-contract.test.sh
@@ -20,6 +20,13 @@ require_pattern() {
   fi
 }
 
+reject_fixed_string() {
+  local file="$1" needle="$2" desc="$3"
+  if grep -Fq -- "$needle" "$file"; then
+    fail "$desc remains in ${file#$SKILL_DIR/}"
+  fi
+}
+
 mutation_workflows=(
   workflows/roadmap-create.md
   workflows/audit-issues.md
@@ -64,5 +71,16 @@ fi
 tpm_audit="$SKILL_DIR/workflows/tpm-audit.md"
 require_pattern "$tpm_audit" 'cache issues get \[ISSUE_ID\]' 'supported cached issue fetch for relation analysis'
 require_pattern "$tpm_audit" 'blocks`, `blocked_by`, and `related`' 'relation fields from cached issue JSON'
+require_pattern "$tpm_audit" 'Return the JSON inline' 'TPM inline audit JSON return contract'
+require_pattern "$tpm_audit" 'Do not write the artifact yourself' 'TPM child-does-not-write artifact contract'
+
+tpm_audit_project_order="$SKILL_DIR/workflows/tpm-audit-project-order.md"
+require_pattern "$tpm_audit_project_order" 'Return the JSON inline' 'TPM project-order inline JSON return contract'
+require_pattern "$tpm_audit_project_order" 'Do not write the artifact yourself' 'TPM project-order child-does-not-write artifact contract'
+
+audit_issues="$SKILL_DIR/workflows/audit-issues.md"
+require_pattern "$audit_issues" 'Treat `File:` as a destination hint only' 'audit parent File hint handling'
+require_pattern "$audit_issues" 'Write the inline JSON exactly to the resolved absolute path in the caller worktree' 'audit parent writes child JSON artifact'
+reject_fixed_string "$audit_issues" 'Agent returns `.JSON` file. If missing, halt.' 'audit parent assumes child-written JSON artifact'
 
 echo "all pass"

--- a/skills/project-management/tests/label-preflight-contract.test.sh
+++ b/skills/project-management/tests/label-preflight-contract.test.sh
@@ -80,7 +80,9 @@ require_pattern "$tpm_audit_project_order" 'Do not write the artifact yourself' 
 
 audit_issues="$SKILL_DIR/workflows/audit-issues.md"
 require_pattern "$audit_issues" 'Treat `File:` as a destination hint only' 'audit parent File hint handling'
-require_pattern "$audit_issues" 'Write the inline JSON exactly to the resolved absolute path in the caller worktree' 'audit parent writes child JSON artifact'
+require_pattern "$audit_issues" '[Ww]rite the inline JSON exactly to the resolved absolute path in the caller worktree' 'audit parent writes child JSON artifact'
+require_pattern "$audit_issues" 'already-readable artifact inside the caller worktree' 'audit parent readable artifact fallback'
+require_pattern "$audit_issues" 'request a TPM rerun with inline JSON' 'audit parent inline JSON rerun halt'
 reject_fixed_string "$audit_issues" 'Agent returns `.JSON` file. If missing, halt.' 'audit parent assumes child-written JSON artifact'
 
 echo "all pass"

--- a/skills/project-management/workflows/audit-issues.md
+++ b/skills/project-management/workflows/audit-issues.md
@@ -92,9 +92,12 @@ Arguments: (none)
    - Resolve relative paths under the caller worktree (current repo root for project-order audits).
    - Reject absolute paths outside the caller worktree; use the fallback `tmp/...` path instead.
 
-3. **Write artifact**: Ensure `tmp/` exists in the caller worktree. Write the inline JSON exactly to the resolved absolute path in the caller worktree.
+3. **Materialize artifact**:
+   - If inline JSON is present, ensure `tmp/` exists in the caller worktree and write the inline JSON exactly to the resolved absolute path in the caller worktree.
+   - If inline JSON is missing but the returned `File:` path resolves to an already-readable artifact inside the caller worktree, skip writing and use that existing artifact.
+   - Otherwise halt and request a TPM rerun with inline JSON.
 
-4. **Read file**: Use Read tool on the caller-written artifact to get structured findings.
+4. **Read file**: Use Read tool on the caller-written or existing artifact to get structured findings.
 
 5. **Present findings** using this format. Omit empty sections.
 
@@ -260,9 +263,12 @@ TPM reads JSON file directly -- schema: [audit-issues-input.md](../schemas/audit
    - Resolve relative paths under the caller worktree (PROJECT `Worktree:` value, ISSUE `worktree` from the input JSON, or current repo root when empty).
    - Reject absolute paths outside the caller worktree; use the fallback `tmp/...` path instead.
 
-3. **Write artifact**: Ensure `tmp/` exists in the caller worktree. Write the inline JSON exactly to the resolved absolute path in the caller worktree.
+3. **Materialize artifact**:
+   - If inline JSON is present, ensure `tmp/` exists in the caller worktree and write the inline JSON exactly to the resolved absolute path in the caller worktree.
+   - If inline JSON is missing but the returned `File:` path resolves to an already-readable artifact inside the caller worktree, skip writing and use that existing artifact.
+   - Otherwise halt and request a TPM rerun with inline JSON.
 
-4. **Read file**: Use Read tool on the caller-written artifact to get structured findings.
+4. **Read file**: Use Read tool on the caller-written or existing artifact to get structured findings.
 
 ---
 

--- a/skills/project-management/workflows/audit-issues.md
+++ b/skills/project-management/workflows/audit-issues.md
@@ -81,11 +81,22 @@ Arguments: (none)
 
 ### 2.2 Present Results
 
-1. **Collect JSON path**: Agent returns `.JSON` file. If missing, halt.
+1. **Collect TPM payload**: Agent returns an `<output_format>` block with:
+   - `File: tmp/audit-project-order-YYYYMMDD-HHMMSS.json` (destination hint)
+   - fenced `json` containing the complete project-order audit output
 
-2. **Read file**: Use Read tool to get structured findings.
+   Treat `File:` as a destination hint only; do not assume the child agent wrote that file. If inline JSON is missing and the returned path is not already readable in the caller worktree, halt and request a TPM rerun with inline JSON.
 
-3. **Present findings** using this format. Omit empty sections.
+2. **Resolve artifact path**:
+   - Use the returned `File:` path if present; otherwise choose `tmp/audit-project-order-YYYYMMDD-HHMMSS.json`.
+   - Resolve relative paths under the caller worktree (current repo root for project-order audits).
+   - Reject absolute paths outside the caller worktree; use the fallback `tmp/...` path instead.
+
+3. **Write artifact**: Ensure `tmp/` exists in the caller worktree. Write the inline JSON exactly to the resolved absolute path in the caller worktree.
+
+4. **Read file**: Use Read tool on the caller-written artifact to get structured findings.
+
+5. **Present findings** using this format. Omit empty sections.
 
    <output_format>
 
@@ -238,9 +249,20 @@ TPM reads JSON file directly -- schema: [audit-issues-input.md](../schemas/audit
 
 ### 4.2 Process Audit Results
 
-1. **Collect JSON path**: Agent returns `.JSON` file. If missing, halt.
+1. **Collect TPM payload**: Agent returns an `<output_format>` block with:
+   - `File: tmp/audit-[MODE]-YYYYMMDD-HHMMSS.json` (destination hint)
+   - fenced `json` containing the complete audit output
 
-2. **Read file**: Use Read tool to get structured findings.
+   Treat `File:` as a destination hint only; do not assume the child agent wrote that file. If inline JSON is missing and the returned path is not already readable in the caller worktree, halt and request a TPM rerun with inline JSON.
+
+2. **Resolve artifact path**:
+   - Use the returned `File:` path if present; otherwise choose `tmp/audit-project-YYYYMMDD-HHMMSS.json` (PROJECT) or `tmp/audit-issues-YYYYMMDD-HHMMSS.json` (ISSUE).
+   - Resolve relative paths under the caller worktree (PROJECT `Worktree:` value, ISSUE `worktree` from the input JSON, or current repo root when empty).
+   - Reject absolute paths outside the caller worktree; use the fallback `tmp/...` path instead.
+
+3. **Write artifact**: Ensure `tmp/` exists in the caller worktree. Write the inline JSON exactly to the resolved absolute path in the caller worktree.
+
+4. **Read file**: Use Read tool on the caller-written artifact to get structured findings.
 
 ---
 

--- a/skills/project-management/workflows/tpm-audit-project-order.md
+++ b/skills/project-management/workflows/tpm-audit-project-order.md
@@ -140,9 +140,9 @@ Assuming reorders applied, find position 1 among `planned`/`backlog` with no inc
 
 ## 5. Return Output
 
-1. **Build JSON** per [audit-project-order-output.md](../schemas/audit-project-order-output.md), filename `tmp/audit-project-order-YYYYMMDD-HHMMSS.json`.
+1. **Build JSON** per [audit-project-order-output.md](../schemas/audit-project-order-output.md). Set the destination hint to `tmp/audit-project-order-YYYYMMDD-HHMMSS.json`.
 
-2. **Return the JSON** in your response (the calling agent writes the file):
+2. **Return the JSON inline** in your response. Do not write the artifact yourself; the calling agent writes the file in its worktree using the returned `File:` hint.
 
    <output_format>
    File: tmp/audit-project-order-YYYYMMDD-HHMMSS.json

--- a/skills/project-management/workflows/tpm-audit.md
+++ b/skills/project-management/workflows/tpm-audit.md
@@ -649,9 +649,9 @@ For each input issue, assign action based on analysis:
 
 ## 12. Return Output
 
-1. **Build JSON** per [audit-output.md](../schemas/audit-output.md), filename `tmp/audit-project-YYYYMMDD-HHMMSS.json` (PROJECT) or `tmp/audit-issues-YYYYMMDD-HHMMSS.json` (ISSUES).
+1. **Build JSON** per [audit-output.md](../schemas/audit-output.md). Set the destination hint to `tmp/audit-project-YYYYMMDD-HHMMSS.json` (PROJECT) or `tmp/audit-issues-YYYYMMDD-HHMMSS.json` (ISSUES).
 
-2. **Return the JSON** in your response (the calling agent writes the file):
+2. **Return the JSON inline** in your response. Do not write the artifact yourself; the calling agent writes the file in its worktree using the returned `File:` hint.
 
    <output_format>
    File: tmp/audit-[MODE]-YYYYMMDD-HHMMSS.json


### PR DESCRIPTION
## Summary

- Make `audit-issues.md` treat TPM `File:` lines as destination hints, write returned inline JSON into the caller worktree, then read the caller-written artifact.
- Clarify `tpm-audit.md` and `tpm-audit-project-order.md` so child TPM workflows return JSON inline and do not write artifacts themselves.
- Add a static regression check for the inline JSON / parent-written artifact contract.

Closes #416

## Tests

- `bash skills/project-management/tests/label-preflight-contract.test.sh`
- `git diff --check`
