### PR TITLE
fix(#519): parented session-root issue expects In Review/In Progress, not Done

### DIFF
--- a/skills/dev/workflows/dev-implement.md
+++ b/skills/dev/workflows/dev-implement.md
@@ -433,8 +433,8 @@ Summary: [ISSUE_ID] ✓
 
 **If bundled**: Mark task completed. Next sub-issue is a separate task, or proceed to § 11 if none remain.
 
-**Linear sub-issue of a parent** → mark issue Done (`.agents/skills/linear/scripts/linear.sh issues update [ISSUE_ID] --state "Done"`).
-**Parent or standalone issue** → do NOT mark Done (handled by PR merge workflow and issue tracker sync).
+**Bundled Linear sub-issue** (a sub-issue processed under its parent in the § 4-10 loop) → mark issue Done (`.agents/skills/linear/scripts/linear.sh issues update [ISSUE_ID] --state "Done"`). The parent session aggregates these in § 11.
+**Managed session-root issue** (this single delegation is the top-level managed issue of the worktree — whether or not it has a parent) → do NOT mark Done. It follows the managed lifecycle and stays In Progress/In Review until PR merge (handled by the PR merge workflow and issue tracker sync; see orch `start-worktree.md` § 5.3).
 **GitHub/ad-hoc** → do not close the issue here; PR body/merge handles closure when appropriate.
 
 Do NOT push or submit PR — orchestrator handles after review passes.

--- a/skills/linear/scripts/commands/cache-query.sh
+++ b/skills/linear/scripts/commands/cache-query.sh
@@ -494,6 +494,9 @@ cache_list_relations() {
 
 cache_validate_completion() {
     local issue_ids=()
+    # Roles parallel issue_ids: positional targets are managed session roots;
+    # bundle-expanded children (below) are bundle sub-issues.
+    local roles=()
     local include_children_of=""
 
     while [[ $# -gt 0 ]]; do
@@ -508,6 +511,7 @@ cache_validate_completion() {
             ;;
         *)
             issue_ids+=("$1")
+            roles+=("session-root")
             shift
             ;;
         esac
@@ -533,13 +537,17 @@ cache_validate_completion() {
         child_ids=$(echo "$bundle" | jq -r '[.children[] | select(.state_type | IN("completed", "canceled") | not) | .id] | .[]' 2>/dev/null)
         for child_id in $child_ids; do
             issue_ids+=("$child_id")
+            roles+=("bundle-child")
         done
     fi
 
     local results="[]"
     local all_ok="true"
 
-    for issue_id in "${issue_ids[@]}"; do
+    local i
+    for i in "${!issue_ids[@]}"; do
+        local issue_id="${issue_ids[$i]}"
+        local role="${roles[$i]}"
         local issue
         issue=$(jq --arg id "$issue_id" '.[] | select(.identifier == $id or .id == $id)' \
             "$CACHE_DIR/issues.json" 2>/dev/null)
@@ -557,7 +565,7 @@ cache_validate_completion() {
         fi
 
         local result
-        result=$(build_completion_validation_result "$issue_id" "$state" "$parent_id" "$has_summary")
+        result=$(build_completion_validation_result "$issue_id" "$state" "$parent_id" "$has_summary" "$role")
 
         if [ "$(echo "$result" | jq -r '.ok')" != "true" ]; then
             all_ok="false"

--- a/skills/linear/scripts/commands/issues.sh
+++ b/skills/linear/scripts/commands/issues.sh
@@ -2215,6 +2215,9 @@ complete_issue() {
 # Supports multiple issues for bundle validation
 validate_completion() {
     local issue_ids=()
+    # Roles parallel issue_ids: positional targets are managed session roots;
+    # bundle-expanded children (below) are bundle sub-issues.
+    local roles=()
     local include_children_of=""
 
     # Parse arguments
@@ -2230,6 +2233,7 @@ validate_completion() {
             ;;
         *)
             issue_ids+=("$1")
+            roles+=("session-root")
             shift
             ;;
         esac
@@ -2255,13 +2259,17 @@ validate_completion() {
         child_ids=$(echo "$bundle" | jq -r '[.children[] | select(.state_type | IN("completed", "canceled") | not) | .id] | .[]' 2>/dev/null)
         for child_id in $child_ids; do
             issue_ids+=("$child_id")
+            roles+=("bundle-child")
         done
     fi
 
     local results="[]"
     local all_ok="true"
 
-    for issue_id in "${issue_ids[@]}"; do
+    local i
+    for i in "${!issue_ids[@]}"; do
+        local issue_id="${issue_ids[$i]}"
+        local role="${roles[$i]}"
         # Get issue state
         local issue
         issue=$(get_issue "$issue_id")
@@ -2277,7 +2285,7 @@ validate_completion() {
         has_summary=$(echo "$comments" | jq 'any(.[]; .body | (contains("Completion Summary") or contains("Bundle Complete")))')
 
         local result
-        result=$(build_completion_validation_result "$issue_id" "$state" "$parent_id" "$has_summary")
+        result=$(build_completion_validation_result "$issue_id" "$state" "$parent_id" "$has_summary" "$role")
 
         if [ "$(echo "$result" | jq -r '.ok')" != "true" ]; then
             all_ok="false"

--- a/skills/linear/scripts/lib/issue-validation.sh
+++ b/skills/linear/scripts/lib/issue-validation.sh
@@ -2,35 +2,72 @@
 
 set -euo pipefail
 
-completion_expected_state() {
-	local parent_id="${1:-}"
+# Expected completion state(s) for an issue, keyed by its ROLE in the validation.
+#
+#   bundle-child  A sub-issue processed under its parent session as part of a
+#                 bundle. It is marked Done per-sub-issue while the parent
+#                 session aggregates it, so it must be "Done".
+#
+#   session-root  The managed top-level issue of a worktree session (a single
+#                 delegation / decomposition child worked directly). Whether or
+#                 not it has a parent, it follows the managed lifecycle and
+#                 stays pre-merge until PR merge (see orch start-worktree.md
+#                 § 5.3), so it may be "In Progress" OR "In Review" at
+#                 validation time. This is the default role.
+#
+# Emits one accepted state per line.
+completion_expected_states() {
+	local role="${1:-session-root}"
 
-	if [[ -n "$parent_id" ]]; then
+	if [[ "$role" == "bundle-child" ]]; then
 		printf 'Done\n'
 		return 0
 	fi
 
 	printf 'In Progress\n'
+	printf 'In Review\n'
 }
 
+# True when $state is one of the accepted states for the given role.
 completion_state_matches() {
 	local state="${1:-}"
-	local parent_id="${2:-}"
-	local expected_state
+	local role="${2:-session-root}"
+	local expected
 
-	expected_state=$(completion_expected_state "$parent_id")
-	[[ "$state" == "$expected_state" ]]
+	while IFS= read -r expected; do
+		[[ -n "$expected" ]] || continue
+		if [[ "$state" == "$expected" ]]; then
+			return 0
+		fi
+	done < <(completion_expected_states "$role")
+
+	return 1
 }
 
+# Build the completion-validation result JSON for one issue.
+#
+# Args: issue_id state parent_id has_summary [role]
+#
+# The distinguishing "role" is supplied explicitly by the caller (positional
+# target => session-root; bundle-expanded child => bundle-child); it — not
+# parent_id — drives the expected-state decision, so a parented issue run as
+# the managed session root is no longer forced to Done. It is the last,
+# defaulted argument so the first four positions stay compatible with the
+# original signature. parent_id is retained for call-site provenance and to
+# keep the record shape self-describing.
+#
+# Output shape is stable: {id, state, state_ok, has_summary, ok}
 build_completion_validation_result() {
 	local issue_id="$1"
 	local state="$2"
+	# shellcheck disable=SC2034  # provenance only; role (not parent_id) decides expected state
 	local parent_id="$3"
 	local has_summary="$4"
+	local role="${5:-session-root}"
 	local state_ok="false"
 	local ok="false"
 
-	if completion_state_matches "$state" "$parent_id"; then
+	if completion_state_matches "$state" "$role"; then
 		state_ok="true"
 	fi
 

--- a/skills/linear/tests/completion-validation-parented-root.test.sh
+++ b/skills/linear/tests/completion-validation-parented-root.test.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Regression test for vstack #519.
+#
+# completion_expected_state() used to return "Done" for ANY issue with a parent,
+# so a decomposition child run as the managed top-level session (kept In Review
+# until PR merge per orch start-worktree.md § 5.3) failed validate-completion's
+# state_ok gate. The lib now keys the expected state on an explicit call-site
+# "role":
+#   - bundle-child : a sub-issue processed under its parent session -> expects Done.
+#   - session-root : the managed top-level issue (parented or not) -> expects a
+#                    pre-merge managed state (In Progress OR In Review).
+#
+# This exercises the pure function lib directly (no network). The pre-fix lib
+# fails the case-2 assertions below (a parented session root in In Review/In
+# Progress yielded state_ok=false).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB="$SCRIPT_DIR/../scripts/lib/issue-validation.sh"
+
+# shellcheck disable=SC1090
+source "$LIB"
+
+pass=0
+fail=0
+
+# assert_result LABEL WANT_STATE_OK WANT_OK -- <args to build_completion_validation_result>
+# Defensive against a build failure (e.g. a pre-fix signature mismatch): a
+# nonzero/invalid result is recorded as a clean FAIL rather than aborting.
+assert_result() {
+	local label="$1" want_state_ok="$2" want_ok="$3"
+	shift 3
+
+	local out rc got_state_ok got_ok
+	set +e
+	out=$(build_completion_validation_result "$@" 2>/dev/null)
+	rc=$?
+	set -e
+	if [[ $rc -ne 0 || -z "$out" ]]; then
+		out='{}'
+	fi
+
+	# Use has() rather than `// "ERR"` — jq's // treats boolean false as empty.
+	got_state_ok=$(echo "$out" | jq -r 'if has("state_ok") then (.state_ok | tostring) else "ERR" end')
+	got_ok=$(echo "$out" | jq -r 'if has("ok") then (.ok | tostring) else "ERR" end')
+
+	if [[ "$got_state_ok" == "$want_state_ok" && "$got_ok" == "$want_ok" ]]; then
+		pass=$((pass + 1))
+	else
+		fail=$((fail + 1))
+		echo "FAIL: $label"
+		echo "  want state_ok=$want_state_ok ok=$want_ok"
+		echo "  got  state_ok=$got_state_ok ok=$got_ok"
+		echo "  output: $out"
+	fi
+}
+
+# Args order: issue_id state parent_id has_summary role
+
+# --- Case 1: bundled sub-issue (validated as a child under a parent session) ---
+# Still expects Done.
+assert_result "case1 bundle-child Done"       true  true  "CC-C1" "Done"      "CC-PARENT" "true" "bundle-child"
+assert_result "case1 bundle-child In Review"  false false "CC-C1" "In Review" "CC-PARENT" "true" "bundle-child"
+assert_result "case1 bundle-child In Progress" false false "CC-C1" "In Progress" "CC-PARENT" "true" "bundle-child"
+
+# --- Case 2: managed session-root issue WITH a parent (the #519 fix) ---
+# No longer forced to Done; accepts the pre-merge managed state.
+assert_result "case2 parented root In Review"   true  true  "CC-R1" "In Review"   "CC-PARENT" "true" "session-root"
+assert_result "case2 parented root In Progress" true  true  "CC-R1" "In Progress" "CC-PARENT" "true" "session-root"
+assert_result "case2 parented root Backlog"     false false "CC-R1" "Backlog"     "CC-PARENT" "true" "session-root"
+assert_result "case2 parented root Todo"        false false "CC-R1" "Todo"        "CC-PARENT" "true" "session-root"
+
+# --- Case 3: managed session-root issue WITHOUT a parent ---
+assert_result "case3 standalone root In Progress" true  true  "CC-R2" "In Progress" "" "true" "session-root"
+assert_result "case3 standalone root In Review"   true  true  "CC-R2" "In Review"   "" "true" "session-root"
+# A session root is pre-merge, so Done is NOT an accepted pre-merge state.
+assert_result "case3 standalone root Done"        false false "CC-R2" "Done"        "" "true" "session-root"
+assert_result "case3 standalone root Backlog"     false false "CC-R2" "Backlog"     "" "true" "session-root"
+
+# --- Case 4: ok is true only when state_ok AND has_summary ---
+assert_result "case4 state ok but no summary"  true  false "CC-R3" "In Review" "" "false" "session-root"
+assert_result "case4 summary but bad state"    false false "CC-R3" "Backlog"   "" "true"  "session-root"
+assert_result "case4 state ok and summary"     true  true  "CC-R3" "In Review" "" "true"  "session-root"
+assert_result "case4 bundle child ok"          true  true  "CC-C2" "Done"      "CC-PARENT" "true"  "bundle-child"
+
+echo "pass: $pass fail: $fail"
+[[ "$fail" -eq 0 ]]

--- a/skills/orch/workflows/dev-start.md
+++ b/skills/orch/workflows/dev-start.md
@@ -205,6 +205,8 @@ Handoff from prior agents:
    | `.results[].state_ok` | `true` | Re-delegate § 2 |
    | `.results[].has_summary` | `true` | Re-delegate § 2 with retry instructions |
 
+   `state_ok` checks the per-role managed state: bundle-expanded sub-issues (from `--include-children-of`) must be `Done`, while the primary target — the managed session-root issue, **whether or not it has a parent** — must be in a pre-merge state (`In Progress` or `In Review`, per `start-worktree.md` § 5.3). Do not expect `Done` for the session root before merge.
+
 3. **On failure**: Do NOT proceed. Re-delegate to the same agent with retry instructions specifying the missing step(s). Never proceed with "may have a different format" or similar excuses.
 
 4. **Store QA state**:


### PR DESCRIPTION
Closes #519

## Problem
`completion_expected_state()` in `linear/scripts/lib/issue-validation.sh` returned `Done` for **any** parented issue. So a decomposition child run as the managed top-level session (kept `In Review` until merge per `start-worktree.md` §5.3) failed `validate-completion`'s `state_ok` gate — because the gate demanded `Done`, which `dev-implement.md` §10 and the managed lifecycle forbid pre-merge. dev-start §3's failure action would loop or force a §5.3 violation.

## Root cause
The lib conflated *"has a parent"* with *"is a bundled sub-issue processed under its parent"*. But the call site already knows the difference deterministically: positional targets are managed **session roots**; IDs from `--include-children-of <PARENT>` expansion are **bundle children**.

## Fix
- **`issue-validation.sh`** — expected state now keyed by an explicit `role`: `bundle-child` → `Done`; `session-root` (default) → the set `{In Progress, In Review}`. `completion_state_matches` accepts a set; `build_completion_validation_result` gains `role` as a trailing defaulted arg (signature/JSON shape stable).
- **Call sites** (`commands/issues.sh`, `commands/cache-query.sh`) — build a `roles[]` array parallel to `issue_ids[]` (positional → session-root, bundle-expanded → bundle-child) and pass it through.
- **Docs** — `dev-implement.md` §10 scoped to bundled sub-issues; `dev-start.md` §3 documents the per-role `state_ok` semantics; `start-worktree.md` §5.3 already consistent (untouched).

## Test
New `completion-validation-parented-root.test.sh` (15 assertions, pure-lib, hermetic): bundle-child expects Done; parented **session root** in In Review/In Progress → `state_ok=true`, Backlog → false; parentless root likewise; `ok` = `state_ok && has_summary`. Fails against the pre-fix lib (In-Review parented root → false). Existing linear tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)