### PR TITLE
fix(orch): re-delegation ordering and the session-guard claim on the shared initialize path

### DIFF
--- a/skills/orch/SKILL.md
+++ b/skills/orch/SKILL.md
@@ -24,7 +24,7 @@ Load IN ORDER before anything else; do not proceed if any fails: 1. `github`. 2.
 
 > **MODE SWITCH**: Loading this skill puts you in **orchestrator mode**. Do not write code yourself. Delegate all implementation, review, and QA work to specialist sub-agents using the workflows in this skill.
 
-> If you are running in **Claude Code**: Always create a team before launching agents; spawn and delegate within the team context so agents share state and can be messaged for re-delegation. Create tasks before spawning (or within the existing team context) — task creation notifications wake idle agents prematurely. Ask questions with the `AskUserQuestion` tool. `SendMessage` accepts exactly `to`, `summary`, `message` — extra fields have caused duplicate delivery on idle wake-up.
+> If you are running in **Claude Code**: Always create a team before launching agents; spawn and delegate within the team context so agents share state and can be messaged for re-delegation. Task creation and assignment notifications wake a live agent immediately — assignment is a wake, not only spawn-time creation. Fresh spawn: create tasks before spawning, so they exist before the agent does. Re-delegation to a live agent: send the delegation message before creating and assigning the task — an agent woken by the assignment alone starts from the bare `task_assignment` payload without the delegation. Ask questions with the `AskUserQuestion` tool. `SendMessage` accepts exactly `to`, `summary`, `message` — extra fields have caused duplicate delivery on idle wake-up.
 
 > If you are running in **Codex**: Under `approval_policy = never` the CLI classifies shell CONTROL SYNTAX — loops, multi-command blocks, env-assignment prefixes, substitution (a literal backtick counts), redirection — as approval-required regardless of the inner commands, rejecting the shape with `approval required by policy, but AskForApproval is set to Never`. That error means the command *shape* was flagged, not access: do not retry the same shape and do not wait for approval (none can arrive) — rewrite as one simple command per tool call. Replace polling loops with the orch waiters `.agents/skills/orch/scripts/ci-wait` (CI status), `.agents/skills/orch/scripts/approval-wait` (review approval), and `.agents/skills/orch/scripts/queue-wait` (merge-queue / auto-merge outcome) — orch scripts, never `github.sh` subcommands. A policy-rejected top-level `git rebase` has a documented replacement: the worktree skill's guarded `create <ID> --reuse --replay` path with `worktree restack continue|skip|abort` controls (worktree SKILL.md § Policy-blocked rebase (cherry-pick replay fallback)) — never an improvised force-push. Authoring rules: [§ Harness-Safe Shell](#harness-safe-shell); full shape catalogue and rewrite patterns: [references/codex-runtime.md](references/codex-runtime.md).
 >
@@ -213,7 +213,7 @@ Stages: `SPAWN (bootstrap) → DELEGATE → WORK (agent executes itself, no sub-
 
 #### Dev Agent Persistence
 
-Dev agents persist for the entire session; re-delegate them for review-fix, QA-fix, comment-fix, and CI-fix cycles (each re-delegation: create new tasks → send delegation). Shut down only on explicit user request or a stall confirmed via the [escalation sequence](#wait-for-agent-return-before-acting) — quiet ≠ stalled; idle ≠ stuck.
+Dev agents persist for the entire session; re-delegate them for review-fix, QA-fix, comment-fix, and CI-fix cycles (each re-delegation: send delegation → create and assign new tasks — task assignment wakes a live agent, so the delegation goes first). Shut down only on explicit user request or a stall confirmed via the [escalation sequence](#wait-for-agent-return-before-acting) — quiet ≠ stalled; idle ≠ stuck.
 
 #### Review Agent Lifecycle Management
 
@@ -243,7 +243,7 @@ The acceptance decision table lives in the delegating workflow — `dev-start.md
 
 **Invalid stall signals** (never sufficient alone or combined): return-message timeout, clean git status/diff/log, no modified files — a worktree also looks clean during an agent's research/planning phase. The sole positive signal that overrides a missing return is a valid `dev-artifact-check` for the current `dev_round_id`.
 
