### PR TITLE
fix(github): scope pr-merge --check CI to current run

### DIFF
--- a/skills/github/scripts/commands/pr-merge.sh
+++ b/skills/github/scripts/commands/pr-merge.sh
@@ -26,6 +26,45 @@ source "$SCRIPT_DIR/../lib/pr-branch.sh"
 # CI completes. Callers should `await-mergeable` and retry rather than fix.
 TRANSIENT_PREFIXES='unknown:|ci_pending:|ci_unconfigured:|ci_fetch_failed:'
 
+# Scope a `gh pr checks` array to the current authoritative run per workflow so
+# stale checks from a SUPERSEDED workflow run don't leak into the current
+# PR/head status (vstack#492). A single canceled prior run left Lint/Integration/
+# etc. as CANCELLED; with no newer instance of those jobs yet created, they were
+# the only copies and were wrongly counted as current failures.
+#
+# Approach: parse each check's owning workflow RUN_ID from its `link`
+# (`.../actions/runs/<RUN_ID>/job/<JOB_ID>`), group run-bearing checks by their
+# `workflow`, and within each workflow keep ONLY the checks belonging to that
+# workflow's LATEST run (max RUN_ID). This (a) drops an old run's checks when a
+# newer run of the same workflow exists, and (b) — the reported case — drops the
+# old canceled job even when the newer run hasn't recreated it yet, leaving it
+# correctly absent (reported as not-yet-created/pending, not failed). Distinct
+# workflows are never collapsed (e.g. a separate "License Key Guard" workflow is
+# preserved). Checks with no parseable run in `link` (external/required contexts,
+# default-setup `.../runs/<CHECK_RUN_ID>` links, or older gh output with no link)
+# are always kept, deduped by name keeping the latest `startedAt`. An all-empty
+# link/startedAt array (older gh) passes through unchanged.
+#
+# This must stay aligned with orch ci-wait's scope_current_run (byte-for-byte).
+scope_current_run() {
+  jq -c '
+    def runid:
+      (.link // "")
+      | ((capture("/actions/runs/(?<r>[0-9]+)")? | .r) // null)
+      | (if . == null then null else tonumber end);
+    map(. + {"_runid": runid})
+    | ([.[] | select(._runid == null)]) as $norun
+    | ([.[] | select(._runid != null)]) as $withrun
+    | ($withrun
+        | group_by(.workflow)
+        | map((map(._runid) | max) as $mx | map(select(._runid == $mx)))
+        | add // []) as $scoped
+    | ($norun | group_by(.name) | map(sort_by(.startedAt // "") | last)) as $norun_deduped
+    | ($scoped + $norun_deduped)
+    | map(del(._runid))
+  '
+}
+
 show_help() {
     cat <<'EOF'
 Merge PR as bot account with safety checks
@@ -95,7 +134,7 @@ run_checks() {
     # 2. Check CI status
     local ci_json
     set +e
-    ci_json=$(gh pr checks "$pr_num" --json name,state,bucket 2>&1)
+    ci_json=$(gh pr checks "$pr_num" --json name,state,bucket,link,startedAt,workflow 2>&1)
     set -e
 
     # `gh pr checks` exits 8 while checks are pending, but still prints usable
@@ -107,8 +146,12 @@ run_checks() {
     elif [ "$(echo "$ci_json" | jq 'length')" -eq 0 ]; then
         warnings+=("ci_unconfigured: No status checks configured")
     else
-        local ci_classification pending failed
-        ci_classification=$(echo "$ci_json" | jq -c '
+        # Drop checks belonging to superseded workflow runs before classifying,
+        # so a prior canceled run can't be reported as a current merge blocker
+        # (vstack#492). Mirrors orch ci-wait's pre-classification scoping.
+        local scoped_ci_json ci_classification pending failed
+        scoped_ci_json=$(echo "$ci_json" | scope_current_run)
+        ci_classification=$(echo "$scoped_ci_json" | jq -c '
             def bucket:
                 (.bucket // (
                     if (.state == "SUCCESS") then "pass"

--- a/skills/github/tests/pr-merge.sh
+++ b/skills/github/tests/pr-merge.sh
@@ -122,5 +122,49 @@ assert_eq "$(jq -r '.issues | length' <<<"$out")" "0" "successful and skipped ch
 assert_eq "$(jq -r .transient <<<"$out")" "false" "mergeable PR is not transient"
 
 echo
+echo "=== pr-merge --check superseded-run scoping (vstack#492/#494) ==="
+
+# An OLD superseded run (RUN_ID 29098545030) left several CANCELLED named jobs;
+# the NEW authoritative run (RUN_ID 29099680623) on the current head is still
+# in progress ("Changes"). Scoping must drop the superseded run's CANCELLED jobs
+# so they are NOT reported as ci_failed blockers — only the current run's
+# still-pending check gates the merge (transient, retryable).
+checks='[
+  {"name":"Lint","state":"CANCELLED","bucket":"cancel","link":"https://github.com/owner/repo/actions/runs/29098545030/job/101","workflow":"CI","startedAt":"2026-07-10T10:00:00Z"},
+  {"name":"Linux Integration","state":"CANCELLED","bucket":"cancel","link":"https://github.com/owner/repo/actions/runs/29098545030/job/102","workflow":"CI","startedAt":"2026-07-10T10:00:01Z"},
+  {"name":"macOS","state":"CANCELLED","bucket":"cancel","link":"https://github.com/owner/repo/actions/runs/29098545030/job/103","workflow":"CI","startedAt":"2026-07-10T10:00:02Z"},
+  {"name":"Changes","state":"IN_PROGRESS","bucket":"pending","link":"https://github.com/owner/repo/actions/runs/29099680623/job/201","workflow":"CI","startedAt":"2026-07-10T11:00:00Z"},
+  {"name":"License Key Guard","state":"SUCCESS","bucket":"pass","link":"https://github.com/owner/repo/actions/runs/29099680623/job/202","workflow":"CI","startedAt":"2026-07-10T11:00:01Z"}
+]'
+out=$(STUB_CHECKS="$checks" STUB_CHECKS_EXIT=8 run_check)
+assert_eq "$(jq -r '[.issues[] | select(startswith("ci_failed:"))] | length' <<<"$out")" "0" "superseded CANCELLED jobs not reported as ci_failed"
+assert_eq "$(jq -r .transient <<<"$out")" "true" "only current run's pending check blocks (transient)"
+assert_contains "$out" "ci_pending: Changes (IN_PROGRESS)" "current run's pending check is the only blocker"
+assert_eq "$(jq -r '.issues | map(select(test("Lint|Linux Integration|macOS"))) | length' <<<"$out")" "0" "no superseded CANCELLED job names leak into issues"
+
+# The current-head run (RUN_ID 29099680623) has RE-CREATED and passed the jobs
+# the old run (29098545030) left CANCELLED. Scoping keeps only the newer run, so
+# the PR is cleanly mergeable — the stale CANCELLED copies must not block.
+checks='[
+  {"name":"Lint","state":"CANCELLED","bucket":"cancel","link":"https://github.com/owner/repo/actions/runs/29098545030/job/101","workflow":"CI","startedAt":"2026-07-10T10:00:00Z"},
+  {"name":"Lint","state":"SUCCESS","bucket":"pass","link":"https://github.com/owner/repo/actions/runs/29099680623/job/201","workflow":"CI","startedAt":"2026-07-10T11:00:00Z"},
+  {"name":"Changes","state":"SUCCESS","bucket":"pass","link":"https://github.com/owner/repo/actions/runs/29099680623/job/202","workflow":"CI","startedAt":"2026-07-10T11:00:01Z"}
+]'
+out=$(STUB_CHECKS="$checks" run_check)
+assert_eq "$(jq -r .can_merge <<<"$out")" "true" "superseded-then-replaced run is mergeable"
+assert_eq "$(jq -r '.issues | length' <<<"$out")" "0" "no stale CANCELLED Lint blocks the merge"
+
+# Guard: a genuinely-current cancellation (no newer run exists) must STILL be
+# reported as a failure — scoping only drops superseded runs, it must not mask
+# the latest run's own CANCELLED result.
+checks='[
+  {"name":"Lint","state":"SUCCESS","bucket":"pass","link":"https://github.com/owner/repo/actions/runs/29099680623/job/201","workflow":"CI","startedAt":"2026-07-10T11:00:00Z"},
+  {"name":"Integration","state":"CANCELLED","bucket":"cancel","link":"https://github.com/owner/repo/actions/runs/29099680623/job/202","workflow":"CI","startedAt":"2026-07-10T11:00:01Z"}
+]'
+out=$(STUB_CHECKS="$checks" STUB_CHECKS_EXIT=8 run_check)
+assert_eq "$(jq -r .can_merge <<<"$out")" "false" "current-run CANCELLED still blocks merge"
+assert_contains "$out" "ci_failed: Integration (CANCELLED)" "current-run CANCELLED reported as ci_failed"
+
+echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary
- Fix `pr-merge --check` (`skills/github/scripts/commands/pr-merge.sh`) counting CANCELLED checks from a superseded workflow run as current merge blockers — the same defect fixed for `ci-wait` in #492, and the classifier the ci-wait comment says must stay aligned with it.
- Ports ci-wait's `scope_current_run()` (byte-for-byte identical jq) into pr-merge.sh: fetches `gh pr checks --json name,state,bucket,link,startedAt,workflow` and scopes to the latest run per workflow before the existing bucket classifier. Bucketing and all can_merge/issues/warnings logic, exit-8-while-pending handling, `ci_fetch_failed`/`ci_unconfigured` guards, and output shape are unchanged; scoping never turns a non-empty array empty (backward compatible).

## Sibling audit
Only pr-merge ran the unscoped merge-readiness classifier. `ci-logs` (diagnostic log fetch), `pr-list-ready`/`pr-list-failing` (use GitHub's `statusCheckRollup`, already latest-per-context and treat CANCELLED as passing), and `pr-cross-check`/`pr-data` (no classifier) are not affected — left intentionally.

## Completed Issues
- Closes #494

## Test Plan
- `skills/github/tests/pr-merge.sh` +8 assertions (fixtures mirrored from ci_wait's superseded_pending/superseded_replaced): superseded CANCELLED jobs + newer in-progress run are NOT reported as `ci_failed` (only the current pending check blocks, transient); superseded-then-replaced → can_merge true, 0 issues; and a guard that a genuinely-current CANCELLED (no newer run) STILL blocks (`ci_failed`) so scoping never masks the latest run's own cancel.
- pr-merge test 23/23 pass; `bash -n` clean.
