### PR TITLE
fix(orch): emit a shell-inert prose kickoff for codex handoffs

### DIFF
--- a/skills/orch/scripts/open-terminal
+++ b/skills/orch/scripts/open-terminal
@@ -131,13 +131,19 @@ start_cmd() {
     printf '%s\n' "$out"
     return
   fi
+  # The codex arms must stay plain prose built from shell-inert characters
+  # (letters, digits, space, ./#-): codex has no /orch slash command, and the
+  # composed line crosses at least one more quoting layer (e.g. an agent-confine
+  # wrapper) before the spawned window's shell runs it, so a `$` that has lost
+  # its single quotes gets expanded there and codex launches with no prompt at
+  # all (vstack#976).
   case "$TRACKER:$HARNESS" in
     linear:claude)   printf "claude -n %q --model 'opus[1m]' --effort max '/orch start %s'\n" "$item" "$item" ;;
-    linear:codex)    printf "codex '\$orch start %s'\n" "$item" ;;
+    linear:codex)    printf "codex 'Read .agents/skills/orch/SKILL.md and execute the orch start workflow for %s'\n" "$item" ;;
     linear:opencode) printf "opencode --prompt '/orch start %s'\n" "$item" ;;
     linear:pi)       printf "pi '/skill:orch start %s'\n" "$item" ;;
     github:claude)   printf "claude -n github-%q --model 'opus[1m]' --effort max '/orch start github %s#%s'\n" "$item" "$repo" "$item" ;;
-    github:codex)    printf "codex '\$orch start github %s#%s'\n" "$repo" "$item" ;;
+    github:codex)    printf "codex 'Read .agents/skills/orch/SKILL.md and execute the orch start workflow for github %s#%s'\n" "$repo" "$item" ;;
     github:opencode) printf "opencode --prompt '/orch start github %s#%s'\n" "$repo" "$item" ;;
     github:pi)       printf "pi '/skill:orch start github %s#%s'\n" "$repo" "$item" ;;
     *) echo "Error: unsupported harness: $HARNESS" >&2; exit 1 ;;

