### PR TITLE
fix(codex): drop unsupported top-level skills field from agent TOML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ docs/plans/
 /.opencode/**
 /.pi/**
 !/.pi/prompts/
-!/.pi/prompts/pi-update.md
+!/.pi/prompts/*.md
 /opencode.json
 
 # npm artifacts (pi-extensions are published to npm)

--- a/.pi/prompts/gh-release.md
+++ b/.pi/prompts/gh-release.md
@@ -1,0 +1,172 @@
+---
+description: Cut a new vstack GitHub feature release with CLI version/tag sync
+argument-hint: "[patch|minor|major]"
+---
+Cut a new vstack GitHub feature release. Optional bump override: `$ARGUMENTS`.
+
+## Intent
+Review all repository changes since the latest GitHub release, commit safe local work that should ship, ensure docs/tests are current, bump the CLI version, create a matching GitHub release/tag, and leave the local repo clean and pushed.
+
+## Hard rules
+- Never release with dirty or untracked local files after the preflight work-intake step. The release/tag steps require `git status --short` to be empty except for the intentional version bump before its commit.
+- Do not blindly `git add -A`. Inspect dirty and untracked paths, stage only files that are intended to ship, and exclude secrets/private files, ignored build outputs, caches, temp artifacts, local machine config, and generated noise.
+- If any dirty/untracked file is ambiguous, private-looking, ignored, or unrelated to the release, stop and ask before staging it. Do not stash/drop user work silently.
+- Commit safe dirty/untracked release content before the clean/current release preflight. The release preflight starts only after this feature/docs commit is complete and the worktree is clean.
+- Never release from a branch that is behind or diverged from `origin/main`.
+- Keep CLI package version and GitHub release tag exactly in sync:
+  - `cli/Cargo.toml` `[package].version = X.Y.Z`
+  - Git tag/release `vX.Y.Z`
+- Do not bump npm Pi extension package versions as part of this template unless explicitly requested; use `/npm-deploy` for Pi extension npm publishing.
+- Do not move an existing release pointer for a new feature release. Create a new version/tag/release.
+- Stage only intended files in each commit: feature/docs fixes in the work-intake commit; version files in the release-version commit.
+
+## Work-intake: commit safe local changes first
+1. Inspect local state before release preflight:
+   ```bash
+   git status --short --untracked-files=all
+   git diff --stat
+   git diff --name-only
+   ```
+2. Classify every dirty or untracked path:
+   - intended product/docs/test/release content → eligible to stage,
+   - private/secrets/local config (`.env*`, credentials, tokens, local settings) → do not stage; stop and ask,
+   - ignored/build/cache/temp artifacts → do not stage; stop and ask if they must remain,
+   - unrelated user work → do not stage; ask whether to include, commit separately, or stop.
+3. For untracked files, verify they are not ignored before considering them:
+   ```bash
+   git check-ignore -v -- <path> || true
+   ```
+   Ignored files are excluded by default. If an ignored file appears required for the release, ask before forcing it into git.
+4. Stage only safe intended paths explicitly:
+   ```bash
+   git add <intended-file> [<intended-file> ...]
+   git diff --cached --stat
+   git diff --cached --name-only
+   ```
+5. Run validation appropriate for the staged change. At minimum for CLI or TUI changes run:
+   ```bash
+   cd cli && cargo test
+   ```
+6. Commit the staged work before release preflight with a descriptive non-version message, for example:
+   ```bash
+   git commit -m "vstack: improve TUI reinstall flow"
+   ```
+7. Re-check local state:
+   ```bash
+   git status --short --untracked-files=all
+   ```
+   If anything remains dirty/untracked, stop and ask unless it is intentionally excluded and safe to leave out of the release. Do not proceed to release preflight until the worktree is clean.
+
+## Preflight: clean and current
+1. Inspect branch and status:
+   ```bash
+   git status --short --branch
+   git fetch origin --tags
+   git rev-parse --abbrev-ref HEAD
+   git rev-list --left-right --count HEAD...origin/main
+   ```
+2. Require:
+   - branch is `main`,
+   - no dirty/untracked files,
+   - no ahead/behind/diverged commits unless they are intentionally pushed before release.
+3. If local commits are ahead, push them before continuing. If behind/diverged, stop and reconcile.
+4. Confirm latest release:
+   ```bash
+   gh release list --limit 10
+   git tag --sort=-v:refname | head
+   ```
+
+## Audit changes since latest release
+1. Identify latest GitHub CLI release tag (normally latest `vX.Y.Z` from `gh release list`, not Pi package tags).
+2. Inspect changes:
+   ```bash
+   git log --oneline <latest-release-tag>..HEAD
+   git diff --stat <latest-release-tag>..HEAD
+   git diff --name-only <latest-release-tag>..HEAD
+   ```
+3. Classify semver:
+   - patch: bug fixes, docs, internal cleanup, non-breaking behavior fixes.
+   - minor: additive CLI commands/options/features, new packages/extensions/agents/skills surfaced to users.
+   - major: breaking CLI behavior, lock/config format break, removed/renamed commands/options, incompatible install behavior.
+4. If the user supplied an explicit bump in `$1`, verify it is not lower than the change classification. Ask before using a lower bump.
+
+## Documentation freshness check
+Compare code changes to docs before bumping:
+- Read affected docs/README files and changed source.
+- Check CLI docs/help examples, AGENTS.md repo layout/rules, README feature lists, Pi extension docs if included, command flags, config keys, release/install commands, and examples.
+- Ensure new commands/options/config fields/user-visible behavior are documented.
+- Ensure removed/renamed/dead behavior is not still documented.
+- Grep for stale old names/versions/config keys if renames happened.
+- If docs are stale, update docs and commit those docs before the version bump, then restart preflight cleanliness/currentness.
+
+## Validation before version bump
+Run required validation for the changed areas:
+- Always run CLI tests:
+  ```bash
+  cd cli && cargo test
+  ```
+- If CLI behavior/install paths changed, run an integration smoke in a temp dir, e.g.:
+  ```bash
+  tmp=$(mktemp -d)
+  (cd "$tmp" && cargo run --manifest-path /mnt/Tertiary/dev/vstack/cli/Cargo.toml -- add /mnt/Tertiary/dev/vstack --all --copy -y)
+  ```
+  Read the printed scope summary and verify it is project-scoped in the temp dir.
+- If Pi extensions changed in the release range, run each affected package's validation (`npm run check`, or available typecheck/test/build scripts) and consider `/npm-deploy` separately.
+- If docs/examples changed only, run enough checks to confirm examples are still true.
+- Do not release on failing validation unless the user explicitly accepts the risk.
+
+## Bump CLI version
+1. Compute next `X.Y.Z` from latest release and semver classification.
+2. Update `cli/Cargo.toml` `[package].version` to `X.Y.Z`.
+3. If `Cargo.lock` contains the `vstack` package version, update it by running appropriate cargo metadata/build/test command from `cli/`.
+4. Re-run `cd cli && cargo test` after the version bump.
+5. Confirm:
+   ```bash
+   grep '^version = ' cli/Cargo.toml
+   git diff -- cli/Cargo.toml Cargo.lock
+   ```
+6. Commit only intended version files:
+   ```bash
+   git add cli/Cargo.toml Cargo.lock
+   git commit -m "vstack: release vX.Y.Z"
+   ```
+
+## Create and push release
+1. Ensure clean status after commit:
+   `git status --short --branch`.
+2. Push main:
+   `git push origin main`.
+3. Create annotated or lightweight tag matching CLI version exactly:
+   `git tag vX.Y.Z`.
+4. Push tag:
+   `git push origin vX.Y.Z`.
+5. Create GitHub release as latest:
+   ```bash
+   gh release create vX.Y.Z --title "vstack X.Y.Z" --generate-notes --latest
+   ```
+   If generated notes omit important highlights, edit the release notes with a concise summary from the audit.
+
+## Final post-release checks
+1. Verify GitHub release/tag:
+   ```bash
+   gh release view vX.Y.Z
+   git ls-remote --tags origin vX.Y.Z
+   ```
+2. Confirm version/tag sync:
+   - `cli/Cargo.toml` version is `X.Y.Z`.
+   - Git tag and release are `vX.Y.Z`.
+3. Confirm clean/current:
+   ```bash
+   git status --short --branch
+   git rev-list --left-right --count HEAD...origin/main
+   ```
+
+## Final report
+Report:
+- latest previous release tag,
+- semver classification and chosen new version,
+- docs freshness findings/changes,
+- validation commands/results,
+- release commit and tag,
+- GitHub release URL,
+- final clean/current git status.

--- a/.pi/prompts/npm-deploy.md
+++ b/.pi/prompts/npm-deploy.md
@@ -1,0 +1,110 @@
+---
+description: Audit changed Pi extensions, validate, bump, publish to npm, tag, push, refresh, and verify
+argument-hint: "[package-name]"
+---
+Run a complete npm deployment pass for vstack Pi extensions. Optional package filter: `$ARGUMENTS`.
+
+## Intent
+Find every `pi-extensions/*/package.json` package whose source/docs/package contents changed since its last npm deployment tag, then validate, bump, publish, tag, push, refresh, and verify it. Leave no dirty/untracked files.
+
+vstack distribution is independent of npm. `vstack add`/`refresh` copies local source — npm publishing only populates the pi.dev gallery and lets external users run `pi install npm:@vanillagreen/<name>`. Skipping a publish never breaks vstack consumers.
+
+## Hard rules
+- Publish only Pi extension packages that actually need a new npm version.
+- Use scoped npm names from `package.json` (normally `@vanillagreen/<name>`).
+- Per-package release tags use `<unscoped-name>-v<version>` (example: `pi-qol-v1.0.4`).
+- Never publish outside `op run --env-file=../../.env.npm -- npm publish --userconfig=../../.npmrc`.
+- Never write or log npm tokens. `.env.npm` only contains an `op://` reference, never a literal token; never commit `.env.npm` (gitignored).
+- Never use `op run --no-masking` outside one-off auth verification.
+- Stage only intended files. Preserve unrelated user dirty files; if unrelated dirt exists, stop and ask unless the user explicitly included it.
+- Version bump commits are separate from source/docs commits when source/docs changes are not already committed.
+- After any committed Pi package source change, run `vstack refresh -g`, then `vstack verify -g <changed packages...>`.
+
+## Skip publish for
+- Refactors with no behavior change.
+- Internal cleanup, comment/typo fixes.
+- README/doc edits unless gallery copy needs updating.
+
+Semver bump rules:
+- patch — bug fix, no API change.
+- minor — additive: new tool, new setting, backward-compatible feature.
+- major — breaking: removed/renamed tool, changed setting key, dropped Pi peerDependency support.
+
+## Audit
+1. Inspect `git status --short --branch`.
+2. Enumerate all packages:
+   - `find pi-extensions -maxdepth 2 -name package.json -print | sort`
+   - For each manifest, read `name` and `version`.
+3. For each package, compute:
+   - current npm version: `npm view <name> version`
+   - expected current tag: `<unscoped-name>-v<package.json version>`
+   - source drift since that tag: `git diff --name-only <tag>..HEAD -- <package-dir>` when the tag exists.
+4. Mark a package for deployment if any of these are true:
+   - package files changed since its current version tag,
+   - `package.json` version is greater than npm version,
+   - npm version exists but matching git tag is missing,
+   - user package filter names the package.
+
+## Documentation freshness check
+For each marked package, compare changed code to package docs before publishing:
+- Read its README and package `vstack.extensionManager.settings`.
+- Look for stale setting keys, config examples, commands, shortcuts, tool names, default values, package names, behavior claims, screenshots captions, and install/publish instructions.
+- If new user-visible behavior, settings, commands, tool behavior, critical safety behavior, or workflow changes are missing from docs, update docs first.
+- Also grep all Pi extension READMEs for stale unscoped config examples such as `"pi-web-tools"` under `vstack.extensionManager.config`; current keys should be scoped (`"@vanillagreen/pi-web-tools"`).
+
+## Validation
+For every marked package, run the strongest available validation before publish:
+- If `scripts.check` exists: `npm run check`.
+- Else run available `typecheck`, `test:unit`, `test`, and/or `build` scripts as applicable.
+- If no scripts exist, run lightweight syntax/import checks where practical (for TS-only Pi extensions, use an existing package with `tsx` if available, or explain why live import is not practical due peer deps).
+- For repo-level/CLI changes discovered while auditing, run relevant repo tests too (`cd cli && cargo test`).
+- Do not proceed on failing validation unless the user explicitly accepts the risk.
+
+## Commit source/docs before version bumps
+If there are intended source/docs changes not yet committed:
+1. Stage only those intended files.
+2. Commit with a concise package-scoped message.
+3. Re-check status.
+
+## Version bump and publish
+For each marked package that needs publishing:
+1. Choose semver bump:
+   - patch: bug fix, docs packaged with runtime, settings/docs cleanup, UI fix.
+   - minor: additive new command/tool/setting/feature.
+   - major: breaking setting/tool/API behavior.
+2. Bump the package only:
+   ```bash
+   cd pi-extensions/<dir>
+   npm version <patch|minor|major> --no-git-tag-version
+   cd ../..
+   ```
+3. Stage only that package's `package.json` and any lockfile changed by `npm version`.
+4. Commit version bumps. Prefer a single coordinated commit if deploying multiple packages.
+5. Publish each package:
+   ```bash
+   cd pi-extensions/<dir>
+   op run --env-file=../../.env.npm -- npm publish --userconfig=../../.npmrc
+   cd ../..
+   ```
+6. Verify npm reports the new version:
+   `npm view <name> version`.
+7. Create per-package git tags at the version-bump commit:
+   `git tag <unscoped-name>-v<version>`.
+
+## Push, refresh, verify
+1. Push `main` and all new package tags.
+2. Run:
+   ```bash
+   vstack refresh -g
+   vstack verify -g <changed scoped package names...>
+   ```
+3. Confirm `git status --short --branch` is clean and local `main` matches `origin/main`.
+
+## Final report
+Report:
+- packages audited and deployed,
+- versions published to npm,
+- commits and tags pushed,
+- validation commands/results,
+- refresh/verify result,
+- final git status.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ cli/src/
 │   ├── claude.rs        → .claude/agents/*.md (disallowedTools, effort/background/isolation/memory, skills, hooks frontmatter)
 │   ├── cursor.rs        → .cursor/rules/*.mdc (description + alwaysApply + skills)
 │   ├── opencode.rs      → .opencode/agents/*.md (YAML frontmatter + skills)
-│   ├── codex.rs         → .codex/agents/*.toml (developer_instructions + skills)
+│   ├── codex.rs         → .codex/agents/*.toml (developer_instructions + Required Skills section)
 │   └── pi.rs            → .pi/agents/*.md (name, description, deny-tools, model, pane)
 └── tui/                 Install wizard: install_flow, state, summary, multiselect, render
 
@@ -41,7 +41,7 @@ skill-templates/         Templates for new skills
 - **Skill dependencies use frontmatter.** `dependencies: { required: [...], optional: [...] }` in SKILL.md.
 - **Hooks diverge by harness.** Claude Code: native shell hooks + settings.json + agent frontmatter. Cursor: safety `.mdc` rules. OpenCode: `.opencode/agents/*.md` + instructions. Codex: native shell hooks under `<scope>/.codex/hooks/` registered in `<scope>/.codex/hooks.json` with `[features] hooks = true` in `config.toml` — events without a codex equivalent (e.g. Claude's `TaskCompleted`) fall back to inline prose in `developer_instructions`. Pi: native TS implementations in the `@vanillagreen/pi-hooks` extension, listening on `tool_call`/`tool_result`/`turn_end`; each hook independently toggleable in pi-extension-manager.
 - **Pi extensions are npm-shaped.** vstack copies them to `<scope>/packages/<name>`, runs `npm install --omit=dev --package-lock=false --legacy-peer-deps --no-audit --no-fund` there when `package.json` has `dependencies` or `optionalDependencies`, and registers the path in Pi's `settings.json` `packages` array.
-- **Skill/hook attribution is config-driven.** Source `vstack.toml` `[agent-skills]` is authoritative — explicit entries skip prefix matching. `[role-skills]` adds skills to all agents of a role. Project `vstack.toml` also has `[agent-skills]` populated at install; users add/remove and refresh. Agents get `skills:` frontmatter and a "Required Skills" body section.
+- **Skill/hook attribution is config-driven.** Source `vstack.toml` `[agent-skills]` is authoritative — explicit entries skip prefix matching. `[role-skills]` adds skills to all agents of a role. Project `vstack.toml` also has `[agent-skills]` populated at install; users add/remove and refresh. Markdown-based harnesses get `skills:` frontmatter; Codex agents get a "Required Skills" instruction section.
 - **Reconciliation is automatic.** After every `vstack add`, all installed agents are regenerated with the current full set of installed skills and hooks.
 - **Project root walks up from CWD.** `config::project_root()` finds `.vstack-lock.json`, `.claude/`, `.cursor/`, `.codex/`, `.opencode/`, `.pi/`, or `.agents/` by walking parents. `$HOME` is rejected as a project root when only user-level harness dirs (`~/.claude`, `~/.pi`, etc.) exist there with no `.vstack-lock.json`, so project-scope writes never accidentally route into user state.
 - **Runtime settings are split from secrets.** Portable skill scripts load `.env`, then `vstack.settings.toml` / `.vstack/settings.toml` `[env]`, then `.env.local`. Put committed non-sensitive defaults in `vstack.settings.toml`; reserve `.env.local` for secrets, API keys, private URLs, signing keys, and personal overrides. Existing `.env.local` settings remain supported for compatibility.

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Secret values may also be injected by the parent process at launch time. GitHub 
 | Claude Code | Richest native hook support. Works per project or globally. |
 | Cursor | Project scope only; safety rules surface as `.cursor/rules`. |
 | OpenCode | Config-dir aware. |
-| Codex | Project agents live in `.codex/agents/*.toml`; their `skills = [...]` and Required Skills section point project installs at `.agents/skills/<name>/SKILL.md`. Native hooks are used for supported events; events without a Codex equivalent fall back to safety guidance inside agent instructions. |
+| Codex | Project agents live in `.codex/agents/*.toml`; their Required Skills section points project installs at `.agents/skills/<name>/SKILL.md`. Native hooks are used for supported events; events without a Codex equivalent fall back to safety guidance inside agent instructions. |
 | Pi | Adds Pi extension installation alongside agents and skills. |
 
 Windows: CLI runs natively; symlink mode falls back to copy.

--- a/cli/src/commands/check.rs
+++ b/cli/src/commands/check.rs
@@ -60,6 +60,32 @@ fn parse_skills_field(frontmatter: &str) -> Vec<String> {
     Vec::new()
 }
 
+fn parse_required_skills_section(content: &str) -> Vec<String> {
+    let Some(start) = content.find("## Required Skills") else {
+        return Vec::new();
+    };
+    let after_header = &content[start + "## Required Skills".len()..];
+    let section = after_header
+        .find("\n## ")
+        .map(|end| &after_header[..end])
+        .unwrap_or(after_header);
+
+    section
+        .lines()
+        .filter_map(|line| {
+            let trimmed = line.trim_start();
+            let rest = trimmed.strip_prefix("- `")?;
+            let end = rest.find('`')?;
+            let name = rest[..end].trim();
+            if name.is_empty() {
+                None
+            } else {
+                Some(name.to_string())
+            }
+        })
+        .collect()
+}
+
 fn read_agent_skills(path: &Path) -> Vec<String> {
     let Ok(content) = std::fs::read_to_string(path) else {
         return Vec::new();
@@ -67,8 +93,16 @@ fn read_agent_skills(path: &Path) -> Vec<String> {
     if let Ok((fm, _body)) = split_yaml_frontmatter(&content) {
         return parse_skills_field(&fm);
     }
-    // Codex agents use [developer_instructions] TOML, not YAML frontmatter.
-    // Detect skill blocks via a `skills =` TOML line.
+    // Codex agents keep their skill inventory inside developer_instructions.
+    if let Some(body) = crate::agent::extract_body_from_codex_toml(&content) {
+        let skills = parse_required_skills_section(&body);
+        if !skills.is_empty() {
+            return skills;
+        }
+    }
+
+    // Backward compatibility for older Codex agent files generated with an
+    // unsupported top-level `skills = [...]` field.
     for line in content.lines() {
         let trimmed = line.trim_start();
         if let Some(rest) = trimmed.strip_prefix("skills =") {
@@ -278,7 +312,7 @@ fn check_staleness(entry: &LockEntry) -> &'static str {
 
 #[cfg(test)]
 mod parse_skills_field_tests {
-    use super::parse_skills_field;
+    use super::{parse_required_skills_section, parse_skills_field};
 
     #[test]
     fn comma_separated_inline() {
@@ -314,5 +348,17 @@ mod parse_skills_field_tests {
         assert!(parse_skills_field("name: x").is_empty());
         assert!(parse_skills_field("skills:").is_empty());
         assert!(parse_skills_field("skills: []").is_empty());
+    }
+
+    #[test]
+    fn required_skills_section_lists_codex_skill_names() {
+        let body = "# Agent\n\n## Required Skills\n\n- `dev`: Delegation (`.agents/skills/dev/SKILL.md`)\n- `github`: GitHub helpers (`.agents/skills/github/SKILL.md`)\n\n## Other\n\nText.";
+        let skills = parse_required_skills_section(body);
+        assert_eq!(skills, vec!["dev".to_string(), "github".to_string()]);
+    }
+
+    #[test]
+    fn missing_required_skills_section_yields_empty_vec() {
+        assert!(parse_required_skills_section("# Agent\n\n## Notes\n").is_empty());
     }
 }

--- a/cli/src/harness/codex.rs
+++ b/cli/src/harness/codex.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 /// Generate a Codex agent file (.codex/agents/<name>.toml)
 ///
 /// Format: TOML with name, description, model, sandbox_mode,
-/// skills, and developer_instructions (the agent body).
+/// and developer_instructions (the agent body).
 ///
 /// Hooks are NOT rendered here — codex hooks install as native shell hooks via
 /// `installer::install_hook_codex` (which writes `<scope>/.codex/hooks/*.sh`,
@@ -80,10 +80,6 @@ pub fn generate_agent(
         output.push_str(&format!("model_reasoning_effort = \"{effort}\"\n"));
     }
     output.push_str(&format!("sandbox_mode = \"{sandbox_mode}\"\n"));
-    if !skills.is_empty() {
-        let names: Vec<String> = skills.iter().map(|(name, _)| name.clone()).collect();
-        output.push_str(&format!("skills = {}\n", toml_string_array(&names)));
-    }
 
     // Developer instructions as multiline TOML string
     output.push_str("developer_instructions = '''\n");
@@ -333,7 +329,7 @@ mod tests {
     }
 
     #[test]
-    fn writes_skills_field_and_project_local_inventory() {
+    fn writes_project_local_required_skills_without_unsupported_top_level_field() {
         let dir = std::env::temp_dir().join(format!(
             "vstack_codex_skills_project_{}",
             std::process::id()
@@ -352,7 +348,7 @@ mod tests {
         let path = generate_agent(&agent, false, &dir, &skills, &[], &AgentExtras::default())
             .expect("generate ok");
         let content = std::fs::read_to_string(&path).unwrap();
-        assert!(content.contains("skills = [\"dev\", \"github\"]"));
+        assert!(!content.contains("\nskills = "));
         assert!(content.contains("## Required Skills"));
         assert!(content.contains("`.agents/skills/dev/SKILL.md`"));
         assert!(!content.contains(".codex/skills/dev/SKILL.md"));

--- a/pi-extensions/pi-agents-tmux/README.md
+++ b/pi-extensions/pi-agents-tmux/README.md
@@ -13,20 +13,20 @@ Delegate work to specialized agents from a running Pi session. Agents run either
 - Monitor groups tasks by session (pane, bg lane, bg one-shot) under expandable Active and Completed sections, with active sessions first and newest invocations first inside each section; repeated same-agent launches get session numbers and task numbers reset per session. Steering/follow-up delivery mode is shown in expanded rows and trace metadata.
 - Chat completion rows show actual results, never a repeat of the original request.
 - Task detail shows Summary and Completion tabs; Summary contains task metadata, artifacts, and task text, while Completion contains result summary, files changed, and validation.
-- Bg one-shot transcripts keep start/end/tool audit events but omit successful streaming `message_update` snapshots by default to avoid large duplicate JSONL files. Failed runs preserve the latest unfinalized update as `buffered: true`; set `PI_AGENTS_TMUX_TRANSCRIPT_FULL=1` before launching Pi to retain every stream snapshot for debugging.
-- `needs_completion` diagnostics try to attach a best-effort worker `cwdSnapshot` for Git worktree cwds, so `get_subagent_result` can show HEAD, dirty status, and last commit without manual shell inspection when the snapshot is available. Dirty scans avoid content filters, reject unsafe tracked paths, enforce the lstat deadline across parent/final probes, and skip tracked paths under symlinked parent directories.
+- Bg one-shot transcripts keep enough history to inspect results without creating oversized session files.
+- When a task needs manual completion, result views include useful repository context when available.
 - Dashboard widget shows live state, turns, tokens, and cost for every spawned agent; working agents stay above attention/completed agents, newest invocations lead each bucket, and activity updates do not reshuffle rows. Once you hide it, lifecycle updates do not reopen it until you toggle it back in.
-- Task registry locking is cross-process and stale-lock aware; if a killed or stalled Pi process leaves a lock behind, dashboard and Monitor refreshes wait for stale recovery and skip transient lock contention instead of exiting Pi. Pane completion collection leaves or restores outbox files until terminal task state and the processed archive path are persisted, so lock contention can retry without losing completions.
+- Dashboard and Monitor refreshes recover gracefully if another Pi process is updating agent state.
 - Grouped completion notifications batch multiple agents finishing together.
-- When `pi-session-bridge` is loaded, spawn/queue/start/steer/completion lifecycle points publish structured `agent.*` activity broker events without adding chat messages (`agent.spawned`, `agent.task_queued`, `agent.task_started`, `agent.steered`, `agent.task_completed`, `agent.task_blocked`, `agent.task_failed`, `agent.needs_completion`, `agent.empty_after_compact`, `agent.pane_cwd_stale`).
+- When `pi-session-bridge` is loaded, other tools can subscribe to agent lifecycle updates without adding chat messages.
 - `taskId` retrieval, mid-run steering, and pane stop without losing memory. When `pi-session-bridge` provides compact input events, trace views humanize `steer` vs `followUp` input records instead of showing raw JSON only.
 - Stop kills the tmux process but preserves the session — next launch resumes it.
-- Bg agents get fresh sessions per call by default; opt into shared memory with an explicit `sessionKey`. Bg completions are captured from the child process's final assistant output; `complete_subagent` is reserved for persistent pane/follow-up tasks and is withheld from bg children.
-- Bg one-shot children have a process-level deadline (`bgTaskTimeoutMs`, default 30 minutes). A child that never exits is marked failed with `reason: "unresponsive_timeout"`, its process group is terminated, and the parent parallel queue keeps draining instead of waiting forever.
+- Bg agents get fresh sessions per call by default; opt into shared memory with an explicit `sessionKey`.
+- Bg one-shot agents have a configurable timeout so one stalled child does not block the rest of a parallel run.
 - Inventory-aware launch guard rejects unknown agent names with the available list.
 - Large parallel calls run through a flat worker pool capped at `maxConcurrency`; callers do not need to split requests. Pane idle waits use `wait_for_subagent_idle`.
-- Persistent panes auto-resume after detected provider rate limits. Scheduling prefers validated structured quota snapshots (Claude usage endpoints, Codex/OpenAI `wham/usage` fixtures/seams, SDK reset/retry fields) and records `resetSource`; malformed quota data falls back with sanitized diagnostics, and localized `resets <time>` prose is only a degraded fallback before plain backoff.
-- Periodic pane idle-stall probes cache `pi-bridge` resolution at extension load. A structured `spawn`/`ENOENT` for the expected `pi-bridge` binary is treated as genuinely missing and skips silently; other ENOENT/spawn failures are written to `subagent-diagnostics.jsonl`. If initial resolver setup fails, one `pi-bridge resolver failed: ...` diagnostic is written.
+- Persistent panes can auto-resume after detected provider rate limits.
+- Idle pane checks are quiet by default and write diagnostics only when something needs attention.
 
 ## Install
 
@@ -110,17 +110,17 @@ Frontmatter fields:
 
 Everything after the frontmatter is the agent's system prompt.
 
-Pane tasks move through queued → running → completed | blocked | failed. On Linux, before reusing a live pane, `subagent` verifies the pane process cwd is still present and matches the requested task `cwd`; stale or mismatched panes return a structured `pane-cwd-stale` error, publish `agent.pane_cwd_stale`, and should be recovered with `stop_subagent` plus a retry using `forceSpawn: true`. Stop kills the tmux process; the session file is preserved so the next launch resumes memory.
+Pane tasks move through queued → running → completed | blocked | failed. If a saved pane no longer points at the right working directory, stop it and launch a fresh pane. Stop closes the tmux process but preserves the session so the next launch can resume memory.
 
 Persistent pane children own their tmux pane and set the pane title to `agent:<name>`. Background one-shot children keep the same agent identity for authorization but do not update the inherited parent pane title or poll pane inbox files.
 
-See [`DEVELOPMENT.md`](./DEVELOPMENT.md) for the underlying tool surface (`subagent`, `delegate_subagent`, `get_subagent_result`, `steer_subagent`, `stop_subagent`, `wait_for_subagent_idle`) and activity broker mapping.
+See [`DEVELOPMENT.md`](./DEVELOPMENT.md) for contributor-facing tool schemas and lifecycle internals.
 
 ## Restricted delegation (`delegate_subagent`)
 
 vstack-installed engineer agents default to denying `subagent` so they cannot orchestrate fleets, but they still need to spend a fresh context window on reconnaissance work. `delegate_subagent` is the bridge:
 
-- Only visible to child Pi processes whose `PI_SUBAGENT_CHILD_AGENT` is set (panes and bg one-shot children both export this for issue #228). Visible pane ownership is separate: only pane launchers export `PI_SUBAGENT_CHILD_PANE=1`.
+- Only available to child agent sessions launched by this extension.
 - Only the targets listed in the caller agent's `allowed-subagents:` frontmatter are accepted; missing or unlisted targets fail with an inventory error.
 - Single-dispatch only — no `tasks`, `chain`, `agentScope`, `sessionKey`, `forceSpawn`, or `resumeSession` exposure.
 - Targets with `pane: true` are rejected — restricted delegation is bg-only.
@@ -160,7 +160,7 @@ There is one execution-concurrency knob — `maxConcurrency` — and it caps con
 | --- | --- |
 | Enable agents | Master toggle for the subagent tools, dashboard, and pane helpers. |
 | Max concurrency | Cap on concurrent one-shot/background agent executions in the parallel dispatch queue; persistent pane agents only occupy the queue until launch/enqueue. |
-| Background task timeout | Deadline in milliseconds for bg one-shot child processes. On timeout the child is marked failed with `reason: "unresponsive_timeout"` and its process group is terminated. Set `0` to disable. |
+| Background task timeout | Deadline in milliseconds for bg one-shot agents. Set `0` to disable. |
 | Subagent model source | Use the agent's `model:` or inherit the parent session model. |
 | Subagent thinking source | Use the model `:effort` suffix or inherit the parent thinking level. |
 | Reused session budget threshold | Fraction of model context allowed before an explicit `sessionKey` lane is considered too full. |
@@ -186,14 +186,14 @@ There is one execution-concurrency knob — `maxConcurrency` — and it caps con
 | Truncate agent results | Apply Pi-sized inline caps to tool output. |
 | Result max bytes | Inline byte cap per agent result. |
 | Result max lines | Inline line cap per agent result. |
-| Preserve full agent output | Save oversized output to the session runtime and include the artifact path. |
+| Preserve full agent output | Save oversized output and include a path to retrieve it. |
 
 ### Persistent panes
 
 | Setting | What it does |
 | --- | --- |
-| Completion poll interval | Parent poll rate for pane completion files. |
-| Child inbox poll interval | Child pane poll rate for incoming tasks. |
+| Completion poll interval | How often the parent checks persistent pane results. |
+| Child inbox poll interval | How often child panes check for new tasks. |
 | Force session bridge for panes | Load `pi-session-bridge` in pane launchers so steering keeps working. |
 
 ### Keyboard

--- a/pi-extensions/pi-claude-bridge/DEVELOPMENT.md
+++ b/pi-extensions/pi-claude-bridge/DEVELOPMENT.md
@@ -1,0 +1,17 @@
+# pi-claude-bridge — development notes
+
+Implementation details for contributors. End-user setup, settings, and troubleshooting live in [`README.md`](./README.md).
+
+## Stream and tool-result handling
+
+- The bridge runs Claude Code through the Claude Agent SDK while Pi remains the owner of the visible TUI and tool execution.
+- If the SDK stream yields a completed assistant tool-use message before `message_stop`, the bridge treats that assistant message as the tool-turn boundary. Pi executes the tool calls immediately, and the matching tool results are delivered back before the turn continues.
+- Tool results whose IDs were never registered in the active assistant tool-use turn are refused instead of being queued against another pending call. Remaining handlers receive an internal-error result so the turn cannot report false success.
+- If a query tears down while parallel tool results are still queued or unresolved, the bridge writes diagnostics, marks the Claude session for rebuild, and re-imports delivered results from Pi history on the next turn.
+
+## Diagnostics
+
+- Rate-limit errors are deduplicated before user notification. The bridge emits `vstack:rate-limit` so `pi-qol` can opt into reset-time auto-resume.
+- Stream-idle stalls close the stalled Claude Code subprocess and return a retryable assistant error. `CLAUDE_BRIDGE_STREAM_IDLE_TIMEOUT` accepts bare seconds or `ms`, `s`, and `m` suffixes.
+- Integrity diagnostics are written to `~/.pi/agent/claude-bridge-diag.log` with counts, affected tool names, and sampled tool-call IDs.
+- Startup preflight failures preserve the underlying `code`, `errno`, `syscall`, `path`, `cwd`, and detected executable file type before handing the error back to the SDK.

--- a/pi-extensions/pi-claude-bridge/README.md
+++ b/pi-extensions/pi-claude-bridge/README.md
@@ -3,9 +3,9 @@
 ![Claude bridge demo response](https://raw.githubusercontent.com/vanillagreencom/vstack/main/pi-extensions/pi-claude-bridge/assets/bridge-demo.png)
 ![Claude Bridge settings panel](https://raw.githubusercontent.com/vanillagreencom/vstack/main/pi-extensions/pi-claude-bridge/assets/settings-panel.png)
 
-Run Claude Code as a Pi provider. Adds `claude-bridge/*` models to `/model` and routes Pi turns through the Claude Agent SDK while keeping Pi's tools and TUI.
+Run Claude Code as a Pi provider. Adds `claude-bridge/*` models to `/model` while keeping Pi's tools and TUI.
 
-Forked from [`elidickinson/pi-claude-bridge`](https://github.com/elidickinson/pi-claude-bridge). The provider, MCP bridge, session sync, and SDK plumbing come from upstream; this fork removes the AskClaude tool and adds opt-in forwarding for Pi prompt context.
+Forked from [`elidickinson/pi-claude-bridge`](https://github.com/elidickinson/pi-claude-bridge). This fork removes the AskClaude tool and adds opt-in forwarding for Pi prompt context.
 
 ## Highlights
 
@@ -100,18 +100,18 @@ The bridge registers `claude-bridge/claude-fable-5` and `claude-bridge/claude-op
 
 Claude Code's `/extra-usage` local command works through the Claude Agent SDK. In Pi, use `/claude-bridge:extra` to run that flow from claude-bridge. Persist automatic launch on extra-usage errors with **Allow extra usage helper** in `/extensions:settings`.
 
-When Claude Code emits rate-limit reset metadata, the bridge shows one red ASCII `[rate-limit]` Pi warning with the reset timestamp including timezone context, deduplicates repeated Claude Code error lines, and suppresses the SDK's follow-up `Claude Code returned an error result: ...` wrapper when the bridge already emitted the terminal error. The bridge also emits `vstack:rate-limit` on Pi's extension event bus so `pi-qol` can opt into reset-time auto-resume.
+When Claude Code reports a rate-limit reset time, the bridge shows one clear `[rate-limit]` warning with timezone context and avoids repeating the same error line. If `pi-qol` is installed, it can use the reset time to resume later.
 
 Allowed-warning rate-limit events are filtered before user notification. The bridge normalizes unambiguous numeric utilization (`0 < value < 1` as fractional, `1 < value <= 100` as percent), suppresses low or unit-ambiguous values such as exact `1`, and only shows a neutral warning at 80%+ instead of claiming an unverified `% used` value. Check Claude Code `/usage` for exact allowed-warning utilization.
 
-If Claude Code accepts a turn but produces no assistant/tool output, the bridge treats that stream-idle stall as a retryable overload/rate-limit failure: it closes the stalled Claude Code subprocess, emits a normal assistant error with a backoff hint, and lets `pi-agents-tmux` reuse its existing rate-limit retry ladder. Tune the first-output timeout with `CLAUDE_BRIDGE_STREAM_IDLE_TIMEOUT` (bare numbers are seconds; suffixes `ms`, `s`, and `m` are accepted). Default: `90s`; set `0` to disable.
+If Claude Code accepts a turn but produces no visible output, the bridge returns a retryable assistant error with a backoff hint instead of leaving Pi stuck waiting. Tune the first-output timeout with `CLAUDE_BRIDGE_STREAM_IDLE_TIMEOUT` (bare numbers are seconds; suffixes `ms`, `s`, and `m` are accepted). Default: `90s`; set `0` to disable.
 
 ## Debugging
 
 Set `CLAUDE_BRIDGE_DEBUG=1` to write bridge logs to `~/.pi/agent/claude-bridge.log` and per-query Claude Code CLI logs under `~/.pi/agent/cc-cli-logs/`.
 
-If a Claude Code SDK stream yields a completed assistant tool-use message before a `message_stop` stream event, the bridge treats that assistant message as the tool-turn boundary. Pi executes the tool calls immediately and Claude Code's MCP handlers stay blocked until the matching Pi tool results are delivered, preventing empty inline tool results or one-render-cycle-late result batches in subagent panes.
+Tool-result integrity problems are surfaced even when debug logging is off. Pi shows an error notification and writes a diagnostic file to `~/.pi/agent/claude-bridge-diag.log` so lost or mismatched tool output is visible.
 
-Tool-result integrity failures are surfaced even when debug logging is off. If the bridge has to repair missing Claude Code `tool_use` / Pi `toolResult` pairs with `[no tool result recorded]`, Pi shows an error notification and writes a JSON diagnostic to `~/.pi/agent/claude-bridge-diag.log` with counts, affected tool names, and sampled tool-call IDs so the lost output is visible. Tool results whose IDs were never registered in the active assistant tool-use turn are refused instead of being queued against another pending call, and any remaining MCP handlers receive an internal-error result so the turn cannot report false success. If a query tears down while parallel tool results are still queued or unresolved, the bridge writes the same kind of diagnostic, marks the Claude session for rebuild, and re-imports delivered results from Pi history on the next turn instead of silently resuming a corrupted session.
+Startup failures include the resolved Claude executable and working directory, which makes missing binaries and wrong launch directories easier to fix.
 
-Before starting Claude Code, the bridge preflights the resolved executable and working directory. Failures include the underlying `code`, `errno`, `syscall`, `path`, `cwd`, and detected executable file type so spawn issues point at the real failing path instead of the Claude Agent SDK's generic native-binary message. If Node still emits a spawn error after preflight, the bridge wraps that error with the same context before handing it back to the SDK.
+Contributor-facing stream, tool-result, and startup diagnostics are documented in [`DEVELOPMENT.md`](./DEVELOPMENT.md).

--- a/pi-extensions/pi-session-bridge/DEVELOPMENT.md
+++ b/pi-extensions/pi-session-bridge/DEVELOPMENT.md
@@ -1,0 +1,65 @@
+# pi-session-bridge — development notes
+
+Implementation details for contributors and custom client authors. End-user setup, commands, settings, and security guidance live in [`README.md`](./README.md).
+
+## Raw protocol
+
+Connect to the advertised Unix socket and exchange one JSON object per LF-delimited record. Requests may include `id`; responses use `type:"response"` with the same `id`.
+
+Example requests:
+
+```json
+{"id":"1","type":"get_state"}
+{"id":"2","type":"prompt","message":"Run tests","deliverAs":"auto"}
+{"id":"3","type":"steer","message":"Focus on errors"}
+{"id":"4","type":"follow_up","message":"Summarize when done"}
+{"id":"5","type":"abort"}
+```
+
+Example response and event:
+
+```json
+{"type":"response","id":"1","command":"get_state","success":true,"data":{}}
+{"type":"event","event":"input","timestamp":"...","data":{"source":"extension","streamingBehavior":"followUp","textBytes":42,"textLength":42,"textPreview":"summarize when done"},"truncated":true,"originalBytes":96,"rawEventPath":"/tmp/pi-session-bridge-1000/raw/12345.jsonl","rawEventRef":"6"}
+{"type":"event","event":"message_update","timestamp":"...","data":{"role":"assistant","contentIndex":0,"deltaLength":50000,"deltaBytes":50000,"deltaPreview":"Hello..."},"truncated":true,"originalBytes":50012,"rawEventPath":"/tmp/pi-session-bridge-1000/raw/12345.jsonl","rawEventRef":"7"}
+{"type":"event","event":"vstack_activity","timestamp":"...","data":{"type":"agent.task_completed","source":"pi-agents","severity":"success","importance":"normal","summary":"agent done"}}
+```
+
+Clients receive events by default. Send `{"type":"subscribe","enabled":false}` to mute them. `vstack_activity` rows are bridge events, not `sendMessage()` chat entries, so they do not render in the conversation.
+
+## Compact event envelopes
+
+`pi-bridge history` and the `stream` channel both default to compact event envelopes:
+
+- `input` -> `{ source, streamingBehavior, imagesCount, textBytes, textLength, textPreview, textTruncated }`.
+- `message_update` -> `{ role, type, contentIndex, deltaLength, deltaBytes, deltaPreview }`.
+- `tool_execution_*` -> `{ toolName, toolUseId, status, isError, *Bytes, *Preview, artifactPath, logPath, detailPath }`.
+- `agent_end` -> `{ status, stopReason, usage, messagesCount, finalTextBytes, finalTextLength, finalTextPreview }`.
+
+When a payload is shrunk, the envelope adds `truncated: true`, `originalBytes`, `rawEventPath`, and `rawEventRef`. Raw spills live in per-session JSONL files under `<bridgeDir>/raw/<pid>.jsonl`.
+
+The sidecar size is bounded by `maxRawSpillBytes`: each spill checks the current file size, lazily compacts to live slots when needed, and refuses the spill with `rawError` if it would still overflow. Sidecars are cleaned up on `session_shutdown` and process exit, and stale files belonging to dead pids are removed on bridge start.
+
+## Activity broker
+
+`pi-session-bridge` exposes an in-process broker at `globalThis[Symbol.for("vstack.pi.activity")]` for local Pi extensions:
+
+```ts
+interface PiActivityBroker {
+  publish(event: PiActivityEvent): void;
+  subscribe(listener: (event: PiActivityEvent) => void): () => void;
+  recent(limit?: number): PiActivityEvent[];
+}
+```
+
+`publish()` is best-effort and fail-open. The broker keeps a 100-event ring buffer; `recent(limit)` returns newest-first validated events for in-process replay. `pi-bridge stream` emits live broker publications as `event:"vstack_activity"` only while the bridge is connected.
+
+## Slash command delivery
+
+`pi-bridge send` uses a hybrid slash dispatch path:
+
+- Plain text keeps the normal `sendUserMessage` path.
+- `/skill:<name> ...` expands client-side from the loaded skill's `sourceInfo.path`.
+- Repeated skill sends in the same Pi session skip the `SKILL.md` body until the skill content hash changes, the session shuts down, or the bridge restarts.
+- Prompt templates expand client-side with Pi-compatible `$1`, `$@`, `$ARGUMENTS`, `${@:N[:L]}`, and `${N:-default}` substitution.
+- Extension/TUI commands are pasted into Pi's own tmux pane with `send-keys -l` after resolving the pane by walking parent processes from `process.pid`.

--- a/pi-extensions/pi-session-bridge/README.md
+++ b/pi-extensions/pi-session-bridge/README.md
@@ -2,15 +2,15 @@
 
 ![Session bridge CLI flow](https://raw.githubusercontent.com/vanillagreencom/vstack/main/pi-extensions/pi-session-bridge/assets/session-bridge-cli.png)
 
-Control a running Pi session from outside the TUI. The interactive Pi terminal stays visible; a Unix-domain socket exposes a structured JSONL side channel for external clients.
+Control a running Pi session from outside the TUI. The interactive Pi terminal stays visible while local clients send prompts, steering, follow-ups, and questions through `pi-bridge`.
 
 ## Highlights
 
-- External clients send prompts, steering, follow-ups, and aborts over a structured socket; plain text and expanded skills avoid tmux key injection, while extension/TUI slash commands use a guarded own-pane tmux route.
+- External clients send prompts, steering, follow-ups, and aborts through the bridge.
 - Subscribe to live Pi events (messages, tool calls, agent end) without scraping panes.
-- Activity broker at `Symbol.for("vstack.pi.activity")` lets local extensions publish structured `vstack_activity` events to the bridge stream without chat noise.
+- Local extensions can publish activity updates to bridge clients without adding chat messages.
 - Discover active Pi sessions through registry files; target by pid, cwd, session, or name.
-- `pi-bridge` CLI handles common operations; raw JSONL protocol is documented for any language.
+- `pi-bridge` CLI handles common operations; contributor-facing protocol notes live in [`DEVELOPMENT.md`](./DEVELOPMENT.md).
 - When `pi-questions` is loaded, external clients can list, answer, and reject pending questions.
 
 ## Install
@@ -62,74 +62,33 @@ If exactly one active bridge exists, target flags are optional. Filters: `--pid`
 
 ### Compact vs raw history
 
-`pi-bridge history` and the `stream` channel both default to compact event envelopes:
+`pi-bridge history` and the `stream` channel default to compact event previews so large tool outputs do not overwhelm the TUI or bridge clients.
 
-- `input` → `{ source, streamingBehavior, imagesCount, textBytes, textLength, textPreview, textTruncated }`; idle prompts omit `streamingBehavior`, mid-stream interrupts use `steer`, and queued prompts use `followUp`.
-- `message_update` → `{ role, type, contentIndex, deltaLength, deltaBytes, deltaPreview }`.
-- `tool_execution_*` → `{ toolName, toolUseId, status, isError, *Bytes, *Preview, artifactPath, logPath, detailPath }`.
-- `agent_end` → `{ status, stopReason, usage, messagesCount, finalTextBytes, finalTextLength, finalTextPreview }`.
-
-When a payload had to be shrunk the envelope adds sibling metadata: `truncated: true`, `originalBytes`, `rawEventPath` (per-session JSONL under `<bridgeDir>/raw/<pid>.jsonl`), `rawEventRef` (line ref). The sidecar's on-disk size is bounded by `maxRawSpillBytes`: each spill compares against `statSync` of the file, runs a lazy compaction that rewrites the JSONL with only the slots whose envelopes are still in history, and refuses the spill if the file would still overflow. Sidecars are cleaned up on `session_shutdown` and process exit, and stale files belonging to dead pids are removed on bridge start. When a spill is disabled or refused the envelope carries a `rawError` string instead of `rawEventPath`/`rawEventRef`.
-
-Pass `--raw` (or `--verbose`) to `pi-bridge history` to rehydrate compact envelopes from the sidecar:
+Pass `--raw` (or `--verbose`) to `pi-bridge history` when you need the full stored payload:
 
 - `--event NAME` — only return events with that name (e.g. `tool_execution_end`).
 - `--since TS` — only return events with `timestamp >= TS` (ISO 8601, ms precision).
 - `--max-bytes N` — cap response payload (default ~1 MiB; older events trimmed first, the most recent envelope is always included).
 
-The `history` response also includes `totalEvents`, `responseTruncated`, `rawSpillPath`, and (when raw recovery fails) `rawErrors` so callers can decide whether to page further or read the JSONL directly.
+The `history` response includes enough metadata for callers to page further or request raw payloads when needed.
 
 ## Raw protocol
 
-Connect to the advertised Unix socket and exchange one JSON object per LF-delimited record. Requests may include `id`; responses use `type:"response"` with the same `id`.
-
-Example requests:
-
-```json
-{"id":"1","type":"get_state"}
-{"id":"2","type":"prompt","message":"Run tests","deliverAs":"auto"}
-{"id":"3","type":"steer","message":"Focus on errors"}
-{"id":"4","type":"follow_up","message":"Summarize when done"}
-{"id":"5","type":"abort"}
-```
-
-Example response and event:
-
-```json
-{"type":"response","id":"1","command":"get_state","success":true,"data":{}}
-{"type":"event","event":"input","timestamp":"...","data":{"source":"extension","streamingBehavior":"followUp","textBytes":42,"textLength":42,"textPreview":"summarize when done"},"truncated":true,"originalBytes":96,"rawEventPath":"/tmp/pi-session-bridge-1000/raw/12345.jsonl","rawEventRef":"6"}
-{"type":"event","event":"message_update","timestamp":"...","data":{"role":"assistant","contentIndex":0,"deltaLength":50000,"deltaBytes":50000,"deltaPreview":"Hello..."},"truncated":true,"originalBytes":50012,"rawEventPath":"/tmp/pi-session-bridge-1000/raw/12345.jsonl","rawEventRef":"7"}
-{"type":"event","event":"vstack_activity","timestamp":"...","data":{"type":"agent.task_completed","source":"pi-agents","severity":"success","importance":"normal","summary":"agent done"}}
-```
-
-Clients receive events by default. Send `{"type":"subscribe","enabled":false}` to mute them. `vstack_activity` rows are bridge events, not `sendMessage()` chat entries, so they do not render in the conversation.
-
-Compact event envelopes always include enough fields to reason about the original payload (preview, byte count, truncation flag). To replay raw deltas/results call `history` with `{"raw":true}` or read the per-session JSONL referenced by `rawEventPath` directly.
+Most users should use the `pi-bridge` CLI. Custom client authors can use the local socket protocol; request/response examples and event-envelope details are in [`DEVELOPMENT.md`](./DEVELOPMENT.md).
 
 ## Activity broker
 
-`pi-session-bridge` exposes an in-process broker at `globalThis[Symbol.for("vstack.pi.activity")]` for local Pi extensions:
-
-```ts
-interface PiActivityBroker {
-  publish(event: PiActivityEvent): void;
-  subscribe(listener: (event: PiActivityEvent) => void): () => void;
-  recent(limit?: number): PiActivityEvent[];
-}
-```
-
-`publish()` is best-effort and fail-open. The broker keeps a 100-event ring buffer; `recent(limit)` returns newest-first validated events for in-process replay. `pi-bridge stream` emits live broker publications as `event:"vstack_activity"` only while the bridge is connected; external clients that need earlier rows must use an in-process consumer before they leave the ring.
+Local Pi extensions can publish activity updates that `pi-bridge stream` exposes to connected clients. This is used by vstack extensions for agent progress, background tasks, and questions without adding messages to the conversation. Contributor-facing broker details are in [`DEVELOPMENT.md`](./DEVELOPMENT.md).
 
 ## Slash command notes
 
 `pi-bridge send` uses a hybrid slash dispatch path:
 
-- Plain text keeps the normal `sendUserMessage` path.
-- `/skill:<name> ...` expands client-side from the loaded skill's `sourceInfo.path`, inlining the same `<skill ...>` block Pi's editor would produce the first time a skill is loaded in a Pi session.
-- Repeated `/skill:<name> ...` sends in the same Pi session skip the `SKILL.md` body and send `Skill <name> (previously loaded). Invocation: ...` instead. Changing the `SKILL.md` file content changes its hash and forces a fresh full expansion; session shutdown evicts that session, bridge restart loses the in-memory cache, and the bridge keeps only the 100 most recent sessions.
-- Prompt templates (`/<name> ...` from loaded prompt paths) expand client-side with Pi-compatible `$1`, `$@`, `$ARGUMENTS`, `${@:N[:L]}`, and `${N:-default}` substitution; unquoted spaces, tabs, and newlines split arguments, while quoted newlines stay inside the argument.
-- Extension/TUI commands (for example `/bridge:ping` and `/tasks:add`) are pasted into Pi's own tmux pane with `send-keys -l` + enter after resolving the pane by walking parent processes from `process.pid`. This briefly shows text in the editor and always delivers immediately (`deliverAs` does not apply to this route).
-- If tmux pane resolution or paste fails, the bridge falls back to the old raw `sendUserMessage` behavior instead of failing the request.
+- Plain text sends a normal user message.
+- `/skill:<name> ...` and prompt templates expand before being sent, matching Pi's editor behavior.
+- Repeated skill sends in the same Pi session use a short reminder instead of resending the entire skill body.
+- Extension/TUI commands, such as `/bridge:ping` and `/tasks:add`, are delivered to Pi's own editor so they behave like typed commands.
+- If command delivery fails, the bridge falls back to sending the text as a normal message.
 
 ## Settings
 
@@ -147,7 +106,7 @@ Project settings in `.pi/settings.json` apply only after Pi marks the workspace 
 | Max history response bytes | Maximum bytes returned in a single `history` response; older envelopes drop first. |
 | Event preview bytes | Bytes of `delta`/`result`/`output` retained as `*Preview` strings inside compact events. |
 | Spill raw events | When `true`, oversized payloads spill to the per-session JSONL so `history --raw` can rehydrate them. |
-| Max raw spill bytes | Cap on the on-disk size of the per-session raw JSONL. New spills check `statSync` of the file; if appending would exceed the cap, the sidecar is rewritten with only live slots, and the spill is refused (with `rawError`) when even the compacted file plus the new line would not fit. |
+| Max raw spill bytes | Cap on stored raw event payloads for `history --raw`. |
 | Max request line bytes | Maximum JSONL request size accepted. |
 | Registry heartbeat | Ms between registry file updates. |
 | Notify on start | In-TUI notification when the bridge starts. |


### PR DESCRIPTION
## Summary

Codex agent TOML no longer emits a top-level `skills = [...]` field — Codex has no such field, so it was an unsupported key. Skill inventory already renders inside `developer_instructions` as the "Required Skills" section.

- `cli/src/harness/codex.rs` — stop writing the top-level `skills` array; the Required Skills section remains the single source.
- `cli/src/commands/check.rs` — `parse_required_skills_section` reads skill names from the Required Skills body, with a backward-compat fallback for older agent files that still carry the top-level field (+2 unit tests).
- Docs updated to match: `AGENTS.md` / `README.md` codex.rs output description.
- pi-extensions READMEs slimmed to user-facing content; implementation detail moved into new `DEVELOPMENT.md` files (pi-claude-bridge, pi-session-bridge), per the "READMEs are user-facing only" rule.

## Validation

- `cargo fmt --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test` — 293 passed, 0 failed

Clean merge into `main` (`git merge-tree --write-tree` exit 0; main never touched these files since the divergence base). The branch's two `/gh-release`+`/npm-deploy` prompt commits are byte-identical to main's existing copy and no-op on merge.
