### PR TITLE
fix(issue-419): github pr-merge --check misclassifies in-progress checks as ci_failed

### DIFF
--- a/skills/github/README.md
+++ b/skills/github/README.md
@@ -46,6 +46,10 @@ emits structured JSON on stdout with `status` (`no_pr`, `auth_error`,
 `error`, `detail`, `exit_code`, and `number:null`, then exits nonzero. Stderr
 keeps the raw `gh`/`op` detail for logs.
 
+`pr-merge --check` reports still-running checks as `ci_pending: ...` and sets
+`transient: true` when those pending checks are the only blockers. Terminal
+failed or cancelled checks remain `ci_failed: ...` and are not transient.
+
 ## Git HTTPS Fallback
 
 Use `scripts/git-https-auth` for the GitHub network operations in workflows

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -88,10 +88,11 @@ parsing stderr:
 | `1`  | BLOCKED               | `BLOCKED PR #N`              | Checks failed; nothing merged, nothing queued |
 
 A BLOCKED outcome is further classified on stderr as **transient** (mergeable
-UNKNOWN, CI pending — caller should `await-mergeable` and retry) or
-**permanent** (conflicts, ci_failed, changes_requested — caller must fix and
-re-push). Programmatic callers can check the `transient` field in the
-`--check` JSON output before deciding to retry.
+UNKNOWN, `ci_pending`, CI fetch uncertainty — caller should
+`await-mergeable` and retry) or **permanent** (conflicts, `ci_failed`,
+`changes_requested` — caller must fix and re-push). Programmatic callers can
+check the `transient` field in the `--check` JSON output before deciding to
+retry.
 
 ### PR Merge Check Output
 
