### PR TITLE
docs(github): document pr-merge's thread-gate bounds and the unreachable-thread escape path

### DIFF
--- a/skills/github/README.md
+++ b/skills/github/README.md
@@ -78,6 +78,17 @@ conflicting flags fail before any GitHub lookup or mutation. A nonzero forced
 mutation returns exit `1` unless the exact-head post-state is already `MERGED`.
 Auto-merge or queue enrollment active before the call cannot mask the failure.
 
+That gate is deliberately narrower than GitHub's
+`required_conversation_resolution`, which requires *all* conversations resolved
+with no outdated/active distinction: an outdated thread no longer refers to the
+current diff and is not actionable. It is also policy, not mechanism —
+`pr-merge` gates only merges that go through it, and a raw `gh pr merge` or the
+UI Merge button bypasses it. Conversely, where branch protection *is* enabled,
+an outdated thread can become unreachable in the UI while still blocking the
+merge (404 on click, zero visible conversations, merge refused); `pr-threads`
+plus `resolve-thread` clear it by thread id through GraphQL. See SKILL.md
+§ PR blocked with no visible conversations.
+
 ## Git HTTPS Fallback
 
 Use `scripts/git-https-auth` for the GitHub network operations in workflows

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -26,7 +26,7 @@ CLI wrapper for GitHub API operations used in PR workflows. Provides structured 
 |---------|---------|
 | `pr-data <N> [--actionable]` | Get PR with threads, comments, files. `--actionable`: unresolved non-outdated only. |
 | `pr-view [N] [--json FIELDS]` | View PR details (wraps gh pr view with bounded auth/no-PR errors) |
-| `pr-threads <N> [--unresolved]` | Get the complete paginated thread list/count; fails rather than returning a partial list. |
+| `pr-threads <N> [--unresolved]` | Get the complete paginated thread list/count, outdated included; fails rather than returning a partial list. See *PR blocked with no visible conversations*. |
 | `pr-review-status <N> [--baseline-ts TS --baseline-threads N]` | Check review state, determine if action needed |
 | `pr-list-ready [--all] [--format=safe\|table]` | List PRs ready for merge |
 | `pr-list-failing [--all] [--format=safe\|table]` | List PRs with CI failures |
@@ -41,7 +41,7 @@ CLI wrapper for GitHub API operations used in PR workflows. Provides structured 
 | `ci-logs <N> [--lines N] [--format=safe\|text]` | Get CI failure logs for PR |
 | `bot-token [--format=safe\|text]` | Check if bot token is configured |
 | `dismiss-review <PR> [--bot\|--user NAME] [--message M]` | Dismiss blocking review |
-| `resolve-thread <PRRT_...>` | Mark thread(s) resolved |
+| `resolve-thread <PRRT_...>` | Mark thread(s) resolved. Works on threads the UI cannot render. See *PR blocked with no visible conversations*. |
 | `unresolve-thread <PRRT_...>` | Reopen thread(s) |
 | `post-reply <PRRT_...\|numeric-id> [body \| --body-file PATH] [--pr N]` | Reply to review comment. `--pr N` is REQUIRED for numeric comment IDs; thread `PRRT_...` IDs need no PR number. Prefer `--body-file` for Markdown with backticks; inline body is safe only for plain strings. |
 | `post-comment <PR> [body \| --body-file PATH]` | Post PR-level comment. Same body-file preference as `post-reply`. |
@@ -131,14 +131,28 @@ PR with neither queue nor auto-merge proof fails closed.
 Actionable review threads (unresolved and not outdated) are a hard local gate.
 They make `can_merge` false and block both immediate merge and `--auto` before
 any merge or queue mutation. A failed or malformed thread lookup also blocks,
-because an unknown review state cannot be treated as clean. The documented
-`--force` flag is the only deliberate override and skips every safety check.
+because an unknown review state cannot be treated as clean.
 
