### PR TITLE
docs(readme): add VGS release banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Author skills, agents, and hooks once. Install them into Claude Code, Cursor, Op
 [![Codex](https://img.shields.io/badge/Codex-supported-0EA5E9?style=flat-square)](#supported-tools)
 [![Pi](https://img.shields.io/badge/Pi-supported-0EA5E9?style=flat-square)](#supported-tools)
 
+> ✨ **Also check out [VGS](https://github.com/vanillagreencom/vgs)** — our newly released Hyprland / Niri quickshell. 🚀
+
 ![vstack TUI](docs/assets/vstack-tui.png)
 
 ---


### PR DESCRIPTION
Adds a one-line banner near the top of the README pointing at the newly released [VGS](https://github.com/vanillagreencom/vgs) Hyprland / Niri quickshell (user request).

https://claude.ai/code/session_01CeKocRj9NTENGbPNdJfATt