### PR TITLE
pi-claude-bridge: mainline connector support + isolated mode (CLAUDE_BRIDGE_ISOLATED)

### DIFF
--- a/pi-extensions/pi-claude-bridge/DEVELOPMENT.md
+++ b/pi-extensions/pi-claude-bridge/DEVELOPMENT.md
@@ -13,5 +13,6 @@ Implementation details for contributors. End-user setup, settings, and troublesh
 
 - Rate-limit errors are deduplicated before user notification. The bridge emits `vstack:rate-limit` so `pi-qol` can opt into reset-time auto-resume.
 - Stream-idle stalls close the stalled Claude Code subprocess and return a retryable assistant error. `CLAUDE_BRIDGE_STREAM_IDLE_TIMEOUT` accepts bare seconds or `ms`, `s`, and `m` suffixes.
-- Integrity diagnostics are written to `~/.pi/agent/claude-bridge-diag.log` with counts, affected tool names, and sampled tool-call IDs.
+- Integrity diagnostics are written to `<piUserDir>/claude-bridge-diag.log` (`PI_CODING_AGENT_DIR` when set, else `~/.pi/agent`) with counts, affected tool names, and sampled tool-call IDs.
+- `CLAUDE_BRIDGE_ISOLATED=1` (embedding hosts) disables all cwd/home discovery fallbacks: the cwd `AGENTS.md` walk, project `.pi/` settings + `claude-bridge.json`, project `APPEND_SYSTEM.md`, and the `$PATH` claude executable search. See `isolatedFromEnv` in `src/config.ts`.
 - Startup preflight failures preserve the underlying `code`, `errno`, `syscall`, `path`, `cwd`, and detected executable file type before handing the error back to the SDK.

--- a/pi-extensions/pi-claude-bridge/README.md
+++ b/pi-extensions/pi-claude-bridge/README.md
@@ -94,6 +94,26 @@ Pi 0.80.6 and newer expose native `max` thinking. Fable 5 bridge metadata forwar
 
 Keys may be bare model IDs (`claude-opus-4-8`), `claude-bridge/<id>`, or `*` for all bridge models. Values are `low`, `medium`, `high`, `xhigh`, or `max`.
 
+### Connectors
+
+The bridge can expose the authenticated Claude account's claude.ai cloud MCP connectors (Gmail, Google Calendar, Google Drive) to the model. These are low-level `provider` options (set in `settings.json` under the extension-manager config, or via env). Off by default so Pi owns tool execution.
+
+| Option (`provider.*`) | Env var | Values | Default | What it does |
+| --- | --- | --- | --- | --- |
+| `enableConnectors` | `CLAUDE_BRIDGE_ENABLE_CONNECTORS` | `true`/`false` | off | Expose the account's Gmail/Calendar/Drive connectors to the model (env OR config enables). |
+| `connectorWriteMode` | `CLAUDE_BRIDGE_CONNECTOR_WRITE` | `deny`/`allow` | `deny` | When connectors are enabled, whether their WRITE tools are exposed. |
+
+For both, the env var wins over config. `connectorWriteMode` only matters when connectors are enabled. Any value other than exactly `allow` is treated as `deny` (fail-closed).
+
+With `connectorWriteMode: "deny"` (the default), connector sessions are **read-only**: search/read/fetch/list tools stay available, but mutating tools (Gmail `create_draft`/labels, Calendar `create_event`/`update_event`/`delete_event`/`respond_to_event`, Drive `create_file`/`copy_file`) are denied. Enforcement is two-layered:
+
+- **Model context:** the known write tools are passed as `disallowedTools` (exact tool ids), so the model does not see them. (Note: the CLI's MCP permission matcher only supports exact tool names or a whole-server `mcp__server__*` glob — partial tool-segment globs are inert — so exact ids are what actually removes today's writes.)
+- **Runtime:** a `PreToolUse` hook blocks any connector tool classified as a write at call time, regardless of permission mode. Classification is **fail-closed** — a tool on a connector namespace is a write unless its verb is a known read prefix (`list_`, `search_`, `get_`, `read_`, `fetch_`, …). This covers not-yet-known write tools (e.g. a future Gmail `send_message` or Drive `delete_file`) that the static id list can't enumerate.
+
+Set `allow` only for a one-shot write-executor session that has already obtained explicit user approval — never for an interactive connector chat.
+
+> **`allow` is per-process, not global.** Memsira's approved-write executor enables writes by setting `CLAUDE_BRIDGE_CONNECTOR_WRITE=allow` in the **child env of a dedicated one-shot process** that runs the single approved write and exits. Do not set `connectorWriteMode: "allow"` in persistent `settings.json` (or `allow` process-globally) for a shared/long-lived sidecar — that would make every connector session in that process write-capable, defeating the approval gate.
+
 ### Fable 5 caveat
 
 The bridge registers `claude-bridge/claude-fable-5`, `claude-bridge/claude-sonnet-5`, and `claude-bridge/claude-opus-4-8` even when Pi's Anthropic model registry has not shipped those entries yet. For Fable 5, the bridge asks Claude Code to use Opus 4.8 as the availability fallback and preserves Claude Code's content-safety fallback events so Pi labels rerouted turns as Opus 4.8. Content-safety fallback still depends on Claude Code's own Fable 5 support; use Claude Code 2.1.170 or newer, and set `ANTHROPIC_DEFAULT_FABLE_MODEL` / `ANTHROPIC_DEFAULT_OPUS_MODEL` yourself when routing provider-specific model IDs through Bedrock, Vertex, or Foundry.

--- a/pi-extensions/pi-claude-bridge/README.md
+++ b/pi-extensions/pi-claude-bridge/README.md
@@ -114,6 +114,17 @@ Set `allow` only for a one-shot write-executor session that has already obtained
 
 > **`allow` is per-process, not global.** Memsira's approved-write executor enables writes by setting `CLAUDE_BRIDGE_CONNECTOR_WRITE=allow` in the **child env of a dedicated one-shot process** that runs the single approved write and exits. Do not set `connectorWriteMode: "allow"` in persistent `settings.json` (or `allow` process-globally) for a shared/long-lived sidecar — that would make every connector session in that process write-capable, defeating the approval gate.
 
+### Isolated mode (embedding hosts)
+
+Host apps that embed the bridge and own every config dir explicitly can set `CLAUDE_BRIDGE_ISOLATED=1` in the bridge process env. Isolated mode disables every cwd/home discovery fallback so nothing outside the host-owned dirs is read:
+
+- no cwd-ancestor `AGENTS.md` walk — instructions come only from `<PI_CODING_AGENT_DIR>/AGENTS.md`;
+- no project `.pi/settings.json` / `.pi/claude-bridge.json` reads (even for trusted projects);
+- no project `.pi/APPEND_SYSTEM.md`;
+- no `$PATH` search for the `claude` executable — the host either pins `pathToClaudeCodeExecutable` or gets the Claude Agent SDK's bundled default.
+
+Config, logs, and `AGENTS.md` all resolve under `PI_CODING_AGENT_DIR`. Normal pi CLI usage (flag unset) is unchanged.
+
 ### Fable 5 caveat
 
 The bridge registers `claude-bridge/claude-fable-5`, `claude-bridge/claude-sonnet-5`, and `claude-bridge/claude-opus-4-8` even when Pi's Anthropic model registry has not shipped those entries yet. For Fable 5, the bridge asks Claude Code to use Opus 4.8 as the availability fallback and preserves Claude Code's content-safety fallback events so Pi labels rerouted turns as Opus 4.8. Content-safety fallback still depends on Claude Code's own Fable 5 support; use Claude Code 2.1.170 or newer, and set `ANTHROPIC_DEFAULT_FABLE_MODEL` / `ANTHROPIC_DEFAULT_OPUS_MODEL` yourself when routing provider-specific model IDs through Bedrock, Vertex, or Foundry.
@@ -130,9 +141,9 @@ If Claude Code accepts a turn but produces no visible output, the bridge returns
 
 ## Debugging
 
-Set `CLAUDE_BRIDGE_DEBUG=1` to write bridge logs to `~/.pi/agent/claude-bridge.log` and per-query Claude Code CLI logs under `~/.pi/agent/cc-cli-logs/`.
+Set `CLAUDE_BRIDGE_DEBUG=1` to write bridge logs to `<agent dir>/claude-bridge.log` and per-query Claude Code CLI logs under `<agent dir>/cc-cli-logs/`, where `<agent dir>` is `PI_CODING_AGENT_DIR` when set, else `~/.pi/agent`. Override the exact files with `CLAUDE_BRIDGE_DEBUG_PATH` / `CLAUDE_BRIDGE_DIAG_PATH`.
 
-Tool-result integrity problems are surfaced even when debug logging is off. Pi shows an error notification and writes a diagnostic file to `~/.pi/agent/claude-bridge-diag.log` so lost or mismatched tool output is visible.
+Tool-result integrity problems are surfaced even when debug logging is off. Pi shows an error notification and writes a diagnostic file to `<agent dir>/claude-bridge-diag.log` so lost or mismatched tool output is visible.
 
 Startup failures include the resolved Claude executable and working directory, which makes missing binaries and wrong launch directories easier to fix.
 

--- a/pi-extensions/pi-claude-bridge/bundle/index.js
+++ b/pi-extensions/pi-claude-bridge/bundle/index.js
@@ -21978,7 +21978,6 @@ import { spawn as spawnProcess } from "child_process";
 import { createHash } from "crypto";
 import { accessSync, appendFileSync as appendFileSync3, chmodSync, constants as fsConstants, mkdirSync as mkdirSync3, readFileSync as readFileSync7, realpathSync as realpathSync3, statSync as statSync3 } from "fs";
 import { resolve as pathResolve } from "path";
-import { homedir as homedir6 } from "os";
 import { delimiter, dirname as dirname5, join as join6 } from "path";
 
 // node_modules/change-case/dist/index.js
