### PR TITLE
fix(pi-claude-bridge): reuse sessions for follow-up batches and capture whole mid-query user runs

### DIFF
--- a/pi-extensions/pi-claude-bridge/CHANGELOG.md
+++ b/pi-extensions/pi-claude-bridge/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Consumer-impacting changes
 
+### 2.1.0
+
+- Delivering multiple queued Pi follow-ups in one call (steer-queue drain, `followUpMode="all"`) no longer forces a Claude session rebuild: the REUSE path now recognizes an unbounded trailing run of user messages, combines them into one prompt, and resumes the existing session — no session-file rewrite and no prompt-cache flush (vstack#963).
+- Mid-query queued follow-ups are no longer silently dropped: when Pi injects several user messages during an active query, the entire trailing run is captured for replay after the query instead of only the last message, and the session cursor only advances over messages actually captured. Anything skipped now emits a `deferred_user_replay_skipped` diagnostic instead of vanishing (vstack#967).
+- New exports: `planIncrementalPromptBatch(messages, cursor)` (REUSE-path prompt-batch planner) and `planDeferredUserReplay(messages)` (mid-query trailing-user-run capture plan).
+- `cc-session-io` dependency floor raised to 0.3.2 (content-block `addUserMessage` with empty-content guard; `importMessages` keeps non-tool_result blocks alongside tool results).
+
 ### 2.0.1
 
 - Claude Code's in-process meta-tools (`ToolSearch`, `ListMcpResources`, `ReadMcpResource`, `ScheduleWakeup`) are now classified as child-executed (`isChildExecutedTool`), matched by exact name. They no longer appear as Pi tool calls, no longer end the Pi turn, and no longer produce a `pendingResults` entry that the reaper later drops — the "dropped 1 tool result(s) whose handler never matched (ToolSearch)" warnings, the phantom failed tool calls, and the spurious pi-turn boundaries they caused are gone (vstack#980).

--- a/pi-extensions/pi-claude-bridge/bundle/index.js
+++ b/pi-extensions/pi-claude-bridge/bundle/index.js
@@ -43742,7 +43742,7 @@ function spawnClaudeCodeWithDiagnostics(options) {
   };
 }
 
-// node_modules/cc-session-io/dist/chunk-D6EZBJOC.js
+// node_modules/cc-session-io/dist/chunk-7RWUSC7F.js
 import { randomUUID } from "crypto";
 import { mkdirSync as mkdirSync4, writeFileSync as writeFileSync2, appendFileSync as appendFileSync3, existsSync as existsSync6, rmSync as rmSync2 } from "fs";
 import { dirname as dirname6 } from "path";
@@ -44000,13 +44000,16 @@ var Session = class {
     this._lastUuid = uuid3;
     return record2;
   }
-  /** Add a user text message. Returns its uuid. */
-  addUserMessage(text) {
+  /** Add a user message, as plain text or content blocks. Returns its uuid. */
+  addUserMessage(content) {
+    if (Array.isArray(content) && content.length === 0) {
+      throw new Error("addUserMessage: content array is empty; Anthropic rejects empty message content");
+    }
     const base = this.baseFields();
     const record2 = {
       type: "user",
       ...base,
-      message: { role: "user", content: text }
+      message: { role: "user", content }
     };
     this._pendingRecords.push(record2);
     return base.uuid;
@@ -44094,16 +44097,17 @@ var Session = class {
           const toolResults = msg.content.filter(
             (b) => b.type === "tool_result"
           );
+          const rest = msg.content.filter(
+            (b) => b.type !== "tool_result"
+          );
           if (toolResults.length > 0) {
             this.addToolResults(toolResults.map((r) => ({
               toolUseId: r.tool_use_id,
               content: r.content,
               isError: r.is_error
             })));
-          } else {
-            const text = msg.content.filter((b) => b.type === "text").map((b) => b.text).join("\n");
-            this.addUserMessage(text || JSON.stringify(msg.content));
           }
+          if (rest.length > 0) this.addUserMessage(rest);
         }
       }
     }
@@ -44402,6 +44406,22 @@ function convertAndImportMessages(session, messages, customToolNameToSdk, cwd) {
   }
   if (repaired.length) session.importMessages(repaired);
 }