@@ -100,7 +101,9 @@ re-push). Programmatic callers can check the `transient` field in the
 ```
 
 `transient: true` means every blocking issue is recoverable by waiting
-(prefixes `unknown:`, `ci_unconfigured:`, `ci_fetch_failed:`).
+(prefixes `unknown:`, `ci_pending:`, `ci_unconfigured:`,
+`ci_fetch_failed:`). Still-running checks are reported as `ci_pending: ...`;
+terminal failing or cancelled checks remain `ci_failed: ...`.
 
 ### Waiting for merge state (gotcha)
 

--- a/skills/github/scripts/commands/pr-merge.sh
+++ b/skills/github/scripts/commands/pr-merge.sh
@@ -10,6 +10,7 @@
 # When BLOCKED, stderr distinguishes TRANSIENT issues (mergeable UNKNOWN,
 # ci pending — caller should `await-mergeable` and retry) from PERMANENT
 # issues (conflicts, ci_failed, changes_requested — caller must fix and re-push).
+# Still-running checks are emitted as ci_pending, not ci_failed.
 
 set -euo pipefail
 
@@ -23,7 +24,7 @@ source "$SCRIPT_DIR/../lib/pr-branch.sh"
 
 # Issue prefixes that resolve on their own once GitHub finishes computing or
 # CI completes. Callers should `await-mergeable` and retry rather than fix.
-TRANSIENT_PREFIXES='unknown:|ci_unconfigured:|ci_fetch_failed:'
+TRANSIENT_PREFIXES='unknown:|ci_pending:|ci_unconfigured:|ci_fetch_failed:'
 
 show_help() {
     cat <<'EOF'
@@ -92,20 +93,43 @@ run_checks() {
     fi
 
     # 2. Check CI status
-    local ci_json ci_pass
-    if ! ci_json=$(gh pr checks "$pr_num" --json name,state 2>&1); then
+    local ci_json
+    set +e
+    ci_json=$(gh pr checks "$pr_num" --json name,state,bucket 2>&1)
+    set -e
+
+    # `gh pr checks` exits 8 while checks are pending, but still prints usable
+    # JSON. Treat any valid array response as authoritative regardless of the
+    # command's exit status.
+    if ! jq -e 'type == "array"' >/dev/null 2>&1 <<<"$ci_json"; then
         can_merge=false
         issues+=("ci_fetch_failed: Failed to fetch CI checks from GitHub")
-    elif ! jq -e 'type == "array"' >/dev/null 2>&1 <<<"$ci_json"; then
-        can_merge=false
-        issues+=("ci_fetch_failed: Invalid CI response from GitHub")
     elif [ "$(echo "$ci_json" | jq 'length')" -eq 0 ]; then
         warnings+=("ci_unconfigured: No status checks configured")
     else
-        ci_pass=$(echo "$ci_json" | jq 'all(.state == "SUCCESS" or .state == "SKIPPED")')
-        if [ "$ci_pass" != "true" ]; then
-            local failed
-            failed=$(echo "$ci_json" | jq -r '[.[] | select(.state != "SUCCESS" and .state != "SKIPPED")] | map(.name + " (" + .state + ")") | join(", ")')
+        local ci_classification pending failed
+        ci_classification=$(echo "$ci_json" | jq -c '
+            def bucket:
+                (.bucket // (
+                    if (.state == "SUCCESS") then "pass"
+                    elif (.state == "SKIPPED") then "skipping"
+                    elif ((.state // "") | IN("PENDING", "QUEUED", "IN_PROGRESS", "WAITING", "REQUESTED", "EXPECTED")) then "pending"
+                    elif (.state == "CANCELLED") then "cancel"
+                    else "fail"
+                    end
+                ));
+            {
+                pending: [.[] | select(bucket == "pending") | .name + " (" + .state + ")"],
+                failed: [.[] | select((bucket != "pass") and (bucket != "skipping") and (bucket != "pending")) | .name + " (" + .state + ")"]
+            }
+        ')
+        pending=$(echo "$ci_classification" | jq -r '.pending | join(", ")')
+        failed=$(echo "$ci_classification" | jq -r '.failed | join(", ")')
+        if [ -n "$pending" ]; then
+            can_merge=false
+            issues+=("ci_pending: $pending")
+        fi
+        if [ -n "$failed" ]; then
             can_merge=false
             issues+=("ci_failed: $failed")
         fi

--- a/skills/github/tests/pr-merge.sh
+++ b/skills/github/tests/pr-merge.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Regression tests for pr-merge --check CI readiness classification.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../.." && pwd)"
+PR_MERGE="$REPO_ROOT/skills/github/scripts/commands/pr-merge.sh"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local got="$1" want="$2" name="$3"
+    if [[ "$got" == "$want" ]]; then
+        PASS=$((PASS + 1))
+        printf '  ok    %s\n' "$name"
+    else
+        FAIL=$((FAIL + 1))
+        printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$name" "$want" "$got"
+    fi
+}
+
+assert_contains() {
+    local haystack="$1" needle="$2" name="$3"
+    if grep -qF -- "$needle" <<<"$haystack"; then
+        PASS=$((PASS + 1))
+        printf '  ok    %s\n' "$name"
+    else
+        FAIL=$((FAIL + 1))
+        printf '  FAIL  %s\n        wanted substring: %s\n        in: %s\n' "$name" "$needle" "$haystack"
+    fi
+}
+
+mkdir -p "$TMPDIR/bin" "$TMPDIR/repo"
+git -C "$TMPDIR/repo" init -q
+
+cat >"$TMPDIR/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+    auth)
+        if [[ "${2:-}" == "status" ]]; then
+            echo "Logged in"
+            exit 0
+        fi
+        ;;
+    repo)
+        if [[ "${2:-}" == "view" ]]; then
+            echo '{"owner":{"login":"owner"},"name":"repo"}'
+            exit 0
+        fi
+        ;;
+    api)
+        if [[ "${2:-}" == "graphql" ]]; then
+            echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}'
+            exit 0
+        fi
+        ;;
+    pr)
+        case "${2:-}" in
+            view)
+                if [[ "$*" == *"--json title"* ]]; then
+                    echo '{"title":"Test PR"}'
+                    exit 0
+                fi
+                if [[ "$*" == *"--json mergeable"* ]]; then
+                    echo "MERGEABLE"
+                    exit 0
+                fi
+                if [[ "$*" == *"--json reviewDecision,latestReviews"* ]]; then
+                    echo '{"reviewDecision":"APPROVED","latestReviews":[{"state":"APPROVED"}]}'
+                    exit 0
+                fi
+                ;;
+            checks)
+                printf '%s\n' "${STUB_CHECKS:?}"
+                exit "${STUB_CHECKS_EXIT:-0}"
+                ;;
+        esac
+        ;;
+esac
+
+printf 'unexpected gh call: %s\n' "$*" >&2
+exit 1
+EOF
+chmod +x "$TMPDIR/bin/gh"
+
+run_check() {
+    (cd "$TMPDIR/repo" && PATH="$TMPDIR/bin:$PATH" env -u GH_TOKEN -u GITHUB_TOKEN "$PR_MERGE" 123 --check)
+}
+
+echo "=== pr-merge --check CI classification ==="
+
+checks='[{"name":"Linux Integration","state":"IN_PROGRESS","bucket":"pending"},{"name":"Cross-Platform","state":"PENDING","bucket":"pending"}]'
+out=$(STUB_CHECKS="$checks" STUB_CHECKS_EXIT=8 run_check)
+assert_eq "$(jq -r .can_merge <<<"$out")" "false" "pending checks block merge"
+assert_eq "$(jq -r .transient <<<"$out")" "true" "pending-only checks are transient"
+assert_eq "$(jq -r '.issues | length' <<<"$out")" "1" "pending-only emits one issue"
+assert_contains "$(jq -r '.issues[0]' <<<"$out")" "ci_pending:" "pending issue uses ci_pending prefix"
+assert_contains "$(jq -r '.issues[0]' <<<"$out")" "Linux Integration (IN_PROGRESS)" "pending issue names running check"
+
+checks='[{"name":"Unit Tests","state":"SUCCESS","bucket":"pass"},{"name":"Lint","state":"FAILURE","bucket":"fail"}]'
+out=$(STUB_CHECKS="$checks" run_check)
+assert_eq "$(jq -r .can_merge <<<"$out")" "false" "failed checks block merge"
+assert_eq "$(jq -r .transient <<<"$out")" "false" "failed checks are permanent"
+assert_contains "$(jq -r '.issues[0]' <<<"$out")" "ci_failed: Lint (FAILURE)" "failed issue preserves ci_failed prefix"
+
+checks='[{"name":"Unit Tests","state":"IN_PROGRESS","bucket":"pending"},{"name":"Lint","state":"FAILURE","bucket":"fail"}]'
+out=$(STUB_CHECKS="$checks" STUB_CHECKS_EXIT=8 run_check)
+assert_eq "$(jq -r .can_merge <<<"$out")" "false" "mixed pending and failed checks block merge"
+assert_eq "$(jq -r .transient <<<"$out")" "false" "mixed pending and failed checks are not transient"
+assert_contains "$(jq -r '.issues[]' <<<"$out")" "ci_pending: Unit Tests (IN_PROGRESS)" "mixed output includes pending issue"
+assert_contains "$(jq -r '.issues[]' <<<"$out")" "ci_failed: Lint (FAILURE)" "mixed output includes failed issue"
+
+checks='[{"name":"Unit Tests","state":"SUCCESS","bucket":"pass"},{"name":"Optional Job","state":"SKIPPED","bucket":"skipping"}]'
+out=$(STUB_CHECKS="$checks" run_check)
+assert_eq "$(jq -r .can_merge <<<"$out")" "true" "successful and skipped checks can merge"
+assert_eq "$(jq -r '.issues | length' <<<"$out")" "0" "successful and skipped checks emit no issues"
+assert_eq "$(jq -r .transient <<<"$out")" "false" "mergeable PR is not transient"
+
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/skills/orch/scripts/ci-wait
+++ b/skills/orch/scripts/ci-wait
@@ -168,7 +168,12 @@ trap 'rm -f "$checks_stderr"' EXIT
 elapsed=0
 while [ $elapsed -lt $MAX_WAIT ]; do
   # Capture stderr so we can distinguish auth/repo failures from "no checks yet".
-  if ! checks_json=$(gh pr checks "$PR_NUM" --repo "$REPO" --json name,state 2>"$checks_stderr"); then
+  checks_status=0
+  set +e
+  checks_json=$(gh pr checks "$PR_NUM" --repo "$REPO" --json name,state 2>"$checks_stderr")
+  checks_status=$?
+  set -e
+  if [ "$checks_status" -ne 0 ] && ! jq -e 'type == "array"' >/dev/null 2>&1 <<<"$checks_json"; then
     echo "gh pr checks failed for PR #$PR_NUM in $REPO:" >&2
     cat "$checks_stderr" >&2
     exit 1

--- a/skills/orch/tests/ci_wait.sh
+++ b/skills/orch/tests/ci_wait.sh
@@ -142,6 +142,18 @@ case "${1:-}" in
     fi
     if [[ "${2:-}" == "checks" ]]; then
       _stub_auth_ok || { echo "HTTP 401: Bad credentials" >&2; exit 1; }
+      if [[ "${STUB_PR_CHECKS_MODE:-}" == "pending_once" ]]; then
+        count=0
+        if [[ -f "${STUB_PR_CHECKS_COUNT_FILE:?}" ]]; then
+          count="$(cat "$STUB_PR_CHECKS_COUNT_FILE")"
+        fi
+        count=$((count + 1))
+        printf '%s' "$count" > "$STUB_PR_CHECKS_COUNT_FILE"
+        if [[ "$count" -eq 1 ]]; then
+          echo '[{"name":"build","state":"IN_PROGRESS"}]'
+          exit 8
+        fi
+      fi
       echo '[{"name":"build","state":"SUCCESS"}]'
       exit 0
     fi
@@ -257,6 +269,18 @@ rc=$?
 set -e
 assert_eq "$rc" "3" "case7: hanging keyring auth exits 3" "$stderr"
 assert_contains "$(cat "$stderr")" "no working GitHub auth path" "case7: hanging keyring auth reports no working path" "$stderr"
+
+# Case 8: gh pr checks exits 8 while checks are pending but still prints valid
+# JSON. ci-wait should treat the JSON as authoritative and keep polling.
+stderr="$TMP_ROOT/case8.err"
+checks_count_file="$TMP_ROOT/case8-checks-count"
+set +e
+output=$(run_wait STUB_PR_CHECKS_MODE=pending_once STUB_PR_CHECKS_COUNT_FILE="$checks_count_file" 2>"$stderr")
+rc=$?
+set -e
+assert_eq "$rc" "0" "case8: pending checks exit code keeps polling" "$stderr"
+assert_contains "$output" "CI passed" "case8: ci-wait reaches CI passed after pending checks"
+assert_eq "$(cat "$checks_count_file")" "2" "case8: ci-wait polls again after pending JSON" "$stderr"
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/skills/orch/tests/workflow_helpers.sh
+++ b/skills/orch/tests/workflow_helpers.sh
@@ -131,9 +131,11 @@ assert_file_not_contains "$merge_workflow" "fetch --all --prune" "merge-pr avoid
 assert_file_not_contains "$merge_workflow" "git-https-auth -C [MAIN_REPO_ROOT] pull" "merge-pr avoids pull during post-merge sync"
 assert_file_not_contains "$merge_workflow" "git -C [MAIN_REPO_ROOT] pull" "merge-pr avoids plain git pull during post-merge sync"
 assert_file_not_contains "$merge_workflow" "git-https-auth -C [MAIN_REPO_ROOT] merge" "merge-pr keeps local merge outside HTTPS credential wrapper"
-assert_file_contains "$merge_workflow" 'If `CHECK.transient == true`, wait and re-check' "merge-pr waits on transient readiness before prompting"
+assert_file_contains "$merge_workflow" 'If `CHECK.transient == true`, route by the transient issue prefix' "merge-pr routes transient readiness before prompting"
 assert_file_contains "$merge_workflow" '`ci_pending:` (checks still running)' "merge-pr treats pending CI as transient readiness"
-assert_file_contains "$merge_workflow" 'Treat `CHECK.transient` as the contract' "merge-pr uses pr-merge transient contract"
+assert_file_contains "$merge_workflow" 'Treat `CHECK.transient` as the' "merge-pr uses pr-merge transient contract"
+assert_file_contains "$merge_workflow" '.agents/skills/orch/scripts/ci-wait [PR_NUMBER] 15 600' "merge-pr uses bounded CI wait for pending checks"
+assert_file_contains "$merge_workflow" 'Do not repeat § 3.1 indefinitely' "merge-pr forbids unbounded transient wait loops"
 assert_file_contains "$merge_workflow" 'git-https-auth -C [MAIN_REPO_ROOT] fetch --prune origin "+refs/heads/[BASE_BRANCH]:refs/remotes/origin/[BASE_BRANCH]"' "merge-pr sync fetches explicit origin base branch through HTTPS auth helper"
 assert_file_contains "$merge_workflow" 'git -C [MAIN_REPO_ROOT] merge --ff-only "origin/[BASE_BRANCH]"' "merge-pr sync fast-forwards to quoted fetched origin base branch with plain git"
 

--- a/skills/orch/tests/workflow_helpers.sh
+++ b/skills/orch/tests/workflow_helpers.sh
@@ -131,6 +131,9 @@ assert_file_not_contains "$merge_workflow" "fetch --all --prune" "merge-pr avoid
 assert_file_not_contains "$merge_workflow" "git-https-auth -C [MAIN_REPO_ROOT] pull" "merge-pr avoids pull during post-merge sync"
 assert_file_not_contains "$merge_workflow" "git -C [MAIN_REPO_ROOT] pull" "merge-pr avoids plain git pull during post-merge sync"
 assert_file_not_contains "$merge_workflow" "git-https-auth -C [MAIN_REPO_ROOT] merge" "merge-pr keeps local merge outside HTTPS credential wrapper"
+assert_file_contains "$merge_workflow" 'If `CHECK.transient == true`, wait and re-check' "merge-pr waits on transient readiness before prompting"
+assert_file_contains "$merge_workflow" '`ci_pending:` (checks still running)' "merge-pr treats pending CI as transient readiness"
+assert_file_contains "$merge_workflow" 'Treat `CHECK.transient` as the contract' "merge-pr uses pr-merge transient contract"
 assert_file_contains "$merge_workflow" 'git-https-auth -C [MAIN_REPO_ROOT] fetch --prune origin "+refs/heads/[BASE_BRANCH]:refs/remotes/origin/[BASE_BRANCH]"' "merge-pr sync fetches explicit origin base branch through HTTPS auth helper"
 assert_file_contains "$merge_workflow" 'git -C [MAIN_REPO_ROOT] merge --ff-only "origin/[BASE_BRANCH]"' "merge-pr sync fast-forwards to quoted fetched origin base branch with plain git"
 

--- a/skills/orch/workflows/merge-pr.md
+++ b/skills/orch/workflows/merge-pr.md
@@ -67,11 +67,14 @@ Use the output as `CHECK`.
 
 ### 3.1 Resolve transient readiness blockers before prompting
 
-If `CHECK.transient == true`, wait and re-check — do NOT prompt the user yet.
-Transient issue prefixes include `unknown:` (GitHub still computing mergeable
-status), `ci_pending:` (checks still running), `ci_unconfigured:`, and
-`ci_fetch_failed:`. Treat `CHECK.transient` as the contract; do not special-case
-only `unknown:`.
+If `CHECK.transient == true`, route by the transient issue prefix before any
+user prompt. Transient issue prefixes include `unknown:` (GitHub still
+computing mergeable status), `ci_pending:` (checks still running),
+`ci_unconfigured:`, and `ci_fetch_failed:`. Treat `CHECK.transient` as the
+contract for whether the block may resolve by waiting, but choose the wait path
+from the specific issue prefix.
+
+For `unknown:` only, wait for GitHub's merge-state computation and re-check:
 
 ```bash
 .agents/skills/github/scripts/github.sh await-mergeable [PR_NUMBER]
