### PR TITLE
fix(#593): preserve OpenCode config newline

### DIFF
--- a/cli/src/installer/hooks/opencode.rs
+++ b/cli/src/installer/hooks/opencode.rs
@@ -50,7 +50,7 @@ pub(crate) fn opencode_hook_instruction_contents(hook: &Hook) -> String {
     format!("# Safety: {}\n\n{}", hook.name, hook.safety_prose())
 }
 
-fn install_hook_opencode_at_path(
+pub(super) fn install_hook_opencode_at_path(
     hook: &Hook,
     config_path: &Path,
     instruction_path: &Path,
@@ -110,7 +110,7 @@ fn install_hook_opencode_at_path(
         instructions.push(serde_json::Value::String(instruction_ref.to_string()));
     }
 
-    let output = serde_json::to_string_pretty(&config)?;
+    let output = serialize_opencode_config(&config)?;
     std::fs::write(config_path, output)?;
 
     Ok(())
@@ -221,11 +221,17 @@ pub(super) fn remove_hook_from_opencode_json_at_path(
     }
 
     if changed {
-        let output = serde_json::to_string_pretty(&config)?;
+        let output = serialize_opencode_config(&config)?;
         std::fs::write(config_path, output)?;
     }
     if remove_instruction {
         let _ = std::fs::remove_file(instruction_path);
     }
     Ok(())
+}
+
+fn serialize_opencode_config(config: &serde_json::Value) -> Result<String> {
+    let mut output = serde_json::to_string_pretty(config)?;
+    output.push('\n');
+    Ok(output)
 }

--- a/cli/src/installer/hooks/tests.rs
+++ b/cli/src/installer/hooks/tests.rs
@@ -1,4 +1,4 @@
-use super::opencode::remove_hook_from_opencode_json_at_path;
+use super::opencode::{install_hook_opencode_at_path, remove_hook_from_opencode_json_at_path};
 use super::*;
 
 fn hook_fixture(name: &str, event: &str, matcher: Option<&str>) -> Hook {
@@ -537,6 +537,8 @@ fn remove_hook_from_opencode_removes_instruction() {
 
     let result = std::fs::read_to_string(&config_path).unwrap();
     let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+    assert!(result.ends_with('\n'));
+    assert!(!result.ends_with("\n\n"));
 
     // instructions and permission should be gone
     assert!(
@@ -554,6 +556,40 @@ fn remove_hook_from_opencode_removes_instruction() {
 
     // Cleanup
     let _ = std::fs::remove_dir_all(&base);
+}
+
+#[test]
+fn install_hook_opencode_normalizes_trailing_newlines_and_is_idempotent() {
+    for (label, trailing) in [("none", ""), ("one", "\n"), ("multiple", "\n\n\n")] {
+        let base = tmpdir(&format!("opencode_newline_{label}"));
+        let config_path = base.join("opencode.json");
+        let instruction_path = base.join("instructions").join("vstack-hook-guard.md");
+        let instruction_ref = "instructions/vstack-hook-guard.md";
+        let hook = hook_fixture("guard", "PreToolUse", Some("Bash"));
+        std::fs::write(&config_path, format!("{{\"custom\":true}}{trailing}")).unwrap();
+
+        install_hook_opencode_at_path(&hook, &config_path, &instruction_path, instruction_ref)
+            .unwrap();
+
+        let first = std::fs::read(&config_path).unwrap();
+        assert!(first.ends_with(b"\n"), "{label}: missing trailing newline");
+        assert!(
+            !first.ends_with(b"\n\n"),
+            "{label}: emitted multiple trailing newlines"
+        );
+        let parsed: serde_json::Value = serde_json::from_slice(&first).unwrap();
+        assert_eq!(parsed.get("custom"), Some(&serde_json::json!(true)));
+
+        install_hook_opencode_at_path(&hook, &config_path, &instruction_path, instruction_ref)
+            .unwrap();
+
+        assert_eq!(
+            std::fs::read(&config_path).unwrap(),
+            first,
+            "{label}: second install changed the rendered config"
+        );
+        let _ = std::fs::remove_dir_all(&base);
+    }
 }
 
 #[test]

--- a/cli/tests/hook_lifecycle.rs
+++ b/cli/tests/hook_lifecycle.rs
@@ -175,6 +175,53 @@ fn agent_frontmatter(content: &str) -> &str {
         .expect("frontmatter present")
 }
 
+fn assert_single_trailing_newline(bytes: &[u8], context: &str) {
+    assert!(bytes.ends_with(b"\n"), "{context} has no trailing newline");
+    assert!(
+        !bytes.ends_with(b"\n\n"),
+        "{context} has multiple trailing newlines"
+    );
+    serde_json::from_slice::<serde_json::Value>(bytes)
+        .unwrap_or_else(|error| panic!("{context} is not valid JSON: {error}"));
+}
+
+#[test]
+fn opencode_project_config_is_newline_terminated_across_refreshes() {
+    let sandbox = Sandbox::new("opencode-config-newline");
+
+    let output = sandbox
+        .vstack()
+        .arg("add")
+        .arg(&sandbox.source)
+        .args(["--hook", "guard", "--harness", "opencode", "--copy", "-y"])
+        .output()
+        .unwrap();
+    assert_success(output, "vstack add");
+
+    let config_path = sandbox.project.join("opencode.json");
+    let installed = fs::read(&config_path).unwrap();
+    assert_single_trailing_newline(&installed, "installed OpenCode project config");
+
+    for refresh_number in 1..=2 {
+        let output = sandbox
+            .vstack()
+            .args(["refresh", "--scope", "project", "-v"])
+            .output()
+            .unwrap();
+        assert_success(output, &format!("vstack refresh {refresh_number}"));
+
+        let refreshed = fs::read(&config_path).unwrap();
+        assert_single_trailing_newline(
+            &refreshed,
+            &format!("OpenCode project config after refresh {refresh_number}"),
+        );
+        assert_eq!(
+            refreshed, installed,
+            "refresh {refresh_number} changed the rendered OpenCode project config"
+        );
+    }
+}
+
 #[test]
 fn agent_install_without_hooks_does_not_emit_claude_hook_frontmatter() {
     let sandbox = Sandbox::new("add-no-hooks");


### PR DESCRIPTION
## Summary

- Route OpenCode project config writes through one serializer that emits exactly one trailing newline.
- Use the serializer for both hook installation and hook removal without changing other JSON emitters.
- Cover zero, one, and multiple trailing-newline inputs, repeated installation, and a real downstream project add followed by two refreshes.

## Validation

- `cargo fmt --all -- --check`
- Focused OpenCode unit and hook-lifecycle integration tests
- `cargo test` (365 unit tests and 17 integration tests passed; 2 opt-in tests ignored)
- `cargo clippy --all-targets -- -D warnings`
- `cli/scripts/integration-check.sh`
- JSON parsing and byte-idempotence assertions are included in the regressions
- `git diff --check`

Fixes #593
