### PR TITLE
docs(linear,project-management): completed-blocker relations are satisfied history, never stale metadata

### DIFF
--- a/skills/linear/SKILL.md
+++ b/skills/linear/SKILL.md
@@ -132,6 +132,8 @@ sortOrder → sort_order  # Manual sort position
 
 Blocking relations must connect peers of one bundle: same direct parent, or both top-level (and same project). An issue cannot block its own ancestor or descendant — the parent-child hierarchy already encodes that dependency; use `--related` for traceability. Rejections for cross-subtree pairs prescribe the valid pair at the level where the subtrees separate. Before either acceptance or remediation, the guard proves each parent chain reaches an explicit null root through well-formed edges with unique IDs/identifiers. It also requires an explicit null or well-formed project value; incomplete, cyclic, or malformed hierarchy data is rejected before mutation.
 
+A blocking relation pointing at a Done or Canceled issue is **satisfied history, not stale metadata** — Linear itself already treats the dependent issue as unblocked. The relation stays for provenance and traceability; never remove or "fix" it, and audits must never classify it as stale. The only legitimate audit output for a completed-blocker relation is a scheduling signal ("gates cleared, ready to schedule"). Cautionary precedent: an audit agent once emitted a "STALE blocked_by METADATA" section listing issues whose blockers were Done, framing valid history as defects and inviting destructive cleanup — the issues were simply ready to schedule.
+
 ## Common Pitfalls
 
 | Option | Accepts | On failure |

--- a/skills/linear/tests/completed-blocker-relations-doc.test.sh
+++ b/skills/linear/tests/completed-blocker-relations-doc.test.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Doc-contract test for the completed-blocker relation rule (#745).
+# SKILL.md's "Blocked Label vs Issue Relations" section must state that a
+# blocking relation pointing at a Done/Canceled issue is satisfied history
+# (Linear already treats the issue as unblocked), that the relation stays for
+# provenance, that audits must never classify it as stale metadata or remove
+# it, and that the only legitimate audit output is a scheduling signal.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PASS=0
+FAIL=0
+
+assert_file_contains() {
+  local file="$1" pattern="$2" name="$3"
+  if grep -Fq -- "$pattern" "$file"; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        missing pattern: %s\n        file: %s\n' "$name" "$pattern" "$file"
+  fi
+}
+
+echo "=== linear SKILL.md completed-blocker relation contract ==="
+
+skill_md="$SKILL_DIR/SKILL.md"
+
+assert_file_contains "$skill_md" 'satisfied history, not stale metadata' "completed blockers framed as satisfied history, not stale metadata"
+assert_file_contains "$skill_md" 'Linear itself already treats the dependent issue as unblocked' "Linear auto-unblock semantics stated"
+assert_file_contains "$skill_md" 'never remove or "fix" it, and audits must never classify it as stale' "removal and stale classification forbidden"
+assert_file_contains "$skill_md" 'gates cleared, ready to schedule' "scheduling signal is the only legitimate audit output"
+assert_file_contains "$skill_md" 'STALE blocked_by METADATA' "observed failure mode kept as cautionary rationale"
+
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/skills/project-management/references/dependencies.md
+++ b/skills/project-management/references/dependencies.md
@@ -75,6 +75,15 @@ See issue tracker CLI skill for commands (`issues add-relation`, `issues list-re
 | `related` | Informational link, no blocking |
 | `duplicate` | Issues are duplicates (for merging) |
 
+### Completed Blockers Are Satisfied History
+
+A blocking relation pointing at a **Done or Canceled** issue is auto-satisfied — the tracker itself treats the dependent issue as unblocked the moment the blocker completes. The relation is satisfied history, not stale metadata:
+
+- **Keep the relation.** It stays for provenance and traceability of why work was sequenced. Never remove or "fix" a relation because its blocker is Done/Canceled.
+- **Audits must never classify completed-blocker relations as stale metadata.** The only legitimate audit output for them is a scheduling signal: "gates cleared, ready to schedule."
+
+**Why**: during a backlog staleness audit, an audit agent produced a "STALE blocked_by METADATA" section listing issues whose blockers were Done, framing the relations themselves as defects needing cleanup. That framing invites destructive removal of valid history; the correct read was that those issues were simply ready to schedule.
+
 ### Quick Reference
 
 ```bash
@@ -130,6 +139,6 @@ When pulling issues:
 
 ### Resolving a Blocker
 
-1. Complete the blocking issue (relation auto-clears)
+1. Complete the blocking issue (the block auto-clears; the relation itself stays as satisfied history — do not remove it)
 2. **If external**: Remove `blocked` label + add resolution comment
 3. Move blocked issue back to active state

--- a/skills/project-management/schemas/audit-output.md
+++ b/skills/project-management/schemas/audit-output.md
@@ -42,6 +42,9 @@ Located at `findings.*`:
 | `wrong_project[]` | `issue`, `title`, `from`, `to`, `to_id`, `reason` |
 | `hierarchy[]` | `action`(`make_parent`\|`make_child`\|`bundle`\|`update_parent_desc`), `issue`\|`issues[]`, `parent`\|`children[]`\|`new_parent_title`, `reason` |
 | `combine[]` | `target`, `absorb[]`, `reason` |
+| `ready_to_schedule[]` | `id`, `title`, `cleared_blockers[]`, `reason` |
+
+**`ready_to_schedule[]`**: Scheduling signal only — an active issue whose blockers are all Done/Cancelled ("gates cleared, ready to schedule"). Completed-blocker relations are satisfied history, never stale metadata: they must not appear in `remove_relations[]` or under any stale-metadata framing.
 
 **`obsolete[].evidence`**: `{completed_by[], files_verified[], deliverables_checked[]}` — OR for decision-eliminated: `{decision_eliminated: true, decision_ref: "[REF]", eliminated_pattern: "..."}`
 
@@ -67,6 +70,7 @@ Located at `findings.*`:
     "wrong_project": 0,
     "combinations": 0,
     "relation_violations": 0,
+    "ready_to_schedule": 0,
     "architecture_gaps": {"critical": 0, "required": 0, "research": 0},
     "project_recommendations": {"new_projects": 0, "reopen_projects": 0}
   },
@@ -82,6 +86,7 @@ Located at `findings.*`:
     "wrong_project": [],
     "hierarchy": [],
     "combine": [],
+    "ready_to_schedule": [],
     "architecture_gaps": [],
     "project_recommendations": []
   },

