### PR TITLE
fix(pi-session-bridge,pi-qol): observe pi's session_info_changed event

### DIFF
--- a/pi-extensions/pi-qol/README.md
+++ b/pi-extensions/pi-qol/README.md
@@ -76,7 +76,7 @@ Glyph style: each package exposes `glyphStyle` (`unicode` default, `ascii` for t
 | Show compact statusline | Render or disable the QOL statusline row. |
 | Replace built-in footer | Hide Pi's default footer while the QOL statusline is enabled. |
 | Use π prompt editor | Use the compact prompt editor. |
-| Show session name title | Show the session name above the prompt and in the tmux pane title. |
+| Show session name title | Show the session name above the prompt and in the tmux pane title; refreshes as soon as Pi reports a session metadata change. |
 | Sync session name to tmux window name | Rename the tmux window to `π <session>`. |
 | Input bottom padding | Blank lines below the prompt. |
 | Show dirty marker | Append `*` to the branch when the worktree is dirty. |

--- a/pi-extensions/pi-qol/extensions/qol.ts
+++ b/pi-extensions/pi-qol/extensions/qol.ts
@@ -668,6 +668,13 @@ export default function qol(pi: ExtensionAPI): void {
 	pi.on("thinking_level_select", (_event, ctx) => {
 		if (ctx.hasUI) requestRender();
 	});
+	// Renames land immediately instead of waiting for the SESSION_TITLE_SYNC_INTERVAL_MS
+	// poll installed by installSessionTitleSync; the poll stays as the backstop for
+	// name changes Pi does not announce.
+	pi.on("session_info_changed", (_event, ctx) => {
+		if (!ctx.hasUI) return;
+		syncSessionTitle(ctx);
+	});
 	pi.on("agent_start", (_event, ctx) => {
 		clearIdleCompactionTimer();
 		clearTmuxWindowMark();

--- a/pi-extensions/pi-qol/package.json
+++ b/pi-extensions/pi-qol/package.json
@@ -79,7 +79,7 @@
         {
           "key": "showSessionNameTitle",
           "label": "Show session name title",
-          "description": "Show the named session above the prompt. In tmux, update the current pane title to \"π <session>\" and enable a pane border title padded with non-breaking spaces so tmux does not trim it.",
+          "description": "Show the named session above the prompt. In tmux, update the current pane title to \"π <session>\" and enable a pane border title padded with non-breaking spaces so tmux does not trim it. The title refreshes as soon as Pi reports a session metadata change.",
           "type": "boolean",
           "default": true,
           "category": "Statusline",

--- a/pi-extensions/pi-qol/tests/statusline-toggle.test.ts
+++ b/pi-extensions/pi-qol/tests/statusline-toggle.test.ts
@@ -145,3 +145,42 @@ test("statusline.enabled=false keeps QOL editor helpers but skips statusline/foo
 	expect(fake.api.exec.mock.calls.length).toBe(0);
 	fake.handlers.session_shutdown?.({ reason: "quit" }, ctx);
 });
+
+test("session_info_changed syncs the session title without waiting for the poll", async () => {
+	writeQolConfig({ "sessionSearch.enabled": false, "sessionAutoRename.enabled": false });
+	let sessionName: string | undefined;
+	const fake = makeFakeApi();
+	fake.api.getSessionName = () => sessionName;
+	qolDefault(fake.api);
+	const ctx = makeCtx();
+
+	fake.handlers.session_start?.({ reason: "startup" }, ctx);
+	const requestRender = mock(() => {});
+	const editorFactory = ctx.ui.setEditorComponent.mock.calls.at(-1)?.[0];
+	editorFactory?.({ requestRender }, makeTheme(), {});
+	requestRender.mockClear();
+	const statusCallsBefore = ctx.ui.setStatus.mock.calls.length;
+
+	sessionName = "Renamed session";
+	fake.handlers.session_info_changed?.({ name: sessionName }, ctx);
+
+	// syncSessionTitle re-renders on a changed name and always reasserts the
+	// session-manager status slot, so both prove the handler ran the sync.
+	expect(requestRender.mock.calls.length).toBeGreaterThan(0);
+	expect(ctx.ui.setStatus.mock.calls.length).toBeGreaterThan(statusCallsBefore);
+	expect(ctx.ui.setStatus.mock.calls.at(-1)?.[0]).toBe("session-manager");
+	fake.handlers.session_shutdown?.({ reason: "quit" }, ctx);
+});
+
+test("session_info_changed is a no-op without a UI", async () => {
+	writeQolConfig({ "sessionSearch.enabled": false, "sessionAutoRename.enabled": false });
+	const fake = makeFakeApi();
+	fake.api.getSessionName = () => "Headless rename";
+	qolDefault(fake.api);
+	const ctx = makeCtx();
+	ctx.hasUI = false;
+
+	fake.handlers.session_info_changed?.({ name: "Headless rename" }, ctx);
+
+	expect(ctx.ui.setStatus.mock.calls.length).toBe(0);
+});

--- a/pi-extensions/pi-session-bridge/README.md
+++ b/pi-extensions/pi-session-bridge/README.md
@@ -7,7 +7,7 @@ Control a running Pi session from outside the TUI. The interactive Pi terminal s
 ## Highlights
 
 - External clients send prompts, steering, follow-ups, and aborts through the bridge.
-- Subscribe to live Pi events (messages, tool calls, agent end) without scraping panes.
+- Subscribe to live Pi events (messages, tool calls, session metadata changes, agent end) without scraping panes.
 - Local extensions can publish activity updates to bridge clients without adding chat messages.
 - Discover active Pi sessions through registry files; target by pid, cwd, session, or name.
 - `pi-bridge` CLI handles common operations; contributor-facing protocol notes live in [`DEVELOPMENT.md`](./DEVELOPMENT.md).

--- a/pi-extensions/pi-session-bridge/extensions/__tests__/event-sanitizer.test.ts
+++ b/pi-extensions/pi-session-bridge/extensions/__tests__/event-sanitizer.test.ts
@@ -137,6 +137,60 @@ describe("sanitizeBridgeEvent", () => {
 		expect(result.raw).toEqual(payload);
 	});
 
+	test("session_info_changed compacts the renamed session to a preview", () => {
+		const payload = { type: "session_info_changed", name: "Rename the bridge registry" };
+		const result = sanitizeBridgeEvent("session_info_changed", payload, baseConfig);
+		const data = result.data as Record<string, unknown>;
+
+		expect(data.nameBytes).toBe(Buffer.byteLength(payload.name, "utf8"));
+		expect(data.nameLength).toBe(payload.name.length);
+		expect(data.namePreview).toBe(payload.name);
+		expect("nameTruncated" in data).toBe(false);
+		expect("name" in data).toBe(false);
+		expect("type" in data).toBe(false);
+		expect(result.truncated).toBe(true);
+		expect(result.raw).toEqual(payload);
+	});
+
+	test("session_info_changed truncates an oversized session name", () => {
+		const name = `named session ${"x".repeat(500)}`;
+		const payload = { name };
+		const result = sanitizeBridgeEvent("session_info_changed", payload, { ...baseConfig, previewBytes: 32 });
+		const data = result.data as Record<string, unknown>;
+
+		expect(data.nameBytes).toBe(Buffer.byteLength(name, "utf8"));
+		expect(data.nameLength).toBe(name.length);
+		expect((data.namePreview as string).length).toBeLessThanOrEqual(32);
+		expect(data.nameTruncated).toBe(true);
+		expect(result.truncated).toBe(true);
+		expect(result.raw).toEqual(payload);
+	});
+
+	test("session_info_changed emits an empty descriptor when the name is cleared", () => {
+		const payload = { type: "session_info_changed", name: undefined };
+		const result = sanitizeBridgeEvent("session_info_changed", payload, baseConfig);
+
+		expect(result.data).toEqual({});
+		expect(result.truncated).toBe(true);
+	});
+
+	test("session_info_changed passes non-record payloads through untouched", () => {
+		for (const payload of [undefined, null, "renamed", 42, ["renamed"]]) {
+			const result = sanitizeBridgeEvent("session_info_changed", payload, baseConfig);
+			expect(result.data).toEqual(payload);
+			expect(result.truncated).toBe(false);
+			expect(result.raw).toBeUndefined();
+		}
+	});
+
+	test("session_info_changed ignores a non-string name", () => {
+		const result = sanitizeBridgeEvent("session_info_changed", { name: 7 }, baseConfig);
+		const data = result.data as Record<string, unknown>;
+
+		expect("namePreview" in data).toBe(false);
+		expect("nameBytes" in data).toBe(false);
+	});
+
 	test("message_update reads role/contentIndex/delta from assistantMessageEvent envelope", () => {
 		const payload = {
 			assistantMessageEvent: {

--- a/pi-extensions/pi-session-bridge/extensions/__tests__/session-info-events.test.ts
+++ b/pi-extensions/pi-session-bridge/extensions/__tests__/session-info-events.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from "bun:test";
+
+import { BRIDGE_STREAM_EVENT_NAMES, REGISTRY_REFRESH_EVENT_NAMES } from "../session-bridge.js";
+
+test("session_info_changed is streamed to clients and refreshes registry metadata", () => {
+	expect(BRIDGE_STREAM_EVENT_NAMES).toContain("session_info_changed");
+	expect(REGISTRY_REFRESH_EVENT_NAMES.has("session_info_changed")).toBe(true);
+});
+
+test("every registry-refresh event is also streamed", () => {
+	const streamed = new Set<string>(BRIDGE_STREAM_EVENT_NAMES);
+	for (const eventName of REGISTRY_REFRESH_EVENT_NAMES) {
+		expect(streamed.has(eventName)).toBe(true);
+	}
+});
+
+test("streamed event names are unique", () => {
+	expect(new Set<string>(BRIDGE_STREAM_EVENT_NAMES).size).toBe(BRIDGE_STREAM_EVENT_NAMES.length);
+});

--- a/pi-extensions/pi-session-bridge/extensions/event-sanitizer.ts
+++ b/pi-extensions/pi-session-bridge/extensions/event-sanitizer.ts
@@ -22,6 +22,7 @@ const COMPACTED_EVENT_NAMES = new Set([
 	"tool_execution_update",
 	"tool_execution_end",
 	"agent_end",
+	"session_info_changed",
 	"session_compact",
 	"session_tree",
 ]);
@@ -103,6 +104,8 @@ function compactKnownEvent(eventName: string, payload: unknown, previewBytes: nu
 			return compactToolExecution(eventName, payload, previewBytes);
 		case "agent_end":
 			return compactAgentEnd(payload, previewBytes);
+		case "session_info_changed":
+			return compactSessionInfoChanged(payload, previewBytes);
 		case "session_compact":
 		case "session_tree":
 			return compactSessionTree(payload, previewBytes);
@@ -325,6 +328,28 @@ function pickAgentEndMessageCount(source: Record<string, unknown>): number | und
 	if (typeof source.messages_count === "number" && Number.isFinite(source.messages_count)) return source.messages_count;
 	if (asRecord(source.message)) return 1;
 	return undefined;
+}
+
+function compactSessionInfoChanged(payload: unknown, previewBytes: number): CompactResult {
+	const source = asRecord(payload);
+	if (!source) return { compact: payload, truncated: false };
+
+	// Pi sends `{ type, name }` and nothing else; `name` is undefined when the
+	// session name is cleared, so an empty compact is a legitimate outcome.
+	const name = pickString(source, "name");
+	const compact: Record<string, unknown> = {};
+	if (name !== undefined) {
+		const previewed = previewString(name, previewBytes);
+		compact.nameBytes = Buffer.byteLength(name, "utf8");
+		compact.nameLength = name.length;
+		compact.namePreview = previewed.preview;
+		if (previewed.truncated) compact.nameTruncated = true;
+	}
+
+	// The descriptor replaces the payload record wholesale (every unrecognized
+	// key is dropped), so report the replacement and let the raw spill keep the
+	// original — same contract as compactInputEvent/compactAgentEnd.
+	return { compact, truncated: true };
 }
 
 function compactSessionTree(payload: unknown, previewBytes: number): CompactResult {

--- a/pi-extensions/pi-session-bridge/extensions/session-bridge.ts
+++ b/pi-extensions/pi-session-bridge/extensions/session-bridge.ts
@@ -45,6 +45,37 @@ const DEFAULT_HISTORY_LIMIT = 500;
 const DEFAULT_MAX_LINE_BYTES = 1024 * 1024;
 const MAX_SKILL_EXPANSION_CACHE_SESSIONS = 100;
 
+/** Pi events the bridge republishes (after sanitizing) to subscribed clients. */
+export const BRIDGE_STREAM_EVENT_NAMES = [
+	"agent_start",
+	"agent_end",
+	"turn_start",
+	"turn_end",
+	"message_start",
+	"message_update",
+	"message_end",
+	"tool_execution_start",
+	"tool_execution_update",
+	"tool_execution_end",
+	"model_select",
+	"thinking_level_select",
+	"session_info_changed",
+	"session_compact",
+	"session_tree",
+] as const;
+
+/**
+ * Subset of {@link BRIDGE_STREAM_EVENT_NAMES} that changes the metadata written
+ * into the discovery registry (agent state, model, thinking level, session name).
+ */
+export const REGISTRY_REFRESH_EVENT_NAMES = new Set<string>([
+	"agent_start",
+	"agent_end",
+	"model_select",
+	"thinking_level_select",
+	"session_info_changed",
+]);
+
 type JsonObject = Record<string, unknown>;
 type VstackConfig = Record<string, unknown>;
 type Delivery = "auto" | "steer" | "followUp" | "now";
@@ -714,25 +745,10 @@ export default function sessionBridge(pi: ExtensionAPI) {
 		return { action: "continue" as const };
 	});
 
-	for (const eventName of [
-		"agent_start",
-		"agent_end",
-		"turn_start",
-		"turn_end",
-		"message_start",
-		"message_update",
-		"message_end",
-		"tool_execution_start",
-		"tool_execution_update",
-		"tool_execution_end",
-		"model_select",
-		"thinking_level_select",
-		"session_compact",
-		"session_tree",
-	] as const) {
+	for (const eventName of BRIDGE_STREAM_EVENT_NAMES) {
 		pi.on(eventName as never, async (event: unknown, ctx: ExtensionContext) => {
 			currentCtx = ctx;
-			if (eventName === "agent_start" || eventName === "agent_end" || eventName === "model_select" || eventName === "thinking_level_select") {
+			if (REGISTRY_REFRESH_EVENT_NAMES.has(eventName)) {
 				writeRegistrySoon(eventName);
 			}
 			publish(eventName, event);


### PR DESCRIPTION
Closes #822

Recovered work. The abandoned branch `backup/main-pre-issue-433-sync-20260706` (commits `2ac279f0`, `36a9b129`, authored 2026-07-04) was never PR'd. Verified against current main and the installed pi runtime that the gap is real and un-superseded, then **reimplemented against current main** — that branch is 3 weeks stale and merging it would revert ~86k lines.

## The event is real

`/usr/lib/pi/pi` contains:

```
const event2 = { type: "session_info_changed", name: this.sessionManager.getSessionName() };
```

It fires on session rename. Before this change `session_info_changed` appeared nowhere in the repo.

## Changes

**`session-bridge.ts`** — the `pi.on(...)` subscription list omitted the event, so the bridge never refreshed its discovery registry on a rename. Extracted the inline array to an exported `BRIDGE_STREAM_EVENT_NAMES` and the refresh predicate to an exported `REGISTRY_REFRESH_EVENT_NAMES` set (replacing a four-term `||` chain with a set lookup), and added the event to both.

**`event-sanitizer.ts`** — added the event to `COMPACTED_EVENT_NAMES` and a `compactSessionInfoChanged` handler, so it no longer flows through uncompacted now that the bridge subscribes.

**`pi-qol/qol.ts`** — added a subscription calling `syncSessionTitle`, so a rename lands immediately rather than up to one `SESSION_TITLE_SYNC_INTERVAL_MS` late. The polling timer stays as the backstop for changes pi does not announce.

## Two defects in the original work, deliberately not ported

1. **Phantom `previousName` field.** The abandoned compactor read `previousName`/`previous_name`. Pi sends `name` only — that branch would have emitted dead fields forever.
2. **Wrong `truncated` semantics.** The original returned `truncated: truncated || name !== undefined || previousName !== undefined`, which yields `false` for a cleared-name payload. In this file `truncated` means *the payload was replaced by a descriptor*, not *a string was cut* — `compactInputEvent` and `compactAgentEnd` both return `truncated: true` unconditionally once the payload is a record. A `false` there would tell clients the payload passed through intact when every key had in fact been dropped. Now returns `truncated: true`, matching the established contract.

The original also churned in qol (first commit added `refreshStatusline` + `requestRender`, second removed both); this lands the settled title-sync-only version. `currentCtx = ctx` was dropped to match the neighbouring `model_select`/`thinking_level_select` handlers, which don't set it.

No `package.json` version bumps — recent extension commits don't bump; versions land in a separate release commit (e.g. `622b9d5f`).

## Tests

New: structural assertions that the event is in both exported sets, plus invariants that every registry-refresh event is streamed and streamed names are unique; sanitizer cases for happy path, oversized-name truncation, cleared name (empty descriptor, `truncated: true`), and non-record passthrough; qol cases for the UI sync path and the headless no-op guard.

- `pi-session-bridge`: **68 pass, 0 fail** (8 files)
- `pi-qol`: **93 pass, 0 fail** (14 files)