### PR TITLE
fix(github): preserve force merge failure

### DIFF
--- a/skills/github/README.md
+++ b/skills/github/README.md
@@ -73,9 +73,10 @@ when already merged, exit `75` with a distinct message when either a required
 merge-queue entry or classic auto-merge is active, and exit `1` when no merged,
 queued, or armed postcondition can be proven. Required-queue membership is read
 through GraphQL because `gh pr view --json` does not expose it.
-`--force` remains immediate-only: a nonzero forced mutation returns exit `1`
-unless the exact-head post-state is already `MERGED`. Auto-merge or queue
-enrollment active before the call cannot mask the immediate failure.
+`--force` remains immediate-only and cannot be combined with `--auto`; the
+conflicting flags fail before any GitHub lookup or mutation. A nonzero forced
+mutation returns exit `1` unless the exact-head post-state is already `MERGED`.
+Auto-merge or queue enrollment active before the call cannot mask the failure.
 
 ## Git HTTPS Fallback
 

--- a/skills/github/README.md
+++ b/skills/github/README.md
@@ -73,6 +73,9 @@ when already merged, exit `75` with a distinct message when either a required
 merge-queue entry or classic auto-merge is active, and exit `1` when no merged,
 queued, or armed postcondition can be proven. Required-queue membership is read
 through GraphQL because `gh pr view --json` does not expose it.
+`--force` remains immediate-only: a nonzero forced mutation returns exit `1`
+unless the exact-head post-state is already `MERGED`. Auto-merge or queue
+enrollment active before the call cannot mask the immediate failure.
 
 ## Git HTTPS Fallback
 

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -134,9 +134,11 @@ any merge or queue mutation. A failed or malformed thread lookup also blocks,
 because an unknown review state cannot be treated as clean. The documented
 `--force` flag is the only deliberate override and skips every safety check.
 
-`--force` has immediate-only semantics. If its guarded `gh pr merge` mutation
-fails and the exact-head post-state is not `MERGED`, `pr-merge` returns BLOCKED
-even when classic auto-merge or a merge-queue entry was already active.
+`--force` has immediate-only semantics and cannot be combined with `--auto`;
+the conflicting flags fail before any GitHub lookup or mutation. If its
+guarded `gh pr merge` mutation fails and the exact-head post-state is not
+`MERGED`, `pr-merge` returns BLOCKED even when classic auto-merge or a
+merge-queue entry was already active.
 Pre-existing deferred state is not proof that the forced immediate attempt
 succeeded. An authoritative exact-head `MERGED` post-state remains success;
 non-force and `--auto` idempotent pending outcomes retain exit `75`.

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -134,6 +134,13 @@ any merge or queue mutation. A failed or malformed thread lookup also blocks,
 because an unknown review state cannot be treated as clean. The documented
 `--force` flag is the only deliberate override and skips every safety check.
 
