### PR TITLE
fix(orch): converge bot-review-wait to complete when approval is reviewer-own-terminal

### DIFF
--- a/skills/orch/scripts/bot-review-wait
+++ b/skills/orch/scripts/bot-review-wait
@@ -556,6 +556,32 @@ pr_terminal_fallback_applied() {
   jq -e 'any(.[]?.signals[]?; . == "pr_review_decision:approved")' >/dev/null <<<"$entries"
 }
 
+# True when every effective (non-skipped) reviewer has reached a terminal
+# APPROVED state through its OWN reviewer signal (formal approval, sticky
+# "approved" verdict, or a 👍 reaction) AND no reviewer has unresolved threads.
+# In that case the PR is already reviewer-own-terminal approved and clear, so
+# the sticky "- [ ]" checklist drain must not gate completion (vstack#487): a
+# long-budget waiter would otherwise block on wait_for_checklist for the whole
+# remaining budget while a short waiter over the same state returns promptly.
+# The bounded wait_for_terminal_settle window still runs for Codex-style late
+# inline threads. This deliberately requires a stronger own-approval signal than
+# apply_pr_terminal_fallback's promotion check (which also accepts sticky:pending
+# / eyes-less pending) so a still-pending sticky does NOT skip the checklist.
+reviewers_own_terminal_approved() {
+  local entries="$1"
+  jq -e '
+    [.[] | select(.status != "skipped")] as $eff
+    | ($eff | length > 0)
+      and ($eff | all(
+            .status == "approved"
+            and ((.unresolved_threads // 0) == 0)
+            and ((.signals // []) | any(
+                   . == "formal_review:approved"
+                   or . == "sticky:approved"
+                   or . == "reaction:+1"))))
+  ' >/dev/null <<<"$entries"
+}
+
 requires_terminal_settle() {
   local entries="$1"
   local verdict
@@ -621,10 +647,21 @@ wait_for_terminal_settle() {
 terminal_posting_done() {
   local entries="$1"
 
-  # The PR-level fallback already verified that no unresolved review threads
-  # remain. Still apply the terminal settle window because Codex-style inline
-  # threads may appear shortly after early approval signals.
-  if pr_terminal_fallback_applied "$entries"; then
+  # Skip the sticky "- [ ]" checklist drain when approval is already
+  # terminal-and-clear — either promoted via the PR-level reviewDecision
+  # fallback (pr_terminal_fallback_applied) OR every reviewer is approved
+  # through its own signal with zero unresolved threads
+  # (reviewers_own_terminal_approved, vstack#487). In both cases no unresolved
+  # review threads remain, so the terminal result must not depend on how much
+  # MAX_WAIT budget is left: a long waiter and a short waiter over the same
+  # state converge on the same complete/approved. The bounded terminal settle
+  # window still runs because Codex-style inline threads may appear shortly
+  # after early approval signals.
+  #
+  # The unbounded checklist wait only applies when approval is NOT yet
+  # reviewer-own-terminal (e.g. a still-pending sticky) or the verdict is
+  # changes/pending, so genuine checklist_timeout cases are preserved.
+  if pr_terminal_fallback_applied "$entries" || reviewers_own_terminal_approved "$entries"; then
     wait_for_terminal_settle "$entries"
     return $?
   fi

--- a/skills/orch/tests/bot_review_wait.sh
+++ b/skills/orch/tests/bot_review_wait.sh
@@ -57,7 +57,7 @@ cat > "$FAKE_GITHUB_SH" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 if [[ "${1:-}" == "sticky-comment" && "${3:-}" == "--body" ]]; then
-  if [[ "${2:-}" == "3" || "${2:-}" == "9" ]]; then
+  if [[ "${2:-}" == "3" || "${2:-}" == "9" || "${2:-}" == "14" ]]; then
     printf '%s\n' '- [ ] stale checklist item'
   fi
   exit 0
@@ -185,6 +185,14 @@ case "${1:-}" in
         echo '[{"user":{"login":"claude[bot]"},"state":"APPROVED","submitted_at":"2026-01-01T00:00:00Z"}]'
         exit 0
         ;;
+      repos/*/pulls/14/reviews)
+        # PR 14 (#487): claude[bot] formal approval; codex 👍 (own reactions),
+        # zero unresolved threads, but a stale sticky "- [ ]" checklist. Both
+        # reviewers are terminal-approved via their OWN signals, so completion
+        # must not block on the checklist drain regardless of MAX_WAIT budget.
+        echo '[{"user":{"login":"claude[bot]"},"state":"APPROVED","submitted_at":"2026-01-01T00:00:00Z"}]'
+        exit 0
+        ;;
       repos/*/pulls/10/reviews)
         count_file="${FAKE_GH_STATE_DIR:-}/pr10-reviews-count"
         count=0
@@ -245,12 +253,17 @@ JSON
 JSON
         exit 0
         ;;
-      repos/*/issues/5/comments|repos/*/issues/6/comments|repos/*/issues/7/comments|repos/*/issues/8/comments|repos/*/issues/9/comments|repos/*/issues/10/comments|repos/*/issues/11/comments|repos/*/issues/12/comments|repos/*/issues/13/comments)
+      repos/*/issues/5/comments|repos/*/issues/6/comments|repos/*/issues/7/comments|repos/*/issues/8/comments|repos/*/issues/9/comments|repos/*/issues/10/comments|repos/*/issues/11/comments|repos/*/issues/12/comments|repos/*/issues/13/comments|repos/*/issues/14/comments)
         echo '[]'
         exit 0
         ;;
       repos/*/issues/1/comments|repos/*/issues/1/reactions|repos/*/issues/2/reactions|repos/*/issues/12/reactions|repos/*/issues/13/reactions|repos/*/issues/comments/*/reactions)
         echo '[]'
+        exit 0
+        ;;
+      repos/*/issues/14/reactions)
+        # PR 14 (#487): Codex approved the PR body with 👍.
+        echo '[{"user":{"login":"chatgpt-codex-connector[bot]"},"content":"+1"}]'
         exit 0
         ;;
       repos/*/issues/3/reactions|repos/*/issues/comments/3001/reactions)
@@ -347,7 +360,7 @@ JSON
   pr)
     case "${2:-}" in
       view)
-        if [[ "${3:-}" == "3" || "${3:-}" == "4" || "${3:-}" == "5" || "${3:-}" == "6" || "${3:-}" == "8" || "${3:-}" == "11" ]]; then
+        if [[ "${3:-}" == "3" || "${3:-}" == "4" || "${3:-}" == "5" || "${3:-}" == "6" || "${3:-}" == "8" || "${3:-}" == "11" || "${3:-}" == "14" ]]; then
           echo '{"reviewDecision":"APPROVED"}'
         else
           echo '{"reviewDecision":"REVIEW_REQUIRED"}'
@@ -523,6 +536,42 @@ assert_eq "$code" "0" "timeout final read observes reviewer terminal state"
 assert_eq "$(jq -r .status <<<"$output")" "complete" "timeout final read emits complete JSON for terminal reviewer"
 assert_eq "$(jq -r .elapsed_seconds <<<"$output")" "1" "timeout final read keeps elapsed capped at max wait"
 assert_contains "$(jq -c '.reviewers[0].signals' <<<"$output")" "reaction:+1" "timeout final read uses refreshed reviewer signals"
+
+cat > "$TMP_ROOT/repo/.env.local" <<EOF
+GIT_HOST_CLI="$FAKE_GITHUB_SH"
+EOF
+# #487: both reviewers are terminal-approved via their OWN signals (claude[bot]
+# formal APPROVED, codex 👍) with zero unresolved threads, but a stale sticky
+# "- [ ]" checklist never drains. The terminal result must be independent of the
+# MAX_WAIT budget: a long-budget waiter must NOT block on the checklist drain
+# (which, pre-fix, burned up to PHASE3_MAX / remaining budget and then emitted
+# checklist_timeout). Wrapped in `timeout 8s` so a regression that reinstates the
+# unbounded checklist wait would kill the run and fail loudly rather than pass.
+set +e
+long_output=$(timeout 8s bash -c 'cd "$1" && PATH="$2:$PATH" BOT_REVIEW_SETTLE_SECONDS=0 .agents/skills/orch/scripts/bot-review-wait 14 1 600 --json --reviewers "claude[bot],chatgpt-codex-connector[bot]"' bash "$TMP_ROOT/repo" "$TMP_ROOT/bin")
+long_code=$?
+set -e
+assert_eq "$long_code" "0" "own-terminal approval + stale checklist completes on long budget (#487)"
+assert_json "$long_output" "own-terminal approval long budget emits parseable JSON"
+assert_eq "$(jq -r .status <<<"$long_output")" "complete" "own-terminal approval emits complete, not checklist_timeout (#487)"
+assert_eq "$(jq -r .verdict <<<"$long_output")" "approved" "own-terminal approval keeps approved verdict (#487)"
+# Must return well under the pre-fix checklist window (PHASE3_MAX=300, capped by
+# the 600s budget); a couple of seconds of stub wall-time is fine, 300+ is not.
+long_elapsed="$(jq -r .elapsed_seconds <<<"$long_output")"
+assert_eq "$([[ "$long_elapsed" =~ ^[0-9]+$ && "$long_elapsed" -lt 30 ]] && echo under || echo "$long_elapsed")" "under" "own-terminal approval does not consume the long budget on the checklist (#487)"
+# Resolution must come from reviewer-own signals, not the PR-level fallback
+# promotion — neither reviewer should carry pr_review_decision:approved.
+assert_eq "$(jq -r '[.reviewers[] | .signals[] | select(. == "pr_review_decision:approved")] | length' <<<"$long_output")" "0" "own-terminal approval resolves without PR-level fallback promotion (#487)"
+
+# Duration independence: the same stubbed state under a short budget yields the
+# identical terminal status/verdict.
+set +e
+short_output=$(timeout 8s bash -c 'cd "$1" && PATH="$2:$PATH" BOT_REVIEW_SETTLE_SECONDS=0 .agents/skills/orch/scripts/bot-review-wait 14 1 10 --json --reviewers "claude[bot],chatgpt-codex-connector[bot]"' bash "$TMP_ROOT/repo" "$TMP_ROOT/bin")
+short_code=$?
+set -e
+assert_eq "$short_code" "0" "own-terminal approval completes on short budget (#487)"
+assert_eq "$(jq -r .status <<<"$short_output")" "$(jq -r .status <<<"$long_output")" "long and short budgets agree on status (#487)"
+assert_eq "$(jq -r .verdict <<<"$short_output")" "$(jq -r .verdict <<<"$long_output")" "long and short budgets agree on verdict (#487)"
 
 cat > "$TMP_ROOT/repo/.env.local" <<EOF
 GIT_HOST_CLI="$FAKE_GITHUB_SH"


### PR DESCRIPTION
## Summary
- Fix `bot-review-wait` staying pending for minutes after all reviewers approve, while a fresh short invocation over the same PR state returns `complete/approved` immediately — a terminal result that wrongly depended on remaining `MAX_WAIT` budget.
- Root cause: `terminal_posting_done` skipped the sticky `- [ ]` checklist drain only when `pr_terminal_fallback_applied` (a signal added *only* to reviewers the PR-level fallback promotes from pending→approved). When both reviewers are approved via their **own** terminal signals (Codex `reaction:+1`, Claude `formal_review:approved`/`sticky:approved`), nothing is promoted, the signal is absent, so the waiter fell into `wait_for_checklist` and blocked up to PHASE3_MAX (≈300s, matching the observed ~353s) on a checklist that never drains. The stronger (reviewer-own-terminal) approval paradoxically waited longer than the weaker fallback promotion.
- Fix: new `reviewers_own_terminal_approved` helper — true when every non-skipped reviewer is `approved` with zero unresolved threads and carries an own approval signal (`formal_review:approved` | `sticky:approved` | `reaction:+1`). `terminal_posting_done` now skips the checklist drain when `pr_terminal_fallback_applied OR reviewers_own_terminal_approved`, still running the bounded `wait_for_terminal_settle` (BOT_REVIEW_SETTLE_SECONDS) for late Codex inline threads. Requires `sticky:approved` specifically, so a still-pending sticky keeps gating on the checklist.

## Non-regressions
Pending reviewers still loop to timeout; changes-requested still hits the checklist wait / `checklist_timeout` (exit 2); #448 established-approval retention and #450 no-foreign-attribution unchanged; exit codes (0/1/2/3) intact.

## Completed Issues
- Closes #487

## Test Plan
- New stubbed PR 14 in `skills/orch/tests/bot_review_wait.sh`: Claude formal APPROVED + Codex 👍, zero unresolved threads, but a stale `- [ ]` sticky checklist. A long-budget invocation (`14 1 600`, wrapped in `timeout 8s`) asserts exit 0 / `complete` / `approved` / elapsed < 30s and that no reviewer carries `pr_review_decision:approved` (proving the reviewer-own path resolved it, not the fallback). Duration-independence: long and short (`14 1 10`) agree on status+verdict.
- `bash skills/orch/tests/run-all.sh` — all 6 files pass (bot_review_wait 84/0). `bash -n` clean.
