### PR TITLE
Fix decider next-id for custom ID schemes

### DIFF
--- a/skills/decider/README.md
+++ b/skills/decider/README.md
@@ -20,7 +20,7 @@ EOF
 
 Optionally set `DECISIONS_DIR` in committed `vstack.settings.toml` under `[env]` to override auto-discovery (searches `docs/decisions/`, `decisions/`, `doc/decisions/`, `adr/`). Existing `.env.local` overrides still work.
 
-`decisions next-id` derives the active ID scheme from the `INDEX.md` ID column, preserving schemes such as `D001` or `ADR-0001` and ignoring ID-looking text in prose cells. For an empty index or an intentional scheme switch, set `DECISION_ID_PREFIX` and `DECISION_ID_WIDTH` under `[env]`.
+`decisions next-id` derives the active ID scheme from the last populated `INDEX.md` ID-column value, preserving schemes such as `D001` or `ADR-0001` and ignoring ID-looking text in prose cells. If that value has no numeric suffix, `next-id` fails with a configuration hint instead of guessing. For an empty index or an intentional scheme switch, set `DECISION_ID_PREFIX` and `DECISION_ID_WIDTH` under `[env]`.
 
 Before the directory is initialized, `search` and `list` return an empty result (`[]`, exit 0) with a note on stderr; `next-id` and `get` error until it exists.
 

--- a/skills/decider/README.md
+++ b/skills/decider/README.md
@@ -20,6 +20,8 @@ EOF
 
 Optionally set `DECISIONS_DIR` in committed `vstack.settings.toml` under `[env]` to override auto-discovery (searches `docs/decisions/`, `decisions/`, `doc/decisions/`, `adr/`). Existing `.env.local` overrides still work.
 
+`decisions next-id` derives the active ID scheme from the `INDEX.md` ID column, preserving schemes such as `D001` or `ADR-0001` and ignoring ID-looking text in prose cells. For an empty index or an intentional scheme switch, set `DECISION_ID_PREFIX` and `DECISION_ID_WIDTH` under `[env]`.
+
 Before the directory is initialized, `search` and `list` return an empty result (`[]`, exit 0) with a note on stderr; `next-id` and `get` error until it exists.
 
 ## Decision Templates

--- a/skills/decider/SKILL.md
+++ b/skills/decider/SKILL.md
@@ -62,7 +62,7 @@ Project-level configuration:
 | Variable | Purpose | Default |
 |----------|---------|---------|
 | `$DECISIONS_DIR` | Path to decision documents directory | Auto-discovers `docs/decisions/`, `decisions/`, `doc/decisions/`, or `adr/` with `INDEX.md` |
-| `$DECISION_ID_PREFIX` | Optional prefix used by `next-id` | Inferred from the last ID-column value with a numeric suffix, or `D` |
+| `$DECISION_ID_PREFIX` | Optional prefix used by `next-id` | Inferred from the last populated ID-column value, or `D` |
 | `$DECISION_ID_WIDTH` | Optional zero-padding width used by `next-id` | Inferred from the selected ID-column scheme, or `3` |
 
 Set `DECISIONS_DIR` in committed `vstack.settings.toml` under `[env]` when it is shared project policy. `.env.local` remains supported for local overrides.

--- a/skills/decider/SKILL.md
+++ b/skills/decider/SKILL.md
@@ -15,7 +15,7 @@ metadata:
 
 > **Problem with this skill?** Run `vstack report` — it files to the owning repo automatically. Do not hand-file.
 
-Manages Architecture Decision Records (ADRs) — represented in this skill as numbered `DXXX` architectural decision documents indexed in `INDEX.md` (by default under `docs/decisions/`) — with canonical templates, creation/update workflows, and a search CLI. Provides the single source of truth for decision entry format and lifecycle.
+Manages Architecture Decision Records (ADRs) — represented in this skill as numbered decision documents indexed in `INDEX.md` (by default under `docs/decisions/`) — with canonical templates, creation/update workflows, and a search CLI. Provides the single source of truth for decision entry format and lifecycle.
 
 ```bash
 .agents/skills/decider/scripts/decisions <command> [options]
@@ -29,8 +29,8 @@ Manages Architecture Decision Records (ADRs) — represented in this skill as nu
 | `search "[KEYWORDS]"` | Ranked keyword search (AND, scored) over INDEX summaries **and** decision bodies | JSON `[{id, decision, path, score}]` |
 | `search "a\|b"` | Regex OR search | JSON `[{id, decision, path}]` |
 | `list` | List all active decisions | JSON `[{id, decision, path}]` |
-| `next-id` | Get next available DXXX | Single `DXXX` line |
-| `get [DXXX]` | Get decision details | JSON `{id, decision, status, date, path}` |
+| `next-id` | Get next available decision ID from the INDEX ID column | Single decision ID line |
+| `get [DECISION_ID]` | Get decision details | JSON `{id, decision, status, date, path}` |
 
 Options: `--limit N` (default: 5) for search results.
 
@@ -62,6 +62,8 @@ Project-level configuration:
 | Variable | Purpose | Default |
 |----------|---------|---------|
 | `$DECISIONS_DIR` | Path to decision documents directory | Auto-discovers `docs/decisions/`, `decisions/`, `doc/decisions/`, or `adr/` with `INDEX.md` |
+| `$DECISION_ID_PREFIX` | Optional prefix used by `next-id` | Inferred from the last ID-column value with a numeric suffix, or `D` |
+| `$DECISION_ID_WIDTH` | Optional zero-padding width used by `next-id` | Inferred from the selected ID-column scheme, or `3` |
 
 Set `DECISIONS_DIR` in committed `vstack.settings.toml` under `[env]` when it is shared project policy. `.env.local` remains supported for local overrides.
 
@@ -86,7 +88,7 @@ If the decisions directory does not exist (never initialized), read-only lookups
 
 ### Decision Entry Format
 
-All entries require: title (`# DXXX: Title`), date, status, research ref (or `—`), decision statement, rationale, revisit conditions. See `schemas/decision-format.md` for full constraints.
+All entries require: title (`# [DECISION_ID]: Title`), date, status, research ref (or `—`), decision statement, rationale, revisit conditions. The default examples use `DXXX`; projects with an existing numeric-suffix scheme such as `ADR-0001` should preserve that scheme consistently. See `schemas/decision-format.md` for full constraints.
 
 ## Decision Approval
 

