### PR TITLE
test(pi-claude-bridge): port account-persistence and rotation-guard coverage from PR #992

### DIFF
--- a/pi-extensions/pi-claude-bridge/tests/unit-account-rotation-stream.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-account-rotation-stream.mjs
@@ -462,6 +462,37 @@ describe("managed account stream rotation", () => {
 		assert.equal(events.filter((event) => event.type === "error").length, 1);
 	});
 
+	it("uses the attempt buffer as a replay guard if context commit state is disturbed", async () => {
+		const observed = observedState();
+		globalThis[CLAUDE_ACCOUNT_ROUTER_SYMBOL] = makeRouter(observed);
+		let calls = 0;
+		__testSetSdkQueryFactory(() => {
+			calls += 1;
+			return {
+				async *[Symbol.asyncIterator]() {
+					yield { type: "system", subtype: "init", session_id: "buffer-guard-session" };
+					for (const message of STREAMED_TEXT("committed-by-buffer")) yield message;
+					// Model the reentrancy race: a different live context received the
+					// commit stamp, leaving this attempt context falsely replayable.
+					// The buffer's own committed flag must still block the replay.
+					ctx().committedOutput = false;
+					throw new Error("socket timeout after buffered output");
+				},
+				close() {},
+				async interrupt() {},
+				async accountInfo() { return {}; },
+				async usage_EXPERIMENTAL_MAY_CHANGE_DO_NOT_RELY_ON_THIS_API_YET() { return {}; },
+			};
+		});
+
+		const events = await collect(streamClaudeAgentSdk(model, context, { sessionId: "buffer-replay-guard" }));
+		assert.equal(calls, 1);
+		assert.equal(observed.acquires.length, 1);
+		assert.deepEqual(observed.failures, [{ profileId: "a", kind: "network" }]);
+		assert.ok(textEvents(events).includes("committed-by-buffer"));
+		assert.equal(events.filter((event) => event.type === "error").length, 1);
+	});
+
 	it("records a post-output transport failure without replaying the request", async () => {
 		const observed = observedState();
 		globalThis[CLAUDE_ACCOUNT_ROUTER_SYMBOL] = makeRouter(observed);
@@ -652,6 +683,47 @@ describe("managed account stream rotation", () => {
 		assert.equal(calls, 1);
 		assert.equal(observed.acquires.length, 1);
 		assert.equal(events.filter((event) => event.type === "error").length, 1);
+	});
+
+	it("clears mid-turn rebuild flags after a successful managed completion", async () => {
+		// A transient needsRebuild/forceRotate set mid-turn must not survive a
+		// completed managed query: success persists a fresh record on purpose.
+		const observed = observedState();
+		globalThis[CLAUDE_ACCOUNT_ROUTER_SYMBOL] = makeRouter(observed);
+		__testSetBridgeIntegrityState({
+			sharedSession: {
+				sessionId: "existing-session",
+				cursor: 0,
+				cwd: process.cwd(),
+				accountProfileId: "a",
+				claudeConfigDir: "/profiles/a",
+			},
+		});
+		__testSetSdkQueryFactory(() => ({
+			async *[Symbol.asyncIterator]() {
+				yield { type: "system", subtype: "init", session_id: "successful-session" };
+				const state = __testGetBridgeIntegrityState().sharedSession;
+				if (state) {
+					__testSetBridgeIntegrityState({
+						sharedSession: { ...state, needsRebuild: true, forceRotate: true },
+					});
+				}
+				yield { type: "result", subtype: "success", result: "success-clears-flags" };
+			},
+			close() {},
+			async interrupt() {},
+			async accountInfo() { return { email: "a@example.com", subscriptionType: "max" }; },
+			async usage_EXPERIMENTAL_MAY_CHANGE_DO_NOT_RELY_ON_THIS_API_YET() { return {}; },
+		}));
+
+		const events = await collect(streamClaudeAgentSdk(model, context, { sessionId: "clear-flags" }));
+		assert.ok(textEvents(events).includes("success-clears-flags"));
+		const state = __testGetBridgeIntegrityState().sharedSession;
+		assert.equal(state?.sessionId, "successful-session");
+		assert.equal(state?.accountProfileId, "a");
+		assert.equal(state?.claudeConfigDir, "/profiles/a");
+		assert.equal(state?.needsRebuild, undefined);
+		assert.equal(state?.forceRotate, undefined);
 	});
 });
 

