### PR TITLE
docs(cross-repo): generalise the probe contract to partial results

### DIFF
--- a/docs/cross-repo.md
+++ b/docs/cross-repo.md
@@ -45,3 +45,11 @@ All three sessions send into each other's tmux panes. The failure modes are not 
 - **Re-capture after sending, before Enter.** If the composer holds anything that is not your own just-sent text — an in-progress draft, an earlier queued line, a menu — do not press Enter. Surface the collision instead.
 - **Verify delivery by a short distinctive fragment.** Long phrases wrap across lines and a `grep` for them returns zero on a message that landed fine. Search the scrollback (`capture-pane -S -300`), not just the visible pane.
 - **Backticks in the message body get shell-expanded** by the sending shell and silently drop identifiers. Quote with single quotes, or avoid them.
+
+## Capability Probe Contract
+
+For any probe whose result other repos store and act on — connector inventories being the live case.
+
+- **An empty result is not evidence of absence.** It must never overwrite a known-good inventory; mark the snapshot as a failed check and render "couldn't check", not "not connected", so a retry cannot erase what was already known.
+- **A partial result is not evidence of absence either, and it is more dangerous.** An empty probe looks wrong; a partial one looks successful. A search-driven probe returns a lower bound — whatever the search surfaced — so a result can be genuinely non-failing and still incomplete. `probe_failed = false` answers "did the probe error", never "is this list complete".
+- **Consumers may only treat a result as an enumeration if it says it is one.** Absent an explicit completeness signal, treat every probe result as a lower bound and never conclude a capability is missing from it.


### PR DESCRIPTION
The agreed probe contract covered only the **empty** case: an empty result must not overwrite a known-good inventory. A live finding from the memsira session shows that is insufficient.

## The finding

An account demonstrably has Slack — 19 real `mcp__claude_ai_Slack` tool ids enumerated and a real Slack write completed. Its stored inventory read `atlassian, gmail, calendar, drive` with **`probe_failed = false`**.

Attach succeeded. The probe succeeded. The answer was still wrong.

## Why the existing contract does not catch it

The probe is **search-driven**, so it returns a *lower bound* — whatever the search surfaced — not an enumeration. That makes a partial result **more dangerous than an empty one**: an empty probe looks wrong and trips the existing guard, while a partial one looks successful and sails through it.

`probe_failed` answers *did the probe error*. It never answers *is this list complete*, and nothing else did either.

## Why here rather than in an app

drovr is adopting the probe contract right now and would inherit the identical gap the moment it enables connectors. This is the case `docs/cross-repo.md` exists for — one rule, both consumers, no second wording to drift from.

Bridge-side deliverable is tracked in vstack#838 (deterministic enumeration, or an explicit completeness signal). The storage half stays downstream in memsira#275. This PR only records the rule consumers must follow in the meantime: absent an explicit completeness signal, treat every probe result as a lower bound and never conclude a capability is missing from it.

Docs only. Three bullets.
