### PR TITLE
feat(pi-claude-bridge): record child-executed connector calls as session entries

### DIFF
--- a/pi-extensions/pi-claude-bridge/DEVELOPMENT.md
+++ b/pi-extensions/pi-claude-bridge/DEVELOPMENT.md
@@ -26,8 +26,23 @@ The classifier is namespace-based on purpose. "Any name Pi cannot resolve" would
 
 Two consequences worth knowing:
 
-- The child's real result is **observed, never re-delivered** (`noteChildExecutedToolResults`, fed from the SDK's `user` message). It already reached the model inside the child. The debug line records the tool name, error flag, and content size — never the payload, which is live account data and the bridge's debug log sits outside a host app's redaction boundary.
-- A connector call therefore leaves **no tool record in the Pi transcript at all**. Pi has no content-block type for a provider-executed tool call, so the honest options were "absent" or "present and wrong". Restoring visibility needs a Pi-side representation for delegated calls.
+- The child's real result is **observed, never re-delivered** (`noteChildExecutedToolResults`, fed from the SDK's `user` message). It already reached the model inside the child. The debug line records the tool name, error flag, and payload byte size — never the payload, which is live account data and the bridge's debug log sits outside a host app's redaction boundary.
+- A connector call still produces **no tool card**. Pi's assistant content is `text | thinking | toolCall`, and any `toolCall` block is dispatched by its agent loop, so there is no way to say "a call happened, someone else ran it" as content — the honest options were "absent" or "present and wrong". Rendering one needs a Pi-side representation for delegated calls, which is an upstream ask.
+
+### The audit trail
+
+What the transcript *can* carry is a record that is not content. Each child-executed call appends a session `CustomEntry` of type `claude-bridge-connector-call` (`src/connector-audit.ts`), which pi documents as *"Does NOT participate in LLM context (ignored by `buildSessionContext`)"*: it is never a content block, so the agent loop cannot dispatch it, and `convertPiMessages` reads messages rather than entries, so it is never projected back into the child's session. **Never use `CustomMessageEntry`** for this — the sibling type DOES enter context, which is the whole bug again.
+
+Each record is `{ name, toolUseId, outcome, byteSize?, childSessionId?, reason? }` — enough to pair it to the child's own transcript by `tool_use_id`, and no payload.
+
+Two things the shape is deliberate about:
+
+- `outcome` is `ok | error | **unobserved**`. A call whose result never came back (abort, stream-idle timeout, a query that just ended) is recorded at teardown naming the cause, beside the Pi-side `drainPendingToolCalls`. Silence there would leave an answer in the transcript as the only evidence a call was ever made — the same "can I trust this?" question the mirrored `Tool ... not found` answered wrongly.
+- Recording is keyed on the `tool_use` id, not on the call site. The SDK can re-yield a `user` message, and either path (result or teardown) can reach a call first; one call is one record, whichever gets there.
+
+The audit map is query-scoped and is NOT cleared by `resetToolTracking` — that runs at every child message boundary, and clearing it there would make a call abandoned in an earlier child message unrecordable at teardown, which is the one case the trail exists for.
+
+Note that pi/core's `createBranchedSession` copies every non-label entry root→leaf, so a fork inherits the parent's connector-call records. Harmless for an audit trail, unlike the `claude-bridge-session` marker it sits beside, which needed a `piSessionId` guard for exactly that reason.
 
 ## Connector write enforcement
 

--- a/pi-extensions/pi-claude-bridge/README.md
+++ b/pi-extensions/pi-claude-bridge/README.md
@@ -110,6 +110,8 @@ Sessions are **read-only** by default: the model can look things up, but cannot 
 
 Connector tools run inside Claude Code rather than in Pi, so Pi shows the model's answer but no tool card for the lookup itself. (Before this was handled, Pi showed a card claiming `Tool … not found` for calls that had actually succeeded — so an answer built on real data looked invented.)
 
