### PR TITLE
fix(pi-claude-bridge): end tool-use turns at message_stop; stop stranding tool calls

### DIFF
--- a/pi-extensions/pi-claude-bridge/DEVELOPMENT.md
+++ b/pi-extensions/pi-claude-bridge/DEVELOPMENT.md
@@ -5,9 +5,13 @@ Implementation details for contributors. End-user setup, settings, and troublesh
 ## Stream and tool-result handling
 
 - The bridge runs Claude Code through the Claude Agent SDK while Pi remains the owner of the visible TUI and tool execution.
-- If the SDK stream yields a completed assistant tool-use message before `message_stop`, the bridge treats that assistant message as the tool-turn boundary. Pi executes the tool calls immediately, and the matching tool results are delivered back before the turn continues.
+- A tool-use turn ends at the stream's `message_stop`, not at the first early signal. The SDK yields the completed assistant message AND invokes the MCP tool handlers before `message_delta` arrives — and `message_delta` is what carries the message's real output-token count, so ending the pi stream at either early signal froze pi's per-turn output figures at the `message_start` placeholders (1–7 tokens; 2026-07-28 token test). The early signals now only arm a ~1.5s grace timer (`scheduleToolUseTurnEnd`) that force-finalizes the turn if the terminal events never arrive (the pi 0.80 steer-draining case), so the MCP handlers can never deadlock waiting on a stream pi will not end.
+- An MCP handler claims its tool-call id by tool name + arguments; when no exact match exists but exactly ONE unclaimed call of that tool type does, it is claimed anyway (`argsMismatch` diag) — the handler receives the schema-VALIDATED input while the record holds the raw streamed input, and a stripped key must not strand the call. Nested schema objects also validate permissively (`.passthrough()`) unless the schema says `additionalProperties: false`, matching JSON Schema's default.
 - Tool results whose IDs were never registered in the active assistant tool-use turn are refused instead of being queued against another pending call. Remaining handlers receive an internal-error result so the turn cannot report false success.
+- Queued results that can no longer be consumed (their handler already gave up) are reaped at the next child message boundary with a `stale_queued_tool_results_dropped` diagnostic, instead of poisoning every later mismatch report for the query.
 - If a query tears down while parallel tool results are still queued or unresolved, the bridge writes diagnostics, marks the Claude session for rebuild, and re-imports delivered results from Pi history on the next turn.
+- Integrity events (mismatch, synthetic-result repair, stale-result reap, unmatched handler) are also appended to the pi session as `claude-bridge-integrity` custom entries — compact metadata only — so a post-mortem works from the session file alone.
+- Unpaired tool_uses in a session rebuild are paired with an explicit `is_error` result telling the model the output was lost and to re-run the tool if needed, instead of cc-session-io's bare `[no tool result recorded]` placeholder that models read as real output.
 
 ## Child-executed tools (claude.ai connectors)
 

--- a/pi-extensions/pi-claude-bridge/README.md
+++ b/pi-extensions/pi-claude-bridge/README.md
@@ -202,7 +202,7 @@ If Claude Code accepts a turn but produces no visible output, the bridge returns
 
 Set `CLAUDE_BRIDGE_DEBUG=1` to write bridge logs to `<agent dir>/claude-bridge.log` and per-query Claude Code CLI logs under `<agent dir>/cc-cli-logs/`, where `<agent dir>` is `PI_CODING_AGENT_DIR` when set, else `~/.pi/agent`. Override the exact files with `CLAUDE_BRIDGE_DEBUG_PATH` / `CLAUDE_BRIDGE_DIAG_PATH`.
 
-Tool-result integrity problems are surfaced even when debug logging is off. Pi shows an error notification and writes a diagnostic file to `<agent dir>/claude-bridge-diag.log` so lost or mismatched tool output is visible.
+Tool-result integrity problems are surfaced even when debug logging is off. Pi shows an error notification, writes a diagnostic file to `<agent dir>/claude-bridge-diag.log`, and appends a `claude-bridge-integrity` custom entry to the pi session transcript (compact metadata only — never tool output), so lost or mismatched tool output stays analyzable from the session file alone.
 
 Startup failures include the resolved Claude executable and working directory, which makes missing binaries and wrong launch directories easier to fix.
 

