### PR TITLE
feat: dep-radar skill — pinned-version sweep, safe auto-update, capability report

### DIFF
--- a/skills/dep-radar/README.md
+++ b/skills/dep-radar/README.md
@@ -1,0 +1,52 @@
+# Dep Radar
+
+Pinned-version sweep, safe auto-update, and capability reporting for repos
+that pin dependencies deliberately (SDKs, runtime binaries with SHA constants,
+npm/cargo deps, vendored forks, model weights, GitHub Actions).
+
+Pinning buys reproducibility and supply-chain safety; the cost is drift.
+Dep Radar is the refresh loop that makes pinning safe: it inventories every
+pinned surface, detects upstream changes cheaply, reads the actual changelogs,
+auto-applies the safe tier via one PR per surface, and reports everything that
+deserves a product-owner decision.
+
+## What it does
+
+| Phase | Action |
+|-------|--------|
+| 0 — Inventory | Generates and maintains `docs/dep-radar/inventory.md` in your repo: every pinned surface with its pin location, upstream check, refresh procedure, verify command, and risk tier. |
+| 1 — Detect | Compares upstream latest against `docs/dep-radar/last-seen.json`; unchanged surfaces cost a few registry calls and the run stops early. |
+| 2 — Research | Reads real changelogs/release notes for each changed surface — never guesses from version numbers. |
+| 3 — Classify | Sorts findings into auto vs. report per the policy and the inventory's owner rules. |
+| 4 — Apply | Opens one PR per surface for the auto tier; verifies locally before opening; merges only when checks pass. |
+| 5 — Report | Writes a dated report of what was applied and what awaits an owner decision, every run. |
+
+## The policy contract
+
+- **Auto-applied** (one PR per surface, merged only when checks pass):
+  security fixes; patch/minor bumps; pinned-binary version+SHA refreshes from
+  official manifests only; SDK bumps with clean changelogs; internal
+  improvements with no user-facing behavior change.
+- **Reported, never auto-applied**: new user-facing capabilities; breaking or
+  major bumps; vendored-fork rebases; model swaps.
+- Uncertain findings are always reported, never auto-applied.
+- Every run ends with a dated report, even an idle one.
+- Your inventory's owner rules can make the skill more conservative
+  (demote auto → report) but never less (a rule cannot promote report → auto).
+
+## Repo-agnostic by design
+
+The skill contains no project-specific content. Everything about *your* repo —
+which packages are pinned where, how to refresh and verify each one, extra
+owner rules — lives in `docs/dep-radar/inventory.md`, which the skill writes
+on first run and keeps in sync on every run after.
+
+## Setup
+
+1. Install the `github` skill (required for the PR flow); add `worktree` if
+   you want per-surface branch isolation when multiple bumps land in one run.
+2. Invoke via your AI coding harness (e.g. `/dep-radar`), on demand or from a
+   schedule/loop.
+3. On first run, review the generated inventory's risk tiers.
+
+No configuration keys are required.

