### PR TITLE
fix(pi-claude-bridge): ship the connector API that the README promised

### DIFF
--- a/.github/workflows/skill-tests.yml
+++ b/.github/workflows/skill-tests.yml
@@ -70,6 +70,17 @@ jobs:
       - name: deep-research node suite
         run: node --test skills/deep-research/tests/deep-research.test.mjs
 
+      # The bridge ships ~256 unit tests that nothing in CI ran until now, so
+      # "tests pass" on a bridge PR meant "passed on the author's machine".
+      # Build first: one suite loads bundle/connector-inventory.js rather than
+      # src, so a src change without a rebuild has to fail here.
+      - name: pi-claude-bridge unit suite
+        working-directory: pi-extensions/pi-claude-bridge
+        run: |
+          npm ci --no-audit --no-fund || npm install --no-audit --no-fund
+          npm run build
+          npm run test:unit
+
   cli-tests:
     name: CLI (cargo test + integration check)
     runs-on: ubuntu-latest

--- a/pi-extensions/pi-claude-bridge/README.md
+++ b/pi-extensions/pi-claude-bridge/README.md
@@ -148,7 +148,13 @@ The bridge registers `claude-bridge/claude-fable-5`, `claude-bridge/claude-opus-
 
 The older way to answer "does this account have Slack?" was a capability probe: a model turn that enumerated connectors via `ToolSearch`. A search returns what the search surfaced — a lower bound — and nothing in the result said so, so an account with Slack attached could produce an inventory without Slack and no failure signal (vstack#838). This command calls the account's connector list endpoint instead, so the answer is complete by construction.
 
-`listAccountConnectors()` in `src/connector-inventory.ts` is the programmatic form for host apps. It returns a discriminated result: on success `{ ok: true, complete: true, connectors }`, and on any transport or protocol failure `{ ok: false, reason }`. An account with no connectors is a successful empty list; a failure is never reported as an empty inventory. Credentials resolve from `CLAUDE_CONFIG_DIR` before `$HOME`, so a host running one sidecar per Claude account reads the right account.
+`listAccountConnectors()` is the programmatic form for host apps. Import it from the package's `./connector-inventory` entry point:
+
+```ts
+import { listAccountConnectors, resolveClaudeOAuth } from "@vanillagreen/pi-claude-bridge/connector-inventory";
+```
+
+That entry point is a separate build output. It cannot come from `bundle/index.js`, which exports only pi's extension registration and is tree-shaken against what `index.ts` itself calls — `connectorServerNamespace` was dropped from it entirely for that reason. `tests/unit-connector-inventory-artifact.mjs` loads the built artifact rather than `src/` so a source change without a rebuild fails. It returns a discriminated result: on success `{ ok: true, complete: true, connectors }`, and on any transport or protocol failure `{ ok: false, reason }`. An account with no connectors is a successful empty list; a failure is never reported as an empty inventory. Credentials resolve from `CLAUDE_CONFIG_DIR` before `$HOME`, so a host running one sidecar per Claude account reads the right account.
 
 ## Extra usage and rate limits
 

--- a/pi-extensions/pi-claude-bridge/README.md
+++ b/pi-extensions/pi-claude-bridge/README.md
@@ -154,7 +154,13 @@ The older way to answer "does this account have Slack?" was a capability probe: 
 import { listAccountConnectors, resolveClaudeOAuth } from "@vanillagreen/pi-claude-bridge/connector-inventory";
 ```
 
