### PR TITLE
fix(#660): alias numeric workflow-state keys to issue-N; pin key convention in docs

### DIFF
--- a/skills/orch/SKILL.md
+++ b/skills/orch/SKILL.md
@@ -179,6 +179,8 @@ Both `approval-wait` and `ci-wait` use `scripts/lib/gh-auth.sh`, which wraps the
 
 To target a state directory from a worktree, pass the global `--state-dir <path>` flag before the subcommand: it applies to every action and takes precedence over `ORCH_STATE_DIR`. Prefer the flag over an `ORCH_STATE_DIR=… workflow-state …` env prefix — the env-assignment prefix is rejected under Codex `approval=never` as a flagged command shape, while a plain flag is classifier-safe. `ORCH_STATE_DIR` remains supported as an environment fallback (default: `tmp`). Put non-secret workflow settings in committed `vstack.settings.toml` under `[env]`; `.env.local` remains supported for secrets and personal overrides.
 
+State keys are the normalized issue IDs — `issue-N` for GitHub issues (per `start` routing), `PROJ-123` for Linear — never the bare GitHub issue number. As a safety net, every action except `init` aliases a bare numeric key to the `issue-N` state file when only that file exists; the exact-key file wins when present, and the command errors (exit 2) instead of guessing when files exist under both keys.
+
 ```bash
 .agents/skills/orch/scripts/workflow-state --state-dir /path/to/tmp append PROJ-123 fixed_items '{"description":"Fix"}'
 ```
@@ -413,7 +415,7 @@ Never edit or write code unless the user explicitly asks. Delegate to the domain
 
 Use workflow state files for data that must survive compaction: issue tracking, sub-issues, agent persistence, cycle counts, fix/escalation tracking, audit trails. Use the `workflow-state` CLI for all reads/writes, including `set-git-head` and `set-now` instead of inline command-substitution state-write snippets.
 
-Location: `<state-dir>/workflow-state-[ID].json` — `<state-dir>` resolves to the global `--state-dir <path>` flag, then `$ORCH_STATE_DIR`, then `tmp/`. From a worktree, prefer `--state-dir` over an `ORCH_STATE_DIR=…` env prefix (rejected under Codex `approval=never`).
+Location: `<state-dir>/workflow-state-[ID].json` — `[ID]` is the normalized workflow-state key (`issue-N` for GitHub, `PROJ-123` for Linear), and `<state-dir>` resolves to the global `--state-dir <path>` flag, then `$ORCH_STATE_DIR`, then `tmp/`. From a worktree, prefer `--state-dir` over an `ORCH_STATE_DIR=…` env prefix (rejected under Codex `approval=never`).
 
 #### Compaction Recovery Protocol
 

--- a/skills/orch/schemas/workflow-state.md
+++ b/skills/orch/schemas/workflow-state.md
@@ -4,6 +4,8 @@ Persistent state file for orch workflows. Survives context compaction.
 
 **Location**: `<state-dir>/workflow-state-[ISSUE_ID].json` — `<state-dir>` resolves to the global `--state-dir <path>` flag, then `$ORCH_STATE_DIR`, then `tmp/`.
 
+**Key**: `[ISSUE_ID]` is the normalized workflow-state key — `issue-N` for GitHub issues, `PROJ-123` for Linear — never the bare GitHub issue number. As a safety net, every `workflow-state` action except `init` aliases a bare numeric key to the `issue-N` file when only that file exists; the exact-key file wins when present, and the command errors instead of guessing when files exist under both keys.
+
 ## Schema
 
 ```json

--- a/skills/orch/scripts/workflow-state
+++ b/skills/orch/scripts/workflow-state
@@ -18,6 +18,34 @@ get_state_file() {
     echo "${STATE_DIR}/${STATE_PREFIX}-${issue_id}.json"
 }
 
+# Resolve the state file for a key. GitHub-issue orchestration stores state
+# under the normalized `issue-N` key, so a bare numeric tracker number aliases
+# to the normalized file when only that file exists. The exact-key file wins
+# when it exists; if files exist under BOTH keys the target is ambiguous —
+# error out rather than guess. Non-numeric keys resolve to the exact file only.
+# Used by every subcommand except `init` (init always creates the exact key).
+resolve_state_file() {
+    local issue_id="$1"
+    local exact
+    exact=$(get_state_file "$issue_id")
+
+    if [[ "$issue_id" =~ ^[0-9]+$ ]]; then
+        local normalized
+        normalized=$(get_state_file "issue-${issue_id}")
+        if [[ -f "$exact" && -f "$normalized" ]]; then
+            echo "Error: ambiguous state key '$issue_id': both $exact and $normalized exist" >&2
+            echo "Remove or merge one file, then retry with the intended key" >&2
+            exit 2
+        fi
+        if [[ ! -f "$exact" && -f "$normalized" ]]; then
+            echo "$normalized"
+            return 0
+        fi
+    fi
+
+    echo "$exact"
+}
+
 ensure_state_exists() {
     local state_file="$1"
     if [[ ! -f "$state_file" ]]; then
@@ -122,7 +150,7 @@ cmd_get() {
     local jq_path="${2:-.}"
 
     local state_file
-    state_file=$(get_state_file "$issue_id")
+    state_file=$(resolve_state_file "$issue_id")
     ensure_state_exists "$state_file"
 
     jq -r "$jq_path" "$state_file"
@@ -133,7 +161,7 @@ cmd_update() {
     local jq_expr="$2"
 
     local state_file
-    state_file=$(get_state_file "$issue_id")
+    state_file=$(resolve_state_file "$issue_id")
     ensure_state_exists "$state_file"
 
     atomic_update "$state_file" "$jq_expr"
@@ -145,7 +173,7 @@ cmd_append() {
     local value="$3"
 
     local state_file
-    state_file=$(get_state_file "$issue_id")
+    state_file=$(resolve_state_file "$issue_id")
     ensure_state_exists "$state_file"
 
     # Handle nested fields (e.g., pr_comment_review.fixes)
@@ -170,7 +198,7 @@ cmd_increment() {
     local field="$2"
 
     local state_file
-    state_file=$(get_state_file "$issue_id")
+    state_file=$(resolve_state_file "$issue_id")
     ensure_state_exists "$state_file"
 
     atomic_update "$state_file" ".${field} += 1"
@@ -182,7 +210,7 @@ cmd_set() {
     local value="$3"
 
     local state_file
-    state_file=$(get_state_file "$issue_id")
+    state_file=$(resolve_state_file "$issue_id")
     ensure_state_exists "$state_file"
 
     if [[ "$value" == "{"* ]] || [[ "$value" == "["* ]] || [[ "$value" == "null" ]] || [[ "$value" == "true" ]] || [[ "$value" == "false" ]] || [[ "$value" =~ ^[0-9]+$ ]]; then
@@ -222,7 +250,7 @@ cmd_set_now() {
 
 cmd_path() {
     local issue_id="$1"
-    get_state_file "$issue_id"
+    resolve_state_file "$issue_id"
 }
 
 cmd_exists() {
@@ -240,7 +268,7 @@ cmd_exists() {
     fi
 
     local state_file
-    state_file=$(get_state_file "$issue_id")
+    state_file=$(resolve_state_file "$issue_id")
 
     if [[ "$json" == true ]]; then
         local exists=false
@@ -285,6 +313,14 @@ Commands:
   set-now <issue_id> <field>     Set field to current epoch seconds
   path <issue_id>               Print state file path
   exists [--json] <issue_id>    Exit 0 if exists, 1 if not; --json prints status and exits 0
+
+Keys:
+  GitHub-issue orchestration stores state under the normalized key issue-<N>.
+  Every command except init accepts the bare tracker number as an alias: when
+  only <state-dir>/workflow-state-issue-<N>.json exists, a numeric <issue_id>
+  resolves to that file. The exact-key file wins when it exists; if files
+  exist under BOTH keys the command errors (exit 2) instead of guessing.
+  init always creates the exact key given — pass the normalized key to init.
 
 Examples:
   workflow-state init PROJ-123 --agent rust --worktree /tmp/wt

--- a/skills/orch/tests/workflow-state-numeric-key-alias.sh
+++ b/skills/orch/tests/workflow-state-numeric-key-alias.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# Regression tests for the numeric-key → issue-N state-file alias (vstack#660).
+# GitHub-issue orchestration stores state under the normalized `issue-N` key,
+# but managed workflow callers historically substituted the bare tracker
+# number (e.g. `workflow-state append 290 …`), which targeted the nonexistent
+# tmp/workflow-state-290.json and errored. Every subcommand except init now
+# resolves a purely numeric key to the `issue-N` file when only that file
+# exists; the exact-key file wins when present; when files exist under BOTH
+# keys the command errors loudly (exit 2) instead of guessing; non-numeric
+# keys never alias.
+
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../.." && pwd)"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+WS="$REPO_ROOT/skills/orch/scripts/workflow-state"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local got="$1" want="$2" name="$3"
+  if [[ "$got" == "$want" ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$name" "$want" "$got"
+  fi
+}
+
+assert_contains() {
+  local haystack="$1" needle="$2" name="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        missing substring: %s\n        in: %s\n' "$name" "$needle" "$haystack"
+  fi
+}
+
+assert_file_exists() {
+  local file="$1" name="$2"
+  if [[ -f "$file" ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected file to exist: %s\n' "$name" "$file"
+  fi
+}
+
+assert_file_absent() {
+  local file="$1" name="$2"
+  if [[ ! -f "$file" ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected file to be absent: %s\n' "$name" "$file"
+  fi
+}
+
+echo "=== workflow-state numeric-key issue-N alias ==="
+
+# Test 1: numeric key falls through to the issue-N file when only that exists,
+# uniformly across get / append / increment / set / set-now / update / path /
+# exists — and never creates a bare-number file as a side effect.
+sd_alias="$TMP_ROOT/alias"
+"$WS" --state-dir "$sd_alias" init issue-290 \
+  --worktree "$REPO_ROOT" --branch issue-290 >/dev/null
+
+branch_val="$("$WS" --state-dir "$sd_alias" get 290 .branch)"
+assert_eq "$branch_val" "issue-290" "numeric get aliases to the issue-N file"
+
+"$WS" --state-dir "$sd_alias" append 290 pr_comment_review.replied \
+  '{"source_id":"T1","commit":"abc123","outcome":"applied"}'
+replied_id="$("$WS" --state-dir "$sd_alias" get issue-290 '.pr_comment_review.replied[0].source_id')"
+assert_eq "$replied_id" "T1" "numeric append writes into the issue-N file"
+
+"$WS" --state-dir "$sd_alias" increment 290 pr_comment_review.iterations
+iterations="$("$WS" --state-dir "$sd_alias" get issue-290 .pr_comment_review.iterations)"
+assert_eq "$iterations" "1" "numeric increment writes into the issue-N file"
+
+"$WS" --state-dir "$sd_alias" set 290 skip_qa true
+skip_qa="$("$WS" --state-dir "$sd_alias" get issue-290 .skip_qa)"
+assert_eq "$skip_qa" "true" "numeric set writes into the issue-N file"
+
+"$WS" --state-dir "$sd_alias" set-now 290 review_delegated_at
+delegated_at="$("$WS" --state-dir "$sd_alias" get issue-290 .review_delegated_at)"
+assert_eq "$([[ "$delegated_at" =~ ^[0-9]+$ ]] && echo numeric)" "numeric" \
+  "numeric set-now writes epoch seconds into the issue-N file"
+
+"$WS" --state-dir "$sd_alias" update 290 '.cycles += 2'
+cycles="$("$WS" --state-dir "$sd_alias" get issue-290 .cycles)"
+assert_eq "$cycles" "2" "numeric update applies jq against the issue-N file"
+
+path_val="$("$WS" --state-dir "$sd_alias" path 290)"
+assert_eq "$path_val" "$sd_alias/workflow-state-issue-290.json" \
+  "numeric path prints the issue-N file path"
+
+exists_json="$("$WS" --state-dir "$sd_alias" exists --json 290)"
+assert_eq "$(jq -r '.exists' <<<"$exists_json")" "true" \
+  "numeric exists --json reports the issue-N state"
+assert_eq "$(jq -r '.path' <<<"$exists_json")" "$sd_alias/workflow-state-issue-290.json" \
+  "numeric exists --json reports the resolved issue-N path"
+
+assert_file_absent "$sd_alias/workflow-state-290.json" \
+  "aliased writes never create a bare-number state file"
+
+# Test 2: exact-key file wins when it exists — a numeric key with its own
+# state file is untouched by the alias.
+sd_exact="$TMP_ROOT/exact"
+"$WS" --state-dir "$sd_exact" init 123 \
+  --worktree "$REPO_ROOT" --branch bare-123 >/dev/null
+assert_file_exists "$sd_exact/workflow-state-123.json" \
+  "init always creates the exact key given"
+exact_branch="$("$WS" --state-dir "$sd_exact" get 123 .branch)"
+assert_eq "$exact_branch" "bare-123" "exact-key file wins for numeric get"
+
+# Test 3: both files exist → loud error (exit 2), never a guess, for reads
+# and writes alike; neither file is modified.
+sd_both="$TMP_ROOT/both"
+"$WS" --state-dir "$sd_both" init issue-777 \
+  --worktree "$REPO_ROOT" --branch issue-777 >/dev/null
+"$WS" --state-dir "$sd_both" init 777 \
+  --worktree "$REPO_ROOT" --branch bare-777 >/dev/null
+
+set +e
+both_get_out="$("$WS" --state-dir "$sd_both" get 777 .branch 2>&1)"
+both_get_status=$?
+both_set_out="$("$WS" --state-dir "$sd_both" set 777 skip_qa true 2>&1)"
+both_set_status=$?
+set -e
+assert_eq "$both_get_status" "2" "ambiguous numeric get exits 2"
+assert_contains "$both_get_out" "ambiguous state key '777'" \
+  "ambiguous numeric get names the conflicting key"
+assert_eq "$both_set_status" "2" "ambiguous numeric set exits 2"
+assert_contains "$both_set_out" "ambiguous state key '777'" \
+  "ambiguous numeric set names the conflicting key"
+normalized_skip="$("$WS" --state-dir "$sd_both" get issue-777 .skip_qa)"
+assert_eq "$normalized_skip" "false" "ambiguous write leaves the issue-N file untouched"
+
+# Test 4: non-numeric keys never alias — a missing Linear-style key errors on
+# its own exact file even when a same-suffix issue-N file exists nearby, and
+# an existing Linear key resolves normally.
+sd_nonnum="$TMP_ROOT/nonnum"
+"$WS" --state-dir "$sd_nonnum" init PROJ-123 \
+  --worktree "$REPO_ROOT" --branch proj-123 >/dev/null
+proj_branch="$("$WS" --state-dir "$sd_nonnum" get PROJ-123 .branch)"
+assert_eq "$proj_branch" "proj-123" "non-numeric keys resolve their exact file"
+
+set +e
+missing_out="$("$WS" --state-dir "$sd_nonnum" get PROJ-404 .branch 2>&1)"
+missing_status=$?
+set -e
+assert_eq "$([[ "$missing_status" -ne 0 ]] && echo nonzero)" "nonzero" \
+  "missing non-numeric key still errors"
+assert_contains "$missing_out" "workflow-state-PROJ-404.json" \
+  "missing non-numeric key error names the exact file (no alias probe)"
+
+# Test 5: missing numeric key with no normalized file either → standard
+# not-found error against the exact bare-number path.
+set +e
+missing_num_out="$("$WS" --state-dir "$sd_nonnum" get 555 .branch 2>&1)"
+missing_num_status=$?
+set -e
+assert_eq "$([[ "$missing_num_status" -ne 0 ]] && echo nonzero)" "nonzero" \
+  "numeric key with no state file at all errors"
+assert_contains "$missing_num_out" "workflow-state-555.json" \
+  "numeric no-file error names the exact bare-number path"
+
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/skills/orch/tests/workflow_helpers.sh
+++ b/skills/orch/tests/workflow_helpers.sh
@@ -314,6 +314,23 @@ if [[ -f "$settings_example" ]]; then
   assert_file_contains "$settings_example" 'REVIEWER_SLOT_BUDGET = "0"' "settings example documents the reviewer slot budget default"
 fi
 
+# vstack#660 — GitHub-issue orchestration stores workflow state under the
+# normalized `issue-N` key, so workflow docs must define `issue_id`/[ISSUE_ID]
+# as that workflow-state key (never the bare GitHub issue number), and
+# review-pr-comments § 6.1 step 8 must append replies under [ISSUE_ID] with
+# the key clarified in place.
+assert_file_contains "$comments_workflow" 'workflow-state append [ISSUE_ID] pr_comment_review.replied' "review-pr-comments § 6.1 step 8 appends replies under the [ISSUE_ID] state key"
+assert_file_contains "$comments_workflow" '# [ISSUE_ID] is the workflow-state key (e.g. issue-290), matching the' "review-pr-comments § 6.1 step 8 clarifies the state key in place"
+assert_file_contains "$comments_workflow" 'never the bare GitHub issue number' "review-pr-comments defines issue_id as the normalized state key"
+assert_file_contains "$submit_workflow" 'never the bare GitHub issue number' "submit-pr defines issue_id as the workflow-state key"
+for workflow_path in dev-fix dev-start initialize post-summary review-pr; do
+  assert_file_contains "$REPO_ROOT/skills/orch/workflows/$workflow_path.md" \
+    'workflow-state key — the normalized issue ID' \
+    "$workflow_path defines caller issue_id as the normalized workflow-state key"
+done
+assert_file_contains "$orch_skill" 'never the bare GitHub issue number' "orch skill states the workflow-state key convention"
+assert_file_contains "$state_schema" 'never the bare GitHub issue number' "workflow-state schema states the key convention"
+
 assert_file_not_contains "$qa_workflow" "Pipe benchmark output" "qa-review avoids pipe-based benchmark recording"
 assert_file_not_contains "$qa_workflow" "pipe results" "qa-review avoids pipe-based perf capture guidance"
 assert_file_contains "$qa_workflow" "Do not use shell pipelines" "qa-review bans Codex-unsafe benchmark shell plumbing"

--- a/skills/orch/workflows/dev-fix.md
+++ b/skills/orch/workflows/dev-fix.md
@@ -14,7 +14,7 @@ Delegate fix items to a specialist dev agent. Works standalone (user-initiated) 
 - `worktree`: worktree path
 - `lifecycle` (optional): `"managed"` (return to caller at § 3) | `"self"` (default, standalone).
 - `dev_agent` (optional): name of alive dev agent for fix delegation. If absent, determine from state/labels.
-- `issue_id` (optional): Issue ID. If absent, extracted from branch.
+- `issue_id` (optional): workflow-state key — the normalized issue ID (`issue-N` for GitHub, `PROJ-123` for Linear), never the bare GitHub issue number. If absent, extracted from branch.
 - `items` (optional): formatted review items. If absent, build from conversation context.
 - `source` (optional): `pr-review` | `qa-review` | `review` | `local-review`. Default: `conversation`.
 - `qa_agent` (optional): QA agent name (for qa-review source).

--- a/skills/orch/workflows/dev-start.md
+++ b/skills/orch/workflows/dev-start.md
@@ -13,7 +13,7 @@ Delegate development work to specialist agent(s). Handles single issues and bund
 **Caller context parameters** (via `⤵`):
 - `worktree`: worktree path
 - `lifecycle` (optional): `"managed"` (return to caller at § 4) | `"self"` (default, standalone).
-- `issue_id` (optional): Issue ID. If absent, extracted from branch.
+- `issue_id` (optional): workflow-state key — the normalized issue ID (`issue-N` for GitHub, `PROJ-123` for Linear), never the bare GitHub issue number. If absent, extracted from branch.
 
 **Standalone init** (`lifecycle: "self"` only):
 ```bash

--- a/skills/orch/workflows/fix-reconcile.md
+++ b/skills/orch/workflows/fix-reconcile.md
@@ -14,7 +14,7 @@ Batch workflow — checks if applied fixes address existing open issues. Process
 
 | Context | Source | Required |
 |---------|--------|----------|
-| `issue_id` | Caller issue ID for workflow-state lookup | Yes |
+| `issue_id` | Caller workflow-state key (normalized issue ID, e.g. `issue-N` — never the bare GitHub issue number) | Yes |
 | `pr_number` | Caller PR number for comments | Yes |
 
 ## 1. Gather Fixes

--- a/skills/orch/workflows/initialize.md
+++ b/skills/orch/workflows/initialize.md
@@ -13,7 +13,7 @@ Set up team, auth, cache, and workflow state for a worktree session.
 
 **Caller context parameters** (via `⤵`):
 - `lifecycle` (optional): `"managed"` (return to caller at § 2) | `"self"` (default, standalone).
-- `issue_id` (optional): Issue ID. If absent, extracted from branch.
+- `issue_id` (optional): workflow-state key — the normalized issue ID (`issue-N` for GitHub, `PROJ-123` for Linear), never the bare GitHub issue number. If absent, extracted from branch.
 - `tracker` (optional): `linear` or `github`.
 - `github_repo` (optional): `OWNER/REPO` for GitHub work items.
 

--- a/skills/orch/workflows/post-summary.md
+++ b/skills/orch/workflows/post-summary.md
@@ -13,7 +13,7 @@ Post summary comments to git host and issue tracker, and selective handoff comme
 **Caller context parameters** (via `⤵`):
 - `worktree`: worktree path
 - `lifecycle` (optional): `"managed"` (return to caller at § 3) | `"self"` (default, standalone).
-- `issue_id` (optional): Issue ID. If absent, extracted from branch.
+- `issue_id` (optional): workflow-state key — the normalized issue ID (`issue-N` for GitHub, `PROJ-123` for Linear), never the bare GitHub issue number. If absent, extracted from branch.
 - `pr_number` (optional): PR number for git host comment. If absent, detected from branch.
 
 **Standalone init** (`lifecycle: "self"` only):

--- a/skills/orch/workflows/review-pr-comments.md
+++ b/skills/orch/workflows/review-pr-comments.md
@@ -17,7 +17,7 @@ Route PR review comments to domain agents, auto-fix valid items, loop until stab
 **Caller context parameters** (via `⤵`):
 - `worktree`: worktree path
 - `lifecycle` (optional): `"managed"` (return to caller at § 8) | `"self"` (default, standalone).
-- `issue_id` (optional): issue tracker ID. If absent, extracted from branch.
+- `issue_id` (optional): workflow-state key — the normalized issue ID (`issue-N` for GitHub, `PROJ-123` for Linear), never the bare GitHub issue number. If absent, extracted from branch.
 - `pr_number` (optional): PR number. If absent, resolved from branch.
 
 **Standalone init** (`lifecycle: "self"` only):
@@ -112,7 +112,7 @@ Output: `threads` (inline) + `comments` (PR-level).
 
 ### 1.5 Resolve Issue Context
 
-1. **Identify parent issue**: Extract `[ISSUE_ID]` from branch name. If not found, ask user.
+1. **Identify parent issue**: use caller `issue_id` when provided; otherwise run `.agents/skills/orch/scripts/git-context issue-from-branch .` and use the output as `[ISSUE_ID]` — the normalized workflow-state key (e.g. `issue-290`), never the bare GitHub issue number. If no issue id matches, ask user.
 
 2. **Get worktree**:
    ```bash
@@ -356,6 +356,8 @@ Issue suggestions: [N] items → § 6.2 audit
    # Markdown-heavy alternative:
    #   .agents/skills/github/scripts/github.sh post-reply "[THREAD_ID]" --body-file "$REPLY_FILE" --pr "[PR_NUMBER]"
    .agents/skills/github/scripts/github.sh resolve-thread "[THREAD_ID]"
+   # [ISSUE_ID] is the workflow-state key (e.g. issue-290), matching the
+   # state file created at init — never the bare tracker number (290).
    .agents/skills/orch/scripts/workflow-state append [ISSUE_ID] pr_comment_review.replied '{"source_id":"[THREAD_ID]","commit":"[COMMIT_SHA]","outcome":"[applied|skipped|blocked|already_fixed]"}'
    ```
 

--- a/skills/orch/workflows/review-pr.md
+++ b/skills/orch/workflows/review-pr.md
@@ -15,7 +15,7 @@ Pre-submission code review: fix handling, QA checks, and issue audit.
 - `agents` (optional): list of review agent names. Default: every `reviewer-*` agent from the active harness registry. Do not hardcode a count — enumerate from the registry.
 - `lifecycle` (optional): `"managed"` (return to caller at § 11) | `"self"` (default, standalone).
 - `dev_agent` (optional): alive dev agent for fix delegation. If absent, fixes use sub-agent tasks.
-- `issue_id` (optional): issue tracker ID. If absent, extracted from branch.
+- `issue_id` (optional): workflow-state key — the normalized issue ID (`issue-N` for GitHub, `PROJ-123` for Linear), never the bare GitHub issue number. If absent, extracted from branch.
 
 **If PR# provided:**
 ```bash

--- a/skills/orch/workflows/submit-pr.md
+++ b/skills/orch/workflows/submit-pr.md
@@ -10,7 +10,7 @@ Run a local pre-PR review, push changes, create/update the PR, triage review com
 | `submit-pr [PR#]` | Manage existing PR |
 | (from start-worktree) | Managed lifecycle with caller context |
 
-**Caller context parameters** (via `⤵`): `worktree`, `lifecycle` (`"managed"` → return at § 7 | `"self"` default), `issue_id` (extracted from branch if absent).
+**Caller context parameters** (via `⤵`): `worktree`, `lifecycle` (`"managed"` → return at § 7 | `"self"` default), `issue_id` (workflow-state key — the normalized issue ID, e.g. `issue-N` for GitHub, never the bare GitHub issue number; extracted from branch if absent).
 
 **If PR# provided:**
 ```bash


### PR DESCRIPTION
Closes #660. GitHub-issue orchestration stores state under the normalized `issue-N` key, but review-pr-comments § 6.1 step 8 (and the provenance text in seven other workflow docs) invited bare-number substitution — `workflow-state append 290 ...` targets nonexistent `workflow-state-290.json`.

Fixed at both layers:

- **Script**: new `resolve_state_file()` used by every subcommand except `init` — a purely numeric key falls through to `workflow-state-issue-<N>.json` when only that exists; the exact-key file wins when present; both existing errors loudly (exit 2, no guessing); non-numeric keys never probe the alias; `init` always creates the exact key.
- **Docs**: all eight caller-issue_id workflow docs now define \[ISSUE_ID\] as the normalized workflow-state key (`issue-N` for GitHub, `PROJ-123` for Linear), § 1.5 resolves it via `git-context issue-from-branch`, § 6.1 step 8 pins the key form in-fence; SKILL.md + schema document the convention and alias.

Validation: new workflow-state-numeric-key-alias suite 22/22 (aliased reads/writes, no bare-number file creation, init exactness, exact-key precedence, ambiguity exit 2 leaving files untouched, non-numeric isolation); workflow_helpers doc-contract block pins the corrected command shapes; full orch run-all: all 14 files pass.

https://claude.ai/code/session_016s6ZSLTTRft6fH29wHn1TN