### PR TITLE
fix(cli): terminate JSON artifacts with a trailing newline

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -121,6 +121,18 @@ pub struct SourceRegistry {
     pub project_current: BTreeMap<String, String>,
 }
 
+/// Serialize `value` as pretty JSON terminated by exactly one newline.
+/// vstack's JSON artifacts are POSIX text files and some are tracked by
+/// consuming repos (`.vstack-lock.json`), so the terminator keeps every
+/// rewrite from adding a `\ No newline at end of file` line to their diffs.
+pub fn to_json_pretty(value: &impl Serialize) -> Result<String> {
+    let mut out = serde_json::to_string_pretty(value)?;
+    if !out.ends_with('\n') {
+        out.push('\n');
+    }
+    Ok(out)
+}
+
 impl LockFile {
     pub fn load(path: &Path) -> Result<Self> {
         if !path.exists() {
@@ -138,7 +150,7 @@ impl LockFile {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
         }
-        let content = serde_json::to_string_pretty(self)?;
+        let content = to_json_pretty(self)?;
         std::fs::write(path, content)?;
         Ok(())
     }
@@ -192,7 +204,7 @@ impl SourceRegistry {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
         }
-        let content = serde_json::to_string_pretty(self)?;
+        let content = to_json_pretty(self)?;
         std::fs::write(path, content)?;
         Ok(())
     }
@@ -1668,6 +1680,67 @@ mod source_registry_tests {
             .status()
             .unwrap();
         assert!(status.success());
+    }
+
+    #[test]
+    fn lock_file_save_terminates_with_exactly_one_newline() {
+        let dir = sandbox("lock_newline");
+        let path = dir.join(".vstack-lock.json");
+
+        let mut lock = LockFile {
+            version: 1,
+            ..Default::default()
+        };
+        lock.add(LockEntry {
+            name: "guard".to_string(),
+            kind: ItemKind::Hook,
+            source: "vanillagreencom/vstack".to_string(),
+            source_repo: Some("vanillagreencom/vstack".to_string()),
+            harnesses: vec!["codex".to_string()],
+            method: InstallMethod::Copy,
+            installed_at: "2026-07-24T00:00:00Z".to_string(),
+            source_hash: String::new(),
+        });
+
+        lock.save(&path).unwrap();
+        let first = fs::read_to_string(&path).unwrap();
+        assert!(
+            first.ends_with("}\n"),
+            "lock file must end with one newline"
+        );
+        assert!(
+            !first.ends_with("\n\n"),
+            "lock file must not end with a blank line"
+        );
+
+        // Load/save round-trips must not accumulate terminators, otherwise
+        // every refresh would grow the file by a blank line.
+        LockFile::load(&path).unwrap().save(&path).unwrap();
+        assert_eq!(fs::read_to_string(&path).unwrap(), first);
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn source_registry_save_terminates_with_exactly_one_newline() {
+        let dir = sandbox("registry_newline");
+        let path = dir.join("sources.json");
+
+        let mut registry = SourceRegistry::default();
+        registry.remember("vanillagreencom/vstack");
+
+        registry.save(&path).unwrap();
+        let first = fs::read_to_string(&path).unwrap();
+        assert!(first.ends_with("}\n"), "registry must end with one newline");
+        assert!(
+            !first.ends_with("\n\n"),
+            "registry must not end with a blank line"
+        );
+
+        SourceRegistry::load(&path).unwrap().save(&path).unwrap();
+        assert_eq!(fs::read_to_string(&path).unwrap(), first);
+
+        let _ = fs::remove_dir_all(dir);
     }
 
     #[test]

--- a/cli/src/installer/hooks.rs
+++ b/cli/src/installer/hooks.rs
@@ -240,7 +240,7 @@ fn install_hook_claude(hook: &Hook, global: bool) -> Result<()> {
 
     event_arr.push(hook_entry);
 
-    let output = serde_json::to_string_pretty(&settings)?;
+    let output = crate::config::to_json_pretty(&settings)?;
     std::fs::write(&settings_path, output)?;
 
     Ok(())
@@ -432,7 +432,7 @@ fn merge_codex_hooks_json_owned(
     }
     event_arr.push(entry);
 
-    let output = serde_json::to_string_pretty(&doc)?;
+    let output = crate::config::to_json_pretty(&doc)?;
     std::fs::write(hooks_json, output)?;
     Ok(())
 }
@@ -765,7 +765,7 @@ fn remove_hook_from_claude_settings(global: bool, name: &str, script_path: &Path
     }
 
     if changed {
-        let output = serde_json::to_string_pretty(&settings)?;
+        let output = crate::config::to_json_pretty(&settings)?;
         std::fs::write(&settings_path, output)?;
     }
     Ok(())
@@ -811,7 +811,7 @@ fn remove_hook_from_codex_json(global: bool, name: &str, script_path: &Path) -> 
                 }
             }
         } else {
-            let output = serde_json::to_string_pretty(&doc)?;
+            let output = crate::config::to_json_pretty(&doc)?;
             std::fs::write(&hooks_json, output)
                 .with_context(|| format!("writing Codex hooks config {}", hooks_json.display()))?;
         }

--- a/cli/src/pi_extension.rs
+++ b/cli/src/pi_extension.rs
@@ -51,7 +51,7 @@ pub fn write_source_index(global: bool, index: &SourceIndex) -> Result<()> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    let pretty = serde_json::to_string_pretty(index)?;
+    let pretty = crate::config::to_json_pretty(index)?;
     std::fs::write(&path, pretty)?;
     Ok(())
 }
@@ -837,7 +837,7 @@ fn write_settings(path: &Path, value: &serde_json::Value) -> Result<()> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    let pretty = serde_json::to_string_pretty(value)?;
+    let pretty = crate::config::to_json_pretty(value)?;
     std::fs::write(path, pretty)?;
     Ok(())
 }


### PR DESCRIPTION
Closes #805

## Problem

`vstack refresh` rewrote `.vstack-lock.json` without a trailing newline, so every refresh diff in a repo that tracks the lock carried a `\ No newline at end of file` line — permanent, self-reproducing churn (observed on hyprtrade-io after #802).

## Fix

Adds a shared `config::to_json_pretty` helper (pretty JSON + exactly one terminating newline, idempotent) and routes the JSON writers through it: the lock file, the source registry, Claude/Codex hook settings, and the pi extension source index + settings.

The helper matches prior art already in the tree — `serialize_opencode_config` and the tmux/theme writer in `apply.rs` both already terminated their output this way. This just makes the behavior uniform instead of per-writer.

Audited every remaining `to_string_pretty` call: the rest either already append a newline (`opencode.rs`, `apply.rs`) or are test fixtures. No production writer is left unterminated.

## Note for consuming repos

Because the hook-settings and pi-settings writers were also unterminated, the next `vstack refresh` in a repo that **tracks** those files will show a one-time single-newline diff on them alongside the lock. That is the fix landing, not drift — it does not repeat.

## Verification

- `cargo test --manifest-path cli/Cargo.toml` (exactly as CI invokes it) — 454 passed / 0 failed, plus the 17-test integration binary green.
- Two new tests, for the lock and the source registry: output ends with exactly one `\n`, never a blank line, and a load→save round-trip is byte-identical so terminators cannot accumulate across refreshes.
- `cargo fmt --check` clean. `cargo clippy --all-targets` emits the same 2 warnings as `main` — none introduced here (CI does not gate on clippy).