### PR TITLE
fix(#698): dev sessions count in reviewer slot accounting

### DIFF
--- a/skills/orch/SKILL.md
+++ b/skills/orch/SKILL.md
@@ -364,7 +364,7 @@ Re-delegate for review fix, QA fix, comment fix, or CI fix cycles. Each re-deleg
 
 #### Review Agent Lifecycle Management
 
-Reviewer persistence is budget-conditional: persistent when the budget allows, waves when it does not. `orch-env REVIEWER_SLOT_BUDGET 0` prints the runtime's total concurrent agent-session budget, counting the primary session (`0` = unlimited). Available reviewer slots = budget − 1 (primary) − live persistent agent sessions (`child_sessions` entries with status `active`), minimum 1. Recompute at every review-cycle start — live sessions change between cycles.
+Reviewer persistence is budget-conditional: persistent when the budget allows, waves when it does not. `orch-env REVIEWER_SLOT_BUDGET 0` prints the runtime's total concurrent agent-session budget, counting the primary session (`0` = unlimited). Available reviewer slots = budget − 1 (primary) − live persistent agent sessions (`child_sessions` entries with status `active`; a record with no `status` field counts as active — legacy records predate the status stamp), minimum 1. Recompute at every review-cycle start — live sessions change between cycles.
 
 **Persistent mode** (unlimited budget, or the reviewer set fits the available slots) — review agents persist across fix → re-review cycles:
 - Read `review_agents` and `review_agent_ids` before spawning.

--- a/skills/orch/schemas/workflow-state.md
+++ b/skills/orch/schemas/workflow-state.md
@@ -90,7 +90,7 @@ Persistent state file for orch workflows. Survives context compaction.
 | `branch` | string | Git branch name |
 | `team_name` | string | Agent team name (optional, for recovery) |
 | `qa_labels` | string[] | QA trigger labels from dev return |
-| `child_sessions` | object | Per-agent lifecycle keyed by logical agent name: `{agent: {status, agent_id, runtime_agent_type, agent_type_fallback, spawned_at}}` |
+| `child_sessions` | object | Per-agent lifecycle keyed by logical agent name: `{agent: {status, agent_id, runtime_agent_type, agent_type_fallback, spawned_at}}`. `status` is `"active"` while the session is live (`dev-start.md` § 2 stamps it at spawn) and `"closed"` once the caller's shutdown step retires it (`start-worktree.md` § 5.5). Reviewer slot accounting treats a record with a missing `status` field as active — legacy records predate the field (vstack#698) |
 | `review_agents` | string[] | Reviewer names currently expected to stay alive across fix/re-review cycles; in wave mode (`REVIEWER_SLOT_BUDGET` exceeded) only the currently launched wave |
 | `review_agent_ids` | object | Reviewer session IDs keyed by name — reuse before spawning `{"name":"id",...}` |
 | `review_agent_runtime_types` | object | Reviewer runtime agent metadata keyed by logical reviewer name: `{name: {agent_type, fallback}}`; records Codex `worker` fallback without changing logical keys |

--- a/skills/orch/tests/workflow_helpers.sh
+++ b/skills/orch/tests/workflow_helpers.sh
@@ -368,6 +368,27 @@ assert_file_contains "$reviewer_review_workflow" 'decision-path provenance rule'
 assert_file_contains "$reviewer_review_workflow" 'do not hunt for the intended file' "reviewer review workflow stops reviewers from burning a cycle on bad paths"
 assert_file_contains "$reviewer_review_workflow" 'decisions search "[RELEVANT_KEYWORDS]"' "reviewer review workflow routes recovery through the decider CLI"
 
+# vstack#698 — dev-session status in reviewer slot accounting: the dev-start
+# persistence write recorded child_sessions without a status field while the
+# review-pr live-session query counted only status == "active", so a live
+# persistent dev agent freed a phantom slot and reviewer fan-out hit the
+# runtime thread limit. Both sides are fixed for defense in depth: the writer
+# stamps status "active", the reader defaults a missing status to active
+# (legacy records persist in workflow-state files across sessions), the
+# schema documents the back-compat rule, and the start-worktree shutdown
+# step retires records to "closed".
+dev_start_workflow="$REPO_ROOT/skills/orch/workflows/dev-start.md"
+start_worktree_workflow="$REPO_ROOT/skills/orch/workflows/start-worktree.md"
+assert_file_contains "$dev_start_workflow" '.child_sessions["[AGENT_TYPE]"] = {"status": "active"' "dev-start persistence write stamps status active"
+assert_file_contains "$dev_start_workflow" 'marks the session live for reviewer slot accounting' "dev-start explains why the status stamp matters"
+assert_file_contains "$review_pr_workflow" '(.value.status // "active") == "active"' "review-pr live-session count defaults a missing status to active"
+assert_file_not_contains "$review_pr_workflow" 'select(.value.status == "active")' "review-pr drops the strict status match that missed legacy records"
+assert_file_contains "$review_pr_workflow" 'record with no `status` field counts as active' "review-pr documents the legacy-record back-compat rule"
+assert_file_contains "$state_schema" 'missing `status` field as active' "workflow-state schema documents missing-status-means-active"
+assert_file_contains "$state_schema" '"status": "active"' "workflow-state schema example shows an active child session"
+assert_file_contains "$start_worktree_workflow" '.value.status = "closed"' "start-worktree shutdown retires child sessions to closed"
+assert_file_contains "$orch_skill" 'a record with no `status` field counts as active' "orch skill slot-accounting note carries the back-compat rule"
+
 assert_file_not_contains "$qa_workflow" "Pipe benchmark output" "qa-review avoids pipe-based benchmark recording"
 assert_file_not_contains "$qa_workflow" "pipe results" "qa-review avoids pipe-based perf capture guidance"
 assert_file_contains "$qa_workflow" "Do not use shell pipelines" "qa-review bans Codex-unsafe benchmark shell plumbing"

--- a/skills/orch/workflows/dev-start.md
+++ b/skills/orch/workflows/dev-start.md
@@ -104,8 +104,10 @@ Before each implementation delegation, capture the current `HEAD`:
 
 **After each spawn**, persist the agent session:
 ```bash
-.agents/skills/orch/scripts/workflow-state update [ISSUE_ID] '.child_sessions["[AGENT_TYPE]"] = {"agent_id": "[AGENT_OR_TASK_ID]", "runtime_agent_type": "[RUNTIME_AGENT_TYPE]", "agent_type_fallback": [FALLBACK_REASON_JSON_OR_NULL]}'
+.agents/skills/orch/scripts/workflow-state update [ISSUE_ID] '.child_sessions["[AGENT_TYPE]"] = {"status": "active", "agent_id": "[AGENT_OR_TASK_ID]", "runtime_agent_type": "[RUNTIME_AGENT_TYPE]", "agent_type_fallback": [FALLBACK_REASON_JSON_OR_NULL]}'
 ```
+
+`"status": "active"` marks the session live for reviewer slot accounting (`review-pr.md` § 2 counts active child sessions when computing wave sizes) — omitting it makes a live dev agent free a phantom reviewer slot (vstack#698). Only the caller's finalization step retires the record (`start-worktree.md` § 5.5 sets `status` to `"closed"`).
 
 ### If Single Issue
 

--- a/skills/orch/workflows/review-pr.md
+++ b/skills/orch/workflows/review-pr.md
@@ -103,8 +103,10 @@ Use the output as `AGENTS`. If the command fails or prints no agents, skip revie
 The printed value is `SLOT_BUDGET` — the runtime's total concurrent agent-session budget, counting this primary session (`0` = unlimited; Codex collaboration runtime: `4`). If `SLOT_BUDGET` is `0`, use **persistent mode** — today's semantics: every reviewer launches before the coordinated delegation batch and stays alive through fix/re-review cycles. Otherwise count the live persistent agent sessions:
 
 ```bash
-.agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.child_sessions // {} | [to_entries[] | select(.value.status == "active")] | length'
+.agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.child_sessions // {} | [to_entries[] | select((.value.status // "active") == "active")] | length'
 ```
+
+A record with no `status` field counts as active — legacy child-session records written before the `status` stamp (vstack#698) persist in workflow-state files, and an unretired record means a live dev/QA session holding a slot.
 
 Use the output as `LIVE_AGENTS`, then compute `REVIEWER_SLOTS = SLOT_BUDGET - 1 - LIVE_AGENTS` (minimum `1`; the `1` is this primary session). If the `[AGENTS]` count fits within `REVIEWER_SLOTS`, use persistent mode. If it exceeds `REVIEWER_SLOTS`, use **wave mode**: run reviewers in sequential waves of up to `REVIEWER_SLOTS` (§ 2.2), retiring each completed session to release its slot. One policy, two modes: persistent when the budget allows, waves when it does not. Recompute the mode at every § 2 entry — live sessions change between cycles.
 

--- a/skills/orch/workflows/start-worktree.md
+++ b/skills/orch/workflows/start-worktree.md
@@ -158,6 +158,11 @@ If invoked as `start github OWNER/REPO#N`, parse it before initialization:
 ### 5.5 Shutdown Team
 
 1. Terminate all still-active agents from `child_sessions` in workflow state.
+2. Retire the terminated records so reviewer slot accounting (`review-pr.md` § 2) stops counting them:
+
+   ```bash
+   .agents/skills/orch/scripts/workflow-state update [ISSUE_ID] '.child_sessions = ((.child_sessions // {}) | with_entries(.value.status = "closed"))'
+   ```
 
 ### 5.6 Offer Merge
 


### PR DESCRIPTION
Closes #698. The #644 wave design's LIVE_AGENTS query counts only `child_sessions` records with `status == "active"`, but dev-start § 2's documented persistence expression never wrote a status — a live persistent dev agent counted as 0, so reviewer fan-out overestimated available Codex slots and hit runtime spawn failures.

Fixed at all layers: dev-start's writer stamps `status: "active"`; review-pr's reader tolerates legacy records (`(.value.status // "active") == "active"`); start-worktree § 5.5 — which terminated agents but never touched their records — now retires them (`with_entries(.value.status = "closed")`); the schema documents the lifecycle and the missing-status-means-active back-compat rule, mirrored in SKILL.md's slot-budget prose so they can't drift.

Validation: +9 doc-contract asserts (writer stamp, tolerant-reader form with a negative on the old strict form, schema text, retire expression); full orch run-all 16/16 (workflow_helpers 232/232); the three jq expressions functionally verified against a real state file (active=1, legacy=1, post-retire=0).

https://claude.ai/code/session_016s6ZSLTTRft6fH29wHn1TN