### PR TITLE
docs(#668): guard-safe backtick search shapes for reviewers + passthrough pins

### DIFF
--- a/pi-extensions/pi-hooks/tests/bash-guards.test.ts
+++ b/pi-extensions/pi-hooks/tests/bash-guards.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
 
-import { gitCommitTargets, nearestCargoManifestDir, projectGitCommitCwd, resolveProjectGitCommit } from "../extensions/bash-guards.ts";
+import { gitCommitTargets, isBareCd, nearestCargoManifestDir, projectGitCommitCwd, resolveProjectGitCommit } from "../extensions/bash-guards.ts";
 
 function runGit(args: string[], cwd: string): void {
 	const result = spawnSync("git", args, { cwd, encoding: "utf8" });
@@ -377,5 +377,21 @@ describe("nearestCargoManifestDir", () => {
 		} finally {
 			rmSync(root, { recursive: true, force: true });
 		}
+	});
+});
+
+describe("bare cd detection", () => {
+	test("matches a bare cd but not a scoped or chained one", () => {
+		expect(isBareCd("cd /tmp")).toBe(true);
+		expect(isBareCd("  cd sub/dir")).toBe(true);
+		expect(isBareCd("(cd /tmp && ls)")).toBe(false);
+		expect(isBareCd("cd /tmp && ls")).toBe(false);
+	});
+
+	test("read-only searches with backtick-bearing patterns are never bare cd (vstack#668)", () => {
+		expect(isBareCd('rg -n "`vstack refresh`" skills/')).toBe(false);
+		expect(isBareCd("rg -n '`vstack refresh`' skills/")).toBe(false);
+		expect(isBareCd("rg -n '\\x60vstack refresh\\x60' skills/")).toBe(false);
+		expect(isBareCd("rg -n '[\\x60]jq' skills/")).toBe(false);
 	});
 });

--- a/pi-extensions/pi-hooks/tests/hooks.test.ts
+++ b/pi-extensions/pi-hooks/tests/hooks.test.ts
@@ -397,3 +397,29 @@ describe("pi-hooks pre-commit tool_call", () => {
 		});
 	});
 });
+
+describe("pi-hooks bash guard passthrough", () => {
+	test("passes reviewer searches whose patterns contain backticks (vstack#668)", async () => {
+		const project = initCleanRustRepo("pi-hooks-project-");
+		try {
+			const handler = installToolCallHandler();
+			expect(await handler({ toolName: "bash", input: { command: 'rg -n "`vstack refresh`" skills/' } }, { cwd: project })).toBeUndefined();
+			expect(await handler({ toolName: "bash", input: { command: "rg -n '\\x60vstack refresh\\x60' skills/" } }, { cwd: project })).toBeUndefined();
+		} finally {
+			rmSync(project, { recursive: true, force: true });
+		}
+	});
+
+	test("still blocks a bare cd", async () => {
+		const project = initCleanRustRepo("pi-hooks-project-");
+		try {
+			const handler = installToolCallHandler();
+			expect(await handler({ toolName: "bash", input: { command: "cd /tmp" } }, { cwd: project })).toEqual({
+				block: true,
+				reason: "Bare 'cd' changes working directory permanently across tool calls. Use a subshell instead: (cd /path && command)",
+			});
+		} finally {
+			rmSync(project, { recursive: true, force: true });
+		}
+	});
+});

--- a/skills/reviewer/SKILL.md
+++ b/skills/reviewer/SKILL.md
@@ -101,6 +101,12 @@ Codex classifies every one of these shapes as approval-required even when the un
 
 Validate by exit status, not by redirection. Run the predicate as a bare command and rely on its exit code; the parsed output printed to stdout is harmless, so do NOT suppress it. To check a JSON artifact, run `jq -e <filter> <path>` — its exit status IS the check. For example, `jq -e . tmp/review-x.json` ✓ is correct, whereas `jq -e . tmp/review-x.json >/dev/null` ✗ is rejected under Codex `approval=never` even though it only reads the file.
 
+Searching backtick-bearing text (e.g. Markdown inline code) must not put a literal backtick in the command: command-shape guards classify any backtick as command substitution and reject the command before it runs, even for a read-only search — inside double quotes the substitution would be real. Write the pattern with the regex hex escape `\x60` in single quotes instead; it matches a backtick without one appearing in the command (inside a bracket expression, use `[\x60]`). Fixed-string mode (`rg -F`) has no escapes and would need a literal backtick, so use regex mode:
+
+```bash
+rg -n '\x60vstack refresh\x60' skills/
+```
+
 Batch independent checks as separate tool calls (or parallel independent execs) instead of shell composition.
 
 ## Configuration

