### PR TITLE
fix(#557): self-consistent hierarchy guard remediation for nested relations

### DIFF
--- a/skills/linear/SKILL.md
+++ b/skills/linear/SKILL.md
@@ -125,6 +125,8 @@ sortOrder → sort_order  # Manual sort position
 | Issue A blocked by Issue B (both in Linear) | Relation: `--blocked-by` |
 | Issue blocked by external factor (vendor, license) | `blocked` label + comment |
 
+Blocking relations must connect peers of one bundle: same direct parent, or both top-level (and same project). An issue cannot block its own ancestor or descendant — the parent-child hierarchy already encodes that dependency; use `--related` for traceability. Rejections for cross-subtree pairs prescribe the valid pair at the level where the subtrees separate.
+
 ## Common Pitfalls
 
 | Option | Accepts | On failure |

--- a/skills/linear/patterns/workflow-actions.md
+++ b/skills/linear/patterns/workflow-actions.md
@@ -106,6 +106,8 @@ scripts/linear.sh issues remove-relation [ISSUE_ID] --blocked-by [OTHER_ID]
 scripts/linear.sh cache issues list-relations [ISSUE_ID]
 ```
 
+`--blocks`/`--blocked-by` are guarded: both issues must be in the same project, and a blocking relation must connect peers of one bundle — two issues with the same direct parent, or two top-level issues. An issue never blocks its own ancestor or descendant; the parent-child hierarchy already encodes that dependency (use `--related` for traceability). When a cross-subtree pair is rejected, the error prescribes the one replacement pair at the level where the subtrees separate (the children of the lowest common ancestor); the prescribed command is validated against the same rule, so it always passes.
+
 ## Priority Updates
 
 ```bash

--- a/skills/linear/scripts/commands/issues.sh
+++ b/skills/linear/scripts/commands/issues.sh
@@ -1811,25 +1811,26 @@ add_relation() {
         related_issue_uuid="$temp"
     fi
 
-    # Validation for blocking relations: same-project + blocking-level (no cross-bundle children)
+    # Validation for blocking relations: same-project + blocking-level rule
+    # (blocking relations connect peers of one bundle — see issue-validation.sh)
     if [ "$relation_type" = "blocks" ]; then
+        # Parent chain fetched 5 levels deep so the remediation can locate the
+        # lowest common ancestor of nested hierarchies.
         local validation_query='
         query ValidateBlocking($id1: String!, $id2: String!) {
-            issue1: issue(id: $id1) { identifier project { id name } parent { identifier } }
-            issue2: issue(id: $id2) { identifier project { id name } parent { identifier } }
+            issue1: issue(id: $id1) { identifier project { id name } parent { identifier parent { identifier parent { identifier parent { identifier parent { identifier } } } } } }
+            issue2: issue(id: $id2) { identifier project { id name } parent { identifier parent { identifier parent { identifier parent { identifier parent { identifier } } } } } }
         }'
         local validation_result
         validation_result=$(graphql_query "$validation_query" "{\"id1\": \"$issue_id\", \"id2\": \"$related_issue_uuid\"}")
 
-        local project1_id project2_id project1_name project2_name issue1_id issue2_id parent1_id parent2_id
+        local project1_id project2_id project1_name project2_name issue1_id issue2_id
         project1_id=$(echo "$validation_result" | jq -r '.issue1.project.id // empty')
         project2_id=$(echo "$validation_result" | jq -r '.issue2.project.id // empty')
         project1_name=$(echo "$validation_result" | jq -r '.issue1.project.name // "none"')
         project2_name=$(echo "$validation_result" | jq -r '.issue2.project.name // "none"')
         issue1_id=$(echo "$validation_result" | jq -r '.issue1.identifier')
         issue2_id=$(echo "$validation_result" | jq -r '.issue2.identifier')
-        parent1_id=$(echo "$validation_result" | jq -r '.issue1.parent.identifier // empty')
-        parent2_id=$(echo "$validation_result" | jq -r '.issue2.parent.identifier // empty')
 
         # Check 1: Same-project
         if [ "$project1_id" != "$project2_id" ]; then
@@ -1837,21 +1838,22 @@ add_relation() {
             return 1
         fi
 
-        # Check 2: Blocking-level rule — children must not block outside their bundle
+        # Check 2: Blocking-level rule — a blocking relation connects peers of
+        # one bundle: same direct parent, or both top-level. The rejection
+        # message derives its remediation from the same predicate
+        # (blocking_level_ok), so a prescribed command is never itself rejected.
         # issue1 = blocker (from), issue2 = blocked (to)
-        if [ -n "$parent1_id" ] || [ -n "$parent2_id" ]; then
-            # Both are children under the same parent → intra-bundle, allowed
-            if [ -n "$parent1_id" ] && [ -n "$parent2_id" ] && [ "$parent1_id" = "$parent2_id" ]; then
-                : # valid intra-bundle relation
-            # Blocker is a child, blocked is outside that bundle
-            elif [ -n "$parent1_id" ] && [ "$parent1_id" != "$issue2_id" ]; then
-                echo "{\"error\": \"Blocking-level violation: $issue1_id is a child of $parent1_id and cannot block $issue2_id (outside its bundle). Use '$parent1_id --blocks $issue2_id' for the parent-level dependency, and '$issue1_id --related $issue2_id' for traceability.\"}" >&2
-                return 1
-            # Blocked is a child, blocker is outside that bundle
-            elif [ -n "$parent2_id" ] && [ "$parent2_id" != "$issue1_id" ]; then
-                echo "{\"error\": \"Blocking-level violation: $issue2_id is a child of $parent2_id and cannot be blocked by $issue1_id (outside its bundle). Use '$issue1_id --blocks $parent2_id' for the parent-level dependency, and '$issue1_id --related $issue2_id' for traceability.\"}" >&2
-                return 1
-            fi
+        local chain1 chain2 parent1_id parent2_id
+        chain1=$(echo "$validation_result" | jq -r '.issue1 | recurse(.parent; . != null) | .identifier')
+        chain2=$(echo "$validation_result" | jq -r '.issue2 | recurse(.parent; . != null) | .identifier')
+        parent1_id=$(sed -n '2p' <<<"$chain1")
+        parent2_id=$(sed -n '2p' <<<"$chain2")
+
+        if ! blocking_level_ok "$parent1_id" "$parent2_id"; then
+            local violation_message
+            violation_message=$(blocking_level_violation_message "$issue1_id" "$issue2_id" "$chain1" "$chain2")
+            echo "{\"error\": \"$violation_message\"}" >&2
+            return 1
         fi
     fi
 

--- a/skills/linear/scripts/lib/issue-validation.sh
+++ b/skills/linear/scripts/lib/issue-validation.sh
@@ -83,3 +83,100 @@ build_completion_validation_result() {
 		--argjson ok "$ok" \
 		'{id: $id, state: $state, state_ok: $state_ok, has_summary: $has_summary, ok: $ok}'
 }
+
+# --- Blocking-relation hierarchy guard (add-relation / block) ---
+#
+# Invariant: a blocking relation connects peers of one bundle — two issues
+# with the SAME direct parent, or two top-level issues. An issue never blocks
+# its own ancestor or descendant: the parent-child hierarchy already encodes
+# that dependency. Cross-subtree dependencies are expressed at the level
+# where the subtrees separate (the children of the lowest common ancestor).
+#
+# Ancestor chains are newline-separated identifier lists, self first, root
+# last (e.g. "CC-766\nCC-763\nCC-761").
+
+# blocking_level_ok BLOCKER_PARENT BLOCKED_PARENT
+# The single acceptance predicate for the blocking-level rule. Both the guard
+# and the remediation generator use it, so a prescribed replacement command is
+# accepted by construction.
+blocking_level_ok() {
+	local p1="${1:-}" p2="${2:-}"
+
+	if [[ -z "$p1" && -z "$p2" ]]; then
+		return 0 # both top-level
+	fi
+	if [[ -n "$p1" && "$p1" == "$p2" ]]; then
+		return 0 # siblings under the same parent
+	fi
+	return 1
+}
+
+# hierarchy_chain_contains CHAIN ID — true when ID is an entry of CHAIN.
+hierarchy_chain_contains() {
+	local chain="$1" id="$2"
+	[[ -n "$id" ]] && grep -qxF "$id" <<<"$chain"
+}
+
+# hoist_to_lca_child CHAIN OTHER_CHAIN
+# Print two lines: the entry of CHAIN whose parent is the lowest common
+# ancestor of both chains (the subtree root where the chains separate), then
+# that entry's parent (empty line when the entry is a root, i.e. the chains
+# share no ancestor). Callers must have excluded ancestor/descendant pairs.
+hoist_to_lca_child() {
+	local chain="$1" other="$2"
+	local -a entries=()
+	mapfile -t entries <<<"$chain"
+
+	local i parent
+	for ((i = 0; i < ${#entries[@]}; i++)); do
+		parent="${entries[i + 1]:-}"
+		if [[ -z "$parent" ]] || hierarchy_chain_contains "$other" "$parent"; then
+			printf '%s\n%s\n' "${entries[i]}" "$parent"
+			return 0
+		fi
+	done
+}
+
+# blocking_level_violation_message BLOCKER BLOCKED CHAIN1 CHAIN2
+# Compose the plain-text rejection message for a blocking-level violation.
+# Ancestor/descendant pairs get a single explanation (no replacement command
+# exists). Cross-subtree pairs get the one hoisted pair that satisfies
+# blocking_level_ok; the candidate is re-checked through that same predicate
+# before it is printed, so the prescription is never itself rejected.
+blocking_level_violation_message() {
+	local blocker="$1" blocked="$2" chain1="$3" chain2="$4"
+
+	if [[ "$blocker" == "$blocked" ]]; then
+		printf 'Hierarchy violation: %s cannot block itself.' "$blocker"
+		return 0
+	fi
+
+	local ancestor="" descendant=""
+	if hierarchy_chain_contains "$chain1" "$blocked"; then
+		ancestor="$blocked" descendant="$blocker"
+	elif hierarchy_chain_contains "$chain2" "$blocker"; then
+		ancestor="$blocker" descendant="$blocked"
+	fi
+	if [[ -n "$ancestor" ]]; then
+		printf 'Hierarchy violation: %s is an ancestor of %s — an issue cannot carry a blocking relation against its own ancestor; the parent-child hierarchy already encodes that dependency. No relation is needed while %s stays under %s; use '\''%s --related %s'\'' for traceability. A true sequencing gate belongs between sibling issues at the level that owns the ordering.' \
+			"$ancestor" "$descendant" "$descendant" "$ancestor" "$descendant" "$ancestor"
+		return 0
+	fi
+
+	local -a hoist1=() hoist2=()
+	mapfile -t hoist1 < <(hoist_to_lca_child "$chain1" "$chain2")
+	mapfile -t hoist2 < <(hoist_to_lca_child "$chain2" "$chain1")
+	local cand1="${hoist1[0]:-}" cand1_parent="${hoist1[1]:-}"
+	local cand2="${hoist2[0]:-}" cand2_parent="${hoist2[1]:-}"
+
+	if [[ -n "$cand1" && -n "$cand2" && "$cand1" != "$cand2" ]] \
+		&& blocking_level_ok "$cand1_parent" "$cand2_parent"; then
+		printf 'Blocking-level violation: %s and %s sit in different bundles; a blocking relation must connect peers of one bundle (same direct parent, or both top-level). Express the dependency where the subtrees separate: use '\''%s --blocks %s'\'', and '\''%s --related %s'\'' for traceability.' \
+			"$blocker" "$blocked" "$cand1" "$cand2" "$blocker" "$blocked"
+		return 0
+	fi
+
+	# Defensive fallback: no candidate satisfies the guard's own predicate.
+	printf 'Blocking-level violation: %s and %s sit in different bundles; a blocking relation must connect peers of one bundle (same direct parent, or both top-level). No replacement pair satisfies the rule; restructure the hierarchy or use '\''%s --related %s'\'' for traceability.' \
+		"$blocker" "$blocked" "$blocker" "$blocked"
+}

--- a/skills/linear/tests/issues-add-relation-hierarchy.test.sh
+++ b/skills/linear/tests/issues-add-relation-hierarchy.test.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# Regression test for #557: the add-relation blocking-level guard must emit
+# self-consistent remediation. Any command it prescribes must itself pass the
+# guard, and ancestor/descendant pairs get a single explanation instead of a
+# prescription (there is no valid replacement pair for them).
+#
+# Fixture hierarchy (all in project "Test"):
+#   CC-761 (root)
+#     ├── CC-763 ── CC-766, CC-768
+#     └── CC-764 ── CC-767
+#   CC-780 (root)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+mkdir -p "$TMP_ROOT/.agents/skills" "$TMP_ROOT/bin"
+cp -R "$SKILL_DIR" "$TMP_ROOT/.agents/skills/linear"
+
+cat >"$TMP_ROOT/bin/curl" <<'SH'
+#!/usr/bin/env bash
+config="$(cat)"
+payload="$(sed -n 's/^data = //p' <<<"$config" | jq -r)"
+query="$(jq -r '.query' <<<"$payload")"
+variables="$(jq -c '.variables' <<<"$payload")"
+printf '%s\n' "$payload" >> "${CURL_PAYLOAD_LOG:?}"
+
+# identifier -> uuid used by the resolve query; validate/mutation see uuids
+uuid_for() { printf 'uuid-%s' "${1#CC-}"; }
+
+# Issue node with project + 5-level parent chain, as ValidateBlocking selects
+issue_node() {
+  local prj='"project":{"id":"proj-1","name":"Test"}'
+  case "$1" in
+  uuid-761) printf '{"identifier":"CC-761",%s,"parent":null}' "$prj" ;;
+  uuid-763) printf '{"identifier":"CC-763",%s,"parent":{"identifier":"CC-761","parent":null}}' "$prj" ;;
+  uuid-764) printf '{"identifier":"CC-764",%s,"parent":{"identifier":"CC-761","parent":null}}' "$prj" ;;
+  uuid-766) printf '{"identifier":"CC-766",%s,"parent":{"identifier":"CC-763","parent":{"identifier":"CC-761","parent":null}}}' "$prj" ;;
+  uuid-767) printf '{"identifier":"CC-767",%s,"parent":{"identifier":"CC-764","parent":{"identifier":"CC-761","parent":null}}}' "$prj" ;;
+  uuid-768) printf '{"identifier":"CC-768",%s,"parent":{"identifier":"CC-763","parent":{"identifier":"CC-761","parent":null}}}' "$prj" ;;
+  uuid-780) printf '{"identifier":"CC-780",%s,"parent":null}' "$prj" ;;
+  *) printf 'null' ;;
+  esac
+}
+
+case "$query" in
+*"ValidateBlocking"*)
+  id1="$(jq -r '.id1' <<<"$variables")"
+  id2="$(jq -r '.id2' <<<"$variables")"
+  printf '{"data":{"issue1":%s,"issue2":%s}}___HTTP_CODE___200' "$(issue_node "$id1")" "$(issue_node "$id2")"
+  ;;
+*"GetIssue"*)
+  ref="$(jq -r '.id' <<<"$variables")"
+  printf '{"data":{"issue":{"id":"%s"}}}___HTTP_CODE___200' "$(uuid_for "$ref")"
+  ;;
+*"issueRelationCreate"*)
+  printf '%s' '{"data":{"issueRelationCreate":{"success":true,"issueRelation":{"id":"rel-1","type":"blocks","issue":{"identifier":"CC-X","title":"t"},"relatedIssue":{"identifier":"CC-Y","title":"t"}}}}}___HTTP_CODE___200'
+  ;;
+*"RefreshIssues"*)
+  printf '%s' '{"data":{"issues":{"nodes":[]}}}___HTTP_CODE___200'
+  ;;
+*)
+  printf '%s' '{"errors":[{"message":"unexpected query"}]}___HTTP_CODE___200'
+  ;;
+esac
+SH
+chmod +x "$TMP_ROOT/bin/curl"
+
+run_add_relation() {
+  local payload_log="$1"
+  shift
+  : >"$payload_log"
+  PATH="$TMP_ROOT/bin:$PATH" \
+    LINEAR_API_KEY=test-token \
+    CURL_PAYLOAD_LOG="$payload_log" \
+    bash "$TMP_ROOT/.agents/skills/linear/scripts/linear.sh" issues add-relation "$@"
+}
+
+# Extract a prescribed replacement command ("use 'A --blocks B'") from stderr.
+# Prints "A B" or nothing.
+extract_prescription() {
+  sed -n "s/.*[Uu]se '\([A-Z][A-Z]*-[0-9][0-9]*\) --blocks \([A-Z][A-Z]*-[0-9][0-9]*\)'.*/\1 \2/p" "$1"
+}
+
+# A rejection must not have created the relation.
+assert_no_mutation() {
+  local payload_log="$1" label="$2"
+  if jq -s -e 'any(.[]; .query | contains("issueRelationCreate"))' "$payload_log" >/dev/null; then
+    echo "FAIL $label: rejected relation still sent issueRelationCreate"
+    cat "$payload_log"
+    exit 1
+  fi
+}
+
+# Rejected commands may only prescribe replacements the guard accepts: drive
+# every prescription back through the guard (issue #557 regression).
+assert_prescription_satisfiable() {
+  local err_file="$1" label="$2"
+  local prescription
+  prescription="$(extract_prescription "$err_file")"
+  [ -n "$prescription" ] || return 0
+  local from to
+  read -r from to <<<"$prescription"
+  if ! run_add_relation "$TMP_ROOT/prescription-payloads.jsonl" "$from" --blocks "$to" \
+    >"$TMP_ROOT/prescription.out" 2>"$TMP_ROOT/prescription.err"; then
+    echo "FAIL $label: prescribed command '$from --blocks $to' is itself rejected:"
+    cat "$TMP_ROOT/prescription.err"
+    exit 1
+  fi
+}
+
+reject() {
+  local label="$1"
+  shift
+  set +e
+  run_add_relation "$TMP_ROOT/payloads.jsonl" "$@" >"$TMP_ROOT/out" 2>"$TMP_ROOT/err"
+  local rc=$?
+  set -e
+  if [ "$rc" -eq 0 ]; then
+    echo "FAIL $label: expected rejection, got success"
+    cat "$TMP_ROOT/out"
+    exit 1
+  fi
+  assert_no_mutation "$TMP_ROOT/payloads.jsonl" "$label"
+  assert_prescription_satisfiable "$TMP_ROOT/err" "$label"
+}
+
+accept() {
+  local label="$1"
+  shift
+  if ! run_add_relation "$TMP_ROOT/payloads.jsonl" "$@" >"$TMP_ROOT/out" 2>"$TMP_ROOT/err"; then
+    echo "FAIL $label: expected acceptance, got rejection:"
+    cat "$TMP_ROOT/err"
+    exit 1
+  fi
+  if ! jq -s -e 'any(.[]; .query | contains("issueRelationCreate"))' "$TMP_ROOT/payloads.jsonl" >/dev/null; then
+    echo "FAIL $label: accepted relation never sent issueRelationCreate"
+    cat "$TMP_ROOT/payloads.jsonl"
+    exit 1
+  fi
+}
+
+# --- (b) ancestor/descendant pairs: one clear explanation, no prescription ---
+for args in "CC-766 --blocks CC-763" "CC-766 --blocks CC-761" "CC-761 --blocks CC-766" "CC-763 --blocked-by CC-766"; do
+  # shellcheck disable=SC2086
+  reject "ancestor case ($args)" $args
+  if ! grep -q "cannot carry a blocking relation against its own ancestor" "$TMP_ROOT/err"; then
+    echo "FAIL ancestor case ($args): missing ancestor explanation:"
+    cat "$TMP_ROOT/err"
+    exit 1
+  fi
+  if grep -q -- "--blocks" "$TMP_ROOT/err"; then
+    echo "FAIL ancestor case ($args): explanation must not prescribe a --blocks command:"
+    cat "$TMP_ROOT/err"
+    exit 1
+  fi
+  if [ "$(wc -l <"$TMP_ROOT/err")" -ne 1 ] || ! jq -e '.error' "$TMP_ROOT/err" >/dev/null; then
+    echo "FAIL ancestor case ($args): expected exactly one JSON error line:"
+    cat "$TMP_ROOT/err"
+    exit 1
+  fi
+done
+
+# --- (a)+(c) hoistable cases: the correct accepted pair is prescribed ---
+reject "cousins (CC-766 --blocks CC-767)" CC-766 --blocks CC-767
+if [ "$(extract_prescription "$TMP_ROOT/err")" != "CC-763 CC-764" ]; then
+  echo "FAIL cousins: expected prescription 'CC-763 --blocks CC-764', stderr:"
+  cat "$TMP_ROOT/err"
+  exit 1
+fi
+
+reject "depth mismatch (CC-766 --blocks CC-764)" CC-766 --blocks CC-764
+if [ "$(extract_prescription "$TMP_ROOT/err")" != "CC-763 CC-764" ]; then
+  echo "FAIL depth mismatch: expected prescription 'CC-763 --blocks CC-764', stderr:"
+  cat "$TMP_ROOT/err"
+  exit 1
+fi
+
+reject "different roots (CC-766 --blocks CC-780)" CC-766 --blocks CC-780
+if [ "$(extract_prescription "$TMP_ROOT/err")" != "CC-761 CC-780" ]; then
+  echo "FAIL different roots: expected prescription 'CC-761 --blocks CC-780', stderr:"
+  cat "$TMP_ROOT/err"
+  exit 1
+fi
+
+# --- (d) relations the rule blesses still pass ---
+accept "siblings (CC-763 --blocks CC-764)" CC-763 --blocks CC-764
+accept "leaf siblings (CC-766 --blocks CC-768)" CC-766 --blocks CC-768
+accept "top-level (CC-761 --blocks CC-780)" CC-761 --blocks CC-780
+accept "blocked-by siblings (CC-764 --blocked-by CC-763)" CC-764 --blocked-by CC-763
+
+echo "all pass"


### PR DESCRIPTION
## Summary

The add-relation hierarchy guard used an asymmetric elif chain with only one level of parent context — two branches applied two different hoisting rules, so a rejection's prescribed remediation was itself rejected with a different prescription (root → child → grandchild reproduction in #557).

## Fix

- Single acceptance predicate `blocking_level_ok` (both top-level, or same direct parent), matching the documented ecosystem contract (project-management dependencies.md, tpm-audit violation table).
- Remediation derived from the SAME predicate: 5-level ancestor chains per side; ancestor/descendant pairs get one clear explanation (hierarchy already encodes the dependency; use --related) and no command; hoistable pairs are lifted to the children of the lowest common ancestor and the candidate is re-checked through the predicate before printing — prescriptions are satisfiable by construction.
- **Behavior change**: direct child-blocks-its-own-parent (previously accepted by accident of the elif structure) is now rejected with the ancestor explanation, aligning the guard with the documented contract. `block --by` shares the path.
- New 195-line regression test drives every prescription back through the guard; covers all four ancestor shapes, cousins/depth-mismatch/different-root hoisting, and sibling/top-level acceptance. All 13 linear test files green.

Closes #557

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016s6ZSLTTRft6fH29wHn1TN