### PR TITLE
fix(reviewer,orch): put the item schema on the authoring path (#885)

### DIFF
--- a/skills/orch/scripts/review-artifact-check
+++ b/skills/orch/scripts/review-artifact-check
@@ -149,8 +149,18 @@ finding_item_detail() {
                   else [] end )
                 as $badnum
               | ($missing + $badcat + $badnum) as $problems
+              # Name the expected set, not just what is wrong. The rejection is
+              # relayed verbatim to the agent that has to redo the artifact, and
+              # a bare "missing id, description, estimate, category" does not
+              # tell it that `detail` should have been `description` or that
+              # priority stops at 4 — so the same agent reaches for `priority: 5`
+              # or a plausible-but-wrong field name again (vstack#885).
               | if ($problems | length) > 0
                 then "\($arr)[\($i)]: missing/invalid \($problems | join(", "))"
+                     + " — every blockers[]/suggestions[] item requires:"
+                     + " id, title, location (path plus symbol, no line numbers),"
+                     + " description, recommendation, priority (integer 1-4),"
+                     + " estimate (1-5); suggestions also category (fix|issue)"
                 else empty end
             )
           | (first(.[]) // "") ) )

--- a/skills/orch/tests/review_artifact_check.sh
+++ b/skills/orch/tests/review_artifact_check.sh
@@ -517,5 +517,81 @@ assert_file_contains "$submit_pr" 'review-artifact-check --file "$LOCAL_OUTPUT" 
 assert_file_contains "$submit_pr" "git-context timestamp epoch" "submit-pr captures an epoch boundary before running the local review"
 assert_file_contains "$submit_pr" 'reason `incomplete`' "submit-pr documents the incomplete-artifact rejection (vstack#678)"
 
+# --- vstack#885: the rejection has to teach the schema, not just flag it ---
+# Four artifacts were rejected in one session by agents that followed the
+# workflow text without opening the schema file. Two reached for `priority: 5`;
+# two used plausible-but-wrong field names (`detail`, `remediation`, `file`+
+# `line`). The rejection is relayed verbatim to the agent that must redo the
+# work, so it names the whole expected item shape.
+REQ_SPEC="every blockers[]/suggestions[] item requires: id, title, location (path plus symbol, no line numbers), description, recommendation, priority (integer 1-4), estimate (1-5); suggestions also category (fix|issue)"
+
+# The check exits 1 on a rejected artifact, which is the case under test here —
+# swallow it so `set -e`/`pipefail` do not abort the suite on an expected failure.
+detail_of() { "$CHECK" --file "$1" 2>/dev/null | jq -r '.detail // ""' || true; }
+
+# priority: 5 — the "lower than the lowest" instinct.
+p5="$TMP_ROOT/p5.json"
+jq -n '{agent:"reviewer-safety",timestamp:"t",verdict:"pass",summary:"s",blockers:[],
+  suggestions:[{id:1,title:"t",location:"a.rs (`f`)",description:"d",recommendation:"r",
+  priority:5,estimate:2,category:"fix"}],qa_metadata:{safety:{}}}' > "$p5"
+d="$(detail_of "$p5")"
+assert_substr "$d" "suggestions[0]: missing/invalid priority(not 1..4)" \
+  "priority 5 is still reported as out of range"
+assert_substr "$d" "$REQ_SPEC" "the priority rejection states the 1-4 range and the full item shape"
+
+# `detail` instead of `description`, with id/estimate/category omitted.
+alias1="$TMP_ROOT/alias1.json"
+jq -n '{agent:"reviewer-arch",timestamp:"t",verdict:"pass",summary:"s",blockers:[],
+  suggestions:[{title:"t",location:"a.rs",detail:"d",recommendation:"r",priority:3}],
+  qa_metadata:{arch_review:{}}}' > "$alias1"
+d="$(detail_of "$alias1")"
+assert_substr "$d" "suggestions[0]: missing/invalid id, description, estimate, category" \
+  "a detail/description swap is reported by field name"
+assert_substr "$d" "$REQ_SPEC" "the swap rejection names the correct field set"
+
+# file+line instead of location, remediation instead of recommendation.
+alias2="$TMP_ROOT/alias2.json"
+jq -n '{agent:"reviewer-safety",timestamp:"t",verdict:"pass",summary:"s",blockers:[],
+  suggestions:[{title:"t",file:"a.rs",line:12,description:"d",remediation:"r",priority:3}],
+  qa_metadata:{safety:{}}}' > "$alias2"
+d="$(detail_of "$alias2")"
+assert_substr "$d" "suggestions[0]: missing/invalid id, location, recommendation, estimate, category" \
+  "file/line and remediation are reported as the missing canonical fields"
+assert_substr "$d" "no line numbers" "the rejection states that location carries no line numbers"
+
+# Aliases are NOT accepted — one canonical spelling, taught rather than guessed.
+assert_eq "$("$CHECK" --file "$alias1" 2>/dev/null | jq -r '.reason' || true)" "incomplete" \
+  "an aliased field name is still rejected, not silently accepted"
+
+# A well-formed item produces no detail at all.
+good="$TMP_ROOT/good.json"
+jq -n '{agent:"reviewer-safety",timestamp:"t",verdict:"pass",summary:"s",blockers:[],
+  suggestions:[{id:1,title:"t",location:"a.rs (`f`)",description:"d",recommendation:"r",
+  priority:4,estimate:2,category:"issue"}],qa_metadata:{safety:{}}}' > "$good"
+assert_eq "$("$CHECK" --file "$good" | jq -r '.reason')" "valid" "a schema-correct artifact is still valid"
+assert_eq "$(detail_of "$good")" "" "a valid artifact carries no detail"
+
+# --- The authoring path must carry the requirements, not just the recovery path ---
+# This is the actual defect in vstack#885: an agent that follows the workflow
+# text without opening the schema file had strictly less information than the
+# rejection it would then receive.
+qa_review="$REPO_ROOT/skills/reviewer/workflows/qa-review.md"
+assert_file_contains "$qa_review" "priority" "qa-review 2.6 names the priority field inline"
+assert_file_contains "$qa_review" "1-4" "qa-review 2.6 states the priority range inline"
+assert_file_contains "$qa_review" "no line numbers" "qa-review 2.6 states the location shape inline"
+assert_file_contains "$qa_review" "recommendation" "qa-review 2.6 names recommendation inline"
+assert_file_contains "$qa_review" "fix" "qa-review 2.6 names the suggestion categories inline"
+
+reviewer_skill="$REPO_ROOT/skills/reviewer/SKILL.md"
+assert_file_contains "$reviewer_skill" "Output Contract" "reviewer SKILL has an output-contract section"
+assert_file_contains "$reviewer_skill" "1-4" "reviewer SKILL states the priority range"
+assert_file_contains "$reviewer_skill" "no 5" "reviewer SKILL says there is no P5"
+assert_file_contains "$reviewer_skill" 'not `detail`' "reviewer SKILL warns against the detail alias"
+assert_file_contains "$reviewer_skill" 'not `remediation`' "reviewer SKILL warns against the remediation alias"
+assert_file_contains "$reviewer_skill" "no line numbers" "reviewer SKILL states the location shape"
+
+review_pr_recovery="$REPO_ROOT/skills/orch/workflows/review-pr.md"
+assert_file_contains "$review_pr_recovery" "integer 1-4" "review-pr's rejection text states the priority range"
+
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/skills/orch/workflows/review-pr.md
+++ b/skills/orch/workflows/review-pr.md
@@ -269,7 +269,7 @@ Run `review-artifact-check` on every return message and every watchdog sweep. It
 
 **If `ok == false` after a return message** — the return is **incomplete** (even if its `File:` path looks valid or the message body contains JSON). Send that agent **exactly one** re-delegation:
 
