### PR TITLE
fix(pi-claude-bridge): stop offering a second name for a connector tool

### DIFF
--- a/pi-extensions/pi-claude-bridge/DEVELOPMENT.md
+++ b/pi-extensions/pi-claude-bridge/DEVELOPMENT.md
@@ -17,6 +17,11 @@ So a `tool_use` under `mcp__claude_ai_` is **never mirrored into the Pi stream**
 
 Mirroring one used to make Pi's agent loop look the name up in `context.tools`, miss, and write a synthetic `Tool <name> not found` error result into the transcript — for a call that had **succeeded**, next to an answer built from its real payload. That reads as a fabricating model, and a rebuild (`syncSharedSession`) projected the false result back into the child's session, turning a wrong mirror into a wrong conversation of record. Found in two host apps at once (drovr#311, memsira#320).
 
+Two places used to hand the model a SECOND name for a connector tool, and a second name is a name that can be wrong:
+
+- `mapPiToolNameToSdk` PascalCased anything it could not map, so a connector call projected back into the child's session became `McpClaudeAiSlackSlackSearchChannels`. The model imitated that alias on the next turn and got a real `Tool ... not found` from the MCP dispatcher before retrying the canonical name — one wasted round-trip per affected call. Connector names now pass through unchanged; the fix above stops them reaching this path at all, but LEGACY Pi history recorded before it still carries them.
+- `resolveMcpTools` re-offered every `context.tools` entry under the bridge's own MCP prefix, including one sitting on the connector namespace. Such a tool is uncallable anyway (a `tool_use` there is treated as child-executed and never handed to Pi), so it is now filtered out and the two halves agree end to end.
+
 The classifier is namespace-based on purpose. "Any name Pi cannot resolve" would also swallow a genuine Pi↔child tool-name mismatch, which should stay a loud dispatcher error.
 
 Two consequences worth knowing:

--- a/pi-extensions/pi-claude-bridge/bundle/index.js
+++ b/pi-extensions/pi-claude-bridge/bundle/index.js
@@ -26912,6 +26912,663 @@ function splitPrefixSuffix(input, options = {}) {
   ];
 }
 
