### PR TITLE
docs(agents): two ways provenance tags fail — artifact reads and tone

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,6 +238,11 @@ Real instance (2026-07-24): a live connector enumeration went upstream as the ex
 
 The corollary that resolves most cases: checking your own code's *behavior* against a fact corroborates it (it tests whether the code copes). Checking a *list you populated* does not (it tests your memory of what you typed).
 
+Two ways the tags fail in practice, both observed:
+
+- **Reading the artifact instead of the source.** Control-flow claims derived from a vendored, minified, post-bundler copy are not `[live]` readings of the code — they are `[inferred]` from a lossy transform. This is structurally likely here for the same reason as the round-trip: consuming repos hold bundles, not sources, so the nearest copy is the wrong one. Cite `src/` with file and line; if only a bundle is at hand, say so and downgrade the claim.
+- **Tone upgrading a tag.** `[inferred]` labelled honestly and then described as "the most promising lead" functions as `[live]` for every reader. The tag is not a disclaimer that buys stronger prose — if the surrounding sentence would survive being read as verified, the tag is not doing its job.
+
 Same family as the date-stamping rule below — both let a future reader judge how far to trust a line without re-deriving it.
 
 ## Cross-Repo Review Gate


### PR DESCRIPTION
Both failures observed within hours of the convention landing in #830, on the same lead — the vstack#832 connector-race hypothesis. Adding them because the convention as merged did not catch either.

## 1. Reading the artifact instead of the source

The drovr session supplied a "the warm path already exists in-bundle" hypothesis whose three premises were all false. The root cause is the instructive part and it was not carelessness: they read the **vendored, minified, post-esbuild bundle** and reasoned about control flow from it. I read `src/index.ts` and got a different answer.

This is structurally likely here for exactly the same reason as the round-trip already documented in that section: **consuming repos hold bundles, not sources**, so the nearest copy is the wrong one. A control-flow claim from a lossy transform is `[inferred]`, not `[live]`, however carefully it was read.

The rule added is cheap: cite `src/` with file and line, and if only a bundle is at hand, say so and downgrade.

## 2. Tone upgrading a tag

Self-diagnosed by the same session, and the sharper of the two: the lead was tagged `[inferred]` **honestly**, then described as *"the most promising lead"*. That is `[inferred]` doing the work of `[live]` by tone, and every reader downstream acts on the prose rather than the bracket.

This is a real gap in what #830 shipped. The tag is not a disclaimer that licenses stronger prose — if the surrounding sentence would survive being read as verified, the tag is not doing its job.

Worth noting the convention still worked: it is why the source got read at all, and why the lead was retracted in hours rather than after someone built a rig. But a taxonomy that can be defeated by an adjective needs the adjective named.

Docs only. Five lines.