### PR TITLE
fix(#521): add classifier-safe --state-dir flag to workflow-state

### DIFF
--- a/skills/orch/README.md
+++ b/skills/orch/README.md
@@ -46,7 +46,7 @@ Set non-sensitive values in `vstack.settings.toml` under `[env]`. Existing `.env
 
 | Variable | Purpose | Default |
 |----------|---------|---------|
-| `ORCH_STATE_DIR` | State file directory | `tmp` |
+| `ORCH_STATE_DIR` | State file directory (env fallback for the `--state-dir` flag, which wins) | `tmp` |
 | `ORCH_CACHE_DIR` | Parallel-group safety cache | `.cache/orch` |
 | `GH_TOKEN` / `GITHUB_TOKEN` | Pre-resolved GitHub token from the parent process | current `gh` auth |
 | `GH_BOT_TOKEN` | Bot GitHub token for worktree auth | `GH_TOKEN` / `GITHUB_TOKEN`, then current `gh` auth |
@@ -77,6 +77,8 @@ Use `skills/orch/scripts/git-context branch|head|issue-from-branch|repo-root|com
 Use `skills/orch/scripts/workflow-state exists --json ISSUE_ID` when a workflow needs structured existence status without relying on shell exit-code capture.
 
 Use `skills/orch/scripts/workflow-state set-git-head ISSUE_ID FIELD [WORKTREE_PATH]` and `set-now ISSUE_ID FIELD` for common state writes that would otherwise require nested `$(git ...)` or `$(date ...)` snippets.
+
+To target a canonical state directory from a worktree, pass the global `skills/orch/scripts/workflow-state --state-dir PATH SUBCOMMAND ...` flag before the subcommand rather than an `ORCH_STATE_DIR=… workflow-state …` env prefix. The env-assignment prefix is rejected under Codex `approval=never` (a flagged command shape); the plain flag is classifier-safe. `--state-dir` takes precedence over the `ORCH_STATE_DIR` environment fallback, which stays supported.
 
 Use `skills/orch/scripts/pr-view-json WORKTREE_PATH --json number,state` when a workflow needs to inspect the current branch's PR. It prints the structured `status=no_pr` JSON with exit code 0 so `submit-pr` can route to PR creation without shell fallback expressions.
 

--- a/skills/orch/SKILL.md
+++ b/skills/orch/SKILL.md
@@ -168,10 +168,15 @@ Both `bot-review-wait` and `ci-wait` use `scripts/lib/gh-auth.sh`, which wraps t
 
 ### `workflow-state` actions
 
-`ORCH_STATE_DIR` overrides state directory (default: `tmp`). Put non-secret workflow settings in committed `vstack.settings.toml` under `[env]`; `.env.local` remains supported for secrets and personal overrides.
+To target a state directory from a worktree, pass the global `--state-dir <path>` flag before the subcommand: it applies to every action and takes precedence over `ORCH_STATE_DIR`. Prefer the flag over an `ORCH_STATE_DIR=… workflow-state …` env prefix — the env-assignment prefix is rejected under Codex `approval=never` as a flagged command shape, while a plain flag is classifier-safe. `ORCH_STATE_DIR` remains supported as an environment fallback (default: `tmp`). Put non-secret workflow settings in committed `vstack.settings.toml` under `[env]`; `.env.local` remains supported for secrets and personal overrides.
+
+```bash
+.agents/skills/orch/scripts/workflow-state --state-dir /path/to/tmp append PROJ-123 fixed_items '{"description":"Fix"}'
+```
 
 | Action | Purpose |
 |--------|---------|
+| `--state-dir <path>` (global, before subcommand) | Override state directory for every action; precedence over `ORCH_STATE_DIR` |
 | `init <ID> --agent <name> --worktree <path> [--branch <b>] [--team <t>]` | Initialize state file |
 | `exists [--json] <ID>` | Check state file exists; `--json` prints `{issue_id,path,exists}` and exits 0 |
 | `path <ID>` | Print state file path |
@@ -196,7 +201,7 @@ Audit input and roadmap-plan schemas live in `project-management/schemas/` — c
 
 | Variable | Purpose | Default |
 |----------|---------|---------|
-| `ORCH_STATE_DIR` | Override state file directory | `tmp` |
+| `ORCH_STATE_DIR` | Override state file directory (env fallback for the `--state-dir` flag, which wins when both are set) | `tmp` |
 | `ORCH_CACHE_DIR` | Parallel-group safety cache directory | `.cache/orch` |
 | `GH_ISSUE_PATTERN` | Regex for issue IDs in branch names | — |
 | `BOT_REVIEWERS` | Comma-separated bot usernames to wait for | Auto-detects |
@@ -390,7 +395,7 @@ Never edit or write code unless the user explicitly asks. Delegate to the domain
 
 Use workflow state files for data that must survive compaction: issue tracking, sub-issues, agent persistence, cycle counts, fix/escalation tracking, audit trails. Use the `workflow-state` CLI for all reads/writes, including `set-git-head` and `set-now` instead of inline command-substitution state-write snippets.
 
-Location: `$ORCH_STATE_DIR/workflow-state-[ID].json` (default: `tmp/`)
+Location: `<state-dir>/workflow-state-[ID].json` — `<state-dir>` resolves to the global `--state-dir <path>` flag, then `$ORCH_STATE_DIR`, then `tmp/`. From a worktree, prefer `--state-dir` over an `ORCH_STATE_DIR=…` env prefix (rejected under Codex `approval=never`).
 
 #### Compaction Recovery Protocol
 

--- a/skills/orch/schemas/workflow-state.md
+++ b/skills/orch/schemas/workflow-state.md
@@ -2,7 +2,7 @@
 
 Persistent state file for orch workflows. Survives context compaction.
 
-**Location**: `$ORCH_STATE_DIR/workflow-state-[ISSUE_ID].json` (default: `tmp/`)
+**Location**: `<state-dir>/workflow-state-[ISSUE_ID].json` — `<state-dir>` resolves to the global `--state-dir <path>` flag, then `$ORCH_STATE_DIR`, then `tmp/`.
 
 ## Schema
 
@@ -102,10 +102,13 @@ Persistent state file for orch workflows. Survives context compaction.
 
 All operations use `.agents/skills/orch/scripts/workflow-state` (run with `help` for full usage).
 
+To target a state directory from a worktree, pass the global `--state-dir <path>` flag before the subcommand — it takes precedence over `ORCH_STATE_DIR`. Prefer it over an `ORCH_STATE_DIR=… workflow-state …` env prefix, which is rejected under Codex `approval=never` as a flagged command shape; a plain flag is classifier-safe. `ORCH_STATE_DIR` stays supported as an environment fallback.
+
 ```bash
 .agents/skills/orch/scripts/workflow-state init PROJ-123 --agent backend --worktree /tmp/wt
 .agents/skills/orch/scripts/workflow-state get PROJ-123 .cycles
 .agents/skills/orch/scripts/workflow-state increment PROJ-123 cycles
 .agents/skills/orch/scripts/workflow-state append PROJ-123 json_paths "review.json"
 .agents/skills/orch/scripts/workflow-state set PROJ-123 pr_review_baseline '{"last_ts":"2026-01-28","last_threads":2}'
+.agents/skills/orch/scripts/workflow-state --state-dir /path/to/tmp append PROJ-123 fixed_items '{"description":"Fix"}'
 ```

--- a/skills/orch/scripts/workflow-state
+++ b/skills/orch/scripts/workflow-state
@@ -258,7 +258,14 @@ cmd_exists() {
 
 cmd_help() {
     cat << 'EOF'
-Usage: workflow-state <command> <issue_id> [args...]
+Usage: workflow-state [--state-dir <path>] <command> <issue_id> [args...]
+
+Global options (before the subcommand):
+  --state-dir <path>            Override state directory for all subcommands.
+                                Takes precedence over ORCH_STATE_DIR. Prefer this
+                                flag over the ORCH_STATE_DIR=… env prefix from
+                                worktree sessions: a plain flag is classifier-safe
+                                under Codex approval=never.
 
 Commands:
   init <issue_id> [options]     Create new state file
@@ -291,15 +298,43 @@ Examples:
   workflow-state set-git-head PROJ-123 pre_delegate_sha /tmp/wt
   workflow-state set-now PROJ-123 review_delegated_at
   workflow-state update PROJ-123 '.fixed_items | map(select(.source == "qa-review"))'
+  workflow-state --state-dir /path/to/tmp append PROJ-123 fixed_items '{"description":"Fix"}'
 
 Environment:
-  ORCH_STATE_DIR    Override state directory (default: tmp)
+  ORCH_STATE_DIR    Override state directory (default: tmp). Fallback for
+                    --state-dir; the flag wins when both are set.
 
 Dependencies:
   jq               JSON processing
   flock             File locking (util-linux)
 EOF
 }
+
+# Global options may precede the subcommand. --state-dir <path> (or
+# --state-dir=<path>) overrides the state directory for EVERY subcommand and
+# takes precedence over ORCH_STATE_DIR (which stays supported as a fallback).
+# Prefer this flag from worktree sessions: a plain flag is classifier-safe under
+# Codex approval=never, whereas an `ORCH_STATE_DIR=… workflow-state …`
+# env-assignment prefix is rejected as a flagged command shape.
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --state-dir)
+            if [[ $# -lt 2 ]]; then
+                echo "Error: --state-dir requires a path argument" >&2
+                exit 2
+            fi
+            STATE_DIR="$2"
+            shift 2
+            ;;
+        --state-dir=*)
+            STATE_DIR="${1#--state-dir=}"
+            shift
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
 
 # Main dispatch
 case "${1:-help}" in

--- a/skills/orch/tests/workflow-state-state-dir-flag.sh
+++ b/skills/orch/tests/workflow-state-state-dir-flag.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Regression tests for the classifier-safe `--state-dir` global flag on
+# workflow-state. The env-prefix form `ORCH_STATE_DIR=… workflow-state …` is
+# rejected under Codex approval=never (env-assignment prefix is a flagged
+# command shape), so worktree sessions target a canonical state directory with
+# the plain `--state-dir <path>` flag instead. ORCH_STATE_DIR stays supported as
+# a fallback. These tests fail against a pre-fix script that lacks the flag
+# (`--state-dir` dispatches as an unknown command).
+
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../.." && pwd)"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+WS="$REPO_ROOT/skills/orch/scripts/workflow-state"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local got="$1" want="$2" name="$3"
+  if [[ "$got" == "$want" ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$name" "$want" "$got"
+  fi
+}
+
+assert_file_exists() {
+  local file="$1" name="$2"
+  if [[ -f "$file" ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected file to exist: %s\n' "$name" "$file"
+  fi
+}
+
+assert_file_absent() {
+  local file="$1" name="$2"
+  if [[ ! -f "$file" ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected file to be absent: %s\n' "$name" "$file"
+  fi
+}
+
+echo "=== workflow-state --state-dir global flag ==="
+
+# Test 1: --state-dir with NO ORCH_STATE_DIR env and no env prefix. init writes
+# to and get reads back from <state-dir>/workflow-state-<ID>.json.
+sd_flag_only="$TMP_ROOT/flag-only"
+env -u ORCH_STATE_DIR "$WS" --state-dir "$sd_flag_only" init issue-flag \
+  --worktree "$REPO_ROOT" --branch issue-flag >/dev/null
+assert_file_exists "$sd_flag_only/workflow-state-issue-flag.json" \
+  "--state-dir init writes to flagged dir (no env)"
+
+branch_val="$(env -u ORCH_STATE_DIR "$WS" --state-dir "$sd_flag_only" get issue-flag .branch)"
+assert_eq "$branch_val" "issue-flag" "--state-dir get reads back from flagged dir"
+
+# Test 4 (grouped with 1): flag is a true global option — works for a second
+# subcommand (append) and its readback (get).
+env -u ORCH_STATE_DIR "$WS" --state-dir "$sd_flag_only" append issue-flag json_paths "review.json" >/dev/null
+first_path="$(env -u ORCH_STATE_DIR "$WS" --state-dir "$sd_flag_only" get issue-flag '.json_paths[0]')"
+assert_eq "$first_path" "review.json" "--state-dir works for append + get subcommands"
+
+# --state-dir=<path> equals form is accepted too.
+sd_equals="$TMP_ROOT/equals-form"
+env -u ORCH_STATE_DIR "$WS" --state-dir="$sd_equals" init issue-eq \
+  --worktree "$REPO_ROOT" --branch issue-eq >/dev/null
+assert_file_exists "$sd_equals/workflow-state-issue-eq.json" \
+  "--state-dir=<path> equals form works"
+
+# Test 2: --state-dir takes precedence over ORCH_STATE_DIR when both are set.
+sd_prec_flag="$TMP_ROOT/precedence-flag"
+sd_prec_env="$TMP_ROOT/precedence-env"
+ORCH_STATE_DIR="$sd_prec_env" "$WS" --state-dir "$sd_prec_flag" init issue-prec \
+  --worktree "$REPO_ROOT" --branch issue-prec >/dev/null
+assert_file_exists "$sd_prec_flag/workflow-state-issue-prec.json" \
+  "--state-dir takes precedence over ORCH_STATE_DIR"
+assert_file_absent "$sd_prec_env/workflow-state-issue-prec.json" \
+  "ORCH_STATE_DIR ignored when --state-dir present"
+
+# Test 3: ORCH_STATE_DIR still works when --state-dir is absent (back-compat).
+sd_env_only="$TMP_ROOT/env-only"
+ORCH_STATE_DIR="$sd_env_only" "$WS" init issue-env \
+  --worktree "$REPO_ROOT" --branch issue-env >/dev/null
+assert_file_exists "$sd_env_only/workflow-state-issue-env.json" \
+  "ORCH_STATE_DIR still works without --state-dir (back-compat)"
+
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Closes #521

## Problem
The documented cross-worktree state-targeting form `ORCH_STATE_DIR=… workflow-state append …` is an env-assignment command prefix, which Codex `AskForApproval=Never` rejects (`approval required by policy…`) — same shape class as #369/#510 — even though it only writes a local JSON file. The same command without the prefix succeeds.

## Fix (`skills/orch/scripts/workflow-state` + orch guidance)
- Added a global `--state-dir <path>` (and `--state-dir=<path>`) option parsed before subcommand dispatch, overriding the state dir for **all** subcommands. Precedence: `--state-dir` flag > `ORCH_STATE_DIR` env (still supported) > `tmp`. The safe invocation is now a plain single command: `workflow-state --state-dir /path/to/tmp append CC-720 …`.
- Updated `orch/README.md`, `orch/SKILL.md`, `orch/schemas/workflow-state.md` to prescribe the flag (with the Codex-approval rationale) and keep `ORCH_STATE_DIR` documented as the env fallback.

## Test
New `tests/workflow-state-state-dir-flag.sh` (7 assertions, hermetic): flag writes/reads the right file with no env prefix; `--state-dir` overrides `ORCH_STATE_DIR`; env still works alone (back-compat); flag works across subcommands. Fails against the pre-fix script (`Unknown command: --state-dir`). Full orch suite green (9/9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)