### PR TITLE
Fix deep-research required section list

### DIFF
--- a/skills/deep-research/SKILL.md
+++ b/skills/deep-research/SKILL.md
@@ -138,5 +138,5 @@ Manual review checks (need judgment; `validate` cannot perform them):
 
 - Template: `templates/findings.md`
 - Format checklist: `templates/findings-report-format.md` (this is a Markdown format guide, not a machine-readable schema)
-- Required report sections: `Executive Summary`, `Key Findings`, `Evidence and Sources`, `Tradeoffs / Alternatives`, `Recommendation / Decision Criteria`, `Risks / Unknowns`, `Revisit Conditions`, and `Research Metadata`.
+- Required report sections: `Research Question`, `Executive Summary`, `Key Findings`, `Evidence and Sources`, `Tradeoffs / Alternatives`, `Recommendation / Decision Criteria`, `Risks / Unknowns`, `Revisit Conditions`, and `Research Metadata`.
 - Do not embed raw Exa JSON in `findings.md`. Store provider payloads in the sidecar JSON (`findings.raw.json` by default, or the explicit `--raw-output`/`rawOutputPath`).


### PR DESCRIPTION
## Summary

- include `Research Question` in deep-research's documented required report sections
- align SKILL.md with the existing template and validator

## Validation

- `node --test skills/deep-research/tests/deep-research.test.mjs`
- `git diff --check origin/main...HEAD`

Closes #958
