### PR TITLE
fix(cli): emit Claude hook timeout on the command handler, not the matcher group

### DIFF
--- a/cli/src/commands/refresh.rs
+++ b/cli/src/commands/refresh.rs
@@ -133,7 +133,7 @@ fn observed_source_repo_for_lock_entry(
             &entry.source,
         ));
     }
-    config::parse_github_slug(&entry.source).map(|source_repo| Some(source_repo))
+    config::parse_github_slug(&entry.source).map(Some)
 }
 
 fn sync_lock_entry_source_repo(source_records: &[ResolvedSource], entry: &mut config::LockEntry) {

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -843,10 +843,8 @@ pub fn parse_github_slug(url: &str) -> Option<String> {
             return None;
         }
         path
-    } else if let Some(after) = url.strip_prefix("ssh://git@github.com/") {
-        after
     } else {
-        return None;
+        url.strip_prefix("ssh://git@github.com/")?
     };
     let after = after
         .trim_end_matches('/')

--- a/cli/src/installer/hooks.rs
+++ b/cli/src/installer/hooks.rs
@@ -207,23 +207,24 @@ fn install_hook_claude(hook: &Hook, global: bool) -> Result<()> {
     // Global installs: use the absolute path under the global config dir.
     let command = claude_hook_command(global, &hook.name, &dest);
     let hook_entry = {
-        let mut entry = serde_json::json!({
-            "hooks": [{
-                "type": "command",
-                "command": command,
-            }]
+        // Claude Code reads `timeout` from the command handler object, not the
+        // matcher group, so it must live beside `command`.
+        let mut handler = serde_json::json!({
+            "type": "command",
+            "command": command,
         });
+        if let Some(timeout) = hook.timeout {
+            handler
+                .as_object_mut()
+                .unwrap()
+                .insert("timeout".into(), serde_json::Value::Number(timeout.into()));
+        }
+        let mut entry = serde_json::json!({ "hooks": [handler] });
         if let Some(ref matcher) = hook.matcher {
             entry
                 .as_object_mut()
                 .unwrap()
                 .insert("matcher".into(), serde_json::Value::String(matcher.clone()));
-        }
-        if let Some(timeout) = hook.timeout {
-            entry
-                .as_object_mut()
-                .unwrap()
-                .insert("timeout".into(), serde_json::Value::Number(timeout.into()));
         }
         entry
     };

--- a/cli/src/installer/hooks/tests.rs
+++ b/cli/src/installer/hooks/tests.rs
@@ -134,6 +134,113 @@ fn merge_codex_hooks_json_replaces_existing_hook_registration() {
 }
 
 #[test]
+fn install_hook_claude_places_timeout_on_handler_not_group() {
+    let dir = tmpdir("claude_timeout_handler");
+    let mut hook = hook_fixture("probe", "SessionStart", None);
+    hook.timeout = Some(15);
+    crate::test_util::with_project_root(&dir, || {
+        install_hook_claude(&hook, false).unwrap();
+    });
+
+    let settings_path = dir.join(".claude").join("settings.json");
+    let doc: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&settings_path).unwrap()).unwrap();
+    let arr = doc
+        .pointer("/hooks/SessionStart")
+        .and_then(|v| v.as_array())
+        .expect("SessionStart array present");
+    assert_eq!(arr.len(), 1);
+    assert!(
+        arr[0].pointer("/timeout").is_none(),
+        "timeout must not sit on the matcher group, got: {doc}"
+    );
+    assert_eq!(
+        arr[0].pointer("/hooks/0/timeout").and_then(|v| v.as_u64()),
+        Some(15)
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn install_hook_claude_migrates_legacy_group_level_timeout() {
+    let dir = tmpdir("claude_timeout_migrate");
+    let claude_dir = dir.join(".claude");
+    std::fs::create_dir_all(&claude_dir).unwrap();
+    // Legacy install put timeout on the matcher group; a user-authored entry
+    // with the same shape must survive untouched.
+    std::fs::write(
+        claude_dir.join("settings.json"),
+        r#"{
+  "hooks": {
+    "SessionStart": [
+      {
+        "timeout": 15,
+        "hooks": [{"type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/probe.sh\""}]
+      },
+      {
+        "timeout": 99,
+        "hooks": [{"type": "command", "command": "bash /usr/local/bin/user-own.sh"}]
+      }
+    ]
+  }
+}"#,
+    )
+    .unwrap();
+
+    let mut hook = hook_fixture("probe", "SessionStart", None);
+    hook.timeout = Some(15);
+    crate::test_util::with_project_root(&dir, || {
+        install_hook_claude(&hook, false).unwrap();
+    });
+
+    let doc: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(claude_dir.join("settings.json")).unwrap())
+            .unwrap();
+    let arr = doc
+        .pointer("/hooks/SessionStart")
+        .and_then(|v| v.as_array())
+        .expect("SessionStart array present");
+    assert_eq!(arr.len(), 2);
+    let user = &arr[0];
+    assert_eq!(
+        user.pointer("/hooks/0/command").and_then(|v| v.as_str()),
+        Some("bash /usr/local/bin/user-own.sh")
+    );
+    assert_eq!(
+        user.pointer("/timeout").and_then(|v| v.as_u64()),
+        Some(99),
+        "user-authored entry must not be rewritten"
+    );
+    let owned = &arr[1];
+    assert!(
+        owned.pointer("/timeout").is_none(),
+        "stale group-level timeout must be removed on reinstall, got: {doc}"
+    );
+    assert_eq!(
+        owned.pointer("/hooks/0/timeout").and_then(|v| v.as_u64()),
+        Some(15)
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn install_hook_claude_without_timeout_emits_no_timeout_key() {
+    let dir = tmpdir("claude_timeout_absent");
+    let mut hook = hook_fixture("probe", "SessionStart", None);
+    hook.timeout = None;
+    crate::test_util::with_project_root(&dir, || {
+        install_hook_claude(&hook, false).unwrap();
+    });
+
+    let body = std::fs::read_to_string(dir.join(".claude").join("settings.json")).unwrap();
+    assert!(
+        !body.contains("timeout"),
+        "no timeout key should be emitted, got: {body}"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn hook_prune_preserves_user_handlers_with_same_basename() {
     let mut hooks_obj = serde_json::json!({
             "PreToolUse": [

--- a/cli/tests/hook_lifecycle.rs
+++ b/cli/tests/hook_lifecycle.rs
@@ -476,8 +476,12 @@ fn refresh_upserts_claude_hook_registration_when_event_changes() {
         .expect("PostCompact hook present");
     assert_eq!(post.len(), 1, "stale or duplicate hooks: {settings}");
     assert!(post[0].pointer("/matcher").is_none());
+    assert!(
+        post[0].pointer("/timeout").is_none(),
+        "timeout must not sit on the matcher group: {settings}"
+    );
     assert_eq!(
-        post[0].pointer("/timeout").and_then(|v| v.as_u64()),
+        post[0].pointer("/hooks/0/timeout").and_then(|v| v.as_u64()),
         Some(7)
     );
 }


### PR DESCRIPTION
Closes #942.

`install_hook_claude` wrote hook-frontmatter `timeout` onto the matcher-group object beside `hooks`; Claude Code reads `timeout` from the inner command handler (`{"type":"command","command":...,"timeout":N}`), so the configured timeout was ignored. The handler object now carries it; the group entry keeps only `hooks` + optional `matcher`.

- The Codex site (`merge_codex_hooks_json_owned`) already emits handler-level timeout and is untouched.
- Self-heal on reinstall: `install_hook_claude` replaces installer-owned entries wholesale (matched by exact owned command), so a legacy wrong-placement entry migrates on the next `vstack refresh`; user-authored entries survive byte-identical (proven by test).
- 3 new unit tests (fresh placement, legacy migration, no-timeout emits no key); `hook_lifecycle` integration test updated — it previously asserted the wrong placement.
- Separate commit fixes two pre-existing clippy 1.96 lints on the base that failed `-D warnings`.

`cargo test` green (468 + 17), `cargo clippy --all-targets -- -D warnings` clean.

https://claude.ai/code/session_01F5pphTKqnTuSp9UktZZ6u8