### PR TITLE
orch(issue-452): make external review verdict check harness-safe

### DIFF
--- a/skills/orch/scripts/review-artifact-check
+++ b/skills/orch/scripts/review-artifact-check
@@ -9,19 +9,54 @@ set -euo pipefail
 
 usage() {
   cat >&2 << 'EOF'
-Usage: review-artifact-check <worktree_path> <agent_name> <delegated_at_epoch>
+Usage:
+  review-artifact-check <worktree_path> <agent_name> <delegated_at_epoch>
+  review-artifact-check --file <json_path>
 
-Checks [WORKTREE]/tmp/review-[AGENT]-*.json newest-first and prints JSON:
+Glob mode: checks [WORKTREE]/tmp/review-[AGENT]-*.json newest-first.
+File mode (--file): checks one explicit JSON file (existence + verdict),
+for artifacts written to a known path such as the external review output.
+
+Both modes print JSON:
   {ok: bool, path: string|null, reason: "valid"|"missing"|"stale"|"invalid"}
 
 reason meanings when ok=false:
-  missing  no review-[AGENT]-*.json files found
-  stale    newest artifact mtime < delegated_at_epoch
-  invalid  newest fresh artifact fails `jq -e '.verdict'`
+  missing  no matching artifact found (glob) / file does not exist (--file)
+  stale    newest artifact mtime < delegated_at_epoch (glob mode only)
+  invalid  artifact fails `jq -e '.verdict'`
 
 Exit 0 when a valid artifact was found, 1 otherwise, 2 on usage error.
 EOF
 }
