### PR TITLE
feat(linear): add --description-file to issues create/update

### DIFF
--- a/skills/linear/patterns/workflow-actions.md
+++ b/skills/linear/patterns/workflow-actions.md
@@ -44,7 +44,9 @@ scripts/linear.sh issues update [ISSUE_ID] --state "Canceled"
 ## Scope Changes
 
 ```bash
-scripts/linear.sh issues update [ISSUE_ID] --description "[UPDATED_DESCRIPTION]"
+# For a multiline description, write it to a file and use --description-file
+# (preferred for markdown; required under `never` approval where heredocs are blocked).
+scripts/linear.sh issues update [ISSUE_ID] --description-file [DESCRIPTION_PATH]
 scripts/linear.sh comments create [ISSUE_ID] --body "Scope updated: [WHAT_CHANGED]"
 
 scripts/linear.sh issues update [ISSUE_ID] --project "[TARGET_PROJECT]"
@@ -75,7 +77,8 @@ Portable minimum:
 
 ```bash
 scripts/linear.sh cache issues get [PARENT_ID] --with-bundle
-scripts/linear.sh issues update [PARENT_ID] --description "[REGENERATED_DESCRIPTION]"
+# Write the regenerated body to a file, then pass --description-file (preferred for markdown).
+scripts/linear.sh issues update [PARENT_ID] --description-file [DESCRIPTION_PATH]
 ```
 
 ## Fix Relation Violations

--- a/skills/linear/scripts/commands/issues.sh
+++ b/skills/linear/scripts/commands/issues.sh
@@ -45,6 +45,19 @@ emit_linear_issue_activity() { return 0; }
 
 emit_linear_relation_activity() { return 0; }
 
+read_description_file() {
+    local description_file="$1"
+    if [[ -z "$description_file" ]]; then
+        echo '{"error": "--description-file requires a non-empty path argument"}' >&2
+        return 1
+    fi
+    if [[ ! -r "$description_file" ]]; then
+        echo "{\"error\": \"--description-file path not readable: $description_file\"}" >&2
+        return 1
+    fi
+    description=$(<"$description_file")
+}
+
 linear_update_activity_type() {
     local normalized="$1"
     local state state_type
@@ -123,6 +136,7 @@ Create Options:
   --title <text>        Issue title (required)
   --team <name>         Team name (default: $LINEAR_TEAM from project config)
   --description <text>  Issue description
+  --description-file <path>  Read description from file (preferred for markdown)
   --label(s) <a,b,c>    Comma-separated label names
   --project <name|uuid> Project (name or UUID, auto-resolved)
   --state <name>        Initial state (case-sensitive, fails with available list)
@@ -138,6 +152,7 @@ Update Options:
   --label(s) <a,b,c>    Replace labels (comma-separated)
   --title <text>        New title
   --description <text>  New description
+  --description-file <path>  Read new description from file (preferred for markdown)
   --project <name|uuid> Move to project (name or UUID, auto-resolved)
   --priority <0-4>      Priority: 0=None, 1=Urgent, 2=High, 3=Normal, 4=Low
   --estimate <0-5>      Effort estimate (points); 0 clears the estimate (unset)
@@ -774,6 +789,7 @@ create_issue() {
     local title=""
     local team=""
     local description=""
+    local description_file=""
     local labels=""
     local project=""
     local state=""
@@ -797,6 +813,10 @@ create_issue() {
             ;;
         --description)
             description="$2"
+            shift 2
+            ;;
+        --description-file)
+            description_file="$2"
             shift 2
             ;;
         --labels | --label)
@@ -850,6 +870,14 @@ create_issue() {
         *) break ;;
         esac
     done
+
+    if [[ -n "$description" && -n "$description_file" ]]; then
+        echo '{"error": "--description and --description-file are mutually exclusive"}' >&2
+        return 1
+    fi
+    if [[ -n "$description_file" ]]; then
+        read_description_file "$description_file"
+    fi
 
     # Apply team default if not specified
     team=$(apply_team_default "$team")
@@ -1062,6 +1090,7 @@ update_issue() {
     local labels=""
     local title=""
     local description=""
+    local description_file=""
     local project=""
     local priority=""
     local assignee=""
@@ -1106,6 +1135,14 @@ update_issue() {
             ;;
         --description=*)
             description="${1#*=}"
+            shift
+            ;;
+        --description-file)
+            description_file="$2"
+            shift 2
+            ;;
+        --description-file=*)
+            description_file="${1#*=}"
             shift
             ;;
         --project)
@@ -1195,6 +1232,14 @@ update_issue() {
         *) break ;;
         esac
     done
+
+    if [[ -n "$description" && -n "$description_file" ]]; then
+        echo '{"error": "--description and --description-file are mutually exclusive"}' >&2
+        return 1
+    fi
+    if [[ -n "$description_file" ]]; then
+        read_description_file "$description_file"
+    fi
 
     local input_parts=()
 

--- a/skills/linear/tests/issues-description-file.test.sh
+++ b/skills/linear/tests/issues-description-file.test.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Regression test for issues create/update --description-file parsing without the real API.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+mkdir -p "$TMP_ROOT/.agents/skills" "$TMP_ROOT/bin"
+cp -R "$SKILL_DIR" "$TMP_ROOT/.agents/skills/linear"
+
+# Mocked curl: routes by GraphQL operation, logs each request payload for assertions.
+cat >"$TMP_ROOT/bin/curl" <<'SH'
+#!/usr/bin/env bash
+config="$(cat)"
+payload="$(sed -n 's/^data = //p' <<<"$config" | jq -r)"
+query="$(jq -r '.query' <<<"$payload")"
+variables="$(jq -c '.variables' <<<"$payload")"
+printf '%s\n' "$payload" >> "${CURL_PAYLOAD_LOG:?}"
+
+issue_json='{"id":"issue-uuid","identifier":"PROJ-1","title":"t","description":"d","state":{"name":"Todo","type":"unstarted"},"assignee":null,"project":null,"projectMilestone":null,"cycle":null,"parent":null,"team":{"name":"Claude"},"labels":{"nodes":[]},"priority":3,"estimate":null,"sortOrder":1.0,"url":"https://linear.app/test/issue/PROJ-1","createdAt":"2026-07-03T00:00:00Z","updatedAt":"2026-07-03T00:00:00Z","archivedAt":null,"trashed":null,"relations":{"nodes":[]},"inverseRelations":{"nodes":[]}}'
+
+case "$query" in
+*"teams(filter:"*)
+  printf '%s' '{"data":{"teams":{"nodes":[{"id":"team-uuid"}]}}}___HTTP_CODE___200'
+  ;;
+*"issueCreate(input:"*)
+  printf '%s' "{\"data\":{\"issueCreate\":{\"success\":true,\"issue\":$issue_json}}}___HTTP_CODE___200"
+  ;;
+*"issueUpdate(id:"*)
+  printf '%s' "{\"data\":{\"issueUpdate\":{\"success\":true,\"issue\":$issue_json}}}___HTTP_CODE___200"
+  ;;
+*"issue(id:"*)
+  printf '%s' '{"data":{"issue":{"identifier":"PROJ-1","team":{"name":"Claude"}}}}___HTTP_CODE___200'
+  ;;
+*)
+  printf '%s' '{"errors":[{"message":"unexpected query"}]}___HTTP_CODE___200'
+  ;;
+esac
+SH
+chmod +x "$TMP_ROOT/bin/curl"
+
+LINEAR="$TMP_ROOT/.agents/skills/linear/scripts/linear.sh"
+
+# Multiline markdown with backticks and quotes that must survive verbatim.
+desc_file="$TMP_ROOT/description.md"
+cat >"$desc_file" <<'MD'
+## Plan
+
+Use `foo_bar()` and preserve "quoted" values exactly.
+
+- item one
+- item two
+MD
+
+# --- create with --description-file --------------------------------------------
+create_log="$TMP_ROOT/create-payloads.jsonl"
+: >"$create_log"
+create_out="$(PATH="$TMP_ROOT/bin:$PATH" LINEAR_API_KEY=test-token CURL_PAYLOAD_LOG="$create_log" \
+  bash "$LINEAR" issues create --title "New task" --team Claude --description-file "$desc_file")"
+
+if ! jq -e '.success == true and .identifier == "PROJ-1"' >/dev/null <<<"$create_out"; then
+  echo "FAIL issues create --description-file returned unexpected output: $create_out"
+  exit 1
+fi
+
+if ! jq -s -e '
+  any(.[];
+    (.query | contains("issueCreate"))
+    and (.variables.input.description | contains("## Plan"))
+    and (.variables.input.description | contains("`foo_bar()`"))
+    and (.variables.input.description | contains("\"quoted\""))
+    and (.variables.input.description | contains("- item one")))
+' "$create_log" >/dev/null; then
+  echo "FAIL issueCreate payload did not carry the markdown description verbatim"
+  cat "$create_log"
+  exit 1
+fi
+
+# --- update with --description-file --------------------------------------------
+update_log="$TMP_ROOT/update-payloads.jsonl"
+: >"$update_log"
+update_out="$(PATH="$TMP_ROOT/bin:$PATH" LINEAR_API_KEY=test-token CURL_PAYLOAD_LOG="$update_log" \
+  bash "$LINEAR" issues update PROJ-1 --description-file "$desc_file")"
+
+if ! jq -e '.success == true' >/dev/null <<<"$update_out"; then
+  echo "FAIL issues update --description-file returned unexpected output: $update_out"
+  exit 1
+fi
+
+if ! jq -s -e '
+  any(.[];
+    (.query | contains("issueUpdate"))
+    and (.variables.input.description | contains("## Plan"))
+    and (.variables.input.description | contains("`foo_bar()`"))
+    and (.variables.input.description | contains("\"quoted\"")))
+' "$update_log" >/dev/null; then
+  echo "FAIL issueUpdate payload did not carry the markdown description verbatim"
+  cat "$update_log"
+  exit 1
+fi
+
+# --- helper: assert a command fails with an expected stderr substring -----------
+assert_fails() {
+  local expected="$1"; shift
+  local err_file="$TMP_ROOT/err.txt"
+  local rc
+  set +e
+  PATH="$TMP_ROOT/bin:$PATH" LINEAR_API_KEY=test-token \
+    bash "$LINEAR" "$@" >"$TMP_ROOT/out.txt" 2>"$err_file"
+  rc=$?
+  set -e
+  if [[ "$rc" -eq 0 ]]; then
+    echo "FAIL command unexpectedly succeeded: $*"
+    cat "$TMP_ROOT/out.txt"
+    exit 1
+  fi
+  if ! grep -q "$expected" "$err_file"; then
+    echo "FAIL command '$*' missing expected error '$expected'"
+    cat "$err_file"
+    exit 1
+  fi
+}
+
+# --- mutual exclusivity (create + update) --------------------------------------
+assert_fails "mutually exclusive" issues create --title "New task" --team Claude \
+  --description inline --description-file "$desc_file"
+assert_fails "mutually exclusive" issues update PROJ-1 \
+  --description inline --description-file "$desc_file"
+
+# --- unreadable / missing path errors (create + update) ------------------------
+assert_fails "not readable" issues create --title "New task" --team Claude \
+  --description-file "$TMP_ROOT/does-not-exist.md"
+assert_fails "not readable" issues update PROJ-1 \
+  --description-file "$TMP_ROOT/does-not-exist.md"
+
+echo "all pass"

--- a/skills/project-management/references/issues.md
+++ b/skills/project-management/references/issues.md
@@ -111,6 +111,8 @@ Use `--parent [ISSUE_ID]` when:
 
 ## CLI Command
 
+Write the multiline description body to a file with the harness file-write tool (e.g. `tmp/issue-description.md`), then pass it via `--description-file` — preferred for markdown and required under `never` approval where heredocs/command-substitution are blocked:
+
 ```bash
 LABELS="agent:[TYPE],[DOMAIN_LABEL],critical-path" # full validated issue-label set
 
