### PR TITLE
linear: support clearing issue estimates for zero-point coordination parents

### DIFF
--- a/skills/linear/scripts/commands/issues.sh
+++ b/skills/linear/scripts/commands/issues.sh
@@ -140,7 +140,8 @@ Update Options:
   --description <text>  New description
   --project <name|uuid> Move to project (name or UUID, auto-resolved)
   --priority <0-4>      Priority: 0=None, 1=Urgent, 2=High, 3=Normal, 4=Low
-  --estimate <1-5>      Effort estimate (points)
+  --estimate <0-5>      Effort estimate (points); 0 clears the estimate (unset)
+  --clear-estimate      Clear the estimate (unset; e.g. coordination parents = no estimate)
   --assignee <name|me>  Change assignee
   --parent <id>         Set parent issue (convert to sub-issue)
   --remove-parent       Remove parent (convert to top-level issue)
@@ -181,6 +182,11 @@ Examples:
   # Cycle (sprint) assignment
   issues.sh update PROJ-42 --cycle 864d7ea0-2347-4048-80cd-5be977d904e4
   issues.sh update PROJ-42 --clear-cycle
+
+  # Estimate (1-5 real points; clear for coordination-only parents)
+  issues.sh update PROJ-42 --estimate 3
+  issues.sh update PROJ-42 --clear-estimate      # Unset estimate (coordination parent)
+  issues.sh update PROJ-42 --estimate 0          # Alias for --clear-estimate
 
   # Bulk operations (reduces API calls)
   issues.sh list --project-id <uuid> --with-relations   # Single query with all relations
@@ -514,7 +520,7 @@ bulk_update_issues() {
             update_args+=("$_key" "$_val")
             shift
             ;;
-        --remove-parent | --clear-cycle)
+        --remove-parent | --clear-cycle | --clear-estimate)
             update_args+=("$1")
             shift
             ;;
