### PR TITLE
fix(cli): resolve each locked entry against its own recorded source (#755)

### DIFF
--- a/cli/src/commands/add.rs
+++ b/cli/src/commands/add.rs
@@ -452,6 +452,40 @@ mod source_option_tests {
             vec![crate::REPO, "owner/custom"]
         );
     }
+
+    /// The lock must record the source the install actually read from, even
+    /// when that directory does not look like a canonical vstack repo (here a
+    /// dot-named dir carrying only `skills/`). Recording the registry's current
+    /// source instead points every later refresh at the wrong repo.
+    #[test]
+    fn resolve_source_for_app_prefers_the_passed_source_over_the_registry_current() {
+        let root = std::env::temp_dir().join(format!(
+            "vstack-add-passed-source-{}-{:?}",
+            std::process::id(),
+            std::time::SystemTime::now()
+        ));
+        let alternate = root.join(".agents");
+        std::fs::create_dir_all(alternate.join("skills/demo")).unwrap();
+        let project_root = root.join("project");
+        std::fs::create_dir_all(&project_root).unwrap();
+
+        let mut registry = config::SourceRegistry::default();
+        registry.remember_for_project(&project_root, "/repo/current-vstack");
+
+        let resolved =
+            resolve_source_for_app(Some(&alternate.to_string_lossy()), &registry, &project_root)
+                .expect("passed source should resolve");
+
+        let canonical = std::fs::canonicalize(&alternate).unwrap();
+        assert_eq!(resolved.source, canonical.display().to_string());
+        assert_eq!(resolved.dir, canonical);
+        assert!(
+            !crate::resolve::is_vstack_source(&alternate),
+            "fixture must exercise the non-canonical-layout case"
+        );
+
+        let _ = std::fs::remove_dir_all(root);
+    }
 }
 
 /// vstack#71: walk each agent's [agent-skills] + [role-skills] + transitive

--- a/cli/src/commands/refresh.rs
+++ b/cli/src/commands/refresh.rs
@@ -11,7 +11,7 @@ use crate::refresh_sources::{
 };
 use crate::skill::Skill;
 use anyhow::Result;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 /// Result counts from one invocation of [`refresh_items_in_scope`].
@@ -37,6 +37,12 @@ pub struct RefreshStats {
     /// Canonical project-owned skills managed through `[skill-instructions]`
     /// despite having no vstack lock entry or upstream package source.
     pub project_owned_skills: HashSet<String>,
+    /// Locked items that could not be refreshed because their source is gone
+    /// or no longer carries the asset, mapped to the reason. Tracked
+    /// separately from [`Self::failures`] (a failed install attempt) so the
+    /// report can never fall through to "unchanged" with the stored hash —
+    /// that silently masked an entry whose source had stopped providing it.
+    pub missing: BTreeMap<String, String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -76,8 +82,22 @@ impl RefreshStats {
         });
     }
 
+    /// Record that `item` has no asset to refresh from. `source` is the source
+    /// root it resolved to, or `None` when no source resolved at all.
+    fn mark_missing(&mut self, item: &str, source: Option<&Path>) {
+        let reason = match source {
+            Some(root) => format!("not found in source {}", root.display()),
+            None => "source not found".to_string(),
+        };
+        self.missing.insert(item.to_string(), reason);
+    }
+
     pub fn has_failures(&self) -> bool {
         !self.failures.is_empty()
+    }
+
+    pub fn has_missing(&self) -> bool {
+        !self.missing.is_empty()
     }
 }
 
@@ -186,15 +206,11 @@ pub fn refresh_items_in_scope(
             continue;
         }
         let Some(source) = refresh_source_for_entry(sources, entry) else {
-            if name_filter.is_none() {
-                eprintln!("  ! {} — source not found, skipped", name);
-            }
+            stats.mark_missing(name, None);
             continue;
         };
         let Some(agent) = source.agents.iter().find(|a| &a.name == name) else {
-            if name_filter.is_none() {
-                eprintln!("  ! {} — source not found, skipped", name);
-            }
+            stats.mark_missing(name, Some(&source.root));
             continue;
         };
 
