### PR TITLE
fix(hooks): pre-commit clippy runs per owning manifest — workspace-excluded crates

### DIFF
--- a/hooks/pre-commit-check.sh
+++ b/hooks/pre-commit-check.sh
@@ -3,7 +3,7 @@
 # name: pre-commit-check
 # event: PreToolUse
 # matcher: Bash
-# description: Validate formatting and lint before git commits on source files. Rust runs cargo fmt plus a Clippy lane scoped to the staged files' packages; VSTACK_PRE_COMMIT_RUST_CLIPPY (env or vstack.settings.toml [env]) replaces the Clippy lane with a repo-owned command or "off" skips it. Biome projects (JS/TS/JSON) check staged paths.
+# description: Validate formatting and lint before git commits on source files. Rust runs cargo fmt plus a Clippy lane scoped per staged file's owning crate manifest (workspace-excluded crates included); VSTACK_PRE_COMMIT_RUST_CLIPPY (env or vstack.settings.toml [env]) replaces the Clippy lane with a repo-owned command or "off" skips it. Biome projects (JS/TS/JSON) check staged paths.
 # safety: Prevents committing code that fails format or lint checks.
 # ---
 
@@ -68,7 +68,7 @@ if echo "$STAGED" | grep -qE '\.rs$'; then
   # Clippy lane, three tiers via VSTACK_PRE_COMMIT_RUST_CLIPPY (parent env
   # wins; then the repo's vstack.settings.toml / .vstack/settings.toml [env]
   # table — parsed inline because this hook must stay self-contained):
-  #   unset -> default clippy scoped to the staged files' packages
+  #   unset -> default clippy scoped per staged file's owning crate manifest
   #   "off" -> skip entirely (repo-owned validation is authoritative)
   #   other -> run verbatim via `bash -c`; its exit status decides
   CLIPPY_CMD="${VSTACK_PRE_COMMIT_RUST_CLIPPY:-}"
@@ -90,25 +90,31 @@ if echo "$STAGED" | grep -qE '\.rs$'; then
       exit 2
     fi
   else
-    # Default: scope clippy to the packages that own the staged .rs files so
-    # pre-existing warnings in unrelated workspace crates can't block the
-    # commit. Fall back to --workspace when no package name resolves (virtual
-    # manifest, parse failure).
-    PKG_NAMES=""
+    # Default: run clippy once per owning manifest — the nearest Cargo.toml
+    # with a [package] table above each staged .rs file. --manifest-path
+    # scopes cargo's default package selection to that package whether or
+    # not it is a member of the root workspace, so crates on the workspace
+    # `exclude` list lint against their own manifest instead of failing
+    # `-p` resolution from the repo root (vstack#742), and pre-existing
+    # warnings in unrelated workspace crates can't block the commit. Fall
+    # back to a single --workspace run when no owning manifest resolves
+    # (virtual manifest only, files outside any package).
+    OWNING_MANIFESTS=""
     if [ -n "$REPO_ROOT" ]; then
