### PR TITLE
fix(#510): forbid redirection in reviewer Harness-Safe Shell rule (#369 regression)

### DIFF
--- a/skills/reviewer/SKILL.md
+++ b/skills/reviewer/SKILL.md
@@ -87,7 +87,21 @@ Use this table to avoid duplicate findings across parallel reviewers. If domains
 
 ### Harness-Safe Shell
 
-Reviewer agents run under the same strict approval policies as orchestrators (Codex `approval=never`). Run each validation or read-only check as its own command with explicit arguments. Do NOT combine checks with `&&`, `||`, `;`, plumbing pipelines, `$(...)`, or a single multi-file invocation (e.g. `bash -n a b c d`). Batch independent checks as separate tool calls (or parallel independent execs) instead of shell composition — the harness can classify compound or composed shapes as approval-required even when approval is disabled.
+Reviewer agents run under the same strict approval policies as orchestrators (Codex `approval=never`). Run each validation or read-only check as its own command with explicit arguments.
+
+Do NOT combine, compose, or wrap a check with any of these shapes:
+
+- `&&`, `||`, `;`, or plumbing pipelines (`|`);
+- command substitution `$(...)` or backticks;
+- a single multi-file invocation (e.g. `bash -n a b c d`);
+- output or error redirection — `>`, `>>`, `2>`, `&>`, and specifically `>/dev/null` (or `2>/dev/null`);
+- inline conditionals or test-and-run shapes — `if ...; then ... fi`, `[[ ... ]] && ...`.
+
+Codex classifies every one of these shapes as approval-required even when the underlying operation is purely read-only, and rejects the command with `approval required by policy, but AskForApproval is set to Never`. The failure is the command *shape*, not access — the same predicate run as a bare command succeeds.
+
+Validate by exit status, not by redirection. Run the predicate as a bare command and rely on its exit code; the parsed output printed to stdout is harmless, so do NOT suppress it. To check a JSON artifact, run `jq -e <filter> <path>` — its exit status IS the check. For example, `jq -e . tmp/review-x.json` ✓ is correct, whereas `jq -e . tmp/review-x.json >/dev/null` ✗ is rejected under Codex `approval=never` even though it only reads the file.
+
+Batch independent checks as separate tool calls (or parallel independent execs) instead of shell composition.
 
 ## Configuration
 

--- a/skills/reviewer/tests/harness-safe-shell-lint.test.sh
+++ b/skills/reviewer/tests/harness-safe-shell-lint.test.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Regression test for the reviewer skill's "Harness-Safe Shell" rule (vstack#510,
+# a recurrence of #369). Under Codex `approval=never`, a required read-only
+# validation such as `jq -e <filter> <file> >/dev/null` is rejected because the
+# *shape* (output redirection) is classified as approval-required — not because
+# of access. The rule must therefore forbid redirection/substitution/composition
+# in prescribed command examples, and must prescribe the redirection-free
+# `jq -e <filter> <file>` form (exit status IS the check).
+#
+# Two parts:
+#   a. Doc lint  — scan ONLY fenced ```bash / ```sh command blocks in the
+#      reviewer SKILL.md and workflows/*.md for Codex-hostile shapes. Prose and
+#      inline `code` (including the rule text that necessarily quotes the very
+#      tokens it forbids) are excluded, so the rule cannot flag itself.
+#   b. Behavioral — prove the prescribed redirection-free predicate
+#      `jq -e . <file>` works by exit status alone.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
+TMP_ROOT="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+PASS=0
+FAIL=0
+
+pass() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+fail() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
+
+# scan_cmd_blocks <file>
+# Emits "file:lineno: [reason] line" for every Codex-hostile shape found inside a
+# fenced ```bash / ```sh block. Lines outside such blocks (prose, inline code,
+# ```json output blocks) are never scanned, so the rule describing `>/dev/null`
+# does not trip the lint.
+scan_cmd_blocks() {
+  awk -v f="$1" '
+    /^[[:space:]]*```/ {
+      if (infence == 0) {
+        infence = 1
+        lang = $0
+        sub(/^[[:space:]]*```/, "", lang)
+        gsub(/[[:space:]]/, "", lang)
+        iscmd = (lang == "bash" || lang == "sh") ? 1 : 0
+      } else {
+        infence = 0
+        iscmd = 0
+      }
+      next
+    }
+    (infence && iscmd) {
+      reason = ""
+      if ($0 ~ />\/dev\/null/)                     reason = "redirect-to-/dev/null"
+      else if ($0 ~ /([[:space:]]>>?|[0-9]>|&>)/)  reason = "output/error redirection"
+      else if ($0 ~ /\$\(/)                        reason = "command substitution $("
+      else if ($0 ~ / && /)                        reason = "&& composition"
+      else if ($0 ~ / \|\| /)                      reason = "|| composition"
+      if (reason != "") printf "%s:%d: [%s] %s\n", f, NR, reason, $0
+    }
+  ' "$1"
+}
+
+echo "=== reviewer harness-safe-shell lint ==="
+
+# --- Part a: doc lint ------------------------------------------------------
+
+# a.1 — the real reviewer docs must contain zero offending shapes.
+DOCS=("$SKILL_DIR/SKILL.md" "$SKILL_DIR"/workflows/*.md)
+offenders=""
+for doc in "${DOCS[@]}"; do
+  out="$(scan_cmd_blocks "$doc")"
+  [[ -n "$out" ]] && offenders+="$out"$'\n'
+done
+if [[ -z "$offenders" ]]; then
+  pass "reviewer command blocks are free of Codex-hostile shapes"
+  echo "  all pass"
+else
+  fail "Codex-hostile shapes found in reviewer command blocks:"
+  printf '%s' "$offenders" | sed 's/^/          /'
+fi
+
+# a.2 — the lint has teeth: an injected `>/dev/null` inside a fenced bash block
+# must be flagged.
+SCRATCH_CMD="$TMP_ROOT/inject-cmd.md"
+cp "$SKILL_DIR/workflows/review.md" "$SCRATCH_CMD"
+printf '\n```bash\njq -e . tmp/review-x.json >/dev/null\n```\n' >> "$SCRATCH_CMD"
+if [[ -n "$(scan_cmd_blocks "$SCRATCH_CMD")" ]]; then
+  pass "lint flags an injected >/dev/null in a fenced command block"
+else
+  fail "lint MISSED an injected >/dev/null (no teeth)"
+fi
+
+# a.3 — the lint is correctly scoped: the same token in prose / inline code must
+# NOT be flagged (this is what lets the rule quote `>/dev/null` safely).
+SCRATCH_PROSE="$TMP_ROOT/inject-prose.md"
+cp "$SKILL_DIR/workflows/review.md" "$SCRATCH_PROSE"
+printf '\nThis prose mentions `jq -e . file >/dev/null` and `$(cmd)` inline and must not be flagged.\n' >> "$SCRATCH_PROSE"
+if [[ -z "$(scan_cmd_blocks "$SCRATCH_PROSE")" ]]; then
+  pass "lint ignores forbidden tokens in prose / inline code (fenced-block scoping)"
+else
+  fail "lint false-flagged a forbidden token that appeared only in prose"
+fi
+
+# --- Part b: behavioral ----------------------------------------------------
+
+# The prescribed redirection-free predicate `jq -e . <file>` must validate a JSON
+# artifact by exit status alone — no `>/dev/null` needed.
+GOOD_JSON="$TMP_ROOT/review-sample.json"
+printf '{"verdict":"pass","blockers":[],"suggestions":[]}\n' > "$GOOD_JSON"
+set +e
+good_out="$(jq -e . "$GOOD_JSON")"
+good_code=$?
+set -e
+if [[ "$good_code" -eq 0 && -n "$good_out" ]]; then
+  pass "redirection-free 'jq -e . <file>' exits 0 on valid JSON (parsed output is harmless)"
+else
+  fail "redirection-free jq predicate did not exit 0 on valid JSON (code=$good_code)"
+fi
+
+# Exit status IS the check: invalid JSON makes the same bare predicate fail,
+# so no redirection is ever required to observe the result.
+BAD_JSON="$TMP_ROOT/review-bad.json"
+printf 'not-json' > "$BAD_JSON"
+set +e
+bad_err="$(jq -e . "$BAD_JSON" 2>&1)"
+bad_code=$?
+set -e
+if [[ "$bad_code" -ne 0 ]]; then
+  pass "redirection-free 'jq -e . <file>' exits nonzero on invalid JSON"
+else
+  fail "jq predicate unexpectedly exited 0 on invalid JSON"
+fi
+
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/skills/reviewer/workflows/review.md
+++ b/skills/reviewer/workflows/review.md
@@ -19,14 +19,17 @@ Extract from delegation message:
 
 ### 1.1 Diff
 
+If the delegation provided a `Diff-range`, compute the diff directly:
+
 ```bash
-# Use Diff-range from delegation if provided, otherwise diff full branch
-if [[ -n "$DIFF_RANGE" ]]; then
-  git -C [WORKTREE_PATH] diff $DIFF_RANGE
-else
-  .agents/skills/orch/scripts/resolve-base-branch [WORKTREE_PATH]
-  git -C [WORKTREE_PATH] diff "origin/[BASE_BRANCH_FROM_PREVIOUS_COMMAND]"...HEAD
-fi
+git -C [WORKTREE_PATH] diff [DIFF_RANGE]
+```
+
+Otherwise resolve the base branch, then diff the branch against it (two separate commands, no shell composition):
+
+```bash
+.agents/skills/orch/scripts/resolve-base-branch [WORKTREE_PATH]
+git -C [WORKTREE_PATH] diff "origin/[BASE_BRANCH_FROM_PREVIOUS_COMMAND]"...HEAD
 ```
 
 Review for noteworthy findings only — skip minor style issues. Exclude research documents.


### PR DESCRIPTION
Closes #510

## Problem
A reviewer following `reviewer/workflows/review.md` ran a required read-only `jq -e <filter> <file> >/dev/null` validation. Under Codex `AskForApproval=Never` it was rejected (`approval required by policy...`); the same predicate **without** `>/dev/null` returned true — so the rejection was command *shape*, not access. Recurrence of #369 (fixed for orch/dev by #370) in the reviewer workflow, which #370 didn't touch.

## Root cause
The reviewer skill's **Harness-Safe Shell** rule (`SKILL.md`) forbade `&&`/`||`/`;`/pipes/`$(...)`/multi-file — but **not output redirection**. So `jq -e . file >/dev/null` passed the letter of the rule yet still tripped Codex.

## Fix
- **Strengthen the rule** — also forbid `>`, `>>`, `2>`, `&>`, `>/dev/null`, and inline conditionals (`if...then`, `[[...]] && ...`); explain it's shape-not-access; prescribe the redirection-free form: `jq -e <filter> <path>` (exit status is the check; don't suppress stdout), with a concrete ✓/✗ example.
- **Audit workflow docs** — `review.md` §1.1 had an `if/else/fi` diff-range block (itself now forbidden); converted to two atomic, composition-free commands (matches #370's pattern). `qa-review.md`/`codebase-review.md` had no offending shapes.
- **Regression test** `tests/harness-safe-shell-lint.test.sh` — scans only fenced `bash`/`sh` blocks (so the rule's own prose can't self-trigger), asserts the docs are clean, catches an injected `>/dev/null`, and verifies the redirection-free `jq -e` predicate works by exit status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)