@@ -315,9 +331,11 @@ pub fn refresh_items_in_scope(
         .filter(|(n, _)| pass(n))
     {
         let Some(source) = refresh_source_for_entry(sources, entry) else {
+            stats.mark_missing(name, None);
             continue;
         };
         let Some(skill) = source.skills.iter().find(|s| &s.name == name) else {
+            stats.mark_missing(name, Some(&source.root));
             continue;
         };
 
@@ -381,9 +399,11 @@ pub fn refresh_items_in_scope(
         .filter(|(n, _)| pass(n))
     {
         let Some(source) = refresh_source_for_entry(sources, entry) else {
+            stats.mark_missing(name, None);
             continue;
         };
         let Some(hook) = source.hooks.iter().find(|hook| hook.name == entry.name) else {
+            stats.mark_missing(name, Some(&source.root));
             continue;
         };
         let mut succeeded = 0usize;
@@ -416,9 +436,11 @@ pub fn refresh_items_in_scope(
         .filter(|(n, _)| pass(n))
     {
         let Some(source) = refresh_source_for_entry(sources, entry) else {
+            stats.mark_missing(name, None);
             continue;
         };
         let Some(ext) = source_pi_extension_for_lock_name(&source.pi_extensions, name) else {
+            stats.mark_missing(name, Some(&source.root));
             continue;
         };
         match crate::pi_extension::install_pi_extension(ext, global) {
@@ -963,7 +985,13 @@ fn run_one(global: bool, verbose: bool) -> Result<()> {
         let source_resolved = source_records
             .iter()
             .any(|source| source.aliases.iter().any(|alias| alias == &entry.source));
+        // Repair only a source that has genuinely gone away. An entry whose
+        // recorded source still exists keeps it even when nothing else in the
+        // lock references it: rewriting it here is what silently re-pointed
+        // alternate-source entries at the majority source and undid every
+        // hand-correction of the lock.
         if !source_resolved
+            && !crate::refresh_sources::recorded_source_exists(&entry.source)
             && let Some(replacement) = &fallback_source
             && &entry.source != replacement
         {
@@ -1018,15 +1046,35 @@ fn run_one(global: bool, verbose: bool) -> Result<()> {
             .max()
             .unwrap_or(0);
         for (_, kind, name, old, new) in &changes {
-            let changed = is_updated(name, old, new);
-            let mark = if changed { "!" } else { "✓" };
-            let label = if changed { "changed" } else { "unchanged" };
+            let missing = stats.missing.contains_key(name);
+            let changed = !missing && is_updated(name, old, new);
+            let mark = if missing {
+                "?"
+            } else if changed {
+                "!"
+            } else {
+                "✓"
+            };
+            let label = if missing {
+                "missing"
+            } else if changed {
+                "changed"
+            } else {
+                "unchanged"
+            };
             let old_short = if old.is_empty() {
                 "—".to_string()
             } else {
                 old.chars().take(8).collect()
             };
-            let new_short: String = new.chars().take(8).collect();
+            // A missing item's stored hash is deliberately not echoed as the
+            // new value: printing "<hash> → <hash> (unchanged)" is exactly the
+            // masking this state exists to prevent.
+            let new_short: String = if missing {
+                "—".to_string()
+            } else {
+                new.chars().take(8).collect()
+            };
             eprintln!(
                 "  {mark} {:kw$}  {:nw$}  {} → {}  ({})",
                 kind,
@@ -1088,6 +1136,9 @@ fn run_one(global: bool, verbose: bool) -> Result<()> {
         stats.pi_refreshed,
         count_updated(ItemKind::PiExtension),
     );
+    for (item, reason) in &stats.missing {
+        eprintln!("  ? {item} — {reason}; not refreshed");
+    }
     if stats.has_failures() {
         for failure in &stats.failures {
             let harness = failure
@@ -1100,6 +1151,13 @@ fn run_one(global: bool, verbose: bool) -> Result<()> {
         anyhow::bail!(
             "failed to refresh {} item/harness install(s)",
             stats.failures.len()
+        );
+    }
+    if stats.has_missing() {
+        anyhow::bail!(
+            "{} locked item(s) missing from their source; \
+             re-add them or run `vstack remove` to drop the stale entries",
+            stats.missing.len()
         );
     }
     Ok(())

--- a/cli/src/commands/refresh/tests.rs
+++ b/cli/src/commands/refresh/tests.rs
@@ -725,6 +725,107 @@ fn refresh_items_reports_agent_write_failure_without_success() {
     let _ = std::fs::remove_dir_all(root);
 }
 
+/// Anti-masking regression: an entry whose source no longer carries the asset
+/// used to be skipped silently, after which the report echoed the stored hash
+/// as `<hash> → <hash> (unchanged)` and refresh exited 0. Edits that never
+/// propagated were indistinguishable from a genuinely up-to-date install.
+#[test]
+fn refresh_reports_items_missing_from_their_source_instead_of_skipping() {
+    let root = tmpdir("missing-from-source");
+    let project = root.join("project");
+    let source = make_source(&root, "source");
+    std::fs::create_dir_all(&project).unwrap();
+    write_colliding_source(&source, "1", "PreToolUse", "source-model");
+
+    let mut lock = LockFile::default();
+    // Locked, but absent from the source: nothing to refresh from.
+    lock.add(lock_entry(
+        "gone",
+        ItemKind::Skill,
+        &source,
+        vec!["claude-code"],
+    ));
+    lock.add(lock_entry(
+        "vanished",
+        ItemKind::Agent,
+        &source,
+        vec!["claude-code"],
+    ));
+    // Present in the source: must still refresh normally alongside them.
+    lock.add(lock_entry(
+        "shared",
+        ItemKind::Skill,
+        &source,
+        vec!["claude-code"],
+    ));
+    let sources = vec![RefreshSource::from_root(&source)];
+
+    let stats = crate::test_util::with_project_root(&project, || {
+        let mut project_config = ProjectConfig::default();
+        refresh_items_in_scope(false, &lock, &sources, &mut project_config, &project, None)
+    });
+
+    assert!(stats.has_missing());
+    assert_eq!(
+        stats.missing.keys().cloned().collect::<Vec<_>>(),
+        vec!["gone".to_string(), "vanished".to_string()]
+    );
+    for name in ["gone", "vanished"] {
+        assert!(
+            stats.missing[name].contains(&source.display().to_string()),
+            "missing reason must name the resolved source: {}",
+            stats.missing[name]
+        );
+        assert!(
+            !stats.successful_items.contains(name),
+            "{name} must not count as refreshed"
+        );
+    }
+    assert_eq!(stats.skills_refreshed, 1);
+    assert!(stats.successful_items.contains("shared"));
+
+    let _ = std::fs::remove_dir_all(root);
+}
+
+/// The single-source fallback must not silently reinstall an entry from a
+/// source it was never installed from — it reports missing instead.
+#[test]
+fn refresh_reports_missing_when_the_recorded_source_is_not_loaded() {
+    let root = tmpdir("unloaded-source");
+    let project = root.join("project");
+    let loaded = make_source(&root, "loaded");
+    let alternate = root.join(".agents");
+    std::fs::create_dir_all(alternate.join("skills/shared")).unwrap();
+    std::fs::create_dir_all(&project).unwrap();
+    write_colliding_source(&loaded, "1", "PreToolUse", "source-model");
+
+    let mut lock = LockFile::default();
+    lock.add(lock_entry(
+        "shared",
+        ItemKind::Skill,
+        &alternate,
+        vec!["claude-code"],
+    ));
+    let sources = vec![RefreshSource::from_root(&loaded)];
+
+    let stats = crate::test_util::with_project_root(&project, || {
+        let mut project_config = ProjectConfig::default();
+        refresh_items_in_scope(false, &lock, &sources, &mut project_config, &project, None)
+    });
+
+    assert_eq!(stats.skills_refreshed, 0);
+    assert_eq!(
+        stats.missing.get("shared").map(String::as_str),
+        Some("source not found")
+    );
+    assert!(
+        !project.join(".claude/skills/shared/SKILL.md").exists(),
+        "must not install from a source the entry was never installed from"
+    );
+
+    let _ = std::fs::remove_dir_all(root);
+}
+
 #[test]
 fn refresh_rejects_agent_name_that_escapes_output_dir() {
     let root = tmpdir("agent-name-traversal");

--- a/cli/src/refresh_sources.rs
+++ b/cli/src/refresh_sources.rs
@@ -58,7 +58,7 @@ pub(crate) fn resolve_sources(lock: &config::LockFile) -> Vec<PathBuf> {
 }
 
 pub(crate) fn resolve_source_records(lock: &config::LockFile) -> Vec<ResolvedSource> {
-    resolve_source_records_with(lock, resolve_single_source)
+    resolve_source_records_with(lock, resolve_recorded_source)
 }
 
 fn resolve_source_records_with(
@@ -156,7 +156,13 @@ pub(crate) fn refresh_source_for_entry<'a>(
         return Some(source);
     }
 
-    if sources.len() == 1 {
+    // Legacy/moved-source fallback: an old lock may record a source string
+    // that no longer names anything on disk (a renamed repo, or a pre-1.0 lock
+    // with no meaningful source). Those may fall back to the sole loaded
+    // source. An entry whose own recorded source still exists must never be
+    // rebound to a different one — that silently reinstalled such entries from
+    // the wrong repo and masked the real source's edits.
+    if sources.len() == 1 && !recorded_source_exists(&entry.source) {
         sources.first()
     } else {
         None
@@ -217,6 +223,33 @@ pub(crate) fn source_pi_extension_for_lock_name<'a>(
 
 pub(crate) fn resolve_single_source(source: &str) -> Option<PathBuf> {
     resolve_single_source_with(source, true, true)
+}
+
+/// Resolve a source string that a lock entry recorded at install time.
+///
+/// Discovery (`resolve_single_source`) applies the [`crate::resolve::is_vstack_source`]
+/// layout heuristic so that walking up from CWD does not mistake an arbitrary
+/// directory for a package source. A recorded source needs no such guess: the
+/// user named it explicitly on `vstack add`, which accepts any directory
+/// holding the asset. Applying the heuristic here silently dropped alternate
+/// sources that the heuristic rejects — a dot-named dir, or one carrying only
+/// `skills/` — after which the entry fell back to whatever other source was
+/// loaded and edits to the real source stopped propagating.
+pub(crate) fn resolve_recorded_source(source: &str) -> Option<PathBuf> {
+    let path = Path::new(source);
+    if path.is_absolute() && path.is_dir() {
+        return Some(path.to_path_buf());
+    }
+    resolve_single_source(source)
+}
+
+/// Whether an entry's recorded source still names a usable directory on disk.
+///
+/// Deliberately side-effect free (no remote fetch): callers use it in per-entry
+/// loops to decide whether an entry may fall back to a different source.
+pub(crate) fn recorded_source_exists(source: &str) -> bool {
+    let path = Path::new(source);
+    path.is_absolute() && path.is_dir()
 }
 
 pub(crate) fn resolve_source_path(source: &str) -> Option<PathBuf> {
@@ -316,6 +349,13 @@ mod tests {
         ))
     }
 
+    fn make_vstack_source(root: &Path, name: &str) -> PathBuf {
+        let source = root.join(name);
+        std::fs::create_dir_all(source.join("agents")).unwrap();
+        std::fs::create_dir_all(source.join("skills")).unwrap();
+        source
+    }
+
     fn lock_entry(name: &str, source: &str) -> LockEntry {
         LockEntry {
             name: name.into(),
@@ -340,6 +380,65 @@ mod tests {
             Some(source.clone())
         );
         assert!(resolve_single_source(&root.to_string_lossy()).is_none());
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    /// `vstack add <SOURCE>` accepts any directory holding the asset, so a lock
+    /// entry may record one that the discovery heuristic rejects — a dot-named
+    /// dir, or one carrying only `skills/`. Dropping it here is what made
+    /// refresh fall back to the majority source and stop propagating edits.
+    #[test]
+    fn resolve_source_records_keeps_a_source_the_layout_heuristic_rejects() {
+        let root = tmpdir("recorded-alternate");
+        let alternate = root.join(".agents");
+        std::fs::create_dir_all(alternate.join("skills/demo")).unwrap();
+        assert!(
+            !crate::resolve::is_vstack_source(&alternate),
+            "fixture must exercise the heuristic-rejected case"
+        );
+        assert_eq!(resolve_single_source(&alternate.to_string_lossy()), None);
+
+        assert_eq!(
+            resolve_recorded_source(&alternate.to_string_lossy()),
+            Some(alternate.clone())
+        );
+
+        let mut lock = config::LockFile::default();
+        lock.add(lock_entry("demo", &alternate.to_string_lossy()));
+        let records = resolve_source_records(&lock);
+
+        assert_eq!(
+            records.iter().map(|r| r.root.clone()).collect::<Vec<_>>(),
+            vec![alternate]
+        );
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    /// An entry whose own source still exists must never be silently rebound to
+    /// the sole other loaded source; that reinstalled it from the wrong repo.
+    /// The fallback stays available for a source that has genuinely gone away.
+    #[test]
+    fn refresh_source_for_entry_only_falls_back_when_the_recorded_source_is_gone() {
+        let root = tmpdir("no-rebind");
+        let alternate = root.join(".agents");
+        std::fs::create_dir_all(alternate.join("skills/demo")).unwrap();
+        let only_source = make_vstack_source(&root, "other");
+        let sources = vec![RefreshSource::from_root(&only_source)];
+
+        let live = lock_entry("demo", &alternate.to_string_lossy());
+        assert!(
+            refresh_source_for_entry(&sources, &live).is_none(),
+            "an entry whose recorded source exists must not bind to a different source"
+        );
+
+        let vanished = lock_entry("demo", &root.join("deleted-repo").to_string_lossy());
+        assert_eq!(
+            refresh_source_for_entry(&sources, &vanished).map(|s| s.root.clone()),
+            Some(only_source),
+            "legacy lock with a missing source keeps the single-source fallback"
+        );
 
         let _ = std::fs::remove_dir_all(root);
     }


### PR DESCRIPTION
Closes #755.

## Root cause — deeper than the issue described

The issue framed this as two defects: (a) `add` recording the wrong source, and (b) refresh ignoring the recorded source. Investigation found (a) is **not** an independent bug — `resolve_source_for_app` already prefers the passed SOURCE, and there's now a test pinning that. The wrong value in the lock was written *later*, by refresh itself.

The actual chain:

1. `resolve_single_source` applies the `is_vstack_source` **layout heuristic**, which exists so that walking up from CWD doesn't mistake an arbitrary directory for a package source. A recorded source needs no such guess — the user named it explicitly, and `add` accepts any directory holding the asset.
2. Applying that heuristic to recorded sources silently **dropped** any source it rejects: a dot-named dir, or one carrying only `skills/`. `~/dotfiles/.agents` is both.
3. With its own source dropped, the entry fell through to the single-source fallback and was reinstalled from the *wrong* repo.
4. `run_one`'s source-repair path then **rewrote `entry.source` in the lock** to that fallback — which is why hand-correcting the lock never stuck, and why the lock reads `/home/method/dev/vstack` after an install from `~/dotfiles/.agents`.

So one heuristic misapplication produced all three reported symptoms.

## Changes

- **`resolve_recorded_source`** — a recorded absolute directory that exists is trusted as-is, no layout heuristic. Discovery still uses the heuristic; only recorded sources bypass it.
- **No silent rebinding** — `refresh_source_for_entry` falls back to the sole loaded source only when the recorded source is genuinely *gone*. An entry whose source still exists is never rebound. Same guard added to `run_one`'s lock-repair path, so a valid recorded source is no longer overwritten.
- **`missing` state** — locked items whose source is gone, or which the source no longer provides, are tracked separately from install failures across all four kinds (agents, skills, hooks, pi-extensions). They render as `? name — … ; not refreshed`, and refresh exits non-zero.
- The missing row prints `— → —`, deliberately **not** the stored hash. Echoing `<hash> → <hash> (unchanged)` is exactly the masking this state exists to prevent.

## Behaviour change worth noting

`vstack refresh` now **exits non-zero** when a locked item is missing from its source, where it previously printed a skip line and exited 0. That's the reporting the issue asked for, but it is a breaking change for any `vstack refresh && …` chain.

I checked the blast radius against every real lock on this machine — drovr, memsira, hyprtrade, vshell all have **every** locked item present in source and are unaffected. The single missing entry anywhere is `vstack-issues` in `~/dev/vstack`, which is this exact bug: its content lives in `~/dotfiles/.agents` while its lock records the vstack repo. After this merges that refresh will fail loudly until the entry is re-added with the correct source — which is the intended outcome, not a regression.

## Tests

`cargo test` **370 + 17 pass, 0 fail**; `cargo clippy --all-targets` clean. New coverage: the passed SOURCE wins over the registry current even for a heuristic-rejected layout; `resolve_source_records` keeps a source the heuristic rejects; and fallback happens only when the recorded source is gone, while a legacy lock with a vanished source still gets it.