### PR TITLE
fix(orch): scope ci-wait checks to current run, dropping superseded canceled runs

### DIFF
--- a/skills/orch/scripts/ci-wait
+++ b/skills/orch/scripts/ci-wait
@@ -261,11 +261,51 @@ is_transient_failure() {
   return 1
 }
 
+# Scope a `gh pr checks` array to the current authoritative run per workflow so
+# stale checks from a SUPERSEDED workflow run don't leak into the current
+# PR/head status (vstack#492). A single canceled prior run left Lint/Integration/
+# etc. as CANCELLED; with no newer instance of those jobs yet created, they were
+# the only copies and were wrongly counted as current failures.
+#
+# Approach: parse each check's owning workflow RUN_ID from its `link`
+# (`.../actions/runs/<RUN_ID>/job/<JOB_ID>`), group run-bearing checks by their
+# `workflow`, and within each workflow keep ONLY the checks belonging to that
+# workflow's LATEST run (max RUN_ID). This (a) drops an old run's checks when a
+# newer run of the same workflow exists, and (b) — the reported case — drops the
+# old canceled job even when the newer run hasn't recreated it yet, leaving it
+# correctly absent (reported as not-yet-created/pending, not failed). Distinct
+# workflows are never collapsed (e.g. a separate "License Key Guard" workflow is
+# preserved). Checks with no parseable run in `link` (external/required contexts,
+# default-setup `.../runs/<CHECK_RUN_ID>` links, or older gh output with no link)
+# are always kept, deduped by name keeping the latest `startedAt`. An all-empty
+# link/startedAt array (older gh) passes through unchanged.
+scope_current_run() {
+  jq -c '
+    def runid:
+      (.link // "")
+      | ((capture("/actions/runs/(?<r>[0-9]+)")? | .r) // null)
+      | (if . == null then null else tonumber end);
+    map(. + {"_runid": runid})
+    | ([.[] | select(._runid == null)]) as $norun
+    | ([.[] | select(._runid != null)]) as $withrun
+    | ($withrun
+        | group_by(.workflow)
+        | map((map(._runid) | max) as $mx | map(select(._runid == $mx)))
+        | add // []) as $scoped
+    | ($norun | group_by(.name) | map(sort_by(.startedAt // "") | last)) as $norun_deduped
+    | ($scoped + $norun_deduped)
+    | map(del(._runid))
+  '
+}
+
 # Failure check `link` is `https://github.com/owner/repo/actions/runs/<RUN_ID>/job/<JOB_ID>` —
 # extract RUN_ID, not the trailing JOB_ID (which `gh run rerun` won't accept as a workflow run).
+# Scope to the current run first so a rerun never targets a superseded/canceled
+# run (vstack#492).
 get_failed_run_id() {
   local pr="$1"
-  gh pr checks "$pr" --repo "$REPO" --json name,state,bucket,link 2>/dev/null | \
+  gh pr checks "$pr" --repo "$REPO" --json name,state,bucket,link,startedAt,workflow 2>/dev/null | \
+    scope_current_run | \
     jq -r '
       def bucket:
         (.bucket // (
@@ -308,7 +348,7 @@ while [ "$elapsed" -lt "$MAX_WAIT" ]; do
   # Capture stderr so we can distinguish auth/repo failures from "no checks yet".
   checks_status=0
   set +e
-  checks_json=$(gh pr checks "$PR_NUM" --repo "$REPO" --json name,state,bucket 2>"$checks_stderr")
+  checks_json=$(gh pr checks "$PR_NUM" --repo "$REPO" --json name,state,bucket,link,startedAt,workflow 2>"$checks_stderr")
   checks_status=$?
   set -e
   if [ "$checks_status" -ne 0 ] && ! jq -e 'type == "array"' >/dev/null 2>&1 <<<"$checks_json"; then
@@ -338,6 +378,10 @@ while [ "$elapsed" -lt "$MAX_WAIT" ]; do
 
   # Reset no-checks counter once we see checks
   no_checks_count=0
+
+  # Drop checks belonging to superseded workflow runs before classifying, so a
+  # prior canceled run can't be reported as a current failure (vstack#492).
+  checks_json=$(echo "$checks_json" | scope_current_run)
 
   # Count checks by GitHub's bucket classifier, with state fallbacks for older
   # gh output. This must stay aligned with github pr-merge --check.

--- a/skills/orch/tests/ci_wait.sh
+++ b/skills/orch/tests/ci_wait.sh
@@ -197,6 +197,40 @@ case "${1:-}" in
         echo '[]'
         exit 0
       fi
+      # vstack#492: an OLD superseded run (RUN_ID 29098545030) left several
+      # CANCELLED named jobs; the NEW authoritative run (RUN_ID 29099680623) on
+      # the current head has only its classifier job IN_PROGRESS and has NOT yet
+      # created Lint/Integration/etc. Scoping to the latest run per workflow must
+      # drop the OLD canceled jobs so they are not reported as current failures.
+      if [[ "${STUB_PR_CHECKS_MODE:-}" == "superseded_pending" ]]; then
+        cat <<'JSON'
+[
+  {"name":"Lint","state":"CANCELLED","bucket":"cancel","link":"https://github.com/owner/repo/actions/runs/29098545030/job/101","workflow":"CI","startedAt":"2026-07-10T10:00:00Z","completedAt":"2026-07-10T10:00:30Z"},
+  {"name":"Linux Integration","state":"CANCELLED","bucket":"cancel","link":"https://github.com/owner/repo/actions/runs/29098545030/job/102","workflow":"CI","startedAt":"2026-07-10T10:00:01Z","completedAt":"2026-07-10T10:00:31Z"},
+  {"name":"macOS","state":"CANCELLED","bucket":"cancel","link":"https://github.com/owner/repo/actions/runs/29098545030/job/103","workflow":"CI","startedAt":"2026-07-10T10:00:02Z","completedAt":"2026-07-10T10:00:32Z"},
+  {"name":"Windows","state":"CANCELLED","bucket":"cancel","link":"https://github.com/owner/repo/actions/runs/29098545030/job/104","workflow":"CI","startedAt":"2026-07-10T10:00:03Z","completedAt":"2026-07-10T10:00:33Z"},
+  {"name":"Loom","state":"CANCELLED","bucket":"cancel","link":"https://github.com/owner/repo/actions/runs/29098545030/job/105","workflow":"CI","startedAt":"2026-07-10T10:00:04Z","completedAt":"2026-07-10T10:00:34Z"},
+  {"name":"Bench (iai-callgrind)","state":"CANCELLED","bucket":"cancel","link":"https://github.com/owner/repo/actions/runs/29098545030/job/106","workflow":"CI","startedAt":"2026-07-10T10:00:05Z","completedAt":"2026-07-10T10:00:35Z"},
+  {"name":"Changes","state":"IN_PROGRESS","bucket":"pending","link":"https://github.com/owner/repo/actions/runs/29099680623/job/201","workflow":"CI","startedAt":"2026-07-10T11:00:00Z","completedAt":""},
+  {"name":"License Key Guard","state":"SUCCESS","bucket":"pass","link":"https://github.com/owner/repo/actions/runs/29099680623/job/202","workflow":"CI","startedAt":"2026-07-10T11:00:01Z","completedAt":"2026-07-10T11:00:20Z"}
+]
+JSON
+        exit 8
+      fi
+      # vstack#492 (part 2): once the NEW run recreates a named job (Lint on
+      # RUN_ID 29099680623, SUCCESS), that current-head instance must replace the
+      # OLD run's CANCELLED "Lint" (RUN_ID 29098545030) by context name, leaving
+      # no stale CANCELLED entry in failed_checks.
+      if [[ "${STUB_PR_CHECKS_MODE:-}" == "superseded_replaced" ]]; then
+        cat <<'JSON'
+[
+  {"name":"Lint","state":"CANCELLED","bucket":"cancel","link":"https://github.com/owner/repo/actions/runs/29098545030/job/101","workflow":"CI","startedAt":"2026-07-10T10:00:00Z","completedAt":"2026-07-10T10:00:30Z"},
+  {"name":"Lint","state":"SUCCESS","bucket":"pass","link":"https://github.com/owner/repo/actions/runs/29099680623/job/201","workflow":"CI","startedAt":"2026-07-10T11:00:00Z","completedAt":"2026-07-10T11:05:00Z"},
+  {"name":"Changes","state":"SUCCESS","bucket":"pass","link":"https://github.com/owner/repo/actions/runs/29099680623/job/202","workflow":"CI","startedAt":"2026-07-10T11:00:01Z","completedAt":"2026-07-10T11:00:20Z"}
+]
+JSON
+        exit 0
+      fi
       if [[ "${STUB_PR_CHECKS_MODE:-}" == "failure" ]]; then
         echo '[{"name":"build","state":"FAILURE"}]'
         exit 1
@@ -488,6 +522,40 @@ rc=$?
 set -e
 assert_eq "$rc" "0" "case17: https origin without .git exits 0" "$stderr"
 assert_eq "$(cat "$repo_arg_file")" "owner/repo" "case17: --repo slug preserved without .git" "$stderr"
+
+echo "=== ci-wait superseded-run scoping (vstack#492) ==="
+
+# Case 18: an OLD canceled run's CANCELLED jobs must NOT be reported as current
+# failures when the NEW authoritative run has only its classifier job pending and
+# has not yet recreated those jobs. Scoping to the latest run per workflow drops
+# the superseded run's checks, so the verdict is pending (waiting on "Changes"),
+# never a false fail on the stale CANCELLED Lint/Integration/etc.
+stderr="$TMP_ROOT/case18.err"
+set +e
+output=$(run_wait_json_short STUB_PR_CHECKS_MODE=superseded_pending 2>"$stderr")
+rc=$?
+set -e
+assert_eq "$rc" "1" "case18: superseded-run pending exits 1 (timeout)" "$stderr"
+assert_eq "$(json_field "$output" '.status')" "timeout" "case18: json status is timeout" "$stderr"
+assert_eq "$(json_field "$output" '.verdict')" "pending" "case18: verdict pending, not fail" "$stderr"
+assert_eq "$(json_field "$output" '.failed_checks | length')" "0" "case18: no stale CANCELLED jobs in failed_checks" "$stderr"
+assert_contains "$output" '"Changes"' "case18: current classifier job reported as pending" "$stderr"
+assert_not_contains "$output" '"Lint"' "case18: superseded run's Lint dropped from output" "$stderr"
+assert_not_contains "$output" '"Linux Integration"' "case18: superseded run's Integration dropped" "$stderr"
+
+# Case 19: once the NEW run recreates a named job (Lint SUCCESS on the newest
+# RUN_ID), that current-head instance replaces the OLD run's CANCELLED "Lint" by
+# context name — no stale CANCELLED entry survives, verdict passes.
+stderr="$TMP_ROOT/case19.err"
+set +e
+output=$(run_wait_json STUB_PR_CHECKS_MODE=superseded_replaced 2>"$stderr")
+rc=$?
+set -e
+assert_eq "$rc" "0" "case19: superseded-then-replaced exits 0" "$stderr"
+assert_eq "$(json_field "$output" '.verdict')" "pass" "case19: verdict pass after replacement" "$stderr"
+assert_eq "$(json_field "$output" '.failed_checks | length')" "0" "case19: no CANCELLED Lint in failed_checks" "$stderr"
+assert_not_contains "$output" '"CANCELLED"' "case19: no stale CANCELLED state survives" "$stderr"
+assert_eq "$(json_field "$output" '[.passed_checks[].name] | map(select(. == "Lint")) | length')" "1" "case19: exactly one current Lint instance kept" "$stderr"
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"


### PR DESCRIPTION
## Summary
- Fix `ci-wait` mixing CANCELLED checks from a superseded workflow run into the current-head status, reporting them as current `failed_checks` (which could misroute an orchestrator into false CI-failure recovery). Observed when an old canceled run's jobs appeared as failures while the new authoritative run had only its classifier in progress and hadn't recreated the named jobs yet.
- New `scope_current_run()` jq filter, applied to the raw `gh pr checks` array before classification: parses the RUN_ID from each check's `link`, groups run-bearing checks by `workflow`, and keeps only the checks from the latest run per workflow. This drops a superseded run's checks even when the newer run hasn't recreated a given job (so it's correctly absent → pending, not failed), and never collapses distinct workflows. External/no-run contexts (link without `/actions/runs/`) are preserved, deduped by name keeping the latest `startedAt`. Empty-field inputs pass through unchanged (backward compatible).
- Applied in the poll loop and in `get_failed_run_id` (so a transient-failure rerun never targets a canceled/superseded run). Preserves the deterministic emit contract (#454), the `.git`-slug fix (#476), exit codes, timeout-while-pending, and JSON shape.

## Completed Issues
- Closes #492

## Follow-up (not in this PR)
`skills/github/scripts/commands/pr-merge.sh` runs the parallel `gh pr checks` classifier that this script's comment says must stay aligned with it, and has the same unscoped-superseded-run flaw at the merge gate. A follow-up applies the same run-scoping there.

## Test Plan
- New `gh` stub fixtures in `skills/orch/tests/ci_wait.sh`: `superseded_pending` (old canceled run 29098545030 with CANCELLED Lint/Linux Integration/macOS/Windows/Loom/Bench + new run 29099680623 with only `Changes` IN_PROGRESS) and `superseded_replaced` (old CANCELLED Lint + new SUCCESS Lint). Case 18 asserts verdict=pending, `failed_checks` empty, `Changes` present, canceled checks dropped. Case 19 asserts verdict=pass, no surviving CANCELLED, exactly one current Lint.
- `bash skills/orch/tests/run-all.sh` — all 6 files pass (ci_wait 68 assertions). `bash -n` clean.
