### PR TITLE
fix(issue-431): lease worktree push after auto-rebase

### DIFF
--- a/skills/worktree/README.md
+++ b/skills/worktree/README.md
@@ -58,9 +58,12 @@ are not modified. Set `VSTACK_GITHUB_GIT_HTTPS_FALLBACK=never` to disable this
 for a call.
 
 When `worktree push` auto-rebases a branch before pushing, it uses a scoped
-`--force-with-lease` for the target branch so already-pushed PR branches can be
-rebased onto an advanced `origin/main` without failing non-fast-forward. Calls
-that skip auto-rebase still use plain pushes.
+`--force-with-lease` pinned to the target branch OID known before the rebase so
+already-pushed PR branches can be rebased onto an advanced `origin/main`
+without failing non-fast-forward. If the remote branch has advanced beyond the
+local branch, the command aborts and asks you to fetch/rebase/merge first
+instead of overwriting unseen remote commits. Calls that skip auto-rebase still
+use plain pushes.
 
 `codex-setup` applies the same env/config symlinks, copies, mkdirs, bot remote, bot git identity, and lightweight dependency bootstrap that `create` applies after creating a worktree. `codex-branch` renames or switches the app-created worktree branch to the lower-case issue branch expected by `orch`. `codex-cleanup` is intentionally a no-op lifecycle hook for this script; Codex owns app-created worktree and branch deletion. Keep project-level teardown such as stopping containers or removing disposable caches in the Codex environment cleanup script after this command, but do not call `worktree remove` from the hook.
 

--- a/skills/worktree/README.md
+++ b/skills/worktree/README.md
@@ -57,6 +57,11 @@ configured bot remote is `git@github.com:...` / `ssh://git@github.com/...` and
 are not modified. Set `VSTACK_GITHUB_GIT_HTTPS_FALLBACK=never` to disable this
 for a call.
 
+When `worktree push` auto-rebases a branch before pushing, it uses a scoped
+`--force-with-lease` for the target branch so already-pushed PR branches can be
+rebased onto an advanced `origin/main` without failing non-fast-forward. Calls
+that skip auto-rebase still use plain pushes.
+
 `codex-setup` applies the same env/config symlinks, copies, mkdirs, bot remote, bot git identity, and lightweight dependency bootstrap that `create` applies after creating a worktree. `codex-branch` renames or switches the app-created worktree branch to the lower-case issue branch expected by `orch`. `codex-cleanup` is intentionally a no-op lifecycle hook for this script; Codex owns app-created worktree and branch deletion. Keep project-level teardown such as stopping containers or removing disposable caches in the Codex environment cleanup script after this command, but do not call `worktree remove` from the hook.
 
 ## Configuration

--- a/skills/worktree/SKILL.md
+++ b/skills/worktree/SKILL.md
@@ -44,6 +44,10 @@ config. This lets Codex/GitHub-authenticated sessions push without a working
 SSH key. Set `VSTACK_GITHUB_GIT_HTTPS_FALLBACK=never` to force the normal SSH
 path.
 
+When `push` performs its auto-rebase, the following push uses a scoped
+`--force-with-lease` for the target branch. Plain pushes are still used when
+`--no-rebase` is passed or no auto-rebase runs.
+
 `remove` deletes the worktree before deleting the local branch. Branch deletion uses safe `git branch -d`; if that fails after worktree removal, the script exits non-zero with a diagnostic naming the remaining branch and manual `git branch -D` recovery command.
 
 When a configured symlink path is already tracked in the worktree branch, the script marks that path assume-unchanged before replacing it so `git status` stays clean.

--- a/skills/worktree/SKILL.md
+++ b/skills/worktree/SKILL.md
@@ -45,8 +45,11 @@ SSH key. Set `VSTACK_GITHUB_GIT_HTTPS_FALLBACK=never` to force the normal SSH
 path.
 
 When `push` performs its auto-rebase, the following push uses a scoped
-`--force-with-lease` for the target branch. Plain pushes are still used when
-`--no-rebase` is passed or no auto-rebase runs.
+`--force-with-lease` pinned to the target branch OID known before the rebase.
+Plain pushes are still used when `--no-rebase` is passed or no auto-rebase
+runs. If the remote branch has advanced beyond the local branch, `push` aborts
+and asks the user to fetch/rebase/merge first instead of overwriting unseen
+remote commits.
 
 `remove` deletes the worktree before deleting the local branch. Branch deletion uses safe `git branch -d`; if that fails after worktree removal, the script exits non-zero with a diagnostic naming the remaining branch and manual `git branch -D` recovery command.
 

