### PR TITLE
feat(pi-tool-renderer): add configurable read image rendering

### DIFF
--- a/pi-extensions/pi-tool-renderer/README.md
+++ b/pi-extensions/pi-tool-renderer/README.md
@@ -93,6 +93,7 @@ Glyph style: each package exposes `glyphStyle` (`unicode` default, `ascii` for t
 | Setting | What it does |
 | --- | --- |
 | Read output mode | `preview`, `summary`, or `hidden`. |
+| Read image display | With Pi `terminal.showImages=false`: `off` hides images, `always` shows them in read output, and `on` shows them only while tools are expanded. Changes from Extension Settings apply immediately. Floating overlays temporarily hide images but keep their layout space. |
 | Search output mode | `preview`, `count`, or `hidden`. |
 | Bash output mode | `opencode`, `preview`, `summary`, or `hidden`. |
 | Live bash output delay (ms) | Wait this long before showing a running bash output tail. |

--- a/pi-extensions/pi-tool-renderer/extensions/__tests__/read-images.test.ts
+++ b/pi-extensions/pi-tool-renderer/extensions/__tests__/read-images.test.ts
@@ -1,0 +1,228 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { resetCapabilitiesCache, setCapabilities } from "@earendil-works/pi-tui";
+
+import {
+	clearTrackedToolExecutionComponents,
+	installLiveSettingsRefresh,
+	trackToolExecutionComponent,
+} from "../tool-renderer/live-settings.js";
+import { RESERVED_IMAGE_ROW_MARKER, TOOL_RENDER_OVERLAY_CHECK_SYMBOL } from "../tool-renderer/overlay.js";
+import { recordProjectTrust } from "../tool-renderer/settings.js";
+import { registerRead } from "../tool-renderer/tools.js";
+
+const createdDirs: string[] = [];
+const imageData = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=";
+
+type ReadImageSetting = "off" | "always" | "on" | boolean;
+
+afterEach(() => {
+	resetCapabilitiesCache();
+	clearTrackedToolExecutionComponents();
+	for (const dir of createdDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function writeSettings(cwd: string, config: Record<string, unknown>): void {
+	writeFileSync(
+		join(cwd, ".pi", "settings.json"),
+		JSON.stringify({
+			vstack: {
+				extensionManager: {
+					config: { "@vanillagreen/pi-tool-renderer": config },
+				},
+			},
+		}),
+	);
+}
+
+function tempCwd(showReadImages?: ReadImageSetting, overrides: Record<string, unknown> = {}): string {
+	const cwd = mkdtempSync(join(tmpdir(), "pi-tool-renderer-read-images-"));
+	createdDirs.push(cwd);
+	mkdirSync(join(cwd, ".pi"), { recursive: true });
+	const config = { ...overrides };
+	if (showReadImages !== undefined) config.showReadImages = showReadImages;
+	writeSettings(cwd, config);
+	recordProjectTrust({ cwd, isProjectTrusted: () => true });
+	return cwd;
+}
+
+function writeImageMode(cwd: string, showReadImages: ReadImageSetting): void {
+	writeSettings(cwd, { showReadImages });
+}
+
+function readRenderer(cwd: string): any {
+	let definition: any;
+	const pi = {
+		registerTool(tool: any) {
+			definition = tool;
+		},
+	};
+	const agent = {
+		createReadTool: () => ({
+			description: "read",
+			parameters: {},
+			execute: async () => ({ content: [] }),
+		}),
+	};
+	registerRead(pi as any, agent, cwd);
+	return definition;
+}
+
+function renderImageResult(
+	definition: any,
+	cwd: string,
+	expanded: boolean,
+	showImages: boolean,
+	state: Record<string, unknown> = {},
+	overlayCheck?: () => boolean,
+): string[] {
+	const context: any = {
+		args: { path: "image.png" },
+		cwd,
+		invalidate() {},
+		showImages,
+		state,
+	};
+	if (overlayCheck) context[TOOL_RENDER_OVERLAY_CHECK_SYMBOL] = overlayCheck;
+	const component = definition.renderResult(
+		{
+			content: [
+				{ type: "text", text: "Read image file [image/png]" },
+				{ type: "image", data: imageData, mimeType: "image/png" },
+			],
+		},
+		{ expanded, isPartial: false },
+		{ bold: (text: string) => text, fg: (_token: string, text: string) => text },
+		context,
+	);
+	return component.render(40);
+}
+
+function hasTerminalImage(lines: string[]): boolean {
+	return lines.some((line) => line.includes("\x1b_G"));
+}
+
+describe("read image rendering", () => {
+	test("on follows expanded state across repeated toggles", () => {
+		const cwd = tempCwd("on");
+		const definition = readRenderer(cwd);
+		const state = {};
+		setCapabilities({ images: "kitty", trueColor: true, hyperlinks: true });
+
+		expect(hasTerminalImage(renderImageResult(definition, cwd, false, false, state))).toBe(false);
+		expect(hasTerminalImage(renderImageResult(definition, cwd, true, false, state))).toBe(true);
+		expect(hasTerminalImage(renderImageResult(definition, cwd, false, false, state))).toBe(false);
+		expect(hasTerminalImage(renderImageResult(definition, cwd, true, false, state))).toBe(true);
+	});
+
+	test("always shows images in collapsed and expanded output even when read text is hidden", () => {
+		const cwd = tempCwd("always", { readOutputMode: "hidden" });
+		const definition = readRenderer(cwd);
+		setCapabilities({ images: "kitty", trueColor: true, hyperlinks: true });
+
+		expect(hasTerminalImage(renderImageResult(definition, cwd, false, false))).toBe(true);
+		expect(hasTerminalImage(renderImageResult(definition, cwd, true, false))).toBe(true);
+	});
+
+	test("extension settings events refresh always and off immediately", () => {
+		const cwd = tempCwd("off");
+		const definition = readRenderer(cwd);
+		const state = {};
+		const settingsHandlers = new Set<(data: unknown) => void>();
+		const lifecycleHandlers = new Map<string, Array<() => void>>();
+		const pi = {
+			events: {
+				on(channel: string, handler: (data: unknown) => void) {
+					if (channel === "vstack:extension-settings-changed") settingsHandlers.add(handler);
+					return () => settingsHandlers.delete(handler);
+				},
+			},
+			on(event: string, handler: () => void) {
+				const handlers = lifecycleHandlers.get(event) ?? [];
+				handlers.push(handler);
+				lifecycleHandlers.set(event, handlers);
+			},
+		};
+		installLiveSettingsRefresh(pi as any);
+		setCapabilities({ images: "kitty", trueColor: true, hyperlinks: true });
+
+		let lines = renderImageResult(definition, cwd, false, false, state);
+		let renderRequests = 0;
+		trackToolExecutionComponent({
+			invalidate() {
+				lines = renderImageResult(definition, cwd, false, false, state);
+			},
+			ui: {
+				requestRender() {
+					renderRequests++;
+				},
+			},
+		});
+		const emitSetting = (value: ReadImageSetting) => {
+			writeImageMode(cwd, value);
+			for (const handler of settingsHandlers) {
+				handler({ extensionId: "@vanillagreen/pi-tool-renderer", key: "showReadImages", value });
+			}
+		};
+
+		expect(hasTerminalImage(lines)).toBe(false);
+		emitSetting("always");
+		expect(hasTerminalImage(lines)).toBe(true);
+		emitSetting("off");
+		expect(hasTerminalImage(lines)).toBe(false);
+		expect(renderRequests).toBe(2);
+
+		for (const handler of lifecycleHandlers.get("session_shutdown") ?? []) handler();
+	});
+
+	test("floating overlays hide images without removing their reserved rows", () => {
+		const cwd = tempCwd("always");
+		const definition = readRenderer(cwd);
+		const state = {};
+		let overlayActive = false;
+		setCapabilities({ images: "kitty", trueColor: true, hyperlinks: true });
+
+		const visibleLines = renderImageResult(definition, cwd, false, false, state, () => overlayActive);
+		overlayActive = true;
+		const hiddenLines = renderImageResult(definition, cwd, false, false, state, () => overlayActive);
+		overlayActive = false;
+		const restoredLines = renderImageResult(definition, cwd, false, false, state, () => overlayActive);
+
+		expect(hasTerminalImage(visibleLines)).toBe(true);
+		expect(hasTerminalImage(hiddenLines)).toBe(false);
+		expect(hiddenLines).toHaveLength(visibleLines.length);
+		expect(hiddenLines.some((line) => line.includes(RESERVED_IMAGE_ROW_MARKER))).toBe(true);
+		expect(hasTerminalImage(restoredLines)).toBe(true);
+		expect(restoredLines).toHaveLength(visibleLines.length);
+	});
+
+	test("off and an unset setting keep custom images hidden", () => {
+		setCapabilities({ images: "kitty", trueColor: true, hyperlinks: true });
+		for (const setting of ["off", undefined] as const) {
+			const cwd = tempCwd(setting);
+			const definition = readRenderer(cwd);
+			expect(hasTerminalImage(renderImageResult(definition, cwd, false, false))).toBe(false);
+			expect(hasTerminalImage(renderImageResult(definition, cwd, true, false))).toBe(false);
+		}
+	});
+
+	test("keeps boolean true compatible with expanded-only behavior", () => {
+		const cwd = tempCwd(true);
+		const definition = readRenderer(cwd);
+		setCapabilities({ images: "kitty", trueColor: true, hyperlinks: true });
+
+		expect(hasTerminalImage(renderImageResult(definition, cwd, false, false))).toBe(false);
+		expect(hasTerminalImage(renderImageResult(definition, cwd, true, false))).toBe(true);
+	});
+
+	test("does not duplicate Pi's built-in image rendering", () => {
+		const cwd = tempCwd("always");
+		const definition = readRenderer(cwd);
+		setCapabilities({ images: "kitty", trueColor: true, hyperlinks: true });
+
+		expect(hasTerminalImage(renderImageResult(definition, cwd, true, true))).toBe(false);
+	});
+});

--- a/pi-extensions/pi-tool-renderer/extensions/__tests__/tool-chrome.test.ts
+++ b/pi-extensions/pi-tool-renderer/extensions/__tests__/tool-chrome.test.ts
@@ -3,15 +3,19 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { visibleWidth } from "@earendil-works/pi-tui";
+import { Image, resetCapabilitiesCache, setCapabilities, visibleWidth } from "@earendil-works/pi-tui";
 
 import { stripAnsi } from "../tool-renderer/ansi.js";
-import { __test } from "../tool-renderer/chrome.js";
+import { __test, withResultTheme } from "../tool-renderer/chrome.js";
+import { clearTrackedToolExecutionComponents, refreshToolExecutionComponents } from "../tool-renderer/live-settings.js";
+import { RESERVED_IMAGE_ROW_MARKER, TOOL_RENDER_OVERLAY_CHECK_SYMBOL } from "../tool-renderer/overlay.js";
 import { recordProjectTrust } from "../tool-renderer/settings.js";
 
 const createdDirs: string[] = [];
 
 afterEach(() => {
+	resetCapabilitiesCache();
+	clearTrackedToolExecutionComponents();
 	for (const dir of createdDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
 });
 
@@ -69,5 +73,62 @@ describe("tool chrome", () => {
 		const rendered = ["", "● Bash $ echo hi", ""];
 
 		expect(__test.renderToolChromeLines(toolComponent(cwd), rendered, 40)).toEqual(rendered);
+	});
+
+	test("result renderers receive live overlay state and register for settings refresh", () => {
+		let overlayActive = false;
+		let invalidations = 0;
+		let renderRequests = 0;
+		const context: any = {};
+		const wrapped = withResultTheme(
+			{
+				invalidate: () => invalidations++,
+				ui: {
+					hasOverlay: () => overlayActive,
+					requestRender: () => renderRequests++,
+				},
+			},
+			(_result: any, _options: any, _theme: any, renderContext: any) => renderContext,
+		);
+
+		wrapped({}, {}, theme, context);
+		expect(context[TOOL_RENDER_OVERLAY_CHECK_SYMBOL]()).toBe(false);
+		overlayActive = true;
+		expect(context[TOOL_RENDER_OVERLAY_CHECK_SYMBOL]()).toBe(true);
+		refreshToolExecutionComponents();
+		expect(invalidations).toBe(1);
+		expect(renderRequests).toBe(1);
+	});
+
+	test("preserves blank rows reserved by Kitty image components", () => {
+		const cwd = tempCwd();
+		setCapabilities({ images: "kitty", trueColor: true, hyperlinks: true });
+		const image = new Image(
+			"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+			"image/png",
+			{ fallbackColor: (text: string) => text },
+			{ maxHeightCells: 3, maxWidthCells: 4 },
+		);
+		const imageLines = image.render(20);
+		const rendered = ["", "read image.png", "", ...imageLines];
+		const lines = __test.renderToolChromeLines(toolComponent(cwd), rendered, 20);
+		const imageLineIndex = lines.findIndex((line) => line.includes("\x1b_G"));
+
+		expect(imageLines.length).toBeGreaterThan(1);
+		expect(imageLineIndex).toBeGreaterThan(0);
+		expect(lines.slice(imageLineIndex + 1, -1)).toEqual(imageLines.slice(1));
+	});
+
+	test("preserves hidden image padding markers and trailing rows", () => {
+		const cwd = tempCwd();
+		const lines = __test.renderToolChromeLines(
+			toolComponent(cwd),
+			["", "read image.png", "", RESERVED_IMAGE_ROW_MARKER, "", ""],
+			20,
+		);
+		const markerIndex = lines.findIndex((line) => line.includes(RESERVED_IMAGE_ROW_MARKER));
+
+		expect(markerIndex).toBeGreaterThan(0);
+		expect(lines.slice(markerIndex + 1, -1)).toEqual(["", ""]);
 	});
 });

--- a/pi-extensions/pi-tool-renderer/extensions/tool-renderer.ts
+++ b/pi-extensions/pi-tool-renderer/extensions/tool-renderer.ts
@@ -16,6 +16,7 @@ import {
 	installSkillInvocationRenderer,
 	installUserMessageRenderer,
 } from "./tool-renderer/messages.js";
+import { installLiveSettingsRefresh } from "./tool-renderer/live-settings.js";
 import { recordProjectTrust, settingBoolean } from "./tool-renderer/settings.js";
 import { registerStackEvents } from "./tool-renderer/stack.js";
 import { registerBash, registerEdit, registerRead, registerReadOnly, registerWrite } from "./tool-renderer/tools.js";
@@ -31,6 +32,7 @@ export default async function toolRenderer(pi: ExtensionAPI): Promise<void> {
 
 	registerStackEvents(pi);
 	installToolExecutionRendererPatch(pi);
+	installLiveSettingsRefresh(pi);
 	installToolChromePatch();
 	registerToolChromeEvents(pi);
 	installWorkingLoaderAlignmentPatch();

--- a/pi-extensions/pi-tool-renderer/extensions/tool-renderer/chrome.ts
+++ b/pi-extensions/pi-tool-renderer/extensions/tool-renderer/chrome.ts
@@ -22,6 +22,8 @@ import {
 	componentDefinesRenderer,
 } from "./generic.js";
 import { settingBoolean, settingEnum, toolChromeMode } from "./settings.js";
+import { RESERVED_IMAGE_ROW_MARKER, TOOL_RENDER_OVERLAY_CHECK_SYMBOL } from "./overlay.js";
+import { trackToolExecutionComponent } from "./live-settings.js";
 import { glyphs } from "./glyphs.js";
 import { subtleRule } from "./theme.js";
 
@@ -44,6 +46,10 @@ export function withCallTheme(component: any, renderer: (args: any, theme: any, 
 export function withResultTheme(component: any, renderer: (result: any, options: any, theme: any, context: any) => any): (result: any, options: any, theme: any, context: any) => any {
 	return function renderResultWithRememberedTheme(this: any, result: any, options: any, theme: any, context: any) {
 		rememberToolChromeTheme(component, theme);
+		trackToolExecutionComponent(component);
+		if (context && typeof context === "object" && typeof component?.ui?.hasOverlay === "function") {
+			context[TOOL_RENDER_OVERLAY_CHECK_SYMBOL] = () => component.ui.hasOverlay();
+		}
 		return renderer.call(this, result, options, theme, context);
 	};
 }
@@ -130,11 +136,17 @@ function shouldOmitBottomToolChromeRule(core: string[]): boolean {
 	return core.some((line) => /(?:└─+(?:┴─+)?┘|\+-+(?:\+-+)?\+)/.test(stripAnsi(line ?? "")));
 }
 
+function isTerminalImageLine(line: string): boolean {
+	return line.includes("\x1b_G") || line.includes("\x1b]1337;File=") || line.includes(RESERVED_IMAGE_ROW_MARKER);
+}
+
 function renderedToolCore(rendered: string[], width: number, cwd?: string): string[] | undefined {
 	let start = 0;
 	while (start < rendered.length && stripAnsi(rendered[start] ?? "").trim().length === 0) start++;
 	let end = rendered.length - 1;
-	while (end >= start && stripAnsi(rendered[end] ?? "").trim().length === 0) end--;
+	if (!rendered.some(isTerminalImageLine)) {
+		while (end >= start && stripAnsi(rendered[end] ?? "").trim().length === 0) end--;
+	}
 	if (start > end) return undefined;
 	const renderWidth = stableRenderWidth(width, cwd);
 	return rendered.slice(start, end + 1).flatMap((line) => {

--- a/pi-extensions/pi-tool-renderer/extensions/tool-renderer/images.ts
+++ b/pi-extensions/pi-tool-renderer/extensions/tool-renderer/images.ts
@@ -1,0 +1,127 @@
+import { convertToPng } from "@earendil-works/pi-coding-agent";
+import { Container, getCapabilities, Image, Spacer } from "@earendil-works/pi-tui";
+
+import { floatingOverlayActive, RESERVED_IMAGE_ROW_MARKER } from "./overlay.js";
+import { readImageMode } from "./settings.js";
+
+type ImageConversionResult = Awaited<ReturnType<typeof convertToPng>>;
+
+function ignoreConversionError(): void {}
+
+class OverlayAwareImage {
+	private context: any;
+
+	constructor(private readonly image: Image, context: any) {
+		this.context = context;
+	}
+
+	setContext(context: any): void {
+		this.context = context;
+	}
+
+	invalidate(): void {
+		this.image.invalidate();
+	}
+
+	render(width: number): string[] {
+		const lines = this.image.render(width);
+		if (!floatingOverlayActive(this.context)) return lines;
+		return lines.map((_line, index) => index === 0 ? RESERVED_IMAGE_ROW_MARKER : "");
+	}
+}
+
+interface ReadImageBlock {
+	type: "image";
+	data: string;
+	mimeType: string;
+}
+
+interface ReadImageCacheEntry {
+	sourceData: string;
+	sourceMimeType: string;
+	converted?: NonNullable<ImageConversionResult>;
+	conversionStarted?: boolean;
+	renderedData?: string;
+	renderedMimeType?: string;
+	component?: OverlayAwareImage;
+}
+
+interface ReadImageRenderState {
+	entries: Map<number, ReadImageCacheEntry>;
+}
+
+function readImageBlocks(result: any): ReadImageBlock[] {
+	if (!Array.isArray(result?.content)) return [];
+	return result.content.filter(
+		(part: any): part is ReadImageBlock => part?.type === "image" && typeof part.data === "string" && typeof part.mimeType === "string",
+	);
+}
+
+function readImageRenderState(context: any): ReadImageRenderState {
+	const state = context?.state;
+	if (!state || typeof state !== "object") return { entries: new Map() };
+	const record = state as Record<string, unknown>;
+	if (!record.vstackReadImages || typeof record.vstackReadImages !== "object") {
+		record.vstackReadImages = { entries: new Map<number, ReadImageCacheEntry>() };
+	}
+	return record.vstackReadImages as ReadImageRenderState;
+}
+
+function readImageComponent(block: ReadImageBlock, index: number, theme: any, context: any): OverlayAwareImage | undefined {
+	const state = readImageRenderState(context);
+	let entry = state.entries.get(index);
+	if (!entry || entry.sourceData !== block.data || entry.sourceMimeType !== block.mimeType) {
+		entry = { sourceData: block.data, sourceMimeType: block.mimeType };
+		state.entries.set(index, entry);
+	}
+
+	let data = block.data;
+	let mimeType = block.mimeType;
+	if (getCapabilities().images === "kitty" && mimeType !== "image/png") {
+		if (!entry.converted) {
+			if (!entry.conversionStarted) {
+				entry.conversionStarted = true;
+				void convertToPng(data, mimeType).then((converted: ImageConversionResult) => {
+					if (state.entries.get(index) !== entry || !converted) return;
+					entry.converted = converted;
+					entry.component = undefined;
+					context?.invalidate?.();
+				}, ignoreConversionError);
+			}
+			return undefined;
+		}
+		data = entry.converted.data;
+		mimeType = entry.converted.mimeType;
+	}
+
+	if (!entry.component || entry.renderedData !== data || entry.renderedMimeType !== mimeType) {
+		entry.renderedData = data;
+		entry.renderedMimeType = mimeType;
+		const image = new Image(data, mimeType, { fallbackColor: (text: string) => theme.fg("toolOutput", text) });
+		entry.component = new OverlayAwareImage(image, context);
+	} else {
+		entry.component.setContext(context);
+	}
+	return entry.component;
+}
+
+export function renderReadImages(component: any, result: any, expanded: boolean, theme: any, context: any, cwd: string): any {
+	const effectiveCwd = context?.cwd ?? cwd;
+	const mode = readImageMode(effectiveCwd);
+	if (mode === "off" || (mode === "on" && !expanded) || context?.showImages !== false) return component;
+	if (!getCapabilities().images) return component;
+	const blocks = readImageBlocks(result);
+	if (blocks.length === 0) return component;
+
+	const container = new Container();
+	container.addChild(component);
+	let hasImages = false;
+	for (const [index, block] of blocks.entries()) {
+		const image = readImageComponent(block, index, theme, context);
+		if (!image) continue;
+		container.addChild(new Spacer(1));
+		container.addChild(image);
+		hasImages = true;
+	}
+	return hasImages ? container : component;
+}

--- a/pi-extensions/pi-tool-renderer/extensions/tool-renderer/live-settings.ts
+++ b/pi-extensions/pi-tool-renderer/extensions/tool-renderer/live-settings.ts
@@ -1,0 +1,61 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+import { CONFIG_ID } from "./settings.js";
+
+const SETTINGS_EVENT = "vstack:extension-settings-changed";
+
+interface ToolExecutionUi {
+	requestRender?: () => void;
+}
+
+interface TrackedToolExecutionComponent {
+	invalidate?: () => void;
+	ui?: ToolExecutionUi;
+}
+
+const activeToolExecutionComponents = new Set<TrackedToolExecutionComponent>();
+
+interface ExtensionSettingChange {
+	extensionId?: unknown;
+	key?: unknown;
+}
+
+export function trackToolExecutionComponent(component: unknown): void {
+	if (component && typeof component === "object") activeToolExecutionComponents.add(component as TrackedToolExecutionComponent);
+}
+
+export function refreshToolExecutionComponents(): void {
+	const userInterfaces = new Set<ToolExecutionUi>();
+	for (const component of activeToolExecutionComponents) {
+		if (component.ui) userInterfaces.add(component.ui);
+		try {
+			component.invalidate?.();
+		} catch {
+			// Ignore stale components left behind by a session transition.
+		}
+	}
+	for (const ui of userInterfaces) {
+		try {
+			ui.requestRender?.();
+		} catch {
+			// Ignore stale TUI instances left behind by a session transition.
+		}
+	}
+}
+
+export function clearTrackedToolExecutionComponents(): void {
+	activeToolExecutionComponents.clear();
+}
+
+export function installLiveSettingsRefresh(pi: ExtensionAPI): void {
+	const unsubscribe = pi.events.on(SETTINGS_EVENT, (data: unknown) => {
+		const change = data as ExtensionSettingChange | undefined;
+		if (change?.extensionId !== CONFIG_ID || change.key !== "showReadImages") return;
+		refreshToolExecutionComponents();
+	});
+	pi.on("session_start", clearTrackedToolExecutionComponents);
+	pi.on("session_shutdown", () => {
+		unsubscribe();
+		clearTrackedToolExecutionComponents();
+	});
+}

--- a/pi-extensions/pi-tool-renderer/extensions/tool-renderer/overlay.ts
+++ b/pi-extensions/pi-tool-renderer/extensions/tool-renderer/overlay.ts
@@ -1,0 +1,21 @@
+export const TOOL_RENDER_OVERLAY_CHECK_SYMBOL = Symbol.for("vstack.pi-tool-renderer.overlay-check");
+export const RESERVED_IMAGE_ROW_MARKER = "\x1b[0m\x1b[0m";
+
+const VSTACK_MODAL_LOCK_SYMBOL = Symbol.for("vstack.pi.modal-lock");
+
+interface VstackModalLock {
+	depth: number;
+}
+
+export function floatingOverlayActive(context: any): boolean {
+	const checker = context?.[TOOL_RENDER_OVERLAY_CHECK_SYMBOL];
+	if (typeof checker === "function") {
+		try {
+			return checker() === true;
+		} catch {
+			return false;
+		}
+	}
+	const lock = (globalThis as unknown as Record<PropertyKey, unknown>)[VSTACK_MODAL_LOCK_SYMBOL] as VstackModalLock | undefined;
+	return typeof lock?.depth === "number" && lock.depth > 0;
+}

--- a/pi-extensions/pi-tool-renderer/extensions/tool-renderer/settings.ts
+++ b/pi-extensions/pi-tool-renderer/extensions/tool-renderer/settings.ts
@@ -121,12 +121,20 @@ export function stackShell(cwd?: string): { renderShell?: "self" } {
 }
 
 export type ReadOutputMode = "hidden" | "summary" | "preview";
+export type ReadImageMode = "off" | "always" | "on";
 export type SearchOutputMode = "hidden" | "count" | "preview";
 export type BashOutputMode = "hidden" | "summary" | "opencode" | "preview";
 export type McpOutputMode = "hidden" | "summary" | "preview";
 
 export function readOutputMode(cwd?: string): ReadOutputMode {
 	return settingEnum("readOutputMode", ["hidden", "summary", "preview"] as const, "preview", cwd);
+}
+
+export function readImageMode(cwd?: string): ReadImageMode {
+	const value = readVstackConfig(cwd).showReadImages;
+	if (value === true || value === "on") return "on";
+	if (value === "always") return "always";
+	return "off";
 }
 
 export function searchOutputMode(cwd?: string): SearchOutputMode {

--- a/pi-extensions/pi-tool-renderer/extensions/tool-renderer/tools.ts
+++ b/pi-extensions/pi-tool-renderer/extensions/tool-renderer/tools.ts
@@ -15,6 +15,7 @@ import {
 	suppressReadOnlyBashDiffOutput,
 	type StructuredDiff,
 } from "./diff.js";
+import { renderReadImages } from "./images.js";
 import {
 	bashLiveOutputDelayMs,
 	bashLiveTailLines,
@@ -154,7 +155,7 @@ export function registerRead(pi: ExtensionAPI, agent: any, cwd: string): void {
 			const count = lineCount(content);
 			const summary = readResultSummary(result, context?.args ?? {}, theme);
 			const mode = readOutputMode(context?.cwd ?? cwd);
-			if (mode === "hidden") return makeEmpty();
+			if (mode === "hidden") return renderReadImages(makeEmpty(), result, expanded, theme, context, cwd);
 			let text = `${stackPrefix(theme)}${call}${theme.fg("dim", " · ")}${summary}`;
 			if (mode === "preview" && expanded && content) {
 				const limit = Math.max(1, Math.floor(settingNumber("readPreviewLines", 80, context?.cwd)));
@@ -164,7 +165,7 @@ export function registerRead(pi: ExtensionAPI, agent: any, cwd: string): void {
 					.join("\n")}`;
 				if (count > limit) text += `\n${treeConnector(theme, "│")}${theme.fg("muted", `… ${count - limit} more line(s)`)}`;
 			}
-			return makeTruncatedLines(text);
+			return renderReadImages(makeTruncatedLines(text), result, expanded, theme, context, cwd);
 		},
 	});
 }

--- a/pi-extensions/pi-tool-renderer/package.json
+++ b/pi-extensions/pi-tool-renderer/package.json
@@ -276,6 +276,20 @@
           "apply": "live"
         },
         {
+          "key": "showReadImages",
+          "label": "Read image display",
+          "description": "Image results when Pi terminal.showImages is false: off hides them, always shows them in read output, and on shows them only while tools are expanded. Changes apply immediately. Floating overlays temporarily hide images while preserving their layout space.",
+          "type": "enum",
+          "enumValues": [
+            "off",
+            "always",
+            "on"
+          ],
+          "default": "off",
+          "category": "Read",
+          "apply": "live"
+        },
+        {
           "key": "searchPreviewLines",
           "label": "Expanded search/list preview lines",
           "description": "Head lines shown for grep/find/ls when expanded.",


### PR DESCRIPTION
This takes a stab at #624 by adding a native option to `pi-tool-renderer` to do image rendering in supported terminals. I have tested this in Kitty and WezTerm. Let me know if you need any changes or improvements!

**Read image rendering**

- Add extension-owned image rendering for `read` results when Pi's native `terminal.showImages` setting is disabled.
- Support `off`, `always`, and expanded-only `on` modes while preserving boolean compatibility.
- Convert non-PNG images for Kitty terminals and prevent duplicate native/custom rendering.

**UI behavior**

- Temporarily hide terminal graphics under floating overlays while preserving their layout space.
- Restore images when overlays close.
- Apply Extension Settings changes immediately without requiring tool expansion toggles.

**Tests**

- Cover image modes, live settings updates, overlay suppression, row preservation, conversion behavior, and duplicate prevention.

Closes #624

> *Note:* this was done in conjunction with GPT 5.6 Sol high reasoning.

EDIT: Just a heads up, I have tested the CI/CD on my fork as well to make sure things are passing: https://github.com/mehalter/vstack/actions/runs/29747999766?pr=1