### PR TITLE
fix(iced-rs): remove invalid mouse_area on_press_maybe guidance

### DIFF
--- a/skills/iced-rs/SKILL.md
+++ b/skills/iced-rs/SKILL.md
@@ -218,9 +218,15 @@ Iced tracks widgets by tree position. Conditional wrapping changes tree shape an
 // WRONG: conditional wrapping changes tree shape
 if dragging { mouse_area(label).into() } else { label.into() }
 
-// RIGHT: always wrap, conditionally enable
-mouse_area(label).on_press_maybe(if enable { Some(msg) } else { None })
+// RIGHT: always wrap, conditionally attach the handler
+let mut area = mouse_area(label);
+if enable {
+    area = area.on_press(msg);
+}
+area
 ```
+
+`MouseArea` has no `on_press_maybe` — its `on_press` takes a plain `Message`, so gate the call, not the wrapper. (`on_press_maybe(Option<Message>)` is `button`-only.)
 
 ### view() is pure
 

--- a/skills/iced-rs/references/guide-custom-widgets.md
+++ b/skills/iced-rs/references/guide-custom-widgets.md
@@ -422,7 +422,7 @@ Used in `view()` as `my_widget(self.value).width(300).on_press(Message::Tick).in
 
 Non-negotiable — violating causes subtle bugs:
 
-- **Widget tree consistency** — always wrap, conditionally enable. Never `if cond { mouse_area(x).into() } else { x.into() }`. Prefer `mouse_area(x).on_press_maybe(...)`.
+- **Widget tree consistency** — always wrap, conditionally attach the handler. Never `if cond { mouse_area(x).into() } else { x.into() }`. `MouseArea` has **no `on_press_maybe`** (that is `button`-only); its `on_press` takes a plain `Message`, so keep the wrapper unconditional and gate the call: `let mut a = mouse_area(x); if cond { a = a.on_press(msg); } a`.
 - **`view()` is pure** — no side effects, no mutable state. All state in `State`, mutated only in `update()`.
 - **Single message per interaction** — one interaction → one message. Composite actions use a state machine in `update()`.
 - **Overlay state isolation** — overlay layers must not affect base layer widget structure.

--- a/skills/iced-rs/references/widgets.md
+++ b/skills/iced-rs/references/widgets.md
@@ -83,9 +83,15 @@ Never wrap conditionally:
 // WRONG — tree shape changes, breaks event tracking
 if enabled { mouse_area(label).into() } else { label.into() }
 
-// RIGHT — always wrap, conditionally enable
-mouse_area(label).on_press_maybe(if enabled { Some(msg) } else { None })
+// RIGHT — always wrap, conditionally attach the handler
+let mut area = mouse_area(label);
+if enabled {
+    area = area.on_press(msg);
+}
+area
 ```
+
+`MouseArea` has **no `on_press_maybe`** — that method is `button`-specific (see row above). `MouseArea::on_press` takes a plain `Message`, not an `Option`, so gate the `.on_press(...)` call itself while keeping the wrapper unconditional.
 
 ### Overlay / floating content
 

--- a/skills/iced-rs/tests/mouse-area-no-on-press-maybe.test.sh
+++ b/skills/iced-rs/tests/mouse-area-no-on-press-maybe.test.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# vstack#478: MouseArea (Iced 0.14) has NO `on_press_maybe` method — only `button`
+# does. The skill previously recommended `mouse_area(x).on_press_maybe(...)`, which
+# does not compile. This guard fails if that misuse is ever reintroduced into the
+# guidance sources (SKILL.md + references/), so a future reference refresh cannot
+# silently restore the bug.
+#
+# Run: bash skills/iced-rs/tests/mouse-area-no-on-press-maybe.test.sh
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
+
+PASS=0
+FAIL=0
+
+pass() { printf '  PASS: %s\n' "$1"; PASS=$((PASS + 1)); }
+fail() { printf '  FAIL: %s\n' "$1" >&2; FAIL=$((FAIL + 1)); }
+
+# Guidance sources to police (SKILL.md + reference docs). Bundled upstream
+# `examples/` are real iced code and use the valid button.on_press_maybe, so they
+# are intentionally out of scope.
+SOURCES=("$SKILL_DIR/SKILL.md" "$SKILL_DIR/references")
+
+# 1. No `mouse_area(...).on_press_maybe(...)` construct anywhere in the guidance.
+#    Matches a `mouse_area` occurrence followed on the same line by `.on_press_maybe`.
+if grep -rnE 'mouse_area.*\.on_press_maybe' "${SOURCES[@]}" >/dev/null 2>&1; then
+    fail "found forbidden mouse_area(...).on_press_maybe(...) construct:"
+    grep -rnE 'mouse_area.*\.on_press_maybe' "${SOURCES[@]}" >&2 || true
+else
+    pass "no mouse_area(...).on_press_maybe(...) construct in guidance sources"
+fi
+
+# 2. The correct conditional pattern (gate the on_press call, keep wrapper) is present.
+if grep -rqE 'area = area\.on_press\(' "$SKILL_DIR/SKILL.md" "$SKILL_DIR/references/widgets.md"; then
+    pass "corrected conditional mouse_area on_press pattern present"
+else
+    fail "corrected conditional mouse_area on_press pattern missing from SKILL.md / widgets.md"
+fi
+
+# 3. The VALID button on_press_maybe guidance must stay intact (do not over-correct).
+if grep -qE 'on_press_maybe\(self, on_press: Option<Message>\)' "$SKILL_DIR/references/widget-button.md"; then
+    pass "button on_press_maybe(Option<Message>) API guidance intact"
+else
+    fail "button on_press_maybe API guidance was removed from widget-button.md"
+fi
+
+printf '\nPASS=%d FAIL=%d\n' "$PASS" "$FAIL"
+if [ "$FAIL" -ne 0 ]; then exit 1; fi


### PR DESCRIPTION
## Summary
- Remove invalid `mouse_area(...).on_press_maybe(...)` guidance from the iced-rs skill. Iced 0.14 `MouseArea` has no `on_press_maybe` method (verified against the bundled 0.14 reference — `MouseArea::on_press(self, message: Message)` takes a plain Message; `on_press_maybe(Option<Message>)` is `button`-only), so code following the old guidance did not compile.
- Replaced the three occurrences (`SKILL.md`, `references/widgets.md`, `references/guide-custom-widgets.md`) with the always-wrap / conditionally-attach pattern (`let mut area = mouse_area(content); if enabled { area = area.on_press(msg); } area`), preserving the widget-tree-consistency principle. Each site now states explicitly that `on_press_maybe` is button-specific so agents don't generalize the button API to other widgets.
- Left the valid `button.on_press_maybe(...)` guidance untouched.

## Context
- Durable upstream fix for the pattern hyprtrade patched locally in their PR #166 (CC-700/CC-686); a subsequent `vstack refresh` had restored the invalid upstream examples, so the fix must live upstream.

## Completed Issues
- Closes #478

## Test Plan
- New `skills/iced-rs/tests/mouse-area-no-on-press-maybe.test.sh` regression guard: fails if any `mouse_area(...).on_press_maybe(...)` construct reappears in the guidance sources, asserts the corrected `area = area.on_press(` pattern is present, and confirms the valid `button.on_press_maybe(Option<Message>)` guidance remains. Passes 3/3; negative test (reintroducing the bug) fails as expected. `bash -n` clean.
