### PR TITLE
fix(#509): recover second-opinion review JSON from one-shot prose responses

### DIFF
--- a/skills/second-opinion/schemas/review-finding-prompt.md
+++ b/skills/second-opinion/schemas/review-finding-prompt.md
@@ -1,4 +1,6 @@
-Output ONLY valid JSON — no markdown fences, no explanation before or after:
+Output ONLY valid JSON — no markdown fences, no explanation before or after.
+
+This is a single fresh session with no prior turns and no session history. Output the COMPLETE JSON object in THIS response — do NOT claim the JSON was "already delivered", "above", or "previously", because there is no earlier message. If you have nothing to report, still emit the full JSON object below with an empty `blockers` array and verdict "pass":
 
 {
   "agent": "external-TARGET",

--- a/skills/second-opinion/scripts/second-opinion
+++ b/skills/second-opinion/scripts/second-opinion
@@ -322,7 +322,11 @@ trap 'rm -f "$PROMPT_TMP"' EXIT
 printf '%s\n' "$PROMPT" > "$PROMPT_TMP"
 
 STDERR_TMP=$(mktemp)
-trap 'rm -f "$PROMPT_TMP" "$STDERR_TMP"' EXIT
+# RETRY_PROMPT_TMP is created only when extraction fails and a retry runs; keep
+# it in the cleanup trap. Sidecar files written by preserve_raw_and_fail are
+# deliberately NOT tracked here — they are the durable record of a lost response.
+RETRY_PROMPT_TMP=""
+trap 'rm -f "$PROMPT_TMP" "$STDERR_TMP" "$RETRY_PROMPT_TMP"' EXIT
 
 # --- Invoke external CLI ------------------------------------------------------
 
@@ -333,26 +337,33 @@ EXIT_CODE=0
 CLAUDE_CMD="${SECOND_OPINION_CLAUDE_CMD:-claude -p --no-session-persistence --model opus --effort max --allowedTools Bash(read-only:true),Read,Glob,Grep}"
 CODEX_CMD="${SECOND_OPINION_CODEX_CMD:-codex exec -m gpt-5.6-sol -s read-only -c model_reasoning_effort=xhigh --ephemeral}"
 
-case "$TARGET_CLI" in
-  claude)
-    echo "→ cmd: timeout ${TIMEOUT}s $CLAUDE_CMD" >&2
-    # shellcheck disable=SC2086
-    RESULT=$(cd "$CWD" && timeout "$TIMEOUT" \
-      $CLAUDE_CMD \
-      < "$PROMPT_TMP" 2>"$STDERR_TMP") || EXIT_CODE=$?
-    ;;
-  codex)
-    echo "→ cmd: timeout ${TIMEOUT}s $CODEX_CMD" >&2
-    # shellcheck disable=SC2086
-    RESULT=$(cd "$CWD" && timeout "$TIMEOUT" \
-      $CODEX_CMD \
-      < "$PROMPT_TMP" 2>"$STDERR_TMP") || EXIT_CODE=$?
-    ;;
-  *)
-    echo "{\"error\": \"Unknown target: $TARGET_CLI\"}" >&2
-    exit 1
-    ;;
-esac
+# Invoke the resolved target CLI with a prompt file on stdin. Echoes the CLI's
+# stdout on our stdout and returns its exit code (124 on timeout). Reused for
+# the retry on JSON-extraction failure, so it stays side-effect-free beyond
+# writing the CLI's stderr to STDERR_TMP.
+run_target_cli() {
+  local prompt_file="$1"
+  local rc=0
+  case "$TARGET_CLI" in
+    claude)
+      echo "→ cmd: timeout ${TIMEOUT}s $CLAUDE_CMD" >&2
+      # shellcheck disable=SC2086
+      (cd "$CWD" && timeout "$TIMEOUT" $CLAUDE_CMD < "$prompt_file" 2>"$STDERR_TMP") || rc=$?
+      ;;
+    codex)
+      echo "→ cmd: timeout ${TIMEOUT}s $CODEX_CMD" >&2
+      # shellcheck disable=SC2086
+      (cd "$CWD" && timeout "$TIMEOUT" $CODEX_CMD < "$prompt_file" 2>"$STDERR_TMP") || rc=$?
+      ;;
+    *)
+      echo "{\"error\": \"Unknown target: $TARGET_CLI\"}" >&2
+      rc=2
+      ;;
+  esac
+  return "$rc"
+}
+
+RESULT=$(run_target_cli "$PROMPT_TMP") || EXIT_CODE=$?
 
 if [[ $EXIT_CODE -eq 124 ]]; then
   echo "{\"error\": \"Timeout after ${TIMEOUT}s\", \"target\": \"$TARGET_CLI\"}" >&2
