### PR TITLE
fix(linear): fail closed on writes instead of guessing a team

### DIFF
--- a/skills/linear/DEVELOPMENT.md
+++ b/skills/linear/DEVELOPMENT.md
@@ -44,19 +44,59 @@ invents one.
 - `LINEAR_TEAM_SOURCE` / `LINEAR_API_KEY_SOURCE` record `environment`,
   `project-config`, or `unset`, captured before project files load. `auth-check`
   reports them and flags a machine-wide key paired with no project team.
+- `LINEAR_TEAM_ENV_BLANK` marks the one case the source values cannot express:
+  `LINEAR_TEAM` exported as an empty string. The parent-env snapshot in
+  `vstack-env.sh` gives the process environment precedence over project files,
+  so an empty export blocks a configured team while resolving to no target. It
+  reports `team_source: "unset"` with `team_source_file: null` (nothing set the
+  target) and warns that the export is shadowing the project value.
+  `auth-check` sets `team_source_file` only when a project file supplied the
+  resolved team, so the file never appears next to an environment-sourced or
+  empty target.
 
 Two layers enforce the fail-closed rule:
 
 1. **Dispatcher** — `linear_guard_write_action "$action" "<write actions>" "$@"`
    runs right after the action is parsed, so a write refuses before any API
-   call, including issue-identifier lookups. `--help` is exempt.
+   call, including issue-identifier lookups. It reads only the first remaining
+   argument, and only to let `<action> --help` through. It must never search
+   argv for a `--team`: that token is just as likely to be free text in a
+   comment body or an issue title, and honoring it would let user content open
+   the gate.
+   The list holds the write actions with **no** `--team` parser. The four that
+   do parse one — `issues create`, `projects create`, `cycles create`,
+   `labels create` — are omitted and instead call `linear_set_team_target` +
+   `linear_require_team_target` immediately after their parse loop, still
+   before any API call. Adding `--team` to another write means moving it out of
+   the dispatcher list and into that pattern.
 2. **Wire** — `graphql_query` refuses any document whose first token is
    `mutation` when `LINEAR_TEAM_TARGET` is empty. A write action missing from a
    dispatcher list degrades to a later refusal, never to a cross-workspace
-   write.
+   write. `linear_query_is_mutation` classifies by the leading token, so a
+   document that buries its operation behind a leading fragment would evade it;
+   `tests/graphql-document-classification.test.sh` fails the build if any
+   document in `scripts/` takes that shape.
 
 Read paths omit the team filter when the target is empty; they never send an
-empty team name (which would match nothing) or a guessed one.
+empty team name (which would match nothing) or a guessed one. `statuses` and
+`cycles` reads apply `LINEAR_TEAM` as their default filter; `issues list` never
+has — it filters by team only when `--team` is passed, and that asymmetry is
+load-bearing for cross-team listings.
+
+## What the Guard Does Not Cover
+
+The guard proves a team is **configured**, not that a write lands in it. A
+mutation addressed by an existing entity ID or identifier
+(`issues update ABC-123`, `comments create ABC-123`, `issues archive`, relation
+and project mutations) is routed by that ID inside whatever workspace the API
+key reaches — the team target never constrains it. With `LINEAR_TEAM` set to one
+team, `issues update <id-from-another-workspace> --state Done` still succeeds.
+
+So the guarantee is: an unconfigured project cannot write to Linear at all, and
+newly created entities land in the named team. A configured project handed a
+foreign identifier will still act on it. Nothing here validates that an
+identifier belongs to `LINEAR_TEAM`; that would cost a lookup on every mutation
+and is not implemented.
 
 Projects are seeded with `vstack.settings.toml.example`, which project-scope
 `vstack add` / `vstack refresh` merge into `<project>/vstack.settings.toml`

--- a/skills/linear/DEVELOPMENT.md
+++ b/skills/linear/DEVELOPMENT.md
@@ -25,4 +25,40 @@ skills/linear/
 2. Source `../lib/common.sh`
 3. Add `show_help()` function
 4. Add to case statement in `scripts/linear.sh`
-5. Update Commands table in `SKILL.md`
+5. Register the script's write actions with `linear_guard_write_action` (see below)
+6. Update Commands table in `SKILL.md`
+
+## Team Targeting
+
+A team name is not a workspace-independent identifier: it resolves inside
+whatever workspace `LINEAR_API_KEY` reaches. A substituted default therefore
+writes into whichever tracker the key happens to own, so nothing in the skill
+invents one.
+
+`common.sh` resolves the target once per invocation:
+
+- `DEFAULT_TEAM` is `LINEAR_TEAM` verbatim, empty when unset.
+- `LINEAR_TEAM_TARGET` starts at `DEFAULT_TEAM`; `linear_set_team_target "$team"`
+  registers an explicit `--team` over it. It must run in the command's own shell
+  (not `$(...)`) so the value reaches the guards.
+- `LINEAR_TEAM_SOURCE` / `LINEAR_API_KEY_SOURCE` record `environment`,
+  `project-config`, or `unset`, captured before project files load. `auth-check`
+  reports them and flags a machine-wide key paired with no project team.
+
+Two layers enforce the fail-closed rule:
+
+1. **Dispatcher** — `linear_guard_write_action "$action" "<write actions>" "$@"`
+   runs right after the action is parsed, so a write refuses before any API
+   call, including issue-identifier lookups. `--help` is exempt.
+2. **Wire** — `graphql_query` refuses any document whose first token is
+   `mutation` when `LINEAR_TEAM_TARGET` is empty. A write action missing from a
+   dispatcher list degrades to a later refusal, never to a cross-workspace
+   write.
+
+Read paths omit the team filter when the target is empty; they never send an
+empty team name (which would match nothing) or a guessed one.
+
+Projects are seeded with `vstack.settings.toml.example`, which project-scope
+`vstack add` / `vstack refresh` merge into `<project>/vstack.settings.toml`
+without overwriting existing keys. The seeded `LINEAR_TEAM = ""` is inert: empty
+is exactly the unset case, so an unedited seed keeps writes refused.

--- a/skills/linear/README.md
+++ b/skills/linear/README.md
@@ -6,11 +6,22 @@ CLI wrapper for Linear's GraphQL API with local cache, bulk operations, and stru
 
 1. Install Bash 4.0 or newer. macOS system Bash 3.2 is unsupported; invoke `linear.sh` with the newer Bash executable.
 2. Add `LINEAR_API_KEY` to `.env.local` for live API commands and sync
-3. Optionally set non-secret defaults such as `LINEAR_TEAM`, `LINEAR_FORMAT`, and `LINEAR_TEAM_PREFIX` in committed `vstack.settings.toml`
+3. Set `LINEAR_TEAM` to this project's team in committed `vstack.settings.toml` under `[env]` — required for any write. Other non-secret defaults such as `LINEAR_FORMAT` and `LINEAR_TEAM_PREFIX` go in the same table.
 
 ```bash
-./scripts/linear.sh auth-check
+./scripts/linear.sh auth-check --strict
 ./scripts/linear.sh sync --reconcile
+```
+
+## Team Target
+
+`LINEAR_TEAM` has no default. A team name resolves inside whatever workspace `LINEAR_API_KEY` reaches, so with no team configured the CLI has no target of its own: writes (create, update, comment, archive, relation, state change) refuse with an actionable error before any API call, and reads run without a team filter rather than guessing one. Pass `--team <name>` to target a team for a single command.
+
+`auth-check` is the preflight. It reports the resolved team, whether it came from the process environment or project config, and `writes_enabled`; it warns when a machine-wide `LINEAR_API_KEY` is paired with no project team, and when an exported `LINEAR_TEAM` shadows the project's own value. `auth-check --strict` exits non-zero when writes would refuse.
+
+```bash
+./scripts/linear.sh auth-check --strict
+{"ok":true,"team":"Platform","team_source":"project-config","team_source_file":"vstack.settings.toml","api_key_source":"environment","writes_enabled":true,"warnings":[]}
 ```
 
 Read-only cache queries (`./scripts/linear.sh cache ...` except `cache attachments fetch`) use existing `.cache/linear` data and do not require API auth. Cache and attachment paths are anchored to the physical git worktree root from `git rev-parse --show-toplevel`, so symlinked checkout spellings and canonical skill invocation paths read and write the same cache. If no cache exists, the error JSON includes the checked `cache_dir` and `meta_path`.
@@ -34,9 +45,9 @@ Use explicit list actions for dependency reads: `issues list-relations ISSUE` an
 | Variable | Purpose | Default |
 |----------|---------|---------|
 | `LINEAR_API_KEY` | API key (required for live API commands and sync; not required for cache reads) | — |
-| `LINEAR_TEAM` | Default team name | `Claude` |
+| `LINEAR_TEAM` | Team every write targets | — (unset refuses writes) |
 | `LINEAR_FORMAT` | Default output format | `safe` |
-| `LINEAR_TEAM_PREFIX` | Issue identifier prefix | `CC` |
+| `LINEAR_TEAM_PREFIX` | Issue identifier prefix | `PROJ` |
 
 Keep `LINEAR_API_KEY` in `.env.local`. Shared non-secret defaults can live in `vstack.settings.toml` under `[env]`; `.env.local` still wins for local overrides.
 

--- a/skills/linear/README.md
+++ b/skills/linear/README.md
@@ -15,9 +15,11 @@ CLI wrapper for Linear's GraphQL API with local cache, bulk operations, and stru
 
 ## Team Target
 
-`LINEAR_TEAM` has no default. A team name resolves inside whatever workspace `LINEAR_API_KEY` reaches, so with no team configured the CLI has no target of its own: writes (create, update, comment, archive, relation, state change) refuse with an actionable error before any API call, and reads run without a team filter rather than guessing one. Pass `--team <name>` to target a team for a single command.
+`LINEAR_TEAM` has no default. A team name resolves inside whatever workspace `LINEAR_API_KEY` reaches, so with no team configured the CLI has no target of its own: writes (create, update, comment, archive, relation, state change) refuse with an actionable error before any API call, and reads run without a team filter rather than guessing one.
 
