### PR TITLE
fix(cli): count content-changing refresh writes, not just source-hash equality

### DIFF
--- a/cli/src/commands/refresh.rs
+++ b/cli/src/commands/refresh.rs
@@ -25,6 +25,15 @@ pub struct RefreshStats {
     pub failures: Vec<RefreshFailure>,
     /// Map of agent_name → (full merged required-skills list, newly added skill names).
     pub upstream_skill_updates: HashMap<String, (Vec<String>, Vec<String>)>,
+    /// Names of items whose generated/installed on-disk content actually
+    /// changed during this refresh. Distinct from source-hash equality: an
+    /// agent re-renders when the installed skill set (or injected project
+    /// instructions) changes even though the agent's own source hash is
+    /// unchanged, and a rendered skill can differ from its source via injected
+    /// instructions/notice. Tracked for agents and skills (the artifacts that
+    /// derive from external state); hooks and Pi packages rely on source-hash
+    /// equality alone.
+    pub content_changed: HashSet<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -52,6 +61,10 @@ impl RefreshStats {
         self.successful_items.insert(name.to_string());
     }
 
+    fn mark_content_changed(&mut self, name: &str) {
+        self.content_changed.insert(name.to_string());
+    }
+
     fn fail(&mut self, item: &str, harness: Option<Harness>, err: impl std::fmt::Display) {
         self.failures.push(RefreshFailure {
             item: item.to_string(),
@@ -63,6 +76,16 @@ impl RefreshStats {
     pub fn has_failures(&self) -> bool {
         !self.failures.is_empty()
     }
+}
+
+/// Content hash of an installed skill directory, resolving a symlinked install
+/// dir to its canonical target and skipping the volatile `.vstack-refreshed`
+/// marker (its per-process PID payload changes every run). Returned value is
+/// only ever compared before-vs-after within a single refresh, so the absolute
+/// value is irrelevant.
+fn hash_installed_skill_dir(path: &Path) -> u64 {
+    let resolved = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    config::hash_dir_bytes_excluding(&resolved, &[".vstack-refreshed"])
 }
 
 /// Generic upstream-merge: starts with `project_list` if present, else
@@ -195,6 +218,7 @@ pub fn refresh_items_in_scope(
 
         let mut succeeded = 0usize;
         let mut failed = false;
+        let mut content_changed = false;
         for harness_id in &entry.harnesses {
             if let Some(harness) = Harness::from_id(harness_id) {
                 let matched_hooks = crate::resolve::matched_installed_hooks_for_agent_harness(
@@ -204,9 +228,20 @@ pub fn refresh_items_in_scope(
                     &agent.role,
                     harness.id(),
                 );
+                // Compare the bytes actually written to the destination against
+                // what was there before: agent files re-render when the
+                // installed skill set / injected instructions change even
+                // though the agent's own source hash is unchanged.
+                let out_path = harness
+                    .agents_dir(global)
+                    .join(harness.agent_filename(&agent.name));
+                let before = config::hash_file_bytes(&out_path);
                 match harness.generate_agent(agent, global, &skill_pairs, &matched_hooks, &extras) {
                     Ok(_) => {
                         succeeded += 1;
+                        if config::hash_file_bytes(&out_path) != before {
+                            content_changed = true;
+                        }
                         if matches!(harness, Harness::Codex) {
                             regenerated_codex_agents.push(agent.clone());
                         }
@@ -221,6 +256,9 @@ pub fn refresh_items_in_scope(
         if succeeded > 0 && !failed {
             stats.agents_refreshed += 1;
             stats.mark_success(name);
+            if content_changed {
+                stats.mark_content_changed(name);
+            }
         }
     }
 
@@ -236,6 +274,7 @@ pub fn refresh_items_in_scope(
             let error = format!("failed to install Codex hook prose: {err:#}");
             for agent in &regenerated_codex_agents {
                 stats.fail(&agent.name, Some(Harness::Codex), &error);
+                stats.content_changed.remove(&agent.name);
                 if stats.successful_items.remove(&agent.name) && stats.agents_refreshed > 0 {
                     stats.agents_refreshed -= 1;
                 }
@@ -259,11 +298,25 @@ pub fn refresh_items_in_scope(
 
         let mut succeeded = 0usize;
         let mut failed = false;
+        let mut content_changed = false;
         for harness_id in &entry.harnesses {
             if let Some(harness) = Harness::from_id(harness_id) {
                 let skill_instr = project_config.skill_instructions_for(&skill.name);
+                // Snapshot the installed skill content before/after: a rendered
+                // skill can differ from its source (injected instructions/notice)
+                // while the lock's source hash is unchanged.
+                let before = harness
+                    .install_skill(skill, global)
+                    .ok()
+                    .map(|dest| hash_installed_skill_dir(&dest))
+                    .unwrap_or(0);
                 match installer::install_skill(skill, harness, global, entry.method, skill_instr) {
-                    Ok(_) => succeeded += 1,
+                    Ok(result) => {
+                        succeeded += 1;
+                        if hash_installed_skill_dir(&result.path) != before {
+                            content_changed = true;
+                        }
+                    }
                     Err(err) => {
                         failed = true;
                         stats.fail(name, Some(harness), err);
@@ -274,6 +327,9 @@ pub fn refresh_items_in_scope(
         if succeeded > 0 && !failed {
             stats.skills_refreshed += 1;
             stats.mark_success(name);
+            if content_changed {
+                stats.mark_content_changed(name);
+            }
         }
     }
 
@@ -701,6 +757,16 @@ fn run_one(global: bool, verbose: bool) -> Result<()> {
     }
     lock.save(&lock_path)?;
 
+    // An item counts as "updated" when its source hash changed OR its
+    // generated/installed on-disk content changed. The latter catches
+    // artifacts that re-render from external state (agents embedding the
+    // installed skill set; skills with injected instructions) whose own source
+    // hash is unchanged — so the summary never reports "0 updated" while
+    // refresh actually rewrote tracked output.
+    let is_updated = |name: &str, old: &str, new: &str| -> bool {
+        old != new || stats.content_changed.contains(name)
+    };
+
     if verbose {
         let kind_w = changes
             .iter()
@@ -713,8 +779,9 @@ fn run_one(global: bool, verbose: bool) -> Result<()> {
             .max()
             .unwrap_or(0);
         for (_, kind, name, old, new) in &changes {
-            let mark = if old == new { "✓" } else { "!" };
-            let label = if old == new { "unchanged" } else { "changed" };
+            let changed = is_updated(name, old, new);
+            let mark = if changed { "!" } else { "✓" };
+            let label = if changed { "changed" } else { "unchanged" };
             let old_short = if old.is_empty() {
                 "—".to_string()
             } else {
@@ -735,7 +802,7 @@ fn run_one(global: bool, verbose: bool) -> Result<()> {
     } else {
         let mut updated_by_kind: HashMap<ItemKind, Vec<String>> = HashMap::new();
         for (kind, _, name, old, new) in &changes {
-            if old != new {
+            if is_updated(name, old, new) {
                 updated_by_kind.entry(*kind).or_default().push(name.clone());
             }
         }
@@ -768,7 +835,7 @@ fn run_one(global: bool, verbose: bool) -> Result<()> {
     let count_updated = |kind: ItemKind| -> usize {
         changes
             .iter()
-            .filter(|(k, _, _, old, new)| *k == kind && old != new)
+            .filter(|(k, _, name, old, new)| *k == kind && is_updated(name, old, new))
             .count()
     };
     eprintln!(

--- a/cli/src/commands/refresh/tests.rs
+++ b/cli/src/commands/refresh/tests.rs
@@ -296,6 +296,135 @@ fn refresh_items_use_lock_source_for_colliding_names_and_mapping() {
 }
 
 #[test]
+fn refresh_counts_content_changes_when_source_hashes_are_unchanged() {
+    // Regression for the "0 updated" summary bug: a refresh that re-renders
+    // agent and skill output (via injected project instructions) must be
+    // counted as updated even though neither item's SOURCE hash changed.
+    let root = tmpdir("content-change-count");
+    let project = root.join("project");
+    let source = make_source(&root, "source");
+    std::fs::create_dir_all(&project).unwrap();
+    write_colliding_source(&source, "1", "PreToolUse", "model-x");
+
+    let mut lock = LockFile::default();
+    lock.add(lock_entry("rust", ItemKind::Agent, &source, vec!["claude-code"]));
+    lock.add(lock_entry(
+        "shared",
+        ItemKind::Skill,
+        &source,
+        vec!["claude-code"],
+    ));
+    let sources = vec![RefreshSource::from_root(&source)];
+
+    let agent_path = project.join(".claude/agents/rust.md");
+    let skill_path = project.join(".claude/skills/shared/SKILL.md");
+
+    crate::test_util::with_project_root(&project, || {
+        // First refresh: baseline install, no project instructions.
+        let mut project_config = ProjectConfig::default();
+        let first =
+            refresh_items_in_scope(false, &lock, &sources, &mut project_config, &project, None);
+        assert_eq!(first.agents_refreshed, 1);
+        assert_eq!(first.skills_refreshed, 1);
+
+        let agent_before = std::fs::read_to_string(&agent_path).unwrap();
+        let skill_before = std::fs::read_to_string(&skill_path).unwrap();
+
+        // Source hashes as recorded after the baseline install. These must NOT
+        // change across the second refresh — that is the whole point: the old
+        // summary derived "updated" from these alone and reported 0.
+        let agent_hash_before = crate::config::compute_source_hash(&lock.entries["rust"]);
+        let skill_hash_before = crate::config::compute_source_hash(&lock.entries["shared"]);
+
+        // Inject project-level instructions in memory only (never written to
+        // the on-disk vstack.toml that source hashing reads). This re-renders
+        // both the agent file and the skill's SKILL.md.
+        project_config
+            .agent_instructions
+            .insert("rust".into(), "Extra project guidance for rust.".into());
+        project_config
+            .skill_instructions
+            .insert("shared".into(), "Project-specific skill note.".into());
+
+        let second =
+            refresh_items_in_scope(false, &lock, &sources, &mut project_config, &project, None);
+
+        // The generated artifacts actually changed on disk.
+        let agent_after = std::fs::read_to_string(&agent_path).unwrap();
+        let skill_after = std::fs::read_to_string(&skill_path).unwrap();
+        assert_ne!(agent_before, agent_after, "agent file should have changed");
+        assert_ne!(skill_before, skill_after, "skill file should have changed");
+
+        // Source hashes are unchanged, so the old (source-hash-only) counting
+        // would have reported 0 updated for both kinds.
+        let agent_hash_after = crate::config::compute_source_hash(&lock.entries["rust"]);
+        let skill_hash_after = crate::config::compute_source_hash(&lock.entries["shared"]);
+        assert_eq!(
+            agent_hash_before, agent_hash_after,
+            "agent source hash must be unchanged"
+        );
+        assert_eq!(
+            skill_hash_before, skill_hash_after,
+            "skill source hash must be unchanged"
+        );
+
+        // The content-change signal that now feeds the "N updated" counters
+        // reflects the real on-disk writes.
+        assert!(
+            second.content_changed.contains("rust"),
+            "agent content change not tracked: {:?}",
+            second.content_changed
+        );
+        assert!(
+            second.content_changed.contains("shared"),
+            "skill content change not tracked: {:?}",
+            second.content_changed
+        );
+        assert_eq!(second.agents_refreshed, 1);
+        assert_eq!(second.skills_refreshed, 1);
+    });
+
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn refresh_reports_no_content_change_on_idempotent_refresh() {
+    // The inverse guarantee: refreshing twice with no source or config change
+    // must report nothing updated (empty content_changed set).
+    let root = tmpdir("content-change-idempotent");
+    let project = root.join("project");
+    let source = make_source(&root, "source");
+    std::fs::create_dir_all(&project).unwrap();
+    write_colliding_source(&source, "1", "PreToolUse", "model-x");
+
+    let mut lock = LockFile::default();
+    lock.add(lock_entry("rust", ItemKind::Agent, &source, vec!["claude-code"]));
+    lock.add(lock_entry(
+        "shared",
+        ItemKind::Skill,
+        &source,
+        vec!["claude-code"],
+    ));
+    let sources = vec![RefreshSource::from_root(&source)];
+
+    crate::test_util::with_project_root(&project, || {
+        let mut project_config = ProjectConfig::default();
+        // Prime the install once.
+        refresh_items_in_scope(false, &lock, &sources, &mut project_config, &project, None);
+        // Second refresh with identical inputs must detect no content change.
+        let again =
+            refresh_items_in_scope(false, &lock, &sources, &mut project_config, &project, None);
+        assert!(
+            again.content_changed.is_empty(),
+            "idempotent refresh reported content changes: {:?}",
+            again.content_changed
+        );
+    });
+
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
 fn refresh_items_reports_agent_write_failure_without_success() {
     let root = tmpdir("agent-write-failure");
     let project = root.join("project");

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -597,8 +597,9 @@ fn resolve_pi_extension_dir(source_root: &Path, name: &str) -> Option<PathBuf> {
     None
 }
 
-/// Compute a content hash for a single file.
-fn hash_file_bytes(path: &Path) -> u64 {
+/// Compute a content hash for a single file. Returns 0 when the file is
+/// missing or unreadable, so callers can treat 0 as "absent".
+pub(crate) fn hash_file_bytes(path: &Path) -> u64 {
     match std::fs::read(path) {
         Ok(content) => fnv1a(&content),
         Err(_) => 0,
@@ -607,6 +608,14 @@ fn hash_file_bytes(path: &Path) -> u64 {
 
 /// Compute a content hash for a directory (all files, sorted by relative path).
 fn hash_dir_bytes(dir: &Path) -> u64 {
+    hash_dir_bytes_excluding(dir, &[])
+}
+
+/// Like [`hash_dir_bytes`] but ignores files whose name matches `exclude_files`.
+/// Used to compare installed artifacts while skipping volatile bookkeeping
+/// files (e.g. the per-process `.vstack-refreshed` marker) that change every
+/// run without reflecting a real content change.
+pub(crate) fn hash_dir_bytes_excluding(dir: &Path, exclude_files: &[&str]) -> u64 {
     let mut state = FNV_OFFSET;
     let mut walker = walkdir::WalkDir::new(dir)
         .min_depth(1)
@@ -621,6 +630,12 @@ fn hash_dir_bytes(dir: &Path) -> u64 {
             continue;
         }
         if !entry.file_type().is_file() {
+            continue;
+        }
+        if exclude_files
+            .iter()
+            .any(|name| entry.file_name().to_str() == Some(*name))
+        {
             continue;
         }
         // Read content first; if unreadable, skip the entire entry. Folding


### PR DESCRIPTION
## Summary
- Fix `vstack refresh` reporting `0 updated` while it regenerates tracked output files. The "N updated" counters and the `-v` changed/unchanged label were derived solely from source-package hash equality, but a generated artifact can change content while its own source hash is unchanged — e.g. an agent re-renders when the resolved skill set / hook-events frontmatter / injected project instructions change, and a rendered skill differs from source via injected instructions.
- Now detect content change at the refresh layer by comparing destination bytes before/after each write: agents hash the generated file, skills hash the installed dir (canonicalized through the symlink, excluding the volatile `.vstack-refreshed` marker whose per-run PID payload would otherwise always read as changed). An item counts as updated iff `old != new` **or** its on-disk content changed. Hooks/Pi keep source-hash-only (self-contained outputs). Counting unit stays per-lock-entry and is documented in code.

## Completed Issues
- Closes #483

## Test Plan
- New tests in `cli/src/commands/refresh/tests.rs`: `refresh_counts_content_changes_when_source_hashes_are_unchanged` (re-renders both an agent and a skill via project instructions; asserts on-disk bytes changed, both source hashes unchanged, and the updated set contains both) and `refresh_reports_no_content_change_on_idempotent_refresh` (no false positives).
- `cargo build` clean; `cargo test` 353 passed / 0 failed (+16 integration); `cargo clippy --all-targets` clean.
- End-to-end: idempotent refresh still reports `0 updated`; retargeting a hook so `rust.md` loses its hooks frontmatter now prints `! agent rust <hash> → <hash> (changed)` (identical source hash) and `1 agent(s) (1 updated)`.

## Note
This changes CLI source only; the installed `vstack` binary is unaffected until a release is cut. No skill/agent files change, so no downstream refresh is required.
