### PR TITLE
fix(issue-447): make on-disk artifact the sole review-pr completion condition

### DIFF
--- a/skills/orch/DEVELOPMENT.md
+++ b/skills/orch/DEVELOPMENT.md
@@ -53,6 +53,7 @@ Tests stage isolated repos/worktrees with parametrized CLI stubs on `PATH`. Each
 - `bot_review_wait.sh` — review-wait state machine + auth ladder.
 - `ci_wait.sh` — CI-wait state machine + auth ladder.
 - `session_init.sh` — worktree Linear auth diagnostic preservation.
+- `review_artifact_check.sh` — deterministic reviewer artifact acceptance (`review-artifact-check`) + review-pr wiring assertions.
 
 ## Codex App Worktree Routing
 

--- a/skills/orch/README.md
+++ b/skills/orch/README.md
@@ -82,6 +82,8 @@ Use `skills/orch/scripts/pr-view-json WORKTREE_PATH --json number,state` when a 
 
 Use `skills/orch/scripts/review-init` to initialize standalone review context and print branch, worktree, issue ID, state path, and whether state was created as JSON.
 
+Use `skills/orch/scripts/review-artifact-check WORKTREE_PATH AGENT_NAME DELEGATED_AT_EPOCH` to deterministically validate a reviewer's on-disk JSON artifact (existence, `mtime >=` delegation epoch, `jq -e '.verdict'`). It prints `{ok, path, reason}`; review-pr accepts a reviewer completion only when `ok == true`.
+
 Use `skills/orch/scripts/tracker-for-issue ISSUE_ID` when workflow docs need tracker branching without inline shell conditionals.
 
 ## System Dependencies

