### PR TITLE
fix(issue-454): make ci-wait always emit a deterministic result

### DIFF
--- a/skills/orch/SKILL.md
+++ b/skills/orch/SKILL.md
@@ -158,6 +158,8 @@ Follow ALL [Workflow Execution](#workflow-execution) rules for every command.
 | `open-terminal` | Launch-only handoff helper for Linear/GitHub worktrees |
 | `parallel-groups` | Local cache for safe parallel handoff analysis |
 
+`ci-wait --json` returns `{status, verdict, elapsed_seconds, pending_checks, failed_checks, passed_checks}` where `status` is `complete`/`timeout`/`error` and `verdict` is `pass`/`fail`/`pending`. Every exit path emits a final stdout result (a `CI passed`/`CI failed`/`CI timeout`/`CI error` line without `--json`); checks still in progress at the deadline report `status: "timeout"`, never silent success.
+
 `bot-review-wait --json` returns `status: "error"` and exits non-zero on GitHub auth/API failures instead of polling until timeout with empty output. If a bot's direct signal remains pending after GitHub reports `reviewDecision=APPROVED`, the waiter treats the reviewer as approved only when any configured `BOT_CHECK_NAME` has passed and there are no unresolved review threads, then skips stale sticky-checklist waiting. Once a reviewer shows a clean reviewer-own approval (e.g. `reaction:+1` with zero unresolved threads), a later formal COMMENTED review does not regress it to pending/unknown within the run — the entry stays approved with signal `established_approval:retained`; only new unresolved threads or a changes-requested signal downgrade it.
 
 `session-init --json` reports worktree Linear auth as the structured `linear_auth` object from `linear auth-check`. `linear_auth.error = "not installed"` is reserved for a missing Linear skill command; API key, 1Password, and API failures keep their original auth-check diagnostic.

--- a/skills/orch/scripts/ci-wait
+++ b/skills/orch/scripts/ci-wait
@@ -1,11 +1,32 @@
 #!/usr/bin/env bash
-# Wait for CI checks to complete, output only on completion or failure
-# Auto-retries transient infrastructure failures (max 1 retry)
+# Wait for CI checks to complete. Always emits a final result on stdout —
+# a "CI passed"/"CI failed"/"CI timeout"/"CI error" line, or a JSON object
+# with --json — so callers can route pass vs fail deterministically
+# (vstack#454). Auto-retries transient infrastructure failures (max 1 retry).
 #
 # Uses JSON-based state detection to avoid false positives from stale checks
 # left by prior workflow runs (e.g., SKIPPED checks from defer-ci runs).
 #
-# Usage: ci-wait <PR#> [poll_interval] [max_wait]
+# Usage: ci-wait <PR#> [poll_interval] [max_wait] [--json]
+#
+# Exit codes:
+#   0 - CI complete and passing
+#   1 - CI failed, timed out with checks still pending, or a non-auth error
+#       (no checks registered, merge conflicts, repo/API failure)
+#   3 - GitHub auth/CLI error (matches bot-review-wait)
+#
+# JSON output (always when --json):
+#   {
+#     "status": "complete" | "timeout" | "error",
+#     "verdict": "pass" | "fail" | "pending",
+#     "elapsed_seconds": <int>,
+#     "error": <string>,            # only when status == "error"
+#     "pending_checks": [ {name,state} ... ],
+#     "failed_checks":  [ {name,state} ... ],
+#     "passed_checks":  [ {name,state} ... ]
+#   }
+#   Still-pending checks at the deadline report status "timeout", never
+#   silent success.
 #
 # Auth resolution ladder (see vstack#19):
 #   1. Validate the currently selected GH_TOKEN/GITHUB_TOKEN once, if present.
@@ -28,7 +49,88 @@ PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 # shellcheck source=lib/gh-auth.sh
 source "$SCRIPT_DIR/lib/gh-auth.sh"
 
+# --- arg parse (before auth so error paths can honor --json) ---
+JSON_OUTPUT=false
+POSITIONAL=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --json) JSON_OUTPUT=true; shift ;;
+    *) POSITIONAL+=("$1"); shift ;;
+  esac
+done
+
+PR_NUM="${POSITIONAL[0]:?Usage: ci-wait <PR#> [poll_interval] [max_wait] [--json]}"
+POLL_INTERVAL="${POSITIONAL[1]:-15}"
+MAX_WAIT="${POSITIONAL[2]:-600}"
+START_TIME="$(date +%s)"
+elapsed=0
+
+update_elapsed() {
+  local now
+  now="$(date +%s)"
+  elapsed=$((now - START_TIME))
+}
+
+EMPTY_CLASSES='{"pending":[],"failed":[],"passed":[]}'
+# Last classification seen by the poll loop, so timeout/error results can
+# report the checks that were still outstanding.
+last_check_classes="$EMPTY_CLASSES"
+
+# Emit the final machine-readable result on stdout. Every exit path routes
+# through here (or emit_error) so the script can never finish silently.
+#   status: complete | timeout | error
+#   verdict derives from the classes: pending > fail > pass.
+emit_result() {
+  local status="$1" classes="$2" error_msg="${3:-}"
+  update_elapsed
+  local verdict
+  verdict=$(jq -r '
+    if (.pending | length) > 0 then "pending"
+    elif (.failed | length) > 0 then "fail"
+    elif (.passed | length) > 0 then "pass"
+    else "pending" end' <<<"$classes")
+  if $JSON_OUTPUT; then
+    jq -n \
+      --arg s "$status" \
+      --arg v "$verdict" \
+      --argjson elapsed "$elapsed" \
+      --arg error "$error_msg" \
+      --argjson classes "$(jq -c 'map_values(map({name, state: (.state // .bucket // "UNKNOWN")}))' <<<"$classes")" \
+      '{
+        status: $s,
+        verdict: $v,
+        elapsed_seconds: $elapsed,
+        pending_checks: $classes.pending,
+        failed_checks: $classes.failed,
+        passed_checks: $classes.passed
+      } + (if $error == "" then {} else {error: $error} end)'
+    return 0
+  fi
+  case "$status" in
+    complete)
+      if [[ "$verdict" == "pass" ]]; then
+        echo "CI passed"
+      else
+        echo "CI failed:"
+        jq -r '.failed[] | "  \(.name): \(.state // .bucket // "FAILED")"' <<<"$classes"
+      fi
+      ;;
+    timeout)
+      echo "CI timeout after ${elapsed}s (verdict: $verdict)"
+      jq -r '.pending[]? | "  pending: \(.name)"' <<<"$classes"
+      ;;
+    error)
+      echo "CI error: $error_msg"
+      ;;
+  esac
+}
+
+emit_error() {
+  emit_result "error" "$last_check_classes" "$1"
+}
+
 if ! command -v gh >/dev/null 2>&1; then
