### PR TITLE
feat(#543): configurable ci-fix cycle cap (CI_FIX_MAX_CYCLES, default 6)

### DIFF
--- a/skills/orch/README.md
+++ b/skills/orch/README.md
@@ -52,6 +52,7 @@ Set non-sensitive values in `vstack.settings.toml` under `[env]`. Existing `.env
 | `GH_BOT_TOKEN` | Bot GitHub token for worktree auth | `GH_TOKEN` / `GITHUB_TOKEN`, then current `gh` auth |
 | `GH_ISSUE_PATTERN` | Issue ID regex for branch names | `[A-Z]+-[0-9]+` |
 | `CI_WAIT_NO_CHECKS_GRACE` | Seconds `ci-wait` keeps polling before failing when no CI checks have registered yet (covers approval-gated CI dispatch latency) | `180` |
+| `CI_FIX_MAX_CYCLES` | Max automated ci-fix cycles per PR submission (`submit-pr`) or merge recovery (`merge-pr`) before the workflow reports the persistent CI failure — failing checks, last error, per-cycle attempts — back to the user | `6` |
 
 Bot reviews are asynchronous: no orch workflow blocks PR submission on bot-specific signals — emoji reactions, sticky comments, and checklist prose are never parsed as gates. Merges gate on internal review, green CI, zero unresolved review comments (every bot comment replied to and resolved), and a GitHub-native approval verdict from any reviewer — human or bot — polled by `approval-wait` via `reviewDecision`, with a latest-review-per-reviewer fallback when no required-review protection exists. If no approval verdict arrives within 15 minutes, the workflow prompts the user to force merge, keep waiting, or stop. The approval gate runs before CI verification, so repos that start CI only after an approval (approval-gated jobs or a merge queue) never deadlock; on always-on repos the post-approval CI verify simply returns quickly.
 
@@ -84,6 +85,8 @@ Use `skills/orch/scripts/review-init` to initialize standalone review context an
 Use `skills/orch/scripts/review-artifact-check WORKTREE_PATH AGENT_NAME DELEGATED_AT_EPOCH` to deterministically validate a reviewer's on-disk JSON artifact (existence, `mtime >=` delegation epoch, `jq -e '.verdict'`). It prints `{ok, path, reason}`; review-pr accepts a reviewer completion only when `ok == true`.
 
 Use `skills/orch/scripts/tracker-for-issue ISSUE_ID` when workflow docs need tracker branching without inline shell conditionals.
+
+Use `skills/orch/scripts/orch-env VAR_NAME DEFAULT` to print the effective value of a vstack `[env]` setting (process env > `vstack.settings.toml` > default) when a workflow step needs a configurable value without inline shell fallbacks. With a numeric default, a non-numeric effective value falls back to the default — e.g. `orch-env CI_FIX_MAX_CYCLES 6` for the ci-fix cycle budget.
 
 ## System Dependencies
 

--- a/skills/orch/SKILL.md
+++ b/skills/orch/SKILL.md
@@ -154,6 +154,7 @@ Follow ALL [Workflow Execution](#workflow-execution) rules for every command.
 | `tracker-for-issue` | Print `github` for `issue-*` ids and `linear` otherwise |
 | `approval-wait` | Poll for a GitHub-native review approval verdict (`reviewDecision`/`latestReviews`) plus unresolved-thread count — the submit-pr § 4 approval-gate poller; never parses bot reactions or sticky prose |
 | `ci-wait` | Block until CI completes on a PR — runs after the approval gate; `CI_WAIT_NO_CHECKS_GRACE` (default 180s) bounds how long it tolerates unregistered checks |
+| `orch-env` | Print the effective value of a vstack `[env]` setting (process env > `vstack.settings.toml` > supplied default; numeric defaults reject non-numeric values) — how workflows read `CI_FIX_MAX_CYCLES` |
 | `session-init` | Initialize session state for a new worktree (called by `initialize.md`) |
 | `open-terminal` | Launch-only handoff helper for Linear/GitHub worktrees |
 | `parallel-groups` | Local cache for safe parallel handoff analysis |
@@ -204,6 +205,7 @@ Audit input and roadmap-plan schemas live in `project-management/schemas/` — c
 | `ORCH_STATE_DIR` | Override state file directory (env fallback for the `--state-dir` flag, which wins when both are set) | `tmp` |
 | `ORCH_CACHE_DIR` | Parallel-group safety cache directory | `.cache/orch` |
 | `GH_ISSUE_PATTERN` | Regex for issue IDs in branch names | — |
+| `CI_FIX_MAX_CYCLES` | Max automated ci-fix cycles per PR submission / merge recovery (read via `orch-env CI_FIX_MAX_CYCLES 6`) | `6` |
 
 ## System Dependencies
 

--- a/skills/orch/scripts/orch-env
+++ b/skills/orch/scripts/orch-env
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Print the effective value of a vstack [env] setting for workflow steps.
+#
+# Precedence matches lib/vstack-env.sh: parent process env > .env.local >
+# vstack.settings.toml / .vstack/settings.toml [env] > .env > supplied
+# default. When the supplied default is numeric, a non-numeric effective
+# value falls back to the default so workflow bounds always get a usable
+# number.
+#
+# Usage: orch-env VAR_NAME DEFAULT
+#   orch-env CI_FIX_MAX_CYCLES 6
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: orch-env VAR_NAME DEFAULT" >&2
+  exit 2
+fi
+
+VAR_NAME="$1"
+DEFAULT="$2"
+
+if ! [[ "$VAR_NAME" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+  echo "orch-env: invalid variable name: $VAR_NAME" >&2
+  exit 2
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+# shellcheck source=lib/vstack-env.sh
+source "$SCRIPT_DIR/lib/vstack-env.sh"
+vstack_load_project_env "$PROJECT_ROOT"
+
+value="${!VAR_NAME-}"
+[[ -n "$value" ]] || value="$DEFAULT"
+if [[ "$DEFAULT" =~ ^[0-9]+$ ]] && ! [[ "$value" =~ ^[0-9]+$ ]]; then
+  value="$DEFAULT"
+fi
+printf '%s\n' "$value"

--- a/skills/orch/tests/orch_env.sh
+++ b/skills/orch/tests/orch_env.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Regression tests for the orch-env effective-setting reader (vstack#543).
+#
+# orch-env VAR_NAME DEFAULT prints the effective value of a vstack [env]
+# setting with the standard precedence (process env > vstack.settings.toml
+# [env] > supplied default). With a numeric default, a non-numeric effective
+# value falls back to the default so workflow cycle bounds always get a
+# usable number. Workflows use it to read CI_FIX_MAX_CYCLES (default 6).
+
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../.." && pwd)"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+ORCH_ENV="$REPO_ROOT/skills/orch/scripts/orch-env"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local got="$1" want="$2" name="$3"
+  if [[ "$got" == "$want" ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$name" "$want" "$got"
+  fi
+}
+
+echo "=== orch-env effective-setting reader ==="
+
+# Isolated project roots: orch-env resolves the project from the cwd's git
+# toplevel, so each scenario gets its own repo with no vstack settings noise.
+proj_bare="$TMP_ROOT/proj-bare"
+git init -q "$proj_bare"
+
+proj_settings="$TMP_ROOT/proj-settings"
+git init -q "$proj_settings"
+cat > "$proj_settings/vstack.settings.toml" <<'TOML'
+[env]
+CI_FIX_MAX_CYCLES = "4"
+TOML
+
+proj_bad="$TMP_ROOT/proj-bad"
+git init -q "$proj_bad"
+cat > "$proj_bad/vstack.settings.toml" <<'TOML'
+[env]
+CI_FIX_MAX_CYCLES = "many"
+TOML
+
+# Test 1: nothing set anywhere -> the supplied default.
+got="$(cd "$proj_bare" && env -u CI_FIX_MAX_CYCLES "$ORCH_ENV" CI_FIX_MAX_CYCLES 6)"
+assert_eq "$got" "6" "prints the supplied default when the setting is unset"
+
+# Test 2: vstack.settings.toml [env] value wins over the default.
+got="$(cd "$proj_settings" && env -u CI_FIX_MAX_CYCLES "$ORCH_ENV" CI_FIX_MAX_CYCLES 6)"
+assert_eq "$got" "4" "settings-file value overrides the default"
+
+# Test 3: process env wins over the settings file.
+got="$(cd "$proj_settings" && CI_FIX_MAX_CYCLES=9 "$ORCH_ENV" CI_FIX_MAX_CYCLES 6)"
+assert_eq "$got" "9" "process env overrides the settings-file value"
+
+# Test 4: non-numeric settings value with a numeric default -> default.
+got="$(cd "$proj_bad" && env -u CI_FIX_MAX_CYCLES "$ORCH_ENV" CI_FIX_MAX_CYCLES 6)"
+assert_eq "$got" "6" "non-numeric settings value falls back to the numeric default"
+
+# Test 5: non-numeric env override with a numeric default -> default.
+got="$(cd "$proj_bare" && CI_FIX_MAX_CYCLES=abc "$ORCH_ENV" CI_FIX_MAX_CYCLES 6)"
+assert_eq "$got" "6" "non-numeric env value falls back to the numeric default"
+
+# Test 6: non-numeric defaults pass any value through unchanged.
+got="$(cd "$proj_bad" && env -u CI_FIX_MAX_CYCLES "$ORCH_ENV" CI_FIX_MAX_CYCLES auto)"
+assert_eq "$got" "many" "non-numeric default does not enforce numeric values"
+
+# Test 7: usage errors exit 2.
+set +e
+(cd "$proj_bare" && "$ORCH_ENV" CI_FIX_MAX_CYCLES >/dev/null 2>&1)
+missing_arg_code=$?
+(cd "$proj_bare" && "$ORCH_ENV" 'bad-name!' 6 >/dev/null 2>&1)
+bad_name_code=$?
+set -e
+assert_eq "$missing_arg_code" "2" "missing DEFAULT argument exits 2"
+assert_eq "$bad_name_code" "2" "invalid variable name exits 2"
+
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/skills/orch/tests/workflow_helpers.sh
+++ b/skills/orch/tests/workflow_helpers.sh
@@ -186,7 +186,20 @@ assert_file_contains "$merge_workflow" 'isInMergeQueue mergeQueueEntry { state }
 assert_file_contains "$merge_workflow" 'workflows/ci-fix.md [PR_NUMBER] § 1-7 → § 5 step 2' "merge-pr routes queue ejection / disarmed auto-merge into ci-fix recovery"
 assert_file_contains "$merge_workflow" 'merge-group** run (workflow event `merge_group`)' "merge-pr points ci-fix at the failing merge-group run on ejection"
 assert_file_contains "$merge_workflow" '.agents/skills/orch/scripts/approval-wait [PR_NUMBER] 15 300 --json' "merge-pr re-confirms approval after a recovery push"
-assert_file_contains "$merge_workflow" 'Max 2 recovery cycles per merge-pr run' "merge-pr bounds queued-merge recovery cycles"
+
+# vstack#543 — the ci-fix cycle caps are configurable via CI_FIX_MAX_CYCLES
+# (default 6), read deterministically through orch-env; at the cap both
+# workflows must report the failing checks and per-cycle attempts, never a
+# bare "CI failing" / "persistent failure".
+assert_file_contains "$merge_workflow" 'orch-env CI_FIX_MAX_CYCLES 6' "merge-pr reads the configurable ci-fix cycle budget via orch-env"
+assert_file_contains "$merge_workflow" 'Max [MAX_CYCLES] recovery cycles per merge-pr run' "merge-pr bounds queued-merge recovery cycles by the configured budget"
+assert_file_contains "$merge_workflow" 'report the failing check names' "merge-pr cap report names the failing checks"
+assert_file_contains "$merge_workflow" 'what each cycle attempted' "merge-pr cap report lists per-cycle attempts"
+assert_file_contains "$submit_workflow" 'orch-env CI_FIX_MAX_CYCLES 6' "submit-pr reads the configurable ci-fix cycle budget via orch-env"
+assert_file_contains "$submit_workflow" 'Max [MAX_CYCLES] ci-fix cycles' "submit-pr bounds ci-fix cycles by the configured budget"
+assert_file_contains "$submit_workflow" 'what each cycle attempted' "submit-pr cap report lists per-cycle attempts"
+assert_file_not_contains "$submit_workflow" 'Max 2 ci-fix cycles' "submit-pr drops the hardcoded ci-fix cycle cap"
+assert_file_not_contains "$merge_workflow" 'Max 2 recovery cycles' "merge-pr drops the hardcoded recovery cycle cap"
 
 assert_file_not_contains "$qa_workflow" "Pipe benchmark output" "qa-review avoids pipe-based benchmark recording"
 assert_file_not_contains "$qa_workflow" "pipe results" "qa-review avoids pipe-based perf capture guidance"

--- a/skills/orch/workflows/merge-pr.md
+++ b/skills/orch/workflows/merge-pr.md
@@ -277,7 +277,13 @@ merge. Detach them first.
    | `OPEN` on a plain auto-merge repo, `autoMergeRequest == null` after `--auto` armed it, or a required check failed (probe: `.agents/skills/orch/scripts/ci-wait [PR_NUMBER] 15 60 --json` → `verdict=fail`) | Auto-merge disarmed by a check failure | Recovery cycle below |
    | Poll bound reached, still queued/armed | Deep queue | Report still-queued: the merge stays armed and fires when checks and protection clear. Skip steps 3-6 (they assume a landed merge) and note in § 7 that sync/cleanup should be re-run via `merge-pr [PR_NUMBER]` once merged |
 
-   **Recovery cycle** — no manual CI-fixing; route the failure back into ci-fix automatically. Max 2 recovery cycles per merge-pr run (a session-scoped count, parallel to ci-fix's own internal cycle cap); at the cap, report the persistent failure, skip steps 3-6, and hand back to the user.
+   **Recovery cycle** — no manual CI-fixing; route the failure back into ci-fix automatically. Before the first recovery cycle, read the budget:
+
+   ```bash
+   .agents/skills/orch/scripts/orch-env CI_FIX_MAX_CYCLES 6
+   ```
+
+   The printed value is `MAX_CYCLES` — the effective `CI_FIX_MAX_CYCLES` (process env > `vstack.settings.toml` `[env]` > default 6; non-numeric falls back to 6). Max [MAX_CYCLES] recovery cycles per merge-pr run (a session-scoped count, parallel to ci-fix's own internal cycle cap); at the cap, report the failing check names, ci-fix's last error summary, and what each cycle attempted — never a bare "persistent failure" — then skip steps 3-6 and hand back to the user.
 
    1. **Run Workflow**: `⤵ workflows/ci-fix.md [PR_NUMBER] § 1-7 → § 5 step 2`. For a queue ejection the failing run is the **merge-group** run (workflow event `merge_group`), not necessarily the PR-head run — locate it via the failing run link in the PR's checks or `gh run list --event merge_group --limit 10`, and point ci-fix's log fetching at that run.
    2. **Re-confirm approval** after ci-fix pushed a fix — pushes can dismiss reviewer approvals:

--- a/skills/orch/workflows/submit-pr.md
+++ b/skills/orch/workflows/submit-pr.md
@@ -342,15 +342,23 @@ On always-on repos CI has been running since the PR was created or updated in §
 
 ### 5.2 CI Failure Recovery
 
+On first entry, read the ci-fix cycle budget:
+
+```bash
+.agents/skills/orch/scripts/orch-env CI_FIX_MAX_CYCLES 6
+```
+
+The printed value is `MAX_CYCLES` — the effective `CI_FIX_MAX_CYCLES` (process env > `vstack.settings.toml` `[env]` > default 6; non-numeric falls back to 6).
+
 1. **Run Workflow**: `⤵ workflows/ci-fix.md [PR_NUMBER] § 1-7 → § 5.2 step 2`
 
 2. **After ci-fix returns**:
    - If fix applied → ci-fix already pushed and re-verified CI (its § 5); treat its final CI result as the § 5.1 result and re-route via the § 5.1 step 2 table. A recovery push may also dismiss existing reviewer approvals — when ci-fix pushed commits, re-confirm the § 4 approval with a short wait (`approval-wait [PR_NUMBER] 15 300 --json`) before § 6.
    - If fix not possible → Ask user: `Skip CI` | `Retry` | `Abort`
 
-3. **Max 2 ci-fix cycles** per PR submission.
+3. **Max [MAX_CYCLES] ci-fix cycles** per PR submission — keep routing CI failures back into step 1 until CI passes or the budget is spent.
 
-4. **After max cycles** → § 6 with note: "CI failing, may need manual intervention"
+4. **After max cycles** → § 6 with a failure report, never a bare "CI is failing": name the checks still failing (from the last ci-wait/ci-fix result), quote ci-fix's last error summary, and list what each cycle attempted, then note "CI failing after [MAX_CYCLES] ci-fix cycles, may need manual intervention".
 
 ---
 

--- a/vstack.settings.toml
+++ b/vstack.settings.toml
@@ -5,6 +5,7 @@
 BOT_EMAIL = ""
 BOT_NAME = ""
 BOT_REMOTE_NAME = ""
+CI_FIX_MAX_CYCLES = "6"
 DECISIONS_DIR = "docs/decisions"
 GH_BOT_USERNAME = ""
 GH_ISSUE_PATTERN = "cc-[0-9]+"

--- a/vstack.settings.toml.example
+++ b/vstack.settings.toml.example
@@ -39,6 +39,11 @@ CI_WAIT_NO_CHECKS_GRACE = "180"
 # checks have registered yet. Raise for repos whose CI dispatches only after a
 # review approval (approval-gated jobs / merge queue) with slow dispatch.
 
+CI_FIX_MAX_CYCLES = "6"
+# Used by: orch (`submit-pr` / `merge-pr`). Max automated ci-fix cycles per PR
+# submission or merge recovery before reporting the persistent CI failure back
+# to the user.
+
 # BOT / COMMIT IDENTITY
 
 BOT_NAME = "automation-bot"


### PR DESCRIPTION
## Summary

The ci-fix cycle caps (submit-pr § 5.2, merge-pr § 5 recovery) were hardcoded at 2. Agents should keep fixing CI and only hand back after a configurable budget — default 6 — with a real failure report.

## Changes

- New `skills/orch/scripts/orch-env VAR DEFAULT` — prints the effective [env] setting (process env > .env.local > vstack.settings.toml [env] > .env > default; numeric-default guard). 8-assertion test.
- Both workflow caps read `orch-env CI_FIX_MAX_CYCLES 6` at section entry; at the cap they must name the failing checks, quote ci-fix's last error summary, and list what each cycle attempted — never a bare "CI is failing".
- `CI_FIX_MAX_CYCLES = "6"` shipped in vstack.settings.toml.example and vstack's own settings; README/SKILL config+scripts tables updated.

orch suite: all 12 files green (workflow_helpers 102, orch_env 8).

Closes #543

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016s6ZSLTTRft6fH29wHn1TN