+function planIncrementalPromptBatch(messages, cursor) {
+  const lastIndex = messages.length - 1;
+  if (lastIndex < 0 || messages[lastIndex].role !== "user") return void 0;
+  const boundedCursor = Math.max(0, Math.min(cursor, lastIndex));
+  let promptStart = boundedCursor;
+  if (messages[promptStart]?.role === "assistant") promptStart++;
+  const pendingPrompts = messages.slice(promptStart);
+  if (pendingPrompts.length === 0 || pendingPrompts.some((message) => message.role !== "user")) {
+    return void 0;
+  }
+  return {
+    cursorBeforeQuery: promptStart,
+    promptStart,
+    userMessageCount: pendingPrompts.length
+  };
+}
 function verifyWrittenSession2(jsonlPath, expectedSessionId, expectedRecordCount, cwd) {
   const warnings = verifyWrittenSession(jsonlPath, expectedSessionId, expectedRecordCount);
   for (const msg of warnings) {
@@ -44441,21 +44461,22 @@ function debugSessionPaths(label, cwd, jsonlPath) {
 function syncSharedSession(messages, cwd, customToolNameToSdk, modelId) {
   const priorMessages = messages.slice(0, -1);
   if (sharedSession && !sharedSession.needsRebuild) {
-    const missed = priorMessages.slice(sharedSession.cursor);
-    const trailingAssistantOnly = missed.length === 1 && missed[0].role === "assistant";
-    if (missed.length === 0 || trailingAssistantOnly) {
-      if (trailingAssistantOnly) {
-        setSharedSession({ ...sharedSession, cursor: priorMessages.length, cwd });
-      }
-      debug(`Case 3: ${trailingAssistantOnly ? "advanced cursor past trailing assistant, " : ""}resuming session ${sharedSession.sessionId.slice(0, 8)}, cursor=${sharedSession.cursor}`);
-      debug(`syncResult: path=reuse sessionId=${sharedSession.sessionId} cursor=${sharedSession.cursor}`);
-      return { sessionId: sharedSession.sessionId };
+    const batch = planIncrementalPromptBatch(messages, sharedSession.cursor);
+    if (batch) {
+      setSharedSession({ ...sharedSession, cursor: batch.cursorBeforeQuery, cwd });
+      const batching = batch.userMessageCount > 1 ? `batched ${batch.userMessageCount} consecutive user messages, ` : batch.cursorBeforeQuery > sharedSession.cursor ? "advanced cursor past trailing assistant, " : "";
+      debug(`Case 3: ${batching}resuming session ${sharedSession.sessionId.slice(0, 8)}, cursor=${batch.cursorBeforeQuery}`);
+      debug(`syncResult: path=reuse sessionId=${sharedSession.sessionId} cursor=${batch.cursorBeforeQuery} promptUsers=${batch.userMessageCount}`);
+      return {
+        sessionId: sharedSession.sessionId,
+        promptMessages: messages.slice(batch.promptStart)
+      };
     }
   }
   if (priorMessages.length === 0) {
     debug(`Case 1: clean start, ${messages.length} total messages`);
     debug(`syncResult: path=clean-start`);
-    return { sessionId: null };
+    return { sessionId: null, promptMessages: messages.slice(-1) };
   }
   const previousSessionId = sharedSession?.sessionId;
   const previousCursor = sharedSession?.cursor ?? 0;
@@ -44483,7 +44504,7 @@ function syncSharedSession(messages, cwd, customToolNameToSdk, modelId) {
   }
   debugSessionPaths(`${session.sessionId.slice(0, 8)}`, cwd, session.jsonlPath);
   debug(`syncResult: path=rebuild sessionId=${session.sessionId} priors=${priorMessages.length} ${previousSessionId === void 0 ? "first" : preserveId ? "preserved" : "rotated-post-abort"}`);
-  return { sessionId: session.sessionId };
+  return { sessionId: session.sessionId, promptMessages: messages.slice(-1) };
 }
 
 // src/stream-idle-watchdog.ts
@@ -45167,39 +45188,42 @@ function extractAllToolResults2(context) {
   return results;
 }
 function extractUserPrompt(messages) {
-  const last = messages[messages.length - 1];
-  if (!last || last.role !== "user") return null;
-  if (typeof last.content === "string") return last.content;
-  return messageContentToText(last.content) || "";
+  if (messages.length === 0 || messages.some((message) => message.role !== "user")) return null;
+  return messages.map(
+    (message) => typeof message.content === "string" ? message.content : messageContentToText(message.content) || ""
+  ).join("\n\n");
 }
 function extractUserPromptBlocks(messages) {
-  const last = messages[messages.length - 1];
-  if (!last || last.role !== "user") return null;
-  if (typeof last.content === "string") {
-    debug(`extractUserPromptBlocks: content is string (length=${last.content.length})`);
-    return null;
-  }
-  if (!Array.isArray(last.content)) {
-    debug(`extractUserPromptBlocks: content is ${typeof last.content}`);
-    return null;
-  }
-  debug(`extractUserPromptBlocks: ${last.content.length} blocks, types=${last.content.map((b) => b.type).join(",")}`);
+  if (messages.length === 0 || messages.some((message) => message.role !== "user")) return null;
   let hasImage = false;
   const blocks = [];
-  for (const block of last.content) {
-    if (block.type === "text" && block.text) {
-      blocks.push({ type: "text", text: block.text });
-    } else if (block.type === "image") {
-      debug(`image block: mimeType=${block.mimeType}, data length=${(block.data ?? "").length}, keys=${Object.keys(block).join(",")}`);
-      if (!block.data || !block.mimeType) {
-        debug(`image block missing data or mimeType, skipping`);
-        continue;
+  for (let messageIndex = 0; messageIndex < messages.length; messageIndex++) {
+    const content = messages[messageIndex].content;
+    if (messageIndex > 0) blocks.push({ type: "text", text: "\n\n" });
+    if (typeof content === "string") {
+      if (content) blocks.push({ type: "text", text: content });
+      continue;
+    }
+    if (!Array.isArray(content)) {
+      debug(`extractUserPromptBlocks: content is ${typeof content}`);
+      continue;
+    }
+    debug(`extractUserPromptBlocks: ${content.length} blocks, types=${content.map((b) => b.type).join(",")}`);
+    for (const block of content) {
+      if (block.type === "text" && block.text) {
+        blocks.push({ type: "text", text: block.text });
+      } else if (block.type === "image") {
+        debug(`image block: mimeType=${block.mimeType}, data length=${(block.data ?? "").length}, keys=${Object.keys(block).join(",")}`);
+        if (!block.data || !block.mimeType) {
+          debug(`image block missing data or mimeType, skipping`);
+          continue;
+        }
+        hasImage = true;
+        blocks.push({
+          type: "image",
+          source: { type: "base64", media_type: block.mimeType, data: block.data }
+        });
       }
-      hasImage = true;
-      blocks.push({
-        type: "image",
-        source: { type: "base64", media_type: block.mimeType, data: block.data }
-      });
     }
   }
   return hasImage ? blocks : null;
@@ -45521,7 +45545,7 @@ function streamClaudeAgentSdk(model, context, options) {
       piUI?.notify(`Claude bridge: ${queryCtx.pendingToolCalls.size} tool handler(s) still waiting \u2014 provider may be stuck`, "warning");
     }
     if (lastMsgRole === "user") {
-      const userPrompt = extractUserPrompt(context.messages);
+      const userPrompt = extractUserPrompt(context.messages.slice(-1));
       if (userPrompt) {
         ctx().deferredUserMessages.push(userPrompt);
         debug(`provider: deferred user message for replay after query: ${userPrompt.slice(0, 60)}`);
@@ -45585,8 +45609,9 @@ function streamClaudeAgentSdk(model, context, options) {
   ctx().resetToolTracking();
   ctx().latestCursor = 0;
   const { mcpTools, customToolNameToSdk, customToolNameToPi } = resolveMcpTools(context);
-  const promptBlocks = extractUserPromptBlocks(context.messages);
-  let promptText = extractUserPrompt(context.messages) ?? "";
+  const { sessionId: resumeSessionId, promptMessages } = syncSharedSession(context.messages, cwd, customToolNameToSdk, model.id);
+  const promptBlocks = extractUserPromptBlocks(promptMessages);
+  let promptText = extractUserPrompt(promptMessages) ?? "";
   if (!promptText && !promptBlocks) {
     diagDump("empty_prompt", {
       contextLength: context.messages.length,
@@ -45616,7 +45641,6 @@ function streamClaudeAgentSdk(model, context, options) {
   const strictMcpConfigEnabled = !appendSystemPrompt && providerSettings.strictMcpConfig !== false;
   const claudeExecutable = resolveClaudeExecutable(providerSettings.pathToClaudeCodeExecutable);
   const claudeExecutablePreflight = claudeExecutable ? preflightClaudeExecutable(claudeExecutable, cwd) : void 0;
-  const { sessionId: resumeSessionId } = syncSharedSession(context.messages, cwd, customToolNameToSdk, model.id);
   const requestedEffort = options?.reasoning ? model.thinkingLevelMap?.[options.reasoning] ?? REASONING_TO_EFFORT[options.reasoning] : void 0;
   const effort = resolveConfiguredEffort(model.id, requestedEffort, providerSettings);
   const extraArgs = {};
@@ -46059,6 +46083,7 @@ export {
   mapToolName,
   normalizeRateLimitUtilization,
   noteChildExecutedToolResults,
+  planIncrementalPromptBatch,
   preflightClaudeExecutable,
   primeConnectorServers,
   processAssistantMessage,

--- a/pi-extensions/pi-claude-bridge/bundle/index.js
+++ b/pi-extensions/pi-claude-bridge/bundle/index.js
@@ -44414,10 +44414,10 @@ function planIncrementalPromptBatch(messages, cursor) {
   if (messages[promptStart]?.role === "assistant") promptStart++;
   const pendingPrompts = messages.slice(promptStart);
   if (pendingPrompts.length === 0 || pendingPrompts.some((message) => message.role !== "user")) {
+    debug(`planIncrementalPromptBatch: rejected \u2014 cursor=${cursor} promptStart=${promptStart} tail roles=[${messages.slice(boundedCursor).map((m) => m.role).join(", ")}]`);
     return void 0;
   }
   return {
-    cursorBeforeQuery: promptStart,
     promptStart,
     userMessageCount: pendingPrompts.length
   };
@@ -44463,20 +44463,20 @@ function syncSharedSession(messages, cwd, customToolNameToSdk, modelId) {
   if (sharedSession && !sharedSession.needsRebuild) {
     const batch = planIncrementalPromptBatch(messages, sharedSession.cursor);
     if (batch) {
-      setSharedSession({ ...sharedSession, cursor: batch.cursorBeforeQuery, cwd });
-      const batching = batch.userMessageCount > 1 ? `batched ${batch.userMessageCount} consecutive user messages, ` : batch.cursorBeforeQuery > sharedSession.cursor ? "advanced cursor past trailing assistant, " : "";
-      debug(`Case 3: ${batching}resuming session ${sharedSession.sessionId.slice(0, 8)}, cursor=${batch.cursorBeforeQuery}`);
-      debug(`syncResult: path=reuse sessionId=${sharedSession.sessionId} cursor=${batch.cursorBeforeQuery} promptUsers=${batch.userMessageCount}`);
+      setSharedSession({ ...sharedSession, cursor: batch.promptStart, cwd });
+      const batching = batch.userMessageCount > 1 ? `batched ${batch.userMessageCount} consecutive user messages, ` : batch.promptStart > sharedSession.cursor ? "advanced cursor past trailing assistant, " : "";
+      debug(`Case 3: ${batching}resuming session ${sharedSession.sessionId.slice(0, 8)}, cursor=${batch.promptStart}`);
+      debug(`syncResult: path=reuse sessionId=${sharedSession.sessionId} cursor=${batch.promptStart} promptUsers=${batch.userMessageCount}`);
       return {
         sessionId: sharedSession.sessionId,
-        promptMessages: messages.slice(batch.promptStart)
+        promptStart: batch.promptStart
       };
     }
   }
   if (priorMessages.length === 0) {
     debug(`Case 1: clean start, ${messages.length} total messages`);
     debug(`syncResult: path=clean-start`);
-    return { sessionId: null, promptMessages: messages.slice(-1) };
+    return { sessionId: null, promptStart: messages.length - 1 };
   }
   const previousSessionId = sharedSession?.sessionId;
   const previousCursor = sharedSession?.cursor ?? 0;
@@ -44504,7 +44504,7 @@ function syncSharedSession(messages, cwd, customToolNameToSdk, modelId) {
   }
   debugSessionPaths(`${session.sessionId.slice(0, 8)}`, cwd, session.jsonlPath);
   debug(`syncResult: path=rebuild sessionId=${session.sessionId} priors=${priorMessages.length} ${previousSessionId === void 0 ? "first" : preserveId ? "preserved" : "rotated-post-abort"}`);
-  return { sessionId: session.sessionId, promptMessages: messages.slice(-1) };
+  return { sessionId: session.sessionId, promptStart: messages.length - 1 };
 }
 
 // src/stream-idle-watchdog.ts
@@ -45228,6 +45228,17 @@ function extractUserPromptBlocks(messages) {
   }
   return hasImage ? blocks : null;
 }
+function planDeferredUserReplay(messages) {
+  let runStart = messages.length;
+  while (runStart > 0 && messages[runStart - 1]?.role === "user") runStart--;
+  const trailingUsers = messages.slice(runStart);
+  const prompt = trailingUsers.length > 0 ? extractUserPrompt(trailingUsers) : null;
+  return {
+    runStart,
+    userMessageCount: trailingUsers.length,
+    prompt: prompt?.trim() ? prompt : null
+  };
+}
 async function* wrapPromptStream(blocks) {
   yield {
     type: "user",
@@ -45544,15 +45555,24 @@ function streamClaudeAgentSdk(model, context, options) {
       debug(`WARNING: ${queryCtx.pendingToolCalls.size} MCP handlers still waiting after delivering ${allResults.length} results`);
       piUI?.notify(`Claude bridge: ${queryCtx.pendingToolCalls.size} tool handler(s) still waiting \u2014 provider may be stuck`, "warning");
     }
+    let capturedThrough = context.messages.length;
     if (lastMsgRole === "user") {
-      const userPrompt = extractUserPrompt(context.messages.slice(-1));
-      if (userPrompt) {
-        ctx().deferredUserMessages.push(userPrompt);
-        debug(`provider: deferred user message for replay after query: ${userPrompt.slice(0, 60)}`);
+      const replay = planDeferredUserReplay(context.messages);
+      if (replay.prompt) {
+        ctx().deferredUserMessages.push(replay.prompt);
+        debug(`provider: deferred ${replay.userMessageCount} user message(s) for replay after query: ${replay.prompt.slice(0, 60)}`);
+      } else {
+        capturedThrough = replay.runStart;
+        diagDump("deferred_user_replay_skipped", {
+          contextLength: context.messages.length,
+          runStart: replay.runStart,
+          userMessageCount: replay.userMessageCount,
+          messageRoles: context.messages.map((m, i) => `[${i}]${m.role}`).join(" ")
+        });
       }
     }
-    if (sharedSession) sharedSession.cursor = context.messages.length;
-    queryCtx.latestCursor = Math.max(queryCtx.latestCursor, context.messages.length);
+    if (sharedSession) sharedSession.cursor = capturedThrough;
+    queryCtx.latestCursor = Math.max(queryCtx.latestCursor, capturedThrough);
     return stream;
   }
   const lastMsg = context.messages[context.messages.length - 1];
@@ -45609,16 +45629,25 @@ function streamClaudeAgentSdk(model, context, options) {
   ctx().resetToolTracking();
   ctx().latestCursor = 0;
   const { mcpTools, customToolNameToSdk, customToolNameToPi } = resolveMcpTools(context);
-  const { sessionId: resumeSessionId, promptMessages } = syncSharedSession(context.messages, cwd, customToolNameToSdk, model.id);
+  const bridgeConfig = loadConfig(cwd);
+  const providerSettings = bridgeConfig.provider ?? {};
+  const claudeExecutable = resolveClaudeExecutable(providerSettings.pathToClaudeCodeExecutable);
+  const claudeExecutablePreflight = claudeExecutable ? preflightClaudeExecutable(claudeExecutable, cwd) : void 0;
+  const cursorBeforeSync = sharedSession?.cursor ?? null;
+  const { sessionId: resumeSessionId, promptStart } = syncSharedSession(context.messages, cwd, customToolNameToSdk, model.id);
+  const promptMessages = context.messages.slice(promptStart);
   const promptBlocks = extractUserPromptBlocks(promptMessages);
   let promptText = extractUserPrompt(promptMessages) ?? "";
-  if (!promptText && !promptBlocks) {
+  if (!promptText.trim() && !promptBlocks) {
     diagDump("empty_prompt", {
       contextLength: context.messages.length,
       lastMsgRole: lastMsg?.role,
       isReentrant,
       stackDepth: stackDepth(),
       activeQueryExists: ctx().activeQuery !== null,
+      cursorBeforeSync,
+      promptStart,
+      promptRoles: promptMessages.map((m) => m.role).join(" "),
       sharedSession: sharedSession ? { sessionId: sharedSession.sessionId.slice(0, 8), cursor: sharedSession.cursor } : null,
       messageRoles: context.messages.map((m, i) => `[${i}]${m.role}`).join(" ")
     });
@@ -45626,8 +45655,6 @@ function streamClaudeAgentSdk(model, context, options) {
   }
   const prompt = promptBlocks ? wrapPromptStream(promptBlocks) : promptText;
   const mcpServers = buildMcpServers(mcpTools, ctx());
-  const bridgeConfig = loadConfig(cwd);
-  const providerSettings = bridgeConfig.provider ?? {};
   const enableCloudMcp = connectorsEnabledFor(bridgeConfig);
   const connectorWriteMode = connectorWriteModeFor(bridgeConfig);
   const connectorServers = enableCloudMcp ? connectorServersSnapshot() : {};
@@ -45639,8 +45666,6 @@ function streamClaudeAgentSdk(model, context, options) {
   const systemPromptAppend = appendParts.length > 0 ? appendParts.join("\n\n") : void 0;
   const settingSources = enableCloudMcp ? providerSettings.settingSources ?? ["user", "project", "local"] : appendSystemPrompt ? void 0 : providerSettings.settingSources ?? ["user", "project"];
   const strictMcpConfigEnabled = !appendSystemPrompt && providerSettings.strictMcpConfig !== false;
-  const claudeExecutable = resolveClaudeExecutable(providerSettings.pathToClaudeCodeExecutable);
-  const claudeExecutablePreflight = claudeExecutable ? preflightClaudeExecutable(claudeExecutable, cwd) : void 0;
   const requestedEffort = options?.reasoning ? model.thinkingLevelMap?.[options.reasoning] ?? REASONING_TO_EFFORT[options.reasoning] : void 0;
   const effort = resolveConfiguredEffort(model.id, requestedEffort, providerSettings);
   const extraArgs = {};
@@ -46083,6 +46108,7 @@ export {
   mapToolName,
   normalizeRateLimitUtilization,
   noteChildExecutedToolResults,
+  planDeferredUserReplay,
   planIncrementalPromptBatch,
   preflightClaudeExecutable,
   primeConnectorServers,

--- a/pi-extensions/pi-claude-bridge/package-lock.json
+++ b/pi-extensions/pi-claude-bridge/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@vanillagreen/pi-claude-bridge",
-  "version": "1.11.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vanillagreen/pi-claude-bridge",
-      "version": "1.11.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.220",
         "@anthropic-ai/sdk": "^0.112.4",
-        "cc-session-io": "^0.3.1",
+        "cc-session-io": "^0.3.2",
         "change-case": "^5.4.4"
       },
       "devDependencies": {
@@ -26,8 +26,8 @@
         "node": ">=22.19.0"
       },
       "peerDependencies": {
-        "@earendil-works/pi-ai": "*",
-        "@earendil-works/pi-coding-agent": "*"
+        "@earendil-works/pi-ai": ">=0.81.0",
+        "@earendil-works/pi-coding-agent": ">=0.81.0"
       },
       "peerDependenciesMeta": {
         "@earendil-works/pi-ai": {
@@ -1973,9 +1973,9 @@
       }
     },
     "node_modules/cc-session-io": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cc-session-io/-/cc-session-io-0.3.1.tgz",
-      "integrity": "sha512-FPswREdPLqetYkmdUTF36NVGzjyrhUJ8PzP9wLraoL/54q9Q72dHC8PCc/OhF/bH3n0M5iO/2SRGfMwZZZaDgQ==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/cc-session-io/-/cc-session-io-0.3.2.tgz",
+      "integrity": "sha512-fPbR5g8s3OAhZV4ToOb4qFwtNvbLztL7P/J6kK1OENNbnMsWiNNxso0IcDOtAkLL939ZGKGFqGDIbLRfULvEFQ==",
       "license": "MIT",
       "bin": {
         "cc-session": "dist/cli.js"

--- a/pi-extensions/pi-claude-bridge/package.json
+++ b/pi-extensions/pi-claude-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vanillagreen/pi-claude-bridge",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Pi provider bridge that runs Claude Code through the Claude Agent SDK, with opt-in forwarding for Pi prompt context.",
   "type": "module",
   "keywords": [
@@ -144,7 +144,7 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.220",
     "@anthropic-ai/sdk": "^0.112.4",
-    "cc-session-io": "^0.3.1",
+    "cc-session-io": "^0.3.2",
     "change-case": "^5.4.4"
   },
   "peerDependencies": {

--- a/pi-extensions/pi-claude-bridge/src/convert.ts
+++ b/pi-extensions/pi-claude-bridge/src/convert.ts
@@ -149,6 +149,10 @@ export function convertPiMessages(
 	for (let i = 0; i < messages.length; i++) {
 		const msg = messages[i];
 		if (msg.role === "user") {
+			// Rebuild imports each pi user message as its OWN record. The REUSE path
+			// (extractUserPrompt/extractUserPromptBlocks in index.ts) instead merges a
+			// trailing user run into one "\n\n"-joined prompt — accepted divergence,
+			// see the comment there; the merged form is never re-imported here.
 			anthropicMessages.push(userMessageToAnthropic(msg));
 		} else if (msg.role === "assistant") {
 			const content = Array.isArray(msg.content) ? msg.content : [];

--- a/pi-extensions/pi-claude-bridge/src/index.ts
+++ b/pi-extensions/pi-claude-bridge/src/index.ts
@@ -220,7 +220,15 @@ function extractAllToolResults(context: Context): McpResult[] {
 	return results;
 }
 
-/** Combine one or more consecutive user messages into a single SDK prompt. */
+/** Combine one or more consecutive user messages into a single SDK prompt.
+ *
+ *  Representation divergence, accepted on purpose: this MERGES N pi user
+ *  messages into ONE Claude user record ("\n\n"-joined), while a REBUILD
+ *  (convertPiMessages in convert.ts) imports the same pi history as N separate
+ *  user records. Streaming N SDKUserMessages instead would collapse N pi turns
+ *  into one Pi reply with double-counted usage, so the join stays. The merged
+ *  form is only ever a query's live prompt — it is never re-imported, so the
+ *  two representations never meet in one session file. */
 function extractUserPrompt(messages: Context["messages"]): string | null {
 	if (messages.length === 0 || messages.some((message) => message.role !== "user")) return null;
 	return messages.map((message) =>
@@ -229,7 +237,8 @@ function extractUserPrompt(messages: Context["messages"]): string | null {
 }
 
 /** Combine consecutive user messages as ContentBlockParam[] while preserving images.
- *  Returns null if no images — caller should fall back to the string prompt. */
+ *  Returns null if no images — caller should fall back to the string prompt.
+ *  Same N-into-1 merge as extractUserPrompt (see its comment for why). */
 function extractUserPromptBlocks(messages: Context["messages"]): ContentBlockParam[] | null {
 	if (messages.length === 0 || messages.some((message) => message.role !== "user")) return null;
 
@@ -265,6 +274,31 @@ function extractUserPromptBlocks(messages: Context["messages"]): ContentBlockPar
 		}
 	}
 	return hasImage ? blocks : null;
+}
+
+export interface DeferredUserReplayPlan {
+	// Index where the trailing consecutive user run begins (=== messages.length
+	// when the context doesn't end in a user message).
+	runStart: number;
+	userMessageCount: number;
+	// All trailing user messages combined into one replay prompt, or null when
+	// there is nothing usable to replay (no trailing users, or all-empty text).
+	prompt: string | null;
+}
+
+/** Plan replay of user messages pi injected mid-query (steer drain, followUp).
+ *  Captures the ENTIRE trailing consecutive user run, not just the last
+ *  message — dropping the earlier ones was silent input loss (vstack#967). */
+export function planDeferredUserReplay(messages: Context["messages"]): DeferredUserReplayPlan {
+	let runStart = messages.length;
+	while (runStart > 0 && messages[runStart - 1]?.role === "user") runStart--;
+	const trailingUsers = messages.slice(runStart);
+	const prompt = trailingUsers.length > 0 ? extractUserPrompt(trailingUsers) : null;
+	return {
+		runStart,
+		userMessageCount: trailingUsers.length,
+		prompt: prompt?.trim() ? prompt : null,
+	};
 }
 
 async function* wrapPromptStream(blocks: ContentBlockParam[]): AsyncIterable<SDKUserMessage> {
@@ -747,16 +781,29 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 		//   - A followUp is delivered between tool-result turns.
 		// The bridge can't forward these mid-query (the SDK query is in progress),
 		// so we save them for replay as continuation queries after consumeQuery ends.
+		// The cursor may only advance over messages actually captured for replay:
+		// claiming Claude owns a user message that was never deferred is permanent
+		// silent input loss (vstack#967 — only the LAST of several trailing user
+		// messages was captured while the cursor skipped them all).
+		let capturedThrough = context.messages.length;
 		if (lastMsgRole === "user") {
-			const userPrompt = extractUserPrompt(context.messages.slice(-1));
-			if (userPrompt) {
-				ctx().deferredUserMessages.push(userPrompt);
-				debug(`provider: deferred user message for replay after query: ${userPrompt.slice(0, 60)}`);
+			const replay = planDeferredUserReplay(context.messages);
+			if (replay.prompt) {
+				ctx().deferredUserMessages.push(replay.prompt);
+				debug(`provider: deferred ${replay.userMessageCount} user message(s) for replay after query: ${replay.prompt.slice(0, 60)}`);
+			} else {
+				capturedThrough = replay.runStart;
+				diagDump("deferred_user_replay_skipped", {
+					contextLength: context.messages.length,
+					runStart: replay.runStart,
+					userMessageCount: replay.userMessageCount,
+					messageRoles: context.messages.map((m, i) => `[${i}]${m.role}`).join(" "),
+				});
 			}
 		}
 
-		if (sharedSession) sharedSession.cursor = context.messages.length;
-		queryCtx.latestCursor = Math.max(queryCtx.latestCursor, context.messages.length);
+		if (sharedSession) sharedSession.cursor = capturedThrough;
+		queryCtx.latestCursor = Math.max(queryCtx.latestCursor, capturedThrough);
 		return stream;
 	}
 
@@ -822,19 +869,36 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 	ctx().latestCursor = 0;
 
 	const { mcpTools, customToolNameToSdk, customToolNameToPi } = resolveMcpTools(context);
-	const { sessionId: resumeSessionId, promptMessages } = syncSharedSession(context.messages, cwd, customToolNameToSdk, model.id);
+
+	// Config + executable preflight run BEFORE syncSharedSession on purpose: the
+	// sync's REBUILD path is destructive (deleteSession + createSession + save),
+	// so a misconfigured executable must fail this query while the previous
+	// session file is still intact.
+	const bridgeConfig = loadConfig(cwd);
+	const providerSettings = bridgeConfig.provider ?? {};
+	const claudeExecutable = resolveClaudeExecutable(providerSettings.pathToClaudeCodeExecutable);
+	const claudeExecutablePreflight = claudeExecutable ? preflightClaudeExecutable(claudeExecutable, cwd) : undefined;
+
+	const cursorBeforeSync = sharedSession?.cursor ?? null;
+	const { sessionId: resumeSessionId, promptStart } = syncSharedSession(context.messages, cwd, customToolNameToSdk, model.id);
+	const promptMessages = context.messages.slice(promptStart);
 	const promptBlocks = extractUserPromptBlocks(promptMessages);
 	let promptText = extractUserPrompt(promptMessages) ?? "";
 
-	// Guard: empty prompt means the last context message isn't a user message.
-	// This should never happen with the state stack fix — dump diagnostics if it does.
-	if (!promptText && !promptBlocks) {
+	// Guard: a prompt with no usable content means the last context message
+	// isn't a user message (or the batch was all-empty — joined batches turn ""
+	// into "\n\n", so test the trimmed text, not truthiness). Should never
+	// happen with the state stack fix — dump diagnostics if it does.
+	if (!promptText.trim() && !promptBlocks) {
 		diagDump("empty_prompt", {
 			contextLength: context.messages.length,
 			lastMsgRole: lastMsg?.role,
 			isReentrant,
 			stackDepth: stackDepth(),
 			activeQueryExists: ctx().activeQuery !== null,
+			cursorBeforeSync,
+			promptStart,
+			promptRoles: promptMessages.map((m) => m.role).join(" "),
 			sharedSession: sharedSession ? { sessionId: sharedSession.sessionId.slice(0, 8), cursor: sharedSession.cursor } : null,
 			messageRoles: context.messages.map((m, i) => `[${i}]${m.role}`).join(" "),
 		});
@@ -846,8 +910,6 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 		? wrapPromptStream(promptBlocks)
 		: promptText;
 	const mcpServers = buildMcpServers(mcpTools, ctx());
-	const bridgeConfig = loadConfig(cwd);
-	const providerSettings = bridgeConfig.provider ?? {};
 	// Whether to expose the Claude account's claude.ai cloud MCP connectors
 	// (Gmail/Calendar/Drive). Enabled via env or config; drives setting-sources,
 	// tool isolation, and the ENABLE_CLAUDEAI_MCP_SERVERS child-env gate below.
@@ -881,8 +943,6 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 			? undefined
 			: providerSettings.settingSources ?? ["user", "project"];
 	const strictMcpConfigEnabled = !appendSystemPrompt && providerSettings.strictMcpConfig !== false;
-	const claudeExecutable = resolveClaudeExecutable(providerSettings.pathToClaudeCodeExecutable);
-	const claudeExecutablePreflight = claudeExecutable ? preflightClaudeExecutable(claudeExecutable, cwd) : undefined;
 	// Prefer the model's own thinkingLevelMap when present (pi-ai 0.72+ ships
 	// per-model overrides — e.g. opus-4-7 wants xhigh→xhigh, not xhigh→max).
 	// Fall back to our generic table for older pi-ai or unmapped levels.

--- a/pi-extensions/pi-claude-bridge/src/index.ts
+++ b/pi-extensions/pi-claude-bridge/src/index.ts
@@ -57,7 +57,7 @@ export { classifyClaudeExecutableBytes, preflightClaudeExecutable, resolveClaude
 export { __testGetBridgeIntegrityState, __testSetBridgeIntegrityState, INTEGRITY_CUSTOM_TYPE, appendIntegrityEntry, reportToolResultMismatch } from "./bridge-state.js";
 export { CONNECTOR_CALL_CUSTOM_TYPE, connectorResultByteSize, flushConnectorCallAudit, recordConnectorCallResult, setConnectorCallAuditSink, type ConnectorCallAuditData, type ConnectorCallAuditSink, type ConnectorCallOutcome } from "./connector-audit.js";
 export { CLAUDE_AI_CONNECTOR_TOOL_PATTERNS, connectorMcpServers, connectorDeclarationsDisabled, CLAUDE_BRIDGE_TOOL_ISOLATION, CONNECTOR_DISCOVERY_TOOLS, CONNECTOR_WRITE_TOOLS, DISALLOWED_BUILTIN_TOOLS, connectorQueryOptions, connectorWriteDenyHook, connectorWriteModeFor, connectorWriteModeFromEnv, connectorsEnabledFor, connectorsEnabledFromEnv, isChildExecutedTool, isChildInternalTool, isConnectorTool, isConnectorWriteTool, toolIsolationForQuery } from "./connectors.js";
-export { restoreSharedSessionFromPi, shouldRestorePersistedBridgeEntry } from "./session-persistence.js";
+export { planIncrementalPromptBatch, restoreSharedSessionFromPi, shouldRestorePersistedBridgeEntry } from "./session-persistence.js";
 export { NATIVE_PROVIDER_UNSUPPORTED_MESSAGE, buildNativeProvider, claudeAuthSourceLabel, supportsNativeProvider } from "./native-provider.js";
 export { DEFAULT_STREAM_IDLE_TIMEOUT_MS, STREAM_IDLE_BACKOFF_HINT_MS, STREAM_IDLE_TIMEOUT_ENV, buildStreamIdleTimeoutErrorMessage, createStreamIdleWatchdog, streamIdleTimeoutMsFromEnv, type StreamIdleTimeoutInfo, type StreamIdleWatchdog, type StreamIdleWatchdogState } from "./stream-idle-watchdog.js";
 export { ALLOWED_RATE_LIMIT_WARNING_UTILIZATION_THRESHOLD, formatAllowedRateLimitWarning, formatResetTimestamp, isExtraUsageRequiredMessage, isUsageLimitMessage, normalizeRateLimitUtilization, resetTimestampMs, uniqueNonEmptyLines } from "./rate-limit.js";
@@ -220,44 +220,48 @@ function extractAllToolResults(context: Context): McpResult[] {
 	return results;
 }
 
-/** Extract the last user message from context as a prompt string. Returns null if last message is not a user message. */
+/** Combine one or more consecutive user messages into a single SDK prompt. */
 function extractUserPrompt(messages: Context["messages"]): string | null {
-	const last = messages[messages.length - 1];
-	if (!last || last.role !== "user") return null;
-	if (typeof last.content === "string") return last.content;
-	return messageContentToText(last.content) || "";
+	if (messages.length === 0 || messages.some((message) => message.role !== "user")) return null;
+	return messages.map((message) =>
+		typeof message.content === "string" ? message.content : messageContentToText(message.content) || "",
+	).join("\n\n");
 }
 
-/** Extract the last user message as ContentBlockParam[] (preserving images).
- *  Returns null if no images — caller should fall back to string prompt. */
+/** Combine consecutive user messages as ContentBlockParam[] while preserving images.
+ *  Returns null if no images — caller should fall back to the string prompt. */
 function extractUserPromptBlocks(messages: Context["messages"]): ContentBlockParam[] | null {
-	const last = messages[messages.length - 1];
-	if (!last || last.role !== "user") return null;
-	if (typeof last.content === "string") {
-		debug(`extractUserPromptBlocks: content is string (length=${last.content.length})`);
-		return null;
-	}
-	if (!Array.isArray(last.content)) {
-		debug(`extractUserPromptBlocks: content is ${typeof last.content}`);
-		return null;
-	}
-	debug(`extractUserPromptBlocks: ${last.content.length} blocks, types=${last.content.map((b: any) => b.type).join(",")}`);
+	if (messages.length === 0 || messages.some((message) => message.role !== "user")) return null;
+
 	let hasImage = false;
 	const blocks: ContentBlockParam[] = [];
-	for (const block of last.content) {
-		if (block.type === "text" && block.text) {
-			blocks.push({ type: "text", text: block.text });
-		} else if (block.type === "image") {
-			debug(`image block: mimeType=${(block as any).mimeType}, data length=${((block as any).data ?? "").length}, keys=${Object.keys(block).join(",")}`);
-			if (!(block as any).data || !(block as any).mimeType) {
-				debug(`image block missing data or mimeType, skipping`);
-				continue;
+	for (let messageIndex = 0; messageIndex < messages.length; messageIndex++) {
+		const content = messages[messageIndex].content;
+		if (messageIndex > 0) blocks.push({ type: "text", text: "\n\n" });
+		if (typeof content === "string") {
+			if (content) blocks.push({ type: "text", text: content });
+			continue;
+		}
+		if (!Array.isArray(content)) {
+			debug(`extractUserPromptBlocks: content is ${typeof content}`);
+			continue;
+		}
+		debug(`extractUserPromptBlocks: ${content.length} blocks, types=${content.map((b: any) => b.type).join(",")}`);
+		for (const block of content) {
+			if (block.type === "text" && block.text) {
+				blocks.push({ type: "text", text: block.text });
+			} else if (block.type === "image") {
+				debug(`image block: mimeType=${(block as any).mimeType}, data length=${((block as any).data ?? "").length}, keys=${Object.keys(block).join(",")}`);
+				if (!(block as any).data || !(block as any).mimeType) {
+					debug(`image block missing data or mimeType, skipping`);
+					continue;
+				}
+				hasImage = true;
+				blocks.push({
+					type: "image",
+					source: { type: "base64", media_type: block.mimeType as Base64ImageSource["media_type"], data: block.data },
+				});
 			}
-			hasImage = true;
-			blocks.push({
-				type: "image",
-				source: { type: "base64", media_type: block.mimeType as Base64ImageSource["media_type"], data: block.data },
-			});
 		}
 	}
 	return hasImage ? blocks : null;
@@ -744,7 +748,7 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 		// The bridge can't forward these mid-query (the SDK query is in progress),
 		// so we save them for replay as continuation queries after consumeQuery ends.
 		if (lastMsgRole === "user") {
-			const userPrompt = extractUserPrompt(context.messages);
+			const userPrompt = extractUserPrompt(context.messages.slice(-1));
 			if (userPrompt) {
 				ctx().deferredUserMessages.push(userPrompt);
 				debug(`provider: deferred user message for replay after query: ${userPrompt.slice(0, 60)}`);
@@ -818,8 +822,9 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 	ctx().latestCursor = 0;
 
 	const { mcpTools, customToolNameToSdk, customToolNameToPi } = resolveMcpTools(context);
-	const promptBlocks = extractUserPromptBlocks(context.messages);
-	let promptText = extractUserPrompt(context.messages) ?? "";
+	const { sessionId: resumeSessionId, promptMessages } = syncSharedSession(context.messages, cwd, customToolNameToSdk, model.id);
+	const promptBlocks = extractUserPromptBlocks(promptMessages);
+	let promptText = extractUserPrompt(promptMessages) ?? "";
 
 	// Guard: empty prompt means the last context message isn't a user message.
 	// This should never happen with the state stack fix — dump diagnostics if it does.
@@ -878,8 +883,6 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 	const strictMcpConfigEnabled = !appendSystemPrompt && providerSettings.strictMcpConfig !== false;
 	const claudeExecutable = resolveClaudeExecutable(providerSettings.pathToClaudeCodeExecutable);
 	const claudeExecutablePreflight = claudeExecutable ? preflightClaudeExecutable(claudeExecutable, cwd) : undefined;
-	const { sessionId: resumeSessionId } = syncSharedSession(context.messages, cwd, customToolNameToSdk, model.id);
-
 	// Prefer the model's own thinkingLevelMap when present (pi-ai 0.72+ ships
 	// per-model overrides — e.g. opus-4-7 wants xhigh→xhigh, not xhigh→max).
 	// Fall back to our generic table for older pi-ai or unmapped levels.

--- a/pi-extensions/pi-claude-bridge/src/session-persistence.ts
+++ b/pi-extensions/pi-claude-bridge/src/session-persistence.ts
@@ -192,6 +192,42 @@ function convertAndImportMessages(
 
 interface SyncResult {
 	sessionId: string | null;
+	promptMessages: Context["messages"];
+}
+
+export interface IncrementalPromptBatchPlan {
+	cursorBeforeQuery: number;
+	promptStart: number;
+	userMessageCount: number;
+}
+
+/**
+ * Recognize history that Claude already owns followed only by user messages
+ * delivered together by Pi (for example, followUpMode="all"). Claude Code has
+ * already persisted the optional leading assistant message; every user message
+ * after it must be sent as this query's prompt rather than imported via rebuild.
+ */
+export function planIncrementalPromptBatch(
+	messages: Context["messages"],
+	cursor: number,
+): IncrementalPromptBatchPlan | undefined {
+	const lastIndex = messages.length - 1;
+	if (lastIndex < 0 || (messages[lastIndex] as { role?: string }).role !== "user") return undefined;
+
+	const boundedCursor = Math.max(0, Math.min(cursor, lastIndex));
+	let promptStart = boundedCursor;
+	if ((messages[promptStart] as { role?: string } | undefined)?.role === "assistant") promptStart++;
+
+	const pendingPrompts = messages.slice(promptStart);
+	if (pendingPrompts.length === 0 || pendingPrompts.some((message) => (message as { role?: string }).role !== "user")) {
+		return undefined;
+	}
+
+	return {
+		cursorBeforeQuery: promptStart,
+		promptStart,
+		userMessageCount: pendingPrompts.length,
+	};
 }
 
 /**
@@ -280,16 +316,18 @@ export function syncSharedSession(
 
 	// REUSE path
 	if (sharedSession && !sharedSession.needsRebuild) {
-		const missed = priorMessages.slice(sharedSession.cursor);
-		const trailingAssistantOnly =
-			missed.length === 1 && (missed[0] as { role?: string }).role === "assistant";
-		if (missed.length === 0 || trailingAssistantOnly) {
-			if (trailingAssistantOnly) {
-				setSharedSession({ ...sharedSession, cursor: priorMessages.length, cwd });
-			}
-			debug(`Case 3: ${trailingAssistantOnly ? "advanced cursor past trailing assistant, " : ""}resuming session ${sharedSession.sessionId.slice(0, 8)}, cursor=${sharedSession.cursor}`);
-			debug(`syncResult: path=reuse sessionId=${sharedSession.sessionId} cursor=${sharedSession.cursor}`);
-			return { sessionId: sharedSession.sessionId };
+		const batch = planIncrementalPromptBatch(messages, sharedSession.cursor);
+		if (batch) {
+			setSharedSession({ ...sharedSession, cursor: batch.cursorBeforeQuery, cwd });
+			const batching = batch.userMessageCount > 1
+				? `batched ${batch.userMessageCount} consecutive user messages, `
+				: batch.cursorBeforeQuery > sharedSession.cursor ? "advanced cursor past trailing assistant, " : "";
+			debug(`Case 3: ${batching}resuming session ${sharedSession.sessionId.slice(0, 8)}, cursor=${batch.cursorBeforeQuery}`);
+			debug(`syncResult: path=reuse sessionId=${sharedSession.sessionId} cursor=${batch.cursorBeforeQuery} promptUsers=${batch.userMessageCount}`);
+			return {
+				sessionId: sharedSession.sessionId,
+				promptMessages: messages.slice(batch.promptStart),
+			};
 		}
 	}
 
@@ -297,7 +335,7 @@ export function syncSharedSession(
 	if (priorMessages.length === 0) {
 		debug(`Case 1: clean start, ${messages.length} total messages`);
 		debug(`syncResult: path=clean-start`);
-		return { sessionId: null };
+		return { sessionId: null, promptMessages: messages.slice(-1) };
 	}
 	const previousSessionId = sharedSession?.sessionId;
 	const previousCursor = sharedSession?.cursor ?? 0;
@@ -330,5 +368,5 @@ export function syncSharedSession(
 	}
 	debugSessionPaths(`${session.sessionId.slice(0, 8)}`, cwd, session.jsonlPath);
 	debug(`syncResult: path=rebuild sessionId=${session.sessionId} priors=${priorMessages.length} ${previousSessionId === undefined ? "first" : preserveId ? "preserved" : "rotated-post-abort"}`);
-	return { sessionId: session.sessionId };
+	return { sessionId: session.sessionId, promptMessages: messages.slice(-1) };
 }

--- a/pi-extensions/pi-claude-bridge/src/session-persistence.ts
+++ b/pi-extensions/pi-claude-bridge/src/session-persistence.ts
@@ -192,11 +192,15 @@ function convertAndImportMessages(
 
 interface SyncResult {
 	sessionId: string | null;
-	promptMessages: Context["messages"];
+	// Index into the caller's messages array where this query's prompt begins.
+	// Everything from promptStart to the end is user input Claude has not seen;
+	// the caller slices it out itself (single owner of the messages array).
+	promptStart: number;
 }
 
 export interface IncrementalPromptBatchPlan {
-	cursorBeforeQuery: number;
+	// Doubles as the cursor to store before the query runs: Claude owns
+	// [0, promptStart) and the prompt delivers [promptStart, end).
 	promptStart: number;
 	userMessageCount: number;
 }
@@ -220,20 +224,18 @@ export function planIncrementalPromptBatch(
 
 	const pendingPrompts = messages.slice(promptStart);
 	if (pendingPrompts.length === 0 || pendingPrompts.some((message) => (message as { role?: string }).role !== "user")) {
+		// Log the rejected tail so a diag log can tell apart "two assistants in
+		// tail" vs "toolResult in tail" vs "stale cursor" without a repro.
+		debug(`planIncrementalPromptBatch: rejected — cursor=${cursor} promptStart=${promptStart} tail roles=[${messages.slice(boundedCursor).map((m) => (m as { role?: string }).role).join(", ")}]`);
 		return undefined;
 	}
 
 	return {
-		cursorBeforeQuery: promptStart,
 		promptStart,
 		userMessageCount: pendingPrompts.length,
 	};
 }
 
-/**
- * Ensure the shared session has all messages up to (but not including) the last user message.
- * Returns session ID to resume from, or null if no resume needed.
- */
 // Read the session file we just wrote and sanity-check it. Warns instead of
 // throwing — CC may be more tolerant than our checks, so a false positive
 // shouldn't block the user. Pure logic is in session-verify.js; this wrapper
@@ -282,10 +284,17 @@ function debugSessionPaths(label: string, cwd: string, jsonlPath: string): void 
 }
 
 // Two semantic paths:
-//   REUSE — pi's history is in sync with the existing sharedSession (or drifted
-//     only by the trailing final-assistant message that pi appends after
-//     streamSimple returns, which CC's own persisted session already has).
-//     Returns the existing sessionId. Keeps CC's prompt cache warm.
+//   REUSE — pi's history is in sync with the existing sharedSession, drifted
+//     only by an optional trailing assistant message (the final-assistant pi
+//     appends after streamSimple returns, which CC's own persisted session
+//     already has) plus an unbounded trailing run of user messages delivered
+//     together by pi (steer-queue drain, followUpMode="all"). The whole user
+//     run becomes this query's prompt. The unbounded run is safe because
+//     promptStart can never land on a user message Claude already persisted:
+//     Claude owns [0, cursor), promptStart starts at the cursor and only ever
+//     advances (past the one optional assistant), so everything from
+//     promptStart on is new input. Returns the existing sessionId. Keeps CC's
+//     prompt cache warm.
 //   REBUILD — no session yet, or pi's history has diverged (non-trailing
 //     missed messages, e.g. another provider took a turn). Wipes the existing
 //     session file (if any) and writes a fresh one containing all prior
@@ -318,15 +327,15 @@ export function syncSharedSession(
 	if (sharedSession && !sharedSession.needsRebuild) {
 		const batch = planIncrementalPromptBatch(messages, sharedSession.cursor);
 		if (batch) {
-			setSharedSession({ ...sharedSession, cursor: batch.cursorBeforeQuery, cwd });
+			setSharedSession({ ...sharedSession, cursor: batch.promptStart, cwd });
 			const batching = batch.userMessageCount > 1
 				? `batched ${batch.userMessageCount} consecutive user messages, `
-				: batch.cursorBeforeQuery > sharedSession.cursor ? "advanced cursor past trailing assistant, " : "";
-			debug(`Case 3: ${batching}resuming session ${sharedSession.sessionId.slice(0, 8)}, cursor=${batch.cursorBeforeQuery}`);
-			debug(`syncResult: path=reuse sessionId=${sharedSession.sessionId} cursor=${batch.cursorBeforeQuery} promptUsers=${batch.userMessageCount}`);
+				: batch.promptStart > sharedSession.cursor ? "advanced cursor past trailing assistant, " : "";
+			debug(`Case 3: ${batching}resuming session ${sharedSession.sessionId.slice(0, 8)}, cursor=${batch.promptStart}`);
+			debug(`syncResult: path=reuse sessionId=${sharedSession.sessionId} cursor=${batch.promptStart} promptUsers=${batch.userMessageCount}`);
 			return {
 				sessionId: sharedSession.sessionId,
-				promptMessages: messages.slice(batch.promptStart),
+				promptStart: batch.promptStart,
 			};
 		}
 	}
@@ -335,7 +344,7 @@ export function syncSharedSession(
 	if (priorMessages.length === 0) {
 		debug(`Case 1: clean start, ${messages.length} total messages`);
 		debug(`syncResult: path=clean-start`);
-		return { sessionId: null, promptMessages: messages.slice(-1) };
+		return { sessionId: null, promptStart: messages.length - 1 };
 	}
 	const previousSessionId = sharedSession?.sessionId;
 	const previousCursor = sharedSession?.cursor ?? 0;
@@ -368,5 +377,5 @@ export function syncSharedSession(
 	}
 	debugSessionPaths(`${session.sessionId.slice(0, 8)}`, cwd, session.jsonlPath);
 	debug(`syncResult: path=rebuild sessionId=${session.sessionId} priors=${priorMessages.length} ${previousSessionId === undefined ? "first" : preserveId ? "preserved" : "rotated-post-abort"}`);
-	return { sessionId: session.sessionId, promptMessages: messages.slice(-1) };
+	return { sessionId: session.sessionId, promptStart: messages.length - 1 };
 }

--- a/pi-extensions/pi-claude-bridge/tests/unit-deferred-replay.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-deferred-replay.mjs
@@ -1,0 +1,60 @@
+/**
+ * Tests for planDeferredUserReplay — the re-entrant branch's capture plan for
+ * user messages pi injects mid-query (steer drain, followUp delivery).
+ *
+ * vstack#967: when the context ended in MULTIPLE trailing user messages, only
+ * the last was deferred while the cursor advanced past all of them — the
+ * earlier ones were permanently and silently lost. The plan must cover the
+ * entire trailing user run, and the caller advances the cursor to the end of
+ * the context only when the plan produced a replay prompt (otherwise it stops
+ * at runStart so nothing unclaimed is skipped).
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { planDeferredUserReplay } from "../src/index.ts";
+
+const user = (text) => ({ role: "user", content: text });
+const toolResult = () => ({ role: "toolResult", content: [], toolCallId: "t1" });
+const assistant = () => ({ role: "assistant", content: [] });
+
+describe("planDeferredUserReplay", () => {
+	it("captures BOTH trailing users after a tool result (vstack#967 shape)", () => {
+		const messages = [assistant(), toolResult(), user("u_a"), user("u_b")];
+
+		const plan = planDeferredUserReplay(messages);
+
+		assert.equal(plan.runStart, 2);
+		assert.equal(plan.userMessageCount, 2);
+		// Both messages, in order, in one combined replay prompt.
+		assert.equal(plan.prompt, "u_a\n\nu_b");
+		// Caller contract: prompt captured → cursor lands at messages.length,
+		// covering exactly the messages that were deferred.
+		assert.equal(messages.length, plan.runStart + plan.userMessageCount);
+	});
+
+	it("keeps the single trailing user unchanged", () => {
+		const plan = planDeferredUserReplay([assistant(), toolResult(), user("steer")]);
+
+		assert.equal(plan.runStart, 2);
+		assert.equal(plan.userMessageCount, 1);
+		assert.equal(plan.prompt, "steer");
+	});
+
+	it("returns no prompt when the context does not end in a user message", () => {
+		const plan = planDeferredUserReplay([assistant(), toolResult()]);
+
+		assert.equal(plan.runStart, 2);
+		assert.equal(plan.userMessageCount, 0);
+		assert.equal(plan.prompt, null);
+	});
+
+	it("returns no prompt for an all-empty user run so the caller can diagnose it", () => {
+		const plan = planDeferredUserReplay([assistant(), toolResult(), user(""), user("  ")]);
+
+		// runStart still marks the run — the caller holds the cursor here instead
+		// of silently claiming messages that were never captured.
+		assert.equal(plan.runStart, 2);
+		assert.equal(plan.userMessageCount, 2);
+		assert.equal(plan.prompt, null);
+	});
+});

--- a/pi-extensions/pi-claude-bridge/tests/unit-followup-batch.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-followup-batch.mjs
@@ -1,0 +1,63 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { planIncrementalPromptBatch } from "../src/index.ts";
+
+const msg = (role) => ({ role, content: role === "assistant" ? [] : role });
+const roles = (...values) => values.map(msg);
+
+describe("planIncrementalPromptBatch", () => {
+	it("batches followUpMode=all users after Claude's trailing assistant", () => {
+		const plan = planIncrementalPromptBatch(
+			roles("user", "assistant", "user", "user"),
+			1,
+		);
+
+		assert.deepEqual(plan, {
+			cursorBeforeQuery: 2,
+			promptStart: 2,
+			userMessageCount: 2,
+		});
+	});
+
+	it("keeps the normal single-user reuse path unchanged", () => {
+		const plan = planIncrementalPromptBatch(
+			roles("user", "assistant", "user"),
+			1,
+		);
+
+		assert.deepEqual(plan, {
+			cursorBeforeQuery: 2,
+			promptStart: 2,
+			userMessageCount: 1,
+		});
+	});
+
+	it("supports a cursor already advanced past the assistant", () => {
+		const plan = planIncrementalPromptBatch(
+			roles("user", "assistant", "user", "user"),
+			2,
+		);
+
+		assert.deepEqual(plan, {
+			cursorBeforeQuery: 2,
+			promptStart: 2,
+			userMessageCount: 2,
+		});
+	});
+
+	it("rejects genuine history divergence containing an intervening assistant", () => {
+		const plan = planIncrementalPromptBatch(
+			roles("user", "assistant", "user", "assistant", "user"),
+			1,
+		);
+
+		assert.equal(plan, undefined);
+	});
+
+	it("rejects a non-user final prompt", () => {
+		assert.equal(
+			planIncrementalPromptBatch(roles("user", "assistant", "toolResult"), 1),
+			undefined,
+		);
+	});
+});

--- a/pi-extensions/pi-claude-bridge/tests/unit-followup-batch.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-followup-batch.mjs
@@ -13,7 +13,6 @@ describe("planIncrementalPromptBatch", () => {
 		);
 
 		assert.deepEqual(plan, {
-			cursorBeforeQuery: 2,
 			promptStart: 2,
 			userMessageCount: 2,
 		});
@@ -26,7 +25,6 @@ describe("planIncrementalPromptBatch", () => {
 		);
 
 		assert.deepEqual(plan, {
-			cursorBeforeQuery: 2,
 			promptStart: 2,
 			userMessageCount: 1,
 		});
@@ -39,7 +37,6 @@ describe("planIncrementalPromptBatch", () => {
 		);
 
 		assert.deepEqual(plan, {
-			cursorBeforeQuery: 2,
 			promptStart: 2,
 			userMessageCount: 2,
 		});
@@ -57,6 +54,13 @@ describe("planIncrementalPromptBatch", () => {
 	it("rejects a non-user final prompt", () => {
 		assert.equal(
 			planIncrementalPromptBatch(roles("user", "assistant", "toolResult"), 1),
+			undefined,
+		);
+	});
+
+	it("rejects a toolResult inside the pending tail", () => {
+		assert.equal(
+			planIncrementalPromptBatch(roles("user", "assistant", "toolResult", "user"), 1),
 			undefined,
 		);
 	});

--- a/pi-extensions/pi-claude-bridge/tests/unit-sync-shared-session.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-sync-shared-session.mjs
@@ -1,0 +1,81 @@
+/**
+ * Tests for syncSharedSession's REUSE path (and the disk-free clean start).
+ *
+ * The planner unit tests alone cannot protect the caller contract: a mutation
+ * that returns the last message instead of the whole pending batch passes them
+ * while still dropping every queued follow-up but one (vstack#963). These tests
+ * pin syncSharedSession itself: same sessionId kept (no rebuild), promptStart
+ * covering the WHOLE trailing user run by content, and the stored cursor.
+ *
+ * REUSE and clean start touch no disk or API, so no fixtures are needed; the
+ * destructive REBUILD path is covered by the int-session-* integration tests.
+ */
+import { afterEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { syncSharedSession } from "../src/session-persistence.js";
+import { __testGetBridgeIntegrityState, setSharedSession } from "../src/bridge-state.js";
+
+const user = (text) => ({ role: "user", content: text });
+const assistant = () => ({ role: "assistant", content: [] });
+const CWD = "/repo";
+
+const promptContents = (messages, promptStart) =>
+	messages.slice(promptStart).map((message) => message.content);
+
+afterEach(() => setSharedSession(null));
+
+describe("syncSharedSession REUSE path", () => {
+	it("keeps the session and prompts BOTH queued follow-ups, by content", () => {
+		setSharedSession({ sessionId: "sess-reuse", cursor: 1, cwd: CWD });
+		const messages = [user("u1"), assistant(), user("u2"), user("u3")];
+
+		const result = syncSharedSession(messages, CWD);
+
+		assert.equal(result.sessionId, "sess-reuse");
+		assert.equal(result.promptStart, 2);
+		// Content assertion, not length: promptStart = messages.length - 1 (the
+		// old slice(-1) behavior) would still yield ONE user message here.
+		assert.deepEqual(promptContents(messages, result.promptStart), ["u2", "u3"]);
+		assert.deepEqual(__testGetBridgeIntegrityState().sharedSession, {
+			sessionId: "sess-reuse",
+			cursor: 2,
+			cwd: CWD,
+		});
+	});
+
+	it("keeps the single-user reuse case: one new user after the trailing assistant", () => {
+		setSharedSession({ sessionId: "sess-single", cursor: 1, cwd: CWD });
+		const messages = [user("u1"), assistant(), user("u2")];
+
+		const result = syncSharedSession(messages, CWD);
+
+		assert.equal(result.sessionId, "sess-single");
+		assert.equal(result.promptStart, 2);
+		assert.deepEqual(promptContents(messages, result.promptStart), ["u2"]);
+		assert.equal(__testGetBridgeIntegrityState().sharedSession.cursor, 2);
+	});
+
+	it("keeps the trailing-assistant reuse case: cursor already past the assistant", () => {
+		setSharedSession({ sessionId: "sess-past", cursor: 2, cwd: CWD });
+		const messages = [user("u1"), assistant(), user("u2"), user("u3")];
+
+		const result = syncSharedSession(messages, CWD);
+
+		assert.equal(result.sessionId, "sess-past");
+		assert.equal(result.promptStart, 2);
+		assert.deepEqual(promptContents(messages, result.promptStart), ["u2", "u3"]);
+		assert.equal(__testGetBridgeIntegrityState().sharedSession.cursor, 2);
+	});
+});
+
+describe("syncSharedSession clean start", () => {
+	it("returns no resume id and prompts the sole user message", () => {
+		const messages = [user("hello")];
+
+		const result = syncSharedSession(messages, CWD);
+
+		assert.equal(result.sessionId, null);
+		assert.equal(result.promptStart, 0);
+		assert.deepEqual(promptContents(messages, result.promptStart), ["hello"]);
+	});
+});


### PR DESCRIPTION
Supersedes #964, carrying @2093686099's commit and authorship intact as the foundation — the diagnosis in #963 and the core `planIncrementalPromptBatch` mechanism are theirs and were verified sound in review. This PR completes the remaining review findings and fixes the sibling bug #967 in the same functions.

**On top of the foundation commit:**

- **Blocker 1 (dep/bundle):** `cc-session-io` floor raised to ^0.3.2 (the fix relies on its content-block and import behaviors), lockfile regenerated, bundle rebuilt reproducibly — single chunk id, verified against a clean `npm ci`.
- **Blocker 2 (coverage):** new `unit-sync-shared-session.mjs` exercises `syncSharedSession` itself — the `slice(-1)` data-loss mutant that previously survived the whole suite now fails 2 tests (mutation-checked).
- **Blocker 3:** the REUSE design contract in `session-persistence.ts` now states the real invariant (optional trailing assistant + unbounded trailing user run) and why the unbounded run is safe.
- **Hardening:** executable preflight restored ahead of the destructive REBUILD write; empty-prompt guard survives joined batches (`!promptText.trim()`) and its diagDump records the pre-sync cursor, promptStart, and roles; planner returns `promptStart` (single owner of the messages array; `cursorBeforeQuery` duplication collapsed); N-into-1 merge vs rebuild's N-record import documented at both sites as an accepted divergence; planner rejections now debug-log the tail role sequence.
- **#967:** the re-entrant deferred path captures the ENTIRE trailing user run via new `planDeferredUserReplay` (was: last message only — silent input loss), advances the cursor only over what was actually captured, and diagDumps any skipped run. Covered by `unit-deferred-replay.mjs` including the `[…, toolResult, u_a, u_b]` shape.
- **Packaging:** 2.0.1 → 2.1.0 with a CHANGELOG "Consumer-impacting changes" entry (new exports `planIncrementalPromptBatch`, `planDeferredUserReplay`; cc-session-io floor).

**Validation:** `tsc --noEmit` clean; unit 397/397; full `npm test` including live integration green — int-cache measured a 95% cache hit rate on turns 3+, which is the #963 fix working against the real SDK, not stubs.

Closes #963
Closes #967

https://claude.ai/code/session_01ReyxkK9aLisEvSxTQqzv3j