-**Escalation** — **quiet ≠ stalled**: only after the 10-minute quiet window from delegation AND a confirmed stall (task status unchanged across multiple idle cycles; no new session-log entries for 10+ minutes; or agent process exited / zero CPU). Then: (1) re-message once specifying the missing step; (2) wait 5 min, re-check — new activity → go idle; (3) still inactive → shut down → respawn → re-create tasks → re-delegate.
+**Escalation** — **quiet ≠ stalled**: only after the 10-minute quiet window from delegation AND a confirmed stall (task status unchanged across multiple idle cycles; no new session-log entries for 10+ minutes; or agent process exited / zero CPU). Then: (1) re-message once specifying the missing step; (2) wait 5 min, re-check — new activity → go idle; (3) still inactive → shut down → re-create tasks → respawn → re-delegate.
 
 #### Orchestrator Never Fixes Code
 

--- a/skills/orch/tests/workflow_helpers.sh
+++ b/skills/orch/tests/workflow_helpers.sh
@@ -652,5 +652,27 @@ assert_file_contains "$dev_start_workflow" '`child_sessions` keys, reports, and 
 assert_file_contains "$state_schema" '{name: {agent_type, task_name?, fallback}}' "workflow-state schema extends reviewer runtime metadata with task_name"
 assert_file_contains "$state_schema" '"task_name": "security_review"' "workflow-state schema example shows a translated runtime task_name"
 
+# vstack#925 — in Claude Code, a task ASSIGNMENT notification wakes a live
+# agent immediately, not only task creation at spawn time. The old
+# re-delegation order (create task → assign → send delegation) therefore
+# started fix rounds from the bare task_assignment payload: the delegation
+# carrying the item list landed one turn after the wake, and the agent
+# reconstructed the item set itself — a mis-keyed dev-return artifact and a
+# false acceptance failure whenever its dedupe differed from the
+# orchestrator's. Re-delegation to a live agent now sends the delegation
+# BEFORE creating and assigning the task; fresh spawns keep
+# create-before-spawn (tasks exist before the agent does), and the
+# escalation ladder re-creates tasks before respawning for the same reason.
+assert_file_contains "$orch_skill" 'send delegation → create and assign new tasks' "SKILL Dev Agent Persistence re-delegation sends the delegation before task assignment"
+assert_file_not_contains "$orch_skill" 'create new tasks → send delegation' "SKILL drops the assignment-first re-delegation order"
+assert_file_contains "$orch_skill" 'Task creation and assignment notifications wake a live agent immediately' "SKILL Claude Code note states assignment wakes a live agent, not only spawn-time creation"
+assert_file_contains "$orch_skill" 'send the delegation message before creating and assigning the task' "SKILL Claude Code note orders the delegation before create+assign"
+assert_file_contains "$orch_skill" 'shut down → re-create tasks → respawn → re-delegate' "SKILL escalation re-creates tasks before the respawn"
+for workflow_path in dev-fix review-pr-comments ci-fix; do
+  assert_file_contains "$REPO_ROOT/skills/orch/workflows/$workflow_path.md" \
+    'send the delegation message before creating and assigning its task' \
+    "$workflow_path re-delegation sends the delegation before task assignment"
+done
+
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/skills/orch/tests/workflow_helpers.sh
+++ b/skills/orch/tests/workflow_helpers.sh
@@ -674,5 +674,27 @@ for workflow_path in dev-fix review-pr-comments ci-fix; do
     "$workflow_path re-delegation sends the delegation before task assignment"
 done
 
