### PR TITLE
feat(pi-claude-bridge): register Claude Opus 5 in the model picker

### DIFF
--- a/pi-extensions/pi-claude-bridge/README.md
+++ b/pi-extensions/pi-claude-bridge/README.md
@@ -11,7 +11,7 @@ Forked from [`elidickinson/pi-claude-bridge`](https://github.com/elidickinson/pi
 
 ## Highlights
 
-- `claude-bridge/claude-fable-5`, Sonnet 5, Opus 4.8, Opus 4.7, Sonnet 4.6, and Haiku in `/model`.
+- `claude-bridge/claude-fable-5`, Opus 5, Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 5, Sonnet 4.6, and Haiku in `/model`. `/model opus` selects Opus 5; older Opus releases stay selectable by full ID.
 - Pi tool calls run on Pi; Claude Code handles reasoning.
 - Tool-use turns block until Pi-delivered tool results reach Claude Code, including persistent subagent panes.
 - Session continuity across normal turns, `/compact`, tree navigation, and abort recovery.
@@ -138,9 +138,9 @@ Host apps that embed the bridge and own every config dir explicitly can set `CLA
 
 Bridge settings come only from the authoritative `<PI_CODING_AGENT_DIR>/claude-bridge.json`; logs still resolve under `PI_CODING_AGENT_DIR`. Normal Pi CLI usage (flag unset) is unchanged.
 
-### Fable 5 caveat
+### Fable 5 and Opus 5 caveat
 
-The bridge registers `claude-bridge/claude-fable-5`, `claude-bridge/claude-sonnet-5`, and `claude-bridge/claude-opus-4-8` even when Pi's Anthropic model registry has not shipped those entries yet. For Fable 5, the bridge asks Claude Code to use Opus 4.8 as the availability fallback and preserves Claude Code's content-safety fallback events so Pi labels rerouted turns as Opus 4.8. Content-safety fallback still depends on Claude Code's own Fable 5 support; use Claude Code 2.1.170 or newer, and set `ANTHROPIC_DEFAULT_FABLE_MODEL` / `ANTHROPIC_DEFAULT_OPUS_MODEL` yourself when routing provider-specific model IDs through Bedrock, Vertex, or Foundry.
+The bridge registers `claude-bridge/claude-fable-5`, `claude-bridge/claude-opus-5`, `claude-bridge/claude-sonnet-5`, and `claude-bridge/claude-opus-4-8` even when Pi's Anthropic model registry has not shipped those entries yet. Fable 5 and Opus 5 both run classifiers that can decline a turn, so for each of them the bridge asks Claude Code to use Opus 4.8 as the availability fallback and preserves Claude Code's content-safety fallback events so Pi labels rerouted turns as Opus 4.8. Content-safety fallback still depends on Claude Code's own Fable 5 support; use Claude Code 2.1.170 or newer, and set `ANTHROPIC_DEFAULT_FABLE_MODEL` / `ANTHROPIC_DEFAULT_OPUS_MODEL` yourself when routing provider-specific model IDs through Bedrock, Vertex, or Foundry.
 
 ## Extra usage and rate limits
 

--- a/pi-extensions/pi-claude-bridge/bundle/index.js
+++ b/pi-extensions/pi-claude-bridge/bundle/index.js
@@ -27088,12 +27088,14 @@ function convertPiMessages(messages, customToolNameToSdk) {
 // src/models.ts
 var FABLE_MODEL_ID = "claude-fable-5";
 var FABLE_FALLBACK_MODEL_ID = "claude-opus-4-8";
+var OPUS_5_MODEL_ID = "claude-opus-5";
 var SONNET_5_MODEL_ID = "claude-sonnet-5";
 function fallbackModelForPrimaryModel(modelId) {
-  return modelId === FABLE_MODEL_ID ? FABLE_FALLBACK_MODEL_ID : void 0;
+  return modelId === FABLE_MODEL_ID || modelId === OPUS_5_MODEL_ID ? FABLE_FALLBACK_MODEL_ID : void 0;
 }
 var MODEL_IDS_IN_ORDER = [
   FABLE_MODEL_ID,
+  OPUS_5_MODEL_ID,
   FABLE_FALLBACK_MODEL_ID,
   "claude-opus-4-7",
   "claude-opus-4-6",
@@ -27105,6 +27107,15 @@ var FALLBACK_MODELS = {
   [FABLE_MODEL_ID]: {
     id: FABLE_MODEL_ID,
     name: "Claude Fable 5",
+    reasoning: true,
+    thinkingLevelMap: { xhigh: "xhigh", max: "max" },
+    input: ["text", "image"],
+    contextWindow: 1e6,
+    maxTokens: 128e3
+  },
+  [OPUS_5_MODEL_ID]: {
+    id: OPUS_5_MODEL_ID,
+    name: "Claude Opus 5",
     reasoning: true,
     thinkingLevelMap: { xhigh: "xhigh", max: "max" },
     input: ["text", "image"],
@@ -27129,6 +27140,9 @@ var FALLBACK_MODELS = {
     maxTokens: 128e3
   }
 };
+function modelDisplayName(modelId) {
+  return FALLBACK_MODELS[modelId]?.name ?? modelId;
+}
 function buildModels(piAiModels) {
   return MODEL_IDS_IN_ORDER.map((id) => piAiModels.find((m) => m.id === id) ?? FALLBACK_MODELS[id]).filter((m) => m != null).map(({ id, name, reasoning, input, contextWindow, maxTokens, thinkingLevelMap }) => ({
     id,
@@ -44567,8 +44581,11 @@ async function consumeQuery(sdkQuery, customToolNameToPi, model, cwd, bridgeConf
           const fallbackModel = message.fallback_model;
           updateTurnOutputModel(fallbackModel);
           debug("consumeQuery: model_refusal_fallback", JSON.stringify({ originalModel, fallbackModel }));
-          if (originalModel === FABLE_MODEL_ID && fallbackModel === FABLE_FALLBACK_MODEL_ID) {
-            safeNotify("Claude bridge switched Fable 5 to Opus 4.8 after Claude Code safety fallback.", "info");
+          if (typeof fallbackModel === "string" && typeof originalModel === "string" && fallbackModelForPrimaryModel(originalModel) === fallbackModel) {
+            safeNotify(
+              `Claude bridge switched ${modelDisplayName(originalModel)} to ${modelDisplayName(fallbackModel)} after Claude Code safety fallback.`,
+              "info"
+            );
           }
         }
         break;

--- a/pi-extensions/pi-claude-bridge/src/index.ts
+++ b/pi-extensions/pi-claude-bridge/src/index.ts
@@ -4,7 +4,7 @@ import { type ExtensionAPI, type ExtensionUIContext } from "@earendil-works/pi-c
 import { createSdkMcpServer, query, type EffortLevel, type SDKMessage, type SDKUserMessage, type SettingSource } from "@anthropic-ai/claude-agent-sdk";
 import type { Base64ImageSource, ContentBlockParam, MessageParam } from "@anthropic-ai/sdk/resources";
 import { PROVIDER_ID, messageContentToText } from "./convert.js";
-import { FABLE_FALLBACK_MODEL_ID, FABLE_MODEL_ID, buildModels, fallbackModelForPrimaryModel } from "./models.js";
+import { buildModels, fallbackModelForPrimaryModel, modelDisplayName } from "./models.js";
 import { MCP_SERVER_NAME, MCP_TOOL_PREFIX, extractSkillsBlock } from "./skills.js";
 import { extractAllToolResults as _extractAllToolResults, type McpResult } from "./extract-tool-results.js";
 import { QueryContext, ctx, drainPendingToolCalls, stackDepth, pushContext, popContext, toolCallDrainCause } from "./query-state.js";
@@ -450,8 +450,13 @@ async function consumeQuery(
 					const fallbackModel = (message as any).fallback_model;
 					updateTurnOutputModel(fallbackModel);
 					debug("consumeQuery: model_refusal_fallback", JSON.stringify({ originalModel, fallbackModel }));
-					if (originalModel === FABLE_MODEL_ID && fallbackModel === FABLE_FALLBACK_MODEL_ID) {
-						safeNotify("Claude bridge switched Fable 5 to Opus 4.8 after Claude Code safety fallback.", "info");
+					// Notify only for reroutes we configured, so an unexpected pairing from
+					// Claude Code is still logged above but not announced as one of ours.
+					if (typeof fallbackModel === "string" && typeof originalModel === "string" && fallbackModelForPrimaryModel(originalModel) === fallbackModel) {
+						safeNotify(
+							`Claude bridge switched ${modelDisplayName(originalModel)} to ${modelDisplayName(fallbackModel)} after Claude Code safety fallback.`,
+							"info",
+						);
 					}
 				}
 				break;

--- a/pi-extensions/pi-claude-bridge/src/models.ts
+++ b/pi-extensions/pi-claude-bridge/src/models.ts
@@ -3,15 +3,19 @@
 // Extracted from index.ts so tests can import without activating the extension.
 
 export const FABLE_MODEL_ID = "claude-fable-5";
+// Opus 4.8 is both a selectable model and the safety-fallback target for the two
+// primaries whose classifiers can decline a turn (Fable 5, Opus 5).
 export const FABLE_FALLBACK_MODEL_ID = "claude-opus-4-8";
+export const OPUS_5_MODEL_ID = "claude-opus-5";
 export const SONNET_5_MODEL_ID = "claude-sonnet-5";
 
 export function fallbackModelForPrimaryModel(modelId: string): string | undefined {
-	return modelId === FABLE_MODEL_ID ? FABLE_FALLBACK_MODEL_ID : undefined;
+	return modelId === FABLE_MODEL_ID || modelId === OPUS_5_MODEL_ID ? FABLE_FALLBACK_MODEL_ID : undefined;
 }
 
 export const MODEL_IDS_IN_ORDER = [
 	FABLE_MODEL_ID,
+	OPUS_5_MODEL_ID,
 	FABLE_FALLBACK_MODEL_ID,
 	"claude-opus-4-7",
 	"claude-opus-4-6",
@@ -40,6 +44,15 @@ const FALLBACK_MODELS: Record<string, BridgeModelMetadata> = {
 		contextWindow: 1000000,
 		maxTokens: 128000,
 	},
+	[OPUS_5_MODEL_ID]: {
+		id: OPUS_5_MODEL_ID,
+		name: "Claude Opus 5",
+		reasoning: true,
+		thinkingLevelMap: { xhigh: "xhigh", max: "max" },
+		input: ["text", "image"],
+		contextWindow: 1000000,
+		maxTokens: 128000,
+	},
 	[FABLE_FALLBACK_MODEL_ID]: {
 		id: FABLE_FALLBACK_MODEL_ID,
 		name: "Claude Opus 4.8",
@@ -58,6 +71,13 @@ const FALLBACK_MODELS: Record<string, BridgeModelMetadata> = {
 		maxTokens: 128000,
 	},
 };
+
+// Human label for the safety-fallback notice. Every id that participates in a
+// fallbackModelForPrimaryModel pairing has an entry above; the raw id is the
+// last-resort label so an unmapped pairing still reads sensibly.
+export function modelDisplayName(modelId: string): string {
+	return FALLBACK_MODELS[modelId]?.name ?? modelId;
+}
 
 // Project pi-ai's model entries down to the fields pi's registerProvider expects,
 // keep MODEL_IDS_IN_ORDER ordering, and fill bridge-owned future IDs when pi-ai

--- a/pi-extensions/pi-claude-bridge/tests/unit-models.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-models.mjs
@@ -5,7 +5,7 @@
  */
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { FABLE_FALLBACK_MODEL_ID, FABLE_MODEL_ID, MODEL_IDS_IN_ORDER, SONNET_5_MODEL_ID, buildModels, fallbackModelForPrimaryModel, resolveModelId } from "../src/models.js";
+import { FABLE_FALLBACK_MODEL_ID, FABLE_MODEL_ID, MODEL_IDS_IN_ORDER, OPUS_5_MODEL_ID, SONNET_5_MODEL_ID, buildModels, fallbackModelForPrimaryModel, modelDisplayName, resolveModelId } from "../src/models.js";
 
 // Simulated pi-ai registry entry — extra fields mimic the ones pi-ai exposes
 // that must not leak into the provider-registered MODELS array.
@@ -34,20 +34,25 @@ describe("MODELS projection", () => {
 		assert.deepEqual(models.map((m) => m.id), MODEL_IDS_IN_ORDER);
 	});
 
-	it("lists Fable 5 before Opus models", () => {
+	it("lists Fable 5 first, then Opus 5 ahead of older Opus models", () => {
 		const models = buildModels(MODEL_IDS_IN_ORDER.map(mockPiAiModel));
 		assert.equal(models[0]?.id, FABLE_MODEL_ID);
-		assert.equal(models[1]?.id, FABLE_FALLBACK_MODEL_ID);
+		assert.equal(models[1]?.id, OPUS_5_MODEL_ID);
+		assert.equal(models[2]?.id, FABLE_FALLBACK_MODEL_ID);
 	});
 
 	it("fills bridge-owned future IDs missing from pi-ai and drops unknown missing IDs", () => {
 		const models = buildModels([mockPiAiModel("claude-haiku-4-5")]);
-		assert.deepEqual(models.map((m) => m.id), ["claude-fable-5", "claude-opus-4-8", "claude-sonnet-5", "claude-haiku-4-5"]);
+		assert.deepEqual(models.map((m) => m.id), ["claude-fable-5", "claude-opus-5", "claude-opus-4-8", "claude-sonnet-5", "claude-haiku-4-5"]);
 		assert.equal(models.find((m) => m.id === "claude-fable-5")?.name, "Claude Fable 5");
 		assert.equal(models.find((m) => m.id === "claude-fable-5")?.contextWindow, 1000000);
 		assert.equal(models.find((m) => m.id === "claude-opus-4-8")?.maxTokens, 128000);
 		assert.equal(models.find((m) => m.id === "claude-sonnet-5")?.name, "Claude Sonnet 5");
 		assert.equal(models.find((m) => m.id === "claude-sonnet-5")?.contextWindow, 1000000);
+		assert.equal(models.find((m) => m.id === "claude-opus-5")?.name, "Claude Opus 5");
+		assert.equal(models.find((m) => m.id === "claude-opus-5")?.contextWindow, 1000000);
+		assert.equal(models.find((m) => m.id === "claude-opus-5")?.maxTokens, 128000);
+		assert.deepEqual(models.find((m) => m.id === "claude-opus-5")?.thinkingLevelMap, { xhigh: "xhigh", max: "max" });
 		assert.deepEqual(models.find((m) => m.id === "claude-fable-5")?.thinkingLevelMap, { xhigh: "xhigh", max: "max" });
 	});
 
@@ -82,8 +87,13 @@ describe("MODELS projection", () => {
 describe("resolveModelId", () => {
 	const models = buildModels(MODEL_IDS_IN_ORDER.map(mockPiAiModel));
 
-	it("opus shortcut resolves to claude-opus-4-8 (first opus in order)", () => {
-		assert.equal(resolveModelId(models, "opus"), "claude-opus-4-8");
+	it("opus shortcut resolves to claude-opus-5 (first opus in order)", () => {
+		assert.equal(resolveModelId(models, "opus"), OPUS_5_MODEL_ID);
+	});
+
+	it("older opus IDs stay selectable by full ID despite the shortcut moving", () => {
+		assert.equal(resolveModelId(models, "claude-opus-4-8"), FABLE_FALLBACK_MODEL_ID);
+		assert.equal(resolveModelId(models, "claude-opus-4-7"), "claude-opus-4-7");
 	});
 
 	it("fable shortcut resolves to claude-fable-5", () => {
@@ -106,10 +116,19 @@ describe("resolveModelId", () => {
 		assert.equal(resolveModelId(models, "gpt-9"), "gpt-9");
 	});
 
-	it("configures Opus 4.8 availability fallback for Fable 5 only", () => {
+	it("configures Opus 4.8 safety fallback for the two models whose classifiers decline", () => {
 		assert.equal(fallbackModelForPrimaryModel(FABLE_MODEL_ID), FABLE_FALLBACK_MODEL_ID);
+		assert.equal(fallbackModelForPrimaryModel(OPUS_5_MODEL_ID), FABLE_FALLBACK_MODEL_ID);
 		assert.equal(fallbackModelForPrimaryModel(FABLE_FALLBACK_MODEL_ID), undefined);
 		assert.equal(fallbackModelForPrimaryModel(SONNET_5_MODEL_ID), undefined);
 		assert.equal(fallbackModelForPrimaryModel("claude-sonnet-4-6"), undefined);
+	});
+
+	it("labels every model in a configured fallback pairing", () => {
+		for (const id of [FABLE_MODEL_ID, OPUS_5_MODEL_ID, FABLE_FALLBACK_MODEL_ID]) {
+			assert.notEqual(modelDisplayName(id), id);
+		}
+		assert.equal(modelDisplayName("claude-opus-5"), "Claude Opus 5");
+		assert.equal(modelDisplayName("gpt-9"), "gpt-9");
 	});
 });


### PR DESCRIPTION
## What

The Claude Bridge's model picker was missing **Claude Opus 5**.

pi's bundled pi-ai anthropic catalog already ships the full entry — verified in the installed runtime:

```
"claude-opus-5": { id: "claude-opus-5", name: "Claude Opus 5", provider: "anthropic",
  reasoning: true, input: ["text","image"], contextWindow: 1e6, maxTokens: 128000,
  thinkingLevelMap: { xhigh: "xhigh", max: "max" }, compat: { forceAdaptiveThinking: true, ... } }
```

`buildModels` intersects that catalog with the bridge's own `MODEL_IDS_IN_ORDER` allowlist, and Opus 5 was not on it — so it was filtered out and unreachable from `/model`. The registry was otherwise current: Sonnet 5, Fable 5, Opus 4.8/4.7/4.6, Sonnet 4.6, and Haiku 4.5 were all already present.

## Changes

- **`claude-opus-5` added to `MODEL_IDS_IN_ORDER`**, ranked after Fable 5 and ahead of the 4.x Opus releases.
- **Bridge-owned fallback metadata** for Opus 5, mirroring pi-ai's values — same pattern already used for Fable 5 / Opus 4.8 / Sonnet 5, so consumers pinned to an older pi-ai still get the model.
- **Opus 4.8 configured as Opus 5's safety fallback.** Opus 5 runs the same class of classifiers as Fable 5 and can return a refusal; Opus 4.8 is the documented reroute target. Without this an Opus 5 refusal just fails the turn.
- **Refusal notice generalized** — it was hardcoded to the Fable 5 → Opus 4.8 pair. It now covers any pairing the bridge configures, and only announces reroutes we asked for (an unexpected pairing from Claude Code is still logged, not announced as ours).

## Behavior change worth flagging

`resolveModelId` returns the **first partial match**, so `/model opus` now resolves to **Opus 5** instead of Opus 4.8. Older Opus releases remain selectable by full ID (`claude-opus-4-8`, `claude-opus-4-7`, …) — pinned by a new test.

## Deliberately excluded

`claude-mythos-5` — Project Glasswing invitation-only. Adding it would put an entry in every user's picker that fails for anyone outside the program.

## Verification

- `npm run test:unit` — **237/237 pass** (52 suites; +2 new tests: full-ID selection of older Opus releases, and display labels for every fallback pairing).
- `npx tsc --noEmit` clean.
- `bundle/index.js` rebuilt in the same commit, per repo convention.

https://claude.ai/code/session_018LpgYWmefqC3ZF1jzUCuzY
