### PR TITLE
fix(second-opinion): fall back to stdout for the failure cause block

### DIFF
--- a/skills/second-opinion/SKILL.md
+++ b/skills/second-opinion/SKILL.md
@@ -107,7 +107,7 @@ On script failure (non-zero exit), stderr contains a JSON error object:
 | 1 | CLI not found, missing prompt, invalid JSON response | Report error to user, suggest checking CLI installation |
 | 3 | `review`: derived diff scope is empty or invalid — nothing to review | Report; verify the worktree has committed/pending changes or pass an explicit `--range` |
 | 4 | `review`/`audit`: model self-reported no review was performed (`qa_metadata.review_performed: false`), omitted the required `qa_metadata` object, or stayed structurally incomplete after the one-shot retry (missing `verdict` or the `blockers`/`suggestions`/`questions` arrays) | Report; the response is preserved as `<output>.noreview.json` / `<output>.incomplete.json` — never treat it as a pass |
-| 5 | `review`/`audit`: the external CLI never produced a review — non-zero exit (quota, auth, network) or empty response on a zero exit. Distinct from 4: 4 is a model that answered unusably, 5 is a lane that never answered | Report; partial output is preserved as `<output>.failed.json` and the CLI's own error text is echoed on stderr |
+| 5 | `review`/`audit`: the external CLI never produced a review — non-zero exit (quota, auth, network) or empty response on a zero exit. Distinct from 4: 4 is a model that answered unusably, 5 is a lane that never answered | Report; partial output is preserved as `<output>.failed.json` and the CLI's own error text — from whichever stream it used, stderr or stdout — is echoed on stderr |
 | 124 | Timeout (default 300s) | Report timeout, suggest `--timeout` increase or narrower `--range` |
 
 If the script fails during the orch `review-pr` or `submit-pr` (local pre-PR review) workflows, **continue** — external review is advisory.

