### PR TITLE
feat: ship orch settings template so installs merge the review-flow keys

### DIFF
--- a/skills/orch/tests/settings-example-sync.test.sh
+++ b/skills/orch/tests/settings-example-sync.test.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# vstack#683-class guard: the orch skill ships vstack.settings.toml.example so
+# project installs merge the orch keys' defaults. This test keeps that template
+# in lockstep with the repo-root vstack.settings.toml.example — every orch key
+# must exist in BOTH files with IDENTICAL default values, so the two places
+# users learn the options can never drift.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_TEMPLATE="$SCRIPT_DIR/../vstack.settings.toml.example"
+ROOT_TEMPLATE="$SCRIPT_DIR/../../../vstack.settings.toml.example"
+
+ORCH_KEYS="PR_REVIEW_GATE PR_REVIEW_NUDGE_SECS PR_REVIEW_NUDGE PR_REVIEW_CHECK CI_WAIT_NO_CHECKS_GRACE CI_FIX_MAX_CYCLES REVIEWER_SLOT_BUDGET"
+
+fail=0
+
+check() {
+  if ! eval "$2"; then
+    echo "FAIL: $1"
+    fail=1
+  fi
+}
+
+value_of() {
+  # First uncommented assignment of key $2 in file $1, value only.
+  sed -n "s/^$2 = \"\(.*\)\"$/\1/p" "$1" | head -1
+}
+
+check "orch skill template exists" "[ -f \"\$SKILL_TEMPLATE\" ]"
+check "root template exists (skip-safe in downstream installs)" "[ -f \"\$ROOT_TEMPLATE\" ] || exit 0"
+
+check "skill template declares [env]" "grep -q '^\[env\]' \"\$SKILL_TEMPLATE\""
+
+for key in $ORCH_KEYS; do
+  skill_val="$(value_of "$SKILL_TEMPLATE" "$key")"
+  root_val="$(value_of "$ROOT_TEMPLATE" "$key")"
+  check "$key present in skill template" "grep -q \"^$key = \" \"\$SKILL_TEMPLATE\""
+  check "$key present in root template" "grep -q \"^$key = \" \"\$ROOT_TEMPLATE\""
+  if [ "$skill_val" != "$root_val" ]; then
+    echo "FAIL: $key default drift: skill='$skill_val' root='$root_val'"
+    fail=1
+  fi
+done
+
+# The security caveat for name-matched evidence must travel with the key.
+check "PR_REVIEW_CHECK carries the trust-model caveat" \
+  "grep -B2 '^PR_REVIEW_CHECK = ' \"\$SKILL_TEMPLATE\" | grep -qi 'SECURITY' || grep -B6 '^PR_REVIEW_CHECK = ' \"\$SKILL_TEMPLATE\" | grep -qi 'SECURITY'"
+
+if [ "$fail" -ne 0 ]; then
+  echo "settings-example-sync: FAIL"
+  exit 1
+fi
+echo "pass: settings-example-sync"

--- a/skills/orch/vstack.settings.toml.example
+++ b/skills/orch/vstack.settings.toml.example
@@ -1,0 +1,52 @@
+[env]
+
+# ORCH — PR review gate, CI waits, and reviewer fan-out.
+# Project-scope `vstack add` / `vstack refresh` merge these defaults into
+# <project>/vstack.settings.toml (never overwriting existing keys). Full key
+# reference: orch README.md / DEVELOPMENT.md.
+
+# Reviewer merge gate mode: "approval" requires a GitHub-native review
+# approval before merge (orch submit-pr/merge-pr); "review" requires a formal
+# review of the current head from a non-author reviewer plus zero unresolved
+# threads — the right mode for review bots that comment but never approve.
+# Set "off" ONLY for repos with no review bots and no reviewer policy — the
+# review wait is skipped entirely. Legacy PR_APPROVAL_GATE ("on"/"off") is
+# still honored when this key is unset.
+PR_REVIEW_GATE = "approval"
+
+# Used by: orch (`approval-wait`). Seconds without the gate's signal (for the
+# current head) before nudging the reviewer, once per head; a push resets the
+# clock. "0" disables nudging.
+PR_REVIEW_NUDGE_SECS = "600"
+
+# Used by: orch (`approval-wait`). Comment body posted as the nudge — set it
+# to whatever summons this repo's review bot (e.g. "@devin review"). Empty =
+# fall back to a GitHub-native re-review request to the PR's reviewers.
+PR_REVIEW_NUDGE = ""
+
+# Used by: orch (`approval-wait`, review mode). Name/context of the trusted
+# reviewer's check-run OR commit status: a success for that exact name on the
+# current head counts as review-received when a clean re-analysis submits no
+# review object (e.g. "Devin Review"). Empty = review objects only. SECURITY:
+# match by name means any app could publish it — name only the trusted bot's
+# check on repos where all publishers are trusted.
+PR_REVIEW_CHECK = ""
+
+# Used by: orch (`ci-wait`). Seconds to keep polling before failing when no CI
+# checks have registered yet. Raise for repos whose CI dispatches only after a
+# review approval (approval-gated jobs / merge queue) with slow dispatch.
+CI_WAIT_NO_CHECKS_GRACE = "180"
+
+# Used by: orch (`submit-pr` / `merge-pr`). Max automated ci-fix cycles per PR
+# submission or merge recovery before reporting the persistent CI failure back
+# to the user.
+CI_FIX_MAX_CYCLES = "6"
+
+# Used by: orch (`review-pr` / `review` / `review-codebase`). Total concurrent
+# agent-session budget of the harness runtime, counting the primary session.
+# "0" = unlimited: every reviewer launches up front and persists through
+# fix/re-review cycles. When the reviewer set exceeds the available slots,
+# review workflows run reviewers in bounded sequential waves, retiring each
+# completed session to release its slot. Codex collaboration runtime: four
+# total threads -> set "4".
+REVIEWER_SLOT_BUDGET = "0"


### PR DESCRIPTION
Skill-shipped `vstack.settings.toml.example` files are the mechanism project installs actually merge defaults from — and only second-opinion shipped one, so none of the new review-flow keys reached consuming projects' settings automatically; users had to hand-copy from the repo-root example they never see. Ships `skills/orch/vstack.settings.toml.example` (all 7 orch keys with the same defaults and comments as the root example, including the PR_REVIEW_CHECK trust-model caveat) plus a sync test that fails on any key/default drift between the two files (skip-safe in downstream installs without the repo root).

https://claude.ai/code/session_016s6ZSLTTRft6fH29wHn1TN