--- a/pi-extensions/pi-claude-bridge/bundle/index.js
+++ b/pi-extensions/pi-claude-bridge/bundle/index.js
@@ -27906,6 +27906,16 @@ var QueryContext = class {
   pendingResults = /* @__PURE__ */ new Map();
   turnToolCallIds = [];
   turnToolCalls = [];
+  /**
+   * id → Pi tool name for every tool call this QUERY recorded, across all child
+   * messages. Deliberately NOT cleared by resetToolTracking: per-message tracking
+   * resets at every message boundary, but `pendingResults` is query-scoped, so a
+   * result stranded there outlives the message that named it. Without this map a
+   * teardown report can only say "1 queued" with empty toolNames and 0/0
+   * counters — which is exactly the unactionable record the 2026-07-28 diag log
+   * showed. Bounded by the number of tool calls in one query.
+   */
+  queryToolNames = /* @__PURE__ */ new Map();
   claimedToolCallIds = /* @__PURE__ */ new Set();
   deliveredToolResultIds = /* @__PURE__ */ new Set();
   resolvedToolResultIds = /* @__PURE__ */ new Set();
@@ -27913,6 +27923,12 @@ var QueryContext = class {
   reportedToolResultMismatch = false;
   deferredUserMessages = [];
   handledTerminalError = false;
+  /** Armed grace timer for ending a tool_use turn whose terminal stream events
+   *  (message_delta/message_stop) never arrive. The normal path ends the turn at
+   *  message_stop, AFTER message_delta delivered the real output-token count;
+   *  this is the deadlock backstop for streams that go silent instead. Managed
+   *  by schedule/cancelToolUseTurnEnd in assistant-stream.ts. */
+  scheduledToolUseEnd = null;
   // Tool calls the CHILD executes itself (claude.ai connectors — see
   // isChildExecutedTool). Deliberately NOT in turnToolCalls/turnToolCallIds:
   // those track calls Pi owes a result for, and Pi owes nothing here. Kept only
@@ -28012,6 +28028,10 @@ var QueryContext = class {
     this.turnSawStreamEvent = false;
     this.turnSawToolCall = false;
     this.handledTerminalError = false;
+    if (this.scheduledToolUseEnd) {
+      clearTimeout(this.scheduledToolUseEnd.timer);
+      this.scheduledToolUseEnd = null;
+    }
     this.turnUsageCarry = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
     this.currentMessageUsage = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
     this.currentMessageId = void 0;
@@ -28044,6 +28064,7 @@ var QueryContext = class {
   }
   recordToolCall(id, toolName, args = {}) {
     if (!id) return;
+    this.queryToolNames.set(id, toolName);
     if (!this.turnToolCallIds.includes(id)) this.turnToolCallIds.push(id);
     const existing = this.turnToolCalls.find((call) => call.id === id);
     if (existing) {
@@ -28068,17 +28089,40 @@ var QueryContext = class {
     let chosen;
     let match = "none";
     let ambiguous = false;
+    let argsMismatch = false;
     if (exact.length > 0) {
       chosen = exact[0];
       match = "tool-args";
       ambiguous = exact.length > 1;
-    } else if (byName.length === 1 && !hasRecordedArgs(byName[0].arguments)) {
+    } else if (byName.length === 1) {
       chosen = byName[0];
       match = "tool-name";
+      argsMismatch = hasRecordedArgs(byName[0].arguments);
     }
     if (!chosen) return { match: "none", ambiguous: false, available: unclaimed.length };
     this.claimedToolCallIds.add(chosen.id);
-    return { toolCallId: chosen.id, match, ambiguous, available: unclaimed.length };
+    return { toolCallId: chosen.id, match, ambiguous, available: unclaimed.length, ...argsMismatch ? { argsMismatch } : {} };
+  }
+  /**
+   * Drain results still queued in `pendingResults` and report what was dropped.
+   *
+   * Called at a child MESSAGE boundary (message_start / the no-stream-events
+   * assistant fallback): by then the child has necessarily received every tool
+   * result for the previous message — a handler that matched resolved its result
+   * directly or from this queue, and one that never matched already returned an
+   * error. Whatever is still queued therefore belongs to a call whose handler
+   * gave up, and no consumer will ever come for it. Left in place, each entry
+   * poisons every later mismatch report for the whole query (queued>0 with 0/0
+   * counters and no tool names) and forces a session rebuild per turn.
+   */
+  takeStaleQueuedResults() {
+    if (this.pendingResults.size === 0) return [];
+    const stale = [...this.pendingResults.keys()].map((id) => ({
+      id,
+      toolName: this.queryToolNames.get(id) ?? "unknown"
+    }));
+    this.pendingResults.clear();
+    return stale;
   }
   markToolResultDelivered(id) {
     if (id) this.deliveredToolResultIds.add(id);
@@ -28103,9 +28147,15 @@ var QueryContext = class {
     const unresolvedIds = expectedIds.filter((id) => !this.resolvedToolResultIds.has(id));
     const affectedIds = /* @__PURE__ */ new Set([...missingDeliveredIds, ...unresolvedIds, ...waitingIds, ...queuedIds, ...unmatchedResultIds]);
     const counts = /* @__PURE__ */ new Map();
-    for (const call of this.turnToolCalls) {
-      if (affectedIds.size > 0 && !affectedIds.has(call.id)) continue;
-      counts.set(call.toolName, (counts.get(call.toolName) ?? 0) + 1);
+    if (affectedIds.size > 0) {
+      for (const id of affectedIds) {
+        const name = this.queryToolNames.get(id) ?? this.turnToolCalls.find((call) => call.id === id)?.toolName ?? "unknown";
+        counts.set(name, (counts.get(name) ?? 0) + 1);
+      }
+    } else {
+      for (const call of this.turnToolCalls) {
+        counts.set(call.toolName, (counts.get(call.toolName) ?? 0) + 1);
+      }
     }
     return {
       expectedIds,
@@ -42901,9 +42951,8 @@ function jsonSchemaPropertyToZod(prop) {
     }
     case "object": {
       if (prop.properties && typeof prop.properties === "object" && !Array.isArray(prop.properties)) {
-        base = external_exports.object(jsonSchemaToZodShape(prop));
-        if (prop.additionalProperties === false) base = base.strict();
-        else if (prop.additionalProperties === true) base = base.passthrough();
+        const obj = external_exports.object(jsonSchemaToZodShape(prop));
+        base = prop.additionalProperties === false ? obj.strict() : obj.passthrough();
       } else {
         base = external_exports.record(external_exports.string(), external_exports.unknown());
       }
@@ -43313,6 +43362,28 @@ function findUnpairedToolUses(messages) {
   }
   return missing;
 }
+var LOST_TOOL_RESULT_TEXT = "Claude bridge: the result of this tool call was lost before the session was rebuilt (the turn was interrupted). Treat the call as failed \u2014 it may or may not have executed. Re-run the tool if its output is still needed.";
+function insertLostToolResultPlaceholders(messages, missing) {
+  const block = (id) => ({ type: "tool_result", tool_use_id: id, content: LOST_TOOL_RESULT_TEXT, is_error: true });
+  const byAssistant = /* @__PURE__ */ new Map();
+  for (const item of missing) {
+    const group = byAssistant.get(item.assistantIndex) ?? [];
+    group.push(item);
+    byAssistant.set(item.assistantIndex, group);
+  }
+  for (const assistantIndex of [...byAssistant.keys()].sort((a, b) => b - a)) {
+    const group = byAssistant.get(assistantIndex);
+    const blocks = group.map((item) => block(item.id));
+    const userIndex = group[0].userIndex;
+    if (userIndex != null && messages[userIndex]?.role === "user") {
+      const user = messages[userIndex];
+      const existing = typeof user.content === "string" ? user.content ? [{ type: "text", text: user.content }] : [] : Array.isArray(user.content) ? user.content : [];
+      user.content = [...blocks, ...existing];
+    } else {
+      messages.splice(assistantIndex + 1, 0, { role: "user", content: blocks });
+    }
+  }
+}
 function summarizeMissingToolNames(missing) {
   const counts = /* @__PURE__ */ new Map();
   for (const item of missing) counts.set(item.toolName, (counts.get(item.toolName) ?? 0) + 1);
@@ -43345,6 +43416,17 @@ function argKeys(args) {
 function safeToolCallSummary(calls) {
   return calls.map((call) => ({ id: call.id, toolName: call.toolName, argKeys: argKeys(call.arguments) }));
 }
+var INTEGRITY_CUSTOM_TYPE = "claude-bridge-integrity";
+function appendIntegrityEntry(label, data) {
+  try {
+    if (!extensionApi) return false;
+    extensionApi.appendEntry(INTEGRITY_CUSTOM_TYPE, { label, at: (/* @__PURE__ */ new Date()).toISOString(), ...data });
+    return true;
+  } catch (error51) {
+    debug("appendIntegrityEntry failed:", error51);
+    return false;
+  }
+}
 function compactToolNameSummary(names, limit = 12) {
   const shown = names.slice(0, limit).map(({ name, count }) => count > 1 ? `${name}\xD7${count}` : name);
   if (names.length > limit) shown.push(`+${names.length - limit} more`);
@@ -43363,8 +43445,13 @@ function reportSyntheticToolResultRepair(missing, context) {
       missing: missing.slice(0, 50),
       ...context
     });
+    appendIntegrityEntry("repair_tool_pairing_synthetic_results", {
+      count: missing.length,
+      toolNames,
+      sampledToolCallIds: sampledToolCallIds.slice(0, 12)
+    });
     safeNotify(
-      `Claude bridge: ${missing.length} missing tool result(s) repaired with "[no tool result recorded]"${toolNameSummary.length ? ` for ${toolNameSummary.join(", ")}` : ""}. Real tool output was lost before Claude session import; see ${diagLogPath()}.`,
+      `Claude bridge: ${missing.length} missing tool result(s) repaired with an explicit error placeholder${toolNameSummary.length ? ` for ${toolNameSummary.join(", ")}` : ""}. Real tool output was lost before Claude session import; see ${diagLogPath()}.`,
       "error"
     );
   } catch (error51) {
@@ -43393,6 +43480,16 @@ function reportToolResultMismatch(queryCtx, reason, cwd, opts = {}) {
         needsRebuild: sharedSession.needsRebuild === true,
         forceRotate: sharedSession.forceRotate === true
       } : null
+    });
+    appendIntegrityEntry("tool_result_delivery_mismatch", {
+      reason,
+      toolNames: progress.toolNames,
+      expectedCount: progress.expectedCount,
+      deliveredCount: progress.deliveredCount,
+      resolvedCount: progress.resolvedCount,
+      waitingIds: progress.waitingIds,
+      queuedIds: progress.queuedIds,
+      unmatchedResultIds: progress.unmatchedResultIds
     });
     safeNotify(
       `Claude bridge: tool result delivery interrupted during ${reason}; delivered ${progress.deliveredCount}/${progress.expectedCount}, resolved ${progress.resolvedCount}/${progress.expectedCount}, waiting=${progress.waitingCount}, queued=${progress.queuedCount}, unmatched=${progress.unmatchedResultCount}${toolNameSummary.length ? `, tools=${toolNameSummary.join(", ")}` : ""}. Claude session will rebuild before the next turn; see ${diagLogPath()}.`,
@@ -44122,6 +44219,7 @@ function convertAndImportMessages(session, messages, customToolNameToSdk, cwd) {
     );
   }
   const missingToolResults = findUnpairedToolUses(anthropicMessages);
+  if (missingToolResults.length > 0) insertLostToolResultPlaceholders(anthropicMessages, missingToolResults);
   const repaired = repairToolPairing(anthropicMessages);
   if (missingToolResults.length > 0) {
     reportSyntheticToolResultRepair(missingToolResults, {
@@ -44464,12 +44562,75 @@ function finalizeCurrentStream(stopReason) {
   ctx().currentPiStream.end();
   ctx().currentPiStream = null;
 }
+var TOOL_USE_END_GRACE_MS = 1500;
+function endToolUseTurn(c) {
+  if (!c.currentPiStream || !c.turnOutput) return;
+  cancelScheduledToolUseEnd(c);
+  c.turnOutput.stopReason = "toolUse";
+  c.currentPiStream.push({ type: "done", reason: "toolUse", message: c.turnOutput });
+  c.currentPiStream.end();
+  c.currentPiStream = null;
+}
+function cancelScheduledToolUseEnd(c) {
+  if (!c.scheduledToolUseEnd) return;
+  clearTimeout(c.scheduledToolUseEnd.timer);
+  c.scheduledToolUseEnd = null;
+}
+function scheduleToolUseTurnEnd(c, action, source) {
+  if (!c.currentPiStream || !c.turnOutput) return;
+  if (c.scheduledToolUseEnd?.stream === c.currentPiStream) return;
+  cancelScheduledToolUseEnd(c);
+  const stream = c.currentPiStream;
+  const timer = setTimeout(() => {
+    if (c.currentPiStream !== stream) return;
+    debug(`scheduleToolUseTurnEnd: no terminal stream event within ${TOOL_USE_END_GRACE_MS}ms (${source}) \u2014 force-ending tool_use turn`);
+    c.scheduledToolUseEnd = null;
+    action();
+  }, TOOL_USE_END_GRACE_MS);
+  timer.unref?.();
+  c.scheduledToolUseEnd = { stream, timer };
+}
+function reapStaleQueuedResults(c) {
+  const stale = c.takeStaleQueuedResults();
+  if (stale.length === 0) return;
+  const names = stale.map((entry) => entry.toolName);
+  debug(`reapStaleQueuedResults: dropping ${stale.length} queued tool result(s) with no possible consumer:`, names.join(", "));
+  diagDump("stale_queued_tool_results_dropped", { count: stale.length, stale });
+  appendIntegrityEntry("stale_queued_tool_results_dropped", { count: stale.length, stale });
+  safeNotify(
+    `Claude bridge: dropped ${stale.length} tool result(s) whose handler never matched (${names.slice(0, 6).join(", ")}${names.length > 6 ? ", \u2026" : ""}). The model saw an error for these calls and may retry them.`,
+    "warning"
+  );
+}
 function updateTurnOutputModel(modelId) {
   const c = ctx();
   if (typeof modelId !== "string" || !modelId || !c.turnOutput) return;
   if (c.turnOutput.model === modelId) return;
   debug(`provider: active Claude model changed ${c.turnOutput.model} -> ${modelId}`);
   c.turnOutput.model = modelId;
+}
+function finalizeToolUseTurnFromMcpInvocation(queryCtx, toolCallId, toolName, mappedArgs) {
+  if (!queryCtx.currentPiStream || !queryCtx.turnOutput) return;
+  let idx = queryCtx.turnBlocks.findIndex((b) => b.type === "toolCall" && b.id === toolCallId);
+  if (idx >= 0) {
+    const block = queryCtx.turnBlocks[idx];
+    if ("partialJson" in block) {
+      block.arguments = mapToolArgs(block.name, parsePartialJson(block.partialJson, block.arguments));
+      queryCtx.updateToolCallArgs(block.id, block.arguments);
+      delete block.partialJson;
+      delete block.index;
+      queryCtx.currentPiStream.push({ type: "toolcall_end", contentIndex: idx, toolCall: block, partial: queryCtx.turnOutput });
+    }
+  } else {
+    queryCtx.turnBlocks.push({ type: "toolCall", id: toolCallId, name: toolName, arguments: mappedArgs });
+    idx = queryCtx.turnBlocks.length - 1;
+    const block = queryCtx.turnBlocks[idx];
+    queryCtx.currentPiStream.push({ type: "toolcall_start", contentIndex: idx, partial: queryCtx.turnOutput });
+    queryCtx.currentPiStream.push({ type: "toolcall_end", contentIndex: idx, toolCall: block, partial: queryCtx.turnOutput });
+  }
+  queryCtx.turnSawToolCall = true;
+  debug(`mcp handler: finalizing tool_use turn from MCP invocation [${toolCallId}] (${toolName}) \u2014 terminal stream events never arrived`);
+  endToolUseTurn(queryCtx);
 }
 function processStreamEvent(message, customToolNameToPi, model) {
   const c = ctx();
@@ -44481,6 +44642,7 @@ function processStreamEvent(message, customToolNameToPi, model) {
     return;
   }
   if (event?.type === "message_start") {
+    reapStaleQueuedResults(c);
     c.resetToolTracking();
     c.beginChildMessage(event.message?.id);
     updateTurnOutputModel(event.message?.model);
@@ -44584,10 +44746,7 @@ function processStreamEvent(message, customToolNameToPi, model) {
     return;
   }
   if (event?.type === "message_stop" && c.turnSawToolCall) {
-    c.turnOutput.stopReason = "toolUse";
-    c.currentPiStream.push({ type: "done", reason: "toolUse", message: c.turnOutput });
-    c.currentPiStream.end();
-    c.currentPiStream = null;
+    endToolUseTurn(c);
     return;
   }
   if (event?.type !== "message_stop" && event?.type !== "ping") {
@@ -44634,7 +44793,7 @@ function appendMissingToolUsesFromAssistant(assistantMsg, model, customToolNameT
     c.currentPiStream?.push({ type: "toolcall_start", contentIndex: idx, partial: c.turnOutput });
     c.currentPiStream?.push({ type: "toolcall_end", contentIndex: idx, toolCall: toolBlock, partial: c.turnOutput });
   }
-  if (assistantMsg.usage && c.turnOutput) updateUsage(c.turnOutput, assistantMsg.usage, model);
+  if (assistantMsg.usage && c.turnOutput && c.currentPiStream) updateUsage(c.turnOutput, assistantMsg.usage, model);
   return sawToolUse;
 }
 function noteChildExecutedToolResults(message) {
@@ -44660,16 +44819,11 @@ function processAssistantMessage(message, model, customToolNameToPi) {
   if (c.turnSawStreamEvent) {
     if (appendMissingToolUsesFromAssistant(assistantMsg, model, customToolNameToPi)) {
       c.turnSawToolCall = true;
-      if (c.currentPiStream && c.turnOutput) {
-        c.turnOutput.stopReason = "toolUse";
-        c.currentPiStream.push({ type: "done", reason: "toolUse", message: c.turnOutput });
-        c.currentPiStream.end();
-        c.currentPiStream = null;
-        debug("processAssistantMessage boundary: ended streamed tool_use turn from assistant message");
-      }
+      scheduleToolUseTurnEnd(c, () => endToolUseTurn(c), "assistant-boundary");
     }
     return;
   }
+  reapStaleQueuedResults(c);
   c.resetToolTracking();
   c.beginChildMessage(assistantMsg.id);
   debug(`processAssistantMessage fallback: ${assistantMsg.content.length} blocks, types=${assistantMsg.content.map((b) => b.type).join(",")}`);
@@ -44717,10 +44871,7 @@ function processAssistantMessage(message, model, customToolNameToPi) {
   }
   if (assistantMsg.usage && c.turnOutput) updateUsage(c.turnOutput, assistantMsg.usage, model);
   if (c.turnSawToolCall && c.currentPiStream && c.turnOutput) {
-    c.turnOutput.stopReason = "toolUse";
-    c.currentPiStream.push({ type: "done", reason: "toolUse", message: c.turnOutput });
-    c.currentPiStream.end();
-    c.currentPiStream = null;
+    endToolUseTurn(c);
   }
 }
 
@@ -44868,32 +45019,6 @@ function resolveMcpTools(context, excludeToolName) {
   }
   return { mcpTools, customToolNameToSdk, customToolNameToPi };
 }
-function finalizeToolUseTurnFromMcpInvocation(queryCtx, toolCallId, toolName, mappedArgs) {
-  if (!queryCtx.currentPiStream || !queryCtx.turnOutput) return;
-  let idx = queryCtx.turnBlocks.findIndex((b) => b.type === "toolCall" && b.id === toolCallId);
-  if (idx >= 0) {
-    const block = queryCtx.turnBlocks[idx];
-    if ("partialJson" in block) {
-      block.arguments = mapToolArgs(block.name, parsePartialJson(block.partialJson, block.arguments));
-      queryCtx.updateToolCallArgs(block.id, block.arguments);
-      delete block.partialJson;
-      delete block.index;
-      queryCtx.currentPiStream.push({ type: "toolcall_end", contentIndex: idx, toolCall: block, partial: queryCtx.turnOutput });
-    }
-  } else {
-    queryCtx.turnBlocks.push({ type: "toolCall", id: toolCallId, name: toolName, arguments: mappedArgs });
-    idx = queryCtx.turnBlocks.length - 1;
-    const block = queryCtx.turnBlocks[idx];
-    queryCtx.currentPiStream.push({ type: "toolcall_start", contentIndex: idx, partial: queryCtx.turnOutput });
-    queryCtx.currentPiStream.push({ type: "toolcall_end", contentIndex: idx, toolCall: block, partial: queryCtx.turnOutput });
-  }
-  queryCtx.turnSawToolCall = true;
-  queryCtx.turnOutput.stopReason = "toolUse";
-  debug(`mcp handler: finalizing tool_use turn from MCP invocation [${toolCallId}] (${toolName}) \u2014 SDK invoked the tool before message_stop/assistant message`);
-  queryCtx.currentPiStream.push({ type: "done", reason: "toolUse", message: queryCtx.turnOutput });
-  queryCtx.currentPiStream.end();
-  queryCtx.currentPiStream = null;
-}
 function buildMcpServers(tools, queryCtx) {
   if (!tools.length) return void 0;
   const mcpTools = tools.map((tool) => ({
@@ -44913,9 +45038,23 @@ function buildMcpServers(tools, queryCtx) {
           turnToolCallIds: queryCtx.turnToolCallIds,
           turnToolCalls: safeToolCallSummary(queryCtx.turnToolCalls)
         });
+        appendIntegrityEntry("tool_handler_unmatched", {
+          toolName: tool.name,
+          argKeys: argKeys(mappedArgs),
+          available: claim.available,
+          turnToolCallIds: queryCtx.turnToolCallIds
+        });
         return { content: [{ type: "text", text: `Claude bridge internal error: no matching tool_call id for ${tool.name}` }], isError: true };
       }
-      if (claim.match !== "tool-args" || claim.ambiguous) {
+      if (claim.argsMismatch) {
+        debug(`mcp handler: ${tool.name} [${toolCallId}] claimed sole same-name call despite args mismatch`);
+        diagDump("tool_claim_args_mismatch", {
+          toolName: tool.name,
+          toolCallId,
+          handlerArgKeys: argKeys(mappedArgs),
+          recordedArgKeys: argKeys(queryCtx.turnToolCalls.find((call) => call.id === toolCallId)?.arguments)
+        });
+      } else if (claim.match !== "tool-args" || claim.ambiguous) {
         debug(`mcp handler: ${tool.name} [${toolCallId}] claimed by ${claim.match}${claim.ambiguous ? " (ambiguous)" : ""}`);
       }
       if (toolCallId && queryCtx.pendingResults.has(toolCallId)) {
@@ -44926,7 +45065,11 @@ function buildMcpServers(tools, queryCtx) {
         return result;
       }
       debug(`mcp handler: ${tool.name} [${toolCallId}] \u2192 waiting`);
-      finalizeToolUseTurnFromMcpInvocation(queryCtx, toolCallId, tool.name, mappedArgs);
+      scheduleToolUseTurnEnd(
+        queryCtx,
+        () => finalizeToolUseTurnFromMcpInvocation(queryCtx, toolCallId, tool.name, mappedArgs),
+        `mcp-invocation:${tool.name}`
+      );
       return new Promise((resolve5) => {
         queryCtx.pendingToolCalls.set(toolCallId, {
           toolName: tool.name,
@@ -45661,11 +45804,14 @@ export {
   CONNECTOR_WRITE_TOOLS,
   DEFAULT_STREAM_IDLE_TIMEOUT_MS,
   DISALLOWED_BUILTIN_TOOLS,
+  INTEGRITY_CUSTOM_TYPE,
   STREAM_IDLE_BACKOFF_HINT_MS,
   STREAM_IDLE_TIMEOUT_ENV,
   __testGetBridgeIntegrityState,
   __testSetBridgeIntegrityState,
+  appendIntegrityEntry,
   buildStreamIdleTimeoutErrorMessage,
+  cancelScheduledToolUseEnd,
   classifyClaudeExecutableBytes,
   connectorCachePath,
   connectorCacheScopeKey,
@@ -45685,6 +45831,8 @@ export {
   createStreamIdleWatchdog,
   credentialCandidatePaths,
   index_default as default,
+  endToolUseTurn,
+  finalizeToolUseTurnFromMcpInvocation,
   flushConnectorCallAudit,
   formatAllowedRateLimitWarning,
   formatResetTimestamp,
@@ -45700,6 +45848,7 @@ export {
   processAssistantMessage,
   processStreamEvent,
   readCachedConnectors,
+  reapStaleQueuedResults,
   recordConnectorCallResult,
   reportToolResultMismatch,
   resolveClaudeExecutable,
@@ -45707,6 +45856,7 @@ export {
   resolveConfiguredEffort,
   resolveMcpTools,
   restoreSharedSessionFromPi,
+  scheduleToolUseTurnEnd,
   setConnectorCallAuditSink,
   shouldRestorePersistedBridgeEntry,
   spawnClaudeCodeWithDiagnostics,

--- a/pi-extensions/pi-claude-bridge/package.json
+++ b/pi-extensions/pi-claude-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vanillagreen/pi-claude-bridge",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "Pi provider bridge that runs Claude Code through the Claude Agent SDK, with opt-in forwarding for Pi prompt context.",
   "type": "module",
   "keywords": [

--- a/pi-extensions/pi-claude-bridge/src/assistant-stream.ts
+++ b/pi-extensions/pi-claude-bridge/src/assistant-stream.ts
@@ -1,9 +1,10 @@
 import { calculateCost, type AssistantMessage, type Model } from "@earendil-works/pi-ai";
 import { type SDKMessage } from "@anthropic-ai/claude-agent-sdk";
+import { appendIntegrityEntry, safeNotify } from "./bridge-state.js";
 import { connectorResultByteSize, recordConnectorCallResult } from "./connector-audit.js";
 import { isChildExecutedTool } from "./connectors.js";
-import { debug } from "./debug.js";
-import { ctx } from "./query-state.js";
+import { debug, diagDump } from "./debug.js";
+import { ctx, type QueryContext } from "./query-state.js";
 import { mapToolArgs, mapToolName } from "./tool-mapping.js";
 
 // --- Usage helpers ---
@@ -63,12 +64,140 @@ export function finalizeCurrentStream(stopReason?: string): void {
 	ctx().currentPiStream = null;
 }
 
+// --- Tool-use turn end: deferred to the stream's terminal events ---
+//
+// The Claude Code CLI dispatches MCP tool calls (and the SDK yields the
+// completed assistant message) BEFORE the stream's message_delta arrives — and
+// message_delta is what carries the message's REAL output-token count (measured:
+// handler invoked ~45ms before message_delta on every tool-use turn). Ending
+// the pi stream at either of those early signals therefore froze usage at the
+// message_start placeholder values, which is why pi sessions recorded 1–7
+// output tokens per tool-use turn while the final text turn recorded hundreds
+// (2026-07-28 token test, both bridge panes).
+//
+// So the turn now ends at message_stop, exactly like the streamed-text case,
+// and the early signals only ARM a grace timer. The timer is the deadlock
+// backstop for the one observed case where the terminal events never arrive
+// (pi 0.80 steer draining): pi cannot execute tools before the stream ends, and
+// the MCP handler cannot resolve before pi executes, so a stream that has gone
+// silent must be ended by force — just 1.5s later instead of immediately.
+
+const TOOL_USE_END_GRACE_MS = 1500;
+
+/** End the current pi stream as a tool_use turn boundary. Safe to call when the
+ *  turn already ended (no-op). */
+export function endToolUseTurn(c: QueryContext): void {
+	if (!c.currentPiStream || !c.turnOutput) return;
+	cancelScheduledToolUseEnd(c);
+	c.turnOutput.stopReason = "toolUse";
+	c.currentPiStream.push({ type: "done", reason: "toolUse", message: c.turnOutput });
+	c.currentPiStream.end();
+	c.currentPiStream = null;
+}
+
+export function cancelScheduledToolUseEnd(c: QueryContext): void {
+	if (!c.scheduledToolUseEnd) return;
+	clearTimeout(c.scheduledToolUseEnd.timer);
+	c.scheduledToolUseEnd = null;
+}
+
+/**
+ * Arm the grace timer that force-ends the current tool_use turn if the stream's
+ * terminal events never arrive. First arming per stream wins; message_stop (or
+ * resetTurnState) disarms it. `action` runs only if the SAME stream is still
+ * current when the grace elapses — a turn that ended normally makes it a no-op.
+ */
+export function scheduleToolUseTurnEnd(c: QueryContext, action: () => void, source: string): void {
+	if (!c.currentPiStream || !c.turnOutput) return;
+	if (c.scheduledToolUseEnd?.stream === c.currentPiStream) return;
+	cancelScheduledToolUseEnd(c);
+	const stream = c.currentPiStream;
+	const timer = setTimeout(() => {
+		if (c.currentPiStream !== stream) return;
+		debug(`scheduleToolUseTurnEnd: no terminal stream event within ${TOOL_USE_END_GRACE_MS}ms (${source}) — force-ending tool_use turn`);
+		c.scheduledToolUseEnd = null;
+		action();
+	}, TOOL_USE_END_GRACE_MS);
+	timer.unref?.();
+	c.scheduledToolUseEnd = { stream, timer };
+}
+
+/**
+ * Drop queued tool results that no handler can ever consume again, and say so
+ * everywhere it matters. Runs at a child message boundary — by then every
+ * handler for the previous message has either resolved (directly or from this
+ * queue) or already returned an error, so anything still queued is the real
+ * output of a call whose handler gave up. See takeStaleQueuedResults for why
+ * leaving them queued poisoned every later mismatch report and forced a
+ * session rebuild per turn.
+ */
+export function reapStaleQueuedResults(c: QueryContext): void {
+	const stale = c.takeStaleQueuedResults();
+	if (stale.length === 0) return;
+	const names = stale.map((entry) => entry.toolName);
+	debug(`reapStaleQueuedResults: dropping ${stale.length} queued tool result(s) with no possible consumer:`, names.join(", "));
+	diagDump("stale_queued_tool_results_dropped", { count: stale.length, stale });
+	appendIntegrityEntry("stale_queued_tool_results_dropped", { count: stale.length, stale });
+	safeNotify(
+		`Claude bridge: dropped ${stale.length} tool result(s) whose handler never matched (${names.slice(0, 6).join(", ")}${names.length > 6 ? ", …" : ""}). ` +
+		`The model saw an error for these calls and may retry them.`,
+		"warning",
+	);
+}
+
 export function updateTurnOutputModel(modelId: unknown): void {
 	const c = ctx();
 	if (typeof modelId !== "string" || !modelId || !c.turnOutput) return;
 	if (c.turnOutput.model === modelId) return;
 	debug(`provider: active Claude model changed ${c.turnOutput.model} -> ${modelId}`);
 	c.turnOutput.model = modelId;
+}
+
+/** Force-finalizes the current pi turn as a tool_use boundary when its terminal
+ *  stream events never arrived (the grace-timer action armed by an MCP handler
+ *  invocation — see scheduleToolUseTurnEnd).
+ *
+ *  Observed with Claude Code under pi 0.80's steer draining (tool result and
+ *  drained steer arrive in one provider call): the NEXT tool turn's tool_use
+ *  streams in, the SDK invokes the MCP handler — and neither terminal event
+ *  ever arrives. The invocation itself proves the assistant turn is committed,
+ *  so end the pi stream here exactly like the `message_stop` path; otherwise
+ *  the handler blocks on a result pi will never deliver (deadlock). No-op when
+ *  the turn already ended (stream null) or the tool call isn't part of the
+ *  currently streamed turn. */
+export function finalizeToolUseTurnFromMcpInvocation(
+	queryCtx: QueryContext,
+	toolCallId: string,
+	toolName: string,
+	mappedArgs: Record<string, unknown>,
+): void {
+	if (!queryCtx.currentPiStream || !queryCtx.turnOutput) return;
+	let idx = queryCtx.turnBlocks.findIndex((b: any) => b.type === "toolCall" && b.id === toolCallId);
+	if (idx >= 0) {
+		const block = queryCtx.turnBlocks[idx] as any;
+		if ("partialJson" in block) {
+			// Stream ended before content_block_stop — settle the args from the
+			// partial JSON the same way content_block_stop would have.
+			block.arguments = mapToolArgs(block.name, parsePartialJson(block.partialJson, block.arguments));
+			queryCtx.updateToolCallArgs(block.id, block.arguments);
+			delete block.partialJson;
+			delete block.index;
+			queryCtx.currentPiStream.push({ type: "toolcall_end", contentIndex: idx, toolCall: block, partial: queryCtx.turnOutput });
+		}
+	} else {
+		// The invocation can arrive before the tool_use is streamed at all
+		// (observed after a tool-result+steer provider call reset the turn):
+		// synthesize the toolCall from the claim — the MCP call carries the
+		// authoritative id, name, and arguments.
+		queryCtx.turnBlocks.push({ type: "toolCall", id: toolCallId, name: toolName, arguments: mappedArgs });
+		idx = queryCtx.turnBlocks.length - 1;
+		const block = queryCtx.turnBlocks[idx] as any;
+		queryCtx.currentPiStream.push({ type: "toolcall_start", contentIndex: idx, partial: queryCtx.turnOutput });
+		queryCtx.currentPiStream.push({ type: "toolcall_end", contentIndex: idx, toolCall: block, partial: queryCtx.turnOutput });
+	}
+	queryCtx.turnSawToolCall = true;
+	debug(`mcp handler: finalizing tool_use turn from MCP invocation [${toolCallId}] (${toolName}) — terminal stream events never arrived`);
+	endToolUseTurn(queryCtx);
 }
 
 /** Maps Anthropic stream events to pi stream events (text, thinking, toolcall).
@@ -88,6 +217,9 @@ export function processStreamEvent(
 	}
 
 	if (event?.type === "message_start") {
+		// The child moving to a new message proves every result for the previous
+		// one reached it; anything still queued can never be consumed.
+		reapStaleQueuedResults(c);
 		c.resetToolTracking();
 		// A new child message begins: bank what the previous one billed before its
 		// counters are replaced. No-op on the turn's first, and no-op if this same
@@ -208,14 +340,13 @@ export function processStreamEvent(
 	}
 
 	if (event?.type === "message_stop" && c.turnSawToolCall) {
-		// Tool call complete — end this pi stream. The SDK will still yield an
-		// assistant message for this turn, but currentPiStream=null causes
-		// consumeQuery to skip it. The MCP handler blocks the generator until
-		// pi delivers the tool result via the next streamSimple call.
-		c.turnOutput.stopReason = "toolUse";
-		c.currentPiStream!.push({ type: "done", reason: "toolUse", message: c.turnOutput });
-		c.currentPiStream!.end();
-		c.currentPiStream = null;
+		// Tool call complete — end this pi stream, disarming any grace timer the
+		// MCP-invocation or assistant-boundary path armed. This is the NORMAL end
+		// for a tool-use turn: message_delta already delivered the message's real
+		// usage just above, so the done event carries correct output tokens. The
+		// MCP handler blocks the generator until pi delivers the tool result via
+		// the next streamSimple call.
+		endToolUseTurn(c);
 
 		// Cursor is updated by the next streamSimple call (tool result delivery path)
 		// which sets cursor = context.messages.length with the post-tool-result context.
@@ -280,7 +411,11 @@ function appendMissingToolUsesFromAssistant(
 		c.currentPiStream?.push({ type: "toolcall_start", contentIndex: idx, partial: c.turnOutput });
 		c.currentPiStream?.push({ type: "toolcall_end", contentIndex: idx, toolCall: toolBlock as any, partial: c.turnOutput });
 	}
-	if (assistantMsg.usage && c.turnOutput) updateUsage(c.turnOutput, assistantMsg.usage, model);
+	// Only while the stream is still live: the SDK's assistant yields carry the
+	// message_start placeholder usage (output ≈ 1–7), and once the done event has
+	// delivered turnOutput to pi, overwriting its usage with those placeholders
+	// would corrupt the very figure message_delta got right.
+	if (assistantMsg.usage && c.turnOutput && c.currentPiStream) updateUsage(c.turnOutput, assistantMsg.usage, model);
 	return sawToolUse;
 }
 
@@ -325,24 +460,22 @@ export function processAssistantMessage(message: SDKMessage, model: Model<any>, 
 	if (!assistantMsg?.content) return;
 	updateTurnOutputModel(assistantMsg.model);
 	if (c.turnSawStreamEvent) {
-		// Claude Agent SDK can yield the completed assistant message before (or
-		// instead of) a stream_event message_stop for a tool-use turn. Treat that
-		// assistant message as a hard turn boundary so Pi executes the tool calls
-		// and the MCP handlers stay blocked until real tool results are delivered.
-		// Without this fallback, Claude Code can continue internally with empty MCP
-		// results and Pi only sees the real outputs one render cycle later.
+		// The SDK yields the completed assistant message BEFORE the stream's
+		// message_delta/message_stop on every tool-use turn (measured — this is
+		// the norm, not a fallback). Record any tool_use blocks the stream hasn't
+		// delivered yet, but do NOT end the pi stream here: message_delta, which
+		// arrives tens of ms later, carries the message's real output-token count,
+		// and message_stop is the normal turn end. Ending here froze usage at the
+		// message_start placeholders (1–7 output tokens per tool turn). The grace
+		// timer force-ends the turn if the terminal events never arrive, so pi
+		// still gets to execute the tools and unblock the MCP handlers.
 		if (appendMissingToolUsesFromAssistant(assistantMsg, model, customToolNameToPi)) {
 			c.turnSawToolCall = true;
-			if (c.currentPiStream && c.turnOutput) {
-				c.turnOutput.stopReason = "toolUse";
-				c.currentPiStream.push({ type: "done", reason: "toolUse", message: c.turnOutput });
-				c.currentPiStream.end();
-				c.currentPiStream = null;
-				debug("processAssistantMessage boundary: ended streamed tool_use turn from assistant message");
-			}
+			scheduleToolUseTurnEnd(c, () => endToolUseTurn(c), "assistant-boundary");
 		}
 		return;
 	}
+	reapStaleQueuedResults(c);
 	c.resetToolTracking();
 	// The no-stream-events path also sees a message boundary. It is keyed on the
 	// message ID rather than trusted blindly, because this branch is ALSO reached
@@ -395,11 +528,11 @@ export function processAssistantMessage(message: SDKMessage, model: Model<any>, 
 	}
 	if (assistantMsg.usage && c.turnOutput) updateUsage(c.turnOutput, assistantMsg.usage, model);
 
-	// End the stream on tool_use, same as processStreamEvent's message_stop handler.
+	// End the stream on tool_use. Immediate (no grace deferral) ON PURPOSE: this
+	// branch only runs when NO content blocks streamed for the message, so there
+	// is no reason to expect terminal stream events either, and the completed
+	// message's own usage — applied just above — is the best figure available.
 	if (c.turnSawToolCall && c.currentPiStream && c.turnOutput) {
-		c.turnOutput.stopReason = "toolUse";
-		c.currentPiStream.push({ type: "done", reason: "toolUse", message: c.turnOutput });
-		c.currentPiStream.end();
-		c.currentPiStream = null;
+		endToolUseTurn(c);
 	}
 }

--- a/pi-extensions/pi-claude-bridge/src/bridge-state.ts
+++ b/pi-extensions/pi-claude-bridge/src/bridge-state.ts
@@ -56,6 +56,33 @@ export function safeToolCallSummary(calls: Array<{ id: string; toolName: string;
 	return calls.map((call) => ({ id: call.id, toolName: call.toolName, argKeys: argKeys(call.arguments) }));
 }
 
+export const INTEGRITY_CUSTOM_TYPE = "claude-bridge-integrity";
+
+/**
+ * Persist a bridge integrity event into the pi session transcript.
+ *
+ * The diag log and a piUI toast both die with the machine or the render cycle:
+ * the 2026-07-28 post-mortem found `Error: Claude bridge: …` messages that were
+ * SHOWN but existed nowhere in the pi session file, making analysis from the
+ * session alone impossible. A `CustomEntry` closes that gap the same way the
+ * connector-call audit does — persisted, never part of built context, never
+ * dispatchable by pi's agent loop. Payloads must stay compact metadata (ids,
+ * counts, tool names), never tool output.
+ *
+ * Never throws; returns whether the entry was appended (false outside a pi
+ * session — tests, embedded hosts without extensionApi).
+ */
+export function appendIntegrityEntry(label: string, data: Record<string, unknown>): boolean {
+	try {
+		if (!extensionApi) return false;
+		extensionApi.appendEntry(INTEGRITY_CUSTOM_TYPE, { label, at: new Date().toISOString(), ...data });
+		return true;
+	} catch (error) {
+		debug("appendIntegrityEntry failed:", error);
+		return false;
+	}
+}
+
 function compactToolNameSummary(names: Array<{ name: string; count: number }>, limit = 12): string[] {
 	const shown = names.slice(0, limit).map(({ name, count }) => count > 1 ? `${name}×${count}` : name);
 	if (names.length > limit) shown.push(`+${names.length - limit} more`);
@@ -75,8 +102,13 @@ export function reportSyntheticToolResultRepair(missing: MissingToolResult[], co
 			missing: missing.slice(0, 50),
 			...context,
 		});
+		appendIntegrityEntry("repair_tool_pairing_synthetic_results", {
+			count: missing.length,
+			toolNames,
+			sampledToolCallIds: sampledToolCallIds.slice(0, 12),
+		});
 		safeNotify(
-			`Claude bridge: ${missing.length} missing tool result(s) repaired with "[no tool result recorded]"` +
+			`Claude bridge: ${missing.length} missing tool result(s) repaired with an explicit error placeholder` +
 			`${toolNameSummary.length ? ` for ${toolNameSummary.join(", ")}` : ""}. ` +
 			`Real tool output was lost before Claude session import; see ${diagLogPath()}.`,
 			"error",
@@ -110,6 +142,16 @@ export function reportToolResultMismatch(queryCtx: QueryContext, reason: string,
 				needsRebuild: sharedSession.needsRebuild === true,
 				forceRotate: sharedSession.forceRotate === true,
 			} : null,
+		});
+		appendIntegrityEntry("tool_result_delivery_mismatch", {
+			reason,
+			toolNames: progress.toolNames,
+			expectedCount: progress.expectedCount,
+			deliveredCount: progress.deliveredCount,
+			resolvedCount: progress.resolvedCount,
+			waitingIds: progress.waitingIds,
+			queuedIds: progress.queuedIds,
+			unmatchedResultIds: progress.unmatchedResultIds,
 		});
 		safeNotify(
 			`Claude bridge: tool result delivery interrupted during ${reason}; ` +

--- a/pi-extensions/pi-claude-bridge/src/index.ts
+++ b/pi-extensions/pi-claude-bridge/src/index.ts
@@ -39,7 +39,7 @@ export {
 export { connectorCachePath, connectorCacheScopeKey, readCachedConnectors, writeCachedConnectors } from "./connector-cache.js";
 import { debug, diagDump, makeCliDebugOptions, moduleInstanceId } from "./debug.js";
 import { preflightClaudeExecutable, resolveClaudeExecutable, spawnClaudeCodeWithDiagnostics } from "./claude-executable.js";
-import { argKeys, extensionApi, piUI, reportToolResultMismatch, safeNotify, safeToolCallSummary, setExtensionApi, setPiUI, setSharedSession, sharedSession } from "./bridge-state.js";
+import { appendIntegrityEntry, argKeys, extensionApi, piUI, reportToolResultMismatch, safeNotify, safeToolCallSummary, setExtensionApi, setPiUI, setSharedSession, sharedSession } from "./bridge-state.js";
 import { connectorMcpServers, connectorQueryOptions, connectorWriteModeFor, connectorsEnabledFor, isChildExecutedTool } from "./connectors.js";
 import { flushConnectorCallAudit } from "./connector-audit.js";
 import { readCachedConnectors, writeCachedConnectors } from "./connector-cache.js";
@@ -47,20 +47,20 @@ import { restoreSharedSessionFromPi, schedulePersistSharedSession, syncSharedSes
 import { STREAM_IDLE_BACKOFF_HINT_MS, activeStreamIdleWatchdogs, buildStreamIdleTimeoutErrorMessage, createStreamIdleWatchdog, formatDurationShort, streamIdleTimeoutMsFromEnv } from "./stream-idle-watchdog.js";
 import { RATE_LIMIT_AUTO_RESUME_EVENT, RATE_LIMIT_TOKEN, formatAllowedRateLimitWarning, formatResetTimestamp, isExtraUsageRequiredMessage, uniqueNonEmptyLines } from "./rate-limit.js";
 import { mapToolArgs } from "./tool-mapping.js";
-import { ensureTurnStarted, finalizeCurrentStream, noteChildExecutedToolResults, parsePartialJson, processAssistantMessage, processStreamEvent, updateTurnOutputModel } from "./assistant-stream.js";
+import { ensureTurnStarted, finalizeCurrentStream, finalizeToolUseTurnFromMcpInvocation, noteChildExecutedToolResults, processAssistantMessage, processStreamEvent, scheduleToolUseTurnEnd, updateTurnOutputModel } from "./assistant-stream.js";
 
 // Re-exports: the module decomposition must not change the bundle entry's
 // public surface — unit tests and downstream consumers import these from
 // bundle/index.js.
 export { classifyClaudeExecutableBytes, preflightClaudeExecutable, resolveClaudeExecutable, spawnClaudeCodeWithDiagnostics, wrapClaudeSpawnErrorForSdk, type ClaudeExecutableFileType, type ClaudeExecutablePreflightResult } from "./claude-executable.js";
-export { __testGetBridgeIntegrityState, __testSetBridgeIntegrityState, reportToolResultMismatch } from "./bridge-state.js";
+export { __testGetBridgeIntegrityState, __testSetBridgeIntegrityState, INTEGRITY_CUSTOM_TYPE, appendIntegrityEntry, reportToolResultMismatch } from "./bridge-state.js";
 export { CONNECTOR_CALL_CUSTOM_TYPE, connectorResultByteSize, flushConnectorCallAudit, recordConnectorCallResult, setConnectorCallAuditSink, type ConnectorCallAuditData, type ConnectorCallAuditSink, type ConnectorCallOutcome } from "./connector-audit.js";
 export { CLAUDE_AI_CONNECTOR_TOOL_PATTERNS, connectorMcpServers, connectorDeclarationsDisabled, CLAUDE_BRIDGE_TOOL_ISOLATION, CONNECTOR_DISCOVERY_TOOLS, CONNECTOR_WRITE_TOOLS, DISALLOWED_BUILTIN_TOOLS, connectorQueryOptions, connectorWriteDenyHook, connectorWriteModeFor, connectorWriteModeFromEnv, connectorsEnabledFor, connectorsEnabledFromEnv, isChildExecutedTool, isConnectorWriteTool, toolIsolationForQuery } from "./connectors.js";
 export { restoreSharedSessionFromPi, shouldRestorePersistedBridgeEntry } from "./session-persistence.js";
 export { DEFAULT_STREAM_IDLE_TIMEOUT_MS, STREAM_IDLE_BACKOFF_HINT_MS, STREAM_IDLE_TIMEOUT_ENV, buildStreamIdleTimeoutErrorMessage, createStreamIdleWatchdog, streamIdleTimeoutMsFromEnv, type StreamIdleTimeoutInfo, type StreamIdleWatchdog, type StreamIdleWatchdogState } from "./stream-idle-watchdog.js";
 export { ALLOWED_RATE_LIMIT_WARNING_UTILIZATION_THRESHOLD, formatAllowedRateLimitWarning, formatResetTimestamp, isExtraUsageRequiredMessage, normalizeRateLimitUtilization, uniqueNonEmptyLines } from "./rate-limit.js";
 export { mapToolName } from "./tool-mapping.js";
-export { noteChildExecutedToolResults, processAssistantMessage, processStreamEvent } from "./assistant-stream.js";
+export { cancelScheduledToolUseEnd, endToolUseTurn, finalizeToolUseTurnFromMcpInvocation, noteChildExecutedToolResults, processAssistantMessage, processStreamEvent, reapStaleQueuedResults, scheduleToolUseTurnEnd } from "./assistant-stream.js";
 
 // Compat (#2): use factory if available (pi-ai ≥0.66), else fall back to constructor (gsd-pi etc.)
 const _piAi = piAi as any;
@@ -285,54 +285,12 @@ export function resolveMcpTools(context: Context, excludeToolName?: string): {
 	return { mcpTools, customToolNameToSdk, customToolNameToPi };
 }
 
-/** Finalizes the current pi turn when the SDK invokes an MCP tool handler
- *  before emitting `message_stop` or the completed assistant message.
- *
- *  Observed with Claude Code under pi 0.80's steer draining (tool result and
- *  drained steer arrive in one provider call): the NEXT tool turn's tool_use
- *  streams in, the SDK invokes the MCP handler — and neither terminal event
- *  ever arrives. The invocation itself proves the assistant turn is committed,
- *  so end the pi stream here exactly like the `message_stop` path; otherwise
- *  the handler blocks on a result pi will never deliver (deadlock). No-op when
- *  the turn already ended (stream null) or the tool call isn't part of the
- *  currently streamed turn. */
-function finalizeToolUseTurnFromMcpInvocation(
-	queryCtx: QueryContext,
-	toolCallId: string,
-	toolName: string,
-	mappedArgs: Record<string, unknown>,
-): void {
-	if (!queryCtx.currentPiStream || !queryCtx.turnOutput) return;
-	let idx = queryCtx.turnBlocks.findIndex((b: any) => b.type === "toolCall" && b.id === toolCallId);
-	if (idx >= 0) {
-		const block = queryCtx.turnBlocks[idx] as any;
-		if ("partialJson" in block) {
-			// Stream ended before content_block_stop — settle the args from the
-			// partial JSON the same way content_block_stop would have.
-			block.arguments = mapToolArgs(block.name, parsePartialJson(block.partialJson, block.arguments));
-			queryCtx.updateToolCallArgs(block.id, block.arguments);
-			delete block.partialJson;
-			delete block.index;
-			queryCtx.currentPiStream.push({ type: "toolcall_end", contentIndex: idx, toolCall: block, partial: queryCtx.turnOutput });
-		}
-	} else {
-		// The invocation can arrive before the tool_use is streamed at all
-		// (observed after a tool-result+steer provider call reset the turn):
-		// synthesize the toolCall from the claim — the MCP call carries the
-		// authoritative id, name, and arguments.
-		queryCtx.turnBlocks.push({ type: "toolCall", id: toolCallId, name: toolName, arguments: mappedArgs });
-		idx = queryCtx.turnBlocks.length - 1;
-		const block = queryCtx.turnBlocks[idx] as any;
-		queryCtx.currentPiStream.push({ type: "toolcall_start", contentIndex: idx, partial: queryCtx.turnOutput });
-		queryCtx.currentPiStream.push({ type: "toolcall_end", contentIndex: idx, toolCall: block, partial: queryCtx.turnOutput });
-	}
-	queryCtx.turnSawToolCall = true;
-	queryCtx.turnOutput.stopReason = "toolUse";
-	debug(`mcp handler: finalizing tool_use turn from MCP invocation [${toolCallId}] (${toolName}) — SDK invoked the tool before message_stop/assistant message`);
-	queryCtx.currentPiStream.push({ type: "done", reason: "toolUse", message: queryCtx.turnOutput });
-	queryCtx.currentPiStream.end();
-	queryCtx.currentPiStream = null;
-}
+// finalizeToolUseTurnFromMcpInvocation moved to assistant-stream.ts: it is now
+// the grace-timer ACTION armed by scheduleToolUseTurnEnd rather than an
+// immediate end. The CLI invokes MCP handlers before message_delta arrives on
+// every tool-use turn, and message_delta is what carries the real output-token
+// count — ending the pi stream at handler invocation is what froze pi's
+// per-turn output figures at the message_start placeholders (1–7 tokens).
 
 // Creates an MCP server that bridges pi tools to the SDK. Each tool handler
 // blocks on a Promise until pi delivers the tool result via streamSimple.
@@ -359,9 +317,25 @@ function buildMcpServers(tools: Tool[], queryCtx: QueryContext): Record<string, 
 					turnToolCallIds: queryCtx.turnToolCallIds,
 					turnToolCalls: safeToolCallSummary(queryCtx.turnToolCalls),
 				});
+				appendIntegrityEntry("tool_handler_unmatched", {
+					toolName: tool.name,
+					argKeys: argKeys(mappedArgs),
+					available: claim.available,
+					turnToolCallIds: queryCtx.turnToolCallIds,
+				});
 				return { content: [{ type: "text", text: `Claude bridge internal error: no matching tool_call id for ${tool.name}` }], isError: true } satisfies McpResult;
 			}
-			if (claim.match !== "tool-args" || claim.ambiguous) {
+			if (claim.argsMismatch) {
+				// Claimed anyway (sole same-name candidate) — record the divergence so
+				// a schema/validator drift stays visible without stranding the call.
+				debug(`mcp handler: ${tool.name} [${toolCallId}] claimed sole same-name call despite args mismatch`);
+				diagDump("tool_claim_args_mismatch", {
+					toolName: tool.name,
+					toolCallId,
+					handlerArgKeys: argKeys(mappedArgs),
+					recordedArgKeys: argKeys(queryCtx.turnToolCalls.find((call) => call.id === toolCallId)?.arguments),
+				});
+			} else if (claim.match !== "tool-args" || claim.ambiguous) {
 				debug(`mcp handler: ${tool.name} [${toolCallId}] claimed by ${claim.match}${claim.ambiguous ? " (ambiguous)" : ""}`);
 			}
 			if (toolCallId && queryCtx.pendingResults.has(toolCallId)) {
@@ -372,7 +346,14 @@ function buildMcpServers(tools: Tool[], queryCtx: QueryContext): Record<string, 
 				return result;
 			}
 			debug(`mcp handler: ${tool.name} [${toolCallId}] → waiting`);
-			finalizeToolUseTurnFromMcpInvocation(queryCtx, toolCallId, tool.name, mappedArgs);
+			// Don't end the pi turn here — message_delta (real output tokens) and
+			// message_stop are normally milliseconds behind this invocation. Arm the
+			// grace timer instead; it force-finalizes only if they never arrive.
+			scheduleToolUseTurnEnd(
+				queryCtx,
+				() => finalizeToolUseTurnFromMcpInvocation(queryCtx, toolCallId, tool.name, mappedArgs),
+				`mcp-invocation:${tool.name}`,
+			);
 			return new Promise<McpResult>((resolve) => {
 				queryCtx.pendingToolCalls.set(toolCallId, {
 					toolName: tool.name,

--- a/pi-extensions/pi-claude-bridge/src/query-state.ts
+++ b/pi-extensions/pi-claude-bridge/src/query-state.ts
@@ -79,6 +79,12 @@ export interface ClaimedToolCall {
 	match: "tool-args" | "tool-name" | "none";
 	ambiguous: boolean;
 	available: number;
+	/** True when the claim went through the sole-same-name fallback even though
+	 *  the recorded call had (different) arguments. Recorded args come from the
+	 *  raw streamed input while the handler receives the MCP server's
+	 *  schema-validated copy, so a benign divergence (stripped unknown key,
+	 *  applied default) must not strand the call — but it is worth a diagnostic. */
+	argsMismatch?: boolean;
 }
 
 export interface ToolResultProgress {
@@ -144,6 +150,16 @@ export class QueryContext {
 	pendingResults = new Map<string, McpResult>();
 	turnToolCallIds: string[] = [];
 	turnToolCalls: TurnToolCallRecord[] = [];
+	/**
+	 * id → Pi tool name for every tool call this QUERY recorded, across all child
+	 * messages. Deliberately NOT cleared by resetToolTracking: per-message tracking
+	 * resets at every message boundary, but `pendingResults` is query-scoped, so a
+	 * result stranded there outlives the message that named it. Without this map a
+	 * teardown report can only say "1 queued" with empty toolNames and 0/0
+	 * counters — which is exactly the unactionable record the 2026-07-28 diag log
+	 * showed. Bounded by the number of tool calls in one query.
+	 */
+	queryToolNames = new Map<string, string>();
 	claimedToolCallIds = new Set<string>();
 	deliveredToolResultIds = new Set<string>();
 	resolvedToolResultIds = new Set<string>();
@@ -151,6 +167,12 @@ export class QueryContext {
 	reportedToolResultMismatch = false;
 	deferredUserMessages: string[] = [];
 	handledTerminalError = false;
+	/** Armed grace timer for ending a tool_use turn whose terminal stream events
+	 *  (message_delta/message_stop) never arrive. The normal path ends the turn at
+	 *  message_stop, AFTER message_delta delivered the real output-token count;
+	 *  this is the deadlock backstop for streams that go silent instead. Managed
+	 *  by schedule/cancelToolUseTurnEnd in assistant-stream.ts. */
+	scheduledToolUseEnd: { stream: unknown; timer: ReturnType<typeof setTimeout> } | null = null;
 
 	// Tool calls the CHILD executes itself (claude.ai connectors — see
 	// isChildExecutedTool). Deliberately NOT in turnToolCalls/turnToolCallIds:
@@ -246,6 +268,12 @@ export class QueryContext {
 		this.turnSawStreamEvent = false;
 		this.turnSawToolCall = false;
 		this.handledTerminalError = false;
+		// A new pi message means the previous turn's stream is done with; an armed
+		// end-timer for it must not fire into the new turn's state.
+		if (this.scheduledToolUseEnd) {
+			clearTimeout(this.scheduledToolUseEnd.timer);
+			this.scheduledToolUseEnd = null;
+		}
 		// Usage accounting IS per-Pi-message, so it resets with the message it
 		// describes — unlike tool-call tracking below.
 		this.turnUsageCarry = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
@@ -289,6 +317,7 @@ export class QueryContext {
 
 	recordToolCall(id: string | undefined, toolName: string, args: Record<string, unknown> = {}): void {
 		if (!id) return;
+		this.queryToolNames.set(id, toolName);
 		if (!this.turnToolCallIds.includes(id)) this.turnToolCallIds.push(id);
 		const existing = this.turnToolCalls.find((call) => call.id === id);
 		if (existing) {
@@ -317,22 +346,57 @@ export class QueryContext {
 		let match: ClaimedToolCall["match"] = "none";
 		let ambiguous = false;
 
+		let argsMismatch = false;
 		if (exact.length > 0) {
 			chosen = exact[0];
 			match = "tool-args";
 			ambiguous = exact.length > 1;
-		} else if (byName.length === 1 && !hasRecordedArgs(byName[0].arguments)) {
-			// The SDK can invoke the MCP handler after content_block_start but
-			// before input_json_delta/content_block_stop finalizes arguments.
-			// Falling back to the sole same-name, argument-less call preserves that
-			// race without ever claiming a different tool type.
+		} else if (byName.length === 1) {
+			// A single unclaimed call of this tool type is the only call this
+			// handler can possibly belong to, so claim it even when the recorded
+			// arguments differ. Two known benign sources of divergence:
+			//   - the SDK can invoke the handler after content_block_start but
+			//     before input_json_delta/content_block_stop finalizes arguments,
+			//     so the record still holds a partial parse;
+			//   - the handler receives the MCP server's schema-VALIDATED copy of
+			//     the input (zod may strip unknown keys or apply defaults) while
+			//     the record holds the raw streamed input.
+			// Refusing here stranded the call outright: the handler errored into
+			// the child while pi's real result sat queued forever (diag log
+			// 2026-07-28, `edit` with argKeys [edits, path] on both sides). A
+			// same-type sole-candidate claim is strictly safer than that. With
+			// SEVERAL same-name candidates and no exact match we still refuse —
+			// cross-pairing two live calls is the one outcome worse than failing.
 			chosen = byName[0];
 			match = "tool-name";
+			argsMismatch = hasRecordedArgs(byName[0].arguments);
 		}
 
 		if (!chosen) return { match: "none", ambiguous: false, available: unclaimed.length };
 		this.claimedToolCallIds.add(chosen.id);
-		return { toolCallId: chosen.id, match, ambiguous, available: unclaimed.length };
+		return { toolCallId: chosen.id, match, ambiguous, available: unclaimed.length, ...(argsMismatch ? { argsMismatch } : {}) };
+	}
+
+	/**
+	 * Drain results still queued in `pendingResults` and report what was dropped.
+	 *
+	 * Called at a child MESSAGE boundary (message_start / the no-stream-events
+	 * assistant fallback): by then the child has necessarily received every tool
+	 * result for the previous message — a handler that matched resolved its result
+	 * directly or from this queue, and one that never matched already returned an
+	 * error. Whatever is still queued therefore belongs to a call whose handler
+	 * gave up, and no consumer will ever come for it. Left in place, each entry
+	 * poisons every later mismatch report for the whole query (queued>0 with 0/0
+	 * counters and no tool names) and forces a session rebuild per turn.
+	 */
+	takeStaleQueuedResults(): Array<{ id: string; toolName: string }> {
+		if (this.pendingResults.size === 0) return [];
+		const stale = [...this.pendingResults.keys()].map((id) => ({
+			id,
+			toolName: this.queryToolNames.get(id) ?? "unknown",
+		}));
+		this.pendingResults.clear();
+		return stale;
 	}
 
 	markToolResultDelivered(id: string | undefined): void {
@@ -361,9 +425,21 @@ export class QueryContext {
 		const unresolvedIds = expectedIds.filter((id) => !this.resolvedToolResultIds.has(id));
 		const affectedIds = new Set([...missingDeliveredIds, ...unresolvedIds, ...waitingIds, ...queuedIds, ...unmatchedResultIds]);
 		const counts = new Map<string, number>();
-		for (const call of this.turnToolCalls) {
-			if (affectedIds.size > 0 && !affectedIds.has(call.id)) continue;
-			counts.set(call.toolName, (counts.get(call.toolName) ?? 0) + 1);
+		if (affectedIds.size > 0) {
+			// Name the affected ids from the query-scoped map, not just this
+			// message's records: a queued straggler from an earlier child message is
+			// exactly the case a mismatch report exists for, and this message's
+			// turnToolCalls no longer knows it.
+			for (const id of affectedIds) {
+				const name = this.queryToolNames.get(id)
+					?? this.turnToolCalls.find((call) => call.id === id)?.toolName
+					?? "unknown";
+				counts.set(name, (counts.get(name) ?? 0) + 1);
+			}
+		} else {
+			for (const call of this.turnToolCalls) {
+				counts.set(call.toolName, (counts.get(call.toolName) ?? 0) + 1);
+			}
 		}
 		return {
 			expectedIds,

--- a/pi-extensions/pi-claude-bridge/src/session-persistence.ts
+++ b/pi-extensions/pi-claude-bridge/src/session-persistence.ts
@@ -7,7 +7,7 @@ import { extensionApi, piUI, reportSyntheticToolResultRepair, setSharedSession, 
 import { convertPiMessages } from "./convert.js";
 import { DEBUG, DEBUG_LOG_PATH, debug, diagDump } from "./debug.js";
 import { verifyWrittenSession as _verifyWrittenSession } from "./session-verify.js";
-import { findUnpairedToolUses } from "./tool-pairing-audit.js";
+import { findUnpairedToolUses, insertLostToolResultPlaceholders } from "./tool-pairing-audit.js";
 
 // --- Session persistence ---
 
@@ -167,8 +167,13 @@ function convertAndImportMessages(
 		debug(`convertAndImportMessages: sanitized ${sanitizedIds.size} tool IDs:`,
 			[...sanitizedIds.entries()].map(([orig, clean]) => orig === clean ? orig : `${orig}→${clean}`).join(", "));
 	}
-	// Pre-repair for debug logging; importMessages also repairs internally (idempotent).
+	// Pre-repair: pair every orphaned tool_use with an EXPLICIT bridge-authored
+	// error result before cc-session-io's repairToolPairing can backfill its bare
+	// "[no tool result recorded]" placeholder — which the model reads as tool
+	// output and silently reasons on. Ours is is_error and says what to do.
+	// repairToolPairing still runs after (idempotent; finds nothing left).
 	const missingToolResults = findUnpairedToolUses(anthropicMessages);
+	if (missingToolResults.length > 0) insertLostToolResultPlaceholders(anthropicMessages, missingToolResults);
 	const repaired = repairToolPairing(anthropicMessages);
 	if (missingToolResults.length > 0) {
 		reportSyntheticToolResultRepair(missingToolResults, {

--- a/pi-extensions/pi-claude-bridge/src/tool-pairing-audit.ts
+++ b/pi-extensions/pi-claude-bridge/src/tool-pairing-audit.ts
@@ -52,6 +52,54 @@ export function findUnpairedToolUses(messages: Array<{ role?: string; content?: 
 	return missing;
 }
 
+export const LOST_TOOL_RESULT_TEXT =
+	"Claude bridge: the result of this tool call was lost before the session was rebuilt "
+	+ "(the turn was interrupted). Treat the call as failed — it may or may not have executed. "
+	+ "Re-run the tool if its output is still needed.";
+
+/**
+ * Insert explicit, bridge-authored error results for every unpaired tool_use,
+ * IN PLACE, before cc-session-io's repairToolPairing runs.
+ *
+ * repairToolPairing backfills with a bare "[no tool result recorded]" — a
+ * placeholder the model reads as tool OUTPUT and keeps reasoning on (observed:
+ * two bash calls in the 2026-07-28 token test, silently treated as if they had
+ * returned). An is_error result that says what happened and what to do turns a
+ * silent correctness hazard into a recoverable failure.
+ *
+ * Results are prepended to the immediately following user message (tool_result
+ * blocks must lead a user message), or a new user message is inserted when none
+ * follows. `missing` must come from findUnpairedToolUses on the same array.
+ */
+export function insertLostToolResultPlaceholders(
+	messages: Array<{ role?: string; content?: unknown }>,
+	missing: MissingToolResult[],
+): void {
+	const block = (id: string) => ({ type: "tool_result", tool_use_id: id, content: LOST_TOOL_RESULT_TEXT, is_error: true });
+	const byAssistant = new Map<number, MissingToolResult[]>();
+	for (const item of missing) {
+		const group = byAssistant.get(item.assistantIndex) ?? [];
+		group.push(item);
+		byAssistant.set(item.assistantIndex, group);
+	}
+	// Descending order so inserting a new user message never shifts an index a
+	// later (earlier-in-array) group still needs.
+	for (const assistantIndex of [...byAssistant.keys()].sort((a, b) => b - a)) {
+		const group = byAssistant.get(assistantIndex)!;
+		const blocks = group.map((item) => block(item.id));
+		const userIndex = group[0].userIndex;
+		if (userIndex != null && messages[userIndex]?.role === "user") {
+			const user = messages[userIndex] as { role: string; content: unknown };
+			const existing = typeof user.content === "string"
+				? (user.content ? [{ type: "text", text: user.content }] : [])
+				: Array.isArray(user.content) ? user.content : [];
+			user.content = [...blocks, ...existing];
+		} else {
+			messages.splice(assistantIndex + 1, 0, { role: "user", content: blocks });
+		}
+	}
+}
+
 export function summarizeMissingToolNames(missing: MissingToolResult[]): Array<{ name: string; count: number }> {
 	const counts = new Map<string, number>();
 	for (const item of missing) counts.set(item.toolName, (counts.get(item.toolName) ?? 0) + 1);

--- a/pi-extensions/pi-claude-bridge/src/typebox-to-zod.ts
+++ b/pi-extensions/pi-claude-bridge/src/typebox-to-zod.ts
@@ -28,9 +28,15 @@ export function jsonSchemaPropertyToZod(prop: Record<string, unknown>): z.ZodTyp
 		}
 		case "object": {
 			if (prop.properties && typeof prop.properties === "object" && !Array.isArray(prop.properties)) {
-				base = z.object(jsonSchemaToZodShape(prop));
-				if (prop.additionalProperties === false) base = (base as z.ZodObject<Record<string, z.ZodTypeAny>>).strict();
-				else if (prop.additionalProperties === true) base = (base as z.ZodObject<Record<string, z.ZodTypeAny>>).passthrough();
+				const obj = z.object(jsonSchemaToZodShape(prop));
+				// JSON Schema's default is PERMISSIVE (additionalProperties omitted
+				// means allowed); zod's default is to silently STRIP unknown keys.
+				// Stripping matters here: the MCP handler compares its validated
+				// input against the raw streamed tool_use input to claim a call id,
+				// so a silently dropped key made the two diverge and the claim fail
+				// (stranding the call — see claimToolCall). Only an explicit
+				// additionalProperties:false may reject/strip.
+				base = prop.additionalProperties === false ? obj.strict() : obj.passthrough();
 			} else {
 				base = z.record(z.string(), z.unknown());
 			}

--- a/pi-extensions/pi-claude-bridge/tests/unit-assistant-boundary.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-assistant-boundary.mjs
@@ -23,7 +23,7 @@ function installFakeStream() {
 describe("assistant tool-use boundary fallback", () => {
 	beforeEach(() => resetStack());
 
-	it("ends a streamed tool-use turn when the SDK assistant message arrives before message_stop", () => {
+	it("defers the streamed tool-use turn end to message_stop so message_delta usage lands", () => {
 		const c = ctx();
 		c.resetTurnState(model);
 		const events = installFakeStream();
@@ -51,14 +51,29 @@ describe("assistant tool-use boundary fallback", () => {
 			},
 		}, model, new Map([["mcp__custom-tools__bash", "bash"]]));
 
-		assert.equal(c.currentPiStream, null);
-		assert.equal(c.turnOutput.stopReason, "toolUse");
+		// Boundary arms the deferred end instead of closing the stream: the SDK
+		// yields this assistant message BEFORE message_delta, and message_delta is
+		// what carries the message's real output-token count.
+		assert.ok(c.currentPiStream, "boundary must not end the stream directly");
+		assert.ok(c.scheduledToolUseEnd, "boundary arms the grace timer");
 		assert.deepEqual(c.turnToolCallIds, ["toolu_1"]);
 		assert.equal(c.turnBlocks.length, 1, "must not duplicate streamed tool call block");
 		assert.equal(c.turnBlocks[0].arguments.command, "echo hi");
 		assert.ok(!("partialJson" in c.turnBlocks[0]), "partial JSON should be finalized");
+
+		// message_delta then message_stop — the normal terminal events.
+		processStreamEvent({ type: "stream_event", event: {
+			type: "message_delta", delta: { stop_reason: "tool_use" }, usage: { output_tokens: 187 },
+		} }, new Map(), model);
+		processStreamEvent({ type: "stream_event", event: { type: "message_stop" } }, new Map(), model);
+
+		assert.equal(c.currentPiStream, null);
+		assert.equal(c.scheduledToolUseEnd, null, "grace timer disarmed at turn end");
+		assert.equal(c.turnOutput.stopReason, "toolUse");
+		assert.equal(c.turnOutput.usage.output, 187, "message_delta usage must reach the delivered message");
 		assert.equal(events.at(-2).type, "done");
 		assert.equal(events.at(-2).reason, "toolUse");
+		assert.equal(events.at(-2).message.usage.output, 187, "done event carries the real output count");
 		assert.equal(events.at(-1).type, "stream_end");
 	});
 
@@ -80,12 +95,46 @@ describe("assistant tool-use boundary fallback", () => {
 			},
 		}, model, new Map([["mcp__custom-tools__read", "read"]]));
 
-		assert.equal(c.currentPiStream, null);
+		assert.ok(c.currentPiStream, "boundary defers the end to message_stop");
+		assert.ok(c.scheduledToolUseEnd, "boundary arms the grace timer");
 		assert.deepEqual(c.turnToolCallIds, ["toolu_missing"]);
 		assert.equal(c.turnBlocks.length, 1);
 		assert.equal(c.turnBlocks[0].name, "read");
 		assert.equal(c.turnBlocks[0].arguments.path, "README.md");
+		processStreamEvent({ type: "stream_event", event: { type: "message_stop" } }, new Map([["mcp__custom-tools__read", "read"]]), model);
+		assert.equal(c.currentPiStream, null);
 		assert.deepEqual(events.map((event) => event.type), ["start", "toolcall_start", "toolcall_end", "done", "stream_end"]);
+	});
+
+	it("grace timer force-ends the tool-use turn when terminal events never arrive", (t) => {
+		t.mock.timers.enable({ apis: ["setTimeout"] });
+		const c = ctx();
+		c.resetTurnState(model);
+		const events = installFakeStream();
+		c.turnSawStreamEvent = true;
+
+		processAssistantMessage({
+			type: "assistant",
+			message: {
+				content: [{
+					type: "tool_use",
+					id: "toolu_silent",
+					name: "mcp__custom-tools__bash",
+					input: { command: "echo hi" },
+				}],
+			},
+		}, model, new Map([["mcp__custom-tools__bash", "bash"]]));
+
+		assert.ok(c.currentPiStream, "turn stays open awaiting message_stop");
+		assert.ok(c.scheduledToolUseEnd, "grace timer armed");
+
+		t.mock.timers.tick(1500);
+
+		assert.equal(c.currentPiStream, null, "grace elapsed — turn force-ended");
+		assert.equal(c.scheduledToolUseEnd, null);
+		assert.equal(events.at(-2).type, "done");
+		assert.equal(events.at(-2).reason, "toolUse");
+		assert.equal(events.at(-1).type, "stream_end");
 	});
 
 	it("records assistant tool-use ids even after the stream already ended", () => {

--- a/pi-extensions/pi-claude-bridge/tests/unit-child-executed-tools.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-child-executed-tools.mjs
@@ -179,7 +179,13 @@ describe("child-executed tools are never mirrored as Pi tool calls", () => {
 		assert.equal(c.turnBlocks.length, 1, "only the Pi tool call is mirrored");
 		assert.equal(c.turnBlocks[0].name, "read");
 		assert.deepEqual(c.turnToolCallIds, ["toolu_pi"]);
-		assert.equal(c.currentPiStream, null, "a real Pi tool call still ends the turn");
+		// The boundary no longer ends the turn directly — it arms the grace timer
+		// and lets message_stop end it, so message_delta's usage can land first.
+		assert.equal(c.turnSawToolCall, true);
+		assert.ok(c.scheduledToolUseEnd, "a real Pi tool call arms the deferred turn end");
+		processStreamEvent(streamEvent({ type: "message_stop" }), new Map(), model);
+		assert.equal(c.currentPiStream, null, "message_stop ends the tool-use turn");
+		assert.equal(c.scheduledToolUseEnd, null, "grace timer disarmed at turn end");
 	});
 });
 

--- a/pi-extensions/pi-claude-bridge/tests/unit-integrity-reporting.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-integrity-reporting.mjs
@@ -3,7 +3,8 @@ import assert from "node:assert/strict";
 import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { QueryContext } from "../src/query-state.js";
-import { __testGetBridgeIntegrityState, __testSetBridgeIntegrityState, reportToolResultMismatch } from "../src/index.js";
+import { __testGetBridgeIntegrityState, __testSetBridgeIntegrityState, INTEGRITY_CUSTOM_TYPE, appendIntegrityEntry, reapStaleQueuedResults, reportToolResultMismatch } from "../src/index.js";
+import { setExtensionApi } from "../src/bridge-state.js";
 
 let dir;
 let diagPath;
@@ -83,5 +84,76 @@ describe("tool-result integrity reporting", () => {
 		assert.doesNotThrow(() => reportToolResultMismatch(makeMismatchContext(), "query teardown", "/repo"));
 		assert.equal(readDiagEntries().length, 1);
 		assert.equal(__testGetBridgeIntegrityState().sharedSession.needsRebuild, true);
+	});
+});
+
+describe("integrity entries persisted to the pi session", () => {
+	let sessionEntries;
+
+	beforeEach(() => {
+		dir = mkdtempSync("/tmp/claude-bridge-integrity-");
+		diagPath = join(dir, "diag.log");
+		process.env.CLAUDE_BRIDGE_DIAG_PATH = diagPath;
+		notifications = [];
+		sessionEntries = [];
+		__testSetBridgeIntegrityState({
+			ui: { notify: (message, level) => notifications.push({ message, level }) },
+			sharedSession: { sessionId: "session-12345678", cursor: 4, cwd: "/repo" },
+		});
+		setExtensionApi({ appendEntry: (customType, data) => sessionEntries.push({ customType, data }) });
+	});
+
+	afterEach(() => {
+		setExtensionApi(undefined);
+		__testSetBridgeIntegrityState({ ui: null, sharedSession: null });
+		delete process.env.CLAUDE_BRIDGE_DIAG_PATH;
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it("a mismatch report is persisted as a claude-bridge-integrity entry", () => {
+		reportToolResultMismatch(makeMismatchContext(), "query teardown", "/repo");
+
+		assert.equal(sessionEntries.length, 1);
+		assert.equal(sessionEntries[0].customType, INTEGRITY_CUSTOM_TYPE);
+		assert.equal(sessionEntries[0].data.label, "tool_result_delivery_mismatch");
+		assert.deepEqual(sessionEntries[0].data.queuedIds, ["t1"]);
+		assert.deepEqual(sessionEntries[0].data.toolNames, [{ name: "bash", count: 1 }]);
+		assert.equal(JSON.stringify(sessionEntries[0]).includes("should-not-leak"), false, "never tool arguments or output");
+	});
+
+	it("appendIntegrityEntry reports false when no pi session exists and never throws", () => {
+		setExtensionApi(undefined);
+		assert.equal(appendIntegrityEntry("anything", { count: 1 }), false);
+		setExtensionApi({ appendEntry: () => { throw new Error("append failed"); } });
+		assert.doesNotThrow(() => appendIntegrityEntry("anything", { count: 1 }));
+		assert.equal(appendIntegrityEntry("anything", { count: 1 }), false);
+	});
+
+	it("reaping stale queued results drops them, diags, notifies, and persists", () => {
+		const queryCtx = new QueryContext();
+		queryCtx.recordToolCall("bash-lost", "bash", { command: "echo should-not-leak" });
+		queryCtx.pendingResults.set("bash-lost", { toolCallId: "bash-lost", content: [{ type: "text", text: "should-not-leak" }] });
+		queryCtx.resetToolTracking();
+
+		reapStaleQueuedResults(queryCtx);
+
+		assert.equal(queryCtx.pendingResults.size, 0);
+		const diag = readDiagEntries();
+		assert.equal(diag.length, 1);
+		assert.equal(diag[0].label, "stale_queued_tool_results_dropped");
+		assert.deepEqual(diag[0].stale, [{ id: "bash-lost", toolName: "bash" }]);
+		assert.equal(sessionEntries.length, 1);
+		assert.equal(sessionEntries[0].data.label, "stale_queued_tool_results_dropped");
+		assert.equal(notifications.length, 1);
+		assert.equal(notifications[0].level, "warning");
+		assert.match(notifications[0].message, /bash/);
+		assert.equal(JSON.stringify(diag).includes("should-not-leak"), false, "diag never carries tool output");
+		assert.equal(JSON.stringify(sessionEntries).includes("should-not-leak"), false, "session entry never carries tool output");
+	});
+
+	it("reaping nothing appends nothing", () => {
+		reapStaleQueuedResults(new QueryContext());
+		assert.equal(sessionEntries.length, 0);
+		assert.equal(notifications.length, 0);
 	});
 });

--- a/pi-extensions/pi-claude-bridge/tests/unit-querycontext.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-querycontext.mjs
@@ -106,6 +106,45 @@ describe("QueryContext class", () => {
 		assert.equal(claim.ambiguous, false);
 	});
 
+	it("claimToolCall claims the sole same-name call even when recorded args diverge", () => {
+		// Recorded args = raw streamed input; handler args = zod-validated copy.
+		// A stripped/extra key must not strand the only call this handler can be.
+		ctx().recordToolCall("edit-1", "edit", { path: "a.ts", edits: [{ oldText: "x", newText: "y", stray: true }] });
+
+		const claim = ctx().claimToolCall("edit", { path: "a.ts", edits: [{ oldText: "x", newText: "y" }] });
+
+		assert.equal(claim.toolCallId, "edit-1");
+		assert.equal(claim.match, "tool-name");
+		assert.equal(claim.argsMismatch, true);
+		assert.equal(ctx().claimedToolCallIds.has("edit-1"), true);
+	});
+
+	it("claimToolCall still refuses when several same-name calls all mismatch", () => {
+		ctx().recordToolCall("edit-a", "edit", { path: "a.ts", edits: [] });
+		ctx().recordToolCall("edit-b", "edit", { path: "b.ts", edits: [] });
+
+		const claim = ctx().claimToolCall("edit", { path: "c.ts", edits: [] });
+
+		assert.equal(claim.toolCallId, undefined);
+		assert.equal(claim.match, "none");
+		assert.equal(claim.available, 2);
+	});
+
+	it("takeStaleQueuedResults drains the queue and names tools across message resets", () => {
+		ctx().recordToolCall("bash-lost", "bash", { command: "echo hi", timeout: 120 });
+		ctx().pendingResults.set("bash-lost", { content: [{ type: "text", text: "hi" }] });
+		ctx().resetToolTracking(); // new child message: per-message records cleared
+
+		const progress = ctx().toolResultProgress();
+		assert.equal(progress.queuedCount, 1);
+		assert.deepEqual(progress.toolNames, [{ name: "bash", count: 1 }], "query-scoped names survive the reset");
+
+		const stale = ctx().takeStaleQueuedResults();
+		assert.deepEqual(stale, [{ id: "bash-lost", toolName: "bash" }]);
+		assert.equal(ctx().pendingResults.size, 0);
+		assert.deepEqual(ctx().takeStaleQueuedResults(), [], "second drain is empty");
+	});
+
 	it("toolResultProgress reports teardown mismatch counts", () => {
 		ctx().recordToolCall("t0", "read", { path: "a" });
 		ctx().recordToolCall("t1", "grep", { pattern: "x" });

--- a/pi-extensions/pi-claude-bridge/tests/unit-session-integrity.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-session-integrity.mjs
@@ -11,7 +11,7 @@ import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { repairToolPairing } from "cc-session-io";
 import { verifyWrittenSession } from "../src/session-verify.js";
-import { findUnpairedToolUses, summarizeMissingToolNames } from "../src/tool-pairing-audit.js";
+import { findUnpairedToolUses, insertLostToolResultPlaceholders, summarizeMissingToolNames } from "../src/tool-pairing-audit.js";
 
 // --- repairToolPairing ---
 
@@ -73,6 +73,71 @@ describe("tool pairing audit", () => {
 		assert.equal(missing[0].id, "orphan");
 		assert.equal(missing[0].toolName, "Bash");
 		assert.equal(missing[0].userIndex, 1);
+	});
+});
+
+describe("insertLostToolResultPlaceholders", () => {
+	it("prepends explicit error results to the following user message", () => {
+		const msgs = [
+			{ role: "assistant", content: [
+				{ type: "tool_use", id: "ok", name: "Read", input: {} },
+				{ type: "tool_use", id: "lost", name: "Bash", input: {} },
+			] },
+			{ role: "user", content: [{ type: "tool_result", tool_use_id: "ok", content: "fine" }] },
+		];
+
+		insertLostToolResultPlaceholders(msgs, findUnpairedToolUses(msgs));
+
+		assert.equal(msgs.length, 2);
+		assert.equal(msgs[1].content[0].type, "tool_result");
+		assert.equal(msgs[1].content[0].tool_use_id, "lost");
+		assert.equal(msgs[1].content[0].is_error, true);
+		assert.match(msgs[1].content[0].content, /Treat the call as failed/);
+		assert.equal(msgs[1].content[1].tool_use_id, "ok", "real result preserved after placeholders");
+		assert.deepEqual(findUnpairedToolUses(msgs), [], "nothing left for repairToolPairing to pad");
+	});
+
+	it("wraps a string user message and keeps its text", () => {
+		const msgs = [
+			{ role: "assistant", content: [{ type: "tool_use", id: "orphan", name: "Bash", input: {} }] },
+			{ role: "user", content: "next prompt" },
+		];
+
+		insertLostToolResultPlaceholders(msgs, findUnpairedToolUses(msgs));
+
+		assert.equal(msgs[1].content[0].type, "tool_result");
+		assert.equal(msgs[1].content[0].tool_use_id, "orphan");
+		assert.deepEqual(msgs[1].content[1], { type: "text", text: "next prompt" });
+		assert.deepEqual(findUnpairedToolUses(msgs), []);
+	});
+
+	it("inserts a new user message when the tool_use is the last message", () => {
+		const msgs = [
+			{ role: "assistant", content: [{ type: "tool_use", id: "tail", name: "Bash", input: {} }] },
+		];
+
+		insertLostToolResultPlaceholders(msgs, findUnpairedToolUses(msgs));
+
+		assert.equal(msgs.length, 2);
+		assert.equal(msgs[1].role, "user");
+		assert.equal(msgs[1].content[0].tool_use_id, "tail");
+		assert.deepEqual(findUnpairedToolUses(msgs), []);
+	});
+
+	it("handles several affected assistant messages without index drift", () => {
+		const msgs = [
+			{ role: "assistant", content: [{ type: "tool_use", id: "a", name: "Bash", input: {} }] },
+			{ role: "assistant", content: [{ type: "tool_use", id: "b", name: "Read", input: {} }] },
+			{ role: "user", content: "closing prompt" },
+		];
+
+		insertLostToolResultPlaceholders(msgs, findUnpairedToolUses(msgs));
+
+		assert.equal(msgs.length, 4);
+		assert.equal(msgs[1].role, "user");
+		assert.equal(msgs[1].content[0].tool_use_id, "a");
+		assert.equal(msgs[3].content[0].tool_use_id, "b");
+		assert.deepEqual(findUnpairedToolUses(msgs), []);
 	});
 });
 

--- a/pi-extensions/pi-claude-bridge/tests/unit-typebox-to-zod.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-typebox-to-zod.mjs
@@ -73,4 +73,40 @@ describe("jsonSchemaToZodShape", () => {
 		assert.deepEqual(json.properties.item.required, ["requiredName"]);
 		assert.ok(json.properties.item.properties.optionalNote);
 	});
+
+	it("keeps unknown keys on objects without additionalProperties:false (JSON Schema default)", () => {
+		// zod's default is to silently STRIP unknown keys; JSON Schema's default is
+		// to allow them. Stripping made the handler's validated input diverge from
+		// the raw streamed tool_use input, which broke tool-call id claiming.
+		const shape = jsonSchemaToZodShape({
+			type: "object",
+			properties: {
+				edits: {
+					type: "array",
+					items: { type: "object", properties: { oldText: { type: "string" } }, required: ["oldText"] },
+				},
+			},
+			required: ["edits"],
+		});
+
+		const parsed = z.object(shape).parse({ edits: [{ oldText: "a", stray: 1 }] });
+		assert.equal(parsed.edits[0].stray, 1, "unknown nested key must survive validation");
+	});
+
+	it("still rejects unknown keys when additionalProperties is explicitly false", () => {
+		const shape = jsonSchemaToZodShape({
+			type: "object",
+			properties: {
+				item: {
+					type: "object",
+					additionalProperties: false,
+					properties: { name: { type: "string" } },
+					required: ["name"],
+				},
+			},
+			required: ["item"],
+		});
+
+		assert.throws(() => z.object(shape).parse({ item: { name: "a", stray: 1 } }));
+	});
 });


### PR DESCRIPTION
Root-causes and fixes the claude-bridge failures from the 2026-07-28 harness token test (diag log: 43× tool_result_delivery_mismatch, 6× synthetic-result repair, 1× tool_handler_unmatched over 9 days).

## Root causes found

1. **Output tokens lost (pi recorded 1–7/turn).** Probed the SDK message ordering live: the CLI invokes MCP handlers and yields the completed assistant message ~45ms **before** `message_delta` — the event carrying the message's real output count. The bridge ended the pi stream at those early signals, freezing usage at `message_start` placeholders. Tool-use turns now end at `message_stop` like text turns; the early signals only arm a **1.5s grace timer** (deadlock backstop for the pi 0.80 steer-drain case the old immediate finalize was built for).

2. **Stranded tool calls → rebuild churn.** A handler whose zod-validated args diverged from the raw streamed input (zod strips unknown nested keys by default; JSON Schema's default is permissive) refused to claim the sole same-name call → errored into the child while pi's real result queued forever → every later teardown reported a misleading `0/0`-with-queued mismatch (empty toolNames) → `needsRebuild` per turn (~1.7× cache-write churn vs Claude Code direct). Fixed at three layers: sole-candidate claims succeed with an `tool_claim_args_mismatch` diag; nested schemas validate with `.passthrough()` unless `additionalProperties:false`; dead queued results are reaped at the next message boundary with a named `stale_queued_tool_results_dropped` diagnostic.

3. **Errors shown but never persisted.** Integrity events now also append `claude-bridge-integrity` custom entries to the pi session (compact metadata only), so post-mortems work from the session file alone. Teardown reports name tools via a query-scoped id→name map.

4. **Fabricated placeholders.** Unpaired tool_uses in a rebuild now get an explicit `is_error` "result was lost — re-run if needed" result instead of cc-session-io's bare `[no tool result recorded]` that the model silently reads as real output.

## Validation

- 341 unit tests pass (14 new: claim fallback, zod passthrough, stale reap, grace timer, deferred boundary usage, integrity entries, lost-result placeholders).
- Full integration suite green (smoke, multi-turn, cache, session-new/rebuild/resume/compact/fork, cursor-after-tools, tool-message incl. steer/parallel/abort).
- Live end-to-end via pi 0.82.1: tool-use turns now record real output (139/122/89 tokens) instead of 1–7.

## Consumer impact (memsira / drovr vendored builds)

Export surface is strictly additive (`INTEGRITY_CUSTOM_TYPE`, `appendIntegrityEntry`, turn-end helpers). Hosts see: correct per-turn output tokens, fewer forced session rebuilds, new opaque `claude-bridge-integrity` entries (memsira persists via real pi sessions; drovr has no `extensionApi` so the append no-ops). Connector paths untouched. Version bumped to 1.10.0; both hosts should re-vendor via their `sync-claude-bridge.mjs`.

https://claude.ai/code/session_01F5pphTKqnTuSp9UktZZ6u8