### PR TITLE
fix(#621): handle --help and reject unknown flags in worktree create

### DIFF
--- a/skills/worktree/scripts/worktree
+++ b/skills/worktree/scripts/worktree
@@ -1196,7 +1196,30 @@ case "${1:-}" in
     ;;
 
   create)
+    if [[ "${2:-}" == "--help" || "${2:-}" == "-h" ]]; then
+      echo "Usage: $0 create <ID> [BRANCH] [options]"
+      echo ""
+      echo "Create a worktree for an issue ID (resolved to trees/<id>), optionally with an"
+      echo "explicit branch-name positional."
+      echo ""
+      echo "Options:"
+      echo "  --base BRANCH   Checkout an existing remote branch into the worktree"
+      echo "  --from REF      Create a new branch starting from REF (branch, tag, or commit)"
+      echo "  --pr NUMBER     Look up the branch from a PR number (implies --base)"
+      echo "  --reuse         Explicitly reuse and update an existing issue worktree"
+      echo "  --restack       When reusing, stop in the conflict state for resolution"
+      echo "                  instead of aborting the rebase"
+      exit 0
+    fi
     ISSUE="${2:?Error: create requires an issue ID}"
+    # Reject an option-looking issue ID before it becomes the ISSUE and a
+    # trees/<id> path. Otherwise `create --typo` would compute trees/--typo and
+    # proceed to attempt creation instead of failing clearly (#621).
+    if [[ "$ISSUE" == -* ]]; then
+      echo "Error: unknown option '$ISSUE' for create" >&2
+      echo "Run: $0 create --help" >&2
+      exit 1
+    fi
     shift 2
     BASE=""
     BRANCH=""
@@ -1211,6 +1234,14 @@ case "${1:-}" in
         --pr) PR="$2"; shift 2 ;;
         --reuse) REUSE=true; shift ;;
         --restack) RESTACK=true; shift ;;
+        # An unknown --flag must fail rather than be silently captured as a
+        # branch name. A legitimate positional branch name (not leading with
+        # '-') still falls through to the permissive arm below (#621).
+        -*)
+          echo "Error: unknown option '$1' for create" >&2
+          echo "Run: $0 create --help" >&2
+          exit 1
+          ;;
         *) BRANCH="$1"; shift ;;
       esac
     done

--- a/skills/worktree/tests/worktree_create_active_guard.sh
+++ b/skills/worktree/tests/worktree_create_active_guard.sh
@@ -384,6 +384,58 @@ assert_path_exists "$RACE_ROOT/trees/issue-race/.git" "concurrent claim creates 
 assert_eq "$(git -C "$RACE_ROOT/main" worktree list --porcelain | grep -c '^branch refs/heads/issue-race$')" "1" "concurrent claim registers the issue branch once"
 assert_eq "$(git -C "$RACE_ROOT/main" config --get extensions.worktreeConfig)" "true" "concurrent loser does not prevent successful setup"
 
