### PR TITLE
fix(#552,#553): activate --agent applies label; complete parses summary flags and rejects unknown args

### DIFF
--- a/skills/linear/README.md
+++ b/skills/linear/README.md
@@ -36,6 +36,10 @@ Read-only cache queries (`./scripts/linear.sh cache ...` except `cache attachmen
 
 Use `comments create ISSUE --body-file tmp/comment.md` for Markdown or multi-line comments. Inline `--body` is intended for short plain strings.
 
+Use `issues activate ISSUE --agent NAME` to claim an issue: it sets "In Progress" and applies the exclusive `agent:NAME` label in a single update (replacing any existing `agent:*` label), and fails without changing state when the label does not exist.
+
+Use `issues complete ISSUE --summary-file tmp/summary.md` (or `--summary "text"`) to post the completion summary comment and then transition to "Done". The comment is posted first, so a failed post leaves the issue state unchanged; unknown or trailing arguments are rejected before any mutation.
+
 Use `issues create --parent PROJ-42` to create a sub-issue. The command resolves the parent identifier to a UUID, sends `parentId` on create, and verifies the returned issue is linked. If Linear ignores the create-time parent, the command repairs the link with `issueUpdate`; if that cannot be verified, it exits nonzero.
 
 `issues bulk-update` applies each issue update independently. If one update fails after earlier items changed, the command emits a JSON summary with `partial: true`, per-issue success/error entries, and exits nonzero.

--- a/skills/linear/SKILL.md
+++ b/skills/linear/SKILL.md
@@ -39,7 +39,7 @@ CLI wrapper for Linear's GraphQL API with local cache, bulk operations, and stru
 
 | Resource | Actions |
 |----------|---------|
-| `issues` | list, get, create, update, children, list-relations, add-relation, remove-relation, bulk-get, bulk-update |
+| `issues` | list, get, create, update, children, list-relations, add-relation, remove-relation, bulk-get, bulk-update, activate (`--agent <name>` applies the exclusive `agent:<name>` label), block, unblock, complete (`--summary <text>` / `--summary-file <path>` post the completion comment before the Done transition), validate-completion |
 | `comments` | list, create (`--body` or `--body-file`) |
 | `projects` | list, get, create, update, list-dependencies, add-dependency, remove-dependency, post-update, list-updates |
 | `initiatives` | list, get, create, add-project |
@@ -139,6 +139,9 @@ sortOrder → sort_order  # Manual sort position
 - State names are case-sensitive and team-specific — verify with `linear.sh statuses list`
 - Available states: Backlog, Todo, In Progress, In Review, Done, Canceled (not "Cancelled")
 - `agent:*` labels are mutually exclusive (only one per issue)
+- `issues activate ISSUE --agent NAME` applies `agent:NAME` in the same update as the "In Progress" transition, replacing any existing `agent:*` label; it fails without changing state when the label does not exist
+- `issues complete ISSUE --summary-file PATH` posts the completion summary comment first and only then transitions to "Done"; a failed post leaves the state unchanged
+- `issues validate-completion` is a pre-merge check: session-root targets are expected in "In Progress"/"In Review" (Done fails `state_ok` — managed roots stay pre-merge until PR merge), while `--include-children-of` bundle children are expected in "Done"
 - `--labels` replaces the full issue-label set on update. Workflow callers must fetch current labels, compute the final set, validate against `cache labels list --format=safe`, then call update with the full final set.
 - `cache labels list --format=safe` returns issue labels with `id`, `name`, `team`, `parent`, and `is_group` so workflows can reject parent/group labels before mutation.
 - `issues bulk-update` is non-atomic. If one item fails after earlier updates succeeded, it emits a JSON summary with `partial: true`, per-issue results, and exits nonzero.

--- a/skills/linear/patterns/workflow-actions.md
+++ b/skills/linear/patterns/workflow-actions.md
@@ -17,8 +17,11 @@ For the underlying command syntax, use the main `linear` skill command docs firs
 scripts/linear.sh issues activate [ISSUE_ID] --agent [AGENT]
 scripts/linear.sh issues block [ISSUE_ID] --by [BLOCKER_ID] --reason "[REASON]"
 scripts/linear.sh issues unblock [ISSUE_ID]
+scripts/linear.sh issues complete [ISSUE_ID] --summary-file [SUMMARY_PATH]
 scripts/linear.sh issues update [ISSUE_ID] --state "Done"
 ```
+
+`activate --agent` applies the exclusive `agent:[AGENT]` label together with the "In Progress" transition and fails without changing state when the label does not exist. `complete` posts the completion summary comment before transitioning to "Done", so a failed post leaves the state unchanged.
 
 ## Cancel / Merge / Combine
 

--- a/skills/linear/scripts/commands/issues.sh
+++ b/skills/linear/scripts/commands/issues.sh
@@ -92,11 +92,12 @@ Actions:
   remove-relation Delete an issue relation
 
 Workflow Actions (composite operations for dev):
-  activate       Claim issue: set "In Progress"
+  activate       Claim issue: set "In Progress" (--agent applies agent:<name> label)
   block          Block issue: add label + relation + comment
   unblock        Unblock issue: remove label + comment
-  complete       Complete issue: set "Done"
-  validate-completion  Check state + summary (--include-children-of <ID> for bundles)
+  complete       Complete issue: post optional summary comment, then set "Done"
+  validate-completion  Pre-merge check: state + summary comment
+                 (--include-children-of <ID> for bundles)
 
 Output Formats (all query commands):
   --format=safe         Flat, null-safe array (DEFAULT)
@@ -171,6 +172,27 @@ Relation Options (add-relation):
   --related <id>        Mark as related
   --duplicate <id>      Mark as duplicate
 
+Activate Options:
+  --agent <name>        Apply the exclusive agent:<name> issue label together
+                        with the "In Progress" transition (replaces any existing
+                        agent:* label, preserves other labels). Fails without
+                        changing state when the label does not exist.
+
+Complete Options:
+  --summary <text>       Post a completion summary comment, then set "Done"
+  --summary-file <path>  Read the summary from a file (preferred for markdown)
+  The comment is posted BEFORE the state transition; if posting fails the issue
+  state is unchanged. Text lacking a "Completion Summary"/"Bundle Complete"
+  marker is prefixed with a "## Completion Summary" heading so
+  validate-completion detects it.
+
+Validate-Completion:
+  Pre-merge validation. Session-root issues (positional targets) are expected
+  in "In Progress" or "In Review" — "Done" fails state_ok because managed
+  session roots stay pre-merge until PR merge. Bundle children expanded via
+  --include-children-of are expected in "Done". Each issue must also have a
+  comment containing "Completion Summary" or "Bundle Complete".
+
 Examples:
   # Basic operations
   issues.sh list --label "backend" --state "Todo"
@@ -208,10 +230,11 @@ Examples:
   issues.sh bulk-get PROJ-184 PROJ-185 PROJ-186 PROJ-187    # Multiple issues with full details
 
   # Workflow actions (dev shortcuts)
-  issues.sh activate PROJ-42 --agent rust        # Claim issue for work
+  issues.sh activate PROJ-42 --agent rust        # In Progress + agent:rust label
   issues.sh block PROJ-42 --by PROJ-41 --reason "Need market data types first"
   issues.sh unblock PROJ-42                      # Resume after blocker resolved
   issues.sh complete PROJ-42                     # Mark done
+  issues.sh complete PROJ-42 --summary-file tmp/completion-summary-PROJ-42.md  # Summary comment, then done
   issues.sh validate-completion PROJ-42 --include-children-of PROJ-42  # Bundle validation
 
   # Bundle operations (single API call)
@@ -1996,6 +2019,9 @@ remove_relation() {
 
 # Activate an issue: set state to "In Progress"
 # Usage: activate_issue CC-XXX [--agent <name>]
+# --agent applies the exclusive agent:<name> issue label in the same
+# issueUpdate mutation as the state change. The label is validated before any
+# mutation, so an unknown agent fails without touching issue state.
 activate_issue() {
     local issue_id="$1"
     shift
@@ -2024,9 +2050,33 @@ activate_issue() {
         esac
     done
 
-    # Update state to In Progress
+    local final_labels=""
+    if [ -n "$agent" ]; then
+        local agent_label="agent:$agent"
+        # Fail before the state change when the agent label doesn't resolve —
+        # update_issue's own label handling is warn+skip, which would silently
+        # activate without the label.
+        local agent_label_id
+        if ! agent_label_id=$(resolve_label_id "$agent_label") || [ -z "$agent_label_id" ]; then
+            echo "{\"error\": \"Agent label not found: '$agent_label'. Issue state unchanged. Verify agent labels with 'linear.sh cache labels list --format=safe'.\"}" >&2
+            return 1
+        fi
+
+        # Agent labels are exclusive: replace any existing agent:* label and
+        # preserve all other labels (--labels replaces the full set).
+        local issue_result
+        issue_result=$(get_issue "$issue_id" --format=raw)
+        final_labels=$(echo "$issue_result" | jq -r --arg agent_label "$agent_label" \
+            '[.issue.labels.nodes[].name | select(startswith("agent:") | not)] + [$agent_label] | join(",")')
+    fi
+
+    # Update state to In Progress (single mutation carries the label set too)
     local update_result
-    update_result=$(update_issue "$issue_id" --state "In Progress")
+    if [ -n "$agent" ]; then
+        update_result=$(update_issue "$issue_id" --state "In Progress" --labels "$final_labels")
+    else
+        update_result=$(update_issue "$issue_id" --state "In Progress")
+    fi
     local update_success
     update_success=$(echo "$update_result" | jq -r '.success // false')
 
@@ -2037,7 +2087,11 @@ activate_issue() {
 
     local identifier
     identifier=$(echo "$update_result" | jq -r '.identifier // empty')
-    echo "{\"success\": true, \"identifier\": \"$identifier\", \"action\": \"activated\"}"
+    if [ -n "$agent" ]; then
+        echo "{\"success\": true, \"identifier\": \"$identifier\", \"action\": \"activated\", \"agent\": \"$agent\"}"
+    else
+        echo "{\"success\": true, \"identifier\": \"$identifier\", \"action\": \"activated\"}"
+    fi
 }
 
 # Block an issue: add blocked label, create blocked-by relation, post comment
@@ -2188,25 +2242,127 @@ unblock_issue() {
 }
 
 # Complete an issue: set state to "Done"
-# Usage: complete_issue CC-XXX
+# Usage: complete_issue CC-XXX [--summary <text> | --summary-file <path>]
+# The summary comment is posted BEFORE the state transition so a failed post
+# never yields a Done issue without a completion summary. Unknown or trailing
+# arguments are rejected before any mutation.
 complete_issue() {
     local issue_id="$1"
+    shift
+
+    local summary=""
+    local summary_file=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+        --summary)
+            if [[ -n "${2:-}" && ! "$2" =~ ^- ]]; then
+                summary="$2"
+                shift 2
+            else
+                echo '{"error": "--summary requires a text value"}' >&2
+                return 1
+            fi
+            ;;
+        --summary=*)
+            summary="${1#*=}"
+            if [ -z "$summary" ]; then
+                echo '{"error": "--summary requires a text value"}' >&2
+                return 1
+            fi
+            shift
+            ;;
+        --summary-file)
+            if [[ -n "${2:-}" && ! "$2" =~ ^- ]]; then
+                summary_file="$2"
+                shift 2
+            else
+                echo '{"error": "--summary-file requires a path argument"}' >&2
+                return 1
+            fi
+            ;;
+        --summary-file=*)
+            summary_file="${1#*=}"
+            if [ -z "$summary_file" ]; then
+                echo '{"error": "--summary-file requires a path argument"}' >&2
+                return 1
+            fi
+            shift
+            ;;
+        -*)
+            echo "{\"error\": \"Unknown option: $1. Usage: issues.sh complete <issue-id> [--summary <text> | --summary-file <path>]\"}" >&2
+            return 1
+            ;;
+        *)
+            echo "{\"error\": \"Unexpected argument: $1. Usage: issues.sh complete <issue-id> [--summary <text> | --summary-file <path>]\"}" >&2
+            return 1
+            ;;
+        esac
+    done
+
+    if [[ -n "$summary" && -n "$summary_file" ]]; then
+        echo '{"error": "--summary and --summary-file are mutually exclusive"}' >&2
+        return 1
+    fi
+    if [[ -n "$summary_file" ]]; then
+        if [[ ! -r "$summary_file" ]]; then
+            echo "{\"error\": \"--summary-file path not readable: $summary_file\"}" >&2
+            return 1
+        fi
+        summary=$(<"$summary_file")
+        if [ -z "$summary" ]; then
+            echo "{\"error\": \"--summary-file is empty: $summary_file\"}" >&2
+            return 1
+        fi
+    fi
+
+    if [ -n "$summary" ]; then
+        # validate-completion detects the summary by these markers; prefix the
+        # canonical heading when the caller's text carries neither.
+        if [[ "$summary" != *"Completion Summary"* && "$summary" != *"Bundle Complete"* ]]; then
+            summary="## Completion Summary"$'\n\n'"$summary"
+        fi
+
+        # Post the comment first: a posting failure must leave state unchanged
+        local comment_result=""
+        local comment_rc=0
+        set +e
+        comment_result=$("$SCRIPT_DIR/comments.sh" create "$issue_id" --body "$summary")
+        comment_rc=$?
+        set -e
+        if [ "$comment_rc" -ne 0 ] || [ "$(echo "$comment_result" | jq -r '.success // false')" != "true" ]; then
+            echo "{\"error\": \"Completion summary comment failed for $issue_id. Issue state unchanged.\"}" >&2
+            return 1
+        fi
+    fi
 
     local update_result
