### PR TITLE
feat(#692): external worktree base (~/dev/.worktrees/<repo>) + canonical path guards

### DIFF
--- a/skills/worktree/README.md
+++ b/skills/worktree/README.md
@@ -22,7 +22,9 @@ Run from the main checkout of a git repo with an `origin` remote. New-work claim
 ./scripts/worktree remove PROJ-123
 ```
 
-Defaults: detects branch from `origin/HEAD` (fallback: `main`), creates worktrees under sibling `trees/`, then applies configured symlinks and copies. Set `WORKTREE_BASE_DIR` to use another parent directory; relative paths resolve from the main checkout, absolute paths are used as-is.
+Defaults: detects branch from `origin/HEAD` (fallback: `main`), creates worktrees under `<parent-of-checkout>/.worktrees/<checkout-name>/` — an external per-repo dir beside the checkout, so recursive editor/file watchers on the repo never ingest worktree build outputs and sibling repos cannot collide — then applies configured symlinks and copies. Set `WORKTREE_BASE_DIR` to use another parent directory; relative paths resolve from the main checkout, absolute paths and `~` are used as-is. Avoid pointing it inside the repo root.
+
+Issue-ID commands (`remove`, `push`, `restack`, `path`, `exists`, `create --reuse`) resolve against the configured base dir first, then fall back to the worktree registered for the issue branch — worktrees created under an older base-dir convention keep working unmoved, with no auto-migration. Path comparisons are canonical (symlink-resolved on both sides), so a tree registered under a legacy symlinked spelling is recognized as the same tree when addressed by its physical path, and a foreign repo's worktree is still refused.
 
 Bare `create <ID>` claims new work only. Every new-branch mode, including `--from`, checks the normalized issue branch, an explicit requested branch, and `BOT_NAME/<issue>` for matching worktrees, local/remote refs, and open PRs. Existing ownership exits 75 without rebasing or modifying a branch. Origin remote-head and GitHub PR discovery are authoritative: an outage exits 1 before worktree config, branch, or target-path mutation instead of being treated as absence. Unreachable secondary remotes are skipped with a warning (they cannot hold other sessions' pushes); reachable ones still count as ownership. A repository-local per-issue lock holds the final repeated discovery through `git worktree add`, so concurrent claimers produce one worktree and one exit 75. Inspect or monitor owned work instead of launching another implementer. Run each issue create separately and check its result; do not batch creates in a shell loop whose last success can mask an earlier active-work exit.
 
@@ -84,7 +86,7 @@ Set non-sensitive project defaults in `vstack.settings.toml` under `[env]`. Exis
 
 | Variable | Purpose |
 |----------|---------|
-| `WORKTREE_BASE_DIR` | Parent directory for created worktrees (default: `../trees`) |
+| `WORKTREE_BASE_DIR` | Parent directory for created worktrees (default: `../.worktrees/<checkout-name>`, an external per-repo dir beside the checkout) |
 | `WORKTREE_DEFAULT_BRANCH` | Override default branch detection |
 | `WORKTREE_SYMLINKS` | Space-separated paths to symlink into worktrees |
 | `WORKTREE_RELATIVE_SYMLINKS` | Space-separated `path=target` symlinks created inside each worktree |
@@ -102,7 +104,7 @@ pointed at each worktree's own `AGENTS.md`:
 
 ```toml
 [env]
-WORKTREE_BASE_DIR = "../trees"
+WORKTREE_BASE_DIR = "~/dev/.worktrees/myproject"
 WORKTREE_SYMLINKS = ".env.local .claude/agents .claude/hooks .claude/skills"
 WORKTREE_RELATIVE_SYMLINKS = ".claude/CLAUDE.md=../AGENTS.md"
 WORKTREE_MKDIRS = "tmp"

--- a/skills/worktree/SKILL.md
+++ b/skills/worktree/SKILL.md
@@ -14,7 +14,9 @@ metadata:
 
 # Worktree Management
 
-Portable git worktree manager. Layout defaults to `project/main` (repo) + `project/trees/{id}` (worktrees); projects can override the worktree parent directory.
+Portable git worktree manager. Worktrees live outside the repo root by default — `<parent-of-checkout>/.worktrees/<checkout-name>/{id}` — so recursive editor/file watchers on the repo never ingest worktree build outputs, and sibling repos cannot collide on a shared parent dir. Projects can override the worktree parent directory with `WORKTREE_BASE_DIR`.
+
+Issue-ID resolution prefers the configured base dir and falls back to the worktree registered for the issue branch, so trees created under an older base-dir convention keep working unmoved (`list`/`remove`/`push`/`restack`/`create --reuse`); there is no auto-migration. Path comparisons are canonical (physical, symlink-resolved on both sides), so a worktree registered under a legacy symlinked spelling and addressed via its physical path — or vice versa — is recognized as the same tree, never as a foreign one.
 
 Resolves project root via `git rev-parse`, detects default branch automatically, and reads project-specific config from `.env`, `vstack.settings.toml`, then `.env.local` (`.env.local` wins).
 
@@ -214,7 +216,7 @@ Set non-sensitive defaults in committed `vstack.settings.toml` under `[env]`. Ex
 
 | Variable | Effect |
 |----------|--------|
-| `WORKTREE_BASE_DIR` | Parent directory for created worktrees. Relative paths resolve from the main checkout; absolute paths are used as-is. Default: `../trees` |
+| `WORKTREE_BASE_DIR` | Parent directory for created worktrees. Relative paths resolve from the main checkout; absolute paths and `~` are used as-is. Default: `../.worktrees/<checkout-name>` (external per-repo dir beside the checkout). Do not point it inside the repo root: worktree build outputs under the repo can exhaust recursive file-watcher (inotify) budgets |
 | `WORKTREE_SYMLINKS` | Space-separated paths symlinked from main checkout into each worktree; include `.env.local` only if worktrees should share local secrets/overrides |
 | `WORKTREE_RELATIVE_SYMLINKS` | Space-separated `path=target` symlinks created inside each worktree, with relative targets resolving from the link location |
 | `WORKTREE_COPIES` | Space-separated files copied from main checkout into each worktree |
@@ -224,7 +226,7 @@ Example: share local env plus generated Claude assets, but keep `.claude/CLAUDE.
 
 ```toml
 [env]
-WORKTREE_BASE_DIR = "../trees"
+WORKTREE_BASE_DIR = "~/dev/.worktrees/myproject"
 WORKTREE_SYMLINKS = ".env.local .claude/agents .claude/hooks .claude/skills"
 WORKTREE_RELATIVE_SYMLINKS = ".claude/CLAUDE.md=../AGENTS.md"
 WORKTREE_MKDIRS = "tmp"

--- a/skills/worktree/scripts/worktree
+++ b/skills/worktree/scripts/worktree
@@ -14,11 +14,13 @@
 #     skip            Skip the current commit in that paused restack
 #     abort           Abort that paused restack and clear pending authorization
 #
-# Layout: project/main (repo) + project/trees/{id} (worktrees by default)
+# Layout: main checkout (repo) + external worktree parent dir
+#   default: <parent-of-checkout>/.worktrees/<checkout-name>/{id}
 # Config: reads .env, vstack.settings.toml, then .env.local for optional settings (see below)
 #
 # vstack.settings.toml [env] and .env/.env.local config vars:
-#   WORKTREE_BASE_DIR        - parent directory for worktrees (relative to main checkout or absolute; default: ../trees)
+#   WORKTREE_BASE_DIR        - parent directory for worktrees (relative to main checkout or absolute;
+#                              default: ../.worktrees/<checkout-name>, an external per-repo sibling dir)
 #   WORKTREE_DEFAULT_BRANCH  - default branch name (auto-detected if unset, fallback: main)
 #   WORKTREE_SYMLINKS        - space-separated paths to symlink from main into worktrees
 #   WORKTREE_RELATIVE_SYMLINKS - space-separated path=target symlinks created inside worktrees
@@ -34,6 +36,22 @@ set -euo pipefail
 
 readonly ACTIVE_WORK_EXIT=75
 
+canonical_existing_dir() {
+  local path="$1"
+  [[ -d "$path" ]] || return 1
+  (cd "$path" && pwd -P)
+}
+
+# Canonical (physical) path equality: both sides resolve through pwd -P, so a
+# path reached via a compatibility symlink and its physical form compare
+# equal. False when either side is not an existing directory.
+same_canonical_dir() {
+  local a="" b=""
+  a="$(canonical_existing_dir "$1" 2>/dev/null)" || return 1
+  b="$(canonical_existing_dir "$2" 2>/dev/null)" || return 1
+  [[ "$a" == "$b" ]]
+}
+
 # Resolve PROJECT_ROOT via git (works at any depth, inside worktrees too)
 PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
 if [[ -z "$PROJECT_ROOT" ]]; then
@@ -46,12 +64,9 @@ _git_common_dir=$(git -C "$PROJECT_ROOT" rev-parse --git-common-dir 2>/dev/null)
 if [[ "$_git_common_dir" != ".git" && -n "$_git_common_dir" ]]; then
   PROJECT_ROOT="$(cd "$PROJECT_ROOT" && cd "$(dirname "$_git_common_dir")" && pwd)"
 fi
-
-canonical_existing_dir() {
-  local path="$1"
-  [[ -d "$path" ]] || return 1
-  (cd "$path" && pwd -P)
-}
+# Physical form so registry, base-dir, and guard comparisons all share one
+# canonical anchor even when the script is invoked through a symlinked path.
+PROJECT_ROOT="$(canonical_existing_dir "$PROJECT_ROOT")"
 
 git_common_dir_path() {
   local checkout="$1" common_dir=""
@@ -308,24 +323,31 @@ strip_trailing_slashes() {
 
 resolve_worktree_base_dir() {
   local raw="${WORKTREE_BASE_DIR:-}"
-  if [[ -z "$raw" ]]; then
-    printf '%s\n' "$(dirname "$PROJECT_ROOT")/trees"
-    return
-  fi
-
-  if [[ "$raw" == "~" ]]; then
-    raw="${HOME:?WORKTREE_BASE_DIR uses ~ but HOME is not set}"
-  elif [[ "$raw" == "~/"* ]]; then
-    raw="${HOME:?WORKTREE_BASE_DIR uses ~ but HOME is not set}/${raw#~/}"
-  fi
-
-  raw="$(strip_trailing_slashes "$raw")"
-
   local path
-  if [[ "$raw" == /* ]]; then
-    path="$raw"
+  if [[ -z "$raw" ]]; then
+    # Default: an external per-repo dir beside the checkout. Worktrees (and
+    # their build outputs) must not live under the repo root — an editor
+    # recursively watching the repo would ingest every worktree's build
+    # artifacts and can exhaust the per-user inotify budget. A shared sibling
+    # like ../trees would collide across repos (two repos' issue-1 would
+    # resolve to the same path), so the repo name disambiguates.
+    path="$(dirname "$PROJECT_ROOT")/.worktrees/$(basename "$PROJECT_ROOT")"
   else
-    path="$PROJECT_ROOT/$raw"
+    if [[ "$raw" == "~" ]]; then
+      raw="${HOME:?WORKTREE_BASE_DIR uses ~ but HOME is not set}"
+    elif [[ "$raw" == "~/"* ]]; then
+      # ${raw:2}, not ${raw#~/}: an unquoted ~ in a strip pattern is itself
+      # tilde-expanded to $HOME, so the prefix would never match.
+      raw="${HOME:?WORKTREE_BASE_DIR uses ~ but HOME is not set}/${raw:2}"
+    fi
+
+    raw="$(strip_trailing_slashes "$raw")"
+
+    if [[ "$raw" == /* ]]; then
+      path="$raw"
+    else
+      path="$PROJECT_ROOT/$raw"
+    fi
   fi
 
   [[ "$path" == "/" ]] && { printf '/\n'; return; }
@@ -655,7 +677,10 @@ worktree_for_branch() {
         # A stanza without a worktree path is not ownership proof; success
         # must always carry a usable path for command-substitution callers.
         if [[ -n "$current_path" ]]; then
-          printf '%s\n' "$current_path"
+          # Report the physical path when it resolves; git may have recorded
+          # an older lexical (symlinked) spelling. A stale registration whose
+          # directory is gone is reported as recorded.
+          canonical_existing_dir "$current_path" 2>/dev/null || printf '%s\n' "$current_path"
           return 0
         fi
         ;;
@@ -663,6 +688,26 @@ worktree_for_branch() {
     esac
   done < <(git -C "$PROJECT_ROOT" worktree list --porcelain -z)
   return 1
+}
+
+# Resolve an issue ID to its worktree path. Prefers the configured
+# WORKTREE_BASE_DIR target; when nothing exists there, falls back to the
+# worktree registered for the issue branch so trees created under an older
+# base-dir convention keep working unmoved (no auto-migration). The main
+# checkout is never a fallback target.
+worktree_path_for_issue() {
+  local issue="$1" configured="" registered=""
+  configured="$(worktree_path "$issue")"
+  if [[ -e "$configured" || -L "$configured" ]]; then
+    printf '%s\n' "$configured"
+    return 0
+  fi
+  registered="$(worktree_for_branch "$(issue_branch_name "$issue")" 2>/dev/null || true)"
+  if [[ -n "$registered" ]] && ! same_canonical_dir "$registered" "$PROJECT_ROOT"; then
+    printf '%s\n' "$registered"
+    return 0
+  fi
+  printf '%s\n' "$configured"
 }
 
 rebase_in_progress() {
@@ -807,7 +852,7 @@ resolve_restack_worktree() {
   elif [[ "$arg" == */* ]]; then
     printf '%s\n' "$arg"
   else
-    worktree_path "$arg"
+    worktree_path_for_issue "$arg"
   fi
 }
 
@@ -1199,7 +1244,8 @@ case "${1:-}" in
     if [[ "${2:-}" == "--help" || "${2:-}" == "-h" ]]; then
       echo "Usage: $0 create <ID> [BRANCH] [options]"
       echo ""
-      echo "Create a worktree for an issue ID (resolved to trees/<id>), optionally with an"
+      echo "Create a worktree for an issue ID (resolved under the configured worktree base"
+      echo "dir; default: ../.worktrees/<repo> beside the main checkout), optionally with an"
       echo "explicit branch-name positional."
       echo ""
       echo "Options:"
@@ -1245,7 +1291,10 @@ case "${1:-}" in
         *) BRANCH="$1"; shift ;;
       esac
     done
-    WT_PATH="$(worktree_path "$ISSUE")"
+    # Prefer the configured target; fall back to the registered worktree for
+    # the issue branch so trees created under an older base-dir convention are
+    # still recognized as active work and reusable in place.
+    WT_PATH="$(worktree_path_for_issue "$ISSUE")"
 
     # 1. Existing work is an ownership signal. Bare create is only for claiming
     # new work; reuse must be explicit so discovery cannot rewrite another
@@ -1465,7 +1514,8 @@ case "${1:-}" in
       echo "Usage: $0 remove [ID|/path]"
       echo ""
       echo "Remove a worktree and delete its local branch when it is safely merged."
-      echo "Accepts an issue ID (resolved to trees/<id>) or a direct worktree path."
+      echo "Accepts an issue ID (resolved under the configured worktree base dir, falling"
+      echo "back to the worktree registered for the issue branch) or a direct path."
       exit 0
     fi
     ARG="${2:?Error: remove requires an issue ID or path}"
@@ -1482,17 +1532,30 @@ case "${1:-}" in
     if [[ "$ARG" == */* ]]; then
       WT_PATH="$ARG"
     else
-      WT_PATH="$(worktree_path "$ARG")"
+      WT_PATH="$(worktree_path_for_issue "$ARG")"
     fi
-    # Auto-relocate if cwd is inside the worktree being removed
+    # Auto-relocate if cwd is inside the worktree being removed. Both sides
+    # are physical (pwd -P); the boundary-aware match avoids treating a
+    # sibling like .../issue-10 as inside .../issue-1.
     WT_REAL="$(cd "$WT_PATH" 2>/dev/null && pwd -P)" || WT_REAL=""
     CWD_REAL="$(pwd -P)"
-    if [[ -n "$WT_REAL" && "$CWD_REAL" == "$WT_REAL"* ]]; then
+    CWD_INSIDE_WT=false
+    if [[ -n "$WT_REAL" ]] && [[ "$CWD_REAL" == "$WT_REAL" || "$CWD_REAL" == "$WT_REAL"/* ]]; then
+      CWD_INSIDE_WT=true
       cd "$PROJECT_ROOT"
       echo "Relocated cwd to $PROJECT_ROOT" >&2
     fi
     BRANCH=""
     if [[ -d "$WT_PATH" ]]; then
+      # Only a worktree registered to this repository (compared canonically,
+      # so a legacy symlinked spelling still matches its physical form) may
+      # be mutated. A foreign repo's worktree reachable through a shared or
+      # symlinked base dir must not have its symlinks stripped or its
+      # registration touched.
+      if ! is_registered_project_worktree "$WT_PATH"; then
+        echo "Error: $WT_PATH is not a registered worktree of $PROJECT_ROOT; refusing to remove it." >&2
+        exit 1
+      fi
       BRANCH=$(git -C "$WT_PATH" branch --show-current 2>/dev/null)
       remove_symlinks "$WT_PATH"
       git -C "$PROJECT_ROOT" worktree remove --force "$WT_PATH"
@@ -1519,7 +1582,7 @@ case "${1:-}" in
       fi
     fi
     echo "Removed: $WT_PATH"
-    if [[ -n "$WT_REAL" && "$CWD_REAL" == "$WT_REAL"* ]]; then
+    if [[ "$CWD_INSIDE_WT" == true ]]; then
       echo "" >&2
       echo "Warning: Session cwd was inside deleted worktree. Start a new session from:" >&2
       echo "  $PROJECT_ROOT" >&2
@@ -1531,7 +1594,18 @@ case "${1:-}" in
 
   cleanup)
     git_with_github_https_auth -C "$PROJECT_ROOT" fetch --prune origin
-    for wt in $(git -C "$PROJECT_ROOT" worktree list --porcelain | grep "^worktree " | grep -v "$PROJECT_ROOT$" | cut -d' ' -f2); do
+    # Collect candidates first: NUL-delimited porcelain parsing survives paths
+    # with spaces, and the main checkout is excluded by canonical comparison —
+    # git may report it under an older lexical (symlinked) spelling that a
+    # textual match against $PROJECT_ROOT would miss.
+    CLEANUP_TREES=()
+    while IFS= read -r -d '' CLEANUP_LINE; do
+      [[ "$CLEANUP_LINE" == worktree\ * ]] || continue
+      CLEANUP_WT="${CLEANUP_LINE#worktree }"
+      same_canonical_dir "$CLEANUP_WT" "$PROJECT_ROOT" && continue
+      CLEANUP_TREES+=("$CLEANUP_WT")
+    done < <(git -C "$PROJECT_ROOT" worktree list --porcelain -z)
+    for wt in ${CLEANUP_TREES[@]+"${CLEANUP_TREES[@]}"}; do
       BRANCH=$(git -C "$wt" branch --show-current 2>/dev/null)
       if [[ -n "$BRANCH" ]] && git -C "$PROJECT_ROOT" branch -d "$BRANCH" 2>/dev/null; then
         remove_symlinks "$wt"
@@ -1542,11 +1616,11 @@ case "${1:-}" in
     ;;
 
   path)
-    worktree_path "${2:?Error: path requires an issue ID}"
+    worktree_path_for_issue "${2:?Error: path requires an issue ID}"
     ;;
 
   exists)
-    WT_PATH="$(worktree_path "${2:?Error: exists requires an issue ID}")"
+    WT_PATH="$(worktree_path_for_issue "${2:?Error: exists requires an issue ID}")"
     [[ -d "$WT_PATH" ]] && echo "true" || echo "false"
     ;;
 
@@ -1597,7 +1671,7 @@ case "${1:-}" in
     elif WT_PATH="$(current_checkout_path_for_issue "$ARG")"; then
       :
     else
-      WT_PATH="$(worktree_path "$ARG")"
+      WT_PATH="$(worktree_path_for_issue "$ARG")"
     fi
 
     if ! is_git_worktree_path "$WT_PATH"; then
@@ -1671,7 +1745,7 @@ case "${1:-}" in
     elif [[ "$ARG" == */* ]]; then
       WT_PATH="$ARG"
     else
-      WT_PATH="$(worktree_path "$ARG")"
+      WT_PATH="$(worktree_path_for_issue "$ARG")"
     fi
     if ! is_git_worktree_path "$WT_PATH"; then
       echo "Error: Not a git worktree: $WT_PATH" >&2
@@ -1692,7 +1766,7 @@ case "${1:-}" in
     elif [[ "$ARG" == */* ]]; then
       WT_PATH="$ARG"
     else
-      WT_PATH="$(worktree_path "$ARG")"
+      WT_PATH="$(worktree_path_for_issue "$ARG")"
     fi
     if ! is_git_worktree_path "$WT_PATH"; then
       echo "Error: Not a git worktree: $WT_PATH" >&2
@@ -1713,7 +1787,7 @@ case "${1:-}" in
     elif [[ "$ARG" == */* ]]; then
       WT_PATH="$ARG"
     else
-      WT_PATH="$(worktree_path "$ARG")"
+      WT_PATH="$(worktree_path_for_issue "$ARG")"
     fi
     if ! is_git_worktree_path "$WT_PATH"; then
       echo "Error: Not a git worktree: $WT_PATH" >&2
@@ -1763,7 +1837,7 @@ case "${1:-}" in
     elif [[ "$ARG" == */* ]]; then
       WT_PATH="$ARG"
     else
-      WT_PATH="$(worktree_path "$ARG")"
+      WT_PATH="$(worktree_path_for_issue "$ARG")"
     fi
     echo "Codex cleanup hook complete; app owns worktree deletion: $WT_PATH"
     ;;

--- a/skills/worktree/tests/worktree_base_dir.sh
+++ b/skills/worktree/tests/worktree_base_dir.sh
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+# Coverage for vstack#692: external default worktree base dir
+# (<parent-of-checkout>/.worktrees/<checkout-name>), absolute and ~ overrides,
+# canonical (symlink-resolved) path comparisons, and compatibility with
+# worktrees registered under an older base-dir convention.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKTREE_SCRIPT="${WORKTREE_SCRIPT:-$(cd "$TEST_DIR/.." && pwd)/scripts/worktree}"
+TMP_ROOT="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+# Default resolution must come from the script, not an inherited override.
+unset WORKTREE_BASE_DIR
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local got="$1" want="$2" name="$3"
+  if [[ "$got" == "$want" ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$name" "$want" "$got"
+  fi
+}
+
+assert_contains() {
+  local haystack="$1" needle="$2" name="$3"
+  if grep -qF -- "$needle" <<<"$haystack"; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        wanted substring: %s\n        in: %s\n' "$name" "$needle" "$haystack"
+  fi
+}
+
+assert_not_contains() {
+  local haystack="$1" needle="$2" name="$3"
+  if grep -qF -- "$needle" <<<"$haystack"; then
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        unwanted substring: %s\n        in: %s\n' "$name" "$needle" "$haystack"
+  else
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  fi
+}
+
+assert_path_exists() {
+  local path="$1" name="$2"
+  if [[ -e "$path" ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        missing path: %s\n' "$name" "$path"
+  fi
+}
+
+assert_path_absent() {
+  local path="$1" name="$2"
+  if [[ ! -e "$path" ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        unexpected path: %s\n' "$name" "$path"
+  fi
+}
+
+assert_branch_absent() {
+  local repo="$1" branch="$2" name="$3"
+  if git -C "$repo" show-ref --verify --quiet "refs/heads/$branch"; then
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        unexpected branch: %s\n' "$name" "$branch"
+  else
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  fi
+}
+
+# No open PRs anywhere in this file; ownership signals are local/remote refs.
+mkdir -p "$TMP_ROOT/bin"
+cat >"$TMP_ROOT/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+chmod +x "$TMP_ROOT/bin/gh"
+export PATH="$TMP_ROOT/bin:$PATH"
+
+# make_repo ROOT [NAME]: main checkout at ROOT/NAME with a bare origin.
+make_repo() {
+  local root="$1" name="${2:-main}"
+  mkdir -p "$root/$name"
+  git -C "$root/$name" init -q -b main
+  git -C "$root/$name" config user.email test@example.com
+  git -C "$root/$name" config user.name Test
+  git -C "$root/$name" config commit.gpgsign false
+  printf 'base\n' >"$root/$name/base.txt"
+  git -C "$root/$name" add base.txt
+  git -C "$root/$name" commit -q -m base
+  git init -q --bare "$root/origin-$name.git"
+  git -C "$root/$name" remote add origin "$root/origin-$name.git"
+  git -C "$root/$name" push -q -u origin main
+}
+
+echo "=== default base dir: external .worktrees/<repo> beside the checkout ==="
+
+DEFAULT_ROOT="$TMP_ROOT/default"
+make_repo "$DEFAULT_ROOT" repo-a
+make_repo "$DEFAULT_ROOT" repo-b
+
+default_path=$(cd "$DEFAULT_ROOT/repo-a" && "$WORKTREE_SCRIPT" path ISSUE-1)
+assert_eq "$default_path" "$DEFAULT_ROOT/.worktrees/repo-a/issue-1" "default resolves outside the repo to .worktrees/<repo>"
+
+sibling_path=$(cd "$DEFAULT_ROOT/repo-b" && "$WORKTREE_SCRIPT" path ISSUE-1)
+assert_eq "$sibling_path" "$DEFAULT_ROOT/.worktrees/repo-b/issue-1" "sibling repos get distinct default base dirs for the same ID"
+
+default_create_out=$(cd "$DEFAULT_ROOT/repo-a" && "$WORKTREE_SCRIPT" create issue-default)
+assert_eq "$default_create_out" "$DEFAULT_ROOT/.worktrees/repo-a/issue-default" "create lands in the default external base dir"
+assert_path_exists "$DEFAULT_ROOT/.worktrees/repo-a/issue-default/.git" "default-created worktree is registered"
+assert_path_absent "$DEFAULT_ROOT/repo-a/trees" "create adds nothing under the repo root"
+
+# cleanup parses the registry under the new layout and excludes the main
+# checkout by canonical comparison. Its collection semantics are unchanged:
+# a branch checked out in a worktree still refuses `git branch -d`, so the
+# worktree is skipped, and the main checkout is never a candidate.
+set +e
+(cd "$DEFAULT_ROOT/repo-a" && "$WORKTREE_SCRIPT" cleanup >"$DEFAULT_ROOT/cleanup.out" 2>"$DEFAULT_ROOT/cleanup.err")
+cleanup_code=$?
+set -e
+assert_eq "$cleanup_code" "0" "cleanup runs cleanly under the default external layout"
+assert_path_exists "$DEFAULT_ROOT/.worktrees/repo-a/issue-default/.git" "cleanup skips a worktree whose branch is checked out"
+assert_path_exists "$DEFAULT_ROOT/repo-a/base.txt" "cleanup never touches the main checkout"
+
+echo "=== explicit absolute and ~ overrides ==="
+
+abs_path=$(cd "$DEFAULT_ROOT/repo-a" && WORKTREE_BASE_DIR="$DEFAULT_ROOT/abs-base" "$WORKTREE_SCRIPT" path ISSUE-2)
+assert_eq "$abs_path" "$DEFAULT_ROOT/abs-base/issue-2" "absolute WORKTREE_BASE_DIR is honored"
+
+mkdir -p "$DEFAULT_ROOT/home"
+tilde_path=$(cd "$DEFAULT_ROOT/repo-a" && HOME="$DEFAULT_ROOT/home" WORKTREE_BASE_DIR='~/wt' "$WORKTREE_SCRIPT" path ISSUE-2)
+assert_eq "$tilde_path" "$DEFAULT_ROOT/home/wt/issue-2" "~ WORKTREE_BASE_DIR expands against HOME"
+
+echo "=== canonical comparison through a symlinked base dir ==="
+
+SYM_ROOT="$TMP_ROOT/symlinked"
+make_repo "$SYM_ROOT"
+mkdir -p "$SYM_ROOT/real-trees"
+# Compatibility shape: an in-repo `trees` symlink pointing at an external dir.
+ln -s "$SYM_ROOT/real-trees" "$SYM_ROOT/main/trees"
+printf 'WORKTREE_BASE_DIR="trees"\n' >"$SYM_ROOT/main/.env"
+
+sym_create_out=$(cd "$SYM_ROOT/main" && "$WORKTREE_SCRIPT" create issue-sym)
+assert_eq "$sym_create_out" "$SYM_ROOT/main/trees/issue-sym" "create reports the configured (symlinked) path"
+assert_path_exists "$SYM_ROOT/real-trees/issue-sym/.git" "worktree physically lands behind the symlink"
+
+# The same tree addressed through the symlinked spelling is active work, not a
+# foreign/incomplete target.
+set +e
+(cd "$SYM_ROOT/main" && "$WORKTREE_SCRIPT" create issue-sym >"$SYM_ROOT/again.out" 2>"$SYM_ROOT/again.err")
+sym_again_code=$?
+set -e
+sym_again_err="$(cat "$SYM_ROOT/again.err")"
+assert_eq "$sym_again_code" "75" "bare create through the symlink exits 75 for the owned tree"
+assert_contains "$sym_again_err" "Active work already exists" "symlinked spelling is recognized as the same tree"
+assert_not_contains "$sym_again_err" "not a registered worktree" "same tree is never treated as foreign"
+
+# Repoint the config at the physical dir: the tree registered under the
+# symlinked spelling must still be recognized and reusable in place.
+printf 'WORKTREE_BASE_DIR="%s"\n' "$SYM_ROOT/real-trees" >"$SYM_ROOT/main/.env"
+sym_reuse_out=$(cd "$SYM_ROOT/main" && "$WORKTREE_SCRIPT" create issue-sym --reuse)
+assert_eq "$sym_reuse_out" "$SYM_ROOT/real-trees/issue-sym" "--reuse recognizes the tree via its physical path"
+
+sym_remove_out=$(cd "$SYM_ROOT/main" && "$WORKTREE_SCRIPT" remove issue-sym)
+assert_eq "$sym_remove_out" "Removed: $SYM_ROOT/real-trees/issue-sym" "remove works via the physical path"
+assert_path_absent "$SYM_ROOT/real-trees/issue-sym" "removed worktree is gone from the physical dir"
+assert_branch_absent "$SYM_ROOT/main" "issue-sym" "removed merged branch is deleted"
+
+echo "=== foreign worktree behind the configured path is still refused ==="
+
+FOREIGN_ROOT="$TMP_ROOT/foreign"
+make_repo "$FOREIGN_ROOT"
+make_repo "$FOREIGN_ROOT/other"
+git -C "$FOREIGN_ROOT/other/main" worktree add -q -b issue-foreign "$FOREIGN_ROOT/shared-trees/issue-foreign" main
+printf 'keep\n' >"$FOREIGN_ROOT/shared-trees/issue-foreign/marker"
+printf 'secret\n' >"$FOREIGN_ROOT/shared-trees/issue-foreign/.env.local"
+printf 'WORKTREE_BASE_DIR="../shared-trees"\nWORKTREE_SYMLINKS=".env.local"\n' >"$FOREIGN_ROOT/main/.env"
+
+set +e
+(cd "$FOREIGN_ROOT/main" && "$WORKTREE_SCRIPT" create issue-foreign --reuse >"$FOREIGN_ROOT/reuse.out" 2>"$FOREIGN_ROOT/reuse.err")
+foreign_reuse_code=$?
+set -e
+assert_eq "$foreign_reuse_code" "75" "--reuse exits 75 for another repository's worktree"
+assert_contains "$(cat "$FOREIGN_ROOT/reuse.err")" "not a registered worktree" "foreign tree is reported as unregistered, not reused"
+
+set +e
+(cd "$FOREIGN_ROOT/main" && "$WORKTREE_SCRIPT" remove issue-foreign >"$FOREIGN_ROOT/remove.out" 2>"$FOREIGN_ROOT/remove.err")
+foreign_remove_code=$?
+set -e
+assert_eq "$foreign_remove_code" "1" "remove refuses another repository's worktree"
+assert_contains "$(cat "$FOREIGN_ROOT/remove.err")" "refusing to remove" "remove names the refusal"
+assert_path_exists "$FOREIGN_ROOT/shared-trees/issue-foreign/.git" "foreign worktree registration is untouched"
+assert_path_exists "$FOREIGN_ROOT/shared-trees/issue-foreign/marker" "foreign worktree contents are untouched"
+assert_path_exists "$FOREIGN_ROOT/shared-trees/issue-foreign/.env.local" "foreign worktree keeps files matching configured symlink paths"
+
+echo "=== worktrees registered under an older base-dir convention keep working ==="
+
+LEGACY_ROOT="$TMP_ROOT/legacy"
+make_repo "$LEGACY_ROOT"
+# Legacy convention: sibling trees/ dir, registered directly with git.
+git -C "$LEGACY_ROOT/main" worktree add -q -b issue-legacy "$LEGACY_ROOT/trees/issue-legacy" main
+git -C "$LEGACY_ROOT/main" worktree add -q -b issue-legacy-rm "$LEGACY_ROOT/trees/issue-legacy-rm" main
+
+legacy_path=$(cd "$LEGACY_ROOT/main" && "$WORKTREE_SCRIPT" path issue-legacy)
+assert_eq "$legacy_path" "$LEGACY_ROOT/trees/issue-legacy" "path falls back to the registered legacy worktree"
+
+legacy_exists=$(cd "$LEGACY_ROOT/main" && "$WORKTREE_SCRIPT" exists issue-legacy)
+assert_eq "$legacy_exists" "true" "exists sees the registered legacy worktree"
+
+set +e
+(cd "$LEGACY_ROOT/main" && "$WORKTREE_SCRIPT" create issue-legacy >"$LEGACY_ROOT/create.out" 2>"$LEGACY_ROOT/create.err")
+legacy_create_code=$?
+set -e
+assert_eq "$legacy_create_code" "75" "bare create still refuses the active legacy worktree"
+assert_contains "$(cat "$LEGACY_ROOT/create.err")" "$LEGACY_ROOT/trees/issue-legacy" "refusal names the legacy location"
+
+legacy_reuse_out=$(cd "$LEGACY_ROOT/main" && "$WORKTREE_SCRIPT" create issue-legacy --reuse)
+assert_eq "$legacy_reuse_out" "$LEGACY_ROOT/trees/issue-legacy" "--reuse resolves to the legacy worktree unmoved"
+
+set +e
+legacy_restack_err="$(cd "$LEGACY_ROOT/main" && "$WORKTREE_SCRIPT" restack abort issue-legacy 2>&1)"
+legacy_restack_code=$?
+set -e
+assert_eq "$legacy_restack_code" "1" "restack control on a legacy tree fails only on missing paused state"
+assert_contains "$legacy_restack_err" "$LEGACY_ROOT/trees/issue-legacy" "restack resolves the ID to the legacy worktree"
+assert_contains "$legacy_restack_err" "missing a paused rebase" "restack refusal is the paused-state check, not resolution"
+
+printf 'legacy work\n' >"$LEGACY_ROOT/trees/issue-legacy/work.txt"
+git -C "$LEGACY_ROOT/trees/issue-legacy" add work.txt
+git -C "$LEGACY_ROOT/trees/issue-legacy" commit -q -m 'legacy work'
+set +e
+(cd "$LEGACY_ROOT/main" && "$WORKTREE_SCRIPT" push issue-legacy --no-rebase >"$LEGACY_ROOT/push.out" 2>"$LEGACY_ROOT/push.err")
+legacy_push_code=$?
+set -e
+assert_eq "$legacy_push_code" "0" "push resolves the ID to the legacy worktree"
+if git -C "$LEGACY_ROOT/main" ls-remote --exit-code --heads origin issue-legacy >/dev/null 2>&1; then
+  PASS=$((PASS + 1))
+  printf '  ok    push publishes the legacy worktree branch\n'
+else
+  FAIL=$((FAIL + 1))
+  printf '  FAIL  push publishes the legacy worktree branch\n'
+fi
+
+fresh_create_out=$(cd "$LEGACY_ROOT/main" && "$WORKTREE_SCRIPT" create issue-fresh)
+assert_eq "$fresh_create_out" "$LEGACY_ROOT/.worktrees/main/issue-fresh" "new IDs land in the new default while legacy trees drain"
+assert_path_exists "$LEGACY_ROOT/trees/issue-legacy/.git" "legacy worktree stays unmoved (no auto-migration)"
+
+legacy_remove_out=$(cd "$LEGACY_ROOT/main" && "$WORKTREE_SCRIPT" remove issue-legacy-rm)
+assert_eq "$legacy_remove_out" "Removed: $LEGACY_ROOT/trees/issue-legacy-rm" "remove resolves the ID to the legacy worktree"
+assert_path_absent "$LEGACY_ROOT/trees/issue-legacy-rm" "legacy worktree is removed"
+assert_branch_absent "$LEGACY_ROOT/main" "issue-legacy-rm" "legacy merged branch is deleted"
+
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/skills/worktree/tests/worktree_create_active_guard.sh
+++ b/skills/worktree/tests/worktree_create_active_guard.sh
@@ -86,6 +86,9 @@ make_repo() {
   printf 'base\n' >"$root/main/base.txt"
   git -C "$root/main" add base.txt
   git -C "$root/main" commit -q -m base
+  # Pin the historical sibling trees/ base so this file's path assertions stay
+  # explicit; default base-dir resolution is covered by worktree_base_dir.sh.
+  printf 'WORKTREE_BASE_DIR="../trees"\n' >"$root/main/.env"
   git init -q --bare "$root/origin.git"
   git -C "$root/main" remote add origin "$root/origin.git"
   git -C "$root/main" push -q -u origin main

--- a/skills/worktree/tests/worktree_create_restack.sh
+++ b/skills/worktree/tests/worktree_create_restack.sh
@@ -155,6 +155,9 @@ make_repo() {
   printf 'orig\n' > "$repo/file.txt"
   git -C "$repo" add file.txt
   git -C "$repo" commit -q -m base
+  # Pin the historical sibling trees/ base so this file's path assertions stay
+  # explicit; default base-dir resolution is covered by worktree_base_dir.sh.
+  printf 'WORKTREE_BASE_DIR="../trees"\n' > "$repo/.env"
 }
 
 # Build a main+origin pair whose issue worktree diverges from origin/main on

--- a/skills/worktree/tests/worktree_create_secondary_remote.sh
+++ b/skills/worktree/tests/worktree_create_secondary_remote.sh
@@ -76,6 +76,9 @@ git -C "$ROOT/main" config commit.gpgsign false
 printf 'base\n' >"$ROOT/main/base.txt"
 git -C "$ROOT/main" add base.txt
 git -C "$ROOT/main" commit -q -m base
+# Pin the historical sibling trees/ base so this file's path assertions stay
+# explicit; default base-dir resolution is covered by worktree_base_dir.sh.
+printf 'WORKTREE_BASE_DIR="../trees"\n' >"$ROOT/main/.env"
 git init -q --bare "$ROOT/origin.git"
 git -C "$ROOT/main" remote add origin "$ROOT/origin.git"
 git -C "$ROOT/main" push -q -u origin main

--- a/vstack.settings.toml.example
+++ b/vstack.settings.toml.example
@@ -13,8 +13,11 @@
 WORKTREE_DEFAULT_BRANCH = "main"
 # Used by: worktree, orch
 
-WORKTREE_BASE_DIR = "../trees"
-# Used by: worktree. Relative paths resolve from the main checkout.
+# WORKTREE_BASE_DIR = "~/dev/.worktrees/myproject"
+# Used by: worktree. Omit to use the default: <parent-of-checkout>/.worktrees/<checkout-name>,
+# an external per-repo dir beside the checkout. Relative paths resolve from the
+# main checkout. Do not point it inside the repo root: worktree build outputs
+# under the repo can exhaust recursive file-watcher (inotify) budgets.
 
 WORKTREE_SYMLINKS = ".env.local opencode.json .agents .cursor .codex .opencode .pi .claude/settings.json .claude/agents .claude/hooks .claude/skills"
 # Used by: worktree. Include `.env.local` only when worktrees should share local secrets.


### PR DESCRIPTION
Closes #692. In-repo worktree storage caused a workstation incident: an editor watching one repo root ingested ~1.07M entries (~600GB of `trees/*/target`), exhausting the inotify budget and breaking unrelated software. New convention: worktrees live outside repo roots.

- **Default**: unset `WORKTREE_BASE_DIR` now resolves to `<parent>/.worktrees/<repo>` (the old default was a SHARED sibling `../trees` that would collide same-ID worktrees across repos). Absolute + `~` overrides unchanged — and the `~/` expansion is now actually functional (pre-existing bug: the strip pattern itself tilde-expanded, so it never matched).
- **Canonical compares**: one `same_canonical_dir` helper + physical-form PROJECT_ROOT anchor every path guard, so a tree addressed through a compatibility symlink is the same tree, never foreign. Real safety fix in `remove`: it now fail-fasts on non-registered targets BEFORE any mutation (previously it stripped symlink-path files inside a foreign tree first) and the cwd-relocation prefix compare is boundary-aware (`issue-10` no longer matches inside `issue-1`).
- **Migration**: new `worktree_path_for_issue` registry fallback wired through create/remove/push/restack/path/exists/codex-* — legacy in-repo trees keep working unmoved; new IDs land at the external default. codex-setup/cleanup verified path-agnostic. Push/lease/restack authorization semantics untouched.

Validation: 9/9 worktree test files green incl. new worktree_base_dir.sh (41 asserts: no-collision default, symlinked-base same-tree recognition + foreign refusal with untouched contents, full legacy-registration compat); three fixture suites pinned to `../trees` so their ~130 location asserts stay meaningful; Bash 3.2-clean.

https://claude.ai/code/session_016s6ZSLTTRft6fH29wHn1TN