### PR TITLE
`nix run github:vanillagreencom/vstack` fails to build due to outdated `cargoHash`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,7 @@
 
             sourceRoot = "source/cli";
 
-            cargoHash = "sha256-Zg9VgmZ4uTA9AhuBfvhXp6kr1f8+QXnkPpEMQ6ipvsU=";
+            cargoLock.lockFile = ./cli/Cargo.lock;
 
             nativeBuildInputs = with pkgs; [
               git


### PR DESCRIPTION
The `cargoHash` in `flake.nix` is outdated. Instead of manually maintaining it, may I suggest this more durable fix, where the lock information is instead read from `Cargo.lock`, which is itself maintained as a matter of process?