### PR TITLE
docs(worktree): own the broken-.agents recovery guidance upstream

### DIFF
--- a/skills/worktree/README.md
+++ b/skills/worktree/README.md
@@ -12,6 +12,15 @@ skills/worktree/
     └── worktree-session-guard   # Ownership leases (see below)
 ```
 
+## Recovering a broken `.agents` link
+
+Route by shape. `git checkout -- .agents` is **never** the recovery: the path holds no tracked content, so the command succeeds and changes nothing while the link stays broken.
+
+- `.agents` missing, or a real directory rather than a symlink (`test -L .agents` fails) → `worktree fix-links <ID|PATH>`, run **from the main checkout** (the worktree's own copy of the script is reached through the broken link).
+- A genuinely modified or corrupt **tracked** file → `git checkout -- <path>`; such a file never lives under a symlinked path.
+
+`fix-links` is also the repair after anything that can replace a configured symlink with tracked content: a manual rebase, a partially-completed `remove`, or a restack replay. A worktree whose `.agents` is not a symlink cannot be trusted for local verification until it is fixed.
+
 ## Session guard
 
 `worktree-session-guard` records a session's claim on an issue worktree as a **native Git worktree lock** whose reason line carries the owner and heartbeat, so `git worktree remove [--force]` refuses it and `git worktree prune` leaves the registration alone. Using the native lock rather than a private marker file is deliberate: it needs no cooperation from whoever runs the cleanup.

--- a/skills/worktree/SKILL.md
+++ b/skills/worktree/SKILL.md
@@ -237,6 +237,28 @@ Some execution policies reject top-level `git rebase` porcelain outright — Cod
     .agents/skills/worktree/scripts/worktree fix-links <ID>
     ```
 
+## Recovering a broken `.agents` link
+
+The configured symlinks (`WORKTREE_SYMLINKS`, typically `.agents`) point from a worktree back into the main checkout, so a large harness library is shared rather than copied per branch. When one goes missing or turns into a real directory, **route the recovery by shape** — the wrong instinct here is a git command that cannot possibly help.
+
+**`git checkout -- .agents` is never the recovery.** The path holds no tracked content, so there is nothing for git to restore; the command succeeds and changes nothing, which reads as "recovered" while the link is still broken.
+
+| Symptom | Recovery |
+|---|---|
+| `.agents` missing, or a real directory instead of a symlink (`test -L .agents` fails) | `worktree fix-links <ID\|PATH>` — **from the main checkout** |
+| A genuinely modified or corrupt **tracked** file | `git checkout -- <path>` — such a file never lives under a symlinked path |
+
+**Run `fix-links` from the main checkout, not from the broken worktree.** The worktree's own copy of this script is reached *through* the link that is broken, so invoking it from there is the one place it may not exist:
+
+```bash
+cd /path/to/main/checkout
+.agents/skills/worktree/scripts/worktree fix-links <ID|WORKTREE_PATH>
+```
+
+`fix-links` is also the repair after any operation that can replace a configured symlink with tracked content — a manual rebase, a partially-completed `remove`, or a restack replay (see step 11 above).
+
+**A worktree whose `.agents` is not a symlink cannot be trusted for local verification.** Project tooling resolving paths through it is reading either nothing or the wrong checkout's copy. Fix the link before believing any result from that tree — and prefer tooling that fails closed with a diagnostic naming the missing file over tooling that silently degrades.
+
 ## Session guard (ownership leases)
 
 `scripts/worktree-session-guard` stops cleanup from destroying a worktree a session is still working in. The lease is recorded as a **native Git worktree lock** whose reason line carries the owner and heartbeat, so `git worktree remove [--force]` refuses it and `git worktree prune` never prunes the registration — even after the directory itself is gone. That needs no cooperation from whoever runs the cleanup, which a private marker file would.


### PR DESCRIPTION
Requested by hyprtrade while stripping harness mechanics out of their `AGENTS.md`: the generic broken-`.agents` recovery guidance belongs to the skill that *creates* those symlinks, not to every consumer repo's `AGENTS.md`. Agreed — it generalizes to any consumer using `WORKTREE_SYMLINKS`, and duplicated prose is how consumers drift from the mechanism.

## Absorbed

- **`git checkout -- .agents` is never the recovery.** The path holds no tracked content, so the command succeeds and changes nothing — which reads as "recovered" while the link is still broken. That false signal is why this needs saying at all.
- **Route by shape**: broken link → `fix-links`; corrupt **tracked** file → `git checkout -- <path>`, and such a file never lives under a symlinked path.
- **Run `fix-links` from the main checkout** — the worktree's own copy of the script is reached *through* the very link that is broken.
- `fix-links` is also the repair after a manual rebase, a partially-completed `remove`, or a restack replay.
- A worktree whose `.agents` is not a symlink cannot be trusted for local verification until it is fixed.

Consumer-specific bindings (which validate command fails closed, local drift tooling) stay downstream — only the mechanism moved. Added to both `SKILL.md` and `README.md`.

Worktree suite green, 18 files.

https://claude.ai/code/session_01NRP92pU9qsPjWYM9FstQ8D