-`--force` has immediate-only semantics and cannot be combined with `--auto`;
-the conflicting flags fail before any GitHub lookup or mutation. If its
-guarded `gh pr merge` mutation fails and the exact-head post-state is not
-`MERGED`, `pr-merge` returns BLOCKED even when classic auto-merge or a
-merge-queue entry was already active.
+Two bounds on that gate:
+
+- **Narrower than branch protection.** GitHub's
+  `required_conversation_resolution` requires *all* conversations resolved and
+  draws no outdated/active distinction. `pr-merge` deliberately counts only
+  threads that are unresolved *and* not outdated, because a thread pinned to a
+  diff that no longer exists cannot be acted on. A repo relying on `pr-merge`
+  alone therefore has a narrower guarantee than one relying on branch
+  protection.
+- **Policy, not mechanism.** `pr-merge` is the enforcement point only for
+  merges that go through it. A raw `gh pr merge` or the GitHub UI Merge button
+  bypasses the skill entirely, so a repo whose CI does not independently gate
+  threads has no thread enforcement on those paths.
+
+The documented `--force` flag is the only deliberate override of that gate and
+skips every safety check. It has immediate-only semantics and cannot be
+combined with `--auto`; the conflicting flags fail before any GitHub lookup or
+mutation. If its guarded `gh pr merge` mutation fails and the exact-head
+post-state is not `MERGED`, `pr-merge` returns BLOCKED even when classic
+auto-merge or a merge-queue entry was already active.
 Pre-existing deferred state is not proof that the forced immediate attempt
 succeeded. An authoritative exact-head `MERGED` post-state remains success;
 non-force and `--auto` idempotent pending outcomes retain exit `75`.
@@ -149,6 +163,25 @@ UNKNOWN, `ci_pending`, CI fetch uncertainty — caller should
 `changes_requested` — caller must fix and re-push). Programmatic callers can
 check the `transient` field in the `--check` JSON output before deciding to
 retry.