+  emit_error "gh CLI not found on PATH"
   echo "ci-wait: gh CLI not found on PATH" >&2
   exit 3
 fi
@@ -77,6 +179,7 @@ if [[ "$AUTH_READY" != "true" ]]; then
 fi
 
 if [[ "$AUTH_READY" != "true" ]]; then
+  emit_error "no working GitHub auth path"
   {
     echo "ci-wait: no working GitHub auth path."
     echo "Tried: env GH_TOKEN/GITHUB_TOKEN, gh keyring, project GH_BOT_TOKEN."
@@ -85,10 +188,6 @@ if [[ "$AUTH_READY" != "true" ]]; then
   exit 3
 fi
 
-PR_NUM="${1:?Usage: ci-wait <PR#> [poll_interval] [max_wait]}"
-POLL_INTERVAL="${2:-15}"
-MAX_WAIT="${3:-600}"
-
 # --- Resolve repo explicitly so gh calls don't depend on local auth/inference ---
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true)
 if [ -z "$REPO" ]; then
@@ -96,6 +195,7 @@ if [ -z "$REPO" ]; then
   REPO=$(echo "$origin_url" | sed -nE 's#^.*github\.com[:/]+([^/]+/[^/]+?)(\.git)?$#\1#p')
 fi
 if [ -z "$REPO" ]; then
