### PR TITLE
fix(#704): tracker-route qa-review context reads

### DIFF
--- a/skills/orch/workflows/review-pr.md
+++ b/skills/orch/workflows/review-pr.md
@@ -419,6 +419,7 @@ If >4 suggestion items: show first 3 + `All N fixes`. Refine via "Other".
    Follow workflow: .agents/skills/reviewer/workflows/qa-review.md
 
    Issue: [ISSUE_ID]
+   Tracker: [TRACKER] [OWNER/REPO]
    Branch: [BRANCH]
    Worktree: [WORKTREE_PATH]
    Trigger: [needs-* label]
@@ -432,6 +433,8 @@ If >4 suggestion items: show first 3 + `All N fixes`. Refine via "Other".
    - Escalated (accepted): [For each escalated_item with source "qa-review": "[DESCRIPTION] — [REASON]"]
    - Do NOT re-report fixed or escalated items. Only report NEW issues or regressions introduced by the fixes.
    </delegation_format>
+
+   Omit `[OWNER/REPO]` when `TRACKER=linear`.
 
 4. **Wait for completion.**
 

--- a/skills/reviewer/tests/tracker-routing-contract.test.sh
+++ b/skills/reviewer/tests/tracker-routing-contract.test.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Regression test for tracker-conditional QA-review context reads (#704, the
+# #655 tracker-routing class reaching the reviewer skill).
+# qa-review.md is a markdown contract, so this test statically verifies that
+# the workflow resolves tracker context once before any tracker command, keeps
+# the Linear cache reads inside an explicit Linear route, gives the GitHub
+# route an exact live-read command, and carries no unconditional `linear.sh`
+# in any shared section — a GitHub-tracked QA review must never emit Linear
+# cache failures. Also verifies the orch caller passes tracker context in the
+# QA delegation (when orch is present).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+require_pattern() {
+  local file="$1" pattern="$2" desc="$3"
+  if ! grep -Eq -- "$pattern" "$file"; then
+    fail "$desc missing in ${file#$SKILL_DIR/}"
+  fi
+}
+
+require_fixed() {
+  local file="$1" needle="$2" desc="$3"
+  if ! grep -Fq -- "$needle" "$file"; then
+    fail "$desc missing in ${file#$SKILL_DIR/}"
+  fi
+}
+
+qa_review="$SKILL_DIR/workflows/qa-review.md"
+[[ -f "$qa_review" ]] || fail "workflow not found: workflows/qa-review.md"
+
+# --- qa-review 1.1: tracker resolution happens once, before any tracker command ---
+
+require_pattern "$qa_review" '1\.1 Resolve Tracker' 'tracker resolution section'
+require_pattern "$qa_review" 'Resolve tracker context once, before any tracker command' 'resolve-once rule'
+require_pattern "$qa_review" 'explicit `Tracker:` value in the delegation prompt' 'delegation-context precedence'
+require_pattern "$qa_review" 'starting with `issue-` → `github`; otherwise `linear`' 'issue-id inference fallback'
+require_fixed "$qa_review" 'gh repo view --json nameWithOwner --jq .nameWithOwner' 'repository resolution for inferred github tracker'
+require_pattern "$qa_review" 'Store the result as `TRACKER`' 'TRACKER stored once'
+
+# --- qa-review 1.1: GitHub reviews degrade explicitly, never silently ---
+
+require_pattern "$qa_review" 'GitHub reviews must not run Linear commands' 'GitHub no-Linear rule'
+require_pattern "$qa_review" 'A missing Linear cache is not an error for a GitHub-tracked review' 'missing-cache-not-an-error rule'
+require_pattern "$qa_review" 'do not silently fall back to the other tracker' 'no-silent-fallback rule'
+
+# --- qa-review 1.2: context read is tracker-conditional ---
+
+require_pattern "$qa_review" '\*\*Linear route \(TRACKER=linear\)\*\*' 'Linear context-read route'
+require_pattern "$qa_review" '\*\*GitHub route \(TRACKER=github\)\*\*' 'GitHub context-read route'
+require_fixed "$qa_review" '.agents/skills/linear/scripts/linear.sh cache issues get [ISSUE_ID]' 'Linear issue cache read retained in Linear route'
+require_fixed "$qa_review" '.agents/skills/linear/scripts/linear.sh cache comments list [ISSUE_ID]' 'Linear comments cache read retained in Linear route'
+require_fixed "$qa_review" 'gh issue view [N] --repo [OWNER/REPO] --json number,title,body,comments,labels,url' 'GitHub live issue/comments read'
+
+# --- qa-review: no `linear.sh` outside the Linear route (shared sections clean) ---
+
+linear_route="$tmp/linear-route.md"
+sed -n '/^\*\*Linear route (TRACKER=linear)\*\*/,/^\*\*GitHub route (TRACKER=github)\*\*/p' "$qa_review" > "$linear_route"
+[[ -s "$linear_route" ]] || fail 'Linear route section could not be extracted'
+grep -Fq 'linear.sh' "$linear_route" || fail 'extracted Linear route contains no linear.sh command (extraction broken)'
+
+shared="$tmp/shared-sections.md"
+sed '/^\*\*Linear route (TRACKER=linear)\*\*/,/^\*\*GitHub route (TRACKER=github)\*\*/d' "$qa_review" > "$shared"
+[[ -s "$shared" ]] || fail 'shared sections could not be extracted'
+if grep -Fq 'linear.sh' "$shared"; then
+  fail 'unconditional linear.sh reference outside the Linear route in qa-review.md'
+fi
+
+# --- orch caller: QA delegation carries tracker context (when orch is present) ---
+
+review_pr="$SKILL_DIR/../orch/workflows/review-pr.md"
+if [[ -f "$review_pr" ]]; then
+  qa_delegation="$tmp/qa-delegation.md"
+  sed -n '/qa-review\.md/,/<\/delegation_format>/p' "$review_pr" > "$qa_delegation"
+  [[ -s "$qa_delegation" ]] || fail 'QA delegation format could not be extracted from orch review-pr.md'
+  require_fixed "$qa_delegation" 'Tracker: [TRACKER] [OWNER/REPO]' 'tracker context in orch QA delegation'
+  require_pattern "$review_pr" 'Omit `\[OWNER/REPO\]` when `TRACKER=linear`' 'linear repository-omission note in orch QA delegation'
+fi
+
+echo "all pass"

--- a/skills/reviewer/workflows/qa-review.md
+++ b/skills/reviewer/workflows/qa-review.md
@@ -10,11 +10,34 @@ QA agents are review-only. They are never assigned as issue owners.
 
 ## 1. Set Up
 
-### 1.1 Read Context
+### 1.1 Resolve Tracker
+
+Resolve tracker context once, before any tracker command. Every later tracker-specific read routes through it. Precedence:
+
+1. **Delegation context**: an explicit `Tracker:` value in the delegation prompt (with `[OWNER/REPO]` for `github`).
+2. **Inference fallback**: `[ISSUE_ID]` starting with `issue-` → `github`; otherwise `linear`. The GitHub issue number `[N]` is `[ISSUE_ID]` without the `issue-` prefix (orch key normalization). For `github` with no repository value, resolve it in the worktree:
+
+   ```bash
+   gh repo view --json nameWithOwner --jq .nameWithOwner
+   ```
+
+Store the result as `TRACKER`, plus `[OWNER/REPO]` when `TRACKER=github`.
+
+**GitHub reviews must not run Linear commands**: when `TRACKER=github`, no `sync`, Linear cache read, or Linear mutation may run anywhere in this workflow. A missing Linear cache is not an error for a GitHub-tracked review — read live GitHub context instead (§ 1.2). If a tracker read fails on the resolved route, report the gap in your review output; do not silently fall back to the other tracker.
+
+### 1.2 Read Context
+
+**Linear route (TRACKER=linear)**:
 
 ```bash
 .agents/skills/linear/scripts/linear.sh cache issues get [ISSUE_ID]
 .agents/skills/linear/scripts/linear.sh cache comments list [ISSUE_ID]
+```
+
+**GitHub route (TRACKER=github)** — read the live issue body and comments in one command:
+
+```bash
+gh issue view [N] --repo [OWNER/REPO] --json number,title,body,comments,labels,url
 ```
 
 Extract from delegation prompt:
@@ -136,7 +159,7 @@ File: [WORKTREE_PATH]/tmp/review-[AGENT]-YYYYMMDD-HHMMSS.json
 ## Constraints
 
 **Do NOT**:
-- Claim the issue (`.agents/skills/linear/scripts/linear.sh issues activate`)
+- Claim the issue (Linear `issues activate`, GitHub self-assign)
 - Modify issue tracker state (labels, status)
 - Mark issue done
 - Create commits for code changes or push changes


### PR DESCRIPTION
Closes #704. The reviewer QA workflow § 1.1 unconditionally ran `linear.sh cache` reads even for GitHub-tracker sessions — noisy failures before recovery. Now (mirroring #655's pattern): tracker resolved ONCE (caller-supplied `Tracker:` line — review-pr § 6.3 now sends it — with `issue-N` prefix inference fallback per the #660 key convention); Linear route keeps the cache reads; GitHub route reads live body+comments in one Codex-safe `gh issue view --json` command; explicit-degradation rules (no Linear commands anywhere under github; failures reported, never silently tracker-swapped). Full audit confirmed those two reads were the only tracker-specific commands in the workflow.

Validation: new reviewer tracker-routing-contract test (sed-extract proof of zero `linear.sh` outside the Linear route, with extraction-sanity teeth); reviewer 3/3, project-management 7/7, orch run-all 16/16.

https://claude.ai/code/session_016s6ZSLTTRft6fH29wHn1TN