### PR TITLE
fix(issue-457): add deep-research validate subcommand + Exa-grounded flag guidance

### DIFF
--- a/skills/deep-research/README.md
+++ b/skills/deep-research/README.md
@@ -4,15 +4,19 @@ Portable Exa Deep Search skill for producing evidence-backed findings reports in
 
 Run `scripts/deep-research doctor` to verify Node/fetch availability and whether `EXA_API_KEY` is configured.
 
-Report mode defaults:
+Report mode defaults (within Exa `/search` limits: `numResults` 1-100, `text.maxCharacters` 1-10000):
 
-| Mode | Exa type | Results | Text cap | Timeout |
-|---|---|---:|---:|---:|
-| `lite` | `deep-lite` | 15 | 10k chars/result | 5 min |
-| `standard` | `deep-reasoning` | 50 | 16k chars/result | 10 min |
-| `full` | `deep-reasoning` | 150 | 24k chars/result | 30 min |
+| Mode | Exa type | Results | Text cap | Timeout | Synthesis |
+|---|---|---:|---:|---:|---|
+| `lite` | `deep-lite` | 15 | 10k chars/result | 5 min | No (evidence brief) |
+| `standard` | `deep-reasoning` | 50 | 10k chars/result | 10 min | Yes (`outputSchema`) |
+| `full` | `deep-reasoning` | 100 | 10k chars/result | 30 min | Yes, per fanned-out query |
 
 `report --output findings.md` writes clean Markdown and defaults raw metadata to `findings.raw.json`.
+
+Repeated `--additional-query` values are sent as Exa `additionalQueries` in one request (`lite`/`standard`) or fanned out as separate requests with URL dedupe (`full`). The sidecar metadata records the queries and how they were applied.
+
+After generating a report, run `scripts/deep-research validate findings.md findings.raw.json` for deterministic post-run checks (required sections, query-expansion metadata consistency, synthesis presence, duplicated sections). It prints `{ok, errors, warnings}` and exits non-zero on errors.
 
 The findings format is mode-adaptive: `lite`, `standard`, and `full` use the same required sections, while mode/source/query counts are recorded in `## Research Metadata`. This avoids separate templates drifting over time.
 

--- a/skills/deep-research/SKILL.md
+++ b/skills/deep-research/SKILL.md
@@ -34,7 +34,7 @@ Use this skill for evidence-backed research reports, architectural investigation
 - For workflow-owned research, write `findings.md` to the requested research docs path exactly.
 - Include citations/source URLs in every findings report.
 - Keep `findings.md` clean and human-readable; preserve raw Exa metadata in a sidecar JSON file (`findings.raw.json` by default when `--output findings.md` is used). Evidence excerpts must be sanitized so source Markdown headings do not render as large quoted headings.
-- Once the requested report and raw sidecar exist, validate them and stop. Do not add local reproduction, benchmark, test, code-inspection, or implementation work unless the caller explicitly requested local validation in addition to Exa research.
+- Once the requested report and raw sidecar exist, run `deep-research validate <findings.md> <findings.raw.json>` (see § Validation) and stop. Do not add local reproduction, benchmark, test, code-inspection, or implementation work unless the caller explicitly requested local validation in addition to Exa research.
 - If `EXA_API_KEY` is missing, fail with clear setup instructions. `EXA_API_KEY` may be a direct key or a 1Password `op://vault/item/field` reference when the `op` CLI is installed and signed in.
 - Use `--mode standard` by default. Use `--mode lite` for fast spikes and `--mode full` for strategic/high-risk decisions. Explicit `--type`, `--num-results`, and `--text-max-characters` override mode defaults.
 - Use one adaptive findings format for all modes. The mode changes depth/source volume and Exa content settings, not the required report sections; record mode and source counts in `## Research Metadata`.
@@ -46,16 +46,26 @@ Use this skill for evidence-backed research reports, architectural investigation
 skills/deep-research/scripts/deep-research report "question" --mode standard --output path/to/findings.md
 skills/deep-research/scripts/deep-research report --query-file prompt.txt --context-glob 'context-*.md' --mode full --output findings.md
 skills/deep-research/scripts/deep-research json "question" --output raw.json
