### PR TITLE
chore: gitignore the cross-repo mailbox log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,7 @@ Thumbs.db
 # Local vstack install state (per-checkout absolute paths; do not commit)
 .vstack-lock.json
 vstack-local.toml
+
+# Cross-repo mailbox log — machine-local session coordination, never committed
+# (docs/cross-repo.md, the curated contract, IS tracked on purpose)
+docs/cross-repo-notes.md


### PR DESCRIPTION
docs/cross-repo-notes.md is the machine-local append-only mailbox log between vstack and its consuming repos — session coordination state, not repo content. Ignoring it prevents a broad `git add` from ever committing it. The curated contract (docs/cross-repo.md) stays tracked on purpose; tmp/ (audit + handoff reports) verified already ignored.

https://claude.ai/code/session_018Kw7BTS6JiyL6WHUrEC2Xk