+# vstack#877/#926 — the session-guard lease is claimed on the shared
+# initialize path. The launcher-side claim in start.md was unreachable for
+# worktree-launched sessions: open-terminal creates the worktree and starts
+# the session inside it, `start` routes that session to start-worktree.md,
+# and neither it nor initialize.md claimed — so every session launched
+# through orch's own mandated path ran unprotected from `worktree cleanup`.
+# initialize.md § 1 now claims immediately after WORKTREE_PATH resolves;
+# start-worktree.md § 1 invokes that section, which covers the launched
+# path, and start.md's step is a pointer, never a drifting duplicate claim.
+# The --repo warning must travel with the claim command: claim/refresh
+# reject --repo, and a wrapper that swallows that error leaves the guard
+# looking installed while it silently never claims.
+initialize_workflow="$REPO_ROOT/skills/orch/workflows/initialize.md"
+start_workflow="$REPO_ROOT/skills/orch/workflows/start.md"
+assert_file_contains "$initialize_workflow" 'worktree-session-guard claim [WORKTREE_PATH] --owner [ISSUE_ID]' "initialize § 1 claims the session-guard lease after WORKTREE_PATH resolves"
+assert_file_contains "$initialize_workflow" 'Do **not** pass `--repo`' "initialize claim carries the --repo rejection warning"
+assert_file_contains "$initialize_workflow" 'silently never claims' "initialize claim warns that a swallowed --repo failure never claims"
+assert_file_contains "$initialize_workflow" 'Exit 75 means another session already holds the lease' "initialize claim keeps the foreign-lease coordination rule"
+assert_file_contains "$start_worktree_workflow" 'workflows/initialize.md § 1-2' "start-worktree § 1 routes through initialize, so launched sessions claim"
+assert_file_not_contains "$start_workflow" 'worktree-session-guard claim' "start.md carries no duplicate claim command to drift from initialize"
+assert_file_contains "$start_workflow" 'claimed by the working session in `initialize.md`' "start.md points at the shared initialize claim"
+
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/skills/orch/workflows/ci-fix.md
+++ b/skills/orch/workflows/ci-fix.md
@@ -119,6 +119,8 @@ If `.exists` is `true`, read `.team_name`:
 .agents/skills/orch/scripts/workflow-state new-round-id [ISSUE_ID] dev_round_id
 ```
 
+**In Claude Code**, when the target agent is already alive: send the delegation message before creating and assigning its task — task assignment wakes a live agent immediately, and an agent woken by the bare `task_assignment` payload starts the round without the delegation.
+
 <delegation_format>
 CI failure on PR #[PR_NUMBER] ([BRANCH_NAME]).
 

--- a/skills/orch/workflows/dev-fix.md
+++ b/skills/orch/workflows/dev-fix.md
@@ -124,6 +124,8 @@ Apply [Worktree Scope](../SKILL.md#worktree-scope): if in a worktree and `ISSUE_
    ```
    Use the printed token as `[DEV_ROUND_ID]`. Also note the delegated review-item numbers (the `#[N]` in `[FORMATTED_ITEMS]`) as `[ITEM_NUMBERS]` (comma-separated) for step 6's exact item-set check.
 