-> Your review return is incomplete: `review-artifact-check` reports `[reason]`[ — `[detail]`] for `[WORKTREE_PATH]/tmp/review-[AGENT]-*.json`. Write your full review JSON to `[WORKTREE_PATH]/tmp/review-[AGENT]-YYYYMMDD-HHMMSS.json` using your harness file-write tool (not shell redirection), following every required field of `review-finding.md` (each `blockers[]`/`suggestions[]` item needs `id`, `title`, `location`, `description`, `recommendation`, `priority`, `estimate`; suggestions also `category ∈ {fix,issue}`), then return `Verdict:` and `File:` again.
+> Your review return is incomplete: `review-artifact-check` reports `[reason]`[ — `[detail]`] for `[WORKTREE_PATH]/tmp/review-[AGENT]-*.json`. Write your full review JSON to `[WORKTREE_PATH]/tmp/review-[AGENT]-YYYYMMDD-HHMMSS.json` using your harness file-write tool (not shell redirection), following every required field of `review-finding.md` (each `blockers[]`/`suggestions[]` item needs `id`, `title`, `location` — path plus symbol, no line numbers — `description`, `recommendation`, `priority` as an integer 1-4, `estimate` 1-5; suggestions also `category ∈ {fix,issue}`), then return `Verdict:` and `File:` again.
 
 If `review-artifact-check` still reports `ok == false` after the re-delegation return (or the agent hits its § 3.2 deadline), mark the agent `unresponsive` — do not re-delegate a second time.
 