--- a/skills/orch/SKILL.md
+++ b/skills/orch/SKILL.md
@@ -150,6 +150,7 @@ Follow ALL [Workflow Execution](#workflow-execution) rules for every command.
 | `pr-view-json` | Print PR view JSON and return success for expected `status=no_pr` so workflows can route to PR creation without shell fallback expressions |
 | `resolve-base-branch` | Print the worktree base branch (`WORKTREE_DEFAULT_BRANCH`, remote HEAD, or `main`) |
 | `review-init` | Initialize standalone review context and print branch/worktree/issue/state JSON |
+| `review-artifact-check` | Validate a reviewer's on-disk JSON artifact (exists, `mtime >=` delegation epoch, `jq -e '.verdict'`) and print `{ok, path, reason}` — the sole review-pr completion condition |
 | `tracker-for-issue` | Print `github` for `issue-*` ids and `linear` otherwise |
 | `bot-review-wait` | Block until bot review posts on a PR — invoked by per-issue agents inside their submit-pr flow |
 | `ci-wait` | Block until CI completes on a PR — same |

--- a/skills/orch/schemas/workflow-state.md
+++ b/skills/orch/schemas/workflow-state.md
@@ -89,7 +89,7 @@ Persistent state file for orch workflows. Survives context compaction.
 | `skip_qa` | boolean | Skip QA for re-cycle (cleared after routing) |
 | `cycles` | number | Review/fix cycle count |
 | `submit_cycles` | number | Submit-PR iteration count (bot review/CI loops) |
-| `review_delegated_at` | number | Epoch seconds of last review delegation — gates the § 3 filesystem-fallback watchdog |
+| `review_delegated_at` | number | Epoch seconds of last review delegation — gates § 3 `review-artifact-check` artifact acceptance |
 | `review_skipped` | string | Set to `tiny-docs` when the user takes the tiny/docs-only review skip path |
 | `json_paths` | string[] | Accumulated review JSON file paths |
 | `fixed_items` | object[] | Blockers successfully fixed |

--- a/skills/orch/scripts/review-artifact-check
+++ b/skills/orch/scripts/review-artifact-check
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Deterministically validate a reviewer's on-disk JSON artifact for review-pr
+# acceptance. A reviewer completion is only real when
+# [WORKTREE]/tmp/review-[AGENT]-*.json exists, is newer than the delegation
+# timestamp, and satisfies `jq -e '.verdict'` — return-message prose alone
+# never counts.
+
+set -euo pipefail
+
+usage() {
+  cat >&2 << 'EOF'
+Usage: review-artifact-check <worktree_path> <agent_name> <delegated_at_epoch>
+
+Checks [WORKTREE]/tmp/review-[AGENT]-*.json newest-first and prints JSON:
+  {ok: bool, path: string|null, reason: "valid"|"missing"|"stale"|"invalid"}
+
+reason meanings when ok=false:
+  missing  no review-[AGENT]-*.json files found
+  stale    newest artifact mtime < delegated_at_epoch
+  invalid  newest fresh artifact fails `jq -e '.verdict'`
+
+Exit 0 when a valid artifact was found, 1 otherwise, 2 on usage error.
+EOF
+}
+
+if [[ $# -ne 3 ]]; then
+  usage
+  exit 2
+fi
+
+worktree="$1"
+agent="$2"
+delegated_at="$3"
+
+if [[ ! -d "$worktree" ]]; then
+  echo "Error: worktree path '$worktree' is not a directory" >&2
+  exit 2
+fi
+if [[ -z "$agent" ]]; then
+  echo "Error: agent_name must be non-empty" >&2
+  exit 2
+fi
+if ! [[ "$delegated_at" =~ ^[0-9]+$ ]]; then
+  echo "Error: delegated_at_epoch must be epoch seconds, got '$delegated_at'" >&2
+  exit 2
+fi
+
+emit() {
+  local ok="$1" path="$2" reason="$3"
+  jq -n --argjson ok "$ok" --arg path "$path" --arg reason "$reason" \
+    '{ok: $ok, path: (if $path == "" then null else $path end), reason: $reason}'
+}
+
+file_mtime() {
+  stat -c %Y "$1" 2>/dev/null || stat -f %m "$1"
+}
+
+reason="missing"
+fail_path=""
+
+while IFS= read -r file; do
+  [[ -n "$file" ]] || continue
+  mtime="$(file_mtime "$file")"
+  if (( mtime < delegated_at )); then
+    if [[ -z "$fail_path" ]]; then
+      fail_path="$file"
+      reason="stale"
+    fi
+    continue
+  fi
+  if ! jq -e '.verdict' "$file" >/dev/null 2>&1; then
+    if [[ -z "$fail_path" ]]; then
+      fail_path="$file"
+      reason="invalid"
+    fi
+    continue
+  fi
+  emit true "$file" "valid"
+  exit 0
+done < <(ls -1t "$worktree/tmp/review-$agent-"*.json 2>/dev/null)
+
+emit false "$fail_path" "$reason"
+exit 1

--- a/skills/orch/tests/review_artifact_check.sh
+++ b/skills/orch/tests/review_artifact_check.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Regression tests for review-artifact-check: deterministic on-disk acceptance
+# of reviewer JSON artifacts in the orch review-pr workflow.
+
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../.." && pwd)"
+CHECK="$REPO_ROOT/skills/orch/scripts/review-artifact-check"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local got="$1" want="$2" name="$3"
+  if [[ "$got" == "$want" ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$name" "$want" "$got"
+  fi
+}
+
+assert_file_contains() {
+  local file="$1" pattern="$2" name="$3"
+  if grep -Fq -- "$pattern" "$file"; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        missing pattern: %s\n        file: %s\n' "$name" "$pattern" "$file"
+  fi
+}
+
+assert_file_not_contains() {
+  local file="$1" pattern="$2" name="$3"
+  if grep -Fq -- "$pattern" "$file"; then
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        unexpected pattern: %s\n        file: %s\n' "$name" "$pattern" "$file"
+  else
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  fi
+}
+
+echo "=== review-artifact-check ==="
+
+worktree="$TMP_ROOT/wt"
+mkdir -p "$worktree/tmp"
+delegated_at=1750000000
+before=$((delegated_at - 100))
+after=$((delegated_at + 100))
+later=$((delegated_at + 200))
+
+# --- missing: no artifacts at all ---
+set +e
+out="$("$CHECK" "$worktree" reviewer-quality "$delegated_at")"
+rc=$?
+set -e
+assert_eq "$rc" "1" "missing artifact exits 1"
+assert_eq "$(jq -r '.ok' <<<"$out")" "false" "missing artifact reports ok=false"
+assert_eq "$(jq -r '.path' <<<"$out")" "null" "missing artifact reports null path"
+assert_eq "$(jq -r '.reason' <<<"$out")" "missing" "missing artifact reports reason=missing"
+
+# --- other agent's artifact does not count ---
+other="$worktree/tmp/review-reviewer-arch-20260709-010101.json"
+printf '{"verdict":"pass","items":[]}' > "$other"
+touch -d "@$after" "$other"
+set +e
+out="$("$CHECK" "$worktree" reviewer-quality "$delegated_at")"
+rc=$?
+set -e
+assert_eq "$rc" "1" "other agent's artifact exits 1"
+assert_eq "$(jq -r '.reason' <<<"$out")" "missing" "other agent's artifact still reason=missing"
+
+# --- stale: artifact predates delegation ---
+stale="$worktree/tmp/review-reviewer-quality-20260709-010101.json"
+printf '{"verdict":"pass","items":[]}' > "$stale"
+touch -d "@$before" "$stale"
+set +e
+out="$("$CHECK" "$worktree" reviewer-quality "$delegated_at")"
+rc=$?
+set -e
+assert_eq "$rc" "1" "stale artifact exits 1"
+assert_eq "$(jq -r '.ok' <<<"$out")" "false" "stale artifact reports ok=false"
+assert_eq "$(jq -r '.path' <<<"$out")" "$stale" "stale artifact reports its path"
+assert_eq "$(jq -r '.reason' <<<"$out")" "stale" "stale artifact reports reason=stale"
+
+# --- invalid: fresh artifact without verdict field ---
+invalid="$worktree/tmp/review-reviewer-quality-20260709-020202.json"
+printf '{"items":[]}' > "$invalid"
+touch -d "@$after" "$invalid"
+set +e
+out="$("$CHECK" "$worktree" reviewer-quality "$delegated_at")"
+rc=$?
+set -e
+assert_eq "$rc" "1" "fresh artifact missing verdict exits 1"
+assert_eq "$(jq -r '.reason' <<<"$out")" "invalid" "fresh artifact missing verdict reports reason=invalid"
+assert_eq "$(jq -r '.path' <<<"$out")" "$invalid" "invalid report points at newest fresh artifact"
+
+# --- valid: fresh artifact with verdict wins over stale/invalid siblings ---
+valid="$worktree/tmp/review-reviewer-quality-20260709-030303.json"
+printf '{"verdict":"action_required","items":[{"category":"fix"}]}' > "$valid"
+touch -d "@$later" "$valid"
+out="$("$CHECK" "$worktree" reviewer-quality "$delegated_at")"
+assert_eq "$(jq -r '.ok' <<<"$out")" "true" "valid fresh artifact reports ok=true"
+assert_eq "$(jq -r '.path' <<<"$out")" "$valid" "valid fresh artifact reports its path"
+assert_eq "$(jq -r '.reason' <<<"$out")" "valid" "valid fresh artifact reports reason=valid"
+
+# --- newest artifact invalid: falls back to older fresh valid artifact ---
+newest_invalid="$worktree/tmp/review-reviewer-quality-20260709-040404.json"
+printf 'not json' > "$newest_invalid"
+touch -d "@$((later + 100))" "$newest_invalid"
+out="$("$CHECK" "$worktree" reviewer-quality "$delegated_at")"
+assert_eq "$(jq -r '.ok' <<<"$out")" "true" "newest-invalid falls back to older valid artifact"
+assert_eq "$(jq -r '.path' <<<"$out")" "$valid" "fallback selects the older fresh valid artifact"
+
+# --- usage errors ---
+set +e
+"$CHECK" "$worktree" reviewer-quality >/dev/null 2>&1
+assert_eq "$?" "2" "missing arguments exit 2"
+"$CHECK" "$worktree" reviewer-quality not-a-number >/dev/null 2>&1
+assert_eq "$?" "2" "non-numeric delegated_at exits 2"
+"$CHECK" "$TMP_ROOT/does-not-exist" reviewer-quality "$delegated_at" >/dev/null 2>&1
+assert_eq "$?" "2" "nonexistent worktree exits 2"
+set -e
+
+# --- review-pr.md wires the deterministic acceptance ---
+review_pr="$REPO_ROOT/skills/orch/workflows/review-pr.md"
+assert_file_contains "$review_pr" ".agents/skills/orch/scripts/review-artifact-check [WORKTREE_PATH] [AGENT]" "review-pr acceptance runs review-artifact-check"
+assert_file_not_contains "$review_pr" 'A return message arrives with `Verdict:` and `File:` lines, *or*' "review-pr no longer accepts return-message-only completion"
+assert_file_contains "$review_pr" "a return message with \`Verdict:\`/\`File:\` lines is never sufficient by itself" "review-pr states artifact is the only acceptance condition"
+assert_file_contains "$review_pr" "exactly one" "review-pr limits incomplete returns to one re-delegation"
+assert_file_contains "$review_pr" "using your harness file-write tool" "review-pr re-delegation instructs harness file-write tool"
+
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/skills/orch/workflows/review-pr.md
+++ b/skills/orch/workflows/review-pr.md
@@ -129,7 +129,7 @@ After launch/reuse, store the active reviewer set:
 .agents/skills/orch/scripts/workflow-state set [ISSUE_ID] review_agent_runtime_types '[AGENT_RUNTIME_TYPE_MAP_JSON]'
 ```
 
-**Record delegation timestamp immediately before the actual delegation batch** — gates the § 3 watchdog filesystem fallback against stale JSONs from earlier cycles and output produced during reviewer spawn/bootstrap:
+**Record delegation timestamp immediately before the actual delegation batch** — gates § 3.1 `review-artifact-check` acceptance against stale JSONs from earlier cycles and output produced during reviewer spawn/bootstrap:
 ```bash
 .agents/skills/orch/scripts/workflow-state set-now [ISSUE_ID] review_delegated_at
 ```
@@ -189,14 +189,25 @@ Do NOT shutdown reviewers — needed for re-review in § 4.
 
 ### 3.1 Completion
 
-`OUTSTANDING = [AGENTS] ∪ ({external} if EXTERNAL_REVIEW_REQUESTED)`. An agent completes when *either*:
-- A return message arrives with `Verdict:` and `File:` lines, *or*
-- Latest `[WORKTREE_PATH]/tmp/review-[AGENT]-*.json` with `mtime >= review_delegated_at` validates with `jq -e '.verdict'`
+`OUTSTANDING = [AGENTS] ∪ ({external} if EXTERNAL_REVIEW_REQUESTED)`. An agent completes **only** when its on-disk artifact validates — a return message with `Verdict:`/`File:` lines is never sufficient by itself. Check deterministically:
 
-On completion, append and drop from `OUTSTANDING`:
+```bash
+.agents/skills/orch/scripts/workflow-state get [ISSUE_ID] .review_delegated_at
+.agents/skills/orch/scripts/review-artifact-check [WORKTREE_PATH] [AGENT] [REVIEW_DELEGATED_AT_FROM_PREVIOUS_COMMAND]
+```
+
+Run `review-artifact-check` on every return message and every watchdog sweep. It prints `{ok, path, reason}` after validating existence, `mtime >= review_delegated_at`, and `jq -e '.verdict'`.
+
+**If `ok == true`** — the agent is complete. Append `path` and drop from `OUTSTANDING`:
 ```bash
 .agents/skills/orch/scripts/workflow-state append [ISSUE_ID] json_paths "[PATH]"
 ```
+
+**If `ok == false` after a return message** — the return is **incomplete** (even if its `File:` path looks valid or the message body contains JSON). Send that agent **exactly one** re-delegation:
+
+> Your review return is incomplete: `review-artifact-check` reports `[reason]` for `[WORKTREE_PATH]/tmp/review-[AGENT]-*.json`. Write your full review JSON to `[WORKTREE_PATH]/tmp/review-[AGENT]-YYYYMMDD-HHMMSS.json` using your harness file-write tool (not shell redirection), then return `Verdict:` and `File:` again.
+
+If `review-artifact-check` still reports `ok == false` after the re-delegation return (or the agent hits its § 3.2 deadline), mark the agent `unresponsive` — do not re-delegate a second time.
 
 ### 3.2 Watchdog Rules
 
@@ -208,7 +219,7 @@ Per-agent deadline from `review_delegated_at`:
 
 | Event | Action |
 |-------|--------|
-| Return arrives | Append JSON, remove from `OUTSTANDING`. |
+| Return arrives | Run `review-artifact-check` (§ 3.1). `ok == true` → append `path`, remove from `OUTSTANDING`. `ok == false` → one re-delegation per § 3.1. |
 | 2 min after first return (or 10 min from delegation if zero returns yet) — once per cycle | Send each outstanding agent one ping: `Status check on [ISSUE_ID] review — return your verdict if complete, or report blocker.` |
 | 2 min after ping | Mark each non-perf agent still in `OUTSTANDING` as `unresponsive`. |
 | Per-agent deadline reached | Mark that agent `unresponsive`. |


### PR DESCRIPTION
## Summary
- Make the on-disk validated JSON artifact the **only** acceptance condition for a reviewer return in `orch review-pr` — removes the ambiguous "Verdict:/File: message OR file" branch that let agents "complete" a review without ever writing the durable artifact (breaking compaction recovery).
- Add deterministic helper `skills/orch/scripts/review-artifact-check <worktree> <agent> <delegated_at_epoch>` that validates existence, `mtime >= delegated_at`, and `jq -e '.verdict'`, printing `{ok, path, reason}`. Orchestrators run one command instead of interpreting prose.
- A `Verdict:` return whose artifact fails validation is treated as incomplete and triggers exactly one re-delegation instructing the agent to write the file with its harness file-write tool.

## Completed Issues
- Closes #447

## Test Plan
- New self-contained suite `skills/orch/tests/review_artifact_check.sh` (missing/stale/invalid/valid, other-agent isolation, newest-invalid fallback, usage exit codes, review-pr.md wiring assertions).
- `bash skills/orch/tests/run-all.sh` — all 6 files pass.