--- a/skills/decider/schemas/decision-format.md
+++ b/skills/decider/schemas/decision-format.md
@@ -88,7 +88,7 @@ Use `// REVISIT([DECISION_ID]):` in code to mark implementation points tied to d
 | `Active` | Decision is in effect | Default for new decisions |
 | `Superseded by [DECISION_ID]` | Fully replaced by another decision | New decision covers entire scope |
 | `Revisited` | Re-evaluated with outcome noted | Conditions changed, decision re-assessed |
-| `Active ([COMPONENTS] -> [DECISION_ID])` | Partially superseded | New decision replaces specific components only |
+| `Active ([COMPONENTS] → [DECISION_ID])` | Partially superseded | New decision replaces specific components only |
 
 ## Cross-Reference Conventions
 

--- a/skills/decider/schemas/decision-format.md
+++ b/skills/decider/schemas/decision-format.md
@@ -2,13 +2,13 @@
 
 Defines the canonical structure and constraints for decision documents and the decision index.
 
-## Decision Document (`DXXX-descriptor.md`)
+## Decision Document (`[DECISION_ID]-descriptor.md`)
 
 ### Required Elements
 
 | Element | Format | Constraint |
 |---------|--------|------------|
-| Title | `# DXXX: Title` | H1, uppercase D, zero-padded 3-digit number |
+| Title | `# [DECISION_ID]: Title` | H1 using the project decision ID scheme |
 | Index back-link | `[← Decision Index](INDEX.md)` | Immediately after title |
 | Date | `**Date**: YYYY-MM-DD` | ISO 8601 date |
 | Status | `**Status**: [VALUE]` | See Status Values below |
@@ -34,11 +34,11 @@ Defines the canonical structure and constraints for decision documents and the d
 
 ### File Naming
 
-Pattern: `DXXX-kebab-case-descriptor.md`
+Pattern: `[DECISION_ID]-kebab-case-descriptor.md`
 
-- `DXXX`: Zero-padded sequential ID (D001, D010, D034)
+- `DECISION_ID`: Sequential ID with a numeric suffix. The default scheme is `D001`, `D010`, `D034`; projects may consistently use another scheme such as `ADR-0001`.
 - `descriptor`: Kebab-case summary of the decision topic (2-5 words)
-- Examples: `D001-session-caching.md`, `D010-test-organization.md`
+- Examples: `D001-session-caching.md`, `D010-test-organization.md`, `ADR-0001-runtime-choice.md`
 
 ## INDEX.md Structure
 
@@ -74,11 +74,11 @@ Pattern: `DXXX-kebab-case-descriptor.md`
 
 ### Status Values
 - **Active**: Current decision in effect
-- **Superseded by DXXX**: Replaced by newer decision
+- **Superseded by [DECISION_ID]**: Replaced by newer decision
 - **Revisited**: Re-evaluated, with outcome noted
 
 ### Code Comments
-Use `// REVISIT(DXXX):` in code to mark implementation points tied to decisions.
+Use `// REVISIT([DECISION_ID]):` in code to mark implementation points tied to decisions.
 ```
 
 ## Status Values
@@ -86,19 +86,19 @@ Use `// REVISIT(DXXX):` in code to mark implementation points tied to decisions.
 | Value | Meaning | When |
 |-------|---------|------|
 | `Active` | Decision is in effect | Default for new decisions |
-| `Superseded by DXXX` | Fully replaced by another decision | New decision covers entire scope |
+| `Superseded by [DECISION_ID]` | Fully replaced by another decision | New decision covers entire scope |
 | `Revisited` | Re-evaluated with outcome noted | Conditions changed, decision re-assessed |
-| `Active ([COMPONENTS] → DXXX)` | Partially superseded | New decision replaces specific components only |
+| `Active ([COMPONENTS] -> [DECISION_ID])` | Partially superseded | New decision replaces specific components only |
 
 ## Cross-Reference Conventions
 
 | Reference Type | Format |
 |----------------|--------|
-| Decision-to-decision | `[DXXX](DXXX-descriptor.md)` |
+| Decision-to-decision | `[DECISION_ID](DECISION_ID-descriptor.md)` |
 | Decision-to-research | `[RESEARCH-ID](../research/RESEARCH-ID/findings.md)` |
 | Decision-to-code | `` `path/to/file.rs` `` or `[file](../../path/to/file.rs)` |
-| Code-to-decision | `// REVISIT(DXXX): [reason]` |
-| Issue-to-decision | `**Decision [DXXX]**: [path/to/DXXX-descriptor.md]` |
+| Code-to-decision | `// REVISIT([DECISION_ID]): [reason]` |
+| Issue-to-decision | `**Decision [DECISION_ID]**: [path/to/DECISION_ID-descriptor.md]` |
 
 ## Content Guidelines
 

--- a/skills/decider/scripts/decisions
+++ b/skills/decider/scripts/decisions
@@ -7,12 +7,14 @@
 #   decisions search --issue PROJ-189            Find decisions linked to an issue
 #   decisions search "seqlock|mmap"             Regex OR (pipe = regex mode)
 #   decisions list                              List all active decisions (compact)
-#   decisions next-id                           Get next available DXXX
+#   decisions next-id                           Get next available decision ID
 #   decisions get D017                          Get decision details
 #
 # Environment:
