### PR TITLE
fix(#557): unbounded ancestor validation + Bash 3.2 portability

### DIFF
--- a/skills/linear/scripts/commands/issues.sh
+++ b/skills/linear/scripts/commands/issues.sh
@@ -1725,6 +1725,65 @@ list_relations() {
     esac
 }
 
+# Parent levels selected per ancestor query. A chain that comes back with
+# exactly this many parents may be cut off by the query depth rather than
+# rooted; extend_ancestor_chain keeps fetching until a short chunk proves a
+# true root (null parent).
+ANCESTOR_FETCH_DEPTH=5
+ANCESTOR_FETCH_MAX_CHUNKS=20
+
+# build_parent_selection DEPTH — nested GraphQL parent selection, DEPTH levels
+build_parent_selection() {
+    local depth="$1" selection="" i
+    for ((i = 0; i < depth; i++)); do
+        selection="parent { identifier $selection }"
+    done
+    printf '%s' "$selection"
+}
+
+# extend_ancestor_chain CHAIN
+# Complete a possibly-truncated ancestor chain (newline-separated identifiers,
+# self first). A chain shorter than ANCESTOR_FETCH_DEPTH+1 entries already
+# ends at a true root; a full-length chain may instead be cut off by the
+# query depth, so follow up with chunked ancestor queries for the deepest
+# entry until a chunk comes back short. Prints the completed chain. Fails
+# (error on stderr) when the hierarchy exceeds the chunk bound or a lookup
+# misbehaves — callers must treat failure as "do not derive remediation",
+# never as "chain is complete".
+extend_ancestor_chain() {
+    local chain="$1"
+    local full=$((ANCESTOR_FETCH_DEPTH + 1))
+    local chunks=0
+    local segment="$chain"
+    local deepest chunk_result rest
+
+    while [ "$(printf '%s\n' "$segment" | grep -c '')" -ge "$full" ]; do
+        chunks=$((chunks + 1))
+        if [ "$chunks" -gt "$ANCESTOR_FETCH_MAX_CHUNKS" ]; then
+            echo "{\"error\": \"Hierarchy too deep to validate: no root issue within $((ANCESTOR_FETCH_DEPTH + ANCESTOR_FETCH_MAX_CHUNKS * ANCESTOR_FETCH_DEPTH)) ancestor levels. Refusing to validate the blocking relation against a truncated ancestor chain.\"}" >&2
+            return 1
+        fi
+        deepest=$(printf '%s\n' "$chain" | tail -n 1)
+        local chunk_query="
+        query AncestorChunk(\$id: String!) {
+            issue(id: \$id) { identifier $(build_parent_selection "$ANCESTOR_FETCH_DEPTH") }
+        }"
+        chunk_result=$(graphql_query "$chunk_query" "{\"id\": \"$deepest\"}") || return 1
+        segment=$(echo "$chunk_result" | jq -r '.issue | recurse(.parent; . != null) | .identifier')
+        if [ "$(printf '%s\n' "$segment" | sed -n '1p')" != "$deepest" ]; then
+            echo "{\"error\": \"Ancestor lookup for $deepest returned an unexpected issue; refusing to validate the blocking relation against an incomplete ancestor chain.\"}" >&2
+            return 1
+        fi
+        rest=$(printf '%s\n' "$segment" | tail -n +2)
+        if [ -n "$rest" ]; then
+            chain="$chain
+$rest"
+        fi
+    done
+
+    printf '%s\n' "$chain"
+}
+
 add_relation() {
     local issue_ref="$1"
     shift
@@ -1814,13 +1873,15 @@ add_relation() {
     # Validation for blocking relations: same-project + blocking-level rule
     # (blocking relations connect peers of one bundle — see issue-validation.sh)
     if [ "$relation_type" = "blocks" ]; then
-        # Parent chain fetched 5 levels deep so the remediation can locate the
-        # lowest common ancestor of nested hierarchies.
-        local validation_query='
-        query ValidateBlocking($id1: String!, $id2: String!) {
-            issue1: issue(id: $id1) { identifier project { id name } parent { identifier parent { identifier parent { identifier parent { identifier parent { identifier } } } } } }
-            issue2: issue(id: $id2) { identifier project { id name } parent { identifier parent { identifier parent { identifier parent { identifier parent { identifier } } } } } }
-        }'
+        # The parent chain is fetched ANCESTOR_FETCH_DEPTH levels per query and
+        # extended chunk-by-chunk to a proven root when remediation needs it.
+        local ancestor_selection
+        ancestor_selection=$(build_parent_selection "$ANCESTOR_FETCH_DEPTH")
+        local validation_query="
+        query ValidateBlocking(\$id1: String!, \$id2: String!) {
+            issue1: issue(id: \$id1) { identifier project { id name } $ancestor_selection }
+            issue2: issue(id: \$id2) { identifier project { id name } $ancestor_selection }
+        }"
         local validation_result
         validation_result=$(graphql_query "$validation_query" "{\"id1\": \"$issue_id\", \"id2\": \"$related_issue_uuid\"}")
 
@@ -1850,9 +1911,17 @@ add_relation() {
         parent2_id=$(sed -n '2p' <<<"$chain2")
 
         if ! blocking_level_ok "$parent1_id" "$parent2_id"; then
+            # The accept/reject decision above only needs direct parents, which
+            # the initial fetch always covers. Remediation (ancestor detection,
+            # LCA hoisting) needs COMPLETE chains: extend both to a proven root
+            # first, and fail closed — reject without a derived prescription —
+            # when a full chain cannot be established.
             local violation_message
-            violation_message=$(blocking_level_violation_message "$issue1_id" "$issue2_id" "$chain1" "$chain2")
-            echo "{\"error\": \"$violation_message\"}" >&2
+            if chain1=$(extend_ancestor_chain "$chain1") \
+                && chain2=$(extend_ancestor_chain "$chain2"); then
+                violation_message=$(blocking_level_violation_message "$issue1_id" "$issue2_id" "$chain1" "$chain2")
+                echo "{\"error\": \"$violation_message\"}" >&2
+            fi
             return 1
         fi
     fi

--- a/skills/linear/scripts/lib/issue-validation.sh
+++ b/skills/linear/scripts/lib/issue-validation.sh
@@ -124,8 +124,12 @@ hierarchy_chain_contains() {
 # share no ancestor). Callers must have excluded ancestor/descendant pairs.
 hoist_to_lca_child() {
 	local chain="$1" other="$2"
+	# Bash 3.2 (macOS system bash) lacks the array-read builtin.
 	local -a entries=()
-	mapfile -t entries <<<"$chain"
+	local line
+	while IFS= read -r line; do
+		entries+=("$line")
+	done <<<"$chain"
 
 	local i parent
 	for ((i = 0; i < ${#entries[@]}; i++)); do
@@ -163,11 +167,16 @@ blocking_level_violation_message() {
 		return 0
 	fi
 
-	local -a hoist1=() hoist2=()
-	mapfile -t hoist1 < <(hoist_to_lca_child "$chain1" "$chain2")
-	mapfile -t hoist2 < <(hoist_to_lca_child "$chain2" "$chain1")
-	local cand1="${hoist1[0]:-}" cand1_parent="${hoist1[1]:-}"
-	local cand2="${hoist2[0]:-}" cand2_parent="${hoist2[1]:-}"
+	# hoist_to_lca_child prints "candidate\nparent"; command substitution
+	# strips the trailing newline of an empty parent line (Bash 3.2 compatible).
+	local hoist1 hoist2
+	hoist1=$(hoist_to_lca_child "$chain1" "$chain2")
+	hoist2=$(hoist_to_lca_child "$chain2" "$chain1")
+	local cand1 cand1_parent cand2 cand2_parent
+	cand1=$(sed -n '1p' <<<"$hoist1")
+	cand1_parent=$(sed -n '2p' <<<"$hoist1")
+	cand2=$(sed -n '1p' <<<"$hoist2")
+	cand2_parent=$(sed -n '2p' <<<"$hoist2")
 
 	if [[ -n "$cand1" && -n "$cand2" && "$cand1" != "$cand2" ]] \
 		&& blocking_level_ok "$cand1_parent" "$cand2_parent"; then

--- a/skills/linear/tests/bash32-portability.test.sh
+++ b/skills/linear/tests/bash32-portability.test.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Regression test for #557 (reopened): the skill's scripts run under
+# `#!/usr/bin/env bash` with no Bash 4 guarantee (macOS ships system Bash
+# 3.2), so Bash-4-only builtins and declarations must not appear in shell
+# code. jq programs may use their own [-1]/negative indexing — this scans
+# for shell constructs only.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+violations="$(grep -rnE 'mapfile|readarray|declare -A|local -A' \
+  "$SKILL_DIR/scripts/lib" "$SKILL_DIR/scripts/commands" || true)"
+
+if [ -n "$violations" ]; then
+  echo "FAIL Bash-4-only constructs found (macOS system bash is 3.2):"
+  echo "$violations"
+  exit 1
+fi
+
+echo "all pass"

--- a/skills/linear/tests/issues-add-relation-deep-hierarchy.test.sh
+++ b/skills/linear/tests/issues-add-relation-deep-hierarchy.test.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# Regression test for #557 (reopened): hierarchies deeper than the per-query
+# parent selection cap must not silently truncate ancestor chains. The stub
+# emulates the server's depth-capped responses, so the guard only sees the
+# full hierarchy if it issues follow-up AncestorChunk queries. Covers: an
+# ancestor pair beyond the cap, deep-but-valid siblings, deep cousins whose
+# LCA sits beyond the cap, and the fail-closed chunk bound.
+#
+# Fixture (project "Test"):
+#   CC-701 (root) <- CC-702 <- ... <- CC-707 <- CC-708, CC-709   (8 levels)
+#   CC-701 <- CC-751 <- CC-752 <- ... <- CC-757                  (second branch)
+#   CC-9000 (root) <- CC-9001 <- ... <- CC-9120                  (121 levels)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+mkdir -p "$TMP_ROOT/.agents/skills" "$TMP_ROOT/bin"
+cp -R "$SKILL_DIR" "$TMP_ROOT/.agents/skills/linear"
+
+cat >"$TMP_ROOT/bin/curl" <<'SH'
+#!/usr/bin/env bash
+config="$(cat)"
+payload="$(sed -n 's/^data = //p' <<<"$config" | jq -r)"
+query="$(jq -r '.query' <<<"$payload")"
+variables="$(jq -c '.variables' <<<"$payload")"
+printf '%s\n' "$payload" >> "${CURL_PAYLOAD_LOG:?}"
+
+to_identifier() {
+  case "$1" in
+  uuid-*) printf 'CC-%s' "${1#uuid-}" ;;
+  *) printf '%s' "$1" ;;
+  esac
+}
+
+parent_of() {
+  case "$1" in
+  CC-702) echo CC-701 ;; CC-703) echo CC-702 ;; CC-704) echo CC-703 ;;
+  CC-705) echo CC-704 ;; CC-706) echo CC-705 ;; CC-707) echo CC-706 ;;
+  CC-708) echo CC-707 ;; CC-709) echo CC-707 ;;
+  CC-751) echo CC-701 ;; CC-752) echo CC-751 ;; CC-753) echo CC-752 ;;
+  CC-754) echo CC-753 ;; CC-755) echo CC-754 ;; CC-756) echo CC-755 ;;
+  CC-757) echo CC-756 ;;
+  CC-9???)
+    local n="${1#CC-}"
+    if [ "$n" -gt 9000 ]; then printf 'CC-%d' "$((n - 1))"; fi
+    ;;
+  *) : ;;
+  esac
+}
+
+# Emulate the server honoring the query's parent selection depth: nest at most
+# DEPTH parent levels; beyond that the parent FIELD is absent (truncation),
+# while a real root within the depth gets an explicit "parent":null.
+# DEPTH must match ANCESTOR_FETCH_DEPTH in issues.sh.
+nested_issue() {
+  local id="$1" depth="$2" p
+  if [ "$depth" -eq 0 ]; then
+    printf '{"identifier":"%s"}' "$id"
+    return
+  fi
+  p="$(parent_of "$id")"
+  if [ -z "$p" ]; then
+    printf '{"identifier":"%s","parent":null}' "$id"
+  else
+    printf '{"identifier":"%s","parent":%s}' "$id" "$(nested_issue "$p" $((depth - 1)))"
+  fi
+}
+
+top_issue() {
+  nested_issue "$(to_identifier "$1")" 5 | jq -c '. + {project: {id: "proj-1", name: "Test"}}'
+}
+
+case "$query" in
+*"ValidateBlocking"*)
+  id1="$(jq -r '.id1' <<<"$variables")"
+  id2="$(jq -r '.id2' <<<"$variables")"
+  printf '{"data":{"issue1":%s,"issue2":%s}}___HTTP_CODE___200' "$(top_issue "$id1")" "$(top_issue "$id2")"
+  ;;
+*"AncestorChunk"*)
+  ref="$(to_identifier "$(jq -r '.id' <<<"$variables")")"
+  printf '{"data":{"issue":%s}}___HTTP_CODE___200' "$(nested_issue "$ref" 5)"
+  ;;
+*"GetIssue"*)
+  ref="$(jq -r '.id' <<<"$variables")"
+  printf '{"data":{"issue":{"id":"uuid-%s"}}}___HTTP_CODE___200' "${ref#CC-}"
+  ;;
+*"issueRelationCreate"*)
+  printf '%s' '{"data":{"issueRelationCreate":{"success":true,"issueRelation":{"id":"rel-1","type":"blocks","issue":{"identifier":"CC-X","title":"t"},"relatedIssue":{"identifier":"CC-Y","title":"t"}}}}}___HTTP_CODE___200'
+  ;;
+*"RefreshIssues"*)
+  printf '%s' '{"data":{"issues":{"nodes":[]}}}___HTTP_CODE___200'
+  ;;
+*)
+  printf '%s' '{"errors":[{"message":"unexpected query"}]}___HTTP_CODE___200'
+  ;;
+esac
+SH
+chmod +x "$TMP_ROOT/bin/curl"
+
+run_add_relation() {
+  local payload_log="$1"
+  shift
+  : >"$payload_log"
+  PATH="$TMP_ROOT/bin:$PATH" \
+    LINEAR_API_KEY=test-token \
+    CURL_PAYLOAD_LOG="$payload_log" \
+    bash "$TMP_ROOT/.agents/skills/linear/scripts/linear.sh" issues add-relation "$@"
+}
+
+extract_prescription() {
+  sed -n "s/.*[Uu]se '\([A-Z][A-Z]*-[0-9][0-9]*\) --blocks \([A-Z][A-Z]*-[0-9][0-9]*\)'.*/\1 \2/p" "$1"
+}
+
+# --- deep ancestor pair (root is beyond the per-query parent cap) ---
+for args in "CC-708 --blocks CC-701" "CC-701 --blocks CC-708"; do
+  set +e
+  # shellcheck disable=SC2086
+  run_add_relation "$TMP_ROOT/payloads.jsonl" $args >"$TMP_ROOT/out" 2>"$TMP_ROOT/err"
+  rc=$?
+  set -e
+  if [ "$rc" -eq 0 ]; then
+    echo "FAIL deep ancestor ($args): expected rejection, got success"
+    exit 1
+  fi
+  if ! grep -q "cannot carry a blocking relation against its own ancestor" "$TMP_ROOT/err"; then
+    echo "FAIL deep ancestor ($args): missing ancestor explanation:"
+    cat "$TMP_ROOT/err"
+    exit 1
+  fi
+  if grep -q -- "--blocks" "$TMP_ROOT/err"; then
+    echo "FAIL deep ancestor ($args): truncated chain produced a bogus prescription:"
+    cat "$TMP_ROOT/err"
+    exit 1
+  fi
+  if ! jq -s -e 'any(.[]; .query | contains("AncestorChunk"))' "$TMP_ROOT/payloads.jsonl" >/dev/null; then
+    echo "FAIL deep ancestor ($args): expected follow-up AncestorChunk queries"
+    cat "$TMP_ROOT/payloads.jsonl"
+    exit 1
+  fi
+done
+
+# --- deep-but-valid siblings: accepted, no follow-up ancestor queries needed ---
+if ! run_add_relation "$TMP_ROOT/payloads.jsonl" CC-708 --blocks CC-709 >"$TMP_ROOT/out" 2>"$TMP_ROOT/err"; then
+  echo "FAIL deep siblings: expected acceptance, got rejection:"
+  cat "$TMP_ROOT/err"
+  exit 1
+fi
+if ! jq -s -e 'any(.[]; .query | contains("issueRelationCreate"))' "$TMP_ROOT/payloads.jsonl" >/dev/null; then
+  echo "FAIL deep siblings: accepted relation never sent issueRelationCreate"
+  exit 1
+fi
+if jq -s -e 'any(.[]; .query | contains("AncestorChunk"))' "$TMP_ROOT/payloads.jsonl" >/dev/null; then
+  echo "FAIL deep siblings: accept path should not need AncestorChunk queries"
+  cat "$TMP_ROOT/payloads.jsonl"
+  exit 1
+fi
+
+# --- deep cousins: LCA beyond the cap; prescription must be the pair under it ---
+set +e
+run_add_relation "$TMP_ROOT/payloads.jsonl" CC-708 --blocks CC-757 >"$TMP_ROOT/out" 2>"$TMP_ROOT/err"
+rc=$?
+set -e
+if [ "$rc" -eq 0 ]; then
+  echo "FAIL deep cousins: expected rejection, got success"
+  exit 1
+fi
+if [ "$(extract_prescription "$TMP_ROOT/err")" != "CC-702 CC-751" ]; then
+  echo "FAIL deep cousins: expected prescription 'CC-702 --blocks CC-751', stderr:"
+  cat "$TMP_ROOT/err"
+  exit 1
+fi
+if ! run_add_relation "$TMP_ROOT/payloads.jsonl" CC-702 --blocks CC-751 >"$TMP_ROOT/out" 2>"$TMP_ROOT/err"; then
+  echo "FAIL deep cousins: prescribed command 'CC-702 --blocks CC-751' is itself rejected:"
+  cat "$TMP_ROOT/err"
+  exit 1
+fi
+
+# --- chunk bound exceeded: fail closed, no remediation from a truncated chain ---
+set +e
+run_add_relation "$TMP_ROOT/payloads.jsonl" CC-9120 --blocks CC-9000 >"$TMP_ROOT/out" 2>"$TMP_ROOT/err"
+rc=$?
+set -e
+if [ "$rc" -eq 0 ]; then
+  echo "FAIL chunk bound: expected rejection, got success"
+  exit 1
+fi
+if ! grep -q "Hierarchy too deep to validate" "$TMP_ROOT/err"; then
+  echo "FAIL chunk bound: missing fail-closed error:"
+  cat "$TMP_ROOT/err"
+  exit 1
+fi
+if grep -q "[Uu]se '" "$TMP_ROOT/err"; then
+  echo "FAIL chunk bound: fail-closed rejection must not carry a prescription:"
+  cat "$TMP_ROOT/err"
+  exit 1
+fi
+if [ "$(wc -l <"$TMP_ROOT/err")" -ne 1 ] || ! jq -e '.error' "$TMP_ROOT/err" >/dev/null; then
+  echo "FAIL chunk bound: expected exactly one JSON error line:"
+  cat "$TMP_ROOT/err"
+  exit 1
+fi
+if jq -s -e 'any(.[]; .query | contains("issueRelationCreate"))' "$TMP_ROOT/payloads.jsonl" >/dev/null; then
+  echo "FAIL chunk bound: rejected relation still sent issueRelationCreate"
+  exit 1
+fi
+
+echo "all pass"


### PR DESCRIPTION
## Summary

Corrects the two regressions Brad reopened #557 with (from the first fix, PR 558):

1. **Silent 5-level ancestor cap**: acceptance only ever reads direct parents (never truncation-affected, zero extra queries on the accept path); the rejection path now completes possibly-truncated chains via chunked `AncestorChunk` queries until a short chunk proves a true root — bounded at 20 chunks (105 levels) with a fail-closed "hierarchy too deep to validate" rejection and NO derived prescription. The guard never validates remediation against a truncated chain. Validation and chunk queries share one generated selection so depths can't drift.
2. **Bash 3.2 portability**: all three `mapfile` uses replaced with 3.2-safe forms; swept the new code for other Bash-4isms; `bash32-portability.test.sh` greps lib+commands for `mapfile|readarray|declare -A` permanently.

Deep-hierarchy regression test (211 lines) emulates depth-capped server responses: ancestor-beyond-cap both directions, deep-valid siblings (no chunk queries on accept), deep cousins with LCA beyond cap (prescription driven back through the guard), and 121-level chunk-bound exhaustion. The ancestor case genuinely reproduces the reported contradiction under the pre-fix code. All 15 linear test files green.

Closes #557

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016s6ZSLTTRft6fH29wHn1TN