@@ -22657,6 +22656,10 @@ function expandHome(input) {
 function piUserDir() {
   return resolve(expandHome(process.env.PI_CODING_AGENT_DIR?.trim() || "~/.pi/agent"));
 }
+function isolatedFromEnv() {
+  const v2 = (process.env.CLAUDE_BRIDGE_ISOLATED ?? "").trim().toLowerCase();
+  return v2 === "1" || v2 === "true" || v2 === "yes" || v2 === "on";
+}
 function asRecord(value) {
   return value && typeof value === "object" && !Array.isArray(value) ? value : void 0;
 }
@@ -22706,6 +22709,7 @@ function projectSettingsTrusted(settingsPath) {
 }
 function settingsPaths(cwd) {
   const user = join2(piUserDir(), "settings.json");
+  if (isolatedFromEnv()) return [user];
   const project = projectSettingsPath(cwd);
   return projectSettingsTrusted(project) ? [user, project] : [user];
 }
@@ -22828,8 +22832,9 @@ function managerToConfig(raw) {
 }
 function loadConfig(cwd) {
   const global2 = tryParseJson(join2(piUserDir(), "claude-bridge.json"));
-  const projectSettings = projectSettingsPath(cwd);
-  const trustedProject = projectSettingsTrusted(projectSettings);
+  const isolated = isolatedFromEnv();
+  const projectSettings = isolated ? void 0 : projectSettingsPath(cwd);
+  const trustedProject = projectSettings !== void 0 && projectSettingsTrusted(projectSettings);
   const project = trustedProject ? tryParseJson(join2(dirname2(projectSettings), "claude-bridge.json")) : {};
   const manager = managerToConfig(readManagerConfig(cwd));
   const provider = normalizeProviderConfig({ ...global2.provider, ...project.provider, ...manager.provider });
@@ -22889,13 +22894,17 @@ function decideRegistration(state) {
 
 // src/agents-md.ts
 import { existsSync as existsSync5, readFileSync as readFileSync5 } from "fs";
-import { homedir as homedir4 } from "os";
 import { dirname as dirname3, join as join4, resolve as resolve2 } from "path";
-var GLOBAL_AGENTS_PATH = join4(homedir4(), ".pi", "agent", "AGENTS.md");
+function globalAgentsPath() {
+  return join4(piUserDir(), "AGENTS.md");
+}
 function resolveAgentsMdPath() {
-  const fromCwd = findAgentsMdInParents(process.cwd());
-  if (fromCwd) return fromCwd;
-  if (existsSync5(GLOBAL_AGENTS_PATH)) return GLOBAL_AGENTS_PATH;
+  if (!isolatedFromEnv()) {
+    const fromCwd = findAgentsMdInParents(process.cwd());
+    if (fromCwd) return fromCwd;
+  }
+  const globalPath = globalAgentsPath();
+  if (existsSync5(globalPath)) return globalPath;
   return void 0;
 }
 function findAgentsMdInParents(startDir) {
@@ -22934,13 +22943,7 @@ function sanitizeAgentsContent(content) {
 
 // src/prompt-context.ts
 import { existsSync as existsSync6, readFileSync as readFileSync6 } from "fs";
-import { homedir as homedir5 } from "os";
 import { dirname as dirname4, join as join5, resolve as resolve3 } from "path";
-function piUserDir2() {
-  const configured = process.env.PI_CODING_AGENT_DIR?.trim();
-  if (configured) return resolve3(configured.replace(/^~(?=\/|$)/, homedir5()));
-  return join5(homedir5(), ".pi", "agent");
-}
 function readTrimmed(path) {
   try {
     if (!existsSync6(path)) return void 0;
@@ -22963,9 +22966,9 @@ function findProjectAppendSystem(startDir) {
 }
 function readAppendSystemPromptFiles(cwd) {
   const files = [
-    { label: "global APPEND_SYSTEM.md", path: join5(piUserDir2(), "APPEND_SYSTEM.md") }
+    { label: "global APPEND_SYSTEM.md", path: join5(piUserDir(), "APPEND_SYSTEM.md") }
   ];
-  const projectPath = findProjectAppendSystem(cwd);
+  const projectPath = isolatedFromEnv() ? void 0 : findProjectAppendSystem(cwd);
   if (projectPath) files.push({ label: "project .pi/APPEND_SYSTEM.md", path: projectPath });
   const seen = /* @__PURE__ */ new Set();
   const output = [];
@@ -37639,10 +37642,9 @@ var _piAi = piAi;
 var getModels = await resolveGetModels(_piAi);
 var newAssistantMessageEventStream = typeof _piAi.createAssistantMessageEventStream === "function" ? _piAi.createAssistantMessageEventStream : () => new _piAi.AssistantMessageEventStream();
 var DEBUG = process.env.CLAUDE_BRIDGE_DEBUG === "1";
-var DEBUG_LOG_PATH = process.env.CLAUDE_BRIDGE_DEBUG_PATH || join6(homedir6(), ".pi", "agent", "claude-bridge.log");
-var DEFAULT_DIAG_LOG_PATH = join6(homedir6(), ".pi", "agent", "claude-bridge-diag.log");
+var DEBUG_LOG_PATH = process.env.CLAUDE_BRIDGE_DEBUG_PATH || join6(piUserDir(), "claude-bridge.log");
 function diagLogPath() {
-  return process.env.CLAUDE_BRIDGE_DIAG_PATH || DEFAULT_DIAG_LOG_PATH;
+  return process.env.CLAUDE_BRIDGE_DIAG_PATH || join6(piUserDir(), "claude-bridge-diag.log");
 }
 if (DEBUG) {
   try {
@@ -37682,6 +37684,7 @@ function executableFromPath(name) {
 function resolveClaudeExecutable(configured) {
   const trimmed = configured?.trim();
   if (trimmed) return trimmed;
+  if (isolatedFromEnv()) return void 0;
   return executableFromPath("claude") ?? executableFromPath("claude-code");
 }
 function errnoValue(err) {
@@ -39640,6 +39643,7 @@ export {
   processAssistantMessage,
   processStreamEvent,
   reportToolResultMismatch,
+  resolveClaudeExecutable,
   resolveConfiguredEffort,
   restoreSharedSessionFromPi,
   shouldRestorePersistedBridgeEntry,

--- a/pi-extensions/pi-claude-bridge/bundle/index.js
+++ b/pi-extensions/pi-claude-bridge/bundle/index.js
@@ -22741,6 +22741,12 @@ function stringFrom(raw, key) {
 function hasOwn(raw, key) {
   return Object.prototype.hasOwnProperty.call(raw, key);
 }
+function normalizeConnectorWriteMode(value) {
+  if (typeof value !== "string") return void 0;
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "deny" || normalized === "allow") return normalized;
+  return void 0;
+}
 function normalizeEffortLevel(value) {
   if (typeof value !== "string") return void 0;
   const normalized = value.trim().toLowerCase();
@@ -22778,6 +22784,9 @@ function normalizeProviderConfig(provider) {
   const modelEffortOverrides = normalizeModelEffortOverrides(raw.modelEffortOverrides);
   if (modelEffortOverrides) out.modelEffortOverrides = modelEffortOverrides;
   else delete out.modelEffortOverrides;
+  const connectorWriteMode = normalizeConnectorWriteMode(raw.connectorWriteMode);
+  if (connectorWriteMode) out.connectorWriteMode = connectorWriteMode;
+  else delete out.connectorWriteMode;
   return out;
 }
 function managerToConfig(raw) {
@@ -22799,6 +22808,8 @@ function managerToConfig(raw) {
   if (strictMcpConfig !== void 0) provider.strictMcpConfig = strictMcpConfig;
   const enableConnectors = boolFrom(raw, "enableConnectors");
   if (enableConnectors !== void 0) provider.enableConnectors = enableConnectors;
+  const connectorWriteMode = normalizeConnectorWriteMode(raw.connectorWriteMode);
+  if (connectorWriteMode) provider.connectorWriteMode = connectorWriteMode;
   const claudePath = stringFrom(raw, "pathToClaudeCodeExecutable");
   if (claudePath) provider.pathToClaudeCodeExecutable = claudePath;
   const includeAppendSystemPromptMd = boolFrom(raw, "includeAppendSystemPromptMd");
@@ -38000,9 +38011,85 @@ var CLAUDE_AI_CONNECTOR_TOOL_PATTERNS = [
   "mcp__claude_ai_Google_Drive__*"
 ];
 var CONNECTOR_DISCOVERY_TOOLS = ["ToolSearch", "ListMcpResources", "ReadMcpResource"];
-function toolIsolationForQuery(connectorsEnabled) {
+var CONNECTOR_NS_GMAIL = "mcp__claude_ai_Gmail__";
+var CONNECTOR_NS_CALENDAR = "mcp__claude_ai_Google_Calendar__";
+var CONNECTOR_NS_DRIVE = "mcp__claude_ai_Google_Drive__";
+var CONNECTOR_NAMESPACES = [CONNECTOR_NS_GMAIL, CONNECTOR_NS_CALENDAR, CONNECTOR_NS_DRIVE];
+var CONNECTOR_READ_PREFIXES = [
+  "list_",
+  "search_",
+  "get_",
+  "read_",
+  "fetch_",
+  "find_",
+  "download_",
+  "describe_",
+  "query_",
+  "count_",
+  "view_"
+];
+var CONNECTOR_WRITE_TOOLS = [
+  `${CONNECTOR_NS_GMAIL}create_draft`,
+  `${CONNECTOR_NS_GMAIL}create_label`,
+  `${CONNECTOR_NS_GMAIL}label_message`,
+  `${CONNECTOR_NS_GMAIL}label_thread`,
+  `${CONNECTOR_NS_GMAIL}unlabel_message`,
+  `${CONNECTOR_NS_GMAIL}unlabel_thread`,
+  `${CONNECTOR_NS_GMAIL}apply_sensitive_label`,
+  `${CONNECTOR_NS_GMAIL}remove_sensitive_label`,
+  `${CONNECTOR_NS_CALENDAR}create_event`,
+  `${CONNECTOR_NS_CALENDAR}update_event`,
+  `${CONNECTOR_NS_CALENDAR}delete_event`,
+  `${CONNECTOR_NS_CALENDAR}respond_to_event`,
+  `${CONNECTOR_NS_DRIVE}create_file`,
+  `${CONNECTOR_NS_DRIVE}copy_file`
+];
+function isConnectorWriteTool(name) {
+  const ns2 = CONNECTOR_NAMESPACES.find((n10) => name.startsWith(n10));
+  if (!ns2) return false;
+  const tool = name.slice(ns2.length);
+  return !CONNECTOR_READ_PREFIXES.some((prefix) => tool.startsWith(prefix));
+}
+function connectorWriteModeFromEnv() {
+  const v2 = (process.env.CLAUDE_BRIDGE_CONNECTOR_WRITE ?? "").trim().toLowerCase();
+  if (v2 === "allow") return "allow";
+  if (v2 === "deny") return "deny";
+  return void 0;
+}
+function connectorWriteModeFor(config2) {
+  const resolved = connectorWriteModeFromEnv() ?? normalizeConnectorWriteMode(config2?.provider?.connectorWriteMode);
+  return resolved === "allow" ? "allow" : "deny";
+}
+function connectorWriteDenyHook() {
+  return async (input) => {
+    try {
+      if (input.hook_event_name !== "PreToolUse") return { continue: true };
+      if (!isConnectorWriteTool(input.tool_name)) return { continue: true };
+      return connectorWriteDenyOutput(String(input.tool_name));
+    } catch {
+      const toolName = typeof input?.tool_name === "string" ? input.tool_name : "<unknown>";
+      return connectorWriteDenyOutput(toolName);
+    }
+  };
+}
+function connectorWriteDenyOutput(toolName) {
+  return {
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: `Connector write tool "${toolName}" is blocked in read-only connector mode. Connector writes must go through Memsira's gated approval flow.`
+    }
+  };
+}
+function connectorQueryOptions(connectorsEnabled, writeMode = "deny") {
+  const isolation = toolIsolationForQuery(connectorsEnabled, writeMode);
+  if (!connectorsEnabled || writeMode === "allow") return isolation;
+  return { ...isolation, hooks: { PreToolUse: [{ hooks: [connectorWriteDenyHook()] }] } };
+}
+function toolIsolationForQuery(connectorsEnabled, writeMode = "deny") {
   if (!connectorsEnabled) return CLAUDE_BRIDGE_TOOL_ISOLATION;
   const disallowedTools = DISALLOWED_BUILTIN_TOOLS.filter((t10) => !CONNECTOR_DISCOVERY_TOOLS.includes(t10));
+  if (writeMode !== "allow") disallowedTools.push(...CONNECTOR_WRITE_TOOLS);
   return {
     disallowedTools,
     allowedTools: [...CLAUDE_BRIDGE_TOOL_ISOLATION.allowedTools, ...CLAUDE_AI_CONNECTOR_TOOL_PATTERNS]
@@ -39059,6 +39146,7 @@ function streamClaudeAgentSdk(model, context, options) {
   const bridgeConfig = loadConfig(cwd);
   const providerSettings = bridgeConfig.provider ?? {};
   const enableCloudMcp = connectorsEnabledFor(bridgeConfig);
+  const connectorWriteMode = connectorWriteModeFor(bridgeConfig);
   const appendSystemPrompt = providerSettings.appendSystemPrompt !== false;
   const agentsAppend = appendSystemPrompt ? extractAgentsAppend() : void 0;
   const skillsAppend = appendSystemPrompt ? extractSkillsBlock(context.systemPrompt) : void 0;
@@ -39081,7 +39169,7 @@ function streamClaudeAgentSdk(model, context, options) {
     cwd,
     model: model.id,
     env: childEnv,
-    ...toolIsolationForQuery(enableCloudMcp),
+    ...connectorQueryOptions(enableCloudMcp, connectorWriteMode),
     permissionMode: "bypassPermissions",
     includePartialMessages: true,
     ...fallbackModel ? { fallbackModel } : {},
@@ -39408,6 +39496,7 @@ export {
   CLAUDE_AI_CONNECTOR_TOOL_PATTERNS,
   CLAUDE_BRIDGE_TOOL_ISOLATION,
   CONNECTOR_DISCOVERY_TOOLS,
+  CONNECTOR_WRITE_TOOLS,
   DEFAULT_STREAM_IDLE_TIMEOUT_MS,
   DISALLOWED_BUILTIN_TOOLS,
   STREAM_IDLE_BACKOFF_HINT_MS,
@@ -39416,12 +39505,17 @@ export {
   __testSetBridgeIntegrityState,
   buildStreamIdleTimeoutErrorMessage,
   classifyClaudeExecutableBytes,
+  connectorQueryOptions,
+  connectorWriteDenyHook,
+  connectorWriteModeFor,
+  connectorWriteModeFromEnv,
   connectorsEnabledFor,
   connectorsEnabledFromEnv,
   createStreamIdleWatchdog,
   index_default as default,
   formatAllowedRateLimitWarning,
   formatResetTimestamp,
+  isConnectorWriteTool,
   isExtraUsageRequiredMessage,
   mapToolName,
   normalizeRateLimitUtilization,

--- a/pi-extensions/pi-claude-bridge/bundle/index.js
+++ b/pi-extensions/pi-claude-bridge/bundle/index.js
@@ -37985,6 +37985,24 @@ var CLAUDE_BRIDGE_TOOL_ISOLATION = {
   disallowedTools: DISALLOWED_BUILTIN_TOOLS,
   allowedTools: [`mcp__${MCP_SERVER_NAME}__*`]
 };
+function connectorsEnabled() {
+  const v2 = (process.env.CLAUDE_BRIDGE_ENABLE_CONNECTORS ?? "").trim().toLowerCase();
+  return v2 === "1" || v2 === "true" || v2 === "yes" || v2 === "on";
+}
+var CLAUDE_AI_CONNECTOR_TOOL_PATTERNS = [
+  "mcp__claude_ai_Gmail__*",
+  "mcp__claude_ai_Google_Calendar__*",
+  "mcp__claude_ai_Google_Drive__*"
+];
+var CONNECTOR_DISCOVERY_TOOLS = ["ToolSearch", "ListMcpResources", "ReadMcpResource"];
+function toolIsolationForQuery() {
+  if (!connectorsEnabled()) return CLAUDE_BRIDGE_TOOL_ISOLATION;
+  const disallowedTools = DISALLOWED_BUILTIN_TOOLS.filter((t10) => !CONNECTOR_DISCOVERY_TOOLS.includes(t10));
+  return {
+    disallowedTools,
+    allowedTools: [...CLAUDE_BRIDGE_TOOL_ISOLATION.allowedTools, ...CLAUDE_AI_CONNECTOR_TOOL_PATTERNS]
+  };
+}
 var sharedSession = null;
 var extensionApi;
 var piUI;
@@ -39041,7 +39059,7 @@ function streamClaudeAgentSdk(model, context, options) {
   const promptContextAppend = buildPromptContextAppend(context.systemPrompt, cwd, bridgeConfig.promptContext ?? {});
   const appendParts = [agentsAppend, skillsAppend, promptContextAppend.text].filter((part) => Boolean(part));
   const systemPromptAppend = appendParts.length > 0 ? appendParts.join("\n\n") : void 0;
-  const settingSources = appendSystemPrompt ? void 0 : providerSettings.settingSources ?? ["user", "project"];
+  const settingSources = connectorsEnabled() ? providerSettings.settingSources ?? ["user", "project", "local"] : appendSystemPrompt ? void 0 : providerSettings.settingSources ?? ["user", "project"];
   const strictMcpConfigEnabled = !appendSystemPrompt && providerSettings.strictMcpConfig !== false;
   const claudeExecutable = resolveClaudeExecutable(providerSettings.pathToClaudeCodeExecutable);
   const claudeExecutablePreflight = claudeExecutable ? preflightClaudeExecutable(claudeExecutable, cwd) : void 0;
@@ -39052,12 +39070,13 @@ function streamClaudeAgentSdk(model, context, options) {
   if (strictMcpConfigEnabled) extraArgs["strict-mcp-config"] = null;
   if (effort) extraArgs["thinking-display"] = "summarized";
   const fallbackModel = fallbackModelForPrimaryModel(model.id);
-  const childEnv = { ...process.env, ENABLE_CLAUDEAI_MCP_SERVERS: "0", DISABLE_AUTO_COMPACT: "1" };
+  const enableCloudMcp = connectorsEnabled();
+  const childEnv = { ...process.env, ENABLE_CLAUDEAI_MCP_SERVERS: enableCloudMcp ? "1" : "0", DISABLE_AUTO_COMPACT: "1" };
   const queryOptions = {
     cwd,
     model: model.id,
     env: childEnv,
-    ...CLAUDE_BRIDGE_TOOL_ISOLATION,
+    ...toolIsolationForQuery(),
     permissionMode: "bypassPermissions",
     includePartialMessages: true,
     ...fallbackModel ? { fallbackModel } : {},
@@ -39081,7 +39100,7 @@ function streamClaudeAgentSdk(model, context, options) {
     `model=${model.id} msgs=${context.messages.length} tools=${mcpTools.length}`,
     `resume=${resumeSessionId?.slice(0, 8) ?? "none"} effort=${effort ?? "default"}`,
     `fallback=${fallbackModel ?? "none"}`,
-    `appendSys=${appendSystemPrompt} promptCtx=${promptContextAppend.labels.join(",") || "none"} strictMcp=${strictMcpConfigEnabled} fastMode=${providerSettings.fastMode === true}`,
+    `appendSys=${appendSystemPrompt} promptCtx=${promptContextAppend.labels.join(",") || "none"} strictMcp=${strictMcpConfigEnabled} fastMode=${providerSettings.fastMode === true} connectors=${enableCloudMcp}`,
     `claudeExec=${claudeExecutablePreflight ? `${claudeExecutablePreflight.fileType}:${claudeExecutablePreflight.path}` : "sdk-default"}`,
     `prompt=${promptText.slice(0, 60)}${promptBlocks ? " [+images]" : ""}`
   );
@@ -39381,7 +39400,9 @@ function index_default(pi) {
 }
 export {
   ALLOWED_RATE_LIMIT_WARNING_UTILIZATION_THRESHOLD,
+  CLAUDE_AI_CONNECTOR_TOOL_PATTERNS,
   CLAUDE_BRIDGE_TOOL_ISOLATION,
+  CONNECTOR_DISCOVERY_TOOLS,
   DEFAULT_STREAM_IDLE_TIMEOUT_MS,
   DISALLOWED_BUILTIN_TOOLS,
   STREAM_IDLE_BACKOFF_HINT_MS,
@@ -39390,6 +39411,7 @@ export {
   __testSetBridgeIntegrityState,
   buildStreamIdleTimeoutErrorMessage,
   classifyClaudeExecutableBytes,
+  connectorsEnabled,
   createStreamIdleWatchdog,
   index_default as default,
   formatAllowedRateLimitWarning,
@@ -39406,6 +39428,7 @@ export {
   shouldRestorePersistedBridgeEntry,
   spawnClaudeCodeWithDiagnostics,
   streamIdleTimeoutMsFromEnv,
+  toolIsolationForQuery,
   uniqueNonEmptyLines,
   wrapClaudeSpawnErrorForSdk
 };

--- a/pi-extensions/pi-claude-bridge/bundle/index.js
+++ b/pi-extensions/pi-claude-bridge/bundle/index.js
@@ -22797,6 +22797,8 @@ function managerToConfig(raw) {
   }
   const strictMcpConfig = boolFrom(raw, "strictMcpConfig");
   if (strictMcpConfig !== void 0) provider.strictMcpConfig = strictMcpConfig;
+  const enableConnectors = boolFrom(raw, "enableConnectors");
+  if (enableConnectors !== void 0) provider.enableConnectors = enableConnectors;
   const claudePath = stringFrom(raw, "pathToClaudeCodeExecutable");
   if (claudePath) provider.pathToClaudeCodeExecutable = claudePath;
   const includeAppendSystemPromptMd = boolFrom(raw, "includeAppendSystemPromptMd");
@@ -37985,9 +37987,12 @@ var CLAUDE_BRIDGE_TOOL_ISOLATION = {
   disallowedTools: DISALLOWED_BUILTIN_TOOLS,
   allowedTools: [`mcp__${MCP_SERVER_NAME}__*`]
 };
-function connectorsEnabled() {
+function connectorsEnabledFromEnv() {
   const v2 = (process.env.CLAUDE_BRIDGE_ENABLE_CONNECTORS ?? "").trim().toLowerCase();
   return v2 === "1" || v2 === "true" || v2 === "yes" || v2 === "on";
+}
+function connectorsEnabledFor(config2) {
+  return connectorsEnabledFromEnv() || config2?.provider?.enableConnectors === true;
 }
 var CLAUDE_AI_CONNECTOR_TOOL_PATTERNS = [
   "mcp__claude_ai_Gmail__*",
@@ -37995,8 +38000,8 @@ var CLAUDE_AI_CONNECTOR_TOOL_PATTERNS = [
   "mcp__claude_ai_Google_Drive__*"
 ];
 var CONNECTOR_DISCOVERY_TOOLS = ["ToolSearch", "ListMcpResources", "ReadMcpResource"];
-function toolIsolationForQuery() {
-  if (!connectorsEnabled()) return CLAUDE_BRIDGE_TOOL_ISOLATION;
+function toolIsolationForQuery(connectorsEnabled) {
+  if (!connectorsEnabled) return CLAUDE_BRIDGE_TOOL_ISOLATION;
   const disallowedTools = DISALLOWED_BUILTIN_TOOLS.filter((t10) => !CONNECTOR_DISCOVERY_TOOLS.includes(t10));
   return {
     disallowedTools,
@@ -39053,13 +39058,14 @@ function streamClaudeAgentSdk(model, context, options) {
   const mcpServers = buildMcpServers(mcpTools, ctx());
   const bridgeConfig = loadConfig(cwd);
   const providerSettings = bridgeConfig.provider ?? {};
+  const enableCloudMcp = connectorsEnabledFor(bridgeConfig);
   const appendSystemPrompt = providerSettings.appendSystemPrompt !== false;
   const agentsAppend = appendSystemPrompt ? extractAgentsAppend() : void 0;
   const skillsAppend = appendSystemPrompt ? extractSkillsBlock(context.systemPrompt) : void 0;
   const promptContextAppend = buildPromptContextAppend(context.systemPrompt, cwd, bridgeConfig.promptContext ?? {});
   const appendParts = [agentsAppend, skillsAppend, promptContextAppend.text].filter((part) => Boolean(part));
   const systemPromptAppend = appendParts.length > 0 ? appendParts.join("\n\n") : void 0;
-  const settingSources = connectorsEnabled() ? providerSettings.settingSources ?? ["user", "project", "local"] : appendSystemPrompt ? void 0 : providerSettings.settingSources ?? ["user", "project"];
+  const settingSources = enableCloudMcp ? providerSettings.settingSources ?? ["user", "project", "local"] : appendSystemPrompt ? void 0 : providerSettings.settingSources ?? ["user", "project"];
   const strictMcpConfigEnabled = !appendSystemPrompt && providerSettings.strictMcpConfig !== false;
   const claudeExecutable = resolveClaudeExecutable(providerSettings.pathToClaudeCodeExecutable);
   const claudeExecutablePreflight = claudeExecutable ? preflightClaudeExecutable(claudeExecutable, cwd) : void 0;
@@ -39070,13 +39076,12 @@ function streamClaudeAgentSdk(model, context, options) {
   if (strictMcpConfigEnabled) extraArgs["strict-mcp-config"] = null;
   if (effort) extraArgs["thinking-display"] = "summarized";
   const fallbackModel = fallbackModelForPrimaryModel(model.id);
-  const enableCloudMcp = connectorsEnabled();
   const childEnv = { ...process.env, ENABLE_CLAUDEAI_MCP_SERVERS: enableCloudMcp ? "1" : "0", DISABLE_AUTO_COMPACT: "1" };
   const queryOptions = {
     cwd,
     model: model.id,
     env: childEnv,
-    ...toolIsolationForQuery(),
+    ...toolIsolationForQuery(enableCloudMcp),
     permissionMode: "bypassPermissions",
     includePartialMessages: true,
     ...fallbackModel ? { fallbackModel } : {},
@@ -39411,7 +39416,8 @@ export {
   __testSetBridgeIntegrityState,
   buildStreamIdleTimeoutErrorMessage,
   classifyClaudeExecutableBytes,
-  connectorsEnabled,
+  connectorsEnabledFor,
+  connectorsEnabledFromEnv,
   createStreamIdleWatchdog,
   index_default as default,
   formatAllowedRateLimitWarning,

--- a/pi-extensions/pi-claude-bridge/bundle/index.js
+++ b/pi-extensions/pi-claude-bridge/bundle/index.js
@@ -21976,10 +21976,10 @@ function readSession(jsonlPath, projectPath) {
 // src/index.ts
 import { spawn as spawnProcess } from "child_process";
 import { createHash } from "crypto";
-import { accessSync, appendFileSync as appendFileSync3, chmodSync, constants as fsConstants, mkdirSync as mkdirSync3, readFileSync as readFileSync6, realpathSync as realpathSync3, statSync as statSync3 } from "fs";
+import { accessSync, appendFileSync as appendFileSync3, chmodSync, constants as fsConstants, mkdirSync as mkdirSync3, readFileSync as readFileSync7, realpathSync as realpathSync3, statSync as statSync3 } from "fs";
 import { resolve as pathResolve } from "path";
-import { homedir as homedir5 } from "os";
-import { delimiter, dirname as dirname5, join as join5 } from "path";
+import { homedir as homedir6 } from "os";
+import { delimiter, dirname as dirname5, join as join6 } from "path";
 
 // node_modules/change-case/dist/index.js
 var SPLIT_LOWER_UPPER_RE = new RegExp("([\\p{Ll}\\d])(\\p{Lu})", "gu");
@@ -22840,22 +22840,69 @@ function loadConfig(cwd) {
   };
 }
 
-// src/agents-md.ts
+// src/auth-presence.ts
 import { existsSync as existsSync4, readFileSync as readFileSync4 } from "fs";
-import { homedir as homedir3 } from "os";
-import { dirname as dirname3, join as join3, resolve as resolve2 } from "path";
-var GLOBAL_AGENTS_PATH = join3(homedir3(), ".pi", "agent", "AGENTS.md");
+import { homedir as homedir3, platform as osPlatform } from "os";
+import { join as join3 } from "path";
+function resolveClaudeConfigDir(env = process.env) {
+  const configured = env.CLAUDE_CONFIG_DIR;
+  if (typeof configured === "string" && configured.trim().length > 0) return configured.trim();
+  return join3(homedir3(), ".claude");
+}
+function nonEmptyEnv(value) {
+  return typeof value === "string" && value.trim().length > 0;
+}
+function envTruthy(value) {
+  const v2 = value?.trim().toLowerCase();
+  return v2 === "1" || v2 === "true";
+}
+function hasApiKeyHelper(configDir) {
+  try {
+    const settingsPath = join3(configDir, "settings.json");
+    if (!existsSync4(settingsPath)) return false;
+    const parsed = JSON.parse(readFileSync4(settingsPath, "utf8"));
+    return typeof parsed?.apiKeyHelper === "string" && parsed.apiKeyHelper.trim().length > 0;
+  } catch {
+    return false;
+  }
+}
+function hasClaudeCredentials(env = process.env, platform = osPlatform()) {
+  if (nonEmptyEnv(env.CLAUDE_CODE_OAUTH_TOKEN)) return true;
+  if (nonEmptyEnv(env.ANTHROPIC_API_KEY)) return true;
+  if (nonEmptyEnv(env.ANTHROPIC_AUTH_TOKEN)) return true;
+  if (envTruthy(env.CLAUDE_CODE_USE_BEDROCK)) return true;
+  if (envTruthy(env.CLAUDE_CODE_USE_VERTEX)) return true;
+  if (envTruthy(env.CLAUDE_CODE_USE_FOUNDRY)) return true;
+  if (envTruthy(env.CLAUDE_CODE_USE_ANTHROPIC_AWS)) return true;
+  if (envTruthy(env.CLAUDE_CODE_USE_MANTLE)) return true;
+  const configDir = resolveClaudeConfigDir(env);
+  if (existsSync4(join3(configDir, ".credentials.json"))) return true;
+  if (hasApiKeyHelper(configDir)) return true;
+  if (platform === "darwin") return true;
+  return false;
+}
+function decideRegistration(state) {
+  if (!state.isPrimary) return "noop";
+  if (state.credentialed) return state.registered ? "noop" : "register";
+  return "unregister";
+}
+
+// src/agents-md.ts
+import { existsSync as existsSync5, readFileSync as readFileSync5 } from "fs";
+import { homedir as homedir4 } from "os";
+import { dirname as dirname3, join as join4, resolve as resolve2 } from "path";
+var GLOBAL_AGENTS_PATH = join4(homedir4(), ".pi", "agent", "AGENTS.md");
 function resolveAgentsMdPath() {
   const fromCwd = findAgentsMdInParents(process.cwd());
   if (fromCwd) return fromCwd;
-  if (existsSync4(GLOBAL_AGENTS_PATH)) return GLOBAL_AGENTS_PATH;
+  if (existsSync5(GLOBAL_AGENTS_PATH)) return GLOBAL_AGENTS_PATH;
   return void 0;
 }
 function findAgentsMdInParents(startDir) {
   let current = resolve2(startDir);
   while (true) {
-    const candidate = join3(current, "AGENTS.md");
-    if (existsSync4(candidate)) return candidate;
+    const candidate = join4(current, "AGENTS.md");
+    if (existsSync5(candidate)) return candidate;
     const parent = dirname3(current);
     if (parent === current) break;
     current = parent;
@@ -22866,7 +22913,7 @@ function extractAgentsAppend() {
   const agentsPath = resolveAgentsMdPath();
   if (!agentsPath) return void 0;
   try {
-    const content = readFileSync4(agentsPath, "utf-8").trim();
+    const content = readFileSync5(agentsPath, "utf-8").trim();
     if (!content) return void 0;
     const sanitized = sanitizeAgentsContent(content);
     return sanitized.length > 0 ? `# CLAUDE.md
@@ -22886,18 +22933,18 @@ function sanitizeAgentsContent(content) {
 }
 
 // src/prompt-context.ts
-import { existsSync as existsSync5, readFileSync as readFileSync5 } from "fs";
-import { homedir as homedir4 } from "os";
-import { dirname as dirname4, join as join4, resolve as resolve3 } from "path";
+import { existsSync as existsSync6, readFileSync as readFileSync6 } from "fs";
+import { homedir as homedir5 } from "os";
+import { dirname as dirname4, join as join5, resolve as resolve3 } from "path";
 function piUserDir2() {
   const configured = process.env.PI_CODING_AGENT_DIR?.trim();
-  if (configured) return resolve3(configured.replace(/^~(?=\/|$)/, homedir4()));
-  return join4(homedir4(), ".pi", "agent");
+  if (configured) return resolve3(configured.replace(/^~(?=\/|$)/, homedir5()));
+  return join5(homedir5(), ".pi", "agent");
 }
 function readTrimmed(path) {
   try {
-    if (!existsSync5(path)) return void 0;
-    const content = readFileSync5(path, "utf8").trim();
+    if (!existsSync6(path)) return void 0;
+    const content = readFileSync6(path, "utf8").trim();
     return content.length > 0 ? content : void 0;
   } catch {
     return void 0;
@@ -22906,8 +22953,8 @@ function readTrimmed(path) {
 function findProjectAppendSystem(startDir) {
   let current = resolve3(startDir);
   while (true) {
-    const candidate = join4(current, ".pi", "APPEND_SYSTEM.md");
-    if (existsSync5(candidate)) return candidate;
+    const candidate = join5(current, ".pi", "APPEND_SYSTEM.md");
+    if (existsSync6(candidate)) return candidate;
     const parent = dirname4(current);
     if (parent === current) break;
     current = parent;
@@ -22916,7 +22963,7 @@ function findProjectAppendSystem(startDir) {
 }
 function readAppendSystemPromptFiles(cwd) {
   const files = [
-    { label: "global APPEND_SYSTEM.md", path: join4(piUserDir2(), "APPEND_SYSTEM.md") }
+    { label: "global APPEND_SYSTEM.md", path: join5(piUserDir2(), "APPEND_SYSTEM.md") }
   ];
   const projectPath = findProjectAppendSystem(cwd);
   if (projectPath) files.push({ label: "project .pi/APPEND_SYSTEM.md", path: projectPath });
@@ -37592,8 +37639,8 @@ var _piAi = piAi;
 var getModels = await resolveGetModels(_piAi);
 var newAssistantMessageEventStream = typeof _piAi.createAssistantMessageEventStream === "function" ? _piAi.createAssistantMessageEventStream : () => new _piAi.AssistantMessageEventStream();
 var DEBUG = process.env.CLAUDE_BRIDGE_DEBUG === "1";
-var DEBUG_LOG_PATH = process.env.CLAUDE_BRIDGE_DEBUG_PATH || join5(homedir5(), ".pi", "agent", "claude-bridge.log");
-var DEFAULT_DIAG_LOG_PATH = join5(homedir5(), ".pi", "agent", "claude-bridge-diag.log");
+var DEBUG_LOG_PATH = process.env.CLAUDE_BRIDGE_DEBUG_PATH || join6(homedir6(), ".pi", "agent", "claude-bridge.log");
+var DEFAULT_DIAG_LOG_PATH = join6(homedir6(), ".pi", "agent", "claude-bridge-diag.log");
 function diagLogPath() {
   return process.env.CLAUDE_BRIDGE_DIAG_PATH || DEFAULT_DIAG_LOG_PATH;
 }
@@ -37623,7 +37670,7 @@ function debug(...args) {
 function executableFromPath(name) {
   const paths = (process.env.PATH ?? "").split(delimiter).filter(Boolean);
   for (const dir of paths) {
-    const candidate = join5(dir, name);
+    const candidate = join6(dir, name);
     try {
       accessSync(candidate, fsConstants.X_OK);
       return candidate;
@@ -37738,7 +37785,7 @@ function preflightClaudeExecutable(path, cwd) {
   }
   let fileType;
   try {
-    fileType = classifyClaudeExecutableBytes(readFileSync6(realPath).subarray(0, 16));
+    fileType = classifyClaudeExecutableBytes(readFileSync7(realPath).subarray(0, 16));
   } catch (err) {
     throw makeClaudePreflightError("Claude Code executable preflight failed: cannot read executable header before spawning Claude Code.", {
       code: codeValue(err, "EACCES"),
@@ -37835,12 +37882,12 @@ function makeCliDebugOptions(tag) {
   if (!DEBUG) return {};
   const seq = nextCliDebugSeq++;
   const ts = (/* @__PURE__ */ new Date()).toISOString().replace(/[:.]/g, "-");
-  const logDir = join5(dirname5(DEBUG_LOG_PATH), "cc-cli-logs");
+  const logDir = join6(dirname5(DEBUG_LOG_PATH), "cc-cli-logs");
   try {
     mkdirSync3(logDir, { recursive: true });
   } catch {
   }
-  const debugFile = join5(logDir, `${ts}-${tag}-${seq}.log`);
+  const debugFile = join6(logDir, `${ts}-${tag}-${seq}.log`);
   debug(`cli-debug: ${tag} #${seq} \u2192 ${debugFile}`);
   return {
     debug: true,
@@ -37950,6 +37997,7 @@ function __testSetBridgeIntegrityState(state) {
 function __testGetBridgeIntegrityState() {
   return { sharedSession };
 }
+var PRIMARY_INSTANCE_KEY = /* @__PURE__ */ Symbol.for("claude-bridge:primaryInstance");
 var ACTIVE_STREAM_SIMPLE_KEY = /* @__PURE__ */ Symbol.for("claude-bridge:activeStreamSimple");
 var COMMANDS_REGISTERED_KEY = /* @__PURE__ */ Symbol.for("claude-bridge:commandsRegistered");
 var SDK_TO_PI_TOOL_NAME = {
@@ -39043,6 +39091,58 @@ async function consumeQuery(sdkQuery, customToolNameToPi, model, cwd, bridgeConf
   debug(`consumeQuery: for-await loop exited, wasAborted=${wasAborted()}, capturedSessionId=${capturedSessionId?.slice(0, 8) ?? "none"}`);
   return { capturedSessionId };
 }
+function claimPrimaryInstance() {
+  const g2 = globalThis;
+  if (!g2[PRIMARY_INSTANCE_KEY]) g2[PRIMARY_INSTANCE_KEY] = streamClaudeAgentSdk;
+  return g2[PRIMARY_INSTANCE_KEY] === streamClaudeAgentSdk;
+}
+function releaseProviderTokens(event) {
+  const g2 = globalThis;
+  if (g2[ACTIVE_STREAM_SIMPLE_KEY] === streamClaudeAgentSdk) {
+    debug(`${event}: clearing ACTIVE_STREAM_SIMPLE_KEY`);
+    g2[ACTIVE_STREAM_SIMPLE_KEY] = void 0;
+  }
+  if (g2[PRIMARY_INSTANCE_KEY] === streamClaudeAgentSdk) {
+    debug(`${event}: clearing PRIMARY_INSTANCE_KEY`);
+    g2[PRIMARY_INSTANCE_KEY] = void 0;
+  }
+}
+function applyProviderRegistration(trigger) {
+  const pi = extensionApi;
+  if (!pi) {
+    debug(`${trigger}: applyProviderRegistration skipped \u2014 no extensionApi`);
+    return;
+  }
+  const g2 = globalThis;
+  const isPrimary = claimPrimaryInstance();
+  const credentialed = hasClaudeCredentials();
+  const registered = g2[ACTIVE_STREAM_SIMPLE_KEY] === streamClaudeAgentSdk;
+  const decision = decideRegistration({ credentialed, isPrimary, registered });
+  debug(`${trigger}: registration decision=${decision} credentialed=${credentialed} isPrimary=${isPrimary} registered=${registered} (module=${moduleInstanceId})`);
+  if (decision === "register") {
+    g2[ACTIVE_STREAM_SIMPLE_KEY] = streamClaudeAgentSdk;
+    try {
+      pi.registerProvider(PROVIDER_ID, {
+        baseUrl: "claude-bridge",
+        apiKey: "not-used",
+        api: "claude-bridge",
+        models: MODELS,
+        // Cast: pi-ai AssistantMessageEventStream diamond dep between pi-coding-agent and pi-agent-core
+        streamSimple: streamClaudeAgentSdk
+      });
+    } catch (err) {
+      if (g2[ACTIVE_STREAM_SIMPLE_KEY] === streamClaudeAgentSdk) g2[ACTIVE_STREAM_SIMPLE_KEY] = void 0;
+      debug(`${trigger}: registerProvider threw; released stream guard for retry (kept primary):`, err);
+    }
+  } else if (decision === "unregister") {
+    try {
+      pi.unregisterProvider(PROVIDER_ID);
+    } catch (err) {
+      debug(`${trigger}: unregisterProvider threw (ignored):`, err);
+    }
+    if (g2[ACTIVE_STREAM_SIMPLE_KEY] === streamClaudeAgentSdk) g2[ACTIVE_STREAM_SIMPLE_KEY] = void 0;
+  }
+}
 function streamClaudeAgentSdk(model, context, options) {
   const stream = newAssistantMessageEventStream();
   const lastMsgRole = context.messages[context.messages.length - 1]?.role;
@@ -39112,6 +39212,37 @@ function streamClaudeAgentSdk(model, context, options) {
     queueMicrotask(() => {
       c2.resetTurnState(model);
       stream.push({ type: "done", reason: "stop", message: c2.turnOutput });
+      stream.end();
+    });
+    return stream;
+  }
+  if (!hasClaudeCredentials()) {
+    try {
+      applyProviderRegistration("pre-spawn");
+    } catch {
+    }
+    const message = "Claude account not connected \u2014 connect an account (or run `claude login`) and retry.";
+    debug(`provider: pre-spawn credential check failed; failing fast: ${message}`);
+    const errorOutput = {
+      role: "assistant",
+      content: [],
+      api: model.api,
+      provider: model.provider,
+      model: model.id,
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 }
+      },
+      stopReason: "error",
+      timestamp: Date.now(),
+      errorMessage: message
+    };
+    queueMicrotask(() => {
+      stream.push({ type: "error", reason: "error", error: errorOutput });
       stream.end();
     });
     return stream;
@@ -39446,11 +39577,6 @@ function index_default(pi) {
   const clearSession = (event) => {
     debug(`${event}: clearing session ${sharedSession?.sessionId?.slice(0, 8) ?? "none"}`);
     sharedSession = null;
-    const g10 = globalThis;
-    if (g10[ACTIVE_STREAM_SIMPLE_KEY] === streamClaudeAgentSdk) {
-      debug(`${event}: clearing ACTIVE_STREAM_SIMPLE_KEY`);
-      g10[ACTIVE_STREAM_SIMPLE_KEY] = void 0;
-    }
   };
   pi.on("session_start", (event, ctx2) => {
     recordProjectTrust(ctx2);
@@ -39459,8 +39585,12 @@ function index_default(pi) {
       clearSession(`session_start:${event.reason}`);
     }
     if (event.reason === "startup" || event.reason === "resume") restoreSharedSessionFromPi(ctx2);
+    applyProviderRegistration(`session_start:${event.reason}`);
   });
-  pi.on("session_shutdown", () => clearSession("session_shutdown"));
+  pi.on("session_shutdown", () => {
+    clearSession("session_shutdown");
+    releaseProviderTokens("session_shutdown");
+  });
   pi.on("message_end", (event, ctx2) => {
     const message = event.message;
     if (message?.role === "assistant" && message.provider === PROVIDER_ID) schedulePersistSharedSession(ctx2);
@@ -39476,20 +39606,7 @@ function index_default(pi) {
   };
   pi.on("session_compact", () => markRebuild("session_compact"));
   pi.on("session_tree", () => markRebuild("session_tree"));
-  const g2 = globalThis;
-  if (!g2[ACTIVE_STREAM_SIMPLE_KEY]) {
-    g2[ACTIVE_STREAM_SIMPLE_KEY] = streamClaudeAgentSdk;
-    pi.registerProvider(PROVIDER_ID, {
-      baseUrl: "claude-bridge",
-      apiKey: "not-used",
-      api: "claude-bridge",
-      models: MODELS,
-      // Cast: pi-ai AssistantMessageEventStream diamond dep between pi-coding-agent and pi-agent-core
-      streamSimple: streamClaudeAgentSdk
-    });
-  } else {
-    debug(`provider: skipping re-registration, parent instance active (module=${moduleInstanceId})`);
-  }
+  applyProviderRegistration("load");
 }
 export {
   ALLOWED_RATE_LIMIT_WARNING_UTILIZATION_THRESHOLD,

--- a/pi-extensions/pi-claude-bridge/package-lock.json
+++ b/pi-extensions/pi-claude-bridge/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vanillagreen/pi-claude-bridge",
-  "version": "1.6.2",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vanillagreen/pi-claude-bridge",
-      "version": "1.6.2",
+      "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.158",

--- a/pi-extensions/pi-claude-bridge/package.json
+++ b/pi-extensions/pi-claude-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vanillagreen/pi-claude-bridge",
-  "version": "1.6.2",
+  "version": "1.7.0",
   "description": "Pi provider bridge that runs Claude Code through the Claude Agent SDK, with opt-in forwarding for Pi prompt context.",
   "type": "module",
   "keywords": [

--- a/pi-extensions/pi-claude-bridge/src/agents-md.ts
+++ b/pi-extensions/pi-claude-bridge/src/agents-md.ts
@@ -2,20 +2,30 @@
 //
 // Pi uses AGENTS.md for long-lived instructions; Claude Code reads the same
 // content under "# CLAUDE.md". We walk up from cwd looking for AGENTS.md,
-// fall back to ~/.pi/agent/AGENTS.md, and rewrite pi-specific references
+// fall back to <piUserDir>/AGENTS.md (~/.pi/agent/AGENTS.md unless
+// PI_CODING_AGENT_DIR points elsewhere), and rewrite pi-specific references
 // (~/.pi, .pi/, .pi, pi) to their Claude Code equivalents so any paths or
 // references in the file still resolve inside the CC subprocess.
+//
+// In isolated mode (CLAUDE_BRIDGE_ISOLATED=1) the cwd walk is disabled: only
+// the piUserDir file is consulted, so a host app that owns the agent dir owns
+// the full instruction surface.
 
 import { existsSync, readFileSync } from "fs";
-import { homedir } from "os";
 import { dirname, join, resolve } from "path";
+import { isolatedFromEnv, piUserDir } from "./config.js";
 
-const GLOBAL_AGENTS_PATH = join(homedir(), ".pi", "agent", "AGENTS.md");
+function globalAgentsPath(): string {
+	return join(piUserDir(), "AGENTS.md");
+}
 
 export function resolveAgentsMdPath(): string | undefined {
-	const fromCwd = findAgentsMdInParents(process.cwd());
-	if (fromCwd) return fromCwd;
-	if (existsSync(GLOBAL_AGENTS_PATH)) return GLOBAL_AGENTS_PATH;
+	if (!isolatedFromEnv()) {
+		const fromCwd = findAgentsMdInParents(process.cwd());
+		if (fromCwd) return fromCwd;
+	}
+	const globalPath = globalAgentsPath();
+	if (existsSync(globalPath)) return globalPath;
 	return undefined;
 }
 

--- a/pi-extensions/pi-claude-bridge/src/auth-presence.ts
+++ b/pi-extensions/pi-claude-bridge/src/auth-presence.ts
@@ -1,0 +1,158 @@
+// --- Claude credential presence (availability honesty) ---
+//
+// The bridge may only advertise claude-bridge models when the machine actually
+// has Claude credentials the Claude Agent SDK can authenticate with. Otherwise
+// pi's ModelRegistry.hasConfiguredAuth() would treat the dummy `apiKey:
+// "not-used"` as "configured" and the provider would look connected while every
+// request fails at spawn time.
+//
+// This module answers two pure questions used to gate registration:
+//   1. hasClaudeCredentials() — are real credentials present RIGHT NOW?
+//   2. decideRegistration()   — given credential presence + the primary-instance
+//      / stream-guard tokens, should we register / unregister / do nothing?
+//
+// SECURITY: this module only ever checks for the EXISTENCE of credentials — a
+// file's presence, an env var being non-empty, a settings key being a non-empty
+// string. It NEVER opens or logs `.credentials.json`, and where it must parse
+// `settings.json` (for apiKeyHelper) it reads only whether the key is a
+// non-empty string and never logs its value. Credential CONTENTS are never read
+// or logged.
+
+import { existsSync, readFileSync } from "fs";
+import { homedir, platform as osPlatform } from "os";
+import { join } from "path";
+
+/**
+ * Resolve the Claude config directory the same way the bundled cc-session-io
+ * (getClaudeDir) and Claude Code itself resolve it: an explicit
+ * CLAUDE_CONFIG_DIR wins, otherwise ~/.claude.
+ *
+ * Deliberate divergence from cc-session-io's plain `env ?? default`: we treat a
+ * SET-BUT-EMPTY/whitespace CLAUDE_CONFIG_DIR as unset and fall back to ~/.claude
+ * (an empty string would otherwise resolve credential probes to the process cwd
+ * root). The returned value is trimmed so downstream joins never carry stray
+ * whitespace.
+ */
+export function resolveClaudeConfigDir(env: NodeJS.ProcessEnv = process.env): string {
+	const configured = env.CLAUDE_CONFIG_DIR;
+	if (typeof configured === "string" && configured.trim().length > 0) return configured.trim();
+	return join(homedir(), ".claude");
+}
+
+function nonEmptyEnv(value: string | undefined): boolean {
+	return typeof value === "string" && value.trim().length > 0;
+}
+
+// Matches how Claude Code interprets its boolean provider-routing env flags:
+// only "1" / "true" (case-insensitive) enable them.
+function envTruthy(value: string | undefined): boolean {
+	const v = value?.trim().toLowerCase();
+	return v === "1" || v === "true";
+}
+
+/**
+ * True when `${configDir}/settings.json` exists, parses as JSON, and carries a
+ * non-empty `apiKeyHelper` string (an enterprise/custom auth command that
+ * produces a key). Parse/read errors are tolerated as "not present". The helper
+ * VALUE is never logged — only its presence/non-emptiness is used.
+ */
+function hasApiKeyHelper(configDir: string): boolean {
+	try {
+		const settingsPath = join(configDir, "settings.json");
+		if (!existsSync(settingsPath)) return false;
+		const parsed = JSON.parse(readFileSync(settingsPath, "utf8")) as { apiKeyHelper?: unknown };
+		return typeof parsed?.apiKeyHelper === "string" && parsed.apiKeyHelper.trim().length > 0;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * True when real Claude credentials are present in any location the Claude Agent
+ * SDK would authenticate from, WITHOUT reading credential contents. Checked in
+ * cheap-first order:
+ *   - env: non-empty CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_API_KEY /
+ *     ANTHROPIC_AUTH_TOKEN, or any truthy cloud-provider routing flag the Claude
+ *     Code SDK recognizes — CLAUDE_CODE_USE_BEDROCK / _VERTEX / _FOUNDRY /
+ *     _ANTHROPIC_AWS / _MANTLE (such routing needs no local key file);
+ *   - `.credentials.json` in the resolved config dir (existence only — the file
+ *     is never opened; written mode 0600 by `claude login`);
+ *   - `settings.json` apiKeyHelper (presence only — see hasApiKeyHelper).
+ *
+ * PLATFORM ASYMMETRY: on macOS the `claude` CLI stores OAuth tokens in the login
+ * Keychain, NOT in `.credentials.json`, so file-absence is NOT evidence of
+ * logged-out and we cannot cheaply/safely probe the Keychain here. On darwin,
+ * when no other signal is present, we default to credentialed=true — preserving
+ * the pre-fix "always available" behavior for Mac subscription users. Honesty
+ * enforcement therefore applies on Linux/Windows, where `.credentials.json`
+ * existence is an observable, truthful proxy (empirically, `claude auth logout`
+ * unlinks it).
+ */
+export function hasClaudeCredentials(
+	env: NodeJS.ProcessEnv = process.env,
+	platform: NodeJS.Platform = osPlatform(),
+): boolean {
+	if (nonEmptyEnv(env.CLAUDE_CODE_OAUTH_TOKEN)) return true;
+	if (nonEmptyEnv(env.ANTHROPIC_API_KEY)) return true;
+	if (nonEmptyEnv(env.ANTHROPIC_AUTH_TOKEN)) return true;
+	if (envTruthy(env.CLAUDE_CODE_USE_BEDROCK)) return true;
+	if (envTruthy(env.CLAUDE_CODE_USE_VERTEX)) return true;
+	if (envTruthy(env.CLAUDE_CODE_USE_FOUNDRY)) return true;
+	if (envTruthy(env.CLAUDE_CODE_USE_ANTHROPIC_AWS)) return true;
+	if (envTruthy(env.CLAUDE_CODE_USE_MANTLE)) return true;
+
+	const configDir = resolveClaudeConfigDir(env);
+	if (existsSync(join(configDir, ".credentials.json"))) return true;
+	if (hasApiKeyHelper(configDir)) return true;
+
+	if (platform === "darwin") return true;
+
+	return false;
+}
+
+/**
+ * Snapshot of the inputs to a registration decision.
+ *
+ * The bridge keeps two process-global tokens (Symbol.for): a PRIMARY-instance
+ * token, claimed unconditionally by the first-loaded module instance, and the
+ * stream-guard token holding the registered instance's streamSimple. ONLY the
+ * primary instance may ever register/unregister or claim the stream guard — this
+ * prevents a subagent module reload (a fresh, non-primary instance) from
+ * stealing ownership and registering ITS streamSimple, which would split-brain
+ * the shared session/ctx and break tool-result delivery.
+ */
+export interface RegistrationState {
+	/** Does the machine have Claude credentials right now? */
+	credentialed: boolean;
+	/** Is THIS module instance the primary (first-loaded) instance? */
+	isPrimary: boolean;
+	/** Has this instance already registered (owns the stream guard)? */
+	registered: boolean;
+}
+
+export type RegistrationDecision = "register" | "unregister" | "noop";
+
+/**
+ * Pure decision for extension load, every session_start re-check, and the
+ * pre-spawn fail-fast path.
+ *
+ * Rules:
+ *   - Not the primary instance                    → NOOP (never touch registration).
+ *   - Primary + credentialed + not registered     → REGISTER (claim guard + register).
+ *   - Primary + credentialed + already registered → NOOP.
+ *   - Primary + uncredentialed                    → UNREGISTER (defensive).
+ *
+ * The uncredentialed primary always returns UNREGISTER rather than NOOP:
+ * pi.unregisterProvider is idempotent ("Has no effect if the provider was never
+ * registered"), and a defensive call is the ONLY way to retract a registration
+ * that survived a /reload — the ModelRegistry's registeredProviders is a
+ * process-lifetime Map and module reload does NOT clear it. (At extension-load
+ * time this defensive unregister only filters the pending-registration queue and
+ * cannot mutate the persistent registry; the authoritative retraction happens on
+ * the post-load session_start re-check — see applyProviderRegistration.)
+ */
+export function decideRegistration(state: RegistrationState): RegistrationDecision {
+	if (!state.isPrimary) return "noop";
+	if (state.credentialed) return state.registered ? "noop" : "register";
+	return "unregister";
+}

--- a/pi-extensions/pi-claude-bridge/src/config.ts
+++ b/pi-extensions/pi-claude-bridge/src/config.ts
@@ -13,6 +13,14 @@ export type BridgeEffortLevel = "low" | "medium" | "high" | "xhigh" | "max";
 
 const VALID_EFFORT_LEVELS = new Set<BridgeEffortLevel>(["low", "medium", "high", "xhigh", "max"]);
 
+/**
+ * Per-session control over claude.ai connector WRITE tools when connectors are
+ * enabled. `deny` (default) hides Gmail/Calendar/Drive mutating tools so
+ * connector chat sessions are read-only; `allow` exposes them (used only by the
+ * one-shot approved-write executor). Reads are always available.
+ */
+export type ConnectorWriteMode = "deny" | "allow";
+
 export interface Config {
 	enabled?: boolean;
 	/** Low-level Claude Agent SDK plumbing. Most users won't need these. */
@@ -36,6 +44,19 @@ export interface Config {
 		 * enables it). See docs/plans/claude-bridge-google-connectors.md.
 		 */
 		enableConnectors?: boolean;
+		/**
+		 * When connectors are enabled, whether their WRITE tools
+		 * (create/update/delete/label/etc.) are exposed. Defaults to `deny`
+		 * (read-only), enforced two ways: known write tools are removed from the
+		 * model's context (disallowedTools by exact id), and a PreToolUse hook
+		 * blocks any connector write tool by name prefix at call time (covers
+		 * future write tools). `allow` disables both — intended ONLY for a
+		 * one-shot approved-write executor process. Also settable via
+		 * CLAUDE_BRIDGE_CONNECTOR_WRITE=deny|allow (env wins over config). Any
+		 * value but exact `allow` is treated as `deny`. Ignored when connectors
+		 * are disabled.
+		 */
+		connectorWriteMode?: ConnectorWriteMode;
 	};
 	/** Extra Pi context forwarded to Claude Code on top of AGENTS.md + skills. */
 	promptContext?: {
@@ -163,6 +184,13 @@ function hasOwn(raw: SettingsRecord, key: string): boolean {
 	return Object.prototype.hasOwnProperty.call(raw, key);
 }
 
+export function normalizeConnectorWriteMode(value: unknown): ConnectorWriteMode | undefined {
+	if (typeof value !== "string") return undefined;
+	const normalized = value.trim().toLowerCase();
+	if (normalized === "deny" || normalized === "allow") return normalized;
+	return undefined;
+}
+
 export function normalizeEffortLevel(value: unknown): BridgeEffortLevel | undefined {
 	if (typeof value !== "string") return undefined;
 	const normalized = value.trim().toLowerCase();
@@ -203,6 +231,13 @@ function normalizeProviderConfig(provider: Config["provider"] | undefined): Conf
 	const modelEffortOverrides = normalizeModelEffortOverrides(raw.modelEffortOverrides);
 	if (modelEffortOverrides) out.modelEffortOverrides = modelEffortOverrides;
 	else delete out.modelEffortOverrides;
+	// Fail closed: legacy config files are merged raw, so an unvalidated
+	// connectorWriteMode (e.g. "Deny", "read-only", true) must not slip through as
+	// a truthy non-"allow" value. Drop anything that isn't exactly deny/allow so
+	// the resolver falls back to the default deny.
+	const connectorWriteMode = normalizeConnectorWriteMode(raw.connectorWriteMode);
+	if (connectorWriteMode) out.connectorWriteMode = connectorWriteMode;
+	else delete out.connectorWriteMode;
 	return out;
 }
 
@@ -226,6 +261,8 @@ function managerToConfig(raw: SettingsRecord): Partial<Config> {
 	if (strictMcpConfig !== undefined) provider.strictMcpConfig = strictMcpConfig;
 	const enableConnectors = boolFrom(raw, "enableConnectors");
 	if (enableConnectors !== undefined) provider.enableConnectors = enableConnectors;
+	const connectorWriteMode = normalizeConnectorWriteMode(raw.connectorWriteMode);
+	if (connectorWriteMode) provider.connectorWriteMode = connectorWriteMode;
 	const claudePath = stringFrom(raw, "pathToClaudeCodeExecutable");
 	if (claudePath) provider.pathToClaudeCodeExecutable = claudePath;
 

--- a/pi-extensions/pi-claude-bridge/src/config.ts
+++ b/pi-extensions/pi-claude-bridge/src/config.ts
@@ -75,8 +75,27 @@ function expandHome(input: string): string {
 	return input;
 }
 
-function piUserDir(): string {
+/**
+ * The Pi agent config dir: `PI_CODING_AGENT_DIR` when set, else `~/.pi/agent`.
+ * Every bridge default that used to hardcode `~/.pi/agent` routes through this
+ * so a host app that owns the agent dir owns those paths too.
+ */
+export function piUserDir(): string {
 	return resolve(expandHome(process.env.PI_CODING_AGENT_DIR?.trim() || "~/.pi/agent"));
+}
+
+/**
+ * Isolated mode (`CLAUDE_BRIDGE_ISOLATED=1`): a host app embedding the bridge
+ * declares that nothing outside its explicitly configured dirs may be read.
+ * Disables every cwd/home discovery fallback — the cwd AGENTS.md walk, project
+ * `.pi/` settings + claude-bridge.json, project APPEND_SYSTEM.md, and the
+ * `$PATH` claude executable search. Reads stay confined to `piUserDir()` (i.e.
+ * `PI_CODING_AGENT_DIR`) and the explicitly configured executable path.
+ * Default (unset) behavior for normal pi CLI users is unchanged.
+ */
+export function isolatedFromEnv(): boolean {
+	const v = (process.env.CLAUDE_BRIDGE_ISOLATED ?? "").trim().toLowerCase();
+	return v === "1" || v === "true" || v === "yes" || v === "on";
 }
 
 function asRecord(value: unknown): SettingsRecord | undefined {
@@ -140,6 +159,7 @@ function projectSettingsTrusted(settingsPath: string): boolean {
 
 function settingsPaths(cwd: string): string[] {
 	const user = join(piUserDir(), "settings.json");
+	if (isolatedFromEnv()) return [user];
 	const project = projectSettingsPath(cwd);
 	return projectSettingsTrusted(project) ? [user, project] : [user];
 }
@@ -284,8 +304,9 @@ function managerToConfig(raw: SettingsRecord): Partial<Config> {
 
 export function loadConfig(cwd: string): Config {
 	const global = tryParseJson(join(piUserDir(), "claude-bridge.json"));
-	const projectSettings = projectSettingsPath(cwd);
-	const trustedProject = projectSettingsTrusted(projectSettings);
+	const isolated = isolatedFromEnv();
+	const projectSettings = isolated ? undefined : projectSettingsPath(cwd);
+	const trustedProject = projectSettings !== undefined && projectSettingsTrusted(projectSettings);
 	const project = trustedProject ? tryParseJson(join(dirname(projectSettings), "claude-bridge.json")) : {};
 	const manager = managerToConfig(readManagerConfig(cwd));
 	const provider = normalizeProviderConfig({ ...global.provider, ...project.provider, ...manager.provider });

--- a/pi-extensions/pi-claude-bridge/src/config.ts
+++ b/pi-extensions/pi-claude-bridge/src/config.ts
@@ -28,6 +28,14 @@ export interface Config {
 		settingSources?: SettingSource[];
 		strictMcpConfig?: boolean;
 		pathToClaudeCodeExecutable?: string;
+		/**
+		 * Expose the authenticated Claude account's claude.ai cloud MCP
+		 * connectors (Gmail / Google Calendar / Google Drive, etc.) to the model.
+		 * Off by default so Pi owns tool execution and tokens stay lean. Also
+		 * settable via the CLAUDE_BRIDGE_ENABLE_CONNECTORS env var (env OR config
+		 * enables it). See docs/plans/claude-bridge-google-connectors.md.
+		 */
+		enableConnectors?: boolean;
 	};
 	/** Extra Pi context forwarded to Claude Code on top of AGENTS.md + skills. */
 	promptContext?: {
@@ -216,6 +224,8 @@ function managerToConfig(raw: SettingsRecord): Partial<Config> {
 	}
 	const strictMcpConfig = boolFrom(raw, "strictMcpConfig");
 	if (strictMcpConfig !== undefined) provider.strictMcpConfig = strictMcpConfig;
+	const enableConnectors = boolFrom(raw, "enableConnectors");
+	if (enableConnectors !== undefined) provider.enableConnectors = enableConnectors;
 	const claudePath = stringFrom(raw, "pathToClaudeCodeExecutable");
 	if (claudePath) provider.pathToClaudeCodeExecutable = claudePath;
 

--- a/pi-extensions/pi-claude-bridge/src/index.ts
+++ b/pi-extensions/pi-claude-bridge/src/index.ts
@@ -1,7 +1,7 @@
 import { calculateCost, type AssistantMessage, type AssistantMessageEventStream, type Context, type Model, type SimpleStreamOptions, type Tool } from "@earendil-works/pi-ai";
 import * as piAi from "@earendil-works/pi-ai";
 import { type ExtensionAPI, type ExtensionUIContext } from "@earendil-works/pi-coding-agent";
-import { createSdkMcpServer, query, type EffortLevel, type SDKMessage, type SDKUserMessage, type SettingSource, type SpawnOptions, type SpawnedProcess } from "@anthropic-ai/claude-agent-sdk";
+import { createSdkMcpServer, query, type EffortLevel, type HookCallback, type SDKMessage, type SDKUserMessage, type SettingSource, type SpawnOptions, type SpawnedProcess } from "@anthropic-ai/claude-agent-sdk";
 import type { Base64ImageSource, ContentBlockParam, MessageParam } from "@anthropic-ai/sdk/resources";
 import { createSession, deleteSession, openSession, repairToolPairing } from "cc-session-io";
 import { spawn as spawnProcess } from "child_process";
@@ -17,7 +17,7 @@ import { verifyWrittenSession as _verifyWrittenSession } from "./session-verify.
 import { extractAllToolResults as _extractAllToolResults, type McpResult } from "./extract-tool-results.js";
 import { QueryContext, ctx, stackDepth, pushContext, popContext } from "./query-state.js";
 import { findUnpairedToolUses, summarizeMissingToolNames, type MissingToolResult } from "./tool-pairing-audit.js";
-import { loadConfig, normalizeEffortLevel, recordProjectTrust, type Config } from "./config.js";
+import { loadConfig, normalizeConnectorWriteMode, normalizeEffortLevel, recordProjectTrust, type Config, type ConnectorWriteMode } from "./config.js";
 import { extractAgentsAppend } from "./agents-md.js";
 import { buildPromptContextAppend } from "./prompt-context.js";
 import { jsonSchemaToZodShape } from "./typebox-to-zod.js";
@@ -543,6 +543,141 @@ export const CLAUDE_AI_CONNECTOR_TOOL_PATTERNS = [
 // discoverable. Verified: disallowing ToolSearch reliably yields NO_CONNECTORS.
 export const CONNECTOR_DISCOVERY_TOOLS = ["ToolSearch", "ListMcpResources", "ReadMcpResource"];
 
+// --- Connector WRITE tool control (read-inline / write-by-approval) ---
+//
+// Connector tools execute INSIDE claude via the bridge, so Memsira's Pi-level
+// ConsentGate never sees them. To keep every connector WRITE explicit + gated,
+// connector chat sessions run read-only (writes denied); the model performs a
+// write only through a gated Pi custom-tool whose app-side dispatcher runs a
+// ONE-SHOT write-enabled bridge query. This block is the bridge lever for that:
+// deny connector write tools by default, allow them only for that executor.
+//
+// Cloud connector server namespaces (the `mcp__<server>__` prefix).
+const CONNECTOR_NS_GMAIL = "mcp__claude_ai_Gmail__";
+const CONNECTOR_NS_CALENDAR = "mcp__claude_ai_Google_Calendar__";
+const CONNECTOR_NS_DRIVE = "mcp__claude_ai_Google_Drive__";
+const CONNECTOR_NAMESPACES = [CONNECTOR_NS_GMAIL, CONNECTOR_NS_CALENDAR, CONNECTOR_NS_DRIVE];
+
+// Read-verb prefixes: a connector tool whose name (the segment after its
+// namespace) starts with one of these is a non-mutating READ and always stays
+// available. Everything else on a connector namespace is treated as a WRITE.
+// Observed reads (POC): list_labels, search_threads, get_message, list_calendars,
+// list_events, get_event — i.e. list_/search_/get_; the rest are common Google
+// read verbs. Keep this list tight: mis-classifying a read as a write only
+// blocks a read (safe, easily fixed), whereas mis-classifying a write as a read
+// would open an ungated mutation.
+const CONNECTOR_READ_PREFIXES = [
+	"list_", "search_", "get_", "read_", "fetch_", "find_",
+	"download_", "describe_", "query_", "count_", "view_",
+];
+
+// Explicit known write tool names (current claude.ai connectors). Passed to the
+// SDK disallowedTools so today's writes are removed from the model's context by
+// exact tool id (the CLI matcher only supports exact ids or a whole-server glob).
+export const CONNECTOR_WRITE_TOOLS = [
+	`${CONNECTOR_NS_GMAIL}create_draft`,
+	`${CONNECTOR_NS_GMAIL}create_label`,
+	`${CONNECTOR_NS_GMAIL}label_message`,
+	`${CONNECTOR_NS_GMAIL}label_thread`,
+	`${CONNECTOR_NS_GMAIL}unlabel_message`,
+	`${CONNECTOR_NS_GMAIL}unlabel_thread`,
+	`${CONNECTOR_NS_GMAIL}apply_sensitive_label`,
+	`${CONNECTOR_NS_GMAIL}remove_sensitive_label`,
+	`${CONNECTOR_NS_CALENDAR}create_event`,
+	`${CONNECTOR_NS_CALENDAR}update_event`,
+	`${CONNECTOR_NS_CALENDAR}delete_event`,
+	`${CONNECTOR_NS_CALENDAR}respond_to_event`,
+	`${CONNECTOR_NS_DRIVE}create_file`,
+	`${CONNECTOR_NS_DRIVE}copy_file`,
+];
+
+// Classify a connector tool name as a WRITE (mutating) tool. FAIL CLOSED: a tool
+// on a connector namespace is a write UNLESS its verb is a known read prefix, so
+// not-yet-known future write tools (e.g. Gmail send_message, Drive delete_file,
+// Calendar add_attendee) are classified as writes and blocked in a read-only
+// session. Non-connector tools (Pi custom-tools, ToolSearch, MCP-resource tools)
+// are never connector writes → false. Used by connectorWriteDenyHook and by
+// callers (e.g. the one-shot write executor) that enumerate live connector tools.
+export function isConnectorWriteTool(name: string): boolean {
+	const ns = CONNECTOR_NAMESPACES.find((n) => name.startsWith(n));
+	if (!ns) return false;
+	const tool = name.slice(ns.length);
+	return !CONNECTOR_READ_PREFIXES.some((prefix) => tool.startsWith(prefix));
+}
+
+// Connector write mode from the env override. `allow` exposes connector write
+// tools; `deny` hides them. Returns undefined when unset so config can decide.
+export function connectorWriteModeFromEnv(): ConnectorWriteMode | undefined {
+	const v = (process.env.CLAUDE_BRIDGE_CONNECTOR_WRITE ?? "").trim().toLowerCase();
+	if (v === "allow") return "allow";
+	if (v === "deny") return "deny";
+	return undefined;
+}
+
+// Resolve the connector write mode: env wins over config, default `deny`
+// (mirrors connectorsEnabledFor's env-first precedence). Only meaningful when
+// connectors are enabled; connector chat sessions keep the default deny and the
+// one-shot approved-write executor sets allow (env or config).
+//
+// FAIL CLOSED: writes are enabled ONLY by an explicit, validated `allow`. The
+// config value is re-normalized here (defense in depth over normalizeProviderConfig)
+// so a raw legacy-config value like "Deny"/"read-only"/true can never be treated
+// as a truthy non-deny and silently open writes — anything but exact allow → deny.
+export function connectorWriteModeFor(config?: Config): ConnectorWriteMode {
+	const resolved = connectorWriteModeFromEnv() ?? normalizeConnectorWriteMode(config?.provider?.connectorWriteMode);
+	return resolved === "allow" ? "allow" : "deny";
+}
+
+// PreToolUse hook that hard-blocks connector WRITE tools at call time. Hooks run
+// regardless of permissionMode (we use bypassPermissions), so this — not the
+// static deny lists — is the real prefix-based runtime enforcement of
+// isConnectorWriteTool. disallowedTools removes today's KNOWN writes from model
+// context, but the CLI matcher can't glob the tool segment, so a future write
+// tool (e.g. mcp__claude_ai_Gmail__send_message, ..._Drive__delete_file) would
+// otherwise be callable in a read-only session; this hook denies it by prefix.
+export function connectorWriteDenyHook(): HookCallback {
+	return async (input) => {
+		// The CLI treats a hook error/timeout as an EMPTY hook output and lets
+		// the tool call proceed (fail OPEN) — so any exception in this body
+		// must convert to a deny, never an allow. Today's body is pure string
+		// checks on schema-validated input; the catch pins that invariant for
+		// whatever gets added here later.
+		try {
+			if (input.hook_event_name !== "PreToolUse") return { continue: true };
+			if (!isConnectorWriteTool(input.tool_name)) return { continue: true };
+			return connectorWriteDenyOutput(String(input.tool_name));
+		} catch {
+			const toolName = typeof (input as { tool_name?: unknown })?.tool_name === "string"
+				? (input as { tool_name: string }).tool_name
+				: "<unknown>";
+			return connectorWriteDenyOutput(toolName);
+		}
+	};
+}
+
+function connectorWriteDenyOutput(toolName: string) {
+	return {
+		hookSpecificOutput: {
+			hookEventName: "PreToolUse" as const,
+			permissionDecision: "deny" as const,
+			permissionDecisionReason:
+				`Connector write tool "${toolName}" is blocked in read-only connector mode. ` +
+				`Connector writes must go through Memsira's gated approval flow.`,
+		},
+	};
+}
+
+// Connector query-option fragment: tool isolation (allow/deny lists) plus, when
+// connectors are enabled and writes are denied, the runtime PreToolUse write
+// hook. Spread into the SDK query options; continuation queries inherit it via
+// `{ ...queryOptions }`. Exported so the wiring is unit-testable end to end.
+export function connectorQueryOptions(connectorsEnabled: boolean, writeMode: ConnectorWriteMode = "deny"): Partial<Pick<NonNullable<Parameters<typeof query>[0]["options"]>, "tools" | "allowedTools" | "disallowedTools" | "hooks">> {
+	const isolation = toolIsolationForQuery(connectorsEnabled, writeMode);
+	// Only enforce (and only meaningful) when connectors are on and writes denied.
+	if (!connectorsEnabled || writeMode === "allow") return isolation;
+	return { ...isolation, hooks: { PreToolUse: [{ hooks: [connectorWriteDenyHook()] }] } };
+}
+
 // Tool isolation for a query. When connectors are enabled we still remove
 // Claude Code's filesystem/shell built-ins (via disallowedTools; Pi owns those)
 // and auto-allow the cloud connector tool namespaces so the model can call
@@ -553,11 +688,18 @@ export const CONNECTOR_DISCOVERY_TOOLS = ["ToolSearch", "ListMcpResources", "Rea
 // view (verified — Pi's SDK-injected custom-tools survive it, but connectors do
 // not). Dropping `tools` leaves the connectors visible; disallowedTools still
 // hard-denies the built-ins so Pi keeps ownership of file/shell/web tools.
-export function toolIsolationForQuery(connectorsEnabled: boolean): Partial<Pick<NonNullable<Parameters<typeof query>[0]["options"]>, "tools" | "allowedTools" | "disallowedTools">> {
+export function toolIsolationForQuery(connectorsEnabled: boolean, writeMode: ConnectorWriteMode = "deny"): Partial<Pick<NonNullable<Parameters<typeof query>[0]["options"]>, "tools" | "allowedTools" | "disallowedTools">> {
 	if (!connectorsEnabled) return CLAUDE_BRIDGE_TOOL_ISOLATION;
 	// Keep ToolSearch + MCP-resource tools available so the model can discover the
 	// deferred cloud connector tools; still block file/shell/web built-ins.
 	const disallowedTools = DISALLOWED_BUILTIN_TOOLS.filter((t) => !CONNECTOR_DISCOVERY_TOOLS.includes(t));
+	// Deny connector WRITE tools unless writes are explicitly allowed (fail
+	// closed: any mode but exact "allow" is treated as read-only). This removes
+	// today's KNOWN writes from the model's context by exact id; deny rules take
+	// precedence over the CLAUDE_AI_CONNECTOR_TOOL_PATTERNS allow rules below, so
+	// reads stay available. Runtime enforcement covering unknown/future write
+	// tools is done by connectorWriteDenyHook — see connectorQueryOptions.
+	if (writeMode !== "allow") disallowedTools.push(...CONNECTOR_WRITE_TOOLS);
 	return {
 		disallowedTools,
 		allowedTools: [...CLAUDE_BRIDGE_TOOL_ISOLATION.allowedTools, ...CLAUDE_AI_CONNECTOR_TOOL_PATTERNS],
@@ -1965,6 +2107,9 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 	// (Gmail/Calendar/Drive). Enabled via env or config; drives setting-sources,
 	// tool isolation, and the ENABLE_CLAUDEAI_MCP_SERVERS child-env gate below.
 	const enableCloudMcp = connectorsEnabledFor(bridgeConfig);
+	// Connector WRITE control: read-only by default (writes denied); the one-shot
+	// approved-write executor sets CLAUDE_BRIDGE_CONNECTOR_WRITE=allow / config.
+	const connectorWriteMode = connectorWriteModeFor(bridgeConfig);
 	const appendSystemPrompt = providerSettings.appendSystemPrompt !== false;
 	const agentsAppend = appendSystemPrompt ? extractAgentsAppend() : undefined;
 	const skillsAppend = appendSystemPrompt ? extractSkillsBlock(context.systemPrompt) : undefined;
@@ -2024,7 +2169,7 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 		cwd,
 		model: model.id,
 		env: childEnv,
-		...toolIsolationForQuery(enableCloudMcp),
+		...connectorQueryOptions(enableCloudMcp, connectorWriteMode),
 		permissionMode: "bypassPermissions",
 		includePartialMessages: true,
 		...(fallbackModel ? { fallbackModel } : {}),

--- a/pi-extensions/pi-claude-bridge/src/index.ts
+++ b/pi-extensions/pi-claude-bridge/src/index.ts
@@ -505,7 +505,7 @@ export const CLAUDE_BRIDGE_TOOL_ISOLATION = {
 	allowedTools: [`mcp__${MCP_SERVER_NAME}__*`],
 } satisfies Pick<NonNullable<Parameters<typeof query>[0]["options"]>, "tools" | "allowedTools" | "disallowedTools">;
 
-// --- POC: Claude account cloud MCP connectors (Gmail / Calendar / Drive) ---
+// --- Claude account cloud MCP connectors (Gmail / Calendar / Drive) ---
 //
 // By default the bridge suppresses claude.ai cloud MCP servers (see the
 // ENABLE_CLAUDEAI_MCP_SERVERS="0" note near the query builder) so Pi owns tool
@@ -514,9 +514,17 @@ export const CLAUDE_BRIDGE_TOOL_ISOLATION = {
 // exposing Gmail/Calendar/Drive tools the account has connected. Gated so the
 // default behavior is unchanged. See
 // docs/plans/claude-bridge-google-connectors.md.
-export function connectorsEnabled(): boolean {
+export function connectorsEnabledFromEnv(): boolean {
 	const v = (process.env.CLAUDE_BRIDGE_ENABLE_CONNECTORS ?? "").trim().toLowerCase();
 	return v === "1" || v === "true" || v === "yes" || v === "on";
+}
+
+// Connectors are enabled if EITHER the env var is truthy OR the resolved bridge
+// config sets `provider.enableConnectors`. Env is the simplest per-process knob
+// (one sidecar per Claude account sets it in its child env); config lets a host
+// app enable it declaratively via its written settings.json.
+export function connectorsEnabledFor(config?: Config): boolean {
+	return connectorsEnabledFromEnv() || config?.provider?.enableConnectors === true;
 }
 
 // Cloud MCP connector tool namespaces auto-allowed when connectors are enabled.
@@ -545,8 +553,8 @@ export const CONNECTOR_DISCOVERY_TOOLS = ["ToolSearch", "ListMcpResources", "Rea
 // view (verified — Pi's SDK-injected custom-tools survive it, but connectors do
 // not). Dropping `tools` leaves the connectors visible; disallowedTools still
 // hard-denies the built-ins so Pi keeps ownership of file/shell/web tools.
-export function toolIsolationForQuery(): Partial<Pick<NonNullable<Parameters<typeof query>[0]["options"]>, "tools" | "allowedTools" | "disallowedTools">> {
-	if (!connectorsEnabled()) return CLAUDE_BRIDGE_TOOL_ISOLATION;
+export function toolIsolationForQuery(connectorsEnabled: boolean): Partial<Pick<NonNullable<Parameters<typeof query>[0]["options"]>, "tools" | "allowedTools" | "disallowedTools">> {
+	if (!connectorsEnabled) return CLAUDE_BRIDGE_TOOL_ISOLATION;
 	// Keep ToolSearch + MCP-resource tools available so the model can discover the
 	// deferred cloud connector tools; still block file/shell/web built-ins.
 	const disallowedTools = DISALLOWED_BUILTIN_TOOLS.filter((t) => !CONNECTOR_DISCOVERY_TOOLS.includes(t));
@@ -1953,6 +1961,10 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 	const mcpServers = buildMcpServers(mcpTools, ctx());
 	const bridgeConfig = loadConfig(cwd);
 	const providerSettings = bridgeConfig.provider ?? {};
+	// Whether to expose the Claude account's claude.ai cloud MCP connectors
+	// (Gmail/Calendar/Drive). Enabled via env or config; drives setting-sources,
+	// tool isolation, and the ENABLE_CLAUDEAI_MCP_SERVERS child-env gate below.
+	const enableCloudMcp = connectorsEnabledFor(bridgeConfig);
 	const appendSystemPrompt = providerSettings.appendSystemPrompt !== false;
 	const agentsAppend = appendSystemPrompt ? extractAgentsAppend() : undefined;
 	const skillsAppend = appendSystemPrompt ? extractSkillsBlock(context.systemPrompt) : undefined;
@@ -1964,12 +1976,12 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 	// SDK uses isolation mode and avoids filesystem settings. If users turn that
 	// off, load user/project settings but pass --strict-mcp-config so Claude Code
 	// ignores auto-discovered filesystem MCP servers while Pi owns tool execution.
-	// POC: claude.ai cloud MCP connectors only load when Claude Code resolves its
+	// claude.ai cloud MCP connectors only load when Claude Code resolves its
 	// filesystem setting sources. The SDK treats settingSources=undefined as
 	// isolation (no sources), which drops the connectors even with
 	// ENABLE_CLAUDEAI_MCP_SERVERS=1. When connectors are enabled we force the CLI
 	// default source set so Gmail/Calendar/Drive surface.
-	const settingSources: SettingSource[] | undefined = connectorsEnabled()
+	const settingSources: SettingSource[] | undefined = enableCloudMcp
 		? (providerSettings.settingSources ?? ["user", "project", "local"])
 		: appendSystemPrompt
 			? undefined
@@ -2005,15 +2017,14 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 	// also autocompact would double-flush the prompt cache and races pi's
 	// threshold with CC's, including CC's anti-thrashing guard (issue #8).
 	// Manual /compact in CC still works (we never invoke it).
-	// POC: when connectors are enabled, allow claude.ai cloud MCP servers so the
+	// When connectors are enabled, allow claude.ai cloud MCP servers so the
 	// authenticated account's Gmail/Calendar/Drive tools load. Default stays "0".
-	const enableCloudMcp = connectorsEnabled();
 	const childEnv = { ...process.env, ENABLE_CLAUDEAI_MCP_SERVERS: enableCloudMcp ? "1" : "0", DISABLE_AUTO_COMPACT: "1" };
 	const queryOptions: NonNullable<Parameters<typeof query>[0]["options"]> = {
 		cwd,
 		model: model.id,
 		env: childEnv,
-		...toolIsolationForQuery(),
+		...toolIsolationForQuery(enableCloudMcp),
 		permissionMode: "bypassPermissions",
 		includePartialMessages: true,
 		...(fallbackModel ? { fallbackModel } : {}),

--- a/pi-extensions/pi-claude-bridge/src/index.ts
+++ b/pi-extensions/pi-claude-bridge/src/index.ts
@@ -505,6 +505,57 @@ export const CLAUDE_BRIDGE_TOOL_ISOLATION = {
 	allowedTools: [`mcp__${MCP_SERVER_NAME}__*`],
 } satisfies Pick<NonNullable<Parameters<typeof query>[0]["options"]>, "tools" | "allowedTools" | "disallowedTools">;
 
+// --- POC: Claude account cloud MCP connectors (Gmail / Calendar / Drive) ---
+//
+// By default the bridge suppresses claude.ai cloud MCP servers (see the
+// ENABLE_CLAUDEAI_MCP_SERVERS="0" note near the query builder) so Pi owns tool
+// execution and tokens stay lean. This opt-in flag lets the authenticated
+// Claude account's authorized Google connectors flow through to the model,
+// exposing Gmail/Calendar/Drive tools the account has connected. Gated so the
+// default behavior is unchanged. See
+// docs/plans/claude-bridge-google-connectors.md.
+export function connectorsEnabled(): boolean {
+	const v = (process.env.CLAUDE_BRIDGE_ENABLE_CONNECTORS ?? "").trim().toLowerCase();
+	return v === "1" || v === "true" || v === "yes" || v === "on";
+}
+
+// Cloud MCP connector tool namespaces auto-allowed when connectors are enabled.
+// Names match Claude Code's claude.ai connector servers.
+export const CLAUDE_AI_CONNECTOR_TOOL_PATTERNS = [
+	"mcp__claude_ai_Gmail__*",
+	"mcp__claude_ai_Google_Calendar__*",
+	"mcp__claude_ai_Google_Drive__*",
+];
+
+// Claude Code registers a Claude account's cloud connectors as DEFERRED tools
+// that the model must load via ToolSearch (and enumerate via the MCP-resource
+// tools). The default bridge isolation disallows all three so Pi owns tool
+// discovery — but that hides the connectors from the model entirely. When
+// connectors are enabled we must let these through so Gmail/Calendar/Drive are
+// discoverable. Verified: disallowing ToolSearch reliably yields NO_CONNECTORS.
+export const CONNECTOR_DISCOVERY_TOOLS = ["ToolSearch", "ListMcpResources", "ReadMcpResource"];
+
+// Tool isolation for a query. When connectors are enabled we still remove
+// Claude Code's filesystem/shell built-ins (via disallowedTools; Pi owns those)
+// and auto-allow the cloud connector tool namespaces so the model can call
+// Gmail/Calendar/Drive.
+//
+// Critically, we must OMIT `tools: []` in the connector path: an empty --tools
+// allowlist strips the claude.ai cloud MCP connector tools from the model's
+// view (verified — Pi's SDK-injected custom-tools survive it, but connectors do
+// not). Dropping `tools` leaves the connectors visible; disallowedTools still
+// hard-denies the built-ins so Pi keeps ownership of file/shell/web tools.
+export function toolIsolationForQuery(): Partial<Pick<NonNullable<Parameters<typeof query>[0]["options"]>, "tools" | "allowedTools" | "disallowedTools">> {
+	if (!connectorsEnabled()) return CLAUDE_BRIDGE_TOOL_ISOLATION;
+	// Keep ToolSearch + MCP-resource tools available so the model can discover the
+	// deferred cloud connector tools; still block file/shell/web built-ins.
+	const disallowedTools = DISALLOWED_BUILTIN_TOOLS.filter((t) => !CONNECTOR_DISCOVERY_TOOLS.includes(t));
+	return {
+		disallowedTools,
+		allowedTools: [...CLAUDE_BRIDGE_TOOL_ISOLATION.allowedTools, ...CLAUDE_AI_CONNECTOR_TOOL_PATTERNS],
+	};
+}
+
 // --- Session persistence ---
 
 interface SessionState {
@@ -1913,9 +1964,16 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 	// SDK uses isolation mode and avoids filesystem settings. If users turn that
 	// off, load user/project settings but pass --strict-mcp-config so Claude Code
 	// ignores auto-discovered filesystem MCP servers while Pi owns tool execution.
-	const settingSources: SettingSource[] | undefined = appendSystemPrompt
-		? undefined
-		: providerSettings.settingSources ?? ["user", "project"];
+	// POC: claude.ai cloud MCP connectors only load when Claude Code resolves its
+	// filesystem setting sources. The SDK treats settingSources=undefined as
+	// isolation (no sources), which drops the connectors even with
+	// ENABLE_CLAUDEAI_MCP_SERVERS=1. When connectors are enabled we force the CLI
+	// default source set so Gmail/Calendar/Drive surface.
+	const settingSources: SettingSource[] | undefined = connectorsEnabled()
+		? (providerSettings.settingSources ?? ["user", "project", "local"])
+		: appendSystemPrompt
+			? undefined
+			: providerSettings.settingSources ?? ["user", "project"];
 	const strictMcpConfigEnabled = !appendSystemPrompt && providerSettings.strictMcpConfig !== false;
 	const claudeExecutable = resolveClaudeExecutable(providerSettings.pathToClaudeCodeExecutable);
 	const claudeExecutablePreflight = claudeExecutable ? preflightClaudeExecutable(claudeExecutable, cwd) : undefined;
@@ -1947,12 +2005,15 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 	// also autocompact would double-flush the prompt cache and races pi's
 	// threshold with CC's, including CC's anti-thrashing guard (issue #8).
 	// Manual /compact in CC still works (we never invoke it).
-	const childEnv = { ...process.env, ENABLE_CLAUDEAI_MCP_SERVERS: "0", DISABLE_AUTO_COMPACT: "1" };
+	// POC: when connectors are enabled, allow claude.ai cloud MCP servers so the
+	// authenticated account's Gmail/Calendar/Drive tools load. Default stays "0".
+	const enableCloudMcp = connectorsEnabled();
+	const childEnv = { ...process.env, ENABLE_CLAUDEAI_MCP_SERVERS: enableCloudMcp ? "1" : "0", DISABLE_AUTO_COMPACT: "1" };
 	const queryOptions: NonNullable<Parameters<typeof query>[0]["options"]> = {
 		cwd,
 		model: model.id,
 		env: childEnv,
-		...CLAUDE_BRIDGE_TOOL_ISOLATION,
+		...toolIsolationForQuery(),
 		permissionMode: "bypassPermissions",
 		includePartialMessages: true,
 		...(fallbackModel ? { fallbackModel } : {}),
@@ -1975,7 +2036,7 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 		`model=${model.id} msgs=${context.messages.length} tools=${mcpTools.length}`,
 		`resume=${resumeSessionId?.slice(0, 8) ?? "none"} effort=${effort ?? "default"}`,
 		`fallback=${fallbackModel ?? "none"}`,
-		`appendSys=${appendSystemPrompt} promptCtx=${promptContextAppend.labels.join(",") || "none"} strictMcp=${strictMcpConfigEnabled} fastMode=${providerSettings.fastMode === true}`,
+		`appendSys=${appendSystemPrompt} promptCtx=${promptContextAppend.labels.join(",") || "none"} strictMcp=${strictMcpConfigEnabled} fastMode=${providerSettings.fastMode === true} connectors=${enableCloudMcp}`,
 		`claudeExec=${claudeExecutablePreflight ? `${claudeExecutablePreflight.fileType}:${claudeExecutablePreflight.path}` : "sdk-default"}`,
 		`prompt=${promptText.slice(0, 60)}${promptBlocks ? " [+images]" : ""}`);
 

--- a/pi-extensions/pi-claude-bridge/src/index.ts
+++ b/pi-extensions/pi-claude-bridge/src/index.ts
@@ -18,6 +18,7 @@ import { extractAllToolResults as _extractAllToolResults, type McpResult } from 
 import { QueryContext, ctx, stackDepth, pushContext, popContext } from "./query-state.js";
 import { findUnpairedToolUses, summarizeMissingToolNames, type MissingToolResult } from "./tool-pairing-audit.js";
 import { loadConfig, normalizeConnectorWriteMode, normalizeEffortLevel, recordProjectTrust, type Config, type ConnectorWriteMode } from "./config.js";
+import { decideRegistration, hasClaudeCredentials } from "./auth-presence.js";
 import { extractAgentsAppend } from "./agents-md.js";
 import { buildPromptContextAppend } from "./prompt-context.js";
 import { jsonSchemaToZodShape } from "./typebox-to-zod.js";
@@ -456,20 +457,31 @@ export function __testGetBridgeIntegrityState(): { sharedSession: SessionState |
 
 // --- Constants ---
 
-// Global key to prevent re-registration of the provider across module reloads.
+// Two process-global tokens govern provider registration across module reloads.
+// Extensions like pi-subagents spawn a subagent that loads THIS module again as
+// a fresh (non-primary) instance. Two failure modes must be prevented:
+//   (1) a subagent's registerProvider() overwriting the parent's `streamSimple`
+//       in the shared ModelRegistry — the parent would then deliver tool results
+//       through the subagent's empty-state streamSimple and break tool pairing;
+//   (2) a subagent STEALING registration ownership: if the parent loaded
+//       uncredentialed and the user logged in mid-session, a later subagent load
+//       would see credentialed + no-owner and claim ownership + register ITS
+//       streamSimple, split-braining the shared session/ctx.
 //
-// Extensions like pi-subagents spawn a subagent and it loads this module
-// again. Without this guard, the subagent's call to registerProvider() would
-// overwrite the parent's `streamSimple` function reference in the shared
-// ModelRegistry. When the parent later delivers a tool result, it would call
-// the subagent's `streamSimple` (which has empty state) instead of its own.
+// PRIMARY_INSTANCE_KEY — claimed UNCONDITIONALLY (regardless of credentials) by
+// the first-loaded module instance. ONLY the primary instance may ever
+// register, unregister, or claim the stream guard. Non-primary instances
+// (subagents) always no-op. This is the authority token; it closes (2).
 //
-// By storing the active streamSimple in a Symbol.for() global (shared across all
-// module instances), we ensure only the FIRST instance to register takes effect.
-// Subsequent instances wrap the stored function instead of overwriting it.
+// ACTIVE_STREAM_SIMPLE_KEY — holds the registered instance's `streamSimple`.
+// Only the primary claims it, and only while a registration is live. It doubles
+// as the "already registered" flag (guard === our streamSimple) and the routing
+// target for reentrant subagent calls; it closes (1).
 //
-// On session_shutdown (including /reload), clearSession() resets this so a fresh
-// registration can occur for the next session.
+// Both are released on session_shutdown (incl. /reload) by releaseProviderTokens
+// so the next module load starts clean. See applyProviderRegistration for the
+// state machine and auth-presence.ts/decideRegistration for the pure decision.
+const PRIMARY_INSTANCE_KEY = Symbol.for("claude-bridge:primaryInstance");
 const ACTIVE_STREAM_SIMPLE_KEY = Symbol.for("claude-bridge:activeStreamSimple");
 const COMMANDS_REGISTERED_KEY = Symbol.for("claude-bridge:commandsRegistered");
 
@@ -1963,6 +1975,92 @@ async function consumeQuery(
 	return { capturedSessionId };
 }
 
+// Claim the primary-instance token for this module instance if unclaimed, and
+// report whether this instance is the primary. First-loaded instance wins,
+// UNCONDITIONALLY (before any credential check), so a later subagent load can
+// never become primary and steal registration ownership.
+function claimPrimaryInstance(): boolean {
+	const g = globalThis as Record<symbol, any>;
+	if (!g[PRIMARY_INSTANCE_KEY]) g[PRIMARY_INSTANCE_KEY] = streamClaudeAgentSdk;
+	return g[PRIMARY_INSTANCE_KEY] === streamClaudeAgentSdk;
+}
+
+// Release both process-global tokens this instance owns. Called on
+// session_shutdown (incl. /reload) so the freshly loaded instance starts clean.
+// NOTE: this does NOT unregister the provider — the ModelRegistry's
+// registeredProviders is a process-lifetime Map that survives module reload, so
+// retraction on logout is handled by applyProviderRegistration's defensive
+// unregister on the next load/session_start, not here.
+function releaseProviderTokens(event: string): void {
+	const g = globalThis as Record<symbol, any>;
+	if (g[ACTIVE_STREAM_SIMPLE_KEY] === streamClaudeAgentSdk) {
+		debug(`${event}: clearing ACTIVE_STREAM_SIMPLE_KEY`);
+		g[ACTIVE_STREAM_SIMPLE_KEY] = undefined;
+	}
+	if (g[PRIMARY_INSTANCE_KEY] === streamClaudeAgentSdk) {
+		debug(`${event}: clearing PRIMARY_INSTANCE_KEY`);
+		g[PRIMARY_INSTANCE_KEY] = undefined;
+	}
+}
+
+// Conditional (un)registration driven by real credential presence + instance
+// primacy. Run at extension load, on every session_start, and at pre-spawn
+// (fail-fast) so a `claude login` / logout is reflected without a /reload.
+//
+// decideRegistration encodes the pure state machine; this wrapper performs the
+// matching token mutations so tokens and registration never diverge:
+//   - register:   claim the stream guard, THEN registerProvider. If register
+//     throws/queue-fails, release the stream guard (but keep primacy) so a
+//     later re-check can retry cleanly (self-healing); errors are swallowed so
+//     a session_start handler can't crash the dispatch.
+//   - unregister: pi.unregisterProvider (idempotent), THEN release the stream
+//     guard if we own it. Defensive even when we never registered — this is the
+//     only retraction path for a stale registration surviving /reload. At LOAD
+//     the SDK's unregister only filters the pending-registration queue and can't
+//     mutate the persistent registry (loader.js), so the effective retraction
+//     lands on the post-load session_start re-check; the load-time call is a
+//     harmless idempotent no-op that also cancels any same-pass queued register.
+// Non-primary instances (subagents) always decide noop and touch nothing.
+function applyProviderRegistration(trigger: string): void {
+	const pi = extensionApi;
+	if (!pi) { debug(`${trigger}: applyProviderRegistration skipped — no extensionApi`); return; }
+	const g = globalThis as Record<symbol, any>;
+	const isPrimary = claimPrimaryInstance();
+	const credentialed = hasClaudeCredentials();
+	const registered = g[ACTIVE_STREAM_SIMPLE_KEY] === streamClaudeAgentSdk;
+	const decision = decideRegistration({ credentialed, isPrimary, registered });
+	debug(`${trigger}: registration decision=${decision} credentialed=${credentialed} isPrimary=${isPrimary} registered=${registered} (module=${moduleInstanceId})`);
+	if (decision === "register") {
+		// Claim ordering: stream guard BEFORE registerProvider so a concurrent
+		// subagent can never observe a registered provider without an owner.
+		g[ACTIVE_STREAM_SIMPLE_KEY] = streamClaudeAgentSdk;
+		try {
+			pi.registerProvider(PROVIDER_ID, {
+				baseUrl: "claude-bridge",
+				apiKey: "not-used",
+				api: "claude-bridge",
+				models: MODELS,
+				// Cast: pi-ai AssistantMessageEventStream diamond dep between pi-coding-agent and pi-agent-core
+				streamSimple: streamClaudeAgentSdk as any,
+			});
+		} catch (err) {
+			// Self-heal: release ONLY the stream guard we just claimed so a later
+			// re-check (primary + credentialed + not-registered → register) retries.
+			// Keep PRIMARY_INSTANCE_KEY: releasing it would reopen the subagent
+			// ownership-steal window, and retry does not need it released.
+			if (g[ACTIVE_STREAM_SIMPLE_KEY] === streamClaudeAgentSdk) g[ACTIVE_STREAM_SIMPLE_KEY] = undefined;
+			debug(`${trigger}: registerProvider threw; released stream guard for retry (kept primary):`, err);
+		}
+	} else if (decision === "unregister") {
+		try {
+			pi.unregisterProvider(PROVIDER_ID);
+		} catch (err) {
+			debug(`${trigger}: unregisterProvider threw (ignored):`, err);
+		}
+		if (g[ACTIVE_STREAM_SIMPLE_KEY] === streamClaudeAgentSdk) g[ACTIVE_STREAM_SIMPLE_KEY] = undefined;
+	}
+}
+
 /** Provider entry point. Pi calls this for each new prompt and each tool result.
  *  Two cases: tool result delivery (active query) or fresh query. */
 function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: SimpleStreamOptions): AssistantMessageEventStream {
@@ -2061,6 +2159,34 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 	}
 
 	// --- Fresh query ---
+
+	// Fail-fast credential re-check (only for a fresh query — NEVER for
+	// tool-result delivery of an in-flight query, handled above, where creds were
+	// valid at start and failing mid-turn would break tool pairing). This bounds
+	// the retraction-latency window from "next session boundary" to "first use":
+	// if credentials vanished since the last session_start, (a) trigger the same
+	// re-evaluation applyProviderRegistration does (primary-only; retracts the
+	// stale registration), and (b) fail this request with a clear, actionable
+	// message instead of letting the SDK spawn die with a generic error. The
+	// check is cheap (existsSync + env reads only, no credential contents).
+	if (!hasClaudeCredentials()) {
+		try { applyProviderRegistration("pre-spawn"); } catch { /* best effort */ }
+		const message = "Claude account not connected — connect an account (or run `claude login`) and retry.";
+		debug(`provider: pre-spawn credential check failed; failing fast: ${message}`);
+		const errorOutput: AssistantMessage = {
+			role: "assistant", content: [],
+			api: model.api, provider: model.provider, model: model.id,
+			usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+			stopReason: "error", timestamp: Date.now(),
+			errorMessage: message,
+		};
+		queueMicrotask(() => {
+			stream.push({ type: "error", reason: "error", error: errorOutput });
+			stream.end();
+		});
+		return stream;
+	}
 
 	// 1. Determine reentrancy and push parent context if needed.
 	const isReentrant = ctx().activeQuery !== null;
@@ -2476,20 +2602,15 @@ export default function (pi: ExtensionAPI) {
 		return;
 	}
 
-	// Reset shared session on pi session lifecycle events
+	// Reset shared (Claude) conversation state on pi session lifecycle events.
+	// Registration tokens are managed separately by applyProviderRegistration
+	// (load / session_start / pre-spawn) and releaseProviderTokens (shutdown), so
+	// a mid-session credential flip is handled while token ownership is intact.
 	const clearSession = (event: string) => {
 		debug(`${event}: clearing session ${sharedSession?.sessionId?.slice(0, 8) ?? "none"}`);
 		sharedSession = null;
-
-		// Clear the global streamSimple if this instance registered it.
-		// This allows /reload to work — the old instance clears the flag so
-		// the new instance can register fresh without wrapping stale state.
-		const g = globalThis as Record<symbol, any>;
-		if (g[ACTIVE_STREAM_SIMPLE_KEY] === streamClaudeAgentSdk) {
-			debug(`${event}: clearing ACTIVE_STREAM_SIMPLE_KEY`);
-			g[ACTIVE_STREAM_SIMPLE_KEY] = undefined;
-		}
 	};
+
 	pi.on("session_start", (event, ctx) => {
 		recordProjectTrust(ctx);
 		piUI = ctx.ui;
@@ -2501,8 +2622,14 @@ export default function (pi: ExtensionAPI) {
 		// them would --resume the parent's Claude jsonl and leak conversation past the
 		// fork point. Letting the first fork turn rebuild is the correct path.
 		if (event.reason === "startup" || event.reason === "resume") restoreSharedSessionFromPi(ctx);
+		// Live availability flip: re-evaluate credential presence every
+		// session_start so login/logout since load is reflected without /reload.
+		applyProviderRegistration(`session_start:${event.reason}`);
 	});
-	pi.on("session_shutdown", () => clearSession("session_shutdown"));
+	pi.on("session_shutdown", () => {
+		clearSession("session_shutdown");
+		releaseProviderTokens("session_shutdown");
+	});
 	pi.on("message_end", (event, ctx) => {
 		const message = (event as { message?: AssistantMessage }).message;
 		if (message?.role === "assistant" && message.provider === PROVIDER_ID) schedulePersistSharedSession(ctx);
@@ -2529,30 +2656,14 @@ export default function (pi: ExtensionAPI) {
 
 	// --- Provider ---
 	//
-	// Guard against re-registration when the module is loaded multiple times
-	// (e.g., when spawning subagents). The shared ModelRegistry would otherwise
-	// overwrite the parent's streamSimple, breaking tool result delivery.
-	// See ACTIVE_STREAM_SIMPLE_KEY for the full mechanism.
-
-	const g = globalThis as Record<symbol, any>;
-	if (!g[ACTIVE_STREAM_SIMPLE_KEY]) {
-		// First instance: store our streamSimple and register.
-		g[ACTIVE_STREAM_SIMPLE_KEY] = streamClaudeAgentSdk;
-		pi.registerProvider(PROVIDER_ID, {
-			baseUrl: "claude-bridge",
-			apiKey: "not-used",
-			api: "claude-bridge",
-			models: MODELS,
-			// Cast: pi-ai AssistantMessageEventStream diamond dep between pi-coding-agent and pi-agent-core
-			streamSimple: streamClaudeAgentSdk as any,
-		});
-	} else {
-		// Subsequent instance (subagent session): skip registration entirely.
-		// The subagent already has access to claude-bridge models via the shared
-		// ModelRegistry from the parent's registration. Calls to those models
-		// will route through the parent's streamSimple via the reentrant
-		// QueryContext stack mechanism.
-		debug(`provider: skipping re-registration, parent instance active (module=${moduleInstanceId})`);
-	}
-
+	// Register the provider ONLY when real Claude credentials are present, so
+	// claude-bridge models are never advertised as available/selectable when a
+	// request would fail at spawn time (pi's ModelRegistry.hasConfiguredAuth()
+	// treats the dummy apiKey as "configured", so the gate must live here).
+	//
+	// applyProviderRegistration also claims the primary-instance token (first
+	// load wins) and enforces the multi-instance guard: a non-primary subagent
+	// reload always no-ops, so it never overwrites the parent's streamSimple nor
+	// steals ownership. See PRIMARY_INSTANCE_KEY / ACTIVE_STREAM_SIMPLE_KEY.
+	applyProviderRegistration("load");
 }

--- a/pi-extensions/pi-claude-bridge/src/index.ts
+++ b/pi-extensions/pi-claude-bridge/src/index.ts
@@ -8,7 +8,6 @@ import { spawn as spawnProcess } from "child_process";
 import { createHash } from "crypto";
 import { accessSync, appendFileSync, chmodSync, constants as fsConstants, mkdirSync, readFileSync, realpathSync, statSync } from "fs";
 import { resolve as pathResolve } from "path";
-import { homedir } from "os";
 import { delimiter, dirname, join } from "path";
 import { PROVIDER_ID, messageContentToText, convertPiMessages } from "./convert.js";
 import { FABLE_FALLBACK_MODEL_ID, FABLE_MODEL_ID, buildModels, fallbackModelForPrimaryModel } from "./models.js";
@@ -17,7 +16,7 @@ import { verifyWrittenSession as _verifyWrittenSession } from "./session-verify.
 import { extractAllToolResults as _extractAllToolResults, type McpResult } from "./extract-tool-results.js";
 import { QueryContext, ctx, stackDepth, pushContext, popContext } from "./query-state.js";
 import { findUnpairedToolUses, summarizeMissingToolNames, type MissingToolResult } from "./tool-pairing-audit.js";
-import { loadConfig, normalizeConnectorWriteMode, normalizeEffortLevel, recordProjectTrust, type Config, type ConnectorWriteMode } from "./config.js";
+import { isolatedFromEnv, loadConfig, normalizeConnectorWriteMode, normalizeEffortLevel, piUserDir, recordProjectTrust, type Config, type ConnectorWriteMode } from "./config.js";
 import { decideRegistration, hasClaudeCredentials } from "./auth-presence.js";
 import { extractAgentsAppend } from "./agents-md.js";
 import { buildPromptContextAppend } from "./prompt-context.js";
@@ -33,14 +32,14 @@ const newAssistantMessageEventStream: () => AssistantMessageEventStream =
 		: () => new _piAi.AssistantMessageEventStream();
 
 // --- Debug logging ---
-// CLAUDE_BRIDGE_DEBUG=1 enables debug logging to ~/.pi/agent/claude-bridge.log
+// CLAUDE_BRIDGE_DEBUG=1 enables debug logging to <piUserDir>/claude-bridge.log
+// (~/.pi/agent/claude-bridge.log unless PI_CODING_AGENT_DIR points elsewhere).
 
 const DEBUG = process.env.CLAUDE_BRIDGE_DEBUG === "1";
-const DEBUG_LOG_PATH = process.env.CLAUDE_BRIDGE_DEBUG_PATH || join(homedir(), ".pi", "agent", "claude-bridge.log");
-const DEFAULT_DIAG_LOG_PATH = join(homedir(), ".pi", "agent", "claude-bridge-diag.log");
+const DEBUG_LOG_PATH = process.env.CLAUDE_BRIDGE_DEBUG_PATH || join(piUserDir(), "claude-bridge.log");
 
 function diagLogPath(): string {
-	return process.env.CLAUDE_BRIDGE_DIAG_PATH || DEFAULT_DIAG_LOG_PATH;
+	return process.env.CLAUDE_BRIDGE_DIAG_PATH || join(piUserDir(), "claude-bridge-diag.log");
 }
 
 // Ensure log directories exist when debug is enabled
@@ -82,9 +81,13 @@ function executableFromPath(name: string): string | undefined {
 	return undefined;
 }
 
-function resolveClaudeExecutable(configured?: string): string | undefined {
+export function resolveClaudeExecutable(configured?: string): string | undefined {
 	const trimmed = configured?.trim();
 	if (trimmed) return trimmed;
+	// Isolated mode: never run whatever `claude` happens to be on $PATH — the
+	// host app either pins an executable in config or gets the SDK's bundled
+	// default, which ships inside the host bundle.
+	if (isolatedFromEnv()) return undefined;
 	return executableFromPath("claude") ?? executableFromPath("claude-code");
 }
 

--- a/pi-extensions/pi-claude-bridge/src/prompt-context.ts
+++ b/pi-extensions/pi-claude-bridge/src/prompt-context.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync } from "fs";
-import { homedir } from "os";
 import { dirname, join, resolve } from "path";
+import { isolatedFromEnv, piUserDir } from "./config.js";
 
 export interface PromptContextSettings {
 	includeAppendSystemPromptMd?: boolean;
@@ -12,12 +12,6 @@ export interface PromptContextSettings {
 export interface PromptContextAppend {
 	text?: string;
 	labels: string[];
-}
-
-function piUserDir(): string {
-	const configured = process.env.PI_CODING_AGENT_DIR?.trim();
-	if (configured) return resolve(configured.replace(/^~(?=\/|$)/, homedir()));
-	return join(homedir(), ".pi", "agent");
 }
 
 function readTrimmed(path: string): string | undefined {
@@ -46,7 +40,8 @@ export function readAppendSystemPromptFiles(cwd: string): Array<{ label: string;
 	const files: Array<{ label: string; path: string }> = [
 		{ label: "global APPEND_SYSTEM.md", path: join(piUserDir(), "APPEND_SYSTEM.md") },
 	];
-	const projectPath = findProjectAppendSystem(cwd);
+	// Isolated mode: no cwd-ancestor discovery — the host app owns the prompt surface.
+	const projectPath = isolatedFromEnv() ? undefined : findProjectAppendSystem(cwd);
 	if (projectPath) files.push({ label: "project .pi/APPEND_SYSTEM.md", path: projectPath });
 
 	const seen = new Set<string>();

--- a/pi-extensions/pi-claude-bridge/tests/unit-auth-presence.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-auth-presence.mjs
@@ -1,0 +1,170 @@
+/**
+ * Tests for claude-bridge credential presence detection and the pure
+ * registration decision that gates provider availability (W8-2 availability
+ * honesty). These exercise auth-presence.ts directly — no live pi instance.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { resolveClaudeConfigDir, hasClaudeCredentials, decideRegistration } from "../src/auth-presence.ts";
+
+function withTempHome(fn) {
+	const root = mkdtempSync(join(tmpdir(), "claude-bridge-auth-"));
+	try {
+		return fn(root);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+}
+
+// Pin the platform to linux in credential tests so the darwin Keychain default
+// never masks a real false/true; darwin behavior is tested explicitly.
+const LINUX = "linux";
+
+describe("resolveClaudeConfigDir", () => {
+	it("prefers an explicit non-empty CLAUDE_CONFIG_DIR", () => {
+		assert.equal(resolveClaudeConfigDir({ CLAUDE_CONFIG_DIR: "/custom/dir" }), "/custom/dir");
+	});
+
+	it("returns the TRIMMED CLAUDE_CONFIG_DIR value", () => {
+		assert.equal(resolveClaudeConfigDir({ CLAUDE_CONFIG_DIR: "  /custom/dir  " }), "/custom/dir");
+	});
+
+	it("ignores an empty/whitespace CLAUDE_CONFIG_DIR and falls back to ~/.claude", () => {
+		const fallback = resolveClaudeConfigDir({ CLAUDE_CONFIG_DIR: "   " });
+		assert.ok(fallback.endsWith("/.claude"), `expected ~/.claude fallback, got ${fallback}`);
+	});
+
+	it("falls back to ~/.claude when unset", () => {
+		const fallback = resolveClaudeConfigDir({});
+		assert.ok(fallback.endsWith("/.claude"), `expected ~/.claude fallback, got ${fallback}`);
+	});
+});
+
+describe("hasClaudeCredentials", () => {
+	it("is false when no signal and no .credentials.json exists (linux)", () => withTempHome((dir) => {
+		assert.equal(hasClaudeCredentials({ CLAUDE_CONFIG_DIR: dir }, LINUX), false);
+	}));
+
+	it("is true when .credentials.json exists in the resolved config dir", () => withTempHome((dir) => {
+		writeFileSync(join(dir, ".credentials.json"), "{}");
+		assert.equal(hasClaudeCredentials({ CLAUDE_CONFIG_DIR: dir }, LINUX), true);
+	}));
+
+	it("honors CLAUDE_CONFIG_DIR override for the credentials file location", () => withTempHome((dir) => {
+		const nested = join(dir, "alt");
+		mkdirSync(nested, { recursive: true });
+		writeFileSync(join(nested, ".credentials.json"), "{}");
+		assert.equal(hasClaudeCredentials({ CLAUDE_CONFIG_DIR: nested }, LINUX), true);
+		assert.equal(hasClaudeCredentials({ CLAUDE_CONFIG_DIR: dir }, LINUX), false);
+	}));
+
+	// Env-based credential sources (no file needed) --------------------------
+	it("is true for non-empty CLAUDE_CODE_OAUTH_TOKEN", () => withTempHome((dir) => {
+		assert.equal(hasClaudeCredentials({ CLAUDE_CONFIG_DIR: dir, CLAUDE_CODE_OAUTH_TOKEN: "tok" }, LINUX), true);
+	}));
+
+	it("is true for non-empty ANTHROPIC_API_KEY", () => withTempHome((dir) => {
+		assert.equal(hasClaudeCredentials({ CLAUDE_CONFIG_DIR: dir, ANTHROPIC_API_KEY: "sk-ant-x" }, LINUX), true);
+	}));
+
+	it("is true for non-empty ANTHROPIC_AUTH_TOKEN", () => withTempHome((dir) => {
+		assert.equal(hasClaudeCredentials({ CLAUDE_CONFIG_DIR: dir, ANTHROPIC_AUTH_TOKEN: "at-x" }, LINUX), true);
+	}));
+
+	it("is true for truthy CLAUDE_CODE_USE_BEDROCK (1/true), false otherwise", () => withTempHome((dir) => {
+		assert.equal(hasClaudeCredentials({ CLAUDE_CONFIG_DIR: dir, CLAUDE_CODE_USE_BEDROCK: "1" }, LINUX), true);
+		assert.equal(hasClaudeCredentials({ CLAUDE_CONFIG_DIR: dir, CLAUDE_CODE_USE_BEDROCK: "true" }, LINUX), true);
+		assert.equal(hasClaudeCredentials({ CLAUDE_CONFIG_DIR: dir, CLAUDE_CODE_USE_BEDROCK: "0" }, LINUX), false);
+		assert.equal(hasClaudeCredentials({ CLAUDE_CONFIG_DIR: dir, CLAUDE_CODE_USE_BEDROCK: "yes" }, LINUX), false);
+	}));
+
+	it("is true for truthy CLAUDE_CODE_USE_VERTEX (1/true)", () => withTempHome((dir) => {
+		assert.equal(hasClaudeCredentials({ CLAUDE_CONFIG_DIR: dir, CLAUDE_CODE_USE_VERTEX: "1" }, LINUX), true);
+		assert.equal(hasClaudeCredentials({ CLAUDE_CONFIG_DIR: dir, CLAUDE_CODE_USE_VERTEX: "false" }, LINUX), false);
+	}));
+
+	it("is true for truthy CLAUDE_CODE_USE_FOUNDRY / _ANTHROPIC_AWS / _MANTLE", () => withTempHome((dir) => {
+		for (const flag of ["CLAUDE_CODE_USE_FOUNDRY", "CLAUDE_CODE_USE_ANTHROPIC_AWS", "CLAUDE_CODE_USE_MANTLE"]) {
+			assert.equal(hasClaudeCredentials({ CLAUDE_CONFIG_DIR: dir, [flag]: "1" }, LINUX), true, `${flag}=1`);
+			assert.equal(hasClaudeCredentials({ CLAUDE_CONFIG_DIR: dir, [flag]: "true" }, LINUX), true, `${flag}=true`);
+			assert.equal(hasClaudeCredentials({ CLAUDE_CONFIG_DIR: dir, [flag]: "0" }, LINUX), false, `${flag}=0`);
+		}
+	}));
+
+	it("treats empty/whitespace token env vars as absent", () => withTempHome((dir) => {
+		assert.equal(hasClaudeCredentials({ CLAUDE_CONFIG_DIR: dir, CLAUDE_CODE_OAUTH_TOKEN: "", ANTHROPIC_API_KEY: "   ", ANTHROPIC_AUTH_TOKEN: "" }, LINUX), false);
+	}));
+
+	// settings.json apiKeyHelper ---------------------------------------------
+	it("is true when settings.json has a non-empty apiKeyHelper string", () => withTempHome((dir) => {
+		writeFileSync(join(dir, "settings.json"), JSON.stringify({ apiKeyHelper: "/usr/local/bin/get-key.sh" }));
+		assert.equal(hasClaudeCredentials({ CLAUDE_CONFIG_DIR: dir }, LINUX), true);
+	}));
+
+	it("is false when settings.json lacks apiKeyHelper or it is empty", () => withTempHome((dir) => {
+		writeFileSync(join(dir, "settings.json"), JSON.stringify({ apiKeyHelper: "", other: 1 }));
+		assert.equal(hasClaudeCredentials({ CLAUDE_CONFIG_DIR: dir }, LINUX), false);
+	}));
+
+	it("tolerates malformed settings.json as apiKeyHelper-absent", () => withTempHome((dir) => {
+		writeFileSync(join(dir, "settings.json"), "{ not valid json");
+		assert.equal(hasClaudeCredentials({ CLAUDE_CONFIG_DIR: dir }, LINUX), false);
+	}));
+
+	// Platform asymmetry -----------------------------------------------------
+	it("defaults to credentialed on darwin when no other signal is present", () => withTempHome((dir) => {
+		assert.equal(hasClaudeCredentials({ CLAUDE_CONFIG_DIR: dir }, "darwin"), true);
+	}));
+
+	it("does NOT default-credential on linux/win32 without a signal", () => withTempHome((dir) => {
+		assert.equal(hasClaudeCredentials({ CLAUDE_CONFIG_DIR: dir }, "linux"), false);
+		assert.equal(hasClaudeCredentials({ CLAUDE_CONFIG_DIR: dir }, "win32"), false);
+	}));
+});
+
+describe("decideRegistration", () => {
+	// Primacy gate ------------------------------------------------------------
+	it("non-primary instance → always noop, regardless of credentials/registration", () => {
+		assert.equal(decideRegistration({ credentialed: true, isPrimary: false, registered: false }), "noop");
+		assert.equal(decideRegistration({ credentialed: true, isPrimary: false, registered: true }), "noop");
+		assert.equal(decideRegistration({ credentialed: false, isPrimary: false, registered: true }), "noop");
+	});
+
+	// Primary transitions -----------------------------------------------------
+	it("primary + credentialed + not registered → register", () => {
+		assert.equal(decideRegistration({ credentialed: true, isPrimary: true, registered: false }), "register");
+	});
+
+	it("primary + credentialed + already registered → noop", () => {
+		assert.equal(decideRegistration({ credentialed: true, isPrimary: true, registered: true }), "noop");
+	});
+
+	it("primary + uncredentialed + registered → unregister (retract)", () => {
+		assert.equal(decideRegistration({ credentialed: false, isPrimary: true, registered: true }), "unregister");
+	});
+
+	it("primary + uncredentialed + not registered → unregister (DEFENSIVE, idempotent)", () => {
+		assert.equal(decideRegistration({ credentialed: false, isPrimary: true, registered: false }), "unregister");
+	});
+});
+
+describe("decideRegistration — logout → /reload sequence", () => {
+	it("walks register → noop → unregister → defensive-unregister across a reload", () => {
+		// 1. Fresh load, credentialed: claim + register.
+		assert.equal(decideRegistration({ credentialed: true, isPrimary: true, registered: false }), "register");
+		// 2. Later session_start, still credentialed and registered: nothing to do.
+		assert.equal(decideRegistration({ credentialed: true, isPrimary: true, registered: true }), "noop");
+		// 3. User logs out; session_start re-check retracts.
+		assert.equal(decideRegistration({ credentialed: false, isPrimary: true, registered: true }), "unregister");
+		// 4. /reload: shutdown released tokens; the reloaded primary instance is
+		//    uncredentialed and "not registered" from its own token's POV, yet the
+		//    ModelRegistry entry survives the reload — so it must STILL unregister
+		//    defensively to retract the stale registration.
+		assert.equal(decideRegistration({ credentialed: false, isPrimary: true, registered: false }), "unregister");
+		// 5. Subsequent session_start, still logged out: remains unregister (idempotent).
+		assert.equal(decideRegistration({ credentialed: false, isPrimary: true, registered: false }), "unregister");
+	});
+});

--- a/pi-extensions/pi-claude-bridge/tests/unit-connector-writes.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-connector-writes.mjs
@@ -1,0 +1,152 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+	connectorWriteModeFromEnv,
+	connectorWriteModeFor,
+	toolIsolationForQuery,
+	connectorQueryOptions,
+	connectorWriteDenyHook,
+	isConnectorWriteTool,
+	CONNECTOR_WRITE_TOOLS,
+	CLAUDE_AI_CONNECTOR_TOOL_PATTERNS,
+} from "../bundle/index.js";
+
+function withEnv(value, fn) {
+	const prev = process.env.CLAUDE_BRIDGE_CONNECTOR_WRITE;
+	if (value === undefined) delete process.env.CLAUDE_BRIDGE_CONNECTOR_WRITE;
+	else process.env.CLAUDE_BRIDGE_CONNECTOR_WRITE = value;
+	try { return fn(); } finally {
+		if (prev === undefined) delete process.env.CLAUDE_BRIDGE_CONNECTOR_WRITE;
+		else process.env.CLAUDE_BRIDGE_CONNECTOR_WRITE = prev;
+	}
+}
+
+// Drive the hook the way the SDK does: PreToolUse input + tool name.
+async function runHook(hook, toolName) {
+	return hook({ hook_event_name: "PreToolUse", tool_name: toolName, tool_input: {}, tool_use_id: "t1" }, "t1", { signal: new AbortController().signal });
+}
+function isDeny(out) {
+	return out?.hookSpecificOutput?.permissionDecision === "deny";
+}
+
+test("connectorWriteModeFromEnv parses deny/allow (case-insensitive), else undefined", () => {
+	assert.equal(withEnv("allow", connectorWriteModeFromEnv), "allow");
+	assert.equal(withEnv(" ALLOW ", connectorWriteModeFromEnv), "allow");
+	assert.equal(withEnv("deny", connectorWriteModeFromEnv), "deny");
+	assert.equal(withEnv("DENY", connectorWriteModeFromEnv), "deny");
+	for (const v of [undefined, "", "1", "true", "read-only", "nope"]) {
+		assert.equal(withEnv(v, connectorWriteModeFromEnv), undefined, String(v));
+	}
+});
+
+test("connectorWriteModeFor defaults to deny (no env, no config)", () => {
+	assert.equal(withEnv(undefined, () => connectorWriteModeFor(undefined)), "deny");
+	assert.equal(withEnv(undefined, () => connectorWriteModeFor({ provider: {} })), "deny");
+});
+
+test("connectorWriteModeFor: env allow enables writes", () => {
+	assert.equal(withEnv("allow", () => connectorWriteModeFor(undefined)), "allow");
+});
+
+test("connectorWriteModeFor: config allow enables writes", () => {
+	assert.equal(withEnv(undefined, () => connectorWriteModeFor({ provider: { connectorWriteMode: "allow" } })), "allow");
+});
+
+test("connectorWriteModeFor: env beats config both directions", () => {
+	assert.equal(withEnv("deny", () => connectorWriteModeFor({ provider: { connectorWriteMode: "allow" } })), "deny");
+	assert.equal(withEnv("allow", () => connectorWriteModeFor({ provider: { connectorWriteMode: "deny" } })), "allow");
+});
+
+test("connectorWriteModeFor FAILS CLOSED on unvalidated config values", () => {
+	// Legacy config files are merged raw; a truthy non-"allow" value must NOT
+	// silently open writes. Anything that isn't a valid "allow" resolves to
+	// "deny" (validated strings are trimmed + lowercased first).
+	for (const bad of ["Deny", "read-only", "on", "1", "allowed", true, 1, {}, null]) {
+		assert.equal(
+			withEnv(undefined, () => connectorWriteModeFor({ provider: { connectorWriteMode: bad } })),
+			"deny",
+			`config value ${JSON.stringify(bad)} must resolve to deny`,
+		);
+	}
+});
+
+test("isConnectorWriteTool classifies known + future write tools as writes (fail closed)", () => {
+	const writes = [
+		...CONNECTOR_WRITE_TOOLS,
+		// not-yet-known future writes must still classify as writes
+		"mcp__claude_ai_Gmail__send_message",
+		"mcp__claude_ai_Gmail__update_draft",
+		"mcp__claude_ai_Gmail__create_filter",
+		"mcp__claude_ai_Google_Drive__update_file",
+		"mcp__claude_ai_Google_Drive__delete_file",
+		"mcp__claude_ai_Google_Drive__move_file",
+		"mcp__claude_ai_Google_Calendar__add_attendee",
+	];
+	for (const name of writes) assert.equal(isConnectorWriteTool(name), true, name);
+});
+
+test("isConnectorWriteTool leaves connector reads + non-connector tools available", () => {
+	const reads = [
+		"mcp__claude_ai_Gmail__search_threads",
+		"mcp__claude_ai_Gmail__get_message",
+		"mcp__claude_ai_Gmail__list_labels",
+		"mcp__claude_ai_Google_Calendar__list_events",
+		"mcp__claude_ai_Google_Calendar__get_event",
+		"mcp__claude_ai_Google_Drive__search_files",
+		"mcp__claude_ai_Google_Drive__fetch_file",
+		"mcp__claude_ai_Google_Drive__download_file",
+		// discovery + Pi custom tools are never connector writes
+		"ToolSearch",
+		"ListMcpResources",
+		"mcp__custom-tools__anything",
+	];
+	for (const name of reads) assert.equal(isConnectorWriteTool(name), false, name);
+});
+
+test("PreToolUse hook denies connector writes (known + future) and allows reads", async () => {
+	const hook = connectorWriteDenyHook();
+	// future write: not a known read verb → deny
+	assert.ok(isDeny(await runHook(hook, "mcp__claude_ai_Gmail__send_message")), "send_message denied");
+	assert.ok(isDeny(await runHook(hook, "mcp__claude_ai_Gmail__create_draft")), "create_draft denied");
+	assert.ok(isDeny(await runHook(hook, "mcp__claude_ai_Google_Drive__delete_file")), "delete_file denied");
+	// reads pass through untouched
+	assert.equal(isDeny(await runHook(hook, "mcp__claude_ai_Gmail__search_threads")), false, "search_threads allowed");
+	assert.equal((await runHook(hook, "mcp__claude_ai_Gmail__search_threads")).continue, true, "search_threads continues");
+	// non-connector tools pass through
+	assert.equal((await runHook(hook, "ToolSearch")).continue, true, "ToolSearch continues");
+	assert.equal((await runHook(hook, "mcp__custom-tools__foo")).continue, true, "custom tool continues");
+});
+
+test("connectorQueryOptions(true) [deny] wires BOTH disallowedTools ids AND the PreToolUse hook", () => {
+	const opts = connectorQueryOptions(true); // default deny
+	for (const w of CONNECTOR_WRITE_TOOLS) assert.ok(opts.disallowedTools.includes(w), `deny id ${w}`);
+	for (const p of CLAUDE_AI_CONNECTOR_TOOL_PATTERNS) assert.ok(opts.allowedTools.includes(p), `allow ${p}`);
+	assert.ok(Array.isArray(opts.hooks?.PreToolUse), "PreToolUse hook registered");
+	assert.equal(opts.hooks.PreToolUse.length, 1);
+	assert.equal(typeof opts.hooks.PreToolUse[0].hooks[0], "function");
+});
+
+test("connectorQueryOptions(true, 'allow') exposes writes and registers NO hook", () => {
+	const opts = connectorQueryOptions(true, "allow");
+	for (const w of CONNECTOR_WRITE_TOOLS) assert.ok(!opts.disallowedTools.includes(w), `not denied ${w}`);
+	assert.equal(opts.hooks, undefined, "no write hook when writes allowed");
+	for (const p of CLAUDE_AI_CONNECTOR_TOOL_PATTERNS) assert.ok(opts.allowedTools.includes(p), `allow ${p}`);
+});
+
+test("connectorQueryOptions(false) [connectors off] is default isolation, no hook, no write denies", () => {
+	const deny = connectorQueryOptions(false, "deny");
+	const allow = connectorQueryOptions(false, "allow");
+	assert.deepEqual(deny, allow); // write mode ignored when connectors off
+	assert.deepEqual(deny.tools, []);
+	assert.equal(deny.hooks, undefined);
+	for (const w of CONNECTOR_WRITE_TOOLS) assert.ok(!deny.disallowedTools.includes(w), `no connector write in default isolation ${w}`);
+});
+
+test("toolIsolationForQuery still denies writes fail-closed (any non-allow mode)", () => {
+	for (const mode of ["deny", undefined, "read-only"]) {
+		const iso = toolIsolationForQuery(true, mode);
+		for (const w of CONNECTOR_WRITE_TOOLS) assert.ok(iso.disallowedTools.includes(w), `mode ${mode} denies ${w}`);
+	}
+	const allow = toolIsolationForQuery(true, "allow");
+	for (const w of CONNECTOR_WRITE_TOOLS) assert.ok(!allow.disallowedTools.includes(w), `allow exposes ${w}`);
+});

--- a/pi-extensions/pi-claude-bridge/tests/unit-connectors.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-connectors.mjs
@@ -1,0 +1,56 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+	connectorsEnabledFromEnv,
+	connectorsEnabledFor,
+	toolIsolationForQuery,
+	CLAUDE_AI_CONNECTOR_TOOL_PATTERNS,
+	CONNECTOR_DISCOVERY_TOOLS,
+	CLAUDE_BRIDGE_TOOL_ISOLATION,
+	DISALLOWED_BUILTIN_TOOLS,
+} from "../bundle/index.js";
+
+function withEnv(value, fn) {
+	const prev = process.env.CLAUDE_BRIDGE_ENABLE_CONNECTORS;
+	if (value === undefined) delete process.env.CLAUDE_BRIDGE_ENABLE_CONNECTORS;
+	else process.env.CLAUDE_BRIDGE_ENABLE_CONNECTORS = value;
+	try { return fn(); } finally {
+		if (prev === undefined) delete process.env.CLAUDE_BRIDGE_ENABLE_CONNECTORS;
+		else process.env.CLAUDE_BRIDGE_ENABLE_CONNECTORS = prev;
+	}
+}
+
+test("connectorsEnabledFromEnv parses truthy/falsey", () => {
+	for (const v of ["1", "true", "yes", "on", "TRUE", " On "]) assert.equal(withEnv(v, connectorsEnabledFromEnv), true, v);
+	for (const v of [undefined, "", "0", "false", "no", "off", "nope"]) assert.equal(withEnv(v, connectorsEnabledFromEnv), false, String(v));
+});
+
+test("connectorsEnabledFor: env OR config.provider.enableConnectors", () => {
+	assert.equal(withEnv(undefined, () => connectorsEnabledFor(undefined)), false);
+	assert.equal(withEnv(undefined, () => connectorsEnabledFor({ provider: {} })), false);
+	assert.equal(withEnv(undefined, () => connectorsEnabledFor({ provider: { enableConnectors: true } })), true);
+	assert.equal(withEnv("0", () => connectorsEnabledFor({ provider: { enableConnectors: true } })), true);
+	assert.equal(withEnv("1", () => connectorsEnabledFor({ provider: { enableConnectors: false } })), true);
+});
+
+test("toolIsolationForQuery(false) is the default isolation (connectors suppressed)", () => {
+	const iso = toolIsolationForQuery(false);
+	assert.deepEqual(iso, CLAUDE_BRIDGE_TOOL_ISOLATION);
+	assert.deepEqual(iso.tools, []); // empty --tools; connectors intentionally hidden
+});
+
+test("toolIsolationForQuery(true) exposes connectors: drops empty tools, allows patterns, un-blocks ToolSearch", () => {
+	const iso = toolIsolationForQuery(true);
+	// `tools: []` must be omitted (an empty --tools allowlist strips cloud connectors).
+	assert.equal("tools" in iso, false);
+	// Connector namespaces are auto-allowed.
+	for (const p of CLAUDE_AI_CONNECTOR_TOOL_PATTERNS) assert.ok(iso.allowedTools.includes(p), `allow ${p}`);
+	// Discovery tools (ToolSearch etc.) must NOT be disallowed — connectors are deferred behind them.
+	for (const d of CONNECTOR_DISCOVERY_TOOLS) assert.ok(!iso.disallowedTools.includes(d), `un-block ${d}`);
+	// File/shell built-ins stay blocked so Pi keeps tool ownership.
+	for (const b of ["Read", "Write", "Bash", "WebFetch"]) assert.ok(iso.disallowedTools.includes(b), `still block ${b}`);
+});
+
+test("discovery tools are a subset of the default disallow list", () => {
+	for (const d of CONNECTOR_DISCOVERY_TOOLS) assert.ok(DISALLOWED_BUILTIN_TOOLS.includes(d), `${d} is disallowed by default`);
+});

--- a/pi-extensions/pi-claude-bridge/tests/unit-isolation.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-isolation.mjs
@@ -1,0 +1,190 @@
+/**
+ * Tests for isolated mode (CLAUDE_BRIDGE_ISOLATED=1) and the piUserDir routing
+ * of paths that previously hardcoded ~/.pi/agent.
+ *
+ * Isolated mode is the contract for host apps that embed the bridge and own
+ * every config dir explicitly (PI_CODING_AGENT_DIR + CLAUDE_CONFIG_DIR): no
+ * cwd-ancestor discovery, no $PATH executable fallback, nothing read from the
+ * real home directory. Default (unset) behavior must be byte-identical to the
+ * pre-isolation bridge.
+ */
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { isolatedFromEnv, loadConfig, piUserDir, recordProjectTrust } from "../src/config.ts";
+import { resolveAgentsMdPath } from "../src/agents-md.ts";
+import { readAppendSystemPromptFiles } from "../src/prompt-context.ts";
+import { resolveClaudeExecutable } from "../src/index.ts";
+
+const ENV_KEYS = ["CLAUDE_BRIDGE_ISOLATED", "PI_CODING_AGENT_DIR", "PATH"];
+
+function withEnv(overrides, fn) {
+	const saved = new Map(ENV_KEYS.map((key) => [key, process.env[key]]));
+	try {
+		for (const [key, value] of Object.entries(overrides)) {
+			if (value === undefined) delete process.env[key];
+			else process.env[key] = value;
+		}
+		return fn();
+	} finally {
+		for (const [key, value] of saved) {
+			if (value === undefined) delete process.env[key];
+			else process.env[key] = value;
+		}
+	}
+}
+
+function withTempDir(fn) {
+	const dir = mkdtempSync(join(tmpdir(), "claude-bridge-isolation-"));
+	try {
+		return fn(dir);
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+}
+
+describe("isolatedFromEnv", () => {
+	it("is off when unset, empty, or falsy", () => {
+		for (const value of [undefined, "", "0", "false", "off", "no", "nonsense"]) {
+			withEnv({ CLAUDE_BRIDGE_ISOLATED: value }, () => {
+				assert.equal(isolatedFromEnv(), false, `value: ${value}`);
+			});
+		}
+	});
+
+	it("accepts the same truthy spellings as the connector flag", () => {
+		for (const value of ["1", "true", "yes", "on", " TRUE ", "Yes"]) {
+			withEnv({ CLAUDE_BRIDGE_ISOLATED: value }, () => {
+				assert.equal(isolatedFromEnv(), true, `value: ${value}`);
+			});
+		}
+	});
+});
+
+describe("piUserDir", () => {
+	it("defaults to ~/.pi/agent when PI_CODING_AGENT_DIR is unset (no-behavior-change proof)", () => {
+		withEnv({ PI_CODING_AGENT_DIR: undefined }, () => {
+			assert.equal(piUserDir(), resolve(join(homedir(), ".pi", "agent")));
+		});
+	});
+
+	it("resolves PI_CODING_AGENT_DIR when set", () => withTempDir((dir) => {
+		withEnv({ PI_CODING_AGENT_DIR: dir }, () => {
+			assert.equal(piUserDir(), resolve(dir));
+		});
+	}));
+});
+
+describe("resolveAgentsMdPath isolation", () => {
+	it("default mode still finds AGENTS.md in cwd parents", () => withTempDir((dir) => {
+		const cwdDir = join(dir, "cwd");
+		mkdirSync(cwdDir, { recursive: true });
+		writeFileSync(join(cwdDir, "AGENTS.md"), "# personal instructions\n");
+		const oldCwd = process.cwd();
+		try {
+			process.chdir(cwdDir);
+			withEnv({ CLAUDE_BRIDGE_ISOLATED: undefined }, () => {
+				assert.equal(resolveAgentsMdPath(), join(process.cwd(), "AGENTS.md"));
+			});
+		} finally {
+			process.chdir(oldCwd);
+		}
+	}));
+
+	it("isolated mode ignores cwd AGENTS.md and reads only piUserDir", () => withTempDir((dir) => {
+		const cwdDir = join(dir, "cwd");
+		const agentDir = join(dir, "agent");
+		mkdirSync(cwdDir, { recursive: true });
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(join(cwdDir, "AGENTS.md"), "# personal instructions\n");
+		const oldCwd = process.cwd();
+		try {
+			process.chdir(cwdDir);
+			withEnv({ CLAUDE_BRIDGE_ISOLATED: "1", PI_CODING_AGENT_DIR: agentDir }, () => {
+				// No app-owned AGENTS.md → nothing at all (cwd file must NOT leak).
+				assert.equal(resolveAgentsMdPath(), undefined);
+				// App-owned AGENTS.md wins once present.
+				writeFileSync(join(agentDir, "AGENTS.md"), "# app instructions\n");
+				assert.equal(resolveAgentsMdPath(), resolve(join(agentDir, "AGENTS.md")));
+			});
+		} finally {
+			process.chdir(oldCwd);
+		}
+	}));
+});
+
+describe("loadConfig isolation", () => {
+	it("isolated mode ignores trusted project config and reads only piUserDir", () => withTempDir((dir) => {
+		const agentDir = join(dir, "agent");
+		const project = join(dir, "project");
+		mkdirSync(agentDir, { recursive: true });
+		mkdirSync(join(project, ".pi"), { recursive: true });
+		writeFileSync(join(agentDir, "claude-bridge.json"), JSON.stringify({ provider: { fastMode: false } }));
+		writeFileSync(join(project, ".pi", "claude-bridge.json"), JSON.stringify({ provider: { fastMode: true, pathToClaudeCodeExecutable: "/opt/evil/claude" } }));
+		writeFileSync(join(project, ".pi", "settings.json"), JSON.stringify({
+			vstack: { extensionManager: { config: { "@vanillagreen/pi-claude-bridge": { pathToClaudeCodeExecutable: "/opt/evil/claude2" } } } },
+		}));
+		withEnv({ PI_CODING_AGENT_DIR: agentDir }, () => {
+			recordProjectTrust({ cwd: project, isProjectTrusted: () => true });
+			// Sanity: default mode DOES read the trusted project config.
+			withEnv({ CLAUDE_BRIDGE_ISOLATED: undefined }, () => {
+				const config = loadConfig(project);
+				assert.equal(config.provider?.fastMode, true);
+			});
+			// Isolated mode ignores both project files even though trust is recorded.
+			withEnv({ CLAUDE_BRIDGE_ISOLATED: "1" }, () => {
+				const config = loadConfig(project);
+				assert.equal(config.provider?.fastMode, false);
+				assert.equal(config.provider?.pathToClaudeCodeExecutable, undefined);
+			});
+		});
+	}));
+});
+
+describe("readAppendSystemPromptFiles isolation", () => {
+	it("isolated mode skips project .pi/APPEND_SYSTEM.md but keeps the piUserDir file", () => withTempDir((dir) => {
+		const agentDir = join(dir, "agent");
+		const project = join(dir, "project");
+		mkdirSync(agentDir, { recursive: true });
+		mkdirSync(join(project, ".pi"), { recursive: true });
+		writeFileSync(join(agentDir, "APPEND_SYSTEM.md"), "global extra\n");
+		writeFileSync(join(project, ".pi", "APPEND_SYSTEM.md"), "project extra\n");
+		withEnv({ PI_CODING_AGENT_DIR: agentDir }, () => {
+			withEnv({ CLAUDE_BRIDGE_ISOLATED: undefined }, () => {
+				const labels = readAppendSystemPromptFiles(project).map((file) => file.label);
+				assert.deepEqual(labels, ["global APPEND_SYSTEM.md", "project .pi/APPEND_SYSTEM.md"]);
+			});
+			withEnv({ CLAUDE_BRIDGE_ISOLATED: "1" }, () => {
+				const files = readAppendSystemPromptFiles(project);
+				assert.deepEqual(files.map((file) => file.label), ["global APPEND_SYSTEM.md"]);
+				assert.equal(files[0].content, "global extra");
+			});
+		});
+	}));
+});
+
+describe("resolveClaudeExecutable isolation", () => {
+	it("a configured path always wins", () => {
+		withEnv({ CLAUDE_BRIDGE_ISOLATED: "1" }, () => {
+			assert.equal(resolveClaudeExecutable("/opt/app/bin/claude"), "/opt/app/bin/claude");
+		});
+	});
+
+	it("default mode falls back to $PATH; isolated mode never does", () => withTempDir((dir) => {
+		const bin = join(dir, "bin");
+		mkdirSync(bin, { recursive: true });
+		const fakeClaude = join(bin, "claude");
+		writeFileSync(fakeClaude, "#!/bin/sh\nexit 0\n");
+		chmodSync(fakeClaude, 0o755);
+		withEnv({ PATH: bin }, () => {
+			withEnv({ CLAUDE_BRIDGE_ISOLATED: undefined }, () => {
+				assert.equal(resolveClaudeExecutable(undefined), fakeClaude);
+			});
+			withEnv({ CLAUDE_BRIDGE_ISOLATED: "1" }, () => {
+				assert.equal(resolveClaudeExecutable(undefined), undefined);
+			});
+		});
+	}));
+});


### PR DESCRIPTION
## What

Two things, per coordination with the vstack steward (2026-07-19):

1. **Mainlines the `poc-claude-bridge-connectors` branch** (4 commits, rebased onto current main): opt-in claude.ai cloud-MCP connectors (`CLAUDE_BRIDGE_ENABLE_CONNECTORS`, env OR config), connector write control (deny by default, `CLAUDE_BRIDGE_CONNECTOR_WRITE`), and availability honesty (provider registers only when Claude credentials exist). memsira has been vendoring the bridge from this branch's tip; mainlining ends the vendored-fork drift.
2. **Adds isolated mode** for embedding hosts (memsira), closing every homedir/cwd escape found in memsira's runtime-isolation audit.

## Isolation changes (top commit)

**Unconditional — provably no behavior change when `PI_CODING_AGENT_DIR` is unset** (`piUserDir()` falls back to exactly `~/.pi/agent`, covered by unit test):

- global `AGENTS.md`, `claude-bridge.log`, `claude-bridge-diag.log`, and the `cc-cli-logs/` dir now resolve under `piUserDir()` instead of hardcoded `homedir()/.pi/agent`. A host that sets `PI_CODING_AGENT_DIR` now owns all of them; nothing else changes for CLI users.

**New env flag `CLAUDE_BRIDGE_ISOLATED=1`** (same truthy parsing as `CLAUDE_BRIDGE_ENABLE_CONNECTORS`; default off, CLI behavior unchanged):

- no cwd-ancestor `AGENTS.md` walk — a user's personal or repo instructions cannot leak into a host app's model prompts;
- no project `.pi/settings.json` / `.pi/claude-bridge.json` reads, even for trusted projects;
- no project `.pi/APPEND_SYSTEM.md` discovery;
- no `$PATH` `claude`/`claude-code` fallback in `resolveClaudeExecutable` — the host either pins `pathToClaudeCodeExecutable` or gets the SDK's bundled default, never whatever binary is on the user's PATH (this was silently bypassing memsira's SHA-verified app-managed claude binary).

## Tests

`npm run test:unit` on the rebased tip: **212/212 pass** (main's pi-ai-compat tests + connector-branch tests + new `tests/unit-isolation.mjs`).

The isolation test matrix covers: flag parsing (unset/falsy/truthy spellings), `piUserDir()` default = `resolve(~/.pi/agent)` (the no-behavior-change proof), cwd-AGENTS.md leak blocked while app-owned AGENTS.md still read, trusted-project config ignored only in isolated mode (default mode contrast-tested), project APPEND_SYSTEM.md skipped with global kept, and PATH-fallback allowed by default / blocked when isolated with configured path always winning.

`tsc --noEmit` clean; bundle rebuilt (`npm run build`, deterministic — rebased commit's bundle byte-matches a fresh rebuild).

## Rebase notes

- `package.json` version kept at the branch's `1.7.0` (> main's `1.6.2`); steward owns the final bump + tag per coordination.
- `package-lock.json` version field synced.
- main's `pi-ai-compat` changes (`resolveGetModels`, Fable max thinking) merged cleanly with the connector work; the compat tests pass on the tip.

## Downstream

memsira will re-vendor `bundle/index.js` from this branch tip (pinned SHA) and set `CLAUDE_BRIDGE_ISOLATED=1` for every sidecar it spawns, then re-point to the canonical merged SHA after this lands.

https://claude.ai/code/session_01WfXkWyWJ2MCQdVa86nhTko