### PR TITLE
fix(#611): refresh the /agents pop-up against live lifecycle state

### DIFF
--- a/pi-extensions/pi-agents-tmux/extensions/subagent/browser.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/browser.ts
@@ -10,7 +10,7 @@ import { ensurePersistentPane, paneExists, stopPersistentPane, tmux } from "./pa
 import { readPaneRegistry, readTaskRegistry } from "./tasks.js";
 import { loadAgentPaneStatuses } from "./browser/shared.js";
 import { animateSpinnersEnabled } from "./settings.js";
-import { sortedMonitorRecords, taskNumberById } from "./task-records.js";
+import { liveDashboardSignature, mergeLiveDashboardItems, sortedMonitorRecords, taskNumberById } from "./task-records.js";
 import {
 	AGENTS_BROWSER_MAX_HEIGHT,
 	AGENTS_BROWSER_WIDTH,
@@ -42,6 +42,7 @@ import {
 	clampMonitorUiToRows,
 	monitorTreeRows,
 	renderMonitorTree,
+	restoreMonitorSelectionByKey,
 	selectableMonitorRows,
 	selectedMonitorRow,
 	type MonitorSectionKind,
@@ -80,6 +81,7 @@ export {
 	monitorTaskRowLabel,
 	monitorTreeRows,
 	renderMonitorTree,
+	restoreMonitorSelectionByKey,
 	type MonitorSectionKind,
 	type MonitorSessionGroup,
 	type MonitorTreeRow,
@@ -102,7 +104,7 @@ export {
 	dashboardDisplayLabels,
 } from "./browser/dashboard-integration.js";
 export { openTraceViewer } from "./browser/trace-viewer.js";
-export { loadTaskRegistrySync, taskNumberById } from "./task-records.js";
+export { liveDashboardSignature, loadTaskRegistrySync, mergeLiveDashboardItems, taskNumberById } from "./task-records.js";
 
 function renderMonitorTabBody(
 	records: PaneTaskRecord[],
@@ -197,10 +199,19 @@ function createAgentsBrowserComponent(
 	let closed = false;
 	let resizeTimer: ReturnType<typeof setTimeout> | undefined;
 	const spinnersAnimated = () => animateSpinnersEnabled(cwd);
-	const animationTimer = getActiveItems().some((item) => isDashboardAnimatingStatus(item.status)) ? setInterval(() => {
-		if (!closed && spinnersAnimated() && getActiveItems().some((item) => isDashboardAnimatingStatus(item.status))) requestRender();
-	}, 120) : undefined;
-	animationTimer?.unref?.();
+	// Single tick for both concerns: pick up live lifecycle changes (a new agent, a
+	// finished one) and animate spinners. It renders only when something moved, so
+	// an idle pop-up stays still. Always armed — agents can start after the pop-up
+	// opened, when nothing was animating yet.
+	const liveTimer = setInterval(() => {
+		if (closed) return;
+		if (refreshMonitorView()) {
+			requestRender();
+			return;
+		}
+		if (spinnersAnimated() && getActiveItems().some((item) => isDashboardAnimatingStatus(item.status))) requestRender();
+	}, 120);
+	liveTimer.unref?.();
 	const scheduleResizeRender = () => {
 		if (closed) return;
 		requestRender();
@@ -215,7 +226,7 @@ function createAgentsBrowserComponent(
 		closed = true;
 		if (resizeTimer) clearTimeout(resizeTimer);
 		resizeTimer = undefined;
-		if (animationTimer) clearInterval(animationTimer);
+		clearInterval(liveTimer);
 		process.off("SIGWINCH", scheduleResizeRender);
 	};
 	const finish = (action: AgentBrowserAction) => {
@@ -234,20 +245,45 @@ function createAgentsBrowserComponent(
 		if (ui.selected >= ui.scroll + layout.listRows) ui.scroll = ui.selected - layout.listRows + 1;
 		ui.scroll = Math.max(0, Math.min(ui.scroll, Math.max(0, list.length - layout.listRows)));
 	};
-	const monitorRecords = sortedMonitorRecords(taskRegistry);
-	const monitorGroups = buildMonitorSessionGroups(monitorRecords);
 	const monitorCollapsedSections = new Set<MonitorSectionKind>();
 	const monitorCollapsedSessions = new Set<string>();
-	const currentMonitorRows = () => monitorTreeRows(monitorGroups, monitorCollapsedSections, monitorCollapsedSessions);
 	const monitorCache = new Map<string, MonitorDetailEntry>();
-	const monitorTaskNumbers = taskNumberById(monitorRecords);
+	// `taskRegistry` is the disk snapshot taken when the pop-up opened. The live
+	// dashboard items are overlaid on it so an open pop-up tracks lifecycle changes
+	// instead of the frozen snapshot, and agrees with the statusline/mini-dashboard.
+	const buildMonitorView = (items: SubagentDashboardItem[]) => {
+		const records = sortedMonitorRecords(mergeLiveDashboardItems(taskRegistry, items));
+		return { groups: buildMonitorSessionGroups(records), records, taskNumbers: taskNumberById(records) };
+	};
+	let monitorSignature = liveDashboardSignature(getActiveItems());
+	let monitorView = buildMonitorView(getActiveItems());
+	const currentMonitorRows = () => monitorTreeRows(monitorView.groups, monitorCollapsedSections, monitorCollapsedSessions);
+	// Rebuilds only when live lifecycle state actually moved, so idle ticks neither
+	// re-sort nor repaint. Selection is restored by row key, not index, so rows
+	// appearing or moving above the cursor do not drag the highlight with them.
+	const refreshMonitorView = (): boolean => {
+		const items = getActiveItems();
+		const signature = liveDashboardSignature(items);
+		if (signature === monitorSignature) return false;
+		monitorSignature = signature;
+		const previousKey = selectedMonitorRow(currentMonitorRows(), ui)?.key;
+		const previousStatuses = new Map(monitorView.records.map((record) => [record.taskId, record.status]));
+		monitorView = buildMonitorView(items);
+		// Detail panes cache per task; drop the ones whose lifecycle moved so the
+		// inspector reloads instead of serving a stale trace.
+		for (const record of monitorView.records) {
+			if (previousStatuses.has(record.taskId) && previousStatuses.get(record.taskId) !== record.status) monitorCache.delete(record.taskId);
+		}
+		restoreMonitorSelectionByKey(ui, currentMonitorRows(), previousKey);
+		return true;
+	};
 	const loadMonitorRecord = (record: PaneTaskRecord | undefined, group?: MonitorSessionGroup) => {
 		if (!record) return;
 		const cacheKey = record.taskId;
 		const entry = monitorCache.get(cacheKey);
 		if (entry?.items || entry?.loading || entry?.error) return;
 		monitorCache.set(cacheKey, { loading: true });
-		void traceViewerItems(record, monitorTaskNumbers.get(record.taskId), discovery, group?.sessionNumber).then((items) => {
+		void traceViewerItems(record, monitorView.taskNumbers.get(record.taskId), discovery, group?.sessionNumber).then((items) => {
 			monitorCache.set(cacheKey, { items });
 			requestRender();
 		}).catch((error) => {
@@ -477,11 +513,12 @@ function createAgentsBrowserComponent(
 		const bodyWidth = agentFrameContentWidth(safeWidth);
 		const tabLine = renderAgentBrowserTabs(ui.tab, bodyWidth, theme);
 		if (ui.tab === "monitor") {
+			refreshMonitorView();
 			clampMonitor();
 			loadMonitorSelection();
 			const rows = currentMonitorRows();
 			const footer = monitorFooterHint(theme);
-			const lines = [tabLine, "", ...renderMonitorTabBody(monitorRecords, rows, monitorCollapsedSessions, monitorCache, discovery, ui, bodyWidth, theme, layout, spinnersAnimated()), agentDivider(bodyWidth, theme), ...wrapTextWithAnsi(footer, bodyWidth)];
+			const lines = [tabLine, "", ...renderMonitorTabBody(monitorView.records, rows, monitorCollapsedSessions, monitorCache, discovery, ui, bodyWidth, theme, layout, spinnersAnimated()), agentDivider(bodyWidth, theme), ...wrapTextWithAnsi(footer, bodyWidth)];
 			return agentFrame(lines, safeWidth, theme, layout.innerRows, "Monitor");
 		}
 		clamp();

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/browser/monitor-tree.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/browser/monitor-tree.ts
@@ -191,6 +191,15 @@ function selectedMonitorRowIndex(rows: MonitorTreeRow[], ui: AgentBrowserUiState
 	return selected ? rows.findIndex((row) => row.key === selected.key) : -1;
 }
 
+// Rows are rebuilt whenever live lifecycle state moves. Re-anchoring the cursor to
+// the row key it was on keeps the highlight on the same task when rows appear,
+// disappear, or reorder above it; index-based selection would drift instead.
+export function restoreMonitorSelectionByKey(ui: AgentBrowserUiState, rows: MonitorTreeRow[], key: string | undefined): void {
+	if (key === undefined) return;
+	const index = selectableMonitorRows(rows).findIndex((row) => row.key === key);
+	if (index >= 0) ui.monitorSelected = index;
+}
+
 export function clampMonitorUiToRows(ui: AgentBrowserUiState, rows: MonitorTreeRow[], listRows: number): void {
 	const selectable = selectableMonitorRows(rows);
 	ui.monitorSelected = Math.max(0, Math.min(ui.monitorSelected, Math.max(0, selectable.length - 1)));

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/task-records.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/task-records.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs";
 import { taskRegistryPath } from "./paths.js";
-import type { PaneTaskRecord, PaneTaskRegistry, PaneTaskStatus, UsageStats } from "./types.js";
+import type { PaneTaskRecord, PaneTaskRegistry, PaneTaskStatus, SubagentDashboardItem, SubagentDashboardStatus, UsageStats } from "./types.js";
 
 export type MonitorSessionType = "pane" | "bg-lane" | "bg-one-shot";
 
@@ -59,6 +59,55 @@ export function sortedMonitorRecords(registry: PaneTaskRegistry): PaneTaskRecord
 	return Object.values(registry)
 		.filter((record) => record.taskId && record.agent)
 		.sort((a, b) => recordTimestampLocal(b) - recordTimestampLocal(a));
+}
+
+export function monitorStatusFromDashboard(status: SubagentDashboardStatus): PaneTaskStatus {
+	// `waiting` only exists on the dashboard; the registry models that as `queued`.
+	return status === "waiting" ? "queued" : status;
+}
+
+// One live lifecycle fingerprint for the whole dashboard item set. Cheap enough to
+// compare on a UI tick, and changes exactly when a monitor row would need to move.
+export function liveDashboardSignature(items: SubagentDashboardItem[]): string {
+	return items
+		.map((item) => `${item.taskId}|${item.status}|${item.updatedAt ?? ""}|${item.completedAt ?? ""}`)
+		.sort()
+		.join("|");
+}
+
+// `tasks.json` is a disk snapshot; `dashboardState.items` is the authoritative
+// in-memory lifecycle view the statusline and mini-dashboard render from. Overlay
+// live items on the snapshot so all three surfaces agree: live wins on lifecycle
+// fields, the snapshot keeps completion detail (summary/files/validation/notes)
+// that never reaches a dashboard item, and history records the dashboard has
+// dropped stay visible.
+export function mergeLiveDashboardItems(registry: PaneTaskRegistry, items: SubagentDashboardItem[]): PaneTaskRegistry {
+	if (items.length === 0) return registry;
+	const merged: PaneTaskRegistry = { ...registry };
+	for (const item of items) {
+		if (!item.taskId || !item.agent) continue;
+		const record = merged[item.taskId];
+		merged[item.taskId] = {
+			...record,
+			taskId: item.taskId,
+			agent: item.agent,
+			task: item.task ?? record?.task ?? "",
+			status: monitorStatusFromDashboard(item.status),
+			kind: item.kind ?? record?.kind,
+			paneId: item.paneId ?? record?.paneId,
+			sessionKey: item.sessionKey ?? record?.sessionKey,
+			sessionMode: item.sessionMode ?? record?.sessionMode,
+			transcriptPath: item.transcriptPath ?? record?.transcriptPath,
+			deliverAs: item.deliverAs ?? record?.deliverAs,
+			usage: item.usage ?? record?.usage,
+			model: item.model ?? record?.model,
+			effort: item.effort ?? record?.effort,
+			createdAt: record?.createdAt ?? item.startedAt ?? item.updatedAt,
+			updatedAt: item.updatedAt ?? record?.updatedAt,
+			completedAt: item.completedAt ?? record?.completedAt,
+		};
+	}
+	return merged;
 }
 
 export function taskNumberById(records: PaneTaskRecord[]): Map<string, number> {

--- a/pi-extensions/pi-agents-tmux/tests/monitor-live-refresh.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/monitor-live-refresh.test.ts
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+	buildMonitorSessionGroups,
+	liveDashboardSignature,
+	mergeLiveDashboardItems,
+	monitorTreeRows,
+	restoreMonitorSelectionByKey,
+} from "../extensions/subagent/browser.js";
+import { sortedMonitorRecords } from "../extensions/subagent/task-records.js";
+import type { AgentBrowserUiState, PaneTaskRecord, PaneTaskRegistry, SubagentDashboardItem } from "../extensions/subagent/types.js";
+
+function record(agent: string, taskId: string, createdAt: string, extra: Partial<PaneTaskRecord> = {}): PaneTaskRecord {
+	return { agent, createdAt, status: "running", task: `${agent} work`, taskId, ...extra };
+}
+
+function item(agent: string, taskId: string, updatedAt: string, extra: Partial<SubagentDashboardItem> = {}): SubagentDashboardItem {
+	return { agent, kind: "oneshot", startedAt: updatedAt, status: "running", task: `${agent} work`, taskId, updatedAt, ...extra };
+}
+
+function registryOf(...records: PaneTaskRecord[]): PaneTaskRegistry {
+	return Object.fromEntries(records.map((entry) => [entry.taskId, entry]));
+}
+
+function uiState(overrides: Partial<AgentBrowserUiState> = {}): AgentBrowserUiState {
+	return {
+		inspectorScroll: 0,
+		monitorScroll: 0,
+		monitorSelected: 0,
+		monitorSubtab: 0,
+		pane: "list",
+		scope: "both",
+		scroll: 0,
+		selected: 0,
+		tab: "monitor",
+		...overrides,
+	};
+}
+
+function rowsFor(registry: PaneTaskRegistry, items: SubagentDashboardItem[]) {
+	return monitorTreeRows(buildMonitorSessionGroups(sortedMonitorRecords(mergeLiveDashboardItems(registry, items))));
+}
+
+test("Monitor refresh surfaces an agent started after the snapshot was taken", () => {
+	const snapshot = registryOf(record("planner", "planner-1", "2026-05-14T05:00:00.000Z"));
+	const live = [item("planner", "planner-1", "2026-05-14T05:00:30.000Z"), item("reviewer-arch", "reviewer-arch-9", "2026-05-14T05:01:00.000Z")];
+
+	const merged = mergeLiveDashboardItems(snapshot, live);
+
+	assert.deepEqual(Object.keys(merged).sort(), ["planner-1", "reviewer-arch-9"]);
+	assert.equal(merged["reviewer-arch-9"]?.status, "running");
+	assert.equal(merged["reviewer-arch-9"]?.agent, "reviewer-arch");
+	assert.equal(merged["reviewer-arch-9"]?.createdAt, "2026-05-14T05:01:00.000Z");
+});
+
+test("Monitor refresh transitions a finished agent off running and keeps snapshot-only detail", () => {
+	const snapshot = registryOf(record("planner", "planner-1", "2026-05-14T05:00:00.000Z", { filesChanged: ["a.ts"], summary: "persisted summary" }));
+	const live = [item("planner", "planner-1", "2026-05-14T05:02:00.000Z", { completedAt: "2026-05-14T05:02:00.000Z", status: "completed" })];
+
+	const merged = mergeLiveDashboardItems(snapshot, live);
+
+	assert.equal(merged["planner-1"]?.status, "completed");
+	assert.equal(merged["planner-1"]?.completedAt, "2026-05-14T05:02:00.000Z");
+	// Completion detail never reaches a dashboard item, so the snapshot must win there.
+	assert.equal(merged["planner-1"]?.summary, "persisted summary");
+	assert.deepEqual(merged["planner-1"]?.filesChanged, ["a.ts"]);
+	assert.equal(merged["planner-1"]?.createdAt, "2026-05-14T05:00:00.000Z");
+
+	const completedSection = monitorTreeRows(buildMonitorSessionGroups(sortedMonitorRecords(merged))).find((row) => row.kind === "section" && row.section === "completed");
+	assert.equal(completedSection?.kind === "section" && completedSection.count, 1);
+});
+
+test("Monitor refresh maps the dashboard-only waiting status onto queued", () => {
+	const merged = mergeLiveDashboardItems({}, [item("planner", "planner-1", "2026-05-14T05:00:00.000Z", { status: "waiting" })]);
+
+	assert.equal(merged["planner-1"]?.status, "queued");
+});
+
+test("Live dashboard signature changes on lifecycle moves and is stable otherwise", () => {
+	const running = item("planner", "planner-1", "2026-05-14T05:00:00.000Z");
+	const base = liveDashboardSignature([running]);
+
+	assert.equal(liveDashboardSignature([running]), base);
+	assert.notEqual(liveDashboardSignature([{ ...running, status: "completed" }]), base);
+	assert.notEqual(liveDashboardSignature([running, item("scout", "scout-2", "2026-05-14T05:01:00.000Z")]), base);
+	// Order is not part of the fingerprint; only the lifecycle content is.
+	const pair = [running, item("scout", "scout-2", "2026-05-14T05:01:00.000Z")];
+	assert.equal(liveDashboardSignature([...pair].reverse()), liveDashboardSignature(pair));
+});
+
+test("Monitor selection stays on the same task when a refresh inserts rows above it", () => {
+	const snapshot = registryOf(record("planner", "planner-1", "2026-05-14T05:00:00.000Z"));
+	const before = rowsFor(snapshot, [item("planner", "planner-1", "2026-05-14T05:00:00.000Z")]);
+	const ui = uiState({ monitorSelected: before.findIndex((row) => row.kind === "task" && row.record.taskId === "planner-1") });
+	const selectedKey = before[ui.monitorSelected]?.key;
+	assert.ok(selectedKey);
+
+	// A newer agent starts; its session sorts above planner's, shifting every row below it.
+	const after = rowsFor(snapshot, [item("planner", "planner-1", "2026-05-14T05:00:00.000Z"), item("scout", "scout-2", "2026-05-14T05:03:00.000Z")]);
+	assert.notEqual(after.findIndex((row) => row.key === selectedKey), ui.monitorSelected);
+
+	restoreMonitorSelectionByKey(ui, after, selectedKey);
+
+	const stillSelected = after[ui.monitorSelected];
+	assert.equal(stillSelected?.key, selectedKey);
+	assert.equal(stillSelected?.kind === "task" && stillSelected.record.taskId, "planner-1");
+});
+
+test("Monitor selection survives a task moving from the active to the completed section", () => {
+	const snapshot = registryOf(record("planner", "planner-1", "2026-05-14T05:00:00.000Z"));
+	const before = rowsFor(snapshot, [item("planner", "planner-1", "2026-05-14T05:00:00.000Z")]);
+	const ui = uiState({ monitorSelected: before.findIndex((row) => row.kind === "task" && row.record.taskId === "planner-1") });
+	const selectedKey = before[ui.monitorSelected]!.key;
+
+	const after = rowsFor(snapshot, [item("planner", "planner-1", "2026-05-14T05:02:00.000Z", { completedAt: "2026-05-14T05:02:00.000Z", status: "completed" })]);
+	restoreMonitorSelectionByKey(ui, after, selectedKey);
+
+	const stillSelected = after[ui.monitorSelected];
+	assert.equal(stillSelected?.key, selectedKey);
+	assert.equal(stillSelected?.kind === "task" && stillSelected.record.status, "completed");
+});
+
+test("Selection restore leaves the cursor put when the previously selected row disappeared", () => {
+	const ui = uiState({ monitorSelected: 2 });
+
+	restoreMonitorSelectionByKey(ui, rowsFor(registryOf(record("planner", "planner-1", "2026-05-14T05:00:00.000Z")), []), "gone:missing");
+
+	assert.equal(ui.monitorSelected, 2);
+});


### PR DESCRIPTION
Closes #611 (the remaining half — the Transcript-tab clamp was fixed separately in #613).

## Root cause

The `/agents` pop-up called `readTaskRegistry` once on open and rendered from that frozen disk snapshot for its whole lifetime. The live `getActiveItems()` callback it already received only drove spinner animation, never the record set. So finished agents kept rendering as "working", newly-started ones never appeared, and the pop-up disagreed with the statusline and mini-dashboard — which both read the authoritative in-memory `dashboardState.items` and therefore agree with each other by construction.

Compounding it, the animation timer was armed *only if* something was already animating when the pop-up opened, so a pop-up opened while idle could never wake up.

## Change

- `mergeLiveDashboardItems` overlays live dashboard items onto the disk snapshot: live wins on lifecycle fields, the snapshot retains completion detail (summary/files/validation/notes) that never reaches a dashboard item, and history the dashboard has dropped stays visible. All three surfaces now converge on the same authoritative source.
- One always-armed 120ms tick replaces the conditional animation timer, handling both live refresh and spinners. It renders only when `liveDashboardSignature` actually moved, so an idle pop-up neither re-sorts nor repaints.
- Selection is restored **by row key, not index** (`restoreMonitorSelectionByKey`), so rows appearing, disappearing, or reordering above the cursor don't drag the highlight.
- Detail-pane cache entries are dropped for tasks whose status changed, so the inspector reloads instead of serving a stale trace.

`waiting` exists only on the dashboard and maps onto the registry's `queued`.

## Tests

New `tests/monitor-live-refresh.test.ts` (7 cases): agent started after the snapshot appears; finished agent transitions off running while keeping snapshot-only detail; `waiting`→`queued` mapping; signature changes on lifecycle moves and is stable otherwise; selection holds when rows are inserted above it; selection survives a task moving from the active to the completed section; selection restore leaves the cursor put when the selected row disappeared.

Suite: **257 pass / 13 fail** on this branch vs **250 pass / 13 fail** on main — the same 13 failures and 2 errors exist on main unchanged (`delegate_subagent runtime behavior`, `child pane title ownership`); this adds 7 passing tests and touches none of them. The repo has no tsconfig, so there is no typecheck gate to run.

## Not verified here

This is TUI code and cannot be fully exercised headlessly. Static reasoning and unit tests cover the record-set and selection logic, but **flicker behaviour and cursor feel in a live terminal have not been observed.** Worth one manual pass: open `/agents` while agents are running, watch a completion land, start a new agent while it's open, and confirm the highlight stays put and the pane doesn't strobe at 120ms.

One narrow known gap, pre-existing and not introduced here: if an item is explicitly removed from the dashboard (`removeDashboardAgent`, duplicate cleanup) its snapshot record can resurface with its last on-disk status. `mergeLiveDashboardItems` early-returns on an empty item set, which is correct — with no live lifecycle facts there is nothing to overlay.