### PR TITLE
feat(reviewer): pair mutation validation with a stability contract (#935)

### DIFF
--- a/agents/reviewer-test.md
+++ b/agents/reviewer-test.md
@@ -31,6 +31,7 @@ Read architecture docs relevant to your role: coverage targets (per-path or per-
 
 - **Report-only** — returns findings; does NOT modify code
 - Focus on tests that catch real bugs
+- Any test you mutation-validate also gets repeat runs at elevated parallelism (reviewer skill's Mutation-Stability Pairing); report both numbers — mutation-pass + stability-fail is a finding, not a pass
 - Derive coverage targets and test type requirements from architecture docs. Do not invent project-specific coverage percentages; when docs are silent, use the reviewer skill's fallback standards and focus on meaningful untested behavior.
 
 ## Output

--- a/skills/reviewer/SKILL.md
+++ b/skills/reviewer/SKILL.md
@@ -54,6 +54,14 @@ All reviewer agents share this baseline stance, then narrow it through their own
 
 Return `pass` only when your review domain has no verified blocker in scope. Put a finding in `blockers[]` when the scoped code introduces or contains a domain regression, an unjustified fallback-standard violation, or unresolved high-risk uncertainty that can be verified only by the author. Put a finding in `suggestions[]` only when it is actionable but non-blocking.
 
+## Mutation-Stability Pairing
+
+Mutation-validating a test (temporarily breaking the code under test to confirm the test fails, then reverting) proves the test can fail for the right reason — not that it only fails for the right reason. Every test you mutation-validate therefore also gets a stability check: run the validated test(s) N times (default N=10) at elevated parallelism — an explicit thread count around double the runner's default, e.g. for a Rust suite pass `--test-threads` at twice the logical-CPU count cargo defaults to, or the equivalent concurrency flag for other runners.
+
+Report both numbers wherever the validation is cited — in the finding's `description`, or in the artifact `summary` when the validation supports a pass — in this fixed format: `mutation: killed X/X; stability: Y/N at T threads` (mutants killed/introduced, passing runs/total runs, thread count).
+
+A test that passes mutation but fails any stability run is a finding (concurrency-sensitive test), never a pass.
+
 ## Output Contract
 
 Your review artifact is validated deterministically by orch's `review-artifact-check`. A single malformed item rejects the **whole** artifact and costs a re-delegation round-trip, so get the item shape right the first time.

--- a/skills/reviewer/tests/mutation-stability-contract.test.sh
+++ b/skills/reviewer/tests/mutation-stability-contract.test.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Contract test for the mutation-stability pairing: any test a reviewer
+# mutation-validates also gets N repeat runs at elevated parallelism, both
+# numbers are reported in one fixed format, and a mutation-pass +
+# stability-fail is a finding, never a pass. The contract is markdown, so
+# this test statically pins the canonical section in SKILL.md, the hooks
+# that make it binding at validation time in both review workflows, and the
+# duty mirror in the reviewer-test agent file (when the canonical agents
+# directory is present alongside the skill).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+require_pattern() {
+  local file="$1" pattern="$2" desc="$3"
+  if ! grep -Eq -- "$pattern" "$file"; then
+    fail "$desc missing in ${file#$SKILL_DIR/}"
+  fi
+}
+
+require_fixed() {
+  local file="$1" needle="$2" desc="$3"
+  if ! grep -Fq -- "$needle" "$file"; then
+    fail "$desc missing in ${file#$SKILL_DIR/}"
+  fi
+}
+
+skill="$SKILL_DIR/SKILL.md"
+review="$SKILL_DIR/workflows/review.md"
+qa_review="$SKILL_DIR/workflows/qa-review.md"
+[[ -f "$skill" ]] || fail "SKILL.md not found"
+[[ -f "$review" ]] || fail "workflow not found: workflows/review.md"
+[[ -f "$qa_review" ]] || fail "workflow not found: workflows/qa-review.md"
+
+# --- canonical contract in SKILL.md ---
+
+require_pattern "$skill" '^## Mutation-Stability Pairing' 'canonical Mutation-Stability Pairing section'
+require_fixed "$skill" 'then reverting' 'mutation is reverted before reporting'
+require_fixed "$skill" 'default N=10' 'default repeat count'
+require_fixed "$skill" '--test-threads' 'concrete elevated-parallelism example'
+require_fixed "$skill" 'mutation: killed X/X; stability: Y/N at T threads' 'fixed two-number report format'
+require_fixed "$skill" 'concurrency-sensitive' 'finding classification for stability failures'
+require_fixed "$skill" 'never a pass' 'stability-fail-is-a-finding rule'
+
+# --- the pairing binds at validation time in both review workflows ---
+
+require_fixed "$review" 'Mutation-Stability Pairing' 'pairing hook in code-review workflow'
+require_fixed "$qa_review" 'Mutation-Stability Pairing' 'pairing hook in QA-review workflow'
+
+# --- reviewer-test agent mirrors the duty (when the canonical agents dir is present) ---
+
+agent_file="$SKILL_DIR/../../agents/reviewer-test.md"
+if [[ -f "$agent_file" ]]; then
+  require_fixed "$agent_file" 'Mutation-Stability Pairing' 'duty mirror in reviewer-test agent'
+  require_fixed "$agent_file" 'finding, not a pass' 'finding-not-pass rule in reviewer-test agent'
+fi
+
+echo "all pass"

--- a/skills/reviewer/workflows/qa-review.md
+++ b/skills/reviewer/workflows/qa-review.md
@@ -67,6 +67,7 @@ Use domain grouping and risk flags to focus review on changed files relevant to 
 
 Run your agent-specific review. See your agent file for exact commands and Output section for blocker/suggestion mapping.
 Run each validation or read-only check as its own command per the reviewer skill's Harness-Safe Shell rule; do not combine checks into compound or composed shells under Codex `approval=never`.
+Mutation-validating a test as evidence commits you to the reviewer skill's Mutation-Stability Pairing: the paired repeat runs, the fixed `mutation: …; stability: …` report line, and a finding — not a pass — on a stability failure.
 Apply the reviewer skill's General Review Ethos and Reviewer Scope Boundaries. Stay within this agent's domain; do not duplicate another specialist unless your domain adds distinct evidence, impact, or remediation.
 
 ### 2.4 Classify Regressions (performance QA agent only)

--- a/skills/reviewer/workflows/review.md
+++ b/skills/reviewer/workflows/review.md
@@ -36,6 +36,7 @@ Review for noteworthy findings only — skip minor style issues. Exclude researc
 Apply the reviewer skill's General Review Ethos and Reviewer Scope Boundaries. Stay within this agent's domain; do not duplicate another specialist unless your domain adds distinct evidence, impact, or remediation.
 Read changed files and directly affected call paths from the worktree as needed before reporting non-trivial findings; the delegating agent does not need to inline full file contents.
 When running read-only checks to verify a finding, follow the reviewer skill's Harness-Safe Shell rule: one command per check, no compound or composed shells.
+Mutation-validating a test as evidence commits you to the reviewer skill's Mutation-Stability Pairing: the paired repeat runs, the fixed `mutation: …; stability: …` report line, and a finding — not a pass — on a stability failure.
 If a changed path was deleted, inspect it from the git diff or git history; do not try to `Read` the deleted working-tree path directly.
 
 ### 1.2 Read Decisions


### PR DESCRIPTION
Closes #935.

New always-loaded `## Mutation-Stability Pairing` section in reviewer SKILL.md (mutation validation proves a test can fail for the right reason, not that it only fails for the right reason): every mutation-validated test also gets N repeat runs (default 10) at elevated parallelism, both numbers reported in a fixed `mutation: killed X/X; stability: Y/N at T threads` line, and a mutation-pass + stability-fail is a finding (concurrency-sensitive test), never a pass. One-line hooks at the two validation steps (review.md § 1.1, qa-review.md § 2.3) plus a Guidelines mirror in agents/reviewer-test.md. Stated tool-agnostically with the Rust `--test-threads` example; schema untouched — the numbers route into the existing description/summary evidence fields.

Mutation validation had no prior definition anywhere in the skill, so this is the contract's first statement, pinned by a new doc test (section, N default, fixed format, finding-not-pass rule, both hooks, agent mirror). Reviewer suite 4/4 and full orch run-all 27/27 green.

https://claude.ai/code/session_01CeKocRj9NTENGbPNdJfATt