### PR TITLE
pi-claude-bridge 2.0.0: native pi provider registration (requires pi ≥ 0.81)

### DIFF
--- a/pi-extensions/pi-claude-bridge/DEVELOPMENT.md
+++ b/pi-extensions/pi-claude-bridge/DEVELOPMENT.md
@@ -48,34 +48,35 @@ The audit map is query-scoped and is NOT cleared by `resetToolTracking` — that
 
 Note that pi/core's `createBranchedSession` copies every non-label entry root→leaf, so a fork inherits the parent's connector-call records. Harmless for an audit trail, unlike the `claude-bridge-session` marker it sits beside, which needed a `piSessionId` guard for exactly that reason.
 
-## Provider registration and the pi ≥0.81 native provider API (evaluated 2026-07-28, not adopted)
+## Provider registration — native pi ≥0.81 provider API (adopted in 2.0)
 
-The bridge registers via the legacy `registerProvider(name, config)` overload, gated by real
-credential presence (`auth-presence.ts` `decideRegistration`) and two process-global symbol tokens
-(`PRIMARY_INSTANCE_KEY`, `ACTIVE_STREAM_SIMPLE_KEY`). pi 0.81 added a first-class
-`registerProvider(provider: Provider)` form whose `auth.apiKey.resolve()`/`check()` report
-configured-ness so pi's availability snapshot hides unconfigured providers, which looks like a
-replacement for the credential-gated register/unregister machinery. It was evaluated against
-pi-coding-agent 0.82.1 sources and rejected for now:
+Since 2.0 the bridge registers a native `Provider` object (`native-provider.ts`) via
+`pi.registerProvider(provider)`: registration is UNCONDITIONAL (once primary), and the provider's
+own `auth.apiKey.check()/resolve()` report configured-ness from the same existence-only credential
+probes as before (`auth-presence.ts`), so pi itself hides claude-bridge models while no Claude
+account is connected and shows them when one appears. The 1.x credential-gated
+register/unregister state machine (`decideRegistration`) is gone. **Hosts must embed pi ≥0.81**
+(peer range `>=0.81.0`); on an older host the extension declines loudly once
+(`NATIVE_PROVIDER_UNSUPPORTED_MESSAGE`) instead of registering wrongly through the legacy overload.
 
-- **The symbol guards are not removable.** `registerNativeProvider` (model-runtime.js) is
-  upsert-by-id that *replaces* the stored provider object — a subagent module reload re-registering
-  the same id would swap in ITS `streamSimple` closure, exactly the split-brain the tokens exist to
-  prevent. The largest piece of the machinery survives the migration untouched.
-- **The legacy path is not removable either.** memsira/drovr embed pi 0.80.x with peer range `*`,
-  so the native form would have to be feature-detected and the legacy path kept indefinitely — two
-  parallel registration state machines instead of one, both needing tests.
-- **Mid-session credential changes would regress.** Today an external `claude login`/logout is
-  reflected deterministically at every session_start and at pre-spawn fail-fast. The native path
-  hands that to pi's availability-snapshot refresh cadence (`snapshot.configuredProviders`), which
-  the bridge does not control.
-- The subscription-billing constraint is NOT the blocker: under the native form `streamSimple`
-  would remain the bridge's own CC-subprocess router. Registration plumbing is simply not improved
-  by the migration while pre-0.81 hosts must be supported.
+This was first evaluated on 2026-07-28 and NOT adopted, then adopted the same day after the owner
+lifted the pre-0.81 host-compat constraint (memsira/drovr upgrade their embedded pi in lockstep —
+they are the only consumers). What the original evaluation flagged, and how each point resolved:
 
-Revisit when the minimum supported embedded host is pi ≥0.81 AND pi offers owner-aware provider
-dedupe (so the guards could go too); then the native form becomes a true replacement rather than a
-duplicate path.
+- **The symbol guards stay — by design, not oversight.** pi's `registerNativeProvider` is
+  upsert-by-id that *replaces* the stored provider object; an unguarded subagent module reload
+  re-registering the same id would swap in ITS `streamSimple` closure and split-brain the shared
+  session. `PRIMARY_INSTANCE_KEY`/`ACTIVE_STREAM_SIMPLE_KEY` therefore survive into 2.x. If pi
+  ever grows owner-aware provider dedupe, the guards can go.
+- **The two-parallel-paths objection dissolved** with the host floor at 0.81: there is exactly one
+  registration path in 2.x.
+- **Mid-session credential timing is kept deterministic** rather than left to pi's refresh
+  cadence: session_start and pre-spawn re-UPSERT the same provider object, which triggers pi's
+  model-snapshot/availability recompute at exactly the boundaries 1.x re-checked — and the
+  pre-spawn `hasClaudeCredentials()` fail-fast in `streamSimple` remains, so a logout is a clear
+  actionable error at first use even if a picker snapshot is stale.
+- The subscription-billing constraint is untouched: BOTH native stream entry points
+  (`stream`/`streamSimple`) are the same Claude Code subprocess router — there is no raw-API path.
 
 ## Connector write enforcement
 

