### PR TITLE
fix(pi-extensions): show resolved values for extension-owned config channels

### DIFF
--- a/pi-extensions/pi-claude-bridge/DEVELOPMENT.md
+++ b/pi-extensions/pi-claude-bridge/DEVELOPMENT.md
@@ -78,6 +78,14 @@ they are the only consumers). What the original evaluation flagged, and how each
 - The subscription-billing constraint is untouched: BOTH native stream entry points
   (`stream`/`streamSimple`) are the same Claude Code subprocess router — there is no raw-API path.
 
+## Config channels
+
+`loadConfig` layers three sources, lowest precedence first: `<piUserDir>/claude-bridge.json`, a trusted project's `.pi/claude-bridge.json`, then extension-manager config in `settings.json`. Isolated mode (`CLAUDE_BRIDGE_ISOLATED=1`) keeps only the first.
+
+Each `claude-bridge.json` is read by `legacyFileConfig`, which accepts both the nested legacy shape (`provider.*`, `promptContext.*`) and the manager's flat manifest keys; nested wins when a file carries both for one key. Provider values are normalized once over the merged result, so an invalid `forceEffort` in a higher layer still clears a valid one below it.
+
+`resolveExternalConfigValue(key, cwd)` reports what those files — and only those files — resolve for one manifest key, plus the concrete file that supplied it. It shares `legacyLayers`/`mergeLayers` with `loadConfig` and applies the same normalization, so the two cannot drift. `registerExternalConfigResolver` publishes it under `Symbol.for("vstack.pi.extension-config-resolver")` keyed by `PACKAGE_ID`; the vstack extension manager calls it when neither of its own scopes holds a key, and renders the value with its source file. Registration happens before the `config.enabled === false` early return, because a bridge disabled by `claude-bridge.json` is precisely the case the settings editor has to explain. The contract itself is documented in [`pi-extension-manager/DEVELOPMENT.md`](../pi-extension-manager/DEVELOPMENT.md).
+
 ## Connector write enforcement
 
 Write denial with `connectorWriteMode: "deny"` is two-layered:

--- a/pi-extensions/pi-claude-bridge/README.md
+++ b/pi-extensions/pi-claude-bridge/README.md
@@ -54,6 +54,8 @@ Open `/extensions:settings`; settings appear under the **Claude Bridge** tab.
 
 Project settings in `.pi/settings.json` apply only after Pi marks the workspace trusted; before trust, vstack Pi extensions read user/global settings only.
 
+The bridge also reads `claude-bridge.json` (`~/.pi/agent/claude-bridge.json`, and `.pi/claude-bridge.json` in a trusted project). Settings the bridge takes from one of those files are shown with the file that supplies them, so the editor reports the value the bridge resolves rather than the default. Changing the setting in the editor writes Pi settings, which take precedence over `claude-bridge.json`.
+
 ### General
 
 | Setting | What it does |
