### PR TITLE
fix(cli): accept a .agents symlink into the same repository's worktree (#886)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,10 +116,14 @@ the local skill has no lock entry. For project-owned skills, vstack maintains
 only its marked `Project Instructions` block; updates and removals are
 idempotent and leave the rest of the skill and unrelated project files intact.
 Project skill installs and refreshes preflight the `.agents/skills` ownership
-boundary before changing project-owned skills. If `.agents` resolves outside
-the selected checkout, run the command from the checkout that owns it or use a
-project-local `.agents` directory. Failures leave the lock and installed files
-unchanged. Project hook removal uses the same strict preflight before changing
+boundary before changing project-owned skills. A `.agents` symlink into another
+working tree of the **same** repository is accepted — that is the layout the
+`worktree` skill provisions, so refresh works from an issue worktree and writes
+through to the shared `.agents` (same-repository identity is proved by
+`git rev-parse --git-common-dir`, not assumed from the path). If `.agents`
+resolves outside the selected checkout **and** outside its repository, run the
+command from the checkout that owns it or use a project-local `.agents`
+directory. Failures leave the lock and installed files unchanged. Project hook removal uses the same strict preflight before changing
 hook files, settings, locks, or generated agents; global removal remains
 independent of project configuration.
 

--- a/cli/src/commands/refresh.rs
+++ b/cli/src/commands/refresh.rs
@@ -689,6 +689,64 @@ run from the checkout that owns that path, or replace it with a project-local .a
     )
 }
 
