### PR TITLE
fix(pi-claude-bridge): dedup duplicated rejected-turn text across differing yield ids

### DIFF
--- a/pi-extensions/pi-claude-bridge/bundle/index.js
+++ b/pi-extensions/pi-claude-bridge/bundle/index.js
@@ -44836,7 +44836,7 @@ function processAssistantMessage(message, model, customToolNameToPi) {
   }
   c.beginChildMessage(assistantMsg.id);
   debug(`processAssistantMessage fallback: ${assistantMsg.content.length} blocks, types=${assistantMsg.content.map((b) => b.type).join(",")}${sameMessage ? " (same message re-yield)" : ""}`);
-  const alreadyRendered = (type, content) => sameMessage && c.turnBlocks.some((b) => b.type === type && (type === "text" ? b.text : b.thinking) === content);
+  const alreadyRendered = (type, content) => c.turnBlocks.some((b) => b.type === type && (type === "text" ? b.text : b.thinking) === content);
   for (const block of assistantMsg.content) {
     if (block.type === "text" && block.text) {
       if (alreadyRendered("text", block.text)) continue;
@@ -45143,8 +45143,12 @@ async function consumeQuery(sdkQuery, customToolNameToPi, model, cwd, bridgeConf
         break;
       case "result":
         if (!ctx().turnSawStreamEvent && message.subtype === "success") {
-          ensureTurnStarted();
           const text = message.result || "";
+          if (ctx().turnBlocks.some((b) => b.type === "text" && b.text === text)) {
+            debug("consumeQuery: result text already rendered by assistant fallback; skipping duplicate");
+            break;
+          }
+          ensureTurnStarted();
           ctx().turnBlocks.push({ type: "text", text });
           const idx = ctx().turnBlocks.length - 1;
           ctx().currentPiStream?.push({ type: "text_start", contentIndex: idx, partial: ctx().turnOutput });

--- a/pi-extensions/pi-claude-bridge/package.json
+++ b/pi-extensions/pi-claude-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vanillagreen/pi-claude-bridge",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "description": "Pi provider bridge that runs Claude Code through the Claude Agent SDK, with opt-in forwarding for Pi prompt context.",
   "type": "module",
   "keywords": [

--- a/pi-extensions/pi-claude-bridge/src/assistant-stream.ts
+++ b/pi-extensions/pi-claude-bridge/src/assistant-stream.ts
@@ -494,8 +494,15 @@ export function processAssistantMessage(message: SDKMessage, model: Model<any>, 
 	// produced no content blocks, since `turnSawStreamEvent` only tracks those.
 	c.beginChildMessage(assistantMsg.id);
 	debug(`processAssistantMessage fallback: ${assistantMsg.content.length} blocks, types=${assistantMsg.content.map((b: any) => b.type).join(",")}${sameMessage ? " (same message re-yield)" : ""}`);
+	// Deduped against the WHOLE current turn, not just same-id re-yields: a
+	// rejected turn's synthesized error message ("You've hit your weekly limit")
+	// arrives as multiple assistant yields whose ids DIFFER or are absent
+	// (measured 2026-07-28: one pi message, two byte-identical text blocks), so
+	// an id-keyed guard alone still rendered it twice. A model legitimately
+	// producing two byte-identical full blocks in one turn is vanishingly rare;
+	// rendering such a duplicate once is the better failure mode.
 	const alreadyRendered = (type: string, content: string): boolean =>
-		sameMessage && c.turnBlocks.some((b: any) => b.type === type && (type === "text" ? b.text : b.thinking) === content);
+		c.turnBlocks.some((b: any) => b.type === type && (type === "text" ? b.text : b.thinking) === content);
 	for (const block of assistantMsg.content) {
 		if (block.type === "text" && block.text) {
 			if (alreadyRendered("text", block.text)) continue;

--- a/pi-extensions/pi-claude-bridge/src/index.ts
+++ b/pi-extensions/pi-claude-bridge/src/index.ts
@@ -442,8 +442,15 @@ async function consumeQuery(
 				break;
 			case "result":
 				if (!ctx().turnSawStreamEvent && message.subtype === "success") {
-					ensureTurnStarted();
 					const text = message.result || "";
+					// The no-stream-events assistant fallback may have already rendered
+					// this exact text (it does not set turnSawStreamEvent) — re-pushing
+					// it here is the other half of the duplicated-output bug.
+					if (ctx().turnBlocks.some((b: any) => b.type === "text" && b.text === text)) {
+						debug("consumeQuery: result text already rendered by assistant fallback; skipping duplicate");
+						break;
+					}
+					ensureTurnStarted();
 					ctx().turnBlocks.push({ type: "text", text });
 					const idx = ctx().turnBlocks.length - 1;
 					ctx().currentPiStream?.push({ type: "text_start", contentIndex: idx, partial: ctx().turnOutput });

--- a/pi-extensions/pi-claude-bridge/tests/unit-assistant-boundary.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-assistant-boundary.mjs
@@ -306,6 +306,24 @@ describe("no-stream-events fallback: same-message re-yields", () => {
 		assert.equal(events.filter((e) => e.type === "text_start").length, 2);
 	});
 
+	it("renders identical text only once even when the yields carry different ids", () => {
+		// A rejected turn's synthesized error message arrives as multiple yields
+		// whose ids differ or are absent — measured 2026-07-28: one pi message
+		// carried two byte-identical "You've hit your weekly limit" blocks.
+		const c = ctx();
+		c.resetTurnState(model);
+		const events = installFakeStream();
+		const text = "You've hit your weekly limit · resets Jul 30, 4am (America/Los_Angeles)";
+		const mk = (id) => ({ type: "assistant", message: { ...(id ? { id } : {}), content: [{ type: "text", text }] } });
+
+		processAssistantMessage(mk("msg_attempt_1"), model, new Map());
+		processAssistantMessage(mk("msg_attempt_2"), model, new Map());
+		processAssistantMessage(mk(undefined), model, new Map());
+
+		assert.equal(c.turnBlocks.filter((b) => b.type === "text").length, 1);
+		assert.equal(events.filter((e) => e.type === "text_start").length, 1);
+	});
+
 	it("does not duplicate a re-yielded tool call block and keeps claim state", () => {
 		const c = ctx();
 		c.resetTurnState(model);


### PR DESCRIPTION
Follow-up to #945 — the duplicate "You've hit your weekly limit" line survived 1.10.1: the dedup keyed on the assistant message id, but the rejected turn's synthesized error message arrives as multiple yields whose ids **differ or are absent** (verified in the live session file: one pi assistant message, two byte-identical text blocks).

- The no-stream-events fallback now dedups byte-identical text/thinking blocks against the **whole current turn**, not just same-id re-yields. A model legitimately producing two byte-identical full blocks in one turn is vanishingly rare; rendering such a duplicate once is the better failure mode.
- Second latent path closed: the `result`-success renderer runs when `turnSawStreamEvent` is false, which the assistant fallback never sets — it could re-push text the fallback already rendered. It now skips already-rendered text.

348 unit tests pass (1 new). Version 1.10.2.

https://claude.ai/code/session_01F5pphTKqnTuSp9UktZZ6u8