--- a/skills/reviewer/SKILL.md
+++ b/skills/reviewer/SKILL.md
@@ -54,6 +54,27 @@ All reviewer agents share this baseline stance, then narrow it through their own
 
 Return `pass` only when your review domain has no verified blocker in scope. Put a finding in `blockers[]` when the scoped code introduces or contains a domain regression, an unjustified fallback-standard violation, or unresolved high-risk uncertainty that can be verified only by the author. Put a finding in `suggestions[]` only when it is actionable but non-blocking.
 
+## Output Contract
+
+Your review artifact is validated deterministically by orch's `review-artifact-check`. A single malformed item rejects the **whole** artifact and costs a re-delegation round-trip, so get the item shape right the first time.
+
+Every `blockers[]` and `suggestions[]` item requires all of:
+
+| Field | Value |
+|-------|-------|
+| `id` | Sequential number within its array |
+| `title` | Concise title, 5-10 words |
+| `location` | One string: path plus symbol, **no line numbers** — e.g. ``"rust-core/src/runtime/driver.rs (`RuntimeDriver::run_cycle`)"``. There are no `file`/`line` fields; line or hunk evidence belongs in `description`, where it cannot go stale |
+| `description` | The problem statement. The field is `description`, not `detail` |
+| `recommendation` | Actionable fix steps. The field is `recommendation`, not `remediation` |
+| `priority` | Integer **1-4** only — P1 Urgent, P2 High, P3 Normal, P4 Low |
+| `estimate` | 1-5 points (1=hours, 2=half-day, 3=day, 4=2-3 days, 5=week+) |
+| `category` | **Suggestions only**: `fix` (apply in this PR) or `issue` (track separately). The orchestrator routes suggestions on this field, so an item without it matches no filter and is silently dropped |
+
+**`priority` has no 5.** The instinct to reach for one is real — it usually means "the least important thing in this report" — but the scale ends at 4, and the schema has no place to record that ranking. Use P4, or drop the finding: a finding that does not justify P4 is one of the cosmetic items the approval bar above already excludes.
+
+Full schema, including `questions[]` and `qa_metadata`: [`schemas/review-finding.md`](./schemas/review-finding.md).
+
 ## Reviewer Scope Boundaries
 
 Use this table to avoid duplicate findings across parallel reviewers. If domains overlap, the primary owner reports the item; secondary reviewers report only when they add materially different evidence, impact, or remediation.

--- a/skills/reviewer/workflows/qa-review.md
+++ b/skills/reviewer/workflows/qa-review.md
@@ -119,6 +119,20 @@ targeted regression output.
 1. **Build JSON** per [`../schemas/review-finding.md`](../schemas/review-finding.md), filename `[WORKTREE_PATH]/tmp/review-[AGENT]-YYYYMMDD-HHMMSS.json`.
    - `[AGENT]` is your FULL agent name, including its `reviewer-` prefix. For `reviewer-security` the file is `review-reviewer-security-20260720-141530.json`. The doubled `review-reviewer-` is correct — do not shorten or de-duplicate it to `review-security-…`; orch's `review-artifact-check` globs the literal full agent name and reports the artifact `missing` otherwise.
    - Standard fields: `agent`, `timestamp`, `verdict`, `summary`, `blockers[]`, `suggestions[]`