@@ -119,13 +121,19 @@ LABELS="agent:[TYPE],[DOMAIN_LABEL],critical-path" # full validated issue-label 
   --project "Phase 1: Foundation" \
   --labels "$LABELS" \
   --estimate 3 \
-  --description "## Summary
+  --description-file tmp/issue-description.md
+```
+
+Where `tmp/issue-description.md` contains, for example:
+
+```markdown
+## Summary
 Auth service for user login and session management.
 
 ## Acceptance Criteria
 - [ ] Login endpoint returns JWT
 - [ ] Token refresh works
-- [ ] Unit tests pass"
+- [ ] Unit tests pass
 ```
 
 ## Cancellation

--- a/skills/project-management/templates/issue-description-template.md
+++ b/skills/project-management/templates/issue-description-template.md
@@ -36,13 +36,15 @@ Standard format for issue tracker descriptions created by workflows. Match the s
 
 ## Rules
 
-1. **Always use heredoc** (`cat <<'EOF'`) for `--description` — never inline single-line strings
+1. **Always use `--description-file`** for multiline descriptions — write the description to a file with the harness file-write tool, then pass its path. Never inline single-line strings, and never use a heredoc/command-substitution (`--description "$(cat <<'EOF' … )"`): under `never` approval those shell shapes are treated as approval-required and callers can't set a substantial description safely.
 2. **Use fields directly** — review agents write issue-quality `description` and `recommendation`; no expansion needed at assembly time
 3. **Omit empty lines** — drop Research, Decision, Context lines with no data
-4. **No escaped newlines in heredoc** — write actual newlines. JSON `\n` sequences become real newlines when the agent writes the heredoc content
+4. **Write actual newlines in the file** — JSON `\n` sequences become real newlines when the agent writes the description file
 5. **Check decisions before creating** — `.agents/skills/decider/scripts/decisions search "[RELEVANT_KEYWORDS]"` to check if the proposed approach is governed by an active decision. Description must not contradict it. Reference the decision at the top of the description
 
 ## CLI Usage
+
+Write the description body to a file (e.g. `tmp/issue-description.md`) with the harness file-write tool, then pass its path:
 
 ```bash
 .agents/skills/linear/scripts/linear.sh issues create \