+    local update_rc=0
+    set +e
     update_result=$(update_issue "$issue_id" --state "Done")
+    update_rc=$?
+    set -e
 
     local update_success
     update_success=$(echo "$update_result" | jq -r '.success // false')
 
-    if [ "$update_success" != "true" ]; then
-        echo "$update_result"
+    if [ "$update_rc" -ne 0 ] || [ "$update_success" != "true" ]; then
+        if [ -n "$summary" ]; then
+            echo "{\"error\": \"State transition to Done failed after the summary comment was posted. Rerun 'issues.sh complete $issue_id' without summary flags to avoid a duplicate comment.\"}" >&2
+        fi
+        if [ -n "$update_result" ]; then
+            echo "$update_result"
+        fi
         return 1
     fi
 
     # Return result
     local identifier
     identifier=$(echo "$update_result" | jq -r '.identifier // empty')
-    echo "{\"success\": true, \"identifier\": \"$identifier\", \"action\": \"completed\"}"
+    if [ -n "$summary" ]; then
+        echo "{\"success\": true, \"identifier\": \"$identifier\", \"action\": \"completed\", \"summary_posted\": true}"
+    else
+        echo "{\"success\": true, \"identifier\": \"$identifier\", \"action\": \"completed\"}"
+    fi
 }
 
 # Validate issue completion: check state is "In Progress" and has Completion Summary comment

