### PR TITLE
fix(cli): stop the vstack.toml banner sync from deleting the preamble (#896)

### DIFF
--- a/cli/src/project_config.rs
+++ b/cli/src/project_config.rs
@@ -1603,19 +1603,55 @@ fn repair_project_config_structure(path: &Path) {
     }
 }
 
+/// Refresh the canonical banner at the top of `vstack.toml`.
+///
+/// This USED TO splice `header + content[launch_instructions_marker..]`, which
+/// silently deleted everything between the banner and that marker (vstack#896).
+/// That region is not spare space: TOML requires top-level keys to appear BEFORE
+/// the first table header, so `project-skills-dir` — and any comment explaining
+/// it — has to live exactly there. A consumer that set it lost the key on the
+/// first refresh that rewrote the file, which then made refresh refuse that
+/// project's own skills and exit non-zero on every subsequent run.
+///
+/// Replace only the leading comment block, and keep the rest verbatim.
 fn sync_project_config_header(content: &str) -> String {
-    let header = project_config_header();
-    let marker_start = content
-        .find("# ── Launch Instructions")
-        .or_else(|| content.find("# ── Execute on Launch"))
-        .or_else(|| section_start(content, "[agent-launch-instructions]"));
-    let Some(marker_start) = marker_start else {
-        return content.to_string();
-    };
+    // Only touch files that look like a vstack.toml: a leading `# ─` banner and
+    // a recognizable body. Both guards are the pre-existing preconditions.
     if !content.trim_start().starts_with("# ─") {
         return content.to_string();
     }
-    format!("{}\n\n\n{}", header.trim_end(), &content[marker_start..])
+    if content
+        .find("# ── Launch Instructions")
+        .or_else(|| content.find("# ── Execute on Launch"))
+        .or_else(|| section_start(content, "[agent-launch-instructions]"))
+        .is_none()
+    {
+        return content.to_string();
+    }
+
+    let header = project_config_header();
+    let rest = content[leading_comment_block_end(content)..].trim_start_matches('\n');
+    if rest.is_empty() {
+        let mut out = header.trim_end().to_string();
+        if content.ends_with('\n') {
+            out.push('\n');
+        }
+        return out;
+    }
+    format!("{}\n\n\n{}", header.trim_end(), rest)
+}
+
+/// Byte offset just past the leading run of comment lines. Blank lines and
+/// anything else end the block, so only the banner itself is consumed.
+fn leading_comment_block_end(content: &str) -> usize {
+    let mut offset = 0;
+    for line in content.split_inclusive('\n') {
+        if !line.trim_start().starts_with('#') {
+            break;
+        }
+        offset += line.len();
+    }
+    offset
 }
 
 fn launch_instructions_heading() -> String {
@@ -2577,6 +2613,92 @@ fn strip_skills_reference(content: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    // ── vstack#896: the banner sync must not eat the preamble ──────────────
+    //
+    // `sync_project_config_header` used to splice
+    // `header + content[launch_instructions_marker..]`, deleting everything
+    // between. TOML requires top-level keys to precede the first table header,
+    // so `project-skills-dir` lives exactly in that region — it was destroyed on
+    // the first refresh that rewrote the file, which then made refresh refuse
+    // that project's own skills and exit non-zero forever after.
+
+    fn header_sync_fixture(body: &str) -> String {
+        format!(
+            "{}\n\n\n{}",
+            super::project_config_header().trim_end(),
+            body
+        )
+    }
+
+    const LAUNCH_BODY: &str = "# ── Launch Instructions ───────────────────────────────\n#\n[agent-launch-instructions]\nresearcher = \"x\"\n";
+
+    #[test]
+    fn sync_header_preserves_a_top_level_key_before_the_first_table() {
+        let content = header_sync_fixture(&format!(
+            "# ── Project-Owned Skills ──\n# why this key exists\nproject-skills-dir = \"project-skills\"\n\n\n{LAUNCH_BODY}"
+        ));
+        let out = super::sync_project_config_header(&content);
+        assert!(
+            out.contains("project-skills-dir = \"project-skills\""),
+            "the key must survive a header sync:\n{out}"
+        );
+        assert!(
+            out.contains("# why this key exists"),
+            "its explanatory comment must survive too:\n{out}"
+        );
+        assert!(out.contains("[agent-launch-instructions]"));
+    }
+
+    #[test]
+    fn sync_header_is_idempotent_with_a_top_level_key_present() {
+        let content = header_sync_fixture(&format!(
+            "project-skills-dir = \"project-skills\"\n\n\n{LAUNCH_BODY}"
+        ));
+        let once = super::sync_project_config_header(&content);
+        let twice = super::sync_project_config_header(&once);
+        assert_eq!(once, twice, "a second sync must change nothing");
+        assert_eq!(
+            content, once,
+            "a file already in canonical shape must be left byte-identical"
+        );
+    }
+
+    #[test]
+    fn sync_header_still_replaces_a_stale_banner() {
+        // The sync must keep doing its job: an outdated banner is refreshed,
+        // and only the banner is refreshed.
+        let content = format!(
+            "# ─ old banner line\n# another stale line\n\n\nproject-skills-dir = \"p\"\n\n\n{LAUNCH_BODY}"
+        );
+        let out = super::sync_project_config_header(&content);
+        assert!(out.starts_with(super::project_config_header().trim_end()));
+        assert!(!out.contains("old banner line"), "stale banner must go:\n{out}");
+        assert!(
+            out.contains("project-skills-dir = \"p\""),
+            "user content after the banner must stay:\n{out}"
+        );
+    }
+
+    #[test]
+    fn sync_header_leaves_a_non_vstack_file_alone() {
+        // No leading `# ─` banner: not ours to rewrite.
+        let content = format!("# some other file\n\nproject-skills-dir = \"p\"\n\n{LAUNCH_BODY}");
+        assert_eq!(super::sync_project_config_header(&content), content);
+        // Banner but no recognizable body: also untouched.
+        let no_body = format!("{}\n\n\nkey = 1\n", super::project_config_header().trim_end());
+        assert_eq!(super::sync_project_config_header(&no_body), no_body);
+    }
+
+    #[test]
+    fn leading_comment_block_end_stops_at_the_first_non_comment_line() {
+        let content = "# a\n# b\n\nkey = 1\n";
+        let end = super::leading_comment_block_end(content);
+        assert_eq!(&content[end..], "\nkey = 1\n");
+        // An all-comment file consumes everything rather than running past the end.
+        let all = "# a\n# b\n";
+        assert_eq!(super::leading_comment_block_end(all), all.len());
+    }
+
     use super::*;
 
     // vstack: regression. `normalize_attached_section_headers` used to


### PR DESCRIPTION
## Root cause

`sync_project_config_header` rebuilt the top of the file as

```rust
format!("{}\n\n\n{}", header.trim_end(), &content[marker_start..])
```

— discarding **everything** between the banner and the "Launch Instructions" marker. TOML requires top-level keys to appear before the first table header, so `project-skills-dir` and its explanatory comment have to live in exactly the region that splice threw away.

## One fix, both symptoms — the second was a consequence

1. The key vanished on the first refresh that rewrote the file.
2. The **next** run then parsed a config with no `project-skills-dir`, so `resolve_relocated_project_skills` returned `None`, the `inside_relocated` exception in `refresh.rs` could not apply, and refresh refused the project's own four skills and exited 1 — forever after.

**The containment check was never broken.** It was correctly refusing, because the configuration it depends on had been deleted underneath it. No change was needed there.

## This reconciles the contradiction in the thread

hyprtrade verified exit 0 and idempotency at `4d817dec`; I reproduced deletion on the **same binary**. Both are true. `repair_project_config_structure` only writes when its output differs, so a file already in canonical shape is never rewritten and the key survives — that is the state their three runs were in. Once anything made a run rewrite the file, the key went, and every later run refused.

So it is **not** a regression in `4d817dec..main` — that range contains no Rust at all.

## The fix

Replace only the leading comment block; keep the rest verbatim. Both preconditions are retained, so a non-vstack file and a file with no recognizable body are still left alone, and a stale banner is still refreshed.

## Two of my own observations were misleading — worth naming

While bisecting, two intermediate results pointed the wrong way and were fixture artifacts, not behaviour:

- truncating with `head -N` cut a multiline string, producing **invalid TOML**, which short-circuited the write and looked like "the key survives";
- a hand-written minimal fixture began `# opening…` rather than `# ─`, so it returned early via a different guard.

Both are recorded in the commit so the next person does not re-derive them.

## Verification

Five unit tests: key survival, comment survival, idempotency (byte-identical on a canonical file), stale-banner replacement still working, both untouched-file preconditions, and the block-scanner boundary. `cargo test` **465 + 17 pass**. The two clippy warnings on this crate are pre-existing (`refresh.rs:136`, `config.rs:846`).

End to end against hyprtrade's real checkout with this binary:

| | released binary | this branch |
|---|---|---|
| exit | 1 | **0** |
| skills refused | 4 | **0** |
| `project-skills-dir` | stripped every run | **intact** |
| working tree | `vstack.toml` modified | **clean** |
| second run | strips again | **idempotent** |

That closes **hyprtrade#424**, which earlier cycles had routed downstream as theirs.

> **CLI change** — consumers need a binary rebuild, not a skill refresh.

Closes #896

https://claude.ai/code/session_01NRP92pU9qsPjWYM9FstQ8D