+// src/config.ts
+import { existsSync as existsSync2, readFileSync as readFileSync2 } from "fs";
+import { homedir } from "os";
+import { dirname, join as join2, resolve as resolve2 } from "path";
+var PACKAGE_ID = "@vanillagreen/pi-claude-bridge";
+var VALID_EFFORT_LEVELS = /* @__PURE__ */ new Set(["low", "medium", "high", "xhigh", "max"]);
+function expandHome(input) {
+  if (input === "~") return homedir();
+  if (input.startsWith("~/")) return join2(homedir(), input.slice(2));
+  return input;
+}
+function piUserDir() {
+  return resolve2(expandHome(process.env.PI_CODING_AGENT_DIR?.trim() || "~/.pi/agent"));
+}
+function isolatedFromEnv() {
+  const v4 = (process.env.CLAUDE_BRIDGE_ISOLATED ?? "").trim().toLowerCase();
+  return v4 === "1" || v4 === "true" || v4 === "yes" || v4 === "on";
+}
+function asRecord(value) {
+  return value && typeof value === "object" && !Array.isArray(value) ? value : void 0;
+}
+function mergeDeep(target, source) {
+  for (const [key, value] of Object.entries(source)) {
+    const current = asRecord(target[key]);
+    const incoming = asRecord(value);
+    if (current && incoming) target[key] = mergeDeep({ ...current }, incoming);
+    else target[key] = value;
+  }
+  return target;
+}
+function projectSettingsPath(cwd) {
+  let current = resolve2(cwd);
+  while (true) {
+    const candidate = join2(current, ".pi", "settings.json");
+    if (existsSync2(candidate)) return candidate;
+    if (existsSync2(join2(current, ".pi")) || existsSync2(join2(current, ".git")) || existsSync2(join2(current, ".vstack-lock.json"))) return candidate;
+    const parent = dirname(current);
+    if (parent === current) return join2(resolve2(cwd), ".pi", "settings.json");
+    current = parent;
+  }
+}
+var PROJECT_TRUST_SYMBOL = /* @__PURE__ */ Symbol.for("vstack.pi.project-trust");
+function projectTrustRegistry() {
+  const host = globalThis;
+  const existing = host[PROJECT_TRUST_SYMBOL];
+  if (existing) return existing;
+  const created = {};
+  host[PROJECT_TRUST_SYMBOL] = created;
+  return created;
+}
+function recordProjectTrust(ctx2) {
+  if (!ctx2.cwd) return;
+  if (isolatedFromEnv()) return;
+  let trusted = true;
+  try {
+    trusted = ctx2.isProjectTrusted?.() === true;
+  } catch {
+    trusted = false;
+  }
+  const registry2 = projectTrustRegistry();
+  if (!registry2.projectSettings) registry2.projectSettings = /* @__PURE__ */ new Map();
+  registry2.projectSettings.set(projectSettingsPath(ctx2.cwd), trusted);
+}
+function projectSettingsTrusted(settingsPath) {
+  return projectTrustRegistry().projectSettings?.get(settingsPath) === true;
+}
+function settingsPaths(cwd) {
+  const user = join2(piUserDir(), "settings.json");
+  if (isolatedFromEnv()) return [];
+  const project = projectSettingsPath(cwd);
+  return projectSettingsTrusted(project) ? [user, project] : [user];
+}
+function tryParseJson(path) {
+  if (!existsSync2(path)) return {};
+  try {
+    return JSON.parse(readFileSync2(path, "utf-8"));
+  } catch {
+    return {};
+  }
+}
+function readManagerConfig(cwd) {
+  const merged = {};
+  for (const path of settingsPaths(cwd)) {
+    if (!existsSync2(path)) continue;
+    try {
+      const parsed = JSON.parse(readFileSync2(path, "utf8"));
+      const configRoot = asRecord(asRecord(asRecord(parsed?.vstack)?.extensionManager)?.config);
+      const config2 = asRecord(configRoot?.[PACKAGE_ID]);
+      if (config2) mergeDeep(merged, config2);
+    } catch {
+    }
+  }
+  return merged;
+}
+function boolFrom(raw, key) {
+  return typeof raw[key] === "boolean" ? raw[key] : void 0;
+}
+function stringFrom(raw, key) {
+  const value = raw[key];
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : void 0;
+}
+function hasOwn(raw, key) {
+  return Object.prototype.hasOwnProperty.call(raw, key);
+}
+function normalizeConnectorWriteMode(value) {
+  if (typeof value !== "string") return void 0;
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "deny" || normalized === "allow") return normalized;
+  return void 0;
+}
+function normalizeEffortLevel(value) {
+  if (typeof value !== "string") return void 0;
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "" || normalized === "none" || normalized === "auto" || normalized === "default") return void 0;
+  return VALID_EFFORT_LEVELS.has(normalized) ? normalized : void 0;
+}
+function normalizeModelEffortOverrides(value) {
+  let source = value;
+  if (typeof source === "string") {
+    const trimmed = source.trim();
+    if (!trimmed || trimmed === "{}") return void 0;
+    try {
+      source = JSON.parse(trimmed);
+    } catch {
+      return void 0;
+    }
+  }
+  const record2 = asRecord(source);
+  if (!record2) return void 0;
+  const out = {};
+  for (const [modelId, rawEffort] of Object.entries(record2)) {
+    const key = modelId.trim();
+    const effort = normalizeEffortLevel(rawEffort);
+    if (key && effort) out[key] = effort;
+  }
+  return Object.keys(out).length > 0 ? out : void 0;
+}
+function normalizeProviderConfig(provider) {
+  if (!provider) return {};
+  const raw = provider;
+  const out = { ...provider };
+  const forceEffort = normalizeEffortLevel(raw.forceEffort);
+  if (forceEffort) out.forceEffort = forceEffort;
+  else delete out.forceEffort;
+  const modelEffortOverrides = normalizeModelEffortOverrides(raw.modelEffortOverrides);
+  if (modelEffortOverrides) out.modelEffortOverrides = modelEffortOverrides;
+  else delete out.modelEffortOverrides;
+  const connectorWriteMode = normalizeConnectorWriteMode(raw.connectorWriteMode);
+  if (connectorWriteMode) out.connectorWriteMode = connectorWriteMode;
+  else delete out.connectorWriteMode;
+  return out;
+}
+function managerToConfig(raw) {
+  const provider = {};
+  const promptContext = {};
+  const appendSystemPrompt = boolFrom(raw, "appendSystemPrompt");
+  if (appendSystemPrompt !== void 0) provider.appendSystemPrompt = appendSystemPrompt;
+  const allowExtraUsage = boolFrom(raw, "allowExtraUsage");
+  if (allowExtraUsage !== void 0) provider.allowExtraUsage = allowExtraUsage;
+  const fastMode = boolFrom(raw, "fastMode");
+  if (fastMode !== void 0) provider.fastMode = fastMode;
+  if (hasOwn(raw, "forceEffort")) {
+    provider.forceEffort = normalizeEffortLevel(raw.forceEffort);
+  }
+  if (hasOwn(raw, "modelEffortOverrides")) {
+    provider.modelEffortOverrides = normalizeModelEffortOverrides(raw.modelEffortOverrides);
+  }
+  const strictMcpConfig = boolFrom(raw, "strictMcpConfig");
+  if (strictMcpConfig !== void 0) provider.strictMcpConfig = strictMcpConfig;
+  const enableConnectors = boolFrom(raw, "enableConnectors");
+  if (enableConnectors !== void 0) provider.enableConnectors = enableConnectors;
+  const connectorWriteMode = normalizeConnectorWriteMode(raw.connectorWriteMode);
+  if (connectorWriteMode) provider.connectorWriteMode = connectorWriteMode;
+  const claudePath = stringFrom(raw, "pathToClaudeCodeExecutable");
+  if (claudePath) provider.pathToClaudeCodeExecutable = claudePath;
+  const includeAppendSystemPromptMd = boolFrom(raw, "includeAppendSystemPromptMd");
+  if (includeAppendSystemPromptMd !== void 0) promptContext.includeAppendSystemPromptMd = includeAppendSystemPromptMd;
+  const includeProjectAgentsHook = boolFrom(raw, "includeProjectAgentsHook");
+  if (includeProjectAgentsHook !== void 0) promptContext.includeProjectAgentsHook = includeProjectAgentsHook;
+  const includeTaskPanelHook = boolFrom(raw, "includeTaskPanelHook");
+  if (includeTaskPanelHook !== void 0) promptContext.includeTaskPanelHook = includeTaskPanelHook;
+  const includeCavemanHook = boolFrom(raw, "includeCavemanHook");
+  if (includeCavemanHook !== void 0) promptContext.includeCavemanHook = includeCavemanHook;
+  return {
+    ...boolFrom(raw, "enabled") !== void 0 ? { enabled: boolFrom(raw, "enabled") } : {},
+    ...Object.keys(provider).length ? { provider } : {},
+    ...Object.keys(promptContext).length ? { promptContext } : {}
+  };
+}
+function loadConfig(cwd) {
+  const global2 = tryParseJson(join2(piUserDir(), "claude-bridge.json"));
+  const isolated = isolatedFromEnv();
+  const projectSettings = isolated ? void 0 : projectSettingsPath(cwd);
+  const trustedProject = projectSettings !== void 0 && projectSettingsTrusted(projectSettings);
+  const project = trustedProject ? tryParseJson(join2(dirname(projectSettings), "claude-bridge.json")) : {};
+  const manager = isolated ? {} : managerToConfig(readManagerConfig(cwd));
+  const provider = normalizeProviderConfig({ ...global2.provider, ...project.provider, ...manager.provider });
+  return {
+    enabled: manager.enabled ?? project.enabled ?? global2.enabled ?? true,
+    provider,
+    promptContext: { ...global2.promptContext, ...project.promptContext, ...manager.promptContext }
+  };
+}
+
+// src/skills.ts
+var MCP_SERVER_NAME = "custom-tools";
+var MCP_TOOL_PREFIX = `mcp__${MCP_SERVER_NAME}__`;
+function extractSkillsBlock(systemPrompt) {
+  if (!systemPrompt) return void 0;
+  const startMarker = "The following skills provide specialized instructions for specific tasks.";
+  const endMarker = "</available_skills>";
+  const start = systemPrompt.indexOf(startMarker);
+  if (start === -1) return void 0;
+  const end = systemPrompt.indexOf(endMarker, start);
+  if (end === -1) return void 0;
+  return rewriteSkillsBlock(systemPrompt.slice(start, end + endMarker.length).trim());
+}
+function rewriteSkillsBlock(skillsBlock) {
+  return skillsBlock.replace(
+    "Use the read tool to load a skill's file",
+    `Use the read tool (mcp__${MCP_SERVER_NAME}__read) to load a skill's file`
+  );
+}
+
+// src/connector-inventory.ts
+var CONNECTOR_NS_PREFIX = "mcp__claude_ai_";
+var DEFAULT_API_BASE = "https://api.anthropic.com";
+var DEFAULT_PROXY_BASE = "https://mcp-proxy.anthropic.com/v1/mcp";
+var OAUTH_BETA_HEADER = "oauth-2025-04-20";
+function connectorServerName(connectorName) {
+  return `claude.ai ${connectorName.trim()}`;
+}
+function connectorProxyUrl(installedServerId, proxyBase = DEFAULT_PROXY_BASE) {
+  return `${trimTrailingSlashes(proxyBase)}/${encodeURIComponent(installedServerId)}`;
+}
+function connectorServerNamespace(connectorName) {
+  return `${CONNECTOR_NS_PREFIX}${connectorName.trim().replace(/\s+/g, "_")}__`;
+}
+function credentialCandidatePaths(env = process.env) {
+  const roots = [];
+  const configDir = env.CLAUDE_CONFIG_DIR?.trim();
+  if (configDir) roots.push(configDir);
+  const home = env.HOME?.trim();
+  if (home) roots.push(`${home}/.claude`, home);
+  const seen = /* @__PURE__ */ new Set();
+  const paths = [];
+  for (const root of roots) {
+    for (const name of [".credentials.json", ".claude.json"]) {
+      const p4 = `${root}/${name}`;
+      if (!seen.has(p4)) {
+        seen.add(p4);
+        paths.push(p4);
+      }
+    }
+  }
+  return paths;
+}
+function resolveClaudeOAuth(readFile, env = process.env) {
+  let accessToken;
+  let organizationUuid;
+  for (const path of credentialCandidatePaths(env)) {
+    const raw = readFile(path);
+    if (!raw) continue;
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      continue;
+    }
+    accessToken ??= nonEmptyString(parsed?.claudeAiOauth?.accessToken);
+    organizationUuid ??= nonEmptyString(parsed?.oauthAccount?.organizationUuid);
+    if (accessToken && organizationUuid) break;
+  }
+  if (!accessToken || !organizationUuid) return void 0;
+  return { accessToken, organizationUuid };
+}
+function nonEmptyString(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : void 0;
+}
+function connectorsListUrl(organizationUuid, apiBase = DEFAULT_API_BASE) {
+  return `${trimTrailingSlashes(apiBase)}/api/oauth/organizations/${encodeURIComponent(organizationUuid)}/mcp/connectors/list`;
+}
+function trimTrailingSlashes(value) {
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === 47) end--;
+  return value.slice(0, end);
+}
+async function listAccountConnectors(deps) {
+  const { credentials, apiBase, signal } = deps;
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const url2 = connectorsListUrl(credentials.organizationUuid, apiBase);
+  const fail = (reason) => ({ ok: false, complete: false, reason: redactSecret(reason, credentials.accessToken) });
+  let response;
+  try {
+    response = await fetchImpl(url2, {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${credentials.accessToken}`,
+        "anthropic-beta": OAUTH_BETA_HEADER,
+        "Content-Type": "application/json"
+      },
+      body: "{}",
+      signal
+    });
+  } catch (error51) {
+    return fail(`connector list request failed: ${errorText(error51)}`);
+  }
+  let bodyText;
+  try {
+    bodyText = await response.text();
+  } catch (error51) {
+    return fail(`connector list response unreadable: ${errorText(error51)}`);
+  }
+  if (!response.ok) {
+    return fail(`connector list returned HTTP ${response.status}${apiErrorSuffix(bodyText)}`);
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(bodyText);
+  } catch {
+    return fail("connector list returned a non-JSON body");
+  }
+  if (!Array.isArray(parsed?.results)) {
+    return fail("connector list response had no results array");
+  }
+  const connectors = [];
+  for (const raw of parsed.results) {
+    const entry = raw;
+    const name = nonEmptyString(entry?.name);
+    if (!name) {
+      return fail("connector list contained an entry with no name");
+    }
+    connectors.push({
+      name,
+      installedServerId: nonEmptyString(entry?.installedServerId),
+      directoryUuid: nonEmptyString(entry?.directoryUuid),
+      installState: nonEmptyString(entry?.installState),
+      description: nonEmptyString(entry?.description),
+      isAuthless: typeof entry?.isAuthless === "boolean" ? entry.isAuthless : void 0
+    });
+  }
+  return { ok: true, complete: true, connectors };
+}
+function apiErrorSuffix(bodyText) {
+  try {
+    const message = JSON.parse(bodyText)?.error?.message;
+    return typeof message === "string" && message.trim() ? ` (${message.trim()})` : "";
+  } catch {
+    return "";
+  }
+}
+function redactSecret(text, secret) {
+  if (!secret || secret.length < 8) return text;
+  let out = text;
+  for (const form of /* @__PURE__ */ new Set([secret, encodeURIComponent(secret)])) {
+    out = out.split(form).join("[redacted]");
+  }
+  return out;
+}
+function errorText(error51) {
+  return error51 instanceof Error ? error51.message : String(error51);
+}
+
+// src/connectors.ts
+var DISALLOWED_BUILTIN_TOOLS = [
+  "Read",
+  "Write",
+  "Edit",
+  "MultiEdit",
+  "Glob",
+  "Grep",
+  "Bash",
+  "Agent",
+  "Task",
+  "NotebookEdit",
+  "EnterWorktree",
+  "ExitWorktree",
+  "CronList",
+  "CronCreate",
+  "CronDelete",
+  "TeamCreate",
+  "TeamDelete",
+  "TaskOutput",
+  "TaskStop",
+  "SendMessage",
+  "Skill",
+  "TodoRead",
+  "TodoWrite",
+  "ListMcpResources",
+  "ReadMcpResource",
+  "WebFetch",
+  "WebSearch",
+  "AskUserQuestion",
+  "EnterPlanMode",
+  "ExitPlanMode",
+  "ToolSearch",
+  "ScheduleWakeup"
+];
+var CLAUDE_BRIDGE_TOOL_ISOLATION = {
+  tools: [],
+  disallowedTools: DISALLOWED_BUILTIN_TOOLS,
+  allowedTools: [`mcp__${MCP_SERVER_NAME}__*`]
+};
+function connectorsEnabledFromEnv() {
+  const v4 = (process.env.CLAUDE_BRIDGE_ENABLE_CONNECTORS ?? "").trim().toLowerCase();
+  return v4 === "1" || v4 === "true" || v4 === "yes" || v4 === "on";
+}
+function connectorsEnabledFor(config2) {
+  return connectorsEnabledFromEnv() || config2?.provider?.enableConnectors === true;
+}
+var CLAUDE_AI_CONNECTOR_TOOL_PATTERNS = [
+  "mcp__claude_ai_Gmail__*",
+  "mcp__claude_ai_Google_Calendar__*",
+  "mcp__claude_ai_Google_Drive__*",
+  "mcp__claude_ai_Slack__*",
+  "mcp__claude_ai_Atlassian__*"
+];
+var CONNECTOR_DISCOVERY_TOOLS = ["ToolSearch", "ListMcpResources", "ReadMcpResource"];
+var CONNECTOR_NS_PREFIX2 = "mcp__claude_ai_";
+var CONNECTOR_NS_GMAIL = `${CONNECTOR_NS_PREFIX2}Gmail__`;
+var CONNECTOR_NS_CALENDAR = `${CONNECTOR_NS_PREFIX2}Google_Calendar__`;
+var CONNECTOR_NS_DRIVE = `${CONNECTOR_NS_PREFIX2}Google_Drive__`;
+var CONNECTOR_NS_SLACK = `${CONNECTOR_NS_PREFIX2}Slack__`;
+var CONNECTOR_NS_ATLASSIAN = `${CONNECTOR_NS_PREFIX2}Atlassian__`;
+var CONNECTOR_READ_VERBS = /* @__PURE__ */ new Set([
+  "list",
+  "search",
+  "get",
+  "read",
+  "fetch",
+  "find",
+  "download",
+  "describe",
+  "query",
+  "count",
+  "view",
+  "lookup",
+  "whoami"
+]);
+var CONNECTOR_MUTATION_WORDS = /* @__PURE__ */ new Set([
+  "create",
+  "update",
+  "delete",
+  "remove",
+  "add",
+  "edit",
+  "send",
+  "post",
+  "write",
+  "upload",
+  "publish",
+  "schedule",
+  "transition",
+  "archive",
+  "move",
+  "copy",
+  "revoke",
+  "assign",
+  "invite",
+  "share",
+  "rename",
+  "replace",
+  "set",
+  "merge",
+  "resolve",
+  "lock",
+  "unlock",
+  "acknowledge",
+  "ack",
+  "book",
+  "start",
+  "stop",
+  "terminate",
+  "restart",
+  "join",
+  "leave",
+  "star",
+  "unstar",
+  "forward",
+  "sync",
+  "approve",
+  "reject",
+  "close",
+  "reopen",
+  "cancel",
+  "enable",
+  "disable",
+  "grant",
+  "trigger",
+  "execute",
+  "apply",
+  "submit",
+  "pin",
+  "unpin",
+  "mute",
+  "unmute",
+  "subscribe",
+  "unsubscribe",
+  "follow",
+  "unfollow",
+  "clear",
+  "purge",
+  "reset",
+  "rotate",
+  "deploy",
+  "install",
+  "uninstall",
+  "save",
+  "store",
+  "put",
+  "patch",
+  "insert",
+  "append",
+  "prepend",
+  "duplicate",
+  "restore",
+  "revert",
+  "import",
+  "export",
+  "upsert",
+  "sign",
+  "complete",
+  "claim",
+  "release",
+  "promote",
+  "demote",
+  "escalate",
+  "resend",
+  "retry",
+  "react",
+  "vote"
+]);
+function connectorNameWords(segment) {
+  return segment.replace(/([a-z0-9])([A-Z])/g, "$1 $2").replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2").split(/[^A-Za-z0-9]+/).filter(Boolean).map((word) => word.toLowerCase());
+}
+var CONNECTOR_WRITE_TOOLS = [
+  `${CONNECTOR_NS_GMAIL}create_draft`,
+  `${CONNECTOR_NS_GMAIL}create_label`,
+  `${CONNECTOR_NS_GMAIL}label_message`,
+  `${CONNECTOR_NS_GMAIL}label_thread`,
+  `${CONNECTOR_NS_GMAIL}unlabel_message`,
+  `${CONNECTOR_NS_GMAIL}unlabel_thread`,
+  `${CONNECTOR_NS_GMAIL}apply_sensitive_label`,
+  `${CONNECTOR_NS_GMAIL}remove_sensitive_label`,
+  `${CONNECTOR_NS_CALENDAR}create_event`,
+  `${CONNECTOR_NS_CALENDAR}update_event`,
+  `${CONNECTOR_NS_CALENDAR}delete_event`,
+  `${CONNECTOR_NS_CALENDAR}respond_to_event`,
+  `${CONNECTOR_NS_DRIVE}create_file`,
+  `${CONNECTOR_NS_DRIVE}copy_file`,
+  // Slack + Atlassian writes, taken from a live enumeration of an account with
+  // both connectors attached. The PreToolUse hook already denies these by verb;
+  // listing them by id also removes them from the model's context in a
+  // read-only session (the CLI matcher needs exact ids). Additive only — an id
+  // missing here is still denied at call time.
+  `${CONNECTOR_NS_SLACK}slack_send_message`,
+  `${CONNECTOR_NS_SLACK}slack_send_message_draft`,
+  `${CONNECTOR_NS_SLACK}slack_schedule_message`,
+  `${CONNECTOR_NS_SLACK}slack_create_canvas`,
+  `${CONNECTOR_NS_SLACK}slack_update_canvas`,
+  `${CONNECTOR_NS_ATLASSIAN}createJiraIssue`,
+  `${CONNECTOR_NS_ATLASSIAN}editJiraIssue`,
+  `${CONNECTOR_NS_ATLASSIAN}transitionJiraIssue`,
+  `${CONNECTOR_NS_ATLASSIAN}addCommentToJiraIssue`,
+  `${CONNECTOR_NS_ATLASSIAN}addWorklogToJiraIssue`,
+  `${CONNECTOR_NS_ATLASSIAN}createIssueLink`,
+  `${CONNECTOR_NS_ATLASSIAN}createConfluencePage`,
+  `${CONNECTOR_NS_ATLASSIAN}updateConfluencePage`,
+  `${CONNECTOR_NS_ATLASSIAN}createConfluenceFooterComment`,
+  `${CONNECTOR_NS_ATLASSIAN}createConfluenceInlineComment`,
+  `${CONNECTOR_NS_ATLASSIAN}createCompassComponent`,
+  `${CONNECTOR_NS_ATLASSIAN}createCompassComponentRelationship`,
+  `${CONNECTOR_NS_ATLASSIAN}createCompassCustomFieldDefinition`
+];
+function isChildExecutedTool(name) {
+  return typeof name === "string" && name.startsWith(CONNECTOR_NS_PREFIX2);
+}
+function isConnectorWriteTool(name) {
+  if (!name.startsWith(CONNECTOR_NS_PREFIX2)) return false;
+  const sep2 = name.indexOf("__", CONNECTOR_NS_PREFIX2.length);
+  if (sep2 <= CONNECTOR_NS_PREFIX2.length) return true;
+  const server = name.slice(CONNECTOR_NS_PREFIX2.length, sep2);
+  const words = connectorNameWords(name.slice(sep2 + "__".length));
+  const serverWords = connectorNameWords(server);
+  let skipped = 0;
+  while (skipped < serverWords.length && words[skipped] === serverWords[skipped] && !CONNECTOR_MUTATION_WORDS.has(words[skipped])) skipped++;
+  const rest = words.slice(skipped);
+  if (rest.length === 0) return true;
+  if (!CONNECTOR_READ_VERBS.has(rest[0])) return true;
+  return rest.some((word) => CONNECTOR_MUTATION_WORDS.has(word));
+}
+function connectorWriteModeFromEnv() {
+  const v4 = (process.env.CLAUDE_BRIDGE_CONNECTOR_WRITE ?? "").trim().toLowerCase();
+  if (v4 === "allow") return "allow";
+  if (v4 === "deny") return "deny";
+  return void 0;
+}
+function connectorWriteModeFor(config2) {
+  const resolved = connectorWriteModeFromEnv() ?? normalizeConnectorWriteMode(config2?.provider?.connectorWriteMode);
+  return resolved === "allow" ? "allow" : "deny";
+}
+function connectorWriteDenyHook() {
+  return async (input) => {
+    try {
+      if (input.hook_event_name !== "PreToolUse") return { continue: true };
+      if (!isConnectorWriteTool(input.tool_name)) return { continue: true };
+      return connectorWriteDenyOutput(String(input.tool_name));
+    } catch {
+      const toolName = typeof input?.tool_name === "string" ? input.tool_name : "<unknown>";
+      return connectorWriteDenyOutput(toolName);
+    }
+  };
+}
+function connectorWriteDenyOutput(toolName) {
+  return {
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: `Connector write tool "${toolName}" is blocked in read-only connector mode. Connector writes must go through the host application's gated approval flow.`
+    }
+  };
+}
+function connectorQueryOptions(connectorsEnabled, writeMode = "deny") {
+  const isolation = toolIsolationForQuery(connectorsEnabled, writeMode);
+  if (!connectorsEnabled || writeMode === "allow") return isolation;
+  return { ...isolation, hooks: { PreToolUse: [{ hooks: [connectorWriteDenyHook()] }] } };
+}
+function toolIsolationForQuery(connectorsEnabled, writeMode = "deny") {
+  if (!connectorsEnabled) return CLAUDE_BRIDGE_TOOL_ISOLATION;
+  const disallowedTools = DISALLOWED_BUILTIN_TOOLS.filter((t) => !CONNECTOR_DISCOVERY_TOOLS.includes(t));
+  if (writeMode !== "allow") disallowedTools.push(...CONNECTOR_WRITE_TOOLS);
+  return {
+    disallowedTools,
+    allowedTools: [...CLAUDE_BRIDGE_TOOL_ISOLATION.allowedTools, ...CLAUDE_AI_CONNECTOR_TOOL_PATTERNS]
+  };
+}
+function connectorMcpServers(inventory) {
+  if (!inventory.ok) return {};
+  if (connectorDeclarationsDisabled()) return {};
+  const servers = {};
+  for (const entry of inventory.connectors) {
+    if (entry.installState !== "connected") continue;
+    if (!entry.installedServerId) continue;
+    servers[connectorServerName(entry.name)] = {
+      type: "claudeai-proxy",
+      url: connectorProxyUrl(entry.installedServerId),
+      id: entry.installedServerId,
+      alwaysLoad: true
+    };
+  }
+  return servers;
+}
+function connectorDeclarationsDisabled(env = process.env) {
+  const v4 = (env.CLAUDE_BRIDGE_CONNECTOR_DECLARE ?? "").trim().toLowerCase();
+  return v4 === "off" || v4 === "0" || v4 === "false" || v4 === "no";
+}
+
 // src/convert.ts
 var PROVIDER_ID = "claude-bridge";
 var PI_TO_SDK_TOOL_NAME = {
@@ -26929,6 +27586,7 @@ function sanitizeToolId(id, cache) {
 }
 function mapPiToolNameToSdk(name, customToolNameToSdk) {
   if (!name) return "";
+  if (isChildExecutedTool(name)) return name;
   const normalized = name.toLowerCase();
   if (customToolNameToSdk) {
     const mapped = customToolNameToSdk.get(name) ?? customToolNameToSdk.get(normalized);
@@ -27155,26 +27813,6 @@ function buildModels(piAiModels) {
     thinkingLevelMap,
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }
   }));
-}
-
-// src/skills.ts
-var MCP_SERVER_NAME = "custom-tools";
-var MCP_TOOL_PREFIX = `mcp__${MCP_SERVER_NAME}__`;
-function extractSkillsBlock(systemPrompt) {
-  if (!systemPrompt) return void 0;
-  const startMarker = "The following skills provide specialized instructions for specific tasks.";
-  const endMarker = "</available_skills>";
-  const start = systemPrompt.indexOf(startMarker);
-  if (start === -1) return void 0;
-  const end = systemPrompt.indexOf(endMarker, start);
-  if (end === -1) return void 0;
-  return rewriteSkillsBlock(systemPrompt.slice(start, end + endMarker.length).trim());
-}
-function rewriteSkillsBlock(skillsBlock) {
-  return skillsBlock.replace(
-    "Use the read tool to load a skill's file",
-    `Use the read tool (mcp__${MCP_SERVER_NAME}__read) to load a skill's file`
-  );
 }
 
 // src/extract-tool-results.ts