--- a/skills/linear/tests/issues-activate-agent.test.sh
+++ b/skills/linear/tests/issues-activate-agent.test.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Regression test for #552: issues activate --agent must apply the exclusive
+# agent:<name> label (same issueUpdate as the state change) or fail loudly
+# before any state change when the label does not exist.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+mkdir -p "$TMP_ROOT/.agents/skills" "$TMP_ROOT/bin"
+cp -R "$SKILL_DIR" "$TMP_ROOT/.agents/skills/linear"
+
+cat >"$TMP_ROOT/bin/curl" <<'SH'
+#!/usr/bin/env bash
+config="$(cat)"
+payload="$(sed -n 's/^data = //p' <<<"$config" | jq -r)"
+query="$(jq -r '.query' <<<"$payload")"
+variables="$(jq -c '.variables' <<<"$payload")"
+printf '%s\n' "$payload" >> "${CURL_PAYLOAD_LOG:?}"
+
+case "$query" in
+*"issueLabels(filter:"*)
+  case "$(jq -r '.name' <<<"$variables")" in
+  "agent:rust")
+    printf '%s' '{"data":{"issueLabels":{"nodes":[{"id":"label-agent-rust"}]}}}___HTTP_CODE___200'
+    ;;
+  "backend")
+    printf '%s' '{"data":{"issueLabels":{"nodes":[{"id":"label-backend"}]}}}___HTTP_CODE___200'
+    ;;
+  *)
+    printf '%s' '{"data":{"issueLabels":{"nodes":[]}}}___HTTP_CODE___200'
+    ;;
+  esac
+  ;;
+*"teams(filter:"*)
+  printf '%s' '{"data":{"teams":{"nodes":[{"id":"team-uuid"}]}}}___HTTP_CODE___200'
+  ;;
+*"workflowStates(filter:"*)
+  printf '%s' '{"data":{"workflowStates":{"nodes":[{"id":"state-in-progress"}]}}}___HTTP_CODE___200'
+  ;;
+*"issue(id:"*)
+  printf '%s' '{"data":{"issue":{"id":"issue-uuid","identifier":"CC-760","title":"t","description":null,"state":{"name":"Todo","type":"unstarted"},"assignee":null,"project":null,"projectMilestone":null,"cycle":null,"team":{"name":"Claude"},"labels":{"nodes":[{"name":"agent:old"},{"name":"backend"}]},"priority":3,"estimate":null,"sortOrder":1.0,"url":"https://linear.app/test/issue/CC-760","branchName":"cc-760","createdAt":"2026-07-14T00:00:00Z","updatedAt":"2026-07-14T00:00:00Z","archivedAt":null,"trashed":null,"parent":null,"children":{"nodes":[]},"relations":{"nodes":[]},"inverseRelations":{"nodes":[]}}}}___HTTP_CODE___200'
+  ;;
+*"issueUpdate(id:"*)
+  printf '%s' '{"data":{"issueUpdate":{"success":true,"issue":{"id":"issue-uuid","identifier":"CC-760","title":"t","description":null,"state":{"name":"In Progress","type":"started"},"assignee":null,"project":null,"projectMilestone":null,"cycle":null,"parent":null,"team":{"name":"Claude"},"labels":{"nodes":[{"name":"backend"},{"name":"agent:rust"}]},"priority":3,"estimate":null,"sortOrder":1.0,"url":"https://linear.app/test/issue/CC-760","createdAt":"2026-07-14T00:00:00Z","updatedAt":"2026-07-14T00:00:01Z","archivedAt":null,"trashed":null,"relations":{"nodes":[]},"inverseRelations":{"nodes":[]}}}}}___HTTP_CODE___200'
+  ;;
+*)
+  printf '%s' '{"errors":[{"message":"unexpected query"}]}___HTTP_CODE___200'
+  ;;
+esac
+SH
+chmod +x "$TMP_ROOT/bin/curl"
+
+run_activate() {
+  local payload_log="$1"
+  shift
+  : >"$payload_log"
+  PATH="$TMP_ROOT/bin:$PATH" \
+    LINEAR_API_KEY=test-token \
+    CURL_PAYLOAD_LOG="$payload_log" \
+    bash "$TMP_ROOT/.agents/skills/linear/scripts/linear.sh" issues activate "$@"
+}
+
+# --- activate --agent applies the label in the same issueUpdate as the state change
+agent_payload="$TMP_ROOT/agent-payloads.jsonl"
+out="$(run_activate "$agent_payload" CC-760 --agent rust 2>"$TMP_ROOT/agent.err")"
+
+if ! jq -e '.success == true and .action == "activated" and .agent == "rust"' >/dev/null <<<"$out"; then
+  echo "FAIL activate --agent returned unexpected output: $out"
+  exit 1
+fi
+
+if ! jq -s -e 'any(.[]; (.query | contains("issueUpdate"))
+    and .variables.input.stateId == "state-in-progress"
+    and .variables.input.labelIds == ["label-backend", "label-agent-rust"])' "$agent_payload" >/dev/null; then
+  echo "FAIL issueUpdate did not carry state + replaced agent label set in one mutation"
+  cat "$agent_payload"
+  exit 1
+fi
+
+if [[ "$(jq -s '[.[] | select(.query | contains("issueUpdate"))] | length' "$agent_payload")" != "1" ]]; then
+  echo "FAIL expected exactly one issueUpdate mutation"
+  cat "$agent_payload"
+  exit 1
+fi
+
+# --- unknown agent fails before any state change
+bogus_payload="$TMP_ROOT/bogus-payloads.jsonl"
+set +e
+run_activate "$bogus_payload" CC-760 --agent bogus >"$TMP_ROOT/bogus.out" 2>"$TMP_ROOT/bogus.err"
+rc=$?
+set -e
+if [[ "$rc" -eq 0 ]]; then
+  echo "FAIL activate --agent bogus unexpectedly succeeded"
+  cat "$TMP_ROOT/bogus.out"
+  exit 1
+fi
+if ! grep -q "Agent label not found: 'agent:bogus'" "$TMP_ROOT/bogus.err"; then
+  echo "FAIL missing clear error for unknown agent label"
+  cat "$TMP_ROOT/bogus.err"
+  exit 1
+fi
+if jq -s -e 'any(.[]; .query | contains("issueUpdate"))' "$bogus_payload" >/dev/null; then
+  echo "FAIL unknown agent label still mutated issue state"
+  cat "$bogus_payload"
+  exit 1
+fi
+
+# --- activate without --agent keeps prior behavior (state only, no labels touched)
+plain_payload="$TMP_ROOT/plain-payloads.jsonl"
+out="$(run_activate "$plain_payload" CC-760 2>"$TMP_ROOT/plain.err")"
+if ! jq -e '.success == true and .action == "activated" and (has("agent") | not)' >/dev/null <<<"$out"; then
+  echo "FAIL plain activate returned unexpected output: $out"
+  exit 1
+fi
+if ! jq -s -e 'any(.[]; (.query | contains("issueUpdate"))
+    and .variables.input.stateId == "state-in-progress"
+    and (.variables.input | has("labelIds") | not))' "$plain_payload" >/dev/null; then
+  echo "FAIL plain activate should not send labelIds"
+  cat "$plain_payload"
+  exit 1
+fi
+
+echo "all pass"