--- a/skills/project-management/tests/completed-blocker-contract.test.sh
+++ b/skills/project-management/tests/completed-blocker-contract.test.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Regression test for the completed-blocker relation rule (#745).
+# A blocking relation pointing at a Done/Cancelled issue is satisfied history —
+# the tracker already treats the issue as unblocked. These workflows are
+# markdown contracts, so this test statically verifies the rule end-to-end:
+# dependencies.md documents the semantics, tpm-audit's relation checks forbid
+# stale-metadata framing and emit a ready-to-schedule signal instead, and the
+# output schema carries the ready_to_schedule[] finding array.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+require_pattern() {
+  local file="$1" pattern="$2" desc="$3"
+  if ! grep -Eq -- "$pattern" "$file"; then
+    fail "$desc missing in ${file#$SKILL_DIR/}"
+  fi
+}
+
+# --- Reference: references/dependencies.md documents the semantics ---
+
+deps="$SKILL_DIR/references/dependencies.md"
+[[ -f "$deps" ]] || fail "reference not found: references/dependencies.md"
+require_pattern "$deps" 'Completed Blockers Are Satisfied History' 'completed-blockers section'
+require_pattern "$deps" 'auto-satisfied' 'auto-satisfied semantics'
+require_pattern "$deps" 'satisfied history, not stale metadata' 'satisfied-history (non-stale) framing'
+require_pattern "$deps" 'Never remove or "fix" a relation because its blocker is Done/Canceled' 'removal prohibition'
+require_pattern "$deps" 'must never classify completed-blocker relations as stale metadata' 'stale-classification prohibition'
+require_pattern "$deps" 'gates cleared, ready to schedule' 'scheduling signal as only legitimate output'
+require_pattern "$deps" 'STALE blocked_by METADATA' 'observed failure mode as cautionary rationale'
+require_pattern "$deps" 'the relation itself stays as satisfied history' 'resolving-a-blocker checklist keeps the relation'
+
+# --- Workflow: tpm-audit § 4.4 relation checks enforce the rule ---
+
+tpm_audit="$SKILL_DIR/workflows/tpm-audit.md"
+require_pattern "$tpm_audit" 'Completed-blocker relations are auto-satisfied, never stale' 'completed-blocker rule in § 4.4'
+require_pattern "$tpm_audit" 'Do NOT add such relations to `remove_relations\[\]`' 'remove_relations prohibition'
+require_pattern "$tpm_audit" 'do NOT report them under any stale-metadata heading' 'stale-metadata heading prohibition'
+require_pattern "$tpm_audit" 'STALE blocked_by METADATA' 'observed failure mode as cautionary rationale'
+require_pattern "$tpm_audit" 'scheduling signal: add it to `ready_to_schedule\[\]`' 'ready-to-schedule signal instruction'
+require_pattern "$tpm_audit" 'Completed-blocker relations preserved \(surfaced only as ready-to-schedule signals, never flagged as stale or removed\)' 'pre-output verification checklist item'
+
+# --- Schema: audit-output.md carries the ready_to_schedule finding array ---
+
+schema="$SKILL_DIR/schemas/audit-output.md"
+require_pattern "$schema" '`ready_to_schedule\[\]` \| `id`, `title`, `cleared_blockers\[\]`, `reason`' 'ready_to_schedule finding array fields'
+require_pattern "$schema" 'Scheduling signal only' 'ready_to_schedule signal-only semantics'
+require_pattern "$schema" 'never stale metadata' 'schema-level non-stale framing'
+require_pattern "$schema" '"ready_to_schedule": \[\]' 'ready_to_schedule in findings template'
+require_pattern "$schema" '"ready_to_schedule": 0' 'ready_to_schedule in summary counts'
+
+echo "all pass"