--- a/skills/dep-radar/SKILL.md
+++ b/skills/dep-radar/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: dep-radar
+description: "Sweep every pinned version in the repo (SDKs, pinned runtime binaries, npm/cargo deps, vendored forks, model weights), check upstream, read changelogs, auto-apply safe bumps via one PR per surface, and report new-capability opportunities to the product owner. Self-maintains a per-repo inventory; run on a schedule/loop or on demand."
+license: MIT
+user-invocable: true
+dependencies:
+  required: [github]
+  optional: [worktree]
+metadata:
+  author: vanillagreen
+  source: vstack
+  repository: "https://github.com/vanillagreencom/vstack"
+  bugs: "https://github.com/vanillagreencom/vstack/issues"
+  version: "1.0.0"
+---
+
+# dep-radar — pinned-version sweep, safe auto-update, and capability report
+
+Repos pin versions deliberately (reproducibility, SHA verification, supply-chain
+safety). The cost of pinning is drift: model lists lag pinned SDKs, pinned
+runtime binaries fall behind upstream contract changes. This skill is the
+refresh loop that makes pinning safe: **inventory → detect → research →
+classify → auto-fix the safe tier → report the product tier**.
+
+The skill is the generic engine; everything repo-specific lives in a per-repo
+inventory that the skill itself generates and maintains (Phase 0). Nothing here
+may be edited per-project — project differences (concrete package names, pinned
+binaries, fork lists) belong only in the inventory file.
+
+Load `github` before Phase 4 — all PR creation, CI status, and merge operations
+go through it. Load `worktree` when applying more than one surface in a run, so
+each surface's branch gets an isolated working copy.
+
+## Operating policy (the contract with the product owner)
+
+The contract, verbatim:
+
+> AUTO-apply: security fixes; patch/minor bumps; pinned-binary version+SHA refreshes from OFFICIAL manifests only; SDK bumps with clean changelogs; internal improvements with no user-facing behavior change.
+>
+> REPORT (never auto): new user-facing capabilities; breaking/major bumps; vendored-fork rebases; model swaps.
+>
+> Uncertain → report.
+>
+> Every run ends with a dated report.
+>
+> Inventory owner-rules may demote auto→report, never promote report→auto.
+
+Elaborated:
+
+- **Auto-apply, no ask** — one PR per surface (never batch); merge only if all
+  checks pass: security advisories; patch/minor bumps of routine deps;
+  pinned-runtime-binary version+SHA refreshes sourced only from the official
+  release manifest; SDK bumps whose changelog shows no breaking changes;
+  internal code improvements a new version enables **when they change no
+  user-facing behavior** (better API replacing a workaround, deprecation fixes).
+- **Report, never auto-apply**: new user-facing capabilities a bump unlocks
+  (e.g. new provider models a pinned AI SDK exposes); major/breaking bumps;
+  vendored-fork rebases; model-weight swaps; anything the inventory marks as an
+  owner decision (repos add their own rules there — e.g. data-scope changes).
+- When uncertain, classify as report — a deferred bump is recoverable; a bad
+  auto-merge is not.
+- Every run ends with a dated report even when nothing was applied.
+- Inventory owner rules override the generic tiers in the report direction
+  only: a rule can demote auto→report, never promote report→auto.
+
+## Phase 0 — inventory (self-maintaining)
+
+The per-repo inventory lives at `docs/dep-radar/inventory.md`: a table of every
+pinned surface with — pin location, upstream check command, refresh procedure,
+verify command, risk tier (auto / report), applicable playbook, and any
+repo-specific owner rules.
+
+- **First run** (no inventory): discover pins by sweeping the repo — package
+  manifests + lockfiles, `vendor/` dirs, SHA-256 constants near download/pin
+  code, model manifest scripts, version constants referencing upstream
+  releases — then WRITE the inventory and have the owner glance at the tiers.
+- **Every run**: diff discovered pins against the inventory; add new surfaces,
+  drop removed ones, and note the change in the run report.
+
+## Phase 1 — detect (cheap; makes scheduled runs nearly free)
+
+Read `docs/dep-radar/last-seen.json` (create if absent). Query upstream latest
+for each surface. If nothing changed since last-seen, update `checked_at`,
+write a one-line report, and stop — an idle run should cost a few registry
+calls, not a build. (Skip-if-unchanged, same principle as tiered-CI nightlies.)
+
+## Phase 2 — research
+
+For each changed surface, read the actual changelog/release notes online —
+never guess from version numbers. Extract: breaking changes, deprecations,
+security fixes, new capabilities, and anything touching contracts the repo
+depends on (the inventory names these per surface — e.g. an OAuth flow, an
+RPC protocol, a model catalog).
+
+## Phase 3 — classify
+
+Sort every finding into **auto** / **report** per the policy plus the
+inventory's per-surface tier and owner rules.
+
+## Phase 4 — apply the auto tier
+
+One branch + PR **per surface** (never batch surfaces — keeps reverts
+surgical). Apply the inventory's refresh procedure, run its verify command,
+and only open the PR when verification passes locally. PR body: old→new
+version, changelog summary with links, what was verified. Use the `github`
+skill for PR creation, CI waits, and merge; respect the repo's
+review/merge-queue conventions.
+
+Internal-improvement pass (bounded): if the changelog shows a better way to do
+something the codebase already does, implement it in the same PR when small or
+a follow-up PR when not. No user-facing behavior changes in this tier.
+
+## Phase 5 — report
+
+Write `docs/dep-radar/report-<YYYY-MM-DD>.md` (committed with the last-seen
+update): what was auto-applied (PR links), and what awaits an owner decision —
+each report item with the capability, what it would unlock, estimated
+effort/risk, and a recommendation. Surface the report to the owner (PR
+description / handoff doc), not just the file.
+
+## Technology playbooks
+
+Applied per surface by what the repo actually has (the inventory records which
+apply). Concrete package, binary, and fork names live in the inventory, never
+here.
+
+- **Pinned AI/agent SDK** (a coding-agent or LLM SDK pinned by exact version):
+  registry `latest` + release notes. New provider models exposed by a bump are
+  the canonical report-tier item; a clean-changelog bump itself is auto-tier.
+  Verify: build + test suites; confirm expected models/features appear.
+- **Pinned runtime binary with SHA constants** (an app-managed runtime binary
+  pinned by version plus per-platform SHA-256/size constants): version + SHAs
+  refreshed **only from the official release manifest** for the exact version —
+  never a third party, never hand-computed from a local download alone. Watch
+  changelogs specifically for auth/protocol/contract changes. Verify: pin unit
+  tests + a live download smoke on the host platform.
+- **Routine npm/pnpm deps**: `pnpm -r outdated` and `pnpm audit`. Auto:
+  patch/minor + all security. Report: major. Verify: typecheck + tests.
+- **Routine cargo deps**: `cargo update --dry-run` and `cargo audit` (if
+  installed). Same tiers. Verify: workspace tests with the repo's CI feature
+  parity.
+- **Vendored/patched upstream forks** (upstream projects vendored with local
+  patches): upstream releases are report-only — rebasing local patches is
+  owner-decided, never automatic.
+- **Model weights / artifact SHA pins**: report-only; verify scripts exist in
+  the repo, use them for integrity checks, never swap weights automatically.
+- **Pinned GitHub Actions SHAs**: auto for patch/minor tag moves of the same
+  action (refresh the SHA comment too); report for majors.
+
+## Guardrails
+
+- One PR per surface; never batch.
+- If a bump's verification fails, do not ship a partial bump; report the
+  failure with error output instead.
+- Never auto-rebase vendored forks; never swap model weights automatically.
+- Migration-bearing dep bumps (DB/storage tooling): check the repo's
+  merge-order/version-gap hazards before merging.
+- Honor every owner rule recorded in the inventory (these override the
+  generic tiers in the report direction only — a rule can demote auto→report,
+  never promote report→auto).
+- Harness-safe shell: run upstream checks and verify commands as single simple
+  commands — no loops, no command substitution, no composition — so runs
+  survive restrictive harness approval policies.

