### PR TITLE
fix(github): block merges on unresolved review threads

### DIFF
--- a/skills/github/README.md
+++ b/skills/github/README.md
@@ -66,7 +66,8 @@ failed or cancelled checks remain `ci_failed: ...` and are not transient.
 Actionable review threads (unresolved and not outdated), plus failures to read
 thread state, are permanent blockers. They stop both immediate merge and
 `--auto` before any merge or queue mutation. Only the explicit, dangerous
-`--force` flag bypasses that safety gate.
+`--force` flag bypasses that safety gate. Thread retrieval follows every
+GraphQL page and fails rather than treating an incomplete list as clean.
 Merge execution is exact-head guarded. A successful mutation returns exit `0`
 when already merged, exit `75` with a distinct message when either a required
 merge-queue entry or classic auto-merge is active, and exit `1` when no merged,

--- a/skills/github/README.md
+++ b/skills/github/README.md
@@ -63,6 +63,10 @@ keeps the raw `gh`/`op` detail for logs.
 `pr-merge --check` reports still-running checks as `ci_pending: ...` and sets
 `transient: true` when those pending checks are the only blockers. Terminal
 failed or cancelled checks remain `ci_failed: ...` and are not transient.
+Actionable review threads (unresolved and not outdated), plus failures to read
+thread state, are permanent blockers. They stop both immediate merge and
+`--auto` before any merge or queue mutation. Only the explicit, dangerous
+`--force` flag bypasses that safety gate.
 Merge execution is exact-head guarded. A successful mutation returns exit `0`
 when already merged, exit `75` with a distinct message when either a required
 merge-queue entry or classic auto-merge is active, and exit `1` when no merged,

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -26,7 +26,7 @@ CLI wrapper for GitHub API operations used in PR workflows. Provides structured 
 |---------|---------|
 | `pr-data <N> [--actionable]` | Get PR with threads, comments, files. `--actionable`: unresolved non-outdated only. |
 | `pr-view [N] [--json FIELDS]` | View PR details (wraps gh pr view with bounded auth/no-PR errors) |
-| `pr-threads <N> [--unresolved]` | Get thread list/count |
+| `pr-threads <N> [--unresolved]` | Get the complete paginated thread list/count; fails rather than returning a partial list. |
 | `pr-review-status <N> [--baseline-ts TS --baseline-threads N]` | Check review state, determine if action needed |
 | `pr-list-ready [--all] [--format=safe\|table]` | List PRs ready for merge |
 | `pr-list-failing [--all] [--format=safe\|table]` | List PRs with CI failures |

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -32,7 +32,7 @@ CLI wrapper for GitHub API operations used in PR workflows. Provides structured 
 | `pr-list-failing [--all] [--format=safe\|table]` | List PRs with CI failures |
 | `pr-create [--title T] [--body B \| --body-file PATH] [--draft] [--dry-run] [--force]` | Create PR as bot. Safety checks: not main, has commits, pushed. Prefer `--body-file` for Markdown with backticks/code fences; `--body` is safe only for plain strings. `--force` skips checks. |
 | `pr-edit-body <N> --body-file PATH` | Update an existing PR body through the sanitized router. |
-| `pr-merge <N> [--check\|--force\|--auto]` | Merge PR. `--check`: JSON readiness only. `--auto`: queue for auto-merge if blocked now. Three exit codes — see below. |
+| `pr-merge <N> [--check\|--force\|--auto]` | Merge PR. `--check`: JSON readiness only. `--auto`: queue for auto-merge if blocked now, but never bypass actionable review threads. `--force`: deliberate override of all safety checks. Three exit codes — see below. |
 | `pr-cross-check [N...] [--quick\|--verify]` | Cross-PR analysis. `--verify`: full build+test (auto-detects build system). |
 | `pr-issue <N> [--format=safe\|text]` | Extract issue ID from PR branch (configurable via `GH_ISSUE_PATTERN`) |
 | `label-add <PR-or-issue> <label> [--reason TEXT] [--issue] [--required\|--optional]` | Check the live label inventory, then add a label through an authoritative REST capability boundary; direct script execution also loads current-project env. |
@@ -127,6 +127,12 @@ membership with GraphQL because `gh pr view --json` does not expose
 `mergeQueueEntry`. An `OPEN` PR with no `autoMergeRequest` is therefore still a
 successful exit `75` when its required merge-queue entry is active; an `OPEN`
 PR with neither queue nor auto-merge proof fails closed.