+  emit_error "could not resolve GitHub repo (gh repo view and git remote both failed)"
   echo "Could not resolve GitHub repo (gh repo view and git remote both failed)" >&2
   exit 1
 fi
@@ -104,6 +204,7 @@ fi
 merge_state=$(gh pr view "$PR_NUM" --repo "$REPO" --json mergeStateStatus --jq '.mergeStateStatus' 2>/dev/null || echo "UNKNOWN")
 case "$merge_state" in
   DIRTY|CONFLICTING)
+    emit_error "PR #$PR_NUM has merge conflicts (state: $merge_state); CI will not trigger until conflicts are resolved"
     echo "PR #$PR_NUM has merge conflicts (state: $merge_state)" >&2
     echo "CI will not trigger until conflicts are resolved." >&2
     echo "Rebase onto the default branch and force-push to fix." >&2
@@ -195,8 +296,8 @@ classify_checks() {
 checks_stderr=$(mktemp)
 trap 'rm -f "$checks_stderr"' EXIT
 
-elapsed=0
-while [ $elapsed -lt $MAX_WAIT ]; do
+update_elapsed
+while [ "$elapsed" -lt "$MAX_WAIT" ]; do
   # Capture stderr so we can distinguish auth/repo failures from "no checks yet".
   checks_status=0
   set +e
@@ -204,6 +305,7 @@ while [ $elapsed -lt $MAX_WAIT ]; do
   checks_status=$?
   set -e
   if [ "$checks_status" -ne 0 ] && ! jq -e 'type == "array"' >/dev/null 2>&1 <<<"$checks_json"; then
+    emit_error "gh pr checks failed for PR #$PR_NUM in $REPO"
     echo "gh pr checks failed for PR #$PR_NUM in $REPO:" >&2
     cat "$checks_stderr" >&2
     exit 1
@@ -213,6 +315,7 @@ while [ $elapsed -lt $MAX_WAIT ]; do
   if [ -z "$checks_json" ] || [ "$checks_json" = "[]" ] || [ "$checks_json" = "null" ]; then
     no_checks_count=$((no_checks_count + 1))
     if [ $no_checks_count -ge $max_no_checks ]; then
+      emit_error "no CI checks registered on PR #$PR_NUM after ${elapsed}s (merge conflicts, draft/defer-ci gating, or webhook delay)"
       echo "No CI checks after ${elapsed}s" >&2
       echo "Possible causes: merge conflicts, draft/defer-ci gating, or webhook delay." >&2
       merge_state=$(gh pr view "$PR_NUM" --repo "$REPO" --json mergeStateStatus --jq '.mergeStateStatus' 2>/dev/null || echo "UNKNOWN")
@@ -222,7 +325,7 @@ while [ $elapsed -lt $MAX_WAIT ]; do
       exit 1
     fi
     sleep "$POLL_INTERVAL"
-    elapsed=$((elapsed + POLL_INTERVAL))
+    update_elapsed
     continue
   fi
 
@@ -232,6 +335,7 @@ while [ $elapsed -lt $MAX_WAIT ]; do
   # Count checks by GitHub's bucket classifier, with state fallbacks for older
   # gh output. This must stay aligned with github pr-merge --check.
   check_classes=$(echo "$checks_json" | classify_checks)
+  last_check_classes="$check_classes"
   pending_count=$(echo "$check_classes" | jq '.pending | length')
   failed_count=$(echo "$check_classes" | jq '.failed | length')
   success_count=$(echo "$check_classes" | jq '.passed | length')
@@ -244,7 +348,10 @@ while [ $elapsed -lt $MAX_WAIT ]; do
 
   # Check for failure (only when all checks have settled)
   if [ "$failed_count" -gt 0 ] && [ "$pending_count" -eq 0 ]; then
-    failed_run=$(get_failed_run_id "$PR_NUM")
+    # `gh pr checks` exits nonzero when checks have failed; without the guard
+    # the pipefail status escapes the substitution and errexit kills the
+    # script before any result is emitted (silent-exit class of vstack#454).
+    failed_run=$(get_failed_run_id "$PR_NUM" || true)
 
     # Try auto-retry for transient failures
     if [ -n "$failed_run" ] && [ $retries -lt $max_retries ] && is_transient_failure "$failed_run"; then
@@ -253,11 +360,11 @@ while [ $elapsed -lt $MAX_WAIT ]; do
       retries=$((retries + 1))
       seen_in_progress=false  # Reset — rerun will produce new checks
       sleep 10
+      update_elapsed
       continue
     fi
 
-    echo "CI failed:"
-    echo "$check_classes" | jq -r '.failed[] | "  \(.name): \(.state // .bucket // "FAILED")"'
+    emit_result "complete" "$check_classes"
     exit 1
   fi
 
@@ -265,7 +372,7 @@ while [ $elapsed -lt $MAX_WAIT ]; do
   if [ "$pending_count" -eq 0 ] && [ "$success_count" -gt 0 ]; then
     if [ "$seen_in_progress" = true ]; then
       # We watched checks go from in-progress to complete — reliable
-      echo "CI passed"
+      emit_result "complete" "$check_classes"
       exit 0
     fi
     # Only seeing completed/skipped checks but never saw in-progress.
@@ -274,15 +381,19 @@ while [ $elapsed -lt $MAX_WAIT ]; do
     stale_count=$((stale_count + 1))
     if [ "$stale_count" -ge "$max_stale" ]; then
       # Waited long enough for new checks to appear — genuinely complete
-      echo "CI passed"
+      emit_result "complete" "$check_classes"
       exit 0
     fi
   fi
 
   sleep "$POLL_INTERVAL"
-  elapsed=$((elapsed + POLL_INTERVAL))
+  update_elapsed
 done
 
-echo "CI timeout after ${MAX_WAIT}s"
-gh pr checks "$PR_NUM" --repo "$REPO"
+# Deadline reached with checks still outstanding — report timeout, not
+# success, so callers never mistake in-progress CI for a pass.
+emit_result "timeout" "$last_check_classes"
+if ! $JSON_OUTPUT; then
+  gh pr checks "$PR_NUM" --repo "$REPO" >&2 || true
+fi
 exit 1

--- a/skills/orch/tests/ci_wait.sh
+++ b/skills/orch/tests/ci_wait.sh
@@ -14,6 +14,11 @@
 #                                        -> token preflight wins once
 #   7. no env token + hanging keyring auth
 #                                        -> bounded failure, not hang
+#
+# Plus the deterministic-output contract (vstack#454): ci-wait must always
+# emit a parseable result on stdout — pass/fail/timeout/error — and must
+# report still-pending checks at the deadline as a timeout, never as
+# success or silence (cases 10-14).
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -166,6 +171,18 @@ case "${1:-}" in
           exit 8
         fi
       fi
+      if [[ "${STUB_PR_CHECKS_MODE:-}" == "pending_always" ]]; then
+        echo '[{"name":"build","state":"IN_PROGRESS"}]'
+        exit 8
+      fi
+      if [[ "${STUB_PR_CHECKS_MODE:-}" == "empty" ]]; then
+        echo '[]'
+        exit 0
+      fi
+      if [[ "${STUB_PR_CHECKS_MODE:-}" == "failure" ]]; then
+        echo '[{"name":"build","state":"FAILURE"}]'
+        exit 1
+      fi
       echo '[{"name":"build","state":"SUCCESS"}]'
       exit 0
     fi
@@ -196,6 +213,23 @@ run_wait_short() {
   (cd "$TMP_ROOT/repo" \
     && PATH="$TMP_ROOT/bin:$PATH" \
        env "$@" .agents/skills/orch/scripts/ci-wait 1 1 5)
+}
+
+run_wait_json() {
+  (cd "$TMP_ROOT/repo" \
+    && PATH="$TMP_ROOT/bin:$PATH" \
+       env "$@" .agents/skills/orch/scripts/ci-wait 1 1 30 --json)
+}
+
+run_wait_json_short() {
+  (cd "$TMP_ROOT/repo" \
+    && PATH="$TMP_ROOT/bin:$PATH" \
+       env "$@" .agents/skills/orch/scripts/ci-wait 1 1 5 --json)
+}
+
+# jq field extractor for --json output assertions.
+json_field() {
+  jq -r "$2" <<<"$1" 2>/dev/null || echo "UNPARSEABLE"
 }
 
 echo "=== ci-wait auth handling ==="
@@ -312,6 +346,83 @@ set -e
 assert_eq "$rc" "0" "case9: EXPECTED checks are treated as pending" "$stderr"
 assert_contains "$output" "CI passed" "case9: ci-wait reaches CI passed after expected check clears"
 assert_eq "$(cat "$checks_count_file")" "2" "case9: ci-wait polls again after EXPECTED JSON" "$stderr"
+
+echo "=== ci-wait output contract (vstack#454) ==="
+
+# Case 10: --json pass. Result must be a parseable object with
+# status=complete / verdict=pass.
+stderr="$TMP_ROOT/case10.err"
+set +e
+output=$(run_wait_json 2>"$stderr")
+rc=$?
+set -e
+assert_eq "$rc" "0" "case10: json pass exits 0" "$stderr"
+assert_eq "$(json_field "$output" '.status')" "complete" "case10: json status is complete" "$stderr"
+assert_eq "$(json_field "$output" '.verdict')" "pass" "case10: json verdict is pass" "$stderr"
+assert_eq "$(json_field "$output" '.passed_checks | length')" "1" "case10: json lists passed checks" "$stderr"
+
+# Case 11: checks still IN_PROGRESS at the deadline must report a timeout,
+# never exit 0 or stay silent (the vstack#454 defect).
+stderr="$TMP_ROOT/case11.err"
+set +e
+output=$(run_wait_json_short STUB_PR_CHECKS_MODE=pending_always 2>"$stderr")
+rc=$?
+set -e
+assert_eq "$rc" "1" "case11: pending checks at deadline exit 1" "$stderr"
+assert_eq "$(json_field "$output" '.status')" "timeout" "case11: json status is timeout" "$stderr"
+assert_eq "$(json_field "$output" '.verdict')" "pending" "case11: json verdict is pending" "$stderr"
+assert_eq "$(json_field "$output" '.pending_checks[0].name')" "build" "case11: json lists pending checks" "$stderr"
+
+# Case 11b: same deadline scenario in text mode still emits a stdout result.
+stderr="$TMP_ROOT/case11b.err"
+set +e
+output=$(run_wait_short STUB_PR_CHECKS_MODE=pending_always 2>"$stderr")
+rc=$?
+set -e
+assert_eq "$rc" "1" "case11b: text-mode timeout exits 1" "$stderr"
+assert_contains "$output" "CI timeout" "case11b: text-mode timeout prints CI timeout on stdout"
+
+# Case 12: no checks ever registered -> status=error with diagnostic, not
+# a silent exit.
+stderr="$TMP_ROOT/case12.err"
+set +e
+output=$(run_wait_json STUB_PR_CHECKS_MODE=empty 2>"$stderr")
+rc=$?
+set -e
+assert_eq "$rc" "1" "case12: no registered checks exit 1" "$stderr"
+assert_eq "$(json_field "$output" '.status')" "error" "case12: json status is error" "$stderr"
+assert_contains "$(json_field "$output" '.error')" "no CI checks" "case12: json error names the cause"
+
+# Case 12b: same in text mode — stdout carries a CI error line.
+stderr="$TMP_ROOT/case12b.err"
+set +e
+output=$(run_wait STUB_PR_CHECKS_MODE=empty 2>"$stderr")
+rc=$?
+set -e
+assert_eq "$rc" "1" "case12b: text-mode no-checks exit 1" "$stderr"
+assert_contains "$output" "CI error" "case12b: text-mode no-checks prints CI error on stdout"
+
+# Case 13: settled failing check -> status=complete / verdict=fail.
+stderr="$TMP_ROOT/case13.err"
+set +e
+output=$(run_wait_json STUB_PR_CHECKS_MODE=failure 2>"$stderr")
+rc=$?
+set -e
+assert_eq "$rc" "1" "case13: failed checks exit 1" "$stderr"
+assert_eq "$(json_field "$output" '.status')" "complete" "case13: json status is complete" "$stderr"
+assert_eq "$(json_field "$output" '.verdict')" "fail" "case13: json verdict is fail" "$stderr"
+assert_eq "$(json_field "$output" '.failed_checks[0].name')" "build" "case13: json lists failed checks" "$stderr"
+
+# Case 14: auth failure with --json still yields a parseable error object.
+rm -f "$TMP_ROOT/repo/.env.local"
+stderr="$TMP_ROOT/case14.err"
+set +e
+output=$(run_wait_json GH_TOKEN=bad-token STUB_GH_DENY_KEYRING=1 2>"$stderr")
+rc=$?
+set -e
+assert_eq "$rc" "3" "case14: json auth failure exits 3" "$stderr"
+assert_eq "$(json_field "$output" '.status')" "error" "case14: json auth failure reports status error" "$stderr"
+assert_contains "$(json_field "$output" '.error')" "auth" "case14: json auth failure names auth in error"
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/skills/orch/workflows/submit-pr.md
+++ b/skills/orch/workflows/submit-pr.md
@@ -357,15 +357,17 @@ All bot review comments resolved (or max iterations). Verify no late-arriving th
 
 3. **Wait for CI**:
    ```bash
-   .agents/skills/orch/scripts/ci-wait [PR_NUMBER]
+   .agents/skills/orch/scripts/ci-wait [PR_NUMBER] --json
    ```
+   The result is a JSON object: `status` (`complete`/`timeout`/`error`) plus `verdict` (`pass`/`fail`/`pending`). ci-wait always emits it — no silent completion.
 
 4. **Handle CI result**:
 
    | Result | Action |
    |--------|--------|
-   | ✅ Pass | → § 6 |
-   | ❌ Fail | → § 5 |
+   | ✅ `status=complete`, `verdict=pass` | → § 6 |
+   | ❌ `status=complete`, `verdict=fail` | → § 5 |
+   | ⏱ `status=timeout` or `status=error` | Re-run step 3 once; if it repeats → Ask user: `Skip CI` \| `Retry` \| `Abort` |
 
 ---
 


### PR DESCRIPTION
## Summary
- Give `ci-wait` a deterministic output contract: every exit path now emits a final result (`CI passed`/`CI failed`/`CI timeout`/`CI error`, or a JSON object with `--json`), so callers can always route pass vs fail. Previously several paths (no checks registered, merge conflict, repo/API/auth failure, and a pipefail-into-errexit on `gh pr checks`) could exit with no stdout.
- Checks still in progress at the deadline report `status=timeout`/`verdict=pending`, never silent success. `--json` mirrors `bot-review-wait`. Exit codes preserved (0 pass, 1 fail/timeout, 3 auth) so `merge-pr`/`ci-fix` callers are unaffected; `submit-pr` switched to `--json`.

## Completed Issues
- Closes #454

## Test Plan
- New cases in `skills/orch/tests/ci_wait.sh` (json pass, timeout-with-pending json+text, no-checks error json+text, settled failure, json auth failure).
- `bash skills/orch/tests/run-all.sh` — all 5 files pass (48 ci-wait assertions).
