### PR TITLE
feat(pi-claude-bridge): enumerate connectors from the account, not the model

### DIFF
--- a/pi-extensions/pi-claude-bridge/README.md
+++ b/pi-extensions/pi-claude-bridge/README.md
@@ -142,6 +142,14 @@ Bridge settings come only from the authoritative `<PI_CODING_AGENT_DIR>/claude-b
 
 The bridge registers `claude-bridge/claude-fable-5`, `claude-bridge/claude-opus-5`, `claude-bridge/claude-sonnet-5`, and `claude-bridge/claude-opus-4-8` even when Pi's Anthropic model registry has not shipped those entries yet. Fable 5 and Opus 5 both run classifiers that can decline a turn, so for each of them the bridge asks Claude Code to use Opus 4.8 as the availability fallback and preserves Claude Code's content-safety fallback events so Pi labels rerouted turns as Opus 4.8. Content-safety fallback still depends on Claude Code's own Fable 5 support; use Claude Code 2.1.170 or newer, and set `ANTHROPIC_DEFAULT_FABLE_MODEL` / `ANTHROPIC_DEFAULT_OPUS_MODEL` yourself when routing provider-specific model IDs through Bedrock, Vertex, or Foundry.
 
+## Connector inventory
+
+`/claude-bridge:connectors` lists the Claude account's installed claude.ai connectors by asking the account, not the model.
+
+The older way to answer "does this account have Slack?" was a capability probe: a model turn that enumerated connectors via `ToolSearch`. A search returns what the search surfaced — a lower bound — and nothing in the result said so, so an account with Slack attached could produce an inventory without Slack and no failure signal (vstack#838). This command calls the account's connector list endpoint instead, so the answer is complete by construction.
+
+`listAccountConnectors()` in `src/connector-inventory.ts` is the programmatic form for host apps. It returns a discriminated result: on success `{ ok: true, complete: true, connectors }`, and on any transport or protocol failure `{ ok: false, reason }`. An account with no connectors is a successful empty list; a failure is never reported as an empty inventory. Credentials resolve from `CLAUDE_CONFIG_DIR` before `$HOME`, so a host running one sidecar per Claude account reads the right account.
+
 ## Extra usage and rate limits
 
 Claude Code's `/extra-usage` local command works through the Claude Agent SDK. In Pi, use `/claude-bridge:extra` to run that flow from claude-bridge. Persist automatic launch on extra-usage errors with **Allow extra usage helper** in `/extensions:settings`.

--- a/pi-extensions/pi-claude-bridge/bundle/index.js
+++ b/pi-extensions/pi-claude-bridge/bundle/index.js
@@ -42405,6 +42405,9 @@ function jsonSchemaToZodShape(schema) {
   return shape;
 }
 
+// src/index.ts
+import { readFileSync as nodeReadFileSync } from "node:fs";
+
 // src/pi-ai-compat.ts
 var dynamicImport = (specifier) => import(specifier);
 async function resolveGetModels(root, loadCompat = () => dynamicImport("@earendil-works/pi-ai/compat")) {
@@ -42412,6 +42415,128 @@ async function resolveGetModels(root, loadCompat = () => dynamicImport("@earendi
   const compat = await loadCompat();
   if (typeof compat?.getModels !== "function") throw new Error("pi-ai getModels API is unavailable");
   return compat.getModels;
+}
+
+// src/connector-inventory.ts
+var DEFAULT_API_BASE = "https://api.anthropic.com";
+var OAUTH_BETA_HEADER = "oauth-2025-04-20";
+function credentialCandidatePaths(env = process.env) {
+  const roots = [];
+  const configDir = env.CLAUDE_CONFIG_DIR?.trim();
+  if (configDir) roots.push(configDir);
+  const home = env.HOME?.trim();
+  if (home) roots.push(`${home}/.claude`, home);
+  const seen = /* @__PURE__ */ new Set();
+  const paths = [];
+  for (const root of roots) {
+    for (const name of [".credentials.json", ".claude.json"]) {
+      const p4 = `${root}/${name}`;
+      if (!seen.has(p4)) {
+        seen.add(p4);
+        paths.push(p4);
+      }
+    }
+  }
+  return paths;
+}
+function resolveClaudeOAuth(readFile, env = process.env) {
+  let accessToken;
+  let organizationUuid;
+  for (const path of credentialCandidatePaths(env)) {
+    const raw = readFile(path);
+    if (!raw) continue;
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      continue;
+    }
+    accessToken ??= nonEmptyString(parsed?.claudeAiOauth?.accessToken);
+    organizationUuid ??= nonEmptyString(parsed?.oauthAccount?.organizationUuid);
+    if (accessToken && organizationUuid) break;
+  }
+  if (!accessToken || !organizationUuid) return void 0;
+  return { accessToken, organizationUuid };
+}
+function nonEmptyString(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : void 0;
+}
+function connectorsListUrl(organizationUuid, apiBase = DEFAULT_API_BASE) {
+  return `${apiBase.replace(/\/+$/, "")}/api/oauth/organizations/${encodeURIComponent(organizationUuid)}/mcp/connectors/list`;
+}
+async function listAccountConnectors(deps) {
+  const { credentials, apiBase, signal } = deps;
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const url2 = connectorsListUrl(credentials.organizationUuid, apiBase);
+  const fail = (reason) => ({ ok: false, complete: false, reason: redactSecret(reason, credentials.accessToken) });
+  let response;
+  try {
+    response = await fetchImpl(url2, {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${credentials.accessToken}`,
+        "anthropic-beta": OAUTH_BETA_HEADER,
+        "Content-Type": "application/json"
+      },
+      body: "{}",
+      signal
+    });
+  } catch (error51) {
+    return fail(`connector list request failed: ${errorText(error51)}`);
+  }
+  let bodyText;
+  try {
+    bodyText = await response.text();
+  } catch (error51) {
+    return fail(`connector list response unreadable: ${errorText(error51)}`);
+  }
+  if (!response.ok) {
+    return fail(`connector list returned HTTP ${response.status}${apiErrorSuffix(bodyText)}`);
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(bodyText);
+  } catch {
+    return fail("connector list returned a non-JSON body");
+  }
+  if (!Array.isArray(parsed?.results)) {
+    return fail("connector list response had no results array");
+  }
+  const connectors = [];
+  for (const raw of parsed.results) {
+    const entry = raw;
+    const name = nonEmptyString(entry?.name);
+    if (!name) {
+      return fail("connector list contained an entry with no name");
+    }
+    connectors.push({
+      name,
+      installedServerId: nonEmptyString(entry?.installedServerId),
+      directoryUuid: nonEmptyString(entry?.directoryUuid),
+      description: nonEmptyString(entry?.description),
+      isAuthless: typeof entry?.isAuthless === "boolean" ? entry.isAuthless : void 0
+    });
+  }
+  return { ok: true, complete: true, connectors };
+}
+function apiErrorSuffix(bodyText) {
+  try {
+    const message = JSON.parse(bodyText)?.error?.message;
+    return typeof message === "string" && message.trim() ? ` (${message.trim()})` : "";
+  } catch {
+    return "";
+  }
+}
+function redactSecret(text, secret) {
+  if (!secret || secret.length < 8) return text;
+  let out = text;
+  for (const form of /* @__PURE__ */ new Set([secret, encodeURIComponent(secret)])) {
+    out = out.split(form).join("[redacted]");
+  }
+  return out;
+}
+function errorText(error51) {
+  return error51 instanceof Error ? error51.message : String(error51);
 }
 
 // src/debug.ts
