### PR TITLE
Seed skill settings during project installs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@ skill-templates/         Templates for new skills
 - **Reconciliation is automatic.** After every `vstack add`, all installed agents are regenerated with the current full set of installed skills and hooks.
 - **Project root walks up from CWD.** `config::project_root()` finds `.vstack-lock.json`, `.claude/`, `.cursor/`, `.codex/`, `.opencode/`, `.pi/`, or `.agents/` by walking parents. `$HOME` is rejected as a project root when only user-level harness dirs (`~/.claude`, `~/.pi`, etc.) exist there with no `.vstack-lock.json`, so project-scope writes never accidentally route into user state.
 - **Runtime settings are split from secrets.** Portable skill scripts load `.env`, then `vstack.settings.toml` / `.vstack/settings.toml` `[env]`, then `.env.local`. Put committed non-sensitive defaults in `vstack.settings.toml`; reserve `.env.local` for secrets, API keys, private URLs, signing keys, and personal overrides. Existing `.env.local` settings remain supported for compatibility.
+- **Skill settings templates are opt-in.** A skill can ship `vstack.settings.toml.example`; project-scope `vstack add` and `vstack refresh` merge its `[env]` defaults into `<project>/vstack.settings.toml`, creating the file when missing and never overwriting existing keys. Global installs do not write project settings.
 
 ## Formats
 