--- a/skills/dep-radar/tests/generic-engine-lint.test.sh
+++ b/skills/dep-radar/tests/generic-engine-lint.test.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Architecture-invariant lint: the dep-radar skill is the GENERIC engine.
+# All repo-specific content (concrete package, binary, fork, and project
+# names) lives in each repo's generated docs/dep-radar/inventory.md — never
+# in the skill. The maintainer-approved draft originally named real packages
+# and projects; this lint keeps them (and their kin) from creeping back in.
+#
+# Teeth: an offender injected into a copy of the doc must be flagged.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+PASS=0
+FAIL=0
+
+pass() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+fail() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
+
+# Concrete names that appeared in earlier drafts of this skill and must never
+# appear in the generic skill docs (the tripwire for known offenders; new
+# concrete names are still a review responsibility). Matched case-insensitively
+# as whole words so e.g. "tao" cannot false-positive inside an unrelated word.
+DENYLIST=(
+  earendil
+  pi-coding-agent
+  wasapi
+  wry
+  tao
+)
+
+# scan <file> — prints "file: name" for every denylisted name found.
+scan() {
+  local f="$1" name
+  for name in "${DENYLIST[@]}"; do
+    if grep -qiw -- "$name" "$f"; then
+      printf '%s: %s\n' "$f" "$name"
+    fi
+  done
+}
+
+echo "=== dep-radar generic-engine lint ==="
+
+# --- Real docs must be free of concrete project/package names ---------------
+
+DOCS=("$SKILL_DIR/SKILL.md" "$SKILL_DIR/README.md")
+offenders=""
+for doc in "${DOCS[@]}"; do
+  out="$(scan "$doc")"
+  [[ -n "$out" ]] && offenders+="$out"$'\n'
+done
+if [[ -z "$offenders" ]]; then
+  pass "SKILL.md and README.md name no concrete packages/projects"
+else
+  fail "concrete names found in generic skill docs:"
+  printf '%s' "$offenders" | sed 's/^/          /'
+fi
+
+# --- Teeth ------------------------------------------------------------------
+
+SCRATCH="$TMP_ROOT/inject-pkg.md"
+cp "$SKILL_DIR/SKILL.md" "$SCRATCH"
+printf '\nRefresh the pinned @earendil-works/pi-coding-agent SDK.\n' >> "$SCRATCH"
+if [[ -n "$(scan "$SCRATCH")" ]]; then
+  pass "lint flags an injected concrete SDK package name"
+else
+  fail "lint MISSED an injected concrete SDK package name (no teeth)"
+fi
+
+SCRATCH="$TMP_ROOT/inject-fork.md"
+cp "$SKILL_DIR/SKILL.md" "$SCRATCH"
+printf '\nRebase the vendored tao fork onto upstream.\n' >> "$SCRATCH"
+if [[ -n "$(scan "$SCRATCH")" ]]; then
+  pass "lint flags an injected concrete vendored-fork name"
+else
+  fail "lint MISSED an injected concrete vendored-fork name (no teeth)"
+fi
+
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/skills/dep-radar/tests/policy-contract-lint.test.sh
+++ b/skills/dep-radar/tests/policy-contract-lint.test.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Doc-contract lint for the dep-radar operating policy.
+#
+# The skill's value rests on a maintainer-approved contract: what may be
+# auto-applied, what must only ever be reported, uncertain→report, one PR per
+# surface, and the demote-only owner-rule. A future edit that softens any of
+# those tiers (e.g. "may promote report→auto", batching surfaces into one PR)
+# would silently turn a safe refresh loop into an unsafe one. This lint pins
+# each contract clause in SKILL.md, and proves its own teeth by mutating a
+# copy of the doc to violate each rule and asserting the check catches it.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
+SKILL_MD="$SKILL_DIR/SKILL.md"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+PASS=0
+FAIL=0
+
+pass() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+fail() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
+
+# check_contract <file>
+# Prints the names of missing/violated contract clauses (empty output = doc
+# honors the full contract). Each clause is pinned as a fixed string that the
+# canonical SKILL.md carries on a single line, so plain grep -F is exact.
+check_contract() {
+  local f="$1" missing=""
+  grep -qF 'AUTO-apply: security fixes; patch/minor bumps; pinned-binary version+SHA refreshes from OFFICIAL manifests only; SDK bumps with clean changelogs; internal improvements with no user-facing behavior change.' "$f" \
+    || missing="$missing auto-tier-list"
+  grep -qF 'REPORT (never auto): new user-facing capabilities; breaking/major bumps; vendored-fork rebases; model swaps.' "$f" \
+    || missing="$missing report-tier-list"
+  grep -qF 'Uncertain → report.' "$f" \
+    || missing="$missing uncertain-to-report"
+  grep -qF 'Every run ends with a dated report.' "$f" \
+    || missing="$missing dated-report-every-run"
+  grep -qF 'never promote report→auto' "$f" \
+    || missing="$missing demote-only-owner-rule"
+  grep -qiF 'one PR per surface' "$f" \
+    || missing="$missing one-pr-per-surface"
+  grep -qF 'never batch' "$f" \
+    || missing="$missing never-batch"
+  printf '%s' "$missing"
+}
+
+# mutate <name> <sed-script> → prints mutated copy's path.
+mutate() {
+  local out="$TMP_ROOT/mutant-$1.md"
+  sed "$2" "$SKILL_MD" > "$out"
+  printf '%s' "$out"
+}
+
+# expect_caught <clause-name> <mutant-path> <description>
+# The mutated doc must fail the check, and the failure must name the clause.
+expect_caught() {
+  local clause="$1" mutant="$2" desc="$3" out
+  out="$(check_contract "$mutant")"
+  if [[ "$out" == *"$clause"* ]]; then
+    pass "$desc"
+  else
+    fail "$desc (check output: '$out')"
+  fi
+}
+
+echo "=== dep-radar policy contract lint ==="
+
+# --- The real doc honors the full contract ---------------------------------
+
+missing="$(check_contract "$SKILL_MD")"
+if [[ -z "$missing" ]]; then
+  pass "SKILL.md carries every policy contract clause"
+else
+  fail "SKILL.md is missing contract clauses:$missing"
+fi
+
+# --- Frontmatter contract ---------------------------------------------------
+
+if grep -q '^name: dep-radar$' "$SKILL_MD"; then
+  pass "frontmatter names the skill dep-radar"
+else
+  fail "frontmatter name is not dep-radar"
+fi
+
+if grep -q '^user-invocable: true$' "$SKILL_MD"; then
+  pass "frontmatter declares user-invocable: true"
+else
+  fail "frontmatter missing user-invocable: true"
+fi
+
+if grep -q 'required: \[github\]' "$SKILL_MD"; then
+  pass "frontmatter declares the github skill as a required dependency"
+else
+  fail "frontmatter missing required github dependency (the PR flow needs it)"
+fi
+
+# --- Teeth: each violated rule must be caught -------------------------------
+
+expect_caught auto-tier-list \
+  "$(mutate no-auto '/AUTO-apply: security fixes/d')" \
+  "deleting the AUTO-apply tier list is caught"
+
+expect_caught report-tier-list \
+  "$(mutate no-report '/REPORT (never auto)/d')" \
+  "deleting the REPORT tier list is caught"
+
+expect_caught uncertain-to-report \
+  "$(mutate uncertain-flip 's/Uncertain → report\./Uncertain → auto-apply./')" \
+  "flipping uncertain→report to uncertain→auto is caught"
+
+expect_caught dated-report-every-run \
+  "$(mutate no-dated '/Every run ends with a dated report/d')" \
+  "deleting the every-run dated report rule is caught"
+
+expect_caught demote-only-owner-rule \
+  "$(mutate promote 's/never promote report→auto/may promote report→auto/g')" \
+  "softening the owner-rule to allow report→auto promotion is caught"
+
+expect_caught one-pr-per-surface \
+  "$(mutate batch-run 's/per surface/per run/g')" \
+  "rewording one-PR-per-surface to one-PR-per-run is caught"
+
+expect_caught never-batch \
+  "$(mutate batch-ok 's/never batch/batch freely/g')" \
+  "removing the never-batch rule is caught"
+
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/vstack.toml
+++ b/vstack.toml
@@ -73,6 +73,7 @@ generalist = [
     "github",
     "dev",
     "linear",
+    "dep-radar",
 ]
 
 planner = [


### PR DESCRIPTION
Adds the cross-repo `dep-radar` skill (maintainer directive): a generic pinned-version sweep + safe auto-update + capability-report engine.

## Design
- **Generic engine, per-repo inventory**: all repo-specific content lives in a `docs/dep-radar/inventory.md` the skill generates and maintains itself (Phase 0). Nothing project-specific ships in the skill — enforced by `tests/generic-engine-lint.test.sh`.
- **Phases**: self-maintaining inventory → skip-if-unchanged detect → changelog research → classify → auto-apply one-PR-per-surface → dated owner report; technology playbooks for pinned SDKs, SHA-pinned runtime binaries, npm/cargo routine deps, vendored forks (report-only), model weights (report-only), pinned Action SHAs.
- **Policy contract encoded verbatim** and pinned by `tests/policy-contract-lint.test.sh` with mutation teeth (7 injected violations, each caught): auto tier list, report tier list, uncertain→report, dated report every run, one-PR-per-surface/never-batch, demote-only owner rules.
- **Frontmatter**: orch-shaped — MIT, user-invocable, `required: [github]` / `optional: [worktree]`, full metadata, version 1.0.0.
- **Mapping**: added to the generalist `[agent-skills]` entry (cross-cutting maintenance fits the generalist charter; primary-agent use covered by `user-invocable`). No settings keys read → no settings templates shipped.

## Verification
- policy lint 11/11, generic lint 3/3; orch suite 17/17 files; both tests 100755 (CI `skills/*/tests/*.sh` glob picks them up).

Skill-set change only — no CLI release needed.

https://claude.ai/code/session_017x6AyjyPypo3vbVyjB4Nhq