### PR TITLE
docs(reviewer): add Harness-Safe Shell guidance for strict approval policies

### DIFF
--- a/skills/reviewer/SKILL.md
+++ b/skills/reviewer/SKILL.md
@@ -85,6 +85,10 @@ Use this table to avoid duplicate findings across parallel reviewers. If domains
 - Review JSON artifacts must be created through the active harness file-write/edit path. In Codex, use `apply_patch` to add or update the target file under `[WORKTREE_PATH]/tmp/`. Do not create review JSON with shell redirection, heredocs, `tee`, `echo >`, command substitution, or other shell-plumbing writes.
 - **Return requires an agent-to-agent message.** Every `**Return exactly**` step must be delivered through the harness return channel. Claude Code uses `SendMessage`; Codex uses `send_input`; OpenCode resumes the stored `task_id`; Pi bg agents return via the final assistant message captured by `subagent`. Disk writes never count as a return path. In Pi persistent panes, after printing the exact return body once, call `complete_subagent` with the final status/summary/files/validation; bg agents must not call `complete_subagent`.
 
+### Harness-Safe Shell
+
+Reviewer agents run under the same strict approval policies as orchestrators (Codex `approval=never`). Run each validation or read-only check as its own command with explicit arguments. Do NOT combine checks with `&&`, `||`, `;`, plumbing pipelines, `$(...)`, or a single multi-file invocation (e.g. `bash -n a b c d`). Batch independent checks as separate tool calls (or parallel independent execs) instead of shell composition — the harness can classify compound or composed shapes as approval-required even when approval is disabled.
+
 ## Configuration
 
 This skill is workflow-based. The shared review ethos and scope boundaries live in this file; lifecycle behavior is defined in the workflow files. Reviewer specialist agents (`reviewer-arch`, `reviewer-correctness`, `reviewer-doc`, `reviewer-error`, `reviewer-perf`, `reviewer-quality`, `reviewer-safety`, `reviewer-security`, `reviewer-structure`, `reviewer-test`) and QA agents map to this skill in `vstack.toml [agent-skills]`.

--- a/skills/reviewer/workflows/qa-review.md
+++ b/skills/reviewer/workflows/qa-review.md
@@ -43,6 +43,7 @@ Use domain grouping and risk flags to focus review on changed files relevant to 
 ### 2.3 Run Agent Review
 
 Run your agent-specific review. See your agent file for exact commands and Output section for blocker/suggestion mapping.
+Run each validation or read-only check as its own command per the reviewer skill's Harness-Safe Shell rule; do not combine checks into compound or composed shells under Codex `approval=never`.
 Apply the reviewer skill's General Review Ethos and Reviewer Scope Boundaries. Stay within this agent's domain; do not duplicate another specialist unless your domain adds distinct evidence, impact, or remediation.
 
 ### 2.4 Classify Regressions (performance QA agent only)

--- a/skills/reviewer/workflows/review.md
+++ b/skills/reviewer/workflows/review.md
@@ -32,6 +32,7 @@ fi
 Review for noteworthy findings only — skip minor style issues. Exclude research documents.
 Apply the reviewer skill's General Review Ethos and Reviewer Scope Boundaries. Stay within this agent's domain; do not duplicate another specialist unless your domain adds distinct evidence, impact, or remediation.
 Read changed files and directly affected call paths from the worktree as needed before reporting non-trivial findings; the delegating agent does not need to inline full file contents.
+When running read-only checks to verify a finding, follow the reviewer skill's Harness-Safe Shell rule: one command per check, no compound or composed shells.
 If a changed path was deleted, inspect it from the git diff or git history; do not try to `Read` the deleted working-tree path directly.
 
 ### 1.2 Read Decisions


### PR DESCRIPTION
## Summary
- Add concise Harness-Safe-Shell guidance to the `reviewer` skill so reviewer/QA agents split read-only validation into separate exec calls under strict approval policies (Codex `approval=never`), instead of compound/composed shells (`&&`, `||`, `;`, plumbing pipelines, `$(...)`, or a single multi-file `bash -n a b c d`) that the harness can classify as approval-required even when approval is disabled.
- Reviewer agents run under the same strict policy as orchestrators but previously had none of the Harness-Safe-Shell guidance the `orch` skill carries — this closes that gap (issue suggestion #2). Added a short subsection to `reviewer/SKILL.md` plus one-line pointers in `review.md` and `qa-review.md` where agents run checks.

## Scope note
The underlying classifier behavior (Codex rejecting compound read-only execs under never-ask) is an upstream Codex limitation, not fixable in vstack. vstack does not prescribe any compound validation command; the rejected command in the report was an agent-composed multi-file `bash -n` over a downstream project's own tools. This change is purely the vstack-side guidance improvement so reviewer agents avoid the shape.

## Completed Issues
- Closes #484

## Test Plan
- Doc-only guidance change (no reviewer test harness). Verified markdown renders cleanly and the added guidance contains no compound-command example that would itself violate the rule (`bash -n a b c d` appears only as a negative example).