+Each of those lookups is still recorded in the session file as a `claude-bridge-connector-call` entry — the tool name, whether it succeeded, and how many bytes came back, never the contents. So "did it really look that up?" has an answer even though nothing is drawn in the transcript.
+
 Extension-manager settings use flat package-scoped keys:
 
 ```json

--- a/pi-extensions/pi-claude-bridge/bundle/index.js
+++ b/pi-extensions/pi-claude-bridge/bundle/index.js
@@ -27921,6 +27921,19 @@ var QueryContext = class {
   // instead of logging as "unmatched" (which reads like a bug).
   /** tool_use id → raw SDK tool name. */
   childExecutedToolCalls = /* @__PURE__ */ new Map();
+  /**
+   * The same calls, for the connector-call audit trail (see connector-audit.ts).
+   *
+   * Query-scoped and deliberately NOT cleared by resetToolTracking: that runs at
+   * every child message boundary, and a call issued in one child message is only
+   * reconciled after that message ends. Clearing it there would make an abandoned
+   * call unrecordable at teardown — which is the one case the trail exists for.
+   */
+  connectorCallAudit = /* @__PURE__ */ new Map();
+  /** Claude Code session id for this query, from the SDK's `system` init message.
+   *  Undefined until it arrives; the audit trail omits the field rather than
+   *  guessing. */
+  childSessionId;
   /** Anthropic content-block indexes of the current assistant message that carry
    *  a child-executed tool_use. Scoped to one message: cleared at message_start,
    *  and an index is released as soon as a new block starts there. */
@@ -28017,7 +28030,16 @@ var QueryContext = class {
   /** Note a tool_use the child runs itself. `streamIndex` is present only on the
    *  streamed path, where later deltas/stops for that block must be skipped. */
   noteChildExecutedToolCall(id, rawName, streamIndex) {
-    if (id) this.childExecutedToolCalls.set(id, rawName);
+    if (id) {
+      this.childExecutedToolCalls.set(id, rawName);
+      if (!this.connectorCallAudit.has(id)) {
+        this.connectorCallAudit.set(id, {
+          name: rawName,
+          ...this.childSessionId ? { childSessionId: this.childSessionId } : {},
+          recorded: false
+        });
+      }
+    }
     if (typeof streamIndex === "number") this.childExecutedStreamIndexes.add(streamIndex);
   }
   recordToolCall(id, toolName, args = {}) {
@@ -43390,6 +43412,58 @@ function __testGetBridgeIntegrityState() {
   return { sharedSession };
 }
 
+// src/connector-audit.ts
+var CONNECTOR_CALL_CUSTOM_TYPE = "claude-bridge-connector-call";
+function connectorResultByteSize(content) {
+  if (content === void 0 || content === null) return void 0;
+  if (typeof content === "string") return Buffer.byteLength(content, "utf8");
+  try {
+    const json2 = JSON.stringify(content);
+    return typeof json2 === "string" ? Buffer.byteLength(json2, "utf8") : void 0;
+  } catch {
+    return void 0;
+  }
+}
+function appendConnectorCallAudit(data) {
+  if (!extensionApi) return false;
+  try {
+    extensionApi.appendEntry(CONNECTOR_CALL_CUSTOM_TYPE, data);
+    return true;
+  } catch (error51) {
+    debug("appendConnectorCallAudit failed:", error51);
+    return false;
+  }
+}
+function recordConnectorCallResult(queryCtx, toolUseId, name, isError, byteSize) {
+  const pending = queryCtx.connectorCallAudit.get(toolUseId);
+  if (pending?.recorded) return false;
+  const childSessionId = pending?.childSessionId ?? queryCtx.childSessionId;
+  queryCtx.connectorCallAudit.set(toolUseId, { ...pending, name, childSessionId, recorded: true });
+  return appendConnectorCallAudit({
+    name,
+    toolUseId,
+    outcome: isError ? "error" : "ok",
+    ...byteSize !== void 0 ? { byteSize } : {},
+    ...childSessionId ? { childSessionId } : {}
+  });
+}
+function flushConnectorCallAudit(queryCtx, reason) {
+  let appended = 0;
+  for (const [toolUseId, state] of queryCtx.connectorCallAudit) {
+    if (state.recorded) continue;
+    queryCtx.connectorCallAudit.set(toolUseId, { ...state, recorded: true });
+    const childSessionId = state.childSessionId ?? queryCtx.childSessionId;
+    if (appendConnectorCallAudit({
+      name: state.name,
+      toolUseId,
+      outcome: "unobserved",
+      reason,
+      ...childSessionId ? { childSessionId } : {}
+    })) appended++;
+  }
+  return appended;
+}
+
 // node_modules/cc-session-io/dist/chunk-D6EZBJOC.js
 import { randomUUID } from "crypto";
 import { mkdirSync as mkdirSync4, writeFileSync as writeFileSync2, appendFileSync as appendFileSync3, existsSync as existsSync6, rmSync as rmSync2 } from "fs";
@@ -44558,8 +44632,10 @@ function noteChildExecutedToolResults(message) {
     if (block?.type !== "tool_result") continue;
     const name = c.childExecutedToolCalls.get(block.tool_use_id);
     if (!name) continue;
-    const size = typeof block.content === "string" ? block.content.length : Array.isArray(block.content) ? block.content.length : 0;
-    debug(`child-executed tool result: ${name} [${block.tool_use_id}] isError=${block.is_error === true} contentSize=${size}`);
+    const isError = block.is_error === true;
+    const byteSize = connectorResultByteSize(block.content);
+    const audited = recordConnectorCallResult(c, block.tool_use_id, name, isError, byteSize);
+    debug(`child-executed tool result: ${name} [${block.tool_use_id}] isError=${isError} byteSize=${byteSize ?? "unknown"} audited=${audited}`);
   }
 }
 function processAssistantMessage(message, model, customToolNameToPi) {
@@ -44912,6 +44988,7 @@ async function consumeQuery(sdkQuery, customToolNameToPi, model, cwd, bridgeConf
       case "system":
         if (message.subtype === "init" && message.session_id) {
           capturedSessionId = message.session_id;
+          queryCtx.childSessionId = capturedSessionId;
         } else if (message.subtype === "model_refusal_fallback") {
           const originalModel = message.original_model;
           const fallbackModel = message.fallback_model;
@@ -45365,6 +45442,8 @@ function streamClaudeAgentSdk(model, context, options) {
       const drained = drainPendingToolCalls(ctx(), cause);
       if (drained > 0) debug(`provider: query teardown drained ${drained} waiting MCP handler(s) as errors (cause=${cause})`);
       ctx().pendingResults.clear();
+      const unobserved = flushConnectorCallAudit(ctx(), cause);
+      if (unobserved > 0) debug(`provider: query teardown recorded ${unobserved} connector call(s) with no observed result (cause=${cause})`);
       if (isReentrant) {
         popContext();
       } else {
@@ -45563,6 +45642,7 @@ export {
   ALLOWED_RATE_LIMIT_WARNING_UTILIZATION_THRESHOLD,
   CLAUDE_AI_CONNECTOR_TOOL_PATTERNS,
   CLAUDE_BRIDGE_TOOL_ISOLATION,
+  CONNECTOR_CALL_CUSTOM_TYPE,
   CONNECTOR_DISCOVERY_TOOLS,
   CONNECTOR_WRITE_TOOLS,
   DEFAULT_STREAM_IDLE_TIMEOUT_MS,
@@ -45579,6 +45659,7 @@ export {
   connectorMcpServers,
   connectorProxyUrl,
   connectorQueryOptions,
+  connectorResultByteSize,
   connectorServerName,
   connectorServerNamespace,
   connectorWriteDenyHook,
@@ -45590,6 +45671,7 @@ export {
   createStreamIdleWatchdog,
   credentialCandidatePaths,
   index_default as default,
+  flushConnectorCallAudit,
   formatAllowedRateLimitWarning,
   formatResetTimestamp,
   isChildExecutedTool,
@@ -45604,6 +45686,7 @@ export {
   processAssistantMessage,
   processStreamEvent,
   readCachedConnectors,
+  recordConnectorCallResult,
   reportToolResultMismatch,
   resolveClaudeExecutable,
   resolveClaudeOAuth,

--- a/pi-extensions/pi-claude-bridge/src/assistant-stream.ts
+++ b/pi-extensions/pi-claude-bridge/src/assistant-stream.ts
@@ -1,5 +1,6 @@
 import { calculateCost, type AssistantMessage, type Model } from "@earendil-works/pi-ai";
 import { type SDKMessage } from "@anthropic-ai/claude-agent-sdk";
+import { connectorResultByteSize, recordConnectorCallResult } from "./connector-audit.js";
 import { isChildExecutedTool } from "./connectors.js";
 import { debug } from "./debug.js";
 import { ctx } from "./query-state.js";
@@ -294,9 +295,13 @@ function appendMissingToolUsesFromAssistant(
  * anything true about these calls at all — the Pi transcript claimed they failed
  * and nothing anywhere claimed otherwise.
  *
- * The payload is NEVER logged, only its shape: a connector result is live account
- * data (mail, messages, documents) and the bridge's debug log sits outside a host
- * app's redaction boundary.
+ * The payload is NEVER logged or recorded, only its shape: a connector result is
+ * live account data (mail, messages, documents) and the bridge's debug log sits
+ * outside a host app's redaction boundary.
+ *
+ * Observing it is also what makes the call auditable: each one appends a session
+ * `CustomEntry` (connector-audit.ts) so the Pi session records that the call
+ * happened, without a content block Pi's agent loop could try to dispatch.
  */
 export function noteChildExecutedToolResults(message: SDKMessage): void {
 	const c = ctx();
@@ -307,10 +312,10 @@ export function noteChildExecutedToolResults(message: SDKMessage): void {
 		if (block?.type !== "tool_result") continue;
 		const name = c.childExecutedToolCalls.get(block.tool_use_id);
 		if (!name) continue;
-		const size = typeof block.content === "string"
-			? block.content.length
-			: Array.isArray(block.content) ? block.content.length : 0;
-		debug(`child-executed tool result: ${name} [${block.tool_use_id}] isError=${block.is_error === true} contentSize=${size}`);
+		const isError = block.is_error === true;
+		const byteSize = connectorResultByteSize(block.content);
+		const audited = recordConnectorCallResult(c, block.tool_use_id, name, isError, byteSize);
+		debug(`child-executed tool result: ${name} [${block.tool_use_id}] isError=${isError} byteSize=${byteSize ?? "unknown"} audited=${audited}`);
 	}
 }
 

--- a/pi-extensions/pi-claude-bridge/src/connector-audit.ts
+++ b/pi-extensions/pi-claude-bridge/src/connector-audit.ts
@@ -1,0 +1,147 @@
+// Audit trail for connector calls the `claude` child executes itself.
+//
+// A claude.ai connector tool runs INSIDE the child, on the child's own MCP
+// servers, and is deliberately never mirrored into the Pi stream (see
+// isChildExecutedTool). That is the honest behaviour — mirroring wrote
+// `Tool <name> not found` into the transcript for calls that had SUCCEEDED
+// (drovr#311 / memsira#320) — but it leaves the Pi session with no record that
+// the call happened at all, so "did it really look that up?" could only be
+// answered from the child's own transcript.
+//
+// A pi `CustomEntry` closes that gap without reintroducing the bug: it is
+// persisted in the session file, is NOT a content block, and is documented as
+// "ignored by buildSessionContext", so Pi's agent loop can never dispatch it and
+// `convertPiMessages` (which reads messages, not entries) can never project it
+// back into the child's session. `CustomMessageEntry` is the sibling type that
+// DOES enter context — using it here would recreate the whole problem.
+//
+// The payload is never recorded. A connector result is live account data (mail,
+// messages, documents); the audit answers whether a call happened and what came
+// back, not what it said.
+
+import { extensionApi } from "./bridge-state.js";
+import { debug } from "./debug.js";
+import type { QueryContext, ToolCallDrainCause } from "./query-state.js";
+
+export const CONNECTOR_CALL_CUSTOM_TYPE = "claude-bridge-connector-call";
+
+/**
+ * What the bridge observed of a connector call.
+ *
+ * `unobserved` is the load-bearing one: the call was issued and the query ended
+ * before its result came back. Recording nothing for it would leave an answer in
+ * the transcript with no trace of the call behind it — indistinguishable from a
+ * turn where no call was ever made. Same reasoning as `interruptedToolCallResult`
+ * for Pi-side tools: a call that did not complete says so.
+ */
+export type ConnectorCallOutcome = "ok" | "error" | "unobserved";
+
+export interface ConnectorCallAuditData {
+	/** Raw connector tool name as the child invoked it (`mcp__claude_ai_<Server>__<tool>`). */
+	name: string;
+	/** The child's own `tool_use` id — the join key to its transcript. */
+	toolUseId: string;
+	outcome: ConnectorCallOutcome;
+	/** UTF-8 byte size of the observed result payload. Absent when the result was
+	 *  never observed, or could not be measured — never a confident 0 for
+	 *  something that was not sized. */
+	byteSize?: number;
+	/** Claude Code session that executed the call. Absent when the SDK never
+	 *  reported one for this query. */
+	childSessionId?: string;
+	/** Why an `unobserved` call ended. Absent for observed ones. */
+	reason?: ToolCallDrainCause;
+}
+
+/**
+ * Approximate UTF-8 byte size of a child tool result's payload.
+ *
+ * A string payload is measured directly; any other shape is measured as its JSON
+ * serialization, so a structured or image result reports the size it really
+ * carried. (The debug line this replaces reported `content.length` for an array
+ * payload — a BLOCK count wearing a byte size's name.)
+ *
+ * Returns undefined when there is nothing to measure or the payload cannot be
+ * serialized, so the caller omits the field rather than recording a 0 it did not
+ * measure. The payload itself is never returned or logged.
+ */
+export function connectorResultByteSize(content: unknown): number | undefined {
+	if (content === undefined || content === null) return undefined;
+	if (typeof content === "string") return Buffer.byteLength(content, "utf8");
+	try {
+		const json = JSON.stringify(content);
+		return typeof json === "string" ? Buffer.byteLength(json, "utf8") : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Append one audit entry. Returns whether it was actually persisted, so a caller
+ * can log the truth rather than assume — the extension API is absent whenever the
+ * bridge runs outside a pi session (tests, the connector-inventory entry point).
+ *
+ * Never throws: an audit record must not be able to fail a turn.
+ */
+export function appendConnectorCallAudit(data: ConnectorCallAuditData): boolean {
+	if (!extensionApi) return false;
+	try {
+		extensionApi.appendEntry(CONNECTOR_CALL_CUSTOM_TYPE, data);
+		return true;
+	} catch (error) {
+		debug("appendConnectorCallAudit failed:", error);
+		return false;
+	}
+}
+
+/**
+ * Record the observed result of a child-executed connector call, once.
+ *
+ * Keyed on the tool_use id rather than on the call site: the SDK can re-yield a
+ * `user` message, and an audit trail that counts one call twice is worse than
+ * one that counts it not at all. Returns whether an entry was appended.
+ */
+export function recordConnectorCallResult(
+	queryCtx: QueryContext,
+	toolUseId: string,
+	name: string,
+	isError: boolean,
+	byteSize: number | undefined,
+): boolean {
+	const pending = queryCtx.connectorCallAudit.get(toolUseId);
+	if (pending?.recorded) return false;
+	const childSessionId = pending?.childSessionId ?? queryCtx.childSessionId;
+	queryCtx.connectorCallAudit.set(toolUseId, { ...pending, name, childSessionId, recorded: true });
+	return appendConnectorCallAudit({
+		name,
+		toolUseId,
+		outcome: isError ? "error" : "ok",
+		...(byteSize !== undefined ? { byteSize } : {}),
+		...(childSessionId ? { childSessionId } : {}),
+	});
+}
+
+/**
+ * Record every connector call this query issued whose result never came back,
+ * naming the cause. Runs at query teardown, beside the Pi-side tool drain, and is
+ * idempotent — a call already recorded is skipped, and one recorded here is
+ * marked so a late arrival cannot record it again.
+ *
+ * Returns how many entries were appended.
+ */
+export function flushConnectorCallAudit(queryCtx: QueryContext, reason: ToolCallDrainCause): number {
+	let appended = 0;
+	for (const [toolUseId, state] of queryCtx.connectorCallAudit) {
+		if (state.recorded) continue;
+		queryCtx.connectorCallAudit.set(toolUseId, { ...state, recorded: true });
+		const childSessionId = state.childSessionId ?? queryCtx.childSessionId;
+		if (appendConnectorCallAudit({
+			name: state.name,
+			toolUseId,
+			outcome: "unobserved",
+			reason,
+			...(childSessionId ? { childSessionId } : {}),
+		})) appended++;
+	}
+	return appended;
+}

--- a/pi-extensions/pi-claude-bridge/src/index.ts
+++ b/pi-extensions/pi-claude-bridge/src/index.ts
@@ -41,6 +41,7 @@ import { debug, diagDump, makeCliDebugOptions, moduleInstanceId } from "./debug.
 import { preflightClaudeExecutable, resolveClaudeExecutable, spawnClaudeCodeWithDiagnostics } from "./claude-executable.js";
 import { argKeys, extensionApi, piUI, reportToolResultMismatch, safeNotify, safeToolCallSummary, setExtensionApi, setPiUI, setSharedSession, sharedSession } from "./bridge-state.js";
 import { connectorMcpServers, connectorQueryOptions, connectorWriteModeFor, connectorsEnabledFor, isChildExecutedTool } from "./connectors.js";
+import { flushConnectorCallAudit } from "./connector-audit.js";
 import { readCachedConnectors, writeCachedConnectors } from "./connector-cache.js";
 import { restoreSharedSessionFromPi, schedulePersistSharedSession, syncSharedSession } from "./session-persistence.js";
 import { STREAM_IDLE_BACKOFF_HINT_MS, activeStreamIdleWatchdogs, buildStreamIdleTimeoutErrorMessage, createStreamIdleWatchdog, formatDurationShort, streamIdleTimeoutMsFromEnv } from "./stream-idle-watchdog.js";
@@ -53,6 +54,7 @@ import { ensureTurnStarted, finalizeCurrentStream, noteChildExecutedToolResults,
 // bundle/index.js.
 export { classifyClaudeExecutableBytes, preflightClaudeExecutable, resolveClaudeExecutable, spawnClaudeCodeWithDiagnostics, wrapClaudeSpawnErrorForSdk, type ClaudeExecutableFileType, type ClaudeExecutablePreflightResult } from "./claude-executable.js";
 export { __testGetBridgeIntegrityState, __testSetBridgeIntegrityState, reportToolResultMismatch } from "./bridge-state.js";
+export { CONNECTOR_CALL_CUSTOM_TYPE, connectorResultByteSize, flushConnectorCallAudit, recordConnectorCallResult, type ConnectorCallAuditData, type ConnectorCallOutcome } from "./connector-audit.js";
 export { CLAUDE_AI_CONNECTOR_TOOL_PATTERNS, connectorMcpServers, connectorDeclarationsDisabled, CLAUDE_BRIDGE_TOOL_ISOLATION, CONNECTOR_DISCOVERY_TOOLS, CONNECTOR_WRITE_TOOLS, DISALLOWED_BUILTIN_TOOLS, connectorQueryOptions, connectorWriteDenyHook, connectorWriteModeFor, connectorWriteModeFromEnv, connectorsEnabledFor, connectorsEnabledFromEnv, isChildExecutedTool, isConnectorWriteTool, toolIsolationForQuery } from "./connectors.js";
 export { restoreSharedSessionFromPi, shouldRestorePersistedBridgeEntry } from "./session-persistence.js";
 export { DEFAULT_STREAM_IDLE_TIMEOUT_MS, STREAM_IDLE_BACKOFF_HINT_MS, STREAM_IDLE_TIMEOUT_ENV, buildStreamIdleTimeoutErrorMessage, createStreamIdleWatchdog, streamIdleTimeoutMsFromEnv, type StreamIdleTimeoutInfo, type StreamIdleWatchdog, type StreamIdleWatchdogState } from "./stream-idle-watchdog.js";
@@ -481,6 +483,10 @@ async function consumeQuery(
 			case "system":
 				if ((message as any).subtype === "init" && (message as any).session_id) {
 					capturedSessionId = (message as any).session_id;
+					// Also on this message's query context, so the connector-call audit
+					// trail can name the child session that executed a call — including
+					// from the teardown flush, which runs outside this function's scope.
+					queryCtx.childSessionId = capturedSessionId;
 				} else if ((message as any).subtype === "model_refusal_fallback") {
 					const originalModel = (message as any).original_model;
 					const fallbackModel = (message as any).fallback_model;
@@ -1088,6 +1094,12 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 				const drained = drainPendingToolCalls(ctx(), cause);
 				if (drained > 0) debug(`provider: query teardown drained ${drained} waiting MCP handler(s) as errors (cause=${cause})`);
 				ctx().pendingResults.clear();
+
+				// Same idea for calls the CHILD owned: one whose result never came back
+				// is recorded as unobserved rather than left silent, so an answer in the
+				// transcript is never the only evidence a connector call was made.
+				const unobserved = flushConnectorCallAudit(ctx(), cause);
+				if (unobserved > 0) debug(`provider: query teardown recorded ${unobserved} connector call(s) with no observed result (cause=${cause})`);
 
 				if (isReentrant) {
 					popContext();  // merges deferred messages and restores parent

--- a/pi-extensions/pi-claude-bridge/src/query-state.ts
+++ b/pi-extensions/pi-claude-bridge/src/query-state.ts
@@ -56,6 +56,18 @@ export function drainPendingToolCalls(queryCtx: QueryContext, cause: ToolCallDra
 	return drained;
 }
 
+/** One connector call's audit state for the life of a query. `recorded` means an
+ *  entry for it has already been appended (or attempted), so neither a re-yielded
+ *  result nor the teardown flush can record it twice. */
+export interface ConnectorCallAuditState {
+	name: string;
+	/** The child session that issued it, captured when the call was seen — a
+	 *  continuation query gets a new one, and a call is audited against the session
+	 *  that actually made it. */
+	childSessionId?: string;
+	recorded: boolean;
+}
+
 export interface TurnToolCallRecord {
 	id: string;
 	toolName: string;
@@ -148,6 +160,19 @@ export class QueryContext {
 	// instead of logging as "unmatched" (which reads like a bug).
 	/** tool_use id → raw SDK tool name. */
 	childExecutedToolCalls = new Map<string, string>();
+	/**
+	 * The same calls, for the connector-call audit trail (see connector-audit.ts).
+	 *
+	 * Query-scoped and deliberately NOT cleared by resetToolTracking: that runs at
+	 * every child message boundary, and a call issued in one child message is only
+	 * reconciled after that message ends. Clearing it there would make an abandoned
+	 * call unrecordable at teardown — which is the one case the trail exists for.
+	 */
+	connectorCallAudit = new Map<string, ConnectorCallAuditState>();
+	/** Claude Code session id for this query, from the SDK's `system` init message.
+	 *  Undefined until it arrives; the audit trail omits the field rather than
+	 *  guessing. */
+	childSessionId: string | undefined;
 	/** Anthropic content-block indexes of the current assistant message that carry
 	 *  a child-executed tool_use. Scoped to one message: cleared at message_start,
 	 *  and an index is released as soon as a new block starts there. */
@@ -246,7 +271,19 @@ export class QueryContext {
 	/** Note a tool_use the child runs itself. `streamIndex` is present only on the
 	 *  streamed path, where later deltas/stops for that block must be skipped. */
 	noteChildExecutedToolCall(id: string | undefined, rawName: string, streamIndex?: number): void {
-		if (id) this.childExecutedToolCalls.set(id, rawName);
+		if (id) {
+			this.childExecutedToolCalls.set(id, rawName);
+			// Both emission paths can see the same call (streamed block, then the
+			// SDK's completed copy), so never overwrite an existing audit state —
+			// that would resurrect one already recorded.
+			if (!this.connectorCallAudit.has(id)) {
+				this.connectorCallAudit.set(id, {
+					name: rawName,
+					...(this.childSessionId ? { childSessionId: this.childSessionId } : {}),
+					recorded: false,
+				});
+			}
+		}
 		if (typeof streamIndex === "number") this.childExecutedStreamIndexes.add(streamIndex);
 	}
 

--- a/pi-extensions/pi-claude-bridge/tests/unit-connector-audit.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-connector-audit.mjs
@@ -1,0 +1,245 @@
+// A connector call runs inside the `claude` child and is never mirrored into the
+// Pi stream (drovr#311 / memsira#320), which left the Pi session with no record
+// that it happened. These tests pin the record that closes that gap: a session
+// CustomEntry per call, never a content block, never the payload.
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { noteChildExecutedToolResults } from "../src/index.ts";
+import {
+	CONNECTOR_CALL_CUSTOM_TYPE,
+	connectorResultByteSize,
+	flushConnectorCallAudit,
+} from "../src/connector-audit.ts";
+import { setExtensionApi } from "../src/bridge-state.ts";
+import { ctx, resetStack } from "../src/query-state.ts";
+
+const model = {
+	api: "claude-bridge",
+	provider: "claude-bridge",
+	id: "claude-haiku-4-5",
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+};
+
+const CONNECTOR_TOOL = "mcp__claude_ai_Slack__slack_read_user_profile";
+
+/** Records what the bridge appended, and nothing else: `appendEntry` is the only
+ *  surface a CustomEntry may go through — `sendMessage`/`appendCustomMessageEntry`
+ *  would put it in LLM context, which is the bug this feature must not recreate. */
+function installFakeExtensionApi() {
+	const entries = [];
+	setExtensionApi({
+		appendEntry(customType, data) { entries.push({ customType, data }); },
+	});
+	return entries;
+}
+
+function userMessageWithResult(toolUseId, content, isError) {
+	return {
+		type: "user",
+		message: {
+			content: [{
+				type: "tool_result",
+				tool_use_id: toolUseId,
+				content,
+				...(isError !== undefined ? { is_error: isError } : {}),
+			}],
+		},
+	};
+}
+
+describe("connector result byte size", () => {
+	it("measures a string payload in UTF-8 bytes", () => {
+		assert.equal(connectorResultByteSize("abc"), 3);
+		// Multibyte: a character count would say 2 here.
+		assert.equal(connectorResultByteSize("é☃"), 5);
+	});
+
+	it("measures a block array as its payload, not as a block count", () => {
+		// The debug line this replaced reported `content.length` for an array — a
+		// block count wearing a byte size's name. A one-block array carrying 300
+		// bytes must not report 1.
+		const payload = "x".repeat(300);
+		const size = connectorResultByteSize([{ type: "text", text: payload }]);
+		assert.ok(size > 300, `expected the payload to be measured, got ${size}`);
+	});
+
+	it("reports nothing it did not measure", () => {
+		assert.equal(connectorResultByteSize(undefined), undefined);
+		assert.equal(connectorResultByteSize(null), undefined);
+		const circular = {};
+		circular.self = circular;
+		assert.equal(connectorResultByteSize(circular), undefined, "unserializable must not read as 0 bytes");
+	});
+});
+
+describe("connector call audit entries", () => {
+	beforeEach(() => resetStack());
+	afterEach(() => setExtensionApi(undefined));
+
+	it("records one entry for an observed result, with no payload in it", () => {
+		const entries = installFakeExtensionApi();
+		const c = ctx();
+		c.resetTurnState(model);
+		c.childSessionId = "child-sess-1";
+		c.noteChildExecutedToolCall("toolu_conn", CONNECTOR_TOOL, 0);
+
+		noteChildExecutedToolResults(userMessageWithResult("toolu_conn", "User ID: US9TAA048"));
+
+		assert.equal(entries.length, 1);
+		assert.equal(entries[0].customType, CONNECTOR_CALL_CUSTOM_TYPE);
+		assert.deepEqual(entries[0].data, {
+			name: CONNECTOR_TOOL,
+			toolUseId: "toolu_conn",
+			outcome: "ok",
+			byteSize: 18,
+			childSessionId: "child-sess-1",
+		});
+		assert.equal(
+			JSON.stringify(entries[0].data).includes("US9TAA048"), false,
+			"a connector result is live account data and must never reach the record",
+		);
+	});
+
+	it("records a child-side failure as an error, not as a success", () => {
+		const entries = installFakeExtensionApi();
+		const c = ctx();
+		c.resetTurnState(model);
+		c.noteChildExecutedToolCall("toolu_conn", CONNECTOR_TOOL, 0);
+
+		noteChildExecutedToolResults(userMessageWithResult("toolu_conn", "not_authed", true));
+
+		assert.equal(entries.length, 1);
+		assert.equal(entries[0].data.outcome, "error");
+	});
+
+	it("records one entry per call even if the SDK re-yields the result", () => {
+		const entries = installFakeExtensionApi();
+		const c = ctx();
+		c.resetTurnState(model);
+		c.noteChildExecutedToolCall("toolu_conn", CONNECTOR_TOOL, 0);
+
+		noteChildExecutedToolResults(userMessageWithResult("toolu_conn", "payload"));
+		noteChildExecutedToolResults(userMessageWithResult("toolu_conn", "payload"));
+
+		assert.equal(entries.length, 1, "an audit trail that counts one call twice is worse than none");
+	});
+
+	it("omits a session id it was never given", () => {
+		const entries = installFakeExtensionApi();
+		const c = ctx();
+		c.resetTurnState(model);
+		c.noteChildExecutedToolCall("toolu_conn", CONNECTOR_TOOL, 0);
+
+		noteChildExecutedToolResults(userMessageWithResult("toolu_conn", "payload"));
+
+		assert.equal("childSessionId" in entries[0].data, false);
+	});
+
+	it("audits a call against the child session that made it", () => {
+		// A continuation query reuses this context with a NEW child session id. A
+		// call issued before that must not be attributed to the later session.
+		const entries = installFakeExtensionApi();
+		const c = ctx();
+		c.resetTurnState(model);
+		c.childSessionId = "child-sess-1";
+		c.noteChildExecutedToolCall("toolu_conn", CONNECTOR_TOOL, 0);
+		c.childSessionId = "child-sess-2";
+
+		noteChildExecutedToolResults(userMessageWithResult("toolu_conn", "payload"));
+
+		assert.equal(entries[0].data.childSessionId, "child-sess-1");
+	});
+
+	it("does not throw when there is no session to record into", () => {
+		setExtensionApi(undefined);
+		const c = ctx();
+		c.resetTurnState(model);
+		c.noteChildExecutedToolCall("toolu_conn", CONNECTOR_TOOL, 0);
+
+		noteChildExecutedToolResults(userMessageWithResult("toolu_conn", "payload"));
+	});
+
+	it("survives an appendEntry that throws", () => {
+		setExtensionApi({ appendEntry() { throw new Error("session write failed"); } });
+		const c = ctx();
+		c.resetTurnState(model);
+		c.noteChildExecutedToolCall("toolu_conn", CONNECTOR_TOOL, 0);
+
+		noteChildExecutedToolResults(userMessageWithResult("toolu_conn", "payload"));
+	});
+});
+
+describe("connector calls whose result never came back", () => {
+	beforeEach(() => resetStack());
+	afterEach(() => setExtensionApi(undefined));
+
+	it("records an issued call the query never saw finish, naming the cause", () => {
+		const entries = installFakeExtensionApi();
+		const c = ctx();
+		c.resetTurnState(model);
+		c.childSessionId = "child-sess-1";
+		c.noteChildExecutedToolCall("toolu_conn", CONNECTOR_TOOL, 0);
+
+		const appended = flushConnectorCallAudit(c, "abort");
+
+		assert.equal(appended, 1);
+		assert.deepEqual(entries[0].data, {
+			name: CONNECTOR_TOOL,
+			toolUseId: "toolu_conn",
+			outcome: "unobserved",
+			reason: "abort",
+			childSessionId: "child-sess-1",
+		});
+	});
+
+	it("leaves an already-observed call alone", () => {
+		const entries = installFakeExtensionApi();
+		const c = ctx();
+		c.resetTurnState(model);
+		c.noteChildExecutedToolCall("toolu_conn", CONNECTOR_TOOL, 0);
+		noteChildExecutedToolResults(userMessageWithResult("toolu_conn", "payload"));
+
+		assert.equal(flushConnectorCallAudit(c, "query-end"), 0);
+		assert.equal(entries.length, 1);
+		assert.equal(entries[0].data.outcome, "ok");
+	});
+
+	it("records an abandoned call once, however often teardown runs", () => {
+		const entries = installFakeExtensionApi();
+		const c = ctx();
+		c.resetTurnState(model);
+		c.noteChildExecutedToolCall("toolu_conn", CONNECTOR_TOOL, 0);
+
+		flushConnectorCallAudit(c, "query-end");
+		flushConnectorCallAudit(c, "query-end");
+
+		assert.equal(entries.length, 1);
+	});
+
+	it("cannot be un-recorded by a result arriving after teardown", () => {
+		const entries = installFakeExtensionApi();
+		const c = ctx();
+		c.resetTurnState(model);
+		c.noteChildExecutedToolCall("toolu_conn", CONNECTOR_TOOL, 0);
+
+		flushConnectorCallAudit(c, "stream-idle-timeout");
+		noteChildExecutedToolResults(userMessageWithResult("toolu_conn", "payload"));
+
+		assert.equal(entries.length, 1, "one call is one record, whichever path got there first");
+		assert.equal(entries[0].data.outcome, "unobserved");
+	});
+
+	it("still knows about a call whose child message boundary has passed", () => {
+		// resetToolTracking runs at every child message_start. The audit map is
+		// query-scoped precisely so a call abandoned in an earlier child message is
+		// still recordable at teardown.
+		const entries = installFakeExtensionApi();
+		const c = ctx();
+		c.resetTurnState(model);
+		c.noteChildExecutedToolCall("toolu_conn", CONNECTOR_TOOL, 0);
+		c.resetToolTracking();
+
+		assert.equal(flushConnectorCallAudit(c, "query-end"), 1);
+		assert.equal(entries[0].data.name, CONNECTOR_TOOL);
+	});
+});


### PR DESCRIPTION
A claude.ai connector tool runs inside the `claude` child and is never mirrored into the Pi stream (#932) — mirroring wrote `Tool <name> not found` for calls that had **succeeded**. Correct, but it left the Pi session with no record that the call happened at all, so "did it really look that up?" could only be answered from the child's own transcript.

## The mechanism

A pi `CustomEntry` closes the gap without reintroducing the bug. The SDK documents it as *"Does NOT participate in LLM context (ignored by `buildSessionContext`)"* — so it is never a content block the agent loop can dispatch, and `convertPiMessages` reads messages rather than entries, so it is never projected back into the child's session. **`CustomMessageEntry` is the sibling type that DOES enter context** — using it here would recreate the whole problem. The bridge already uses this surface for its `claude-bridge-session` markers.

Each child-executed call appends `claude-bridge-connector-call`:

```
{ name, toolUseId, outcome, byteSize?, childSessionId?, reason? }
```

No payload — a connector result is live account data (mail, messages, documents). `toolUseId` is the join key to the child's own transcript.

## Two deliberate bits of shape

- **`outcome` is `ok | error | unobserved`.** A call whose result never came back (abort, stream-idle timeout, plain query end) is recorded at teardown naming the cause, beside the Pi-side `drainPendingToolCalls`. Silence there would leave the model's answer as the only evidence a call was ever made — the same "can I trust this?" the mirrored `Tool ... not found` answered wrongly.
- **Recording is keyed on the `tool_use` id, not the call site.** The SDK can re-yield a `user` message, and either path (result or teardown) can reach a call first. One call is one record, whichever gets there.

The audit map is query-scoped and NOT cleared by `resetToolTracking`, which runs at every child message boundary — clearing it there would make a call abandoned in an earlier child message unrecordable at teardown, which is the one case the trail exists for.

Also fixes the debug line's `contentSize`: it reported an array payload's **block count** under a byte size's name.

## Not in scope

The UI half. Rendering a tool card still needs either a pi-ai block type for provider-executed calls (an upstream ask) or a Pi-side proxy tool per connector tool (a security-surface change). This is the audit half only.

## Verification

- 15 new tests in `tests/unit-connector-audit.mjs`, including that the payload never reaches the record.
- Verified failing with the behaviour removed, not just passing with it: dropping the dedupe guard fails 2, disabling the flush fails 4.
- `npm run test:unit` 319/319 · `npm run typecheck` clean · bundle rebuilt.

Downstream: drovr and memsira both vendor this bundle and will re-vendor.

https://claude.ai/code/session_01N4gvdEi7z2xjzB46nyNhJe