### PR TITLE
feat(#541): order approval gate before CI verify; portable queued merge; retire defer-ci

### DIFF
--- a/skills/github/scripts/commands/label-add.sh
+++ b/skills/github/scripts/commands/label-add.sh
@@ -28,7 +28,7 @@ Options:
   --help, -h        Show this help.
 
 Examples:
-  label-add.sh 44 defer-ci --reason "skip heavy CI"
+  label-add.sh 44 needs-qa --reason "ready for QA review"
   label-add.sh 123 needs-triage --issue
 EOF
 }

--- a/skills/github/scripts/commands/label-remove.sh
+++ b/skills/github/scripts/commands/label-remove.sh
@@ -28,7 +28,7 @@ Options:
   --help, -h        Show this help.
 
 Examples:
-  label-remove.sh 44 defer-ci --reason "CI passed; re-enable"
+  label-remove.sh 44 needs-qa --reason "QA review complete"
   label-remove.sh 123 needs-triage --issue
 EOF
 }

--- a/skills/github/scripts/commands/pr-create.sh
+++ b/skills/github/scripts/commands/pr-create.sh
@@ -52,7 +52,7 @@ Examples:
   EOF
   github.sh pr-create --title "feat: Add feature" --body-file tmp/pr-body.md
 
-  github.sh pr-create --draft --label defer-ci  # Defer CI until ready
+  github.sh pr-create --draft --label needs-qa  # Draft PR with a triage label
   github.sh pr-create --dry-run  # Preview without creating
 EOF
 }

--- a/skills/github/tests/env-first-auth.sh
+++ b/skills/github/tests/env-first-auth.sh
@@ -169,33 +169,33 @@ assert_eq "$(jq -r .number <<<"$output")" "42" "github.sh router falls back to k
 assert_eq "$(wc -l <"$TMP_ROOT/op.calls")" "1" "unresolved GH_TOKEN attempts op once before keyring fallback"
 
 rm -f "$TMP_ROOT/op.calls"
