### PR TITLE
feat(#676): --all-projects batch cache enumeration for issue audits

### DIFF
--- a/skills/linear/SKILL.md
+++ b/skills/linear/SKILL.md
@@ -75,6 +75,7 @@ Reads go through `cache`. Writes go through live commands (auto-update cache via
 ```bash
 # READS → cache (fast, no API calls)
 linear.sh cache issues list --project "Phase 2" --state "Todo,In Progress"
+linear.sh cache issues list --all-projects --state "Backlog,Todo" --max --format=compact
 linear.sh cache issues get ABC-100 --with-bundle
 
 # WRITES → live (hit API, auto-update cache)
@@ -85,6 +86,8 @@ linear.sh issues update ABC-100 --state "Done"
 linear.sh sync --reconcile      # Incremental + reconcile archived
 linear.sh sync --full           # Full re-sync
 ```
+
+`cache issues list --all-projects` enumerates every project in ONE command — each row carries its `project` name, and other filters (`--state`, `--max`, `--format`) compose. Use it for cross-project comparison sets instead of looping `--project` per project; restricted harness approval policies reject loop-shaped commands. Mutually exclusive with `--project`.
 
 ## Output Formats
 

--- a/skills/linear/scripts/commands/cache-query.sh
+++ b/skills/linear/scripts/commands/cache-query.sh
@@ -22,9 +22,14 @@ Linear Cache Query - Read from local cache
 Usage: cache-query.sh <resource> <action> [options]
 
 Issues:
-  issues list [--project X] [--state Y] [--label Z] [--cycle N|UUID|current|previous|next]
+  issues list [--project X | --all-projects] [--state Y] [--label Z]
+              [--cycle N|UUID|current|previous|next]
               [--updated-since Nd] [--search REGEX] [--max] [--include-archived]
               [--format=safe|compact|ids|table]
+              --all-projects enumerates every project in ONE command (each row
+              carries its project name; rows without a project carry ""). Use it
+              instead of looping per project — restricted harnesses reject loop
+              shapes. Mutually exclusive with --project.
   issues get <ID> [--with-bundle] [--format=safe|compact|raw]
   issues children <ID> [--recursive] [--pending] [--format=safe|ids]
   issues list-relations <ID>
@@ -57,6 +62,7 @@ All output uses the same formatters as live API commands.
 
 Examples:
   cache-query.sh issues list --project "Phase 2" --format=compact
+  cache-query.sh issues list --all-projects --state "Backlog,Todo" --max --format=compact
   cache-query.sh issues get PROJ-100 --with-bundle
   cache-query.sh projects list --state started
   cache-query.sh status
@@ -70,6 +76,7 @@ EOF
 cache_list_issues() {
     local project="" state="" label="" updated_since="" search="" cycle=""
     local include_archived="false" paginate_all="false" limit="75"
+    local all_projects="false"
     FORMAT="${DEFAULT_FORMAT}"
 
     while [[ $# -gt 0 ]]; do
@@ -82,6 +89,13 @@ cache_list_issues() {
             project="$2"
             shift 2
             ;; # treated same — filter by project.id or project.name
+        --all-projects)
+            # Explicit batch enumeration across every project in one command.
+            # Harness approval classifiers reject per-project shell loops, so
+            # audit workflows load the full comparison set through this flag.
+            all_projects="true"
+            shift
+            ;;
         --state | --status)
             state="$2"
             shift 2
@@ -139,6 +153,11 @@ cache_list_issues() {
         *) shift ;;
         esac
     done
+
+    if [[ "$all_projects" == "true" && -n "$project" ]]; then
+        echo '{"error": "--all-projects cannot be combined with --project/--project-id: it already enumerates every project"}' >&2
+        return 1
+    fi
 
     # Build jq filter chain
     local jq_filter='.'

--- a/skills/linear/tests/cache-issues-all-projects.test.sh
+++ b/skills/linear/tests/cache-issues-all-projects.test.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Batch all-project cache enumeration (vstack #676).
+#
+# Audit workflows load a cross-project comparison set from the cache. The
+# natural per-project shell loop is rejected by restricted harness approval
+# classifiers (loop shape, not access), so `cache issues list` grew an explicit
+# `--all-projects` flag: ONE command that enumerates every project, each row
+# carrying its `project` name, composable with the existing filters and
+# mutually exclusive with `--project`. This test locks in:
+#   A. --all-projects returns rows from multiple seeded projects, each tagged
+#      with its project name (rows without a project carry "").
+#   B. --state composes with --all-projects.
+#   C. --all-projects + --project fails loudly (nonzero exit, clear error).
+#   D. Per-project call output is unchanged, and the all-projects row shape is
+#      identical to the per-project row shape (superset-compatible consumers).
+#
+# Fully offline — pure cache read, no curl needed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+mkdir -p "$TMP_ROOT/.agents/skills" "$TMP_ROOT/.cache/linear"
+cp -R "$SKILL_DIR" "$TMP_ROOT/.agents/skills/linear"
+LINEAR="$TMP_ROOT/.agents/skills/linear/scripts/linear.sh"
+
+cat >"$TMP_ROOT/.cache/linear/meta.json" <<'JSON'
+{"synced_at":"2026-07-17T00:00:00+00:00"}
+JSON
+
+# One cached issue record with an explicit project assignment.
+# Args: identifier state_name state_type project_name (empty = no project)
+issue_record() {
+  local id="$1" sname="$2" stype="$3" pname="$4" project_json="null"
+  if [[ -n "$pname" ]]; then
+    project_json="{\"id\":\"proj-$pname\",\"name\":\"$pname\"}"
+  fi
+  printf '{"id":"uuid-%s","identifier":"%s","title":"%s title","description":null,"state":{"name":"%s","type":"%s"},"assignee":null,"labels":{"nodes":[]},"project":%s,"projectMilestone":null,"cycle":null,"priority":3,"estimate":null,"parent":null,"relations":{"nodes":[]},"inverseRelations":{"nodes":[]},"archivedAt":null,"trashed":false}\n' \
+    "$id" "$id" "$id" "$sname" "$stype" "$project_json"
+}
+
+{
+  issue_record CC-1 Backlog backlog Alpha
+  issue_record CC-2 Done completed Alpha
+  issue_record CC-3 Todo unstarted Beta
+  issue_record CC-4 Backlog backlog ""
+} | jq -s '.' >"$TMP_ROOT/.cache/linear/issues.json"
+
+run_list() {
+  bash "$LINEAR" cache issues list "$@"
+}
+
+fail=0
+
+check() {
+  local label="$1" out="$2" filter="$3"
+  if ! jq -e "$filter" >/dev/null 2>&1 <<<"$out"; then
+    echo "FAIL: $label"
+    echo "  filter: $filter"
+    echo "  output: $out"
+    fail=1
+  fi
+}
+
+# --- A: rows from every seeded project, each tagged with its project --------
+outA="$(run_list --all-projects --max --format=compact 2>/dev/null)"
+check "A: all four cached issues enumerated" "$outA" 'length == 4'
+check "A: Alpha rows carry project Alpha" "$outA" \
+  '[.[] | select(.project == "Alpha") | .id] | sort == ["CC-1", "CC-2"]'
+check "A: Beta row carries project Beta" "$outA" \
+  '[.[] | select(.project == "Beta") | .id] == ["CC-3"]'
+check "A: project-less row carries empty project" "$outA" \
+  '[.[] | select(.project == "") | .id] == ["CC-4"]'
+
+# Safe (default) format carries project per row too.
+outAsafe="$(run_list --all-projects --max 2>/dev/null)"
+check "A: safe format enumerates all projects with project field" "$outAsafe" \
+  '(length == 4) and ([.[] | select(.id == "CC-3") | .project] == ["Beta"])'
+
+# --- B: --state composes with --all-projects --------------------------------
+outB="$(run_list --all-projects --state "Backlog,Todo" --max --format=compact 2>/dev/null)"
+check "B: Done row excluded by composed state filter" "$outB" \
+  '[.[].id] | sort == ["CC-1", "CC-3", "CC-4"]'
+
+# --- C: mutual exclusion with --project fails loudly -------------------------
+rcC=0
+errC="$(run_list --all-projects --project "Alpha" --max 2>&1 >/dev/null)" || rcC=$?
+if [[ "$rcC" -eq 0 ]]; then
+  echo "FAIL: C: --all-projects with --project must exit nonzero"
+  fail=1
+fi
+if [[ "$errC" != *"--all-projects cannot be combined with --project"* ]]; then
+  echo "FAIL: C: conflict error message missing"
+  echo "  stderr: $errC"
+  fail=1
+fi
+
+# --- D: per-project call unchanged; row shape matches --all-projects ---------
+outD="$(run_list --project "Alpha" --max --format=compact 2>/dev/null)"
+check "D: per-project call returns only that project's issues" "$outD" \
+  '[.[].id] | sort == ["CC-1", "CC-2"]'
+check "D: per-project rows keep the compact field set" "$outD" \
+  '.[0] | keys | sort == ["agent", "blocked_by", "blocks", "estimate", "id", "labels", "parent_id", "priority", "project", "sort_order", "state", "state_type", "title"]'
+
+per_project_keys="$(jq -c '[.[] | select(.id == "CC-1")][0] | keys | sort' <<<"$outD")"
+all_projects_keys="$(jq -c '[.[] | select(.id == "CC-1")][0] | keys | sort' <<<"$outA")"
+if [[ "$per_project_keys" != "$all_projects_keys" ]]; then
+  echo "FAIL: D: --all-projects row shape diverges from per-project row shape"
+  echo "  per-project:  $per_project_keys"
+  echo "  all-projects: $all_projects_keys"
+  fail=1
+fi
+
+if [[ "$fail" -ne 0 ]]; then
+  echo "cache-issues-all-projects: FAIL"
+  exit 1
+fi
+
+echo "all pass"

--- a/skills/project-management/tests/comparison-set-contract.test.sh
+++ b/skills/project-management/tests/comparison-set-contract.test.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Regression test for harness-safe comparison-set loading (#676).
+# Under restricted harness approval policies (Codex AskForApproval=Never) a
+# per-project shell loop over `cache issues list --project` is rejected on
+# command shape alone, so the cross-project comparison-set loads in tpm-audit
+# and tpm-roadmap-plan must stay ONE simple `--all-projects` command. These
+# workflows are markdown contracts, so this test statically pins that shape.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+require_pattern() {
+  local file="$1" pattern="$2" desc="$3"
+  if ! grep -Eq -- "$pattern" "$file"; then
+    fail "$desc missing in ${file#$SKILL_DIR/}"
+  fi
+}
+
+require_fixed() {
+  local file="$1" needle="$2" desc="$3"
+  if ! grep -Fq -- "$needle" "$file"; then
+    fail "$desc missing in ${file#$SKILL_DIR/}"
+  fi
+}
+
+forbid_fixed() {
+  local file="$1" needle="$2" desc="$3"
+  if grep -Fq -- "$needle" "$file"; then
+    fail "$desc present in ${file#$SKILL_DIR/}"
+  fi
+}
+
+batch_cmd='.agents/skills/linear/scripts/linear.sh cache issues list --all-projects --state "Backlog,Todo,In Progress,In Review,Done" --max'
+
+# --- tpm-audit 1.5: comparison set is one --all-projects command ---
+
+tpm_audit="$SKILL_DIR/workflows/tpm-audit.md"
+[[ -f "$tpm_audit" ]] || fail "workflow not found: workflows/tpm-audit.md"
+
+section="$tmp/tpm-audit-1.5.md"
+sed -n '/^### 1\.5 /,/^### 1\.6 /p' "$tpm_audit" > "$section"
+[[ -s "$section" ]] || fail 'tpm-audit section 1.5 could not be extracted'
+
+require_fixed "$section" "$batch_cmd" 'single --all-projects comparison-set command'
+require_pattern "$section" 'Never loop `--project`' 'no-loop instruction'
+forbid_fixed "$section" 'Run for each project' 'per-project loop instruction'
+forbid_fixed "$section" '--project "[PROJECT_NAME]"' 'per-project fetch command'
+forbid_fixed "$section" 'for p in' 'shell loop shape'
+
+# --- tpm-roadmap-plan 1.5: same single-command contract ---
+
+roadmap_plan="$SKILL_DIR/workflows/tpm-roadmap-plan.md"
+[[ -f "$roadmap_plan" ]] || fail "workflow not found: workflows/tpm-roadmap-plan.md"
+
+section="$tmp/tpm-roadmap-plan-1.5.md"
+sed -n '/^### 1\.5 /,/^### 1\.6 /p' "$roadmap_plan" > "$section"
+[[ -s "$section" ]] || fail 'tpm-roadmap-plan section 1.5 could not be extracted'
+
+require_fixed "$section" "$batch_cmd" 'single --all-projects all-issues command'
+forbid_fixed "$section" 'for each project' 'per-project fetch instruction'
+forbid_fixed "$section" '--project "[PROJECT_NAME]"' 'per-project fetch command'
+forbid_fixed "$section" 'for p in' 'shell loop shape'
+
+# --- linear skill: the batch flag the workflows depend on is documented ---
+
+linear_skill="$SKILL_DIR/../linear/SKILL.md"
+[[ -f "$linear_skill" ]] || fail "linear SKILL.md not found next to project-management"
+require_fixed "$linear_skill" '--all-projects' 'batch enumeration flag documentation'
+
+echo "PASS: comparison-set contract"

--- a/skills/project-management/workflows/tpm-audit.md
+++ b/skills/project-management/workflows/tpm-audit.md
@@ -98,12 +98,12 @@ For proposed issues, use provided fields directly.
 
 ### 1.5 Fetch Comparison Set
 
-**Linear (TRACKER=linear)** — fetch issues from ALL projects (from 1.3) for duplicate/obsolete/fit checking:
+**Linear (TRACKER=linear)** — fetch issues from ALL projects for duplicate/obsolete/fit checking in ONE command:
 ```bash
-.agents/skills/linear/scripts/linear.sh cache issues list --project "[PROJECT_NAME]" --state "Backlog,Todo,In Progress,In Review,Done" --max
+.agents/skills/linear/scripts/linear.sh cache issues list --all-projects --state "Backlog,Todo,In Progress,In Review,Done" --max
 ```
 
-Run for each project. Store all issues for comparison in 6.
+Each row carries its `project` name. Never loop `--project` over the projects from 1.3 — restricted harness approval policies reject loop-shaped commands, and the single `--all-projects` call returns the same rows. Store all issues for comparison in 6.
 
 **Why all projects**: Cross-project duplicate detection, obsolete checking against completed work, and project fit evaluation all require visibility into the full backlog.
 

--- a/skills/project-management/workflows/tpm-roadmap-plan.md
+++ b/skills/project-management/workflows/tpm-roadmap-plan.md
@@ -72,12 +72,12 @@ For each proposed issue:
 
 ### 1.5 Fetch All Issues
 
-1. **Fetch issues** for each project:
+1. **Fetch issues** across ALL projects in ONE command (never loop `--project` per project — restricted harness approval policies reject loop-shaped commands):
    ```bash
-   .agents/skills/linear/scripts/linear.sh cache issues list --project "[PROJECT_NAME]" --state "Backlog,Todo,In Progress,In Review,Done" --max
+   .agents/skills/linear/scripts/linear.sh cache issues list --all-projects --state "Backlog,Todo,In Progress,In Review,Done" --max
    ```
 
-2. **Store** for comparison: `id`, `title`, `description`, `project`, `state`, `agent`, `labels[]`, `blocked_by[]`, `blocks[]`.
+2. **Store** for comparison: `id`, `title`, `description`, `project`, `state`, `agent`, `labels[]`, `blocked_by[]`, `blocks[]`. Each row already carries its `project` name.
 
 ### 1.6 Read Research Context
 


### PR DESCRIPTION
Closes #676. Audit workflows needed the all-projects Linear comparison set, but the natural per-project Bash loop is rejected by the Codex `AskForApproval=Never` classifier (loop/array shape). `cache issues list` gains `--all-projects`: single-command enumeration across every project, mutually exclusive with `--project` (loud error), composing with `--state`/`--max`/`--format`, and byte-identical row shape to the per-project call (existing formatters already emit `project` per row; project-less rows carry `""`).

tpm-audit.md § 1.5 and tpm-roadmap-plan.md § 1.5 (the identical shape) become ONE pipe-free simple command with an explicit never-loop note; audit-issues.md needed no change (it delegates comparison loading to tpm-audit).

Validation: new offline cache-fixture suite (multi-project tagging, "" project, format parity, filter composition, conflict error, per-project parity) + a doc contract pinning both § 1.5 single commands and forbidding per-project fetch loops. Full linear suite 21/21, project-management 6/6.

https://claude.ai/code/session_016s6ZSLTTRft6fH29wHn1TN
