### PR TITLE
test(#580): hermetic second-opinion timeout-defaults test

### DIFF
--- a/skills/second-opinion/tests/timeout-defaults.test.sh
+++ b/skills/second-opinion/tests/timeout-defaults.test.sh
@@ -6,9 +6,19 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
-SECOND_OPINION="$REPO_ROOT/skills/second-opinion/scripts/second-opinion"
 TMP_ROOT="$(mktemp -d)"
 trap 'rm -rf "$TMP_ROOT"' EXIT
+
+# Hermetic copy: the script resolves PROJECT_ROOT from its own location and
+# loads that project's settings files, so running the in-repo copy leaks the
+# repository's committed vstack.settings.toml (e.g. SECOND_OPINION_TIMEOUT)
+# into a test that pins the BUILT-IN default (vstack#580). Copy the skill to
+# a temp root with no git repo and no settings so only defaults + caller env
+# apply.
+mkdir -p "$TMP_ROOT/proj/skills"
+git init -q "$TMP_ROOT/proj"
+cp -R "$REPO_ROOT/skills/second-opinion" "$TMP_ROOT/proj/skills/second-opinion"
+SECOND_OPINION="$TMP_ROOT/proj/skills/second-opinion/scripts/second-opinion"
 
 mkdir -p "$TMP_ROOT/bin" "$TMP_ROOT/work"
 


### PR DESCRIPTION
The test invoked the in-repo script, whose PROJECT_ROOT (git toplevel of its own location) legitimately loads the repository's committed `vstack.settings.toml` — now carrying the deliberate `SECOND_OPINION_TIMEOUT = "3000"` project choice — so the built-in-default assertion failed on main. The test now copies the skill into a temp git project with no settings files: only built-in defaults and caller env apply, and the repo's own timeout choice coexists with the documented 300s built-in.

Closes #580

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016s6ZSLTTRft6fH29wHn1TN