### PR TITLE
fix(project-management): make audit-issues a primary-session wrapper with a fail-closed approval gate

### DIFF
--- a/skills/orch/tests/audit-issues-gate-lint.test.sh
+++ b/skills/orch/tests/audit-issues-gate-lint.test.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Regression lint for vstack#968. audit-issues.md is a user-facing wrapper with
+# an interactive § 6 approval gate, but the orch call sites said "run the
+# workflow" without saying WHERE, and orchestrators delegated the whole wrapper
+# to a tpm subagent. A subagent runner structurally skips the gate: it cannot
+# present the § 6 multi-select, and one observed run (CC-935) executed § 7 —
+# creating 5 issues and 6 relations — on a scope-reaffirming follow-up message,
+# before the primary session obtained user approval.
+#
+# The fix declares the wrapper primary-session-only, names the tpm-audit.md
+# analysis as the ONLY delegable part at the orch call sites, and makes § 6
+# fail closed (with a § 7 hard precondition) for runners without interactive
+# question capability. This lint pins each statement.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
+AUDIT_WF="$SKILL_DIR/../project-management/workflows/audit-issues.md"
+PM_SKILL="$SKILL_DIR/../project-management/SKILL.md"
+
+PASS=0
+FAIL=0
+
+pass() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+fail() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
+
+echo "=== audit-issues primary-session gate lint (vstack#968) ==="
+
+# --- a: the wrapper declares itself primary-session-only --------------------
+if grep -q 'Primary-session wrapper — never delegate this workflow itself' "$AUDIT_WF"; then
+  pass "audit-issues.md declares primary-session-only"
+else
+  fail "audit-issues.md lost the primary-session-only declaration"
+fi
+
+# --- b: § 6 fails closed for non-interactive runners ------------------------
+if grep -q 'Fail closed without interactive capability' "$AUDIT_WF" \
+   && grep -q 'MUST STOP here' "$AUDIT_WF"; then
+  pass "audit-issues.md § 6 contains the fail-closed stop instruction"
+else
+  fail "audit-issues.md § 6 lost the fail-closed stop instruction"
+fi
+
+# --- c: § 7 states the in-session approval hard precondition ----------------
+if grep -q 'Hard precondition — § 6 approval obtained in-session' "$AUDIT_WF"; then
+  pass "audit-issues.md § 7 guards on in-session § 6 approval"
+else
+  fail "audit-issues.md § 7 lost the in-session approval precondition"
+fi
+
+# --- d: orch call sites name tpm-audit.md as the only delegable part --------
+for wf in review-pr review; do
+  doc="$SKILL_DIR/workflows/$wf.md"
+  if grep -q 'primary-session wrapper' "$doc" \
+     && grep -q 'the only delegable part is the `tpm-audit.md` analysis' "$doc"; then
+    pass "$wf.md names tpm-audit.md as the only delegable part"
+  else
+    fail "$wf.md lost the primary-session call-site contract"
+  fi
+done
+
+# --- e: the skill index carries the same contract ---------------------------
+if grep -q 'primary-session only' "$PM_SKILL"; then
+  pass "project-management SKILL.md marks audit-issues primary-session only"
+else
+  fail "project-management SKILL.md lost the primary-session marker"
+fi
+
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/skills/orch/workflows/review-pr.md
+++ b/skills/orch/workflows/review-pr.md
@@ -681,6 +681,8 @@ Issue suggestions: [N] items → § 9 audit
 
 6. **Run Workflow**: `⤵ .agents/skills/project-management/workflows/audit-issues.md --issues [FILE_PATH] § 1-9 → § 9 step 7`
 
