### PR TITLE
fix: make TPM audit verification repository aware

### DIFF
--- a/skills/project-management/README.md
+++ b/skills/project-management/README.md
@@ -64,5 +64,5 @@ Before using roadmap, audit, research, or cycle-planning workflows, configure th
 - **Same-project rule**: Blocking relations and parent-child relations must be within the same project
 - **Blocking level rule**: Blocking relations go on bundle parents, not children
 - **Label preflight**: Issue creates/label updates load live issue-label inventory + project taxonomy, validate full final `labels[]`, and preserve unrelated labels on updates
-- **Repository-aware verification**: Audits prefer PR/branch changes, discover tracked source roots across monorepos, and skip code-path checks for documentation-only scope
+- **Repository-aware verification**: Audits retain a separate PR/branch/path context per issue, discover tracked source roots across monorepos, halt on Git producer failures, and skip code-path checks for documentation-only scope
 - **Workflows return JSON only**: No direct modifications to the issue tracker — recommendations are executed by the caller

--- a/skills/project-management/README.md
+++ b/skills/project-management/README.md
@@ -2,7 +2,8 @@
 
 TPM methodology for roadmap planning, cycle planning, issue auditing, prioritization, and progress tracking. Workflows analyze issue tracker state and return structured JSON recommendations — the orchestrator or user handles execution.
 
-This skill is methodology-based. All guidance lives in reference documents, workflows, and schemas.
+The methodology lives in reference documents, workflows, and schemas. A small
+portable helper resolves repository-aware verification paths for audits.
 
 ## Structure
 
@@ -24,6 +25,8 @@ skills/project-management/
 │   ├── tpm-roadmap-plan.md                 # Cross-project analysis, architecture gaps
 │   ├── tpm-audit.md                        # Audit issues/projects for relations, hierarchy
 │   └── tpm-audit-project-order.md          # Analyze project dependencies and ordering
+├── scripts/
+│   └── verification-scope                  # Resolve changed paths or tracked source roots for audits
 └── schemas/
     ├── cycle-plan-output.md                # Cycle planning JSON output schema
     ├── roadmap-plan-output.md              # Roadmap analysis JSON output schema
@@ -38,6 +41,8 @@ This skill requires an issue tracker CLI for all read/write operations. Configur
 | Dependency | Purpose | Variable |
 |------------|---------|----------|
 | Issue tracker CLI (e.g., `linear` skill) | Issue CRUD, cache, comments, labels, relations | `.agents/skills/linear/scripts/linear.sh` |
+| Git | Resolve branch changes and tracked source roots for audit verification | `git` on `PATH` |
+| jq | Emit the verification-scope JSON contract | `jq` on `PATH` |
 
 ## Issue Tracker Setup Expectations
 
@@ -59,4 +64,5 @@ Before using roadmap, audit, research, or cycle-planning workflows, configure th
 - **Same-project rule**: Blocking relations and parent-child relations must be within the same project
 - **Blocking level rule**: Blocking relations go on bundle parents, not children
 - **Label preflight**: Issue creates/label updates load live issue-label inventory + project taxonomy, validate full final `labels[]`, and preserve unrelated labels on updates
+- **Repository-aware verification**: Audits prefer PR/branch changes, discover tracked source roots across monorepos, and skip code-path checks for documentation-only scope
 - **Workflows return JSON only**: No direct modifications to the issue tracker — recommendations are executed by the caller

--- a/skills/project-management/SKILL.md
+++ b/skills/project-management/SKILL.md
@@ -90,6 +90,7 @@ TPM workflows return JSON recommendations only.
 - `<delegation_format>` and `<output_format>` tags are literal templates: fill `[PLACEHOLDERS]`, omit empty lines, add nothing else, do not paraphrase.
 - When a user-visible `<output_format>` report is followed by an `Ask user`, `AskUserQuestion`, or question-tool step, send the filled report as a normal assistant message first. Then invoke the question tool separately with only a concise question and concise options; do not paste the report into the question text, option labels, or option descriptions unless a short summary is explicitly requested. This keeps Pi question popups focused on the choice instead of the preceding report.
 - Before any issue create or label update, load the live issue-label inventory and project taxonomy, build the full final `labels[]` set, and run the label preflight in `references/labels.md`. Unknown labels, parent/group labels, missing required categories, or exclusivity violations stop the workflow before mutation.
+- In multi-issue audits, resolve and retain repository verification context per issue/contract. A PR, branch, or resolved path set associated with one issue must not scope another issue's checks.
 
 ## Hierarchy
 

