### PR TITLE
fix(#611): make Transcript subtab reachable in /agents monitor detail

### DIFF
--- a/pi-extensions/pi-agents-tmux/extensions/subagent/browser.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/browser.ts
@@ -16,7 +16,6 @@ import {
 	AGENTS_BROWSER_WIDTH,
 	AGENTS_LEFT_MAX_WIDTH,
 	AGENTS_LEFT_MIN_WIDTH,
-	MONITOR_SUBTAB_LABELS,
 	type AgentBrowserAction,
 	type AgentBrowserLayout,
 	type AgentBrowserUiState,
@@ -50,6 +49,7 @@ import {
 } from "./browser/monitor-tree.js";
 import {
 	monitorFooterHint,
+	monitorSubtabCount,
 	renderMonitorDetail,
 	traceViewerItems,
 } from "./browser/monitor-task-detail.js";
@@ -87,6 +87,7 @@ export {
 export { type MonitorSessionType } from "./task-records.js";
 export {
 	monitorFooterHint,
+	monitorSubtabCount,
 	renderMonitorDetail,
 	traceViewerItems,
 } from "./browser/monitor-task-detail.js";
@@ -342,7 +343,9 @@ function createAgentsBrowserComponent(
 				return;
 			}
 			if (ui.tab === "monitor" && ui.pane === "inspector") {
-				const total = MONITOR_SUBTAB_LABELS.length;
+				const selectedRow = selectedMonitorRow(currentMonitorRows(), ui);
+				const entry = selectedRow?.kind === "task" ? monitorCache.get(selectedRow.record.taskId) : undefined;
+				const total = monitorSubtabCount(entry);
 				if (ui.monitorSubtab < total - 1) {
 					ui.monitorSubtab += 1;
 					ui.inspectorScroll = 0;

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/browser/monitor-task-detail.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/browser/monitor-task-detail.ts
@@ -95,6 +95,16 @@ export function monitorFooterHint(theme: Theme): string {
 	return `${ansiYellow("tab")} ${theme.fg("dim", "switch · ")}${ansiYellow("↑/↓ -/=")} ${theme.fg("dim", "page · ")}${ansiYellow("←/→")} ${theme.fg("dim", "pane · ")}${ansiYellow("enter")} ${theme.fg("dim", "open/toggle")}${theme.fg("dim", " · ")}${ansiYellow("esc")} ${theme.fg("dim", "close")}`;
 }
 
+// The number of navigable subtabs for the currently-selected task. Detail
+// navigation must clamp to the *actual* rendered subtab count — which includes
+// the conditional "Transcript" tab (index 2) whenever the record has a
+// transcriptPath — not the static MONITOR_SUBTAB_LABELS placeholder length
+// (Summary/Completion only). Before the trace items load, fall back to the
+// placeholder count so navigation stays bounded (vstack#611).
+export function monitorSubtabCount(entry: MonitorDetailEntry | undefined): number {
+	return entry?.items?.length ?? MONITOR_SUBTAB_LABELS.length;
+}
+
 export function renderMonitorDetail(
 	record: PaneTaskRecord | undefined,
 	cache: Map<string, MonitorDetailEntry>,

--- a/pi-extensions/pi-agents-tmux/tests/dashboard-ux.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/dashboard-ux.test.ts
@@ -13,6 +13,7 @@ import {
 	clampMonitorUiToRows,
 	isAgentFrontmatterEditShortcut,
 	monitorFooterHint,
+	monitorSubtabCount,
 	monitorTreeRows,
 	renderMonitorDetail,
 	renderAgentBrowserTabs,
@@ -1034,6 +1035,48 @@ test("Monitor tab task rendering still exposes task trace metadata", async () =>
 	assert.equal(items[2]!.label, "Transcript");
 	assert.equal(items[2]!.path, "/tmp/planner-transcript.jsonl");
 	assert.match(items[2]!.text, /Transcript file could not be read\./);
+});
+
+test("Monitor detail navigation can reach the Transcript subtab (vstack#611)", async () => {
+	const taskId = "planner-1700000120-transcript";
+	const taskRecord = record("planner", taskId, "2026-05-14T05:02:00.000Z", {
+		summary: "completed planner summary",
+		completionSourcePath: "/tmp/planner-source.json",
+		transcriptPath: "/tmp/planner-transcript.jsonl",
+	});
+	const items = await traceViewerItems(taskRecord, 1, { agents: [agent("planner", true)] });
+
+	// Three subtabs exist when a transcript is present: Summary, Completion, Transcript.
+	assert.equal(items.length, 3);
+	assert.equal(items[2]!.label, "Transcript");
+
+	// The right-arrow navigation clamp must derive its bound from the actual
+	// rendered subtab count, not the static MONITOR_SUBTAB_LABELS length (2).
+	// Before the fix the clamp stopped at index 1, leaving Transcript (index 2)
+	// permanently unreachable.
+	const entry = { items };
+	const reachableCount = monitorSubtabCount(entry);
+	assert.equal(reachableCount, 3);
+	const maxReachableIndex = reachableCount - 1;
+	assert.equal(maxReachableIndex, 2);
+
+	// Rendering the detail at the last reachable subtab shows the Transcript tab
+	// active with its content, proving the tab is navigable end to end.
+	const rendered = renderMonitorDetail(
+		taskRecord,
+		new Map([[taskId, entry]]),
+		uiState({ tab: "monitor", pane: "inspector", monitorSubtab: maxReachableIndex }),
+		120,
+		40,
+		ansiTheme as any,
+	).join("\n");
+	assert.match(rendered, /Transcript/);
+	assert.match(rendered, /Transcript file could not be read\./);
+});
+
+test("monitorSubtabCount falls back to the placeholder count before items load", () => {
+	assert.equal(monitorSubtabCount(undefined), 2);
+	assert.equal(monitorSubtabCount({ loading: true }), 2);
 });
 
 test("Monitor trace labels delivery mode and humanizes input transcript events", async () => {


### PR DESCRIPTION
Addresses the Transcript-tab part of #611 (does **not** close it — the state-sync symptom below remains open).

## Symptom B — Transcript tab unreachable (FIXED)
In the `/agents` browser monitor **Detail** pane, subtabs are built from the selected task's loaded trace items: `Summary`, `Completion`, and a **conditional `Transcript` tab (index 2) present only when the record has a `transcriptPath`**. But the right-arrow navigation clamp in `browser.ts` used the **static** `MONITOR_SUBTAB_LABELS.length` (= 2), so `ui.monitorSubtab` could never advance past index 1 — the Transcript tab was permanently unreachable even though `renderMonitorDetail` renders it fine.

**Fix:** derive the clamp bound from the actual rendered subtab count via a new `monitorSubtabCount(entry)` = `entry?.items?.length ?? MONITOR_SUBTAB_LABELS.length` (falls back to the placeholder count before trace items load), keyed off the currently-selected task's cache entry.

- `extensions/subagent/browser.ts`: right-arrow clamp uses `monitorSubtabCount(entry)` for the selected task.
- `extensions/subagent/browser/monitor-task-detail.ts`: new exported `monitorSubtabCount` helper.
- `tests/dashboard-ux.test.ts`: +2 tests (Transcript subtab reachable at index 2; placeholder fallback = 2).

Suite: `bun test ./tests ./extensions/subagent/__tests__` → **265 pass, 0 fail**.

## Symptom A — statusline vs dashboard lag/divergence (NOT in this PR; #611 stays open)
Root cause identified but deliberately not fixed here (TUI-bound, not unit-verifiable in this harness): the `/agents` pop-up reads `readTaskRegistry` **once at open** and builds its monitor records from that frozen snapshot, never re-reading live lifecycle state while open — so it can keep showing finished agents as "working" and miss newly-started ones, disagreeing with the live mini-dashboard (which shares one authoritative `dashboardState`). Pane completions additionally lag up to the 2s `completionPoller`. Full findings posted to #611 for a follow-up that can verify live-refresh behavior in the TUI.

https://claude.ai/code/session_013uQ8SgPh8DC4jQUzbLvK8C