### PR TITLE
fix(issue-448): retain established Codex approval across bot-review-wait polls

### DIFF
--- a/skills/orch/DEVELOPMENT.md
+++ b/skills/orch/DEVELOPMENT.md
@@ -40,6 +40,8 @@ The emitted reviewer signals include `pr_review_decision:approved` and `pr_threa
 
 Codex-style reaction approvals and PR-level approved fallbacks then run a short terminal settle window (`BOT_REVIEW_SETTLE_SECONDS`, default 180s). The waiter re-reads reviewer status during that window and returns to the normal review loop if late inline threads appear, preventing merge workflows from treating early approval as final while the bot is still posting review comments.
 
+Within a run, a reviewer-own clean approval (`reaction:+1`, `formal_review:approved`, or `sticky:approved` with zero unresolved threads) is remembered as an established approval. Codex withdraws its 👍 reaction when it posts a follow-up formal COMMENTED review, which would otherwise recompute the reviewer as unknown/pending on the next poll; instead the waiter retains the approval and tags the entry `established_approval:retained`. Only new unresolved threads or a changes-requested signal downgrade an established approval (and doing so clears it). PR-level `pr_review_decision:approved` fallback promotions do not establish reviewer-own approvals.
+
 ## Tests
 
 ```bash

--- a/skills/orch/SKILL.md
+++ b/skills/orch/SKILL.md
@@ -157,7 +157,7 @@ Follow ALL [Workflow Execution](#workflow-execution) rules for every command.
 | `open-terminal` | Launch-only handoff helper for Linear/GitHub worktrees |
 | `parallel-groups` | Local cache for safe parallel handoff analysis |
 
-`bot-review-wait --json` returns `status: "error"` and exits non-zero on GitHub auth/API failures instead of polling until timeout with empty output. If a bot's direct signal remains pending after GitHub reports `reviewDecision=APPROVED`, the waiter treats the reviewer as approved only when any configured `BOT_CHECK_NAME` has passed and there are no unresolved review threads, then skips stale sticky-checklist waiting.
+`bot-review-wait --json` returns `status: "error"` and exits non-zero on GitHub auth/API failures instead of polling until timeout with empty output. If a bot's direct signal remains pending after GitHub reports `reviewDecision=APPROVED`, the waiter treats the reviewer as approved only when any configured `BOT_CHECK_NAME` has passed and there are no unresolved review threads, then skips stale sticky-checklist waiting. Once a reviewer shows a clean reviewer-own approval (e.g. `reaction:+1` with zero unresolved threads), a later formal COMMENTED review does not regress it to pending/unknown within the run — the entry stays approved with signal `established_approval:retained`; only new unresolved threads or a changes-requested signal downgrade it.
 
 `session-init --json` reports worktree Linear auth as the structured `linear_auth` object from `linear auth-check`. `linear_auth.error = "not installed"` is reserved for a missing Linear skill command; API key, 1Password, and API failures keep their original auth-check diagnostic.
 

--- a/skills/orch/scripts/bot-review-wait
+++ b/skills/orch/scripts/bot-review-wait
@@ -359,6 +359,63 @@ apply_pr_terminal_fallback() {
   ' <<<"$entries"
 }
 
+# Reviewer-own approvals established earlier in this run, one login per line.
+# Codex withdraws its 👍 reaction when it posts a follow-up formal COMMENTED
+# review, which would otherwise recompute the reviewer as unknown/pending and
+# block completion. Only new unresolved threads or a changes-requested signal
+# may downgrade an established approval. A file (not a shell variable) because
+# entries are collected inside command substitutions.
+ESTABLISHED_APPROVALS_FILE="$(mktemp)"
+trap 'rm -f "$ESTABLISHED_APPROVALS_FILE"' EXIT
+
+established_approvals_json() {
+  jq -R -s -c 'split("\n") | map(select(length > 0))' \
+    "$ESTABLISHED_APPROVALS_FILE" 2>/dev/null || printf '[]'
+}
+
+apply_established_approvals() {
+  local entries="$1"
+  local established
+  established=$(established_approvals_json)
+  if [[ "$established" == "[]" ]]; then
+    printf '%s' "$entries"
+    return 0
+  fi
+  jq -c --argjson est "$established" '
+    map(
+      .reviewer as $r |
+      if ($est | index($r))
+         and (.status == "pending" or .status == "unknown")
+         and ((.unresolved_threads // 0) == 0)
+      then
+        .status = "approved"
+        | .signals += ["established_approval:retained"]
+      else
+        .
+      end
+    )
+  ' <<<"$entries"
+}
+
+# Reviewer-own approval signals only — PR-level reviewDecision fallback does
+# not establish an approval for a specific reviewer.
+record_established_approvals() {
+  local entries="$1"
+  local current
+  current=$(established_approvals_json)
+  jq -r --argjson est "$current" '
+    ($est - [.[] | select(.status == "changes") | .reviewer]) as $kept
+    | ($kept + [.[]
+        | select(.status == "approved")
+        | select((.unresolved_threads // 0) == 0)
+        | select((.signals // [])
+            | any(. == "reaction:+1" or . == "formal_review:approved" or . == "sticky:approved"))
+        | .reviewer])
+    | unique
+    | .[]
+  ' <<<"$entries" > "$ESTABLISHED_APPROVALS_FILE"
+}
+
 collect_reviewers_or_exit() {
   local entries
   if ! entries=$(collect_reviewers); then
@@ -366,6 +423,8 @@ collect_reviewers_or_exit() {
     exit 3
   fi
   entries=$(apply_pr_terminal_fallback "$entries")
+  entries=$(apply_established_approvals "$entries")
+  record_established_approvals "$entries"
   printf '%s' "$entries"
 }
 

--- a/skills/orch/tests/bot_review_wait.sh
+++ b/skills/orch/tests/bot_review_wait.sh
@@ -167,6 +167,24 @@ case "${1:-}" in
         echo '[{"user":{"login":"vg-claude"},"state":"CHANGES_REQUESTED","submitted_at":"2026-01-01T00:00:00Z"}]'
         exit 0
         ;;
+      repos/*/pulls/10/reviews)
+        count_file="${FAKE_GH_STATE_DIR:-}/pr10-reviews-count"
+        count=0
+        if [[ -n "${FAKE_GH_STATE_DIR:-}" && -f "$count_file" ]]; then
+          count="$(cat "$count_file")"
+        fi
+        count=$((count + 1))
+        if [[ -n "${FAKE_GH_STATE_DIR:-}" ]]; then
+          mkdir -p "$FAKE_GH_STATE_DIR"
+          printf '%s' "$count" > "$count_file"
+        fi
+        if [[ "$count" -ge 2 ]]; then
+          echo '[{"user":{"login":"chatgpt-codex-connector[bot]"},"state":"COMMENTED","submitted_at":"2026-01-01T00:10:00Z"}]'
+        else
+          echo '[]'
+        fi
+        exit 0
+        ;;
       repos/*/issues/2/comments)
         cat <<'JSON'
 [
@@ -209,7 +227,7 @@ JSON
 JSON
         exit 0
         ;;
-      repos/*/issues/5/comments|repos/*/issues/6/comments|repos/*/issues/7/comments|repos/*/issues/8/comments|repos/*/issues/9/comments)
+      repos/*/issues/5/comments|repos/*/issues/6/comments|repos/*/issues/7/comments|repos/*/issues/8/comments|repos/*/issues/9/comments|repos/*/issues/10/comments)
         echo '[]'
         exit 0
         ;;
@@ -281,6 +299,24 @@ JSON
         ;;
       repos/*/issues/comments/5001/reactions)
         echo '[]'
+        exit 0
+        ;;
+      repos/*/issues/10/reactions)
+        count_file="${FAKE_GH_STATE_DIR:-}/pr10-reactions-count"
+        count=0
+        if [[ -n "${FAKE_GH_STATE_DIR:-}" && -f "$count_file" ]]; then
+          count="$(cat "$count_file")"
+        fi
+        count=$((count + 1))
+        if [[ -n "${FAKE_GH_STATE_DIR:-}" ]]; then
+          mkdir -p "$FAKE_GH_STATE_DIR"
+          printf '%s' "$count" > "$count_file"
+        fi
+        if [[ "$count" -ge 2 ]]; then
+          echo '[]'
+        else
+          echo '[{"user":{"login":"chatgpt-codex-connector[bot]"},"content":"+1"}]'
+        fi
         exit 0
         ;;
     esac
@@ -395,6 +431,19 @@ assert_eq "$(cat "$TMP_ROOT/pr8-state/pr8-reactions-count")" "3" "BOT_CHECK_NAME
 assert_eq "$(jq -r .status <<<"$output")" "complete" "BOT_CHECK_NAME late inline thread emits complete JSON"
 assert_eq "$(jq -r .verdict <<<"$output")" "changes" "BOT_CHECK_NAME late inline thread changes the verdict"
 assert_contains "$(jq -c '.reviewers[0].signals' <<<"$output")" "inline:1" "BOT_CHECK_NAME late inline thread is represented in reviewer signals"
+
+cat > "$TMP_ROOT/repo/.env.local" <<EOF
+GIT_HOST_CLI="$FAKE_GITHUB_SH"
+EOF
+set +e
+output=$(timeout 15s bash -c 'cd "$1" && PATH="$2:$PATH" FAKE_GH_STATE_DIR="$3" BOT_REVIEW_SETTLE_SECONDS=2 BOT_REVIEW_SETTLE_INTERVAL=1 .agents/skills/orch/scripts/bot-review-wait 10 1 6 --json --reviewers "chatgpt-codex-connector[bot]"' bash "$TMP_ROOT/repo" "$TMP_ROOT/bin" "$TMP_ROOT/pr10-state")
+code=$?
+set -e
+assert_eq "$code" "0" "established +1 approval survives later formal COMMENTED review"
+assert_eq "$(jq -r .status <<<"$output")" "complete" "COMMENTED after clean +1 emits complete JSON"
+assert_eq "$(jq -r .verdict <<<"$output")" "approved" "COMMENTED after clean +1 keeps approved verdict"
+assert_eq "$(jq -r '.approved_reviewers | join(",")' <<<"$output")" "chatgpt-codex-connector[bot]" "COMMENTED after clean +1 keeps Codex approved"
+assert_eq "$(cat "$TMP_ROOT/pr10-state/pr10-reviews-count")" "3" "settle window re-reads reviewer status after COMMENTED regression"
 
 set +e
 output=$(run_wait 4 1 1 --json --reviewers 'vg-claude')


### PR DESCRIPTION
## Summary
- Fix `bot-review-wait` regressing an established Codex approval back to pending/unknown after a later formal COMMENTED review. Once a reviewer has a clean own-approval signal (`reaction:+1`, `formal_review:approved`, or `sticky:approved`) with zero unresolved threads, that approval is retained across polls.
- Only a new changes-requested status or new unresolved threads may downgrade an established approval. PR-level `reviewDecision` fallback does not by itself establish a per-reviewer approval.

## Completed Issues
- Closes #448

## Test Plan
- Regression cases added to `skills/orch/tests/bot_review_wait.sh`.
- `bash skills/orch/tests/run-all.sh` — all 5 files pass.
