### PR TITLE
docs(#568): safe temp-dir integration check wrapper; correct README claim

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,7 +192,7 @@ Each canonical agent declares its own `effort:` in frontmatter. Harnesses write 
 
 - **No project-specific references.** Zero mentions of specific apps, crate names, paths, or tools in `agents/`, `skills/`, `hooks/`.
 - **Validate ctx7 IDs.** Every library ID in SKILL.md ctx7 tables must resolve via `npx ctx7@latest docs <id> "test"`.
-- **Test after CLI changes.** `cd cli && cargo test`. Integration: `cargo run -- add .. --all --copy` into a temp dir.
+- **Test after CLI changes.** `cd cli && cargo test`. Integration: `cli/scripts/integration-check.sh` — installs into a throwaway temp project and verifies the scope. Running `cargo run -- add .. --all --copy` from inside the checkout installs into the checkout itself (project scope = nearest project root from CWD), so it is not the validation path.
 - **Hooks must be portable.** No hardcoded paths.
 - **Child workflows return JSON to parent.** Subagent workflows output JSON in `<output_format>` tags; the calling primary agent writes files.
 - **Workflow shell examples must be harness-safe.** Use simple commands with explicit arguments. Avoid inline `$(...)`, shell loops, heredocs, array-building snippets, and redirected writes in required workflow steps; Codex may classify those helper shapes as approval-required under `never` approval. Use helper scripts (`git-context`, `workflow-state`) for derived values, use harness file-write/edit tools or `apply_patch` for tmp Markdown/JSON files, and read multiple required docs with separate file reads instead of a shell `for` loop.
@@ -247,7 +247,7 @@ Worktree/feature branch dev: test via local project Pi settings for that checkou
 ```bash
 cd cli && cargo build                    # build
 cd cli && cargo test                     # unit + integration tests
-cd cli && cargo run -- add .. --all -y   # integration test against this repo
+cli/scripts/integration-check.sh         # integration check in a throwaway temp project
 ```
 
 ## Publishing & Releases

--- a/cli/README.md
+++ b/cli/README.md
@@ -18,11 +18,13 @@ Unit + integration tests:
 cargo test
 ```
 
-Integration test against this repo's source tree (writes into a temp dir, then exits — does not mutate the working copy):
+Integration check — installs everything from this repo into a throwaway temp project and verifies the printed `Scope:` line points there:
 
 ```bash
-cargo run -- add .. --all --copy
+scripts/integration-check.sh
 ```
+
+Do not validate by running `cargo run -- add .. --all --copy` from inside this checkout: `vstack add` resolves PROJECT scope by walking up from the current directory to the nearest project root, which is this checkout itself — so that command installs every item into the source working copy, not a temp dir.
 
 ## Skill / Pi extension test surfaces
 

--- a/cli/scripts/integration-check.sh
+++ b/cli/scripts/integration-check.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Safe integration check: install everything from this repo into a throwaway
+# temp project. `vstack add` resolves PROJECT scope by walking up from the
+# CWD (cli/src/config.rs::find_project_root_within) looking for
+# .vstack-lock.json or a harness dir (.claude/ .cursor/ .codex/ .opencode/
+# .pi/ .agents/), so running it from inside this checkout installs into the
+# checkout itself. This wrapper runs the install from a seeded temp dir
+# instead, then verifies the printed scope actually landed there.
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "$0")" && pwd -P)
+cli_dir=$(cd "$script_dir/.." && pwd -P)
+repo_root=$(cd "$cli_dir/.." && pwd -P)
+
+cargo build --manifest-path "$cli_dir/Cargo.toml"
+
+tmp_project=$(mktemp -d)
+trap 'rm -rf "$tmp_project"' EXIT
+mkdir "$tmp_project/.claude" # project marker — .git is not one (see config.rs)
+tmp_phys=$(cd "$tmp_project" && pwd -P)
+
+log=$tmp_project/vstack-add.log
+if ! (cd "$tmp_project" && "$cli_dir/target/debug/vstack" add "$repo_root" --all --copy -y) >"$log" 2>&1; then
+  cat "$log" >&2
+  echo "FAIL: vstack add exited non-zero" >&2
+  exit 1
+fi
+
+# display_path() shortens paths under $HOME to ~/…
+tmp_display=$tmp_phys
+case $tmp_phys in "$HOME"/*) tmp_display="~${tmp_phys#"$HOME"}" ;; esac
+
+scope_line=$(grep '^Scope:' "$log" || true)
+grep '^Installed' "$log" || true
+echo "$scope_line"
+case $scope_line in
+*"($tmp_phys)"* | *"($tmp_display)"*)
+  echo "OK: install landed in the temp project; source checkout untouched."
+  ;;
+*)
+  cat "$log" >&2
+  echo "FAIL: scope resolved outside the temp project (expected $tmp_phys): $scope_line" >&2
+  exit 1
+  ;;
+esac


### PR DESCRIPTION
## Summary

`cargo run -- add .. --all --copy` from inside the checkout resolves PROJECT scope to the checkout itself (config.rs walks up from CWD for .vstack-lock.json / harness dirs) and installs 53 items into the source worktree — the README's "writes into a temp dir, does not mutate the working copy" claim was false.

## Changes

- New `cli/scripts/integration-check.sh`: builds the CLI, seeds a temp project (`.claude/` marker — .git is not one), installs from the temp dir, and fails non-zero unless the printed scope is the temp dir (handles ~-shortened display paths and symlinked tmp).
- cli/README.md integration paragraph corrected; AGENTS.md "Test after CLI changes" bullet and Build & Test block point at the wrapper (.claude/CLAUDE.md is a symlink — no separate edit).
- Validated live: `Scope: PROJECT (/tmp/tmp.L5qVnPtsqA)`, 53 items, source checkout untouched.

Closes #568

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016s6ZSLTTRft6fH29wHn1TN