### PR TITLE
fix: make generated markdownlint cwd-independent

### DIFF
--- a/skills/orch/tests/generated-start-markdownlint.sh
+++ b/skills/orch/tests/generated-start-markdownlint.sh
@@ -14,6 +14,7 @@ TMP_ROOT="$(cd "$(mktemp -d)" && pwd -P)"
 trap 'rm -rf "$TMP_ROOT"' EXIT
 PROJECT="$TMP_ROOT/project"
 GENERATED="$PROJECT/.agents/skills/orch/workflows/start.md"
+GENERATED_RELATIVE=".agents/skills/orch/workflows/start.md"
 SNAPSHOT="$TMP_ROOT/start-after-add.md"
 
 PASS=0
@@ -60,7 +61,8 @@ lint_generated() {
 
   # These three style rules are intentionally disabled by the downstream
   # repository from #586. All other default rules, including MD022/55/56, run.
-  if "${runner[@]}" --disable MD013 MD031 MD060 -- "$GENERATED"; then
+  if (cd "$PROJECT" && "${runner[@]}" --disable MD013 MD031 MD060 -- \
+    "$GENERATED_RELATIVE"); then
     pass "$phase output passes markdownlint"
   else
     fail "$phase output fails markdownlint"

--- a/skills/orch/tests/run-all.sh
+++ b/skills/orch/tests/run-all.sh
@@ -18,6 +18,8 @@ FILTER="${1:-}"
 
 FAIL_FILES=()
 RUN=0
+EXTERNAL_CALLER_CWD="$(mktemp -d)"
+trap 'rm -rf "$EXTERNAL_CALLER_CWD"' EXIT
 
 for test_file in "$TEST_DIR"/*.sh; do
   [[ -f "$test_file" ]] || continue
@@ -28,7 +30,16 @@ for test_file in "$TEST_DIR"/*.sh; do
   fi
   RUN=$((RUN + 1))
   printf '\n──── %s ────\n' "$base"
-  if bash "$test_file"; then
+  if [[ "$base" == "generated-start-markdownlint" ]]; then
+    # Keep this regression independent of the suite's caller. markdownlint's
+    # ignore handling rejects absolute fixture paths outside its working tree.
+    (cd "$EXTERNAL_CALLER_CWD" && bash "$test_file")
+    test_status=$?
+  else
+    bash "$test_file"
+    test_status=$?
+  fi
+  if [[ "$test_status" -eq 0 ]]; then
     :
   else
     FAIL_FILES+=("$base")


### PR DESCRIPTION
## Summary

- run generated-workflow markdownlint from the fixture project with the relative `.agents/skills/orch/workflows/start.md` path
- make the orch suite invoke this regression from an external caller working directory
- retain canonical byte comparison, repeated-refresh idempotence, and failure-count/nonzero-exit assertions

## Validation

- `skills/orch/tests/generated-start-markdownlint.sh` from the vstack worktree (14 checks passed)
- the same focused test invoked by absolute path from `/home/method/dev/hyprtrade` (14 checks passed)
- `skills/orch/tests/run-all.sh` (all 13 test files passed)
- `cargo test` from `cli/` (380 passed, 2 ignored)
- `cli/scripts/integration-check.sh`
- `bash -n skills/orch/tests/generated-start-markdownlint.sh`
- `bash -n skills/orch/tests/run-all.sh`
- `git diff --cached --check`

Fixes #589
