### PR TITLE
fix(#504): require --body-file for multiline Linear comments in dev-implement

### DIFF
--- a/skills/dev/tests/handoff-body-file-lint.test.sh
+++ b/skills/dev/tests/handoff-body-file-lint.test.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Regression lint: reject multiline inline --body in dev workflow docs.
+#
+# A `linear.sh comments create ... --body "` whose opening quote does NOT close
+# on the same physical line spills the message body across lines. When such a
+# body contains a backticked CLI command, Bash evaluates the backticks before
+# the comment is posted, producing a malformed comment (and running arbitrary
+# commands). Multiline bodies must use the tmp-file + `--body-file` pattern.
+#
+# Rule (deterministic, per physical line): a line that contains both
+# `comments create` and an inline `--body "` is flagged when the line has an
+# odd number of `"` characters (unterminated quote => multiline body).
+# Single-line `--body "short text"` (even quote count) and `--body-file` are
+# allowed. Hermetic: scans files on disk only, no network.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKFLOWS_DIR="$(cd "$SCRIPT_DIR/../workflows" && pwd)"
+
+offenders=0
+
+while IFS= read -r -d '' file; do
+  lineno=0
+  while IFS= read -r line; do
+    lineno=$((lineno + 1))
+    # Candidate: a `comments create` invocation with an inline `--body "…`.
+    # `--body-file` has no `"` after it, so it never matches this pattern.
+    case "$line" in
+      *"comments create"*'--body "'*) ;;
+      *) continue ;;
+    esac
+    # Strip every non-quote character; an odd count means the quote is
+    # unterminated on this line => the body continues onto later lines.
+    quotes="${line//[!\"]/}"
+    if (( ${#quotes} % 2 == 1 )); then
+      printf '%s:%d: multiline inline --body (use tmp file + --body-file)\n' "$file" "$lineno"
+      offenders=$((offenders + 1))
+    fi
+  done < "$file"
+done < <(find "$WORKFLOWS_DIR" -type f -name '*.md' -print0)
+
+if (( offenders > 0 )); then
+  echo "FAIL: $offenders multiline inline --body occurrence(s) found"
+  exit 1
+fi
+
+echo "all pass"

--- a/skills/dev/workflows/dev-implement.md
+++ b/skills/dev/workflows/dev-implement.md
@@ -161,9 +161,10 @@ When work in another domain must happen first (prerequisite issue doesn't exist)
    .agents/skills/linear/scripts/linear.sh issues update [ISSUE_ID] --labels "agent:[AGENT_TYPE],[COMPONENT],blocked"
    ```
 
-2. **Post structured comment** (Linear only):
-   ```bash
-   .agents/skills/linear/scripts/linear.sh comments create [ISSUE_ID] --body "BLOCKED: Cross-domain prerequisite needed.
+2. **Post structured comment** (Linear only). Create `tmp/blocked-[ISSUE_ID].md` with:
+
+   ```markdown
+   BLOCKED: Cross-domain prerequisite needed.
 
    **Required Domain**: [DOMAIN]
    **Suggested Labels**: agent:[DOMAIN], [COMPONENT]
@@ -176,7 +177,13 @@ When work in another domain must happen first (prerequisite issue doesn't exist)
    - [Deliverable 1]
    - [Deliverable 2]
 
-   Requesting orchestrator create prerequisite issue."
+   Requesting orchestrator create prerequisite issue.
+   ```
+
+   Then post it:
+
+   ```bash
+   .agents/skills/linear/scripts/linear.sh comments create [ISSUE_ID] --body-file tmp/blocked-[ISSUE_ID].md
    ```
 
 3. **Report to orchestrator**: Final message must state the blocker, domain and labels for the new issue, and that the issue description is ready for creation.
@@ -383,10 +390,17 @@ Check blocking relations:
 ```
 Read `.blocks` from the JSON output.
 
-Post a handoff comment to each downstream issue **only if** this work changed an API, interface, file, or contract the downstream issue depends on:
+Post a handoff comment to each downstream issue **only if** this work changed an API, interface, file, or contract the downstream issue depends on. Create `tmp/downstream-handoff-[ISSUE_ID]-to-[DOWNSTREAM_ISSUE_ID].md` with:
+
+```markdown
+Handoff from [ISSUE_ID]:
+- [RELEVANT_CONTEXT: what changed, what downstream needs to know]
+```
+
+Then post it:
+
 ```bash
-.agents/skills/linear/scripts/linear.sh comments create [DOWNSTREAM_ISSUE_ID] --body "Handoff from [ISSUE_ID]:
-- [RELEVANT_CONTEXT: what changed, what downstream needs to know]"
+.agents/skills/linear/scripts/linear.sh comments create [DOWNSTREAM_ISSUE_ID] --body-file tmp/downstream-handoff-[ISSUE_ID]-to-[DOWNSTREAM_ISSUE_ID].md
 ```
 
 Do NOT post handoff to the completed issue — that conflates audiences. Handoff Notes (§ 9.1) are for the next agent in this bundle. Downstream handoff is for agents working on issues this one unblocks.
@@ -437,9 +451,10 @@ Do NOT push or submit PR — orchestrator handles after review passes.
    .agents/skills/linear/scripts/linear.sh issues update [PARENT_ID] --labels "[EXISTING_LABELS],[AGGREGATED_QA_LABELS]"
    ```
 
-2. **Post parent summary** (Linear only, tree format for sub-issues, blocking info shown):
-   ```bash
-   .agents/skills/linear/scripts/linear.sh comments create [PARENT_ID] --body "## Bundle Complete
+2. **Post parent summary** (Linear only, tree format for sub-issues, blocking info shown). Create `tmp/bundle-summary-[PARENT_ID].md` with:
+
+   ```markdown
+   ## Bundle Complete
    **Agent**: [NAME] | **Branch**: [BRANCH]
 
    Sub-issues (tree):
@@ -447,7 +462,13 @@ Do NOT push or submit PR — orchestrator handles after review passes.
    ↳ [SUB_ISSUE_2] ✓ | blocked by: [SUB_ISSUE_1]
       ↳ [SUB_ISSUE_3] ✓  ← nested
    Files: N | Commits: N | QA: [LABELS]
-   [Discovered work: ...]"
+   [Discovered work: ...]
+   ```
+
+   Then post it:
+
+   ```bash
+   .agents/skills/linear/scripts/linear.sh comments create [PARENT_ID] --body-file tmp/bundle-summary-[PARENT_ID].md
    ```
 
 3. Send this result to the orchestrator as an agent-to-agent message. **Posting the parent summary comment is not a return** — the orchestrator does not poll the filesystem or issue tracker, and turn text is not visible across team boundaries. Send exactly one message with the body below, then go idle.


### PR DESCRIPTION
Closes #504

## Problem

`skills/dev/workflows/dev-implement.md` had three example blocks posting a Linear comment with an inline **multiline** `--body "…"` argument (§3.2 blocked comment, §9.2 downstream handoff, §11 bundle summary). This conflicts with the same file's §1 shell-safety rule and §9.1's `--body-file` pattern. In a real bundled run, a handoff body containing a backticked CLI command caused Bash to evaluate the backticks before posting, producing a malformed comment that had to be superseded.

## Change

- Convert all three sites to the `tmp/*.md` + `--body-file` pattern, mirroring §9.1. Message content is preserved verbatim inside ` ```markdown ` fences; §9.1 (already correct) is untouched. No sections renumbered.
- Add `skills/dev/tests/handoff-body-file-lint.test.sh` — a hermetic regression lint that scans `skills/dev/workflows/*.md` and fails on any `comments create … --body "` line whose quote is unterminated (multiline inline body). Single-line `--body "text"` and `--body-file` pass.

## Verification

- `bash skills/dev/tests/handoff-body-file-lint.test.sh` → `all pass`
- Negative check: lint flags a scratch multiline `--body "` line and exits 1.
- `grep -n 'comments create' skills/dev/workflows/dev-implement.md` → every hit now uses `--body-file`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)