### PR TITLE
fix(#627): add pr-comments commit-message mapping to dev-fix

### DIFF
--- a/skills/dev/workflows/dev-fix.md
+++ b/skills/dev/workflows/dev-fix.md
@@ -83,6 +83,7 @@ git commit -m "[PREFIX]([ISSUE_ID]): [MESSAGE]"
 | Source | Commit Message |
 |--------|----------------|
 | `pr-review` | "Address PR review - [brief description]" |
+| `pr-comments` | "Address PR comments - [brief description]" |
 | `qa-review` | "Address QA review - [brief description]" |
 | `review` | "Address review - [brief description]" |
 | `local-review` | "Address local pre-PR review - [brief description]" |


### PR DESCRIPTION
Closes #627.

`skills/dev/workflows/dev-fix.md` §4.2's commit-message table mapped `pr-review`, `qa-review`, `review`, `local-review`, and `suggestions`, but not `pr-comments` — the source that `skills/orch/workflows/review-pr-comments.md` §6.1 delegates with `Source: pr-comments`. Agents reaching dev-fix with that source had to improvise a commit message (CC-785 fell back to the `pr-review` form).

Adds a style-consistent `pr-comments` row (`"Address PR comments - [brief description]"`) so the upstream/downstream contracts agree. No other source-list in dev-fix.md enumerates the values. Dev skill tests (3) pass.