### PR TITLE
feat(worktree,orch): wire the session guard into the destructive lifecycle (#877)

### DIFF
--- a/skills/orch/workflows/start.md
+++ b/skills/orch/workflows/start.md
@@ -85,6 +85,18 @@ If the issue is not open, stop and ask for a different item.
    ```
    Exit 75 means a branch or open PR already owns the issue even though the configured path was absent; inspect/monitor it instead of delegating. Use the successful create output as `WT_PATH`.
 
+5. **Claim the worktree for this session.** `create` never claims — a lease means "a live session is working here", and this workflow is what knows that (vstack#877). Run it for a worktree you just created AND for an existing one you confirmed you own in step 3 above:
+
+   ```bash
+   .agents/skills/worktree/scripts/worktree-session-guard claim [WT_PATH] --owner [ISSUE_ID]
+   ```
+
+   While the lease is held, `worktree cleanup` will not collect this tree and another session's `create --reuse` is refused by name. `worktree remove` releases it at teardown, so nothing else has to.
+
+   Do **not** pass `--repo`: `claim` and `refresh` reject it, and a swallowed failure leaves the guard looking installed while it silently never claims.
+
+   Exit 75 means another session already holds the lease — treat it exactly like step 3's existing-worktree case and coordinate instead of proceeding. Exit 1 with a `flock` message means the host has no `flock`, so the session runs unguarded; continue, but do not assume the tree is protected.
+
 ## 5. Handoff Or Continue
 
 Ask one action:

--- a/skills/worktree/README.md
+++ b/skills/worktree/README.md
@@ -16,7 +16,19 @@ skills/worktree/
 
 `worktree-session-guard` records a session's claim on an issue worktree as a **native Git worktree lock** whose reason line carries the owner and heartbeat, so `git worktree remove [--force]` refuses it and `git worktree prune` leaves the registration alone. Using the native lock rather than a private marker file is deliberate: it needs no cooperation from whoever runs the cleanup.
 
-The `worktree` entry point does **not** drive it yet — claim and release explicitly (vstack#877). Wiring `create` to claim while only `remove` releases would leave every worktree claimed for its whole life, which turns a lease-aware `cleanup` into a no-op unless `--stale` is passed; that trade is a policy decision, so the mechanism ships ahead of the integration. `VSTACK_SESSION_OWNER` sets the owner, which the workflow sets to the issue ID.
+`VSTACK_SESSION_OWNER` sets the owner, which the workflow sets to the issue ID.
+
+**Claiming is explicit; the destructive commands respect a lease** (vstack#877):
+
+| Command | Behaviour |
+|---|---|
+| `create` | never claims |
+| `create --reuse\|--restack` | refuses a foreign lease by name (exit 75), refreshes its own in place |
+| `remove` | releases its own lease first, so a claiming session can tear down its tree; a foreign lease refuses the removal |
+| `cleanup` | never collects a claimed worktree, and reports every skip |
+| `cleanup --stale [--ttl-minutes N]` | also releases and collects leases past the TTL (default 720) |
+
+`create` deliberately does not claim: a lease means "a live session is working here", which only something that knows a session's lifetime can assert — orch claims in `orch/workflows/start.md`. If `create` claimed, every worktree would stay claimed for life and `cleanup` would collect nothing without `--stale`; releasing on a merged branch was the other candidate and it guts the guarantee, since uncommitted work in a merged tree is what the originating incident lost.
 
 `status PATH --owner NAME` is the read-only ownership probe and answers by exit code alone: 0 lease for this owner, 1 path not registered, 3 unclaimed, 4 locked outside the guard, 75 claimed by a different owner. `claim` is not a probe — it takes or rewrites the lease.
 

--- a/skills/worktree/SKILL.md
+++ b/skills/worktree/SKILL.md
@@ -241,7 +241,7 @@ Some execution policies reject top-level `git rebase` porcelain outright — Cod
 
 `scripts/worktree-session-guard` stops cleanup from destroying a worktree a session is still working in. The lease is recorded as a **native Git worktree lock** whose reason line carries the owner and heartbeat, so `git worktree remove [--force]` refuses it and `git worktree prune` never prunes the registration — even after the directory itself is gone. That needs no cooperation from whoever runs the cleanup, which a private marker file would.
 
-**Not yet wired into `create`/`remove`/`cleanup`** — drive it explicitly for now (vstack#877 tracks the lifecycle integration; see the note at the end of this section for why it is not automatic yet). Owner defaults to `$VSTACK_SESSION_OWNER`, else `$USER`; the workflow sets it to the issue ID:
+**Claiming is explicit; the destructive commands are wired** (vstack#877). Owner defaults to `$VSTACK_SESSION_OWNER`, else `$USER`; the workflow sets it to the issue ID:
 
 ```bash
 scripts/worktree-session-guard claim   <PATH> --owner <ID>
@@ -251,6 +251,22 @@ scripts/worktree-session-guard sweep --dry-run               # every lease past 
 ```
 
 **Exit codes** — `status` answers "may I work here?" by exit code alone: 0 lease for this owner, 1 path not registered, 3 unclaimed, 4 locked outside the guard, 75 claimed by a different owner. Use `status`, not `claim`, to probe: `claim` takes or rewrites the lease.
+
+**`--repo` applies only to `release`/`status`/`list`/`sweep`.** `claim` and `refresh` reject it, because the target worktree is itself a checkout of the repository. Passing it makes every claim fail, and a best-effort wrapper around that swallows the error — the guard then looks installed while silently never claiming, with `status` returning 3 as the only symptom.
+
+### Lifecycle
+
+| Command | Behaviour |
+|---|---|
+| `worktree create` | **Never claims.** A fresh worktree is unclaimed. |
+| `worktree create --reuse\|--restack` | Refuses a foreign lease by name (exit 75); **refreshes** its own in place, so a long reuse cycle cannot age past the TTL and be swept. |
+| `worktree remove` | Releases **its own** lease before removing, so a claiming session can tear down its own tree. A foreign lease is left alone and refuses the removal, naming the owner. |
+| `worktree cleanup` | **Never collects a claimed worktree** — not even one this session claimed, since our own lease still means work is in progress. Every skip is reported; a quiet cleanup means nothing was held back. |
+| `worktree cleanup --stale [--ttl-minutes N]` | Additionally releases and collects leases past the TTL (default 720) — the abandoned-session recovery path. |
+
+**Claiming is the caller's job, deliberately.** A lease means "a live session is working here", and only something that knows a session's lifetime can say that truthfully. orch claims in `orch/workflows/start.md` once the worktree is the session's, and `remove` releases at teardown.
+
+If `create` claimed instead, every worktree would stay claimed for life — nothing but an explicit `remove` releases — so a lease-aware `cleanup` would collect nothing without `--stale`, trading a silent-destruction bug for a silent-accumulation one. Releasing on a provably merged branch was the other candidate and it guts the guarantee: a merged branch does not mean an idle tree, and uncommitted work in one is exactly what the incident behind this guard lost.
 
 **Limits, stated rather than papered over.**
 
@@ -262,7 +278,7 @@ The guard requires `flock(1)` and checks only whether it is on PATH — it is a 
 
 A Git worktree lock does not block writes, commits, or rebases inside the worktree, and `git worktree remove -f -f` or a plain `rm -rf` still destroy a claimed tree — `status` and `list` exist so such a removal can be attributed afterwards.
 
-**Why the lifecycle wiring is not in yet.** Claiming on `create` and releasing only on `remove` leaves every worktree claimed for its whole life, so a lease-aware `cleanup` stops collecting merged worktrees entirely unless `--stale` is passed — a behaviour change for every consumer, not a local one. Deciding whether that is the right trade (or whether a provably-merged branch should release the lease, since the work has landed) is a policy call, so the mechanism ships first and the wiring waits on that decision.
+Without `$VSTACK_SESSION_OWNER` (or `$HT_SESSION_OWNER`) the owner falls back to `$USER`, which is a login rather than a session: two sessions on one machine then share an identity, and either can `remove` a tree the other claimed. `cleanup` is unaffected — it skips every lease regardless of owner — so the exposure is limited to explicitly naming another session's worktree. Set the session owner to make a lease name one session.
 
 ## System Dependencies
 

--- a/skills/worktree/scripts/worktree
+++ b/skills/worktree/scripts/worktree
@@ -15,6 +15,13 @@
 #     continue        Continue an exact tool-created, paused restack
 #     skip            Skip the current commit in that paused restack
 #     abort           Abort that paused restack and clear pending authorization
+#   cleanup options:
+#     --stale         Also collect worktrees whose session guard lease is past
+#                     the TTL (an abandoned session)
+#     --ttl-minutes N Staleness horizon for --stale (default: 720)
+#
+# Session guard: `create` never claims a lease — see the "Session guard
+# lifecycle" block below for why, and orch's workflows/start.md for who does.
 #
 # Layout: main checkout (repo) + external worktree parent dir
 #   default: <parent-of-checkout>/.worktrees/<checkout-name>/{id}
@@ -1630,6 +1637,154 @@ worktree_lock_reason() {
   printf '%s\n' "${reason:-locked}"
 }
 
+# ─── Session guard lifecycle (#877) ──────────────────────────────────────────
+#
+# `worktree-session-guard` wraps git's native worktree lock with owner/TTL lease
+# semantics. Claiming is deliberately NOT automatic — `create` never takes a
+# lease.
+#
+# The reason is that a lease means "a live session is working here", and only
+# something that knows a session's lifetime can say that truthfully. If `create`
+# claimed, every worktree would stay claimed for life (nothing but an explicit
+# `remove` releases), so a lease-aware `cleanup` would collect nothing without
+# `--stale` — trading a silent-destruction bug for a silent-accumulation one.
+# Claiming therefore stays with the caller that knows when work starts and ends;
+# orch does it in `workflows/start.md`.
+#
+# What IS automatic is the destructive side, because that is where the incident
+# was (hyprtrade CC-1000, worktrees destroyed under live sessions):
+#
+#   cleanup           never collects a worktree under a guard lease; `--stale`
+#                     collects leases past the TTL
+#   remove            releases only the caller's OWN lease, so a claiming
+#                     session can still tear down its own tree
+#   create --reuse    refuses a foreign lease by name, refreshes its own
+#
+SESSION_GUARD="$SCRIPT_DIR/worktree-session-guard"
+readonly SESSION_GUARD_DEFAULT_TTL_MINUTES=720
+
+session_guard_available() {
+  [[ -x "$SESSION_GUARD" ]]
+}
+
+# Mirror the guard's own owner resolution so `claim` and `remove` cannot
+# disagree about identity. $USER is a login, not a session: two sessions on one
+# machine share it. orch sets VSTACK_SESSION_OWNER to the issue ID, which is
+# what makes a lease name one session.
+session_guard_owner() {
+  printf '%s' "${VSTACK_SESSION_OWNER:-${HT_SESSION_OWNER:-${USER:-}}}"
+}
+
+# Read-only ownership probe. Sets SESSION_GUARD_PROBE_ERR to the guard's own
+# stderr so a caller can quote it verbatim (it names the owning session).
+# Returns the guard's status exit code: 0 ours, 3 no lock, 4 locked outside the
+# guard, 75 someone else's.
+#
+# `--repo` is passed deliberately: `status`/`release` accept it, so the probe
+# does not depend on the caller's cwd. `claim`/`refresh` REJECT it — see
+# refresh_own_session_lease.
+probe_session_lease() {
+  local wt="$1" owner="$2" rc=0
+  SESSION_GUARD_PROBE_ERR=""
+  SESSION_GUARD_PROBE_ERR="$("$SESSION_GUARD" status "$wt" --owner "$owner" --repo "$PROJECT_ROOT" 2>&1 >/dev/null)" || rc=$?
+  return "$rc"
+}
+
+# Release this session's OWN lease on a worktree it is about to remove. Without
+# this a session that claimed its worktree cannot tear it down — the lease is a
+# native git lock, so `refuse_locked_worktree` and git itself both refuse. It
+# must therefore run BEFORE that precheck, and after the ownership guard so a
+# foreign repository's lease is never touched.
+#
+# Only an owner-matching guard lease is released. A foreign lease, a lock taken
+# outside the guard, and an unreadable state are all left exactly as they are
+# and fall through to the precheck, which names the owner and the way out.
+release_own_session_lease() {
+  local wt="$1" owner rc=0
+  session_guard_available || return 0
+  owner="$(session_guard_owner)"
+  [[ -n "$owner" ]] || return 0
+  probe_session_lease "$wt" "$owner" || rc=$?
+  # 0 alone means "a guard lease exists AND it is ours".
+  [[ "$rc" -eq 0 ]] || return 0
+  if ! "$SESSION_GUARD" release "$wt" --owner "$owner" --repo "$PROJECT_ROOT" >/dev/null; then
+    echo "Error: could not release this session's guard lease on $wt; refusing to remove it." >&2
+    echo "  Release it, then retry: $SESSION_GUARD release \"$wt\" --owner \"$owner\"" >&2
+    return 1
+  fi
+  echo "Released session guard lease (owner=$owner): $wt" >&2
+  return 0
+}
+
+# `--reuse`/`--restack` re-enter an existing worktree, which is the
+# second-implementer gap of #571 for the session-lifetime case. A foreign lease
+# is refused by name; our own is refreshed so a long reuse cycle cannot age past
+# the TTL and be swept while it is still working.
+reuse_respects_session_lease() {
+  local wt="$1" owner rc=0
+  session_guard_available || return 0
+  owner="$(session_guard_owner)"
+  [[ -n "$owner" ]] || return 0
+  probe_session_lease "$wt" "$owner" || rc=$?
+  case "$rc" in
+    3) return 0 ;;  # no lock at all
+    4) return 0 ;;  # locked outside the guard — refuse_locked_worktree's business
+    0) ;;
+    75)
+      echo "Error: $wt is claimed by another session; refusing to reuse it." >&2
+      [[ -n "$SESSION_GUARD_PROBE_ERR" ]] && printf '%s\n' "$SESSION_GUARD_PROBE_ERR" | sed 's/^/  /' >&2
+      echo "Coordinate with the owning session instead of reusing its worktree." >&2
+      return 1
+      ;;
+    *)
+      echo "Error: could not read the session guard state of $wt (exit $rc); refusing to reuse it." >&2
+      [[ -n "$SESSION_GUARD_PROBE_ERR" ]] && printf '%s\n' "$SESSION_GUARD_PROBE_ERR" | sed 's/^/  /' >&2
+      return 1
+      ;;
+  esac
+  # `refresh` REJECTS `--repo` — it applies only to release/status/list/sweep.
+  # Passing it fails every refresh, and a best-effort wrapper would swallow that
+  # so the guard looks wired while silently never refreshing. Do not add it.
+  if ! "$SESSION_GUARD" refresh "$wt" --owner "$owner" >/dev/null; then
+    echo "Error: could not refresh this session's guard lease on $wt." >&2
+    return 1
+  fi
+  return 0
+}
+
+# `cleanup` is the untargeted sweeper, so it is the operation that destroyed
+# live worktrees in the incident this guard exists for. It never removes a
+# claimed worktree — not even one claimed by THIS session, since our own lease
+# still means work is in progress there.
+cleanup_lease_permits_removal() {
+  local wt="$1" rc=0
+  session_guard_available || return 0
+  "$SESSION_GUARD" status "$wt" --repo "$PROJECT_ROOT" >/dev/null 2>&1 || rc=$?
+  case "$rc" in
+    3) return 0 ;;     # no lock at all
+    0 | 75) ;;         # a guard lease is present — ours (0) or another's (75)
+    4)
+      echo "Skipped (locked outside the session guard): $wt" >&2
+      return 1
+      ;;
+    *)
+      echo "Skipped (session guard state could not be read, exit $rc): $wt" >&2
+      return 1
+      ;;
+  esac
+  if [[ "$CLEANUP_STALE" != true ]]; then
+    echo "Skipped (a session holds a guard lease): $wt" >&2
+    echo "  Let that session release it, or pass --stale to collect leases past the ${CLEANUP_TTL_MINUTES}m TTL." >&2
+    return 1
+  fi
+  if "$SESSION_GUARD" release "$wt" --stale --ttl-minutes "$CLEANUP_TTL_MINUTES" --repo "$PROJECT_ROOT" >/dev/null 2>&1; then
+    echo "Released stale session guard lease: $wt" >&2
+    return 0
+  fi
+  echo "Skipped (guard lease is not past the ${CLEANUP_TTL_MINUTES}m TTL): $wt" >&2
+  return 1
+}
+
 # Refuse to act on a worktree that carries a native `git worktree lock`.
 # `git worktree remove --force` does NOT override a lock (git wants `-f -f`),
 # so a locked worktree is unremovable. This is a DIAGNOSTIC precheck, not the
@@ -1969,6 +2124,11 @@ case "${1:-}" in
         refuse_existing_worktree "$ISSUE" "$WT_PATH" || exit "$ACTIVE_WORK_EXIT"
       fi
 
+      # A guard lease is the session-lifetime half of that same ownership
+      # signal: refuse another session's tree by name, refresh our own so a
+      # long reuse cycle cannot age past the TTL (#877). Before any mutation.
+      reuse_respects_session_lease "$WT_PATH" || exit "$ACTIVE_WORK_EXIT"
+
       # Network/ref discovery must succeed before the claim lock or any setup
       # mutation. Repeat it under the per-issue lock immediately before reuse.
       discover_ownership_remote_heads || exit 1
@@ -2229,6 +2389,13 @@ case "${1:-}" in
       if ! require_non_main_project_worktree "$WT_PATH" "remove it"; then
         exit 1
       fi
+      # A session that claimed this worktree must be able to tear it down, and
+      # its lease IS a native git lock — so the release has to come before the
+      # lock precheck below, not after it (#877). Only our own lease is
+      # released; a foreign one falls through and the precheck names its owner.
+      if ! release_own_session_lease "$WT_PATH"; then
+        exit 1
+      fi
       # Diagnostic precheck: a locked worktree cannot be removed, and git's own
       # refusal names neither the owning session nor the unlock command (#800).
       # Runs after the ownership guard so a foreign or main checkout is rejected
@@ -2291,6 +2458,44 @@ case "${1:-}" in
     ;;
 
   cleanup)
+    CLEANUP_STALE=false
+    CLEANUP_TTL_MINUTES="$SESSION_GUARD_DEFAULT_TTL_MINUTES"
+    shift || true
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --help|-h)
+          echo "Usage: $0 cleanup [--stale] [--ttl-minutes N]"
+          echo ""
+          echo "Remove worktrees whose branch is already merged into origin/$DEFAULT_BRANCH."
+          echo "A worktree held by a session guard lease is never collected, and every"
+          echo "skip is reported — a quiet cleanup means nothing was held back."
+          echo ""
+          echo "Options:"
+          echo "  --stale             Also collect worktrees whose guard lease is past the TTL"
+          echo "                      (an abandoned session). Releases the lease, then removes."
+          echo "  --ttl-minutes N     Staleness horizon for --stale (default: $SESSION_GUARD_DEFAULT_TTL_MINUTES)"
+          exit 0
+          ;;
+        --stale) CLEANUP_STALE=true; shift ;;
+        --ttl-minutes)
+          if [[ $# -lt 2 ]]; then
+            echo "Error: --ttl-minutes requires a value" >&2
+            exit 1
+          fi
+          if ! [[ "$2" =~ ^[0-9]{1,10}$ ]]; then
+            echo "Error: --ttl-minutes must be a non-negative integer of at most 10 digits" >&2
+            exit 1
+          fi
+          CLEANUP_TTL_MINUTES="$2"
+          shift 2
+          ;;
+        *)
+          echo "Error: unknown option '$1' for cleanup" >&2
+          echo "Run: $0 cleanup --help" >&2
+          exit 1
+          ;;
+      esac
+    done
     git_with_github_https_auth -C "$PROJECT_ROOT" fetch --prune origin
     CLEANUP_FAILED=false
     CLEANUP_MERGE_TARGET="origin/$DEFAULT_BRANCH"
@@ -2313,6 +2518,11 @@ case "${1:-}" in
       if [[ -n "$BRANCH" ]] && \
          git -C "$PROJECT_ROOT" show-ref --verify --quiet "refs/heads/$BRANCH" && \
          git -C "$PROJECT_ROOT" merge-base --is-ancestor "$BRANCH" "$CLEANUP_MERGE_TARGET"; then
+        # A merged branch does NOT mean an idle tree: uncommitted work in it is
+        # exactly what the CC-1000 incident lost. Ask the lease, not the branch.
+        if ! cleanup_lease_permits_removal "$wt"; then
+          continue
+        fi
         CLEANUP_REMOVE_OUTPUT=""
         if ! CLEANUP_REMOVE_OUTPUT="$(git -C "$PROJECT_ROOT" worktree remove --force "$wt" 2>&1)"; then
           CLEANUP_FAILED=true
@@ -2620,7 +2830,7 @@ case "${1:-}" in
     ;;
 
   *)
-    echo "Usage: $0 create|restack|list|remove|cleanup|path|exists|check|push|fix-links|codex-setup|codex-branch|codex-cleanup|claude-setup|claude-cleanup [ID|/path] [options]" >&2
+    echo "Usage: $0 create|restack|list|remove|cleanup [--stale]|path|exists|check|push|fix-links|codex-setup|codex-branch|codex-cleanup|claude-setup|claude-cleanup [ID|/path] [options]" >&2
     exit 1
     ;;
 esac

--- a/skills/worktree/tests/worktree_session_guard_lifecycle.sh
+++ b/skills/worktree/tests/worktree_session_guard_lifecycle.sh
@@ -1,0 +1,295 @@
+#!/usr/bin/env bash
+# Lifecycle integration between `worktree` and `worktree-session-guard` (#877).
+#
+# The shape under test is Option C from the issue: claiming is NOT automatic —
+# `create` never takes a lease — while the DESTRUCTIVE operations all respect
+# one. That split is the whole design:
+#
+#   * If `create` claimed, every worktree would stay claimed for life (nothing
+#     but an explicit `remove` releases), so a lease-aware `cleanup` would stop
+#     collecting merged worktrees entirely unless `--stale` were passed. The
+#     alternative — releasing on a provably merged branch — guts the guarantee,
+#     because uncommitted work in a merged tree is exactly what the CC-1000
+#     incident lost.
+#   * The destructive side is where the incident actually was, so that is what
+#     is wired: `cleanup` never collects a claimed tree, `remove` releases only
+#     its OWN lease, `create --reuse` refuses a foreign one and refreshes its
+#     own.
+#
+# The guard serializes every mutation through flock(1), so this suite can only
+# run where flock exists — a capability check, matching worktree_session_guard.sh.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKTREE_PACKAGE_DIR="$(cd "$TEST_DIR/.." && pwd)"
+WORKTREE_SCRIPT="$WORKTREE_PACKAGE_DIR/scripts/worktree"
+GUARD_SCRIPT="$WORKTREE_PACKAGE_DIR/scripts/worktree-session-guard"
+
+if ! command -v flock >/dev/null 2>&1; then
+  printf 'SKIP: worktree session guard lifecycle needs flock(1), which is not on PATH\n' >&2
+  exit 0
+fi
+
+TMP_ROOT="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+PASS=0
+FAIL=0
+
+pass() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+fail() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
+
+assert_eq() {
+  local got="$1" want="$2" name="$3"
+  if [[ "$got" == "$want" ]]; then
+    pass "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$name" "$want" "$got"
+  fi
+}
+
+assert_contains() {
+  local haystack="$1" needle="$2" name="$3"
+  if grep -qF -- "$needle" <<<"$haystack"; then
+    pass "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        wanted substring: %s\n        in: %s\n' "$name" "$needle" "$haystack"
+  fi
+}
+
+assert_path_exists() {
+  [[ -e "$1" ]] && pass "$2" || fail "$2 (missing: $1)"
+}
+
+assert_path_absent() {
+  [[ ! -e "$1" ]] && pass "$2" || fail "$2 (still exists: $1)"
+}
+
+# Exit code of `guard status`: 0 ours, 3 no lock, 4 non-guard lock, 75 foreign.
+guard_status_code() {
+  local wt="$1" repo="$2" rc=0
+  shift 2
+  "$GUARD_SCRIPT" status "$wt" --repo "$repo" "$@" >/dev/null 2>&1 || rc=$?
+  printf '%s' "$rc"
+}
+
+make_repo() {
+  local root="$1"
+  mkdir -p "$root/main" "$root/bin" "$root/gh-state"
+  git -C "$root/main" init -q -b main
+  git -C "$root/main" config user.email test@example.com
+  git -C "$root/main" config user.name Test
+  git -C "$root/main" config commit.gpgsign false
+  printf 'base\n' >"$root/main/base.txt"
+  git -C "$root/main" add base.txt
+  git -C "$root/main" commit -q -m base
+  printf 'WORKTREE_BASE_DIR="../trees"\n' >"$root/main/.env"
+  git init -q --bare "$root/origin.git"
+  git -C "$root/main" remote add origin "$root/origin.git"
+  git -C "$root/main" push -q -u origin main
+
+  cat >"$root/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}:${2:-}" in
+  pr:list) ;;
+  pr:view) printf 'issue-x\n' ;;
+esac
+STUB
+  chmod +x "$root/bin/gh"
+}
+
+# A merged worktree that `cleanup` would collect if nothing held it.
+add_merged_tree() {
+  local root="$1" name="$2"
+  git -C "$root/main" worktree add -q -b "$name" "$root/trees/$name" main
+}
+
+echo "=== create does not claim ==="
+
+ROOT="$TMP_ROOT/create"
+make_repo "$ROOT"
+export PATH="$ROOT/bin:$PATH"
+export GH_STATE="$ROOT/gh-state"
+export VSTACK_SESSION_OWNER="ISSUE-1"
+
+(cd "$ROOT/main" && "$WORKTREE_SCRIPT" create issue-1 >/dev/null 2>&1)
+CREATED="$ROOT/trees/issue-1"
+assert_path_exists "$CREATED" "create made the worktree"
+# 3 is "no lock at all". Anything else means create took a lease, which would
+# make cleanup lease-aware-but-useless for every consumer.
+assert_eq "$(guard_status_code "$CREATED" "$ROOT/main")" "3" \
+  "create leaves the worktree unclaimed"
+
+echo "=== remove releases its own lease ==="
+
+"$GUARD_SCRIPT" claim "$CREATED" --owner ISSUE-1 >/dev/null
+assert_eq "$(guard_status_code "$CREATED" "$ROOT/main" --owner ISSUE-1)" "0" \
+  "the lease is held before remove"
+set +e
+remove_out=$(cd "$ROOT/main" && "$WORKTREE_SCRIPT" remove issue-1 2>"$ROOT/remove.err")
+remove_code=$?
+set -e
+assert_eq "$remove_code" "0" "remove of a self-claimed worktree exits 0"
+assert_contains "$remove_out" "Removed: $CREATED" "remove reports the removal"
+assert_contains "$(cat "$ROOT/remove.err")" "Released session guard lease (owner=ISSUE-1)" \
+  "remove says it released the lease rather than doing it silently"
+assert_path_absent "$CREATED" "the self-claimed worktree is gone"
+
+echo "=== remove refuses a foreign lease ==="
+
+FOREIGN_ROOT="$TMP_ROOT/foreign"
+make_repo "$FOREIGN_ROOT"
+add_merged_tree "$FOREIGN_ROOT" "issue-foreign"
+FOREIGN_WT="$FOREIGN_ROOT/trees/issue-foreign"
+"$GUARD_SCRIPT" claim "$FOREIGN_WT" --owner OTHER-SESSION >/dev/null
+set +e
+foreign_out=$(cd "$FOREIGN_ROOT/main" && "$WORKTREE_SCRIPT" remove issue-foreign 2>"$FOREIGN_ROOT/foreign.err")
+foreign_code=$?
+set -e
+foreign_err="$(cat "$FOREIGN_ROOT/foreign.err")"
+assert_eq "$foreign_code" "1" "remove of a foreign-claimed worktree exits nonzero"
+assert_contains "$foreign_err" "locked worktree" "the refusal names the lock"
+assert_contains "$foreign_err" "OTHER-SESSION" "the refusal names the owning session"
+assert_contains "$foreign_err" "Nothing in the worktree was modified." \
+  "the refusal states the tree was left intact"
+assert_path_exists "$FOREIGN_WT" "the foreign-claimed worktree survives"
+assert_eq "$(guard_status_code "$FOREIGN_WT" "$FOREIGN_ROOT/main" --owner OTHER-SESSION)" "0" \
+  "the foreign lease is left in place"
+if grep -qF "Removed:" <<<"$foreign_out"; then
+  fail "remove of a foreign-claimed worktree does not report a removal"
+else
+  pass "remove of a foreign-claimed worktree does not report a removal"
+fi
+
+echo "=== cleanup is lease-aware ==="
+
+CLEAN_ROOT="$TMP_ROOT/cleanup"
+make_repo "$CLEAN_ROOT"
+add_merged_tree "$CLEAN_ROOT" "issue-free"
+add_merged_tree "$CLEAN_ROOT" "issue-held"
+HELD="$CLEAN_ROOT/trees/issue-held"
+FREE="$CLEAN_ROOT/trees/issue-free"
+"$GUARD_SCRIPT" claim "$HELD" --owner LIVE-SESSION >/dev/null
+
+set +e
+clean_out=$(cd "$CLEAN_ROOT/main" && "$WORKTREE_SCRIPT" cleanup 2>"$CLEAN_ROOT/cleanup.err")
+clean_code=$?
+set -e
+clean_err="$(cat "$CLEAN_ROOT/cleanup.err")"
+assert_eq "$clean_code" "0" "cleanup exits 0 with a held worktree present"
+assert_contains "$clean_out" "Cleaned: $FREE" "cleanup still collects unclaimed merged worktrees"
+assert_path_absent "$FREE" "the unclaimed merged worktree is gone"
+assert_path_exists "$HELD" "the claimed worktree survives cleanup"
+assert_contains "$clean_err" "Skipped (a session holds a guard lease): $HELD" \
+  "cleanup reports the skip instead of silently passing over it"
+assert_contains "$clean_err" "--stale" "the skip message names the recovery path"
+assert_eq "$(guard_status_code "$HELD" "$CLEAN_ROOT/main" --owner LIVE-SESSION)" "0" \
+  "cleanup does not release the lease it skipped"
+
+echo "=== cleanup --stale respects the TTL ==="
+
+# A fresh lease is not stale at any sane TTL, so --stale must still refuse it.
+set +e
+fresh_out=$(cd "$CLEAN_ROOT/main" && "$WORKTREE_SCRIPT" cleanup --stale 2>"$CLEAN_ROOT/fresh.err")
+fresh_code=$?
+set -e
+assert_eq "$fresh_code" "0" "cleanup --stale exits 0 with only a fresh lease"
+assert_path_exists "$HELD" "cleanup --stale leaves a fresh lease alone"
+assert_contains "$(cat "$CLEAN_ROOT/fresh.err")" "not past the" \
+  "cleanup --stale explains that the lease is too young"
+if grep -qF "Cleaned: $HELD" <<<"$fresh_out"; then
+  fail "cleanup --stale does not collect a fresh lease"
+else
+  pass "cleanup --stale does not collect a fresh lease"
+fi
+
+# --ttl-minutes 0 makes every lease stale, which is the abandoned-session path.
+set +e
+stale_out=$(cd "$CLEAN_ROOT/main" && "$WORKTREE_SCRIPT" cleanup --stale --ttl-minutes 0 2>"$CLEAN_ROOT/stale.err")
+stale_code=$?
+set -e
+assert_eq "$stale_code" "0" "cleanup --stale --ttl-minutes 0 exits 0"
+assert_contains "$stale_out" "Cleaned: $HELD" "cleanup --stale collects a past-TTL lease"
+assert_path_absent "$HELD" "the abandoned worktree is collected"
+assert_contains "$(cat "$CLEAN_ROOT/stale.err")" "Released stale session guard lease: $HELD" \
+  "cleanup --stale says which lease it released"
+
+echo "=== cleanup option handling ==="
+
+set +e
+bogus_err=$(cd "$CLEAN_ROOT/main" && "$WORKTREE_SCRIPT" cleanup --bogus 2>&1 >/dev/null)
+bogus_code=$?
+set -e
+assert_eq "$bogus_code" "1" "cleanup rejects an unknown option"
+assert_contains "$bogus_err" "unknown option '--bogus'" "cleanup names the unknown option"
+
+set +e
+ttl_err=$(cd "$CLEAN_ROOT/main" && "$WORKTREE_SCRIPT" cleanup --stale --ttl-minutes abc 2>&1 >/dev/null)
+ttl_code=$?
+set -e
+assert_eq "$ttl_code" "1" "cleanup rejects a non-numeric --ttl-minutes"
+assert_contains "$ttl_err" "non-negative integer" "the --ttl-minutes refusal says what is required"
+
+help_out=$(cd "$CLEAN_ROOT/main" && "$WORKTREE_SCRIPT" cleanup --help)
+assert_contains "$help_out" "--stale" "cleanup --help documents --stale"
+assert_contains "$help_out" "never collected" "cleanup --help states the lease guarantee"
+
+echo "=== create --reuse and leases ==="
+
+REUSE_ROOT="$TMP_ROOT/reuse"
+make_repo "$REUSE_ROOT"
+export GH_STATE="$REUSE_ROOT/gh-state"
+VSTACK_SESSION_OWNER="ISSUE-R" \
+  bash -c "cd '$REUSE_ROOT/main' && '$WORKTREE_SCRIPT' create issue-r" >/dev/null 2>&1
+REUSE_WT="$REUSE_ROOT/trees/issue-r"
+
+# Another session holds it: reuse must refuse by name and change nothing.
+"$GUARD_SCRIPT" claim "$REUSE_WT" --owner OTHER-R >/dev/null
+set +e
+reuse_err=$(VSTACK_SESSION_OWNER="ISSUE-R" bash -c \
+  "cd '$REUSE_ROOT/main' && '$WORKTREE_SCRIPT' create issue-r --reuse" 2>&1 >/dev/null)
+reuse_code=$?
+set -e
+assert_eq "$reuse_code" "75" "reuse of a foreign-claimed worktree exits 75 (active work)"
+assert_contains "$reuse_err" "claimed by another session" "the reuse refusal is explicit"
+assert_contains "$reuse_err" "OTHER-R" "the reuse refusal names the owning session"
+assert_path_exists "$REUSE_WT" "the foreign-claimed worktree survives a refused reuse"
+
+# Our own lease: reuse must REFRESH the heartbeat, not merely tolerate the
+# lease. A reuse cycle longer than the TTL would otherwise be swept as
+# abandoned while it is still working.
+"$GUARD_SCRIPT" release "$REUSE_WT" --owner OTHER-R --force >/dev/null 2>&1
+"$GUARD_SCRIPT" claim "$REUSE_WT" --owner ISSUE-R >/dev/null 2>&1
+lease_heartbeat() {
+  "$GUARD_SCRIPT" status "$REUSE_WT" --repo "$REUSE_ROOT/main" --owner ISSUE-R 2>/dev/null \
+    | jq -r '.heartbeat_at'
+}
+before_heartbeat="$(lease_heartbeat)"
+before_claimed="$("$GUARD_SCRIPT" status "$REUSE_WT" --repo "$REUSE_ROOT/main" --owner ISSUE-R 2>/dev/null | jq -r '.claimed_at')"
+sleep 1
+set +e
+VSTACK_SESSION_OWNER="ISSUE-R" bash -c \
+  "cd '$REUSE_ROOT/main' && '$WORKTREE_SCRIPT' create issue-r --reuse" >/dev/null 2>"$REUSE_ROOT/reuse-own.err"
+reuse_own_code=$?
+set -e
+after_heartbeat="$(lease_heartbeat)"
+after_claimed="$("$GUARD_SCRIPT" status "$REUSE_WT" --repo "$REUSE_ROOT/main" --owner ISSUE-R 2>/dev/null | jq -r '.claimed_at')"
+assert_eq "$reuse_own_code" "0" "reuse of a self-claimed worktree succeeds"
+assert_eq "$(guard_status_code "$REUSE_WT" "$REUSE_ROOT/main" --owner ISSUE-R)" "0" \
+  "reuse leaves our own lease in place"
+if [[ -n "$before_heartbeat" && "$after_heartbeat" > "$before_heartbeat" ]]; then
+  pass "reuse refreshes the lease heartbeat"
+else
+  fail "reuse refreshes the lease heartbeat (before=$before_heartbeat after=$after_heartbeat)"
+fi
+# `refresh` extends the heartbeat without ever unlocking; a re-claim would reset
+# claimed_at and momentarily drop the lock, which is what this pins against.
+assert_eq "$after_claimed" "$before_claimed" \
+  "reuse refreshes in place rather than re-claiming (lock never drops)"
+
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Implements **Option C** from the issue. #883 landed the mechanism; this wires it.

## Shape

| Command | Behaviour |
|---|---|
| `create` | **never claims** |
| `create --reuse\|--restack` | refuses a foreign lease by name (exit 75), **refreshes** its own in place |
| `remove` | releases only its **own** lease, before the lock precheck, so a claiming session can tear down its own tree; a foreign lease refuses and names the owner |
| `cleanup` | **never collects a claimed worktree** — including one this session claimed — and reports every skip |
| `cleanup --stale [--ttl-minutes N]` | also releases and collects leases past the TTL (default 720) |

orch claims in `workflows/start.md`, for both a freshly created worktree and an existing one it confirmed it owns. `remove` releases at teardown, so no workflow has to.

## Why `create` does not claim

A lease means "a live session is working here", which only something that knows a session's lifetime can assert. If `create` claimed, every worktree would stay claimed for life — nothing but an explicit `remove` releases — so a lease-aware `cleanup` would collect nothing without `--stale`, trading a silent-destruction bug for a silent-accumulation one.

That is not hypothetical. The earlier attempt at this broke `worktree_base_dir` (6 cleanup assertions), `worktree_create_active_guard`, and `worktree_recover_local` for exactly that reason. **All three are green here**, which is the evidence that C composes where A and B did not.

Releasing on a provably merged branch (option B) was the other candidate and it guts the guarantee: a merged branch does not mean an idle tree, and uncommitted work in one is precisely what the CC-1000 incident lost. So `cleanup` asks the lease, not the branch.

## The two traps, respected and recorded in the code

1. **`claim`/`refresh` reject `--repo`** — it applies only to `release`/`status`/`list`/`sweep`. Passing it fails every claim, and a best-effort wrapper swallows that, so the guard looks installed while silently never claiming (`status` returning 3 is the only symptom). The status/release probes *do* pass `--repo`, which is allowed and frees them from the caller's cwd; `refresh` does not, with a comment saying why not to "fix" it.
2. **The release in `remove` must precede `refuse_locked_worktree`**, because the lease *is* a native git lock — otherwise a session cannot remove its own worktree. It still runs after the ownership guard, so a foreign repository's lease is never touched.

## Ownership

Uses the guard's own resolution (`VSTACK_SESSION_OWNER` → `HT_SESSION_OWNER` → `$USER`) so `claim` and `remove` cannot disagree about identity. The `$USER` fallback is a login rather than a session; that is documented rather than papered over. `cleanup` is unaffected either way — it skips every lease regardless of owner, so the untargeted sweeper (the operation behind the incident) is fully protected.

## Tests

New `worktree_session_guard_lifecycle.sh`, **43 assertions**: create-does-not-claim, self-release-then-remove, foreign-lease refusal with the tree provably left intact, cleanup skip vs. collect, `--stale` TTL behaviour in **both** directions (a fresh lease is refused, a past-TTL one is collected), option handling, and that reuse *refreshes* the heartbeat without resetting `claimed_at` — i.e. it never drops the lock.

Full worktree suite green (18 files). orch `run-all` unchanged from main on this host.

Closes #877

https://claude.ai/code/session_01NRP92pU9qsPjWYM9FstQ8D