### PR TITLE
fix(pi-claude-bridge): drain torn-turn tool calls as errors naming the cause

### DIFF
--- a/pi-extensions/pi-claude-bridge/bundle/index.js
+++ b/pi-extensions/pi-claude-bridge/bundle/index.js
@@ -27189,6 +27189,30 @@ function extractAllToolResults(messages) {
 }
 
 // src/query-state.ts
+var DRAIN_CAUSE_TEXT = {
+  "abort": "the turn was aborted",
+  "stream-idle-timeout": "the Claude Code stream went idle and the turn timed out",
+  "query-end": "the query ended"
+};
+function interruptedToolCallResult(cause) {
+  return {
+    content: [{ type: "text", text: `Claude bridge: ${DRAIN_CAUSE_TEXT[cause]} before this tool call's result was delivered. The call did not complete and produced no output.` }],
+    isError: true
+  };
+}
+function toolCallDrainCause(flags) {
+  if (flags.wasAborted || flags.signalAborted) return "abort";
+  if (flags.streamIdleTimedOut) return "stream-idle-timeout";
+  return "query-end";
+}
+function drainPendingToolCalls(queryCtx, cause) {
+  const drained = queryCtx.pendingToolCalls.size;
+  if (drained === 0) return 0;
+  const result = interruptedToolCallResult(cause);
+  for (const pending of queryCtx.pendingToolCalls.values()) pending.resolve(result);
+  queryCtx.pendingToolCalls.clear();
+  return drained;
+}
 function normalizeForCompare(value) {
   if (Array.isArray(value)) return value.map(normalizeForCompare);
   if (value && typeof value === "object") {
@@ -44888,10 +44912,8 @@ function streamClaudeAgentSdk(model, context, options) {
     wasAborted = true;
     abortCtx.deferredUserMessages = [];
     reportToolResultMismatch(abortCtx, "abort", cwd, { forceRotate: true });
-    for (const pending of abortCtx.pendingToolCalls.values()) {
-      pending.resolve({ content: [{ type: "text", text: "Operation aborted" }] });
-    }
-    abortCtx.pendingToolCalls.clear();
+    const drained = drainPendingToolCalls(abortCtx, "abort");
+    if (drained > 0) debug(`provider: abort drained ${drained} waiting MCP handler(s) as errors`);
     abortCtx.pendingResults.clear();
     requestAbort();
   };
@@ -44983,11 +45005,10 @@ function streamClaudeAgentSdk(model, context, options) {
     activeStreamIdleWatchdogs.delete(abortCtx);
     if (options?.signal) options.signal.removeEventListener("abort", onAbort);
     if (ctx().activeQuery === sdkQuery) {
-      reportToolResultMismatch(ctx(), "query teardown", cwd, { forceRotate: wasAborted || options?.signal?.aborted || streamIdleTimedOut });
-      for (const pending of ctx().pendingToolCalls.values()) {
-        pending.resolve({ content: [{ type: "text", text: "Query ended" }] });
-      }
-      ctx().pendingToolCalls.clear();
+      const cause = toolCallDrainCause({ wasAborted, signalAborted: options?.signal?.aborted, streamIdleTimedOut });
+      reportToolResultMismatch(ctx(), "query teardown", cwd, { forceRotate: cause !== "query-end" });
+      const drained = drainPendingToolCalls(ctx(), cause);
+      if (drained > 0) debug(`provider: query teardown drained ${drained} waiting MCP handler(s) as errors (cause=${cause})`);
       ctx().pendingResults.clear();
       if (isReentrant) {
         popContext();

--- a/pi-extensions/pi-claude-bridge/src/index.ts
+++ b/pi-extensions/pi-claude-bridge/src/index.ts
@@ -7,7 +7,7 @@ import { PROVIDER_ID, messageContentToText } from "./convert.js";
 import { FABLE_FALLBACK_MODEL_ID, FABLE_MODEL_ID, buildModels, fallbackModelForPrimaryModel } from "./models.js";
 import { MCP_SERVER_NAME, MCP_TOOL_PREFIX, extractSkillsBlock } from "./skills.js";
 import { extractAllToolResults as _extractAllToolResults, type McpResult } from "./extract-tool-results.js";
-import { QueryContext, ctx, stackDepth, pushContext, popContext } from "./query-state.js";
+import { QueryContext, ctx, drainPendingToolCalls, stackDepth, pushContext, popContext, toolCallDrainCause } from "./query-state.js";
 import { loadConfig, normalizeEffortLevel, recordProjectTrust, type Config } from "./config.js";
 import { decideRegistration, hasClaudeCredentials } from "./auth-presence.js";
 import { extractAgentsAppend } from "./agents-md.js";
@@ -913,8 +913,8 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 		// Prevent stale deferred messages from being replayed by parent on pop
 		abortCtx.deferredUserMessages = [];
 		reportToolResultMismatch(abortCtx, "abort", cwd, { forceRotate: true });
-		for (const pending of abortCtx.pendingToolCalls.values()) { pending.resolve({ content: [{ type: "text", text: "Operation aborted" }] }); }
-		abortCtx.pendingToolCalls.clear();
+		const drained = drainPendingToolCalls(abortCtx, "abort");
+		if (drained > 0) debug(`provider: abort drained ${drained} waiting MCP handler(s) as errors`);
 		abortCtx.pendingResults.clear();
 		requestAbort();
 	};
@@ -1025,10 +1025,12 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 			activeStreamIdleWatchdogs.delete(abortCtx);
 			if (options?.signal) options.signal.removeEventListener("abort", onAbort);
 			if (ctx().activeQuery === sdkQuery) {
-				reportToolResultMismatch(ctx(), "query teardown", cwd, { forceRotate: wasAborted || options?.signal?.aborted || streamIdleTimedOut });
-				// Drain pending handlers for this query
-				for (const pending of ctx().pendingToolCalls.values()) { pending.resolve({ content: [{ type: "text", text: "Query ended" }] }); }
-				ctx().pendingToolCalls.clear();
+				const cause = toolCallDrainCause({ wasAborted, signalAborted: options?.signal?.aborted, streamIdleTimedOut });
+				reportToolResultMismatch(ctx(), "query teardown", cwd, { forceRotate: cause !== "query-end" });
+				// Drain pending handlers for this query as errors naming the cause —
+				// their results are never coming.
+				const drained = drainPendingToolCalls(ctx(), cause);
+				if (drained > 0) debug(`provider: query teardown drained ${drained} waiting MCP handler(s) as errors (cause=${cause})`);
 				ctx().pendingResults.clear();
 
 				if (isReentrant) {

--- a/pi-extensions/pi-claude-bridge/src/query-state.ts
+++ b/pi-extensions/pi-claude-bridge/src/query-state.ts
@@ -14,6 +14,48 @@ export interface PendingToolCall {
 	resolve: (result: McpResult) => void;
 }
 
+// Why pending MCP handlers were drained without a real tool result. A drained
+// handler is waiting on a result pi will now never deliver, so the drain must
+// resolve as an error — never as a successful result whose text merely says the
+// turn died, which a consumer cannot tell apart from a tool that genuinely
+// returned that string. The cause is carried because an abort, an idle timeout,
+// and a plain end-with-stragglers are different things to act on.
+export type ToolCallDrainCause = "abort" | "stream-idle-timeout" | "query-end";
+
+const DRAIN_CAUSE_TEXT: Record<ToolCallDrainCause, string> = {
+	"abort": "the turn was aborted",
+	"stream-idle-timeout": "the Claude Code stream went idle and the turn timed out",
+	"query-end": "the query ended",
+};
+
+export function interruptedToolCallResult(cause: ToolCallDrainCause): McpResult {
+	return {
+		content: [{ type: "text", text: `Claude bridge: ${DRAIN_CAUSE_TEXT[cause]} before this tool call's result was delivered. The call did not complete and produced no output.` }],
+		isError: true,
+	};
+}
+
+// Precedence matches the forceRotate expression at the query-teardown site: an
+// explicit abort (pi's signal or our own abort handler) outranks a stream-idle
+// timeout, which outranks a plain end with stragglers.
+export function toolCallDrainCause(flags: { wasAborted?: boolean; signalAborted?: boolean; streamIdleTimedOut?: boolean }): ToolCallDrainCause {
+	if (flags.wasAborted || flags.signalAborted) return "abort";
+	if (flags.streamIdleTimedOut) return "stream-idle-timeout";
+	return "query-end";
+}
+
+/** Resolves every handler still waiting on `queryCtx` with an error result naming
+ *  `cause`, clears the map, and returns how many were drained. Scoped to the one
+ *  context it is given — never touches a sibling or parent query's handlers. */
+export function drainPendingToolCalls(queryCtx: QueryContext, cause: ToolCallDrainCause): number {
+	const drained = queryCtx.pendingToolCalls.size;
+	if (drained === 0) return 0;
+	const result = interruptedToolCallResult(cause);
+	for (const pending of queryCtx.pendingToolCalls.values()) pending.resolve(result);
+	queryCtx.pendingToolCalls.clear();
+	return drained;
+}
+
 export interface TurnToolCallRecord {
 	id: string;
 	toolName: string;

--- a/pi-extensions/pi-claude-bridge/tests/unit-tool-drain.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-tool-drain.mjs
@@ -1,0 +1,118 @@
+/**
+ * Tests for draining MCP handlers that are still waiting when a query tears down.
+ * A drained handler must resolve as an ERROR naming the teardown cause — never as
+ * a successful result whose text merely says the turn died, which a consumer
+ * cannot tell apart from a tool that genuinely returned that string.
+ * Uses the real module — no API calls, no extension activation.
+ */
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { QueryContext, ctx, drainPendingToolCalls, interruptedToolCallResult, resetStack, toolCallDrainCause } from "../src/query-state.js";
+
+// Registers a waiting handler the same way buildMcpServers does: the handler's
+// return value IS this promise, so awaiting it is what a real tool call sees.
+function registerWaitingCall(queryCtx, toolCallId, toolName = "read") {
+	return new Promise((resolve) => {
+		queryCtx.pendingToolCalls.set(toolCallId, {
+			toolName,
+			resolve: (result) => {
+				queryCtx.markToolResultResolved(toolCallId);
+				resolve(result);
+			},
+		});
+	});
+}
+
+describe("pending tool call drain", () => {
+	beforeEach(() => resetStack());
+
+	it("resolves a waiting call as an error, not a success carrying teardown text", async () => {
+		const waiting = registerWaitingCall(ctx(), "call-1");
+		assert.equal(drainPendingToolCalls(ctx(), "query-end"), 1);
+
+		const result = await waiting;
+		assert.equal(result.isError, true, "drained tool call must be marked as an error");
+		assert.equal(result.content[0].type, "text");
+		assert.match(result.content[0].text, /the query ended before this tool call's result was delivered/);
+	});
+
+	it("names the abort cause distinctly from a plain query end", async () => {
+		const waiting = registerWaitingCall(ctx(), "call-abort");
+		assert.equal(drainPendingToolCalls(ctx(), "abort"), 1);
+
+		const result = await waiting;
+		assert.equal(result.isError, true);
+		assert.match(result.content[0].text, /the turn was aborted/);
+		assert.doesNotMatch(result.content[0].text, /the query ended/);
+	});
+
+	it("names the stream-idle timeout cause distinctly", async () => {
+		const waiting = registerWaitingCall(ctx(), "call-idle");
+		assert.equal(drainPendingToolCalls(ctx(), "stream-idle-timeout"), 1);
+
+		const result = await waiting;
+		assert.equal(result.isError, true);
+		assert.match(result.content[0].text, /stream went idle and the turn timed out/);
+	});
+
+	it("every cause is an error and every cause reads differently", () => {
+		const texts = new Set();
+		for (const cause of ["abort", "stream-idle-timeout", "query-end"]) {
+			const result = interruptedToolCallResult(cause);
+			assert.equal(result.isError, true, `${cause} must be an error result`);
+			assert.ok(result.content[0].text.length > 0);
+			texts.add(result.content[0].text);
+		}
+		assert.equal(texts.size, 3, "each teardown cause must produce its own message");
+	});
+
+	it("drains every waiting handler, clears the map, and marks them resolved", async () => {
+		const first = registerWaitingCall(ctx(), "call-a", "read");
+		const second = registerWaitingCall(ctx(), "call-b", "grep");
+
+		assert.equal(drainPendingToolCalls(ctx(), "abort"), 2);
+		assert.equal(ctx().pendingToolCalls.size, 0);
+		for (const result of await Promise.all([first, second])) assert.equal(result.isError, true);
+		assert.ok(ctx().resolvedToolResultIds.has("call-a"));
+		assert.ok(ctx().resolvedToolResultIds.has("call-b"));
+	});
+
+	it("is a no-op with nothing waiting", () => {
+		assert.equal(drainPendingToolCalls(ctx(), "query-end"), 0);
+	});
+
+	it("is scoped to the context it is given and leaves other queries alone", async () => {
+		const other = new QueryContext();
+		let otherResolved = false;
+		void registerWaitingCall(other, "other-call").then(() => { otherResolved = true; });
+		const mine = registerWaitingCall(ctx(), "my-call");
+
+		assert.equal(drainPendingToolCalls(ctx(), "query-end"), 1);
+		await mine;
+		await new Promise((resolve) => setImmediate(resolve));
+
+		assert.equal(otherResolved, false, "another query's handlers must not be drained");
+		assert.equal(other.pendingToolCalls.size, 1);
+	});
+});
+
+describe("teardown cause selection", () => {
+	it("maps a plain end with stragglers to query-end", () => {
+		assert.equal(toolCallDrainCause({}), "query-end");
+		assert.equal(toolCallDrainCause({ wasAborted: false, signalAborted: false, streamIdleTimedOut: false }), "query-end");
+	});
+
+	it("maps our own abort handler and pi's abort signal to abort", () => {
+		assert.equal(toolCallDrainCause({ wasAborted: true }), "abort");
+		assert.equal(toolCallDrainCause({ signalAborted: true }), "abort");
+	});
+
+	it("maps a stream-idle timeout to stream-idle-timeout", () => {
+		assert.equal(toolCallDrainCause({ streamIdleTimedOut: true }), "stream-idle-timeout");
+	});
+
+	it("prefers abort when a timeout and an abort both fired", () => {
+		assert.equal(toolCallDrainCause({ streamIdleTimedOut: true, wasAborted: true }), "abort");
+		assert.equal(toolCallDrainCause({ streamIdleTimedOut: true, signalAborted: true }), "abort");
+	});
+});


### PR DESCRIPTION
Closes #840

## The defect

When a query died with MCP tool handlers still waiting, the bridge resolved each one with a **success-shaped** result whose content was a bare string:

```js
pending.resolve({ content: [{ type: "text", text: "Query ended" }] });      // teardown
pending.resolve({ content: [{ type: "text", text: "Operation aborted" }] }); // abort
```

No `isError`. A consumer cannot tell that apart from a tool that genuinely returned that text, so a torn turn read as a successful call.

**There were two such sites, not one.** The issue identified the teardown drain; the abort handler had the same shape and is fixed here too.

That this is a defect rather than a design choice is settled by the same file: the unmatched-result path already builds an `McpResult` with `isError: true` and an explanatory message, over the same map. The file already knew the right shape — two paths just didn't use it.

## The fix

Both sites now go through `drainPendingToolCalls(ctx, cause)` in `query-state.ts`, which resolves every waiting handler with `isError: true` and a message naming *why* the result is never coming — an abort, a stream-idle timeout, and a plain end-with-stragglers are different things for a consumer to act on.

`forceRotate` at the teardown site was rewritten as `cause !== "query-end"`. That is exactly equivalent to the previous `wasAborted || signalAborted || streamIdleTimedOut`, since `toolCallDrainCause` returns `query-end` only when none of the three is set — verified, not assumed.

**The drain stays scoped to the one context it is given.** That is the bridge's structural advantage over the downstream app that hit this class (memsira#279, where a session-scoped error can only reach its own sink because broadcast would kill unrelated chats). There is no broadcast hazard here, and a test now pins that a drain leaves a sibling query's handlers untouched so it cannot regress.

## Bundle

`bundle/index.js` regenerated. Checked the convention rather than guessing: all six most recent commits touching `src/` also shipped a bundle rebuild. Verified the artifact actually reflects the change — the new cause strings are present, `text: "Query ended"` is gone, and the three remaining `Operation aborted` hits are unrelated (two from a bundled dependency, one the untouched `turnOutput.errorMessage`).

## Tests

`tests/unit-tool-drain.mjs`, 11 cases: error-not-success, each cause distinct and all marked errors, full drain and map clear, no-op when empty, context scoping, and cause precedence including abort winning over a concurrent timeout.

Full unit suite: **235 pass, 0 fail** (52 suites).

**Coverage honesty** — these exercise the extracted helper and the cause mapping directly. They do *not* drive a real torn turn through a live subprocess; that the two call sites invoke the helper correctly is verified by reading the diff, not by execution. Per the repo's own rule that green CI is not proof for subprocess-driving code, treat the integration as reviewed rather than tested.
