### PR TITLE
fix(github): make --format command-specific in help and reject it in pr-view

### DIFF
--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -132,14 +132,17 @@ Resolution rules:
 
 ## Output Formats
 
+`--format` is command-specific, not a global flag. Only the commands listed
+below accept it; others (e.g. `pr-view`, which takes only `--json FIELDS`) do not.
+
 | Format | Description | Commands |
 |--------|-------------|----------|
-| `safe` | DEFAULT. Flat, normalized JSON | All |
+| `safe` | DEFAULT. Flat, normalized JSON | pr-data, pr-threads, pr-list-ready, pr-list-failing, pr-issue, ci-logs, bot-token |
 | `raw` | Original API structure | pr-data, pr-threads |
 | `text` | Plain text extraction | pr-issue, ci-logs, bot-token |
 | `table` | Human-readable table | pr-list-ready, pr-list-failing |
 
-`--json` is accepted as alias for `--format=safe`.
+`--json` is accepted as alias for `--format=safe` on the commands above.
 
 ## Configuration
 

--- a/skills/github/scripts/commands/pr-view.sh
+++ b/skills/github/scripts/commands/pr-view.sh
@@ -67,6 +67,10 @@ Options:
   --json FIELDS    Output specific fields as JSON (e.g., --json number,title)
   --help           Show this help
 
+Note:
+  --format is not supported here. For a normalized safe/raw PR view use
+  'github.sh pr-data [PR] --format=safe|raw'.
+
 Errors:
   Emits structured JSON with status=no_pr, auth_error, token_resolution_failed,
   token_resolution_timeout, token_resolution_unavailable, auth_timeout,
@@ -99,6 +103,13 @@ main() {
             --help|-h)
                 show_help
                 exit 0
+                ;;
+            --format|--format=*)
+                emit_error_result "unsupported_flag" \
+                    "pr-view does not support --format" \
+                    "pr-view accepts only --json FIELDS. For normalized safe/raw PR output use: github.sh pr-data [PR] --format=safe|raw" \
+                    2
+                exit 2
                 ;;
             -*)
                 extra_args+=("$1")

--- a/skills/github/scripts/github.sh
+++ b/skills/github/scripts/github.sh
@@ -91,8 +91,18 @@ Commands:
   sticky-comment     Get claude bot sticky comment with verdict
 
 Output Formats:
-  --format=safe    Flat, normalized structure (DEFAULT)
-  --format=raw     Original GitHub API structure
+  --format is command-specific, not a global option. Supported modes
+  (default is safe where applicable):
+    pr-data          safe | raw
+    pr-threads       safe | raw
+    pr-list-ready    safe | table
+    pr-list-failing  safe | table
+    ci-logs          safe | text
+    pr-issue         safe | text
+    bot-token        safe | text
+  Commands not listed above (e.g. pr-view) do not accept --format; see
+  './github.sh <command> --help'. For a normalized safe/raw PR view, use
+  pr-data.
 
 Examples:
   # Get PR data with all threads and comments