-#   DECISIONS_DIR    Path to decision documents directory (required)
-#                    Example: docs/decisions
+#   DECISIONS_DIR        Path to decision documents directory (required)
+#                        Example: docs/decisions
+#   DECISION_ID_PREFIX   Optional ID prefix for next-id (default: inferred)
+#   DECISION_ID_WIDTH    Optional zero-padding width for next-id (default: inferred)
 #
 # Missing directory:
 #   Read-only lookups (search, list) treat an absent decisions directory as
@@ -26,7 +28,7 @@
 # Output:
 #   search:   JSON array [{id, decision, path}] (keyword adds score field)
 #   list:     JSON array [{id, decision, path}] of active decisions
-#   next-id:  Single line "DXXX"
+#   next-id:  Single line decision ID
 #   get:      JSON {id, decision, status, date, path}
 #
 set -euo pipefail
@@ -204,8 +206,8 @@ Actions:
                        explicit linkage lookup and does not scan bodies.
   search --issue ID    Find decisions linked to a specific issue
   list                 List all active decisions (compact)
-  next-id              Get next available DXXX
-  get <DXXX>           Get decision details (status, date, path)
+  next-id              Get next available decision ID
+  get <DECISION_ID>    Get decision details (status, date, path)
 
 Options:
   --limit N            Max results (default: 5)
@@ -233,7 +235,7 @@ Examples:
   decisions search "seqlock|mmap"          # Regex OR (pipe = regex mode)
   decisions search "FFI" --limit 3         # Limit results
   decisions list                           # All active decisions
-  decisions next-id                        # Next available DXXX
+  decisions next-id                        # Next available decision ID
   decisions get D017                       # Details for D017
 EOF
 }
