### PR TITLE
fix(issue-428): linear skill: issues create --parent is silently ignored (sub-issue not linked)

### DIFF
--- a/skills/linear/README.md
+++ b/skills/linear/README.md
@@ -36,6 +36,8 @@ Read-only cache queries (`./scripts/linear.sh cache ...` except `cache attachmen
 
 Use `comments create ISSUE --body-file tmp/comment.md` for Markdown or multi-line comments. Inline `--body` is intended for short plain strings.
 
+Use `issues create --parent PROJ-42` to create a sub-issue. The command resolves the parent identifier to a UUID, sends `parentId` on create, and verifies the returned issue is linked. If Linear ignores the create-time parent, the command repairs the link with `issueUpdate`; if that cannot be verified, it exits nonzero.
+
 `issues bulk-update` applies each issue update independently. If one update fails after earlier items changed, the command emits a JSON summary with `partial: true`, per-issue success/error entries, and exits nonzero.
 
 Use explicit list actions for dependency reads: `issues list-relations ISSUE` and `projects list-dependencies PROJECT`. The older read-only aliases `issues relations` and `projects dependencies` remain accepted for compatibility, but new workflows should use the explicit names.

--- a/skills/linear/SKILL.md
+++ b/skills/linear/SKILL.md
@@ -129,7 +129,7 @@ sortOrder → sort_order  # Manual sort position
 | `--project` | Name or UUID | Fail with "not found" |
 | `--state` | Exact name (case-sensitive) | Fail, lists available states |
 | `--milestone` | Name or UUID | Fail with "not found" |
-| `--parent` | Issue identifier or UUID | Fail if the parent cannot be resolved or verified after create/update |
+| `--parent` | Issue identifier or UUID | Fail if the parent cannot be resolved; create also fails if the link cannot be verified or repaired |
 | `--labels` | Comma-separated issue-label names | Warn + skip invalid, continue (workflow callers must preflight strictly) |
 | `--assignee` | Name or `me` | Silent fail |
 

--- a/skills/linear/SKILL.md
+++ b/skills/linear/SKILL.md
@@ -129,6 +129,7 @@ sortOrder → sort_order  # Manual sort position
 | `--project` | Name or UUID | Fail with "not found" |
 | `--state` | Exact name (case-sensitive) | Fail, lists available states |
 | `--milestone` | Name or UUID | Fail with "not found" |
+| `--parent` | Issue identifier or UUID | Fail if the parent cannot be resolved or verified after create/update |
 | `--labels` | Comma-separated issue-label names | Warn + skip invalid, continue (workflow callers must preflight strictly) |
 | `--assignee` | Name or `me` | Silent fail |
 

--- a/skills/linear/scripts/commands/issues.sh
+++ b/skills/linear/scripts/commands/issues.sh
@@ -982,7 +982,13 @@ create_issue() {
     # Write-through: upsert new issue into cache
     local created_issue
     created_issue=$(echo "$result" | jq '.issueCreate.issue // empty')
-    if [[ -n "$requested_parent_id" && -n "$created_issue" && "$created_issue" != "null" ]]; then
+    if [[ -n "$requested_parent_id" ]]; then
+        if [[ -z "$created_issue" || "$created_issue" = "null" ]]; then
+            jq -nc --arg parent "$parent" \
+                '{error: "Issue created but response omitted issue object; cannot verify requested parent " + $parent}' >&2
+            return 1
+        fi
+
         local created_parent_id
         created_parent_id=$(echo "$created_issue" | jq -r '.parent.id // empty')
         if [ "$created_parent_id" != "$requested_parent_id" ]; then

--- a/skills/linear/scripts/commands/issues.sh
+++ b/skills/linear/scripts/commands/issues.sh
@@ -777,6 +777,7 @@ create_issue() {
     local milestone=""
     local cycle=""
     local estimate=""
+    local requested_parent_id=""
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
@@ -819,6 +820,10 @@ create_issue() {
         --parent)
             parent="$2"
             shift 2
+            ;;
+        --parent=*)
+            parent="${1#*=}"
+            shift
             ;;
         --milestone)
             milestone="$2"
@@ -933,12 +938,12 @@ create_issue() {
     # Handle parent (for sub-issues) - resolve identifier to UUID
     if [ -n "$parent" ]; then
         local parent_id
-        parent_id=$(resolve_issue_id "$parent")
-        if [ -z "$parent_id" ]; then
+        if ! parent_id=$(resolve_issue_id "$parent") || [ -z "$parent_id" ]; then
             echo "{\"error\": \"Parent issue not found: $parent\"}" >&2
             return 1
         fi
-        input_parts+=("\"parentId\": \"$parent_id\"")
+        requested_parent_id="$parent_id"
+        input_parts+=("\"parentId\": \"$requested_parent_id\"")
     fi
 
     # Handle milestone (auto-resolves name or UUID, fail fast on miss)
@@ -977,6 +982,51 @@ create_issue() {
     # Write-through: upsert new issue into cache
     local created_issue
     created_issue=$(echo "$result" | jq '.issueCreate.issue // empty')
+    if [[ -n "$requested_parent_id" && -n "$created_issue" && "$created_issue" != "null" ]]; then
+        local created_parent_id
+        created_parent_id=$(echo "$created_issue" | jq -r '.parent.id // empty')
+        if [ "$created_parent_id" != "$requested_parent_id" ]; then
+            local child_issue_id
+            child_issue_id=$(echo "$created_issue" | jq -r '.id // empty')
+            if [ -z "$child_issue_id" ]; then
+                jq -nc --arg parent "$parent" \
+                    '{error: "Issue created but response omitted child id; cannot verify requested parent " + $parent}' >&2
+                return 1
+            fi
+
+            local parent_fix_mutation="
+            mutation EnsureIssueParent(\$id: String!, \$input: IssueUpdateInput!) {
+                issueUpdate(id: \$id, input: \$input) {
+                    success
+                    issue {
+                        $ISSUE_RETURN_FIELDS
+                    }
+                }
+            }"
+            local parent_fix_variables
+            parent_fix_variables=$(jq -cn --arg id "$child_issue_id" --arg parentId "$requested_parent_id" \
+                '{id: $id, input: {parentId: $parentId}}')
+            local parent_fix_result
+            if ! parent_fix_result=$(graphql_query "$parent_fix_mutation" "$parent_fix_variables"); then
+                jq -nc --arg child "$child_issue_id" --arg parent "$parent" \
+                    '{error: "Issue " + $child + " was created, but Linear did not attach parent " + $parent + " during create and the follow-up repair failed"}' >&2
+                return 1
+            fi
+
+            local updated_issue
+            updated_issue=$(echo "$parent_fix_result" | jq '.issueUpdate.issue // empty')
+            local updated_parent_id
+            updated_parent_id=$(echo "$updated_issue" | jq -r '.parent.id // empty')
+            if [ "$updated_parent_id" != "$requested_parent_id" ]; then
+                jq -nc --arg child "$child_issue_id" --arg parent "$parent" \
+                    '{error: "Issue " + $child + " was created, but parent " + $parent + " could not be verified after follow-up repair"}' >&2
+                return 1
+            fi
+
+            result=$(echo "$parent_fix_result" | jq -c '{issueCreate: {success: (.issueUpdate.success // false), issue: .issueUpdate.issue}}')
+            created_issue="$updated_issue"
+        fi
+    fi
     [[ -n "$created_issue" && "$created_issue" != "null" ]] && cache_upsert_issue "$created_issue" 2>/dev/null || true
     [[ -n "$created_issue" && "$created_issue" != "null" ]] && cache_patch_relation_snapshots "$created_issue" 2>/dev/null || true
     # Download any attachments in the new issue description

--- a/skills/linear/tests/issues-create-parent.test.sh
+++ b/skills/linear/tests/issues-create-parent.test.sh
@@ -17,6 +17,7 @@ config="$(cat)"
 payload="$(sed -n 's/^data = //p' <<<"$config" | jq -r)"
 query="$(jq -r '.query' <<<"$payload")"
 variables="$(jq -c '.variables' <<<"$payload")"
+scenario="${LINEAR_PARENT_TEST_CASE:-repair}"
 printf '%s\n' "$payload" >> "${CURL_PAYLOAD_LOG:?}"
 
 case "$query" in
@@ -41,14 +42,34 @@ case "$query" in
     printf '%s' '{"errors":[{"message":"issueCreate missing parentId"}]}___HTTP_CODE___200'
     exit 0
   fi
-  printf '%s' '{"data":{"issueCreate":{"success":true,"issue":{"id":"child-uuid","identifier":"CC-558","title":"child","description":"c","state":{"name":"Todo","type":"unstarted"},"assignee":null,"project":{"id":"project-uuid","name":"X"},"projectMilestone":null,"cycle":null,"parent":null,"team":{"name":"Claude"},"labels":{"nodes":[{"name":"agent:rust"}]},"priority":3,"estimate":null,"sortOrder":1.0,"url":"https://linear.app/test/issue/CC-558","createdAt":"2026-07-03T00:00:00Z","updatedAt":"2026-07-03T00:00:00Z","archivedAt":null,"trashed":null,"relations":{"nodes":[]},"inverseRelations":{"nodes":[]}}}}}___HTTP_CODE___200'
+  case "$scenario" in
+  missing-issue)
+    printf '%s' '{"data":{"issueCreate":{"success":true,"issue":null}}}___HTTP_CODE___200'
+    ;;
+  missing-child-id)
+    printf '%s' '{"data":{"issueCreate":{"success":true,"issue":{"identifier":"CC-558","title":"child","description":"c","state":{"name":"Todo","type":"unstarted"},"assignee":null,"project":{"id":"project-uuid","name":"X"},"projectMilestone":null,"cycle":null,"parent":null,"team":{"name":"Claude"},"labels":{"nodes":[{"name":"agent:rust"}]},"priority":3,"estimate":null,"sortOrder":1.0,"url":"https://linear.app/test/issue/CC-558","createdAt":"2026-07-03T00:00:00Z","updatedAt":"2026-07-03T00:00:00Z","archivedAt":null,"trashed":null,"relations":{"nodes":[]},"inverseRelations":{"nodes":[]}}}}}___HTTP_CODE___200'
+    ;;
+  *)
+    printf '%s' '{"data":{"issueCreate":{"success":true,"issue":{"id":"child-uuid","identifier":"CC-558","title":"child","description":"c","state":{"name":"Todo","type":"unstarted"},"assignee":null,"project":{"id":"project-uuid","name":"X"},"projectMilestone":null,"cycle":null,"parent":null,"team":{"name":"Claude"},"labels":{"nodes":[{"name":"agent:rust"}]},"priority":3,"estimate":null,"sortOrder":1.0,"url":"https://linear.app/test/issue/CC-558","createdAt":"2026-07-03T00:00:00Z","updatedAt":"2026-07-03T00:00:00Z","archivedAt":null,"trashed":null,"relations":{"nodes":[]},"inverseRelations":{"nodes":[]}}}}}___HTTP_CODE___200'
+    ;;
+  esac
   ;;
 *"issueUpdate(id:"*)
   if [[ "$(jq -r '.id' <<<"$variables")" != "child-uuid" || "$(jq -r '.input.parentId // empty' <<<"$variables")" != "parent-uuid" ]]; then
     printf '%s' '{"errors":[{"message":"unexpected parent repair"}]}___HTTP_CODE___200'
     exit 0
   fi
-  printf '%s' '{"data":{"issueUpdate":{"success":true,"issue":{"id":"child-uuid","identifier":"CC-558","title":"child","description":"c","state":{"name":"Todo","type":"unstarted"},"assignee":null,"project":{"id":"project-uuid","name":"X"},"projectMilestone":null,"cycle":null,"parent":{"id":"parent-uuid","identifier":"CC-557","title":"parent"},"team":{"name":"Claude"},"labels":{"nodes":[{"name":"agent:rust"}]},"priority":3,"estimate":null,"sortOrder":1.0,"url":"https://linear.app/test/issue/CC-558","createdAt":"2026-07-03T00:00:00Z","updatedAt":"2026-07-03T00:00:01Z","archivedAt":null,"trashed":null,"relations":{"nodes":[]},"inverseRelations":{"nodes":[]}}}}}___HTTP_CODE___200'
+  case "$scenario" in
+  update-error)
+    printf '%s' '{"errors":[{"message":"update failed"}]}___HTTP_CODE___200'
+    ;;
+  repair-unverified)
+    printf '%s' '{"data":{"issueUpdate":{"success":true,"issue":{"id":"child-uuid","identifier":"CC-558","title":"child","description":"c","state":{"name":"Todo","type":"unstarted"},"assignee":null,"project":{"id":"project-uuid","name":"X"},"projectMilestone":null,"cycle":null,"parent":null,"team":{"name":"Claude"},"labels":{"nodes":[{"name":"agent:rust"}]},"priority":3,"estimate":null,"sortOrder":1.0,"url":"https://linear.app/test/issue/CC-558","createdAt":"2026-07-03T00:00:00Z","updatedAt":"2026-07-03T00:00:01Z","archivedAt":null,"trashed":null,"relations":{"nodes":[]},"inverseRelations":{"nodes":[]}}}}}___HTTP_CODE___200'
+    ;;
+  *)
+    printf '%s' '{"data":{"issueUpdate":{"success":true,"issue":{"id":"child-uuid","identifier":"CC-558","title":"child","description":"c","state":{"name":"Todo","type":"unstarted"},"assignee":null,"project":{"id":"project-uuid","name":"X"},"projectMilestone":null,"cycle":null,"parent":{"id":"parent-uuid","identifier":"CC-557","title":"parent"},"team":{"name":"Claude"},"labels":{"nodes":[{"name":"agent:rust"}]},"priority":3,"estimate":null,"sortOrder":1.0,"url":"https://linear.app/test/issue/CC-558","createdAt":"2026-07-03T00:00:00Z","updatedAt":"2026-07-03T00:00:01Z","archivedAt":null,"trashed":null,"relations":{"nodes":[]},"inverseRelations":{"nodes":[]}}}}}___HTTP_CODE___200'
+    ;;
+  esac
   ;;
 *)
   printf '%s' '{"errors":[{"message":"unexpected query"}]}___HTTP_CODE___200'
@@ -57,9 +78,17 @@ esac
 SH
 chmod +x "$TMP_ROOT/bin/curl"
 
-export CURL_PAYLOAD_LOG="$TMP_ROOT/payloads.jsonl"
-out="$(
-  PATH="$TMP_ROOT/bin:$PATH" LINEAR_API_KEY=test-token \
+run_create() {
+  local scenario="$1"
+  local stdout_file="$2"
+  local stderr_file="$3"
+  local payload_log="$4"
+
+  : >"$payload_log"
+  PATH="$TMP_ROOT/bin:$PATH" \
+    LINEAR_API_KEY=test-token \
+    CURL_PAYLOAD_LOG="$payload_log" \
+    LINEAR_PARENT_TEST_CASE="$scenario" \
     bash "$TMP_ROOT/.agents/skills/linear/scripts/linear.sh" issues create \
       --title child \
       --team Claude \
@@ -67,30 +96,78 @@ out="$(
       --labels agent:rust \
       --priority 3 \
       --parent CC-557 \
-      --description c
-)"
+      --description c \
+      >"$stdout_file" 2>"$stderr_file"
+}
 
+success_out="$TMP_ROOT/success.out"
+success_err="$TMP_ROOT/success.err"
+success_payload="$TMP_ROOT/success-payloads.jsonl"
+if ! run_create repair "$success_out" "$success_err" "$success_payload"; then
+  echo "FAIL issues create --parent repair scenario failed"
+  cat "$success_err"
+  exit 1
+fi
+
+out="$(cat "$success_out")"
 if ! jq -e '.success == true and .identifier == "CC-558" and .data.issue.parent.identifier == "CC-557"' >/dev/null <<<"$out"; then
   echo "FAIL issues create --parent returned unexpected output: $out"
   exit 1
 fi
 
-if ! jq -s -e 'any(.[]; (.query | contains("query GetIssue")) and .variables.id == "CC-557")' "$CURL_PAYLOAD_LOG" >/dev/null; then
+if ! jq -s -e 'any(.[]; (.query | contains("query GetIssue")) and .variables.id == "CC-557")' "$success_payload" >/dev/null; then
   echo "FAIL --parent identifier was not resolved through GetIssue"
-  cat "$CURL_PAYLOAD_LOG"
+  cat "$success_payload"
   exit 1
 fi
 
-if ! jq -s -e 'any(.[]; (.query | contains("issueCreate")) and .variables.input.parentId == "parent-uuid" and .variables.input.projectId == "project-uuid" and .variables.input.labelIds == ["label-uuid"])' "$CURL_PAYLOAD_LOG" >/dev/null; then
+if ! jq -s -e 'any(.[]; (.query | contains("issueCreate")) and .variables.input.parentId == "parent-uuid" and .variables.input.projectId == "project-uuid" and .variables.input.labelIds == ["label-uuid"])' "$success_payload" >/dev/null; then
   echo "FAIL issueCreate payload did not include resolved parent/project/label ids"
-  cat "$CURL_PAYLOAD_LOG"
+  cat "$success_payload"
   exit 1
 fi
 
-if ! jq -s -e 'any(.[]; (.query | contains("issueUpdate")) and .variables.id == "child-uuid" and .variables.input.parentId == "parent-uuid")' "$CURL_PAYLOAD_LOG" >/dev/null; then
+if ! jq -s -e 'any(.[]; (.query | contains("issueUpdate")) and .variables.id == "child-uuid" and .variables.input.parentId == "parent-uuid")' "$success_payload" >/dev/null; then
   echo "FAIL missing follow-up issueUpdate parent repair"
-  cat "$CURL_PAYLOAD_LOG"
+  cat "$success_payload"
   exit 1
 fi
+
+assert_create_fails() {
+  local scenario="$1"
+  local expected="$2"
+  local stdout_file="$TMP_ROOT/$scenario.out"
+  local stderr_file="$TMP_ROOT/$scenario.err"
+  local payload_log="$TMP_ROOT/$scenario-payloads.jsonl"
+  local rc
+
+  set +e
+  run_create "$scenario" "$stdout_file" "$stderr_file" "$payload_log"
+  rc=$?
+  set -e
+
+  if [[ "$rc" -eq 0 ]]; then
+    echo "FAIL scenario $scenario unexpectedly succeeded"
+    cat "$stdout_file"
+    exit 1
+  fi
+
+  if ! grep -q "$expected" "$stderr_file"; then
+    echo "FAIL scenario $scenario missing expected error: $expected"
+    cat "$stderr_file"
+    exit 1
+  fi
+
+  if [[ -s "$stdout_file" ]] && jq -e '.success == true' "$stdout_file" >/dev/null 2>&1; then
+    echo "FAIL scenario $scenario emitted normalized success"
+    cat "$stdout_file"
+    exit 1
+  fi
+}
+
+assert_create_fails missing-issue "omitted issue object"
+assert_create_fails missing-child-id "omitted child id"
+assert_create_fails update-error "follow-up repair failed"
+assert_create_fails repair-unverified "could not be verified after follow-up repair"
 
 echo "all pass"

--- a/skills/linear/tests/issues-create-parent.test.sh
+++ b/skills/linear/tests/issues-create-parent.test.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Regression test: issues create --parent must link the created issue.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+mkdir -p "$TMP_ROOT/.agents/skills" "$TMP_ROOT/bin"
+cp -R "$SKILL_DIR" "$TMP_ROOT/.agents/skills/linear"
+
+cat >"$TMP_ROOT/bin/curl" <<'SH'
+#!/usr/bin/env bash
+config="$(cat)"
+payload="$(sed -n 's/^data = //p' <<<"$config" | jq -r)"
+query="$(jq -r '.query' <<<"$payload")"
+variables="$(jq -c '.variables' <<<"$payload")"
+printf '%s\n' "$payload" >> "${CURL_PAYLOAD_LOG:?}"
+
+case "$query" in
+*"teams(filter:"*)
+  printf '%s' '{"data":{"teams":{"nodes":[{"id":"team-uuid"}]}}}___HTTP_CODE___200'
+  ;;
+*"projects(filter:"*)
+  printf '%s' '{"data":{"projects":{"nodes":[{"id":"project-uuid"}]}}}___HTTP_CODE___200'
+  ;;
+*"issueLabels(filter:"*)
+  printf '%s' '{"data":{"issueLabels":{"nodes":[{"id":"label-uuid"}]}}}___HTTP_CODE___200'
+  ;;
+*"issue(id:"*)
+  if [[ "$(jq -r '.id' <<<"$variables")" != "CC-557" ]]; then
+    printf '%s' '{"errors":[{"message":"unexpected parent lookup"}]}___HTTP_CODE___200'
+    exit 0
+  fi
+  printf '%s' '{"data":{"issue":{"id":"parent-uuid"}}}___HTTP_CODE___200'
+  ;;
+*"issueCreate(input:"*)
+  if [[ "$(jq -r '.input.parentId // empty' <<<"$variables")" != "parent-uuid" ]]; then
+    printf '%s' '{"errors":[{"message":"issueCreate missing parentId"}]}___HTTP_CODE___200'
+    exit 0
+  fi
+  printf '%s' '{"data":{"issueCreate":{"success":true,"issue":{"id":"child-uuid","identifier":"CC-558","title":"child","description":"c","state":{"name":"Todo","type":"unstarted"},"assignee":null,"project":{"id":"project-uuid","name":"X"},"projectMilestone":null,"cycle":null,"parent":null,"team":{"name":"Claude"},"labels":{"nodes":[{"name":"agent:rust"}]},"priority":3,"estimate":null,"sortOrder":1.0,"url":"https://linear.app/test/issue/CC-558","createdAt":"2026-07-03T00:00:00Z","updatedAt":"2026-07-03T00:00:00Z","archivedAt":null,"trashed":null,"relations":{"nodes":[]},"inverseRelations":{"nodes":[]}}}}}___HTTP_CODE___200'
+  ;;
+*"issueUpdate(id:"*)
+  if [[ "$(jq -r '.id' <<<"$variables")" != "child-uuid" || "$(jq -r '.input.parentId // empty' <<<"$variables")" != "parent-uuid" ]]; then
+    printf '%s' '{"errors":[{"message":"unexpected parent repair"}]}___HTTP_CODE___200'
+    exit 0
+  fi
+  printf '%s' '{"data":{"issueUpdate":{"success":true,"issue":{"id":"child-uuid","identifier":"CC-558","title":"child","description":"c","state":{"name":"Todo","type":"unstarted"},"assignee":null,"project":{"id":"project-uuid","name":"X"},"projectMilestone":null,"cycle":null,"parent":{"id":"parent-uuid","identifier":"CC-557","title":"parent"},"team":{"name":"Claude"},"labels":{"nodes":[{"name":"agent:rust"}]},"priority":3,"estimate":null,"sortOrder":1.0,"url":"https://linear.app/test/issue/CC-558","createdAt":"2026-07-03T00:00:00Z","updatedAt":"2026-07-03T00:00:01Z","archivedAt":null,"trashed":null,"relations":{"nodes":[]},"inverseRelations":{"nodes":[]}}}}}___HTTP_CODE___200'
+  ;;
+*)
+  printf '%s' '{"errors":[{"message":"unexpected query"}]}___HTTP_CODE___200'
+  ;;
+esac
+SH
+chmod +x "$TMP_ROOT/bin/curl"
+
+export CURL_PAYLOAD_LOG="$TMP_ROOT/payloads.jsonl"
+out="$(
+  PATH="$TMP_ROOT/bin:$PATH" LINEAR_API_KEY=test-token \
+    bash "$TMP_ROOT/.agents/skills/linear/scripts/linear.sh" issues create \
+      --title child \
+      --team Claude \
+      --project X \
+      --labels agent:rust \
+      --priority 3 \
+      --parent CC-557 \
+      --description c
+)"
+
+if ! jq -e '.success == true and .identifier == "CC-558" and .data.issue.parent.identifier == "CC-557"' >/dev/null <<<"$out"; then
+  echo "FAIL issues create --parent returned unexpected output: $out"
+  exit 1
+fi
+
+if ! jq -s -e 'any(.[]; (.query | contains("query GetIssue")) and .variables.id == "CC-557")' "$CURL_PAYLOAD_LOG" >/dev/null; then
+  echo "FAIL --parent identifier was not resolved through GetIssue"
+  cat "$CURL_PAYLOAD_LOG"
+  exit 1
+fi
+
+if ! jq -s -e 'any(.[]; (.query | contains("issueCreate")) and .variables.input.parentId == "parent-uuid" and .variables.input.projectId == "project-uuid" and .variables.input.labelIds == ["label-uuid"])' "$CURL_PAYLOAD_LOG" >/dev/null; then
+  echo "FAIL issueCreate payload did not include resolved parent/project/label ids"
+  cat "$CURL_PAYLOAD_LOG"
+  exit 1
+fi
+
+if ! jq -s -e 'any(.[]; (.query | contains("issueUpdate")) and .variables.id == "child-uuid" and .variables.input.parentId == "parent-uuid")' "$CURL_PAYLOAD_LOG" >/dev/null; then
+  echo "FAIL missing follow-up issueUpdate parent repair"
+  cat "$CURL_PAYLOAD_LOG"
+  exit 1
+fi
+
+echo "all pass"


### PR DESCRIPTION
## Summary
- Resolve `--parent` on Linear issue create and include `parentId` in the create mutation.
- Verify the created issue's parent, repair missing parent links with `issueUpdate`, and fail with JSON errors when verification cannot succeed.
- Add regression coverage for parent create, repair success, repair failure, missing child data, and update documentation for the behavior.

## Completed Issues
- Closes #428 - linear skill: issues create --parent is silently ignored (sub-issue not linked)

## Review Notes
- Internal review found docs, error-handling, and test coverage blockers.
- Fixed in `8bc0ae0f8fce4c77c2afc301f647d7cce71b6303`.
- Targeted re-review passed for documentation, error handling, and tests.
- External second-opinion review timed out after its configured 300s limit; internal review completed successfully.

## Test Plan
- `bash skills/linear/tests/issues-create-parent.test.sh`
- `bash skills/linear/tests/update-emit-newline.test.sh`
- `bash skills/linear/tests/comments-body-file.test.sh`
- `bash skills/linear/tests/bulk-update-diagnostics.test.sh`
- `bash skills/linear/tests/action-aliases.test.sh`
- `bash skills/linear/tests/cache-no-auth.test.sh`
- `./skills/linear/tests/issues-create-parent.test.sh`
- `cd cli && cargo test`
