### PR TITLE
fix(#619): handle --help and reject unknown flags in worktree remove

### DIFF
--- a/skills/worktree/scripts/worktree
+++ b/skills/worktree/scripts/worktree
@@ -1430,7 +1430,23 @@ case "${1:-}" in
     ;;
 
   remove)
+    if [[ "${2:-}" == "--help" || "${2:-}" == "-h" ]]; then
+      echo "Usage: $0 remove [ID|/path]"
+      echo ""
+      echo "Remove a worktree and delete its local branch when it is safely merged."
+      echo "Accepts an issue ID (resolved to trees/<id>) or a direct worktree path."
+      exit 0
+    fi
     ARG="${2:?Error: remove requires an issue ID or path}"
+    # Reject stray option-looking arguments before they are treated as an
+    # identifier and turned into a trees/<id> path. Otherwise `remove --help`
+    # (or any typo'd flag) would compute trees/--help and falsely report a
+    # removal, risking deletion of an oddly-named path/ref (#619).
+    if [[ "$ARG" == -* ]]; then
+      echo "Error: unknown option '$ARG' for remove" >&2
+      echo "Run: $0 remove --help" >&2
+      exit 1
+    fi
     # Accept either issue ID or direct path
     if [[ "$ARG" == */* ]]; then
       WT_PATH="$ARG"

--- a/skills/worktree/tests/worktree_remove.sh
+++ b/skills/worktree/tests/worktree_remove.sh
@@ -147,6 +147,54 @@ assert_eq "$merged_out" "Removed: $MERGED_ROOT/trees/issue-merged" "merged branc
 assert_path_absent "$MERGED_ROOT/trees/issue-merged" "merged branch worktree removed"
 assert_branch_absent "$MERGED_ROOT/main" "issue-merged" "merged branch deleted"
 
+# remove --help / -h print usage, exit 0, and never delete or report a removal.
+HELP_ROOT="$TMP_ROOT/help"
+make_repo "$HELP_ROOT/main"
+git -C "$HELP_ROOT/main" worktree add -q -b issue-help "$HELP_ROOT/trees/issue-help" main
+set +e
+help_out=$(cd "$HELP_ROOT/main" && "$WORKTREE_SCRIPT" remove --help 2>"$HELP_ROOT/help.err")
+help_code=$?
+set -e
+assert_eq "$help_code" "0" "remove --help exits 0"
+assert_contains "$help_out" "Usage: " "remove --help prints usage"
+if grep -qF -- "Removed:" <<<"$help_out"; then
+  FAIL=$((FAIL + 1))
+  printf '  FAIL  %s\n' "remove --help does not report a removal"
+else
+  PASS=$((PASS + 1))
+  printf '  ok    %s\n' "remove --help does not report a removal"
+fi
+assert_path_exists "$HELP_ROOT/trees/issue-help" "remove --help does not delete the worktree"
+assert_branch_exists "$HELP_ROOT/main" "issue-help" "remove --help does not delete the branch"
+
+set +e
+help_short_out=$(cd "$HELP_ROOT/main" && "$WORKTREE_SCRIPT" remove -h 2>"$HELP_ROOT/help-short.err")
+help_short_code=$?
+set -e
+assert_eq "$help_short_code" "0" "remove -h exits 0"
+assert_contains "$help_short_out" "Usage: " "remove -h prints usage"
+assert_path_exists "$HELP_ROOT/trees/issue-help" "remove -h does not delete the worktree"
+
+# Unknown option-looking argument fails with nonzero exit and no removal.
+BOGUS_ROOT="$TMP_ROOT/bogus"
+make_repo "$BOGUS_ROOT/main"
+git -C "$BOGUS_ROOT/main" worktree add -q -b issue-bogus "$BOGUS_ROOT/trees/issue-bogus" main
+set +e
+bogus_out=$(cd "$BOGUS_ROOT/main" && "$WORKTREE_SCRIPT" remove --bogus 2>"$BOGUS_ROOT/bogus.err")
+bogus_code=$?
+set -e
+assert_eq "$bogus_code" "1" "remove --bogus exits nonzero"
+assert_contains "$(cat "$BOGUS_ROOT/bogus.err")" "unknown option '--bogus'" "remove --bogus reports unknown option"
+if grep -qF -- "Removed:" <<<"$bogus_out"; then
+  FAIL=$((FAIL + 1))
+  printf '  FAIL  %s\n' "remove --bogus does not report a removal"
+else
+  PASS=$((PASS + 1))
+  printf '  ok    %s\n' "remove --bogus does not report a removal"
+fi
+assert_path_exists "$BOGUS_ROOT/trees/issue-bogus" "remove --bogus does not delete an unrelated worktree"
+assert_path_absent "$BOGUS_ROOT/trees/--bogus" "remove --bogus never computes a trees/--bogus path"
+
 # Unmerged branch: worktree is removed, branch remains, exit 1 includes diagnostic.
 UNMERGED_ROOT="$TMP_ROOT/unmerged"
 make_repo "$UNMERGED_ROOT/main"


### PR DESCRIPTION
Closes #619.

## Problem
The `remove)` handler in `skills/worktree/scripts/worktree` consumed `$2` straight into `ARG` with no `--help`/`-h` or option-shape check, so `remove --help` set `ARG=--help`, fell through to the identifier branch, computed `<repo>/trees/--help`, and printed `Removed: <repo>/trees/--help` with exit 0 — a **false success**. Any `-`-leading typo behaved the same, and if such an odd path/ref existed it would have been passed to `git worktree remove --force` / `rm -rf`.

## Fix
- `remove --help`/`remove -h` → print remove-specific usage and exit 0, before consuming `$2`, with no mutation.
- A `[[ "$ARG" == -* ]]` guard rejects any remaining option-looking argument (error to stderr, exit 1) before it is used as an identifier or turned into a `trees/<id>` path.
- Valid `remove <id>` / `remove /path` behavior unchanged. Mirrors the existing `push` handler style.

## Verification
- `skills/worktree/tests/worktree_remove.sh` → **pass: 72, fail: 0** (10 new assertions: `--help`/`-h` exit 0 + `Usage:` + no `Removed:` + worktree/branch intact; `--bogus` exit 1 + `unknown option` + no removal + no `trees/--bogus` created).
- All sibling `worktree_*.sh` and `bash32-portability.test.sh` green.

## Scope
Fixed `remove` only, per the issue. Assessed siblings: `restack` already fails-closed on unknown actions; `path`/`exists` are read-only; `create --help` is a **related but distinct** bug (would try to create `trees/--help`, no false deletion) with behavior risk to its permissive branch-name capture — filing a separate follow-up rather than force-fitting a shared guard.

https://claude.ai/code/session_013uQ8SgPh8DC4jQUzbLvK8C