-      PKG_NAMES=$(echo "$STAGED" | grep -E '\.rs$' | while IFS= read -r path; do
+      OWNING_MANIFESTS=$(echo "$STAGED" | grep -E '\.rs$' | while IFS= read -r path; do
         dir=$(dirname "$path")
         while :; do
-          if [ -f "$REPO_ROOT/$dir/Cargo.toml" ]; then
-            # `name = "..."` from the [package] table only ([[bin]] and
-            # dependency tables also carry `name` keys).
-            awk '
-              /^[[:space:]]*\[/ { in_pkg = ($0 ~ /^[[:space:]]*\[package\][[:space:]]*(#.*)?$/); next }
-              in_pkg && /^[[:space:]]*name[[:space:]]*=/ {
-                if (match($0, /"[^"]*"/)) { print substr($0, RSTART + 1, RLENGTH - 2) }
-                exit
-              }
-            ' "$REPO_ROOT/$dir/Cargo.toml"
+          if [ "$dir" = "." ]; then
+            candidate="$REPO_ROOT/Cargo.toml"
+          else
+            candidate="$REPO_ROOT/$dir/Cargo.toml"
+          fi
+          if [ -f "$candidate" ]; then
+            # Only a manifest with a [package] table owns files; a virtual
+            # workspace manifest has no default package to scope to.
+            if grep -qE '^[[:space:]]*\[package\][[:space:]]*(#.*)?$' "$candidate"; then
+              echo "$candidate"
+            fi
             break
           fi
           if [ "$dir" = "." ] || [ "$dir" = "/" ] || [ -z "$dir" ]; then
@@ -119,25 +125,22 @@ if echo "$STAGED" | grep -qE '\.rs$'; then
       done | sort -u | grep -v '^$' || true)
     fi
 
-    PKG_ARGS=()
-    if [ -n "$PKG_NAMES" ]; then
-      while IFS= read -r pkg; do
-        PKG_ARGS+=(-p "$pkg")
+    if [ -n "$OWNING_MANIFESTS" ]; then
+      while IFS= read -r manifest; do
+        if ! CLIPPY_OUTPUT=$(cargo clippy --manifest-path "$manifest" --all-targets -- -D warnings 2>&1); then
+          print_output_tail "$CLIPPY_OUTPUT"
+          echo "cargo clippy found warnings in $manifest. Fix them before committing." >&2
+          exit 2
+        fi
       done <<EOF
-$PKG_NAMES
+$OWNING_MANIFESTS
 EOF
-    fi
-
-    if [ -n "$PKG_NAMES" ]; then
-      SCOPE_ARGS=(${PKG_ARGS[@]+"${PKG_ARGS[@]}"})
     else
-      SCOPE_ARGS=(--workspace)
-    fi
-
-    if ! CLIPPY_OUTPUT=$(cargo clippy ${MANIFEST_ARGS[@]+"${MANIFEST_ARGS[@]}"} ${SCOPE_ARGS[@]+"${SCOPE_ARGS[@]}"} --all-targets -- -D warnings 2>&1); then
-      print_output_tail "$CLIPPY_OUTPUT"
-      echo "cargo clippy found warnings. Fix them before committing." >&2
-      exit 2
+      if ! CLIPPY_OUTPUT=$(cargo clippy ${MANIFEST_ARGS[@]+"${MANIFEST_ARGS[@]}"} --workspace --all-targets -- -D warnings 2>&1); then
+        print_output_tail "$CLIPPY_OUTPUT"
+        echo "cargo clippy found warnings. Fix them before committing." >&2
+        exit 2
+      fi
     fi
   fi
 fi

--- a/hooks/tests/pre-commit-check.test.sh
+++ b/hooks/tests/pre-commit-check.test.sh
@@ -1,14 +1,17 @@
 #!/usr/bin/env bash
-# Regression tests for the pre-commit-check hook's Rust Clippy lane (vstack#737).
+# Regression tests for the pre-commit-check hook's Rust Clippy lane
+# (vstack#737, vstack#742).
 #
 # The hook previously hard-coded `cargo clippy --workspace --all-targets`
 # with stderr discarded, so commits failed on pre-existing warnings in
 # unrelated crates with no actionable output and no way to configure the
 # lane. These tests assert the three-tier VSTACK_PRE_COMMIT_RUST_CLIPPY
-# semantics (unset -> package-scoped default, "off" -> skip, custom -> run
-# verbatim via bash -c), the vstack.settings.toml fallback, the --workspace
-# fallback when no package resolves, the nested-manifest --manifest-path
-# behavior, and that fmt/clippy diagnostics now reach stderr on failure.
+# semantics (unset -> per-owning-manifest default, "off" -> skip, custom ->
+# run verbatim via bash -c), the vstack.settings.toml fallback, the
+# --workspace fallback when no owning manifest resolves, the
+# nested-manifest behavior, that workspace-excluded crates lint against
+# their own manifest instead of failing `-p` resolution (vstack#742), and
+# that fmt/clippy diagnostics reach stderr on failure.
 #
 # `cargo` is stubbed with a PATH shim that records invocations, so the suite
 # needs no Rust toolchain or real workspace.
@@ -133,18 +136,22 @@ echo 'pub fn a() {}' >"$REPO_A/crates/foo/src/lib.rs"
 echo 'pub fn b() {}' >"$REPO_A/crates/foo/src/extra.rs"
 echo 'pub fn c() {}' >"$REPO_A/crates/bar/src/lib.rs"
 git -C "$REPO_A" add -A
+REPO_A_PHYS="$(cd "$REPO_A" && pwd -P)"
 
-echo "=== pre-commit-check Rust clippy lane (vstack#737) ==="
+echo "=== pre-commit-check Rust clippy lane (vstack#737, vstack#742) ==="
 
-# --- Default: package-scoped clippy ------------------------------------------
+# --- Default: one clippy run per owning manifest ------------------------------
 run_hook "$REPO_A"
 assert_eq "$rc" "0" "default run with clean shims exits 0"
 assert_contains "$log" "cargo fmt --check" "fmt lane still runs"
-assert_contains "$log" "cargo clippy -p bar -p foo --all-targets -- -D warnings" \
-  "default clippy is scoped to staged packages, deduped and sorted"
-assert_not_contains "$log" "--workspace" "default clippy does not use --workspace when packages resolve"
+assert_contains "$log" "cargo clippy --manifest-path $REPO_A_PHYS/crates/bar/Cargo.toml --all-targets -- -D warnings" \
+  "default clippy runs against bar's manifest"
+assert_contains "$log" "cargo clippy --manifest-path $REPO_A_PHYS/crates/foo/Cargo.toml --all-targets -- -D warnings" \
+  "default clippy runs against foo's manifest (deduped across its staged files)"
+assert_not_contains "$log" " -p " "default clippy no longer passes -p package args"
+assert_not_contains "$log" "--workspace" "default clippy does not use --workspace when manifests resolve"
 
-# --- Workspace fallback when no package name resolves ------------------------
+# --- Workspace fallback when no owning manifest resolves ----------------------
 REPO_B="$TMP_ROOT/virtual-repo"
 make_repo "$REPO_B"
 cat >"$REPO_B/Cargo.toml" <<'EOF'
@@ -158,9 +165,9 @@ git -C "$REPO_B" add -A
 run_hook "$REPO_B"
 assert_eq "$rc" "0" "virtual-manifest run exits 0"
 assert_contains "$log" "cargo clippy --workspace --all-targets -- -D warnings" \
-  "clippy falls back to --workspace when no package resolves"
+  "clippy falls back to --workspace when no owning manifest resolves"
 
-# --- Nested manifest keeps --manifest-path and gains -p scoping --------------
+# --- Nested manifest: clippy targets the nested crate's own manifest ----------
 REPO_C="$TMP_ROOT/nested-repo"
 make_repo "$REPO_C"
 mkdir -p "$REPO_C/cli/src"
@@ -177,11 +184,44 @@ run_hook "$REPO_C"
 assert_eq "$rc" "0" "nested-manifest run exits 0"
 assert_contains "$log" "cargo fmt --manifest-path $REPO_C_PHYS/cli/Cargo.toml --check" \
   "fmt uses the nested manifest path"
-assert_contains "$log" "cargo clippy --manifest-path $REPO_C_PHYS/cli/Cargo.toml -p nested-cli --all-targets -- -D warnings" \
-  "clippy combines nested manifest path with package scoping"
+assert_contains "$log" "cargo clippy --manifest-path $REPO_C_PHYS/cli/Cargo.toml --all-targets -- -D warnings" \
+  "clippy targets the nested crate's own manifest"
+assert_not_contains "$log" " -p " "nested-manifest clippy passes no -p args"
+
+# --- Workspace-excluded crate lints against its own manifest (vstack#742) -----
+REPO_D="$TMP_ROOT/excluded-repo"
+make_repo "$REPO_D"
+cat >"$REPO_D/Cargo.toml" <<'EOF'
+[workspace]
+members = ["crates/member"]
+exclude = ["standalone"]
+EOF
+mkdir -p "$REPO_D/crates/member/src" "$REPO_D/standalone/src"
+cat >"$REPO_D/crates/member/Cargo.toml" <<'EOF'
+[package]
+name = "member"
+version = "0.1.0"
+EOF
+cat >"$REPO_D/standalone/Cargo.toml" <<'EOF'
+[package]
+name = "fixture-generator"
+version = "0.1.0"
+EOF
+echo 'pub fn m() {}' >"$REPO_D/crates/member/src/lib.rs"
+echo 'pub fn s() {}' >"$REPO_D/standalone/src/lib.rs"
+git -C "$REPO_D" add -A
+
+REPO_D_PHYS="$(cd "$REPO_D" && pwd -P)"
+run_hook "$REPO_D"
+assert_eq "$rc" "0" "excluded-crate commit is not blocked"
+assert_contains "$log" "cargo clippy --manifest-path $REPO_D_PHYS/standalone/Cargo.toml --all-targets -- -D warnings" \
+  "excluded crate lints against its own manifest"
+assert_contains "$log" "cargo clippy --manifest-path $REPO_D_PHYS/crates/member/Cargo.toml --all-targets -- -D warnings" \
+  "member crate staged alongside still gets its own run"
+assert_not_contains "$log" " -p " "excluded-crate run passes no -p args"
+assert_not_contains "$log" "--workspace" "excluded-crate run does not fall back to --workspace"
 
 # --- Env override: run verbatim via bash -c ----------------------------------
-REPO_A_PHYS="$(cd "$REPO_A" && pwd -P)"
 run_hook "$REPO_A" VSTACK_PRE_COMMIT_RUST_CLIPPY='echo "override-ran $PWD" >>"$CARGO_LOG"'
 assert_eq "$rc" "0" "passing env override exits 0"
 assert_contains "$log" "override-ran $REPO_A_PHYS" "override command runs verbatim from the repo root"
@@ -222,7 +262,8 @@ rm "$REPO_A/vstack.settings.toml"
 run_hook "$REPO_A" CARGO_CLIPPY_EXIT=1
 assert_eq "$rc" "2" "clippy failure exits 2"
 assert_contains "$err" "clippy::float_cmp" "clippy diagnostics are no longer swallowed"
-assert_contains "$err" "cargo clippy found warnings" "clippy guidance line still present"
+assert_contains "$err" "cargo clippy found warnings in $REPO_A_PHYS/crates/bar/Cargo.toml" \
+  "clippy guidance names the failing manifest"
 
 run_hook "$REPO_A" CARGO_FMT_EXIT=1
 assert_eq "$rc" "2" "fmt failure exits 2"

--- a/vstack.settings.toml.example
+++ b/vstack.settings.toml.example
@@ -160,8 +160,9 @@ SECOND_OPINION_CODEX_CMD = "codex exec -m gpt-5.6-sol -s read-only -c model_reas
 # Used by: hooks/pre-commit-check.sh (the Clippy lane for staged Rust files).
 # Three tiers:
 #   unset (default) — the hook runs `cargo clippy --all-targets -- -D warnings`
-#     scoped to the packages that own the staged .rs files (`-p <pkg>` per
-#     package), falling back to `--workspace` when no package resolves.
+#     once per crate manifest owning a staged .rs file (`--manifest-path`, so
+#     workspace-excluded crates lint against their own manifest), falling back
+#     to `--workspace` when no owning manifest resolves.
 #   "off" — skip the hook's Clippy lane entirely. Use when repo-owned
 #     validation (feature-matrix lanes, a project validator) is authoritative
 #     and the hook's default-feature lane could flag pre-existing warnings the


### PR DESCRIPTION
Closes #742.

Follow-up to #738, found by review bot on the hyprtrade propagation (hyprtrade#349): package-name `-p` scoping fails with "package not found in workspace" when a staged .rs file belongs to a crate on the root workspace's `exclude` list, spuriously blocking valid commits.

The default lane now resolves each staged .rs file to its owning manifest (nearest Cargo.toml WITH a `[package]` table — virtual workspace manifests don't own files) and runs `cargo clippy --manifest-path <manifest> --all-targets -- -D warnings` once per deduped manifest. Cargo's default package selection scopes correctly whether the crate is a workspace member or excluded/standalone, so the `[package] name` extraction and `-p` args are gone entirely. `--workspace` fallback (with nested-manifest args) remains for files no `[package]` manifest owns; failure messages now name the failing manifest.

Tests: 38/38 — new mixed fixture (excluded crate + member crate staged together, each linting against its own manifest, no `-p`, no `--workspace`), all #738 override/off/settings/diagnostics tests adapted and green.

https://claude.ai/code/session_017x6AyjyPypo3vbVyjB4Nhq