### PR TITLE
Support custom source catalog roots

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,8 @@ cli/src/
 ├── pi_extension.rs      Pi extension discovery, install/remove, settings.json merge
 ├── config.rs            Lock file (JSON), project root detection, staleness/mtime helpers
 ├── scope.rs             Scope enum (project | global | all); uniform `--scope`/`-g` parsing
-├── mapping.rs           Source vstack.toml — MappingConfig (agent-skills, role-skills, hook-events)
+├── catalog.rs           Source catalog discovery from default dirs or vstack.toml `[catalog]`
+├── mapping.rs           Source vstack.toml — MappingConfig (catalog, agent-skills, role-skills, hook-events)
 ├── project_config.rs    Project vstack.toml — ProjectConfig, ensure/write/update
 ├── resolve.rs           Shared helpers — skill-pair resolution, hook source attribution/matching, read_existing_extras, is_vstack_source
 ├── installer.rs         Symlink/copy logic, install/remove orchestration
@@ -27,17 +28,17 @@ cli/src/
 
 (agent.rs, skill.rs, hook.rs, frontmatter.rs are simple parsers — names match their job.)
 
-vstack.toml              Skill/hook-to-agent mapping (read at install)
-agents/                  Canonical agents — `role` field drives per-harness access control
-skills/                  Skill packages — each has SKILL.md with optional dependencies
-hooks/                   Safety hooks — bash scripts with YAML comment headers
-pi-extensions/           Pi extension packages (npm-shaped). package.json has `pi.extensions`
+vstack.toml              Source catalog + skill/hook-to-agent mapping (read at install)
+agents/                  Default canonical agents dir — `role` field drives per-harness access control
+skills/                  Default skill packages dir — each has SKILL.md with optional dependencies
+hooks/                   Default safety hooks dir — bash scripts with YAML comment headers
+pi-extensions/           Default Pi extension packages dir (npm-shaped). package.json has `pi.extensions`
 skill-templates/         Templates for new skills
 ```
 
 ## Key Design Decisions
 
-- **Discovered dynamically.** CLI scans `agents/`, `skills/`, `hooks/`, `pi-extensions/` at runtime. No hardcoded lists.
+- **Discovered dynamically.** CLI scans source catalog roots at runtime. Default roots are `agents/`, `skills/`, `hooks/`, `pi-extensions/`, and `extras/`; a source `vstack.toml` `[catalog]` table can override each item kind's roots.
 - **Canonical source is harness-agnostic.** Translation happens in `cli/src/harness/`.
 - **Agent `role` drives access control.** `analyst` → planning/research/recon artifacts. `reviewer` → report-only/subagent (may write reports, not product code). `engineer` → full access/primary. `manager` → analysis/report artifacts.
 - **Skill dependencies and ownership use frontmatter.** `dependencies: { required: [...], optional: [...] }` in SKILL.md. Shipped VStack skills also declare `metadata.source`, `metadata.repository`, and `metadata.bugs` so agents can route upstream failures to the owning project.
@@ -119,6 +120,15 @@ On install vstack copies the package into `<scope>/packages/<name>` and adds `./
 
 ### Mapping config (`vstack.toml`)
 ```toml
+[catalog]
+# Each omitted key keeps its default root. Paths are source-root-relative.
+# A path can be a container dir, one specific item dir/file, or use `*` on the final segment only.
+agents = ["agents"]
+skills = ["skills", "packages/skills/*", "one-offs/specific-skill"]
+hooks = ["hooks"]
+pi_extensions = ["pi-extensions", "pkgs/plugins/pi-*"]
+extras = ["extras"]
+
 [agent-skills]
 rust = ["github", "worktree", ...]
 iced = ["iced-rs", "iced-shadcn", ...]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,7 +122,8 @@ On install vstack copies the package into `<scope>/packages/<name>` and adds `./
 ```toml
 [catalog]
 # Each omitted key keeps its default root. Paths are source-root-relative.
-# A path can be a container dir, one specific item dir/file, or use `*` on the final segment only.
+# Packaged items use item dirs; agents/hooks may also name one `.md`/`.sh` file.
+# A path can use `*` on the final segment only.
 agents = ["agents"]
 skills = ["skills", "packages/skills/*", "one-offs/specific-skill"]
 hooks = ["hooks"]

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ pi_extensions = ["pkgs/plugins/pi-*", "pkgs/plugins/a-specific-extension"]
 extras = ["theme-packs"]
 ```
 
