### PR TITLE
fix: Bash 3.2-safe verification-scope dedup; project-management portability lint

### DIFF
--- a/skills/project-management/scripts/verification-scope
+++ b/skills/project-management/scripts/verification-scope
@@ -173,15 +173,20 @@ source_root_for_path() {
   fi
 }
 
-declare -A seen_candidates=()
-declare -a unique_candidates=()
-for path in "${candidates[@]}"; do
-  if [[ -z "${seen_candidates[$path]+x}" ]]; then
-    seen_candidates["$path"]=1
-    unique_candidates+=("$path")
-  fi
+# Dedup with a linear scan over an indexed array: associative arrays are
+# Bash 4+ and this skill must run under macOS system Bash 3.2.
+unique_candidates=()
+for path in ${candidates[@]+"${candidates[@]}"}; do
+  duplicate=false
+  for existing in ${unique_candidates[@]+"${unique_candidates[@]}"}; do
+    if [[ "$existing" == "$path" ]]; then
+      duplicate=true
+      break
+    fi
+  done
+  [[ "$duplicate" == true ]] || unique_candidates+=("$path")
 done
-candidates=("${unique_candidates[@]}")
+candidates=(${unique_candidates[@]+"${unique_candidates[@]}"})
 
 mode="repository"
 if [[ "$force_docs_only" == true ]]; then
@@ -200,16 +205,15 @@ elif [[ ${#candidates[@]} -gt 0 ]]; then
   done
 fi
 
-declare -A seen_roots=()
-declare -a source_roots=()
+source_roots=()
 
 add_source_root() {
-  local root="$1"
+  local root="$1" existing
   [[ -n "$root" && "$root" != "." ]] || root="."
-  if [[ -z "${seen_roots[$root]+x}" ]]; then
-    seen_roots["$root"]=1
-    source_roots+=("$root")
-  fi
+  for existing in ${source_roots[@]+"${source_roots[@]}"}; do
+    [[ "$existing" == "$root" ]] && return 0
+  done
+  source_roots+=("$root")
 }
 
 if [[ "$mode" == "repository" ]]; then

--- a/skills/project-management/tests/bash32-portability.test.sh
+++ b/skills/project-management/tests/bash32-portability.test.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Regression: project-management scripts must stay Bash 3.2-compatible
+# (macOS system bash). Guards against Bash 4+ constructs reappearing
+# (vstack#582 follow-up — verification-scope shipped with declare -A).
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
+
+PASS=0
+FAIL=0
+
+check_absent() {
+  local pattern="$1" label="$2"
+  if grep -rnE "$pattern" "$SKILL_DIR/scripts" 2>/dev/null | grep -v '^Binary'; then
+    FAIL=$((FAIL + 1))
+    printf 'FAIL: %s\n' "$label" >&2
+  else
+    PASS=$((PASS + 1))
+    printf 'PASS: %s\n' "$label"
+  fi
+}
+
+check_absent 'mapfile|readarray' "no mapfile/readarray in scripts/"
+check_absent 'declare -[a-zA-Z]*A|local -[a-zA-Z]*A' "no associative arrays in scripts/"
+check_absent '\$\{[A-Za-z_]+(,,|\^\^)\}' "no case-conversion expansions in scripts/"
+check_absent 'exec \{[A-Za-z_]+\}' "no auto-allocated FDs in scripts/"
+
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Greptile P2 on vanillagreencom/hyprtrade#259: the #582 `verification-scope` script shipped two `declare -A` dedups — Bash 4+ syntax against the 3.2 portability standard the same bundle establishes (#575/#577). Rewritten as linear-scan indexed arrays with `set -u`-safe empty expansions; behavior identical (verification-scope test green). project-management gains the same portability lint as the worktree and linear skills so this class can't regress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016s6ZSLTTRft6fH29wHn1TN