### PR TITLE
test(decider): derive executable from skill root

### DIFF
--- a/skills/decider/tests/decider-search-missing-dir.test.sh
+++ b/skills/decider/tests/decider-search-missing-dir.test.sh
@@ -12,8 +12,8 @@
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$TEST_DIR/../../.." && pwd)"
-DECISIONS="$REPO_ROOT/skills/decider/scripts/decisions"
+SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
+DECISIONS="$SKILL_DIR/scripts/decisions"
 
 PASS=0
 FAIL=0


### PR DESCRIPTION
## Summary

- derive the decider regression test executable directly from the skill root
- remove the misleading repository-root variable and layout-dependent path
- keep the #561 missing-directory regression portable when the skill is installed elsewhere

## Validation

- `bash -n skills/decider/tests/decider-search-missing-dir.test.sh`
- `bash skills/decider/tests/decider-search-missing-dir.test.sh` (34 passed)
- copied `skills/decider` beneath an arbitrary non-`skills` directory and reran the test (34 passed)
- `git diff --check`

No documentation update is needed because this changes only the test harness's path derivation, not decider behavior or its public workflow.

Closes #563
