### PR TITLE
pi-claude-bridge: isolated mode also skips the recordProjectTrust cwd walk

### DIFF
--- a/pi-extensions/pi-claude-bridge/bundle/index.js
+++ b/pi-extensions/pi-claude-bridge/bundle/index.js
@@ -22694,6 +22694,7 @@ function projectTrustRegistry() {
 }
 function recordProjectTrust(ctx2) {
   if (!ctx2.cwd) return;
+  if (isolatedFromEnv()) return;
   let trusted = true;
   try {
     trusted = ctx2.isProjectTrusted?.() === true;

--- a/pi-extensions/pi-claude-bridge/package-lock.json
+++ b/pi-extensions/pi-claude-bridge/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vanillagreen/pi-claude-bridge",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vanillagreen/pi-claude-bridge",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.158",

--- a/pi-extensions/pi-claude-bridge/package.json
+++ b/pi-extensions/pi-claude-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vanillagreen/pi-claude-bridge",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Pi provider bridge that runs Claude Code through the Claude Agent SDK, with opt-in forwarding for Pi prompt context.",
   "type": "module",
   "keywords": [

--- a/pi-extensions/pi-claude-bridge/src/config.ts
+++ b/pi-extensions/pi-claude-bridge/src/config.ts
@@ -141,6 +141,10 @@ function projectTrustRegistry(): ProjectTrustRegistry {
 
 export function recordProjectTrust(ctx: { cwd?: string; isProjectTrusted?: () => boolean }): void {
 	if (!ctx.cwd) return;
+	// Isolated mode never reads project config, so recording trust would only
+	// run the cwd-ancestor `.pi/settings.json` walk (a filesystem probe outside
+	// the host-owned dirs) for a result nothing consumes. Skip it entirely.
+	if (isolatedFromEnv()) return;
 	let trusted = true;
 	try {
 		trusted = ctx.isProjectTrusted?.() === true;

--- a/pi-extensions/pi-claude-bridge/tests/unit-isolation.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-isolation.mjs
@@ -143,6 +143,28 @@ describe("loadConfig isolation", () => {
 	}));
 });
 
+describe("recordProjectTrust isolation", () => {
+	it("isolated mode records nothing (no cwd walk, no trust entry)", () => withTempDir((dir) => {
+		const agentDir = join(dir, "agent");
+		const project = join(dir, "project");
+		mkdirSync(agentDir, { recursive: true });
+		mkdirSync(join(project, ".pi"), { recursive: true });
+		writeFileSync(join(project, ".pi", "settings.json"), "{}");
+		writeFileSync(join(project, ".pi", "claude-bridge.json"), JSON.stringify({ provider: { fastMode: true } }));
+		withEnv({ PI_CODING_AGENT_DIR: agentDir }, () => {
+			// Trust recorded while isolated must be a no-op: a later default-mode
+			// loadConfig still treats the project as untrusted.
+			withEnv({ CLAUDE_BRIDGE_ISOLATED: "1" }, () => {
+				recordProjectTrust({ cwd: project, isProjectTrusted: () => true });
+			});
+			withEnv({ CLAUDE_BRIDGE_ISOLATED: undefined }, () => {
+				const config = loadConfig(project);
+				assert.equal(config.provider?.fastMode, undefined);
+			});
+		});
+	}));
+});
+
 describe("readAppendSystemPromptFiles isolation", () => {
 	it("isolated mode skips project .pi/APPEND_SYSTEM.md but keeps the piUserDir file", () => withTempDir((dir) => {
 		const agentDir = join(dir, "agent");


### PR DESCRIPTION
Follow-up to #744, caught by memsira's live strace verification: with `CLAUDE_BRIDGE_ISOLATED=1`, `recordProjectTrust` (session_start) still ran `projectSettingsPath`'s cwd-ancestor `.pi/settings.json` walk — a filesystem probe outside the host-owned dirs (e.g. `access(~/.pi/settings.json)`) whose result nothing consumes in isolated mode (project config reads are already disabled). Early-return instead.

- One-line guard + regression test (trust recorded while isolated is a no-op observable via a later default-mode `loadConfig`).
- Suite: 213/213 green, tsc clean, bundle rebuilt.
- Default (non-isolated) behavior unchanged.

memsira will re-vendor from this tip and re-point to the canonical SHA after merge, as before.

https://claude.ai/code/session_01WfXkWyWJ2MCQdVa86nhTko