-`auth-check` is the preflight. It reports the resolved team, whether it came from the process environment or project config, and `writes_enabled`; it warns when a machine-wide `LINEAR_API_KEY` is paired with no project team, and when an exported `LINEAR_TEAM` shadows the project's own value. `auth-check --strict` exits non-zero when writes would refuse.
+`--team <name>` is a per-call override only where a team is part of the request: `issues create`, `projects create`, `cycles create`, and `labels create` (plus the `issues list`, `cycles list`, and `statuses list/get` read filters). Every other write takes its target from `LINEAR_TEAM` alone, so configure it rather than relying on a flag.
+
+`auth-check` is the preflight. It reports the resolved team, whether it came from the process environment or project config (`team_source_file` names the file only when a project file supplied the resolved value), and `writes_enabled`; it warns when a machine-wide `LINEAR_API_KEY` is paired with no project team, and when an exported `LINEAR_TEAM` — including an exported empty one — shadows the project's own value. `auth-check --strict` exits non-zero when writes would refuse.
 
 ```bash
 ./scripts/linear.sh auth-check --strict

--- a/skills/linear/SKILL.md
+++ b/skills/linear/SKILL.md
@@ -117,7 +117,7 @@ Cache and attachment files live under `.cache/linear` in the physical git worktr
 
 Put `LINEAR_API_KEY` in `.env.local`. Put non-secret defaults in committed `vstack.settings.toml` under `[env]`; `.env.local` still wins for local overrides.
 
-`LINEAR_TEAM` has no default. A team name resolves inside whatever workspace the API key reaches, so an unset team means no target: every write (create, update, comment, archive, relation, state change) refuses with an actionable error before any API call, and reads run without a team filter. An explicit `--team <name>` satisfies a single command. `linear.sh auth-check` reports the resolved team, where it came from, and `writes_enabled`; `linear.sh auth-check --strict` exits non-zero when writes would refuse — run it before the first mutation in a project.
+`LINEAR_TEAM` has no default. A team name resolves inside whatever workspace the API key reaches, so an unset team means no target: every write (create, update, comment, archive, relation, state change) refuses with an actionable error before any API call, and reads run without a team filter. `--team <name>` overrides it per call only on the actions that take a team — `issues create`, `projects create`, `cycles create`, `labels create`; every other write requires the configured value. `linear.sh auth-check` reports the resolved team, where it came from, and `writes_enabled`; `linear.sh auth-check --strict` exits non-zero when writes would refuse — run it before the first mutation in a project.
 
 ## Safe Format Field Mapping
 

--- a/skills/linear/SKILL.md
+++ b/skills/linear/SKILL.md
@@ -55,7 +55,7 @@ CLI wrapper for Linear's GraphQL API with local cache, bulk operations, and stru
 | `documents` | list, get |
 | `sync` | Sync Linear data to local cache |
 | `cache` | Query local cache (issues, projects, cycles, initiatives, comments, labels, attachments) |
-| `auth-check` | Validate API key |
+| `auth-check` | Validate API key and report the resolved team target (`--strict` also fails when no team is configured) |
 
 Compatibility aliases: `issues relations` maps to `issues list-relations`, and `projects dependencies` maps to `projects list-dependencies`. Prefer the explicit action names in new workflows.
 
@@ -111,11 +111,13 @@ Cache and attachment files live under `.cache/linear` in the physical git worktr
 | Variable | Purpose | Default |
 |----------|---------|---------|
 | `LINEAR_API_KEY` | API key (required for live API commands and sync; not required for cache reads) | — |
-| `LINEAR_TEAM` | Default team name | `Claude` |
+| `LINEAR_TEAM` | Team every write targets | — (unset refuses writes) |
 | `LINEAR_FORMAT` | Default output format | `safe` |
-| `LINEAR_TEAM_PREFIX` | Issue identifier prefix | `CC` |
+| `LINEAR_TEAM_PREFIX` | Issue identifier prefix | `PROJ` |
 
 Put `LINEAR_API_KEY` in `.env.local`. Put non-secret defaults in committed `vstack.settings.toml` under `[env]`; `.env.local` still wins for local overrides.
+
+`LINEAR_TEAM` has no default. A team name resolves inside whatever workspace the API key reaches, so an unset team means no target: every write (create, update, comment, archive, relation, state change) refuses with an actionable error before any API call, and reads run without a team filter. An explicit `--team <name>` satisfies a single command. `linear.sh auth-check` reports the resolved team, where it came from, and `writes_enabled`; `linear.sh auth-check --strict` exits non-zero when writes would refuse — run it before the first mutation in a project.
 
 ## Safe Format Field Mapping
 

--- a/skills/linear/scripts/commands/auth-check.sh
+++ b/skills/linear/scripts/commands/auth-check.sh
@@ -1,26 +1,130 @@
 #!/bin/bash
-# Lightweight auth validation
-# Usage: ./linear.sh auth-check
-# Returns: {"ok": true/false, "error": "..."} — exit 0 on success, 1 on failure
+# Auth + target preflight
+# Usage: ./linear.sh auth-check [--strict]
+# Returns: {"ok": true/false, "team": ..., "team_source": ..., "writes_enabled": ...}
+# Exit 0 when the API key works. With --strict, also requires a team target so
+# the check matches what a write would do.
 
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../lib/common.sh"
 
+strict=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+  --strict)
+    strict=1
+    shift
+    ;;
+  --help | -h)
+    cat <<'EOF'
+Auth + target preflight
+
+Usage: auth-check [--strict]
+
+Reports API key validity, the resolved Linear team, and where that team came
+from. Linear writes refuse when no team resolves, so run this before the first
+mutation in a new project.
+
+Options:
+  --strict    Exit 1 when no team target is configured (writes would refuse)
+
+Fields:
+  ok              API key is set and the API answered
+  team            Resolved team name, or null
+  team_source     environment | project-config | unset
+  api_key_source  environment | project-config | unset
+  writes_enabled  false when a mutation would be refused
+  warnings        Configuration hazards found
+EOF
+    exit 0
+    ;;
+  *)
+    echo "{\"error\": \"Unknown option: $1. Run --help for valid options.\"}" >&2
+    exit 1
+    ;;
+  esac
+done
+
+# Team declared by project files, read independently of the process environment
+# so a box-global export that shadows project config is visible here.
+project_declared_team=""
+if [[ -n "$PROJECT_ROOT" ]]; then
+  project_declared_team="$(
+    unset LINEAR_TEAM
+    vstack_source_env_file "$PROJECT_ROOT/.env"
+    vstack_load_settings_file "$PROJECT_ROOT/vstack.settings.toml"
+    vstack_load_settings_file "$PROJECT_ROOT/.vstack/settings.toml"
+    vstack_source_env_file "$PROJECT_ROOT/.env.local"
+    printf '%s' "${LINEAR_TEAM:-}"
+  )" || project_declared_team=""
+fi
+
+team_source_file=""
+if [[ -n "$PROJECT_ROOT" ]]; then
+  for candidate in .env vstack.settings.toml .vstack/settings.toml .env.local; do
+    [[ -f "$PROJECT_ROOT/$candidate" ]] || continue
+    if grep -Eq '^[[:space:]]*(export[[:space:]]+)?LINEAR_TEAM[[:space:]]*=' "$PROJECT_ROOT/$candidate"; then
+      team_source_file="$candidate"
+    fi
+  done
+fi
+
+warnings=()
+
+if [[ -z "$LINEAR_TEAM_TARGET" ]]; then
+  warnings+=("No LINEAR_TEAM configured: Linear writes are refused. Set LINEAR_TEAM in vstack.settings.toml [env] (committed, non-secret) or .env.local, or pass --team <name>.")
+  if [[ "$LINEAR_API_KEY_SOURCE" == "environment" ]]; then
+    warnings+=("LINEAR_API_KEY comes from the process environment (a machine-wide key reaches every workspace it owns) while this project names no team. Until LINEAR_TEAM is set, this project has no Linear target of its own.")
+  fi
+elif [[ "$LINEAR_TEAM_SOURCE" == "environment" && -n "$project_declared_team" && "$project_declared_team" != "$LINEAR_TEAM_TARGET" ]]; then
+  warnings+=("LINEAR_TEAM from the process environment (\"$LINEAR_TEAM_TARGET\") overrides the project value (\"$project_declared_team\"). Writes go to the environment value.")
+fi
+
+emit() {
+  local ok="$1"
+  local error="${2:-}"
+  local writes_enabled="false"
+  [[ -n "$LINEAR_TEAM_TARGET" ]] && writes_enabled="true"
+
+  jq -cn \
+    --argjson ok "$ok" \
+    --arg error "$error" \
+    --arg team "$LINEAR_TEAM_TARGET" \
+    --arg team_source "$LINEAR_TEAM_SOURCE" \
+    --arg team_source_file "$team_source_file" \
+    --arg api_key_source "$LINEAR_API_KEY_SOURCE" \
+    --argjson writes_enabled "$writes_enabled" \
+    --args \
+    '{ok: $ok}
+     + (if $error == "" then {} else {error: $error} end)
+     + {
+         team: (if $team == "" then null else $team end),
+         team_source: $team_source,
+         team_source_file: (if $team_source_file == "" then null else $team_source_file end),
+         api_key_source: $api_key_source,
+         writes_enabled: $writes_enabled,
+         warnings: $ARGS.positional
+       }' "${warnings[@]+"${warnings[@]}"}"
+}
+
 if [[ -z "${LINEAR_API_KEY:-}" ]]; then
-  echo '{"ok":false,"error":"LINEAR_API_KEY not set"}'
+  emit false "LINEAR_API_KEY not set"
   exit 1
 fi
 
 result=$(graphql_query "{ viewer { id } }" "{}" 2>/dev/null) || {
-  echo '{"ok":false,"error":"API request failed"}'
+  emit false "API request failed"
   exit 1
 }
 
 viewer_id=$(echo "$result" | jq -r '.viewer.id // empty')
-if [[ -n "$viewer_id" ]]; then
-  echo '{"ok":true}'
-else
-  echo '{"ok":false,"error":"Invalid API key"}'
+if [[ -z "$viewer_id" ]]; then
+  emit false "Invalid API key"
+  exit 1
+fi
+
+emit true
+if ((strict)) && [[ -z "$LINEAR_TEAM_TARGET" ]]; then
   exit 1
 fi

--- a/skills/linear/scripts/commands/auth-check.sh
+++ b/skills/linear/scripts/commands/auth-check.sh
@@ -30,12 +30,13 @@ Options:
   --strict    Exit 1 when no team target is configured (writes would refuse)
 
 Fields:
-  ok              API key is set and the API answered
-  team            Resolved team name, or null
-  team_source     environment | project-config | unset
-  api_key_source  environment | project-config | unset
-  writes_enabled  false when a mutation would be refused
-  warnings        Configuration hazards found
+  ok                API key is set and the API answered
+  team              Resolved team name, or null
+  team_source       environment | project-config | unset
+  team_source_file  Project file that set the resolved team, or null
+  api_key_source    environment | project-config | unset
+  writes_enabled    false when a mutation would be refused
+  warnings          Configuration hazards found
 EOF
     exit 0
     ;;
@@ -73,12 +74,20 @@ fi
 warnings=()
 
 if [[ -z "$LINEAR_TEAM_TARGET" ]]; then
-  warnings+=("No LINEAR_TEAM configured: Linear writes are refused. Set LINEAR_TEAM in vstack.settings.toml [env] (committed, non-secret) or .env.local, or pass --team <name>.")
+  # Nothing resolved, so no file is the source of the target.
+  team_source_file=""
+  warnings+=("No LINEAR_TEAM configured: Linear writes are refused. Set LINEAR_TEAM in vstack.settings.toml [env] (committed, non-secret) or .env.local.")
+  if [[ "${LINEAR_TEAM_ENV_BLANK:-0}" == "1" && -n "$project_declared_team" ]]; then
+    warnings+=("LINEAR_TEAM is exported as an empty value, which overrides the project value (\"$project_declared_team\"). Unset it in the environment to use project configuration.")
+  fi
   if [[ "$LINEAR_API_KEY_SOURCE" == "environment" ]]; then
     warnings+=("LINEAR_API_KEY comes from the process environment (a machine-wide key reaches every workspace it owns) while this project names no team. Until LINEAR_TEAM is set, this project has no Linear target of its own.")
   fi
-elif [[ "$LINEAR_TEAM_SOURCE" == "environment" && -n "$project_declared_team" && "$project_declared_team" != "$LINEAR_TEAM_TARGET" ]]; then
-  warnings+=("LINEAR_TEAM from the process environment (\"$LINEAR_TEAM_TARGET\") overrides the project value (\"$project_declared_team\"). Writes go to the environment value.")
+elif [[ "$LINEAR_TEAM_SOURCE" == "environment" ]]; then
+  team_source_file=""
+  if [[ -n "$project_declared_team" && "$project_declared_team" != "$LINEAR_TEAM_TARGET" ]]; then
+    warnings+=("LINEAR_TEAM from the process environment (\"$LINEAR_TEAM_TARGET\") overrides the project value (\"$project_declared_team\"). Writes go to the environment value.")
+  fi
 fi
 
 emit() {

--- a/skills/linear/scripts/commands/comments.sh
+++ b/skills/linear/scripts/commands/comments.sh
@@ -280,6 +280,9 @@ delete_comment() {
 action="${1:-help}"
 shift || true
 
+# Fail closed: a write needs a resolved team target before any API call.
+linear_guard_write_action "$action" "create update delete" "$@" || exit 1
+
 case "$action" in
     list)
         if [ -z "${1:-}" ]; then

--- a/skills/linear/scripts/commands/cycles.sh
+++ b/skills/linear/scripts/commands/cycles.sh
@@ -19,13 +19,13 @@ Actions:
   update  Update a cycle (name, dates)
 
 List Options:
-  --team <name>         Team name (default: from project config)
+  --team <name>         Team name (default: $LINEAR_TEAM; unset = all teams)
   --type <type>         Filter: current, previous, next, or all (default: all)
   --limit <n>           Max results (default: 50)
 
 Create Options:
   --name <text>         Cycle name (optional, defaults to "Cycle N")
-  --team <name>         Team name (default: from project config)
+  --team <name>         Team name (default: $LINEAR_TEAM; required when unset)
   --start <date>        Start date (YYYY-MM-DD, required)
   --end <date>          End date (YYYY-MM-DD, required)
 
@@ -72,33 +72,42 @@ list_cycles() {
         esac
     done
 
-    team=$(apply_team_default "$team")
+    linear_set_team_target "$team"
+    team="$LINEAR_TEAM_TARGET"
 
-    # Get team ID
-    local team_query='query GetTeam($name: String!) { teams(filter: {name: {eq: $name}}) { nodes { id } } }'
-    local team_result
-    team_result=$(graphql_query "$team_query" "{\"name\": \"$team\"}")
-    local team_id
-    team_id=$(echo "$team_result" | jq -r '.teams.nodes[0].id // empty')
-    if [ -z "$team_id" ]; then
-        echo "{\"error\": \"Team not found: $team\"}" >&2
-        return 1
+    # No configured team means no team filter, never a guessed one.
+    local filter_parts=()
+    if [ -n "$team" ]; then
+        # Get team ID
+        local team_query='query GetTeam($name: String!) { teams(filter: {name: {eq: $name}}) { nodes { id } } }'
+        local team_result
+        team_result=$(graphql_query "$team_query" "{\"name\": \"$team\"}")
+        local team_id
+        team_id=$(echo "$team_result" | jq -r '.teams.nodes[0].id // empty')
+        if [ -z "$team_id" ]; then
+            echo "{\"error\": \"Team not found: $team\"}" >&2
+            return 1
+        fi
+        filter_parts+=("\"team\": {\"id\": {\"eq\": \"$team_id\"}}")
     fi
-
-    local filter_json="{\"team\": {\"id\": {\"eq\": \"$team_id\"}}}"
 
     # Add cycle type filter
     case "$cycle_type" in
         current)
-            filter_json="{\"team\": {\"id\": {\"eq\": \"$team_id\"}}, \"isActive\": {\"eq\": true}}"
+            filter_parts+=("\"isActive\": {\"eq\": true}")
             ;;
         previous)
-            filter_json="{\"team\": {\"id\": {\"eq\": \"$team_id\"}}, \"isPast\": {\"eq\": true}}"
+            filter_parts+=("\"isPast\": {\"eq\": true}")
             ;;
         next)
-            filter_json="{\"team\": {\"id\": {\"eq\": \"$team_id\"}}, \"isNext\": {\"eq\": true}}"
+            filter_parts+=("\"isNext\": {\"eq\": true}")
             ;;
     esac
+
+    local filter_json="{}"
+    if [ ${#filter_parts[@]} -gt 0 ]; then
+        filter_json=$(IFS=,; echo "{${filter_parts[*]}}")
+    fi
 
     local query='
     query ListCycles($filter: CycleFilter, $first: Int) {
@@ -162,8 +171,10 @@ create_cycle() {
         esac
     done
 
-    # Apply team default and validate required fields
-    team=$(apply_team_default "$team")
+    # Resolve the team target and validate required fields
+    linear_set_team_target "$team"
+    linear_require_team_target || return 1
+    team="$LINEAR_TEAM_TARGET"
     if [ -z "$start_date" ]; then
         echo '{"error": "Required: --start (YYYY-MM-DD)"}' >&2
         return 1
@@ -306,6 +317,9 @@ update_cycle() {
 # Main routing
 action="${1:-help}"
 shift || true
+
+# Fail closed: a write needs a resolved team target before any API call.
+linear_guard_write_action "$action" "create update" "$@" || exit 1
 
 case "$action" in
     list)

--- a/skills/linear/scripts/commands/cycles.sh
+++ b/skills/linear/scripts/commands/cycles.sh
@@ -319,7 +319,7 @@ action="${1:-help}"
 shift || true
 
 # Fail closed: a write needs a resolved team target before any API call.
-linear_guard_write_action "$action" "create update" "$@" || exit 1
+linear_guard_write_action "$action" "update" "$@" || exit 1
 
 case "$action" in
     list)

--- a/skills/linear/scripts/commands/initiatives.sh
+++ b/skills/linear/scripts/commands/initiatives.sh
@@ -436,6 +436,9 @@ remove_project() {
 action="${1:-help}"
 shift || true
 
+# Fail closed: a write needs a resolved team target before any API call.
+linear_guard_write_action "$action" "create update delete add-project remove-project" "$@" || exit 1
+
 case "$action" in
     list)
         list_initiatives "$@"

--- a/skills/linear/scripts/commands/issues.sh
+++ b/skills/linear/scripts/commands/issues.sh
@@ -111,7 +111,7 @@ List Options:
   --state <name>        Filter by state (e.g., "Todo", "In Progress,Todo")
   --project <name>      Filter by project name
   --project-id <uuid>   Filter by project ID
-  --team <name>         Filter by team name (default: \$LINEAR_TEAM; unset = all teams)
+  --team <name>         Filter by team name (no default; omit = all teams)
   --assignee <name|me>  Filter by assignee
   --updated-since <Nd>  Filter by updated date (e.g., "7d")
   --created-since <Nd>  Filter by created date
@@ -2661,7 +2661,7 @@ main() {
 
     # Fail closed: a write needs a resolved team target before any API call.
     linear_guard_write_action "$action" \
-        "create update archive trash delete bulk-update add-relation remove-relation activate block unblock complete" \
+        "update archive trash delete bulk-update add-relation remove-relation activate block unblock complete" \
         "$@" || exit 1
 
     case "$action" in

--- a/skills/linear/scripts/commands/issues.sh
+++ b/skills/linear/scripts/commands/issues.sh
@@ -111,7 +111,7 @@ List Options:
   --state <name>        Filter by state (e.g., "Todo", "In Progress,Todo")
   --project <name>      Filter by project name
   --project-id <uuid>   Filter by project ID
-  --team <name>         Filter by team name (default: \$LINEAR_TEAM from project config)
+  --team <name>         Filter by team name (default: \$LINEAR_TEAM; unset = all teams)
   --assignee <name|me>  Filter by assignee
   --updated-since <Nd>  Filter by updated date (e.g., "7d")
   --created-since <Nd>  Filter by created date
@@ -135,7 +135,7 @@ Bulk Update:
 
 Create Options:
   --title <text>        Issue title (required)
-  --team <name>         Team name (default: $LINEAR_TEAM from project config)
+  --team <name>         Team name (default: $LINEAR_TEAM; required when unset)
   --description <text>  Issue description
   --description-file <path>  Read description from file (preferred for markdown)
   --label(s) <a,b,c>    Comma-separated label names
@@ -922,8 +922,11 @@ create_issue() {
         read_description_file "$description_file"
     fi
 
-    # Apply team default if not specified
-    team=$(apply_team_default "$team")
+    # Resolve the team target; creating an issue without one is refused here,
+    # before any API call.
+    linear_set_team_target "$team"
+    linear_require_team_target || return 1
+    team="$LINEAR_TEAM_TARGET"
 
     if [ -z "$title" ]; then
         echo '{"error": "Required: --title"}' >&2
@@ -2655,6 +2658,11 @@ main() {
     # Main routing
     action="${1:-help}"
     shift || true
+
+    # Fail closed: a write needs a resolved team target before any API call.
+    linear_guard_write_action "$action" \
+        "create update archive trash delete bulk-update add-relation remove-relation activate block unblock complete" \
+        "$@" || exit 1
 
     case "$action" in
     list)

--- a/skills/linear/scripts/commands/labels.sh
+++ b/skills/linear/scripts/commands/labels.sh
@@ -275,6 +275,9 @@ delete_label() {
 action="${1:-help}"
 shift || true
 
+# Fail closed: a write needs a resolved team target before any API call.
+linear_guard_write_action "$action" "create update delete" "$@" || exit 1
+
 case "$action" in
     list)
         list_labels "$@"

--- a/skills/linear/scripts/commands/labels.sh
+++ b/skills/linear/scripts/commands/labels.sh
@@ -128,6 +128,13 @@ create_label() {
         esac
     done
 
+    # Resolve the team target; creating a label without one is refused here,
+    # before any API call. --team stays optional as a scope selector: it narrows
+    # a workspace label to one team, and the configured target satisfies the
+    # requirement when it is omitted.
+    linear_set_team_target "$team"
+    linear_require_team_target || return 1
+
     if [ -z "$name" ]; then
         echo '{"error": "Required: --name"}' >&2
         return 1
@@ -276,7 +283,7 @@ action="${1:-help}"
 shift || true
 
 # Fail closed: a write needs a resolved team target before any API call.
-linear_guard_write_action "$action" "create update delete" "$@" || exit 1
+linear_guard_write_action "$action" "update delete" "$@" || exit 1
 
 case "$action" in
     list)

--- a/skills/linear/scripts/commands/milestones.sh
+++ b/skills/linear/scripts/commands/milestones.sh
@@ -344,6 +344,9 @@ delete_milestone() {
 action="${1:-help}"
 shift || true
 
+# Fail closed: a write needs a resolved team target before any API call.
+linear_guard_write_action "$action" "create update delete" "$@" || exit 1
+
 case "$action" in
     list)
         list_milestones "$@"

--- a/skills/linear/scripts/commands/project-labels.sh
+++ b/skills/linear/scripts/commands/project-labels.sh
@@ -242,6 +242,9 @@ delete_project_label() {
 action="${1:-help}"
 shift || true
 
+# Fail closed: a write needs a resolved team target before any API call.
+linear_guard_write_action "$action" "create update delete" "$@" || exit 1
+
 case "$action" in
     list)
         list_project_labels "$@"

--- a/skills/linear/scripts/commands/projects.sh
+++ b/skills/linear/scripts/commands/projects.sh
@@ -421,8 +421,11 @@ create_project() {
         esac
     done
 
-    # Apply team default if not specified
-    team=$(apply_team_default "$team")
+    # Resolve the team target; creating a project without one is refused here,
+    # before any API call.
+    linear_set_team_target "$team"
+    linear_require_team_target || return 1
+    team="$LINEAR_TEAM_TARGET"
 
     if [ -z "$name" ]; then
         echo '{"error": "Required: --name"}' >&2
@@ -1256,6 +1259,9 @@ set_sort_order() {
 # Main routing
 action="${1:-help}"
 shift || true
+
+# Fail closed: a write needs a resolved team target before any API call.
+linear_guard_write_action "$action" "create update delete add-dependency remove-dependency post-update reorder set-sort-order" "$@" || exit 1
 
 case "$action" in
 list)

--- a/skills/linear/scripts/commands/projects.sh
+++ b/skills/linear/scripts/commands/projects.sh
@@ -1261,7 +1261,7 @@ action="${1:-help}"
 shift || true
 
 # Fail closed: a write needs a resolved team target before any API call.
-linear_guard_write_action "$action" "create update delete add-dependency remove-dependency post-update reorder set-sort-order" "$@" || exit 1
+linear_guard_write_action "$action" "update delete add-dependency remove-dependency post-update reorder set-sort-order" "$@" || exit 1
 
 case "$action" in
 list)

--- a/skills/linear/scripts/commands/statuses.sh
+++ b/skills/linear/scripts/commands/statuses.sh
@@ -18,10 +18,10 @@ Actions:
   get     Get a single state by name
 
 List Options:
-  --team <name>         Team name (default: from project config)
+  --team <name>         Team name (default: $LINEAR_TEAM; unset = all teams)
 
 Get Options:
-  --team <name>         Team name (default: from project config)
+  --team <name>         Team name (default: $LINEAR_TEAM; unset = all teams)
   --name <name>         State name (required)
 
 Examples:
@@ -48,9 +48,14 @@ list_statuses() {
         esac
     done
 
-    team=$(apply_team_default "$team")
+    linear_set_team_target "$team"
+    team="$LINEAR_TEAM_TARGET"
 
-    local filter_json="{\"team\": {\"name\": {\"eq\": \"$team\"}}}"
+    # No configured team means no team filter, never a guessed one.
+    local filter_json="{}"
+    if [ -n "$team" ]; then
+        filter_json="{\"team\": {\"name\": {\"eq\": \"$team\"}}}"
+    fi
 
     local query='
     query ListStates($filter: WorkflowStateFilter) {
@@ -104,14 +109,18 @@ get_status() {
         esac
     done
 
-    team=$(apply_team_default "$team")
+    linear_set_team_target "$team"
+    team="$LINEAR_TEAM_TARGET"
 
     if [ -z "$name" ]; then
         echo '{"error": "Required: --name"}' >&2
         return 1
     fi
 
-    local filter_json="{\"team\": {\"name\": {\"eq\": \"$team\"}}, \"name\": {\"eq\": \"$name\"}}"
+    local filter_json="{\"name\": {\"eq\": \"$name\"}}"
+    if [ -n "$team" ]; then
+        filter_json="{\"team\": {\"name\": {\"eq\": \"$team\"}}, \"name\": {\"eq\": \"$name\"}}"
+    fi
 
     local query='
     query GetState($filter: WorkflowStateFilter) {

--- a/skills/linear/scripts/commands/sync.sh
+++ b/skills/linear/scripts/commands/sync.sh
@@ -247,28 +247,43 @@ sync_projects() {
 }
 
 sync_cycles() {
-    local team_name
-    team_name=$(apply_team_default "")
-    local query='
-    query SyncCycles($after: String, $teamName: String!) {
-        cycles(filter: {team: {name: {eq: $teamName}}}, first: 50, after: $after) {
+    local team_name="$LINEAR_TEAM_TARGET"
+    local cycle_fields='
             pageInfo { hasNextPage endCursor }
             nodes {
                 id number name startsAt endsAt progress
                 issueCountHistory completedIssueCountHistory
                 scopeHistory completedScopeHistory
                 team { name }
-            }
+            }'
+
+    # No configured team means no team filter, never a guessed one.
+    local query
+    if [ -n "$team_name" ]; then
+        query="
+    query SyncCycles(\$after: String, \$teamName: String!) {
+        cycles(filter: {team: {name: {eq: \$teamName}}}, first: 50, after: \$after) {$cycle_fields
         }
-    }'
+    }"
+    else
+        query="
+    query SyncCycles(\$after: String) {
+        cycles(first: 50, after: \$after) {$cycle_fields
+        }
+    }"
+    fi
 
     local all_nodes="[]"
     local cursor="null"
     local page=0
 
     while true; do
+        local variables="{\"after\": $cursor}"
+        if [ -n "$team_name" ]; then
+            variables="{\"after\": $cursor, \"teamName\": \"$team_name\"}"
+        fi
         local result
-        result=$(graphql_query "$query" "{\"after\": $cursor, \"teamName\": \"$team_name\"}")
+        result=$(graphql_query "$query" "$variables")
         local nodes
         nodes=$(echo "$result" | jq '.cycles.nodes')
         all_nodes=$(echo "$all_nodes" "$nodes" | jq -s 'add')

--- a/skills/linear/scripts/commands/teams.sh
+++ b/skills/linear/scripts/commands/teams.sh
@@ -25,7 +25,7 @@ Get:
 
 Examples:
   teams.sh list
-  teams.sh get claude
+  teams.sh get "<team-name>"
 EOF
 }
 

--- a/skills/linear/scripts/lib/common.sh
+++ b/skills/linear/scripts/lib/common.sh
@@ -37,6 +37,10 @@ _CALLER_LINEAR_API_KEY="${LINEAR_API_KEY:-}"
 
 # Captured before project files load so auth-check can tell a box-global export
 # (which reaches whatever workspace the key owns) from project configuration.
+# An exported-but-empty value is tracked separately: the env snapshot in
+# vstack-env.sh makes it win over the project files, so it silently blocks a
+# configured team rather than being absent.
+_CALLER_LINEAR_TEAM_SET="${LINEAR_TEAM+x}"
 _CALLER_LINEAR_TEAM="${LINEAR_TEAM:-}"
 
 # Load public config and local secrets before deriving defaults.
@@ -69,7 +73,15 @@ else
     LINEAR_TEAM_SOURCE="unset"
 fi
 
-unset _CALLER_LINEAR_API_KEY_SET _CALLER_LINEAR_API_KEY _CALLER_LINEAR_TEAM
+# 1 when the process environment exported LINEAR_TEAM as an empty value, which
+# resolves to no target while shadowing anything the project files declare.
+if [[ -n "$_CALLER_LINEAR_TEAM_SET" && -z "$_CALLER_LINEAR_TEAM" ]]; then
+    LINEAR_TEAM_ENV_BLANK=1
+else
+    LINEAR_TEAM_ENV_BLANK=0
+fi
+
+unset _CALLER_LINEAR_API_KEY_SET _CALLER_LINEAR_API_KEY _CALLER_LINEAR_TEAM _CALLER_LINEAR_TEAM_SET
 
 # Default values can be overridden by vstack.settings.toml [env] or .env.local.
 # LINEAR_TEAM has no built-in fallback on purpose: a team name resolves inside
@@ -505,7 +517,7 @@ linear_set_team_target() {
 }
 
 linear_team_target_error() {
-    echo '{"error": "No Linear team configured for this project - refusing to write. A team name resolves inside whatever workspace LINEAR_API_KEY reaches, so writing without one can land in another project tracker. Fix: set LINEAR_TEAM in this project vstack.settings.toml [env] (committed, non-secret) or .env.local, or pass --team <name>. Verify with: linear.sh auth-check --strict"}' >&2
+    echo '{"error": "No Linear team configured for this project - refusing to write. A team name resolves inside whatever workspace LINEAR_API_KEY reaches, so writing without one can land in another project tracker. Fix: set LINEAR_TEAM in this project vstack.settings.toml [env] (committed, non-secret) or .env.local. The create actions that take a team (issues, projects, cycles, labels) also accept --team <name> for one call. Verify with: linear.sh auth-check --strict"}' >&2
 }
 
 # Fail-closed gate for every Linear write.
@@ -517,49 +529,32 @@ linear_require_team_target() {
     return 1
 }
 
-# Best-effort scan of a command's argv for an explicit --team. The command's own
-# parser stays authoritative; this only lets the pre-dispatch guard see a team
-# that parser has not reached yet.
-linear_capture_explicit_team() {
-    while [ $# -gt 0 ]; do
-        case "$1" in
-        --team)
-            [ $# -ge 2 ] && linear_set_team_target "$2"
-            return 0
-            ;;
-        --team=*)
-            linear_set_team_target "${1#--team=}"
-            return 0
-            ;;
-        --)
-            return 0
-            ;;
-        esac
-        shift
-    done
-    return 0
-}
-
 # Dispatcher guard: refuse a write action before any API call when no team target
-# resolves. graphql_query enforces the same rule at the wire, so a missing entry
-# in a script's write-action list degrades to a later refusal, never to a write.
-# Usage: linear_guard_write_action "$action" "create update delete" "$@" || exit 1
+# resolves. It never searches argv for a team - a `--team` token in unparsed
+# arguments is just as likely to be free text (a comment body, an issue title),
+# and honoring it would let user content open the gate. Only the first remaining
+# argument is read, and only to let `<action> --help` through. The action list
+# therefore holds only the write actions with no --team parser of their own;
+# actions that do parse it call linear_set_team_target + linear_require_team_target
+# after their parse loop, before any API call. graphql_query enforces the same
+# rule at the wire, so a missing entry degrades to a later refusal, never to a
+# write.
+# Usage: linear_guard_write_action "$action" "update delete" "$@" || exit 1
 linear_guard_write_action() {
     local action="${1:-}"
     local write_actions="${2:-}"
-    shift 2 2>/dev/null || true
+    local first_arg="${3:-}"
 
     case " $write_actions " in
     *" $action "*) ;;
     *) return 0 ;;
     esac
 
-    # Help never needs a target.
-    case "${1:-}" in
+    # `<action> --help` prints usage and writes nothing.
+    case "$first_arg" in
     --help | -h) return 0 ;;
     esac
 
-    linear_capture_explicit_team "$@"
     linear_require_team_target
 }
 
@@ -592,7 +587,7 @@ resolve_project_id() {
 }
 
 # Resolve team name to UUID
-# Usage: resolve_team_id "claude"
+# Usage: resolve_team_id "$LINEAR_TEAM_TARGET"
 resolve_team_id() {
     local team_ref="$1"
 

--- a/skills/linear/scripts/lib/common.sh
+++ b/skills/linear/scripts/lib/common.sh
@@ -35,6 +35,10 @@ unset PROJECT_ROOT_RAW
 _CALLER_LINEAR_API_KEY_SET="${LINEAR_API_KEY+x}"
 _CALLER_LINEAR_API_KEY="${LINEAR_API_KEY:-}"
 
+# Captured before project files load so auth-check can tell a box-global export
+# (which reaches whatever workspace the key owns) from project configuration.
+_CALLER_LINEAR_TEAM="${LINEAR_TEAM:-}"
+
 # Load public config and local secrets before deriving defaults.
 # shellcheck source=vstack-env.sh
 source "$_LIB_DIR/vstack-env.sh"
@@ -44,12 +48,41 @@ if [[ -n "$_CALLER_LINEAR_API_KEY_SET" ]]; then
     LINEAR_API_KEY="$_CALLER_LINEAR_API_KEY"
     export LINEAR_API_KEY
 fi
-unset _CALLER_LINEAR_API_KEY_SET _CALLER_LINEAR_API_KEY
+
+# Where each target-selecting value came from: environment (process env, e.g. a
+# box-global export), project-config (.env / vstack.settings.toml / .env.local),
+# or unset. auth-check reports these; a global key with no project team is the
+# combination that writes into another project's workspace.
+if [[ -n "$_CALLER_LINEAR_API_KEY" ]]; then
+    LINEAR_API_KEY_SOURCE="environment"
+elif [[ -n "${LINEAR_API_KEY:-}" ]]; then
+    LINEAR_API_KEY_SOURCE="project-config"
+else
+    LINEAR_API_KEY_SOURCE="unset"
+fi
+
+if [[ -n "$_CALLER_LINEAR_TEAM" ]]; then
+    LINEAR_TEAM_SOURCE="environment"
+elif [[ -n "${LINEAR_TEAM:-}" ]]; then
+    LINEAR_TEAM_SOURCE="project-config"
+else
+    LINEAR_TEAM_SOURCE="unset"
+fi
+
+unset _CALLER_LINEAR_API_KEY_SET _CALLER_LINEAR_API_KEY _CALLER_LINEAR_TEAM
 
 # Default values can be overridden by vstack.settings.toml [env] or .env.local.
-DEFAULT_TEAM="${LINEAR_TEAM:-Claude}"
+# LINEAR_TEAM has no built-in fallback on purpose: a team name resolves inside
+# whatever workspace the API key reaches, so a guessed default silently targets
+# another project's tracker. Unset means "no team" — reads drop the team filter,
+# writes refuse (see linear_require_team_target).
+DEFAULT_TEAM="${LINEAR_TEAM:-}"
 DEFAULT_FORMAT="${LINEAR_FORMAT:-safe}"    # safe, raw, ids, table
 DEFAULT_PREFIX="${LINEAR_TEAM_PREFIX:-PROJ}" # Issue identifier prefix (e.g., PROJ-123)
+
+# Team target for this invocation. An explicit --team registers over the
+# configured value through linear_set_team_target.
+LINEAR_TEAM_TARGET="$DEFAULT_TEAM"
 
 # Source formatters
 source "$_LIB_DIR/formatters.sh"
@@ -133,6 +166,18 @@ validate_length() {
     return 0
 }
 
+# A GraphQL document is a write when its first token is `mutation`.
+linear_query_is_mutation() {
+    local query="${1:-}"
+    local leading="${query%%[![:space:]]*}"
+    query="${query#"$leading"}"
+
+    case "$query" in
+    mutation | mutation[!A-Za-z0-9_]*) return 0 ;;
+    esac
+    return 1
+}
+
 # Make GraphQL request with error handling and retry
 # Usage: graphql_query "query string" '{"var": "value"}'
 graphql_query() {
@@ -144,6 +189,12 @@ graphql_query() {
     local max_retries=3
     local retry_delay=1
     local attempt=1
+
+    # Single choke point for writes: no mutation leaves this process without a
+    # resolved team target, whatever path built it.
+    if linear_query_is_mutation "$query"; then
+        linear_require_team_target || return 1
+    fi
 
     check_api_key
 
@@ -435,11 +486,81 @@ parse_format_arg() {
     echo "${remaining_args[@]:-}"
 }
 
-# Apply team default if not specified
-# Usage: team=$(apply_team_default "$team")
-apply_team_default() {
-    local team="${1:-}"
-    echo "${team:-${DEFAULT_TEAM}}"
+# Team targeting
+# -----------------------------------------------------------------------------
+# Nothing below invents a team name. The API key alone decides which workspace a
+# name resolves in, so a substituted default writes into whichever tracker that
+# key reaches.
+
+# Set the team target for this invocation: explicit --team wins, otherwise the
+# configured LINEAR_TEAM (which may be empty).
+# Usage: linear_set_team_target "$team"; team="$LINEAR_TEAM_TARGET"
+linear_set_team_target() {
+    local explicit="${1:-}"
+    if [ -n "$explicit" ]; then
+        LINEAR_TEAM_TARGET="$explicit"
+    else
+        LINEAR_TEAM_TARGET="$DEFAULT_TEAM"
+    fi
+}
+
+linear_team_target_error() {
+    echo '{"error": "No Linear team configured for this project - refusing to write. A team name resolves inside whatever workspace LINEAR_API_KEY reaches, so writing without one can land in another project tracker. Fix: set LINEAR_TEAM in this project vstack.settings.toml [env] (committed, non-secret) or .env.local, or pass --team <name>. Verify with: linear.sh auth-check --strict"}' >&2
+}
+
+# Fail-closed gate for every Linear write.
+linear_require_team_target() {
+    if [ -n "${LINEAR_TEAM_TARGET:-}" ]; then
+        return 0
+    fi
+    linear_team_target_error
+    return 1
+}
+
+# Best-effort scan of a command's argv for an explicit --team. The command's own
+# parser stays authoritative; this only lets the pre-dispatch guard see a team
+# that parser has not reached yet.
+linear_capture_explicit_team() {
+    while [ $# -gt 0 ]; do
+        case "$1" in
+        --team)
+            [ $# -ge 2 ] && linear_set_team_target "$2"
+            return 0
+            ;;
+        --team=*)
+            linear_set_team_target "${1#--team=}"
+            return 0
+            ;;
+        --)
+            return 0
+            ;;
+        esac
+        shift
+    done
+    return 0
+}
+
+# Dispatcher guard: refuse a write action before any API call when no team target
+# resolves. graphql_query enforces the same rule at the wire, so a missing entry
+# in a script's write-action list degrades to a later refusal, never to a write.
+# Usage: linear_guard_write_action "$action" "create update delete" "$@" || exit 1
+linear_guard_write_action() {
+    local action="${1:-}"
+    local write_actions="${2:-}"
+    shift 2 2>/dev/null || true
+
+    case " $write_actions " in
+    *" $action "*) ;;
+    *) return 0 ;;
+    esac
+
+    # Help never needs a target.
+    case "${1:-}" in
+    --help | -h) return 0 ;;
+    esac
+
+    linear_capture_explicit_team "$@"
+    linear_require_team_target
 }
 
 # Resolve project name or UUID to UUID

--- a/skills/linear/scripts/linear.sh
+++ b/skills/linear/scripts/linear.sh
@@ -61,8 +61,9 @@ Environment:
   Runtime         Bash 4.0 or newer. macOS system Bash 3.2 is unsupported.
   LINEAR_API_KEY  Required. Set in .env.local or export directly.
   LINEAR_TEAM     Required for writes; no default. Set it in vstack.settings.toml
-                  [env] (committed, non-secret) or pass --team <name>. With no
-                  team, writes refuse and reads run without a team filter.
+                  [env] (committed, non-secret). With no team, writes refuse and
+                  reads run without a team filter. Only issues/projects/cycles/
+                  labels create take --team <name> as a per-call override.
 
 For resource-specific help:
   ./linear.sh <resource> --help

--- a/skills/linear/scripts/linear.sh
+++ b/skills/linear/scripts/linear.sh
@@ -29,7 +29,7 @@ Resources:
   statuses        Workflow state operations (list, get)
   documents       Document operations (list, get)
   session-status  Aggregated session status for /start workflow
-  auth-check      Lightweight API key validation (exit 0 = ok)
+  auth-check      API key + team target preflight (--strict fails with no team)
   sync            Sync Linear data to local cache
   cache           Query local cache (issues, projects, cycles, initiatives, comments, labels)
 
@@ -60,7 +60,9 @@ Examples:
 Environment:
   Runtime         Bash 4.0 or newer. macOS system Bash 3.2 is unsupported.
   LINEAR_API_KEY  Required. Set in .env.local or export directly.
-                  Non-secret defaults such as LINEAR_TEAM can be set in vstack.settings.toml.
+  LINEAR_TEAM     Required for writes; no default. Set it in vstack.settings.toml
+                  [env] (committed, non-secret) or pass --team <name>. With no
+                  team, writes refuse and reads run without a team filter.
 
 For resource-specific help:
   ./linear.sh <resource> --help

--- a/skills/linear/tests/comments-body-file.test.sh
+++ b/skills/linear/tests/comments-body-file.test.sh
@@ -27,7 +27,7 @@ cat >"$body_file" <<'MD'
 MD
 
 export CURL_CONFIG_CAPTURE="$TMP_ROOT/curl-config.txt"
-out="$(PATH="$TMP_ROOT/bin:$PATH" LINEAR_API_KEY=test-token bash "$TMP_ROOT/.agents/skills/linear/scripts/linear.sh" comments create PROJ-1 --body-file "$body_file")"
+out="$(PATH="$TMP_ROOT/bin:$PATH" LINEAR_API_KEY=test-token LINEAR_TEAM=TestTeam bash "$TMP_ROOT/.agents/skills/linear/scripts/linear.sh" comments create PROJ-1 --body-file "$body_file")"
 
 if ! jq -e '.success == true and .data.comment.id == "comment-1"' >/dev/null <<<"$out"; then
   echo "FAIL comments create --body-file returned unexpected output: $out"
@@ -42,7 +42,7 @@ if [[ "$body" != *"Completion Summary"* || "$body" != *'`code` and multi-line ma
 fi
 
 set +e
-PATH="$TMP_ROOT/bin:$PATH" LINEAR_API_KEY=test-token bash "$TMP_ROOT/.agents/skills/linear/scripts/linear.sh" comments create PROJ-1 --body inline --body-file "$body_file" >"$TMP_ROOT/conflict.out" 2>&1
+PATH="$TMP_ROOT/bin:$PATH" LINEAR_API_KEY=test-token LINEAR_TEAM=TestTeam bash "$TMP_ROOT/.agents/skills/linear/scripts/linear.sh" comments create PROJ-1 --body inline --body-file "$body_file" >"$TMP_ROOT/conflict.out" 2>&1
 rc=$?
 set -e
 if [[ "$rc" -eq 0 ]]; then

--- a/skills/linear/tests/graphql-document-classification.test.sh
+++ b/skills/linear/tests/graphql-document-classification.test.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# `graphql_query` refuses a write when no team target resolves, and it decides
+# what a write is with `linear_query_is_mutation`, which reads the document's
+# leading token. That classifier is only as good as the shape of the documents
+# in this skill: one that buried its operation behind a leading fragment, a
+# comment, or a BOM would be posted as a read and skip the guard entirely.
+#
+# This lint holds that precondition. Every GraphQL document literal in scripts/
+# must start with its operation keyword, and must classify the way its operation
+# says it should.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCRIPTS="$SKILL_DIR/scripts"
+
+# Load the classifier without running any command script.
+eval "$(sed -n '/^linear_query_is_mutation()/,/^}/p' "$SCRIPTS/lib/common.sh")"
+
+if ! declare -F linear_query_is_mutation >/dev/null 2>&1; then
+  echo "FAIL could not load linear_query_is_mutation from lib/common.sh"
+  exit 1
+fi
+
+fails=0
+checked=0
+
+classify_expect() {
+  # Reference classification, independent of the implementation: the first
+  # non-space, non-comment token of the document.
+  awk '
+    { sub(/\r$/, "") }
+    /^[[:space:]]*$/ { next }
+    /^[[:space:]]*#/ { next }
+    { sub(/^[[:space:]]+/, ""); print $1; exit }
+  '
+}
+
+check_document() {
+  local origin="$1"
+  local doc="$2"
+
+  # Only GraphQL documents; skip shell strings that merely mention the words.
+  case "$doc" in
+  *"{"*) ;;
+  *) return 0 ;;
+  esac
+
+  # Does the document carry a mutation operation anywhere, leading or not?
+  local has_mutation=0
+  if printf '%s' "$doc" | grep -Eq '(^|[^A-Za-z0-9_])mutation[[:space:]({]'; then
+    has_mutation=1
+  fi
+
+  local first
+  first="$(printf '%s\n' "$doc" | classify_expect)"
+  case "$first" in
+  query* | mutation* | fragment* | "{"*) ;;
+  *)
+    # Not a GraphQL document unless it hides an operation inside.
+    [ "$has_mutation" -eq 1 ] || return 0
+    ;;
+  esac
+
+  checked=$((checked + 1))
+
+  local got="read"
+  if linear_query_is_mutation "$doc"; then
+    got="write"
+  fi
+
+  # The property: the classifier is true iff the document performs a write.
+  # A mutation the classifier calls a read is posted with no team guard at all.
+  if [ "$has_mutation" -eq 1 ] && [ "$got" != "write" ]; then
+    echo "FAIL $origin: carries a mutation operation but classifies as a read"
+    echo "     the write guard would not see it - put the mutation keyword first"
+    printf '     %s\n' "$(printf '%s' "$doc" | head -c 120)"
+    fails=$((fails + 1))
+  elif [ "$has_mutation" -eq 0 ] && [ "$got" = "write" ]; then
+    echo "FAIL $origin: no mutation operation but classifies as a write"
+    printf '     %s\n' "$(printf '%s' "$doc" | head -c 120)"
+    fails=$((fails + 1))
+  fi
+}
+
+# Extract every single-quoted document literal. Command scripts assign GraphQL
+# to `query='...'` / `mutation='...'` / `local query='...'` and to *_query vars;
+# the double-quoted ones are built by interpolation and are covered by the
+# runtime assertions in team-target-fail-closed.test.sh.
+while IFS= read -r script; do
+  rel="${script#"$SKILL_DIR/"}"
+  # shellcheck disable=SC2016
+  docs="$(awk -v origin="$rel" '
+    # Start of a single-quoted assignment whose value looks like GraphQL.
+    !collecting && $0 ~ /^[[:space:]]*(local[[:space:]]+)?[A-Za-z_][A-Za-z0-9_]*=\x27/ {
+      line = $0
+      sub(/^[[:space:]]*(local[[:space:]]+)?[A-Za-z_][A-Za-z0-9_]*=\x27/, "", line)
+      if (line ~ /\x27/) {
+        sub(/\x27.*$/, "", line)
+        printf "%s\t%s\n", NR, line
+        next
+      }
+      collecting = 1
+      start = NR
+      buf = line
+      next
+    }
+    collecting {
+      if ($0 ~ /\x27/) {
+        line = $0
+        sub(/\x27.*$/, "", line)
+        buf = buf " " line
+        printf "%s\t%s\n", start, buf
+        collecting = 0
+        buf = ""
+        next
+      }
+      buf = buf " " $0
+    }
+  ' "$script")"
+
+  while IFS=$'\t' read -r lineno doc; do
+    [ -n "${doc:-}" ] || continue
+    check_document "$rel:$lineno" "$doc"
+  done <<<"$docs"
+done < <(find "$SCRIPTS" -name '*.sh' -type f | sort)
+
+# The classifier itself must hold for the shapes the lint is protecting against.
+assert_class() {
+  local expect="$1" doc="$2" label="$3"
+  local got="read"
+  if linear_query_is_mutation "$doc"; then
+    got="write"
+  fi
+  if [ "$got" != "$expect" ]; then
+    echo "FAIL classifier: $label expected $expect, got $got"
+    fails=$((fails + 1))
+  fi
+}
+
+assert_class write '
+    mutation CreateIssue($input: IssueCreateInput!) { issueCreate(input: $input) { success } }' "leading-newline mutation"
+assert_class write 'mutation{ x }' "brace-attached mutation"
+assert_class write '   mutation	Tabbed { x }' "tab-separated mutation"
+assert_class read 'query GetTeam($name: String!) { teams { nodes { id } } }' "query"
+assert_class read '{ viewer { id } }' "shorthand query"
+assert_class read 'mutationLike { x }' "identifier starting with mutation"
+
+if [ "$checked" -eq 0 ]; then
+  echo "FAIL no GraphQL documents found - the extractor stopped matching"
+  exit 1
+fi
+
+if [ "$fails" -ne 0 ]; then
+  echo "graphql-document-classification: FAIL ($fails)"
+  exit 1
+fi
+
+echo "all pass ($checked documents)"

--- a/skills/linear/tests/issues-activate-agent.test.sh
+++ b/skills/linear/tests/issues-activate-agent.test.sh
@@ -59,7 +59,7 @@ run_activate() {
   shift
   : >"$payload_log"
   PATH="$TMP_ROOT/bin:$PATH" \
-    LINEAR_API_KEY=test-token \
+    LINEAR_API_KEY=test-token LINEAR_TEAM=TestTeam \
     CURL_PAYLOAD_LOG="$payload_log" \
     bash "$TMP_ROOT/.agents/skills/linear/scripts/linear.sh" issues activate "$@"
 }

--- a/skills/linear/tests/issues-add-relation-deep-hierarchy.test.sh
+++ b/skills/linear/tests/issues-add-relation-deep-hierarchy.test.sh
@@ -116,7 +116,7 @@ run_add_relation() {
   shift
   : >"$payload_log"
   PATH="$TMP_ROOT/bin:$PATH" \
-    LINEAR_API_KEY=test-token \
+    LINEAR_API_KEY=test-token LINEAR_TEAM=TestTeam \
     CURL_PAYLOAD_LOG="$payload_log" \
     bash "$TMP_ROOT/.agents/skills/linear/scripts/linear.sh" issues add-relation "$@"
 }

--- a/skills/linear/tests/issues-add-relation-hierarchy.test.sh
+++ b/skills/linear/tests/issues-add-relation-hierarchy.test.sh
@@ -93,7 +93,7 @@ if [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
   : >"$payload_log"
   set +e
   output=$(PATH="$TMP_ROOT/bin:$PATH" \
-    LINEAR_API_KEY=test-token \
+    LINEAR_API_KEY=test-token LINEAR_TEAM=TestTeam \
     CURL_PAYLOAD_LOG="$payload_log" \
     bash "$TMP_ROOT/.agents/skills/linear/scripts/linear.sh" \
       issues add-relation CC-763 --blocks CC-764 2>&1)
@@ -119,7 +119,7 @@ run_add_relation() {
   shift
   : >"$payload_log"
   PATH="$TMP_ROOT/bin:$PATH" \
-    LINEAR_API_KEY=test-token \
+    LINEAR_API_KEY=test-token LINEAR_TEAM=TestTeam \
     CURL_PAYLOAD_LOG="$payload_log" \
     bash "$TMP_ROOT/.agents/skills/linear/scripts/linear.sh" issues add-relation "$@"
 }

--- a/skills/linear/tests/issues-archive-trash-entity-verify.test.sh
+++ b/skills/linear/tests/issues-archive-trash-entity-verify.test.sh
@@ -29,6 +29,9 @@ cp -R "$SKILL_DIR" "$TMP_ROOT/.agents/skills/linear"
 # Cache lives under the project root — make the tmp root a git repo
 git -C "$TMP_ROOT" init -q
 
+# Writes require a configured Linear team, as in any real project
+printf '[env]\nLINEAR_TEAM = "Fixture"\n' >"$TMP_ROOT/vstack.settings.toml"
+
 UUID="aaaaaaaa-bbbb-cccc-dddd-000000000042"
 URL="https://linear.app/test/issue/PROJ-42"
 

--- a/skills/linear/tests/issues-complete-summary.test.sh
+++ b/skills/linear/tests/issues-complete-summary.test.sh
@@ -54,7 +54,7 @@ run_complete() {
   shift 2
   : >"$payload_log"
   PATH="$TMP_ROOT/bin:$PATH" \
-    LINEAR_API_KEY=test-token \
+    LINEAR_API_KEY=test-token LINEAR_TEAM=TestTeam \
     CURL_PAYLOAD_LOG="$payload_log" \
     LINEAR_COMPLETE_TEST_CASE="$scenario" \
     bash "$TMP_ROOT/.agents/skills/linear/scripts/linear.sh" issues complete "$@"

--- a/skills/linear/tests/issues-description-file.test.sh
+++ b/skills/linear/tests/issues-description-file.test.sh
@@ -58,7 +58,7 @@ MD
 # --- create with --description-file --------------------------------------------
 create_log="$TMP_ROOT/create-payloads.jsonl"
 : >"$create_log"
-create_out="$(PATH="$TMP_ROOT/bin:$PATH" LINEAR_API_KEY=test-token CURL_PAYLOAD_LOG="$create_log" \
+create_out="$(PATH="$TMP_ROOT/bin:$PATH" LINEAR_API_KEY=test-token LINEAR_TEAM=TestTeam CURL_PAYLOAD_LOG="$create_log" \
   bash "$LINEAR" issues create --title "New task" --team Claude --description-file "$desc_file")"
 
 if ! jq -e '.success == true and .identifier == "PROJ-1"' >/dev/null <<<"$create_out"; then
@@ -82,7 +82,7 @@ fi
 # --- update with --description-file --------------------------------------------
 update_log="$TMP_ROOT/update-payloads.jsonl"
 : >"$update_log"
-update_out="$(PATH="$TMP_ROOT/bin:$PATH" LINEAR_API_KEY=test-token CURL_PAYLOAD_LOG="$update_log" \
+update_out="$(PATH="$TMP_ROOT/bin:$PATH" LINEAR_API_KEY=test-token LINEAR_TEAM=TestTeam CURL_PAYLOAD_LOG="$update_log" \
   bash "$LINEAR" issues update PROJ-1 --description-file "$desc_file")"
 
 if ! jq -e '.success == true' >/dev/null <<<"$update_out"; then
@@ -108,7 +108,7 @@ assert_fails() {
   local err_file="$TMP_ROOT/err.txt"
   local rc
   set +e
-  PATH="$TMP_ROOT/bin:$PATH" LINEAR_API_KEY=test-token \
+  PATH="$TMP_ROOT/bin:$PATH" LINEAR_API_KEY=test-token LINEAR_TEAM=TestTeam \
     bash "$LINEAR" "$@" >"$TMP_ROOT/out.txt" 2>"$err_file"
   rc=$?
   set -e

--- a/skills/linear/tests/issues-update-format-safe.test.sh
+++ b/skills/linear/tests/issues-update-format-safe.test.sh
@@ -47,7 +47,7 @@ chmod +x "$TMP_ROOT/bin/curl"
 LINEAR="$TMP_ROOT/.agents/skills/linear/scripts/linear.sh"
 
 run_update() {
-  PATH="$TMP_ROOT/bin:$PATH" LINEAR_API_KEY=test-token \
+  PATH="$TMP_ROOT/bin:$PATH" LINEAR_API_KEY=test-token LINEAR_TEAM=TestTeam \
     bash "$LINEAR" issues update "$@"
 }
 

--- a/skills/linear/tests/settings-example-sync.test.sh
+++ b/skills/linear/tests/settings-example-sync.test.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# The linear skill ships vstack.settings.toml.example so project installs merge
+# its keys' defaults. This keeps that template in lockstep with the repo-root
+# vstack.settings.toml.example: every key the skill template declares must exist
+# in BOTH files with IDENTICAL default values, so the two places users learn the
+# options can never drift.
+#
+# LINEAR_TEAM must stay empty in both: a non-empty placeholder would be a
+# guessed team name, and a guessed name resolves inside whatever workspace the
+# API key reaches.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_TEMPLATE="$SCRIPT_DIR/../vstack.settings.toml.example"
+ROOT_TEMPLATE="$SCRIPT_DIR/../../../vstack.settings.toml.example"
+
+fail=0
+
+note_fail() {
+  echo "FAIL: $1"
+  fail=1
+}
+
+value_of() {
+  # First uncommented assignment of key $2 in file $1, value only.
+  sed -n "s/^$2 = \"\(.*\)\"$/\1/p" "$1" | head -1
+}
+
+[ -f "$SKILL_TEMPLATE" ] || {
+  echo "FAIL: linear skill template missing"
+  exit 1
+}
+grep -q '^\[env\]' "$SKILL_TEMPLATE" || note_fail "skill template declares [env]"
+
+# Downstream installs ship the skill without the repo root template.
+[ -f "$ROOT_TEMPLATE" ] || {
+  echo "pass: settings-example-sync (no root template)"
+  exit 0
+}
+
+keys="$(sed -n 's/^\([A-Z][A-Z0-9_]*\) = .*/\1/p' "$SKILL_TEMPLATE")"
+[ -n "$keys" ] || note_fail "skill template declares at least one key"
+
+for key in $keys; do
+  if ! grep -q "^$key = " "$ROOT_TEMPLATE"; then
+    note_fail "$key present in root template"
+    continue
+  fi
+  skill_val="$(value_of "$SKILL_TEMPLATE" "$key")"
+  root_val="$(value_of "$ROOT_TEMPLATE" "$key")"
+  if [ "$skill_val" != "$root_val" ]; then
+    note_fail "$key default drift: skill='$skill_val' root='$root_val'"
+  fi
+done
+
+# The seeded target must never be a guessed team name.
+for template in "$SKILL_TEMPLATE" "$ROOT_TEMPLATE"; do
+  team_val="$(value_of "$template" "LINEAR_TEAM")"
+  if [ -n "$team_val" ]; then
+    note_fail "LINEAR_TEAM in $(basename "$(dirname "$template")")/$(basename "$template") seeds a team name ('$team_val'); it must be empty"
+  fi
+done
+
+# An unedited seed must stay fail-closed, so the key has to carry the reason.
+grep -B12 '^LINEAR_TEAM = ' "$SKILL_TEMPLATE" | grep -qi 'refuse' ||
+  note_fail "LINEAR_TEAM in the skill template explains that writes refuse without it"
+
+if [ "$fail" -ne 0 ]; then
+  echo "settings-example-sync: FAIL"
+  exit 1
+fi
+echo "pass: settings-example-sync"

--- a/skills/linear/tests/team-target-fail-closed.test.sh
+++ b/skills/linear/tests/team-target-fail-closed.test.sh
@@ -1,0 +1,319 @@
+#!/usr/bin/env bash
+# Regression test: the Linear CLI must never substitute a guessed team.
+#
+# A team name resolves inside whatever workspace LINEAR_API_KEY reaches, so a
+# hardcoded default silently targets another project's tracker. With no team
+# configured, writes must refuse before any API call, reads must drop the team
+# filter, and auth-check must report the target it would use.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+PROJECT="$TMP_ROOT/project"
+mkdir -p "$PROJECT/.agents/skills" "$PROJECT/bin"
+git -C "$PROJECT" init -q -b main
+cp -R "$SKILL_DIR" "$PROJECT/.agents/skills/linear"
+
+LINEAR="$PROJECT/.agents/skills/linear/scripts/linear.sh"
+CURL_LOG="$TMP_ROOT/curl-payloads.jsonl"
+ERR_FILE="$TMP_ROOT/stderr.txt"
+
+cat >"$PROJECT/bin/curl" <<'SH'
+#!/usr/bin/env bash
+config="$(cat)"
+payload="$(sed -n 's/^data = //p' <<<"$config" | jq -r)"
+printf '%s\n' "$payload" >>"${CURL_LOG:?}"
+query="$(jq -r '.query' <<<"$payload")"
+
+case "$query" in
+*"teams(filter:"*)
+  printf '%s' '{"data":{"teams":{"nodes":[{"id":"team-uuid"}]}}}___HTTP_CODE___200'
+  ;;
+*"viewer"*)
+  printf '%s' '{"data":{"viewer":{"id":"viewer-uuid"}}}___HTTP_CODE___200'
+  ;;
+*"issue(id:"*)
+  printf '%s' '{"data":{"issue":{"id":"issue-uuid"}}}___HTTP_CODE___200'
+  ;;
+*"issueCreate(input:"*)
+  printf '%s' '{"data":{"issueCreate":{"success":true,"issue":{"id":"issue-uuid","identifier":"TEAM-1","title":"t","description":"","state":{"name":"Todo","type":"unstarted"},"assignee":null,"project":null,"projectMilestone":null,"cycle":null,"parent":null,"team":{"name":"Explicit"},"labels":{"nodes":[]},"priority":3,"estimate":null,"sortOrder":1.0,"url":"https://linear.app/x/issue/TEAM-1","createdAt":"2026-07-30T00:00:00Z","updatedAt":"2026-07-30T00:00:00Z","archivedAt":null,"trashed":null,"relations":{"nodes":[]},"inverseRelations":{"nodes":[]}}}}}___HTTP_CODE___200'
+  ;;
+*"commentCreate(input:"*)
+  printf '%s' '{"data":{"commentCreate":{"success":true,"comment":{"id":"comment-uuid","body":"b","createdAt":"2026-07-30T00:00:00Z","user":{"name":"tester"}}}}}___HTTP_CODE___200'
+  ;;
+*"workflowStates(filter:"*)
+  printf '%s' '{"data":{"workflowStates":{"nodes":[]}}}___HTTP_CODE___200'
+  ;;
+*"cycles(filter:"*)
+  printf '%s' '{"data":{"cycles":{"nodes":[]}}}___HTTP_CODE___200'
+  ;;
+*"issues(filter:"*)
+  printf '%s' '{"data":{"issues":{"nodes":[]}}}___HTTP_CODE___200'
+  ;;
+*)
+  printf '%s' '{"data":{}}___HTTP_CODE___200'
+  ;;
+esac
+SH
+chmod +x "$PROJECT/bin/curl"
+
+OUT=""
+ERR=""
+RC=0
+
+fail() {
+  echo "FAIL $*"
+  [[ -s "$CURL_LOG" ]] && echo "--- curl payloads ---" && cat "$CURL_LOG"
+  exit 1
+}
+
+# Run the CLI inside the temp project with LINEAR_TEAM absent from the process
+# environment (parent env wins over project files, so it must be cleared).
+run_linear() {
+  : >"$CURL_LOG"
+  set +e
+  OUT="$(cd "$PROJECT" && env -u LINEAR_TEAM \
+    PATH="$PROJECT/bin:$PATH" \
+    LINEAR_API_KEY=test-token \
+    CURL_LOG="$CURL_LOG" \
+    bash "$LINEAR" "$@" 2>"$ERR_FILE")"
+  RC=$?
+  set -e
+  ERR="$(cat "$ERR_FILE")"
+}
+
+# Same, with LINEAR_TEAM exported by the caller.
+run_linear_env_team() {
+  local team="$1"
+  shift
+  : >"$CURL_LOG"
+  set +e
+  OUT="$(cd "$PROJECT" && env \
+    PATH="$PROJECT/bin:$PATH" \
+    LINEAR_API_KEY=test-token \
+    LINEAR_TEAM="$team" \
+    CURL_LOG="$CURL_LOG" \
+    bash "$LINEAR" "$@" 2>"$ERR_FILE")"
+  RC=$?
+  set -e
+  ERR="$(cat "$ERR_FILE")"
+}
+
+set_settings_team() {
+  printf '[env]\nLINEAR_TEAM = "%s"\n' "$1" >"$PROJECT/vstack.settings.toml"
+}
+
+clear_settings() {
+  rm -f "$PROJECT/vstack.settings.toml"
+}
+
+api_calls() {
+  wc -l <"$CURL_LOG" | tr -d ' '
+}
+
+assert_no_guessed_team() {
+  local label="$1"
+  jq -s -e 'all(.[]; (.variables | tostring | contains("team")) | not)' "$CURL_LOG" >/dev/null ||
+    fail "$label sent a team filter with no configured team: $(cat "$CURL_LOG")"
+  if grep -riq "claude" "$CURL_LOG"; then
+    fail "$label carried a guessed team name: $(cat "$CURL_LOG")"
+  fi
+}
+
+assert_refused() {
+  local label="$1"
+  [[ "$RC" -ne 0 ]] || fail "$label exited 0; expected a refusal. stdout: $OUT"
+  grep -q "No Linear team configured" <<<"$ERR" || fail "$label missing refusal message: $ERR"
+  grep -q "LINEAR_TEAM" <<<"$ERR" || fail "$label refusal does not name LINEAR_TEAM: $ERR"
+  grep -q "vstack.settings.toml" <<<"$ERR" || fail "$label refusal does not name vstack.settings.toml: $ERR"
+  grep -q -- "--team" <<<"$ERR" || fail "$label refusal does not mention --team: $ERR"
+  [[ "$(api_calls)" == "0" ]] || fail "$label attempted $(api_calls) API call(s) before refusing"
+}
+
+echo "=== writes refuse when no team is configured ==="
+
+clear_settings
+
+run_linear issues create --title "Cross-workspace write"
+assert_refused "issues create"
+
+run_linear issues update TEAM-1 --state Done
+assert_refused "issues update"
+
+run_linear issues complete TEAM-1
+assert_refused "issues complete"
+
+run_linear issues archive TEAM-1
+assert_refused "issues archive"
+
+run_linear issues add-relation TEAM-1 --blocks TEAM-2
+assert_refused "issues add-relation"
+
+run_linear comments create TEAM-1 --body "hello"
+assert_refused "comments create"
+
+run_linear projects create --name "New project"
+assert_refused "projects create"
+
+run_linear cycles create --start 2026-08-01 --end 2026-08-15
+assert_refused "cycles create"
+
+run_linear labels create --name backend
+assert_refused "labels create"
+
+run_linear milestones create --project P --name Alpha
+assert_refused "milestones create"
+
+run_linear initiatives create --name "Phase 1"
+assert_refused "initiatives create"
+
+echo "=== a blank configured value stays unset (seeded template is inert) ==="
+
+set_settings_team ""
+run_linear issues create --title "Blank team"
+assert_refused "issues create with blank LINEAR_TEAM"
+
+echo "=== help never needs a team target ==="
+
+run_linear issues create --help
+[[ "$RC" -eq 0 ]] || fail "issues create --help exited $RC: $ERR"
+grep -q "Create Options:" <<<"$OUT" || fail "issues create --help did not print help: $OUT"
+
+echo "=== explicit --team satisfies the requirement ==="
+
+clear_settings
+run_linear issues create --title "Explicit target" --team Explicit
+[[ "$RC" -eq 0 ]] || fail "issues create --team exited $RC: $ERR"
+jq -s -e 'any(.[]; (.query | contains("teams(filter:")) and .variables.name == "Explicit")' "$CURL_LOG" >/dev/null ||
+  fail "explicit --team was not used to resolve the team"
+jq -s -e 'any(.[]; (.query | contains("issueCreate")) and .variables.input.teamId == "team-uuid")' "$CURL_LOG" >/dev/null ||
+  fail "issueCreate did not carry the resolved team id"
+
+echo "=== configured LINEAR_TEAM proceeds ==="
+
+set_settings_team "Configured"
+run_linear issues create --title "Configured target"
+[[ "$RC" -eq 0 ]] || fail "issues create with configured team exited $RC: $ERR"
+jq -s -e 'any(.[]; (.query | contains("teams(filter:")) and .variables.name == "Configured")' "$CURL_LOG" >/dev/null ||
+  fail "configured LINEAR_TEAM was not used"
+
+run_linear comments create TEAM-1 --body "hello"
+[[ "$RC" -eq 0 ]] || fail "comments create with configured team exited $RC: $ERR"
+jq -s -e 'any(.[]; .query | contains("commentCreate"))' "$CURL_LOG" >/dev/null ||
+  fail "comments create did not reach the API with a configured team"
+
+echo "=== reads never send a guessed team ==="
+
+clear_settings
+
+run_linear statuses list
+[[ "$RC" -eq 0 ]] || fail "statuses list exited $RC: $ERR"
+assert_no_guessed_team "statuses list"
+
+run_linear cycles list --type current
+[[ "$RC" -eq 0 ]] || fail "cycles list exited $RC: $ERR"
+jq -s -e 'all(.[]; (.query | contains("teams(filter:")) | not)' "$CURL_LOG" >/dev/null ||
+  fail "cycles list resolved a team with no configured team"
+assert_no_guessed_team "cycles list"
+
+run_linear statuses get --name "In Progress"
+[[ "$RC" -eq 0 ]] || fail "statuses get exited $RC: $ERR"
+assert_no_guessed_team "statuses get"
+
+run_linear issues list --limit 5
+[[ "$RC" -eq 0 ]] || fail "issues list exited $RC: $ERR"
+assert_no_guessed_team "issues list"
+
+# The team filter is still applied when one is configured.
+set_settings_team "Configured"
+run_linear cycles list --type current
+[[ "$RC" -eq 0 ]] || fail "cycles list with configured team exited $RC: $ERR"
+jq -s -e 'any(.[]; (.query | contains("teams(filter:")) and .variables.name == "Configured")' "$CURL_LOG" >/dev/null ||
+  fail "cycles list did not resolve the configured team"
+jq -s -e 'any(.[]; .variables.filter.team.id.eq == "team-uuid")' "$CURL_LOG" >/dev/null ||
+  fail "cycles list did not scope to the configured team: $(cat "$CURL_LOG")"
+
+run_linear statuses list
+jq -s -e 'any(.[]; .variables.filter.team.name.eq == "Configured")' "$CURL_LOG" >/dev/null ||
+  fail "statuses list did not scope to the configured team: $(cat "$CURL_LOG")"
+clear_settings
+
+run_linear sync --full --no-attachments
+[[ "$(api_calls)" != "0" ]] || fail "sync issued no requests; the assertion below would be vacuous"
+assert_no_guessed_team "sync"
+jq -s -e 'any(.[]; .query | contains("SyncCycles"))' "$CURL_LOG" >/dev/null ||
+  fail "sync did not query cycles"
+
+set_settings_team "Configured"
+run_linear sync --full --no-attachments
+jq -s -e 'any(.[]; (.query | contains("SyncCycles")) and .variables.teamName == "Configured")' "$CURL_LOG" >/dev/null ||
+  fail "sync did not scope cycles to the configured team: $(cat "$CURL_LOG")"
+clear_settings
+
+echo "=== graphql_query refuses any mutation without a target ==="
+
+: >"$CURL_LOG"
+set +e
+backstop_err="$(cd "$PROJECT" && env -u LINEAR_TEAM \
+  PATH="$PROJECT/bin:$PATH" \
+  LINEAR_API_KEY=test-token \
+  CURL_LOG="$CURL_LOG" \
+  bash -c 'source .agents/skills/linear/scripts/lib/common.sh
+graphql_query "
+    mutation UnregisteredWrite(\$input: IssueCreateInput!) { issueCreate(input: \$input) { success } }" "{}"' 2>&1)"
+backstop_rc=$?
+set -e
+[[ "$backstop_rc" -ne 0 ]] || fail "graphql_query allowed a mutation with no team target"
+grep -q "No Linear team configured" <<<"$backstop_err" || fail "graphql_query refusal message missing: $backstop_err"
+[[ "$(api_calls)" == "0" ]] || fail "graphql_query issued a request before refusing"
+
+: >"$CURL_LOG"
+set +e
+(cd "$PROJECT" && env -u LINEAR_TEAM \
+  PATH="$PROJECT/bin:$PATH" \
+  LINEAR_API_KEY=test-token \
+  CURL_LOG="$CURL_LOG" \
+  bash -c 'source .agents/skills/linear/scripts/lib/common.sh
+graphql_query "query Ping { viewer { id } }" "{}"' >/dev/null 2>&1)
+read_rc=$?
+set -e
+[[ "$read_rc" -eq 0 ]] || fail "graphql_query blocked a read with no team target"
+[[ "$(api_calls)" == "1" ]] || fail "read query did not reach the API: $(api_calls) call(s)"
+
+echo "=== auth-check reports the target ==="
+
+clear_settings
+run_linear auth-check
+[[ "$RC" -eq 0 ]] || fail "auth-check exited $RC with a valid key: $ERR"
+jq -e '.ok == true and .team == null and .team_source == "unset" and .writes_enabled == false' <<<"$OUT" >/dev/null ||
+  fail "auth-check did not report an unresolved team: $OUT"
+jq -e '.api_key_source == "environment"' <<<"$OUT" >/dev/null ||
+  fail "auth-check did not attribute the API key to the environment: $OUT"
+jq -e '[.warnings[] | select(contains("LINEAR_TEAM"))] | length > 0' <<<"$OUT" >/dev/null ||
+  fail "auth-check did not warn about the missing team: $OUT"
+jq -e '[.warnings[] | select(contains("process environment"))] | length > 0' <<<"$OUT" >/dev/null ||
+  fail "auth-check did not flag the global key with no project team: $OUT"
+
+run_linear auth-check --strict
+[[ "$RC" -ne 0 ]] || fail "auth-check --strict exited 0 with no team configured: $OUT"
+
+set_settings_team "Configured"
+run_linear auth-check --strict
+[[ "$RC" -eq 0 ]] || fail "auth-check --strict exited $RC with a configured team: $OUT $ERR"
+jq -e '.team == "Configured" and .team_source == "project-config" and .writes_enabled == true and (.warnings | length) == 0' <<<"$OUT" >/dev/null ||
+  fail "auth-check did not report the configured team: $OUT"
+jq -e '.team_source_file == "vstack.settings.toml"' <<<"$OUT" >/dev/null ||
+  fail "auth-check did not name the file that set the team: $OUT"
+
+run_linear_env_team "EnvTeam" auth-check
+[[ "$RC" -eq 0 ]] || fail "auth-check exited $RC with an exported team: $ERR"
+jq -e '.team == "EnvTeam" and .team_source == "environment" and .writes_enabled == true' <<<"$OUT" >/dev/null ||
+  fail "auth-check did not report the exported team: $OUT"
+jq -e '[.warnings[] | select(contains("overrides the project value"))] | length > 0' <<<"$OUT" >/dev/null ||
+  fail "auth-check did not warn that the environment shadows project config: $OUT"
+
+echo "all pass"

--- a/skills/linear/tests/team-target-fail-closed.test.sh
+++ b/skills/linear/tests/team-target-fail-closed.test.sh
@@ -45,6 +45,15 @@ case "$query" in
 *"commentCreate(input:"*)
   printf '%s' '{"data":{"commentCreate":{"success":true,"comment":{"id":"comment-uuid","body":"b","createdAt":"2026-07-30T00:00:00Z","user":{"name":"tester"}}}}}___HTTP_CODE___200'
   ;;
+*"projectCreate(input:"*)
+  printf '%s' '{"data":{"projectCreate":{"success":true,"project":{"id":"project-uuid","name":"P","url":"https://linear.app/x/project/P","state":"planned"}}}}___HTTP_CODE___200'
+  ;;
+*"cycleCreate(input:"*)
+  printf '%s' '{"data":{"cycleCreate":{"success":true,"cycle":{"id":"cycle-uuid","number":1,"name":"C","startsAt":"2026-08-01T00:00:00Z","endsAt":"2026-08-15T00:00:00Z","team":{"name":"Explicit"}}}}}___HTTP_CODE___200'
+  ;;
+*"issueLabelCreate(input:"*)
+  printf '%s' '{"data":{"issueLabelCreate":{"success":true,"issueLabel":{"id":"label-uuid","name":"backend","color":"#fff","description":null,"isGroup":false,"team":null,"parent":null,"createdAt":"2026-07-30T00:00:00Z"}}}}___HTTP_CODE___200'
+  ;;
 *"workflowStates(filter:"*)
   printf '%s' '{"data":{"workflowStates":{"nodes":[]}}}___HTTP_CODE___200'
   ;;
@@ -119,6 +128,10 @@ assert_no_guessed_team() {
   local label="$1"
   jq -s -e 'all(.[]; (.variables | tostring | contains("team")) | not)' "$CURL_LOG" >/dev/null ||
     fail "$label sent a team filter with no configured team: $(cat "$CURL_LOG")"
+  # sync builds team scoping into the query document itself, where a variables-
+  # only check cannot see it.
+  jq -s -e 'all(.[]; (.query | test("team[[:space:]]*:")) | not)' "$CURL_LOG" >/dev/null ||
+    fail "$label inlined a team filter into the query document: $(cat "$CURL_LOG")"
   if grep -riq "claude" "$CURL_LOG"; then
     fail "$label carried a guessed team name: $(cat "$CURL_LOG")"
   fi
@@ -130,7 +143,10 @@ assert_refused() {
   grep -q "No Linear team configured" <<<"$ERR" || fail "$label missing refusal message: $ERR"
   grep -q "LINEAR_TEAM" <<<"$ERR" || fail "$label refusal does not name LINEAR_TEAM: $ERR"
   grep -q "vstack.settings.toml" <<<"$ERR" || fail "$label refusal does not name vstack.settings.toml: $ERR"
-  grep -q -- "--team" <<<"$ERR" || fail "$label refusal does not mention --team: $ERR"
+  grep -q -- "--team" <<<"$ERR" || fail "$label refusal does not name the per-call override: $ERR"
+  # The message may only offer --team where a parser actually accepts it.
+  grep -qE 'issues, projects, cycles, labels' <<<"$ERR" ||
+    fail "$label refusal offers --team without naming the actions that take it: $ERR"
   [[ "$(api_calls)" == "0" ]] || fail "$label attempted $(api_calls) API call(s) before refusing"
 }
 
@@ -171,6 +187,35 @@ assert_refused "milestones create"
 run_linear initiatives create --name "Phase 1"
 assert_refused "initiatives create"
 
+echo "=== free text is not a team target ==="
+
+# The guard must not read a team out of unparsed argv: a `--team` token in a
+# comment body or an issue title is ordinary user text, and honoring it would
+# let any write open its own gate.
+clear_settings
+
+run_linear comments create TEAM-1 --body "--team=CC"
+assert_refused "comments create with --team=CC as the body"
+
+run_linear comments create TEAM-1 --body "--team"
+assert_refused "comments create with a bare --team body"
+
+run_linear comments create TEAM-1 --body "see --team CC for context"
+assert_refused "comments create with --team inside prose"
+
+run_linear issues update TEAM-1 --title "--team" --state Done
+assert_refused "issues update with a bare --team title"
+
+run_linear issues update TEAM-1 --title "--team=CC" --state Done
+assert_refused "issues update with --team=CC as the title"
+
+run_linear issues create --title "--team=CC"
+assert_refused "issues create with --team=CC as the title"
+
+run_linear issues comment TEAM-1 --body "--team=CC"
+[[ "$RC" -ne 0 ]] || fail "issues comment redirect exited 0"
+[[ "$(api_calls)" == "0" ]] || fail "issues comment redirect issued $(api_calls) API call(s)"
+
 echo "=== a blank configured value stays unset (seeded template is inert) ==="
 
 set_settings_team ""
@@ -179,9 +224,17 @@ assert_refused "issues create with blank LINEAR_TEAM"
 
 echo "=== help never needs a team target ==="
 
+clear_settings
 run_linear issues create --help
 [[ "$RC" -eq 0 ]] || fail "issues create --help exited $RC: $ERR"
 grep -q "Create Options:" <<<"$OUT" || fail "issues create --help did not print help: $OUT"
+
+# `update` is guarded at the dispatcher, so its help path is the one that needs
+# the exemption.
+run_linear issues update --help
+[[ "$RC" -eq 0 ]] || fail "issues update --help exited $RC: $ERR"
+grep -q "Update Options:" <<<"$OUT" || fail "issues update --help did not print help: $OUT"
+[[ "$(api_calls)" == "0" ]] || fail "issues update --help issued an API call"
 
 echo "=== explicit --team satisfies the requirement ==="
 
@@ -205,6 +258,34 @@ run_linear comments create TEAM-1 --body "hello"
 [[ "$RC" -eq 0 ]] || fail "comments create with configured team exited $RC: $ERR"
 jq -s -e 'any(.[]; .query | contains("commentCreate"))' "$CURL_LOG" >/dev/null ||
   fail "comments create did not reach the API with a configured team"
+
+# Free text stays free text: a configured project still writes the body as-is.
+run_linear comments create TEAM-1 --body "--team=CC"
+[[ "$RC" -eq 0 ]] || fail "comments create with a --team-shaped body exited $RC: $ERR"
+jq -s -e 'any(.[]; (.query | contains("commentCreate")) and (.variables.input.body | startswith("--team=CC")))' "$CURL_LOG" >/dev/null ||
+  fail "comment body was not preserved verbatim: $(cat "$CURL_LOG")"
+
+# Every create action that parses --team resolves its target after parsing.
+clear_settings
+for create_case in "projects create --name P --team Explicit:projectCreate" \
+  "cycles create --start 2026-08-01 --end 2026-08-15 --team Explicit:cycleCreate" \
+  "labels create --name backend --team Explicit:issueLabelCreate"; do
+  args="${create_case%:*}"
+  op="${create_case##*:}"
+  # shellcheck disable=SC2086
+  run_linear $args
+  [[ "$RC" -eq 0 ]] || fail "$args exited $RC: $ERR"
+  jq -s -e --arg op "$op" 'any(.[]; .query | contains($op))' "$CURL_LOG" >/dev/null ||
+    fail "$args did not reach $op: $(cat "$CURL_LOG")"
+done
+
+# labels create takes an optional --team; with none passed it still needs a
+# configured target, and it must not invent a team scope for the label.
+set_settings_team "Configured"
+run_linear labels create --name backend
+[[ "$RC" -eq 0 ]] || fail "labels create with configured team exited $RC: $ERR"
+jq -s -e 'any(.[]; (.query | contains("issueLabelCreate")) and (.variables.input | has("teamId") | not))' "$CURL_LOG" >/dev/null ||
+  fail "labels create scoped the label to a team that was never requested: $(cat "$CURL_LOG")"
 
 echo "=== reads never send a guessed team ==="
 
@@ -313,7 +394,23 @@ run_linear_env_team "EnvTeam" auth-check
 [[ "$RC" -eq 0 ]] || fail "auth-check exited $RC with an exported team: $ERR"
 jq -e '.team == "EnvTeam" and .team_source == "environment" and .writes_enabled == true' <<<"$OUT" >/dev/null ||
   fail "auth-check did not report the exported team: $OUT"
+jq -e '.team_source_file == null' <<<"$OUT" >/dev/null ||
+  fail "auth-check named a project file for an environment-sourced team: $OUT"
 jq -e '[.warnings[] | select(contains("overrides the project value"))] | length > 0' <<<"$OUT" >/dev/null ||
   fail "auth-check did not warn that the environment shadows project config: $OUT"
+
+# An exported-but-empty LINEAR_TEAM wins over the project file (parent env
+# beats project config) and resolves to nothing. Attribution must say so
+# instead of naming a file that supplied nothing.
+run_linear_env_team "" auth-check
+[[ "$RC" -eq 0 ]] || fail "auth-check exited $RC with an exported empty team: $ERR"
+jq -e '.team == null and .team_source == "unset" and .team_source_file == null and .writes_enabled == false' <<<"$OUT" >/dev/null ||
+  fail "auth-check attribution is self-contradictory for an exported empty team: $OUT"
+jq -e '[.warnings[] | select(contains("exported as an empty value"))] | length > 0' <<<"$OUT" >/dev/null ||
+  fail "auth-check did not warn that an empty export shadows project config: $OUT"
+
+run_linear_env_team "" issues create --title "Empty export"
+assert_refused "issues create with an exported empty LINEAR_TEAM"
+clear_settings
 
 echo "all pass"

--- a/skills/linear/vstack.settings.toml.example
+++ b/skills/linear/vstack.settings.toml.example
@@ -1,0 +1,18 @@
+[env]
+
+# LINEAR — which Linear team this project writes to.
+# Project-scope `vstack add` / `vstack refresh` merge these defaults into
+# <project>/vstack.settings.toml (never overwriting existing keys). Full key
+# reference: linear README.md.
+
+# Used by: linear (every command). The team every write targets.
+# There is no built-in default. A team name resolves inside whatever workspace
+# LINEAR_API_KEY reaches, so an unset value means "no target": writes refuse
+# with an actionable error and reads drop the team filter instead of guessing.
+# Set this to the project's own team name, then confirm the target with
+# `linear.sh auth-check --strict`. An explicit `--team <name>` overrides it for
+# a single command.
+LINEAR_TEAM = ""
+
+# Used by: linear. Issue identifier prefix used in examples (e.g. PROJ-123).
+LINEAR_TEAM_PREFIX = "PROJ"

--- a/skills/linear/vstack.settings.toml.example
+++ b/skills/linear/vstack.settings.toml.example
@@ -10,8 +10,9 @@
 # LINEAR_API_KEY reaches, so an unset value means "no target": writes refuse
 # with an actionable error and reads drop the team filter instead of guessing.
 # Set this to the project's own team name, then confirm the target with
-# `linear.sh auth-check --strict`. An explicit `--team <name>` overrides it for
-# a single command.
+# `linear.sh auth-check --strict`. Only the create actions that take a team
+# (issues, projects, cycles, labels) accept `--team <name>` as a per-call
+# override; every other write needs this key.
 LINEAR_TEAM = ""
 
 # Used by: linear. Issue identifier prefix used in examples (e.g. PROJ-123).

--- a/skills/orch/references/gates.md
+++ b/skills/orch/references/gates.md
@@ -36,4 +36,6 @@ It is the merge-pr § 3.2 queue watch as one command — which is what makes it 
 
 ## `session-init` Linear auth
 
-`session-init --json` reports worktree Linear auth as the structured `linear_auth` object from `linear auth-check`. `linear_auth.error = "not installed"` is reserved for a missing Linear skill command; API key, 1Password, and API failures keep their original auth-check diagnostic.
+`session-init --json` reports worktree Linear auth as the structured `linear_auth` object from `linear auth-check`: `{ok, error?, team, team_source, team_source_file, api_key_source, writes_enabled, warnings}`. `linear_auth.error = "not installed"` is reserved for a missing Linear skill command; API key, 1Password, and API failures keep their original auth-check diagnostic.
+
+`ok` covers reachability only. `writes_enabled` is the write gate: it is `false` when no `LINEAR_TEAM` resolves, which the skill refuses to guess, so every Linear mutation fails until it is set. Read it with `has("writes_enabled")` rather than `//` — the alternative operator swallows a literal `false`. Linear-tracker workflows must check it up front, not discover it at the first write mid-run; `team_source` (`environment` | `project-config` | `unset`) and `warnings` say where the target came from and flag a machine-wide `LINEAR_API_KEY` paired with no project team.