--- a/skills/worktree/scripts/worktree
+++ b/skills/worktree/scripts/worktree
@@ -57,6 +57,20 @@ git_with_github_https_auth() {
   fi
 }
 
+remote_ref_lease_arg() {
+  local wt="$1" remote="$2" branch="$3"
+  local remote_head_ref="refs/heads/$branch"
+  local remote_tracking_ref="refs/remotes/$remote/$branch"
+
+  if git_with_github_https_auth -C "$wt" fetch "$remote" "+${remote_head_ref}:${remote_tracking_ref}" >/dev/null 2>&1; then
+    printf '%s\n' "--force-with-lease=${remote_head_ref}:${remote_tracking_ref}"
+  else
+    # Empty expectation means the remote branch must not already exist. This
+    # keeps first pushes safe while still allowing auto-rebased new branches.
+    printf '%s\n' "--force-with-lease=${remote_head_ref}:"
+  fi
+}
+
 strip_trailing_slashes() {
   local path="$1"
   while [[ "$path" != "/" && "$path" == */ ]]; do
@@ -544,6 +558,7 @@ case "${1:-}" in
       echo "Usage: $0 push [ID|/path] [--set-upstream|-u] [--no-rebase]"
       echo ""
       echo "Push worktree branch to remote. Auto-rebases onto origin/$DEFAULT_BRANCH first."
+      echo "Auto-rebased pushes use --force-with-lease scoped to the target branch."
       echo "Uses BOT_REMOTE_NAME from project config if set, otherwise falls back to origin."
       echo ""
       echo "Options:"
@@ -554,6 +569,7 @@ case "${1:-}" in
     ARG="${2:-}"
     SET_UPSTREAM=""
     AUTO_REBASE=true
+    REBASE_RAN=false
     shift 2 || shift || true
     while [[ $# -gt 0 ]]; do
       case "$1" in
@@ -593,6 +609,7 @@ case "${1:-}" in
           echo "Error: Rebase onto origin/$DEFAULT_BRANCH failed (conflicts). Push with --no-rebase or resolve manually." >&2
           exit 1
         fi
+        REBASE_RAN=true
         # Rebase can replace symlinks with tracked content — restore them
         setup_worktree_links "$WT_PATH"
       fi
@@ -604,10 +621,15 @@ case "${1:-}" in
       [[ -z "$UPSTREAM" ]] && SET_UPSTREAM="-u"
     fi
 
+    PUSH_LEASE=()
+    if [[ "$REBASE_RAN" == true && -n "$CURRENT_BRANCH" ]]; then
+      PUSH_LEASE=("$(remote_ref_lease_arg "$WT_PATH" "$REMOTE" "$CURRENT_BRANCH")")
+    fi
+
     if [[ -n "$SET_UPSTREAM" ]]; then
-      git_with_github_https_auth -C "$WT_PATH" push "$SET_UPSTREAM" "$REMOTE" "HEAD:refs/heads/${CURRENT_BRANCH}"
+      git_with_github_https_auth -C "$WT_PATH" push "$SET_UPSTREAM" "${PUSH_LEASE[@]}" "$REMOTE" "HEAD:refs/heads/${CURRENT_BRANCH}"
     else
-      git_with_github_https_auth -C "$WT_PATH" push "$REMOTE" HEAD
+      git_with_github_https_auth -C "$WT_PATH" push "${PUSH_LEASE[@]}" "$REMOTE" HEAD
     fi
     ;;
 

--- a/skills/worktree/scripts/worktree
+++ b/skills/worktree/scripts/worktree
@@ -61,14 +61,47 @@ remote_ref_lease_arg() {
   local wt="$1" remote="$2" branch="$3"
   local remote_head_ref="refs/heads/$branch"
   local remote_tracking_ref="refs/remotes/$remote/$branch"
+  local expected_oid=""
+  local fetch_err=""
+  local fetch_status=0
 
-  if git_with_github_https_auth -C "$wt" fetch "$remote" "+${remote_head_ref}:${remote_tracking_ref}" >/dev/null 2>&1; then
-    printf '%s\n' "--force-with-lease=${remote_head_ref}:${remote_tracking_ref}"
-  else
-    # Empty expectation means the remote branch must not already exist. This
-    # keeps first pushes safe while still allowing auto-rebased new branches.
-    printf '%s\n' "--force-with-lease=${remote_head_ref}:"
+  expected_oid="$(git -C "$wt" show-ref --verify --hash "$remote_tracking_ref" 2>/dev/null || true)"
+
+  if [[ -z "$expected_oid" && "$remote" != "origin" ]]; then
+    fetch_err="$(mktemp "${TMPDIR:-/tmp}/worktree-lease-fetch.XXXXXX")"
+    if git_with_github_https_auth -C "$wt" fetch "$remote" "+${remote_head_ref}:${remote_tracking_ref}" >/dev/null 2>"$fetch_err"; then
+      expected_oid="$(git -C "$wt" show-ref --verify --hash "$remote_tracking_ref" 2>/dev/null || true)"
+    else
+      fetch_status=$?
+      if grep -qiE "couldn't find remote ref|could not find remote ref|remote ref does not exist|remote branch .* not found" "$fetch_err"; then
+        rm -f "$fetch_err"
+        printf '%s\n' "--force-with-lease=${remote_head_ref}:"
+        return 0
+      fi
+
+      echo "Error: Could not fetch remote branch '$branch' from remote '$remote' for force-with-lease." >&2
+      sed 's/^/  /' "$fetch_err" >&2
+      rm -f "$fetch_err"
+      return "$fetch_status"
+    fi
+    rm -f "$fetch_err"
   fi
+
+  if [[ -z "$expected_oid" ]]; then
+    # Empty expectation means the remote branch must not already exist. This
+    # keeps first pushes safe and prevents overwriting an existing branch that
+    # the local checkout has never observed.
+    printf '%s\n' "--force-with-lease=${remote_head_ref}:"
+    return 0
+  fi
+
+  if ! git -C "$wt" merge-base --is-ancestor "$expected_oid" HEAD; then
+    echo "Error: Remote '$remote/$branch' points at $expected_oid, which is not contained in local branch '$branch'." >&2
+    echo "Fetch and rebase/merge '$remote/$branch' before using worktree push." >&2
+    return 1
+  fi
+
+  printf '%s\n' "--force-with-lease=${remote_head_ref}:${expected_oid}"
 }
 
 strip_trailing_slashes() {
@@ -558,7 +591,7 @@ case "${1:-}" in
       echo "Usage: $0 push [ID|/path] [--set-upstream|-u] [--no-rebase]"
       echo ""
       echo "Push worktree branch to remote. Auto-rebases onto origin/$DEFAULT_BRANCH first."
-      echo "Auto-rebased pushes use --force-with-lease scoped to the target branch."
+      echo "Auto-rebased pushes use --force-with-lease pinned to the pre-rebase target branch OID."
       echo "Uses BOT_REMOTE_NAME from project config if set, otherwise falls back to origin."
       echo ""
       echo "Options:"
@@ -569,7 +602,6 @@ case "${1:-}" in
     ARG="${2:-}"
     SET_UPSTREAM=""
     AUTO_REBASE=true
-    REBASE_RAN=false
     shift 2 || shift || true
     while [[ $# -gt 0 ]]; do
       case "$1" in
@@ -600,16 +632,24 @@ case "${1:-}" in
       REMOTE="origin"
     fi
 
+    CURRENT_BRANCH=$(git -C "$WT_PATH" branch --show-current 2>/dev/null)
+    PUSH_LEASE=()
+    if [[ "$AUTO_REBASE" == true && -n "$CURRENT_BRANCH" && "$CURRENT_BRANCH" != "$DEFAULT_BRANCH" ]]; then
+      if LEASE_ARG="$(remote_ref_lease_arg "$WT_PATH" "$REMOTE" "$CURRENT_BRANCH")"; then
+        PUSH_LEASE=("$LEASE_ARG")
+      else
+        exit 1
+      fi
+    fi
+
     if [[ "$AUTO_REBASE" == true ]]; then
-      git_with_github_https_auth -C "$PROJECT_ROOT" fetch origin >/dev/null 2>&1 || true
-      CURRENT_BRANCH=$(git -C "$WT_PATH" branch --show-current 2>/dev/null)
+      git_with_github_https_auth -C "$PROJECT_ROOT" fetch origin "+refs/heads/$DEFAULT_BRANCH:refs/remotes/origin/$DEFAULT_BRANCH" >/dev/null 2>&1 || true
       if [[ -n "$CURRENT_BRANCH" && "$CURRENT_BRANCH" != "$DEFAULT_BRANCH" ]]; then
         if ! git -C "$WT_PATH" rebase "origin/$DEFAULT_BRANCH" >/dev/null 2>&1; then
           git -C "$WT_PATH" rebase --abort >/dev/null 2>&1 || true
           echo "Error: Rebase onto origin/$DEFAULT_BRANCH failed (conflicts). Push with --no-rebase or resolve manually." >&2
           exit 1
         fi
-        REBASE_RAN=true
         # Rebase can replace symlinks with tracked content — restore them
         setup_worktree_links "$WT_PATH"
       fi
@@ -621,15 +661,20 @@ case "${1:-}" in
       [[ -z "$UPSTREAM" ]] && SET_UPSTREAM="-u"
     fi
 
-    PUSH_LEASE=()
-    if [[ "$REBASE_RAN" == true && -n "$CURRENT_BRANCH" ]]; then
-      PUSH_LEASE=("$(remote_ref_lease_arg "$WT_PATH" "$REMOTE" "$CURRENT_BRANCH")")
-    fi
-
     if [[ -n "$SET_UPSTREAM" ]]; then
-      git_with_github_https_auth -C "$WT_PATH" push "$SET_UPSTREAM" "${PUSH_LEASE[@]}" "$REMOTE" "HEAD:refs/heads/${CURRENT_BRANCH}"
+      if ! git_with_github_https_auth -C "$WT_PATH" push "$SET_UPSTREAM" "${PUSH_LEASE[@]}" "$REMOTE" "HEAD:refs/heads/${CURRENT_BRANCH}"; then
+        if [[ ${#PUSH_LEASE[@]} -gt 0 ]]; then
+          echo "Error: Push rejected. Remote '$REMOTE/$CURRENT_BRANCH' may have changed since the force-with-lease expectation; fetch and rebase/merge before retrying." >&2
+        fi
+        exit 1
+      fi
     else
-      git_with_github_https_auth -C "$WT_PATH" push "${PUSH_LEASE[@]}" "$REMOTE" HEAD
+      if ! git_with_github_https_auth -C "$WT_PATH" push "${PUSH_LEASE[@]}" "$REMOTE" HEAD; then
+        if [[ ${#PUSH_LEASE[@]} -gt 0 ]]; then
+          echo "Error: Push rejected. Remote '$REMOTE/$CURRENT_BRANCH' may have changed since the force-with-lease expectation; fetch and rebase/merge before retrying." >&2
+        fi
+        exit 1
+      fi
     fi
     ;;
 

--- a/skills/worktree/tests/worktree_remove.sh
+++ b/skills/worktree/tests/worktree_remove.sh
@@ -338,6 +338,39 @@ assert_eq "$lease_race_second_code" "1" "auto-rebased push rejects remote branch
 assert_eq "$(git --git-dir="$LEASE_RACE_ROOT/origin.git" rev-parse refs/heads/issue-lease-race)" "$lease_race_external_commit" "remote branch remains at external commit after lease rejection"
 assert_contains "$(cat "$LEASE_RACE_ROOT/lease-race-second.err")" "force-with-lease expectation" "lease rejection diagnostic tells user to fetch and rebase"
 
+DIVERGED_REMOTE_ROOT="$TMP_ROOT/diverged-remote"
+make_repo "$DIVERGED_REMOTE_ROOT/main"
+git init -q --bare "$DIVERGED_REMOTE_ROOT/origin.git"
+git -C "$DIVERGED_REMOTE_ROOT/main" remote add origin "$DIVERGED_REMOTE_ROOT/origin.git"
+git -C "$DIVERGED_REMOTE_ROOT/main" push -q -u origin main
+git -C "$DIVERGED_REMOTE_ROOT/main" worktree add -q -b issue-diverged-push "$DIVERGED_REMOTE_ROOT/trees/issue-diverged-push" main
+printf 'branch-change\n' > "$DIVERGED_REMOTE_ROOT/trees/issue-diverged-push/branch.txt"
+git -C "$DIVERGED_REMOTE_ROOT/trees/issue-diverged-push" add branch.txt
+git -C "$DIVERGED_REMOTE_ROOT/trees/issue-diverged-push" commit -q -m 'branch change'
+(
+  cd "$DIVERGED_REMOTE_ROOT/main" && \
+    "$WORKTREE_SCRIPT" push ISSUE-DIVERGED-PUSH --set-upstream >"$DIVERGED_REMOTE_ROOT/diverged-first.out" 2>"$DIVERGED_REMOTE_ROOT/diverged-first.err"
+)
+diverged_old_oid="$(git --git-dir="$DIVERGED_REMOTE_ROOT/origin.git" rev-parse refs/heads/issue-diverged-push)"
+diverged_old_tree="$(git --git-dir="$DIVERGED_REMOTE_ROOT/origin.git" rev-parse "${diverged_old_oid}^{tree}")"
+diverged_external_commit="$(GIT_AUTHOR_NAME=External GIT_AUTHOR_EMAIL=external@example.com GIT_COMMITTER_NAME=External GIT_COMMITTER_EMAIL=external@example.com git --git-dir="$DIVERGED_REMOTE_ROOT/origin.git" commit-tree "$diverged_old_tree" -p "$diverged_old_oid" -m 'observed external branch update')"
+git --git-dir="$DIVERGED_REMOTE_ROOT/origin.git" update-ref refs/heads/issue-diverged-push "$diverged_external_commit"
+git -C "$DIVERGED_REMOTE_ROOT/main" fetch -q origin "+refs/heads/issue-diverged-push:refs/remotes/origin/issue-diverged-push"
+printf 'local-review-fix\n' > "$DIVERGED_REMOTE_ROOT/trees/issue-diverged-push/fix.txt"
+git -C "$DIVERGED_REMOTE_ROOT/trees/issue-diverged-push" add fix.txt
+git -C "$DIVERGED_REMOTE_ROOT/trees/issue-diverged-push" commit -q -m 'local review fix'
+set +e
+(
+  cd "$DIVERGED_REMOTE_ROOT/main" && \
+    "$WORKTREE_SCRIPT" push ISSUE-DIVERGED-PUSH >"$DIVERGED_REMOTE_ROOT/diverged-second.out" 2>"$DIVERGED_REMOTE_ROOT/diverged-second.err"
+)
+diverged_second_code=$?
+set -e
+assert_eq "$diverged_second_code" "1" "auto-rebased push rejects already-observed remote divergence"
+assert_eq "$(git --git-dir="$DIVERGED_REMOTE_ROOT/origin.git" rev-parse refs/heads/issue-diverged-push)" "$diverged_external_commit" "remote branch remains at observed external commit after divergence rejection"
+assert_contains "$(cat "$DIVERGED_REMOTE_ROOT/diverged-second.err")" "not contained in local branch" "divergence diagnostic names non-ancestor remote tip"
+assert_contains "$(cat "$DIVERGED_REMOTE_ROOT/diverged-second.err")" "Fetch and rebase/merge" "divergence diagnostic tells user to fetch and rebase"
+
 BROKEN_REMOTE_ROOT="$TMP_ROOT/broken-remote"
 make_repo "$BROKEN_REMOTE_ROOT/main"
 git init -q --bare "$BROKEN_REMOTE_ROOT/origin.git"

--- a/skills/worktree/tests/worktree_remove.sh
+++ b/skills/worktree/tests/worktree_remove.sh
@@ -289,6 +289,109 @@ git -C "$REBASE_PUSH_ROOT/main" fetch -q origin "+refs/heads/issue-rebase-push:r
 assert_eq "$(git -C "$REBASE_PUSH_ROOT/main" rev-parse origin/issue-rebase-push)" "$(git -C "$REBASE_PUSH_ROOT/trees/issue-rebase-push" rev-parse HEAD)" "remote branch matches auto-rebased local head"
 assert_path_exists "$REBASE_PUSH_ROOT/trees/issue-rebase-push/main-advanced.txt" "auto-rebase placed branch on advanced main"
 
+LEASE_RACE_ROOT="$TMP_ROOT/lease-race"
+make_repo "$LEASE_RACE_ROOT/main"
+git init -q --bare "$LEASE_RACE_ROOT/origin.git"
+git -C "$LEASE_RACE_ROOT/main" remote add origin "$LEASE_RACE_ROOT/origin.git"
+git -C "$LEASE_RACE_ROOT/main" push -q -u origin main
+git -C "$LEASE_RACE_ROOT/main" worktree add -q -b issue-lease-race "$LEASE_RACE_ROOT/trees/issue-lease-race" main
+printf 'branch-change\n' > "$LEASE_RACE_ROOT/trees/issue-lease-race/branch.txt"
+git -C "$LEASE_RACE_ROOT/trees/issue-lease-race" add branch.txt
+git -C "$LEASE_RACE_ROOT/trees/issue-lease-race" commit -q -m 'branch change'
+(
+  cd "$LEASE_RACE_ROOT/main" && \
+    "$WORKTREE_SCRIPT" push ISSUE-LEASE-RACE --set-upstream >"$LEASE_RACE_ROOT/lease-race-first.out" 2>"$LEASE_RACE_ROOT/lease-race-first.err"
+)
+printf 'main-advanced\n' > "$LEASE_RACE_ROOT/main/main-advanced.txt"
+git -C "$LEASE_RACE_ROOT/main" add main-advanced.txt
+git -C "$LEASE_RACE_ROOT/main" commit -q -m 'advance main'
+git -C "$LEASE_RACE_ROOT/main" push -q origin main
+printf 'review-fix\n' > "$LEASE_RACE_ROOT/trees/issue-lease-race/fix.txt"
+git -C "$LEASE_RACE_ROOT/trees/issue-lease-race" add fix.txt
+git -C "$LEASE_RACE_ROOT/trees/issue-lease-race" commit -q -m 'review fix'
+lease_race_old_oid="$(git --git-dir="$LEASE_RACE_ROOT/origin.git" rev-parse refs/heads/issue-lease-race)"
+lease_race_old_tree="$(git --git-dir="$LEASE_RACE_ROOT/origin.git" rev-parse "${lease_race_old_oid}^{tree}")"
+lease_race_external_commit="$(GIT_AUTHOR_NAME=External GIT_AUTHOR_EMAIL=external@example.com GIT_COMMITTER_NAME=External GIT_COMMITTER_EMAIL=external@example.com git --git-dir="$LEASE_RACE_ROOT/origin.git" commit-tree "$lease_race_old_tree" -p "$lease_race_old_oid" -m 'external branch update')"
+mkdir -p "$LEASE_RACE_ROOT/bin"
+REAL_GIT="$(command -v git)"
+cat > "$LEASE_RACE_ROOT/bin/git" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+for arg in "\$@"; do
+  if [[ "\$arg" == "rebase" && ! -e "$LEASE_RACE_ROOT/lease-race-mutated" ]]; then
+    touch "$LEASE_RACE_ROOT/lease-race-mutated"
+    "$REAL_GIT" --git-dir="$LEASE_RACE_ROOT/origin.git" update-ref refs/heads/issue-lease-race "$lease_race_external_commit"
+    break
+  fi
+done
+exec "$REAL_GIT" "\$@"
+EOF
+chmod +x "$LEASE_RACE_ROOT/bin/git"
+set +e
+(
+  cd "$LEASE_RACE_ROOT/main" && \
+    PATH="$LEASE_RACE_ROOT/bin:$PATH" "$WORKTREE_SCRIPT" push ISSUE-LEASE-RACE >"$LEASE_RACE_ROOT/lease-race-second.out" 2>"$LEASE_RACE_ROOT/lease-race-second.err"
+)
+lease_race_second_code=$?
+set -e
+assert_eq "$lease_race_second_code" "1" "auto-rebased push rejects remote branch update after lease capture"
+assert_eq "$(git --git-dir="$LEASE_RACE_ROOT/origin.git" rev-parse refs/heads/issue-lease-race)" "$lease_race_external_commit" "remote branch remains at external commit after lease rejection"
+assert_contains "$(cat "$LEASE_RACE_ROOT/lease-race-second.err")" "force-with-lease expectation" "lease rejection diagnostic tells user to fetch and rebase"
+
+BROKEN_REMOTE_ROOT="$TMP_ROOT/broken-remote"
+make_repo "$BROKEN_REMOTE_ROOT/main"
+git init -q --bare "$BROKEN_REMOTE_ROOT/origin.git"
+git -C "$BROKEN_REMOTE_ROOT/main" remote add origin "$BROKEN_REMOTE_ROOT/origin.git"
+git -C "$BROKEN_REMOTE_ROOT/main" push -q -u origin main
+git -C "$BROKEN_REMOTE_ROOT/main" remote add broken "$BROKEN_REMOTE_ROOT/missing.git"
+cat > "$BROKEN_REMOTE_ROOT/main/.env.local" <<'ENV'
+BOT_REMOTE_NAME="broken"
+ENV
+git -C "$BROKEN_REMOTE_ROOT/main" worktree add -q -b issue-broken-push "$BROKEN_REMOTE_ROOT/trees/issue-broken-push" main
+printf 'broken-remote-change\n' > "$BROKEN_REMOTE_ROOT/trees/issue-broken-push/branch.txt"
+git -C "$BROKEN_REMOTE_ROOT/trees/issue-broken-push" add branch.txt
+git -C "$BROKEN_REMOTE_ROOT/trees/issue-broken-push" commit -q -m 'branch change'
+set +e
+(
+  cd "$BROKEN_REMOTE_ROOT/main" && \
+    "$WORKTREE_SCRIPT" push ISSUE-BROKEN-PUSH >"$BROKEN_REMOTE_ROOT/broken-push.out" 2>"$BROKEN_REMOTE_ROOT/broken-push.err"
+)
+broken_push_code=$?
+set -e
+assert_eq "$broken_push_code" "1" "force-with-lease setup aborts on non-missing fetch failure"
+assert_contains "$(cat "$BROKEN_REMOTE_ROOT/broken-push.err")" "Could not fetch remote branch 'issue-broken-push' from remote 'broken'" "fetch failure diagnostic names remote branch"
+
+BOT_PUSH_ROOT="$TMP_ROOT/bot-push"
+make_repo "$BOT_PUSH_ROOT/main"
+git init -q --bare "$BOT_PUSH_ROOT/origin.git"
+git init -q --bare "$BOT_PUSH_ROOT/bot.git"
+git -C "$BOT_PUSH_ROOT/main" remote add origin "$BOT_PUSH_ROOT/origin.git"
+git -C "$BOT_PUSH_ROOT/main" remote add bot "$BOT_PUSH_ROOT/bot.git"
+git -C "$BOT_PUSH_ROOT/main" push -q -u origin main
+cat > "$BOT_PUSH_ROOT/main/.env.local" <<'ENV'
+BOT_REMOTE_NAME="bot"
+ENV
+git -C "$BOT_PUSH_ROOT/main" worktree add -q -b issue-bot-push "$BOT_PUSH_ROOT/trees/issue-bot-push" main
+printf 'bot-branch-change\n' > "$BOT_PUSH_ROOT/trees/issue-bot-push/branch.txt"
+git -C "$BOT_PUSH_ROOT/trees/issue-bot-push" add branch.txt
+git -C "$BOT_PUSH_ROOT/trees/issue-bot-push" commit -q -m 'bot branch change'
+(
+  cd "$BOT_PUSH_ROOT/main" && \
+    "$WORKTREE_SCRIPT" push ISSUE-BOT-PUSH --set-upstream >"$BOT_PUSH_ROOT/bot-push-first.out" 2>"$BOT_PUSH_ROOT/bot-push-first.err"
+)
+printf 'main-advanced\n' > "$BOT_PUSH_ROOT/main/main-advanced.txt"
+git -C "$BOT_PUSH_ROOT/main" add main-advanced.txt
+git -C "$BOT_PUSH_ROOT/main" commit -q -m 'advance main'
+git -C "$BOT_PUSH_ROOT/main" push -q origin main
+printf 'bot-review-fix\n' > "$BOT_PUSH_ROOT/trees/issue-bot-push/fix.txt"
+git -C "$BOT_PUSH_ROOT/trees/issue-bot-push" add fix.txt
+git -C "$BOT_PUSH_ROOT/trees/issue-bot-push" commit -q -m 'bot review fix'
+(
+  cd "$BOT_PUSH_ROOT/main" && \
+    "$WORKTREE_SCRIPT" push ISSUE-BOT-PUSH >"$BOT_PUSH_ROOT/bot-push-second.out" 2>"$BOT_PUSH_ROOT/bot-push-second.err"
+)
+assert_eq "$(git --git-dir="$BOT_PUSH_ROOT/bot.git" rev-parse refs/heads/issue-bot-push)" "$(git -C "$BOT_PUSH_ROOT/trees/issue-bot-push" rev-parse HEAD)" "auto-rebased push uses configured bot remote lease"
+
 GITHUB_PUSH_ROOT="$TMP_ROOT/github-push"
 make_repo "$GITHUB_PUSH_ROOT/main"
 git -C "$GITHUB_PUSH_ROOT/main" remote add origin git@github.com:owner/repo.git

--- a/skills/worktree/tests/worktree_remove.sh
+++ b/skills/worktree/tests/worktree_remove.sh
@@ -253,6 +253,42 @@ assert_eq "$codex_push_code" "0" "push issue ID uses current Codex worktree outs
 assert_remote_branch_exists "$CODEX_PUSH_ROOT/main" "issue-codex-push" "push issue ID publishes current Codex worktree branch"
 assert_path_absent "$CODEX_PUSH_ROOT/registry-trees/issue-codex-push" "push issue ID does not require configured registry path"
 
+REBASE_PUSH_ROOT="$TMP_ROOT/rebase-push"
+make_repo "$REBASE_PUSH_ROOT/main"
+git init -q --bare "$REBASE_PUSH_ROOT/origin.git"
+git -C "$REBASE_PUSH_ROOT/main" remote add origin "$REBASE_PUSH_ROOT/origin.git"
+git -C "$REBASE_PUSH_ROOT/main" push -q -u origin main
+git -C "$REBASE_PUSH_ROOT/main" worktree add -q -b issue-rebase-push "$REBASE_PUSH_ROOT/trees/issue-rebase-push" main
+printf 'branch-change\n' > "$REBASE_PUSH_ROOT/trees/issue-rebase-push/branch.txt"
+git -C "$REBASE_PUSH_ROOT/trees/issue-rebase-push" add branch.txt
+git -C "$REBASE_PUSH_ROOT/trees/issue-rebase-push" commit -q -m 'branch change'
+set +e
+(
+  cd "$REBASE_PUSH_ROOT/main" && \
+    "$WORKTREE_SCRIPT" push ISSUE-REBASE-PUSH --set-upstream >"$REBASE_PUSH_ROOT/rebase-push-first.out" 2>"$REBASE_PUSH_ROOT/rebase-push-first.err"
+)
+rebase_push_first_code=$?
+set -e
+assert_eq "$rebase_push_first_code" "0" "push with auto-rebase can create remote branch with lease"
+printf 'main-advanced\n' > "$REBASE_PUSH_ROOT/main/main-advanced.txt"
+git -C "$REBASE_PUSH_ROOT/main" add main-advanced.txt
+git -C "$REBASE_PUSH_ROOT/main" commit -q -m 'advance main'
+git -C "$REBASE_PUSH_ROOT/main" push -q origin main
+printf 'review-fix\n' > "$REBASE_PUSH_ROOT/trees/issue-rebase-push/fix.txt"
+git -C "$REBASE_PUSH_ROOT/trees/issue-rebase-push" add fix.txt
+git -C "$REBASE_PUSH_ROOT/trees/issue-rebase-push" commit -q -m 'review fix'
+set +e
+(
+  cd "$REBASE_PUSH_ROOT/main" && \
+    "$WORKTREE_SCRIPT" push ISSUE-REBASE-PUSH >"$REBASE_PUSH_ROOT/rebase-push-second.out" 2>"$REBASE_PUSH_ROOT/rebase-push-second.err"
+)
+rebase_push_second_code=$?
+set -e
+assert_eq "$rebase_push_second_code" "0" "auto-rebased already-pushed branch pushes with force-with-lease"
+git -C "$REBASE_PUSH_ROOT/main" fetch -q origin "+refs/heads/issue-rebase-push:refs/remotes/origin/issue-rebase-push"
+assert_eq "$(git -C "$REBASE_PUSH_ROOT/main" rev-parse origin/issue-rebase-push)" "$(git -C "$REBASE_PUSH_ROOT/trees/issue-rebase-push" rev-parse HEAD)" "remote branch matches auto-rebased local head"
+assert_path_exists "$REBASE_PUSH_ROOT/trees/issue-rebase-push/main-advanced.txt" "auto-rebase placed branch on advanced main"
+
 GITHUB_PUSH_ROOT="$TMP_ROOT/github-push"
 make_repo "$GITHUB_PUSH_ROOT/main"
 git -C "$GITHUB_PUSH_ROOT/main" remote add origin git@github.com:owner/repo.git


### PR DESCRIPTION
## Summary
- Update `worktree push` to use a scoped `--force-with-lease` after its own auto-rebase instead of a plain push.
- Pin the lease to the pre-rebase remote branch OID, reject unsafe remote divergence, and preserve safe first-push behavior.
- Add regression coverage for already-pushed rebase pushes, unseen remote updates, fetch-failure diagnostics, configured push remotes, and observed divergence guards.

## Context
- No linked decisions found.

## Completed Issues
- Closes #431 - worktree push: plain git push after auto-rebase fails non-fast-forward on already-pushed branches (needs --force-with-lease)

## Test Plan
- `bash -n skills/worktree/scripts/worktree`
- `bash -n skills/worktree/tests/worktree_remove.sh`
- `skills/worktree/tests/worktree_remove.sh` (59 pass, 0 fail)
- Pre-submission internal review: passed after fix cycles; external Claude review timed out twice and was treated as advisory/unresponsive.
