### PR TITLE
feat(worktree): adopt the session guard as a vstack-owned mechanism (refs #877)

### DIFF
--- a/skills/worktree/README.md
+++ b/skills/worktree/README.md
@@ -6,10 +6,26 @@ Git worktree lifecycle management with env/config symlinks.
 
 ```text
 skills/worktree/
-├── SKILL.md          # Agent-facing skill definition
+├── SKILL.md                     # Agent-facing skill definition
 └── scripts/
-    └── worktree      # Entry point
+    ├── worktree                 # Entry point
+    └── worktree-session-guard   # Ownership leases (see below)
 ```
+
+## Session guard
+
+`worktree-session-guard` records a session's claim on an issue worktree as a **native Git worktree lock** whose reason line carries the owner and heartbeat, so `git worktree remove [--force]` refuses it and `git worktree prune` leaves the registration alone. Using the native lock rather than a private marker file is deliberate: it needs no cooperation from whoever runs the cleanup.
+
+The `worktree` entry point does **not** drive it yet — claim and release explicitly (vstack#877). Wiring `create` to claim while only `remove` releases would leave every worktree claimed for its whole life, which turns a lease-aware `cleanup` into a no-op unless `--stale` is passed; that trade is a policy decision, so the mechanism ships ahead of the integration. `VSTACK_SESSION_OWNER` sets the owner, which the workflow sets to the issue ID.
+
+`status PATH --owner NAME` is the read-only ownership probe and answers by exit code alone: 0 lease for this owner, 1 path not registered, 3 unclaimed, 4 locked outside the guard, 75 claimed by a different owner. `claim` is not a probe — it takes or rewrites the lease.
+
+Limits worth knowing before relying on it:
+
+- The lease is keyed on the owner string (the issue ID), so two sessions on the same issue share one lease. Bare `create <ID>` is what refuses a second implementer; `create --reuse|--restack` skips that refusal by design, so **nothing prevents a second implementer there**.
+- Staleness is heartbeat age with no liveness probe, so a session still running that has **outlived its TTL without refreshing** will be treated as abandoned by `release --stale` and `sweep`.
+- The guard requires `flock(1)` and checks only whether it is on PATH — a capability, not a platform — so **wherever flock is available, the claim is mandatory**. Without flock the session is unguarded rather than protected.
+- `git worktree remove -f -f` and `rm -rf` still destroy a claimed worktree; `status` and `list` exist to attribute that afterwards.
 
 ## Setup
 

--- a/skills/worktree/SKILL.md
+++ b/skills/worktree/SKILL.md
@@ -237,11 +237,38 @@ Some execution policies reject top-level `git rebase` porcelain outright — Cod
     .agents/skills/worktree/scripts/worktree fix-links <ID>
     ```
 
+## Session guard (ownership leases)
+
+`scripts/worktree-session-guard` stops cleanup from destroying a worktree a session is still working in. The lease is recorded as a **native Git worktree lock** whose reason line carries the owner and heartbeat, so `git worktree remove [--force]` refuses it and `git worktree prune` never prunes the registration — even after the directory itself is gone. That needs no cooperation from whoever runs the cleanup, which a private marker file would.
+
+**Not yet wired into `create`/`remove`/`cleanup`** — drive it explicitly for now (vstack#877 tracks the lifecycle integration; see the note at the end of this section for why it is not automatic yet). Owner defaults to `$VSTACK_SESSION_OWNER`, else `$USER`; the workflow sets it to the issue ID:
+
+```bash
+scripts/worktree-session-guard claim   <PATH> --owner <ID>
+scripts/worktree-session-guard status  <PATH> --owner <ID>   # read-only probe
+scripts/worktree-session-guard release <PATH> --owner <ID>
+scripts/worktree-session-guard sweep --dry-run               # every lease past the TTL
+```
+
+**Exit codes** — `status` answers "may I work here?" by exit code alone: 0 lease for this owner, 1 path not registered, 3 unclaimed, 4 locked outside the guard, 75 claimed by a different owner. Use `status`, not `claim`, to probe: `claim` takes or rewrites the lease.
+
+**Limits, stated rather than papered over.**
+
+The lease is scoped to the OWNER string, which the workflow sets to the issue ID, so two sessions on the same issue share one lease and either may release it. What refuses a second implementer is bare `create <ID>`, which surveys worktrees, refs, and open PRs and exits 75 on existing ownership; `create --reuse|--restack` skips that refusal by design (#571), so **nothing prevents a second implementer there**. The per-issue claim lock is not that gate either — it is a repository-local flock held only inside one `create` invocation.
+
+Staleness is heartbeat age with **no liveness check**. The recorded pid and host identify who took a claim but are never consulted, so a session that is still running and has **outlived its TTL without refreshing** is indistinguishable from an abandoned one and will be unlocked by `release --stale` or `sweep`. Nothing refreshes a lease automatically and nothing runs `sweep` automatically; confirm the owner is really gone before releasing.
+
+The guard requires `flock(1)` and checks only whether it is on PATH — it is a capability, not a platform, so **wherever flock is available, the claim is mandatory**, including a macOS host whose Homebrew setup installs it. Without flock the session is unguarded rather than protected.
+
+A Git worktree lock does not block writes, commits, or rebases inside the worktree, and `git worktree remove -f -f` or a plain `rm -rf` still destroy a claimed tree — `status` and `list` exist so such a removal can be attributed afterwards.
+
+**Why the lifecycle wiring is not in yet.** Claiming on `create` and releasing only on `remove` leaves every worktree claimed for its whole life, so a lease-aware `cleanup` stops collecting merged worktrees entirely unless `--stale` is passed — a behaviour change for every consumer, not a local one. Deciding whether that is the right trade (or whether a provably-merged branch should release the lease, since the work has landed) is a policy call, so the mechanism ships first and the wiring waits on that decision.
+
 ## System Dependencies
 
 - `git`
 - authenticated `gh` for new-work PR ownership discovery
-- `flock` for repository-local per-issue claim serialization
+- `flock` for repository-local per-issue claim serialization and for the session guard
 - Bash 3.2+ (macOS system bash is supported)
 
 ## Configuration

--- a/skills/worktree/scripts/worktree-session-guard
+++ b/skills/worktree/scripts/worktree-session-guard
@@ -1,0 +1,998 @@
+#!/usr/bin/env bash
+# Ownership guard for issue worktrees (vstack#877).
+#
+# Ported from hyprtrade's tools/worktree-session-guard, which was written after
+# an incident there (CC-1000) where cleanup passes and second base directories
+# repeatedly destroyed LIVE issue worktrees — registration, local branch, and
+# uncommitted work — while sessions were still working in them. Nothing about
+# the mechanism was project-specific, and the worktree skill already documented
+# the choreography it automates, so it belongs here rather than in a copy per
+# consumer repo.
+#
+# A session that is working an issue claims the issue's worktree here. The claim
+# is recorded as a native Git worktree lock whose reason line carries the lease,
+# so cleanup that goes through Git porcelain fails closed instead of destroying
+# live work:
+#
+#   git worktree remove [--force]   refuses a locked worktree
+#   git worktree prune              never prunes a locked registration, even
+#                                   after the directory itself is gone
+#
+# Using the native lock (rather than a private marker file) is deliberate: it
+# needs no cooperation from the cleanup owner, and the vstack worktree CLI
+# already reads and reports worktree lock reasons.
+#
+# The lease is scoped to the OWNER string, which the documented workflow sets to
+# the issue ID. Two sessions working the same issue therefore share one lease:
+# either may refresh or release it, and this guard cannot tell them apart.
+#
+# What refuses a second implementer is bare `worktree create <ID>`, which
+# surveys worktrees, local and remote refs, and open PRs, and exits 75 on
+# existing ownership. The vstack per-issue claim lock is not that gate: it is a
+# repository-local flock taken and released inside one `create` invocation, so
+# it only makes that discovery race-free against a concurrent `create`. It is
+# never held for the length of a session.
+#
+# `create --reuse|--restack` skips the refusal by design (vstack#571), so
+# nothing prevents a second implementer there. Passing `--reuse` IS the
+# operator's assertion of ownership; a live sibling on the same issue has to be
+# coordinated out of band, and reuse should never be run against a worktree
+# this session did not itself claim.
+#
+# Limits, stated rather than papered over:
+#
+#   * REQUIRES flock(1). The gate is a capability, not a platform: every
+#     mutating command serializes through flock, and the code checks only
+#     whether flock is on PATH. So
+#     wherever flock is available, the claim is mandatory — including a macOS
+#     host whose Homebrew setup installs flock. On a host WITHOUT flock, claim, refresh, release and
+#     sweep all fail and that session is unguarded rather than protected.
+#     Nothing else in the repository depends on the guard, so the rest of the
+#     workflow is unaffected.
+#   * `git worktree remove -f -f` and a plain `rm -rf` still destroy a claimed
+#     worktree. `status` and `list` exist so such a removal can be attributed
+#     afterwards; `list` still reports a registration whose directory is gone.
+#   * The vstack `worktree remove` wrapper hands the INTACT tree to
+#     `git worktree remove --force`; it does not pre-strip the configured
+#     symlinks. Nothing is mutated before git runs, so when this guard's lock
+#     makes git refuse the removal, the worktree is left exactly as it was.
+#     Pre-stripping was the old behavior vstack#800 was filed about — the
+#     installed script carries the fix and cites #800 as history only, and
+#     `cleanup` took the same ordering in vstack#784. Git's deletion is not
+#     transactional, so a failure partway through can still leave the tree
+#     partially removed; repair with `worktree fix-links` run from the main
+#     checkout.
+#   * A Git worktree lock does NOT block writes, commits, or rebases inside the
+#     worktree. In particular `worktree create --reuse|--restack` skips the
+#     lock-reason refusal entirely and rebases the claimed branch. Probe with
+#     `status PATH --owner NAME` before reuse; the lock will not do it, and
+#     `claim` is not a probe because it takes or rewrites the lease. The probe
+#     catches a DIFFERENT issue's live claim; nothing prevents a second
+#     implementer there on the same issue.
+#   * `git branch -D` refusal is a property of the branch being checked out in
+#     any registered worktree, not of the lock. The claim's contribution is
+#     keeping the registration alive so that refusal keeps applying.
+#   * Nothing refreshes a lease automatically. `--ttl-minutes` is therefore age
+#     since the last explicit `claim`/`refresh`, and the default must exceed the
+#     longest expected session. Nothing runs `sweep` automatically either, so a
+#     lease past its TTL is released only when an operator asks.
+#   * Staleness is heartbeat age with NO liveness check, so a still-running
+#     session that outlived its TTL without refreshing is indistinguishable
+#     from an abandoned one and will be unlocked by `release --stale` or
+#     `sweep`. Confirm the owner is really gone before releasing.
+
+set -euo pipefail
+
+GUARD_MARKER='vstack-session-guard'
+GUARD_VERSION='v1'
+DEFAULT_TTL_MINUTES=720
+
+EXIT_USAGE=1
+EXIT_NO_LEASE=3
+EXIT_UNMANAGED=4
+EXIT_ENUMERATION=5
+EXIT_OWNED=75
+
+usage() {
+	cat <<'EOF'
+Usage: worktree-session-guard <command> [PATH] [options]
+
+Commands:
+  claim PATH        Claim the worktree for this issue (idempotent for the same
+                    owner, which refreshes the heartbeat in place).
+  refresh PATH      Extend the lease's heartbeat without ever unlocking.
+  release PATH      Release the lease so cleanup may proceed.
+  status PATH       Print the worktree's lock state as JSON. With --owner, the
+                    exit code alone answers "may I work here?" — this is the
+                    read-only ownership probe; `claim` is not, because it takes
+                    or rewrites the lease.
+  list              Print one JSON object per linked worktree of the repository,
+                    including registrations whose directory no longer exists.
+                    The main checkout is never listed.
+  sweep             Release EVERY guard lease of the repository past the TTL.
+                    To recover one abandoned worktree, prefer
+                    `release PATH --stale --owner NAME`; run sweep --dry-run
+                    first, since its blast radius is every lease past the TTL.
+
+PATH is the root of a linked worktree; the main checkout is refused. `release`
+and `status` also accept a worktree whose directory has already been destroyed,
+resolving it through the repository registration instead.
+
+Options:
+  --owner NAME       Lease owner; the workflow sets this to the issue ID
+                     (default: $VSTACK_SESSION_OWNER, else $HT_SESSION_OWNER,
+                     else $USER). Allowed characters: A-Z a-z 0-9 . _ : @ + -
+                     Applies to: claim, refresh, release, status. status
+                     compares owners when --owner is passed OR
+                     a session-owner env var is set, and never falls back to $USER;
+                     with neither it says on stderr that it compared nothing.
+  --ttl-minutes N    Staleness horizon, in minutes since the lease's last claim
+                     or refresh (default: 720, at most 10 digits). Applies to:
+                     release, sweep.
+  --stale            release: also accept a foreign lease past the TTL.
+  --force            release: accept a foreign lease regardless of age.
+  --dry-run          sweep: report what would be released, release nothing.
+  --repo DIR         Any checkout of the target repository (default: current
+                     directory). Applies to: release, status, list, sweep;
+                     needed for release/status when PATH no longer exists.
+
+Staleness is heartbeat age and nothing else. The recorded pid and host identify
+who took a claim but are never consulted, so there is NO liveness check: a
+session that is still running and has outlived its TTL without refreshing WILL
+be treated as abandoned, and `release --stale` or `sweep` will unlock it.
+Nothing refreshes a lease automatically, so run `refresh` if a session will
+outlive the TTL, raise the TTL, or confirm the owner is really gone before
+releasing.
+
+Exit codes:
+  0  success (status: a guard lease is present, and is yours if --owner was
+     given)
+  1  usage, precondition, or Git failure
+  3  status: the worktree carries no lock at all
+  4  status: the worktree is locked outside this guard
+     sweep: a guard lease was left in place because it is unreadable
+  5  list/sweep: the repository's worktrees could not be enumerated, so
+     nothing was examined (never reported as a clean repository)
+ 75  the worktree is claimed by a different owner (claim, refresh, release,
+     status --owner); or is locked outside this guard (claim, refresh,
+     release; status reports that as 4); or, for release --stale, the lease is
+     not yet past the TTL (any owner)
+EOF
+}
+
+fail() {
+	printf 'worktree-session-guard: %s\n' "$1" >&2
+	exit "$EXIT_USAGE"
+}
+
+warn() {
+	printf 'worktree-session-guard: WARN: %s\n' "$1" >&2
+}
+
+now_epoch() { date -u +%s; }
+
+# GNU and BSD date disagree on how to format an epoch. Try GNU first, then BSD,
+# and fail closed rather than writing a lease with an empty timestamp.
+iso_from_epoch() {
+	local epoch="$1" formatted=''
+	formatted="$(date -u -d "@$epoch" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)"
+	if [[ -z "$formatted" ]]; then
+		formatted="$(date -u -r "$epoch" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)"
+	fi
+	[[ -n "$formatted" ]] || fail "no usable date(1): cannot format epoch $epoch"
+	printf '%s\n' "$formatted"
+}
+
+# Canonicalize an existing directory without depending on GNU realpath.
+canonical_dir() {
+	local path="$1"
+	[[ -d "$path" ]] || return 1
+	(cd -P -- "$path" && pwd -P)
+}
+
+# Lexical absolute path, for a worktree whose directory no longer exists and
+# therefore cannot be canonicalized by entering it.
+normalize_abs_path() {
+	local path="$1" out='' part
+	local -a parts=()
+	[[ "$path" == /* ]] || path="$PWD/$path"
+	IFS='/' read -r -a parts <<<"$path"
+	for part in ${parts[@]+"${parts[@]}"}; do
+		case "$part" in
+		'' | '.') continue ;;
+		'..') out="${out%/*}" ;;
+		*) out="$out/$part" ;;
+		esac
+	done
+	printf '%s\n' "${out:-/}"
+}
+
+sanitize_owner() {
+	local owner="$1"
+	[[ -n "$owner" ]] || fail "owner must not be empty; pass --owner or set VSTACK_SESSION_OWNER"
+	[[ ${#owner} -le 64 ]] || fail "owner must be at most 64 characters: $owner"
+	[[ "$owner" =~ ^[A-Za-z0-9._:@+-]+$ ]] \
+		|| fail "owner may only contain A-Z a-z 0-9 . _ : @ + - (got: $owner)"
+	printf '%s\n' "$owner"
+}
+
+# Host is diagnostic only, so coerce it into the lease charset instead of
+# failing a claim on an unusual hostname.
+sanitize_host() {
+	local host="${HOSTNAME:-}"
+	[[ -n "$host" ]] || host="$(uname -n 2>/dev/null || true)"
+	[[ -n "$host" ]] || host="unknown-host"
+	host="${host//[^A-Za-z0-9._:@+-]/-}"
+	printf '%s\n' "$host"
+}
+
+# Two ways a TTL can make the staleness comparison lie, both rejected here:
+# a leading zero makes bash read the value as octal and abort the expression
+# mid-evaluation, and a value large enough to overflow signed 64-bit arithmetic
+# makes the most conservative-looking TTL release every lease. Ten digits is
+# roughly 19,000 years. The comparison itself is minutes-to-minutes, so no
+# multiplication can overflow either.
+require_ttl_minutes() {
+	local value="$1"
+	[[ "$value" =~ ^(0|[1-9][0-9]*)$ ]] \
+		|| fail "--ttl-minutes must be a non-negative integer without leading zeros: $value"
+	[[ ${#value} -le 10 ]] \
+		|| fail "--ttl-minutes must be at most 10 digits: $value"
+}
+
+resolve_repo() {
+	local requested="$1" resolved
+	resolved="$(canonical_dir "$requested")" || fail "not a directory: $requested"
+	git -C "$resolved" rev-parse --git-dir >/dev/null 2>&1 \
+		|| fail "not inside a Git repository: $resolved"
+	printf '%s\n' "$resolved"
+}
+
+common_dir_of() {
+	git -C "$1" rev-parse --path-format=absolute --git-common-dir
+}
+
+# Print the registration directory ($GIT_COMMON_DIR/worktrees/<id>) for a
+# worktree path. Works whether or not the worktree directory still exists,
+# which is what makes a destroyed worktree recoverable instead of a wedge.
+# The worktree root a registration points at. Git records an absolute gitdir by
+# default, but a RELATIVE one under `worktree add --relative-paths` or
+# worktree.useRelativePaths (Git >= 2.48) — resolved against the registration
+# directory, not the repository root.
+registration_worktree_path() {
+	local entry="$1" recorded
+	[[ -f "$entry/gitdir" ]] || return 1
+	recorded="$(head -n 1 -- "$entry/gitdir")"
+	[[ -n "$recorded" ]] || return 1
+	[[ "$recorded" == /* ]] || recorded="$(normalize_abs_path "$entry/$recorded")"
+	printf '%s\n' "${recorded%/.git}"
+}
+
+registration_dir_for() {
+	local repo="$1" target="$2" common_dir entry recorded canonical
+	common_dir="$(common_dir_of "$repo")"
+	[[ -d "$common_dir/worktrees" ]] || return 1
+	for entry in "$common_dir"/worktrees/*; do
+		recorded="$(registration_worktree_path "$entry" || true)"
+		[[ -n "$recorded" ]] || continue
+		if [[ "$recorded" == "$target" ]]; then
+			printf '%s\n' "$entry"
+			return 0
+		fi
+		# The registry can hold a symlinked spelling of a path the caller gave
+		# canonically (or vice versa); compare both ways before giving up.
+		if canonical="$(canonical_dir "$recorded")" && [[ "$canonical" == "$target" ]]; then
+			printf '%s\n' "$entry"
+			return 0
+		fi
+	done
+	return 1
+}
+
+# Registered worktree paths, for a diagnostic that names the spelling the
+# caller should have used instead of only echoing the one that failed.
+registered_worktree_spellings() {
+	local repo="$1" common_dir entry recorded
+	common_dir="$(common_dir_of "$repo")"
+	[[ -d "$common_dir/worktrees" ]] || return 0
+	for entry in "$common_dir"/worktrees/*; do
+		recorded="$(registration_worktree_path "$entry" || true)"
+		[[ -n "$recorded" ]] || continue
+		printf '  %s\n' "$recorded"
+	done
+}
+
+# Resolve PATH to a linked worktree of REPO, refusing the main checkout and a
+# subdirectory of a worktree. Sets RESOLVED_WORKTREE and RESOLVED_REGISTRATION
+# (globals rather than a printed pair, so a path containing spaces survives).
+#
+# require_present=true is used by claim/refresh, which cannot operate on a
+# worktree that is not there. release/status pass false so a lease left behind
+# by a destroyed worktree can still be inspected and cleared.
+resolve_worktree() {
+	local repo="$1" requested="$2" require_present="$3"
+	local resolved git_dir common_dir top registration searched spellings
+
+	if resolved="$(canonical_dir "$requested")"; then
+		git_dir="$(git -C "$resolved" rev-parse --path-format=absolute --git-dir 2>/dev/null)" \
+			|| fail "not inside a Git repository: $resolved"
+		common_dir="$(git -C "$resolved" rev-parse --path-format=absolute --git-common-dir)"
+		[[ "$git_dir" != "$common_dir" ]] \
+			|| fail "refusing the main checkout; only linked worktrees are guarded: $resolved"
+		top="$(git -C "$resolved" rev-parse --path-format=absolute --show-toplevel)"
+		top="$(canonical_dir "$top")" || fail "worktree root is unreadable: $top"
+		[[ "$top" == "$resolved" ]] || fail "not a worktree root: $resolved (use $top)"
+	else
+		[[ "$require_present" != true ]] || fail "not a directory: $requested"
+		resolved="$(normalize_abs_path "$requested")"
+	fi
+
+	registration="$(registration_dir_for "$repo" "$resolved" || true)"
+	if [[ -z "$registration" ]]; then
+		# Name the repository that was actually searched. Without --repo it is
+		# derived from the target, so echoing that back would print the same
+		# path on both sides of the message and tell the reader nothing.
+		searched="$(common_dir_of "$repo")"
+		spellings="$(registered_worktree_spellings "$repo")"
+		printf 'worktree-session-guard: not a registered worktree of the repository at %s: %s\n' \
+			"$searched" "$resolved" >&2
+		if [[ ! -d "$resolved" ]]; then
+			printf 'That directory is gone, so the path could not be canonicalized; it must be given exactly as registered.\n' >&2
+		fi
+		if [[ -z "$spellings" ]]; then
+			printf 'That repository has no linked worktrees. Pass --repo DIR naming a checkout of the repository that registered this worktree.\n' >&2
+		else
+			printf 'Pass --repo DIR to search a different repository. Registered worktrees:\n' >&2
+			printf '%s\n' "$spellings" >&2
+		fi
+		exit "$EXIT_USAGE"
+	fi
+	RESOLVED_WORKTREE="$resolved"
+	RESOLVED_REGISTRATION="$registration"
+}
+
+# Serialize claim/refresh/release/sweep. The lock file lives in the shared
+# common dir, so one acquisition covers every worktree of the repository — a
+# sweep must take it ONCE around its whole loop, never per iteration, or it
+# drops the mutex between worktrees.
+acquire_guard_lock() {
+	local repo="$1" common_dir lock_path
+	command -v flock >/dev/null 2>&1 \
+		|| fail "this guard requires flock(1) to serialize mutations and it is not on PATH, so this worktree is unguarded rather than guarded-and-failing. Install flock to enable the guard on this host."
+	common_dir="$(common_dir_of "$repo")"
+	lock_path="$common_dir/ht-worktree-session-guard.lock"
+	exec 9>"$lock_path" || fail "cannot open the session-guard lock file: $lock_path"
+	flock -x 9 || fail "cannot acquire the session-guard lock: $lock_path"
+}
+
+# Lock states, distinguished because "locked with no reason" (a plain
+# `git worktree lock`) must not be reported as "not locked at all".
+LOCK_STATE_NONE=none
+LOCK_STATE_EMPTY=empty
+LOCK_STATE_REASON=reason
+
+# Sets LEASE_STATE and LEASE_TEXT for a registration directory.
+read_lease() {
+	local lock_file="$1/locked"
+	LEASE_TEXT=''
+	if [[ ! -f "$lock_file" ]]; then
+		LEASE_STATE="$LOCK_STATE_NONE"
+		return 0
+	fi
+	LEASE_TEXT="$(head -n 1 -- "$lock_file" 2>/dev/null || true)"
+	if [[ -z "$LEASE_TEXT" ]]; then
+		LEASE_STATE="$LOCK_STATE_EMPTY"
+	else
+		LEASE_STATE="$LOCK_STATE_REASON"
+	fi
+}
+
+# A lease is ours only at the exact marker AND version. Matching the marker
+# alone would adopt a future version's lock — or a hand-written one that merely
+# starts with the marker — and `release --force` would then unlock it, breaking
+# the documented promise never to touch a lock taken outside this guard.
+#
+# The bare-version form is accepted so a v1 lease truncated to nothing but its
+# prefix stays recoverable through the usual quarantine path rather than
+# becoming an unreleasable foreign lock.
+lease_is_ours() {
+	case "$1" in
+	"$GUARD_MARKER $GUARD_VERSION" | "$GUARD_MARKER $GUARD_VERSION "*) return 0 ;;
+	esac
+	return 1
+}
+
+# True when the registration currently carries a guard lease.
+lease_is_managed() {
+	[[ "$LEASE_STATE" == "$LOCK_STATE_REASON" ]] || return 1
+	lease_is_ours "$LEASE_TEXT"
+}
+
+lease_field() {
+	local lease="$1" key="$2" rest
+	rest="${lease#* $key=}"
+	[[ "$rest" != "$lease" ]] || return 1
+	printf '%s\n' "${rest%% *}"
+}
+
+# Human-readable description of whatever holds the lock, for refusal and
+# displacement messages. Never ends at a bare colon.
+lease_description() {
+	local state="$1" text="$2"
+	case "$state" in
+	"$LOCK_STATE_EMPTY") printf '(locked with no reason recorded)\n' ;;
+	"$LOCK_STATE_REASON") printf '%s\n' "$text" ;;
+	*) printf '(no lock)\n' ;;
+	esac
+}
+
+lease_line() {
+	local owner="$1" host="$2" claimed_epoch="$3" heartbeat_epoch="$4"
+	local claimed_iso heartbeat_iso
+	claimed_iso="$(iso_from_epoch "$claimed_epoch")"
+	heartbeat_iso="$(iso_from_epoch "$heartbeat_epoch")"
+	printf '%s %s owner=%s pid=%s host=%s claimed=%s claimed_epoch=%s heartbeat=%s heartbeat_epoch=%s' \
+		"$GUARD_MARKER" "$GUARD_VERSION" "$owner" "$$" "$host" \
+		"$claimed_iso" "$claimed_epoch" "$heartbeat_iso" "$heartbeat_epoch"
+}
+
+# An epoch the guard did not write is not trusted arithmetic input: past int64
+# the subtraction wraps and about half the wrapped range reads as an enormous
+# age, which would release the lease the tool means to quarantine. The digit
+# cap matches --ttl-minutes, but the units differ: ten digits of SECONDS reach
+# year 2286, where ten digits of minutes reach far further.
+epoch_is_sane() {
+	[[ "$1" =~ ^(0|[1-9][0-9]*)$ ]] || return 1
+	[[ ${#1} -le 10 ]] || return 1
+}
+
+lease_age_seconds() {
+	local lease="$1" now="$2" heartbeat_epoch
+	heartbeat_epoch="$(lease_field "$lease" heartbeat_epoch || true)"
+	epoch_is_sane "$heartbeat_epoch" || return 1
+	printf '%s\n' "$((now - 10#$heartbeat_epoch))"
+}
+
+# Rewrite the lock reason in place. The worktree is never unlocked, because an
+# unlock/relock cycle would open exactly the window this guard exists to close.
+# Shared by claim's same-owner branch and refresh, so the lease format has one
+# writer.
+rewrite_lease() {
+	local registration="$1" owner="$2" existing="$3" now="$4"
+	local lock_file="$1/locked" tmp_file lease claimed_epoch
+
+	[[ -f "$lock_file" ]] || fail "worktree is not locked: $registration"
+	# A corrupted claim time is replaced rather than carried forward, so it
+	# cannot reach iso_from_epoch and abort the refresh with a date(1) error.
+	claimed_epoch="$(lease_field "$existing" claimed_epoch || true)"
+	epoch_is_sane "$claimed_epoch" || claimed_epoch="$now"
+	lease="$(lease_line "$owner" "$(sanitize_host)" "$claimed_epoch" "$now")"
+
+	tmp_file="$lock_file.ht-tmp.$$"
+	printf '%s\n' "$lease" >"$tmp_file" || {
+		rm -f -- "$tmp_file"
+		fail "failed to stage the session lease for $registration"
+	}
+	mv -f -- "$tmp_file" "$lock_file" || {
+		rm -f -- "$tmp_file"
+		fail "failed to update the session lease for $registration"
+	}
+}
+
+# Control characters are escaped, never deleted. This output is the documented
+# attribution mechanism after a removal, so a path or lock reason that comes
+# back altered is worse than one that comes back obviously broken. Escaping a
+# newline also keeps `list` at one JSON object per line.
+#
+# A NUL byte cannot reach here: bash strings are NUL-terminated, so the shell
+# drops one at assignment long before this.
+json_escape() {
+	local value="$1" out char rest code
+	value="${value//\\/\\\\}"
+	value="${value//\"/\\\"}"
+	value="${value//$'\b'/\\b}"
+	value="${value//$'\f'/\\f}"
+	value="${value//$'\n'/\\n}"
+	value="${value//$'\r'/\\r}"
+	value="${value//$'\t'/\\t}"
+	# Whatever remains has no short form, so spell it \u00xx. Guarded because
+	# the character-at-a-time rewrite is only needed for the rare input.
+	if [[ "$value" != "${value//[[:cntrl:]]/}" ]]; then
+		out=''
+		rest="$value"
+		while [[ -n "$rest" ]]; do
+			char="${rest:0:1}"
+			rest="${rest:1}"
+			printf -v code '%d' "'$char"
+			if ((code < 32)); then
+				printf -v char '\\u%04x' "$code"
+			fi
+			out+="$char"
+		done
+		value="$out"
+	fi
+	printf '%s\n' "$value"
+}
+
+# One JSON object per worktree. `locked` is true for ANY worktree lock;
+# `managed` is true only when that lock is a guard lease. The two are
+# deliberately independent, so a foreign lock is never byte-identical to an
+# unlocked worktree.
+emit_status_json() {
+	local worktree="$1" state="$2" lease="$3" now="$4" present="$5"
+	local locked=false managed=false
+	local owner='' pid='' host='' claimed_at='' heartbeat_at='' age=-1
+
+	[[ "$state" == "$LOCK_STATE_NONE" ]] || locked=true
+	if [[ "$state" == "$LOCK_STATE_REASON" ]] && lease_is_ours "$lease"; then
+		managed=true
+		owner="$(lease_field "$lease" owner || true)"
+		pid="$(lease_field "$lease" pid || true)"
+		host="$(lease_field "$lease" host || true)"
+		claimed_at="$(lease_field "$lease" claimed || true)"
+		heartbeat_at="$(lease_field "$lease" heartbeat || true)"
+		age="$(lease_age_seconds "$lease" "$now" || printf '%s' -1)"
+	fi
+
+	printf '{"path":"%s","directory_present":%s,"locked":%s,"managed":%s,"owner":"%s","pid":"%s","host":"%s","claimed_at":"%s","heartbeat_at":"%s","heartbeat_age_seconds":%s,"lock_reason":"%s"}\n' \
+		"$(json_escape "$worktree")" "$present" "$locked" "$managed" \
+		"$(json_escape "$owner")" "$(json_escape "$pid")" "$(json_escape "$host")" \
+		"$(json_escape "$claimed_at")" "$(json_escape "$heartbeat_at")" \
+		"$age" "$(json_escape "$lease")"
+}
+
+# Paths of every linked worktree of REPO, main checkout excluded. Driven by
+# `git worktree list --porcelain`, which still reports a registration whose
+# directory has been destroyed — the case this tool most needs to see.
+#
+# The enumeration is captured in the caller's shell, not consumed through a
+# process substitution: a substitution discards Git's exit status, and a sweep
+# that could not enumerate anything would then report a clean repository. That
+# is the worst failure mode available to a recovery command.
+linked_worktree_paths() {
+	local repo="$1" porcelain line path
+	porcelain="$(git -C "$repo" worktree list --porcelain)" || return 1
+	while IFS= read -r line; do
+		case "$line" in
+		'worktree '*) path="${line#worktree }" ;;
+		*) continue ;;
+		esac
+		if registration_dir_for "$repo" "$path" >/dev/null; then
+			printf '%s\n' "$path"
+		fi
+	done <<<"$porcelain"
+}
+
+# Enumerate into a newline-delimited list, failing closed with a diagnostic
+# that names the repository whose worktrees could not be listed.
+enumerate_or_fail() {
+	local repo="$1" command="$2" listing
+	if ! listing="$(linked_worktree_paths "$repo")"; then
+		printf 'worktree-session-guard: %s could not enumerate the worktrees of %s; nothing was examined\n' \
+			"$command" "$repo" >&2
+		exit "$EXIT_ENUMERATION"
+	fi
+	printf '%s' "$listing"
+}
+
+unlock_worktree() {
+	local repo="$1" worktree="$2"
+	git -C "$repo" worktree unlock "$worktree" \
+		|| fail "failed to unlock worktree: $worktree"
+}
+
+lease_identity() {
+	local lease="$1" owner pid host heartbeat
+	owner="$(lease_field "$lease" owner || printf unknown)"
+	pid="$(lease_field "$lease" pid || printf unknown)"
+	host="$(lease_field "$lease" host || printf unknown)"
+	heartbeat="$(lease_field "$lease" heartbeat || printf unknown)"
+	printf 'owner=%s pid=%s host=%s heartbeat=%s\n' "$owner" "$pid" "$host" "$heartbeat"
+}
+
+# Describe the lease about to be destroyed, so displacing another owner's claim
+# leaves a trace after the lease itself is gone.
+warn_displaced_lease() {
+	local worktree="$1" lease="$2" age="$3"
+	warn "displacing lease on $worktree: $(lease_identity "$lease") age=${age:-unknown}"
+}
+
+# The same record for an ordinary same-owner release. It is not a displacement
+# — releasing your own lease is the expected end of a session — but an owner
+# match only proves the same issue, so the released lease is still recorded
+# rather than vanishing silently.
+note_released_lease() {
+	local worktree="$1" lease="$2"
+	printf 'worktree-session-guard: releasing lease on %s: %s\n' \
+		"$worktree" "$(lease_identity "$lease")" >&2
+}
+
+# The single canonical stale-release sequence, shared by `sweep` and
+# `release --stale`. The caller must already hold the guard lock; the lease is
+# re-read HERE, under that lock, so a claim or refresh that landed after an
+# earlier read cannot be discarded.
+#
+# Returns: 0 released (or would release, when dry_run), 10 lease is still live,
+# 11 no guard lease to release, 12 lease heartbeat unusable (unreadable, out of
+# range, or dated in the future).
+release_lease_if_stale() {
+	local repo="$1" worktree="$2" registration="$3" ttl_minutes="$4" dry_run="$5"
+	local now age
+
+	read_lease "$registration"
+	lease_is_managed || return 11
+
+	now="$(now_epoch)"
+	age="$(lease_age_seconds "$LEASE_TEXT" "$now")" || return 12
+	# A heartbeat in the future cannot be aged against, and bash division
+	# truncates toward zero, so -59s would read as 0 minutes old and satisfy
+	# --ttl-minutes 0. Treat it as untrustworthy and quarantine it instead.
+	((age >= 0)) || return 12
+	# Minutes against minutes: multiplying the TTL out to seconds is what let a
+	# huge --ttl-minutes wrap negative and mark every lease stale.
+	((age / 60 >= 10#$ttl_minutes)) || return 10
+
+	if [[ "$dry_run" == true ]]; then
+		printf 'would release %s (heartbeat %ss old)\n' "$worktree" "$age"
+		return 0
+	fi
+	warn_displaced_lease "$worktree" "$LEASE_TEXT" "${age}s"
+	unlock_worktree "$repo" "$worktree"
+	printf 'released %s (heartbeat %ss old)\n' "$worktree" "$age"
+}
+
+cmd_claim() {
+	local repo="$1" target="$2" owner="$3"
+	local worktree registration now lease existing_owner
+
+	resolve_worktree "$repo" "$target" true
+	worktree="$RESOLVED_WORKTREE"
+	registration="$RESOLVED_REGISTRATION"
+	acquire_guard_lock "$repo"
+	now="$(now_epoch)"
+
+	read_lease "$registration"
+	if [[ "$LEASE_STATE" != "$LOCK_STATE_NONE" ]]; then
+		if ! lease_is_managed; then
+			printf 'worktree-session-guard: %s is locked outside this guard: %s\n' \
+				"$worktree" "$(lease_description "$LEASE_STATE" "$LEASE_TEXT")" >&2
+			printf 'Resolve the existing lock before claiming it.\n' >&2
+			exit "$EXIT_OWNED"
+		fi
+		existing_owner="$(lease_field "$LEASE_TEXT" owner || true)"
+		if [[ "$existing_owner" != "$owner" ]]; then
+			printf 'worktree-session-guard: %s is claimed by owner=%s: %s\n' \
+				"$worktree" "${existing_owner:-unknown}" "$LEASE_TEXT" >&2
+			printf 'Use a different worktree, or release a stale lease with: tools/worktree-session-guard release %s --stale\n' \
+				"$worktree" >&2
+			exit "$EXIT_OWNED"
+		fi
+		rewrite_lease "$registration" "$owner" "$LEASE_TEXT" "$now"
+		printf 'refreshed %s\n' "$worktree"
+		return 0
+	fi
+
+	lease="$(lease_line "$owner" "$(sanitize_host)" "$now" "$now")"
+	git -C "$repo" worktree lock --reason "$lease" "$worktree" \
+		|| fail "failed to lock worktree: $worktree"
+	printf 'claimed %s\n' "$worktree"
+}
+
+cmd_refresh() {
+	local repo="$1" target="$2" owner="$3"
+	local worktree registration now existing_owner
+
+	resolve_worktree "$repo" "$target" true
+	worktree="$RESOLVED_WORKTREE"
+	registration="$RESOLVED_REGISTRATION"
+	acquire_guard_lock "$repo"
+	now="$(now_epoch)"
+
+	read_lease "$registration"
+	[[ "$LEASE_STATE" != "$LOCK_STATE_NONE" ]] \
+		|| fail "no session claim to refresh on $worktree; run claim first"
+
+	if ! lease_is_managed; then
+		printf 'worktree-session-guard: %s is locked outside this guard: %s\n' \
+			"$worktree" "$(lease_description "$LEASE_STATE" "$LEASE_TEXT")" >&2
+		exit "$EXIT_OWNED"
+	fi
+	existing_owner="$(lease_field "$LEASE_TEXT" owner || true)"
+	if [[ "$existing_owner" != "$owner" ]]; then
+		printf 'worktree-session-guard: %s is claimed by owner=%s, not %s\n' \
+			"$worktree" "${existing_owner:-unknown}" "$owner" >&2
+		exit "$EXIT_OWNED"
+	fi
+
+	rewrite_lease "$registration" "$owner" "$LEASE_TEXT" "$now"
+	printf 'refreshed %s\n' "$worktree"
+}
+
+cmd_release() {
+	local repo="$1" target="$2" owner="$3" ttl_minutes="$4" allow_stale="$5" force="$6"
+	local worktree registration existing_owner age now rc=0
+
+	resolve_worktree "$repo" "$target" false
+	worktree="$RESOLVED_WORKTREE"
+	registration="$RESOLVED_REGISTRATION"
+	acquire_guard_lock "$repo"
+
+	read_lease "$registration"
+	if [[ "$LEASE_STATE" == "$LOCK_STATE_NONE" ]]; then
+		printf 'already released %s\n' "$worktree"
+		return 0
+	fi
+	if ! lease_is_managed; then
+		# Same condition claim and refresh report, so the same exit code: a
+		# caller branching on 75 must not see this as a usage error.
+		printf 'worktree-session-guard: %s is locked outside this guard; refusing to unlock: %s\n' \
+			"$worktree" "$(lease_description "$LEASE_STATE" "$LEASE_TEXT")" >&2
+		exit "$EXIT_OWNED"
+	fi
+
+	existing_owner="$(lease_field "$LEASE_TEXT" owner || true)"
+	if [[ "$existing_owner" == "$owner" && "$allow_stale" != true ]]; then
+		# The ordinary "I am done here" release, e.g. orch at merge time. The
+		# lease is recorded before it is destroyed: an owner match only proves
+		# the same ISSUE, so this may be a sibling session's live claim.
+		note_released_lease "$worktree" "$LEASE_TEXT"
+		unlock_worktree "$repo" "$worktree"
+		printf 'released %s\n' "$worktree"
+		return 0
+	fi
+
+	if [[ "$force" == true ]]; then
+		now="$(now_epoch)"
+		age="$(lease_age_seconds "$LEASE_TEXT" "$now" || true)"
+		warn_displaced_lease "$worktree" "$LEASE_TEXT" "${age:+${age}s}"
+		unlock_worktree "$repo" "$worktree"
+		printf 'released %s\n' "$worktree"
+		return 0
+	fi
+
+	if [[ "$allow_stale" != true ]]; then
+		printf 'worktree-session-guard: %s is claimed by owner=%s, not %s: %s\n' \
+			"$worktree" "${existing_owner:-unknown}" "$owner" "$LEASE_TEXT" >&2
+		exit "$EXIT_OWNED"
+	fi
+
+	# --stale means the same thing whoever owns the lease: release it only if
+	# its heartbeat is past the TTL. Exempting the owner match would make the
+	# flag dead exactly where the recovery procedure relies on it, because the
+	# lease is keyed to the issue and a sibling session matches it.
+	release_lease_if_stale "$repo" "$worktree" "$registration" "$ttl_minutes" false || rc=$?
+	case "$rc" in
+	0) return 0 ;;
+	10)
+		printf 'worktree-session-guard: %s is claimed by owner=%s and is not stale (ttl %sm)\n' \
+			"$worktree" "${existing_owner:-unknown}" "$ttl_minutes" >&2
+		exit "$EXIT_OWNED"
+		;;
+	12) fail "lease on $worktree has an unusable heartbeat (unreadable, out of range, or dated in the future); recover with: tools/worktree-session-guard release $worktree --force" ;;
+	*) fail "lease on $worktree changed while releasing it; re-run release" ;;
+	esac
+}
+
+# The read-only ownership probe. With --owner it answers "may I work here?" in
+# the exit code alone, which is what the reuse guidance depends on; `claim`
+# cannot serve that purpose because it takes or rewrites the lease.
+cmd_status() {
+	local repo="$1" target="$2" owner="$3"
+	local worktree registration now present=true existing_owner
+	resolve_worktree "$repo" "$target" false
+	worktree="$RESOLVED_WORKTREE"
+	registration="$RESOLVED_REGISTRATION"
+	[[ -d "$worktree" ]] || present=false
+	now="$(now_epoch)"
+	read_lease "$registration"
+	emit_status_json "$worktree" "$LEASE_STATE" "$LEASE_TEXT" "$now" "$present"
+
+	if [[ "$LEASE_STATE" == "$LOCK_STATE_NONE" ]]; then
+		return "$EXIT_NO_LEASE"
+	fi
+	if ! lease_is_managed; then
+		return "$EXIT_UNMANAGED"
+	fi
+	if [[ -z "$owner" ]]; then
+		# Exit 0 here means only "a guard lease exists", so say so rather than
+		# letting a caller read it as "this worktree is mine".
+		printf 'worktree-session-guard: no ownership comparison performed (pass --owner or set VSTACK_SESSION_OWNER); a guard lease exists on %s\n' \
+			"$worktree" >&2
+		return 0
+	fi
+	existing_owner="$(lease_field "$LEASE_TEXT" owner || true)"
+	if [[ "$existing_owner" != "$owner" ]]; then
+		printf 'worktree-session-guard: %s is claimed by owner=%s, not %s\n' \
+			"$worktree" "${existing_owner:-unknown}" "$owner" >&2
+		return "$EXIT_OWNED"
+	fi
+	return 0
+}
+
+cmd_list() {
+	local repo="$1" now path registration present listing
+	now="$(now_epoch)"
+	listing="$(enumerate_or_fail "$repo" list)"
+	[[ -n "$listing" ]] || return 0
+	while IFS= read -r path; do
+		[[ -n "$path" ]] || continue
+		registration="$(registration_dir_for "$repo" "$path" || true)"
+		[[ -n "$registration" ]] || continue
+		present=true
+		[[ -d "$path" ]] || present=false
+		read_lease "$registration"
+		emit_status_json "$path" "$LEASE_STATE" "$LEASE_TEXT" "$now" "$present"
+	done <<<"$listing"
+}
+
+# Releasing an abandoned lease is the safety valve that keeps this guard from
+# permanently wedging cleanup — including for a worktree whose directory was
+# destroyed, which is the incident this guard exists for. It only ever touches
+# guard-owned leases past the TTL; a foreign lock and a live lease are left
+# exactly as they are.
+cmd_sweep() {
+	local repo="$1" ttl_minutes="$2" dry_run="$3"
+	local path registration released=0 unreadable=0 rc listing
+
+	# Once, around the whole loop: the lock file is per-repository, so
+	# re-acquiring it per worktree would drop the mutex between iterations.
+	acquire_guard_lock "$repo"
+
+	# Enumerate before claiming anything about the repository's state: an
+	# enumeration failure must not be reported as "no stale session claims".
+	listing="$(enumerate_or_fail "$repo" sweep)"
+
+	while IFS= read -r path; do
+		[[ -n "$path" ]] || continue
+		registration="$(registration_dir_for "$repo" "$path" || true)"
+		[[ -n "$registration" ]] || continue
+		rc=0
+		release_lease_if_stale "$repo" "$path" "$registration" "$ttl_minutes" "$dry_run" || rc=$?
+		case "$rc" in
+		0) released=$((released + 1)) ;;
+		12)
+			unreadable=$((unreadable + 1))
+			warn "lease on $path has an unusable heartbeat (unreadable, out of range, or dated in the future) and was left in place; recover with: tools/worktree-session-guard release $path --force"
+			;;
+		esac
+	done <<<"$listing"
+
+	# A dry run mutates nothing, so its summary must never say anything was
+	# released — an operator reading "released" while deciding what to recover
+	# would be reading a mutation that did not happen.
+	if [[ "$unreadable" -gt 0 ]]; then
+		if [[ "$dry_run" == true ]]; then
+			printf '%s stale session claim(s) would be released; %s unusable lease(s) left in place\n' \
+				"$released" "$unreadable"
+		else
+			printf '%s stale session claim(s) released; %s unusable lease(s) left in place\n' \
+				"$released" "$unreadable"
+		fi
+		return "$EXIT_UNMANAGED"
+	fi
+	[[ "$released" -gt 0 ]] || printf 'no stale session claims\n'
+}
+
+# Reject an option the selected command does not act on, rather than accepting
+# it and doing something other than what the caller asked.
+require_flag_applies() {
+	local flag="$1" command="$2" applicable="$3"
+	case " $applicable " in
+	*" $command "*) return 0 ;;
+	esac
+	fail "$flag does not apply to $command (applies to: $applicable)"
+}
+
+main() {
+	local command="${1:-}"
+	case "$command" in
+	-h | --help | '')
+		usage
+		exit 0
+		;;
+	claim | refresh | release | status | list | sweep) shift ;;
+	*)
+		printf 'Unknown command: %s\n' "$command" >&2
+		usage >&2
+		exit "$EXIT_USAGE"
+		;;
+	esac
+
+	local target='' repo='' owner="${VSTACK_SESSION_OWNER:-${HT_SESSION_OWNER:-${USER:-}}}"
+	local ttl_minutes="$DEFAULT_TTL_MINUTES"
+	local allow_stale=false force=false dry_run=false owner_explicit=false
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--owner)
+			[[ $# -ge 2 ]] || fail "--owner requires a value"
+			require_flag_applies --owner "$command" "claim refresh release status"
+			owner="$2"
+			owner_explicit=true
+			shift 2
+			;;
+		--ttl-minutes)
+			[[ $# -ge 2 ]] || fail "--ttl-minutes requires a value"
+			require_flag_applies --ttl-minutes "$command" "release sweep"
+			require_ttl_minutes "$2"
+			ttl_minutes="$2"
+			shift 2
+			;;
+		--repo)
+			[[ $# -ge 2 ]] || fail "--repo requires a value"
+			require_flag_applies --repo "$command" "release status list sweep"
+			repo="$2"
+			shift 2
+			;;
+		--stale)
+			require_flag_applies --stale "$command" "release"
+			allow_stale=true
+			shift
+			;;
+		--force)
+			require_flag_applies --force "$command" "release"
+			force=true
+			shift
+			;;
+		--dry-run)
+			require_flag_applies --dry-run "$command" "sweep"
+			dry_run=true
+			shift
+			;;
+		-*)
+			printf 'Unknown option: %s\n' "$1" >&2
+			usage >&2
+			exit "$EXIT_USAGE"
+			;;
+		*)
+			[[ -z "$target" ]] || fail "unexpected extra argument: $1"
+			target="$1"
+			shift
+			;;
+		esac
+	done
+
+	case "$command" in
+	list | sweep)
+		[[ -z "$target" ]] || fail "$command takes --repo DIR, not a positional path"
+		;;
+	*)
+		target="${target:-.}"
+		# Without an explicit --repo, the target worktree is itself a checkout
+		# of the repository, so nothing depends on where the caller stands.
+		# A destroyed worktree has to fall back to the current directory.
+		if [[ -z "$repo" && -d "$target" ]]; then
+			repo="$target"
+		fi
+		;;
+	esac
+
+	case "$command" in
+	claim | refresh | release) owner="$(sanitize_owner "$owner")" ;;
+	status)
+		# The session-owner env var is the session's declared identity, so honour it as
+		# the comparison owner. $USER is not: it would mismatch every issue-ID
+		# lease and make the probe cry wolf. When neither is available the
+		# probe still runs, but says out loud that it compared nothing, so a 0
+		# cannot be read as "this worktree is mine".
+		if [[ "$owner_explicit" == true || -n "${VSTACK_SESSION_OWNER:-}" || -n "${HT_SESSION_OWNER:-}" ]]; then
+			owner="$(sanitize_owner "$owner")"
+		else
+			owner=''
+		fi
+		;;
+	esac
+
+	repo="$(resolve_repo "${repo:-.}")"
+
+	case "$command" in
+	claim) cmd_claim "$repo" "$target" "$owner" ;;
+	refresh) cmd_refresh "$repo" "$target" "$owner" ;;
+	release) cmd_release "$repo" "$target" "$owner" "$ttl_minutes" "$allow_stale" "$force" ;;
+	status) cmd_status "$repo" "$target" "$owner" ;;
+	list) cmd_list "$repo" ;;
+	sweep) cmd_sweep "$repo" "$ttl_minutes" "$dry_run" ;;
+	esac
+}
+
+main "$@"

--- a/skills/worktree/tests/worktree_session_guard.sh
+++ b/skills/worktree/tests/worktree_session_guard.sh
@@ -1,0 +1,1054 @@
+#!/usr/bin/env bash
+# Regression tests for the worktree session guard (vstack#877).
+#
+# Ported alongside the guard from hyprtrade, where it was written after the
+# CC-1000 incident of cleanup passes destroying live issue worktrees.
+#
+# Every case runs against throwaway repositories under a temporary directory:
+# no repository worktree is claimed, locked, or removed by this suite.
+#
+# The central regression is the one that motivated the guard: a worktree in
+# active use must survive a concurrent cleanup pass, with its registration, its
+# branch, and its uncommitted edits intact. The rest of the suite covers the
+# ways a guard can fail open — an unevaluable TTL, a sweep that reads a lease
+# before taking the mutex, a lease left unreleasable after its directory is
+# destroyed, and a lock state the status output cannot distinguish.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+GUARD="${GUARD:-$ROOT_DIR/scripts/worktree-session-guard}"
+
+# Isolate fixtures from system AND developer git configuration: a global
+# core.hooksPath or commit template would otherwise reach the seed commit.
+export GIT_CONFIG_NOSYSTEM=1
+export GIT_CONFIG_GLOBAL=/dev/null
+
+# Every mutating command serializes through flock(1), so the suite can only run
+# where flock is installed — a capability check, not a platform one, matching
+# the guard itself. The worktree suite runs this unconditionally, so where
+# the primitive is missing it skips instead of aborting on its first claim,
+# following the repo convention for capability-gated tooling tests (see
+# the rest of the worktree suite).
+if ! command -v flock >/dev/null 2>&1; then
+	printf 'SKIP: worktree session guard needs flock(1), which is not on PATH \n' >&2
+	exit 0
+fi
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+run_out="$tmp_dir/run.out"
+run_err="$tmp_dir/run.err"
+RUN_RC=0
+
+fail() {
+	printf 'FAIL: %s\n' "$1" >&2
+	exit 1
+}
+
+assert_eq() {
+	local actual="$1" expected="$2" context="$3"
+	[[ "$actual" == "$expected" ]] || fail "$context: expected '$expected', got '$actual'"
+}
+
+assert_contains() {
+	local path="$1" expected="$2"
+	grep -Fq -- "$expected" "$path" || fail "$path does not contain: $expected"
+}
+
+assert_not_contains() {
+	local path="$1" unexpected="$2"
+	if grep -Fq -- "$unexpected" "$path"; then
+		fail "$path unexpectedly contains: $unexpected"
+	fi
+}
+
+# BSD wc pads its count with leading spaces, so the raw output cannot be
+# string-compared on a supported platform. Arithmetic expansion normalizes it.
+line_count() {
+	local raw
+	raw="$(wc -l <"$1")"
+	printf '%s\n' "$((raw))"
+}
+
+# Prose assertions must survive reflowing, so compare against the file with
+# newlines and runs of spaces collapsed.
+assert_contains_prose() {
+	local path="$1" expected="$2"
+	tr '\n' ' ' <"$path" | tr -s ' ' | grep -Fq -- "$expected" \
+		|| fail "$path does not contain (whitespace-normalized): $expected"
+}
+
+# Run the guard capturing stdout, stderr, and exit status, instead of letting
+# set -e abort on an expected refusal.
+run_guard() {
+	RUN_RC=0
+	"$GUARD" "$@" >"$run_out" 2>"$run_err" || RUN_RC=$?
+}
+
+json_parse() {
+	local file="$1"
+	if command -v jq >/dev/null 2>&1; then
+		jq -e . <"$file" >/dev/null || fail "not valid JSON: $file"
+	elif command -v python3 >/dev/null 2>&1; then
+		python3 -c 'import json,sys; json.load(open(sys.argv[1]))' "$file" \
+			|| fail "not valid JSON: $file"
+	else
+		fail "no JSON parser available (jq or python3 required)"
+	fi
+}
+
+json_field() {
+	local file="$1" field="$2"
+	if command -v jq >/dev/null 2>&1; then
+		jq -r --arg f "$field" '.[$f]' <"$file"
+	else
+		python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))[sys.argv[2]])' \
+			"$file" "$field"
+	fi
+}
+
+# Create a repository with one linked worktree under a caller-chosen fixture
+# name. Prints "REPO WORKTREE". A third argument of "relative" creates the
+# worktree with --relative-paths, so its registration records a path relative to
+# the registration directory rather than an absolute one.
+new_fixture() {
+	local name="$1" branch="$2" layout="${3:-absolute}" repo wt
+	repo="$tmp_dir/$name-repo"
+	wt="$tmp_dir/$name-wt"
+	[[ ! -e "$repo" && ! -e "$wt" ]] || fail "fixture name already used: $name"
+	mkdir -p "$repo"
+	git init -q -b main "$repo"
+	git -C "$repo" config user.email guard-test@example.invalid
+	git -C "$repo" config user.name guard-test
+	printf 'seed\n' >"$repo/seed.txt"
+	git -C "$repo" add seed.txt
+	git -C "$repo" -c commit.gpgsign=false commit -qm seed
+	if [[ "$layout" == relative ]]; then
+		git -C "$repo" worktree add -q --relative-paths -b "$branch" "$wt" main
+	else
+		git -C "$repo" worktree add -q -b "$branch" "$wt" main
+	fi
+	printf '%s %s\n' "$repo" "$wt"
+}
+
+is_registered() {
+	local repo="$1" wt="$2"
+	git -C "$repo" worktree list --porcelain | grep -Fxq "worktree $wt"
+}
+
+# Registration directory ($GIT_DIR/worktrees/<id>) for a worktree path. Used by
+# tests that forge or inspect a lease directly, including after the worktree
+# directory itself is gone.
+#
+# Ask Git while the directory exists: --git-dir returns the registration for an
+# absolute AND a relative registration alike, so this helper cannot drift from
+# the guard the way a hand-rolled comparison did. The manual scan is only for
+# the destroyed-directory cases, and mirrors the guard's relative resolution.
+registration_of() {
+	local repo="$1" target="$2" entry recorded
+	if [[ -d "$target" ]]; then
+		git -C "$target" rev-parse --path-format=absolute --git-dir 2>/dev/null
+		return
+	fi
+	for entry in "$repo"/.git/worktrees/*; do
+		[[ -f "$entry/gitdir" ]] || continue
+		recorded="$(head -n 1 -- "$entry/gitdir")"
+		[[ "$recorded" == /* ]] || recorded="$(lexical_abs "$entry/$recorded")"
+		[[ "${recorded%/.git}" == "$target" ]] || continue
+		printf '%s\n' "$entry"
+		return 0
+	done
+	return 1
+}
+
+# Lexical .. resolution, so a relative registration still resolves after its
+# worktree directory is gone (the same thing the guard does).
+lexical_abs() {
+	local path="$1" out='' part
+	local -a parts=()
+	IFS='/' read -r -a parts <<<"$path"
+	for part in ${parts[@]+"${parts[@]}"}; do
+		case "$part" in
+		'' | '.') continue ;;
+		'..') out="${out%/*}" ;;
+		*) out="$out/$part" ;;
+		esac
+	done
+	printf '%s\n' "${out:-/}"
+}
+
+lock_reason_of() {
+	local repo="$1" target="$2" registration
+	registration="$(registration_of "$repo" "$target")" || return 1
+	[[ -f "$registration/locked" ]] || return 1
+	head -n 1 -- "$registration/locked"
+}
+
+lease_epoch_of() {
+	local repo="$1" target="$2" key="$3" reason
+	reason="$(lock_reason_of "$repo" "$target")" || return 1
+	printf '%s\n' "$reason" | sed "s/.* $key=\([0-9]*\).*/\1/"
+}
+
+forge_lease() {
+	local repo="$1" target="$2" text="$3" registration
+	registration="$(registration_of "$repo" "$target")" || fail "no registration for $target"
+	printf '%s\n' "$text" >"$registration/locked"
+}
+
+# ── Discovery and argument validation ────────────────────────────────
+
+non_git="$tmp_dir/not-a-repo"
+mkdir -p "$non_git"
+
+# Run these from outside any repository, which is the condition they claim to
+# cover — the suite itself runs from the skill's tests directory and in CI.
+(cd "$non_git" && "$GUARD" --help >/dev/null) || fail "--help must succeed outside any repository"
+(cd "$non_git" && "$GUARD" >/dev/null) || fail "bare invocation must succeed outside any repository"
+
+run_guard frobnicate
+assert_eq "$RUN_RC" "1" "unknown command"
+assert_contains "$run_err" "Unknown command: frobnicate"
+
+read -r repo wt <<<"$(new_fixture primary feat)"
+# An empty fixture would make every path argument below default to the current
+# directory, so refuse to continue rather than touch a real worktree.
+[[ -d "$repo" && -d "$wt" ]] || fail "primary fixture was not created"
+
+run_guard claim "$repo" --owner CC-1000
+assert_eq "$RUN_RC" "1" "claiming the main checkout"
+assert_contains "$run_err" "refusing the main checkout"
+
+mkdir -p "$wt/nested"
+run_guard claim "$wt/nested" --owner CC-1000
+assert_eq "$RUN_RC" "1" "claiming a worktree subdirectory"
+assert_contains "$run_err" "not a worktree root"
+rmdir "$wt/nested"
+
+run_guard claim "$non_git" --owner CC-1000
+assert_eq "$RUN_RC" "1" "claiming a path outside a repository"
+assert_contains "$run_err" "not inside a Git repository"
+
+run_guard claim "$wt" --owner "two words"
+assert_eq "$RUN_RC" "1" "owner containing a space"
+assert_contains "$run_err" "owner may only contain"
+
+long_owner="CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"
+assert_eq "${#long_owner}" "65" "long-owner fixture length"
+run_guard claim "$wt" --owner "$long_owner"
+assert_eq "$RUN_RC" "1" "65-character owner"
+assert_contains "$run_err" "at most 64 characters"
+
+# Zero-padded TTL: bash arithmetic would read 08 as octal, abort the comparison
+# mid-expression, and (before the guard rejected it) fall through to unlock.
+for padded in 08 010; do
+	run_guard release "$wt" --owner CC-999 --stale --ttl-minutes "$padded"
+	assert_eq "$RUN_RC" "1" "zero-padded --ttl-minutes $padded"
+	assert_contains "$run_err" "without leading zeros"
+done
+
+run_guard release "$wt" --owner CC-1000 --ttl-minutes soon
+assert_eq "$RUN_RC" "1" "non-numeric TTL"
+assert_contains "$run_err" "must be a non-negative integer"
+
+# An unbounded TTL overflows bash's signed arithmetic, so the most conservative
+# request would otherwise mark every lease stale and release it.
+run_guard release "$wt" --owner CC-999 --stale --ttl-minutes 9223372036854775807
+assert_eq "$RUN_RC" "1" "out-of-range --ttl-minutes"
+assert_contains "$run_err" "at most 10 digits"
+run_guard sweep --repo "$repo" --ttl-minutes 9223372036854775807
+assert_eq "$RUN_RC" "1" "out-of-range --ttl-minutes on sweep"
+assert_contains "$run_err" "at most 10 digits"
+
+# Options must be rejected where they do not apply, not silently ignored.
+run_guard sweep --repo "$repo" --force
+assert_eq "$RUN_RC" "1" "sweep --force"
+assert_contains "$run_err" "--force does not apply to sweep"
+
+run_guard claim "$wt" --owner CC-1000 --dry-run
+assert_eq "$RUN_RC" "1" "claim --dry-run"
+assert_contains "$run_err" "--dry-run does not apply to claim"
+
+run_guard status "$wt" --stale
+assert_eq "$RUN_RC" "1" "status --stale"
+assert_contains "$run_err" "--stale does not apply to status"
+
+run_guard claim "$wt" --owner CC-1000 --repo "$repo"
+assert_eq "$RUN_RC" "1" "claim --repo"
+assert_contains "$run_err" "--repo does not apply to claim"
+
+run_guard list "$wt"
+assert_eq "$RUN_RC" "1" "list with a positional path"
+assert_contains "$run_err" "takes --repo DIR"
+
+# ── Status before and after a claim ──────────────────────────────────
+
+run_guard status "$wt"
+assert_eq "$RUN_RC" "3" "status on an unclaimed worktree"
+json_parse "$run_out"
+assert_eq "$(json_field "$run_out" locked)" "false" "unclaimed locked flag"
+assert_eq "$(json_field "$run_out" managed)" "false" "unclaimed managed flag"
+
+run_guard refresh "$wt" --owner CC-1000
+assert_eq "$RUN_RC" "1" "refresh before any claim"
+assert_contains "$run_err" "no session claim to refresh"
+
+"$GUARD" claim "$wt" --owner CC-1000 >/dev/null || fail "claim must succeed on a free worktree"
+
+run_guard status "$wt"
+assert_eq "$RUN_RC" "0" "status on a claimed worktree"
+json_parse "$run_out"
+assert_eq "$(json_field "$run_out" locked)" "true" "claimed locked flag"
+assert_eq "$(json_field "$run_out" managed)" "true" "claimed managed flag"
+assert_eq "$(json_field "$run_out" owner)" "CC-1000" "claimed owner"
+assert_eq "$(json_field "$run_out" directory_present)" "true" "claimed directory_present"
+
+git -C "$repo" worktree list --porcelain | grep -Fq "locked vstack-session-guard" \
+	|| fail "a claim must be recorded as a native Git worktree lock"
+
+# Same-owner claim is documented as idempotent: it rewrites the lease in place,
+# preserving the original claim time and advancing only the heartbeat.
+claimed_before="$(lease_epoch_of "$repo" "$wt" claimed_epoch)"
+heartbeat_before="$(lease_epoch_of "$repo" "$wt" heartbeat_epoch)"
+sleep 1
+run_guard claim "$wt" --owner CC-1000
+assert_eq "$RUN_RC" "0" "re-claim by the same owner"
+assert_contains "$run_out" "refreshed"
+assert_eq "$(lease_epoch_of "$repo" "$wt" claimed_epoch)" "$claimed_before" \
+	"re-claim must preserve the original claim time"
+[[ "$(lease_epoch_of "$repo" "$wt" heartbeat_epoch)" -gt "$heartbeat_before" ]] \
+	|| fail "re-claim must advance the heartbeat"
+
+# ── Regression: concurrent active use survives cleanup ───────────────
+
+live_file="$wt/live-edit.txt"
+(
+	for i in 1 2 3 4 5 6 7 8; do
+		printf 'edit %s\n' "$i" >>"$live_file"
+		sleep 0.05
+	done
+) &
+writer_pid=$!
+
+cleanup_err="$tmp_dir/cleanup.err"
+if git -C "$repo" worktree remove --force "$wt" 2>"$cleanup_err"; then
+	fail "cleanup removed a worktree claimed by a live session"
+fi
+assert_contains "$cleanup_err" "cannot remove a locked working tree"
+
+wait "$writer_pid"
+
+is_registered "$repo" "$wt" || fail "claimed worktree lost its registration"
+[[ -d "$wt" ]] || fail "claimed worktree directory was destroyed"
+assert_eq "$(line_count "$live_file")" "8" "uncommitted edits written during cleanup"
+
+# branch -D is refused because the branch is checked out in a registered
+# worktree, not because of the lock. The claim's contribution is keeping the
+# registration alive so that refusal keeps applying.
+branch_err="$tmp_dir/branch.err"
+if git -C "$repo" branch -D feat 2>"$branch_err"; then
+	fail "cleanup deleted the branch of a claimed worktree"
+fi
+assert_contains "$branch_err" "cannot delete branch"
+
+# ── A second session cannot take over a live claim ───────────────────
+
+run_guard claim "$wt" --owner CC-999
+assert_eq "$RUN_RC" "75" "claiming a worktree held by another owner"
+assert_contains "$run_err" "is claimed by owner=CC-1000"
+lock_reason_of "$repo" "$wt" | grep -Fq "owner=CC-1000" \
+	|| fail "a refused claim must leave the existing lease untouched"
+
+# Exit 75 is this repo's "someone else owns this work" signal; a refresh
+# conflict is that condition, not tooling breakage.
+run_guard refresh "$wt" --owner CC-999
+assert_eq "$RUN_RC" "75" "refresh by a non-owner"
+assert_contains "$run_err" "is claimed by owner=CC-1000"
+
+run_guard release "$wt" --owner CC-999
+assert_eq "$RUN_RC" "75" "release by a non-owner"
+assert_contains "$run_err" "is claimed by owner=CC-1000"
+lock_reason_of "$repo" "$wt" >/dev/null || fail "a refused release must leave the lock in place"
+
+# status --owner is the read-only ownership probe the reuse guidance depends
+# on: the exit code alone must distinguish "mine" from "someone else's", and
+# the probe must not mutate the lease.
+heartbeat_before="$(lease_epoch_of "$repo" "$wt" heartbeat_epoch)"
+run_guard status "$wt" --owner CC-999
+assert_eq "$RUN_RC" "75" "status --owner against a foreign owner"
+assert_contains "$run_err" "is claimed by owner=CC-1000"
+run_guard status "$wt" --owner CC-1000
+assert_eq "$RUN_RC" "0" "status --owner against your own lease"
+run_guard status "$wt"
+assert_eq "$RUN_RC" "0" "status without --owner does not compare owners"
+assert_eq "$(lease_epoch_of "$repo" "$wt" heartbeat_epoch)" "$heartbeat_before" \
+	"status must never mutate the lease"
+
+# ── Refresh never opens an unlocked window ───────────────────────────
+
+claimed_before="$(lease_epoch_of "$repo" "$wt" claimed_epoch)"
+# Instrumented rather than timed. Racing `worktree remove` against refresh can
+# only catch a window wide enough to hit by chance, so an unlock/relock
+# implementation with a short window passes while still being unsafe. The
+# invariant is structural instead: a rewrite must never take the worktree out
+# of the locked state, so refresh must never invoke `git worktree unlock`.
+# A shim records any such call and delegates everything else to real git.
+unlock_marker="$tmp_dir/refresh-unlock-marker"
+unlock_shim_dir="$tmp_dir/unlock-shim"
+rm -f "$unlock_marker"
+mkdir -p "$unlock_shim_dir"
+refresh_real_git="$(command -v git)"
+{
+	printf '#!/usr/bin/env bash\n'
+	printf 'prev=""\n'
+	printf 'for arg in "$@"; do\n'
+	printf '\tif [[ "$prev" == worktree && "$arg" == unlock ]]; then\n'
+	printf '\t\tprintf "unlock\\n" >>"%s"\n' "$unlock_marker"
+	printf '\tfi\n'
+	printf '\tprev="$arg"\n'
+	printf 'done\n'
+	printf 'exec %s "$@"\n' "$refresh_real_git"
+} >"$unlock_shim_dir/git"
+chmod +x "$unlock_shim_dir/git"
+
+lease_before="$(lock_reason_of "$repo" "$wt")"
+for _ in 1 2 3; do
+	PATH="$unlock_shim_dir:$PATH" "$GUARD" refresh "$wt" --owner CC-1000 >/dev/null \
+		|| fail "refresh must succeed for the owning session"
+done
+
+if [[ -e "$unlock_marker" ]]; then
+	fail "refresh unlocked the worktree; a rewrite must never open an unlocked window"
+fi
+# The shim only observes, so the refresh must genuinely have happened. The
+# lease records the writing process's pid, which differs on every invocation,
+# so this detects a rewrite without waiting a second for the clock to tick.
+[[ "$(lock_reason_of "$repo" "$wt")" != "$lease_before" ]] \
+	|| fail "instrumented refresh did not rewrite the lease"
+assert_eq "$(lease_epoch_of "$repo" "$wt" claimed_epoch)" "$claimed_before" \
+	"refresh must preserve the original claim time"
+
+# One end-to-end attempt, not a spin: the worktree is still locked afterwards.
+removal_err="$tmp_dir/refresh-removal.err"
+if git -C "$repo" worktree remove --force "$wt" 2>"$removal_err"; then
+	fail "worktree was removable after a heartbeat refresh"
+fi
+assert_contains "$removal_err" "cannot remove a locked working tree"
+is_registered "$repo" "$wt" || fail "worktree lost registration during heartbeat refresh"
+
+# ── Release restores removability (no permanent wedge) ───────────────
+
+# --stale must mean the same thing whoever owns the lease. The lease is keyed to
+# the issue, so a sibling session matches the owner: exempting the owner match
+# would make the documented recovery release a live claim instantly.
+run_guard release "$wt" --stale --owner CC-1000
+assert_eq "$RUN_RC" "75" "--stale release of a fresh lease you appear to own"
+assert_contains "$run_err" "is not stale"
+lock_reason_of "$repo" "$wt" >/dev/null || fail "--stale must not release a fresh same-owner lease"
+
+# The success half of the same rule: past the TTL, a same-owner stale release
+# goes through. This is the documented recovery for an abandoned sibling
+# session's lease, so it must be gated by the TTL — not skipped, not blocked.
+run_guard release "$wt" --stale --owner CC-1000 --ttl-minutes 0
+assert_eq "$RUN_RC" "0" "--stale release of a same-owner lease past the TTL"
+assert_contains "$run_err" "displacing lease on"
+assert_contains "$run_err" "owner=CC-1000"
+if lock_reason_of "$repo" "$wt" >/dev/null 2>&1; then
+	fail "a same-owner stale release past the TTL must unlock the worktree"
+fi
+
+"$GUARD" claim "$wt" --owner CC-1000 >/dev/null
+run_guard release "$wt" --owner CC-1000
+assert_eq "$RUN_RC" "0" "owner release must succeed without --stale"
+# Releasing your own lease is expected, but an owner match only proves the same
+# issue, so the released lease still has to leave a record.
+assert_contains "$run_err" "releasing lease on"
+assert_contains "$run_err" "owner=CC-1000"
+
+run_guard status "$wt"
+assert_eq "$RUN_RC" "3" "status after release"
+"$GUARD" release "$wt" --owner CC-1000 | grep -Fq 'already released' \
+	|| fail "release must be idempotent"
+# The uncommitted edits above are exactly what --force exists for; the point is
+# that the same command now succeeds, so a released claim is not a wedge.
+git -C "$repo" worktree remove --force "$wt" \
+	|| fail "cleanup must succeed once the session claim is released"
+
+# ── Default owner resolution ─────────────────────────────────────────
+
+read -r owner_repo owner_wt <<<"$(new_fixture owner env)"
+[[ -d "$owner_repo" && -d "$owner_wt" ]] || fail "owner fixture was not created"
+
+HT_SESSION_OWNER=CC-777 "$GUARD" claim "$owner_wt" >/dev/null \
+	|| fail "claim must fall back to HT_SESSION_OWNER"
+lock_reason_of "$owner_repo" "$owner_wt" | grep -Fq "owner=CC-777" \
+	|| fail "HT_SESSION_OWNER must become the lease owner"
+HT_SESSION_OWNER=CC-777 "$GUARD" release "$owner_wt" >/dev/null 2>&1 \
+	|| fail "release must fall back to HT_SESSION_OWNER"
+
+RUN_RC=0
+env -u HT_SESSION_OWNER -u USER "$GUARD" claim "$owner_wt" >"$run_out" 2>"$run_err" || RUN_RC=$?
+assert_eq "$RUN_RC" "1" "claim with no resolvable owner"
+assert_contains "$run_err" "owner must not be empty"
+
+# The probe must honour HT_SESSION_OWNER too. A wrapper that exports it instead
+# of passing --owner would otherwise get a green probe on a foreign live claim.
+"$GUARD" claim "$owner_wt" --owner CC-777 >/dev/null
+RUN_RC=0
+HT_SESSION_OWNER=CC-888 "$GUARD" status "$owner_wt" >"$run_out" 2>"$run_err" || RUN_RC=$?
+assert_eq "$RUN_RC" "75" "status with HT_SESSION_OWNER naming a non-owner"
+assert_contains "$run_err" "is claimed by owner=CC-777"
+
+# With no owner at all the probe still runs, but must say it compared nothing
+# so exit 0 cannot be read as "this worktree is mine".
+RUN_RC=0
+env -u HT_SESSION_OWNER -u USER "$GUARD" status "$owner_wt" >"$run_out" 2>"$run_err" || RUN_RC=$?
+assert_eq "$RUN_RC" "0" "status with no comparable owner"
+assert_contains "$run_err" "no ownership comparison performed"
+HT_SESSION_OWNER=CC-777 "$GUARD" release "$owner_wt" >/dev/null 2>&1
+
+# ── Prune ────────────────────────────────────────────────────────────
+
+# prune only removes registrations whose directory is missing, so the guarantee
+# can only be exercised with the directory gone. The unlocked control below
+# proves the assertion has teeth.
+read -r prune_repo prune_wt <<<"$(new_fixture prune pruned)"
+[[ -d "$prune_repo" && -d "$prune_wt" ]] || fail "prune fixture was not created"
+"$GUARD" claim "$prune_wt" --owner CC-1000 >/dev/null
+rm -rf "$prune_wt"
+git -C "$prune_repo" worktree prune --expire=now
+is_registered "$prune_repo" "$prune_wt" \
+	|| fail "prune removed the registration of a claimed worktree"
+git -C "$prune_repo" show-ref --verify --quiet refs/heads/pruned \
+	|| fail "prune path deleted the branch of a claimed worktree"
+
+read -r control_repo control_wt <<<"$(new_fixture control unclaimed)"
+[[ -d "$control_repo" && -d "$control_wt" ]] || fail "control fixture was not created"
+rm -rf "$control_wt"
+git -C "$control_repo" worktree prune --expire=now
+if is_registered "$control_repo" "$control_wt"; then
+	fail "control: prune must remove an unclaimed missing worktree (assertion has no teeth)"
+fi
+
+# ── A destroyed worktree's lease stays recoverable ───────────────────
+
+# This is the CC-1000 scenario itself: the worktree vanished under a live
+# session. The lease must still be inspectable and releasable, or the guard
+# turns the incident into a permanent wedge.
+run_guard status "$prune_wt" --repo "$prune_repo"
+assert_eq "$RUN_RC" "0" "status of a claimed worktree whose directory is gone"
+json_parse "$run_out"
+assert_eq "$(json_field "$run_out" directory_present)" "false" "missing directory reported"
+assert_eq "$(json_field "$run_out" managed)" "true" "missing directory still managed"
+
+run_guard list --repo "$prune_repo"
+assert_eq "$RUN_RC" "0" "list with a destroyed worktree"
+assert_eq "$(line_count "$run_out")" "1" "list must still report a destroyed registration"
+json_parse "$run_out"
+
+run_guard sweep --repo "$prune_repo" --ttl-minutes 0
+assert_eq "$RUN_RC" "0" "sweep of a destroyed worktree's lease"
+assert_contains "$run_out" "released"
+git -C "$prune_repo" worktree prune --expire=now
+if is_registered "$prune_repo" "$prune_wt"; then
+	fail "the registration must be prunable once the lease is released"
+fi
+
+# The plain owner-release is what an operator reaches for first, so it must
+# work on a destroyed worktree too — not only sweep.
+read -r gone_repo gone_wt <<<"$(new_fixture gone vanished)"
+[[ -d "$gone_repo" && -d "$gone_wt" ]] || fail "destroyed-release fixture was not created"
+"$GUARD" claim "$gone_wt" --owner CC-1000 >/dev/null
+rm -rf "$gone_wt"
+run_guard release "$gone_wt" --owner CC-1000 --repo "$gone_repo"
+assert_eq "$RUN_RC" "0" "owner release of a destroyed worktree"
+assert_contains "$run_out" "released"
+git -C "$gone_repo" worktree prune --expire=now
+if is_registered "$gone_repo" "$gone_wt"; then
+	fail "the registration must be prunable after an owner release"
+fi
+
+# Resolution is lexical once the directory is gone, so an alternate spelling
+# cannot be canonicalized. Whatever the guard does, it must not fail silently:
+# either it resolves the path, or it names the spelling that is registered.
+read -r spell_repo spell_wt <<<"$(new_fixture spell spelled)"
+[[ -d "$spell_repo" && -d "$spell_wt" ]] || fail "spelling fixture was not created"
+"$GUARD" claim "$spell_wt" --owner CC-1000 >/dev/null
+rm -rf "$spell_wt"
+ln -s "$tmp_dir" "$tmp_dir/alias"
+run_guard release "$tmp_dir/alias/spell-wt" --owner CC-1000 --repo "$spell_repo"
+if [[ "$RUN_RC" != "0" ]]; then
+	assert_eq "$RUN_RC" "1" "alternate spelling of a destroyed worktree"
+	assert_contains "$run_err" "not a registered worktree"
+	# The refusal must name the repository that was searched and the spelling
+	# that is registered, not echo the failing path back as both sides.
+	assert_contains "$run_err" "$spell_repo/.git"
+	assert_contains "$run_err" "$spell_wt"
+	assert_contains "$run_err" "--repo"
+	"$GUARD" release "$spell_wt" --owner CC-1000 --repo "$spell_repo" >/dev/null 2>&1 \
+		|| fail "the registered spelling must still release cleanly"
+fi
+
+# A repository with no linked worktrees at all is the case where --repo is
+# almost certainly the missing argument, so the message must say so.
+run_guard release "$gone_wt" --owner CC-1000 --repo "$control_repo"
+assert_eq "$RUN_RC" "1" "destroyed worktree resolved against the wrong repository"
+assert_contains "$run_err" "$control_repo/.git"
+assert_contains "$run_err" "no linked worktrees"
+assert_contains "$run_err" "--repo DIR"
+
+# ── Sweep: staleness, dry run, and the serialization contract ────────
+
+read -r sweep_repo sweep_wt <<<"$(new_fixture sweep swept)"
+[[ -d "$sweep_repo" && -d "$sweep_wt" ]] || fail "sweep fixture was not created"
+"$GUARD" claim "$sweep_wt" --owner CC-1000 >/dev/null
+
+"$GUARD" sweep --repo "$sweep_repo" | grep -Fq 'no stale session claims' \
+	|| fail "sweep must leave a live lease alone"
+lock_reason_of "$sweep_repo" "$sweep_wt" >/dev/null || fail "sweep released a live lease"
+
+"$GUARD" sweep --repo "$sweep_repo" --ttl-minutes 0 --dry-run | grep -Fq 'would release' \
+	|| fail "sweep --dry-run must report the lease it would release"
+lock_reason_of "$sweep_repo" "$sweep_wt" >/dev/null || fail "sweep --dry-run must not release anything"
+
+# Serialization: sweep must re-read the lease UNDER the guard mutex. Hold the
+# mutex externally, let a refresh land while sweep is blocked on it, and the
+# refreshed lease must survive.
+guard_lock="$sweep_repo/.git/ht-worktree-session-guard.lock"
+stale_epoch=$(($(date -u +%s) - 86400))
+forge_lease "$sweep_repo" "$sweep_wt" \
+	"vstack-session-guard v1 owner=CC-1000 pid=1 host=h claimed=old claimed_epoch=$stale_epoch heartbeat=old heartbeat_epoch=$stale_epoch"
+sweep_out="$tmp_dir/sweep-race.out"
+
+# The evidence that sweep reached the mutex is procfs-only. Rather than degrade
+# to a timing guess that would pass against a read-before-lock implementation,
+# the case announces that it did not run. Portable coverage is CC-1026.
+if [[ ! -r /proc/self/fd ]]; then
+	printf 'SKIP: sweep serialization race needs procfs to observe the blocked child (CC-1026)\n' >&2
+else
+	exec 8>"$guard_lock"
+	flock -x 8
+	# A 60-minute TTL separates the two states: the day-old lease sweep saw
+	# before blocking is stale, the refreshed one it must re-read is not.
+	#
+	# 8>&- closes this test's own handle on the lock in the child: an inherited
+	# fd 8 would satisfy the probe below the instant the child forked, before
+	# it had reached acquire_guard_lock at all.
+	"$GUARD" sweep --repo "$sweep_repo" --ttl-minutes 60 >"$sweep_out" 2>&1 8>&- &
+	sweep_pid=$!
+
+	# Wait for evidence that sweep actually reached the mutex — its own fd on
+	# the lock file. A fixed sleep would let a slow start push the whole sweep
+	# past the unlock, and the pre-fix read-before-lock implementation would
+	# then pass this test too.
+	blocked=false
+	for _ in $(seq 1 200); do
+		for fd in /proc/"$sweep_pid"/fd/*; do
+			[[ -e "$fd" ]] || continue
+			if [[ "$(readlink -- "$fd" 2>/dev/null || true)" == "$guard_lock" ]]; then
+				blocked=true
+				break
+			fi
+		done
+		[[ "$blocked" == true ]] && break
+		sleep 0.05
+	done
+	[[ "$blocked" == true ]] \
+		|| fail "sweep never opened the guard lock; the serialization race was not exercised"
+
+	# Stands in for a refresh that landed while sweep was blocked; refresh
+	# itself would queue behind the same mutex this test is holding.
+	fresh_epoch="$(date -u +%s)"
+	forge_lease "$sweep_repo" "$sweep_wt" \
+		"vstack-session-guard v1 owner=CC-1000 pid=1 host=h claimed=new claimed_epoch=$fresh_epoch heartbeat=new heartbeat_epoch=$fresh_epoch"
+	flock -u 8
+	exec 8>&-
+	wait "$sweep_pid" || fail "sweep must exit cleanly after blocking on the guard lock"
+
+	lock_reason_of "$sweep_repo" "$sweep_wt" | grep -Fq "heartbeat_epoch=$fresh_epoch" \
+		|| fail "sweep discarded a lease refreshed while it was blocked on the mutex"
+	assert_contains "$sweep_out" "no stale session claims"
+fi
+
+# An out-of-range heartbeat wraps signed 64-bit arithmetic and reads as an
+# enormous age, so it must be quarantined like any other unreadable lease
+# rather than evaluated and released at the default TTL.
+forge_lease "$sweep_repo" "$sweep_wt" \
+	"vstack-session-guard v1 owner=CC-1000 pid=1 host=h claimed=x claimed_epoch=1 heartbeat=x heartbeat_epoch=12345678901234567890"
+run_guard sweep --repo "$sweep_repo"
+assert_eq "$RUN_RC" "4" "sweep with an out-of-range heartbeat epoch"
+assert_contains "$run_out" "unusable lease(s) left in place"
+lock_reason_of "$sweep_repo" "$sweep_wt" >/dev/null \
+	|| fail "an out-of-range heartbeat must leave the lease in place"
+run_guard status "$sweep_wt"
+assert_eq "$(json_field "$run_out" heartbeat_age_seconds)" "-1" \
+	"an out-of-range heartbeat must not report a computed age"
+
+# A corrupted claim time must be replaced rather than carried forward, or it
+# would reach iso_from_epoch and abort the refresh with a date(1) error.
+for bad_claim in 12345678901234567890 abc; do
+	forge_lease "$sweep_repo" "$sweep_wt" \
+		"vstack-session-guard v1 owner=CC-1000 pid=1 host=h claimed=x claimed_epoch=$bad_claim heartbeat=x heartbeat_epoch=$(date -u +%s)"
+	run_guard refresh "$sweep_wt" --owner CC-1000
+	assert_eq "$RUN_RC" "0" "refresh over an out-of-range claimed_epoch ($bad_claim)"
+	refreshed_claim="$(lease_epoch_of "$sweep_repo" "$sweep_wt" claimed_epoch)"
+	[[ "$refreshed_claim" =~ ^(0|[1-9][0-9]*)$ && ${#refreshed_claim} -le 10 ]] \
+		|| fail "refresh must replace an unusable claimed_epoch, got '$refreshed_claim'"
+done
+
+# An unreadable lease must be reported, not silently counted as "clean".
+forge_lease "$sweep_repo" "$sweep_wt" "vstack-session-guard v1 garbage"
+run_guard sweep --repo "$sweep_repo" --ttl-minutes 0
+assert_eq "$RUN_RC" "4" "sweep with an unreadable lease"
+assert_contains "$run_out" "unusable lease(s) left in place"
+assert_not_contains "$run_out" "no stale session claims"
+assert_contains "$run_err" "release $sweep_wt --force"
+
+run_guard release "$sweep_wt" --owner CC-1000 --force
+assert_eq "$RUN_RC" "0" "--force recovery of an unreadable lease"
+# The lease cannot be parsed, so the displacement notice reports it as unknown
+# rather than inventing an owner.
+assert_contains "$run_err" "displacing lease on"
+
+# Displacing another owner's lease must leave a trace naming what was destroyed.
+"$GUARD" claim "$sweep_wt" --owner CC-1000 >/dev/null
+run_guard sweep --repo "$sweep_repo" --ttl-minutes 0
+assert_eq "$RUN_RC" "0" "sweep releasing a stale lease"
+assert_contains "$run_out" "released"
+assert_contains "$run_err" "displacing lease on"
+assert_contains "$run_err" "owner=CC-1000"
+
+# ── Stale and forced release ─────────────────────────────────────────
+
+"$GUARD" claim "$sweep_wt" --owner CC-1000 >/dev/null
+run_guard release "$sweep_wt" --owner CC-999 --stale
+assert_eq "$RUN_RC" "75" "--stale release of a fresh lease"
+assert_contains "$run_err" "is not stale"
+
+# A rejected TTL must leave the lease alone, whichever way it was malformed:
+# zero-padded (octal parse) or large enough to overflow the comparison.
+for bad_ttl in 08 9223372036854775807; do
+	run_guard release "$sweep_wt" --owner CC-999 --stale --ttl-minutes "$bad_ttl"
+	assert_eq "$RUN_RC" "1" "malformed --ttl-minutes $bad_ttl on a live foreign lease"
+	lock_reason_of "$sweep_repo" "$sweep_wt" | grep -Fq "owner=CC-1000" \
+		|| fail "malformed --ttl-minutes $bad_ttl released a fresh foreign lease"
+done
+
+run_guard release "$sweep_wt" --owner CC-999 --stale --ttl-minutes 0
+assert_eq "$RUN_RC" "0" "--stale release past the TTL"
+assert_contains "$run_err" "displacing lease on"
+if lock_reason_of "$sweep_repo" "$sweep_wt" >/dev/null 2>&1; then
+	fail "stale release must unlock the worktree"
+fi
+
+"$GUARD" claim "$sweep_wt" --owner CC-1000 >/dev/null
+run_guard release "$sweep_wt" --owner CC-999 --force
+assert_eq "$RUN_RC" "0" "--force release regardless of owner"
+assert_contains "$run_err" "displacing lease on"
+if lock_reason_of "$sweep_repo" "$sweep_wt" >/dev/null 2>&1; then
+	fail "--force release must unlock the worktree"
+fi
+
+# ── A different guard version is a foreign lock ──────────────────────
+
+# Matching the marker alone would adopt a future version's lease, and
+# `release --force` would then unlock a lock this guard did not write.
+forge_lease "$sweep_repo" "$sweep_wt" \
+	"vstack-session-guard v2 owner=CC-1000 pid=1 host=h claimed=x claimed_epoch=1 heartbeat=x heartbeat_epoch=1"
+run_guard release "$sweep_wt" --owner CC-1000 --force
+assert_eq "$RUN_RC" "75" "release --force against a different-version lease"
+assert_contains "$run_err" "locked outside this guard"
+run_guard sweep --repo "$sweep_repo" --ttl-minutes 0
+assert_eq "$RUN_RC" "0" "sweep with a different-version lease"
+assert_contains "$run_out" "no stale session claims"
+lock_reason_of "$sweep_repo" "$sweep_wt" | grep -Fq "v2" \
+	|| fail "a different-version lease must be left exactly as it was"
+
+# But a v1 lease truncated to its bare prefix must stay recoverable rather than
+# becoming an unreleasable foreign lock — the version check must not add a wedge.
+forge_lease "$sweep_repo" "$sweep_wt" "vstack-session-guard v1"
+run_guard release "$sweep_wt" --owner CC-1000 --force
+assert_eq "$RUN_RC" "0" "--force must still recover a bare-prefix v1 lease"
+if lock_reason_of "$sweep_repo" "$sweep_wt" >/dev/null 2>&1; then
+	fail "a bare-prefix v1 lease must be releasable"
+fi
+
+# ── A future-dated heartbeat is quarantined, not released ────────────
+
+# Bash division truncates toward zero, so a heartbeat a few seconds ahead read
+# as 0 minutes old and satisfied --ttl-minutes 0 before this was fixed.
+"$GUARD" claim "$sweep_wt" --owner CC-1000 >/dev/null
+future_epoch=$(($(date -u +%s) + 30))
+forge_lease "$sweep_repo" "$sweep_wt" \
+	"vstack-session-guard v1 owner=CC-1000 pid=1 host=h claimed=x claimed_epoch=1 heartbeat=x heartbeat_epoch=$future_epoch"
+run_guard sweep --repo "$sweep_repo" --ttl-minutes 0
+assert_eq "$RUN_RC" "4" "sweep with a future-dated heartbeat"
+assert_contains "$run_out" "unusable lease(s) left in place"
+assert_contains "$run_err" "dated in the future"
+lock_reason_of "$sweep_repo" "$sweep_wt" | grep -Fq "heartbeat_epoch=$future_epoch" \
+	|| fail "a future-dated heartbeat must be left in place, not released"
+
+run_guard release "$sweep_wt" --owner CC-999 --stale --ttl-minutes 0
+assert_eq "$RUN_RC" "1" "--stale release of a future-dated heartbeat"
+assert_contains "$run_err" "unusable heartbeat"
+lock_reason_of "$sweep_repo" "$sweep_wt" >/dev/null \
+	|| fail "--stale must not release a future-dated heartbeat"
+"$GUARD" release "$sweep_wt" --owner CC-1000 --force >/dev/null 2>&1
+
+# ── A dry run never reports a mutation ───────────────────────────────
+
+# One stale lease plus one unusable lease, so the summary line itself runs.
+read -r dry_repo dry_wt_a <<<"$(new_fixture dry alpha)"
+[[ -d "$dry_repo" && -d "$dry_wt_a" ]] || fail "dry-run fixture was not created"
+dry_wt_b="$tmp_dir/dry-wt-b"
+git -C "$dry_repo" worktree add -q -b dry-beta "$dry_wt_b" main
+"$GUARD" claim "$dry_wt_a" --owner CC-1000 >/dev/null
+"$GUARD" claim "$dry_wt_b" --owner CC-1000 >/dev/null
+forge_lease "$dry_repo" "$dry_wt_b" "vstack-session-guard v1 garbage"
+
+run_guard sweep --repo "$dry_repo" --ttl-minutes 0 --dry-run
+assert_eq "$RUN_RC" "4" "dry-run sweep alongside an unusable lease"
+assert_contains "$run_out" "would be released"
+assert_not_contains "$run_out" "claim(s) released"
+lock_reason_of "$dry_repo" "$dry_wt_a" >/dev/null \
+	|| fail "a dry run must not release anything"
+
+# The same sweep for real reports a mutation, and only then.
+run_guard sweep --repo "$dry_repo" --ttl-minutes 0
+assert_eq "$RUN_RC" "4" "real sweep alongside an unusable lease"
+assert_contains "$run_out" "claim(s) released"
+assert_not_contains "$run_out" "would be released"
+
+# ── Locks taken outside the guard are never touched ──────────────────
+
+# Quote, backslash and a literal tab: a control character must be escaped so
+# the value round-trips, not deleted so it silently changes. This output is the
+# documented attribution mechanism, so an altered reason is the harmful case.
+foreign_reason="$(printf 'manual "investigation" hold\tC:\\tmp')"
+git -C "$sweep_repo" worktree lock --reason "$foreign_reason" "$sweep_wt"
+
+run_guard claim "$sweep_wt" --owner CC-1000
+assert_eq "$RUN_RC" "75" "claiming a worktree locked outside the guard"
+assert_contains "$run_err" "locked outside this guard"
+
+run_guard refresh "$sweep_wt" --owner CC-1000
+assert_eq "$RUN_RC" "75" "refreshing a worktree locked outside the guard"
+assert_contains "$run_err" "locked outside this guard"
+
+# Same condition claim and refresh report, so the same exit code — a caller
+# branching on 75 must not see this as a usage error.
+run_guard release "$sweep_wt" --owner CC-1000 --force
+assert_eq "$RUN_RC" "75" "release must refuse to unlock a foreign lock"
+assert_contains "$run_err" "refusing to unlock"
+
+"$GUARD" sweep --repo "$sweep_repo" --ttl-minutes 0 >/dev/null
+assert_eq "$(lock_reason_of "$sweep_repo" "$sweep_wt")" "$foreign_reason" \
+	"sweep must leave a foreign lock exactly as it was"
+
+# A foreign lock must be distinguishable from an unlocked worktree, and its
+# reason must survive JSON encoding intact.
+run_guard status "$sweep_wt"
+assert_eq "$RUN_RC" "4" "status of a foreign-locked worktree"
+json_parse "$run_out"
+assert_eq "$(json_field "$run_out" locked)" "true" "foreign lock locked flag"
+assert_eq "$(json_field "$run_out" managed)" "false" "foreign lock managed flag"
+assert_eq "$(json_field "$run_out" lock_reason)" "$foreign_reason" \
+	"foreign lock reason must round-trip through JSON"
+# The tab has to survive as a tab, not be dropped or turned into a space.
+case "$(json_field "$run_out" lock_reason)" in
+*"$(printf '\t')"*) ;;
+*) fail "the tab in a lock reason was not preserved through JSON encoding" ;;
+esac
+# Escaping rather than deleting a control character is also what keeps one
+# JSON object on one line, which `list` depends on.
+assert_eq "$(line_count "$run_out")" "1" "status must emit exactly one JSON line"
+
+git -C "$sweep_repo" worktree unlock "$sweep_wt"
+
+# A lock with no reason at all is normal Git usage and must not read as
+# "unlocked" — that is the one state where removal is least safe.
+git -C "$sweep_repo" worktree lock "$sweep_wt"
+run_guard status "$sweep_wt"
+assert_eq "$RUN_RC" "4" "status of a reasonless lock"
+json_parse "$run_out"
+assert_eq "$(json_field "$run_out" locked)" "true" "reasonless lock locked flag"
+assert_eq "$(json_field "$run_out" managed)" "false" "reasonless lock managed flag"
+
+run_guard claim "$sweep_wt" --owner CC-1000
+assert_eq "$RUN_RC" "75" "claiming a reasonless-locked worktree"
+assert_contains "$run_err" "(locked with no reason recorded)"
+
+git -C "$sweep_repo" worktree unlock "$sweep_wt"
+
+# ── list enumerates linked worktrees only ────────────────────────────
+
+read -r list_repo list_wt_a <<<"$(new_fixture list alpha)"
+[[ -d "$list_repo" && -d "$list_wt_a" ]] || fail "list fixture was not created"
+list_wt_b="$tmp_dir/list-wt-b"
+git -C "$list_repo" worktree add -q -b beta "$list_wt_b" main
+"$GUARD" claim "$list_wt_a" --owner CC-1000 >/dev/null
+
+run_guard list --repo "$list_repo"
+assert_eq "$RUN_RC" "0" "list on a two-worktree repository"
+assert_eq "$(line_count "$run_out")" "2" "list must emit one object per linked worktree"
+assert_not_contains "$run_out" "\"path\":\"$list_repo\""
+assert_contains "$run_out" "\"path\":\"$list_wt_a\""
+assert_contains "$run_out" "\"path\":\"$list_wt_b\""
+assert_contains "$run_out" "\"owner\":\"CC-1000\""
+assert_contains "$run_out" '"managed":false'
+
+head -n 1 "$run_out" >"$tmp_dir/list-first.json"
+json_parse "$tmp_dir/list-first.json"
+
+# ── Relative-path worktree registrations ─────────────────────────────
+
+# Git >= 2.48 records a gitdir relative to the registration directory under
+# `worktree add --relative-paths` / worktree.useRelativePaths. Comparing that
+# recorded value to an absolute path can never match, which made every command
+# in such a repository silently report that nothing was there — including
+# sweep, the recovery path. Every assertion below mirrors the absolute-path
+# fixture.
+wt_add_help="$tmp_dir/worktree-add-help.txt"
+git worktree add -h >"$wt_add_help" 2>&1 || true
+# Git spells the flag "--[no-]relative-paths" in its own usage output.
+if grep -Fq -- 'relative-paths' "$wt_add_help"; then
+	read -r rel_repo rel_wt <<<"$(new_fixture rel related relative)"
+	[[ -d "$rel_repo" && -d "$rel_wt" ]] || fail "relative-path fixture was not created"
+	grep -qv '^/' "$rel_repo/.git/worktrees/rel-wt/gitdir" \
+		|| fail "relative-path fixture did not record a relative gitdir"
+
+	run_guard claim "$rel_wt" --owner CC-1000
+	assert_eq "$RUN_RC" "0" "claim on a relative-path worktree"
+	assert_contains "$run_out" "claimed"
+
+	# Prove the suite's own lease reader resolves a relative registration
+	# before relying on it below; a helper that silently reports "not locked"
+	# would make the closing assertion vacuous.
+	lock_reason_of "$rel_repo" "$rel_wt" | grep -Fq "owner=CC-1000" \
+		|| fail "the test helper cannot read a relative-path registration's lease"
+
+	run_guard status "$rel_wt" --owner CC-1000
+	assert_eq "$RUN_RC" "0" "status on a relative-path worktree"
+	assert_eq "$(json_field "$run_out" managed)" "true" "relative-path managed flag"
+
+	run_guard status "$rel_wt" --owner CC-999
+	assert_eq "$RUN_RC" "75" "status --owner on a relative-path worktree"
+
+	run_guard list --repo "$rel_repo"
+	assert_eq "$RUN_RC" "0" "list on a relative-path repository"
+	assert_eq "$(line_count "$run_out")" "1" "list must report the relative-path worktree"
+	assert_contains "$run_out" "\"owner\":\"CC-1000\""
+
+	rel_cleanup_err="$tmp_dir/rel-cleanup.err"
+	if git -C "$rel_repo" worktree remove --force "$rel_wt" 2>"$rel_cleanup_err"; then
+		fail "cleanup removed a claimed relative-path worktree"
+	fi
+	assert_contains "$rel_cleanup_err" "cannot remove a locked working tree"
+
+	# The silent-success report this whole class of bug produces.
+	run_guard sweep --repo "$rel_repo" --ttl-minutes 0
+	assert_eq "$RUN_RC" "0" "sweep on a relative-path repository"
+	assert_not_contains "$run_out" "no stale session claims"
+	assert_contains "$run_out" "released"
+	if lock_reason_of "$rel_repo" "$rel_wt" >/dev/null 2>&1; then
+		fail "sweep must release the relative-path lease"
+	fi
+else
+	printf 'SKIP: git lacks worktree add --relative-paths\n' >&2
+fi
+
+# ── Enumeration failure must not read as a clean repository ──────────
+
+# A sweep that cannot even list the repository's worktrees examined nothing,
+# so reporting "no stale session claims" would be the worst answer available
+# to a recovery command. Force the enumeration to fail with a git shim that
+# rejects `worktree list` and delegates everything else.
+read -r enum_repo enum_wt <<<"$(new_fixture enum enumerated)"
+[[ -d "$enum_repo" && -d "$enum_wt" ]] || fail "enumeration fixture was not created"
+"$GUARD" claim "$enum_wt" --owner CC-1000 >/dev/null
+
+git_shim_dir="$tmp_dir/git-shim"
+mkdir -p "$git_shim_dir"
+real_git="$(command -v git)"
+{
+	printf '#!/usr/bin/env bash\n'
+	printf 'prev=""\n'
+	printf 'for arg in "$@"; do\n'
+	printf '\tif [[ "$prev" == worktree && "$arg" == list ]]; then\n'
+	printf '\t\tprintf "fatal: simulated enumeration failure\\n" >&2\n'
+	printf '\t\texit 128\n'
+	printf '\tfi\n'
+	printf '\tprev="$arg"\n'
+	printf 'done\n'
+	printf 'exec %s "$@"\n' "$real_git"
+} >"$git_shim_dir/git"
+chmod +x "$git_shim_dir/git"
+
+RUN_RC=0
+PATH="$git_shim_dir:$PATH" "$GUARD" sweep --repo "$enum_repo" >"$run_out" 2>"$run_err" || RUN_RC=$?
+assert_eq "$RUN_RC" "5" "sweep when the worktrees cannot be enumerated"
+assert_not_contains "$run_out" "no stale session claims"
+assert_contains "$run_err" "could not enumerate the worktrees"
+assert_contains "$run_err" "$enum_repo"
+lock_reason_of "$enum_repo" "$enum_wt" >/dev/null \
+	|| fail "a failed enumeration must leave every lease untouched"
+
+RUN_RC=0
+PATH="$git_shim_dir:$PATH" "$GUARD" list --repo "$enum_repo" >"$run_out" 2>"$run_err" || RUN_RC=$?
+assert_eq "$RUN_RC" "5" "list when the worktrees cannot be enumerated"
+assert_eq "$(line_count "$run_out")" "0" "list must emit nothing when enumeration failed"
+assert_contains "$run_err" "could not enumerate the worktrees"
+
+# The shim must not be masking a broken fixture: the same commands succeed
+# without it.
+run_guard list --repo "$enum_repo"
+assert_eq "$RUN_RC" "0" "list must succeed once enumeration works again"
+assert_eq "$(line_count "$run_out")" "1" "list must report the enumeration fixture"
+
+# ── The documented exit-code contract ────────────────────────────────
+
+# The skill's agent-facing documents restate the exit codes agents are told to branch
+# on. The behavioural assertions above pin what the tool returns; these pin the
+# prose to the same list, so an exit-code change cannot leave the documents
+# confidently wrong while the suite stays green.
+exit_code_prose='0 lease for this owner, 1 path not registered, 3 unclaimed, 4 locked outside the guard, 75'
+for doc in SKILL.md README.md; do
+	assert_contains_prose "$ROOT_DIR/$doc" "$exit_code_prose"
+done
+
+# The tool's own usage table is the fourth copy of the contract and drifted
+# once already, so pin it too — including the refusal --stale added, which the
+# table's original wording did not cover.
+assert_contains_prose "$GUARD" \
+	'for release --stale, the lease is not yet past the TTL (any owner)'
+
+# The same-issue limitation must travel with the probe wherever it is
+# prescribed, and must attribute the gap to the mechanism that actually has
+# it: bare create refuses existing ownership, --reuse|--restack does not, and
+# the per-issue claim lock is only a mutex over concurrent create invocations.
+# The guard header is included because that is where the earlier
+# misattribution originated.
+for doc in SKILL.md README.md scripts/worktree-session-guard; do
+	assert_contains_prose "$ROOT_DIR/$doc" "nothing prevents a second implementer there"
+done
+
+# Staleness has no liveness check, so every copy that recommends a stale
+# release must name the failure mode rather than promise it cannot happen.
+# This is the second guarantee of this class to propagate across every
+# copy, so it is pinned like the others.
+for doc in SKILL.md README.md scripts/worktree-session-guard; do
+	assert_contains_prose "$ROOT_DIR/$doc" "outlived its TTL without refreshing"
+done
+
+# The guard's availability is a capability, not a platform: it checks only
+# whether flock is on PATH, and a Homebrew macOS setup installs flock. Pinning the capability framing keeps a reader on a configured macOS
+# host from skipping a claim that would in fact have protected them — the
+# under-promise direction is the harmful one here.
+for doc in SKILL.md README.md scripts/worktree-session-guard; do
+	assert_contains_prose "$ROOT_DIR/$doc" "wherever flock is available, the claim is mandatory"
+done
+
+printf 'PASS: worktree session guard regressions\n'


### PR DESCRIPTION
Ports hyprtrade's `tools/worktree-session-guard` into the worktree skill, with its regression suite. **Half of #877** — the mechanism, not the lifecycle wiring. Reasoning for the split is below and it is not a scoping dodge.

## What lands

Nothing about the guard was project-specific, and the skill already documented the choreography it automates, so every consumer was carrying a copy of the script *plus* per-repo agent docs telling sessions to remember the claim/release dance by hand.

The lease is a **native git worktree lock** whose reason line carries owner and heartbeat, so `git worktree remove [--force]` refuses it and `git worktree prune` keeps the registration — no cooperation needed from whoever runs the cleanup, which a private marker file would require.

Adapted for vstack:
- marker renamed to `vstack-session-guard`
- owner resolves from `VSTACK_SESSION_OWNER`, with `HT_SESSION_OWNER` still honoured so hyprtrade sessions keep working
- the doc-coverage assertions now pin this skill's `SKILL.md`/`README.md` instead of hyprtrade's four documents

Those assertions are why the exit-code contract, the same-issue limitation, the no-liveness-check warning, and the flock capability framing all appear verbatim in the docs — the suite fails if prose and behaviour drift apart.

**201 assertions pass.** Full worktree suite **17/17**, with no behaviour change to any existing flow, because nothing calls the guard yet.

## Why the lifecycle wiring is not here

I implemented it. The integration test I wrote proved the whole lifecycle works — claim on `create`, refresh on `--reuse`, release-then-remove, foreign lease refused with the owner named, `cleanup` skipping a claimed worktree, `--stale` collecting a past-TTL one. 16/16.

It also broke **three existing suites**, and not as a test artifact:

```
worktree_base_dir.sh              6 cleanup assertions
worktree_create_active_guard.sh   fatal: already locked
worktree_recover_local.sh         fatal: cannot remove a locked working tree
```

The root cause is a design consequence the proposal did not reckon with: with `create` always claiming and only `remove` releasing, **every worktree stays claimed for its whole life**, so a lease-aware `cleanup` stops collecting merged worktrees at all unless `--stale` is passed. That is a behaviour change for every consumer of the skill.

The obvious alternative — release the lease once a branch is provably merged — weakens exactly the protection the guard exists for, because uncommitted work in the tree would still be lost. That is the incident shape, not a hypothetical.

Choosing between those is a policy call with cross-repo impact, so the mechanism ships first rather than the choice being guessed at inside a refactor. The trade-off is written into `SKILL.md` and `README.md` so the next reader does not have to rediscover it.

Two smaller things worth knowing for whoever picks up the wiring, both found the hard way:

1. `claim`/`refresh` **reject** `--repo` (it applies only to `release`/`status`/`list`/`sweep`). Passing it makes every claim fail — and a best-effort wrapper swallows that, so the guard looks installed and never actually claims.
2. `remove` must release **before** the existing `refuse_locked_worktree` precheck, or a session cannot remove its own worktree. It is addressed by ID *or* path while `create` records the owner as typed, so the release has to try both spellings.

Refs #877

https://claude.ai/code/session_01CCHxmznh9aLRCFAEZNkNRD