-That entry point is a separate build output. It cannot come from `bundle/index.js`, which exports only pi's extension registration and is tree-shaken against what `index.ts` itself calls — `connectorServerNamespace` was dropped from it entirely for that reason. `tests/unit-connector-inventory-artifact.mjs` loads the built artifact rather than `src/` so a source change without a rebuild fails. It returns a discriminated result: on success `{ ok: true, complete: true, connectors }`, and on any transport or protocol failure `{ ok: false, reason }`. An account with no connectors is a successful empty list; a failure is never reported as an empty inventory. Credentials resolve from `CLAUDE_CONFIG_DIR` before `$HOME`, so a host running one sidecar per Claude account reads the right account.
+Consuming apps that regenerate their vendored `package.json` with a closed exports map (`{".": "./bundle/index.js"}`) cannot reach that subpath — Node rejects every unlisted subpath *and* deep path under such a map. The same functions are therefore re-exported from the package root, which is the path those manifests allow:
+
+```ts
+import { listAccountConnectors } from "@vanillagreen/pi-claude-bridge";
+```
+
+The dedicated entry point is a separate build output. It cannot come from `bundle/index.js`, which exports only pi's extension registration and is tree-shaken against what `index.ts` itself calls — `connectorServerNamespace` was dropped from it entirely for that reason. `tests/unit-connector-inventory-artifact.mjs` loads the built artifact rather than `src/` so a source change without a rebuild fails. It returns a discriminated result: on success `{ ok: true, complete: true, connectors }`, and on any transport or protocol failure `{ ok: false, reason }`. An account with no connectors is a successful empty list; a failure is never reported as an empty inventory. Credentials resolve from `CLAUDE_CONFIG_DIR` before `$HOME`, so a host running one sidecar per Claude account reads the right account.
 
 ## Extra usage and rate limits
 