@@ -66,6 +67,15 @@ user-invocable: true
 dependencies:
   required: [linear, github, worktree]
 ```
+
+Optional skill settings template (`skills/*/vstack.settings.toml.example`):
+```toml
+[env]
+
+MY_SKILL_TIMEOUT = "300"
+```
+
+Project installs merge these defaults into `vstack.settings.toml` so shared non-secret settings are available as soon as the skill is installed.
 
 ### Hook header (`hooks/*.sh`)
 ```bash

--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ Portable skill scripts load runtime settings in this order:
 
 Use `vstack.settings.toml` for non-sensitive project defaults that should be committed, such as worktree paths, issue regexes, bot usernames, default Linear team names, and second-opinion command defaults. Keep `.env.local` for secrets, tokens, API keys, private URLs, signing keys, and personal overrides. See [`vstack.settings.toml.example`](vstack.settings.toml.example) and [`.env.local.example`](.env.local.example).
 
+When a project install includes a skill that ships `vstack.settings.toml.example`, `vstack add` seeds `vstack.settings.toml` with that skill's non-sensitive defaults. Existing files are merged by adding missing `[env]` keys only; user values are not overwritten. `vstack refresh` also performs this merge for installed skills.
+
 Secret values may also be injected by the parent process at launch time. GitHub and Linear helpers preserve already-resolved `GH_TOKEN`, `GITHUB_TOKEN`, `GH_BOT_TOKEN`, and `LINEAR_API_KEY` values before reading local files or resolving `op://` references.
 
 ## Supported Tools

--- a/cli/src/commands/add.rs
+++ b/cli/src/commands/add.rs
@@ -1011,6 +1011,7 @@ source (e.g. switching vstack repos, or starting clean), pass --clobber:
     // Perform installation
     let mut results = Vec::new();
     let mut log_lines: Vec<String> = Vec::new();
+    let mut settings_note: Option<String> = None;
 
     // Collect computed agent→skill mappings to write to project vstack.toml
     let mut agent_skill_map: std::collections::HashMap<String, Vec<String>> =
@@ -1147,6 +1148,12 @@ source (e.g. switching vstack repos, or starting clean), pass --clobber:
     // make every item appear outdated on next launch).
     if writes_project_config {
         crate::project_config::write_agent_skills(&config::project_root(), &agent_skill_map);
+        if let Some(result) = crate::project_settings::ensure_skill_settings(
+            &config::project_root(),
+            &selected_skills,
+        )? {
+            settings_note = Some(format!("Project settings: {}", result.summary()));
+        }
     }
 
     // Update lock file
@@ -1247,6 +1254,9 @@ source (e.g. switching vstack repos, or starting clean), pass --clobber:
                     skipped_harnesses.join(", ")
                 ));
             }
+            if let Some(note) = &settings_note {
+                notes.push(note.clone());
+            }
             if global {
                 notes.extend(harnesses.iter().flat_map(|h| {
                     h.summary_paths(true).into_iter().map(move |path| {
@@ -1308,6 +1318,9 @@ source (e.g. switching vstack repos, or starting clean), pass --clobber:
             eprintln!(
                 "  Add per-agent guidance or instructions in vstack.toml, then run `vstack refresh` to apply"
             );
+        }
+        if let Some(note) = &settings_note {
+            eprintln!("  {note}");
         }
         // Check for CLI updates in non-interactive mode
         crate::commands::update::check_update_hint();

--- a/cli/src/commands/refresh.rs
+++ b/cli/src/commands/refresh.rs
@@ -391,6 +391,30 @@ fn run_one(global: bool, verbose: bool) -> Result<()> {
     }
 
     if !global {
+        let project_canon = project_root
+            .canonicalize()
+            .unwrap_or_else(|_| project_root.clone());
+        let project_is_source = source_dirs
+            .iter()
+            .any(|dir| dir.canonicalize().unwrap_or_else(|_| dir.clone()) == project_canon);
+        if !project_is_source {
+            let installed_settings_skills: Vec<Skill> = all_source_skills
+                .iter()
+                .filter(|skill| {
+                    lock.entries
+                        .get(&skill.name)
+                        .is_some_and(|entry| entry.kind == ItemKind::Skill)
+                })
+                .cloned()
+                .collect();
+            if let Some(result) = crate::project_settings::ensure_skill_settings(
+                &project_root,
+                &installed_settings_skills,
+            )? {
+                eprintln!("  + {}", result.summary());
+            }
+        }
+
         let harnesses_by_agent: HashMap<String, Vec<Harness>> = lock
             .entries
             .iter()

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -12,6 +12,7 @@ mod installer;
 mod mapping;
 mod pi_extension;
 mod project_config;
+mod project_settings;
 mod resolve;
 mod scope;
 mod skill;

--- a/cli/src/project_settings.rs
+++ b/cli/src/project_settings.rs
@@ -1,0 +1,382 @@
+use crate::skill::Skill;
+use anyhow::{Context, Result};
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+const SETTINGS_FILE: &str = "vstack.settings.toml";
+const SETTINGS_TEMPLATE: &str = "vstack.settings.toml.example";
+
+#[derive(Debug, Clone)]
+pub struct SettingsMergeResult {
+    pub path: PathBuf,
+    pub created: bool,
+    pub added_keys: Vec<String>,
+}
+
+impl SettingsMergeResult {
+    pub fn summary(&self) -> String {
+        let action = if self.created { "created" } else { "updated" };
+        format!(
+            "{action} {} with {} setting(s): {}",
+            self.path.display(),
+            self.added_keys.len(),
+            self.added_keys.join(", ")
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+struct EnvEntry {
+    key: String,
+    lines: Vec<String>,
+}
+
+pub fn ensure_skill_settings(
+    project_root: &Path,
+    skills: &[Skill],
+) -> Result<Option<SettingsMergeResult>> {
+    let entries = settings_entries_from_skills(skills)?;
+    if entries.is_empty() {
+        return Ok(None);
+    }
+
+    let path = project_root.join(SETTINGS_FILE);
+    let added_keys: Vec<String> = entries.iter().map(|entry| entry.key.clone()).collect();
+
+    if !path.exists() {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("creating {}", parent.display()))?;
+        }
+        std::fs::write(&path, render_new_settings_file(&entries))
+            .with_context(|| format!("writing {}", path.display()))?;
+        return Ok(Some(SettingsMergeResult {
+            path,
+            created: true,
+            added_keys,
+        }));
+    }
+
+    let original =
+        std::fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
+    let existing_keys = env_keys(&original);
+    let missing: Vec<EnvEntry> = entries
+        .into_iter()
+        .filter(|entry| !existing_keys.contains(&entry.key))
+        .collect();
+    if missing.is_empty() {
+        return Ok(None);
+    }
+
+    let added_keys: Vec<String> = missing.iter().map(|entry| entry.key.clone()).collect();
+    let merged = merge_missing_entries(&original, &missing);
+    if merged != original {
+        std::fs::write(&path, merged).with_context(|| format!("writing {}", path.display()))?;
+    }
+
+    Ok(Some(SettingsMergeResult {
+        path,
+        created: false,
+        added_keys,
+    }))
+}
+
+fn settings_entries_from_skills(skills: &[Skill]) -> Result<Vec<EnvEntry>> {
+    let mut entries = Vec::new();
+    let mut seen = BTreeSet::new();
+    for skill in skills {
+        let template = skill.source_dir.join(SETTINGS_TEMPLATE);
+        if !template.exists() {
+            continue;
+        }
+        let content = std::fs::read_to_string(&template)
+            .with_context(|| format!("reading {}", template.display()))?;
+        for entry in extract_env_entries(&content) {
+            if seen.insert(entry.key.clone()) {
+                entries.push(entry);
+            }
+        }
+    }
+    Ok(entries)
+}
+
+fn render_new_settings_file(entries: &[EnvEntry]) -> String {
+    let mut out = String::new();
+    out.push_str("# Public vstack settings seeded from installed skill defaults.\n");
+    out.push_str(
+        "# vstack skill scripts read this [env] table after .env and before .env.local.\n",
+    );
+    out.push_str("# Keep secrets, tokens, and personal overrides in .env.local.\n\n");
+    out.push_str("[env]\n");
+    out.push_str(&render_entries(entries));
+    out
+}
+
+fn merge_missing_entries(original: &str, entries: &[EnvEntry]) -> String {
+    let mut lines: Vec<String> = original.lines().map(str::to_string).collect();
+    let Some(env_start) = lines.iter().position(|line| is_env_header(line)) else {
+        let mut out = original.to_string();
+        if !out.is_empty() && !out.ends_with('\n') {
+            out.push('\n');
+        }
+        if !out.is_empty() && !out.ends_with("\n\n") {
+            out.push('\n');
+        }
+        out.push_str("[env]\n");
+        out.push_str(&render_entries(entries));
+        return out;
+    };
+
+    let env_end = lines
+        .iter()
+        .enumerate()
+        .skip(env_start + 1)
+        .find_map(|(idx, line)| is_table_header(line).then_some(idx))
+        .unwrap_or(lines.len());
+
+    let mut block: Vec<String> = render_entries(entries)
+        .trim_end_matches('\n')
+        .lines()
+        .map(str::to_string)
+        .collect();
+
+    if env_end > 0 && !lines[env_end - 1].trim().is_empty() {
+        block.insert(0, String::new());
+    }
+    if env_end < lines.len() && !block.last().is_some_and(|line| line.trim().is_empty()) {
+        block.push(String::new());
+    }
+
+    lines.splice(env_end..env_end, block);
+    let mut out = lines.join("\n");
+    out.push('\n');
+    out
+}
+
+fn render_entries(entries: &[EnvEntry]) -> String {
+    let mut out = String::new();
+    for entry in entries {
+        if !out.is_empty() && !out.ends_with("\n\n") {
+            out.push('\n');
+        }
+        let mut entry_lines = entry.lines.as_slice();
+        while entry_lines
+            .first()
+            .is_some_and(|line| line.trim().is_empty())
+        {
+            entry_lines = &entry_lines[1..];
+        }
+        for line in entry_lines {
+            out.push_str(line);
+            out.push('\n');
+        }
+    }
+    if !out.ends_with('\n') {
+        out.push('\n');
+    }
+    out
+}
+
+fn extract_env_entries(content: &str) -> Vec<EnvEntry> {
+    let mut entries = Vec::new();
+    let mut in_env = false;
+    let mut pending = Vec::new();
+
+    for line in content.lines() {
+        if is_table_header(line) {
+            if is_env_header(line) {
+                in_env = true;
+                pending.clear();
+                continue;
+            }
+            if in_env {
+                break;
+            }
+        }
+
+        if !in_env {
+            continue;
+        }
+
+        if let Some(key) = assignment_key(line) {
+            let mut lines = Vec::new();
+            lines.append(&mut pending);
+            lines.push(line.to_string());
+            entries.push(EnvEntry { key, lines });
+            continue;
+        }
+
+        if line.trim().is_empty() || line.trim_start().starts_with('#') {
+            pending.push(line.to_string());
+        }
+    }
+
+    entries
+}
+
+fn env_keys(content: &str) -> BTreeSet<String> {
+    let mut keys = BTreeSet::new();
+    let mut in_env = false;
+
+    for line in content.lines() {
+        if is_table_header(line) {
+            if is_env_header(line) {
+                in_env = true;
+                continue;
+            }
+            if in_env {
+                break;
+            }
+        }
+
+        if !in_env {
+            continue;
+        }
+        if let Some(key) = assignment_key(line) {
+            keys.insert(key);
+        }
+    }
+
+    keys
+}
+
+fn is_env_header(line: &str) -> bool {
+    line.trim() == "[env]"
+}
+
+fn is_table_header(line: &str) -> bool {
+    let trimmed = line.trim();
+    trimmed.starts_with('[') && trimmed.ends_with(']')
+}
+
+fn assignment_key(line: &str) -> Option<String> {
+    let trimmed = line.trim_start();
+    if trimmed.is_empty() || trimmed.starts_with('#') {
+        return None;
+    }
+    let (key, _) = trimmed.split_once('=')?;
+    let key = key.trim();
+    if key.is_empty() {
+        return None;
+    }
+    Some(key.trim_matches('"').to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::skill::SkillDep;
+
+    fn temp_root(name: &str) -> PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "vstack_project_settings_{name}_{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&path);
+        std::fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    fn skill(name: &str, source_dir: PathBuf) -> Skill {
+        Skill {
+            name: name.to_string(),
+            description: String::new(),
+            license: None,
+            user_invocable: None,
+            dependencies: None,
+            body: String::new(),
+            source_dir,
+            resolved_deps: Vec::<SkillDep>::new(),
+        }
+    }
+
+    #[test]
+    fn creates_settings_file_from_skill_template() {
+        let root = temp_root("creates");
+        let skill_dir = root.join("source").join("skills").join("second-opinion");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join(SETTINGS_TEMPLATE),
+            r#"[env]
+
+# SECOND OPINION
+SECOND_OPINION_TIMEOUT = "300"
+SECOND_OPINION_CODEX_CMD = "codex exec -m gpt-5.5"
+"#,
+        )
+        .unwrap();
+
+        let project = root.join("project");
+        let result = ensure_skill_settings(&project, &[skill("second-opinion", skill_dir)])
+            .unwrap()
+            .unwrap();
+
+        assert!(result.created);
+        assert_eq!(
+            result.added_keys,
+            vec!["SECOND_OPINION_TIMEOUT", "SECOND_OPINION_CODEX_CMD"]
+        );
+        let settings = std::fs::read_to_string(project.join(SETTINGS_FILE)).unwrap();
+        assert!(settings.contains("[env]"));
+        assert!(settings.contains("SECOND_OPINION_TIMEOUT = \"300\""));
+        assert!(settings.contains("SECOND_OPINION_CODEX_CMD = \"codex exec -m gpt-5.5\""));
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn merges_missing_keys_without_overwriting_existing_values() {
+        let root = temp_root("merges");
+        let skill_dir = root.join("source").join("skills").join("second-opinion");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join(SETTINGS_TEMPLATE),
+            r#"[env]
+
+# SECOND OPINION
+SECOND_OPINION_TIMEOUT = "300"
+SECOND_OPINION_CODEX_CMD = "codex exec -m gpt-5.5"
+"#,
+        )
+        .unwrap();
+        let project = root.join("project");
+        std::fs::create_dir_all(&project).unwrap();
+        std::fs::write(
+            project.join(SETTINGS_FILE),
+            r#"# Existing settings
+
+[env]
+SECOND_OPINION_TIMEOUT = "42"
+
+[other]
+value = true
+"#,
+        )
+        .unwrap();
+
+        let result = ensure_skill_settings(&project, &[skill("second-opinion", skill_dir)])
+            .unwrap()
+            .unwrap();
+
+        assert!(!result.created);
+        assert_eq!(result.added_keys, vec!["SECOND_OPINION_CODEX_CMD"]);
+        let settings = std::fs::read_to_string(project.join(SETTINGS_FILE)).unwrap();
+        assert!(settings.contains("SECOND_OPINION_TIMEOUT = \"42\""));
+        assert!(settings.contains("SECOND_OPINION_CODEX_CMD = \"codex exec -m gpt-5.5\""));
+        assert!(settings.contains("[other]\nvalue = true"));
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn leaves_project_untouched_when_no_skill_templates_exist() {
+        let root = temp_root("none");
+        let skill_dir = root.join("source").join("skills").join("plain");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        let project = root.join("project");
+
+        let result = ensure_skill_settings(&project, &[skill("plain", skill_dir)]).unwrap();
+
+        assert!(result.is_none());
+        assert!(!project.join(SETTINGS_FILE).exists());
+        let _ = std::fs::remove_dir_all(root);
+    }
+}

--- a/skills/second-opinion/README.md
+++ b/skills/second-opinion/README.md
@@ -8,6 +8,7 @@ Cross-model code review and consultation via external AI CLI. Auto-detects your 
 skills/second-opinion/
 ├── SKILL.md                    # Agent-facing routing table + config
 ├── README.md                   # This file
+├── vstack.settings.toml.example # Defaults merged into project settings
 ├── schemas/
 │   └── review-finding-prompt.md  # JSON schema (shared by review + audit)
 ├── scripts/
@@ -49,6 +50,8 @@ From the shell:
 ## Configuration
 
 All optional — defaults work out of the box. Set shared, non-sensitive defaults in `vstack.settings.toml` under `[env]`. Existing `.env.local` values still work and should be reserved for personal overrides.
+
+Project installs seed `vstack.settings.toml` from this skill's `vstack.settings.toml.example` when the file is missing, or merge any missing second-opinion keys into an existing file without overwriting user values.
 
 | Variable | Default | Purpose |
 |----------|---------|---------|

--- a/skills/second-opinion/SKILL.md
+++ b/skills/second-opinion/SKILL.md
@@ -62,6 +62,8 @@ All modes accept:
 
 Set non-sensitive defaults in `vstack.settings.toml` under `[env]`. Existing `.env.local` and `.env` values still work; `.env.local` wins.
 
+Project installs seed `vstack.settings.toml` from this skill's `vstack.settings.toml.example` when missing and merge only absent second-opinion keys into existing files.
+
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `SECOND_OPINION_TARGET` | auto-detect | Force target CLI: `claude` or `codex` |

--- a/skills/second-opinion/scripts/second-opinion
+++ b/skills/second-opinion/scripts/second-opinion
@@ -11,8 +11,8 @@
 # Environment:
 #   SECOND_OPINION_TARGET        Force target CLI (claude|codex)
 #   SECOND_OPINION_TIMEOUT       Timeout in seconds (default: 300)
-#   SECOND_OPINION_CLAUDE_FLAGS  Extra flags for claude -p
-#   SECOND_OPINION_CODEX_FLAGS   Extra flags for codex exec
+#   SECOND_OPINION_CLAUDE_CMD    Full claude command
+#   SECOND_OPINION_CODEX_CMD     Full codex command
 
 set -euo pipefail
 
@@ -100,7 +100,7 @@ Environment (set in vstack.settings.toml [env] or .env.local):
 Default commands:
   claude: claude -p --no-session-persistence --model opus --effort max
             --allowedTools Bash(read-only:true),Read,Glob,Grep
-  codex:  codex exec -m gpt-5.4 -s read-only -c model_reasoning_effort=xhigh
+  codex:  codex exec -m gpt-5.5 -s read-only -c model_reasoning_effort=xhigh
             --ephemeral
 HELP
 }
@@ -331,7 +331,7 @@ EXIT_CODE=0
 
 # Full command templates — override the entire command via project config
 CLAUDE_CMD="${SECOND_OPINION_CLAUDE_CMD:-claude -p --no-session-persistence --model opus --effort max --allowedTools Bash(read-only:true),Read,Glob,Grep}"
-CODEX_CMD="${SECOND_OPINION_CODEX_CMD:-codex exec -m gpt-5.4 -s read-only -c model_reasoning_effort=xhigh --ephemeral}"
+CODEX_CMD="${SECOND_OPINION_CODEX_CMD:-codex exec -m gpt-5.5 -s read-only -c model_reasoning_effort=xhigh --ephemeral}"
 
 case "$TARGET_CLI" in
   claude)

--- a/skills/second-opinion/vstack.settings.toml.example
+++ b/skills/second-opinion/vstack.settings.toml.example
@@ -1,0 +1,15 @@
+[env]
+
+# SECOND OPINION
+
+# Used by: second-opinion.
+SECOND_OPINION_TIMEOUT = "300"
+
+# Used by: second-opinion.
+SECOND_OPINION_CLAUDE_CMD = "claude -p --no-session-persistence --model opus --effort max --allowedTools Bash(read-only:true),Read,Glob,Grep"
+
+# Used by: second-opinion.
+SECOND_OPINION_CODEX_CMD = "codex exec -m gpt-5.5 -s read-only -c model_reasoning_effort=xhigh --ephemeral"
+
+# Uncomment only when this project must force one target instead of auto-detecting.
+# SECOND_OPINION_TARGET = "claude"

--- a/vstack.settings.toml.example
+++ b/vstack.settings.toml.example
@@ -98,7 +98,7 @@ SECOND_OPINION_TIMEOUT = "300"
 SECOND_OPINION_CLAUDE_CMD = "claude -p --no-session-persistence --model opus --effort max --allowedTools Bash(read-only:true),Read,Glob,Grep"
 # Used by: second-opinion.
 
-SECOND_OPINION_CODEX_CMD = "codex exec -m gpt-5.4 -s read-only -c model_reasoning_effort=xhigh --ephemeral"
+SECOND_OPINION_CODEX_CMD = "codex exec -m gpt-5.5 -s read-only -c model_reasoning_effort=xhigh --ephemeral"
 # Used by: second-opinion.
 
 # DEBUG / OVERRIDE HOOKS


### PR DESCRIPTION
## Summary
- Add skill-local `vstack.settings.toml.example` support for project installs and refreshes.
- Seed `vstack.settings.toml` when missing and append only absent `[env]` keys when it already exists.
- Add a second-opinion settings template and align its Codex default command with `gpt-5.5` across docs/examples/runtime.

## Validation
- `cd cli && cargo test`
- `bash skills/second-opinion/tests/timeout-defaults.test.sh`
- Fake project: `vstack add /home/method/Projects/vstack --skill second-opinion --harness codex -y --copy`, verified `vstack.settings.toml` creation and `vstack verify second-opinion`
- Fake project merge smoke confirmed existing `SECOND_OPINION_TIMEOUT = "42"` is preserved while missing command keys are added
- Full fake project: `cargo run --manifest-path /home/method/Projects/vstack/cli/Cargo.toml -- add /home/method/Projects/vstack --all --copy`, then `vstack check --scope project`
- Fake project refresh smoke confirmed `vstack refresh -v --scope project` recreates the settings file for already-installed skills