### PR TITLE
fix(#578): carry authorized restack lease from create to push

### DIFF
--- a/skills/worktree/README.md
+++ b/skills/worktree/README.md
@@ -25,7 +25,7 @@ Defaults: detects branch from `origin/HEAD` (fallback: `main`), creates worktree
 
 Bare `create <ID>` claims new work only. Every new-branch mode, including `--from`, checks the normalized issue branch, an explicit requested branch, and `BOT_NAME/<issue>` for matching worktrees, local/remote refs, and open PRs. Existing ownership exits 75 without rebasing or modifying a branch. Origin remote-head and GitHub PR discovery are authoritative: an outage exits 1 before worktree config, branch, or target-path mutation instead of being treated as absence. Unreachable secondary remotes are skipped with a warning (they cannot hold other sessions' pushes); reachable ones still count as ownership. A repository-local per-issue lock holds the final repeated discovery through `git worktree add`, so concurrent claimers produce one worktree and one exit 75. Inspect or monitor owned work instead of launching another implementer. Run each issue create separately and check its result; do not batch creates in a shell loop whose last success can mask an earlier active-work exit.
 
-The owning session can opt in with `create <ID> --reuse`, which rebases the existing branch onto `origin/<default>` and refreshes its setup. Reuse/restack requires the target's exact canonical path to be registered in this repository's common Git directory; an incomplete directory is preserved and exits 75, even when it sits inside the main checkout. If a reuse rebase conflicts, it aborts back to the clean pre-rebase state and prints the conflicting files plus two recovery paths: `create <ID> --restack` re-runs the rebase and pauses in the conflict state so you can resolve the files, `git -C <path> add` each one, and `GIT_EDITOR=true git -C <path> rebase --continue` (or `rebase --abort` to back out), then re-run `create <ID> --reuse` to finish setup; alternatively `remove <ID>` + `create <ID>` recreates the worktree fresh from `origin/<default>`, discarding the conflicting local commits. Use `create <ID> --pr <N>` or `--base <branch>` to explicitly inspect existing remote work.
+The owning session can opt in with `create <ID> --reuse`, which rebases the existing branch onto `origin/<default>` and refreshes its setup. Reuse/restack requires the target's exact canonical path to be registered in this repository's common Git directory; an incomplete directory is preserved and exits 75, even when it sits inside the main checkout. If a reuse rebase conflicts, it aborts back to the clean pre-rebase state and prints the conflicting files plus two recovery paths: `create <ID> --restack` re-runs the rebase and pauses in the conflict state so you can resolve the files, `git -C <path> add` each one, and `GIT_EDITOR=true git -C <path> rebase --continue` (or `rebase --abort` to back out), then re-run `create <ID> --reuse` to finish setup and `push <ID>` to publish the restacked branch; alternatively `remove <ID>` + `create <ID>` recreates the worktree fresh from `origin/<default>`, discarding the conflicting local commits. Use `create <ID> --pr <N>` or `--base <branch>` to explicitly inspect existing remote work.
 
 `remove` deletes the worktree first, then tries `git branch -d` for the associated local branch. If Git refuses the safe branch delete (for example, the branch is not merged into the current main checkout), the command exits non-zero and prints a diagnostic naming the remaining branch plus the manual `git branch -D` recovery command.
 
@@ -68,6 +68,17 @@ without failing non-fast-forward. If the remote branch has advanced beyond the
 local branch, the command aborts and asks you to fetch/rebase/merge first
 instead of overwriting unseen remote commits. Calls that skip auto-rebase still
 use plain pushes.
+
+When `create --reuse`/`--restack` intentionally rebases a published branch onto
+`origin/<default>`, it records the remote head it observed before rewriting
+history (file `worktree-restack-lease` in the worktree's private git dir). The
+next `worktree push` uses that recorded OID as its exact `--force-with-lease`
+expectation, since the rewritten history can no longer prove the old remote
+head is contained locally. The record is deleted after a successful push. If
+someone pushed to the branch after the restack, git rejects the lease; the
+stale record is discarded and the error asks you to fetch and integrate the new
+remote commits before pushing again. A record naming a different branch is
+ignored, keeping the fail-closed behavior above.
 
 `codex-setup` applies the same env/config symlinks, copies, mkdirs, bot remote, bot git identity, and lightweight dependency bootstrap that `create` applies after creating a worktree. `codex-branch` renames or switches the app-created worktree branch to the lower-case issue branch expected by `orch`. `codex-cleanup` is intentionally a no-op lifecycle hook for this script; Codex owns app-created worktree and branch deletion. Keep project-level teardown such as stopping containers or removing disposable caches in the Codex environment cleanup script after this command, but do not call `worktree remove` from the hook.
 

--- a/skills/worktree/SKILL.md
+++ b/skills/worktree/SKILL.md
@@ -54,6 +54,18 @@ runs. If the remote branch has advanced beyond the local branch, `push` aborts
 and asks the user to fetch/rebase/merge first instead of overwriting unseen
 remote commits.
 
+The one exception is the tool's own restack: an intentional `create
+--reuse`/`--restack` rebase records the remote branch head it observed before
+rewriting history into the worktree's private git dir
+(`worktree-restack-lease`), and the next `push` uses that recorded OID as its
+exact `--force-with-lease` expectation — after the rewrite, the ancestry rule
+above could never pass for the tool's own authorized rebase. The record is
+single-use: deleted once the push succeeds. If the remote moved past the
+recorded head, git rejects the push, the stale record is discarded, and the
+error asks for the new remote commits to be fetched and integrated first. A
+record naming a different branch is ignored and the fail-closed lease behavior
+above applies unchanged.
+
 `remove` deletes the worktree before deleting the local branch. Branch deletion uses safe `git branch -d`; if that fails after worktree removal, the script exits non-zero with a diagnostic naming the remaining branch and manual `git branch -D` recovery command.
 
 When a configured symlink path is already tracked in the worktree branch, the script marks that path assume-unchanged before replacing it so `git status` stays clean.
@@ -87,7 +99,7 @@ For issue workflows, run `codex-branch ISSUE_ID "$CODEX_WORKTREE_PATH"` before o
 
 Bare `create` never rebases an existing worktree. After the owning session opts in with `--reuse`, the branch rebases onto `origin/<default>`. If that rebase conflicts, the run aborts the rebase and exits 1 — the worktree is left clean on its pre-rebase state, so there is no conflict left to resolve in place. The error lists the conflicting files (captured before the abort) and the two supported recovery paths:
 
-1. **Resolve in place:** re-run `create <ID> --restack`. The rebase re-runs and pauses in the conflict state. Resolve the listed files, stage each with `git -C <path> add <file>`, run `GIT_EDITOR=true git -C <path> rebase --continue` (repeat if it stops again), then re-run `create <ID> --reuse` to finish worktree setup. `git -C <path> rebase --abort` backs out to the clean pre-rebase state. This is the supported exception to the no-raw-`git rebase` rule: only `--continue`/`--abort` on the paused rebase, never starting one by hand.
+1. **Resolve in place:** re-run `create <ID> --restack`. The rebase re-runs and pauses in the conflict state. Resolve the listed files, stage each with `git -C <path> add <file>`, run `GIT_EDITOR=true git -C <path> rebase --continue` (repeat if it stops again), re-run `create <ID> --reuse` to finish worktree setup, then publish with `push <ID>` — the restack recorded the pre-rebase remote head, so the push's force-with-lease succeeds without manual force flags. `git -C <path> rebase --abort` backs out to the clean pre-rebase state. This is the supported exception to the no-raw-`git rebase` rule: only `--continue`/`--abort` on the paused rebase, never starting one by hand.
 2. **Discard divergence:** `remove <ID>` then `create <ID>` recreates the worktree fresh from `origin/<default>`, losing the local commits that conflicted.
 
 With no conflict, `--restack` completes the same intentional rebase as `--reuse`.

--- a/skills/worktree/scripts/worktree
+++ b/skills/worktree/scripts/worktree
@@ -132,6 +132,60 @@ remote_ref_lease_arg() {
   printf '%s\n' "--force-with-lease=${remote_head_ref}:${expected_oid}"
 }
 
+# Authorized-restack lease state (#578). An intentional `create --reuse` /
+# `--restack` rebase rewrites history, after which push's ancestry check above
+# can no longer prove the remote head is contained locally — so the remote
+# head observed before the rewrite is recorded in the worktree's private git
+# dir and consumed by the next push as an exact --force-with-lease
+# expectation. Git itself validates the expectation against the live remote at
+# push time, so a remote that moved past the recorded head still rejects.
+restack_lease_path() {
+  local wt="$1" path=""
+  path="$(git -C "$wt" rev-parse --git-path worktree-restack-lease 2>/dev/null)" || return 1
+  [[ -n "$path" ]] || return 1
+  [[ "$path" == /* ]] || path="$wt/$path"
+  printf '%s\n' "$path"
+}
+
+# Record the remote head the upcoming intentional rebase is based on. Records
+# only when the remote branch exists and its head is contained in HEAD — the
+# same requirement push enforces today, checked while the pre-rewrite history
+# can still prove it. Skipping the record fails closed to push's ancestry
+# check. Content: "refs/heads/<branch> <OID>".
+record_restack_lease() {
+  local wt="$1" branch="$2"
+  local remote="${BOT_REMOTE_NAME:-origin}" remote_oid="" lease_file=""
+  [[ -n "$branch" && "$branch" != "$DEFAULT_BRANCH" ]] || return 0
+  git -C "$wt" remote get-url "$remote" >/dev/null 2>&1 || remote="origin"
+  remote_oid="$(git -C "$wt" show-ref --verify --hash "refs/remotes/$remote/$branch" 2>/dev/null || true)"
+  [[ -n "$remote_oid" ]] || return 0
+  git -C "$wt" merge-base --is-ancestor "$remote_oid" HEAD 2>/dev/null || return 0
+  lease_file="$(restack_lease_path "$wt")" || return 0
+  printf 'refs/heads/%s %s\n' "$branch" "$remote_oid" > "$lease_file"
+}
+
+# Print the recorded lease OID when the state file exists and names the given
+# branch. A file naming a different branch or holding a malformed OID is
+# ignored (fail closed to the ancestry-checked lease).
+restack_lease_oid_for_branch() {
+  local wt="$1" branch="$2" lease_file="" recorded_ref="" recorded_oid=""
+  lease_file="$(restack_lease_path "$wt")" || return 1
+  [[ -f "$lease_file" ]] || return 1
+  IFS=' ' read -r recorded_ref recorded_oid < "$lease_file" || true
+  [[ "$recorded_ref" == "refs/heads/$branch" ]] || return 1
+  case "$recorded_oid" in
+    ''|*[!0-9a-f]*) return 1 ;;
+  esac
+  [[ "${#recorded_oid}" -eq 40 || "${#recorded_oid}" -eq 64 ]] || return 1
+  printf '%s\n' "$recorded_oid"
+}
+
+clear_restack_lease() {
+  local wt="$1" lease_file=""
+  lease_file="$(restack_lease_path "$wt")" || return 0
+  rm -f "$lease_file" 2>/dev/null || true
+}
+
 strip_trailing_slashes() {
   local path="$1"
   while [[ "$path" != "/" && "$path" == */ ]]; do
@@ -815,15 +869,20 @@ case "${1:-}" in
       fi
       fetch_origin || exit 1
       CURRENT_BRANCH=$(git -C "$WT_PATH" branch --show-current 2>/dev/null)
-      if [[ -n "$CURRENT_BRANCH" ]]; then
-        if git -C "$WT_PATH" merge-base --is-ancestor "origin/$DEFAULT_BRANCH" HEAD; then
-          : # origin/$DEFAULT_BRANCH already contained — nothing to rebase
-        elif ! REBASE_OUTPUT="$(git -C "$WT_PATH" rebase "origin/$DEFAULT_BRANCH" 2>&1)"; then
+      if [[ -n "$CURRENT_BRANCH" ]] && ! git -C "$WT_PATH" merge-base --is-ancestor "origin/$DEFAULT_BRANCH" HEAD; then
+        # The rebase below rewrites history; record the observed remote head
+        # first so push can still prove this restack was authorized (#578).
+        # Recorded here (not after) because a conflicted --restack rebase
+        # finishes outside this script via `rebase --continue`.
+        record_restack_lease "$WT_PATH" "$CURRENT_BRANCH"
+        if ! REBASE_OUTPUT="$(git -C "$WT_PATH" rebase "origin/$DEFAULT_BRANCH" 2>&1)"; then
           # Capture conflict details before any abort erases the rebase state.
           CONFLICT_FILES="$(git -C "$WT_PATH" diff --name-only --diff-filter=U 2>/dev/null || true)"
           if ! rebase_in_progress "$WT_PATH"; then
             # Rebase never started (e.g. uncommitted changes) — nothing to
-            # abort or resolve; surface git's own message.
+            # abort or resolve; surface git's own message. No history was
+            # rewritten, so the recorded lease is unnecessary.
+            clear_restack_lease "$WT_PATH"
             echo "Error: Rebase onto origin/$DEFAULT_BRANCH failed for $WT_PATH before it could start:" >&2
             sed 's/^/  /' <<<"$REBASE_OUTPUT" >&2
             exit 1
@@ -839,6 +898,7 @@ case "${1:-}" in
             echo "  2. git -C \"$WT_PATH\" add <file>    (each resolved file)" >&2
             echo "  3. GIT_EDITOR=true git -C \"$WT_PATH\" rebase --continue    (repeat if it stops again)" >&2
             echo "  4. $0 create $ISSUE --reuse    (finish worktree setup)" >&2
+            echo "  5. $0 push $ISSUE    (publish the restacked branch)" >&2
             echo "To back out instead: git -C \"$WT_PATH\" rebase --abort" >&2
             exit 1
           fi
@@ -850,6 +910,10 @@ case "${1:-}" in
             sed 's/^/  /' <<<"$CONFLICT_FILES" >&2
           fi
           if [[ "$ABORT_OK" == true ]] && ! rebase_in_progress "$WT_PATH"; then
+            # Abort restored pre-rebase history — no rewrite happened, so the
+            # recorded lease is unnecessary. A failed abort keeps it: the user
+            # may still resolve and continue the rebase by hand.
+            clear_restack_lease "$WT_PATH"
             echo "The rebase was aborted; the worktree is back on its pre-rebase state with no conflicts left to resolve." >&2
           else
             echo "Automatic abort of the failed rebase did NOT complete; the worktree may still hold rebase state." >&2
@@ -1080,6 +1144,8 @@ case "${1:-}" in
       echo ""
       echo "Push worktree branch to remote. Auto-rebases onto origin/$DEFAULT_BRANCH first."
       echo "Auto-rebased pushes use --force-with-lease pinned to the pre-rebase target branch OID."
+      echo "After a create --reuse/--restack rebase, the lease uses the remote head recorded"
+      echo "at restack time instead; the record is deleted once the push succeeds."
       echo "Uses BOT_REMOTE_NAME from project config if set, otherwise falls back to origin."
       echo ""
       echo "Options:"
@@ -1122,8 +1188,15 @@ case "${1:-}" in
 
     CURRENT_BRANCH=$(git -C "$WT_PATH" branch --show-current 2>/dev/null)
     PUSH_LEASE=()
+    RESTACK_LEASE_OID=""
     if [[ "$AUTO_REBASE" == true && -n "$CURRENT_BRANCH" && "$CURRENT_BRANCH" != "$DEFAULT_BRANCH" ]]; then
-      if LEASE_ARG="$(remote_ref_lease_arg "$WT_PATH" "$REMOTE" "$CURRENT_BRANCH")"; then
+      if RESTACK_LEASE_OID="$(restack_lease_oid_for_branch "$WT_PATH" "$CURRENT_BRANCH")"; then
+        # An intentional create --reuse/--restack rebase recorded the remote
+        # head it replaced before rewriting history; use it as the exact
+        # lease expectation. Git rejects the push if the remote has since
+        # moved past the recorded head (#578).
+        PUSH_LEASE=("--force-with-lease=refs/heads/${CURRENT_BRANCH}:${RESTACK_LEASE_OID}")
+      elif LEASE_ARG="$(remote_ref_lease_arg "$WT_PATH" "$REMOTE" "$CURRENT_BRANCH")"; then
         PUSH_LEASE=("$LEASE_ARG")
       else
         exit 1
@@ -1152,22 +1225,40 @@ case "${1:-}" in
       [[ -z "$UPSTREAM" ]] && SET_UPSTREAM="-u"
     fi
 
+    PUSH_OK=true
     if [[ -n "$SET_UPSTREAM" ]]; then
       # ${arr[@]+...} guard: empty-array expansion is an unbound variable
       # under Bash 3.2 with set -u.
-      if ! git_with_github_https_auth -C "$WT_PATH" push "$SET_UPSTREAM" ${PUSH_LEASE[@]+"${PUSH_LEASE[@]}"} "$REMOTE" "HEAD:refs/heads/${CURRENT_BRANCH}"; then
-        if [[ ${#PUSH_LEASE[@]} -gt 0 ]]; then
-          echo "Error: Push rejected. Remote '$REMOTE/$CURRENT_BRANCH' may have changed since the force-with-lease expectation; fetch and rebase/merge before retrying." >&2
-        fi
-        exit 1
-      fi
+      git_with_github_https_auth -C "$WT_PATH" push "$SET_UPSTREAM" ${PUSH_LEASE[@]+"${PUSH_LEASE[@]}"} "$REMOTE" "HEAD:refs/heads/${CURRENT_BRANCH}" || PUSH_OK=false
     else
-      if ! git_with_github_https_auth -C "$WT_PATH" push ${PUSH_LEASE[@]+"${PUSH_LEASE[@]}"} "$REMOTE" HEAD; then
-        if [[ ${#PUSH_LEASE[@]} -gt 0 ]]; then
-          echo "Error: Push rejected. Remote '$REMOTE/$CURRENT_BRANCH' may have changed since the force-with-lease expectation; fetch and rebase/merge before retrying." >&2
+      git_with_github_https_auth -C "$WT_PATH" push ${PUSH_LEASE[@]+"${PUSH_LEASE[@]}"} "$REMOTE" HEAD || PUSH_OK=false
+    fi
+
+    if [[ "$PUSH_OK" != true ]]; then
+      if [[ -n "$RESTACK_LEASE_OID" ]]; then
+        # Distinguish "remote actually moved" from a transient failure before
+        # touching the recorded authorization. A moved remote can never match
+        # the recorded head again, so the stale record is discarded and the
+        # user is told to integrate; any other failure keeps the record so a
+        # retry still carries the restack authorization.
+        REMOTE_NOW="$(git_with_github_https_auth -C "$WT_PATH" ls-remote "$REMOTE" "refs/heads/$CURRENT_BRANCH" 2>/dev/null | cut -f1 || true)"
+        if [[ -n "$REMOTE_NOW" && "$REMOTE_NOW" != "$RESTACK_LEASE_OID" ]]; then
+          clear_restack_lease "$WT_PATH"
+          echo "Error: Remote '$REMOTE/$CURRENT_BRANCH' moved from $RESTACK_LEASE_OID to $REMOTE_NOW after the restack was recorded." >&2
+          echo "The recorded restack authorization covered only the old remote head, so it was discarded." >&2
+          echo "Fetch and integrate the new remote commits (e.g. git -C \"$WT_PATH\" fetch $REMOTE && git -C \"$WT_PATH\" rebase \"$REMOTE/$CURRENT_BRANCH\"), then run push again." >&2
+        else
+          echo "Error: Push failed with the recorded restack lease. The restack authorization was kept; retry push after resolving the failure above." >&2
         fi
-        exit 1
+      elif [[ ${#PUSH_LEASE[@]} -gt 0 ]]; then
+        echo "Error: Push rejected. Remote '$REMOTE/$CURRENT_BRANCH' may have changed since the force-with-lease expectation; fetch and rebase/merge before retrying." >&2
       fi
+      exit 1
+    fi
+
+    if [[ -n "$RESTACK_LEASE_OID" ]]; then
+      # The authorization is single-use: consumed by the successful push.
+      clear_restack_lease "$WT_PATH"
     fi
     ;;
 

--- a/skills/worktree/tests/worktree_push_restack_lease.sh
+++ b/skills/worktree/tests/worktree_push_restack_lease.sh
@@ -1,0 +1,291 @@
+#!/usr/bin/env bash
+# Regression tests for the authorized-restack push lease (vstack#578).
+#
+# `create --reuse`/`--restack` intentionally rebases a published branch onto
+# origin/<default>, rewriting history. After the rewrite, push's fail-closed
+# lease (remote head must be an ancestor of HEAD) can never pass, so the
+# tool's own restack workflow could not publish through `worktree push`. The
+# fix records the observed remote head into the worktree's private git dir
+# (`worktree-restack-lease`) before the rebase starts and lets the next push
+# use it as an exact --force-with-lease expectation. The record is single-use:
+# deleted on push success, and discarded with an actionable error when the
+# remote moved past it. Every other push keeps today's fail-closed behavior:
+# divergence without a record still refuses, and a record naming a different
+# branch is ignored.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKTREE_SCRIPT="${WORKTREE_SCRIPT:-$(cd "$TEST_DIR/.." && pwd)/scripts/worktree}"
+TMP_ROOT="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+mkdir -p "$TMP_ROOT/bin"
+cat >"$TMP_ROOT/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}:${2:-}" in
+  pr:list) ;;
+esac
+STUB
+chmod +x "$TMP_ROOT/bin/gh"
+export PATH="$TMP_ROOT/bin:$PATH"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local got="$1" want="$2" name="$3"
+  if [[ "$got" == "$want" ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$name" "$want" "$got"
+  fi
+}
+
+assert_ne() {
+  local got="$1" unwanted="$2" name="$3"
+  if [[ "$got" != "$unwanted" ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected value to differ from: %s\n' "$name" "$unwanted"
+  fi
+}
+
+assert_contains() {
+  local haystack="$1" needle="$2" name="$3"
+  if grep -qF -- "$needle" <<<"$haystack"; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        wanted substring: %s\n        in: %s\n' "$name" "$needle" "$haystack"
+  fi
+}
+
+assert_not_contains() {
+  local haystack="$1" needle="$2" name="$3"
+  if grep -qF -- "$needle" <<<"$haystack"; then
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        unwanted substring present: %s\n        in: %s\n' "$name" "$needle" "$haystack"
+  else
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  fi
+}
+
+assert_path_exists() {
+  local path="$1" name="$2"
+  if [[ -e "$path" ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        missing path: %s\n' "$name" "$path"
+  fi
+}
+
+assert_path_absent() {
+  local path="$1" name="$2"
+  if [[ ! -e "$path" ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        still exists: %s\n' "$name" "$path"
+  fi
+}
+
+make_repo() {
+  local repo="$1"
+  mkdir -p "$repo"
+  git -C "$repo" init -q -b main
+  git -C "$repo" config user.email test@example.com
+  git -C "$repo" config user.name Test
+  git -C "$repo" config commit.gpgsign false
+  printf 'orig\n' > "$repo/file.txt"
+  git -C "$repo" add file.txt
+  git -C "$repo" commit -q -m base
+}
+
+# Path of the worktree's private restack-lease state file.
+lease_path() {
+  local wt="$1" path
+  path="$(git -C "$wt" rev-parse --git-path worktree-restack-lease)"
+  [[ "$path" == /* ]] || path="$wt/$path"
+  printf '%s\n' "$path"
+}
+
+# Build a main+origin pair with a PUBLISHED issue branch (pushed to origin,
+# like an open PR branch) whose local worktree carries a feature commit.
+make_published_pair() {
+  local root="$1" issue="$2"
+  make_repo "$root/main"
+  git init -q --bare "$root/origin.git"
+  git -C "$root/main" remote add origin "$root/origin.git"
+  git -C "$root/main" push -q -u origin main
+  (cd "$root/main" && "$WORKTREE_SCRIPT" create "$issue" >/dev/null 2>&1)
+  local wt="$root/trees/$issue"
+  printf 'feature\n' > "$wt/file.txt"
+  git -C "$wt" add file.txt
+  git -C "$wt" commit -q -m 'feature edit'
+  git -C "$wt" push -q -u origin "$issue"
+}
+
+echo "=== worktree push authorized-restack lease ==="
+
+# --- Full loop: conflicted --restack → resolve → continue → reuse → push -------
+LOOP_ROOT="$TMP_ROOT/loop"
+make_published_pair "$LOOP_ROOT" issue-loop
+LOOP_WT="$LOOP_ROOT/trees/issue-loop"
+# main edits the same line and advances origin — restack genuinely conflicts.
+printf 'main-side\n' > "$LOOP_ROOT/main/file.txt"
+git -C "$LOOP_ROOT/main" add file.txt
+git -C "$LOOP_ROOT/main" commit -q -m 'main edit'
+git -C "$LOOP_ROOT/main" push -q origin main
+loop_remote_pre="$(git --git-dir="$LOOP_ROOT/origin.git" rev-parse refs/heads/issue-loop)"
+set +e
+(
+  cd "$LOOP_ROOT/main" && \
+    "$WORKTREE_SCRIPT" create issue-loop --restack >"$LOOP_ROOT/create.out" 2>"$LOOP_ROOT/create.err"
+)
+loop_create_code=$?
+set -e
+loop_create_err="$(cat "$LOOP_ROOT/create.err")"
+LOOP_LEASE="$(lease_path "$LOOP_WT")"
+assert_eq "$loop_create_code" "1" "--restack with conflict still exits 1"
+assert_contains "$loop_create_err" "push issue-loop" "--restack guidance ends with the worktree push publish step"
+assert_path_exists "$LOOP_LEASE" "--restack records the lease before pausing in the conflict"
+assert_eq "$(cat "$LOOP_LEASE")" "refs/heads/issue-loop $loop_remote_pre" "recorded lease names the branch and the pre-restack remote head"
+
+# Resolve, continue, and finish setup exactly as the guidance instructs.
+printf 'resolved\n' > "$LOOP_WT/file.txt"
+git -C "$LOOP_WT" add file.txt
+GIT_EDITOR=true git -C "$LOOP_WT" rebase --continue >/dev/null 2>&1
+loop_reuse_out=$(cd "$LOOP_ROOT/main" && "$WORKTREE_SCRIPT" create issue-loop --reuse 2>"$LOOP_ROOT/reuse.err")
+assert_eq "$loop_reuse_out" "$LOOP_WT" "create --reuse after the resolved restack finishes setup"
+assert_path_exists "$LOOP_LEASE" "finishing setup keeps the recorded lease for the coming push"
+
+set +e
+(
+  cd "$LOOP_ROOT/main" && \
+    "$WORKTREE_SCRIPT" push issue-loop >"$LOOP_ROOT/push.out" 2>"$LOOP_ROOT/push.err"
+)
+loop_push_code=$?
+set -e
+assert_eq "$loop_push_code" "0" "push publishes the restacked branch via the recorded lease"
+assert_not_contains "$(cat "$LOOP_ROOT/push.err")" "not contained in local branch" "push does not hit the post-rewrite ancestry refusal"
+assert_path_absent "$LOOP_LEASE" "successful push consumes the recorded lease"
+assert_eq "$(git --git-dir="$LOOP_ROOT/origin.git" rev-parse refs/heads/issue-loop)" "$(git -C "$LOOP_WT" rev-parse HEAD)" "remote head matches the restacked local head"
+
+# --- Clean-reuse rebase (no conflict) has the same rewrite; push must work -----
+CLEAN_ROOT="$TMP_ROOT/clean"
+make_published_pair "$CLEAN_ROOT" issue-clean
+CLEAN_WT="$CLEAN_ROOT/trees/issue-clean"
+# main advances on an unrelated file — the reuse rebase is clean but rewrites.
+printf 'advanced\n' > "$CLEAN_ROOT/main/main-advanced.txt"
+git -C "$CLEAN_ROOT/main" add main-advanced.txt
+git -C "$CLEAN_ROOT/main" commit -q -m 'advance main'
+git -C "$CLEAN_ROOT/main" push -q origin main
+clean_remote_pre="$(git --git-dir="$CLEAN_ROOT/origin.git" rev-parse refs/heads/issue-clean)"
+clean_out=$(cd "$CLEAN_ROOT/main" && "$WORKTREE_SCRIPT" create issue-clean --reuse 2>"$CLEAN_ROOT/reuse.err")
+CLEAN_LEASE="$(lease_path "$CLEAN_WT")"
+assert_eq "$clean_out" "$CLEAN_WT" "clean reuse still prints the worktree path"
+assert_eq "$(cat "$CLEAN_LEASE")" "refs/heads/issue-clean $clean_remote_pre" "clean reuse rebase records the lease too"
+set +e
+(
+  cd "$CLEAN_ROOT/main" && \
+    "$WORKTREE_SCRIPT" push issue-clean >"$CLEAN_ROOT/push.out" 2>"$CLEAN_ROOT/push.err"
+)
+clean_push_code=$?
+set -e
+assert_eq "$clean_push_code" "0" "push publishes the clean-reuse rebase via the recorded lease"
+assert_path_absent "$CLEAN_LEASE" "successful push consumes the clean-reuse lease"
+assert_eq "$(git --git-dir="$CLEAN_ROOT/origin.git" rev-parse refs/heads/issue-clean)" "$(git -C "$CLEAN_WT" rev-parse HEAD)" "remote head matches the rebased local head"
+
+# --- Remote moved after the restack: lease rejects, record discarded -----------
+MOVED_ROOT="$TMP_ROOT/moved"
+make_published_pair "$MOVED_ROOT" issue-moved
+MOVED_WT="$MOVED_ROOT/trees/issue-moved"
+printf 'advanced\n' > "$MOVED_ROOT/main/main-advanced.txt"
+git -C "$MOVED_ROOT/main" add main-advanced.txt
+git -C "$MOVED_ROOT/main" commit -q -m 'advance main'
+git -C "$MOVED_ROOT/main" push -q origin main
+(cd "$MOVED_ROOT/main" && "$WORKTREE_SCRIPT" create issue-moved --reuse >/dev/null 2>&1)
+MOVED_LEASE="$(lease_path "$MOVED_WT")"
+assert_path_exists "$MOVED_LEASE" "reuse rebase recorded the lease before the remote moved"
+# Someone else pushes to the branch after the restack.
+git clone -q "$MOVED_ROOT/origin.git" "$MOVED_ROOT/external"
+git -C "$MOVED_ROOT/external" config user.email test@example.com
+git -C "$MOVED_ROOT/external" config user.name Test
+git -C "$MOVED_ROOT/external" config commit.gpgsign false
+git -C "$MOVED_ROOT/external" checkout -q issue-moved
+printf 'external\n' > "$MOVED_ROOT/external/external.txt"
+git -C "$MOVED_ROOT/external" add external.txt
+git -C "$MOVED_ROOT/external" commit -q -m 'external edit'
+git -C "$MOVED_ROOT/external" push -q origin issue-moved
+moved_remote_head="$(git --git-dir="$MOVED_ROOT/origin.git" rev-parse refs/heads/issue-moved)"
+set +e
+(
+  cd "$MOVED_ROOT/main" && \
+    "$WORKTREE_SCRIPT" push issue-moved >"$MOVED_ROOT/push.out" 2>"$MOVED_ROOT/push.err"
+)
+moved_push_code=$?
+set -e
+moved_push_err="$(cat "$MOVED_ROOT/push.err")"
+assert_eq "$moved_push_code" "1" "push fails when the remote moved past the recorded lease"
+assert_contains "$moved_push_err" "moved from" "error says the remote moved after the restack"
+assert_contains "$moved_push_err" "after the restack was recorded" "error attributes the rejection to the restack lease"
+assert_contains "$moved_push_err" "Fetch and integrate" "error instructs integrating the new remote commits"
+assert_path_absent "$MOVED_LEASE" "the stale restack record is discarded"
+assert_eq "$(git --git-dir="$MOVED_ROOT/origin.git" rev-parse refs/heads/issue-moved)" "$moved_remote_head" "the moved remote head was not overwritten"
+
+# --- Divergence without any restack record: today's fail-closed refusal --------
+PLAIN_ROOT="$TMP_ROOT/plain"
+make_published_pair "$PLAIN_ROOT" issue-plain
+PLAIN_WT="$PLAIN_ROOT/trees/issue-plain"
+plain_remote_pre="$(git --git-dir="$PLAIN_ROOT/origin.git" rev-parse refs/heads/issue-plain)"
+# Rewrite local history outside any tool-authorized restack.
+git -C "$PLAIN_WT" commit -q --amend -m 'amended feature edit'
+assert_path_absent "$(lease_path "$PLAIN_WT")" "no restack record exists for the manual rewrite"
+set +e
+(
+  cd "$PLAIN_ROOT/main" && \
+    "$WORKTREE_SCRIPT" push issue-plain >"$PLAIN_ROOT/push.out" 2>"$PLAIN_ROOT/push.err"
+)
+plain_push_code=$?
+set -e
+plain_push_err="$(cat "$PLAIN_ROOT/push.err")"
+assert_eq "$plain_push_code" "1" "push without a restack record still refuses divergence"
+assert_contains "$plain_push_err" "not contained in local branch" "unchanged fail-closed ancestry error"
+assert_contains "$plain_push_err" "Fetch and rebase/merge" "unchanged fail-closed recovery instruction"
+assert_eq "$(git --git-dir="$PLAIN_ROOT/origin.git" rev-parse refs/heads/issue-plain)" "$plain_remote_pre" "remote branch is untouched"
+
+# --- Record naming a different branch is ignored (fail closed) -----------------
+FOREIGN_ROOT="$TMP_ROOT/foreign"
+make_published_pair "$FOREIGN_ROOT" issue-foreign
+FOREIGN_WT="$FOREIGN_ROOT/trees/issue-foreign"
+foreign_remote_pre="$(git --git-dir="$FOREIGN_ROOT/origin.git" rev-parse refs/heads/issue-foreign)"
+git -C "$FOREIGN_WT" commit -q --amend -m 'amended feature edit'
+FOREIGN_LEASE="$(lease_path "$FOREIGN_WT")"
+printf 'refs/heads/some-other-branch %s\n' "$foreign_remote_pre" > "$FOREIGN_LEASE"
+set +e
+(
+  cd "$FOREIGN_ROOT/main" && \
+    "$WORKTREE_SCRIPT" push issue-foreign >"$FOREIGN_ROOT/push.out" 2>"$FOREIGN_ROOT/push.err"
+)
+foreign_push_code=$?
+set -e
+foreign_push_err="$(cat "$FOREIGN_ROOT/push.err")"
+assert_eq "$foreign_push_code" "1" "record for a different branch does not authorize the push"
+assert_contains "$foreign_push_err" "not contained in local branch" "different-branch record falls back to today's refusal"
+assert_path_exists "$FOREIGN_LEASE" "the ignored record is left in place"
+assert_eq "$(cat "$FOREIGN_LEASE")" "refs/heads/some-other-branch $foreign_remote_pre" "the ignored record content is untouched"
+assert_eq "$(git --git-dir="$FOREIGN_ROOT/origin.git" rev-parse refs/heads/issue-foreign)" "$foreign_remote_pre" "remote branch is untouched"
+
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

The supported `create --restack` flow (#567) rebases a PR branch, but `worktree push` then refused to publish — its lease requires the old remote head to be a local ancestor, impossible after an intentional rebase (observed live on hyprtrade#257). The clean `--reuse` rebase path had the same latent bug (confirmed + tested).

## Design

A state file (`git rev-parse --git-path worktree-restack-lease`, `refs/heads/<branch> <OID>`) carries the authorization: recorded immediately before the tool starts an intentional rebase (only when the remote head is provably an ancestor pre-rewrite, never for the default branch); consumed by push as `--force-with-lease=refs/heads/<branch>:<OID>` in place of the ancestry check; deleted only after a successful push. Remote moved past the recorded OID → git rejects the lease, the tool verifies via ls-remote, discards the stale record, and instructs re-restack. Different-branch/malformed records ignored; every non-restack push path byte-identical to today.

New 32-assertion suite covers both full loops (conflict + clean-reuse), remote-moved rejection, and fail-closed regressions. All 8 worktree suites green.

Closes #578

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016s6ZSLTTRft6fH29wHn1TN