--- a/skills/project-management/SKILL.md
+++ b/skills/project-management/SKILL.md
@@ -124,4 +124,5 @@ Score = (Critical Path x 3) + (Dependencies x 2) + (Risk x 2) + (Value x 1) - (E
 ## Dependencies
 
 - Issue tracker CLI (e.g., `linear` skill)
+- `git` (repository/change-aware audit verification scope)
 - `jq`

--- a/skills/project-management/scripts/verification-scope
+++ b/skills/project-management/scripts/verification-scope
@@ -64,6 +64,28 @@ fi
 
 declare -a candidates=()
 basis="tracked-files"
+producer_output=""
+
+cleanup() {
+  if [[ -n "$producer_output" ]]; then
+    rm -f "$producer_output"
+  fi
+}
+trap cleanup EXIT
+
+capture_git_paths() {
+  local diagnostic="$1"
+  shift
+
+  if [[ -n "$producer_output" ]]; then
+    rm -f "$producer_output"
+  fi
+  producer_output="$(mktemp "${TMPDIR:-/tmp}/verification-scope.XXXXXX")" \
+    || fail "could not create temporary file for Git output"
+  if ! git -C "$repo_root" "$@" >"$producer_output"; then
+    fail "$diagnostic"
+  fi
+}
 
 normalize_path() {
   local path="$1"
@@ -93,9 +115,12 @@ elif [[ -n "$base_ref" ]]; then
   basis="base-ref"
   git -C "$repo_root" rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null \
     || fail "base ref is not a commit: $base_ref"
+  capture_git_paths \
+    "git diff failed for base ref '$base_ref'; verify the ref and that it shares history with HEAD" \
+    diff --name-only -z "${base_ref}...HEAD" --
   while IFS= read -r -d '' path; do
     candidates+=("$path")
-  done < <(git -C "$repo_root" diff --name-only -z "${base_ref}...HEAD" --)
+  done <"$producer_output"
 fi
 
 is_doc_path() {
@@ -188,11 +213,14 @@ add_source_root() {
 }
 
 if [[ "$mode" == "repository" ]]; then
+  capture_git_paths \
+    "git ls-files failed while discovering tracked source roots" \
+    ls-files -z
   while IFS= read -r -d '' path; do
     if is_source_file "$path"; then
       add_source_root "$(source_root_for_path "$path")"
     fi
-  done < <(git -C "$repo_root" ls-files -z)
+  done <"$producer_output"
 elif [[ "$mode" == "changed" ]]; then
   for path in "${candidates[@]}"; do
     if is_source_file "$path"; then

--- a/skills/project-management/scripts/verification-scope
+++ b/skills/project-management/scripts/verification-scope
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+# Resolve repository-aware paths for tpm-audit code and deliverable checks.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: verification-scope [--worktree PATH] [--base-ref REF]
+                          [--changed-file PATH]... [--docs-only]
+
+Prefer --changed-file for PR-provided paths or --base-ref for a branch diff.
+Without either, tracked source roots are discovered across the repository.
+EOF
+}
+
+fail() {
+  echo "verification-scope: $*" >&2
+  exit 1
+}
+
+worktree="."
+base_ref=""
+force_docs_only=false
+declare -a explicit_paths=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --worktree)
+      [[ $# -ge 2 ]] || fail "--worktree requires a path"
+      worktree="$2"
+      shift 2
+      ;;
+    --base-ref)
+      [[ $# -ge 2 ]] || fail "--base-ref requires a ref"
+      base_ref="$2"
+      shift 2
+      ;;
+    --changed-file)
+      [[ $# -ge 2 ]] || fail "--changed-file requires a repository-relative path"
+      explicit_paths+=("$2")
+      shift 2
+      ;;
+    --docs-only)
+      force_docs_only=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+[[ -d "$worktree" ]] || fail "worktree does not exist: $worktree"
+repo_root="$(git -C "$worktree" rev-parse --show-toplevel 2>/dev/null)" \
+  || fail "worktree is not inside a Git repository: $worktree"
+repo_root="$(cd "$repo_root" && pwd -P)"
+
+if [[ -n "$base_ref" && ${#explicit_paths[@]} -gt 0 ]]; then
+  fail "use either --base-ref or --changed-file, not both"
+fi
+
+declare -a candidates=()
+basis="tracked-files"
+
+normalize_path() {
+  local path="$1"
+  while [[ "$path" == ./* ]]; do
+    path="${path#./}"
+  done
+  if [[ "$path" == "$repo_root"/* ]]; then
+    path="${path#"$repo_root"/}"
+  elif [[ "$path" == /* ]]; then
+    fail "path is outside the worktree: $path"
+  fi
+  [[ -n "$path" ]] || fail "empty changed path"
+  case "$path" in
+    ..|../*|*/..|*/../*)
+      fail "path escapes the worktree: $path"
+      ;;
+  esac
+  printf '%s\n' "$path"
+}
+
+if [[ ${#explicit_paths[@]} -gt 0 ]]; then
+  basis="changed-files"
+  for path in "${explicit_paths[@]}"; do
+    candidates+=("$(normalize_path "$path")")
+  done
+elif [[ -n "$base_ref" ]]; then
+  basis="base-ref"
+  git -C "$repo_root" rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null \
+    || fail "base ref is not a commit: $base_ref"
+  while IFS= read -r -d '' path; do
+    candidates+=("$path")
+  done < <(git -C "$repo_root" diff --name-only -z "${base_ref}...HEAD" --)
+fi
+
+is_doc_path() {
+  local path="$1"
+  case "$path" in
+    docs/*|doc/*|documentation/*|*.md|*.mdx|*.rst|*.adoc|*.txt)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+is_source_file() {
+  local path="$1"
+  if [[ -f "$repo_root/$path" && -x "$repo_root/$path" ]]; then
+    return 0
+  fi
+  case "$path" in
+    *.c|*.cc|*.cpp|*.cxx|*.h|*.hh|*.hpp|*.hxx|*.cs|*.go|*.java|*.js|*.jsx|*.kt|*.kts|*.lua|*.php|*.py|*.rb|*.rs|*.scala|*.sh|*.swift|*.ts|*.tsx|*.vue|*.svelte|*.zig)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+source_root_for_path() {
+  local path="$1"
+  if [[ "$path" == src/* ]]; then
+    printf 'src\n'
+  elif [[ "$path" == */src/* ]]; then
+    printf '%s/src\n' "${path%%/src/*}"
+  elif [[ "$path" == */scripts/* ]]; then
+    printf '%s/scripts\n' "${path%%/scripts/*}"
+  elif [[ "$path" == */extensions/* ]]; then
+    printf '%s/extensions\n' "${path%%/extensions/*}"
+  elif [[ "$path" == */tests/* ]]; then
+    printf '%s/tests\n' "${path%%/tests/*}"
+  elif [[ "$path" == */test/* ]]; then
+    printf '%s/test\n' "${path%%/test/*}"
+  elif [[ "$path" == */hooks/* ]]; then
+    printf '%s/hooks\n' "${path%%/hooks/*}"
+  elif [[ "$path" == */bin/* ]]; then
+    printf '%s/bin\n' "${path%%/bin/*}"
+  else
+    dirname "$path"
+  fi
+}
+
+declare -A seen_candidates=()
+declare -a unique_candidates=()
+for path in "${candidates[@]}"; do
+  if [[ -z "${seen_candidates[$path]+x}" ]]; then
+    seen_candidates["$path"]=1
+    unique_candidates+=("$path")
+  fi
+done
+candidates=("${unique_candidates[@]}")
+
+mode="repository"
+if [[ "$force_docs_only" == true ]]; then
+  for path in "${candidates[@]}"; do
+    is_doc_path "$path" \
+      || fail "--docs-only path is not documentation: $path"
+  done
+  mode="docs-only"
+elif [[ ${#candidates[@]} -gt 0 ]]; then
+  mode="docs-only"
+  for path in "${candidates[@]}"; do
+    if ! is_doc_path "$path"; then
+      mode="changed"
+      break
+    fi
+  done
+fi
+
+declare -A seen_roots=()
+declare -a source_roots=()
+
+add_source_root() {
+  local root="$1"
+  [[ -n "$root" && "$root" != "." ]] || root="."
+  if [[ -z "${seen_roots[$root]+x}" ]]; then
+    seen_roots["$root"]=1
+    source_roots+=("$root")
+  fi
+}
+
+if [[ "$mode" == "repository" ]]; then
+  while IFS= read -r -d '' path; do
+    if is_source_file "$path"; then
+      add_source_root "$(source_root_for_path "$path")"
+    fi
+  done < <(git -C "$repo_root" ls-files -z)
+elif [[ "$mode" == "changed" ]]; then
+  for path in "${candidates[@]}"; do
+    if is_source_file "$path"; then
+      add_source_root "$(source_root_for_path "$path")"
+    fi
+  done
+fi
+
+if [[ "$mode" == "repository" && ${#source_roots[@]} -eq 0 ]]; then
+  fail "no tracked source roots found; pass changed paths or --docs-only for a documentation-only audit"
+fi
+
+declare -a verification_paths=()
+if [[ "$mode" == "repository" ]]; then
+  verification_paths=("${source_roots[@]}")
+else
+  verification_paths=("${candidates[@]}")
+fi
+
+json_array() {
+  if [[ $# -eq 0 ]]; then
+    printf '[]'
+  else
+    printf '%s\0' "$@" | jq -Rs 'split("\u0000")[:-1]'
+  fi
+}
+
+changed_json="$(json_array "${candidates[@]}")"
+roots_json="$(json_array "${source_roots[@]}")"
+paths_json="$(json_array "${verification_paths[@]}")"
+code_verification_required=true
+if [[ "$mode" == "docs-only" ]]; then
+  code_verification_required=false
+fi
+
+jq -n \
+  --arg worktree "$repo_root" \
+  --arg mode "$mode" \
+  --arg basis "$basis" \
+  --arg base_ref "$base_ref" \
+  --argjson changed_files "$changed_json" \
+  --argjson source_roots "$roots_json" \
+  --argjson verification_paths "$paths_json" \
+  --argjson code_verification_required "$code_verification_required" \
+  '{
+    worktree: $worktree,
+    mode: $mode,
+    basis: $basis,
+    base_ref: (if $base_ref == "" then null else $base_ref end),
+    changed_files: $changed_files,
+    source_roots: $source_roots,
+    verification_paths: $verification_paths,
+    code_verification_required: $code_verification_required
+  }'

--- a/skills/project-management/tests/verification-scope.test.sh
+++ b/skills/project-management/tests/verification-scope.test.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Regression test for repository-aware tpm-audit verification scope (#582).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+RESOLVER="$SKILL_DIR/scripts/verification-scope"
+WORKFLOW="$SKILL_DIR/workflows/tpm-audit.md"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+require_jq() {
+  local json="$1" expression="$2" description="$3"
+  if ! jq -e "$expression" >/dev/null <<<"$json"; then
+    fail "$description"
+  fi
+}
+
+[[ -x "$RESOLVER" ]] || fail "verification-scope is not executable"
+
+fixture="$(mktemp -d)"
+docs_fixture="$(mktemp -d)"
+trap 'rm -rf "$fixture" "$docs_fixture"' EXIT
+
+mkdir -p "$fixture/crate-a/src" "$fixture/crate-b/src" "$fixture/docs"
+printf '[workspace]\nmembers = ["crate-a", "crate-b"]\n' >"$fixture/Cargo.toml"
+printf 'pub fn alpha() {}\n' >"$fixture/crate-a/src/lib.rs"
+printf 'fn main() {}\n' >"$fixture/crate-b/src/main.rs"
+printf '# Audit notes\n' >"$fixture/docs/audit.md"
+git -C "$fixture" init -q
+git -C "$fixture" add .
+
+repository_json="$($RESOLVER --worktree "$fixture")"
+require_jq "$repository_json" '.mode == "repository"' \
+  "repository fallback mode was not selected"
+require_jq "$repository_json" '.source_roots == ["crate-a/src", "crate-b/src"]' \
+  "multi-crate source roots were not discovered"
+require_jq "$repository_json" '.verification_paths | index("src") | not' \
+  "resolver invented a repository-root src directory"
+
+changed_json="$($RESOLVER --worktree "$fixture" --changed-file crate-b/src/main.rs)"
+require_jq "$changed_json" '.mode == "changed"' \
+  "changed-file mode was not selected"
+require_jq "$changed_json" '.source_roots == ["crate-b/src"]' \
+  "changed-file mode did not narrow to the affected crate"
+require_jq "$changed_json" '.verification_paths == ["crate-b/src/main.rs"]' \
+  "changed-file verification path was not preserved"
+
+git -C "$fixture" config user.name "Verification Scope Test"
+git -C "$fixture" config user.email "verification-scope@example.invalid"
+git -C "$fixture" commit -qm "fixture: initial workspace"
+base_ref="$(git -C "$fixture" rev-parse HEAD)"
+printf 'pub fn beta() {}\n' >>"$fixture/crate-a/src/lib.rs"
+git -C "$fixture" add crate-a/src/lib.rs
+git -C "$fixture" commit -qm "fixture: change crate a"
+
+base_json="$($RESOLVER --worktree "$fixture" --base-ref "$base_ref")"
+require_jq "$base_json" '.mode == "changed"' \
+  "base-ref mode did not resolve a changed scope"
+require_jq "$base_json" '.changed_files == ["crate-a/src/lib.rs"]' \
+  "base-ref mode did not preserve the branch change set"
+require_jq "$base_json" '.source_roots == ["crate-a/src"]' \
+  "base-ref mode did not narrow to the changed crate"
+
+docs_json="$($RESOLVER --worktree "$fixture" --changed-file docs/audit.md)"
+require_jq "$docs_json" '.mode == "docs-only"' \
+  "documentation-only change was not classified"
+require_jq "$docs_json" '.code_verification_required == false' \
+  "documentation-only audit still requires code verification"
+require_jq "$docs_json" '.source_roots == []' \
+  "documentation-only audit invented source roots"
+
+if "$RESOLVER" --worktree "$fixture" --docs-only \
+  --changed-file crate-a/src/lib.rs >/dev/null 2>&1; then
+  fail "--docs-only accepted a source file"
+fi
+if "$RESOLVER" --worktree "$fixture" \
+  --changed-file ../outside.rs >/dev/null 2>&1; then
+  fail "resolver accepted a path outside the worktree"
+fi
+
+printf '# Documentation repository\n' >"$docs_fixture/README.md"
+git -C "$docs_fixture" init -q
+git -C "$docs_fixture" add README.md
+if no_source_output="$($RESOLVER --worktree "$docs_fixture" 2>&1)"; then
+  fail "repository fallback succeeded without tracked source roots"
+fi
+if [[ "$no_source_output" != *"no tracked source roots found"* ]]; then
+  fail "repository fallback did not explain the missing source scope"
+fi
+
+if grep -Fq '${WORKTREE:-.}/src/' "$WORKFLOW"; then
+  fail "tpm-audit still hardcodes a repository-root src directory"
+fi
+grep -Fq 'scripts/verification-scope' "$WORKFLOW" \
+  || fail "tpm-audit does not invoke verification-scope"
+grep -Fq 'docs-only' "$WORKFLOW" \
+  || fail "tpm-audit does not document the docs-only path"
+grep -Fq 'verification_paths' "$WORKFLOW" \
+  || fail "tpm-audit does not consume resolved verification paths"
+
+echo "all pass"

--- a/skills/project-management/tests/verification-scope.test.sh
+++ b/skills/project-management/tests/verification-scope.test.sh
@@ -23,7 +23,8 @@ require_jq() {
 
 fixture="$(mktemp -d)"
 docs_fixture="$(mktemp -d)"
-trap 'rm -rf "$fixture" "$docs_fixture"' EXIT
+history_fixture="$(mktemp -d)"
+trap 'rm -rf "$fixture" "$docs_fixture" "$history_fixture"' EXIT
 
 mkdir -p "$fixture/crate-a/src" "$fixture/crate-b/src" "$fixture/docs"
 printf '[workspace]\nmembers = ["crate-a", "crate-b"]\n' >"$fixture/Cargo.toml"
@@ -48,6 +49,26 @@ require_jq "$changed_json" '.source_roots == ["crate-b/src"]' \
   "changed-file mode did not narrow to the affected crate"
 require_jq "$changed_json" '.verification_paths == ["crate-b/src/main.rs"]' \
   "changed-file verification path was not preserved"
+
+# A multi-issue audit must retain an independent scope for each contract.
+issue_a_json="$($RESOLVER --worktree "$fixture" --changed-file crate-a/src/lib.rs)"
+issue_b_json="$($RESOLVER --worktree "$fixture" --changed-file crate-b/src/main.rs)"
+issue_contexts="$(jq -n \
+  --argjson issue_a "$issue_a_json" \
+  --argjson issue_b "$issue_b_json" \
+  '{"ISSUE-A": $issue_a, "ISSUE-B": $issue_b}')"
+require_jq "$issue_contexts" \
+  '.["ISSUE-A"].verification_paths == ["crate-a/src/lib.rs"]' \
+  "first issue did not retain its own verification scope"
+require_jq "$issue_contexts" \
+  '.["ISSUE-B"].verification_paths == ["crate-b/src/main.rs"]' \
+  "second issue did not retain its own verification scope"
+require_jq "$issue_contexts" \
+  '.["ISSUE-A"].verification_paths | index("crate-b/src/main.rs") | not' \
+  "second issue verification scope leaked into the first issue"
+require_jq "$issue_contexts" \
+  '.["ISSUE-B"].verification_paths | index("crate-a/src/lib.rs") | not' \
+  "first issue verification scope leaked into the second issue"
 
 git -C "$fixture" config user.name "Verification Scope Test"
 git -C "$fixture" config user.email "verification-scope@example.invalid"
@@ -92,6 +113,38 @@ if [[ "$no_source_output" != *"no tracked source roots found"* ]]; then
   fail "repository fallback did not explain the missing source scope"
 fi
 
+mkdir -p "$history_fixture/src"
+printf 'fn main() {}\n' >"$history_fixture/src/main.rs"
+git -C "$history_fixture" init -q
+git -C "$history_fixture" config user.name "Verification Scope Test"
+git -C "$history_fixture" config user.email "verification-scope@example.invalid"
+git -C "$history_fixture" add src/main.rs
+git -C "$history_fixture" commit -qm "fixture: first history"
+disconnected_base="$(git -C "$history_fixture" rev-parse HEAD)"
+git -C "$history_fixture" checkout -q --orphan disconnected
+git -C "$history_fixture" rm -q -rf .
+mkdir -p "$history_fixture/src"
+printf 'fn disconnected() {}\n' >"$history_fixture/src/disconnected.rs"
+git -C "$history_fixture" add src/disconnected.rs
+git -C "$history_fixture" commit -qm "fixture: disconnected history"
+if disconnected_output="$($RESOLVER --worktree "$history_fixture" \
+  --base-ref "$disconnected_base" 2>&1)"; then
+  fail "base-ref mode accepted disconnected histories"
+fi
+if [[ "$disconnected_output" != *"git diff failed for base ref"* ]]; then
+  fail "disconnected-history failure did not identify git diff"
+fi
+
+corrupt_index="$docs_fixture/corrupt-index"
+printf 'invalid index\n' >"$corrupt_index"
+if producer_output="$(GIT_INDEX_FILE="$corrupt_index" \
+  "$RESOLVER" --worktree "$fixture" 2>&1)"; then
+  fail "repository discovery ignored a git ls-files producer failure"
+fi
+if [[ "$producer_output" != *"git ls-files failed"* ]]; then
+  fail "producer failure did not identify git ls-files"
+fi
+
 if grep -Fq '${WORKTREE:-.}/src/' "$WORKFLOW"; then
   fail "tpm-audit still hardcodes a repository-root src directory"
 fi
@@ -101,5 +154,9 @@ grep -Fq 'docs-only' "$WORKFLOW" \
   || fail "tpm-audit does not document the docs-only path"
 grep -Fq 'verification_paths' "$WORKFLOW" \
   || fail "tpm-audit does not consume resolved verification paths"
+grep -Fq 'VERIFICATION_CONTEXTS[ISSUE_KEY]' "$WORKFLOW" \
+  || fail "tpm-audit does not retain verification context per issue"
+grep -Fq "reuse another issue's linked PR" "$WORKFLOW" \
+  || fail "tpm-audit does not prohibit cross-issue verification scope reuse"
 
 echo "all pass"

--- a/skills/project-management/workflows/tpm-audit.md
+++ b/skills/project-management/workflows/tpm-audit.md
@@ -99,30 +99,65 @@ For EACH project from 1.3, extract from name + description + content:
 | **Scope** | What components/modules does this project own? |
 
 **[PROJECT only]** For the target project, note constants/APIs it modifies and
-verify them after resolving repository scope in § 1.7. Search only the resolved
-paths, starting with the most specific target path:
+verify them after resolving the owning issue's scope in § 2.1 (or the separate
+project scope in § 9.2). Search only the resolved paths, starting with the most
+specific target path:
 ```bash
 rg -n "[CONSTANT_NAME]|[API_NAME]" "[WORKTREE]/[TARGET_PATH]"
 ```
 
-### 1.7 Resolve Verification Scope
+### 1.7 Collect Verification Evidence
 
-Establish one repository-aware `VERIFICATION_CONTEXT` before any code or
-deliverable checks. A repository-root `src/` is never assumed.
+For EACH input issue, independently record any linked PR and its changed files,
+known implementation branch/base ref, concrete paths, and documentation-only
+signals. Key this evidence by the issue identifier; for a proposed item, use its
+stable input index.
 
-Choose the narrowest trustworthy input in this order:
+A linked PR or branch belongs only to the issue that identifies it (or is
+explicitly documented as implementing it). Do not infer that association from
+another input issue. Do not establish one global `VERIFICATION_CONTEXT`; scope
+resolution happens per extracted contract in § 2.1.
 
-1. **PR changed files** when an input issue links to a PR. Read the PR file list,
+---
+
+**Done/Cancelled issue rule**: Done and Cancelled issues are historical records. Never modify their labels, agent assignments, priorities, or state. They may appear in relation analysis (as sources/targets of valid historical links) and cross-project comparison (to detect duplicates of completed work), but all fix recommendations must exclude them. Only active issues (Backlog, Todo, In Progress, In Review) are candidates for changes.
+
+---
+
+## 2. Extract Contracts
+
+For each INPUT issue, extract from title + description:
+
+| Field | Extract |
+|-------|---------|
+| **Target** | Component/file being modified |
+| **Creates** | New APIs, seams, types, tests this introduces |
+| **Consumes** | Existing APIs, seams, types this uses or extends |
+| **Problem** | What bug/gap/feature it addresses |
+| **Decisions** | Use decider skill: `.agents/skills/decider/scripts/decisions search "[TARGET_KEYWORDS]"` for decisions governing the target area. Flag if proposed approach contradicts an active decision |
+
+**Build** contract table: `ID | Target | Creates | Consumes | Problem | Decision Conflict`
+
+### 2.1 Resolve Verification Scope Per Contract
+
+For EACH contract row, set `ISSUE_KEY` to its issue identifier or proposed-item
+index and resolve one repository-aware context. A repository-root `src/` is
+never assumed.
+
+Choose the narrowest trustworthy input for that issue only, in this order:
+
+1. **PR changed files** when this issue directly links to the PR or the PR is
+   explicitly documented as implementing this issue. Read that PR's file list,
    then pass each repository-relative path as `--changed-file`.
-2. **Branch diff** when the audit runs in an implementation worktree and its
-   base ref is known.
-3. **Concrete issue paths** from the contract/location fields when they cover
-   the complete implementation scope.
-4. **Repository discovery** when no reliable change set exists. The resolver
-   discovers every tracked source root; this supports monorepos and multi-crate
-   workspaces with paths such as `crate-a/src` and `crate-b/src`.
-5. **Documentation-only scope** when every deliverable and changed path is
-   documentation. Use `--docs-only` when there is no concrete change set yet.
+2. **Branch diff** when the branch is known to implement this issue and its base
+   ref is known.
+3. **Concrete issue paths** from this contract's target/location fields when
+   they cover its complete implementation scope.
+4. **Repository discovery** as this issue's fallback when no reliable change
+   set exists. The resolver discovers every tracked source root; this supports
+   monorepos and multi-crate workspaces such as `crate-a/src` and `crate-b/src`.
+5. **Documentation-only scope** when this issue's deliverables and changed paths
+   are all documentation. Use `--docs-only` when no concrete change set exists.
 
 Changed-file example (repeat `--changed-file` as needed):
 ```bash
@@ -144,12 +179,15 @@ Documentation-only example:
 .agents/skills/project-management/scripts/verification-scope --worktree "[WORKTREE]" --docs-only --changed-file "[DOC_PATH]"
 ```
 
-Store the returned JSON as `VERIFICATION_CONTEXT` and extract:
+Store each result independently as `VERIFICATION_CONTEXTS[ISSUE_KEY]`. Never
+reuse another issue's linked PR, branch diff, or resolved context. During later
+checks, `ISSUE_VERIFICATION_CONTEXT` means only the map entry for the issue
+currently being checked. Extract:
 
 - `mode`: `changed`, `repository`, or `docs-only`
 - `changed_files[]`: the explicit or diff-derived paths
 - `source_roots[]`: affected or repository-discovered source roots
-- `verification_paths[]`: exact paths every later search must use
+- `verification_paths[]`: exact paths later searches for this issue must use
 - `code_verification_required`: whether code-path checks apply
 
 All returned paths are repository-relative. Resolve them against the returned
@@ -157,9 +195,9 @@ absolute `worktree` before `rg`, `ls`, or file reads.
 
 Rules:
 
-- In `changed` mode, search the exact changed/contract target first. Expand
-  only when a creates-consumes contract or architecture reference proves a
-  second path is relevant.
+- In `changed` mode, search this issue's exact changed/contract target first.
+  Expand only when its creates-consumes contract or an architecture reference
+  proves a second path is relevant.
 - In `repository` mode, search the returned tracked source roots. Never replace
   them with `[WORKTREE]/src`.
 - In `docs-only` mode, skip code-path checks. Read the resolved documentation
@@ -167,26 +205,9 @@ Rules:
   of code evidence as a mismatch or obsolete-work signal.
 - If code verification is required but `verification_paths[]` is empty, halt
   with a clear scope-resolution error. Do not continue with a guessed path.
-
----
-
-**Done/Cancelled issue rule**: Done and Cancelled issues are historical records. Never modify their labels, agent assignments, priorities, or state. They may appear in relation analysis (as sources/targets of valid historical links) and cross-project comparison (to detect duplicates of completed work), but all fix recommendations must exclude them. Only active issues (Backlog, Todo, In Progress, In Review) are candidates for changes.
-
----
-
-## 2. Extract Contracts
-
-For each INPUT issue, extract from title + description:
-
-| Field | Extract |
-|-------|---------|
-| **Target** | Component/file being modified |
-| **Creates** | New APIs, seams, types, tests this introduces |
-| **Consumes** | Existing APIs, seams, types this uses or extends |
-| **Problem** | What bug/gap/feature it addresses |
-| **Decisions** | Use decider skill: `.agents/skills/decider/scripts/decisions search "[TARGET_KEYWORDS]"` for decisions governing the target area. Flag if proposed approach contradicts an active decision |
-
-**Build** contract table: `ID | Target | Creates | Consumes | Problem | Decision Conflict`
+- For a creates-consumes pair, load both issues' contexts independently. An
+  explicitly shared seam may be inspected for both contracts, but neither
+  issue's context replaces the other's.
 
 ---
 
@@ -331,9 +352,12 @@ For each candidate pair (A, B):
 
 ### 5.2 Verify Against Repository State
 
-**Skip code-path checks if** `VERIFICATION_CONTEXT.mode == "docs-only"`.
-Verify documentation contracts against the resolved documentation paths
-instead.
+For each issue in the pair, load only its
+`ISSUE_VERIFICATION_CONTEXT = VERIFICATION_CONTEXTS[ISSUE_KEY]`.
+
+**Skip that issue's code-path checks if**
+`ISSUE_VERIFICATION_CONTEXT.mode == "docs-only"`. Verify its documentation
+contract against its resolved documentation paths instead.
 
 Otherwise, verify contracts against actual code when target files exist. Use
 the most specific contract target first:
@@ -381,9 +405,10 @@ ls "[WORKTREE]/[TARGET_PATH]"
 rg -n "pub fn|export function|def " "[WORKTREE]/[TARGET_PATH]"
 ```
 
-If `VERIFICATION_CONTEXT.mode == "docs-only"`, infer ownership from the issue
-contract, project definition, and documented paths; do not manufacture a code
-path merely to validate an agent label.
+Load the current issue's `ISSUE_VERIFICATION_CONTEXT`. If its mode is
+`docs-only`, infer ownership from that issue's contract, project definition,
+and documented paths; do not manufacture a code path merely to validate an
+agent label.
 
 **Add** to `agent_mismatch[]`:
 ```json
@@ -441,10 +466,12 @@ Detect issues that should be canceled because work is complete.
    rg -n "pub fn [FUNCTION]|pub struct [TYPE]|export class [TYPE]|export function [FUNCTION]" "[WORKTREE]/[TARGET_PATH]"
    ```
 
-   If no concrete target exists, search the explicit
-   `VERIFICATION_CONTEXT.verification_paths[]`. For `docs-only`, read the
-   documentation paths and verify every documentation deliverable instead of
-   running code-symbol searches.
+   If no concrete target exists, search the current issue's explicit
+   `ISSUE_VERIFICATION_CONTEXT.verification_paths[]`. For `docs-only`, read
+   that issue's documentation paths and verify every documentation deliverable
+   instead of running code-symbol searches. For a comparison-set issue not yet
+   in `VERIFICATION_CONTEXTS`, first extract its contract and resolve a new map
+   entry under that issue's identifier; never borrow an input issue's entry.
 
 3. **Read resolved deliverable files** — check implementation files for stubs
    versus complete code, or documentation files for the promised content
@@ -608,18 +635,20 @@ Extract:
 
 For each repository-relative module path from 9.1, inspect that exact path. A
 module referenced by architecture documentation may extend beyond a PR's
-changed paths; add that concrete path to the verification scope rather than
-falling back to a repository-root `src/`:
+changed paths; inspect that concrete architecture path without adding it to an
+unrelated issue's context or falling back to a repository-root `src/`:
 ```bash
 ls -la "[WORKTREE]/[MODULE_PATH]"
 rg -n "pub struct|pub fn|pub trait|export class|export function" "[WORKTREE]/[MODULE_PATH]"
 rg -n "TODO|unimplemented|todo|FIXME" "[WORKTREE]/[MODULE_PATH]"
 ```
 
-If `VERIFICATION_CONTEXT.mode == "docs-only"`, classify implementation state
-only when the PROJECT audit itself requires architecture-gap analysis. Resolve
-the architecture's concrete module paths first; do not reinterpret a
-documentation-only change set as evidence that the modules are missing.
+Do not use an issue's linked PR or `ISSUE_VERIFICATION_CONTEXT` as the scope for
+the whole project. When architecture-gap analysis lacks concrete module paths,
+resolve repository discovery separately as `PROJECT_VERIFICATION_CONTEXT` and
+use it only for § 9. If an issue-specific context is `docs-only`, do not
+reinterpret that documentation-only change set as evidence that architecture
+modules are missing.
 
 Classify:
 
@@ -728,7 +757,7 @@ For each input issue, assign action based on analysis:
 
 ### 11.1 Core Checks (All Issues)
 
-- [ ] 1.7: Repository/change-aware verification scope resolved; docs-only path handled explicitly
+- [ ] 1.7/2.1: Verification evidence collected and a distinct `VERIFICATION_CONTEXTS[ISSUE_KEY]` entry resolved for every input issue/contract; no linked PR, branch, or scope reused across issues; docs-only handled explicitly
 - [ ] 2: Contract extracted (target, creates, consumes, problem)
 - [ ] 4.5: Relation violations scanned (cross-project, cross-bundle, child→standalone)
 - [ ] 5.1-5.2: Relations analyzed against the resolved code or documentation paths

--- a/skills/project-management/workflows/tpm-audit.md
+++ b/skills/project-management/workflows/tpm-audit.md
@@ -98,10 +98,75 @@ For EACH project from 1.3, extract from name + description + content:
 | **Work Type** | What kind of issues belong here? |
 | **Scope** | What components/modules does this project own? |
 
-**[PROJECT only]** For target project, also grep codebase for constants/APIs it modifies:
+**[PROJECT only]** For the target project, note constants/APIs it modifies and
+verify them after resolving repository scope in § 1.7. Search only the resolved
+paths, starting with the most specific target path:
 ```bash
-grep -rn "[CONSTANT_NAME]\|[API_NAME]" ${WORKTREE:-.}/src/
+rg -n "[CONSTANT_NAME]|[API_NAME]" "[WORKTREE]/[TARGET_PATH]"
 ```
+
+### 1.7 Resolve Verification Scope
+
+Establish one repository-aware `VERIFICATION_CONTEXT` before any code or
+deliverable checks. A repository-root `src/` is never assumed.
+
+Choose the narrowest trustworthy input in this order:
+
+1. **PR changed files** when an input issue links to a PR. Read the PR file list,
+   then pass each repository-relative path as `--changed-file`.
+2. **Branch diff** when the audit runs in an implementation worktree and its
+   base ref is known.
+3. **Concrete issue paths** from the contract/location fields when they cover
+   the complete implementation scope.
+4. **Repository discovery** when no reliable change set exists. The resolver
+   discovers every tracked source root; this supports monorepos and multi-crate
+   workspaces with paths such as `crate-a/src` and `crate-b/src`.
+5. **Documentation-only scope** when every deliverable and changed path is
+   documentation. Use `--docs-only` when there is no concrete change set yet.
+
+Changed-file example (repeat `--changed-file` as needed):
+```bash
+.agents/skills/project-management/scripts/verification-scope --worktree "[WORKTREE]" --changed-file "[PATH_1]" --changed-file "[PATH_2]"
+```
+
+Branch-diff example:
+```bash
+.agents/skills/project-management/scripts/verification-scope --worktree "[WORKTREE]" --base-ref "[BASE_REF]"
+```
+
+Repository-discovery example:
+```bash
+.agents/skills/project-management/scripts/verification-scope --worktree "[WORKTREE]"
+```
+
+Documentation-only example:
+```bash
+.agents/skills/project-management/scripts/verification-scope --worktree "[WORKTREE]" --docs-only --changed-file "[DOC_PATH]"
+```
+
+Store the returned JSON as `VERIFICATION_CONTEXT` and extract:
+
+- `mode`: `changed`, `repository`, or `docs-only`
+- `changed_files[]`: the explicit or diff-derived paths
+- `source_roots[]`: affected or repository-discovered source roots
+- `verification_paths[]`: exact paths every later search must use
+- `code_verification_required`: whether code-path checks apply
+
+All returned paths are repository-relative. Resolve them against the returned
+absolute `worktree` before `rg`, `ls`, or file reads.
+
+Rules:
+
+- In `changed` mode, search the exact changed/contract target first. Expand
+  only when a creates-consumes contract or architecture reference proves a
+  second path is relevant.
+- In `repository` mode, search the returned tracked source roots. Never replace
+  them with `[WORKTREE]/src`.
+- In `docs-only` mode, skip code-path checks. Read the resolved documentation
+  paths and verify documentation deliverables directly; do not treat the lack
+  of code evidence as a mismatch or obsolete-work signal.
+- If code verification is required but `verification_paths[]` is empty, halt
+  with a clear scope-resolution error. Do not continue with a guessed path.
 
 ---
 
@@ -264,11 +329,21 @@ For each candidate pair (A, B):
 
 **Blocking level rule**: Blocking relations go on bundle parents, not children. A child issue must not block an issue under a different parent. If A is bundled under parent P1 and B is under parent P2 (or standalone), then P1 blocks P2 — never A blocks B.
 
-### 5.2 Verify with Code
+### 5.2 Verify Against Repository State
 
-**Verify** contracts against actual code when target files exist:
+**Skip code-path checks if** `VERIFICATION_CONTEXT.mode == "docs-only"`.
+Verify documentation contracts against the resolved documentation paths
+instead.
+
+Otherwise, verify contracts against actual code when target files exist. Use
+the most specific contract target first:
 ```bash
-grep -rn "consumedThing" ${WORKTREE:-.}/src/
+rg -n "consumedThing" "[WORKTREE]/[TARGET_PATH]"
+```
+
+If the contract names no concrete target, search the resolved paths explicitly:
+```bash
+rg -n "consumedThing" "[WORKTREE]/[VERIFICATION_PATH_1]" "[WORKTREE]/[VERIFICATION_PATH_2]"
 ```
 
 - Contract matches code → confidence high
@@ -300,11 +375,15 @@ For each blocking relationship (A blocks B) where both are active:
 **Code verification** (when target exists):
 ```bash
 # Check if target is in specific directory
-ls ${WORKTREE:-.}/src/[TARGET_MODULE]/
+ls "[WORKTREE]/[TARGET_PATH]"
 
 # Check for public function signatures
-grep -rn "pub fn\|export function\|def " ${WORKTREE:-.}/src/[TARGET_MODULE]/
+rg -n "pub fn|export function|def " "[WORKTREE]/[TARGET_PATH]"
 ```
+
+If `VERIFICATION_CONTEXT.mode == "docs-only"`, infer ownership from the issue
+contract, project definition, and documented paths; do not manufacture a code
+path merely to validate an agent label.
 
 **Add** to `agent_mismatch[]`:
 ```json
@@ -356,12 +435,19 @@ Detect issues that should be canceled because work is complete.
 
 1. **Extract deliverables** from issue description
 
-2. **Verify EACH deliverable** exists in codebase:
+2. **Verify EACH deliverable** in its resolved target path. For code-bearing
+   audits, search the specific implementation path first:
    ```bash
-   grep -rn "pub fn [FUNCTION]\|pub struct [TYPE]\|export class [TYPE]\|export function [FUNCTION]" ${WORKTREE:-.}/src/
+   rg -n "pub fn [FUNCTION]|pub struct [TYPE]|export class [TYPE]|export function [FUNCTION]" "[WORKTREE]/[TARGET_PATH]"
    ```
 
-3. **Read implementation files** — check for stubs vs complete code
+   If no concrete target exists, search the explicit
+   `VERIFICATION_CONTEXT.verification_paths[]`. For `docs-only`, read the
+   documentation paths and verify every documentation deliverable instead of
+   running code-symbol searches.
+
+3. **Read resolved deliverable files** — check implementation files for stubs
+   versus complete code, or documentation files for the promised content
 
 4. **Calculate confidence**:
 
@@ -520,12 +606,20 @@ Extract:
 
 ### 9.2 Analyze Implementation State
 
-For each module from 9.1:
+For each repository-relative module path from 9.1, inspect that exact path. A
+module referenced by architecture documentation may extend beyond a PR's
+changed paths; add that concrete path to the verification scope rather than
+falling back to a repository-root `src/`:
 ```bash
-ls -la ${WORKTREE:-.}/src/[MODULE]/
-grep -rn "pub struct\|pub fn\|pub trait\|export class\|export function" ${WORKTREE:-.}/src/[MODULE]/
-grep -rn "TODO\|unimplemented\|todo\|FIXME" ${WORKTREE:-.}/src/[MODULE]/
+ls -la "[WORKTREE]/[MODULE_PATH]"
+rg -n "pub struct|pub fn|pub trait|export class|export function" "[WORKTREE]/[MODULE_PATH]"
+rg -n "TODO|unimplemented|todo|FIXME" "[WORKTREE]/[MODULE_PATH]"
 ```
+
+If `VERIFICATION_CONTEXT.mode == "docs-only"`, classify implementation state
+only when the PROJECT audit itself requires architecture-gap analysis. Resolve
+the architecture's concrete module paths first; do not reinterpret a
+documentation-only change set as evidence that the modules are missing.
 
 Classify:
 
@@ -634,9 +728,10 @@ For each input issue, assign action based on analysis:
 
 ### 11.1 Core Checks (All Issues)
 
+- [ ] 1.7: Repository/change-aware verification scope resolved; docs-only path handled explicitly
 - [ ] 2: Contract extracted (target, creates, consumes, problem)
 - [ ] 4.5: Relation violations scanned (cross-project, cross-bundle, child→standalone)
-- [ ] 5.1-5.2: Relations analyzed with code verification
+- [ ] 5.1-5.2: Relations analyzed against the resolved code or documentation paths
 - [ ] 5.3: Priority alignment checked (skip if proposed without priority)
 - [ ] 5.4: Agent label verified
 - [ ] 5.5: Label co-occurrence checked


### PR DESCRIPTION
## Summary

- resolve TPM audit verification paths from PR/branch changes or tracked repository source roots instead of assuming a root `src/`
- retain a distinct verification context per audited issue/contract so linked PRs and branches cannot narrow unrelated issue checks
- support monorepos, multi-crate workspaces, explicit contract paths, and documentation-only audits with a structured scope contract
- propagate `git diff` and `git ls-files` failures before consuming path output
- add executable regression fixtures for multi-issue scope isolation, multi-crate discovery, disconnected histories, Git producer failures, docs-only behavior, missing-source diagnostics, and path containment

## Validation

- `bash skills/project-management/tests/verification-scope.test.sh`
- `bash skills/project-management/tests/label-preflight-contract.test.sh`
- `bash skills/project-management/tests/hierarchy-contract.test.sh`
- `bash -n skills/project-management/scripts/verification-scope`
- `bash -n skills/project-management/tests/verification-scope.test.sh`
- `cargo test` from `cli/` (380 passed, 2 ignored)
- `cli/scripts/integration-check.sh`
- `git diff --check`

Closes #582
