### PR TITLE
fix(#696): decision paths in delegations must come from decider CLI output, verified

### DIFF
--- a/skills/orch/tests/workflow_helpers.sh
+++ b/skills/orch/tests/workflow_helpers.sh
@@ -341,6 +341,33 @@ done
 assert_file_contains "$orch_skill" 'never the bare GitHub issue number' "orch skill states the workflow-state key convention"
 assert_file_contains "$state_schema" 'never the bare GitHub issue number' "workflow-state schema states the key convention"
 
+# vstack#696 — decision-path provenance: during an orch re-review wave the
+# delegation prompt cited two non-existent decision files composed from
+# memory, and a reviewer burned a cycle discovering the real ones. Every
+# workflow that injects decision references must (a) source paths ONLY from
+# the decider CLI's JSON output (the CLI resolves them from the decision
+# index) and (b) verify each path with a single `test -f` before injection,
+# omitting failures with a one-line lookup-failure note instead of passing
+# the broken path through. The delegation templates carry a slot for that
+# note, submit-pr applies the same rule to PR-body decision citations, and
+# the reviewer workflow carries the receiving-side fallback so a stray bad
+# path never costs another review cycle.
+reviewer_review_workflow="$REPO_ROOT/skills/reviewer/workflows/review.md"
+for workflow_path in dev-fix review review-pr review-pr-comments; do
+  workflow="$REPO_ROOT/skills/orch/workflows/$workflow_path.md"
+  assert_file_contains "$workflow" 'ONLY authorized source' "$workflow_path pins the decider CLI JSON output as the only decision-path source"
+  assert_file_contains "$workflow" 'never compose or recall a decision path from memory' "$workflow_path bans memory-composed decision paths"
+  assert_file_contains "$workflow" 'test -f [DECISION_FILE_PATH]' "$workflow_path verifies each decision path before injection"
+  assert_file_contains "$workflow" 'decision index lookup failed for [DECISION_ID]' "$workflow_path omits failed paths with the lookup-failure note"
+  assert_file_contains "$workflow" 'For each decision whose path failed verification' "$workflow_path delegation template carries the failed-verification slot"
+  assert_file_not_contains "$workflow" 'For each matching decision: "' "$workflow_path delegation template injects only verified decisions"
+done
+assert_file_contains "$submit_workflow" 'test -f [DECISION_FILE_PATH]' "submit-pr verifies decision paths cited in the PR body"
+assert_file_contains "$submit_workflow" 'omit entries whose path fails' "submit-pr omits unverified decision paths from the PR body"
+assert_file_contains "$reviewer_review_workflow" 'decision-path provenance rule' "reviewer review workflow names the provenance rule on broken paths"
+assert_file_contains "$reviewer_review_workflow" 'do not hunt for the intended file' "reviewer review workflow stops reviewers from burning a cycle on bad paths"
+assert_file_contains "$reviewer_review_workflow" 'decisions search "[RELEVANT_KEYWORDS]"' "reviewer review workflow routes recovery through the decider CLI"
+
 assert_file_not_contains "$qa_workflow" "Pipe benchmark output" "qa-review avoids pipe-based benchmark recording"
 assert_file_not_contains "$qa_workflow" "pipe results" "qa-review avoids pipe-based perf capture guidance"
 assert_file_contains "$qa_workflow" "Do not use shell pipelines" "qa-review bans Codex-unsafe benchmark shell plumbing"

--- a/skills/orch/workflows/dev-fix.md
+++ b/skills/orch/workflows/dev-fix.md
@@ -106,6 +106,14 @@ Apply [Worktree Scope](../SKILL.md#worktree-scope): if in a worktree and `ISSUE_
    ```
    Collect decision IDs, summaries, and file paths from the JSON output for the `Decisions:` section below. Issue-linked lookup is exactly `decisions search --issue [ISSUE_ID]` — the decisions CLI has no bare `issue` action; never shorten the command in delegation guidance.
 
+   The `path` fields in this JSON output are the ONLY authorized source for decision file paths in delegation guidance — the CLI resolves them from the decision index; never compose or recall a decision path from memory, however plausible the `DXXX-slug` looks (vstack#696). Verify every collected path before injecting it (belt-and-suspenders against index drift) — one simple command per path:
+
+   ```bash
+   test -f [DECISION_FILE_PATH]
+   ```
+
+   **If the check fails**: omit that path and carry the one-line note `- decision index lookup failed for [DECISION_ID]` in the `Decisions:` block instead — a broken path must never reach a specialist.
+
 5. **Delegate** to `[AGENT_TYPE]` agent (reuse existing dev agent if available).
 
    ⚠ Fill placeholders only ([Format Tags Are Literal](../SKILL.md#format-tags-are-literal)). `Recommendation:` = technical fix, not procedure steps. The agent owns validate/commit/return per `dev/workflows/dev-fix.md`.
@@ -123,7 +131,8 @@ Apply [Worktree Scope](../SKILL.md#worktree-scope): if in a worktree and `ISSUE_
    [If qa_agent:] QA: [QA_AGENT]
 
    Decisions:
-   [For each matching decision: "- [DECISION_ID]: [ONE_LINE_SUMMARY] — [DECISION_FILE_PATH]"]
+   [For each verified decision: "- [DECISION_ID]: [ONE_LINE_SUMMARY] — [DECISION_FILE_PATH]"]
+   [For each decision whose path failed verification: "- decision index lookup failed for [DECISION_ID]"]
    [If none: "- No linked decisions found."]
 
    Review items:

--- a/skills/orch/workflows/review-pr-comments.md
+++ b/skills/orch/workflows/review-pr-comments.md
@@ -123,6 +123,14 @@ Output: `threads` (inline) + `comments` (PR-level).
 
 3. **Decision context**: `.agents/skills/decider/scripts/decisions search --issue [ISSUE_ID]`. Collect matching IDs and summaries for § 3 delegation prompt.
 
+   The `path` fields in this JSON output are the ONLY authorized source for decision file paths in delegation guidance — the CLI resolves them from the decision index; never compose or recall a decision path from memory, however plausible the `DXXX-slug` looks (vstack#696). Verify every collected path before injecting it (belt-and-suspenders against index drift) — one simple command per path:
+
+   ```bash
+   test -f [DECISION_FILE_PATH]
+   ```
+
+   **If the check fails**: omit that path and carry the one-line note `decision index lookup failed for [DECISION_ID]` in the decision-context lines instead — a broken path must never reach a domain agent.
+
 ## 2. Detect Domains
 
 Map each comment to a domain based on source and file path. Domain-to-agent routing is project-configurable — example defaults:
@@ -153,7 +161,8 @@ Parent Issue: [ISSUE_ID]
 Worktree: [WORKTREE_PATH]
 
 Decision context (read before classifying — do NOT suggest changes that contradict these):
-[For each matching decision: "[DECISION_ID]: [ONE_LINE_SUMMARY] — [DECISION_FILE_PATH]"]
+[For each verified decision: "[DECISION_ID]: [ONE_LINE_SUMMARY] — [DECISION_FILE_PATH]"]
+[For each decision whose path failed verification: "decision index lookup failed for [DECISION_ID]"]
 [If none: "No linked decisions found."]
 
 Comments for your review:

--- a/skills/orch/workflows/review-pr.md
+++ b/skills/orch/workflows/review-pr.md
@@ -60,6 +60,14 @@ git -C [WORKTREE_PATH] diff "origin/[BASE_BRANCH_FROM_PREVIOUS_COMMAND]"...HEAD 
 
 Collect decision IDs and summaries from the JSON output. If decisions found: include in the delegation prompt below. Agents MUST read cited decisions before suggesting changes that could contradict them.
 
+The `path` fields in this JSON output are the ONLY authorized source for decision file paths in delegation guidance — the CLI resolves them from the decision index; never compose or recall a decision path from memory, however plausible the `DXXX-slug` looks (vstack#696). Verify every collected path before injecting it (belt-and-suspenders against index drift) — one simple command per path:
+
+```bash
+test -f [DECISION_FILE_PATH]
+```
+
+**If the check fails**: omit that path and carry the one-line note `- decision index lookup failed for [DECISION_ID]` in the `Decisions:` block instead — a broken path must never reach a reviewer.
+
 ### 1.2 Check for Re-Review Context
 
 ```bash
@@ -173,7 +181,8 @@ Worktree: [WORKTREE_PATH]
 Branch: [BRANCH]
 
 Decisions:
-[For each matching decision: "- [DECISION_ID]: [ONE_LINE_SUMMARY] — [DECISION_FILE_PATH]"]
+[For each verified decision: "- [DECISION_ID]: [ONE_LINE_SUMMARY] — [DECISION_FILE_PATH]"]
+[For each decision whose path failed verification: "- decision index lookup failed for [DECISION_ID]"]
 [If none: "- No linked decisions found."]
 <if re-review cycle>
 Re-review cycle [N]. Already resolved — do NOT re-report:

--- a/skills/orch/workflows/review.md
+++ b/skills/orch/workflows/review.md
@@ -55,6 +55,14 @@ git diff $DIFF_RANGE --stat
 
 Collect decision IDs and summaries from JSON output.
 
+The `path` fields in this JSON output are the ONLY authorized source for decision file paths in delegation guidance — the CLI resolves them from the decision index; never compose or recall a decision path from memory, however plausible the `DXXX-slug` looks (vstack#696). Verify every collected path before injecting it (belt-and-suspenders against index drift) — one simple command per path:
+
+```bash
+test -f [DECISION_FILE_PATH]
+```
+
+**If the check fails**: omit that path and carry the one-line note `- decision index lookup failed for [DECISION_ID]` in the `Decisions:` block instead — a broken path must never reach a reviewer.
+
 ## 2. Launch Review Agents
 
 **Detect team context:**
@@ -90,7 +98,8 @@ Branch: [BRANCH]
 Diff-range: [DIFF_RANGE]
 
 Decisions:
-[For each matching decision: "- [DECISION_ID]: [ONE_LINE_SUMMARY] — [DECISION_FILE_PATH]"]
+[For each verified decision: "- [DECISION_ID]: [ONE_LINE_SUMMARY] — [DECISION_FILE_PATH]"]
+[For each decision whose path failed verification: "- decision index lookup failed for [DECISION_ID]"]
 [If none: "- No linked decisions found."]
 </delegation_format>
 

--- a/skills/orch/workflows/submit-pr.md
+++ b/skills/orch/workflows/submit-pr.md
@@ -140,7 +140,7 @@ Bot reviews are **asynchronous** in this workflow: GitHub review bots post on th
    [1-3 bullets describing changes]
 
    ## Context
-   [For each matching decision from `.agents/skills/decider/scripts/decisions search --issue [ISSUE_ID]` (decider skill):]
+   [For each matching decision from `.agents/skills/decider/scripts/decisions search --issue [ISSUE_ID]` (decider skill) — paths come from that JSON output only, never from memory, and each is verified with `test -f [DECISION_FILE_PATH]` (one command per path); omit entries whose path fails (vstack#696):]
    - **[DECISION_ID]**: [ONE_LINE_SUMMARY] — `[DECISION_FILE_PATH]`
    [For each research file linked to the issue:]
    - **Research**: [TITLE] — `[RESEARCH_FILE_PATH]`

--- a/skills/reviewer/workflows/review.md
+++ b/skills/reviewer/workflows/review.md
@@ -42,6 +42,8 @@ If a changed path was deleted, inspect it from the git diff or git history; do n
 
 Read decision files listed in delegation. Do NOT suggest changes that contradict them.
 
+If a listed decision file does not exist (`test -f [PATH]` fails), the delegation broke the orchestrator's decision-path provenance rule (vstack#696) — do not hunt for the intended file. Note the broken reference in your returned report and recover decision context directly with `.agents/skills/decider/scripts/decisions search "[RELEVANT_KEYWORDS]"` (decider skill), reading the full files at the paths its JSON output returns.
+
 ### 1.3 Classify Findings
 
 Read the orch skill's recommendation-bias patterns. Apply its decision flow to ALL findings — a finding must pass actionability and relatedness checks before entering `blockers[]` or `suggestions[]`. Then use size to categorize suggestions as `fix` or `issue`.


### PR DESCRIPTION
Closes #696. A review-wave delegation named two hallucinated decision files; the reviewer burned a cycle discovering the real ones. Decision paths reached delegation prompts with no provenance rule and no existence check.

Deterministic fix at all four orch delegation sites (dev-fix, review, review-pr, review-pr-comments) plus the submit-pr PR-body site: the decider CLI's JSON `path` fields are the ONLY authorized source (the CLI resolves from the decision index — never compose a path from memory, however plausible the `DXXX-slug` looks), belt-and-suspenders `test -f` per path before injection (Codex-safe, one command per path), and failed lookups are OMITTED with an explicit `decision index lookup failed for [ID]` slot line instead of passing through. Receiving side (reviewer workflow): a broken path is reported, not hunted — context recovered via `decisions search`.

Validation: workflow_helpers +25 asserts (per-site provenance pins, memory-composition ban, verification step, failure slot, negative assert on the old unverified template line); full orch run-all 16/16; reviewer/decider/dev suites green.

https://claude.ai/code/session_016s6ZSLTTRft6fH29wHn1TN