### PR TITLE
fix(github): restore Bash 3.2 review status

### DIFF
--- a/skills/github/scripts/commands/pr-review-status.sh
+++ b/skills/github/scripts/commands/pr-review-status.sh
@@ -97,11 +97,9 @@ fi
 # Skipped reviewers (BOT_SKIPPED_REVIEWERS) are excluded.
 PENDING_BOTS_JSON='[]'
 if [[ -n "${BOT_REVIEWERS:-}" ]]; then
-    declare -A _SKIPPED_SET=()
+    _skipped_reviewers=()
     if [[ -n "${BOT_SKIPPED_REVIEWERS:-}" ]]; then
-        for s in $(printf '%s' "$BOT_SKIPPED_REVIEWERS" | tr ',' ' '); do
-            [[ -n "$s" ]] && _SKIPPED_SET["$s"]=1
-        done
+        IFS=',' read -ra _skipped_reviewers <<< "$BOT_SKIPPED_REVIEWERS"
     fi
     _pending=()
     IFS=',' read -ra _BR <<< "$BOT_REVIEWERS"
@@ -109,7 +107,16 @@ if [[ -n "${BOT_REVIEWERS:-}" ]]; then
         _b="${_b#"${_b%%[![:space:]]*}"}"
         _b="${_b%"${_b##*[![:space:]]}"}"
         [[ -z "$_b" ]] && continue
-        [[ -n "${_SKIPPED_SET[$_b]:-}" ]] && continue
+        _is_skipped="false"
+        for _s in "${_skipped_reviewers[@]+"${_skipped_reviewers[@]}"}"; do
+            _s="${_s#"${_s%%[![:space:]]*}"}"
+            _s="${_s%"${_s##*[![:space:]]}"}"
+            if [[ -n "$_s" ]] && [[ "$_s" == "$_b" ]]; then
+                _is_skipped="true"
+                break
+            fi
+        done
+        [[ "$_is_skipped" == "true" ]] && continue
         _entry=$(bot_review_status "$PR_NUM" "$_b" 2>/dev/null || echo '{"status":"unknown"}')
         _st=$(echo "$_entry" | jq -r '.status // "unknown"')
         if [[ "$_st" == "pending" || "$_st" == "unknown" ]]; then

--- a/skills/github/tests/bot_review_status.sh
+++ b/skills/github/tests/bot_review_status.sh
@@ -13,6 +13,8 @@ set -euo pipefail
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FIXTURES="$TEST_DIR/fixtures"
 LIB="$TEST_DIR/../scripts/lib/github-api.sh"
+PR_REVIEW_STATUS="$TEST_DIR/../scripts/commands/pr-review-status.sh"
+SCRIPTS_DIR="$TEST_DIR/../scripts"
 
 # get_repo_info / project root helpers in github-api.sh shell out to gh + git.
 # Stub project root to the test dir so `set -u` does not blow up at source time.
@@ -43,6 +45,13 @@ assert_contains() {
         FAIL=$((FAIL + 1))
         printf '  FAIL  %s\n        wanted substring: %s\n        in: %s\n' "$name" "$needle" "$haystack"
     fi
+}
+
+assert_file_eq() {
+    local got_file="$1" want="$2" name="$3"
+    local got
+    got="$(cat "$got_file")"
+    assert_eq "$got" "$want" "$name"
 }
 
 fx() { cat "$FIXTURES/$1"; }
@@ -256,6 +265,45 @@ assert_eq "$(compute_sticky_verdict_from_body "Verdict: approval withheld")" "ch
 assert_eq "$(compute_sticky_verdict_from_body "Verdict: rejected")" "changes" "rejected verdict = changes"
 assert_eq "$(compute_sticky_verdict_from_body "Verdict: denied")" "changes" "denied verdict = changes"
 assert_eq "$(compute_sticky_verdict_from_body "Recommendation: no approval")" "changes" "no approval text = changes"
+
+# --- pr-review-status production command ---
+echo
+echo "=== pr-review-status reviewer selection ==="
+PR_STATUS_ROOT="$(mktemp -d)"
+trap 'rm -rf "$PR_STATUS_ROOT"' EXIT
+mkdir -p "$PR_STATUS_ROOT/commands" "$PR_STATUS_ROOT/lib"
+cp "$PR_REVIEW_STATUS" "$PR_STATUS_ROOT/commands/pr-review-status.sh"
+cp "$FIXTURES/pr-review-status/github-api.sh" "$PR_STATUS_ROOT/lib/github-api.sh"
+cp "$FIXTURES/pr-review-status/sticky-comment.sh" "$PR_STATUS_ROOT/commands/sticky-comment.sh"
+cp "$FIXTURES/pr-review-status/pr-threads.sh" "$PR_STATUS_ROOT/commands/pr-threads.sh"
+chmod +x "$PR_STATUS_ROOT/commands/pr-review-status.sh"
+chmod +x "$PR_STATUS_ROOT/commands/sticky-comment.sh"
+chmod +x "$PR_STATUS_ROOT/commands/pr-threads.sh"
+REVIEW_CALL_LOG="$PR_STATUS_ROOT/reviewer-calls"
+
+status_out=$(BOT_REVIEWERS=' pending-bot , pending-bot-extra , approved-live , unknown-bot , approved-bot ' \
+    BOT_SKIPPED_REVIEWERS=' pending-bot , approved-bot ' \
+    BOT_REVIEW_STATUS_CALL_LOG="$REVIEW_CALL_LOG" \
+    "$PR_STATUS_ROOT/commands/pr-review-status.sh" 42)
+assert_eq "$(echo "$status_out" | jq -c '.pending_bot_reviewers')" \
+    '["pending-bot-extra","unknown-bot"]' \
+    "exact skipped-reviewer matching preserves pending reviewer order"
+assert_eq "$(echo "$status_out" | jq -r '.reason')" \
+    "pending_bot_reviewer" \
+    "remaining pending reviewers keep the pending-bot decision"
+assert_file_eq "$REVIEW_CALL_LOG" $'pending-bot-extra\napproved-live\nunknown-bot' \
+    "skipped reviewers are not queried and similar reviewer names do not collide"
+
+# Guard every shipped GitHub script, including commands that fixture-driven
+# unit tests do not otherwise execute, against Bash 4-only syntax.
+echo
+echo "=== Bash 3.2 portability ==="
+BASH32_PATTERN='mapfile|readarray|declare -[a-zA-Z]*A|local -[a-zA-Z]*A'
+BASH32_PATTERN="$BASH32_PATTERN"'|(^|[^$])\{[A-Za-z_][A-Za-z0-9_]*\}[<>]'
+BASH32_PATTERN="$BASH32_PATTERN"'|\$\{[A-Za-z_][A-Za-z0-9_]*(\[[^]]*\])?(,,|\^\^)'
+portability_violations="$(grep -rnE "$BASH32_PATTERN" "$SCRIPTS_DIR" \
+    | grep -vE '^[^:]+:[0-9]+:[[:space:]]*#' || true)"
+assert_eq "$portability_violations" "" "all shipped GitHub scripts avoid Bash 4-only constructs"
 
 echo
 echo "----"

--- a/skills/github/tests/fixtures/pr-review-status/github-api.sh
+++ b/skills/github/tests/fixtures/pr-review-status/github-api.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+bot_review_status() {
+    local reviewer="$2"
+
+    printf '%s\n' "$reviewer" >> "$BOT_REVIEW_STATUS_CALL_LOG"
+    case "$reviewer" in
+        pending-bot-extra)
+            printf '{"status":"pending"}\n'
+            ;;
+        approved-live)
+            printf '{"status":"approved"}\n'
+            ;;
+        unknown-bot)
+            printf '{"status":"unknown"}\n'
+            ;;
+        *)
+            printf '{"status":"changes"}\n'
+            ;;
+    esac
+}

--- a/skills/github/tests/fixtures/pr-review-status/pr-threads.sh
+++ b/skills/github/tests/fixtures/pr-review-status/pr-threads.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+printf '%s\n' '{"unresolved_count":0}'

--- a/skills/github/tests/fixtures/pr-review-status/sticky-comment.sh
+++ b/skills/github/tests/fixtures/pr-review-status/sticky-comment.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+printf '%s\n' '{"updated_at":"2026-07-21T00:00:00Z","verdict":"approved"}'


### PR DESCRIPTION
Closes #789.

## Summary

- replace the Bash 4 associative skipped-reviewer set with a Bash 3.2-safe indexed list and exact-match scan
- preserve reviewer order and avoid prefix collisions in skip matching
- exercise the real `pr-review-status` command with multiple skipped, approved, pending, and unknown reviewers
- scan every shipped GitHub production script for forbidden Bash 4-only constructs in the normal skill suite

## Validation

- full 14-script GitHub skill suite
- `bot_review_status.sh` (`57` pass, `0` fail)
- syntax checks for production, tests, and fixtures
- Bash 3.2 forbidden-construct scan
- `git diff --check`