--- a/skills/project-management/workflows/tpm-audit.md
+++ b/skills/project-management/workflows/tpm-audit.md
@@ -313,6 +313,8 @@ For input issues with existing relations, add to candidate pairs for verificatio
 
 **Done issue relations are valid historical records.** Flag removal only for wrong dependencies (no creates-consumes), never because source is Done.
 
+**Completed-blocker relations are auto-satisfied, never stale.** A `blocked_by` relation whose blocker is Done/Cancelled is satisfied history — the tracker already treats the issue as unblocked, and the relation stays for provenance/traceability. Do NOT add such relations to `remove_relations[]`, and do NOT report them under any stale-metadata heading (a prior audit emitted a "STALE blocked_by METADATA" section listing issues whose blockers were Done — that framing is wrong and invites destructive cleanup). The only legitimate finding for an active issue whose blockers have all completed is a scheduling signal: add it to `ready_to_schedule[]` (PROJECT mode) or note "gates cleared, ready to schedule" in the issue's `reason` (ISSUE mode).
+
 ### 4.5 Scan for Relation Violations
 
 **Iterate** ALL `blocks`/`blocked_by` relations on input issues (and their children if bundled).
@@ -785,6 +787,7 @@ For each input issue, assign action based on analysis:
 
 - [ ] 1.7/2.1: Verification evidence collected and a distinct `VERIFICATION_CONTEXTS[ISSUE_KEY]` entry resolved for every input issue/contract; no linked PR, branch, or scope reused across issues; docs-only handled explicitly
 - [ ] 2: Contract extracted (target, creates, consumes, problem)
+- [ ] 4.4: Completed-blocker relations preserved (surfaced only as ready-to-schedule signals, never flagged as stale or removed)
 - [ ] 4.5: Relation violations scanned (cross-project, cross-bundle, child→standalone)
 - [ ] 5.1-5.2: Relations analyzed against the resolved code or documentation paths
 - [ ] 5.3: Priority alignment checked (skip if proposed without priority)


### PR DESCRIPTION
Closes #745 (maintainer-requested).

Encodes the rule at all three sites: a `blocked_by` relation whose blocker is Done/Cancelled is satisfied history — the tracker already treats the issue as unblocked, the relation stays for provenance — and audits must never classify it as stale metadata or remove it; the only legitimate finding is a scheduling signal.

- linear SKILL.md § Blocked Label vs Issue Relations: the rule + the observed 'STALE blocked_by METADATA' failure mode as rationale.
- project-management references/dependencies.md: new 'Completed Blockers Are Satisfied History' subsection; 'Resolving a Blocker' clarified (block auto-clears, relation stays).
- tpm-audit § 4.4: binding prohibition (never in `remove_relations[]`/stale headings) + § 11.1 checklist item; new `ready_to_schedule[]` finding array in the audit-output schema (signal-only semantics, wired into template + summary counts) so the instruction references a real field.

Tests: new doc-contract tests in each skill's own convention (linear 5/5; project-management 19 assertions, all pass); full linear 23/23 + project-management 8/8 suites green.

https://claude.ai/code/session_017x6AyjyPypo3vbVyjB4Nhq