### PR TITLE
feat(pi-questions): opt-in answersAsUserMessage steer emission (#928)

### DIFF
--- a/pi-extensions/pi-questions/README.md
+++ b/pi-extensions/pi-questions/README.md
@@ -13,6 +13,7 @@ Structured inline questions for Pi. Multi-tab categories, built-in free-text fal
 - Wrapped option labels stay readable in narrow panes.
 - `pi-session-bridge` integration lets external clients list, answer, and reject pending questions.
 - When the bridge is loaded, question opened/answered/rejected lifecycle points publish structured `question.*` activity broker events without adding chat messages.
+- Optional **Answers as user message** setting (off by default) mirrors each answered question into the conversation as a steer-delivered user message for observer extensions such as [pi-automode](https://github.com/czottmann/pi-automode).
 - `pi-qol` notification hook fires before prompts open.
 
 ## Install
@@ -89,8 +90,21 @@ Project settings in `.pi/settings.json` apply only after Pi marks the workspace 
 | Visible option rows | Rows shown before scrolling. |
 | Default question header | Fallback title when a request has no header. |
 | Bridge replies enabled | Allow `pi-session-bridge` to answer/reject pending questions. |
+| Answers as user message | Off by default. Mirror each answered question into the conversation as a steer-delivered user message. See [Answers as user messages](#answers-as-user-messages). |
 
 Glyph style: each package exposes `glyphStyle` (`unicode` default, `ascii` for terminal-safe chrome). `@vanillagreen/pi-tool-renderer.globalGlyphStyleOverride=ascii` forces ASCII chrome across vstack Pi extensions while leaving tool/model/user content unchanged.
+
+## Answers as user messages
+
+Off by default. Enable **Answers as user message** in `/extensions:settings` to have every answered question also delivered to the agent as one steer user message, with the question quoted and the chosen answers below:
+
+```
+> Which path?
+
+Use current branch
+```
+
+Multi-question requests emit one block per tab, prefixed with the tab header (`> Path: Which path?`); a tab with nothing selected shows `(no selection)`; cancelled or dismissed questions send nothing. Enable this when observer extensions such as [pi-automode](https://github.com/czottmann/pi-automode) need to read decisions from the conversation stream — they classify user messages but ignore tool output for security reasons. On Pi cores without `sendUserMessage` steer delivery, the setting silently falls back to tool output only.
 
 ## Bridge control
 

--- a/pi-extensions/pi-questions/extensions/__tests__/activity.test.ts
+++ b/pi-extensions/pi-questions/extensions/__tests__/activity.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 
-import { buildQuestionActivity, publishQuestionActivity, type PiActivityEvent, type QuestionActivityEvent } from "../activity.js";
+import { buildQuestionActivity, publishQuestionActivity, publishQuestionDebug, type PiActivityEvent, type QuestionActivityEvent } from "../activity.js";
 
 const BROKER_SYMBOL = Symbol.for("vstack.pi.activity");
 
@@ -63,5 +63,18 @@ describe("question activity", () => {
 			result: { cancelled: true, requestId: "que_1" },
 		}));
 		expect(event).toMatchObject({ importance: "normal", severity: "warning", type: "question.rejected" });
+	});
+
+	test("question.debug breadcrumbs publish via the broker and stay silent without one", () => {
+		publishQuestionDebug("no broker installed");
+		const events = installBroker();
+		publishQuestionDebug("answersAsUserMessage: steer delivery unavailable");
+		expect(events).toEqual([{
+			importance: "noisy",
+			severity: "debug",
+			source: "pi-questions",
+			summary: "answersAsUserMessage: steer delivery unavailable",
+			type: "question.debug",
+		}]);
 	});
 });