@@ -429,14 +440,103 @@ extract_json() {
   return 1
 }
 
+# --- Retry + raw-preservation helpers (review/audit) --------------------------
+
+# Build the follow-up prompt for the one-shot retry: the raw first response plus
+# the canonical JSON schema and an instruction to serialize it now. The schema
+# file is the shared source of the JSON structure for both review and audit, so
+# re-reading it here works regardless of which mode produced the first response.
+build_retry_prompt() {
+  local raw="$1"
+  local schema_file="$SCRIPT_DIR/../schemas/review-finding-prompt.md"
+  local schema=""
+  if [[ -f "$schema_file" ]]; then
+    schema=$(sed "s/external-TARGET/external-${TARGET_CLI}/g; s/ISO_8601/$(date -u +%Y-%m-%dT%H:%M:%SZ)/g" "$schema_file")
+  fi
+  cat <<RETRY
+Your previous response did not contain a parseable JSON object. This is a single fresh session with no prior turns and no session history — there is no earlier message and nothing was "delivered above" or "previously". Serialize your review as the COMPLETE JSON object now, in THIS response, without changing any of your findings. Output ONLY the JSON object — no prose before or after.
+
+--- Your previous response ---
+${raw}
+--- End of your previous response ---
+
+Emit exactly this JSON structure:
+${schema}
+RETRY
+}
+
+# Persist the raw (and optional retry) response so a lost review is auditable,
+# emit an error JSON that carries the sidecar path(s), then exit 1.
+preserve_raw_and_fail() {
+  local raw="$1"
+  local retry="${2:-}"
+  local raw_path retry_path=""
+
+  if [[ -n "$OUTPUT_PATH" ]]; then
+    mkdir -p "$(dirname "$OUTPUT_PATH")"
+    raw_path="${OUTPUT_PATH}.raw.txt"
+    printf '%s\n' "$raw" > "$raw_path"
+    if [[ -n "$retry" ]]; then
+      retry_path="${OUTPUT_PATH}.retry.txt"
+      printf '%s\n' "$retry" > "$retry_path"
+    fi
+  else
+    raw_path=$(mktemp)
+    printf '%s\n' "$raw" > "$raw_path"
+    if [[ -n "$retry" ]]; then
+      retry_path=$(mktemp)
+      printf '%s\n' "$retry" > "$retry_path"
+    fi
+  fi
+
+  if [[ -n "$retry_path" ]]; then
+    jq -n --arg target "$TARGET_CLI" --argjson len "${#raw}" \
+      --arg rawpath "$raw_path" --arg retrypath "$retry_path" \
+      '{error: "Failed to extract JSON from \($target) response after retry", raw_length: $len, raw_response: $rawpath, retry_response: $retrypath}' >&2
+    echo "→ retry response preserved: $retry_path" >&2
+  else
+    jq -n --arg target "$TARGET_CLI" --argjson len "${#raw}" --arg rawpath "$raw_path" \
+      '{error: "Failed to extract JSON from \($target) response after retry", raw_length: $len, raw_response: $rawpath}' >&2
+  fi
+  echo "→ raw response preserved: $raw_path" >&2
+  echo "--- First 30 lines of raw response ---" >&2
+  printf '%s\n' "$raw" | head -30 >&2
+  exit 1
+}
+
 if [[ "$MODE" == "review" || "$MODE" == "audit" ]]; then
