### PR TITLE
fix(reviewer): state that [AGENT] keeps its reviewer- prefix in artifact names (#761)

### DIFF
--- a/skills/reviewer/SKILL.md
+++ b/skills/reviewer/SKILL.md
@@ -32,7 +32,7 @@ Code-review, whole-codebase review, and QA-review workflows plus the structured-
 
 | Schema | Purpose |
 |--------|---------|
-| `schemas/review-finding.md` | Canonical JSON output shape for any review or QA verdict. Saved to `[worktree-path]/tmp/review-{agent}-YYYYMMDD-HHMMSS.json`. |
+| `schemas/review-finding.md` | Canonical JSON output shape for any review or QA verdict. Saved to `[worktree-path]/tmp/review-{agent}-YYYYMMDD-HHMMSS.json`, where `{agent}` is the FULL agent name including its `reviewer-` prefix — `reviewer-security` writes `review-reviewer-security-20260720-141530.json`, never `review-security-…`. |
 
 ## General Review Ethos
 

--- a/skills/reviewer/schemas/review-finding.md
+++ b/skills/reviewer/schemas/review-finding.md
@@ -2,6 +2,8 @@
 
 All review/QA agents output JSON to `[worktree-path]/tmp/review-{agent}-YYYYMMDD-HHMMSS.json`.
 
+`{agent}` is your FULL agent name, including its `reviewer-` prefix. For `reviewer-security` the file is `review-reviewer-security-20260720-141530.json`. The doubled `review-reviewer-` is correct — do not shorten or de-duplicate it to `review-security-…`; orch's `review-artifact-check` globs the literal full agent name and reports the artifact `missing` otherwise.
+
 Create the JSON artifact with the active harness file-write/edit tool. In Codex, use `apply_patch` to add or update the target file under `tmp/`. Do not use shell redirection, heredocs, `tee`, `echo >`, command substitution, or redirected `cat` writes for review artifacts.
 
 ## Schema

--- a/skills/reviewer/workflows/codebase-review.md
+++ b/skills/reviewer/workflows/codebase-review.md
@@ -49,6 +49,8 @@ Read the orch skill's recommendation-bias patterns if available. Apply its actio
 
 Build JSON per [`../schemas/review-finding.md`](../schemas/review-finding.md). Target artifact path: `[WORKTREE_PATH]/tmp/review-[AGENT]-codebase-YYYYMMDD-HHMMSS.json`.
 
+`[AGENT]` is your FULL agent name, including its `reviewer-` prefix. For `reviewer-security` the file is `review-reviewer-security-codebase-20260720-141530.json`. The doubled `review-reviewer-` is correct — do not shorten or de-duplicate it to `review-security-codebase-…`; orch's `review-artifact-check` globs the literal full agent name and reports the artifact `missing` otherwise.
+
 Artifact write path:
 - Create `[WORKTREE_PATH]/tmp` with `mkdir -p [WORKTREE_PATH]/tmp` if it does not exist.
 - Write the JSON with the harness file-write/edit tool. In Codex, use `apply_patch` to add or update the exact artifact path.
@@ -56,7 +58,7 @@ Artifact write path:
 
 Send this result to the orchestrator as an agent-to-agent message. **Writing the JSON to disk is not a return**.
 
-**Return exactly**:
+**Return exactly** (`[AGENT]` is your full agent name including the `reviewer-` prefix, e.g. `review-reviewer-security-codebase-20260720-141530.json`):
 
 <output_format>
 Verdict: [pass|action_required]
@@ -71,7 +73,7 @@ File: [WORKTREE_PATH]/tmp/review-[AGENT]-codebase-YYYYMMDD-HHMMSS.json
 ## Constraints
 
 **Do NOT**:
-- Modify project files other than the required `[WORKTREE_PATH]/tmp/review-[AGENT]-codebase-YYYYMMDD-HHMMSS.json` review artifact
+- Modify project files other than the required `[WORKTREE_PATH]/tmp/review-[AGENT]-codebase-YYYYMMDD-HHMMSS.json` review artifact (`[AGENT]` in full, prefix included — `reviewer-security` → `review-reviewer-security-codebase-…`)
 - Modify issue tracker state
 - Create commits or push changes
 - Call other subagents

--- a/skills/reviewer/workflows/qa-review.md
+++ b/skills/reviewer/workflows/qa-review.md
@@ -117,6 +117,7 @@ targeted regression output.
 ### 2.6 Return JSON Report
 
 1. **Build JSON** per [`../schemas/review-finding.md`](../schemas/review-finding.md), filename `[WORKTREE_PATH]/tmp/review-[AGENT]-YYYYMMDD-HHMMSS.json`.
+   - `[AGENT]` is your FULL agent name, including its `reviewer-` prefix. For `reviewer-security` the file is `review-reviewer-security-20260720-141530.json`. The doubled `review-reviewer-` is correct — do not shorten or de-duplicate it to `review-security-…`; orch's `review-artifact-check` globs the literal full agent name and reports the artifact `missing` otherwise.
    - Standard fields: `agent`, `timestamp`, `verdict`, `summary`, `blockers[]`, `suggestions[]`
    - If performance QA agent: include `benchmark_commit` from § 2.5
    - `qa_metadata.[agent_type]` populated per your agent (project-configurable):
@@ -131,7 +132,7 @@ targeted regression output.
    - `action_required`: 1+ items in `blockers[]`
    - `pass`: `blockers[]` empty
 
-2. **Create the artifact** at `[WORKTREE_PATH]/tmp/review-[AGENT]-YYYYMMDD-HHMMSS.json` with the harness file-write/edit tool. In Codex, use `apply_patch` to add or update the exact path. Do not use shell redirection, heredocs, `tee`, `echo >`, command substitution, or redirected `cat` writes.
+2. **Create the artifact** at `[WORKTREE_PATH]/tmp/review-[AGENT]-YYYYMMDD-HHMMSS.json` — `[AGENT]` in full, prefix included (`reviewer-security` → `review-reviewer-security-20260720-141530.json`), never shortened to `review-security-…` — with the harness file-write/edit tool. In Codex, use `apply_patch` to add or update the exact path. Do not use shell redirection, heredocs, `tee`, `echo >`, command substitution, or redirected `cat` writes.
 
 3. **Return the JSON** in your response so the calling agent can validate the same content:
 
@@ -141,7 +142,7 @@ targeted regression output.
 
 Send this result to the orchestrator as an agent-to-agent message. **Writing the JSON to disk is not a return** — the orchestrator does not poll the filesystem, and turn text is not visible across team boundaries. Send exactly one message with the body below, then go idle.
 
-**Return exactly**:
+**Return exactly** (`[AGENT]` and `[AGENT_NAME]` are both your full agent name including the `reviewer-` prefix — `reviewer-security` reports `agent: reviewer-security` and the file `review-reviewer-security-20260720-141530.json`):
 
 <output_format>
 QA_COMPLETE

--- a/skills/reviewer/workflows/review.md
+++ b/skills/reviewer/workflows/review.md
@@ -58,6 +58,8 @@ Items listed as fixed or escalated are already resolved — do NOT re-report the
 
 Build JSON per [`../schemas/review-finding.md`](../schemas/review-finding.md). Target artifact path: `[WORKTREE_PATH]/tmp/review-[AGENT]-YYYYMMDD-HHMMSS.json`.
 
+`[AGENT]` is your FULL agent name, including its `reviewer-` prefix. For `reviewer-security` the file is `review-reviewer-security-20260720-141530.json`. The doubled `review-reviewer-` is correct — do not shorten or de-duplicate it to `review-security-…`; orch's `review-artifact-check` globs the literal full agent name and reports the artifact `missing` otherwise.
+
 Artifact write path:
 - Create `[WORKTREE_PATH]/tmp` with `mkdir -p [WORKTREE_PATH]/tmp` if it does not exist.
 - Write the JSON with the harness file-write/edit tool. In Codex, use `apply_patch` to add or update the exact artifact path.
@@ -71,7 +73,7 @@ Artifact write path:
 
 Send this result to the orchestrator as an agent-to-agent message. **Writing the JSON to disk is not a return** — the orchestrator does not poll the filesystem, and turn text is not visible across team boundaries. Send exactly one message with the body below, then go idle.
 
-**Return exactly** (return to orchestrator):
+**Return exactly** (return to orchestrator; `[AGENT]` is your full agent name including the `reviewer-` prefix, e.g. `review-reviewer-security-20260720-141530.json`):
 
 <output_format>
 Verdict: [pass|action_required]


### PR DESCRIPTION
Closes #761.

## Root cause

The artifact template is `[WORKTREE_PATH]/tmp/review-[AGENT]-YYYYMMDD-HHMMSS.json`. Since reviewer agent names already start with `reviewer-`, the *correct* expansion `review-reviewer-security` reads as a duplication, so agents "simplify" it to `review-security-`. orch's `review-artifact-check` then reports `missing`, costing one re-delegation round-trip per offender (2 of 10 in hyprtrade CC-927).

## Why the docs, not the convention

`skills/orch/scripts/review-artifact-check:192` globs:

```sh
ls -1t "$worktree/tmp/review-$agent-"*.json
```

`$agent` is the full agent name, so `review-reviewer-security-*.json` is genuinely correct. The checker and the naming convention are right — only the documentation was ambiguous. The issue floated changing the convention to `[AGENT]-report-*.json`; that would ripple through orch and every consumer to solve a docs problem, so this PR leaves the contract untouched.

## Scope

The issue named `workflows/review.md` lines 59 and 78. The same ambiguous template appears at **10 occurrences across 5 files**, and an agent may read only one of them, so fixing the two named would leave the rest to drift identically:

- `SKILL.md` — schema table
- `schemas/review-finding.md` — the canonical shape doc
- `workflows/review.md` — target path + return format
- `workflows/qa-review.md` — build step, create step, return format
- `workflows/codebase-review.md` — target path, return format, constraints (this one carries an extra `-codebase` infix, preserved exactly)

Each site now states that `[AGENT]` is the full name including the `reviewer-` prefix, gives a worked example (`reviewer-security` → `review-reviewer-security-20260720-141530.json`), says plainly not to shorten it despite the apparent redundancy, and cites the checker's glob so the reader knows *why*.

## Tests

`bash skills/orch/tests/run-all.sh` — **all 19 files passed**. `skills/reviewer/` has no test directory. Docs-only; `skills/orch/` untouched.