### PR TITLE
fix(#705): bare-word gate-mode values; tolerant reader for quote-corrupted state

### DIFF
--- a/skills/orch/schemas/workflow-state.md
+++ b/skills/orch/schemas/workflow-state.md
@@ -117,11 +117,14 @@ All operations use `.agents/skills/orch/scripts/workflow-state` (run with `help`
 
 To target a state directory from a worktree, pass the global `--state-dir <path>` flag before the subcommand — it takes precedence over `ORCH_STATE_DIR`. Prefer it over an `ORCH_STATE_DIR=… workflow-state …` env prefix, which is rejected under Codex `approval=never` as a flagged command shape; a plain flag is classifier-safe. `ORCH_STATE_DIR` stays supported as an environment fallback.
 
+`set` and `append` values are JSON only when they look like it — a `{`/`[` prefix, exactly `null`/`true`/`false`, or all digits. Every other value is stored as a raw string, so pass plain strings bare: `set PROJ-123 pr_review.mode review`, never `'"review"'` (the quotes would be stored literally — vstack#705). `update` always takes a jq expression.
+
 ```bash
 .agents/skills/orch/scripts/workflow-state init PROJ-123 --agent backend --worktree /tmp/wt
 .agents/skills/orch/scripts/workflow-state get PROJ-123 .cycles
 .agents/skills/orch/scripts/workflow-state increment PROJ-123 cycles
 .agents/skills/orch/scripts/workflow-state append PROJ-123 json_paths "review.json"
+.agents/skills/orch/scripts/workflow-state set PROJ-123 pr_review.mode review
 .agents/skills/orch/scripts/workflow-state set PROJ-123 pr_review_baseline '{"last_ts":"2026-01-28","last_threads":2}'
 .agents/skills/orch/scripts/workflow-state --state-dir /path/to/tmp append PROJ-123 fixed_items '{"description":"Fix"}'
 ```

--- a/skills/orch/scripts/workflow-state
+++ b/skills/orch/scripts/workflow-state
@@ -308,7 +308,10 @@ Commands:
   update <issue_id> <jq_expr>   Run arbitrary jq expression
   append <issue_id> <field> <value>   Append to array field
   increment <issue_id> <field>  Increment numeric field
-  set <issue_id> <field> <value>  Set field value
+  set <issue_id> <field> <value>  Set field value ({/[ prefix, null/true/false,
+                                or all digits parse as JSON; anything else is
+                                stored as a raw string — pass strings bare,
+                                never pre-quoted '"..."')
   set-git-head <issue_id> <field> [worktree]  Set field to current HEAD SHA
   set-now <issue_id> <field>     Set field to current epoch seconds
   path <issue_id>               Print state file path
@@ -330,6 +333,7 @@ Examples:
   workflow-state increment PROJ-123 pr_comment_review.iterations
   workflow-state append PROJ-123 json_paths "review.json"
   workflow-state append PROJ-123 fixed_items '{"description":"Fix","commit":"abc"}'
+  workflow-state set PROJ-123 pr_review.mode review
   workflow-state set PROJ-123 pr_review_baseline '{"last_ts":"2026-01-28","last_threads":2}'
   workflow-state set-git-head PROJ-123 pre_delegate_sha /tmp/wt
   workflow-state set-now PROJ-123 review_delegated_at

--- a/skills/orch/tests/workflow-state-set-string-semantics.sh
+++ b/skills/orch/tests/workflow-state-set-string-semantics.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# Regression tests for vstack#705: `workflow-state set` stores non-JSON values
+# as RAW strings — it never parses JSON string literals. submit-pr § 4 used to
+# document `set … pr_review.mode '"[GATE_MODE]"'`, which stored the quote
+# characters literally (serialized `"\"review\""`) and broke the § 6.1 gate 4
+# mode comparison. Pinned here:
+#   1. set semantics: a `{`/`[` prefix, exactly null/true/false, or an
+#      all-digit value splices as JSON; every other value — including one that
+#      starts with a double quote — is stored verbatim via `jq --arg`.
+#      `append` shares the `{`/`[` hybrid; `update` is always a jq expression.
+#   2. The fixed submit-pr § 4 shapes (bare `[GATE_MODE]` / `off`) store clean
+#      strings, and the § 6.1 gate 4 tolerant read (`gsub`-strip) resolves
+#      clean, legacy quote-corrupted, legacy-gate-only, and empty states alike.
+#   3. Docs lint (with injected-offender teeth): no `workflow-state set` line
+#      in skills/**/*.md may wrap its value in the `'"…"'` idiom.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../.." && pwd)"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+WS="$REPO_ROOT/skills/orch/scripts/workflow-state"
+SUBMIT_DOC="$REPO_ROOT/skills/orch/workflows/submit-pr.md"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local got="$1" want="$2" name="$3"
+  if [[ "$got" == "$want" ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$name" "$want" "$got"
+  fi
+}
+
+assert_file_contains() {
+  local file="$1" needle="$2" name="$3"
+  if grep -qF "$needle" "$file"; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        missing in %s: %s\n' "$name" "$file" "$needle"
+  fi
+}
+
+echo "=== workflow-state set raw-string semantics (vstack#705) ==="
+
+# --- Part 1: set / update / append value semantics -------------------------
+
+sd="$TMP_ROOT/state"
+"$WS" --state-dir "$sd" init issue-705 \
+  --worktree "$REPO_ROOT" --branch issue-705 >/dev/null
+sf="$sd/workflow-state-issue-705.json"
+
+# Test 1: a bare string stores a clean JSON string.
+"$WS" --state-dir "$sd" set issue-705 pr_review.mode review
+assert_eq "$(jq -c '.pr_review.mode' "$sf")" '"review"' \
+  "bare-string set stores a clean JSON string"
+
+# Test 2 (pinned raw semantics): a pre-quoted value stores the quote
+# characters literally — set never parses JSON string literals.
+"$WS" --state-dir "$sd" set issue-705 pr_review.mode '"review"'
+assert_eq "$(jq -c '.pr_review.mode' "$sf")" '"\"review\""' \
+  "pre-quoted set stores literal quote characters (raw-string semantics)"
+
+# Test 3: JSON-looking values splice as JSON; `off` is none of them.
+"$WS" --state-dir "$sd" set issue-705 pr_review_baseline '{"last_ts":"t","last_threads":2}'
+assert_eq "$(jq -r '.pr_review_baseline | type' "$sf")" "object" \
+  "set splices a {…} value as a JSON object"
+"$WS" --state-dir "$sd" set issue-705 review_agents '["a"]'
+assert_eq "$(jq -c '.review_agents' "$sf")" '["a"]' \
+  "set splices a […] value as a JSON array"
+"$WS" --state-dir "$sd" set issue-705 skip_qa true
+assert_eq "$(jq -c '.skip_qa' "$sf")" "true" \
+  "set splices true as a JSON boolean"
+"$WS" --state-dir "$sd" set issue-705 pre_delegate_sha null
+assert_eq "$(jq -r '.pre_delegate_sha | type' "$sf")" "null" \
+  "set splices null as JSON null"
+"$WS" --state-dir "$sd" set issue-705 cycles 7
+assert_eq "$(jq -c '.cycles' "$sf")" "7" \
+  "set splices an all-digit value as a JSON number"
+"$WS" --state-dir "$sd" set issue-705 pr_approval.gate off
+assert_eq "$(jq -c '.pr_approval.gate' "$sf")" '"off"' \
+  "set stores off as the clean string it looks like"
+
+# Test 4: update is a jq expression — string literals need their JSON quotes.
+"$WS" --state-dir "$sd" update issue-705 '.pr_approval.gate = "off"'
+assert_eq "$(jq -c '.pr_approval.gate' "$sf")" '"off"' \
+  "update applies jq-expression (JSON) semantics"
+
+# Test 5: append shares the hybrid — bare strings verbatim, {/[ as JSON.
+"$WS" --state-dir "$sd" append issue-705 json_paths plain.json
+"$WS" --state-dir "$sd" append issue-705 json_paths '"quoted.json"'
+"$WS" --state-dir "$sd" append issue-705 fixed_items '{"description":"x"}'
+assert_eq "$(jq -c '.json_paths' "$sf")" '["plain.json","\"quoted.json\""]' \
+  "append stores bare strings clean and pre-quoted strings verbatim"
+assert_eq "$(jq -r '.fixed_items[0] | type' "$sf")" "object" \
+  "append splices a {…} value as a JSON object"
+
+# --- Part 2: documented § 4 shapes + § 6.1 gate 4 tolerant read ------------
+
+TOLERANT_READ='(.pr_review.mode // .pr_approval.gate // "") | gsub("\"";"")'
+
+# Clean state written by the fixed § 4 commands.
+"$WS" --state-dir "$sd" init issue-705c \
+  --worktree "$REPO_ROOT" --branch issue-705 >/dev/null
+"$WS" --state-dir "$sd" set issue-705c pr_review.mode off
+"$WS" --state-dir "$sd" set issue-705c pr_approval.gate off
+assert_eq "$("$WS" --state-dir "$sd" get issue-705c "$TOLERANT_READ")" "off" \
+  "gate 4 read resolves a clean recorded mode"
+
+# Legacy state corrupted by the pre-#705 quoted idiom.
+"$WS" --state-dir "$sd" init issue-705l \
+  --worktree "$REPO_ROOT" --branch issue-705 >/dev/null
+"$WS" --state-dir "$sd" set issue-705l pr_review.mode '"off"'
+"$WS" --state-dir "$sd" set issue-705l pr_approval.gate '"off"'
+assert_eq "$("$WS" --state-dir "$sd" get issue-705l "$TOLERANT_READ")" "off" \
+  "gate 4 read tolerates legacy quote-corrupted state"
+
+# Older state with only the legacy gate field recorded.
+"$WS" --state-dir "$sd" init issue-705g \
+  --worktree "$REPO_ROOT" --branch issue-705 >/dev/null
+"$WS" --state-dir "$sd" set issue-705g pr_approval.gate off
+assert_eq "$("$WS" --state-dir "$sd" get issue-705g "$TOLERANT_READ")" "off" \
+  "gate 4 read falls back to the legacy pr_approval.gate field"
+
+# Nothing recorded at all → empty, never an error.
+"$WS" --state-dir "$sd" init issue-705e \
+  --worktree "$REPO_ROOT" --branch issue-705 >/dev/null
+assert_eq "$("$WS" --state-dir "$sd" get issue-705e "$TOLERANT_READ")" "" \
+  "gate 4 read yields empty when no mode was recorded"
+
+# The docs must carry exactly these shapes.
+assert_file_contains "$SUBMIT_DOC" \
+  "workflow-state set [ISSUE_ID] pr_review.mode [GATE_MODE]" \
+  "submit-pr records the gate mode as a bare word"
+assert_file_contains "$SUBMIT_DOC" \
+  "workflow-state set [ISSUE_ID] pr_approval.gate off" \
+  "submit-pr records the legacy off gate as a bare word"
+assert_file_contains "$SUBMIT_DOC" "$TOLERANT_READ" \
+  "submit-pr gate 4 documents the quote-tolerant mode read"
+
+# --- Part 3: docs lint — no set line may carry a '"…"'-wrapped value -------
+
+# scan_set_quoted <file>
+# Emits every line that invokes `workflow-state set` (the helper path token
+# followed by the plain `set` subcommand) AND contains the two-character
+# sequence  '"  — the single-quoted-double-quote idiom. The JSON-object idiom
+# `set … '{"k":…}'` never puts those two characters adjacent, so it is not
+# flagged; neither are set-git-head/set-now lines (no ` set ` token).
+scan_set_quoted() {
+  grep -n "scripts/workflow-state" "$1" 2>/dev/null \
+    | grep " set " | grep -F "'\"" || true
+}
+
+offenders=""
+while IFS= read -r doc; do
+  out="$(scan_set_quoted "$doc")"
+  [[ -n "$out" ]] && offenders+="$doc: $out"$'\n'
+done < <(find "$REPO_ROOT/skills" -name '*.md' | LC_ALL=C sort)
+
+if [[ -z "$offenders" ]]; then
+  PASS=$((PASS + 1))
+  printf '  ok    %s\n' "no skills doc passes workflow-state set a quote-wrapped value"
+else
+  FAIL=$((FAIL + 1))
+  printf '  FAIL  %s\n' "workflow-state set lines carry '\"…\"'-wrapped values:"
+  printf '%s' "$offenders" | sed 's/^/          /'
+fi
+
+# Teeth: the scanner flags an injected offender and accepts the legal shapes.
+scratch="$TMP_ROOT/inject.md"
+
+printf '%s\n' ".agents/skills/orch/scripts/workflow-state set [ISSUE_ID] pr_review.mode '\"[GATE_MODE]\"'" > "$scratch"
+assert_eq "$([[ -n "$(scan_set_quoted "$scratch")" ]] && echo flagged)" "flagged" \
+  "lint flags a set line with a '\"…\"'-wrapped value"
+
+printf '%s\n' ".agents/skills/orch/scripts/workflow-state set [ISSUE_ID] pr_review.mode [GATE_MODE]" > "$scratch"
+assert_eq "$([[ -z "$(scan_set_quoted "$scratch")" ]] && echo clean)" "clean" \
+  "lint accepts the bare-word set shape"
+
+printf '%s\n' ".agents/skills/orch/scripts/workflow-state set [ISSUE_ID] pr_review_baseline '{\"last_ts\":\"x\",\"last_threads\":1}'" > "$scratch"
+assert_eq "$([[ -z "$(scan_set_quoted "$scratch")" ]] && echo clean)" "clean" \
+  "lint accepts the JSON-object set idiom"
+
+printf '%s\n' ".agents/skills/orch/scripts/workflow-state set-git-head [ISSUE_ID] pre_delegate_sha '\"x\"'" > "$scratch"
+assert_eq "$([[ -z "$(scan_set_quoted "$scratch")" ]] && echo clean)" "clean" \
+  "lint scopes to the plain set subcommand (set-git-head untouched)"
+
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/skills/orch/workflows/submit-pr.md
+++ b/skills/orch/workflows/submit-pr.md
@@ -300,15 +300,15 @@ The printed value is `GATE_MODE` — `approval`, `review`, or `off`. The resolut
 - **`review`** — wait for a formal review of the **current head commit** from any non-author reviewer, in any state: COMMENTED counts, and an approval is also a review. This is the correct mode for commenting-only review bots (Devin- or Codex-style reviewers) that never mark PRs APPROVED — under `approval` mode their COMMENTED reviews would idle every PR to timeout. The mode carries an obligation: once the review arrives, triage every reviewer comment, reply to each thread, and resolve all threads — the gate passes only at reviewed-at-head with zero unresolved threads, and only then does § 5 Verify CI run. While waiting, approval-wait itself nudges a reviewer that stays silent past `PR_REVIEW_NUDGE_SECS` (see Nudging below). Some review bots submit a review object only when they have findings, so a clean re-analysis would leave this predicate unsatisfiable (vstack#654): set `PR_REVIEW_CHECK` to the exact name the trusted review bot publishes on analyzed heads (e.g. `Devin Review`) and a `success` signal of that name on the current head also satisfies the review-received predicate — matched on either evidence surface, a check-run conclusion or a commit-status context (vstack#681: some bots publish statuses, not check-runs) — every other condition (no standing CHANGES_REQUESTED, zero unresolved threads) still applies, and the JSON result names the satisfying signal in `review_evidence` (`"review"` or `"check"`; with `"check"`, `review_evidence_surface` reports `"check_run"` or `"status"`). Both surfaces are matched by name/context, so the setting must name a signal produced by the trusted review bot — the same user-configured trust model as `PR_REVIEW_NUDGE`. Note that a status-only reviewer's `success` cannot re-fire the repo's CI by itself — repos gating CI on review evidence need the status re-fire bridge (orch `DEVELOPMENT.md` § CI Triggering Patterns); without it, one bounded manual rerun-in-place of the failed gate run after evidence success is the documented fallback.
 - **`off`** — no reviewer gate (repos with NO review bots and no reviewer policy). Skip the wait loop entirely and go straight to § 5 — the internal review (gate 1), CI (gate 2), and comment-hygiene (gate 3) gates still apply in full.
 
-Record the resolved mode; for `off`, also record the legacy gate field the § 6.1 gate 4 check reads:
+Record the resolved mode; for `off`, also record the legacy gate field the § 6.1 gate 4 check reads. Pass the value as a bare word — `workflow-state set` stores plain strings raw, so a pre-quoted value like `'"off"'` would store literal quote characters and break the gate 4 comparison (vstack#705):
 
 ```bash
-.agents/skills/orch/scripts/workflow-state set [ISSUE_ID] pr_review.mode '"[GATE_MODE]"'
+.agents/skills/orch/scripts/workflow-state set [ISSUE_ID] pr_review.mode [GATE_MODE]
 ```
 
 ```bash
 # off mode only:
-.agents/skills/orch/scripts/workflow-state set [ISSUE_ID] pr_approval.gate '"off"'
+.agents/skills/orch/scripts/workflow-state set [ISSUE_ID] pr_approval.gate off
 ```
 
 The mode is explicit configuration by design — no auto-detection. An empty requested-reviewer list proves nothing (review bots never appear as requested reviewers before their first review), so only the project settings can state "this repo has no reviewers" or "this repo's reviewers comment but never approve."
@@ -428,7 +428,11 @@ A PR merges on exactly four gates — all deterministic. Bot-SPECIFIC signals (e
    | `0` | Gate met |
    | `> 0` | Run ONE triage pass: `⤵ workflows/review-pr-comments.md [PR_NUMBER] § 1-8 → § 6.1 step 3` with managed context (bounded by `pr_comment_review.iterations`, max 5). If that pass pushed commits, re-run § 5 and re-confirm the § 4 gate with a short approval-wait (`approval-wait [PR_NUMBER] 15 300 --json --mode [GATE_MODE]`; skip when `GATE_MODE` is `off`). Then re-run the gate 3 command once; if threads remain, present them and ask user: `Triage again` \| `Force merge` \| `Stop here` |
 
-4. **Gate 4** — verify the recorded § 4 result: met when the wait ended `approved` (approval mode) or `reviewed` (review mode), when `pr_approval.forced` was recorded by an explicit user override, or when the mode is `off` (`pr_review.mode` / legacy `pr_approval.gate` — reviewer-less repo, gate not applicable). Do not re-run the wait here — the gate 3 escape hatch above already re-confirms the gate after any late pushes.
+4. **Gate 4** — verify the recorded § 4 result: met when the wait ended `approved` (approval mode) or `reviewed` (review mode), when `pr_approval.forced` was recorded by an explicit user override, or when the mode is `off` (`pr_review.mode` / legacy `pr_approval.gate` — reviewer-less repo, gate not applicable). Read the recorded mode with:
+   ```bash
+   .agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '(.pr_review.mode // .pr_approval.gate // "") | gsub("\"";"")'
+   ```
+   The `gsub` strips literal quote characters — state files written by the pre-vstack#705 docs stored the mode as `"\"off\""`, and this read compares equal to `off` for both forms. Do not re-run the wait here — the gate 3 escape hatch above already re-confirms the gate after any late pushes.
 
 5. **Record results**: `MERGE_READY = true` only when all four gates are met (gate 4 by verdict or recorded force).
 


### PR DESCRIPTION
Closes #705. `workflow-state set` stores JSON-lookalike values (`{`/`[` prefix, `null`/`true`/`false`, all-digits) as JSON and EVERYTHING else verbatim — so submit-pr § 4's documented `'"[GATE_MODE]"'` idiom stored literal quote characters, breaking later mode comparisons.

Docs fix + tolerant reader (changing `set` to parse JSON-when-valid would silently re-type existing raw-string callers — rejected): both § 4 commands are now bare-word with the raw-string semantics pinned in a note; § 6.1 gate 4 reads via `gsub("\"";"")` normalization verified against clean, quote-corrupted, legacy-gate-only, and empty state forms; the schema + script help document the JSON-lookalike rule. Exhaustive audit: the idiom existed at exactly those two sites in all of skills/.

Validation: new 23-assert semantics test (set/append/update contrast pins, tolerant read against all four forms, docs lint with injected-offender teeth forbidding quote-wrapped set values); full orch run-all 17/17.

https://claude.ai/code/session_016s6ZSLTTRft6fH29wHn1TN