### PR TITLE
fix(second-opinion): preserve raw first response when the reformat retry succeeds

### DIFF
--- a/skills/second-opinion/scripts/second-opinion
+++ b/skills/second-opinion/scripts/second-opinion
@@ -408,8 +408,9 @@ printf '%s\n' "$PROMPT" > "$PROMPT_TMP"
 
 STDERR_TMP=$(mktemp)
 # RETRY_PROMPT_TMP is created only when extraction fails and a retry runs; keep
-# it in the cleanup trap. Sidecar files written by preserve_raw_and_fail are
-# deliberately NOT tracked here — they are the durable record of a lost response.
+# it in the cleanup trap. Sidecar files written by preserve_raw_response and
+# preserve_raw_and_fail are deliberately NOT tracked here — they are the durable
+# record of a lost or reformatted response.
 RETRY_PROMPT_TMP=""
 trap 'rm -f "$PROMPT_TMP" "$STDERR_TMP" "$RETRY_PROMPT_TMP"' EXIT
 
@@ -610,6 +611,25 @@ ${schema}
 RETRY
 }
 
+# vstack#940: persist the raw first response the moment a retry is attempted —
+# BEFORE the retry outcome is known. A successful reformat retry replaces
+# RESULT wholesale, so without this sidecar the only record of what the model
+# actually said is discarded exactly when the retry "succeeds", making a
+# dropped/softened/merged finding unauditable. Sets RAW_PRESERVED_PATH;
+# preserve_raw_and_fail reuses it so the both-failed path never duplicates the
+# content.
+RAW_PRESERVED_PATH=""
+preserve_raw_response() {
+  local raw="$1"
+  if [[ -n "$OUTPUT_PATH" ]]; then
+    mkdir -p "$(dirname "$OUTPUT_PATH")"
+    RAW_PRESERVED_PATH="${OUTPUT_PATH}.raw.txt"
+  else
+    RAW_PRESERVED_PATH=$(mktemp)
+  fi
+  printf '%s\n' "$raw" > "$RAW_PRESERVED_PATH"
+}
+
 # Persist the raw (and optional retry) response so a lost review is auditable,
 # emit an error JSON that carries the sidecar path(s), then exit 1.
 preserve_raw_and_fail() {
@@ -617,21 +637,25 @@ preserve_raw_and_fail() {
   local retry="${2:-}"
   local raw_path retry_path=""
 
-  if [[ -n "$OUTPUT_PATH" ]]; then
+  # The raw first response was already written when the retry was attempted
+  # (vstack#940) — reuse that sidecar instead of writing it a second time.
+  if [[ -n "$RAW_PRESERVED_PATH" ]]; then
+    raw_path="$RAW_PRESERVED_PATH"
+  elif [[ -n "$OUTPUT_PATH" ]]; then
     mkdir -p "$(dirname "$OUTPUT_PATH")"
     raw_path="${OUTPUT_PATH}.raw.txt"
     printf '%s\n' "$raw" > "$raw_path"
-    if [[ -n "$retry" ]]; then
-      retry_path="${OUTPUT_PATH}.retry.txt"
-      printf '%s\n' "$retry" > "$retry_path"
-    fi
   else
     raw_path=$(mktemp)
     printf '%s\n' "$raw" > "$raw_path"
-    if [[ -n "$retry" ]]; then
+  fi
+  if [[ -n "$retry" ]]; then
+    if [[ -n "$OUTPUT_PATH" ]]; then
+      retry_path="${OUTPUT_PATH}.retry.txt"
+    else
       retry_path=$(mktemp)
-      printf '%s\n' "$retry" > "$retry_path"
     fi
+    printf '%s\n' "$retry" > "$retry_path"
   fi
 
   if [[ -n "$retry_path" ]]; then
@@ -732,6 +756,11 @@ if [[ "$MODE" == "review" || "$MODE" == "audit" ]]; then
   # of being written as a findings-less artifact.
   RETRY_WHY=""
   RETRY_PROBLEM=""
+  # Byte counts of the raw responses, recorded into the artifact's qa_metadata
+  # (vstack#940) so a reformat that shrank the review is visible in the
+  # artifact itself. Measured on the untouched CLI output, before extraction.
+  RAW_RESPONSE_BYTES=${#RESULT}
+  RETRY_RESPONSE_BYTES=""
   if JSON=$(extract_json "$RESULT"); then
     if response_incomplete_schema "$JSON"; then
       RETRY_WHY="first response JSON is structurally incomplete"
@@ -745,6 +774,9 @@ if [[ "$MODE" == "review" || "$MODE" == "audit" ]]; then
 
   if [[ -n "$RETRY_WHY" ]]; then
     echo "→ $RETRY_WHY; retrying once with captured response" >&2
+    # Persist the raw first response now, before the retry outcome is known
+    # (vstack#940) — a successful reformat must not erase the original.
+    preserve_raw_response "$RESULT"
     RETRY_PROMPT_TMP=$(mktemp)
     if [[ -n "$RETRY_PROBLEM" ]]; then
       build_retry_prompt "$RESULT" "$RETRY_PROBLEM" > "$RETRY_PROMPT_TMP"
@@ -755,6 +787,7 @@ if [[ "$MODE" == "review" || "$MODE" == "audit" ]]; then
     RETRY_RESULT=""
     RETRY_EXIT=0
     RETRY_RESULT=$(run_target_cli "$RETRY_PROMPT_TMP") || RETRY_EXIT=$?
+    RETRY_RESPONSE_BYTES=${#RETRY_RESULT}
 
     if [[ $RETRY_EXIT -eq 124 ]]; then
       echo "→ retry timed out after ${TIMEOUT}s" >&2
@@ -776,6 +809,7 @@ if [[ "$MODE" == "review" || "$MODE" == "audit" ]]; then
           incomplete
       fi
       echo "→ retry recovered valid JSON (${#JSON} bytes)" >&2
+      echo "→ raw first response preserved: $RAW_PRESERVED_PATH" >&2
       RESULT="$JSON"
     else
       echo "→ retry response still not parseable" >&2
@@ -801,8 +835,17 @@ if [[ "$MODE" == "review" || "$MODE" == "audit" ]]; then
   # its filesystem mtime. The schema keeps ISO_8601 as a hint; this is the
   # authoritative value. RESULT is already jq-validated JSON here, so the rewrite
   # succeeds; if jq unexpectedly fails, keep the extracted JSON unchanged.
+  # Also record the raw response byte counts in qa_metadata (vstack#940) —
+  # retry_response_bytes only when a retry actually ran — so a reformat that
+  # shrank the review is visible in the artifact, next to the .raw.txt sidecar.
   STAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-  if STAMPED=$(printf '%s' "$RESULT" | jq --arg ts "$STAMP" '.timestamp = $ts' 2>/dev/null); then
+  if STAMPED=$(printf '%s' "$RESULT" | jq --arg ts "$STAMP" \
+      --argjson raw_bytes "$RAW_RESPONSE_BYTES" \
+      --argjson retry_bytes "${RETRY_RESPONSE_BYTES:-null}" \
+      '.timestamp = $ts
+       | .qa_metadata.raw_response_bytes = $raw_bytes
+       | if $retry_bytes == null then .
+         else .qa_metadata.retry_response_bytes = $retry_bytes end' 2>/dev/null); then
     RESULT="$STAMPED"
   fi
 fi

--- a/skills/second-opinion/tests/review-json-recovery.test.sh
+++ b/skills/second-opinion/tests/review-json-recovery.test.sh
@@ -72,6 +72,17 @@ assert_file_contains() {
   fi
 }
 
+assert_jq() {
+  local file="$1" expr="$2" name="$3"
+  if [[ -f "$file" ]] && jq -e "$expr" "$file" >/dev/null 2>&1; then
+    pass "$name"
+  else
+    fail "$name"
+    printf '        expected jq expression to hold on %s: %s\n' "$file" "$expr" >&2
+    [[ -f "$file" ]] && sed -n '1,10p' "$file" >&2
+  fi
+}
+
 # --- Fake target CLI ----------------------------------------------------------
 # Consumes the prompt on stdin, increments an on-disk counter, and emits the
 # canned response for that call number. Named `claude` and placed on PATH so the
@@ -145,6 +156,17 @@ assert_eq "$rc1" "0" "scenario 1 exits 0 after retry"
 assert_file_exists "$s1_out" "scenario 1 writes the --output artifact"
 assert_file_contains "$s1_out" "Null deref in parser" "scenario 1 artifact contains the retry's findings"
 assert_eq "$(cat "$COUNTER")" "2" "scenario 1 invoked the CLI twice (retry ran)"
+# vstack#940: a successful reformat retry must not discard the raw first
+# response — it is the only evidence of what the model actually said.
+assert_file_exists "$s1_out.raw.txt" "scenario 1 preserves the raw first response on retry success"
+assert_file_contains "$s1_out.raw.txt" "already delivered above" "scenario 1 raw sidecar holds the original raw bytes"
+assert_file_contains "$s1_err" "raw first response preserved: $s1_out.raw.txt" "scenario 1 stderr names the raw sidecar path"
+# Byte counts land in qa_metadata: raw = first response minus the trailing
+# newline the sidecar's printf adds; retry = stub response 2 minus its own.
+s1_raw_bytes=$(( $(wc -c < "$s1_out.raw.txt") - 1 ))
+s1_retry_bytes=$(( $(wc -c < "$s1_r2") - 1 ))
+assert_jq "$s1_out" ".qa_metadata.raw_response_bytes == $s1_raw_bytes" "scenario 1 qa_metadata records raw_response_bytes"
+assert_jq "$s1_out" ".qa_metadata.retry_response_bytes == $s1_retry_bytes" "scenario 1 qa_metadata records retry_response_bytes"
 
 # --- Scenario 2: clean first response, no retry ------------------------------
 echo "=== scenario 2: clean first response, no retry ==="
@@ -167,6 +189,8 @@ assert_file_exists "$s2_out" "scenario 2 writes the --output artifact"
 assert_file_contains "$s2_out" "Clean, no issues found" "scenario 2 artifact contains the first response's findings"
 assert_eq "$(cat "$COUNTER")" "1" "scenario 2 invoked the CLI once (no retry)"
 assert_file_absent "$s2_out.raw.txt" "scenario 2 writes no raw sidecar"
+assert_jq "$s2_out" '.qa_metadata.raw_response_bytes | type == "number"' "scenario 2 qa_metadata records raw_response_bytes"
+assert_jq "$s2_out" '.qa_metadata | has("retry_response_bytes") | not' "scenario 2 qa_metadata has no retry_response_bytes (no retry ran)"
 
 # --- Scenario 3: total failure preserves raw ---------------------------------
 echo "=== scenario 3: total failure preserves raw response ==="
@@ -187,6 +211,8 @@ assert_file_exists "$s3_out.raw.txt" "scenario 3 writes the <output>.raw.txt sid
 assert_file_contains "$s3_out.raw.txt" "critical SQL injection in login()" "scenario 3 sidecar preserves the raw findings"
 assert_file_contains "$s3_err" "raw_response" "scenario 3 error JSON references the raw sidecar path"
 assert_file_absent "$s3_out" "scenario 3 writes no JSON artifact on failure"
+assert_file_exists "$s3_out.retry.txt" "scenario 3 writes the <output>.retry.txt sidecar"
+assert_file_contains "$s3_out.retry.txt" "provided previously" "scenario 3 retry sidecar preserves the retry response"
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"


### PR DESCRIPTION
Closes #940.

When `extract_json` failed on the first response and the one-shot retry succeeded, the raw first response was discarded — the accepted artifact rested on a re-serialization nobody could audit. Now:

- `preserve_raw_response` writes `<output>.raw.txt` the moment a retry is attempted, before its outcome is known (covers both the reformat retry and the incomplete-schema retry). On success, stderr names the sidecar next to the existing "retry recovered valid JSON" line.
- `preserve_raw_and_fail` reuses the already-written sidecar; both-failed behavior (incl. the no-OUTPUT_PATH mktemp fallback) unchanged.
- `qa_metadata` now records `raw_response_bytes` (always) and `retry_response_bytes` (when a retry ran) in the same jq pass that stamps `.timestamp`, so a large shrink is visible in the artifact itself. `review-artifact-check` tolerates the new keys — no schema change needed.
- Cleanup trap untouched: sidecars remain exempt, so the raw record survives the successful exit.

Tests: extended `review-json-recovery.test.sh` (15→23 asserts) — retry-success preserves raw bytes + stderr path, qa_metadata byte counts exact-matched, both-failed path re-verified. All 7 second-opinion suites pass.

https://claude.ai/code/session_01F5pphTKqnTuSp9UktZZ6u8