@@ -81,8 +84,28 @@ Use the second command output as `CHECK`.
 
 `await-mergeable` polls `state` + `mergeStateStatus` (never `mergeable` — stays UNKNOWN after merge, hangs forever). Exit 124 on timeout → surface to user.
 
-If the refreshed `CHECK.transient` is still `true`, repeat this § 3.1
-wait/re-check step. Continue to § 3.2 only after `CHECK.transient` is `false`.
+For `ci_pending:`, wait on CI with the bounded CI watcher, then re-check:
+
+```bash
+.agents/skills/orch/scripts/ci-wait [PR_NUMBER] 15 600
+.agents/skills/github/scripts/github.sh pr-merge [PR_NUMBER] --check
+```
+Use the second command output as `CHECK`. If `ci-wait` exits nonzero or times
+out, surface that result to the user, re-run `pr-merge --check` once for fresh
+state, then continue to § 3.2 without another automatic wait loop.
+
+For `ci_fetch_failed:` or `ci_unconfigured:`, use a short bounded backoff before
+re-checking:
+
+```bash
+sleep 30
+.agents/skills/github/scripts/github.sh pr-merge [PR_NUMBER] --check
+```
+Use the second command output as `CHECK`. Repeat at most three total checks
+before continuing to § 3.2 with the latest `CHECK`.
+
+Do not repeat § 3.1 indefinitely. Continue to § 3.2 when `CHECK.transient` is
+`false` or when the relevant bounded wait/backoff path times out.
 
 ### 3.2 Parse and act
 