@@ -27484,210 +28122,6 @@ function popContext() {
   const parent = contextStack[contextStack.length - 1];
   parent.deferredUserMessages.push(..._ctx.deferredUserMessages);
   _ctx = contextStack.pop();
-}
-
-// src/config.ts
-import { existsSync as existsSync2, readFileSync as readFileSync2 } from "fs";
-import { homedir } from "os";
-import { dirname, join as join2, resolve as resolve2 } from "path";
-var PACKAGE_ID = "@vanillagreen/pi-claude-bridge";
-var VALID_EFFORT_LEVELS = /* @__PURE__ */ new Set(["low", "medium", "high", "xhigh", "max"]);
-function expandHome(input) {
-  if (input === "~") return homedir();
-  if (input.startsWith("~/")) return join2(homedir(), input.slice(2));
-  return input;
-}
-function piUserDir() {
-  return resolve2(expandHome(process.env.PI_CODING_AGENT_DIR?.trim() || "~/.pi/agent"));
-}
-function isolatedFromEnv() {
-  const v4 = (process.env.CLAUDE_BRIDGE_ISOLATED ?? "").trim().toLowerCase();
-  return v4 === "1" || v4 === "true" || v4 === "yes" || v4 === "on";
-}
-function asRecord(value) {
-  return value && typeof value === "object" && !Array.isArray(value) ? value : void 0;
-}
-function mergeDeep(target, source) {
-  for (const [key, value] of Object.entries(source)) {
-    const current = asRecord(target[key]);
-    const incoming = asRecord(value);
-    if (current && incoming) target[key] = mergeDeep({ ...current }, incoming);
-    else target[key] = value;
-  }
-  return target;
-}
-function projectSettingsPath(cwd) {
-  let current = resolve2(cwd);
-  while (true) {
-    const candidate = join2(current, ".pi", "settings.json");
-    if (existsSync2(candidate)) return candidate;
-    if (existsSync2(join2(current, ".pi")) || existsSync2(join2(current, ".git")) || existsSync2(join2(current, ".vstack-lock.json"))) return candidate;
-    const parent = dirname(current);
-    if (parent === current) return join2(resolve2(cwd), ".pi", "settings.json");
-    current = parent;
-  }
-}
-var PROJECT_TRUST_SYMBOL = /* @__PURE__ */ Symbol.for("vstack.pi.project-trust");
-function projectTrustRegistry() {
-  const host = globalThis;
-  const existing = host[PROJECT_TRUST_SYMBOL];
-  if (existing) return existing;
-  const created = {};
-  host[PROJECT_TRUST_SYMBOL] = created;
-  return created;
-}
-function recordProjectTrust(ctx2) {
-  if (!ctx2.cwd) return;
-  if (isolatedFromEnv()) return;
-  let trusted = true;
-  try {
-    trusted = ctx2.isProjectTrusted?.() === true;
-  } catch {
-    trusted = false;
-  }
-  const registry2 = projectTrustRegistry();
-  if (!registry2.projectSettings) registry2.projectSettings = /* @__PURE__ */ new Map();
-  registry2.projectSettings.set(projectSettingsPath(ctx2.cwd), trusted);
-}
-function projectSettingsTrusted(settingsPath) {
-  return projectTrustRegistry().projectSettings?.get(settingsPath) === true;
-}
-function settingsPaths(cwd) {
-  const user = join2(piUserDir(), "settings.json");
-  if (isolatedFromEnv()) return [];
-  const project = projectSettingsPath(cwd);
-  return projectSettingsTrusted(project) ? [user, project] : [user];
-}
-function tryParseJson(path) {
-  if (!existsSync2(path)) return {};
-  try {
-    return JSON.parse(readFileSync2(path, "utf-8"));
-  } catch {
-    return {};
-  }
-}
-function readManagerConfig(cwd) {
-  const merged = {};
-  for (const path of settingsPaths(cwd)) {
-    if (!existsSync2(path)) continue;
-    try {
-      const parsed = JSON.parse(readFileSync2(path, "utf8"));
-      const configRoot = asRecord(asRecord(asRecord(parsed?.vstack)?.extensionManager)?.config);
-      const config2 = asRecord(configRoot?.[PACKAGE_ID]);
-      if (config2) mergeDeep(merged, config2);
-    } catch {
-    }
-  }
-  return merged;
-}
-function boolFrom(raw, key) {
-  return typeof raw[key] === "boolean" ? raw[key] : void 0;
-}
-function stringFrom(raw, key) {
-  const value = raw[key];
-  return typeof value === "string" && value.trim().length > 0 ? value.trim() : void 0;
-}
-function hasOwn(raw, key) {
-  return Object.prototype.hasOwnProperty.call(raw, key);
-}
-function normalizeConnectorWriteMode(value) {
-  if (typeof value !== "string") return void 0;
-  const normalized = value.trim().toLowerCase();
-  if (normalized === "deny" || normalized === "allow") return normalized;
-  return void 0;
-}
-function normalizeEffortLevel(value) {
-  if (typeof value !== "string") return void 0;
-  const normalized = value.trim().toLowerCase();
-  if (normalized === "" || normalized === "none" || normalized === "auto" || normalized === "default") return void 0;
-  return VALID_EFFORT_LEVELS.has(normalized) ? normalized : void 0;
-}
-function normalizeModelEffortOverrides(value) {
-  let source = value;
-  if (typeof source === "string") {
-    const trimmed = source.trim();
-    if (!trimmed || trimmed === "{}") return void 0;
-    try {
-      source = JSON.parse(trimmed);
-    } catch {
-      return void 0;
-    }
-  }
-  const record2 = asRecord(source);
-  if (!record2) return void 0;
-  const out = {};
-  for (const [modelId, rawEffort] of Object.entries(record2)) {
-    const key = modelId.trim();
-    const effort = normalizeEffortLevel(rawEffort);
-    if (key && effort) out[key] = effort;
-  }
-  return Object.keys(out).length > 0 ? out : void 0;
-}
-function normalizeProviderConfig(provider) {
-  if (!provider) return {};
-  const raw = provider;
-  const out = { ...provider };
-  const forceEffort = normalizeEffortLevel(raw.forceEffort);
-  if (forceEffort) out.forceEffort = forceEffort;
-  else delete out.forceEffort;
-  const modelEffortOverrides = normalizeModelEffortOverrides(raw.modelEffortOverrides);
-  if (modelEffortOverrides) out.modelEffortOverrides = modelEffortOverrides;
-  else delete out.modelEffortOverrides;
-  const connectorWriteMode = normalizeConnectorWriteMode(raw.connectorWriteMode);
-  if (connectorWriteMode) out.connectorWriteMode = connectorWriteMode;
-  else delete out.connectorWriteMode;
-  return out;
-}
-function managerToConfig(raw) {
-  const provider = {};
-  const promptContext = {};
-  const appendSystemPrompt = boolFrom(raw, "appendSystemPrompt");
-  if (appendSystemPrompt !== void 0) provider.appendSystemPrompt = appendSystemPrompt;
-  const allowExtraUsage = boolFrom(raw, "allowExtraUsage");
-  if (allowExtraUsage !== void 0) provider.allowExtraUsage = allowExtraUsage;
-  const fastMode = boolFrom(raw, "fastMode");
-  if (fastMode !== void 0) provider.fastMode = fastMode;
-  if (hasOwn(raw, "forceEffort")) {
-    provider.forceEffort = normalizeEffortLevel(raw.forceEffort);
-  }
-  if (hasOwn(raw, "modelEffortOverrides")) {
-    provider.modelEffortOverrides = normalizeModelEffortOverrides(raw.modelEffortOverrides);
-  }
-  const strictMcpConfig = boolFrom(raw, "strictMcpConfig");
-  if (strictMcpConfig !== void 0) provider.strictMcpConfig = strictMcpConfig;
-  const enableConnectors = boolFrom(raw, "enableConnectors");
-  if (enableConnectors !== void 0) provider.enableConnectors = enableConnectors;
-  const connectorWriteMode = normalizeConnectorWriteMode(raw.connectorWriteMode);
-  if (connectorWriteMode) provider.connectorWriteMode = connectorWriteMode;
-  const claudePath = stringFrom(raw, "pathToClaudeCodeExecutable");
-  if (claudePath) provider.pathToClaudeCodeExecutable = claudePath;
-  const includeAppendSystemPromptMd = boolFrom(raw, "includeAppendSystemPromptMd");
-  if (includeAppendSystemPromptMd !== void 0) promptContext.includeAppendSystemPromptMd = includeAppendSystemPromptMd;
-  const includeProjectAgentsHook = boolFrom(raw, "includeProjectAgentsHook");
-  if (includeProjectAgentsHook !== void 0) promptContext.includeProjectAgentsHook = includeProjectAgentsHook;
-  const includeTaskPanelHook = boolFrom(raw, "includeTaskPanelHook");
-  if (includeTaskPanelHook !== void 0) promptContext.includeTaskPanelHook = includeTaskPanelHook;
-  const includeCavemanHook = boolFrom(raw, "includeCavemanHook");
-  if (includeCavemanHook !== void 0) promptContext.includeCavemanHook = includeCavemanHook;
-  return {
-    ...boolFrom(raw, "enabled") !== void 0 ? { enabled: boolFrom(raw, "enabled") } : {},
-    ...Object.keys(provider).length ? { provider } : {},
-    ...Object.keys(promptContext).length ? { promptContext } : {}
-  };
-}
-function loadConfig(cwd) {
-  const global2 = tryParseJson(join2(piUserDir(), "claude-bridge.json"));
-  const isolated = isolatedFromEnv();
-  const projectSettings = isolated ? void 0 : projectSettingsPath(cwd);
-  const trustedProject = projectSettings !== void 0 && projectSettingsTrusted(projectSettings);
-  const project = trustedProject ? tryParseJson(join2(dirname(projectSettings), "claude-bridge.json")) : {};
-  const manager = isolated ? {} : managerToConfig(readManagerConfig(cwd));
-  const provider = normalizeProviderConfig({ ...global2.provider, ...project.provider, ...manager.provider });
-  return {
-    enabled: manager.enabled ?? project.enabled ?? global2.enabled ?? true,
-    provider,
-    promptContext: { ...global2.promptContext, ...project.promptContext, ...manager.promptContext }
-  };
 }
 
 // src/auth-presence.ts
