### PR TITLE
fix(#655): route audit-issues execution through the resolved tracker

### DIFF
--- a/skills/orch/workflows/review-pr-comments.md
+++ b/skills/orch/workflows/review-pr-comments.md
@@ -368,7 +368,7 @@ Issue suggestions: [N] items → § 6.2 audit
 **Skip if** no issue suggestions AND no blocked items.
 
 1. **Build audit-input file** from issue suggestions + blocked items
-2. **Write file**: `[WORKTREE_PATH]/tmp/audit-pr-comments-YYYYMMDD-HHMMSS.json` per `.agents/skills/project-management/schemas/audit-issues-input.md`
+2. **Write file**: `[WORKTREE_PATH]/tmp/audit-pr-comments-YYYYMMDD-HHMMSS.json` per `.agents/skills/project-management/schemas/audit-issues-input.md` — set `tracker.type` to the resolved `TRACKER` (plus `tracker.repository` `[OWNER/REPO]` for GitHub items) so the audit routes through the correct tracker
 3. **Invoke workflow**: `⤵ .agents/skills/project-management/workflows/audit-issues.md --issues [FILE_PATH] § 1-9 → § 6.3`
 
 ### 6.3 Check for New Comments & Re-Triage

--- a/skills/orch/workflows/review-pr.md
+++ b/skills/orch/workflows/review-pr.md
@@ -592,6 +592,7 @@ Issue suggestions: [N] items → § 9 audit
 
 5. **Write file**: `[WORKTREE_PATH]/tmp/audit-start-YYYYMMDD-HHMMSS.json`
    - Schema: `.agents/skills/project-management/schemas/audit-issues-input.md`
+   - Set `tracker.type` to the resolved `TRACKER`; for GitHub items also set `tracker.repository` to `[OWNER/REPO]`. audit-issues executes every preflight and approved action through this tracker — GitHub items complete the audit via `gh`/github-skill commands without Linear.
 
 6. **Run Workflow**: `⤵ .agents/skills/project-management/workflows/audit-issues.md --issues [FILE_PATH] § 1-9 → § 9 step 7`
 

--- a/skills/project-management/README.md
+++ b/skills/project-management/README.md
@@ -36,17 +36,18 @@ skills/project-management/
 
 ## Skill Dependencies
 
-This skill requires an issue tracker CLI for all read/write operations. Configure the `.agents/skills/linear/scripts/linear.sh` variable to point to your issue tracker's CLI tool.
+This skill requires an issue tracker CLI for all read/write operations. Issue-mode audits resolve the tracker per work item: Linear-tracked items use the `linear` skill CLI; GitHub-tracked items use `gh` plus the `github` skill and never require Linear to be installed or authenticated. Project-level workflows (cycle-plan, roadmap, project/project-order audits) are Linear-only.
 
 | Dependency | Purpose | Variable |
 |------------|---------|----------|
-| Issue tracker CLI (e.g., `linear` skill) | Issue CRUD, cache, comments, labels, relations | `.agents/skills/linear/scripts/linear.sh` |
+| Issue tracker CLI (e.g., `linear` skill) | Linear issue CRUD, cache, comments, labels, relations | `.agents/skills/linear/scripts/linear.sh` |
+| GitHub CLI + `github` skill | GitHub issue CRUD, comments, labels for GitHub-tracked audits | `gh` on `PATH`; `.agents/skills/github/scripts/github.sh` |
 | Git | Resolve branch changes and tracked source roots for audit verification | `git` on `PATH` |
 | jq | Emit the verification-scope JSON contract | `jq` on `PATH` |
 
 ## Issue Tracker Setup Expectations
 
-Before using roadmap, audit, research, or cycle-planning workflows, configure the companion issue-tracker skill and sync its cache so issues, projects, relations, and issue labels are readable. The workflows depend on current issue-label inventory from the issue-tracker skill; they should not infer labels from stale docs alone.
+Before using roadmap, audit, research, or cycle-planning workflows, configure the companion issue-tracker skill and sync its cache so issues, projects, relations, and issue labels are readable. The workflows depend on current issue-label inventory from the issue-tracker skill; they should not infer labels from stale docs alone. GitHub-tracked issue audits load their label and issue inventory live via `gh` (no cache/sync step) and represent hierarchy/relations as documented body links, since GitHub has no Linear project, bundle, or typed-relation model in these workflows.
 
 - **Issue labels vs project labels**: Issue creation uses issue labels. Project labels are separate issue-tracker resources and do not satisfy issue-label requirements. See [Label management](references/labels.md) and [Issue creation](references/issues.md).
 - **Agent routing**: If a project routes work by agent, define one exclusive Agent label group/category and document the allowed agent labels in the project's taxonomy. Multi-agent bundle or coordination parents may need a documented multi-agent routing convention, but the exact label/value is project-defined.

--- a/skills/project-management/SKILL.md
+++ b/skills/project-management/SKILL.md
@@ -37,7 +37,7 @@ User-facing wrappers and TPM-execution workflows for project-level planning, aud
 | Workflow | Purpose |
 |----------|---------|
 | [cycle-plan](workflows/cycle-plan.md) | User dialog + Linear actions for cycle planning; delegates analysis to `tpm-cycle-plan` |
-| [audit-issues](workflows/audit-issues.md) | User dialog + Linear actions for issue/project audits; delegates to `tpm-audit` / `tpm-audit-project-order` |
+| [audit-issues](workflows/audit-issues.md) | User dialog + tracker actions (Linear or GitHub) for issue audits; project/project-order audits are Linear-only; delegates to `tpm-audit` / `tpm-audit-project-order` |
 | [roadmap-plan](workflows/roadmap-plan.md) | Specialist consultation + research gating; delegates to `tpm-roadmap-plan` |
 | [roadmap-create](workflows/roadmap-create.md) | Execute a roadmap plan: project + issue creation via audit |
 | [research-spike](workflows/research-spike.md) | User-initiated research with consultation, asset prep, and researcher delegation |
@@ -82,7 +82,7 @@ TPM workflows return JSON recommendations only.
 | Dependencies | [references/dependencies.md](references/dependencies.md) |
 | Prioritization factors | [references/prioritization.md](references/prioritization.md) |
 | Label management | [references/labels.md](references/labels.md) |
-| Issue tracker CLI | Companion issue tracker skill (`.agents/skills/linear/scripts/linear.sh`) |
+| Issue tracker CLI | Companion tracker skills — Linear: `.agents/skills/linear/scripts/linear.sh`; GitHub: `gh` + `.agents/skills/github/scripts/github.sh` |
 
 ## Execution Rules
 
@@ -91,6 +91,7 @@ TPM workflows return JSON recommendations only.
 - When a user-visible `<output_format>` report is followed by an `Ask user`, `AskUserQuestion`, or question-tool step, send the filled report as a normal assistant message first. Then invoke the question tool separately with only a concise question and concise options; do not paste the report into the question text, option labels, or option descriptions unless a short summary is explicitly requested. This keeps Pi question popups focused on the choice instead of the preceding report.
 - Before any issue create or label update, load the live issue-label inventory and project taxonomy, build the full final `labels[]` set, and run the label preflight in `references/labels.md`. Unknown labels, parent/group labels, missing required categories, or exclusivity violations stop the workflow before mutation.
 - In multi-issue audits, resolve and retain repository verification context per issue/contract. A PR, branch, or resolved path set associated with one issue must not scope another issue's checks.
+- Issue-mode audits resolve tracker context once (audit-issues § 1.2.1) and route every preflight, TPM fetch, and mutation through that tracker. GitHub-tracked audits must not require Linear installation, sync, or authentication; where GitHub lacks a Linear concept, the workflow degrades explicitly (documented note in the audit summary), never silently.
 
 ## Hierarchy
 
@@ -124,6 +125,6 @@ Score = (Critical Path x 3) + (Dependencies x 2) + (Risk x 2) + (Value x 1) - (E
 
 ## Dependencies
 
-- Issue tracker CLI (e.g., `linear` skill)
+- Issue tracker CLI — `linear` skill for Linear-tracked work; `github` skill + `gh` for GitHub-tracked issue audits
 - `git` (repository/change-aware audit verification scope)
 - `jq`

--- a/skills/project-management/schemas/audit-issues-input.md
+++ b/skills/project-management/schemas/audit-issues-input.md
@@ -10,6 +10,7 @@ Input file for issue audit workflows — transforms review agent findings into t
 {
   "source": "review|pr-comments|research-complete|roadmap",
   "parent_issue": "PROJ-456",
+  "tracker": {"type": "linear|github", "repository": "owner/repo"},
   "worktree": "/path/to/worktree",
   "blocked_issues": ["PROJ-456"],
   "research_ref": "docs/research/PROJ-123/findings.md",
@@ -50,6 +51,7 @@ Input file for issue audit workflows — transforms review agent findings into t
 |-------|----------|-------------|
 | `source` | Yes | Caller workflow name |
 | `parent_issue` | Yes | Issue being worked on (hierarchy hint) |
+| `tracker` | No | Execution tracker context — see § Tracker |
 | `worktree` | Yes | Path to worktree for code analysis |
 | `blocked_issues` | No | Issue IDs blocked by research |
 | `research_ref` | No | Path to research findings |
@@ -77,6 +79,17 @@ Input file for issue audit workflows — transforms review agent findings into t
 | `blocks_issues` | No | Existing issue IDs this item blocks |
 | `blocked_by_issues` | No | Existing issue IDs that block this item |
 
+## Tracker
+
+`tracker` fixes the execution tracker for the whole audit: every inventory preflight, TPM context fetch, and approved mutation routes through it (audit-issues § 1.2, § 7). Callers that already resolved a tracker (e.g. orch `TRACKER`) must set it.
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `type` | Yes (when block present) | `linear` or `github`. |
+| `repository` | github only | `owner/repo` the issues live in. |
+
+When the block is absent, audit-issues infers the tracker from `parent_issue`: an `issue-N` form ID → `github` (repository resolved via `gh repo view` in the worktree); otherwise `linear`. GitHub mode must not require Linear sync, session status, project inventory, or Linear mutation commands.
+
 ## Hierarchy Contract
 
 `hierarchy_contract` is a **binding directive, not a hint**. In
@@ -99,6 +112,8 @@ issue into the coordination-only parent of the new domain children. `parent_issu
 - `parent_issue` is converted to a coordination-only parent by the producer (research-complete § 6.6) — it must not be treated as one domain's implementation leaf nor recommended as an `update`/`expand` target for covered-item scope.
 
 ## Building from Review Agent JSONs
+
+Set top-level `tracker` from the caller's resolved `TRACKER` (plus `repository` for GitHub items) so the audit executes through the correct tracker — review-pr § 9 and review-pr-comments § 6.2 pass it through.
 
 ### Suggestions (category=issue)
 

--- a/skills/project-management/schemas/audit-output.md
+++ b/skills/project-management/schemas/audit-output.md
@@ -9,10 +9,13 @@ Output path: `tmp/audit-project-YYYYMMDD-HHMMSS.json` or `tmp/audit-issues-YYYYM
   "mode": "project|issue",
   "generated": "ISO timestamp",
   "worktree": "path",
+  "tracker": {"type": "linear|github", "repository": "owner/repo"},
   "projects_analyzed": [{"id": "uuid", "name": "string", "scope": "summary"}],
   "contracts": [{"id": "[ISSUE_ID]", "target": "...", "creates": [], "consumes": [], "problem": "..."}]
 }
 ```
+
+`tracker` echoes the resolved execution tracker from the audit input (audit-issues-input § Tracker) so analyzed-mode consumers route mutations without re-inference; `repository` is set for `github` only. In `github` mode, `projects_analyzed` is empty and all project-placement fields are `null`/omitted (no project inventory).
 
 ## Label Contract
 

--- a/skills/project-management/tests/tracker-routing-contract.test.sh
+++ b/skills/project-management/tests/tracker-routing-contract.test.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Regression test for tracker-conditional audit routing (#655).
+# These workflows are markdown contracts, so this test statically verifies that
+# audit-issues resolves tracker context once, keeps Linear preflight/mutations
+# out of the GitHub path, gives every section 7 action a GitHub execution route,
+# degrades missing Linear concepts explicitly, and that the schema and orch
+# callers carry tracker context into the audit input.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+require_pattern() {
+  local file="$1" pattern="$2" desc="$3"
+  if ! grep -Eq -- "$pattern" "$file"; then
+    fail "$desc missing in ${file#$SKILL_DIR/}"
+  fi
+}
+
+require_fixed() {
+  local file="$1" needle="$2" desc="$3"
+  if ! grep -Fq -- "$needle" "$file"; then
+    fail "$desc missing in ${file#$SKILL_DIR/}"
+  fi
+}
+
+# --- Schema: audit-issues-input.md carries tracker context ---
+
+schema="$SKILL_DIR/schemas/audit-issues-input.md"
+[[ -f "$schema" ]] || fail "schema not found: schemas/audit-issues-input.md"
+require_fixed "$schema" '"tracker": {"type": "linear|github", "repository": "owner/repo"}' 'tracker block in schema example'
+require_pattern "$schema" '\| `tracker` \| No \|' 'tracker field definition row'
+require_pattern "$schema" 'infers the tracker from `parent_issue`' 'tracker inference default'
+require_pattern "$schema" 'GitHub mode must not require Linear sync, session status, project inventory, or Linear mutation commands' 'GitHub-without-Linear guarantee'
+
+# --- audit-issues: tracker resolution happens once, before any tracker command ---
+
+audit_issues="$SKILL_DIR/workflows/audit-issues.md"
+require_pattern "$audit_issues" '1\.2\.1 Resolve Tracker' 'tracker resolution section'
+require_pattern "$audit_issues" 'Input file `tracker`' 'input-file tracker precedence'
+require_pattern "$audit_issues" 'starting with `issue-` → `github`; otherwise `linear`' 'issue-id inference fallback'
+require_fixed "$audit_issues" 'gh repo view --json nameWithOwner' 'repository resolution for inferred github tracker'
+require_fixed "$audit_issues" 'Project audits are Linear-only; GitHub repositories have no project inventory in this workflow.' 'project-mode halt for github tracker'
+require_pattern "$audit_issues" 'Linear installation/authentication is not a prerequisite' 'no-Linear prerequisite for github audits'
+
+# --- audit-issues 1.2: preflight is tracker-conditional; GitHub branch is Linear-free ---
+
+require_pattern "$audit_issues" '1\.2\.2 Preflight .* \(TRACKER=linear\)' 'Linear preflight branch'
+require_pattern "$audit_issues" '1\.2\.3 Preflight .* \(TRACKER=github\)' 'GitHub preflight branch'
+require_fixed "$audit_issues" '.agents/skills/linear/scripts/linear.sh sync --reconcile' 'Linear sync retained in Linear branch'
+require_fixed "$audit_issues" 'gh label list --repo [OWNER/REPO] --limit 200 --json name,description' 'GitHub live label inventory'
+require_fixed "$audit_issues" 'gh issue list --repo [OWNER/REPO] --state open --limit 200 --json number,title,labels' 'GitHub open-issue inventory'
+
+github_preflight="$tmp/github-preflight.md"
+sed -n '/^#### 1\.2\.3 /,/^### 1\.3 /p' "$audit_issues" > "$github_preflight"
+[[ -s "$github_preflight" ]] || fail 'GitHub preflight section could not be extracted'
+if grep -Fq 'linear.sh' "$github_preflight"; then
+  fail 'GitHub preflight branch contains a Linear command'
+fi
+
+# --- audit-issues 7: every approved action has a GitHub execution route ---
+
+require_pattern "$audit_issues" '\*\*Linear route \(TRACKER=linear\)\*\*' 'Linear execution route'
+require_pattern "$audit_issues" '\*\*GitHub route \(TRACKER=github\)\*\*' 'GitHub execution route'
+require_fixed "$audit_issues" 'gh issue create --repo [OWNER/REPO] --title "[TITLE]" --body-file [BODY_FILE] --label "[VALIDATED_FINAL_LABELS]"' 'GitHub create route with validated labels'
+require_fixed "$audit_issues" 'gh issue edit [N] --repo [OWNER/REPO] --body-file [BODY_FILE]' 'GitHub body-edit route'
+require_fixed "$audit_issues" 'github.sh label-add [N] "[LABEL]" --issue' 'label add via github skill'
+require_fixed "$audit_issues" 'github.sh label-remove [N] "[LABEL]" --issue' 'label remove via github skill'
+require_fixed "$audit_issues" 'gh issue close [N] --repo [OWNER/REPO] --reason "not planned"' 'GitHub cancel/supersede close route'
+require_fixed "$audit_issues" 'gh issue view [N] --repo [OWNER/REPO] --json labels' 'GitHub label preflight fetch'
+
+github_route="$tmp/github-route.md"
+sed -n '/^\*\*GitHub route (TRACKER=github)\*\*/,/^\*\*Create template\*\*/p' "$audit_issues" > "$github_route"
+[[ -s "$github_route" ]] || fail 'GitHub route section could not be extracted'
+if grep -Fq 'linear.sh' "$github_route"; then
+  fail 'GitHub execution route contains a Linear command'
+fi
+
+github_supersede="$tmp/github-supersede.md"
+sed -n '/^\*\*Superseded issues -- GitHub\*\*/,/^#### 7\.2\.1 /p' "$audit_issues" > "$github_supersede"
+[[ -s "$github_supersede" ]] || fail 'GitHub supersede section could not be extracted'
+if grep -Fq 'linear.sh' "$github_supersede"; then
+  fail 'GitHub supersede route contains a Linear command'
+fi
+
+# --- audit-issues: Linear-only concepts degrade explicitly, never silently ---
+
+require_pattern "$audit_issues" 'GitHub hierarchy & relations \(explicit degradation\)' 'hierarchy/relations degradation note'
+require_pattern "$audit_issues" 'Do not silently drop an approved hierarchy or relation action' 'no-silent-drop rule'
+require_pattern "$audit_issues" 'GitHub repositories have no project state or Todo sort-order model' 'positioning degradation for github'
+require_pattern "$audit_issues" 'positioning: n/a \(github\)' 'positioning skip recorded in summary'
+require_pattern "$audit_issues" 'Degraded \(github\)' 'degradation line in audit summary'
+require_pattern "$audit_issues" 'no recursive child query' 'research-ref child propagation degradation'
+require_pattern "$audit_issues" 'Relations -- GitHub' 'post-cancellation cleanup github branch'
+require_pattern "$audit_issues" 'Tracker: \[TRACKER\] \[OWNER/REPO\]' 'tracker context in TPM delegation'
+
+# --- tpm-audit: context fetch branches by tracker; project inventory degrades ---
+
+tpm_audit="$SKILL_DIR/workflows/tpm-audit.md"
+require_pattern "$tpm_audit" '`TRACKER` \(and `REPOSITORY` for github\)' 'tracker extraction in ISSUES mode'
+require_pattern "$tpm_audit" 'PROJECT mode audits Linear projects and is Linear-only' 'PROJECT mode Linear-only note'
+require_fixed "$tpm_audit" 'gh label list --repo [REPOSITORY] --limit 200 --json name,description' 'GitHub label inventory in TPM'
+require_fixed "$tpm_audit" 'gh issue view [N] --repo [REPOSITORY] --json number,title,body,labels,state,url' 'GitHub issue fetch in TPM'
+require_fixed "$tpm_audit" 'gh issue list --repo [REPOSITORY] --state all --limit 200 --json number,title,state,labels' 'GitHub comparison set in TPM'
+require_pattern "$tpm_audit" 'github: no project inventory' 'TPM project-placement degradation'
+
+# --- orch callers: audit input carries tracker context (when orch is present) ---
+
+review_pr="$SKILL_DIR/../orch/workflows/review-pr.md"
+if [[ -f "$review_pr" ]]; then
+  require_pattern "$review_pr" 'Set `tracker\.type` to the resolved `TRACKER`' 'review-pr passes tracker context'
+  require_pattern "$review_pr" 'tracker\.repository' 'review-pr passes repository context'
+fi
+
+review_pr_comments="$SKILL_DIR/../orch/workflows/review-pr-comments.md"
+if [[ -f "$review_pr_comments" ]]; then
+  require_pattern "$review_pr_comments" 'set `tracker\.type` to the resolved `TRACKER`' 'review-pr-comments passes tracker context'
+fi
+
+echo "all pass"

--- a/skills/project-management/workflows/audit-issues.md
+++ b/skills/project-management/workflows/audit-issues.md
@@ -13,9 +13,11 @@ Audit tracked issues and projects for relations, hierarchy, project placement, d
 | `audit-issues --issues [file_path]` | `issue` | Proposed issues from JSON file |
 | `audit-issues --analyzed [file_path]` | `analyzed` | Pre-analyzed audit-output JSON (skips TPM) |
 
-**When called by parent workflow** (start, research-complete, review-pr-comments):
+**When called by parent workflow** (start, review-pr, research-complete, review-pr-comments):
 
 `--issues [file_path]` -- JSON file with all context. Schema: [audit-issues-input.md](../schemas/audit-issues-input.md)
+
+The input file's optional `tracker` block fixes the execution tracker for the whole audit (schema § Tracker). Callers with a resolved tracker (e.g. orch `TRACKER`) must set it so GitHub-tracked audits never touch Linear.
 
 **Hierarchy**: TPM determines final placement using `parent_issue` from file + per-item analysis.
 
@@ -40,11 +42,30 @@ Set MODE and TARGET from input:
 | `--issues [file_path]` | MODE=issue, TARGET=file_path |
 | `--analyzed [file_path]` | MODE=analyzed, TARGET=file_path |
 
-**File mode**: Read JSON file, extract `source`, `parent_issue`, `worktree`, `items[]`.
+**File mode**: Read JSON file, extract `source`, `parent_issue`, `tracker`, `worktree`, `items[]`.
 
-**Analyzed mode**: Read pre-analyzed audit output (project-management skill schemas audit-output ISSUE mode format with embedded `create_fields` per issue and top-level `source`, `parent_issue`, `research_ref`, `plan_path`).
+**Analyzed mode**: Read pre-analyzed audit output (project-management skill schemas audit-output ISSUE mode format with embedded `create_fields` per issue and top-level `source`, `parent_issue`, `research_ref`, `plan_path`, and optional `tracker`).
 
-### 1.2 Ensure Cache Fresh & Query Status
+### 1.2 Resolve Tracker & Preflight Inventory
+
+#### 1.2.1 Resolve Tracker
+
+Resolve tracker context once, before any tracker command. Every later preflight, fetch, and mutation routes through it. Precedence:
+
+1. **Input file `tracker`** (file/analyzed modes): use `tracker.type`; for `github`, use `tracker.repository` as `[OWNER/REPO]`.
+2. **Caller context**: a parent workflow's resolved tracker (e.g. orch `TRACKER`) passed with the invocation.
+3. **Inference fallback**: `parent_issue` (or the first target issue ID) starting with `issue-` → `github`; otherwise `linear`. For `github` with no repository value, resolve it in the caller worktree:
+   ```bash
+   gh repo view --json nameWithOwner --jq .nameWithOwner
+   ```
+
+Store the result as `TRACKER`, plus `[OWNER/REPO]` when `TRACKER=github`.
+
+**Mode constraint**: `project-order` and `project` modes audit Linear projects and are **Linear only**. If `TRACKER=github` and MODE is `project` or `project-order`, halt with: "Project audits are Linear-only; GitHub repositories have no project inventory in this workflow." Do not fall back to a partial audit.
+
+**GitHub mode must not run Linear commands**: when `TRACKER=github`, no `sync`, `session-status`, Linear cache read, or Linear mutation may run anywhere in this workflow. Linear installation/authentication is not a prerequisite for a GitHub-tracked audit.
+
+#### 1.2.2 Preflight — Linear (TRACKER=linear)
 
 ```bash
 .agents/skills/linear/scripts/linear.sh sync --reconcile
@@ -53,6 +74,22 @@ Set MODE and TARGET from input:
 ```
 
 Extract `project` field for fallback resolution. Store the issue-label inventory for all create/update preflights. Load project taxonomy/application rules from project configuration/docs (for example `vstack.toml` `[skill-instructions]`). Use issue labels only; never validate issue creates against project labels.
+
+#### 1.2.3 Preflight — GitHub (TRACKER=github)
+
+Load the live repository label inventory:
+
+```bash
+gh label list --repo [OWNER/REPO] --limit 200 --json name,description
+```
+
+Load the open-issue inventory for duplicate checks and backlog context:
+
+```bash
+gh issue list --repo [OWNER/REPO] --state open --limit 200 --json number,title,labels
+```
+
+There is no sync/session-status equivalent — the live API is authoritative, so a fresh query replaces cache freshness. Store the label inventory for all create/update preflights and load project taxonomy/application rules the same way as Linear mode. If the repository declares no label taxonomy, validate proposed labels against the live repository label list only — never invent labels, and never auto-create missing ones.
 
 ### 1.3 Route by Mode
 
@@ -68,6 +105,8 @@ Extract `project` field for fallback resolution. Store the issue-label inventory
 ---
 
 ## 2. Project Order Audit
+
+**Linear only** (project mode — § 1.2.1 halts GitHub sessions before this point).
 
 **Skip if** MODE = project OR MODE = issue.
 
@@ -185,6 +224,8 @@ Output: "Project order verified. No changes needed." → **END**
 
 ## 3. Resolve Target
 
+**Linear only** (project mode — § 1.2.1 halts GitHub sessions before this point).
+
 **Skip if** MODE = issue.
 
 ### 3.1 Resolve Project Target
@@ -248,7 +289,10 @@ Worktree: [WORKTREE_PATH] (empty if main repo)
 Follow workflow: .agents/skills/project-management/workflows/tpm-audit.md
 
 Arguments: --issues [FILE_PATH]
+Tracker: [TRACKER] [OWNER/REPO]
 </delegation_format>
+
+Omit `[OWNER/REPO]` when TRACKER=linear.
 
 TPM reads JSON file directly -- schema: [audit-issues-input.md](../schemas/audit-issues-input.md)
 
@@ -453,6 +497,8 @@ Action:
 
 **Reason column**: 2-3 sentences explaining why this action, what evidence supports it, and impact.
 
+**GitHub mode**: the Project column shows `—` (no project inventory); Structure/Relations columns show the body-link representation from § 7.2 (e.g. `Parent: #N`, `Blocked by: #N`).
+
 ---
 
 ## 6. Confirm Changes with User
@@ -513,26 +559,36 @@ Before any approved mutation that creates an issue or changes labels:
    - `agent_mismatch`: `replace_category` for taxonomy category `agent`.
    - `label_cooccurrence`: `add` the missing label/category label.
    - Any `set_labels[]`/metadata update: use its explicit mode (`add`, `replace_category`, or `replace_all`) and target category when present.
-2. **For existing issues**, fetch current labels and compute the full final set:
+2. **For existing issues**, fetch current labels and compute the full final set.
+
+   **Linear**:
    ```bash
    .agents/skills/linear/scripts/linear.sh cache issues get [ISSUE_ID]
    ```
+
+   **GitHub**:
+   ```bash
+   gh issue view [N] --repo [OWNER/REPO] --json labels
+   ```
+
    Preserve unrelated labels. Replace only labels in the target taxonomy category unless the action explicitly says `replace_all_labels: true`.
 3. **Validate final labels** with the inventory/taxonomy loaded in § 1.2 per [labels.md](../references/labels.md).
-4. **Halt before mutation** on unknown labels, parent/group labels, missing required categories, or exclusivity violations. Report the failing label set and ask the user. If a required taxonomy label is missing from Linear, request explicit authorization before creating it; never create labels automatically.
-5. **Use only validated final labels** in `issues create --labels` or `issues update --labels`.
+4. **Halt before mutation** on unknown labels, parent/group labels, missing required categories, or exclusivity violations. Report the failing label set and ask the user. If a required taxonomy label is missing from the tracker's live label inventory, request explicit authorization before creating it; never create labels automatically (GitHub: `gh label create` only after explicit authorization).
+5. **Use only validated final labels** — Linear: `issues create --labels` / `issues update --labels`; GitHub: `gh issue create --label` and the github skill's `label-add`/`label-remove` commands.
 
 Unknown labels, parent/group labels, missing required categories, or exclusivity violations halt before mutation.
 
 Do not run `issues update --labels "agent:new"` or any other partial label replacement unless the validated final label set really contains only that label.
 
-For each approved change:
+For each approved change that routes through a workflow-actions reference (Linear routes only -- GitHub routes carry their commands inline in § 7.2):
 
-1. **Read the referenced section** from the issue tracker CLI's workflow-actions patterns.
+1. **Read the referenced section** from the Linear CLI's workflow-actions patterns.
 
 2. **Execute the pattern** exactly as documented.
 
 ### 7.1 Execute Project Actions
+
+**Linear only** (project mode -- § 1.2.1 halts GitHub sessions before this point).
 
 **Skip if** MODE = issue.
 
@@ -558,6 +614,10 @@ For each approved change:
 
 Process `create` actions first -- use created IDs to resolve `#N` references in subsequent actions.
 
+Action semantics are tracker-agnostic; the mutation route is selected by `TRACKER` from § 1.2.1. Never mix routes within one audit.
+
+**Linear route (TRACKER=linear)**:
+
 | Action | Reference |
 |--------|-----------|
 | create | See **Create template** below -- use `--parent` per `hierarchy` field. Child must be in same project as parent; if not, create standalone with `related`. If `hierarchy.parent` is null and action is `make_child`, resolve to `parent_issue` from audit input file. For `hierarchy_contract` items (§ 4.2 step 3) the standalone fallback is not permitted: create the child in the contract parent's project -- never downgrade to standalone. |
@@ -567,7 +627,20 @@ Process `create` actions first -- use created IDs to resolve `#N` references in 
 | supersede, combine | workflow-actions § Cancel / Merge / Combine |
 | cancel | workflow-actions § Cancel Obsolete Issues |
 
-**Create template**: Use project-level templates issue-description-template for the description. For parent/bundle issues, use project-level templates parent-issue-template. Write the description body to a file and pass `--description-file` (never inline strings or a heredoc). Every create command must include `--labels "[VALIDATED_FINAL_LABELS]"` from § 7.0.
+**GitHub route (TRACKER=github)** -- issue mutations use `gh issue` against `[OWNER/REPO]` from § 1.2.1; label mutations on existing issues go through the github skill's `label-add`/`label-remove` commands (its bot-token conventions apply):
+
+| Action | Execution |
+|--------|-----------|
+| create | Write the description (see **Create template** below) to a tmp file, then run `gh issue create --repo [OWNER/REPO] --title "[TITLE]" --body-file [BODY_FILE] --label "[VALIDATED_FINAL_LABELS]"`. Represent hierarchy per **GitHub hierarchy & relations** below. |
+| skip | No action required |
+| valid | No action required |
+| expand, update | Body: fetch with `gh issue view [N] --repo [OWNER/REPO] --json body --jq .body`, apply edits in a tmp file, then run `gh issue edit [N] --repo [OWNER/REPO] --body-file [BODY_FILE]`. Title: `gh issue edit [N] --repo [OWNER/REPO] --title "[TITLE]"`. Labels: `.agents/skills/github/scripts/github.sh label-add [N] "[LABEL]" --issue` / `.agents/skills/github/scripts/github.sh label-remove [N] "[LABEL]" --issue`. |
+| supersede, combine | Comment then close -- see **Superseded issues -- GitHub** below |
+| cancel | `gh issue comment [N] --repo [OWNER/REPO] --body "[CANCEL_REASON]"`, then `gh issue close [N] --repo [OWNER/REPO] --reason "not planned"` |
+
+**GitHub hierarchy & relations (explicit degradation)**: GitHub items in this workflow have no Linear parent/child bundle or typed relation objects. Represent structure in issue bodies instead: `hierarchy.action: make_child` → a `Parent: #[PARENT_NUMBER]` line at the top of the child body plus a `gh issue comment` on the parent noting the new sub-item; `blocks`/`blocked_by`/`related` → `Blocks: #N` / `Blocked by: #N` / `Related: #N` body lines (added to existing issues via the body-edit route above). These are documented representations, not enforced tracker semantics -- cascade-cancel, cross-project constraints, and bundle queries do not apply. Do not silently drop an approved hierarchy or relation action: either record its body representation or report it as not executed and why.
+
+**Create template**: Use project-level templates issue-description-template for the description. For parent/bundle issues, use project-level templates parent-issue-template. Write the description body to a file and pass it by file (Linear: `--description-file`; GitHub: `--body-file`) -- never inline strings or a heredoc. Every create command must include the validated final labels from § 7.0 (Linear: `--labels "[VALIDATED_FINAL_LABELS]"`; GitHub: `--label "[VALIDATED_FINAL_LABELS]"`).
 
 **Analyzed mode**: When MODE = analyzed, issue creation fields (description, recommendation, location, estimate, priority, agent_label, labels, source_path) come from `issues[].create_fields`. `create_fields.labels[]` is authoritative and required for create; `agent_label` is derived/backward-compatible only. Use `source_path` for `[ORIGIN_CONTEXT]` in issue-description-template. For bundle parents (`create_fields.is_bundle_parent: true`), use parent-issue-template. Top-level `parent_issue` and `research_ref` available for hierarchy fallback and description refs.
 
@@ -575,12 +648,23 @@ Process `create` actions first -- use created IDs to resolve `#N` references in 
 
 **Superseded issues**: After creating issues (which resolves `#N` → `[ISSUE_ID]`), for each approved supersession from `supersedes[]`:
 
+**Superseded issues -- Linear**:
+
 1. **Fetch children**: `.agents/skills/linear/scripts/linear.sh cache issues children [SUPERSEDED_ID]`
 2. **Detach** any children with independent scope (not covered by replacement): `.agents/skills/linear/scripts/linear.sh issues update [CHILD_ID] --remove-parent`
 3. **Comment** on superseded issue: `"Superseded by [ISSUE_ID] (DXXX). Scope fully covered."`
 4. **Cancel**: `.agents/skills/linear/scripts/linear.sh issues update [SUPERSEDED_ID] --state "Canceled"` -- remaining children cascade-canceled by issue tracker
 
+**Superseded issues -- GitHub** (explicit degradation -- no bundle model, no cascade):
+
+1. **Comment**: `gh issue comment [N] --repo [OWNER/REPO] --body "Superseded by #[NEW_NUMBER]. Scope fully covered."`
+2. **Close**: `gh issue close [N] --repo [OWNER/REPO] --reason "not planned"`
+
+There is no child detach/cascade step. If the superseded issue body lists sub-items (`Parent: #N` back-references or a task list), enumerate them in the close comment so scope is not silently lost.
+
 #### 7.2.1 Position in Active Project
+
+**Linear only.** Skip if `TRACKER=github` -- GitHub repositories have no project state or Todo sort-order model in this workflow. Record the skip as `positioning: n/a (github)` in the § 8 summary; do not silently omit it.
 
 After each `create` action, determine whether the new issue should be moved to Todo with a sort position.
 
@@ -620,9 +704,16 @@ After each `create` action, determine whether the new issue should be moved to T
 
 For each approved `research_refs` issue:
 
-1. **Get current description**:
+1. **Get current description**.
+
+   **Linear**:
    ```bash
    .agents/skills/linear/scripts/linear.sh cache issues get [ISSUE_ID] | jq -r '.description'
+   ```
+
+   **GitHub**:
+   ```bash
+   gh issue view [N] --repo [OWNER/REPO] --json body --jq .body
    ```
 
 2. **Check existing**: If `[RESEARCH_REF]` path already exists, skip.
@@ -634,17 +725,23 @@ For each approved `research_refs` issue:
 4. **Add Decision** if `decision_ref` present AND not already in description:
    - Add `**Decision [DECISION_ID]**: [project decision documents]/[DECISION_ID]-[DESCRIPTOR].md` after Research block
 
-5. **Propagate to children**:
+   Apply the updated description -- Linear: `issues update [ISSUE_ID] --description-file [BODY_FILE]`; GitHub: `gh issue edit [N] --repo [OWNER/REPO] --body-file [BODY_FILE]`.
+
+5. **Propagate to children**.
+
+   **Linear**:
    ```bash
    .agents/skills/linear/scripts/linear.sh cache issues children [ISSUE_ID] --recursive --format=safe | jq -r '.[].id'
    ```
    For each child: repeat steps 1-4. Skip if reference already present.
 
+   **GitHub** (explicit degradation -- no recursive child query): propagate only to issues created in this audit whose body carries `Parent: #[N]` for the target issue; repeat steps 1-4 for each. Report any deeper propagation as not performed.
+
 ### 7.4 Post-Cancellation Cleanup
 
 For each issue canceled during § 7.1 or § 7.2 (superseded, obsolete, or duplicate):
 
-**Relations**:
+**Relations -- Linear**:
 
 1. **Fetch relations**: `.agents/skills/linear/scripts/linear.sh issues list-relations [CANCELED_ID]`
 2. **Remove `blocks` relations** to non-canceled issues:
@@ -655,20 +752,27 @@ For each issue canceled during § 7.1 or § 7.2 (superseded, obsolete, or duplic
 
 `related` relations are preserved as historical record.
 
+**Relations -- GitHub**: there are no tracked relation objects to remove. Scan the § 1.2.3 open-issue inventory plus issues touched in this audit for body lines referencing the closed number (`Blocked by: #[CLOSED_NUMBER]`, `Blocks: #[CLOSED_NUMBER]`); update those bodies via the § 7.2 body-edit route, or note the stale reference in a comment on the affected issue. Then run the same "Add blocker?" presentation as Linear mode for issues whose only blocker reference was the closed number.
+
 **Stale references** (decision-eliminated or superseded cancellations only):
 
 1. **Identify old pattern**: From `obsolete[].evidence.eliminated_pattern` or `supersedes[].reason`
-2. **Check parent and siblings**:
+2. **Check related issues**.
+
+   **Linear** (parent and siblings):
    ```bash
    .agents/skills/linear/scripts/linear.sh cache issues get [PARENT_ID]
    .agents/skills/linear/scripts/linear.sh cache issues children [PARENT_ID]
    ```
+
+   **GitHub**: check the audited item set and the § 1.2.3 open-issue inventory titles (no cache or children queries exist).
 3. **Flag matches**: Non-canceled issues where title or description references the old pattern
 4. **Present**: "Update stale references? #N: [ISSUE_ID]: [OLD] → [NEW]"
 5. **Execute approved**:
-   - Title: `.agents/skills/linear/scripts/linear.sh issues update [ID] --title "[UPDATED]"`
-   - Description: `.agents/skills/linear/scripts/linear.sh issues update [ID] --description "[UPDATED]"`
-   - Comment: `"Updated: [OLD] → [NEW] per [DECISION_ID]"`
+   - Linear title: `.agents/skills/linear/scripts/linear.sh issues update [ID] --title "[UPDATED]"`
+   - Linear description: `.agents/skills/linear/scripts/linear.sh issues update [ID] --description "[UPDATED]"`
+   - GitHub: `gh issue edit [N] --repo [OWNER/REPO] --title "[UPDATED]"` and the § 7.2 body-edit route for descriptions
+   - Comment (either tracker): `"Updated: [OLD] → [NEW] per [DECISION_ID]"`
 
 ### 7.5 Relation Direction Reference
 
@@ -687,6 +791,8 @@ For each issue canceled during § 7.1 or § 7.2 (superseded, obsolete, or duplic
 
 ### ✅ AUDIT COMPLETE
 
+**Tracker**: [linear|github ([OWNER/REPO])]
+
 **Issues**:
 - ✨ Created: N ([ISSUE_ID], ...)
 - 🔄 Modified: N (expand/update/supersede/combine)
@@ -697,8 +803,11 @@ For each issue canceled during § 7.1 or § 7.2 (superseded, obsolete, or duplic
 - 📚 Research refs: N
 - 👾 Gap issues created: N
 - ⏭️ Skipped: N
+- ⚠️ Degraded (github): [positioning n/a, hierarchy/relations as body links | —]
 
 </output_format>
+
+The Degraded line appears only for `TRACKER=github`: list every audit obligation executed through a documented degradation (§ 7.2 hierarchy/relations representation, § 7.2.1 positioning, § 7.3 child propagation, § 7.4 relation cleanup) so nothing is silently skipped.
 
 ---
 

--- a/skills/project-management/workflows/tpm-audit.md
+++ b/skills/project-management/workflows/tpm-audit.md
@@ -26,9 +26,10 @@ File contains all context — read with Read tool. Optional fields for research-
 
 Parse arguments → set `MODE` (project | issues).
 
-**PROJECT mode**: Store `WORKTREE` from delegation prompt (default: `.`).
+**PROJECT mode**: Store `WORKTREE` from delegation prompt (default: `.`). PROJECT mode audits Linear projects and is Linear-only (`TRACKER=linear`).
 
 **ISSUES mode**: Read JSON file with Read tool, extract:
+- `TRACKER` (and `REPOSITORY` for github) from the delegation prompt `Tracker:` line or the file's `tracker` field; when absent, infer: `parent_issue` starting with `issue-` → `github`, otherwise `linear`
 - `WORKTREE` from `worktree` field
 - `PARENT_ISSUE` from `parent_issue` field
 - `SOURCE` from `source` field
@@ -41,17 +42,25 @@ Parse arguments → set `MODE` (project | issues).
 
 ### 1.2 Load Issue Label Policy
 
-Load live issue-label inventory and project taxonomy/application rules before validating agent/domain/workflow labels or recommending label changes:
+Load live issue-label inventory and project taxonomy/application rules before validating agent/domain/workflow labels or recommending label changes.
 
+**Linear (TRACKER=linear)**:
 ```bash
 .agents/skills/linear/scripts/linear.sh cache labels list --format=safe
 ```
 
-If the label cache is missing/stale, report that the caller must run `sync --reconcile` before mutation. TPM does not mutate labels, but all `agent_mismatch`, `label_cooccurrence`, `recommended_issue.labels[]`, and `create_fields.labels[]` recommendations must be expressible against live issue labels and project taxonomy. Use issue labels only; project labels are separate.
+If the label cache is missing/stale, report that the caller must run `sync --reconcile` before mutation.
+
+**GitHub (TRACKER=github)** — live repository labels; no cache or sync involved:
+```bash
+gh label list --repo [REPOSITORY] --limit 200 --json name,description
+```
+
+TPM does not mutate labels, but all `agent_mismatch`, `label_cooccurrence`, `recommended_issue.labels[]`, and `create_fields.labels[]` recommendations must be expressible against the tracker's live issue labels and project taxonomy. Use issue labels only; project labels are separate.
 
 ### 1.3 Fetch All Projects
 
-Query ALL project states:
+**Linear (TRACKER=linear)** — query ALL project states:
 ```bash
 .agents/skills/linear/scripts/linear.sh cache projects list --state started
 .agents/skills/linear/scripts/linear.sh cache projects list --state planned
@@ -62,6 +71,8 @@ Query ALL project states:
 
 Store project IDs and metadata for cross-project analysis.
 
+**GitHub (TRACKER=github)** — explicit degradation: no project inventory exists in this workflow. Record an empty project set. Project-placement fields (`recommended_project`, `wrong_project`, project moves) must be `null`/omitted with reason "github: no project inventory" — never invent a placement. Duplicate/fit checks scope to the repository backlog from § 1.5 instead.
+
 ### 1.4 Fetch Input Issues
 
 **PROJECT**: Fetch all issues in target project (all states):
@@ -69,17 +80,25 @@ Store project IDs and metadata for cross-project analysis.
 .agents/skills/linear/scripts/linear.sh cache issues list --project "[PROJECT]" --state "Backlog,Todo,In Progress,In Review,Done" --max
 ```
 
-**ISSUES**: For existing issues, fetch each:
+**ISSUES**: For existing issues, fetch each.
+
+Linear:
 ```bash
 .agents/skills/linear/scripts/linear.sh cache issues get [ISSUE_ID]
 ```
 Use the returned issue JSON for relation analysis. The supported cache payload includes `blocks`, `blocked_by`, and `related`; do not call a separate relation cache subcommand.
 
+GitHub:
+```bash
+gh issue view [N] --repo [REPOSITORY] --json number,title,body,labels,state,url
+```
+There is no relation payload — relation analysis uses body-link references (`Blocks: #N`, `Blocked by: #N`, `Related: #N`, `Parent: #N`).
+
 For proposed issues, use provided fields directly.
 
 ### 1.5 Fetch Comparison Set
 
-Fetch issues from ALL projects (from 1.3) for duplicate/obsolete/fit checking:
+**Linear (TRACKER=linear)** — fetch issues from ALL projects (from 1.3) for duplicate/obsolete/fit checking:
 ```bash
 .agents/skills/linear/scripts/linear.sh cache issues list --project "[PROJECT_NAME]" --state "Backlog,Todo,In Progress,In Review,Done" --max
 ```
@@ -88,7 +107,14 @@ Run for each project. Store all issues for comparison in 6.
 
 **Why all projects**: Cross-project duplicate detection, obsolete checking against completed work, and project fit evaluation all require visibility into the full backlog.
 
+**GitHub (TRACKER=github)** — fetch the repository backlog, open and closed, for the same duplicate/obsolete checks:
+```bash
+gh issue list --repo [REPOSITORY] --state all --limit 200 --json number,title,state,labels
+```
+
 ### 1.6 Extract Project Definitions
+
+**GitHub (TRACKER=github)**: skip — there are no project definitions; treat the repository as the single scope for fit evaluation.
 
 For EACH project from 1.3, extract from name + description + content:
 


### PR DESCRIPTION
Closes #655. audit-issues unconditionally initialized Linear (sync/session/labels) and routed every section-7 mutation through the Linear CLI, so a GitHub-tracker orch session (review-pr § 9 `category: issue` suggestions) could not complete the managed audit path.

Design: tracker context resolves once (§ 1.2.1; input-file `tracker` block → caller-resolved orch TRACKER → inference from `issue-N`), and every preflight/fetch/mutation branches on it. GitHub mode: live-API inventory (`gh label list`, `gh issue list`), section-7 routes through gh + github.sh label commands with bot-token conventions, and a hard rule that no Linear command may run. Linear-only concepts degrade EXPLICITLY, never silently: project/project-order modes halt for GitHub; hierarchy/relations become body-link representations (`Parent: #N`, `Blocked by: #N`); § 8 summary lists every degraded obligation under `Degraded (github):`. Orch callers (review-pr § 9, review-pr-comments § 6.2) now pass the tracker block; schemas document it.

Validation: new tracker-routing-contract doc test (sed-extracted GitHub sections proven linear.sh-free, routing/degradation phrases pinned, caller passthrough asserted); full project-management suite green; dev suite green (incl. the GitHub/Linear cache-separation guard); orch run-all all files green. Existing test-asserted contract strings preserved.

https://claude.ai/code/session_016s6ZSLTTRft6fH29wHn1TN