--- a/pi-extensions/pi-claude-bridge/bundle/connector-inventory.js
+++ b/pi-extensions/pi-claude-bridge/bundle/connector-inventory.js
@@ -47,7 +47,12 @@ function nonEmptyString(value) {
   return typeof value === "string" && value.trim() ? value.trim() : void 0;
 }
 function connectorsListUrl(organizationUuid, apiBase = DEFAULT_API_BASE) {
-  return `${apiBase.replace(/\/+$/, "")}/api/oauth/organizations/${encodeURIComponent(organizationUuid)}/mcp/connectors/list`;
+  return `${trimTrailingSlashes(apiBase)}/api/oauth/organizations/${encodeURIComponent(organizationUuid)}/mcp/connectors/list`;
+}
+function trimTrailingSlashes(value) {
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === 47) end--;
+  return value.slice(0, end);
 }
 async function listAccountConnectors(deps) {
   const { credentials, apiBase, signal } = deps;

--- a/pi-extensions/pi-claude-bridge/bundle/connector-inventory.js
+++ b/pi-extensions/pi-claude-bridge/bundle/connector-inventory.js
@@ -1,0 +1,132 @@
+// src/connector-inventory.ts
+var CONNECTOR_NS_PREFIX = "mcp__claude_ai_";
+var DEFAULT_API_BASE = "https://api.anthropic.com";
+var OAUTH_BETA_HEADER = "oauth-2025-04-20";
+function connectorServerNamespace(connectorName) {
+  return `${CONNECTOR_NS_PREFIX}${connectorName.trim().replace(/\s+/g, "_")}__`;
+}
+function credentialCandidatePaths(env = process.env) {
+  const roots = [];
+  const configDir = env.CLAUDE_CONFIG_DIR?.trim();
+  if (configDir) roots.push(configDir);
+  const home = env.HOME?.trim();
+  if (home) roots.push(`${home}/.claude`, home);
+  const seen = /* @__PURE__ */ new Set();
+  const paths = [];
+  for (const root of roots) {
+    for (const name of [".credentials.json", ".claude.json"]) {
+      const p = `${root}/${name}`;
+      if (!seen.has(p)) {
+        seen.add(p);
+        paths.push(p);
+      }
+    }
+  }
+  return paths;
+}
+function resolveClaudeOAuth(readFile, env = process.env) {
+  let accessToken;
+  let organizationUuid;
+  for (const path of credentialCandidatePaths(env)) {
+    const raw = readFile(path);
+    if (!raw) continue;
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      continue;
+    }
+    accessToken ??= nonEmptyString(parsed?.claudeAiOauth?.accessToken);
+    organizationUuid ??= nonEmptyString(parsed?.oauthAccount?.organizationUuid);
+    if (accessToken && organizationUuid) break;
+  }
+  if (!accessToken || !organizationUuid) return void 0;
+  return { accessToken, organizationUuid };
+}
+function nonEmptyString(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : void 0;
+}
+function connectorsListUrl(organizationUuid, apiBase = DEFAULT_API_BASE) {
+  return `${apiBase.replace(/\/+$/, "")}/api/oauth/organizations/${encodeURIComponent(organizationUuid)}/mcp/connectors/list`;
+}
+async function listAccountConnectors(deps) {
+  const { credentials, apiBase, signal } = deps;
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const url = connectorsListUrl(credentials.organizationUuid, apiBase);
+  const fail = (reason) => ({ ok: false, complete: false, reason: redactSecret(reason, credentials.accessToken) });
+  let response;
+  try {
+    response = await fetchImpl(url, {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${credentials.accessToken}`,
+        "anthropic-beta": OAUTH_BETA_HEADER,
+        "Content-Type": "application/json"
+      },
+      body: "{}",
+      signal
+    });
+  } catch (error) {
+    return fail(`connector list request failed: ${errorText(error)}`);
+  }
+  let bodyText;
+  try {
+    bodyText = await response.text();
+  } catch (error) {
+    return fail(`connector list response unreadable: ${errorText(error)}`);
+  }
+  if (!response.ok) {
+    return fail(`connector list returned HTTP ${response.status}${apiErrorSuffix(bodyText)}`);
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(bodyText);
+  } catch {
+    return fail("connector list returned a non-JSON body");
+  }
+  if (!Array.isArray(parsed?.results)) {
+    return fail("connector list response had no results array");
+  }
+  const connectors = [];
+  for (const raw of parsed.results) {
+    const entry = raw;
+    const name = nonEmptyString(entry?.name);
+    if (!name) {
+      return fail("connector list contained an entry with no name");
+    }
+    connectors.push({
+      name,
+      installedServerId: nonEmptyString(entry?.installedServerId),
+      directoryUuid: nonEmptyString(entry?.directoryUuid),
+      description: nonEmptyString(entry?.description),
+      isAuthless: typeof entry?.isAuthless === "boolean" ? entry.isAuthless : void 0
+    });
+  }
+  return { ok: true, complete: true, connectors };
+}
+function apiErrorSuffix(bodyText) {
+  try {
+    const message = JSON.parse(bodyText)?.error?.message;
+    return typeof message === "string" && message.trim() ? ` (${message.trim()})` : "";
+  } catch {
+    return "";
+  }
+}
+function redactSecret(text, secret) {
+  if (!secret || secret.length < 8) return text;
+  let out = text;
+  for (const form of /* @__PURE__ */ new Set([secret, encodeURIComponent(secret)])) {
+    out = out.split(form).join("[redacted]");
+  }
+  return out;
+}
+function errorText(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+export {
+  connectorServerNamespace,
+  connectorsListUrl,
+  credentialCandidatePaths,
+  listAccountConnectors,
+  resolveClaudeOAuth
+};

--- a/pi-extensions/pi-claude-bridge/bundle/index.js
+++ b/pi-extensions/pi-claude-bridge/bundle/index.js
@@ -42418,8 +42418,12 @@ async function resolveGetModels(root, loadCompat = () => dynamicImport("@earendi
 }
 
 // src/connector-inventory.ts
+var CONNECTOR_NS_PREFIX = "mcp__claude_ai_";
 var DEFAULT_API_BASE = "https://api.anthropic.com";
 var OAUTH_BETA_HEADER = "oauth-2025-04-20";
+function connectorServerNamespace(connectorName) {
+  return `${CONNECTOR_NS_PREFIX}${connectorName.trim().replace(/\s+/g, "_")}__`;
+}
 function credentialCandidatePaths(env = process.env) {
   const roots = [];
   const configDir = env.CLAUDE_CONFIG_DIR?.trim();
@@ -43014,12 +43018,12 @@ var CLAUDE_AI_CONNECTOR_TOOL_PATTERNS = [
   "mcp__claude_ai_Atlassian__*"
 ];
 var CONNECTOR_DISCOVERY_TOOLS = ["ToolSearch", "ListMcpResources", "ReadMcpResource"];
-var CONNECTOR_NS_PREFIX = "mcp__claude_ai_";
-var CONNECTOR_NS_GMAIL = `${CONNECTOR_NS_PREFIX}Gmail__`;
-var CONNECTOR_NS_CALENDAR = `${CONNECTOR_NS_PREFIX}Google_Calendar__`;
-var CONNECTOR_NS_DRIVE = `${CONNECTOR_NS_PREFIX}Google_Drive__`;
-var CONNECTOR_NS_SLACK = `${CONNECTOR_NS_PREFIX}Slack__`;
-var CONNECTOR_NS_ATLASSIAN = `${CONNECTOR_NS_PREFIX}Atlassian__`;
+var CONNECTOR_NS_PREFIX2 = "mcp__claude_ai_";
+var CONNECTOR_NS_GMAIL = `${CONNECTOR_NS_PREFIX2}Gmail__`;
+var CONNECTOR_NS_CALENDAR = `${CONNECTOR_NS_PREFIX2}Google_Calendar__`;
+var CONNECTOR_NS_DRIVE = `${CONNECTOR_NS_PREFIX2}Google_Drive__`;
+var CONNECTOR_NS_SLACK = `${CONNECTOR_NS_PREFIX2}Slack__`;
+var CONNECTOR_NS_ATLASSIAN = `${CONNECTOR_NS_PREFIX2}Atlassian__`;
 var CONNECTOR_READ_VERBS = /* @__PURE__ */ new Set([
   "list",
   "search",
@@ -43171,10 +43175,10 @@ var CONNECTOR_WRITE_TOOLS = [
   `${CONNECTOR_NS_ATLASSIAN}createCompassCustomFieldDefinition`
 ];
 function isConnectorWriteTool(name) {
-  if (!name.startsWith(CONNECTOR_NS_PREFIX)) return false;
-  const sep2 = name.indexOf("__", CONNECTOR_NS_PREFIX.length);
-  if (sep2 <= CONNECTOR_NS_PREFIX.length) return true;
-  const server = name.slice(CONNECTOR_NS_PREFIX.length, sep2);
+  if (!name.startsWith(CONNECTOR_NS_PREFIX2)) return false;
+  const sep2 = name.indexOf("__", CONNECTOR_NS_PREFIX2.length);
+  if (sep2 <= CONNECTOR_NS_PREFIX2.length) return true;
+  const server = name.slice(CONNECTOR_NS_PREFIX2.length, sep2);
   const words = connectorNameWords(name.slice(sep2 + "__".length));
   const serverWords = connectorNameWords(server);
   let skipped = 0;
@@ -45309,17 +45313,21 @@ export {
   buildStreamIdleTimeoutErrorMessage,
   classifyClaudeExecutableBytes,
   connectorQueryOptions,
+  connectorServerNamespace,
   connectorWriteDenyHook,
   connectorWriteModeFor,
   connectorWriteModeFromEnv,
   connectorsEnabledFor,
   connectorsEnabledFromEnv,
+  connectorsListUrl,
   createStreamIdleWatchdog,
+  credentialCandidatePaths,
   index_default as default,
   formatAllowedRateLimitWarning,
   formatResetTimestamp,
   isConnectorWriteTool,
   isExtraUsageRequiredMessage,
+  listAccountConnectors,
   mapToolName,
   normalizeRateLimitUtilization,
   preflightClaudeExecutable,
@@ -45327,6 +45335,7 @@ export {
   processStreamEvent,
   reportToolResultMismatch,
   resolveClaudeExecutable,
+  resolveClaudeOAuth,
   resolveConfiguredEffort,
   restoreSharedSessionFromPi,
   shouldRestorePersistedBridgeEntry,

--- a/pi-extensions/pi-claude-bridge/bundle/index.js
+++ b/pi-extensions/pi-claude-bridge/bundle/index.js
@@ -42466,7 +42466,12 @@ function nonEmptyString(value) {
   return typeof value === "string" && value.trim() ? value.trim() : void 0;
 }
 function connectorsListUrl(organizationUuid, apiBase = DEFAULT_API_BASE) {
-  return `${apiBase.replace(/\/+$/, "")}/api/oauth/organizations/${encodeURIComponent(organizationUuid)}/mcp/connectors/list`;
+  return `${trimTrailingSlashes(apiBase)}/api/oauth/organizations/${encodeURIComponent(organizationUuid)}/mcp/connectors/list`;
+}
+function trimTrailingSlashes(value) {
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === 47) end--;
+  return value.slice(0, end);
 }
 async function listAccountConnectors(deps) {
   const { credentials, apiBase, signal } = deps;

--- a/pi-extensions/pi-claude-bridge/package.json
+++ b/pi-extensions/pi-claude-bridge/package.json
@@ -160,7 +160,7 @@
     "typescript": "^6.0.3"
   },
   "scripts": {
-    "build": "esbuild src/index.ts --bundle --platform=node --format=esm --target=node22 --outfile=bundle/index.js --external:@earendil-works/pi-ai --external:@earendil-works/pi-coding-agent",
+    "build": "esbuild src/index.ts --bundle --platform=node --format=esm --target=node22 --outfile=bundle/index.js --external:@earendil-works/pi-ai --external:@earendil-works/pi-coding-agent && esbuild src/connector-inventory.ts --bundle --platform=node --format=esm --target=node22 --outfile=bundle/connector-inventory.js",
     "prepack": "npm run build",
     "test:unit": "node --import tsx --test tests/unit-*.mjs",
     "test": "set -a && [ -f .env.test ] && . ./.env.test; set +a && npm run test:unit && tests/int-smoke.sh && tests/int-multi-turn.sh && tests/int-cache.sh && node --import tsx --test tests/int-*.mjs",
@@ -198,5 +198,9 @@
     "@earendil-works/pi-coding-agent": {
       "optional": true
     }
+  },
+  "exports": {
+    ".": "./bundle/index.js",
+    "./connector-inventory": "./bundle/connector-inventory.js"
   }
 }

--- a/pi-extensions/pi-claude-bridge/src/connector-inventory.ts
+++ b/pi-extensions/pi-claude-bridge/src/connector-inventory.ts
@@ -150,7 +150,18 @@ function nonEmptyString(value: unknown): string | undefined {
 }
 
 export function connectorsListUrl(organizationUuid: string, apiBase: string = DEFAULT_API_BASE): string {
-	return `${apiBase.replace(/\/+$/, "")}/api/oauth/organizations/${encodeURIComponent(organizationUuid)}/mcp/connectors/list`;
+	return `${trimTrailingSlashes(apiBase)}/api/oauth/organizations/${encodeURIComponent(organizationUuid)}/mcp/connectors/list`;
+}
+
+// Linear-time trailing-slash trim. This was `apiBase.replace(/\/+$/, "")`, which
+// CodeQL correctly flags as a polynomial regex on uncontrolled input: `apiBase`
+// is a caller-supplied parameter, and an anchored `+` backtracks on a long run
+// of slashes. It only became reachable as library input once this module gained
+// a real export surface, which is exactly the exposure the export was for.
+function trimTrailingSlashes(value: string): string {
+	let end = value.length;
+	while (end > 0 && value.charCodeAt(end - 1) === 47 /* "/" */) end--;
+	return value.slice(0, end);
 }
 
 export type ListConnectorsDeps = {

--- a/pi-extensions/pi-claude-bridge/src/index.ts
+++ b/pi-extensions/pi-claude-bridge/src/index.ts
@@ -16,6 +16,24 @@ import { jsonSchemaToZodShape } from "./typebox-to-zod.js";
 import { readFileSync as nodeReadFileSync } from "node:fs";
 import { resolveGetModels } from "./pi-ai-compat.js";
 import { listAccountConnectors, resolveClaudeOAuth } from "./connector-inventory.js";
+// Re-exported from the extension entry point ON PURPOSE. Consuming apps
+// regenerate their vendored package.json with a CLOSED exports map
+// ({".": "./bundle/index.js"}), which makes Node reject BOTH a subpath import
+// and a deep path into the package (ERR_PACKAGE_PATH_NOT_EXPORTED) — verified.
+// So the ./connector-inventory entry point alone does not reach them. Naming
+// these here puts them in bundle/index.js's own export list, which is the one
+// path their existing manifest already allows, and incidentally keeps esbuild
+// from tree-shaking helpers index.ts never calls itself.
+export {
+	connectorServerNamespace,
+	connectorsListUrl,
+	credentialCandidatePaths,
+	listAccountConnectors,
+	resolveClaudeOAuth,
+	type ClaudeOAuthCredentials,
+	type ConnectorEntry,
+	type ConnectorInventory,
+} from "./connector-inventory.js";
 import { debug, diagDump, makeCliDebugOptions, moduleInstanceId } from "./debug.js";
 import { preflightClaudeExecutable, resolveClaudeExecutable, spawnClaudeCodeWithDiagnostics } from "./claude-executable.js";
 import { argKeys, extensionApi, piUI, reportToolResultMismatch, safeNotify, safeToolCallSummary, setExtensionApi, setPiUI, setSharedSession, sharedSession } from "./bridge-state.js";

--- a/pi-extensions/pi-claude-bridge/tests/unit-connector-inventory-artifact.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-connector-inventory-artifact.mjs
@@ -31,6 +31,33 @@ before(async () => {
 	artifact = await import(`file://${artifactPath}`);
 });
 
+// The entry point consuming apps can actually reach. They regenerate their
+// vendored package.json with a CLOSED exports map ({".": "./bundle/index.js"}),
+// and Node rejects every unlisted subpath AND deep path under such a map
+// (ERR_PACKAGE_PATH_NOT_EXPORTED, verified). So the dedicated
+// ./connector-inventory entry is unreachable for them and the ROOT bundle is
+// the only allowed path — which makes this the load-bearing case, not the
+// secondary one.
+describe("root bundle re-export (the path a closed exports map allows)", () => {
+	let root;
+
+	before(async () => {
+		const rootPath = join(here, "..", "bundle", "index.js");
+		assert.ok(existsSync(rootPath), "bundle/index.js missing — run `npm run build`");
+		root = await import(`file://${rootPath}`);
+	});
+
+	it("exposes the connector API from the extension entry point", () => {
+		for (const name of ["listAccountConnectors", "resolveClaudeOAuth", "connectorServerNamespace"]) {
+			assert.equal(typeof root[name], "function", `${name} is not reachable from bundle/index.js`);
+		}
+	});
+
+	it("still registers the pi extension as its default export", () => {
+		assert.equal(typeof root.default, "function");
+	});
+});
+
 describe("shipped connector API", () => {
 	it("exports the documented programmatic surface", () => {
 		for (const name of [

--- a/pi-extensions/pi-claude-bridge/tests/unit-connector-inventory-artifact.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-connector-inventory-artifact.mjs
@@ -1,0 +1,73 @@
+/**
+ * Artifact test: loads the BUILT bundle, not src.
+ *
+ * Every other unit suite here imports from `../src/*.ts`, which proves the
+ * source is correct and proves nothing about what the package actually ships.
+ * Those are different objects and they can disagree — `connectorServerNamespace`
+ * was tree-shaken out of `bundle/index.js` entirely because index.ts never calls
+ * it, so a consumer following the README could not import the function the
+ * README named.
+ *
+ * This suite exists to catch that class: the public programmatic surface must be
+ * importable and callable FROM THE SHIPPED ARTIFACT. It fails on a stale bundle,
+ * which is the point — a src change without a rebuild should be caught here.
+ */
+import { describe, it, before } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const artifactPath = join(here, "..", "bundle", "connector-inventory.js");
+
+let artifact;
+
+before(async () => {
+	assert.ok(
+		existsSync(artifactPath),
+		`bundle/connector-inventory.js missing — run \`npm run build\` before the tests`,
+	);
+	artifact = await import(`file://${artifactPath}`);
+});
+
+describe("shipped connector API", () => {
+	it("exports the documented programmatic surface", () => {
+		for (const name of [
+			"listAccountConnectors",
+			"resolveClaudeOAuth",
+			"connectorServerNamespace",
+			"connectorsListUrl",
+			"credentialCandidatePaths",
+		]) {
+			assert.equal(typeof artifact[name], "function", `${name} is not exported from the built artifact`);
+		}
+	});
+
+	// Regression for the actual defect: this helper is unused by index.ts, so it
+	// was dropped from the extension bundle by tree-shaking. A named export in
+	// src is not a shipped export.
+	it("keeps exports that the extension entry point never calls", () => {
+		assert.equal(artifact.connectorServerNamespace("Google Calendar"), "mcp__claude_ai_Google_Calendar__");
+	});
+
+	it("is callable end to end against an injected transport", async () => {
+		const result = await artifact.listAccountConnectors({
+			credentials: { accessToken: "x".repeat(24), organizationUuid: "org" },
+			fetchImpl: async () => new Response(JSON.stringify({ results: [{ name: "Slack", installedServerId: "s1" }] }), { status: 200 }),
+		});
+		assert.equal(result.ok, true);
+		assert.equal(result.complete, true);
+		assert.deepEqual(result.connectors.map((c) => c.name), ["Slack"]);
+	});
+
+	it("still reports failure rather than an empty list", async () => {
+		const result = await artifact.listAccountConnectors({
+			credentials: { accessToken: "x".repeat(24), organizationUuid: "org" },
+			fetchImpl: async () => new Response("nope", { status: 500 }),
+		});
+		assert.equal(result.ok, false);
+		assert.equal(result.connectors, undefined);
+		assert.match(result.reason, /HTTP 500/);
+	});
+});


### PR DESCRIPTION
Found while verifying drovr's claim that comments don't survive bundling. They were right — and the grep that confirmed it showed `connectorServerNamespace` with **0 hits** in the bundle, which turned out to be a real defect of mine.

## The defect

#848's README called `listAccountConnectors()` "the programmatic form for host apps." **It was not importable as shipped.** I verified the source and then made a claim about the artifact — the same conflation both overseers have been cataloguing tonight.

Three independent reasons:

| | |
|---|---|
| no `main`, no `exports` in package.json | a bare specifier import fails outright |
| `bundle/index.js` exports only pi's extension default | the functions are inside it but unreachable |
| esbuild tree-shakes against what `index.ts` calls | `connectorServerNamespace` was dropped entirely |

That last one is the sharp edge: **a named export in `src` is not a shipped export.**

## Fix

A second build output (`bundle/connector-inventory.js`, 4.2kb) plus an `exports` map, so this resolves:

```ts
import { listAccountConnectors } from "@vanillagreen/pi-claude-bridge/connector-inventory";
```

Verified by importing the **built artifact** and calling it — all five functions present, `connectorServerNamespace("Google Calendar")` → `mcp__claude_ai_Google_Calendar__`, success and failure paths intact.

## The test that would have caught it

Every existing suite here imports from `src/*.ts`. That proves the source correct and says nothing about what ships. The new suite loads the built bundle and fails on a stale or missing one — verified by deleting the artifact and watching it fail.

## CI never ran this package's tests

No workflow referenced `pi-extensions`. The "256/256" in recent bridge PRs was true and **local**, sitting next to "CI green" in a way that implied CI had validated it. It had not.

CI now installs, builds, and runs the suite — which also makes the artifact test meaningful there rather than only on my machine.

260/260 green locally.

https://claude.ai/code/session_018LpgYWmefqC3ZF1jzUCuzY