### PR TITLE
fix(#629): stamp review artifact timestamps and validate --file freshness

### DIFF
--- a/skills/orch/DEVELOPMENT.md
+++ b/skills/orch/DEVELOPMENT.md
@@ -58,7 +58,7 @@ Tests stage isolated repos/worktrees with parametrized CLI stubs on `PATH`. Each
 - `approval_wait.sh` — GitHub-native approval verdict detection + output contract.
 - `ci_wait.sh` — CI-wait state machine + auth ladder.
 - `session_init.sh` — worktree Linear auth diagnostic preservation.
-- `review_artifact_check.sh` — deterministic reviewer artifact acceptance (`review-artifact-check`) + review-pr wiring assertions.
+- `review_artifact_check.sh` — deterministic reviewer artifact acceptance (`review-artifact-check`), including `--file` freshness with an optional delegated-at boundary, plus review-pr and submit-pr `--file` wiring assertions.
 
 All tests discovered by `run-all.sh` are part of the installed orch skill and
 must pass in downstream projects without access to the vstack source checkout.

--- a/skills/orch/README.md
+++ b/skills/orch/README.md
@@ -82,7 +82,7 @@ Use `skills/orch/scripts/pr-view-json WORKTREE_PATH --json number,state` when a 
 
 Use `skills/orch/scripts/review-init` to initialize standalone review context and print branch, worktree, issue ID, state path, and whether state was created as JSON.
 
-Use `skills/orch/scripts/review-artifact-check WORKTREE_PATH AGENT_NAME DELEGATED_AT_EPOCH` to deterministically validate a reviewer's on-disk JSON artifact (existence, `mtime >=` delegation epoch, `jq -e '.verdict'`). It prints `{ok, path, reason}`; review-pr accepts a reviewer completion only when `ok == true`.
+Use `skills/orch/scripts/review-artifact-check WORKTREE_PATH AGENT_NAME DELEGATED_AT_EPOCH` to deterministically validate a reviewer's on-disk JSON artifact (existence, `mtime >=` delegation epoch, `jq -e '.verdict'`). It prints `{ok, path, reason}`; review-pr accepts a reviewer completion only when `ok == true`. `review-artifact-check --file <json_path> [delegated_at_epoch]` validates one explicit artifact (such as an external second-opinion review output); when the optional `delegated_at_epoch` is supplied it applies the same freshness gate, so a stale or misdated file is rejected instead of accepted on existence + verdict alone.
 
 Use `skills/orch/scripts/tracker-for-issue ISSUE_ID` when workflow docs need tracker branching without inline shell conditionals.
 

--- a/skills/orch/SKILL.md
+++ b/skills/orch/SKILL.md
@@ -152,7 +152,7 @@ Follow ALL [Workflow Execution](#workflow-execution) rules for every command.
 | `pr-view-json` | Print PR view JSON and return success for expected `status=no_pr` so workflows can route to PR creation without shell fallback expressions |
 | `resolve-base-branch` | Print the worktree base branch (`WORKTREE_DEFAULT_BRANCH`, remote HEAD, or `main`) |
 | `review-init` | Initialize standalone review context and print branch/worktree/issue/state JSON |
-| `review-artifact-check` | Validate a reviewer's on-disk JSON artifact (exists, `mtime >=` delegation epoch, `jq -e '.verdict'`) and print `{ok, path, reason}` — the sole review-pr completion condition |
+| `review-artifact-check` | Validate a reviewer's on-disk JSON artifact (exists, `mtime >=` delegation epoch, `jq -e '.verdict'`) and print `{ok, path, reason}` — the sole review-pr completion condition. `--file <path> [delegated_at_epoch]` validates one explicit artifact; the optional boundary applies the same freshness gate so a stale/misdated external review is rejected |
 | `tracker-for-issue` | Print `github` for `issue-*` ids and `linear` otherwise |
 | `approval-wait` | Poll for a GitHub-native review approval verdict (`reviewDecision`/`latestReviews`) plus unresolved-thread count — the submit-pr § 4 approval-gate poller; never parses bot reactions or sticky prose |
 | `ci-wait` | Block until CI completes on a PR — runs after the approval gate; correlates the current-head substantive run with custom aggregate status, and `CI_WAIT_NO_CHECKS_GRACE` (default 180s) bounds unregistered checks |

--- a/skills/orch/scripts/review-artifact-check
+++ b/skills/orch/scripts/review-artifact-check
@@ -11,18 +11,21 @@ usage() {
   cat >&2 << 'EOF'
 Usage:
   review-artifact-check <worktree_path> <agent_name> <delegated_at_epoch>
-  review-artifact-check --file <json_path>
+  review-artifact-check --file <json_path> [delegated_at_epoch]
 
 Glob mode: checks [WORKTREE]/tmp/review-[AGENT]-*.json newest-first.
-File mode (--file): checks one explicit JSON file (existence + verdict),
-for artifacts written to a known path such as the external review output.
+File mode (--file): checks one explicit JSON file, for artifacts written to a
+known path such as the external review output. Validates existence + verdict;
+when the optional delegated_at_epoch is supplied it ALSO applies glob mode's
+freshness gate against filesystem mtime.
 
 Both modes print JSON:
   {ok: bool, path: string|null, reason: "valid"|"missing"|"stale"|"invalid"}
 
 reason meanings when ok=false:
   missing  no matching artifact found (glob) / file does not exist (--file)
-  stale    newest artifact mtime < delegated_at_epoch (glob mode only)
+  stale    artifact mtime < delegated_at_epoch (glob mode, or --file when the
+           optional boundary is supplied)
   invalid  artifact fails `jq -e '.verdict'`
 
 Exit 0 when a valid artifact was found, 1 otherwise, 2 on usage error.
@@ -35,20 +38,40 @@ emit() {
     '{ok: $ok, path: (if $path == "" then null else $path end), reason: $reason}'
 }
 
+file_mtime() {
+  stat -c %Y "$1" 2>/dev/null || stat -f %m "$1"
+}
+
 # --- File mode: validate one explicit JSON path deterministically ---
 if [[ "${1:-}" == "--file" ]]; then
-  if [[ $# -ne 2 ]]; then
+  # Accept an OPTIONAL trailing delegated_at_epoch. When present, apply the same
+  # freshness gate as glob mode (artifact mtime < delegated_at → stale); when
+  # omitted, keep the existence + verdict behavior so existing callers do not
+  # break.
+  if [[ $# -lt 2 || $# -gt 3 ]]; then
     usage
     exit 2
   fi
   file="$2"
+  delegated_at="${3:-}"
   if [[ -z "$file" ]]; then
     echo "Error: --file requires a non-empty path" >&2
+    exit 2
+  fi
+  if [[ -n "$delegated_at" ]] && ! [[ "$delegated_at" =~ ^[0-9]+$ ]]; then
+    echo "Error: delegated_at_epoch must be epoch seconds, got '$delegated_at'" >&2
     exit 2
   fi
   if [[ ! -f "$file" ]]; then
     emit false "" "missing"
     exit 1
+  fi
+  if [[ -n "$delegated_at" ]]; then
+    mtime="$(file_mtime "$file")"
+    if (( mtime < delegated_at )); then
+      emit false "$file" "stale"
+      exit 1
+    fi
   fi
   if ! jq -e '.verdict' "$file" >/dev/null 2>&1; then
     emit false "$file" "invalid"
@@ -79,10 +102,6 @@ if ! [[ "$delegated_at" =~ ^[0-9]+$ ]]; then
   echo "Error: delegated_at_epoch must be epoch seconds, got '$delegated_at'" >&2
   exit 2
 fi
-
-file_mtime() {
-  stat -c %Y "$1" 2>/dev/null || stat -f %m "$1"
-}
 
 reason="missing"
 fail_path=""

--- a/skills/orch/tests/review_artifact_check.sh
+++ b/skills/orch/tests/review_artifact_check.sh
@@ -128,10 +128,54 @@ assert_eq "$(jq -r '.ok' <<<"$out")" "true" "--file valid reports ok=true"
 assert_eq "$(jq -r '.path' <<<"$out")" "$ext_valid" "--file valid reports its path"
 assert_eq "$(jq -r '.reason' <<<"$out")" "valid" "--file valid reports reason=valid"
 
-# --file does not apply the staleness gate — an old mtime still validates
+# --file with NO boundary does not apply the staleness gate — an old mtime still validates
 touch -d "@$before" "$ext_valid"
 out="$("$CHECK" --file "$ext_valid")"
-assert_eq "$(jq -r '.ok' <<<"$out")" "true" "--file ignores mtime (no staleness gate)"
+assert_eq "$(jq -r '.ok' <<<"$out")" "true" "--file without boundary ignores mtime (existence+verdict only)"
+
+# --- --file mode: OPTIONAL delegated_at boundary applies glob mode's freshness gate ---
+# older-than-boundary mtime → stale
+touch -d "@$before" "$ext_valid"
+set +e
+out="$("$CHECK" --file "$ext_valid" "$delegated_at")"
+rc=$?
+set -e
+assert_eq "$rc" "1" "--file with boundary, older mtime exits 1"
+assert_eq "$(jq -r '.ok' <<<"$out")" "false" "--file stale reports ok=false"
+assert_eq "$(jq -r '.path' <<<"$out")" "$ext_valid" "--file stale reports its path"
+assert_eq "$(jq -r '.reason' <<<"$out")" "stale" "--file older-than-boundary reports reason=stale"
+
+# newer-than-boundary mtime → valid
+touch -d "@$after" "$ext_valid"
+out="$("$CHECK" --file "$ext_valid" "$delegated_at")"
+rc=$?
+assert_eq "$rc" "0" "--file with boundary, newer mtime exits 0"
+assert_eq "$(jq -r '.ok' <<<"$out")" "true" "--file fresh (mtime >= boundary) reports ok=true"
+assert_eq "$(jq -r '.reason' <<<"$out")" "valid" "--file newer-than-boundary reports reason=valid"
+
+# mtime exactly equal to boundary is fresh (not stale) — matches glob mode's >= semantics
+touch -d "@$delegated_at" "$ext_valid"
+out="$("$CHECK" --file "$ext_valid" "$delegated_at")"
+assert_eq "$(jq -r '.reason' <<<"$out")" "valid" "--file mtime == boundary is fresh"
+
+# fresh mtime but missing verdict → invalid (freshness passes, verdict gate fails)
+ext_fresh_noverdict="$worktree/tmp/review-external-20260709-070707.json"
+printf '{"items":[]}' > "$ext_fresh_noverdict"
+touch -d "@$after" "$ext_fresh_noverdict"
+set +e
+out="$("$CHECK" --file "$ext_fresh_noverdict" "$delegated_at")"
+rc=$?
+set -e
+assert_eq "$rc" "1" "--file fresh-but-no-verdict with boundary exits 1"
+assert_eq "$(jq -r '.reason' <<<"$out")" "invalid" "--file fresh-but-no-verdict with boundary reports reason=invalid"
+
+# missing file with a boundary still reports missing (existence checked before freshness)
+set +e
+out="$("$CHECK" --file "$worktree/tmp/review-external-nope.json" "$delegated_at")"
+rc=$?
+set -e
+assert_eq "$rc" "1" "--file missing with boundary exits 1"
+assert_eq "$(jq -r '.reason' <<<"$out")" "missing" "--file missing with boundary reports reason=missing"
 
 # --file: missing file
 set +e
@@ -164,6 +208,10 @@ assert_eq "$?" "2" "non-numeric delegated_at exits 2"
 assert_eq "$?" "2" "nonexistent worktree exits 2"
 "$CHECK" --file >/dev/null 2>&1
 assert_eq "$?" "2" "--file with no path exits 2"
+"$CHECK" --file "$ext_valid" not-a-number >/dev/null 2>&1
+assert_eq "$?" "2" "--file non-numeric boundary exits 2"
+"$CHECK" --file "$ext_valid" "$delegated_at" extra-arg >/dev/null 2>&1
+assert_eq "$?" "2" "--file with too many args exits 2"
 set -e
 
 # --- review-pr.md wires the deterministic acceptance ---
@@ -175,6 +223,12 @@ assert_file_contains "$review_pr" "exactly one" "review-pr limits incomplete ret
 assert_file_contains "$review_pr" "using your harness file-write tool" "review-pr re-delegation instructs harness file-write tool"
 assert_file_contains "$review_pr" 'review-artifact-check --file "$EXTERNAL_OUTPUT"' "review-pr validates external output via --file mode"
 assert_file_not_contains "$review_pr" "if jq -e '.verdict'" "review-pr no longer prescribes inline if/redirection for external verdict check"
+assert_file_contains "$review_pr" 'review-artifact-check --file "$EXTERNAL_OUTPUT" [REVIEW_DELEGATED_AT_FROM_PREVIOUS_COMMAND]' "review-pr passes review_delegated_at as the --file freshness boundary"
+
+# --- submit-pr.md wires the --file freshness boundary for the local review ---
+submit_pr="$REPO_ROOT/skills/orch/workflows/submit-pr.md"
+assert_file_contains "$submit_pr" 'review-artifact-check --file "$LOCAL_OUTPUT" [LOCAL_STARTED_AT]' "submit-pr passes a delegated-at boundary to the --file freshness check"
+assert_file_contains "$submit_pr" "git-context timestamp epoch" "submit-pr captures an epoch boundary before running the local review"
 
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/skills/orch/workflows/review-pr.md
+++ b/skills/orch/workflows/review-pr.md
@@ -165,9 +165,10 @@ mkdir -p [WORKTREE_PATH]/tmp
   --output "$EXTERNAL_OUTPUT"
 ```
 
-**On success** — validate deterministically, then append. `review-artifact-check --file` checks existence and `jq -e '.verdict'` and prints `{ok, path, reason}` — no inline conditional or redirection:
+**On success** — validate deterministically, then append. Pass `review_delegated_at` (recorded in § 2.2) as the freshness boundary so a stale or misdated external artifact is rejected the same way glob mode rejects stale reviewer JSONs. `review-artifact-check --file` then checks existence, `mtime >= review_delegated_at`, and `jq -e '.verdict'`, printing `{ok, path, reason}` — no inline conditional or redirection:
 ```bash
-.agents/skills/orch/scripts/review-artifact-check --file "$EXTERNAL_OUTPUT"
+.agents/skills/orch/scripts/workflow-state get [ISSUE_ID] .review_delegated_at
+.agents/skills/orch/scripts/review-artifact-check --file "$EXTERNAL_OUTPUT" [REVIEW_DELEGATED_AT_FROM_PREVIOUS_COMMAND]
 ```
 **If `ok == true`** — append the external JSON:
 ```bash

--- a/skills/orch/workflows/submit-pr.md
+++ b/skills/orch/workflows/submit-pr.md
@@ -74,9 +74,11 @@ Bot reviews are **asynchronous** in this workflow: GitHub review bots post on th
    ```
    Use the output as `LOCAL_PASSES`. If `LOCAL_PASSES >= 2` → § 2.
 
-2. **Run the local review** (advisory — on script failure, report and continue to § 2):
+2. **Run the local review** (advisory — on script failure, report and continue to § 2). Capture an epoch freshness boundary *before* the review writes the artifact so step 3 can reject a stale or misdated file the way glob mode does:
    ```bash
    mkdir -p [WORKTREE_PATH]/tmp
+   .agents/skills/orch/scripts/git-context timestamp epoch
+   # Use the output as LOCAL_STARTED_AT (delegated-at boundary for the freshness check).
    .agents/skills/orch/scripts/git-context timestamp compact
    # Use [WORKTREE_PATH]/tmp/review-local-[TIMESTAMP_FROM_PREVIOUS_COMMAND].json as LOCAL_OUTPUT.
    .agents/skills/second-opinion/scripts/second-opinion review \
@@ -84,9 +86,9 @@ Bot reviews are **asynchronous** in this workflow: GitHub review bots post on th
      --output "$LOCAL_OUTPUT"
    ```
 
-3. **Validate the artifact**:
+3. **Validate the artifact** — pass `LOCAL_STARTED_AT` so existence, freshness (`mtime >= LOCAL_STARTED_AT`), and `jq -e '.verdict'` are all checked:
    ```bash
-   .agents/skills/orch/scripts/review-artifact-check --file "$LOCAL_OUTPUT"
+   .agents/skills/orch/scripts/review-artifact-check --file "$LOCAL_OUTPUT" [LOCAL_STARTED_AT]
    ```
    Count the pass:
    ```bash

--- a/skills/second-opinion/README.md
+++ b/skills/second-opinion/README.md
@@ -98,3 +98,5 @@ Edit the full command string to change model, effort level, or tool access. No a
 The orch skill's `review-pr` workflow optionally offers an external review at § 2.1. If accepted, the script produces review-finding JSON (same schema as internal review agents) that flows through the standard blocker/suggestion/issue pipeline.
 
 The orch `submit-pr` workflow also runs `review` as a local pre-PR review of the branch diff (standalone lifecycle), draining bot-class findings at local speed instead of blocking on asynchronous GitHub review bots.
+
+In `review` and `audit` modes the artifact's `timestamp` field is wrapper-stamped: after the model responds, the script overwrites `timestamp` with its own UTC wall clock (`date -u`), so the recorded time reflects when the wrapper wrote the file rather than a value the reviewing model serialized. Both orch workflows pass a delegated-at boundary to `review-artifact-check --file`, which rejects an artifact whose filesystem mtime predates that boundary — freshness never depends on a model-supplied timestamp.

--- a/skills/second-opinion/SKILL.md
+++ b/skills/second-opinion/SKILL.md
@@ -39,6 +39,8 @@ Override with `SECOND_OPINION_TARGET=claude|codex` in committed `vstack.settings
 | `quick [question]` | [workflows/quick.md](workflows/quick.md) | Text response |
 | `detect` | (built-in) | Target CLI name |
 
+**Timestamp is wrapper-stamped.** In `review` and `audit` modes the JSON `timestamp` field is overwritten by the wrapper with its own UTC wall clock (`date -u`) after the model responds — the schema keeps `ISO_8601` only as a hint. The written value therefore reflects when the wrapper produced the artifact, not a value the reviewing model serialized (which could be stale or fabricated). Downstream freshness checks (`orch review-artifact-check --file <path> [delegated_at]`) validate filesystem mtime, and the stamped `timestamp` stays consistent with it.
+
 ## Common Options
 
 All modes accept:

--- a/skills/second-opinion/scripts/second-opinion
+++ b/skills/second-opinion/scripts/second-opinion
@@ -537,6 +537,18 @@ if [[ "$MODE" == "review" || "$MODE" == "audit" ]]; then
       preserve_raw_and_fail "$RESULT" "$RETRY_RESULT"
     fi
   fi
+
+  # Stamp the authoritative timestamp ourselves. The reviewing model serializes
+  # a `timestamp` field, but a model-supplied value is unverifiable — it can emit
+  # a stale or fabricated time (vstack#629). Overwrite it with the wrapper's own
+  # UTC wall clock so the artifact's content timestamp is trustworthy and matches
+  # its filesystem mtime. The schema keeps ISO_8601 as a hint; this is the
+  # authoritative value. RESULT is already jq-validated JSON here, so the rewrite
+  # succeeds; if jq unexpectedly fails, keep the extracted JSON unchanged.
+  STAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  if STAMPED=$(printf '%s' "$RESULT" | jq --arg ts "$STAMP" '.timestamp = $ts' 2>/dev/null); then
+    RESULT="$STAMPED"
+  fi
 fi
 
 # --- Output -------------------------------------------------------------------

--- a/skills/second-opinion/tests/timestamp-stamp.test.sh
+++ b/skills/second-opinion/tests/timestamp-stamp.test.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Regression test for second-opinion artifact timestamp stamping (vstack#629).
+#
+# The review artifact's `timestamp` field was serialized by the reviewing model,
+# so a stale or fabricated value could survive into the written JSON — and orch's
+# --file acceptance did not re-derive freshness. The fix: after the model
+# responds and before writing the artifact, the wrapper overwrites `timestamp`
+# with its own `date -u` UTC wall clock so the content timestamp is trustworthy
+# and consistent with the file's mtime.
+#
+# Drives the real script with a fake target CLI that emits a review JSON carrying
+# a deliberately BOGUS timestamp, then asserts the written artifact's timestamp
+# was overwritten to ~now while the rest of the findings are preserved.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+SECOND_OPINION="$REPO_ROOT/skills/second-opinion/scripts/second-opinion"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+PASS=0
+FAIL=0
+
+pass() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+fail() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1" >&2; }
+
+assert_eq() {
+  local got="$1" want="$2" name="$3"
+  if [[ "$got" == "$want" ]]; then
+    pass "$name"
+  else
+    fail "$name"
+    printf '        expected: %s\n        got:      %s\n' "$want" "$got" >&2
+  fi
+}
+
+assert_ne() {
+  local got="$1" unwanted="$2" name="$3"
+  if [[ "$got" != "$unwanted" ]]; then
+    pass "$name"
+  else
+    fail "$name"
+    printf '        expected NOT: %s\n        got:          %s\n' "$unwanted" "$got" >&2
+  fi
+}
+
+# BOGUS_TS is the stale/fabricated timestamp the model emits. It must never
+# survive into the written artifact.
+BOGUS_TS="2020-01-01T00:00:00Z"
+
+# --- Fake target CLI ----------------------------------------------------------
+# Consumes the prompt on stdin and emits a valid review JSON whose `timestamp`
+# is the bogus value. Named `claude` so `command -v claude` passes; the actual
+# command run is this stub via SECOND_OPINION_CLAUDE_CMD.
+mkdir -p "$TMP_ROOT/bin"
+STUB="$TMP_ROOT/bin/claude"
+cat > "$STUB" <<SH
+#!/usr/bin/env bash
+set -euo pipefail
+cat >/dev/null   # consume the prompt on stdin
+cat <<'JSON'
+{"agent":"external-claude","timestamp":"$BOGUS_TS","verdict":"action_required","summary":"One blocker found","blockers":[{"id":1,"title":"Null deref in parser","location":"src/parse.rs (\`parse\`)","description":"pointer may be null","recommendation":"guard it","priority":1,"estimate":2}],"suggestions":[],"questions":[],"qa_metadata":{}}
+JSON
+SH
+chmod +x "$STUB"
+
+# --- Throwaway git repo for --cwd --------------------------------------------
+WORK="$TMP_ROOT/work"
+mkdir -p "$WORK"
+git -C "$WORK" init -q
+git -C "$WORK" config user.email test@example.com
+git -C "$WORK" config user.name test
+printf 'hello\n' > "$WORK/file.txt"
+git -C "$WORK" add file.txt
+git -C "$WORK" -c commit.gpgsign=false commit -q -m init
+
+mkdir -p "$TMP_ROOT/out"
+OUT="$TMP_ROOT/out/review.json"
+
+echo "=== artifact timestamp is wrapper-stamped, not model-supplied ==="
+
+before=$(date -u +%s)
+rc=0
+set +e
+PATH="$TMP_ROOT/bin:$PATH" \
+  SECOND_OPINION_TARGET=claude \
+  SECOND_OPINION_CLAUDE_CMD="$STUB" \
+  "$SECOND_OPINION" review --range HEAD --cwd "$WORK" --output "$OUT" \
+  >/dev/null 2>"$TMP_ROOT/stderr"
+rc=$?
+set -e
+after=$(date -u +%s)
+
+assert_eq "$rc" "0" "review exits 0"
+
+if [[ ! -f "$OUT" ]]; then
+  fail "artifact was written"
+  printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+  exit 1
+fi
+pass "artifact was written"
+
+written_ts="$(jq -r '.timestamp' "$OUT")"
+
+# The bogus model-supplied value must have been overwritten.
+assert_ne "$written_ts" "$BOGUS_TS" "written timestamp is NOT the model-supplied bogus value"
+
+# The written value must be the wrapper's own wall clock: parse it to epoch and
+# confirm it falls within the [before, after] window of the run.
+written_epoch="$(date -u -d "$written_ts" +%s 2>/dev/null || echo "")"
+if [[ -z "$written_epoch" ]]; then
+  fail "written timestamp parses as an ISO-8601 UTC time (got '$written_ts')"
+elif (( written_epoch >= before && written_epoch <= after )); then
+  pass "written timestamp is the wrapper's own ~now stamp"
+else
+  fail "written timestamp is the wrapper's own ~now stamp"
+  printf '        window: [%s, %s]  got: %s (%s)\n' "$before" "$after" "$written_epoch" "$written_ts" >&2
+fi
+
+# The rest of the model's findings must be preserved unchanged.
+assert_eq "$(jq -r '.verdict' "$OUT")" "action_required" "verdict is preserved"
+assert_eq "$(jq -r '.summary' "$OUT")" "One blocker found" "summary is preserved"
+assert_eq "$(jq -r '.blockers[0].title' "$OUT")" "Null deref in parser" "blocker findings are preserved"
+
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Closes #629.

Two vstack skills combined into a provenance hole: `second-opinion review` wrote an artifact whose `timestamp` was **model-serialized** (thus unverifiable/fabricatable), and `review-artifact-check --file` accepted it because explicit-file mode checked only existence + `.verdict` — unlike glob mode, which gates on `mtime < delegated_at → stale`.

## Fix
- **(A) second-opinion self-stamps** the authoritative `timestamp` with its own `date -u` after the model JSON is validated (`skills/second-opinion/scripts/second-opinion`), so content time is trustworthy and matches filesystem mtime. Safe fallback if jq fails.
- **(B) `review-artifact-check --file`** now accepts an optional trailing `delegated_at_epoch` and applies glob mode's exact freshness gate (reusing the hoisted `file_mtime`; `stale` now reachable in --file mode). Backward-compatible when the boundary is omitted. Usage/help + reason table updated.
- **(C) Callers wired**: `review-pr.md` §2.1 passes the async `review_delegated_at` boundary; `submit-pr.md` §1.2 captures a `git-context timestamp epoch` before the review and passes it. Harness-safe (helper→placeholder pattern, no inline `$(...)`).
- Docs updated in the same commit (orch SKILL/README/DEVELOPMENT; second-opinion SKILL/README).

## Verification
- `skills/orch/tests/review_artifact_check.sh` → **58 pass** (new: --file boundary stale/valid/mtime-boundary/non-numeric/too-many-args + caller-wiring assertions; fail-before confirmed).
- `skills/second-opinion/tests/timestamp-stamp.test.sh` → **7 pass** (bogus model ts overwritten to ~now; fail-before was 5 pass/2 fail).
- `skills/orch/tests/run-all.sh` → all 12 files pass (incl. harness-safe workflow-state lint); second-opinion regression suites green.

https://claude.ai/code/session_013uQ8SgPh8DC4jQUzbLvK8C