### PR TITLE
fix(#561): decider search returns empty success when decisions dir is absent

### DIFF
--- a/skills/decider/README.md
+++ b/skills/decider/README.md
@@ -38,6 +38,8 @@ EOF
 
 Optionally set `DECISIONS_DIR` in committed `vstack.settings.toml` under `[env]` to override auto-discovery (searches `docs/decisions/`, `decisions/`, `doc/decisions/`, `adr/`). Existing `.env.local` overrides still work.
 
+Before the directory is initialized, `search` and `list` return an empty result (`[]`, exit 0) with a note on stderr; `next-id` and `get` error until it exists.
+
 ## Decision Templates
 
 | Template | Lines | When to Use |

--- a/skills/decider/SKILL.md
+++ b/skills/decider/SKILL.md
@@ -61,6 +61,8 @@ Project-level configuration:
 
 Set `DECISIONS_DIR` in committed `vstack.settings.toml` under `[env]` when it is shared project policy. `.env.local` remains supported for local overrides.
 
+If the decisions directory does not exist (never initialized), read-only lookups (`search`, `list`) emit an empty JSON array with a stderr note and exit 0 — no decisions recorded is not an error. `next-id` and `get` still require an initialized directory, and a configured path that exists but is not a directory is always a hard error.
+
 ## Decision Lifecycle
 
 ```

--- a/skills/decider/scripts/decisions
+++ b/skills/decider/scripts/decisions
@@ -13,6 +13,12 @@
 #   DECISIONS_DIR    Path to decision documents directory (required)
 #                    Example: docs/decisions
 #
+# Missing directory:
+#   Read-only lookups (search, list) treat an absent decisions directory as
+#   "no decisions recorded": they emit an empty JSON array, note it on stderr,
+#   and exit 0. Commands that feed the creation workflow (next-id, get) still
+#   require an initialized directory and fail hard without one.
+#
 # Options:
 #   --limit N        Max results for search (default: 5)
 #
@@ -87,22 +93,50 @@ if [[ -z "${DECISIONS_DIR:-}" ]]; then
   unset _dir _candidate
 fi
 
+# An absent directory (unset and undiscovered, or a configured path that does
+# not exist) is not an error by itself: read-only lookups treat it as "no
+# decisions recorded" while creation-workflow commands still require it. A
+# configured path that exists but is not a directory is always a hard error.
+DECISIONS_DIR_ABSENT=0
+
 if [[ -z "${DECISIONS_DIR:-}" ]]; then
-  echo "Error: Could not find decisions directory. Set DECISIONS_DIR or create docs/decisions/INDEX.md" >&2
+  DECISIONS_DIR=""
+  DECISIONS_DIR_ABSENT=1
+elif [[ ! -e "$DECISIONS_DIR" ]]; then
+  DECISIONS_DIR_ABSENT=1
+elif [[ ! -d "$DECISIONS_DIR" ]]; then
+  echo "Error: DECISIONS_DIR '$DECISIONS_DIR' is not a directory" >&2
   exit 1
 fi
 
-if [[ ! -d "$DECISIONS_DIR" ]]; then
-  echo "Error: DECISIONS_DIR '$DECISIONS_DIR' does not exist" >&2
-  exit 1
+INDEX_FILE=""
+if [[ "$DECISIONS_DIR_ABSENT" -eq 0 ]]; then
+  INDEX_FILE="$DECISIONS_DIR/INDEX.md"
+  if [[ ! -f "$INDEX_FILE" ]]; then
+    echo "Error: INDEX.md not found in '$DECISIONS_DIR'" >&2
+    exit 1
+  fi
 fi
 
-INDEX_FILE="$DECISIONS_DIR/INDEX.md"
-
-if [[ ! -f "$INDEX_FILE" ]]; then
-  echo "Error: INDEX.md not found in '$DECISIONS_DIR'" >&2
+# Hard requirement for commands that feed the creation workflow.
+require_decisions_dir() {
+  [[ "$DECISIONS_DIR_ABSENT" -eq 1 ]] || return 0
+  if [[ -n "$DECISIONS_DIR" ]]; then
+    echo "Error: DECISIONS_DIR '$DECISIONS_DIR' does not exist" >&2
+  else
+    echo "Error: Could not find decisions directory. Set DECISIONS_DIR or create docs/decisions/INDEX.md" >&2
+  fi
   exit 1
-fi
+}
+
+# Empty-result diagnostic for read-only lookups when no directory exists.
+note_missing_decisions_dir() {
+  if [[ -n "$DECISIONS_DIR" ]]; then
+    echo "note: decisions directory '$DECISIONS_DIR' not present — no decisions recorded" >&2
+  else
+    echo "note: no decisions directory found — no decisions recorded" >&2
+  fi
+}
 
 PCRE_GREP="$(resolve_pcre_grep || true)"
 if [[ -z "$PCRE_GREP" ]]; then
@@ -184,6 +218,8 @@ Search scoring:
 
 Environment:
   DECISIONS_DIR    Path to decision documents directory (required)
+                   Absent directory: search/list emit [] and exit 0 (note on
+                   stderr); next-id/get still error until it is initialized.
 
 Examples:
   decisions search "FFI error handling"    # Top decisions about FFI errors
@@ -212,6 +248,17 @@ search_decisions() {
     esac
   done
 
+  if [[ -z "$issue" && -z "$query" ]]; then
+    echo '{"error": "Provide a search query or --issue ID"}' >&2
+    return 1
+  fi
+
+  if [[ "$DECISIONS_DIR_ABSENT" -eq 1 ]]; then
+    note_missing_decisions_dir
+    echo '[]'
+    return 0
+  fi
+
   local all
   all=$(parse_index)
 
@@ -222,7 +269,7 @@ search_decisions() {
       .[] | select(.research | test($issue + "(?![0-9])"; "i")) |
       {id, decision, path}
     ]'
-  elif [[ -n "$query" ]]; then
+  else
     # Check if query contains regex operators — if so, use raw regex mode
     if echo "$query" | grep -qE '[|()\\]'; then
       echo "$all" | jq --arg q "$query" --argjson limit "$limit" '[
@@ -257,13 +304,16 @@ search_decisions() {
         ] | sort_by(-.score) | .[:$limit]
       '
     fi
-  else
-    echo '{"error": "Provide a search query or --issue ID"}' >&2
-    return 1
   fi
 }
 
 list_decisions() {
+  if [[ "$DECISIONS_DIR_ABSENT" -eq 1 ]]; then
+    note_missing_decisions_dir
+    echo '[]'
+    return 0
+  fi
+
   local all
   all=$(parse_index)
   echo "$all" | jq '[.[] | select(.status | startswith("Active")) | {id, decision, path}]'
@@ -325,9 +375,11 @@ case "$action" in
     list_decisions
     ;;
   next-id)
+    require_decisions_dir
     cmd_next_id
     ;;
   get)
+    require_decisions_dir
     cmd_get "$@"
     ;;
   help|--help|-h)

--- a/skills/decider/tests/decider-search-missing-dir.test.sh
+++ b/skills/decider/tests/decider-search-missing-dir.test.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Regression tests for decisions missing-directory handling (vstack#561).
+#
+# In a repository with no decisions directory, read-only lookups (search,
+# list) previously exited 1 with "DECISIONS_DIR '...' does not exist", turning
+# an inapplicable lookup into a workflow failure. They now emit an empty JSON
+# array with a stderr note and exit 0. These tests assert that soft path for
+# both the configured-but-absent and unset-undiscovered cases, and that real
+# errors are preserved: zero-match searches in an existing directory are
+# unchanged, a configured path that exists but is a file stays a hard error,
+# and creation-workflow commands (next-id, get) still require the directory.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../.." && pwd)"
+DECISIONS="$REPO_ROOT/skills/decider/scripts/decisions"
+
+PASS=0
+FAIL=0
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+ERR_FILE="$TMP_ROOT/stderr"
+
+# Run the decisions script from a given directory with DECISIONS_DIR removed
+# from the parent environment (pass VAR=value args to set it explicitly).
+# Captures stdout in $out, stderr in $err, exit code in $rc.
+run_decisions() {
+  local dir="$1"
+  shift
+  set +e
+  out=$( (cd "$dir" && env -u DECISIONS_DIR "$@" "$DECISIONS" "${ARGS[@]}") 2>"$ERR_FILE")
+  rc=$?
+  set -e
+  err="$(cat "$ERR_FILE")"
+}
+
+assert_eq() {
+  local got="$1" want="$2" name="$3"
+  if [[ "$got" == "$want" ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$name" "$want" "$got"
+  fi
+}
+
+assert_contains() {
+  local got="$1" needle="$2" name="$3"
+  if [[ "$got" == *"$needle"* ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected to contain: %s\n        got:      %s\n' "$name" "$needle" "$got"
+  fi
+}
+
+echo "=== decisions missing decisions dir (vstack#561) ==="
+
+# --- Project with a configured DECISIONS_DIR that does not exist -------------
+# Mirrors the reported failure: vstack.settings.toml sets DECISIONS_DIR but
+# the repository has no decisions directory.
+NO_DIR="$TMP_ROOT/no-dir-project"
+mkdir -p "$NO_DIR"
+printf '[env]\nDECISIONS_DIR = "docs/decisions"\n' >"$NO_DIR/vstack.settings.toml"
+
+ARGS=(search --issue PROJ-557)
+run_decisions "$NO_DIR"
+assert_eq "$rc" "0" "issue search with absent dir exits 0"
+assert_eq "$out" "[]" "issue search with absent dir emits empty array"
+assert_contains "$err" "docs/decisions" "issue search note names the missing dir"
+assert_contains "$err" "not present" "issue search notes dir not present on stderr"
+
+ARGS=(search "ffi error handling")
+run_decisions "$NO_DIR"
+assert_eq "$rc" "0" "keyword search with absent dir exits 0"
+assert_eq "$out" "[]" "keyword search with absent dir emits empty array"
+assert_contains "$err" "not present" "keyword search notes dir not present on stderr"
+
+ARGS=(list)
+run_decisions "$NO_DIR"
+assert_eq "$rc" "0" "list with absent dir exits 0"
+assert_eq "$out" "[]" "list with absent dir emits empty array"
+assert_contains "$err" "not present" "list notes dir not present on stderr"
+
+# Creation-workflow commands still require the directory.
+ARGS=(next-id)
+run_decisions "$NO_DIR"
+assert_eq "$rc" "1" "next-id with absent dir still errors"
+assert_contains "$err" "does not exist" "next-id reports missing DECISIONS_DIR"
+
+ARGS=(get D001)
+run_decisions "$NO_DIR"
+assert_eq "$rc" "1" "get with absent dir still errors"
+assert_contains "$err" "does not exist" "get reports missing DECISIONS_DIR"
+
+# --- DECISIONS_DIR unset and auto-discovery finds nothing --------------------
+UNSET_DIR="$TMP_ROOT/unset-project"
+mkdir -p "$UNSET_DIR"
+
+ARGS=(search --issue PROJ-557)
+run_decisions "$UNSET_DIR"
+assert_eq "$rc" "0" "issue search with undiscovered dir exits 0"
+assert_eq "$out" "[]" "issue search with undiscovered dir emits empty array"
+assert_contains "$err" "no decisions directory found" "undiscovered dir noted on stderr"
+
+ARGS=(help)
+run_decisions "$UNSET_DIR"
+assert_eq "$rc" "0" "help works without a decisions dir"
+assert_contains "$out" "Decision Lookup Tool" "help prints usage without a decisions dir"
+
+# --- Existing directory: zero-match and match behavior unchanged -------------
+HAS_DIR="$TMP_ROOT/has-dir-project"
+mkdir -p "$HAS_DIR/docs/decisions"
+cat >"$HAS_DIR/docs/decisions/INDEX.md" <<'EOF'
+# Architectural Decision Log
+
+| Date | ID | Research | Decision | Rationale | Revisit When | Status | Link |
+|------|----|----------|----------|-----------|--------------|--------|------|
+| 2026-01-10 | D001 | PROJ-100 | Use Redis for session caching | Fast and simple | If latency degrades | Active | [Full](D001-session-caching.md) |
+EOF
+
+ARGS=(search "zzz nonexistent term")
+run_decisions "$HAS_DIR" DECISIONS_DIR=docs/decisions
+assert_eq "$rc" "0" "zero-match keyword search in existing dir exits 0"
+assert_eq "$out" "[]" "zero-match keyword search emits empty array"
+assert_eq "$err" "" "zero-match keyword search emits no stderr note"
+
+ARGS=(search --issue PROJ-999)
+run_decisions "$HAS_DIR" DECISIONS_DIR=docs/decisions
+assert_eq "$rc" "0" "zero-match issue search in existing dir exits 0"
+assert_eq "$out" "[]" "zero-match issue search emits empty array"
+assert_eq "$err" "" "zero-match issue search emits no stderr note"
+
+ARGS=(search "redis")
+run_decisions "$HAS_DIR" DECISIONS_DIR=docs/decisions
+assert_eq "$rc" "0" "matching keyword search in existing dir exits 0"
+assert_contains "$out" '"D001"' "matching keyword search returns D001"
+
+ARGS=(next-id)
+run_decisions "$HAS_DIR" DECISIONS_DIR=docs/decisions
+assert_eq "$rc" "0" "next-id in existing dir exits 0"
+assert_eq "$out" "D002" "next-id in existing dir returns D002"
+
+# --- Configured path exists but is a file: hard error for every command ------
+touch "$TMP_ROOT/not-a-dir"
+
+ARGS=(search --issue PROJ-557)
+run_decisions "$NO_DIR" DECISIONS_DIR="$TMP_ROOT/not-a-dir"
+assert_eq "$rc" "1" "search with file at DECISIONS_DIR exits nonzero"
+assert_eq "$out" "" "search with file at DECISIONS_DIR emits no result"
+assert_contains "$err" "is not a directory" "search with file at DECISIONS_DIR reports hard error"
+
+ARGS=(next-id)
+run_decisions "$NO_DIR" DECISIONS_DIR="$TMP_ROOT/not-a-dir"
+assert_eq "$rc" "1" "next-id with file at DECISIONS_DIR exits nonzero"
+assert_contains "$err" "is not a directory" "next-id with file at DECISIONS_DIR reports hard error"
+
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/skills/decider/workflows/search-decisions.md
+++ b/skills/decider/workflows/search-decisions.md
@@ -31,7 +31,7 @@ Searches INDEX.md Research column for exact issue reference match (with negative
 [{"id":"D017","decision":"Storage Trait Design","path":"docs/decisions/D017-storage-trait-design.md"}]
 ```
 
-**If no matches**: Empty array `[]`.
+**If no matches**: Empty array `[]`. The same empty array (exit 0, with a stderr note) is returned when the project has no decisions directory yet — treat it as "no decisions recorded", not a failure.
 
 ---
 


### PR DESCRIPTION
## Summary

`decisions search`/`list` hard-errored in repositories with no architecture-decisions directory, turning inapplicable read-only lookups into workflow failures.

## Changes

- Read-only lookups (`search` keyword/--issue/regex, `list`) treat an absent directory (configured-but-missing, or unset with failed auto-discovery) as "no decisions recorded": byte-identical `[]` on stdout (same as zero matches in an existing dir), one-line stderr note, exit 0. Callers already treat empty arrays as "no governing decisions".
- Creation-workflow commands (`next-id`, `get`) keep the exact pre-existing hard errors; dir-exists-but-INDEX-missing unchanged for all commands.
- Drive-by correctness: configured path that exists but is a FILE now errors "is not a directory" (previously misreported "does not exist").
- `help` works without a directory (previously errored).
- First decider test suite: 34 assertions covering the reported repro, zero-match-existing-dir regression anchors, file-not-dir hard error, and next-id/get hard errors.
- SKILL.md/README/workflow/--help documented.

Closes #561

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016s6ZSLTTRft6fH29wHn1TN