--- a/skills/orch/tests/open-terminal-codex-prompt.sh
+++ b/skills/orch/tests/open-terminal-codex-prompt.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# Regression tests for the codex kickoff prompt emitted by open-terminal.
+#
+# Bug (vstack#976): the codex arms emitted `codex '\$orch start <item>'`. The
+# composed line crosses another quoting layer (e.g. an agent-confine wrapper)
+# before the spawned window's shell runs it; once the single quotes were
+# consumed, fish expanded the bare `$orch` to empty and errored, so codex
+# launched with NO prompt argv and every fleet worker sat at an empty composer.
+# Codex also has no /orch slash command, so the arms must deliver a plain-prose
+# kickoff naming .agents/skills/orch/SKILL.md, built only from shell-inert
+# characters — no `$`, backtick, or anything else a downstream shell layer
+# could expand after one round of quote consumption.
+#
+# The test runs a byte-identical copy of open-terminal inside a temp git repo so
+# `git rev-parse --show-toplevel` resolves to a hermetic PROJECT_ROOT, stubs the
+# worktree CLI and gh, and stubs ghostty to capture the composed command it
+# would launch.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$TEST_DIR/.." && pwd)/scripts"
+SRC_OT="$SCRIPTS_DIR/open-terminal"
+SRC_LIB="$SCRIPTS_DIR/lib/vstack-env.sh"
+TMP_ROOT="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local got="$1" want="$2" name="$3"
+  if [[ "$got" == "$want" ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$name" "$want" "$got"
+  fi
+}
+
+assert_contains() {
+  local haystack="$1" needle="$2" name="$3"
+  if grep -qF -- "$needle" <<<"$haystack"; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        wanted substring: %s\n        in: %s\n' "$name" "$needle" "$haystack"
+  fi
+}
+
+assert_not_contains() {
+  local haystack="$1" needle="$2" name="$3"
+  if grep -qF -- "$needle" <<<"$haystack"; then
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        forbidden substring: %s\n        in: %s\n' "$name" "$needle" "$haystack"
+  else
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  fi
+}
+
+# Stub bin: ghostty captures its final argument — the composed `cd ... && codex
+# ...` command open_gui hands to `bash -lc` — into $OT_CAPTURE; gh exits 1 so
+# resolve_repo yields empty without touching the network (the github case
+# passes --repo explicitly).
+BIN="$TMP_ROOT/bin"
+mkdir -p "$BIN"
+cat > "$BIN/ghostty" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "${!#}" > "$OT_CAPTURE"
+exit 0
+EOF
+cat > "$BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+chmod +x "$BIN/ghostty" "$BIN/gh"
+
+# Stub worktree CLI: `create <item>` makes and prints a temp dir.
+STUB="$TMP_ROOT/worktree-stub"
+cat > "$STUB" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "\${1:-}" == "create" ]]; then
+  d="$TMP_ROOT/wt/\${2:-unknown}"
+  mkdir -p "\$d"
+  printf '%s\n' "\$d"
+  exit 0
+fi
+echo "unexpected worktree stub call: \$*" >&2
+exit 1
+EOF
+chmod +x "$STUB"
+
+# Temp git repo containing a copy of open-terminal + its lib, so the script's
+# PROJECT_ROOT resolves to this repo.
+REPO="$TMP_ROOT/repo"
+mkdir -p "$REPO/scripts/lib"
+cp "$SRC_OT" "$REPO/scripts/open-terminal"
+cp "$SRC_LIB" "$REPO/scripts/lib/vstack-env.sh"
+chmod +x "$REPO/scripts/open-terminal"
+git -C "$REPO" init -q
+OT="$REPO/scripts/open-terminal"
+
+# open_gui launches the (stubbed) terminal via `setsid ... &`, so the capture
+# file lands asynchronously after open-terminal itself has exited.
+wait_capture() {
+  local f="$1" i
+  for i in $(seq 1 50); do
+    [[ -s "$f" ]] && return 0
+    sleep 0.1
+  done
+  return 1
+}
+
+echo "=== open-terminal codex kickoff prompt ==="
+
+# Case 1: linear:codex — plain-prose kickoff carrying the item, with nothing a
+# downstream shell layer could expand.
+CAP1="$TMP_ROOT/cap1"
+set +e
+c1_out=$(OT_CAPTURE="$CAP1" PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness codex cc-737 2>"$TMP_ROOT/c1.err")
+c1_code=$?
+set -e
+assert_eq "$c1_code" "0" "linear:codex launch succeeds"
+if wait_capture "$CAP1"; then
+  c1_cmd="$(cat "$CAP1")"
+  assert_contains "$c1_cmd" "codex 'Read .agents/skills/orch/SKILL.md and execute the orch start workflow for CC-737'" \
+    "linear:codex emits the prose kickoff naming SKILL.md and the item"
+  assert_not_contains "$c1_cmd" '$' "linear:codex command contains no \$"
+  assert_not_contains "$c1_cmd" '`' "linear:codex command contains no backtick"
+else
+  FAIL=$((FAIL + 1))
+  printf '  FAIL  linear:codex never invoked the terminal stub\n'
+fi
+
+# Case 2: github:codex — same prose shape carrying repo#item.
+CAP2="$TMP_ROOT/cap2"
+set +e
+c2_out=$(OT_CAPTURE="$CAP2" PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tracker github --repo acme/widgets --ghostty --harness codex 42 2>"$TMP_ROOT/c2.err")
+c2_code=$?
+set -e
+assert_eq "$c2_code" "0" "github:codex launch succeeds"
+if wait_capture "$CAP2"; then
+  c2_cmd="$(cat "$CAP2")"
+  assert_contains "$c2_cmd" "codex 'Read .agents/skills/orch/SKILL.md and execute the orch start workflow for github acme/widgets#42'" \
+    "github:codex emits the prose kickoff carrying repo#item"
+  assert_not_contains "$c2_cmd" '$' "github:codex command contains no \$"
+  assert_not_contains "$c2_cmd" '`' "github:codex command contains no backtick"
+else
+  FAIL=$((FAIL + 1))
+  printf '  FAIL  github:codex never invoked the terminal stub\n'
+fi
+
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
open-terminal's codex arms emitted `codex '$orch start <item>'`. The composed line crosses another quoting layer (an agent-confine wrapper downstream) before the spawned tmux window's shell runs it; once the single quotes were consumed, fish expanded the bare `$orch` to empty and errored — codex launched with no prompt argv and every codex fleet worker sat at an empty composer (4/4 observed launches, one idled 5.5h). Codex also has no `/orch` slash command, so the literal prompt was wrong even when it survived.

Both codex arms (linear + github) now emit a plain-prose kickoff built only from shell-inert characters that names `.agents/skills/orch/SKILL.md` and the work item. Adds a regression test that captures the composed command via a ghostty stub and asserts it carries the item and contains no `$`/backtick.

Closes #976

https://claude.ai/code/session_01ReyxkK9aLisEvSxTQqzv3j