### PR TITLE
fix(#616): treat already-queued pr-merge --auto as queued, not blocked

### DIFF
--- a/skills/github/scripts/commands/pr-merge.sh
+++ b/skills/github/scripts/commands/pr-merge.sh
@@ -7,6 +7,11 @@
 #   75  QUEUED / AUTO-MERGE     — merge queue entry or classic auto-merge is active
 #   1   BLOCKED                — checks failed; no merge attempted, none queued
 #
+# `--auto` is idempotent for merge-queue repositories: a re-invocation on a PR
+# that is already enrolled reports QUEUED (75) from the authoritative post-call
+# snapshot, not BLOCKED, even though `gh pr merge --auto` exits nonzero when the
+# PR is already queued (vstack#616).
+#
 # When BLOCKED, stderr distinguishes TRANSIENT issues (mergeable UNKNOWN,
 # ci pending — caller should `await-mergeable` and retry) from PERMANENT
 # issues (conflicts, ci_failed, changes_requested — caller must fix and re-push).
@@ -473,25 +478,20 @@ main() {
         merge_output=$(gh_with_token "" "${cmd[@]}" 2>&1) || merge_exit=$?
     fi
 
-    if [ "$merge_exit" -ne 0 ]; then
-        # Merge command itself failed. Surface as BLOCKED with raw output.
-        local fail_args=(
-            --severity error
-            --importance important
-            --summary "PR #$pr_num merge blocked"
-            --pr-number "$pr_num"
-            --details-json "$(jq -cn --arg output "$merge_output" '{merge_output: $output, transient: false}')"
-        )
-        [ -n "$pr_branch" ] && fail_args+=(--branch "$pr_branch")
-        bash "$SCRIPT_DIR/../_activity-emit.sh" pr.merge_blocked "${fail_args[@]}" || true
-        echo "BLOCKED PR #$pr_num — gh pr merge failed" >&2
-        printf '%s\n' "$merge_output" | sed 's/^/  /' >&2
-        exit 1
-    fi
-
-    # Determine outcome from one authenticated post-call snapshot. GitHub's
-    # required merge queue can return success while the PR stays OPEN and
-    # autoMergeRequest stays null; an active queue entry is authoritative.
+    # Determine outcome from one authenticated post-call snapshot, taken
+    # REGARDLESS of gh's exit code. gh's exit status is not authoritative for
+    # merge-queue repositories:
+    #   - a required queue can return SUCCESS while the PR stays OPEN with a
+    #     null autoMergeRequest (vstack#608), and
+    #   - a re-invocation of `--auto` on an ALREADY-QUEUED PR returns NONZERO
+    #     even though GitHub still reports it queued, isInMergeQueue: true
+    #     (vstack#616).
+    # Only the GraphQL snapshot (state + mergeQueueEntry) is authoritative, so
+    # take it first and classify from it. This deliberately does not gate on
+    # gh's "already queued" stderr wording — that text is a version- and
+    # API-dependent GraphQL error and cannot be pinned reliably. The snapshot
+    # decides, and it is fail-closed: a genuine failure leaves no active queue
+    # entry.
     local post_snapshot post_state post_auto post_head post_in_queue post_queue_entry post_queue_state
     post_snapshot=$(post_merge_snapshot "$pr_num" "$token")
     post_state=$(jq -r '.state' <<<"$post_snapshot")
@@ -506,6 +506,32 @@ main() {
     # or auto-merge state to the commit we attempted.
     if [ -n "$post_head" ] && [ "$post_head" != "$expected_head" ]; then
         echo "BLOCKED PR #$pr_num — head changed during merge attempt (expected=$expected_head, actual=$post_head)" >&2
+        exit 1
+    fi
+
+    # A NONZERO `gh pr merge` exit is only benign when the authoritative
+    # snapshot proves a real success state: an already-enrolled merge queue
+    # entry (vstack#616), classic auto-merge already enabled, or an already
+    # merged PR. Anything else — conflicts, auth failure, CI, no enrollment —
+    # leaves no such proof and stays BLOCKED with the raw gh output. When the
+    # snapshot does prove success, fall through to the shared classification
+    # below so the outcome (MERGED / QUEUED / AUTO-MERGE) is reported once.
+    if [ "$merge_exit" -ne 0 ] \
+        && [ "$post_state" != "MERGED" ] \
+        && [ "$post_in_queue" != "true" ] \
+        && [ "$post_queue_entry" != "true" ] \
+        && [ "$post_auto" != "true" ]; then
+        local fail_args=(
+            --severity error
+            --importance important
+            --summary "PR #$pr_num merge blocked"
+            --pr-number "$pr_num"
+            --details-json "$(jq -cn --arg output "$merge_output" '{merge_output: $output, transient: false}')"
+        )
+        [ -n "$pr_branch" ] && fail_args+=(--branch "$pr_branch")
+        bash "$SCRIPT_DIR/../_activity-emit.sh" pr.merge_blocked "${fail_args[@]}" || true
+        echo "BLOCKED PR #$pr_num — gh pr merge failed" >&2
+        printf '%s\n' "$merge_output" | sed 's/^/  /' >&2
         exit 1
     fi
 

--- a/skills/github/tests/pr-merge.sh
+++ b/skills/github/tests/pr-merge.sh
@@ -127,8 +127,12 @@ case "${1:-}" in
                     echo "missing effective token for merge" >&2
                     exit 44
                 fi
+                if [[ "${STUB_MERGE_EXIT:-0}" != "0" ]]; then
+                    printf '%s\n' "${STUB_MERGE_STDERR:-failed to run merge}" >&2
+                    exit "${STUB_MERGE_EXIT}"
+                fi
                 echo "merge command accepted"
-                exit "${STUB_MERGE_EXIT:-0}"
+                exit 0
                 ;;
             checks)
                 printf '%s\n' "${STUB_CHECKS:?}"
@@ -310,6 +314,50 @@ status=$?
 set -e
 assert_eq "$status" "75" "classic auto-merge survives queue-query fallback"
 assert_contains "$out" "AUTO-MERGE ENABLED PR #123" "fallback preserves classic output"
+
+echo
+echo "=== pr-merge already-queued idempotency (vstack#616) ==="
+
+# A SECOND `--auto` call on a PR already enrolled in a required merge queue:
+# `gh pr merge --auto` returns NONZERO with GitHub's already-queued error, but
+# the authoritative post-call snapshot still reports an active mergeQueueEntry
+# (isInMergeQueue: true). The wrapper must take that snapshot instead of
+# short-circuiting to BLOCKED, and report the queued/exit-75 contract.
+set +e
+out=$(STUB_CHECKS="$checks" \
+    STUB_HEAD="already-queued-head" \
+    STUB_MERGE_EXIT=1 \
+    STUB_MERGE_STDERR="failed to run merge: GraphQL: Pull request Pull request is already queued to merge (enablePullRequestAutoMerge)" \
+    STUB_POST_STATE=OPEN \
+    STUB_POST_AUTO_JSON=null \
+    STUB_POST_IN_QUEUE=true \
+    STUB_POST_QUEUE_ENTRY_JSON='{"state":"QUEUED"}' \
+    STUB_POST_QUEUE_STATE=QUEUED \
+    run_merge 2>&1)
+status=$?
+set -e
+assert_eq "$status" "75" "already-queued --auto re-invocation is queued, not blocked"
+assert_contains "$out" "QUEUED IN MERGE QUEUE PR #123" "already-queued re-invocation reports merge-queue outcome"
+assert_contains "$out" "queueState=QUEUED" "already-queued re-invocation preserves queue state"
+
+# Fail-closed guard: a GENUINE `gh pr merge` failure — nonzero exit with NO
+# active queue entry, no auto-merge, PR still OPEN — must stay BLOCKED and
+# surface the raw gh output. The nonzero-exit path must not swallow real
+# failures just because it now takes the snapshot.
+set +e
+out=$(STUB_CHECKS="$checks" \
+    STUB_MERGE_EXIT=1 \
+    STUB_MERGE_STDERR="failed to run merge: Pull request is not mergeable: the base branch policy prohibits the merge" \
+    STUB_POST_STATE=OPEN \
+    STUB_POST_AUTO_JSON=null \
+    STUB_POST_IN_QUEUE=false \
+    STUB_POST_QUEUE_ENTRY_JSON=null \
+    run_merge 2>&1)
+status=$?
+set -e
+assert_eq "$status" "1" "genuine gh pr merge failure stays blocked"
+assert_contains "$out" "BLOCKED PR #123 — gh pr merge failed" "genuine failure reports gh pr merge failed"
+assert_contains "$out" "base branch policy prohibits the merge" "genuine failure surfaces raw gh output"
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"


### PR DESCRIPTION
Closes #616.

## Problem
`github.sh pr-merge <N> --auto` was not idempotent for a PR already in a required merge queue. `gh pr merge --auto` exits **nonzero** on an already-queued PR, and the wrapper's `merge_exit != 0 → BLOCKED; exit 1` block fired **before** the authoritative post-call `mergeQueueEntry` snapshot (added by #610) could run — so a second `--auto` call reported BLOCKED even though GitHub still had the PR queued (`isInMergeQueue: true`).

## Fix (`skills/github/scripts/commands/pr-merge.sh`)
- The post-call snapshot (`post_merge_snapshot`) now runs **unconditionally**, regardless of `gh`'s exit code.
- BLOCKED now fires only when `merge_exit != 0` **and** the snapshot proves no success state (`state != MERGED` && not in queue && no queue entry && no auto-merge). Otherwise control falls through to the shared MERGED(0)/QUEUED(75)/AUTO-MERGE(75) classification, reported once.
- Deliberately does **not** gate on `gh`'s already-queued stderr wording — that text is a version/API-dependent GraphQL error and can't be pinned reliably. The authoritative GraphQL snapshot decides, which is strictly more robust and stays fail-closed (a genuine failure leaves no active queue entry). Reuses the existing exit-75 queued contract; no new code invented.

Distinct from #608/#610 (initial enrollment → OPEN/autoMergeRequest==null snapshot); this covers re-invocation on an already-queued PR.

## Verification
- `skills/github/tests/pr-merge.sh` → **pass: 42, fail: 0**, including two new #616 groups: already-queued re-invocation returns exit 75/QUEUED (not BLOCKED), and a genuine failure still returns exit 1/BLOCKED with raw output. All 36 pre-existing assertions unchanged.
- All sibling github `*.test.sh` pass; `bash -n` clean.

https://claude.ai/code/session_013uQ8SgPh8DC4jQUzbLvK8C