@@ -52,7 +54,12 @@ Standard format for issue tracker descriptions created by workflows. Match the s
   --priority [PRIORITY] \
   --estimate [ESTIMATE] \
   --parent [PARENT_ID] \
-  --description "$(cat <<'EOF'
+  --description-file tmp/issue-description.md
+```
+
+Where `tmp/issue-description.md` contains, for example:
+
+```markdown
 **Source**: PR review suggestion (e.g., test-review)
 
 Connection pool capacity growth path is untested. A burst of concurrent
@@ -68,6 +75,6 @@ and the cap at max_connections*4 is untested.
 ## Context
 
 - **Location**: `src/pool/connection_pool.rs` (`ConnectionPool::grow`)
-EOF
-)"
 ```
+
+`--description-file` and `--description` are mutually exclusive. The same flag works on `issues update` for editing an existing description.

--- a/skills/project-management/workflows/audit-issues.md
+++ b/skills/project-management/workflows/audit-issues.md
@@ -561,7 +561,7 @@ Process `create` actions first -- use created IDs to resolve `#N` references in 
 | supersede, combine | workflow-actions § Cancel / Merge / Combine |
 | cancel | workflow-actions § Cancel Obsolete Issues |
 
-**Create template**: Use project-level templates issue-description-template for `--description`. For parent/bundle issues, use project-level templates parent-issue-template. Always heredoc, never inline strings. Every create command must include `--labels "[VALIDATED_FINAL_LABELS]"` from § 7.0.
+**Create template**: Use project-level templates issue-description-template for the description. For parent/bundle issues, use project-level templates parent-issue-template. Write the description body to a file and pass `--description-file` (never inline strings or a heredoc). Every create command must include `--labels "[VALIDATED_FINAL_LABELS]"` from § 7.0.
 
 **Analyzed mode**: When MODE = analyzed, issue creation fields (description, recommendation, location, estimate, priority, agent_label, labels, source_path) come from `issues[].create_fields`. `create_fields.labels[]` is authoritative and required for create; `agent_label` is derived/backward-compatible only. Use `source_path` for `[ORIGIN_CONTEXT]` in issue-description-template. For bundle parents (`create_fields.is_bundle_parent: true`), use parent-issue-template. Top-level `parent_issue` and `research_ref` available for hierarchy fallback and description refs.
 


