### PR TITLE
docs(pi-tool-renderer): condense Read image display README row

### DIFF
--- a/pi-extensions/pi-tool-renderer/README.md
+++ b/pi-extensions/pi-tool-renderer/README.md
@@ -93,7 +93,7 @@ Glyph style: each package exposes `glyphStyle` (`unicode` default, `ascii` for t
 | Setting | What it does |
 | --- | --- |
 | Read output mode | `preview`, `summary`, or `hidden`. |
-| Read image display | With Pi `terminal.showImages=false`: `off` hides images, `always` shows them in read output, and `on` shows them only while tools are expanded. Changes from Extension Settings apply immediately. Floating overlays temporarily hide images but keep their layout space. |
+| Read image display | `off`, `always`, or `on` (expanded-only); requires Pi `terminal.showImages=false`. |
 | Search output mode | `preview`, `count`, or `hidden`. |
 | Bash output mode | `opencode`, `preview`, `summary`, or `hidden`. |
 | Live bash output delay (ms) | Wait this long before showing a running bash output tail. |


### PR DESCRIPTION
Follow-up to #763. The `Read image display` settings-table row landed as a four-clause paragraph; every other row in that table is a single terse clause. Condensed to the enum values + the `terminal.showImages=false` precondition, dropping the applies-immediately / floating-overlay prose (that behavior lives in the code and the SKILL, not the settings quick-reference).

Docs-only, one line.