### PR TITLE
fix(#628): strip Markdown inline-code delimiters before resolving sidecar path

### DIFF
--- a/skills/deep-research/scripts/deep-research
+++ b/skills/deep-research/scripts/deep-research
@@ -127,6 +127,16 @@ function parseArgs(argv) {
 function cleanPath(path) { return path?.startsWith("@") ? path.slice(1) : path; }
 function resolvePath(path) { return resolve(cleanPath(path)); }
 
+// A report may reference a path as Markdown inline code (`path`) or a link
+// ([text](path)); strip those delimiters before resolving so a valid path is
+// not reported missing (vstack#628).
+function stripMarkdownPathDelimiters(ref) {
+  let value = ref.trim();
+  const link = value.match(/^\[[^\]]*\]\(([^)\s]+)\)$/);
+  if (link) value = link[1];
+  return value.replace(/^`+/, "").replace(/`+$/, "").trim();
+}
+
 async function expandSimpleGlob(rawGlob, limit = MAX_CONTEXT_FILES) {
   const cleaned = cleanPath(rawGlob.trim());
   if (!cleaned.includes("*")) return [resolve(cleaned)];
@@ -475,7 +485,10 @@ async function validateCommand(options) {
   }
 
   const sidecarRef = report.match(/Raw metadata sidecar:\s*(\S+)/);
-  if (sidecarRef && resolve(sidecarRef[1]) !== rawPath) warnings.push(`Report references sidecar ${sidecarRef[1]} but ${rawPath} was validated.`);
+  if (sidecarRef) {
+    const referenced = stripMarkdownPathDelimiters(sidecarRef[1]);
+    if (resolve(referenced) !== rawPath) warnings.push(`Report references sidecar ${referenced} but ${rawPath} was validated.`);
+  }
 
   const ok = errors.length === 0;
   jsonOut(process.stdout, { ok, report: reportPath, raw: rawPath, mode: metadata?.researchMode, synthesis, queryCount: metadata?.queryCount, errors, warnings });

--- a/skills/deep-research/tests/deep-research.test.mjs
+++ b/skills/deep-research/tests/deep-research.test.mjs
@@ -208,6 +208,27 @@ test("validate passes on freshly generated report and sidecar", () => {
   assert.equal(json.queryCount, 2);
 });
 
+test("validate ignores Markdown backticks around a report-referenced sidecar path (vstack#628)", () => {
+  const dir = mkdtempSync(join(tmpdir(), "deep-research-validate-backtick-"));
+  const mock = join(dir, "mock.json");
+  const output = join(dir, "findings.md");
+  const raw = join(dir, "findings.raw.json");
+  writeFileSync(mock, JSON.stringify({ answer: "A well-supported synthesized answer.", results: [{ title: "Source", url: "https://example.com", text: "Detailed source text." }] }));
+  const generate = spawnSync(process.execPath, [script, "report", "question", "--additional-query", "variant", "--output", output], { encoding: "utf8", env: { ...process.env, EXA_MOCK_RESPONSE_FILE: mock } });
+  assert.equal(generate.status, 0, generate.stderr);
+
+  // A hand-authored report references the sidecar as Markdown inline code.
+  writeFileSync(output, readFileSync(output, "utf8").replace(/- Raw metadata sidecar: .*/, "- Raw metadata sidecar: `" + raw + "`"));
+  const okJson = JSON.parse(spawnSync(process.execPath, [script, "validate", output, raw], { encoding: "utf8" }).stdout);
+  assert.equal(okJson.ok, true);
+  assert.ok(!okJson.warnings.some((w) => w.startsWith("Report references sidecar")), `unexpected sidecar warning: ${JSON.stringify(okJson.warnings)}`);
+
+  // A genuinely-different (still backticked) path must still warn — the fix must not over-suppress.
+  writeFileSync(output, readFileSync(output, "utf8").replace(/- Raw metadata sidecar: .*/, "- Raw metadata sidecar: `" + join(dir, "other.raw.json") + "`"));
+  const mismatchJson = JSON.parse(spawnSync(process.execPath, [script, "validate", output, raw], { encoding: "utf8" }).stdout);
+  assert.ok(mismatchJson.warnings.some((w) => w.startsWith("Report references sidecar")), `expected a sidecar mismatch warning: ${JSON.stringify(mismatchJson.warnings)}`);
+});
+
 test("validate errors when standard mode lacks synthesis and flags evidence-brief lite", () => {
   const dir = mkdtempSync(join(tmpdir(), "deep-research-validate-synth-"));
   const mock = join(dir, "mock.json");


### PR DESCRIPTION
Closes #628.

The deep-research sidecar validator matched the report's `Raw metadata sidecar:` reference with `\S+`, capturing surrounding Markdown backticks when the path was written as inline code (`` `docs/research/.../findings.raw.json` ``). `resolve()` then compared a backtick-wrapped path against the real sidecar and emitted a false `Report references sidecar ... but ... was validated` warning even though the file exists and the sidecar validates. (The generator itself writes a bare path, so this only bit hand-authored/edited reports — the CC-785 case.)

**Fix:** strip Markdown inline-code (and link `[text](path)`) delimiters from the referenced path before resolving. A genuinely-different path still warns. Root cause reproduced directly; added a regression test asserting both no-false-warning (backticked correct path) and still-warns (backticked wrong path).

Suite: `node --test skills/deep-research/tests/deep-research.test.mjs` → **19 pass, 0 fail** (incl. the new test).