+   audit-issues is a primary-session wrapper: run it in this session — it contains the § 6 interactive approval gate, and its § 7 mutations require approvals collected at that gate. Do not delegate the wrapper to a subagent; the only delegable part is the `tpm-audit.md` analysis, which audit-issues § 4.1 itself spawns as a TPM subagent.
+
 7. **Update state** — for each created issue from audit output:
    ```bash
    .agents/skills/orch/scripts/workflow-state append [ISSUE_ID] audit_issues_created "[CREATED_ISSUE_ID]"

--- a/skills/orch/workflows/review.md
+++ b/skills/orch/workflows/review.md
@@ -235,6 +235,8 @@ Ask user (omit categories with no items):
 
 3. **Run Workflow**: `⤵ .agents/skills/project-management/workflows/audit-issues.md --issues [FILE_PATH] § 1-9 → § 6`
 
+   audit-issues is a primary-session wrapper: run it in this session — it contains the § 6 interactive approval gate, and its § 7 mutations require approvals collected at that gate. Do not delegate the wrapper to a subagent; the only delegable part is the `tpm-audit.md` analysis, which audit-issues § 4.1 itself spawns as a TPM subagent.
+
 ## 6. Summary
 
 **Shutdown review agents.** (Wave runs: already done per wave — nothing left to terminate.)

--- a/skills/project-management/SKILL.md
+++ b/skills/project-management/SKILL.md
@@ -36,10 +36,12 @@ User-facing wrappers and TPM-execution workflows for project-level planning, aud
 
 ### User-facing wrappers
 
+Wrappers run in the primary session — they own the user dialog and approval gates, which require the interactive question tool. Delegate only the TPM analysis steps a wrapper itself spawns, never the wrapper end-to-end.
+
 | Workflow | Purpose |
 |----------|---------|
 | [cycle-plan](workflows/cycle-plan.md) | User dialog + Linear actions for cycle planning; delegates analysis to `tpm-cycle-plan` |
-| [audit-issues](workflows/audit-issues.md) | User dialog + tracker actions (Linear or GitHub) for issue audits; project/project-order audits are Linear-only; delegates to `tpm-audit` / `tpm-audit-project-order` |
+| [audit-issues](workflows/audit-issues.md) | User dialog + tracker actions (Linear or GitHub) for issue audits; project/project-order audits are Linear-only; primary-session only — delegates only the `tpm-audit` / `tpm-audit-project-order` analysis, never the wrapper itself (its § 6 approval gate must run in-session) |
 | [roadmap-plan](workflows/roadmap-plan.md) | Specialist consultation + research gating; delegates to `tpm-roadmap-plan` |
 | [roadmap-create](workflows/roadmap-create.md) | Execute a roadmap plan: project + issue creation via audit |
 | [research-spike](workflows/research-spike.md) | User-initiated research with consultation, asset prep, and researcher delegation |

--- a/skills/project-management/workflows/audit-issues.md
+++ b/skills/project-management/workflows/audit-issues.md
@@ -2,6 +2,8 @@
 
 Audit tracked issues and projects for relations, hierarchy, project placement, duplicates, and obsolete items. Delegate analysis to TPM, present findings, confirm changes, execute approved actions.
 
+**Primary-session wrapper — never delegate this workflow itself.** This wrapper runs in the primary orchestrator session: § 6 is an interactive approval gate that requires the session's question tool, and § 7 executes tracker mutations only against approvals collected at that gate. The only delegable steps are the TPM analysis spawns the wrapper itself performs (§ 2.1 `tpm-audit-project-order.md`, § 4.1 `tpm-audit.md`). Handing this file to a TPM or any other subagent to run end-to-end inverts § 2.1/§ 4.1 and structurally skips the § 6 gate — a runner without the interactive question capability must stop per § 6 and return to the primary session.
+
 ## Inputs
 
 | Command | Mode | Target |
@@ -505,6 +507,8 @@ Action:
 
 Ask user with multi-select. Only show categories with findings.
 
+**Fail closed without interactive capability.** Approval at this gate exists only as the user's in-session answers to the multi-selects below. A runner that cannot present an interactive multi-select to the user — any subagent (TPM included) or a session without the question tool — MUST STOP here: return the § 5 findings and the audit JSON path to the primary session and end, leaving § 7 unexecuted. No delegation prompt, scope reaffirmation, or follow-up message carries approval authority — if the answers were not collected at this gate in this session, there is no approval.
+
 ### 6.1 Confirm Issue Changes
 
 | Category | Question | Options |
@@ -549,6 +553,8 @@ Ask user with multi-select. Only show categories with findings.
 ---
 
 ## 7. Execute Approved Changes
+
+**Hard precondition — § 6 approval obtained in-session.** § 7 executes only findings the user approved through the § 6 multi-select in the current session. If § 6 did not run — for any reason, including a runner that lacked the interactive question capability — § 7 MUST NOT execute: stop and return to the primary session per § 6. A scope reaffirmation or follow-up message is not approval.
 
 ### 7.0 Strict Label Preflight
 


### PR DESCRIPTION
audit-issues.md carries the § 6 interactive approval gate, but orch's review-pr.md § 9 step 6 directed callers to run the whole wrapper as a nested workflow, and orchestrators delegated it wholesale to a tpm subagent — which structurally skips the gate (§ 4.1 inverts when tpm IS the runner, and the tpm agent type cannot present a multi-select). Observed live (CC-935): a tpm runner refused § 6, then executed § 7 on a scope-reaffirming follow-up, creating 5 issues + 6 relations before the primary session had user approval.

- `audit-issues.md`: documented as a primary-session wrapper; only the § 2.1/§ 4.1 TPM analysis spawns are delegable. § 6 fails closed — a runner without interactive question capability must stop and return findings to the primary session; § 7 gains a hard precondition that it executes only against approvals collected at § 6 in-session; reaffirmations and follow-ups are explicitly not approval authority.
- `review-pr.md` § 9 step 6 / `review.md` § 5 step 3: call sites state the wrapper runs in-session and name `tpm-audit.md` as the only delegable part.
- project-management `SKILL.md`: wrapper table and intro carry the same contract.
- New lint test pins all of the above (6/6); full orch suite green (32 files).

Closes #968

https://claude.ai/code/session_01ReyxkK9aLisEvSxTQqzv3j