-Each path is relative to the source repo. A path may point at a container directory or one specific item directory/file; `*` is supported on the final path segment only. Omitted keys keep the default directory for that item kind.
+Each path is relative to the source repo. A path may point at a container directory; skills, Pi extensions, and extras may name one specific item directory, while agents and hooks may also name one specific `.md` or `.sh` file. `*` is supported on the final path segment only. Omitted keys keep the default directory for that item kind.
 
 ### Customizing With `vstack.toml`
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,19 @@ source repo
 Claude Code · Cursor · OpenCode · Codex · Pi
 ```
 
+By default, vstack scans `agents/`, `skills/`, `hooks/`, `pi-extensions/`, and `extras/`. Source repos with a different layout can declare catalog roots in their source `vstack.toml`:
+
+```toml
+[catalog]
+agents = ["pkgs/agents"]
+skills = ["pkgs/skills/*", "one-offs/specific-skill"]
+hooks = ["automation/vstack-hooks"]
+pi_extensions = ["pkgs/plugins/pi-*", "pkgs/plugins/a-specific-extension"]
+extras = ["theme-packs"]
+```
+
+Each path is relative to the source repo. A path may point at a container directory or one specific item directory/file; `*` is supported on the final path segment only. Omitted keys keep the default directory for that item kind.
+
 ### Customizing With `vstack.toml`
 
 `vstack add` writes a `vstack.toml` at your project root. Edit it to customize per-agent behavior, then run `vstack refresh` to apply. Generated agent files are overwritten on refresh — `vstack.toml` is the stable home for overrides.

--- a/cli/src/catalog.rs
+++ b/cli/src/catalog.rs
@@ -120,33 +120,38 @@ fn expand_catalog_entry(source_root: &Path, raw: &str) -> Result<Vec<PathBuf>> {
 }
 
 fn wildcard_match(pattern: &str, candidate: &str) -> bool {
-    if pattern == "*" {
-        return true;
-    }
+    let pattern = pattern.as_bytes();
+    let candidate = candidate.as_bytes();
+    let mut pattern_index = 0;
+    let mut candidate_index = 0;
+    let mut star_index = None;
+    let mut star_match_index = 0;
 
-    let parts: Vec<&str> = pattern.split('*').collect();
-    let mut remainder = candidate;
-    for (index, part) in parts.iter().enumerate() {
-        if part.is_empty() {
-            continue;
-        }
-        if index == 0 && !pattern.starts_with('*') {
-            let Some(stripped) = remainder.strip_prefix(part) else {
-                return false;
-            };
-            remainder = stripped;
-            continue;
-        }
-        let Some(pos) = remainder.find(part) else {
+    while candidate_index < candidate.len() {
+        if pattern_index < pattern.len()
+            && pattern[pattern_index] != b'*'
+            && pattern[pattern_index] == candidate[candidate_index]
+        {
+            pattern_index += 1;
+            candidate_index += 1;
+        } else if pattern_index < pattern.len() && pattern[pattern_index] == b'*' {
+            star_index = Some(pattern_index);
+            pattern_index += 1;
+            star_match_index = candidate_index;
+        } else if let Some(index) = star_index {
+            pattern_index = index + 1;
+            star_match_index += 1;
+            candidate_index = star_match_index;
+        } else {
             return false;
-        };
-        remainder = &remainder[pos + part.len()..];
+        }
     }
 
-    pattern.ends_with('*')
-        || parts
-            .last()
-            .is_none_or(|last| remainder.is_empty() || last.is_empty())
+    while pattern_index < pattern.len() && pattern[pattern_index] == b'*' {
+        pattern_index += 1;
+    }
+
+    pattern_index == pattern.len()
 }
 
 fn normalize_lexical(path: &Path) -> PathBuf {
@@ -463,5 +468,13 @@ extras = ["theme-packs"]
                 .contains("only supported on the last path segment")
         );
         let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn wildcard_match_backtracks_to_later_suffix() {
+        assert!(wildcard_match("*a", "aa"));
+        assert!(wildcard_match("a*a", "ababa"));
+        assert!(wildcard_match("pi-*-hooks", "pi-hooks-hooks"));
+        assert!(!wildcard_match("a*b", "a"));
     }
 }

--- a/cli/src/catalog.rs
+++ b/cli/src/catalog.rs
@@ -1,0 +1,467 @@
+use crate::agent::Agent;
+use crate::extra::Extra;
+use crate::hook::Hook;
+use crate::pi_extension::PiExtension;
+use crate::skill::Skill;
+use anyhow::{Context, Result};
+use std::collections::HashSet;
+use std::path::{Component, Path, PathBuf};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CatalogKind {
+    Agents,
+    Skills,
+    Hooks,
+    PiExtensions,
+    Extras,
+}
+
+impl CatalogKind {
+    pub fn default_paths(self) -> &'static [&'static str] {
+        match self {
+            Self::Agents => &["agents"],
+            Self::Skills => &["skills"],
+            Self::Hooks => &["hooks"],
+            Self::PiExtensions => &["pi-extensions"],
+            Self::Extras => &["extras"],
+        }
+    }
+}
+
+pub(crate) fn has_catalog_table(source_root: &Path) -> bool {
+    let Ok(raw) = std::fs::read_to_string(source_root.join("vstack.toml")) else {
+        return false;
+    };
+    let Ok(parsed) = raw.parse::<toml::Value>() else {
+        return false;
+    };
+    parsed
+        .get("catalog")
+        .and_then(|value| value.as_table())
+        .is_some()
+}
+
+fn configured_paths(source_root: &Path, kind: CatalogKind) -> Vec<String> {
+    crate::mapping::MappingConfig::load(source_root)
+        .catalog
+        .paths_for(kind)
+}
+
+fn expand_configured_paths(source_root: &Path, kind: CatalogKind) -> Result<Vec<PathBuf>> {
+    let mut out = Vec::new();
+    let mut seen = HashSet::new();
+    for raw in configured_paths(source_root, kind) {
+        for path in expand_catalog_entry(source_root, &raw)? {
+            let key = normalize_lexical(&path);
+            if seen.insert(key) {
+                out.push(path);
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn expand_catalog_entry(source_root: &Path, raw: &str) -> Result<Vec<PathBuf>> {
+    let trimmed = raw.trim().trim_end_matches('/');
+    if trimmed.is_empty() {
+        anyhow::bail!("catalog path must not be empty");
+    }
+
+    let rel = Path::new(trimmed);
+    if rel.is_absolute() {
+        anyhow::bail!("catalog path must be relative to the source root: {trimmed}");
+    }
+
+    let mut parts: Vec<String> = Vec::new();
+    for component in rel.components() {
+        match component {
+            Component::CurDir => {}
+            Component::Normal(part) => parts.push(part.to_string_lossy().to_string()),
+            Component::ParentDir | Component::Prefix(_) | Component::RootDir => {
+                anyhow::bail!("catalog path must stay inside the source root: {trimmed}");
+            }
+        }
+    }
+    if parts.is_empty() {
+        anyhow::bail!("catalog path must name a file or directory: {trimmed}");
+    }
+    if parts[..parts.len().saturating_sub(1)]
+        .iter()
+        .any(|part| part.contains('*'))
+    {
+        anyhow::bail!("catalog glob is only supported on the last path segment: {trimmed}");
+    }
+
+    let last = parts.last().expect("non-empty parts");
+    if !last.contains('*') {
+        return Ok(vec![source_root.join(parts.iter().collect::<PathBuf>())]);
+    }
+
+    let parent_rel: PathBuf = parts[..parts.len() - 1].iter().collect();
+    let parent = source_root.join(parent_rel);
+    if !parent.exists() {
+        return Ok(Vec::new());
+    }
+    let mut matches = Vec::new();
+    for entry in std::fs::read_dir(&parent)
+        .with_context(|| format!("reading catalog glob parent {}", parent.display()))?
+    {
+        let entry = entry?;
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+            continue;
+        };
+        if wildcard_match(last, name) {
+            matches.push(path);
+        }
+    }
+    matches.sort();
+    Ok(matches)
+}
+
+fn wildcard_match(pattern: &str, candidate: &str) -> bool {
+    if pattern == "*" {
+        return true;
+    }
+
+    let parts: Vec<&str> = pattern.split('*').collect();
+    let mut remainder = candidate;
+    for (index, part) in parts.iter().enumerate() {
+        if part.is_empty() {
+            continue;
+        }
+        if index == 0 && !pattern.starts_with('*') {
+            let Some(stripped) = remainder.strip_prefix(part) else {
+                return false;
+            };
+            remainder = stripped;
+            continue;
+        }
+        let Some(pos) = remainder.find(part) else {
+            return false;
+        };
+        remainder = &remainder[pos + part.len()..];
+    }
+
+    pattern.ends_with('*')
+        || parts
+            .last()
+            .is_none_or(|last| remainder.is_empty() || last.is_empty())
+}
+
+fn normalize_lexical(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            other => normalized.push(other.as_os_str()),
+        }
+    }
+    normalized
+}
+
+fn discover_files(source_root: &Path, kind: CatalogKind, extension: &str) -> Result<Vec<PathBuf>> {
+    let mut files = Vec::new();
+    for candidate in expand_configured_paths(source_root, kind)? {
+        if !candidate.exists() {
+            continue;
+        }
+        if candidate.is_file() {
+            if candidate.extension().is_some_and(|ext| ext == extension) {
+                files.push(candidate);
+            }
+            continue;
+        }
+        if !candidate.is_dir() {
+            continue;
+        }
+        for entry in std::fs::read_dir(&candidate)
+            .with_context(|| format!("reading catalog directory {}", candidate.display()))?
+        {
+            let path = entry?.path();
+            if path.is_file() && path.extension().is_some_and(|ext| ext == extension) {
+                files.push(path);
+            }
+        }
+    }
+    files.sort();
+    Ok(files)
+}
+
+fn discover_manifest_dirs(
+    source_root: &Path,
+    kind: CatalogKind,
+    manifest: &str,
+) -> Result<Vec<PathBuf>> {
+    let mut dirs = Vec::new();
+    for candidate in expand_configured_paths(source_root, kind)? {
+        if !candidate.exists() || !candidate.is_dir() {
+            continue;
+        }
+        if candidate.join(manifest).is_file() {
+            dirs.push(candidate);
+            continue;
+        }
+        for entry in std::fs::read_dir(&candidate)
+            .with_context(|| format!("reading catalog directory {}", candidate.display()))?
+        {
+            let path = entry?.path();
+            if path.is_dir() && path.join(manifest).is_file() {
+                dirs.push(path);
+            }
+        }
+    }
+    dirs.sort();
+    Ok(dirs)
+}
+
+pub(crate) fn discover_agents(source_root: &Path) -> Result<Vec<Agent>> {
+    let mut out = Vec::new();
+    let mut seen = HashSet::new();
+    for path in discover_files(source_root, CatalogKind::Agents, "md")? {
+        match Agent::from_file(&path) {
+            Ok(agent) if seen.insert(agent.name.clone()) => out.push(agent),
+            Ok(agent) => eprintln!(
+                "Warning: skipping duplicate agent {} from {}",
+                agent.name,
+                path.display()
+            ),
+            Err(err) => eprintln!("Warning: skipping {}: {err}", path.display()),
+        }
+    }
+    out.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(out)
+}
+
+pub(crate) fn discover_skills(source_root: &Path) -> Result<Vec<Skill>> {
+    let mut out = Vec::new();
+    let mut seen = HashSet::new();
+    for dir in discover_manifest_dirs(source_root, CatalogKind::Skills, "SKILL.md")? {
+        let skill_file = dir.join("SKILL.md");
+        match Skill::from_file(&skill_file) {
+            Ok(skill) if seen.insert(skill.name.clone()) => out.push(skill),
+            Ok(skill) => eprintln!(
+                "Warning: skipping duplicate skill {} from {}",
+                skill.name,
+                skill_file.display()
+            ),
+            Err(err) => eprintln!("Warning: skipping {}: {err}", skill_file.display()),
+        }
+    }
+    out.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(out)
+}
+
+pub(crate) fn discover_hooks(source_root: &Path) -> Result<Vec<Hook>> {
+    let mut out = Vec::new();
+    let mut seen = HashSet::new();
+    for path in discover_files(source_root, CatalogKind::Hooks, "sh")? {
+        match Hook::from_file(&path) {
+            Ok(hook) if seen.insert(hook.name.clone()) => out.push(hook),
+            Ok(hook) => eprintln!(
+                "Warning: skipping duplicate hook {} from {}",
+                hook.name,
+                path.display()
+            ),
+            Err(err) => eprintln!("Warning: skipping hook {}: {err}", path.display()),
+        }
+    }
+    out.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(out)
+}
+
+pub(crate) fn discover_pi_extensions(source_root: &Path) -> Result<Vec<PiExtension>> {
+    let mut out = Vec::new();
+    let mut seen = HashSet::new();
+    for dir in discover_manifest_dirs(source_root, CatalogKind::PiExtensions, "package.json")? {
+        match PiExtension::from_dir(&dir) {
+            Ok(ext) if seen.insert(ext.name.clone()) => out.push(ext),
+            Ok(ext) => eprintln!(
+                "Warning: skipping duplicate pi-package {} from {}",
+                ext.name,
+                dir.display()
+            ),
+            Err(err) => eprintln!("Warning: skipping {}: {err}", dir.display()),
+        }
+    }
+    out.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(out)
+}
+
+pub(crate) fn discover_extras(source_root: &Path) -> Result<Vec<Extra>> {
+    let mut out = Vec::new();
+    let mut seen = HashSet::new();
+    for dir in discover_manifest_dirs(source_root, CatalogKind::Extras, "extra.toml")? {
+        match Extra::from_dir(&dir) {
+            Ok(extra) if seen.insert(extra.name().to_string()) => out.push(extra),
+            Ok(extra) => eprintln!(
+                "Warning: skipping duplicate extra {} from {}",
+                extra.name(),
+                dir.display()
+            ),
+            Err(err) => eprintln!("Warning: skipping {}: {err}", dir.display()),
+        }
+    }
+    out.sort_by(|a, b| a.name().cmp(b.name()));
+    Ok(out)
+}
+
+pub(crate) fn find_item_path(
+    source_root: &Path,
+    kind: crate::config::ItemKind,
+    name: &str,
+) -> Option<PathBuf> {
+    match kind {
+        crate::config::ItemKind::Agent => discover_agents(source_root)
+            .ok()?
+            .into_iter()
+            .find(|agent| agent.name == name)
+            .map(|agent| agent.source_path),
+        crate::config::ItemKind::Skill => discover_skills(source_root)
+            .ok()?
+            .into_iter()
+            .find(|skill| skill.name == name)
+            .map(|skill| skill.source_dir),
+        crate::config::ItemKind::Hook => discover_hooks(source_root)
+            .ok()?
+            .into_iter()
+            .find(|hook| hook.name == name)
+            .map(|hook| hook.source_path),
+        crate::config::ItemKind::PiExtension => discover_pi_extensions(source_root)
+            .ok()?
+            .into_iter()
+            .find(|ext| {
+                ext.name == name || crate::pi_extension::legacy_names_for(&ext.name).contains(&name)
+            })
+            .map(|ext| ext.source_dir),
+        crate::config::ItemKind::Extra => discover_extras(source_root)
+            .ok()?
+            .into_iter()
+            .find(|extra| extra.name() == name)
+            .map(|extra| extra.source_dir),
+    }
+}
+
+pub(crate) fn find_source_root_for_item_path(item_path: &Path) -> Option<PathBuf> {
+    let mut dir = if item_path.is_dir() {
+        item_path.to_path_buf()
+    } else {
+        item_path.parent()?.to_path_buf()
+    };
+    loop {
+        if crate::resolve::is_vstack_source(&dir) {
+            return Some(dir);
+        }
+        if !dir.pop() {
+            return None;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn sandbox(label: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock before epoch")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "vstack-catalog-{label}-{}-{nanos}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn custom_catalog_roots_discover_each_item_kind() {
+        let root = sandbox("custom-roots");
+        fs::write(
+            root.join("vstack.toml"),
+            r#"[catalog]
+agents = ["pkgs/agent-defs"]
+skills = ["pkgs/skill-*", "single/custom-skill"]
+hooks = ["pkgs/hook-defs"]
+pi_extensions = ["apps/pi-*"]
+extras = ["theme-packs"]
+"#,
+        )
+        .unwrap();
+
+        fs::create_dir_all(root.join("pkgs/agent-defs")).unwrap();
+        fs::write(
+            root.join("pkgs/agent-defs/rust.md"),
+            "---\nname: rust\ndescription: Rust\nrole: engineer\n---\n# Rust\n",
+        )
+        .unwrap();
+
+        fs::create_dir_all(root.join("pkgs/skill-demo")).unwrap();
+        fs::write(
+            root.join("pkgs/skill-demo/SKILL.md"),
+            "---\nname: demo\ndescription: Demo\n---\n# Demo\n",
+        )
+        .unwrap();
+        fs::create_dir_all(root.join("single/custom-skill")).unwrap();
+        fs::write(
+            root.join("single/custom-skill/SKILL.md"),
+            "---\nname: custom\ndescription: Custom\n---\n# Custom\n",
+        )
+        .unwrap();
+
+        fs::create_dir_all(root.join("pkgs/hook-defs")).unwrap();
+        fs::write(
+            root.join("pkgs/hook-defs/guard.sh"),
+            "# ---\n# name: guard\n# event: PreToolUse\n# matcher: Bash\n# description: Guard\n# ---\n",
+        )
+        .unwrap();
+
+        fs::create_dir_all(root.join("apps/pi-demo")).unwrap();
+        fs::write(
+            root.join("apps/pi-demo/package.json"),
+            "{\"name\":\"@example/pi-demo\",\"version\":\"1.0.0\",\"pi\":{\"extensions\":[]}}\n",
+        )
+        .unwrap();
+
+        fs::create_dir_all(root.join("theme-packs/method")).unwrap();
+        fs::write(
+            root.join("theme-packs/method/extra.toml"),
+            "name = \"method\"\nkind = \"theme-pack\"\ndescription = \"Theme\"\ndefault-theme = \"dark\"\n",
+        )
+        .unwrap();
+
+        assert_eq!(discover_agents(&root).unwrap()[0].name, "rust");
+        let skills: Vec<String> = discover_skills(&root)
+            .unwrap()
+            .into_iter()
+            .map(|skill| skill.name)
+            .collect();
+        assert_eq!(skills, vec!["custom".to_string(), "demo".to_string()]);
+        assert_eq!(discover_hooks(&root).unwrap()[0].name, "guard");
+        assert_eq!(
+            discover_pi_extensions(&root).unwrap()[0].name,
+            "@example/pi-demo"
+        );
+        assert_eq!(discover_extras(&root).unwrap()[0].name(), "method");
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn glob_is_restricted_to_last_segment() {
+        let root = sandbox("bad-glob");
+        let err = expand_catalog_entry(&root, "*/skills").unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("only supported on the last path segment")
+        );
+        let _ = fs::remove_dir_all(root);
+    }
+}

--- a/cli/src/commands/add.rs
+++ b/cli/src/commands/add.rs
@@ -1,9 +1,6 @@
-use crate::agent;
 use crate::agent::Agent;
 use crate::config::{self, InstallMethod, LockFile};
-use crate::extra;
 use crate::harness::Harness;
-use crate::hook;
 use crate::hook::Hook;
 use crate::installer;
 use crate::pi_extension::PiExtension;
@@ -720,6 +717,67 @@ role: engineer
         let _ = std::fs::remove_dir_all(root);
     }
 
+    #[test]
+    fn add_discovers_agent_and_auto_skill_from_custom_catalog() {
+        let root = tmpdir("custom-catalog-add");
+        let source = root.join("source");
+        let project = root.join("project");
+        let home = root.join("home");
+        let config_home = root.join("config");
+        std::fs::create_dir_all(source.join("pkgs/agents")).unwrap();
+        std::fs::create_dir_all(source.join("pkgs/skills/demo")).unwrap();
+        std::fs::create_dir_all(&project).unwrap();
+        std::fs::create_dir_all(&home).unwrap();
+        std::fs::create_dir_all(&config_home).unwrap();
+        std::fs::write(
+            source.join("vstack.toml"),
+            "[catalog]\nagents = [\"pkgs/agents\"]\nskills = [\"pkgs/skills\"]\n\n[agent-skills]\nrust = [\"demo\"]\n",
+        )
+        .unwrap();
+        std::fs::write(
+            source.join("pkgs/agents/rust.md"),
+            "---\nname: rust\ndescription: Rust\nmodel: sonnet\nrole: engineer\n---\n# Rust\n",
+        )
+        .unwrap();
+        std::fs::write(
+            source.join("pkgs/skills/demo/SKILL.md"),
+            "---\nname: demo\ndescription: Demo\n---\n# Demo\n",
+        )
+        .unwrap();
+
+        crate::test_util::with_home_and_config(&home, &config_home, || {
+            crate::test_util::with_project_root(&project, || {
+                run(
+                    Some(source.to_string_lossy().into_owned()),
+                    false,
+                    Some(vec!["codex".into()]),
+                    Some(vec!["rust".into()]),
+                    None,
+                    None,
+                    None,
+                    false,
+                    true,
+                    false,
+                    false,
+                    false,
+                )
+                .unwrap();
+            })
+        });
+
+        assert!(project.join(".codex/agents/rust.toml").exists());
+        assert!(project.join(".agents/skills/demo/SKILL.md").exists());
+        let lock = config::LockFile::load(&project.join(".vstack-lock.json")).unwrap();
+        assert!(lock.entries.contains_key("rust"));
+        assert!(lock.entries.contains_key("demo"));
+        assert!(
+            !lock.entries.get("demo").unwrap().source_hash.is_empty(),
+            "custom catalog skill should get a source hash"
+        );
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
     #[cfg(unix)]
     #[test]
     fn same_path_matches_symlinked_project_root_to_canonical_source() {
@@ -1315,17 +1373,12 @@ source (e.g. switching vstack repos, or starting clean), pass --clobber:
             registry.save(&config::source_registry_path())?;
         }
         let source_dir = resolved.dir.clone();
-        let agents_dir = source_dir.join("agents");
-        let skills_dir = source_dir.join("skills");
-        let hooks_dir = source_dir.join("hooks");
-        let pi_ext_dir = source_dir.join("pi-extensions");
-
-        let all_agents = agent::discover_agents(&agents_dir)?;
-        let all_skills = skill::discover_skills(&skills_dir)?;
-        let all_hooks = hook::discover_hooks(&hooks_dir)?;
+        let all_agents = crate::catalog::discover_agents(&source_dir)?;
+        let all_skills = crate::catalog::discover_skills(&source_dir)?;
+        let all_hooks = crate::catalog::discover_hooks(&source_dir)?;
         let all_pi_extensions =
-            crate::pi_extension::discover_pi_extensions(&pi_ext_dir).unwrap_or_default();
-        let extras = extra::discover_extras(&source_dir)?;
+            crate::catalog::discover_pi_extensions(&source_dir).unwrap_or_default();
+        let extras = crate::catalog::discover_extras(&source_dir)?;
         let dep_graph = skill::build_dependency_graph(&all_skills);
 
         // Filter semantics: passing any item filter restricts the install to
@@ -1524,8 +1577,7 @@ source (e.g. switching vstack repos, or starting clean), pass --clobber:
     // (agent-skills + role-skills + prefix matches) plus transitive
     // dependencies and add any missing canonical skills.
     if !no_auto_skills && !selected_agents.is_empty() {
-        let skills_source_dir = source_dir.join("skills");
-        let all_skills = skill::discover_skills(&skills_source_dir).unwrap_or_default();
+        let all_skills = crate::catalog::discover_skills(&source_dir).unwrap_or_default();
         let added = auto_include_agent_skills(
             &selected_agents,
             &mapping,
@@ -2133,7 +2185,7 @@ fn clone_or_update(source: &str) -> Result<PathBuf> {
 
     if !crate::resolve::is_vstack_source(&repo_dir) {
         anyhow::bail!(
-            "Cloned repo doesn't look like a vstack repo (no agents/, skills/, or hooks/ found)"
+            "Cloned repo doesn't look like a vstack repo (no catalog table or source item directories found)"
         );
     }
 
@@ -2172,13 +2224,9 @@ fn reconcile_agents(
     }
 
     // Discover source agents and skills for descriptions
-    let agents_dir = source_dir.join("agents");
-    let skills_dir = source_dir.join("skills");
-    let hooks_dir = source_dir.join("hooks");
-
-    let source_agents = crate::agent::discover_agents(&agents_dir).unwrap_or_default();
-    let source_skills = crate::skill::discover_skills(&skills_dir).unwrap_or_default();
-    let source_hooks = crate::hook::discover_hooks(&hooks_dir).unwrap_or_default();
+    let source_agents = crate::catalog::discover_agents(source_dir).unwrap_or_default();
+    let source_skills = crate::catalog::discover_skills(source_dir).unwrap_or_default();
+    let source_hooks = crate::catalog::discover_hooks(source_dir).unwrap_or_default();
     let mut regenerated_codex_agents: Vec<crate::agent::Agent> = Vec::new();
     let mut regenerated_codex_agent_names = std::collections::HashSet::new();
 

--- a/cli/src/commands/add.rs
+++ b/cli/src/commands/add.rs
@@ -778,6 +778,57 @@ role: engineer
         let _ = std::fs::remove_dir_all(root);
     }
 
+    #[test]
+    fn add_reports_invalid_pi_extension_catalog_path() {
+        let root = tmpdir("custom-catalog-bad-pi");
+        let source = root.join("source");
+        let project = root.join("project");
+        let home = root.join("home");
+        let config_home = root.join("config");
+        std::fs::create_dir_all(source.join("agents")).unwrap();
+        std::fs::create_dir_all(&project).unwrap();
+        std::fs::create_dir_all(&home).unwrap();
+        std::fs::create_dir_all(&config_home).unwrap();
+        std::fs::write(
+            source.join("vstack.toml"),
+            "[catalog]\nagents = [\"agents\"]\npi_extensions = [\"*/pi-packages\"]\n",
+        )
+        .unwrap();
+        std::fs::write(
+            source.join("agents/rust.md"),
+            "---\nname: rust\ndescription: Rust\nmodel: sonnet\nrole: engineer\n---\n# Rust\n",
+        )
+        .unwrap();
+
+        let err = crate::test_util::with_home_and_config(&home, &config_home, || {
+            crate::test_util::with_project_root(&project, || {
+                run(
+                    Some(source.to_string_lossy().into_owned()),
+                    false,
+                    Some(vec!["codex".into()]),
+                    Some(vec!["rust".into()]),
+                    None,
+                    None,
+                    None,
+                    false,
+                    true,
+                    false,
+                    false,
+                    false,
+                )
+                .unwrap_err()
+            })
+        });
+
+        assert!(
+            err.to_string()
+                .contains("catalog glob is only supported on the last path segment"),
+            "unexpected error: {err:#}"
+        );
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
     #[cfg(unix)]
     #[test]
     fn same_path_matches_symlinked_project_root_to_canonical_source() {
@@ -1376,8 +1427,7 @@ source (e.g. switching vstack repos, or starting clean), pass --clobber:
         let all_agents = crate::catalog::discover_agents(&source_dir)?;
         let all_skills = crate::catalog::discover_skills(&source_dir)?;
         let all_hooks = crate::catalog::discover_hooks(&source_dir)?;
-        let all_pi_extensions =
-            crate::catalog::discover_pi_extensions(&source_dir).unwrap_or_default();
+        let all_pi_extensions = crate::catalog::discover_pi_extensions(&source_dir)?;
         let extras = crate::catalog::discover_extras(&source_dir)?;
         let dep_graph = skill::build_dependency_graph(&all_skills);
 

--- a/cli/src/commands/apply.rs
+++ b/cli/src/commands/apply.rs
@@ -964,7 +964,9 @@ fn resolve_apply_source_root() -> Result<PathBuf> {
 
     for source in candidates {
         if let Some(path) = config::resolve_source_path(&source)
-            && path.join("extras").is_dir()
+            && !crate::catalog::discover_extras(&path)
+                .unwrap_or_default()
+                .is_empty()
         {
             return Ok(path);
         }
@@ -979,7 +981,10 @@ fn resolve_apply_source_root() -> Result<PathBuf> {
 fn find_source_root_with_extras_from_cwd() -> Result<Option<PathBuf>> {
     let mut dir = std::env::current_dir()?;
     loop {
-        if dir.join("extras").is_dir() {
+        if !crate::catalog::discover_extras(&dir)
+            .unwrap_or_default()
+            .is_empty()
+        {
             return Ok(Some(dir));
         }
         if !dir.pop() {
@@ -1007,7 +1012,7 @@ fn build_plan_for_source(
     request: &ApplyRequest,
     env: &ApplyEnvironment,
 ) -> Result<ApplyPlan> {
-    let extras = crate::extra::discover_extras(source_root)?;
+    let extras = crate::catalog::discover_extras(source_root)?;
     let extra = extras
         .iter()
         .find(|extra| extra.name() == request.extra_name)

--- a/cli/src/commands/update_pi.rs
+++ b/cli/src/commands/update_pi.rs
@@ -3,9 +3,8 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use crate::pi_extension::{
-    self, PiExtension, SourceIndex, discover_pi_extensions, install_pi_extension,
-    is_pi_extension_installed, list_installed_vstack_packages, list_npm_packages,
-    read_source_index,
+    self, PiExtension, SourceIndex, install_pi_extension, is_pi_extension_installed,
+    list_installed_vstack_packages, list_npm_packages, read_source_index,
 };
 
 /// What kind of source a package was installed from.
@@ -440,7 +439,7 @@ fn execute(plan: &[PlanItem]) -> Result<()> {
 
     for ((global, repo), names) in &vstack_groups {
         let scope_label = if *global { "global" } else { "project" };
-        let extensions = match discover_pi_extensions(&repo.join("pi-extensions")) {
+        let extensions = match crate::catalog::discover_pi_extensions(repo) {
             Ok(list) => list,
             Err(e) => {
                 eprintln!("  ✗ failed to scan {} ({scope_label}): {e}", repo.display());
@@ -453,7 +452,7 @@ fn execute(plan: &[PlanItem]) -> Result<()> {
         for name in names {
             let Some(ext) = extensions.iter().find(|e| &e.name == name) else {
                 eprintln!(
-                    "  ✗ {name} ({scope_label}): not found in {}/pi-extensions",
+                    "  ✗ {name} ({scope_label}): not found in source catalog at {}",
                     repo.display()
                 );
                 failed.push(format!("{name} ({scope_label})"));

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -902,9 +902,11 @@ pub fn compute_source_hash(entry: &LockEntry) -> String {
 
     match entry.kind {
         ItemKind::Skill => {
-            let dir = source_root.join("skills").join(&entry.name);
-            if dir.exists() {
-                state = fnv1a_chain(state, &hash_dir_bytes(&dir).to_le_bytes());
+            let dir = crate::catalog::find_item_path(&source_root, entry.kind, &entry.name);
+            if let Some(dir) = dir.as_deref()
+                && dir.exists()
+            {
+                state = fnv1a_chain(state, &hash_dir_bytes(dir).to_le_bytes());
             }
             // Only hash this skill's section from project vstack.toml
             let project_config = proj_root.join("vstack.toml");
@@ -914,11 +916,11 @@ pub fn compute_source_hash(entry: &LockEntry) -> String {
             }
         }
         ItemKind::Agent => {
-            let file = source_root
-                .join("agents")
-                .join(format!("{}.md", entry.name));
-            if file.exists() {
-                state = fnv1a_chain(state, &hash_file_bytes(&file).to_le_bytes());
+            let file = crate::catalog::find_item_path(&source_root, entry.kind, &entry.name);
+            if let Some(file) = file.as_deref()
+                && file.exists()
+            {
+                state = fnv1a_chain(state, &hash_file_bytes(file).to_le_bytes());
             }
             // Hash this agent's sections from both configs
             let source_config = source_root.join("vstack.toml");
@@ -930,9 +932,11 @@ pub fn compute_source_hash(entry: &LockEntry) -> String {
             }
         }
         ItemKind::Hook => {
-            let file = source_root.join("hooks").join(format!("{}.sh", entry.name));
-            if file.exists() {
-                state = fnv1a_chain(state, &hash_file_bytes(&file).to_le_bytes());
+            let file = crate::catalog::find_item_path(&source_root, entry.kind, &entry.name);
+            if let Some(file) = file.as_deref()
+                && file.exists()
+            {
+                state = fnv1a_chain(state, &hash_file_bytes(file).to_le_bytes());
             }
             // Hook attribution lives in source vstack.toml [hook-events]
             // (keyed by event:matcher, not hook name). Re-targeting a hook —
@@ -947,14 +951,18 @@ pub fn compute_source_hash(entry: &LockEntry) -> String {
             }
         }
         ItemKind::PiExtension => {
-            if let Some(dir) = resolve_pi_extension_dir(&source_root, &entry.name) {
+            if let Some(dir) = crate::catalog::find_item_path(&source_root, entry.kind, &entry.name)
+                .or_else(|| resolve_pi_extension_dir(&source_root, &entry.name))
+            {
                 state = fnv1a_chain(state, &hash_dir_bytes(&dir).to_le_bytes());
             }
         }
         ItemKind::Extra => {
-            let dir = source_root.join("extras").join(&entry.name);
-            if dir.exists() {
-                state = fnv1a_chain(state, &hash_dir_bytes(&dir).to_le_bytes());
+            let dir = crate::catalog::find_item_path(&source_root, entry.kind, &entry.name);
+            if let Some(dir) = dir.as_deref()
+                && dir.exists()
+            {
+                state = fnv1a_chain(state, &hash_dir_bytes(dir).to_le_bytes());
             }
         }
     }
@@ -1058,7 +1066,7 @@ fn scan_installed_hooks_on_disk_at_with_cursor_global_rules(
         return Vec::new();
     };
 
-    let Ok(source_hooks) = crate::hook::discover_hooks(&source_root.join("hooks")) else {
+    let Ok(source_hooks) = crate::catalog::discover_hooks(&source_root) else {
         return Vec::new();
     };
 
@@ -1967,6 +1975,46 @@ mod source_registry_tests {
         );
         // Must not collapse to the bare FNV offset constant.
         assert_ne!(h1, format!("{:016x}", FNV_OFFSET));
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn source_hash_uses_custom_catalog_skill_path() {
+        let dir = sandbox("catalog_hash_skill");
+        let skill_dir = dir.join("pkgs").join("skills").join("demo");
+        fs::create_dir_all(&skill_dir).unwrap();
+        fs::write(
+            dir.join("vstack.toml"),
+            "[catalog]\nskills = [\"pkgs/skills/*\"]\n",
+        )
+        .unwrap();
+        fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: demo\ndescription: Demo\n---\n# Before\n",
+        )
+        .unwrap();
+
+        let entry = LockEntry {
+            name: "demo".to_string(),
+            kind: ItemKind::Skill,
+            source: dir.display().to_string(),
+            source_repo: None,
+            harnesses: vec!["codex".to_string()],
+            method: InstallMethod::Symlink,
+            installed_at: "2026-07-29T00:00:00Z".to_string(),
+            source_hash: String::new(),
+        };
+
+        let h1 = compute_source_hash(&entry);
+        fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: demo\ndescription: Demo\n---\n# After\n",
+        )
+        .unwrap();
+        let h2 = compute_source_hash(&entry);
+
+        assert!(!h1.is_empty());
+        assert_ne!(h1, h2);
         let _ = fs::remove_dir_all(&dir);
     }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 
 mod agent;
+mod catalog;
 mod commands;
 mod config;
 mod extra;

--- a/cli/src/mapping.rs
+++ b/cli/src/mapping.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 #[derive(Debug, Default, Deserialize, Clone)]
 #[serde(default)]
 pub struct MappingConfig {
+    pub catalog: CatalogConfig,
     #[serde(rename = "agent-skills")]
     pub agent_skills: HashMap<String, Vec<String>>,
     #[serde(rename = "role-skills")]
@@ -19,6 +20,35 @@ pub struct MappingConfig {
     #[serde(skip)]
     pub agent_frontmatter_by_harness:
         HashMap<String, HashMap<String, crate::agent::AgentFrontmatterOverrides>>,
+}
+
+#[derive(Debug, Default, Deserialize, Clone, PartialEq, Eq)]
+#[serde(default)]
+pub struct CatalogConfig {
+    pub agents: Option<Vec<String>>,
+    pub skills: Option<Vec<String>>,
+    pub hooks: Option<Vec<String>>,
+    #[serde(alias = "pi-extensions")]
+    pub pi_extensions: Option<Vec<String>>,
+    pub extras: Option<Vec<String>>,
+}
+
+impl CatalogConfig {
+    pub fn paths_for(&self, kind: crate::catalog::CatalogKind) -> Vec<String> {
+        let configured = match kind {
+            crate::catalog::CatalogKind::Agents => &self.agents,
+            crate::catalog::CatalogKind::Skills => &self.skills,
+            crate::catalog::CatalogKind::Hooks => &self.hooks,
+            crate::catalog::CatalogKind::PiExtensions => &self.pi_extensions,
+            crate::catalog::CatalogKind::Extras => &self.extras,
+        };
+        configured.clone().unwrap_or_else(|| {
+            kind.default_paths()
+                .iter()
+                .map(|path| (*path).to_string())
+                .collect()
+        })
+    }
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/cli/src/pi_extension.rs
+++ b/cli/src/pi_extension.rs
@@ -555,15 +555,16 @@ fn install_pi_extension_inner(
 }
 
 /// Walk up from a package's source dir to find the vstack repo root.
-/// Identified by presence of a top-level `pi-extensions/` sibling and a
-/// `Cargo.toml` or `.git` marker. Returns None if not found.
+/// Catalog-aware sources are accepted, while the legacy `pi-extensions/`
+/// marker remains for older partial package roots.
 fn find_vstack_repo_root(source_dir: &Path) -> Option<PathBuf> {
     let mut dir = source_dir.to_path_buf();
     while dir.pop() {
-        if dir.join("pi-extensions").is_dir()
-            && (dir.join("Cargo.toml").exists()
-                || dir.join(".git").exists()
-                || dir.join("vstack.toml").exists())
+        if crate::resolve::is_vstack_source(&dir)
+            || (dir.join("pi-extensions").is_dir()
+                && (dir.join("Cargo.toml").exists()
+                    || dir.join(".git").exists()
+                    || dir.join("vstack.toml").exists()))
         {
             return Some(dir);
         }

--- a/cli/src/refresh_sources.rs
+++ b/cli/src/refresh_sources.rs
@@ -32,13 +32,10 @@ impl RefreshSource {
             aliases: record.aliases.clone(),
             source_repo: record.source_repo.clone(),
             mapping: MappingConfig::load(&record.root),
-            agents: crate::agent::discover_agents(&record.root.join("agents")).unwrap_or_default(),
-            skills: crate::skill::discover_skills(&record.root.join("skills")).unwrap_or_default(),
-            hooks: crate::hook::discover_hooks(&record.root.join("hooks")).unwrap_or_default(),
-            pi_extensions: crate::pi_extension::discover_pi_extensions(
-                &record.root.join("pi-extensions"),
-            )
-            .unwrap_or_default(),
+            agents: crate::catalog::discover_agents(&record.root).unwrap_or_default(),
+            skills: crate::catalog::discover_skills(&record.root).unwrap_or_default(),
+            hooks: crate::catalog::discover_hooks(&record.root).unwrap_or_default(),
+            pi_extensions: crate::catalog::discover_pi_extensions(&record.root).unwrap_or_default(),
         }
     }
 

--- a/cli/src/resolve.rs
+++ b/cli/src/resolve.rs
@@ -202,6 +202,9 @@ pub fn is_vstack_source(dir: &Path) -> bool {
     {
         return false;
     }
+    if crate::catalog::has_catalog_table(dir) {
+        return true;
+    }
     let count = [
         dir.join("agents").is_dir(),
         dir.join("skills").is_dir(),
@@ -440,5 +443,19 @@ mod tests {
 
         assert_eq!(fallback.len(), 1);
         assert_eq!(fallback[0].name, "fallback");
+    }
+
+    #[test]
+    fn is_vstack_source_accepts_catalog_table_without_default_dirs() {
+        let root = tmpdir("catalog-source");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(
+            root.join("vstack.toml"),
+            "[catalog]\nskills = [\"pkgs/skills/*\"]\n",
+        )
+        .unwrap();
+
+        assert!(is_vstack_source(&root));
+        let _ = std::fs::remove_dir_all(root);
     }
 }

--- a/cli/src/tui/disk_mutations.rs
+++ b/cli/src/tui/disk_mutations.rs
@@ -213,6 +213,7 @@ pub(super) fn perform_move_plans(
 
     let source_dir = source_dir_for_items(items);
     let mapping = source_dir
+        .as_deref()
         .map(crate::mapping::MappingConfig::load)
         .unwrap_or_default();
     project_config.overlay_source_frontmatter(&mapping);
@@ -521,9 +522,11 @@ pub(super) fn perform_inline_update(
     let project_root = config::project_root();
     let source_dir = source_dir_for_items(items);
     let mapping = source_dir
+        .as_deref()
         .map(crate::mapping::MappingConfig::load)
         .unwrap_or_default();
     let refresh_sources: Vec<crate::refresh_sources::RefreshSource> = source_dir
+        .as_deref()
         .map(|root| crate::refresh_sources::RefreshSource {
             root: root.to_path_buf(),
             aliases: vec![root.to_string_lossy().into_owned()],
@@ -660,24 +663,54 @@ pub(super) fn perform_inline_update(
     report
 }
 
-fn source_dir_for_items(items: &DiscoveredItems) -> Option<&std::path::Path> {
-    items
+fn source_dir_for_items(items: &DiscoveredItems) -> Option<std::path::PathBuf> {
+    fn item_path(items: &DiscoveredItems) -> Option<&std::path::Path> {
+        items
+            .agents
+            .first()
+            .map(|agent| agent.source_path.as_path())
+            .or_else(|| items.skills.first().map(|skill| skill.source_dir.as_path()))
+            .or_else(|| items.hooks.first().map(|hook| hook.source_path.as_path()))
+            .or_else(|| {
+                items
+                    .pi_extensions
+                    .first()
+                    .map(|extension| extension.source_dir.as_path())
+            })
+            .or_else(|| items.extras.first().map(|extra| extra.source_dir.as_path()))
+    }
+
+    if let Some(path) = item_path(items)
+        && let Some(root) = crate::catalog::find_source_root_for_item_path(path)
+    {
+        return Some(root);
+    }
+
+    if let Some(path) = items
         .agents
         .first()
         .and_then(|a| a.source_path.parent().and_then(|p| p.parent()))
-        .or_else(|| items.skills.first().and_then(|s| s.source_dir.parent()))
-        .or_else(|| {
-            items
-                .hooks
-                .first()
-                .and_then(|h| h.source_path.parent().and_then(|p| p.parent()))
-        })
-        .or_else(|| {
-            items
-                .pi_extensions
-                .first()
-                .and_then(|e| e.source_dir.parent())
-        })
+    {
+        return Some(path.to_path_buf());
+    }
+    if let Some(path) = items.skills.first().and_then(|s| s.source_dir.parent()) {
+        return Some(path.to_path_buf());
+    }
+    if let Some(path) = items
+        .hooks
+        .first()
+        .and_then(|h| h.source_path.parent().and_then(|p| p.parent()))
+    {
+        return Some(path.to_path_buf());
+    }
+    if let Some(path) = items
+        .pi_extensions
+        .first()
+        .and_then(|e| e.source_dir.parent())
+    {
+        return Some(path.to_path_buf());
+    }
+    None
 }
 
 #[cfg(test)]

--- a/vstack.toml
+++ b/vstack.toml
@@ -10,6 +10,18 @@
 # behave normally.
 is_source_catalog = true
 #
+# Source item discovery defaults to agents/, skills/, hooks/, pi-extensions/,
+# and extras/. Repos with a different package layout can opt in per kind; any
+# omitted key keeps its default. Paths are repo-root-relative, can name a
+# container dir or one specific item, and support `*` on the final segment only.
+#
+# [catalog]
+# agents = ["agents"]
+# skills = ["skills", "packages/skills/*", "one-offs/specific-skill"]
+# hooks = ["hooks"]
+# pi_extensions = ["pi-extensions", "pkgs/plugins/pi-*"]
+# extras = ["extras"]
+#
 # [agent-skills] is the single source of truth for which skills appear in each
 # agent's frontmatter.  When an agent has an explicit entry here, prefix matching
 # is skipped — only the listed skills plus role-skills are attached.

--- a/vstack.toml
+++ b/vstack.toml
@@ -12,8 +12,9 @@ is_source_catalog = true
 #
 # Source item discovery defaults to agents/, skills/, hooks/, pi-extensions/,
 # and extras/. Repos with a different package layout can opt in per kind; any
-# omitted key keeps its default. Paths are repo-root-relative, can name a
-# container dir or one specific item, and support `*` on the final segment only.
+# omitted key keeps its default. Paths are repo-root-relative; packaged items
+# use item dirs, while agents/hooks may also name one `.md`/`.sh` file. `*` is
+# supported on the final segment only.
 #
 # [catalog]
 # agents = ["agents"]


### PR DESCRIPTION
## Summary

- add source-level `[catalog]` roots for agents, skills, hooks, Pi extensions, and extras
- keep existing default directories for omitted catalog keys
- support exact item paths and final-segment `*` globs
- use catalog discovery across add, refresh, update, hashing, and TUI paths

## Validation

- `cd cli && cargo test`
- `cli/scripts/integration-check.sh`
- focused custom catalog, glob, error propagation, source hash, and source detection tests
- `git diff --check origin/main...HEAD`

Closes #954