@@ -45060,6 +45185,31 @@ function showBridgeStatus(ctx2) {
     `Use /claude-bridge:extra to run Claude Code /extra-usage now.`
   ].join("\n"), "info");
 }
+function readCredentialFile(path) {
+  try {
+    return nodeReadFileSync(path, "utf8");
+  } catch {
+    return void 0;
+  }
+}
+async function reportConnectorInventory(ctx2) {
+  const credentials = resolveClaudeOAuth(readCredentialFile);
+  if (!credentials) {
+    ctx2.ui.notify("Claude bridge: no Claude OAuth credentials found \u2014 cannot enumerate connectors.", "error");
+    return;
+  }
+  const inventory = await listAccountConnectors({ credentials });
+  if (!inventory.ok) {
+    ctx2.ui.notify(`Claude bridge: connector enumeration failed \u2014 ${inventory.reason}`, "error");
+    return;
+  }
+  if (inventory.connectors.length === 0) {
+    ctx2.ui.notify("Claude bridge: this account has no connectors installed.", "info");
+    return;
+  }
+  const names = inventory.connectors.map((c) => c.name).join(", ");
+  ctx2.ui.notify(`Claude bridge: ${inventory.connectors.length} connector(s) installed \u2014 ${names}`, "info");
+}
 function registerBridgeCommands(pi) {
   const guard = pi;
   if (guard[COMMANDS_REGISTERED_KEY]) return;
@@ -45094,6 +45244,10 @@ function registerBridgeCommands(pi) {
   pi.registerCommand("claude-bridge:extra", {
     description: "Run Claude Code /extra-usage through claude-bridge",
     handler: async (_args, ctx2) => runExtraUsage(ctx2)
+  });
+  pi.registerCommand("claude-bridge:connectors", {
+    description: "List the Claude account's installed claude.ai connectors",
+    handler: async (_args, ctx2) => reportConnectorInventory(ctx2)
   });
 }
 function index_default(pi) {

--- a/pi-extensions/pi-claude-bridge/src/connector-inventory.ts
+++ b/pi-extensions/pi-claude-bridge/src/connector-inventory.ts
@@ -1,0 +1,247 @@
+// Deterministic enumeration of a Claude account's installed claude.ai connectors.
+//
+// The capability probe this replaces asked the MODEL to enumerate connectors via
+// ToolSearch. A search returns what the search surfaced, which is a LOWER BOUND —
+// nothing in the result distinguishes "these are the connectors" from "these are
+// the connectors the search happened to return this time". Downstream then stored
+// that lower bound as authoritative, so an account with Slack attached could
+// report an inventory without Slack and no failure signal (vstack#838).
+//
+// This module asks the account instead of the model. Verified live against a
+// personal claude_max org: the endpoint is POST (a GET returns 405) and each
+// result carries BOTH `directoryUuid` (the catalog identity) and
+// `installedServerId` (this account's installed instance). A marketplace catalog
+// entry has no installed-server id, which is what establishes this as the
+// attached set rather than the registry listing.
+//
+// Because the answer comes from the account rather than a model turn, the result
+// is complete by construction — hence `complete: true` on success, and no
+// "partial" state. A failure is a failure, never an empty-but-successful list.
+
+const CONNECTOR_NS_PREFIX = "mcp__claude_ai_";
+const DEFAULT_API_BASE = "https://api.anthropic.com";
+// OAuth-token requests to the Anthropic API require this beta header; without it
+// endpoints reject the bearer credential.
+const OAUTH_BETA_HEADER = "oauth-2025-04-20";
+
+export type ConnectorEntry = {
+	name: string;
+	/** This account's installed instance. Present on every live result observed. */
+	installedServerId?: string;
+	/** Catalog identity, shared across accounts that install the same connector. */
+	directoryUuid?: string;
+	description?: string;
+	isAuthless?: boolean;
+};
+
+// Discriminated so a caller cannot read `connectors` without having checked `ok`.
+// `complete` is carried explicitly rather than implied: the whole defect this
+// fixes was a result that looked authoritative while being a lower bound.
+// The absent side of each variant is declared as `?: undefined` rather than
+// omitted: this package compiles with `strict: false`, where narrowing a union
+// by a boolean discriminant does not reliably filter members, so a bare
+// `{ok:true}|{ok:false}` pair makes `inventory.reason` a compile error at every
+// call site. Spelling both sides keeps the union discriminated AND readable
+// without depending on strictNullChecks-era narrowing.
+export type ConnectorInventory =
+	| { ok: true; complete: true; connectors: ConnectorEntry[]; reason?: undefined }
+	| { ok: false; complete: false; connectors?: undefined; reason: string };
+
+export type ClaudeOAuthCredentials = {
+	accessToken: string;
+	organizationUuid: string;
+};
+
+type Json = Record<string, any>;
+
+/**
+ * Tool-namespace prefix for a connector, e.g. `Google Calendar` →
+ * `mcp__claude_ai_Google_Calendar__`. Connector servers are named after the
+ * connector with whitespace replaced by underscores; corroborated against the
+ * independently-authored CLAUDE_AI_CONNECTOR_TOOL_PATTERNS in connectors.ts,
+ * which was built from a live tool enumeration rather than from this rule.
+ */
+export function connectorServerNamespace(connectorName: string): string {
+	return `${CONNECTOR_NS_PREFIX}${connectorName.trim().replace(/\s+/g, "_")}__`;
+}
+
+// Candidate credential files, in precedence order. CLAUDE_CONFIG_DIR is set
+// per-account by hosts that run one sidecar per Claude account, so it must win
+// over the home-directory default or a multi-account host reads the wrong
+// account's connectors. Both file names are probed under each root because the
+// token and the org UUID do not reliably live in the same file across versions.
+export function credentialCandidatePaths(env: NodeJS.ProcessEnv = process.env): string[] {
+	const roots: string[] = [];
+	const configDir = env.CLAUDE_CONFIG_DIR?.trim();
+	if (configDir) roots.push(configDir);
+	const home = env.HOME?.trim();
+	if (home) roots.push(`${home}/.claude`, home);
+	const seen = new Set<string>();
+	const paths: string[] = [];
+	for (const root of roots) {
+		for (const name of [".credentials.json", ".claude.json"]) {
+			const p = `${root}/${name}`;
+			if (!seen.has(p)) { seen.add(p); paths.push(p); }
+		}
+	}
+	return paths;
+}
+
+/**
+ * Pull the OAuth access token and organization UUID out of the Claude config.
+ * They are scanned independently across all candidate files because they are not
+ * guaranteed to co-locate: on the machine this was verified against, the token
+ * lives in `.credentials.json` and the org UUID in `.claude.json`.
+ *
+ * `readFile` returns undefined for a missing/unreadable path. Parse failures are
+ * skipped rather than thrown — a corrupt file must not mask a good one later in
+ * the list.
+ */
+export function resolveClaudeOAuth(
+	readFile: (path: string) => string | undefined,
+	env: NodeJS.ProcessEnv = process.env,
+): ClaudeOAuthCredentials | undefined {
+	let accessToken: string | undefined;
+	let organizationUuid: string | undefined;
+
+	for (const path of credentialCandidatePaths(env)) {
+		const raw = readFile(path);
+		if (!raw) continue;
+		let parsed: Json;
+		try {
+			parsed = JSON.parse(raw) as Json;
+		} catch {
+			continue;
+		}
+		accessToken ??= nonEmptyString(parsed?.claudeAiOauth?.accessToken);
+		organizationUuid ??= nonEmptyString(parsed?.oauthAccount?.organizationUuid);
+		if (accessToken && organizationUuid) break;
+	}
+
+	if (!accessToken || !organizationUuid) return undefined;
+	return { accessToken, organizationUuid };
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+	return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+export function connectorsListUrl(organizationUuid: string, apiBase: string = DEFAULT_API_BASE): string {
+	return `${apiBase.replace(/\/+$/, "")}/api/oauth/organizations/${encodeURIComponent(organizationUuid)}/mcp/connectors/list`;
+}
+
+export type ListConnectorsDeps = {
+	credentials: ClaudeOAuthCredentials;
+	fetchImpl?: typeof fetch;
+	apiBase?: string;
+	signal?: AbortSignal;
+};
+
+/**
+ * Enumerate the account's installed connectors. Never throws: transport and
+ * protocol failures come back as `{ ok: false }` with a reason, so a caller can
+ * distinguish "this account has no connectors" (ok, empty list) from "we could
+ * not find out" — the distinction the search-driven probe could not express.
+ *
+ * The reason string is built only from the HTTP status and the API's own error
+ * message; the bearer token is never interpolated into it or logged.
+ */
+export async function listAccountConnectors(deps: ListConnectorsDeps): Promise<ConnectorInventory> {
+	const { credentials, apiBase, signal } = deps;
+	const fetchImpl = deps.fetchImpl ?? fetch;
+	const url = connectorsListUrl(credentials.organizationUuid, apiBase);
+	// Every failure return goes through this. Transport errors are the risk: a
+	// fetch/proxy layer is free to put the request headers — and therefore the
+	// bearer token — into the message it throws, and that message would otherwise
+	// land in a reason string that callers log.
+	const fail = (reason: string): ConnectorInventory =>
+		({ ok: false, complete: false, reason: redactSecret(reason, credentials.accessToken) });
+
+	let response: Response;
+	try {
+		response = await fetchImpl(url, {
+			method: "POST",
+			headers: {
+				"Authorization": `Bearer ${credentials.accessToken}`,
+				"anthropic-beta": OAUTH_BETA_HEADER,
+				"Content-Type": "application/json",
+			},
+			body: "{}",
+			signal,
+		});
+	} catch (error) {
+		return fail(`connector list request failed: ${errorText(error)}`);
+	}
+
+	let bodyText: string;
+	try {
+		bodyText = await response.text();
+	} catch (error) {
+		return fail(`connector list response unreadable: ${errorText(error)}`);
+	}
+
+	if (!response.ok) {
+		return fail(`connector list returned HTTP ${response.status}${apiErrorSuffix(bodyText)}`);
+	}
+
+	let parsed: Json;
+	try {
+		parsed = JSON.parse(bodyText) as Json;
+	} catch {
+		return fail("connector list returned a non-JSON body");
+	}
+
+	// A missing/!Array `results` is a protocol change, not an empty account. Treat
+	// it as failure — reporting "no connectors" here would recreate exactly the
+	// silent-wrong-answer failure this module exists to remove.
+	if (!Array.isArray(parsed?.results)) {
+		return fail("connector list response had no results array");
+	}
+
+	const connectors: ConnectorEntry[] = [];
+	for (const raw of parsed.results as unknown[]) {
+		const entry = raw as Json;
+		const name = nonEmptyString(entry?.name);
+		// An unnamed entry cannot be matched to a tool namespace by any consumer,
+		// so silently keeping it would understate the inventory in a way the
+		// caller could not detect. Fail instead.
+		if (!name) {
+			return fail("connector list contained an entry with no name");
+		}
+		connectors.push({
+			name,
+			installedServerId: nonEmptyString(entry?.installedServerId),
+			directoryUuid: nonEmptyString(entry?.directoryUuid),
+			description: nonEmptyString(entry?.description),
+			isAuthless: typeof entry?.isAuthless === "boolean" ? entry.isAuthless : undefined,
+		});
+	}
+
+	return { ok: true, complete: true, connectors };
+}
+
+function apiErrorSuffix(bodyText: string): string {
+	try {
+		const message = (JSON.parse(bodyText) as Json)?.error?.message;
+		return typeof message === "string" && message.trim() ? ` (${message.trim()})` : "";
+	} catch {
+		return "";
+	}
+}
+
+// Replace the bearer token wherever it appears in text headed for a caller.
+// Also covers a URL-encoded rendering, since some transports encode headers into
+// an error's message. Short/empty tokens are not substituted — an over-eager
+// match would corrupt unrelated text.
+function redactSecret(text: string, secret: string): string {
+	if (!secret || secret.length < 8) return text;
+	let out = text;
+	for (const form of new Set([secret, encodeURIComponent(secret)])) {
+		out = out.split(form).join("[redacted]");
+	}
+	return out;
+}
+
+function errorText(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}

--- a/pi-extensions/pi-claude-bridge/src/index.ts
+++ b/pi-extensions/pi-claude-bridge/src/index.ts
@@ -13,7 +13,9 @@ import { decideRegistration, hasClaudeCredentials } from "./auth-presence.js";
 import { extractAgentsAppend } from "./agents-md.js";
 import { buildPromptContextAppend } from "./prompt-context.js";
 import { jsonSchemaToZodShape } from "./typebox-to-zod.js";
+import { readFileSync as nodeReadFileSync } from "node:fs";
 import { resolveGetModels } from "./pi-ai-compat.js";
+import { listAccountConnectors, resolveClaudeOAuth } from "./connector-inventory.js";
 import { debug, diagDump, makeCliDebugOptions, moduleInstanceId } from "./debug.js";
 import { preflightClaudeExecutable, resolveClaudeExecutable, spawnClaudeCodeWithDiagnostics } from "./claude-executable.js";
 import { argKeys, extensionApi, piUI, reportToolResultMismatch, safeNotify, safeToolCallSummary, setExtensionApi, setPiUI, setSharedSession, sharedSession } from "./bridge-state.js";
@@ -1076,6 +1078,38 @@ function showBridgeStatus(ctx: { ui: ExtensionUIContext; cwd?: string }): void {
 	].join("\n"), "info");
 }
 
+// Read a credential file, treating any read error as "absent" — a missing or
+// unreadable candidate must fall through to the next one, not abort resolution.
+function readCredentialFile(path: string): string | undefined {
+	try {
+		return nodeReadFileSync(path, "utf8");
+	} catch {
+		return undefined;
+	}
+}
+
+// Deterministic connector enumeration for the host app (vstack#838). Reports the
+// failure reason rather than an empty list, so "no connectors" and "could not
+// check" stay distinguishable.
+async function reportConnectorInventory(ctx: { ui: ExtensionUIContext }): Promise<void> {
+	const credentials = resolveClaudeOAuth(readCredentialFile);
+	if (!credentials) {
+		ctx.ui.notify("Claude bridge: no Claude OAuth credentials found — cannot enumerate connectors.", "error");
+		return;
+	}
+	const inventory = await listAccountConnectors({ credentials });
+	if (!inventory.ok) {
+		ctx.ui.notify(`Claude bridge: connector enumeration failed — ${inventory.reason}`, "error");
+		return;
+	}
+	if (inventory.connectors.length === 0) {
+		ctx.ui.notify("Claude bridge: this account has no connectors installed.", "info");
+		return;
+	}
+	const names = inventory.connectors.map((c) => c.name).join(", ");
+	ctx.ui.notify(`Claude bridge: ${inventory.connectors.length} connector(s) installed — ${names}`, "info");
+}
+
 function registerBridgeCommands(pi: ExtensionAPI): void {
 	const guard = pi as unknown as Record<PropertyKey, unknown>;
 	if (guard[COMMANDS_REGISTERED_KEY]) return;
@@ -1111,6 +1145,10 @@ function registerBridgeCommands(pi: ExtensionAPI): void {
 	pi.registerCommand("claude-bridge:extra", {
 		description: "Run Claude Code /extra-usage through claude-bridge",
 		handler: async (_args: string, ctx) => runExtraUsage(ctx),
+	});
+	pi.registerCommand("claude-bridge:connectors", {
+		description: "List the Claude account's installed claude.ai connectors",
+		handler: async (_args: string, ctx) => reportConnectorInventory(ctx),
 	});
 }
 

--- a/pi-extensions/pi-claude-bridge/tests/unit-connector-inventory.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-connector-inventory.mjs
@@ -1,0 +1,219 @@
+/**
+ * Tests for deterministic connector enumeration (vstack#838).
+ * Pins: credential resolution across split files and per-account CLAUDE_CONFIG_DIR,
+ * the POST shape the endpoint requires, and — most importantly — that every
+ * non-success path reports failure rather than an empty-but-successful list.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+	connectorServerNamespace,
+	connectorsListUrl,
+	credentialCandidatePaths,
+	listAccountConnectors,
+	resolveClaudeOAuth,
+} from "../src/connector-inventory.js";
+import { CLAUDE_AI_CONNECTOR_TOOL_PATTERNS } from "../src/connectors.js";
+
+const CREDS = { accessToken: "sk-ant-oat01-secret", organizationUuid: "org-uuid-1" };
+
+// Mirrors the live payload observed on a personal claude_max org.
+const LIVE_BODY = JSON.stringify({
+	results: [
+		{
+			name: "Gmail",
+			description: "Draft replies, summarize threads, & search your inbox",
+			directoryUuid: "2701e52f-b826-4aaf-8b25-11f2a97c98b0",
+			installedServerId: "cd7a4f5c-c21e-403f-aa35-481aff1d1bb5",
+			customOAuthClientId: null,
+			installState: "unknown",
+			isAuthless: false,
+		},
+		{ name: "Google Calendar", directoryUuid: "2a838eaa", installedServerId: "43bfe39d", isAuthless: false },
+		{ name: "Google Drive", directoryUuid: "b89f7865", installedServerId: "9a94a59a", isAuthless: false },
+	],
+	opt_in_required: false,
+	message: null,
+});
+
+const okFetch = (body = LIVE_BODY, status = 200) => {
+	const calls = [];
+	const impl = async (url, init) => {
+		calls.push({ url, init });
+		return new Response(body, { status });
+	};
+	impl.calls = calls;
+	return impl;
+};
+
+describe("credential resolution", () => {
+	it("reads token and org UUID from separate files", () => {
+		const files = {
+			"/h/.claude/.credentials.json": JSON.stringify({ claudeAiOauth: { accessToken: "tok" } }),
+			"/h/.claude.json": JSON.stringify({ oauthAccount: { organizationUuid: "org" } }),
+		};
+		const got = resolveClaudeOAuth((p) => files[p], { HOME: "/h" });
+		assert.deepEqual(got, { accessToken: "tok", organizationUuid: "org" });
+	});
+
+	it("prefers CLAUDE_CONFIG_DIR over HOME so per-account sidecars stay isolated", () => {
+		const files = {
+			"/acct-b/.credentials.json": JSON.stringify({ claudeAiOauth: { accessToken: "b-tok" } }),
+			"/acct-b/.claude.json": JSON.stringify({ oauthAccount: { organizationUuid: "b-org" } }),
+			"/h/.claude/.credentials.json": JSON.stringify({ claudeAiOauth: { accessToken: "a-tok" } }),
+			"/h/.claude.json": JSON.stringify({ oauthAccount: { organizationUuid: "a-org" } }),
+		};
+		const got = resolveClaudeOAuth((p) => files[p], { HOME: "/h", CLAUDE_CONFIG_DIR: "/acct-b" });
+		assert.deepEqual(got, { accessToken: "b-tok", organizationUuid: "b-org" });
+	});
+
+	it("skips a corrupt file instead of letting it mask a later good one", () => {
+		const files = {
+			"/h/.claude/.credentials.json": "{ not json",
+			"/h/.claude.json": JSON.stringify({
+				claudeAiOauth: { accessToken: "tok" },
+				oauthAccount: { organizationUuid: "org" },
+			}),
+		};
+		const got = resolveClaudeOAuth((p) => files[p], { HOME: "/h" });
+		assert.deepEqual(got, { accessToken: "tok", organizationUuid: "org" });
+	});
+
+	it("returns undefined when either half is missing", () => {
+		const onlyToken = { "/h/.claude/.credentials.json": JSON.stringify({ claudeAiOauth: { accessToken: "tok" } }) };
+		assert.equal(resolveClaudeOAuth((p) => onlyToken[p], { HOME: "/h" }), undefined);
+		const onlyOrg = { "/h/.claude.json": JSON.stringify({ oauthAccount: { organizationUuid: "org" } }) };
+		assert.equal(resolveClaudeOAuth((p) => onlyOrg[p], { HOME: "/h" }), undefined);
+		assert.equal(resolveClaudeOAuth(() => undefined, { HOME: "/h" }), undefined);
+	});
+
+	it("probes CLAUDE_CONFIG_DIR paths before HOME paths", () => {
+		const paths = credentialCandidatePaths({ HOME: "/h", CLAUDE_CONFIG_DIR: "/cfg" });
+		assert.equal(paths[0], "/cfg/.credentials.json");
+		assert.ok(paths.indexOf("/cfg/.claude.json") < paths.indexOf("/h/.claude/.credentials.json"));
+	});
+});
+
+describe("request shape", () => {
+	it("POSTs with the bearer token and oauth beta header", async () => {
+		const f = okFetch();
+		await listAccountConnectors({ credentials: CREDS, fetchImpl: f });
+		assert.equal(f.calls.length, 1);
+		const { url, init } = f.calls[0];
+		assert.equal(url, "https://api.anthropic.com/api/oauth/organizations/org-uuid-1/mcp/connectors/list");
+		// GET returns 405 on this endpoint — the method is load-bearing.
+		assert.equal(init.method, "POST");
+		assert.equal(init.headers.Authorization, `Bearer ${CREDS.accessToken}`);
+		assert.equal(init.headers["anthropic-beta"], "oauth-2025-04-20");
+		assert.equal(init.body, "{}");
+	});
+
+	it("percent-encodes the org UUID into the path", () => {
+		assert.match(connectorsListUrl("a/b"), /organizations\/a%2Fb\/mcp/);
+	});
+
+	it("honors an apiBase override without doubling slashes", () => {
+		assert.equal(
+			connectorsListUrl("o", "https://example.test/"),
+			"https://example.test/api/oauth/organizations/o/mcp/connectors/list",
+		);
+	});
+});
+
+describe("success path", () => {
+	it("returns every connector, marked complete", async () => {
+		const got = await listAccountConnectors({ credentials: CREDS, fetchImpl: okFetch() });
+		assert.equal(got.ok, true);
+		assert.equal(got.complete, true);
+		assert.deepEqual(got.connectors.map((c) => c.name), ["Gmail", "Google Calendar", "Google Drive"]);
+	});
+
+	it("keeps installedServerId — the field that proves this is the attached set", async () => {
+		const got = await listAccountConnectors({ credentials: CREDS, fetchImpl: okFetch() });
+		assert.equal(got.connectors[0].installedServerId, "cd7a4f5c-c21e-403f-aa35-481aff1d1bb5");
+		assert.equal(got.connectors[0].directoryUuid, "2701e52f-b826-4aaf-8b25-11f2a97c98b0");
+	});
+
+	it("an account with no connectors is a successful empty list, not a failure", async () => {
+		const got = await listAccountConnectors({
+			credentials: CREDS,
+			fetchImpl: okFetch(JSON.stringify({ results: [] })),
+		});
+		assert.equal(got.ok, true);
+		assert.equal(got.complete, true);
+		assert.deepEqual(got.connectors, []);
+	});
+});
+
+describe("failure paths never masquerade as an empty inventory", () => {
+	const expectFailure = (got, fragment) => {
+		assert.equal(got.ok, false);
+		assert.equal(got.complete, false);
+		assert.match(got.reason, fragment);
+		assert.equal(got.connectors, undefined);
+	};
+
+	it("HTTP error", async () => {
+		const body = JSON.stringify({ error: { message: "Method Not Allowed" } });
+		expectFailure(
+			await listAccountConnectors({ credentials: CREDS, fetchImpl: okFetch(body, 405) }),
+			/HTTP 405 \(Method Not Allowed\)/,
+		);
+	});
+
+	it("transport throw", async () => {
+		const boom = async () => { throw new Error("ECONNREFUSED"); };
+		expectFailure(
+			await listAccountConnectors({ credentials: CREDS, fetchImpl: boom }),
+			/request failed: ECONNREFUSED/,
+		);
+	});
+
+	it("non-JSON body", async () => {
+		expectFailure(
+			await listAccountConnectors({ credentials: CREDS, fetchImpl: okFetch("<html>502</html>") }),
+			/non-JSON body/,
+		);
+	});
+
+	it("missing results array is a protocol change, not an empty account", async () => {
+		expectFailure(
+			await listAccountConnectors({ credentials: CREDS, fetchImpl: okFetch(JSON.stringify({ ok: true })) }),
+			/no results array/,
+		);
+	});
+
+	it("an unnamed entry fails rather than silently shrinking the list", async () => {
+		const body = JSON.stringify({ results: [{ name: "Gmail" }, { installedServerId: "x" }] });
+		expectFailure(
+			await listAccountConnectors({ credentials: CREDS, fetchImpl: okFetch(body) }),
+			/entry with no name/,
+		);
+	});
+
+	it("never leaks the access token into a failure reason", async () => {
+		const results = await Promise.all([
+			listAccountConnectors({ credentials: CREDS, fetchImpl: okFetch("nope", 500) }),
+			listAccountConnectors({ credentials: CREDS, fetchImpl: async () => { throw new Error(CREDS.accessToken); } }),
+		]);
+		for (const r of results) assert.ok(!r.reason.includes("sk-ant-oat01-secret"), r.reason);
+	});
+});
+
+describe("connectorServerNamespace", () => {
+	it("maps connector names to their tool namespace", () => {
+		assert.equal(connectorServerNamespace("Gmail"), "mcp__claude_ai_Gmail__");
+		assert.equal(connectorServerNamespace("Google Calendar"), "mcp__claude_ai_Google_Calendar__");
+	});
+
+	// Corroboration, not restatement: CLAUDE_AI_CONNECTOR_TOOL_PATTERNS was built
+	// from a live tool enumeration, independently of this naming rule.
+	it("agrees with the independently-derived connector tool patterns", () => {
+		for (const name of ["Gmail", "Google Calendar", "Google Drive", "Slack", "Atlassian"]) {
+			assert.ok(
+				CLAUDE_AI_CONNECTOR_TOOL_PATTERNS.includes(`${connectorServerNamespace(name)}*`),
+				`no pattern for ${name}`,
+			);
+		}
+	});
+});


### PR DESCRIPTION
Closes #838.

## The defect

The capability probe asked the **model** to enumerate connectors via `ToolSearch`. A search returns what the search surfaced — a **lower bound** — and nothing in the result said so. An account demonstrably holding Slack (19 real `mcp__claude_ai_Slack` tool ids, a completed Slack write) produced a stored inventory of `atlassian, gmail, calendar, drive` with `probe_failed = false`. Attach succeeded, the probe succeeded, the answer was wrong.

## The fix

Ask the account instead:

```
POST /api/oauth/organizations/:orgUUID/mcp/connectors/list
Authorization: Bearer <oauth token>
anthropic-beta: oauth-2025-04-20
```

Verified live against a personal `claude_max` org. The method is load-bearing — a GET returns `405`. Each result carries **both** `directoryUuid` (catalog identity) **and** `installedServerId` (this account's installed instance); a marketplace catalog entry has no installed-server id, which is what establishes this as the attached set rather than the registry listing.

Because the answer comes from the account rather than a model turn, it is **complete by construction** — the result carries `complete: true` and there is no partial state.

## Failure is never an empty list

That was the actual bug, so it's pinned by tests. Transport throw, HTTP error, non-JSON body, missing `results` array, and an entry without a name all return `{ ok: false, reason }`. An account with genuinely no connectors is a successful empty list. `"no connectors"` and `"could not check"` stay distinguishable.

## Things worth a reviewer's eye

- **A test caught a token leak in my own first cut.** Transport errors interpolate the thrown message, and a fetch/proxy layer may put request headers — including the bearer token — into it. Failure reasons are now redacted against the token rather than the test being weakened.
- **Credentials resolve `CLAUDE_CONFIG_DIR` before `$HOME`**, so a host running one sidecar per Claude account reads the right account. Token and org UUID are scanned independently because they don't co-locate (token in `.credentials.json`, org in `.claude.json` on the verified machine).
- **The union spells both sides as `?: undefined`** — this package compiles with `strict: false`, where boolean-discriminant narrowing doesn't filter union members, so the plain two-variant union makes `inventory.reason` a compile error at every call site.
- `connectorServerNamespace()` is cross-checked in tests against `CLAUDE_AI_CONNECTOR_TOOL_PATTERNS`, which was derived independently from a live tool enumeration.

## Scope

Bridge-side deliverable only. Replacing the probe call site is downstream — memsira #275 and the drovr equivalent.

This likely also dissolves #832: that race only ever affected the probe turn (−149ms margin, vs +12.5s on a real chat turn) because the probe *was* a model turn. I'm not closing #832 on that reasoning — it should be confirmed when the apps adopt this.

## Verification

`npm run test:unit` — **256/256** (52 suites + the new one; +19 tests). `npx tsc --noEmit` clean. Bundle rebuilt in the same commit.

https://claude.ai/code/session_018LpgYWmefqC3ZF1jzUCuzY