--- a/skills/second-opinion/scripts/second-opinion
+++ b/skills/second-opinion/scripts/second-opinion
@@ -463,10 +463,20 @@ run_target_cli() {
 preserve_cli_failure_and_fail() {
   local reason="$1"          # human-readable cause (e.g. "exited with code 2")
   local partial="${2:-}"     # captured stdout, may be empty
-  local sidecar cause=""
+  local sidecar cause="" cause_source=""
 
   # The CLI's own stderr is the authoritative cause (e.g. the quota message).
-  [[ -s "$STDERR_TMP" ]] && cause=$(head -20 "$STDERR_TMP")
+  # Some CLIs report the failure on stdout with an empty stderr — the Claude
+  # quota-limit message is the concrete case — which left the cause block empty
+  # and made a capped lane read as broken. Fall back to the tail of captured
+  # stdout so the reason surfaces whichever stream carried it.
+  if [[ -s "$STDERR_TMP" ]]; then
+    cause=$(head -20 "$STDERR_TMP")
+    cause_source="${TARGET_CLI} stderr"
+  elif [[ -n "$partial" ]]; then
+    cause=$(printf '%s\n' "$partial" | tail -20)
+    cause_source="${TARGET_CLI} stdout"
+  fi
 
   if [[ -n "$OUTPUT_PATH" ]]; then
     mkdir -p "$(dirname "$OUTPUT_PATH")"
@@ -475,15 +485,15 @@ preserve_cli_failure_and_fail() {
     sidecar=$(mktemp)
   fi
   jq -n --arg target "$TARGET_CLI" --arg reason "$reason" \
-        --arg cause "$cause" --arg stdout "$partial" \
-    '{error: "external CLI failed before producing a review", target: $target, reason: $reason, cause: $cause, partial_stdout: $stdout}' \
+        --arg cause "$cause" --arg cause_source "$cause_source" --arg stdout "$partial" \
+    '{error: "external CLI failed before producing a review", target: $target, reason: $reason, cause: $cause, cause_source: $cause_source, partial_stdout: $stdout}' \
     > "$sidecar"
 
   jq -n --arg target "$TARGET_CLI" --arg reason "$reason" --arg sidecar "$sidecar" \
     '{error: "\($target) \($reason) — refusing to write a review artifact", response: $sidecar}' >&2
   echo "→ external CLI failed: $TARGET_CLI $reason" >&2
   if [[ -n "$cause" ]]; then
-    echo "--- cause (${TARGET_CLI} stderr) ---" >&2
+    echo "--- cause (${cause_source}) ---" >&2
     printf '%s\n' "$cause" >&2
   fi
   echo "→ failed invocation preserved: $sidecar" >&2

--- a/skills/second-opinion/tests/cli-failure-gate.test.sh
+++ b/skills/second-opinion/tests/cli-failure-gate.test.sh
@@ -221,5 +221,23 @@ assert_eq "$rc5" "1" "quick-mode CLI failure keeps the generic exit 1"
 assert_file_absent "$s5_out.failed.json" "quick mode writes no .failed.json (review/audit-only contract)"
 
 echo
+
+# --- Scenario 6: failure reported on stdout with empty stderr ------------------
+# The Claude CLI prints its quota-limit message to stdout and exits non-zero with
+# an empty stderr. The cause block used to read only stderr, so it came out empty
+# and a capped lane was indistinguishable from a broken one. The cause now falls
+# back to the stdout tail, tagged as the stdout source.
+echo "=== scenario 6: non-zero exit, cause on stdout, empty stderr names the stdout cause ==="
+s6_out="$TMP_ROOT/out/review6.json"
+s6_err="$TMP_ROOT/s6.stderr"
+rc6=0
+STUB_RC=1 STUB_STDOUT="$QUOTA_ERR" STUB_STDERR="" run_review "$s6_out" "$s6_err" || rc6=$?
+assert_eq "$rc6" "5" "stdout-reported failure yields EXIT_CLI_FAILED (5)"
+assert_file_exists "$s6_out.failed.json" "stdout-reported failure preserves <output>.failed.json"
+assert_eq "$(jq -r '.cause_source' "$s6_out.failed.json")" "claude stdout" "sidecar tags the cause as the stdout source"
+assert_file_contains "$s6_out.failed.json" "hit your usage limit" "sidecar cause is populated from stdout, not empty"
+assert_file_contains "$s6_err" "hit your usage limit" "stderr surfaces the stdout-reported cause, not a bare code"
+assert_file_contains "$s6_err" "cause (claude stdout)" "printed cause block names the stdout source"
+
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Closes #973.

## Problem

`second-opinion`'s `preserve_cli_failure_and_fail` built its cause block by reading only the captured **stderr**. A CLI that reports failure on **stdout** with an empty stderr produced an empty cause block, so a quota-capped lane was indistinguishable from a broken one. The concrete case: the Claude CLI prints its weekly-limit message (`You've hit your weekly limit …`) to stdout and exits non-zero, stderr empty.

## Change

When stderr is empty on a non-zero exit, the cause falls back to the tail of captured stdout, tagged with a new `cause_source` field naming the stream it came from (`<target> stderr` / `<target> stdout`). The `.failed.json` sidecar already carried the full `partial_stdout`; the fix is that the operator-facing cause block and the sidecar `cause` field are now populated from it instead of coming up empty.

## Validation

- `skills/second-opinion/tests/cli-failure-gate.test.sh` — 29 pass (scenario 6 is new: non-zero exit, message on stdout, empty stderr → cause names the stdout source).
- Regression-proven: against the pre-fix script the 3 new cause-source assertions fail (the message was always in `partial_stdout`, so only the `cause`/`cause_source`/printed-block assertions distinguish fixed from broken).
- Full second-opinion suite: 7/7 files pass.
- `SKILL.md` exit-5 row updated to say the error text comes from whichever stream the CLI used.
