### PR TITLE
fix(#567): actionable worktree rebase-conflict recovery with --restack

### DIFF
--- a/skills/worktree/README.md
+++ b/skills/worktree/README.md
@@ -23,6 +23,8 @@ Run from the main checkout of a git repo with an `origin` remote. Optionally add
 
 Defaults: detects branch from `origin/HEAD` (fallback: `main`), creates worktrees under sibling `trees/`, then applies configured symlinks and copies. Set `WORKTREE_BASE_DIR` to use another parent directory; relative paths resolve from the main checkout, absolute paths are used as-is.
 
+`create` on an already-existing worktree reuses it after rebasing its branch onto `origin/<default>`. If that rebase conflicts, the default run aborts the rebase (the worktree stays clean on its pre-rebase state) and prints the conflicting files plus the two supported recovery paths: `create <ID> --restack` re-runs the rebase and pauses in the conflict state so you can resolve the files, `git -C <path> add` each one, and `GIT_EDITOR=true git -C <path> rebase --continue` (or `rebase --abort` to back out), then re-run `create <ID>` to finish setup; alternatively `remove <ID>` + `create <ID>` recreates the worktree fresh from `origin/<default>`, discarding the conflicting local commits.
+
 `remove` deletes the worktree first, then tries `git branch -d` for the associated local branch. If Git refuses the safe branch delete (for example, the branch is not merged into the current main checkout), the command exits non-zero and prints a diagnostic naming the remaining branch plus the manual `git branch -D` recovery command.
 
 ## Codex Desktop

--- a/skills/worktree/SKILL.md
+++ b/skills/worktree/SKILL.md
@@ -3,7 +3,7 @@ name: worktree
 description: "Git worktree management: create, list, remove isolated working copies with env/config symlinks."
 license: MIT
 user-invocable: true
-argument-hint: "create <ID> [--base <branch>] [--from <ref>] [--pr <N>] | list | remove <ID|path>"
+argument-hint: "create <ID> [--base <branch>] [--from <ref>] [--pr <N>] [--restack] | list | remove <ID|path>"
 metadata:
   author: vanillagreen
   source: vstack
@@ -76,6 +76,16 @@ For issue workflows, run `codex-branch ISSUE_ID "$CODEX_WORKTREE_PATH"` before o
 | `--base BRANCH` | Checkout an existing remote branch into the worktree |
 | `--from REF` | Create a new branch (named after ID) starting from REF (branch, tag, or commit) |
 | `--pr NUMBER` | Look up the branch from a GitHub PR number (implies `--base`) |
+| `--restack` | When reusing an existing worktree and its rebase onto `origin/<default>` conflicts, stop in the conflict state for resolution instead of aborting |
+
+### Reuse rebase conflicts
+
+Reusing an existing worktree rebases its branch onto `origin/<default>` first. If that rebase conflicts, the default run aborts the rebase and exits 1 — the worktree is left clean on its pre-rebase state, so there is no conflict left to resolve in place. The error lists the conflicting files (captured before the abort) and the two supported recovery paths:
+
+1. **Resolve in place:** re-run `create <ID> --restack`. The rebase re-runs and pauses in the conflict state. Resolve the listed files, stage each with `git -C <path> add <file>`, run `GIT_EDITOR=true git -C <path> rebase --continue` (repeat if it stops again), then re-run `create <ID>` to finish worktree setup. `git -C <path> rebase --abort` backs out to the clean pre-rebase state. This is the supported exception to the no-raw-`git rebase` rule: only `--continue`/`--abort` on the paused rebase, never starting one by hand.
+2. **Discard divergence:** `remove <ID>` then `create <ID>` recreates the worktree fresh from `origin/<default>`, losing the local commits that conflicted.
+
+With no conflict, `--restack` is a no-op and reuse behaves as usual.
 
 ## Configuration
 

--- a/skills/worktree/scripts/worktree
+++ b/skills/worktree/scripts/worktree
@@ -5,6 +5,9 @@
 #     --base BRANCH   Checkout an existing remote branch into the worktree
 #     --from REF      Create a new branch starting from REF (branch, tag, or commit)
 #     --pr NUMBER     Look up the branch from a PR number (implies --base)
+#     --restack       When reusing an existing worktree and the rebase onto
+#                     origin/<default> conflicts, stop in the conflict state
+#                     for resolution instead of aborting the rebase
 #
 # Layout: project/main (repo) + project/trees/{id} (worktrees by default)
 # Config: reads .env, vstack.settings.toml, then .env.local for optional settings (see below)
@@ -364,6 +367,18 @@ is_git_worktree_path() {
   [[ -f "$wt/.git" || -d "$wt/.git" ]]
 }
 
+rebase_in_progress() {
+  local wt="$1" state path
+  for state in rebase-merge rebase-apply; do
+    path="$(git -C "$wt" rev-parse --git-path "$state" 2>/dev/null)" || continue
+    [[ "$path" == /* ]] || path="$wt/$path"
+    if [[ -d "$path" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
 case "${1:-}" in
   create)
     # Ensure worktreeConfig is enabled (required for per-worktree git config)
@@ -375,11 +390,13 @@ case "${1:-}" in
     BRANCH=""
     FROM=""
     PR=""
+    RESTACK=false
     while [[ $# -gt 0 ]]; do
       case "$1" in
         --base) BASE="$2"; shift 2 ;;
         --from) FROM="$2"; shift 2 ;;
         --pr) PR="$2"; shift 2 ;;
+        --restack) RESTACK=true; shift ;;
         *) BRANCH="$1"; shift ;;
       esac
     done
@@ -393,9 +410,42 @@ case "${1:-}" in
       if [[ -n "$CURRENT_BRANCH" ]]; then
         if git -C "$WT_PATH" merge-base --is-ancestor "origin/$DEFAULT_BRANCH" HEAD; then
           : # origin/$DEFAULT_BRANCH already contained — nothing to rebase
-        elif ! git -C "$WT_PATH" rebase "origin/$DEFAULT_BRANCH" >/dev/null 2>&1; then
+        elif ! REBASE_OUTPUT="$(git -C "$WT_PATH" rebase "origin/$DEFAULT_BRANCH" 2>&1)"; then
+          # Capture conflict details before any abort erases the rebase state.
+          CONFLICT_FILES="$(git -C "$WT_PATH" diff --name-only --diff-filter=U 2>/dev/null || true)"
+          if ! rebase_in_progress "$WT_PATH"; then
+            # Rebase never started (e.g. uncommitted changes) — nothing to
+            # abort or resolve; surface git's own message.
+            echo "Error: Rebase onto origin/$DEFAULT_BRANCH failed for $WT_PATH before it could start:" >&2
+            sed 's/^/  /' <<<"$REBASE_OUTPUT" >&2
+            exit 1
+          fi
+          if [[ "$RESTACK" == true ]]; then
+            echo "Error: Rebase onto origin/$DEFAULT_BRANCH stopped on conflicts in $WT_PATH." >&2
+            if [[ -n "$CONFLICT_FILES" ]]; then
+              echo "Conflicting files:" >&2
+              sed 's/^/  /' <<<"$CONFLICT_FILES" >&2
+            fi
+            echo "The rebase is paused in the worktree so the conflicts can be resolved:" >&2
+            echo "  1. Edit each conflicting file to remove the conflict markers." >&2
+            echo "  2. git -C \"$WT_PATH\" add <file>    (each resolved file)" >&2
+            echo "  3. GIT_EDITOR=true git -C \"$WT_PATH\" rebase --continue    (repeat if it stops again)" >&2
+            echo "  4. $0 create $ISSUE    (finish worktree setup)" >&2
+            echo "To back out instead: git -C \"$WT_PATH\" rebase --abort" >&2
+            exit 1
+          fi
           git -C "$WT_PATH" rebase --abort >/dev/null 2>&1 || true
-          echo "Error: Rebase onto origin/$DEFAULT_BRANCH failed for $WT_PATH (conflicts). Resolve manually or delete worktree." >&2
+          echo "Error: Rebase onto origin/$DEFAULT_BRANCH failed for $WT_PATH (conflicts)." >&2
+          if [[ -n "$CONFLICT_FILES" ]]; then
+            echo "Conflicting files:" >&2
+            sed 's/^/  /' <<<"$CONFLICT_FILES" >&2
+          fi
+          echo "The rebase was aborted; the worktree is back on its pre-rebase state with no conflicts left to resolve." >&2
+          echo "Recovery options:" >&2
+          echo "  1. Redo the rebase and stop in the conflict state to resolve it:" >&2
+          echo "       $0 create $ISSUE --restack" >&2
+          echo "  2. Discard local divergence and recreate fresh from origin/$DEFAULT_BRANCH:" >&2
+          echo "       $0 remove $ISSUE && $0 create $ISSUE" >&2
           exit 1
         fi
       fi

--- a/skills/worktree/tests/worktree_create_restack.sh
+++ b/skills/worktree/tests/worktree_create_restack.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+# Regression tests for `worktree create` reuse rebase-conflict recovery (vstack#567).
+#
+# When `create` reuses an existing worktree and the rebase onto origin/<default>
+# conflicts, the default path aborts the rebase — so the worktree is clean and
+# there is no conflict state left to "resolve manually". The error must be
+# truthful and actionable: list the conflicting files (captured before the
+# abort) and name the two supported recovery paths (`--restack` or
+# delete/recreate). `--restack` must redo the rebase and stop IN the conflict
+# state with continue/abort guidance. Clean-rebase reuse must keep working
+# unchanged.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKTREE_SCRIPT="${WORKTREE_SCRIPT:-$(cd "$TEST_DIR/.." && pwd)/scripts/worktree}"
+TMP_ROOT="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local got="$1" want="$2" name="$3"
+  if [[ "$got" == "$want" ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$name" "$want" "$got"
+  fi
+}
+
+assert_ne() {
+  local got="$1" unwanted="$2" name="$3"
+  if [[ "$got" != "$unwanted" ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected value to differ from: %s\n' "$name" "$unwanted"
+  fi
+}
+
+assert_contains() {
+  local haystack="$1" needle="$2" name="$3"
+  if grep -qF -- "$needle" <<<"$haystack"; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        wanted substring: %s\n        in: %s\n' "$name" "$needle" "$haystack"
+  fi
+}
+
+assert_not_contains() {
+  local haystack="$1" needle="$2" name="$3"
+  if grep -qF -- "$needle" <<<"$haystack"; then
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        unwanted substring present: %s\n        in: %s\n' "$name" "$needle" "$haystack"
+  else
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  fi
+}
+
+assert_path_exists() {
+  local path="$1" name="$2"
+  if [[ -e "$path" ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        missing path: %s\n' "$name" "$path"
+  fi
+}
+
+assert_is_ancestor() {
+  local repo="$1" ancestor="$2" descendant="$3" name="$4"
+  if git -C "$repo" merge-base --is-ancestor "$ancestor" "$descendant"; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        %s is not an ancestor of %s\n' "$name" "$ancestor" "$descendant"
+  fi
+}
+
+rebase_state_exists() {
+  local wt="$1" state path
+  for state in rebase-merge rebase-apply; do
+    path="$(git -C "$wt" rev-parse --git-path "$state")"
+    [[ "$path" == /* ]] || path="$wt/$path"
+    if [[ -d "$path" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+assert_rebase_in_progress() {
+  local wt="$1" name="$2"
+  if rebase_state_exists "$wt"; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        no rebase-merge/rebase-apply state in: %s\n' "$name" "$wt"
+  fi
+}
+
+assert_no_rebase_in_progress() {
+  local wt="$1" name="$2"
+  if rebase_state_exists "$wt"; then
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        rebase state still present in: %s\n' "$name" "$wt"
+  else
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  fi
+}
+
+make_repo() {
+  local repo="$1"
+  mkdir -p "$repo"
+  git -C "$repo" init -q -b main
+  git -C "$repo" config user.email test@example.com
+  git -C "$repo" config user.name Test
+  git -C "$repo" config commit.gpgsign false
+  printf 'orig\n' > "$repo/file.txt"
+  git -C "$repo" add file.txt
+  git -C "$repo" commit -q -m base
+}
+
+# Build a main+origin pair whose issue worktree diverges from origin/main on
+# the same line of file.txt, so a reuse rebase genuinely conflicts.
+make_conflict_pair() {
+  local root="$1" issue="$2"
+  make_repo "$root/main"
+  git init -q --bare "$root/origin.git"
+  git -C "$root/main" remote add origin "$root/origin.git"
+  git -C "$root/main" push -q -u origin main
+  # Create through the script so reuse exercises the script's own worktree.
+  (cd "$root/main" && "$WORKTREE_SCRIPT" create "$issue" >/dev/null 2>&1)
+  local wt="$root/trees/$issue"
+  printf 'feature\n' > "$wt/file.txt"
+  git -C "$wt" add file.txt
+  git -C "$wt" commit -q -m 'feature edit'
+  printf 'main-side\n' > "$root/main/file.txt"
+  git -C "$root/main" add file.txt
+  git -C "$root/main" commit -q -m 'main edit'
+  git -C "$root/main" push -q origin main
+}
+
+echo "=== worktree create reuse rebase-conflict recovery ==="
+
+# --- Default path: abort, truthful and actionable error ------------------------
+DEFAULT_ROOT="$TMP_ROOT/default"
+make_conflict_pair "$DEFAULT_ROOT" issue-default
+DEFAULT_WT="$DEFAULT_ROOT/trees/issue-default"
+default_pre_head="$(git -C "$DEFAULT_WT" rev-parse HEAD)"
+set +e
+(
+  cd "$DEFAULT_ROOT/main" && \
+    "$WORKTREE_SCRIPT" create issue-default >"$DEFAULT_ROOT/create.out" 2>"$DEFAULT_ROOT/create.err"
+)
+default_code=$?
+set -e
+default_err="$(cat "$DEFAULT_ROOT/create.err")"
+assert_eq "$default_code" "1" "default reuse with conflict exits 1"
+assert_contains "$default_err" "Conflicting files:" "default error reports captured conflict list"
+assert_contains "$default_err" "file.txt" "default error names the conflicting file"
+assert_not_contains "$default_err" "Resolve manually" "default error does not claim a conflict state the abort erased"
+assert_contains "$default_err" "aborted" "default error says the rebase was aborted"
+assert_contains "$default_err" "--restack" "default error names the --restack recovery path"
+assert_contains "$default_err" "remove issue-default" "default error names the delete/recreate recovery path"
+assert_no_rebase_in_progress "$DEFAULT_WT" "default reuse leaves no rebase in progress"
+assert_eq "$(git -C "$DEFAULT_WT" rev-parse HEAD)" "$default_pre_head" "default reuse restores pre-rebase HEAD"
+assert_eq "$(git -C "$DEFAULT_WT" status --porcelain)" "" "default reuse leaves the worktree clean"
+
+# --- --restack: stop in the conflict state with continue/abort guidance --------
+RESTACK_ROOT="$TMP_ROOT/restack"
+make_conflict_pair "$RESTACK_ROOT" issue-restack
+RESTACK_WT="$RESTACK_ROOT/trees/issue-restack"
+set +e
+(
+  cd "$RESTACK_ROOT/main" && \
+    "$WORKTREE_SCRIPT" create issue-restack --restack >"$RESTACK_ROOT/create.out" 2>"$RESTACK_ROOT/create.err"
+)
+restack_code=$?
+set -e
+restack_err="$(cat "$RESTACK_ROOT/create.err")"
+assert_eq "$restack_code" "1" "--restack reuse with conflict exits 1"
+assert_rebase_in_progress "$RESTACK_WT" "--restack leaves the rebase paused in the conflict state"
+assert_eq "$(git -C "$RESTACK_WT" diff --name-only --diff-filter=U)" "file.txt" "--restack leaves file.txt unmerged for resolution"
+assert_contains "$restack_err" "file.txt" "--restack error names the conflicting file"
+assert_contains "$restack_err" "add <file>" "--restack error documents per-file staging"
+assert_contains "$restack_err" "rebase --continue" "--restack error documents the continue command"
+assert_contains "$restack_err" "rebase --abort" "--restack error documents the abort escape hatch"
+
+# The documented recovery path must actually work end to end.
+printf 'resolved\n' > "$RESTACK_WT/file.txt"
+git -C "$RESTACK_WT" add file.txt
+GIT_EDITOR=true git -C "$RESTACK_WT" rebase --continue >/dev/null 2>&1
+resolved_out=$(cd "$RESTACK_ROOT/main" && "$WORKTREE_SCRIPT" create issue-restack 2>"$RESTACK_ROOT/resolved.err")
+assert_eq "$resolved_out" "$RESTACK_WT" "create after resolved restack finishes setup and prints the path"
+assert_is_ancestor "$RESTACK_WT" origin/main HEAD "resolved restack branch contains origin/main"
+assert_eq "$(cat "$RESTACK_WT/file.txt")" "resolved" "resolved restack keeps the manual resolution"
+
+# --- Clean-rebase reuse unchanged ----------------------------------------------
+CLEAN_ROOT="$TMP_ROOT/clean"
+make_repo "$CLEAN_ROOT/main"
+git init -q --bare "$CLEAN_ROOT/origin.git"
+git -C "$CLEAN_ROOT/main" remote add origin "$CLEAN_ROOT/origin.git"
+git -C "$CLEAN_ROOT/main" push -q -u origin main
+(cd "$CLEAN_ROOT/main" && "$WORKTREE_SCRIPT" create issue-clean >/dev/null 2>&1)
+CLEAN_WT="$CLEAN_ROOT/trees/issue-clean"
+printf 'fix\n' > "$CLEAN_WT/fix.txt"
+git -C "$CLEAN_WT" add fix.txt
+git -C "$CLEAN_WT" commit -q -m 'review fix'
+printf 'advanced\n' > "$CLEAN_ROOT/main/main-advanced.txt"
+git -C "$CLEAN_ROOT/main" add main-advanced.txt
+git -C "$CLEAN_ROOT/main" commit -q -m 'advance main'
+git -C "$CLEAN_ROOT/main" push -q origin main
+clean_pre_head="$(git -C "$CLEAN_WT" rev-parse HEAD)"
+clean_out=$(cd "$CLEAN_ROOT/main" && "$WORKTREE_SCRIPT" create issue-clean 2>"$CLEAN_ROOT/create.err")
+assert_eq "$clean_out" "$CLEAN_WT" "clean reuse still prints the worktree path"
+assert_ne "$(git -C "$CLEAN_WT" rev-parse HEAD)" "$clean_pre_head" "clean reuse rebased HEAD onto advanced origin/main"
+assert_path_exists "$CLEAN_WT/main-advanced.txt" "clean reuse pulled in the advanced main content"
+assert_is_ancestor "$CLEAN_WT" origin/main HEAD "clean reuse contains origin/main after rebase"
+restack_noop_out=$(cd "$CLEAN_ROOT/main" && "$WORKTREE_SCRIPT" create issue-clean --restack 2>"$CLEAN_ROOT/restack-noop.err")
+assert_eq "$restack_noop_out" "$CLEAN_WT" "--restack is a no-op when no rebase conflict occurs"
+
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

Reusing a worktree whose branch conflicts with origin/main aborted the rebase then said "Resolve manually" — impossible after the abort erased the state, with no supported path for agents prohibited from raw rebase.

## Changes

- Conflict details (files, rebase output) captured BEFORE any abort.
- Default path: still aborts (clean state) but the message is truthful — lists conflicting files, states the state was reset, names both supported recoveries verbatim (`create <ID> --restack` / `remove <ID> && create <ID>`).
- New `create --restack`: leaves the rebase paused with numbered guidance (per-file `git add`, `GIT_EDITOR=true git rebase --continue` so non-interactive agents don't hang, re-run create to finish, `--abort` to back out). Documented in SKILL.md as the explicit exception to the no-raw-rebase rule.
- Pre-start failures (dirty tree) surface git's own error via a rebase_in_progress() check.
- New 25-assertion suite with real conflicts, including the documented recovery executed end-to-end. Full worktree suite green (59/14/25).

Closes #567

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016s6ZSLTTRft6fH29wHn1TN