+skills/deep-research/scripts/deep-research validate findings.md findings.raw.json
 skills/deep-research/scripts/deep-research doctor
 ```
 
-Modes:
+Modes (Exa `/search` caps: `numResults` 1-100, `text.maxCharacters` 1-10000, `additionalQueries` max 10):
 
-| Mode | Exa type | Default results | Text cap | Timeout | Notes |
-|---|---|---:|---:|---:|---|
-| `lite` | `deep-lite` | 15 | 10k chars/result | 5 min | Fast, lower-cost spikes. |
-| `standard` | `deep-reasoning` | 50 | 16k chars/result | 10 min | Default workflow research. |
-| `full` | `deep-reasoning` | 150 | 24k chars/result | 30 min | Runs primary query plus repeated `--additional-query`, then dedupes URLs. |
+| Mode | Exa type | Default results | Text cap | Timeout | Synthesis | Notes |
+|---|---|---:|---:|---:|---|---|
+| `lite` | `deep-lite` | 15 | 10k chars/result | 5 min | Not requested (no `outputSchema`) — evidence brief only. | Fast, lower-cost spikes. |
+| `standard` | `deep-reasoning` | 50 | 10k chars/result | 10 min | Requested via `outputSchema`. | Default workflow research. |
+| `full` | `deep-reasoning` | 100 | 10k chars/result | 30 min | Requested via `outputSchema`, per query. | Fans out one Exa request per query (primary + each `--additional-query`), then dedupes URLs. |
+
+`--additional-query` semantics (recorded in metadata — verify with `validate`):
+
+| Mode | How expansions are applied | Sidecar `additionalQueriesApplied` |
+|---|---|---|
+| `lite` / `standard` | Sent as Exa `additionalQueries` in the single request; consumed by deep search types as query variations. | `provider-additional-queries` |
+| `full` | One separate Exa request per query; URLs deduped across responses. | `local-fan-out` |
+
+Sidecar metadata records `queryCount` (distinct queries: 1 primary + additional), `requestCount` (Exa API calls), the `additionalQueries` list, and `synthesis` (whether a synthesized answer came back).
 
 Common flags:
 
@@ -77,6 +87,50 @@ Common flags:
 - `--raw-output <path>` (defaults to `findings.raw.json` next to `--output` for report mode)
 - `--no-raw-output`
 - `--timeout <seconds>`
+
+## Task-Type Recipes
+
+| Research need | Flags | Caveats |
+|---|---|---|
+| Technical decision synthesis (algorithm/library choice needing a recommendation) | `--mode standard` (or `full` for high-risk); name authoritative papers/orgs in the query; 1-2 `--additional-query` variants | Audit the source list for off-topic same-acronym papers and low-signal repos; `validate` cannot catch claim-vs-source contradictions. |
+| Targeted evidence brief (collect primary sources, you synthesize) | `--mode lite --include-domain <host>` per authoritative host, `--num-results 15-25` | `lite` requests no synthesis — expect an evidence brief. Do not use when the deliverable is a recommendation; `validate` warns on this. |
+| Broad landscape / vendor comparison | `--mode full`, one `--additional-query` per vendor/angle (max 10) | Breadth trades precision for coverage; expect marketing pages and duplicates — cut them during review. |
+| Current docs / API research | `--mode standard --include-domain <official-docs-host> --start-date <recent>` | Domain filter plus date window keeps results to current official docs; verify version applicability in the report. |
+
+## Choosing Flag Values
+
+- `--num-results`: more results = more noise exposure, not better synthesis. 10-25 for targeted questions; 50 (standard default) for decision research; 100 only for landscape scans where you will prune sources.
+- `--text-max-characters`: caps extracted text per result (Exa max 10000). Lower it (2000-4000) when many sources are expected and only key claims matter; keep the default for dense primary sources.
+- `--include-domain` is a hard host filter ("results will only come from these domains"), not a quality filter: `--include-domain github.com` admits any repo, not just reputable ones, and excludes everything else. Name authoritative projects/organizations in the query text for quality, use domain filters only to constrain hosts, and audit the resulting source list either way.
+- `--additional-query`: phrase each as a full natural-language question from a different angle (terminology variant, competing approach, failure mode) rather than keyword permutations.
+
+## Validation
+
+After generating a report, run:
+
+```bash
+skills/deep-research/scripts/deep-research validate path/to/findings.md path/to/findings.raw.json
+```
+
+Prints `{ok, errors, warnings, mode, synthesis, queryCount}`; exit 0 means no errors. Deterministic checks:
+
+| Check | Severity |
+|---|---|
+| Report and raw sidecar exist; sidecar parses with `metadata` + `raw` | error |
+| All required report sections present | error |
+| `queryCount` consistent with recorded `additionalQueries` and `additionalQueriesApplied` | error |
+| `standard`/`full` payload has a synthesized answer (modes request `outputSchema`) | error |
+| Missing synthesis in other modes (evidence brief — unsuitable as a recommendation) | warning |
+| Sidecar predates additional-query metadata | warning |
+| Key Findings duplicates Executive Summary text | warning |
+| Zero sources; sidecar path mismatch vs report reference | warning |
+
+Manual review checks (need judgment; `validate` cannot perform them):
+
+- Claims contradicted by the returned sources (e.g. complexity classes, benchmark numbers) — spot-check material claims against the cited source text in the sidecar.
+- Off-topic sources sharing an acronym or name with the research subject.
+- Recommendation assertions with no claim-level support in Evidence and Sources.
+- Results generalized beyond what the source established (e.g. a line-chart result applied to candlesticks).
 
 ## Findings Format
 

--- a/skills/deep-research/scripts/deep-research
+++ b/skills/deep-research/scripts/deep-research
@@ -8,10 +8,15 @@ const deepTypes = new Set(["deep-reasoning", "deep-lite", "deep"]);
 const researchModes = new Set(["lite", "standard", "full"]);
 const formats = new Set(["findings", "markdown", "json"]);
 const MAX_CONTEXT_FILES = 25;
+// Exa /search limits: numResults 1-100 (INVALID_NUM_RESULTS), text.maxCharacters 1-10000,
+// additionalQueries 1-10 items. https://exa.ai/docs/reference/search
+const EXA_MAX_NUM_RESULTS = 100;
+const EXA_MAX_TEXT_CHARACTERS = 10000;
+const EXA_MAX_ADDITIONAL_QUERIES = 10;
 const modeDefaults = {
   lite: { type: "deep-lite", numResults: 15, textMaxCharacters: 10000, timeout: 300 },
-  standard: { type: "deep-reasoning", numResults: 50, textMaxCharacters: 16000, timeout: 600 },
-  full: { type: "deep-reasoning", numResults: 150, textMaxCharacters: 24000, timeout: 1800 },
+  standard: { type: "deep-reasoning", numResults: 50, textMaxCharacters: 10000, timeout: 600 },
+  full: { type: "deep-reasoning", numResults: 100, textMaxCharacters: 10000, timeout: 1800 },
 };
 const defaultOutputSchema = {
   type: "object",
@@ -32,11 +37,12 @@ function fail(message, extra = {}) { jsonOut(process.stderr, { ok: false, error:
 function helpPayload() {
   return {
     ok: true,
-    usage: "deep-research report|json|doctor [query] [flags]",
+    usage: "deep-research report|json|validate|doctor [query|paths] [flags]",
     examples: [
       "deep-research report 'question' --mode standard --output findings.md",
       "deep-research report --query-file prompt.txt --context-glob 'context-*.md' --mode full --output findings.md",
       "deep-research json 'question' --output raw.json",
+      "deep-research validate findings.md findings.raw.json",
     ],
     modes: modeDefaults,
     flags: [
@@ -59,6 +65,7 @@ function helpPayload() {
       "--timeout <seconds>",
     ],
     sidecar: "report --output findings.md writes findings.raw.json by default unless --raw-output or --no-raw-output is supplied. Raw provider JSON is not embedded in findings.md.",
+    validate: "validate <findings.md> <findings.raw.json> runs deterministic post-run checks and prints {ok, errors, warnings}. Exit 0 = no errors.",
   };
 }
 
@@ -145,6 +152,9 @@ function applyMode(options) {
   options.timeout = options.explicit.has("timeout") ? options.timeout : defaults.timeout;
   if (!deepTypes.has(options.type)) fail(`Invalid --type ${options.type}`);
   if (!formats.has(options.format)) fail(`Invalid --format ${options.format}`);
+  if (!Number.isInteger(options.numResults) || options.numResults < 1 || options.numResults > EXA_MAX_NUM_RESULTS) fail(`Invalid --num-results ${options.numResults}. Exa /search accepts 1-${EXA_MAX_NUM_RESULTS} (INVALID_NUM_RESULTS).`);
+  if (!Number.isInteger(options.textMaxCharacters) || options.textMaxCharacters < 1 || options.textMaxCharacters > EXA_MAX_TEXT_CHARACTERS) fail(`Invalid --text-max-characters ${options.textMaxCharacters}. Exa text.maxCharacters accepts 1-${EXA_MAX_TEXT_CHARACTERS}.`);
+  if (options.additionalQuery.length > EXA_MAX_ADDITIONAL_QUERIES) fail(`Too many --additional-query values (${options.additionalQuery.length}). Exa additionalQueries accepts at most ${EXA_MAX_ADDITIONAL_QUERIES}.`);
   return options;
 }
 
@@ -195,6 +205,13 @@ function synthesized(raw) {
   if (typeof raw?.data?.answer === "string") return raw.data.answer;
   return "Exa returned sources but no synthesized answer field. Review evidence and raw metadata.";
 }
+function hasSynthesis(raw) {
+  return !isGenericNoAnswer(synthesized(raw));
+}
+function structuredOutputContent(raw) {
+  const content = raw?.output?.content;
+  return content && typeof content === "object" && !Array.isArray(content) ? content : undefined;
+}
 function sourcesMarkdown(results) {
   if (!results.length) return "- No source URLs returned by Exa.";
   return results.map((r, i) => `- [${i + 1}] ${r.title || r.url || "Untitled"}${r.url ? ` — ${r.url}` : ""}${r.publishedDate ? ` (${r.publishedDate})` : ""}`).join("\n");
@@ -217,12 +234,24 @@ function fallbackSummary(raw) {
   const themes = results.slice(0, 5).map((r, i) => `(${i + 1}) ${r.title || r.url || "Untitled"}`).join("; ");
   return `Exa returned ${results.length} sources but no synthesized answer field. The strongest source clusters are: ${themes}. Treat the findings below as an evidence brief and validate recommendations against primary sources before committing.`;
 }
-function keyFindings(raw) {
-  const answer = synthesized(raw);
-  if (!isGenericNoAnswer(answer)) return answer;
-  const results = normalizeResults(raw);
+function sourceFindingBullets(results) {
   if (!results.length) return "- No source-backed findings were returned.";
   return results.slice(0, 8).map((r, i) => `- [${i + 1}] ${r.title || r.url || "Untitled"}: ${resultSnippet(r, 260) || "Review source directly."}`).join("\n");
+}
+// Key Findings must not repeat the Executive Summary: prefer the structured
+// keyFindings array; otherwise fall back to per-source bullets.
+function keyFindings(raw) {
+  const content = structuredOutputContent(raw);
+  const findings = Array.isArray(content?.keyFindings) ? content.keyFindings : Array.isArray(content?.findings) ? content.findings : [];
+  const bullets = findings.map((item) => (typeof item === "string" ? item : JSON.stringify(item))).filter((item) => item.trim());
+  if (bullets.length) return bullets.map((item) => `- ${item.trim()}`).join("\n");
+  return sourceFindingBullets(normalizeResults(raw));
+}
+function recommendationMarkdown(raw) {
+  const content = structuredOutputContent(raw);
+  if (typeof content?.recommendation === "string" && content.recommendation.trim()) return content.recommendation.trim();
+  if (hasSynthesis(raw)) return synthesized(raw);
+  return "No synthesized recommendation was returned (evidence brief only). Derive the decision from the evidence above and validate against primary sources before committing.";
 }
 function evidenceMarkdown(results) {
   return results.map((r, i) => {
@@ -231,17 +260,26 @@ function evidenceMarkdown(results) {
   }).join("\n\n");
 }
 function renderFindings(query, raw, metadata = {}, rawOutput) {
-  const answer = fallbackSummary(raw);
+  const content = structuredOutputContent(raw);
+  const summary = typeof content?.executiveSummary === "string" && content.executiveSummary.trim() ? content.executiveSummary.trim() : fallbackSummary(raw);
   const findings = keyFindings(raw);
+  const recommendation = recommendationMarkdown(raw);
   const results = normalizeResults(raw);
+  const additional = Array.isArray(metadata.additionalQueries) ? metadata.additionalQueries : [];
+  const queryLine = additional.length
+    ? `- Queries: ${metadata.queryCount} (1 primary + ${additional.length} additional, applied via ${metadata.additionalQueriesApplied === "local-fan-out" ? "local per-query fan-out" : "Exa additionalQueries"})`
+    : `- Queries: ${metadata.queryCount || 1}`;
   const metadataLines = [
     `- Mode: ${metadata.researchMode || "standard"}`,
     `- Exa type: ${metadata.type || "deep-reasoning"}`,
-    `- Queries: ${metadata.queryCount || 1}`,
+    queryLine,
+    ...additional.map((q) => `  - Additional query: ${q}`),
+    `- Exa requests: ${metadata.requestCount || 1}`,
+    `- Synthesis: ${hasSynthesis(raw) ? "present" : "absent (evidence brief only)"}`,
     `- Sources: ${metadata.uniqueSourceCount ?? results.length} unique${metadata.sourceCount && metadata.sourceCount !== results.length ? ` (${metadata.sourceCount} returned before dedupe)` : ""}`,
     rawOutput ? `- Raw metadata sidecar: ${rawOutput}` : undefined,
   ].filter(Boolean).join("\n");
-  return `# Findings: ${query}\n\n## Research Question\n\n${query}\n\n## Executive Summary\n\n${answer}\n\n## Key Findings\n\n${findings}\n\n## Evidence and Sources\n\n${sourcesMarkdown(results)}\n\n${evidenceMarkdown(results)}\n\n## Tradeoffs / Alternatives\n\n- Compare benefits against implementation cost, operational risk, and project-specific constraints before committing.\n- Prefer primary-source documentation and current release notes when evidence conflicts.\n\n## Recommendation / Decision Criteria\n\n${answer}\n\nUse the source evidence above as decision criteria; validate any project-specific assumptions before irreversible work.\n\n## Risks / Unknowns\n\n- Verify source freshness and applicability.\n- Re-run if upstream APIs, pricing, or release notes change.\n- Treat uncited or snippet-only claims as hypotheses until confirmed by primary sources.\n\n## Revisit Conditions\n\n- New primary-source documentation contradicts these findings.\n- Implementation constraints differ from supplied context.\n- Exa returns materially different source coverage in a later run.\n\n## Research Metadata\n\n${metadataLines}\n`;
+  return `# Findings: ${query}\n\n## Research Question\n\n${query}\n\n## Executive Summary\n\n${summary}\n\n## Key Findings\n\n${findings}\n\n## Evidence and Sources\n\n${sourcesMarkdown(results)}\n\n${evidenceMarkdown(results)}\n\n## Tradeoffs / Alternatives\n\n- Compare benefits against implementation cost, operational risk, and project-specific constraints before committing.\n- Prefer primary-source documentation and current release notes when evidence conflicts.\n\n## Recommendation / Decision Criteria\n\n${recommendation}\n\nUse the source evidence above as decision criteria; validate any project-specific assumptions before irreversible work.\n\n## Risks / Unknowns\n\n- Verify source freshness and applicability.\n- Re-run if upstream APIs, pricing, or release notes change.\n- Treat uncited or snippet-only claims as hypotheses until confirmed by primary sources.\n\n## Revisit Conditions\n\n- New primary-source documentation contradicts these findings.\n- Implementation constraints differ from supplied context.\n- Exa returns materially different source coverage in a later run.\n\n## Research Metadata\n\n${metadataLines}\n`;
 }
 
 function defaultRawOutputPath(outputPath) {
@@ -266,22 +304,35 @@ function dedupeResults(responses) {
   return { results, sourceCount };
 }
 
-function combineResponses(responses, options, elapsedMs) {
+function uniqueQueries(query, options) {
+  return Array.from(new Set([query, ...options.additionalQuery].map((item) => item.trim()).filter(Boolean)));
+}
+
+function combineResponses(responses, options, query, elapsedMs) {
   const { results, sourceCount } = dedupeResults(responses);
   const answers = responses.map((raw, index) => {
     const answer = synthesized(raw);
-    return answer ? `Query ${index + 1}: ${answer}` : undefined;
+    return !isGenericNoAnswer(answer) ? `Query ${index + 1}: ${answer}` : undefined;
   }).filter(Boolean);
   const raw = responses.length === 1
     ? { ...responses[0], results }
-    : { answer: answers.join("\n\n"), results, responses };
+    : { ...(answers.length ? { answer: answers.join("\n\n") } : {}), results, responses };
+  const queries = uniqueQueries(query, options);
+  const additionalQueries = queries.slice(1);
   const metadata = {
     researchMode: options.mode,
     type: options.type,
     numResults: options.numResults,
     textMaxCharacters: options.textMaxCharacters,
     timeoutSeconds: options.timeout,
-    queryCount: responses.length,
+    // queryCount = distinct queries submitted (primary + additional).
+    // requestCount = Exa API calls: full mode fans out one request per query;
+    // other modes send one request carrying additionalQueries (consumed by deep search types).
+    queryCount: queries.length,
+    requestCount: responses.length,
+    additionalQueries,
+    additionalQueriesApplied: !additionalQueries.length ? "none" : options.mode === "full" ? "local-fan-out" : "provider-additional-queries",
+    synthesis: hasSynthesis(raw),
     sourceCount,
     uniqueSourceCount: results.length,
     elapsedMs,
@@ -323,8 +374,8 @@ async function callExa(query, options) {
     type: options.type,
     numResults: options.numResults,
     contents: options.mode === "lite"
-      ? { text: { maxCharacters: options.textMaxCharacters }, highlights: { maxCharacters: 600, numSentences: 3, highlightsPerUrl: 1 } }
-      : { text: { maxCharacters: options.textMaxCharacters }, highlights: { maxCharacters: 900, numSentences: 4, highlightsPerUrl: 2 }, summary: { query: "Summarize source evidence relevant to the research question, preserving concrete facts and tradeoffs." } },
+      ? { text: { maxCharacters: options.textMaxCharacters }, highlights: { maxCharacters: 600 } }
+      : { text: { maxCharacters: options.textMaxCharacters }, highlights: { maxCharacters: 900 }, summary: { query: "Summarize source evidence relevant to the research question, preserving concrete facts and tradeoffs." } },
     outputSchema: options.mode === "lite" ? undefined : defaultOutputSchema,
     systemPrompt: await buildSystemPrompt(options),
     additionalQueries: options.additionalQuery.length ? options.additionalQuery : undefined,
@@ -335,17 +386,100 @@ async function callExa(query, options) {
   };
   Object.keys(body).forEach((key) => body[key] === undefined && delete body[key]);
   try {
-    const queries = options.mode === "full" ? Array.from(new Set([query, ...options.additionalQuery].map((item) => item.trim()).filter(Boolean))) : [query];
+    const queries = options.mode === "full" ? uniqueQueries(query, options) : [query];
     const responses = [];
     for (const currentQuery of queries) {
       const currentBody = { ...body, query: currentQuery };
       if (options.mode === "full") delete currentBody.additionalQueries;
       responses.push(await callExaBody(currentBody, options, controller));
     }
-    return combineResponses(responses, options, Date.now() - startedAt);
+    return combineResponses(responses, options, query, Date.now() - startedAt);
   } finally {
     clearTimeout(timer);
   }
+}
+
+const requiredReportSections = ["Research Question", "Executive Summary", "Key Findings", "Evidence and Sources", "Tradeoffs / Alternatives", "Recommendation / Decision Criteria", "Risks / Unknowns", "Revisit Conditions", "Research Metadata"];
+const additionalQueriesAppliedValues = new Set(["none", "provider-additional-queries", "local-fan-out"]);
+
+function reportSections(report) {
+  const sections = {};
+  let current;
+  for (const line of report.split(/\r?\n/)) {
+    const heading = line.match(/^##\s+(.+?)\s*$/);
+    if (heading) { current = heading[1]; sections[current] = []; continue; }
+    if (current) sections[current].push(line);
+  }
+  return Object.fromEntries(Object.entries(sections).map(([name, lines]) => [name, lines.join("\n").trim()]));
+}
+
+function normalizedProse(text) {
+  return String(text || "").toLowerCase().replace(/^[\s>*-]+/gm, "").replace(/[#`_[\]()]/g, "").replace(/\s+/g, " ").trim();
+}
+
+async function validateCommand(options) {
+  const [reportArg, rawArg] = options.positional;
+  if (!reportArg || !rawArg) fail("Usage: deep-research validate <findings.md> <findings.raw.json>");
+  const reportPath = resolvePath(reportArg);
+  const rawPath = resolvePath(rawArg);
+  const errors = [];
+  const warnings = [];
+
+  let report = "";
+  if (!existsSync(reportPath)) errors.push(`Report not found: ${reportPath}`);
+  else {
+    report = await readFile(reportPath, "utf8");
+    if (!report.trim()) errors.push(`Report is empty: ${reportPath}`);
+  }
+
+  let sidecar;
+  if (!existsSync(rawPath)) errors.push(`Raw sidecar not found: ${rawPath}`);
+  else {
+    try { sidecar = JSON.parse(await readFile(rawPath, "utf8")); }
+    catch (parseError) { errors.push(`Raw sidecar is not valid JSON: ${parseError.message}`); }
+  }
+
+  const metadata = sidecar && typeof sidecar.metadata === "object" && sidecar.metadata ? sidecar.metadata : undefined;
+  const payload = sidecar && typeof sidecar.raw === "object" && sidecar.raw ? sidecar.raw : undefined;
+  if (sidecar && !metadata) errors.push("Raw sidecar has no metadata object.");
+  if (sidecar && !payload) errors.push("Raw sidecar has no raw provider payload.");
+
+  const sections = report ? reportSections(report) : {};
+  for (const section of requiredReportSections) {
+    if (report && !(section in sections)) errors.push(`Report is missing required section: ## ${section}`);
+  }
+
+  if (metadata) {
+    if (Array.isArray(metadata.additionalQueries)) {
+      const expected = 1 + metadata.additionalQueries.length;
+      if (metadata.queryCount !== expected) errors.push(`metadata.queryCount is ${metadata.queryCount} but 1 primary + ${metadata.additionalQueries.length} additional queries were recorded (expected ${expected}).`);
+      if (!additionalQueriesAppliedValues.has(metadata.additionalQueriesApplied)) errors.push(`metadata.additionalQueriesApplied is ${JSON.stringify(metadata.additionalQueriesApplied)}; expected one of: ${Array.from(additionalQueriesAppliedValues).join(", ")}.`);
+      else if ((metadata.additionalQueriesApplied === "none") !== (metadata.additionalQueries.length === 0)) errors.push("metadata.additionalQueriesApplied contradicts metadata.additionalQueries.");
+    } else warnings.push("Sidecar does not record how additional queries were applied (metadata.additionalQueries missing — sidecar predates this check or was produced by another tool). Re-run with the current script to verify query expansion.");
+  }
+
+  const synthesis = payload ? hasSynthesis(payload) : false;
+  if (metadata && typeof metadata.synthesis === "boolean" && metadata.synthesis !== synthesis) warnings.push(`metadata.synthesis is ${metadata.synthesis} but the raw payload ${synthesis ? "contains" : "lacks"} a synthesized answer.`);
+  if (payload && !synthesis) {
+    const mode = metadata?.researchMode;
+    if (mode === "standard" || mode === "full") errors.push(`Mode ${mode} requests server-side synthesis (outputSchema) but the raw payload has no synthesized answer. Re-run, or treat the report as an evidence brief only.`);
+    else warnings.push("No synthesized answer in the raw payload — this is an evidence brief. Do not use it as a decision recommendation; re-run with --mode standard or --mode full if the deliverable is a recommendation.");
+  }
+  if (payload && !normalizeResults(payload).length) warnings.push("Raw payload contains zero sources. Re-run with broader terms or fewer filters.");
+
+  const summarySection = normalizedProse(sections["Executive Summary"]);
+  const findingsSection = normalizedProse(sections["Key Findings"]);
+  if (summarySection && findingsSection) {
+    const [shorter, longer] = summarySection.length <= findingsSection.length ? [summarySection, findingsSection] : [findingsSection, summarySection];
+    if (summarySection === findingsSection || (shorter.length > 200 && longer.includes(shorter))) warnings.push("Key Findings duplicates the Executive Summary text. Regenerate, or rewrite Key Findings as distinct claims.");
+  }
+
+  const sidecarRef = report.match(/Raw metadata sidecar:\s*(\S+)/);
+  if (sidecarRef && resolve(sidecarRef[1]) !== rawPath) warnings.push(`Report references sidecar ${sidecarRef[1]} but ${rawPath} was validated.`);
+
+  const ok = errors.length === 0;
+  jsonOut(process.stdout, { ok, report: reportPath, raw: rawPath, mode: metadata?.researchMode, synthesis, queryCount: metadata?.queryCount, errors, warnings });
+  process.exit(ok ? 0 : 1);
 }
 
 async function main() {
@@ -359,6 +493,7 @@ async function main() {
     jsonOut(process.stdout, { ok: true, node: process.version, fetch: typeof fetch === "function", exaApiKey: Boolean(process.env.EXA_API_KEY) });
     return;
   }
+  if (options.command === "validate") { await validateCommand(options); return; }
   if (options.command !== "report" && options.command !== "json") fail(`Unknown command: ${options.command}`);
   const query = await resolveQuery(options);
   const { raw, metadata } = await callExa(query, options);

--- a/skills/deep-research/templates/findings-report-format.md
+++ b/skills/deep-research/templates/findings-report-format.md
@@ -21,4 +21,6 @@ Report requirements:
 - Keep evidence excerpts concise and readable; prefer short blockquotes or summaries over raw payload dumps.
 - Do not embed raw Exa JSON or fenced raw metadata blocks in `findings.md`.
 - Preserve raw provider payloads in a sidecar JSON file: `findings.raw.json` by default when writing `findings.md`, or the explicit raw output path supplied by the workflow/tool.
-- Use the same section layout for `lite`, `standard`, and `full`; the `Research Metadata` section records the mode, Exa type, query count, source counts, and sidecar path.
+- Use the same section layout for `lite`, `standard`, and `full`; the `Research Metadata` section records the mode, Exa type, query count (with additional queries and how they were applied), request count, synthesis presence, source counts, and sidecar path.
+- `Key Findings` must contain distinct claims, not a repeat of the `Executive Summary`.
+- Validate the finished pair with `scripts/deep-research validate <findings.md> <findings.raw.json>`.

--- a/skills/deep-research/tests/deep-research.test.mjs
+++ b/skills/deep-research/tests/deep-research.test.mjs
@@ -20,11 +20,26 @@ test("help documents modes, context args, and sidecar behavior", () => {
   assert.equal(result.status, 0);
   const json = JSON.parse(result.stdout);
   assert.equal(json.ok, true);
-  assert.match(json.usage, /report\|json\|doctor/);
-  assert.equal(json.modes.full.numResults, 150);
+  assert.match(json.usage, /report\|json\|validate\|doctor/);
+  assert.equal(json.modes.full.numResults, 100);
+  assert.equal(json.modes.standard.textMaxCharacters, 10000);
   assert.ok(json.flags.includes("--query-file <path>"));
   assert.ok(json.flags.includes("--context-glob <glob>"));
   assert.match(json.sidecar, /not embedded in findings\.md/);
+  assert.match(json.validate, /deterministic post-run checks/);
+});
+
+test("out-of-range num-results and text-max-characters fail with Exa limits", () => {
+  const dir = mkdtempSync(join(tmpdir(), "deep-research-limits-"));
+  const mock = join(dir, "mock.json");
+  writeFileSync(mock, JSON.stringify({ answer: "Answer", results: [] }));
+  const env = { ...process.env, EXA_MOCK_RESPONSE_FILE: mock };
+  const tooMany = spawnSync(process.execPath, [script, "report", "q", "--num-results", "150"], { encoding: "utf8", env });
+  assert.notEqual(tooMany.status, 0);
+  assert.match(tooMany.stderr, /Invalid --num-results 150.*1-100/);
+  const tooLong = spawnSync(process.execPath, [script, "report", "q", "--text-max-characters", "16000"], { encoding: "utf8", env });
+  assert.notEqual(tooLong.status, 0);
+  assert.match(tooLong.stderr, /Invalid --text-max-characters 16000.*1-10000/);
 });
 
 test("findings template and format guide forbid embedded raw metadata", () => {
@@ -131,9 +146,123 @@ test("full mode aggregates multiple mock responses and dedupes URLs", () => {
   const sidecar = JSON.parse(readFileSync(raw, "utf8"));
   assert.equal(sidecar.metadata.sourceCount, 4);
   assert.equal(sidecar.metadata.uniqueSourceCount, 3);
+  assert.equal(sidecar.metadata.requestCount, 2);
+  assert.deepEqual(sidecar.metadata.additionalQueries, ["second"]);
+  assert.equal(sidecar.metadata.additionalQueriesApplied, "local-fan-out");
   const report = readFileSync(output, "utf8");
   assert.match(report, /Mode: full/);
+  assert.match(report, /Queries: 2 \(1 primary \+ 1 additional, applied via local per-query fan-out\)/);
+  assert.match(report, /Additional query: second/);
   assert.doesNotMatch(report, /Dup 2/);
+});
+
+test("standard mode records additional queries as provider additionalQueries", () => {
+  const dir = mkdtempSync(join(tmpdir(), "deep-research-addq-"));
+  const mock = join(dir, "mock.json");
+  const output = join(dir, "findings.md");
+  const raw = join(dir, "raw.json");
+  writeFileSync(mock, JSON.stringify({ answer: "Answer", results: [{ title: "Source", url: "https://example.com" }] }));
+  const result = spawnSync(process.execPath, [script, "report", "main", "--additional-query", "alt one", "--additional-query", "alt two", "--output", output, "--raw-output", raw], { encoding: "utf8", env: { ...process.env, EXA_MOCK_RESPONSE_FILE: mock } });
+  assert.equal(result.status, 0, result.stderr);
+  const stdout = JSON.parse(result.stdout);
+  assert.equal(stdout.queryCount, 3);
+  const sidecar = JSON.parse(readFileSync(raw, "utf8"));
+  assert.equal(sidecar.metadata.queryCount, 3);
+  assert.equal(sidecar.metadata.requestCount, 1);
+  assert.deepEqual(sidecar.metadata.additionalQueries, ["alt one", "alt two"]);
+  assert.equal(sidecar.metadata.additionalQueriesApplied, "provider-additional-queries");
+  assert.match(readFileSync(output, "utf8"), /Queries: 3 \(1 primary \+ 2 additional, applied via Exa additionalQueries\)/);
+});
+
+test("structured output renders distinct summary, findings, and recommendation", () => {
+  const dir = mkdtempSync(join(tmpdir(), "deep-research-structured-"));
+  const mock = join(dir, "mock.json");
+  const output = join(dir, "findings.md");
+  writeFileSync(mock, JSON.stringify({
+    output: { content: { executiveSummary: "Summary text.", keyFindings: ["Finding one.", "Finding two."], recommendation: "Adopt option A." } },
+    results: [{ title: "Source", url: "https://example.com" }],
+  }));
+  const result = spawnSync(process.execPath, [script, "report", "question", "--output", output], { encoding: "utf8", env: { ...process.env, EXA_MOCK_RESPONSE_FILE: mock } });
+  assert.equal(result.status, 0, result.stderr);
+  const report = readFileSync(output, "utf8");
+  assert.match(report, /## Executive Summary\n\nSummary text\./);
+  assert.match(report, /## Key Findings\n\n- Finding one\.\n- Finding two\./);
+  assert.match(report, /## Recommendation \/ Decision Criteria\n\nAdopt option A\./);
+  assert.match(report, /Synthesis: present/);
+});
+
+test("validate passes on freshly generated report and sidecar", () => {
+  const dir = mkdtempSync(join(tmpdir(), "deep-research-validate-ok-"));
+  const mock = join(dir, "mock.json");
+  const output = join(dir, "findings.md");
+  const raw = join(dir, "findings.raw.json");
+  writeFileSync(mock, JSON.stringify({ answer: "A well-supported synthesized answer.", results: [{ title: "Source", url: "https://example.com", text: "Detailed source text." }] }));
+  const generate = spawnSync(process.execPath, [script, "report", "question", "--additional-query", "variant", "--output", output], { encoding: "utf8", env: { ...process.env, EXA_MOCK_RESPONSE_FILE: mock } });
+  assert.equal(generate.status, 0, generate.stderr);
+  const result = spawnSync(process.execPath, [script, "validate", output, raw], { encoding: "utf8" });
+  assert.equal(result.status, 0, result.stderr);
+  const json = JSON.parse(result.stdout);
+  assert.equal(json.ok, true);
+  assert.deepEqual(json.errors, []);
+  assert.equal(json.synthesis, true);
+  assert.equal(json.queryCount, 2);
+});
+
+test("validate errors when standard mode lacks synthesis and flags evidence-brief lite", () => {
+  const dir = mkdtempSync(join(tmpdir(), "deep-research-validate-synth-"));
+  const mock = join(dir, "mock.json");
+  const output = join(dir, "findings.md");
+  const raw = join(dir, "findings.raw.json");
+  writeFileSync(mock, JSON.stringify({ results: [{ title: "Source", url: "https://example.com", text: "Evidence only." }] }));
+  const standard = spawnSync(process.execPath, [script, "report", "question", "--output", output], { encoding: "utf8", env: { ...process.env, EXA_MOCK_RESPONSE_FILE: mock } });
+  assert.equal(standard.status, 0, standard.stderr);
+  const standardValidate = spawnSync(process.execPath, [script, "validate", output, raw], { encoding: "utf8" });
+  assert.equal(standardValidate.status, 1);
+  const standardJson = JSON.parse(standardValidate.stdout);
+  assert.equal(standardJson.ok, false);
+  assert.ok(standardJson.errors.some((e) => /Mode standard requests server-side synthesis/.test(e)));
+  const lite = spawnSync(process.execPath, [script, "report", "question", "--mode", "lite", "--output", output], { encoding: "utf8", env: { ...process.env, EXA_MOCK_RESPONSE_FILE: mock } });
+  assert.equal(lite.status, 0, lite.stderr);
+  const liteValidate = spawnSync(process.execPath, [script, "validate", output, raw], { encoding: "utf8" });
+  assert.equal(liteValidate.status, 0, liteValidate.stderr);
+  const liteJson = JSON.parse(liteValidate.stdout);
+  assert.equal(liteJson.ok, true);
+  assert.ok(liteJson.warnings.some((w) => /evidence brief/.test(w)));
+});
+
+test("validate errors on queryCount mismatch and missing files", () => {
+  const dir = mkdtempSync(join(tmpdir(), "deep-research-validate-bad-"));
+  const mock = join(dir, "mock.json");
+  const output = join(dir, "findings.md");
+  const raw = join(dir, "findings.raw.json");
+  writeFileSync(mock, JSON.stringify({ answer: "Answer", results: [{ title: "Source", url: "https://example.com" }] }));
+  const generate = spawnSync(process.execPath, [script, "report", "question", "--output", output], { encoding: "utf8", env: { ...process.env, EXA_MOCK_RESPONSE_FILE: mock } });
+  assert.equal(generate.status, 0, generate.stderr);
+  const sidecar = JSON.parse(readFileSync(raw, "utf8"));
+  sidecar.metadata.queryCount = 5;
+  writeFileSync(raw, JSON.stringify(sidecar));
+  const mismatch = spawnSync(process.execPath, [script, "validate", output, raw], { encoding: "utf8" });
+  assert.equal(mismatch.status, 1);
+  assert.ok(JSON.parse(mismatch.stdout).errors.some((e) => /queryCount is 5/.test(e)));
+  const missing = spawnSync(process.execPath, [script, "validate", join(dir, "nope.md"), join(dir, "nope.json")], { encoding: "utf8" });
+  assert.equal(missing.status, 1);
+  const missingJson = JSON.parse(missing.stdout);
+  assert.ok(missingJson.errors.some((e) => /Report not found/.test(e)));
+  assert.ok(missingJson.errors.some((e) => /Raw sidecar not found/.test(e)));
+});
+
+test("validate warns when Key Findings duplicates the Executive Summary", () => {
+  const dir = mkdtempSync(join(tmpdir(), "deep-research-validate-dup-"));
+  const report = join(dir, "findings.md");
+  const raw = join(dir, "findings.raw.json");
+  const duplicated = "The same long synthesized answer repeated verbatim across sections, which indicates the report generator collapsed distinct sections into one blob of text and the reader gains nothing from the second copy of it.";
+  const sections = ["# Findings: q", "## Research Question", "q", "## Executive Summary", duplicated, "## Key Findings", duplicated, "## Evidence and Sources", "- [1] Source — https://example.com", "## Tradeoffs / Alternatives", "- t", "## Recommendation / Decision Criteria", "r", "## Risks / Unknowns", "- r", "## Revisit Conditions", "- r", "## Research Metadata", "- Mode: standard"].join("\n\n");
+  writeFileSync(report, sections);
+  writeFileSync(raw, JSON.stringify({ metadata: { researchMode: "standard", queryCount: 1, additionalQueries: [], additionalQueriesApplied: "none", synthesis: true }, raw: { answer: duplicated, results: [{ url: "https://example.com" }] } }));
+  const result = spawnSync(process.execPath, [script, "validate", report, raw], { encoding: "utf8" });
+  assert.equal(result.status, 0, result.stderr);
+  const json = JSON.parse(result.stdout);
+  assert.ok(json.warnings.some((w) => /duplicates the Executive Summary/.test(w)));
 });
 
 test("resolves EXA_API_KEY op:// references with op CLI", () => {


### PR DESCRIPTION
## Summary
- Add a deterministic `deep-research validate <findings.md> <findings.raw.json>` subcommand (the issue's missing command): checks section completeness, `queryCount` vs recorded `additionalQueries`, synthesis presence (error for `standard`/`full`, warning for `lite` evidence briefs), and executive-summary/key-findings duplication; prints `{ok, errors, warnings}`.
- Ground mode defaults in real Exa `/search` limits (`numResults` 1-100, `text.maxCharacters` 1-10000, `additionalQueries` ≤10) and reject out-of-range flags with the API's error tags. Previous `standard`/`full` text caps (16k/24k) and `full` results (150) exceeded Exa's maximum.
- Record `queryCount` vs `requestCount` and `additionalQueriesApplied` in sidecar metadata so callers can verify how `--additional-query` values were applied.
- Document task-type flag recipes, `--num-results`/`--text-max-characters` noise tradeoffs, `--include-domain` host-vs-quality-filter caveat, and manual (LLM-judgment) review checks in SKILL.md.

## Context
- Grounded in current Exa API docs (exa.ai/docs): `/search` deep types, `outputSchema`-based synthesis, `additionalQueries` semantics; the legacy `/research/v1` task API is sunset and is not used.

## Completed Issues
- Closes #457

## Test Plan
- `node --test skills/deep-research/tests/deep-research.test.mjs` — 18/18 pass (incl. new validate + metadata cases).
- Live end-to-end: real `lite` Exa query rendered a report, and `validate` returned exit 0 with the correct evidence-brief warning.