--- a/skills/github/tests/pr-view.sh
+++ b/skills/github/tests/pr-view.sh
@@ -45,6 +45,8 @@ cat > "$TMP_ROOT/bin/gh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 
+printf '%s\n' "$*" >>"${STUB_GH_CALLS:-/dev/null}"
+
 _auth_ok() {
   local tok="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
   if [[ "$tok" == op://* ]]; then
@@ -134,6 +136,27 @@ run_pr_view() {
     && PATH="$TMP_ROOT/bin:$PATH" \
        STUB_OP_CALLS="$TMP_ROOT/op.calls" \
        env -u GH_TOKEN -u GITHUB_TOKEN "$@" "$GITHUB_SH" -C "$TMP_ROOT/repo" pr-view --json number,state)
+}
+
+# Invoke pr-view with an unsupported --format=<mode>, logging every gh call to
+# calls_file so tests can prove the flag is not forwarded to gh pr view.
+run_pr_view_format() {
+  local fmt="$1" calls_file="$2"
+  (cd "$TMP_ROOT/repo" \
+    && PATH="$TMP_ROOT/bin:$PATH" \
+       STUB_GH_CALLS="$calls_file" \
+       env -u GH_TOKEN -u GITHUB_TOKEN "$GITHUB_SH" -C "$TMP_ROOT/repo" pr-view 42 "--format=$fmt")
+}
+
+assert_not_contains() {
+  local haystack="$1" needle="$2" name="$3"
+  if grep -qF -- "$needle" <<<"$haystack"; then
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        unwanted substring: %s\n        in: %s\n' "$name" "$needle" "$haystack"
+  else
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  fi
 }
 
 echo "=== github.sh pr-view ==="
@@ -228,6 +251,46 @@ rc=$?
 set -e
 assert_eq "$rc" "0" "successful pr-view exits 0" "$stderr"
 assert_eq "$(jq -r .number <<<"$output")" "42" "successful pr-view preserves gh JSON" "$stderr"
+
+echo
+echo "=== github.sh pr-view --format rejection ==="
+
+# pr-view advertises only --json FIELDS; --format must be rejected by the
+# wrapper with a clean error, never forwarded to `gh pr view` (which would emit
+# gh's own "unknown flag: --format").
+calls="$TMP_ROOT/gh-format-safe.calls"
+: >"$calls"
+stderr="$TMP_ROOT/format-safe.err"
+set +e
+output=$(run_pr_view_format safe "$calls" 2>"$stderr")
+rc=$?
+set -e
+assert_eq "$rc" "2" "pr-view --format=safe exits nonzero (wrapper rejects)" "$stderr"
+assert_eq "$(jq -r .status <<<"$output")" "unsupported_flag" "pr-view --format=safe emits structured status" "$stderr"
+assert_contains "$(cat "$stderr")" "does not support --format" "pr-view --format=safe clean wrapper error"
+assert_contains "$(cat "$stderr")" "pr-data" "pr-view --format=safe points to pr-data"
+assert_not_contains "$(cat "$stderr")" "unknown flag" "pr-view --format=safe suppresses gh unknown flag"
+assert_not_contains "$(cat "$calls")" "--format" "pr-view --format=safe never forwards --format to gh"
+
+calls="$TMP_ROOT/gh-format-raw.calls"
+: >"$calls"
+stderr="$TMP_ROOT/format-raw.err"
+set +e
+output=$(run_pr_view_format raw "$calls" 2>"$stderr")
+rc=$?
+set -e
+assert_eq "$rc" "2" "pr-view --format=raw exits nonzero (wrapper rejects)" "$stderr"
+assert_eq "$(jq -r .status <<<"$output")" "unsupported_flag" "pr-view --format=raw emits structured status" "$stderr"
+assert_contains "$(cat "$stderr")" "does not support --format" "pr-view --format=raw clean wrapper error"
+assert_not_contains "$(cat "$stderr")" "unknown flag" "pr-view --format=raw suppresses gh unknown flag"
+assert_not_contains "$(cat "$calls")" "--format" "pr-view --format=raw never forwards --format to gh"
+
+echo
+echo "=== github.sh --help no longer advertises --format globally ==="
+
+help_out="$("$GITHUB_SH" --help)"
+assert_contains "$help_out" "command-specific" "root help marks --format as command-specific"
+assert_not_contains "$help_out" "--format=safe    Flat, normalized structure (DEFAULT)" "root help drops global --format=safe block"
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"


### PR DESCRIPTION
## Summary
- Fix `github.sh --help` advertising `--format=safe|raw` as a global option when it is actually command-specific — `github.sh pr-view <PR> --format=safe` failed with `gh`'s `unknown flag: --format` because pr-view forwarded it.
- Root help now accurately enumerates which commands support `--format` and their modes (pr-data/pr-threads: safe|raw; pr-list-ready/pr-list-failing: safe|table; ci-logs/pr-issue/bot-token: safe|text) and states pr-view does not accept it.
- `pr-view` now rejects `--format`/`--format=*` with a clean wrapper-level `unsupported_flag` error (exit 2) pointing to `--json FIELDS` and `pr-data` for normalized output, instead of leaking gh's error. Commands that do support `--format` are unchanged.

## Completed Issues
- Closes #490

## Test Plan
- Extended `skills/github/tests/pr-view.sh`: asserts `pr-view --format=safe|raw` produces the clean wrapper error and never forwards `--format` to `gh pr view`, plus root `--help` no longer presents `--format` as a global option. Suite passes 36/0.
- Enumeration verified against the actual command sources; `bash -n` clean.
