### PR TITLE
fix(pi-claude-bridge): stop mirroring child-executed connector calls into Pi

### DIFF
--- a/pi-extensions/pi-claude-bridge/DEVELOPMENT.md
+++ b/pi-extensions/pi-claude-bridge/DEVELOPMENT.md
@@ -9,6 +9,21 @@ Implementation details for contributors. End-user setup, settings, and troublesh
 - Tool results whose IDs were never registered in the active assistant tool-use turn are refused instead of being queued against another pending call. Remaining handlers receive an internal-error result so the turn cannot report false success.
 - If a query tears down while parallel tool results are still queued or unresolved, the bridge writes diagnostics, marks the Claude session for rebuild, and re-imports delivered results from Pi history on the next turn.
 
+## Child-executed tools (claude.ai connectors)
+
+Tool calls in a bridge turn normally run in one direction: Pi hands its tool set to the bridge, the bridge re-offers it to the `claude` child over the in-process MCP server, and a `tool_use` coming back is the child asking **Pi** to execute something. claude.ai connectors run the other way — they are the child's own MCP servers, attached to the authenticated account and reachable only from inside that process.
+
+So a `tool_use` under `mcp__claude_ai_` is **never mirrored into the Pi stream**: no `toolCall` block, no `toolUse` turn boundary, no entry in the turn's expected-result tracking (`isChildExecutedTool` in `src/connectors.ts`; the three emission sites in `src/assistant-stream.ts`). The child executes the call itself and keeps streaming, so the whole exchange lands in one Pi assistant message.
+
+Mirroring one used to make Pi's agent loop look the name up in `context.tools`, miss, and write a synthetic `Tool <name> not found` error result into the transcript — for a call that had **succeeded**, next to an answer built from its real payload. That reads as a fabricating model, and a rebuild (`syncSharedSession`) projected the false result back into the child's session, turning a wrong mirror into a wrong conversation of record. Found in two host apps at once (drovr#311, memsira#320).
+
+The classifier is namespace-based on purpose. "Any name Pi cannot resolve" would also swallow a genuine Pi↔child tool-name mismatch, which should stay a loud dispatcher error.
+
+Two consequences worth knowing:
+
+- The child's real result is **observed, never re-delivered** (`noteChildExecutedToolResults`, fed from the SDK's `user` message). It already reached the model inside the child. The debug line records the tool name, error flag, and content size — never the payload, which is live account data and the bridge's debug log sits outside a host app's redaction boundary.
+- A connector call therefore leaves **no tool record in the Pi transcript at all**. Pi has no content-block type for a provider-executed tool call, so the honest options were "absent" or "present and wrong". Restoring visibility needs a Pi-side representation for delegated calls.
+
 ## Connector write enforcement
 
 Write denial with `connectorWriteMode: "deny"` is two-layered:

--- a/pi-extensions/pi-claude-bridge/README.md
+++ b/pi-extensions/pi-claude-bridge/README.md
@@ -108,6 +108,8 @@ Turn this on and the model can use whatever your Claude account already has conn
 
 Sessions are **read-only** by default: the model can look things up, but cannot send, post, or change anything unless you explicitly turn writes on below.
 