--- a/pi-extensions/pi-questions/extensions/__tests__/answer-steer.test.ts
+++ b/pi-extensions/pi-questions/extensions/__tests__/answer-steer.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+import { emitAnswerSteer, formatAnswerSteerMessage } from "../answer-steer.js";
+import { normalizeRequest } from "../question-model.js";
+
+describe("answer steer formatting", () => {
+	test("single question matches the quoted issue format", () => {
+		const request = normalizeRequest({
+			questions: [{ header: "Path", question: "Which path?", options: [{ label: "A" }, { label: "B" }] }],
+		});
+		expect(formatAnswerSteerMessage(request, [["A"]])).toBe("> Which path?\n\nA");
+	});
+
+	test("multi-question requests emit one header-prefixed block per tab", () => {
+		const request = normalizeRequest({
+			questions: [
+				{ header: "Path", question: "Which path?", options: [{ label: "A" }] },
+				{ header: "Targets", multiple: true, question: "Which targets?", options: [{ label: "Docs" }, { label: "Tests" }] },
+			],
+		});
+		expect(formatAnswerSteerMessage(request, [["A"], ["Docs", "Tests"]])).toBe(
+			"> Path: Which path?\n\nA\n\n> Targets: Which targets?\n\nDocs, Tests",
+		);
+	});
+
+	test("empty tab answers render as no selection", () => {
+		const request = normalizeRequest({
+			questions: [
+				{ header: "Path", question: "Which path?", options: [{ label: "A" }] },
+				{ header: "Targets", multiple: true, question: "Which targets?", options: [{ label: "Docs" }] },
+			],
+		});
+		expect(formatAnswerSteerMessage(request, [["A"], []])).toBe(
+			"> Path: Which path?\n\nA\n\n> Targets: Which targets?\n\n(no selection)",
+		);
+	});
+
+	test("multi-line questions quote every line", () => {
+		expect(formatAnswerSteerMessage({ questions: [{ header: "Q", question: "Line one\nLine two" }] }, [["Yes"]])).toBe(
+			"> Line one\n> Line two\n\nYes",
+		);
+	});
+
+	test("missing request falls back to question numbering", () => {
+		expect(formatAnswerSteerMessage(undefined, [["Yes"]])).toBe("> Question 1\n\nYes");
+	});
+});
+
+describe("answer steer emission", () => {
+	const request = { questions: [{ header: "Path", question: "Which path?" }] };
+
+	test("delivers one steer user message when the host supports it", () => {
+		const calls: Array<{ content: string; options?: { deliverAs?: string } }> = [];
+		const host = {
+			sendUserMessage(content: string, options?: { deliverAs?: "steer" | "followUp" }) {
+				calls.push({ content, options });
+			},
+		};
+		let noted = 0;
+		expect(emitAnswerSteer(host, request, [["A"]], () => { noted += 1; })).toBe(true);
+		expect(calls).toEqual([{ content: "> Which path?\n\nA", options: { deliverAs: "steer" } }]);
+		expect(noted).toBe(0);
+	});
+
+	test("hosts without sendUserMessage degrade silently", () => {
+		let noted = 0;
+		expect(emitAnswerSteer({}, request, [["A"]], () => { noted += 1; })).toBe(false);
+		expect(noted).toBe(1);
+	});
+
+	test("synchronous send failures degrade silently", () => {
+		let noted = 0;
+		const host = { sendUserMessage: () => { throw new Error("deliverAs unsupported"); } };
+		expect(emitAnswerSteer(host, request, [["A"]], () => { noted += 1; })).toBe(false);
+		expect(noted).toBe(1);
+	});
+
+	test("rejected send promises are absorbed", async () => {
+		let noted = 0;
+		const host = { sendUserMessage: () => Promise.reject(new Error("agent still streaming")) };
+		expect(emitAnswerSteer(host, request, [["A"]], () => { noted += 1; })).toBe(true);
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(noted).toBe(1);
+	});
+});
+
+describe("questions.ts steer wiring", () => {
+	const source = readFileSync(new URL("../questions.ts", import.meta.url), "utf8");
+
+	test("emission is gated on the answersAsUserMessage setting, default off", () => {
+		expect(source).toContain('settingBoolean("answersAsUserMessage", false');
+	});
+
+	test("answered events reach emitAnswerSteer with the original request", () => {
+		expect(source).toContain("emitAnswerSteer(pi, event.request, event.result.answers");
+	});
+
+	test("answered and rejected events publish the originating request", () => {
+		expect(source.replace(/\s+/g, " ")).toContain("openedAt, request, requestId: request.id, result: finalResult");
+	});
+});

