### PR TITLE
fix(pi-claude-bridge): reuse sessions for follow-up batches

### DIFF
--- a/pi-extensions/pi-claude-bridge/bundle/index.js
+++ b/pi-extensions/pi-claude-bridge/bundle/index.js
@@ -43729,7 +43729,7 @@ function spawnClaudeCodeWithDiagnostics(options) {
   };
 }
 
-// node_modules/cc-session-io/dist/chunk-D6EZBJOC.js
+// node_modules/cc-session-io/dist/chunk-7RWUSC7F.js
 import { randomUUID } from "crypto";
 import { mkdirSync as mkdirSync4, writeFileSync as writeFileSync2, appendFileSync as appendFileSync3, existsSync as existsSync6, rmSync as rmSync2 } from "fs";
 import { dirname as dirname6 } from "path";
@@ -43987,13 +43987,16 @@ var Session = class {
     this._lastUuid = uuid3;
     return record2;
   }
-  /** Add a user text message. Returns its uuid. */
-  addUserMessage(text) {
+  /** Add a user message, as plain text or content blocks. Returns its uuid. */
+  addUserMessage(content) {
+    if (Array.isArray(content) && content.length === 0) {
+      throw new Error("addUserMessage: content array is empty; Anthropic rejects empty message content");
+    }
     const base = this.baseFields();
     const record2 = {
       type: "user",
       ...base,
-      message: { role: "user", content: text }
+      message: { role: "user", content }
     };
     this._pendingRecords.push(record2);
     return base.uuid;
@@ -44081,16 +44084,17 @@ var Session = class {
           const toolResults = msg.content.filter(
             (b) => b.type === "tool_result"
           );
+          const rest = msg.content.filter(
+            (b) => b.type !== "tool_result"
+          );
           if (toolResults.length > 0) {
             this.addToolResults(toolResults.map((r) => ({
               toolUseId: r.tool_use_id,
               content: r.content,
               isError: r.is_error
             })));
-          } else {
-            const text = msg.content.filter((b) => b.type === "text").map((b) => b.text).join("\n");
-            this.addUserMessage(text || JSON.stringify(msg.content));
           }
+          if (rest.length > 0) this.addUserMessage(rest);
         }
       }
     }
@@ -44389,6 +44393,22 @@ function convertAndImportMessages(session, messages, customToolNameToSdk, cwd) {
   }
   if (repaired.length) session.importMessages(repaired);
 }
