### PR TITLE
fix(github): git-diff-summary default base prefers fetched origin default branch

### DIFF
--- a/skills/github/scripts/git-diff-summary
+++ b/skills/github/scripts/git-diff-summary
@@ -16,7 +16,9 @@ with stats and risk flags. Designed for review routing decisions.
 Usage: git-diff-summary [-C path] [base-branch]
 
 Arguments:
-  base-branch    Compare against this branch (default: main)
+  base-branch    Compare against this branch (default: the remote default
+                 branch, e.g. origin/main; falls back to local main when
+                 no remote-tracking ref exists)
   -C path        Run as if started in <path> (worktree support)
   --staged       Show only staged changes
   --head         Show uncommitted changes vs HEAD
@@ -25,8 +27,29 @@ Output: JSON with scope (production|support), domain groupings, stats, and risk 
 EOF
 }
 
+# Default base for review scope. A stale local main must not widen scope to
+# unrelated commits (vstack#718), so prefer the already-fetched remote-tracking
+# ref of the repo's default branch. No network: never fetches, so offline/CI
+# calls keep working. Falls back to local main when the repo has no remote.
+resolve_default_base() {
+    local head_ref
+    head_ref=$(git symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null || true)
+    if [ -n "$head_ref" ] && git rev-parse --verify --quiet "$head_ref" >/dev/null; then
+        echo "${head_ref#refs/remotes/}"
+        return
+    fi
+    local candidate
+    for candidate in origin/main origin/master; do
+        if git rev-parse --verify --quiet "refs/remotes/$candidate" >/dev/null; then
+            echo "$candidate"
+            return
+        fi
+    done
+    echo "main"
+}
+
 main() {
-    local base="main"
+    local base=""
     local diff_args=""
     local git_dir=""
 
@@ -40,19 +63,22 @@ main() {
         esac
     done
 
-    # Determine diff command
-    local diff_ref
-    if [ -n "$diff_args" ]; then
-        diff_ref="$diff_args"
-    else
-        diff_ref="${base}...HEAD"
-    fi
-
     # Use -C path if provided, otherwise repo root
     if [ -n "$git_dir" ]; then
         cd "$git_dir"
     else
         cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+    fi
+
+    # Determine diff command (base resolution must run inside the target repo)
+    local diff_ref
+    if [ -n "$diff_args" ]; then
+        diff_ref="$diff_args"
+    else
+        if [ -z "$base" ]; then
+            base=$(resolve_default_base)
+        fi
+        diff_ref="${base}...HEAD"
     fi
 
     # Get file list with status (A/M/D/R)

--- a/skills/github/tests/git-diff-summary-default-base.test.sh
+++ b/skills/github/tests/git-diff-summary-default-base.test.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# vstack#718: git-diff-summary without an explicit base must resolve against
+# the fetched remote default branch (origin/main), not a stale local main.
+# A stale local main previously widened review scope to unrelated commits.
+#
+# Run: bash skills/github/tests/git-diff-summary-default-base.test.sh
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../.." && pwd)"
+SUMMARY="$REPO_ROOT/skills/github/scripts/git-diff-summary"
+
+SANDBOX="$(mktemp -d -t gh-diff-summary-base-XXXXXX)"
+PASS=0
+FAIL=0
+
+cleanup() { rm -rf "$SANDBOX" 2>/dev/null || true; }
+trap cleanup EXIT
+
+assert_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if [ "$expected" = "$actual" ]; then
+        printf '  PASS: %s\n' "$label"
+        PASS=$((PASS + 1))
+    else
+        printf '  FAIL: %s\n    expected: %s\n    actual:   %s\n' "$label" "$expected" "$actual" >&2
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+git_c() {
+    local repo="$1"
+    shift
+    git -C "$repo" "$@"
+}
+
+init_repo() {
+    local repo="$1"
+    mkdir -p "$repo"
+    git_c "$repo" init -q -b main
+    git_c "$repo" config user.email test@example.com
+    git_c "$repo" config user.name test
+    git_c "$repo" config commit.gpgsign false
+    printf 'base\n' > "$repo/README.md"
+    git_c "$repo" add README.md
+    git_c "$repo" commit -q -m init
+}
+
+# Fixture: origin advances main with unrelated commits after the clone's local
+# main was created; the clone fetches (remote-tracking refs are current) but
+# never fast-forwards local main, then branches off origin/main.
+origin_repo="$SANDBOX/origin"
+init_repo "$origin_repo"
+
+clone_repo="$SANDBOX/clone"
+git clone -q "$origin_repo" "$clone_repo"
+git_c "$clone_repo" config user.email test@example.com
+git_c "$clone_repo" config user.name test
+git_c "$clone_repo" config commit.gpgsign false
+
+printf 'unrelated 1\n' > "$origin_repo/unrelated1.txt"
+printf 'unrelated 2\n' > "$origin_repo/unrelated2.txt"
+git_c "$origin_repo" add unrelated1.txt unrelated2.txt
+git_c "$origin_repo" commit -q -m "unrelated work on main"
+
+git_c "$clone_repo" fetch -q origin
+git_c "$clone_repo" checkout -q -b feature origin/main
+printf 'feature\n' > "$clone_repo/feature.txt"
+git_c "$clone_repo" add feature.txt
+git_c "$clone_repo" commit -q -m "feature change"
+
+default_json="$($SUMMARY -C "$clone_repo")"
+assert_eq "default base uses origin default branch, not stale local main" \
+    "1" "$(jq -r '.files_changed' <<<"$default_json")"
+assert_eq "unrelated origin/main files excluded from scope" \
+    '["feature.txt"]' "$(jq -c '[.domains[].files[]] | sort' <<<"$default_json")"
+
+explicit_json="$($SUMMARY -C "$clone_repo" main)"
+assert_eq "explicit base argument still respected (stale local main widens scope)" \
+    "3" "$(jq -r '.files_changed' <<<"$explicit_json")"
+
+# Without origin/HEAD (e.g. remote added manually), fall back to origin/main.
+git_c "$clone_repo" remote set-head origin --delete
+no_head_json="$($SUMMARY -C "$clone_repo")"
+assert_eq "origin/main candidate used when origin/HEAD is unset" \
+    "1" "$(jq -r '.files_changed' <<<"$no_head_json")"
+
+# No remote at all: keep current behavior (local main).
+local_repo="$SANDBOX/local-only"
+init_repo "$local_repo"
+git_c "$local_repo" checkout -q -b feature
+printf 'feature\n' > "$local_repo/feature.txt"
+git_c "$local_repo" add feature.txt
+git_c "$local_repo" commit -q -m "feature change"
+local_json="$($SUMMARY -C "$local_repo")"
+assert_eq "remoteless repo falls back to local main" \
+    '["feature.txt"]' "$(jq -c '[.domains[].files[]] | sort' <<<"$local_json")"
+
+printf '\nPASS=%d FAIL=%d\n' "$PASS" "$FAIL"
+if [ "$FAIL" -ne 0 ]; then exit 1; fi


### PR DESCRIPTION
Closes #718.

Without an explicit base, `git-diff-summary` hardcoded local `main` as the triple-dot base; on a managed worktree with a stale local main the merge-base landed behind origin, silently widening review scope to unrelated commits (seven unrelated files in the reporting run).

Default base now resolves inside the target repo via `resolve_default_base()`: `refs/remotes/origin/HEAD` when resolvable → `origin/main`/`origin/master` remote-tracking refs → local `main` (exact old behavior, remoteless repos). Only already-fetched refs — no network added, offline/CI safe. Explicit base args and `--staged`/`--head` unchanged.

Tests: new `git-diff-summary-default-base.test.sh` fixture (stale-clone scenario; 5/5) — default scope excludes unrelated origin/main files, explicit base preserved, origin/HEAD-unset fallback, remoteless fallback. All 9 github-skill test files pass.

https://claude.ai/code/session_017x6AyjyPypo3vbVyjB4Nhq