### PR TITLE
fix(worktree): reconcile shadowed tracked files before reuse rebases (#873, #874)

### DIFF
--- a/skills/worktree/SKILL.md
+++ b/skills/worktree/SKILL.md
@@ -260,6 +260,8 @@ Configured setup paths (`WORKTREE_SYMLINKS`, `WORKTREE_COPIES`, `WORKTREE_MKDIRS
 
 **Symlink untracked paths only.** When a `WORKTREE_SYMLINKS` directory entry contains tracked files, setup marks them `assume-unchanged` so the symlink does not show as a typechange. Git then refuses to write those paths in that worktree — `cherry-pick`, `checkout`, and `merge` fail with *"local changes would be overwritten"* while `git status` reports clean, which is a hard failure to diagnose. That behavior exists for projects migrating away from committing harness config; it is wrong when the project still tracks the content. Setup warns and names the shadowed files. The fix is to narrow the entry to the untracked subpaths: symlink `.pi/agents` and `.pi/APPEND_SYSTEM.md` rather than `.pi`, so tracked `.pi/prompts/*.md` stay real files in every worktree.
 
+`create --reuse` and `create --restack` no longer fail on this. Before rebasing, they clear the `assume-unchanged` bits, drop the configured symlinks, and restore the shadowed files from the index, so git can detach HEAD; setup is re-applied on every terminal path — success, a rebase that never started, an aborted conflict, and `restack continue`/`restack abort`. A `--restack` that pauses on conflicts deliberately stays un-shadowed, so conflicts are resolved against real files; the links come back when the restack finishes or is aborted. This makes reuse work against an entry that shadows tracked files, but it does not make that configuration correct — narrowing the entry is still the right fix, and setup still warns.
+
 Example: share local env plus generated Claude assets, but keep `.claude/CLAUDE.md` pointed at each worktree's own `AGENTS.md`:
 
 ```toml

--- a/skills/worktree/scripts/worktree
+++ b/skills/worktree/scripts/worktree
@@ -858,6 +858,75 @@ warn_if_links_materialized() {
   return 0
 }
 
+# Undo symlink shadowing so git can check out through the configured paths
+# (#873, #874).
+#
+# `symlink_into_worktree` replaces a configured directory with a symlink and
+# marks the tracked files underneath it --assume-unchanged. Git then refuses any
+# checkout that would rewrite those paths — "Your local changes to the following
+# files would be overwritten by checkout", ending in "could not detach HEAD" —
+# so `git rebase` in the create --reuse/--restack path dies before it starts.
+# `git status --porcelain` is empty throughout, because assume-unchanged is
+# exactly what hides them, which is what makes the failure so confusing.
+#
+# Restoring the index's own content as real files removes the conflict without
+# touching any user work: what we discard is a symlink the tool itself laid
+# down, and the tracked content it hid is recreated from the index verbatim.
+# Callers re-apply setup afterwards, which re-links and re-marks the paths.
+#
+# No-op unless a configured entry actually shadows tracked files, so the
+# ordinary runtime-only symlink case is left completely alone.
+unshadow_tracked_symlink_paths() {
+  local wt="$1" path="" tracked="" checkout_err=""
+  local -a shadowed=()
+  [[ -n "$wt" && -d "$wt" ]] || return 0
+  validate_worktree_setup_config >/dev/null 2>&1 || return 0
+
+  split_worktree_config_words "${WORKTREE_SYMLINKS:-}"
+  for path in ${WORKTREE_CONFIG_WORDS[@]+"${WORKTREE_CONFIG_WORDS[@]}"}; do
+    path="$(normalize_worktree_config_path WORKTREE_SYMLINKS "$path" 2>/dev/null)" || continue
+    tracked="$(git -C "$wt" ls-files -- "$path" "$path/" 2>/dev/null || true)"
+    [[ -n "$tracked" ]] || continue
+
+    # Clear the bit first: while it is set, git will not write these paths even
+    # once the link is gone.
+    printf '%s\n' "$tracked" | \
+      xargs -r git -C "$wt" update-index --no-assume-unchanged 2>/dev/null || true
+
+    # Only a symlink needs removing. A real directory here means a previous
+    # rebase already materialized it (#856); its tracked content is genuine and
+    # a checkout can write straight through it.
+    if [[ -L "$wt/$path" ]] && ! rm -f "$wt/$path" 2>/dev/null; then
+      echo "Error: Could not remove the '$path' symlink in $wt to restore the tracked files it shadows." >&2
+      return 1
+    fi
+    shadowed[${#shadowed[@]}]="$path"
+  done
+
+  [[ ${#shadowed[@]} -gt 0 ]] || return 0
+
+  if ! checkout_err="$(git -C "$wt" checkout -- ${shadowed[@]+"${shadowed[@]}"} 2>&1)"; then
+    echo "Error: Could not restore the tracked files shadowed by WORKTREE_SYMLINKS in $wt:" >&2
+    sed 's/^/  /' <<<"$checkout_err" >&2
+    echo "Re-link the worktree, then retry:" >&2
+    echo "  cd '$PROJECT_ROOT' && $0 fix-links '$wt'" >&2
+    return 1
+  fi
+  return 0
+}
+
+# Re-apply setup after a reuse/restack attempt that un-shadowed the configured
+# paths and then failed. Without this the worktree is left holding real tracked
+# directories where the harness links belong, which is a valid git state but a
+# broken harness.
+restore_unshadowed_worktree_setup() {
+  local wt="$1"
+  setup_app_worktree "$wt" && return 0
+  echo "Warning: Worktree setup could not be reapplied after the failed rebase; harness links may be missing." >&2
+  echo "  Restore them from the main checkout: cd '$PROJECT_ROOT' && $0 fix-links '$wt'" >&2
+  return 0
+}
+
 setup_worktree_links() {
   local wt="$1"
   validate_worktree_setup_config || return 1
@@ -1864,6 +1933,13 @@ case "${1:-}" in
           : # origin/$DEFAULT_BRANCH already contained — nothing to rebase
         else
           REUSE_BASE_OID="$(git -C "$WT_PATH" rev-parse "origin/$DEFAULT_BRANCH")"
+          # Configured symlinks that shadow tracked files make git refuse to
+          # detach HEAD, so the rebase below cannot even start (#873, #874).
+          # Undo the shadowing first; every terminal path re-applies setup.
+          if ! unshadow_tracked_symlink_paths "$WT_PATH"; then
+            restore_unshadowed_worktree_setup "$WT_PATH"
+            exit 1
+          fi
           prepare_restack_authorization "$WT_PATH" "$REUSE_REMOTE" "$CURRENT_BRANCH" "$REUSE_EXPECTED_OID" "$REUSE_BASE_OID" || exit 1
           if REBASE_OUTPUT="$(git -C "$WT_PATH" rebase "origin/$DEFAULT_BRANCH" 2>&1)"; then
             finalize_pending_restack_authorization "$WT_PATH" "$REUSE_REMOTE" "$CURRENT_BRANCH" "$REUSE_EXPECTED_OID" || exit 1
@@ -1874,6 +1950,7 @@ case "${1:-}" in
               # Rebase never started (e.g. uncommitted changes) — nothing to
               # abort or resolve; surface git's own message.
               cancel_pending_restack_authorization "$WT_PATH"
+              restore_unshadowed_worktree_setup "$WT_PATH"
               echo "Error: Rebase onto origin/$DEFAULT_BRANCH failed for $WT_PATH before it could start:" >&2
               sed 's/^/  /' <<<"$REBASE_OUTPUT" >&2
               exit 1
@@ -1883,6 +1960,7 @@ case "${1:-}" in
               git -C "$WT_PATH" rebase --abort >/dev/null 2>&1 || MARKER_ABORT_OK=false
               if [[ "$MARKER_ABORT_OK" == true ]] && ! rebase_in_progress "$WT_PATH"; then
                 cancel_pending_restack_authorization "$WT_PATH"
+                restore_unshadowed_worktree_setup "$WT_PATH"
               fi
               echo "Error: Could not bind the paused rebase to its tool-created restack token; refusing guarded recovery." >&2
               exit 1
@@ -1905,6 +1983,7 @@ case "${1:-}" in
             git -C "$WT_PATH" rebase --abort >/dev/null 2>&1 || ABORT_OK=false
             if [[ "$ABORT_OK" == true ]] && ! rebase_in_progress "$WT_PATH"; then
               cancel_pending_restack_authorization "$WT_PATH"
+              restore_unshadowed_worktree_setup "$WT_PATH"
             fi
             echo "Error: Rebase onto origin/$DEFAULT_BRANCH failed for $WT_PATH (conflicts)." >&2
             if [[ -n "$CONFLICT_FILES" ]]; then

--- a/skills/worktree/tests/worktree_reuse_shadowed_tracked.sh
+++ b/skills/worktree/tests/worktree_reuse_shadowed_tracked.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# `create --reuse` must be able to rebase a worktree whose WORKTREE_SYMLINKS
+# entries shadow tracked files (vstack #873, #874).
+#
+# Setup marks tracked files under a symlinked dir --assume-unchanged. Git then
+# refuses to check out any tree that changes those paths ("Your local changes to
+# the following files would be overwritten"), so `git rebase` dies before it can
+# detach HEAD — while `git status --porcelain` is empty, because assume-unchanged
+# is exactly what makes status ignore them. The reuse path must reconcile that
+# shadowing itself and restore the links afterwards.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKTREE_SCRIPT="${WORKTREE_SCRIPT:-$(cd "$TEST_DIR/.." && pwd)/scripts/worktree}"
+TMP_ROOT="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+PASS=0
+FAIL=0
+
+assert_contains() {
+  local haystack="$1" needle="$2" name="$3"
+  if grep -qF -- "$needle" <<<"$haystack"; then
+    PASS=$((PASS + 1)); printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        wanted substring: %s\n        in: %s\n' "$name" "$needle" "$haystack"
+  fi
+}
+
+assert_eq() {
+  local got="$1" want="$2" name="$3"
+  if [[ "$got" == "$want" ]]; then
+    PASS=$((PASS + 1)); printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        want: %s\n        got:  %s\n' "$name" "$want" "$got"
+  fi
+}
+
+mkdir -p "$TMP_ROOT/bin"
+cat >"$TMP_ROOT/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+chmod +x "$TMP_ROOT/bin/gh"
+export PATH="$TMP_ROOT/bin:$PATH"
+
+ROOT="$TMP_ROOT/repo"
+mkdir -p "$ROOT/main"
+git -C "$ROOT/main" init -q -b main
+git -C "$ROOT/main" config user.email test@example.com
+git -C "$ROOT/main" config user.name Test
+git -C "$ROOT/main" config commit.gpgsign false
+printf 'base\n' >"$ROOT/main/base.txt"
+git -C "$ROOT/main" add base.txt
+git -C "$ROOT/main" commit -q -m base
+git init -q --bare "$ROOT/origin.git"
+git -C "$ROOT/main" remote add origin "$ROOT/origin.git"
+git -C "$ROOT/main" push -q -u origin main
+
+# A harness dir that mixes runtime content with a TRACKED file — the shape that
+# CC-1144's `.agents` relocation produced in hyprtrade.
+mkdir -p "$ROOT/main/harness/skills"
+printf 'harness/**\n!harness/skills/\n!harness/skills/*.md\n' >"$ROOT/main/.gitignore"
+printf 'runtime\n' >"$ROOT/main/harness/state.json"
+printf 'v1\n' >"$ROOT/main/harness/skills/tool.md"
+printf 'WORKTREE_SYMLINKS="harness"\n' >"$ROOT/main/.env"
+git -C "$ROOT/main" add .gitignore harness/skills/tool.md
+git -C "$ROOT/main" commit -q -m harness
+git -C "$ROOT/main" push -q origin main
+
+echo "=== reuse rebases across a symlink entry that shadows tracked files ==="
+
+WT="$( (cd "$ROOT/main" && "$WORKTREE_SCRIPT" create reuse-check) 2>/dev/null )"
+[[ -n "$WT" && -d "$WT" ]] || { echo "FATAL: worktree not created"; exit 1; }
+
+# Branch work that does NOT touch the shadowed path.
+printf 'branch work\n' >"$WT/feature.txt"
+git -C "$WT" add feature.txt
+git -C "$WT" commit -q -m 'feature work'
+
+# Main moves forward AND changes the tracked file hidden behind the symlink.
+# This is what forces git to write through the shadowed path during rebase.
+printf 'v2\n' >"$ROOT/main/harness/skills/tool.md"
+printf 'moved on\n' >"$ROOT/main/other.txt"
+# -f because `worktree create` appends a bare `harness` entry to the COMMON
+# git dir's info/exclude, which makes plain `git add` refuse tracked paths
+# underneath it even in the main checkout (vstack #878).
+git -C "$ROOT/main" add -f harness/skills/tool.md other.txt
+git -C "$ROOT/main" commit -q -m 'advance main and touch tracked harness file'
+git -C "$ROOT/main" push -q origin main
+
+# Precondition the issues call out: git status is clean despite the shadowing.
+assert_eq "$(git -C "$WT" status --porcelain)" "" "git status is clean before reuse"
+
+set +e
+reuse_out="$( (cd "$ROOT/main" && "$WORKTREE_SCRIPT" create reuse-check --reuse) 2>&1 )"
+reuse_status=$?
+set -e
+
+assert_eq "$reuse_status" "0" "create --reuse succeeds"
+assert_contains "$reuse_out" "$WT" "reuse prints the worktree path"
+
+# The rebase actually happened: main's new commit is an ancestor of the branch.
+set +e
+git -C "$WT" merge-base --is-ancestor origin/main HEAD
+ancestor_status=$?
+set -e
+assert_eq "$ancestor_status" "0" "origin/main is contained after reuse"
+
+# The branch commit survived the rebase.
+assert_contains "$(git -C "$WT" log --format=%s -3)" "feature work" "branch commit preserved"
+
+# Setup was reapplied: the harness path is a symlink again, not a materialized
+# directory, and it resolves to the main checkout's content.
+if [[ -L "$WT/harness" ]]; then
+  PASS=$((PASS + 1)); printf '  ok    %s\n' "harness is a symlink again after reuse"
+else
+  FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "harness is a symlink again after reuse"
+fi
+assert_eq "$(cat "$WT/harness/skills/tool.md" 2>/dev/null)" "v2" "harness resolves to main checkout content"
+
+# And the worktree is still clean — the reconciliation must not leave the
+# shadowed paths reported as modified.
+assert_eq "$(git -C "$WT" status --porcelain)" "" "git status is clean after reuse"
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Problem

`create --reuse` / `create --restack` could not rebase a worktree whose `WORKTREE_SYMLINKS` entry shadows tracked files. The rebase failed before it started:

```
error: Your local changes to the following files would be overwritten by checkout:
    harness/skills/tool.md
error: could not detach HEAD
```

`git status --porcelain` was empty throughout, because `assume-unchanged` — set by setup itself — is exactly what hides those paths. That combination is what made this hard to diagnose from the outside.

Two reports, one wall, different entry points:
- **#873** — reuse across CC-1144's tracked `.agents` relocation.
- **#874** — reuse in hyprtrade CC-1142, where setup had marked the tracked skill files assume-unchanged.

Root cause confirmed by reproduction, not inferred: `symlink_into_worktree` marks tracked files under a symlinked directory `--assume-unchanged`, and git refuses to write them for any checkout — which `git rebase` needs in order to detach HEAD.

## Fix

Before rebasing, undo the shadowing: clear the bits, remove the tool's own symlinks, and restore the shadowed content from the index. Then re-apply setup.

Nothing of the user's is discarded — the symlink was laid down by this script, and the tracked content it hid is recreated from the index verbatim.

Setup is re-applied on **every** terminal path: success, a rebase that never started, a failed-and-aborted conflict, a marker-bind failure, and `restack continue` / `restack abort` (which already did it).

A `--restack` that pauses on conflicts deliberately stays un-shadowed, so conflicts are resolved against real files; its links return when the restack completes or aborts.

The helper no-ops unless an entry actually shadows tracked files, so the ordinary runtime-only symlink case is untouched.

This makes reuse work against such a configuration **without endorsing it**. Narrowing the entry to untracked subpaths is still the correct configuration, setup still warns and names the shadowed files, and `SKILL.md` says so.

## Tests

New `skills/worktree/tests/worktree_reuse_shadowed_tracked.sh` builds the exact shape — a symlinked dir holding a tracked file, branch work that does not touch it, and a main that advances *and* modifies it — then asserts:

- `git status` is clean before reuse (the precondition both issues call out)
- `create --reuse` exits 0
- `origin/main` is contained afterwards (the rebase really happened)
- the branch commit survived
- the path is a **symlink** again, resolving to the main checkout's content
- `git status` is clean afterwards

Verified failing before the change (`create --reuse` exit 1, `origin/main` not contained) and passing after.

Full suite green: **15/15**, including `bash32-portability.test.sh`.

## Found along the way

Filed #878 — `worktree create` appends a bare entry to the **common** git dir's `info/exclude`, which stops the *main* checkout staging tracked files under that path (`git add` refuses; `git status` still shows them modified). Same underlying tension, different checkout; not addressed here. The new test's scaffolding needs `git add -f` because of it, with a comment pointing at #878.

Closes #873
Closes #874

https://claude.ai/code/session_01CCHxmznh9aLRCFAEZNkNRD
