### PR TITLE
fix(hooks): pre-commit Clippy lane — package scoping, project override, unsuppressed diagnostics

### DIFF
--- a/.github/workflows/skill-tests.yml
+++ b/.github/workflows/skill-tests.yml
@@ -32,7 +32,7 @@ jobs:
               echo "not executable in git: $f"
               fail=1
             fi
-          done < <(git ls-files -- 'skills/*/tests/*.sh' 'skills/*/scripts/*' | grep -v '/scripts/lib/')
+          done < <(git ls-files -- 'skills/*/tests/*.sh' 'skills/*/scripts/*' 'hooks/tests/*.sh' | grep -v '/scripts/lib/')
           exit "$fail"
 
       - name: orch suite (run-all)
@@ -46,6 +46,19 @@ jobs:
             case "$t" in
               skills/orch/tests/*) continue ;;
             esac
+            echo "=== $t"
+            if ! bash "$t"; then
+              echo "FAILED: $t"
+              fail=1
+            fi
+          done
+          exit "$fail"
+
+      - name: hook suites
+        run: |
+          set -u
+          fail=0
+          for t in hooks/tests/*.sh; do
             echo "=== $t"
             if ! bash "$t"; then
               echo "FAILED: $t"

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Rust and performance reference material now lives directly in the `rust`, `revie
 | Hook | Event | Brief |
 |---|---|---|
 | `block-bare-cd` | `PreToolUse` | Blocks unsafe bare `cd` usage and nudges toward subshell-safe patterns. |
-| `pre-commit-check` | `PreToolUse` | Validates formatting and lint before commits. |
+| `pre-commit-check` | `PreToolUse` | Validates formatting and lint before commits. Rust Clippy lane is scoped to staged packages and configurable via `VSTACK_PRE_COMMIT_RUST_CLIPPY` (custom command or `off`). |
 | `post-edit-lint` | `PostToolUse` | Runs lint checks after source edits. |
 | `task-completed-check` | `TaskCompleted` | Runs final lint checks before marking work complete. Claude-Code-only — codex has no clean equivalent event. |
 

--- a/hooks/pre-commit-check.sh
+++ b/hooks/pre-commit-check.sh
@@ -3,7 +3,7 @@
 # name: pre-commit-check
 # event: PreToolUse
 # matcher: Bash
-# description: Validate formatting and lint before git commits on source files. Supports Rust (cargo fmt + clippy) and Biome projects (JS/TS/JSON).
+# description: Validate formatting and lint before git commits on source files. Rust runs cargo fmt plus a Clippy lane scoped to the staged files' packages; VSTACK_PRE_COMMIT_RUST_CLIPPY (env or vstack.settings.toml [env]) replaces the Clippy lane with a repo-owned command or "off" skips it. Biome projects (JS/TS/JSON) check staged paths.
 # safety: Prevents committing code that fails format or lint checks.
 # ---
 
@@ -23,15 +23,25 @@ if [ -z "$STAGED" ]; then
   exit 0
 fi
 
+# Print the last lines of a failed check's combined output so failures are
+# actionable (cargo/clippy emit diagnostics on stderr; earlier versions
+# discarded them and left only the generic guidance line).
+print_output_tail() {
+  if [ -n "$1" ]; then
+    echo "$1" | tail -40 >&2
+  fi
+}
+
 # Check for Rust files
 if echo "$STAGED" | grep -qE '\.rs$'; then
+  REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || true)
+
   # Locate Cargo.toml so the hook works in repos that nest the manifest
   # (vstack's own `cli/Cargo.toml` is the canonical example) and when
   # the hook is invoked from a subdirectory. Earlier versions ran
   # `cargo fmt --check` from cwd unconditionally and misreported "could
   # not find Cargo.toml" as a fmt failure.
   MANIFEST_ARGS=()
-  REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || true)
   if [ -n "$REPO_ROOT" ] && [ ! -f "$REPO_ROOT/Cargo.toml" ]; then
     MANIFEST=$(echo "$STAGED" | grep -E '\.rs$' | while IFS= read -r path; do
       dir=$(dirname "$path")
@@ -49,15 +59,86 @@ if echo "$STAGED" | grep -qE '\.rs$'; then
   fi
 
   # Format check
-  if ! cargo fmt "${MANIFEST_ARGS[@]}" --check 2>/dev/null; then
+  if ! FMT_OUTPUT=$(cargo fmt ${MANIFEST_ARGS[@]+"${MANIFEST_ARGS[@]}"} --check 2>&1); then
+    print_output_tail "$FMT_OUTPUT"
     echo "cargo fmt --check failed. Run 'cargo fmt' first." >&2
     exit 2
   fi
 
-  # Clippy check
-  if ! cargo clippy "${MANIFEST_ARGS[@]}" --workspace --all-targets -- -D warnings 2>/dev/null; then
-    echo "cargo clippy found warnings. Fix them before committing." >&2
-    exit 2
+  # Clippy lane, three tiers via VSTACK_PRE_COMMIT_RUST_CLIPPY (parent env
+  # wins; then the repo's vstack.settings.toml / .vstack/settings.toml [env]
+  # table — parsed inline because this hook must stay self-contained):
+  #   unset -> default clippy scoped to the staged files' packages
+  #   "off" -> skip entirely (repo-owned validation is authoritative)
+  #   other -> run verbatim via `bash -c`; its exit status decides
+  CLIPPY_CMD="${VSTACK_PRE_COMMIT_RUST_CLIPPY:-}"
+  if [ -z "$CLIPPY_CMD" ] && [ -n "$REPO_ROOT" ]; then
+    for SETTINGS_FILE in "$REPO_ROOT/vstack.settings.toml" "$REPO_ROOT/.vstack/settings.toml"; do
+      [ -f "$SETTINGS_FILE" ] || continue
+      CLIPPY_CMD=$(sed -n 's/^[[:space:]]*VSTACK_PRE_COMMIT_RUST_CLIPPY[[:space:]]*=[[:space:]]*"\(.*\)"[[:space:]]*$/\1/p' "$SETTINGS_FILE" | head -1)
+      [ -n "$CLIPPY_CMD" ] && break
+    done
+  fi
+
+  if [ "$CLIPPY_CMD" = "off" ]; then
+    : # Clippy lane disabled by configuration.
+  elif [ -n "$CLIPPY_CMD" ]; then
+    if ! CLIPPY_OUTPUT=$( (cd "${REPO_ROOT:-.}" && bash -c "$CLIPPY_CMD") 2>&1); then
+      print_output_tail "$CLIPPY_OUTPUT"
+      echo "configured Clippy check failed (VSTACK_PRE_COMMIT_RUST_CLIPPY): $CLIPPY_CMD" >&2
+      echo "Fix the reported warnings before committing." >&2
+      exit 2
+    fi
+  else
+    # Default: scope clippy to the packages that own the staged .rs files so
+    # pre-existing warnings in unrelated workspace crates can't block the
+    # commit. Fall back to --workspace when no package name resolves (virtual
+    # manifest, parse failure).
+    PKG_NAMES=""
+    if [ -n "$REPO_ROOT" ]; then
+      PKG_NAMES=$(echo "$STAGED" | grep -E '\.rs$' | while IFS= read -r path; do
+        dir=$(dirname "$path")
+        while :; do
+          if [ -f "$REPO_ROOT/$dir/Cargo.toml" ]; then
+            # `name = "..."` from the [package] table only ([[bin]] and
+            # dependency tables also carry `name` keys).
+            awk '
+              /^[[:space:]]*\[/ { in_pkg = ($0 ~ /^[[:space:]]*\[package\][[:space:]]*(#.*)?$/); next }
+              in_pkg && /^[[:space:]]*name[[:space:]]*=/ {
+                if (match($0, /"[^"]*"/)) { print substr($0, RSTART + 1, RLENGTH - 2) }
+                exit
+              }
+            ' "$REPO_ROOT/$dir/Cargo.toml"
+            break
+          fi
+          if [ "$dir" = "." ] || [ "$dir" = "/" ] || [ -z "$dir" ]; then
+            break
+          fi
+          dir=$(dirname "$dir")
+        done
+      done | sort -u | grep -v '^$' || true)
+    fi
+
+    PKG_ARGS=()
+    if [ -n "$PKG_NAMES" ]; then
+      while IFS= read -r pkg; do
+        PKG_ARGS+=(-p "$pkg")
+      done <<EOF
+$PKG_NAMES
+EOF
+    fi
+
+    if [ -n "$PKG_NAMES" ]; then
+      SCOPE_ARGS=(${PKG_ARGS[@]+"${PKG_ARGS[@]}"})
+    else
+      SCOPE_ARGS=(--workspace)
+    fi
+
+    if ! CLIPPY_OUTPUT=$(cargo clippy ${MANIFEST_ARGS[@]+"${MANIFEST_ARGS[@]}"} ${SCOPE_ARGS[@]+"${SCOPE_ARGS[@]}"} --all-targets -- -D warnings 2>&1); then
+      print_output_tail "$CLIPPY_OUTPUT"
+      echo "cargo clippy found warnings. Fix them before committing." >&2
+      exit 2
+    fi
   fi
 fi
 

--- a/hooks/tests/pre-commit-check.test.sh
+++ b/hooks/tests/pre-commit-check.test.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+# Regression tests for the pre-commit-check hook's Rust Clippy lane (vstack#737).
+#
+# The hook previously hard-coded `cargo clippy --workspace --all-targets`
+# with stderr discarded, so commits failed on pre-existing warnings in
+# unrelated crates with no actionable output and no way to configure the
+# lane. These tests assert the three-tier VSTACK_PRE_COMMIT_RUST_CLIPPY
+# semantics (unset -> package-scoped default, "off" -> skip, custom -> run
+# verbatim via bash -c), the vstack.settings.toml fallback, the --workspace
+# fallback when no package resolves, the nested-manifest --manifest-path
+# behavior, and that fmt/clippy diagnostics now reach stderr on failure.
+#
+# `cargo` is stubbed with a PATH shim that records invocations, so the suite
+# needs no Rust toolchain or real workspace.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="$(cd "$TEST_DIR/.." && pwd)/pre-commit-check.sh"
+
+PASS=0
+FAIL=0
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+CARGO_LOG="$TMP_ROOT/cargo.log"
+ERR_FILE="$TMP_ROOT/stderr"
+
+# --- cargo PATH shim ---------------------------------------------------------
+BIN_DIR="$TMP_ROOT/bin"
+mkdir -p "$BIN_DIR"
+cat >"$BIN_DIR/cargo" <<'EOF'
+#!/usr/bin/env bash
+echo "cargo $*" >>"$CARGO_LOG"
+case "$1" in
+  fmt)
+    if [ "${CARGO_FMT_EXIT:-0}" != "0" ]; then
+      echo "Diff in src/lib.rs at line 1:" >&2
+    fi
+    exit "${CARGO_FMT_EXIT:-0}"
+    ;;
+  clippy)
+    if [ "${CARGO_CLIPPY_EXIT:-0}" != "0" ]; then
+      echo "error: strict comparison of f32 or f64 (clippy::float_cmp)" >&2
+      echo " --> src/lib.rs:1:1" >&2
+    fi
+    exit "${CARGO_CLIPPY_EXIT:-0}"
+    ;;
+esac
+exit 0
+EOF
+chmod +x "$BIN_DIR/cargo"
+
+# Run the hook from inside a fixture repo with a git-commit tool command on
+# stdin. Extra env assignments come as VAR=value args; the override var is
+# scrubbed from the parent environment first so only explicit settings apply.
+# Captures stdout in $out, stderr in $err, exit code in $rc; truncates the
+# shim log before each run.
+run_hook() {
+  local repo="$1"
+  shift
+  : >"$CARGO_LOG"
+  set +e
+  out=$( (cd "$repo" && env -u VSTACK_PRE_COMMIT_RUST_CLIPPY \
+    PATH="$BIN_DIR:$PATH" CARGO_LOG="$CARGO_LOG" "$@" \
+    bash "$HOOK" <<<'{"command": "git commit -m test"}') 2>"$ERR_FILE")
+  rc=$?
+  set -e
+  err="$(cat "$ERR_FILE")"
+  log="$(cat "$CARGO_LOG" 2>/dev/null || true)"
+}
+
+assert_eq() {
+  local got="$1" want="$2" name="$3"
+  if [[ "$got" == "$want" ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$name" "$want" "$got"
+  fi
+}
+
+assert_contains() {
+  local got="$1" needle="$2" name="$3"
+  if [[ "$got" == *"$needle"* ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected to contain: %s\n        got:      %s\n' "$name" "$needle" "$got"
+  fi
+}
+
+assert_not_contains() {
+  local got="$1" needle="$2" name="$3"
+  if [[ "$got" != *"$needle"* ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected NOT to contain: %s\n        got:      %s\n' "$name" "$needle" "$got"
+  fi
+}
+
+make_repo() {
+  local dir="$1"
+  mkdir -p "$dir"
+  git -C "$dir" init -q
+}
+
+# --- Fixture A: workspace root manifest + two member crates ------------------
+REPO_A="$TMP_ROOT/workspace-repo"
+make_repo "$REPO_A"
+cat >"$REPO_A/Cargo.toml" <<'EOF'
+[workspace]
+members = ["crates/foo", "crates/bar"]
+EOF
+mkdir -p "$REPO_A/crates/foo/src" "$REPO_A/crates/bar/src"
+cat >"$REPO_A/crates/foo/Cargo.toml" <<'EOF'
+[package]
+name = "foo"
+version = "0.1.0"
+
+[[bin]]
+name = "foo-bin"
+EOF
+cat >"$REPO_A/crates/bar/Cargo.toml" <<'EOF'
+[package]
+name = "bar"
+version = "0.1.0"
+EOF
+echo 'pub fn a() {}' >"$REPO_A/crates/foo/src/lib.rs"
+echo 'pub fn b() {}' >"$REPO_A/crates/foo/src/extra.rs"
+echo 'pub fn c() {}' >"$REPO_A/crates/bar/src/lib.rs"
+git -C "$REPO_A" add -A
+
+echo "=== pre-commit-check Rust clippy lane (vstack#737) ==="
+
+# --- Default: package-scoped clippy ------------------------------------------
+run_hook "$REPO_A"
+assert_eq "$rc" "0" "default run with clean shims exits 0"
+assert_contains "$log" "cargo fmt --check" "fmt lane still runs"
+assert_contains "$log" "cargo clippy -p bar -p foo --all-targets -- -D warnings" \
+  "default clippy is scoped to staged packages, deduped and sorted"
+assert_not_contains "$log" "--workspace" "default clippy does not use --workspace when packages resolve"
+
+# --- Workspace fallback when no package name resolves ------------------------
+REPO_B="$TMP_ROOT/virtual-repo"
+make_repo "$REPO_B"
+cat >"$REPO_B/Cargo.toml" <<'EOF'
+[workspace]
+members = []
+EOF
+mkdir -p "$REPO_B/src"
+echo 'fn main() {}' >"$REPO_B/src/main.rs"
+git -C "$REPO_B" add -A
+
+run_hook "$REPO_B"
+assert_eq "$rc" "0" "virtual-manifest run exits 0"
+assert_contains "$log" "cargo clippy --workspace --all-targets -- -D warnings" \
+  "clippy falls back to --workspace when no package resolves"
+
+# --- Nested manifest keeps --manifest-path and gains -p scoping --------------
+REPO_C="$TMP_ROOT/nested-repo"
+make_repo "$REPO_C"
+mkdir -p "$REPO_C/cli/src"
+cat >"$REPO_C/cli/Cargo.toml" <<'EOF'
+[package]
+name = "nested-cli"
+version = "0.1.0"
+EOF
+echo 'fn main() {}' >"$REPO_C/cli/src/main.rs"
+git -C "$REPO_C" add -A
+
+REPO_C_PHYS="$(cd "$REPO_C" && pwd -P)"
+run_hook "$REPO_C"
+assert_eq "$rc" "0" "nested-manifest run exits 0"
+assert_contains "$log" "cargo fmt --manifest-path $REPO_C_PHYS/cli/Cargo.toml --check" \
+  "fmt uses the nested manifest path"
+assert_contains "$log" "cargo clippy --manifest-path $REPO_C_PHYS/cli/Cargo.toml -p nested-cli --all-targets -- -D warnings" \
+  "clippy combines nested manifest path with package scoping"
+
+# --- Env override: run verbatim via bash -c ----------------------------------
+REPO_A_PHYS="$(cd "$REPO_A" && pwd -P)"
+run_hook "$REPO_A" VSTACK_PRE_COMMIT_RUST_CLIPPY='echo "override-ran $PWD" >>"$CARGO_LOG"'
+assert_eq "$rc" "0" "passing env override exits 0"
+assert_contains "$log" "override-ran $REPO_A_PHYS" "override command runs verbatim from the repo root"
+assert_not_contains "$log" "cargo clippy" "override replaces the default clippy invocation"
+
+run_hook "$REPO_A" VSTACK_PRE_COMMIT_RUST_CLIPPY='false'
+assert_eq "$rc" "2" "failing env override exits 2"
+assert_contains "$err" "configured Clippy check failed" "failing override reports the configured command"
+
+# --- off: skip the clippy lane entirely --------------------------------------
+run_hook "$REPO_A" VSTACK_PRE_COMMIT_RUST_CLIPPY=off
+assert_eq "$rc" "0" "off exits 0"
+assert_contains "$log" "cargo fmt --check" "off still runs the fmt lane"
+assert_not_contains "$log" "clippy" "off skips clippy entirely"
+
+# --- Settings-file fallback ---------------------------------------------------
+cat >"$REPO_A/vstack.settings.toml" <<EOF
+[env]
+VSTACK_PRE_COMMIT_RUST_CLIPPY = "echo settings-ran >>\$CARGO_LOG"
+EOF
+run_hook "$REPO_A"
+assert_eq "$rc" "0" "settings-file override exits 0"
+assert_contains "$log" "settings-ran" "settings-file [env] value is parsed and run"
+assert_not_contains "$log" "cargo clippy" "settings-file override replaces the default clippy invocation"
+
+# Env var wins over the settings file.
+run_hook "$REPO_A" VSTACK_PRE_COMMIT_RUST_CLIPPY='echo env-wins >>"$CARGO_LOG"'
+assert_contains "$log" "env-wins" "env override takes precedence over settings file"
+assert_not_contains "$log" "settings-ran" "settings value ignored when env override is set"
+
+printf '[env]\nVSTACK_PRE_COMMIT_RUST_CLIPPY = "off"\n' >"$REPO_A/vstack.settings.toml"
+run_hook "$REPO_A"
+assert_eq "$rc" "0" "settings-file off exits 0"
+assert_not_contains "$log" "clippy" "settings-file off skips clippy"
+rm "$REPO_A/vstack.settings.toml"
+
+# --- Diagnostics reach stderr on failure -------------------------------------
+run_hook "$REPO_A" CARGO_CLIPPY_EXIT=1
+assert_eq "$rc" "2" "clippy failure exits 2"
+assert_contains "$err" "clippy::float_cmp" "clippy diagnostics are no longer swallowed"
+assert_contains "$err" "cargo clippy found warnings" "clippy guidance line still present"
+
+run_hook "$REPO_A" CARGO_FMT_EXIT=1
+assert_eq "$rc" "2" "fmt failure exits 2"
+assert_contains "$err" "Diff in src/lib.rs" "fmt diagnostics are no longer swallowed"
+assert_contains "$err" "cargo fmt --check failed" "fmt guidance line still present"
+
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/vstack.settings.toml.example
+++ b/vstack.settings.toml.example
@@ -150,6 +150,24 @@ SECOND_OPINION_CLAUDE_CMD = "claude -p --no-session-persistence --model opus --e
 SECOND_OPINION_CODEX_CMD = "codex exec -m gpt-5.6-sol -s read-only -c model_reasoning_effort=xhigh --ephemeral"
 # Used by: second-opinion.
 
+# PRE-COMMIT HOOK
+
+# VSTACK_PRE_COMMIT_RUST_CLIPPY = "off"
+# Used by: hooks/pre-commit-check.sh (the Clippy lane for staged Rust files).
+# Three tiers:
+#   unset (default) — the hook runs `cargo clippy --all-targets -- -D warnings`
+#     scoped to the packages that own the staged .rs files (`-p <pkg>` per
+#     package), falling back to `--workspace` when no package resolves.
+#   "off" — skip the hook's Clippy lane entirely. Use when repo-owned
+#     validation (feature-matrix lanes, a project validator) is authoritative
+#     and the hook's default-feature lane could flag pre-existing warnings the
+#     staged change didn't introduce.
+#   any other value — run it verbatim via `bash -c` from the repo root as the
+#     Clippy check; its exit status decides. Use to pin the hook to the repo's
+#     canonical lint command, e.g. "cargo clippy --workspace --all-features
+#     --all-targets -- -D warnings" or "tools/validate --clippy".
+# The environment variable takes precedence over this file.
+
 # DEBUG / OVERRIDE HOOKS
 
 WORKTREE_CLI = ".agents/skills/worktree/scripts/worktree"


### PR DESCRIPTION
Closes #737.

The Rust lane of `hooks/pre-commit-check.sh` hard-coded `cargo clippy --workspace --all-targets` (default features) and discarded stderr — so commits were blocked by pre-existing warnings in unrelated crates/feature combos, with zero actionable output, and repos with intentional feature matrices couldn't align the hook with their canonical validation.

## Changes
- **Three-tier Clippy lane** via `VSTACK_PRE_COMMIT_RUST_CLIPPY` (parent env first, then a self-contained parse of the repo's `vstack.settings.toml` / `.vstack/settings.toml` `[env]` table): unset → default; `off` → skip the lane (repo-owned validation authoritative); any other value → run verbatim from the repo root, exit status decides. Documented in the root settings example.
- **Default lane now package-scoped**: staged .rs files → nearest Cargo.toml → `[package] name` (awk section-tracked so `[[bin]]`/dependency `name` keys can't leak) → deduped `-p` args; `--workspace` fallback when nothing resolves. Nested-manifest handling preserved.
- **Diagnostics unsuppressed**: fmt and clippy capture combined output; failures print the last 40 lines before the guidance message.
- Latent Bash 3.2 empty-array expansion bug fixed (`${arr[@]+...}` guards).

## Tests
New `hooks/tests/pre-commit-check.test.sh` (30/30): fixture repos + a cargo PATH shim recording invocations — package scoping/dedupe, workspace fallback, nested manifest, env override verbatim + failure exit, `off` semantics, settings fallback + precedence, diagnostics surfacing. CI: skill-tests.yml gains a hook-suites step and the executable-bits glob now covers `hooks/tests/*.sh` (hooks tests previously ran nowhere in CI).

https://claude.ai/code/session_017x6AyjyPypo3vbVyjB4Nhq