--- a/skills/orch/scripts/session-init
+++ b/skills/orch/scripts/session-init
@@ -246,6 +246,9 @@ if [[ -n "$GIT_COMMON_DIR" && "$GIT_COMMON_DIR" != ".git" && "$GIT_COMMON_DIR" !
   WT_LINEAR=$(linear_auth_check 2>/dev/null || true)
   WT_LINEAR_OK=$(echo "$WT_LINEAR" | jq -r '.ok // false')
   WT_LINEAR_ERR=$(echo "$WT_LINEAR" | jq -r '.error // empty')
+  # Absent field (older/unavailable auth-check) must not raise a false alarm.
+  # `//` would also swallow a literal false, so test for the key instead.
+  WT_LINEAR_WRITES=$(echo "$WT_LINEAR" | jq -r 'if has("writes_enabled") then (.writes_enabled | tostring) else "true" end')
 
   if [[ "$OUTPUT_FORMAT" == "json" ]]; then
     jq -n \
@@ -271,6 +274,7 @@ if [[ -n "$GIT_COMMON_DIR" && "$GIT_COMMON_DIR" != ".git" && "$GIT_COMMON_DIR" !
     echo "GitHub: $GH_ICON · Linear: $LINEAR_ICON"
     [[ "$WT_GH_OK" != "true" ]] && echo "🔴 GitHub auth failed — run: gh auth login"
     [[ "$WT_LINEAR_OK" != "true" ]] && echo "🔴 Linear auth failed${WT_LINEAR_ERR:+ — $WT_LINEAR_ERR}"
+    [[ "$WT_LINEAR_OK" == "true" && "$WT_LINEAR_WRITES" != "true" ]] && echo "🟡 No Linear team configured — Linear writes refused. Set LINEAR_TEAM in vstack.settings.toml [env]"
   fi
   exit 0
 fi

--- a/skills/orch/tests/session_init.sh
+++ b/skills/orch/tests/session_init.sh
@@ -7,7 +7,8 @@ set -euo pipefail
 
 # The invoking shell's real auth env must not reach the cases below — token
 # and 1Password-resolution cases assert on exactly what each case injects.
-unset GH_TOKEN GITHUB_TOKEN GH_BOT_TOKEN LINEAR_API_KEY
+# LINEAR_TEAM included: the target-reporting cases assert on an unset team.
+unset GH_TOKEN GITHUB_TOKEN GH_BOT_TOKEN LINEAR_API_KEY LINEAR_TEAM
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$TEST_DIR/../../.." && pwd)"
@@ -56,6 +57,14 @@ echo 'fake op failure' >&2
 exit 1
 SH
 chmod +x "$STUB_BIN/op"
+
+# Cases using a plain key reach the API; op:// cases fail before any request.
+cat >"$STUB_BIN/curl" <<'SH'
+#!/usr/bin/env bash
+cat >/dev/null
+printf '%s' '{"data":{"viewer":{"id":"viewer-uuid"}}}___HTTP_CODE___200'
+SH
+chmod +x "$STUB_BIN/curl"
 
 cat >"$STUB_BIN/gh" <<'SH'
 #!/usr/bin/env bash
@@ -157,6 +166,53 @@ gh_available="$(jq -r '.gh_auth.available // false' <<<"$out")"
 gh_active="$(jq -r '.gh_auth.active_account // empty' <<<"$out")"
 assert_eq "$gh_available" "true" "dashboard GitHub auth accepts selected GITHUB_TOKEN"
 assert_eq "$gh_active" "test-user" "dashboard GitHub auth reports selected token account"
+
+echo "=== session-init Linear write-target reporting ==="
+
+# A reachable key with no configured team is the cross-workspace hazard: the
+# dashboard has to say so, and `writes_enabled: false` must survive the JSON
+# path (jq's `//` would swallow a literal false).
+WT_NO_TEAM="$(make_worktree wt-no-team yes)"
+printf 'LINEAR_API_KEY=lin_api_test\n' >"$WT_NO_TEAM/.env.local"
+out="$(
+  cd "$WT_NO_TEAM"
+  TEST_PROJECT_ROOT="$WT_NO_TEAM" PATH="$STUB_BIN:$PATH" "$SCRIPT" --json
+)"
+assert_eq "$(jq -r '.linear_auth.ok // false' <<<"$out")" "true" "reachable key reports ok=true"
+assert_eq "$(jq -r '.linear_auth.writes_enabled' <<<"$out")" "false" "no configured team reports writes_enabled=false"
+assert_eq "$(jq -r '.linear_auth.team_source' <<<"$out")" "unset" "no configured team reports team_source=unset"
+
+text_out="$(
+  cd "$WT_NO_TEAM"
+  TEST_PROJECT_ROOT="$WT_NO_TEAM" PATH="$STUB_BIN:$PATH" "$SCRIPT"
+)"
+if grep -q 'No Linear team configured' <<<"$text_out"; then
+  warned="true"
+else
+  warned="false"
+fi
+assert_eq "$warned" "true" "dashboard warns that Linear writes are refused"
+
+WT_TEAM="$(make_worktree wt-team yes)"
+printf 'LINEAR_API_KEY=lin_api_test\n' >"$WT_TEAM/.env.local"
+printf '[env]\nLINEAR_TEAM = "Configured"\n' >"$WT_TEAM/vstack.settings.toml"
+out="$(
+  cd "$WT_TEAM"
+  TEST_PROJECT_ROOT="$WT_TEAM" PATH="$STUB_BIN:$PATH" "$SCRIPT" --json
+)"
+assert_eq "$(jq -r '.linear_auth.team' <<<"$out")" "Configured" "configured team is reported"
+assert_eq "$(jq -r '.linear_auth.writes_enabled' <<<"$out")" "true" "configured team enables writes"
+
+text_out="$(
+  cd "$WT_TEAM"
+  TEST_PROJECT_ROOT="$WT_TEAM" PATH="$STUB_BIN:$PATH" "$SCRIPT"
+)"
+if grep -q 'No Linear team configured' <<<"$text_out"; then
+  warned="true"
+else
+  warned="false"
+fi
+assert_eq "$warned" "false" "dashboard stays quiet when a team is configured"
 
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/skills/orch/workflows/initialize.md
+++ b/skills/orch/workflows/initialize.md
@@ -34,7 +34,9 @@ Set up team, auth, cache, and workflow state for a worktree session.
    - Read `issue_id` from output; if empty, fall back to the sanitized branch name (replace `/` with `-`) for workflow-state and team naming.
    - Resolve `TRACKER` per [Tracker Resolution](../SKILL.md#tracker-resolution).
 
-2. **If `gh_auth` is false** → report error and fix before proceeding. **Linear only**: also require `linear_auth.ok`; GitHub work items do not need Linear auth.
+2. **If `gh_auth` is false** → report error and fix before proceeding. **Linear only**: also require `linear_auth.ok` and `linear_auth.writes_enabled`; GitHub work items do not need Linear auth.
+
+   `writes_enabled: false` means no `LINEAR_TEAM` is configured for this project, so every Linear write in this workflow will refuse — stop here and set it (`vstack.settings.toml` `[env]`, or `.env.local`) rather than syncing and failing at the first state change. Report `linear_auth.warnings` verbatim; they name the resolved target and its source.
 
 3. **Set `WORKTREE_PATH`** to current working directory.
 

--- a/vstack.settings.toml.example
+++ b/vstack.settings.toml.example
@@ -155,9 +155,10 @@ LINEAR_TEAM = ""
 # Used by: linear. The team every write targets - set it to this project's own
 # team. No default: a team name resolves inside whatever workspace
 # LINEAR_API_KEY reaches, so an empty value refuses Linear writes instead of
-# guessing a target (reads just drop the team filter). An explicit
-# `--team <name>` overrides it for one command. Confirm the resolved target
-# with `linear.sh auth-check --strict`.
+# guessing a target (reads just drop the team filter). Only the create actions
+# that take a team (issues, projects, cycles, labels) accept `--team <name>` as
+# a per-call override; every other write needs this key. Confirm the resolved
+# target with `linear.sh auth-check --strict`.
 
 LINEAR_FORMAT = "safe"
 # Used by: linear. Values: safe, table, ids, raw.

--- a/vstack.settings.toml.example
+++ b/vstack.settings.toml.example
@@ -151,8 +151,13 @@ DECISIONS_DIR = "docs/decisions"
 
 # LINEAR
 
-LINEAR_TEAM = "MyTeam"
-# Used by: linear.
+LINEAR_TEAM = ""
+# Used by: linear. The team every write targets - set it to this project's own
+# team. No default: a team name resolves inside whatever workspace
+# LINEAR_API_KEY reaches, so an empty value refuses Linear writes instead of
+# guessing a target (reads just drop the team filter). An explicit
+# `--team <name>` overrides it for one command. Confirm the resolved target
+# with `linear.sh auth-check --strict`.
 
 LINEAR_FORMAT = "safe"
 # Used by: linear. Values: safe, table, ids, raw.


### PR DESCRIPTION
Closes #965.

## Problem

`skills/linear/scripts/lib/common.sh` resolved its team target fail-open:

```sh
DEFAULT_TEAM="${LINEAR_TEAM:-Claude}"
```

A Linear team *name* resolves inside whatever workspace the `LINEAR_API_KEY` reaches, so the name alone guarantees nothing about the destination. On a machine with a box-global key, any project that never set `LINEAR_TEAM` silently wrote into a different project's workspace. Observed damage: 104 issues from one project created in another's tracker, then swept into its cycle metrics by that project's own triage automation.

## Change

**No guessed default.** Unset resolves to empty. Writes refuse; reads drop the team filter rather than substituting a name.

**Two enforcement layers.** A dispatcher guard (`linear_guard_write_action`) refuses a registered write action before any API call, and `graphql_query` refuses any document `linear_query_is_mutation` classifies as a mutation when no target resolves. The wire-level layer is the un-bypassable one — with the dispatcher fully disabled, all 39 write actions still send zero mutations.

**`--team` is owned by each command's parser.** The guard never searches argv. An earlier revision of this branch scanned unparsed arguments for `--team`, which let free text open its own gate — `comments create ID --body "--team=CC"` sent its mutation on a project with no configured team. The four write actions that accept `--team` (`issues`, `projects`, `cycles`, `labels` create) resolve and require the target immediately after their parse loop, still before any API call, and are omitted from the dispatcher list.

**Preflight.** `auth-check` gains `--strict` and reports `team`, `team_source`, `team_source_file`, `api_key_source`, `writes_enabled`, and `warnings`. `orch` gates on `linear_auth.writes_enabled` at initialization instead of discovering the problem at the first write mid-workflow.

**Settings template.** New `skills/linear/vstack.settings.toml.example` seeds `LINEAR_TEAM = ""` into a project's `vstack.settings.toml` on project-scope `add`/`refresh`. Empty is inert — it means "no target", not a fallback.

## Behavior change for existing projects

A project relying on the implicit `Claude` default loses Linear writes until `LINEAR_TEAM` is set. Projects that already configure it are unaffected. Unconfigured-project *reads* widen from team `Claude` to unfiltered.

## Boundary this does not cover

The gate proves a team is configured, not that a write lands in it. ID-addressed mutations are routed by the identifier, so a configured project handed a foreign identifier still acts on it. Stated plainly in `DEVELOPMENT.md` rather than overclaimed in README/SKILL.md.

## Validation

- `skills/linear/tests/*.sh` — 29 passed, 0 failed (3 new files).
- `skills/orch/tests/run-all.sh` — all 29 files passed.
- Reviewed by correctness, security, test, and doc reviewers. A 39-action sweep against a stubbed `curl` refused 39/39 with zero HTTP calls. Mutation testing confirmed the suite catches restoring the `Claude` default, neutering `linear_require_team_target`, neutering `linear_query_is_mutation`, and disabling the dispatcher guard.
- New code executed under real Bash 3.2.57: 19/19 pass.
- Maintainer repro of the argv hole, stubbed `curl`, no configured team:

```
comments create TEAM-1 --body "hello"                  rc=1  mutations=0
comments create TEAM-1 --body "--team=CC"              rc=1  mutations=0
issues update TEAM-1 --title "--team" --state Done     rc=1  mutations=0
comments create TEAM-1 --body hi --team CC             rc=1  mutations=0
issues create --title t --team SomeTeam                passes the gate
issues create --title t            (no team)           rc=1  mutations=0
comments create TEAM-1 --body hello  (LINEAR_TEAM set) proceeds
```