--- a/skills/orch/workflows/merge-pr.md
+++ b/skills/orch/workflows/merge-pr.md
@@ -65,9 +65,13 @@ For each PR:
 ```
 Use the output as `CHECK`.
 
-### 3.1 Resolve transient "unknown" before prompting
+### 3.1 Resolve transient readiness blockers before prompting
 
-If `issues` contains an entry starting with `unknown:` (GitHub still computing mergeable status), wait and re-check — do NOT prompt the user:
+If `CHECK.transient == true`, wait and re-check — do NOT prompt the user yet.
+Transient issue prefixes include `unknown:` (GitHub still computing mergeable
+status), `ci_pending:` (checks still running), `ci_unconfigured:`, and
+`ci_fetch_failed:`. Treat `CHECK.transient` as the contract; do not special-case
+only `unknown:`.
 
 ```bash
 .agents/skills/github/scripts/github.sh await-mergeable [PR_NUMBER]
@@ -76,6 +80,9 @@ If `issues` contains an entry starting with `unknown:` (GitHub still computing m
 Use the second command output as `CHECK`.
 
 `await-mergeable` polls `state` + `mergeStateStatus` (never `mergeable` — stays UNKNOWN after merge, hangs forever). Exit 124 on timeout → surface to user.
+
+If the refreshed `CHECK.transient` is still `true`, repeat this § 3.1
+wait/re-check step. Continue to § 3.2 only after `CHECK.transient` is `false`.
 
 ### 3.2 Parse and act
 


### PR DESCRIPTION
## Summary
- Classify still-running PR checks as `ci_pending` transient blockers instead of `ci_failed`.
- Keep terminal failing/cancelled checks as permanent `ci_failed` blockers.
- Update merge workflow routing so transient readiness blockers use bounded wait paths before user prompts.

## Completed Issues
- Closes #419 - github pr-merge --check misclassifies in-progress checks as ci_failed

## QA Metrics
- Internal review: 10 reviewer passes after 2 safety fix cycles.
- Review fixes applied: 2.

## Test Plan
- `bash skills/github/tests/pr-merge.sh`
- `bash skills/orch/tests/ci_wait.sh`
- `bash skills/orch/tests/workflow_helpers.sh`
- `bash skills/orch/tests/run-all.sh`
- `git diff --check origin/main...HEAD`
