### PR TITLE
fix(pi-claude-bridge): make the connector write-deny reason product-neutral (#892)

### DIFF
--- a/docs/cross-repo.md
+++ b/docs/cross-repo.md
@@ -141,6 +141,40 @@ Settled by measurement 2026-07-26 (vstack#832) and recorded here because every r
 - **Fail-open is live-observed, not just constructed.** One run in 20 spontaneously started 26 connections and 18 of them failed; the declared Slack still connected, the model still called `mcp__claude_ai_Slack__slack_search_channels`, and the turn answered correctly. That same run is the reason to keep an escape hatch: the account-side connection picture is not stable run to run.
 - **Only `installState === "connected"` connectors are declared.** The rest are never attempted by the CLI either, so declaring them would ask `alwaysLoad` to block startup on servers that cannot connect.
 
+## Connector Write Classification Is A Gate Two Apps Depend On — Must-Agree
+
+Recorded 2026-07-26 (vstack#892), because two consuming apps now gate real
+user-facing approvals on a classification that lives in shared source.
+
+- **`CONNECTOR_WRITE_TOOLS` and `isConnectorWriteTool` are public, not internal**
+  (`pi-extensions/pi-claude-bridge/src/connectors.ts`). memsira routes connector
+  writes through its own gated approval flow. drovr keeps its chat sidecar
+  permanently write-`deny` and runs an approved write as a separate one-shot
+  `claude -p` scoped by `--allowedTools` to exactly one connector tool
+  (drovr#288). Both pin the actions they expose against this classification,
+  because *"the sidecar structurally cannot do this itself"* is the **bridge's**
+  claim, not theirs.
+- **Reclassifying an entry as a READ makes a consumer's confirmation card
+  bypassable, and nothing downstream notices.** Additions are safe and expected;
+  removals and read-verb renames are breaking. Coordinate before changing one.
+  `unit-connectors.mjs` asserts every listed id still classifies as a write and
+  that each connector family stays represented, so the change has to be
+  deliberate.
+- **The connector-cache file format has an external reader.** drovr quarantines
+  the bundle to its sidecar process, so instead of calling
+  `listAccountConnectors` in-process it re-implements the reader half — path
+  `<piUserDir()>/connector-cache/<sha256(CLAUDE_CONFIG_DIR).hex[0..16]>.json`,
+  payload `{version, scope, savedAt, connectors}`, 7-day max age — as the "is
+  this connector installed" half of its write gate. That coupling **fails open**
+  on drift, so a format change degrades them from two gates to one rather than
+  breaking them; bump `CACHE_VERSION` so their staleness check rejects rather
+  than misreads.
+- **Anything the deny path says is shown verbatim to every consumer's model.**
+  The `PreToolUse` deny reason is handed straight to the `claude` child, so
+  product-specific wording in it tells one app's model to use another app's
+  product. It named Memsira until #892; keep it product-neutral and let each
+  host describe its own approval flow in its own prompt. Guarded by a test.
+
 ## Connector Enumeration Is Token-Scoped
 
 Deterministic connector enumeration (vstack#848) answers "which connectors does this account have" by calling the account rather than asking the model. One property is easy to get wrong and fails silently:

--- a/pi-extensions/pi-claude-bridge/bundle/index.js
+++ b/pi-extensions/pi-claude-bridge/bundle/index.js
@@ -43281,7 +43281,7 @@ function connectorWriteDenyOutput(toolName) {
     hookSpecificOutput: {
       hookEventName: "PreToolUse",
       permissionDecision: "deny",
-      permissionDecisionReason: `Connector write tool "${toolName}" is blocked in read-only connector mode. Connector writes must go through Memsira's gated approval flow.`
+      permissionDecisionReason: `Connector write tool "${toolName}" is blocked in read-only connector mode. Connector writes must go through the host application's gated approval flow.`
     }
   };
 }

--- a/pi-extensions/pi-claude-bridge/src/connector-cache.ts
+++ b/pi-extensions/pi-claude-bridge/src/connector-cache.ts
@@ -17,6 +17,19 @@
 // Everything here is best-effort. A missing, unreadable, corrupt, stale, or
 // wrong-version cache returns undefined and the caller falls back to today's
 // behaviour — the same fail-open contract as the inventory call itself.
+//
+// The ON-DISK FORMAT HAS AN EXTERNAL READER (vstack#892). drovr quarantines this
+// bundle to its sidecar process, so rather than calling `listAccountConnectors`
+// in-process it re-implements the reader half — path
+// `<piUserDir()>/connector-cache/<sha256(CLAUDE_CONFIG_DIR).hex[0..16]>.json`,
+// payload `{version, scope, savedAt, connectors}`, 7-day max age — as the
+// "is this connector installed" half of its write gate.
+//
+// That coupling fails OPEN on drift by design, so a format change degrades them
+// from two gates to one rather than breaking them. It is still worth making the
+// change knowingly: bump CACHE_VERSION so their staleness check rejects rather
+// than misreads, and say so in the changelog. `unit-connector-cache.mjs` pins
+// the path shape and payload keys.
 import { createHash } from "node:crypto";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";

--- a/pi-extensions/pi-claude-bridge/src/connectors.ts
+++ b/pi-extensions/pi-claude-bridge/src/connectors.ts
@@ -159,6 +159,22 @@ function connectorNameWords(segment: string): string[] {
 // Explicit known write tool names (current claude.ai connectors). Passed to the
 // SDK disallowedTools so today's writes are removed from the model's context by
 // exact tool id (the CLI matcher only supports exact ids or a whole-server glob).
+//
+// PUBLIC CONTRACT — this list and `isConnectorWriteTool` have downstream
+// dependents that gate real user-facing approvals on them (vstack#892):
+//
+//   memsira  routes connector writes through its own gated approval flow
+//   drovr    keeps its chat sidecar permanently write-`deny` and runs an
+//            approved write as a separate one-shot `claude -p` scoped by
+//            `--allowedTools` to exactly one connector tool (drovr#288)
+//
+// Both pin the actions they expose against this classification, because "the
+// sidecar structurally cannot do this itself" is THIS module's claim, not
+// theirs. RECLASSIFYING AN ENTRY HERE AS A READ WOULD MAKE A CONSUMER'S
+// CONFIRMATION CARD BYPASSABLE. Additions are safe and expected; removals and
+// read-verb reclassifications are breaking — coordinate first, see
+// docs/cross-repo.md. `unit-connectors.mjs` pins the set so a change has to be
+// deliberate.
 export const CONNECTOR_WRITE_TOOLS = [
 	`${CONNECTOR_NS_GMAIL}create_draft`,
 	`${CONNECTOR_NS_GMAIL}create_label`,
@@ -307,6 +323,12 @@ export function connectorWriteDenyHook(): HookCallback {
 	};
 }
 
+// The deny reason is handed verbatim to the `claude` child's model, so it must
+// stay PRODUCT-NEUTRAL: this is shared source and every consuming app shows it.
+// Naming one host told a different app's model to use a product it has never
+// heard of, which is confusing at exactly the moment someone is debugging a
+// refused write (vstack#892). Each host describes its own approval flow in its
+// own prompt; this string only has to say that one exists.
 function connectorWriteDenyOutput(toolName: string) {
 	return {
 		hookSpecificOutput: {
@@ -314,7 +336,7 @@ function connectorWriteDenyOutput(toolName: string) {
 			permissionDecision: "deny" as const,
 			permissionDecisionReason:
 				`Connector write tool "${toolName}" is blocked in read-only connector mode. ` +
-				`Connector writes must go through Memsira's gated approval flow.`,
+				`Connector writes must go through the host application's gated approval flow.`,
 		},
 	};
 }

--- a/pi-extensions/pi-claude-bridge/tests/unit-connectors.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-connectors.mjs
@@ -8,6 +8,9 @@ import {
 	CONNECTOR_DISCOVERY_TOOLS,
 	CLAUDE_BRIDGE_TOOL_ISOLATION,
 	DISALLOWED_BUILTIN_TOOLS,
+	CONNECTOR_WRITE_TOOLS,
+	isConnectorWriteTool,
+	connectorWriteDenyHook,
 } from "../bundle/index.js";
 
 function withEnv(value, fn) {
@@ -53,4 +56,64 @@ test("toolIsolationForQuery(true) exposes connectors: drops empty tools, allows 
 
 test("discovery tools are a subset of the default disallow list", () => {
 	for (const d of CONNECTOR_DISCOVERY_TOOLS) assert.ok(DISALLOWED_BUILTIN_TOOLS.includes(d), `${d} is disallowed by default`);
+});
+
+// --- vstack#892: the deny reason is shared source shown verbatim to a model ---
+
+test("CONTRACT: the connector write-deny reason names no host product", async () => {
+	const hook = connectorWriteDenyHook();
+	const out = await hook({
+		hook_event_name: "PreToolUse",
+		tool_name: "mcp__claude_ai_Gmail__create_draft",
+	});
+	const reason = out.hookSpecificOutput.permissionDecisionReason;
+
+	// The string goes straight to the `claude` child's model in EVERY consuming
+	// app, so naming one host tells another app's model to use a product it has
+	// never heard of. Each host describes its own approval flow in its own
+	// prompt; this only has to say that one exists.
+	for (const product of ["Memsira", "memsira", "drovr", "Drovr", "hyprtrade"]) {
+		assert.ok(!reason.includes(product), `deny reason must not name "${product}": ${reason}`);
+	}
+	assert.ok(reason.includes("mcp__claude_ai_Gmail__create_draft"), "names the refused tool");
+	assert.ok(/host application/i.test(reason), "points at the host's approval flow generically");
+
+	// The malformed-input path returns the same message, so it cannot drift.
+	const fallback = await hook({ hook_event_name: "PreToolUse", tool_name: 42 });
+	assert.equal(fallback.hookSpecificOutput.permissionDecision, "deny");
+	for (const product of ["Memsira", "memsira", "drovr"]) {
+		assert.ok(!fallback.hookSpecificOutput.permissionDecisionReason.includes(product));
+	}
+});
+
+// --- vstack#892: CONNECTOR_WRITE_TOOLS is a public contract, not an internal ---
+
+// memsira routes connector writes through its own gated approval flow; drovr
+// keeps its chat sidecar permanently write-`deny` and runs an approved write as
+// a one-shot `claude -p` scoped to exactly one tool (drovr#288). Both pin the
+// actions they expose against this classification, because "the sidecar
+// structurally cannot do this itself" is THIS module's claim, not theirs.
+//
+// Reclassifying an entry here as a READ would make a consumer's confirmation
+// card bypassable, and nothing downstream would notice. Additions are safe and
+// expected — this asserts every listed id still classifies as a write, so a
+// removal or a read-verb rename has to be deliberate.
+test("CONTRACT: every CONNECTOR_WRITE_TOOLS entry still classifies as a write", () => {
+	assert.ok(CONNECTOR_WRITE_TOOLS.length > 0, "the write list must not be emptied");
+	for (const name of CONNECTOR_WRITE_TOOLS) {
+		assert.equal(isConnectorWriteTool(name), true, `${name} must stay a write`);
+	}
+});
+
+test("CONTRACT: the connectors consumers gate on are all represented", () => {
+	// A whole connector family vanishing from the list is the shape that would
+	// silently un-gate a consumer, so pin the families rather than exact ids.
+	// Server segments as they actually appear in the tool id — Google connectors
+	// are `Google_Calendar` / `Google_Drive`, not `Calendar` / `Drive`.
+	for (const ns of ["Gmail", "Google_Calendar", "Google_Drive", "Slack", "Atlassian"]) {
+		assert.ok(
+			CONNECTOR_WRITE_TOOLS.some((t) => t.includes(`claude_ai_${ns}__`)),
+			`${ns} writes must stay enumerated`,
+		);
+	}
 });


### PR DESCRIPTION
## The fix

The `PreToolUse` deny reason is handed verbatim to the `claude` child's model, and this is shared source, so every consuming app showed it. It named Memsira — telling **drovr's** model to use "Memsira's gated approval flow", a product it has never heard of.

```diff
-Connector writes must go through Memsira's gated approval flow.
+Connector writes must go through the host application's gated approval flow.
```

Taken as **option 1**, the reporter's own preference. A host-supplied label would add a query option so each app could name itself; that is more surface than a one-line string deserves, and each host already describes its own approval flow in its own prompt — this string only has to say that one exists.

## Also acted on: the two contracts the issue flagged

Both gate real user-facing approvals on shared source, so they are now documented as public rather than left as internals someone could change casually.

- **`CONNECTOR_WRITE_TOOLS` / `isConnectorWriteTool` are public.** memsira routes writes through its own approval flow; drovr keeps its chat sidecar permanently write-`deny` and runs an approved write as a one-shot `claude -p` scoped to exactly one tool (drovr#288). Both pin against this classification because *"the sidecar structurally cannot do this itself"* is the **bridge's** claim, not theirs — so reclassifying an entry as a read would make a consumer's confirmation card bypassable with nothing downstream noticing. Additions stay safe and expected.
- **The connector-cache on-disk format has an external reader.** drovr quarantines the bundle to its sidecar and re-implements the reader half. It fails open on drift, so a format change degrades them to one gate rather than breaking them — but the note now says to bump `CACHE_VERSION` so their staleness check *rejects* rather than misreads.

Both are recorded in `docs/cross-repo.md` as a must-agree row, which is where the source comments now point — the existing connector-server-key row was the model.

## Tests

Three contract assertions in `unit-connectors.mjs`:

- the deny reason names no host product, on **both** the normal and the malformed-input path (the catch branch returns the same message, so it cannot drift separately)
- every `CONNECTOR_WRITE_TOOLS` entry still classifies as a write
- each connector family (Gmail, Google_Calendar, Google_Drive, Slack, Atlassian) stays represented — a whole family vanishing is the shape that would silently un-gate a consumer

I verified the deny guard has teeth rather than assuming it: reintroducing the old string fails the test, and it passes again once restored.

## Scope

Unit suite **279/279**. Bundle rebuilt — its diff is exactly the one changed string (the new comments are comments, so esbuild strips them). No version bump: this repo bumps package versions in dedicated `chore` commits.

Closes #892

https://claude.ai/code/session_01NRP92pU9qsPjWYM9FstQ8D