### PR TITLE
fix(#545): document required --pr for numeric post-reply IDs in skill synopsis

### DIFF
--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -43,13 +43,15 @@ CLI wrapper for GitHub API operations used in PR workflows. Provides structured 
 | `dismiss-review <PR> [--bot\|--user NAME] [--message M]` | Dismiss blocking review |
 | `resolve-thread <PRRT_...>` | Mark thread(s) resolved |
 | `unresolve-thread <PRRT_...>` | Reopen thread(s) |
-| `post-reply <id> [body \| --body-file PATH]` | Reply to review comment. Prefer `--body-file` for Markdown with backticks; inline body is safe only for plain strings. |
+| `post-reply <PRRT_...\|numeric-id> [body \| --body-file PATH] [--pr N]` | Reply to review comment. `--pr N` is REQUIRED for numeric comment IDs; thread `PRRT_...` IDs need no PR number. Prefer `--body-file` for Markdown with backticks; inline body is safe only for plain strings. |
 | `post-comment <PR> [body \| --body-file PATH]` | Post PR-level comment. Same body-file preference as `post-reply`. |
 | `find-comment <PR> --pattern <regex>` | Find comment by pattern/author |
 | `edit-comment <id> [body \| --body-file PATH]` | Edit existing comment. Same body-file preference as `post-reply`. |
 | `sticky-comment <PR> [--verdict\|--analysis\|--body]` | Get bot sticky comment. `--verdict`: quick pass/fail. `--analysis`: deep recommendation. |
 
 Most commands accept no PR number to auto-detect from the current branch.
+Exception: `post-reply` with a numeric comment ID never auto-detects — it
+requires an explicit `--pr <N>` (thread `PRRT_...` IDs need no PR number).
 
 ### Git HTTPS Auth Helper
 

--- a/skills/github/tests/post-reply-skill-docs.test.sh
+++ b/skills/github/tests/post-reply-skill-docs.test.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Docs regression tests for the post-reply routing-table row in SKILL.md
+# (vstack#545).
+#
+# post-reply.sh requires an explicit --pr <N> for numeric comment IDs
+# (vstack#528; behavior covered by post-reply-numeric-requires-pr.test.sh),
+# but the top-level command table in SKILL.md drifted and still advertised
+# `post-reply <id> [body | --body-file PATH]` with a blanket "auto-detect
+# from the current branch" note. These tests pin the SKILL.md synopsis and
+# the --help text to that contract so the docs can't drift again.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../.." && pwd)"
+SKILL_MD="$REPO_ROOT/skills/github/SKILL.md"
+POST_REPLY="$REPO_ROOT/skills/github/scripts/commands/post-reply.sh"
+
+PASS=0
+FAIL=0
+
+assert_contains() {
+  local got="$1" needle="$2" name="$3"
+  if [[ "$got" == *"$needle"* ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected to contain: %s\n        got:      %s\n' "$name" "$needle" "$got"
+  fi
+}
+
+assert_eq() {
+  local got="$1" want="$2" name="$3"
+  if [[ "$got" == "$want" ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$name" "$want" "$got"
+  fi
+}
+
+echo "=== post-reply SKILL.md synopsis matches --pr contract (vstack#545) ==="
+
+# 1. Exactly one post-reply row in the command routing table.
+row=$(grep '^| `post-reply ' "$SKILL_MD" || true)
+assert_eq "$(printf '%s\n' "$row" | grep -c .)" "1" "SKILL.md has exactly one post-reply routing row"
+
+# 2. The row's synopsis exposes --pr and both ID forms.
+assert_contains "$row" '--pr' "post-reply row synopsis mentions --pr"
+assert_contains "$row" 'PRRT_' "post-reply row distinguishes PRRT_... thread IDs"
+assert_contains "$row" 'numeric' "post-reply row distinguishes numeric comment IDs"
+
+# 3. The row states that --pr is required for numeric comment IDs.
+assert_contains "$row" 'REQUIRED for numeric' "post-reply row marks --pr REQUIRED for numeric IDs"
+
+# 4. The blanket auto-detect note carries the post-reply exception.
+autodetect=$(grep -A 2 'auto-detect from the current branch' "$SKILL_MD" || true)
+assert_contains "$autodetect" 'post-reply' "auto-detect note names the post-reply exception"
+assert_contains "$autodetect" '--pr' "auto-detect exception mentions --pr"
+
+# 5. The script's own --help still declares the same requirement, so the
+#    SKILL.md wording above stays pinned to a real contract.
+help_out=$("$POST_REPLY" --help)
+assert_contains "$help_out" 'required for numeric comment ID' "post-reply --help declares --pr required for numeric IDs"
+
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

The #528/#530 fix made `post-reply` require `--pr <N>` for numeric comment IDs, but the SKILL.md routing table and the branch auto-detect sentence never reflected it — agents following the synopsis hit the runtime error on hyprtrade PR 218 remediation.

## Changes

- Routing row now reads `post-reply <PRRT_...|numeric-id> [body | --body-file PATH] [--pr N]` with the requirement spelled out; wording grounded in `post-reply --help`.
- Auto-detect sentence gains the explicit post-reply numeric-ID exception.
- New docs regression test `post-reply-skill-docs.test.sh` (8 assertions) pins the SKILL.md row AND the script's help text so the table can't silently drift from the contract again.

All 10 github test files green.

Closes #545

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016s6ZSLTTRft6fH29wHn1TN