--- a/skills/linear/tests/issues-complete-summary.test.sh
+++ b/skills/linear/tests/issues-complete-summary.test.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# Regression test for #553: issues complete must parse --summary/--summary-file
+# (post the completion comment BEFORE transitioning to Done) and reject unknown
+# or trailing arguments before any mutation.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+mkdir -p "$TMP_ROOT/.agents/skills" "$TMP_ROOT/bin"
+cp -R "$SKILL_DIR" "$TMP_ROOT/.agents/skills/linear"
+
+cat >"$TMP_ROOT/bin/curl" <<'SH'
+#!/usr/bin/env bash
+config="$(cat)"
+payload="$(sed -n 's/^data = //p' <<<"$config" | jq -r)"
+query="$(jq -r '.query' <<<"$payload")"
+scenario="${LINEAR_COMPLETE_TEST_CASE:-ok}"
+printf '%s\n' "$payload" >> "${CURL_PAYLOAD_LOG:?}"
+
+case "$query" in
+*"commentCreate(input:"*)
+  if [[ "$scenario" == "comment-fail" ]]; then
+    printf '%s' '{"errors":[{"message":"comment rejected"}]}___HTTP_CODE___200'
+  else
+    printf '%s' '{"data":{"commentCreate":{"success":true,"comment":{"id":"comment-1","body":"ok","createdAt":"2026-07-14T00:00:00Z","updatedAt":"2026-07-14T00:00:00Z","user":{"name":"Test"},"issue":{"identifier":"CC-720","updatedAt":"2026-07-14T00:00:00Z"}}}}}___HTTP_CODE___200'
+  fi
+  ;;
+*"teams(filter:"*)
+  printf '%s' '{"data":{"teams":{"nodes":[{"id":"team-uuid"}]}}}___HTTP_CODE___200'
+  ;;
+*"workflowStates(filter:"*)
+  printf '%s' '{"data":{"workflowStates":{"nodes":[{"id":"state-done"}]}}}___HTTP_CODE___200'
+  ;;
+*"issue(id:"*)
+  printf '%s' '{"data":{"issue":{"id":"issue-uuid","identifier":"CC-720","title":"t","description":null,"state":{"name":"In Review","type":"started"},"assignee":null,"project":null,"projectMilestone":null,"cycle":null,"team":{"name":"Claude"},"labels":{"nodes":[{"name":"backend"}]},"priority":3,"estimate":null,"sortOrder":1.0,"url":"https://linear.app/test/issue/CC-720","branchName":"cc-720","createdAt":"2026-07-14T00:00:00Z","updatedAt":"2026-07-14T00:00:00Z","archivedAt":null,"trashed":null,"parent":null,"children":{"nodes":[]},"relations":{"nodes":[]},"inverseRelations":{"nodes":[]}}}}___HTTP_CODE___200'
+  ;;
+*"issueUpdate(id:"*)
+  printf '%s' '{"data":{"issueUpdate":{"success":true,"issue":{"id":"issue-uuid","identifier":"CC-720","title":"t","description":null,"state":{"name":"Done","type":"completed"},"assignee":null,"project":null,"projectMilestone":null,"cycle":null,"parent":null,"team":{"name":"Claude"},"labels":{"nodes":[{"name":"backend"}]},"priority":3,"estimate":null,"sortOrder":1.0,"url":"https://linear.app/test/issue/CC-720","createdAt":"2026-07-14T00:00:00Z","updatedAt":"2026-07-14T00:00:01Z","archivedAt":null,"trashed":null,"relations":{"nodes":[]},"inverseRelations":{"nodes":[]}}}}}___HTTP_CODE___200'
+  ;;
+*)
+  printf '%s' '{"errors":[{"message":"unexpected query"}]}___HTTP_CODE___200'
+  ;;
+esac
+SH
+chmod +x "$TMP_ROOT/bin/curl"
+
+run_complete() {
+  local scenario="$1"
+  local payload_log="$2"
+  shift 2
+  : >"$payload_log"
+  PATH="$TMP_ROOT/bin:$PATH" \
+    LINEAR_API_KEY=test-token \
+    CURL_PAYLOAD_LOG="$payload_log" \
+    LINEAR_COMPLETE_TEST_CASE="$scenario" \
+    bash "$TMP_ROOT/.agents/skills/linear/scripts/linear.sh" issues complete "$@"
+}
+
+# --- --summary-file posts the canonical comment, then transitions
+summary_file="$TMP_ROOT/summary.md"
+cat >"$summary_file" <<'MD'
+## Completion Summary
+
+**Agent**: rust
+
+Implemented the thing.
+MD
+
+file_payload="$TMP_ROOT/file-payloads.jsonl"
+out="$(run_complete ok "$file_payload" CC-720 --summary-file "$summary_file" 2>"$TMP_ROOT/file.err")"
+
+if ! jq -e '.success == true and .action == "completed" and .summary_posted == true' >/dev/null <<<"$out"; then
+  echo "FAIL complete --summary-file returned unexpected output: $out"
+  exit 1
+fi
+
+posted_body="$(jq -s -r '[.[] | select(.query | contains("commentCreate"))][0].variables.input.body' "$file_payload")"
+if [[ "$posted_body" != *"## Completion Summary"* || "$posted_body" != *"Implemented the thing."* ]]; then
+  echo "FAIL posted comment did not carry the summary file content: $posted_body"
+  exit 1
+fi
+if [[ "$posted_body" == *"Completion Summary"*"## Completion Summary"* ]]; then
+  echo "FAIL summary already carrying the marker was double-prefixed: $posted_body"
+  exit 1
+fi
+
+comment_idx="$(jq -s '[to_entries[] | select(.value.query | contains("commentCreate"))][0].key' "$file_payload")"
+update_idx="$(jq -s '[to_entries[] | select(.value.query | contains("issueUpdate"))][0].key' "$file_payload")"
+if [[ "$comment_idx" == "null" || "$update_idx" == "null" || "$comment_idx" -ge "$update_idx" ]]; then
+  echo "FAIL comment post must precede the Done transition (comment=$comment_idx update=$update_idx)"
+  cat "$file_payload"
+  exit 1
+fi
+if ! jq -s -e 'any(.[]; (.query | contains("issueUpdate")) and .variables.input.stateId == "state-done")' "$file_payload" >/dev/null; then
+  echo "FAIL issueUpdate did not target the Done state"
+  cat "$file_payload"
+  exit 1
+fi
+
+# --- inline --summary without a marker gets the canonical heading prefixed
+inline_payload="$TMP_ROOT/inline-payloads.jsonl"
+out="$(run_complete ok "$inline_payload" CC-720 --summary "Shipped it" 2>"$TMP_ROOT/inline.err")"
+if ! jq -e '.success == true and .summary_posted == true' >/dev/null <<<"$out"; then
+  echo "FAIL complete --summary returned unexpected output: $out"
+  exit 1
+fi
+inline_body="$(jq -s -r '[.[] | select(.query | contains("commentCreate"))][0].variables.input.body' "$inline_payload")"
+if [[ "$inline_body" != "## Completion Summary"$'\n\n'"Shipped it" ]]; then
+  echo "FAIL inline summary was not prefixed with the canonical heading: $inline_body"
+  exit 1
+fi
+
+# --- a failed comment post leaves the issue state unchanged
+fail_payload="$TMP_ROOT/fail-payloads.jsonl"
+set +e
+run_complete comment-fail "$fail_payload" CC-720 --summary "Shipped it" >"$TMP_ROOT/fail.out" 2>"$TMP_ROOT/fail.err"
+rc=$?
+set -e
+if [[ "$rc" -eq 0 ]]; then
+  echo "FAIL complete with failing comment post unexpectedly succeeded"
+  cat "$TMP_ROOT/fail.out"
+  exit 1
+fi
+if ! grep -q "Completion summary comment failed" "$TMP_ROOT/fail.err"; then
+  echo "FAIL missing clear error for failed summary comment"
+  cat "$TMP_ROOT/fail.err"
+  exit 1
+fi
+if jq -s -e 'any(.[]; .query | contains("issueUpdate"))' "$fail_payload" >/dev/null; then
+  echo "FAIL issue was transitioned despite failed summary comment"
+  cat "$fail_payload"
+  exit 1
+fi
+
+# --- unknown/trailing arguments are rejected before any mutation
+assert_rejected() {
+  local expected="$1"
+  shift
+  local payload_log="$TMP_ROOT/reject-payloads.jsonl"
+  set +e
+  run_complete ok "$payload_log" "$@" >"$TMP_ROOT/reject.out" 2>"$TMP_ROOT/reject.err"
+  local rc=$?
+  set -e
+  if [[ "$rc" -eq 0 ]]; then
+    echo "FAIL complete $* unexpectedly succeeded"
+    cat "$TMP_ROOT/reject.out"
+    exit 1
+  fi
+  if ! grep -q "$expected" "$TMP_ROOT/reject.err"; then
+    echo "FAIL complete $* missing expected error: $expected"
+    cat "$TMP_ROOT/reject.err"
+    exit 1
+  fi
+  if [[ -s "$payload_log" ]]; then
+    echo "FAIL complete $* reached the API before argument rejection"
+    cat "$payload_log"
+    exit 1
+  fi
+}
+
+assert_rejected "Unexpected argument: stray" CC-720 stray
+assert_rejected "Unknown option: --sumary-file" CC-720 --sumary-file "$summary_file"
+assert_rejected "mutually exclusive" CC-720 --summary "x" --summary-file "$summary_file"
+assert_rejected "not readable" CC-720 --summary-file "$TMP_ROOT/does-not-exist.md"
+
+# --- plain complete keeps prior behavior (no comment, straight to Done)
+plain_payload="$TMP_ROOT/plain-payloads.jsonl"
+out="$(run_complete ok "$plain_payload" CC-720 2>"$TMP_ROOT/plain.err")"
+if ! jq -e '.success == true and .action == "completed" and (has("summary_posted") | not)' >/dev/null <<<"$out"; then
+  echo "FAIL plain complete returned unexpected output: $out"
+  exit 1
+fi
+if jq -s -e 'any(.[]; .query | contains("commentCreate"))' "$plain_payload" >/dev/null; then
+  echo "FAIL plain complete posted an unexpected comment"
+  cat "$plain_payload"
+  exit 1
+fi
+if ! jq -s -e 'any(.[]; (.query | contains("issueUpdate")) and .variables.input.stateId == "state-done")' "$plain_payload" >/dev/null; then
+  echo "FAIL plain complete did not transition to Done"
+  cat "$plain_payload"
+  exit 1
+fi
+
+echo "all pass"


### PR DESCRIPTION
## Summary

Two silent-success bugs in the linear skill's `issues.sh`:

- **#552**: `activate --agent X` parsed the flag into a variable and never used it — activation succeeded with no agent label.
- **#553**: `complete` accepted only the first positional; `--summary-file` (and any trailing args) were dropped silently while the issue still moved to Done, creating a state `validate-completion` rejects.

## Fixes

- **activate**: agent label resolved BEFORE any mutation (invalid agent → clear error, zero mutations); the exclusive `agent:<name>` label (replacing existing `agent:*`, preserving others) rides in the SAME issueUpdate mutation as the state change — API-level atomicity, asserted by test.
- **complete**: `--summary`/`--summary-file` post the canonical completion comment (auto-prefixed with `## Completion Summary` when the validate-completion marker is absent) BEFORE the Done transition — failed post leaves state untouched. Every unknown flag and trailing positional is rejected with usage before any API call.
- Help/docs: new flags documented; `validate-completion` help now states the verified lifecycle (session roots pre-merge expect In Progress/In Review, Done fails state_ok; bundle children expect Done).

2 new stub-convention test files; all 12 linear test files green.

Closes #552
Closes #553

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016s6ZSLTTRft6fH29wHn1TN