### PR TITLE
feat(pi-claude-bridge): safe subscription routing with Pi Claude ids

### DIFF
--- a/pi-extensions/pi-claude-bridge/CHANGELOG.md
+++ b/pi-extensions/pi-claude-bridge/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Consumer-impacting changes
 
+### 2.2.0
+
+- Added the canonical `pi-claude/*` provider identity while retaining `claude-bridge/*` as a saved-session compatibility alias.
+- Added an optional versioned account-router integration for usage-aware Claude subscription profiles. Each request runs with the selected official Claude CLI profile, keeps child sessions and connector credentials profile-scoped, and can retry a pre-output failure on another ready profile without replaying visible output or connector side effects.
+- Managed profile subprocesses now remove inherited API credentials, endpoint overrides, and third-party provider flags so `CLAUDE_CONFIG_DIR` remains the billing identity. Persisted Pi session markers store only the opaque profile id and effective model; profile paths are re-resolved at restore time.
+- Managed Fable requests exhaust ready accounts' Fable allowances before falling back to Opus. Legacy single-profile users retain Claude Code's native model fallback and rate-limit recovery behavior.
+- Extra Usage policy now remains exclusively in Claude account settings; the bridge no longer launches or enforces a separate Extra Usage flow.
+- Updated vulnerable production transitive dependencies; `npm audit --omit=dev` reports no findings.
+
 ### 2.1.0
 
 - Delivering multiple queued Pi follow-ups in one call (steer-queue drain, `followUpMode="all"`) no longer forces a Claude session rebuild: the REUSE path now recognizes an unbounded trailing run of user messages, combines them into one prompt, and resumes the existing session — no session-file rewrite and no prompt-cache flush (vstack#963).

--- a/pi-extensions/pi-claude-bridge/DEVELOPMENT.md
+++ b/pi-extensions/pi-claude-bridge/DEVELOPMENT.md
@@ -50,12 +50,30 @@ The audit map is query-scoped and is NOT cleared by `resetToolTracking` — that
 
 Note that pi/core's `createBranchedSession` copies every non-label entry root→leaf, so a fork inherits the parent's connector-call records. Harmless for an audit trail, unlike the `claude-bridge-session` marker it sits beside, which needed a `piSessionId` guard for exactly that reason.
 
+## Optional account-router contract
+
+The bridge remains usable by itself. A companion may publish `vstack.pi.claude-account-router.v1` on `globalThis` to supply a subscription profile for each fresh request. The bridge passes only an opaque profile id, display label, and optional `CLAUDE_CONFIG_DIR`; credentials remain owned by the official Claude CLI.
+
+Account selection affects every account-scoped surface together:
+
+- the Agent SDK child environment;
+- `cc-session-io` create/open/delete paths;
+- Claude session resume IDs;
+- connector inventory/cache scope;
+- structured `accountInfo()` and experimental `/usage` feedback.
+
+A managed route with no explicit config directory means the real default profile: the child unsets inherited `CLAUDE_CONFIG_DIR`, while bridge-side session and connector paths are pinned explicitly to `$HOME/.claude` so an exported parent value cannot split the two. Persisted bridge-session markers contain only the opaque profile id and effective model. On resume, the companion re-resolves that id to the current profile path; markers from the earlier path-bearing format are accepted once as a migration fallback and rewritten without the path.
+
+A failed pre-output attempt is buffered so protocol setup frames do not leak into Pi, then retried with the failed profile excluded. Text/thinking deltas, Pi tool calls, and child-executed connector dispatches commit the request permanently; failures after that point are surfaced and never replayed, but are still recorded for the next request's routing decision. Child-internal plumbing such as `ToolSearch` is deliberately replay-neutral: it is neither a connector side effect nor account-visible output. `rate_limit_event` reset timestamps are sent back to the router before reranking. Without a router, rejected events retain Claude Code's native fallback behavior and are notified once rather than being converted into a second terminal error.
+
+The reciprocal `vstack.pi.claude-bridge.account-host.v1` service exposes a local `/usage` probe for account-management commands. Both symbols carry `version: 1`; incompatible future shapes must use a new symbol/version instead of mutating this contract in place.
+
 ## Provider registration — native pi ≥0.81 provider API (adopted in 2.0)
 
 Since 2.0 the bridge registers a native `Provider` object (`native-provider.ts`) via
-`pi.registerProvider(provider)`: registration is UNCONDITIONAL (once primary), and the provider's
+`pi.registerProvider(provider)`: registration is UNCONDITIONAL (once primary) for canonical `pi-claude` and the saved-session compatibility alias `claude-bridge`; the provider's
 own `auth.apiKey.check()/resolve()` report configured-ness from the same existence-only credential
-probes as before (`auth-presence.ts`), so pi itself hides claude-bridge models while no Claude
+probes as before (`auth-presence.ts`), so pi itself hides both provider aliases while no Claude
 account is connected and shows them when one appears. The 1.x credential-gated
 register/unregister state machine (`decideRegistration`) is gone. **Hosts must embed pi ≥0.81**
 (peer range `>=0.81.0`); on an older host the extension declines loudly once

--- a/pi-extensions/pi-claude-bridge/README.md
+++ b/pi-extensions/pi-claude-bridge/README.md
@@ -5,16 +5,17 @@ Works with OAuth subscription, no API key, no errors.
 ![Claude bridge demo response](https://raw.githubusercontent.com/vanillagreencom/vstack/main/pi-extensions/pi-claude-bridge/assets/bridge-demo.png)
 ![Claude Bridge settings panel](https://raw.githubusercontent.com/vanillagreencom/vstack/main/pi-extensions/pi-claude-bridge/assets/settings-panel.png)
 
-Run Claude Code as a Pi provider. Adds `claude-bridge/*` models to `/model` while keeping Pi's tools and TUI.
+Run Claude Code as the `pi-claude` Pi provider while keeping Pi's tools and TUI. The old `claude-bridge/*` IDs remain available as a legacy saved-session alias.
 
 Forked from [`elidickinson/pi-claude-bridge`](https://github.com/elidickinson/pi-claude-bridge). This fork removes the AskClaude tool and adds opt-in forwarding for Pi prompt context.
 
 ## Highlights
 
-- `claude-bridge/claude-fable-5`, Opus 5, Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 5, Sonnet 4.6, and Haiku in `/model`. `/model opus` selects Opus 5; older Opus releases stay selectable by full ID.
+- `pi-claude/claude-fable-5`, Opus 5, Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 5, Sonnet 4.6, and Haiku in `/model`. `/model opus` selects Opus 5; older Opus releases stay selectable by full ID.
 - Pi tool calls run on Pi; Claude Code handles reasoning.
 - Tool-use turns block until Pi-delivered tool results reach Claude Code, including persistent subagent panes.
-- Session continuity across normal turns, `/compact`, tree navigation, and abort recovery.
+- Session continuity across normal turns, `/compact`, tree navigation, abort recovery, and account-profile changes.
+- Optional `pi-claude` companion integration for usage-aware subscription account rotation without copying the bridge engine.
 - Thinking-level forwarding with summarized Opus thinking display.
 - Optional Claude effort overrides (`xhigh` → `max` for Opus 4.8).
 - MCP isolation and Claude cloud-MCP suppression to keep tokens lean.
@@ -60,7 +61,7 @@ The bridge also reads `claude-bridge.json` (`~/.pi/agent/claude-bridge.json`, an
 
 | Setting | What it does |
 | --- | --- |
-| Enable Claude bridge provider | Register `claude-bridge/*` models. Reload required. |
+| Enable Pi Claude provider | Register canonical `pi-claude/*` models and the legacy `claude-bridge/*` compatibility alias. Reload required. |
 
 ### Base prompt
 
@@ -87,8 +88,7 @@ The bridge also reads `claude-bridge.json` (`~/.pi/agent/claude-bridge.json`, an
 | Setting | What it does |
 | --- | --- |
 | Strict MCP config | Block filesystem MCP auto-loads; Pi owns tools. |
-| Allow extra usage helper | Let the bridge launch Claude Code's `/extra-usage` flow when extra usage is required. Billing/admin approval still happens in Claude's browser page. |
-| Fast mode | Enable Claude Code fast mode for bridge requests when the selected model supports it. |
+| Fast mode | Enable Claude Code fast mode for bridge requests when the selected model and account support it. |
 | Force Claude effort | Override Pi's thinking-level mapping for every claude-bridge request. `none` keeps Pi's selected level; `max` sends Claude Code `--effort max`. |
 | Model effort overrides | JSON object mapping model IDs to Claude Code efforts, e.g. `{"claude-opus-4-8":"max"}`. Per-model entries beat the global force setting. |
 | Claude executable path | Explicit `claude` binary path; empty auto-detects. |
@@ -99,7 +99,7 @@ Pi 0.80.6 and newer expose native `max` thinking. Fable 5, Opus 5, and Sonnet 5 
 {"claude-opus-4-8":"max"}
 ```
 
-Keys may be bare model IDs (`claude-opus-4-8`), `claude-bridge/<id>`, or `*` for all bridge models. Values are `low`, `medium`, `high`, `xhigh`, or `max`.
+Keys may be bare model IDs (`claude-opus-4-8`), canonical `pi-claude/<id>`, legacy `claude-bridge/<id>`, or `*` for all models. Values are `low`, `medium`, `high`, `xhigh`, or `max`.
 
 ### Connectors
 
@@ -174,11 +174,11 @@ Bridge settings come only from the authoritative `<PI_CODING_AGENT_DIR>/claude-b
 
 ### Fable 5 and Opus 5 caveat
 
-The bridge registers `claude-bridge/claude-fable-5`, `claude-bridge/claude-opus-5`, `claude-bridge/claude-sonnet-5`, and `claude-bridge/claude-opus-4-8` even when Pi's Anthropic model registry has not shipped those entries yet. Fable 5 and Opus 5 both run classifiers that can decline a turn, so for each of them the bridge asks Claude Code to use Opus 4.8 as the availability fallback and preserves Claude Code's content-safety fallback events so Pi labels rerouted turns as Opus 4.8. Content-safety fallback still depends on Claude Code's own Fable 5 support; use Claude Code 2.1.170 or newer, and set `ANTHROPIC_DEFAULT_FABLE_MODEL` / `ANTHROPIC_DEFAULT_OPUS_MODEL` yourself when routing provider-specific model IDs through Bedrock, Vertex, or Foundry.
+The bridge registers `pi-claude/claude-fable-5`, `pi-claude/claude-opus-5`, `pi-claude/claude-sonnet-5`, and `pi-claude/claude-opus-4-8` even when Pi's Anthropic model registry has not shipped those entries yet. Fable 5 and Opus 5 both run classifiers that can decline a turn. In standalone mode, the bridge asks Claude Code to use Opus 4.8 as the availability fallback. With a managed account pool, every ready account's Fable allowance is tried before the router selects Opus; Opus then retains its normal Opus 4.8 safety fallback. The bridge preserves Claude Code's fallback events so Pi labels rerouted turns correctly. Content-safety fallback still depends on Claude Code's own Fable 5 support; use Claude Code 2.1.170 or newer, and set `ANTHROPIC_DEFAULT_FABLE_MODEL` / `ANTHROPIC_DEFAULT_OPUS_MODEL` yourself when routing provider-specific model IDs through Bedrock, Vertex, or Foundry.
 
 ## Connector inventory
 
-`/claude-bridge:connectors` lists the Claude account's installed claude.ai connectors by asking the account, not the model, so the answer is complete by construction.
+`/pi-claude:connectors` lists the Claude account's installed claude.ai connectors by asking the account, not the model, so the answer is complete by construction. `/claude-bridge:connectors` remains a legacy alias.
 
 `listAccountConnectors()` is the programmatic form for host apps. Import it from the package's `./connector-inventory` entry point:
 
@@ -194,9 +194,19 @@ import { listAccountConnectors } from "@vanillagreen/pi-claude-bridge";
 
 It returns a discriminated result: on success `{ ok: true, complete: true, connectors }`, and on any transport or protocol failure `{ ok: false, reason }`. An account with no connectors is a successful empty list; a failure is never reported as an empty inventory. Credentials resolve from `CLAUDE_CONFIG_DIR` before `$HOME`, so a host running one sidecar per Claude account reads the right account.
 
-## Extra usage and rate limits
+## Multiple subscription profiles
 
-Claude Code's `/extra-usage` local command works through the Claude Agent SDK. In Pi, use `/claude-bridge:extra` to run that flow from claude-bridge. Persist automatic launch on extra-usage errors with **Allow extra usage helper** in `/extensions:settings`.
+The optional `pi-claude` companion can provide account profiles through the bridge's versioned account-router integration. Canonical provider IDs are `pi-claude/*`; `claude-bridge/*` remains a legacy alias so existing saved sessions can resume.
+
+For each fresh Claude request, the bridge launches the Agent SDK subprocess with the selected profile's `CLAUDE_CONFIG_DIR`. Claude session files, connector inventory, and resume IDs remain account-scoped. Pi session markers persist only the opaque profile ID and effective model; the companion re-resolves the profile path when a session resumes. When an account reports a rejected rate limit, the bridge can rebuild the Claude session from Pi history under the next profile and retry the prompt.
+
+Retries are deliberately limited to failures before visible output, a Pi tool call, or a connector dispatch. Child-internal plumbing such as `ToolSearch` remains replay-neutral. Once text, thinking, a Pi tool call, or a child-executed connector call has begun, the bridge never replays that request on another account, preventing duplicate tool side effects. Post-output failures are still recorded so the next prompt can avoid the unhealthy account. Managed subscription subprocesses also drop inherited Anthropic API credentials and third-party provider flags so the selected Claude CLI profile remains the request's billing identity.
+
+`pi-claude` owns `/claude-auth`, profile metadata, utilization ranking, and cooldown persistence. The bridge remains the SDK/stream/session engine and can continue updating independently through the small versioned adapter.
+
+## Account usage and rate limits
+
+Extra Usage is owned by Claude's account settings. The bridge neither changes that setting nor blocks Claude Code's native account behavior. If Claude rejects a request because the current allowance is exhausted, the managed account router treats it as a model-scoped limit and can try another account.
 
 When Claude Code reports a rate-limit reset time, the bridge shows one clear `[rate-limit]` warning with timezone context and avoids repeating the same error line. If `pi-qol` is installed, it can use the reset time to resume later.
 

--- a/pi-extensions/pi-claude-bridge/bundle/index.js
+++ b/pi-extensions/pi-claude-bridge/bundle/index.js
@@ -27096,8 +27096,6 @@ function managerToConfig(raw) {
   const promptContext = {};
   const appendSystemPrompt = boolFrom(raw, "appendSystemPrompt");
   if (appendSystemPrompt !== void 0) provider.appendSystemPrompt = appendSystemPrompt;
-  const allowExtraUsage = boolFrom(raw, "allowExtraUsage");
-  if (allowExtraUsage !== void 0) provider.allowExtraUsage = allowExtraUsage;
   const fastMode = boolFrom(raw, "fastMode");
   if (fastMode !== void 0) provider.fastMode = fastMode;
   if (hasOwn(raw, "forceEffort")) {
@@ -27168,7 +27166,6 @@ function loadConfig(cwd) {
   };
 }
 var PROVIDER_KEYS = /* @__PURE__ */ new Set([
-  "allowExtraUsage",
   "appendSystemPrompt",
   "connectorWriteMode",
   "enableConnectors",
@@ -27671,7 +27668,11 @@ function connectorDeclarationsDisabled(env = process.env) {
 }
 
 // src/convert.ts
-var PROVIDER_ID = "claude-bridge";
+var PROVIDER_ID = "pi-claude";
+var LEGACY_PROVIDER_ID = "claude-bridge";
+function isClaudeProvider(provider) {
+  return provider === PROVIDER_ID || provider === LEGACY_PROVIDER_ID;
+}
 var PI_TO_SDK_TOOL_NAME = {
   read: "Read",
   write: "Write",
@@ -27739,7 +27740,7 @@ function assistantProvenancePrefix(msg) {
   const model = typeof msg.model === "string" ? msg.model : void 0;
   const api = typeof msg.api === "string" ? msg.api : void 0;
   if (!provider && !model && !api) return void 0;
-  if (provider === PROVIDER_ID || api === "anthropic") return void 0;
+  if (isClaudeProvider(provider) || api === "anthropic") return void 0;
   return `[Prior Pi assistant response from ${provider ?? api ?? "unknown-provider"}${model ? `/${model}` : ""}]
 `;
 }
@@ -27800,7 +27801,7 @@ function convertPiMessages(messages, customToolNameToSdk) {
           blocks.push({ type: "text", text: block.text });
         } else if (block.type === "thinking") {
           const sig = block.thinkingSignature;
-          const isAnthropicProvider = msg.provider === PROVIDER_ID || msg.api === "anthropic";
+          const isAnthropicProvider = isClaudeProvider(msg.provider) || msg.api === "anthropic";
           if (isAnthropicProvider && sig) {
             blocks.push({ type: "thinking", thinking: block.thinking ?? "", signature: sig });
           }
@@ -28024,6 +28025,9 @@ var QueryContext = class {
   reportedToolResultMismatch = false;
   deferredUserMessages = [];
   handledTerminalError = false;
+  // Once visible text/thinking or a complete tool call reaches Pi, the request
+  // must never be replayed on another account (duplicate side effects).
+  committedOutput = false;
   /** Armed grace timer for ending a tool_use turn whose terminal stream events
    *  (message_delta/message_stop) never arrive. The normal path ends the turn at
    *  message_stop, AFTER message_delta delivered the real output-token count;
@@ -28156,7 +28160,11 @@ var QueryContext = class {
    *  (ToolSearch et al.) is tool plumbing, not account-data access, so nothing
    *  about it belongs in the audit trail and no result needs matching. */
   noteChildExecutedToolCall(id, rawName, streamIndex) {
-    if (id && isConnectorTool(rawName)) {
+    const connector = isConnectorTool(rawName);
+    if (connector) {
+      this.markOutputCommitted();
+    }
+    if (id && connector) {
       this.childExecutedToolCalls.set(id, rawName);
       if (!this.connectorCallAudit.has(id)) {
         this.connectorCallAudit.set(id, {
@@ -28187,6 +28195,9 @@ var QueryContext = class {
   }
   hasRecordedToolCall(id) {
     return Boolean(id && (this.turnToolCallIds.includes(id) || this.turnToolCalls.some((call) => call.id === id)));
+  }
+  markOutputCommitted() {
+    this.committedOutput = true;
   }
   claimToolCall(toolName, args = {}) {
     const unclaimed = this.turnToolCalls.filter((call) => !this.claimedToolCallIds.has(call.id));
@@ -28401,6 +28412,44 @@ function toolResultIds(content) {
   }
   return ids;
 }
+function recoverLaterToolResults(messages) {
+  const recovered = [];
+  for (let i = 0; i < messages.length; i++) {
+    const assistant = messages[i];
+    if (assistant?.role !== "assistant") continue;
+    const uses = toolUses(assistant.content);
+    if (uses.length === 0) continue;
+    const target = messages[i + 1];
+    if (target?.role !== "user") continue;
+    const present = toolResultIds(target.content);
+    const missing = uses.filter((use2) => !present.has(use2.id));
+    if (missing.length === 0) continue;
+    for (const use2 of missing) {
+      let sourceBlock;
+      let sourceUserIndex = -1;
+      for (let j2 = i + 2; j2 < messages.length; j2++) {
+        const candidate = messages[j2];
+        if (candidate?.role !== "user") continue;
+        sourceBlock = contentBlocks(candidate.content).find(
+          (block) => block.type === "tool_result" && block.tool_use_id === use2.id
+        );
+        if (sourceBlock) {
+          sourceUserIndex = j2;
+          break;
+        }
+      }
+      if (!sourceBlock) continue;
+      const targetBlocks = Array.isArray(target.content) ? target.content : typeof target.content === "string" && target.content ? [{ type: "text", text: target.content }] : [];
+      const firstNonResult = targetBlocks.findIndex((block) => block.type !== "tool_result");
+      const insertAt = firstNonResult === -1 ? targetBlocks.length : firstNonResult;
+      targetBlocks.splice(insertAt, 0, { ...sourceBlock });
+      target.content = targetBlocks;
+      present.add(use2.id);
+      recovered.push({ id: use2.id, assistantIndex: i, sourceUserIndex, targetUserIndex: i + 1 });
+    }
+  }
+  return recovered;
+}
 function findUnpairedToolUses(messages) {
   const missing = [];
   for (let i = 0; i < messages.length; i++) {
@@ -28524,6 +28573,12 @@ function reportToolResultMismatch(queryCtx, reason, cwd, opts = {}) {
     queryCtx.reportedToolResultMismatch = true;
     if (sharedSession) {
       sharedSession = { ...sharedSession, needsRebuild: true, ...opts.forceRotate ? { forceRotate: true } : {} };
+    }
+    if (opts.expectedInterruption) {
+      debug(
+        `tool result delivery interrupted as expected during ${reason}; delivered=${progress.deliveredCount}/${progress.expectedCount} resolved=${progress.resolvedCount}/${progress.expectedCount} waiting=${progress.waitingCount} queued=${progress.queuedCount}`
+      );
+      return true;
     }
     const toolNameSummary = compactToolNameSummary(progress.toolNames);
     diagDump("tool_result_delivery_mismatch", {
@@ -28702,16 +28757,16 @@ function claudeAuthSourceLabel(env = process.env) {
   if (env.ANTHROPIC_AUTH_TOKEN?.trim()) return "ANTHROPIC_AUTH_TOKEN";
   return "Claude Code login";
 }
-function buildNativeProvider(piAi2, models, streamSimple, env = process.env) {
+function buildNativeProvider(piAi2, models, streamSimple, env = process.env, hasCredentials = () => hasClaudeCredentials(env), providerId = PROVIDER_ID, providerName = "Pi Claude") {
   if (!supportsNativeProvider(piAi2)) throw new Error(NATIVE_PROVIDER_UNSUPPORTED_MESSAGE);
-  const stamped = models.map((model) => ({ api: "claude-bridge", baseUrl: "claude-bridge", provider: PROVIDER_ID, ...model }));
+  const stamped = models.map((model) => ({ ...model, api: "claude-bridge", baseUrl: "claude-bridge", provider: providerId }));
   const streams = {
     stream: streamSimple,
     streamSimple
   };
   return piAi2.createProvider({
-    id: PROVIDER_ID,
-    name: "Claude (Claude Code)",
+    id: providerId,
+    name: providerName,
     baseUrl: "claude-bridge",
     auth: {
       apiKey: {
@@ -28719,8 +28774,8 @@ function buildNativeProvider(piAi2, models, streamSimple, env = process.env) {
         // check() exists so pi's availability pass never has to call
         // resolve(): both are existence-only, but check is the documented
         // side-effect-free probe.
-        check: async () => hasClaudeCredentials(env) ? { type: "api_key", source: claudeAuthSourceLabel(env) } : void 0,
-        resolve: async () => hasClaudeCredentials(env) ? { auth: { apiKey: "not-used" }, source: claudeAuthSourceLabel(env) } : void 0
+        check: async () => hasCredentials() ? { type: "api_key", source: claudeAuthSourceLabel(env) } : void 0,
+        resolve: async () => hasCredentials() ? { auth: { apiKey: "not-used" }, source: claudeAuthSourceLabel(env) } : void 0
       }
     },
     models: stamped,
@@ -44194,6 +44249,142 @@ import { createHash as createHash2 } from "crypto";
 import { realpathSync as realpathSync4, statSync as statSync4 } from "fs";
 import { resolve as pathResolve } from "path";
 
+// src/account-router.ts
+import { homedir as homedir4 } from "node:os";
+import { join as join10 } from "node:path";
+var CLAUDE_ACCOUNT_ROUTER_SYMBOL = /* @__PURE__ */ Symbol.for("vstack.pi.claude-account-router.v1");
+var CLAUDE_BRIDGE_ACCOUNT_HOST_SYMBOL = /* @__PURE__ */ Symbol.for("vstack.pi.claude-bridge.account-host.v1");
+function resolveClaudeAccountRouter() {
+  const host = globalThis;
+  const candidate = host[CLAUDE_ACCOUNT_ROUTER_SYMBOL];
+  return candidate?.version === 1 ? candidate : void 0;
+}
+function subscriberProfileEnv(profile, base = process.env) {
+  const env = { ...base };
+  const directOverrides = /* @__PURE__ */ new Set([
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_AUTH_TOKEN",
+    "ANTHROPIC_OAUTH_TOKEN",
+    "CLAUDE_CODE_OAUTH_TOKEN",
+    "ANTHROPIC_BASE_URL",
+    "ANTHROPIC_CUSTOM_HEADERS",
+    "ANTHROPIC_AWS_API_KEY",
+    "ANTHROPIC_FOUNDRY_AUTH_TOKEN",
+    "ANTHROPIC_BEDROCK_BASE_URL",
+    "ANTHROPIC_VERTEX_BASE_URL",
+    "ANTHROPIC_FOUNDRY_BASE_URL",
+    "AWS_BEARER_TOKEN_BEDROCK"
+  ]);
+  for (const key of Object.keys(env)) {
+    if (directOverrides.has(key) || key.startsWith("CLAUDE_CODE_USE_")) delete env[key];
+  }
+  const configDir = profile.configDir?.trim();
+  if (configDir) env.CLAUDE_CONFIG_DIR = configDir;
+  else delete env.CLAUDE_CONFIG_DIR;
+  return env;
+}
+function managedClaudeConfigDir(profile, base = process.env) {
+  const configured = profile.configDir?.trim();
+  if (configured) return configured;
+  const home = base.HOME?.trim() || homedir4();
+  return join10(home, ".claude");
+}
+function accountSessionScope(profile, base = process.env) {
+  return profile ? {
+    accountProfileId: profile.profileId,
+    claudeConfigDir: managedClaudeConfigDir(profile, base)
+  } : {};
+}
+function commitsVisibleOutput(event) {
+  if (event.type === "text_delta" || event.type === "thinking_delta" || event.type === "toolcall_delta") {
+    return event.delta.length > 0;
+  }
+  if (event.type === "text_end" || event.type === "thinking_end") return event.content.length > 0;
+  return event.type === "toolcall_end";
+}
+var RetryEventBuffer = class {
+  constructor(target, onCommit) {
+    this.target = target;
+    this.onCommit = onCommit;
+  }
+  target;
+  onCommit;
+  pending = [];
+  committed = false;
+  ended = false;
+  discarded = false;
+  push(event) {
+    if (this.discarded) return;
+    if (this.committed) {
+      this.target.push(event);
+      return;
+    }
+    this.pending.push(event);
+    if (commitsVisibleOutput(event) || event.type === "done" || event.type === "error") this.commit();
+  }
+  end() {
+    if (this.discarded) return;
+    this.ended = true;
+    if (this.committed) this.target.end();
+  }
+  commit() {
+    if (this.discarded || this.committed) return;
+    this.committed = true;
+    this.onCommit?.();
+    for (const event of this.pending) this.target.push(event);
+    this.pending.length = 0;
+    if (this.ended) this.target.end();
+  }
+  discard() {
+    if (this.committed) return;
+    this.discarded = true;
+    this.pending.length = 0;
+  }
+  get hasCommittedOutput() {
+    return this.committed;
+  }
+};
+function rateLimitTypeFromInfo(info) {
+  return info?.rateLimitType ?? info?.rate_limit_type ?? info?.type;
+}
+function rateLimitResetFromInfo(info) {
+  return info?.resetsAt ?? info?.resets_at ?? info?.resetAt ?? info?.reset_at;
+}
+function rateLimitResetMs(info) {
+  const value = rateLimitResetFromInfo(info);
+  if (typeof value === "number" && Number.isFinite(value)) return value < 1e12 ? value * 1e3 : value;
+  if (typeof value !== "string" || !value.trim()) return void 0;
+  const numeric = Number(value);
+  if (Number.isFinite(numeric)) return numeric < 1e12 ? numeric * 1e3 : numeric;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : void 0;
+}
+function classifyClaudeFailure(value) {
+  const details = [value];
+  if (value && typeof value === "object") {
+    const record2 = value;
+    details.push(record2.name, record2.message, record2.code, record2.status, record2.statusCode, record2.body, record2.error);
+  }
+  const text = details.map((detail) => {
+    if (typeof detail === "string" || typeof detail === "number") return String(detail);
+    try {
+      return JSON.stringify(detail ?? "");
+    } catch {
+      return String(detail);
+    }
+  }).join(" ");
+  const normalized = text.toLowerCase().replace(/[_-]+/g, " ");
+  const structuredStatus = value && typeof value === "object" ? Number(value.statusCode ?? value.status) : Number.NaN;
+  if (/\b401\b|authentication (?:failed|error)|oauth org not allowed|oauth token.*expired|token.*expired|unauthorized|invalid token|login required|please run .*login|not logged in/.test(normalized)) return "auth";
+  if (/extra usage|overage/.test(normalized)) return "rate-limit";
+  if (/billing error|payment|required.*billing|credit balance.*(?:low|insufficient|empty)|insufficient credits/.test(normalized)) return "billing";
+  if (/\b429\b|rate limit|usage limit|session limit|weekly limit|monthly limit|limit reached|you(?:'|’)ve hit your .* limit|(?:api|usage|request|token|model|account|subscription) quota|too many requests|resets? (?:at )?\d/.test(normalized)) return "rate-limit";
+  if (/overloaded|capacity/.test(normalized)) return "overloaded";
+  if (Number.isInteger(structuredStatus) && structuredStatus >= 500 && structuredStatus <= 599 || /server error|internal server|(?:http(?: status)?|status|response|error)\s*5\d\d\b/.test(normalized)) return "server";
+  if (/network|timeout|timed out|socket|econn|connection closed|fetch failed|unexpected end|\beof\b/.test(normalized)) return "network";
+  return void 0;
+}
+
 // src/session-verify.ts
 import { closeSync as closeSync2, openSync as openSync2, readSync as readSync2, statSync as statSync3 } from "fs";
 import { StringDecoder } from "node:string_decoder";
@@ -44299,9 +44490,9 @@ function latestPersistedBridgeSession(sessionManager) {
   }
   return void 0;
 }
-function claudeSessionExists(sessionId, cwd) {
+function claudeSessionExists(sessionId, cwd, claudeConfigDir) {
   try {
-    const session = openSession({ sessionId, projectPath: cwd, claudeDir: process.env.CLAUDE_CONFIG_DIR });
+    const session = openSession({ sessionId, projectPath: cwd, claudeDir: claudeConfigDir });
     statSync4(session.jsonlPath);
     return true;
   } catch {
@@ -44315,6 +44506,26 @@ function canonicalize(p2) {
   } catch {
     return pathResolve(p2);
   }
+}
+function resolvePersistedAccountScope(persisted, currentPiSessionId) {
+  if (!persisted.accountProfileId) {
+    return {
+      scope: persisted.claudeConfigDir ? { claudeConfigDir: persisted.claudeConfigDir } : {}
+    };
+  }
+  const route = persisted.modelId ? resolveClaudeAccountRouter()?.current(persisted.modelId, currentPiSessionId) : void 0;
+  if (route?.profileId === persisted.accountProfileId) {
+    return { scope: accountSessionScope(route) };
+  }
+  if (persisted.claudeConfigDir) {
+    return {
+      scope: {
+        accountProfileId: persisted.accountProfileId,
+        claudeConfigDir: persisted.claudeConfigDir
+      }
+    };
+  }
+  return { rejection: "managed profile could not be re-resolved" };
 }
 function shouldRestorePersistedBridgeEntry(persisted, currentPiSessionId, currentCwd) {
   if (!persisted.piSessionId) return "missing piSessionId";
@@ -44336,6 +44547,11 @@ function restoreSharedSessionFromPi(ctx2) {
     debug(`restoreSharedSession: ${rejection} \u2014 forcing rebuild`);
     return;
   }
+  const accountScope = resolvePersistedAccountScope(persisted, currentPiSessionId);
+  if (!accountScope.scope) {
+    debug(`restoreSharedSession: ${accountScope.rejection ?? "account scope unavailable"} \u2014 forcing rebuild`);
+    return;
+  }
   const built = readBuiltSessionContext(ctx2.sessionManager);
   if (!built) return;
   const cursor = Math.max(0, Math.min(persisted.cursor, built.messages.length));
@@ -44344,26 +44560,41 @@ function restoreSharedSessionFromPi(ctx2) {
     debug(`restoreSharedSession: fingerprint mismatch for ${persisted.sessionId.slice(0, 8)}`);
     return;
   }
-  if (!claudeSessionExists(persisted.sessionId, persisted.cwd)) {
+  if (!claudeSessionExists(persisted.sessionId, persisted.cwd, accountScope.scope.claudeConfigDir)) {
     debug(`restoreSharedSession: Claude session missing for ${persisted.sessionId.slice(0, 8)}`);
     return;
   }
-  setSharedSession({ sessionId: persisted.sessionId, cursor, cwd: persisted.cwd });
+  setSharedSession({
+    sessionId: persisted.sessionId,
+    cursor,
+    cwd: persisted.cwd,
+    ...persisted.modelId ? { modelId: persisted.modelId } : {},
+    ...accountScope.scope
+  });
   debug(`restoreSharedSession: restored ${persisted.sessionId.slice(0, 8)}, cursor=${cursor}`);
+}
+var scheduledPersistenceTimers = /* @__PURE__ */ new Set();
+function cancelScheduledSessionPersistence() {
+  for (const timer of scheduledPersistenceTimers) clearTimeout(timer);
+  scheduledPersistenceTimers.clear();
 }
 function schedulePersistSharedSession(ctxLike) {
   if (!extensionApi || !sharedSession || !ctxLike?.sessionManager) return;
+  const sessionManager = ctxLike.sessionManager;
   const snapshot = { ...sharedSession };
   const timer = setTimeout(() => {
+    scheduledPersistenceTimers.delete(timer);
     try {
-      const built = readBuiltSessionContext(ctxLike.sessionManager);
+      const built = readBuiltSessionContext(sessionManager);
       if (!built) return;
       const cursor = Math.max(0, Math.min(snapshot.cursor, built.messages.length));
+      const persistableSnapshot = { ...snapshot };
+      delete persistableSnapshot.claudeConfigDir;
       const data = {
-        ...snapshot,
+        ...persistableSnapshot,
         cursor,
         fingerprint: fingerprintMessages(built.messages.slice(0, cursor)),
-        piSessionId: typeof ctxLike.sessionManager?.getSessionId === "function" ? ctxLike.sessionManager.getSessionId() : void 0,
+        piSessionId: typeof sessionManager?.getSessionId === "function" ? sessionManager.getSessionId() : void 0,
         updatedAt: (/* @__PURE__ */ new Date()).toISOString()
       };
       extensionApi?.appendEntry(BRIDGE_SESSION_CUSTOM_TYPE, data);
@@ -44372,6 +44603,7 @@ function schedulePersistSharedSession(ctxLike) {
       debug("persistSharedSession failed:", error51);
     }
   }, 0);
+  scheduledPersistenceTimers.add(timer);
   timer.unref?.();
 }
 function convertAndImportMessages(session, messages, customToolNameToSdk, cwd) {
@@ -44387,6 +44619,13 @@ function convertAndImportMessages(session, messages, customToolNameToSdk, cwd) {
     debug(
       `convertAndImportMessages: sanitized ${sanitizedIds.size} tool IDs:`,
       [...sanitizedIds.entries()].map(([orig, clean]) => orig === clean ? orig : `${orig}\u2192${clean}`).join(", ")
+    );
+  }
+  const recoveredToolResults = recoverLaterToolResults(anthropicMessages);
+  if (recoveredToolResults.length > 0) {
+    debug(
+      `convertAndImportMessages: recovered ${recoveredToolResults.length} later tool result(s) for original parallel batch`,
+      recoveredToolResults.map((item) => item.id).join(", ")
     );
   }
   const missingToolResults = findUnpairedToolUses(anthropicMessages);
@@ -44422,17 +44661,17 @@ function planIncrementalPromptBatch(messages, cursor) {
     userMessageCount: pendingPrompts.length
   };
 }
-function verifyWrittenSession2(jsonlPath, expectedSessionId, expectedRecordCount, cwd) {
+function verifyWrittenSession2(jsonlPath, expectedSessionId, expectedRecordCount, cwd, claudeConfigDir) {
   const warnings = verifyWrittenSession(jsonlPath, expectedSessionId, expectedRecordCount);
   for (const msg of warnings) {
     debug(`WARNING session verify: ${msg}`);
     piUI?.notify(
       `Session file issue: ${msg}
-cwd=${cwd} realpath=${safeRealpath(cwd)} CLAUDE_CONFIG_DIR=${process.env.CLAUDE_CONFIG_DIR ?? "(unset)"}
+cwd=${cwd} realpath=${safeRealpath(cwd)} CLAUDE_CONFIG_DIR=${claudeConfigDir ?? "(unset)"}
 Please copy and paste this message into a new issue at https://github.com/elidickinson/pi-claude-bridge/issues/new` + (DEBUG ? ` and attach ${DEBUG_LOG_PATH}` : ` (rerun with CLAUDE_BRIDGE_DEBUG=1 to capture a debug log)`),
       "warning"
     );
-    diagDump("session_verify_fail", { msg, jsonlPath, cwd, realpath: safeRealpath(cwd), claudeConfigDir: process.env.CLAUDE_CONFIG_DIR ?? null });
+    diagDump("session_verify_fail", { msg, jsonlPath, cwd, realpath: safeRealpath(cwd), claudeConfigDir: claudeConfigDir ?? null });
   }
 }
 function safeRealpath(p2) {
@@ -44442,7 +44681,7 @@ function safeRealpath(p2) {
     return `<failed: ${e.message}>`;
   }
 }
-function debugSessionPaths(label, cwd, jsonlPath) {
+function debugSessionPaths(label, cwd, jsonlPath, claudeConfigDir) {
   const realCwd = safeRealpath(cwd);
   let fileSize = null;
   let fileExists = false;
@@ -44456,17 +44695,27 @@ function debugSessionPaths(label, cwd, jsonlPath) {
   if (realCwd !== cwd) debug(`${label}: realpath(cwd)=${realCwd} (DIFFERS \u2014 symlink-resolved path is what CC SDK uses)`);
   debug(`${label}: jsonlPath=${jsonlPath}`);
   debug(`${label}: fileExists=${fileExists}${fileSize != null ? ` size=${fileSize}` : ""}`);
-  debug(`${label}: env.CLAUDE_CONFIG_DIR=${process.env.CLAUDE_CONFIG_DIR ?? "(unset)"} HOME=${process.env.HOME ?? "(unset)"}`);
+  debug(`${label}: selected.CLAUDE_CONFIG_DIR=${claudeConfigDir ?? "(unset)"} HOME=${process.env.HOME ?? "(unset)"}`);
 }
-function syncSharedSession(messages, cwd, customToolNameToSdk, modelId) {
+function syncSharedSession(messages, cwd, customToolNameToSdk, modelId, account) {
   const priorMessages = messages.slice(0, -1);
-  if (sharedSession && !sharedSession.needsRebuild) {
+  const accountProfileId = account?.accountProfileId;
+  const claudeConfigDir = account?.claudeConfigDir;
+  const sameAccount = Boolean(
+    sharedSession && sharedSession.accountProfileId === accountProfileId && sharedSession.claudeConfigDir === claudeConfigDir
+  );
+  if (sharedSession && sameAccount && !sharedSession.needsRebuild) {
     const batch = planIncrementalPromptBatch(messages, sharedSession.cursor);
     if (batch) {
-      setSharedSession({ ...sharedSession, cursor: batch.promptStart, cwd });
+      setSharedSession({
+        ...sharedSession,
+        cursor: batch.promptStart,
+        cwd,
+        ...modelId ? { modelId } : {}
+      });
       const batching = batch.userMessageCount > 1 ? `batched ${batch.userMessageCount} consecutive user messages, ` : batch.promptStart > sharedSession.cursor ? "advanced cursor past trailing assistant, " : "";
       debug(`Case 3: ${batching}resuming session ${sharedSession.sessionId.slice(0, 8)}, cursor=${batch.promptStart}`);
-      debug(`syncResult: path=reuse sessionId=${sharedSession.sessionId} cursor=${batch.promptStart} promptUsers=${batch.userMessageCount}`);
+      debug(`syncResult: path=reuse sessionId=${sharedSession.sessionId} cursor=${batch.promptStart} promptUsers=${batch.userMessageCount} account=${accountProfileId ?? "default"}`);
       return {
         sessionId: sharedSession.sessionId,
         promptStart: batch.promptStart
@@ -44474,36 +44723,46 @@ function syncSharedSession(messages, cwd, customToolNameToSdk, modelId) {
     }
   }
   if (priorMessages.length === 0) {
-    debug(`Case 1: clean start, ${messages.length} total messages`);
+    debug(`Case 1: clean start, ${messages.length} total messages, account=${accountProfileId ?? "default"}`);
     debug(`syncResult: path=clean-start`);
     return { sessionId: null, promptStart: messages.length - 1 };
   }
-  const previousSessionId = sharedSession?.sessionId;
-  const previousCursor = sharedSession?.cursor ?? 0;
+  const replacedSessionId = sharedSession?.sessionId;
+  const previousSessionId = sameAccount ? sharedSession?.sessionId : void 0;
+  const previousCursor = sameAccount ? sharedSession?.cursor ?? 0 : 0;
   const preserveId = previousSessionId !== void 0 && !sharedSession?.forceRotate;
   if (preserveId) {
-    deleteSession(previousSessionId, cwd, process.env.CLAUDE_CONFIG_DIR);
+    deleteSession(previousSessionId, cwd, claudeConfigDir);
   }
   const session = createSession({
     projectPath: cwd,
-    claudeDir: process.env.CLAUDE_CONFIG_DIR,
+    claudeDir: claudeConfigDir,
     ...preserveId ? { sessionId: previousSessionId } : {},
     ...modelId ? { model: modelId } : {}
   });
   convertAndImportMessages(session, priorMessages, customToolNameToSdk, cwd);
   session.save();
-  verifyWrittenSession2(session.jsonlPath, session.sessionId, session.messages.length, cwd);
-  setSharedSession({ sessionId: session.sessionId, cursor: priorMessages.length, cwd });
-  if (previousSessionId === void 0) {
+  verifyWrittenSession2(session.jsonlPath, session.sessionId, session.messages.length, cwd, claudeConfigDir);
+  setSharedSession({
+    sessionId: session.sessionId,
+    cursor: priorMessages.length,
+    cwd,
+    ...modelId ? { modelId } : {},
+    ...accountProfileId ? { accountProfileId } : {},
+    ...claudeConfigDir ? { claudeConfigDir } : {}
+  });
+  if (!replacedSessionId) {
     debug(`Case 2: first turn with ${priorMessages.length} prior messages \u2192 session ${session.sessionId.slice(0, 8)}, ${session.messages.length} records`);
+  } else if (!sameAccount) {
+    debug(`Case 4 account-rotation: ${priorMessages.length} prior messages \u2192 new session ${session.sessionId.slice(0, 8)} for account ${accountProfileId ?? "default"} (replaced ${replacedSessionId.slice(0, 8)})`);
   } else if (preserveId) {
     const missedCount = priorMessages.length - previousCursor;
     debug(`Case 4: ${missedCount} missed messages, ${priorMessages.length} total \u2192 rewrote session ${session.sessionId.slice(0, 8)} (same id), ${session.messages.length} records`);
   } else {
     debug(`Case 4 post-abort: ${priorMessages.length} total \u2192 new session ${session.sessionId.slice(0, 8)} (was ${previousSessionId.slice(0, 8)}, rotated to avoid race with orphan writer), ${session.messages.length} records`);
   }
-  debugSessionPaths(`${session.sessionId.slice(0, 8)}`, cwd, session.jsonlPath);
-  debug(`syncResult: path=rebuild sessionId=${session.sessionId} priors=${priorMessages.length} ${previousSessionId === void 0 ? "first" : preserveId ? "preserved" : "rotated-post-abort"}`);
+  debugSessionPaths(`${session.sessionId.slice(0, 8)}`, cwd, session.jsonlPath, claudeConfigDir);
+  debug(`syncResult: path=rebuild sessionId=${session.sessionId} priors=${priorMessages.length} account=${accountProfileId ?? "default"} ${!replacedSessionId ? "first" : preserveId ? "preserved" : "rotated-post-abort"}`);
   return { sessionId: session.sessionId, promptStart: messages.length - 1 };
 }
 
@@ -44605,9 +44864,6 @@ function coerceMessageText(value) {
   } catch {
     return String(value);
   }
-}
-function isExtraUsageRequiredMessage(value) {
-  return /extra[-\s]?usage|overage|extra usage billing|extra usage credits|1M context/i.test(coerceMessageText(value));
 }
 function isUsageLimitMessage(value) {
   const text = coerceMessageText(value);
@@ -45094,16 +45350,17 @@ var newAssistantMessageEventStream = typeof _piAi.createAssistantMessageEventStr
 var PRIMARY_INSTANCE_KEY = /* @__PURE__ */ Symbol.for("claude-bridge:primaryInstance");
 var ACTIVE_STREAM_SIMPLE_KEY = /* @__PURE__ */ Symbol.for("claude-bridge:activeStreamSimple");
 var COMMANDS_REGISTERED_KEY = /* @__PURE__ */ Symbol.for("claude-bridge:commandsRegistered");
+var ROTATION_STATE_KEY = /* @__PURE__ */ Symbol("claude-bridge:rotationState");
 var MODELS = buildModels(getModels("anthropic"));
-var extraUsageHelperInFlight = null;
+var sdkQueryFactory = Okt;
+function __testSetSdkQueryFactory(factory) {
+  sdkQueryFactory = factory ?? Okt;
+}
 function emitRateLimitEvent(payload) {
   try {
     extensionApi?.events?.emit?.(RATE_LIMIT_AUTO_RESUME_EVENT, payload);
   } catch {
   }
-}
-function extraUsageAllowed(config2) {
-  return config2.provider?.allowExtraUsage === true;
 }
 var lastFastModeDisabledNoticeReason = null;
 var FAST_MODE_DISABLED_REASON_TEXT = {
@@ -45124,60 +45381,65 @@ function noteFastModeDisabledReason(message, bridgeConfig) {
   if (reason === lastFastModeDisabledNoticeReason) return;
   lastFastModeDisabledNoticeReason = reason;
   const text = FAST_MODE_DISABLED_REASON_TEXT[reason] ?? `unavailable (${reason})`;
-  safeNotify(`Claude bridge: fast mode is enabled in settings but Claude Code declined it \u2014 ${text}.`, "warning");
+  safeNotify(`Pi Claude: fast mode is enabled in settings but Claude Code declined it \u2014 ${text}.`, "warning");
 }
-function sdkTextFromMessage(message) {
-  if (message.type === "result") return message.result;
-  if (message.type === "assistant") {
-    const content = message.message?.content;
-    if (!Array.isArray(content)) return void 0;
-    return content.map((block) => block?.type === "text" && typeof block.text === "string" ? block.text : "").filter(Boolean).join("\n");
-  }
-  return void 0;
-}
-async function runExtraUsageHelper(cwd, config2 = loadConfig(cwd)) {
-  const providerSettings = config2.provider ?? {};
-  const claudeExecutable = resolveClaudeExecutable(providerSettings.pathToClaudeCodeExecutable);
-  if (claudeExecutable) preflightClaudeExecutable(claudeExecutable, cwd);
-  const helperQuery = Okt({
-    prompt: "/extra-usage",
+async function probeClaudeAccountProfile(input) {
+  const config2 = loadConfig(input.cwd);
+  const claudeExecutable = resolveClaudeExecutable(config2.provider?.pathToClaudeCodeExecutable);
+  if (claudeExecutable) preflightClaudeExecutable(claudeExecutable, input.cwd);
+  const probe = sdkQueryFactory({
+    prompt: "/usage",
     options: {
-      cwd,
-      env: { ...process.env, ENABLE_CLAUDEAI_MCP_SERVERS: "0", DISABLE_AUTO_COMPACT: "1" },
+      cwd: input.cwd,
+      env: {
+        ...subscriberProfileEnv(input.profile),
+        ENABLE_CLAUDEAI_MCP_SERVERS: "0",
+        DISABLE_AUTO_COMPACT: "1"
+      },
       maxTurns: 1,
+      permissionMode: "bypassPermissions",
       ...claudeExecutable ? { pathToClaudeCodeExecutable: claudeExecutable } : {},
       spawnClaudeCodeProcess: spawnClaudeCodeWithDiagnostics,
-      ...makeCliDebugOptions("extra-usage")
+      ...makeCliDebugOptions("account-probe")
     }
   });
-  const outputs = [];
+  const onAbort = () => {
+    void probe.interrupt().catch(() => {
+    });
+    try {
+      probe.close();
+    } catch {
+    }
+  };
+  if (input.signal?.aborted) onAbort();
+  else input.signal?.addEventListener("abort", onAbort, { once: true });
+  let controls;
   try {
-    for await (const message of helperQuery) {
-      const text = sdkTextFromMessage(message)?.trim();
-      if (text && outputs[outputs.length - 1] !== text) outputs.push(text);
+    for await (const message of probe) {
+      if (message.type === "system" && message.subtype === "init" && !controls) {
+        controls = Promise.allSettled([
+          probe.accountInfo(),
+          probe.usage_EXPERIMENTAL_MAY_CHANGE_DO_NOT_RELY_ON_THIS_API_YET()
+        ]).then(([identityResult, usageResult]) => ({
+          ...identityResult.status === "fulfilled" ? { identity: {
+            email: identityResult.value.email,
+            organization: identityResult.value.organization,
+            subscriptionType: identityResult.value.subscriptionType
+          } } : {},
+          ...usageResult.status === "fulfilled" ? { usage: usageResult.value } : {}
+        }));
+      }
     }
+    return controls ? await controls : {};
   } finally {
-    helperQuery.close();
+    input.signal?.removeEventListener("abort", onAbort);
+    probe.close();
   }
-  return outputs.join("\n").trim() || "Claude Code /extra-usage completed.";
 }
-function launchExtraUsageHelperIfAllowed(cwd, config2, reason) {
-  if (!extraUsageAllowed(config2)) return false;
-  if (extraUsageHelperInFlight) return true;
-  extraUsageHelperInFlight = runExtraUsageHelper(cwd, config2).then((message) => {
-    piUI?.notify(`Claude extra usage helper: ${message}`, "info");
-    return message;
-  }).catch((error51) => {
-    const message = error51 instanceof Error ? error51.message : String(error51);
-    piUI?.notify(`Claude extra usage helper failed after ${reason}: ${message}`, "error");
-    throw error51;
-  }).finally(() => {
-    extraUsageHelperInFlight = null;
-  });
-  void extraUsageHelperInFlight.catch(() => {
-  });
-  return true;
-}
+var BRIDGE_ACCOUNT_HOST = {
+  version: 1,
+  probeProfile: probeClaudeAccountProfile
+};
 function extractAllToolResults2(context) {
   const { results, stopIdx } = extractAllToolResults(context.messages);
   debug(`extractAllToolResults: ${results.length} results from ${context.messages.length} msgs, stopped at index ${stopIdx}`);
@@ -45346,7 +45608,12 @@ var REASONING_TO_EFFORT = {
 };
 function normalizeEffortOverrideModelKey(value) {
   const key = value.trim().toLowerCase();
-  return key.startsWith(`${PROVIDER_ID}/`) ? key.slice(PROVIDER_ID.length + 1) : key;
+  for (const providerId of [PROVIDER_ID, LEGACY_PROVIDER_ID]) {
+    if (key.startsWith(`${providerId}/`)) {
+      return key.slice(providerId.length + 1);
+    }
+  }
+  return key;
 }
 function resolveConfiguredEffort(modelId, reasoningEffort, providerConfig) {
   const target = normalizeEffortOverrideModelKey(modelId);
@@ -45358,22 +45625,41 @@ function resolveConfiguredEffort(modelId, reasoningEffort, providerConfig) {
   }
   return normalizeEffortLevel(providerConfig?.forceEffort) ?? reasoningEffort;
 }
-async function consumeQuery(sdkQuery, customToolNameToPi, model, cwd, bridgeConfig, wasAborted) {
+async function consumeQuery(sdkQuery, customToolNameToPi, model, bridgeConfig, wasAborted, account, router) {
   let capturedSessionId;
+  let failure;
+  let accountProbe;
   for await (const message of sdkQuery) {
     if (wasAborted()) break;
     const queryCtx = ctx();
     activeStreamIdleWatchdogs.get(queryCtx)?.noteChunk();
+    if (account) {
+      debug("consumeQuery: managed message", JSON.stringify({
+        type: message.type,
+        subtype: message.subtype,
+        error: message.error,
+        eventType: message.event?.type,
+        deltaType: message.event?.delta?.type,
+        contentType: message.event?.content_block?.type
+      }));
+    }
     if (!queryCtx.turnOutput) continue;
     if (!queryCtx.currentPiStream && !(message.type === "assistant" && queryCtx.turnSawToolCall)) continue;
     switch (message.type) {
       case "stream_event":
         processStreamEvent(message, customToolNameToPi, model);
         break;
-      case "assistant":
+      case "assistant": {
+        const sdkError = message.error;
+        if (sdkError && account && !failure) {
+          failure = { kind: classifyClaudeFailure(sdkError), message: String(sdkError) };
+        }
+        if (sdkError && account) break;
         processAssistantMessage(message, model, customToolNameToPi);
         break;
+      }
       case "result":
+        if (account && failure) break;
         if (!ctx().turnSawStreamEvent && message.subtype === "success") {
           const text = message.result || "";
           if (ctx().turnBlocks.some((b) => b.type === "text" && b.text === text)) {
@@ -45386,18 +45672,22 @@ async function consumeQuery(sdkQuery, customToolNameToPi, model, cwd, bridgeConf
           ctx().currentPiStream?.push({ type: "text_start", contentIndex: idx, partial: ctx().turnOutput });
           ctx().currentPiStream?.push({ type: "text_delta", contentIndex: idx, delta: text, partial: ctx().turnOutput });
           ctx().currentPiStream?.push({ type: "text_end", contentIndex: idx, content: text, partial: ctx().turnOutput });
-        } else if (message.subtype !== "success" && (isExtraUsageRequiredMessage(message) || isUsageLimitMessage(message))) {
+        } else if (message.subtype !== "success") {
           const errorLines = Array.isArray(message.errors) ? uniqueNonEmptyLines(message.errors) : [];
-          const errors = errorLines.length > 0 ? errorLines.join("\n") : String(message.subtype ?? "Claude Code rate limit");
-          const extraUsage = isExtraUsageRequiredMessage(message);
-          const openedExtraUsage = extraUsage && launchExtraUsageHelperIfAllowed(cwd, bridgeConfig, "result error");
-          ctx().handledTerminalError = true;
-          ctx().turnOutput.stopReason = "error";
-          const extraUsageHint = openedExtraUsage ? "\n\nOpened Claude Code /extra-usage helper. Complete billing/admin flow in the browser, then retry the prompt." : extraUsage ? "\n\nRun /claude-bridge:extra, or enable Allow extra usage helper in settings." : "";
-          ctx().turnOutput.errorMessage = `${errors}${extraUsageHint}`;
-          ctx().currentPiStream?.push({ type: "error", reason: "error", error: ctx().turnOutput });
-          ctx().currentPiStream?.end();
-          ctx().currentPiStream = null;
+          const errors = errorLines.length > 0 ? errorLines.join("\n") : String(message.result || message.subtype || "Claude Code request failed");
+          const usageLimit = isUsageLimitMessage(message);
+          if ((account || usageLimit) && (!failure || !failure.rateLimitInfo)) {
+            failure = { kind: usageLimit ? "rate-limit" : classifyClaudeFailure(errors), message: errors };
+          }
+          if (account) break;
+          if (usageLimit) {
+            ctx().handledTerminalError = true;
+            ctx().turnOutput.stopReason = "error";
+            ctx().turnOutput.errorMessage = errors;
+            ctx().currentPiStream?.push({ type: "error", reason: "error", error: ctx().turnOutput });
+            ctx().currentPiStream?.end();
+            ctx().currentPiStream = null;
+          }
         }
         break;
       case "system":
@@ -45405,6 +45695,16 @@ async function consumeQuery(sdkQuery, customToolNameToPi, model, cwd, bridgeConf
           capturedSessionId = message.session_id;
           queryCtx.childSessionId = capturedSessionId;
           noteFastModeDisabledReason(message, bridgeConfig);
+          if (account && router && !accountProbe) {
+            accountProbe = Promise.allSettled([
+              sdkQuery.accountInfo().then((info) => router.recordIdentity(account.profileId, {
+                email: info.email,
+                organization: info.organization,
+                subscriptionType: info.subscriptionType
+              })),
+              sdkQuery.usage_EXPERIMENTAL_MAY_CHANGE_DO_NOT_RELY_ON_THIS_API_YET().then((usage) => router.recordUsage(account.profileId, usage))
+            ]).then(() => void 0);
+          }
         } else if (message.subtype === "model_refusal_fallback") {
           const originalModel = message.original_model;
           const fallbackModel = message.fallback_model;
@@ -45412,7 +45712,7 @@ async function consumeQuery(sdkQuery, customToolNameToPi, model, cwd, bridgeConf
           debug("consumeQuery: model_refusal_fallback", JSON.stringify({ originalModel, fallbackModel }));
           if (typeof fallbackModel === "string" && typeof originalModel === "string" && fallbackModelForPrimaryModel(originalModel) === fallbackModel) {
             safeNotify(
-              `Claude bridge switched ${modelDisplayName(originalModel)} to ${modelDisplayName(fallbackModel)} after Claude Code safety fallback.`,
+              `Pi Claude switched ${modelDisplayName(originalModel)} to ${modelDisplayName(fallbackModel)} after Claude Code safety fallback.`,
               "info"
             );
           }
@@ -45425,21 +45725,27 @@ async function consumeQuery(sdkQuery, customToolNameToPi, model, cwd, bridgeConf
         const info = message.rate_limit_info;
         debug("consumeQuery: rate_limit_event", JSON.stringify(info).slice(0, 300));
         if (info?.status === "rejected") {
-          const resetsAt = formatResetTimestamp(info.resetsAt);
-          const resetAtMs = resetTimestampMs(info.resetsAt);
-          const reason = `${info.rateLimitType ?? "unknown"} rate limit`;
-          const launchedExtraUsage = isExtraUsageRequiredMessage(info) && launchExtraUsageHelperIfAllowed(cwd, bridgeConfig, reason);
-          emitRateLimitEvent({
-            model: model.id,
-            provider: PROVIDER_ID,
-            rateLimitType: info.rateLimitType,
-            reason,
-            resetAt: info.resetsAt,
-            ...Number.isFinite(resetAtMs) ? { resetAtMs } : {},
-            source: "claude-bridge",
-            status: "rejected"
-          });
-          piUI?.notify(`${RATE_LIMIT_TOKEN} Claude ${reason} hit \u2014 resets ${resetsAt}${launchedExtraUsage ? "; opened /extra-usage helper" : ""}`, "warning");
+          const rateLimitType = rateLimitTypeFromInfo(info);
+          const resetAt = rateLimitResetFromInfo(info);
+          const resetAtMs = rateLimitResetMs(info);
+          const reason = `${rateLimitType ?? "unknown"} rate limit`;
+          if (account) {
+            failure = { kind: "rate-limit", message: reason, rateLimitInfo: info };
+            router?.recordRateLimit(account.profileId, info, model.id);
+          } else {
+            const resetsAt = formatResetTimestamp(resetAtMs ?? resetAt);
+            emitRateLimitEvent({
+              model: model.id,
+              provider: model.provider,
+              rateLimitType,
+              reason,
+              resetAt,
+              ...Number.isFinite(resetAtMs) ? { resetAtMs } : {},
+              source: "claude-bridge",
+              status: "rejected"
+            });
+            piUI?.notify(`${RATE_LIMIT_TOKEN} Claude ${reason} hit \u2014 resets ${resetsAt}`, "warning");
+          }
         } else if (info?.status === "allowed_warning") {
           const warning = formatAllowedRateLimitWarning(info);
           if (warning) piUI?.notify(warning, "warning");
@@ -45452,8 +45758,14 @@ async function consumeQuery(sdkQuery, customToolNameToPi, model, cwd, bridgeConf
         break;
     }
   }
-  debug(`consumeQuery: for-await loop exited, wasAborted=${wasAborted()}, capturedSessionId=${capturedSessionId?.slice(0, 8) ?? "none"}`);
-  return { capturedSessionId };
+  if (accountProbe) {
+    await Promise.race([
+      accountProbe,
+      new Promise((resolve5) => setTimeout(resolve5, 1500))
+    ]);
+  }
+  debug(`consumeQuery: for-await loop exited, wasAborted=${wasAborted()}, capturedSessionId=${capturedSessionId?.slice(0, 8) ?? "none"}, failure=${failure?.kind ?? "none"}`);
+  return { capturedSessionId, failure };
 }
 function claimPrimaryInstance() {
   const g = globalThis;
@@ -45462,6 +45774,9 @@ function claimPrimaryInstance() {
 }
 function releaseProviderTokens(event) {
   const g = globalThis;
+  if (g[CLAUDE_BRIDGE_ACCOUNT_HOST_SYMBOL] === BRIDGE_ACCOUNT_HOST) {
+    g[CLAUDE_BRIDGE_ACCOUNT_HOST_SYMBOL] = void 0;
+  }
   if (g[ACTIVE_STREAM_SIMPLE_KEY] === streamClaudeAgentSdk) {
     debug(`${event}: clearing ACTIVE_STREAM_SIMPLE_KEY`);
     g[ACTIVE_STREAM_SIMPLE_KEY] = void 0;
@@ -45471,7 +45786,7 @@ function releaseProviderTokens(event) {
     g[PRIMARY_INSTANCE_KEY] = void 0;
   }
 }
-var nativeProviderInstance;
+var nativeProviderInstances = /* @__PURE__ */ new Map();
 var notifiedNativeUnsupported = false;
 function applyProviderRegistration(trigger) {
   const pi = extensionApi;
@@ -45493,13 +45808,38 @@ function applyProviderRegistration(trigger) {
     }
     return;
   }
-  const credentialed = hasClaudeCredentials();
+  const credentialed = hasClaudeCredentials() || Boolean(resolveClaudeAccountRouter());
   debug(`${trigger}: native registration upsert, credentialed=${credentialed} (module=${moduleInstanceId})`);
-  if (credentialed && connectorsEnabledFor(loadConfig(process.cwd()))) primeConnectorServers();
+  if (hasClaudeCredentials() && connectorsEnabledFor(loadConfig(process.cwd()))) primeConnectorServers();
   g[ACTIVE_STREAM_SIMPLE_KEY] = streamClaudeAgentSdk;
   try {
-    nativeProviderInstance ??= buildNativeProvider(_piAi, MODELS, streamClaudeAgentSdk);
-    pi.registerProvider(nativeProviderInstance);
+    const authProbe = () => hasClaudeCredentials() || Boolean(resolveClaudeAccountRouter());
+    const providerFor = (providerId, providerName) => {
+      let provider = nativeProviderInstances.get(providerId);
+      if (!provider) {
+        provider = buildNativeProvider(
+          _piAi,
+          MODELS,
+          streamClaudeAgentSdk,
+          process.env,
+          authProbe,
+          providerId,
+          providerName
+        );
+        nativeProviderInstances.set(providerId, provider);
+      }
+      return provider;
+    };
+    pi.registerProvider(
+      providerFor(PROVIDER_ID, "Pi Claude")
+    );
+    try {
+      pi.registerProvider(
+        providerFor(LEGACY_PROVIDER_ID, "Pi Claude (legacy alias)")
+      );
+    } catch (legacyError) {
+      debug(`${trigger}: legacy provider alias registration failed:`, legacyError);
+    }
   } catch (err) {
     if (g[ACTIVE_STREAM_SIMPLE_KEY] === streamClaudeAgentSdk) g[ACTIVE_STREAM_SIMPLE_KEY] = void 0;
     debug(`${trigger}: registerProvider threw; released stream guard for retry (kept primary):`, err);
@@ -45587,7 +45927,7 @@ function streamClaudeAgentSdk(model, context, options) {
     });
     return stream;
   }
-  if (!hasClaudeCredentials()) {
+  if (!hasClaudeCredentials() && !resolveClaudeAccountRouter()) {
     try {
       applyProviderRegistration("pre-spawn");
     } catch {
@@ -45628,13 +45968,81 @@ function streamClaudeAgentSdk(model, context, options) {
   ctx().resetTurnState(model);
   ctx().resetToolTracking();
   ctx().latestCursor = 0;
+  ctx().committedOutput = false;
+  const router = resolveClaudeAccountRouter();
+  const rotationOptions = options;
+  const rotationState = rotationOptions?.[ROTATION_STATE_KEY] ?? {
+    excludedProfileIds: /* @__PURE__ */ new Set(),
+    attempts: 0
+  };
+  let account;
+  if (router) {
+    try {
+      account = router.acquire({
+        modelId: model.id,
+        sessionId: options?.sessionId,
+        excludedProfileIds: [...rotationState.excludedProfileIds],
+        forceRerank: rotationState.attempts > 0,
+        reason: rotationState.attempts > 0 ? "automatic-failover" : void 0
+      });
+      rotationState.attempts += 1;
+    } catch (error51) {
+      const message = error51 instanceof Error ? error51.message : String(error51);
+      const resetAtMs = Number(error51?.resetAtMs);
+      const rateLimitType = error51?.rateLimitType;
+      if (ctx().turnOutput) {
+        ctx().turnOutput.stopReason = "error";
+        ctx().turnOutput.errorMessage = message;
+        if (Number.isFinite(resetAtMs)) {
+          Object.assign(ctx().turnOutput, { resetAtMs, rateLimitType });
+        }
+      }
+      if (Number.isFinite(resetAtMs)) {
+        emitRateLimitEvent({
+          model: model.id,
+          provider: model.provider,
+          rateLimitType: rateLimitType ?? "all_accounts",
+          reason: message,
+          resetAt: new Date(resetAtMs).toISOString(),
+          resetAtMs,
+          source: "claude-bridge",
+          status: "rejected"
+        });
+      }
+      const errorOutput = ctx().turnOutput;
+      if (isReentrant) popContext();
+      queueMicrotask(() => {
+        stream.push({ type: "error", reason: "error", error: errorOutput });
+        stream.end();
+      });
+      return stream;
+    }
+  }
+  const queryModel = account?.modelId && account.modelId !== model.id ? { ...model, id: account.modelId, name: modelDisplayName(account.modelId) } : model;
+  const accountScope = accountSessionScope(account);
+  if (queryModel.id !== model.id) {
+    updateTurnOutputModel(queryModel.id);
+    safeNotify(
+      account?.fallbackReason === "fable-quota" ? `Every ready account rejected Claude Fable; using ${modelDisplayName(queryModel.id)}.` : `Pi Claude switched to ${modelDisplayName(queryModel.id)}.`,
+      "info"
+    );
+  }
+  const attemptContext = ctx();
+  const attemptBuffer = account ? new RetryEventBuffer(stream, () => attemptContext.markOutputCommitted()) : void 0;
+  if (attemptBuffer) ctx().currentPiStream = attemptBuffer;
   const { mcpTools, customToolNameToSdk, customToolNameToPi } = resolveMcpTools(context);
   const bridgeConfig = loadConfig(cwd);
   const providerSettings = bridgeConfig.provider ?? {};
   const claudeExecutable = resolveClaudeExecutable(providerSettings.pathToClaudeCodeExecutable);
   const claudeExecutablePreflight = claudeExecutable ? preflightClaudeExecutable(claudeExecutable, cwd) : void 0;
   const cursorBeforeSync = sharedSession?.cursor ?? null;
-  const { sessionId: resumeSessionId, promptStart } = syncSharedSession(context.messages, cwd, customToolNameToSdk, model.id);
+  const { sessionId: resumeSessionId, promptStart } = syncSharedSession(
+    context.messages,
+    cwd,
+    customToolNameToSdk,
+    queryModel.id,
+    accountScope
+  );
   const promptMessages = context.messages.slice(promptStart);
   const promptBlocks = extractUserPromptBlocks(promptMessages);
   let promptText = extractUserPrompt(promptMessages) ?? "";
@@ -45657,7 +46065,7 @@ function streamClaudeAgentSdk(model, context, options) {
   const mcpServers = buildMcpServers(mcpTools, ctx());
   const enableCloudMcp = connectorsEnabledFor(bridgeConfig);
   const connectorWriteMode = connectorWriteModeFor(bridgeConfig);
-  const connectorServers = enableCloudMcp ? connectorServersSnapshot() : {};
+  const connectorServers = enableCloudMcp ? connectorServersSnapshot(accountScope.claudeConfigDir) : {};
   const appendSystemPrompt = providerSettings.appendSystemPrompt !== false;
   const agentsAppend = appendSystemPrompt ? extractAgentsAppend() : void 0;
   const skillsAppend = appendSystemPrompt ? extractSkillsBlock(context.systemPrompt) : void 0;
@@ -45666,15 +46074,19 @@ function streamClaudeAgentSdk(model, context, options) {
   const systemPromptAppend = appendParts.length > 0 ? appendParts.join("\n\n") : void 0;
   const settingSources = enableCloudMcp ? providerSettings.settingSources ?? ["user", "project", "local"] : appendSystemPrompt ? void 0 : providerSettings.settingSources ?? ["user", "project"];
   const strictMcpConfigEnabled = !appendSystemPrompt && providerSettings.strictMcpConfig !== false;
-  const requestedEffort = options?.reasoning ? model.thinkingLevelMap?.[options.reasoning] ?? REASONING_TO_EFFORT[options.reasoning] : void 0;
-  const effort = resolveConfiguredEffort(model.id, requestedEffort, providerSettings);
+  const requestedEffort = options?.reasoning ? queryModel.thinkingLevelMap?.[options.reasoning] ?? REASONING_TO_EFFORT[options.reasoning] : void 0;
+  const effort = resolveConfiguredEffort(queryModel.id, requestedEffort, providerSettings);
   const extraArgs = {};
   if (effort) extraArgs["thinking-display"] = "summarized";
-  const fallbackModel = fallbackModelForPrimaryModel(model.id);
-  const childEnv = { ...process.env, ENABLE_CLAUDEAI_MCP_SERVERS: enableCloudMcp ? "1" : "0", DISABLE_AUTO_COMPACT: "1" };
+  const fallbackModel = account && model.id === "claude-fable-5" && queryModel.id === model.id ? void 0 : fallbackModelForPrimaryModel(queryModel.id);
+  const childEnv = {
+    ...account ? subscriberProfileEnv(account) : process.env,
+    ENABLE_CLAUDEAI_MCP_SERVERS: enableCloudMcp ? "1" : "0",
+    DISABLE_AUTO_COMPACT: "1"
+  };
   const queryOptions = {
     cwd,
-    model: model.id,
+    model: queryModel.id,
     env: childEnv,
     ...connectorQueryOptions(enableCloudMcp, connectorWriteMode),
     permissionMode: "bypassPermissions",
@@ -45698,8 +46110,8 @@ function streamClaudeAgentSdk(model, context, options) {
   };
   debug(
     "provider: fresh query",
-    `model=${model.id} msgs=${context.messages.length} tools=${mcpTools.length}`,
-    `resume=${resumeSessionId?.slice(0, 8) ?? "none"} effort=${effort ?? "default"}`,
+    `model=${queryModel.id} requested=${model.id} msgs=${context.messages.length} tools=${mcpTools.length}`,
+    `resume=${resumeSessionId?.slice(0, 8) ?? "none"} effort=${effort ?? "default"} account=${account?.label ?? "legacy"}`,
     `fallback=${fallbackModel ?? "none"}`,
     `appendSys=${appendSystemPrompt} promptCtx=${promptContextAppend.labels.join(",") || "none"} strictMcp=${strictMcpConfigEnabled} fastMode=${providerSettings.fastMode === true} connectors=${enableCloudMcp}`,
     `claudeExec=${claudeExecutablePreflight ? `${claudeExecutablePreflight.fileType}:${claudeExecutablePreflight.path}` : "sdk-default"}`,
@@ -45707,9 +46119,17 @@ function streamClaudeAgentSdk(model, context, options) {
   );
   let wasAborted = false;
   let streamIdleTimedOut = false;
-  const sdkQuery = Okt({ prompt, options: queryOptions });
+  let retryRequested = false;
+  let retryFailure;
+  const sdkQuery = sdkQueryFactory({ prompt, options: queryOptions });
   ctx().activeQuery = sdkQuery;
   const abortCtx = ctx();
+  let accountFailureRecorded = false;
+  const recordAttemptFailure = (failure) => {
+    if (accountFailureRecorded || !account || !router || !failure.kind || failure.rateLimitInfo || wasAborted || options?.signal?.aborted) return;
+    router.recordFailure(account.profileId, failure.kind, queryModel.id);
+    accountFailureRecorded = true;
+  };
   const requestAbort = () => {
     void sdkQuery.interrupt().catch(() => {
     });
@@ -45731,14 +46151,25 @@ function streamClaudeAgentSdk(model, context, options) {
       if (streamIdleTimedOut || wasAborted || options?.signal?.aborted || abortCtx.activeQuery !== sdkQuery) return;
       streamIdleTimedOut = true;
       abortCtx.deferredUserMessages = [];
-      abortCtx.handledTerminalError = true;
       if (sharedSession) setSharedSession({ ...sharedSession, needsRebuild: true, forceRotate: true });
       const errorMessage = buildStreamIdleTimeoutErrorMessage(timeoutMs);
-      debug("provider: stream idle timeout", `model=${model.id}`, `timeout=${timeoutMs}`, `idle=${idleMs}`);
+      debug("provider: stream idle timeout", `model=${queryModel.id}`, `timeout=${timeoutMs}`, `idle=${idleMs}`);
+      const idleFailure = { kind: "network", message: errorMessage };
+      recordAttemptFailure(idleFailure);
+      if (account && router && !abortCtx.committedOutput) {
+        rotationState.excludedProfileIds.add(account.profileId);
+        retryRequested = true;
+        retryFailure = { kind: "network", message: errorMessage };
+        attemptBuffer?.discard();
+        abortCtx.currentPiStream = null;
+        requestAbort();
+        return;
+      }
+      abortCtx.handledTerminalError = true;
       emitRateLimitEvent({
         idleMs,
-        model: model.id,
-        provider: PROVIDER_ID,
+        model: queryModel.id,
+        provider: queryModel.provider,
         rateLimitType: "stream_idle",
         reason: "Claude Code stream idle timeout",
         retryAfterMs: STREAM_IDLE_BACKOFF_HINT_MS,
@@ -45770,7 +46201,10 @@ function streamClaudeAgentSdk(model, context, options) {
   const onAbort = () => {
     wasAborted = true;
     abortCtx.deferredUserMessages = [];
-    reportToolResultMismatch(abortCtx, "abort", cwd, { forceRotate: true });
+    reportToolResultMismatch(abortCtx, "abort", cwd, {
+      expectedInterruption: true,
+      forceRotate: true
+    });
     const drained = drainPendingToolCalls(abortCtx, "abort");
     if (drained > 0) debug(`provider: abort drained ${drained} waiting MCP handler(s) as errors`);
     abortCtx.pendingResults.clear();
@@ -45780,32 +46214,86 @@ function streamClaudeAgentSdk(model, context, options) {
     if (options.signal.aborted) onAbort();
     else options.signal.addEventListener("abort", onAbort, { once: true });
   }
-  consumeQuery(sdkQuery, customToolNameToPi, model, cwd, bridgeConfig, () => wasAborted).then(async ({ capturedSessionId }) => {
-    debug(`provider: consumeQuery completed, stopReason=${abortCtx.turnOutput?.stopReason}, error=${abortCtx.turnOutput?.errorMessage}, aborted=${wasAborted}`);
+  const requestRotation = (failure) => {
+    recordAttemptFailure(failure);
+    const committedOutput = abortCtx.committedOutput || attemptBuffer?.hasCommittedOutput === true;
+    const eligible = Boolean(account && router && failure.kind && !committedOutput && !wasAborted && !options?.signal?.aborted && rotationState.attempts < 16);
+    debug("provider: account rotation decision", JSON.stringify({
+      eligible,
+      account: account?.label,
+      kind: failure.kind,
+      committedOutput,
+      wasAborted,
+      signalAborted: options?.signal?.aborted === true,
+      attempts: rotationState.attempts
+    }));
+    if (!eligible || !account || !router || !failure.kind) return false;
+    rotationState.excludedProfileIds.add(account.profileId);
+    retryRequested = true;
+    retryFailure = failure;
+    attemptBuffer?.discard();
+    abortCtx.currentPiStream = null;
+    debug(`provider: rotating account after ${failure.kind}, from=${account.label}, attempt=${rotationState.attempts}`);
+    return true;
+  };
+  const surfaceFailure = (failure, aborted2 = false) => {
+    attemptBuffer?.commit();
+    if (failure.rateLimitInfo) {
+      const info = failure.rateLimitInfo;
+      const resetAt = rateLimitResetFromInfo(info);
+      const resetAtMs = rateLimitResetMs(info);
+      emitRateLimitEvent({
+        model: queryModel.id,
+        provider: queryModel.provider,
+        rateLimitType: rateLimitTypeFromInfo(info),
+        reason: failure.message,
+        resetAt,
+        ...Number.isFinite(resetAtMs) ? { resetAtMs } : {},
+        source: "claude-bridge",
+        status: "rejected"
+      });
+      piUI?.notify(`${RATE_LIMIT_TOKEN} Claude ${failure.message} \u2014 resets ${formatResetTimestamp(resetAtMs ?? resetAt)}`, "warning");
+    }
+    if (abortCtx.turnOutput) {
+      abortCtx.turnOutput.stopReason = aborted2 ? "aborted" : "error";
+      abortCtx.turnOutput.errorMessage = failure.message;
+    }
+    abortCtx.currentPiStream?.push({ type: "error", reason: aborted2 ? "aborted" : "error", error: abortCtx.turnOutput });
+    abortCtx.currentPiStream?.end();
+    abortCtx.currentPiStream = null;
+  };
+  consumeQuery(sdkQuery, customToolNameToPi, queryModel, bridgeConfig, () => wasAborted, account, router).then(async ({ capturedSessionId, failure }) => {
+    debug(`provider: consumeQuery completed, stopReason=${abortCtx.turnOutput?.stopReason}, failure=${failure?.kind ?? "none"}, aborted=${wasAborted}`);
     if (streamIdleTimedOut) {
       abortCtx.deferredUserMessages = [];
-      debug("provider: stream idle timeout already surfaced; skipping normal completion");
+      debug(`provider: stream idle timeout ${retryRequested ? "queued account rotation" : "already surfaced"}`);
       return;
     }
     if (wasAborted || options?.signal?.aborted) {
       if (sharedSession) setSharedSession({ ...sharedSession, needsRebuild: true, forceRotate: true });
       abortCtx.deferredUserMessages = [];
       debug(`provider: abort detected, marked sharedSession needsRebuild + forceRotate`);
-      if (abortCtx.turnOutput) {
-        abortCtx.turnOutput.stopReason = "aborted";
-        abortCtx.turnOutput.errorMessage = "Operation aborted";
-      }
-      abortCtx.currentPiStream?.push({ type: "error", reason: "aborted", error: abortCtx.turnOutput });
-      abortCtx.currentPiStream?.end();
-      abortCtx.currentPiStream = null;
+      surfaceFailure({ message: "Operation aborted" }, true);
       return;
     }
-    const sessionId = capturedSessionId ?? sharedSession?.sessionId;
-    if (sessionId) {
-      const cursor = Math.max(context.messages.length, abortCtx.latestCursor, sharedSession?.cursor ?? 0);
-      debug(`provider: query done, session=${sessionId.slice(0, 8)}, cursor=${cursor}`);
-      setSharedSession({ sessionId, cursor, cwd });
+    if (failure) {
+      if (requestRotation(failure)) return;
+      surfaceFailure(failure);
+      return;
     }
+    const completedSessionId = capturedSessionId ?? sharedSession?.sessionId;
+    if (completedSessionId) {
+      const cursor = Math.max(context.messages.length, abortCtx.latestCursor, sharedSession?.cursor ?? 0);
+      debug(`provider: query done, session=${completedSessionId.slice(0, 8)}, cursor=${cursor}, account=${account?.label ?? "legacy"}`);
+      setSharedSession({
+        sessionId: completedSessionId,
+        cursor,
+        cwd,
+        modelId: queryModel.id,
+        ...accountScope
+      });
+    }
+    if (account && router) router.recordSuccess(account.profileId, options?.sessionId);
     try {
       while (abortCtx.deferredUserMessages.length > 0 && !isReentrant && !wasAborted) {
         const steerPrompt = abortCtx.deferredUserMessages.shift();
@@ -45818,17 +46306,29 @@ function streamClaudeAgentSdk(model, context, options) {
           break;
         }
         const contOptions = { ...queryOptions, resume: resumeId, ...makeCliDebugOptions("continuation") };
-        const contQuery = Okt({ prompt: steerPrompt, options: contOptions });
+        const contQuery = sdkQueryFactory({ prompt: steerPrompt, options: contOptions });
         abortCtx.activeQuery = contQuery;
-        debug(`provider: continuation query, model=${model.id}, resume=${resumeId.slice(0, 8)}, prompt=${steerPrompt.slice(0, 60)}`);
+        debug(`provider: continuation query, model=${queryModel.id}, resume=${resumeId.slice(0, 8)}, account=${account?.label ?? "legacy"}, prompt=${steerPrompt.slice(0, 60)}`);
         try {
-          const { capturedSessionId: contSid } = await consumeQuery(contQuery, customToolNameToPi, model, cwd, bridgeConfig, () => wasAborted);
-          const sid = contSid ?? sharedSession?.sessionId;
-          if (sid) {
-            setSharedSession({ sessionId: sid, cursor: sharedSession?.cursor ?? 0, cwd });
+          const continuation = await consumeQuery(contQuery, customToolNameToPi, queryModel, bridgeConfig, () => wasAborted, account, router);
+          if (continuation.failure) {
+            recordAttemptFailure(continuation.failure);
+            surfaceFailure(continuation.failure);
+            break;
           }
+          const sid = continuation.capturedSessionId ?? sharedSession?.sessionId;
+          if (sid) setSharedSession({
+            sessionId: sid,
+            cursor: sharedSession?.cursor ?? 0,
+            cwd,
+            modelId: queryModel.id,
+            ...accountScope
+          });
         } catch (contError) {
           debug(`provider: continuation query error:`, contError);
+          const continuationFailure = { kind: classifyClaudeFailure(contError), message: contError instanceof Error ? contError.message : String(contError) };
+          recordAttemptFailure(continuationFailure);
+          surfaceFailure(continuationFailure);
           break;
         } finally {
           contQuery.close();
@@ -45839,26 +46339,23 @@ function streamClaudeAgentSdk(model, context, options) {
     }
     finalizeCurrentStream(abortCtx.turnOutput?.stopReason, abortCtx);
   }).catch((error51) => {
-    debug(`provider: query error, model=${model.id}, aborted=${Boolean(options?.signal?.aborted)}, error=`, error51);
-    const suppressDuplicateError = abortCtx.handledTerminalError || streamIdleTimedOut;
-    const openedExtraUsage = !suppressDuplicateError && isExtraUsageRequiredMessage(error51) && launchExtraUsageHelperIfAllowed(cwd, bridgeConfig, "query error");
+    debug(`provider: query error, model=${queryModel.id}, aborted=${Boolean(options?.signal?.aborted)}, error=`, error51);
+    const suppressDuplicateError = abortCtx.handledTerminalError || streamIdleTimedOut && !retryRequested;
     if ((wasAborted || options?.signal?.aborted) && sharedSession) {
       setSharedSession({ ...sharedSession, needsRebuild: true, forceRotate: true });
-    } else {
-      setSharedSession(null);
     }
     abortCtx.deferredUserMessages = [];
-    if (suppressDuplicateError) {
-      debug("provider: suppressing duplicate query error after terminal error was already emitted");
+    if (suppressDuplicateError || retryRequested) {
+      debug("provider: suppressing duplicate query error after terminal handling");
       return;
     }
-    if (abortCtx.turnOutput) {
-      abortCtx.turnOutput.stopReason = options?.signal?.aborted ? "aborted" : "error";
-      abortCtx.turnOutput.errorMessage = `${error51 instanceof Error ? error51.message : String(error51)}${openedExtraUsage ? "\n\nOpened Claude Code /extra-usage helper. Complete billing/admin flow in the browser, then retry the prompt." : ""}`;
-    }
-    abortCtx.currentPiStream?.push({ type: "error", reason: abortCtx.turnOutput?.stopReason ?? "error", error: abortCtx.turnOutput });
-    abortCtx.currentPiStream?.end();
-    abortCtx.currentPiStream = null;
+    const failure = {
+      kind: classifyClaudeFailure(error51),
+      message: error51 instanceof Error ? error51.message : String(error51)
+    };
+    if (requestRotation(failure)) return;
+    if (!wasAborted && !options?.signal?.aborted) setSharedSession(null);
+    surfaceFailure(failure, Boolean(options?.signal?.aborted));
   }).finally(() => {
     streamIdleWatchdog?.dispose();
     activeStreamIdleWatchdogs.delete(abortCtx);
@@ -45866,6 +46363,26 @@ function streamClaudeAgentSdk(model, context, options) {
     const cause = toolCallDrainCause({ wasAborted, signalAborted: options?.signal?.aborted, streamIdleTimedOut });
     teardownQuery(abortCtx, sdkQuery, cause, cwd, isReentrant);
     sdkQuery.close();
+  }).then(async () => {
+    if (!retryRequested || wasAborted || options?.signal?.aborted) return;
+    debug(`provider: starting account retry after ${retryFailure?.kind ?? "failure"}; excluded=${[...rotationState.excludedProfileIds].join(",")}`);
+    const retryStream = streamClaudeAgentSdk(model, context, {
+      ...options ?? {},
+      [ROTATION_STATE_KEY]: rotationState
+    });
+    try {
+      for await (const event of retryStream) stream.push(event);
+    } finally {
+      stream.end();
+    }
+  }).catch((error51) => {
+    debug("provider: account retry pipeline failed:", error51);
+    if (abortCtx.turnOutput) {
+      abortCtx.turnOutput.stopReason = "error";
+      abortCtx.turnOutput.errorMessage = error51 instanceof Error ? error51.message : String(error51);
+    }
+    stream.push({ type: "error", reason: "error", error: abortCtx.turnOutput });
+    stream.end();
   });
   return stream;
 }
@@ -45887,9 +46404,8 @@ async function tryOpenExtensionManagerSettings(ctx2) {
 function showBridgeStatus(ctx2) {
   const config2 = loadConfig(commandCwd(ctx2));
   ctx2.ui.notify([
-    `Claude bridge: ${config2.enabled === false ? "disabled" : "enabled"}`,
-    `Extra usage auto-helper: ${extraUsageAllowed(config2) ? "on" : "off"} (settings)`,
-    `Use /claude-bridge:extra to run Claude Code /extra-usage now.`
+    `Pi Claude: ${config2.enabled === false ? "disabled" : "enabled"}`,
+    "Claude account billing settings are managed in Claude."
   ].join("\n"), "info");
 }
 function readCredentialFile(path) {
@@ -45901,16 +46417,22 @@ function readCredentialFile(path) {
 }
 var connectorServerCache = /* @__PURE__ */ new Map();
 var connectorServerPending = /* @__PURE__ */ new Set();
-function connectorScopeKey() {
-  return process.env.CLAUDE_CONFIG_DIR?.trim() || "<default>";
+function connectorScopeKey(claudeConfigDir = process.env.CLAUDE_CONFIG_DIR) {
+  return claudeConfigDir?.trim() || "<default>";
 }
-function primeConnectorServers() {
-  const key = connectorScopeKey();
+function connectorCredentialEnv(claudeConfigDir = process.env.CLAUDE_CONFIG_DIR) {
+  const env = { ...process.env };
+  if (claudeConfigDir?.trim()) env.CLAUDE_CONFIG_DIR = claudeConfigDir.trim();
+  else delete env.CLAUDE_CONFIG_DIR;
+  return env;
+}
+function primeConnectorServers(claudeConfigDir) {
+  const key = connectorScopeKey(claudeConfigDir);
   if (connectorServerCache.has(key) || connectorServerPending.has(key)) return;
   connectorServerPending.add(key);
   void (async () => {
     try {
-      const credentials = resolveClaudeOAuth(readCredentialFile);
+      const credentials = resolveClaudeOAuth(readCredentialFile, connectorCredentialEnv(claudeConfigDir));
       if (!credentials) {
         debug("connectors: no OAuth credentials; declaring none");
         connectorServerCache.set(key, {});
@@ -45939,11 +46461,11 @@ function primeConnectorServers() {
     }
   })();
 }
-function connectorServersSnapshot() {
-  const key = connectorScopeKey();
+function connectorServersSnapshot(claudeConfigDir) {
+  const key = connectorScopeKey(claudeConfigDir);
   const ready = connectorServerCache.get(key);
   if (ready) return ready;
-  primeConnectorServers();
+  primeConnectorServers(claudeConfigDir);
   const cached2 = readCachedConnectors(key);
   if (!cached2) return {};
   const servers = connectorMcpServers({ ok: true, complete: true, connectors: cached2 });
@@ -45952,62 +46474,49 @@ function connectorServersSnapshot() {
   return servers;
 }
 async function reportConnectorInventory(ctx2) {
-  const credentials = resolveClaudeOAuth(readCredentialFile);
+  const account = ctx2.model ? resolveClaudeAccountRouter()?.current(ctx2.model.id, ctx2.sessionManager?.getSessionId?.()) : void 0;
+  const credentials = resolveClaudeOAuth(
+    readCredentialFile,
+    connectorCredentialEnv(account ? accountSessionScope(account).claudeConfigDir : void 0)
+  );
   if (!credentials) {
-    ctx2.ui.notify("Claude bridge: no Claude OAuth credentials found \u2014 cannot enumerate connectors.", "error");
+    ctx2.ui.notify("Pi Claude: no Claude OAuth credentials found \u2014 cannot enumerate connectors.", "error");
     return;
   }
   const inventory = await listAccountConnectors({ credentials });
   if (!inventory.ok) {
-    ctx2.ui.notify(`Claude bridge: connector enumeration failed \u2014 ${inventory.reason}`, "error");
+    ctx2.ui.notify(`Pi Claude: connector enumeration failed \u2014 ${inventory.reason}`, "error");
     return;
   }
   if (inventory.connectors.length === 0) {
-    ctx2.ui.notify("Claude bridge: this account has no connectors installed.", "info");
+    ctx2.ui.notify("Pi Claude: this account has no connectors installed.", "info");
     return;
   }
   const names = inventory.connectors.map((c) => c.name).join(", ");
-  ctx2.ui.notify(`Claude bridge: ${inventory.connectors.length} connector(s) installed \u2014 ${names}`, "info");
+  ctx2.ui.notify(`Pi Claude: ${inventory.connectors.length} connector(s) installed \u2014 ${names}`, "info");
 }
 function registerBridgeCommands(pi) {
   const guard = pi;
   if (guard[COMMANDS_REGISTERED_KEY]) return;
   guard[COMMANDS_REGISTERED_KEY] = true;
-  const runExtraUsage = async (ctx2) => {
-    const cwd = commandCwd(ctx2);
-    if (extraUsageHelperInFlight) {
-      ctx2.ui.notify("Claude extra usage helper already running.", "info");
-      await extraUsageHelperInFlight.catch(() => void 0);
-      return;
+  const openSettings = async (args, ctx2) => {
+    if (args.trim()) {
+      ctx2.ui.notify("Unknown /pi-claude argument.", "warning");
     }
-    try {
-      ctx2.ui.notify("Claude extra usage helper starting\u2026", "info");
-      extraUsageHelperInFlight = runExtraUsageHelper(cwd).finally(() => {
-        extraUsageHelperInFlight = null;
-      });
-      const message = await extraUsageHelperInFlight;
-      ctx2.ui.notify(`Claude extra usage helper: ${message}`, "info");
-    } catch (error51) {
-      const message = error51 instanceof Error ? error51.message : String(error51);
-      ctx2.ui.notify(`Claude extra usage helper failed: ${message}`, "error");
-    }
+    if (await tryOpenExtensionManagerSettings(ctx2)) return;
+    showBridgeStatus(ctx2);
   };
-  pi.registerCommand("claude-bridge", {
-    description: "Open Claude bridge settings/status",
-    handler: async (args, ctx2) => {
-      if (args.trim()) ctx2.ui.notify("Unknown /claude-bridge argument. Use /claude-bridge:extra to run Claude Code /extra-usage.", "warning");
-      if (await tryOpenExtensionManagerSettings(ctx2)) return;
-      showBridgeStatus(ctx2);
-    }
-  });
-  pi.registerCommand("claude-bridge:extra", {
-    description: "Run Claude Code /extra-usage through claude-bridge",
-    handler: async (_args, ctx2) => runExtraUsage(ctx2)
-  });
-  pi.registerCommand("claude-bridge:connectors", {
-    description: "List the Claude account's installed claude.ai connectors",
-    handler: async (_args, ctx2) => reportConnectorInventory(ctx2)
-  });
+  const reportConnectors = async (_args, ctx2) => reportConnectorInventory(ctx2);
+  for (const name of ["pi-claude", "claude-bridge"]) {
+    pi.registerCommand(name, {
+      description: name === "pi-claude" ? "Open Pi Claude settings/status" : "Legacy alias for /pi-claude",
+      handler: openSettings
+    });
+    pi.registerCommand(`${name}:connectors`, {
+      description: name === "pi-claude" ? "List the Claude account's installed claude.ai connectors" : "Legacy alias for /pi-claude:connectors",
+      handler: reportConnectors
+    });
+  }
 }
 function index_default(pi) {
   setExtensionApi(pi);
@@ -46019,6 +46528,10 @@ function index_default(pi) {
   if (config2.enabled === false) {
     debug("provider: disabled by configuration");
     return;
+  }
+  if (claimPrimaryInstance()) {
+    const host = globalThis;
+    host[CLAUDE_BRIDGE_ACCOUNT_HOST_SYMBOL] = BRIDGE_ACCOUNT_HOST;
   }
   const clearSession = (event) => {
     debug(`${event}: clearing session ${sharedSession?.sessionId?.slice(0, 8) ?? "none"}`);
@@ -46034,12 +46547,13 @@ function index_default(pi) {
     applyProviderRegistration(`session_start:${event.reason}`);
   });
   pi.on("session_shutdown", () => {
+    cancelScheduledSessionPersistence();
     clearSession("session_shutdown");
     releaseProviderTokens("session_shutdown");
   });
   pi.on("message_end", (event, ctx2) => {
     const message = event.message;
-    if (message?.role === "assistant" && message.provider === PROVIDER_ID) schedulePersistSharedSession(ctx2);
+    if (message?.role === "assistant" && isClaudeProvider(message.provider)) schedulePersistSharedSession(ctx2);
   });
   const markRebuild = (event) => {
     if (ctx().activeQuery) {
@@ -46065,16 +46579,21 @@ export {
   DISALLOWED_BUILTIN_TOOLS,
   INTEGRITY_CUSTOM_TYPE,
   NATIVE_PROVIDER_UNSUPPORTED_MESSAGE,
+  RetryEventBuffer,
   STREAM_IDLE_BACKOFF_HINT_MS,
   STREAM_IDLE_TIMEOUT_ENV,
   __testGetBridgeIntegrityState,
   __testSetBridgeIntegrityState,
+  __testSetSdkQueryFactory,
   appendIntegrityEntry,
   buildNativeProvider,
   buildStreamIdleTimeoutErrorMessage,
+  cancelScheduledSessionPersistence,
   cancelScheduledToolUseEnd,
   classifyClaudeExecutableBytes,
+  classifyClaudeFailure,
   claudeAuthSourceLabel,
+  commitsVisibleOutput,
   connectorCachePath,
   connectorCacheScopeKey,
   connectorDeclarationsDisabled,
@@ -46102,7 +46621,6 @@ export {
   isChildInternalTool,
   isConnectorTool,
   isConnectorWriteTool,
-  isExtraUsageRequiredMessage,
   isUsageLimitMessage,
   listAccountConnectors,
   mapToolName,
@@ -46114,6 +46632,9 @@ export {
   primeConnectorServers,
   processAssistantMessage,
   processStreamEvent,
+  rateLimitResetFromInfo,
+  rateLimitResetMs,
+  rateLimitTypeFromInfo,
   readCachedConnectors,
   reapStaleQueuedResults,
   recordConnectorCallResult,
@@ -46128,7 +46649,9 @@ export {
   setConnectorCallAuditSink,
   shouldRestorePersistedBridgeEntry,
   spawnClaudeCodeWithDiagnostics,
+  streamClaudeAgentSdk,
   streamIdleTimeoutMsFromEnv,
+  subscriberProfileEnv,
   supportsNativeProvider,
   toolIsolationForQuery,
   uniqueNonEmptyLines,

--- a/pi-extensions/pi-claude-bridge/package-lock.json
+++ b/pi-extensions/pi-claude-bridge/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vanillagreen/pi-claude-bridge",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vanillagreen/pi-claude-bridge",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.220",
@@ -782,9 +782,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
-      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -799,9 +799,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
-      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -816,9 +816,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
-      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -833,9 +833,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
-      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -850,9 +850,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
-      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -867,9 +867,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
-      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -884,9 +884,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -901,9 +901,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
-      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -918,9 +918,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
-      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -935,9 +935,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
-      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -952,9 +952,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
-      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -969,9 +969,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
-      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -986,9 +986,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
-      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -1003,9 +1003,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
-      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1020,9 +1020,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
-      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -1037,9 +1037,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
-      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -1054,9 +1054,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
-      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -1071,9 +1071,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
@@ -1088,9 +1088,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -1105,9 +1105,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
@@ -1122,9 +1122,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -1139,9 +1139,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
-      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
@@ -1156,9 +1156,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
-      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -1173,9 +1173,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
-      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
-      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -1207,9 +1207,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
-      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
@@ -1249,13 +1249,13 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
       "license": "MIT",
       "peer": true,
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -1488,13 +1488,13 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -1590,13 +1590,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
-      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -1880,22 +1873,36 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1912,16 +1919,16 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -2202,9 +2209,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
-      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -2215,32 +2222,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.0",
-        "@esbuild/android-arm": "0.28.0",
-        "@esbuild/android-arm64": "0.28.0",
-        "@esbuild/android-x64": "0.28.0",
-        "@esbuild/darwin-arm64": "0.28.0",
-        "@esbuild/darwin-x64": "0.28.0",
-        "@esbuild/freebsd-arm64": "0.28.0",
-        "@esbuild/freebsd-x64": "0.28.0",
-        "@esbuild/linux-arm": "0.28.0",
-        "@esbuild/linux-arm64": "0.28.0",
-        "@esbuild/linux-ia32": "0.28.0",
-        "@esbuild/linux-loong64": "0.28.0",
-        "@esbuild/linux-mips64el": "0.28.0",
-        "@esbuild/linux-ppc64": "0.28.0",
-        "@esbuild/linux-riscv64": "0.28.0",
-        "@esbuild/linux-s390x": "0.28.0",
-        "@esbuild/linux-x64": "0.28.0",
-        "@esbuild/netbsd-arm64": "0.28.0",
-        "@esbuild/netbsd-x64": "0.28.0",
-        "@esbuild/openbsd-arm64": "0.28.0",
-        "@esbuild/openbsd-x64": "0.28.0",
-        "@esbuild/openharmony-arm64": "0.28.0",
-        "@esbuild/sunos-x64": "0.28.0",
-        "@esbuild/win32-arm64": "0.28.0",
-        "@esbuild/win32-ia32": "0.28.0",
-        "@esbuild/win32-x64": "0.28.0"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escape-html": {
@@ -2367,9 +2374,9 @@
       "license": "Unlicense"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -2685,9 +2692,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.18",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "version": "4.12.33",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.33.tgz",
+      "integrity": "sha512-+SwvkaiJtxsiPjhy9LivY/1m7UsNqCJetM1BrZl9A5DkQhlbHQDU730mMiDPWjnoCYOM8Chf3WrCJw27kNTPFQ==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -3244,9 +3251,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.6.1",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.1.tgz",
-      "integrity": "sha512-4K0myLaWL5EteuSAro91EGFgcfVgxb64Jx+7oDAY6GOkXD4M69yuSEljNcInGVCA5sOPxmZ/EqDLj2x0Q0+Ygg==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
@@ -3257,7 +3264,6 @@
         "@protobufjs/eventemitter": "^1.1.1",
         "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.2",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.1",
@@ -4118,18 +4124,36 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typebox": {

--- a/pi-extensions/pi-claude-bridge/package.json
+++ b/pi-extensions/pi-claude-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vanillagreen/pi-claude-bridge",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Pi provider bridge that runs Claude Code through the Claude Agent SDK, with opt-in forwarding for Pi prompt context.",
   "type": "module",
   "keywords": [
@@ -19,12 +19,12 @@
   },
   "vstack": {
     "extensionManager": {
-      "displayName": "Claude Bridge",
+      "displayName": "Pi Claude",
       "settings": [
         {
           "key": "enabled",
-          "label": "Enable Claude bridge provider",
-          "description": "Register claude-bridge models that route Pi turns through Claude Code via the Claude Agent SDK.",
+          "label": "Enable Pi Claude provider",
+          "description": "Register pi-claude models that route Pi turns through Claude Code via the Claude Agent SDK.",
           "type": "boolean",
           "default": true,
           "category": "General",
@@ -86,18 +86,9 @@
           "apply": "live"
         },
         {
-          "key": "allowExtraUsage",
-          "label": "Allow extra usage helper",
-          "description": "Allow claude-bridge to launch Claude Code's /extra-usage flow when rate limits require extra usage. Billing/admin approval still happens in Claude's browser page.",
-          "type": "boolean",
-          "default": false,
-          "category": "Claude Code",
-          "apply": "live"
-        },
-        {
           "key": "fastMode",
           "label": "Fast mode",
-          "description": "Enable Claude Code fast mode for bridge requests when the selected model supports it. Off by default.",
+          "description": "Enable Claude Code fast mode for bridge requests when the selected model and account support it. Off by default.",
           "type": "boolean",
           "default": false,
           "category": "Claude Code",
@@ -106,7 +97,7 @@
         {
           "key": "forceEffort",
           "label": "Force Claude effort",
-          "description": "Override Pi's thinking-level mapping for all claude-bridge requests. Pi 0.80.6 and newer can select max natively; none keeps Pi's selected level.",
+          "description": "Override Pi's thinking-level mapping for all Pi Claude requests. Pi 0.80.6 and newer can select max natively; none keeps Pi's selected level.",
           "type": "enum",
           "enumValues": [
             "none",
@@ -123,7 +114,7 @@
         {
           "key": "modelEffortOverrides",
           "label": "Model effort overrides",
-          "description": "Optional JSON object mapping claude-bridge model ids to Claude Code effort levels, e.g. {\"claude-opus-4-8\":\"max\"}. Keys may also use claude-bridge/<id> or *.",
+          "description": "Optional JSON object mapping Pi Claude model ids to Claude Code effort levels, e.g. {\"claude-opus-4-8\":\"max\"}. Keys may use pi-claude/<id>, legacy claude-bridge/<id>, or *.",
           "type": "string",
           "default": "{}",
           "category": "Claude Code",

--- a/pi-extensions/pi-claude-bridge/src/account-router.ts
+++ b/pi-extensions/pi-claude-bridge/src/account-router.ts
@@ -1,0 +1,212 @@
+import type { AssistantMessageEvent, AssistantMessageEventStream } from "@earendil-works/pi-ai";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export const CLAUDE_ACCOUNT_ROUTER_SYMBOL = Symbol.for("vstack.pi.claude-account-router.v1");
+export const CLAUDE_BRIDGE_ACCOUNT_HOST_SYMBOL = Symbol.for("vstack.pi.claude-bridge.account-host.v1");
+
+export interface ClaudeAccountRoute {
+	profileId: string;
+	label: string;
+	configDir?: string;
+	/** Effective model selected by the companion after model-scoped quota exhaustion. */
+	modelId?: string;
+	fallbackReason?: "fable-quota";
+}
+
+export type ClaudeAccountFailureKind = "auth" | "billing" | "rate-limit" | "overloaded" | "server" | "network";
+
+export interface ClaudeAccountRouterV1 {
+	version: 1;
+	acquire(input: {
+		modelId: string;
+		sessionId?: string;
+		excludedProfileIds?: string[];
+		forceRerank?: boolean;
+		reason?: string;
+	}): ClaudeAccountRoute;
+	recordIdentity(profileId: string, identity: {
+		email?: string;
+		organization?: string;
+		organizationId?: string;
+		subscriptionType?: string;
+		authMethod?: string;
+	}): void;
+	recordUsage(profileId: string, usage: unknown): void;
+	recordRateLimit(profileId: string, info: Record<string, unknown> | undefined, modelId: string): number;
+	recordFailure(profileId: string, kind: ClaudeAccountFailureKind, modelId: string): void;
+	recordSuccess(profileId: string, sessionId?: string): void;
+	current(modelId: string, sessionId?: string): ClaudeAccountRoute | undefined;
+}
+
+export interface ClaudeBridgeAccountHostV1 {
+	version: 1;
+	probeProfile(input: {
+		profile: ClaudeAccountRoute;
+		cwd: string;
+		signal?: AbortSignal;
+	}): Promise<{
+		identity?: {
+			email?: string;
+			organization?: string;
+			subscriptionType?: string;
+			authMethod?: string;
+		};
+		usage?: unknown;
+	}>;
+}
+
+export function resolveClaudeAccountRouter(): ClaudeAccountRouterV1 | undefined {
+	const host = globalThis as unknown as Record<PropertyKey, unknown>;
+	const candidate = host[CLAUDE_ACCOUNT_ROUTER_SYMBOL] as ClaudeAccountRouterV1 | undefined;
+	return candidate?.version === 1 ? candidate : undefined;
+}
+
+export function subscriberProfileEnv(
+	profile: Pick<ClaudeAccountRoute, "configDir">,
+	base: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+	const env: NodeJS.ProcessEnv = { ...base };
+	// Managed profiles are subscription identities. Inherited API/provider
+	// credentials and endpoint overrides would silently bypass the profile and
+	// create separate billing or route its OAuth token through a gateway.
+	const directOverrides = new Set([
+		"ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_OAUTH_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN",
+		"ANTHROPIC_BASE_URL", "ANTHROPIC_CUSTOM_HEADERS", "ANTHROPIC_AWS_API_KEY",
+		"ANTHROPIC_FOUNDRY_AUTH_TOKEN", "ANTHROPIC_BEDROCK_BASE_URL",
+		"ANTHROPIC_VERTEX_BASE_URL", "ANTHROPIC_FOUNDRY_BASE_URL", "AWS_BEARER_TOKEN_BEDROCK",
+	]);
+	for (const key of Object.keys(env)) {
+		if (directOverrides.has(key) || key.startsWith("CLAUDE_CODE_USE_")) delete env[key];
+	}
+	const configDir = profile.configDir?.trim();
+	if (configDir) env.CLAUDE_CONFIG_DIR = configDir;
+	else delete env.CLAUDE_CONFIG_DIR;
+	return env;
+}
+
+export function managedClaudeConfigDir(
+	profile: Pick<ClaudeAccountRoute, "configDir">,
+	base: NodeJS.ProcessEnv = process.env,
+): string {
+	const configured = profile.configDir?.trim();
+	if (configured) return configured;
+	const home = base.HOME?.trim() || homedir();
+	return join(home, ".claude");
+}
+
+export function accountSessionScope(
+	profile: ClaudeAccountRoute | undefined,
+	base: NodeJS.ProcessEnv = process.env,
+): { accountProfileId?: string; claudeConfigDir?: string } {
+	return profile ? {
+		accountProfileId: profile.profileId,
+		claudeConfigDir: managedClaudeConfigDir(profile, base),
+	} : {};
+}
+
+export function commitsVisibleOutput(event: AssistantMessageEvent): boolean {
+	if (event.type === "text_delta" || event.type === "thinking_delta" || event.type === "toolcall_delta") {
+		return event.delta.length > 0;
+	}
+	if (event.type === "text_end" || event.type === "thinking_end") return event.content.length > 0;
+	return event.type === "toolcall_end";
+}
+
+/**
+ * Holds protocol setup events until the first visible delta/tool call. A failed
+ * account can then be discarded and retried without leaking a duplicate `start`
+ * frame into Pi. Terminal success/error commits the buffered frames.
+ */
+export class RetryEventBuffer {
+	private readonly pending: AssistantMessageEvent[] = [];
+	private committed = false;
+	private ended = false;
+	private discarded = false;
+
+	constructor(
+		private readonly target: AssistantMessageEventStream,
+		private readonly onCommit?: () => void,
+	) {}
+
+	push(event: AssistantMessageEvent): void {
+		if (this.discarded) return;
+		if (this.committed) {
+			this.target.push(event);
+			return;
+		}
+		this.pending.push(event);
+		if (commitsVisibleOutput(event) || event.type === "done" || event.type === "error") this.commit();
+	}
+
+	end(): void {
+		if (this.discarded) return;
+		this.ended = true;
+		if (this.committed) this.target.end();
+	}
+
+	commit(): void {
+		if (this.discarded || this.committed) return;
+		this.committed = true;
+		this.onCommit?.();
+		for (const event of this.pending) this.target.push(event);
+		this.pending.length = 0;
+		if (this.ended) this.target.end();
+	}
+
+	discard(): void {
+		if (this.committed) return;
+		this.discarded = true;
+		this.pending.length = 0;
+	}
+
+	get hasCommittedOutput(): boolean { return this.committed; }
+}
+
+export function rateLimitTypeFromInfo(info: Record<string, unknown> | undefined): unknown {
+	return info?.rateLimitType ?? info?.rate_limit_type ?? info?.type;
+}
+
+export function rateLimitResetFromInfo(info: Record<string, unknown> | undefined): unknown {
+	return info?.resetsAt ?? info?.resets_at ?? info?.resetAt ?? info?.reset_at;
+}
+
+export function rateLimitResetMs(info: Record<string, unknown> | undefined): number | undefined {
+	const value = rateLimitResetFromInfo(info);
+	if (typeof value === "number" && Number.isFinite(value)) return value < 1_000_000_000_000 ? value * 1000 : value;
+	if (typeof value !== "string" || !value.trim()) return undefined;
+	const numeric = Number(value);
+	if (Number.isFinite(numeric)) return numeric < 1_000_000_000_000 ? numeric * 1000 : numeric;
+	const parsed = Date.parse(value);
+	return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+export function classifyClaudeFailure(value: unknown): ClaudeAccountFailureKind | undefined {
+	const details: unknown[] = [value];
+	if (value && typeof value === "object") {
+		const record = value as Record<string, unknown>;
+		details.push(record.name, record.message, record.code, record.status, record.statusCode, record.body, record.error);
+	}
+	const text = details.map((detail) => {
+		if (typeof detail === "string" || typeof detail === "number") return String(detail);
+		try { return JSON.stringify(detail ?? ""); } catch { return String(detail); }
+	}).join(" ");
+	const normalized = text.toLowerCase().replace(/[_-]+/g, " ");
+	const structuredStatus = value && typeof value === "object"
+		? Number((value as Record<string, unknown>).statusCode ?? (value as Record<string, unknown>).status)
+		: Number.NaN;
+	if (/\b401\b|authentication (?:failed|error)|oauth org not allowed|oauth token.*expired|token.*expired|unauthorized|invalid token|login required|please run .*login|not logged in/.test(normalized)) return "auth";
+	// Extra Usage is controlled by Claude account settings. A request asking for
+	// it means the current model allowance was rejected, not that Pi should make
+	// a billing-policy decision or globally disable the profile.
+	if (/extra usage|overage/.test(normalized)) return "rate-limit";
+	if (/billing error|payment|required.*billing|credit balance.*(?:low|insufficient|empty)|insufficient credits/.test(normalized)) return "billing";
+	if (/\b429\b|rate limit|usage limit|session limit|weekly limit|monthly limit|limit reached|you(?:'|’)ve hit your .* limit|(?:api|usage|request|token|model|account|subscription) quota|too many requests|resets? (?:at )?\d/.test(normalized)) return "rate-limit";
+	if (/overloaded|capacity/.test(normalized)) return "overloaded";
+	if (
+		(Number.isInteger(structuredStatus) && structuredStatus >= 500 && structuredStatus <= 599) ||
+		/server error|internal server|(?:http(?: status)?|status|response|error)\s*5\d\d\b/.test(normalized)
+	) return "server";
+	if (/network|timeout|timed out|socket|econn|connection closed|fetch failed|unexpected end|\beof\b/.test(normalized)) return "network";
+	return undefined;
+}

--- a/pi-extensions/pi-claude-bridge/src/bridge-state.ts
+++ b/pi-extensions/pi-claude-bridge/src/bridge-state.ts
@@ -7,6 +7,13 @@ export interface SessionState {
 	sessionId: string;
 	cursor: number;
 	cwd: string;
+	// Effective Claude model used to create/resume this child session. Persisting
+	// it lets the account router re-resolve an opaque profile id after restart.
+	modelId?: string;
+	// Claude Code session files and resume IDs are credential-profile scoped.
+	// A missing value is the legacy/default Claude profile.
+	accountProfileId?: string;
+	claudeConfigDir?: string;
 	// Force the next syncSharedSession call down the REBUILD path. Set when
 	// pi has mutated its messages array out from under us (compact, tree
 	// navigation) or after an abort left the JSONL in an indeterminate state.
@@ -118,7 +125,12 @@ export function reportSyntheticToolResultRepair(missing: MissingToolResult[], co
 	}
 }
 
-export function reportToolResultMismatch(queryCtx: QueryContext, reason: string, cwd: string | undefined, opts: { forceRotate?: boolean } = {}): boolean {
+export function reportToolResultMismatch(
+	queryCtx: QueryContext,
+	reason: string,
+	cwd: string | undefined,
+	opts: { expectedInterruption?: boolean; forceRotate?: boolean } = {},
+): boolean {
 	try {
 		if (queryCtx.reportedToolResultMismatch) return false;
 		const progress = queryCtx.toolResultProgress();
@@ -129,6 +141,15 @@ export function reportToolResultMismatch(queryCtx: QueryContext, reason: string,
 		queryCtx.reportedToolResultMismatch = true;
 		if (sharedSession) {
 			sharedSession = { ...sharedSession, needsRebuild: true, ...(opts.forceRotate ? { forceRotate: true } : {}) };
+		}
+		if (opts.expectedInterruption) {
+			debug(
+				`tool result delivery interrupted as expected during ${reason}; ` +
+				`delivered=${progress.deliveredCount}/${progress.expectedCount} ` +
+				`resolved=${progress.resolvedCount}/${progress.expectedCount} ` +
+				`waiting=${progress.waitingCount} queued=${progress.queuedCount}`,
+			);
+			return true;
 		}
 		const toolNameSummary = compactToolNameSummary(progress.toolNames);
 		diagDump("tool_result_delivery_mismatch", {

--- a/pi-extensions/pi-claude-bridge/src/config.ts
+++ b/pi-extensions/pi-claude-bridge/src/config.ts
@@ -35,7 +35,6 @@ export interface Config {
 	/** Low-level Claude Agent SDK plumbing. Most users won't need these. */
 	provider?: {
 		appendSystemPrompt?: boolean;
-		allowExtraUsage?: boolean;
 		/** Enable Claude Code fast mode for bridge requests. */
 		fastMode?: boolean;
 		/** Force this Claude Code effort level for every bridge request. */
@@ -284,8 +283,6 @@ function managerToConfig(raw: SettingsRecord): Partial<Config> {
 
 	const appendSystemPrompt = boolFrom(raw, "appendSystemPrompt");
 	if (appendSystemPrompt !== undefined) provider.appendSystemPrompt = appendSystemPrompt;
-	const allowExtraUsage = boolFrom(raw, "allowExtraUsage");
-	if (allowExtraUsage !== undefined) provider.allowExtraUsage = allowExtraUsage;
 	const fastMode = boolFrom(raw, "fastMode");
 	if (fastMode !== undefined) provider.fastMode = fastMode;
 	if (hasOwn(raw, "forceEffort")) {
@@ -375,7 +372,6 @@ export function loadConfig(cwd: string): Config {
 }
 
 const PROVIDER_KEYS = new Set([
-	"allowExtraUsage",
 	"appendSystemPrompt",
 	"connectorWriteMode",
 	"enableConnectors",

--- a/pi-extensions/pi-claude-bridge/src/convert.ts
+++ b/pi-extensions/pi-claude-bridge/src/convert.ts
@@ -6,7 +6,12 @@ import type { ContentBlock, Message as SessionMessage } from "cc-session-io";
 import { pascalCase } from "change-case";
 import { isChildExecutedTool } from "./connectors.js";
 
-export const PROVIDER_ID = "claude-bridge";
+export const PROVIDER_ID = "pi-claude";
+export const LEGACY_PROVIDER_ID = "claude-bridge";
+
+export function isClaudeProvider(provider: unknown): boolean {
+	return provider === PROVIDER_ID || provider === LEGACY_PROVIDER_ID;
+}
 
 export const PI_TO_SDK_TOOL_NAME: Record<string, string> = {
 	read: "Read", write: "Write", edit: "Edit", bash: "Bash",
@@ -90,7 +95,7 @@ function assistantProvenancePrefix(msg: PiMessage): string | undefined {
 	const model = typeof (msg as any).model === "string" ? (msg as any).model : undefined;
 	const api = typeof (msg as any).api === "string" ? (msg as any).api : undefined;
 	if (!provider && !model && !api) return undefined;
-	if (provider === PROVIDER_ID || api === "anthropic") return undefined;
+	if (isClaudeProvider(provider) || api === "anthropic") return undefined;
 	return `[Prior Pi assistant response from ${provider ?? api ?? "unknown-provider"}${model ? `/${model}` : ""}]\n`;
 }
 
@@ -164,7 +169,7 @@ export function convertPiMessages(
 					blocks.push({ type: "text", text: block.text });
 				} else if (block.type === "thinking") {
 					const sig = block.thinkingSignature;
-					const isAnthropicProvider = msg.provider === PROVIDER_ID || msg.api === "anthropic";
+					const isAnthropicProvider = isClaudeProvider(msg.provider) || msg.api === "anthropic";
 					if (isAnthropicProvider && sig) {
 						blocks.push({ type: "thinking", thinking: block.thinking ?? "", signature: sig });
 					}

--- a/pi-extensions/pi-claude-bridge/src/index.ts
+++ b/pi-extensions/pi-claude-bridge/src/index.ts
@@ -1,13 +1,22 @@
 import { type AssistantMessage, type AssistantMessageEventStream, type Context, type Model, type SimpleStreamOptions, type Tool } from "@earendil-works/pi-ai";
 import * as piAi from "@earendil-works/pi-ai";
-import { type ExtensionAPI, type ExtensionUIContext } from "@earendil-works/pi-coding-agent";
-import { createSdkMcpServer, query, type EffortLevel, type SDKMessage, type SDKUserMessage, type SettingSource } from "@anthropic-ai/claude-agent-sdk";
+import {
+	type ExtensionAPI,
+	type ExtensionCommandContext,
+	type ExtensionUIContext,
+} from "@earendil-works/pi-coding-agent";
+import { createSdkMcpServer, query, type EffortLevel, type SDKUserMessage, type SettingSource } from "@anthropic-ai/claude-agent-sdk";
 import type { Base64ImageSource, ContentBlockParam, MessageParam } from "@anthropic-ai/sdk/resources";
-import { PROVIDER_ID, messageContentToText } from "./convert.js";
+import {
+	LEGACY_PROVIDER_ID,
+	PROVIDER_ID,
+	isClaudeProvider,
+	messageContentToText,
+} from "./convert.js";
 import { buildModels, fallbackModelForPrimaryModel, modelDisplayName } from "./models.js";
 import { MCP_SERVER_NAME, MCP_TOOL_PREFIX, extractSkillsBlock } from "./skills.js";
 import { extractAllToolResults as _extractAllToolResults, type McpResult } from "./extract-tool-results.js";
-import { QueryContext, ctx, drainPendingToolCalls, stackDepth, pushContext, toolCallDrainCause } from "./query-state.js";
+import { QueryContext, ctx, drainPendingToolCalls, popContext, stackDepth, pushContext, toolCallDrainCause } from "./query-state.js";
 import { teardownQuery } from "./query-teardown.js";
 import { loadConfig, normalizeEffortLevel, recordProjectTrust, registerExternalConfigResolver, type Config } from "./config.js";
 import { hasClaudeCredentials } from "./auth-presence.js";
@@ -44,11 +53,26 @@ import { preflightClaudeExecutable, resolveClaudeExecutable, spawnClaudeCodeWith
 import { appendIntegrityEntry, argKeys, extensionApi, piUI, reportToolResultMismatch, safeNotify, safeToolCallSummary, setExtensionApi, setPiUI, setSharedSession, sharedSession } from "./bridge-state.js";
 import { connectorMcpServers, connectorQueryOptions, connectorWriteModeFor, connectorsEnabledFor, isChildExecutedTool } from "./connectors.js";
 import { readCachedConnectors, writeCachedConnectors } from "./connector-cache.js";
-import { restoreSharedSessionFromPi, schedulePersistSharedSession, syncSharedSession } from "./session-persistence.js";
+import { cancelScheduledSessionPersistence, restoreSharedSessionFromPi, schedulePersistSharedSession, syncSharedSession } from "./session-persistence.js";
 import { STREAM_IDLE_BACKOFF_HINT_MS, activeStreamIdleWatchdogs, buildStreamIdleTimeoutErrorMessage, createStreamIdleWatchdog, formatDurationShort, streamIdleTimeoutMsFromEnv } from "./stream-idle-watchdog.js";
-import { RATE_LIMIT_AUTO_RESUME_EVENT, RATE_LIMIT_TOKEN, formatAllowedRateLimitWarning, formatResetTimestamp, isExtraUsageRequiredMessage, isUsageLimitMessage, resetTimestampMs, uniqueNonEmptyLines } from "./rate-limit.js";
+import { RATE_LIMIT_AUTO_RESUME_EVENT, RATE_LIMIT_TOKEN, formatAllowedRateLimitWarning, formatResetTimestamp, isUsageLimitMessage, uniqueNonEmptyLines } from "./rate-limit.js";
 import { mapToolArgs } from "./tool-mapping.js";
 import { ensureTurnStarted, finalizeCurrentStream, finalizeToolUseTurnFromMcpInvocation, noteChildExecutedToolResults, processAssistantMessage, processStreamEvent, scheduleToolUseTurnEnd, updateTurnOutputModel } from "./assistant-stream.js";
+import {
+	accountSessionScope,
+	classifyClaudeFailure,
+	CLAUDE_BRIDGE_ACCOUNT_HOST_SYMBOL,
+	rateLimitResetFromInfo,
+	rateLimitResetMs,
+	rateLimitTypeFromInfo,
+	resolveClaudeAccountRouter,
+	RetryEventBuffer,
+	subscriberProfileEnv,
+	type ClaudeAccountFailureKind,
+	type ClaudeAccountRoute,
+	type ClaudeAccountRouterV1,
+	type ClaudeBridgeAccountHostV1,
+} from "./account-router.js";
 
 // Re-exports: the module decomposition must not change the bundle entry's
 // public surface — unit tests and downstream consumers import these from
@@ -57,12 +81,21 @@ export { classifyClaudeExecutableBytes, preflightClaudeExecutable, resolveClaude
 export { __testGetBridgeIntegrityState, __testSetBridgeIntegrityState, INTEGRITY_CUSTOM_TYPE, appendIntegrityEntry, reportToolResultMismatch } from "./bridge-state.js";
 export { CONNECTOR_CALL_CUSTOM_TYPE, connectorResultByteSize, flushConnectorCallAudit, recordConnectorCallResult, setConnectorCallAuditSink, type ConnectorCallAuditData, type ConnectorCallAuditSink, type ConnectorCallOutcome } from "./connector-audit.js";
 export { CLAUDE_AI_CONNECTOR_TOOL_PATTERNS, connectorMcpServers, connectorDeclarationsDisabled, CLAUDE_BRIDGE_TOOL_ISOLATION, CONNECTOR_DISCOVERY_TOOLS, CONNECTOR_WRITE_TOOLS, DISALLOWED_BUILTIN_TOOLS, connectorQueryOptions, connectorWriteDenyHook, connectorWriteModeFor, connectorWriteModeFromEnv, connectorsEnabledFor, connectorsEnabledFromEnv, isChildExecutedTool, isChildInternalTool, isConnectorTool, isConnectorWriteTool, toolIsolationForQuery } from "./connectors.js";
-export { planIncrementalPromptBatch, restoreSharedSessionFromPi, shouldRestorePersistedBridgeEntry } from "./session-persistence.js";
+export { cancelScheduledSessionPersistence, planIncrementalPromptBatch, restoreSharedSessionFromPi, shouldRestorePersistedBridgeEntry } from "./session-persistence.js";
 export { NATIVE_PROVIDER_UNSUPPORTED_MESSAGE, buildNativeProvider, claudeAuthSourceLabel, supportsNativeProvider } from "./native-provider.js";
 export { DEFAULT_STREAM_IDLE_TIMEOUT_MS, STREAM_IDLE_BACKOFF_HINT_MS, STREAM_IDLE_TIMEOUT_ENV, buildStreamIdleTimeoutErrorMessage, createStreamIdleWatchdog, streamIdleTimeoutMsFromEnv, type StreamIdleTimeoutInfo, type StreamIdleWatchdog, type StreamIdleWatchdogState } from "./stream-idle-watchdog.js";
-export { ALLOWED_RATE_LIMIT_WARNING_UTILIZATION_THRESHOLD, formatAllowedRateLimitWarning, formatResetTimestamp, isExtraUsageRequiredMessage, isUsageLimitMessage, normalizeRateLimitUtilization, resetTimestampMs, uniqueNonEmptyLines } from "./rate-limit.js";
+export { ALLOWED_RATE_LIMIT_WARNING_UTILIZATION_THRESHOLD, formatAllowedRateLimitWarning, formatResetTimestamp, isUsageLimitMessage, normalizeRateLimitUtilization, resetTimestampMs, uniqueNonEmptyLines } from "./rate-limit.js";
 export { mapToolName } from "./tool-mapping.js";
 export { cancelScheduledToolUseEnd, endToolUseTurn, finalizeToolUseTurnFromMcpInvocation, noteChildExecutedToolResults, processAssistantMessage, processStreamEvent, reapStaleQueuedResults, scheduleToolUseTurnEnd } from "./assistant-stream.js";
+export {
+	classifyClaudeFailure,
+	commitsVisibleOutput,
+	rateLimitResetFromInfo,
+	rateLimitResetMs,
+	rateLimitTypeFromInfo,
+	RetryEventBuffer,
+	subscriberProfileEnv,
+} from "./account-router.js";
 
 // Compat (#2): use factory if available (pi-ai ≥0.66), else fall back to constructor (gsd-pi etc.)
 const _piAi = piAi as any;
@@ -101,11 +134,28 @@ const newAssistantMessageEventStream: () => AssistantMessageEventStream =
 const PRIMARY_INSTANCE_KEY = Symbol.for("claude-bridge:primaryInstance");
 const ACTIVE_STREAM_SIMPLE_KEY = Symbol.for("claude-bridge:activeStreamSimple");
 const COMMANDS_REGISTERED_KEY = Symbol.for("claude-bridge:commandsRegistered");
+const ROTATION_STATE_KEY = Symbol("claude-bridge:rotationState");
+
+interface RotationRequestState {
+	excludedProfileIds: Set<string>;
+	attempts: number;
+}
+
+type BridgeStreamOptions = SimpleStreamOptions & {
+	[ROTATION_STATE_KEY]?: RotationRequestState;
+};
 
 // MODELS is buildModels(getModels("anthropic")) — projection kept in models.js.
 const MODELS = buildModels(getModels("anthropic"));
 
-let extraUsageHelperInFlight: Promise<string> | null = null;
+type SdkQueryFactory = typeof query;
+let sdkQueryFactory: SdkQueryFactory = query;
+
+/** Test seam for exercising the real bridge retry/session orchestration without
+ *  spending Claude usage. Production never calls this. */
+export function __testSetSdkQueryFactory(factory?: SdkQueryFactory): void {
+	sdkQueryFactory = factory ?? query;
+}
 
 function emitRateLimitEvent(payload: Record<string, unknown>): void {
 	try {
@@ -113,10 +163,6 @@ function emitRateLimitEvent(payload: Record<string, unknown>): void {
 	} catch {
 		// Cross-extension broker is best-effort only.
 	}
-}
-
-function extraUsageAllowed(config: Config): boolean {
-	return config.provider?.allowExtraUsage === true;
 }
 
 // The fastMode setting silently no-ops when Claude Code declines fast mode.
@@ -145,67 +191,73 @@ function noteFastModeDisabledReason(message: unknown, bridgeConfig: Config): voi
 	if (reason === lastFastModeDisabledNoticeReason) return;
 	lastFastModeDisabledNoticeReason = reason;
 	const text = FAST_MODE_DISABLED_REASON_TEXT[reason] ?? `unavailable (${reason})`;
-	safeNotify(`Claude bridge: fast mode is enabled in settings but Claude Code declined it — ${text}.`, "warning");
+	safeNotify(`Pi Claude: fast mode is enabled in settings but Claude Code declined it — ${text}.`, "warning");
 }
 
-function sdkTextFromMessage(message: SDKMessage): string | undefined {
-	if (message.type === "result") return (message as any).result;
-	if (message.type === "assistant") {
-		const content = (message as any).message?.content;
-		if (!Array.isArray(content)) return undefined;
-		return content
-			.map((block) => block?.type === "text" && typeof block.text === "string" ? block.text : "")
-			.filter(Boolean)
-			.join("\n");
-	}
-	return undefined;
-}
-
-async function runExtraUsageHelper(cwd: string, config = loadConfig(cwd)): Promise<string> {
-	const providerSettings = config.provider ?? {};
-	const claudeExecutable = resolveClaudeExecutable(providerSettings.pathToClaudeCodeExecutable);
-	if (claudeExecutable) preflightClaudeExecutable(claudeExecutable, cwd);
-
-	const helperQuery = query({
-		prompt: "/extra-usage",
+async function probeClaudeAccountProfile(input: {
+	profile: ClaudeAccountRoute;
+	cwd: string;
+	signal?: AbortSignal;
+}): Promise<{
+	identity?: { email?: string; organization?: string; subscriptionType?: string; authMethod?: string };
+	usage?: unknown;
+}> {
+	const config = loadConfig(input.cwd);
+	const claudeExecutable = resolveClaudeExecutable(config.provider?.pathToClaudeCodeExecutable);
+	if (claudeExecutable) preflightClaudeExecutable(claudeExecutable, input.cwd);
+	const probe = sdkQueryFactory({
+		prompt: "/usage",
 		options: {
-			cwd,
-			env: { ...process.env, ENABLE_CLAUDEAI_MCP_SERVERS: "0", DISABLE_AUTO_COMPACT: "1" },
+			cwd: input.cwd,
+			env: {
+				...subscriberProfileEnv(input.profile),
+				ENABLE_CLAUDEAI_MCP_SERVERS: "0",
+				DISABLE_AUTO_COMPACT: "1",
+			},
 			maxTurns: 1,
+			permissionMode: "bypassPermissions",
 			...(claudeExecutable ? { pathToClaudeCodeExecutable: claudeExecutable } : {}),
 			spawnClaudeCodeProcess: spawnClaudeCodeWithDiagnostics,
-			...makeCliDebugOptions("extra-usage"),
+			...makeCliDebugOptions("account-probe"),
 		},
 	});
-	const outputs: string[] = [];
+	const onAbort = () => {
+		void probe.interrupt().catch(() => {});
+		try { probe.close(); } catch {}
+	};
+	if (input.signal?.aborted) onAbort();
+	else input.signal?.addEventListener("abort", onAbort, { once: true });
+	let controls: Promise<{
+		identity?: { email?: string; organization?: string; subscriptionType?: string; authMethod?: string };
+		usage?: unknown;
+	}> | undefined;
 	try {
-		for await (const message of helperQuery) {
-			const text = sdkTextFromMessage(message)?.trim();
-			if (text && outputs[outputs.length - 1] !== text) outputs.push(text);
+		for await (const message of probe) {
+			if (message.type === "system" && (message as any).subtype === "init" && !controls) {
+				controls = Promise.allSettled([
+					probe.accountInfo(),
+					probe.usage_EXPERIMENTAL_MAY_CHANGE_DO_NOT_RELY_ON_THIS_API_YET(),
+				]).then(([identityResult, usageResult]) => ({
+					...(identityResult.status === "fulfilled" ? { identity: {
+						email: identityResult.value.email,
+						organization: identityResult.value.organization,
+						subscriptionType: identityResult.value.subscriptionType,
+					} } : {}),
+					...(usageResult.status === "fulfilled" ? { usage: usageResult.value } : {}),
+				}));
+			}
 		}
+		return controls ? await controls : {};
 	} finally {
-		helperQuery.close();
+		input.signal?.removeEventListener("abort", onAbort);
+		probe.close();
 	}
-	return outputs.join("\n").trim() || "Claude Code /extra-usage completed.";
 }
 
-function launchExtraUsageHelperIfAllowed(cwd: string, config: Config, reason: string): boolean {
-	if (!extraUsageAllowed(config)) return false;
-	if (extraUsageHelperInFlight) return true;
-	extraUsageHelperInFlight = runExtraUsageHelper(cwd, config)
-		.then((message) => {
-			piUI?.notify(`Claude extra usage helper: ${message}`, "info");
-			return message;
-		})
-		.catch((error) => {
-			const message = error instanceof Error ? error.message : String(error);
-			piUI?.notify(`Claude extra usage helper failed after ${reason}: ${message}`, "error");
-			throw error;
-		})
-		.finally(() => { extraUsageHelperInFlight = null; });
-	void extraUsageHelperInFlight.catch(() => {});
-	return true;
-}
+const BRIDGE_ACCOUNT_HOST: ClaudeBridgeAccountHostV1 = {
+	version: 1,
+	probeProfile: probeClaudeAccountProfile,
+};
 
 // Pi doesn't pass tool results directly — it appends them to the context and calls
 // the provider again. Thin wrapper over extract-tool-results.js that adds per-turn
@@ -454,7 +506,12 @@ const REASONING_TO_EFFORT: Record<string, EffortLevel> = {
 
 function normalizeEffortOverrideModelKey(value: string): string {
 	const key = value.trim().toLowerCase();
-	return key.startsWith(`${PROVIDER_ID}/`) ? key.slice(PROVIDER_ID.length + 1) : key;
+	for (const providerId of [PROVIDER_ID, LEGACY_PROVIDER_ID]) {
+		if (key.startsWith(`${providerId}/`)) {
+			return key.slice(providerId.length + 1);
+		}
+	}
+	return key;
 }
 
 export function resolveConfiguredEffort(
@@ -492,20 +549,44 @@ export function resolveConfiguredEffort(
  *  an assistant message (completed blocks). On tool_use, the stream is ended by
  *  whichever path handles it first (processStreamEvent or processAssistantMessage),
  *  and the MCP handler blocks the generator until pi delivers the tool result. */
+interface ClaudeAttemptFailure {
+	kind?: ClaudeAccountFailureKind;
+	message: string;
+	rateLimitInfo?: Record<string, unknown>;
+}
+
+interface ConsumeQueryResult {
+	capturedSessionId?: string;
+	failure?: ClaudeAttemptFailure;
+}
+
 async function consumeQuery(
 	sdkQuery: ReturnType<typeof query>,
 	customToolNameToPi: Map<string, string>,
 	model: Model<any>,
-	cwd: string,
 	bridgeConfig: Config,
 	wasAborted: () => boolean,
-): Promise<{ capturedSessionId?: string }> {
+	account?: ClaudeAccountRoute,
+	router?: ClaudeAccountRouterV1,
+): Promise<ConsumeQueryResult> {
 	let capturedSessionId: string | undefined;
+	let failure: ClaudeAttemptFailure | undefined;
+	let accountProbe: Promise<void> | undefined;
 
 	for await (const message of sdkQuery) {
 		if (wasAborted()) break;
 		const queryCtx = ctx();
 		activeStreamIdleWatchdogs.get(queryCtx)?.noteChunk();
+		if (account) {
+			debug("consumeQuery: managed message", JSON.stringify({
+				type: message.type,
+				subtype: (message as any).subtype,
+				error: (message as any).error,
+				eventType: (message as any).event?.type,
+				deltaType: (message as any).event?.delta?.type,
+				contentType: (message as any).event?.content_block?.type,
+			}));
+		}
 		if (!queryCtx.turnOutput) continue;
 		if (!queryCtx.currentPiStream && !(message.type === "assistant" && queryCtx.turnSawToolCall)) continue;
 
@@ -513,10 +594,26 @@ async function consumeQuery(
 			case "stream_event":
 				processStreamEvent(message, customToolNameToPi, model);
 				break;
-			case "assistant":
+			case "assistant": {
+				const sdkError = (message as any).error;
+				if (sdkError && account && !failure) {
+					failure = { kind: classifyClaudeFailure(sdkError), message: String(sdkError) };
+				}
+				// Claude Code emits a synthetic assistant text block carrying friendly
+				// rate/auth error copy before the SDK throws. It is not model output:
+				// forwarding it would commit the stream and make safe pre-output
+				// account failover impossible. Real streamed deltas were already
+				// handled above and keep committedOutput=true.
+				if (sdkError && account) break;
 				processAssistantMessage(message, model, customToolNameToPi);
 				break;
+			}
 			case "result":
+				// The SDK can label the synthetic friendly rate-limit carrier as a
+				// successful result immediately before its iterator throws. Once a
+				// managed attempt has a terminal failure signal, that text is still
+				// error metadata, not assistant output.
+				if (account && failure) break;
 				if (!ctx().turnSawStreamEvent && message.subtype === "success") {
 					const text = message.result || "";
 					// The no-stream-events assistant fallback may have already rendered
@@ -532,27 +629,25 @@ async function consumeQuery(
 					ctx().currentPiStream?.push({ type: "text_start", contentIndex: idx, partial: ctx().turnOutput });
 					ctx().currentPiStream?.push({ type: "text_delta", contentIndex: idx, delta: text, partial: ctx().turnOutput });
 					ctx().currentPiStream?.push({ type: "text_end", contentIndex: idx, content: text, partial: ctx().turnOutput });
-				} else if (message.subtype !== "success" && (isExtraUsageRequiredMessage(message) || isUsageLimitMessage(message))) {
-					// isUsageLimitMessage matches the CLI's own usage-limit copy (SDK
-					// USAGE_LIMIT_ERROR_PREFIXES) — e.g. a plain "You've hit your weekly
-					// limit" that the extra-usage regex never matched, so those turns
-					// used to end as a silent empty success. The /extra-usage helper and
-					// its hints stay gated on the narrow extra-usage test.
+				} else if (message.subtype !== "success") {
 					const errorLines = Array.isArray((message as any).errors) ? uniqueNonEmptyLines((message as any).errors) : [];
-					const errors = errorLines.length > 0 ? errorLines.join("\n") : String(message.subtype ?? "Claude Code rate limit");
-					const extraUsage = isExtraUsageRequiredMessage(message);
-					const openedExtraUsage = extraUsage && launchExtraUsageHelperIfAllowed(cwd, bridgeConfig, "result error");
-					ctx().handledTerminalError = true;
-					ctx().turnOutput.stopReason = "error";
-					const extraUsageHint = openedExtraUsage
-						? "\n\nOpened Claude Code /extra-usage helper. Complete billing/admin flow in the browser, then retry the prompt."
-						: extraUsage
-							? "\n\nRun /claude-bridge:extra, or enable Allow extra usage helper in settings."
-							: "";
-					ctx().turnOutput.errorMessage = `${errors}${extraUsageHint}`;
-					ctx().currentPiStream?.push({ type: "error", reason: "error", error: ctx().turnOutput });
-					ctx().currentPiStream?.end();
-					ctx().currentPiStream = null;
+					const errors = errorLines.length > 0 ? errorLines.join("\n") : String((message as any).result || message.subtype || "Claude Code request failed");
+					const usageLimit = isUsageLimitMessage(message);
+					if ((account || usageLimit) && (!failure || !failure.rateLimitInfo)) {
+						failure = { kind: usageLimit ? "rate-limit" : classifyClaudeFailure(errors), message: errors };
+					}
+					// Managed attempts keep terminal error copy buffered as metadata so a
+					// pre-output failure can move to another subscription profile. Legacy
+					// requests retain main's behavior for unrelated non-success subtypes.
+					if (account) break;
+					if (usageLimit) {
+						ctx().handledTerminalError = true;
+						ctx().turnOutput.stopReason = "error";
+						ctx().turnOutput.errorMessage = errors;
+						ctx().currentPiStream?.push({ type: "error", reason: "error", error: ctx().turnOutput });
+						ctx().currentPiStream?.end();
+						ctx().currentPiStream = null;
+					}
 				}
 				break;
 			case "system":
@@ -563,16 +658,25 @@ async function consumeQuery(
 					// from the teardown flush, which runs outside this function's scope.
 					queryCtx.childSessionId = capturedSessionId;
 					noteFastModeDisabledReason(message, bridgeConfig);
+					if (account && router && !accountProbe) {
+						accountProbe = Promise.allSettled([
+							sdkQuery.accountInfo().then((info) => router.recordIdentity(account.profileId, {
+								email: info.email,
+								organization: info.organization,
+								subscriptionType: info.subscriptionType,
+							})),
+							sdkQuery.usage_EXPERIMENTAL_MAY_CHANGE_DO_NOT_RELY_ON_THIS_API_YET()
+								.then((usage) => router.recordUsage(account.profileId, usage)),
+						]).then(() => undefined);
+					}
 				} else if ((message as any).subtype === "model_refusal_fallback") {
 					const originalModel = (message as any).original_model;
 					const fallbackModel = (message as any).fallback_model;
 					updateTurnOutputModel(fallbackModel);
 					debug("consumeQuery: model_refusal_fallback", JSON.stringify({ originalModel, fallbackModel }));
-					// Notify only for reroutes we configured, so an unexpected pairing from
-					// Claude Code is still logged above but not announced as one of ours.
 					if (typeof fallbackModel === "string" && typeof originalModel === "string" && fallbackModelForPrimaryModel(originalModel) === fallbackModel) {
 						safeNotify(
-							`Claude bridge switched ${modelDisplayName(originalModel)} to ${modelDisplayName(fallbackModel)} after Claude Code safety fallback.`,
+							`Pi Claude switched ${modelDisplayName(originalModel)} to ${modelDisplayName(fallbackModel)} after Claude Code safety fallback.`,
 							"info",
 						);
 					}
@@ -585,24 +689,30 @@ async function consumeQuery(
 				noteChildExecutedToolResults(message);
 				break;
 			case "rate_limit_event": {
-				const info = (message as any).rate_limit_info;
+				const info = (message as any).rate_limit_info as Record<string, unknown> | undefined;
 				debug("consumeQuery: rate_limit_event", JSON.stringify(info).slice(0, 300));
 				if (info?.status === "rejected") {
-					const resetsAt = formatResetTimestamp(info.resetsAt);
-					const resetAtMs = resetTimestampMs(info.resetsAt);
-					const reason = `${info.rateLimitType ?? "unknown"} rate limit`;
-					const launchedExtraUsage = isExtraUsageRequiredMessage(info) && launchExtraUsageHelperIfAllowed(cwd, bridgeConfig, reason);
-					emitRateLimitEvent({
-						model: model.id,
-						provider: PROVIDER_ID,
-						rateLimitType: info.rateLimitType,
-						reason,
-						resetAt: info.resetsAt,
-						...(Number.isFinite(resetAtMs) ? { resetAtMs } : {}),
-						source: "claude-bridge",
-						status: "rejected",
-					});
-					piUI?.notify(`${RATE_LIMIT_TOKEN} Claude ${reason} hit — resets ${resetsAt}${launchedExtraUsage ? "; opened /extra-usage helper" : ""}`, "warning");
+					const rateLimitType = rateLimitTypeFromInfo(info);
+					const resetAt = rateLimitResetFromInfo(info);
+					const resetAtMs = rateLimitResetMs(info);
+					const reason = `${rateLimitType ?? "unknown"} rate limit`;
+					if (account) {
+						failure = { kind: "rate-limit", message: reason, rateLimitInfo: info };
+						router?.recordRateLimit(account.profileId, info, model.id);
+					} else {
+						const resetsAt = formatResetTimestamp(resetAtMs ?? resetAt);
+						emitRateLimitEvent({
+							model: model.id,
+							provider: model.provider,
+							rateLimitType,
+							reason,
+							resetAt,
+							...(Number.isFinite(resetAtMs) ? { resetAtMs } : {}),
+							source: "claude-bridge",
+							status: "rejected",
+						});
+						piUI?.notify(`${RATE_LIMIT_TOKEN} Claude ${reason} hit — resets ${resetsAt}`, "warning");
+					}
 				} else if (info?.status === "allowed_warning") {
 					const warning = formatAllowedRateLimitWarning(info);
 					if (warning) piUI?.notify(warning, "warning");
@@ -616,10 +726,14 @@ async function consumeQuery(
 		}
 	}
 
-	// DEBUG: trace when consumeQuery exits
-	debug(`consumeQuery: for-await loop exited, wasAborted=${wasAborted()}, capturedSessionId=${capturedSessionId?.slice(0, 8) ?? "none"}`);
-
-	return { capturedSessionId };
+	if (accountProbe) {
+		await Promise.race([
+			accountProbe,
+			new Promise<void>((resolve) => setTimeout(resolve, 1_500)),
+		]);
+	}
+	debug(`consumeQuery: for-await loop exited, wasAborted=${wasAborted()}, capturedSessionId=${capturedSessionId?.slice(0, 8) ?? "none"}, failure=${failure?.kind ?? "none"}`);
+	return { capturedSessionId, failure };
 }
 
 // Claim the primary-instance token for this module instance if unclaimed, and
@@ -640,6 +754,9 @@ function claimPrimaryInstance(): boolean {
 // replace-by-id), and logout-hiding is the provider's own auth check.
 function releaseProviderTokens(event: string): void {
 	const g = globalThis as Record<symbol, any>;
+	if (g[CLAUDE_BRIDGE_ACCOUNT_HOST_SYMBOL] === BRIDGE_ACCOUNT_HOST) {
+		g[CLAUDE_BRIDGE_ACCOUNT_HOST_SYMBOL] = undefined;
+	}
 	if (g[ACTIVE_STREAM_SIMPLE_KEY] === streamClaudeAgentSdk) {
 		debug(`${event}: clearing ACTIVE_STREAM_SIMPLE_KEY`);
 		g[ACTIVE_STREAM_SIMPLE_KEY] = undefined;
@@ -670,7 +787,7 @@ function releaseProviderTokens(event: string): void {
 // its own streamSimple — the exact split-brain the tokens exist to prevent.
 // On a pre-0.81 host the extension declines loudly (once) instead of
 // registering wrongly through the legacy overload.
-let nativeProviderInstance: unknown;
+const nativeProviderInstances = new Map<string, unknown>();
 let notifiedNativeUnsupported = false;
 
 function applyProviderRegistration(trigger: string): void {
@@ -690,20 +807,44 @@ function applyProviderRegistration(trigger: string): void {
 		}
 		return;
 	}
-	const credentialed = hasClaudeCredentials();
+	const credentialed = hasClaudeCredentials() || Boolean(resolveClaudeAccountRouter());
 	debug(`${trigger}: native registration upsert, credentialed=${credentialed} (module=${moduleInstanceId})`);
-	// Start the connector inventory now, not on the first turn: the query path
-	// can only read a synchronous snapshot, so priming here is what gets the
-	// declarations in place before turn 1 (vstack#832). Fire and forget —
-	// registration must not wait on the network. Only worth it when a Claude
-	// account is actually connected.
-	if (credentialed && connectorsEnabledFor(loadConfig(process.cwd()))) primeConnectorServers();
+	// Prime the default account's connector inventory when it exists. Explicit
+	// managed profiles are primed in their selected child environment per request.
+	if (hasClaudeCredentials() && connectorsEnabledFor(loadConfig(process.cwd()))) primeConnectorServers();
 	// Claim ordering: stream guard BEFORE registerProvider so a concurrent
 	// subagent can never observe a registered provider without an owner.
 	g[ACTIVE_STREAM_SIMPLE_KEY] = streamClaudeAgentSdk;
 	try {
-		nativeProviderInstance ??= buildNativeProvider(_piAi, MODELS, streamClaudeAgentSdk as (...args: unknown[]) => unknown);
-		(pi.registerProvider as (provider: unknown) => void)(nativeProviderInstance);
+		const authProbe = () => hasClaudeCredentials() || Boolean(resolveClaudeAccountRouter());
+		const providerFor = (providerId: string, providerName: string): unknown => {
+			let provider = nativeProviderInstances.get(providerId);
+			if (!provider) {
+				provider = buildNativeProvider(
+					_piAi,
+					MODELS,
+					streamClaudeAgentSdk as (...args: unknown[]) => unknown,
+					process.env,
+					authProbe,
+					providerId,
+					providerName,
+				);
+				nativeProviderInstances.set(providerId, provider);
+			}
+			return provider;
+		};
+		// pi-claude is canonical. Keep the old id registered as a compatibility
+		// alias so saved sessions can resume while Ctrl+P/settings move cleanly.
+		(pi.registerProvider as (provider: unknown) => void)(
+			providerFor(PROVIDER_ID, "Pi Claude"),
+		);
+		try {
+			(pi.registerProvider as (provider: unknown) => void)(
+				providerFor(LEGACY_PROVIDER_ID, "Pi Claude (legacy alias)"),
+			);
+		} catch (legacyError) {
+			debug(`${trigger}: legacy provider alias registration failed:`, legacyError);
+		}
 	} catch (err) {
 		// Self-heal: release ONLY the stream guard we just claimed so a later
 		// re-check retries cleanly. Keep PRIMARY_INSTANCE_KEY: releasing it would
@@ -715,7 +856,7 @@ function applyProviderRegistration(trigger: string): void {
 
 /** Provider entry point. Pi calls this for each new prompt and each tool result.
  *  Two cases: tool result delivery (active query) or fresh query. */
-function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: SimpleStreamOptions): AssistantMessageEventStream {
+export function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: SimpleStreamOptions): AssistantMessageEventStream {
 	const stream = newAssistantMessageEventStream();
 
 	// DEBUG: trace followUp message triggering
@@ -829,12 +970,9 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 	// tool-result delivery of an in-flight query, handled above, where creds were
 	// valid at start and failing mid-turn would break tool pairing). This bounds
 	// the logout-visibility window from "next session boundary" to "first use":
-	// if credentials vanished since the last session_start, (a) re-upsert the
-	// provider (primary-only) so pi's availability recompute hides the models,
-	// and (b) fail this request with a clear, actionable message instead of
-	// letting the SDK spawn die with a generic error. The check is cheap
-	// (existsSync + env reads only, no credential contents).
-	if (!hasClaudeCredentials()) {
+	// if neither a direct Claude login nor the companion account pool exists,
+	// re-upsert provider availability and fail with an actionable message.
+	if (!hasClaudeCredentials() && !resolveClaudeAccountRouter()) {
 		try { applyProviderRegistration("pre-spawn"); } catch { /* best effort */ }
 		const message = "Claude account not connected — connect an account (or run `claude login`) and retry.";
 		debug(`provider: pre-spawn credential check failed; failing fast: ${message}`);
@@ -867,6 +1005,75 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 	ctx().resetTurnState(model);
 	ctx().resetToolTracking();
 	ctx().latestCursor = 0;
+	ctx().committedOutput = false;
+
+	const router = resolveClaudeAccountRouter();
+	const rotationOptions = options as BridgeStreamOptions | undefined;
+	const rotationState: RotationRequestState = rotationOptions?.[ROTATION_STATE_KEY] ?? {
+		excludedProfileIds: new Set<string>(),
+		attempts: 0,
+	};
+	let account: ClaudeAccountRoute | undefined;
+	if (router) {
+		try {
+			account = router.acquire({
+				modelId: model.id,
+				sessionId: options?.sessionId,
+				excludedProfileIds: [...rotationState.excludedProfileIds],
+				forceRerank: rotationState.attempts > 0,
+				reason: rotationState.attempts > 0 ? "automatic-failover" : undefined,
+			});
+			rotationState.attempts += 1;
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			const resetAtMs = Number((error as { resetAtMs?: unknown })?.resetAtMs);
+			const rateLimitType = (error as { rateLimitType?: unknown })?.rateLimitType;
+			if (ctx().turnOutput) {
+				ctx().turnOutput.stopReason = "error";
+				ctx().turnOutput.errorMessage = message;
+				if (Number.isFinite(resetAtMs)) {
+					Object.assign(ctx().turnOutput as AssistantMessage & Record<string, unknown>, { resetAtMs, rateLimitType });
+				}
+			}
+			if (Number.isFinite(resetAtMs)) {
+				emitRateLimitEvent({
+					model: model.id,
+					provider: model.provider,
+					rateLimitType: rateLimitType ?? "all_accounts",
+					reason: message,
+					resetAt: new Date(resetAtMs).toISOString(),
+					resetAtMs,
+					source: "claude-bridge",
+					status: "rejected",
+				});
+			}
+			const errorOutput = ctx().turnOutput!;
+			if (isReentrant) popContext();
+			queueMicrotask(() => {
+				stream.push({ type: "error", reason: "error", error: errorOutput });
+				stream.end();
+			});
+			return stream;
+		}
+	}
+	const queryModel = account?.modelId && account.modelId !== model.id
+		? { ...model, id: account.modelId, name: modelDisplayName(account.modelId) }
+		: model;
+	const accountScope = accountSessionScope(account);
+	if (queryModel.id !== model.id) {
+		updateTurnOutputModel(queryModel.id);
+		safeNotify(
+			account?.fallbackReason === "fable-quota"
+				? `Every ready account rejected Claude Fable; using ${modelDisplayName(queryModel.id)}.`
+				: `Pi Claude switched to ${modelDisplayName(queryModel.id)}.`,
+			"info",
+		);
+	}
+	const attemptContext = ctx();
+	const attemptBuffer = account
+		? new RetryEventBuffer(stream, () => attemptContext.markOutputCommitted())
+		: undefined;
+	if (attemptBuffer) ctx().currentPiStream = attemptBuffer as unknown as AssistantMessageEventStream;
 
 	const { mcpTools, customToolNameToSdk, customToolNameToPi } = resolveMcpTools(context);
 
@@ -880,7 +1087,13 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 	const claudeExecutablePreflight = claudeExecutable ? preflightClaudeExecutable(claudeExecutable, cwd) : undefined;
 
 	const cursorBeforeSync = sharedSession?.cursor ?? null;
-	const { sessionId: resumeSessionId, promptStart } = syncSharedSession(context.messages, cwd, customToolNameToSdk, model.id);
+	const { sessionId: resumeSessionId, promptStart } = syncSharedSession(
+		context.messages,
+		cwd,
+		customToolNameToSdk,
+		queryModel.id,
+		accountScope,
+	);
 	const promptMessages = context.messages.slice(promptStart);
 	const promptBlocks = extractUserPromptBlocks(promptMessages);
 	let promptText = extractUserPrompt(promptMessages) ?? "";
@@ -920,7 +1133,7 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 	// Declare the account's connected connectors explicitly so `alwaysLoad` can
 	// hold startup until they attach — otherwise the turn-1 manifest is built
 	// before the CLI has fetched them (vstack#832).
-	const connectorServers = enableCloudMcp ? connectorServersSnapshot() : {};
+	const connectorServers = enableCloudMcp ? connectorServersSnapshot(accountScope.claudeConfigDir) : {};
 	const appendSystemPrompt = providerSettings.appendSystemPrompt !== false;
 	const agentsAppend = appendSystemPrompt ? extractAgentsAppend() : undefined;
 	const skillsAppend = appendSystemPrompt ? extractSkillsBlock(context.systemPrompt) : undefined;
@@ -947,10 +1160,10 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 	// per-model overrides — e.g. opus-4-7 wants xhigh→xhigh, not xhigh→max).
 	// Fall back to our generic table for older pi-ai or unmapped levels.
 	const requestedEffort = options?.reasoning
-		? ((model as any).thinkingLevelMap?.[options.reasoning] as EffortLevel | undefined)
+		? ((queryModel as any).thinkingLevelMap?.[options.reasoning] as EffortLevel | undefined)
 			?? REASONING_TO_EFFORT[options.reasoning]
 		: undefined;
-	const effort = resolveConfiguredEffort(model.id, requestedEffort, providerSettings);
+	const effort = resolveConfiguredEffort(queryModel.id, requestedEffort, providerSettings);
 
 	const extraArgs: Record<string, string | null> = {};
 	// Opus 4.7 defaults thinking.display to "omitted" (empty thinking text in stream).
@@ -960,7 +1173,12 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 	// (verified in sdk.mjs flag mapping), so the typed form cannot set display
 	// without overriding the model's thinking mode alongside our `--effort`.
 	if (effort) extraArgs["thinking-display"] = "summarized";
-	const fallbackModel = fallbackModelForPrimaryModel(model.id);
+	// With a managed Fable pool, let every account's model-scoped allowance run
+	// out before changing models. Once the router explicitly selects Opus, its
+	// normal Opus→4.8 safety fallback remains enabled.
+	const fallbackModel = account && model.id === "claude-fable-5" && queryModel.id === model.id
+		? undefined
+		: fallbackModelForPrimaryModel(queryModel.id);
 
 	// Suppress claude.ai cloud MCP servers (Figma/Canva/etc. auto-discovered via OAuth
 	// when the user is logged into Anthropic). These are a separate code path from
@@ -974,10 +1192,14 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 	// Manual /compact in CC still works (we never invoke it).
 	// When connectors are enabled, allow claude.ai cloud MCP servers so the
 	// authenticated account's Gmail/Calendar/Drive tools load. Default stays "0".
-	const childEnv = { ...process.env, ENABLE_CLAUDEAI_MCP_SERVERS: enableCloudMcp ? "1" : "0", DISABLE_AUTO_COMPACT: "1" };
+	const childEnv = {
+		...(account ? subscriberProfileEnv(account) : process.env),
+		ENABLE_CLAUDEAI_MCP_SERVERS: enableCloudMcp ? "1" : "0",
+		DISABLE_AUTO_COMPACT: "1",
+	};
 	const queryOptions: NonNullable<Parameters<typeof query>[0]["options"]> = {
 		cwd,
-		model: model.id,
+		model: queryModel.id,
 		env: childEnv,
 		...connectorQueryOptions(enableCloudMcp, connectorWriteMode),
 		permissionMode: "bypassPermissions",
@@ -1002,8 +1224,8 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 	};
 
 	debug("provider: fresh query",
-		`model=${model.id} msgs=${context.messages.length} tools=${mcpTools.length}`,
-		`resume=${resumeSessionId?.slice(0, 8) ?? "none"} effort=${effort ?? "default"}`,
+		`model=${queryModel.id} requested=${model.id} msgs=${context.messages.length} tools=${mcpTools.length}`,
+		`resume=${resumeSessionId?.slice(0, 8) ?? "none"} effort=${effort ?? "default"} account=${account?.label ?? "legacy"}`,
 		`fallback=${fallbackModel ?? "none"}`,
 		`appendSys=${appendSystemPrompt} promptCtx=${promptContextAppend.labels.join(",") || "none"} strictMcp=${strictMcpConfigEnabled} fastMode=${providerSettings.fastMode === true} connectors=${enableCloudMcp}`,
 		`claudeExec=${claudeExecutablePreflight ? `${claudeExecutablePreflight.fileType}:${claudeExecutablePreflight.path}` : "sdk-default"}`,
@@ -1012,11 +1234,22 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 	// 3. Start SDK query and claim it for this context
 	let wasAborted = false;
 	let streamIdleTimedOut = false;
-	const sdkQuery = query({ prompt, options: queryOptions });
+	let retryRequested = false;
+	let retryFailure: ClaudeAttemptFailure | undefined;
+	const sdkQuery = sdkQueryFactory({ prompt, options: queryOptions });
 	ctx().activeQuery = sdkQuery;
 
 	// 4. Capture context for abort handling (must be AFTER pushContext)
 	const abortCtx = ctx();
+	let accountFailureRecorded = false;
+	const recordAttemptFailure = (failure: ClaudeAttemptFailure): void => {
+		if (
+			accountFailureRecorded || !account || !router || !failure.kind ||
+			failure.rateLimitInfo || wasAborted || options?.signal?.aborted
+		) return;
+		router.recordFailure(account.profileId, failure.kind, queryModel.id);
+		accountFailureRecorded = true;
+	};
 
 	const requestAbort = () => {
 		// interrupt() asks the CLI to stop gracefully; close() kills it immediately.
@@ -1038,14 +1271,25 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 				if (streamIdleTimedOut || wasAborted || options?.signal?.aborted || abortCtx.activeQuery !== sdkQuery) return;
 				streamIdleTimedOut = true;
 				abortCtx.deferredUserMessages = [];
-				abortCtx.handledTerminalError = true;
 				if (sharedSession) setSharedSession({ ...sharedSession, needsRebuild: true, forceRotate: true });
 				const errorMessage = buildStreamIdleTimeoutErrorMessage(timeoutMs);
-				debug("provider: stream idle timeout", `model=${model.id}`, `timeout=${timeoutMs}`, `idle=${idleMs}`);
+				debug("provider: stream idle timeout", `model=${queryModel.id}`, `timeout=${timeoutMs}`, `idle=${idleMs}`);
+				const idleFailure = { kind: "network" as const, message: errorMessage };
+				recordAttemptFailure(idleFailure);
+				if (account && router && !abortCtx.committedOutput) {
+					rotationState.excludedProfileIds.add(account.profileId);
+					retryRequested = true;
+					retryFailure = { kind: "network", message: errorMessage };
+					attemptBuffer?.discard();
+					abortCtx.currentPiStream = null;
+					requestAbort();
+					return;
+				}
+				abortCtx.handledTerminalError = true;
 				emitRateLimitEvent({
 					idleMs,
-					model: model.id,
-					provider: PROVIDER_ID,
+					model: queryModel.id,
+					provider: queryModel.provider,
 					rateLimitType: "stream_idle",
 					reason: "Claude Code stream idle timeout",
 					retryAfterMs: STREAM_IDLE_BACKOFF_HINT_MS,
@@ -1079,7 +1323,10 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 		wasAborted = true;
 		// Prevent stale deferred messages from being replayed by parent on pop
 		abortCtx.deferredUserMessages = [];
-		reportToolResultMismatch(abortCtx, "abort", cwd, { forceRotate: true });
+		reportToolResultMismatch(abortCtx, "abort", cwd, {
+			expectedInterruption: true,
+			forceRotate: true,
+		});
 		const drained = drainPendingToolCalls(abortCtx, "abort");
 		if (drained > 0) debug(`provider: abort drained ${drained} waiting MCP handler(s) as errors`);
 		abortCtx.pendingResults.clear();
@@ -1090,47 +1337,94 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 		else options.signal.addEventListener("abort", onAbort, { once: true });
 	}
 
-	// Background consumer — runs until query ends.
-	// The handlers below use the CAPTURED abortCtx, never the live ctx(): the two
-	// only differ while a reentrant (subagent) context is pushed, and a parent
-	// query CAN end in that window (abort, child process death throwing out of
-	// the generator). Live-ctx handlers there mutated the subagent's turn state
-	// and stream and skipped the parent's own teardown entirely.
-	consumeQuery(sdkQuery, customToolNameToPi, model, cwd, bridgeConfig, () => wasAborted)
-		.then(async ({ capturedSessionId }) => {
-			debug(`provider: consumeQuery completed, stopReason=${abortCtx.turnOutput?.stopReason}, error=${abortCtx.turnOutput?.errorMessage}, aborted=${wasAborted}`);
+	const requestRotation = (failure: ClaudeAttemptFailure): boolean => {
+		recordAttemptFailure(failure);
+		const committedOutput = abortCtx.committedOutput || attemptBuffer?.hasCommittedOutput === true;
+		const eligible = Boolean(account && router && failure.kind && !committedOutput && !wasAborted && !options?.signal?.aborted && rotationState.attempts < 16);
+		debug("provider: account rotation decision", JSON.stringify({
+			eligible,
+			account: account?.label,
+			kind: failure.kind,
+			committedOutput,
+			wasAborted,
+			signalAborted: options?.signal?.aborted === true,
+			attempts: rotationState.attempts,
+		}));
+		if (!eligible || !account || !router || !failure.kind) return false;
+		rotationState.excludedProfileIds.add(account.profileId);
+		retryRequested = true;
+		retryFailure = failure;
+		attemptBuffer?.discard();
+		abortCtx.currentPiStream = null;
+		debug(`provider: rotating account after ${failure.kind}, from=${account.label}, attempt=${rotationState.attempts}`);
+		return true;
+	};
+
+	const surfaceFailure = (failure: ClaudeAttemptFailure, aborted = false): void => {
+		attemptBuffer?.commit();
+		if (failure.rateLimitInfo) {
+			const info = failure.rateLimitInfo;
+			const resetAt = rateLimitResetFromInfo(info);
+			const resetAtMs = rateLimitResetMs(info);
+			emitRateLimitEvent({
+				model: queryModel.id, provider: queryModel.provider, rateLimitType: rateLimitTypeFromInfo(info),
+				reason: failure.message, resetAt,
+				...(Number.isFinite(resetAtMs) ? { resetAtMs } : {}),
+				source: "claude-bridge", status: "rejected",
+			});
+			piUI?.notify(`${RATE_LIMIT_TOKEN} Claude ${failure.message} — resets ${formatResetTimestamp(resetAtMs ?? resetAt)}`, "warning");
+		}
+		if (abortCtx.turnOutput) {
+			abortCtx.turnOutput.stopReason = aborted ? "aborted" : "error";
+			abortCtx.turnOutput.errorMessage = failure.message;
+		}
+		abortCtx.currentPiStream?.push({ type: "error", reason: aborted ? "aborted" : "error", error: abortCtx.turnOutput! });
+		abortCtx.currentPiStream?.end();
+		abortCtx.currentPiStream = null;
+	};
+
+	// Background consumer — runs until this account attempt ends. Before any
+	// visible output, a classified failure is replayed once on each remaining
+	// profile. After output/tool use, replay is forbidden.
+	// The handlers below use the captured abortCtx, never the live ctx(): a
+	// parent query can finish while a reentrant child context is pushed.
+	consumeQuery(sdkQuery, customToolNameToPi, queryModel, bridgeConfig, () => wasAborted, account, router)
+		.then(async ({ capturedSessionId, failure }) => {
+			debug(`provider: consumeQuery completed, stopReason=${abortCtx.turnOutput?.stopReason}, failure=${failure?.kind ?? "none"}, aborted=${wasAborted}`);
 			if (streamIdleTimedOut) {
 				abortCtx.deferredUserMessages = [];
-				debug("provider: stream idle timeout already surfaced; skipping normal completion");
+				debug(`provider: stream idle timeout ${retryRequested ? "queued account rotation" : "already surfaced"}`);
 				return;
 			}
 
-			// --- Abort detection in normal completion path ---
 			if (wasAborted || options?.signal?.aborted) {
 				if (sharedSession) setSharedSession({ ...sharedSession, needsRebuild: true, forceRotate: true });
 				abortCtx.deferredUserMessages = [];
 				debug(`provider: abort detected, marked sharedSession needsRebuild + forceRotate`);
-				if (abortCtx.turnOutput) {
-					abortCtx.turnOutput.stopReason = "aborted";
-					abortCtx.turnOutput.errorMessage = "Operation aborted";
-				}
-				abortCtx.currentPiStream?.push({ type: "error", reason: "aborted", error: abortCtx.turnOutput! });
-				abortCtx.currentPiStream?.end();
-				abortCtx.currentPiStream = null;
+				surfaceFailure({ message: "Operation aborted" }, true);
 				return;
 			}
 
-			// --- Capture session ID ---
-			const sessionId = capturedSessionId ?? sharedSession?.sessionId;
-			if (sessionId) {
-				const cursor = Math.max(context.messages.length, abortCtx.latestCursor, sharedSession?.cursor ?? 0);
-				debug(`provider: query done, session=${sessionId.slice(0, 8)}, cursor=${cursor}`);
-				setSharedSession({ sessionId, cursor, cwd });
+			if (failure) {
+				if (requestRotation(failure)) return;
+				surfaceFailure(failure);
+				return;
 			}
 
-			// --- Replay deferred user messages as continuation queries ---
-			// Only for outermost queries — reentrant (subagent) queries leave
-			// deferred messages for the parent to handle after it finishes.
+			const completedSessionId = capturedSessionId ?? sharedSession?.sessionId;
+			if (completedSessionId) {
+				const cursor = Math.max(context.messages.length, abortCtx.latestCursor, sharedSession?.cursor ?? 0);
+				debug(`provider: query done, session=${completedSessionId.slice(0, 8)}, cursor=${cursor}, account=${account?.label ?? "legacy"}`);
+				setSharedSession({
+					sessionId: completedSessionId,
+					cursor,
+					cwd,
+					modelId: queryModel.id,
+					...accountScope,
+				});
+			}
+			if (account && router) router.recordSuccess(account.profileId, options?.sessionId);
+
 			try {
 				while (abortCtx.deferredUserMessages.length > 0 && !isReentrant && !wasAborted) {
 					const steerPrompt = abortCtx.deferredUserMessages.shift()!;
@@ -1145,52 +1439,60 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 					}
 
 					const contOptions = { ...queryOptions, resume: resumeId, ...makeCliDebugOptions("continuation") };
-					const contQuery = query({ prompt: steerPrompt, options: contOptions });
+					const contQuery = sdkQueryFactory({ prompt: steerPrompt, options: contOptions });
 					abortCtx.activeQuery = contQuery;
-
-					debug(`provider: continuation query, model=${model.id}, resume=${resumeId.slice(0, 8)}, prompt=${steerPrompt.slice(0, 60)}`);
+					debug(`provider: continuation query, model=${queryModel.id}, resume=${resumeId.slice(0, 8)}, account=${account?.label ?? "legacy"}, prompt=${steerPrompt.slice(0, 60)}`);
 
 					try {
-						const { capturedSessionId: contSid } = await consumeQuery(contQuery, customToolNameToPi, model, cwd, bridgeConfig, () => wasAborted);
-						const sid = contSid ?? sharedSession?.sessionId;
-						if (sid) {
-							setSharedSession({ sessionId: sid, cursor: sharedSession?.cursor ?? 0, cwd });
+						const continuation = await consumeQuery(contQuery, customToolNameToPi, queryModel, bridgeConfig, () => wasAborted, account, router);
+						if (continuation.failure) {
+							recordAttemptFailure(continuation.failure);
+							surfaceFailure(continuation.failure);
+							break;
 						}
+						const sid = continuation.capturedSessionId ?? sharedSession?.sessionId;
+						if (sid) setSharedSession({
+							sessionId: sid,
+							cursor: sharedSession?.cursor ?? 0,
+							cwd,
+							modelId: queryModel.id,
+							...accountScope,
+						});
 					} catch (contError) {
 						debug(`provider: continuation query error:`, contError);
+						const continuationFailure = { kind: classifyClaudeFailure(contError), message: contError instanceof Error ? contError.message : String(contError) };
+						recordAttemptFailure(continuationFailure);
+						surfaceFailure(continuationFailure);
 						break;
 					} finally {
 						contQuery.close();
 					}
 				}
 			} finally {
-				// Guarantees restoration even if contQuery() throws synchronously
+				// Guarantees restoration even if contQuery() throws synchronously.
 				abortCtx.activeQuery = sdkQuery;
 			}
 
 			finalizeCurrentStream(abortCtx.turnOutput?.stopReason, abortCtx);
 		})
 		.catch((error) => {
-			debug(`provider: query error, model=${model.id}, aborted=${Boolean(options?.signal?.aborted)}, error=`, error);
-			const suppressDuplicateError = abortCtx.handledTerminalError || streamIdleTimedOut;
-			const openedExtraUsage = !suppressDuplicateError && isExtraUsageRequiredMessage(error) && launchExtraUsageHelperIfAllowed(cwd, bridgeConfig, "query error");
+			debug(`provider: query error, model=${queryModel.id}, aborted=${Boolean(options?.signal?.aborted)}, error=`, error);
+			const suppressDuplicateError = abortCtx.handledTerminalError || (streamIdleTimedOut && !retryRequested);
 			if ((wasAborted || options?.signal?.aborted) && sharedSession) {
 				setSharedSession({ ...sharedSession, needsRebuild: true, forceRotate: true });
-			} else {
-				setSharedSession(null);
 			}
 			abortCtx.deferredUserMessages = [];
-			if (suppressDuplicateError) {
-				debug("provider: suppressing duplicate query error after terminal error was already emitted");
+			if (suppressDuplicateError || retryRequested) {
+				debug("provider: suppressing duplicate query error after terminal handling");
 				return;
 			}
-			if (abortCtx.turnOutput) {
-				abortCtx.turnOutput.stopReason = options?.signal?.aborted ? "aborted" : "error";
-				abortCtx.turnOutput.errorMessage = `${error instanceof Error ? error.message : String(error)}${openedExtraUsage ? "\n\nOpened Claude Code /extra-usage helper. Complete billing/admin flow in the browser, then retry the prompt." : ""}`;
-			}
-			abortCtx.currentPiStream?.push({ type: "error", reason: (abortCtx.turnOutput?.stopReason ?? "error") as "aborted" | "error", error: abortCtx.turnOutput! });
-			abortCtx.currentPiStream?.end();
-			abortCtx.currentPiStream = null;
+			const failure: ClaudeAttemptFailure = {
+				kind: classifyClaudeFailure(error),
+				message: error instanceof Error ? error.message : String(error),
+			};
+			if (requestRotation(failure)) return;
+			if (!wasAborted && !options?.signal?.aborted) setSharedSession(null);
+			surfaceFailure(failure, Boolean(options?.signal?.aborted));
 		})
 		.finally(() => {
 			streamIdleWatchdog?.dispose();
@@ -1199,6 +1501,28 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 			const cause = toolCallDrainCause({ wasAborted, signalAborted: options?.signal?.aborted, streamIdleTimedOut });
 			teardownQuery(abortCtx, sdkQuery, cause, cwd, isReentrant);
 			sdkQuery.close();
+		})
+		.then(async () => {
+			if (!retryRequested || wasAborted || options?.signal?.aborted) return;
+			debug(`provider: starting account retry after ${retryFailure?.kind ?? "failure"}; excluded=${[...rotationState.excludedProfileIds].join(",")}`);
+			const retryStream = streamClaudeAgentSdk(model, context, {
+				...(options ?? {}),
+				[ROTATION_STATE_KEY]: rotationState,
+			} as BridgeStreamOptions);
+			try {
+				for await (const event of retryStream) stream.push(event);
+			} finally {
+				stream.end();
+			}
+		})
+		.catch((error) => {
+			debug("provider: account retry pipeline failed:", error);
+			if (abortCtx.turnOutput) {
+				abortCtx.turnOutput.stopReason = "error";
+				abortCtx.turnOutput.errorMessage = error instanceof Error ? error.message : String(error);
+			}
+			stream.push({ type: "error", reason: "error", error: abortCtx.turnOutput! });
+			stream.end();
 		});
 
 	return stream;
@@ -1224,9 +1548,8 @@ async function tryOpenExtensionManagerSettings(ctx: { ui: ExtensionUIContext }):
 function showBridgeStatus(ctx: { ui: ExtensionUIContext; cwd?: string }): void {
 	const config = loadConfig(commandCwd(ctx));
 	ctx.ui.notify([
-		`Claude bridge: ${config.enabled === false ? "disabled" : "enabled"}`,
-		`Extra usage auto-helper: ${extraUsageAllowed(config) ? "on" : "off"} (settings)`,
-		`Use /claude-bridge:extra to run Claude Code /extra-usage now.`,
+		`Pi Claude: ${config.enabled === false ? "disabled" : "enabled"}`,
+		"Claude account billing settings are managed in Claude.",
 	].join("\n"), "info");
 }
 
@@ -1253,8 +1576,15 @@ function readCredentialFile(path: string): string | undefined {
 const connectorServerCache = new Map<string, Record<string, unknown>>();
 const connectorServerPending = new Set<string>();
 
-function connectorScopeKey(): string {
-	return process.env.CLAUDE_CONFIG_DIR?.trim() || "<default>";
+function connectorScopeKey(claudeConfigDir: string | undefined = process.env.CLAUDE_CONFIG_DIR): string {
+	return claudeConfigDir?.trim() || "<default>";
+}
+
+function connectorCredentialEnv(claudeConfigDir: string | undefined = process.env.CLAUDE_CONFIG_DIR): NodeJS.ProcessEnv {
+	const env = { ...process.env };
+	if (claudeConfigDir?.trim()) env.CLAUDE_CONFIG_DIR = claudeConfigDir.trim();
+	else delete env.CLAUDE_CONFIG_DIR;
+	return env;
 }
 
 // Kick off the inventory fetch for the current credential scope. Fire and
@@ -1270,13 +1600,13 @@ function connectorScopeKey(): string {
 //
 // FAILS OPEN throughout: no credentials, a failed inventory, or a thrown call
 // all resolve to "declare nothing" rather than breaking the turn.
-export function primeConnectorServers(): void {
-	const key = connectorScopeKey();
+export function primeConnectorServers(claudeConfigDir?: string): void {
+	const key = connectorScopeKey(claudeConfigDir);
 	if (connectorServerCache.has(key) || connectorServerPending.has(key)) return;
 	connectorServerPending.add(key);
 	void (async () => {
 		try {
-			const credentials = resolveClaudeOAuth(readCredentialFile);
+			const credentials = resolveClaudeOAuth(readCredentialFile, connectorCredentialEnv(claudeConfigDir));
 			if (!credentials) {
 				debug("connectors: no OAuth credentials; declaring none");
 				connectorServerCache.set(key, {});
@@ -1308,13 +1638,13 @@ export function primeConnectorServers(): void {
 }
 
 /** Synchronous snapshot for the query path; `{}` until priming resolves. */
-function connectorServersSnapshot(): Record<string, unknown> {
-	const key = connectorScopeKey();
+function connectorServersSnapshot(claudeConfigDir?: string): Record<string, unknown> {
+	const key = connectorScopeKey(claudeConfigDir);
 	const ready = connectorServerCache.get(key);
 	if (ready) return ready;
 	// Always start (or continue) the live fetch — the cache is a head start, not
 	// a replacement, and the refresh keeps the next process current.
-	primeConnectorServers();
+	primeConnectorServers(claudeConfigDir);
 	// Fall back to the previous run's inventory, read synchronously. This is the
 	// only thing that can populate turn 1 of a cold process, because priming
 	// cannot finish before the first query is built (vstack#870).
@@ -1329,23 +1659,29 @@ function connectorServersSnapshot(): Record<string, unknown> {
 // Deterministic connector enumeration for the host app (vstack#838). Reports the
 // failure reason rather than an empty list, so "no connectors" and "could not
 // check" stay distinguishable.
-async function reportConnectorInventory(ctx: { ui: ExtensionUIContext }): Promise<void> {
-	const credentials = resolveClaudeOAuth(readCredentialFile);
+async function reportConnectorInventory(ctx: { ui: ExtensionUIContext; model?: Model<any>; sessionManager?: { getSessionId?: () => string } }): Promise<void> {
+	const account = ctx.model
+		? resolveClaudeAccountRouter()?.current(ctx.model.id, ctx.sessionManager?.getSessionId?.())
+		: undefined;
+	const credentials = resolveClaudeOAuth(
+		readCredentialFile,
+		connectorCredentialEnv(account ? accountSessionScope(account).claudeConfigDir : undefined),
+	);
 	if (!credentials) {
-		ctx.ui.notify("Claude bridge: no Claude OAuth credentials found — cannot enumerate connectors.", "error");
+		ctx.ui.notify("Pi Claude: no Claude OAuth credentials found — cannot enumerate connectors.", "error");
 		return;
 	}
 	const inventory = await listAccountConnectors({ credentials });
 	if (!inventory.ok) {
-		ctx.ui.notify(`Claude bridge: connector enumeration failed — ${inventory.reason}`, "error");
+		ctx.ui.notify(`Pi Claude: connector enumeration failed — ${inventory.reason}`, "error");
 		return;
 	}
 	if (inventory.connectors.length === 0) {
-		ctx.ui.notify("Claude bridge: this account has no connectors installed.", "info");
+		ctx.ui.notify("Pi Claude: this account has no connectors installed.", "info");
 		return;
 	}
 	const names = inventory.connectors.map((c) => c.name).join(", ");
-	ctx.ui.notify(`Claude bridge: ${inventory.connectors.length} connector(s) installed — ${names}`, "info");
+	ctx.ui.notify(`Pi Claude: ${inventory.connectors.length} connector(s) installed — ${names}`, "info");
 }
 
 function registerBridgeCommands(pi: ExtensionAPI): void {
@@ -1353,41 +1689,29 @@ function registerBridgeCommands(pi: ExtensionAPI): void {
 	if (guard[COMMANDS_REGISTERED_KEY]) return;
 	guard[COMMANDS_REGISTERED_KEY] = true;
 
-	const runExtraUsage = async (ctx: { ui: ExtensionUIContext; cwd?: string }) => {
-		const cwd = commandCwd(ctx);
-		if (extraUsageHelperInFlight) {
-			ctx.ui.notify("Claude extra usage helper already running.", "info");
-			await extraUsageHelperInFlight.catch(() => undefined);
-			return;
+	const openSettings = async (args: string, ctx: ExtensionCommandContext) => {
+		if (args.trim()) {
+			ctx.ui.notify("Unknown /pi-claude argument.", "warning");
 		}
-		try {
-			ctx.ui.notify("Claude extra usage helper starting…", "info");
-			extraUsageHelperInFlight = runExtraUsageHelper(cwd)
-				.finally(() => { extraUsageHelperInFlight = null; });
-			const message = await extraUsageHelperInFlight;
-			ctx.ui.notify(`Claude extra usage helper: ${message}`, "info");
-		} catch (error) {
-			const message = error instanceof Error ? error.message : String(error);
-			ctx.ui.notify(`Claude extra usage helper failed: ${message}`, "error");
-		}
+		if (await tryOpenExtensionManagerSettings(ctx)) return;
+		showBridgeStatus(ctx);
 	};
-
-	pi.registerCommand("claude-bridge", {
-		description: "Open Claude bridge settings/status",
-		handler: async (args: string, ctx) => {
-			if (args.trim()) ctx.ui.notify("Unknown /claude-bridge argument. Use /claude-bridge:extra to run Claude Code /extra-usage.", "warning");
-			if (await tryOpenExtensionManagerSettings(ctx)) return;
-			showBridgeStatus(ctx);
-		},
-	});
-	pi.registerCommand("claude-bridge:extra", {
-		description: "Run Claude Code /extra-usage through claude-bridge",
-		handler: async (_args: string, ctx) => runExtraUsage(ctx),
-	});
-	pi.registerCommand("claude-bridge:connectors", {
-		description: "List the Claude account's installed claude.ai connectors",
-		handler: async (_args: string, ctx) => reportConnectorInventory(ctx),
-	});
+	const reportConnectors = async (_args: string, ctx: ExtensionCommandContext) =>
+		reportConnectorInventory(ctx);
+	for (const name of ["pi-claude", "claude-bridge"]) {
+		pi.registerCommand(name, {
+			description: name === "pi-claude"
+				? "Open Pi Claude settings/status"
+				: "Legacy alias for /pi-claude",
+			handler: openSettings,
+		});
+		pi.registerCommand(`${name}:connectors`, {
+			description: name === "pi-claude"
+				? "List the Claude account's installed claude.ai connectors"
+				: "Legacy alias for /pi-claude:connectors",
+			handler: reportConnectors,
+		});
+	}
 }
 
 // --- Extension registration ---
@@ -1407,6 +1731,10 @@ export default function (pi: ExtensionAPI) {
 	if (config.enabled === false) {
 		debug("provider: disabled by configuration");
 		return;
+	}
+	if (claimPrimaryInstance()) {
+		const host = globalThis as Record<symbol, any>;
+		host[CLAUDE_BRIDGE_ACCOUNT_HOST_SYMBOL] = BRIDGE_ACCOUNT_HOST;
 	}
 
 	// Reset shared (Claude) conversation state on pi session lifecycle events.
@@ -1434,12 +1762,13 @@ export default function (pi: ExtensionAPI) {
 		applyProviderRegistration(`session_start:${event.reason}`);
 	});
 	pi.on("session_shutdown", () => {
+		cancelScheduledSessionPersistence();
 		clearSession("session_shutdown");
 		releaseProviderTokens("session_shutdown");
 	});
 	pi.on("message_end", (event, ctx) => {
 		const message = (event as { message?: AssistantMessage }).message;
-		if (message?.role === "assistant" && message.provider === PROVIDER_ID) schedulePersistSharedSession(ctx);
+		if (message?.role === "assistant" && isClaudeProvider(message.provider)) schedulePersistSharedSession(ctx);
 	});
 
 	// pi /compact and session-tree navigation (rewind / fork-at-point /

--- a/pi-extensions/pi-claude-bridge/src/native-provider.ts
+++ b/pi-extensions/pi-claude-bridge/src/native-provider.ts
@@ -56,11 +56,14 @@ export function buildNativeProvider(
 	models: Array<Record<string, unknown>>,
 	streamSimple: (...args: unknown[]) => unknown,
 	env: NodeJS.ProcessEnv = process.env,
+	hasCredentials: () => boolean = () => hasClaudeCredentials(env),
+	providerId = PROVIDER_ID,
+	providerName = "Pi Claude",
 ): unknown {
 	if (!supportsNativeProvider(piAi)) throw new Error(NATIVE_PROVIDER_UNSUPPORTED_MESSAGE);
 	// The legacy config path stamped provider/api/baseUrl onto each model during
 	// composition; createProvider passes models through verbatim, so stamp here.
-	const stamped = models.map((model) => ({ api: "claude-bridge", baseUrl: "claude-bridge", provider: PROVIDER_ID, ...model }));
+	const stamped = models.map((model) => ({ ...model, api: "claude-bridge", baseUrl: "claude-bridge", provider: providerId }));
 	// The Claude Code subprocess router IS the implementation for both stream
 	// entry points — there is no raw-API shape to dispatch to.
 	const streams = {
@@ -68,8 +71,8 @@ export function buildNativeProvider(
 		streamSimple,
 	};
 	return (piAi as { createProvider: (input: unknown) => unknown }).createProvider({
-		id: PROVIDER_ID,
-		name: "Claude (Claude Code)",
+		id: providerId,
+		name: providerName,
 		baseUrl: "claude-bridge",
 		auth: {
 			apiKey: {
@@ -77,8 +80,8 @@ export function buildNativeProvider(
 				// check() exists so pi's availability pass never has to call
 				// resolve(): both are existence-only, but check is the documented
 				// side-effect-free probe.
-				check: async () => (hasClaudeCredentials(env) ? { type: "api_key" as const, source: claudeAuthSourceLabel(env) } : undefined),
-				resolve: async () => (hasClaudeCredentials(env)
+				check: async () => (hasCredentials() ? { type: "api_key" as const, source: claudeAuthSourceLabel(env) } : undefined),
+				resolve: async () => (hasCredentials()
 					? { auth: { apiKey: "not-used" }, source: claudeAuthSourceLabel(env) }
 					: undefined),
 			},

--- a/pi-extensions/pi-claude-bridge/src/query-state.ts
+++ b/pi-extensions/pi-claude-bridge/src/query-state.ts
@@ -168,6 +168,9 @@ export class QueryContext {
 	reportedToolResultMismatch = false;
 	deferredUserMessages: string[] = [];
 	handledTerminalError = false;
+	// Once visible text/thinking or a complete tool call reaches Pi, the request
+	// must never be replayed on another account (duplicate side effects).
+	committedOutput = false;
 	/** Armed grace timer for ending a tool_use turn whose terminal stream events
 	 *  (message_delta/message_stop) never arrive. The normal path ends the turn at
 	 *  message_stop, AFTER message_delta delivered the real output-token count;
@@ -305,7 +308,14 @@ export class QueryContext {
 	 *  (ToolSearch et al.) is tool plumbing, not account-data access, so nothing
 	 *  about it belongs in the audit trail and no result needs matching. */
 	noteChildExecutedToolCall(id: string | undefined, rawName: string, streamIndex?: number): void {
-		if (id && isConnectorTool(rawName)) {
+		const connector = isConnectorTool(rawName);
+		if (connector) {
+			// A connector can perform an account-visible side effect before Pi sees
+			// any output. Internal child plumbing such as ToolSearch cannot, so it
+			// must stay replayable when a profile fails before visible output.
+			this.markOutputCommitted();
+		}
+		if (id && connector) {
 			this.childExecutedToolCalls.set(id, rawName);
 			// Both emission paths can see the same call (streamed block, then the
 			// SDK's completed copy), so never overwrite an existing audit state —
@@ -342,6 +352,10 @@ export class QueryContext {
 
 	hasRecordedToolCall(id: string | undefined): boolean {
 		return Boolean(id && (this.turnToolCallIds.includes(id) || this.turnToolCalls.some((call) => call.id === id)));
+	}
+
+	markOutputCommitted(): void {
+		this.committedOutput = true;
 	}
 
 	claimToolCall(toolName: string, args: Record<string, unknown> = {}): ClaimedToolCall {

--- a/pi-extensions/pi-claude-bridge/src/rate-limit.ts
+++ b/pi-extensions/pi-claude-bridge/src/rate-limit.ts
@@ -16,12 +16,6 @@ function coerceMessageText(value: unknown): string {
 	catch { return String(value); }
 }
 
-/** Narrow test: this message is about EXTRA usage specifically — the paid
- *  beyond-plan pool the /extra-usage helper flow can enable. */
-export function isExtraUsageRequiredMessage(value: unknown): boolean {
-	return /extra[-\s]?usage|overage|extra usage billing|extra usage credits|1M context/i.test(coerceMessageText(value));
-}
-
 /** Broad test: any "a usage limit was genuinely reached" message, matched
  *  against the CLI's own copy (SDK `USAGE_LIMIT_ERROR_PREFIXES`, e.g. "You've
  *  hit your weekly limit…"). Substring rather than prefix match because the

--- a/pi-extensions/pi-claude-bridge/src/session-persistence.ts
+++ b/pi-extensions/pi-claude-bridge/src/session-persistence.ts
@@ -3,11 +3,16 @@ import { createSession, deleteSession, openSession, repairToolPairing } from "cc
 import { createHash } from "crypto";
 import { realpathSync, statSync } from "fs";
 import { resolve as pathResolve } from "path";
+import { accountSessionScope, resolveClaudeAccountRouter } from "./account-router.js";
 import { extensionApi, piUI, reportSyntheticToolResultRepair, setSharedSession, sharedSession, type SessionState } from "./bridge-state.js";
 import { convertPiMessages } from "./convert.js";
 import { DEBUG, DEBUG_LOG_PATH, debug, diagDump } from "./debug.js";
 import { verifyWrittenSession as _verifyWrittenSession } from "./session-verify.js";
-import { findUnpairedToolUses, insertLostToolResultPlaceholders } from "./tool-pairing-audit.js";
+import {
+	findUnpairedToolUses,
+	insertLostToolResultPlaceholders,
+	recoverLaterToolResults,
+} from "./tool-pairing-audit.js";
 
 // --- Session persistence ---
 
@@ -52,9 +57,9 @@ function latestPersistedBridgeSession(sessionManager: unknown): PersistedBridgeS
 	return undefined;
 }
 
-function claudeSessionExists(sessionId: string, cwd: string): boolean {
+function claudeSessionExists(sessionId: string, cwd: string, claudeConfigDir?: string): boolean {
 	try {
-		const session = openSession({ sessionId, projectPath: cwd, claudeDir: process.env.CLAUDE_CONFIG_DIR });
+		const session = openSession({ sessionId, projectPath: cwd, claudeDir: claudeConfigDir });
 		statSync(session.jsonlPath);
 		return true;
 	} catch {
@@ -65,6 +70,38 @@ function claudeSessionExists(sessionId: string, cwd: string): boolean {
 function canonicalize(p: string | undefined): string | undefined {
 	if (!p) return undefined;
 	try { return realpathSync.native(p); } catch { return pathResolve(p); }
+}
+
+function resolvePersistedAccountScope(
+	persisted: PersistedBridgeSessionState,
+	currentPiSessionId: string | undefined,
+): { scope?: { accountProfileId?: string; claudeConfigDir?: string }; rejection?: string } {
+	if (!persisted.accountProfileId) {
+		return {
+			scope: persisted.claudeConfigDir ? { claudeConfigDir: persisted.claudeConfigDir } : {},
+		};
+	}
+
+	const route = persisted.modelId
+		? resolveClaudeAccountRouter()?.current(persisted.modelId, currentPiSessionId)
+		: undefined;
+	if (route?.profileId === persisted.accountProfileId) {
+		return { scope: accountSessionScope(route) };
+	}
+
+	// Migration only: older markers stored an identifying config path. Accept it
+	// once so existing sessions resume, then the next marker persists only the
+	// opaque profile id + model id and resolves the path through the router.
+	if (persisted.claudeConfigDir) {
+		return {
+			scope: {
+				accountProfileId: persisted.accountProfileId,
+				claudeConfigDir: persisted.claudeConfigDir,
+			},
+		};
+	}
+
+	return { rejection: "managed profile could not be re-resolved" };
 }
 
 // Decides whether a persisted bridge-session marker is safe to restore.
@@ -103,6 +140,11 @@ export function restoreSharedSessionFromPi(ctx: { sessionManager?: unknown; cwd?
 		debug(`restoreSharedSession: ${rejection} — forcing rebuild`);
 		return;
 	}
+	const accountScope = resolvePersistedAccountScope(persisted, currentPiSessionId);
+	if (!accountScope.scope) {
+		debug(`restoreSharedSession: ${accountScope.rejection ?? "account scope unavailable"} — forcing rebuild`);
+		return;
+	}
 	const built = readBuiltSessionContext(ctx.sessionManager);
 	if (!built) return;
 	const cursor = Math.max(0, Math.min(persisted.cursor, built.messages.length));
@@ -111,27 +153,47 @@ export function restoreSharedSessionFromPi(ctx: { sessionManager?: unknown; cwd?
 		debug(`restoreSharedSession: fingerprint mismatch for ${persisted.sessionId.slice(0, 8)}`);
 		return;
 	}
-	if (!claudeSessionExists(persisted.sessionId, persisted.cwd)) {
+	if (!claudeSessionExists(persisted.sessionId, persisted.cwd, accountScope.scope.claudeConfigDir)) {
 		debug(`restoreSharedSession: Claude session missing for ${persisted.sessionId.slice(0, 8)}`);
 		return;
 	}
-	setSharedSession({ sessionId: persisted.sessionId, cursor, cwd: persisted.cwd });
+	setSharedSession({
+		sessionId: persisted.sessionId,
+		cursor,
+		cwd: persisted.cwd,
+		...(persisted.modelId ? { modelId: persisted.modelId } : {}),
+		...accountScope.scope,
+	});
 	debug(`restoreSharedSession: restored ${persisted.sessionId.slice(0, 8)}, cursor=${cursor}`);
+}
+
+const scheduledPersistenceTimers = new Set<ReturnType<typeof setTimeout>>();
+
+export function cancelScheduledSessionPersistence(): void {
+	for (const timer of scheduledPersistenceTimers) clearTimeout(timer);
+	scheduledPersistenceTimers.clear();
 }
 
 export function schedulePersistSharedSession(ctxLike?: { sessionManager?: unknown }): void {
 	if (!extensionApi || !sharedSession || !ctxLike?.sessionManager) return;
+	// Extension contexts become guarded/stale as soon as shutdown or replacement
+	// starts. Capture the plain SessionManager reference now and cancel the timer
+	// on shutdown rather than dereferencing the ctx proxy from the next tick.
+	const sessionManager = ctxLike.sessionManager;
 	const snapshot = { ...sharedSession };
 	const timer = setTimeout(() => {
+		scheduledPersistenceTimers.delete(timer);
 		try {
-			const built = readBuiltSessionContext(ctxLike.sessionManager);
+			const built = readBuiltSessionContext(sessionManager);
 			if (!built) return;
 			const cursor = Math.max(0, Math.min(snapshot.cursor, built.messages.length));
+			const persistableSnapshot = { ...snapshot };
+			delete persistableSnapshot.claudeConfigDir;
 			const data: PersistedBridgeSessionState = {
-				...snapshot,
+				...persistableSnapshot,
 				cursor,
 				fingerprint: fingerprintMessages(built.messages.slice(0, cursor)),
-				piSessionId: typeof (ctxLike.sessionManager as any)?.getSessionId === "function" ? (ctxLike.sessionManager as any).getSessionId() : undefined,
+				piSessionId: typeof (sessionManager as any)?.getSessionId === "function" ? (sessionManager as any).getSessionId() : undefined,
 				updatedAt: new Date().toISOString(),
 			};
 			extensionApi?.appendEntry(BRIDGE_SESSION_CUSTOM_TYPE, data);
@@ -140,6 +202,7 @@ export function schedulePersistSharedSession(ctxLike?: { sessionManager?: unknow
 			debug("persistSharedSession failed:", error);
 		}
 	}, 0);
+	scheduledPersistenceTimers.add(timer);
 	timer.unref?.();
 }
 
@@ -167,11 +230,18 @@ function convertAndImportMessages(
 		debug(`convertAndImportMessages: sanitized ${sanitizedIds.size} tool IDs:`,
 			[...sanitizedIds.entries()].map(([orig, clean]) => orig === clean ? orig : `${orig}→${clean}`).join(", "));
 	}
-	// Pre-repair: pair every orphaned tool_use with an EXPLICIT bridge-authored
-	// error result before cc-session-io's repairToolPairing can backfill its bare
-	// "[no tool result recorded]" placeholder — which the model reads as tool
-	// output and silently reasons on. Ours is is_error and says what to do.
-	// repairToolPairing still runs after (idempotent; finds nothing left).
+	// A steer can make Pi split one parallel Claude batch across several visible
+	// assistant/tool-result pairs. Recover those real later results before the
+	// generic repair layer mistakes them for lost output.
+	const recoveredToolResults = recoverLaterToolResults(anthropicMessages);
+	if (recoveredToolResults.length > 0) {
+		debug(
+			`convertAndImportMessages: recovered ${recoveredToolResults.length} later tool result(s) for original parallel batch`,
+			recoveredToolResults.map((item) => item.id).join(", "),
+		);
+	}
+	// Pair every remaining orphaned tool_use with an explicit bridge-authored
+	// error result before cc-session-io can insert a bare placeholder.
 	const missingToolResults = findUnpairedToolUses(anthropicMessages);
 	if (missingToolResults.length > 0) insertLostToolResultPlaceholders(anthropicMessages, missingToolResults);
 	const repaired = repairToolPairing(anthropicMessages);
@@ -245,18 +315,19 @@ function verifyWrittenSession(
 	expectedSessionId: string,
 	expectedRecordCount: number,
 	cwd: string,
+	claudeConfigDir?: string,
 ): void {
 	const warnings = _verifyWrittenSession(jsonlPath, expectedSessionId, expectedRecordCount);
 	for (const msg of warnings) {
 		debug(`WARNING session verify: ${msg}`);
 		piUI?.notify(
 			`Session file issue: ${msg}\n` +
-			`cwd=${cwd} realpath=${safeRealpath(cwd)} CLAUDE_CONFIG_DIR=${process.env.CLAUDE_CONFIG_DIR ?? "(unset)"}\n` +
+			`cwd=${cwd} realpath=${safeRealpath(cwd)} CLAUDE_CONFIG_DIR=${claudeConfigDir ?? "(unset)"}\n` +
 			`Please copy and paste this message into a new issue at https://github.com/elidickinson/pi-claude-bridge/issues/new` +
 			(DEBUG ? ` and attach ${DEBUG_LOG_PATH}` : ` (rerun with CLAUDE_BRIDGE_DEBUG=1 to capture a debug log)`),
 			"warning",
 		);
-		diagDump("session_verify_fail", { msg, jsonlPath, cwd, realpath: safeRealpath(cwd), claudeConfigDir: process.env.CLAUDE_CONFIG_DIR ?? null });
+		diagDump("session_verify_fail", { msg, jsonlPath, cwd, realpath: safeRealpath(cwd), claudeConfigDir: claudeConfigDir ?? null });
 	}
 }
 
@@ -267,7 +338,7 @@ function safeRealpath(p: string): string {
 // Diagnostic snapshot of where a session file was just written. Catches the
 // class of bugs where pi writes to ~/.claude/projects/<X> but CC SDK reads
 // from ~/.claude/projects/<Y> (symlinks, CLAUDE_CONFIG_DIR, hash mismatch).
-function debugSessionPaths(label: string, cwd: string, jsonlPath: string): void {
+function debugSessionPaths(label: string, cwd: string, jsonlPath: string, claudeConfigDir?: string): void {
 	const realCwd = safeRealpath(cwd);
 	let fileSize: number | null = null;
 	let fileExists = false;
@@ -280,7 +351,7 @@ function debugSessionPaths(label: string, cwd: string, jsonlPath: string): void 
 	if (realCwd !== cwd) debug(`${label}: realpath(cwd)=${realCwd} (DIFFERS — symlink-resolved path is what CC SDK uses)`);
 	debug(`${label}: jsonlPath=${jsonlPath}`);
 	debug(`${label}: fileExists=${fileExists}${fileSize != null ? ` size=${fileSize}` : ""}`);
-	debug(`${label}: env.CLAUDE_CONFIG_DIR=${process.env.CLAUDE_CONFIG_DIR ?? "(unset)"} HOME=${process.env.HOME ?? "(unset)"}`);
+	debug(`${label}: selected.CLAUDE_CONFIG_DIR=${claudeConfigDir ?? "(unset)"} HOME=${process.env.HOME ?? "(unset)"}`);
 }
 
 // Two semantic paths:
@@ -320,19 +391,33 @@ export function syncSharedSession(
 	cwd: string,
 	customToolNameToSdk?: Map<string, string>,
 	modelId?: string,
+	account?: { accountProfileId?: string; claudeConfigDir?: string },
 ): SyncResult {
 	const priorMessages = messages.slice(0, -1); // everything before the new user prompt
+	const accountProfileId = account?.accountProfileId;
+	const claudeConfigDir = account?.claudeConfigDir;
+	const sameAccount = Boolean(
+		sharedSession &&
+		sharedSession.accountProfileId === accountProfileId &&
+		sharedSession.claudeConfigDir === claudeConfigDir,
+	);
 
-	// REUSE path
-	if (sharedSession && !sharedSession.needsRebuild) {
+	// REUSE path. A Claude session can only be resumed under the credential
+	// profile that created its JSONL and prompt cache.
+	if (sharedSession && sameAccount && !sharedSession.needsRebuild) {
 		const batch = planIncrementalPromptBatch(messages, sharedSession.cursor);
 		if (batch) {
-			setSharedSession({ ...sharedSession, cursor: batch.promptStart, cwd });
+			setSharedSession({
+				...sharedSession,
+				cursor: batch.promptStart,
+				cwd,
+				...(modelId ? { modelId } : {}),
+			});
 			const batching = batch.userMessageCount > 1
 				? `batched ${batch.userMessageCount} consecutive user messages, `
 				: batch.promptStart > sharedSession.cursor ? "advanced cursor past trailing assistant, " : "";
 			debug(`Case 3: ${batching}resuming session ${sharedSession.sessionId.slice(0, 8)}, cursor=${batch.promptStart}`);
-			debug(`syncResult: path=reuse sessionId=${sharedSession.sessionId} cursor=${batch.promptStart} promptUsers=${batch.userMessageCount}`);
+			debug(`syncResult: path=reuse sessionId=${sharedSession.sessionId} cursor=${batch.promptStart} promptUsers=${batch.userMessageCount} account=${accountProfileId ?? "default"}`);
 			return {
 				sessionId: sharedSession.sessionId,
 				promptStart: batch.promptStart,
@@ -342,40 +427,47 @@ export function syncSharedSession(
 
 	// REBUILD path
 	if (priorMessages.length === 0) {
-		debug(`Case 1: clean start, ${messages.length} total messages`);
+		debug(`Case 1: clean start, ${messages.length} total messages, account=${accountProfileId ?? "default"}`);
 		debug(`syncResult: path=clean-start`);
 		return { sessionId: null, promptStart: messages.length - 1 };
 	}
-	const previousSessionId = sharedSession?.sessionId;
-	const previousCursor = sharedSession?.cursor ?? 0;
-	// preserveId: rebuild in place (deleteSession + createSession with the
-	// existing UUID), so prompt-cache UUIDs stay stable for log correlation
-	// and for any tools that key off them. Skipped only when there's a
-	// concurrent writer we shouldn't race — see forceRotate docs above.
+	const replacedSessionId = sharedSession?.sessionId;
+	const previousSessionId = sameAccount ? sharedSession?.sessionId : undefined;
+	const previousCursor = sameAccount ? sharedSession?.cursor ?? 0 : 0;
+	// Preserve a UUID only within the same credential profile. Reusing an A
+	// account session id under B can resume the wrong transcript or miss the file.
 	const preserveId = previousSessionId !== undefined && !sharedSession?.forceRotate;
 	if (preserveId) {
-		// Wipe prior jsonl + companion dir (no-op if nothing to wipe).
-		deleteSession(previousSessionId!, cwd, process.env.CLAUDE_CONFIG_DIR);
+		deleteSession(previousSessionId!, cwd, claudeConfigDir);
 	}
 	const session = createSession({
 		projectPath: cwd,
-		claudeDir: process.env.CLAUDE_CONFIG_DIR,
+		claudeDir: claudeConfigDir,
 		...(preserveId ? { sessionId: previousSessionId } : {}),
 		...(modelId ? { model: modelId } : {}),
 	});
 	convertAndImportMessages(session, priorMessages, customToolNameToSdk, cwd);
 	session.save();
-	verifyWrittenSession(session.jsonlPath, session.sessionId, session.messages.length, cwd);
-	setSharedSession({ sessionId: session.sessionId, cursor: priorMessages.length, cwd });
-	if (previousSessionId === undefined) {
+	verifyWrittenSession(session.jsonlPath, session.sessionId, session.messages.length, cwd, claudeConfigDir);
+	setSharedSession({
+		sessionId: session.sessionId,
+		cursor: priorMessages.length,
+		cwd,
+		...(modelId ? { modelId } : {}),
+		...(accountProfileId ? { accountProfileId } : {}),
+		...(claudeConfigDir ? { claudeConfigDir } : {}),
+	});
+	if (!replacedSessionId) {
 		debug(`Case 2: first turn with ${priorMessages.length} prior messages → session ${session.sessionId.slice(0, 8)}, ${session.messages.length} records`);
+	} else if (!sameAccount) {
+		debug(`Case 4 account-rotation: ${priorMessages.length} prior messages → new session ${session.sessionId.slice(0, 8)} for account ${accountProfileId ?? "default"} (replaced ${replacedSessionId.slice(0, 8)})`);
 	} else if (preserveId) {
 		const missedCount = priorMessages.length - previousCursor;
 		debug(`Case 4: ${missedCount} missed messages, ${priorMessages.length} total → rewrote session ${session.sessionId.slice(0, 8)} (same id), ${session.messages.length} records`);
 	} else {
-		debug(`Case 4 post-abort: ${priorMessages.length} total → new session ${session.sessionId.slice(0, 8)} (was ${previousSessionId.slice(0, 8)}, rotated to avoid race with orphan writer), ${session.messages.length} records`);
+		debug(`Case 4 post-abort: ${priorMessages.length} total → new session ${session.sessionId.slice(0, 8)} (was ${previousSessionId!.slice(0, 8)}, rotated to avoid race with orphan writer), ${session.messages.length} records`);
 	}
-	debugSessionPaths(`${session.sessionId.slice(0, 8)}`, cwd, session.jsonlPath);
-	debug(`syncResult: path=rebuild sessionId=${session.sessionId} priors=${priorMessages.length} ${previousSessionId === undefined ? "first" : preserveId ? "preserved" : "rotated-post-abort"}`);
+	debugSessionPaths(`${session.sessionId.slice(0, 8)}`, cwd, session.jsonlPath, claudeConfigDir);
+	debug(`syncResult: path=rebuild sessionId=${session.sessionId} priors=${priorMessages.length} account=${accountProfileId ?? "default"} ${!replacedSessionId ? "first" : preserveId ? "preserved" : "rotated-post-abort"}`);
 	return { sessionId: session.sessionId, promptStart: messages.length - 1 };
 }

--- a/pi-extensions/pi-claude-bridge/src/tool-pairing-audit.ts
+++ b/pi-extensions/pi-claude-bridge/src/tool-pairing-audit.ts
@@ -9,6 +9,13 @@ export interface MissingToolResult {
 	userIndex: number | null;
 }
 
+export interface RecoveredToolResult {
+	id: string;
+	assistantIndex: number;
+	sourceUserIndex: number;
+	targetUserIndex: number;
+}
+
 function contentBlocks(content: unknown): Array<Record<string, any>> {
 	return Array.isArray(content) ? content.filter((block): block is Record<string, any> => Boolean(block && typeof block === "object")) : [];
 }
@@ -25,6 +32,66 @@ function toolResultIds(content: unknown): Set<string> {
 		if (block.type === "tool_result" && typeof block.tool_use_id === "string") ids.add(block.tool_use_id);
 	}
 	return ids;
+}
+
+/**
+ * Pi can split a parallel Claude tool batch into several visible turns when a
+ * steer is drained after the first tool result. The first assistant message
+ * still contains every tool_use, while later sibling results sit behind small
+ * duplicate assistant/tool-result pairs. Anthropic history requires every
+ * result immediately after the original batch, so copy those already-recorded
+ * later results into that first user result message before generic repair adds
+ * a false "[no tool result recorded]" placeholder.
+ *
+ * The later pair stays intact because Pi also recorded its duplicate tool_use;
+ * copying is therefore required to keep both assistant messages valid.
+ */
+export function recoverLaterToolResults(
+	messages: Array<{ role?: string; content?: unknown }>,
+): RecoveredToolResult[] {
+	const recovered: RecoveredToolResult[] = [];
+	for (let i = 0; i < messages.length; i++) {
+		const assistant = messages[i];
+		if (assistant?.role !== "assistant") continue;
+		const uses = toolUses(assistant.content);
+		if (uses.length === 0) continue;
+
+		const target = messages[i + 1];
+		if (target?.role !== "user") continue;
+		const present = toolResultIds(target.content);
+		const missing = uses.filter((use) => !present.has(use.id));
+		if (missing.length === 0) continue;
+
+		for (const use of missing) {
+			let sourceBlock: Record<string, any> | undefined;
+			let sourceUserIndex = -1;
+			for (let j = i + 2; j < messages.length; j++) {
+				const candidate = messages[j];
+				if (candidate?.role !== "user") continue;
+				sourceBlock = contentBlocks(candidate.content).find(
+					(block) => block.type === "tool_result" && block.tool_use_id === use.id,
+				);
+				if (sourceBlock) {
+					sourceUserIndex = j;
+					break;
+				}
+			}
+			if (!sourceBlock) continue;
+
+			const targetBlocks = Array.isArray(target.content)
+				? target.content as Array<Record<string, any>>
+				: typeof target.content === "string" && target.content
+					? [{ type: "text", text: target.content }]
+					: [];
+			const firstNonResult = targetBlocks.findIndex((block) => block.type !== "tool_result");
+			const insertAt = firstNonResult === -1 ? targetBlocks.length : firstNonResult;
+			targetBlocks.splice(insertAt, 0, { ...sourceBlock });
+			target.content = targetBlocks;
+			present.add(use.id);
+			recovered.push({ id: use.id, assistantIndex: i, sourceUserIndex, targetUserIndex: i + 1 });
+		}
+	}
+	return recovered;
 }
 
 /**

--- a/pi-extensions/pi-claude-bridge/tests/int-session-compact.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/int-session-compact.mjs
@@ -82,8 +82,9 @@ try {
 	}
 	const postEventLog = fullLog.slice(compactIdx);
 
-	// Capture both the path and the rebuild flavor (preserved | rotated-post-abort | first).
-	const syncResults = [...postEventLog.matchAll(/syncResult: path=(reuse|rebuild|clean-start)(?: sessionId=\S+ priors=\d+ (\S+))?/g)]
+	// Capture both the path and rebuild flavor. Account-scoped sessions include
+	// an `account=…` token before the flavor; legacy sessions may omit it.
+	const syncResults = [...postEventLog.matchAll(/syncResult: path=(reuse|rebuild|clean-start)(?: sessionId=\S+ priors=\d+(?: account=\S+)? (\S+))?/g)]
 		.map((m) => ({ path: m[1], flavor: m[2] }));
 	console.log(`  Post-event syncResults: ${JSON.stringify(syncResults)}`);
 
@@ -104,7 +105,7 @@ try {
 
 	// Compact has no concurrent CC writer, so the rebuild should preserve
 	// the sessionId and wipe the JSONL in place (preserveId branch). If we
-	// see "rotated-post-abort" here, the needsRebuild → preserveId logic
+	// see "rotated" here, the needsRebuild → preserveId logic
 	// got re-conflated and we're leaking orphan JSONLs into ~/.claude/projects/
 	// on every compact.
 	if (first.path === "rebuild" && first.flavor !== "preserved") {

--- a/pi-extensions/pi-claude-bridge/tests/int-session-resume.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/int-session-resume.mjs
@@ -150,9 +150,12 @@ try {
   const debugLog = readFileSync(DEBUG_LOG, "utf8");
   const sessionIds = new Set();
   const rotatedPostAbort = [];
-  for (const match of debugLog.matchAll(/syncResult: path=(reuse|rebuild) sessionId=([a-f0-9-]+)(?: priors=\d+ (\S+))?/g)) {
+  // Account-scoped sessions include `account=…` before the rebuild flavor;
+  // legacy sessions may omit it. The current persistence log names the
+  // post-abort branch `rotated`.
+  for (const match of debugLog.matchAll(/syncResult: path=(reuse|rebuild) sessionId=([a-f0-9-]+)(?: priors=\d+(?: account=\S+)? (\S+))?/g)) {
     sessionIds.add(match[2]);
-    if (match[3] === "rotated-post-abort") rotatedPostAbort.push(match[2]);
+    if (match[3] === "rotated") rotatedPostAbort.push(match[2]);
   }
   if (sessionIds.size === 0) finish(1, "FAIL: no syncResult markers found in debug log");
   if (sessionIds.size > 2) finish(1, `FAIL: expected ≤2 distinct sessionIds (one pre-abort, one post-abort rotation), got ${sessionIds.size}: ${[...sessionIds].join(", ")}`);

--- a/pi-extensions/pi-claude-bridge/tests/unit-account-rotation-stream.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-account-rotation-stream.mjs
@@ -1,0 +1,599 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
+
+import {
+	__testGetBridgeIntegrityState,
+	__testSetBridgeIntegrityState,
+	__testSetSdkQueryFactory,
+	streamClaudeAgentSdk,
+} from "../src/index.ts";
+import { CLAUDE_ACCOUNT_ROUTER_SYMBOL } from "../src/account-router.ts";
+import { setExtensionApi } from "../src/bridge-state.ts";
+import { ctx, resetStack } from "../src/query-state.ts";
+import { RATE_LIMIT_AUTO_RESUME_EVENT } from "../src/rate-limit.ts";
+
+const model = {
+	id: "claude-haiku-4-5",
+	name: "Claude Haiku",
+	api: "claude-bridge",
+	provider: "pi-claude",
+	baseUrl: "claude-bridge",
+	reasoning: true,
+	input: ["text", "image"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 200000,
+	maxTokens: 8192,
+};
+const context = { messages: [{ role: "user", content: "hello", timestamp: Date.now() }] };
+
+function fakeSdkQuery(messages, accountLabel, observed) {
+	let closed = false;
+	return {
+		async *[Symbol.asyncIterator]() {
+			for (const message of messages) {
+				if (closed) break;
+				if (message instanceof Error) throw message;
+				yield message;
+			}
+		},
+		close() { closed = true; },
+		async interrupt() { closed = true; },
+		async accountInfo() {
+			return { email: `${accountLabel}@example.com`, subscriptionType: "max" };
+		},
+		async usage_EXPERIMENTAL_MAY_CHANGE_DO_NOT_RELY_ON_THIS_API_YET() {
+			observed.usageProbes.push(accountLabel);
+			return { subscription_type: "max", rate_limits_available: true, rate_limits: null };
+		},
+	};
+}
+
+function makeRouter(observed, options = {}) {
+	const accounts = [
+		{ profileId: "a", label: "account-a", configDir: "/profiles/a" },
+		{ profileId: "b", label: "account-b", configDir: "/profiles/b" },
+	];
+	return {
+		version: 1,
+		acquire(input) {
+			observed.acquires.push(input);
+			if (options.unavailable) {
+				const error = new Error("No Claude subscription account is available");
+				if (options.resetAtMs) Object.assign(error, { resetAtMs: options.resetAtMs, rateLimitType: "all_accounts" });
+				throw error;
+			}
+			const excluded = new Set(input.excludedProfileIds ?? []);
+			const selected = accounts.find((account) => !excluded.has(account.profileId));
+			if (!selected) throw new Error("All Claude accounts are cooling down");
+			return selected;
+		},
+		recordIdentity(profileId, identity) { observed.identities.push({ profileId, identity }); },
+		recordUsage(profileId) { observed.usageRecords.push(profileId); },
+		recordRateLimit(profileId, info) {
+			observed.rateLimits.push({ profileId, info });
+			return Date.now() + 60_000;
+		},
+		recordFailure(profileId, kind) { observed.failures.push({ profileId, kind }); },
+		recordSuccess(profileId) { observed.successes.push(profileId); },
+		current() { return undefined; },
+	};
+}
+
+function observedState() {
+	return {
+		acquires: [],
+		queryEnvs: [],
+		usageProbes: [],
+		usageRecords: [],
+		identities: [],
+		rateLimits: [],
+		failures: [],
+		successes: [],
+	};
+}
+
+async function collect(stream) {
+	const events = [];
+	for await (const event of stream) events.push(event);
+	return events;
+}
+
+beforeEach(() => {
+	process.env.CLAUDE_BRIDGE_STREAM_IDLE_TIMEOUT = "0";
+	resetStack();
+	setExtensionApi(undefined);
+	__testSetBridgeIntegrityState({ sharedSession: null, ui: null });
+});
+
+afterEach(() => {
+	delete process.env.CLAUDE_BRIDGE_STREAM_IDLE_TIMEOUT;
+	delete globalThis[CLAUDE_ACCOUNT_ROUTER_SYMBOL];
+	__testSetSdkQueryFactory();
+	resetStack();
+	setExtensionApi(undefined);
+	__testSetBridgeIntegrityState({ sharedSession: null, ui: null });
+});
+
+describe("managed account stream rotation", () => {
+	it("retries a rejected pre-output request on the next profile without leaking the first attempt", async () => {
+		const observed = observedState();
+		globalThis[CLAUDE_ACCOUNT_ROUTER_SYMBOL] = makeRouter(observed);
+		let calls = 0;
+		__testSetSdkQueryFactory(((input) => {
+			observed.queryEnvs.push(input.options.env);
+			calls += 1;
+			if (calls === 1) {
+				return fakeSdkQuery([
+					{ type: "system", subtype: "init", session_id: "session-a" },
+					{
+						type: "rate_limit_event",
+						rate_limit_info: {
+							status: "rejected",
+							rateLimitType: "five_hour",
+							resetsAt: new Date(Date.now() + 60_000).toISOString(),
+						},
+					},
+					{
+						type: "assistant",
+						error: "rate_limit",
+						message: {
+							model: "<synthetic>",
+							content: [{ type: "text", text: "You've hit your session limit" }],
+							usage: { input_tokens: 0, output_tokens: 0 },
+						},
+					},
+					{ type: "result", subtype: "success", result: "You've hit your session limit" },
+				], "a", observed);
+			}
+			return fakeSdkQuery([
+				{ type: "system", subtype: "init", session_id: "session-b" },
+				{ type: "result", subtype: "success", result: "ok-from-b" },
+			], "b", observed);
+		}));
+
+		const events = await collect(streamClaudeAgentSdk(model, context, { sessionId: "pi-session" }));
+		assert.equal(calls, 2);
+		assert.equal(observed.acquires.length, 2);
+		assert.deepEqual(observed.acquires[1].excludedProfileIds, ["a"]);
+		assert.deepEqual(observed.queryEnvs.map((env) => env.CLAUDE_CONFIG_DIR), [
+			"/profiles/a", "/profiles/b",
+		]);
+		assert.deepEqual(
+			events.filter((event) => event.type === "text_delta").map((event) => event.delta),
+			["ok-from-b"],
+		);
+		assert.equal(events.filter((event) => event.type === "error").length, 0);
+		assert.equal(events.filter((event) => event.type === "start").length, 1);
+		assert.equal(observed.rateLimits[0].profileId, "a");
+		assert.deepEqual(observed.successes, ["b"]);
+	});
+
+	it("rotates on a pre-output network failure", async () => {
+		const observed = observedState();
+		globalThis[CLAUDE_ACCOUNT_ROUTER_SYMBOL] = makeRouter(observed);
+		let calls = 0;
+		__testSetSdkQueryFactory((input) => {
+			observed.queryEnvs.push(input.options.env);
+			calls += 1;
+			return calls === 1
+				? fakeSdkQuery([
+					{ type: "system", subtype: "init", session_id: "session-a" },
+					new Error("socket timeout before response"),
+				], "a", observed)
+				: fakeSdkQuery([
+					{ type: "system", subtype: "init", session_id: "session-b" },
+					{ type: "result", subtype: "success", result: "network-recovered" },
+				], "b", observed);
+		});
+
+		const events = await collect(streamClaudeAgentSdk(model, context, { sessionId: "network-session" }));
+		assert.equal(calls, 2);
+		assert.deepEqual(observed.failures, [{ profileId: "a", kind: "network" }]);
+		assert.ok(events.some((event) => event.type === "text_delta" && event.delta === "network-recovered"));
+		assert.equal(events.some((event) => event.type === "error"), false);
+	});
+
+	it("treats an Extra Usage rejection as a model limit and rotates accounts", async () => {
+		const observed = observedState();
+		globalThis[CLAUDE_ACCOUNT_ROUTER_SYMBOL] = makeRouter(observed);
+		let calls = 0;
+		__testSetSdkQueryFactory(() => {
+			calls += 1;
+			return calls === 1
+				? fakeSdkQuery([
+					{ type: "system", subtype: "init", session_id: "session-a" },
+					{ type: "assistant", error: "extra_usage_disabled" },
+					{ type: "result", subtype: "success", result: "Extra usage is disabled" },
+				], "a", observed)
+				: fakeSdkQuery([
+					{ type: "system", subtype: "init", session_id: "session-b" },
+					{ type: "result", subtype: "success", result: "recovered-without-local-billing-policy" },
+				], "b", observed);
+		});
+
+		const events = await collect(streamClaudeAgentSdk(model, context, { sessionId: "extra-usage-session" }));
+		assert.equal(calls, 2);
+		assert.deepEqual(observed.failures, [{ profileId: "a", kind: "rate-limit" }]);
+		assert.ok(events.some((event) => event.type === "text_delta" && event.delta === "recovered-without-local-billing-policy"));
+		assert.equal(events.some((event) => event.type === "error"), false);
+	});
+
+	it("never replays after visible text has committed", async () => {
+		const observed = observedState();
+		globalThis[CLAUDE_ACCOUNT_ROUTER_SYMBOL] = makeRouter(observed);
+		let calls = 0;
+		__testSetSdkQueryFactory(((input) => {
+			calls += 1;
+			return fakeSdkQuery([
+				{ type: "system", subtype: "init", session_id: "session-a" },
+				{
+					type: "stream_event",
+					event: { type: "message_start", message: { model: model.id, usage: { input_tokens: 1 } } },
+				},
+				{
+					type: "stream_event",
+					event: { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } },
+				},
+				{
+					type: "stream_event",
+					event: { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "already-visible" } },
+				},
+				{
+					type: "assistant",
+					error: "rate_limit",
+					message: { model: model.id, content: [{ type: "text", text: "already-visible" }], usage: { input_tokens: 1, output_tokens: 1 } },
+				},
+				{
+					type: "rate_limit_event",
+					rate_limit_info: {
+						status: "rejected",
+						rateLimitType: "five_hour",
+						resetsAt: new Date(Date.now() + 60_000).toISOString(),
+					},
+				},
+				{ type: "result", subtype: "error_during_execution", errors: ["rate limit"] },
+			], "a", observed);
+		}));
+
+		const events = await collect(streamClaudeAgentSdk(model, context, { sessionId: "pi-session" }));
+		assert.equal(calls, 1);
+		assert.equal(observed.acquires.length, 1);
+		assert.ok(events.some((event) => event.type === "text_delta" && event.delta === "already-visible"));
+		assert.equal(events.filter((event) => event.type === "error").length, 1);
+	});
+
+	it("uses the attempt buffer as a replay guard if context commit state is disturbed", async () => {
+		const observed = observedState();
+		globalThis[CLAUDE_ACCOUNT_ROUTER_SYMBOL] = makeRouter(observed);
+		let calls = 0;
+		__testSetSdkQueryFactory(() => {
+			calls += 1;
+			return {
+				async *[Symbol.asyncIterator]() {
+					yield { type: "system", subtype: "init", session_id: "buffer-guard-session" };
+					yield { type: "stream_event", event: { type: "message_start", message: { model: model.id, usage: { input_tokens: 1 } } } };
+					yield { type: "stream_event", event: { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } } };
+					yield { type: "stream_event", event: { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "committed-by-buffer" } } };
+					// Model the old reentrancy race: a different live context received the
+					// commit stamp, leaving this attempt context falsely replayable.
+					ctx().committedOutput = false;
+					throw new Error("socket timeout after buffered output");
+				},
+				close() {},
+				async interrupt() {},
+				async accountInfo() { return {}; },
+				async usage_EXPERIMENTAL_MAY_CHANGE_DO_NOT_RELY_ON_THIS_API_YET() { return {}; },
+			};
+		});
+
+		const events = await collect(streamClaudeAgentSdk(model, context, { sessionId: "buffer-replay-guard" }));
+		assert.equal(calls, 1);
+		assert.equal(observed.acquires.length, 1);
+		assert.ok(events.some((event) => event.type === "text_delta" && event.delta === "committed-by-buffer"));
+		assert.equal(events.filter((event) => event.type === "error").length, 1);
+	});
+
+	it("records a post-output transport failure without replaying the request", async () => {
+		const observed = observedState();
+		globalThis[CLAUDE_ACCOUNT_ROUTER_SYMBOL] = makeRouter(observed);
+		let calls = 0;
+		__testSetSdkQueryFactory(() => {
+			calls += 1;
+			return fakeSdkQuery([
+				{ type: "system", subtype: "init", session_id: "session-a" },
+				{ type: "stream_event", event: { type: "message_start", message: { model: model.id, usage: { input_tokens: 1 } } } },
+				{ type: "stream_event", event: { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } } },
+				{ type: "stream_event", event: { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "committed" } } },
+				new Error("socket timeout after output"),
+			], "a", observed);
+		});
+
+		const events = await collect(streamClaudeAgentSdk(model, context, { sessionId: "post-output-network" }));
+		assert.equal(calls, 1);
+		assert.deepEqual(observed.failures, [{ profileId: "a", kind: "network" }]);
+		assert.ok(events.some((event) => event.type === "text_delta" && event.delta === "committed"));
+		assert.equal(events.filter((event) => event.type === "error").length, 1);
+	});
+
+	it("rotates after child-internal ToolSearch plumbing fails before visible output", async () => {
+		const observed = observedState();
+		globalThis[CLAUDE_ACCOUNT_ROUTER_SYMBOL] = makeRouter(observed);
+		let calls = 0;
+		__testSetSdkQueryFactory(() => {
+			calls += 1;
+			return calls === 1
+				? fakeSdkQuery([
+					{ type: "system", subtype: "init", session_id: "tool-search-session" },
+					{ type: "stream_event", event: { type: "message_start", message: { model: model.id, usage: { input_tokens: 1 } } } },
+					{
+						type: "stream_event",
+						event: {
+							type: "content_block_start",
+							index: 0,
+							content_block: { type: "tool_use", id: "tool-search-1", name: "ToolSearch", input: {} },
+						},
+					},
+					new Error("socket timeout after internal tool search"),
+				], "a", observed)
+				: fakeSdkQuery([
+					{ type: "system", subtype: "init", session_id: "recovered-session" },
+					{ type: "result", subtype: "success", result: "recovered-after-tool-search" },
+				], "b", observed);
+		});
+
+		const events = await collect(streamClaudeAgentSdk(model, context, { sessionId: "tool-search-replay-boundary" }));
+		assert.equal(calls, 2);
+		assert.deepEqual(observed.failures, [{ profileId: "a", kind: "network" }]);
+		assert.ok(events.some((event) => event.type === "text_delta" && event.delta === "recovered-after-tool-search"));
+		assert.equal(events.some((event) => event.type === "error"), false);
+	});
+
+	it("never replays after a child-executed connector call starts", async () => {
+		const observed = observedState();
+		globalThis[CLAUDE_ACCOUNT_ROUTER_SYMBOL] = makeRouter(observed);
+		let calls = 0;
+		__testSetSdkQueryFactory(() => {
+			calls += 1;
+			return fakeSdkQuery([
+				{ type: "system", subtype: "init", session_id: "connector-session" },
+				{ type: "stream_event", event: { type: "message_start", message: { model: model.id, usage: { input_tokens: 1 } } } },
+				{
+					type: "stream_event",
+					event: {
+						type: "content_block_start",
+						index: 0,
+						content_block: { type: "tool_use", id: "connector-1", name: "mcp__claude_ai_Gmail__search_threads", input: {} },
+					},
+				},
+				new Error("socket timeout after connector dispatch"),
+			], "a", observed);
+		});
+
+		const events = await collect(streamClaudeAgentSdk(model, context, { sessionId: "connector-replay-boundary" }));
+		assert.equal(calls, 1);
+		assert.equal(observed.acquires.length, 1);
+		assert.deepEqual(observed.failures, [{ profileId: "a", kind: "network" }]);
+		assert.equal(events.filter((event) => event.type === "error").length, 1);
+	});
+
+	it("clears mid-turn rebuild flags after a successful managed completion", async () => {
+		const observed = observedState();
+		globalThis[CLAUDE_ACCOUNT_ROUTER_SYMBOL] = makeRouter(observed);
+		__testSetBridgeIntegrityState({
+			sharedSession: {
+				sessionId: "existing-session",
+				cursor: 0,
+				cwd: process.cwd(),
+				modelId: model.id,
+				accountProfileId: "a",
+				claudeConfigDir: "/profiles/a",
+			},
+		});
+		__testSetSdkQueryFactory(() => ({
+			async *[Symbol.asyncIterator]() {
+				yield { type: "system", subtype: "init", session_id: "successful-session" };
+				const state = __testGetBridgeIntegrityState().sharedSession;
+				if (state) {
+					__testSetBridgeIntegrityState({
+						sharedSession: { ...state, needsRebuild: true, forceRotate: true },
+					});
+				}
+				yield { type: "result", subtype: "success", result: "success-clears-flags" };
+			},
+			close() {},
+			async interrupt() {},
+			async accountInfo() { return { email: "a@example.com", subscriptionType: "max" }; },
+			async usage_EXPERIMENTAL_MAY_CHANGE_DO_NOT_RELY_ON_THIS_API_YET() { return {}; },
+		}));
+
+		const events = await collect(streamClaudeAgentSdk(model, context, { sessionId: "clear-flags" }));
+		assert.ok(events.some((event) => event.type === "text_delta" && event.delta === "success-clears-flags"));
+		const state = __testGetBridgeIntegrityState().sharedSession;
+		assert.equal(state?.sessionId, "successful-session");
+		assert.equal(state?.needsRebuild, undefined);
+		assert.equal(state?.forceRotate, undefined);
+	});
+
+	it("uses Opus only after the account router reports every Fable allowance spent", async () => {
+		const observed = observedState();
+		const fableModel = { ...model, id: "claude-fable-5", name: "Claude Fable 5" };
+		const router = makeRouter(observed);
+		router.acquire = (input) => {
+			observed.acquires.push(input);
+			return {
+				profileId: "b",
+				label: "account-b",
+				configDir: "/profiles/b",
+				modelId: "claude-opus-5",
+				fallbackReason: "fable-quota",
+			};
+		};
+		globalThis[CLAUDE_ACCOUNT_ROUTER_SYMBOL] = router;
+		let queryOptions;
+		__testSetSdkQueryFactory((input) => {
+			queryOptions = input.options;
+			return fakeSdkQuery([
+				{ type: "system", subtype: "init", session_id: "opus-session" },
+				{ type: "result", subtype: "success", result: "opus-after-fable" },
+			], "b", observed);
+		});
+
+		const events = await collect(streamClaudeAgentSdk(fableModel, context, { sessionId: "fable-spent" }));
+		assert.equal(queryOptions.model, "claude-opus-5");
+		assert.equal(queryOptions.fallbackModel, "claude-opus-4-8");
+		assert.equal(queryOptions.env.CLAUDE_CONFIG_DIR, "/profiles/b");
+		assert.ok(events.some((event) => event.type === "text_delta" && event.delta === "opus-after-fable"));
+	});
+
+	it("does not let SDK model fallback skip another managed Fable account", async () => {
+		const observed = observedState();
+		const fableModel = { ...model, id: "claude-fable-5", name: "Claude Fable 5" };
+		globalThis[CLAUDE_ACCOUNT_ROUTER_SYMBOL] = makeRouter(observed);
+		let queryOptions;
+		__testSetSdkQueryFactory((input) => {
+			queryOptions = input.options;
+			return fakeSdkQuery([
+				{ type: "system", subtype: "init", session_id: "fable-session" },
+				{ type: "result", subtype: "success", result: "fable-first" },
+			], "a", observed);
+		});
+
+		await collect(streamClaudeAgentSdk(fableModel, context, { sessionId: "fable-ready" }));
+		assert.equal(queryOptions.model, "claude-fable-5");
+		assert.equal(queryOptions.fallbackModel, undefined);
+	});
+
+	it("surfaces an unavailable pool without starting Claude Code", async () => {
+		const observed = observedState();
+		const resetAtMs = Date.now() + 60_000;
+		globalThis[CLAUDE_ACCOUNT_ROUTER_SYMBOL] = makeRouter(observed, { unavailable: true, resetAtMs });
+		let calls = 0;
+		__testSetSdkQueryFactory(() => {
+			calls += 1;
+			throw new Error("must not start");
+		});
+
+		const events = await collect(streamClaudeAgentSdk(model, context, { sessionId: "pi-session" }));
+		assert.equal(calls, 0);
+		assert.equal(events.length, 1);
+		assert.equal(events[0].type, "error");
+		assert.match(events[0].error.errorMessage, /No Claude subscription account/);
+		assert.equal(events[0].error.resetAtMs, resetAtMs);
+		assert.equal(events[0].error.rateLimitType, "all_accounts");
+	});
+
+	it("reports an already-aborted request without rotating", async () => {
+		const observed = observedState();
+		globalThis[CLAUDE_ACCOUNT_ROUTER_SYMBOL] = makeRouter(observed);
+		let calls = 0;
+		__testSetSdkQueryFactory(() => {
+			calls += 1;
+			return fakeSdkQuery([
+				{ type: "system", subtype: "init", session_id: "session-a" },
+				{ type: "result", subtype: "success", result: "must-not-render" },
+			], "a", observed);
+		});
+		const controller = new AbortController();
+		controller.abort();
+		const events = await collect(streamClaudeAgentSdk(model, context, {
+			sessionId: "aborted-session",
+			signal: controller.signal,
+		}));
+		assert.equal(calls, 1);
+		assert.equal(observed.acquires.length, 1);
+		assert.equal(events.filter((event) => event.type === "error").length, 1);
+		assert.equal(events.find((event) => event.type === "error")?.reason, "aborted");
+	});
+
+	it("does not rotate an unclassified invalid request", async () => {
+		const observed = observedState();
+		globalThis[CLAUDE_ACCOUNT_ROUTER_SYMBOL] = makeRouter(observed);
+		let calls = 0;
+		__testSetSdkQueryFactory(() => {
+			calls += 1;
+			return fakeSdkQuery([
+				{ type: "system", subtype: "init", session_id: "session-a" },
+				{ type: "result", subtype: "error_during_execution", errors: ["invalid request shape"] },
+			], "a", observed);
+		});
+
+		const events = await collect(streamClaudeAgentSdk(model, context, { sessionId: "pi-session" }));
+		assert.equal(calls, 1);
+		assert.equal(observed.acquires.length, 1);
+		assert.equal(events.filter((event) => event.type === "error").length, 1);
+	});
+});
+
+describe("legacy account path", () => {
+	it("lets Claude's successful fallback recover a rejected rate-limit event", async () => {
+		const previousToken = process.env.CLAUDE_CODE_OAUTH_TOKEN;
+		process.env.CLAUDE_CODE_OAUTH_TOKEN = "test-only";
+		const notifications = [];
+		const autoResumeEvents = [];
+		setExtensionApi({
+			events: {
+				emit(name, payload) {
+					if (name === RATE_LIMIT_AUTO_RESUME_EVENT) autoResumeEvents.push(payload);
+				},
+			},
+		});
+		__testSetBridgeIntegrityState({
+			sharedSession: null,
+			ui: { notify(message, level) { notifications.push({ message, level }); } },
+		});
+		__testSetSdkQueryFactory(() => fakeSdkQuery([
+			{ type: "system", subtype: "init", session_id: "legacy-fallback-session" },
+			{
+				type: "rate_limit_event",
+				rate_limit_info: {
+					status: "rejected",
+					rateLimitType: "five_hour",
+					resetsAt: new Date(Date.now() + 60_000).toISOString(),
+				},
+			},
+			{ type: "stream_event", event: { type: "message_start", message: { model: model.id, usage: { input_tokens: 1 } } } },
+			{ type: "stream_event", event: { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } } },
+			{ type: "stream_event", event: { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "fallback-recovered" } } },
+			{ type: "stream_event", event: { type: "content_block_stop", index: 0 } },
+			{ type: "stream_event", event: { type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { output_tokens: 1 } } },
+			{ type: "stream_event", event: { type: "message_stop" } },
+			{ type: "result", subtype: "success", result: "fallback-recovered" },
+		], "legacy", observedState()));
+
+		try {
+			const events = await collect(streamClaudeAgentSdk(model, context, { sessionId: "legacy-session" }));
+			assert.deepEqual(
+				events.filter((event) => event.type === "text_delta").map((event) => event.delta),
+				["fallback-recovered"],
+			);
+			assert.equal(events.some((event) => event.type === "error"), false);
+			assert.equal(notifications.filter(({ message }) => message.includes("[rate-limit]")).length, 1);
+			assert.equal(autoResumeEvents.length, 1);
+			const state = __testGetBridgeIntegrityState().sharedSession;
+			assert.equal(state?.sessionId, "legacy-fallback-session");
+			assert.equal(state?.needsRebuild, undefined);
+			assert.equal(state?.forceRotate, undefined);
+		} finally {
+			setExtensionApi(undefined);
+			if (previousToken === undefined) delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
+			else process.env.CLAUDE_CODE_OAUTH_TOKEN = previousToken;
+		}
+	});
+
+	it("preserves legacy silent handling for unrelated non-success results", async () => {
+		const previousToken = process.env.CLAUDE_CODE_OAUTH_TOKEN;
+		process.env.CLAUDE_CODE_OAUTH_TOKEN = "test-only";
+		__testSetSdkQueryFactory(() => fakeSdkQuery([
+			{ type: "system", subtype: "init", session_id: "legacy-non-success" },
+			{ type: "result", subtype: "error_max_turns", errors: ["maximum turns reached"] },
+		], "legacy", observedState()));
+
+		try {
+			const events = await collect(streamClaudeAgentSdk(model, context, { sessionId: "legacy-non-success" }));
+			assert.equal(events.some((event) => event.type === "error"), false);
+		} finally {
+			if (previousToken === undefined) delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
+			else process.env.CLAUDE_CODE_OAUTH_TOKEN = previousToken;
+		}
+	});
+});

--- a/pi-extensions/pi-claude-bridge/tests/unit-account-router.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-account-router.mjs
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+	accountSessionScope,
+	classifyClaudeFailure,
+	rateLimitResetMs,
+	rateLimitTypeFromInfo,
+	RetryEventBuffer,
+	subscriberProfileEnv,
+} from "../src/account-router.ts";
+
+function fakeStream() {
+	const events = [];
+	let ended = false;
+	return {
+		events,
+		get ended() { return ended; },
+		push(event) { events.push(event); },
+		end() { ended = true; },
+	};
+}
+
+describe("subscriberProfileEnv", () => {
+	it("selects CLAUDE_CONFIG_DIR without inheriting API billing credentials", () => {
+		const env = subscriberProfileEnv(
+			{ configDir: "/profiles/max" },
+			{
+				PATH: "/bin",
+				CLAUDE_CONFIG_DIR: "/profiles/old",
+				ANTHROPIC_API_KEY: "secret",
+				ANTHROPIC_AUTH_TOKEN: "secret",
+				ANTHROPIC_OAUTH_TOKEN: "secret",
+				CLAUDE_CODE_OAUTH_TOKEN: "secret",
+				ANTHROPIC_BASE_URL: "https://gateway.invalid",
+				ANTHROPIC_CUSTOM_HEADERS: "Authorization: secret",
+				ANTHROPIC_AWS_API_KEY: "secret",
+				ANTHROPIC_FOUNDRY_AUTH_TOKEN: "secret",
+				AWS_BEARER_TOKEN_BEDROCK: "secret",
+				CLAUDE_CODE_USE_BEDROCK: "1",
+			},
+		);
+		assert.equal(env.PATH, "/bin");
+		assert.equal(env.CLAUDE_CONFIG_DIR, "/profiles/max");
+		assert.equal(env.ANTHROPIC_API_KEY, undefined);
+		assert.equal(env.ANTHROPIC_AUTH_TOKEN, undefined);
+		assert.equal(env.ANTHROPIC_OAUTH_TOKEN, undefined);
+		assert.equal(env.CLAUDE_CODE_OAUTH_TOKEN, undefined);
+		assert.equal(env.ANTHROPIC_BASE_URL, undefined);
+		assert.equal(env.ANTHROPIC_CUSTOM_HEADERS, undefined);
+		assert.equal(env.ANTHROPIC_AWS_API_KEY, undefined);
+		assert.equal(env.ANTHROPIC_FOUNDRY_AUTH_TOKEN, undefined);
+		assert.equal(env.AWS_BEARER_TOKEN_BEDROCK, undefined);
+		assert.equal(env.CLAUDE_CODE_USE_BEDROCK, undefined);
+	});
+
+	it("uses the real default profile by unsetting CLAUDE_CONFIG_DIR", () => {
+		const env = subscriberProfileEnv(
+			{ configDir: undefined },
+			{ HOME: "/home/test", CLAUDE_CONFIG_DIR: "/profiles/old" },
+		);
+		assert.equal(env.CLAUDE_CONFIG_DIR, undefined);
+		assert.deepEqual(
+			accountSessionScope({ profileId: "default", label: "default" }, env),
+			{ accountProfileId: "default", claudeConfigDir: "/home/test/.claude" },
+		);
+	});
+});
+
+describe("RetryEventBuffer", () => {
+	it("discards protocol setup events when an account fails before output", () => {
+		const target = fakeStream();
+		const buffer = new RetryEventBuffer(target);
+		buffer.push({ type: "start", partial: {} });
+		buffer.push({ type: "text_start", contentIndex: 0, partial: {} });
+		buffer.discard();
+		buffer.end();
+		assert.deepEqual(target.events, []);
+		assert.equal(target.ended, false);
+	});
+
+	it("flushes setup exactly once at the first visible delta", () => {
+		const target = fakeStream();
+		let commits = 0;
+		const buffer = new RetryEventBuffer(target, () => { commits += 1; });
+		buffer.push({ type: "start", partial: {} });
+		buffer.push({ type: "text_start", contentIndex: 0, partial: {} });
+		buffer.push({ type: "text_delta", contentIndex: 0, delta: "hello", partial: {} });
+		buffer.push({ type: "text_end", contentIndex: 0, content: "hello", partial: {} });
+		buffer.end();
+		assert.deepEqual(target.events.map((event) => event.type), [
+			"start", "text_start", "text_delta", "text_end",
+		]);
+		assert.equal(commits, 1);
+		assert.equal(target.ended, true);
+	});
+
+	it("treats a complete tool call as committed output", () => {
+		const target = fakeStream();
+		const buffer = new RetryEventBuffer(target);
+		buffer.push({ type: "start", partial: {} });
+		buffer.push({ type: "toolcall_end", contentIndex: 0, toolCall: {}, partial: {} });
+		assert.equal(buffer.hasCommittedOutput, true);
+		assert.deepEqual(target.events.map((event) => event.type), ["start", "toolcall_end"]);
+	});
+});
+
+describe("account routing helpers", () => {
+	it("classifies retryable Claude failures", () => {
+		assert.equal(classifyClaudeFailure("rate_limit"), "rate-limit");
+		assert.equal(classifyClaudeFailure("You've hit your session limit · resets 7:10pm"), "rate-limit");
+		assert.equal(classifyClaudeFailure("authentication_failed"), "auth");
+		assert.equal(classifyClaudeFailure("401 authentication_error"), "auth");
+		assert.equal(classifyClaudeFailure("OAuth token has expired; please run /login"), "auth");
+		assert.equal(classifyClaudeFailure("Extra usage is disabled for this account"), "rate-limit");
+		assert.equal(classifyClaudeFailure("Credit balance is too low"), "billing");
+		assert.equal(classifyClaudeFailure({ status: 429, message: "request rejected" }), "rate-limit");
+		assert.equal(classifyClaudeFailure("usage quota exceeded"), "rate-limit");
+		assert.equal(classifyClaudeFailure("disk quota exceeded"), undefined);
+		assert.equal(classifyClaudeFailure("API overloaded"), "overloaded");
+		assert.equal(classifyClaudeFailure({ statusCode: 503, message: "temporarily unavailable" }), "server");
+		assert.equal(classifyClaudeFailure("processed 500 files"), undefined);
+		assert.equal(classifyClaudeFailure("socket timeout"), "network");
+		assert.equal(classifyClaudeFailure("invalid request"), undefined);
+	});
+
+	it("normalizes camel/snake rate-limit payload variants", () => {
+		const resetSeconds = Math.floor((Date.now() + 60_000) / 1000);
+		assert.equal(rateLimitTypeFromInfo({ rate_limit_type: "seven_day_fable" }), "seven_day_fable");
+		assert.equal(rateLimitResetMs({ resets_at: resetSeconds }), resetSeconds * 1000);
+		assert.equal(rateLimitResetMs({ resetsAt: "2030-01-01T00:00:00Z" }), Date.parse("2030-01-01T00:00:00Z"));
+	});
+
+	it("keeps account-scoped session metadata explicit", () => {
+		assert.deepEqual(
+			accountSessionScope({ profileId: "2", label: "max", configDir: "/profiles/max" }),
+			{ accountProfileId: "2", claudeConfigDir: "/profiles/max" },
+		);
+		assert.deepEqual(
+			accountSessionScope(
+				{ profileId: "1", label: "default" },
+				{ HOME: "/home/test", CLAUDE_CONFIG_DIR: "/profiles/inherited" },
+			),
+			{ accountProfileId: "1", claudeConfigDir: "/home/test/.claude" },
+		);
+	});
+});

--- a/pi-extensions/pi-claude-bridge/tests/unit-account-session-persistence.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-account-session-persistence.mjs
@@ -1,0 +1,157 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { after, afterEach, beforeEach, describe, it } from "node:test";
+import { createSession } from "cc-session-io";
+
+import { CLAUDE_ACCOUNT_ROUTER_SYMBOL } from "../src/account-router.ts";
+import {
+	__testGetBridgeIntegrityState,
+	__testSetBridgeIntegrityState,
+	setExtensionApi,
+} from "../src/bridge-state.ts";
+import {
+	cancelScheduledSessionPersistence,
+	restoreSharedSessionFromPi,
+	schedulePersistSharedSession,
+} from "../src/session-persistence.ts";
+
+const root = mkdtempSync(join(tmpdir(), "claude-account-persistence-"));
+const cwd = join(root, "project");
+const profileDir = join(root, "profile-a");
+
+function fingerprint(messages) {
+	return createHash("sha256").update(JSON.stringify(messages)).digest("hex");
+}
+
+beforeEach(() => {
+	mkdirSync(cwd, { recursive: true });
+	mkdirSync(profileDir, { recursive: true });
+	cancelScheduledSessionPersistence();
+	setExtensionApi(undefined);
+	__testSetBridgeIntegrityState({ sharedSession: null, ui: null });
+	delete globalThis[CLAUDE_ACCOUNT_ROUTER_SYMBOL];
+});
+
+afterEach(() => {
+	cancelScheduledSessionPersistence();
+	setExtensionApi(undefined);
+	__testSetBridgeIntegrityState({ sharedSession: null, ui: null });
+	delete globalThis[CLAUDE_ACCOUNT_ROUTER_SYMBOL];
+});
+
+after(() => rmSync(root, { recursive: true, force: true }));
+
+describe("account-scoped session persistence", () => {
+	it("persists only the opaque profile id and model, not the identifying config path", async () => {
+		const entries = [];
+		setExtensionApi({ appendEntry(type, data) { entries.push({ type, data }); } });
+		__testSetBridgeIntegrityState({
+			sharedSession: {
+				sessionId: "child-session",
+				cursor: 1,
+				cwd,
+				modelId: "claude-opus-5",
+				accountProfileId: "profile-a",
+				claudeConfigDir: profileDir,
+			},
+		});
+		const messages = [{ role: "user", content: "hello", timestamp: 1 }];
+		schedulePersistSharedSession({
+			sessionManager: {
+				buildSessionContext: () => ({ messages }),
+				getSessionId: () => "pi-session",
+			},
+		});
+		await new Promise((resolve) => setTimeout(resolve, 10));
+
+		assert.equal(entries.length, 1);
+		assert.equal(entries[0].type, "claude-bridge-session");
+		assert.equal(entries[0].data.accountProfileId, "profile-a");
+		assert.equal(entries[0].data.modelId, "claude-opus-5");
+		assert.equal("claudeConfigDir" in entries[0].data, false);
+	});
+
+	it("re-resolves an opaque persisted profile through the account router", () => {
+		const messages = [{ role: "user", content: "hello", timestamp: 1 }];
+		const child = createSession({ projectPath: cwd, claudeDir: profileDir });
+		child.addUserMessage("hello");
+		child.save();
+		globalThis[CLAUDE_ACCOUNT_ROUTER_SYMBOL] = {
+			version: 1,
+			current(modelId, sessionId) {
+				assert.equal(modelId, "claude-opus-5");
+				assert.equal(sessionId, "pi-session");
+				return { profileId: "profile-a", label: "Account A", configDir: profileDir };
+			},
+		};
+		const marker = {
+			type: "custom",
+			customType: "claude-bridge-session",
+			data: {
+				sessionId: child.sessionId,
+				cursor: 1,
+				cwd,
+				modelId: "claude-opus-5",
+				accountProfileId: "profile-a",
+				fingerprint: fingerprint(messages),
+				piSessionId: "pi-session",
+				updatedAt: new Date().toISOString(),
+			},
+		};
+
+		restoreSharedSessionFromPi({
+			cwd,
+			sessionManager: {
+				getEntries: () => [marker],
+				getSessionId: () => "pi-session",
+				getCwd: () => cwd,
+				buildSessionContext: () => ({ messages }),
+			},
+		});
+
+		assert.deepEqual(__testGetBridgeIntegrityState().sharedSession, {
+			sessionId: child.sessionId,
+			cursor: 1,
+			cwd,
+			modelId: "claude-opus-5",
+			accountProfileId: "profile-a",
+			claudeConfigDir: profileDir,
+		});
+	});
+
+	it("accepts one legacy path-bearing marker as a migration fallback", () => {
+		const messages = [{ role: "user", content: "legacy", timestamp: 1 }];
+		const child = createSession({ projectPath: cwd, claudeDir: profileDir });
+		child.addUserMessage("legacy");
+		child.save();
+		const marker = {
+			type: "custom",
+			customType: "claude-bridge-session",
+			data: {
+				sessionId: child.sessionId,
+				cursor: 1,
+				cwd,
+				accountProfileId: "profile-a",
+				claudeConfigDir: profileDir,
+				fingerprint: fingerprint(messages),
+				piSessionId: "pi-session",
+				updatedAt: new Date().toISOString(),
+			},
+		};
+
+		restoreSharedSessionFromPi({
+			cwd,
+			sessionManager: {
+				getEntries: () => [marker],
+				getSessionId: () => "pi-session",
+				getCwd: () => cwd,
+				buildSessionContext: () => ({ messages }),
+			},
+		});
+
+		assert.equal(__testGetBridgeIntegrityState().sharedSession?.claudeConfigDir, profileDir);
+	});
+});

--- a/pi-extensions/pi-claude-bridge/tests/unit-account-session-scope.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-account-session-scope.mjs
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { after, beforeEach, describe, it } from "node:test";
+import { openSession } from "cc-session-io";
+
+import {
+	__testGetBridgeIntegrityState,
+	__testSetBridgeIntegrityState,
+} from "../src/bridge-state.ts";
+import { syncSharedSession } from "../src/session-persistence.ts";
+
+const root = mkdtempSync(join(tmpdir(), "claude-account-session-"));
+const cwd = join(root, "project");
+const accountA = join(root, "account-a");
+const accountB = join(root, "account-b");
+
+beforeEach(() => {
+	rmSync(cwd, { recursive: true, force: true });
+	rmSync(accountA, { recursive: true, force: true });
+	rmSync(accountB, { recursive: true, force: true });
+	mkdirSync(cwd, { recursive: true });
+	__testSetBridgeIntegrityState({ sharedSession: null, ui: null });
+});
+after(() => rmSync(root, { recursive: true, force: true }));
+
+describe("account-scoped Claude sessions", () => {
+	it("never resumes or deletes account A's session while switching to account B", () => {
+		const messages = [
+			{ role: "user", content: "prior context", timestamp: Date.now() },
+			{ role: "user", content: "current prompt", timestamp: Date.now() },
+		];
+		const first = syncSharedSession(
+			messages,
+			cwd,
+			undefined,
+			"claude-opus-5",
+			{ accountProfileId: "a", claudeConfigDir: accountA },
+		);
+		assert.ok(first.sessionId);
+		const firstPath = openSession({
+			sessionId: first.sessionId,
+			projectPath: cwd,
+			claudeDir: accountA,
+		}).jsonlPath;
+		assert.equal(existsSync(firstPath), true);
+
+		const second = syncSharedSession(
+			messages,
+			cwd,
+			undefined,
+			"claude-opus-5",
+			{ accountProfileId: "b", claudeConfigDir: accountB },
+		);
+		assert.ok(second.sessionId);
+		assert.notEqual(second.sessionId, first.sessionId);
+		assert.equal(existsSync(firstPath), true, "switching accounts must not delete A's transcript");
+		const state = __testGetBridgeIntegrityState().sharedSession;
+		assert.equal(state?.accountProfileId, "b");
+		assert.equal(state?.claudeConfigDir, accountB);
+		assert.equal(state?.modelId, "claude-opus-5");
+
+		const reused = syncSharedSession(
+			messages,
+			cwd,
+			undefined,
+			"claude-opus-5",
+			{ accountProfileId: "b", claudeConfigDir: accountB },
+		);
+		assert.equal(reused.sessionId, second.sessionId);
+	});
+
+	it("keeps the account-scoped session warm for a batched trailing user run", () => {
+		const initial = [
+			{ role: "user", content: "prior", timestamp: Date.now() },
+			{ role: "user", content: "first prompt", timestamp: Date.now() },
+		];
+		const first = syncSharedSession(
+			initial,
+			cwd,
+			undefined,
+			"claude-opus-5",
+			{ accountProfileId: "a", claudeConfigDir: accountA },
+		);
+		assert.ok(first.sessionId);
+
+		const batched = [
+			initial[0],
+			{ role: "assistant", content: [{ type: "text", text: "done" }] },
+			{ role: "user", content: "follow-up one", timestamp: Date.now() },
+			{ role: "user", content: "follow-up two", timestamp: Date.now() },
+		];
+		const reused = syncSharedSession(
+			batched,
+			cwd,
+			undefined,
+			"claude-opus-5",
+			{ accountProfileId: "a", claudeConfigDir: accountA },
+		);
+		assert.equal(reused.sessionId, first.sessionId);
+		assert.equal(reused.promptStart, 2);
+	});
+});

--- a/pi-extensions/pi-claude-bridge/tests/unit-child-executed-tools.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-child-executed-tools.mjs
@@ -461,6 +461,17 @@ describe("usage across a Pi turn that spans several child messages", () => {
 describe("child-executed tool results", () => {
 	beforeEach(() => resetStack());
 
+	it("commits connector dispatches but keeps internal child plumbing replayable", () => {
+		const c = ctx();
+		c.noteChildExecutedToolCall("toolu_ts", "ToolSearch", 0);
+		assert.equal(c.committedOutput, false);
+		assert.equal(c.childExecutedStreamIndexes.has(0), true);
+
+		c.noteChildExecutedToolCall("toolu_conn", CONNECTOR_TOOL, 1);
+		assert.equal(c.committedOutput, true);
+		assert.equal(c.connectorCallAudit.has("toolu_conn"), true);
+	});
+
 	it("recognizes the child's own result without re-delivering it", () => {
 		const c = ctx();
 		c.resetTurnState(model);

--- a/pi-extensions/pi-claude-bridge/tests/unit-config.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-config.mjs
@@ -28,14 +28,14 @@ function withTempDirs(fn) {
 describe("loadConfig", () => {
 	it("ignores project settings until project trust is recorded", () => withTempDirs(({ user, project }) => {
 		writeFileSync(join(user, "settings.json"), JSON.stringify({
-			vstack: { extensionManager: { config: { "@vanillagreen/pi-claude-bridge": { allowExtraUsage: false } } } },
+			vstack: { extensionManager: { config: { "@vanillagreen/pi-claude-bridge": { fastMode: false } } } },
 		}));
 		writeFileSync(join(project, ".pi", "settings.json"), JSON.stringify({
-			vstack: { extensionManager: { config: { "@vanillagreen/pi-claude-bridge": { allowExtraUsage: true } } } },
+			vstack: { extensionManager: { config: { "@vanillagreen/pi-claude-bridge": { fastMode: true } } } },
 		}));
 
 		const config = loadConfig(project);
-		assert.equal(config.provider?.allowExtraUsage, false);
+		assert.equal(config.provider?.fastMode, false);
 	}));
 
 	it("reads trusted legacy project config from project root when cwd is nested", () => withTempDirs(({ project }) => {
@@ -49,17 +49,17 @@ describe("loadConfig", () => {
 		assert.equal(config.provider?.fastMode, true);
 	}));
 
-	it("maps extension-manager allowExtraUsage into provider config", () => withTempDirs(({ user, project }) => {
+	it("lets trusted project settings override user settings", () => withTempDirs(({ user, project }) => {
 		writeFileSync(join(user, "settings.json"), JSON.stringify({
-			vstack: { extensionManager: { config: { "@vanillagreen/pi-claude-bridge": { allowExtraUsage: false } } } },
+			vstack: { extensionManager: { config: { "@vanillagreen/pi-claude-bridge": { fastMode: false } } } },
 		}));
 		writeFileSync(join(project, ".pi", "settings.json"), JSON.stringify({
-			vstack: { extensionManager: { config: { "@vanillagreen/pi-claude-bridge": { allowExtraUsage: true } } } },
+			vstack: { extensionManager: { config: { "@vanillagreen/pi-claude-bridge": { fastMode: true } } } },
 		}));
 		recordProjectTrust({ cwd: project, isProjectTrusted: () => true });
 
 		const config = loadConfig(project);
-		assert.equal(config.provider?.allowExtraUsage, true);
+		assert.equal(config.provider?.fastMode, true);
 	}));
 
 	it("maps extension-manager effort overrides into provider config", () => withTempDirs(({ user, project }) => {

--- a/pi-extensions/pi-claude-bridge/tests/unit-effort-overrides.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-effort-overrides.mjs
@@ -18,10 +18,13 @@ describe("Claude bridge effort overrides", () => {
 		}), "max");
 	});
 
-	it("accepts claude-bridge/<id> model override keys and wildcard keys", () => {
+	it("accepts canonical and legacy provider-prefixed override keys", () => {
 		assert.equal(resolveConfiguredEffort("claude-opus-4-8", "xhigh", {
-			modelEffortOverrides: { "claude-bridge/claude-opus-4-8": "max" },
+			modelEffortOverrides: { "pi-claude/claude-opus-4-8": "max" },
 		}), "max");
+		assert.equal(resolveConfiguredEffort("claude-opus-4-8", "xhigh", {
+			modelEffortOverrides: { "claude-bridge/claude-opus-4-8": "high" },
+		}), "high");
 		assert.equal(resolveConfiguredEffort("claude-haiku-4-5", "medium", {
 			modelEffortOverrides: { "*": "low" },
 		}), "low");

--- a/pi-extensions/pi-claude-bridge/tests/unit-extra-usage.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-extra-usage.mjs
@@ -1,21 +1,13 @@
-/**
- * Tests for extra-usage detection helpers.
- */
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { formatResetTimestamp, isExtraUsageRequiredMessage, isUsageLimitMessage, uniqueNonEmptyLines } from "../src/index.ts";
 
-describe("isExtraUsageRequiredMessage", () => {
-	it("detects Claude Code extra-usage rate-limit text", () => {
-		assert.equal(isExtraUsageRequiredMessage("Fast mode requires extra usage billing — /extra-usage to enable"), true);
-		assert.equal(isExtraUsageRequiredMessage({ message: "Extra usage is required for 1M context" }), true);
-		assert.equal(isExtraUsageRequiredMessage(new Error("overage not provisioned")), true);
-	});
+import {
+	formatResetTimestamp,
+	isUsageLimitMessage,
+	uniqueNonEmptyLines,
+} from "../src/index.ts";
 
-	it("ignores normal rate-limit text", () => {
-		assert.equal(isExtraUsageRequiredMessage("Claude rate limited; resets at 12:00"), false);
-	});
-
+describe("Claude usage-limit messages", () => {
 	it("deduplicates repeated Claude Code error lines", () => {
 		assert.deepEqual(uniqueNonEmptyLines(["You're out of extra usage", "You're out of extra usage", " other "]), [
 			"You're out of extra usage",
@@ -28,18 +20,11 @@ describe("isExtraUsageRequiredMessage", () => {
 		assert.match(formatted, /2026|May|23|13|1|UTC|GMT|AM|PM/i);
 		assert.equal(formatResetTimestamp("not a date"), "unknown");
 	});
-});
 
-describe("isUsageLimitMessage", () => {
-	it("matches the CLI's own usage-limit copy that the extra-usage regex never did", () => {
-		// The under-match the audit called out: a plain weekly-limit rejection.
+	it("matches the CLI's official plan and Extra Usage limit copy", () => {
 		assert.equal(isUsageLimitMessage("You've hit your weekly limit · resets Thursday 4am"), true);
-		assert.equal(isExtraUsageRequiredMessage("You've hit your weekly limit · resets Thursday 4am"), false);
 		assert.equal(isUsageLimitMessage("You've reached your session limit"), true);
 		assert.equal(isUsageLimitMessage("You're out of usage credits"), true);
-	});
-
-	it("matches extra-usage variants of the official prefixes too", () => {
 		assert.equal(isUsageLimitMessage("You're out of extra usage"), true);
 		assert.equal(isUsageLimitMessage("Your seat type doesn't include extra usage"), true);
 	});
@@ -53,7 +38,7 @@ describe("isUsageLimitMessage", () => {
 		assert.equal(isUsageLimitMessage(resultMessage), true);
 	});
 
-	it("ignores unrelated errors and non-limit rate-limit prose", () => {
+	it("ignores unrelated errors and generic rate-limit prose", () => {
 		assert.equal(isUsageLimitMessage("Claude rate limited; resets at 12:00"), false);
 		assert.equal(isUsageLimitMessage(new Error("ECONNRESET")), false);
 		assert.equal(isUsageLimitMessage(undefined), false);

--- a/pi-extensions/pi-claude-bridge/tests/unit-import.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-import.mjs
@@ -4,7 +4,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { sanitizeToolId, convertPiMessages } from "../src/convert.js";
-import { findUnpairedToolUses } from "../src/tool-pairing-audit.js";
+import { findUnpairedToolUses, recoverLaterToolResults } from "../src/tool-pairing-audit.js";
 
 /** Shorthand: convert pi messages and return just the anthropic messages. */
 function convert(messages, customToolNameToSdk) {
@@ -121,9 +121,9 @@ describe("thinking block filtering", () => {
 		assert.equal(result[0].content[0].type, "text");
 	});
 
-	it("Anthropic provider thinking with signature preserved", () => {
+	it("canonical Pi Claude thinking with signature is preserved", () => {
 		const msgs = [
-			{ role: "assistant", provider: "claude-bridge", content: [
+			{ role: "assistant", provider: "pi-claude", content: [
 				{ type: "thinking", thinking: "reasoning...", thinkingSignature: "sig123" },
 				{ type: "text", text: "answer" },
 			]},
@@ -248,6 +248,62 @@ describe("message structure", () => {
 		assert.equal(result[2].role, "user");
 		assert.equal(result[2].content, "please continue after tools");
 		assert.deepEqual(findUnpairedToolUses(result), []);
+	});
+
+	it("recovers real sibling results when a steer splits one parallel batch across later turns", () => {
+		const msgs = [
+			{ role: "assistant", content: [
+				{ type: "toolCall", id: "t1", name: "SlowTool", arguments: { seconds: 3 } },
+				{ type: "toolCall", id: "t2", name: "SlowTool", arguments: { seconds: 4 } },
+				{ type: "toolCall", id: "t3", name: "SlowTool", arguments: { seconds: 5 } },
+			] },
+			{ role: "toolResult", toolCallId: "t1", content: "first" },
+			{ role: "user", content: "steer" },
+			{ role: "assistant", content: [{ type: "toolCall", id: "t2", name: "SlowTool", arguments: { seconds: 4 } }] },
+			{ role: "toolResult", toolCallId: "t2", content: "second" },
+			{ role: "assistant", content: [{ type: "toolCall", id: "t3", name: "SlowTool", arguments: { seconds: 5 } }] },
+			{ role: "toolResult", toolCallId: "t3", content: "third" },
+		];
+
+		const result = convert(msgs);
+		assert.deepEqual(findUnpairedToolUses(result).map((item) => item.id), ["t2", "t3"]);
+		assert.deepEqual(
+			recoverLaterToolResults(result).map((item) => item.id),
+			["t2", "t3"],
+		);
+		assert.deepEqual(findUnpairedToolUses(result), []);
+		assert.deepEqual(
+			result[1].content.map((block) => block.tool_use_id),
+			["t1", "t2", "t3"],
+		);
+		assert.equal(result[1].content[1].content, "second");
+		assert.equal(result[1].content[2].content, "third");
+	});
+
+	it("prepends recovered tool results before text in the target user message", () => {
+		const messages = [
+			{ role: "assistant", content: [
+				{ type: "tool_use", id: "t1", name: "Read", input: {} },
+				{ type: "tool_use", id: "t2", name: "Read", input: {} },
+			] },
+			{ role: "user", content: [
+				{ type: "tool_result", tool_use_id: "t1", content: "first" },
+				{ type: "text", text: "continue after tools" },
+			] },
+			{ role: "user", content: [
+				{ type: "tool_result", tool_use_id: "t2", content: "second" },
+			] },
+		];
+
+		recoverLaterToolResults(messages);
+		assert.deepEqual(
+			messages[1].content.map((block) => block.type),
+			["tool_result", "tool_result", "text"],
+		);
+		assert.deepEqual(
+			messages[1].content.filter((block) => block.type === "tool_result").map((block) => block.tool_use_id),
+			["t1", "t2"],
+		);
 	});
 
 	it("mixed conversation: user → assistant(tool) → toolResult → assistant(text)", () => {

--- a/pi-extensions/pi-claude-bridge/tests/unit-integrity-reporting.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-integrity-reporting.mjs
@@ -63,13 +63,14 @@ describe("tool-result integrity reporting", () => {
 		assert.equal(sharedSession.forceRotate, undefined);
 	});
 
-	it("abort teardown marks forceRotate and still reports exactly once", () => {
+	it("expected abort teardown marks forceRotate without raising an integrity error", () => {
 		const queryCtx = makeMismatchContext();
-		assert.equal(reportToolResultMismatch(queryCtx, "abort", "/repo", { forceRotate: true }), true);
-		assert.equal(reportToolResultMismatch(queryCtx, "abort", "/repo", { forceRotate: true }), false);
+		const options = { expectedInterruption: true, forceRotate: true };
+		assert.equal(reportToolResultMismatch(queryCtx, "abort", "/repo", options), true);
+		assert.equal(reportToolResultMismatch(queryCtx, "abort", "/repo", options), false);
 
-		assert.equal(readDiagEntries().length, 1);
-		assert.equal(notifications.length, 1);
+		assert.equal(statSync(diagPath, { throwIfNoEntry: false }), undefined);
+		assert.equal(notifications.length, 0);
 		const { sharedSession } = __testGetBridgeIntegrityState();
 		assert.equal(sharedSession.needsRebuild, true);
 		assert.equal(sharedSession.forceRotate, true);

--- a/pi-extensions/pi-claude-bridge/tests/unit-isolation.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-isolation.mjs
@@ -168,7 +168,7 @@ describe("loadConfig isolation", () => {
 		}));
 		withEnv({ PI_CODING_AGENT_DIR: agentDir }, () => {
 			recordProjectTrust({ cwd: project, isProjectTrusted: () => true });
-			// Normal Pi behavior is unchanged: trusted project manager settings win.
+			// Trusted project settings win in normal mode.
 			withEnv({ CLAUDE_BRIDGE_ISOLATED: undefined }, () => {
 				const config = loadConfig(project);
 				assert.equal(config.provider?.fastMode, true);

--- a/pi-extensions/pi-claude-bridge/tests/unit-native-provider.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-native-provider.mjs
@@ -3,7 +3,7 @@
  * replacement for the credential-gated register/unregister state machine.
  * The provider registers unconditionally; these tests pin that its auth
  * check/resolve report configured-ness truthfully (that is what makes pi hide
- * unconfigured claude-bridge models), that credential probes run at CALL time
+ * unconfigured Pi Claude models), that credential probes run at CALL time
  * (login/logout between calls is seen), and that both stream entry points are
  * the Claude Code subprocess router.
  * Uses the real modules — no API calls, no extension activation.
@@ -67,14 +67,30 @@ describe("buildNativeProvider", () => {
 
 	it("builds a provider whose id, models, and stamped fields match the bridge contract", () => {
 		const provider = buildNativeProvider(piAi, MODELS, () => {}, {});
-		assert.equal(provider.id, "claude-bridge");
+		assert.equal(provider.id, "pi-claude");
 		const models = provider.getModels();
 		assert.equal(models.length, 1);
 		assert.equal(models[0].id, "claude-haiku-4-5");
 		// The legacy config path stamped these during composition; the native
 		// path must stamp them itself or downstream provider routing breaks.
-		assert.equal(models[0].provider, "claude-bridge");
+		assert.equal(models[0].provider, "pi-claude");
 		assert.equal(models[0].api, "claude-bridge");
+	});
+
+	it("can build the legacy provider alias without changing the internal bridge API", () => {
+		const provider = buildNativeProvider(
+			piAi,
+			[{ ...MODELS[0], provider: "anthropic" }],
+			() => {},
+			{},
+			() => true,
+			"claude-bridge",
+			"Pi Claude (legacy alias)",
+		);
+		assert.equal(provider.id, "claude-bridge");
+		assert.equal(provider.name, "Pi Claude (legacy alias)");
+		assert.equal(provider.getModels()[0].provider, "claude-bridge");
+		assert.equal(provider.getModels()[0].api, "claude-bridge");
 	});
 
 	it("reports unconfigured when no credential signal exists", { skip: onDarwin }, () => withTempConfigDir(async (dir) => {
@@ -82,6 +98,18 @@ describe("buildNativeProvider", () => {
 		assert.equal(await provider.auth.apiKey.check({ ctx: {} }), undefined);
 		assert.equal(await provider.auth.apiKey.resolve({ ctx: {} }), undefined);
 	}));
+
+	it("accepts a dynamic companion account-pool credential probe", async () => {
+		let available = false;
+		const provider = buildNativeProvider(piAi, MODELS, () => {}, {}, () => available);
+		assert.equal(await provider.auth.apiKey.check({ ctx: {} }), undefined);
+		available = true;
+		assert.deepEqual(
+			await provider.auth.apiKey.check({ ctx: {} }),
+			{ type: "api_key", source: "Claude Code login" },
+		);
+		assert.equal((await provider.auth.apiKey.resolve({ ctx: {} })).auth.apiKey, "not-used");
+	});
 
 	it("reports configured with a source label when credentials exist", () => withTempConfigDir(async (dir) => {
 		writeFileSync(join(dir, ".credentials.json"), "{}");


### PR DESCRIPTION
## Summary

- add an optional versioned `pi-claude` account-router contract without duplicating the bridge engine
- scope Agent SDK environment, Claude sessions/resume IDs, connector inventory, and usage feedback to the selected subscription profile
- retry classified auth/rate/network failures only before visible output or connector side effects; post-output failures are recorded but never replayed
- exhaust ready Fable allowances across managed profiles before selecting Opus
- expose canonical `pi-claude/*` provider IDs while retaining `claude-bridge/*` and slash-command compatibility aliases
- preserve parallel tool results during session rebuilds and publish package version `2.2.0`
- keep the package fully standalone when no companion router is present

This supersedes #971 and is rebuilt as one commit directly on current `main` (`5007aa1e`, including #984 and #991).

## Requested-review fixes from #971

- **Legacy no-router regression:** a rejected `rate_limit_event` no longer creates managed failure state. A real provider-entry regression test now follows that event with streamed fallback success and asserts one warning, one broker event, no appended error, persisted session state, and no stale rebuild flags.
- **Current-main integration:** preserves #984's `isConnectorTool` / `isChildInternalTool` split and #991's #963/#967 follow-up batching, deferred replay, and load-bearing `Case` markers.
- **Replay boundary:** child-internal plumbing such as `ToolSearch` remains retryable; only connector dispatch marks a child-executed call as committed.
- **Reentrancy:** captures the attempt context when constructing `RetryEventBuffer` and also gates rotation on the buffer's own committed state.
- **Default profile path:** managed routes without `configDir` explicitly use `$HOME/.claude` for bridge-side session/connector I/O while the child unsets inherited `CLAUDE_CONFIG_DIR`.
- **Successful completion:** replaces stale session state so mid-turn `needsRebuild` / `forceRotate` flags do not survive success.
- **Tool-result order:** recovered parallel results are inserted before text blocks.
- **Classification:** narrows generic `quota` and `5xx` matching to avoid examples such as `disk quota exceeded` and `processed 500 files`.
- **Session privacy:** Pi markers persist only opaque profile ID + effective model; the config path is re-resolved through the router. Old path-bearing markers remain a one-time migration fallback.
- **Legacy result behavior:** unrelated no-router non-success results keep main's existing silent behavior.

## Maintainer-visible product choices

Two choices called out in the prior review remain intentional and are now explicit in README/CHANGELOG:

1. Extra Usage policy stays in Claude account settings; the bridge-side helper/setting is removed.
2. `pi-claude/*` is canonical while `claude-bridge/*` remains registered as a saved-session compatibility alias (so both currently appear in the model picker).

## Verification

- `npm ci`
- `npm run typecheck`
- `npm run test:unit` — **426 passed, 2 skipped**
- `npm run build` twice — byte-identical bundles
- `npm audit --omit=dev` — **0 vulnerabilities**
- `npm pack --dry-run --json` — no `.env.test` or test-output artifacts
- `tests/int-smoke.sh` — **3/3 passed**
- `tests/int-multi-turn.sh` — **5/5 passed**
- `tests/int-cache.sh` — **98% aggregate cache hit, 1 clean start, 4 reuses, 0 rebuilds**
- remaining live integration files — **15/16 passed** (fork, compact, new-session, session rebuild, and all 7 tool-message cases); `int-session-resume.mjs` could not start its non-bridge control turn because this machine's configured `openai-codex` alternate provider is logged out (`No API key found for openai-codex`), before Pi Claude is invoked
- `pi --list-models` — 8 canonical `pi-claude` and 8 legacy `claude-bridge` entries
