### PR TITLE
fix(pi-claude-bridge): drop dead initializers in preflightClaudeExecutable

### DIFF
--- a/pi-extensions/pi-claude-bridge/bundle/index.js
+++ b/pi-extensions/pi-claude-bridge/bundle/index.js
@@ -42522,7 +42522,7 @@ function classifyClaudeExecutableBytes(bytes) {
   return "unknown";
 }
 function preflightClaudeExecutable(path, cwd) {
-  let realCwd = cwd;
+  let realCwd;
   try {
     const cwdStat = statSync2(cwd);
     if (!cwdStat.isDirectory()) {
@@ -42546,7 +42546,7 @@ function preflightClaudeExecutable(path, cwd) {
       cause: err
     });
   }
-  let realPath = path;
+  let realPath;
   try {
     const stat = statSync2(path);
     if (!stat.isFile()) {

--- a/pi-extensions/pi-claude-bridge/src/claude-executable.ts
+++ b/pi-extensions/pi-claude-bridge/src/claude-executable.ts
@@ -107,7 +107,7 @@ export function classifyClaudeExecutableBytes(bytes: Uint8Array): ClaudeExecutab
 }
 
 export function preflightClaudeExecutable(path: string, cwd: string): ClaudeExecutablePreflightResult {
-	let realCwd = cwd;
+	let realCwd: string;
 	try {
 		const cwdStat = statSync(cwd);
 		if (!cwdStat.isDirectory()) {
@@ -132,7 +132,7 @@ export function preflightClaudeExecutable(path: string, cwd: string): ClaudeExec
 		});
 	}
 
-	let realPath = path;
+	let realPath: string;
 	try {
 		const stat = statSync(path);
 		if (!stat.isFile()) {


### PR DESCRIPTION
Closes #815

## What

`realCwd`/`realPath` in `preflightClaudeExecutable` were initialized to `cwd`/`path` and then always overwritten by `realpathSync(...)` on the success path, while the catch always throws — so the initializers were never read (CodeQL "useless assignment to local variable", surfaced when #814 moved the function into `claude-executable.ts`).

## Fix

Declared as bare typed locals (`let realCwd: string;`). `tsc` proves definite assignment because the catch completes with `throw`, so no `!` assertion is needed. Pure cleanup, no behavior change.

## Verification

- `npm run typecheck` — clean.
- `npm run build` + `npm run test:unit` — **219/219** against the rebuilt bundle.
- Bundle export surface **identical** to main; bundle diff is exactly the two changed lines.