### PR TITLE
fix(#615): accept --format=ids for linear issues create

### DIFF
--- a/skills/linear/scripts/commands/issues.sh
+++ b/skills/linear/scripts/commands/issues.sh
@@ -147,6 +147,8 @@ Create Options:
   --parent <id>         Parent issue ID (creates sub-issue)
   --milestone <name|uuid> Project milestone (name or UUID)
   --cycle <id>          Cycle (sprint) ID
+  --format=ids          Print ONLY the created issue identifier (for capture;
+                        default output is the full JSON create response)
 
 Update Options:
   --state <name>        New state
@@ -198,6 +200,7 @@ Examples:
   issues.sh list --label "backend" --state "Todo"
   issues.sh get PROJ-42
   issues.sh create --title "New task" --labels "backend,priority:high"
+  issues.sh create --title "Bundle" --project "Phase 2" --format=ids  # Print only the new identifier
   issues.sh update PROJ-42 --state "In Progress"
   issues.sh archive PROJ-42
 
@@ -823,12 +826,21 @@ create_issue() {
     local cycle=""
     local estimate=""
     local requested_parent_id=""
+    local output_format=""
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
         --title)
             title="$2"
             shift 2
+            ;;
+        --format)
+            output_format="$2"
+            shift 2
+            ;;
+        --format=*)
+            output_format="${1#--format=}"
+            shift
             ;;
         --team)
             team="$2"
@@ -1102,7 +1114,14 @@ create_issue() {
     local normalized
     normalized=$(normalize_mutation_response "$result" "issueCreate" "issue")
     emit_linear_issue_activity "linear.issue_created" "info" "$normalized"
-    echo "$normalized"
+    # --format=ids mirrors the query-command contract: print ONLY the created
+    # identifier (one per line, nothing else) so workflows can capture it
+    # deterministically. Any other/absent format keeps the default JSON output.
+    if [ "$output_format" = "ids" ]; then
+        echo "$normalized" | jq -r '.identifier // empty'
+    else
+        echo "$normalized"
+    fi
 }
 
 update_issue() {

--- a/skills/linear/tests/issues-create-format-ids.test.sh
+++ b/skills/linear/tests/issues-create-format-ids.test.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Regression test: `issues create --format=ids` must be accepted by the parser and
+# print ONLY the created issue identifier (one line, nothing else). The merge /
+# start-new / plan-issues workflows capture that identifier deterministically, so a
+# parser rejection (the #615 "Unknown option: --format=ids" bug) silently breaks them.
+# Runs fully offline against a mocked curl — the bug is a pre-mutation parse rejection.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+mkdir -p "$TMP_ROOT/.agents/skills" "$TMP_ROOT/bin"
+cp -R "$SKILL_DIR" "$TMP_ROOT/.agents/skills/linear"
+
+# Mocked curl: routes by GraphQL operation. issueCreate returns a fixed issue.
+cat >"$TMP_ROOT/bin/curl" <<'SH'
+#!/usr/bin/env bash
+config="$(cat)"
+payload="$(sed -n 's/^data = //p' <<<"$config" | jq -r)"
+query="$(jq -r '.query' <<<"$payload")"
+
+issue_json='{"id":"issue-uuid","identifier":"PROJ-1","title":"t","description":"d","state":{"name":"Todo","type":"unstarted"},"assignee":null,"project":null,"projectMilestone":null,"cycle":null,"parent":null,"team":{"name":"Claude"},"labels":{"nodes":[]},"priority":3,"estimate":null,"sortOrder":1.0,"url":"https://linear.app/test/issue/PROJ-1","createdAt":"2026-07-03T00:00:00Z","updatedAt":"2026-07-03T00:00:00Z","archivedAt":null,"trashed":null,"relations":{"nodes":[]},"inverseRelations":{"nodes":[]}}'
+
+case "$query" in
+*"teams(filter:"*)
+  printf '%s' '{"data":{"teams":{"nodes":[{"id":"team-uuid"}]}}}___HTTP_CODE___200'
+  ;;
+*"issueCreate(input:"*)
+  printf '%s' "{\"data\":{\"issueCreate\":{\"success\":true,\"issue\":$issue_json}}}___HTTP_CODE___200"
+  ;;
+*)
+  printf '%s' '{"errors":[{"message":"unexpected query"}]}___HTTP_CODE___200'
+  ;;
+esac
+SH
+chmod +x "$TMP_ROOT/bin/curl"
+
+LINEAR="$TMP_ROOT/.agents/skills/linear/scripts/linear.sh"
+
+run_create() {
+  PATH="$TMP_ROOT/bin:$PATH" LINEAR_API_KEY=test-token \
+    bash "$LINEAR" issues create "$@"
+}
+
+# --- --format=ids (equals form): accepted, prints ONLY the identifier -----------
+ids_out="$(run_create --title "New task" --team Claude --format=ids)"
+if [[ "$ids_out" != "PROJ-1" ]]; then
+  echo "FAIL create --format=ids expected exactly 'PROJ-1', got: [$ids_out]"
+  exit 1
+fi
+
+# --- --format ids (space form): same contract -----------------------------------
+ids_out_space="$(run_create --title "New task" --team Claude --format ids)"
+if [[ "$ids_out_space" != "PROJ-1" ]]; then
+  echo "FAIL create --format ids expected exactly 'PROJ-1', got: [$ids_out_space]"
+  exit 1
+fi
+
+# --- default (no --format): full JSON create response is unchanged ---------------
+default_out="$(run_create --title "New task" --team Claude)"
+if ! jq -e '.success == true and .identifier == "PROJ-1"' >/dev/null <<<"$default_out"; then
+  echo "FAIL default create output changed; expected JSON with success/identifier, got: $default_out"
+  exit 1
+fi
+
+# --- parser no longer rejects --format=ids (the #615 bug) ------------------------
+set +e
+err_out="$(run_create --title "New task" --team Claude --format=ids 2>&1 >/dev/null)"
+set -e
+if grep -q "Unknown option" <<<"$err_out"; then
+  echo "FAIL parser still rejects --format=ids: $err_out"
+  exit 1
+fi
+
+echo "all pass"


### PR DESCRIPTION
Closes #615.

## Problem
`issues create --help` advertises `--format=ids`, but `create_issue()` in `skills/linear/scripts/commands/issues.sh` had no `--format` handling — the parser's `-*` catch-all rejected it with `{"error": "Unknown option: --format=ids..."}` **before** the mutation. Three orch workflows (`merge-pr.md`, `start-new.md`, `plan-issues.md`) call `issues create ... --format=ids` and capture the printed identifier, so the rejection silently breaks them.

## Fix
- Parse `--format`/`--format=<v>` in `create_issue`. When the value is `ids`, print only `jq -r '.identifier // empty'` of the normalized create response (mirrors the existing query-command `ids` contract; `// empty` yields empty rather than `null` on failure, matching the workflows' "empty output → abort" guard). Any other/absent format keeps the full-JSON default output unchanged.
- Aligned `--help` (Create Options + example) so help and parser agree.
- Added offline regression test `skills/linear/tests/issues-create-format-ids.test.sh` (equals form, space form, default-unchanged, and parser-no-longer-rejects).

## Verification
Full linear suite run individually: **16/16 pass** (offline; mutation tests mock curl, and the parse rejection precedes any API call).

https://claude.ai/code/session_013uQ8SgPh8DC4jQUzbLvK8C