+
+emit() {
+  local ok="$1" path="$2" reason="$3"
+  jq -n --argjson ok "$ok" --arg path "$path" --arg reason "$reason" \
+    '{ok: $ok, path: (if $path == "" then null else $path end), reason: $reason}'
+}
+
+# --- File mode: validate one explicit JSON path deterministically ---
+if [[ "${1:-}" == "--file" ]]; then
+  if [[ $# -ne 2 ]]; then
+    usage
+    exit 2
+  fi
+  file="$2"
+  if [[ -z "$file" ]]; then
+    echo "Error: --file requires a non-empty path" >&2
+    exit 2
+  fi
+  if [[ ! -f "$file" ]]; then
+    emit false "" "missing"
+    exit 1
+  fi
+  if ! jq -e '.verdict' "$file" >/dev/null 2>&1; then
+    emit false "$file" "invalid"
+    exit 1
+  fi
+  emit true "$file" "valid"
+  exit 0
+fi
 
 if [[ $# -ne 3 ]]; then
   usage
@@ -44,12 +79,6 @@ if ! [[ "$delegated_at" =~ ^[0-9]+$ ]]; then
   echo "Error: delegated_at_epoch must be epoch seconds, got '$delegated_at'" >&2
   exit 2
 fi
-
-emit() {
-  local ok="$1" path="$2" reason="$3"
-  jq -n --argjson ok "$ok" --arg path "$path" --arg reason "$reason" \
-    '{ok: $ok, path: (if $path == "" then null else $path end), reason: $reason}'
-}
 
 file_mtime() {
   stat -c %Y "$1" 2>/dev/null || stat -f %m "$1"

--- a/skills/orch/tests/review_artifact_check.sh
+++ b/skills/orch/tests/review_artifact_check.sh
@@ -118,6 +118,42 @@ out="$("$CHECK" "$worktree" reviewer-quality "$delegated_at")"
 assert_eq "$(jq -r '.ok' <<<"$out")" "true" "newest-invalid falls back to older valid artifact"
 assert_eq "$(jq -r '.path' <<<"$out")" "$valid" "fallback selects the older fresh valid artifact"
 
+# --- --file mode: explicit path validation (external review output) ---
+ext_valid="$worktree/tmp/review-external-20260709-050505.json"
+printf '{"verdict":"pass","items":[]}' > "$ext_valid"
+out="$("$CHECK" --file "$ext_valid")"
+rc=$?
+assert_eq "$rc" "0" "--file valid artifact exits 0"
+assert_eq "$(jq -r '.ok' <<<"$out")" "true" "--file valid reports ok=true"
+assert_eq "$(jq -r '.path' <<<"$out")" "$ext_valid" "--file valid reports its path"
+assert_eq "$(jq -r '.reason' <<<"$out")" "valid" "--file valid reports reason=valid"
+
+# --file does not apply the staleness gate — an old mtime still validates
+touch -d "@$before" "$ext_valid"
+out="$("$CHECK" --file "$ext_valid")"
+assert_eq "$(jq -r '.ok' <<<"$out")" "true" "--file ignores mtime (no staleness gate)"
+
+# --file: missing file
+set +e
+out="$("$CHECK" --file "$worktree/tmp/review-external-does-not-exist.json")"
+rc=$?
+set -e
+assert_eq "$rc" "1" "--file missing artifact exits 1"
+assert_eq "$(jq -r '.ok' <<<"$out")" "false" "--file missing reports ok=false"
+assert_eq "$(jq -r '.path' <<<"$out")" "null" "--file missing reports null path"
+assert_eq "$(jq -r '.reason' <<<"$out")" "missing" "--file missing reports reason=missing"
+
+# --file: exists but no verdict field
+ext_invalid="$worktree/tmp/review-external-20260709-060606.json"
+printf '{"items":[]}' > "$ext_invalid"
+set +e
+out="$("$CHECK" --file "$ext_invalid")"
+rc=$?
+set -e
+assert_eq "$rc" "1" "--file missing verdict exits 1"
+assert_eq "$(jq -r '.reason' <<<"$out")" "invalid" "--file missing verdict reports reason=invalid"
+assert_eq "$(jq -r '.path' <<<"$out")" "$ext_invalid" "--file invalid reports the file path"
+
 # --- usage errors ---
 set +e
 "$CHECK" "$worktree" reviewer-quality >/dev/null 2>&1
@@ -126,6 +162,8 @@ assert_eq "$?" "2" "missing arguments exit 2"
 assert_eq "$?" "2" "non-numeric delegated_at exits 2"
 "$CHECK" "$TMP_ROOT/does-not-exist" reviewer-quality "$delegated_at" >/dev/null 2>&1
 assert_eq "$?" "2" "nonexistent worktree exits 2"
+"$CHECK" --file >/dev/null 2>&1
+assert_eq "$?" "2" "--file with no path exits 2"
 set -e
 
 # --- review-pr.md wires the deterministic acceptance ---
@@ -135,6 +173,8 @@ assert_file_not_contains "$review_pr" 'A return message arrives with `Verdict:` 
 assert_file_contains "$review_pr" "a return message with \`Verdict:\`/\`File:\` lines is never sufficient by itself" "review-pr states artifact is the only acceptance condition"
 assert_file_contains "$review_pr" "exactly one" "review-pr limits incomplete returns to one re-delegation"
 assert_file_contains "$review_pr" "using your harness file-write tool" "review-pr re-delegation instructs harness file-write tool"
+assert_file_contains "$review_pr" 'review-artifact-check --file "$EXTERNAL_OUTPUT"' "review-pr validates external output via --file mode"
+assert_file_not_contains "$review_pr" "if jq -e '.verdict'" "review-pr no longer prescribes inline if/redirection for external verdict check"
 
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/skills/orch/workflows/review-pr.md
+++ b/skills/orch/workflows/review-pr.md
@@ -171,15 +171,15 @@ mkdir -p [WORKTREE_PATH]/tmp
   --output "$EXTERNAL_OUTPUT"
 ```
 
-**On success** — validate and append:
+**On success** — validate deterministically, then append. `review-artifact-check --file` checks existence and `jq -e '.verdict'` and prints `{ok, path, reason}` — no inline conditional or redirection:
 ```bash
-# Basic schema check: verdict field must exist
-if jq -e '.verdict' "$EXTERNAL_OUTPUT" >/dev/null 2>&1; then
-  .agents/skills/orch/scripts/workflow-state append [ISSUE_ID] json_paths "$EXTERNAL_OUTPUT"
-else
-  echo "Warning: external review JSON missing verdict field — skipping" >&2
-fi
+.agents/skills/orch/scripts/review-artifact-check --file "$EXTERNAL_OUTPUT"
 ```
+**If `ok == true`** — append the external JSON:
+```bash
+.agents/skills/orch/scripts/workflow-state append [ISSUE_ID] json_paths "$EXTERNAL_OUTPUT"
+```
+**If `ok == false`** — the external JSON is missing or has no `verdict` field. Report the `reason` to the user and skip the append (external review is advisory).
 
 **On failure**: report to user but **continue** — external review is advisory, not blocking.
 


### PR DESCRIPTION
## Summary
- Make the one remaining harness-unsafe prescribed command in `review-pr.md` safe for the Codex `functions.exec` approval=Never runtime. The external-review "on success" step used an inline `if jq -e '.verdict' "$FILE" >/dev/null 2>&1; then … else echo … fi`, exactly the redirection/conditional shape that runtime rejects before execution.
- Add a `--file <path>` mode to `review-artifact-check` that validates one explicit JSON file (existence + `jq -e '.verdict'`) and prints `{ok, path, reason}`. review-pr.md now runs that single command and appends on `ok == true` — no inline conditional, redirection, or `&&`/`else` control flow.
- Audited `review-pr.md` and `submit-pr.md` for other prescribed unsafe shapes (redirection to `tmp/`, `$(...)`, `for`/`while`, `&&`/`||` control flow): this was the only violation.

## Completed Issues
- Closes #452

## Test Plan
- Extended `skills/orch/tests/review_artifact_check.sh` with `--file` valid/missing/invalid-verdict/usage cases + review-pr.md wiring assertions.
- `bash skills/orch/tests/run-all.sh` — all 6 files pass (244 assertions, 0 fail).