+echo "=== worktree create option/help parsing (#621) ==="
+
+# --help / -h print create-specific usage, exit 0, and create nothing. This is
+# the sibling of the remove --help fix (#619) at both create parse sites.
+CREATE_HELP_ROOT="$TMP_ROOT/create-help"
+make_repo "$CREATE_HELP_ROOT"
+export GH_STATE="$CREATE_HELP_ROOT/gh-state"
+set +e
+create_help_out=$(cd "$CREATE_HELP_ROOT/main" && "$WORKTREE_SCRIPT" create --help 2>"$CREATE_HELP_ROOT/help.err")
+create_help_code=$?
+set -e
+assert_eq "$create_help_code" "0" "create --help exits 0"
+assert_contains "$create_help_out" "Usage: " "create --help prints usage"
+assert_contains "$create_help_out" "--restack" "create --help lists the create-specific options"
+assert_path_absent "$CREATE_HELP_ROOT/trees" "create --help creates no worktree tree"
+
+set +e
+create_help_short_out=$(cd "$CREATE_HELP_ROOT/main" && "$WORKTREE_SCRIPT" create -h 2>"$CREATE_HELP_ROOT/help-short.err")
+create_help_short_code=$?
+set -e
+assert_eq "$create_help_short_code" "0" "create -h exits 0"
+assert_contains "$create_help_short_out" "Usage: " "create -h prints usage"
+assert_path_absent "$CREATE_HELP_ROOT/trees" "create -h creates no worktree tree"
+
+# Parse site 1: an option-looking first positional ($2) must fail, not become
+# the ISSUE and a trees/<id> path.
+set +e
+create_optid_out=$(cd "$CREATE_HELP_ROOT/main" && "$WORKTREE_SCRIPT" create --bogus 2>"$CREATE_HELP_ROOT/optid.err")
+create_optid_code=$?
+set -e
+assert_eq "$create_optid_code" "1" "create --bogus (option-looking issue ID) exits nonzero"
+assert_contains "$(cat "$CREATE_HELP_ROOT/optid.err")" "unknown option '--bogus'" "option-looking issue ID reports unknown option"
+assert_path_absent "$CREATE_HELP_ROOT/trees/--bogus" "option-looking issue ID never computes a trees/--bogus path"
+
+# Parse site 2: an unknown --flag in the option loop must fail, not be silently
+# captured as a branch name.
+set +e
+create_flag_out=$(cd "$CREATE_HELP_ROOT/main" && "$WORKTREE_SCRIPT" create issue-flagcheck --bogus 2>"$CREATE_HELP_ROOT/flag.err")
+create_flag_code=$?
+set -e
+assert_eq "$create_flag_code" "1" "create <id> --bogus exits nonzero"
+assert_contains "$(cat "$CREATE_HELP_ROOT/flag.err")" "unknown option '--bogus'" "unknown flag in the option loop reports unknown option"
+assert_path_absent "$CREATE_HELP_ROOT/trees/issue-flagcheck" "unknown flag creates no worktree"
+assert_branch_absent "$CREATE_HELP_ROOT/main" "issue-flagcheck" "unknown flag creates no branch"
+
+# Over-rejection guard: a legitimate positional branch name (not leading with
+# '-') must STILL be accepted alongside the issue ID.
+create_branch_out=$(cd "$CREATE_HELP_ROOT/main" && "$WORKTREE_SCRIPT" create issue-legit custom-branch-name)
+assert_eq "$create_branch_out" "$CREATE_HELP_ROOT/trees/issue-legit" "create <id> <branch> returns the worktree path"
+assert_path_exists "$CREATE_HELP_ROOT/trees/issue-legit/.git" "create <id> <branch> registers the worktree"
+assert_eq "$(git -C "$CREATE_HELP_ROOT/trees/issue-legit" branch --show-current)" "custom-branch-name" "create <id> <branch> uses the positional branch name"
+
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Closes #621. Sibling of #619 (worktree `remove`, PR #620) — same option-as-identifier class, applied to `create`.

## Problem (two parse sites in the `create)` handler)
1. `ISSUE="${2:?...}"` consumed `$2` directly, so `create --help` set `ISSUE=--help` and `worktree_path` computed `trees/--help`, proceeding to attempt creation instead of printing usage.
2. The option loop's `*) BRANCH="$1"` arm silently captured any unrecognized argument — including unknown `--flags` — as a branch name.

## Fix
- `create --help`/`-h` → print create-specific usage (options + positional branch) and exit 0, before consuming `$2`, with no creation/locks/state.
- `[[ "$ISSUE" == -* ]]` guard rejects an option-looking first positional (error + exit 1) before it becomes a `trees/<id>` path.
- A new `-*)` arm in the option loop (before `*)`) rejects unknown `--flags`; a **legitimate positional branch name** (not leading `-`) still falls through to the unchanged permissive `*) BRANCH="$1"` arm.

Bash 3.2-safe; mirrors the merged #619 pattern.

## Verification
- `skills/worktree/tests/worktree_create_active_guard.sh` → **pass: 79, fail: 0** (17 new #621 assertions, incl. `--help`/`-h` exit 0 + no creation, `--bogus` at both sites exits nonzero + creates nothing, and a **preserved legit positional-branch** case).
- All sibling `worktree_*.sh` + `bash32-portability.test.sh` green.

## Note
A branch name literally starting with `-` is now rejected as an unknown option (pathological/unsupported by git tooling anyway); every non-`-` positional branch name still works. Consistent with #619.

https://claude.ai/code/session_013uQ8SgPh8DC4jQUzbLvK8C