+`--force` has immediate-only semantics. If its guarded `gh pr merge` mutation
+fails and the exact-head post-state is not `MERGED`, `pr-merge` returns BLOCKED
+even when classic auto-merge or a merge-queue entry was already active.
+Pre-existing deferred state is not proof that the forced immediate attempt
+succeeded. An authoritative exact-head `MERGED` post-state remains success;
+non-force and `--auto` idempotent pending outcomes retain exit `75`.
+
 A BLOCKED outcome is further classified on stderr as **transient** (mergeable
 UNKNOWN, `ci_pending`, CI fetch uncertainty — caller should
 `await-mergeable` and retry) or **permanent** (conflicts, `ci_failed`,

--- a/skills/github/scripts/commands/pr-merge.sh
+++ b/skills/github/scripts/commands/pr-merge.sh
@@ -91,7 +91,8 @@ Options:
   --delete-branch  Delete branch after merge (default: true)
   --keep-branch    Keep branch after merge
   --check          Run checks only, output JSON, don't merge
-  --force          Skip checks and merge (requires explicit user decision)
+  --force          Skip checks and merge (requires explicit user decision;
+                   cannot be combined with --auto)
   --auto           If immediate merge is blocked, enable GitHub auto-merge
                    (will fire when CI + branch protection clear). Exits 75.
                    Never bypasses actionable unresolved review threads.
@@ -422,6 +423,11 @@ main() {
             ;;
         esac
     done
+
+    if [ "$force" = true ] && [ "$auto" = true ]; then
+        echo "Error: --force and --auto cannot be combined; --force is immediate-only" >&2
+        exit 1
+    fi
 
     if [ -z "$pr_num" ]; then
         echo '{"error": "PR number required"}' >&2

--- a/skills/github/scripts/commands/pr-merge.sh
+++ b/skills/github/scripts/commands/pr-merge.sh
@@ -15,6 +15,10 @@
 # that is already enrolled reports QUEUED (75) from the authoritative post-call
 # snapshot, not BLOCKED, even though `gh pr merge --auto` exits nonzero when the
 # PR is already queued (vstack#616).
+# `--force` is deliberately different: it promises an immediate attempt, so a
+# nonzero merge mutation stays BLOCKED unless the exact head is now MERGED.
+# Auto-merge or a queue entry already active before the call is not success
+# proof for this mode (vstack#782).
 #
 # When BLOCKED, stderr distinguishes TRANSIENT issues (mergeable UNKNOWN,
 # ci pending — caller should `await-mergeable` and retry) from PERMANENT
@@ -545,18 +549,24 @@ main() {
         exit 1
     fi
 
-    # A NONZERO `gh pr merge` exit is only benign when the authoritative
-    # snapshot proves a real success state: an already-enrolled merge queue
-    # entry (vstack#616), classic auto-merge already enabled, or an already
-    # merged PR. Anything else — conflicts, auth failure, CI, no enrollment —
-    # leaves no such proof and stays BLOCKED with the raw gh output. When the
-    # snapshot does prove success, fall through to the shared classification
-    # below so the outcome (MERGED / QUEUED / AUTO-MERGE) is reported once.
+    # A NONZERO `gh pr merge` exit is only benign outside `--force` when the
+    # authoritative snapshot proves a real success state: an already-enrolled
+    # merge queue entry (vstack#616), classic auto-merge already enabled, or an
+    # already merged PR. Anything else — conflicts, auth failure, CI, no
+    # enrollment — leaves no such proof and stays BLOCKED with the raw gh
+    # output. When the snapshot does prove success, fall through to the shared
+    # classification below so the outcome (MERGED / QUEUED / AUTO-MERGE) is
+    # reported once.
+    # `--force` promises an immediate mutation, so pre-existing pending state
+    # must never convert its failed mutation into success (vstack#782). An
+    # exact-head MERGED snapshot remains authoritative even if the CLI returned
+    # nonzero after the server completed the merge.
     if [ "$merge_exit" -ne 0 ] \
         && [ "$post_state" != "MERGED" ] \
-        && [ "$post_in_queue" != "true" ] \
-        && [ "$post_queue_entry" != "true" ] \
-        && [ "$post_auto" != "true" ]; then
+        && { [ "$force" = true ] \
+            || { [ "$post_in_queue" != "true" ] \
+                && [ "$post_queue_entry" != "true" ] \
+                && [ "$post_auto" != "true" ]; }; }; then
         local fail_args=(
             --severity error
             --importance important

--- a/skills/github/tests/pr-merge.sh
+++ b/skills/github/tests/pr-merge.sh
@@ -216,6 +216,10 @@ run_merge_force() {
     (cd "$TMPDIR/repo" && PATH="$TMPDIR/bin:$PATH" env -u GH_TOKEN -u GITHUB_TOKEN "$PR_MERGE" 123 --force --keep-branch)
 }
 
+run_merge_force_auto() {
+    (cd "$TMPDIR/repo" && PATH="$TMPDIR/bin:$PATH" env -u GH_TOKEN -u GITHUB_TOKEN "$PR_MERGE" 123 --force --auto --keep-branch)
+}
+
 echo "=== pr-merge --check CI classification ==="
 
 checks='[{"name":"Linux Integration","state":"IN_PROGRESS","bucket":"pending"},{"name":"Cross-Platform","state":"PENDING","bucket":"pending"}]'
@@ -557,6 +561,18 @@ assert_contains "$out" "base branch policy prohibits the merge" "genuine failure
 
 echo
 echo "=== pr-merge --force immediate failure contract (vstack#782) ==="
+
+# Force and auto request contradictory outcomes. Reject the combination before
+# PR resolution, authentication, checks, or any merge/queue mutation.
+call_log="$TMPDIR/force-auto-calls.log"
+: >"$call_log"
+set +e
+out=$(STUB_CALL_LOG="$call_log" run_merge_force_auto 2>&1)
+status=$?
+set -e
+assert_eq "$status" "1" "--force and --auto are rejected as conflicting modes"
+assert_contains "$out" "--force and --auto cannot be combined" "conflicting modes report a clear usage error"
+assert_eq "$(cat "$call_log")" "" "conflicting modes make no GitHub API or mutation calls"
 
 # The authoritative exact-head postcondition wins over a CLI transport/status
 # failure: the requested immediate outcome actually happened.

--- a/skills/github/tests/pr-merge.sh
+++ b/skills/github/tests/pr-merge.sh
@@ -556,5 +556,57 @@ assert_contains "$out" "BLOCKED PR #123 — gh pr merge failed" "genuine failure
 assert_contains "$out" "base branch policy prohibits the merge" "genuine failure surfaces raw gh output"
 
 echo
+echo "=== pr-merge --force immediate failure contract (vstack#782) ==="
+
+# The authoritative exact-head postcondition wins over a CLI transport/status
+# failure: the requested immediate outcome actually happened.
+set +e
+out=$(STUB_MERGE_EXIT=1 \
+    STUB_MERGE_STDERR="failed to read the completed mutation response" \
+    STUB_POST_STATE=MERGED \
+    STUB_MERGE_COMMIT=forced-merge-oid \
+    STUB_POST_AUTO_JSON=null \
+    STUB_POST_IN_QUEUE=false \
+    STUB_POST_QUEUE_ENTRY_JSON=null \
+    run_merge_force 2>&1)
+status=$?
+set -e
+assert_eq "$status" "0" "failed CLI remains success when exact-head post-state is MERGED"
+assert_contains "$out" "MERGED PR #123" "force reports the authoritative immediate postcondition"
+
+# `--force` is an immediate-only operation. A pre-existing classic auto-merge
+# request must not make a rejected immediate mutation appear successful.
+set +e
+out=$(STUB_MERGE_EXIT=1 \
+    STUB_MERGE_STDERR="failed to run merge: Pull request is not mergeable: the base branch policy prohibits the merge" \
+    STUB_POST_STATE=OPEN \
+    STUB_POST_AUTO_JSON='{"enabledAt":"2026-07-21T00:00:00Z"}' \
+    STUB_POST_IN_QUEUE=false \
+    STUB_POST_QUEUE_ENTRY_JSON=null \
+    run_merge_force 2>&1)
+status=$?
+set -e
+assert_eq "$status" "1" "failed --force stays blocked when classic auto-merge was already armed"
+assert_contains "$out" "BLOCKED PR #123 — gh pr merge failed" "failed --force reports its immediate mutation failure"
+assert_contains "$out" "base branch policy prohibits the merge" "failed --force preserves the immediate failure detail"
+
+# Required-queue membership is likewise not proof that an immediate --force
+# attempt succeeded. Queue idempotency remains reserved for non-force modes.
+set +e
+out=$(STUB_MERGE_EXIT=1 \
+    STUB_MERGE_STDERR="failed to run merge: merge queue is required" \
+    STUB_POST_STATE=OPEN \
+    STUB_POST_AUTO_JSON=null \
+    STUB_POST_IN_QUEUE=true \
+    STUB_POST_QUEUE_ENTRY_JSON='{"state":"QUEUED"}' \
+    STUB_POST_QUEUE_STATE=QUEUED \
+    run_merge_force 2>&1)
+status=$?
+set -e
+assert_eq "$status" "1" "failed --force stays blocked when a queue entry was already active"
+assert_contains "$out" "BLOCKED PR #123 — gh pr merge failed" "queued --force failure is not reported as pending success"
+assert_contains "$out" "merge queue is required" "queued --force failure preserves the immediate failure detail"
+
+echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Closes #782.

## Summary

- keep `--force` immediate-only when its merge mutation is rejected
- prevent pre-existing auto-merge or merge-queue state from masking that failure
- continue accepting an authoritative exact-head `MERGED` postcondition if the CLI returned nonzero after server completion
- preserve non-force and `--auto` idempotent pending behavior

## Validation

- full 14-script GitHub skill suite
- combined `pr-merge.sh` suite after guarded restack (`80` pass, `0` fail)
- Bash syntax and changed-line Bash 3.2 checks
- `git diff --check`