+
+Actionable review threads (unresolved and not outdated) are a hard local gate.
+They make `can_merge` false and block both immediate merge and `--auto` before
+any merge or queue mutation. A failed or malformed thread lookup also blocks,
+because an unknown review state cannot be treated as clean. The documented
+`--force` flag is the only deliberate override and skips every safety check.
 
 A BLOCKED outcome is further classified on stderr as **transient** (mergeable
 UNKNOWN, `ci_pending`, CI fetch uncertainty — caller should

--- a/skills/github/scripts/commands/pr-merge.sh
+++ b/skills/github/scripts/commands/pr-merge.sh
@@ -7,6 +7,10 @@
 #   75  QUEUED / AUTO-MERGE     — merge queue entry or classic auto-merge is active
 #   1   BLOCKED                — checks failed; no merge attempted, none queued
 #
+# Actionable unresolved review threads are a local hard gate: neither an
+# immediate merge nor `--auto` may mutate merge state while they remain. Only
+# the deliberately dangerous `--force` override skips this gate.
+#
 # `--auto` is idempotent for merge-queue repositories: a re-invocation on a PR
 # that is already enrolled reports QUEUED (75) from the authoritative post-call
 # snapshot, not BLOCKED, even though `gh pr merge --auto` exits nonzero when the
@@ -86,12 +90,13 @@ Options:
   --force          Skip checks and merge (requires explicit user decision)
   --auto           If immediate merge is blocked, enable GitHub auto-merge
                    (will fire when CI + branch protection clear). Exits 75.
+                   Never bypasses actionable unresolved review threads.
   --dry-run        Show what would happen without merging
 
 Modes:
   (default)        Run checks, block if critical issues, merge if pass
   --check          Run checks, output JSON for workflow to parse
-  --force          Skip all checks, merge immediately
+  --force          Deliberately skip all checks, including review threads
   --auto           Enable auto-merge when immediate merge is blocked
 
 Exit codes:
@@ -183,11 +188,29 @@ run_checks() {
         fi
     fi
 
-    # 3. Check unresolved threads
-    local unresolved
-    unresolved=$("$SCRIPT_DIR/pr-threads.sh" "$pr_num" --unresolved 2>/dev/null | jq -r '.unresolved_count // 0')
-    if [ "$unresolved" != "0" ]; then
-        warnings+=("unresolved_threads: $unresolved thread(s) need attention")
+    # 3. Check actionable review threads. GitHub does not protect merges on
+    # unresolved conversations by default, so this is a local hard gate rather
+    # than a warning. Outdated threads no longer refer to the current diff and
+    # are not actionable. A failed or malformed lookup also blocks: treating an
+    # unknown review state as clean would recreate the unsafe merge path.
+    local threads_json unresolved
+    if ! threads_json=$("$SCRIPT_DIR/pr-threads.sh" "$pr_num" --unresolved 2>/dev/null); then
+        can_merge=false
+        issues+=("review_threads_fetch_failed: Failed to fetch actionable review threads from GitHub")
+    elif ! jq -e '
+        (.threads | type == "array") and
+        all(.threads[];
+            (.is_resolved | type == "boolean") and
+            (.is_outdated | type == "boolean"))
+    ' >/dev/null 2>&1 <<<"$threads_json"; then
+        can_merge=false
+        issues+=("review_threads_fetch_failed: GitHub returned malformed review thread data")
+    else
+        unresolved=$(jq '[.threads[] | select(.is_resolved == false and .is_outdated == false)] | length' <<<"$threads_json")
+        if [ "$unresolved" -gt 0 ]; then
+            can_merge=false
+            issues+=("unresolved_threads: $unresolved actionable thread(s) need attention")
+        fi
     fi
 
     # 4. Check review status
@@ -264,7 +287,11 @@ print_blocked() {
     if [ "$transient" = "true" ]; then
         echo "Hint: github.sh await-mergeable $pr_num && retry" >&2
     fi
-    echo "Use --auto to queue for auto-merge, or --force to merge anyway." >&2
+    if echo "$check_result" | jq -e '[.issues[] | select(test("^(unresolved_threads|review_threads_fetch_failed):"))] | length > 0' >/dev/null 2>&1; then
+        echo "Resolve the review-thread gate and retry. Use --force only after an explicit decision to override it." >&2
+    else
+        echo "Use --auto to queue for auto-merge, or --force after an explicit decision to override safety checks." >&2
+    fi
 }
 
 # Run gh with the same effective identity used for the merge mutation. Keep the
@@ -417,9 +444,15 @@ main() {
         can_merge=$(echo "$check_result" | jq -r '.can_merge')
 
         if [ "$can_merge" != "true" ]; then
+            # `--auto` may defer GitHub-enforced blockers, but it must never
+            # bypass local review-thread safety. GitHub can otherwise accept
+            # and immediately merge a PR whose conversations remain open.
+            local has_review_thread_gate
+            has_review_thread_gate=$(echo "$check_result" | jq '[.issues[] | select(test("^(unresolved_threads|review_threads_fetch_failed):"))] | length > 0')
+
             # If --auto, fall through to enable auto-merge below.
             # Otherwise, exit BLOCKED with breakdown.
-            if [ "$auto" != true ]; then
+            if [ "$auto" != true ] || [ "$has_review_thread_gate" = "true" ]; then
                 local blocked_severity
                 blocked_severity=$(merge_blocked_severity "$check_result")
                 local block_args=(

--- a/skills/github/scripts/commands/pr-merge.sh
+++ b/skills/github/scripts/commands/pr-merge.sh
@@ -194,7 +194,10 @@ run_checks() {
     # are not actionable. A failed or malformed lookup also blocks: treating an
     # unknown review state as clean would recreate the unsafe merge path.
     local threads_json unresolved
-    if ! threads_json=$("$SCRIPT_DIR/pr-threads.sh" "$pr_num" --unresolved 2>/dev/null); then
+    # Fetch the complete unfiltered list. Filtering unresolved threads inside
+    # pr-threads would discard nodes whose isResolved value is missing, null,
+    # or malformed before this trust-boundary validation can reject them.
+    if ! threads_json=$("$SCRIPT_DIR/pr-threads.sh" "$pr_num" 2>/dev/null); then
         can_merge=false
         issues+=("review_threads_fetch_failed: Failed to fetch actionable review threads from GitHub")
     elif ! jq -e '

--- a/skills/github/scripts/commands/pr-threads.sh
+++ b/skills/github/scripts/commands/pr-threads.sh
@@ -91,12 +91,15 @@ get_pr_threads() {
     owner=$(get_owner "$repo_info")
     repo=$(get_repo "$repo_info")
 
-    # GraphQL query
-    local query='
+    # GitHub caps one reviewThreads connection page at 100 nodes. Fetch every
+    # page before emitting anything so merge callers cannot mistake a partial
+    # result for a clean review state.
+    local initial_query='
 query($owner: String!, $repo: String!, $number: Int!) {
   repository(owner: $owner, name: $repo) {
     pullRequest(number: $number) {
       reviewThreads(first: 100) {
+        pageInfo { hasNextPage endCursor }
         nodes {
           id
           isResolved
@@ -115,8 +118,89 @@ query($owner: String!, $repo: String!, $number: Int!) {
   }
 }'
 
+    local page_query='
+query($owner: String!, $repo: String!, $number: Int!, $cursor: String!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 100, after: $cursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          isResolved
+          isOutdated
+          path
+          line
+          comments(first: 1) {
+            nodes {
+              author { login }
+              body
+            }
+          }
+        }
+      }
+    }
+  }
+}'
+
+    local all_nodes='[]'
+    local cursor="" page_count=0
+    while :; do
+        page_count=$((page_count + 1))
+        if [ "$page_count" -gt 1000 ]; then
+            echo '{"error": "Review thread pagination exceeded safety limit"}' >&2
+            exit 1
+        fi
+
+        local page_result
+        if [ -z "$cursor" ]; then
+            page_result=$(gh_graphql "$initial_query" -F owner="$owner" -F repo="$repo" -F number="$pr_num") || exit 1
+        else
+            page_result=$(gh_graphql "$page_query" -F owner="$owner" -F repo="$repo" -F number="$pr_num" -F cursor="$cursor") || exit 1
+        fi
+
+        # Fail closed on a missing PR, malformed nodes, or a next-page flag
+        # without a usable cursor. No partial list is printed on failure.
+        if ! jq -e '
+            .repository.pullRequest.reviewThreads as $threads |
+            ($threads | type == "object") and
+            ($threads.nodes | type == "array") and
+            ($threads.pageInfo.hasNextPage | type == "boolean") and
+            (($threads.pageInfo.hasNextPage == false) or
+             (($threads.pageInfo.endCursor | type) == "string" and
+              ($threads.pageInfo.endCursor | length) > 0))
+        ' >/dev/null 2>&1 <<<"$page_result"; then
+            echo '{"error": "GitHub returned malformed review thread pagination data"}' >&2
+            exit 1
+        fi
+
+        local page_nodes has_next next_cursor
+        page_nodes=$(jq -c '.repository.pullRequest.reviewThreads.nodes' <<<"$page_result") || exit 1
+        all_nodes=$(jq -cn --argjson accumulated "$all_nodes" --argjson page "$page_nodes" '$accumulated + $page') || exit 1
+        has_next=$(jq -r '.repository.pullRequest.reviewThreads.pageInfo.hasNextPage' <<<"$page_result") || exit 1
+
+        if [ "$has_next" = "false" ]; then
+            break
+        fi
+
+        next_cursor=$(jq -r '.repository.pullRequest.reviewThreads.pageInfo.endCursor' <<<"$page_result") || exit 1
+        if [ "$next_cursor" = "$cursor" ]; then
+            echo '{"error": "GitHub review thread pagination cursor did not advance"}' >&2
+            exit 1
+        fi
+        cursor="$next_cursor"
+    done
+
     local result
-    result=$(gh_graphql "$query" -F owner="$owner" -F repo="$repo" -F number="$pr_num") || exit 1
+    result=$(jq -cn --argjson nodes "$all_nodes" '{
+        repository: {
+            pullRequest: {
+                reviewThreads: {
+                    nodes: $nodes,
+                    pageInfo: {hasNextPage: false, endCursor: null}
+                }
+            }
+        }
+    }') || exit 1
 
     # Apply format and filters
     case "$FORMAT" in

--- a/skills/github/scripts/commands/pr-threads.sh
+++ b/skills/github/scripts/commands/pr-threads.sh
@@ -175,7 +175,11 @@ query($owner: String!, $repo: String!, $number: Int!, $cursor: String!) {
 
         local page_nodes has_next next_cursor
         page_nodes=$(jq -c '.repository.pullRequest.reviewThreads.nodes' <<<"$page_result") || exit 1
-        all_nodes=$(jq -cn --argjson accumulated "$all_nodes" --argjson page "$page_nodes" '$accumulated + $page') || exit 1
+        # Keep review bodies out of exec arguments: a handful of maximum-size
+        # comments can exceed macOS ARG_MAX even though the API response is
+        # valid. Two compact JSON values on stdin let jq merge without an OS
+        # argument-size ceiling.
+        all_nodes=$(printf '%s\n%s\n' "$all_nodes" "$page_nodes" | jq -sc '.[0] + .[1]') || exit 1
         has_next=$(jq -r '.repository.pullRequest.reviewThreads.pageInfo.hasNextPage' <<<"$page_result") || exit 1
 
         if [ "$has_next" = "false" ]; then
@@ -191,11 +195,13 @@ query($owner: String!, $repo: String!, $number: Int!, $cursor: String!) {
     done
 
     local result
-    result=$(jq -cn --argjson nodes "$all_nodes" '{
+    # The complete multi-page result can be larger still; wrap stdin rather
+    # than copying it into jq's argv.
+    result=$(printf '%s\n' "$all_nodes" | jq -c '{
         repository: {
             pullRequest: {
                 reviewThreads: {
-                    nodes: $nodes,
+                    nodes: .,
                     pageInfo: {hasNextPage: false, endCursor: null}
                 }
             }

--- a/skills/github/tests/pr-merge.sh
+++ b/skills/github/tests/pr-merge.sh
@@ -286,6 +286,26 @@ outdated_threads='[{"id":"PRRT_outdated","isResolved":false,"isOutdated":true,"p
 out=$(STUB_CHECKS="$checks" STUB_THREADS_JSON="$outdated_threads" run_check)
 assert_eq "$(jq -r .can_merge <<<"$out")" "true" "outdated unresolved thread is not actionable"
 
+malformed_threads='[
+  {"id":"PRRT_null","isResolved":null,"isOutdated":false,"path":"src/null.rs","line":1,"comments":{"nodes":[]}},
+  {"id":"PRRT_missing","isOutdated":false,"path":"src/missing.rs","line":2,"comments":{"nodes":[]}},
+  {"id":"PRRT_string","isResolved":"false","isOutdated":false,"path":"src/string.rs","line":3,"comments":{"nodes":[]}}
+]'
+out=$(STUB_CHECKS="$checks" STUB_THREADS_JSON="$malformed_threads" run_check)
+assert_eq "$(jq -r .can_merge <<<"$out")" "false" "malformed thread state blocks readiness"
+assert_contains "$(jq -r '.issues[]' <<<"$out")" "review_threads_fetch_failed: GitHub returned malformed review thread data" "malformed node reaches trust-boundary validation"
+
+: >"$call_log"
+set +e
+out=$(STUB_CHECKS="$checks" \
+    STUB_THREADS_JSON="$malformed_threads" \
+    STUB_CALL_LOG="$call_log" \
+    run_merge 2>&1)
+status=$?
+set -e
+assert_eq "$status" "1" "malformed thread state blocks --auto"
+assert_not_contains "$(cat "$call_log")" "pr merge" "malformed thread state never invokes gh pr merge"
+
 # Forty valid maximum-size comment bodies produce a ~2.5 MiB page, exceeding
 # macOS ARG_MAX (and typical Linux ARG_MAX). The query boundary must stream
 # this payload through jq stdin rather than fail while constructing argv.

--- a/skills/github/tests/pr-merge.sh
+++ b/skills/github/tests/pr-merge.sh
@@ -95,6 +95,20 @@ case "${1:-}" in
                 echo '{"errors":[{"message":"review threads unavailable"}]}'
                 exit 1
             fi
+            if [[ "${STUB_THREADS_LARGE_PAGE:-false}" == "true" ]]; then
+                jq -cn '{data:{repository:{pullRequest:{reviewThreads:{
+                    nodes: [range(0; 40) | {
+                        id: ("PRRT_large_" + tostring),
+                        isResolved: true,
+                        isOutdated: false,
+                        path: "src/large-page.rs",
+                        line: .,
+                        comments: {nodes: [{author: {login: "reviewer"}, body: ("x" * 65536)}]}
+                    }],
+                    pageInfo:{hasNextPage:false,endCursor:null}
+                }}}}}'
+                exit 0
+            fi
             if [[ "$*" == *"cursor=cursor-page-2"* ]]; then
                 if [[ "${STUB_THREADS_PAGE2_FETCH_FAIL:-false}" == "true" ]]; then
                     echo '{"errors":[{"message":"second review thread page unavailable"}]}'
@@ -271,6 +285,12 @@ assert_not_contains "$(cat "$call_log")" "pr merge" "immediate path never invoke
 outdated_threads='[{"id":"PRRT_outdated","isResolved":false,"isOutdated":true,"path":"src/old.rs","line":7,"comments":{"nodes":[{"author":{"login":"reviewer"},"body":"Stale diff"}]}}]'
 out=$(STUB_CHECKS="$checks" STUB_THREADS_JSON="$outdated_threads" run_check)
 assert_eq "$(jq -r .can_merge <<<"$out")" "true" "outdated unresolved thread is not actionable"
+
+# Forty valid maximum-size comment bodies produce a ~2.5 MiB page, exceeding
+# macOS ARG_MAX (and typical Linux ARG_MAX). The query boundary must stream
+# this payload through jq stdin rather than fail while constructing argv.
+out=$(STUB_CHECKS="$checks" STUB_THREADS_LARGE_PAGE=true run_check)
+assert_eq "$(jq -r .can_merge <<<"$out")" "true" "large valid review page avoids ARG_MAX failure"
 
 first_page_threads=$(jq -cn '[range(0; 100) | {
     id: ("PRRT_resolved_" + tostring),

--- a/skills/github/tests/pr-merge.sh
+++ b/skills/github/tests/pr-merge.sh
@@ -95,8 +95,27 @@ case "${1:-}" in
                 echo '{"errors":[{"message":"review threads unavailable"}]}'
                 exit 1
             fi
-            jq -cn --argjson nodes "${STUB_THREADS_JSON:-[]}" \
-                '{data:{repository:{pullRequest:{reviewThreads:{nodes:$nodes}}}}}'
+            if [[ "$*" == *"cursor=cursor-page-2"* ]]; then
+                if [[ "${STUB_THREADS_PAGE2_FETCH_FAIL:-false}" == "true" ]]; then
+                    echo '{"errors":[{"message":"second review thread page unavailable"}]}'
+                    exit 1
+                fi
+                if [[ "${STUB_THREADS_PAGE2_MALFORMED:-false}" == "true" ]]; then
+                    jq -cn --argjson nodes "${STUB_THREADS_PAGE2_JSON:-[]}" \
+                        '{data:{repository:{pullRequest:{reviewThreads:{nodes:$nodes,pageInfo:{hasNextPage:true,endCursor:null}}}}}}'
+                    exit 0
+                fi
+                jq -cn --argjson nodes "${STUB_THREADS_PAGE2_JSON:-[]}" \
+                    '{data:{repository:{pullRequest:{reviewThreads:{nodes:$nodes,pageInfo:{hasNextPage:false,endCursor:null}}}}}}'
+                exit 0
+            fi
+            if [[ -n "${STUB_THREADS_PAGE2_JSON:-}" ]]; then
+                jq -cn --argjson nodes "${STUB_THREADS_JSON:-[]}" \
+                    '{data:{repository:{pullRequest:{reviewThreads:{nodes:$nodes,pageInfo:{hasNextPage:true,endCursor:"cursor-page-2"}}}}}}'
+            else
+                jq -cn --argjson nodes "${STUB_THREADS_JSON:-[]}" \
+                    '{data:{repository:{pullRequest:{reviewThreads:{nodes:$nodes,pageInfo:{hasNextPage:false,endCursor:null}}}}}}'
+            fi
             exit 0
         fi
         ;;
@@ -252,6 +271,49 @@ assert_not_contains "$(cat "$call_log")" "pr merge" "immediate path never invoke
 outdated_threads='[{"id":"PRRT_outdated","isResolved":false,"isOutdated":true,"path":"src/old.rs","line":7,"comments":{"nodes":[{"author":{"login":"reviewer"},"body":"Stale diff"}]}}]'
 out=$(STUB_CHECKS="$checks" STUB_THREADS_JSON="$outdated_threads" run_check)
 assert_eq "$(jq -r .can_merge <<<"$out")" "true" "outdated unresolved thread is not actionable"
+
+first_page_threads=$(jq -cn '[range(0; 100) | {
+    id: ("PRRT_resolved_" + tostring),
+    isResolved: true,
+    isOutdated: false,
+    path: "src/first-page.rs",
+    line: .,
+    comments: {nodes: [{author: {login: "reviewer"}, body: "Resolved"}]}
+}]')
+out=$(STUB_CHECKS="$checks" \
+    STUB_THREADS_JSON="$first_page_threads" \
+    STUB_THREADS_PAGE2_JSON="$actionable_threads" \
+    run_check)
+assert_eq "$(jq -r .can_merge <<<"$out")" "false" "actionable thread after first 100 blocks readiness"
+assert_contains "$(jq -r '.issues[]' <<<"$out")" "unresolved_threads: 1 actionable thread(s)" "second-page blocker reaches merge gate"
+
+: >"$call_log"
+set +e
+out=$(STUB_CHECKS="$checks" \
+    STUB_THREADS_JSON="$first_page_threads" \
+    STUB_THREADS_PAGE2_JSON='[]' \
+    STUB_THREADS_PAGE2_FETCH_FAIL=true \
+    STUB_CALL_LOG="$call_log" \
+    run_merge 2>&1)
+status=$?
+set -e
+assert_eq "$status" "1" "second-page fetch failure blocks --auto"
+assert_contains "$out" "review_threads_fetch_failed:" "second-page failure reaches fail-closed merge gate"
+assert_not_contains "$(cat "$call_log")" "pr merge" "second-page failure never invokes gh pr merge"
+
+: >"$call_log"
+set +e
+out=$(STUB_CHECKS="$checks" \
+    STUB_THREADS_JSON="$first_page_threads" \
+    STUB_THREADS_PAGE2_JSON='[]' \
+    STUB_THREADS_PAGE2_MALFORMED=true \
+    STUB_CALL_LOG="$call_log" \
+    run_merge 2>&1)
+status=$?
+set -e
+assert_eq "$status" "1" "malformed second-page cursor state blocks --auto"
+assert_contains "$out" "review_threads_fetch_failed:" "malformed pagination reaches fail-closed merge gate"
+assert_not_contains "$(cat "$call_log")" "pr merge" "malformed pagination never invokes gh pr merge"
 
 : >"$call_log"
 set +e

--- a/skills/github/tests/pr-merge.sh
+++ b/skills/github/tests/pr-merge.sh
@@ -33,12 +33,27 @@ assert_contains() {
     fi
 }
 
+assert_not_contains() {
+    local haystack="$1" needle="$2" name="$3"
+    if ! grep -qF -- "$needle" <<<"$haystack"; then
+        PASS=$((PASS + 1))
+        printf '  ok    %s\n' "$name"
+    else
+        FAIL=$((FAIL + 1))
+        printf '  FAIL  %s\n        unwanted substring: %s\n        in: %s\n' "$name" "$needle" "$haystack"
+    fi
+}
+
 mkdir -p "$TMPDIR/bin" "$TMPDIR/repo"
 git -C "$TMPDIR/repo" init -q
 
 cat >"$TMPDIR/bin/gh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
+
+if [[ -n "${STUB_CALL_LOG:-}" ]]; then
+    printf '%s\n' "$*" >>"$STUB_CALL_LOG"
+fi
 
 case "${1:-}" in
     auth)
@@ -76,7 +91,12 @@ case "${1:-}" in
                     '{data:{repository:{pullRequest:{state:$state,headRefOid:$head,headRefName:$branch,mergeCommit:(if $commit == "" then null else {oid:$commit} end),autoMergeRequest:$auto,isInMergeQueue:$in_queue,mergeQueueEntry:$queue_entry}}}}'
                 exit 0
             fi
-            echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}'
+            if [[ "${STUB_THREADS_FETCH_FAIL:-false}" == "true" ]]; then
+                echo '{"errors":[{"message":"review threads unavailable"}]}'
+                exit 1
+            fi
+            jq -cn --argjson nodes "${STUB_THREADS_JSON:-[]}" \
+                '{data:{repository:{pullRequest:{reviewThreads:{nodes:$nodes}}}}}'
             exit 0
         fi
         ;;
@@ -155,6 +175,14 @@ run_merge() {
     (cd "$TMPDIR/repo" && PATH="$TMPDIR/bin:$PATH" env -u GH_TOKEN -u GITHUB_TOKEN "$PR_MERGE" 123 --auto --keep-branch)
 }
 
+run_merge_immediate() {
+    (cd "$TMPDIR/repo" && PATH="$TMPDIR/bin:$PATH" env -u GH_TOKEN -u GITHUB_TOKEN "$PR_MERGE" 123 --keep-branch)
+}
+
+run_merge_force() {
+    (cd "$TMPDIR/repo" && PATH="$TMPDIR/bin:$PATH" env -u GH_TOKEN -u GITHUB_TOKEN "$PR_MERGE" 123 --force --keep-branch)
+}
+
 echo "=== pr-merge --check CI classification ==="
 
 checks='[{"name":"Linux Integration","state":"IN_PROGRESS","bucket":"pending"},{"name":"Cross-Platform","state":"PENDING","bucket":"pending"}]'
@@ -183,6 +211,72 @@ out=$(STUB_CHECKS="$checks" run_check)
 assert_eq "$(jq -r .can_merge <<<"$out")" "true" "successful and skipped checks can merge"
 assert_eq "$(jq -r '.issues | length' <<<"$out")" "0" "successful and skipped checks emit no issues"
 assert_eq "$(jq -r .transient <<<"$out")" "false" "mergeable PR is not transient"
+
+echo
+echo "=== pr-merge actionable review-thread safety gate (vstack#785) ==="
+
+checks='[{"name":"CI Required","state":"SUCCESS","bucket":"pass"}]'
+actionable_threads='[{"id":"PRRT_actionable","isResolved":false,"isOutdated":false,"path":"src/lib.rs","line":12,"comments":{"nodes":[{"author":{"login":"reviewer"},"body":"Fix this safety bug"}]}}]'
+out=$(STUB_CHECKS="$checks" STUB_THREADS_JSON="$actionable_threads" run_check)
+assert_eq "$(jq -r .can_merge <<<"$out")" "false" "actionable unresolved thread blocks readiness"
+assert_eq "$(jq -r .transient <<<"$out")" "false" "actionable unresolved thread is a permanent block"
+assert_contains "$(jq -r '.issues[]' <<<"$out")" "unresolved_threads: 1 actionable thread(s)" "actionable thread is a blocking issue"
+assert_eq "$(jq -r '.warnings | map(select(startswith("unresolved_threads:"))) | length' <<<"$out")" "0" "actionable thread is never downgraded to warning"
+
+call_log="$TMPDIR/review-thread-calls.log"
+: >"$call_log"
+set +e
+out=$(STUB_CHECKS="$checks" \
+    STUB_THREADS_JSON="$actionable_threads" \
+    STUB_CALL_LOG="$call_log" \
+    run_merge 2>&1)
+status=$?
+set -e
+assert_eq "$status" "1" "--auto cannot bypass actionable review thread gate"
+assert_contains "$out" "BLOCKED PR #123 — no merge attempted, none queued" "--auto reports fail-closed outcome"
+assert_contains "$out" "Resolve the review-thread gate and retry" "blocked output does not recommend ineffective --auto bypass"
+assert_not_contains "$(cat "$call_log")" "pr merge" "--auto never invokes gh pr merge"
+assert_not_contains "$(cat "$call_log")" "mergeQueueEntry" "--auto never reaches post-mutation merge queue API"
+
+: >"$call_log"
+set +e
+out=$(STUB_CHECKS="$checks" \
+    STUB_THREADS_JSON="$actionable_threads" \
+    STUB_CALL_LOG="$call_log" \
+    run_merge_immediate 2>&1)
+status=$?
+set -e
+assert_eq "$status" "1" "immediate merge fails closed on actionable review thread"
+assert_not_contains "$(cat "$call_log")" "pr merge" "immediate path never invokes gh pr merge"
+
+outdated_threads='[{"id":"PRRT_outdated","isResolved":false,"isOutdated":true,"path":"src/old.rs","line":7,"comments":{"nodes":[{"author":{"login":"reviewer"},"body":"Stale diff"}]}}]'
+out=$(STUB_CHECKS="$checks" STUB_THREADS_JSON="$outdated_threads" run_check)
+assert_eq "$(jq -r .can_merge <<<"$out")" "true" "outdated unresolved thread is not actionable"
+
+: >"$call_log"
+set +e
+out=$(STUB_CHECKS="$checks" \
+    STUB_THREADS_FETCH_FAIL=true \
+    STUB_CALL_LOG="$call_log" \
+    run_merge 2>&1)
+status=$?
+set -e
+assert_eq "$status" "1" "review-thread lookup failure blocks --auto"
+assert_contains "$out" "review_threads_fetch_failed:" "lookup failure has explicit blocking issue"
+assert_not_contains "$(cat "$call_log")" "pr merge" "lookup failure never invokes gh pr merge"
+
+: >"$call_log"
+set +e
+out=$(STUB_CHECKS="$checks" \
+    STUB_THREADS_JSON="$actionable_threads" \
+    STUB_CALL_LOG="$call_log" \
+    STUB_POST_STATE=MERGED \
+    STUB_MERGE_COMMIT=forced-merge-oid \
+    run_merge_force 2>&1)
+status=$?
+set -e
+assert_eq "$status" "0" "documented --force remains a deliberate override"
+assert_contains "$(cat "$call_log")" "pr merge" "--force deliberately invokes gh pr merge"
 
 echo
 echo "=== pr-merge --check superseded-run scoping (vstack#492/#494) ==="


### PR DESCRIPTION
Closes #785.

## Summary

- treat actionable unresolved review threads as permanent merge blockers
- fail closed when review-thread state cannot be fetched or validated
- prevent `--auto` from bypassing the local thread gate while preserving explicit `--force`
- add regression coverage for immediate, auto, outdated-thread, fetch-failure, and force paths

## Validation

- all 14 GitHub skill test scripts
- `skills/github/tests/pr-merge.sh` (59 pass, 0 fail)
- Bash syntax and Bash 3.2 portability checks
- `git diff --check`
