### PR TITLE
fix(pi-hooks): resolve nested cli/Cargo.toml in pre-commit guard

### DIFF
--- a/pi-extensions/pi-hooks/extensions/bash-guards.ts
+++ b/pi-extensions/pi-hooks/extensions/bash-guards.ts
@@ -1,6 +1,6 @@
 import { accessSync, constants, existsSync, realpathSync, statSync } from "node:fs";
 import { spawn } from "node:child_process";
-import { isAbsolute, relative, resolve } from "node:path";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 
 import { findCargoWorkspaceRootResultAsync, runCargoAsync, runWorkspaceClippyAsync } from "./cargo.js";
 
@@ -1429,6 +1429,28 @@ export interface BlockReason {
  * configured lint budget. Git target probes use short async timeouts and do not
  * block the main thread.
  */
+/**
+ * Locate the nearest Cargo manifest directory for the relevant Rust files when
+ * the repo root has no Cargo.toml (vstack nests its workspace under cli/), so
+ * `cargo metadata` from the repo root finds nothing. Mirrors
+ * hooks/pre-commit-check.sh: walk up from each file's directory to the first
+ * ancestor that contains a Cargo.toml. Returns an absolute directory or null.
+ * Files are repo-root-relative (from `git ... --name-only`).
+ */
+export function nearestCargoManifestDir(repoRoot: string, files: string[]): string | null {
+	for (const file of files) {
+		let dir = dirname(file);
+		while (dir && dir !== "." && dir !== "/" && dir !== "..") {
+			const candidate = join(repoRoot, dir);
+			if (existsSync(join(candidate, "Cargo.toml"))) return candidate;
+			const parent = dirname(dir);
+			if (parent === dir) break;
+			dir = parent;
+		}
+	}
+	return null;
+}
+
 export async function runPreCommitCheck(cwd: string, timeoutMs: number, command: string): Promise<BlockReason | undefined> {
 	const metadataBudget = Math.min(5000, Math.floor(timeoutMs / 4));
 	const commit = await resolveProjectGitCommit(command, cwd, metadataBudget);
@@ -1439,7 +1461,17 @@ export async function runPreCommitCheck(cwd: string, timeoutMs: number, command:
 	if (rustFiles.kind === "error") return { reason: `pi-hooks pre-commit: ${rustFiles.reason}` };
 	if (rustFiles.files.length === 0) return undefined;
 
-	const workspace = await findCargoWorkspaceRootResultAsync(commit.cwd, metadataBudget);
+	let workspace = await findCargoWorkspaceRootResultAsync(commit.cwd, metadataBudget);
+	if (workspace.kind === "none") {
+		// The manifest may live in a subdirectory (vstack nests cli/Cargo.toml),
+		// so `cargo metadata` from the repo root finds nothing. Mirror
+		// hooks/pre-commit-check.sh and resolve the workspace from the nearest
+		// Cargo.toml above the relevant Rust files.
+		const manifestDir = nearestCargoManifestDir(commit.root, rustFiles.files);
+		if (manifestDir) {
+			workspace = await findCargoWorkspaceRootResultAsync(manifestDir, metadataBudget);
+		}
+	}
 	if (workspace.kind === "error") return { reason: `pi-hooks pre-commit: ${workspace.reason}` };
 	if (workspace.kind === "none") {
 		return { reason: `pi-hooks pre-commit: found Rust files but could not identify a Cargo workspace: ${workspace.reason}` };

--- a/pi-extensions/pi-hooks/tests/bash-guards.test.ts
+++ b/pi-extensions/pi-hooks/tests/bash-guards.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
 
-import { gitCommitTargets, projectGitCommitCwd, resolveProjectGitCommit } from "../extensions/bash-guards.ts";
+import { gitCommitTargets, nearestCargoManifestDir, projectGitCommitCwd, resolveProjectGitCommit } from "../extensions/bash-guards.ts";
 
 function runGit(args: string[], cwd: string): void {
 	const result = spawnSync("git", args, { cwd, encoding: "utf8" });
@@ -353,6 +353,29 @@ git commit -m test`, project, 1000)).toBe(resolve(project));
 		} finally {
 			rmSync(project, { recursive: true, force: true });
 			rmSync(other, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("nearestCargoManifestDir", () => {
+	test("resolves a Cargo.toml nested under the repo root (vstack cli/)", () => {
+		const root = mkdtempSync(join(tmpdir(), "pi-hooks-ws-"));
+		try {
+			mkdirSync(join(root, "cli", "src", "harness"), { recursive: true });
+			writeFileSync(join(root, "cli", "Cargo.toml"), "[package]\nname = \"x\"\nversion = \"0.0.0\"\n");
+			expect(nearestCargoManifestDir(root, ["cli/src/harness/codex.rs"])).toBe(join(root, "cli"));
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	test("returns null when no Cargo.toml sits above the files", () => {
+		const root = mkdtempSync(join(tmpdir(), "pi-hooks-ws-"));
+		try {
+			mkdirSync(join(root, "docs"), { recursive: true });
+			expect(nearestCargoManifestDir(root, ["docs/notes.rs"])).toBeNull();
+		} finally {
+			rmSync(root, { recursive: true, force: true });
 		}
 	});
 });


### PR DESCRIPTION
The pre-commit Bash guard ran `cargo metadata` from the repo root to find the Cargo workspace. vstack nests its manifest at `cli/Cargo.toml`, so detection from the root returned `none` and blocked every Rust commit from the repo root ("could not identify a Cargo workspace").

Mirrors the canonical `hooks/pre-commit-check.sh` (which already walks up from each staged `.rs` file to the nearest `Cargo.toml`): adds `nearestCargoManifestDir` and re-resolves the workspace from it when root detection returns `none`. Brings the `.ts` port to parity with the `.sh`.

Validated via tsx against the real repo (root→none, then →cli/→ok) + unit tests. Bun suite not run locally (bun unavailable).