### PR TITLE
fix(orch): validate the dev-return commit against the worktree's git repo

### DIFF
--- a/skills/orch/schemas/dev-return.md
+++ b/skills/orch/schemas/dev-return.md
@@ -168,14 +168,22 @@ skip the artifact to stay honest — `analysis` is the honest spelling.
 Orch validates the artifact deterministically with
 `.agents/skills/orch/scripts/dev-artifact-check` (round mode:
 `--worktree WT --issue ISSUE --round-id RID [--expect-items N,N,...]`). It prints
-`{ok, path, reason}`; the gates are ordered and the first failure wins:
+`{ok, path, reason, warning}`; the gates are ordered and the first failure wins:
 
 | Order | reason | Meaning |
 |-------|--------|---------|
 | 1 | `missing` | No artifact at the resolved round-scoped path |
 | 2 | `invalid` | Internal `round_id` != expected, OR not parseable JSON, OR a required field wrong-typed/empty: `kind` ∈ implement\|fix\|analysis; `issue`/`branch` non-empty **strings**; `round_id` non-empty string; `schema_version` a number. implement/fix additionally require `commit`/`validate` non-empty strings; **analysis requires the inverse** — no `commit`, `validate`, or `validate_note` key present at all |
-| 3 | `incomplete` | `items[]` fails the applicable rule (below), or an `analysis` artifact's `summary` is not a non-empty string |
+| 3 | `commit_unresolvable` | The artifact's `commit` names no object in the worktree's git repo (vstack#994) — e.g. a hand-reconstructed SHA with a fabricated tail. Round mode only; skipped when the worktree is not a git repo, and always in `--file` mode (no repo to check against) |
+| 4 | `incomplete` | `items[]` fails the applicable rule (below), or an `analysis` artifact's `summary` is not a non-empty string |
 | — | `valid` | All gates pass |
+
+**`warning: "commit_unreachable"` (non-fatal, vstack#994):** the `commit`
+resolves as a commit object but is not an ancestor of the current `HEAD` — the
+signature of a receipt orphaned by a later rebase. `ok` stays `true` and
+`reason` stays `valid`: a legitimate rebase orphans the SHAs of every
+previously accepted round, so this is a signal for the orchestrator to weigh,
+not a failure. `warning` is `null` in every other case.
 
 **Items rule:**
 - With `--expect-items N,N,...` (fix rounds — the orchestrator passes the delegated
@@ -194,7 +202,8 @@ Orch validates the artifact deterministically with
 The mtime/freshness gate is gone — identity is by round id (see above), so there
 is no `stale` reason. A fresh **valid** artifact for the current round lets orch
 accept a completion whose live return message was lost, without re-delegation. The
-artifact proves the agent finished its tail; git/tracker corroboration and
+artifact proves the agent finished its tail, and (vstack#994) that its `commit`
+names a real object in the worktree's repo; tracker corroboration and
 exact-commit binding (`.commit == git rev-parse HEAD`) stay in the orch acceptance
 decision table (`dev-start.md` § 3 / `dev-fix.md`). An `analysis` artifact has no
 `commit`, so its round has no exact-commit binding and no validate gate — the

--- a/skills/orch/scripts/dev-artifact-check
+++ b/skills/orch/scripts/dev-artifact-check
@@ -31,9 +31,16 @@
 # recommendation/evidence is the round's deliverable → else incomplete).
 #
 # The scalars prove the agent finished its tail; the items gates prove a fix or
-# bundled artifact carries its per-item results. Git/tracker corroboration (and
-# exact-commit binding) stay in the orch workflow; this script never runs git or
-# tracker checks.
+# bundled artifact carries its per-item results. In round mode, when the
+# worktree is a git repo and the artifact carries a .commit, the recorded SHA is
+# additionally checked against that repo (vstack#994): a SHA that names no
+# object fails with reason=commit_unresolvable (a hand-fabricated SHA — same
+# short prefix as HEAD, invented tail — passes every schema gate yet proves
+# nothing), and a commit that resolves but is not an ancestor of HEAD is
+# surfaced as the NON-FATAL warning=commit_unreachable (a legitimate rebase
+# orphans the SHAs of previously accepted rounds, so this is a signal for the
+# orchestrator, not a failure). Exact-commit binding (.commit == the observed
+# HEAD) and tracker corroboration stay in the orch workflow.
 
 set -euo pipefail
 
@@ -50,7 +57,8 @@ Usage:
   dev-artifact-check --file <json_path> [--round-id RID] [--expect-items N,N,...]
 
 Round mode (the production path): resolves WT/tmp/dev-return-ISSUE-RID.json,
-requires it exists, its internal .round_id == RID, then the scalar/kind/items gates.
+requires it exists, its internal .round_id == RID, then the scalar/kind, commit
+object (against WT's git repo, vstack#994), and items gates.
 File mode: validates one explicit JSON file (round_id checked only when --round-id
 is supplied). It is a test/parity affordance — round-trip checks and known-path
 artifacts — with no production caller; the orch workflows always use round mode.
@@ -63,10 +71,11 @@ decision ∈ {Applied,Skipped,Blocked}, every reasoning non-empty. Without it, a
 fix/bundled artifact only needs a non-empty, well-formed items[].
 
 Prints JSON: {ok: bool, path: string|null,
-              reason: "valid"|"missing"|"invalid"|"incomplete"}
+              reason: "valid"|"missing"|"invalid"|"commit_unresolvable"|"incomplete",
+              warning: "commit_unreachable"|null}
 
 Gates ordered: missing → (round_id mismatch → invalid) → scalars → invalid →
-items → incomplete → valid.
+commit object → commit_unresolvable → items → incomplete → valid.
 
 reason meanings when ok=false:
   missing     artifact file does not exist at the resolved path
@@ -78,11 +87,21 @@ reason meanings when ok=false:
               .validate, or .validate_note key present at all (an analysis round
               produces no commit and runs no validation, so their presence is a
               fabricated claim — vstack#952)
+  commit_unresolvable
+              the artifact's .commit names no object in the worktree's repo
+              (vstack#994) — e.g. a hand-reconstructed SHA with a fabricated
+              tail. Round mode only, and only when the worktree is a git repo;
+              --file mode has no repo to check against and skips this gate.
   incomplete  items[] fails the applicable rule — exact-set (with --expect-items)
               or non-empty-well-formed (kind fix OR bundled==true). kind implement
               without bundled keeps allowing items: []. kind analysis is
               incomplete when .summary is not a non-empty string (the
               recommendation is the round's deliverable).
+
+warning=commit_unreachable (NON-FATAL, ok stays true): the .commit resolves as a
+commit object but is not an ancestor of the current HEAD — the signature of a
+receipt orphaned by a later rebase (vstack#994). Expected after a legitimate
+rebase; the orchestrator decides what it means for the round.
 
 Exit 0 when a valid artifact was found, 1 otherwise, 2 on usage error.
 EOF
@@ -113,14 +132,15 @@ check_id_token() {
 # one that was never recorded (vstack#884). Both are null when the artifact is
 # missing or unparseable.
 emit() {
-  local ok="$1" path="$2" reason="$3" validate=null validate_note=null
+  local ok="$1" path="$2" reason="$3" warning="${4:-}" validate=null validate_note=null
   if [[ -n "$path" && -f "$path" ]]; then
     validate="$(jq -c 'if (.validate? | type) == "string" then .validate else null end' "$path" 2>/dev/null || printf 'null')"
     validate_note="$(jq -c 'if (.validate_note? | type) == "string" then .validate_note else null end' "$path" 2>/dev/null || printf 'null')"
   fi
-  jq -n --argjson ok "$ok" --arg path "$path" --arg reason "$reason" \
+  jq -n --argjson ok "$ok" --arg path "$path" --arg reason "$reason" --arg warning "$warning" \
     --argjson validate "${validate:-null}" --argjson validate_note "${validate_note:-null}" \
     '{ok: $ok, path: (if $path == "" then null else $path end), reason: $reason,
+      warning: (if $warning == "" then null else $warning end),
       validate: $validate, validate_note: $validate_note}'
 }
 
@@ -209,12 +229,15 @@ analysis_incomplete() {
 }
 
 # Shared gate: existence → (round_id match, when expected) → required scalars
-# (invalid) → items/summary (incomplete) → valid. Emits {ok, path, reason},
-# returns 0 iff valid. want_round "" skips the round_id match (--file mode
-# without --round-id). expect_items "" uses the fix/bundled fallback instead of
-# the exact-set rule.
+# (invalid) → commit object (commit_unresolvable, vstack#994) → items/summary
+# (incomplete) → valid. Emits {ok, path, reason, warning}, returns 0 iff valid.
+# want_round "" skips the round_id match (--file mode without --round-id).
+# expect_items "" uses the fix/bundled fallback instead of the exact-set rule.
+# repo "" skips the commit checks (--file mode); so does a worktree that is not
+# a git repo — production worktrees always are, and a check that cannot run
+# proves nothing either way.
 validate_artifact() {
-  local file="$1" want_round="$2" expect_items="$3"
+  local file="$1" want_round="$2" expect_items="$3" repo="${4:-}" warning=""
   if [[ ! -f "$file" ]]; then
     emit false "" "missing"
     return 1
@@ -226,6 +249,26 @@ validate_artifact() {
   if ! has_required_fields "$file"; then
     emit false "$file" "invalid"
     return 1
+  fi
+  # vstack#994: a .commit that passed the scalar gate must name a real commit
+  # object in the worktree's repo — a fabricated SHA (same short prefix as HEAD,
+  # invented tail) reads as evidence while proving nothing. Resolvable but not
+  # an ancestor of HEAD is the orphaned-by-rebase signature: non-fatal warning,
+  # because a legitimate rebase produces it on every previously accepted round.
+  local commit=""
+  if [[ -n "$repo" ]] && git -C "$repo" rev-parse --git-dir >/dev/null 2>&1; then
+    commit="$(jq -r 'if (.commit? | type) == "string" then .commit else "" end' "$file" 2>/dev/null || true)"
+  fi
+  if [[ -n "$commit" ]]; then
+    if [[ "$(git -C "$repo" cat-file -t "$commit" 2>/dev/null)" != "commit" ]]; then
+      printf '%s: artifact commit %s: no such object in the repo at %s\n' "$PROG" "$commit" "$repo" >&2
+      emit false "$file" "commit_unresolvable"
+      return 1
+    fi
+    if ! git -C "$repo" merge-base --is-ancestor "$commit" HEAD >/dev/null 2>&1; then
+      warning="commit_unreachable"
+      printf '%s: artifact commit %s resolves but is not an ancestor of HEAD in %s (orphaned by a rebase?)\n' "$PROG" "$commit" "$repo" >&2
+    fi
   fi
   if [[ -n "$expect_items" ]]; then
     if ! items_exact_ok "$file" "$expect_items"; then
@@ -240,7 +283,7 @@ validate_artifact() {
     emit false "$file" "incomplete"
     return 1
   fi
-  emit true "$file" "valid"
+  emit true "$file" "valid" "$warning"
   return 0
 }
 
@@ -255,6 +298,7 @@ fi
 file=""
 want_round=""
 expect_items=""
+repo=""
 
 if [[ "${1:-}" == "--file" ]]; then
   shift
@@ -286,6 +330,7 @@ elif [[ "${1:-}" == --* ]]; then
   check_id_token --issue "$issue"
   check_id_token --round-id "$round_id"
   want_round="$round_id"
+  repo="$worktree"
   file="$worktree/tmp/dev-return-$issue-$round_id.json"
 else
   # Neither --file nor round mode → usage error. One identity model (round id);
@@ -298,4 +343,4 @@ fi
 if [[ -n "$expect_items" && ! "$expect_items" =~ $EXPECT_GRAMMAR ]]; then
   die "--expect-items must be comma-separated item numbers, got '$expect_items'"
 fi
-if validate_artifact "$file" "$want_round" "$expect_items"; then exit 0; else exit 1; fi
+if validate_artifact "$file" "$want_round" "$expect_items" "$repo"; then exit 0; else exit 1; fi

--- a/skills/orch/tests/dev_artifact_check.sh
+++ b/skills/orch/tests/dev_artifact_check.sh
@@ -266,6 +266,81 @@ printf 'Recommend: re-scope; seam moved in refactor.\n' > "$rt_wt/analysis.md"
 "$WRITE" --worktree "$rt_wt" --kind analysis --issue issue-9 --round-id 9-10 --branch b --summary-file "$rt_wt/analysis.md" --no-summary >/dev/null
 assert_eq "$(reason --worktree "$rt_wt" --issue issue-9 --round-id 9-10)" "valid" "writer analysis output round-trips as valid (vstack#952)"
 
+# --- vstack#994: the recorded commit must name a real object in the worktree's repo ---
+# Case 1 (hyprtrade CC-1006): a dev agent hand-reconstructed a full SHA from the
+# short form — same 8-char prefix as HEAD, fabricated tail — and the receipt
+# passed every schema gate while naming no object. That must now fail with the
+# distinct fatal reason commit_unresolvable. Case 2: a commit orphaned by a
+# later rebase still resolves as an object but is no ancestor of HEAD; per the
+# issue that is a distinct NON-FATAL signal (warning=commit_unreachable, ok
+# stays true) because a legitimate rebase produces it. All the non-git-repo
+# worktrees above (plain mktemp dirs) skip these gates entirely.
+gitwt="$TMP_ROOT/gitwt"
+mkdir -p "$gitwt/tmp"
+git -C "$gitwt" init -q -b main
+git -C "$gitwt" config user.email test@example.com
+git -C "$gitwt" config user.name Test
+git -C "$gitwt" config commit.gpgsign false
+git -C "$gitwt" commit -q --allow-empty -m base
+git -C "$gitwt" commit -q --allow-empty -m orphan-me
+orphan_sha="$(git -C "$gitwt" rev-parse HEAD)"
+git -C "$gitwt" reset -q --hard HEAD~1   # orphan_sha still resolves, now unreachable
+head_sha="$(git -C "$gitwt" rev-parse HEAD)"
+fake_sha="${head_sha:0:8}00000000000000000000000000000000"
+gartifact="$gitwt/tmp/dev-return-$issue-$R.json"
+
+# valid, reachable commit (HEAD) → valid with no warning
+printf '%s' "$valid_impl" | jq -c --arg c "$head_sha" '.commit=$c' > "$gartifact"
+out="$("$CHECK" --worktree "$gitwt" --issue "$issue" --round-id "$R")"
+rc=$?
+assert_eq "$rc" "0" "reachable HEAD commit exits 0"
+assert_eq "$(jq -r '.reason' <<<"$out")" "valid" "reachable HEAD commit reports reason=valid"
+assert_eq "$(jq -r '.warning' <<<"$out")" "null" "reachable HEAD commit reports warning=null"
+
+# fabricated SHA (real prefix, invented tail) → ok=false, commit_unresolvable, exit 1
+printf '%s' "$valid_impl" | jq -c --arg c "$fake_sha" '.commit=$c' > "$gartifact"
+set +e
+out="$("$CHECK" --worktree "$gitwt" --issue "$issue" --round-id "$R" 2>/dev/null)"
+rc=$?
+err="$("$CHECK" --worktree "$gitwt" --issue "$issue" --round-id "$R" 2>&1 >/dev/null)"
+set -e
+assert_eq "$rc" "1" "fabricated commit SHA exits 1"
+assert_eq "$(jq -r '.ok' <<<"$out")" "false" "fabricated commit SHA reports ok=false"
+assert_eq "$(jq -r '.reason' <<<"$out")" "commit_unresolvable" "fabricated commit SHA reports reason=commit_unresolvable"
+assert_eq "$(grep -F "$fake_sha" <<<"$err" | grep -cF 'no such object')" "1" "commit_unresolvable stderr names the sha and 'no such object'"
+
+# orphaned-but-real commit → NON-FATAL: ok=true, reason=valid, warning=commit_unreachable
+printf '%s' "$valid_impl" | jq -c --arg c "$orphan_sha" '.commit=$c' > "$gartifact"
+out="$("$CHECK" --worktree "$gitwt" --issue "$issue" --round-id "$R" 2>/dev/null)"
+rc=$?
+assert_eq "$rc" "0" "orphaned-but-real commit still exits 0 (non-fatal per vstack#994)"
+assert_eq "$(jq -r '.ok' <<<"$out")" "true" "orphaned commit reports ok=true"
+assert_eq "$(jq -r '.reason' <<<"$out")" "valid" "orphaned commit reports reason=valid"
+assert_eq "$(jq -r '.warning' <<<"$out")" "commit_unreachable" "orphaned commit reports warning=commit_unreachable"
+
+# analysis artifact (no commit key) in a git worktree → unaffected by the commit gates
+printf '%s' "$valid_analysis" > "$gartifact"
+out="$("$CHECK" --worktree "$gitwt" --issue "$issue" --round-id "$R")"
+assert_eq "$(jq -r '.reason' <<<"$out")" "valid" "commit-less analysis artifact in a git worktree stays valid"
+assert_eq "$(jq -r '.warning' <<<"$out")" "null" "commit-less analysis artifact reports warning=null"
+
+# gate ordering: scalar invalid beats the commit gates; commit_unresolvable beats incomplete
+printf '%s' "$valid_impl" | jq -c 'del(.commit)' > "$gartifact"
+assert_eq "$(reason --worktree "$gitwt" --issue "$issue" --round-id "$R")" "invalid" "missing .commit in a git worktree stays reason=invalid (scalar gate first)"
+printf '%s' "$valid_fix" | jq -c --arg c "$fake_sha" '.commit=$c | .items=[]' > "$gartifact"
+assert_eq "$(reason --worktree "$gitwt" --issue "$issue" --round-id "$R")" "commit_unresolvable" "commit_unresolvable beats incomplete (fake sha + empty items)"
+
+# non-repo worktree keeps today's behavior: commit gates skipped, still valid
+printf '%s' "$valid_impl" > "$artifact"
+out="$("$CHECK" --worktree "$worktree" --issue "$issue" --round-id "$R")"
+assert_eq "$(jq -r '.reason' <<<"$out")" "valid" "non-git worktree skips the commit gates (reason=valid)"
+assert_eq "$(jq -r '.warning' <<<"$out")" "null" "non-git worktree reports warning=null"
+
+# --file mode has no repo to check against → fabricated sha still validates
+gext="$TMP_ROOT/dev-return-994.json"
+printf '%s' "$valid_impl" | jq -c --arg c "$fake_sha" '.commit=$c' > "$gext"
+assert_eq "$(reason --file "$gext")" "valid" "--file mode skips the commit gates (no repo)"
+
 # --- doc wiring: ALL FOUR dev/QA paths mint a fresh round id + accept via round mode ---
 # dev-start / orch dev-fix / review-pr-comments / ci-fix each mint dev_round_id
 # before delegating and accept via dev-artifact-check round mode — one identity


### PR DESCRIPTION
Closes #994. `dev-artifact-check` validated schema and round-id but never checked that the recorded `.commit` names a real git object — a hand-fabricated SHA (same short prefix as HEAD, invented tail) passed with `{"ok": true}` (hyprtrade CC-1006, case 1), and a receipt orphaned by a later rebase looked identical to a good one (case 2).

Round mode now checks the artifact's `.commit` against the worktree's repo: a SHA naming no object fails with the new fatal reason `commit_unresolvable`; a commit that resolves but isn't an ancestor of HEAD is surfaced as the NON-FATAL `warning: commit_unreachable` (a legitimate rebase orphans previously accepted rounds' SHAs — signal for the orchestrator, not a failure). `--file` mode has no repo and skips the gate. Exact-commit binding stays in the orch workflow, as documented. Schema doc updated; JSON output gains the `warning` field.

Tests: fabricated-SHA fails, orphaned-commit warns with ok=true, valid passes, no-commit-field unchanged, file-mode skip — dev_artifact_check.sh 149/0; full orch suite green (32 files).

https://claude.ai/code/session_01Wbt7N7TTxEDPNxKFAC5jWC