### PR TITLE
fix(ci): stop the ownership guard mislabelling vstack's own install path (#865)

### DIFF
--- a/.github/workflows/issue-ownership-guard.yml
+++ b/.github/workflows/issue-ownership-guard.yml
@@ -56,7 +56,13 @@ jobs:
           #      - bare path fragments under asset-ish dirs, even without backticks
           : > "$tokens"
           grep -oE '`[^`]+`' "$body" | sed 's/`//g' >> "$tokens" || true
-          grep -oE '(tools|\.config|skills|agents|hooks|pi-extensions)/[A-Za-z0-9._/-]+' "$body" >> "$tokens" || true
+          # The optional `.agents/` prefix is load-bearing, not decoration. Without
+          # it the alternation matches `agents` MID-WORD inside `.agents/skills/`,
+          # emitting a phantom `agents/skills/` token that exists nowhere and so
+          # scores a foreign hit — on the standard install path, i.e. the exact
+          # vocabulary legitimate vstack issues use (#865). Matching the longer
+          # form from index 0 leaves no tail for the phantom to match.
+          grep -oE '(\.agents/)?(tools|\.config|skills|agents|hooks|pi-extensions)/[A-Za-z0-9._/-]+' "$body" >> "$tokens" || true
           sort -u "$tokens" -o "$tokens"
 
           # CLI verbs, flags, and common tool words that appear in legitimate
@@ -79,6 +85,12 @@ jobs:
           while IFS= read -r tok; do
             tok="$(printf '%s' "$tok" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
             if [ -z "$tok" ]; then continue; fi
+
+            # `.agents/` is the INSTALL MIRROR of this repo's own assets, and it is
+            # gitignored — so it is absent from the CI checkout and every reference
+            # to it would otherwise resolve to "missing". Strip the prefix and judge
+            # the asset it names: `.agents/skills/worktree` is `skills/worktree`.
+            tok="${tok#.agents/}"
 
             # vstack's own global state dir (~/.config/vstack) is not foreign.
             # tools/* and .config/* otherwise do not exist here — clearly foreign.


### PR DESCRIPTION
Closes #865.

The guard labelled #859 — a maintainer-filed issue about `.agents` layout and the installer — as a possible project-local asset, which is the opposite of its stated precision-first design.

## Mechanism

The bare-path scan's alternation had no left boundary:

```
grep -oE '(tools|\.config|skills|agents|hooks|pi-extensions)/[A-Za-z0-9._/-]+'
```

`agents` matches **mid-word** inside `.agents/skills/`, emitting a phantom `agents/skills/` token. That path exists nowhere in the repo, so it lands in the missing-under-asset-dir branch and scores a foreign hit — triggered by the standard install path, i.e. the exact vocabulary legitimate vstack issues use.

Compounding it: `.agents/` is **gitignored**, so it is absent from the CI checkout. Every `.agents/...` reference resolved to "missing" rather than to the asset it names, so nothing offset the phantom.

## Fix

1. Match an optional `.agents/` prefix so the longer form wins from index 0 and leaves no tail for the phantom to match.
2. Strip that prefix before classification — `.agents/skills/worktree` is `skills/worktree`.

## Verification

Replayed the workflow's own tokenize+classify logic against real issue bodies, in a **CI-shaped tree** (`git archive`, no install mirror — a replay in a working tree that has `.agents/` measures the wrong thing, and my first pass did exactly that):

| body | before | after |
| --- | --- | --- |
| #859 (legit vstack) | NUDGE (`vstack_hits=0 foreign_hits=1`) | **NO ACTION** (`vstack_hits=1`) |
| #865 (legit vstack) | — | **NO ACTION** (`vstack_hits=2`) |
| genuinely foreign (`tools/validate`, `.config/foo`, `visual-qa`) | NUDGE (`foreign_hits=3`) | **NUDGE**, unchanged |

The foreign arm is the half worth checking: a "fix" that only silences false positives by never firing would pass the first two rows and be useless.