### PR TITLE
feat(cli): support project-owned skills outside .agents (relocate-and-link) (#859)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ Claude Code · Cursor · OpenCode · Codex · Pi
 `vstack add` writes a `vstack.toml` at your project root. Edit it to customize per-agent behavior, then run `vstack refresh` to apply. Generated agent files are overwritten on refresh — `vstack.toml` is the stable home for overrides.
 
 ```toml
+# Where this project's OWN skills live (must be a top-level key, above any table).
+# Refresh links each subdirectory into .agents/skills/<name>.
+project-skills-dir = "project-skills"
+
 # Skills assigned to each agent.
 [agent-skills]
 rust = ["github", "worktree"]
@@ -118,6 +122,13 @@ project-local `.agents` directory. Failures leave the lock and installed files
 unchanged. Project hook removal uses the same strict preflight before changing
 hook files, settings, locks, or generated agents; global removal remains
 independent of project configuration.
+
+Skills vstack did not install belong in `project-skills-dir` (tracked), never as
+real directories inside `.agents`. Refresh links each one into
+`.agents/skills/<name>`, which keeps `.agents` fully untracked — otherwise it
+becomes a hybrid tree, and a rebase materializes the symlink into a real
+directory holding only the tracked files, silently dropping every installed
+skill beneath it.
 
 Key rules:
 

--- a/cli/src/commands/refresh.rs
+++ b/cli/src/commands/refresh.rs
@@ -198,11 +198,28 @@ pub fn refresh_items_in_scope(
         }
     };
 
+    let relocated_project_skills = if global {
+        None
+    } else {
+        match resolve_relocated_project_skills(project_root, project_config) {
+            Ok(relocated) => relocated,
+            Err(err) => {
+                stats.fail("project-skills-dir", None, err);
+                return stats;
+            }
+        }
+    };
+
     if let Some(skills_root) = project_owned_skills_root.as_ref() {
+        // Link first, so the instruction pass below sees the links it manages.
+        if let Some(relocated) = relocated_project_skills.as_ref() {
+            link_relocated_project_skills(skills_root, relocated, &pass, &mut stats);
+        }
         refresh_project_owned_skill_instructions(
             lock,
             project_config,
             skills_root,
+            relocated_project_skills.as_ref(),
             &pass,
             &mut stats,
         );
@@ -492,6 +509,167 @@ struct ProjectOwnedSkillsRoot {
     canonical: PathBuf,
 }
 
+/// The configured out-of-`.agents` home for project-owned skills.
+struct RelocatedProjectSkills {
+    /// Project-root-relative directory exactly as configured, used to build the
+    /// `../../<dir>/<name>` link target.
+    relative: String,
+    canonical: PathBuf,
+}
+
+/// Resolve `project-skills-dir` from `vstack.toml`.
+///
+/// Returns `Ok(None)` when unset, or set but not yet created — an absent
+/// directory is a project that has not adopted the convention, not an error.
+/// Everything else fails closed: the directory must stay inside the project and
+/// must not sit inside `.agents`, which is the tree the convention exists to
+/// keep free of tracked content.
+fn resolve_relocated_project_skills(
+    project_root: &Path,
+    project_config: &crate::project_config::ProjectConfig,
+) -> Result<Option<RelocatedProjectSkills>> {
+    let Some(configured) = project_config.project_skills_dir.as_deref() else {
+        return Ok(None);
+    };
+    let relative = configured.trim().trim_end_matches('/');
+    if relative.is_empty() {
+        return Ok(None);
+    }
+    if Path::new(relative).is_absolute() || relative.split('/').any(|part| part == "..") {
+        anyhow::bail!(
+            "project-skills-dir must be a relative path inside the project, got: {relative}"
+        );
+    }
+
+    let dir = project_root.join(relative);
+    let canonical = match dir.canonicalize() {
+        Ok(path) => path,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => {
+            return Err(anyhow::anyhow!(
+                "failed to resolve project-skills-dir {}: {err}",
+                dir.display()
+            ));
+        }
+    };
+    let project_root_canon = project_root
+        .canonicalize()
+        .map_err(|err| anyhow::anyhow!("failed to resolve project root: {err}"))?;
+    if !canonical.starts_with(&project_root_canon) {
+        anyhow::bail!(
+            "refusing project-skills-dir outside the project root: {}",
+            dir.display()
+        );
+    }
+    if !canonical.is_dir() {
+        anyhow::bail!("project-skills-dir is not a directory: {}", dir.display());
+    }
+    if canonical.starts_with(project_root_canon.join(".agents")) {
+        anyhow::bail!(
+            "project-skills-dir must live outside .agents (that is the point of relocating it): {}",
+            dir.display()
+        );
+    }
+    Ok(Some(RelocatedProjectSkills {
+        relative: relative.to_string(),
+        canonical,
+    }))
+}
+
+/// Link each `<project-skills-dir>/<name>` into `.agents/skills/<name>`.
+///
+/// Only ever replaces an existing SYMLINK. A real directory already sitting at
+/// the destination is somebody's committed skill or a materialized harness dir,
+/// and silently deleting either would be the bug this feature exists to avoid.
+fn link_relocated_project_skills(
+    skills_root: &ProjectOwnedSkillsRoot,
+    relocated: &RelocatedProjectSkills,
+    pass: &impl Fn(&str) -> bool,
+    stats: &mut RefreshStats,
+) {
+    let entries = match std::fs::read_dir(&relocated.canonical) {
+        Ok(entries) => entries,
+        Err(err) => {
+            stats.fail(
+                &relocated.relative,
+                None,
+                format!("failed to enumerate project-skills-dir: {err}"),
+            );
+            return;
+        }
+    };
+
+    let mut dirs: Vec<PathBuf> = Vec::new();
+    for entry in entries {
+        match entry {
+            Ok(entry) => dirs.push(entry.path()),
+            Err(err) => {
+                stats.fail(
+                    &relocated.relative,
+                    None,
+                    format!("failed to enumerate project-skills-dir: {err}"),
+                );
+                return;
+            }
+        }
+    }
+    dirs.sort();
+
+    for source in dirs {
+        let Some(name) = source.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        if !pass(name) || crate::path_safety::validate_item_name(name).is_err() {
+            continue;
+        }
+        if !source.join("SKILL.md").is_file() {
+            continue;
+        }
+
+        let dest = skills_root.path.join(name);
+        let target = format!("../../{}/{}", relocated.relative, name);
+        match std::fs::symlink_metadata(&dest) {
+            Ok(meta) if meta.file_type().is_symlink() => {
+                if std::fs::read_link(&dest).is_ok_and(|current| current == Path::new(&target)) {
+                    continue; // already correct
+                }
+                if let Err(err) = std::fs::remove_file(&dest) {
+                    stats.fail(name, None, format!("failed to replace stale link: {err}"));
+                    continue;
+                }
+            }
+            Ok(_) => {
+                stats.fail(
+                    name,
+                    None,
+                    format!(
+                        "refusing to replace existing non-symlink path with a project-skills link: {}",
+                        dest.display()
+                    ),
+                );
+                continue;
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) => {
+                stats.fail(name, None, format!("failed to inspect {}: {err}", dest.display()));
+                continue;
+            }
+        }
+
+        if let Some(parent) = dest.parent()
+            && let Err(err) = std::fs::create_dir_all(parent)
+        {
+            stats.fail(name, None, format!("failed to create .agents/skills: {err}"));
+            continue;
+        }
+        if let Err(err) = std::os::unix::fs::symlink(&target, &dest) {
+            stats.fail(name, None, format!("failed to link project skill: {err}"));
+            continue;
+        }
+        stats.mark_content_changed(name);
+    }
+}
+
 /// Validate the ownership boundary used by all project refresh writes.
 ///
 /// This must run before lock reconciliation, hook pruning, or installation.
@@ -580,6 +758,7 @@ fn refresh_project_owned_skill_instructions(
     lock: &config::LockFile,
     project_config: &ProjectConfig,
     skills_root: &ProjectOwnedSkillsRoot,
+    relocated: Option<&RelocatedProjectSkills>,
     pass: &impl Fn(&str) -> bool,
     stats: &mut RefreshStats,
 ) {
@@ -631,7 +810,15 @@ fn refresh_project_owned_skill_instructions(
                 continue;
             }
         };
-        if !skill_dir_canon.starts_with(&skills_root.canonical) {
+        // A skill dir normally has to resolve inside `.agents/skills`. The one
+        // exception is a link into the configured `project-skills-dir`, which is
+        // the whole point of the relocate-and-link convention — without this the
+        // convention is not merely unsupported, it hard-fails the refresh.
+        // Still fails closed for anything resolving anywhere else.
+        let inside_skills_root = skill_dir_canon.starts_with(&skills_root.canonical);
+        let inside_relocated = relocated
+            .is_some_and(|reloc| skill_dir_canon.starts_with(&reloc.canonical));
+        if !inside_skills_root && !inside_relocated {
             stats.fail(
                 name,
                 None,

--- a/cli/src/commands/refresh/tests.rs
+++ b/cli/src/commands/refresh/tests.rs
@@ -940,3 +940,170 @@ fn refresh_rejects_agent_name_that_escapes_output_dir() {
 
     let _ = std::fs::remove_dir_all(root);
 }
+
+/// #859: project-owned skills relocated OUT of `.agents` and linked back in.
+///
+/// The convention exists to keep `.agents` free of tracked content: a project
+/// that commits skills inside it makes the directory a hybrid tracked/untracked
+/// tree, and a rebase then materializes the symlink into a real directory
+/// holding only the tracked subset (#856).
+#[test]
+fn refresh_links_relocated_project_skills_into_agents() {
+    let root = tmpdir("relocated-project-skills-link");
+    let project = root.join("project");
+    let source_dir = project.join("project-skills/benchmark");
+    std::fs::create_dir_all(&source_dir).unwrap();
+    std::fs::create_dir_all(project.join(".agents/skills")).unwrap();
+    let source_md = source_dir.join("SKILL.md");
+    std::fs::write(
+        &source_md,
+        "---\nname: benchmark\ndescription: Local benchmark\n---\n\n# Benchmark\n\nBody.\n",
+    )
+    .unwrap();
+
+    let lock = LockFile::default();
+    let sources = Vec::new();
+    let mut project_config = ProjectConfig {
+        project_skills_dir: Some("project-skills".into()),
+        ..ProjectConfig::default()
+    };
+    project_config
+        .skill_instructions
+        .insert("benchmark".into(), "Project rule.".into());
+
+    let link = project.join(".agents/skills/benchmark");
+    let stats = refresh_items_in_scope(false, &lock, &sources, &mut project_config, &project, None);
+    assert!(
+        stats.failures.is_empty(),
+        "relocate-and-link refresh failed: {:?}",
+        stats.failures
+    );
+    assert_eq!(
+        std::fs::read_link(&link).unwrap(),
+        std::path::Path::new("../../project-skills/benchmark"),
+        "refresh must link .agents/skills/<name> at the relocated source"
+    );
+    // Instructions belong in the TRACKED source file, not in a copy under .agents.
+    assert!(
+        std::fs::read_to_string(&source_md)
+            .unwrap()
+            .contains("## Project Instructions\n\nProject rule.")
+    );
+    assert!(stats.project_owned_skills.contains("benchmark"));
+
+    // Idempotent: an already-correct link is left exactly as it is.
+    let again = refresh_items_in_scope(false, &lock, &sources, &mut project_config, &project, None);
+    assert!(again.failures.is_empty());
+    assert_eq!(
+        std::fs::read_link(&link).unwrap(),
+        std::path::Path::new("../../project-skills/benchmark")
+    );
+
+    let _ = std::fs::remove_dir_all(root);
+}
+
+/// A real directory at the destination is somebody's committed skill or a
+/// materialized harness dir. Deleting either to make room for a link would be
+/// the very bug this feature exists to prevent.
+#[test]
+fn refresh_refuses_to_replace_a_real_directory_with_a_project_skills_link() {
+    let root = tmpdir("relocated-project-skills-clobber");
+    let project = root.join("project");
+    std::fs::create_dir_all(project.join("project-skills/benchmark")).unwrap();
+    std::fs::write(
+        project.join("project-skills/benchmark/SKILL.md"),
+        "---\nname: benchmark\ndescription: relocated\n---\n\n# Benchmark\n",
+    )
+    .unwrap();
+    let squatter = project.join(".agents/skills/benchmark");
+    std::fs::create_dir_all(&squatter).unwrap();
+    let squatter_md = squatter.join("SKILL.md");
+    let squatter_body = "---\nname: benchmark\ndescription: committed in place\n---\n\n# Committed\n";
+    std::fs::write(&squatter_md, squatter_body).unwrap();
+
+    let lock = LockFile::default();
+    let sources = Vec::new();
+    let mut project_config = ProjectConfig {
+        project_skills_dir: Some("project-skills".into()),
+        ..ProjectConfig::default()
+    };
+
+    let stats = refresh_items_in_scope(false, &lock, &sources, &mut project_config, &project, None);
+    assert!(
+        stats
+            .failures
+            .iter()
+            .any(|f| f.error.contains("refusing to replace existing non-symlink path")),
+        "expected a refusal, got: {:?}",
+        stats.failures
+    );
+    assert!(!squatter.is_symlink(), "the real directory must survive");
+    assert_eq!(std::fs::read_to_string(&squatter_md).unwrap(), squatter_body);
+
+    let _ = std::fs::remove_dir_all(root);
+}
+
+/// The relaxation is scoped to the CONFIGURED directory. Without the opt-in a
+/// link pointing out of `.agents/skills` is still refused, which is the guard
+/// that keeps an arbitrary escape from being followed.
+#[test]
+fn refresh_still_refuses_an_unconfigured_link_out_of_the_skills_root() {
+    let root = tmpdir("relocated-project-skills-unconfigured");
+    let project = root.join("project");
+    std::fs::create_dir_all(project.join("elsewhere/benchmark")).unwrap();
+    std::fs::create_dir_all(project.join(".agents/skills")).unwrap();
+    std::fs::write(
+        project.join("elsewhere/benchmark/SKILL.md"),
+        "---\nname: benchmark\ndescription: unconfigured\n---\n\n# Benchmark\n",
+    )
+    .unwrap();
+    std::os::unix::fs::symlink(
+        "../../elsewhere/benchmark",
+        project.join(".agents/skills/benchmark"),
+    )
+    .unwrap();
+
+    let lock = LockFile::default();
+    let sources = Vec::new();
+    let mut project_config = ProjectConfig::default(); // no project-skills-dir
+
+    let stats = refresh_items_in_scope(false, &lock, &sources, &mut project_config, &project, None);
+    assert!(
+        stats
+            .failures
+            .iter()
+            .any(|f| f.error.contains("outside skills root")),
+        "expected the escape guard to still fire, got: {:?}",
+        stats.failures
+    );
+
+    let _ = std::fs::remove_dir_all(root);
+}
+
+/// `project-skills-dir` must stay inside the project and outside `.agents`.
+#[test]
+fn refresh_rejects_project_skills_dir_inside_agents() {
+    let root = tmpdir("relocated-project-skills-inside-agents");
+    let project = root.join("project");
+    std::fs::create_dir_all(project.join(".agents/mine/benchmark")).unwrap();
+    std::fs::create_dir_all(project.join(".agents/skills")).unwrap();
+
+    let lock = LockFile::default();
+    let sources = Vec::new();
+    let mut project_config = ProjectConfig {
+        project_skills_dir: Some(".agents/mine".into()),
+        ..ProjectConfig::default()
+    };
+
+    let stats = refresh_items_in_scope(false, &lock, &sources, &mut project_config, &project, None);
+    assert!(
+        stats
+            .failures
+            .iter()
+            .any(|f| f.error.contains("must live outside .agents")),
+        "expected rejection, got: {:?}",
+        stats.failures
+    );
+
+    let _ = std::fs::remove_dir_all(root);
+}

--- a/cli/src/project_config.rs
+++ b/cli/src/project_config.rs
@@ -68,6 +68,18 @@ pub struct ProjectConfig {
     pub agent_instructions: HashMap<String, String>,
     #[serde(rename = "skill-instructions")]
     pub skill_instructions: HashMap<String, String>,
+    /// Directory holding project-owned skills that live OUTSIDE `.agents`,
+    /// relative to the project root (e.g. `project-skills`). Refresh links each
+    /// `<dir>/<name>` into `.agents/skills/<name>`.
+    ///
+    /// The point is to keep `.agents` free of tracked content. A project that
+    /// commits its own skills *inside* `.agents` makes that directory a hybrid
+    /// tracked/untracked tree, and a rebase then materializes the symlink into
+    /// a real directory holding only the tracked subset — silently dropping
+    /// every vstack-installed skill under it (#856). Relocating the tracked
+    /// half removes the cause rather than detecting the damage.
+    #[serde(rename = "project-skills-dir", default)]
+    pub project_skills_dir: Option<String>,
     #[serde(rename = "custom-hooks", default)]
     pub custom_hooks: Vec<CustomHook>,
 }


### PR DESCRIPTION
Closes #859.

A project that commits its own skills **inside** `.agents` makes that directory a hybrid tracked/untracked tree — the root cause behind the #856 incident class. A rebase materializes the symlink into a real directory holding only the tracked subset, silently dropping every vstack-installed skill beneath it. #856 and #857 detect and narrow the damage; this removes the cause.

## The convention was actively refused, not just unsupported

Worth stating because it changes how the issue reads. Before this change, a hand-made `.agents/skills/<name>` → `../../project-skills/<name>` link produced:

```
! foo — refusing project-owned skill directory outside skills root: .../.agents/skills/foo
Error: failed to refresh 1 item/harness install(s)
```

Verified against the shipped binary. So adopting the convention manually broke `vstack refresh` outright.

## Change

New top-level `project-skills-dir` key in `vstack.toml`. Refresh links each `<dir>/<name>` containing a `SKILL.md` into `.agents/skills/<name>`, leaving `.agents` fully untracked. `[skill-instructions]` keep working and land in the **tracked source file**, not a copy under `.agents`.

Fails closed everywhere it matters:

- the relaxation is scoped to the **configured** directory — an unconfigured link out of the skills root is still refused, so the escape guard is intact;
- `project-skills-dir` must be relative, inside the project root, and **outside `.agents`** (that being the point);
- a **real directory** at the destination is never replaced — it is somebody's committed skill or an already-materialized harness dir, and deleting either is precisely the bug this exists to prevent. Only a stale symlink is replaced.

## Verification

Four unit tests: link creation + idempotence + instructions reaching the tracked source; refusal to clobber a real directory (asserting the file survives byte-for-byte); the unconfigured-escape guard still firing; and rejection of a `project-skills-dir` inside `.agents`.

Also exercised end-to-end against the built binary on a scratch project — link absent → created; link present → left alone; real dir squatting → refused with the directory preserved; no opt-in → still refused.

`cargo test` 458 passed / 0 failed. Clippy introduces no new warnings (the two that exist are pre-existing on main in `config.rs` and `refresh.rs:136`, both untouched here).

## README

Two sentences in the existing project-owned paragraph plus one commented key in the sample config — kept deliberately short per the issue. The key is placed **above** the tables in the example, since a bare TOML key after a table header would parse as part of that table.