### PR TITLE
fix(orch,worktree): review-before-CI after ci-fix push; rebase-map for rewritten SHAs

### DIFF
--- a/skills/orch/schemas/workflow-state.md
+++ b/skills/orch/schemas/workflow-state.md
@@ -58,6 +58,9 @@ Persistent state file for orch workflows. Survives context compaction.
     }
   ],
   "audit_issues_created": ["PROJ-200", "PROJ-201"],
+  "rebase_map": {
+    "0a1b2c3d4e5f60718293a4b5c6d7e8f901234567": "76543210f9e8d7c6b5a49382716051423344abcd"
+  },
   "pr_review_baseline": {
     "last_ts": "2026-01-28T10:00:00Z",
     "last_threads": 2
@@ -106,6 +109,7 @@ Persistent state file for orch workflows. Survives context compaction.
 | `fixed_items` | object[] | Blockers successfully fixed |
 | `escalated_items` | object[] | Blockers that couldn't be fixed |
 | `audit_issues_created` | string[] | Issue IDs created by audit |
+| `rebase_map` | object | Old→new commit SHA map accumulated from `worktree push` auto-rebase output (`rebase-map:` lines — vstack#728). Keys are pre-rebase SHAs; values are post-rebase SHAs, or the literal `"dropped"` when the replayed commit vanished. SHAs stored elsewhere in state are rewritten at push time (`submit-pr.md` § 2 step 1); the map remains for artifact-sourced references (e.g. perf QA `benchmark_commit`) — resolve through it repeatedly until no key matches, since a later rebase maps new → newer |
 | `pr_review_baseline` | object | Baseline for PR comment loop detection |
 | `pr_comment_review` | object | PR comment review tracking: `iterations`, `fixes[]`, `issues_created[]`, `skipped[]`, `replied[]` (thread IDs answered) |
 | `pr_local_review` | object | Local pre-PR review tracking: `passes` (max 2 per submission) |

--- a/skills/orch/tests/workflow_helpers.sh
+++ b/skills/orch/tests/workflow_helpers.sh
@@ -466,6 +466,56 @@ assert_file_contains "$state_schema" '"status": "active"' "workflow-state schema
 assert_file_contains "$start_worktree_workflow" '.value.status = "closed"' "start-worktree shutdown retires child sessions to closed"
 assert_file_contains "$orch_skill" 'a record with no `status` field counts as active' "orch skill slot-accounting note carries the back-compat rule"
 
+# vstack#726 — review-before-CI holds after EVERY push, including ci-fix
+# recovery pushes: a fix push moves the PR head and outdates exact-head review
+# evidence, and approval-gated repos start CI for a head only after that
+# evidence exists. ci-fix § 5 must therefore re-confirm the review gate at the
+# new head (mode resolved via approval-wait --resolve-mode, skip when off)
+# BEFORE ci-wait; the old order (ci-wait, then re-confirm) deadlocked gated
+# repos or read an intentionally red gate run as a fix failure. submit-pr
+# § 5.2 and merge-pr's recovery cycle rely on that in-ci-fix ordering, and the
+# § 6.1 gate 3 escape hatch re-confirms the gate before re-running § 5.
+ci_fix_workflow="$REPO_ROOT/skills/orch/workflows/ci-fix.md"
+assert_file_contains "$ci_fix_workflow" 'approval-wait --resolve-mode' "ci-fix resolves the gate mode via approval-wait --resolve-mode"
+assert_file_contains "$ci_fix_workflow" '.agents/skills/orch/scripts/approval-wait [PR_NUMBER] 15 300 --json --mode [GATE_MODE]' "ci-fix runs the short exact-head review re-confirmation"
+assert_file_contains "$ci_fix_workflow" 'no repo detection (vstack#726)' "ci-fix applies the reorder universally without repo detection"
+assert_file_contains "$ci_fix_workflow" 'not a fix failure' "ci-fix does not read a review-gated missing CI run as a fix failure"
+ci_fix_gate_line="$(grep -n -m1 -F 'approval-wait [PR_NUMBER] 15 300 --json --mode [GATE_MODE]' "$ci_fix_workflow" | cut -d: -f1)"
+ci_fix_wait_line="$(grep -n -m1 -F 'scripts/ci-wait [PR_NUMBER]' "$ci_fix_workflow" | cut -d: -f1)"
+ci_fix_ordering="missing-steps"
+if [[ -n "$ci_fix_gate_line" && -n "$ci_fix_wait_line" && "$ci_fix_gate_line" -lt "$ci_fix_wait_line" ]]; then
+  ci_fix_ordering="review-before-ci"
+fi
+assert_eq "$ci_fix_ordering" "review-before-ci" "ci-fix § 5 re-confirms the review gate before ci-wait"
+assert_file_contains "$submit_workflow" 're-confirmed the § 4 gate at the new head, and only then re-verified CI' "submit-pr § 5.2 states ci-fix re-confirms review before re-verifying CI"
+assert_file_not_contains "$submit_workflow" 'before § 6 (skip this re-confirm when' "submit-pr drops the after-CI gate re-confirmation ordering"
+assert_file_contains "$submit_workflow" 'then re-run § 5 — review before CI holds after every push (vstack#726)' "submit-pr gate 3 escape hatch re-confirms review before re-running CI"
+assert_file_contains "$submit_workflow" 're-confirms this gate at its new head before re-verifying CI, vstack#726' "submit-pr § 4 full cycle notes the per-push ci-fix re-confirmation"
+assert_file_contains "$merge_workflow" 'before re-verifying CI (its § 5, vstack#726)' "merge-pr recovery cycle relies on ci-fix's pre-CI gate re-confirmation"
+
+# vstack#728 — `worktree push` auto-rebases onto the updated base and
+# legitimately rewrites branch commits, so commit SHAs recorded pre-push
+# (fixed_items, pr_comment_review.fixes, perf QA benchmark_commit) go stale.
+# The push now prints one `rebase-map: <old> <new>` line per rewritten commit
+# (functional coverage: skills/worktree/tests/worktree_push_rebase.sh);
+# submit-pr § 2 step 1 must record the map in workflow state (rebase_map),
+# rewrite stored fix commits via workflow-state update, and forbid publishing
+# unreconciled pre-rebase SHAs; post-summary resolves artifact-sourced SHAs
+# through the recorded map.
+post_summary_workflow="$REPO_ROOT/skills/orch/workflows/post-summary.md"
+assert_file_contains "$submit_workflow" 'rebase-map: [OLD_SHA] [NEW_SHA]' "submit-pr documents the worktree push rebase-map output"
+assert_file_contains "$submit_workflow" '.rebase_map = (.rebase_map // {}) + {"[OLD_SHA]": "[NEW_SHA]"}' "submit-pr records the rebase map in workflow state"
+assert_file_contains "$submit_workflow" '(.fixed_items[]? | select(.commit == "[RECORDED_SHA]") | .commit) = "[MAPPED_SHA]"' "submit-pr rewrites fixed_items commits from the map"
+assert_file_contains "$submit_workflow" '(.pr_comment_review.fixes[]? | select(.commit == "[RECORDED_SHA]") | .commit) = "[MAPPED_SHA]"' "submit-pr rewrites pr-comment fix commits from the map"
+assert_file_contains "$submit_workflow" 'unreconciled pre-rebase SHAs is forbidden (vstack#728)' "submit-pr forbids publication with stale pre-rebase SHAs"
+assert_file_contains "$submit_workflow" 'follow the chain until no key matches' "submit-pr resolves artifact-sourced SHAs through the map chain"
+assert_file_contains "$submit_workflow" 'resolve through the step 1 rebase map when one was recorded (vstack#728)' "submit-pr PR body requires reconciled commit SHAs"
+assert_file_contains "$submit_workflow" 'publishing a stale pre-rebase SHA is forbidden (vstack#728)' "submit-pr § 6.2 summary forbids stale SHAs"
+assert_file_contains "$post_summary_workflow" 'resolve every published SHA through it' "post-summary resolves published SHAs through the rebase map"
+assert_file_contains "$post_summary_workflow" 'unreconciled pre-rebase SHA is forbidden (vstack#728)' "post-summary forbids stale-SHA publication"
+assert_file_contains "$state_schema" '`rebase_map` | object' "workflow-state schema documents the rebase map field"
+assert_file_contains "$state_schema" 'resolve through it repeatedly until no key matches' "workflow-state schema documents chained map resolution"
+
 assert_file_not_contains "$qa_workflow" "Pipe benchmark output" "qa-review avoids pipe-based benchmark recording"
 assert_file_not_contains "$qa_workflow" "pipe results" "qa-review avoids pipe-based perf capture guidance"
 assert_file_contains "$qa_workflow" "Do not use shell pipelines" "qa-review bans Codex-unsafe benchmark shell plumbing"

--- a/skills/orch/workflows/ci-fix.md
+++ b/skills/orch/workflows/ci-fix.md
@@ -185,30 +185,43 @@ Report findings for user decision.
 
 ## 5. Verify
 
-After fix is pushed:
+A fix push moved the PR head, so the review gate is re-confirmed at the new head **before** CI is waited on — the same review-before-CI ordering as `submit-pr.md` § 4 → § 5, applied universally with no repo detection (vstack#726). On approval-gated repos CI for the new head starts only after exact-head review evidence exists, so waiting on CI first would deadlock or watch an intentionally red gate run; on always-on repos CI has been running since the push, so the short re-confirmation costs nothing.
 
-```bash
-.agents/skills/orch/scripts/ci-wait [PR_NUMBER]
-```
+1. **Re-confirm the review gate at the new head** — resolve the mode through the existing gate vocabulary, never by detection:
+   ```bash
+   .agents/skills/orch/scripts/approval-wait --resolve-mode
+   ```
+   The printed value is `GATE_MODE`. Skip to step 2 when it is `off`. Otherwise run the short exact-head re-confirmation:
+   ```bash
+   .agents/skills/orch/scripts/approval-wait [PR_NUMBER] 15 300 --json --mode [GATE_MODE]
+   ```
+   - `approved` / `reviewed` → step 2.
+   - `comments` / `changes_requested` → new review feedback on the fix push. Managed: return it to the caller's review-gate handling (`submit-pr.md` § 4 step 1 triage pass). Standalone: run that triage pass, then re-run this step.
+   - `timeout` → no exact-head review evidence yet. On repos whose CI is gated on review evidence, CI cannot have started — a missing or red gate run here is not a fix failure. Report the unconfirmed gate, then re-run this step once or stop and hand back.
 
-**Post to issue tracker** — **Linear only** (GitHub items: the PR conversation already records the fix):
-```bash
-.agents/skills/github/scripts/github.sh pr-issue [PR_NUMBER] --format=text
-```
-Use the output as `ISSUE`.
+2. **Wait for CI**:
+   ```bash
+   .agents/skills/orch/scripts/ci-wait [PR_NUMBER]
+   ```
 
-If `ISSUE` is non-empty, determine tracker:
+3. **Post to issue tracker** — **Linear only** (GitHub items: the PR conversation already records the fix):
+   ```bash
+   .agents/skills/github/scripts/github.sh pr-issue [PR_NUMBER] --format=text
+   ```
+   Use the output as `ISSUE`.
 
-```bash
-.agents/skills/orch/scripts/tracker-for-issue "$ISSUE"
-```
-Use the output as `TRACKER`.
+   If `ISSUE` is non-empty, determine tracker:
 
-If `TRACKER` is `linear`, post the short status:
+   ```bash
+   .agents/skills/orch/scripts/tracker-for-issue "$ISSUE"
+   ```
+   Use the output as `TRACKER`.
 
-```bash
-.agents/skills/linear/scripts/linear.sh comments create "$ISSUE" --body "CI Fix: [ERROR_TYPE] → [FIX_DESCRIPTION]"
-```
+   If `TRACKER` is `linear`, post the short status:
+
+   ```bash
+   .agents/skills/linear/scripts/linear.sh comments create "$ISSUE" --body "CI Fix: [ERROR_TYPE] → [FIX_DESCRIPTION]"
+   ```
 
 ## 6. Present Results
 

--- a/skills/orch/workflows/merge-pr.md
+++ b/skills/orch/workflows/merge-pr.md
@@ -293,7 +293,7 @@ merge. Detach them first.
    A rerun-in-place (`gh run rerun` / rerun-failed-jobs) re-executes the workflow definition and verifier state pinned at the original triggering event — a PR that changes gate or CI workflow behavior only exhibits its new behavior on a fresh head (new push → attempt-1 run), never via a rerun of an old attempt. Reruns are for flakes and re-gating on unchanged workflows; behavior changes need a new commit and push.
 
    1. **Run Workflow**: `⤵ workflows/ci-fix.md [PR_NUMBER] § 1-7 → § 5 step 2`. For a queue ejection the failing run is the **merge-group** run (workflow event `merge_group`), not necessarily the PR-head run — locate it via the failing run link in the PR's checks or `gh run list --event merge_group --limit 10`, and point ci-fix's log fetching at that run.
-   2. **Re-confirm the review gate** after ci-fix pushed a fix — pushes can dismiss reviewer approvals and move the head past the reviewed commit (skip when the § 3.2 `GATE_MODE` is `off`):
+   2. **Re-confirm the review gate** after ci-fix pushed a fix — pushes can dismiss reviewer approvals and move the head past the reviewed commit. ci-fix itself already re-confirmed the gate at the new head before re-verifying CI (its § 5, vstack#726); this short wait re-checks that the evidence still stands at the head about to be re-armed (skip when the § 3.2 `GATE_MODE` is `off`):
       ```bash
       .agents/skills/orch/scripts/approval-wait [PR_NUMBER] 15 300 --json --mode [GATE_MODE]
       ```

--- a/skills/orch/workflows/post-summary.md
+++ b/skills/orch/workflows/post-summary.md
@@ -86,6 +86,7 @@ Use the first output as `ISSUE_ID` and the tracker output as `TRACKER`. Use curr
    - **Created Issues**: From `audit_issues_created` + `pr_comment_review.issues_created`. Include project name.
    - **QA Metrics**: Include if QA agents ran (project-configurable).
    - **Recommendations Processed**: Dedupe by description across cycles.
+   - **Commit SHAs**: when workflow state carries a `.rebase_map` (recorded by `submit-pr.md` § 2 step 1 after a `worktree push` auto-rebase rewrote the branch), resolve every published SHA through it — follow the chain until no key matches. Publishing an unreconciled pre-rebase SHA is forbidden (vstack#728); fix SHAs stored in state were already rewritten at push time, so the map matters for artifact-sourced references like a perf QA `benchmark_commit`.
 
 ---
 

--- a/skills/orch/workflows/submit-pr.md
+++ b/skills/orch/workflows/submit-pr.md
@@ -119,6 +119,21 @@ Bot reviews are **asynchronous** in this workflow: GitHub review bots post on th
    .agents/skills/worktree/scripts/worktree push "[WORKTREE_PATH]" --set-upstream
    ```
 
+   **Rebase-map reconciliation (required).** `worktree push` auto-rebases the branch onto the updated base; that legitimately rewrites every branch commit, and the push then prints one `rebase-map: [OLD_SHA] [NEW_SHA]` line per rewritten commit (`[NEW_SHA]` is the literal word `dropped` when the replayed commit vanished because its patch was already upstream). Commit SHAs recorded before the push — `fixed_items`, `pr_comment_review.fixes`, a perf QA `benchmark_commit` — now name commits that no longer exist on the branch. When the push output contains any `rebase-map:` lines, reconcile before anything publishes them; publication (PR body, § 6.2 summary, `post-summary.md`) with unreconciled pre-rebase SHAs is forbidden (vstack#728):
+
+   1. Record the map so later sessions can still resolve artifact-sourced SHAs — one command per mapping line, `dropped` stored literally:
+      ```bash
+      .agents/skills/orch/scripts/workflow-state update [ISSUE_ID] '.rebase_map = (.rebase_map // {}) + {"[OLD_SHA]": "[NEW_SHA]"}'
+      ```
+   2. Rewrite every stored fix commit that matches a mapped old SHA. A recorded short SHA matches when it is a prefix of `[OLD_SHA]`; replace it with `[NEW_SHA]` truncated to the recorded length (one command per matching item):
+      ```bash
+      .agents/skills/orch/scripts/workflow-state update [ISSUE_ID] '(.fixed_items[]? | select(.commit == "[RECORDED_SHA]") | .commit) = "[MAPPED_SHA]"'
+      ```
+      ```bash
+      .agents/skills/orch/scripts/workflow-state update [ISSUE_ID] '(.pr_comment_review.fixes[]? | select(.commit == "[RECORDED_SHA]") | .commit) = "[MAPPED_SHA]"'
+      ```
+   3. Regenerate any already-drafted publication text from the reconciled state, and resolve every SHA sourced from a review/QA artifact rather than state (e.g. perf QA `benchmark_commit`) through `.rebase_map` before publishing it — follow the chain until no key matches, since a later rebase maps new → newer.
+
 2. **Check for existing PR**:
    ```bash
    .agents/skills/orch/scripts/pr-view-json "[WORKTREE_PATH]" --json number,state
@@ -163,6 +178,7 @@ Bot reviews are **asynchronous** in this workflow: GitHub review bots post on th
    - **Completed Issues**: Use `Closes` keyword for issue tracker linkage. Indent sub-issues.
    - **Created Issues**: Include if issues created during local review or comment triage.
    - **QA Metrics**: Include if QA agents ran. Format is project-configurable based on which QA agent types are active.
+   - **Commit SHAs**: every SHA published in the body (fix commits, perf `benchmark_commit`) must be post-reconciliation — resolve through the step 1 rebase map when one was recorded (vstack#728).
 
 4. **Create or update PR**. CI configured on `pull_request` runs from the moment the PR exists — orch never defers, queues, or gates it behind bot review activity. Approval-gated repos start their heavy CI only after the § 4 review-gate verdict instead; that is repo-side configuration (see orch `DEVELOPMENT.md` § CI Triggering Patterns) and needs no detection here.
 
@@ -317,7 +333,7 @@ Bot-SPECIFIC signals (emoji reactions, sticky-comment prose, checklist text) are
 
 **Nudging.** approval-wait nudges silent reviewers itself: when the mode's signal has not arrived within `PR_REVIEW_NUDGE_SECS` (default 600s, `0` disables) of the wait starting or of the head last changing, it posts the user-configured `PR_REVIEW_NUDGE` comment body on the PR — or, when that setting is empty, falls back to a GitHub-native re-review request to the PR's requested and past reviewers (silence when there is nobody to re-request). Each head SHA is nudged at most once; a push restarts the nudge clock and re-arms the nudge for the new head. Both keys live in `vstack.settings.toml` `[env]` next to the gate mode — the nudge text is project configuration, no bot names are built in.
 
-The full cycle after any fix-up push is: push fixes → the head changes → wait for a NEW review of the new head (approval-wait nudges after `PR_REVIEW_NUDGE_SECS` if the reviewer stays silent) → triage, reply to, and resolve every thread → § 5 Verify CI (→ § 5.2 ci-fix cycles, bounded by `CI_FIX_MAX_CYCLES`, when red) → § 6 merge gates.
+The full cycle after any fix-up push is: push fixes → the head changes → wait for a NEW review of the new head (approval-wait nudges after `PR_REVIEW_NUDGE_SECS` if the reviewer stays silent) → triage, reply to, and resolve every thread → § 5 Verify CI (→ § 5.2 ci-fix cycles, bounded by `CI_FIX_MAX_CYCLES`, when red — each ci-fix push re-confirms this gate at its new head before re-verifying CI, vstack#726) → § 6 merge gates.
 
 1. **Review wait loop.** Poll for the gate verdict and new review comments together (skip when `GATE_MODE` is `off`):
    ```bash
@@ -387,7 +403,7 @@ A rerun-in-place (`gh run rerun` / rerun-failed-jobs) re-executes the workflow d
 1. **Run Workflow**: `⤵ workflows/ci-fix.md [PR_NUMBER] § 1-7 → § 5.2 step 2`
 
 2. **After ci-fix returns**:
-   - If fix applied → ci-fix already pushed and re-verified CI (its § 5); treat its final CI result as the § 5.1 result and re-route via the § 5.1 step 2 table. A recovery push may also dismiss existing reviewer approvals or move the head past the reviewed commit — when ci-fix pushed commits, re-confirm the § 4 gate with a short wait (`approval-wait [PR_NUMBER] 15 300 --json --mode [GATE_MODE]`) before § 6 (skip this re-confirm when `GATE_MODE` is `off`).
+   - If fix applied → ci-fix already pushed, re-confirmed the § 4 gate at the new head, and only then re-verified CI (its § 5). The ordering is deliberate (vstack#726): a recovery push dismisses or outdates exact-head review evidence, and on approval-gated repos CI for the new head starts only after the renewed evidence exists — re-confirming the review gate after ci-wait would deadlock those repos or read an intentionally red gate run as a fix failure. Record ci-fix's gate re-confirmation result as the § 4 result for the § 6.1 gate 4 check (skip the record when `GATE_MODE` is `off`), treat its final CI result as the § 5.1 result, and re-route via the § 5.1 step 2 table. If ci-fix instead returned a gate re-confirmation of `comments` or `changes_requested` (new review feedback on the fix push, no CI result yet), route that status through the § 4 step 1 table first, then re-enter § 5.1.
    - If fix not possible → Ask user: `Skip CI` | `Retry` | `Abort`
 
 3. **Max [MAX_CYCLES] ci-fix cycles** per PR submission — keep routing CI failures back into step 1 until CI passes or the budget is spent.
@@ -426,7 +442,7 @@ A PR merges on exactly four gates — all deterministic. Bot-SPECIFIC signals (e
    | `unresolved_count` | Action |
    |--------------------|--------|
    | `0` | Gate met |
-   | `> 0` | Run ONE triage pass: `⤵ workflows/review-pr-comments.md [PR_NUMBER] § 1-8 → § 6.1 step 3` with managed context (bounded by `pr_comment_review.iterations`, max 5). If that pass pushed commits, re-run § 5 and re-confirm the § 4 gate with a short approval-wait (`approval-wait [PR_NUMBER] 15 300 --json --mode [GATE_MODE]`; skip when `GATE_MODE` is `off`). Then re-run the gate 3 command once; if threads remain, present them and ask user: `Triage again` \| `Force merge` \| `Stop here` |
+   | `> 0` | Run ONE triage pass: `⤵ workflows/review-pr-comments.md [PR_NUMBER] § 1-8 → § 6.1 step 3` with managed context (bounded by `pr_comment_review.iterations`, max 5). If that pass pushed commits, re-confirm the § 4 gate with a short approval-wait (`approval-wait [PR_NUMBER] 15 300 --json --mode [GATE_MODE]`; skip when `GATE_MODE` is `off`), then re-run § 5 — review before CI holds after every push (vstack#726). Then re-run the gate 3 command once; if threads remain, present them and ask user: `Triage again` \| `Force merge` \| `Stop here` |
 
 4. **Gate 4** — verify the recorded § 4 result: met when the wait ended `approved` (approval mode) or `reviewed` (review mode), when `pr_approval.forced` was recorded by an explicit user override, or when the mode is `off` (`pr_review.mode` / legacy `pr_approval.gate` — reviewer-less repo, gate not applicable). Read the recorded mode with:
    ```bash
@@ -448,7 +464,7 @@ A PR merges on exactly four gates — all deterministic. Bot-SPECIFIC signals (e
    - `issue_id`: [ISSUE_ID]
    - `pr_number`: [PR_NUMBER]
 
-2. **Post summary** — skip if no fixes AND no issues created. Write to a file first (same backtick hazard as PR body):
+2. **Post summary** — skip if no fixes AND no issues created. Fix SHAs come from workflow state, which § 2 step 1 reconciled after any rebase; resolve artifact-sourced SHAs (perf `benchmark_commit`) through `.rebase_map` — publishing a stale pre-rebase SHA is forbidden (vstack#728). Write to a file first (same backtick hazard as PR body):
    ```bash
    mkdir -p [WORKTREE_PATH]/tmp
    .agents/skills/orch/scripts/git-context timestamp compact

--- a/skills/worktree/README.md
+++ b/skills/worktree/README.md
@@ -78,6 +78,15 @@ later commits must descend from that head. The authorization is consumed after
 a successful push. Unexpected local rewrites and remote movement fail closed.
 Calls that skip auto-rebase still use plain pushes.
 
+When the auto-rebase rewrites branch commits, `worktree push` prints one
+`rebase-map: <old-sha> <new-sha>` line per rewritten commit on stdout
+(`dropped` in place of the new SHA when the replayed commit vanished because
+its patch was already upstream), so callers can remap commit SHAs recorded
+before the rebase — orch `submit-pr.md` § 2 step 1 consumes this to rewrite
+workflow-state fix references before publication (vstack#728). Commits pair by
+position when the pre/post counts match, otherwise by commit subject. A push
+that skips the rebase, or one run with `--no-rebase`, prints no map.
+
 `codex-setup` applies the same env/config symlinks, copies, mkdirs, bot remote, bot git identity, and lightweight dependency bootstrap that `create` applies after creating a worktree. `codex-branch` renames or switches the app-created worktree branch to the lower-case issue branch expected by `orch`. `codex-cleanup` is intentionally a no-op lifecycle hook for this script; Codex owns app-created worktree and branch deletion. Keep project-level teardown such as stopping containers or removing disposable caches in the Codex environment cleanup script after this command, but do not call `worktree remove` from the hook.
 
 ## Configuration

--- a/skills/worktree/scripts/worktree
+++ b/skills/worktree/scripts/worktree
@@ -313,6 +313,60 @@ remote_ref_lease_arg() {
   printf '%s\n' "--force-with-lease=${remote_head_ref}:${expected_oid}"
 }
 
+# After a push auto-rebase rewrote the branch, print one machine-readable
+# "rebase-map: <old-sha> <new-sha>" line per rewritten commit on stdout so
+# callers (orch submit-pr) can remap commit SHAs recorded before the rebase
+# (vstack#728). A replayed commit that vanished (its patch was already
+# upstream) maps to "rebase-map: <old-sha> dropped". Inputs are the pre- and
+# post-rebase outputs of `git log --reverse --format='%H %s'
+# origin/<default>..HEAD`. Commits pair by position when the counts match
+# (rebase preserves order); on a count mismatch they pair by subject,
+# consuming each post-rebase line at most once. Bash 3.2: consumed indices
+# are tracked in a space-delimited string, no associative arrays.
+emit_rebase_map() {
+  local pre_list="$1" post_list="$2"
+  if [[ -z "$pre_list" || "$pre_list" == "$post_list" ]]; then
+    return 0
+  fi
+  local pre_count=0 post_count=0
+  pre_count="$(printf '%s\n' "$pre_list" | grep -c '^')"
+  if [[ -n "$post_list" ]]; then
+    post_count="$(printf '%s\n' "$post_list" | grep -c '^')"
+  fi
+  echo "→ auto-rebase rewrote $pre_count branch commit(s); rebase-map lines follow (vstack#728)" >&2
+  local i=1 j=1 old_line="" old_sha="" old_subject="" new_line="" new_sha="" used_idx=""
+  while [[ "$i" -le "$pre_count" ]]; do
+    old_line="$(printf '%s\n' "$pre_list" | sed -n "${i}p")"
+    old_sha="${old_line%% *}"
+    old_subject="${old_line#* }"
+    new_sha=""
+    if [[ "$pre_count" -eq "$post_count" ]]; then
+      new_line="$(printf '%s\n' "$post_list" | sed -n "${i}p")"
+      new_sha="${new_line%% *}"
+    else
+      j=1
+      while [[ "$j" -le "$post_count" ]]; do
+        case " $used_idx " in
+          *" $j "*) j=$((j + 1)); continue ;;
+        esac
+        new_line="$(printf '%s\n' "$post_list" | sed -n "${j}p")"
+        if [[ "${new_line#* }" == "$old_subject" ]]; then
+          new_sha="${new_line%% *}"
+          used_idx="$used_idx $j"
+          break
+        fi
+        j=$((j + 1))
+      done
+    fi
+    if [[ -z "$new_sha" ]]; then
+      echo "rebase-map: $old_sha dropped"
+    elif [[ "$new_sha" != "$old_sha" ]]; then
+      echo "rebase-map: $old_sha $new_sha"
+    fi
+    i=$((i + 1))
+  done
+}
+
 strip_trailing_slashes() {
   local path="$1"
   while [[ "$path" != "/" && "$path" == */ ]]; do
@@ -1645,6 +1699,7 @@ case "${1:-}" in
       echo ""
       echo "Push worktree branch to remote. Auto-rebases onto origin/$DEFAULT_BRANCH first."
       echo "Auto-rebased and supported create --reuse/--restack pushes use --force-with-lease pinned to the pre-rewrite target branch OID."
+      echo "When the auto-rebase rewrites branch commits, prints one 'rebase-map: <old-sha> <new-sha>' line per rewritten commit on stdout ('dropped' when the replayed commit vanished) so callers can remap recorded SHAs (vstack#728)."
       echo "Uses BOT_REMOTE_NAME from project config if set, otherwise falls back to origin."
       echo ""
       echo "Options:"
@@ -1700,13 +1755,19 @@ case "${1:-}" in
       if [[ -n "$CURRENT_BRANCH" && "$CURRENT_BRANCH" != "$DEFAULT_BRANCH" ]]; then
         if git -C "$WT_PATH" merge-base --is-ancestor "origin/$DEFAULT_BRANCH" HEAD; then
           echo "→ origin/$DEFAULT_BRANCH already contained in $CURRENT_BRANCH; skipping rebase" >&2
-        elif ! git -C "$WT_PATH" rebase "origin/$DEFAULT_BRANCH" >/dev/null 2>&1; then
-          git -C "$WT_PATH" rebase --abort >/dev/null 2>&1 || true
-          echo "Error: Rebase onto origin/$DEFAULT_BRANCH failed (conflicts). Push with --no-rebase or resolve manually." >&2
-          exit 1
         else
+          # Snapshot the branch-only commits before/after the rebase so a
+          # rewrite is reported as an old→new commit map (vstack#728).
+          PRE_REBASE_COMMITS="$(git -C "$WT_PATH" log --reverse --format='%H %s' "origin/$DEFAULT_BRANCH..HEAD")"
+          if ! git -C "$WT_PATH" rebase "origin/$DEFAULT_BRANCH" >/dev/null 2>&1; then
+            git -C "$WT_PATH" rebase --abort >/dev/null 2>&1 || true
+            echo "Error: Rebase onto origin/$DEFAULT_BRANCH failed (conflicts). Push with --no-rebase or resolve manually." >&2
+            exit 1
+          fi
           # Rebase can replace symlinks with tracked content — restore them
           setup_worktree_links "$WT_PATH"
+          POST_REBASE_COMMITS="$(git -C "$WT_PATH" log --reverse --format='%H %s' "origin/$DEFAULT_BRANCH..HEAD")"
+          emit_rebase_map "$PRE_REBASE_COMMITS" "$POST_REBASE_COMMITS"
         fi
       fi
     fi

--- a/skills/worktree/tests/worktree_push_rebase.sh
+++ b/skills/worktree/tests/worktree_push_rebase.sh
@@ -154,6 +154,7 @@ assert_not_contains "$(cat "$ANCESTOR_ROOT/push.err")" "Rebase onto origin/main 
 assert_contains "$(cat "$ANCESTOR_ROOT/push.err")" "skipping rebase" "push reports it skipped the unnecessary rebase"
 assert_eq "$ancestor_post_head" "$ancestor_pre_head" "HEAD is unchanged (no rebase happened)"
 assert_eq "$(git --git-dir="$ANCESTOR_ROOT/origin.git" rev-parse refs/heads/issue-ancestor)" "$ancestor_pre_head" "feature branch lands on remote at the merge commit"
+assert_not_contains "$(cat "$ANCESTOR_ROOT/push.out")" "rebase-map:" "skipped rebase emits no rebase-map lines"
 
 # --- Rebase still happens when genuinely behind -------------------------------
 # Feature does NOT contain origin/main as an ancestor (main advanced after the
@@ -170,10 +171,14 @@ printf 'advanced\n' > "$BEHIND_ROOT/main/main-advanced.txt"
 git -C "$BEHIND_ROOT/main" add main-advanced.txt
 git -C "$BEHIND_ROOT/main" commit -q -m 'advance main'
 git -C "$BEHIND_ROOT/main" push -q origin main
-# Feature adds its own (non-conflicting) file on the old base.
+# Feature adds its own (non-conflicting) files on the old base — two commits,
+# so the vstack#728 rebase map must pair each rewritten commit by position.
 printf 'fix\n' > "$BEHIND_ROOT/trees/issue-behind/fix.txt"
 git -C "$BEHIND_ROOT/trees/issue-behind" add fix.txt
 git -C "$BEHIND_ROOT/trees/issue-behind" commit -q -m 'review fix'
+printf 'fix2\n' > "$BEHIND_ROOT/trees/issue-behind/fix2.txt"
+git -C "$BEHIND_ROOT/trees/issue-behind" add fix2.txt
+git -C "$BEHIND_ROOT/trees/issue-behind" commit -q -m 'second review fix'
 git -C "$BEHIND_ROOT/trees/issue-behind" fetch -q origin
 # Precondition: branch does NOT yet contain the advanced origin/main.
 set +e
@@ -182,6 +187,8 @@ behind_precond=$?
 set -e
 assert_eq "$behind_precond" "1" "behind branch does not contain origin/main before push"
 behind_pre_head="$(git -C "$BEHIND_ROOT/trees/issue-behind" rev-parse HEAD)"
+behind_pre_c1="$(git -C "$BEHIND_ROOT/trees/issue-behind" rev-parse HEAD~1)"
+behind_pre_c2="$behind_pre_head"
 set +e
 (
   cd "$BEHIND_ROOT/main" && \
@@ -196,6 +203,17 @@ assert_ne "$behind_post_head" "$behind_pre_head" "rebase rewrote HEAD (rebase ac
 assert_path_exists "$BEHIND_ROOT/trees/issue-behind/main-advanced.txt" "rebase moved the base onto advanced origin/main"
 assert_is_ancestor "$BEHIND_ROOT/trees/issue-behind" origin/main HEAD "origin/main is contained after rebase"
 assert_eq "$(git --git-dir="$BEHIND_ROOT/origin.git" rev-parse refs/heads/issue-behind)" "$behind_post_head" "remote branch matches rebased local head"
+
+# --- vstack#728: the rebase prints an old→new commit map -----------------------
+# Both branch commits were rewritten; push stdout must carry one
+# `rebase-map: <old-sha> <new-sha>` line per commit, paired by position.
+behind_post_c1="$(git -C "$BEHIND_ROOT/trees/issue-behind" rev-parse HEAD~1)"
+behind_post_c2="$behind_post_head"
+behind_push_out="$(cat "$BEHIND_ROOT/push.out")"
+assert_contains "$behind_push_out" "rebase-map: $behind_pre_c1 $behind_post_c1" "rebase map pairs the first rewritten commit"
+assert_contains "$behind_push_out" "rebase-map: $behind_pre_c2 $behind_post_c2" "rebase map pairs the second rewritten commit"
+assert_eq "$(grep -c '^rebase-map: ' <<<"$behind_push_out")" "2" "rebase map emits exactly one line per rewritten commit"
+assert_contains "$(cat "$BEHIND_ROOT/push.err")" "rebase-map lines follow (vstack#728)" "rebase map announces itself on stderr"
 
 # --- --no-rebase skips the rebase (unchanged behavior) ------------------------
 # A behind branch pushed with --no-rebase must not be rebased: HEAD stays put
@@ -226,6 +244,49 @@ norebase_post_head="$(git -C "$NOREBASE_ROOT/trees/issue-norebase" rev-parse HEA
 assert_eq "$norebase_code" "0" "--no-rebase push succeeds"
 assert_eq "$norebase_post_head" "$norebase_pre_head" "--no-rebase leaves HEAD unchanged"
 assert_path_absent "$NOREBASE_ROOT/trees/issue-norebase/main-advanced.txt" "--no-rebase does not pull in advanced main"
+assert_not_contains "$(cat "$NOREBASE_ROOT/push.out")" "rebase-map:" "--no-rebase emits no rebase-map lines"
+
+# --- vstack#728: a commit dropped by the rebase maps to "dropped" --------------
+# The branch carries a commit whose patch main already merged (different SHA,
+# same patch-id) plus its own fix. The rebase drops the duplicated commit, so
+# pre/post counts differ and the map must pair by subject: the surviving commit
+# maps old→new, the vanished one maps old→dropped.
+DROP_ROOT="$TMP_ROOT/dropped"
+make_repo "$DROP_ROOT/main"
+git init -q --bare "$DROP_ROOT/origin.git"
+git -C "$DROP_ROOT/main" remote add origin "$DROP_ROOT/origin.git"
+git -C "$DROP_ROOT/main" push -q -u origin main
+git -C "$DROP_ROOT/main" worktree add -q -b issue-dropped "$DROP_ROOT/trees/issue-dropped" main
+# Branch commit 1: the patch main will independently merge.
+printf 'dup\n' > "$DROP_ROOT/trees/issue-dropped/dup.txt"
+git -C "$DROP_ROOT/trees/issue-dropped" add dup.txt
+git -C "$DROP_ROOT/trees/issue-dropped" commit -q -m 'duplicated change'
+# Branch commit 2: the branch's own fix.
+printf 'fix\n' > "$DROP_ROOT/trees/issue-dropped/fix.txt"
+git -C "$DROP_ROOT/trees/issue-dropped" add fix.txt
+git -C "$DROP_ROOT/trees/issue-dropped" commit -q -m 'review fix'
+# main lands the same patch under another subject and advances origin.
+printf 'dup\n' > "$DROP_ROOT/main/dup.txt"
+git -C "$DROP_ROOT/main" add dup.txt
+git -C "$DROP_ROOT/main" commit -q -m 'main landed the dup patch'
+git -C "$DROP_ROOT/main" push -q origin main
+drop_pre_c1="$(git -C "$DROP_ROOT/trees/issue-dropped" rev-parse HEAD~1)"
+drop_pre_c2="$(git -C "$DROP_ROOT/trees/issue-dropped" rev-parse HEAD)"
+set +e
+(
+  cd "$DROP_ROOT/main" && \
+    "$WORKTREE_SCRIPT" push "$DROP_ROOT/trees/issue-dropped" --set-upstream \
+      >"$DROP_ROOT/push.out" 2>"$DROP_ROOT/push.err"
+)
+drop_code=$?
+set -e
+drop_post_head="$(git -C "$DROP_ROOT/trees/issue-dropped" rev-parse HEAD)"
+drop_push_out="$(cat "$DROP_ROOT/push.out")"
+assert_eq "$drop_code" "0" "push succeeds when the rebase drops a duplicated commit"
+assert_eq "$(git -C "$DROP_ROOT/trees/issue-dropped" rev-list --count origin/main..HEAD)" "1" "rebase dropped the duplicated commit"
+assert_contains "$drop_push_out" "rebase-map: $drop_pre_c1 dropped" "rebase map reports the vanished commit as dropped"
+assert_contains "$drop_push_out" "rebase-map: $drop_pre_c2 $drop_post_head" "rebase map pairs the surviving commit by subject"
+assert_eq "$(grep -c '^rebase-map: ' <<<"$drop_push_out")" "2" "dropped-commit rebase map covers both pre-rebase commits"
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"


### PR DESCRIPTION
Closes #726, Closes #728.

## #726 — review re-confirmation before CI after a ci-fix push
ci-fix § 5 said only "ci-wait" while submit-pr § 5.2 re-confirmed the review gate *after* CI — contradicting § 4's own push → new review → CI doctrine and deadlocking approval-gated repos (CI can't start before exact-head review evidence). The reorder lives once in ci-fix § 5 (resolve GATE_MODE via `approval-wait --resolve-mode`, short exact-head re-confirmation, then ci-wait), so submit-pr § 5.2, merge-pr recovery, and standalone ci-fix all inherit it. Unified ordering, no repo detection — on always-on repos CI runs from the push anyway, so the re-confirm-first order costs nothing. Also fixed the same latent order in § 6.1 gate 3's escape hatch.

## #728 — rebase-map after worktree push auto-rebase
`worktree push` discarded its auto-rebase output entirely, while submit/post-summary published `fixed_items` / QA `benchmark_commit` SHAs recorded pre-rebase. The script now snapshots branch commits before/after the rebase and prints one `rebase-map: <old> <new>` line per rewritten commit (`dropped` when the patch was already upstream) — position pairing when counts match, consume-once subject pairing otherwise; Bash 3.2, single-line Codex-safe output. submit-pr § 2 gains a required reconciliation block: record `.rebase_map` in workflow state (new schema field, chained resolution for repeat rebases), rewrite `fixed_items`/`pr_comment_review.fixes`, resolve artifact-sourced SHAs through the map; publication with unreconciled pre-rebase SHAs is forbidden at every publish site.

## Tests
- workflow_helpers.sh: +22 assertions incl. an ordering check on ci-fix § 5 (292/292).
- worktree_push_rebase.sh: map assertions on the behind fixture + new dropped-commit fixture exercising subject pairing (25/25).
- Full orch suite 19/19 files; worktree suite 9/9 files.

https://claude.ai/code/session_017x6AyjyPypo3vbVyjB4Nhq