-(cd "$TMP_ROOT/repo" && PATH="$TMP_ROOT/bin:$PATH" STUB_KEYRING_OK=1 GH_TOKEN=op://vault/github/user "$REPO_ROOT/skills/github/scripts/commands/label-add.sh" 42 defer-ci >/dev/null)
+(cd "$TMP_ROOT/repo" && PATH="$TMP_ROOT/bin:$PATH" STUB_KEYRING_OK=1 GH_TOKEN=op://vault/github/user "$REPO_ROOT/skills/github/scripts/commands/label-add.sh" 42 test-label >/dev/null)
 assert_eq "$(wc -l <"$TMP_ROOT/op.calls")" "1" "label-add falls back to keyring for unresolved GH_TOKEN"
 
 rm -f "$TMP_ROOT/op.calls"
-(cd "$TMP_ROOT/repo" && PATH="$TMP_ROOT/bin:$PATH" STUB_KEYRING_OK=1 GITHUB_TOKEN=op://vault/github/user "$REPO_ROOT/skills/github/scripts/commands/label-remove.sh" 42 defer-ci >/dev/null)
+(cd "$TMP_ROOT/repo" && PATH="$TMP_ROOT/bin:$PATH" STUB_KEYRING_OK=1 GITHUB_TOKEN=op://vault/github/user "$REPO_ROOT/skills/github/scripts/commands/label-remove.sh" 42 test-label >/dev/null)
 assert_eq "$(wc -l <"$TMP_ROOT/op.calls")" "1" "label-remove falls back to keyring for unresolved GITHUB_TOKEN"
 
 cat > "$TMP_ROOT/repo/.env.local" <<'ENVEOF'
 GH_BOT_TOKEN=ghs_ROUTERBOT123
 ENVEOF
 rm -f "$TMP_ROOT/op.calls"
-output=$(cd "$TMP_ROOT/repo" && PATH="$TMP_ROOT/bin:$PATH" "$REPO_ROOT/skills/github/scripts/commands/label-add.sh" 42 defer-ci)
+output=$(cd "$TMP_ROOT/repo" && PATH="$TMP_ROOT/bin:$PATH" "$REPO_ROOT/skills/github/scripts/commands/label-add.sh" 42 test-label)
 assert_eq "$output" "updated" "direct label-add loads project GH_BOT_TOKEN"
 assert_file_missing "$TMP_ROOT/op.calls" "direct label-add project direct token avoids op"
 
 rm -f "$TMP_ROOT/op.calls"
-output=$(cd "$TMP_ROOT/repo" && PATH="$TMP_ROOT/bin:$PATH" "$REPO_ROOT/skills/github/scripts/commands/label-remove.sh" 42 defer-ci)
+output=$(cd "$TMP_ROOT/repo" && PATH="$TMP_ROOT/bin:$PATH" "$REPO_ROOT/skills/github/scripts/commands/label-remove.sh" 42 test-label)
 assert_eq "$output" "updated" "direct label-remove loads project GH_BOT_TOKEN"
 assert_file_missing "$TMP_ROOT/op.calls" "direct label-remove project direct token avoids op"
 
 rm -f "$TMP_ROOT/op.calls"
-output=$(cd "$TMP_ROOT/repo" && PATH="$TMP_ROOT/bin:$PATH" "$REPO_ROOT/skills/github/scripts/github.sh" -C "$TMP_ROOT/repo" label-add 42 defer-ci)
+output=$(cd "$TMP_ROOT/repo" && PATH="$TMP_ROOT/bin:$PATH" "$REPO_ROOT/skills/github/scripts/github.sh" -C "$TMP_ROOT/repo" label-add 42 test-label)
 assert_eq "$output" "updated" "github.sh router loads project GH_BOT_TOKEN for label-add"
 assert_file_missing "$TMP_ROOT/op.calls" "label-add project direct token avoids op"
 
 rm -f "$TMP_ROOT/op.calls"
-output=$(cd "$TMP_ROOT/repo" && PATH="$TMP_ROOT/bin:$PATH" "$REPO_ROOT/skills/github/scripts/github.sh" -C "$TMP_ROOT/repo" label-remove 42 defer-ci)
+output=$(cd "$TMP_ROOT/repo" && PATH="$TMP_ROOT/bin:$PATH" "$REPO_ROOT/skills/github/scripts/github.sh" -C "$TMP_ROOT/repo" label-remove 42 test-label)
 assert_eq "$output" "updated" "github.sh router loads project GH_BOT_TOKEN for label-remove"
 assert_file_missing "$TMP_ROOT/op.calls" "label-remove project direct token avoids op"
 

--- a/skills/orch/DEVELOPMENT.md
+++ b/skills/orch/DEVELOPMENT.md
@@ -36,6 +36,15 @@ their SSH failures should not block branch cleanup or tracker closure.
 
 Statuses: `approved` (exit 0); `changes_requested`, `comments`, `timeout` (exit 1); `error` (exit 1, or 3 on auth failure — same auth contract as `ci-wait`). Every exit path emits a final stdout result; `--json` always prints one well-formed object.
 
+## CI Triggering Patterns
+
+The `defer-ci` label pattern is retired — orch never defers, queues, or labels CI. The workflow contract that replaces it: `submit-pr.md` orders the approval gate (§ 4) before CI verification (§ 5), universally and with no repo detection, so CI that only starts after an approval can never deadlock the workflow. Two portable repo-side patterns build on that contract:
+
+- **Approval-gated jobs** (any GitHub plan): trigger the workflow on `pull_request` plus `pull_request_review: types: [submitted]`. A cheap gate job checks the PR's `reviewDecision` (or latest-review approval when no required-review protection exists); heavy jobs declare `needs:` on the gate. Cheap lint/unit jobs can still run unconditionally on `pull_request`.
+- **Merge queue** (GitHub Enterprise / public repos): run heavy CI on `merge_group`, minimal CI on `pull_request`, and require the approval for queue entry via branch protection. `merge-pr.md` § 5 handles the queued merge portably with `pr-merge --auto` (exit 75 = queued/armed), watches queue membership, and on ejection (failed merge-group run) routes back into ci-fix automatically — bounded, per-PR, with no cross-session coordination.
+
+Always-on CI (everything on `pull_request`) needs no change — § 5 just verifies checks that already ran. `ci-wait` tolerates post-approval dispatch latency via `CI_WAIT_NO_CHECKS_GRACE` (default 180s) before reporting "no checks registered". This section is guidance for consuming repos; vstack's own CI is unaffected.
+
 ## Tests
 
 ```bash

--- a/skills/orch/README.md
+++ b/skills/orch/README.md
@@ -20,7 +20,7 @@ Invoke via your AI coding harness (e.g., `/orch <command>` or `/skill:orch <comm
 | `review-codebase [PATH]` | Whole-codebase reviewer fanout |
 | `review-pr [PR_NUMBER]` | Pre-submission review |
 | `review-pr-comments PR_NUMBER` | Triage PR review comments |
-| `submit-pr [PR_NUMBER]` | Local review, push, create PR, CI, async triage, approval merge gate |
+| `submit-pr [PR_NUMBER]` | Local review, push, create PR, async triage, approval gate, CI verify, merge gates |
 | `merge-pr PR_NUMBER \| all` | Verify and merge PR(s) |
 | `parallel-check [ISSUE_IDS]` | Verify parallel work safety |
 
@@ -51,8 +51,9 @@ Set non-sensitive values in `vstack.settings.toml` under `[env]`. Existing `.env
 | `GH_TOKEN` / `GITHUB_TOKEN` | Pre-resolved GitHub token from the parent process | current `gh` auth |
 | `GH_BOT_TOKEN` | Bot GitHub token for worktree auth | `GH_TOKEN` / `GITHUB_TOKEN`, then current `gh` auth |
 | `GH_ISSUE_PATTERN` | Issue ID regex for branch names | `[A-Z]+-[0-9]+` |
+| `CI_WAIT_NO_CHECKS_GRACE` | Seconds `ci-wait` keeps polling before failing when no CI checks have registered yet (covers approval-gated CI dispatch latency) | `180` |
 
-Bot reviews are asynchronous: no orch workflow blocks PR submission on bot-specific signals — emoji reactions, sticky comments, and checklist prose are never parsed as gates. Merges gate on internal review, green CI, zero unresolved review comments (every bot comment replied to and resolved), and a GitHub-native approval verdict from any reviewer — human or bot — polled by `approval-wait` via `reviewDecision`, with a latest-review-per-reviewer fallback when no required-review protection exists. If no approval verdict arrives within 15 minutes, the workflow prompts the user to force merge, keep waiting, or stop.
+Bot reviews are asynchronous: no orch workflow blocks PR submission on bot-specific signals — emoji reactions, sticky comments, and checklist prose are never parsed as gates. Merges gate on internal review, green CI, zero unresolved review comments (every bot comment replied to and resolved), and a GitHub-native approval verdict from any reviewer — human or bot — polled by `approval-wait` via `reviewDecision`, with a latest-review-per-reviewer fallback when no required-review protection exists. If no approval verdict arrives within 15 minutes, the workflow prompts the user to force merge, keep waiting, or stop. The approval gate runs before CI verification, so repos that start CI only after an approval (approval-gated jobs or a merge queue) never deadlock; on always-on repos the post-approval CI verify simply returns quickly.
 
 See [`DEVELOPMENT.md`](./DEVELOPMENT.md) for GitHub auth fallback details and the test runner.
 

--- a/skills/orch/SKILL.md
+++ b/skills/orch/SKILL.md
@@ -81,7 +81,7 @@ When invoked with `<command> [args]`, route to the corresponding workflow.
 | `review-codebase` | `[PATH]` | `workflows/review-codebase.md` | Ad-hoc whole-codebase reviewer fanout |
 | `review-pr` | `[PR_NUMBER]` | `workflows/review-pr.md` | Pre-submission review |
 | `review-pr-comments` | `PR_NUMBER` \| `BRANCH` | `workflows/review-pr-comments.md` | Triage PR comments |
-| `submit-pr` | `[PR_NUMBER]` | `workflows/submit-pr.md` | Local review, push, create PR, CI, async triage, approval gate |
+| `submit-pr` | `[PR_NUMBER]` | `workflows/submit-pr.md` | Local review, push, create PR, async triage, approval gate, CI verify |
 | `merge-pr` | `PR_NUMBER` \| `all` | `workflows/merge-pr.md` | Verify and merge |
 | `fix-reconcile` | — | `workflows/fix-reconcile.md` | Internal (not user-invocable) |
 | `post-summary` | `[ISSUE_ID]` | `workflows/post-summary.md` | Post summary comments |
@@ -120,7 +120,7 @@ Follow ALL [Workflow Execution](#workflow-execution) rules for every command.
 | `workflows/review-codebase.md` | `review-codebase` | Whole-codebase reviewer fanout with findings only |
 | `workflows/review-pr.md` | `review-pr` | Pre-submission review with fix handling and QA |
 | `workflows/review-pr-comments.md` | `review-pr-comments` | Triage PR review comments via domain agents |
-| `workflows/submit-pr.md` | `submit-pr` | Local pre-PR review, push, create PR, CI, async comment triage, approval merge gates |
+| `workflows/submit-pr.md` | `submit-pr` | Local pre-PR review, push, create PR, async comment triage, approval gate before CI verify, merge gates |
 | `workflows/merge-pr.md` | `merge-pr` | Verify conditions and merge PR(s) |
 
 ### Per-Issue Lifecycle
@@ -152,8 +152,8 @@ Follow ALL [Workflow Execution](#workflow-execution) rules for every command.
 | `review-init` | Initialize standalone review context and print branch/worktree/issue/state JSON |
 | `review-artifact-check` | Validate a reviewer's on-disk JSON artifact (exists, `mtime >=` delegation epoch, `jq -e '.verdict'`) and print `{ok, path, reason}` — the sole review-pr completion condition |
 | `tracker-for-issue` | Print `github` for `issue-*` ids and `linear` otherwise |
-| `approval-wait` | Poll for a GitHub-native review approval verdict (`reviewDecision`/`latestReviews`) plus unresolved-thread count — the submit-pr merge-gate poller; never parses bot reactions or sticky prose |
-| `ci-wait` | Block until CI completes on a PR — invoked by per-issue agents inside their submit-pr flow |
+| `approval-wait` | Poll for a GitHub-native review approval verdict (`reviewDecision`/`latestReviews`) plus unresolved-thread count — the submit-pr § 4 approval-gate poller; never parses bot reactions or sticky prose |
+| `ci-wait` | Block until CI completes on a PR — runs after the approval gate; `CI_WAIT_NO_CHECKS_GRACE` (default 180s) bounds how long it tolerates unregistered checks |
 | `session-init` | Initialize session state for a new worktree (called by `initialize.md`) |
 | `open-terminal` | Launch-only handoff helper for Linear/GitHub worktrees |
 | `parallel-groups` | Local cache for safe parallel handoff analysis |

--- a/skills/orch/scripts/ci-wait
+++ b/skills/orch/scripts/ci-wait
@@ -5,7 +5,8 @@
 # (vstack#454). Auto-retries transient infrastructure failures (max 1 retry).
 #
 # Uses JSON-based state detection to avoid false positives from stale checks
-# left by prior workflow runs (e.g., SKIPPED checks from defer-ci runs).
+# left by prior workflow runs (e.g., SUCCESS/SKIPPED checks from a superseded
+# earlier run).
 #
 # Usage: ci-wait <PR#> [poll_interval] [max_wait] [--json]
 #
@@ -41,6 +42,13 @@
 #
 # Environment:
 #   GIT_HOST_CLI  - (optional) Path to git host CLI script for enriched output
+#   CI_WAIT_NO_CHECKS_GRACE - (optional) Seconds to keep polling before failing
+#                 when no checks have registered yet (default 180). ci-wait
+#                 runs after the submit-pr approval gate; approval-gated repos
+#                 dispatch CI from the pull_request_review event, so check
+#                 registration can lag. Within the grace window the result
+#                 stays verdict "pending"; past it, the explicit "no checks
+#                 registered" diagnostic fires.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -237,10 +245,23 @@ TRANSIENT_PATTERNS=(
 retries=0
 max_retries=1
 no_checks_count=0
-max_no_checks=4  # Give CI ~60s to register checks before failing
+# Grace window for check registration, in seconds. Approval-gated repos start
+# CI only after a review approval lands (pull_request_review dispatch), so
+# checks can take minutes to register after the approval gate clears. Within
+# the window the loop keeps polling (verdict stays "pending"); past it, the
+# explicit no-checks diagnostic below fires.
+NO_CHECKS_GRACE="${CI_WAIT_NO_CHECKS_GRACE:-180}"
+if ! [[ "$NO_CHECKS_GRACE" =~ ^[0-9]+$ ]]; then
+  NO_CHECKS_GRACE=180
+fi
+max_no_checks=$(((NO_CHECKS_GRACE + POLL_INTERVAL - 1) / POLL_INTERVAL))
+if [ "$max_no_checks" -lt 1 ]; then
+  max_no_checks=1
+fi
 
-# Guard against stale-check race condition: when called right after removing
-# defer-ci label, old run checks (SUCCESS/SKIPPED) may be the only ones visible.
+# Guard against stale-check race condition: when a fresh run was just
+# triggered (new push, review-approval dispatch), checks from an old run
+# (SUCCESS/SKIPPED) may be the only ones visible.
 # Only declare "passed" after we've seen at least one check go through
 # IN_PROGRESS/PENDING, proving a fresh run was observed.
 seen_in_progress=false
@@ -362,9 +383,10 @@ while [ "$elapsed" -lt "$MAX_WAIT" ]; do
   if [ -z "$checks_json" ] || [ "$checks_json" = "[]" ] || [ "$checks_json" = "null" ]; then
     no_checks_count=$((no_checks_count + 1))
     if [ $no_checks_count -ge $max_no_checks ]; then
-      emit_error "no CI checks registered on PR #$PR_NUM after ${elapsed}s (merge conflicts, draft/defer-ci gating, or webhook delay)"
-      echo "No CI checks after ${elapsed}s" >&2
-      echo "Possible causes: merge conflicts, draft/defer-ci gating, or webhook delay." >&2
+      emit_error "no CI checks registered on PR #$PR_NUM after ${elapsed}s (merge conflicts, draft status, approval-gated CI not yet dispatched, or webhook delay)"
+      echo "No CI checks after ${elapsed}s (grace ${NO_CHECKS_GRACE}s)" >&2
+      echo "Possible causes: merge conflicts, draft status, approval-gated CI not yet dispatched, or webhook delay." >&2
+      echo "Raise CI_WAIT_NO_CHECKS_GRACE if this repo's CI dispatch is slower." >&2
       merge_state=$(gh pr view "$PR_NUM" --repo "$REPO" --json mergeStateStatus --jq '.mergeStateStatus' 2>/dev/null || echo "UNKNOWN")
       if [ "$merge_state" = "DIRTY" ] || [ "$merge_state" = "CONFLICTING" ]; then
         echo "PR has merge conflicts (state: $merge_state) — CI will not trigger." >&2

--- a/skills/orch/tests/ci_wait.sh
+++ b/skills/orch/tests/ci_wait.sh
@@ -19,6 +19,11 @@
 # emit a parseable result on stdout — pass/fail/timeout/error — and must
 # report still-pending checks at the deadline as a timeout, never as
 # success or silence (cases 10-14).
+#
+# Plus the no-checks registration grace (vstack#541): CI_WAIT_NO_CHECKS_GRACE
+# (default 180s) bounds how long ci-wait polls before failing when no checks
+# have registered. Inside the window the verdict stays pending; past it, the
+# explicit "no CI checks" error fires (cases 12, 12b, 12c).
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -434,25 +439,43 @@ set -e
 assert_eq "$rc" "1" "case11b: text-mode timeout exits 1" "$stderr"
 assert_contains "$output" "CI timeout" "case11b: text-mode timeout prints CI timeout on stdout"
 
-# Case 12: no checks ever registered -> status=error with diagnostic, not
-# a silent exit.
+# Case 12: no checks ever registered and the grace window (overridden via
+# CI_WAIT_NO_CHECKS_GRACE) has elapsed -> status=error with diagnostic, not
+# a silent exit. The override also proves the env var drives the cutoff:
+# with the 180s default and this 30s deadline, the error path could never
+# fire (see case 12c).
 stderr="$TMP_ROOT/case12.err"
 set +e
-output=$(run_wait_json STUB_PR_CHECKS_MODE=empty 2>"$stderr")
+output=$(run_wait_json STUB_PR_CHECKS_MODE=empty CI_WAIT_NO_CHECKS_GRACE=3 2>"$stderr")
 rc=$?
 set -e
-assert_eq "$rc" "1" "case12: no registered checks exit 1" "$stderr"
+assert_eq "$rc" "1" "case12: no registered checks past grace exit 1" "$stderr"
 assert_eq "$(json_field "$output" '.status')" "error" "case12: json status is error" "$stderr"
 assert_contains "$(json_field "$output" '.error')" "no CI checks" "case12: json error names the cause"
+assert_contains "$(cat "$stderr")" "grace 3s" "case12: CI_WAIT_NO_CHECKS_GRACE override sets the grace window"
 
 # Case 12b: same in text mode — stdout carries a CI error line.
 stderr="$TMP_ROOT/case12b.err"
 set +e
-output=$(run_wait STUB_PR_CHECKS_MODE=empty 2>"$stderr")
+output=$(run_wait STUB_PR_CHECKS_MODE=empty CI_WAIT_NO_CHECKS_GRACE=3 2>"$stderr")
 rc=$?
 set -e
 assert_eq "$rc" "1" "case12b: text-mode no-checks exit 1" "$stderr"
 assert_contains "$output" "CI error" "case12b: text-mode no-checks prints CI error on stdout"
+
+# Case 12c: no checks registered but still INSIDE the default 180s grace
+# window when the deadline hits -> timeout with verdict pending, never the
+# no-checks error. Approval-gated repos dispatch CI from the
+# pull_request_review event, so registration can legitimately lag this long.
+stderr="$TMP_ROOT/case12c.err"
+set +e
+output=$(run_wait_json_short STUB_PR_CHECKS_MODE=empty 2>"$stderr")
+rc=$?
+set -e
+assert_eq "$rc" "1" "case12c: no checks inside grace window exit 1 (timeout)" "$stderr"
+assert_eq "$(json_field "$output" '.status')" "timeout" "case12c: json status is timeout, not error" "$stderr"
+assert_eq "$(json_field "$output" '.verdict')" "pending" "case12c: verdict stays pending inside grace window" "$stderr"
+assert_not_contains "$output" "no CI checks" "case12c: no-checks error suppressed inside grace window"
 
 # Case 13: settled failing check -> status=complete / verdict=fail.
 stderr="$TMP_ROOT/case13.err"

--- a/skills/orch/tests/workflow_helpers.sh
+++ b/skills/orch/tests/workflow_helpers.sh
@@ -150,6 +150,18 @@ assert_file_contains "$submit_workflow" 'No approval verdict' "submit-pr prompts
 assert_file_contains "$submit_workflow" 'Force merge' "submit-pr offers an explicit force-merge override"
 assert_file_contains "$submit_workflow" 'pr-threads [PR_NUMBER] --unresolved' "submit-pr merge gate checks unresolved threads deterministically"
 assert_file_contains "$submit_workflow" '`status=complete`, `verdict=pass`' "submit-pr merge gate requires green CI"
+
+# vstack#541 — the approval gate (§ 4) must run BEFORE CI verification (§ 5):
+# approval-gated repos only start CI once an approval verdict exists, so the
+# reverse order would deadlock. Compare section-header line numbers.
+approval_gate_line="$(grep -n -m1 '^## 4\. Approval Gate' "$submit_workflow" | cut -d: -f1)"
+ci_verify_line="$(grep -n -m1 '^## 5\. Verify CI' "$submit_workflow" | cut -d: -f1)"
+submit_ordering="missing-sections"
+if [[ -n "$approval_gate_line" && -n "$ci_verify_line" && "$approval_gate_line" -lt "$ci_verify_line" ]]; then
+  submit_ordering="approval-before-ci"
+fi
+assert_eq "$submit_ordering" "approval-before-ci" "submit-pr orders the approval gate (§ 4) before CI verify (§ 5)"
+assert_file_contains "$submit_workflow" 'CI_WAIT_NO_CHECKS_GRACE' "submit-pr documents the ci-wait no-checks grace window"
 assert_file_not_contains "$comments_workflow" 'Wait for All Bot Reviews' "review-pr-comments drops the bot completion pre-check"
 assert_file_not_contains "$comments_workflow" 'sleep 300' "review-pr-comments does not sleep-wait for bot re-review"
 
@@ -167,6 +179,14 @@ assert_file_contains "$merge_workflow" 'git -C [MAIN_REPO_ROOT] merge --ff-only 
 assert_file_not_contains "$merge_workflow" 'branch -D "$PR_BRANCH"' "merge-pr § 5a no longer force-deletes the PR branch unconditionally"
 assert_file_contains "$merge_workflow" 'branch refs/heads/[PR_BRANCH]' "merge-pr § 5a guards branch delete against worktree checkout"
 assert_file_contains "$merge_workflow" '`not_approved` — a GitHub-native approval verdict is required' "merge-pr treats not_approved as a merge gate, not advice"
+assert_file_contains "$merge_workflow" 'pr-merge [PR_NUMBER] --auto' "merge-pr re-runs check/queue-blocked merges with pr-merge --auto"
+assert_file_contains "$merge_workflow" 'QUEUED FOR AUTO-MERGE' "merge-pr treats pr-merge exit 75 as success-pending"
+assert_file_contains "$merge_workflow" 'gh pr view [PR_NUMBER] --json state,mergedAt' "merge-pr watches queued merges via PR state on a bounded poll"
+assert_file_contains "$merge_workflow" 'isInMergeQueue mergeQueueEntry { state }' "merge-pr watch loop reads queue membership via GraphQL"
+assert_file_contains "$merge_workflow" 'workflows/ci-fix.md [PR_NUMBER] § 1-7 → § 5 step 2' "merge-pr routes queue ejection / disarmed auto-merge into ci-fix recovery"
+assert_file_contains "$merge_workflow" 'merge-group** run (workflow event `merge_group`)' "merge-pr points ci-fix at the failing merge-group run on ejection"
+assert_file_contains "$merge_workflow" '.agents/skills/orch/scripts/approval-wait [PR_NUMBER] 15 300 --json' "merge-pr re-confirms approval after a recovery push"
+assert_file_contains "$merge_workflow" 'Max 2 recovery cycles per merge-pr run' "merge-pr bounds queued-merge recovery cycles"
 
 assert_file_not_contains "$qa_workflow" "Pipe benchmark output" "qa-review avoids pipe-based benchmark recording"
 assert_file_not_contains "$qa_workflow" "pipe results" "qa-review avoids pipe-based perf capture guidance"

--- a/skills/orch/workflows/merge-pr.md
+++ b/skills/orch/workflows/merge-pr.md
@@ -245,16 +245,46 @@ merge. Detach them first.
    ```
    Use the output as `MAIN_REPO_ROOT`.
 
-2. **Merge** (before cleanup — worktree survives if merge fails):
+2. **Merge** (before cleanup — worktree survives if merge fails). Attempt the immediate merge first:
    ```bash
    [MAIN_REPO_ROOT]/.agents/skills/github/scripts/github.sh -C [MAIN_REPO_ROOT] pr-merge [PR_NUMBER] [--force]
    ```
 
-   Exit `75` = queued for auto-merge (fires when CI + branch protection clear). Wait before sync:
+   Exit `0` = MERGED → step 3.
+
+   **If pr-merge reports BLOCKED** (exit `1`) and the block is pending required checks or a merge queue — the issues/stderr mention `ci_pending:`, required checks that have not started yet, or that the base branch requires merges through a merge queue — re-run with `--auto`:
    ```bash
-   [MAIN_REPO_ROOT]/.agents/skills/github/scripts/github.sh -C [MAIN_REPO_ROOT] await-mergeable [PR_NUMBER]
+   [MAIN_REPO_ROOT]/.agents/skills/github/scripts/github.sh -C [MAIN_REPO_ROOT] pr-merge [PR_NUMBER] --auto
    ```
-   Never poll `gh pr view --json mergeable` — stays UNKNOWN after merge, loops forever.
+   One flag covers both repo shapes with no detection: on merge-queue repos GitHub enqueues the PR; on plain repos it arms auto-merge to fire when CI and branch protection clear. `--auto` never bypasses the § 3 readiness gates — GitHub still requires the checks and approval to complete before the merge fires. For any other BLOCKED cause (conflicts, `ci_failed:`, `changes_requested:`), do not queue — surface the failure and return to § 3.2.
+
+   Exit `75` = QUEUED FOR AUTO-MERGE — treat as success-pending and run the watch loop below. Ejection is per-PR: a failed merge-group run removes only this PR from the queue while other queued PRs re-test and merge independently, so each session's own merge-pr watch owns recovery for its own PR and parallel sessions never need to coordinate.
+
+   **Watch loop** — each poll runs the two commands below, then routes; `sleep 30` between polls, at most 20 polls (~10 min):
+   ```bash
+   gh pr view [PR_NUMBER] --json state,mergedAt
+   ```
+   ```bash
+   gh api graphql -f query='query($owner: String!, $repo: String!, $number: Int!) { repository(owner: $owner, name: $repo) { pullRequest(number: $number) { isInMergeQueue mergeQueueEntry { state } autoMergeRequest { enabledAt } } } }' -F owner='{owner}' -F repo='{repo}' -F number=[PR_NUMBER]
+   ```
+   `gh pr view --json` exposes no queue-membership field (verified against gh 2.96.0), so the GraphQL query is required; gh fills the `{owner}`/`{repo}` placeholders from the current repo. Track across polls whether any earlier poll observed the PR queued or armed (`isInMergeQueue == true`, `mergeQueueEntry` non-null, or `autoMergeRequest` non-null) — use that as `WAS_QUEUED`. Never poll `gh pr view --json mergeable` — stays UNKNOWN after merge, loops forever.
+
+   | Observation | Meaning | Action |
+   |-------------|---------|--------|
+   | `state == "MERGED"` | Merge landed | → step 3 |
+   | `OPEN`, still queued or armed, no failed required check | Waiting on checks / queue position | Continue polling |
+   | `OPEN`, `WAS_QUEUED`, now `isInMergeQueue == false` and `mergeQueueEntry == null`, not merged | **Ejected** — the merge-group CI run failed and GitHub removed this PR from the queue | Recovery cycle below |
+   | `OPEN` on a plain auto-merge repo, `autoMergeRequest == null` after `--auto` armed it, or a required check failed (probe: `.agents/skills/orch/scripts/ci-wait [PR_NUMBER] 15 60 --json` → `verdict=fail`) | Auto-merge disarmed by a check failure | Recovery cycle below |
+   | Poll bound reached, still queued/armed | Deep queue | Report still-queued: the merge stays armed and fires when checks and protection clear. Skip steps 3-6 (they assume a landed merge) and note in § 7 that sync/cleanup should be re-run via `merge-pr [PR_NUMBER]` once merged |
+
+   **Recovery cycle** — no manual CI-fixing; route the failure back into ci-fix automatically. Max 2 recovery cycles per merge-pr run (a session-scoped count, parallel to ci-fix's own internal cycle cap); at the cap, report the persistent failure, skip steps 3-6, and hand back to the user.
+
+   1. **Run Workflow**: `⤵ workflows/ci-fix.md [PR_NUMBER] § 1-7 → § 5 step 2`. For a queue ejection the failing run is the **merge-group** run (workflow event `merge_group`), not necessarily the PR-head run — locate it via the failing run link in the PR's checks or `gh run list --event merge_group --limit 10`, and point ci-fix's log fetching at that run.
+   2. **Re-confirm approval** after ci-fix pushed a fix — pushes can dismiss reviewer approvals:
+      ```bash
+      .agents/skills/orch/scripts/approval-wait [PR_NUMBER] 15 300 --json
+      ```
+   3. **Re-arm and resume**: re-run `pr-merge [PR_NUMBER] --auto` (command above) and restart the watch loop from the top with a fresh poll budget.
 
 3. **Sync issue tracker cache** — **Linear only** (merged PRs close issues via magic words; cache must reflect done states):
    ```bash

--- a/skills/orch/workflows/review-pr-comments.md
+++ b/skills/orch/workflows/review-pr-comments.md
@@ -36,7 +36,7 @@ On any `gh` or `.agents/skills/github/scripts/github.sh` failure: halt, report e
 
 ### 1.1 Async Bot Review Policy
 
-Bot reviews are asynchronous. Triage what exists on the PR **right now** — never block triage on a bot reaching terminal status first. Bot prose is never parsed as a gate: emoji reactions, sticky comments, and checklist text carry no gating weight. Comments that arrive after this pass are caught by a later triage pass or by the caller's merge gates (`submit-pr.md` § 6.1: zero unresolved comments plus a GitHub-native approval verdict, polled via `approval-wait`).
+Bot reviews are asynchronous. Triage what exists on the PR **right now** — never block triage on a bot reaching terminal status first. Bot prose is never parsed as a gate: emoji reactions, sticky comments, and checklist text carry no gating weight. Comments that arrive after this pass are caught by a later triage pass, by the caller's approval gate (`submit-pr.md` § 4: a GitHub-native approval verdict polled via `approval-wait` together with new comments), or by its merge gates (`submit-pr.md` § 6.1: zero unresolved comments as a final live check).
 
 ### 1.2 Fetch Actionable Data
 

--- a/skills/orch/workflows/start-worktree.md
+++ b/skills/orch/workflows/start-worktree.md
@@ -161,7 +161,7 @@ If invoked as `start github OWNER/REPO#N`, parse it before initialization:
 
 ### 5.6 Offer Merge
 
-**Skip if** no PR created (§ 4), CI not passing, or the § 4 merge gates report `MERGE_READY = false` (unresolved review comments or no approval verdict).
+**Skip if** no PR created (§ 4), CI not passing, or the § 4 submit-pr merge gates (`submit-pr.md` § 6.1) report `MERGE_READY = false` (unresolved review comments or no approval verdict).
 
 → Ask user: `orch merge-pr [PR_NUMBER]` | `Skip`
 

--- a/skills/orch/workflows/submit-pr.md
+++ b/skills/orch/workflows/submit-pr.md
@@ -1,6 +1,6 @@
 # Submit PR Workflow
 
-Run a local pre-PR review, push changes, create/update the PR with CI running immediately, triage review comments asynchronously, and verify merge gates.
+Run a local pre-PR review, push changes, create/update the PR, triage review comments asynchronously, wait for the GitHub-native approval verdict, verify CI, and confirm merge gates. The approval gate (§ 4) runs before CI verification (§ 5) so repos that start CI only after an approval never deadlock.
 
 ## Inputs
 
@@ -162,7 +162,7 @@ Bot reviews are **asynchronous** in this workflow: GitHub review bots post on th
    - **Created Issues**: Include if issues created during local review or comment triage.
    - **QA Metrics**: Include if QA agents ran. Format is project-configurable based on which QA agent types are active.
 
-4. **Create or update PR**. CI runs immediately from the moment the PR exists — never defer, queue, or gate it behind bot review activity.
+4. **Create or update PR**. CI configured on `pull_request` runs from the moment the PR exists — orch never defers, queues, or gates it behind bot review activity. Approval-gated repos start their heavy CI only after the § 4 approval verdict instead; that is repo-side configuration (see orch `DEVELOPMENT.md` § CI Triggering Patterns) and needs no detection here.
 
    **No existing PR** → create. Always pass the body via `--body-file`:
    ```bash
@@ -188,7 +188,7 @@ Bot reviews are **asynchronous** in this workflow: GitHub review bots post on th
 
 ## 3. Async Comment Triage
 
-Bot reviews are asynchronous: review bots may post minutes or hours after the PR opens. **Bot prose is never a gate signal** — emoji reactions, sticky comments, and checklist text are never parsed for gating. Triage whatever review comments exist right now and move on; the merge gates (§ 6.1) later require every comment replied to and resolved plus a GitHub-native approval verdict, and findings that arrive after merge get an immediate follow-up fix or an explicit tracking issue. Every bot comment still gets a reply and resolution — the hygiene standard is unchanged.
+Bot reviews are asynchronous: review bots may post minutes or hours after the PR opens. **Bot prose is never a gate signal** — emoji reactions, sticky comments, and checklist text are never parsed for gating. Triage whatever review comments exist right now and move on; the approval gate (§ 4) polls for the GitHub-native approval verdict and new comments together, the merge gates (§ 6.1) require every comment replied to and resolved, and findings that arrive after merge get an immediate follow-up fix or an explicit tracking issue. Every bot comment still gets a reply and resolution — the hygiene standard is unchanged.
 
 ### 3.1 Opportunistic Triage
 
@@ -196,7 +196,7 @@ Bot reviews are asynchronous: review bots may post minutes or hours after the PR
    ```bash
    .agents/skills/github/scripts/github.sh pr-threads [PR_NUMBER] --unresolved
    ```
-   Read `.unresolved_count` from the JSON output and use it as `UNRESOLVED_FROM_PREVIOUS_COMMAND`. If it is `0` → § 3.5 (nothing to triage yet — later arrivals are handled at the § 6.1 gate).
+   Read `.unresolved_count` from the JSON output and use it as `UNRESOLVED_FROM_PREVIOUS_COMMAND`. If it is `0` → § 3.5 (nothing to triage yet — later arrivals are handled by the § 4 approval gate).
 
 2. **Run Workflow**: `⤵ workflows/review-pr-comments.md [PR_NUMBER] § 1-8 → § 3.1 step 3` with context:
    - `lifecycle`: `"managed"`
@@ -225,7 +225,7 @@ Bot reviews are asynchronous: review bots may post minutes or hours after the PR
 
    **If issues created** → § 3.2
 
-   **Otherwise** → § 3.5. Fixes pushed during triage were already replied to and their threads resolved by `review-pr-comments.md`. Do not wait for a bot re-review round — any re-review comments land in existing or new threads and are caught at the § 6.1 gate.
+   **Otherwise** → § 3.5. Fixes pushed during triage were already replied to and their threads resolved by `review-pr-comments.md`. Do not wait for a bot re-review round — any re-review comments land in existing or new threads and are caught by the § 4 approval gate or the § 6.1 gate 3 final check.
 
 ### 3.2 Implement Created Issues
 
@@ -282,9 +282,49 @@ If `design` label present:
 
 ---
 
-## 4. Verify CI
+## 4. Approval Gate
 
-CI has been running since the PR was created or updated in § 2 — there is no bot gate in front of it.
+The approval gate runs **before** CI verification — universally, with no repo detection. Consuming repos may configure CI to start only after an approval verdict exists (approval-gated jobs or a merge queue; see orch `DEVELOPMENT.md` § CI Triggering Patterns), so waiting on CI first would deadlock those repos. On repos whose CI runs immediately from § 2, verifying CI after approval (§ 5) simply returns quickly.
+
+Bot-SPECIFIC signals (emoji reactions, sticky-comment prose, checklist text) are never parsed for gating; this gate reads only GitHub-native review verdicts, from any reviewer — human or bot.
+
+1. **Approval wait loop.** Poll for a GitHub-native approval verdict and new review comments together:
+   ```bash
+   .agents/skills/orch/scripts/approval-wait [PR_NUMBER] 30 900 --json
+   ```
+   The result is a JSON object: `status` (`approved`/`changes_requested`/`comments`/`timeout`/`error`) plus `review_decision`, `approvals`, `changes_requested`, and `unresolved_count`. approval-wait always emits it — no silent completion. Detection uses `gh pr view --json reviewDecision,latestReviews` (either signal: the branch-protection aggregate `reviewDecision == "APPROVED"`, or the latest-review-per-reviewer fallback when no protection is configured); any reviewer counts, human or bot.
+
+   Route on `status`:
+
+   | `status` | Action |
+   |----------|--------|
+   | `approved`, `unresolved_count == 0` | Approval verdict recorded → step 2 |
+   | `approved`, `unresolved_count > 0` | Approval recorded; run the triage pass below to clear the comments. If the pass pushed no commits, the approval stands → step 2 (thread hygiene is re-confirmed at the § 6.1 gate 3 final check); if it pushed commits, restart step 1 |
+   | `changes_requested` or `comments` | New review feedback: run the triage pass below, then restart step 1 |
+   | `timeout` | No approval verdict after 15 min → Ask user: "No approval verdict on PR #[PR_NUMBER] after [ELAPSED] min" — `Force merge` \| `Keep waiting` \| `Stop here` |
+   | `error` | Re-run step 1 once; if it repeats, report the error and ask user: `Keep waiting` \| `Stop here` |
+
+   **Triage pass** (bounded by `pr_comment_review.iterations`, max 5 — read it before each pass; at the cap, present the remaining feedback and ask user: `Triage again` \| `Force merge` \| `Stop here`):
+   - `⤵ workflows/review-pr-comments.md [PR_NUMBER] § 1-8 → § 4 step 1` with managed context — fixes real findings, replies to and resolves every comment.
+   - Pushes made by a triage pass may dismiss or refresh existing reviewer approvals (stale-review dismissal) and re-trigger reviewer re-review — restarting step 1 already handles re-approval; no separate re-check is needed.
+
+   **User choices on `timeout`:**
+   - `Keep waiting` → restart step 1.
+   - `Force merge` → record the override, then treat the approval gate as met and continue to step 2 (the § 6.1 gates still apply):
+     ```bash
+     .agents/skills/orch/scripts/workflow-state set [ISSUE_ID] pr_approval.forced true
+     ```
+   - `Stop here` → § 6 with the approval gate unmet (`MERGE_READY = false`); the PR stays open awaiting approval. Skip § 5 — on approval-gated repos CI cannot start until the approval lands.
+
+2. **Record the result** for the § 6.1 gate 4 check — approval status (`approved`, or forced via `pr_approval.forced`) and the `unresolved_count` at approval time — then → § 5.
+
+---
+
+## 5. Verify CI
+
+On always-on repos CI has been running since the PR was created or updated in § 2. On approval-gated repos, checks register only after the § 4 approval gate completes — which is why this section runs after § 4. Neither case needs detecting: ci-wait treats "no checks yet" as pending within its registration grace window (`CI_WAIT_NO_CHECKS_GRACE`, default 180s) and fails with an explicit diagnostic only past it.
+
+### 5.1 Wait for CI
 
 1. **Wait for CI**:
    ```bash
@@ -297,17 +337,15 @@ CI has been running since the PR was created or updated in § 2 — there is no 
    | Result | Action |
    |--------|--------|
    | ✅ `status=complete`, `verdict=pass` | → § 6 |
-   | ❌ `status=complete`, `verdict=fail` | → § 5 |
+   | ❌ `status=complete`, `verdict=fail` | → § 5.2 |
    | ⏱ `status=timeout` or `status=error` | Re-run step 1 once; if it repeats → Ask user: `Skip CI` \| `Retry` \| `Abort` |
 
----
+### 5.2 CI Failure Recovery
 
-## 5. CI Failure Recovery
-
-1. **Run Workflow**: `⤵ workflows/ci-fix.md [PR_NUMBER] § 1-7 → § 5 step 2`
+1. **Run Workflow**: `⤵ workflows/ci-fix.md [PR_NUMBER] § 1-7 → § 5.2 step 2`
 
 2. **After ci-fix returns**:
-   - If fix applied → ci-fix already pushed and re-verified CI (its § 5); treat its final CI result as the § 4 result and re-route via the § 4 step 2 table.
+   - If fix applied → ci-fix already pushed and re-verified CI (its § 5); treat its final CI result as the § 5.1 result and re-route via the § 5.1 step 2 table. A recovery push may also dismiss existing reviewer approvals — when ci-fix pushed commits, re-confirm the § 4 approval with a short wait (`approval-wait [PR_NUMBER] 15 300 --json`) before § 6.
    - If fix not possible → Ask user: `Skip CI` | `Retry` | `Abort`
 
 3. **Max 2 ci-fix cycles** per PR submission.
@@ -320,14 +358,14 @@ CI has been running since the PR was created or updated in § 2 — there is no 
 
 ### 6.1 Merge Gates
 
-A PR merges on exactly four gates — all deterministic. Bot-SPECIFIC signals (emoji reactions, sticky-comment prose, checklist text) are never parsed for gating; the approval gate reads only GitHub-native review verdicts, from any reviewer — human or bot.
+A PR merges on exactly four gates — all deterministic. Bot-SPECIFIC signals (emoji reactions, sticky-comment prose, checklist text) are never parsed for gating; the approval gate reads only GitHub-native review verdicts, from any reviewer — human or bot. Gates 2 and 4 **verify results already recorded** by § 5 and § 4 — do not re-run the waits here; gate 3 is a final live check.
 
 | # | Gate | Check |
 |---|------|-------|
 | 1 | Internal review verdict recorded | Managed: `review-pr.md` completed with verdict `pass` before this workflow. Standalone: workflow state `json_paths` is non-empty |
-| 2 | CI green | § 4 result is `status=complete`, `verdict=pass` (equivalently: `gh pr checks [PR_NUMBER]` shows all checks passing) |
+| 2 | CI green | § 5 result is `status=complete`, `verdict=pass` (equivalently: `gh pr checks [PR_NUMBER]` shows all checks passing) |
 | 3 | Zero unresolved review comments | `pr-threads` reports `unresolved_count == 0` AND every actionable PR-level bot comment has a reply (tracked in `pr_comment_review.replied`) |
-| 4 | GitHub-native approval verdict | `reviewDecision == "APPROVED"`, or — when `reviewDecision` is empty (no required-review protection) — at least one reviewer whose latest review is APPROVED and none whose latest review is CHANGES_REQUESTED |
+| 4 | GitHub-native approval verdict | § 4 ended `approved` — `reviewDecision == "APPROVED"`, or, when `reviewDecision` is empty (no required-review protection), at least one reviewer whose latest review is APPROVED and none whose latest review is CHANGES_REQUESTED — or `pr_approval.forced` is recorded |
 
 1. **Gate 1** — standalone only (managed callers reach this workflow only after `review-pr.md` passed):
    ```bash
@@ -335,9 +373,9 @@ A PR merges on exactly four gates — all deterministic. Bot-SPECIFIC signals (e
    ```
    If `json_paths` is empty, no internal review is recorded: report the unmet gate and recommend `orch review-pr [PR_NUMBER]` before merge.
 
-2. **Gate 2** — from § 4: met when the final CI result was `status=complete`, `verdict=pass`.
+2. **Gate 2** — verify the recorded § 5 result: met when the final CI result was `status=complete`, `verdict=pass`. Do not re-run ci-wait.
 
-3. **Gate 3**:
+3. **Gate 3 — final live check**:
    ```bash
    .agents/skills/github/scripts/github.sh pr-threads [PR_NUMBER] --unresolved
    ```
@@ -346,35 +384,9 @@ A PR merges on exactly four gates — all deterministic. Bot-SPECIFIC signals (e
    | `unresolved_count` | Action |
    |--------------------|--------|
    | `0` | Gate met |
-   | `> 0` | → step 4's triage row — the approval wait loop owns comment routing from here |
+   | `> 0` | Run ONE triage pass: `⤵ workflows/review-pr-comments.md [PR_NUMBER] § 1-8 → § 6.1 step 3` with managed context (bounded by `pr_comment_review.iterations`, max 5). If that pass pushed commits, re-run § 5 and re-confirm approval per § 4 with a short approval-wait (`approval-wait [PR_NUMBER] 15 300 --json`). Then re-run the gate 3 command once; if threads remain, present them and ask user: `Triage again` \| `Force merge` \| `Stop here` |
 
-4. **Gate 4 — approval wait loop.** Poll for a GitHub-native approval verdict and new review comments together:
-   ```bash
-   .agents/skills/orch/scripts/approval-wait [PR_NUMBER] 30 900 --json
-   ```
-   The result is a JSON object: `status` (`approved`/`changes_requested`/`comments`/`timeout`/`error`) plus `review_decision`, `approvals`, `changes_requested`, and `unresolved_count`. approval-wait always emits it — no silent completion. Detection uses `gh pr view --json reviewDecision,latestReviews` (either signal: the branch-protection aggregate, or the latest-review-per-reviewer fallback when no protection is configured); any reviewer counts, human or bot.
-
-   Route on `status`:
-
-   | `status` | Action |
-   |----------|--------|
-   | `approved`, `unresolved_count == 0` | Gates 3 and 4 met → step 5 |
-   | `approved`, `unresolved_count > 0` | Approval recorded; run the triage pass below to clear gate 3, then re-run the gate 3 command once — do not re-wait for approval |
-   | `changes_requested` or `comments` | New review feedback: run the triage pass below, then restart step 4 |
-   | `timeout` | No approval verdict after 15 min → Ask user: "No approval verdict on PR #[PR_NUMBER] after [ELAPSED] min" — `Force merge` \| `Keep waiting` \| `Stop here` |
-   | `error` | Re-run step 4 once; if it repeats, report the error and ask user: `Keep waiting` \| `Stop here` |
-
-   **Triage pass** (bounded by `pr_comment_review.iterations`, max 5 — read it before each pass; at the cap, present the remaining feedback and ask user: `Triage again` \| `Force merge` \| `Stop here`):
-   - `⤵ workflows/review-pr-comments.md [PR_NUMBER] § 1-8 → § 6.1 step 4` with managed context — fixes real findings, replies to and resolves every comment. Pushed fix commits re-trigger CI and reviewer re-review automatically.
-   - If the pass pushed new commits, re-run § 4 to re-verify gate 2 before restarting the approval wait.
-
-   **User choices on `timeout`:**
-   - `Keep waiting` → restart step 4.
-   - `Force merge` → record the override, then treat gate 4 as met (gates 1-3 must still hold):
-     ```bash
-     .agents/skills/orch/scripts/workflow-state set [ISSUE_ID] pr_approval.forced true
-     ```
-   - `Stop here` → § 6.2 with gate 4 unmet (`MERGE_READY = false`); the PR stays open awaiting approval.
+4. **Gate 4** — verify the recorded § 4 result: met when the approval wait ended `approved`, or when `pr_approval.forced` was recorded by an explicit user override. Do not re-run the approval wait here — the gate 3 escape hatch above already re-confirms approval after any late pushes.
 
 5. **Record results**: `MERGE_READY = true` only when all four gates are met (gate 4 by verdict or recorded force).
 
@@ -452,6 +464,6 @@ A PR merges on exactly four gates — all deterministic. Bot-SPECIFIC signals (e
 
 ## 7. Return State
 
-**If managed**: Return to the parent workflow's next section with the § 6.1 gate results (`MERGE_READY`, approval status, unresolved thread count, CI verdict).
+**If managed**: Return to the parent workflow's next section with the § 6.1 gate results (`MERGE_READY`, the § 4 approval status, unresolved thread count, the § 5 CI verdict).
 
 **If standalone**: Session complete — PR submitted. Summary presented in § 6.2.

--- a/vstack.settings.toml.example
+++ b/vstack.settings.toml.example
@@ -34,6 +34,11 @@ ORCH_STATE_DIR = "tmp"
 ORCH_CACHE_DIR = ".cache/orch"
 # Used by: orch (`parallel-groups`).
 
+CI_WAIT_NO_CHECKS_GRACE = "180"
+# Used by: orch (`ci-wait`). Seconds to keep polling before failing when no CI
+# checks have registered yet. Raise for repos whose CI dispatches only after a
+# review approval (approval-gated jobs / merge queue) with slow dispatch.
+
 # BOT / COMMIT IDENTITY
 
 BOT_NAME = "automation-bot"


### PR DESCRIPTION
## Summary

Follow-up to #538: consuming repos are moving CI to run only after review approval (approval-gated jobs or merge queues) instead of the retired defer-ci label hack. This inverts submit-pr's ordering assumption and needs portable queued-merge handling.

## Changes

- **submit-pr**: approval gate (§ 4) now runs BEFORE CI verification (§ 5) — universal ordering, no repo detection. Approval-gated repos can't deadlock waiting for CI that won't start; always-on repos just verify quickly post-approval. § 6.1 gates 2/4 verify recorded results; gate 3 keeps the final live thread check with a bounded escape hatch.
- **ci-wait**: `CI_WAIT_NO_CHECKS_GRACE` (default 180s) replaces the hardcoded ~60s no-checks window — approval-gated CI registers checks only after approval. Clear diagnostic past the grace.
- **merge-pr**: immediate merge first; blocked on pending checks/merge queue → `pr-merge --auto` (one flag covers merge-queue enqueue and plain auto-merge arming — portable, no Enterprise detection), exit 75 watched via `gh pr view --json state,mergedAt` bounded polling.
- **defer-ci retirement**: help examples and test fixtures swept; `grep defer-ci` now hits only the docs retirement note and lint assertions.
- **Docs**: "CI Triggering Patterns" section in orch DEVELOPMENT.md documents the two repo-side patterns (approval-gated jobs, merge_group) and the ordering contract.

orch suite 11/11 files green (ci_wait 73, workflow_helpers 89 incl. new ordering assertion); all 9 github test files green.

Closes #541

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016s6ZSLTTRft6fH29wHn1TN
