### PR TITLE
fix(pi-claude-bridge): correct rate-limit reset dates and de-duplicate rejected-turn output

### DIFF
--- a/pi-extensions/pi-claude-bridge/bundle/index.js
+++ b/pi-extensions/pi-claude-bridge/bundle/index.js
@@ -44432,9 +44432,15 @@ function uniqueNonEmptyLines(values) {
   }
   return out;
 }
+function resetTimestampMs(value) {
+  let parsed = typeof value === "number" ? value : typeof value === "string" ? Date.parse(value) : Number.NaN;
+  if (!Number.isFinite(parsed)) return void 0;
+  if (typeof value === "number" && Math.abs(parsed) < 1e12) parsed *= 1e3;
+  return parsed;
+}
 function formatResetTimestamp(value) {
-  const parsed = typeof value === "number" ? value : typeof value === "string" ? Date.parse(value) : Number.NaN;
-  if (!Number.isFinite(parsed)) return "unknown";
+  const parsed = resetTimestampMs(value);
+  if (parsed === void 0) return "unknown";
   return new Date(parsed).toLocaleString(void 0, {
     day: "numeric",
     hour: "numeric",
@@ -44823,12 +44829,17 @@ function processAssistantMessage(message, model, customToolNameToPi) {
     }
     return;
   }
-  reapStaleQueuedResults(c);
-  c.resetToolTracking();
+  const sameMessage = typeof assistantMsg.id === "string" && assistantMsg.id.length > 0 && assistantMsg.id === c.currentMessageId;
+  if (!sameMessage) {
+    reapStaleQueuedResults(c);
+    c.resetToolTracking();
+  }
   c.beginChildMessage(assistantMsg.id);
-  debug(`processAssistantMessage fallback: ${assistantMsg.content.length} blocks, types=${assistantMsg.content.map((b) => b.type).join(",")}`);
+  debug(`processAssistantMessage fallback: ${assistantMsg.content.length} blocks, types=${assistantMsg.content.map((b) => b.type).join(",")}${sameMessage ? " (same message re-yield)" : ""}`);
+  const alreadyRendered = (type, content) => sameMessage && c.turnBlocks.some((b) => b.type === type && (type === "text" ? b.text : b.thinking) === content);
   for (const block of assistantMsg.content) {
     if (block.type === "text" && block.text) {
+      if (alreadyRendered("text", block.text)) continue;
       ensureTurnStarted();
       c.turnBlocks.push({ type: "text", text: block.text });
       const idx = c.turnBlocks.length - 1;
@@ -44836,6 +44847,7 @@ function processAssistantMessage(message, model, customToolNameToPi) {
       c.currentPiStream?.push({ type: "text_delta", contentIndex: idx, delta: block.text, partial: c.turnOutput });
       c.currentPiStream?.push({ type: "text_end", contentIndex: idx, content: block.text, partial: c.turnOutput });
     } else if (block.type === "thinking") {
+      if (alreadyRendered("thinking", block.thinking ?? "")) continue;
       ensureTurnStarted();
       c.turnBlocks.push({ type: "thinking", thinking: block.thinking ?? "", thinkingSignature: block.signature ?? "" });
       const idx = c.turnBlocks.length - 1;
@@ -44853,6 +44865,14 @@ function processAssistantMessage(message, model, customToolNameToPi) {
       const mappedName = mapToolName(block.name, customToolNameToPi);
       const mappedArgs = mapToolArgs(mappedName, block.input);
       c.recordToolCall(block.id, mappedName, mappedArgs);
+      const existingIdx = c.turnBlocks.findIndex((b) => b.type === "toolCall" && b.id === block.id);
+      if (existingIdx >= 0) {
+        const existing = c.turnBlocks[existingIdx];
+        existing.name = mappedName;
+        existing.arguments = mappedArgs;
+        c.updateToolCallArgs(block.id, mappedArgs);
+        continue;
+      }
       c.turnBlocks.push({
         type: "toolCall",
         id: block.id,
@@ -45167,7 +45187,7 @@ async function consumeQuery(sdkQuery, customToolNameToPi, model, cwd, bridgeConf
         debug("consumeQuery: rate_limit_event", JSON.stringify(info).slice(0, 300));
         if (info?.status === "rejected") {
           const resetsAt = formatResetTimestamp(info.resetsAt);
-          const resetAtMs = typeof info.resetsAt === "string" ? Date.parse(info.resetsAt) : void 0;
+          const resetAtMs = resetTimestampMs(info.resetsAt);
           const reason = `${info.rateLimitType ?? "unknown"} rate limit`;
           const launchedExtraUsage = isExtraUsageRequiredMessage(info) && launchExtraUsageHelperIfAllowed(cwd, bridgeConfig, reason);
           emitRateLimitEvent({
@@ -45851,6 +45871,7 @@ export {
   reapStaleQueuedResults,
   recordConnectorCallResult,
   reportToolResultMismatch,
+  resetTimestampMs,
   resolveClaudeExecutable,
   resolveClaudeOAuth,
   resolveConfiguredEffort,

--- a/pi-extensions/pi-claude-bridge/package.json
+++ b/pi-extensions/pi-claude-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vanillagreen/pi-claude-bridge",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Pi provider bridge that runs Claude Code through the Claude Agent SDK, with opt-in forwarding for Pi prompt context.",
   "type": "module",
   "keywords": [

--- a/pi-extensions/pi-claude-bridge/src/assistant-stream.ts
+++ b/pi-extensions/pi-claude-bridge/src/assistant-stream.ts
@@ -475,16 +475,30 @@ export function processAssistantMessage(message: SDKMessage, model: Model<any>, 
 		}
 		return;
 	}
-	reapStaleQueuedResults(c);
-	c.resetToolTracking();
+	// The SDK yields the SAME assistant message more than once (per-block
+	// partial copies and the completed message share one id). With stream
+	// events, the streamed path already renders content and the duplicates are
+	// naturally ignored; on this no-stream-events path each yield used to be
+	// re-rendered wholesale — a rate-limited turn printed "You've hit your
+	// weekly limit" twice. Same-message yields keep the turn's tracking (a
+	// reset mid-message would wipe live tool-claim state) and render only
+	// blocks not already rendered.
+	const sameMessage = typeof assistantMsg.id === "string" && assistantMsg.id.length > 0 && assistantMsg.id === c.currentMessageId;
+	if (!sameMessage) {
+		reapStaleQueuedResults(c);
+		c.resetToolTracking();
+	}
 	// The no-stream-events path also sees a message boundary. It is keyed on the
 	// message ID rather than trusted blindly, because this branch is ALSO reached
 	// for a message whose `message_start` already streamed — any message that
 	// produced no content blocks, since `turnSawStreamEvent` only tracks those.
 	c.beginChildMessage(assistantMsg.id);
-	debug(`processAssistantMessage fallback: ${assistantMsg.content.length} blocks, types=${assistantMsg.content.map((b: any) => b.type).join(",")}`);
+	debug(`processAssistantMessage fallback: ${assistantMsg.content.length} blocks, types=${assistantMsg.content.map((b: any) => b.type).join(",")}${sameMessage ? " (same message re-yield)" : ""}`);
+	const alreadyRendered = (type: string, content: string): boolean =>
+		sameMessage && c.turnBlocks.some((b: any) => b.type === type && (type === "text" ? b.text : b.thinking) === content);
 	for (const block of assistantMsg.content) {
 		if (block.type === "text" && block.text) {
+			if (alreadyRendered("text", block.text)) continue;
 			ensureTurnStarted();
 			c.turnBlocks.push({ type: "text", text: block.text });
 			const idx = c.turnBlocks.length - 1;
@@ -492,6 +506,7 @@ export function processAssistantMessage(message: SDKMessage, model: Model<any>, 
 			c.currentPiStream?.push({ type: "text_delta", contentIndex: idx, delta: block.text, partial: c.turnOutput });
 			c.currentPiStream?.push({ type: "text_end", contentIndex: idx, content: block.text, partial: c.turnOutput });
 		} else if (block.type === "thinking") {
+			if (alreadyRendered("thinking", block.thinking ?? "")) continue;
 			ensureTurnStarted();
 			c.turnBlocks.push({ type: "thinking", thinking: block.thinking ?? "", thinkingSignature: block.signature ?? "" });
 			const idx = c.turnBlocks.length - 1;
@@ -511,6 +526,17 @@ export function processAssistantMessage(message: SDKMessage, model: Model<any>, 
 			const mappedName = mapToolName(block.name, customToolNameToPi);
 			const mappedArgs = mapToolArgs(mappedName, block.input);
 			c.recordToolCall(block.id, mappedName, mappedArgs);
+			// A same-message re-yield of an already-mirrored call refreshes its
+			// arguments in place — a second toolCall block would make pi dispatch
+			// the tool twice.
+			const existingIdx = c.turnBlocks.findIndex((b: any) => b.type === "toolCall" && b.id === block.id);
+			if (existingIdx >= 0) {
+				const existing = c.turnBlocks[existingIdx] as any;
+				existing.name = mappedName;
+				existing.arguments = mappedArgs;
+				c.updateToolCallArgs(block.id, mappedArgs);
+				continue;
+			}
 			c.turnBlocks.push({
 				type: "toolCall", id: block.id,
 				name: mappedName,

--- a/pi-extensions/pi-claude-bridge/src/index.ts
+++ b/pi-extensions/pi-claude-bridge/src/index.ts
@@ -45,7 +45,7 @@ import { flushConnectorCallAudit } from "./connector-audit.js";
 import { readCachedConnectors, writeCachedConnectors } from "./connector-cache.js";
 import { restoreSharedSessionFromPi, schedulePersistSharedSession, syncSharedSession } from "./session-persistence.js";
 import { STREAM_IDLE_BACKOFF_HINT_MS, activeStreamIdleWatchdogs, buildStreamIdleTimeoutErrorMessage, createStreamIdleWatchdog, formatDurationShort, streamIdleTimeoutMsFromEnv } from "./stream-idle-watchdog.js";
-import { RATE_LIMIT_AUTO_RESUME_EVENT, RATE_LIMIT_TOKEN, formatAllowedRateLimitWarning, formatResetTimestamp, isExtraUsageRequiredMessage, uniqueNonEmptyLines } from "./rate-limit.js";
+import { RATE_LIMIT_AUTO_RESUME_EVENT, RATE_LIMIT_TOKEN, formatAllowedRateLimitWarning, formatResetTimestamp, isExtraUsageRequiredMessage, resetTimestampMs, uniqueNonEmptyLines } from "./rate-limit.js";
 import { mapToolArgs } from "./tool-mapping.js";
 import { ensureTurnStarted, finalizeCurrentStream, finalizeToolUseTurnFromMcpInvocation, noteChildExecutedToolResults, processAssistantMessage, processStreamEvent, scheduleToolUseTurnEnd, updateTurnOutputModel } from "./assistant-stream.js";
 
@@ -58,7 +58,7 @@ export { CONNECTOR_CALL_CUSTOM_TYPE, connectorResultByteSize, flushConnectorCall
 export { CLAUDE_AI_CONNECTOR_TOOL_PATTERNS, connectorMcpServers, connectorDeclarationsDisabled, CLAUDE_BRIDGE_TOOL_ISOLATION, CONNECTOR_DISCOVERY_TOOLS, CONNECTOR_WRITE_TOOLS, DISALLOWED_BUILTIN_TOOLS, connectorQueryOptions, connectorWriteDenyHook, connectorWriteModeFor, connectorWriteModeFromEnv, connectorsEnabledFor, connectorsEnabledFromEnv, isChildExecutedTool, isConnectorWriteTool, toolIsolationForQuery } from "./connectors.js";
 export { restoreSharedSessionFromPi, shouldRestorePersistedBridgeEntry } from "./session-persistence.js";
 export { DEFAULT_STREAM_IDLE_TIMEOUT_MS, STREAM_IDLE_BACKOFF_HINT_MS, STREAM_IDLE_TIMEOUT_ENV, buildStreamIdleTimeoutErrorMessage, createStreamIdleWatchdog, streamIdleTimeoutMsFromEnv, type StreamIdleTimeoutInfo, type StreamIdleWatchdog, type StreamIdleWatchdogState } from "./stream-idle-watchdog.js";
-export { ALLOWED_RATE_LIMIT_WARNING_UTILIZATION_THRESHOLD, formatAllowedRateLimitWarning, formatResetTimestamp, isExtraUsageRequiredMessage, normalizeRateLimitUtilization, uniqueNonEmptyLines } from "./rate-limit.js";
+export { ALLOWED_RATE_LIMIT_WARNING_UTILIZATION_THRESHOLD, formatAllowedRateLimitWarning, formatResetTimestamp, isExtraUsageRequiredMessage, normalizeRateLimitUtilization, resetTimestampMs, uniqueNonEmptyLines } from "./rate-limit.js";
 export { mapToolName } from "./tool-mapping.js";
 export { cancelScheduledToolUseEnd, endToolUseTurn, finalizeToolUseTurnFromMcpInvocation, noteChildExecutedToolResults, processAssistantMessage, processStreamEvent, reapStaleQueuedResults, scheduleToolUseTurnEnd } from "./assistant-stream.js";
 
@@ -494,7 +494,7 @@ async function consumeQuery(
 				debug("consumeQuery: rate_limit_event", JSON.stringify(info).slice(0, 300));
 				if (info?.status === "rejected") {
 					const resetsAt = formatResetTimestamp(info.resetsAt);
-					const resetAtMs = typeof info.resetsAt === "string" ? Date.parse(info.resetsAt) : undefined;
+					const resetAtMs = resetTimestampMs(info.resetsAt);
 					const reason = `${info.rateLimitType ?? "unknown"} rate limit`;
 					const launchedExtraUsage = isExtraUsageRequiredMessage(info) && launchExtraUsageHelperIfAllowed(cwd, bridgeConfig, reason);
 					emitRateLimitEvent({

--- a/pi-extensions/pi-claude-bridge/src/rate-limit.ts
+++ b/pi-extensions/pi-claude-bridge/src/rate-limit.ts
@@ -24,9 +24,22 @@ export function uniqueNonEmptyLines(values: unknown[]): string[] {
 	return out;
 }
 
+/** Epoch milliseconds from an SDK reset timestamp, or undefined.
+ *  `SDKRateLimitInfo.resetsAt` is a bare number in epoch SECONDS (measured:
+ *  treating it as ms rendered "resets Jan 21, 1970" for a Jul 2026 reset).
+ *  The unit is undocumented, so detect by magnitude — epoch seconds stay below
+ *  1e12 until the year 33658, epoch ms passed 1e12 in 2001 — and accept ISO
+ *  strings for older payloads. */
+export function resetTimestampMs(value: unknown): number | undefined {
+	let parsed = typeof value === "number" ? value : typeof value === "string" ? Date.parse(value) : Number.NaN;
+	if (!Number.isFinite(parsed)) return undefined;
+	if (typeof value === "number" && Math.abs(parsed) < 1e12) parsed *= 1000;
+	return parsed;
+}
+
 export function formatResetTimestamp(value: unknown): string {
-	const parsed = typeof value === "number" ? value : typeof value === "string" ? Date.parse(value) : Number.NaN;
-	if (!Number.isFinite(parsed)) return "unknown";
+	const parsed = resetTimestampMs(value);
+	if (parsed === undefined) return "unknown";
 	return new Date(parsed).toLocaleString(undefined, {
 		day: "numeric",
 		hour: "numeric",

--- a/pi-extensions/pi-claude-bridge/tests/unit-assistant-boundary.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-assistant-boundary.mjs
@@ -266,3 +266,66 @@ describe("assistant tool-use boundary fallback", () => {
 		assert.equal(c.turnBlocks.length, 0);
 	});
 });
+
+describe("no-stream-events fallback: same-message re-yields", () => {
+	beforeEach(() => resetStack());
+
+	it("renders a re-yielded identical text block only once", () => {
+		// The SDK yields the SAME assistant message more than once (partial +
+		// completed copies share one id). A rate-limited turn used to print
+		// "You've hit your weekly limit" twice through this path.
+		const c = ctx();
+		c.resetTurnState(model);
+		const events = installFakeStream();
+		const msg = {
+			type: "assistant",
+			message: {
+				id: "msg_dup",
+				content: [{ type: "text", text: "You've hit your weekly limit · resets Jul 30, 4am" }],
+				usage: { input_tokens: 1, output_tokens: 2 },
+			},
+		};
+
+		processAssistantMessage(msg, model, new Map());
+		processAssistantMessage(msg, model, new Map());
+
+		assert.equal(c.turnBlocks.filter((b) => b.type === "text").length, 1);
+		assert.equal(events.filter((e) => e.type === "text_start").length, 1);
+	});
+
+	it("a distinct new message still renders", () => {
+		const c = ctx();
+		c.resetTurnState(model);
+		const events = installFakeStream();
+		const mk = (id, text) => ({ type: "assistant", message: { id, content: [{ type: "text", text }] } });
+
+		processAssistantMessage(mk("msg_a", "first"), model, new Map());
+		processAssistantMessage(mk("msg_b", "second"), model, new Map());
+
+		assert.deepEqual(c.turnBlocks.filter((b) => b.type === "text").map((b) => b.text), ["first", "second"]);
+		assert.equal(events.filter((e) => e.type === "text_start").length, 2);
+	});
+
+	it("does not duplicate a re-yielded tool call block and keeps claim state", () => {
+		const c = ctx();
+		c.resetTurnState(model);
+		const events = installFakeStream();
+		const msg = {
+			type: "assistant",
+			message: {
+				id: "msg_tool",
+				content: [{ type: "tool_use", id: "toolu_dup", name: "mcp__custom-tools__bash", input: { command: "echo hi" } }],
+			},
+		};
+
+		processAssistantMessage(msg, model, new Map([["mcp__custom-tools__bash", "bash"]]));
+		const claim = c.claimToolCall("bash", { command: "echo hi", timeout: 120 });
+		assert.equal(claim.toolCallId, "toolu_dup");
+
+		processAssistantMessage(msg, model, new Map([["mcp__custom-tools__bash", "bash"]]));
+
+		assert.equal(c.turnBlocks.filter((b) => b.type === "toolCall").length, 1, "no duplicate toolCall block");
+		assert.equal(events.filter((e) => e.type === "toolcall_start").length, 1);
+		assert.equal(c.claimedToolCallIds.has("toolu_dup"), true, "same-message re-yield must not wipe claim state");
+	});
+});

--- a/pi-extensions/pi-claude-bridge/tests/unit-rate-limit.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-rate-limit.mjs
@@ -9,9 +9,35 @@ import {
 	buildStreamIdleTimeoutErrorMessage,
 	createStreamIdleWatchdog,
 	formatAllowedRateLimitWarning,
+	formatResetTimestamp,
 	normalizeRateLimitUtilization,
+	resetTimestampMs,
 	streamIdleTimeoutMsFromEnv,
 } from "../src/index.ts";
+
+describe("rate-limit reset timestamps", () => {
+	// SDKRateLimitInfo.resetsAt is a bare number in epoch SECONDS. Treating it
+	// as milliseconds rendered "resets Jan 21, 1970" for a Jul 2026 reset.
+	const JUL_30_2026_SECONDS = 1785412800; // 2026-07-30T04:00:00-07:00
+
+	it("treats a bare numeric resetsAt as epoch seconds", () => {
+		assert.equal(resetTimestampMs(JUL_30_2026_SECONDS), JUL_30_2026_SECONDS * 1000);
+		assert.match(formatResetTimestamp(JUL_30_2026_SECONDS), /2026/);
+		assert.doesNotMatch(formatResetTimestamp(JUL_30_2026_SECONDS), /1970/);
+	});
+
+	it("passes epoch milliseconds through unchanged", () => {
+		assert.equal(resetTimestampMs(JUL_30_2026_SECONDS * 1000), JUL_30_2026_SECONDS * 1000);
+		assert.match(formatResetTimestamp(JUL_30_2026_SECONDS * 1000), /2026/);
+	});
+
+	it("parses ISO strings and rejects garbage", () => {
+		assert.equal(resetTimestampMs("2026-07-30T11:00:00Z"), Date.parse("2026-07-30T11:00:00Z"));
+		assert.equal(resetTimestampMs("not a date"), undefined);
+		assert.equal(resetTimestampMs(undefined), undefined);
+		assert.equal(formatResetTimestamp(undefined), "unknown");
+	});
+});
 
 describe("rate_limit_event allowed_warning", () => {
 	it("suppresses low fractional utilization for seven_day warnings", () => {


### PR DESCRIPTION
Follow-up to #939, from a live screenshot: hitting the weekly limit printed four lines for one event — a bridge warning with "resets **Jan 21, 1970**", the same "You've hit your weekly limit" text **twice**, and the SDK's error result.

- **1970 date**: `SDKRateLimitInfo.resetsAt` is a bare number in epoch **seconds**; `formatResetTimestamp` treated numbers as ms. New `resetTimestampMs` detects the unit by magnitude (numbers < 1e12 are seconds) and also feeds the auto-resume event's `resetAtMs`, which was previously only populated for string payloads.
- **Duplicate text**: the SDK yields the same assistant message more than once (partial + completed copies share one id); the no-stream-events fallback re-rendered every yield. Same-id re-yields now render only unrendered blocks, keep tool-claim state (the mid-message `resetToolTracking` wiped it), and refresh a re-yielded `tool_use`'s args in place instead of duplicating the block pi would then dispatch twice.
- The remaining two lines (CC's own notice + the SDK error that fails the turn) are correct and kept.

347 unit tests pass (6 new: epoch-unit handling, re-yield text/tool dedup, claim-state preservation). Version 1.10.1; consumers can pick it up on their next sync — display-level, no API change.

https://claude.ai/code/session_01F5pphTKqnTuSp9UktZZ6u8