### PR TITLE
fix(pi-claude-bridge): cache the connector inventory across processes (#870)

### DIFF
--- a/pi-extensions/pi-claude-bridge/bundle/index.js
+++ b/pi-extensions/pi-claude-bridge/bundle/index.js
@@ -42557,18 +42557,70 @@ function errorText(error51) {
   return error51 instanceof Error ? error51.message : String(error51);
 }
 
+// src/connector-cache.ts
+import { createHash } from "node:crypto";
+import { mkdirSync as mkdirSync2, readFileSync as readFileSync6, writeFileSync } from "node:fs";
+import { dirname as dirname4, join as join6 } from "node:path";
+var CACHE_VERSION = 1;
+var MAX_AGE_MS = 7 * 24 * 60 * 60 * 1e3;
+function connectorCacheScopeKey(env = process.env) {
+  return env.CLAUDE_CONFIG_DIR?.trim() || "<default>";
+}
+function connectorCachePath(scopeKey = connectorCacheScopeKey()) {
+  const digest = createHash("sha256").update(scopeKey).digest("hex").slice(0, 16);
+  return join6(piUserDir(), "connector-cache", `${digest}.json`);
+}
+function readCachedConnectors(scopeKey = connectorCacheScopeKey(), now = Date.now()) {
+  let raw;
+  try {
+    raw = readFileSync6(connectorCachePath(scopeKey), "utf8");
+  } catch {
+    return void 0;
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return void 0;
+  }
+  if (parsed?.version !== CACHE_VERSION) return void 0;
+  if (parsed?.scope !== scopeKey) return void 0;
+  const savedAt = typeof parsed?.savedAt === "number" ? parsed.savedAt : 0;
+  if (!savedAt || now - savedAt > MAX_AGE_MS || savedAt > now) return void 0;
+  if (!Array.isArray(parsed?.connectors)) return void 0;
+  const connectors = parsed.connectors.filter(
+    (entry) => entry && typeof entry.name === "string" && entry.name.trim()
+  );
+  return connectors.length > 0 ? connectors : void 0;
+}
+function writeCachedConnectors(connectors, scopeKey = connectorCacheScopeKey(), now = Date.now()) {
+  if (!Array.isArray(connectors) || connectors.length === 0) return false;
+  const path = connectorCachePath(scopeKey);
+  try {
+    mkdirSync2(dirname4(path), { recursive: true, mode: 448 });
+    writeFileSync(
+      path,
+      JSON.stringify({ version: CACHE_VERSION, scope: scopeKey, savedAt: now, connectors }),
+      { mode: 384 }
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 // src/debug.ts
-import { appendFileSync as appendFileSync2, chmodSync, mkdirSync as mkdirSync2 } from "fs";
-import { dirname as dirname4, join as join6 } from "path";
+import { appendFileSync as appendFileSync2, chmodSync, mkdirSync as mkdirSync3 } from "fs";
+import { dirname as dirname5, join as join7 } from "path";
 var DEBUG = process.env.CLAUDE_BRIDGE_DEBUG === "1";
-var DEBUG_LOG_PATH = process.env.CLAUDE_BRIDGE_DEBUG_PATH || join6(piUserDir(), "claude-bridge.log");
+var DEBUG_LOG_PATH = process.env.CLAUDE_BRIDGE_DEBUG_PATH || join7(piUserDir(), "claude-bridge.log");
 function diagLogPath() {
-  return process.env.CLAUDE_BRIDGE_DIAG_PATH || join6(piUserDir(), "claude-bridge-diag.log");
+  return process.env.CLAUDE_BRIDGE_DIAG_PATH || join7(piUserDir(), "claude-bridge-diag.log");
 }
 if (DEBUG) {
   try {
-    mkdirSync2(dirname4(DEBUG_LOG_PATH), { recursive: true });
-    mkdirSync2(dirname4(diagLogPath()), { recursive: true, mode: 448 });
+    mkdirSync3(dirname5(DEBUG_LOG_PATH), { recursive: true });
+    mkdirSync3(dirname5(diagLogPath()), { recursive: true, mode: 448 });
   } catch {
   }
 }
@@ -42593,12 +42645,12 @@ function makeCliDebugOptions(tag) {
   if (!DEBUG) return {};
   const seq = nextCliDebugSeq++;
   const ts2 = (/* @__PURE__ */ new Date()).toISOString().replace(/[:.]/g, "-");
-  const logDir = join6(dirname4(DEBUG_LOG_PATH), "cc-cli-logs");
+  const logDir = join7(dirname5(DEBUG_LOG_PATH), "cc-cli-logs");
   try {
-    mkdirSync2(logDir, { recursive: true });
+    mkdirSync3(logDir, { recursive: true });
   } catch {
   }
-  const debugFile = join6(logDir, `${ts2}-${tag}-${seq}.log`);
+  const debugFile = join7(logDir, `${ts2}-${tag}-${seq}.log`);
   debug(`cli-debug: ${tag} #${seq} \u2192 ${debugFile}`);
   return {
     debug: true,
@@ -42616,7 +42668,7 @@ function diagDump(label, data) {
     const entry = { ts: ts2, moduleInstanceId, label, ...data };
     const path = diagLogPath();
     try {
-      mkdirSync2(dirname4(path), { recursive: true, mode: 448 });
+      mkdirSync3(dirname5(path), { recursive: true, mode: 448 });
     } catch {
     }
     appendFileSync2(path, JSON.stringify(entry) + "\n", { mode: 384 });
@@ -42632,12 +42684,12 @@ function diagDump(label, data) {
 
 // src/claude-executable.ts
 import { spawn as spawnProcess } from "child_process";
-import { accessSync, constants as fsConstants, readFileSync as readFileSync6, realpathSync as realpathSync2, statSync as statSync2 } from "fs";
-import { delimiter, join as join7 } from "path";
+import { accessSync, constants as fsConstants, readFileSync as readFileSync7, realpathSync as realpathSync2, statSync as statSync2 } from "fs";
+import { delimiter, join as join8 } from "path";
 function executableFromPath(name) {
   const paths = (process.env.PATH ?? "").split(delimiter).filter(Boolean);
   for (const dir of paths) {
-    const candidate = join7(dir, name);
+    const candidate = join8(dir, name);
     try {
       accessSync(candidate, fsConstants.X_OK);
       return candidate;
@@ -42753,7 +42805,7 @@ function preflightClaudeExecutable(path, cwd) {
   }
   let fileType;
   try {
-    fileType = classifyClaudeExecutableBytes(readFileSync6(realPath).subarray(0, 16));
+    fileType = classifyClaudeExecutableBytes(readFileSync7(realPath).subarray(0, 16));
   } catch (err) {
     throw makeClaudePreflightError("Claude Code executable preflight failed: cannot read executable header before spawning Claude Code.", {
       code: codeValue(err, "EACCES"),
@@ -43270,17 +43322,17 @@ function connectorDeclarationsDisabled(env = process.env) {
 
 // node_modules/cc-session-io/dist/chunk-D6EZBJOC.js
 import { randomUUID } from "crypto";
-import { mkdirSync as mkdirSync3, writeFileSync, appendFileSync as appendFileSync3, existsSync as existsSync6, rmSync as rmSync2 } from "fs";
-import { dirname as dirname5 } from "path";
-import { readFileSync as readFileSync7 } from "fs";
+import { mkdirSync as mkdirSync4, writeFileSync as writeFileSync2, appendFileSync as appendFileSync3, existsSync as existsSync6, rmSync as rmSync2 } from "fs";
+import { dirname as dirname6 } from "path";
+import { readFileSync as readFileSync8 } from "fs";
 import { realpathSync as realpathSync3 } from "fs";
 import { homedir as homedir3 } from "os";
-import { join as join8 } from "path";
+import { join as join9 } from "path";
 function parseJsonl(content) {
   return content.split("\n").filter((line) => line.trim()).map(parseRecord);
 }
 function parseJsonlFile(path) {
-  return parseJsonl(readFileSync7(path, "utf-8"));
+  return parseJsonl(readFileSync8(path, "utf-8"));
 }
 function parseRecord(line) {
   const raw = JSON.parse(line);
@@ -43293,7 +43345,7 @@ function serializeRecord(record2) {
 }
 var MAX_SANITIZED_LENGTH = 200;
 function getClaudeDir(claudeDir) {
-  return claudeDir ?? process.env.CLAUDE_CONFIG_DIR ?? join8(homedir3(), ".claude");
+  return claudeDir ?? process.env.CLAUDE_CONFIG_DIR ?? join9(homedir3(), ".claude");
 }
 function normalizeProjectPath(projectPath) {
   try {
@@ -43311,10 +43363,10 @@ function projectPathToHash(projectPath) {
   return `${sanitized.slice(0, MAX_SANITIZED_LENGTH)}-${Math.abs(h).toString(36)}`;
 }
 function getProjectDir(projectPath, claudeDir) {
-  return join8(getClaudeDir(claudeDir), "projects", projectPathToHash(normalizeProjectPath(projectPath)));
+  return join9(getClaudeDir(claudeDir), "projects", projectPathToHash(normalizeProjectPath(projectPath)));
 }
 function getSessionPath(sessionId, projectPath, claudeDir) {
-  return join8(getProjectDir(projectPath, claudeDir), `${sessionId}.jsonl`);
+  return join9(getProjectDir(projectPath, claudeDir), `${sessionId}.jsonl`);
 }
 function repairToolPairing(messages) {
   const result = [];
@@ -43649,15 +43701,15 @@ var Session = class {
   /** Write pending records to disk. Creates the file/directory if needed. */
   save() {
     if (this._pendingRecords.length === 0) return;
-    const dir = dirname5(this.jsonlPath);
+    const dir = dirname6(this.jsonlPath);
     if (!existsSync6(dir)) {
-      mkdirSync3(dir, { recursive: true });
+      mkdirSync4(dir, { recursive: true });
     }
     const data = this._pendingRecords.map((r) => serializeRecord(r) + "\n").join("");
     if (this._fileExists) {
       appendFileSync3(this.jsonlPath, data, "utf-8");
     } else {
-      writeFileSync(this.jsonlPath, data, "utf-8");
+      writeFileSync2(this.jsonlPath, data, "utf-8");
       this._fileExists = true;
     }
     this._records.push(...this._pendingRecords);
@@ -43712,7 +43764,7 @@ function readSession(jsonlPath, projectPath) {
 }
 
 // src/session-persistence.ts
-import { createHash } from "crypto";
+import { createHash as createHash2 } from "crypto";
 import { realpathSync as realpathSync4, statSync as statSync4 } from "fs";
 import { resolve as pathResolve } from "path";
 
@@ -43803,7 +43855,7 @@ function fingerprintMessages(messages) {
     }
     return message;
   });
-  return createHash("sha256").update(JSON.stringify(normalized)).digest("hex");
+  return createHash2("sha256").update(JSON.stringify(normalized)).digest("hex");
 }
 function readBuiltSessionContext(sessionManager) {
   const built = typeof sessionManager?.buildSessionContext === "function" ? sessionManager.buildSessionContext() : void 0;
@@ -45262,6 +45314,9 @@ function primeConnectorServers() {
         Object.keys(servers).join(", ") || "none"
       );
       connectorServerCache.set(key, servers);
+      if (writeCachedConnectors(inventory.connectors, key)) {
+        debug(`connectors: cached ${inventory.connectors.length} entries`);
+      }
     } catch (error51) {
       debug("connectors: declaration lookup threw; declaring none", error51);
       connectorServerCache.set(key, {});
@@ -45275,7 +45330,12 @@ function connectorServersSnapshot() {
   const ready = connectorServerCache.get(key);
   if (ready) return ready;
   primeConnectorServers();
-  return {};
+  const cached2 = readCachedConnectors(key);
+  if (!cached2) return {};
+  const servers = connectorMcpServers({ ok: true, complete: true, connectors: cached2 });
+  if (Object.keys(servers).length === 0) return {};
+  debug(`connectors: turn-1 declarations from cache \u2014 ${Object.keys(servers).join(", ")}`);
+  return servers;
 }
 async function reportConnectorInventory(ctx2) {
   const credentials = resolveClaudeOAuth(readCredentialFile);
@@ -45393,6 +45453,8 @@ export {
   __testSetBridgeIntegrityState,
   buildStreamIdleTimeoutErrorMessage,
   classifyClaudeExecutableBytes,
+  connectorCachePath,
+  connectorCacheScopeKey,
   connectorDeclarationsDisabled,
   connectorMcpServers,
   connectorProxyUrl,
@@ -45419,6 +45481,7 @@ export {
   primeConnectorServers,
   processAssistantMessage,
   processStreamEvent,
+  readCachedConnectors,
   reportToolResultMismatch,
   resolveClaudeExecutable,
   resolveClaudeOAuth,
@@ -45429,7 +45492,8 @@ export {
   streamIdleTimeoutMsFromEnv,
   toolIsolationForQuery,
   uniqueNonEmptyLines,
-  wrapClaudeSpawnErrorForSdk
+  wrapClaudeSpawnErrorForSdk,
+  writeCachedConnectors
 };
 /*! Bundled license information:
 

--- a/pi-extensions/pi-claude-bridge/src/connector-cache.ts
+++ b/pi-extensions/pi-claude-bridge/src/connector-cache.ts
@@ -1,0 +1,105 @@
+// Cross-PROCESS cache of the connector inventory (vstack#870).
+//
+// #868 primes the inventory at provider registration, but the fetch takes ~1.5s
+// while the first query is built at ~0.5-0.8s, so turn 1 of a cold sidecar goes
+// out with no declarations and gets exactly the #832 bug it was meant to fix.
+//
+// An in-process cache cannot help the consumer that needs it most. drovr builds
+// a sidecar lazily on the first bridge round and, since their sidecars are
+// per-SESSION, that is a fresh process for every new chat — so their exposure is
+// once per chat, indefinitely, and every one of those is a cold process. The
+// cache therefore has to survive process boundaries.
+//
+// Keyed by credential scope, because that is what selects the account: the org
+// UUID in the inventory request is ignored and only the credential decides whose
+// connectors come back. Two accounts on one host must not share a cache entry.
+//
+// Everything here is best-effort. A missing, unreadable, corrupt, stale, or
+// wrong-version cache returns undefined and the caller falls back to today's
+// behaviour — the same fail-open contract as the inventory call itself.
+import { createHash } from "node:crypto";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { piUserDir } from "./config.js";
+import type { ConnectorEntry } from "./connector-inventory.js";
+
+const CACHE_VERSION = 1;
+/** Long enough to be useful across a machine's lifetime, short enough that a
+ *  removed connector stops being declared without needing a manual purge. A
+ *  stale entry is not dangerous — a connector that no longer resolves simply
+ *  fails to connect, which is the fail-open path — so this is hygiene, not a
+ *  correctness boundary. */
+const MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+export function connectorCacheScopeKey(env: NodeJS.ProcessEnv = process.env): string {
+	return env.CLAUDE_CONFIG_DIR?.trim() || "<default>";
+}
+
+/**
+ * Our own state directory, not the Claude config dir. The credential directory
+ * belongs to the CLI; the scope is encoded in the filename instead so we never
+ * write into someone else's tree. Hashed rather than escaped because a config
+ * dir is an arbitrary absolute path.
+ */
+export function connectorCachePath(scopeKey: string = connectorCacheScopeKey()): string {
+	const digest = createHash("sha256").update(scopeKey).digest("hex").slice(0, 16);
+	return join(piUserDir(), "connector-cache", `${digest}.json`);
+}
+
+/**
+ * Synchronous by design. The query path has no await boundary to hang a read on
+ * — `streamClaudeAgentSdk` returns its stream and claims the SDK query handle in
+ * the same tick — which is the whole reason the in-memory prime loses the race.
+ * A single small `readFileSync` is what makes turn 1 reachable at all.
+ */
+export function readCachedConnectors(
+	scopeKey: string = connectorCacheScopeKey(),
+	now: number = Date.now(),
+): ConnectorEntry[] | undefined {
+	let raw: string;
+	try {
+		raw = readFileSync(connectorCachePath(scopeKey), "utf8");
+	} catch {
+		return undefined;
+	}
+	let parsed: any;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		return undefined;
+	}
+	if (parsed?.version !== CACHE_VERSION) return undefined;
+	// Scope is stored as well as hashed into the path: a hash collision or a
+	// hand-copied file would otherwise hand one account another's connectors,
+	// which is the exact failure the token-scoping note in connector-inventory.ts
+	// warns about.
+	if (parsed?.scope !== scopeKey) return undefined;
+	const savedAt = typeof parsed?.savedAt === "number" ? parsed.savedAt : 0;
+	if (!savedAt || now - savedAt > MAX_AGE_MS || savedAt > now) return undefined;
+	if (!Array.isArray(parsed?.connectors)) return undefined;
+	const connectors = parsed.connectors.filter(
+		(entry: any) => entry && typeof entry.name === "string" && entry.name.trim(),
+	);
+	return connectors.length > 0 ? (connectors as ConnectorEntry[]) : undefined;
+}
+
+/** Best-effort write; a failure here must never affect the turn. */
+export function writeCachedConnectors(
+	connectors: ConnectorEntry[],
+	scopeKey: string = connectorCacheScopeKey(),
+	now: number = Date.now(),
+): boolean {
+	if (!Array.isArray(connectors) || connectors.length === 0) return false;
+	const path = connectorCachePath(scopeKey);
+	try {
+		mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+		writeFileSync(
+			path,
+			JSON.stringify({ version: CACHE_VERSION, scope: scopeKey, savedAt: now, connectors }),
+			{ mode: 0o600 },
+		);
+		return true;
+	} catch {
+		return false;
+	}
+}

--- a/pi-extensions/pi-claude-bridge/src/index.ts
+++ b/pi-extensions/pi-claude-bridge/src/index.ts
@@ -36,10 +36,12 @@ export {
 	type ConnectorEntry,
 	type ConnectorInventory,
 } from "./connector-inventory.js";
+export { connectorCachePath, connectorCacheScopeKey, readCachedConnectors, writeCachedConnectors } from "./connector-cache.js";
 import { debug, diagDump, makeCliDebugOptions, moduleInstanceId } from "./debug.js";
 import { preflightClaudeExecutable, resolveClaudeExecutable, spawnClaudeCodeWithDiagnostics } from "./claude-executable.js";
 import { argKeys, extensionApi, piUI, reportToolResultMismatch, safeNotify, safeToolCallSummary, setExtensionApi, setPiUI, setSharedSession, sharedSession } from "./bridge-state.js";
 import { connectorMcpServers, connectorQueryOptions, connectorWriteModeFor, connectorsEnabledFor } from "./connectors.js";
+import { readCachedConnectors, writeCachedConnectors } from "./connector-cache.js";
 import { restoreSharedSessionFromPi, schedulePersistSharedSession, syncSharedSession } from "./session-persistence.js";
 import { STREAM_IDLE_BACKOFF_HINT_MS, activeStreamIdleWatchdogs, buildStreamIdleTimeoutErrorMessage, createStreamIdleWatchdog, formatDurationShort, streamIdleTimeoutMsFromEnv } from "./stream-idle-watchdog.js";
 import { RATE_LIMIT_AUTO_RESUME_EVENT, RATE_LIMIT_TOKEN, formatAllowedRateLimitWarning, formatResetTimestamp, isExtraUsageRequiredMessage, uniqueNonEmptyLines } from "./rate-limit.js";
@@ -1171,6 +1173,12 @@ export function primeConnectorServers(): void {
 			debug(`connectors: declaring ${Object.keys(servers).length} of ${inventory.connectors.length} installed`,
 				Object.keys(servers).join(", ") || "none");
 			connectorServerCache.set(key, servers);
+			// Persist so the NEXT cold process has this synchronously. Priming always
+			// loses the race against turn 1 in its own process; a cache written by an
+			// earlier run is the only thing turn 1 can read in time (vstack#870).
+			if (writeCachedConnectors(inventory.connectors, key)) {
+				debug(`connectors: cached ${inventory.connectors.length} entries`);
+			}
 		} catch (error) {
 			debug("connectors: declaration lookup threw; declaring none", error);
 			connectorServerCache.set(key, {});
@@ -1185,8 +1193,18 @@ function connectorServersSnapshot(): Record<string, unknown> {
 	const key = connectorScopeKey();
 	const ready = connectorServerCache.get(key);
 	if (ready) return ready;
+	// Always start (or continue) the live fetch — the cache is a head start, not
+	// a replacement, and the refresh keeps the next process current.
 	primeConnectorServers();
-	return {};
+	// Fall back to the previous run's inventory, read synchronously. This is the
+	// only thing that can populate turn 1 of a cold process, because priming
+	// cannot finish before the first query is built (vstack#870).
+	const cached = readCachedConnectors(key);
+	if (!cached) return {};
+	const servers = connectorMcpServers({ ok: true, complete: true, connectors: cached });
+	if (Object.keys(servers).length === 0) return {};
+	debug(`connectors: turn-1 declarations from cache — ${Object.keys(servers).join(", ")}`);
+	return servers;
 }
 
 // Deterministic connector enumeration for the host app (vstack#838). Reports the

--- a/pi-extensions/pi-claude-bridge/tests/unit-connector-cache.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-connector-cache.mjs
@@ -1,0 +1,110 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import {
+	connectorCachePath, connectorCacheScopeKey, readCachedConnectors, writeCachedConnectors,
+	connectorMcpServers,
+} from "../bundle/index.js";
+
+// piUserDir() reads PI_CODING_AGENT_DIR, so each test gets its own state dir.
+function withStateDir(fn) {
+	const dir = mkdtempSync(join(tmpdir(), "conn-cache-"));
+	const prev = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = dir;
+	try { return fn(dir); } finally {
+		if (prev === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = prev;
+		rmSync(dir, { recursive: true, force: true });
+	}
+}
+
+const SLACK = { name: "Slack", installedServerId: "id-slack", installState: "connected" };
+
+test("round-trips across processes: what one run writes, a cold run reads", () => {
+	withStateDir(() => {
+		assert.equal(writeCachedConnectors([SLACK], "/scope/a"), true);
+		const read = readCachedConnectors("/scope/a");
+		assert.deepEqual(read, [SLACK]);
+		// And it must survive the same derivation the live path uses.
+		assert.deepEqual(
+			Object.keys(connectorMcpServers({ ok: true, complete: true, connectors: read })),
+			["claude.ai Slack"],
+		);
+	});
+});
+
+test("scopes are isolated — one account never reads another's connectors", () => {
+	// The org UUID is ignored by the inventory API; only the credential selects
+	// the account. A shared cache entry would hand over the wrong account's list.
+	withStateDir(() => {
+		writeCachedConnectors([SLACK], "/scope/a");
+		assert.equal(readCachedConnectors("/scope/b"), undefined);
+		assert.notEqual(connectorCachePath("/scope/a"), connectorCachePath("/scope/b"));
+	});
+});
+
+test("a file whose recorded scope disagrees with the requested one is rejected", () => {
+	// Guards a hash collision or a hand-copied cache file.
+	withStateDir(() => {
+		const path = connectorCachePath("/scope/a");
+		mkdirSync(dirname(path), { recursive: true });
+		writeFileSync(path, JSON.stringify({ version: 1, scope: "/scope/OTHER", savedAt: Date.now(), connectors: [SLACK] }));
+		assert.equal(readCachedConnectors("/scope/a"), undefined);
+	});
+});
+
+test("stale, future-dated, wrong-version, corrupt and missing all fail open", () => {
+	withStateDir(() => {
+		const path = connectorCachePath("/scope/a");
+		mkdirSync(dirname(path), { recursive: true });
+		const base = { version: 1, scope: "/scope/a", connectors: [SLACK] };
+
+		writeFileSync(path, JSON.stringify({ ...base, savedAt: Date.now() - 8 * 24 * 3600 * 1000 }));
+		assert.equal(readCachedConnectors("/scope/a"), undefined, "8 days old must expire");
+
+		writeFileSync(path, JSON.stringify({ ...base, savedAt: Date.now() + 60_000 }));
+		assert.equal(readCachedConnectors("/scope/a"), undefined, "future savedAt is not trusted");
+
+		writeFileSync(path, JSON.stringify({ ...base, version: 999, savedAt: Date.now() }));
+		assert.equal(readCachedConnectors("/scope/a"), undefined, "version mismatch must invalidate");
+
+		writeFileSync(path, "{not json");
+		assert.equal(readCachedConnectors("/scope/a"), undefined, "corrupt must not throw");
+
+		rmSync(path);
+		assert.equal(readCachedConnectors("/scope/a"), undefined, "missing must not throw");
+	});
+});
+
+test("within the freshness window it is used", () => {
+	withStateDir(() => {
+		const path = connectorCachePath("/scope/a");
+		mkdirSync(dirname(path), { recursive: true });
+		writeFileSync(path, JSON.stringify({ version: 1, scope: "/scope/a", savedAt: Date.now() - 6 * 24 * 3600 * 1000, connectors: [SLACK] }));
+		assert.deepEqual(readCachedConnectors("/scope/a"), [SLACK]);
+	});
+});
+
+test("empty and malformed entry lists are not written or returned", () => {
+	withStateDir(() => {
+		assert.equal(writeCachedConnectors([], "/scope/a"), false);
+		assert.equal(readCachedConnectors("/scope/a"), undefined);
+		writeCachedConnectors([{ nope: true }, SLACK], "/scope/b");
+		assert.deepEqual(readCachedConnectors("/scope/b"), [SLACK], "unnamed entries are dropped");
+	});
+});
+
+test("scope key follows CLAUDE_CONFIG_DIR", () => {
+	const prev = process.env.CLAUDE_CONFIG_DIR;
+	try {
+		process.env.CLAUDE_CONFIG_DIR = "/tmp/acct-one";
+		assert.equal(connectorCacheScopeKey(), "/tmp/acct-one");
+		delete process.env.CLAUDE_CONFIG_DIR;
+		assert.equal(connectorCacheScopeKey(), "<default>");
+	} finally {
+		if (prev === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+		else process.env.CLAUDE_CONFIG_DIR = prev;
+	}
+});


### PR DESCRIPTION
Closes #870. Follow-up to #868, which fixed #832 from turn 2 onward but missed turn 1.

## The gap

Priming starts at provider registration, but `listAccountConnectors()` takes **~1.5s** while the first query is built at **~0.5–0.8s**. `connectorServersSnapshot()` returns `{}` and turn 1 goes out undeclared — the original #832 failure.

**drovr is exposed on every new chat.** They don't warm up: `SidecarHost.warm()` is a handshake, not a model turn, and its only caller uses a throwaway sidecar. Chat sidecars are built lazily on the first bridge round, and since their #262 made sidecars per-session, a user's first prompt is turn 1 of a fresh process — **once per new chat, indefinitely**. memsira is unexposed only because their warmup turn happens to close it for an unrelated reason, which is exactly the accidental dependency worth removing.

## The fix

An in-process cache cannot help when every exposure is a fresh process, so the inventory goes to disk and is read **synchronously** at snapshot time. There is no await boundary in the query path to hang a read on — `streamClaudeAgentSdk` returns its stream and claims `ctx().activeQuery` in the same tick, which is precisely why priming loses the race.

Measured: **484µs** to read 27 entries in a cold process and derive the 7 declarations, against a ~1.5s fetch.

- **Scoped by credential.** The org UUID in the inventory request is ignored; only the credential selects the account. The scope is stored *in* the file as well as hashed into its name, so a hash collision or a hand-copied file cannot hand one account another's connectors.
- **Written under `piUserDir()`**, not the Claude config dir — that directory belongs to the CLI.
- **Fails open** like the inventory call itself: missing, corrupt, stale (>7d), future-dated, wrong-version, or empty all return `undefined` and leave today's behaviour.
- **The live fetch still runs on every snapshot**, so this is a head start, not a replacement, and the next process gets fresher data.

## Why not the bounded await

It is the more complete fix — it would also cover the first-ever run — but it needs an async-safe reentrancy reservation, because reentrancy is read from `ctx().activeQuery` (`index.ts:744`, set at `:887`) and there is no awaitable activation hook (both registration call sites are synchronous). That is query-lifecycle and abort-path surgery under a race we would then have to prove absent. Traded for a residual gap I would rather state than hide:

**The first cold sidecar for a credential on a machine still misses turn 1.** Every one after that is covered.

## Verification

7 new cache tests plus a genuine two-process check — one process writes real 27-entry inventory data, a **separate** process reads it and derives exactly `claude.ai Atlassian, Excalidraw, Figma, Gmail, Google Calendar, Google Drive, Slack`.

`npm run test:unit`: **276 pass, 0 fail.** Typecheck clean, bundle rebuilt.

**Unit tests are not sufficient here and I am not treating them as such.** #868 shipped broken with everything green because the measurement bypassed the async cache. memsira has a rig at `~/Documents/memsira-connector-rig` and offered a 3-minute run against a branch; asking them to run it before merge. Decisive signal: two turns on one cold sidecar, reading the per-query `provider-N.log` files separately — **turn 1 must show `0/11` with 14 connects, not `0/8` with 7**.

Not merging until that comes back.