### PR TITLE
fix(#507): case-fold open-terminal issue IDs; parent env wins over project settings

### DIFF
--- a/skills/decider/scripts/lib/vstack-env.sh
+++ b/skills/decider/scripts/lib/vstack-env.sh
@@ -72,6 +72,15 @@ vstack_load_settings_file() {
     [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
     value="$(vstack_unquote_value "$value")"
 
+    # Parent-process values win over project [env] tables. The snapshot array is
+    # only present when called via vstack_load_project_env; `declare -p`
+    # short-circuits (without erroring under set -u) when it is undeclared, e.g.
+    # a standalone call, so the assoc-array key subscript is only evaluated once
+    # the array is known to exist.
+    if declare -p _VSTACK_PARENT_ENV >/dev/null 2>&1 && [[ -v "_VSTACK_PARENT_ENV[$key]" ]]; then
+      continue
+    fi
+
     printf -v "$key" '%s' "$value"
     export "$key"
   done < "$file"
@@ -81,8 +90,35 @@ vstack_load_project_env() {
   local project_root="$1"
   [[ -n "$project_root" ]] || return 0
 
+  # Snapshot parent-process variables (name -> value) so project files cannot
+  # clobber caller-provided values (documented precedence: parent process wins
+  # over project files). compgen -e lists only exported names (the environment),
+  # excluding this function's locals, and is captured before any file loads so
+  # it holds parent env only — not values set by .env below. The stored value is
+  # used to re-assert parent precedence after loading.
+  declare -gA _VSTACK_PARENT_ENV=()
+  local _vstack_name
+  while IFS= read -r _vstack_name; do
+    _VSTACK_PARENT_ENV["$_vstack_name"]="${!_vstack_name-}"
+  done < <(compgen -e)
+
+  # Load order (lowest to highest among project files): .env, then settings,
+  # then .env.local. vstack_load_settings_file skips parent keys directly; the
+  # env files are sourced wholesale, so their clobbers are undone below.
   vstack_source_env_file "$project_root/.env"
   vstack_load_settings_file "$project_root/vstack.settings.toml"
   vstack_load_settings_file "$project_root/.vstack/settings.toml"
   vstack_source_env_file "$project_root/.env.local"
+
+  # Re-assert parent values so parent env wins over every project file, while
+  # the .env < settings < .env.local order is preserved for non-parent keys.
+  # Only changed keys are rewritten; a readonly var can never differ from its
+  # snapshot, so this never attempts to assign one.
+  for _vstack_name in "${!_VSTACK_PARENT_ENV[@]}"; do
+    if [[ "${!_vstack_name-}" != "${_VSTACK_PARENT_ENV[$_vstack_name]}" ]]; then
+      export "$_vstack_name=${_VSTACK_PARENT_ENV[$_vstack_name]}"
+    fi
+  done
+
+  unset _VSTACK_PARENT_ENV
 }

--- a/skills/github/scripts/lib/vstack-env.sh
+++ b/skills/github/scripts/lib/vstack-env.sh
@@ -72,6 +72,15 @@ vstack_load_settings_file() {
     [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
     value="$(vstack_unquote_value "$value")"
 
+    # Parent-process values win over project [env] tables. The snapshot array is
+    # only present when called via vstack_load_project_env; `declare -p`
+    # short-circuits (without erroring under set -u) when it is undeclared, e.g.
+    # a standalone call, so the assoc-array key subscript is only evaluated once
+    # the array is known to exist.
+    if declare -p _VSTACK_PARENT_ENV >/dev/null 2>&1 && [[ -v "_VSTACK_PARENT_ENV[$key]" ]]; then
+      continue
+    fi
+
     printf -v "$key" '%s' "$value"
     export "$key"
   done < "$file"
@@ -81,8 +90,35 @@ vstack_load_project_env() {
   local project_root="$1"
   [[ -n "$project_root" ]] || return 0
 
+  # Snapshot parent-process variables (name -> value) so project files cannot
+  # clobber caller-provided values (documented precedence: parent process wins
+  # over project files). compgen -e lists only exported names (the environment),
+  # excluding this function's locals, and is captured before any file loads so
+  # it holds parent env only — not values set by .env below. The stored value is
+  # used to re-assert parent precedence after loading.
+  declare -gA _VSTACK_PARENT_ENV=()
+  local _vstack_name
+  while IFS= read -r _vstack_name; do
+    _VSTACK_PARENT_ENV["$_vstack_name"]="${!_vstack_name-}"
+  done < <(compgen -e)
+
+  # Load order (lowest to highest among project files): .env, then settings,
+  # then .env.local. vstack_load_settings_file skips parent keys directly; the
+  # env files are sourced wholesale, so their clobbers are undone below.
   vstack_source_env_file "$project_root/.env"
   vstack_load_settings_file "$project_root/vstack.settings.toml"
   vstack_load_settings_file "$project_root/.vstack/settings.toml"
   vstack_source_env_file "$project_root/.env.local"
+
+  # Re-assert parent values so parent env wins over every project file, while
+  # the .env < settings < .env.local order is preserved for non-parent keys.
+  # Only changed keys are rewritten; a readonly var can never differ from its
+  # snapshot, so this never attempts to assign one.
+  for _vstack_name in "${!_VSTACK_PARENT_ENV[@]}"; do
+    if [[ "${!_vstack_name-}" != "${_VSTACK_PARENT_ENV[$_vstack_name]}" ]]; then
+      export "$_vstack_name=${_VSTACK_PARENT_ENV[$_vstack_name]}"
+    fi
+  done
+
+  unset _VSTACK_PARENT_ENV
 }

--- a/skills/linear/scripts/lib/vstack-env.sh
+++ b/skills/linear/scripts/lib/vstack-env.sh
@@ -72,6 +72,15 @@ vstack_load_settings_file() {
     [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
     value="$(vstack_unquote_value "$value")"
 
+    # Parent-process values win over project [env] tables. The snapshot array is
+    # only present when called via vstack_load_project_env; `declare -p`
+    # short-circuits (without erroring under set -u) when it is undeclared, e.g.
+    # a standalone call, so the assoc-array key subscript is only evaluated once
+    # the array is known to exist.
+    if declare -p _VSTACK_PARENT_ENV >/dev/null 2>&1 && [[ -v "_VSTACK_PARENT_ENV[$key]" ]]; then
+      continue
+    fi
+
     printf -v "$key" '%s' "$value"
     export "$key"
   done < "$file"
@@ -81,8 +90,35 @@ vstack_load_project_env() {
   local project_root="$1"
   [[ -n "$project_root" ]] || return 0
 
+  # Snapshot parent-process variables (name -> value) so project files cannot
+  # clobber caller-provided values (documented precedence: parent process wins
+  # over project files). compgen -e lists only exported names (the environment),
+  # excluding this function's locals, and is captured before any file loads so
+  # it holds parent env only — not values set by .env below. The stored value is
+  # used to re-assert parent precedence after loading.
+  declare -gA _VSTACK_PARENT_ENV=()
+  local _vstack_name
+  while IFS= read -r _vstack_name; do
+    _VSTACK_PARENT_ENV["$_vstack_name"]="${!_vstack_name-}"
+  done < <(compgen -e)
+
+  # Load order (lowest to highest among project files): .env, then settings,
+  # then .env.local. vstack_load_settings_file skips parent keys directly; the
+  # env files are sourced wholesale, so their clobbers are undone below.
   vstack_source_env_file "$project_root/.env"
   vstack_load_settings_file "$project_root/vstack.settings.toml"
   vstack_load_settings_file "$project_root/.vstack/settings.toml"
   vstack_source_env_file "$project_root/.env.local"
+
+  # Re-assert parent values so parent env wins over every project file, while
+  # the .env < settings < .env.local order is preserved for non-parent keys.
+  # Only changed keys are rewritten; a readonly var can never differ from its
+  # snapshot, so this never attempts to assign one.
+  for _vstack_name in "${!_VSTACK_PARENT_ENV[@]}"; do
+    if [[ "${!_vstack_name-}" != "${_VSTACK_PARENT_ENV[$_vstack_name]}" ]]; then
+      export "$_vstack_name=${_VSTACK_PARENT_ENV[$_vstack_name]}"
+    fi
+  done
+
+  unset _VSTACK_PARENT_ENV
 }

--- a/skills/orch/scripts/lib/vstack-env.sh
+++ b/skills/orch/scripts/lib/vstack-env.sh
@@ -72,6 +72,15 @@ vstack_load_settings_file() {
     [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
     value="$(vstack_unquote_value "$value")"
 
+    # Parent-process values win over project [env] tables. The snapshot array is
+    # only present when called via vstack_load_project_env; `declare -p`
+    # short-circuits (without erroring under set -u) when it is undeclared, e.g.
+    # a standalone call, so the assoc-array key subscript is only evaluated once
+    # the array is known to exist.
+    if declare -p _VSTACK_PARENT_ENV >/dev/null 2>&1 && [[ -v "_VSTACK_PARENT_ENV[$key]" ]]; then
+      continue
+    fi
+
     printf -v "$key" '%s' "$value"
     export "$key"
   done < "$file"
@@ -81,8 +90,35 @@ vstack_load_project_env() {
   local project_root="$1"
   [[ -n "$project_root" ]] || return 0
 
+  # Snapshot parent-process variables (name -> value) so project files cannot
+  # clobber caller-provided values (documented precedence: parent process wins
+  # over project files). compgen -e lists only exported names (the environment),
+  # excluding this function's locals, and is captured before any file loads so
+  # it holds parent env only — not values set by .env below. The stored value is
+  # used to re-assert parent precedence after loading.
+  declare -gA _VSTACK_PARENT_ENV=()
+  local _vstack_name
+  while IFS= read -r _vstack_name; do
+    _VSTACK_PARENT_ENV["$_vstack_name"]="${!_vstack_name-}"
+  done < <(compgen -e)
+
+  # Load order (lowest to highest among project files): .env, then settings,
+  # then .env.local. vstack_load_settings_file skips parent keys directly; the
+  # env files are sourced wholesale, so their clobbers are undone below.
   vstack_source_env_file "$project_root/.env"
   vstack_load_settings_file "$project_root/vstack.settings.toml"
   vstack_load_settings_file "$project_root/.vstack/settings.toml"
   vstack_source_env_file "$project_root/.env.local"
+
+  # Re-assert parent values so parent env wins over every project file, while
+  # the .env < settings < .env.local order is preserved for non-parent keys.
+  # Only changed keys are rewritten; a readonly var can never differ from its
+  # snapshot, so this never attempts to assign one.
+  for _vstack_name in "${!_VSTACK_PARENT_ENV[@]}"; do
+    if [[ "${!_vstack_name-}" != "${_VSTACK_PARENT_ENV[$_vstack_name]}" ]]; then
+      export "$_vstack_name=${_VSTACK_PARENT_ENV[$_vstack_name]}"
+    fi
+  done
+
+  unset _VSTACK_PARENT_ENV
 }

--- a/skills/orch/scripts/open-terminal
+++ b/skills/orch/scripts/open-terminal
@@ -117,8 +117,20 @@ launched=0
 for raw in "${ITEMS[@]}"; do
   item="$raw"
   if [[ "$TRACKER" == "linear" ]]; then
-    item="$(printf '%s' "$item" | tr '[:lower:]' '[:upper:]')"
-    [[ "$item" =~ ^$GH_ISSUE_PATTERN$ ]] || { echo "Error: invalid issue id: $raw" >&2; exit 1; }
+    # Validate case-insensitively, then normalize to whichever case the
+    # configured GH_ISSUE_PATTERN accepts, so lowercase-convention projects
+    # (e.g. GH_ISSUE_PATTERN="cc-[0-9]+") work without forcing uppercase.
+    item_upper="$(printf '%s' "$raw" | tr '[:lower:]' '[:upper:]')"
+    item_lower="$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]')"
+    if [[ "$item_upper" =~ ^$GH_ISSUE_PATTERN$ ]]; then
+      item="$item_upper"
+    elif [[ "$item_lower" =~ ^$GH_ISSUE_PATTERN$ ]]; then
+      item="$item_lower"
+    elif [[ "$raw" =~ ^$GH_ISSUE_PATTERN$ ]]; then
+      item="$raw"
+    else
+      echo "Error: invalid issue id: $raw" >&2; exit 1
+    fi
     wt="$("$WORKTREE_CLI" create "$item")"
     title="$item"
   else

--- a/skills/orch/tests/open-terminal-issue-id.sh
+++ b/skills/orch/tests/open-terminal-issue-id.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Regression tests for open-terminal issue-id validation and case normalization.
+#
+# Bug 1 (vstack#507): open-terminal force-uppercased the item before matching
+# GH_ISSUE_PATTERN, so lowercase-convention projects (e.g. cc-[0-9]+) rejected
+# every id. It must now validate case-insensitively and normalize to whichever
+# case the configured pattern accepts.
+#
+# The test runs a byte-identical copy of open-terminal inside a temp git repo so
+# `git rev-parse --show-toplevel` resolves to a hermetic PROJECT_ROOT, and stubs
+# the worktree CLI, GUI terminal, and gh so nothing external is launched.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$TEST_DIR/.." && pwd)/scripts"
+SRC_OT="$SCRIPTS_DIR/open-terminal"
+SRC_LIB="$SCRIPTS_DIR/lib/vstack-env.sh"
+TMP_ROOT="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local got="$1" want="$2" name="$3"
+  if [[ "$got" == "$want" ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$name" "$want" "$got"
+  fi
+}
+
+assert_contains() {
+  local haystack="$1" needle="$2" name="$3"
+  if grep -qF -- "$needle" <<<"$haystack"; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        wanted substring: %s\n        in: %s\n' "$name" "$needle" "$haystack"
+  fi
+}
+
+# Shared stub bin: a fake GUI terminal (exit 0 so open_gui's success echo runs)
+# and a fake gh (exit 1 so resolve_repo yields empty without touching network).
+BIN="$TMP_ROOT/bin"
+mkdir -p "$BIN"
+cat > "$BIN/ghostty" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+cat > "$BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+chmod +x "$BIN/ghostty" "$BIN/gh"
+
+# Stub worktree CLI: `create <item>` makes and prints a temp dir.
+STUB="$TMP_ROOT/worktree-stub"
+cat > "$STUB" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "\${1:-}" == "create" ]]; then
+  d="$TMP_ROOT/wt/\${2:-unknown}"
+  mkdir -p "\$d"
+  printf '%s\n' "\$d"
+  exit 0
+fi
+echo "unexpected worktree stub call: \$*" >&2
+exit 1
+EOF
+chmod +x "$STUB"
+
+# Build a temp git repo containing a copy of open-terminal + its lib, so the
+# script's PROJECT_ROOT resolves to this repo. $2 optional settings body.
+make_ot_repo() {
+  local repo="$1" settings="${2:-}"
+  mkdir -p "$repo/scripts/lib"
+  cp "$SRC_OT" "$repo/scripts/open-terminal"
+  cp "$SRC_LIB" "$repo/scripts/lib/vstack-env.sh"
+  chmod +x "$repo/scripts/open-terminal"
+  git -C "$repo" init -q
+  if [[ -n "$settings" ]]; then
+    printf '%s\n' "$settings" > "$repo/vstack.settings.toml"
+  fi
+  printf '%s\n' "$repo/scripts/open-terminal"
+}
+
+echo "=== open-terminal issue-id normalization ==="
+
+# Repo A: no project settings -> built-in default pattern [A-Z]+-[0-9]+.
+REPO_A="$TMP_ROOT/repo-a"
+OT_A="$(make_ot_repo "$REPO_A")"
+
+# Case 1: default pattern normalizes lowercase and uppercase input to uppercase.
+set +e
+c1a_out=$(PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT_A" --ghostty --cmd 'echo {item}' cc-737 2>"$TMP_ROOT/c1a.err")
+c1a_code=$?
+set -e
+assert_eq "$c1a_code" "0" "default pattern: lowercase input accepted"
+assert_contains "$c1a_out" "Opened terminal 'CC-737'" "default pattern: cc-737 normalizes to CC-737"
+
+set +e
+c1b_out=$(PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT_A" --ghostty --cmd 'echo {item}' CC-737 2>"$TMP_ROOT/c1b.err")
+c1b_code=$?
+set -e
+assert_eq "$c1b_code" "0" "default pattern: uppercase input accepted"
+assert_contains "$c1b_out" "Opened terminal 'CC-737'" "default pattern: CC-737 stays CC-737"
+
+# Repo B: project settings force an UNRELATED uppercase pattern. A parent-env
+# GH_ISSUE_PATTERN of cc-[0-9]+ must win (Bug 2) and drive lowercase
+# normalization (Bug 1); without the Bug 2 fix the settings pattern would win
+# and both ids would be rejected.
+REPO_B="$TMP_ROOT/repo-b"
+OT_B="$(make_ot_repo "$REPO_B" '[env]
+GH_ISSUE_PATTERN = "ZZ-[0-9]+"')"
+
+# Case 2: lowercase pattern normalizes uppercase and lowercase input to lowercase.
+set +e
+c2a_out=$(GH_ISSUE_PATTERN='cc-[0-9]+' PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT_B" --ghostty --cmd 'echo {item}' CC-737 2>"$TMP_ROOT/c2a.err")
+c2a_code=$?
+set -e
+assert_eq "$c2a_code" "0" "lowercase pattern (parent env wins over settings): uppercase input accepted"
+assert_contains "$c2a_out" "Opened terminal 'cc-737'" "lowercase pattern: CC-737 normalizes to cc-737"
+
+set +e
+c2b_out=$(GH_ISSUE_PATTERN='cc-[0-9]+' PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT_B" --ghostty --cmd 'echo {item}' cc-737 2>"$TMP_ROOT/c2b.err")
+c2b_code=$?
+set -e
+assert_eq "$c2b_code" "0" "lowercase pattern: lowercase input accepted"
+assert_contains "$c2b_out" "Opened terminal 'cc-737'" "lowercase pattern: cc-737 stays cc-737"
+
+# Case 3: an id that matches no case of the default pattern is rejected.
+set +e
+c3_out=$(PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT_A" --ghostty --cmd 'echo {item}' 12ab 2>"$TMP_ROOT/c3.err")
+c3_code=$?
+set -e
+assert_eq "$c3_code" "1" "invalid id exits nonzero"
+assert_contains "$(cat "$TMP_ROOT/c3.err")" "Error: invalid issue id" "invalid id reports a clear error"
+
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/skills/orch/tests/vstack-env-precedence.sh
+++ b/skills/orch/tests/vstack-env-precedence.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Regression tests for vstack-env.sh project-config precedence.
+#
+# Contract (highest to lowest priority):
+#   parent-process env  >  .env.local  >  vstack.settings.toml/.vstack/settings.toml  >  .env
+#
+# Bug 2 (vstack#507): the settings loader clobbered caller-provided env. Parent
+# values must now win over every project file, while the .env < settings <
+# .env.local order is preserved for keys the parent did not set.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB="$(cd "$TEST_DIR/.." && pwd)/scripts/lib/vstack-env.sh"
+TMP_ROOT="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local got="$1" want="$2" name="$3"
+  if [[ "$got" == "$want" ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$name" "$want" "$got"
+  fi
+}
+
+echo "=== vstack-env precedence ==="
+
+# Shared project root for scenarios 1 and 2.
+PROJ="$TMP_ROOT/proj"
+mkdir -p "$PROJ"
+printf 'FOO="from-env"\n' > "$PROJ/.env"
+cat > "$PROJ/vstack.settings.toml" <<'TOML'
+[env]
+FOO = "from-settings"
+BAR = "bar-settings"
+TOML
+printf 'BAZ="from-local"\n' > "$PROJ/.env.local"
+
+# Scenario 1: no parent FOO -> settings overrides .env (existing contract).
+set +e
+s1_out=$(
+  set -euo pipefail
+  source "$LIB"
+  vstack_load_project_env "$PROJ"
+  printf '%s|%s|%s\n' "$FOO" "$BAR" "$BAZ"
+)
+s1_code=$?
+set -e
+assert_eq "$s1_code" "0" "scenario 1 loads without error"
+assert_eq "$s1_out" "from-settings|bar-settings|from-local" "scenario 1: settings overrides .env; .env.local applied"
+
+# Scenario 2: parent FOO exported -> parent wins over both .env and settings;
+# a key the parent did not set (BAR) is still taken from settings.
+set +e
+s2_out=$(
+  set -euo pipefail
+  export FOO=from-parent
+  source "$LIB"
+  vstack_load_project_env "$PROJ"
+  printf '%s|%s\n' "$FOO" "$BAR"
+)
+s2_code=$?
+set -e
+assert_eq "$s2_code" "0" "scenario 2 loads without error"
+assert_eq "$s2_out" "from-parent|bar-settings" "scenario 2: parent env wins over project files; other settings keys still applied"
+
+# Scenario 3: the issue's exact case. Parent GH_ISSUE_PATTERN must survive a
+# conflicting lowercase pattern in project settings.
+PROJ3="$TMP_ROOT/proj3"
+mkdir -p "$PROJ3"
+printf 'FOO="from-env"\n' > "$PROJ3/.env"
+cat > "$PROJ3/vstack.settings.toml" <<'TOML'
+[env]
+GH_ISSUE_PATTERN = "cc-[0-9]+"
+TOML
+set +e
+s3_out=$(
+  set -euo pipefail
+  export GH_ISSUE_PATTERN='CC-[0-9]+'
+  source "$LIB"
+  vstack_load_project_env "$PROJ3"
+  printf '%s\n' "$GH_ISSUE_PATTERN"
+)
+s3_code=$?
+set -e
+assert_eq "$s3_code" "0" "scenario 3 loads without error"
+assert_eq "$s3_out" 'CC-[0-9]+' "scenario 3: parent GH_ISSUE_PATTERN wins over conflicting settings"
+
+# Scenario 4: standalone-call safety. vstack_load_settings_file must work in a
+# fresh subshell with no _VSTACK_PARENT_ENV snapshot, without erroring under
+# set -u, and still set a fresh key.
+STANDALONE="$TMP_ROOT/standalone.toml"
+cat > "$STANDALONE" <<'TOML'
+[env]
+FRESH_KEY = "fresh-val"
+TOML
+set +e
+s4_out=$(
+  set -euo pipefail
+  source "$LIB"
+  vstack_load_settings_file "$STANDALONE"
+  printf '%s\n' "$FRESH_KEY"
+)
+s4_code=$?
+set -e
+assert_eq "$s4_code" "0" "scenario 4: standalone settings load does not error without a snapshot"
+assert_eq "$s4_out" "fresh-val" "scenario 4: standalone settings load sets a fresh key"
+
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/skills/second-opinion/scripts/lib/vstack-env.sh
+++ b/skills/second-opinion/scripts/lib/vstack-env.sh
@@ -72,6 +72,15 @@ vstack_load_settings_file() {
     [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
     value="$(vstack_unquote_value "$value")"
 
+    # Parent-process values win over project [env] tables. The snapshot array is
+    # only present when called via vstack_load_project_env; `declare -p`
+    # short-circuits (without erroring under set -u) when it is undeclared, e.g.
+    # a standalone call, so the assoc-array key subscript is only evaluated once
+    # the array is known to exist.
+    if declare -p _VSTACK_PARENT_ENV >/dev/null 2>&1 && [[ -v "_VSTACK_PARENT_ENV[$key]" ]]; then
+      continue
+    fi
+
     printf -v "$key" '%s' "$value"
     export "$key"
   done < "$file"
@@ -81,8 +90,35 @@ vstack_load_project_env() {
   local project_root="$1"
   [[ -n "$project_root" ]] || return 0
 
+  # Snapshot parent-process variables (name -> value) so project files cannot
+  # clobber caller-provided values (documented precedence: parent process wins
+  # over project files). compgen -e lists only exported names (the environment),
+  # excluding this function's locals, and is captured before any file loads so
+  # it holds parent env only — not values set by .env below. The stored value is
+  # used to re-assert parent precedence after loading.
+  declare -gA _VSTACK_PARENT_ENV=()
+  local _vstack_name
+  while IFS= read -r _vstack_name; do
+    _VSTACK_PARENT_ENV["$_vstack_name"]="${!_vstack_name-}"
+  done < <(compgen -e)
+
+  # Load order (lowest to highest among project files): .env, then settings,
+  # then .env.local. vstack_load_settings_file skips parent keys directly; the
+  # env files are sourced wholesale, so their clobbers are undone below.
   vstack_source_env_file "$project_root/.env"
   vstack_load_settings_file "$project_root/vstack.settings.toml"
   vstack_load_settings_file "$project_root/.vstack/settings.toml"
   vstack_source_env_file "$project_root/.env.local"
+
+  # Re-assert parent values so parent env wins over every project file, while
+  # the .env < settings < .env.local order is preserved for non-parent keys.
+  # Only changed keys are rewritten; a readonly var can never differ from its
+  # snapshot, so this never attempts to assign one.
+  for _vstack_name in "${!_VSTACK_PARENT_ENV[@]}"; do
+    if [[ "${!_vstack_name-}" != "${_VSTACK_PARENT_ENV[$_vstack_name]}" ]]; then
+      export "$_vstack_name=${_VSTACK_PARENT_ENV[$_vstack_name]}"
+    fi
+  done
+
+  unset _VSTACK_PARENT_ENV
 }

--- a/skills/worktree/scripts/lib/vstack-env.sh
+++ b/skills/worktree/scripts/lib/vstack-env.sh
@@ -72,6 +72,15 @@ vstack_load_settings_file() {
     [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
     value="$(vstack_unquote_value "$value")"
 
+    # Parent-process values win over project [env] tables. The snapshot array is
+    # only present when called via vstack_load_project_env; `declare -p`
+    # short-circuits (without erroring under set -u) when it is undeclared, e.g.
+    # a standalone call, so the assoc-array key subscript is only evaluated once
+    # the array is known to exist.
+    if declare -p _VSTACK_PARENT_ENV >/dev/null 2>&1 && [[ -v "_VSTACK_PARENT_ENV[$key]" ]]; then
+      continue
+    fi
+
     printf -v "$key" '%s' "$value"
     export "$key"
   done < "$file"
@@ -81,8 +90,35 @@ vstack_load_project_env() {
   local project_root="$1"
   [[ -n "$project_root" ]] || return 0
 
+  # Snapshot parent-process variables (name -> value) so project files cannot
+  # clobber caller-provided values (documented precedence: parent process wins
+  # over project files). compgen -e lists only exported names (the environment),
+  # excluding this function's locals, and is captured before any file loads so
+  # it holds parent env only — not values set by .env below. The stored value is
+  # used to re-assert parent precedence after loading.
+  declare -gA _VSTACK_PARENT_ENV=()
+  local _vstack_name
+  while IFS= read -r _vstack_name; do
+    _VSTACK_PARENT_ENV["$_vstack_name"]="${!_vstack_name-}"
+  done < <(compgen -e)
+
+  # Load order (lowest to highest among project files): .env, then settings,
+  # then .env.local. vstack_load_settings_file skips parent keys directly; the
+  # env files are sourced wholesale, so their clobbers are undone below.
   vstack_source_env_file "$project_root/.env"
   vstack_load_settings_file "$project_root/vstack.settings.toml"
   vstack_load_settings_file "$project_root/.vstack/settings.toml"
   vstack_source_env_file "$project_root/.env.local"
+
+  # Re-assert parent values so parent env wins over every project file, while
+  # the .env < settings < .env.local order is preserved for non-parent keys.
+  # Only changed keys are rewritten; a readonly var can never differ from its
+  # snapshot, so this never attempts to assign one.
+  for _vstack_name in "${!_VSTACK_PARENT_ENV[@]}"; do
+    if [[ "${!_vstack_name-}" != "${_VSTACK_PARENT_ENV[$_vstack_name]}" ]]; then
+      export "$_vstack_name=${_VSTACK_PARENT_ENV[$_vstack_name]}"
+    fi
+  done
+
+  unset _VSTACK_PARENT_ENV
 }


### PR DESCRIPTION
Closes #507

Two coupled bugs in vstack assets.

## Bug 1 — `orch/scripts/open-terminal` force-uppercased the item

The linear branch did `tr '[:lower:]' '[:upper:]'` then matched `GH_ISSUE_PATTERN`, so projects with a lowercase pattern (hyprtrade: `cc-[0-9]+`) rejected **every** ID (`CC-737` can't match `^cc-[0-9]+$`). Now validates case-insensitively and normalizes `item` to whichever case the configured pattern actually accepts:
- default `[A-Z]+-[0-9]+`: `cc-737`/`CC-737` → `CC-737` (unchanged behavior)
- lowercase `cc-[0-9]+`: `CC-737`/`cc-737` → `cc-737` (fixed)

## Bug 2 — `lib/vstack-env.sh` settings loader clobbered parent-process env

`vstack_load_settings_file` unconditionally overrode caller-provided env, contradicting the documented convention (github README/SKILL: "helpers preserve parent-process values over project files") and defeating the `GH_ISSUE_PATTERN=… open-terminal` workaround.

Fix honors the full precedence **parent > `.env.local` > settings > `.env`**:
- Snapshot parent env (name→value) via `compgen -e` *before* any file loads.
- Settings loader skips keys the parent set (guarded so standalone calls are safe).
- After all files load, re-assert parent values (compare-first, so readonly vars are never reassigned) — this makes parent win over the wholesale-sourced `.env`/`.env.local` too, while `.env < settings < .env.local` is preserved for non-parent keys.

Applied identically to all six byte-identical copies (orch, github, linear, worktree, second-opinion, decider). `github.sh`'s own token snapshot/restore is left in place.

## Tests
- `orch/tests/vstack-env-precedence.sh` (8) — settings>.env, parent>settings, the exact `GH_ISSUE_PATTERN` repro, standalone-loader safety.
- `orch/tests/open-terminal-issue-id.sh` (10) — default + lowercase pattern normalization (end-to-end, exercising both fixes), invalid-id rejection.
- `worktree/tests/worktree_remove.sh` still 59/59 (no precedence regression); full `orch/tests/run-all.sh` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)