+
+### PR blocked with no visible conversations
+
+Under `required_conversation_resolution`, an outdated thread can become
+unreachable in the UI while still blocking the merge: after a rebase or
+force-push the commented commits are gone, clicking the unresolved
+conversation 404s, and the PR shows zero visible conversations yet refuses to
+merge (github/community discussions #144455, #10592, #184355). GraphQL
+`resolveReviewThread` still acts on threads the UI cannot render, so this skill
+is the escape hatch:
+
+```bash
+github.sh pr-threads 42                  # complete list, outdated included
+github.sh resolve-thread PRRT_kwDO...    # resolve by thread id
+```
+
+`pr-threads` follows every page and fails rather than returning a partial list,
+so a thread id absent from its output is genuinely absent. Repeat
+`resolve-thread` per blocking id until the merge clears.
 
 ### PR Merge Check Output
 

--- a/skills/github/tests/pr-merge-thread-gate-docs.test.sh
+++ b/skills/github/tests/pr-merge-thread-gate-docs.test.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Docs regression tests for pr-merge's review-thread gate (vstack#825).
+#
+# pr-merge counts only threads that are unresolved AND not outdated, which is
+# deliberately narrower than GitHub's required_conversation_resolution. That
+# divergence, the fact that the gate binds only merges routed through the
+# skill, and the recovery path for outdated threads that block a merge while
+# being unreachable in the UI all live in prose only. These tests pin that
+# prose to the real script behavior so neither side can drift silently.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../.." && pwd)"
+SKILL_MD="$REPO_ROOT/skills/github/SKILL.md"
+README_MD="$REPO_ROOT/skills/github/README.md"
+PR_MERGE="$REPO_ROOT/skills/github/scripts/commands/pr-merge.sh"
+
+PASS=0
+FAIL=0
+
+assert_contains() {
+  local got="$1" needle="$2" name="$3"
+  if [[ "$got" == *"$needle"* ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected to contain: %s\n' "$name" "$needle"
+  fi
+}
+
+assert_matches() {
+  local got="$1" pattern="$2" name="$3"
+  if grep -qE "$pattern" <<<"$got"; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected to match: %s\n' "$name" "$pattern"
+  fi
+}
+
+echo "=== pr-merge thread-gate docs match the script (vstack#825) ==="
+
+# 0. The behavior the docs describe is still what the script does. If this
+#    filter changes, the prose below is wrong and must be revisited.
+script_src=$(cat "$PR_MERGE")
+assert_contains "$script_src" \
+  'select(.is_resolved == false and .is_outdated == false)' \
+  "pr-merge.sh still counts unresolved AND non-outdated threads only"
+assert_matches "$script_src" 'unresolved_threads\|review_threads_fetch_failed' \
+  "pr-merge.sh still fails closed on unreadable thread state"
+
+skill_src=$(cat "$SKILL_MD")
+readme_src=$(cat "$README_MD")
+
+# 1. Actionable-only semantics, named against the platform setting it diverges
+#    from, so an operator can tell the two guarantees apart.
+assert_contains "$skill_src" 'required_conversation_resolution' \
+  "SKILL.md names required_conversation_resolution"
+assert_matches "$skill_src" 'narrower guarantee|Narrower than branch protection' \
+  "SKILL.md states the gate is narrower than branch protection"
+assert_matches "$skill_src" 'not outdated|non-outdated' \
+  "SKILL.md states outdated threads are excluded from the gate"
+
+# 2. Policy, not mechanism: the gate binds only merges routed through pr-merge.
+assert_matches "$skill_src" 'Policy, not mechanism' \
+  "SKILL.md frames the gate as policy rather than mechanism"
+assert_matches "$skill_src" 'UI Merge button|Merge button' \
+  "SKILL.md names the UI Merge button as a bypass"
+assert_matches "$skill_src" 'raw .gh pr merge' \
+  "SKILL.md names raw gh pr merge as a bypass"
+
+# 3. The unreachable-thread escape path. Match on the searchable heading an
+#    operator would land on, then on both commands the recovery needs.
+assert_contains "$skill_src" '### PR blocked with no visible conversations' \
+  "SKILL.md has a findable heading for the unreachable-thread case"
+escape_block=$(sed -n '/^### PR blocked with no visible conversations$/,/^### /p' "$SKILL_MD")
+assert_contains "$escape_block" 'resolveReviewThread' \
+  "escape path names the GraphQL mutation the UI cannot reach"
+assert_contains "$escape_block" 'pr-threads' \
+  "escape path tells the operator to list threads with pr-threads"
+assert_contains "$escape_block" 'resolve-thread' \
+  "escape path tells the operator to resolve by id with resolve-thread"
+assert_matches "$escape_block" 'force-push|rebase' \
+  "escape path explains how a thread becomes unreachable"
+
+# 4. The command table rows stay index entries pointing at that prose.
+threads_row=$(grep '^| `pr-threads ' "$SKILL_MD" || true)
+resolve_row=$(grep '^| `resolve-thread ' "$SKILL_MD" || true)
+assert_contains "$threads_row" 'PR blocked with no visible conversations' \
+  "pr-threads row points at the escape-path section"
+assert_contains "$resolve_row" 'PR blocked with no visible conversations' \
+  "resolve-thread row points at the escape-path section"
+
+# 5. README carries the same three points for the non-agent surface.
+assert_contains "$readme_src" 'required_conversation_resolution' \
+  "README.md names required_conversation_resolution"
+assert_matches "$readme_src" 'policy, not mechanism' \
+  "README.md states the policy-not-mechanism bound"
+assert_matches "$readme_src" 'unreachable in the UI' \
+  "README.md states the unreachable-thread hazard"
+assert_contains "$readme_src" 'resolve-thread' \
+  "README.md points at resolve-thread for recovery"
+
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Closes #825

Docs only — no script or behavior change. Two of the issue's original five items were decided **not** to build (see the issue comment): no strict mode counting outdated threads (it would voluntarily reproduce a deadlock operators often cannot see or reach), and no warning when `required_conversation_resolution` is disabled (that item's premise inverted).

## What this documents

All three behaviors verified against `pr-merge.sh` before writing:

- **Narrower than branch protection.** The gate counts only threads that are unresolved *and* not outdated (line ~217), because a thread pinned to a diff that no longer exists cannot be acted on. GitHub's `required_conversation_resolution` draws no such distinction, so a repo relying on `pr-merge` alone has a narrower guarantee. Stated as the deliberate design choice it is.
- **Policy, not mechanism.** `pr-merge` enforces only for merges that go through it — a raw `gh pr merge` or the UI Merge button bypasses the skill entirely. This became load-bearing when drovr removed its CI thread term in drovr#259.
- **The unreachable-thread escape path** (the most useful addition). Under `required_conversation_resolution`, an outdated thread can become unreachable in the UI while still blocking the merge — after a rebase or force-push the commented commits are gone, the conversation link 404s, and the PR shows zero visible conversations yet refuses to merge (github/community #144455, #10592, #184355). GraphQL `resolveReviewThread` still acts on those threads, so the skill is the escape hatch: `pr-threads` to list (complete, outdated included, fails rather than returning a partial list), `resolve-thread` by id to clear. The memsira session used exactly this 8 times on one PR today.

It lands under a heading someone hitting the problem would actually search for — *PR blocked with no visible conversations* — with the `pr-threads` and `resolve-thread` command-table rows cross-referencing it, since the table is where an operator looks first.

The existing `--force` prose is preserved, only reflowed around the new bullets.

## Tests

New `skills/github/tests/pr-merge-thread-gate-docs.test.sh` (**19 pass, 0 fail**) asserts each claim stays documented — the narrower-than-branch-protection statement, the outdated exclusion, both bypass paths named, the findable heading, the GraphQL mutation named, the list-then-resolve-by-id recovery, and the command-table cross-references. Follows the existing `post-reply-skill-docs.test.sh` pattern.

Full github skill suite green — all 15 test files.