### PR TITLE
fix(#608): recognize required merge queue enrollment

### DIFF
--- a/skills/github/README.md
+++ b/skills/github/README.md
@@ -63,6 +63,11 @@ keeps the raw `gh`/`op` detail for logs.
 `pr-merge --check` reports still-running checks as `ci_pending: ...` and sets
 `transient: true` when those pending checks are the only blockers. Terminal
 failed or cancelled checks remain `ci_failed: ...` and are not transient.
+Merge execution is exact-head guarded. A successful mutation returns exit `0`
+when already merged, exit `75` with a distinct message when either a required
+merge-queue entry or classic auto-merge is active, and exit `1` when no merged,
+queued, or armed postcondition can be proven. Required-queue membership is read
+through GraphQL because `gh pr view --json` does not expose it.
 
 ## Git HTTPS Fallback
 

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -111,9 +111,17 @@ parsing stderr:
 
 | Exit | Meaning | Stderr line | When |
 |------|---------|-------------|------|
-| `0`  | MERGED                | `MERGED PR #N`               | Merge completed immediately |
-| `75` | QUEUED FOR AUTO-MERGE | `QUEUED FOR AUTO-MERGE PR #N`| `--auto` enabled GitHub auto-merge; fires when CI + branch protection clear |
-| `1`  | BLOCKED               | `BLOCKED PR #N`              | Checks failed; nothing merged, nothing queued |
+| `0`  | MERGED | `MERGED PR #N` | Merge completed immediately |
+| `75` | MERGE PENDING | `QUEUED IN MERGE QUEUE PR #N` | A required GitHub merge queue has an active entry |
+| `75` | MERGE PENDING | `AUTO-MERGE ENABLED PR #N` | Classic auto-merge is armed until protection clears |
+| `1`  | BLOCKED | `BLOCKED PR #N` | Nothing merged, queued, or armed |
+
+Before mutating merge state, `pr-merge` resolves the exact PR head and passes
+it through `--match-head-commit`. After a successful `gh` call it reads queue
+membership with GraphQL because `gh pr view --json` does not expose
+`mergeQueueEntry`. An `OPEN` PR with no `autoMergeRequest` is therefore still a
+successful exit `75` when its required merge-queue entry is active; an `OPEN`
+PR with neither queue nor auto-merge proof fails closed.
 
 A BLOCKED outcome is further classified on stderr as **transient** (mergeable
 UNKNOWN, `ci_pending`, CI fetch uncertainty — caller should

--- a/skills/github/scripts/commands/pr-merge.sh
+++ b/skills/github/scripts/commands/pr-merge.sh
@@ -4,7 +4,7 @@
 #
 # Outcomes (distinct exit codes + messages):
 #   0   MERGED                 — merge completed immediately
-#   75  QUEUED FOR AUTO-MERGE  — --auto enabled, merge fires when CI/branch-protection clears
+#   75  QUEUED / AUTO-MERGE     — merge queue entry or classic auto-merge is active
 #   1   BLOCKED                — checks failed; no merge attempted, none queued
 #
 # When BLOCKED, stderr distinguishes TRANSIENT issues (mergeable UNKNOWN,
@@ -91,7 +91,7 @@ Modes:
 
 Exit codes:
   0    MERGED                 — merge completed immediately
-  75   QUEUED FOR AUTO-MERGE  — --auto enabled, will fire when CI clears
+  75   QUEUED / AUTO-MERGE     — merge queue entry or classic auto-merge is active
   1    BLOCKED                — checks failed; nothing queued
 
 Examples:
@@ -262,6 +262,71 @@ print_blocked() {
     echo "Use --auto to queue for auto-merge, or --force to merge anyway." >&2
 }
 
+# Run gh with the same effective identity used for the merge mutation. Keep the
+# token scoped to the subprocess so the caller's environment is never changed.
+gh_with_token() {
+    local auth_token="${1:-}"
+    shift
+
+    if [ -n "$auth_token" ]; then
+        GH_TOKEN="$auth_token" gh "$@"
+    else
+        gh "$@"
+    fi
+}
+
+# Read one authoritative post-mutation snapshot. `gh pr view --json` does not
+# expose merge-queue membership, so required-queue repositories need GraphQL.
+# Fall back to the classic `gh pr view` fields when the queue query itself is
+# unavailable; queue membership remains false in that fail-closed fallback.
+post_merge_snapshot() {
+    local pr_num="$1"
+    local auth_token="$2"
+    local snapshot=""
+
+    if snapshot=$(gh_with_token "$auth_token" api graphql \
+        -f query='query($owner: String!, $repo: String!, $number: Int!) { repository(owner: $owner, name: $repo) { pullRequest(number: $number) { state headRefOid headRefName mergeCommit { oid } autoMergeRequest { enabledAt } isInMergeQueue mergeQueueEntry { state } } } }' \
+        -F owner='{owner}' -F repo='{repo}' -F number="$pr_num" 2>/dev/null) && \
+        jq -e '.data.repository.pullRequest != null' >/dev/null 2>&1 <<<"$snapshot"; then
+        jq -c '
+            .data.repository.pullRequest
+            | {
+                state: (.state // "UNKNOWN"),
+                head: (.headRefOid // ""),
+                head_branch: (.headRefName // ""),
+                merge_commit: (.mergeCommit.oid // ""),
+                auto_merge: (.autoMergeRequest != null),
+                in_merge_queue: (.isInMergeQueue == true),
+                merge_queue_entry: (.mergeQueueEntry != null),
+                queue_state: (.mergeQueueEntry.state // ""),
+                source: "graphql"
+            }
+        ' <<<"$snapshot"
+        return 0
+    fi
+
+    if snapshot=$(gh_with_token "$auth_token" pr view "$pr_num" \
+        --json state,headRefOid,headRefName,mergeCommit,autoMergeRequest 2>/dev/null) && \
+        jq -e 'type == "object"' >/dev/null 2>&1 <<<"$snapshot"; then
+        jq -c '
+            {
+                state: (.state // "UNKNOWN"),
+                head: (.headRefOid // ""),
+                head_branch: (.headRefName // ""),
+                merge_commit: (.mergeCommit.oid // ""),
+                auto_merge: (.autoMergeRequest != null),
+                in_merge_queue: false,
+                merge_queue_entry: false,
+                queue_state: "",
+                source: "pr-view-fallback"
+            }
+        ' <<<"$snapshot"
+        return 0
+    fi
+
+    jq -cn '{state:"UNKNOWN",head:"",head_branch:"",merge_commit:"",auto_merge:false,in_merge_queue:false,merge_queue_entry:false,queue_state:"",source:"unavailable"}'
+}
+
 main() {
     local pr_num="" method="--squash" delete_branch=true
     local check_only=false force=false dry_run=false auto=false
@@ -386,18 +451,26 @@ main() {
         exit 0
     fi
 
+    # Resolve and guard the exact head before mutating merge state. This prevents
+    # a review/CI race from queuing or merging a newer, unverified commit.
+    local expected_head
+    if ! expected_head=$(gh_with_token "$token" pr view "$pr_num" --json headRefOid --jq '.headRefOid' 2>/dev/null) || [ -z "$expected_head" ]; then
+        echo "BLOCKED PR #$pr_num — could not resolve exact head SHA for guarded merge" >&2
+        exit 1
+    fi
+
     # Build merge command. --auto enables GitHub's auto-merge — it queues the
     # merge to fire when CI + branch protection clear, returning success now.
     # Without --auto, gh attempts an immediate merge and fails if blocked.
-    local -a cmd=(gh pr merge "$pr_num" "$method")
+    local -a cmd=(pr merge "$pr_num" "$method" --match-head-commit "$expected_head")
     [ "$auto" = true ] && cmd+=(--auto)
 
     local merge_output merge_exit=0
     if [ -n "$token" ]; then
-        merge_output=$(GH_TOKEN="$token" "${cmd[@]}" 2>&1) || merge_exit=$?
+        merge_output=$(gh_with_token "$token" "${cmd[@]}" 2>&1) || merge_exit=$?
     else
         echo "Warning: GH_BOT_TOKEN not configured, using current user" >&2
-        merge_output=$("${cmd[@]}" 2>&1) || merge_exit=$?
+        merge_output=$(gh_with_token "" "${cmd[@]}" 2>&1) || merge_exit=$?
     fi
 
     if [ "$merge_exit" -ne 0 ]; then
@@ -416,17 +489,30 @@ main() {
         exit 1
     fi
 
-    # Determine outcome by re-reading PR state. With --auto, gh exits 0 in
-    # both the merged-immediately case (CI was already green) and the queued
-    # case — only the post-call state distinguishes them.
-    local post_state post_auto
-    post_state=$(gh pr view "$pr_num" --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")
-    post_auto=$(gh pr view "$pr_num" --json autoMergeRequest --jq '.autoMergeRequest != null' 2>/dev/null || echo "false")
+    # Determine outcome from one authenticated post-call snapshot. GitHub's
+    # required merge queue can return success while the PR stays OPEN and
+    # autoMergeRequest stays null; an active queue entry is authoritative.
+    local post_snapshot post_state post_auto post_head post_in_queue post_queue_entry post_queue_state
+    post_snapshot=$(post_merge_snapshot "$pr_num" "$token")
+    post_state=$(jq -r '.state' <<<"$post_snapshot")
+    post_auto=$(jq -r '.auto_merge' <<<"$post_snapshot")
+    post_head=$(jq -r '.head' <<<"$post_snapshot")
+    post_in_queue=$(jq -r '.in_merge_queue' <<<"$post_snapshot")
+    post_queue_entry=$(jq -r '.merge_queue_entry' <<<"$post_snapshot")
+    post_queue_state=$(jq -r '.queue_state' <<<"$post_snapshot")
+
+    # The mutation itself was match-head guarded. Also reject a post-call
+    # snapshot that belongs to a different head instead of crediting its queue
+    # or auto-merge state to the commit we attempted.
+    if [ -n "$post_head" ] && [ "$post_head" != "$expected_head" ]; then
+        echo "BLOCKED PR #$pr_num — head changed during merge attempt (expected=$expected_head, actual=$post_head)" >&2
+        exit 1
+    fi
 
     if [ "$post_state" = "MERGED" ]; then
         echo "MERGED PR #$pr_num" >&2
         local merge_commit
-        merge_commit=$(gh pr view "$pr_num" --json mergeCommit --jq '.mergeCommit.oid // ""' 2>/dev/null || true)
+        merge_commit=$(jq -r '.merge_commit' <<<"$post_snapshot")
         local merged_args=(
             --severity success
             --importance important
@@ -440,24 +526,38 @@ main() {
         # fails inside worktrees). Best-effort — branch may already be gone.
         if [ "$delete_branch" = true ]; then
             local branch
-            branch=$(gh pr view "$pr_num" --json headRefName --jq '.headRefName' 2>/dev/null || true)
+            branch=$(jq -r '.head_branch' <<<"$post_snapshot")
             if [ -n "$branch" ]; then
-                gh api -X DELETE "repos/{owner}/{repo}/git/refs/heads/$branch" 2>/dev/null || true
+                gh_with_token "$token" api -X DELETE "repos/{owner}/{repo}/git/refs/heads/$branch" 2>/dev/null || true
             fi
         fi
         exit 0
     fi
 
-    if [ "$auto" = true ] && [ "$post_auto" = "true" ]; then
+    if [ "$post_in_queue" = "true" ] || [ "$post_queue_entry" = "true" ]; then
         local queued_args=(
             --severity info
             --importance normal
-            --summary "PR #$pr_num queued for auto-merge"
+            --summary "PR #$pr_num queued in merge queue"
             --pr-number "$pr_num"
         )
         [ -n "$pr_branch" ] && queued_args+=(--branch "$pr_branch")
         bash "$SCRIPT_DIR/../_activity-emit.sh" pr.merge_queued "${queued_args[@]}" || true
-        echo "QUEUED FOR AUTO-MERGE PR #$pr_num — will fire when CI + branch protection clear" >&2
+        echo "QUEUED IN MERGE QUEUE PR #$pr_num — queueState=${post_queue_state:-active}" >&2
+        echo "  Track with: github.sh await-mergeable $pr_num" >&2
+        exit 75
+    fi
+
+    if [ "$post_auto" = "true" ]; then
+        local auto_args=(
+            --severity info
+            --importance normal
+            --summary "PR #$pr_num auto-merge enabled"
+            --pr-number "$pr_num"
+        )
+        [ -n "$pr_branch" ] && auto_args+=(--branch "$pr_branch")
+        bash "$SCRIPT_DIR/../_activity-emit.sh" pr.merge_queued "${auto_args[@]}" || true
+        echo "AUTO-MERGE ENABLED PR #$pr_num — will fire when CI + branch protection clear" >&2
         echo "  Track with: github.sh await-mergeable $pr_num" >&2
         exit 75
     fi
@@ -473,7 +573,7 @@ main() {
     )
     [ -n "$pr_branch" ] && blocked_args+=(--branch "$pr_branch")
     bash "$SCRIPT_DIR/../_activity-emit.sh" pr.merge_blocked "${blocked_args[@]}" || true
-    echo "BLOCKED PR #$pr_num — gh reported success but state=$post_state, autoMerge=$post_auto" >&2
+    echo "BLOCKED PR #$pr_num — gh reported success but state=$post_state, autoMerge=$post_auto, mergeQueue=false" >&2
     printf '%s\n' "$merge_output" | sed 's/^/  /' >&2
     exit 1
 }

--- a/skills/github/tests/pr-merge.sh
+++ b/skills/github/tests/pr-merge.sh
@@ -55,6 +55,27 @@ case "${1:-}" in
         ;;
     api)
         if [[ "${2:-}" == "graphql" ]]; then
+            if [[ "$*" == *"mergeQueueEntry"* ]]; then
+                if [[ "${STUB_POST_GRAPHQL_FAIL:-false}" == "true" ]]; then
+                    echo '{"errors":[{"message":"queue fields unavailable"}]}'
+                    exit 1
+                fi
+                if [[ "${STUB_REQUIRE_TOKEN:-false}" == "true" && "${GH_TOKEN:-}" != "ghp_test_token" ]]; then
+                    echo "missing effective token for post-merge GraphQL" >&2
+                    exit 41
+                fi
+                jq -cn \
+                    --arg state "${STUB_POST_STATE:-OPEN}" \
+                    --arg head "${STUB_POST_HEAD:-${STUB_HEAD:-test-head}}" \
+                    --arg branch "${STUB_HEAD_BRANCH:-issue-123}" \
+                    --arg commit "${STUB_MERGE_COMMIT:-}" \
+                    --arg queue_state "${STUB_POST_QUEUE_STATE:-}" \
+                    --argjson auto "${STUB_POST_AUTO_JSON:-null}" \
+                    --argjson in_queue "${STUB_POST_IN_QUEUE:-false}" \
+                    --argjson queue_entry "${STUB_POST_QUEUE_ENTRY_JSON:-null}" \
+                    '{data:{repository:{pullRequest:{state:$state,headRefOid:$head,headRefName:$branch,mergeCommit:(if $commit == "" then null else {oid:$commit} end),autoMergeRequest:$auto,isInMergeQueue:$in_queue,mergeQueueEntry:$queue_entry}}}}'
+                exit 0
+            fi
             echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}'
             exit 0
         fi
@@ -66,6 +87,18 @@ case "${1:-}" in
                     echo '{"title":"Test PR"}'
                     exit 0
                 fi
+                if [[ "$*" == *"--json headRefName"* ]]; then
+                    echo "${STUB_HEAD_BRANCH:-issue-123}"
+                    exit 0
+                fi
+                if [[ "$*" == *"--json headRefOid"* ]]; then
+                    if [[ "${STUB_REQUIRE_TOKEN:-false}" == "true" && "${GH_TOKEN:-}" != "ghp_test_token" ]]; then
+                        echo "missing effective token for head guard" >&2
+                        exit 42
+                    fi
+                    echo "${STUB_HEAD:-test-head}"
+                    exit 0
+                fi
                 if [[ "$*" == *"--json mergeable"* ]]; then
                     echo "MERGEABLE"
                     exit 0
@@ -74,6 +107,28 @@ case "${1:-}" in
                     echo '{"reviewDecision":"APPROVED","latestReviews":[{"state":"APPROVED"}]}'
                     exit 0
                 fi
+                if [[ "$*" == *"--json state,headRefOid,headRefName,mergeCommit,autoMergeRequest"* ]]; then
+                    jq -cn \
+                        --arg state "${STUB_POST_STATE:-OPEN}" \
+                        --arg head "${STUB_POST_HEAD:-${STUB_HEAD:-test-head}}" \
+                        --arg branch "${STUB_HEAD_BRANCH:-issue-123}" \
+                        --arg commit "${STUB_MERGE_COMMIT:-}" \
+                        --argjson auto "${STUB_POST_AUTO_JSON:-null}" \
+                        '{state:$state,headRefOid:$head,headRefName:$branch,mergeCommit:(if $commit == "" then null else {oid:$commit} end),autoMergeRequest:$auto}'
+                    exit 0
+                fi
+                ;;
+            merge)
+                if [[ "$*" != *"--match-head-commit ${STUB_HEAD:-test-head}"* ]]; then
+                    echo "missing exact --match-head-commit guard" >&2
+                    exit 43
+                fi
+                if [[ "${STUB_REQUIRE_TOKEN:-false}" == "true" && "${GH_TOKEN:-}" != "ghp_test_token" ]]; then
+                    echo "missing effective token for merge" >&2
+                    exit 44
+                fi
+                echo "merge command accepted"
+                exit "${STUB_MERGE_EXIT:-0}"
                 ;;
             checks)
                 printf '%s\n' "${STUB_CHECKS:?}"
@@ -90,6 +145,10 @@ chmod +x "$TMPDIR/bin/gh"
 
 run_check() {
     (cd "$TMPDIR/repo" && PATH="$TMPDIR/bin:$PATH" env -u GH_TOKEN -u GITHUB_TOKEN "$PR_MERGE" 123 --check)
+}
+
+run_merge() {
+    (cd "$TMPDIR/repo" && PATH="$TMPDIR/bin:$PATH" env -u GH_TOKEN -u GITHUB_TOKEN "$PR_MERGE" 123 --auto --keep-branch)
 }
 
 echo "=== pr-merge --check CI classification ==="
@@ -164,6 +223,93 @@ checks='[
 out=$(STUB_CHECKS="$checks" STUB_CHECKS_EXIT=8 run_check)
 assert_eq "$(jq -r .can_merge <<<"$out")" "false" "current-run CANCELLED still blocks merge"
 assert_contains "$out" "ci_failed: Integration (CANCELLED)" "current-run CANCELLED reported as ci_failed"
+
+echo
+echo "=== pr-merge post-mutation outcomes (vstack#608) ==="
+
+checks='[{"name":"CI Required","state":"SUCCESS","bucket":"pass"}]'
+
+# Exact Hyprtrade PR #263 false-negative shape at head
+# 28132e9b990a595417f79f4e213b4e984bf676fd: gh accepted the guarded
+# mutation, the PR remained OPEN, autoMergeRequest was null, and the active
+# mergeQueueEntry was authoritative proof that the operation succeeded.
+set +e
+out=$(STUB_CHECKS="$checks" \
+    STUB_HEAD="28132e9b990a595417f79f4e213b4e984bf676fd" \
+    STUB_POST_STATE=OPEN \
+    STUB_POST_AUTO_JSON=null \
+    STUB_POST_IN_QUEUE=false \
+    STUB_POST_QUEUE_ENTRY_JSON='{"state":"QUEUED"}' \
+    STUB_POST_QUEUE_STATE=QUEUED \
+    STUB_REQUIRE_TOKEN=true \
+    GH_BOT_TOKEN=ghp_test_token \
+    run_merge 2>&1)
+status=$?
+set -e
+assert_eq "$status" "75" "active mergeQueueEntry is success-pending"
+assert_contains "$out" "QUEUED IN MERGE QUEUE PR #123" "merge-queue outcome is explicit"
+assert_contains "$out" "queueState=QUEUED" "merge-queue state is preserved"
+
+set +e
+out=$(STUB_CHECKS="$checks" \
+    STUB_POST_STATE=OPEN \
+    STUB_POST_AUTO_JSON='{"enabledAt":"2026-07-15T00:00:00Z"}' \
+    STUB_POST_IN_QUEUE=false \
+    STUB_POST_QUEUE_ENTRY_JSON=null \
+    run_merge 2>&1)
+status=$?
+set -e
+assert_eq "$status" "75" "classic auto-merge remains success-pending"
+assert_contains "$out" "AUTO-MERGE ENABLED PR #123" "classic auto-merge outcome is distinct"
+
+set +e
+out=$(STUB_CHECKS="$checks" \
+    STUB_POST_STATE=MERGED \
+    STUB_MERGE_COMMIT=merged-oid \
+    STUB_POST_AUTO_JSON=null \
+    STUB_POST_IN_QUEUE=false \
+    STUB_POST_QUEUE_ENTRY_JSON=null \
+    run_merge 2>&1)
+status=$?
+set -e
+assert_eq "$status" "0" "immediate direct merge remains success"
+assert_contains "$out" "MERGED PR #123" "merged outcome remains explicit"
+
+set +e
+out=$(STUB_CHECKS="$checks" \
+    STUB_POST_STATE=OPEN \
+    STUB_POST_AUTO_JSON=null \
+    STUB_POST_IN_QUEUE=false \
+    STUB_POST_QUEUE_ENTRY_JSON=null \
+    run_merge 2>&1)
+status=$?
+set -e
+assert_eq "$status" "1" "OPEN and genuinely unqueued remains blocked"
+assert_contains "$out" "mergeQueue=false" "blocked outcome names absent queue proof"
+
+set +e
+out=$(STUB_CHECKS="$checks" \
+    STUB_HEAD=guarded-head \
+    STUB_POST_HEAD=newer-unreviewed-head \
+    STUB_POST_STATE=OPEN \
+    STUB_POST_IN_QUEUE=true \
+    STUB_POST_QUEUE_ENTRY_JSON='{"state":"QUEUED"}' \
+    run_merge 2>&1)
+status=$?
+set -e
+assert_eq "$status" "1" "post-call head drift fails closed"
+assert_contains "$out" "head changed during merge attempt" "head drift has clear diagnostic"
+
+set +e
+out=$(STUB_CHECKS="$checks" \
+    STUB_POST_GRAPHQL_FAIL=true \
+    STUB_POST_STATE=OPEN \
+    STUB_POST_AUTO_JSON='{"enabledAt":"2026-07-15T00:00:00Z"}' \
+    run_merge 2>&1)
+status=$?
+set -e
+assert_eq "$status" "75" "classic auto-merge survives queue-query fallback"
+assert_contains "$out" "AUTO-MERGE ENABLED PR #123" "fallback preserves classic output"
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"


### PR DESCRIPTION
## Summary

- treat an authoritative active `mergeQueueEntry` as successful pending merge even when the PR remains `OPEN` and `autoMergeRequest` is null
- keep classic auto-merge and immediate merge outcomes distinct, while failing closed when no merged, queued, or armed postcondition exists
- guard every merge mutation with the exact PR head and reject post-call head drift
- use the same effective GitHub identity for mutation, postcondition verification, and branch cleanup

## Regression coverage

- exact Hyprtrade PR #263 shape at head `28132e9b990a595417f79f4e213b4e984bf676fd`
- active merge queue, classic auto-merge, immediate merge, truly unqueued, head-drift, auth propagation, and GraphQL fallback cases
- all 12 canonical GitHub skill test scripts pass
- `bash -n` passes for the command and regression test
- `git diff --check` passes

Closes #608
