### PR TITLE
fix(orch): guard merge-pr §5a branch delete against worktree checkout

### DIFF
--- a/skills/orch/tests/workflow_helpers.sh
+++ b/skills/orch/tests/workflow_helpers.sh
@@ -138,6 +138,8 @@ assert_file_contains "$merge_workflow" '.agents/skills/orch/scripts/ci-wait [PR_
 assert_file_contains "$merge_workflow" 'Do not repeat § 3.1 indefinitely' "merge-pr forbids unbounded transient wait loops"
 assert_file_contains "$merge_workflow" 'git-https-auth -C [MAIN_REPO_ROOT] fetch --prune origin "+refs/heads/[BASE_BRANCH]:refs/remotes/origin/[BASE_BRANCH]"' "merge-pr sync fetches explicit origin base branch through HTTPS auth helper"
 assert_file_contains "$merge_workflow" 'git -C [MAIN_REPO_ROOT] merge --ff-only "origin/[BASE_BRANCH]"' "merge-pr sync fast-forwards to quoted fetched origin base branch with plain git"
+assert_file_not_contains "$merge_workflow" 'branch -D "$PR_BRANCH"' "merge-pr § 5a no longer force-deletes the PR branch unconditionally"
+assert_file_contains "$merge_workflow" 'branch refs/heads/[PR_BRANCH]' "merge-pr § 5a guards branch delete against worktree checkout"
 
 assert_file_not_contains "$qa_workflow" "Pipe benchmark output" "qa-review avoids pipe-based benchmark recording"
 assert_file_not_contains "$qa_workflow" "pipe results" "qa-review avoids pipe-based perf capture guidance"

--- a/skills/orch/workflows/merge-pr.md
+++ b/skills/orch/workflows/merge-pr.md
@@ -286,11 +286,19 @@ merge. Detach them first.
       gh pr view [PR_NUMBER] --json headRefName --jq .headRefName
       ```
       Use the output as `PR_BRANCH`.
-   2. If `[PR_BRANCH]` exists locally and is not the current branch, delete it:
-      ```bash
-      git -C [MAIN_REPO_ROOT] branch -D "$PR_BRANCH"
-      ```
-   3. Worktree removal is handled by step 6 when § 4.1 captured a cleanup request.
+   2. Delete the local `[PR_BRANCH]` **only when no worktree owns it**:
+
+      - **If § 4.1 captured a worktree-cleanup request** for this PR's issue → **skip** the standalone delete; step 6's `worktree remove` removes the worktree and safely deletes the merged branch. Continue to step 3.
+      - **Otherwise**, list registered worktrees to confirm the branch is free before deleting:
+        ```bash
+        git -C [MAIN_REPO_ROOT] worktree list --porcelain
+        ```
+        | Output condition | Action |
+        |------------------|--------|
+        | A `branch refs/heads/[PR_BRANCH]` line is present | A worktree still has it checked out — do NOT delete (`branch -D` would fail). Leave it for worktree removal or the § 5b maintenance sweep; note in § 7. |
+        | No such line, and `[PR_BRANCH]` exists locally and is not the current branch | Delete it: `git -C [MAIN_REPO_ROOT] branch -D "[PR_BRANCH]"` |
+        | `[PR_BRANCH]` is absent locally or is the current branch | Nothing to delete. |
+   3. When § 4.1 captured a cleanup request, step 6's `worktree remove` owns branch deletion; the standalone delete above is intentionally skipped.
 
    ### 5b. Project maintenance sweep (explicit only)
 


### PR DESCRIPTION
## Summary
- Fix `merge-pr.md` §5a deleting the merged PR's local branch before §5 step 6 removes the issue worktree. When the branch was still checked out by that worktree, `git branch -D "$PR_BRANCH"` failed with `Cannot delete branch checked out at <worktree>` even though the merge succeeded (the old guard only checked "not the current branch").
- §5a step 2 now deletes the branch only when no worktree owns it: if §4.1 captured a worktree-cleanup request, it skips the standalone delete entirely — step 6's `worktree remove` already removes the worktree and safely deletes the branch (`git branch -d`). Otherwise it consults `git worktree list --porcelain` via a decision table and deletes only when no `branch refs/heads/[PR_BRANCH]` line is present. §5b, §6's "must be last / destroys session cwd" semantics, and the merge steps are unchanged. Commands stay harness-safe (one simple command per call, no `$(...)`/`&&` plumbing).

## Completed Issues
- Closes #498

## Test Plan
- Added assertions in `skills/orch/tests/workflow_helpers.sh`: the unconditional `branch -D "$PR_BRANCH"` before worktree removal is gone, and the worktree-checkout guard (`branch refs/heads/[PR_BRANCH]`) is present.
- `bash skills/orch/tests/run-all.sh` — all 6 files pass (49/49).