-  JSON=$(extract_json "$RESULT") || {
-    echo "{\"error\": \"Failed to extract JSON from $TARGET_CLI response\", \"raw_length\": ${#RESULT}}" >&2
-    echo "--- First 30 lines of raw response ---" >&2
-    printf '%s\n' "$RESULT" | head -30 >&2
-    exit 1
-  }
-  RESULT="$JSON"
+  if JSON=$(extract_json "$RESULT"); then
+    RESULT="$JSON"
+  else
+    # The one-shot reviewer sometimes returns prose claiming the JSON was
+    # "already delivered above" — but with --no-session-persistence /
+    # --ephemeral there is no prior turn. Retry ONCE, feeding the raw response
+    # back with the schema so it serializes the findings it already produced.
+    echo "→ extract_json failed on first response; retrying once with captured response" >&2
+    RETRY_PROMPT_TMP=$(mktemp)
+    build_retry_prompt "$RESULT" > "$RETRY_PROMPT_TMP"
+
+    RETRY_RESULT=""
+    RETRY_EXIT=0
+    RETRY_RESULT=$(run_target_cli "$RETRY_PROMPT_TMP") || RETRY_EXIT=$?
+
+    if [[ $RETRY_EXIT -eq 124 ]]; then
+      echo "→ retry timed out after ${TIMEOUT}s" >&2
+      preserve_raw_and_fail "$RESULT" "$RETRY_RESULT"
+    elif [[ $RETRY_EXIT -ne 0 ]]; then
+      echo "→ retry exited with code $RETRY_EXIT" >&2
+      preserve_raw_and_fail "$RESULT" "$RETRY_RESULT"
+    elif [[ ${#RETRY_RESULT} -eq 0 ]]; then
+      echo "→ retry returned an empty response" >&2
+      preserve_raw_and_fail "$RESULT" "$RETRY_RESULT"
+    elif JSON=$(extract_json "$RETRY_RESULT"); then
+      echo "→ retry recovered valid JSON (${#JSON} bytes)" >&2
+      RESULT="$JSON"
+    else
+      echo "→ retry response still not parseable" >&2
+      preserve_raw_and_fail "$RESULT" "$RETRY_RESULT"
+    fi
+  fi
 fi
 
 # --- Output -------------------------------------------------------------------

--- a/skills/second-opinion/tests/review-json-recovery.test.sh
+++ b/skills/second-opinion/tests/review-json-recovery.test.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# Regression test for second-opinion review/audit JSON recovery (vstack#509).
+#
+# The one-shot reviewer (claude --no-session-persistence / codex --ephemeral)
+# sometimes returns prose claiming the JSON verdict was "already delivered
+# above" — but there is no prior turn, so extract_json failed and the review was
+# lost. The fix: state the full-JSON contract in the prompt, retry ONCE with the
+# captured response + schema on extraction failure, and preserve the raw
+# response in a <output>.raw.txt sidecar when extraction still fails.
+#
+# Drives the real script with a fake target CLI (no network, no real claude /
+# codex). The stub reads the prompt on stdin and emits a different canned
+# response on call 1 vs call 2 via an on-disk invocation counter.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+SECOND_OPINION="$REPO_ROOT/skills/second-opinion/scripts/second-opinion"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+PASS=0
+FAIL=0
+
+pass() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+fail() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1" >&2; }
+
+assert_eq() {
+  local got="$1" want="$2" name="$3"
+  if [[ "$got" == "$want" ]]; then
+    pass "$name"
+  else
+    fail "$name"
+    printf '        expected: %s\n        got:      %s\n' "$want" "$got" >&2
+  fi
+}
+
+assert_file_exists() {
+  local file="$1" name="$2"
+  if [[ -f "$file" ]]; then
+    pass "$name"
+  else
+    fail "$name"
+    printf '        expected file to exist: %s\n' "$file" >&2
+  fi
+}
+
+assert_file_absent() {
+  local file="$1" name="$2"
+  if [[ ! -e "$file" ]]; then
+    pass "$name"
+  else
+    fail "$name"
+    printf '        expected file to NOT exist: %s\n' "$file" >&2
+  fi
+}
+
+assert_file_contains() {
+  local file="$1" needle="$2" name="$3"
+  if [[ -f "$file" ]] && grep -Fq "$needle" "$file"; then
+    pass "$name"
+  else
+    fail "$name"
+    printf '        expected file %s to contain: %s\n' "$file" "$needle" >&2
+    if [[ -f "$file" ]]; then
+      echo "        --- file contents ---" >&2
+      sed -n '1,40p' "$file" >&2
+    else
+      echo "        (file does not exist)" >&2
+    fi
+  fi
+}
+
+# --- Fake target CLI ----------------------------------------------------------
+# Consumes the prompt on stdin, increments an on-disk counter, and emits the
+# canned response for that call number. Named `claude` and placed on PATH so the
+# script's `command -v claude` validation passes; the actual command run is this
+# stub via SECOND_OPINION_CLAUDE_CMD.
+mkdir -p "$TMP_ROOT/bin"
+STUB="$TMP_ROOT/bin/claude"
+cat > "$STUB" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+cat >/dev/null   # consume the prompt on stdin
+n=$(cat "$STUB_COUNTER" 2>/dev/null || echo 0)
+[[ -n "$n" ]] || n=0
+n=$((n + 1))
+printf '%s' "$n" > "$STUB_COUNTER"
+if [[ "$n" -eq 1 ]]; then
+  cat "$STUB_RESP1_FILE"
+else
+  cat "$STUB_RESP2_FILE"
+fi
+SH
+chmod +x "$STUB"
+
+# --- Throwaway git repo for --cwd --------------------------------------------
+WORK="$TMP_ROOT/work"
+mkdir -p "$WORK"
+git -C "$WORK" init -q
+git -C "$WORK" config user.email test@example.com
+git -C "$WORK" config user.name test
+printf 'hello\n' > "$WORK/file.txt"
+git -C "$WORK" add file.txt
+git -C "$WORK" -c commit.gpgsign=false commit -q -m init
+
+COUNTER="$TMP_ROOT/counter"
+mkdir -p "$TMP_ROOT/out"
+
+# run_review <resp1_file> <resp2_file> <output_path> <stderr_file> -> exit code
+run_review() {
+  printf '0' > "$COUNTER"   # reset invocation counter before each run
+  local rc=0
+  set +e
+  PATH="$TMP_ROOT/bin:$PATH" \
+    SECOND_OPINION_TARGET=claude \
+    SECOND_OPINION_CLAUDE_CMD="$STUB" \
+    STUB_COUNTER="$COUNTER" \
+    STUB_RESP1_FILE="$1" \
+    STUB_RESP2_FILE="$2" \
+    "$SECOND_OPINION" review --range HEAD --cwd "$WORK" --output "$3" \
+      >/dev/null 2>"$4"
+  rc=$?
+  set -e
+  return "$rc"
+}
+
+# --- Scenario 1: retry recovers findings -------------------------------------
+echo "=== scenario 1: retry recovers findings ==="
+s1_r1="$TMP_ROOT/s1-resp1.txt"
+s1_r2="$TMP_ROOT/s1-resp2.txt"
+printf 'My review is complete; the final JSON verdict was already delivered above.\n' > "$s1_r1"
+cat > "$s1_r2" <<'JSON'
+{"agent":"external-claude","timestamp":"2026-07-13T00:00:00Z","verdict":"action_required","summary":"One blocker found","blockers":[{"id":1,"title":"Null deref in parser","location":"src/parse.rs (`parse`)","description":"pointer may be null","recommendation":"guard it","priority":1,"estimate":2}],"suggestions":[],"questions":[],"qa_metadata":{}}
+JSON
+s1_out="$TMP_ROOT/out/review1.json"
+s1_err="$TMP_ROOT/s1.stderr"
+rc1=0
+run_review "$s1_r1" "$s1_r2" "$s1_out" "$s1_err" || rc1=$?
+assert_eq "$rc1" "0" "scenario 1 exits 0 after retry"
+assert_file_exists "$s1_out" "scenario 1 writes the --output artifact"
+assert_file_contains "$s1_out" "Null deref in parser" "scenario 1 artifact contains the retry's findings"
+assert_eq "$(cat "$COUNTER")" "2" "scenario 1 invoked the CLI twice (retry ran)"
+
+# --- Scenario 2: clean first response, no retry ------------------------------
+echo "=== scenario 2: clean first response, no retry ==="
+s2_r1="$TMP_ROOT/s2-resp1.txt"
+s2_r2="$TMP_ROOT/s2-resp2.txt"
+cat > "$s2_r1" <<'FENCE'
+Here is my review of the changes:
+
+```json
+{"agent":"external-claude","timestamp":"2026-07-13T00:00:00Z","verdict":"pass","summary":"Clean, no issues found","blockers":[],"suggestions":[],"questions":[],"qa_metadata":{}}
+```
+FENCE
+printf 'unused second response\n' > "$s2_r2"
+s2_out="$TMP_ROOT/out/review2.json"
+s2_err="$TMP_ROOT/s2.stderr"
+rc2=0
+run_review "$s2_r1" "$s2_r2" "$s2_out" "$s2_err" || rc2=$?
+assert_eq "$rc2" "0" "scenario 2 exits 0"
+assert_file_exists "$s2_out" "scenario 2 writes the --output artifact"
+assert_file_contains "$s2_out" "Clean, no issues found" "scenario 2 artifact contains the first response's findings"
+assert_eq "$(cat "$COUNTER")" "1" "scenario 2 invoked the CLI once (no retry)"
+assert_file_absent "$s2_out.raw.txt" "scenario 2 writes no raw sidecar"
+
+# --- Scenario 3: total failure preserves raw ---------------------------------
+echo "=== scenario 3: total failure preserves raw response ==="
+s3_r1="$TMP_ROOT/s3-resp1.txt"
+s3_r2="$TMP_ROOT/s3-resp2.txt"
+printf 'I found a critical SQL injection in login(); the JSON verdict was already delivered above.\n' > "$s3_r1"
+printf 'As I said, the review is done and the JSON was provided previously.\n' > "$s3_r2"
+s3_out="$TMP_ROOT/out/review3.json"
+s3_err="$TMP_ROOT/s3.stderr"
+rc3=0
+run_review "$s3_r1" "$s3_r2" "$s3_out" "$s3_err" || rc3=$?
+if [[ "$rc3" -ne 0 ]]; then
+  pass "scenario 3 exits nonzero"
+else
+  fail "scenario 3 exits nonzero (got $rc3)"
+fi
+assert_file_exists "$s3_out.raw.txt" "scenario 3 writes the <output>.raw.txt sidecar"
+assert_file_contains "$s3_out.raw.txt" "critical SQL injection in login()" "scenario 3 sidecar preserves the raw findings"
+assert_file_contains "$s3_err" "raw_response" "scenario 3 error JSON references the raw sidecar path"
+assert_file_absent "$s3_out" "scenario 3 writes no JSON artifact on failure"
+
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Closes #509

## Problem
`second-opinion review`/`audit` invokes a one-shot external CLI (`claude --no-session-persistence` / `codex --ephemeral`). The model sometimes returns prose claiming its JSON verdict was "already delivered above" — but with no session persistence there is no prior turn, so `extract_json` failed and the review was **lost** (nonzero exit, no artifact).

## Fix (`skills/second-opinion/scripts/second-opinion` + schema)
- **One-shot contract in the prompt/schema** — states the full JSON must appear in *this* response; "already delivered/above/previously" is invalid. Lives in the shared `schemas/review-finding-prompt.md`, so both `review` and `audit` get it.
- **Retry once** — refactored the CLI call into `run_target_cli`; on extraction failure it re-invokes the same CLI with the captured raw response + schema, asking it to serialize the findings it already produced. Full timeout/nonzero/empty/parse guards; single retry only.
- **Preserve raw on final failure** — writes `<output>.raw.txt` (+`.retry.txt`) sidecars (or `mktemp` if no `--output`) and adds their paths to the error JSON, so findings are auditable instead of silently dropped.

## Tests
New `tests/review-json-recovery.test.sh` (14 assertions, hermetic — fake CLI via `SECOND_OPINION_CLAUDE_CMD` with a call counter): retry recovers findings from the exact #509 prose; clean first response passes; total failure preserves the raw sidecar. Confirmed the retry-recovery assertion fails against the pre-fix script. Pre-existing `timeout-defaults` test still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)