### PR TITLE
test(#563): derive decider test executable from skill root

### DIFF
--- a/skills/decider/tests/decider-search-missing-dir.test.sh
+++ b/skills/decider/tests/decider-search-missing-dir.test.sh
@@ -12,8 +12,8 @@
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$TEST_DIR/../../.." && pwd)"
-DECISIONS="$REPO_ROOT/skills/decider/scripts/decisions"
+SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
+DECISIONS="$SKILL_DIR/scripts/decisions"
 
 PASS=0
 FAIL=0


### PR DESCRIPTION
REPO_ROOT computed three levels above tests/ is the skill container, not the repo root — in vendored installs it resolves to `.agents` and only works because the appended path re-adds `skills/decider/...`. Derive `SKILL_DIR` from the test dir and the executable from it, independent of the enclosing layout. Flagged by Greptile on vanillagreencom/hyprtrade#253; 34 assertions still green.

Closes #563

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016s6ZSLTTRft6fH29wHn1TN