### PR TITLE
docs(connectors): connector enumeration is scoped by token, not by org

### DIFF
--- a/docs/cross-repo.md
+++ b/docs/cross-repo.md
@@ -54,6 +54,14 @@ All three sessions send into each other's tmux panes. The failure modes are not 
 - **Verify delivery by a short distinctive fragment.** Long phrases wrap across lines and a `grep` for them returns zero on a message that landed fine. Search the scrollback (`capture-pane -S -300`), not just the visible pane.
 - **Backticks in the message body get shell-expanded** by the sending shell and silently drop identifiers. Quote with single quotes, or avoid them.
 
+## Connector Enumeration Is Token-Scoped
+
+Deterministic connector enumeration (vstack#848) answers "which connectors does this account have" by calling the account rather than asking the model. One property is easy to get wrong and fails silently:
+
+- **The organization UUID in the request path is ignored.** Verified live — an all-zero UUID and the literal string `not-a-uuid` both returned the bearer token's own account, identical to passing the real org. The **token alone** selects the account.
+- **So a multi-account host cannot scope by org.** Selecting an account means selecting the credential — which `CLAUDE_CONFIG_DIR` gets read — not passing that account's UUID. This matters for named-multi-account work: passing account B's org UUID with account A's token returns **account A's connectors, marked complete**, with nothing anomalous in the result.
+- Treat a connector inventory as belonging to whichever credential produced it, and carry the account identity alongside it rather than inferring it from the request you made.
+
 ## Capability Probe Contract
 
 For any probe whose result other repos store and act on — connector inventories being the live case.

--- a/pi-extensions/pi-claude-bridge/src/connector-inventory.ts
+++ b/pi-extensions/pi-claude-bridge/src/connector-inventory.ts
@@ -47,6 +47,16 @@ export type ConnectorInventory =
 	| { ok: true; complete: true; connectors: ConnectorEntry[]; reason?: undefined }
 	| { ok: false; complete: false; connectors?: undefined; reason: string };
 
+// SCOPING IS BY TOKEN, NOT BY ORG. Verified live: the org UUID in the path is
+// ignored — an all-zero UUID and the literal string "not-a-uuid" both returned
+// the bearer token's own account, identically to the real org. A multi-account
+// host therefore CANNOT select an account by passing its organizationUuid; the
+// only thing that selects an account is which credential the token came from
+// (i.e. which CLAUDE_CONFIG_DIR was read). Getting that wrong yields a
+// confident, well-formed answer for the WRONG account.
+//
+// The real UUID is still sent rather than a placeholder, so the call keeps
+// working if the API starts enforcing it.
 export type ClaudeOAuthCredentials = {
 	accessToken: string;
 	organizationUuid: string;


### PR DESCRIPTION
Follow-up to #848, from verifying that change end-to-end against a live account.

## Finding

The organization UUID in the connector-list request path is **ignored**. Verified live:

| org UUID sent | result |
|---|---|
| the real one | Gmail, Google Calendar, Google Drive |
| `00000000-0000-0000-0000-000000000000` | Gmail, Google Calendar, Google Drive |
| `not-a-uuid` | Gmail, Google Calendar, Google Drive |

The **bearer token alone** selects the account.

## Why it matters

A multi-account host cannot scope by org. Selecting an account means selecting the *credential* — which `CLAUDE_CONFIG_DIR` gets read — not passing that account's UUID. Passing account B's org with account A's token returns **account A's connectors, marked complete**, with nothing anomalous in the result to catch it.

drovr has named multi-account on its roadmap and memsira is adopting the probe contract, so this goes in `docs/cross-repo.md` beside the contract rather than only in the module.

The real UUID is still sent rather than a placeholder, so the call keeps working if the API starts enforcing it.

Docs and comments only — no behavior change. 256/256 unit tests still green, bundle rebuilt.

https://claude.ai/code/session_018LpgYWmefqC3ZF1jzUCuzY