### PR TITLE
docs(cross-repo): ownership follows the dependency, not the vocabulary

### DIFF
--- a/docs/cross-repo.md
+++ b/docs/cross-repo.md
@@ -23,6 +23,12 @@ Two ways the tags fail in practice, both observed:
 
 Same family as the date-stamping rule below — both let a future reader judge how far to trust a line without re-deriving it.
 
+## Deciding Which Repo Owns a Change
+
+**Ownership follows the dependency, not the vocabulary.** Ask one question: does this change need anything from another repo? If not, it is yours — however much shared language it borrows.
+
+"Shared" is a vibe and cannot be checked; the dependency question can. The failure it prevents is the one recorded above, where two handoffs each assigned a feature to the other and neither built it — that is this bug's specific instance, and the vocabulary trap is its general form. A mechanism can be upstream in one use and purely local in another: probe convergence used as an attach-race gate is the bridge's, while the same convergence used as inventory reconciliation needs nothing upstream and belongs to the app. Calling both "the convergence work" makes the second read as upstream-blocked and stalls it behind a repo that owes it nothing.
+
 ## Cross-Repo Review Gate
 
 Agreed shape for drovr, memsira, and hyprtrade (settled 2026-07-24). Empirically tested on two repos independently — memsira PR #272 and drovr PR #262, each a live PR with a real unresolved thread — not inferred from docs. Recorded here so it is not re-litigated per repo.


### PR DESCRIPTION
Proposed by the drovr session, and independently confirmed by memsira from the other side of the same disagreement — two accounts, not one restated back.

## What happened

drovr asked that "convergence" be recorded as vstack-owned so neither app claimed it. memsira pushed back: convergence **as a probe gate** for the attach race is the bridge's, but convergence **as inventory reconciliation** (memsira#275) is pure app-side and needs nothing upstream. drovr withdrew.

Had the broader framing stuck, #275 would have read as upstream-blocked, and memsira's next session would have sat waiting on vstack for a change touching one function in its own repo.

## The rule

**Does this change need anything from another repo? If not, it is yours — however much shared language it borrows.**

That is checkable. "Shared" is not; it is a vibe, and it is precisely the label that produced the deadlock already recorded in this file, where two handoffs each assigned a feature to the other and neither built it. That deadlock is this bug's instance; the vocabulary trap is its general form, which is why it belongs next to the tagged-claims rule rather than in a status message.

The failure mode is that one mechanism can be upstream in one use and purely local in another. Calling both "the convergence work" makes the second read as blocked behind a repo that owes it nothing.

## Provenance

drovr framed it as a generalisation that fell out of an argument they **lost**, which is both accurate and the stronger version of the case — and memsira reported the identical split independently, from the side that won it. Both repos have already adopted it locally and deferred the canonical home here.

Docs only. One short section.