@@ -143,7 +145,7 @@ Extension-manager settings use flat package-scoped keys:
 }
 ```
 
-Legacy `.pi/claude-bridge.json` configuration keeps these options nested under `provider`. Environment variables work with either format. Connectors remain off by default so Pi owns tool execution.
+Legacy `claude-bridge.json` configuration nests these options under `provider` (prompt-context flags under `promptContext`); the flat keys above are accepted there too. Environment variables work with either format. Connectors remain off by default so Pi owns tool execution.
 
 | Extension-manager key | Env var | Values | Default | What it does |
 | --- | --- | --- | --- | --- |

--- a/pi-extensions/pi-claude-bridge/bundle/index.js
+++ b/pi-extensions/pi-claude-bridge/bundle/index.js
@@ -26941,8 +26941,9 @@ function splitPrefixSuffix(input, options = {}) {
 // src/config.ts
 import { existsSync as existsSync2, readFileSync as readFileSync2 } from "fs";
 import { homedir } from "os";
-import { dirname, join as join2, resolve as resolve2 } from "path";
+import { dirname, join as join2, resolve as resolve2, sep as sep2 } from "path";
 var PACKAGE_ID = "@vanillagreen/pi-claude-bridge";
+var EXTERNAL_CONFIG_RESOLVER_SYMBOL = /* @__PURE__ */ Symbol.for("vstack.pi.extension-config-resolver");
 var VALID_EFFORT_LEVELS = /* @__PURE__ */ new Set(["low", "medium", "high", "xhigh", "max"]);
 function expandHome(input) {
   if (input === "~") return homedir();
@@ -27127,19 +27128,85 @@ function managerToConfig(raw) {
     ...Object.keys(promptContext).length ? { promptContext } : {}
   };
 }
-function loadConfig(cwd) {
-  const global2 = tryParseJson(join2(piUserDir(), "claude-bridge.json"));
-  const isolated = isolatedFromEnv();
-  const projectSettings = isolated ? void 0 : projectSettingsPath(cwd);
-  const trustedProject = projectSettings !== void 0 && projectSettingsTrusted(projectSettings);
-  const project = trustedProject ? tryParseJson(join2(dirname(projectSettings), "claude-bridge.json")) : {};
-  const manager = isolated ? {} : managerToConfig(readManagerConfig(cwd));
-  const provider = normalizeProviderConfig({ ...global2.provider, ...project.provider, ...manager.provider });
+function legacyFileConfig(path) {
+  const raw = asRecord(tryParseJson(path)) ?? {};
+  const flat = managerToConfig(raw);
+  const provider = { ...flat.provider, ...asRecord(raw.provider) };
+  const promptContext = { ...flat.promptContext, ...asRecord(raw.promptContext) };
   return {
-    enabled: manager.enabled ?? project.enabled ?? global2.enabled ?? true,
-    provider,
-    promptContext: { ...global2.promptContext, ...project.promptContext, ...manager.promptContext }
+    ...flat.enabled !== void 0 ? { enabled: flat.enabled } : {},
+    ...Object.keys(provider ?? {}).length ? { provider } : {},
+    ...Object.keys(promptContext ?? {}).length ? { promptContext } : {}
   };
+}
+function legacyLayers(cwd) {
+  const globalPath = join2(piUserDir(), "claude-bridge.json");
+  const layers = [{ path: globalPath, config: legacyFileConfig(globalPath) }];
+  if (isolatedFromEnv()) return layers;
+  const projectSettings = projectSettingsPath(cwd);
+  if (!projectSettingsTrusted(projectSettings)) return layers;
+  const projectPath = join2(dirname(projectSettings), "claude-bridge.json");
+  return [...layers, { path: projectPath, config: legacyFileConfig(projectPath) }];
+}
+function mergeLayers(layers) {
+  const merged = { provider: {}, promptContext: {} };
+  for (const layer of layers) {
+    if (layer.config.enabled !== void 0) merged.enabled = layer.config.enabled;
+    merged.provider = { ...merged.provider, ...layer.config.provider };
+    merged.promptContext = { ...merged.promptContext, ...layer.config.promptContext };
+  }
+  return merged;
+}
+function loadConfig(cwd) {
+  const legacy = mergeLayers(legacyLayers(cwd));
+  const manager = isolatedFromEnv() ? {} : managerToConfig(readManagerConfig(cwd));
+  const provider = normalizeProviderConfig({ ...legacy.provider, ...manager.provider });
+  return {
+    enabled: manager.enabled ?? legacy.enabled ?? true,
+    provider,
+    promptContext: { ...legacy.promptContext, ...manager.promptContext }
+  };
+}
+var PROVIDER_KEYS = /* @__PURE__ */ new Set([
+  "allowExtraUsage",
+  "appendSystemPrompt",
+  "connectorWriteMode",
+  "enableConnectors",
+  "fastMode",
+  "forceEffort",
+  "modelEffortOverrides",
+  "pathToClaudeCodeExecutable",
+  "strictMcpConfig"
+]);
+var PROMPT_CONTEXT_KEYS = /* @__PURE__ */ new Set([
+  "includeAppendSystemPromptMd",
+  "includeCavemanHook",
+  "includeProjectAgentsHook",
+  "includeTaskPanelHook"
+]);
+function configValueForKey(config2, key) {
+  if (key === "enabled") return config2.enabled;
+  if (PROVIDER_KEYS.has(key)) return normalizeProviderConfig(config2.provider)?.[key];
+  if (PROMPT_CONTEXT_KEYS.has(key)) return config2.promptContext?.[key];
+  return void 0;
+}
+function displayPath(path) {
+  const home = homedir();
+  return home && path.startsWith(home + sep2) ? `~${path.slice(home.length)}` : path;
+}
+function resolveExternalConfigValue(key, cwd) {
+  const layers = legacyLayers(cwd);
+  const value = configValueForKey(mergeLayers(layers), key);
+  if (value === void 0) return { explicit: false, value: void 0 };
+  const source = [...layers].reverse().find((layer) => configValueForKey(layer.config, key) !== void 0)?.path;
+  return { explicit: true, value, ...source ? { source: displayPath(source) } : {} };
+}
+function registerExternalConfigResolver() {
+  const host = globalThis;
+  const existing = asRecord(host[EXTERNAL_CONFIG_RESOLVER_SYMBOL]);
+  const registry2 = existing ?? {};
+  if (!existing) host[EXTERNAL_CONFIG_RESOLVER_SYMBOL] = registry2;
+  registry2[PACKAGE_ID] = (key, cwd) => resolveExternalConfigValue(key, cwd);
 }
 
 // src/skills.ts
@@ -27517,10 +27584,10 @@ function isChildExecutedTool(name) {
 }
 function isConnectorWriteTool(name) {
   if (!name.startsWith(CONNECTOR_NS_PREFIX2)) return false;
-  const sep2 = name.indexOf("__", CONNECTOR_NS_PREFIX2.length);
-  if (sep2 <= CONNECTOR_NS_PREFIX2.length) return true;
-  const server = name.slice(CONNECTOR_NS_PREFIX2.length, sep2);
-  const words = connectorNameWords(name.slice(sep2 + "__".length));
+  const sep3 = name.indexOf("__", CONNECTOR_NS_PREFIX2.length);
+  if (sep3 <= CONNECTOR_NS_PREFIX2.length) return true;
+  const server = name.slice(CONNECTOR_NS_PREFIX2.length, sep3);
+  const words = connectorNameWords(name.slice(sep3 + "__".length));
   const serverWords = connectorNameWords(server);
   let skipped = 0;
   while (skipped < serverWords.length && words[skipped] === serverWords[skipped] && !CONNECTOR_MUTATION_WORDS.has(words[skipped])) skipped++;
@@ -45885,6 +45952,7 @@ function index_default(pi) {
   process.env.CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC = "1";
   const config2 = loadConfig(process.cwd());
   debug("loadConfig:", JSON.stringify(config2));
+  registerExternalConfigResolver();
   registerBridgeCommands(pi);
   if (config2.enabled === false) {
     debug("provider: disabled by configuration");

--- a/pi-extensions/pi-claude-bridge/src/config.ts
+++ b/pi-extensions/pi-claude-bridge/src/config.ts
@@ -7,9 +7,16 @@
 import type { SettingSource } from "@anthropic-ai/claude-agent-sdk";
 import { existsSync, readFileSync } from "fs";
 import { homedir } from "os";
-import { dirname, join, resolve } from "path";
+import { dirname, join, resolve, sep } from "path";
 
 export const PACKAGE_ID = "@vanillagreen/pi-claude-bridge";
+
+/**
+ * Registry the vstack extension manager reads to display the value an
+ * extension actually resolves for a manifest key, for extensions whose config
+ * has channels the manager does not own. Keyed by package id.
+ */
+const EXTERNAL_CONFIG_RESOLVER_SYMBOL = Symbol.for("vstack.pi.extension-config-resolver");
 
 export type BridgeEffortLevel = "low" | "medium" | "high" | "xhigh" | "max";
 
@@ -312,17 +319,121 @@ function managerToConfig(raw: SettingsRecord): Partial<Config> {
 	};
 }
 
-export function loadConfig(cwd: string): Config {
-	const global = tryParseJson(join(piUserDir(), "claude-bridge.json"));
-	const isolated = isolatedFromEnv();
-	const projectSettings = isolated ? undefined : projectSettingsPath(cwd);
-	const trustedProject = projectSettings !== undefined && projectSettingsTrusted(projectSettings);
-	const project = trustedProject ? tryParseJson(join(dirname(projectSettings), "claude-bridge.json")) : {};
-	const manager: Partial<Config> = isolated ? {} : managerToConfig(readManagerConfig(cwd));
-	const provider = normalizeProviderConfig({ ...global.provider, ...project.provider, ...manager.provider });
+/**
+ * A `claude-bridge.json` file. Legacy files nest provider options under
+ * `provider` and prompt-context flags under `promptContext`; the manifest's flat
+ * key shape is accepted too, so a file written either way resolves the same.
+ * Nested wins when a file carries both shapes for one key.
+ */
+function legacyFileConfig(path: string): Partial<Config> {
+	const raw = asRecord(tryParseJson(path)) ?? {};
+	const flat = managerToConfig(raw);
+	const provider = { ...flat.provider, ...asRecord(raw.provider) } as Config["provider"];
+	const promptContext = { ...flat.promptContext, ...asRecord(raw.promptContext) } as Config["promptContext"];
 	return {
-		enabled: manager.enabled ?? project.enabled ?? global.enabled ?? true,
-		provider,
-		promptContext: { ...global.promptContext, ...project.promptContext, ...manager.promptContext },
+		...(flat.enabled !== undefined ? { enabled: flat.enabled } : {}),
+		...(Object.keys(provider ?? {}).length ? { provider } : {}),
+		...(Object.keys(promptContext ?? {}).length ? { promptContext } : {}),
 	};
+}
+
+interface LegacyLayer {
+	path: string;
+	config: Partial<Config>;
+}
+
+/** Legacy config layers, lowest precedence first. */
+function legacyLayers(cwd: string): LegacyLayer[] {
+	const globalPath = join(piUserDir(), "claude-bridge.json");
+	const layers: LegacyLayer[] = [{ path: globalPath, config: legacyFileConfig(globalPath) }];
+	if (isolatedFromEnv()) return layers;
+	const projectSettings = projectSettingsPath(cwd);
+	if (!projectSettingsTrusted(projectSettings)) return layers;
+	const projectPath = join(dirname(projectSettings), "claude-bridge.json");
+	return [...layers, { path: projectPath, config: legacyFileConfig(projectPath) }];
+}
+
+function mergeLayers(layers: LegacyLayer[]): Partial<Config> {
+	const merged: Partial<Config> = { provider: {}, promptContext: {} };
+	for (const layer of layers) {
+		if (layer.config.enabled !== undefined) merged.enabled = layer.config.enabled;
+		merged.provider = { ...merged.provider, ...layer.config.provider };
+		merged.promptContext = { ...merged.promptContext, ...layer.config.promptContext };
+	}
+	return merged;
+}
+
+export function loadConfig(cwd: string): Config {
+	const legacy = mergeLayers(legacyLayers(cwd));
+	const manager: Partial<Config> = isolatedFromEnv() ? {} : managerToConfig(readManagerConfig(cwd));
+	const provider = normalizeProviderConfig({ ...legacy.provider, ...manager.provider });
+	return {
+		enabled: manager.enabled ?? legacy.enabled ?? true,
+		provider,
+		promptContext: { ...legacy.promptContext, ...manager.promptContext },
+	};
+}
+
+const PROVIDER_KEYS = new Set([
+	"allowExtraUsage",
+	"appendSystemPrompt",
+	"connectorWriteMode",
+	"enableConnectors",
+	"fastMode",
+	"forceEffort",
+	"modelEffortOverrides",
+	"pathToClaudeCodeExecutable",
+	"strictMcpConfig",
+]);
+
+const PROMPT_CONTEXT_KEYS = new Set([
+	"includeAppendSystemPromptMd",
+	"includeCavemanHook",
+	"includeProjectAgentsHook",
+	"includeTaskPanelHook",
+]);
+
+function configValueForKey(config: Partial<Config>, key: string): unknown {
+	if (key === "enabled") return config.enabled;
+	if (PROVIDER_KEYS.has(key)) return normalizeProviderConfig(config.provider)?.[key as keyof NonNullable<Config["provider"]>];
+	if (PROMPT_CONTEXT_KEYS.has(key)) return config.promptContext?.[key as keyof NonNullable<Config["promptContext"]>];
+	return undefined;
+}
+
+/** Home-relative when possible, because the point is telling a user what to edit. */
+function displayPath(path: string): string {
+	const home = homedir();
+	return home && path.startsWith(home + sep) ? `~${path.slice(home.length)}` : path;
+}
+
+export interface ExternalConfigResolution {
+	explicit: boolean;
+	value: unknown;
+	source?: string;
+}
+
+/**
+ * The effective value of a manifest key from the config channels the extension
+ * manager does not own — the legacy `claude-bridge.json` files. Manager config
+ * outranks these, so the manager consults this only when neither of its own
+ * scopes holds the key.
+ */
+export function resolveExternalConfigValue(key: string, cwd: string): ExternalConfigResolution {
+	const layers = legacyLayers(cwd);
+	const value = configValueForKey(mergeLayers(layers), key);
+	if (value === undefined) return { explicit: false, value: undefined };
+	const source = [...layers].reverse().find((layer) => configValueForKey(layer.config, key) !== undefined)?.path;
+	return { explicit: true, value, ...(source ? { source: displayPath(source) } : {}) };
+}
+
+/**
+ * Publish the resolver before any early return, so a bridge disabled by a
+ * legacy file still explains itself in the settings editor.
+ */
+export function registerExternalConfigResolver(): void {
+	const host = globalThis as unknown as Record<PropertyKey, unknown>;
+	const existing = asRecord(host[EXTERNAL_CONFIG_RESOLVER_SYMBOL]);
+	const registry = existing ?? {};
+	if (!existing) host[EXTERNAL_CONFIG_RESOLVER_SYMBOL] = registry;
+	registry[PACKAGE_ID] = (key: string, cwd: string) => resolveExternalConfigValue(key, cwd);
 }

--- a/pi-extensions/pi-claude-bridge/src/index.ts
+++ b/pi-extensions/pi-claude-bridge/src/index.ts
@@ -9,7 +9,7 @@ import { MCP_SERVER_NAME, MCP_TOOL_PREFIX, extractSkillsBlock } from "./skills.j
 import { extractAllToolResults as _extractAllToolResults, type McpResult } from "./extract-tool-results.js";
 import { QueryContext, ctx, drainPendingToolCalls, stackDepth, pushContext, toolCallDrainCause } from "./query-state.js";
 import { teardownQuery } from "./query-teardown.js";
-import { loadConfig, normalizeEffortLevel, recordProjectTrust, type Config } from "./config.js";
+import { loadConfig, normalizeEffortLevel, recordProjectTrust, registerExternalConfigResolver, type Config } from "./config.js";
 import { hasClaudeCredentials } from "./auth-presence.js";
 import { NATIVE_PROVIDER_UNSUPPORTED_MESSAGE, buildNativeProvider, supportsNativeProvider } from "./native-provider.js";
 import { extractAgentsAppend } from "./agents-md.js";
@@ -1336,6 +1336,10 @@ export default function (pi: ExtensionAPI) {
 
 	const config = loadConfig(process.cwd());
 	debug("loadConfig:", JSON.stringify(config));
+	// Registered before the disabled early return: a bridge switched off by
+	// claude-bridge.json is exactly when the settings editor has to show where
+	// that value came from.
+	registerExternalConfigResolver();
 	registerBridgeCommands(pi);
 	if (config.enabled === false) {
 		debug("provider: disabled by configuration");

--- a/pi-extensions/pi-claude-bridge/tests/unit-config-resolver.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-config-resolver.mjs
@@ -1,0 +1,158 @@
+/**
+ * Tests for the external-config resolver the vstack extension manager calls to
+ * display the value claude-bridge actually resolves from claude-bridge.json.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { loadConfig, recordProjectTrust, resolveExternalConfigValue } from "../src/config.ts";
+
+function withTempDirs(fn) {
+	const root = mkdtempSync(join(tmpdir(), "claude-bridge-resolver-"));
+	const oldPiDir = process.env.PI_CODING_AGENT_DIR;
+	const oldIsolated = process.env.CLAUDE_BRIDGE_ISOLATED;
+	const oldHome = process.env.HOME;
+	try {
+		const user = join(root, "user");
+		const project = join(root, "project");
+		mkdirSync(user, { recursive: true });
+		mkdirSync(join(project, ".pi"), { recursive: true });
+		process.env.PI_CODING_AGENT_DIR = user;
+		delete process.env.CLAUDE_BRIDGE_ISOLATED;
+		return fn({ root, user, project });
+	} finally {
+		if (oldPiDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = oldPiDir;
+		if (oldIsolated === undefined) delete process.env.CLAUDE_BRIDGE_ISOLATED;
+		else process.env.CLAUDE_BRIDGE_ISOLATED = oldIsolated;
+		if (oldHome === undefined) delete process.env.HOME;
+		else process.env.HOME = oldHome;
+		rmSync(root, { recursive: true, force: true });
+	}
+}
+
+describe("resolveExternalConfigValue", () => {
+	it("reports no value when no legacy config file exists", () => withTempDirs(({ project }) => {
+		assert.deepEqual(resolveExternalConfigValue("enabled", project), { explicit: false, value: undefined });
+		assert.deepEqual(resolveExternalConfigValue("fastMode", project), { explicit: false, value: undefined });
+	}));
+
+	it("reports a global legacy value with the file that supplied it", () => withTempDirs(({ user, project }) => {
+		writeFileSync(join(user, "claude-bridge.json"), JSON.stringify({ enabled: false }));
+
+		const resolved = resolveExternalConfigValue("enabled", project);
+		assert.equal(resolved.explicit, true);
+		assert.equal(resolved.value, false);
+		assert.equal(resolved.source, join(user, "claude-bridge.json"));
+		// The bug this closes: the modal must not render the manifest default.
+		assert.equal(loadConfig(project).enabled, false);
+	}));
+
+	it("shows the global source as a home-relative path", () => withTempDirs(({ root, user, project }) => {
+		process.env.HOME = root;
+		writeFileSync(join(user, "claude-bridge.json"), JSON.stringify({ enabled: false }));
+
+		assert.equal(resolveExternalConfigValue("enabled", project).source, "~/user/claude-bridge.json");
+	}));
+
+	it("lets a trusted project legacy file override the global one", () => withTempDirs(({ user, project }) => {
+		writeFileSync(join(user, "claude-bridge.json"), JSON.stringify({ enabled: false, provider: { fastMode: false } }));
+		writeFileSync(join(project, ".pi", "claude-bridge.json"), JSON.stringify({ enabled: true, provider: { fastMode: true } }));
+		recordProjectTrust({ cwd: project, isProjectTrusted: () => true });
+
+		const enabled = resolveExternalConfigValue("enabled", project);
+		assert.equal(enabled.value, true);
+		assert.equal(enabled.source, join(project, ".pi", "claude-bridge.json"));
+
+		const fastMode = resolveExternalConfigValue("fastMode", project);
+		assert.equal(fastMode.value, true);
+		assert.equal(fastMode.source, join(project, ".pi", "claude-bridge.json"));
+
+		// A key only the global file sets still reports the global file.
+		writeFileSync(join(user, "claude-bridge.json"), JSON.stringify({ provider: { strictMcpConfig: false } }));
+		const strict = resolveExternalConfigValue("strictMcpConfig", project);
+		assert.equal(strict.value, false);
+		assert.equal(strict.source, join(user, "claude-bridge.json"));
+	}));
+
+	it("resolves the nested legacy provider and promptContext shapes", () => withTempDirs(({ user, project }) => {
+		writeFileSync(join(user, "claude-bridge.json"), JSON.stringify({
+			promptContext: { includeAppendSystemPromptMd: true },
+			provider: {
+				enableConnectors: true,
+				forceEffort: "max",
+				modelEffortOverrides: { "claude-opus-4-8": "max" },
+				pathToClaudeCodeExecutable: "/opt/claude/bin/claude",
+			},
+		}));
+
+		assert.equal(resolveExternalConfigValue("enableConnectors", project).value, true);
+		assert.equal(resolveExternalConfigValue("forceEffort", project).value, "max");
+		assert.deepEqual(resolveExternalConfigValue("modelEffortOverrides", project).value, { "claude-opus-4-8": "max" });
+		assert.equal(resolveExternalConfigValue("pathToClaudeCodeExecutable", project).value, "/opt/claude/bin/claude");
+		assert.equal(resolveExternalConfigValue("includeAppendSystemPromptMd", project).value, true);
+	}));
+
+	it("resolves the flat manifest key shape the same way loadConfig does", () => withTempDirs(({ user, project }) => {
+		writeFileSync(join(user, "claude-bridge.json"), JSON.stringify({
+			fastMode: true,
+			includeCavemanHook: true,
+			strictMcpConfig: false,
+		}));
+
+		assert.equal(resolveExternalConfigValue("fastMode", project).value, true);
+		assert.equal(resolveExternalConfigValue("strictMcpConfig", project).value, false);
+		assert.equal(resolveExternalConfigValue("includeCavemanHook", project).value, true);
+
+		const config = loadConfig(project);
+		assert.equal(config.provider?.fastMode, true);
+		assert.equal(config.provider?.strictMcpConfig, false);
+		assert.equal(config.promptContext?.includeCavemanHook, true);
+	}));
+
+	it("drops values the loader would normalize away", () => withTempDirs(({ user, project }) => {
+		writeFileSync(join(user, "claude-bridge.json"), JSON.stringify({
+			provider: { connectorWriteMode: "read-only", forceEffort: "ultracode" },
+		}));
+
+		assert.equal(resolveExternalConfigValue("forceEffort", project).explicit, false);
+		assert.equal(resolveExternalConfigValue("connectorWriteMode", project).explicit, false);
+		assert.equal(loadConfig(project).provider?.forceEffort, undefined);
+	}));
+
+	it("ignores the project legacy file in isolated mode", () => withTempDirs(({ user, project }) => {
+		writeFileSync(join(user, "claude-bridge.json"), JSON.stringify({ enabled: false }));
+		writeFileSync(join(project, ".pi", "claude-bridge.json"), JSON.stringify({ enabled: true }));
+		recordProjectTrust({ cwd: project, isProjectTrusted: () => true });
+		process.env.CLAUDE_BRIDGE_ISOLATED = "1";
+
+		const resolved = resolveExternalConfigValue("enabled", project);
+		assert.equal(resolved.value, false);
+		assert.equal(resolved.source, join(user, "claude-bridge.json"));
+		assert.equal(loadConfig(project).enabled, false);
+	}));
+
+	it("ignores an untrusted project legacy file", () => withTempDirs(({ user, project }) => {
+		writeFileSync(join(user, "claude-bridge.json"), JSON.stringify({ enabled: false }));
+		writeFileSync(join(project, ".pi", "claude-bridge.json"), JSON.stringify({ enabled: true }));
+
+		assert.equal(resolveExternalConfigValue("enabled", project).value, false);
+	}));
+
+	it("reports only non-manager channels, since manager config outranks them", () => withTempDirs(({ user, project }) => {
+		writeFileSync(join(user, "settings.json"), JSON.stringify({
+			vstack: { extensionManager: { config: { "@vanillagreen/pi-claude-bridge": { enabled: true, fastMode: true } } } },
+		}));
+
+		assert.equal(resolveExternalConfigValue("enabled", project).explicit, false);
+		assert.equal(resolveExternalConfigValue("fastMode", project).explicit, false);
+	}));
+
+	it("reports no value for keys it does not own", () => withTempDirs(({ user, project }) => {
+		writeFileSync(join(user, "claude-bridge.json"), JSON.stringify({ enabled: false }));
+
+		assert.deepEqual(resolveExternalConfigValue("glyphStyle", project), { explicit: false, value: undefined });
+	}));
+});

--- a/pi-extensions/pi-extension-manager/DEVELOPMENT.md
+++ b/pi-extensions/pi-extension-manager/DEVELOPMENT.md
@@ -1,0 +1,29 @@
+# pi-extension-manager — development notes
+
+Implementation details for contributors. End-user commands, settings, and behavior live in [`README.md`](./README.md).
+
+## External config resolvers
+
+The settings editor owns exactly one config channel: `vstack.extensionManager.config[<packageName>]` in project and user `settings.json`. An extension that also reads its own file (a legacy config path, a host-owned file) resolves values the manager cannot see, so the manifest default it renders can be the opposite of the effective value.
+
+Such an extension publishes a resolver on `globalThis` under `Symbol.for("vstack.pi.extension-config-resolver")`, in a record keyed by package name — the same id `getConfigValue`/`setConfigValue` key manager config by:
+
+```ts
+type ExternalConfigResolver = (key: string, cwd: string) => { explicit: boolean; value: unknown; source?: string } | undefined;
+
+const registry = (globalThis as any)[Symbol.for("vstack.pi.extension-config-resolver")] ??= {};
+registry["@scope/my-extension"] = (key, cwd) => ({ explicit: true, value: resolved, source: "~/.pi/agent/my-extension.json" });
+```
+
+Contract:
+
+- `key` is a manifest settings key from `vstack.extensionManager.settings`. Return `undefined` (or `explicit: false`) for keys the extension does not own or has no value for.
+- Report **only** the channels the manager does not own. Manager config outranks them, and `getConfigValue` consults the resolver only after both manager scopes miss, so folding manager config back in would just be redundant work.
+- `value` must be what the extension's own loader produces for that key — same normalization, same precedence between its files. A resolver that reports a raw value its loader would reject re-creates the divergence this mechanism exists to close.
+- `source` is the concrete file behind the value, home-relative for display. The UI names it, so the user knows what to edit.
+- Register before any early return in the extension's entry point. A value that disables the extension is exactly the case where the modal has to explain itself.
+- No unregister: the registry lives for the process.
+
+`getConfigValue` returns `{ explicit: true, scope: "external", value, source }` for a resolved external value. A resolver that throws is treated as "nothing set" and the row falls back to the schema default — a broken resolver must never take the modal down. Results are memoized per `Inventory`, so a resolver is called once per key per popup open rather than once per rendered row.
+
+The editor treats an external value as read-only for its own reset paths: `delete` names the source file instead of running a reset that `resetConfigKeys` (which only deletes from `settings.json`) cannot perform, and the extension-wide reset counts only `project`/`user` rows. Writing the row is still allowed — that is the documented way to override the file, because manager config wins.

--- a/pi-extensions/pi-extension-manager/README.md
+++ b/pi-extensions/pi-extension-manager/README.md
@@ -46,6 +46,8 @@ Open `/extensions:settings`; settings appear under the **Extension Manager** tab
 
 Project settings in `.pi/settings.json` apply only after Pi marks the workspace trusted; before trust, vstack Pi extensions read user/global settings only.
 
+Some packages also keep a config file of their own. A row whose value comes from one of those files shows the value the package actually resolves, and names the file under the setting. Editing the row writes Pi settings, which override that file; `delete` reports the file instead of resetting, because the value is not stored in Pi settings.
+
 | Setting | What it does |
 | --- | --- |
 | Enable manager UI | Expose `/extensions` and the manager UI. `/extensions:enable` is always available as recovery. |

--- a/pi-extensions/pi-extension-manager/extensions/manager/inventory.ts
+++ b/pi-extensions/pi-extension-manager/extensions/manager/inventory.ts
@@ -367,7 +367,7 @@ export function buildInventory(_pi: ExtensionAPI, ctx: ExtensionContext): Invent
 
 	applyDisableState(items, managerState);
 	items.sort(compareInventoryItems);
-	return { auditLines, items, managerState, packages: items.filter((item) => item.kind === "package"), settingsFiles };
+	return { auditLines, cwd: ctx.cwd ?? process.cwd(), items, managerState, packages: items.filter((item) => item.kind === "package"), settingsFiles };
 }
 
 export function npmCandidatesFromInventory(inventory: Inventory): { name: string; npmName: string }[] {

--- a/pi-extensions/pi-extension-manager/extensions/manager/quick-settings-ui.ts
+++ b/pi-extensions/pi-extension-manager/extensions/manager/quick-settings-ui.ts
@@ -36,6 +36,7 @@ import {
 	setConfigValue,
 } from "./settings.js";
 import {
+	type ConfigValue,
 	type Inventory,
 	type InventoryItem,
 	type ManagerTab,
@@ -50,6 +51,16 @@ import {
 	SETTINGS_EVENT,
 	TAB_ALL,
 } from "./types.js";
+
+const EXTERNAL_SOURCE_FALLBACK = "the extension's own config file";
+
+function externalSource(config: ConfigValue): string {
+	return config.source ?? EXTERNAL_SOURCE_FALLBACK;
+}
+
+function externalSourceNote(config: ConfigValue): string {
+	return `Value comes from ${externalSource(config)}. Editing it here writes Pi settings, which override that file.`;
+}
 
 function settingPackages(inventory: Inventory): InventoryItem[] {
 	return inventory.packages.filter((item) => item.packageName && item.settingsSchema?.length && item.state !== "shadowed");
@@ -119,26 +130,49 @@ function saveQuickSetting(pi: ExtensionAPI, ctx: ExtensionCommandContext | Exten
 	if (apply !== "live") ctx.ui.notify(applyMessage(row.schema), apply === "restart" ? "warning" : "info");
 }
 
+// resetConfigKeys only deletes from settings.json, so a value owned by another
+// config file survives the reset. Report that instead of a reset that did not
+// happen.
+function isManagerOwned(config: ConfigValue): boolean {
+	return config.scope === "project" || config.scope === "user";
+}
+
 function resetQuickSetting(pi: ExtensionAPI, ctx: ExtensionCommandContext | ExtensionContext, inventory: Inventory, row: QuickSettingRow): void {
-	if (!getConfigValue(inventory, row.extensionId, row.schema).explicit) {
-		ctx.ui.notify(`${row.schema.label ?? row.schema.key} is already using its default.`, "info");
+	const config = getConfigValue(inventory, row.extensionId, row.schema);
+	const label = row.schema.label ?? row.schema.key;
+	if (!config.explicit) {
+		ctx.ui.notify(`${label} is already using its default.`, "info");
+		return;
+	}
+	if (!isManagerOwned(config)) {
+		ctx.ui.notify(`${label} is set by ${externalSource(config)} and cannot be reset from here. Edit that file, or press enter to override it in Pi settings.`, "warning");
 		return;
 	}
 	resetConfigKeys(inventory, row.extensionId, [row.schema.key]);
 	pi.events.emit(SETTINGS_EVENT, { extensionId: row.extensionId, key: row.schema.key, value: row.schema.default });
-	notifyReset(ctx, row.schema.label ?? row.schema.key, [row.schema]);
+	notifyReset(ctx, label, [row.schema]);
 }
 
 function resetQuickSettingsForExtension(pi: ExtensionAPI, ctx: ExtensionCommandContext | ExtensionContext, inventory: Inventory, rows: QuickSettingRow[], extensionId: string, label: string): void {
-	const scoped = rows.filter((row) => row.extensionId === extensionId);
-	const explicit = scoped.filter((row) => getConfigValue(inventory, row.extensionId, row.schema).explicit);
-	if (explicit.length === 0) {
+	const scoped = rows.filter((row) => row.extensionId === extensionId).map((row) => ({ config: getConfigValue(inventory, row.extensionId, row.schema), row }));
+	const managed = scoped.filter((entry) => isManagerOwned(entry.config));
+	const external = scoped.filter((entry) => entry.config.explicit && !isManagerOwned(entry.config));
+	if (managed.length === 0) {
+		if (external.length > 0) {
+			const sources = [...new Set(external.map((entry) => externalSource(entry.config)))].join(", ");
+			ctx.ui.notify(`${label} has no settings stored in Pi settings; ${external.length === 1 ? "1 value comes" : `${external.length} values come`} from ${sources}.`, "warning");
+			return;
+		}
 		ctx.ui.notify(`${label} settings are already using defaults.`, "info");
 		return;
 	}
-	resetConfigKeys(inventory, extensionId, explicit.map((row) => row.schema.key));
-	for (const row of explicit) pi.events.emit(SETTINGS_EVENT, { extensionId, key: row.schema.key, value: row.schema.default });
-	notifyReset(ctx, `${label} settings`, explicit.map((row) => row.schema));
+	resetConfigKeys(inventory, extensionId, managed.map((entry) => entry.row.schema.key));
+	for (const entry of managed) pi.events.emit(SETTINGS_EVENT, { extensionId, key: entry.row.schema.key, value: entry.row.schema.default });
+	notifyReset(ctx, `${label} settings`, managed.map((entry) => entry.row.schema));
+	if (external.length > 0) {
+		const sources = [...new Set(external.map((entry) => externalSource(entry.config)))].join(", ");
+		ctx.ui.notify(`${external.length} ${label} value${external.length === 1 ? " is" : "s are"} still set by ${sources}.`, "warning");
+	}
 }
 
 function createQuickSettingsComponent(pi: ExtensionAPI, ctx: ExtensionCommandContext | ExtensionContext, inventory: Inventory, ui: QuickSettingsUiState, theme: Theme, requestRender: () => void, getLayout: () => PopupLayout, done: (action: QuickSettingsAction) => void) {
@@ -330,6 +364,7 @@ function createQuickSettingsComponent(pi: ExtensionAPI, ctx: ExtensionCommandCon
 			const rowText = truncateToWidth(`${itemPad}${label}${" ".repeat(Math.max(1, 36 - visibleWidth(labelText)))}${valueText}`, bodyWidth, "…");
 			lines.push(selected ? managerSelectedLine(theme, rowText, bodyWidth) : rowText);
 			if (selected && !isEditing && row.schema.description) lines.push(...wrapDescription(row.schema.description, bodyWidth, theme, "    "));
+			if (selected && !isEditing && config.scope === "external") lines.push(...wrapDescription(externalSourceNote(config), bodyWidth, theme, "    ", "dim"));
 		}
 		const moreBefore = ui.scroll > 0 ? `↑ ${ui.scroll}` : "";
 		const moreAfter = ui.scroll + layout.listRows < filtered().length ? `↓ ${filtered().length - ui.scroll - layout.listRows}` : "";

--- a/pi-extensions/pi-extension-manager/extensions/manager/render.ts
+++ b/pi-extensions/pi-extension-manager/extensions/manager/render.ts
@@ -27,10 +27,10 @@ export function wrapLine(line: string, width: number): string[] {
 	return wrapped.map((part) => truncateToWidth(part, safeWidth, ""));
 }
 
-export function wrapDescription(text: string, width: number, theme: Theme, indent = ""): string[] {
+export function wrapDescription(text: string, width: number, theme: Theme, indent = "", tone: "muted" | "dim" = "muted"): string[] {
 	const indentWidth = visibleWidth(indent);
 	const contentWidth = Math.max(1, width - indentWidth);
-	return wrapLine(text, contentWidth).map((line) => `${indent}${theme.fg("muted", line)}`);
+	return wrapLine(text, contentWidth).map((line) => `${indent}${theme.fg(tone, line)}`);
 }
 
 export function countBy<T>(items: T[], key: (item: T) => string): Record<string, number> {

--- a/pi-extensions/pi-extension-manager/extensions/manager/settings.ts
+++ b/pi-extensions/pi-extension-manager/extensions/manager/settings.ts
@@ -4,6 +4,7 @@ import { dirname, join } from "node:path";
 import { stringifyError } from "./format.js";
 import { findProjectPiDir, userPiDir } from "./paths.js";
 import {
+	EXTERNAL_CONFIG_RESOLVER_SYMBOL,
 	LIST_ROWS,
 	MANAGER_ID,
 	MANAGER_INNER_ROWS,
@@ -13,6 +14,9 @@ import {
 	QUICK_SETTINGS_ROWS,
 	VSTACK_MODAL_LOCK_SYMBOL,
 	type ConfigValue,
+	type ExternalConfigResolution,
+	type ExternalConfigResolver,
+	type ExternalConfigResolverRegistry,
 	type Inventory,
 	type InventoryItem,
 	type ManagerState,
@@ -136,6 +140,50 @@ export function defaultWriteScope(item: InventoryItem | undefined, files: Settin
 	return projectSettingsWritable(files) ? "project" : "user";
 }
 
+export function externalConfigResolvers(): ExternalConfigResolverRegistry {
+	const host = globalThis as unknown as Record<PropertyKey, unknown>;
+	const existing = asRecord(host[EXTERNAL_CONFIG_RESOLVER_SYMBOL]);
+	if (existing) return existing as ExternalConfigResolverRegistry;
+	const created: ExternalConfigResolverRegistry = {};
+	host[EXTERNAL_CONFIG_RESOLVER_SYMBOL] = created;
+	return created;
+}
+
+/**
+ * Ask the owning extension for the value it resolves from its own config files.
+ * A missing, malformed, or throwing resolver is indistinguishable from "nothing
+ * external is set" — the modal must never fail to render because of one.
+ */
+function externalConfigValue(extensionId: string, key: string, cwd: string): ExternalConfigResolution | undefined {
+	const resolver = externalConfigResolvers()[extensionId] as ExternalConfigResolver | undefined;
+	if (typeof resolver !== "function") return undefined;
+	try {
+		const resolved = resolver(key, cwd);
+		return resolved && typeof resolved === "object" && resolved.explicit === true ? resolved : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+// External lookups touch the filesystem, and the settings popup re-reads every
+// visible row on each keystroke. One resolver call per (extension, key) per
+// inventory keeps that cost off the render path; the inventory is rebuilt each
+// time the popup opens, so edits to the external file still show up.
+const externalConfigCache = new WeakMap<Inventory, Map<string, ExternalConfigResolution | undefined>>();
+
+function cachedExternalConfigValue(inventory: Inventory, extensionId: string, key: string): ExternalConfigResolution | undefined {
+	let cache = externalConfigCache.get(inventory);
+	if (!cache) {
+		cache = new Map();
+		externalConfigCache.set(inventory, cache);
+	}
+	const cacheKey = `${extensionId}::${key}`;
+	if (cache.has(cacheKey)) return cache.get(cacheKey);
+	const resolved = externalConfigValue(extensionId, key, inventory.cwd);
+	cache.set(cacheKey, resolved);
+	return resolved;
+}
+
 export function getConfigValue(inventory: Inventory, extensionId: string, schema: SettingsSchema): ConfigValue {
 	const project = managerStateFrom(inventory.settingsFiles.find((file) => file.scope === "project")?.json ?? {});
 	const user = managerStateFrom(inventory.settingsFiles.find((file) => file.scope === "user")?.json ?? {});
@@ -145,6 +193,10 @@ export function getConfigValue(inventory: Inventory, extensionId: string, schema
 	if (Object.prototype.hasOwnProperty.call(user.config[extensionId] ?? {}, schema.key)) {
 		return { explicit: true, scope: "user", value: user.config[extensionId]![schema.key] };
 	}
+	// Manager config outranks the extension's own files, matching how extensions
+	// layer the two, so this runs only when neither manager scope holds the key.
+	const external = cachedExternalConfigValue(inventory, extensionId, schema.key);
+	if (external) return { explicit: true, scope: "external", value: external.value, source: external.source };
 	return { explicit: false, scope: "default", value: schema.default };
 }
 

--- a/pi-extensions/pi-extension-manager/extensions/manager/types.ts
+++ b/pi-extensions/pi-extension-manager/extensions/manager/types.ts
@@ -15,6 +15,7 @@ export const MANAGER_INNER_ROWS = 32;
 export const QUICK_SETTINGS_INNER_ROWS = 30;
 export const QUICK_SETTINGS_ROWS = 18;
 export const VSTACK_MODAL_LOCK_SYMBOL = Symbol.for("vstack.pi.modal-lock");
+export const EXTERNAL_CONFIG_RESOLVER_SYMBOL = Symbol.for("vstack.pi.extension-config-resolver");
 export const VSTACK_OPEN_QUICK_SETTINGS_SYMBOL = Symbol.for("vstack.pi.extension-manager.open-quick-settings");
 export const NPM_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 export const TAB_ALL = "all";
@@ -75,9 +76,27 @@ export interface ManagerState {
 
 export interface ConfigValue {
 	value: unknown;
-	scope: Scope | "default";
+	/** `external` — the effective value comes from a config file the manager does not own. */
+	scope: Scope | "default" | "external";
 	explicit: boolean;
+	/** Display path of the file behind an `external` value. */
+	source?: string;
 }
+
+export interface ExternalConfigResolution {
+	explicit: boolean;
+	value: unknown;
+	source?: string;
+}
+
+/**
+ * An extension that reads settings from channels beyond manager config publishes
+ * one of these under EXTERNAL_CONFIG_RESOLVER_SYMBOL, keyed by package name, so
+ * the settings editor can show the value the extension actually resolves.
+ */
+export type ExternalConfigResolver = (key: string, cwd: string) => ExternalConfigResolution | undefined;
+
+export type ExternalConfigResolverRegistry = Record<string, ExternalConfigResolver>;
 
 export interface PopupLayout {
 	bodyRows: number;
@@ -142,6 +161,7 @@ export interface Inventory {
 	settingsFiles: SettingsFile[];
 	managerState: ManagerState;
 	auditLines: string[];
+	cwd: string;
 }
 
 export interface ManagerTab {

--- a/pi-extensions/pi-extension-manager/test/settings.test.ts
+++ b/pi-extensions/pi-extension-manager/test/settings.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+import { buildInventory } from "../extensions/manager/inventory.ts";
+import { getConfigValue } from "../extensions/manager/settings.ts";
+import { EXTERNAL_CONFIG_RESOLVER_SYMBOL, type ExternalConfigResolver, type SettingsSchema } from "../extensions/manager/types.ts";
+
+const rootTmp = join(process.cwd(), "tmp", "pi-extension-manager-settings-tests");
+const PACKAGE_ID = "@scope/external-settings";
+const SCHEMA: SettingsSchema = { default: true, key: "enabled", label: "Enabled", type: "boolean" };
+
+const originalEnv = {
+	HOME: process.env.HOME,
+	NPM_CONFIG_PREFIX: process.env.NPM_CONFIG_PREFIX,
+	npm_config_prefix: process.env.npm_config_prefix,
+	PI_CODING_AGENT_DIR: process.env.PI_CODING_AGENT_DIR,
+};
+
+function writeJson(path: string, value: unknown): void {
+	mkdirSync(dirname(path), { recursive: true });
+	writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function writePackage(dir: string, name: string): void {
+	mkdirSync(join(dir, "extensions"), { recursive: true });
+	writeFileSync(join(dir, "extensions", "index.ts"), "export default function () {}\n", "utf8");
+	writeJson(join(dir, "package.json"), {
+		name,
+		version: "1.0.0",
+		pi: { extensions: ["./extensions/index.ts"] },
+		vstack: { extensionManager: { displayName: "External Settings", settings: [SCHEMA] } },
+	});
+}
+
+function registerResolver(resolver: ExternalConfigResolver, extensionId = PACKAGE_ID): void {
+	const host = globalThis as unknown as Record<PropertyKey, Record<string, ExternalConfigResolver>>;
+	host[EXTERNAL_CONFIG_RESOLVER_SYMBOL] = { ...(host[EXTERNAL_CONFIG_RESOLVER_SYMBOL] ?? {}), [extensionId]: resolver };
+}
+
+function setupProject(managerConfig?: { scope: "project" | "user"; value: unknown }): string {
+	const project = join(rootTmp, "project");
+	const projectPi = join(project, ".pi");
+	const userPi = process.env.PI_CODING_AGENT_DIR!;
+	writePackage(join(userPi, "npm", "node_modules", ...PACKAGE_ID.split("/")), PACKAGE_ID);
+	const config = managerConfig ? { vstack: { extensionManager: { config: { [PACKAGE_ID]: { enabled: managerConfig.value } } } } } : {};
+	writeJson(join(userPi, "settings.json"), { packages: [`npm:${PACKAGE_ID}`], ...(managerConfig?.scope === "user" ? config : {}) });
+	writeJson(join(projectPi, "settings.json"), managerConfig?.scope === "project" ? config : {});
+	return project;
+}
+
+function inventory(cwd: string) {
+	return buildInventory({} as never, { cwd, isProjectTrusted: () => true } as never);
+}
+
+beforeEach(() => {
+	rmSync(rootTmp, { force: true, recursive: true });
+	mkdirSync(rootTmp, { recursive: true });
+	process.env.HOME = join(rootTmp, "home");
+	process.env.NPM_CONFIG_PREFIX = join(rootTmp, "npm-prefix");
+	process.env.npm_config_prefix = process.env.NPM_CONFIG_PREFIX;
+	process.env.PI_CODING_AGENT_DIR = join(rootTmp, "home", ".pi", "agent");
+	delete (globalThis as unknown as Record<PropertyKey, unknown>)[EXTERNAL_CONFIG_RESOLVER_SYMBOL];
+});
+
+afterEach(() => {
+	delete (globalThis as unknown as Record<PropertyKey, unknown>)[EXTERNAL_CONFIG_RESOLVER_SYMBOL];
+	if (originalEnv.HOME === undefined) delete process.env.HOME;
+	else process.env.HOME = originalEnv.HOME;
+	if (originalEnv.NPM_CONFIG_PREFIX === undefined) delete process.env.NPM_CONFIG_PREFIX;
+	else process.env.NPM_CONFIG_PREFIX = originalEnv.NPM_CONFIG_PREFIX;
+	if (originalEnv.npm_config_prefix === undefined) delete process.env.npm_config_prefix;
+	else process.env.npm_config_prefix = originalEnv.npm_config_prefix;
+	if (originalEnv.PI_CODING_AGENT_DIR === undefined) delete process.env.PI_CODING_AGENT_DIR;
+	else process.env.PI_CODING_AGENT_DIR = originalEnv.PI_CODING_AGENT_DIR;
+	rmSync(rootTmp, { force: true, recursive: true });
+});
+
+test("a registered resolver supplies the value when no manager scope holds the key", () => {
+	const project = setupProject();
+	const seen: Array<[string, string]> = [];
+	registerResolver((key, cwd) => {
+		seen.push([key, cwd]);
+		return { explicit: true, source: "~/.pi/agent/external.json", value: false };
+	});
+
+	const config = getConfigValue(inventory(project), PACKAGE_ID, SCHEMA);
+	expect(config).toEqual({ explicit: true, scope: "external", source: "~/.pi/agent/external.json", value: false });
+	expect(seen).toEqual([["enabled", project]]);
+});
+
+test("manager project scope outranks a registered resolver", () => {
+	const project = setupProject({ scope: "project", value: true });
+	registerResolver(() => ({ explicit: true, source: "~/.pi/agent/external.json", value: false }));
+
+	const config = getConfigValue(inventory(project), PACKAGE_ID, SCHEMA);
+	expect(config).toEqual({ explicit: true, scope: "project", value: true });
+});
+
+test("manager user scope outranks a registered resolver", () => {
+	const project = setupProject({ scope: "user", value: true });
+	registerResolver(() => ({ explicit: true, source: "~/.pi/agent/external.json", value: false }));
+
+	const config = getConfigValue(inventory(project), PACKAGE_ID, SCHEMA);
+	expect(config).toEqual({ explicit: true, scope: "user", value: true });
+});
+
+test("a resolver that reports nothing falls back to the schema default", () => {
+	const project = setupProject();
+	registerResolver(() => undefined);
+	expect(getConfigValue(inventory(project), PACKAGE_ID, SCHEMA)).toEqual({ explicit: false, scope: "default", value: true });
+
+	registerResolver(() => ({ explicit: false, value: false }));
+	expect(getConfigValue(inventory(project), PACKAGE_ID, SCHEMA)).toEqual({ explicit: false, scope: "default", value: true });
+});
+
+test("a throwing resolver falls back to the schema default instead of breaking the modal", () => {
+	const project = setupProject();
+	registerResolver(() => {
+		throw new Error("resolver exploded");
+	});
+
+	expect(getConfigValue(inventory(project), PACKAGE_ID, SCHEMA)).toEqual({ explicit: false, scope: "default", value: true });
+});
+
+test("a resolver registered for another extension is not consulted", () => {
+	const project = setupProject();
+	let calls = 0;
+	registerResolver(() => {
+		calls += 1;
+		return { explicit: true, value: false };
+	}, "@scope/other");
+
+	expect(getConfigValue(inventory(project), PACKAGE_ID, SCHEMA)).toEqual({ explicit: false, scope: "default", value: true });
+	expect(calls).toBe(0);
+});
+
+test("resolver results are reused across reads of one inventory", () => {
+	const project = setupProject();
+	let calls = 0;
+	registerResolver(() => {
+		calls += 1;
+		return { explicit: true, source: "~/.pi/agent/external.json", value: false };
+	});
+
+	const inv = inventory(project);
+	for (let i = 0; i < 5; i += 1) expect(getConfigValue(inv, PACKAGE_ID, SCHEMA).value).toBe(false);
+	expect(calls).toBe(1);
+
+	expect(getConfigValue(inventory(project), PACKAGE_ID, SCHEMA).value).toBe(false);
+	expect(calls).toBe(2);
+});


### PR DESCRIPTION
Closes #961.

## Problem

The extension-manager settings editor owns exactly one config channel:
`vstack.extensionManager.config[<packageName>]` in project/user `settings.json`. When an extension
also reads a file of its own, the manager renders the manifest default for keys it cannot see — which
can be the opposite of the effective value.

The damaging instance: `{"enabled": false}` in `~/.pi/agent/claude-bridge.json` disables the Claude
bridge provider while the modal row reads **on**, with no way to tell from the UI that the bridge is
off. The same divergence applied to every bridge key readable from both channels.

Removing the legacy file was not an option — under `CLAUDE_BRIDGE_ISOLATED=1` it is the authoritative
config channel for embedding hosts.

## Change

A general contract rather than a bridge special case. An extension publishes a resolver on
`globalThis` under `Symbol.for("vstack.pi.extension-config-resolver")`, keyed by package name:

```ts
type ExternalConfigResolver = (key: string, cwd: string) => { explicit: boolean; value: unknown; source?: string } | undefined;
```

**Manager** — `getConfigValue` consults the resolver after both manager scopes miss, and returns
`{ explicit: true, scope: "external", value, source }`. Manager config still wins, matching how
extensions layer the two. The selected row names the owning file in a dim note under the description.
Results are memoized per `Inventory`, so a filesystem-reading resolver is called once per key per
popup open rather than once per rendered row per keystroke. A throwing resolver is treated as
"nothing set" and can never take the modal down.

Because `resetConfigKeys` only deletes from `settings.json`, an external value cannot be reset by the
manager — the previous code would have reported a reset that did not happen. `delete` now names the
source file, and the extension-wide reset counts only `project`/`user` rows.

**Bridge** — `resolveExternalConfigValue` reports what the legacy files resolve for one manifest key,
sharing `legacyLayers`/`mergeLayers`/normalization with `loadConfig` so the displayed and loaded
values cannot drift. Isolated mode and the project-trust check are honored. It is registered before
the `config.enabled === false` early return, since a bridge disabled by `claude-bridge.json` is
exactly the case the editor has to explain.

`legacyFileConfig` now also accepts the flat manifest key shape alongside the nested
`provider`/`promptContext` one (nested wins within a file). Flat keys in a legacy file were previously
parsed and silently ignored; leaving that in place would have created a fresh UI/effective divergence
as soon as the resolver reported them.

## Validation

- `pi-claude-bridge`: `npm run test:unit` → 374 pass / 0 fail (11 new in `tests/unit-config-resolver.mjs`); `npm run typecheck` clean.
- `pi-extension-manager`: `bun test` → 23 pass / 0 fail (7 new in `test/settings.test.ts`); `tsc --noEmit` over `extensions/**/*.ts` clean.
- `node --test pi-extensions/package-policy.test.mjs` → 3 pass / 0 fail.
- Real-path checks against the built `bundle/index.js`: activating the bundle with `enabled: false` in `claude-bridge.json` registers the resolver and resolves `{ explicit: true, value: false, source: "~/.pi/agent/claude-bridge.json" }`; the real `buildInventory`/`getConfigValue` path renders the row as `false` / `external`, and adding the key to `settings.json` flips it back to `user`.
- `bundle/index.js` rebuilt from source; an independent `npm run build` reproduces the committed bytes.

Not verified: nothing inside a live Pi session — the popup was exercised through its own
render/input functions with a stub theme, not a real terminal.

No version bumps; no publishing.