+   **In Claude Code**, when the target agent is already alive: send the delegation message before creating and assigning its task — task assignment wakes a live agent immediately, and an agent woken by the bare `task_assignment` payload starts the round without the delegation.
+
    ⚠ Fill placeholders only ([Format Tags Are Literal](../SKILL.md#format-tags-are-literal)). `Recommendation:` = technical fix, not procedure steps. The agent owns validate/commit/return per `dev/workflows/dev-fix.md`.
    - ✅ `"Read X from parent state and forward to child — fix in parent so descendants inherit."`
    - ❌ `"1. Apply fix. 2. Run validate. 3. Commit. 4. Let orchestrator handle linkage."`

--- a/skills/orch/workflows/initialize.md
+++ b/skills/orch/workflows/initialize.md
@@ -38,12 +38,24 @@ Set up team, auth, cache, and workflow state for a worktree session.
 
 3. **Set `WORKTREE_PATH`** to current working directory.
 
-4. **Sync cache** — **Linear only**:
+4. **Claim the worktree for this session.** `create` never claims — a lease means "a live session is working here", and a session initializing state in the worktree is that session. This shared step covers every route into a worktree session, including worktree-launched ones that never pass through `start.md`. **Skip if** `WORKTREE_PATH` is the main checkout, not a linked worktree (the guard refuses the main checkout).
+
+   ```bash
+   .agents/skills/worktree/scripts/worktree-session-guard claim [WORKTREE_PATH] --owner [ISSUE_ID]
+   ```
+
+   While the lease is held, `worktree cleanup` will not collect this tree and another session's `create --reuse` is refused by name. `worktree remove` releases it at teardown, so nothing else has to.
+
+   Do **not** pass `--repo`: `claim` and `refresh` reject it, and a swallowed failure leaves the guard looking installed while it silently never claims.
+
+   Exit 75 means another session already holds the lease — coordinate with that owner instead of proceeding ([Worktree Scope](../SKILL.md#worktree-scope)). Exit 1 with a `flock` message means the host has no `flock`, so the session runs unguarded; continue, but do not assume the tree is protected.
+
+5. **Sync cache** — **Linear only**:
    ```bash
    .agents/skills/linear/scripts/linear.sh sync --reconcile
    ```
 
-5. **Init workflow state**:
+6. **Init workflow state**:
    ```bash
    .agents/skills/orch/scripts/workflow-state init [ISSUE_ID] --team "[ISSUE_ID_LOWERCASE]" \
      --agent "[AGENT]" --worktree "[WORKTREE_PATH]" --branch "[BRANCH]"

--- a/skills/orch/workflows/review-pr-comments.md
+++ b/skills/orch/workflows/review-pr-comments.md
@@ -328,6 +328,8 @@ Issue suggestions: [N] items → § 6.2 audit
    ```
    Use the printed token as `[DEV_ROUND_ID]`; note this group's delegated item numbers (`#[N]`) as `[ITEM_NUMBERS]` (comma-separated) for step 5's exact item-set check.
 
+   **In Claude Code**, when the target agent is already alive: send the delegation message before creating and assigning its task — task assignment wakes a live agent immediately, and an agent woken by the bare `task_assignment` payload starts the round without the delegation.
+
    ⚠ Fill placeholders only ([Format Tags Are Literal](../SKILL.md#format-tags-are-literal)). `Recommendation:` = technical fix only; the agent owns process per `dev/workflows/dev-fix.md`.
 
    <delegation_format>

--- a/skills/orch/workflows/start.md
+++ b/skills/orch/workflows/start.md
@@ -85,17 +85,7 @@ If the issue is not open, stop and ask for a different item.
    ```
    Exit 75 means a branch or open PR already owns the issue even though the configured path was absent; inspect/monitor it instead of delegating. Use the successful create output as `WT_PATH`.
 
-5. **Claim the worktree for this session.** `create` never claims — a lease means "a live session is working here", and this workflow is what knows that (vstack#877). Run it for a worktree you just created AND for an existing one you confirmed you own in step 3 above:
-
-   ```bash
-   .agents/skills/worktree/scripts/worktree-session-guard claim [WT_PATH] --owner [ISSUE_ID]
-   ```
-
-   While the lease is held, `worktree cleanup` will not collect this tree and another session's `create --reuse` is refused by name. `worktree remove` releases it at teardown, so nothing else has to.
-
-   Do **not** pass `--repo`: `claim` and `refresh` reject it, and a swallowed failure leaves the guard looking installed while it silently never claims.
-
-   Exit 75 means another session already holds the lease — treat it exactly like step 3's existing-worktree case and coordinate instead of proceeding. Exit 1 with a `flock` message means the host has no `flock`, so the session runs unguarded; continue, but do not assume the tree is protected.
+5. **Session-guard lease** — claimed by the working session in `initialize.md` § 1 step 4, which every § 5 route (continue-here, handoff, manual) reaches through `start-worktree.md` § 1. This launcher step never claims: a lease means "a live session is working here", and for a handoff that session is the launched one.
 
 ## 5. Handoff Or Continue
 

--- a/skills/worktree/README.md
+++ b/skills/worktree/README.md
@@ -37,7 +37,7 @@ Route by shape. `git checkout -- .agents` is **never** the recovery: the path ho
 | `cleanup` | never collects a claimed worktree, and reports every skip |
 | `cleanup --stale [--ttl-minutes N]` | also releases and collects leases past the TTL (default 720) |
 
-`create` deliberately does not claim: a lease means "a live session is working here", which only something that knows a session's lifetime can assert — orch claims in `orch/workflows/start.md`. If `create` claimed, every worktree would stay claimed for life and `cleanup` would collect nothing without `--stale`; releasing on a merged branch was the other candidate and it guts the guarantee, since uncommitted work in a merged tree is what the originating incident lost.
+`create` deliberately does not claim: a lease means "a live session is working here", which only something that knows a session's lifetime can assert — orch claims in `orch/workflows/initialize.md`. If `create` claimed, every worktree would stay claimed for life and `cleanup` would collect nothing without `--stale`; releasing on a merged branch was the other candidate and it guts the guarantee, since uncommitted work in a merged tree is what the originating incident lost.
 
 `status PATH --owner NAME` is the read-only ownership probe and answers by exit code alone: 0 lease for this owner, 1 path not registered, 3 unclaimed, 4 locked outside the guard, 75 claimed by a different owner. `claim` is not a probe — it takes or rewrites the lease.
 

--- a/skills/worktree/SKILL.md
+++ b/skills/worktree/SKILL.md
@@ -130,7 +130,7 @@ scripts/worktree-session-guard sweep --dry-run               # every lease past 
 | `worktree cleanup` | **Never collects a claimed worktree** — not even one this session claimed, since our own lease still means work is in progress. Every skip is reported; a quiet cleanup means nothing was held back. |
 | `worktree cleanup --stale [--ttl-minutes N]` | Additionally releases and collects leases past the TTL (default 720) — the abandoned-session recovery path. |
 
-Claiming is the caller's job: orch claims in `orch/workflows/start.md` once the worktree is the session's, and `remove` releases at teardown. Design rationale and the guard's limits — shared same-issue leases, staleness without liveness, flock availability, what the lock does not block, and the `$USER` owner fallback: [references/session-guard.md](references/session-guard.md).
+Claiming is the caller's job: orch claims in `orch/workflows/initialize.md` once the worktree is the session's, and `remove` releases at teardown. Design rationale and the guard's limits — shared same-issue leases, staleness without liveness, flock availability, what the lock does not block, and the `$USER` owner fallback: [references/session-guard.md](references/session-guard.md).
 
 ## System Dependencies
 

--- a/skills/worktree/references/session-guard.md
+++ b/skills/worktree/references/session-guard.md
@@ -8,7 +8,7 @@ Recording the lease as a native `git worktree lock` reason line needs no coopera
 
 ## Why claiming is the caller's job
 
-**Claiming is the caller's job, deliberately.** A lease means "a live session is working here", and only something that knows a session's lifetime can say that truthfully. orch claims in `orch/workflows/start.md` once the worktree is the session's, and `remove` releases at teardown.
+**Claiming is the caller's job, deliberately.** A lease means "a live session is working here", and only something that knows a session's lifetime can say that truthfully. orch claims in `orch/workflows/initialize.md` once the worktree is the session's, and `remove` releases at teardown.
 
 If `create` claimed instead, every worktree would stay claimed for life — nothing but an explicit `remove` releases — so a lease-aware `cleanup` would collect nothing without `--stale`, trading a silent-destruction bug for a silent-accumulation one. Releasing on a provably merged branch was the other candidate and it guts the guarantee: a merged branch does not mean an idle tree, and uncommitted work in one is exactly what the incident behind this guard lost.
 

--- a/skills/worktree/scripts/worktree
+++ b/skills/worktree/scripts/worktree
@@ -24,7 +24,7 @@
 #     --ttl-minutes N Staleness horizon for --stale (default: 720)
 #
 # Session guard: `create` never claims a lease — see the "Session guard
-# lifecycle" block below for why, and orch's workflows/start.md for who does.
+# lifecycle" block below for why, and orch's workflows/initialize.md for who does.
 #
 # Layout: main checkout (repo) + external worktree parent dir
 #   default: <parent-of-checkout>/.worktrees/<checkout-name>/{id}
@@ -1728,7 +1728,7 @@ worktree_lock_reason() {
 # `remove` releases), so a lease-aware `cleanup` would collect nothing without
 # `--stale` — trading a silent-destruction bug for a silent-accumulation one.
 # Claiming therefore stays with the caller that knows when work starts and ends;
-# orch does it in `workflows/start.md`.
+# orch does it in `workflows/initialize.md`.
 #
 # What IS automatic is the destructive side, because that is where the incident
 # was (hyprtrade CC-1000, worktrees destroyed under live sessions):
@@ -1768,8 +1768,8 @@ session_guard_owner() {
 }
 
 # Owner identity carried by an issue-addressed command (`remove <ID>`,
-# `create <ID> --reuse`). The documented claim in orch's workflows/start.md is
-# `claim [WT_PATH] --owner [ISSUE_ID]`, so on a default install — where no
+# `create <ID> --reuse`). The documented claim in orch's workflows/initialize.md
+# is `claim [WORKTREE_PATH] --owner [ISSUE_ID]`, so on a default install — where no
 # session-owner env var is set — the issue ID IS the identity the lease
 # carries, and deriving it from the command's own argument is what makes claim
 # and release agree without any session env plumbing (#907). Prints nothing
@@ -1804,8 +1804,8 @@ probe_session_lease() {
 # foreign repository's lease is never touched.
 #
 # Ownership is proved by probe, once per identity the caller can claim: the
-# issue ID the command was addressed with first (that is the identity start.md
-# claims with, #907), then the session env ladder. Only an owner-matching
+# issue ID the command was addressed with first (that is the identity orch's
+# initialize.md claims with, #907), then the session env ladder. Only an owner-matching
 # guard lease is released. A foreign lease, a lock taken outside the guard,
 # and an unreadable state are all left exactly as they are and fall through to
 # the precheck, which names the owner and the way out.
@@ -1851,7 +1851,7 @@ reuse_respects_session_lease() {
     env_owner=""
   fi
   # Same identity order as release_own_session_lease: the issue ID the command
-  # was addressed with (the identity start.md claims with, #907), then the
+  # was addressed with (the identity orch's initialize.md claims with, #907), then the
   # session env ladder. A 75 only means "not this identity's lease" — the next
   # candidate may still own it; every other state holds for all identities.
   for candidate in "$issue_owner" "$env_owner"; do

--- a/skills/worktree/tests/worktree_session_guard_lifecycle.sh
+++ b/skills/worktree/tests/worktree_session_guard_lifecycle.sh
@@ -176,7 +176,7 @@ fi
 
 echo "=== issue-addressed calls derive the owner (default install) ==="
 
-# start.md claims with `--owner ISSUE_ID`, and a default install sets no
+# orch's initialize.md claims with `--owner ISSUE_ID`, and a default install sets no
 # session-owner env var — so `remove <ID>` must derive that same identity from
 # its own argument, or claim and release never agree (#907).
 DERIVE_ROOT="$TMP_ROOT/derive"
@@ -211,7 +211,7 @@ assert_contains "$(cat "$DERIVE_ROOT/derive2.err")" "(owner=SESSION-X)" \
 assert_path_absent "$D2" "the env-claimed worktree is gone"
 
 # `create <ID> --reuse` derives the same identity, so the session that claimed
-# per start.md can re-enter its own worktree without env plumbing.
+# per orch's initialize.md can re-enter its own worktree without env plumbing.
 env -u VSTACK_SESSION_OWNER -u HT_SESSION_OWNER bash -c \
   "cd '$DERIVE_ROOT/main' && '$WORKTREE_SCRIPT' create issue-d3" >/dev/null 2>&1
 D3="$DERIVE_ROOT/trees/issue-d3"


### PR DESCRIPTION
Closes #925. Closes #926.

**#925** — in Claude Code, a task ASSIGNMENT wakes a live agent immediately, so the old re-delegation order (create → assign → send) started fix rounds from the bare `task_assignment` payload with the delegation landing a turn late. Re-delegation to a live agent now sends the delegation before creating and assigning the task — stated once in the harness note, in Dev Agent Persistence, and as a one-liner in dev-fix § 2, review-pr-comments § 6.1, and ci-fix; the escalation ladder also re-creates tasks before respawning. Fresh-spawn ordering unchanged. New workflow_helpers pins on all five statements.

**#926** — the session-guard claim moved from start.md § 1 step 5 (unreachable for worktree-launched sessions: open-terminal → start routes to start-worktree.md, which never claimed) to initialize.md § 1 immediately after WORKTREE_PATH resolves — the single path every route shares, with the --repo rejection warning, exit-75 coordination, and flock-less caveat carried over, and a skip-if for the main checkout. start.md's step is now a pointer (asserted: no duplicate claim command to drift). Worktree-skill docs/comments updated start.md → initialize.md cross-references.

Validation: full orch run-all — all 27 files pass; touched worktree lifecycle suite passes.

https://claude.ai/code/session_01CeKocRj9NTENGbPNdJfATt