### PR TITLE
fix(orch): approval-wait treats HTTP 429 rate limits as transient

### DIFF
--- a/skills/orch/scripts/approval-wait
+++ b/skills/orch/scripts/approval-wait
@@ -44,7 +44,8 @@
 # comments instead of idling out the full timeout.
 #
 # Transient GitHub API failures (vstack#748): inside the poll loop, an HTTP
-# 5xx, timeout, or transport error from any GitHub query is RETRYABLE — the
+# 5xx, HTTP 429 rate limit, timeout, or transport error from any GitHub
+# query is RETRYABLE — the
 # poller logs it to stderr, doubles the poll interval for the next attempt
 # (capped at 8x), and keeps waiting inside the existing max_wait budget. A
 # fully successful poll resets the backoff. Only when the budget expires on
@@ -461,7 +462,8 @@ count_unresolved_threads() {
 
 # Classify the failed gh call whose stderr sits in GH_ERR_FILE (vstack#748).
 # Transient — retryable inside the wait budget — means the service or
-# transport hiccuped: HTTP 5xx, timeouts, connection/DNS/TLS failures, or a
+# transport hiccuped: HTTP 5xx, HTTP 429 rate limits, timeouts,
+# connection/DNS/TLS failures, or a
 # timeout(1)-style exit 124. Anything else (HTTP 404, 401/403, malformed
 # arguments, unparseable success bodies) is terminal, exactly as before.
 gh_failure_is_transient() {
@@ -474,6 +476,7 @@ gh_failure_is_transient() {
     *"connection refused"*|*"connection reset"*|*"network is unreachable"*) return 0 ;;
     *"no such host"*|*"could not resolve"*|*[Tt]"emporary failure"*) return 0 ;;
     *"unexpected EOF"*|*"TLS handshake"*) return 0 ;;
+    *"HTTP 429"*|*"rate limit"*|*"abuse detection"*) return 0 ;;
   esac
   return 1
 }

--- a/skills/orch/tests/approval_wait.sh
+++ b/skills/orch/tests/approval_wait.sh
@@ -201,6 +201,19 @@ case "${1:-}" in
         fi
         mode="commented_at_head"
       fi
+      if [[ "$mode" == "flaky_429" ]]; then
+        count=0
+        if [[ -f "${STUB_REVIEWS_COUNT_FILE:?}" ]]; then
+          count="$(cat "$STUB_REVIEWS_COUNT_FILE")"
+        fi
+        count=$((count + 1))
+        printf '%s' "$count" > "$STUB_REVIEWS_COUNT_FILE"
+        if [[ "$count" -le 2 ]]; then
+          echo "HTTP 429: You have exceeded a secondary rate limit. Please wait a few minutes before you try again." >&2
+          exit 1
+        fi
+        mode="commented_at_head"
+      fi
       if [[ "$mode" == "http_503" ]]; then
         echo "HTTP 503: No server is currently available to service your request." >&2
         exit 1
@@ -1090,6 +1103,18 @@ assert_eq "$(json_field "$output" '.status')" "reviewed" "transient1: status rev
 assert_eq "$(json_field "$output" '.transient_api_errors')" "2" "transient1: transient_api_errors counts the absorbed 503s" "$stderr"
 assert_eq "$(cat "$count_file")" "3" "transient1: reviews endpoint retried until it recovered" "$stderr"
 assert_contains "$(cat "$stderr")" "transient GitHub error" "transient1: each transient failure is logged to stderr"
+
+# Transient 1b (vstack#752): HTTP 429 rate limits are transient too — twice
+# then success recovers exactly like a 5xx.
+stderr="$TMP_ROOT/transient1b.err"
+count_file="$TMP_ROOT/transient1b-count"
+set +e
+output=$(run_review_json STUB_REVIEWS_MODE=flaky_429 STUB_REVIEWS_COUNT_FILE="$count_file" 2>"$stderr")
+rc=$?
+set -e
+assert_eq "$rc" "0" "transient1b: 429 twice then success exits 0" "$stderr"
+assert_eq "$(json_field "$output" '.status')" "reviewed" "transient1b: status reviewed despite rate limits" "$stderr"
+assert_eq "$(json_field "$output" '.transient_api_errors')" "2" "transient1b: transient_api_errors counts the absorbed 429s" "$stderr"
 
 # Transient 2: a persistent 503 becomes terminal only when the wait budget
 # expires — the pre-#748 error message is preserved, plus the count.


### PR DESCRIPTION
Closes #752 (review-bot finding on the #750 propagation, hyprtrade#352).

`gh_failure_is_transient` matched HTTP 5xx, timeouts, and transport errors but let `HTTP 429` (primary/secondary rate limit) fall through to terminal — the canonical retryable case for a waiter that already has bounded backoff. `HTTP 429`, "rate limit", and "abuse detection" stderr shapes now classify transient; header docs updated; new `flaky_429` stub mode + test (429×2 → success with `transient_api_errors: 2`). approval_wait.sh 182/182; full orch suite green.

https://claude.ai/code/session_017x6AyjyPypo3vbVyjB4Nhq