@@ -376,17 +378,70 @@ list_decisions() {
 }
 
 cmd_next_id() {
+  local all
+  all=$(parse_index)
+
+  local prefix="D"
+  local width=3
+  local prefix_configured=0
+  local width_configured=0
+
+  if [[ "${DECISION_ID_PREFIX+x}" == "x" ]]; then
+    prefix="$DECISION_ID_PREFIX"
+    prefix_configured=1
+  fi
+
+  if [[ "${DECISION_ID_WIDTH+x}" == "x" ]]; then
+    if [[ ! "$DECISION_ID_WIDTH" =~ ^[1-9][0-9]*$ ]]; then
+      echo "Error: DECISION_ID_WIDTH must be a positive integer" >&2
+      return 1
+    fi
+    width="$DECISION_ID_WIDTH"
+    width_configured=1
+  fi
+
+  local id
+  local parsed_prefix
+  local parsed_num
+
+  if [[ "$prefix_configured" -eq 0 ]]; then
+    # Infer the ID format from the last INDEX ID column with a numeric suffix.
+    # This keeps next-id scheme-agnostic while ignoring prose in other columns.
+    while IFS= read -r id; do
+      if [[ "$id" =~ ^(.*[^0-9])?([0-9]+)$ ]]; then
+        prefix="${BASH_REMATCH[1]}"
+        if [[ "$width_configured" -eq 0 ]]; then
+          width="${#BASH_REMATCH[2]}"
+        fi
+      fi
+    done < <(echo "$all" | jq -r '.[] | .id // empty')
+  elif [[ "$width_configured" -eq 0 ]]; then
+    # A configured prefix selects the scheme; infer padding from matching rows.
+    while IFS= read -r id; do
+      if [[ "$id" =~ ^(.*[^0-9])?([0-9]+)$ ]]; then
+        parsed_prefix="${BASH_REMATCH[1]}"
+        if [[ "$parsed_prefix" == "$prefix" ]]; then
+          width="${#BASH_REMATCH[2]}"
+        fi
+      fi
+    done < <(echo "$all" | jq -r '.[] | .id // empty')
+  fi
+
   local max_num=0
 
-  while IFS= read -r num; do
+  while IFS= read -r id; do
+    [[ "$id" =~ ^(.*[^0-9])?([0-9]+)$ ]] || continue
+    parsed_prefix="${BASH_REMATCH[1]}"
+    parsed_num="${BASH_REMATCH[2]}"
+    [[ "$parsed_prefix" == "$prefix" ]] || continue
     # Force base-10 interpretation (strip leading zeros that bash treats as octal)
-    local decimal=$((10#$num))
+    local decimal=$((10#$parsed_num))
     if [[ "$decimal" -gt "$max_num" ]]; then
       max_num="$decimal"
     fi
-  done < <("$PCRE_GREP" -oP 'D(\d+)' "$INDEX_FILE" | "$PCRE_GREP" -oP '\d+' | sort -n || true)
+  done < <(echo "$all" | jq -r '.[] | .id // empty')
 
-  printf "D%03d\n" $((max_num + 1))
+  printf "%s%0*d\n" "$prefix" "$width" $((max_num + 1))
 }
 
 cmd_get() {

--- a/skills/decider/scripts/decisions
+++ b/skills/decider/scripts/decisions
@@ -156,6 +156,23 @@ fi
 
 trim() { echo "$1" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//'; }
 
+PARSED_ID_PREFIX=""
+PARSED_ID_NUM=""
+
+split_decision_id() {
+  local value="$1"
+  PARSED_ID_PREFIX=""
+  PARSED_ID_NUM=""
+
+  if [[ "$value" =~ ^(.*[^0-9])?([0-9]+)$ ]]; then
+    PARSED_ID_PREFIX="${BASH_REMATCH[1]}"
+    PARSED_ID_NUM="${BASH_REMATCH[2]}"
+    return 0
+  fi
+
+  return 1
+}
+
 # Parse the INDEX.md table into JSON
 parse_index() {
   if [[ ! -f "$INDEX_FILE" ]]; then
@@ -401,27 +418,36 @@ cmd_next_id() {
   fi
 
   local id
+  local last_id=""
   local parsed_prefix
   local parsed_num
 
+  while IFS= read -r id; do
+    [[ -n "$id" ]] || continue
+    last_id="$id"
+  done < <(echo "$all" | jq -r '.[] | .id // empty')
+
   if [[ "$prefix_configured" -eq 0 ]]; then
-    # Infer the ID format from the last INDEX ID column with a numeric suffix.
-    # This keeps next-id scheme-agnostic while ignoring prose in other columns.
-    while IFS= read -r id; do
-      if [[ "$id" =~ ^(.*[^0-9])?([0-9]+)$ ]]; then
-        prefix="${BASH_REMATCH[1]}"
-        if [[ "$width_configured" -eq 0 ]]; then
-          width="${#BASH_REMATCH[2]}"
-        fi
+    # Infer the ID format from the actual last populated INDEX ID column. If it
+    # is not incrementable, fail loudly instead of falling back to an older row
+    # and returning a plausible but wrong ID.
+    if [[ -n "$last_id" ]]; then
+      if ! split_decision_id "$last_id"; then
+        echo "Error: Last decision ID '$last_id' in INDEX.md has no numeric suffix. Set DECISION_ID_PREFIX and DECISION_ID_WIDTH to select a scheme explicitly." >&2
+        return 1
       fi
-    done < <(echo "$all" | jq -r '.[] | .id // empty')
+      prefix="$PARSED_ID_PREFIX"
+      if [[ "$width_configured" -eq 0 ]]; then
+        width="${#PARSED_ID_NUM}"
+      fi
+    fi
   elif [[ "$width_configured" -eq 0 ]]; then
     # A configured prefix selects the scheme; infer padding from matching rows.
     while IFS= read -r id; do
-      if [[ "$id" =~ ^(.*[^0-9])?([0-9]+)$ ]]; then
-        parsed_prefix="${BASH_REMATCH[1]}"
+      if split_decision_id "$id"; then
+        parsed_prefix="$PARSED_ID_PREFIX"
         if [[ "$parsed_prefix" == "$prefix" ]]; then
-          width="${#BASH_REMATCH[2]}"
+          width="${#PARSED_ID_NUM}"
         fi
       fi
     done < <(echo "$all" | jq -r '.[] | .id // empty')
@@ -430,9 +456,9 @@ cmd_next_id() {
   local max_num=0
 
   while IFS= read -r id; do
-    [[ "$id" =~ ^(.*[^0-9])?([0-9]+)$ ]] || continue
-    parsed_prefix="${BASH_REMATCH[1]}"
-    parsed_num="${BASH_REMATCH[2]}"
+    split_decision_id "$id" || continue
+    parsed_prefix="$PARSED_ID_PREFIX"
+    parsed_num="$PARSED_ID_NUM"
     [[ "$parsed_prefix" == "$prefix" ]] || continue
     # Force base-10 interpretation (strip leading zeros that bash treats as octal)
     local decimal=$((10#$parsed_num))

--- a/skills/decider/templates/decision-entry.md
+++ b/skills/decider/templates/decision-entry.md
@@ -164,7 +164,7 @@ For large architectural decisions spanning multiple concerns (design, API, schem
 1. **Title**: `# [DECISION_ID]: [TITLE]` — H1 using the project's decision ID scheme
 2. **Back-link**: Always include `[← Decision Index](INDEX.md)` after title
 3. **Metadata bold labels**: `**Date**:`, `**Status**:`, `**Research**:` — bold key, colon, space, value
-4. **Status values**: `Active`, `Superseded by [DECISION_ID]`, `Revisited`, `Active ([COMPONENTS] -> [DECISION_ID])`
+4. **Status values**: `Active`, `Superseded by [DECISION_ID]`, `Revisited`, `Active ([COMPONENTS] → [DECISION_ID])`
 5. **Research refs**: `[RESEARCH-ID](../research/RESEARCH-ID/findings.md)` or `—` if no research
 6. **H2 for sections** (`##`), H3 for subsections (`###`), H4 for sub-subsections (`####`)
 7. **Tables**: Standard markdown pipe-and-dash format

--- a/skills/decider/templates/decision-entry.md
+++ b/skills/decider/templates/decision-entry.md
@@ -2,7 +2,7 @@
 
 Template for creating `[DECISION_ID]-[DESCRIPTOR].md` files in the project decision documents directory.
 
-## Minimal Entry (D001-style)
+## Minimal Entry
 
 For focused, single-topic decisions with clear rationale.
 
@@ -30,7 +30,7 @@ For focused, single-topic decisions with clear rationale.
 **References**: [Related decision IDs, research IDs, external links]
 ```
 
-## Standard Entry (D010-style)
+## Standard Entry
 
 For decisions with alternatives considered, code patterns, and structured rationale.
 
@@ -93,7 +93,7 @@ For decisions with alternatives considered, code patterns, and structured ration
 - [Condition 2]
 ```
 
-## Comprehensive Entry (D033-style)
+## Comprehensive Entry
 
 For large architectural decisions spanning multiple concerns (design, API, schema, deployment).
 
@@ -106,7 +106,7 @@ For large architectural decisions spanning multiple concerns (design, API, schem
 **Status**: Active
 **Research**: [RESEARCH_REF or —]
 **Applies to**: [Context string — optional]
-**Refines**: [DXXX, DYYY — optional, for refinements of prior decisions]
+**Refines**: [DECISION_ID], [DECISION_ID] — optional, for refinements of prior decisions
 **API Contract**: [path — optional]
 
 ## Summary
@@ -143,7 +143,7 @@ For large architectural decisions spanning multiple concerns (design, API, schem
 
 | Decision | Change | Rationale |
 |----------|--------|-----------|
-| [DXXX] | [what changes] | [why] |
+| [DECISION_ID] | [what changes] | [why] |
 
 ## Resolved Decisions
 
@@ -161,16 +161,16 @@ For large architectural decisions spanning multiple concerns (design, API, schem
 
 ## Formatting Rules
 
-1. **Title**: `# [DECISION_ID]: [TITLE]` — H1, uppercase D + zero-padded number
+1. **Title**: `# [DECISION_ID]: [TITLE]` — H1 using the project's decision ID scheme
 2. **Back-link**: Always include `[← Decision Index](INDEX.md)` after title
 3. **Metadata bold labels**: `**Date**:`, `**Status**:`, `**Research**:` — bold key, colon, space, value
-4. **Status values**: `Active`, `Superseded by DXXX`, `Revisited`, `Active ([COMPONENTS] → DXXX)`
+4. **Status values**: `Active`, `Superseded by [DECISION_ID]`, `Revisited`, `Active ([COMPONENTS] -> [DECISION_ID])`
 5. **Research refs**: `[RESEARCH-ID](../research/RESEARCH-ID/findings.md)` or `—` if no research
 6. **H2 for sections** (`##`), H3 for subsections (`###`), H4 for sub-subsections (`####`)
 7. **Tables**: Standard markdown pipe-and-dash format
 8. **Code blocks**: Always specify language (e.g., `rust`, `sql`, `json`, `bash`)
-9. **Cross-references**: Always use markdown links `[DXXX](DXXX-descriptor.md)`
-10. **Code comments**: Use `// REVISIT(DXXX):` in source code to mark implementation points
+9. **Cross-references**: Always use markdown links `[DECISION_ID](DECISION_ID-descriptor.md)`
+10. **Code comments**: Use `// REVISIT([DECISION_ID]):` in source code to mark implementation points
 
 ## Size Guidelines
 

--- a/skills/decider/templates/index-row.md
+++ b/skills/decider/templates/index-row.md
@@ -13,20 +13,20 @@ Template for adding rows to the project decision documents `INDEX.md` table.
 | Field | Format | Example |
 |-------|--------|---------|
 | `DATE` | `YYYY-MM-DD` | `2026-03-24` |
-| `DECISION_ID` | `DXXX` (zero-padded) | `D034` |
+| `DECISION_ID` | Project's sequential ID with numeric suffix | `D034` or `ADR-0034` |
 | `RESEARCH_REF` | `[ID](path)` or `—` | `[PROJ-189](../research/PROJ-189/findings.md)` |
 | `DECISION_SUMMARY` | 5-15 word summary of choice | `Use Redis for session caching` |
 | `RATIONALE_SUMMARY` | Key reason in 5-15 words | `Redis proven, cluster-ready` |
 | `REVISIT_WHEN` | Trigger condition, 5-15 words | `Session count exceeds Redis capacity` |
 | `STATUS` | Status value | `Active` |
-| `LINK` | `[Full](DXXX-descriptor.md)` | `Full -> D034-feature-name.md` |
+| `LINK` | `[Full](DECISION_ID-descriptor.md)` | `Full -> D034-feature-name.md` |
 
 ## Status Values
 
 - `Active` — Current decision in effect
-- `Superseded by DXXX` — Replaced by newer decision
+- `Superseded by [DECISION_ID]` — Replaced by newer decision
 - `Revisited` — Re-evaluated, with outcome noted
-- `Active ([COMPONENTS] → DXXX)` — Partially superseded (specific components replaced)
+- `Active ([COMPONENTS] -> [DECISION_ID])` — Partially superseded (specific components replaced)
 
 ## Example Rows
 

--- a/skills/decider/templates/index-row.md
+++ b/skills/decider/templates/index-row.md
@@ -26,7 +26,7 @@ Template for adding rows to the project decision documents `INDEX.md` table.
 - `Active` — Current decision in effect
 - `Superseded by [DECISION_ID]` — Replaced by newer decision
 - `Revisited` — Re-evaluated, with outcome noted
-- `Active ([COMPONENTS] -> [DECISION_ID])` — Partially superseded (specific components replaced)
+- `Active ([COMPONENTS] → [DECISION_ID])` — Partially superseded (specific components replaced)
 
 ## Example Rows
 

--- a/skills/decider/tests/decider-next-id-scheme.test.sh
+++ b/skills/decider/tests/decider-next-id-scheme.test.sh
@@ -101,6 +101,28 @@ run_next_id "$MIXED_REPO" DECISIONS_DIR=docs/decisions DECISION_ID_PREFIX=D
 assert_eq "$rc" "0" "configured prefix next-id exits 0"
 assert_eq "$out" "D009" "configured prefix scans only matching ID-column rows"
 
+BAD_LAST_REPO="$TMP_ROOT/bad-last-repo"
+mkdir -p "$BAD_LAST_REPO/docs/decisions"
+cat >"$BAD_LAST_REPO/docs/decisions/INDEX.md" <<'EOF'
+# Architectural Decision Log
+
+| Date | ID | Research | Decision | Rationale | Revisit When | Status | Link |
+|------|----|----------|----------|-----------|--------------|--------|------|
+| 2026-01-10 | D008 | PROJ-100 | Legacy decision | Existing D-prefixed row | Never | Active | [Full](D008-legacy.md) |
+| 2026-01-11 | ADR-0035 | PROJ-101 | Latest numeric decision | Existing ADR-prefixed row | Never | Active | [Full](ADR-0035-latest.md) |
+| 2026-01-12 | ADR-current | PROJ-102 | Unparseable final ID | Current row has no numeric suffix | Never | Active | [Full](ADR-current.md) |
+EOF
+
+run_next_id "$BAD_LAST_REPO" DECISIONS_DIR=docs/decisions
+assert_eq "$rc" "1" "unparseable final ID exits nonzero"
+assert_eq "$out" "" "unparseable final ID emits no stdout"
+assert_contains "$err" "ADR-current" "unparseable final ID names the bad ID"
+assert_contains "$err" "DECISION_ID_PREFIX" "unparseable final ID points at explicit scheme configuration"
+
+run_next_id "$BAD_LAST_REPO" DECISIONS_DIR=docs/decisions DECISION_ID_PREFIX=ADR-
+assert_eq "$rc" "0" "configured prefix bypasses unparseable final-ID inference"
+assert_eq "$out" "ADR-0036" "configured prefix still scans matching numeric rows"
+
 EMPTY_REPO="$TMP_ROOT/empty-repo"
 mkdir -p "$EMPTY_REPO/docs/decisions"
 cat >"$EMPTY_REPO/docs/decisions/INDEX.md" <<'EOF'

--- a/skills/decider/tests/decider-next-id-scheme.test.sh
+++ b/skills/decider/tests/decider-next-id-scheme.test.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Regression tests for scheme-aware decisions next-id (vstack#956).
+#
+# next-id must derive the next decision number from the INDEX.md ID column, not
+# from DNNN-looking tokens in prose cells, and it must preserve repositories'
+# existing ID schemes such as ADR-0001.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
+DECISIONS="$SKILL_DIR/scripts/decisions"
+
+PASS=0
+FAIL=0
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+ERR_FILE="$TMP_ROOT/stderr"
+
+run_next_id() {
+  local dir="$1"
+  shift
+  set +e
+  out=$( (cd "$dir" && env -u DECISIONS_DIR -u DECISION_ID_PREFIX -u DECISION_ID_WIDTH "$@" "$DECISIONS" next-id) 2>"$ERR_FILE")
+  rc=$?
+  set -e
+  err="$(cat "$ERR_FILE")"
+}
+
+assert_eq() {
+  local got="$1" want="$2" name="$3"
+  if [[ "$got" == "$want" ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$name" "$want" "$got"
+  fi
+}
+
+assert_contains() {
+  local got="$1" needle="$2" name="$3"
+  if [[ "$got" == *"$needle"* ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected to contain: %s\n        got:      %s\n' "$name" "$needle" "$got"
+  fi
+}
+
+echo "=== decisions next-id scheme inference (vstack#956) ==="
+
+ADR_REPO="$TMP_ROOT/adr-repo"
+mkdir -p "$ADR_REPO/docs/decisions"
+cat >"$ADR_REPO/docs/decisions/INDEX.md" <<'EOF'
+# Architectural Decision Log
+
+| Date | ID | Research | Decision | Rationale | Revisit When | Status | Link |
+|------|----|----------|----------|-----------|--------------|--------|------|
+| 2026-01-10 | ADR-0001 | PROJ-100 | First decision | Establishes the log | Never | Active | [Full](ADR-0001-first.md) |
+| 2026-01-11 | ADR-0035 | PROJ-101 | Current scheme | Summary mentions **D1:** and D1/D3/D5 prose labels | Never | Active | [Full](ADR-0035-current.md) |
+EOF
+
+run_next_id "$ADR_REPO" DECISIONS_DIR=docs/decisions
+assert_eq "$rc" "0" "ADR next-id exits 0"
+assert_eq "$out" "ADR-0036" "ADR scheme and width are preserved"
+assert_eq "$err" "" "ADR next-id emits no stderr"
+
+D_REPO="$TMP_ROOT/d-repo"
+mkdir -p "$D_REPO/docs/decisions"
+cat >"$D_REPO/docs/decisions/INDEX.md" <<'EOF'
+# Architectural Decision Log
+
+| Date | ID | Research | Decision | Rationale | Revisit When | Status | Link |
+|------|----|----------|----------|-----------|--------------|--------|------|
+| 2026-01-10 | D001 | PROJ-100 | First decision | Mentions unrelated D999 prose token | Never | Active | [Full](D001-first.md) |
+EOF
+
+run_next_id "$D_REPO" DECISIONS_DIR=docs/decisions
+assert_eq "$rc" "0" "D next-id exits 0"
+assert_eq "$out" "D002" "prose DNNN token does not affect next-id"
+
+MIXED_REPO="$TMP_ROOT/mixed-repo"
+mkdir -p "$MIXED_REPO/docs/decisions"
+cat >"$MIXED_REPO/docs/decisions/INDEX.md" <<'EOF'
+# Architectural Decision Log
+
+| Date | ID | Research | Decision | Rationale | Revisit When | Status | Link |
+|------|----|----------|----------|-----------|--------------|--------|------|
+| 2026-01-10 | D008 | PROJ-100 | Legacy decision | Existing D-prefixed row | Never | Active | [Full](D008-legacy.md) |
+| 2026-01-11 | ADR-0009 | PROJ-101 | Switched scheme | Existing ADR-prefixed row | Never | Active | [Full](ADR-0009-switch.md) |
+| 2026-01-12 | ADR-0035 | PROJ-102 | Latest ADR decision | Current scheme | Never | Active | [Full](ADR-0035-latest.md) |
+EOF
+
+run_next_id "$MIXED_REPO" DECISIONS_DIR=docs/decisions
+assert_eq "$rc" "0" "mixed next-id exits 0"
+assert_eq "$out" "ADR-0036" "unconfigured next-id follows the last ID-column scheme"
+
+run_next_id "$MIXED_REPO" DECISIONS_DIR=docs/decisions DECISION_ID_PREFIX=D
+assert_eq "$rc" "0" "configured prefix next-id exits 0"
+assert_eq "$out" "D009" "configured prefix scans only matching ID-column rows"
+
+EMPTY_REPO="$TMP_ROOT/empty-repo"
+mkdir -p "$EMPTY_REPO/docs/decisions"
+cat >"$EMPTY_REPO/docs/decisions/INDEX.md" <<'EOF'
+# Architectural Decision Log
+
+| Date | ID | Research | Decision | Rationale | Revisit When | Status | Link |
+|------|----|----------|----------|-----------|--------------|--------|------|
+EOF
+
+run_next_id "$EMPTY_REPO" DECISIONS_DIR=docs/decisions
+assert_eq "$rc" "0" "empty index next-id exits 0"
+assert_eq "$out" "D001" "empty index keeps the default DXXX scheme"
+
+run_next_id "$EMPTY_REPO" DECISIONS_DIR=docs/decisions DECISION_ID_PREFIX=ADR- DECISION_ID_WIDTH=4
+assert_eq "$rc" "0" "configured empty index next-id exits 0"
+assert_eq "$out" "ADR-0001" "configured empty index supports custom scheme"
+
+run_next_id "$EMPTY_REPO" DECISIONS_DIR=docs/decisions DECISION_ID_WIDTH=zero
+assert_eq "$rc" "1" "invalid width exits nonzero"
+assert_contains "$err" "DECISION_ID_WIDTH" "invalid width names DECISION_ID_WIDTH"
+
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/skills/decider/workflows/create-decision.md
+++ b/skills/decider/workflows/create-decision.md
@@ -22,7 +22,7 @@ Create a new decision entry: assign ID, write decision file, add INDEX.md row, u
 .agents/skills/decider/scripts/decisions next-id
 ```
 
-**If `.agents/skills/decider/scripts/decisions` is unavailable**: Read `[project decision documents]/INDEX.md`, inspect only the ID column, infer the numeric-suffix scheme from the last populated ID, then increment the highest number with that same prefix. If no ID exists, use the project's documented default or `D001`.
+**If `.agents/skills/decider/scripts/decisions` is unavailable**: Read `[project decision documents]/INDEX.md`, inspect only the ID column, infer the numeric-suffix scheme from the last populated ID, then increment the highest number with that same prefix. If the last populated ID has no numeric suffix, stop and ask for the project's explicit ID scheme. If no ID exists, use the project's documented default or `D001`.
 
 ### 1.2 Generate Descriptor
 
@@ -93,7 +93,7 @@ If the new decision's context references other active decisions as partially aff
 
 1. **Read** referenced decision file
 2. **If** new decision replaces specific components but not the whole:
-   - Update status to `Active ([COMPONENTS] -> [DECISION_ID])` in both the decision file and INDEX.md row
+   - Update status to `Active ([COMPONENTS] → [DECISION_ID])` in both the decision file and INDEX.md row
 3. **If** new decision fully replaces:
    - Update status to `Superseded by [DECISION_ID]` in both locations
 

--- a/skills/decider/workflows/create-decision.md
+++ b/skills/decider/workflows/create-decision.md
@@ -22,7 +22,7 @@ Create a new decision entry: assign ID, write decision file, add INDEX.md row, u
 .agents/skills/decider/scripts/decisions next-id
 ```
 
-**If `.agents/skills/decider/scripts/decisions` not configured**: Read `[project decision documents]/INDEX.md`, find last `DXXX` row, increment by 1. Zero-pad to 3 digits.
+**If `.agents/skills/decider/scripts/decisions` is unavailable**: Read `[project decision documents]/INDEX.md`, inspect only the ID column, infer the numeric-suffix scheme from the last populated ID, then increment the highest number with that same prefix. If no ID exists, use the project's documented default or `D001`.
 
 ### 1.2 Generate Descriptor
 
@@ -33,7 +33,7 @@ Examples:
 - "Test file organization patterns" → `test-file-organization`
 - "Auth/Cloud Storage Stack" → `auth-cloud-storage`
 
-Store as `[DECISION_ID]` (e.g., `D034`) and `[DESCRIPTOR]` (e.g., `auth-cloud-storage`).
+Store as `[DECISION_ID]` (e.g., `D034` or `ADR-0034`) and `[DESCRIPTOR]` (e.g., `auth-cloud-storage`).
 
 ---
 
@@ -66,8 +66,8 @@ Based on scope of the decision, select the appropriate template from `templates/
    **Keep tight** — reference research for details. Decision documents summarize; research documents contain the full analysis.
 
 3. **Add cross-references** if decision relates to existing decisions:
-   - Link to related decisions: `[DXXX](DXXX-descriptor.md)`
-   - Note if decision refines prior work: `**Refines**: [DXXX](DXXX-descriptor.md)`
+   - Link to related decisions: `[DECISION_ID](DECISION_ID-descriptor.md)`
+   - Note if decision refines prior work: `**Refines**: [DECISION_ID](DECISION_ID-descriptor.md)`
 
 ---
 
@@ -93,7 +93,7 @@ If the new decision's context references other active decisions as partially aff
 
 1. **Read** referenced decision file
 2. **If** new decision replaces specific components but not the whole:
-   - Update status to `Active ([COMPONENTS] → [DECISION_ID])` in both the decision file and INDEX.md row
+   - Update status to `Active ([COMPONENTS] -> [DECISION_ID])` in both the decision file and INDEX.md row
 3. **If** new decision fully replaces:
    - Update status to `Superseded by [DECISION_ID]` in both locations
 

--- a/skills/decider/workflows/search-decisions.md
+++ b/skills/decider/workflows/search-decisions.md
@@ -10,7 +10,7 @@ Search and retrieve decision documents by issue reference, keywords, or ID.
 | `.agents/skills/decider/scripts/decisions search "[KEYWORDS]"` | Ranked keyword search (AND, scored) | JSON `[{id, decision, path, score}]` |
 | `.agents/skills/decider/scripts/decisions search "term1\|term2"` | Regex OR search | JSON `[{id, decision, path}]` |
 | `.agents/skills/decider/scripts/decisions list` | List all active decisions | JSON `[{id, decision, path}]` |
-| `.agents/skills/decider/scripts/decisions next-id` | Get next available DXXX | Single line `DXXX` |
+| `.agents/skills/decider/scripts/decisions next-id` | Get next available decision ID from the INDEX ID column | Single decision ID line |
 | `.agents/skills/decider/scripts/decisions get [DECISION_ID]` | Get decision details | JSON `{id, decision, status, date, path}` |
 
 Options: `--limit N` (default: 5) for search results.
@@ -63,7 +63,7 @@ Contains `|`, `()`, or `\` → regex mode (no scoring, direct pattern match).
 .agents/skills/decider/scripts/decisions list
 ```
 
-Returns all decisions with status starting with `Active` (includes partially superseded entries like `Active (X → DXXX)`).
+Returns all decisions with status starting with `Active` (includes partially superseded entries like `Active (X -> [DECISION_ID])`).
 
 ---
 
@@ -73,9 +73,9 @@ Returns all decisions with status starting with `Active` (includes partially sup
 .agents/skills/decider/scripts/decisions next-id
 ```
 
-Reads INDEX.md, finds the highest DXXX number, returns `D{N+1}` (zero-padded).
+Reads `INDEX.md`, inspects only the ID column, infers the numeric-suffix scheme from the last populated ID, and returns the next number with that same prefix and padding. Set `DECISION_ID_PREFIX` and `DECISION_ID_WIDTH` to override the inferred scheme, especially for an empty index.
 
-**Output**: `D034`
+**Output**: `D034` or `ADR-0034`
 
 ---
 

--- a/skills/decider/workflows/search-decisions.md
+++ b/skills/decider/workflows/search-decisions.md
@@ -63,7 +63,7 @@ Contains `|`, `()`, or `\` → regex mode (no scoring, direct pattern match).
 .agents/skills/decider/scripts/decisions list
 ```
 
-Returns all decisions with status starting with `Active` (includes partially superseded entries like `Active (X -> [DECISION_ID])`).
+Returns all decisions with status starting with `Active` (includes partially superseded entries like `Active (X → [DECISION_ID])`).
 
 ---
 
@@ -73,7 +73,7 @@ Returns all decisions with status starting with `Active` (includes partially sup
 .agents/skills/decider/scripts/decisions next-id
 ```
 
-Reads `INDEX.md`, inspects only the ID column, infers the numeric-suffix scheme from the last populated ID, and returns the next number with that same prefix and padding. Set `DECISION_ID_PREFIX` and `DECISION_ID_WIDTH` to override the inferred scheme, especially for an empty index.
+Reads `INDEX.md`, inspects only the ID column, infers the numeric-suffix scheme from the last populated ID, and returns the next number with that same prefix and padding. If the last populated ID has no numeric suffix, `next-id` fails instead of falling back to an older row. Set `DECISION_ID_PREFIX` and `DECISION_ID_WIDTH` to override the inferred scheme, especially for an empty index or an intentional scheme switch.
 
 **Output**: `D034` or `ADR-0034`
 

--- a/skills/decider/workflows/update-decision.md
+++ b/skills/decider/workflows/update-decision.md
@@ -6,7 +6,7 @@ Update the status or content of existing decision entries — supersession, part
 
 | Input | Source | Required |
 |-------|--------|----------|
-| `decision_id` | Caller (DXXX to update) | Yes |
+| `decision_id` | Caller (decision ID to update) | Yes |
 | `update_type` | Caller | Yes |
 | `new_decision_id` | Caller (for supersession) | Conditional |
 | `components` | Caller (for partial supersession) | Conditional |
@@ -19,7 +19,7 @@ Update the status or content of existing decision entries — supersession, part
 | Type | When | Status Change |
 |------|------|---------------|
 | `supersede` | New decision fully replaces this one | `Superseded by [NEW_DECISION_ID]` |
-| `partial_supersede` | New decision replaces specific components | `Active ([COMPONENTS] → [NEW_DECISION_ID])` |
+| `partial_supersede` | New decision replaces specific components | `Active ([COMPONENTS] -> [NEW_DECISION_ID])` |
 | `revisit` | Conditions changed, decision re-assessed | `Revisited` (append outcome) |
 
 ---
@@ -37,7 +37,7 @@ Update the status or content of existing decision entries — supersession, part
 
    **Partial supersession:**
    ```markdown
-   **Status**: Active ([COMPONENTS] → [NEW_DECISION_ID])
+   **Status**: Active ([COMPONENTS] -> [NEW_DECISION_ID])
    ```
 
    **Revisitation:**
@@ -80,5 +80,5 @@ For `supersede` or `partial_supersede`:
 ## 5. Return
 
 ```
-Updated: [DECISION_ID] → [STATUS]
+Updated: [DECISION_ID] -> [STATUS]
 ```

--- a/skills/decider/workflows/update-decision.md
+++ b/skills/decider/workflows/update-decision.md
@@ -19,7 +19,7 @@ Update the status or content of existing decision entries — supersession, part
 | Type | When | Status Change |
 |------|------|---------------|
 | `supersede` | New decision fully replaces this one | `Superseded by [NEW_DECISION_ID]` |
-| `partial_supersede` | New decision replaces specific components | `Active ([COMPONENTS] -> [NEW_DECISION_ID])` |
+| `partial_supersede` | New decision replaces specific components | `Active ([COMPONENTS] → [NEW_DECISION_ID])` |
 | `revisit` | Conditions changed, decision re-assessed | `Revisited` (append outcome) |
 
 ---
@@ -37,7 +37,7 @@ Update the status or content of existing decision entries — supersession, part
 
    **Partial supersession:**
    ```markdown
-   **Status**: Active ([COMPONENTS] -> [NEW_DECISION_ID])
+   **Status**: Active ([COMPONENTS] → [NEW_DECISION_ID])
    ```
 
    **Revisitation:**
@@ -80,5 +80,5 @@ For `supersede` or `partial_supersede`:
 ## 5. Return
 
 ```
-Updated: [DECISION_ID] -> [STATUS]
+Updated: [DECISION_ID] → [STATUS]
 ```


### PR DESCRIPTION
## Summary

- derive `decisions next-id` from parsed INDEX ID-column values
- preserve numeric-suffix schemes such as `ADR-0001`
- add explicit prefix/width overrides and fail on non-incrementable active IDs
- update the decider docs and regression coverage

## Validation

- `bash skills/decider/tests/decider-next-id-scheme.test.sh`
- `bash skills/decider/tests/decider-issue-action-hint.test.sh`
- `bash skills/decider/tests/decider-search-body.test.sh`
- `bash skills/decider/tests/decider-search-missing-dir.test.sh`

Closes #956