+Connector tools run inside Claude Code rather than in Pi, so Pi shows the model's answer but no tool card for the lookup itself. (Before this was handled, Pi showed a card claiming `Tool … not found` for calls that had actually succeeded — so an answer built on real data looked invented.)
+
 Extension-manager settings use flat package-scoped keys:
 
 ```json

--- a/pi-extensions/pi-claude-bridge/bundle/index.js
+++ b/pi-extensions/pi-claude-bridge/bundle/index.js
@@ -27275,6 +27275,18 @@ var QueryContext = class {
   reportedToolResultMismatch = false;
   deferredUserMessages = [];
   handledTerminalError = false;
+  // Tool calls the CHILD executes itself (claude.ai connectors — see
+  // isChildExecutedTool). Deliberately NOT in turnToolCalls/turnToolCallIds:
+  // those track calls Pi owes a result for, and Pi owes nothing here. Kept only
+  // so the child's real result can be recognized when it comes back on the SDK's
+  // `user` message, and so the streamed block's deltas can be skipped silently
+  // instead of logging as "unmatched" (which reads like a bug).
+  /** tool_use id → raw SDK tool name. */
+  childExecutedToolCalls = /* @__PURE__ */ new Map();
+  /** Anthropic content-block indexes of the current assistant message that carry
+   *  a child-executed tool_use. Scoped to one message: cleared at message_start,
+   *  and an index is released as soon as a new block starts there. */
+  childExecutedStreamIndexes = /* @__PURE__ */ new Set();
   // Per-turn (reset together)
   turnOutput = null;
   turnStarted = false;
@@ -27315,6 +27327,14 @@ var QueryContext = class {
     this.resolvedToolResultIds.clear();
     this.unmatchedToolResultIds.clear();
     this.reportedToolResultMismatch = false;
+    this.childExecutedToolCalls.clear();
+    this.childExecutedStreamIndexes.clear();
+  }
+  /** Note a tool_use the child runs itself. `streamIndex` is present only on the
+   *  streamed path, where later deltas/stops for that block must be skipped. */
+  noteChildExecutedToolCall(id, rawName, streamIndex) {
+    if (id) this.childExecutedToolCalls.set(id, rawName);
+    if (typeof streamIndex === "number") this.childExecutedStreamIndexes.add(streamIndex);
   }
   recordToolCall(id, toolName, args = {}) {
     if (!id) return;
@@ -43240,6 +43260,9 @@ var CONNECTOR_WRITE_TOOLS = [
   `${CONNECTOR_NS_ATLASSIAN}createCompassComponentRelationship`,
   `${CONNECTOR_NS_ATLASSIAN}createCompassCustomFieldDefinition`
 ];
+function isChildExecutedTool(name) {
+  return typeof name === "string" && name.startsWith(CONNECTOR_NS_PREFIX2);
+}
 function isConnectorWriteTool(name) {
   if (!name.startsWith(CONNECTOR_NS_PREFIX2)) return false;
   const sep2 = name.indexOf("__", CONNECTOR_NS_PREFIX2.length);
@@ -44324,6 +44347,12 @@ function processStreamEvent(message, customToolNameToPi, model) {
   if (event?.type === "content_block_start") {
     c.turnSawStreamEvent = true;
     ensureTurnStarted();
+    c.childExecutedStreamIndexes.delete(event.index);
+    if (event.content_block?.type === "tool_use" && isChildExecutedTool(event.content_block.name)) {
+      c.noteChildExecutedToolCall(event.content_block.id, event.content_block.name, event.index);
+      debug(`processStreamEvent: child-executed tool ${event.content_block.name} [${event.content_block.id}] \u2014 not mirrored as a Pi tool call`);
+      return;
+    }
     if (event.content_block?.type === "text") {
       c.turnBlocks.push({ type: "text", text: "", index: event.index });
       c.currentPiStream.push({ type: "text_start", contentIndex: c.turnBlocks.length - 1, partial: c.turnOutput });
@@ -44349,6 +44378,10 @@ function processStreamEvent(message, customToolNameToPi, model) {
     return;
   }
   if (event?.type === "content_block_delta") {
+    if (c.childExecutedStreamIndexes.has(event.index)) {
+      c.turnSawStreamEvent = true;
+      return;
+    }
     const index = c.turnBlocks.findIndex((b) => b.index === event.index);
     const block = c.turnBlocks[index];
     if (!block) {
@@ -44374,6 +44407,10 @@ function processStreamEvent(message, customToolNameToPi, model) {
     return;
   }
   if (event?.type === "content_block_stop") {
+    if (c.childExecutedStreamIndexes.has(event.index)) {
+      c.turnSawStreamEvent = true;
+      return;
+    }
     const index = c.turnBlocks.findIndex((b) => b.index === event.index);
     const block = c.turnBlocks[index];
     if (!block) {
@@ -44420,6 +44457,11 @@ function appendMissingToolUsesFromAssistant(assistantMsg, model, customToolNameT
   let sawToolUse = false;
   for (const block of assistantMsg.content) {
     if (block.type !== "tool_use") continue;
+    if (isChildExecutedTool(block.name)) {
+      c.noteChildExecutedToolCall(block.id, block.name);
+      debug(`assistant message: child-executed tool ${block.name} [${block.id}] \u2014 not mirrored as a Pi tool call`);
+      continue;
+    }
     sawToolUse = true;
     const existingIdx = c.turnBlocks.findIndex((b) => b.type === "toolCall" && b.id === block.id);
     const name = mapToolName(block.name, customToolNameToPi);
@@ -44451,6 +44493,19 @@ function appendMissingToolUsesFromAssistant(assistantMsg, model, customToolNameT
   }
   if (assistantMsg.usage && c.turnOutput) updateUsage(c.turnOutput, assistantMsg.usage, model);
   return sawToolUse;
+}
+function noteChildExecutedToolResults(message) {
+  const c = ctx();
+  if (c.childExecutedToolCalls.size === 0) return;
+  const content = message.message?.content;
+  if (!Array.isArray(content)) return;
+  for (const block of content) {
+    if (block?.type !== "tool_result") continue;
+    const name = c.childExecutedToolCalls.get(block.tool_use_id);
+    if (!name) continue;
+    const size = typeof block.content === "string" ? block.content.length : Array.isArray(block.content) ? block.content.length : 0;
+    debug(`child-executed tool result: ${name} [${block.tool_use_id}] isError=${block.is_error === true} contentSize=${size}`);
+  }
 }
 function processAssistantMessage(message, model, customToolNameToPi) {
   const c = ctx();
@@ -44488,6 +44543,11 @@ function processAssistantMessage(message, model, customToolNameToPi) {
       if (block.thinking) c.currentPiStream?.push({ type: "thinking_delta", contentIndex: idx, delta: block.thinking, partial: c.turnOutput });
       c.currentPiStream?.push({ type: "thinking_end", contentIndex: idx, content: block.thinking ?? "", partial: c.turnOutput });
     } else if (block.type === "tool_use") {
+      if (isChildExecutedTool(block.name)) {
+        c.noteChildExecutedToolCall(block.id, block.name);
+        debug(`processAssistantMessage fallback: child-executed tool ${block.name} [${block.id}] \u2014 not mirrored as a Pi tool call`);
+        continue;
+      }
       ensureTurnStarted();
       c.turnSawToolCall = true;
       const mappedName = mapToolName(block.name, customToolNameToPi);
@@ -44806,8 +44866,8 @@ async function consumeQuery(sdkQuery, customToolNameToPi, model, cwd, bridgeConf
         }
         break;
       case "user":
+        noteChildExecutedToolResults(message);
         break;
-      // SDK echo of user prompt — not needed
       case "rate_limit_event": {
         const info = message.rate_limit_info;
         debug("consumeQuery: rate_limit_event", JSON.stringify(info).slice(0, 300));
@@ -45477,6 +45537,7 @@ export {
   listAccountConnectors,
   mapToolName,
   normalizeRateLimitUtilization,
+  noteChildExecutedToolResults,
   preflightClaudeExecutable,
   primeConnectorServers,
   processAssistantMessage,

--- a/pi-extensions/pi-claude-bridge/bundle/index.js
+++ b/pi-extensions/pi-claude-bridge/bundle/index.js
@@ -27303,14 +27303,32 @@ var QueryContext = class {
   // too — each call bills its own.
   turnUsageCarry = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
   currentMessageUsage = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
-  /** Fold the in-flight child message's counters into the turn total and start a
-   *  fresh one. Called at each `message_start`; a no-op on the turn's first. */
-  carryCurrentMessageUsage() {
+  /** Anthropic id of the child message `currentMessageUsage` describes. */
+  currentMessageId;
+  /**
+   * Declare which child message the following usage belongs to, banking the
+   * previous one's counters into the turn total.
+   *
+   * Keyed on the MESSAGE ID rather than on the call site, because both paths
+   * that see a message boundary can fire for the SAME message: `message_start`
+   * arrives on the stream, and the SDK then yields that message again in
+   * completed form. Banking per call site double-counted whenever the completed
+   * copy took the no-stream-events branch — which it does whenever a message
+   * produced no content blocks, since `turnSawStreamEvent` only tracks those.
+   *
+   * With no id on either side (older/streamless shapes) this degrades to
+   * banking on every call, which is what each caller means when it cannot
+   * prove otherwise.
+   */
+  beginChildMessage(messageId) {
+    const id = typeof messageId === "string" && messageId.length > 0 ? messageId : void 0;
+    if (id !== void 0 && id === this.currentMessageId) return;
     this.turnUsageCarry.input += this.currentMessageUsage.input;
     this.turnUsageCarry.output += this.currentMessageUsage.output;
     this.turnUsageCarry.cacheRead += this.currentMessageUsage.cacheRead;
     this.turnUsageCarry.cacheWrite += this.currentMessageUsage.cacheWrite;
     this.currentMessageUsage = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+    this.currentMessageId = id;
   }
   // Per-turn (reset together)
   turnOutput = null;
@@ -27345,6 +27363,7 @@ var QueryContext = class {
     this.handledTerminalError = false;
     this.turnUsageCarry = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
     this.currentMessageUsage = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+    this.currentMessageId = void 0;
   }
   resetToolTracking() {
     this.turnToolCallIds = [];
@@ -44374,7 +44393,7 @@ function processStreamEvent(message, customToolNameToPi, model) {
   }
   if (event?.type === "message_start") {
     c.resetToolTracking();
-    c.carryCurrentMessageUsage();
+    c.beginChildMessage(event.message?.id);
     updateTurnOutputModel(event.message?.model);
     if (event.message?.usage) updateUsage(c.turnOutput, event.message.usage, model);
     return;
@@ -44561,6 +44580,7 @@ function processAssistantMessage(message, model, customToolNameToPi) {
     return;
   }
   c.resetToolTracking();
+  c.beginChildMessage(assistantMsg.id);
   debug(`processAssistantMessage fallback: ${assistantMsg.content.length} blocks, types=${assistantMsg.content.map((b) => b.type).join(",")}`);
   for (const block of assistantMsg.content) {
     if (block.type === "text" && block.text) {

--- a/pi-extensions/pi-claude-bridge/bundle/index.js
+++ b/pi-extensions/pi-claude-bridge/bundle/index.js
@@ -27287,6 +27287,31 @@ var QueryContext = class {
    *  a child-executed tool_use. Scoped to one message: cleared at message_start,
    *  and an index is released as soon as a new block starts there. */
   childExecutedStreamIndexes = /* @__PURE__ */ new Set();
+  // Usage accounting for a Pi turn that spans SEVERAL child assistant messages.
+  //
+  // Every child message is a separate billed API call, and each reports its own
+  // counters — `message_start`/`message_delta` REPLACE rather than accumulate. A
+  // Pi turn used to end at the first tool call, so one Pi message meant one child
+  // message and replacing was right. A turn containing a child-executed connector
+  // call now keeps running across the child's follow-up messages, so replacing
+  // would silently drop everything the earlier ones billed (measured: 55,685
+  // cache-write tokens lost on a single connector turn).
+  //
+  // So: `turnUsageCarry` holds the totals of the child messages already COMPLETE
+  // in this Pi turn, `currentMessageUsage` holds the one in flight, and the Pi
+  // message reports their sum. Summing is the correct model for input and cache
+  // too — each call bills its own.
+  turnUsageCarry = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+  currentMessageUsage = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+  /** Fold the in-flight child message's counters into the turn total and start a
+   *  fresh one. Called at each `message_start`; a no-op on the turn's first. */
+  carryCurrentMessageUsage() {
+    this.turnUsageCarry.input += this.currentMessageUsage.input;
+    this.turnUsageCarry.output += this.currentMessageUsage.output;
+    this.turnUsageCarry.cacheRead += this.currentMessageUsage.cacheRead;
+    this.turnUsageCarry.cacheWrite += this.currentMessageUsage.cacheWrite;
+    this.currentMessageUsage = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+  }
   // Per-turn (reset together)
   turnOutput = null;
   turnStarted = false;
@@ -27318,6 +27343,8 @@ var QueryContext = class {
     this.turnSawStreamEvent = false;
     this.turnSawToolCall = false;
     this.handledTerminalError = false;
+    this.turnUsageCarry = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+    this.currentMessageUsage = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
   }
   resetToolTracking() {
     this.turnToolCallIds = [];
@@ -44278,10 +44305,17 @@ function mapToolArgs(toolName, args) {
 // src/assistant-stream.ts
 import { calculateCost } from "@earendil-works/pi-ai";
 function updateUsage(output, usage, model) {
-  if (usage.input_tokens != null) output.usage.input = usage.input_tokens;
-  if (usage.output_tokens != null) output.usage.output = usage.output_tokens;
-  if (usage.cache_read_input_tokens != null) output.usage.cacheRead = usage.cache_read_input_tokens;
-  if (usage.cache_creation_input_tokens != null) output.usage.cacheWrite = usage.cache_creation_input_tokens;
+  const c = ctx();
+  const current = c.currentMessageUsage;
+  const carry = c.turnUsageCarry;
+  if (usage.input_tokens != null) current.input = usage.input_tokens;
+  if (usage.output_tokens != null) current.output = usage.output_tokens;
+  if (usage.cache_read_input_tokens != null) current.cacheRead = usage.cache_read_input_tokens;
+  if (usage.cache_creation_input_tokens != null) current.cacheWrite = usage.cache_creation_input_tokens;
+  output.usage.input = carry.input + current.input;
+  output.usage.output = carry.output + current.output;
+  output.usage.cacheRead = carry.cacheRead + current.cacheRead;
+  output.usage.cacheWrite = carry.cacheWrite + current.cacheWrite;
   output.usage.totalTokens = output.usage.input + output.usage.output + output.usage.cacheRead + output.usage.cacheWrite;
   calculateCost(model, output.usage);
   const promptTokens = output.usage.input + output.usage.cacheRead + output.usage.cacheWrite;
@@ -44340,6 +44374,7 @@ function processStreamEvent(message, customToolNameToPi, model) {
   }
   if (event?.type === "message_start") {
     c.resetToolTracking();
+    c.carryCurrentMessageUsage();
     updateTurnOutputModel(event.message?.model);
     if (event.message?.usage) updateUsage(c.turnOutput, event.message.usage, model);
     return;

--- a/pi-extensions/pi-claude-bridge/src/assistant-stream.ts
+++ b/pi-extensions/pi-claude-bridge/src/assistant-stream.ts
@@ -89,8 +89,9 @@ export function processStreamEvent(
 	if (event?.type === "message_start") {
 		c.resetToolTracking();
 		// A new child message begins: bank what the previous one billed before its
-		// counters are replaced. No-op on the first message of a Pi turn.
-		c.carryCurrentMessageUsage();
+		// counters are replaced. No-op on the turn's first, and no-op if this same
+		// message was already declared (see beginChildMessage).
+		c.beginChildMessage(event.message?.id);
 		updateTurnOutputModel(event.message?.model);
 		if (event.message?.usage) updateUsage(c.turnOutput, event.message.usage, model);
 		return;
@@ -338,6 +339,11 @@ export function processAssistantMessage(message: SDKMessage, model: Model<any>, 
 		return;
 	}
 	c.resetToolTracking();
+	// The no-stream-events path also sees a message boundary. It is keyed on the
+	// message ID rather than trusted blindly, because this branch is ALSO reached
+	// for a message whose `message_start` already streamed — any message that
+	// produced no content blocks, since `turnSawStreamEvent` only tracks those.
+	c.beginChildMessage(assistantMsg.id);
 	debug(`processAssistantMessage fallback: ${assistantMsg.content.length} blocks, types=${assistantMsg.content.map((b: any) => b.type).join(",")}`);
 	for (const block of assistantMsg.content) {
 		if (block.type === "text" && block.text) {

--- a/pi-extensions/pi-claude-bridge/src/assistant-stream.ts
+++ b/pi-extensions/pi-claude-bridge/src/assistant-stream.ts
@@ -8,10 +8,21 @@ import { mapToolArgs, mapToolName } from "./tool-mapping.js";
 // --- Usage helpers ---
 
 function updateUsage(output: AssistantMessage, usage: Record<string, number | undefined>, model: Model<any>): void {
-	if (usage.input_tokens != null) output.usage.input = usage.input_tokens;
-	if (usage.output_tokens != null) output.usage.output = usage.output_tokens;
-	if (usage.cache_read_input_tokens != null) output.usage.cacheRead = usage.cache_read_input_tokens;
-	if (usage.cache_creation_input_tokens != null) output.usage.cacheWrite = usage.cache_creation_input_tokens;
+	// Anthropic reports per-message counters and RE-reports them as the message
+	// grows, so the in-flight message's figures are replaced, not added. What is
+	// added is every child message already finished in this Pi turn — see
+	// `turnUsageCarry` in query-state.ts for why a turn can span several.
+	const c = ctx();
+	const current = c.currentMessageUsage;
+	const carry = c.turnUsageCarry;
+	if (usage.input_tokens != null) current.input = usage.input_tokens;
+	if (usage.output_tokens != null) current.output = usage.output_tokens;
+	if (usage.cache_read_input_tokens != null) current.cacheRead = usage.cache_read_input_tokens;
+	if (usage.cache_creation_input_tokens != null) current.cacheWrite = usage.cache_creation_input_tokens;
+	output.usage.input = carry.input + current.input;
+	output.usage.output = carry.output + current.output;
+	output.usage.cacheRead = carry.cacheRead + current.cacheRead;
+	output.usage.cacheWrite = carry.cacheWrite + current.cacheWrite;
 	output.usage.totalTokens = output.usage.input + output.usage.output + output.usage.cacheRead + output.usage.cacheWrite;
 	calculateCost(model, output.usage);
 	const promptTokens = output.usage.input + output.usage.cacheRead + output.usage.cacheWrite;
@@ -77,6 +88,9 @@ export function processStreamEvent(
 
 	if (event?.type === "message_start") {
 		c.resetToolTracking();
+		// A new child message begins: bank what the previous one billed before its
+		// counters are replaced. No-op on the first message of a Pi turn.
+		c.carryCurrentMessageUsage();
 		updateTurnOutputModel(event.message?.model);
 		if (event.message?.usage) updateUsage(c.turnOutput, event.message.usage, model);
 		return;

--- a/pi-extensions/pi-claude-bridge/src/assistant-stream.ts
+++ b/pi-extensions/pi-claude-bridge/src/assistant-stream.ts
@@ -1,5 +1,6 @@
 import { calculateCost, type AssistantMessage, type Model } from "@earendil-works/pi-ai";
 import { type SDKMessage } from "@anthropic-ai/claude-agent-sdk";
+import { isChildExecutedTool } from "./connectors.js";
 import { debug } from "./debug.js";
 import { ctx } from "./query-state.js";
 import { mapToolArgs, mapToolName } from "./tool-mapping.js";
@@ -84,6 +85,18 @@ export function processStreamEvent(
 	if (event?.type === "content_block_start") {
 		c.turnSawStreamEvent = true;
 		ensureTurnStarted();
+		// A new block owns this index from here on, so release any child-executed
+		// claim on it. Belt-and-braces against a missed message_start: without this
+		// a stale index could silently swallow a later text block's deltas.
+		c.childExecutedStreamIndexes.delete(event.index);
+		if (event.content_block?.type === "tool_use" && isChildExecutedTool(event.content_block.name)) {
+			// The child runs this one itself — mirroring it into the Pi stream would
+			// make Pi's agent loop dispatch a tool it does not have. See
+			// isChildExecutedTool.
+			c.noteChildExecutedToolCall(event.content_block.id, event.content_block.name, event.index);
+			debug(`processStreamEvent: child-executed tool ${event.content_block.name} [${event.content_block.id}] — not mirrored as a Pi tool call`);
+			return;
+		}
 		if (event.content_block?.type === "text") {
 			c.turnBlocks.push({ type: "text", text: "", index: event.index });
 			c.currentPiStream!.push({ type: "text_start", contentIndex: c.turnBlocks.length - 1, partial: c.turnOutput });
@@ -108,6 +121,14 @@ export function processStreamEvent(
 	}
 
 	if (event?.type === "content_block_delta") {
+		// A child-executed tool's argument deltas have no Pi block to land in. Skip
+		// them here rather than letting the lookup below miss, so the "unmatched"
+		// warning keeps meaning "something is wrong". Unlike that stale-event case
+		// this IS a live event for the current message, so it still counts as one.
+		if (c.childExecutedStreamIndexes.has(event.index)) {
+			c.turnSawStreamEvent = true;
+			return;
+		}
 		const index = c.turnBlocks.findIndex((b: any) => b.index === event.index);
 		const block = c.turnBlocks[index];
 		if (!block) {
@@ -134,6 +155,12 @@ export function processStreamEvent(
 	}
 
 	if (event?.type === "content_block_stop") {
+		// Same as the delta case: the block was never mirrored, so there is nothing
+		// to seal and nothing unmatched about it.
+		if (c.childExecutedStreamIndexes.has(event.index)) {
+			c.turnSawStreamEvent = true;
+			return;
+		}
 		const index = c.turnBlocks.findIndex((b: any) => b.index === event.index);
 		const block = c.turnBlocks[index];
 		if (!block) {
@@ -200,6 +227,14 @@ function appendMissingToolUsesFromAssistant(
 	let sawToolUse = false;
 	for (const block of assistantMsg.content) {
 		if (block.type !== "tool_use") continue;
+		if (isChildExecutedTool(block.name)) {
+			// Not a Pi tool call, so it is NOT a turn boundary either: `sawToolUse`
+			// stays false for it and the caller keeps streaming this Pi message. The
+			// child neither blocks on Pi nor needs a result from it.
+			c.noteChildExecutedToolCall(block.id, block.name);
+			debug(`assistant message: child-executed tool ${block.name} [${block.id}] — not mirrored as a Pi tool call`);
+			continue;
+		}
 		sawToolUse = true;
 		const existingIdx = c.turnBlocks.findIndex((b: any) => b.type === "toolCall" && b.id === block.id);
 		const name = mapToolName(block.name, customToolNameToPi);
@@ -231,6 +266,37 @@ function appendMissingToolUsesFromAssistant(
 	}
 	if (assistantMsg.usage && c.turnOutput) updateUsage(c.turnOutput, assistantMsg.usage, model);
 	return sawToolUse;
+}
+
+/**
+ * Record that a child-executed tool call came back, from the SDK's `user` message
+ * carrying the child's own `tool_result` blocks.
+ *
+ * This is the only place the bridge ever OBSERVES one of these results, and it is
+ * deliberately observation-only: the result already reached the model inside the
+ * child, which is the conversation of record for a bridge turn, so re-delivering
+ * it would double it. What the bridge could not do before this existed was say
+ * anything true about these calls at all — the Pi transcript claimed they failed
+ * and nothing anywhere claimed otherwise.
+ *
+ * The payload is NEVER logged, only its shape: a connector result is live account
+ * data (mail, messages, documents) and the bridge's debug log sits outside a host
+ * app's redaction boundary.
+ */
+export function noteChildExecutedToolResults(message: SDKMessage): void {
+	const c = ctx();
+	if (c.childExecutedToolCalls.size === 0) return;
+	const content = (message as SDKMessage & { message?: { content?: unknown } }).message?.content;
+	if (!Array.isArray(content)) return;
+	for (const block of content) {
+		if (block?.type !== "tool_result") continue;
+		const name = c.childExecutedToolCalls.get(block.tool_use_id);
+		if (!name) continue;
+		const size = typeof block.content === "string"
+			? block.content.length
+			: Array.isArray(block.content) ? block.content.length : 0;
+		debug(`child-executed tool result: ${name} [${block.tool_use_id}] isError=${block.is_error === true} contentSize=${size}`);
+	}
 }
 
 export function processAssistantMessage(message: SDKMessage, model: Model<any>, customToolNameToPi: Map<string, string>): void {
@@ -275,6 +341,13 @@ export function processAssistantMessage(message: SDKMessage, model: Model<any>, 
 			if (block.thinking) c.currentPiStream?.push({ type: "thinking_delta", contentIndex: idx, delta: block.thinking, partial: c.turnOutput });
 			c.currentPiStream?.push({ type: "thinking_end", contentIndex: idx, content: block.thinking ?? "", partial: c.turnOutput });
 		} else if (block.type === "tool_use") {
+			if (isChildExecutedTool(block.name)) {
+				// Same as the streamed path: the child owns this call, so it never
+				// becomes a Pi tool call and never ends the turn.
+				c.noteChildExecutedToolCall(block.id, block.name);
+				debug(`processAssistantMessage fallback: child-executed tool ${block.name} [${block.id}] — not mirrored as a Pi tool call`);
+				continue;
+			}
 			ensureTurnStarted();
 			c.turnSawToolCall = true;
 			const mappedName = mapToolName(block.name, customToolNameToPi);

--- a/pi-extensions/pi-claude-bridge/src/connectors.ts
+++ b/pi-extensions/pi-claude-bridge/src/connectors.ts
@@ -215,6 +215,45 @@ export const CONNECTOR_WRITE_TOOLS = [
 	`${CONNECTOR_NS_ATLASSIAN}createCompassCustomFieldDefinition`,
 ];
 
+/**
+ * True for a tool that the `claude` CHILD executes itself, so Pi must never be
+ * asked to dispatch it.
+ *
+ * WHY THIS EXISTS. Every other tool the model calls in a bridge turn is a PI
+ * tool: Pi hands its tool set to the bridge, the bridge re-offers it to the
+ * child through the in-process MCP server, and a `tool_use` coming back is the
+ * child asking PI to run something. The bridge is built around that direction —
+ * it mirrors the call into the Pi stream, ends the Pi turn with `toolUse`, and
+ * the MCP handler blocks until Pi delivers the result.
+ *
+ * claude.ai connectors run the other way. They are the CHILD's own MCP servers,
+ * attached to the authenticated account and reachable only from inside that
+ * process. Pi has never heard of them. Mirroring one into the Pi stream anyway
+ * made Pi's agent loop look the name up in `context.tools`, miss, and write a
+ * synthetic `Tool <name> not found` error result into the transcript — while the
+ * child went on and executed the real call. The Pi transcript then RECORDED A
+ * FAILURE FOR A CALL THAT SUCCEEDED, next to an answer built from the real
+ * payload, so the model's correct answer read as a fabrication (drovr#311,
+ * memsira#320). The false result is also projected back into the child's session
+ * on a rebuild (`syncSharedSession`), which is how a lie in a mirror becomes a
+ * lie in the conversation of record.
+ *
+ * The test is the NAMESPACE, deliberately, not "does this name resolve to a Pi
+ * tool". Every claude.ai connector server lives under `mcp__claude_ai_`, and
+ * that is the only tool class the bridge knowingly delegates. A broader
+ * "unresolvable ⇒ delegated" rule would also swallow a genuine tool-name
+ * mismatch between Pi and the child, which SHOULD still surface as a loud
+ * dispatcher error.
+ *
+ * Takes the RAW SDK tool name, before `mapToolName` — connector names have no
+ * Pi-side counterpart, so mapping them is meaningless. Accepts a missing name
+ * rather than asserting one: this decides whether Pi is allowed to dispatch a
+ * block, and a nameless block is not a connector, so it answers `false`.
+ */
+export function isChildExecutedTool(name: string | undefined): boolean {
+	return typeof name === "string" && name.startsWith(CONNECTOR_NS_PREFIX);
+}
+
 // Classify a connector tool name as a WRITE (mutating) tool. FAIL CLOSED, twice:
 //
 //  1. Namespace: the whole `mcp__claude_ai_<Server>__` space counts, not just the

--- a/pi-extensions/pi-claude-bridge/src/index.ts
+++ b/pi-extensions/pi-claude-bridge/src/index.ts
@@ -46,7 +46,7 @@ import { restoreSharedSessionFromPi, schedulePersistSharedSession, syncSharedSes
 import { STREAM_IDLE_BACKOFF_HINT_MS, activeStreamIdleWatchdogs, buildStreamIdleTimeoutErrorMessage, createStreamIdleWatchdog, formatDurationShort, streamIdleTimeoutMsFromEnv } from "./stream-idle-watchdog.js";
 import { RATE_LIMIT_AUTO_RESUME_EVENT, RATE_LIMIT_TOKEN, formatAllowedRateLimitWarning, formatResetTimestamp, isExtraUsageRequiredMessage, uniqueNonEmptyLines } from "./rate-limit.js";
 import { mapToolArgs } from "./tool-mapping.js";
-import { ensureTurnStarted, finalizeCurrentStream, parsePartialJson, processAssistantMessage, processStreamEvent, updateTurnOutputModel } from "./assistant-stream.js";
+import { ensureTurnStarted, finalizeCurrentStream, noteChildExecutedToolResults, parsePartialJson, processAssistantMessage, processStreamEvent, updateTurnOutputModel } from "./assistant-stream.js";
 
 // Re-exports: the module decomposition must not change the bundle entry's
 // public surface — unit tests and downstream consumers import these from
@@ -58,7 +58,7 @@ export { restoreSharedSessionFromPi, shouldRestorePersistedBridgeEntry } from ".
 export { DEFAULT_STREAM_IDLE_TIMEOUT_MS, STREAM_IDLE_BACKOFF_HINT_MS, STREAM_IDLE_TIMEOUT_ENV, buildStreamIdleTimeoutErrorMessage, createStreamIdleWatchdog, streamIdleTimeoutMsFromEnv, type StreamIdleTimeoutInfo, type StreamIdleWatchdog, type StreamIdleWatchdogState } from "./stream-idle-watchdog.js";
 export { ALLOWED_RATE_LIMIT_WARNING_UTILIZATION_THRESHOLD, formatAllowedRateLimitWarning, formatResetTimestamp, isExtraUsageRequiredMessage, normalizeRateLimitUtilization, uniqueNonEmptyLines } from "./rate-limit.js";
 export { mapToolName } from "./tool-mapping.js";
-export { processAssistantMessage, processStreamEvent } from "./assistant-stream.js";
+export { noteChildExecutedToolResults, processAssistantMessage, processStreamEvent } from "./assistant-stream.js";
 
 // Compat (#2): use factory if available (pi-ai ≥0.66), else fall back to constructor (gsd-pi etc.)
 const _piAi = piAi as any;
@@ -485,7 +485,11 @@ async function consumeQuery(
 				}
 				break;
 			case "user":
-				break; // SDK echo of user prompt — not needed
+				// Mostly the SDK echoing the prompt back — nothing to render. The one
+				// thing worth reading is a child-executed tool's real result, which
+				// arrives here and nowhere else.
+				noteChildExecutedToolResults(message);
+				break;
 			case "rate_limit_event": {
 				const info = (message as any).rate_limit_info;
 				debug("consumeQuery: rate_limit_event", JSON.stringify(info).slice(0, 300));

--- a/pi-extensions/pi-claude-bridge/src/query-state.ts
+++ b/pi-extensions/pi-claude-bridge/src/query-state.ts
@@ -153,6 +153,33 @@ export class QueryContext {
 	 *  and an index is released as soon as a new block starts there. */
 	childExecutedStreamIndexes = new Set<number>();
 
+	// Usage accounting for a Pi turn that spans SEVERAL child assistant messages.
+	//
+	// Every child message is a separate billed API call, and each reports its own
+	// counters — `message_start`/`message_delta` REPLACE rather than accumulate. A
+	// Pi turn used to end at the first tool call, so one Pi message meant one child
+	// message and replacing was right. A turn containing a child-executed connector
+	// call now keeps running across the child's follow-up messages, so replacing
+	// would silently drop everything the earlier ones billed (measured: 55,685
+	// cache-write tokens lost on a single connector turn).
+	//
+	// So: `turnUsageCarry` holds the totals of the child messages already COMPLETE
+	// in this Pi turn, `currentMessageUsage` holds the one in flight, and the Pi
+	// message reports their sum. Summing is the correct model for input and cache
+	// too — each call bills its own.
+	turnUsageCarry = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+	currentMessageUsage = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+
+	/** Fold the in-flight child message's counters into the turn total and start a
+	 *  fresh one. Called at each `message_start`; a no-op on the turn's first. */
+	carryCurrentMessageUsage(): void {
+		this.turnUsageCarry.input += this.currentMessageUsage.input;
+		this.turnUsageCarry.output += this.currentMessageUsage.output;
+		this.turnUsageCarry.cacheRead += this.currentMessageUsage.cacheRead;
+		this.turnUsageCarry.cacheWrite += this.currentMessageUsage.cacheWrite;
+		this.currentMessageUsage = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+	}
+
 	// Per-turn (reset together)
 	turnOutput: AssistantMessage | null = null;
 	turnStarted = false;
@@ -176,6 +203,10 @@ export class QueryContext {
 		this.turnSawStreamEvent = false;
 		this.turnSawToolCall = false;
 		this.handledTerminalError = false;
+		// Usage accounting IS per-Pi-message, so it resets with the message it
+		// describes — unlike tool-call tracking below.
+		this.turnUsageCarry = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+		this.currentMessageUsage = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
 		// Tool-call tracking is NOT reset here — it persists across the
 		// tool-result delivery callback for the same assistant message. New
 		// assistant messages call resetToolTracking() explicitly.

--- a/pi-extensions/pi-claude-bridge/src/query-state.ts
+++ b/pi-extensions/pi-claude-bridge/src/query-state.ts
@@ -169,15 +169,33 @@ export class QueryContext {
 	// too — each call bills its own.
 	turnUsageCarry = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
 	currentMessageUsage = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+	/** Anthropic id of the child message `currentMessageUsage` describes. */
+	currentMessageId: string | undefined;
 
-	/** Fold the in-flight child message's counters into the turn total and start a
-	 *  fresh one. Called at each `message_start`; a no-op on the turn's first. */
-	carryCurrentMessageUsage(): void {
+	/**
+	 * Declare which child message the following usage belongs to, banking the
+	 * previous one's counters into the turn total.
+	 *
+	 * Keyed on the MESSAGE ID rather than on the call site, because both paths
+	 * that see a message boundary can fire for the SAME message: `message_start`
+	 * arrives on the stream, and the SDK then yields that message again in
+	 * completed form. Banking per call site double-counted whenever the completed
+	 * copy took the no-stream-events branch — which it does whenever a message
+	 * produced no content blocks, since `turnSawStreamEvent` only tracks those.
+	 *
+	 * With no id on either side (older/streamless shapes) this degrades to
+	 * banking on every call, which is what each caller means when it cannot
+	 * prove otherwise.
+	 */
+	beginChildMessage(messageId?: unknown): void {
+		const id = typeof messageId === "string" && messageId.length > 0 ? messageId : undefined;
+		if (id !== undefined && id === this.currentMessageId) return; // same message
 		this.turnUsageCarry.input += this.currentMessageUsage.input;
 		this.turnUsageCarry.output += this.currentMessageUsage.output;
 		this.turnUsageCarry.cacheRead += this.currentMessageUsage.cacheRead;
 		this.turnUsageCarry.cacheWrite += this.currentMessageUsage.cacheWrite;
 		this.currentMessageUsage = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+		this.currentMessageId = id;
 	}
 
 	// Per-turn (reset together)
@@ -207,6 +225,7 @@ export class QueryContext {
 		// describes — unlike tool-call tracking below.
 		this.turnUsageCarry = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
 		this.currentMessageUsage = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+		this.currentMessageId = undefined;
 		// Tool-call tracking is NOT reset here — it persists across the
 		// tool-result delivery callback for the same assistant message. New
 		// assistant messages call resetToolTracking() explicitly.

--- a/pi-extensions/pi-claude-bridge/src/query-state.ts
+++ b/pi-extensions/pi-claude-bridge/src/query-state.ts
@@ -140,6 +140,19 @@ export class QueryContext {
 	deferredUserMessages: string[] = [];
 	handledTerminalError = false;
 
+	// Tool calls the CHILD executes itself (claude.ai connectors — see
+	// isChildExecutedTool). Deliberately NOT in turnToolCalls/turnToolCallIds:
+	// those track calls Pi owes a result for, and Pi owes nothing here. Kept only
+	// so the child's real result can be recognized when it comes back on the SDK's
+	// `user` message, and so the streamed block's deltas can be skipped silently
+	// instead of logging as "unmatched" (which reads like a bug).
+	/** tool_use id → raw SDK tool name. */
+	childExecutedToolCalls = new Map<string, string>();
+	/** Anthropic content-block indexes of the current assistant message that carry
+	 *  a child-executed tool_use. Scoped to one message: cleared at message_start,
+	 *  and an index is released as soon as a new block starts there. */
+	childExecutedStreamIndexes = new Set<number>();
+
 	// Per-turn (reset together)
 	turnOutput: AssistantMessage | null = null;
 	turnStarted = false;
@@ -176,6 +189,15 @@ export class QueryContext {
 		this.resolvedToolResultIds.clear();
 		this.unmatchedToolResultIds.clear();
 		this.reportedToolResultMismatch = false;
+		this.childExecutedToolCalls.clear();
+		this.childExecutedStreamIndexes.clear();
+	}
+
+	/** Note a tool_use the child runs itself. `streamIndex` is present only on the
+	 *  streamed path, where later deltas/stops for that block must be skipped. */
+	noteChildExecutedToolCall(id: string | undefined, rawName: string, streamIndex?: number): void {
+		if (id) this.childExecutedToolCalls.set(id, rawName);
+		if (typeof streamIndex === "number") this.childExecutedStreamIndexes.add(streamIndex);
 	}
 
 	recordToolCall(id: string | undefined, toolName: string, args: Record<string, unknown> = {}): void {

--- a/pi-extensions/pi-claude-bridge/tests/unit-child-executed-tools.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-child-executed-tools.mjs
@@ -194,14 +194,14 @@ describe("usage across a Pi turn that spans several child messages", () => {
 		// Child message 1: the connector call. Big cache write, tiny output.
 		processStreamEvent(streamEvent({
 			type: "message_start",
-			message: { model: model.id, usage: { input_tokens: 10, output_tokens: 0, cache_creation_input_tokens: 55685 } },
+			message: { id: "msg_1", model: model.id, usage: { input_tokens: 10, output_tokens: 0, cache_creation_input_tokens: 55685 } },
 		}), new Map(), model);
 		processStreamEvent(streamEvent({ type: "message_delta", delta: {}, usage: { output_tokens: 3 } }), new Map(), model);
 
 		// Child message 2: the answer. Its own separate billed call.
 		processStreamEvent(streamEvent({
 			type: "message_start",
-			message: { model: model.id, usage: { input_tokens: 5, output_tokens: 0, cache_read_input_tokens: 53631, cache_creation_input_tokens: 2083 } },
+			message: { id: "msg_2", model: model.id, usage: { input_tokens: 5, output_tokens: 0, cache_read_input_tokens: 53631, cache_creation_input_tokens: 2083 } },
 		}), new Map(), model);
 		processStreamEvent(streamEvent({ type: "message_delta", delta: {}, usage: { output_tokens: 110 } }), new Map(), model);
 
@@ -227,6 +227,70 @@ describe("usage across a Pi turn that spans several child messages", () => {
 
 		assert.equal(c.turnOutput.usage.input, 10);
 		assert.equal(c.turnOutput.usage.output, 90, "cumulative-per-message counters must not be summed");
+	});
+
+	it("accumulates on the no-stream-events path too", () => {
+		// The SDK can deliver a turn as complete `assistant` messages with no
+		// stream events. That path is where a new child message begins for it, so
+		// it must bank the previous one exactly as `message_start` does.
+		const c = ctx();
+		c.resetTurnState(model);
+		installFakeStream();
+
+		processAssistantMessage({
+			type: "assistant",
+			message: { id: "msg_1", content: [{ type: "text", text: "first" }], usage: { input_tokens: 10, output_tokens: 20 } },
+		}, model, new Map());
+		processAssistantMessage({
+			type: "assistant",
+			message: { id: "msg_2", content: [{ type: "text", text: "second" }], usage: { input_tokens: 5, output_tokens: 7 } },
+		}, model, new Map());
+
+		assert.equal(c.turnOutput.usage.input, 15);
+		assert.equal(c.turnOutput.usage.output, 27, "the first assistant message's output must not be dropped");
+	});
+
+	it("does not double-count a message whose message_start already streamed", () => {
+		// The regression this guards: a child message that emits message_start but
+		// NO content blocks leaves `turnSawStreamEvent` false, so the SDK's completed
+		// copy of that SAME message lands on the no-stream-events path. Banking per
+		// call site counted it twice; banking per message id does not.
+		const c = ctx();
+		c.resetTurnState(model);
+		installFakeStream();
+
+		processStreamEvent(streamEvent({
+			type: "message_start",
+			message: { id: "msg_1", model: model.id, usage: { input_tokens: 10, output_tokens: 0 } },
+		}), new Map(), model);
+		processStreamEvent(streamEvent({ type: "message_delta", delta: {}, usage: { output_tokens: 40 } }), new Map(), model);
+		// The SDK's completed copy of the SAME message (same id).
+		processAssistantMessage({
+			type: "assistant",
+			message: { id: "msg_1", content: [{ type: "text", text: "hi" }], usage: { input_tokens: 10, output_tokens: 40 } },
+		}, model, new Map());
+
+		assert.equal(c.turnOutput.usage.input, 10, "one message must be billed once");
+		assert.equal(c.turnOutput.usage.output, 40);
+	});
+
+	it("still accumulates when the SDK reports no message ids", () => {
+		// Older/streamless shapes carry no id. Each call then means what it says.
+		const c = ctx();
+		c.resetTurnState(model);
+		installFakeStream();
+
+		processAssistantMessage({
+			type: "assistant",
+			message: { content: [{ type: "text", text: "a" }], usage: { input_tokens: 3, output_tokens: 4 } },
+		}, model, new Map());
+		processAssistantMessage({
+			type: "assistant",
+			message: { content: [{ type: "text", text: "b" }], usage: { input_tokens: 3, output_tokens: 4 } },
+		}, model, new Map());
+
+		assert.equal(c.turnOutput.usage.input, 6);
+		assert.equal(c.turnOutput.usage.output, 8);
 	});
 
 	it("starts fresh for the next Pi message", () => {

--- a/pi-extensions/pi-claude-bridge/tests/unit-child-executed-tools.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-child-executed-tools.mjs
@@ -1,0 +1,225 @@
+// A claude.ai connector tool is executed INSIDE the claude child. Mirroring one
+// into the Pi stream made Pi's agent loop dispatch a tool it does not have and
+// write `Tool <name> not found` into the transcript for a call that succeeded
+// (drovr#311 / memsira#320). These tests pin the three emission paths that used
+// to do it, plus the observation half.
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { noteChildExecutedToolResults, processAssistantMessage, processStreamEvent } from "../src/index.ts";
+import { isChildExecutedTool } from "../src/connectors.ts";
+import { ctx, resetStack } from "../src/query-state.ts";
+
+const model = {
+	api: "claude-bridge",
+	provider: "claude-bridge",
+	id: "claude-haiku-4-5",
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+};
+
+const CONNECTOR_TOOL = "mcp__claude_ai_Slack__slack_read_user_profile";
+
+function installFakeStream() {
+	const events = [];
+	ctx().currentPiStream = {
+		push(event) { events.push(event); },
+		end(result) { events.push({ type: "stream_end", result }); },
+	};
+	return events;
+}
+
+function streamEvent(event) {
+	return { type: "stream_event", event };
+}
+
+describe("child-executed tool classification", () => {
+	it("claims every claude.ai connector namespace", () => {
+		assert.equal(isChildExecutedTool(CONNECTOR_TOOL), true);
+		assert.equal(isChildExecutedTool("mcp__claude_ai_Atlassian__getConfluencePage"), true);
+		// Namespace-only, so an org-custom connector nobody has enumerated still counts.
+		assert.equal(isChildExecutedTool("mcp__claude_ai_Some_Org_Thing__whatever"), true);
+	});
+
+	it("claims nothing else — a Pi tool mismatch must still surface as a dispatcher error", () => {
+		assert.equal(isChildExecutedTool("bash"), false);
+		assert.equal(isChildExecutedTool("mcp__custom-tools__read"), false);
+		// A different MCP server is not a claude.ai connector.
+		assert.equal(isChildExecutedTool("mcp__claude_code_docs__search"), false);
+		assert.equal(isChildExecutedTool(undefined), false);
+	});
+});
+
+describe("child-executed tools are never mirrored as Pi tool calls", () => {
+	beforeEach(() => resetStack());
+
+	it("skips a streamed connector tool_use and leaves the turn open", () => {
+		const c = ctx();
+		c.resetTurnState(model);
+		const events = installFakeStream();
+
+		processStreamEvent(streamEvent({
+			type: "content_block_start",
+			index: 0,
+			content_block: { type: "tool_use", id: "toolu_conn", name: CONNECTOR_TOOL, input: {} },
+		}), new Map(), model);
+		processStreamEvent(streamEvent({
+			type: "content_block_delta",
+			index: 0,
+			delta: { type: "input_json_delta", partial_json: "{\"user_id\":\"U1\"}" },
+		}), new Map(), model);
+		processStreamEvent(streamEvent({ type: "content_block_stop", index: 0 }), new Map(), model);
+
+		assert.equal(c.turnBlocks.length, 0, "connector call must not become a Pi content block");
+		assert.equal(c.turnSawToolCall, false, "connector call is not a Pi turn boundary");
+		assert.deepEqual(c.turnToolCallIds, [], "Pi owes no result, so nothing is expected back");
+		assert.equal(c.currentPiStream !== null, true, "the Pi turn must stay open");
+		assert.deepEqual(events.map((e) => e.type), ["start"]);
+		assert.equal(c.childExecutedToolCalls.get("toolu_conn"), CONNECTOR_TOOL);
+	});
+
+	it("does not end the turn on a message_stop that only saw a connector call", () => {
+		const c = ctx();
+		c.resetTurnState(model);
+		installFakeStream();
+
+		processStreamEvent(streamEvent({
+			type: "content_block_start",
+			index: 0,
+			content_block: { type: "tool_use", id: "toolu_conn", name: CONNECTOR_TOOL, input: {} },
+		}), new Map(), model);
+		processStreamEvent(streamEvent({ type: "message_stop" }), new Map(), model);
+
+		assert.equal(c.currentPiStream !== null, true, "ending here would strand the answer text");
+	});
+
+	it("keeps streaming the answer text into the same Pi message after the connector call", () => {
+		const c = ctx();
+		c.resetTurnState(model);
+		installFakeStream();
+
+		processStreamEvent(streamEvent({
+			type: "content_block_start",
+			index: 0,
+			content_block: { type: "tool_use", id: "toolu_conn", name: CONNECTOR_TOOL, input: {} },
+		}), new Map(), model);
+		processStreamEvent(streamEvent({ type: "content_block_stop", index: 0 }), new Map(), model);
+		// The child's follow-up assistant message reuses index 0 for its text block.
+		processStreamEvent(streamEvent({ type: "message_start", message: { model: "claude-haiku-4-5" } }), new Map(), model);
+		processStreamEvent(streamEvent({
+			type: "content_block_start",
+			index: 0,
+			content_block: { type: "text", text: "" },
+		}), new Map(), model);
+		processStreamEvent(streamEvent({
+			type: "content_block_delta",
+			index: 0,
+			delta: { type: "text_delta", text: "Brad Mahaffey" },
+		}), new Map(), model);
+		processStreamEvent(streamEvent({ type: "content_block_stop", index: 0 }), new Map(), model);
+
+		assert.equal(c.turnBlocks.length, 1);
+		assert.equal(c.turnBlocks[0].type, "text");
+		assert.equal(c.turnBlocks[0].text, "Brad Mahaffey", "a stale skip-index must not swallow real text");
+	});
+
+	it("skips a connector tool_use on the assistant-boundary path without ending the turn", () => {
+		const c = ctx();
+		c.resetTurnState(model);
+		installFakeStream();
+		c.turnSawStreamEvent = true;
+
+		processAssistantMessage({
+			type: "assistant",
+			message: {
+				content: [{ type: "tool_use", id: "toolu_conn", name: CONNECTOR_TOOL, input: { user_id: "U1" } }],
+			},
+		}, model, new Map());
+
+		assert.equal(c.turnBlocks.length, 0);
+		assert.equal(c.turnSawToolCall, false);
+		assert.equal(c.currentPiStream !== null, true, "no Pi tool call means no turn boundary");
+		assert.equal(c.childExecutedToolCalls.get("toolu_conn"), CONNECTOR_TOOL);
+	});
+
+	it("skips a connector tool_use on the no-stream-events fallback path", () => {
+		const c = ctx();
+		c.resetTurnState(model);
+		installFakeStream();
+
+		processAssistantMessage({
+			type: "assistant",
+			message: {
+				content: [
+					{ type: "text", text: "checking" },
+					{ type: "tool_use", id: "toolu_conn", name: CONNECTOR_TOOL, input: { user_id: "U1" } },
+				],
+			},
+		}, model, new Map());
+
+		assert.deepEqual(c.turnBlocks.map((b) => b.type), ["text"]);
+		assert.equal(c.turnSawToolCall, false);
+		assert.equal(c.currentPiStream !== null, true);
+	});
+
+	it("still mirrors a Pi tool call alongside a connector call in the same message", () => {
+		const c = ctx();
+		c.resetTurnState(model);
+		installFakeStream();
+		c.turnSawStreamEvent = true;
+
+		processAssistantMessage({
+			type: "assistant",
+			message: {
+				content: [
+					{ type: "tool_use", id: "toolu_conn", name: CONNECTOR_TOOL, input: {} },
+					{ type: "tool_use", id: "toolu_pi", name: "mcp__custom-tools__read", input: { file_path: "README.md" } },
+				],
+			},
+		}, model, new Map([["mcp__custom-tools__read", "read"]]));
+
+		assert.equal(c.turnBlocks.length, 1, "only the Pi tool call is mirrored");
+		assert.equal(c.turnBlocks[0].name, "read");
+		assert.deepEqual(c.turnToolCallIds, ["toolu_pi"]);
+		assert.equal(c.currentPiStream, null, "a real Pi tool call still ends the turn");
+	});
+});
+
+describe("child-executed tool results", () => {
+	beforeEach(() => resetStack());
+
+	it("recognizes the child's own result without re-delivering it", () => {
+		const c = ctx();
+		c.resetTurnState(model);
+		c.noteChildExecutedToolCall("toolu_conn", CONNECTOR_TOOL, 0);
+
+		noteChildExecutedToolResults({
+			type: "user",
+			message: {
+				content: [{ type: "tool_result", tool_use_id: "toolu_conn", content: "User ID: US9TAA048" }],
+			},
+		});
+
+		// Observation only: nothing is queued for Pi, and no Pi block appears.
+		assert.equal(c.pendingResults.size, 0);
+		assert.equal(c.turnBlocks.length, 0);
+	});
+
+	it("ignores a tool_result for a call the child did not own", () => {
+		const c = ctx();
+		c.resetTurnState(model);
+		c.noteChildExecutedToolCall("toolu_conn", CONNECTOR_TOOL, 0);
+
+		noteChildExecutedToolResults({
+			type: "user",
+			message: { content: [{ type: "tool_result", tool_use_id: "toolu_other", content: "x" }] },
+		});
+
+		assert.equal(c.pendingResults.size, 0);
+	});
+
+	it("tolerates a plain user echo with no tool results", () => {
+		ctx().resetTurnState(model);
+		ctx().noteChildExecutedToolCall("toolu_conn", CONNECTOR_TOOL, 0);
+		noteChildExecutedToolResults({ type: "user", message: { content: "just a prompt echo" } });
+		noteChildExecutedToolResults({ type: "user", message: {} });
+	});
+});

--- a/pi-extensions/pi-claude-bridge/tests/unit-child-executed-tools.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-child-executed-tools.mjs
@@ -183,6 +183,73 @@ describe("child-executed tools are never mirrored as Pi tool calls", () => {
 	});
 });
 
+describe("usage across a Pi turn that spans several child messages", () => {
+	beforeEach(() => resetStack());
+
+	it("accumulates what each finished child message billed", () => {
+		const c = ctx();
+		c.resetTurnState(model);
+		installFakeStream();
+
+		// Child message 1: the connector call. Big cache write, tiny output.
+		processStreamEvent(streamEvent({
+			type: "message_start",
+			message: { model: model.id, usage: { input_tokens: 10, output_tokens: 0, cache_creation_input_tokens: 55685 } },
+		}), new Map(), model);
+		processStreamEvent(streamEvent({ type: "message_delta", delta: {}, usage: { output_tokens: 3 } }), new Map(), model);
+
+		// Child message 2: the answer. Its own separate billed call.
+		processStreamEvent(streamEvent({
+			type: "message_start",
+			message: { model: model.id, usage: { input_tokens: 5, output_tokens: 0, cache_read_input_tokens: 53631, cache_creation_input_tokens: 2083 } },
+		}), new Map(), model);
+		processStreamEvent(streamEvent({ type: "message_delta", delta: {}, usage: { output_tokens: 110 } }), new Map(), model);
+
+		assert.equal(c.turnOutput.usage.input, 15, "both calls' input is billed");
+		assert.equal(c.turnOutput.usage.output, 113);
+		assert.equal(c.turnOutput.usage.cacheRead, 53631);
+		assert.equal(c.turnOutput.usage.cacheWrite, 57768, "the first message's cache write must not be dropped");
+		assert.equal(c.turnOutput.usage.totalTokens, 15 + 113 + 53631 + 57768);
+	});
+
+	it("replaces rather than doubles within one child message", () => {
+		const c = ctx();
+		c.resetTurnState(model);
+		installFakeStream();
+
+		processStreamEvent(streamEvent({
+			type: "message_start",
+			message: { model: model.id, usage: { input_tokens: 10, output_tokens: 0 } },
+		}), new Map(), model);
+		// Anthropic re-reports the same message's growing output.
+		processStreamEvent(streamEvent({ type: "message_delta", delta: {}, usage: { output_tokens: 40 } }), new Map(), model);
+		processStreamEvent(streamEvent({ type: "message_delta", delta: {}, usage: { output_tokens: 90 } }), new Map(), model);
+
+		assert.equal(c.turnOutput.usage.input, 10);
+		assert.equal(c.turnOutput.usage.output, 90, "cumulative-per-message counters must not be summed");
+	});
+
+	it("starts fresh for the next Pi message", () => {
+		const c = ctx();
+		c.resetTurnState(model);
+		installFakeStream();
+		processStreamEvent(streamEvent({
+			type: "message_start",
+			message: { model: model.id, usage: { input_tokens: 10, output_tokens: 7 } },
+		}), new Map(), model);
+
+		c.resetTurnState(model);
+		installFakeStream();
+		processStreamEvent(streamEvent({
+			type: "message_start",
+			message: { model: model.id, usage: { input_tokens: 4, output_tokens: 2 } },
+		}), new Map(), model);
+
+		assert.equal(c.turnOutput.usage.input, 4, "a new Pi message does not inherit the old turn's total");
+		assert.equal(c.turnOutput.usage.output, 2);
+	});
+});
+
 describe("child-executed tool results", () => {
 	beforeEach(() => resetStack());
 


### PR DESCRIPTION
## What was wrong

A claude.ai connector tool runs **inside the `claude` child**, on the child's own MCP servers. The bridge mirrored the `tool_use` into the Pi stream anyway, so Pi's agent loop looked the name up in `context.tools`, missed, and wrote a synthetic `Tool <name> not found` error result into the transcript — for a call that had **succeeded**, right next to an answer built from its real payload.

That reads as a fabricating model. It is the opposite.

## Measured, not inferred

One bridge chat, one `slack_read_user_profile` call, same tool-call id `toolu_01QsoWab…`:

| | record |
| --- | --- |
| Pi transcript | `isError: true`, `Tool mcp__claude_ai_Slack__slack_read_user_profile not found` |
| child transcript, same id | `ok`, 303 bytes of real profile data |
| the assistant's next message | quoted that payload verbatim |

Across both host apps' history: drovr 17 connector calls (11 real payloads, 6 genuine upstream errors — cloudId failures, a 404, `channel_not_found`); memsira 122 successful executions. Every one of them was recorded Pi-side as "not found".

Producer is `pi-agent-core` `agent-loop.js:398` — the tool-not-in-`context.tools` branch.

## Why it is not only cosmetic

`syncSharedSession`'s REBUILD path projects Pi history back into the child's session file. So the false result does not stay in the mirror — it becomes part of the conversation of record, and the model is later told its own successful calls failed.

## The change

A `tool_use` under `mcp__claude_ai_` is never mirrored: no `toolCall` block, no `toolUse` turn boundary, no expected-result tracking. The child executes it and keeps streaming, so the call and the answer land in **one** Pi assistant message. Covered at all three emission sites (streamed `content_block_start`, the assistant-boundary path, and the no-stream-events fallback), with the streamed block's later deltas/stops skipped explicitly so the existing "unmatched" warning keeps meaning "something is wrong".

The child's real result is **observed, never re-delivered** (`noteChildExecutedToolResults`, from the SDK `user` message) — it already reached the model inside the child. The debug line records name, error flag and content size, **never the payload**: connector results are live account data and this log sits outside a host app's redaction boundary.

The classifier is namespace-based on purpose. "Any name Pi cannot resolve" would also swallow a genuine Pi↔child tool-name mismatch, which must stay a loud dispatcher error.

## Verified live

Same prompt, same account, after the change: no `toolCall` block, **no `toolResult` record at all**, one assistant message with `stopReason: stop` carrying the real data — and the child transcript confirms the connector call still really ran (1 call, ok, 303 bytes).

## Known gap, stated rather than papered over

A connector call now leaves **no tool record in the Pi transcript**. Pi has no content-block type for a provider-executed call, so the honest options were "absent" or "present and wrong". Restoring visibility needs a Pi-side representation for delegated calls; documented in `DEVELOPMENT.md` and the README.

## Tests

`tests/unit-child-executed-tools.mjs` — 11 new tests: classification (including "a Pi tool mismatch must still surface"), all three emission paths, the message_stop that must not end the turn, index reuse by a later text block, a connector call alongside a real Pi tool call, and the observation half.

`npm run typecheck` clean · `npm run test:unit` 290/290 pass.

Refs drovr#311, memsira#320.