--- a/pi-extensions/pi-claude-bridge/README.md
+++ b/pi-extensions/pi-claude-bridge/README.md
@@ -23,6 +23,10 @@ Forked from [`elidickinson/pi-claude-bridge`](https://github.com/elidickinson/pi
 
 ## Install
 
+Requires pi ≥ 0.81 (bridge 2.x registers through pi's native provider API, so pi shows the
+Claude models only while a Claude account is actually connected). On older pi, install
+`@vanillagreen/pi-claude-bridge@1.x` instead.
+
 Via [npm](https://www.npmjs.com/package/@vanillagreen/pi-claude-bridge):
 
 ```bash

--- a/pi-extensions/pi-claude-bridge/bundle/index.js
+++ b/pi-extensions/pi-claude-bridge/bundle/index.js
@@ -28610,10 +28610,42 @@ function hasClaudeCredentials(env = process.env, platform = osPlatform()) {
   if (platform === "darwin") return true;
   return false;
 }
-function decideRegistration(state) {
-  if (!state.isPrimary) return "noop";
-  if (state.credentialed) return state.registered ? "noop" : "register";
-  return "unregister";
+
+// src/native-provider.ts
+var NATIVE_PROVIDER_UNSUPPORTED_MESSAGE = "Claude bridge 2.x requires pi >= 0.81 (native provider API). Upgrade the host pi, or pin @vanillagreen/pi-claude-bridge@1.x.";
+function supportsNativeProvider(piAi2) {
+  return typeof piAi2?.createProvider === "function";
+}
+function claudeAuthSourceLabel(env = process.env) {
+  if (env.CLAUDE_CODE_OAUTH_TOKEN?.trim()) return "CLAUDE_CODE_OAUTH_TOKEN";
+  if (env.ANTHROPIC_API_KEY?.trim()) return "ANTHROPIC_API_KEY";
+  if (env.ANTHROPIC_AUTH_TOKEN?.trim()) return "ANTHROPIC_AUTH_TOKEN";
+  return "Claude Code login";
+}
+function buildNativeProvider(piAi2, models, streamSimple, env = process.env) {
+  if (!supportsNativeProvider(piAi2)) throw new Error(NATIVE_PROVIDER_UNSUPPORTED_MESSAGE);
+  const stamped = models.map((model) => ({ api: "claude-bridge", baseUrl: "claude-bridge", provider: PROVIDER_ID, ...model }));
+  const streams = {
+    stream: streamSimple,
+    streamSimple
+  };
+  return piAi2.createProvider({
+    id: PROVIDER_ID,
+    name: "Claude (Claude Code)",
+    baseUrl: "claude-bridge",
+    auth: {
+      apiKey: {
+        name: "Claude Code credentials",
+        // check() exists so pi's availability pass never has to call
+        // resolve(): both are existence-only, but check is the documented
+        // side-effect-free probe.
+        check: async () => hasClaudeCredentials(env) ? { type: "api_key", source: claudeAuthSourceLabel(env) } : void 0,
+        resolve: async () => hasClaudeCredentials(env) ? { auth: { apiKey: "not-used" }, source: claudeAuthSourceLabel(env) } : void 0
+      }
+    },
+    models: stamped,
+    api: streams
+  });
 }
 
 // src/agents-md.ts
@@ -45324,6 +45356,8 @@ function releaseProviderTokens(event) {
     g[PRIMARY_INSTANCE_KEY] = void 0;
   }
 }
+var nativeProviderInstance;
+var notifiedNativeUnsupported = false;
 function applyProviderRegistration(trigger) {
   const pi = extensionApi;
   if (!pi) {
@@ -45332,33 +45366,28 @@ function applyProviderRegistration(trigger) {
   }
   const g = globalThis;
   const isPrimary = claimPrimaryInstance();
+  if (!isPrimary) {
+    debug(`${trigger}: registration noop \u2014 non-primary instance (module=${moduleInstanceId})`);
+    return;
+  }
+  if (!supportsNativeProvider(_piAi)) {
+    debug(`${trigger}: host pi-ai lacks createProvider; refusing to register (module=${moduleInstanceId})`);
+    if (!notifiedNativeUnsupported) {
+      notifiedNativeUnsupported = true;
+      safeNotify(NATIVE_PROVIDER_UNSUPPORTED_MESSAGE, "error");
+    }
+    return;
+  }
   const credentialed = hasClaudeCredentials();
-  const registered = g[ACTIVE_STREAM_SIMPLE_KEY] === streamClaudeAgentSdk;
-  const decision = decideRegistration({ credentialed, isPrimary, registered });
-  debug(`${trigger}: registration decision=${decision} credentialed=${credentialed} isPrimary=${isPrimary} registered=${registered} (module=${moduleInstanceId})`);
-  if (decision === "register") {
-    if (connectorsEnabledFor(loadConfig(process.cwd()))) primeConnectorServers();
-    g[ACTIVE_STREAM_SIMPLE_KEY] = streamClaudeAgentSdk;
-    try {
-      pi.registerProvider(PROVIDER_ID, {
-        baseUrl: "claude-bridge",
-        apiKey: "not-used",
-        api: "claude-bridge",
-        models: MODELS,
-        // Cast: pi-ai AssistantMessageEventStream diamond dep between pi-coding-agent and pi-agent-core
-        streamSimple: streamClaudeAgentSdk
-      });
-    } catch (err) {
-      if (g[ACTIVE_STREAM_SIMPLE_KEY] === streamClaudeAgentSdk) g[ACTIVE_STREAM_SIMPLE_KEY] = void 0;
-      debug(`${trigger}: registerProvider threw; released stream guard for retry (kept primary):`, err);
-    }
-  } else if (decision === "unregister") {
-    try {
-      pi.unregisterProvider(PROVIDER_ID);
-    } catch (err) {
-      debug(`${trigger}: unregisterProvider threw (ignored):`, err);
-    }
+  debug(`${trigger}: native registration upsert, credentialed=${credentialed} (module=${moduleInstanceId})`);
+  if (credentialed && connectorsEnabledFor(loadConfig(process.cwd()))) primeConnectorServers();
+  g[ACTIVE_STREAM_SIMPLE_KEY] = streamClaudeAgentSdk;
+  try {
+    nativeProviderInstance ??= buildNativeProvider(_piAi, MODELS, streamClaudeAgentSdk);
+    pi.registerProvider(nativeProviderInstance);
+  } catch (err) {
     if (g[ACTIVE_STREAM_SIMPLE_KEY] === streamClaudeAgentSdk) g[ACTIVE_STREAM_SIMPLE_KEY] = void 0;
+    debug(`${trigger}: registerProvider threw; released stream guard for retry (kept primary):`, err);
   }
 }
 function streamClaudeAgentSdk(model, context, options) {
@@ -45905,14 +45934,17 @@ export {
   DEFAULT_STREAM_IDLE_TIMEOUT_MS,
   DISALLOWED_BUILTIN_TOOLS,
   INTEGRITY_CUSTOM_TYPE,
+  NATIVE_PROVIDER_UNSUPPORTED_MESSAGE,
   STREAM_IDLE_BACKOFF_HINT_MS,
   STREAM_IDLE_TIMEOUT_ENV,
   __testGetBridgeIntegrityState,
   __testSetBridgeIntegrityState,
   appendIntegrityEntry,
+  buildNativeProvider,
   buildStreamIdleTimeoutErrorMessage,
   cancelScheduledToolUseEnd,
   classifyClaudeExecutableBytes,
+  claudeAuthSourceLabel,
   connectorCachePath,
   connectorCacheScopeKey,
   connectorDeclarationsDisabled,
@@ -45963,6 +45995,7 @@ export {
   shouldRestorePersistedBridgeEntry,
   spawnClaudeCodeWithDiagnostics,
   streamIdleTimeoutMsFromEnv,
+  supportsNativeProvider,
   toolIsolationForQuery,
   uniqueNonEmptyLines,
   wrapClaudeSpawnErrorForSdk,

--- a/pi-extensions/pi-claude-bridge/package.json
+++ b/pi-extensions/pi-claude-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vanillagreen/pi-claude-bridge",
-  "version": "1.11.0",
+  "version": "2.0.0",
   "description": "Pi provider bridge that runs Claude Code through the Claude Agent SDK, with opt-in forwarding for Pi prompt context.",
   "type": "module",
   "keywords": [
@@ -148,8 +148,8 @@
     "change-case": "^5.4.4"
   },
   "peerDependencies": {
-    "@earendil-works/pi-ai": "*",
-    "@earendil-works/pi-coding-agent": "*"
+    "@earendil-works/pi-ai": ">=0.81.0",
+    "@earendil-works/pi-coding-agent": ">=0.81.0"
   },
   "devDependencies": {
     "@earendil-works/pi-ai": "^0.82.1",

--- a/pi-extensions/pi-claude-bridge/src/auth-presence.ts
+++ b/pi-extensions/pi-claude-bridge/src/auth-presence.ts
@@ -6,10 +6,12 @@
 // "not-used"` as "configured" and the provider would look connected while every
 // request fails at spawn time.
 //
-// This module answers two pure questions used to gate registration:
-//   1. hasClaudeCredentials() — are real credentials present RIGHT NOW?
-//   2. decideRegistration()   — given credential presence + the primary-instance
-//      / stream-guard tokens, should we register / unregister / do nothing?
+// This module answers one pure question: hasClaudeCredentials() — are real
+// credentials present RIGHT NOW? Since 2.0 it feeds the native provider's
+// auth check/resolve (native-provider.ts) and the pre-spawn fail-fast, rather
+// than gating register/unregister transitions (the 1.x decideRegistration
+// state machine is gone — registration is unconditional and pi hides
+// unconfigured providers' models itself).
 //
 // SECURITY: this module only ever checks for the EXISTENCE of credentials — a
 // file's presence, an env var being non-empty, a settings key being a non-empty
@@ -110,49 +112,3 @@ export function hasClaudeCredentials(
 	return false;
 }
 
-/**
- * Snapshot of the inputs to a registration decision.
- *
- * The bridge keeps two process-global tokens (Symbol.for): a PRIMARY-instance
- * token, claimed unconditionally by the first-loaded module instance, and the
- * stream-guard token holding the registered instance's streamSimple. ONLY the
- * primary instance may ever register/unregister or claim the stream guard — this
- * prevents a subagent module reload (a fresh, non-primary instance) from
- * stealing ownership and registering ITS streamSimple, which would split-brain
- * the shared session/ctx and break tool-result delivery.
- */
-export interface RegistrationState {
-	/** Does the machine have Claude credentials right now? */
-	credentialed: boolean;
-	/** Is THIS module instance the primary (first-loaded) instance? */
-	isPrimary: boolean;
-	/** Has this instance already registered (owns the stream guard)? */
-	registered: boolean;
-}
-
-export type RegistrationDecision = "register" | "unregister" | "noop";
-
-/**
- * Pure decision for extension load, every session_start re-check, and the
- * pre-spawn fail-fast path.
- *
- * Rules:
- *   - Not the primary instance                    → NOOP (never touch registration).
- *   - Primary + credentialed + not registered     → REGISTER (claim guard + register).
- *   - Primary + credentialed + already registered → NOOP.
- *   - Primary + uncredentialed                    → UNREGISTER (defensive).
- *
- * The uncredentialed primary always returns UNREGISTER rather than NOOP:
- * pi.unregisterProvider is idempotent ("Has no effect if the provider was never
- * registered"), and a defensive call is the ONLY way to retract a registration
- * that survived a /reload — the ModelRegistry's registeredProviders is a
- * process-lifetime Map and module reload does NOT clear it. (At extension-load
- * time this defensive unregister only filters the pending-registration queue and
- * cannot mutate the persistent registry; the authoritative retraction happens on
- * the post-load session_start re-check — see applyProviderRegistration.)
- */
-export function decideRegistration(state: RegistrationState): RegistrationDecision {
-	if (!state.isPrimary) return "noop";
-	if (state.credentialed) return state.registered ? "noop" : "register";
-	return "unregister";
-}

--- a/pi-extensions/pi-claude-bridge/src/index.ts
+++ b/pi-extensions/pi-claude-bridge/src/index.ts
@@ -10,7 +10,8 @@ import { extractAllToolResults as _extractAllToolResults, type McpResult } from 
 import { QueryContext, ctx, drainPendingToolCalls, stackDepth, pushContext, toolCallDrainCause } from "./query-state.js";
 import { teardownQuery } from "./query-teardown.js";
 import { loadConfig, normalizeEffortLevel, recordProjectTrust, type Config } from "./config.js";
-import { decideRegistration, hasClaudeCredentials } from "./auth-presence.js";
+import { hasClaudeCredentials } from "./auth-presence.js";
+import { NATIVE_PROVIDER_UNSUPPORTED_MESSAGE, buildNativeProvider, supportsNativeProvider } from "./native-provider.js";
 import { extractAgentsAppend } from "./agents-md.js";
 import { buildPromptContextAppend } from "./prompt-context.js";
 import { jsonSchemaToZodShape } from "./typebox-to-zod.js";
@@ -57,6 +58,7 @@ export { __testGetBridgeIntegrityState, __testSetBridgeIntegrityState, INTEGRITY
 export { CONNECTOR_CALL_CUSTOM_TYPE, connectorResultByteSize, flushConnectorCallAudit, recordConnectorCallResult, setConnectorCallAuditSink, type ConnectorCallAuditData, type ConnectorCallAuditSink, type ConnectorCallOutcome } from "./connector-audit.js";
 export { CLAUDE_AI_CONNECTOR_TOOL_PATTERNS, connectorMcpServers, connectorDeclarationsDisabled, CLAUDE_BRIDGE_TOOL_ISOLATION, CONNECTOR_DISCOVERY_TOOLS, CONNECTOR_WRITE_TOOLS, DISALLOWED_BUILTIN_TOOLS, connectorQueryOptions, connectorWriteDenyHook, connectorWriteModeFor, connectorWriteModeFromEnv, connectorsEnabledFor, connectorsEnabledFromEnv, isChildExecutedTool, isConnectorWriteTool, toolIsolationForQuery } from "./connectors.js";
 export { restoreSharedSessionFromPi, shouldRestorePersistedBridgeEntry } from "./session-persistence.js";
+export { NATIVE_PROVIDER_UNSUPPORTED_MESSAGE, buildNativeProvider, claudeAuthSourceLabel, supportsNativeProvider } from "./native-provider.js";
 export { DEFAULT_STREAM_IDLE_TIMEOUT_MS, STREAM_IDLE_BACKOFF_HINT_MS, STREAM_IDLE_TIMEOUT_ENV, buildStreamIdleTimeoutErrorMessage, createStreamIdleWatchdog, streamIdleTimeoutMsFromEnv, type StreamIdleTimeoutInfo, type StreamIdleWatchdog, type StreamIdleWatchdogState } from "./stream-idle-watchdog.js";
 export { ALLOWED_RATE_LIMIT_WARNING_UTILIZATION_THRESHOLD, formatAllowedRateLimitWarning, formatResetTimestamp, isExtraUsageRequiredMessage, isUsageLimitMessage, normalizeRateLimitUtilization, resetTimestampMs, uniqueNonEmptyLines } from "./rate-limit.js";
 export { mapToolName } from "./tool-mapping.js";
@@ -95,7 +97,7 @@ const newAssistantMessageEventStream: () => AssistantMessageEventStream =
 //
 // Both are released on session_shutdown (incl. /reload) by releaseProviderTokens
 // so the next module load starts clean. See applyProviderRegistration for the
-// state machine and auth-presence.ts/decideRegistration for the pure decision.
+// native (pi >=0.81) upsert flow.
 const PRIMARY_INSTANCE_KEY = Symbol.for("claude-bridge:primaryInstance");
 const ACTIVE_STREAM_SIMPLE_KEY = Symbol.for("claude-bridge:activeStreamSimple");
 const COMMANDS_REGISTERED_KEY = Symbol.for("claude-bridge:commandsRegistered");
@@ -594,10 +596,10 @@ function claimPrimaryInstance(): boolean {
 
 // Release both process-global tokens this instance owns. Called on
 // session_shutdown (incl. /reload) so the freshly loaded instance starts clean.
-// NOTE: this does NOT unregister the provider — the ModelRegistry's
-// registeredProviders is a process-lifetime Map that survives module reload, so
-// retraction on logout is handled by applyProviderRegistration's defensive
-// unregister on the next load/session_start, not here.
+// NOTE: this does NOT unregister the provider — pi's provider registry is
+// process-lifetime state that survives module reload; the next loaded instance
+// simply upserts its own provider object over ours (registerNativeProvider is
+// replace-by-id), and logout-hiding is the provider's own auth check.
 function releaseProviderTokens(event: string): void {
 	const g = globalThis as Record<symbol, any>;
 	if (g[ACTIVE_STREAM_SIMPLE_KEY] === streamClaudeAgentSdk) {
@@ -610,66 +612,66 @@ function releaseProviderTokens(event: string): void {
 	}
 }
 
-// Conditional (un)registration driven by real credential presence + instance
-// primacy. Run at extension load, on every session_start, and at pre-spawn
-// (fail-fast) so a `claude login` / logout is reflected without a /reload.
+// Native (pi >=0.81) provider registration. Run at extension load, on every
+// session_start, and at pre-spawn.
 //
-// decideRegistration encodes the pure state machine; this wrapper performs the
-// matching token mutations so tokens and registration never diverge:
-//   - register:   claim the stream guard, THEN registerProvider. If register
-//     throws/queue-fails, release the stream guard (but keep primacy) so a
-//     later re-check can retry cleanly (self-healing); errors are swallowed so
-//     a session_start handler can't crash the dispatch.
-//   - unregister: pi.unregisterProvider (idempotent), THEN release the stream
-//     guard if we own it. Defensive even when we never registered — this is the
-//     only retraction path for a stale registration surviving /reload. At LOAD
-//     the SDK's unregister only filters the pending-registration queue and can't
-//     mutate the persistent registry (loader.js), so the effective retraction
-//     lands on the post-load session_start re-check; the load-time call is a
-//     harmless idempotent no-op that also cancels any same-pass queued register.
-// Non-primary instances (subagents) always decide noop and touch nothing.
+// 2.x registers UNCONDITIONALLY (once primary): credential-driven availability
+// is the provider's own auth.check/resolve reporting configured-ness, so pi
+// hides/shows claude-bridge models itself — the 1.x register/unregister state
+// machine (decideRegistration) is gone. What each trigger does now:
+//   - load: build + register the provider (queued by the loader until bindCore).
+//   - session_start: re-upsert the SAME provider object. registerNativeProvider
+//     is upsert-by-id and kicks pi's model-snapshot/availability refresh, so a
+//     `claude login`/logout since the last session boundary is reflected
+//     deterministically — the same guarantee the 1.x re-check gave — without
+//     depending on pi's own refresh cadence.
+//   - pre-spawn: same re-upsert, from the fail-fast path, so a mid-session
+//     logout also flips availability at first use.
+// Non-primary instances (subagents) never touch registration: pi's native
+// registry REPLACES by id, so an unguarded subagent re-register would swap in
+// its own streamSimple — the exact split-brain the tokens exist to prevent.
+// On a pre-0.81 host the extension declines loudly (once) instead of
+// registering wrongly through the legacy overload.
+let nativeProviderInstance: unknown;
+let notifiedNativeUnsupported = false;
+
 function applyProviderRegistration(trigger: string): void {
 	const pi = extensionApi;
 	if (!pi) { debug(`${trigger}: applyProviderRegistration skipped — no extensionApi`); return; }
 	const g = globalThis as Record<symbol, any>;
 	const isPrimary = claimPrimaryInstance();
+	if (!isPrimary) {
+		debug(`${trigger}: registration noop — non-primary instance (module=${moduleInstanceId})`);
+		return;
+	}
+	if (!supportsNativeProvider(_piAi)) {
+		debug(`${trigger}: host pi-ai lacks createProvider; refusing to register (module=${moduleInstanceId})`);
+		if (!notifiedNativeUnsupported) {
+			notifiedNativeUnsupported = true;
+			safeNotify(NATIVE_PROVIDER_UNSUPPORTED_MESSAGE, "error");
+		}
+		return;
+	}
 	const credentialed = hasClaudeCredentials();
-	const registered = g[ACTIVE_STREAM_SIMPLE_KEY] === streamClaudeAgentSdk;
-	const decision = decideRegistration({ credentialed, isPrimary, registered });
-	debug(`${trigger}: registration decision=${decision} credentialed=${credentialed} isPrimary=${isPrimary} registered=${registered} (module=${moduleInstanceId})`);
-	if (decision === "register") {
-		// Start the connector inventory now, not on the first turn: the query path
-		// can only read a synchronous snapshot, so priming here is what gets the
-		// declarations in place before turn 1 (vstack#832). Fire and forget —
-		// registration must not wait on the network.
-		if (connectorsEnabledFor(loadConfig(process.cwd()))) primeConnectorServers();
-		// Claim ordering: stream guard BEFORE registerProvider so a concurrent
-		// subagent can never observe a registered provider without an owner.
-		g[ACTIVE_STREAM_SIMPLE_KEY] = streamClaudeAgentSdk;
-		try {
-			pi.registerProvider(PROVIDER_ID, {
-				baseUrl: "claude-bridge",
-				apiKey: "not-used",
-				api: "claude-bridge",
-				models: MODELS,
-				// Cast: pi-ai AssistantMessageEventStream diamond dep between pi-coding-agent and pi-agent-core
-				streamSimple: streamClaudeAgentSdk as any,
-			});
-		} catch (err) {
-			// Self-heal: release ONLY the stream guard we just claimed so a later
-			// re-check (primary + credentialed + not-registered → register) retries.
-			// Keep PRIMARY_INSTANCE_KEY: releasing it would reopen the subagent
-			// ownership-steal window, and retry does not need it released.
-			if (g[ACTIVE_STREAM_SIMPLE_KEY] === streamClaudeAgentSdk) g[ACTIVE_STREAM_SIMPLE_KEY] = undefined;
-			debug(`${trigger}: registerProvider threw; released stream guard for retry (kept primary):`, err);
-		}
-	} else if (decision === "unregister") {
-		try {
-			pi.unregisterProvider(PROVIDER_ID);
-		} catch (err) {
-			debug(`${trigger}: unregisterProvider threw (ignored):`, err);
-		}
+	debug(`${trigger}: native registration upsert, credentialed=${credentialed} (module=${moduleInstanceId})`);
+	// Start the connector inventory now, not on the first turn: the query path
+	// can only read a synchronous snapshot, so priming here is what gets the
+	// declarations in place before turn 1 (vstack#832). Fire and forget —
+	// registration must not wait on the network. Only worth it when a Claude
+	// account is actually connected.
+	if (credentialed && connectorsEnabledFor(loadConfig(process.cwd()))) primeConnectorServers();
+	// Claim ordering: stream guard BEFORE registerProvider so a concurrent
+	// subagent can never observe a registered provider without an owner.
+	g[ACTIVE_STREAM_SIMPLE_KEY] = streamClaudeAgentSdk;
+	try {
+		nativeProviderInstance ??= buildNativeProvider(_piAi, MODELS, streamClaudeAgentSdk as (...args: unknown[]) => unknown);
+		(pi.registerProvider as (provider: unknown) => void)(nativeProviderInstance);
+	} catch (err) {
+		// Self-heal: release ONLY the stream guard we just claimed so a later
+		// re-check retries cleanly. Keep PRIMARY_INSTANCE_KEY: releasing it would
+		// reopen the subagent ownership-steal window.
 		if (g[ACTIVE_STREAM_SIMPLE_KEY] === streamClaudeAgentSdk) g[ACTIVE_STREAM_SIMPLE_KEY] = undefined;
+		debug(`${trigger}: registerProvider threw; released stream guard for retry (kept primary):`, err);
 	}
 }
 
@@ -775,12 +777,12 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 	// Fail-fast credential re-check (only for a fresh query — NEVER for
 	// tool-result delivery of an in-flight query, handled above, where creds were
 	// valid at start and failing mid-turn would break tool pairing). This bounds
-	// the retraction-latency window from "next session boundary" to "first use":
-	// if credentials vanished since the last session_start, (a) trigger the same
-	// re-evaluation applyProviderRegistration does (primary-only; retracts the
-	// stale registration), and (b) fail this request with a clear, actionable
-	// message instead of letting the SDK spawn die with a generic error. The
-	// check is cheap (existsSync + env reads only, no credential contents).
+	// the logout-visibility window from "next session boundary" to "first use":
+	// if credentials vanished since the last session_start, (a) re-upsert the
+	// provider (primary-only) so pi's availability recompute hides the models,
+	// and (b) fail this request with a clear, actionable message instead of
+	// letting the SDK spawn die with a generic error. The check is cheap
+	// (existsSync + env reads only, no credential contents).
 	if (!hasClaudeCredentials()) {
 		try { applyProviderRegistration("pre-spawn"); } catch { /* best effort */ }
 		const message = "Claude account not connected — connect an account (or run `claude login`) and retry.";
@@ -1394,10 +1396,11 @@ export default function (pi: ExtensionAPI) {
 
 	// --- Provider ---
 	//
-	// Register the provider ONLY when real Claude credentials are present, so
-	// claude-bridge models are never advertised as available/selectable when a
-	// request would fail at spawn time (pi's ModelRegistry.hasConfiguredAuth()
-	// treats the dummy apiKey as "configured", so the gate must live here).
+	// Native registration (pi >=0.81): register unconditionally; the provider's
+	// own auth check/resolve report whether Claude credentials exist, so pi
+	// hides claude-bridge models while no account is connected and shows them
+	// when one appears. session_start and pre-spawn re-upsert the provider to
+	// force pi's availability recompute at those boundaries.
 	//
 	// applyProviderRegistration also claims the primary-instance token (first
 	// load wins) and enforces the multi-instance guard: a non-primary subagent

--- a/pi-extensions/pi-claude-bridge/src/native-provider.ts
+++ b/pi-extensions/pi-claude-bridge/src/native-provider.ts
@@ -1,0 +1,89 @@
+// Native pi >=0.81 provider construction (bridge 2.x).
+//
+// Bridge 1.x could not register unconditionally: pi's legacy
+// ModelRegistry.hasConfiguredAuth() treated the dummy `apiKey: "not-used"` as
+// "configured", so the models looked connected while every request failed at
+// spawn. 1.x therefore gated register/unregister on real credential presence
+// (decideRegistration). The native Provider form inverts that: the provider is
+// ALWAYS registered, and `auth.apiKey.check/resolve` report configured-ness
+// from the same existence-only probes, so pi itself hides claude-bridge models
+// while no Claude credentials are present and shows them when they appear.
+//
+// What the native form does NOT change (see DEVELOPMENT.md "Provider
+// registration"): the process-global primary-instance/stream-guard tokens stay
+// (pi's registerNativeProvider is replace-by-id, so an unguarded subagent
+// re-registration would still swap in its own streamSimple), and the pre-spawn
+// credential fail-fast in streamSimple stays (a mid-session logout must fail
+// the turn with an actionable message even if the picker snapshot is stale).
+//
+// SECURITY: like auth-presence.ts, this module only reports credential
+// EXISTENCE. resolve() hands pi the same dummy key the legacy config carried —
+// the Claude Code subprocess does its own authentication; pi never needs a
+// real secret, so none is read or exposed.
+
+import { hasClaudeCredentials } from "./auth-presence.js";
+import { PROVIDER_ID } from "./convert.js";
+
+export const NATIVE_PROVIDER_UNSUPPORTED_MESSAGE =
+	"Claude bridge 2.x requires pi >= 0.81 (native provider API). Upgrade the host pi, or pin @vanillagreen/pi-claude-bridge@1.x.";
+
+/** pi-ai gained createProvider in 0.81 alongside the object-form
+ *  registerProvider; its presence is the capability signal for both. */
+export function supportsNativeProvider(piAi: unknown): boolean {
+	return typeof (piAi as { createProvider?: unknown })?.createProvider === "function";
+}
+
+/** Auth source label for pi's status UI, chosen by the same existence-only
+ *  probes hasClaudeCredentials uses. Never reads credential contents. */
+export function claudeAuthSourceLabel(env: NodeJS.ProcessEnv = process.env): string {
+	if (env.CLAUDE_CODE_OAUTH_TOKEN?.trim()) return "CLAUDE_CODE_OAUTH_TOKEN";
+	if (env.ANTHROPIC_API_KEY?.trim()) return "ANTHROPIC_API_KEY";
+	if (env.ANTHROPIC_AUTH_TOKEN?.trim()) return "ANTHROPIC_AUTH_TOKEN";
+	return "Claude Code login";
+}
+
+/**
+ * Build the Provider object for pi.registerProvider(provider).
+ *
+ * `piAi` is the HOST's pi-ai namespace (the bundle externalizes it), passed in
+ * rather than imported so a pre-0.81 host fails the supportsNativeProvider()
+ * check with a clear message instead of crashing module load on a missing
+ * named export. `env` is bindable for tests; the credential probes themselves
+ * run at check/resolve CALL time, so a login/logout between calls is seen.
+ */
+export function buildNativeProvider(
+	piAi: unknown,
+	models: Array<Record<string, unknown>>,
+	streamSimple: (...args: unknown[]) => unknown,
+	env: NodeJS.ProcessEnv = process.env,
+): unknown {
+	if (!supportsNativeProvider(piAi)) throw new Error(NATIVE_PROVIDER_UNSUPPORTED_MESSAGE);
+	// The legacy config path stamped provider/api/baseUrl onto each model during
+	// composition; createProvider passes models through verbatim, so stamp here.
+	const stamped = models.map((model) => ({ api: "claude-bridge", baseUrl: "claude-bridge", provider: PROVIDER_ID, ...model }));
+	// The Claude Code subprocess router IS the implementation for both stream
+	// entry points — there is no raw-API shape to dispatch to.
+	const streams = {
+		stream: streamSimple,
+		streamSimple,
+	};
+	return (piAi as { createProvider: (input: unknown) => unknown }).createProvider({
+		id: PROVIDER_ID,
+		name: "Claude (Claude Code)",
+		baseUrl: "claude-bridge",
+		auth: {
+			apiKey: {
+				name: "Claude Code credentials",
+				// check() exists so pi's availability pass never has to call
+				// resolve(): both are existence-only, but check is the documented
+				// side-effect-free probe.
+				check: async () => (hasClaudeCredentials(env) ? { type: "api_key" as const, source: claudeAuthSourceLabel(env) } : undefined),
+				resolve: async () => (hasClaudeCredentials(env)
+					? { auth: { apiKey: "not-used" }, source: claudeAuthSourceLabel(env) }
+					: undefined),
+			},
+		},
+		models: stamped,
+		api: streams,
+	});
+}

--- a/pi-extensions/pi-claude-bridge/tests/unit-auth-presence.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-auth-presence.mjs
@@ -8,7 +8,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { resolveClaudeConfigDir, hasClaudeCredentials, decideRegistration } from "../src/auth-presence.ts";
+import { resolveClaudeConfigDir, hasClaudeCredentials } from "../src/auth-presence.ts";
 
 function withTempHome(fn) {
 	const root = mkdtempSync(join(tmpdir(), "claude-bridge-auth-"));
@@ -123,48 +123,4 @@ describe("hasClaudeCredentials", () => {
 		assert.equal(hasClaudeCredentials({ CLAUDE_CONFIG_DIR: dir }, "linux"), false);
 		assert.equal(hasClaudeCredentials({ CLAUDE_CONFIG_DIR: dir }, "win32"), false);
 	}));
-});
-
-describe("decideRegistration", () => {
-	// Primacy gate ------------------------------------------------------------
-	it("non-primary instance → always noop, regardless of credentials/registration", () => {
-		assert.equal(decideRegistration({ credentialed: true, isPrimary: false, registered: false }), "noop");
-		assert.equal(decideRegistration({ credentialed: true, isPrimary: false, registered: true }), "noop");
-		assert.equal(decideRegistration({ credentialed: false, isPrimary: false, registered: true }), "noop");
-	});
-
-	// Primary transitions -----------------------------------------------------
-	it("primary + credentialed + not registered → register", () => {
-		assert.equal(decideRegistration({ credentialed: true, isPrimary: true, registered: false }), "register");
-	});
-
-	it("primary + credentialed + already registered → noop", () => {
-		assert.equal(decideRegistration({ credentialed: true, isPrimary: true, registered: true }), "noop");
-	});
-
-	it("primary + uncredentialed + registered → unregister (retract)", () => {
-		assert.equal(decideRegistration({ credentialed: false, isPrimary: true, registered: true }), "unregister");
-	});
-
-	it("primary + uncredentialed + not registered → unregister (DEFENSIVE, idempotent)", () => {
-		assert.equal(decideRegistration({ credentialed: false, isPrimary: true, registered: false }), "unregister");
-	});
-});
-
-describe("decideRegistration — logout → /reload sequence", () => {
-	it("walks register → noop → unregister → defensive-unregister across a reload", () => {
-		// 1. Fresh load, credentialed: claim + register.
-		assert.equal(decideRegistration({ credentialed: true, isPrimary: true, registered: false }), "register");
-		// 2. Later session_start, still credentialed and registered: nothing to do.
-		assert.equal(decideRegistration({ credentialed: true, isPrimary: true, registered: true }), "noop");
-		// 3. User logs out; session_start re-check retracts.
-		assert.equal(decideRegistration({ credentialed: false, isPrimary: true, registered: true }), "unregister");
-		// 4. /reload: shutdown released tokens; the reloaded primary instance is
-		//    uncredentialed and "not registered" from its own token's POV, yet the
-		//    ModelRegistry entry survives the reload — so it must STILL unregister
-		//    defensively to retract the stale registration.
-		assert.equal(decideRegistration({ credentialed: false, isPrimary: true, registered: false }), "unregister");
-		// 5. Subsequent session_start, still logged out: remains unregister (idempotent).
-		assert.equal(decideRegistration({ credentialed: false, isPrimary: true, registered: false }), "unregister");
-	});
 });

--- a/pi-extensions/pi-claude-bridge/tests/unit-native-provider.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-native-provider.mjs
@@ -1,0 +1,114 @@
+/**
+ * Tests for the native (pi >=0.81) provider construction — bridge 2.x's
+ * replacement for the credential-gated register/unregister state machine.
+ * The provider registers unconditionally; these tests pin that its auth
+ * check/resolve report configured-ness truthfully (that is what makes pi hide
+ * unconfigured claude-bridge models), that credential probes run at CALL time
+ * (login/logout between calls is seen), and that both stream entry points are
+ * the Claude Code subprocess router.
+ * Uses the real modules — no API calls, no extension activation.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	NATIVE_PROVIDER_UNSUPPORTED_MESSAGE,
+	buildNativeProvider,
+	claudeAuthSourceLabel,
+	supportsNativeProvider,
+} from "../src/native-provider.ts";
+import * as piAi from "@earendil-works/pi-ai";
+
+// The darwin keychain fallback makes "no credentials" unobservable via env
+// probes; production embedders and CI are linux, so pin the unconfigured-case
+// assertions there.
+const onDarwin = process.platform === "darwin";
+
+async function withTempConfigDir(fn) {
+	const dir = mkdtempSync(join(tmpdir(), "claude-bridge-native-test-"));
+	try {
+		return await fn(dir);
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+}
+
+const MODELS = [
+	{ id: "claude-haiku-4-5", name: "Claude Haiku 4.5", reasoning: false, input: ["text"], contextWindow: 200000, maxTokens: 64000, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 } },
+];
+
+describe("supportsNativeProvider", () => {
+	it("detects the installed pi-ai (>=0.81) as supported", () => {
+		assert.equal(supportsNativeProvider(piAi), true);
+	});
+
+	it("rejects hosts without createProvider (pi-ai 0.80.x shape)", () => {
+		assert.equal(supportsNativeProvider({}), false);
+		assert.equal(supportsNativeProvider(undefined), false);
+		assert.equal(supportsNativeProvider({ createProvider: "nope" }), false);
+	});
+});
+
+describe("claudeAuthSourceLabel", () => {
+	it("names the env token that will authenticate, else the login default", () => {
+		assert.equal(claudeAuthSourceLabel({ CLAUDE_CODE_OAUTH_TOKEN: "tok" }), "CLAUDE_CODE_OAUTH_TOKEN");
+		assert.equal(claudeAuthSourceLabel({ ANTHROPIC_API_KEY: "key" }), "ANTHROPIC_API_KEY");
+		assert.equal(claudeAuthSourceLabel({}), "Claude Code login");
+	});
+});
+
+describe("buildNativeProvider", () => {
+	it("throws the versioned message on a pre-0.81 host shape", () => {
+		assert.throws(() => buildNativeProvider({}, MODELS, () => {}), new RegExp("requires pi >= 0.81"));
+		assert.match(NATIVE_PROVIDER_UNSUPPORTED_MESSAGE, /pi-claude-bridge@1\.x/);
+	});
+
+	it("builds a provider whose id, models, and stamped fields match the bridge contract", () => {
+		const provider = buildNativeProvider(piAi, MODELS, () => {}, {});
+		assert.equal(provider.id, "claude-bridge");
+		const models = provider.getModels();
+		assert.equal(models.length, 1);
+		assert.equal(models[0].id, "claude-haiku-4-5");
+		// The legacy config path stamped these during composition; the native
+		// path must stamp them itself or downstream provider routing breaks.
+		assert.equal(models[0].provider, "claude-bridge");
+		assert.equal(models[0].api, "claude-bridge");
+	});
+
+	it("reports unconfigured when no credential signal exists", { skip: onDarwin }, () => withTempConfigDir(async (dir) => {
+		const provider = buildNativeProvider(piAi, MODELS, () => {}, { CLAUDE_CONFIG_DIR: dir });
+		assert.equal(await provider.auth.apiKey.check({ ctx: {} }), undefined);
+		assert.equal(await provider.auth.apiKey.resolve({ ctx: {} }), undefined);
+	}));
+
+	it("reports configured with a source label when credentials exist", () => withTempConfigDir(async (dir) => {
+		writeFileSync(join(dir, ".credentials.json"), "{}");
+		const provider = buildNativeProvider(piAi, MODELS, () => {}, { CLAUDE_CONFIG_DIR: dir });
+		const check = await provider.auth.apiKey.check({ ctx: {} });
+		assert.deepEqual(check, { type: "api_key", source: "Claude Code login" });
+		const resolved = await provider.auth.apiKey.resolve({ ctx: {} });
+		assert.equal(resolved.auth.apiKey, "not-used");
+		assert.equal(resolved.source, "Claude Code login");
+	}));
+
+	it("re-probes credentials at call time — login and logout between calls are seen", { skip: onDarwin }, () => withTempConfigDir(async (dir) => {
+		const provider = buildNativeProvider(piAi, MODELS, () => {}, { CLAUDE_CONFIG_DIR: dir });
+		assert.equal(await provider.auth.apiKey.check({ ctx: {} }), undefined, "starts unconfigured");
+		writeFileSync(join(dir, ".credentials.json"), "{}");
+		assert.notEqual(await provider.auth.apiKey.check({ ctx: {} }), undefined, "login is seen without rebuilding the provider");
+		rmSync(join(dir, ".credentials.json"));
+		assert.equal(await provider.auth.apiKey.check({ ctx: {} }), undefined, "logout is seen without rebuilding the provider");
+	}));
+
+	it("routes BOTH stream entry points through the given streamSimple (subscription billing path)", () => {
+		const calls = [];
+		const streamSimple = (...args) => { calls.push(args); return "stream-result"; };
+		const provider = buildNativeProvider(piAi, MODELS, streamSimple, {});
+		const model = provider.getModels()[0];
+		assert.equal(provider.streamSimple(model, { messages: [] }, {}), "stream-result");
+		assert.equal(provider.stream(model, { messages: [] }, {}), "stream-result");
+		assert.equal(calls.length, 2);
+	});
+});


### PR DESCRIPTION
Adopts pi's first-class provider API — the F1 item from the audit (`tmp/claude-bridge-audit.md`), previously evaluated-and-deferred in #948's decision record. The owner lifted the pre-0.81 host-compat constraint (memsira/drovr, the only consumers, upgrade their embedded pi in lockstep), which dissolved the main objection; the remaining login-timing risk was verified empirically (below).

## What changes

- **Native registration** (`src/native-provider.ts`): the bridge registers a `Provider` object unconditionally (once primary); its `auth.apiKey.check()/resolve()` report configured-ness from the same existence-only credential probes as before, so **pi itself hides claude-bridge models while no Claude account is connected** and shows them when one appears — replacing the 1.x credential-gated register/unregister state machine (`decideRegistration`, removed).
- **Deterministic login/logout reflection retained**: session_start and pre-spawn re-upsert the provider (pi's `registerNativeProvider` is upsert-by-id and triggers the availability recompute), so credential flips are reflected at exactly the boundaries 1.x re-checked. The pre-spawn `hasClaudeCredentials` fail-fast stays for mid-session logouts.
- **Guards retained by design**: pi's native registry replaces-by-id, so the `PRIMARY_INSTANCE_KEY`/`ACTIVE_STREAM_SIMPLE_KEY` subagent double-registration guards survive (documented in DEVELOPMENT.md alongside the updated decision record).
- **Billing unchanged**: both native stream entry points (`stream`/`streamSimple`) are the same Claude Code subprocess router; no raw-API path exists.
- **Breaking**: requires pi ≥ 0.81 (`peerDependencies >= 0.81.0`); on an older host the extension declines loudly once instead of registering through the legacy overload. README notes 1.x as the fallback for older hosts.

## Testing

- Unit 363/363 (new `unit-native-provider.mjs`: configured/unconfigured auth reporting, call-time credential re-probing, model stamping, both stream entry points routing through the given streamSimple). Typecheck + build clean.
- Full integration suite green on a live account: smoke 3/3 (including "model list includes provider" — real native registration through a live pi), multi-turn 5/5, cache test 96% aggregate hit with clean session sync, node int suites 16/16.
- Live TUI e2e with a **throwaway empty CLAUDE_CONFIG_DIR** (no real credentials touched): unconfigured → claude-bridge models absent from the picker (pi's availability layer); dummy credential file created + `/new` → all models appear and pi auto-selects `claude-bridge/claude-sonnet-5`; file removed + `/new` → models gone, pi falls back to another provider. This resolves the login-timing regression risk flagged in the original F1 evaluation.

## Downstream

memsira and drovr upgrade guides rewritten at `tmp/memsira-bridge-update-report.md` / `tmp/drovr-bridge-update-report.md` (repo-local): pi pin bumps 0.80.10 → 0.82.1, re-vendor steps, the presence-vs-availability semantic shift their registration code/tests encode (drovr's `bridge-provider.ts` coupling points enumerated), Claude CLI alignment (drovr's 2.1.220 pin already matches SDK 0.3.220's manifest), and per-app UX enhancement recommendations unlocked by the native auth surface.

https://claude.ai/code/session_018Kw7BTS6JiyL6WHUrEC2Xk