--- a/pi-extensions/pi-claude-bridge/tests/unit-account-session-persistence.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-account-session-persistence.mjs
@@ -1,0 +1,134 @@
+/**
+ * Account-scoped session persistence: the persisted bridge-session marker must
+ * carry ONLY the opaque accountProfileId — config-dir paths are
+ * account-identifying and travel with shared session archives, so the resolved
+ * claudeConfigDir stays in memory and is re-derived through the router's
+ * resolveProfile on restore (see PersistedBridgeSessionState in
+ * session-persistence.ts).
+ */
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { after, afterEach, beforeEach, describe, it } from "node:test";
+import { createSession } from "cc-session-io";
+
+import { CLAUDE_ACCOUNT_ROUTER_SYMBOL } from "../src/account-router.ts";
+import {
+	__testGetBridgeIntegrityState,
+	__testSetBridgeIntegrityState,
+	setExtensionApi,
+} from "../src/bridge-state.ts";
+import {
+	cancelScheduledSessionPersistence,
+	restoreSharedSessionFromPi,
+	schedulePersistSharedSession,
+} from "../src/session-persistence.ts";
+
+const root = mkdtempSync(join(tmpdir(), "claude-account-persistence-"));
+const cwd = join(root, "project");
+const profileDir = join(root, "profile-a");
+
+function fingerprint(messages) {
+	return createHash("sha256").update(JSON.stringify(messages)).digest("hex");
+}
+
+beforeEach(() => {
+	mkdirSync(cwd, { recursive: true });
+	mkdirSync(profileDir, { recursive: true });
+	cancelScheduledSessionPersistence();
+	setExtensionApi(undefined);
+	__testSetBridgeIntegrityState({ sharedSession: null, ui: null });
+	delete globalThis[CLAUDE_ACCOUNT_ROUTER_SYMBOL];
+});
+
+afterEach(() => {
+	cancelScheduledSessionPersistence();
+	setExtensionApi(undefined);
+	__testSetBridgeIntegrityState({ sharedSession: null, ui: null });
+	delete globalThis[CLAUDE_ACCOUNT_ROUTER_SYMBOL];
+});
+
+after(() => rmSync(root, { recursive: true, force: true }));
+
+describe("account-scoped session persistence", () => {
+	it("persists only the opaque profile id, never the identifying config dir", async () => {
+		const entries = [];
+		setExtensionApi({ appendEntry(type, data) { entries.push({ type, data }); } });
+		__testSetBridgeIntegrityState({
+			sharedSession: {
+				sessionId: "child-session",
+				cursor: 1,
+				cwd,
+				accountProfileId: "profile-a",
+				claudeConfigDir: profileDir,
+			},
+		});
+		const messages = [{ role: "user", content: "hello", timestamp: 1 }];
+		schedulePersistSharedSession({
+			sessionManager: {
+				buildSessionContext: () => ({ messages }),
+				getSessionId: () => "pi-session",
+			},
+		});
+		await new Promise((resolve) => setTimeout(resolve, 10));
+
+		assert.equal(entries.length, 1);
+		assert.equal(entries[0].type, "claude-bridge-session");
+		assert.equal(entries[0].data.sessionId, "child-session");
+		assert.equal(entries[0].data.accountProfileId, "profile-a");
+		assert.equal(entries[0].data.piSessionId, "pi-session");
+		assert.equal(entries[0].data.fingerprint, fingerprint(messages));
+		// The privacy invariant this file exists for: nothing but the type
+		// system otherwise stops the resolved config-dir path from being written.
+		assert.equal("claudeConfigDir" in entries[0].data, false);
+	});
+
+	it("re-resolves an opaque persisted profile through the account router", () => {
+		const messages = [{ role: "user", content: "hello", timestamp: 1 }];
+		const child = createSession({ projectPath: cwd, claudeDir: profileDir });
+		child.addUserMessage("hello");
+		child.save();
+		const resolved = [];
+		globalThis[CLAUDE_ACCOUNT_ROUTER_SYMBOL] = {
+			version: 1,
+			resolveProfile(profileId) {
+				resolved.push(profileId);
+				return { profileId: "profile-a", configDir: profileDir };
+			},
+		};
+		const marker = {
+			type: "custom",
+			customType: "claude-bridge-session",
+			data: {
+				sessionId: child.sessionId,
+				cursor: 1,
+				cwd,
+				accountProfileId: "profile-a",
+				fingerprint: fingerprint(messages),
+				piSessionId: "pi-session",
+				updatedAt: new Date().toISOString(),
+			},
+		};
+
+		restoreSharedSessionFromPi({
+			cwd,
+			sessionManager: {
+				getEntries: () => [marker],
+				getSessionId: () => "pi-session",
+				getCwd: () => cwd,
+				buildSessionContext: () => ({ messages }),
+			},
+		});
+
+		assert.deepEqual(resolved, ["profile-a"]);
+		assert.deepEqual(__testGetBridgeIntegrityState().sharedSession, {
+			sessionId: child.sessionId,
+			cursor: 1,
+			cwd,
+			accountProfileId: "profile-a",
+			claudeConfigDir: profileDir,
+		});
+	});
+});


### PR DESCRIPTION
Ports the test coverage that the comparative review of #992 identified as a genuine gap in main's suite — the only part of that PR not already superseded by the shipped 3.x line. Test-only, no src changes, with Co-authored-by credit to @dgk-dev.

- **unit-account-session-persistence.mjs** (new): pins the persistence privacy invariant — a managed session's persisted marker carries only the opaque profile id and never the account-identifying `claudeConfigDir` (previously enforced by nothing but the type system) — and that restore re-resolves the opaque id through the router's `resolveProfile` and rebuilds the full scope.
- **unit-account-rotation-stream.mjs**: the attempt-buffer double guard (a disturbed `committedOutput` flag still can't cause a replay once the buffer committed — defense-in-depth for the reentrancy race class), and managed-scope rebuild-flag clearing after success (previously asserted only in the legacy describe).

Assertions adapted to main's contracts (no `modelId` in SessionState; `resolveProfile` restore; main's stream helpers) — details in the commit. Unit suite 460/460 at branch time.

https://claude.ai/code/session_01Wbt7N7TTxEDPNxKFAC5jWC