### PR TITLE
test: scrub ambient auth env so suites are hermetic (#909)

### DIFF
--- a/skills/github/tests/env-first-auth.sh
+++ b/skills/github/tests/env-first-auth.sh
@@ -2,6 +2,10 @@
 # Regression tests for env-first GitHub token loading.
 set -euo pipefail
 
+# The invoking shell's real auth env must not reach the cases below — every
+# token each case sees is injected by the case itself.
+unset GH_TOKEN GITHUB_TOKEN GH_BOT_TOKEN
+
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$TEST_DIR/../../.." && pwd)"
 TMP_ROOT="$(mktemp -d)"

--- a/skills/orch/tests/ci_wait.sh
+++ b/skills/orch/tests/ci_wait.sh
@@ -50,6 +50,10 @@
 # updated_at, and its failure stays terminal (cases 29-31).
 set -euo pipefail
 
+# The invoking shell's real auth env must not reach the cases below — the
+# sanitizer cases assert on exactly the tokens each case injects.
+unset GH_TOKEN GITHUB_TOKEN GH_BOT_TOKEN
+
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$TEST_DIR/../../.." && pwd)"
 TMP_ROOT="$(mktemp -d)"

--- a/skills/orch/tests/session_init.sh
+++ b/skills/orch/tests/session_init.sh
@@ -5,6 +5,10 @@
 
 set -euo pipefail
 
+# The invoking shell's real auth env must not reach the cases below — token
+# and 1Password-resolution cases assert on exactly what each case injects.
+unset GH_TOKEN GITHUB_TOKEN GH_BOT_TOKEN LINEAR_API_KEY
+
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$TEST_DIR/../../.." && pwd)"
 SCRIPT="$REPO_ROOT/skills/orch/scripts/session-init"


### PR DESCRIPTION
Closes #909.

Unsets `GH_TOKEN`/`GITHUB_TOKEN`/`GH_BOT_TOKEN` (plus `LINEAR_API_KEY` for session-init) at the top of the three affected suites, so every token a case sees is the one it injects. Verified all three pass both with live ambient credentials (previously 8 assertions failed) and with a scrubbed env: env-first-auth 37/0, ci_wait 133/0, session_init 11/0.

https://claude.ai/code/session_01CeKocRj9NTENGbPNdJfATt