### PR TITLE
fix: sync Linear cache before dev reads

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -18,7 +18,7 @@ Unit + integration tests:
 cargo test
 ```
 
-Integration check — installs everything from this repo into a throwaway downstream project, verifies the printed `Scope:` line, refreshes twice, checks generated orch workflow byte identity and markdownlint, and runs the refreshed installed orch suite from an external working directory:
+Integration check — installs everything from this repo into a throwaway downstream project, verifies the printed `Scope:` line, refreshes twice, checks generated orch workflow byte identity and markdownlint plus generated dev workflow byte identity, then runs the refreshed installed dev cache-preflight regression and orch suite from an external working directory:
 
 ```bash
 scripts/integration-check.sh
@@ -31,4 +31,5 @@ Do not validate by running `cargo run -- add .. --all --copy` from inside this c
 The CLI does not run skill or extension tests during ordinary commands. Each test surface lives next to the code it covers, except source-only cross-boundary installation checks, which stay in `scripts/integration-check.sh` so they are not shipped in an installed skill:
 
 - Orch shell tests: [`../skills/orch/DEVELOPMENT.md#tests`](../skills/orch/DEVELOPMENT.md#tests)
+- Dev shell tests: [`../skills/dev/README.md#tests`](../skills/dev/README.md#tests)
 - Pi extension Bun tests: each `pi-extensions/<name>/tests/` directory

--- a/cli/scripts/integration-check.sh
+++ b/cli/scripts/integration-check.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Source integration check: install everything from this repo into a throwaway
-# downstream project, refresh it twice, and verify the installed orch skill.
+# downstream project, refresh it twice, and verify installed workflow contracts.
 #
 # `vstack add` resolves PROJECT scope by walking up from the CWD
 # (cli/src/config.rs::find_project_root_within) looking for .vstack-lock.json or
@@ -9,14 +9,15 @@
 # runs from a seeded temp project and verifies the reported and on-disk scope.
 #
 # Generator checks live here, not in skills/orch/tests: they require both the
-# source CLI and canonical source tree. Every test shipped with the installed
-# orch skill must remain runnable without either source-only dependency.
+# source CLI and canonical source tree. Installed regressions must remain
+# runnable without either source-only dependency.
 set -euo pipefail
 
 script_dir=$(cd "$(dirname "$0")" && pwd -P)
 cli_dir=$(cd "$script_dir/.." && pwd -P)
 repo_root=$(cd "$cli_dir/.." && pwd -P)
 canonical=$repo_root/skills/orch/workflows/start.md
+canonical_dev=$repo_root/skills/dev/workflows/dev-implement.md
 markdownlint_cli_version=0.49.1
 
 cargo build --manifest-path "$cli_dir/Cargo.toml"
@@ -27,6 +28,8 @@ mkdir "$tmp_project/.claude" # project marker — .git is not one (see config.rs
 tmp_phys=$(cd "$tmp_project" && pwd -P)
 generated=$tmp_phys/.agents/skills/orch/workflows/start.md
 generated_relative=.agents/skills/orch/workflows/start.md
+generated_dev=$tmp_phys/.agents/skills/dev/workflows/dev-implement.md
+installed_dev_cache_test=$tmp_phys/.agents/skills/dev/tests/linear-cache-preflight-contract.test.sh
 installed_run_all=$tmp_phys/.agents/skills/orch/tests/run-all.sh
 obsolete_installed_test=$tmp_phys/.agents/skills/orch/tests/generated-start-markdownlint.sh
 snapshot=$tmp_phys/start-after-add.md
@@ -57,6 +60,16 @@ assert_generated_matches() {
   else
     fail "$phase output differs from canonical start workflow"
     diff -u "$canonical" "$generated" || true
+  fi
+}
+
+assert_dev_generated_matches() {
+  local phase=$1
+  if cmp -s "$canonical_dev" "$generated_dev"; then
+    pass "$phase output matches canonical dev-implement workflow"
+  else
+    fail "$phase output differs from canonical dev-implement workflow"
+    diff -u "$canonical_dev" "$generated_dev" || true
   fi
 }
 
@@ -97,7 +110,17 @@ check_generated() {
   fi
 }
 
-echo "=== downstream install and orch verification ==="
+check_dev_generated() {
+  local phase=$1
+  if [[ -f "$generated_dev" ]]; then
+    pass "$phase generated the dev-implement workflow"
+    assert_dev_generated_matches "$phase"
+  else
+    fail "$phase generated the dev-implement workflow"
+  fi
+}
+
+echo "=== downstream install and workflow verification ==="
 
 log=$tmp_phys/vstack-add.log
 if ! (cd "$tmp_phys" && "$cli_dir/target/debug/vstack" add "$repo_root" \
@@ -126,6 +149,7 @@ case $scope_line in
 esac
 
 check_generated "install"
+check_dev_generated "install"
 if [[ -f "$generated" ]]; then
   cp "$generated" "$snapshot"
 fi
@@ -149,6 +173,7 @@ else
 fi
 
 check_generated "first refresh"
+check_dev_generated "first refresh"
 if [[ ! -e "$obsolete_installed_test" ]]; then
   pass "first refresh removes the obsolete installed source-only test"
 else
@@ -172,6 +197,7 @@ else
 fi
 
 check_generated "second refresh"
+check_dev_generated "second refresh"
 if [[ -f "$snapshot" && -f "$generated" ]]; then
   if cmp -s "$snapshot" "$generated"; then
     pass "second refresh is byte-idempotent"
@@ -184,6 +210,22 @@ if grep -Eq 'skill[[:space:]]+orch.*\(unchanged\)' "$refresh_two_log"; then
   pass "second refresh reports orch unchanged"
 else
   fail "second refresh reports orch unchanged"
+fi
+if grep -Eq 'skill[[:space:]]+dev.*\(unchanged\)' "$refresh_two_log"; then
+  pass "second refresh reports dev unchanged"
+else
+  fail "second refresh reports dev unchanged"
+fi
+
+installed_dev_log=$tmp_phys/installed-dev-cache-preflight.log
+if [[ ! -f "$installed_dev_cache_test" ]]; then
+  fail "installed dev cache-preflight regression exists"
+elif (cd "$external_caller_cwd" && bash "$installed_dev_cache_test") \
+  >"$installed_dev_log" 2>&1; then
+  pass "refreshed installed dev cache-preflight regression passes externally"
+else
+  fail "refreshed installed dev cache-preflight regression passes externally"
+  indent_log "$installed_dev_log"
 fi
 
 installed_suite_log=$tmp_phys/installed-orch-suite.log
@@ -199,10 +241,10 @@ fi
 
 verify_log=$tmp_phys/verify.log
 if (cd "$tmp_phys" && "$cli_dir/target/debug/vstack" verify \
-  --scope project orch) >"$verify_log" 2>&1; then
-  pass "verify confirms the refreshed orch install"
+  --scope project orch dev) >"$verify_log" 2>&1; then
+  pass "verify confirms the refreshed orch and dev installs"
 else
-  fail "verify confirms the refreshed orch install"
+  fail "verify confirms the refreshed orch and dev installs"
   indent_log "$verify_log"
 fi
 

--- a/skills/dev/README.md
+++ b/skills/dev/README.md
@@ -6,20 +6,27 @@ Agent workflows for issue implementation and review fix processing, for speciali
 
 | Workflow | Purpose |
 |----------|---------|
-| `workflows/dev-implement.md` | Full implementation lifecycle: activate → plan → implement → validate → commit → QA labels → summary → finalize (§ 1-11) |
+| `workflows/dev-implement.md` | Full implementation lifecycle: sync/activate → plan → implement → validate → commit → QA labels → summary → finalize (§ 1-11) |
 | `workflows/dev-fix.md` | Process review fix items: evaluate → apply/skip → validate → commit → return |
 
 Code-review and QA-review workflows live in the reviewer skill: `skills/reviewer/workflows/review.md` and `skills/reviewer/workflows/qa-review.md`.
 
 ## Structure
 
-```
+```text
 skills/dev/
 ├── SKILL.md              # Skill definition for AI agents
 ├── README.md             # This file
+├── tests/                # Hermetic workflow contract regressions
 └── workflows/
     ├── dev-implement.md  # Main implementation lifecycle (§ 1-11)
     └── dev-fix.md        # Review fix workflow (§ 1-6)
+```
+
+## Tests
+
+```bash
+find skills/dev/tests -type f -name '*.test.sh' -exec bash {} \;
 ```
 
 ## Dependencies

--- a/skills/dev/tests/linear-cache-preflight-contract.test.sh
+++ b/skills/dev/tests/linear-cache-preflight-contract.test.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# Regression test for #602: a Linear work item must establish its local cache
+# before mandatory reads, while GitHub-tracked work must not invoke Linear.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKFLOW="$TEST_DIR/../workflows/dev-implement.md"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+fail() {
+    printf 'FAIL: %s\n' "$*" >&2
+    exit 1
+}
+
+require_text() {
+    needle="$1"
+    description="$2"
+    if ! grep -Fq -- "$needle" "$WORKFLOW"; then
+        fail "$description"
+    fi
+    printf 'ok - %s\n' "$description"
+}
+
+line_of() {
+    needle="$1"
+    match="$(grep -nFm 1 -- "$needle" "$WORKFLOW")"
+    if [ -z "$match" ]; then
+        fail "missing workflow command: $needle"
+    fi
+    line="${match%%:*}"
+    printf '%s\n' "$line"
+}
+
+assert_before() {
+    first="$1"
+    second="$2"
+    description="$3"
+    if [ "$first" -ge "$second" ]; then
+        fail "$description"
+    fi
+    printf 'ok - %s\n' "$description"
+}
+
+SYNC_COMMAND='.agents/skills/linear/scripts/linear.sh sync --reconcile'
+ACTIVATE_COMMAND='.agents/skills/linear/scripts/linear.sh issues activate [ISSUE_ID] --agent [AGENT_TYPE]'
+ISSUE_READ_COMMAND='.agents/skills/linear/scripts/linear.sh cache issues get [ISSUE_ID]'
+COMMENT_READ_COMMAND='.agents/skills/linear/scripts/linear.sh cache comments list [ISSUE_ID]'
+
+sync_line="$(line_of "$SYNC_COMMAND")"
+activate_line="$(line_of "$ACTIVATE_COMMAND")"
+issue_read_line="$(line_of "$ISSUE_READ_COMMAND")"
+comment_read_line="$(line_of "$COMMENT_READ_COMMAND")"
+
+assert_before "$sync_line" "$activate_line" 'sync precedes activation'
+assert_before "$sync_line" "$issue_read_line" 'sync precedes issue cache read'
+assert_before "$sync_line" "$comment_read_line" 'sync precedes comment cache read'
+
+require_text 'A missing cache before that command is expected in a fresh worktree.' \
+    'fresh missing cache is an expected pre-sync state'
+require_text 'that is a sync/auth/API/config' \
+    'sync and authentication failures retain a distinct diagnosis'
+require_text 'after sync succeeded' \
+    'post-sync missing cache is diagnosed as initialization failure'
+require_text 'Never run this Linear preflight for GitHub-tracked or ad-hoc work.' \
+    'non-Linear trackers explicitly skip the preflight'
+
+mkdir -p "$tmp/bin" "$tmp/project"
+COMMAND_LOG="$tmp/commands.log"
+CACHE_META="$tmp/project/meta.json"
+export COMMAND_LOG CACHE_META
+
+cat > "$tmp/bin/linear.sh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$COMMAND_LOG"
+
+if [ "${1:-}" = 'sync' ]; then
+    if [ "${LINEAR_STUB_MODE:-success}" = 'auth-failure' ]; then
+        printf '%s\n' '{"error":"Authentication failed. Check your LINEAR_API_KEY."}' >&2
+        exit 19
+    fi
+    printf '%s\n' '{"synced_at":"2026-07-15T00:00:00Z"}' > "$CACHE_META"
+    exit 0
+fi
+
+if [ ! -f "$CACHE_META" ]; then
+    printf '%s\n' '{"error":"No cache found. Run: linear.sh sync"}' >&2
+    exit 1
+fi
+
+case "${1:-} ${2:-}" in
+    'issues activate') printf '%s\n' '{"activated":true}' ;;
+    'cache issues') printf '%s\n' '{"id":"TEST-1"}' ;;
+    'cache comments') printf '%s\n' '[]' ;;
+    *) printf 'unexpected command: %s\n' "$*" >&2; exit 2 ;;
+esac
+STUB
+chmod +x "$tmp/bin/linear.sh"
+
+run_linear_sequence() {
+    "$tmp/bin/linear.sh" sync --reconcile
+    "$tmp/bin/linear.sh" issues activate TEST-1 --agent dev
+    "$tmp/bin/linear.sh" cache issues get TEST-1
+    "$tmp/bin/linear.sh" cache comments list TEST-1
+}
+
+assert_linear_log() {
+    expected="$tmp/expected.log"
+    cat > "$expected" <<'EXPECTED'
+sync --reconcile
+issues activate TEST-1 --agent dev
+cache issues get TEST-1
+cache comments list TEST-1
+EXPECTED
+    if ! cmp -s "$expected" "$COMMAND_LOG"; then
+        diff -u "$expected" "$COMMAND_LOG" >&2 || true
+        fail "$1"
+    fi
+    printf 'ok - %s\n' "$1"
+}
+
+# Fresh worktree: sync creates the absent cache before reads.
+rm -f "$CACHE_META" "$COMMAND_LOG"
+run_linear_sequence > "$tmp/fresh.out" 2> "$tmp/fresh.err"
+assert_linear_log 'fresh missing cache syncs before successful reads'
+if ! grep -Fq '"id":"TEST-1"' "$tmp/fresh.out"; then
+    fail 'successful sync/read did not return issue context'
+fi
+printf 'ok - successful sync/read returns issue context\n'
+
+# Existing verified cache: session-start reconcile still runs before reads.
+printf '%s\n' '{"synced_at":"2026-07-14T00:00:00Z"}' > "$CACHE_META"
+rm -f "$COMMAND_LOG"
+run_linear_sequence > "$tmp/existing.out" 2> "$tmp/existing.err"
+assert_linear_log 'existing cache is reconciled and then read'
+
+# Auth/API failure: stop at sync and never fall through to cache reads.
+rm -f "$CACHE_META" "$COMMAND_LOG"
+set +e
+(export LINEAR_STUB_MODE=auth-failure; set -e; run_linear_sequence) \
+    > "$tmp/auth.out" 2> "$tmp/auth.err"
+auth_rc=$?
+set -e
+if [ "$auth_rc" -ne 19 ]; then
+    fail "auth failure returned $auth_rc instead of 19"
+fi
+if [ "$(wc -l < "$COMMAND_LOG" | tr -d ' ')" -ne 1 ]; then
+    fail 'auth failure continued beyond sync'
+fi
+if ! grep -Fq 'Authentication failed' "$tmp/auth.err"; then
+    fail 'auth failure diagnostic was not preserved'
+fi
+if grep -Fq 'No cache found' "$tmp/auth.err"; then
+    fail 'auth failure was misreported as a missing cache'
+fi
+printf 'ok - sync/auth failure stops before activation and cache reads\n'
+
+# GitHub path: its documented block contains only the GitHub lookup.
+github_section="$tmp/github-section.md"
+sed -n '/^GitHub only:/,/^Ad-hoc:/p' "$WORKFLOW" > "$github_section"
+if grep -Fq 'linear.sh' "$github_section"; then
+    fail 'GitHub tracker path contains a Linear command'
+fi
+if ! grep -Fq 'gh issue view [N] --repo [OWNER/REPO]' "$github_section"; then
+    fail 'GitHub tracker path lost its issue lookup'
+fi
+printf 'ok - GitHub tracker path performs no Linear work\n'
+
+printf 'all pass\n'

--- a/skills/dev/workflows/dev-implement.md
+++ b/skills/dev/workflows/dev-implement.md
@@ -51,11 +51,21 @@ Determine tracker:
 Linear only:
 
 ```bash
+# Establish the worktree-local cache before any mandatory cache read. This is
+# a full sync in a fresh worktree and an incremental reconcile otherwise.
+.agents/skills/linear/scripts/linear.sh sync --reconcile
 # Activate issue (or parent if bundled), replace [AGENT_TYPE] with your agent type
 .agents/skills/linear/scripts/linear.sh issues activate [ISSUE_ID] --agent [AGENT_TYPE]
 .agents/skills/linear/scripts/linear.sh cache issues get [ISSUE_ID]
 .agents/skills/linear/scripts/linear.sh cache comments list [ISSUE_ID]
 ```
+
+The `sync --reconcile` command must succeed before activation or cache reads.
+A missing cache before that command is expected in a fresh worktree. If sync
+fails, stop and preserve its exact diagnostic: that is a sync/auth/API/config
+failure, not a missing-cache result. If a mandatory cache read reports `No
+cache found` after sync succeeded, stop and report a cache-initialization
+defect. Never run this Linear preflight for GitHub-tracked or ad-hoc work.
 
 GitHub only:
 

--- a/skills/orch/DEVELOPMENT.md
+++ b/skills/orch/DEVELOPMENT.md
@@ -64,7 +64,8 @@ All tests discovered by `run-all.sh` are part of the installed orch skill and
 must pass in downstream projects without access to the vstack source checkout.
 The source-only CLI/generator regression runs through
 `cli/scripts/integration-check.sh`; it validates install/refresh byte identity,
-markdownlint, idempotence, and the refreshed downstream `run-all.sh` suite.
+markdownlint, idempotence, the refreshed downstream `run-all.sh` suite, and the
+installed dev work-item cache-preflight contract.
 
 ## Codex App Worktree Routing
 


### PR DESCRIPTION
## Summary

- run the canonical Linear `sync --reconcile` session preflight before issue activation or mandatory cache reads
- keep GitHub-tracked and ad-hoc work completely outside the Linear path, with distinct guidance for sync/auth failures versus an impossible post-sync missing cache
- add hermetic Bash 5.3/Bash 3.2 regressions and downstream install/refresh verification for the generated dev workflow

## Validation

- focused dev workflow suite: pass
- Docker `bash:3.2` dev workflow suite: pass
- repository-wide `*.test.sh` suite: pass
- orch `run-all.sh`: pass
- Cargo fmt: pass
- Cargo tests: 365 unit + 17 integration passed; 2 ignored
- Cargo clippy with warnings denied: pass
- downstream install, two refreshes, installed regressions, installed orch suite, and `vstack verify orch dev`: 27 pass / 0 fail

Fixes #602