--- a/skills/reviewer/tests/backtick-search-guidance.test.sh
+++ b/skills/reviewer/tests/backtick-search-guidance.test.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# Regression test for the reviewer skill's backtick-search guidance (vstack#668).
+# During an orch review cycle, reviewer-doc ran a read-only rg search whose
+# pattern contained a literal backtick; the harness command-shape guard rejected
+# the command before execution — a backtick anywhere in a command reads as
+# command-substitution shape, and inside double quotes the substitution would be
+# real. The rejecting guard is harness-side, not a vstack hook, so the fix is
+# guidance: SKILL.md § Harness-Safe Shell prescribes the `\x60` hex-escape
+# pattern shape, which matches a backtick without one appearing in the command.
+#
+# Three parts:
+#   a. Doc — SKILL.md must prescribe the `\x60` shape (example line and the
+#      `[\x60]` bracket-expression form), and no fenced ```bash / ```sh block in
+#      the reviewer docs may contain a literal backtick byte. This check is
+#      deliberately byte-level, unlike the quote-stripping harness-safe-shell
+#      lint: coarse shape classifiers flag the byte regardless of quoting, so
+#      prescribed commands must not contain one at all.
+#   b. Behavioral — the prescribed '\x60...\x60' pattern must match
+#      backtick-bearing text exactly like the literal-backtick pattern would,
+#      proving it is a drop-in replacement with zero result drift.
+#   c. Hook passthrough — vstack's own PreToolUse:Bash hooks must pass both the
+#      incident shape and the prescribed shape (exit 0); they were empirically
+#      cleared as the rejecting guard and must never become it. The teeth stay:
+#      block-bare-cd still rejects a genuine bare `cd` with exit 2.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
+TMP_ROOT="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+PASS=0
+FAIL=0
+
+pass() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+fail() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
+
+# scan_backtick_bytes <file>
+# Emits "file:lineno: line" for every literal backtick byte inside a fenced
+# ```bash / ```sh block. Prose and inline code are excluded (the guidance text
+# itself necessarily mentions backticks), but command blocks must be clean even
+# inside quotes — see the byte-level rationale in the header.
+scan_backtick_bytes() {
+  awk -v f="$1" '
+    /^[[:space:]]*```/ {
+      if (infence == 0) {
+        infence = 1
+        lang = $0
+        sub(/^[[:space:]]*```/, "", lang)
+        gsub(/[[:space:]]/, "", lang)
+        iscmd = (lang == "bash" || lang == "sh") ? 1 : 0
+      } else {
+        infence = 0
+        iscmd = 0
+      }
+      next
+    }
+    (infence && iscmd && index($0, "`") > 0) { printf "%s:%d: %s\n", f, NR, $0 }
+  ' "$1"
+}
+
+echo "=== reviewer backtick-search guidance ==="
+
+# --- Part a: doc -----------------------------------------------------------
+
+# a.1 — the prescribed example command must be present verbatim.
+if grep -qF "rg -n '\\x60vstack refresh\\x60' skills/" "$SKILL_DIR/SKILL.md"; then
+  pass "SKILL.md prescribes the \\x60 hex-escape example command"
+else
+  fail "SKILL.md is missing the prescribed \\x60 example command"
+fi
+
+# a.2 — the bracket-expression form must be documented.
+if grep -qF '[\x60]' "$SKILL_DIR/SKILL.md"; then
+  pass "SKILL.md documents the [\\x60] bracket-expression form"
+else
+  fail "SKILL.md is missing the [\\x60] bracket-expression form"
+fi
+
+# a.3 — no fenced command block in the reviewer docs carries a backtick byte.
+DOCS=("$SKILL_DIR/SKILL.md" "$SKILL_DIR"/workflows/*.md)
+offenders=""
+for doc in "${DOCS[@]}"; do
+  out="$(scan_backtick_bytes "$doc")"
+  [ -n "$out" ] && offenders="$offenders$out"$'\n'
+done
+if [ -z "$offenders" ]; then
+  pass "reviewer command blocks contain no literal backtick bytes"
+else
+  fail "literal backtick bytes found in reviewer command blocks:"
+  printf '%s' "$offenders" | sed 's/^/          /'
+fi
+
+# a.4 — the byte scan has teeth: an injected backtick in a fenced bash block
+# must be flagged even when single-quoted (quoting does not clear the byte).
+SCRATCH="$TMP_ROOT/inject-backtick.md"
+cp "$SKILL_DIR/SKILL.md" "$SCRATCH"
+printf '\n```bash\nrg -n '\''`vstack refresh`'\'' skills/\n```\n' >> "$SCRATCH"
+if [ -n "$(scan_backtick_bytes "$SCRATCH")" ]; then
+  pass "byte scan flags an injected single-quoted backtick in a command block"
+else
+  fail "byte scan MISSED an injected backtick (no teeth)"
+fi
+
+# --- Part b: behavioral ----------------------------------------------------
+
+if command -v rg > /dev/null 2>&1; then
+  FIXTURE="$TMP_ROOT/fixture.md"
+  printf 'Run `vstack refresh` after install.\nNo inline code on this line.\n' > "$FIXTURE"
+
+  ESCAPED_PATTERN='\x60vstack refresh\x60'
+  LITERAL_PATTERN='`vstack refresh`'
+  set +e
+  escaped_out="$(rg -n "$ESCAPED_PATTERN" "$FIXTURE")"
+  escaped_code=$?
+  literal_out="$(rg -n "$LITERAL_PATTERN" "$FIXTURE")"
+  literal_code=$?
+  class_out="$(rg -n '[\x60]' "$FIXTURE")"
+  class_code=$?
+  set -e
+
+  if [ "$escaped_code" -eq 0 ] && [ "${escaped_out%%:*}" = "1" ]; then
+    pass "'\\x60...\\x60' pattern matches the backtick-bearing line"
+  else
+    fail "'\\x60...\\x60' pattern did not match (code=$escaped_code, out='$escaped_out')"
+  fi
+
+  if [ "$literal_code" -eq 0 ] && [ "$escaped_out" = "$literal_out" ]; then
+    pass "escaped and literal-backtick patterns return identical matches (drop-in replacement)"
+  else
+    fail "escaped/literal pattern drift (escaped='$escaped_out', literal='$literal_out')"
+  fi
+
+  if [ "$class_code" -eq 0 ] && [ "${class_out%%:*}" = "1" ]; then
+    pass "'[\\x60]' bracket expression matches the backtick-bearing line only"
+  else
+    fail "'[\\x60]' bracket expression did not match line 1 (code=$class_code, out='$class_out')"
+  fi
+else
+  pass "rg not installed — behavioral checks skipped"
+fi
+
+# --- Part c: hook passthrough ----------------------------------------------
+
+HOOKS_DIR="$(cd "$SKILL_DIR/../.." && pwd)/hooks"
+if [ -d "$HOOKS_DIR" ] && command -v jq > /dev/null 2>&1; then
+  # run_hook <hook> <command> → exit code of the hook fed a PreToolUse payload.
+  run_hook() {
+    local payload
+    payload=$(jq -cn --arg c "$2" '{tool_name:"Bash",tool_input:{command:$c}}')
+    printf '%s' "$payload" | bash "$HOOKS_DIR/$1" > /dev/null 2>&1
+  }
+
+  INCIDENT_CMD='rg -n "`vstack refresh`" skills/'
+  SAFE_CMD="rg -n '\\x60vstack refresh\\x60' skills/"
+
+  for hook in block-bare-cd.sh pre-commit-check.sh; do
+    for cmd in "$INCIDENT_CMD" "$SAFE_CMD"; do
+      set +e
+      run_hook "$hook" "$cmd"
+      code=$?
+      set -e
+      if [ "$code" -eq 0 ]; then
+        pass "$hook passes: $cmd"
+      else
+        fail "$hook rejected a read-only search (exit=$code): $cmd"
+      fi
+    done
+  done
+
+  set +e
+  bare_err="$(jq -cn --arg c 'cd /tmp' '{tool_name:"Bash",tool_input:{command:$c}}' | bash "$HOOKS_DIR/block-bare-cd.sh" 2>&1)"
+  bare_code=$?
+  set -e
+  if [ "$bare_code" -eq 2 ] && printf '%s' "$bare_err" | grep -q "Bare 'cd'"; then
+    pass "block-bare-cd still rejects a bare cd with exit 2 (teeth unchanged)"
+  else
+    fail "block-bare-cd teeth check failed (code=$bare_code, err='$bare_err')"
+  fi
+else
+  pass "hooks dir or jq unavailable — hook passthrough skipped (standalone skill install)"
+fi
+
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Closes #668. A reviewer's read-only `rg` pattern with a literal backtick was rejected pre-execution. Investigation confirmed the rejecting guard is the HARNESS's command classifier, not a vstack hook — all four vstack hooks (and the pi-hooks parity port) pass every backtick variant; a double-quoted backtick genuinely is live command substitution, so the harness flag is legitimate.

vstack-side fix is therefore guidance + regression pins:
- **reviewer SKILL.md § Harness-Safe Shell**: "searching backtick-bearing text" — use single-quoted patterns with `\x60` in place of each backtick byte (e.g. `rg -n '\x60vstack refresh\x60' skills/`; `[\x60]` in bracket expressions); `rg -F` explicitly called out as unusable (no escapes in fixed-string mode). Zero backtick bytes in the command, so even coarse byte-level classifiers pass it.
- **Regression pins**: new reviewer test (12 asserts) proves the \x60 pattern returns matches byte-identical to the literal-backtick pattern, pins both PreToolUse hooks' passthrough for the incident + prescribed shapes, and keeps bare-cd teeth; pi-hooks gains 4 mirror tests (37/37 bun tests green).

No hook behavior changed (nothing to change — parity rule satisfied by same-commit mirror tests).

https://claude.ai/code/session_016s6ZSLTTRft6fH29wHn1TN