### PR TITLE
docs: note the intentional parent_issue/blocked_issues coincidence in the audit schema

### DIFF
--- a/skills/project-management/schemas/audit-issues-input.md
+++ b/skills/project-management/schemas/audit-issues-input.md
@@ -79,7 +79,11 @@ Input file for issue audit workflows — transforms review agent findings into t
 
 ## Hierarchy Contract
 
-`hierarchy_contract` is a **binding directive, not a hint**. `parent_issue` and `blocked_issues` alone are hints the TPM may override with per-item analysis; when `hierarchy_contract` is present, placement for the covered items is fixed by the producer, and the TPM's ordinary duplicate/hierarchy inference is bypassed for those items (tpm-audit.md § 7.0 and § 10.2).
+`hierarchy_contract` is a **binding directive, not a hint**. In
+`decompose-under-parent` mode, `parent_issue` is normally the blocked
+implementation issue itself — the same identifier appears in `blocked_issues`,
+as in the example above — because research-complete § 6.5 converts that blocked
+issue into the coordination-only parent of the new domain children. `parent_issue` and `blocked_issues` alone are hints the TPM may override with per-item analysis; when `hierarchy_contract` is present, placement for the covered items is fixed by the producer, and the TPM's ordinary duplicate/hierarchy inference is bypassed for those items (tpm-audit.md § 7.0 and § 10.2).
 
 | Field | Required | Description |
 |-------|----------|-------------|


### PR DESCRIPTION
Greptile P2 on vanillagreencom/hyprtrade#246: the hierarchy-contract example uses the same identifier for `parent_issue` and `blocked_issues[0]`, which read like an error. It's by design — research-complete § 6.5 converts the blocked implementation issue into the coordination parent — and the § Hierarchy Contract section now says so explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016s6ZSLTTRft6fH29wHn1TN