### PR TITLE
fix(#641): emit supported decisions search --issue lookup in dev-fix guidance

### DIFF
--- a/skills/decider/scripts/decisions
+++ b/skills/decider/scripts/decisions
@@ -385,6 +385,10 @@ case "$action" in
   help|--help|-h)
     show_help
     ;;
+  issue|issues)
+    echo "Error: Unknown action '$action' — issue lookup is: decisions search --issue <ISSUE_ID>" >&2
+    exit 1
+    ;;
   *)
     echo "Error: Unknown action '$action'" >&2
     show_help

--- a/skills/decider/tests/decider-issue-action-hint.test.sh
+++ b/skills/decider/tests/decider-issue-action-hint.test.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Regression tests for the unsupported `issue` action hint (vstack#641).
+#
+# During an orch dev-fix cycle, generated guidance told a specialist to run
+# `decisions issue CC-125`. The CLI has no `issue` action — the supported
+# lookup is `decisions search --issue CC-125` — but the generic unknown-action
+# error gave no pointer to it. The dispatcher now catches `issue`/`issues`
+# with a targeted error naming the supported form so an agent that receives
+# stale guidance self-corrects in one step. These tests assert that hint, that
+# other unknown actions keep the generic error + usage, and that the supported
+# `search --issue` lookup still works.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
+DECISIONS="$SKILL_DIR/scripts/decisions"
+
+PASS=0
+FAIL=0
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+ERR_FILE="$TMP_ROOT/stderr"
+
+# Run the decisions script from a given directory with DECISIONS_DIR removed
+# from the parent environment (pass VAR=value args to set it explicitly).
+# Captures stdout in $out, stderr in $err, exit code in $rc.
+run_decisions() {
+  local dir="$1"
+  shift
+  set +e
+  out=$( (cd "$dir" && env -u DECISIONS_DIR "$@" "$DECISIONS" ${ARGS[@]+"${ARGS[@]}"}) 2>"$ERR_FILE")
+  rc=$?
+  set -e
+  err="$(cat "$ERR_FILE")"
+}
+
+assert_eq() {
+  local got="$1" want="$2" name="$3"
+  if [[ "$got" == "$want" ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$name" "$want" "$got"
+  fi
+}
+
+assert_contains() {
+  local got="$1" needle="$2" name="$3"
+  if [[ "$got" == *"$needle"* ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected to contain: %s\n        got:      %s\n' "$name" "$needle" "$got"
+  fi
+}
+
+echo "=== decisions unsupported issue action hint (vstack#641) ==="
+
+# Fixture: a project with one decision linked to CC-125, so the supported
+# lookup has a real match to return.
+PROJ="$TMP_ROOT/project"
+mkdir -p "$PROJ/docs/decisions"
+cat >"$PROJ/docs/decisions/INDEX.md" <<'EOF'
+# Architectural Decision Log
+
+| Date | ID | Research | Decision | Rationale | Revisit When | Status | Link |
+|------|----|----------|----------|-----------|--------------|--------|------|
+| 2026-01-10 | D001 | CC-125 | Use Redis for session caching | Fast and simple | If latency degrades | Active | [Full](D001-session-caching.md) |
+EOF
+
+# --- Unsupported `issue` action gets a targeted hint --------------------------
+ARGS=(issue CC-125)
+run_decisions "$PROJ" DECISIONS_DIR=docs/decisions
+assert_eq "$rc" "1" "issue action exits nonzero"
+assert_eq "$out" "" "issue action emits no stdout result"
+assert_contains "$err" "Unknown action 'issue'" "issue action names the unknown action"
+assert_contains "$err" "search --issue" "issue action hint names the supported lookup"
+
+ARGS=(issues CC-125)
+run_decisions "$PROJ" DECISIONS_DIR=docs/decisions
+assert_eq "$rc" "1" "issues action exits nonzero"
+assert_contains "$err" "search --issue" "issues action hint names the supported lookup"
+
+# --- Other unknown actions keep the generic error + usage ---------------------
+ARGS=(bogus CC-125)
+run_decisions "$PROJ" DECISIONS_DIR=docs/decisions
+assert_eq "$rc" "1" "unknown action exits nonzero"
+assert_contains "$err" "Unknown action 'bogus'" "unknown action reports generic error"
+assert_contains "$out" "Usage: decisions" "unknown action prints usage"
+
+# --- Supported issue lookup still works ---------------------------------------
+ARGS=(search --issue CC-125)
+run_decisions "$PROJ" DECISIONS_DIR=docs/decisions
+assert_eq "$rc" "0" "search --issue exits 0"
+assert_contains "$out" '"D001"' "search --issue returns the linked decision"
+
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/skills/dev/tests/decider-issue-lookup-lint.test.sh
+++ b/skills/dev/tests/decider-issue-lookup-lint.test.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Regression lint for vstack#641: dev workflow docs must never present an
+# unsupported decider issue-lookup shape. Generated dev-fix guidance once told
+# a specialist to run `decisions issue CC-125`; the CLI has no `issue` action —
+# the supported lookup is `decisions search --issue CC-125`. Rule (per physical
+# line, prose and code alike, since guidance text is what agents relay): flag
+# `decisions issue <ID>` / `decisions issues <ID>` and the `decisions show
+# --issue` near-miss. The supported `decisions search --issue` never matches —
+# `search` sits between the two tokens. Also asserts workflows/dev-fix.md still
+# carries the supported form. Hermetic: scans files on disk only, no network.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+offenders=0
+
+while IFS= read -r -d '' file; do
+  matches="$(grep -nE 'decisions[[:space:]]+(issues?([^a-zA-Z0-9_-]|$)|show[[:space:]]+--issue)' "$file" || true)"
+  if [[ -n "$matches" ]]; then
+    printf '%s\n' "$matches" | sed "s|^|$file:|"
+    offenders=$((offenders + 1))
+  fi
+done < <(find "$SKILL_DIR" -maxdepth 2 -type f -name '*.md' -not -path '*/tests/*' -print0)
+
+if (( offenders > 0 )); then
+  echo "FAIL: $offenders file(s) use an unsupported decisions issue-lookup shape (use 'decisions search --issue')"
+  exit 1
+fi
+
+if ! grep -q 'decisions search --issue' "$SKILL_DIR/workflows/dev-fix.md"; then
+  echo "FAIL: workflows/dev-fix.md lost the supported 'decisions search --issue' lookup"
+  exit 1
+fi
+
+echo "all pass"

--- a/skills/dev/workflows/dev-fix.md
+++ b/skills/dev/workflows/dev-fix.md
@@ -40,7 +40,7 @@ For each item in `Review items:`:
 2. **Apply if**: related to parent issue, no new risks
 
 3. **Skip if** pattern conflicts with existing architecture, would break other functionality, does not follow your defined rules or conventions.
-   - **Before applying** (decider skill): `.agents/skills/decider/scripts/decisions search "[RELEVANT_KEYWORDS]"` for decisions governing the affected area → if match found, read the full decision file
+   - **Before applying** (decider skill): `.agents/skills/decider/scripts/decisions search "[RELEVANT_KEYWORDS]"` for decisions governing the affected area; for decisions linked to the issue, `.agents/skills/decider/scripts/decisions search --issue [ISSUE_ID]` (issue lookup is `search --issue` — the CLI has no bare `issue` action) → if match found, read the full decision file
    - If review item contradicts an active decision, skip with decision reference (e.g., "Skipped — contradicts D010")
    - Expanding scope is OK if it relates to the parent issue/PR
 

--- a/skills/orch/tests/decider-issue-lookup-lint.test.sh
+++ b/skills/orch/tests/decider-issue-lookup-lint.test.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Regression lint for vstack#641. During an orch dev-fix cycle the generated
+# delegation guidance told a specialist to run `decisions issue CC-125` — an
+# action the decider CLI rejects; the supported issue lookup is
+# `decisions search --issue CC-125`. The orch dev-fix workflow now gathers
+# decision context itself (§ 2 step 4) and hands resolved IDs/paths plus the
+# exact supported command to the specialist, so nothing is left to improvise.
+#
+# This lint scans the orch SKILL.md and workflows/*.md (every line — prose,
+# inline code, and fenced blocks alike, since guidance text is what agents
+# relay) and FAILS if any line uses an unsupported issue-lookup shape:
+#   - `decisions issue <ID>` / `decisions issues <ID>` (the reported miss)
+#   - `decisions show --issue` (near-miss: `show` is not an action)
+# It also asserts the dev-fix delegation source carries the supported
+# `decisions search --issue` form, so the guidance can't silently drop it.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
+TMP_ROOT="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+PASS=0
+FAIL=0
+
+pass() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+fail() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
+
+# scan_bad_lookup <file>
+# Emits one "file:line: ..." row per line using an unsupported issue-lookup
+# shape. `decisions search --issue` never matches — `search` sits between the
+# two tokens — so the supported form and this lint coexist freely.
+scan_bad_lookup() {
+  grep -nE 'decisions[[:space:]]+(issues?([^a-zA-Z0-9_-]|$)|show[[:space:]]+--issue)' "$1" \
+    | sed "s|^|$1:|" || true
+}
+
+echo "=== orch decider issue-lookup syntax lint (vstack#641) ==="
+
+# --- Part a: the real orch docs must be clean ------------------------------
+DOCS=("$SKILL_DIR/SKILL.md" "$SKILL_DIR"/workflows/*.md)
+offenders=""
+for doc in "${DOCS[@]}"; do
+  out="$(scan_bad_lookup "$doc")"
+  [[ -n "$out" ]] && offenders+="$out"$'\n'
+done
+if [[ -z "$offenders" ]]; then
+  pass "orch docs never use an unsupported decisions issue-lookup shape"
+else
+  fail "orch docs use unsupported decisions issue-lookup shapes:"
+  printf '%s' "$offenders" | sed 's/^/          /'
+fi
+
+# --- Part b: dev-fix delegation guidance carries the supported form --------
+if grep -q 'decisions search --issue' "$SKILL_DIR/workflows/dev-fix.md"; then
+  pass "dev-fix workflow carries the supported 'decisions search --issue' lookup"
+else
+  fail "dev-fix workflow lost the supported 'decisions search --issue' lookup"
+fi
+
+# --- Part c: the lint has teeth --------------------------------------------
+
+# inject_line <descriptor> <line> → prints scratch-file path.
+# Appends <line> to a scratch copy of a real, now-clean workflow doc under
+# $TMP_ROOT (removed by the EXIT trap). The base doc has zero offenders, so
+# any offender reported comes from the injected line alone.
+inject_line() {
+  local scratch="$TMP_ROOT/inject-$1.md"
+  cp "$SKILL_DIR/workflows/dev-fix.md" "$scratch"
+  printf '\n%s\n' "$2" >> "$scratch"
+  printf '%s' "$scratch"
+}
+
+# c.1 — the reported miss IS flagged.
+if [[ -n "$(scan_bad_lookup "$(inject_line miss 'Check decisions: run `decisions issue CC-125` first.')")" ]]; then
+  pass "lint flags the unsupported 'decisions issue <ID>' shape"
+else
+  fail "lint MISSED the unsupported 'decisions issue <ID>' shape (no teeth)"
+fi
+
+# c.2 — near-miss variants ARE flagged.
+if [[ -n "$(scan_bad_lookup "$(inject_line plural 'Run `decisions issues CC-125`.')")" ]]; then
+  pass "lint flags the 'decisions issues <ID>' near-miss"
+else
+  fail "lint MISSED the 'decisions issues <ID>' near-miss (no teeth)"
+fi
+if [[ -n "$(scan_bad_lookup "$(inject_line show 'Run `decisions show --issue CC-125`.')")" ]]; then
+  pass "lint flags the 'decisions show --issue' near-miss"
+else
+  fail "lint MISSED the 'decisions show --issue' near-miss (no teeth)"
+fi
+
+# c.3 — the supported form is NOT flagged.
+if [[ -z "$(scan_bad_lookup "$(inject_line ok 'Run `.agents/skills/decider/scripts/decisions search --issue CC-125`.')")" ]]; then
+  pass "lint accepts the supported 'decisions search --issue' form"
+else
+  fail "lint false-flagged the supported 'decisions search --issue' form"
+fi
+
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/skills/orch/workflows/dev-fix.md
+++ b/skills/orch/workflows/dev-fix.md
@@ -100,7 +100,13 @@ Apply [Worktree Scope](../SKILL.md#worktree-scope): if in a worktree and `ISSUE_
    ```
    Use the output as `TEAM`.
 
-4. **Delegate** to `[AGENT_TYPE]` agent (reuse existing dev agent if available).
+4. **Gather decision context** (decider skill):
+   ```bash
+   .agents/skills/decider/scripts/decisions search --issue [ISSUE_ID]
+   ```
+   Collect decision IDs, summaries, and file paths from the JSON output for the `Decisions:` section below. Issue-linked lookup is exactly `decisions search --issue [ISSUE_ID]` — the decisions CLI has no bare `issue` action; never shorten the command in delegation guidance.
+
+5. **Delegate** to `[AGENT_TYPE]` agent (reuse existing dev agent if available).
 
    ⚠ Fill placeholders only ([Format Tags Are Literal](../SKILL.md#format-tags-are-literal)). `Recommendation:` = technical fix, not procedure steps. The agent owns validate/commit/return per `dev/workflows/dev-fix.md`.
    - ✅ `"Read X from parent state and forward to child — fix in parent so descendants inherit."`
@@ -116,13 +122,17 @@ Apply [Worktree Scope](../SKILL.md#worktree-scope): if in a worktree and `ISSUE_
    Worktree: [WORKTREE_PATH]
    [If qa_agent:] QA: [QA_AGENT]
 
+   Decisions:
+   [For each matching decision: "- [DECISION_ID]: [ONE_LINE_SUMMARY] — [DECISION_FILE_PATH]"]
+   [If none: "- No linked decisions found."]
+
    Review items:
    [FORMATTED_ITEMS]
    </delegation_format>
 
-5. **Wait for completion.** Parse return: item decisions (Applied/Skipped/Blocked), commits, validation status.
+6. **Wait for completion.** Parse return: item decisions (Applied/Skipped/Blocked), commits, validation status.
 
-6. **Update state** — run each block as its own tool call; the appends run once per item, so they can't be folded into a single expression:
+7. **Update state** — run each block as its own tool call; the appends run once per item, so they can't be folded into a single expression:
    ```bash
    # For each applied item:
    .agents/skills/orch/scripts/workflow-state append [ISSUE_ID] fixed_items '{"description":"[DESC]","location":"[LOC]","commit":"[SHA]","source":"[SOURCE]"}'


### PR DESCRIPTION
## Summary

Closes #641. During an orch dev-fix cycle, generated delegation guidance told a specialist to run `decisions issue CC-125` — an action the decisions CLI does not have (the supported lookup is `decisions search --issue`). No canonical file contained the bad syntax; the orchestrator improvised it because `orch/workflows/dev-fix.md` (unlike review.md / review-pr.md) had no decision-context step at all.

Three layers:
- **orch/workflows/dev-fix.md** — new § 2 step 4 "Gather decision context" runs `decisions search --issue [ISSUE_ID]`; the delegation format gains a `Decisions:` section (same shape as review.md) with an explicit note that the CLI has no bare `issue` action. Later steps renumbered (no cross-file references to those numbers).
- **dev/workflows/dev-fix.md** — specialist-side decider bullet names the exact `search --issue` form.
- **decider/scripts/decisions** — dispatcher catches `issue`/`issues` with a targeted hint pointing at `decisions search --issue <ISSUE_ID>`; other unknown actions keep the generic error + usage.

## Tests

- `decider/tests/decider-issue-action-hint.test.sh` (11 asserts): hint on `issue`/`issues`, generic path preserved, supported lookup still returns matches.
- `orch/tests/decider-issue-lookup-lint.test.sh` + `dev/tests/decider-issue-lookup-lint.test.sh`: lint docs for the unsupported shapes with injected-offender teeth checks; assert dev-fix.md carries the supported form.
- Full orch suite 13/13 files pass; all decider and dev tests green. Bash 3.2-safe.