### PR DESCRIPTION
## Summary
- Add `--description-file PATH` to `linear.sh issues create` and `issues update`, mirroring the existing `comments --body-file`. Resolves the conflict between the heredoc-based description template and the orch/dev harness-safe-shell rules (which forbid heredocs/command-substitution under `approval=never`), so substantial multiline issue descriptions can be set without shell-escaping hazards.
- New `read_description_file()` helper (empty-path and unreadable-path errors as `{"error":...}` JSON) reads UTF-8 multiline content exactly, matching `read_body_file`. `--description` and `--description-file` are mutually exclusive; the resolved text flows through the unchanged issueCreate/issueUpdate mutation + cache write-through path. `--help` updated for both subcommands.
- Updated guidance to prefer the file flag in strict harnesses: `project-management` issue-description template, `references/issues.md`, `audit-issues.md`, and the linear `workflow-actions.md` examples. `bulk-update` intentionally out of scope (documented).

## Completed Issues
- Closes #481

## Test Plan
- New `skills/linear/tests/issues-description-file.test.sh` (mocked): create + update with multiline Markdown; backtick/quote preservation asserted in the built mutation payload; `--description` + `--description-file` exclusivity error on both subcommands; unreadable-path error on both.
- All 9 linear test files pass; `bash -n` clean.