@@ -1065,6 +1071,7 @@ update_issue() {
     local cycle=""
     local clear_cycle="false"
     local estimate=""
+    local clear_estimate="false"
     local sort_order=""
 
     while [[ $# -gt 0 ]]; do
@@ -1145,6 +1152,10 @@ update_issue() {
             estimate="${1#*=}"
             shift
             ;;
+        --clear-estimate)
+            clear_estimate="true"
+            shift
+            ;;
         --assignee)
             assignee="$2"
             shift 2
@@ -1204,7 +1215,23 @@ update_issue() {
         input_parts+=("\"description\": $escaped_desc")
     fi
     [ -n "$priority" ] && input_parts+=("\"priority\": $priority")
-    [ -n "$estimate" ] && input_parts+=("\"estimate\": $estimate")
+
+    # Handle estimate. Real estimates are 1-5; Linear represents "no estimate" as
+    # null. Clear the estimate via --clear-estimate or the --estimate 0 alias
+    # (used to bring coordination-only parents into the estimate-0 format).
+    if [ "$clear_estimate" = "true" ] && [ -n "$estimate" ] && [ "$estimate" != "0" ]; then
+        echo '{"error": "Use either --estimate <1-5> or --clear-estimate, not both"}' >&2
+        return 1
+    elif [ "$clear_estimate" = "true" ] || [ "$estimate" = "0" ]; then
+        input_parts+=("\"estimate\": null")
+    elif [ -n "$estimate" ]; then
+        if [[ "$estimate" =~ ^[1-5]$ ]]; then
+            input_parts+=("\"estimate\": $estimate")
+        else
+            echo '{"error": "Invalid --estimate: must be an integer 1-5 (use 0 or --clear-estimate to unset)"}' >&2
+            return 1
+        fi
+    fi
 
     # Sort order only meaningful on parent/standalone issues (sub-issues render under parent)
     if [ -n "$sort_order" ]; then

--- a/skills/linear/tests/estimate-clear.test.sh
+++ b/skills/linear/tests/estimate-clear.test.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# Coverage for clearing issue estimates (vstack#461):
+#   - `--clear-estimate` builds an `estimate: null` mutation input
+#   - `--estimate 0` is a compatibility alias for clearing (maps 0 -> null)
+#   - real estimates 1-5 still pass through; 6+/negative/non-int are rejected
+#   - `--clear-estimate` + `--estimate <1-5>` together is a hard error
+#   - the local cache write-through reflects the cleared (null) value
+#   - `bulk-update` forwards --clear-estimate / --estimate 0 to the mutation
+#
+# Self-contained: the Linear API is fully mocked, no network calls.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ISSUES_SH="$SCRIPT_DIR/../scripts/commands/issues.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fails=0
+pass() { echo "PASS $*"; }
+fail() {
+    echo "FAIL $*"
+    fails=$((fails + 1))
+}
+
+# Run update_issue with a fully mocked API. The mocked graphql_query captures
+# the mutation variables (which carry the built input object) to $1; update_issue
+# stdout is discarded and stderr goes to "$1.err". Echoes update_issue's rc.
+run_update() {
+    local capture="$1"
+    shift
+    CAPTURE_FILE="$capture" LINEAR_API_KEY=test-token \
+        bash -uo pipefail -c '
+            capture="$CAPTURE_FILE"
+            issues_sh="$1"
+            shift
+            # shellcheck disable=SC1090
+            source "$issues_sh"
+            get_issue() { printf "%s" "{\"issue\":{\"team\":{\"name\":\"Test\"}}}"; }
+            attach_download_from_text() { :; }
+            graphql_query() {
+                printf "%s" "$2" >"$capture"
+                printf "%s" "{\"issueUpdate\":{\"success\":true,\"issue\":{\"id\":\"uuid-1\",\"identifier\":\"CC-1\",\"title\":\"t\",\"estimate\":null,\"state\":{\"name\":\"Todo\",\"type\":\"unstarted\"}}}}"
+            }
+            update_issue "$@"
+        ' _ "$ISSUES_SH" "$@" >/dev/null 2>"$capture.err"
+    echo "$?"
+}
+
+# --- --clear-estimate builds estimate: null -------------------------------
+cap="$TMP/clear.json"
+rc="$(run_update "$cap" CC-1 --clear-estimate)"
+if [ "$rc" -eq 0 ] && jq -e '.input | has("estimate") and .estimate == null' "$cap" >/dev/null 2>&1; then
+    pass "--clear-estimate -> estimate: null"
+else
+    fail "--clear-estimate (rc=$rc, input=$(cat "$cap" 2>/dev/null))"
+fi
+
+# --- --estimate 0 aliases to clear ----------------------------------------
+cap="$TMP/zero.json"
+rc="$(run_update "$cap" CC-1 --estimate 0)"
+if [ "$rc" -eq 0 ] && jq -e '.input | has("estimate") and .estimate == null' "$cap" >/dev/null 2>&1; then
+    pass "--estimate 0 -> estimate: null"
+else
+    fail "--estimate 0 (rc=$rc, input=$(cat "$cap" 2>/dev/null))"
+fi
+
+# --- --estimate=0 (equals syntax) aliases to clear ------------------------
+cap="$TMP/zero-eq.json"
+rc="$(run_update "$cap" CC-1 --estimate=0)"
+if [ "$rc" -eq 0 ] && jq -e '.input.estimate == null' "$cap" >/dev/null 2>&1; then
+    pass "--estimate=0 -> estimate: null"
+else
+    fail "--estimate=0 (rc=$rc, input=$(cat "$cap" 2>/dev/null))"
+fi
+
+# --- valid 1-5 estimate still passes through ------------------------------
+cap="$TMP/three.json"
+rc="$(run_update "$cap" CC-1 --estimate 3)"
+if [ "$rc" -eq 0 ] && jq -e '.input.estimate == 3' "$cap" >/dev/null 2>&1; then
+    pass "--estimate 3 -> estimate: 3"
+else
+    fail "--estimate 3 (rc=$rc, input=$(cat "$cap" 2>/dev/null))"
+fi
+
+# --- out-of-range / malformed estimates are rejected ----------------------
+for bad in 6 -2 2.5 abc; do
+    cap="$TMP/bad-$bad.json"
+    rc="$(run_update "$cap" CC-1 --estimate "$bad")"
+    if [ "$rc" -ne 0 ] && [ ! -f "$cap" ] && grep -q "Invalid --estimate" "$cap.err" 2>/dev/null; then
+        pass "--estimate $bad rejected (no mutation built)"
+    else
+        fail "--estimate $bad should be rejected (rc=$rc, err=$(cat "$cap.err" 2>/dev/null))"
+    fi
+done
+
+# --- --clear-estimate + --estimate <1-5> is mutually exclusive ------------
+cap="$TMP/conflict.json"
+rc="$(run_update "$cap" CC-1 --clear-estimate --estimate 3)"
+if [ "$rc" -ne 0 ] && [ ! -f "$cap" ] && grep -q "not both" "$cap.err" 2>/dev/null; then
+    pass "--clear-estimate + --estimate 3 errors"
+else
+    fail "--clear-estimate + --estimate 3 should error (rc=$rc, err=$(cat "$cap.err" 2>/dev/null))"
+fi
+
+# --- --clear-estimate + --estimate 0 is allowed (both mean clear) ---------
+cap="$TMP/both-clear.json"
+rc="$(run_update "$cap" CC-1 --clear-estimate --estimate 0)"
+if [ "$rc" -eq 0 ] && jq -e '.input.estimate == null' "$cap" >/dev/null 2>&1; then
+    pass "--clear-estimate + --estimate 0 -> estimate: null"
+else
+    fail "--clear-estimate + --estimate 0 (rc=$rc, input=$(cat "$cap" 2>/dev/null))"
+fi
+
+# --- cache write-through reflects the cleared value -----------------------
+cache_dir="$TMP/cache"
+mkdir -p "$cache_dir"
+printf '%s' '[{"id":"uuid-1","identifier":"CC-1","title":"t","estimate":3,"state":{"name":"Todo","type":"unstarted"},"relations":{"nodes":[]},"inverseRelations":{"nodes":[]}}]' >"$cache_dir/issues.json"
+LINEAR_API_KEY=test-token \
+    bash -uo pipefail -c '
+        issues_sh="$1"
+        cache_dir="$2"
+        # shellcheck disable=SC1090
+        source "$issues_sh"
+        # cache.sh fixes CACHE_DIR at source time; point it at the test cache.
+        CACHE_DIR="$cache_dir"
+        get_issue() { printf "%s" "{\"issue\":{\"team\":{\"name\":\"Test\"}}}"; }
+        attach_download_from_text() { :; }
+        graphql_query() {
+            printf "%s" "{\"issueUpdate\":{\"success\":true,\"issue\":{\"id\":\"uuid-1\",\"identifier\":\"CC-1\",\"title\":\"t\",\"estimate\":null,\"state\":{\"name\":\"Todo\",\"type\":\"unstarted\"},\"relations\":{\"nodes\":[]},\"inverseRelations\":{\"nodes\":[]}}}}"
+        }
+        update_issue CC-1 --clear-estimate
+    ' _ "$ISSUES_SH" "$cache_dir" >/dev/null 2>&1
+if jq -e '.[] | select(.id == "uuid-1") | .estimate == null' "$cache_dir/issues.json" >/dev/null 2>&1; then
+    pass "cache write-through stores cleared estimate as null (not stale 3)"
+else
+    fail "cache still holds stale estimate: $(jq -c '.[] | {id, estimate}' "$cache_dir/issues.json" 2>/dev/null)"
+fi
+
+# --- bulk-update forwards --clear-estimate to the mutation ----------------
+cap="$TMP/bulk-clear.json"
+out="$(
+    CAPTURE_FILE="$cap" LINEAR_API_KEY=test-token \
+        bash -uo pipefail -c '
+            capture="$CAPTURE_FILE"
+            issues_sh="$1"
+            # shellcheck disable=SC1090
+            source "$issues_sh"
+            get_issue() { printf "%s" "{\"issue\":{\"team\":{\"name\":\"Test\"}}}"; }
+            attach_download_from_text() { :; }
+            graphql_query() {
+                printf "%s" "$2" >"$capture"
+                printf "%s" "{\"issueUpdate\":{\"success\":true,\"issue\":{\"id\":\"uuid-1\",\"identifier\":\"CC-1\",\"title\":\"t\",\"estimate\":null,\"state\":{\"name\":\"Todo\",\"type\":\"unstarted\"}}}}"
+            }
+            bulk_update_issues CC-1 --clear-estimate
+        ' _ "$ISSUES_SH" 2>/dev/null
+)"
+if jq -e '.updated == 1' <<<"$out" >/dev/null 2>&1 && jq -e '.input.estimate == null' "$cap" >/dev/null 2>&1; then
+    pass "bulk-update --clear-estimate -> estimate: null"
+else
+    fail "bulk-update --clear-estimate (out=$out, input=$(cat "$cap" 2>/dev/null))"
+fi
+
+# --- bulk-update rejects an out-of-range estimate per item ----------------
+out="$(
+    LINEAR_API_KEY=test-token \
+        bash -uo pipefail -c '
+            issues_sh="$1"
+            # shellcheck disable=SC1090
+            source "$issues_sh"
+            get_issue() { printf "%s" "{\"issue\":{\"team\":{\"name\":\"Test\"}}}"; }
+            attach_download_from_text() { :; }
+            graphql_query() { printf "%s" "{\"issueUpdate\":{\"success\":true,\"issue\":{}}}"; }
+            bulk_update_issues CC-1 --estimate 6
+        ' _ "$ISSUES_SH" 2>/dev/null
+)"
+if jq -e '.failed == 1 and (.results[0].error | contains("Invalid --estimate"))' <<<"$out" >/dev/null 2>&1; then
+    pass "bulk-update --estimate 6 reported as failed"
+else
+    fail "bulk-update --estimate 6 (out=$out)"
+fi
+
+if [ "$fails" -ne 0 ]; then
+    echo "$fails test(s) failed"
+    exit 1
+fi
+echo "all pass"

--- a/skills/project-management/references/issues.md
+++ b/skills/project-management/references/issues.md
@@ -70,6 +70,7 @@ Use `--parent [ISSUE_ID]` when:
 - Implementation requirements live in sub-issues, never in parents
 - When sub-issues are created, transfer all parent requirements to children
 - Parents retain: summary, research/decision refs, effort rollup, child cross-references
+- Coordination-only parents carry no estimate (the effort lives in the children). Clear a parent's estimate with `issues update [ISSUE_ID] --clear-estimate` (or the `--estimate 0` alias). Linear stores this as "no estimate"; formatters render it as `0`.
 
 **Grouping**: Deliverable-based, not layer-based.
 - Correct: "User Auth → Login UI, Token Service" (one feature)

--- a/skills/project-management/templates/parent-issue-template.md
+++ b/skills/project-management/templates/parent-issue-template.md
@@ -34,6 +34,7 @@ Format for parent/bundle issues that coordinate sub-issues across domains.
 4. **Label**: `agent:multi` if children span 2+ distinct `agent:X` domains
 5. **Blocking relations**: Read [agent-sequencing.md](../../orch/workflows/agent-sequencing.md)
 6. **No implementation detail** — requirements live in children, parent holds only coordination context
+   - Coordination-only parents carry no estimate — clear it with `issues update [ISSUE_ID] --clear-estimate` (or `--estimate 0`). See [issues.md](../references/issues.md) § Sub-Issues.
 7. **Omit empty lines** — drop Research, Decision, Source, Acceptance Criteria lines with no data
 8. **Research/Decision at top** — matches convention in research-complete workflow and audit workflow
 9. **Summary synthesized** — derive from children's descriptions, not repeated from a single child


### PR DESCRIPTION
## Summary
- Add `--clear-estimate` to `linear.sh issues update` and `issues bulk-update`, emitting `"estimate": null` in the `issueUpdate` mutation so coordination-only parent issues can be brought into the project-management estimate-0 format.
- Accept `--estimate 0` (and `--estimate=0`) as a compatibility alias for clearing (→ null), while keeping strict `1-5` validation for real estimates (6/negative/non-integer rejected). `--clear-estimate` + `--estimate <1-5>` is a hard error; `--clear-estimate` + `--estimate 0` is allowed (both clear).
- Cache write-through carries the cleared value (null reads back, formatters render as 0).
- Documented in `--help`; updated project-management coordination-parent guidance (`references/issues.md`, `parent-issue-template.md`) to point at the supported clear operation.

## Completed Issues
- Closes #461

## Test Plan
- New `skills/linear/tests/estimate-clear.test.sh` (clear, `--estimate 0` alias, valid pass-through, rejections, mutual exclusion, cache write-through, both bulk paths) — mocked, no real Linear API.
- All 7 linear test files pass.
