### PR TITLE
fix: truthful worktree message when rebase --abort itself fails

### DIFF
--- a/skills/worktree/scripts/worktree
+++ b/skills/worktree/scripts/worktree
@@ -434,13 +434,19 @@ case "${1:-}" in
             echo "To back out instead: git -C \"$WT_PATH\" rebase --abort" >&2
             exit 1
           fi
-          git -C "$WT_PATH" rebase --abort >/dev/null 2>&1 || true
+          ABORT_OK=true
+          git -C "$WT_PATH" rebase --abort >/dev/null 2>&1 || ABORT_OK=false
           echo "Error: Rebase onto origin/$DEFAULT_BRANCH failed for $WT_PATH (conflicts)." >&2
           if [[ -n "$CONFLICT_FILES" ]]; then
             echo "Conflicting files:" >&2
             sed 's/^/  /' <<<"$CONFLICT_FILES" >&2
           fi
-          echo "The rebase was aborted; the worktree is back on its pre-rebase state with no conflicts left to resolve." >&2
+          if [[ "$ABORT_OK" == true ]] && ! rebase_in_progress "$WT_PATH"; then
+            echo "The rebase was aborted; the worktree is back on its pre-rebase state with no conflicts left to resolve." >&2
+          else
+            echo "Automatic abort of the failed rebase did NOT complete; the worktree may still hold rebase state." >&2
+            echo "Back it out manually first: git -C \"$WT_PATH\" rebase --abort" >&2
+          fi
           echo "Recovery options:" >&2
           echo "  1. Redo the rebase and stop in the conflict state to resolve it:" >&2
           echo "       $0 create $ISSUE --restack" >&2

--- a/skills/worktree/tests/worktree_create_restack.sh
+++ b/skills/worktree/tests/worktree_create_restack.sh
@@ -88,7 +88,7 @@ assert_is_ancestor() {
 rebase_state_exists() {
   local wt="$1" state path
   for state in rebase-merge rebase-apply; do
-    path="$(git -C "$wt" rev-parse --git-path "$state")"
+    path="$(git -C "$wt" rev-parse --git-path "$state" 2>/dev/null)" || continue
     [[ "$path" == /* ]] || path="$wt/$path"
     if [[ -d "$path" ]]; then
       return 0


### PR DESCRIPTION
Greptile P2s on vanillagreencom/hyprtrade#256 against the #567 change:

1. `rebase --abort || true` masked abort failures while the next line unconditionally claimed the worktree was back to a clean pre-rebase state. The message now branches on the abort result AND a `rebase_in_progress` re-check; on failure it says the abort did not complete and gives the manual back-out command.
2. The test's `rebase_state_exists` helper now suppresses `rev-parse` errors (`2>/dev/null || continue`) matching the production predicate.

Full worktree suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016s6ZSLTTRft6fH29wHn1TN