+   - **Every `blockers[]` and `suggestions[]` item requires all of these.** `review-artifact-check` rejects the whole artifact if one item omits one field, and the rejection costs a re-delegation round-trip:
+
+     | Field | Value |
+     |-------|-------|
+     | `id` | Sequential number within its array |
+     | `title` | Concise title, 5-10 words |
+     | `location` | Path plus symbol, **no line numbers** — e.g. ``"rust-core/src/runtime/driver.rs (`RuntimeDriver::run_cycle`)"``. Line or hunk evidence goes in `description`, where it cannot go stale |
+     | `description` | The problem statement. Not `detail` |
+     | `recommendation` | Actionable fix steps. Not `remediation` |
+     | `priority` | Integer **1-4** only (P1 Urgent … P4 Low). There is no P5 — a finding below P4 is a P4 or is not worth reporting |
+     | `estimate` | 1-5 points (1=hours, 2=half-day, 3=day, 4=2-3 days, 5=week+) |
+     | `category` | **Suggestions only**: `fix` (apply in this PR) or `issue` (track separately). The orchestrator routes on this, so an item without it is silently dropped |
+
+     `file`/`line` are not fields — they are one `location` string. Full reference: [`../schemas/review-finding.md`](../schemas/review-finding.md).
    - If performance QA agent: include `benchmark_commit` from § 2.5
    - `qa_metadata.[agent_type]` populated per your agent (project-configurable):
 


### PR DESCRIPTION
## The defect

The authoring path had strictly **less** information than the recovery path. The reviewer workflows point at `schemas/review-finding.md` but never state the required item fields or the `priority` range inline, so an agent that follows the workflow text without opening the schema produces a rejected artifact — and only *then* reads a rejection message that enumerates the fields correctly.

Four artifacts were rejected in one session, each costing a re-delegation. Two failure shapes, each hit twice by different agents:

| Shape | Why it happens |
|---|---|
| `priority: 5` | Agents reach for "lower than the lowest" for a genuinely marginal finding. Nothing said the range is 1-4, and **both** affected agents described their item as the least important in the report — the out-of-range value expressed a real distinction the schema does not offer. |
| Plausible-but-wrong field names | `detail`/`remediation`/`file`+`line` are natural names for `description`/`recommendation`/`location`. `location` is worse than a rename: it is **one** string combining path and symbol, without line numbers. |

## Fixed at all three points

- **`reviewer/SKILL.md`** — new **Output Contract** section: the full item table, the aliases called out by name, and why there is no P5 (a finding that does not justify P4 is one the shared approval bar already excludes).
- **`reviewer/workflows/qa-review.md` § 2.6** — the same table inline, at the point the artifact is built.
- **`orch/workflows/review-pr.md` § 3.1** — the recovery text gains the ranges it was missing. It named the fields but not that `priority` stops at 4, which is why an agent could hit that twice.

## The rejection is now self-correcting

`review-artifact-check`'s `detail` names the whole expected item shape, not only what was wrong:

```
suggestions[0]: missing/invalid id, description, estimate, category — every
blockers[]/suggestions[] item requires: id, title, location (path plus symbol,
no line numbers), description, recommendation, priority (integer 1-4),
estimate (1-5); suggestions also category (fix|issue)
```

A bare `missing id, description, estimate, category` never told the agent that `detail` should have been `description`.

## Aliases deliberately not accepted

The report listed accepting `detail`→`description` as an option. Taking it would create two permanent spellings for one field and make the schema fuzzy at exactly the place orch routes on it. Teaching the shape at authoring time and naming it in the rejection solves the reported problem without that cost.

## Tests

The three real rejection shapes are replayed as fixtures, and their `detail` prefixes match the strings from the report **verbatim** — so these are the reported cases, not lookalikes. Plus doc-coverage assertions so the authoring path cannot silently lose the requirements again.

`review_artifact_check` 147/0 (was 122). orch `run-all` and the reviewer suites unchanged from main on this host.

Closes #885

https://claude.ai/code/session_01NRP92pU9qsPjWYM9FstQ8D