### PR TITLE
fix(github,orch): one shared check-scoping implementation (refs #876)

### DIFF
--- a/skills/github/scripts/commands/pr-merge.sh
+++ b/skills/github/scripts/commands/pr-merge.sh
@@ -39,44 +39,12 @@ source "$SCRIPT_DIR/../lib/pr-branch.sh"
 # CI completes. Callers should `await-mergeable` and retry rather than fix.
 TRANSIENT_PREFIXES='unknown:|ci_pending:|ci_unconfigured:|ci_fetch_failed:'
 
-# Scope a `gh pr checks` array to the current authoritative run per workflow so
-# stale checks from a SUPERSEDED workflow run don't leak into the current
-# PR/head status (vstack#492). A single canceled prior run left Lint/Integration/
-# etc. as CANCELLED; with no newer instance of those jobs yet created, they were
-# the only copies and were wrongly counted as current failures.
-#
-# Approach: parse each check's owning workflow RUN_ID from its `link`
-# (`.../actions/runs/<RUN_ID>/job/<JOB_ID>`), group run-bearing checks by their
-# `workflow`, and within each workflow keep ONLY the checks belonging to that
-# workflow's LATEST run (max RUN_ID). This (a) drops an old run's checks when a
-# newer run of the same workflow exists, and (b) — the reported case — drops the
-# old canceled job even when the newer run hasn't recreated it yet, leaving it
-# correctly absent (reported as not-yet-created/pending, not failed). Distinct
-# workflows are never collapsed (e.g. a separate "License Key Guard" workflow is
-# preserved). Checks with no parseable run in `link` (external/required contexts,
-# default-setup `.../runs/<CHECK_RUN_ID>` links, or older gh output with no link)
-# are always kept, deduped by name keeping the latest `startedAt`. An all-empty
-# link/startedAt array (older gh) passes through unchanged.
-#
-# This must stay aligned with orch ci-wait's scope_current_run (byte-for-byte).
-scope_current_run() {
-  jq -c '
-    def runid:
-      (.link // "")
-      | ((capture("/actions/runs/(?<r>[0-9]+)")? | .r) // null)
-      | (if . == null then null else tonumber end);
-    map(. + {"_runid": runid})
-    | ([.[] | select(._runid == null)]) as $norun
-    | ([.[] | select(._runid != null)]) as $withrun
-    | ($withrun
-        | group_by(.workflow)
-        | map((map(._runid) | max) as $mx | map(select(._runid == $mx)))
-        | add // []) as $scoped
-    | ($norun | group_by(.name) | map(sort_by(.startedAt // "") | last)) as $norun_deduped
-    | ($scoped + $norun_deduped)
-    | map(del(._runid))
-  '
-}
+# Scope a `gh pr checks` array to the current authoritative substantive run per
+# workflow. Shared with orch `ci-wait` so the merge gate and the waiter cannot
+# disagree about which run is current (vstack#876) — see the library for the
+# full rationale.
+# shellcheck source=../lib/ci-run-correlation.sh
+source "$SCRIPT_DIR/../lib/ci-run-correlation.sh"
 
 show_help() {
     cat <<'EOF'

--- a/skills/github/scripts/lib/ci-run-correlation.sh
+++ b/skills/github/scripts/lib/ci-run-correlation.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Shared CI check-rollup scoping for the PR merge/wait path.
+#
+# `gh pr checks` returns the whole check rollup for a PR's head, which can hold
+# several workflow runs from several dispatch events on that SAME head. Deciding
+# CI status means picking the authoritative run per workflow first — otherwise a
+# superseded or degenerate duplicate dispatch is read as a current failure.
+#
+# This lived in TWO places: orch `ci-wait` and github `pr-merge.sh`, each with a
+# comment saying it must stay aligned with the other "byte-for-byte". Nothing
+# enforced that, and they drifted: `ci-wait` grew substantive-run selection and
+# stale-status rewriting (vstack#607) while `pr-merge.sh` kept the original
+# max-run-id version (vstack#492). The two then disagreed on the same PR —
+# `ci-wait` reported pass for the substantive run while `pr-merge --check`
+# reported `can_merge=false` from a second same-head run's zero-second
+# failures — which is vstack#876.
+#
+# One implementation, sourced by both. `ci-run-correlation-alignment.test.sh`
+# fails if either script grows a local copy again.
+
+# Scope a `gh pr checks` array to the current authoritative substantive run per
+# workflow so stale checks from a SUPERSEDED workflow run don't leak into the
+# current PR/head status (vstack#492, vstack#607). `gh pr checks` is already the
+# check rollup for the PR's current head; the run IDs in each Actions link let us
+# correlate duplicate contexts on that head.
+#
+# A later workflow dispatch is not always authoritative. Approval-gated CI can
+# receive a COMMENTED review event after the APPROVED event; that later run is an
+# intentional all-SKIPPED no-op while the earlier approved run is still active.
+# Therefore, per workflow, choose the latest run containing at least one
+# non-skipped check. Only fall back to the latest all-skipped run when no
+# substantive run exists at all.
+#
+# Custom commit statuses such as `CI Required` link to an Actions run but have
+# an empty `workflow` in `gh pr checks`. If such a status still points at an old
+# run while a newer substantive run from the same workflow is pending or has no
+# failures, rewrite the stale status to EXPECTED. It stays pending until that
+# newer run publishes its own status. A newer failed/cancelled run remains a
+# terminal failure, and a missing replacement status eventually hits the normal
+# waiter timeout, preserving fail-closed behavior.
+#
+# Checks with no parseable run in `link` (external contexts, default-setup
+# `.../runs/<CHECK_RUN_ID>` links, or older gh output with no link) are always
+# kept, deduped by name keeping the latest `startedAt`.
+scope_current_run() {
+  jq -c '
+    def runid:
+      (.link // "")
+      | ((capture("/actions/runs/(?<r>[0-9]+)")? | .r) // null)
+      | (if . == null then null else tonumber end);
+    def bucket:
+      (.bucket // (
+        if (.state == "SUCCESS") then "pass"
+        elif (.state == "SKIPPED") then "skipping"
+        elif ((.state // "") | IN("PENDING", "QUEUED", "IN_PROGRESS", "WAITING", "REQUESTED", "EXPECTED")) then "pending"
+        elif (.state == "CANCELLED") then "cancel"
+        else "fail"
+        end
+      ));
+    def status_target:
+      ((.link // "") | test("/actions/runs/[0-9]+/?$"));
+    map(. + {
+      "_runid": runid,
+      "_bucket": bucket,
+      "_status_target": status_target
+    })
+    | ([.[] | select(._runid == null)]) as $norun
+    | ([.[] | select(._runid != null and ((.workflow // "") != ""))]) as $jobs
+    | ([.[] | select(._runid != null and ((.workflow // "") == ""))]) as $run_statuses
+    | ($jobs
+        | group_by(.workflow)
+        | map(
+            group_by(._runid)
+            | map({
+                workflow: (.[0].workflow // ""),
+                runid: .[0]._runid,
+                checks: .,
+                substantive: any(.[]; ._bucket != "skipping"),
+                failed: ([.[] | select((._bucket != "pass") and (._bucket != "skipping") and (._bucket != "pending"))] | length)
+              })
+            | (map(select(.substantive))) as $substantive
+            | if ($substantive | length) > 0 then
+                ($substantive | max_by(.runid))
+              else
+                max_by(.runid)
+              end
+          )) as $selected_runs
+    | ($selected_runs | map(.checks) | add // []) as $scoped_jobs
+    | ($run_statuses
+        | group_by(.name)
+        | map(max_by(._runid))) as $latest_statuses
+    | ($latest_statuses
+        | map(
+            . as $status
+            | ([$jobs[]
+                | select(._runid == $status._runid)
+                | .workflow]
+                | unique
+                | .[0] // "") as $source_workflow
+            | ([$selected_runs[]
+                | select(.workflow == $source_workflow and .runid > $status._runid)]
+                | max_by(.runid)?) as $newer_run
+            | if ($status._status_target
+                  and $source_workflow != ""
+                  and $newer_run != null
+                  and $newer_run.failed == 0) then
+                .state = "EXPECTED"
+                | .bucket = "pending"
+                | ._bucket = "pending"
+              else
+                .
+              end
+          )) as $scoped_statuses
+    | ($norun | group_by(.name) | map(sort_by(.startedAt // "") | last)) as $norun_deduped
+    | ($scoped_jobs + $scoped_statuses + $norun_deduped)
+    | map(del(._runid, ._bucket, ._status_target))
+  '
+}

--- a/skills/github/tests/ci-run-correlation.test.sh
+++ b/skills/github/tests/ci-run-correlation.test.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# `scope_current_run` lived in TWO places — orch `ci-wait` and github
+# `pr-merge.sh` — each carrying a comment that it must stay aligned with the
+# other "byte-for-byte". Nothing enforced that, and they drifted: `ci-wait` grew
+# substantive-run selection and stale-status rewriting (vstack#607) while
+# `pr-merge.sh` kept the original max-run-id version (vstack#492). A merge gate
+# and the waiter feeding it were then scoping the same rollup by different rules
+# (vstack#876).
+#
+# These tests (a) pin the shared implementation's behaviour and (b) fail if
+# either script grows a local copy again, so the drift cannot silently return.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../.." && pwd)"
+LIB="$REPO_ROOT/skills/github/scripts/lib/ci-run-correlation.sh"
+
+PASS=0
+FAIL=0
+pass() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+fail() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
+
+[[ -f "$LIB" ]] || { echo "FATAL: shared library missing at $LIB"; exit 1; }
+# shellcheck source=../scripts/lib/ci-run-correlation.sh
+source "$LIB"
+
+echo "=== single implementation ==="
+
+for script in "$REPO_ROOT/skills/orch/scripts/ci-wait" \
+              "$REPO_ROOT/skills/github/scripts/commands/pr-merge.sh"; do
+  name="$(basename "$script")"
+  if grep -qE '^scope_current_run\(\)' "$script"; then
+    fail "$name defines its own scope_current_run (drift reintroduced — source the shared library instead)"
+  else
+    pass "$name does not define its own scope_current_run"
+  fi
+  if grep -q 'ci-run-correlation.sh' "$script"; then
+    pass "$name sources the shared library"
+  else
+    fail "$name sources the shared library"
+  fi
+done
+
+echo "=== scoping behaviour ==="
+
+run_scope() { scope_current_run <<<"$1"; }
+names_of() { jq -r '[.[] | .name] | sort | join(",")' <<<"$1"; }
+
+# An approval-gated repo can dispatch an all-SKIPPED no-op run AFTER the
+# substantive one. The newer run must not win just because its id is higher.
+NOOP='[
+ {"name":"build","state":"SUCCESS","bucket":"pass","workflow":"CI","startedAt":"2026-07-26T10:00:00Z","link":"https://x/actions/runs/100/job/1"},
+ {"name":"build","state":"SKIPPED","bucket":"skipping","workflow":"CI","startedAt":"2026-07-26T10:06:00Z","link":"https://x/actions/runs/200/job/2"}
+]'
+OUT="$(run_scope "$NOOP")"
+if [[ "$(jq -r '.[0].link' <<<"$OUT")" == *"/runs/100/"* ]] && [[ "$(jq 'length' <<<"$OUT")" == 1 ]]; then
+  pass "a later all-skipped run does not supersede the substantive one"
+else
+  fail "a later all-skipped run does not supersede the substantive one (got $OUT)"
+fi
+
+# Checks with no parseable run id are always kept, deduped by name on startedAt.
+NORUN='[
+ {"name":"external","state":"SUCCESS","bucket":"pass","workflow":"","startedAt":"2026-07-26T10:00:00Z","link":""},
+ {"name":"external","state":"FAILURE","bucket":"fail","workflow":"","startedAt":"2026-07-26T10:09:00Z","link":""}
+]'
+OUT="$(run_scope "$NORUN")"
+if [[ "$(jq 'length' <<<"$OUT")" == 1 ]] && [[ "$(jq -r '.[0].state' <<<"$OUT")" == "FAILURE" ]]; then
+  pass "run-less checks dedupe by name keeping the latest startedAt"
+else
+  fail "run-less checks dedupe by name keeping the latest startedAt (got $OUT)"
+fi
+
+# Distinct workflows are never collapsed into one another.
+TWO='[
+ {"name":"a","state":"SUCCESS","bucket":"pass","workflow":"CI","startedAt":"2026-07-26T10:00:00Z","link":"https://x/actions/runs/100/job/1"},
+ {"name":"b","state":"SUCCESS","bucket":"pass","workflow":"Guard","startedAt":"2026-07-26T10:00:00Z","link":"https://x/actions/runs/50/job/2"}
+]'
+OUT="$(run_scope "$TWO")"
+[[ "$(names_of "$OUT")" == "a,b" ]] \
+  && pass "distinct workflows are both preserved" \
+  || fail "distinct workflows are both preserved (got $(names_of "$OUT"))"
+
+echo "=== vstack#876 reported shape (documents CURRENT behaviour, not a fix) ==="
+
+# The reported rollup: a completed substantive run whose required aggregate
+# passed, plus a SECOND same-head run of the same workflow whose jobs came back
+# as zero-second failures/cancellations.
+#
+# Scoping alone does NOT drop that second run: a run full of failures counts as
+# substantive (it has non-skipped checks), so it wins on run id. `pr-merge
+# --check` therefore still reports ci_failed while the required aggregate is
+# green — which is exactly the disagreement #876 describes, and it is NOT
+# resolved by unifying the scoping. This assertion exists so that is recorded as
+# known behaviour rather than assumed fixed; a change that makes the second run
+# lose should update this test deliberately.
+DUP='[
+ {"name":"build","state":"SUCCESS","bucket":"pass","workflow":"CI","startedAt":"2026-07-26T10:00:00Z","link":"https://x/actions/runs/30201726860/job/1"},
+ {"name":"CI Required","state":"SUCCESS","bucket":"pass","workflow":"","startedAt":"2026-07-26T10:05:00Z","link":"https://x/actions/runs/30201726860"},
+ {"name":"CI Gate Publisher","state":"FAILURE","bucket":"fail","workflow":"CI","startedAt":"2026-07-26T10:06:00Z","link":"https://x/actions/runs/30201902682/job/9"},
+ {"name":"build","state":"CANCELLED","bucket":"cancel","workflow":"CI","startedAt":"2026-07-26T10:06:00Z","link":"https://x/actions/runs/30201902682/job/10"}
+]'
+OUT="$(run_scope "$DUP")"
+if jq -e '[.[] | select(.state == "FAILURE" or .state == "CANCELLED")] | length == 2' >/dev/null <<<"$OUT"; then
+  pass "the second same-head run's failures still survive scoping (#876 remains open)"
+else
+  fail "the second same-head run's failures still survive scoping (#876 remains open)"
+fi
+if jq -e '[.[] | select(.name == "CI Required" and .state == "SUCCESS")] | length == 1' >/dev/null <<<"$OUT"; then
+  pass "the required aggregate stays green alongside those failures"
+else
+  fail "the required aggregate stays green alongside those failures"
+fi
+
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/skills/orch/scripts/ci-wait
+++ b/skills/orch/scripts/ci-wait
@@ -285,103 +285,16 @@ is_transient_failure() {
 }
 
 # Scope a `gh pr checks` array to the current authoritative substantive run per
-# workflow so stale checks from a SUPERSEDED workflow run don't leak into the
-# current PR/head status (vstack#492, vstack#607). `gh pr checks` is already the
-# check rollup for the PR's current head; the run IDs in each Actions link let us
-# correlate duplicate contexts on that head.
-#
-# A later workflow dispatch is not always authoritative. Approval-gated CI can
-# receive a COMMENTED review event after the APPROVED event; that later run is an
-# intentional all-SKIPPED no-op while the earlier approved run is still active.
-# Therefore, per workflow, choose the latest run containing at least one
-# non-skipped check. Only fall back to the latest all-skipped run when no
-# substantive run exists at all.
-#
-# Custom commit statuses such as `CI Required` link to an Actions run but have
-# an empty `workflow` in `gh pr checks`. If such a status still points at an old
-# run while a newer substantive run from the same workflow is pending or has no
-# failures, rewrite the stale status to EXPECTED. It stays pending until that
-# newer run publishes its own status. A newer failed/cancelled run remains a
-# terminal failure, and a missing replacement status eventually hits the normal
-# waiter timeout, preserving fail-closed behavior.
-#
-# Checks with no parseable run in `link` (external contexts, default-setup
-# `.../runs/<CHECK_RUN_ID>` links, or older gh output with no link) are always
-# kept, deduped by name keeping the latest `startedAt`.
-scope_current_run() {
-  jq -c '
-    def runid:
-      (.link // "")
-      | ((capture("/actions/runs/(?<r>[0-9]+)")? | .r) // null)
-      | (if . == null then null else tonumber end);
-    def bucket:
-      (.bucket // (
-        if (.state == "SUCCESS") then "pass"
-        elif (.state == "SKIPPED") then "skipping"
-        elif ((.state // "") | IN("PENDING", "QUEUED", "IN_PROGRESS", "WAITING", "REQUESTED", "EXPECTED")) then "pending"
-        elif (.state == "CANCELLED") then "cancel"
-        else "fail"
-        end
-      ));
-    def status_target:
-      ((.link // "") | test("/actions/runs/[0-9]+/?$"));
-    map(. + {
-      "_runid": runid,
-      "_bucket": bucket,
-      "_status_target": status_target
-    })
-    | ([.[] | select(._runid == null)]) as $norun
-    | ([.[] | select(._runid != null and ((.workflow // "") != ""))]) as $jobs
-    | ([.[] | select(._runid != null and ((.workflow // "") == ""))]) as $run_statuses
-    | ($jobs
-        | group_by(.workflow)
-        | map(
-            group_by(._runid)
-            | map({
-                workflow: (.[0].workflow // ""),
-                runid: .[0]._runid,
-                checks: .,
-                substantive: any(.[]; ._bucket != "skipping"),
-                failed: ([.[] | select((._bucket != "pass") and (._bucket != "skipping") and (._bucket != "pending"))] | length)
-              })
-            | (map(select(.substantive))) as $substantive
-            | if ($substantive | length) > 0 then
-                ($substantive | max_by(.runid))
-              else
-                max_by(.runid)
-              end
-          )) as $selected_runs
-    | ($selected_runs | map(.checks) | add // []) as $scoped_jobs
-    | ($run_statuses
-        | group_by(.name)
-        | map(max_by(._runid))) as $latest_statuses
-    | ($latest_statuses
-        | map(
-            . as $status
-            | ([$jobs[]
-                | select(._runid == $status._runid)
-                | .workflow]
-                | unique
-                | .[0] // "") as $source_workflow
-            | ([$selected_runs[]
-                | select(.workflow == $source_workflow and .runid > $status._runid)]
-                | max_by(.runid)?) as $newer_run
-            | if ($status._status_target
-                  and $source_workflow != ""
-                  and $newer_run != null
-                  and $newer_run.failed == 0) then
-                .state = "EXPECTED"
-                | .bucket = "pending"
-                | ._bucket = "pending"
-              else
-                .
-              end
-          )) as $scoped_statuses
-    | ($norun | group_by(.name) | map(sort_by(.startedAt // "") | last)) as $norun_deduped
-    | ($scoped_jobs + $scoped_statuses + $norun_deduped)
-    | map(del(._runid, ._bucket, ._status_target))
-  '
-}
+# workflow. Shared with github `pr-merge.sh` so the waiter and the merge gate
+# cannot disagree about which run is current (vstack#876) — see the library for
+# the full rationale.
+CI_RUN_CORRELATION_LIB="$SCRIPT_DIR/../../github/scripts/lib/ci-run-correlation.sh"
+if [[ ! -f "$CI_RUN_CORRELATION_LIB" ]]; then
+  echo "ci-wait: missing required library $CI_RUN_CORRELATION_LIB (github skill not installed?)" >&2
+  exit 1
+fi
+# shellcheck source=../../github/scripts/lib/ci-run-correlation.sh
+source "$CI_RUN_CORRELATION_LIB"
 
 # Failure check `link` is `https://github.com/owner/repo/actions/runs/<RUN_ID>/job/<JOB_ID>` —
 # extract RUN_ID, not the trailing JOB_ID (which `gh run rerun` won't accept as a workflow run).

--- a/skills/orch/workflows/submit-pr.md
+++ b/skills/orch/workflows/submit-pr.md
@@ -424,7 +424,7 @@ A PR merges on exactly four gates — all deterministic. Bot-SPECIFIC signals (e
 | # | Gate | Check |
 |---|------|-------|
 | 1 | Internal review verdict recorded | Managed: `review-pr.md` completed with verdict `pass` before this workflow. Standalone: workflow state `json_paths` is non-empty |
-| 2 | CI green | § 5 result is `status=complete`, `verdict=pass` (equivalently: `gh pr checks [PR_NUMBER]` shows all checks passing) |
+| 2 | CI green | § 5 result is `status=complete`, `verdict=pass` |
 | 3 | Zero unresolved review comments | `pr-threads` reports `unresolved_count == 0` AND every actionable PR-level bot comment has a reply (tracked in `pr_comment_review.replied`) |
 | 4 | Reviewer-gate verdict | Mode-aware per the § 4 `GATE_MODE`. `approval`: § 4 ended `approved` — `reviewDecision == "APPROVED"`, or, when `reviewDecision` is empty (no required-review protection), at least one reviewer whose latest review is APPROVED and none whose latest review is CHANGES_REQUESTED. `review`: § 4 ended `reviewed` — a non-author review of the current head with zero unresolved threads. Either mode: also met when `pr_approval.forced` (user Force merge) or `pr_approval.reviewer_down` (`PR_REVIEW_ON_TIMEOUT=proceed` reviewer-down degrade) is recorded. `off` (`pr_review.mode == "off"`, recorded alongside the legacy `pr_approval.gate == "off"`): not applicable for this repo |
 
@@ -435,6 +435,10 @@ A PR merges on exactly four gates — all deterministic. Bot-SPECIFIC signals (e
    If `json_paths` is empty, no internal review is recorded: report the unmet gate and recommend `orch review-pr [PR_NUMBER]` before merge.
 
 2. **Gate 2** — verify the recorded § 5 result: met when the final CI result was `status=complete`, `verdict=pass`. Do not re-run ci-wait.
+
+   **`ci-wait verdict=pass` is NOT the same as "every check in the rollup is green"** (vstack#876). `ci-wait` correlates the head's checks with its Actions runs and judges the current substantive run; `gh pr checks` and `github.sh pr-merge --check` read the whole rollup, which can still hold failures from a SECOND same-head workflow run — e.g. a duplicate dispatch whose jobs come back as zero-second failures or cancellations. Both readings can be correct at once: `CI Required` green for the substantive run, `pr-merge --check` reporting `can_merge=false` from the duplicate's leftovers.
+
+   So a `pr-merge --check` refusal immediately after a green § 5 does **not** invalidate the § 5 verdict, and it is not a reason to re-run ci-wait. Identify which run each reported failure belongs to (`gh pr checks [PR_NUMBER] --json name,state,link,workflow` — the run id is in `link`) before treating it as a real CI failure. If every reported failure belongs to a superseded or duplicate run while the repo's required aggregate is green, that is the known #876 disagreement: report it to the user with the run ids rather than silently forcing or silently abandoning the merge.
 
 3. **Gate 3 — final live check**:
    ```bash


### PR DESCRIPTION
Investigating #876 turned up a latent defect underneath it. This PR fixes **that**, and deliberately does **not** close #876.

## What I found

`scope_current_run` existed **twice** — orch `ci-wait` and github `pr-merge.sh` — each carrying a comment saying it must stay aligned with the other *"byte-for-byte"*. Nothing enforced it, and they had drifted badly:

| copy | size | behaviour |
|---|---|---|
| `ci-wait` | 74 lines | substantive-run selection per workflow + stale run-level status rewriting (#607) |
| `pr-merge.sh` | 18 lines | the original max-run-id version (#492) |

The merge gate and the waiter feeding it were scoping the same rollup by **different rules**, and the comment asserting otherwise was false.

## Fix

Extract `ci-wait`'s current implementation to `skills/github/scripts/lib/ci-run-correlation.sh`; both scripts source it. `ci-wait` fails loudly if the library is absent rather than silently reverting to weaker scoping — orch already hard-depends on the github skill (`session-init`, `pr-view-json`, `refix-route`).

Behaviour preserved exactly:

| suite | before | after |
|---|---|---|
| `ci_wait` | 132 pass / 1 fail | 132 pass / 1 fail |
| `pr-merge` | 83 pass / 0 fail | 83 pass / 0 fail |

That `ci_wait` failure is pre-existing and environment-only (verified on clean `main`), as are `session_init` and github `env-first-auth` — all credential/auth related.

Also corrects `submit-pr.md` § 6, which claimed a `ci-wait` `verdict=pass` was *"equivalently: `gh pr checks` shows all checks passing"*. **It is not**, and that false equivalence is what made #876's handoff ambiguous. Replaced with what actually differs, plus instructions to attribute each reported failure to its run id before treating it as a real CI failure.

## Why this does not close #876

Unifying the scoping does **not** make the reported symptom go away. I ran the reported rollup shape through the shared implementation to check rather than assume:

```
CI Gate Publisher  FAILURE    run=30201902682
build              CANCELLED  run=30201902682
test               FAILURE    run=30201902682
CI Required        SUCCESS    run=30201726860
```

A duplicate same-head run whose jobs return as zero-second failures/cancellations still counts as **substantive** — it has non-skipped checks — so it still wins on run id, and its failures still reach `pr-merge --check` while the required aggregate is green. Exactly the disagreement #876 reports.

That is pinned as an explicit test assertion (`the second same-head run's failures still survive scoping (#876 remains open)`) so the remaining gap is recorded rather than assumed closed, and so a future change that alters it has to do so deliberately.

The real fix has to address the **required-check model** — whether `pr-merge --check` should honor the repo's configured required aggregate. That decides what may merge, so it is safety-sensitive and deserves its own cycle rather than being bolted onto a refactor. I could not reconstruct `ci-wait`'s exact pass path for the reported PR either: the runs live in another repo and the evidence needed is the two runs' correlation data, not the rollup alone.

## Tests

New `skills/github/tests/ci-run-correlation.test.sh` — 9 assertions:

- **drift guard**: fails if either script defines its own `scope_current_run`, and requires both to source the library — so this cannot silently return
- a later all-skipped run does not supersede the substantive one (#607)
- run-less checks dedupe by name keeping the latest `startedAt`
- distinct workflows are never collapsed
- the #876 shape, documenting current behaviour on both sides

Refs #876

https://claude.ai/code/session_01CCHxmznh9aLRCFAEZNkNRD
