### PR TITLE
fix(issue-435): Clarify skill-failure reporting for non-VStack skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ skill-templates/         Templates for new skills
 - **Discovered dynamically.** CLI scans `agents/`, `skills/`, `hooks/`, `pi-extensions/` at runtime. No hardcoded lists.
 - **Canonical source is harness-agnostic.** Translation happens in `cli/src/harness/`.
 - **Agent `role` drives access control.** `analyst` → planning/research/recon artifacts. `reviewer` → report-only/subagent (may write reports, not product code). `engineer` → full access/primary. `manager` → analysis/report artifacts.
-- **Skill dependencies use frontmatter.** `dependencies: { required: [...], optional: [...] }` in SKILL.md.
+- **Skill dependencies and ownership use frontmatter.** `dependencies: { required: [...], optional: [...] }` in SKILL.md. Shipped VStack skills also declare `metadata.source`, `metadata.repository`, and `metadata.bugs` so agents can route upstream failures only to the owning project.
 - **Hooks diverge by harness.** Claude Code: native shell hooks + settings.json + agent frontmatter. Cursor: safety `.mdc` rules. OpenCode: `.opencode/agents/*.md` + instructions. Codex: native shell hooks under `<scope>/.codex/hooks/` registered in `<scope>/.codex/hooks.json` with `[features] hooks = true` in `config.toml` — events without a codex equivalent (e.g. Claude's `TaskCompleted`) fall back to inline prose in `developer_instructions`. Pi: native TS implementations in the `@vanillagreen/pi-hooks` extension, listening on `tool_call`/`tool_result`/`turn_end`; each hook independently toggleable in pi-extension-manager.
 - **Pi extensions are npm-shaped.** vstack copies them to `<scope>/packages/<name>`, runs `npm install --omit=dev --package-lock=false --legacy-peer-deps --no-audit --no-fund` there when `package.json` has `dependencies` or `optionalDependencies`, and registers the path in Pi's `settings.json` `packages` array.
 - **Skill/hook attribution is config-driven.** Source `vstack.toml` `[agent-skills]` is authoritative — explicit entries skip prefix matching. `[role-skills]` adds skills to all agents of a role. Project `vstack.toml` also has `[agent-skills]` populated at install; users add/remove and refresh. Markdown-based harnesses get `skills:` frontmatter; Codex agents get a "Required Skills" instruction section.
@@ -68,7 +68,15 @@ license: MIT
 user-invocable: true
 dependencies:
   required: [linear, github, worktree]
+metadata:
+  author: vanillagreen
+  source: vstack
+  repository: "https://github.com/vanillagreencom/vstack"
+  bugs: "https://github.com/vanillagreencom/vstack/issues"
+  version: "1.0.0"
 ```
+
+Use the ownership fields only when the skill is shipped by VStack. Non-VStack skills should point at their own upstream instead of `vanillagreencom/vstack`.
 
 Optional skill settings template (`skills/*/vstack.settings.toml.example`):
 ```toml

--- a/agents/generalist.md
+++ b/agents/generalist.md
@@ -11,7 +11,7 @@ color: green
 
 Handles cross-cutting maintenance: documentation, stale references, and code organization. Not for domain-specific implementation.
 
-> ***Skill failures must be reported:*** If there is a logic error, script failure, or provenly incorrect guidance, the error must absolutely be reported to the orchestrating agent and user upon your return. If failure is from vstack skill/hook/extension/agent, ask orchestrating agent to consider reporting issue upstream at `github.com/vanillagreencom/vstack`.
+> ***Skill failures must be reported:*** If there is a logic error, script failure, or provenly incorrect guidance, report it to the orchestrating agent and user upon return. Only ask the orchestrating agent to consider filing at `github.com/vanillagreencom/vstack` when the failed asset is part of the VStack distribution: a canonical VStack agent, skill, hook, or Pi extension, or a skill whose metadata/repository explicitly identifies VStack/vanillagreen ownership. For non-VStack skills, report the failure to the orchestrator/user and use that skill's own upstream if known; do not route it to the VStack repo.
 
 ## Capabilities
 

--- a/agents/iced.md
+++ b/agents/iced.md
@@ -11,7 +11,7 @@ color: cyan
 
 Implements Iced UI layer. Focus: 60 FPS, reactive rendering, Elm Architecture, Canvas/Shader rendering, pane_grid docking.
 
-> ***Skill failures must be reported:*** If there is a logic error, script failure, or provenly incorrect guidance, the error must absolutely be reported to the orchestrating agent and user upon your return. If failure is from vstack skill/hook/extension/agent, ask orchestrating agent to consider reporting issue upstream at `github.com/vanillagreencom/vstack`.
+> ***Skill failures must be reported:*** If there is a logic error, script failure, or provenly incorrect guidance, report it to the orchestrating agent and user upon return. Only ask the orchestrating agent to consider filing at `github.com/vanillagreencom/vstack` when the failed asset is part of the VStack distribution: a canonical VStack agent, skill, hook, or Pi extension, or a skill whose metadata/repository explicitly identifies VStack/vanillagreen ownership. For non-VStack skills, report the failure to the orchestrator/user and use that skill's own upstream if known; do not route it to the VStack repo.
 
 ## Capabilities
 

--- a/agents/planner.md
+++ b/agents/planner.md
@@ -13,7 +13,7 @@ You are a software architect and planning specialist. Convert requirements, scou
 
 Planner normally sits between reconnaissance and program planning in this chain: **main agent → scout agent → planner agent → TPM agent → main agent**. Your direct output is the technical plan; when the work affects roadmap shape, issue creation, backlog ordering, project placement, dependencies, or other project-management concerns, also prepare a concise TPM handoff so the main agent can delegate program-organization decisions to `tpm` before implementation.
 
-> ***Skill failures must be reported:*** If there is a logic error, script failure, or provenly incorrect guidance, the error must absolutely be reported to the orchestrating agent and user upon your return. If failure is from vstack skill/hook/extension/agent, ask orchestrating agent to consider reporting issue upstream at `github.com/vanillagreencom/vstack`.
+> ***Skill failures must be reported:*** If there is a logic error, script failure, or provenly incorrect guidance, report it to the orchestrating agent and user upon return. Only ask the orchestrating agent to consider filing at `github.com/vanillagreencom/vstack` when the failed asset is part of the VStack distribution: a canonical VStack agent, skill, hook, or Pi extension, or a skill whose metadata/repository explicitly identifies VStack/vanillagreen ownership. For non-VStack skills, report the failure to the orchestrator/user and use that skill's own upstream if known; do not route it to the VStack repo.
 
 ## Modification Boundaries
 

--- a/agents/researcher.md
+++ b/agents/researcher.md
@@ -11,7 +11,7 @@ color: purple
 
 Executes research issues and writes evidence-backed findings reports.
 
-> ***Skill failures must be reported:*** If there is a logic error, script failure, or provenly incorrect guidance, the error must absolutely be reported to the orchestrating agent and user upon your return. If failure is from vstack skill/hook/extension/agent, ask orchestrating agent to consider reporting issue upstream at `github.com/vanillagreencom/vstack`.
+> ***Skill failures must be reported:*** If there is a logic error, script failure, or provenly incorrect guidance, report it to the orchestrating agent and user upon return. Only ask the orchestrating agent to consider filing at `github.com/vanillagreencom/vstack` when the failed asset is part of the VStack distribution: a canonical VStack agent, skill, hook, or Pi extension, or a skill whose metadata/repository explicitly identifies VStack/vanillagreen ownership. For non-VStack skills, report the failure to the orchestrator/user and use that skill's own upstream if known; do not route it to the VStack repo.
 
 ## Ownership Boundaries
 

--- a/agents/reviewer-arch.md
+++ b/agents/reviewer-arch.md
@@ -13,7 +13,7 @@ color: yellow
 
 Review designs, score compliance, flag anti-patterns.
 
-> ***Skill failures must be reported:*** If there is a logic error, script failure, or provenly incorrect guidance, the error must absolutely be reported to the orchestrating agent and user upon your return. If failure is from vstack skill/hook/extension/agent, ask orchestrating agent to consider reporting issue upstream at `github.com/vanillagreencom/vstack`.
+> ***Skill failures must be reported:*** If there is a logic error, script failure, or provenly incorrect guidance, report it to the orchestrating agent and user upon return. Only ask the orchestrating agent to consider filing at `github.com/vanillagreencom/vstack` when the failed asset is part of the VStack distribution: a canonical VStack agent, skill, hook, or Pi extension, or a skill whose metadata/repository explicitly identifies VStack/vanillagreen ownership. For non-VStack skills, report the failure to the orchestrator/user and use that skill's own upstream if known; do not route it to the VStack repo.
 
 ## Focus Areas
 

--- a/agents/reviewer-correctness.md
+++ b/agents/reviewer-correctness.md
@@ -13,7 +13,7 @@ color: red
 
 Broad correctness reviewer. In diff/PR workflows, audit whether changed code preserves intended behavior, compatibility, feature visibility, and developer workflows. In codebase-review workflows, audit the scoped codebase for material existing correctness risks.
 
-> ***Skill failures must be reported:*** If there is a logic error, script failure, or provenly incorrect guidance, the error must absolutely be reported to the orchestrating agent and user upon your return. If failure is from vstack skill/hook/extension/agent, ask orchestrating agent to consider reporting issue upstream at `github.com/vanillagreencom/vstack`.
+> ***Skill failures must be reported:*** If there is a logic error, script failure, or provenly incorrect guidance, report it to the orchestrating agent and user upon return. Only ask the orchestrating agent to consider filing at `github.com/vanillagreencom/vstack` when the failed asset is part of the VStack distribution: a canonical VStack agent, skill, hook, or Pi extension, or a skill whose metadata/repository explicitly identifies VStack/vanillagreen ownership. For non-VStack skills, report the failure to the orchestrator/user and use that skill's own upstream if known; do not route it to the VStack repo.
 
 ## Focus Areas
 

--- a/agents/reviewer-doc.md
+++ b/agents/reviewer-doc.md
@@ -13,7 +13,7 @@ color: yellow
 
 Technical documentation reviewer ensuring docs accurately reflect implementation.
 
-> ***Skill failures must be reported:*** If there is a logic error, script failure, or provenly incorrect guidance, the error must absolutely be reported to the orchestrating agent and user upon your return. If failure is from vstack skill/hook/extension/agent, ask orchestrating agent to consider reporting issue upstream at `github.com/vanillagreencom/vstack`.
+> ***Skill failures must be reported:*** If there is a logic error, script failure, or provenly incorrect guidance, report it to the orchestrating agent and user upon return. Only ask the orchestrating agent to consider filing at `github.com/vanillagreencom/vstack` when the failed asset is part of the VStack distribution: a canonical VStack agent, skill, hook, or Pi extension, or a skill whose metadata/repository explicitly identifies VStack/vanillagreen ownership. For non-VStack skills, report the failure to the orchestrator/user and use that skill's own upstream if known; do not route it to the VStack repo.
 
 ## Focus Areas
 

--- a/agents/reviewer-error.md
+++ b/agents/reviewer-error.md
@@ -13,7 +13,7 @@ color: orange
 
 Audits error handling for silent failures and inadequate error management.
 
-> ***Skill failures must be reported:*** If there is a logic error, script failure, or provenly incorrect guidance, the error must absolutely be reported to the orchestrating agent and user upon your return. If failure is from vstack skill/hook/extension/agent, ask orchestrating agent to consider reporting issue upstream at `github.com/vanillagreencom/vstack`.
+> ***Skill failures must be reported:*** If there is a logic error, script failure, or provenly incorrect guidance, report it to the orchestrating agent and user upon return. Only ask the orchestrating agent to consider filing at `github.com/vanillagreencom/vstack` when the failed asset is part of the VStack distribution: a canonical VStack agent, skill, hook, or Pi extension, or a skill whose metadata/repository explicitly identifies VStack/vanillagreen ownership. For non-VStack skills, report the failure to the orchestrator/user and use that skill's own upstream if known; do not route it to the VStack repo.
 
 ## Focus Areas
 

--- a/agents/reviewer-perf.md
+++ b/agents/reviewer-perf.md
@@ -13,7 +13,7 @@ color: red
 
 Validate performance, detect regressions, run benchmarks.
 
-> ***Skill failures must be reported:*** If there is a logic error, script failure, or provenly incorrect guidance, the error must absolutely be reported to the orchestrating agent and user upon your return. If failure is from vstack skill/hook/extension/agent, ask orchestrating agent to consider reporting issue upstream at `github.com/vanillagreencom/vstack`.
+> ***Skill failures must be reported:*** If there is a logic error, script failure, or provenly incorrect guidance, report it to the orchestrating agent and user upon return. Only ask the orchestrating agent to consider filing at `github.com/vanillagreencom/vstack` when the failed asset is part of the VStack distribution: a canonical VStack agent, skill, hook, or Pi extension, or a skill whose metadata/repository explicitly identifies VStack/vanillagreen ownership. For non-VStack skills, report the failure to the orchestrator/user and use that skill's own upstream if known; do not route it to the VStack repo.
 
 ## Focus Areas
 

--- a/agents/reviewer-quality.md
+++ b/agents/reviewer-quality.md
@@ -13,7 +13,7 @@ color: purple
 
 Strict maintainability reviewer. In diff/PR workflows, audit the changed implementation shape. In codebase-review workflows, audit the scoped codebase for material maintainability issues. In both modes, judge whether the code is simple, direct, easy to reason about, and aligned with the existing codebase.
 
-> ***Skill failures must be reported:*** If there is a logic error, script failure, or provenly incorrect guidance, the error must absolutely be reported to the orchestrating agent and user upon your return. If failure is from vstack skill/hook/extension/agent, ask orchestrating agent to consider reporting issue upstream at `github.com/vanillagreencom/vstack`.
+> ***Skill failures must be reported:*** If there is a logic error, script failure, or provenly incorrect guidance, report it to the orchestrating agent and user upon return. Only ask the orchestrating agent to consider filing at `github.com/vanillagreencom/vstack` when the failed asset is part of the VStack distribution: a canonical VStack agent, skill, hook, or Pi extension, or a skill whose metadata/repository explicitly identifies VStack/vanillagreen ownership. For non-VStack skills, report the failure to the orchestrator/user and use that skill's own upstream if known; do not route it to the VStack repo.
 
 ## Focus Areas
 

--- a/agents/reviewer-safety.md
+++ b/agents/reviewer-safety.md
@@ -13,7 +13,7 @@ color: red
 
 Audit safety, run verification tools, report violations with locations and remediation guidance.
 
-> ***Skill failures must be reported:*** If there is a logic error, script failure, or provenly incorrect guidance, the error must absolutely be reported to the orchestrating agent and user upon your return. If failure is from vstack skill/hook/extension/agent, ask orchestrating agent to consider reporting issue upstream at `github.com/vanillagreencom/vstack`.
+> ***Skill failures must be reported:*** If there is a logic error, script failure, or provenly incorrect guidance, report it to the orchestrating agent and user upon return. Only ask the orchestrating agent to consider filing at `github.com/vanillagreencom/vstack` when the failed asset is part of the VStack distribution: a canonical VStack agent, skill, hook, or Pi extension, or a skill whose metadata/repository explicitly identifies VStack/vanillagreen ownership. For non-VStack skills, report the failure to the orchestrator/user and use that skill's own upstream if known; do not route it to the VStack repo.
 
 ## Focus Areas
 

--- a/agents/reviewer-security.md
+++ b/agents/reviewer-security.md
@@ -13,7 +13,7 @@ color: red
 
 Application security reviewer for OWASP vulnerabilities. Different from `safety` agent (memory/thread safety).
 
-> ***Skill failures must be reported:*** If there is a logic error, script failure, or provenly incorrect guidance, the error must absolutely be reported to the orchestrating agent and user upon your return. If failure is from vstack skill/hook/extension/agent, ask orchestrating agent to consider reporting issue upstream at `github.com/vanillagreencom/vstack`.
+> ***Skill failures must be reported:*** If there is a logic error, script failure, or provenly incorrect guidance, report it to the orchestrating agent and user upon return. Only ask the orchestrating agent to consider filing at `github.com/vanillagreencom/vstack` when the failed asset is part of the VStack distribution: a canonical VStack agent, skill, hook, or Pi extension, or a skill whose metadata/repository explicitly identifies VStack/vanillagreen ownership. For non-VStack skills, report the failure to the orchestrator/user and use that skill's own upstream if known; do not route it to the VStack repo.
 
 ## Focus Areas
 

--- a/agents/reviewer-structure.md
+++ b/agents/reviewer-structure.md
@@ -13,7 +13,7 @@ color: cyan
 
 Structural lint for code organization.
 
-> ***Skill failures must be reported:*** If there is a logic error, script failure, or provenly incorrect guidance, the error must absolutely be reported to the orchestrating agent and user upon your return. If failure is from vstack skill/hook/extension/agent, ask orchestrating agent to consider reporting issue upstream at `github.com/vanillagreencom/vstack`.
+> ***Skill failures must be reported:*** If there is a logic error, script failure, or provenly incorrect guidance, report it to the orchestrating agent and user upon return. Only ask the orchestrating agent to consider filing at `github.com/vanillagreencom/vstack` when the failed asset is part of the VStack distribution: a canonical VStack agent, skill, hook, or Pi extension, or a skill whose metadata/repository explicitly identifies VStack/vanillagreen ownership. For non-VStack skills, report the failure to the orchestrator/user and use that skill's own upstream if known; do not route it to the VStack repo.
 
 ## Focus Areas
 

--- a/agents/reviewer-test.md
+++ b/agents/reviewer-test.md
@@ -13,7 +13,7 @@ color: blue
 
 QA specialist for test coverage gaps. Domain agents write tests; this agent audits adequacy.
 
-> ***Skill failures must be reported:*** If there is a logic error, script failure, or provenly incorrect guidance, the error must absolutely be reported to the orchestrating agent and user upon your return. If failure is from vstack skill/hook/extension/agent, ask orchestrating agent to consider reporting issue upstream at `github.com/vanillagreencom/vstack`.
+> ***Skill failures must be reported:*** If there is a logic error, script failure, or provenly incorrect guidance, report it to the orchestrating agent and user upon return. Only ask the orchestrating agent to consider filing at `github.com/vanillagreencom/vstack` when the failed asset is part of the VStack distribution: a canonical VStack agent, skill, hook, or Pi extension, or a skill whose metadata/repository explicitly identifies VStack/vanillagreen ownership. For non-VStack skills, report the failure to the orchestrator/user and use that skill's own upstream if known; do not route it to the VStack repo.
 
 ## Focus Areas
 

--- a/agents/rust.md
+++ b/agents/rust.md
@@ -11,7 +11,7 @@ color: orange
 
 Implements performance-critical Rust code. Focus: zero allocations, lock-free structures, measurable latency targets.
 
-> ***Skill failures must be reported:*** If there is a logic error, script failure, or provenly incorrect guidance, the error must absolutely be reported to the orchestrating agent and user upon your return. If failure is from vstack skill/hook/extension/agent, ask orchestrating agent to consider reporting issue upstream at `github.com/vanillagreencom/vstack`.
+> ***Skill failures must be reported:*** If there is a logic error, script failure, or provenly incorrect guidance, report it to the orchestrating agent and user upon return. Only ask the orchestrating agent to consider filing at `github.com/vanillagreencom/vstack` when the failed asset is part of the VStack distribution: a canonical VStack agent, skill, hook, or Pi extension, or a skill whose metadata/repository explicitly identifies VStack/vanillagreen ownership. For non-VStack skills, report the failure to the orchestrator/user and use that skill's own upstream if known; do not route it to the VStack repo.
 
 ## Capabilities
 

--- a/agents/scout.md
+++ b/agents/scout.md
@@ -11,7 +11,7 @@ color: cyan
 
 You are a file-search and reconnaissance specialist. Your job is to discover the smallest useful set of facts another agent needs to act confidently without repeating your search.
 
-> ***Skill failures must be reported:*** If there is a logic error, script failure, or provenly incorrect guidance, the error must absolutely be reported to the orchestrating agent and user upon your return. If failure is from vstack skill/hook/extension/agent, ask orchestrating agent to consider reporting issue upstream at `github.com/vanillagreencom/vstack`.
+> ***Skill failures must be reported:*** If there is a logic error, script failure, or provenly incorrect guidance, report it to the orchestrating agent and user upon return. Only ask the orchestrating agent to consider filing at `github.com/vanillagreencom/vstack` when the failed asset is part of the VStack distribution: a canonical VStack agent, skill, hook, or Pi extension, or a skill whose metadata/repository explicitly identifies VStack/vanillagreen ownership. For non-VStack skills, report the failure to the orchestrator/user and use that skill's own upstream if known; do not route it to the VStack repo.
 
 ## Report-Only Contract
 

--- a/agents/tpm.md
+++ b/agents/tpm.md
@@ -11,7 +11,7 @@ color: blue
 
 Analyzes project lifecycle, roadmaps, and cycle planning. Report findings only.
 
-> ***Skill failures must be reported:*** If there is a logic error, script failure, or provenly incorrect guidance, the error must absolutely be reported to the orchestrating agent and user upon your return. If failure is from vstack skill/hook/extension/agent, ask orchestrating agent to consider reporting issue upstream at `github.com/vanillagreencom/vstack`.
+> ***Skill failures must be reported:*** If there is a logic error, script failure, or provenly incorrect guidance, report it to the orchestrating agent and user upon return. Only ask the orchestrating agent to consider filing at `github.com/vanillagreencom/vstack` when the failed asset is part of the VStack distribution: a canonical VStack agent, skill, hook, or Pi extension, or a skill whose metadata/repository explicitly identifies VStack/vanillagreen ownership. For non-VStack skills, report the failure to the orchestrator/user and use that skill's own upstream if known; do not route it to the VStack repo.
 
 ## Capabilities
 

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -82,13 +82,17 @@ fn init_skill(name: &str) -> Result<()> {
         return Ok(());
     }
     std::fs::create_dir_all(&dir)?;
-    let body = format!(
-        "---\nname: {name}\ndescription: TODO — describe this skill\nlicense: MIT\n---\n\n# {title}\n\nTODO — skill instructions.\n",
-        title = title_case(name),
-    );
+    let body = skill_body(name);
     std::fs::write(dir.join("SKILL.md"), body)?;
     eprintln!("Created skill: {}/SKILL.md", dir.display());
     Ok(())
+}
+
+fn skill_body(name: &str) -> String {
+    format!(
+        "---\nname: {name}\ndescription: TODO — describe this skill\nlicense: MIT\nuser-invocable: true\n# dependencies:\n#   required: [skill-a, skill-b]\n#   optional: [skill-c]\nmetadata:\n  author: your-name\n  # source: your-project\n  # repository: \"https://github.com/owner/repo\"\n  # bugs: \"https://github.com/owner/repo/issues\"\n  version: \"1.0.0\"\n---\n\n# {title}\n\nTODO — skill instructions.\n",
+        title = title_case(name),
+    )
 }
 
 fn init_hook(name: &str) -> Result<()> {
@@ -145,6 +149,17 @@ mod tests {
         assert_eq!(title_case("foo-bar"), "Foo Bar");
         assert_eq!(title_case("rust"), "Rust");
         assert_eq!(title_case(""), "");
+    }
+
+    #[test]
+    fn skill_scaffold_includes_ownership_metadata_guidance() {
+        let body = skill_body("my-skill");
+
+        assert!(body.contains("user-invocable: true"));
+        assert!(body.contains("metadata:\n  author: your-name"));
+        assert!(body.contains("  # source: your-project"));
+        assert!(body.contains("  # repository: \"https://github.com/owner/repo\""));
+        assert!(body.contains("  # bugs: \"https://github.com/owner/repo/issues\""));
     }
 
     #[test]

--- a/skill-templates/SKILL.md.template
+++ b/skill-templates/SKILL.md.template
@@ -7,7 +7,10 @@ user-invocable: true
 #   required: [skill-a, skill-b]
 #   optional: [skill-c]
 metadata:
-  author: vanillagreen
+  author: your-name
+  # source: your-project
+  # repository: "https://github.com/owner/repo"
+  # bugs: "https://github.com/owner/repo/issues"
   version: "1.0.0"
 ---
 

--- a/skills/decider/SKILL.md
+++ b/skills/decider/SKILL.md
@@ -5,6 +5,9 @@ license: MIT
 user-invocable: true
 metadata:
   author: vanillagreen
+  source: vstack
+  repository: "https://github.com/vanillagreencom/vstack"
+  bugs: "https://github.com/vanillagreencom/vstack/issues"
   version: "1.0.0"
 ---
 

--- a/skills/deep-research/SKILL.md
+++ b/skills/deep-research/SKILL.md
@@ -8,6 +8,9 @@ dependencies:
   optional: [decider]
 metadata:
   author: vanillagreen
+  source: vstack
+  repository: "https://github.com/vanillagreencom/vstack"
+  bugs: "https://github.com/vanillagreencom/vstack/issues"
   version: "1.0.0"
 ---
 

--- a/skills/dev/SKILL.md
+++ b/skills/dev/SKILL.md
@@ -8,6 +8,9 @@ dependencies:
   optional: [linear]
 metadata:
   author: vanillagreen
+  source: vstack
+  repository: "https://github.com/vanillagreencom/vstack"
+  bugs: "https://github.com/vanillagreencom/vstack/issues"
   version: "1.2.0"
 ---
 

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -5,6 +5,9 @@ license: MIT
 user-invocable: true
 metadata:
   author: vanillagreen
+  source: vstack
+  repository: "https://github.com/vanillagreencom/vstack"
+  bugs: "https://github.com/vanillagreencom/vstack/issues"
   version: "1.0.0"
 ---
 

--- a/skills/html-artifact/SKILL.md
+++ b/skills/html-artifact/SKILL.md
@@ -6,6 +6,9 @@ user-invocable: true
 argument-hint: "<artifact request>"
 metadata:
   author: vanillagreen
+  source: vstack
+  repository: "https://github.com/vanillagreencom/vstack"
+  bugs: "https://github.com/vanillagreencom/vstack/issues"
   version: "1.0.0"
 ---
 

--- a/skills/iced-rs/SKILL.md
+++ b/skills/iced-rs/SKILL.md
@@ -5,6 +5,9 @@ license: MIT
 user-invocable: true
 metadata:
   author: vanillagreen
+  source: vstack
+  repository: "https://github.com/vanillagreencom/vstack"
+  bugs: "https://github.com/vanillagreencom/vstack/issues"
   version: "3.0.0"
 ---
 

--- a/skills/iced-shadcn/SKILL.md
+++ b/skills/iced-shadcn/SKILL.md
@@ -6,6 +6,9 @@ dependencies:
   required: [iced-rs]
 metadata:
   author: vanillagreen
+  source: vstack
+  repository: "https://github.com/vanillagreencom/vstack"
+  bugs: "https://github.com/vanillagreencom/vstack/issues"
   version: "1.0.0"
 ---
 

--- a/skills/linear/SKILL.md
+++ b/skills/linear/SKILL.md
@@ -5,6 +5,9 @@ license: MIT
 user-invocable: true
 metadata:
   author: vanillagreen
+  source: vstack
+  repository: "https://github.com/vanillagreencom/vstack"
+  bugs: "https://github.com/vanillagreencom/vstack/issues"
   version: "1.0.0"
 ---
 

--- a/skills/orch/SKILL.md
+++ b/skills/orch/SKILL.md
@@ -8,6 +8,9 @@ dependencies:
   optional: [linear]
 metadata:
   author: vanillagreen
+  source: vstack
+  repository: "https://github.com/vanillagreencom/vstack"
+  bugs: "https://github.com/vanillagreencom/vstack/issues"
   version: "2.0.0"
 ---
 

--- a/skills/price-handling/SKILL.md
+++ b/skills/price-handling/SKILL.md
@@ -5,6 +5,9 @@ license: MIT
 user-invocable: true
 metadata:
   author: vanillagreen
+  source: vstack
+  repository: "https://github.com/vanillagreencom/vstack"
+  bugs: "https://github.com/vanillagreencom/vstack/issues"
   version: "1.0.0"
 ---
 

--- a/skills/project-management/SKILL.md
+++ b/skills/project-management/SKILL.md
@@ -8,6 +8,9 @@ dependencies:
   optional: [decider]
 metadata:
   author: vanillagreen
+  source: vstack
+  repository: "https://github.com/vanillagreencom/vstack"
+  bugs: "https://github.com/vanillagreencom/vstack/issues"
   version: "2.0.0"
 ---
 

--- a/skills/reviewer/SKILL.md
+++ b/skills/reviewer/SKILL.md
@@ -5,6 +5,9 @@ license: MIT
 user-invocable: true
 metadata:
   author: vanillagreen
+  source: vstack
+  repository: "https://github.com/vanillagreencom/vstack"
+  bugs: "https://github.com/vanillagreencom/vstack/issues"
   version: "1.0.0"
 ---
 

--- a/skills/second-opinion/SKILL.md
+++ b/skills/second-opinion/SKILL.md
@@ -6,6 +6,9 @@ user-invocable: true
 argument-hint: "review [scope] | challenge [description] | audit [path] | quick [question]"
 metadata:
   author: vanillagreen
+  source: vstack
+  repository: "https://github.com/vanillagreencom/vstack"
+  bugs: "https://github.com/vanillagreencom/vstack/issues"
   version: "1.0.0"
 ---
 

--- a/skills/trading-design/SKILL.md
+++ b/skills/trading-design/SKILL.md
@@ -5,6 +5,9 @@ license: MIT
 user-invocable: true
 metadata:
   author: vanillagreen
+  source: vstack
+  repository: "https://github.com/vanillagreencom/vstack"
+  bugs: "https://github.com/vanillagreencom/vstack/issues"
   version: "2.0.0"
 ---
 

--- a/skills/worktree/SKILL.md
+++ b/skills/worktree/SKILL.md
@@ -6,6 +6,9 @@ user-invocable: true
 argument-hint: "create <ID> [--base <branch>] [--from <ref>] [--pr <N>] | list | remove <ID|path>"
 metadata:
   author: vanillagreen
+  source: vstack
+  repository: "https://github.com/vanillagreencom/vstack"
+  bugs: "https://github.com/vanillagreencom/vstack/issues"
   version: "1.0.0"
 ---
 


### PR DESCRIPTION
## Summary
- Narrowed canonical agent skill-failure guidance so only VStack-owned agents, skills, hooks, and Pi extensions point to the VStack issue tracker.
- Added explicit `source`, `repository`, and `bugs` metadata to shipped VStack skills.
- Updated the skill template and `vstack init --kind skill` scaffold so future skills expose ownership/upstream routing clearly.

## Context
- No linked decisions found.

## Completed Issues
- Closes #435 - Clarify skill-failure reporting for non-VStack skills

## Test Plan
- `git diff --check`
- `cd cli && cargo fmt --check`
- `cd cli && cargo test`
- Tmp init smoke: `vstack init example-skill --kind skill` generated SKILL.md with ownership metadata guidance.
- Internal reviewer fanout: reviewer-arch, reviewer-correctness, reviewer-doc, reviewer-error, reviewer-perf, reviewer-quality, reviewer-safety, reviewer-security, reviewer-structure, reviewer-test all passed.
- CI: CodeQL checks passed on PR #437.