+/// `git rev-parse --git-common-dir` for `dir`, canonicalized. `None` when `dir`
+/// is not inside a Git repository, when git is unavailable, or when the answer
+/// cannot be resolved — every one of which must fail closed at the call site.
+fn git_common_dir(dir: &Path) -> Option<PathBuf> {
+    let output = std::process::Command::new("git")
+        .args(["-C", dir.to_str()?, "rev-parse", "--git-common-dir"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let raw = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if raw.is_empty() {
+        return None;
+    }
+    // `--git-common-dir` is relative to the queried directory unless git is new
+    // enough to have been asked for an absolute path, so resolve it against
+    // `dir` rather than the process cwd.
+    let reported = Path::new(&raw);
+    let absolute = if reported.is_absolute() {
+        reported.to_path_buf()
+    } else {
+        dir.join(reported)
+    };
+    absolute.canonicalize().ok()
+}
+
+/// Positive proof that `target` lives in a working tree of the SAME repository
+/// as `project_root` — both resolve to one `--git-common-dir`.
+///
+/// This is not a relaxation of the containment boundary; it answers a different
+/// and stronger question. Lexical containment asks "is this path under the
+/// project directory", which cannot tell another checkout of the repository the
+/// operator is already working in from an arbitrary directory elsewhere on
+/// disk. vstack's own `worktree` skill provisions the first case: every issue
+/// worktree gets a `.agents` symlink into the main checkout so a ~100 MB harness
+/// library is shared rather than copied per branch (vstack#886). Refusing that
+/// made refresh unusable from any worktree.
+///
+/// Everything else still fails closed. A target that is not a repository has no
+/// common dir; a target in a DIFFERENT repository has a different one.
+fn is_same_repository_worktree(project_root: &Path, target: &Path) -> bool {
+    // `git -C` needs a directory. `target` is normally the canonical
+    // `.agents`/`.agents/skills` directory, but probe its parent if it is not.
+    let probe = if target.is_dir() {
+        target
+    } else {
+        match target.parent() {
+            Some(parent) => parent,
+            None => return false,
+        }
+    };
+    match (git_common_dir(project_root), git_common_dir(probe)) {
+        (Some(project_common), Some(target_common)) => project_common == target_common,
+        _ => false,
+    }
+}
+
 fn resolve_project_owned_skills_root(
     project_root: &Path,
 ) -> Result<Option<ProjectOwnedSkillsRoot>> {
@@ -703,7 +761,9 @@ fn resolve_project_owned_skills_root(
             let skills_dir_canon = skills_dir
                 .canonicalize()
                 .map_err(|err| anyhow::anyhow!("failed to resolve project-owned skills: {err}"))?;
-            if !skills_dir_canon.starts_with(&project_root_canon) {
+            if !skills_dir_canon.starts_with(&project_root_canon)
+                && !is_same_repository_worktree(&project_root_canon, &skills_dir_canon)
+            {
                 anyhow::bail!("{}", escaped_project_owned_skills_message(&skills_dir));
             }
             if !skills_dir_canon.is_dir() {
@@ -733,7 +793,9 @@ fn resolve_project_owned_skills_root(
             let agents_dir_canon = agents_dir
                 .canonicalize()
                 .map_err(|err| anyhow::anyhow!("failed to resolve .agents directory: {err}"))?;
-            if !agents_dir_canon.starts_with(&project_root_canon) {
+            if !agents_dir_canon.starts_with(&project_root_canon)
+                && !is_same_repository_worktree(&project_root_canon, &agents_dir_canon)
+            {
                 anyhow::bail!("{}", escaped_project_owned_skills_message(&skills_dir));
             }
             if !agents_dir_canon.is_dir() {

--- a/cli/src/commands/refresh/tests.rs
+++ b/cli/src/commands/refresh/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::config::{InstallMethod, LockEntry, LockFile};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 fn lock_hook(name: &str, harnesses: Vec<&str>) -> LockEntry {
@@ -36,6 +36,29 @@ fn source_hook_from_path(name: &str, harnesses: Option<Vec<&str>>, source_path: 
         script: String::new(),
         source_path,
     }
+}
+
+/// Run a git command in `dir`, reporting only whether it succeeded. Tests that
+/// need a real repository skip themselves when git is unavailable rather than
+/// failing a host that simply has no git.
+fn git_ok(dir: &Path, args: &[&str]) -> bool {
+    std::process::Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(args)
+        .output()
+        .map(|out| out.status.success())
+        .unwrap_or(false)
+}
+
+fn init_repo_with_commit(dir: &Path) -> bool {
+    git_ok(dir, &["init", "-q", "-b", "main"])
+        && git_ok(dir, &["config", "user.email", "test@example.com"])
+        && git_ok(dir, &["config", "user.name", "Test"])
+        && git_ok(dir, &["config", "commit.gpgsign", "false"])
+        && std::fs::write(dir.join(".vstack-test-base"), "base\n").is_ok()
+        && git_ok(dir, &["add", "-A"])
+        && git_ok(dir, &["commit", "-q", "-m", "base"])
 }
 
 fn tmpdir(label: &str) -> PathBuf {
@@ -722,6 +745,108 @@ fn refresh_rejects_symlinked_agents_ancestor_before_reading_outside_skill() {
     assert!(err.to_string().contains("outside project root"), "{err:#}");
     assert_eq!(std::fs::read(&outside_skill).unwrap(), outside_bytes);
     assert!(!project.join(".vstack-lock.json").exists());
+
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[cfg(unix)]
+#[test]
+fn refresh_accepts_agents_symlink_into_a_sibling_worktree_of_the_same_repo() {
+    use std::os::unix::fs::symlink;
+
+    // vstack's own `worktree` skill provisions exactly this layout: an issue
+    // worktree's `.agents` is a symlink into the main checkout, so a large
+    // harness library is shared instead of copied per branch. The lexical
+    // containment test refused it, which made refresh unusable from any
+    // worktree (vstack#886).
+    let root = tmpdir("project-owned-sibling-worktree");
+    let main = root.join("main");
+    let trees = root.join("trees");
+    std::fs::create_dir_all(main.join(".agents/skills/benchmark")).unwrap();
+    std::fs::create_dir_all(&trees).unwrap();
+    if !init_repo_with_commit(&main) {
+        let _ = std::fs::remove_dir_all(root);
+        return;
+    }
+    let worktree = trees.join("issue-1");
+    if !git_ok(&main, &["worktree", "add", "-q", "-b", "issue-1", worktree.to_str().unwrap()]) {
+        let _ = std::fs::remove_dir_all(root);
+        return;
+    }
+    // The worktree's `.agents` resolves into the main checkout — never a path
+    // prefix of the worktree root.
+    let _ = std::fs::remove_dir_all(worktree.join(".agents"));
+    symlink(main.join(".agents"), worktree.join(".agents")).unwrap();
+    std::fs::write(
+        worktree.join("vstack.toml"),
+        "[skill-instructions]\nbenchmark = \"Project instruction.\"\n",
+    )
+    .unwrap();
+    std::fs::write(
+        main.join(".agents/skills/benchmark/SKILL.md"),
+        "---\nname: benchmark\ndescription: Project owned\n---\n\nBody.\n",
+    )
+    .unwrap();
+
+    let lock = LockFile::default();
+    let sources = Vec::new();
+    let mut project_config = ProjectConfig::load_strict(&worktree).unwrap();
+    let stats =
+        refresh_items_in_scope(false, &lock, &sources, &mut project_config, &worktree, None);
+
+    assert!(
+        stats.failures.is_empty(),
+        "a same-repository worktree symlink must not fail refresh: {:?}",
+        stats.failures
+    );
+    assert!(
+        stats.project_owned_skills.contains("benchmark"),
+        "the shared project-owned skill should be managed, got {:?}",
+        stats.project_owned_skills
+    );
+
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[cfg(unix)]
+#[test]
+fn refresh_still_rejects_agents_symlink_into_a_different_repository() {
+    use std::os::unix::fs::symlink;
+
+    // The same-repository escape hatch is proof of identity, not a blanket
+    // "any git repo will do". A DIFFERENT repository has a different
+    // --git-common-dir and must still fail closed, exactly as a bare directory
+    // does (vstack#886).
+    let root = tmpdir("project-owned-foreign-repo");
+    let project = root.join("project");
+    let foreign = root.join("foreign");
+    let foreign_skill_dir = foreign.join(".agents/skills/benchmark");
+    std::fs::create_dir_all(&project).unwrap();
+    std::fs::create_dir_all(&foreign_skill_dir).unwrap();
+    if !init_repo_with_commit(&project) || !init_repo_with_commit(&foreign) {
+        let _ = std::fs::remove_dir_all(root);
+        return;
+    }
+    symlink(foreign.join(".agents"), project.join(".agents")).unwrap();
+    std::fs::write(
+        project.join("vstack.toml"),
+        "[skill-instructions]\nbenchmark = \"Do not escape.\"\n",
+    )
+    .unwrap();
+    let foreign_skill = foreign_skill_dir.join("SKILL.md");
+    let foreign_bytes = b"---\nname: benchmark\ndescription: Foreign\n---\n\nUntouched.\n";
+    std::fs::write(&foreign_skill, foreign_bytes).unwrap();
+
+    let lock = LockFile::default();
+    let sources = Vec::new();
+    let mut project_config = ProjectConfig::load_strict(&project).unwrap();
+    let stats = refresh_items_in_scope(false, &lock, &sources, &mut project_config, &project, None);
+
+    assert_eq!(stats.failures.len(), 1);
+    assert_eq!(stats.failures[0].item, ".agents/skills");
+    assert!(stats.failures[0].error.contains("outside project root"));
+    assert!(stats.project_owned_skills.is_empty());
+    assert_eq!(std::fs::read(&foreign_skill).unwrap(), foreign_bytes);
 
     let _ = std::fs::remove_dir_all(root);
 }


### PR DESCRIPTION
## The defect

`resolve_project_owned_skills_root` applied a purely **lexical** containment test, so a worktree's `.agents` symlink into the main checkout — the topology vstack's own `worktree` skill provisions via `WORKTREE_SYMLINKS` — was refused with a run-failing exit 1. vstack was rejecting a layout vstack creates, and no issue worktree could run refresh.

Reproduced before changing anything, from a vstack issue worktree:

```
$ vstack refresh --scope project
Error: refusing project-owned skills path outside project root: …/issue-886/.agents/skills
$ echo $?
1
```

The report's claim that `project-skills-dir` does not mitigate it also checks out — the check runs and returns first (`refresh.rs:192` vs `:204`).

## Change

The containment test cannot distinguish "another checkout of the repository the operator is already working in" from "an arbitrary directory elsewhere on disk". This adds the positive proof it was missing: accept when the canonical target resolves to the same `git rev-parse --git-common-dir` as the project root.

That is **identity, not relaxation**. Everything else still fails closed:

- a target that is not a repository has no common dir
- a target in a **different** repository has a different one
- git missing, failing, or unreadable output all resolve to `None`

`--git-common-dir` may be reported relative to the queried directory, so it is resolved against that directory rather than the process cwd.

Applied to **both** preflight branches — the existing `.agents/skills` path and the `.agents` ancestor check that guards against creation following an escaped symlink later in the run. The report only named the first; leaving the second lexical would have kept the failure for a project whose `.agents/skills` does not exist yet.

## Which shape, and why

The report offered two and asked which I preferred. I took the first — same-repository proof — rather than downgrading the refusal to a warning-skip. Both make the exit status honest, but only this one makes refresh actually **work** from a worktree, which is the underlying need; a skip would leave every worktree unable to refresh while merely being quieter about it.

## Tests

- the existing security test `refresh_rejects_symlinked_agents_ancestor_before_reading_outside_skill` is **untouched and still passes** — its target is a bare non-repo directory, so it has no common dir, exactly as the report predicted
- **new**: a real main checkout plus a `git worktree add` sibling with `.agents` symlinked back — refresh succeeds and manages the shared project-owned skill
- **new**: a symlink into a **different** git repository still fails with one failure keyed `.agents/skills`, and the foreign skill's bytes are unchanged
- both new tests skip rather than fail on a host without usable git

`cargo test` 460 + 17 pass, 0 failed. The two clippy warnings on this crate are pre-existing (`refresh.rs:136`, `config.rs:846`) and untouched by this change.

Verified end to end: with this binary, `vstack refresh --scope project` from the `issue-886` worktree completes and exits 0.

## Note for consumers

This is a CLI change, so it needs a binary rebuild — a skill refresh does not carry it.

Closes #886

https://claude.ai/code/session_01NRP92pU9qsPjWYM9FstQ8D