+function planIncrementalPromptBatch(messages, cursor) {
+  const lastIndex = messages.length - 1;
+  if (lastIndex < 0 || messages[lastIndex].role !== "user") return void 0;
+  const boundedCursor = Math.max(0, Math.min(cursor, lastIndex));
+  let promptStart = boundedCursor;
+  if (messages[promptStart]?.role === "assistant") promptStart++;
+  const pendingPrompts = messages.slice(promptStart);
+  if (pendingPrompts.length === 0 || pendingPrompts.some((message) => message.role !== "user")) {
+    return void 0;
+  }
+  return {
+    cursorBeforeQuery: promptStart,
+    promptStart,
+    userMessageCount: pendingPrompts.length
+  };
+}
 function verifyWrittenSession2(jsonlPath, expectedSessionId, expectedRecordCount, cwd) {
   const warnings = verifyWrittenSession(jsonlPath, expectedSessionId, expectedRecordCount);
   for (const msg of warnings) {
@@ -44428,21 +44448,22 @@ function debugSessionPaths(label, cwd, jsonlPath) {
 function syncSharedSession(messages, cwd, customToolNameToSdk, modelId) {
   const priorMessages = messages.slice(0, -1);
   if (sharedSession && !sharedSession.needsRebuild) {
-    const missed = priorMessages.slice(sharedSession.cursor);
-    const trailingAssistantOnly = missed.length === 1 && missed[0].role === "assistant";
-    if (missed.length === 0 || trailingAssistantOnly) {
-      if (trailingAssistantOnly) {
-        setSharedSession({ ...sharedSession, cursor: priorMessages.length, cwd });
-      }
-      debug(`Case 3: ${trailingAssistantOnly ? "advanced cursor past trailing assistant, " : ""}resuming session ${sharedSession.sessionId.slice(0, 8)}, cursor=${sharedSession.cursor}`);
-      debug(`syncResult: path=reuse sessionId=${sharedSession.sessionId} cursor=${sharedSession.cursor}`);
-      return { sessionId: sharedSession.sessionId };
+    const batch = planIncrementalPromptBatch(messages, sharedSession.cursor);
+    if (batch) {
+      setSharedSession({ ...sharedSession, cursor: batch.cursorBeforeQuery, cwd });
+      const batching = batch.userMessageCount > 1 ? `batched ${batch.userMessageCount} consecutive user messages, ` : batch.cursorBeforeQuery > sharedSession.cursor ? "advanced cursor past trailing assistant, " : "";
+      debug(`Case 3: ${batching}resuming session ${sharedSession.sessionId.slice(0, 8)}, cursor=${batch.cursorBeforeQuery}`);
+      debug(`syncResult: path=reuse sessionId=${sharedSession.sessionId} cursor=${batch.cursorBeforeQuery} promptUsers=${batch.userMessageCount}`);
+      return {
+        sessionId: sharedSession.sessionId,
+        promptMessages: messages.slice(batch.promptStart)
+      };
     }
   }
   if (priorMessages.length === 0) {
     debug(`Case 1: clean start, ${messages.length} total messages`);
     debug(`syncResult: path=clean-start`);
-    return { sessionId: null };
+    return { sessionId: null, promptMessages: messages.slice(-1) };
   }
   const previousSessionId = sharedSession?.sessionId;
   const previousCursor = sharedSession?.cursor ?? 0;
@@ -44470,7 +44491,7 @@ function syncSharedSession(messages, cwd, customToolNameToSdk, modelId) {
   }
   debugSessionPaths(`${session.sessionId.slice(0, 8)}`, cwd, session.jsonlPath);
   debug(`syncResult: path=rebuild sessionId=${session.sessionId} priors=${priorMessages.length} ${previousSessionId === void 0 ? "first" : preserveId ? "preserved" : "rotated-post-abort"}`);
-  return { sessionId: session.sessionId };
+  return { sessionId: session.sessionId, promptMessages: messages.slice(-1) };
 }
 
 // src/stream-idle-watchdog.ts
@@ -45154,39 +45175,42 @@ function extractAllToolResults2(context) {
   return results;
 }
 function extractUserPrompt(messages) {
-  const last = messages[messages.length - 1];
-  if (!last || last.role !== "user") return null;
-  if (typeof last.content === "string") return last.content;
-  return messageContentToText(last.content) || "";
+  if (messages.length === 0 || messages.some((message) => message.role !== "user")) return null;
+  return messages.map(
+    (message) => typeof message.content === "string" ? message.content : messageContentToText(message.content) || ""
+  ).join("\n\n");
 }
 function extractUserPromptBlocks(messages) {
-  const last = messages[messages.length - 1];
-  if (!last || last.role !== "user") return null;
-  if (typeof last.content === "string") {
-    debug(`extractUserPromptBlocks: content is string (length=${last.content.length})`);
-    return null;
-  }
-  if (!Array.isArray(last.content)) {
-    debug(`extractUserPromptBlocks: content is ${typeof last.content}`);
-    return null;
-  }
-  debug(`extractUserPromptBlocks: ${last.content.length} blocks, types=${last.content.map((b) => b.type).join(",")}`);
+  if (messages.length === 0 || messages.some((message) => message.role !== "user")) return null;
   let hasImage = false;
   const blocks = [];
-  for (const block of last.content) {
-    if (block.type === "text" && block.text) {
-      blocks.push({ type: "text", text: block.text });
-    } else if (block.type === "image") {
-      debug(`image block: mimeType=${block.mimeType}, data length=${(block.data ?? "").length}, keys=${Object.keys(block).join(",")}`);
-      if (!block.data || !block.mimeType) {
-        debug(`image block missing data or mimeType, skipping`);
-        continue;
+  for (let messageIndex = 0; messageIndex < messages.length; messageIndex++) {
+    const content = messages[messageIndex].content;
+    if (messageIndex > 0) blocks.push({ type: "text", text: "\n\n" });
+    if (typeof content === "string") {
+      if (content) blocks.push({ type: "text", text: content });
+      continue;
+    }
+    if (!Array.isArray(content)) {
+      debug(`extractUserPromptBlocks: content is ${typeof content}`);
+      continue;
+    }
+    debug(`extractUserPromptBlocks: ${content.length} blocks, types=${content.map((b) => b.type).join(",")}`);
+    for (const block of content) {
+      if (block.type === "text" && block.text) {
+        blocks.push({ type: "text", text: block.text });
+      } else if (block.type === "image") {
+        debug(`image block: mimeType=${block.mimeType}, data length=${(block.data ?? "").length}, keys=${Object.keys(block).join(",")}`);
+        if (!block.data || !block.mimeType) {
+          debug(`image block missing data or mimeType, skipping`);
+          continue;
+        }
+        hasImage = true;
+        blocks.push({
+          type: "image",
+          source: { type: "base64", media_type: block.mimeType, data: block.data }
+        });
       }
-      hasImage = true;
-      blocks.push({
-        type: "image",
-        source: { type: "base64", media_type: block.mimeType, data: block.data }
-      });
     }
   }
   return hasImage ? blocks : null;
@@ -45508,7 +45532,7 @@ function streamClaudeAgentSdk(model, context, options) {
       piUI?.notify(`Claude bridge: ${queryCtx.pendingToolCalls.size} tool handler(s) still waiting \u2014 provider may be stuck`, "warning");
     }
     if (lastMsgRole === "user") {
-      const userPrompt = extractUserPrompt(context.messages);
+      const userPrompt = extractUserPrompt(context.messages.slice(-1));
       if (userPrompt) {
         ctx().deferredUserMessages.push(userPrompt);
         debug(`provider: deferred user message for replay after query: ${userPrompt.slice(0, 60)}`);
@@ -45572,8 +45596,9 @@ function streamClaudeAgentSdk(model, context, options) {
   ctx().resetToolTracking();
   ctx().latestCursor = 0;
   const { mcpTools, customToolNameToSdk, customToolNameToPi } = resolveMcpTools(context);
-  const promptBlocks = extractUserPromptBlocks(context.messages);
-  let promptText = extractUserPrompt(context.messages) ?? "";
+  const { sessionId: resumeSessionId, promptMessages } = syncSharedSession(context.messages, cwd, customToolNameToSdk, model.id);
+  const promptBlocks = extractUserPromptBlocks(promptMessages);
+  let promptText = extractUserPrompt(promptMessages) ?? "";
   if (!promptText && !promptBlocks) {
     diagDump("empty_prompt", {
       contextLength: context.messages.length,
@@ -45603,7 +45628,6 @@ function streamClaudeAgentSdk(model, context, options) {
   const strictMcpConfigEnabled = !appendSystemPrompt && providerSettings.strictMcpConfig !== false;
   const claudeExecutable = resolveClaudeExecutable(providerSettings.pathToClaudeCodeExecutable);
   const claudeExecutablePreflight = claudeExecutable ? preflightClaudeExecutable(claudeExecutable, cwd) : void 0;
-  const { sessionId: resumeSessionId } = syncSharedSession(context.messages, cwd, customToolNameToSdk, model.id);
   const requestedEffort = options?.reasoning ? model.thinkingLevelMap?.[options.reasoning] ?? REASONING_TO_EFFORT[options.reasoning] : void 0;
   const effort = resolveConfiguredEffort(model.id, requestedEffort, providerSettings);
   const extraArgs = {};
@@ -46044,6 +46068,7 @@ export {
   mapToolName,
   normalizeRateLimitUtilization,
   noteChildExecutedToolResults,
+  planIncrementalPromptBatch,
   preflightClaudeExecutable,
   primeConnectorServers,
   processAssistantMessage,

--- a/pi-extensions/pi-claude-bridge/src/index.ts
+++ b/pi-extensions/pi-claude-bridge/src/index.ts
@@ -57,7 +57,7 @@ export { classifyClaudeExecutableBytes, preflightClaudeExecutable, resolveClaude
 export { __testGetBridgeIntegrityState, __testSetBridgeIntegrityState, INTEGRITY_CUSTOM_TYPE, appendIntegrityEntry, reportToolResultMismatch } from "./bridge-state.js";
 export { CONNECTOR_CALL_CUSTOM_TYPE, connectorResultByteSize, flushConnectorCallAudit, recordConnectorCallResult, setConnectorCallAuditSink, type ConnectorCallAuditData, type ConnectorCallAuditSink, type ConnectorCallOutcome } from "./connector-audit.js";
 export { CLAUDE_AI_CONNECTOR_TOOL_PATTERNS, connectorMcpServers, connectorDeclarationsDisabled, CLAUDE_BRIDGE_TOOL_ISOLATION, CONNECTOR_DISCOVERY_TOOLS, CONNECTOR_WRITE_TOOLS, DISALLOWED_BUILTIN_TOOLS, connectorQueryOptions, connectorWriteDenyHook, connectorWriteModeFor, connectorWriteModeFromEnv, connectorsEnabledFor, connectorsEnabledFromEnv, isChildExecutedTool, isConnectorWriteTool, toolIsolationForQuery } from "./connectors.js";
-export { restoreSharedSessionFromPi, shouldRestorePersistedBridgeEntry } from "./session-persistence.js";
+export { planIncrementalPromptBatch, restoreSharedSessionFromPi, shouldRestorePersistedBridgeEntry } from "./session-persistence.js";
 export { NATIVE_PROVIDER_UNSUPPORTED_MESSAGE, buildNativeProvider, claudeAuthSourceLabel, supportsNativeProvider } from "./native-provider.js";
 export { DEFAULT_STREAM_IDLE_TIMEOUT_MS, STREAM_IDLE_BACKOFF_HINT_MS, STREAM_IDLE_TIMEOUT_ENV, buildStreamIdleTimeoutErrorMessage, createStreamIdleWatchdog, streamIdleTimeoutMsFromEnv, type StreamIdleTimeoutInfo, type StreamIdleWatchdog, type StreamIdleWatchdogState } from "./stream-idle-watchdog.js";
 export { ALLOWED_RATE_LIMIT_WARNING_UTILIZATION_THRESHOLD, formatAllowedRateLimitWarning, formatResetTimestamp, isExtraUsageRequiredMessage, isUsageLimitMessage, normalizeRateLimitUtilization, resetTimestampMs, uniqueNonEmptyLines } from "./rate-limit.js";
@@ -220,44 +220,48 @@ function extractAllToolResults(context: Context): McpResult[] {
 	return results;
 }
 
-/** Extract the last user message from context as a prompt string. Returns null if last message is not a user message. */
+/** Combine one or more consecutive user messages into a single SDK prompt. */
 function extractUserPrompt(messages: Context["messages"]): string | null {
-	const last = messages[messages.length - 1];
-	if (!last || last.role !== "user") return null;
-	if (typeof last.content === "string") return last.content;
-	return messageContentToText(last.content) || "";
+	if (messages.length === 0 || messages.some((message) => message.role !== "user")) return null;
+	return messages.map((message) =>
+		typeof message.content === "string" ? message.content : messageContentToText(message.content) || "",
+	).join("\n\n");
 }
 
-/** Extract the last user message as ContentBlockParam[] (preserving images).
- *  Returns null if no images — caller should fall back to string prompt. */
+/** Combine consecutive user messages as ContentBlockParam[] while preserving images.
+ *  Returns null if no images — caller should fall back to the string prompt. */
 function extractUserPromptBlocks(messages: Context["messages"]): ContentBlockParam[] | null {
-	const last = messages[messages.length - 1];
-	if (!last || last.role !== "user") return null;
-	if (typeof last.content === "string") {
-		debug(`extractUserPromptBlocks: content is string (length=${last.content.length})`);
-		return null;
-	}
-	if (!Array.isArray(last.content)) {
-		debug(`extractUserPromptBlocks: content is ${typeof last.content}`);
-		return null;
-	}
-	debug(`extractUserPromptBlocks: ${last.content.length} blocks, types=${last.content.map((b: any) => b.type).join(",")}`);
+	if (messages.length === 0 || messages.some((message) => message.role !== "user")) return null;
+
 	let hasImage = false;
 	const blocks: ContentBlockParam[] = [];
-	for (const block of last.content) {
-		if (block.type === "text" && block.text) {
-			blocks.push({ type: "text", text: block.text });
-		} else if (block.type === "image") {
-			debug(`image block: mimeType=${(block as any).mimeType}, data length=${((block as any).data ?? "").length}, keys=${Object.keys(block).join(",")}`);
-			if (!(block as any).data || !(block as any).mimeType) {
-				debug(`image block missing data or mimeType, skipping`);
-				continue;
+	for (let messageIndex = 0; messageIndex < messages.length; messageIndex++) {
+		const content = messages[messageIndex].content;
+		if (messageIndex > 0) blocks.push({ type: "text", text: "\n\n" });
+		if (typeof content === "string") {
+			if (content) blocks.push({ type: "text", text: content });
+			continue;
+		}
+		if (!Array.isArray(content)) {
+			debug(`extractUserPromptBlocks: content is ${typeof content}`);
+			continue;
+		}
+		debug(`extractUserPromptBlocks: ${content.length} blocks, types=${content.map((b: any) => b.type).join(",")}`);
+		for (const block of content) {
+			if (block.type === "text" && block.text) {
+				blocks.push({ type: "text", text: block.text });
+			} else if (block.type === "image") {
+				debug(`image block: mimeType=${(block as any).mimeType}, data length=${((block as any).data ?? "").length}, keys=${Object.keys(block).join(",")}`);
+				if (!(block as any).data || !(block as any).mimeType) {
+					debug(`image block missing data or mimeType, skipping`);
+					continue;
+				}
+				hasImage = true;
+				blocks.push({
+					type: "image",
+					source: { type: "base64", media_type: block.mimeType as Base64ImageSource["media_type"], data: block.data },
+				});
 			}
-			hasImage = true;
-			blocks.push({
-				type: "image",
-				source: { type: "base64", media_type: block.mimeType as Base64ImageSource["media_type"], data: block.data },
-			});
 		}
 	}
 	return hasImage ? blocks : null;
@@ -744,7 +748,7 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 		// The bridge can't forward these mid-query (the SDK query is in progress),
 		// so we save them for replay as continuation queries after consumeQuery ends.
 		if (lastMsgRole === "user") {
-			const userPrompt = extractUserPrompt(context.messages);
+			const userPrompt = extractUserPrompt(context.messages.slice(-1));
 			if (userPrompt) {
 				ctx().deferredUserMessages.push(userPrompt);
 				debug(`provider: deferred user message for replay after query: ${userPrompt.slice(0, 60)}`);
@@ -818,8 +822,9 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 	ctx().latestCursor = 0;
 
 	const { mcpTools, customToolNameToSdk, customToolNameToPi } = resolveMcpTools(context);
-	const promptBlocks = extractUserPromptBlocks(context.messages);
-	let promptText = extractUserPrompt(context.messages) ?? "";
+	const { sessionId: resumeSessionId, promptMessages } = syncSharedSession(context.messages, cwd, customToolNameToSdk, model.id);
+	const promptBlocks = extractUserPromptBlocks(promptMessages);
+	let promptText = extractUserPrompt(promptMessages) ?? "";
 
 	// Guard: empty prompt means the last context message isn't a user message.
 	// This should never happen with the state stack fix — dump diagnostics if it does.
@@ -878,8 +883,6 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 	const strictMcpConfigEnabled = !appendSystemPrompt && providerSettings.strictMcpConfig !== false;
 	const claudeExecutable = resolveClaudeExecutable(providerSettings.pathToClaudeCodeExecutable);
 	const claudeExecutablePreflight = claudeExecutable ? preflightClaudeExecutable(claudeExecutable, cwd) : undefined;
-	const { sessionId: resumeSessionId } = syncSharedSession(context.messages, cwd, customToolNameToSdk, model.id);
-
 	// Prefer the model's own thinkingLevelMap when present (pi-ai 0.72+ ships
 	// per-model overrides — e.g. opus-4-7 wants xhigh→xhigh, not xhigh→max).
 	// Fall back to our generic table for older pi-ai or unmapped levels.

--- a/pi-extensions/pi-claude-bridge/src/session-persistence.ts
+++ b/pi-extensions/pi-claude-bridge/src/session-persistence.ts
@@ -192,6 +192,42 @@ function convertAndImportMessages(
 
 interface SyncResult {
 	sessionId: string | null;
+	promptMessages: Context["messages"];
+}
+
+export interface IncrementalPromptBatchPlan {
+	cursorBeforeQuery: number;
+	promptStart: number;
+	userMessageCount: number;
+}
+
+/**
+ * Recognize history that Claude already owns followed only by user messages
+ * delivered together by Pi (for example, followUpMode="all"). Claude Code has
+ * already persisted the optional leading assistant message; every user message
+ * after it must be sent as this query's prompt rather than imported via rebuild.
+ */
+export function planIncrementalPromptBatch(
+	messages: Context["messages"],
+	cursor: number,
+): IncrementalPromptBatchPlan | undefined {
+	const lastIndex = messages.length - 1;
+	if (lastIndex < 0 || (messages[lastIndex] as { role?: string }).role !== "user") return undefined;
+
+	const boundedCursor = Math.max(0, Math.min(cursor, lastIndex));
+	let promptStart = boundedCursor;
+	if ((messages[promptStart] as { role?: string } | undefined)?.role === "assistant") promptStart++;
+
+	const pendingPrompts = messages.slice(promptStart);
+	if (pendingPrompts.length === 0 || pendingPrompts.some((message) => (message as { role?: string }).role !== "user")) {
+		return undefined;
+	}
+
+	return {
+		cursorBeforeQuery: promptStart,
+		promptStart,
+		userMessageCount: pendingPrompts.length,
+	};
 }
 
 /**
@@ -280,16 +316,18 @@ export function syncSharedSession(
 
 	// REUSE path
 	if (sharedSession && !sharedSession.needsRebuild) {
-		const missed = priorMessages.slice(sharedSession.cursor);
-		const trailingAssistantOnly =
-			missed.length === 1 && (missed[0] as { role?: string }).role === "assistant";
-		if (missed.length === 0 || trailingAssistantOnly) {
-			if (trailingAssistantOnly) {
-				setSharedSession({ ...sharedSession, cursor: priorMessages.length, cwd });
-			}
-			debug(`Case 3: ${trailingAssistantOnly ? "advanced cursor past trailing assistant, " : ""}resuming session ${sharedSession.sessionId.slice(0, 8)}, cursor=${sharedSession.cursor}`);
-			debug(`syncResult: path=reuse sessionId=${sharedSession.sessionId} cursor=${sharedSession.cursor}`);
-			return { sessionId: sharedSession.sessionId };
+		const batch = planIncrementalPromptBatch(messages, sharedSession.cursor);
+		if (batch) {
+			setSharedSession({ ...sharedSession, cursor: batch.cursorBeforeQuery, cwd });
+			const batching = batch.userMessageCount > 1
+				? `batched ${batch.userMessageCount} consecutive user messages, `
+				: batch.cursorBeforeQuery > sharedSession.cursor ? "advanced cursor past trailing assistant, " : "";
+			debug(`Case 3: ${batching}resuming session ${sharedSession.sessionId.slice(0, 8)}, cursor=${batch.cursorBeforeQuery}`);
+			debug(`syncResult: path=reuse sessionId=${sharedSession.sessionId} cursor=${batch.cursorBeforeQuery} promptUsers=${batch.userMessageCount}`);
+			return {
+				sessionId: sharedSession.sessionId,
+				promptMessages: messages.slice(batch.promptStart),
+			};
 		}
 	}
 
@@ -297,7 +335,7 @@ export function syncSharedSession(
 	if (priorMessages.length === 0) {
 		debug(`Case 1: clean start, ${messages.length} total messages`);
 		debug(`syncResult: path=clean-start`);
-		return { sessionId: null };
+		return { sessionId: null, promptMessages: messages.slice(-1) };
 	}
 	const previousSessionId = sharedSession?.sessionId;
 	const previousCursor = sharedSession?.cursor ?? 0;
@@ -330,5 +368,5 @@ export function syncSharedSession(
 	}
 	debugSessionPaths(`${session.sessionId.slice(0, 8)}`, cwd, session.jsonlPath);
 	debug(`syncResult: path=rebuild sessionId=${session.sessionId} priors=${priorMessages.length} ${previousSessionId === undefined ? "first" : preserveId ? "preserved" : "rotated-post-abort"}`);
-	return { sessionId: session.sessionId };
+	return { sessionId: session.sessionId, promptMessages: messages.slice(-1) };
 }

--- a/pi-extensions/pi-claude-bridge/tests/unit-followup-batch.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-followup-batch.mjs
@@ -1,0 +1,63 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { planIncrementalPromptBatch } from "../src/index.ts";
+
+const msg = (role) => ({ role, content: role === "assistant" ? [] : role });
+const roles = (...values) => values.map(msg);
+
+describe("planIncrementalPromptBatch", () => {
+	it("batches followUpMode=all users after Claude's trailing assistant", () => {
+		const plan = planIncrementalPromptBatch(
+			roles("user", "assistant", "user", "user"),
+			1,
+		);
+
+		assert.deepEqual(plan, {
+			cursorBeforeQuery: 2,
+			promptStart: 2,
+			userMessageCount: 2,
+		});
+	});
+
+	it("keeps the normal single-user reuse path unchanged", () => {
+		const plan = planIncrementalPromptBatch(
+			roles("user", "assistant", "user"),
+			1,
+		);
+
+		assert.deepEqual(plan, {
+			cursorBeforeQuery: 2,
+			promptStart: 2,
+			userMessageCount: 1,
+		});
+	});
+
+	it("supports a cursor already advanced past the assistant", () => {
+		const plan = planIncrementalPromptBatch(
+			roles("user", "assistant", "user", "user"),
+			2,
+		);
+
+		assert.deepEqual(plan, {
+			cursorBeforeQuery: 2,
+			promptStart: 2,
+			userMessageCount: 2,
+		});
+	});
+
+	it("rejects genuine history divergence containing an intervening assistant", () => {
+		const plan = planIncrementalPromptBatch(
+			roles("user", "assistant", "user", "assistant", "user"),
+			1,
+		);
+
+		assert.equal(plan, undefined);
+	});
+
+	it("rejects a non-user final prompt", () => {
+		assert.equal(
+			planIncrementalPromptBatch(roles("user", "assistant", "toolResult"), 1),
+			undefined,
+		);
+	});
+});


### PR DESCRIPTION
## Summary

- recognize Pi histories shaped as Claude's already-persisted trailing assistant followed only by consecutive user messages
- pass every queued user message to the next Claude SDK query as one combined prompt instead of rebuilding/importing the session
- preserve text and image blocks while combining prompts
- keep the existing rebuild behavior for genuine divergence involving tools or an intervening assistant/provider turn

Fixes #963.

## Why

With Pi's supported `followUpMode: "all"`, multiple queued follow-ups are appended as consecutive user messages and delivered in one provider call. The bridge previously saw the first queued user message as missed history, entered Case 4, rewrote the Claude session, and lost the warm prompt-cache prefix.

Simply ignoring the missed user message would drop input. This change instead identifies the narrow safe shape and sends all pending users as the current SDK prompt while resuming the existing Claude session.

## Validation

- `npm run typecheck`
- `npm run test:unit` — 377 passed, 2 skipped
- `npm run build`
- no live Claude integration/cache test was run, to avoid another large billed cache rewrite; the new planner has focused unit coverage for the reported history shape and divergence guard
