### PR TITLE
docs(skills): route problem reports through `vstack report` (#863)

### DIFF
--- a/.github/workflows/skill-tests.yml
+++ b/.github/workflows/skill-tests.yml
@@ -35,6 +35,22 @@ jobs:
           done < <(git ls-files -- 'skills/*/tests/*.sh' 'skills/*/scripts/*' 'hooks/tests/*.sh' | grep -v '/scripts/lib/')
           exit "$fail"
 
+      # Every skill must route problem reports through `vstack report`. The
+      # ownership guard is a backstop for issues that bypassed it, so a skill
+      # carrying only a `bugs:` URL sends agents to hand-file in this repo
+      # regardless of who owns the asset (#863).
+      - name: skills point reports at `vstack report`
+        run: |
+          set -u
+          fail=0
+          while IFS= read -r f; do
+            if ! grep -qF 'vstack report' "$f"; then
+              echo "missing \`vstack report\` guidance: $f"
+              fail=1
+            fi
+          done < <(git ls-files -- 'skills/*/SKILL.md')
+          exit "$fail"
+
       - name: orch suite (run-all)
         run: bash skills/orch/tests/run-all.sh
 

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -90,7 +90,7 @@ fn init_skill(name: &str) -> Result<()> {
 
 fn skill_body(name: &str) -> String {
     format!(
-        "---\nname: {name}\ndescription: TODO — describe this skill\nlicense: MIT\nuser-invocable: true\n# dependencies:\n#   required: [skill-a, skill-b]\n#   optional: [skill-c]\nmetadata:\n  author: your-name\n  # source: your-project\n  # repository: \"https://github.com/owner/repo\"\n  # bugs: \"https://github.com/owner/repo/issues\"\n  version: \"1.0.0\"\n---\n\n# {title}\n\nTODO — skill instructions.\n",
+        "---\nname: {name}\ndescription: TODO — describe this skill\nlicense: MIT\nuser-invocable: true\n# dependencies:\n#   required: [skill-a, skill-b]\n#   optional: [skill-c]\nmetadata:\n  author: your-name\n  # source: your-project\n  # repository: \"https://github.com/owner/repo\"\n  # bugs: \"https://github.com/owner/repo/issues\"\n  version: \"1.0.0\"\n---\n\n# {title}\n\n> **Problem with this skill?** Run `vstack report` — it files to the owning repo automatically. Do not hand-file.\n\nTODO — skill instructions.\n",
         title = title_case(name),
     )
 }
@@ -160,6 +160,9 @@ mod tests {
         assert!(body.contains("  # source: your-project"));
         assert!(body.contains("  # repository: \"https://github.com/owner/repo\""));
         assert!(body.contains("  # bugs: \"https://github.com/owner/repo/issues\""));
+        // A new skill must point at the routing command, not only at a bugs URL:
+        // the ownership guard is a backstop for issues that bypassed it (#863).
+        assert!(body.contains("Run `vstack report`"));
     }
 
     #[test]

--- a/skills/decider/SKILL.md
+++ b/skills/decider/SKILL.md
@@ -13,6 +13,8 @@ metadata:
 
 # Decider
 
+> **Problem with this skill?** Run `vstack report` — it files to the owning repo automatically. Do not hand-file.
+
 Manages Architecture Decision Records (ADRs) — represented in this skill as numbered `DXXX` architectural decision documents indexed in `INDEX.md` (by default under `docs/decisions/`) — with canonical templates, creation/update workflows, and a search CLI. Provides the single source of truth for decision entry format and lifecycle.
 
 ```bash

--- a/skills/deep-research/SKILL.md
+++ b/skills/deep-research/SKILL.md
@@ -16,6 +16,8 @@ metadata:
 
 # Deep Research
 
+> **Problem with this skill?** Run `vstack report` — it files to the owning repo automatically. Do not hand-file.
+
 Use this skill for evidence-backed research reports, architectural investigations, vendor/library comparisons, technology choices, and workflow-owned `findings.md` reports.
 
 ## Harness Routing

--- a/skills/dep-radar/SKILL.md
+++ b/skills/dep-radar/SKILL.md
@@ -16,6 +16,8 @@ metadata:
 
 # dep-radar — pinned-version sweep, safe auto-update, and capability report
 
+> **Problem with this skill?** Run `vstack report` — it files to the owning repo automatically. Do not hand-file.
+
 Repos pin versions deliberately (reproducibility, SHA verification, supply-chain
 safety). The cost of pinning is drift: model lists lag pinned SDKs, pinned
 runtime binaries fall behind upstream contract changes. This skill is the

--- a/skills/dev/SKILL.md
+++ b/skills/dev/SKILL.md
@@ -16,6 +16,8 @@ metadata:
 
 # Dev Workflows
 
+> **Problem with this skill?** Run `vstack report` — it files to the owning repo automatically. Do not hand-file.
+
 Dev-agent workflows for specialist agents receiving delegations from an orchestrator.
 
 ## Workflows

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -13,6 +13,8 @@ metadata:
 
 # GitHub Queries
 
+> **Problem with this skill?** Run `vstack report` — it files to the owning repo automatically. Do not hand-file.
+
 CLI wrapper for GitHub API operations used in PR workflows. Provides structured JSON output, bot account support, and configurable issue ID extraction.
 
 ```bash

--- a/skills/html-artifact/SKILL.md
+++ b/skills/html-artifact/SKILL.md
@@ -14,6 +14,8 @@ metadata:
 
 # HTML Artifact
 
+> **Problem with this skill?** Run `vstack report` — it files to the owning repo automatically. Do not hand-file.
+
 Use when the user wants a human-readable artifact from a conversation, plan, approach, report, review, explainer, prototype, or custom editor instead of a long reply or Markdown file.
 
 Rules:

--- a/skills/iced-rs/SKILL.md
+++ b/skills/iced-rs/SKILL.md
@@ -13,6 +13,8 @@ metadata:
 
 # Iced 0.14
 
+> **Problem with this skill?** Run `vstack report` — it files to the owning repo automatically. Do not hand-file.
+
 Framework skill for building any Iced 0.14 UI.
 
 ## Reading order

--- a/skills/iced-shadcn/SKILL.md
+++ b/skills/iced-shadcn/SKILL.md
@@ -14,6 +14,8 @@ metadata:
 
 # iced-shadcn
 
+> **Problem with this skill?** Run `vstack report` — it files to the owning repo automatically. Do not hand-file.
+
 Component design skill for building shadcn Base UI-inspired components in Iced. Covers architecture decisions, family decomposition, implementation methodology, and parity audits.
 
 ## Resources

--- a/skills/linear/SKILL.md
+++ b/skills/linear/SKILL.md
@@ -13,6 +13,8 @@ metadata:
 
 # Linear CLI
 
+> **Problem with this skill?** Run `vstack report` — it files to the owning repo automatically. Do not hand-file.
+
 CLI wrapper for Linear's GraphQL API with local cache, bulk operations, and structured output.
 
 ```bash

--- a/skills/orch/SKILL.md
+++ b/skills/orch/SKILL.md
@@ -16,6 +16,8 @@ metadata:
 
 # Orchestration
 
+> **Problem with this skill?** Run `vstack report` — it files to the owning repo automatically. Do not hand-file.
+
 ## STOP — Required Setup
 
 Load IN ORDER before anything else. Do not proceed if any fails.

--- a/skills/price-handling/SKILL.md
+++ b/skills/price-handling/SKILL.md
@@ -13,6 +13,8 @@ metadata:
 
 # Price Handling Patterns
 
+> **Problem with this skill?** Run `vstack report` — it files to the owning repo automatically. Do not hand-file.
+
 f64 price handling rules for trading systems -- epsilon comparison, tick-size rounding, feed normalization, and display formatting.
 
 ## Resources

--- a/skills/project-management/SKILL.md
+++ b/skills/project-management/SKILL.md
@@ -16,6 +16,8 @@ metadata:
 
 # Project Management
 
+> **Problem with this skill?** Run `vstack report` — it files to the owning repo automatically. Do not hand-file.
+
 User-facing wrappers and TPM-execution workflows for project-level planning, audit, roadmap, and research-driven decomposition.
 
 ## Commands

--- a/skills/reviewer/SKILL.md
+++ b/skills/reviewer/SKILL.md
@@ -13,6 +13,8 @@ metadata:
 
 # Reviewer
 
+> **Problem with this skill?** Run `vstack report` — it files to the owning repo automatically. Do not hand-file.
+
 Code-review, whole-codebase review, and QA-review workflows plus the structured-finding schema. Load this skill when:
 
 - You are doing a code review (any reviewer specialist: correctness, quality, arch, security, error, test, doc, perf, safety, structure) and need to know how to classify findings or format the verdict.

--- a/skills/second-opinion/SKILL.md
+++ b/skills/second-opinion/SKILL.md
@@ -14,6 +14,8 @@ metadata:
 
 # Second Opinion
 
+> **Problem with this skill?** Run `vstack report` — it files to the owning repo automatically. Do not hand-file.
+
 Cross-model second opinion via external AI CLI. Auto-detects the current harness and calls the opposite:
 
 | Running in | Calls |

--- a/skills/trading-design/SKILL.md
+++ b/skills/trading-design/SKILL.md
@@ -13,6 +13,8 @@ metadata:
 
 # Professional Trading UI Design
 
+> **Problem with this skill?** Run `vstack report` — it files to the owning repo automatically. Do not hand-file.
+
 Stack-agnostic. Does not define specific tokens, colors, or pixel values — those belong in your design system.
 
 ## Skill Guidelines

--- a/skills/worktree/SKILL.md
+++ b/skills/worktree/SKILL.md
@@ -14,6 +14,8 @@ metadata:
 
 # Worktree Management
 
+> **Problem with this skill?** Run `vstack report` — it files to the owning repo automatically. Do not hand-file.
+
 Portable git worktree manager. Worktrees live outside the repo root by default — `<parent-of-checkout>/.worktrees/<checkout-name>/{id}` — so recursive editor/file watchers on the repo never ingest worktree build outputs, and sibling repos cannot collide on a shared parent dir. Projects can override the worktree parent directory with `WORKTREE_BASE_DIR`.
 
 Issue-ID resolution prefers the configured base dir and falls back to the worktree registered for the issue branch, so trees created under an older base-dir convention keep working unmoved (`list`/`remove`/`push`/`restack`/`create --reuse`); there is no auto-migration. Path comparisons are canonical (physical, symlink-resolved on both sides), so a worktree registered under a legacy symlinked spelling and addressed via its physical path — or vice versa — is recognized as the same tree, never as a foreign one.


### PR DESCRIPTION
Closes #863.

`vstack report` resolves ownership deterministically (project lock + installed provenance frontmatter) and files project-local problems in the right repo. Nothing pointed agents at it:

```
grep -rl "vstack report" skills/*/SKILL.md | wc -l   ->  0
grep -l  "bugs:"         skills/*/SKILL.md | wc -l   ->  16
```

All 16 skills carried only a `metadata.bugs:` URL aimed at this tracker regardless of who owns the asset, so agents hand-filed here — and `issue-ownership-guard.yml`, whose own header calls it a backstop for "misfiles that bypassed" the command, ended up triaging close to every issue. The backstop was doing the routing because the gate was never wired in.

## Changes

- **One line per `SKILL.md`**, immediately under the H1. Deliberately one line, not a section.
- **Same line in the `vstack init` scaffold** so new skills inherit it instead of repeating the omission, with the existing scaffold test extended to assert it.
- **A CI contract check** over `git ls-files -- 'skills/*/SKILL.md'`, mirroring the executable-bits step already in this workflow. Prose in 16 files rots; the next hand-added skill would silently omit it otherwise.

`metadata.bugs:` is left alone — still correct provenance for a genuinely vstack-owned asset, and the CLI reads ownership from frontmatter.

## Verification

- The CI contract check passes across all 16 skills locally.
- `cargo test skill_scaffold` passes. That assertion is a literal string match on the template, so it is powered by construction — I did not run a deliberate-regression pass on it.