--- a/pi-extensions/pi-questions/extensions/activity.ts
+++ b/pi-extensions/pi-questions/extensions/activity.ts
@@ -42,6 +42,20 @@ export function publishQuestionActivity(event: QuestionActivityEvent): void {
 	}
 }
 
+export function publishQuestionDebug(summary: string): void {
+	try {
+		activityBroker()?.publish({
+			importance: "noisy",
+			severity: "debug",
+			source: "pi-questions",
+			summary,
+			type: "question.debug",
+		});
+	} catch {
+		// Debug breadcrumbs are best-effort and must never affect question lifecycle.
+	}
+}
+
 export function buildQuestionActivity(event: QuestionActivityEvent): PiActivityEvent {
 	const header = event.request?.header || event.request?.questions?.[0]?.header || "Question";
 	const type = event.action === "opened" ? "question.opened" : event.action === "answered" ? "question.answered" : "question.rejected";

--- a/pi-extensions/pi-questions/extensions/answer-steer.ts
+++ b/pi-extensions/pi-questions/extensions/answer-steer.ts
@@ -1,0 +1,47 @@
+// Opt-in mirror of answered questions into the conversation stream.
+//
+// Observer extensions (e.g. pi-automode) classify user messages but ignore
+// tool output for security reasons, so answers returned only as tool results
+// are invisible to them. When the answersAsUserMessage setting is enabled,
+// each answered question is also delivered as one steer user message: the
+// question quoted, the chosen answers below.
+
+export interface AnswerSteerHost {
+	sendUserMessage?: (content: string, options?: { deliverAs?: "steer" | "followUp" }) => unknown;
+}
+
+export type AnswerSteerRequest = { questions?: Array<{ header?: string; question?: string }> } | undefined;
+
+export function formatAnswerSteerMessage(request: AnswerSteerRequest, answers: string[][]): string {
+	const tabs = request?.questions ?? [];
+	const count = Math.max(answers.length, tabs.length);
+	const blocks: string[] = [];
+	for (let index = 0; index < count; index += 1) {
+		const tab = tabs[index];
+		const question = tab?.question?.trim() || tab?.header?.trim() || `Question ${index + 1}`;
+		const header = tab?.header?.trim() ?? "";
+		const labelled = count > 1 && header && header !== question ? `${header}: ${question}` : question;
+		const quoted = labelled.split("\n").map((line) => `> ${line.trim()}`.trimEnd()).join("\n");
+		const tabAnswers = (answers[index] ?? []).map((answer) => answer.trim()).filter((answer) => answer.length > 0);
+		blocks.push(`${quoted}\n\n${tabAnswers.length > 0 ? tabAnswers.join(", ") : "(no selection)"}`);
+	}
+	return blocks.join("\n\n");
+}
+
+export function emitAnswerSteer(host: AnswerSteerHost, request: AnswerSteerRequest, answers: string[][], onUndeliverable?: () => void): boolean {
+	const send = host?.sendUserMessage;
+	if (typeof send !== "function") {
+		onUndeliverable?.();
+		return false;
+	}
+	try {
+		const outcome = send.call(host, formatAnswerSteerMessage(request, answers), { deliverAs: "steer" });
+		if (outcome && typeof (outcome as { catch?: unknown }).catch === "function") {
+			void (outcome as Promise<unknown>).catch(() => onUndeliverable?.());
+		}
+		return true;
+	} catch {
+		onUndeliverable?.();
+		return false;
+	}
+}

--- a/pi-extensions/pi-questions/extensions/questions.ts
+++ b/pi-extensions/pi-questions/extensions/questions.ts
@@ -16,7 +16,8 @@ import { mkdtemp, writeFile } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 
-import { publishQuestionActivity } from "./activity.js";
+import { publishQuestionActivity, publishQuestionDebug } from "./activity.js";
+import { emitAnswerSteer } from "./answer-steer.js";
 import { frameGlyphs, glyphs, treeGlyph } from "./glyphs.js";
 import {
 	DEFAULT_CUSTOM_LABEL,
@@ -530,6 +531,7 @@ function toPendingView(pending: PendingQuestion): PendingQuestionView {
 }
 
 let emitQuestionOpenedEvent: ((event: QuestionEvent) => void) | undefined;
+let unsubscribeAnswerSteer: (() => void) | undefined;
 
 function notifyQuestionOpened(ctx: ExtensionContext, event: QuestionEvent): void {
 	const service = (globalThis as unknown as Record<PropertyKey, unknown>)[QOL_NOTIFICATION_SERVICE_SYMBOL] as QolNotificationService | undefined;
@@ -569,6 +571,7 @@ class QuestionServiceImpl implements QuestionService {
 					action: "answers" in finalResult ? "answered" : "rejected",
 					closedAt: new Date().toISOString(),
 					openedAt,
+					request,
 					requestId: request.id,
 					result: finalResult,
 					source: completeSource,
@@ -1009,6 +1012,19 @@ export default function questions(pi: ExtensionAPI): void {
 	emitQuestionOpenedEvent = (event) => pi.events.emit(QUESTION_OPENED_EVENT, { requestId: event.requestId, request: event.request, source: event.source });
 	let activeCtx: ExtensionContext | undefined;
 
+	let steerUnavailableNoted = false;
+	const noteSteerUnavailable = () => {
+		if (steerUnavailableNoted) return;
+		steerUnavailableNoted = true;
+		publishQuestionDebug("answersAsUserMessage: sendUserMessage steer delivery unavailable; answers stay in tool output only");
+	};
+	unsubscribeAnswerSteer?.();
+	unsubscribeAnswerSteer = service.subscribe((event) => {
+		if (event.action !== "answered" || !event.result || !("answers" in event.result)) return;
+		if (!settingBoolean("answersAsUserMessage", false, activeCtx?.cwd)) return;
+		emitAnswerSteer(pi, event.request, event.result.answers, noteSteerUnavailable);
+	});
+
 	pi.on("session_start", (_event, ctx) => {
 		recordProjectTrust(ctx);
 		activeCtx = ctx;
@@ -1017,6 +1033,8 @@ export default function questions(pi: ExtensionAPI): void {
 
 	pi.on("session_shutdown", () => {
 		service.shutdown();
+		unsubscribeAnswerSteer?.();
+		unsubscribeAnswerSteer = undefined;
 		emitQuestionOpenedEvent = undefined;
 	});
 

--- a/pi-extensions/pi-questions/package.json
+++ b/pi-extensions/pi-questions/package.json
@@ -48,6 +48,15 @@
           "requiresReload": true
         },
         {
+          "key": "answersAsUserMessage",
+          "label": "Answers as user message",
+          "description": "After a question is answered, also deliver the question and chosen answers to the agent as a steer user message so observer extensions that ignore tool output (e.g. pi-automode) can read decisions from the conversation. Off by default: the extra message changes model-visible context.",
+          "type": "boolean",
+          "default": false,
+          "category": "General",
+          "apply": "live"
+        },
+        {
           "key": "glyphStyle",
           "label": "Glyph style",
           "description": "Glyphs for vstack-owned UI chrome. Unicode is the default; ASCII uses plain box/status/separator characters for terminal compatibility. pi-tool-renderer's global override wins when set.",


### PR DESCRIPTION
Closes #928.

New `answersAsUserMessage` setting (default off, live-toggle via pi-extension-manager): when enabled, each answered question is also delivered as one steer user message — question quoted, chosen answers below, multi-tab aware — so observer extensions that classify user messages but ignore tool output (the reporter's pi-automode) can read decisions from the conversation stream. Cancelled/dismissed questions send nothing. Cores without `sendUserMessage` steer delivery degrade silently to tool-output-only with a one-time `question.debug` activity breadcrumb (also covers rejected send promises).

Implementation subscribes to the existing question-service events (answered-only filter), reads the setting per event, and unsubscribes on teardown; formatting and emission live in a new `answer-steer.ts` with its own test file. Bun suite: 20/20 across 3 files. Not live-tested in a running Pi session — the API-shape guard covers the missing-capability path; flagging per the validate-before-finishing rule.

npm publish is deliberately not part of this PR (human-gated release cycle).

https://claude.ai/code/session_01CeKocRj9NTENGbPNdJfATt