### PR TITLE
fix(#687): name post-mutation verification commands; issues view/show dispatcher hint

### DIFF
--- a/skills/linear/SKILL.md
+++ b/skills/linear/SKILL.md
@@ -57,6 +57,8 @@ CLI wrapper for Linear's GraphQL API with local cache, bulk operations, and stru
 
 Compatibility aliases: `issues relations` maps to `issues list-relations`, and `projects dependencies` maps to `projects list-dependencies`. Prefer the explicit action names in new workflows.
 
+There is no `view` or `show` action. Single-issue lookups are `issues get <ID>` (live) or `cache issues get <ID>` (cache); multi-issue lookups are `issues bulk-get <ID1> <ID2> ...`. For post-mutation verification, use live `issues bulk-get` — it returns fresh state for every mutated issue in one command.
+
 ## Hierarchy
 
 ```

--- a/skills/linear/scripts/commands/cache-query.sh
+++ b/skills/linear/scripts/commands/cache-query.sh
@@ -1078,6 +1078,10 @@ main() {
         validate-completion) cache_validate_completion "$@" ;;
         bulk-get) cache_bulk_get_issues "$@" ;;
         --help | -h) show_help ;;
+        view | show)
+            echo "{\"error\": \"Unknown issues action: $action. Cache lookups are 'cache issues get [ISSUE_ID]' or 'cache issues bulk-get [ID_1] [ID_2]'; live lookups are 'issues get' / 'issues bulk-get'.\"}" >&2
+            return 1
+            ;;
         *)
             echo "{\"error\": \"Unknown issues action: $action\"}" >&2
             return 1

--- a/skills/linear/scripts/commands/issues.sh
+++ b/skills/linear/scripts/commands/issues.sh
@@ -2765,6 +2765,13 @@ main() {
         echo "  linear.sh cache comments list [ISSUE_ID]" >&2
         exit 1
         ;;
+    view | show)
+        echo "Error: Unknown action '$action' — supported issue lookups:" >&2
+        echo "  linear.sh issues get [ISSUE_ID]" >&2
+        echo "  linear.sh issues bulk-get [ISSUE_ID_1] [ISSUE_ID_2]   # live state (post-mutation verification)" >&2
+        echo "  linear.sh cache issues get [ISSUE_ID]                 # cache read" >&2
+        exit 1
+        ;;
     help | --help | -h)
         show_help
         ;;

--- a/skills/linear/tests/issues-view-action-hint.test.sh
+++ b/skills/linear/tests/issues-view-action-hint.test.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Regression tests for the unsupported `view` action hint (vstack#687).
+#
+# A focused Linear issue audit's read-only post-mutation verification produced
+# `linear.sh issues view` — an action the issues namespace does not have; the
+# supported lookups are `issues get`, `issues bulk-get`, and `cache issues
+# get` — but the generic unknown-action error gave no pointer to them. The
+# issues dispatcher now catches `view` (and the `show` near-miss) with a
+# targeted error naming the supported lookups, and the cache issues namespace
+# does the same, so an agent that receives stale guidance self-corrects in one
+# step. These tests assert those hints, that other unknown actions keep the
+# generic error, and that real commands still route.
+# Hermetic: curl is stubbed on PATH to fail loudly — no network.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+mkdir -p "$TMP_ROOT/.agents/skills" "$TMP_ROOT/bin"
+cp -R "$SKILL_DIR" "$TMP_ROOT/.agents/skills/linear"
+LINEAR_SH="$TMP_ROOT/.agents/skills/linear/scripts/linear.sh"
+
+# The dispatcher must reject unsupported actions before any API call.
+cat >"$TMP_ROOT/bin/curl" <<'SH'
+#!/usr/bin/env bash
+echo "curl must not be called by dispatcher-hint tests" >&2
+exit 1
+SH
+chmod +x "$TMP_ROOT/bin/curl"
+
+# Minimal cache so cache-query.sh reaches its action dispatch.
+mkdir -p "$TMP_ROOT/.cache/linear"
+printf '{"synced_at": "2026-01-01T00:00:00Z"}\n' >"$TMP_ROOT/.cache/linear/meta.json"
+
+PASS=0
+FAIL=0
+ERR_FILE="$TMP_ROOT/stderr"
+
+# Captures stdout in $out, stderr in $err, exit code in $rc.
+run_linear() {
+  set +e
+  out=$(PATH="$TMP_ROOT/bin:$PATH" LINEAR_API_KEY=test-token \
+    bash "$LINEAR_SH" ${ARGS[@]+"${ARGS[@]}"} 2>"$ERR_FILE")
+  rc=$?
+  set -e
+  err="$(cat "$ERR_FILE")"
+}
+
+assert_eq() {
+  local got="$1" want="$2" name="$3"
+  if [[ "$got" == "$want" ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$name" "$want" "$got"
+  fi
+}
+
+assert_contains() {
+  local got="$1" needle="$2" name="$3"
+  if [[ "$got" == *"$needle"* ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected to contain: %s\n        got:      %s\n' "$name" "$needle" "$got"
+  fi
+}
+
+assert_not_contains() {
+  local got="$1" needle="$2" name="$3"
+  if [[ "$got" != *"$needle"* ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected NOT to contain: %s\n        got:      %s\n' "$name" "$needle" "$got"
+  fi
+}
+
+echo "=== linear.sh unsupported view action hint (vstack#687) ==="
+
+# --- Unsupported `view` action gets a targeted hint ---------------------------
+ARGS=(issues view PROJ-42 --format=safe)
+run_linear
+assert_eq "$rc" "1" "issues view exits nonzero"
+assert_eq "$out" "" "issues view emits no stdout result"
+assert_contains "$err" "Unknown action 'view'" "issues view names the unknown action"
+assert_contains "$err" "linear.sh issues bulk-get" "issues view hint names bulk-get"
+assert_contains "$err" "linear.sh cache issues get" "issues view hint names the cache lookup"
+
+ARGS=(issues show PROJ-42)
+run_linear
+assert_eq "$rc" "1" "issues show near-miss exits nonzero"
+assert_contains "$err" "linear.sh issues bulk-get" "issues show hint names bulk-get"
+
+# Singular resource normalizes to `issues` and still reaches the hint.
+ARGS=(issue view PROJ-42)
+run_linear
+assert_eq "$rc" "1" "issue view (singular) exits nonzero"
+assert_contains "$err" "linear.sh issues bulk-get" "issue view (singular) hint names bulk-get"
+
+# --- Other unknown actions keep the generic error + usage pointer -------------
+ARGS=(issues frobnicate PROJ-42)
+run_linear
+assert_eq "$rc" "1" "unknown action exits nonzero"
+assert_contains "$err" "Unknown action 'frobnicate'" "unknown action reports generic error"
+assert_contains "$err" "Run 'issues.sh --help' for usage." "unknown action points at usage"
+assert_not_contains "$err" "bulk-get" "unknown action gets no view hint"
+
+# --- Cache issues namespace gets the same targeted hint -----------------------
+ARGS=(cache issues view PROJ-42)
+run_linear
+assert_eq "$rc" "1" "cache issues view exits nonzero"
+assert_contains "$err" "Unknown issues action: view" "cache issues view names the unknown action"
+assert_contains "$err" "cache issues get" "cache issues view hint names the cache lookup"
+
+ARGS=(cache issues frobnicate PROJ-42)
+run_linear
+assert_eq "$rc" "1" "unknown cache action exits nonzero"
+assert_contains "$err" "Unknown issues action: frobnicate" "unknown cache action reports generic error"
+assert_not_contains "$err" "bulk-get" "unknown cache action gets no view hint"
+
+# --- Real commands still route ------------------------------------------------
+ARGS=(issues bulk-get --help)
+run_linear
+assert_eq "$rc" "0" "issues bulk-get --help routes and exits 0"
+assert_contains "$out" "Issue Operations" "issues bulk-get --help prints issues usage"
+
+ARGS=(cache issues get --help)
+run_linear
+assert_eq "$rc" "0" "cache issues get --help routes and exits 0"
+
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/skills/project-management/tests/linear-issues-view-lint.test.sh
+++ b/skills/project-management/tests/linear-issues-view-lint.test.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# Regression lint for vstack#687. A focused Linear issue audit's read-only
+# post-mutation verification produced `linear.sh issues view` — an action the
+# Linear CLI does not have; the supported lookups are `issues get`,
+# `issues bulk-get`, and `cache issues get`. No canonical doc carried the bad
+# form — the audit workflow stated no post-mutation verification command at
+# all, so the auditing agent improvised one (same class as vstack#641).
+# audit-issues § 7.5 now names the exact tracker-routed verification commands,
+# and the linear SKILL.md states there is no `view`/`show` action.
+#
+# This lint scans the project-management and linear doc trees (every line —
+# prose, inline code, and fenced blocks alike, since guidance text is what
+# agents relay; linear is a required project-management dependency, so both
+# are present wherever project-management is installed) and FAILS if any line
+# invokes a `view`/`show` issue lookup:
+#   - `linear.sh issues view ...` (the reported miss) / `linear.sh issue view`
+#   - `linear.sh cache issues view ...`
+#   - `issues.sh view` / bare `issues view` / `issues show` shapes
+# The GitHub route's `gh issue view` is a real command (singular `issue`) and
+# must never be flagged. The lint also asserts the docs that state the
+# verification obligation still carry the supported commands, so the guidance
+# can't silently drop them.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
+SKILLS_ROOT="$(cd "$SKILL_DIR/.." && pwd)"
+TMP_ROOT="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+PASS=0
+FAIL=0
+
+pass() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+fail() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
+
+# scan_bad_issues_view <file>
+# Emits one "file:line: ..." row per line that invokes a view/show issue
+# lookup. `gh issue view` never matches — bare-shape matching is plural-only
+# (`issues`), and the CLI shapes require a `linear.sh`/`issues.sh` prefix.
+scan_bad_issues_view() {
+  grep -nE '(linear\.sh[[:space:]]+(cache[[:space:]]+)?issues?|issues\.sh|(^|[^[:alnum:]_./-])issues)[[:space:]]+(view|show)([^[:alnum:]]|$)' "$1" \
+    | sed "s|^|$1:|" || true
+}
+
+echo "=== linear issues view lookup lint (vstack#687) ==="
+
+# --- Part a: project-management and linear docs must be clean ----------------
+offenders=""
+for skill in project-management linear; do
+  while IFS= read -r -d '' doc; do
+    out="$(scan_bad_issues_view "$doc")"
+    [[ -n "$out" ]] && offenders+="$out"$'\n'
+  done < <(find "$SKILLS_ROOT/$skill" -maxdepth 2 -type f -name '*.md' -not -path '*/tests/*' -print0)
+done
+if [[ -z "$offenders" ]]; then
+  pass "project-management/linear docs never invoke a view/show issue lookup"
+else
+  fail "docs invoke a view/show issue lookup (use issues get / issues bulk-get / cache issues get):"
+  printf '%s' "$offenders" | sed 's/^/          /'
+fi
+
+# --- Part b: the obligation-stating docs carry the supported commands --------
+audit_issues="$SKILL_DIR/workflows/audit-issues.md"
+if grep -Fq 'linear.sh issues bulk-get [ISSUE_ID_1] [ISSUE_ID_2] --format=safe' "$audit_issues"; then
+  pass "audit-issues post-mutation verification carries the live bulk-get fetch"
+else
+  fail "audit-issues post-mutation verification lost the live bulk-get fetch"
+fi
+if grep -Fq 'linear.sh cache issues get [ISSUE_ID]' "$audit_issues"; then
+  pass "audit-issues post-mutation verification carries the cache get lookup"
+else
+  fail "audit-issues post-mutation verification lost the cache get lookup"
+fi
+if grep -Fq 'gh issue view [N] --repo [OWNER/REPO] --json number,title,body,labels,state,url' "$audit_issues"; then
+  pass "audit-issues post-mutation verification carries the GitHub-route fetch"
+else
+  fail "audit-issues post-mutation verification lost the GitHub-route fetch"
+fi
+if grep -Eq 'Post-Mutation Verification' "$audit_issues"; then
+  pass "audit-issues § 7 states the post-mutation verification obligation"
+else
+  fail "audit-issues § 7 lost the post-mutation verification section"
+fi
+if grep -Fq 'issues bulk-get' "$SKILLS_ROOT/linear/SKILL.md"; then
+  pass "linear SKILL.md names bulk-get as a supported lookup"
+else
+  fail "linear SKILL.md lost the bulk-get lookup note"
+fi
+
+# --- Part c: the lint has teeth ----------------------------------------------
+
+# inject_line <descriptor> <line> → prints scratch-file path.
+# Appends <line> to a scratch copy of the real, now-clean audit workflow doc
+# under $TMP_ROOT (removed by the EXIT trap). The base doc has zero offenders
+# — including its legitimate GitHub-route `gh issue view` lines — so any
+# offender reported comes from the injected line alone.
+inject_line() {
+  local scratch="$TMP_ROOT/inject-$1.md"
+  cp "$audit_issues" "$scratch"
+  printf '\n%s\n' "$2" >> "$scratch"
+  printf '%s' "$scratch"
+}
+
+# c.1 — the reported miss IS flagged.
+if [[ -n "$(scan_bad_issues_view "$(inject_line miss 'Verify with `.agents/skills/linear/scripts/linear.sh issues view CC-125 --format=safe`.')")" ]]; then
+  pass "lint flags 'linear.sh issues view'"
+else
+  fail "lint MISSED 'linear.sh issues view' (no teeth)"
+fi
+
+# c.2 — near-miss variants ARE flagged.
+if [[ -n "$(scan_bad_issues_view "$(inject_line singular 'Run `linear.sh issue view PROJ-42`.')")" ]]; then
+  pass "lint flags the singular 'linear.sh issue view' near-miss"
+else
+  fail "lint MISSED the singular 'linear.sh issue view' near-miss (no teeth)"
+fi
+if [[ -n "$(scan_bad_issues_view "$(inject_line cache 'Run `linear.sh cache issues view PROJ-42`.')")" ]]; then
+  pass "lint flags 'linear.sh cache issues view'"
+else
+  fail "lint MISSED 'linear.sh cache issues view' (no teeth)"
+fi
+if [[ -n "$(scan_bad_issues_view "$(inject_line bare 'Verify each mutation with `issues view PROJ-42` afterwards.')")" ]]; then
+  pass "lint flags the bare 'issues view' shape"
+else
+  fail "lint MISSED the bare 'issues view' shape (no teeth)"
+fi
+if [[ -n "$(scan_bad_issues_view "$(inject_line show 'Run `issues.sh show PROJ-42`.')")" ]]; then
+  pass "lint flags the 'issues.sh show' near-miss"
+else
+  fail "lint MISSED the 'issues.sh show' near-miss (no teeth)"
+fi
+
+# c.3 — supported and legitimate forms are NOT flagged.
+if [[ -z "$(scan_bad_issues_view "$(inject_line gh 'Fetch with `gh issue view [N] --repo [OWNER/REPO] --json labels`.')")" ]]; then
+  pass "lint accepts the GitHub route's 'gh issue view'"
+else
+  fail "lint false-flagged the GitHub route's 'gh issue view'"
+fi
+if [[ -z "$(scan_bad_issues_view "$(inject_line bulkget 'Verify with `.agents/skills/linear/scripts/linear.sh issues bulk-get PROJ-42 PROJ-43 --format=safe`.')")" ]]; then
+  pass "lint accepts the supported 'issues bulk-get' fetch"
+else
+  fail "lint false-flagged the supported 'issues bulk-get' fetch"
+fi
+if [[ -z "$(scan_bad_issues_view "$(inject_line cacheget 'Read `linear.sh cache issues get PROJ-42`.')")" ]]; then
+  pass "lint accepts the supported 'cache issues get' lookup"
+else
+  fail "lint false-flagged the supported 'cache issues get' lookup"
+fi
+if [[ -z "$(scan_bad_issues_view "$(inject_line prose 'Report the issues shown in the summary.')")" ]]; then
+  pass "lint accepts prose like 'issues shown'"
+else
+  fail "lint false-flagged prose like 'issues shown'"
+fi
+
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/skills/project-management/workflows/audit-issues.md
+++ b/skills/project-management/workflows/audit-issues.md
@@ -774,7 +774,27 @@ For each issue canceled during § 7.1 or § 7.2 (superseded, obsolete, or duplic
    - GitHub: `gh issue edit [N] --repo [OWNER/REPO] --title "[UPDATED]"` and the § 7.2 body-edit route for descriptions
    - Comment (either tracker): `"Updated: [OLD] → [NEW] per [DECISION_ID]"`
 
-### 7.5 Relation Direction Reference
+### 7.5 Post-Mutation Verification
+
+After executing the approved actions, re-fetch every mutated issue with a supported read-only command and confirm the changes landed (state, labels, parent, project, relations, description) before presenting § 8. Use only the commands below -- the Linear CLI has no `view` action; do not improvise one.
+
+**Linear (TRACKER=linear)** -- one live fetch returns fresh post-mutation state for all mutated issues:
+
+```bash
+.agents/skills/linear/scripts/linear.sh issues bulk-get [ISSUE_ID_1] [ISSUE_ID_2] --format=safe
+```
+
+For a single issue, `.agents/skills/linear/scripts/linear.sh cache issues get [ISSUE_ID]` is also supported -- mutations write through to the cache.
+
+**GitHub (TRACKER=github)** -- per mutated issue:
+
+```bash
+gh issue view [N] --repo [OWNER/REPO] --json number,title,body,labels,state,url
+```
+
+Report any mismatch between an approved action and the re-fetched state in § 8 -- do not silently accept it.
+
+### 7.6 Relation Direction Reference
 
 **Project mode**: `from` → relation → `to` (from `findings.add_relations[]`)
 


### PR DESCRIPTION
Closes #687. Same class as #641/#662: audit-issues § 7 stated the post-mutation verification obligation with NO command, so an auditing agent improvised the unsupported `issues view` (no doc ever carried it — the only literal hits are the GitHub route's valid `gh issue view`).

- **audit-issues § 7.5 (new)**: tracker-routed verification — Linear route names live `issues bulk-get ... --format=safe` (fresh state for all mutated issues in one command) + `cache issues get` for singles; GitHub route keeps `gh issue view --json ...`; mismatches surface in § 8.
- **Dispatcher hints**: `view|show` under both the live and cache issues namespaces get targeted errors naming the supported lookups (mirrors the #641/#662 hint style); generic unknown-action path preserved.
- **Lint teeth**: doc scan for the unsupported shapes with injected offenders — explicitly does NOT flag `gh issue view` or prose.

Validation: new hint test 22/22 (hermetic, both namespaces, near-miss normalization); new lint 15/15; full linear (22) + project-management (7) suites green.

https://claude.ai/code/session_016s6ZSLTTRft6fH29wHn1TN