### PR TITLE
fix(worktree): detect materialized harness links at use time (#856)

### DIFF
--- a/skills/worktree/scripts/worktree
+++ b/skills/worktree/scripts/worktree
@@ -89,6 +89,27 @@ fi
 # Load project config and secrets. .env.local still wins for compatibility.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/vstack-env.sh
+# A rebase replaces a symlinked harness dir with a REAL directory holding only
+# the tracked subset, so the untracked skills under it — including this script's
+# own lib — silently vanish (#856). Sourcing a missing lib exits 127 with
+# Bash's own message, which names neither the cause nor the recovery; that is
+# how the live incident presented. Fail loudly instead.
+#
+# The remediation must say "from the main checkout": in the observed incident
+# this script's own copy inside the worktree was among the missing files, so
+# pointing the operator at a worktree-local binary sends them to something that
+# is not there.
+if [[ ! -f "$SCRIPT_DIR/lib/vstack-env.sh" ]]; then
+  {
+    echo "Error: worktree support library is missing: $SCRIPT_DIR/lib/vstack-env.sh"
+    echo "  This is the signature of a materialized harness directory: a rebase replaced"
+    echo "  the symlink with a real directory containing only the tracked files, dropping"
+    echo "  everything installed by vstack."
+    echo "  Recover by running fix-links FROM THE MAIN CHECKOUT (this copy is incomplete):"
+    echo "    cd <main checkout> && .agents/skills/worktree/scripts/worktree fix-links '$PWD'"
+  } >&2
+  exit 1
+fi
 source "$SCRIPT_DIR/lib/vstack-env.sh"
 vstack_load_project_env "$PROJECT_ROOT"
 
@@ -795,6 +816,48 @@ symlink_into_worktree() {
 }
 
 # Apply all symlinks and copies to a worktree
+# Detect a materialized harness directory at USE time (#856).
+#
+# A rebase replaces a configured symlink with a real directory holding only the
+# tracked files underneath it, dropping every vstack-installed path there. The
+# worktree then looks clean to git — `git status` reports nothing, so
+# `git checkout --` is a no-op — and the damage only surfaces later as scripts
+# failing exit 127 on files they used to be able to source.
+#
+# This is deliberately a WARNING, not a failure: the command the operator asked
+# for may not touch the affected paths, and a hard error would be a regression
+# for them. It runs at the points where materialization has just become likely
+# (post-rebase) rather than via a git hook — see the issue thread for why
+# `core.hooksPath` is the wrong mechanism: it replaces the hooks directory
+# wholesale and would disable the consumer's own hooks.
+warn_if_links_materialized() {
+  local wt="$1" path="" materialized=""
+  [[ -n "$wt" && -d "$wt" ]] || return 0
+  validate_worktree_setup_config >/dev/null 2>&1 || return 0
+
+  split_worktree_config_words "${WORKTREE_SYMLINKS:-}"
+  for path in ${WORKTREE_CONFIG_WORDS[@]+"${WORKTREE_CONFIG_WORDS[@]}"}; do
+    path="$(normalize_worktree_config_path WORKTREE_SYMLINKS "$path" 2>/dev/null)" || continue
+    # Only a path that SHOULD be a link and exists as a non-link is damage.
+    [[ -e "$PROJECT_ROOT/$path" ]] || continue
+    if [[ -e "$wt/$path" && ! -L "$wt/$path" ]]; then
+      materialized="$materialized  - $path"$'\n'
+    fi
+  done
+
+  [[ -n "$materialized" ]] || return 0
+  {
+    echo "Warning: harness paths in this worktree are real directories, not symlinks:"
+    printf '%s' "$materialized"
+    echo "  A rebase materialized them, so vstack-installed files under those paths are gone."
+    echo "  git status will look clean — it tracks only the files that survived."
+    echo "  Restore them by running fix-links FROM THE MAIN CHECKOUT, because this"
+    echo "  worktree's own copy of the script may be among the missing files:"
+    echo "    cd '$PROJECT_ROOT' && .agents/skills/worktree/scripts/worktree fix-links '$wt'"
+  } >&2
+  return 0
+}
+
 setup_worktree_links() {
   local wt="$1"
   validate_worktree_setup_config || return 1
@@ -2205,6 +2268,11 @@ case "${1:-}" in
     if ! require_registered_project_worktree "$WT_PATH" "push it"; then
       exit 1
     fi
+    # Push is the usual first command after a MANUAL rebase — the case the
+    # script never sees, and so the case nothing repairs. `create --reuse` and
+    # the restack controls re-run setup themselves, so they self-heal and do
+    # not need the warning; this one does.
+    warn_if_links_materialized "$WT_PATH"
     if [[ "$AUTO_REBASE" == true ]]; then
       validate_worktree_setup_config || exit 1
     fi

--- a/skills/worktree/tests/worktree_materialized_links.sh
+++ b/skills/worktree/tests/worktree_materialized_links.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# #856: a rebase replaces a configured symlink with a real directory holding
+# only the tracked files underneath, dropping every vstack-installed path there.
+# git sees nothing (the surviving files are the tracked ones), so the damage
+# surfaces much later as scripts failing exit 127 on files they used to source.
+#
+# Two detections are asserted here:
+#   1. the support-library guard, which is where the live incident actually
+#      presented — a bare 127 naming neither cause nor recovery;
+#   2. the use-time check on `push`, the usual first command after a MANUAL
+#      rebase (the case the script never sees and therefore never repairs).
+#
+# Both messages must send the operator to the MAIN CHECKOUT: in the observed
+# incident the worktree's own copy of the script was among the missing files.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
+WORKTREE_SCRIPT="${WORKTREE_SCRIPT:-$SKILL_DIR/scripts/worktree}"
+TMP_ROOT="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+PASS=0
+FAIL=0
+ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
+
+assert_contains() {
+  local haystack="$1" needle="$2" name="$3"
+  if grep -qF -- "$needle" <<<"$haystack"; then ok "$name"; else bad "$name" "wanted: $needle"; fi
+}
+assert_lacks() {
+  local haystack="$1" needle="$2" name="$3"
+  if grep -qF -- "$needle" <<<"$haystack"; then bad "$name" "unexpected: $needle"; else ok "$name"; fi
+}
+
+mkdir -p "$TMP_ROOT/bin"
+cat >"$TMP_ROOT/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+chmod +x "$TMP_ROOT/bin/gh"
+export PATH="$TMP_ROOT/bin:$PATH"
+
+ROOT="$TMP_ROOT/repo"
+MAIN="$ROOT/main"
+mkdir -p "$MAIN"
+git -C "$MAIN" init -q -b main
+git -C "$MAIN" config user.email test@example.com
+git -C "$MAIN" config user.name Test
+git -C "$MAIN" config commit.gpgsign false
+printf 'base\n' >"$MAIN/base.txt"
+git -C "$MAIN" add base.txt
+git -C "$MAIN" commit -q -m base
+git init -q --bare "$ROOT/origin.git"
+git -C "$MAIN" remote add origin "$ROOT/origin.git"
+git -C "$MAIN" push -q -u origin main
+
+# harness/ mirrors the real hazard shape: mostly untracked vstack-installed
+# content, with one tracked file underneath that survives materialization.
+mkdir -p "$MAIN/harness/skills"
+printf 'harness/**\n!harness/tracked.md\n' >"$MAIN/.gitignore"
+printf 'installed\n' >"$MAIN/harness/skills/installed.txt"
+printf 'tracked\n' >"$MAIN/harness/tracked.md"
+printf 'WORKTREE_SYMLINKS="harness"\n' >"$MAIN/.env"
+git -C "$MAIN" add .gitignore harness/tracked.md
+git -C "$MAIN" commit -q -m harness
+git -C "$MAIN" push -q origin main
+
+WT="$(cd "$MAIN" && "$WORKTREE_SCRIPT" create mat-check 2>/dev/null | tail -1)"
+
+echo "=== baseline: the link exists and push does not cry wolf ==="
+if [[ -L "$WT/harness" ]]; then ok "harness is a symlink after create"; else bad "harness is a symlink after create"; fi
+set +e
+clean_out="$(cd "$MAIN" && "$WORKTREE_SCRIPT" push mat-check --no-rebase 2>&1)"
+set -e
+assert_lacks "$clean_out" "not symlinks" "no materialization warning on a healthy worktree"
+
+echo "=== push warns when the link has been materialized ==="
+# Exactly what a rebase leaves behind: a real directory with only the tracked
+# file, and the installed content gone.
+rm -f "$WT/harness"
+mkdir -p "$WT/harness"
+printf 'tracked\n' >"$WT/harness/tracked.md"
+set +e
+warn_out="$(cd "$MAIN" && "$WORKTREE_SCRIPT" push mat-check --no-rebase 2>&1)"
+set -e
+assert_contains "$warn_out" "not symlinks" "push reports materialized harness paths"
+assert_contains "$warn_out" "harness" "the warning names the affected path"
+assert_contains "$warn_out" "FROM THE MAIN CHECKOUT" "the warning sends the operator to the main checkout"
+assert_contains "$warn_out" "fix-links" "the warning names the recovery command"
+
+echo "=== fix-links from the main checkout restores it ==="
+(cd "$MAIN" && "$WORKTREE_SCRIPT" fix-links "$WT" >/dev/null 2>&1)
+if [[ -L "$WT/harness" ]]; then ok "fix-links restores the symlink"; else bad "fix-links restores the symlink"; fi
+
+echo "=== a missing support library fails loudly, not with a bare 127 ==="
+# The live incident's actual shape: the script's own lib vanished with the rest
+# of the installed tree, so it died before it could diagnose anything.
+BROKEN="$TMP_ROOT/broken"
+mkdir -p "$BROKEN/scripts/lib"
+cp "$SKILL_DIR/scripts/worktree" "$BROKEN/scripts/worktree"
+chmod +x "$BROKEN/scripts/worktree"
+set +e
+lib_out="$(cd "$MAIN" && "$BROKEN/scripts/worktree" list 2>&1)"
+lib_rc=$?
+set -e
+if [[ "$lib_rc" -ne 0 ]]; then ok "missing library exits non-zero"; else bad "missing library exits non-zero" "rc=0"; fi
+assert_contains "$lib_out" "support library is missing" "names the missing library"
+assert_contains "$lib_out" "materialized" "explains the cause"
+assert_contains "$lib_out" "FROM THE MAIN CHECKOUT" "sends the operator to the main checkout"
+assert_lacks "$lib_out" "No such file or directory" "does not surface bash's bare sourcing error"
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Closes #856.

A rebase replaces a configured symlink with a real directory holding only the tracked files underneath, dropping every vstack-installed path there. The survivors are exactly the tracked files, so `git status` is clean and `git checkout --` is a no-op — the damage surfaces much later as scripts failing exit 127.

## Not the proposed mechanism, and the issue thread settles why

The proposal was a `post-checkout`/`post-rewrite` hook. `core.hooksPath` **replaces the hooks directory wholesale** rather than adding one hook, so installing one would silently disable the consumer repo's own hooks (Husky, pre-commit, lint gates) in every provisioned worktree — a worse and equally silent failure than the one being fixed.

The reporter then confirmed the narrower alternative is a genuine no-op: `hooks` is on git's common-dir list (`path.c` `common_list`), so a linked worktree resolves hooks from `$GIT_COMMON_DIR/hooks` no matter what sits in `$GIT_DIR/worktrees/<id>/hooks/`. They endorsed use-time detection instead, and scoped it.

## What landed

- **The support-library source is guarded.** This is where the live incident (hyprtrade CC-1130) actually presented — a bare 127 naming neither cause nor recovery — and it fires before any later check could run.
- **`push` warns** when a configured symlink is now a real directory. `create --reuse` and the restack controls already re-run setup and self-heal, so they would only warn about something they immediately fix; `push` is the usual first command after a **manual** rebase, which the script never sees.
- **Both messages say to run `fix-links` FROM THE MAIN CHECKOUT.** In the observed incident the worktree's own copy of the script was among the missing files, so an unqualified "run fix-links" sends the operator to a binary that isn't there.

Warning, not failure — the command asked for may not touch the affected paths, and a hard error would be a regression.

## Tests

New `worktree_materialized_links.sh`, 12 assertions: healthy worktree does not cry wolf, push names the path / the main checkout / the recovery command, `fix-links` restores it, and the missing-library path exits non-zero with a real diagnosis rather than bash's bare sourcing error.

**Power-checked against the pre-fix script: 8 of 12 fail**, including all four library-guard assertions. Full worktree suite green (14 files).