### PR TITLE
fix(#518,#520): bot-review-wait bot-thread identity match + interrupt exit status

### DIFF
--- a/skills/github/scripts/lib/github-api.sh
+++ b/skills/github/scripts/lib/github-api.sh
@@ -647,13 +647,24 @@ bot_review_status_compute() {
     fi
 
     # --- unresolved review threads authored by this reviewer ---
+    # Match the thread author to the configured reviewer robustly (vstack#518).
+    # The reviewer login is discovered from REST (reviews/comments/reactions) and
+    # carries the "[bot]" suffix (e.g. "chatgpt-codex-connector[bot]"), while the
+    # GraphQL review-thread author login for the SAME GitHub App bot is the bare
+    # app slug ("chatgpt-codex-connector"). An exact `==` match therefore missed a
+    # bot's unresolved inline thread, leaving the reviewer unknown/pending with
+    # unresolved_threads:0 until timeout. Normalize BOTH sides — lowercase and
+    # strip a trailing "[bot]" — before comparing so attribution is stable across
+    # the REST/GraphQL identity mismatch and login casing.
     local unresolved
     unresolved=$(jq --arg u "$reviewer" '
-        [.[]
-         | select((.isResolved // false) == false)
-         | select((.isOutdated // false) == false)
-         | select([.comments.nodes[]?.author.login // empty] | any(. == $u))
-        ] | length
+        def norm: ascii_downcase | sub("\\[bot\\]$"; "");
+        ($u | norm) as $ru
+        | [.[]
+           | select((.isResolved // false) == false)
+           | select((.isOutdated // false) == false)
+           | select([.comments.nodes[]?.author.login // empty | norm] | any(. == $ru))
+          ] | length
     ' <<<"$threads_json" 2>/dev/null || echo 0)
     [[ -z "$unresolved" || "$unresolved" == "null" ]] && unresolved=0
     if [[ "$unresolved" -gt 0 ]]; then

--- a/skills/orch/scripts/bot-review-wait
+++ b/skills/orch/scripts/bot-review-wait
@@ -122,6 +122,18 @@ finalize() {
 }
 trap finalize EXIT
 
+# vstack#520: interrupt handling. Without an INT/TERM trap, a Ctrl-C (or a
+# SIGTERM) delivered while the script is blocked in a poll `sleep` terminates
+# the process with 128+signum, but the EXIT-trap backstop above captured a
+# normalized `$?` of 0 — so the emitted JSON reported "exit 0" while the process
+# itself exited nonzero, and the two disagreed. Trapping the interrupt to a
+# deterministic `exit 130` (128+SIGINT) makes the process exit 130 AND drives
+# finalize's `local ec=$?` to 130, so the backstop JSON and the real process
+# status agree. Installed right after the EXIT trap so it covers every poll
+# sleep. Normal-path emitters (emit_result/emit_error) call `exit` directly and
+# are unaffected — this fires only on an actual interrupt.
+trap 'exit 130' INT TERM
+
 emit_error() {
   local message="$1"
   RESULT_EMITTED=true

--- a/skills/orch/tests/bot_review_wait.sh
+++ b/skills/orch/tests/bot_review_wait.sh
@@ -151,6 +151,12 @@ case "${1:-}" in
           else
             echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}'
           fi
+        elif [[ "$*" == *"pr=15"* ]]; then
+          # PR 15 (#518): the real GraphQL review-thread author login for a GitHub
+          # App bot is the BARE app slug (no "[bot]" suffix), while the reviewer is
+          # configured/detected as "chatgpt-codex-connector[bot]". Attribution must
+          # normalize both sides or it misses this unresolved inline thread.
+          echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"isResolved":false,"isOutdated":false,"comments":{"nodes":[{"author":{"login":"chatgpt-codex-connector"}}]}}]}}}}}'
         else
           echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}'
         fi
@@ -191,6 +197,12 @@ case "${1:-}" in
         # reviewers are terminal-approved via their OWN signals, so completion
         # must not block on the checklist drain regardless of MAX_WAIT budget.
         echo '[{"user":{"login":"claude[bot]"},"state":"APPROVED","submitted_at":"2026-01-01T00:00:00Z"}]'
+        exit 0
+        ;;
+      repos/*/pulls/15/reviews)
+        # PR 15 (#518): Codex posts a formal COMMENTED review (which alone sets no
+        # terminal status) alongside an unresolved inline thread it authored.
+        echo '[{"user":{"login":"chatgpt-codex-connector[bot]"},"state":"COMMENTED","submitted_at":"2026-01-01T00:10:00Z"}]'
         exit 0
         ;;
       repos/*/pulls/10/reviews)
@@ -253,11 +265,11 @@ JSON
 JSON
         exit 0
         ;;
-      repos/*/issues/5/comments|repos/*/issues/6/comments|repos/*/issues/7/comments|repos/*/issues/8/comments|repos/*/issues/9/comments|repos/*/issues/10/comments|repos/*/issues/11/comments|repos/*/issues/12/comments|repos/*/issues/13/comments|repos/*/issues/14/comments)
+      repos/*/issues/5/comments|repos/*/issues/6/comments|repos/*/issues/7/comments|repos/*/issues/8/comments|repos/*/issues/9/comments|repos/*/issues/10/comments|repos/*/issues/11/comments|repos/*/issues/12/comments|repos/*/issues/13/comments|repos/*/issues/14/comments|repos/*/issues/15/comments)
         echo '[]'
         exit 0
         ;;
-      repos/*/issues/1/comments|repos/*/issues/1/reactions|repos/*/issues/2/reactions|repos/*/issues/12/reactions|repos/*/issues/13/reactions|repos/*/issues/comments/*/reactions)
+      repos/*/issues/1/comments|repos/*/issues/1/reactions|repos/*/issues/2/reactions|repos/*/issues/12/reactions|repos/*/issues/13/reactions|repos/*/issues/15/reactions|repos/*/issues/comments/*/reactions)
         echo '[]'
         exit 0
         ;;
@@ -643,6 +655,75 @@ set -e
 assert_eq "$code" "3" "auth failure exits 3 in --json mode"
 assert_json "$output" "auth failure path emits parseable JSON"
 assert_eq "$(jq -r .status <<<"$output")" "error" "auth failure reports status error"
+
+echo "=== bot-review-wait Codex COMMENTED + unresolved bot thread (#518) ==="
+
+# #518: a Codex reviewer posts a formal COMMENTED review AND leaves an unresolved
+# inline review thread. The thread's GraphQL author login is the bare app slug
+# ("chatgpt-codex-connector") while the reviewer is "chatgpt-codex-connector[bot]".
+# Pre-fix, the exact `author.login == reviewer` match missed the thread, so the
+# reviewer stayed unknown with unresolved_threads:0 and the waiter timed out. The
+# normalized match must attribute the thread, force the reviewer to "changes", and
+# reach a terminal complete/changes result (not unknown/pending, not timeout).
+cat > "$TMP_ROOT/repo/.env.local" <<EOF
+GIT_HOST_CLI="$FAKE_GITHUB_SH"
+EOF
+set +e
+output=$(run_wait 15 1 1 --json --reviewers 'chatgpt-codex-connector[bot]')
+code=$?
+set -e
+assert_eq "$code" "0" "COMMENTED + unresolved bot thread reaches terminal exit 0 (#518)"
+assert_eq "$(jq -r .status <<<"$output")" "complete" "COMMENTED + unresolved bot thread emits complete JSON (#518)"
+assert_eq "$(jq -r .verdict <<<"$output")" "changes" "COMMENTED + unresolved bot thread yields changes verdict (#518)"
+assert_eq "$(jq -r '.reviewers[] | select(.reviewer == "chatgpt-codex-connector[bot]") | .status' <<<"$output")" "changes" "unresolved bot thread forces reviewer status changes, not unknown/pending (#518)"
+assert_eq "$([[ "$(jq -r '.reviewers[] | select(.reviewer == "chatgpt-codex-connector[bot]") | .unresolved_threads' <<<"$output")" -ge 1 ]] && echo ok)" "ok" "unresolved bot thread is counted (unresolved_threads >= 1) despite [bot]-suffix mismatch (#518)"
+assert_eq "$(jq -r '.changes_reviewers | join(",")' <<<"$output")" "chatgpt-codex-connector[bot]" "Codex reviewer is bucketed under changes (#518)"
+assert_contains "$(jq -c '.reviewers[] | select(.reviewer == "chatgpt-codex-connector[bot]") | .signals' <<<"$output")" "inline:1" "unresolved bot thread records inline:1 signal (#518)"
+
+echo "=== bot-review-wait interrupt exit status (#520) ==="
+
+# #520: an interrupt (Ctrl-C / SIGTERM) delivered while the waiter is parked in a
+# poll sleep must exit the process nonzero AND the EXIT-trap JSON backstop must
+# report the SAME nonzero status. Pre-fix, with no INT/TERM trap, the backstop
+# captured a normalized $?=0 (JSON "exit 0") while the process itself exited
+# 128+signum — the two disagreed. The fix's `trap 'exit 130' INT TERM` makes both
+# deterministically 130. SIGINT is inherited-ignored by background jobs in this
+# harness, so SIGTERM (the other signal the fix traps) is the reliable proxy for
+# the interrupt path; the trap covers both. PR 13 stays pending, so the waiter is
+# guaranteed to be sitting in a poll sleep when the signal arrives.
+cat > "$TMP_ROOT/repo/.env.local" <<EOF
+GIT_HOST_CLI="$FAKE_GITHUB_SH"
+EOF
+int_out="$TMP_ROOT/int.out"
+int_code_file="$TMP_ROOT/int.code"
+: > "$int_out"
+rm -f "$int_code_file"
+(
+  cd "$TMP_ROOT/repo"
+  # setsid puts the waiter (and its sleep child) in a fresh process group so the
+  # signal reaches the whole group like a terminal Ctrl-C — without hitting this
+  # test's own shell, which stays in its original group.
+  env PATH="$TMP_ROOT/bin:$PATH" setsid .agents/skills/orch/scripts/bot-review-wait 13 10 30 --json --reviewers 'chatgpt-codex-connector[bot]' >"$int_out" 2>/dev/null &
+  wpid=$!
+  sleep 3
+  wpgid=$(ps -o pgid= -p "$wpid" 2>/dev/null | tr -d ' ')
+  [[ -n "$wpgid" ]] && kill -TERM -"$wpgid" 2>/dev/null || true
+  # Capture the waiter's exit without letting `set -e` abort on its nonzero
+  # (interrupted) status before we record it.
+  set +e
+  wait "$wpid"
+  wcode=$?
+  set -e
+  printf '%s' "$wcode" > "$int_code_file"
+)
+int_code="$(cat "$int_code_file" 2>/dev/null || echo MISSING)"
+int_json="$(cat "$int_out" 2>/dev/null || echo '')"
+reported_exit="$(jq -r '.error // ""' <<<"$int_json" 2>/dev/null | grep -oE 'exit [0-9]+' | grep -oE '[0-9]+' | head -1)"
+assert_eq "$int_code" "130" "interrupt makes the process exit 130 (#520)"
+assert_json "$int_json" "interrupt still emits a parseable JSON backstop (#520)"
+assert_eq "$(jq -r .status <<<"$int_json")" "error" "interrupt backstop reports status error (#520)"
+assert_eq "$reported_exit" "130" "interrupt backstop JSON reports exit 130, not a normalized 0 (#520)"
+assert_eq "$reported_exit" "$int_code" "interrupt backstop JSON exit matches the real process exit (#520)"
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"


### PR DESCRIPTION
Closes #518
Closes #520

Two bugs surfaced together in the `bot-review-wait` flow (bundled — #518's root cause is in a shared lib the waiter calls).

## #518 — Codex COMMENTED review with an unresolved thread is missed
**Root cause (in `github/scripts/lib/github-api.sh`, `bot_review_status_compute`):** per-reviewer thread attribution matched the thread author against the reviewer login with exact `==`. The reviewer login comes from **REST** (`reviews`/`comments`/`reactions` `.user.login`) and carries the `[bot]` suffix (`chatgpt-codex-connector[bot]`), but the **GraphQL** `reviewThreads…author.login` for the same GitHub App is the bare app slug (`chatgpt-codex-connector`). So the match failed → `unresolved_threads: 0`, no `inline:` signal, and a formal `COMMENTED` review (no terminal status of its own) left the reviewer `unknown` until timeout — even though `pr-threads`/`pr-review-status` (author-agnostic) saw the unresolved thread.

**Fix:** normalize both sides (`ascii_downcase | sub("\\[bot\\]$";"")`) before matching. Once `unresolved > 0`, the existing rule forces `status="changes"`, so the reviewer reaches terminal action-required with `unresolved_threads ≥ 1`. #448/#450/#487 behavior preserved (REST-side matches unchanged; both sides already agreed there).

## #520 — SIGINT backstop reported the wrong exit status
The `trap finalize EXIT` backstop captured a normalized `$?`=0 on interrupt, so the JSON said `exit 0` while the process exited nonzero. **Fix:** `trap 'exit 130' INT TERM` after the EXIT trap — an interrupt now exits 130 and `finalize`'s `ec=$?` sees 130, so JSON and process status agree. Normal-path emitters unaffected.

## Tests
Extended `orch/tests/bot_review_wait.sh` (+12 assertions): a COMMENTED Codex review with a **bare-slug** GraphQL thread author → terminal `changes`, `unresolved_threads ≥ 1`, `inline:1`; and an interrupted run (via process-group signal) exits 130 with a matching JSON `exit 130`. Both fail against the pre-fix code (revert-checked). Suite: 96/96; full orch run-all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)