@@ -42484,145 +42918,6 @@ async function resolveGetModels(root, loadCompat = () => dynamicImport("@earendi
   return compat.getModels;
 }
 
-// src/connector-inventory.ts
-var CONNECTOR_NS_PREFIX = "mcp__claude_ai_";
-var DEFAULT_API_BASE = "https://api.anthropic.com";
-var DEFAULT_PROXY_BASE = "https://mcp-proxy.anthropic.com/v1/mcp";
-var OAUTH_BETA_HEADER = "oauth-2025-04-20";
-function connectorServerName(connectorName) {
-  return `claude.ai ${connectorName.trim()}`;
-}
-function connectorProxyUrl(installedServerId, proxyBase = DEFAULT_PROXY_BASE) {
-  return `${trimTrailingSlashes(proxyBase)}/${encodeURIComponent(installedServerId)}`;
-}
-function connectorServerNamespace(connectorName) {
-  return `${CONNECTOR_NS_PREFIX}${connectorName.trim().replace(/\s+/g, "_")}__`;
-}
-function credentialCandidatePaths(env = process.env) {
-  const roots = [];
-  const configDir = env.CLAUDE_CONFIG_DIR?.trim();
-  if (configDir) roots.push(configDir);
-  const home = env.HOME?.trim();
-  if (home) roots.push(`${home}/.claude`, home);
-  const seen = /* @__PURE__ */ new Set();
-  const paths = [];
-  for (const root of roots) {
-    for (const name of [".credentials.json", ".claude.json"]) {
-      const p4 = `${root}/${name}`;
-      if (!seen.has(p4)) {
-        seen.add(p4);
-        paths.push(p4);
-      }
-    }
-  }
-  return paths;
-}
-function resolveClaudeOAuth(readFile, env = process.env) {
-  let accessToken;
-  let organizationUuid;
-  for (const path of credentialCandidatePaths(env)) {
-    const raw = readFile(path);
-    if (!raw) continue;
-    let parsed;
-    try {
-      parsed = JSON.parse(raw);
-    } catch {
-      continue;
-    }
-    accessToken ??= nonEmptyString(parsed?.claudeAiOauth?.accessToken);
-    organizationUuid ??= nonEmptyString(parsed?.oauthAccount?.organizationUuid);
-    if (accessToken && organizationUuid) break;
-  }
-  if (!accessToken || !organizationUuid) return void 0;
-  return { accessToken, organizationUuid };
-}
-function nonEmptyString(value) {
-  return typeof value === "string" && value.trim() ? value.trim() : void 0;
-}
-function connectorsListUrl(organizationUuid, apiBase = DEFAULT_API_BASE) {
-  return `${trimTrailingSlashes(apiBase)}/api/oauth/organizations/${encodeURIComponent(organizationUuid)}/mcp/connectors/list`;
-}
-function trimTrailingSlashes(value) {
-  let end = value.length;
-  while (end > 0 && value.charCodeAt(end - 1) === 47) end--;
-  return value.slice(0, end);
-}
-async function listAccountConnectors(deps) {
-  const { credentials, apiBase, signal } = deps;
-  const fetchImpl = deps.fetchImpl ?? fetch;
-  const url2 = connectorsListUrl(credentials.organizationUuid, apiBase);
-  const fail = (reason) => ({ ok: false, complete: false, reason: redactSecret(reason, credentials.accessToken) });
-  let response;
-  try {
-    response = await fetchImpl(url2, {
-      method: "POST",
-      headers: {
-        "Authorization": `Bearer ${credentials.accessToken}`,
-        "anthropic-beta": OAUTH_BETA_HEADER,
-        "Content-Type": "application/json"
-      },
-      body: "{}",
-      signal
-    });
-  } catch (error51) {
-    return fail(`connector list request failed: ${errorText(error51)}`);
-  }
-  let bodyText;
-  try {
-    bodyText = await response.text();
-  } catch (error51) {
-    return fail(`connector list response unreadable: ${errorText(error51)}`);
-  }
-  if (!response.ok) {
-    return fail(`connector list returned HTTP ${response.status}${apiErrorSuffix(bodyText)}`);
-  }
-  let parsed;
-  try {
-    parsed = JSON.parse(bodyText);
-  } catch {
-    return fail("connector list returned a non-JSON body");
-  }
-  if (!Array.isArray(parsed?.results)) {
-    return fail("connector list response had no results array");
-  }
-  const connectors = [];
-  for (const raw of parsed.results) {
-    const entry = raw;
-    const name = nonEmptyString(entry?.name);
-    if (!name) {
-      return fail("connector list contained an entry with no name");
-    }
-    connectors.push({
-      name,
-      installedServerId: nonEmptyString(entry?.installedServerId),
-      directoryUuid: nonEmptyString(entry?.directoryUuid),
-      installState: nonEmptyString(entry?.installState),
-      description: nonEmptyString(entry?.description),
-      isAuthless: typeof entry?.isAuthless === "boolean" ? entry.isAuthless : void 0
-    });
-  }
-  return { ok: true, complete: true, connectors };
-}
-function apiErrorSuffix(bodyText) {
-  try {
-    const message = JSON.parse(bodyText)?.error?.message;
-    return typeof message === "string" && message.trim() ? ` (${message.trim()})` : "";
-  } catch {
-    return "";
-  }
-}
-function redactSecret(text, secret) {
-  if (!secret || secret.length < 8) return text;
-  let out = text;
-  for (const form of /* @__PURE__ */ new Set([secret, encodeURIComponent(secret)])) {
-    out = out.split(form).join("[redacted]");
-  }
-  return out;
-}
-function errorText(error51) {
-  return error51 instanceof Error ? error51.message : String(error51);
-}
-
 // src/connector-cache.ts
 import { createHash } from "node:crypto";
 import { mkdirSync as mkdirSync2, readFileSync as readFileSync6, writeFileSync } from "node:fs";
@@ -43093,300 +43388,6 @@ function __testSetBridgeIntegrityState(state) {
 }
 function __testGetBridgeIntegrityState() {
   return { sharedSession };
-}
-
-// src/connectors.ts
-var DISALLOWED_BUILTIN_TOOLS = [
-  "Read",
-  "Write",
-  "Edit",
-  "MultiEdit",
-  "Glob",
-  "Grep",
-  "Bash",
-  "Agent",
-  "Task",
-  "NotebookEdit",
-  "EnterWorktree",
-  "ExitWorktree",
-  "CronList",
-  "CronCreate",
-  "CronDelete",
-  "TeamCreate",
-  "TeamDelete",
-  "TaskOutput",
-  "TaskStop",
-  "SendMessage",
-  "Skill",
-  "TodoRead",
-  "TodoWrite",
-  "ListMcpResources",
-  "ReadMcpResource",
-  "WebFetch",
-  "WebSearch",
-  "AskUserQuestion",
-  "EnterPlanMode",
-  "ExitPlanMode",
-  "ToolSearch",
-  "ScheduleWakeup"
-];
-var CLAUDE_BRIDGE_TOOL_ISOLATION = {
-  tools: [],
-  disallowedTools: DISALLOWED_BUILTIN_TOOLS,
-  allowedTools: [`mcp__${MCP_SERVER_NAME}__*`]
-};
-function connectorsEnabledFromEnv() {
-  const v4 = (process.env.CLAUDE_BRIDGE_ENABLE_CONNECTORS ?? "").trim().toLowerCase();
-  return v4 === "1" || v4 === "true" || v4 === "yes" || v4 === "on";
-}
-function connectorsEnabledFor(config2) {
-  return connectorsEnabledFromEnv() || config2?.provider?.enableConnectors === true;
-}
-var CLAUDE_AI_CONNECTOR_TOOL_PATTERNS = [
-  "mcp__claude_ai_Gmail__*",
-  "mcp__claude_ai_Google_Calendar__*",
-  "mcp__claude_ai_Google_Drive__*",
-  "mcp__claude_ai_Slack__*",
-  "mcp__claude_ai_Atlassian__*"
-];
-var CONNECTOR_DISCOVERY_TOOLS = ["ToolSearch", "ListMcpResources", "ReadMcpResource"];
-var CONNECTOR_NS_PREFIX2 = "mcp__claude_ai_";
-var CONNECTOR_NS_GMAIL = `${CONNECTOR_NS_PREFIX2}Gmail__`;
-var CONNECTOR_NS_CALENDAR = `${CONNECTOR_NS_PREFIX2}Google_Calendar__`;
-var CONNECTOR_NS_DRIVE = `${CONNECTOR_NS_PREFIX2}Google_Drive__`;
-var CONNECTOR_NS_SLACK = `${CONNECTOR_NS_PREFIX2}Slack__`;
-var CONNECTOR_NS_ATLASSIAN = `${CONNECTOR_NS_PREFIX2}Atlassian__`;
-var CONNECTOR_READ_VERBS = /* @__PURE__ */ new Set([
-  "list",
-  "search",
-  "get",
-  "read",
-  "fetch",
-  "find",
-  "download",
-  "describe",
-  "query",
-  "count",
-  "view",
-  "lookup",
-  "whoami"
-]);
-var CONNECTOR_MUTATION_WORDS = /* @__PURE__ */ new Set([
-  "create",
-  "update",
-  "delete",
-  "remove",
-  "add",
-  "edit",
-  "send",
-  "post",
-  "write",
-  "upload",
-  "publish",
-  "schedule",
-  "transition",
-  "archive",
-  "move",
-  "copy",
-  "revoke",
-  "assign",
-  "invite",
-  "share",
-  "rename",
-  "replace",
-  "set",
-  "merge",
-  "resolve",
-  "lock",
-  "unlock",
-  "acknowledge",
-  "ack",
-  "book",
-  "start",
-  "stop",
-  "terminate",
-  "restart",
-  "join",
-  "leave",
-  "star",
-  "unstar",
-  "forward",
-  "sync",
-  "approve",
-  "reject",
-  "close",
-  "reopen",
-  "cancel",
-  "enable",
-  "disable",
-  "grant",
-  "trigger",
-  "execute",
-  "apply",
-  "submit",
-  "pin",
-  "unpin",
-  "mute",
-  "unmute",
-  "subscribe",
-  "unsubscribe",
-  "follow",
-  "unfollow",
-  "clear",
-  "purge",
-  "reset",
-  "rotate",
-  "deploy",
-  "install",
-  "uninstall",
-  "save",
-  "store",
-  "put",
-  "patch",
-  "insert",
-  "append",
-  "prepend",
-  "duplicate",
-  "restore",
-  "revert",
-  "import",
-  "export",
-  "upsert",
-  "sign",
-  "complete",
-  "claim",
-  "release",
-  "promote",
-  "demote",
-  "escalate",
-  "resend",
-  "retry",
-  "react",
-  "vote"
-]);
-function connectorNameWords(segment) {
-  return segment.replace(/([a-z0-9])([A-Z])/g, "$1 $2").replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2").split(/[^A-Za-z0-9]+/).filter(Boolean).map((word) => word.toLowerCase());
-}
-var CONNECTOR_WRITE_TOOLS = [
-  `${CONNECTOR_NS_GMAIL}create_draft`,
-  `${CONNECTOR_NS_GMAIL}create_label`,
-  `${CONNECTOR_NS_GMAIL}label_message`,
-  `${CONNECTOR_NS_GMAIL}label_thread`,
-  `${CONNECTOR_NS_GMAIL}unlabel_message`,
-  `${CONNECTOR_NS_GMAIL}unlabel_thread`,
-  `${CONNECTOR_NS_GMAIL}apply_sensitive_label`,
-  `${CONNECTOR_NS_GMAIL}remove_sensitive_label`,
-  `${CONNECTOR_NS_CALENDAR}create_event`,
-  `${CONNECTOR_NS_CALENDAR}update_event`,
-  `${CONNECTOR_NS_CALENDAR}delete_event`,
-  `${CONNECTOR_NS_CALENDAR}respond_to_event`,
-  `${CONNECTOR_NS_DRIVE}create_file`,
-  `${CONNECTOR_NS_DRIVE}copy_file`,
-  // Slack + Atlassian writes, taken from a live enumeration of an account with
-  // both connectors attached. The PreToolUse hook already denies these by verb;
-  // listing them by id also removes them from the model's context in a
-  // read-only session (the CLI matcher needs exact ids). Additive only — an id
-  // missing here is still denied at call time.
-  `${CONNECTOR_NS_SLACK}slack_send_message`,
-  `${CONNECTOR_NS_SLACK}slack_send_message_draft`,
-  `${CONNECTOR_NS_SLACK}slack_schedule_message`,
-  `${CONNECTOR_NS_SLACK}slack_create_canvas`,
-  `${CONNECTOR_NS_SLACK}slack_update_canvas`,
-  `${CONNECTOR_NS_ATLASSIAN}createJiraIssue`,
-  `${CONNECTOR_NS_ATLASSIAN}editJiraIssue`,
-  `${CONNECTOR_NS_ATLASSIAN}transitionJiraIssue`,
-  `${CONNECTOR_NS_ATLASSIAN}addCommentToJiraIssue`,
-  `${CONNECTOR_NS_ATLASSIAN}addWorklogToJiraIssue`,
-  `${CONNECTOR_NS_ATLASSIAN}createIssueLink`,
-  `${CONNECTOR_NS_ATLASSIAN}createConfluencePage`,
-  `${CONNECTOR_NS_ATLASSIAN}updateConfluencePage`,
-  `${CONNECTOR_NS_ATLASSIAN}createConfluenceFooterComment`,
-  `${CONNECTOR_NS_ATLASSIAN}createConfluenceInlineComment`,
-  `${CONNECTOR_NS_ATLASSIAN}createCompassComponent`,
-  `${CONNECTOR_NS_ATLASSIAN}createCompassComponentRelationship`,
-  `${CONNECTOR_NS_ATLASSIAN}createCompassCustomFieldDefinition`
-];
-function isChildExecutedTool(name) {
-  return typeof name === "string" && name.startsWith(CONNECTOR_NS_PREFIX2);
-}
-function isConnectorWriteTool(name) {
-  if (!name.startsWith(CONNECTOR_NS_PREFIX2)) return false;
-  const sep2 = name.indexOf("__", CONNECTOR_NS_PREFIX2.length);
-  if (sep2 <= CONNECTOR_NS_PREFIX2.length) return true;
-  const server = name.slice(CONNECTOR_NS_PREFIX2.length, sep2);
-  const words = connectorNameWords(name.slice(sep2 + "__".length));
-  const serverWords = connectorNameWords(server);
-  let skipped = 0;
-  while (skipped < serverWords.length && words[skipped] === serverWords[skipped] && !CONNECTOR_MUTATION_WORDS.has(words[skipped])) skipped++;
-  const rest = words.slice(skipped);
-  if (rest.length === 0) return true;
-  if (!CONNECTOR_READ_VERBS.has(rest[0])) return true;
-  return rest.some((word) => CONNECTOR_MUTATION_WORDS.has(word));
-}
-function connectorWriteModeFromEnv() {
-  const v4 = (process.env.CLAUDE_BRIDGE_CONNECTOR_WRITE ?? "").trim().toLowerCase();
-  if (v4 === "allow") return "allow";
-  if (v4 === "deny") return "deny";
-  return void 0;
-}
-function connectorWriteModeFor(config2) {
-  const resolved = connectorWriteModeFromEnv() ?? normalizeConnectorWriteMode(config2?.provider?.connectorWriteMode);
-  return resolved === "allow" ? "allow" : "deny";
-}
-function connectorWriteDenyHook() {
-  return async (input) => {
-    try {
-      if (input.hook_event_name !== "PreToolUse") return { continue: true };
-      if (!isConnectorWriteTool(input.tool_name)) return { continue: true };
-      return connectorWriteDenyOutput(String(input.tool_name));
-    } catch {
-      const toolName = typeof input?.tool_name === "string" ? input.tool_name : "<unknown>";
-      return connectorWriteDenyOutput(toolName);
-    }
-  };
-}
-function connectorWriteDenyOutput(toolName) {
-  return {
-    hookSpecificOutput: {
-      hookEventName: "PreToolUse",
-      permissionDecision: "deny",
-      permissionDecisionReason: `Connector write tool "${toolName}" is blocked in read-only connector mode. Connector writes must go through the host application's gated approval flow.`
-    }
-  };
-}
-function connectorQueryOptions(connectorsEnabled, writeMode = "deny") {
-  const isolation = toolIsolationForQuery(connectorsEnabled, writeMode);
-  if (!connectorsEnabled || writeMode === "allow") return isolation;
-  return { ...isolation, hooks: { PreToolUse: [{ hooks: [connectorWriteDenyHook()] }] } };
-}
-function toolIsolationForQuery(connectorsEnabled, writeMode = "deny") {
-  if (!connectorsEnabled) return CLAUDE_BRIDGE_TOOL_ISOLATION;
-  const disallowedTools = DISALLOWED_BUILTIN_TOOLS.filter((t) => !CONNECTOR_DISCOVERY_TOOLS.includes(t));
-  if (writeMode !== "allow") disallowedTools.push(...CONNECTOR_WRITE_TOOLS);
-  return {
-    disallowedTools,
-    allowedTools: [...CLAUDE_BRIDGE_TOOL_ISOLATION.allowedTools, ...CLAUDE_AI_CONNECTOR_TOOL_PATTERNS]
-  };
-}
-function connectorMcpServers(inventory) {
-  if (!inventory.ok) return {};
-  if (connectorDeclarationsDisabled()) return {};
-  const servers = {};
-  for (const entry of inventory.connectors) {
-    if (entry.installState !== "connected") continue;
-    if (!entry.installedServerId) continue;
-    servers[connectorServerName(entry.name)] = {
-      type: "claudeai-proxy",
-      url: connectorProxyUrl(entry.installedServerId),
-      id: entry.installedServerId,
-      alwaysLoad: true
-    };
-  }
-  return servers;
-}
-function connectorDeclarationsDisabled(env = process.env) {
-  const v4 = (env.CLAUDE_BRIDGE_CONNECTOR_DECLARE ?? "").trim().toLowerCase();
-  return v4 === "off" || v4 === "0" || v4 === "false" || v4 === "no";
 }
 
 // node_modules/cc-session-io/dist/chunk-D6EZBJOC.js
@@ -44764,6 +44765,10 @@ function resolveMcpTools(context, excludeToolName) {
   if (!context.tools) return { mcpTools, customToolNameToSdk, customToolNameToPi };
   for (const tool of context.tools) {
     if (tool.name === excludeToolName) continue;
+    if (isChildExecutedTool(tool.name)) {
+      debug(`resolveMcpTools: not re-offering child-native tool ${tool.name}`);
+      continue;
+    }
     const sdkName = `${MCP_TOOL_PREFIX}${tool.name}`;
     mcpTools.push(tool);
     customToolNameToSdk.set(tool.name, sdkName);
@@ -45587,6 +45592,7 @@ export {
   index_default as default,
   formatAllowedRateLimitWarning,
   formatResetTimestamp,
+  isChildExecutedTool,
   isConnectorWriteTool,
   isExtraUsageRequiredMessage,
   listAccountConnectors,
@@ -45602,6 +45608,7 @@ export {
   resolveClaudeExecutable,
   resolveClaudeOAuth,
   resolveConfiguredEffort,
+  resolveMcpTools,
   restoreSharedSessionFromPi,
   shouldRestorePersistedBridgeEntry,
   spawnClaudeCodeWithDiagnostics,

--- a/pi-extensions/pi-claude-bridge/src/convert.ts
+++ b/pi-extensions/pi-claude-bridge/src/convert.ts
@@ -4,6 +4,7 @@
 import type { Message as PiMessage } from "@earendil-works/pi-ai";
 import type { ContentBlock, Message as SessionMessage } from "cc-session-io";
 import { pascalCase } from "change-case";
+import { isChildExecutedTool } from "./connectors.js";
 
 export const PROVIDER_ID = "claude-bridge";
 
@@ -21,6 +22,19 @@ export function sanitizeToolId(id: string, cache: Map<string, string>): string {
 
 export function mapPiToolNameToSdk(name: string, customToolNameToSdk?: Map<string, string>): string {
 	if (!name) return "";
+	// A claude.ai connector name is ALREADY the child's own tool id — the child
+	// owns that namespace natively. PascalCasing it invented an alias
+	// (`mcp__claude_ai_Slack__slack_search_channels` →
+	// `McpClaudeAiSlackSlackSearchChannels`) that appeared in the child's
+	// projected history, so the model imitated it on the next turn and got a
+	// real `Tool ... not found` from the MCP dispatcher before retrying the
+	// canonical name — one wasted round-trip per affected call (memsira#320).
+	//
+	// Connector names stopped reaching this function at all once they stopped
+	// being mirrored as Pi tool calls (isChildExecutedTool), so this is the
+	// belt to that braces: LEGACY Pi history recorded before that fix still
+	// carries them, and a rebuild would still project the alias.
+	if (isChildExecutedTool(name)) return name;
 	const normalized = name.toLowerCase();
 	if (customToolNameToSdk) {
 		const mapped = customToolNameToSdk.get(name) ?? customToolNameToSdk.get(normalized);

--- a/pi-extensions/pi-claude-bridge/src/index.ts
+++ b/pi-extensions/pi-claude-bridge/src/index.ts
@@ -40,7 +40,7 @@ export { connectorCachePath, connectorCacheScopeKey, readCachedConnectors, write
 import { debug, diagDump, makeCliDebugOptions, moduleInstanceId } from "./debug.js";
 import { preflightClaudeExecutable, resolveClaudeExecutable, spawnClaudeCodeWithDiagnostics } from "./claude-executable.js";
 import { argKeys, extensionApi, piUI, reportToolResultMismatch, safeNotify, safeToolCallSummary, setExtensionApi, setPiUI, setSharedSession, sharedSession } from "./bridge-state.js";
-import { connectorMcpServers, connectorQueryOptions, connectorWriteModeFor, connectorsEnabledFor } from "./connectors.js";
+import { connectorMcpServers, connectorQueryOptions, connectorWriteModeFor, connectorsEnabledFor, isChildExecutedTool } from "./connectors.js";
 import { readCachedConnectors, writeCachedConnectors } from "./connector-cache.js";
 import { restoreSharedSessionFromPi, schedulePersistSharedSession, syncSharedSession } from "./session-persistence.js";
 import { STREAM_IDLE_BACKOFF_HINT_MS, activeStreamIdleWatchdogs, buildStreamIdleTimeoutErrorMessage, createStreamIdleWatchdog, formatDurationShort, streamIdleTimeoutMsFromEnv } from "./stream-idle-watchdog.js";
@@ -53,7 +53,7 @@ import { ensureTurnStarted, finalizeCurrentStream, noteChildExecutedToolResults,
 // bundle/index.js.
 export { classifyClaudeExecutableBytes, preflightClaudeExecutable, resolveClaudeExecutable, spawnClaudeCodeWithDiagnostics, wrapClaudeSpawnErrorForSdk, type ClaudeExecutableFileType, type ClaudeExecutablePreflightResult } from "./claude-executable.js";
 export { __testGetBridgeIntegrityState, __testSetBridgeIntegrityState, reportToolResultMismatch } from "./bridge-state.js";
-export { CLAUDE_AI_CONNECTOR_TOOL_PATTERNS, connectorMcpServers, connectorDeclarationsDisabled, CLAUDE_BRIDGE_TOOL_ISOLATION, CONNECTOR_DISCOVERY_TOOLS, CONNECTOR_WRITE_TOOLS, DISALLOWED_BUILTIN_TOOLS, connectorQueryOptions, connectorWriteDenyHook, connectorWriteModeFor, connectorWriteModeFromEnv, connectorsEnabledFor, connectorsEnabledFromEnv, isConnectorWriteTool, toolIsolationForQuery } from "./connectors.js";
+export { CLAUDE_AI_CONNECTOR_TOOL_PATTERNS, connectorMcpServers, connectorDeclarationsDisabled, CLAUDE_BRIDGE_TOOL_ISOLATION, CONNECTOR_DISCOVERY_TOOLS, CONNECTOR_WRITE_TOOLS, DISALLOWED_BUILTIN_TOOLS, connectorQueryOptions, connectorWriteDenyHook, connectorWriteModeFor, connectorWriteModeFromEnv, connectorsEnabledFor, connectorsEnabledFromEnv, isChildExecutedTool, isConnectorWriteTool, toolIsolationForQuery } from "./connectors.js";
 export { restoreSharedSessionFromPi, shouldRestorePersistedBridgeEntry } from "./session-persistence.js";
 export { DEFAULT_STREAM_IDLE_TIMEOUT_MS, STREAM_IDLE_BACKOFF_HINT_MS, STREAM_IDLE_TIMEOUT_ENV, buildStreamIdleTimeoutErrorMessage, createStreamIdleWatchdog, streamIdleTimeoutMsFromEnv, type StreamIdleTimeoutInfo, type StreamIdleWatchdog, type StreamIdleWatchdogState } from "./stream-idle-watchdog.js";
 export { ALLOWED_RATE_LIMIT_WARNING_UTILIZATION_THRESHOLD, formatAllowedRateLimitWarning, formatResetTimestamp, isExtraUsageRequiredMessage, normalizeRateLimitUtilization, uniqueNonEmptyLines } from "./rate-limit.js";
@@ -247,7 +247,7 @@ async function* wrapPromptStream(blocks: ContentBlockParam[]): AsyncIterable<SDK
 // them without activating the extension. `ctx()`, `pushContext()`, `popContext()`
 // are imported at the top of this file.
 
-function resolveMcpTools(context: Context, excludeToolName?: string): {
+export function resolveMcpTools(context: Context, excludeToolName?: string): {
 	mcpTools: Tool[];
 	customToolNameToSdk: Map<string, string>;
 	customToolNameToPi: Map<string, string>;
@@ -260,6 +260,18 @@ function resolveMcpTools(context: Context, excludeToolName?: string): {
 
 	for (const tool of context.tools) {
 		if (tool.name === excludeToolName) continue;
+		// Never re-offer a tool the child owns natively. The claude.ai connector
+		// namespace belongs to the child's own MCP servers, so a Pi tool sitting
+		// on it would be advertised a SECOND time under our prefix — two names
+		// for one capability, and the model picking the wrong one gets a real
+		// `Tool ... not found` from the dispatcher (memsira#320). It would also
+		// be uncallable in any case: a `tool_use` under that namespace is treated
+		// as child-executed and never handed to Pi (isChildExecutedTool), so
+		// filtering here is what makes the two halves agree end to end.
+		if (isChildExecutedTool(tool.name)) {
+			debug(`resolveMcpTools: not re-offering child-native tool ${tool.name}`);
+			continue;
+		}
 		const sdkName = `${MCP_TOOL_PREFIX}${tool.name}`;
 		mcpTools.push(tool);
 		customToolNameToSdk.set(tool.name, sdkName);

--- a/pi-extensions/pi-claude-bridge/tests/unit-connector-alias.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-connector-alias.mjs
@@ -1,0 +1,80 @@
+// The claude.ai connector namespace belongs to the CHILD's own MCP servers.
+// Two places used to hand the model a SECOND name for the same capability, and
+// a second name is a name that can be wrong: the model imitated the alias and
+// got a real `Tool ... not found` from the MCP dispatcher before retrying the
+// canonical one — one wasted round-trip per affected call (memsira#320).
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mapPiToolNameToSdk } from "../src/convert.ts";
+import { isChildExecutedTool } from "../src/connectors.ts";
+import { resolveMcpTools } from "../src/index.ts";
+
+const CONNECTOR_TOOL = "mcp__claude_ai_Slack__slack_search_channels";
+
+describe("connector names are never aliased into the child's history", () => {
+	it("passes a connector name through unchanged", () => {
+		assert.equal(mapPiToolNameToSdk(CONNECTOR_TOOL), CONNECTOR_TOOL);
+		assert.equal(
+			mapPiToolNameToSdk("mcp__claude_ai_Atlassian__getConfluencePage"),
+			"mcp__claude_ai_Atlassian__getConfluencePage",
+		);
+	});
+
+	it("does not produce the PascalCase alias that was observed live", () => {
+		// The exact string from memsira's child transcript 672467eb.
+		assert.notEqual(mapPiToolNameToSdk(CONNECTOR_TOOL), "McpClaudeAiSlackSlackSearchChannels");
+	});
+
+	it("still maps everything else as before", () => {
+		assert.equal(mapPiToolNameToSdk("read"), "Read");
+		assert.equal(mapPiToolNameToSdk("bash"), "Bash");
+		assert.equal(mapPiToolNameToSdk("my_custom_tool"), "MyCustomTool");
+		assert.equal(mapPiToolNameToSdk(""), "");
+	});
+
+	it("still prefers an explicit custom mapping for a non-connector tool", () => {
+		const map = new Map([["my_custom_tool", "mcp__pi__my_custom_tool"]]);
+		assert.equal(mapPiToolNameToSdk("my_custom_tool", map), "mcp__pi__my_custom_tool");
+	});
+
+	it("a connector name wins over a custom mapping — the namespace is the child's", () => {
+		// A host that put a connector-named tool in Pi's set cannot reclaim the
+		// name: the call is treated as child-executed either way, so re-offering
+		// it under our prefix would only produce an uncallable second name.
+		const map = new Map([[CONNECTOR_TOOL, `mcp__pi__${CONNECTOR_TOOL}`]]);
+		assert.equal(mapPiToolNameToSdk(CONNECTOR_TOOL, map), CONNECTOR_TOOL);
+		assert.equal(isChildExecutedTool(CONNECTOR_TOOL), true);
+	});
+});
+
+describe("the bridge MCP manifest never re-offers a child-native tool", () => {
+	it("drops a connector-named Pi tool instead of advertising a second name for it", () => {
+		const { mcpTools, customToolNameToSdk, customToolNameToPi } = resolveMcpTools({
+			tools: [
+				{ name: "read", description: "read a file", parameters: { type: "object" } },
+				{ name: CONNECTOR_TOOL, description: "squatting on the child's namespace", parameters: { type: "object" } },
+			],
+		});
+
+		assert.deepEqual(mcpTools.map((t) => t.name), ["read"]);
+		assert.equal(customToolNameToSdk.has(CONNECTOR_TOOL), false);
+		assert.equal(customToolNameToPi.has(`mcp__pi__${CONNECTOR_TOOL}`), false);
+	});
+
+	it("still offers ordinary Pi tools, and still honours excludeToolName", () => {
+		const { mcpTools } = resolveMcpTools(
+			{
+				tools: [
+					{ name: "read", description: "", parameters: { type: "object" } },
+					{ name: "bash", description: "", parameters: { type: "object" } },
+				],
+			},
+			"bash",
+		);
+		assert.deepEqual(mcpTools.map((t) => t.name), ["read"]);
+	});
+
+	it("tolerates a context with no tools", () => {
+		assert.deepEqual(resolveMcpTools({}).mcpTools, []);
+	});
+});


### PR DESCRIPTION
Follow-up to #932, from memsira's root-cause writeup on memsira#320. **A second name for the same capability is a name that can be wrong**, and the model picked the wrong one.

## The evidence (memsira's, child transcript `672467eb`)

The model called `McpClaudeAiSlackSlackSearchChannels`, got a real `Tool mcp__claude_ai_Slack__slack_search_channels not found` from the MCP dispatcher, then retried the canonical name and got a real Slack payload. **One wasted round-trip per affected call**, and an error in the transcript with nothing wrong behind it.

Note that error is a *different* one from #932's: it comes from the bundle's inlined MCP SDK (`InvalidParams`), not from Pi's agent loop.

## Where the second name came from — two places

1. **`mapPiToolNameToSdk` PascalCases anything it cannot map.** A connector call projected back into the child's session file became the alias above, so the model saw its own "prior" call under that name and imitated it. #932 stops connector calls reaching this path at all — but **legacy Pi history recorded before #932 still carries them**, and a rebuild still projects them. Connector names now pass through unchanged.

2. **`resolveMcpTools` re-offered every `context.tools` entry under the bridge's own MCP prefix**, including one sitting on the connector namespace. Such a tool is uncallable in any case — after #932 a `tool_use` there is treated as child-executed and never handed to Pi — so advertising it could only ever produce a wrong name. It is now filtered out, which is what makes the two halves agree end to end: the namespace belongs to the child, in the manifest and in dispatch alike.

## Scope, stated honestly

**drovr is not affected in practice.** Zero PascalCase aliases and zero dispatcher errors across its child transcripts, because its chats take the session-REUSE path rather than rebuilding. memsira hit it because rebuilds projected the aliases. This lands upstream because the namespace rule should hold for both apps, not because drovr needed it.

## Tests

`tests/unit-connector-alias.mjs`, 8 tests: pass-through for connector names, the exact observed alias not produced, ordinary mapping unchanged, an explicit custom mapping still preferred for a non-connector tool, a connector name winning over a custom mapping, the manifest dropping a connector-named Pi tool, `excludeToolName` still honoured, and an empty context.

Verified in both directions: **4 of 8 fail** with both changes reverted, all pass with them. `typecheck` clean, `test:unit` **304/304**.

`resolveMcpTools` is now exported for the test, matching how the rest of the internals are already re-exported from the bundle entry.

## Note for memsira

This is the second half you asked for; re-vendor after it merges. The manifest filter is a no-op unless a host puts a connector-named tool in Pi's set — worth checking whether yours does, since that is the half that would still bite you at runtime rather than only in projected history.