### PR TITLE
feat(review-gate): shared org review-gate engine skill

### DIFF
--- a/skills/review-gate/README.md
+++ b/skills/review-gate/README.md
@@ -1,0 +1,29 @@
+# review-gate
+
+Org-wide PR review-gate engine. One vendored predicate script is the single
+source of truth for "is this PR head reviewed?"; a commit status posted from
+its verdict blocks merge without false reds; convergence scripts and two
+scaffold workflows keep the status current as review state changes; an
+offline decision-table selftest is the engine's portable proof, run ungated
+in every consumer's CI.
+
+- `SKILL.md` — status model, evidence sources, trust model, settings keys.
+- `scripts/review-predicate.sh` — the predicate (verdict on stdout, exit 2 =
+  no verdict, take no action).
+- `scripts/approval-refire.sh` — status convergence + rerun-in-place for one
+  PR head.
+- `scripts/review-predicate-selftest.sh` — offline selftest; also generates
+  approve/near-miss cases from the invoking repo's own `REVIEW_GATE_*`
+  settings.
+- `scripts/lib/settings.sh` — env > `vstack.settings.toml` > default
+  resolution shared by the scripts.
+- `templates/` — `approval-rerun.yml` / `approval-sweep.yml` one-time
+  adoption scaffolds (repo-owned after copy).
+- `references/adoption.md` — CI wiring (both trust postures), branch
+  protection, merge-queue notes, per-repo settings, per-consumer adoption
+  shapes.
+- `vstack.settings.toml.example` — commented per-repo defaults merged into a
+  project's `vstack.settings.toml` on install/refresh.
+
+Per-repo trust lives in `vstack.settings.toml` (`REVIEW_GATE_*` keys) —
+nothing repo-specific is hard-coded in the engine.

--- a/skills/review-gate/SKILL.md
+++ b/skills/review-gate/SKILL.md
@@ -59,8 +59,9 @@ Evidence for the CURRENT head is any of:
    NOT-EVIDENCE, never a failure — it is silence, and silence is what the
    `awaiting` path already handles.
 3. **Comment-form clean pass** (`REVIEW_GATE_COMMENT_REVIEWERS`): an issue
-   comment by a trusted bot login whose body binds the evidence to this
-   head's sha (full sha or backtick short form, floor
+   comment by a trusted bot login — never the PR author, even if configured
+   — whose body binds the evidence to this head's sha (full sha or a short
+   prefix, bare or backtick-quoted; floor
    `REVIEW_GATE_SHA_PREFIX_FLOOR`).
 4. **Reviewer-outage attestation** (`REVIEW_GATE_OUTAGE_CONTEXT`): a trusted
    orchestrator's status posted only on genuine total reviewer silence.

--- a/skills/review-gate/SKILL.md
+++ b/skills/review-gate/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: review-gate
+description: "Org-wide PR review-gate engine: a commit-status merge gate driven by a single review-evidence predicate (review objects, trusted clean-analysis checks, comment-form clean passes, outage attestation), convergence scripts, an offline decision-table selftest, and one-time CI workflow scaffolds. Load when wiring, adopting, tuning, or debugging a repo's review gate or its REVIEW_GATE_* settings."
+license: MIT
+user-invocable: true
+metadata:
+  author: vanillagreen
+  source: vstack
+  repository: "https://github.com/vanillagreencom/vstack"
+  bugs: "https://github.com/vanillagreencom/vstack/issues"
+  version: "1.0.0"
+---
+
+# Review Gate
+
+> **Problem with this skill?** Run `vstack report` — it files to the owning repo automatically. Do not hand-file.
+
+A shared merge gate for repos whose reviews come from bots and humans that
+signal in different ways. One predicate script is the single source of truth
+for "is this PR head reviewed?"; a commit status posted from its verdict
+blocks merge; convergence scripts and workflows keep that status current as
+review state changes. Consumers vendor `scripts/` via `vstack refresh` and
+configure trust per repo in `vstack.settings.toml` — nothing repo-specific is
+hard-coded in the engine.
+
+## Status model
+
+The gate posts one commit status (context: `REVIEW_GATE_CONTEXT`, default
+`Review gate`) on the PR head. It is a required context, so `pending` blocks
+merge without painting the PR red.
+
+| Verdict | Status | Meaning |
+|---|---|---|
+| `awaiting` | `pending` | No review evidence for this head yet. |
+| `threads-open` | `pending` | Evidence exists but review threads are unresolved. |
+| `changes-requested` | `failure` | A reviewer objects to the current head. Red means a human/bot objection (or a genuinely broken build) — nothing else. |
+| `approved` | `success` | Only from a run attempt whose gate evaluated open (the attempt that actually executes the heavy jobs), or the refire's prior-success fast path. |
+| (exit 2, no verdict) | `pending` | An evidence read failed or config is invalid; take no action, retry later. |
+
+Zero-bypass compatible: while the gate is closed the heavy jobs SKIP (a
+skipped required check satisfies rulesets — safe precisely because the
+pending gate status is what blocks the merge), and nothing ever posts
+`success` without proof an approved attempt ran on that exact sha.
+
+## Evidence sources (`scripts/review-predicate.sh`)
+
+Evidence for the CURRENT head is any of:
+
+1. **Review object** at the exact head from a non-author, non-dismissed
+   login — restricted to `REVIEW_GATE_REVIEW_OBJECT_TRUSTED_LOGINS` when
+   set, and to APPROVED reviews when
+   `REVIEW_GATE_REVIEW_OBJECT_MIN_STATE = "approved"`. Approval is never
+   superseded by a later COMMENTED from the same reviewer; only a later
+   CHANGES_REQUESTED withdraws it.
+2. **Trusted clean-analysis check-run or commit status**
+   (`REVIEW_GATE_TRUSTED_STATUS_CONTEXTS`) succeeding on this head — but a
+   "pass" must prove analysis ran: a success whose output/description
+   matches `REVIEW_GATE_CHECKRUN_SKIP_PATTERNS` (e.g. "rate limited") is
+   NOT-EVIDENCE, never a failure — it is silence, and silence is what the
+   `awaiting` path already handles.
+3. **Comment-form clean pass** (`REVIEW_GATE_COMMENT_REVIEWERS`): an issue
+   comment by a trusted bot login whose body binds the evidence to this
+   head's sha (full sha or backtick short form, floor
+   `REVIEW_GATE_SHA_PREFIX_FLOOR`).
+4. **Reviewer-outage attestation** (`REVIEW_GATE_OUTAGE_CONTEXT`): a trusted
+   orchestrator's status posted only on genuine total reviewer silence.
+   Substitutes for MISSING evidence only.
+
+Changes-requested and unresolved threads always fail closed, even with
+evidence present. Every evidence read fails LOUD (exit 2, no verdict) — a
+transient API error must never flip a healthy PR's merge state. More than
+100 review threads reports overflow and fails closed to `threads-open`.
+
+**Trust model.** Trust keys on names only GitHub controls: the author login
+of a review or comment (exact match on the bot login) or the exact
+check/status context on repos where every publisher is trusted. A comment
+body is never trusted to establish trust — it is read only to BIND evidence
+to a commit, so a stale comment cannot vouch for a later push.
+
+## Scripts
+
+```bash
+# verdict for one PR head (env: GH_REPO, PR_NUMBER, HEAD_SHA[, PR_AUTHOR])
+.agents/skills/review-gate/scripts/review-predicate.sh
+
+# converge the gate status + rerun-in-place for one head (same env; QUIESCE=0|1)
+.agents/skills/review-gate/scripts/approval-refire.sh
+
+# offline decision-table selftest (~1s, no network); run it from the repo root
+.agents/skills/review-gate/scripts/review-predicate-selftest.sh
+```
+
+`approval-refire.sh` posts pending/failure directly (pending blocks on its
+own, no check-run churn) and opens the gate only by re-running the head's
+completed `pull_request` runs — or a direct `success` post when a prior gate
+success proves an approved attempt already ran on that sha. Reruns are capped
+by `REVIEW_GATE_MAX_RERUN_ATTEMPTS`.
+
+## Settings
+
+Every per-repo value is a `REVIEW_GATE_*` key (env > `vstack.settings.toml` >
+default). Full key table with per-repo values, and the workflow trust posture
+(read-only evaluate job, no-checkout post job, `persist-credentials: false`):
+[references/settings.md](references/settings.md).
+
+## Selftest — the engine's portable proof
+
+`scripts/review-predicate-selftest.sh` pins the decision table offline: a
+`gh` shim on PATH answers from fixtures and applies `--jq` through real jq,
+so the real predicate runs unmodified — no network, ~1s. Every case ending
+`approved` is paired with a near-miss that must not. Two layers: a mechanism
+layer with forced configurations pinning every engine behavior, and a
+configured layer that re-derives the approve/near-miss battery from the
+invoking repo's own resolved `REVIEW_GATE_*` values — a repo trusting a
+different bot tests its own trust list, not someone else's defaults.
+
+Every consumer's CI must run it as a deliberately **ungated** job (own job,
+no `needs`, no approval condition): a broken predicate approves nothing, so
+a selftest behind the gate could never run when it matters; a separate job
+reds the build without stopping the gate status from posting.
+
+## Adoption
+
+`templates/approval-rerun.yml` and `templates/approval-sweep.yml` are
+one-time scaffolds copied into `.github/workflows/` by a repo's adoption PR
+(repo-owned after copy; workflow YAML is not synced by `vstack refresh`).
+The repo's own CI wires a gate job that evaluates the predicate and posts
+the status, plus the ungated selftest job. Full wiring, branch-protection
+steps, merge-queue notes, and per-repo values:
+[references/adoption.md](references/adoption.md). An adoption PR deletes the
+local copies it supersedes in the same PR — a redesign removes what it
+replaces, never leaves it dormant.

--- a/skills/review-gate/references/adoption.md
+++ b/skills/review-gate/references/adoption.md
@@ -1,0 +1,233 @@
+# Adopting the review-gate engine
+
+How a consumer repo wires the shared engine: the CI gate job, the two
+scaffold workflows, branch protection, per-repo settings, and the shape of
+each known consumer's adoption PR.
+
+## What an adoption PR contains
+
+1. Vendor the skill (`vstack refresh` places
+   `.agents/skills/review-gate/scripts/` and this reference). The sync
+   verifies the SHIPPED copy: the vendored files are byte-for-byte the
+   catalog's, and the consumer's drift check asserts the vendored copy
+   matches, not the source.
+2. Copy `templates/approval-rerun.yml` and `templates/approval-sweep.yml`
+   into `.github/workflows/`, aligning the `ADAPT`-marked trigger filters
+   with the repo's `REVIEW_GATE_*` values. These are one-time scaffolds —
+   repo-owned after copy; workflow YAML is not an ongoing sync target.
+3. Wire the repo's own `ci.yml`: a gate job (below) and the ungated
+   selftest job.
+4. Set the repo's `REVIEW_GATE_*` keys in `vstack.settings.toml`.
+5. **Delete the local copies the engine supersedes in the same PR** — local
+   predicate/refire scripts, selftests, and any duplicated gate steps. A
+   redesign removes what it replaces, never leaves it dormant.
+6. Repo-side wiring (below): required status context, thread-resolution
+   ruleset, merge-queue handling.
+
+## The CI gate job
+
+The gate is evaluated once per run in a cheap early job; heavy jobs take
+`needs: <gate-job>` and `if: needs.<gate-job>.outputs.approved == 'true'`.
+Skipped required checks satisfy rulesets — safe because the pending gate
+status is what blocks merge.
+
+```yaml
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read      # comment-form evidence, if configured
+      checks: read
+      statuses: write   # posts the gate status
+    outputs:
+      approved: ${{ steps.gate.outputs.approved }}
+    steps:
+      - uses: actions/checkout@<pinned-sha>
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+      - name: Evaluate review gate
+        id: gate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          CTX="$(. .agents/skills/review-gate/scripts/lib/settings.sh && rg_setting REVIEW_GATE_CONTEXT "Review gate")"
+          post() {
+            gh api -X POST "repos/$GH_REPO/statuses/$1" \
+              -f state="$2" -f context="$CTX" \
+              -f description="$(printf %.140s "$3")" \
+              -f target_url="$RUN_URL" >/dev/null
+          }
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            # Merge-queue entries are post-approval by construction, but the
+            # queue still requires the gate context on the group sha.
+            if [ "${{ github.event_name }}" = "merge_group" ]; then
+              post "$GITHUB_SHA" success "merge queue entries are post-approval by construction"
+            fi
+            echo "approved=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if line="$(.agents/skills/review-gate/scripts/review-predicate.sh)"; then
+            verdict="${line#verdict=}"; verdict="${verdict%% *}"
+            detail="${line#*detail=}"
+          else
+            # NO verdict was reached (transient API failure). Fail SAFE, not
+            # red: post pending so merge stays blocked, skip the heavy jobs,
+            # and let the scheduled sweep re-evaluate.
+            verdict="error"
+            detail="review-state read failed; the scheduled sweep retries"
+          fi
+          case "$verdict" in
+            approved)              state=success ;;
+            changes-requested)     state=failure ;;
+            awaiting|threads-open|error) state=pending ;;
+          esac
+          post "$HEAD_SHA" "$state" "$detail"
+          if [ "$verdict" = "approved" ]; then
+            echo "approved=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "approved=false" >> "$GITHUB_OUTPUT"
+          fi
+```
+
+### Trust posture (`REVIEW_GATE_TRUST_PR_WORKFLOWS`)
+
+The snippet above (PR-head checkout, one job holding `statuses: write`) is
+the **self-evaluating** posture — acceptable only with
+`REVIEW_GATE_TRUST_PR_WORKFLOWS = "true"`, i.e. on private, effectively
+single-author repos that deliberately want the bootstrap property (a PR
+fixing a broken predicate is evaluated by its own fixed copy, so the fix can
+open its own gate; under a base-revision predicate the fix would be judged
+by the very bug it repairs). The setting exists to make that trade an
+explicit, visible choice.
+
+The **safe** posture (default, `"false"`) never executes PR-controlled code
+with a write-capable token:
+
+- Split evaluation and posting: an `evaluate` job with **read-only**
+  permissions (`statuses: read`, no write anywhere) checks out the **base
+  revision** (`ref: ${{ github.event.pull_request.base.sha }}`, or fetch the
+  default branch and `git show` the predicate out of it) and runs the
+  base-revision predicate against the PR head's sha; a separate `post` job
+  with only `statuses: write` and **no repo checkout at all** posts the
+  status from the evaluate job's output.
+- `persist-credentials: false` on every checkout in any job that executes
+  repository code (the scaffold workflows already do this; they also pin
+  their checkout to the default branch, which is the same base-revision
+  property for the refire path).
+- The exposure is asymmetric by permission: a consumer of the predicate that
+  holds no `statuses: write` (e.g. a build job deciding whether to run) can
+  at worst be tricked into an unwarranted build, not a green gate — but it
+  is the same root cause, so the base-revision rule applies to every job
+  that executes the predicate with any token.
+
+## The ungated selftest job
+
+```yaml
+  gate-selftest:
+    # DELIBERATELY UNGATED: no `needs`, no approval condition, no path
+    # filter. If the predicate is broken, nothing is ever approved, so a
+    # gated selftest could never run when it matters. A separate job reds
+    # the build without stopping the gate job from posting its status — a
+    # PR with no gate status at all is stuck rather than blocked.
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@<pinned-sha>
+        with:
+          persist-credentials: false
+      - name: Pin the review-gate decision table
+        run: .agents/skills/review-gate/scripts/review-predicate-selftest.sh
+```
+
+Run from the repo root so the selftest resolves the repo's own
+`vstack.settings.toml` — its configured layer generates approve/near-miss
+cases from the repo's actual trust values.
+
+## Repo-side wiring
+
+- Branch protection / ruleset: require the gate context (the repo's
+  `REVIEW_GATE_CONTEXT` value) as a required status check.
+- Keep (or add) the zero-bypass thread-resolution ruleset
+  (`required_review_thread_resolution`) — the CI-side thread term is a
+  latency optimization, not the enforcement point of record.
+- Merge queue repos: the gate job must post the gate context on
+  `merge_group` shas (the snippet's unconditional success post — queue
+  entries are post-approval by construction). Verify the queue's required
+  checks include the gate context and that rerun-in-place (never a separate
+  review-triggered run) is preserved: enqueue counts every check-run on the
+  head, and a stale failed required check from a superseded run blocks it.
+
+## Per-repo settings
+
+| Key | memsira | drovr | hyprtrade |
+|---|---|---|---|
+| `REVIEW_GATE_CONTEXT` | `Review gate` | `Review gate` | `CI Required` (existing aggregate name) or `Review gate` on re-architecture — owner call |
+| `REVIEW_GATE_TRUSTED_STATUS_CONTEXTS` | `Devin Review` | `Devin Review` | `Devin Review` (+ CodeRabbit's check if it is to be trusted — previously used ad hoc with no trust entry) |
+| `REVIEW_GATE_CHECKRUN_SKIP_PATTERNS` | default | default | default — closes the live rate-limited-pass gap |
+| `REVIEW_GATE_COMMENT_REVIEWERS` | `chatgpt-codex-connector[bot]:Reviewed commit:` | (empty — no comment-form reviewer) | (empty unless one is adopted) |
+| `REVIEW_GATE_SHA_PREFIX_FLOOR` | `7` | n/a (default) | n/a (default) |
+| `REVIEW_GATE_OUTAGE_CONTEXT` | `vstack-reviewer-outage` | `vstack-reviewer-outage` | `vstack-reviewer-outage` — carries over unchanged |
+| `REVIEW_GATE_REVIEW_OBJECT_TRUSTED_LOGINS` | (empty) | (empty) | set (e.g. `devin-ai-integration` + any trusted humans) — closes the any-collaborator-COMMENTED gap |
+| `REVIEW_GATE_REVIEW_OBJECT_MIN_STATE` | `any` | `any` | `approved` |
+| `REVIEW_GATE_MAX_RERUN_ATTEMPTS` | `5` | `5` | n/a under its own convergence tool |
+| `REVIEW_GATE_TRUST_PR_WORKFLOWS` | `true` (deliberate: bootstrap property on a private single-author repo — an explicit re-affirmation, not an accident) | `false` (safe posture; outside-contribution exposure not ruled out) | `false` |
+
+## Per-consumer adoption shape
+
+**memsira** — closest to a rename-in-place (its implementation is the
+engine's reference):
+
+- Delete `.github/scripts/review-predicate.sh`, `approval-refire.sh`,
+  `review-predicate-selftest.sh`.
+- Repoint `ci.yml`'s gate step and selftest job, `approval-rerun.yml`, and
+  `approval-sweep.yml` at `.agents/skills/review-gate/scripts/*.sh`.
+- Settings per the table. Setting `REVIEW_GATE_TRUST_PR_WORKFLOWS = "true"`
+  is the explicit, documented re-affirmation of its self-evaluating posture
+  (the alternative is rewiring `ci.yml` — and `ios.yml`, the predicate's
+  second consumer — to the safe two-job shape above).
+- No docs-only waiver to port (deliberately rejected there).
+
+**drovr**:
+
+- Delete `.github/scripts/review-predicate.sh` and repoint
+  `approval-rerun.yml`; drovr has no sweep workflow today — copy
+  `templates/approval-sweep.yml` to gain the thread-resolution backstop, or
+  record that its merge-time thread gate covers it.
+- **Docs-only waiver decision (owner call, flag in the adoption PR):**
+  drovr's `classify-changes.sh` computes a `gate_exempt` docs-only waiver
+  the shared engine deliberately does not have. Either keep it as
+  drovr-local logic layered on top of the shared predicate, or drop it —
+  dropping silently would be a behavior regression.
+- drovr enforces thread resolution at merge time (its `pr-merge` gate +
+  ruleset), not CI-side; the shared predicate's thread term simply adds the
+  CI-side latency signal.
+- No comment-form reviewer; leave `REVIEW_GATE_COMMENT_REVIEWERS` empty.
+
+**hyprtrade** — the largest adoption; **not a script swap**:
+
+- Its gate is a different architecture: flag-parsing CLI tools
+  (`tools/ci-required-gate`, `tools/ci-review-convergence`), status name
+  `CI Required`, a convergence sweep that deliberately never writes on read
+  failure (universal 5-minute retry + escalation to a rolling incident
+  issue instead of fail-loud writes), and no PR-ref triggers at all
+  (convergence runs from `status` / `workflow_run` / `schedule` only, after
+  PR-ref runs left permanently-retained non-green check runs on merge-bound
+  heads).
+- **Scope decision for the owner before implementation:** (a) adopt the
+  full engine including refire/sweep convergence, or (b) adopt the shared
+  **predicate only** (the evidence logic — which is where its two
+  live-observed gaps are) and keep `ci-review-convergence` as the
+  convergence layer. The engine supports (b) cleanly: the predicate is a
+  standalone script with a stable one-line verdict contract.
+- Merge queue: verify `merge_group` posting against its ruleset (above).
+- Carry `REVIEW_GATE_OUTAGE_CONTEXT = "vstack-reviewer-outage"` over
+  unchanged; add the review-object trust keys and skip patterns per the
+  table — both close gaps observed live on its PRs.

--- a/skills/review-gate/references/adoption.md
+++ b/skills/review-gate/references/adoption.md
@@ -126,6 +126,16 @@ with a write-capable token:
   at worst be tricked into an unwarranted build, not a green gate — but it
   is the same root cause, so the base-revision rule applies to every job
   that executes the predicate with any token.
+- The split removes PR-controlled CODE from the write path, but on
+  `pull_request` events the workflow DEFINITION itself still ships with the
+  PR head: a same-repo collaborator PR can edit the posting job directly
+  (fork PRs cannot — their token holds no `statuses: write`). Where
+  collaborators are inside the threat model, the status writer of record
+  must be a workflow defined on a trusted revision — exactly the property
+  the scaffold rerun/sweep workflows already have (non-PR triggers,
+  default-branch checkout). Rely on the scheduled sweep as that writer of
+  record and treat the PR-side gate job as the latency optimization,
+  mirroring the thread-resolution term below.
 
 ## The ungated selftest job
 

--- a/skills/review-gate/references/adoption.md
+++ b/skills/review-gate/references/adoption.md
@@ -167,67 +167,71 @@ cases from the repo's actual trust values.
 
 ## Per-repo settings
 
-| Key | memsira | drovr | hyprtrade |
-|---|---|---|---|
-| `REVIEW_GATE_CONTEXT` | `Review gate` | `Review gate` | `CI Required` (existing aggregate name) or `Review gate` on re-architecture — owner call |
-| `REVIEW_GATE_TRUSTED_STATUS_CONTEXTS` | `Devin Review` | `Devin Review` | `Devin Review` (+ CodeRabbit's check if it is to be trusted — previously used ad hoc with no trust entry) |
-| `REVIEW_GATE_CHECKRUN_SKIP_PATTERNS` | default | default | default — closes the live rate-limited-pass gap |
-| `REVIEW_GATE_COMMENT_REVIEWERS` | `chatgpt-codex-connector[bot]:Reviewed commit:` | (empty — no comment-form reviewer) | (empty unless one is adopted) |
-| `REVIEW_GATE_SHA_PREFIX_FLOOR` | `7` | n/a (default) | n/a (default) |
-| `REVIEW_GATE_OUTAGE_CONTEXT` | `vstack-reviewer-outage` | `vstack-reviewer-outage` | `vstack-reviewer-outage` — carries over unchanged |
-| `REVIEW_GATE_REVIEW_OBJECT_TRUSTED_LOGINS` | (empty) | (empty) | set (e.g. `devin-ai-integration` + any trusted humans) — closes the any-collaborator-COMMENTED gap |
-| `REVIEW_GATE_REVIEW_OBJECT_MIN_STATE` | `any` | `any` | `approved` |
-| `REVIEW_GATE_MAX_RERUN_ATTEMPTS` | `5` | `5` | n/a under its own convergence tool |
-| `REVIEW_GATE_TRUST_PR_WORKFLOWS` | `true` (deliberate: bootstrap property on a private single-author repo — an explicit re-affirmation, not an accident) | `false` (safe posture; outside-contribution exposure not ruled out) | `false` |
+Concrete per-consumer value assignments are tracked on the org adoption issue
+(vstack's issue tracker), not here — this table names each key's decision axis.
+The three adopting consumers map onto the archetypes in the next section.
+
+| Key | Decision axis |
+|---|---|
+| `REVIEW_GATE_CONTEXT` | The repo's protected commit-status name. A repo with an existing aggregate context (archetype C) either sets this to that existing name or renames the context AND updates branch protection/rulesets in the same adoption — a mismatch leaves merges blocked on an absent required check. |
+| `REVIEW_GATE_TRUSTED_STATUS_CONTEXTS` | The repo's trusted clean-analysis reviewer context(s). A context previously trusted ad hoc gets an explicit entry here or stops counting. |
+| `REVIEW_GATE_CHECKRUN_SKIP_PATTERNS` | Default closes the rate-limited-pass gap everywhere; empty is an explicit opt-out. |
+| `REVIEW_GATE_COMMENT_REVIEWERS` | Only for repos with a comment-form reviewer (reviewer login + binding prefix); empty otherwise. |
+| `REVIEW_GATE_SHA_PREFIX_FLOOR` | Only where a comment-form reviewer binds by SHA prefix. |
+| `REVIEW_GATE_OUTAGE_CONTEXT` | Carries over unchanged (`vstack-reviewer-outage`) unless a repo renames its outage attestation. |
+| `REVIEW_GATE_REVIEW_OBJECT_TRUSTED_LOGINS` | Empty = any non-author (adoption-non-breaking). A repo closing the any-collaborator-COMMENTED gap lists its trusted reviewer logins. |
+| `REVIEW_GATE_REVIEW_OBJECT_MIN_STATE` | `any` keeps today's behavior; `approved` requires an APPROVED verdict. |
+| `REVIEW_GATE_MAX_RERUN_ATTEMPTS` | Refire budget; n/a for a repo keeping its own convergence tool. |
+| `REVIEW_GATE_TRUST_PR_WORKFLOWS` | `false` is the safe posture. `true` is a deliberate, documented re-affirmation for a self-evaluating repo (bootstrap property, private single-author) — never an accident of copying. |
 
 ## Per-consumer adoption shape
 
-**memsira** — closest to a rename-in-place (its implementation is the
-engine's reference):
+Three archetypes cover the current consumers; an adoption PR states which one
+it is and follows that shape.
 
-- Delete `.github/scripts/review-predicate.sh`, `approval-refire.sh`,
+**Archetype R — reference-origin** (the repo whose local implementation this
+engine was lifted from; adoption is a rename-in-place):
+
+- Delete the repo-local `review-predicate.sh`, `approval-refire.sh`, and
   `review-predicate-selftest.sh`.
-- Repoint `ci.yml`'s gate step and selftest job, `approval-rerun.yml`, and
-  `approval-sweep.yml` at `.agents/skills/review-gate/scripts/*.sh`.
-- Settings per the table. Setting `REVIEW_GATE_TRUST_PR_WORKFLOWS = "true"`
-  is the explicit, documented re-affirmation of its self-evaluating posture
-  (the alternative is rewiring `ci.yml` — and `ios.yml`, the predicate's
-  second consumer — to the safe two-job shape above).
-- No docs-only waiver to port (deliberately rejected there).
+- Repoint the CI gate step, the selftest job, `approval-rerun.yml`, and
+  `approval-sweep.yml` at `.agents/skills/review-gate/scripts/*.sh` — and
+  every OTHER workflow that consumes the predicate (a second consumer
+  workflow is easy to miss).
+- If the repo keeps its self-evaluating posture, `REVIEW_GATE_TRUST_PR_WORKFLOWS
+  = "true"` is the explicit re-affirmation; the alternative is rewiring the
+  consuming workflows to the safe two-job shape above.
 
-**drovr**:
+**Archetype M — minimal local gate** (predicate-only today, no sweep
+workflow, thread resolution enforced at merge time rather than CI-side):
 
-- Delete `.github/scripts/review-predicate.sh` and repoint
-  `approval-rerun.yml`; drovr has no sweep workflow today — copy
-  `templates/approval-sweep.yml` to gain the thread-resolution backstop, or
-  record that its merge-time thread gate covers it.
-- **Docs-only waiver decision (owner call, flag in the adoption PR):**
-  drovr's `classify-changes.sh` computes a `gate_exempt` docs-only waiver
-  the shared engine deliberately does not have. Either keep it as
-  drovr-local logic layered on top of the shared predicate, or drop it —
-  dropping silently would be a behavior regression.
-- drovr enforces thread resolution at merge time (its `pr-merge` gate +
-  ruleset), not CI-side; the shared predicate's thread term simply adds the
-  CI-side latency signal.
-- No comment-form reviewer; leave `REVIEW_GATE_COMMENT_REVIEWERS` empty.
+- Delete the repo-local predicate and repoint `approval-rerun.yml`; either
+  copy `templates/approval-sweep.yml` to gain the thread-resolution backstop
+  or record that the merge-time thread gate covers it.
+- **Existing local waivers are an explicit adopt-or-drop decision.** The
+  shared engine deliberately ships no exemptions (e.g. a docs-only
+  review-received waiver computed by a repo-local classification script).
+  Keep such a waiver as repo-local logic layered on top of the shared
+  predicate, or drop it in the adoption PR with the behavior change stated —
+  dropping silently is a regression.
+- No comment-form reviewer → leave `REVIEW_GATE_COMMENT_REVIEWERS` empty.
 
-**hyprtrade** — the largest adoption; **not a script swap**:
+**Archetype C — converge-based** (the largest adoption; **not a script
+swap**):
 
-- Its gate is a different architecture: flag-parsing CLI tools
-  (`tools/ci-required-gate`, `tools/ci-review-convergence`), status name
-  `CI Required`, a convergence sweep that deliberately never writes on read
-  failure (universal 5-minute retry + escalation to a rolling incident
-  issue instead of fail-loud writes), and no PR-ref triggers at all
-  (convergence runs from `status` / `workflow_run` / `schedule` only, after
-  PR-ref runs left permanently-retained non-green check runs on merge-bound
-  heads).
-- **Scope decision for the owner before implementation:** (a) adopt the
-  full engine including refire/sweep convergence, or (b) adopt the shared
-  **predicate only** (the evidence logic — which is where its two
-  live-observed gaps are) and keep `ci-review-convergence` as the
-  convergence layer. The engine supports (b) cleanly: the predicate is a
-  standalone script with a stable one-line verdict contract.
-- Merge queue: verify `merge_group` posting against its ruleset (above).
-- Carry `REVIEW_GATE_OUTAGE_CONTEXT = "vstack-reviewer-outage"` over
-  unchanged; add the review-object trust keys and skip patterns per the
-  table — both close gaps observed live on its PRs.
+- Such a repo runs a different architecture: its own flag-parsing gate/
+  convergence CLI tools, an existing protected aggregate context name, a
+  convergence sweep that deliberately never writes on read failure
+  (retry + escalation instead of fail-loud writes), and no PR-ref triggers
+  (convergence from `status` / `workflow_run` / `schedule` only).
+- **Scope decision for the owner before implementation:** (a) adopt the full
+  engine including refire/sweep convergence, or (b) adopt the shared
+  **predicate only** — the evidence logic, where the live-observed gaps are —
+  and keep the repo's convergence layer. The engine supports (b) cleanly:
+  the predicate is a standalone script with a stable one-line verdict
+  contract.
+- **Align `REVIEW_GATE_CONTEXT` explicitly** with the existing protected
+  context name (or rename the context and update rulesets in the same
+  adoption); verify `merge_group` posting against the ruleset.
+- Add the review-object trust keys and skip patterns — both close gaps
+  observed live on this archetype's PRs.

--- a/skills/review-gate/references/adoption.md
+++ b/skills/review-gate/references/adoption.md
@@ -165,6 +165,11 @@ cases from the repo's actual trust values.
 
 - Branch protection / ruleset: require the gate context (the repo's
   `REVIEW_GATE_CONTEXT` value) as a required status check.
+- Verify the status writer of record is trusted-revision-defined: the
+  rerun/sweep workflows must be installed on the default branch (their
+  non-PR triggers and default-branch checkout are the trust property), and
+  adoption sign-off includes confirming the scheduled sweep converges the
+  gate with the PR-side gate job treated as latency optimization only.
 - Keep (or add) the zero-bypass thread-resolution ruleset
   (`required_review_thread_resolution`) — the CI-side thread term is a
   latency optimization, not the enforcement point of record.

--- a/skills/review-gate/references/settings.md
+++ b/skills/review-gate/references/settings.md
@@ -9,7 +9,7 @@ per-repo wiring and values: [adoption.md](adoption.md).
 | Key | Default | Meaning |
 |---|---|---|
 | `REVIEW_GATE_CONTEXT` | `Review gate` | Gate commit-status context (the required check name). |
-| `REVIEW_GATE_TRUSTED_STATUS_CONTEXTS` | `Devin Review` | Clean-analysis check-run/status names; either API counts. |
+| `REVIEW_GATE_TRUSTED_STATUS_CONTEXTS` | (empty) | Clean-analysis check-run/status names; either API counts. Empty disables the source — trust is opt-in per repo, never a shipped vendor default. |
 | `REVIEW_GATE_CHECKRUN_SKIP_PATTERNS` | `rate limited;skipped;queued` | Case-insensitive substrings marking a trusted "pass" as analysis-not-run → not evidence. Empty disables. |
 | `REVIEW_GATE_COMMENT_REVIEWERS` | (empty) | `login:binding-pattern` pairs; first `:` splits; pattern is a literal prefix. Empty disables the source. |
 | `REVIEW_GATE_SHA_PREFIX_FLOOR` | `7` | Shortest sha prefix a comment may bind (4–40). |

--- a/skills/review-gate/references/settings.md
+++ b/skills/review-gate/references/settings.md
@@ -1,0 +1,35 @@
+# Review-gate settings
+
+All keys resolve environment-first, then the repo's `vstack.settings.toml`,
+then the built-in default (`REVIEW_GATE_SETTINGS_FILE` overrides the file
+path, e.g. in tests). List values pack into one string with `;` separators.
+Commented defaults ship in this skill's `vstack.settings.toml.example`;
+per-repo wiring and values: [references/adoption.md](references/adoption.md).
+
+| Key | Default | Meaning |
+|---|---|---|
+| `REVIEW_GATE_CONTEXT` | `Review gate` | Gate commit-status context (the required check name). |
+| `REVIEW_GATE_TRUSTED_STATUS_CONTEXTS` | `Devin Review` | Clean-analysis check-run/status names; either API counts. |
+| `REVIEW_GATE_CHECKRUN_SKIP_PATTERNS` | `rate limited;skipped;queued` | Case-insensitive substrings marking a trusted "pass" as analysis-not-run → not evidence. Empty disables. |
+| `REVIEW_GATE_COMMENT_REVIEWERS` | (empty) | `login:binding-pattern` pairs; first `:` splits; pattern is a literal prefix. Empty disables the source. |
+| `REVIEW_GATE_SHA_PREFIX_FLOOR` | `7` | Shortest sha prefix a comment may bind (4–40). |
+| `REVIEW_GATE_OUTAGE_CONTEXT` | `vstack-reviewer-outage` | Outage-attestation status context. Empty disables. |
+| `REVIEW_GATE_REVIEW_OBJECT_TRUSTED_LOGINS` | (empty) | Review-object trust list. Empty = any non-author (compatible default). |
+| `REVIEW_GATE_REVIEW_OBJECT_MIN_STATE` | `any` | `any` counts any accepted review row; `approved` requires an APPROVED not withdrawn by a later CHANGES_REQUESTED from the same login. |
+| `REVIEW_GATE_MAX_RERUN_ATTEMPTS` | `5` | Refire rerun backstop for pathological ping-pong. |
+| `REVIEW_GATE_TRUST_PR_WORKFLOWS` | `false` | Trust posture for the CI gate job (see Security below). Consumed by workflow wiring, not by the scripts. |
+
+# Security posture
+
+Workflows that execute repository-controlled code with a write-capable token
+are the gate's own attack surface: a malicious PR could edit the predicate,
+read the token, or post an `approved` status. The safe posture (default,
+`REVIEW_GATE_TRUST_PR_WORKFLOWS = "false"`) runs the predicate from the BASE
+revision with a read-only token and posts the status from a separate
+minimal-permission step; checkouts in jobs executing repo code set
+`persist-credentials: false`. Setting `"true"` deliberately accepts
+self-evaluation (PR-head predicate) for its bootstrap property — a PR that
+fixes the gate can open its own gate — which is defensible only on private,
+effectively single-author repos; the settings key exists so that choice is
+explicit and visible, never an accident. Wiring for both postures:
+[references/adoption.md](references/adoption.md).

--- a/skills/review-gate/references/settings.md
+++ b/skills/review-gate/references/settings.md
@@ -4,7 +4,7 @@ All keys resolve environment-first, then the repo's `vstack.settings.toml`,
 then the built-in default (`REVIEW_GATE_SETTINGS_FILE` overrides the file
 path, e.g. in tests). List values pack into one string with `;` separators.
 Commented defaults ship in this skill's `vstack.settings.toml.example`;
-per-repo wiring and values: [references/adoption.md](references/adoption.md).
+per-repo wiring and values: [adoption.md](adoption.md).
 
 | Key | Default | Meaning |
 |---|---|---|
@@ -32,4 +32,4 @@ self-evaluation (PR-head predicate) for its bootstrap property — a PR that
 fixes the gate can open its own gate — which is defensible only on private,
 effectively single-author repos; the settings key exists so that choice is
 explicit and visible, never an accident. Wiring for both postures:
-[references/adoption.md](references/adoption.md).
+[adoption.md](adoption.md).

--- a/skills/review-gate/scripts/approval-refire.sh
+++ b/skills/review-gate/scripts/approval-refire.sh
@@ -55,8 +55,10 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "$script_dir/lib/settings.sh"
 
 QUIESCE="${QUIESCE:-1}"
-MAX_ATTEMPTS="${MAX_ATTEMPTS:-$(rg_setting REVIEW_GATE_MAX_RERUN_ATTEMPTS "5")}"
-GATE_CONTEXT="$(rg_setting REVIEW_GATE_CONTEXT "Review gate")"
+# `|| exit 1`: rg_setting fails on a present-but-unparseable assignment, and
+# that is a configuration error to surface, never an empty value to act on.
+MAX_ATTEMPTS="${MAX_ATTEMPTS:-$(rg_setting REVIEW_GATE_MAX_RERUN_ATTEMPTS "5")}" || exit 1
+GATE_CONTEXT="$(rg_setting REVIEW_GATE_CONTEXT "Review gate")" || exit 1
 
 case "$MAX_ATTEMPTS" in
   ''|*[!0-9]*)

--- a/skills/review-gate/scripts/approval-refire.sh
+++ b/skills/review-gate/scripts/approval-refire.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+# Review-gate convergence for ONE pull request head — the single source of
+# truth for how review-state transitions reach the merge-blocking gate commit
+# status and the CI runs behind it. Shipped by the vstack review-gate skill;
+# vendored into consumers at .agents/skills/review-gate/scripts/.
+#
+# Model: the repo's CI gate job evaluates review-predicate.sh and posts the
+# gate commit status (context: REVIEW_GATE_CONTEXT) on the PR head —
+# `pending` until review evidence exists (blocks merge without a false red),
+# `failure` only on changes-requested, `success` only from a run attempt that
+# executed with the gate open (heavy jobs skip while it is closed). This
+# script converges the status when review state changes between runs:
+#
+#   verdict != approved   → POST the pending/failure status directly. No
+#                           reruns: pending blocks merge on its own, so a
+#                           dismissed review or reopened thread needs no
+#                           check-run churn.
+#   verdict == approved   → the status may read `success` ONLY in two ways:
+#     (a) a PRIOR gate success exists on this same sha — proof an approved
+#         attempt already executed its jobs here (a red build from that
+#         attempt stays blocked by its own red required contexts) — then
+#         post success directly, sparing a pointless full re-run;
+#     (b) otherwise RERUN the head's completed pull_request runs: the new
+#         attempt's gate job re-evaluates, posts success, and the heavy
+#         jobs actually run. Never post success without (a): pre-review
+#         attempts SKIP the heavy jobs, and skipped required checks satisfy
+#         rulesets, so a directly-posted success would merge untested code.
+#
+# Callers (see the skill's templates/):
+#   - approval-rerun.yml (event-driven: review submitted/dismissed, trusted
+#     check_run/status evidence, comment-form reviewer comments)   QUIESCE=1
+#   - approval-sweep.yml (scheduled: transitions that emit no usable Actions
+#     event, chiefly resolving the last review thread)             QUIESCE=0
+#
+# Env (required): GH_TOKEN (or ambient gh auth), GH_REPO, PR_NUMBER, HEAD_SHA
+# Env (optional):
+#   PR_AUTHOR     resolved from the PR when empty.
+#   QUIESCE       "1" (default): wait (bounded) for in-progress runs on the
+#                 head to complete before a rerun decision. "0": act on
+#                 completed runs only (the next scheduled pass catches
+#                 stragglers).
+# Settings (lib/settings.sh — env > vstack.settings.toml > default):
+#   REVIEW_GATE_CONTEXT             gate commit-status context (default "Review gate")
+#   REVIEW_GATE_MAX_RERUN_ATTEMPTS  rerun backstop (default 5): runs at/above
+#                 the cap are left alone (gh run rerun retries manually).
+#                 Attempts only grow on the first awaiting→approved flip per
+#                 head, so the cap exists for pathological ping-pong, not
+#                 normal review cycles. Legacy MAX_ATTEMPTS env is honored.
+#
+# Read errors fail LOUDLY (exit 1) without taking any action: treating a
+# transient API failure as absent evidence could flip a healthy PR's state.
+set -u
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$script_dir/lib/settings.sh"
+
+QUIESCE="${QUIESCE:-1}"
+MAX_ATTEMPTS="${MAX_ATTEMPTS:-$(rg_setting REVIEW_GATE_MAX_RERUN_ATTEMPTS "5")}"
+GATE_CONTEXT="$(rg_setting REVIEW_GATE_CONTEXT "Review gate")"
+
+case "$MAX_ATTEMPTS" in
+  ''|*[!0-9]*)
+    echo "::error::approval-refire: REVIEW_GATE_MAX_RERUN_ATTEMPTS must be an integer, got '$MAX_ATTEMPTS'"
+    exit 1
+    ;;
+esac
+if [ -z "$GATE_CONTEXT" ]; then
+  echo "::error::approval-refire: REVIEW_GATE_CONTEXT must not be empty"
+  exit 1
+fi
+
+for required in GH_REPO PR_NUMBER HEAD_SHA; do
+  if [ -z "$(eval "echo \${$required:-}")" ]; then
+    echo "::error::approval-refire: $required is required"
+    exit 1
+  fi
+done
+
+verdict_line="$("$script_dir/review-predicate.sh")" || {
+  echo "::error::review predicate evaluation failed for PR #$PR_NUMBER; taking no action - re-review (or gh run rerun) to retry"
+  exit 1
+}
+verdict="$(sed -n 's/^verdict=\([a-z-]*\) .*/\1/p' <<<"$verdict_line")"
+detail="$(sed -n 's/^verdict=[a-z-]* detail=//p' <<<"$verdict_line")"
+if [ -z "$verdict" ]; then
+  echo "::error::could not parse predicate output: $verdict_line"
+  exit 1
+fi
+echo "PR #$PR_NUMBER: verdict=$verdict ($detail)"
+
+case "$verdict" in
+  approved)              desired="success" ;;
+  changes-requested)     desired="failure" ;;
+  awaiting|threads-open) desired="pending" ;;
+  *)
+    echo "::error::unknown verdict '$verdict'"
+    exit 1
+    ;;
+esac
+
+# Full status history for the sha (newest first): the latest gate-context
+# entry is the current state; ANY success entry is the approved-attempt proof
+# for the direct-success fast path.
+raw_statuses="$(gh api "repos/$GH_REPO/commits/$HEAD_SHA/statuses" --paginate)" || {
+  echo "::error::could not read commit statuses for $HEAD_SHA; taking no action"
+  exit 1
+}
+gate_statuses="$(jq -s --arg ctx "$GATE_CONTEXT" '[add // [] | .[] | select(.context == $ctx)]' <<<"$raw_statuses")" || {
+  echo "::error::could not parse commit statuses for $HEAD_SHA; taking no action"
+  exit 1
+}
+current_state="$(jq -r '.[0].state // "absent"' <<<"$gate_statuses")"
+current_desc="$(jq -r '.[0].description // ""' <<<"$gate_statuses")"
+ever_succeeded="$(jq '[.[] | select(.state == "success")] | length' <<<"$gate_statuses")"
+
+post_status() {
+  # 140-char API limit on description.
+  gh api -X POST "repos/$GH_REPO/statuses/$HEAD_SHA" \
+    -f state="$1" -f context="$GATE_CONTEXT" \
+    -f description="${2:0:140}" \
+    -f target_url="https://github.com/$GH_REPO/pull/$PR_NUMBER" >/dev/null || {
+    echo "::error::could not post $GATE_CONTEXT=$1 on $HEAD_SHA"
+    exit 1
+  }
+  echo "posted $GATE_CONTEXT=$1 on $HEAD_SHA ($2)"
+}
+
+if [ "$desired" != "success" ]; then
+  if [ "$current_state" = "$desired" ] && [ "$current_desc" = "${detail:0:140}" ]; then
+    echo "PR #$PR_NUMBER: $GATE_CONTEXT already $desired; nothing to do"
+    exit 0
+  fi
+  post_status "$desired" "$detail"
+  exit 0
+fi
+
+# desired == success from here on.
+if [ "$current_state" = "success" ]; then
+  echo "PR #$PR_NUMBER: $GATE_CONTEXT already success; nothing to do"
+  exit 0
+fi
+if [ "$ever_succeeded" -gt 0 ]; then
+  # An approved attempt already executed on this exact sha; its required
+  # contexts stand on their own merits. Skip the redundant full re-run.
+  post_status success "re-approved: an approved CI attempt already ran for this head"
+  exit 0
+fi
+
+# First awaiting→approved flip for this head: rerun its completed
+# pull_request runs so the new attempt opens the gate and executes the jobs.
+# A run cannot be rerun while in progress; in QUIESCE mode wait (bounded) for
+# the head to settle. QUIESCE=0 snapshots once: in-progress runs are left for
+# the next scheduled pass. An attempt still running at decision time is left
+# to finish — its own gate job reads the CURRENT review state live.
+runs="[]"
+polls=1
+[ "$QUIESCE" = "1" ] && polls=60
+for attempt in $(seq 1 "$polls"); do
+  # Paginated + slurped like every other list read: repeated reopen/ready
+  # transitions can push a head past one page of runs.
+  raw_runs="$(gh api "repos/$GH_REPO/actions/runs?head_sha=$HEAD_SHA&per_page=100" --paginate)" || {
+    echo "::error::could not read workflow runs for head $HEAD_SHA"
+    exit 1
+  }
+  runs="$(jq -s '[.[].workflow_runs[]? | select(.event == "pull_request") | {id, name, status, conclusion, run_attempt}]' <<<"$raw_runs")" || {
+    echo "::error::could not parse workflow runs for head $HEAD_SHA"
+    exit 1
+  }
+  in_progress="$(jq '[.[] | select(.status != "completed")] | length' <<<"$runs")"
+  [ "$in_progress" -eq 0 ] && break
+  [ "$QUIESCE" = "1" ] || break
+  [ "$attempt" -eq "$polls" ] && break
+  echo "waiting: $in_progress run(s) still in progress on $HEAD_SHA (poll $attempt)"
+  sleep 30
+done
+if [ "${in_progress:-0}" -ne 0 ]; then
+  echo "::warning::run(s) still in progress on $HEAD_SHA; leaving them to finish (their gate job evaluates the current review state)"
+  exit 0
+fi
+
+total="$(jq length <<<"$runs")"
+if [ "$total" -eq 0 ]; then
+  echo "::warning::no completed pull_request runs exist on head $HEAD_SHA (Actions dispatch failure?); cannot open the gate - push a new commit or dispatch CI manually"
+  exit 0
+fi
+
+exit_code=0
+# `name` reads last: run names contain spaces.
+while read -r id run_attempt name; do
+  [ -z "$id" ] && continue
+  if [ "$run_attempt" -ge "$MAX_ATTEMPTS" ]; then
+    echo "::warning::run $id ($name) is at attempt $run_attempt (cap $MAX_ATTEMPTS); leaving it alone - gh run rerun to retry manually"
+    continue
+  fi
+  echo "rerun (open the review gate): run $id ($name)"
+  gh api -X POST "repos/$GH_REPO/actions/runs/$id/rerun" || {
+    echo "::warning::could not rerun run $id"
+    exit_code=1
+  }
+done < <(jq -r '.[] | "\(.id) \(.run_attempt) \(.name)"' <<<"$runs")
+exit "$exit_code"

--- a/skills/review-gate/scripts/approval-refire.sh
+++ b/skills/review-gate/scripts/approval-refire.sh
@@ -157,7 +157,9 @@ fi
 runs="[]"
 polls=1
 [ "$QUIESCE" = "1" ] && polls=60
-for attempt in $(seq 1 "$polls"); do
+attempt=0
+while [ "$attempt" -lt "$polls" ]; do
+  attempt=$((attempt + 1))
   # Paginated + slurped like every other list read: repeated reopen/ready
   # transitions can push a head past one page of runs.
   raw_runs="$(gh api "repos/$GH_REPO/actions/runs?head_sha=$HEAD_SHA&per_page=100" --paginate)" || {

--- a/skills/review-gate/scripts/lib/settings.sh
+++ b/skills/review-gate/scripts/lib/settings.sh
@@ -27,8 +27,11 @@ rg_setting() { # NAME DEFAULT — resolved value on stdout
   fi
   file="${REVIEW_GATE_SETTINGS_FILE:-vstack.settings.toml}"
   if [ -f "$file" ]; then
-    val="$(sed -n "s/^$name[[:space:]]*=[[:space:]]*\"\(.*\)\"[[:space:]]*\$/\1/p" "$file" | head -n 1)"
-    if [ -n "$val" ]; then
+    # Key PRESENCE decides, not value non-emptiness: `NAME = ""` is a real
+    # assignment ("empty disables" per the settings docs) and must override the
+    # built-in default, exactly like a set-but-empty env var does above.
+    if grep -q "^$name[[:space:]]*=" "$file"; then
+      val="$(sed -n "s/^$name[[:space:]]*=[[:space:]]*\"\(.*\)\"[[:space:]]*\$/\1/p" "$file" | head -n 1)"
       printf '%s' "$val"
       return 0
     fi

--- a/skills/review-gate/scripts/lib/settings.sh
+++ b/skills/review-gate/scripts/lib/settings.sh
@@ -17,8 +17,9 @@
 # Scripts run from the repo root in CI (workflow working directory), so the
 # default settings path is relative.
 
-rg_setting() { # NAME DEFAULT — resolved value on stdout
-  local name="$1" default="$2" val file
+rg_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
+               # a present-but-unparseable assignment (callers must propagate)
+  local name="$1" default="$2" line val file
   # Indirect expansion, not eval: a non-literal NAME must never become code.
   # ${!name+x} tests set-ness of the variable NAMED by $name (Bash 3.2-safe).
   if [ -n "${!name+x}" ]; then
@@ -31,7 +32,17 @@ rg_setting() { # NAME DEFAULT — resolved value on stdout
     # assignment ("empty disables" per the settings docs) and must override the
     # built-in default, exactly like a set-but-empty env var does above.
     if grep -q "^$name[[:space:]]*=" "$file"; then
-      val="$(sed -n "s/^$name[[:space:]]*=[[:space:]]*\"\(.*\)\"[[:space:]]*\$/\1/p" "$file" | head -n 1)"
+      line="$(grep "^$name[[:space:]]*=" "$file" | head -n 1)"
+      # A PRESENT assignment this parser cannot read (e.g. TOML array syntax
+      # for a list key) must fail LOUDLY, never collapse to empty: an empty
+      # value can silently widen the gate (empty trusted-logins = any
+      # non-author). Only the flat single-line basic-string shape is
+      # supported; anything else is a configuration error.
+      if ! printf '%s\n' "$line" | grep -q "^$name[[:space:]]*=[[:space:]]*\".*\"[[:space:]]*\$"; then
+        echo "::error::$file: unsupported syntax for $name (expected a single-line basic string: $name = \"value\"; list keys pack items with ';' separators)" >&2
+        return 1
+      fi
+      val="$(printf '%s\n' "$line" | sed -n "s/^$name[[:space:]]*=[[:space:]]*\"\(.*\)\"[[:space:]]*\$/\1/p")"
       printf '%s' "$val"
       return 0
     fi

--- a/skills/review-gate/scripts/lib/settings.sh
+++ b/skills/review-gate/scripts/lib/settings.sh
@@ -31,18 +31,20 @@ rg_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
     # Key PRESENCE decides, not value non-emptiness: `NAME = ""` is a real
     # assignment ("empty disables" per the settings docs) and must override the
     # built-in default, exactly like a set-but-empty env var does above.
-    if grep -q "^$name[[:space:]]*=" "$file"; then
-      line="$(grep "^$name[[:space:]]*=" "$file" | head -n 1)"
+    if grep -q "^${name}[[:space:]]*=" "$file"; then
+      line="$(grep "^${name}[[:space:]]*=" "$file" | head -n 1)"
       # A PRESENT assignment this parser cannot read (e.g. TOML array syntax
       # for a list key) must fail LOUDLY, never collapse to empty: an empty
       # value can silently widen the gate (empty trusted-logins = any
       # non-author). Only the flat single-line basic-string shape is
-      # supported; anything else is a configuration error.
-      if ! printf '%s\n' "$line" | grep -q "^$name[[:space:]]*=[[:space:]]*\".*\"[[:space:]]*\$"; then
+      # supported — the value is quote-free ([^"]*), which makes the
+      # extraction exact even with a trailing TOML comment (accepted);
+      # anything else is a configuration error.
+      if ! printf '%s\n' "$line" | grep -Eq "^${name}[[:space:]]*=[[:space:]]*\"[^\"]*\"[[:space:]]*(#.*)?\$"; then
         echo "::error::$file: unsupported syntax for $name (expected a single-line basic string: $name = \"value\"; list keys pack items with ';' separators)" >&2
         return 1
       fi
-      val="$(printf '%s\n' "$line" | sed -n "s/^$name[[:space:]]*=[[:space:]]*\"\(.*\)\"[[:space:]]*\$/\1/p")"
+      val="$(printf '%s\n' "$line" | sed -n "s/^${name}[[:space:]]*=[[:space:]]*\"\([^\"]*\)\".*\$/\1/p")"
       printf '%s' "$val"
       return 0
     fi

--- a/skills/review-gate/scripts/lib/settings.sh
+++ b/skills/review-gate/scripts/lib/settings.sh
@@ -1,0 +1,37 @@
+# shellcheck shell=bash
+# Settings resolution for the review-gate engine. Sourced (not executed) by
+# review-predicate.sh, approval-refire.sh and the selftest.
+#
+# Resolution order for every REVIEW_GATE_* key:
+#   1. explicit environment — a SET variable wins even when set to the empty
+#      string, so a caller (or the selftest) can force "explicitly empty";
+#   2. the repo's committed vstack.settings.toml (first uncommented
+#      `KEY = "value"` assignment; the file path can be overridden with
+#      REVIEW_GATE_SETTINGS_FILE, e.g. /dev/null to force built-in defaults);
+#   3. the built-in default passed by the caller.
+#
+# The parser reads flat single-line basic-string TOML assignments only —
+# exactly the shape vstack.settings.toml [env] blocks use. List-valued keys
+# therefore pack multiple items into one string with ';' separators.
+#
+# Scripts run from the repo root in CI (workflow working directory), so the
+# default settings path is relative.
+
+rg_setting() { # NAME DEFAULT — resolved value on stdout
+  local name="$1" default="$2" val file
+  # Indirect expansion, not eval: a non-literal NAME must never become code.
+  # ${!name+x} tests set-ness of the variable NAMED by $name (Bash 3.2-safe).
+  if [ -n "${!name+x}" ]; then
+    printf '%s' "${!name}"
+    return 0
+  fi
+  file="${REVIEW_GATE_SETTINGS_FILE:-vstack.settings.toml}"
+  if [ -f "$file" ]; then
+    val="$(sed -n "s/^$name[[:space:]]*=[[:space:]]*\"\(.*\)\"[[:space:]]*\$/\1/p" "$file" | head -n 1)"
+    if [ -n "$val" ]; then
+      printf '%s' "$val"
+      return 0
+    fi
+  fi
+  printf '%s' "$default"
+}

--- a/skills/review-gate/scripts/review-predicate-selftest.sh
+++ b/skills/review-gate/scripts/review-predicate-selftest.sh
@@ -540,6 +540,10 @@ reset
 CFG_OUTAGE="Gate X"; CFG_GATE_CONTEXT="Gate X"
 run "gate context equal to the outage context is a config error" "" 2
 
+reset
+CFG_GATE_CONTEXT=""
+run "explicitly empty gate context is a config error" "" 2
+
 # ================================================================ configured ===
 # The same discipline against THIS repo's resolved trust settings.
 echo "--- configured layer (this repo's REVIEW_GATE_* settings)"

--- a/skills/review-gate/scripts/review-predicate-selftest.sh
+++ b/skills/review-gate/scripts/review-predicate-selftest.sh
@@ -444,6 +444,15 @@ reviews_set "$(review "reviewer" APPROVED "2026-08-02T19:00:00Z")" \
             "$(review "reviewer" CHANGES_REQUESTED "2026-08-02T18:00:00Z")"
 run "cleared CR fed in reversed array order stays cleared" approved
 
+# An objection is never withdrawn by a later COMMENT — the mirror of the
+# approval-is-never-superseded rule. GitHub keeps requested changes standing
+# until re-approval or dismissal, and so does the reduction.
+reset
+reviews_set "$(review "reviewer" CHANGES_REQUESTED "2026-08-02T18:00:00Z")" \
+            "$(review "reviewer" COMMENTED "2026-08-02T19:00:00Z")" \
+            "$(review "other-reviewer" APPROVED "2026-08-02T19:30:00Z")"
+run "trailing COMMENTED does not withdraw a standing CR" changes-requested
+
 # ...and an APPROVED that POST-dates the CR clears it again.
 reset
 CFG_TRUSTED_LOGINS=""; CFG_MIN_STATE="approved"

--- a/skills/review-gate/scripts/review-predicate-selftest.sh
+++ b/skills/review-gate/scripts/review-predicate-selftest.sh
@@ -39,13 +39,15 @@ predicate="$here/review-predicate.sh"
 # ------------------------------------------------------------ active config ---
 # Resolved exactly as the predicate resolves it, from the invoking repo's
 # environment/settings. The configured layer generates its cases from these.
-ACTIVE_CONTEXTS="$(rg_setting REVIEW_GATE_TRUSTED_STATUS_CONTEXTS "Devin Review")"
-ACTIVE_SKIPS="$(rg_setting REVIEW_GATE_CHECKRUN_SKIP_PATTERNS "rate limited;skipped;queued")"
-ACTIVE_REVIEWERS="$(rg_setting REVIEW_GATE_COMMENT_REVIEWERS "")"
-ACTIVE_FLOOR="$(rg_setting REVIEW_GATE_SHA_PREFIX_FLOOR "7")"
-ACTIVE_OUTAGE="$(rg_setting REVIEW_GATE_OUTAGE_CONTEXT "vstack-reviewer-outage")"
-ACTIVE_TRUSTED_LOGINS="$(rg_setting REVIEW_GATE_REVIEW_OBJECT_TRUSTED_LOGINS "")"
-ACTIVE_MIN_STATE="$(rg_setting REVIEW_GATE_REVIEW_OBJECT_MIN_STATE "any")"
+# `|| exit 1`: rg_setting fails loud on an unparseable assignment; the
+# selftest must not generate cases from a silently-emptied config.
+ACTIVE_CONTEXTS="$(rg_setting REVIEW_GATE_TRUSTED_STATUS_CONTEXTS "Devin Review")" || exit 1
+ACTIVE_SKIPS="$(rg_setting REVIEW_GATE_CHECKRUN_SKIP_PATTERNS "rate limited;skipped;queued")" || exit 1
+ACTIVE_REVIEWERS="$(rg_setting REVIEW_GATE_COMMENT_REVIEWERS "")" || exit 1
+ACTIVE_FLOOR="$(rg_setting REVIEW_GATE_SHA_PREFIX_FLOOR "7")" || exit 1
+ACTIVE_OUTAGE="$(rg_setting REVIEW_GATE_OUTAGE_CONTEXT "vstack-reviewer-outage")" || exit 1
+ACTIVE_TRUSTED_LOGINS="$(rg_setting REVIEW_GATE_REVIEW_OBJECT_TRUSTED_LOGINS "")" || exit 1
+ACTIVE_MIN_STATE="$(rg_setting REVIEW_GATE_REVIEW_OBJECT_MIN_STATE "any")" || exit 1
 
 work="$(mktemp -d)"
 trap 'rm -rf "$work"' EXIT

--- a/skills/review-gate/scripts/review-predicate-selftest.sh
+++ b/skills/review-gate/scripts/review-predicate-selftest.sh
@@ -417,6 +417,17 @@ reviews_set "$(review "reviewer" APPROVED "2026-08-02T18:28:47Z")" \
             "$(review "reviewer" COMMENTED "2026-08-02T18:28:50Z")"
 run "approval NOT superseded by a later COMMENTED (min_state=any)" approved
 
+# PENDING rows are unsubmitted drafts, not review events: one must neither
+# clear a standing changes-requested nor count as evidence.
+reset
+reviews_set "$(review "reviewer" CHANGES_REQUESTED "2026-08-02T18:00:00Z")" \
+            "$(review "reviewer" PENDING "2026-08-02T18:30:00Z")"
+run "a PENDING draft after CHANGES_REQUESTED does not clear the objection" changes-requested
+
+reset
+reviews_set "$(review "reviewer" PENDING)"
+run "a lone PENDING draft is not review evidence" awaiting
+
 # ...but a LATER CHANGES_REQUESTED from the same login does supersede, and
 # fails the whole gate closed.
 reset

--- a/skills/review-gate/scripts/review-predicate-selftest.sh
+++ b/skills/review-gate/scripts/review-predicate-selftest.sh
@@ -41,7 +41,7 @@ predicate="$here/review-predicate.sh"
 # environment/settings. The configured layer generates its cases from these.
 # `|| exit 1`: rg_setting fails loud on an unparseable assignment; the
 # selftest must not generate cases from a silently-emptied config.
-ACTIVE_CONTEXTS="$(rg_setting REVIEW_GATE_TRUSTED_STATUS_CONTEXTS "Devin Review")" || exit 1
+ACTIVE_CONTEXTS="$(rg_setting REVIEW_GATE_TRUSTED_STATUS_CONTEXTS "")" || exit 1
 ACTIVE_SKIPS="$(rg_setting REVIEW_GATE_CHECKRUN_SKIP_PATTERNS "rate limited;skipped;queued")" || exit 1
 ACTIVE_REVIEWERS="$(rg_setting REVIEW_GATE_COMMENT_REVIEWERS "")" || exit 1
 ACTIVE_FLOOR="$(rg_setting REVIEW_GATE_SHA_PREFIX_FLOOR "7")" || exit 1
@@ -331,6 +331,9 @@ run "combined-status read failure" "" 2
 unset GH_SHIM_FAIL
 
 reset
+# The check-runs read only happens for a configured trusted context (the
+# shipped default is empty = source disabled), so force one.
+CFG_CONTEXTS="mech-ctx"
 export GH_SHIM_FAIL=checkruns
 run "check-run read failure" "" 2
 unset GH_SHIM_FAIL

--- a/skills/review-gate/scripts/review-predicate-selftest.sh
+++ b/skills/review-gate/scripts/review-predicate-selftest.sh
@@ -436,6 +436,14 @@ reviews_set "$(review "reviewer" APPROVED "2026-08-02T18:28:47Z")" \
             "$(review "reviewer" CHANGES_REQUESTED "2026-08-02T18:30:00Z")"
 run "APPROVED then later CHANGES_REQUESTED fails closed" changes-requested
 
+# Recency is decided by submitted_at, never by array position: the same
+# cleared objection fed in REVERSED order must still read as cleared.
+reset
+CFG_TRUSTED_LOGINS=""; CFG_MIN_STATE="approved"
+reviews_set "$(review "reviewer" APPROVED "2026-08-02T19:00:00Z")" \
+            "$(review "reviewer" CHANGES_REQUESTED "2026-08-02T18:00:00Z")"
+run "cleared CR fed in reversed array order stays cleared" approved
+
 # ...and an APPROVED that POST-dates the CR clears it again.
 reset
 CFG_TRUSTED_LOGINS=""; CFG_MIN_STATE="approved"

--- a/skills/review-gate/scripts/review-predicate-selftest.sh
+++ b/skills/review-gate/scripts/review-predicate-selftest.sh
@@ -48,6 +48,7 @@ ACTIVE_FLOOR="$(rg_setting REVIEW_GATE_SHA_PREFIX_FLOOR "7")" || exit 1
 ACTIVE_OUTAGE="$(rg_setting REVIEW_GATE_OUTAGE_CONTEXT "vstack-reviewer-outage")" || exit 1
 ACTIVE_TRUSTED_LOGINS="$(rg_setting REVIEW_GATE_REVIEW_OBJECT_TRUSTED_LOGINS "")" || exit 1
 ACTIVE_MIN_STATE="$(rg_setting REVIEW_GATE_REVIEW_OBJECT_MIN_STATE "any")" || exit 1
+ACTIVE_GATE_CONTEXT="$(rg_setting REVIEW_GATE_CONTEXT "Review gate")" || exit 1
 
 work="$(mktemp -d)"
 trap 'rm -rf "$work"' EXIT
@@ -144,6 +145,7 @@ run() { # case-name, expected-verdict, expected-exit
     REVIEW_GATE_OUTAGE_CONTEXT="$CFG_OUTAGE" \
     REVIEW_GATE_REVIEW_OBJECT_TRUSTED_LOGINS="$CFG_TRUSTED_LOGINS" \
     REVIEW_GATE_REVIEW_OBJECT_MIN_STATE="$CFG_MIN_STATE" \
+    REVIEW_GATE_CONTEXT="$CFG_GATE_CONTEXT" \
     GH_REPO="owner/repo" PR_NUMBER=1 HEAD_SHA="$HEAD" PR_AUTHOR="$AUTHOR" \
     "$predicate" 2>/dev/null)"
   rc=$?
@@ -175,6 +177,7 @@ reset() {
   CFG_OUTAGE="$ACTIVE_OUTAGE"
   CFG_TRUSTED_LOGINS="$ACTIVE_TRUSTED_LOGINS"
   CFG_MIN_STATE="$ACTIVE_MIN_STATE"
+  CFG_GATE_CONTEXT="$ACTIVE_GATE_CONTEXT"
 }
 
 # A review login that the ACTIVE config accepts as review-object evidence.
@@ -526,6 +529,16 @@ run "unknown min_state is a config error" "" 2
 reset
 CFG_REVIEWERS="just-a-login-no-pattern"
 run "comment reviewer entry without a pattern is a config error" "" 2
+
+# The gate's own context must never be an evidence source: a posted gate
+# success counting as review evidence would keep the gate green forever.
+reset
+CFG_CONTEXTS="Devin Review;Gate X"; CFG_GATE_CONTEXT="Gate X"
+run "gate context listed as a trusted status context is a config error" "" 2
+
+reset
+CFG_OUTAGE="Gate X"; CFG_GATE_CONTEXT="Gate X"
+run "gate context equal to the outage context is a config error" "" 2
 
 # ================================================================ configured ===
 # The same discipline against THIS repo's resolved trust settings.

--- a/skills/review-gate/scripts/review-predicate-selftest.sh
+++ b/skills/review-gate/scripts/review-predicate-selftest.sh
@@ -479,6 +479,13 @@ CFG_REVIEWERS="mech-bot[bot]:Reviewed commit:"
 comment "other-bot[bot]" "Reviewed commit: \`${HEAD:0:7}\`" >"$fixtures/comments.json"
 run "comment from a DIFFERENT bot than configured is not evidence" awaiting
 
+# The PR author is excluded even when CONFIGURED as the comment reviewer —
+# a bot opening its own update PR must not self-approve it.
+reset
+CFG_REVIEWERS="$AUTHOR:Reviewed commit:"
+comment "$AUTHOR" "Reviewed commit: \`${HEAD:0:7}\`" >"$fixtures/comments.json"
+run "configured comment reviewer that IS the PR author cannot self-approve" awaiting
+
 # Floor mechanism at a non-default value.
 reset
 CFG_REVIEWERS="mech-bot[bot]:Reviewed commit:"; CFG_FLOOR="10"

--- a/skills/review-gate/scripts/review-predicate-selftest.sh
+++ b/skills/review-gate/scripts/review-predicate-selftest.sh
@@ -1,0 +1,566 @@
+#!/usr/bin/env bash
+# Selftest for review-predicate.sh — pins the gate's decision table without
+# touching the network. This is the engine's portable proof: every consumer's
+# CI runs it in a deliberately UNGATED job (a broken predicate approves
+# nothing, so a selftest behind the gate could never run when it matters).
+#
+# Why this exists: the predicate is the single thing standing between
+# "reviewed" and "merged", it is only ever exercised in production, and every
+# widening of its evidence sources is a place the gate could be made to say
+# "approved" when nothing reviewed anything. The dangerous direction is not a
+# false `awaiting` — that is visible and annoying — it is a false `approved`,
+# which is silent. So every case below that ends in `approved` is paired with
+# a near-miss that must NOT.
+#
+# TWO LAYERS:
+#   1. Mechanism layer — env-forced configurations pin every engine behavior
+#      with known values: the evidence sources, the trust model near-misses,
+#      the skip-pattern (pass-without-analysis) filter, review-object trust,
+#      approval non-supersession, fail-loud reads, and config validation.
+#   2. Configured layer — the same approve/near-miss discipline re-derived
+#      from THIS repo's resolved REVIEW_GATE_* settings (env >
+#      vstack.settings.toml > defaults), so a repo trusting a different bot
+#      tests its OWN trust list, not someone else's defaults.
+#
+# Mechanism: a `gh` shim earlier on PATH answers from fixtures and applies any
+# `--jq` filter with real jq, so the predicate runs unmodified. Run:
+#
+#   .agents/skills/review-gate/scripts/review-predicate-selftest.sh
+#
+# Exit 0 = all cases pass. Any failure prints the case, the expectation and
+# what the predicate actually said.
+set -u
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+predicate="$here/review-predicate.sh"
+[ -x "$predicate" ] || { echo "not executable: $predicate" >&2; exit 1; }
+. "$here/lib/settings.sh"
+
+# ------------------------------------------------------------ active config ---
+# Resolved exactly as the predicate resolves it, from the invoking repo's
+# environment/settings. The configured layer generates its cases from these.
+ACTIVE_CONTEXTS="$(rg_setting REVIEW_GATE_TRUSTED_STATUS_CONTEXTS "Devin Review")"
+ACTIVE_SKIPS="$(rg_setting REVIEW_GATE_CHECKRUN_SKIP_PATTERNS "rate limited;skipped;queued")"
+ACTIVE_REVIEWERS="$(rg_setting REVIEW_GATE_COMMENT_REVIEWERS "")"
+ACTIVE_FLOOR="$(rg_setting REVIEW_GATE_SHA_PREFIX_FLOOR "7")"
+ACTIVE_OUTAGE="$(rg_setting REVIEW_GATE_OUTAGE_CONTEXT "vstack-reviewer-outage")"
+ACTIVE_TRUSTED_LOGINS="$(rg_setting REVIEW_GATE_REVIEW_OBJECT_TRUSTED_LOGINS "")"
+ACTIVE_MIN_STATE="$(rg_setting REVIEW_GATE_REVIEW_OBJECT_MIN_STATE "any")"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+HEAD='a1b2c3d4e5f60718293a4b5c6d7e8f9012345678'
+OTHER='ffffffffffffffffffffffffffffffffffffffff'
+AUTHOR='author-under-test'
+
+fixtures="$work/fixtures"
+shim="$work/bin"
+mkdir -p "$fixtures" "$shim"
+
+# The shim: dispatch on the request, honour --jq, and obey a failure switch so
+# the fail-loud path is testable too.
+cat >"$shim/gh" <<'SHIM'
+#!/usr/bin/env bash
+set -u
+url=""; filter=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    api|--paginate|--slurp) ;;
+    -f|-F) shift ;;
+    --jq) shift; filter="$1" ;;
+    graphql) url="graphql" ;;
+    *) [ -z "$url" ] && url="$1" ;;
+  esac
+  shift
+done
+case "$url" in
+  *"/check-runs"*) name=checkruns ;;
+  *"/reviews"*)  name=reviews ;;
+  *"/statuses"*) name=statuses ;;
+  *"/status"*)   name=status ;;
+  *"/issues/"*"/comments"*) name=comments ;;
+  graphql)       name=graphql ;;
+  *"/pulls/"*)   name=pull ;;
+  *) echo "shim: unexpected request: $url" >&2; exit 90 ;;
+esac
+if [ -n "${GH_SHIM_FAIL:-}" ] && [ "$GH_SHIM_FAIL" = "$name" ]; then
+  echo "shim: simulated API failure for $name" >&2
+  exit 1
+fi
+file="$GH_SHIM_FIXTURES/$name.json"
+[ -f "$file" ] || { echo "shim: no fixture $file" >&2; exit 91; }
+if [ -n "$filter" ]; then jq -r "$filter" <"$file"; else cat "$file"; fi
+SHIM
+chmod +x "$shim/gh"
+
+# ------------------------------------------------------------------ helpers ---
+list_items() { # ';'-separated string -> one trimmed non-empty item per line
+  printf '%s' "$1" | tr ';' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -v '^$' || true
+}
+first_item() { list_items "$1" | head -n 1; }
+
+comment() { # login, body
+  jq -n --arg login "$1" --arg body "$2" '[{user:{login:$login},body:$body}]'
+}
+threads() { # isResolved values as args
+  local nodes="[]"
+  for r in "$@"; do nodes="$(jq -c --argjson r "$r" '. + [{isResolved:$r}]' <<<"$nodes")"; done
+  jq -n --argjson nodes "$nodes" \
+    '{data:{repository:{pullRequest:{reviewThreads:{pageInfo:{hasNextPage:false},nodes:$nodes}}}}}'
+}
+review() { # login, state, submitted_at -> one review row (append with reviews_add)
+  jq -n --arg sha "$HEAD" --arg login "$1" --arg state "$2" --arg at "${3:-2026-01-01T00:00:00Z}" \
+    '{commit_id:$sha,state:$state,submitted_at:$at,user:{login:$login}}'
+}
+reviews_set() { # rows... -> reviews.json
+  local rows="[]" row
+  for row in "$@"; do rows="$(jq -c --argjson r "$row" '. + [$r]' <<<"$rows")"; done
+  printf '%s\n' "$rows" >"$fixtures/reviews.json"
+}
+checkrun() { # name, conclusion, summary -> checkruns.json
+  jq -n --arg name "$1" --arg conclusion "$2" --arg summary "${3:-}" \
+    '{check_runs:[{name:$name,conclusion:$conclusion,output:{title:null,summary:$summary}}]}' \
+    >"$fixtures/checkruns.json"
+}
+status_ctx() { # context, state, description -> status.json
+  jq -n --arg ctx "$1" --arg state "$2" --arg desc "${3:-}" \
+    '{statuses:[{context:$ctx,state:$state,description:$desc}]}' >"$fixtures/status.json"
+}
+
+cases=0
+failures=0
+run() { # case-name, expected-verdict, expected-exit
+  local name="$1" want="$2" want_exit="${3:-0}" line rc verdict
+  cases=$((cases + 1))
+  line="$(PATH="$shim:$PATH" GH_SHIM_FIXTURES="$fixtures" \
+    REVIEW_GATE_SETTINGS_FILE=/dev/null \
+    REVIEW_GATE_TRUSTED_STATUS_CONTEXTS="$CFG_CONTEXTS" \
+    REVIEW_GATE_CHECKRUN_SKIP_PATTERNS="$CFG_SKIPS" \
+    REVIEW_GATE_COMMENT_REVIEWERS="$CFG_REVIEWERS" \
+    REVIEW_GATE_SHA_PREFIX_FLOOR="$CFG_FLOOR" \
+    REVIEW_GATE_OUTAGE_CONTEXT="$CFG_OUTAGE" \
+    REVIEW_GATE_REVIEW_OBJECT_TRUSTED_LOGINS="$CFG_TRUSTED_LOGINS" \
+    REVIEW_GATE_REVIEW_OBJECT_MIN_STATE="$CFG_MIN_STATE" \
+    GH_REPO="owner/repo" PR_NUMBER=1 HEAD_SHA="$HEAD" PR_AUTHOR="$AUTHOR" \
+    "$predicate" 2>/dev/null)"
+  rc=$?
+  verdict="${line#verdict=}"; verdict="${verdict%% *}"
+  if [ "$rc" != "$want_exit" ]; then
+    echo "FAIL  $name: exit $rc, wanted $want_exit" >&2
+    failures=$((failures + 1))
+    return
+  fi
+  if [ "$want_exit" = "0" ] && [ "$verdict" != "$want" ]; then
+    echo "FAIL  $name: verdict=$verdict, wanted $want" >&2
+    failures=$((failures + 1))
+    return
+  fi
+  echo "ok    $name ($want)"
+}
+reset() {
+  printf '[]\n' >"$fixtures/reviews.json"
+  printf '[]\n' >"$fixtures/comments.json"
+  printf '{"check_runs":[]}\n' >"$fixtures/checkruns.json"
+  printf '{"statuses":[]}\n' >"$fixtures/status.json"
+  threads >"$fixtures/graphql.json"
+  jq -n --arg a "$AUTHOR" '{user:{login:$a}}' >"$fixtures/pull.json"
+  unset GH_SHIM_FAIL || true
+  CFG_CONTEXTS="$ACTIVE_CONTEXTS"
+  CFG_SKIPS="$ACTIVE_SKIPS"
+  CFG_REVIEWERS="$ACTIVE_REVIEWERS"
+  CFG_FLOOR="$ACTIVE_FLOOR"
+  CFG_OUTAGE="$ACTIVE_OUTAGE"
+  CFG_TRUSTED_LOGINS="$ACTIVE_TRUSTED_LOGINS"
+  CFG_MIN_STATE="$ACTIVE_MIN_STATE"
+}
+
+# A review login that the ACTIVE config accepts as review-object evidence.
+trusted_reviewer() {
+  if [ -n "$ACTIVE_TRUSTED_LOGINS" ]; then first_item "$ACTIVE_TRUSTED_LOGINS"; else echo "reviewer"; fi
+}
+
+# The full comment-form battery for one 'login:pattern' pair. Every approving
+# case is paired with the near-misses that decide whether the carve-out is a
+# trust model or a grep.
+comment_battery() { # login, pattern, floor
+  local login="$1" pattern="$2" floor="$3" prefix short
+  prefix="$(printf '%.*s' "$floor" "$HEAD")"
+
+  reset
+  CFG_REVIEWERS="$login:$pattern"; CFG_FLOOR="$floor"
+  comment "$login" "$pattern \`$prefix\`" >"$fixtures/comments.json"
+  run "[$login] comment, backtick-quoted floor-length sha at head" approved
+
+  reset
+  CFG_REVIEWERS="$login:$pattern"; CFG_FLOOR="$floor"
+  comment "$login" "$pattern $HEAD" >"$fixtures/comments.json"
+  run "[$login] comment, full 40-char sha at head" approved
+
+  # Markdown decoration between the binding pattern and the sha (bold label,
+  # backticks) — the real shipped shape of at least one live bot.
+  reset
+  CFG_REVIEWERS="$login:$pattern"; CFG_FLOOR="$floor"
+  comment "$login" "**Clean pass.** **$pattern** \`$prefix\`" >"$fixtures/comments.json"
+  run "[$login] comment with markdown-decorated binding line" approved
+
+  # Trust keys on the AUTHOR, so the same words from anyone else are not
+  # evidence: a PR author could otherwise approve their own PR by typing a
+  # sentence.
+  reset
+  CFG_REVIEWERS="$login:$pattern"; CFG_FLOOR="$floor"
+  comment "mallory" "$pattern \`$prefix\`" >"$fixtures/comments.json"
+  run "[$login] SAME BODY, wrong author" awaiting
+
+  reset
+  CFG_REVIEWERS="$login:$pattern"; CFG_FLOOR="$floor"
+  comment "$AUTHOR" "$pattern \`$prefix\`" >"$fixtures/comments.json"
+  run "[$login] same body, posted by the PR AUTHOR" awaiting
+
+  # The body binds the evidence to a commit, so a comment about an earlier
+  # push must not vouch for what was pushed after it.
+  reset
+  CFG_REVIEWERS="$login:$pattern"; CFG_FLOOR="$floor"
+  comment "$login" "$pattern \`$(printf '%.*s' "$floor" "$OTHER")\`" >"$fixtures/comments.json"
+  run "[$login] comment naming a DIFFERENT sha" awaiting
+
+  reset
+  CFG_REVIEWERS="$login:$pattern"; CFG_FLOOR="$floor"
+  comment "$login" "Clean pass, no binding line here." >"$fixtures/comments.json"
+  run "[$login] comment with no binding line" awaiting
+
+  # A degenerate prefix must not match every head (the floor).
+  short="$(printf '%.*s' "$((floor - 1))" "$HEAD")"
+  reset
+  CFG_REVIEWERS="$login:$pattern"; CFG_FLOOR="$floor"
+  comment "$login" "$pattern \`$short\`" >"$fixtures/comments.json"
+  run "[$login] comment with a sub-floor sha prefix" awaiting
+
+  # Evidence-present is not evidence-approves-everything: the carve-out
+  # substitutes for MISSING evidence only.
+  reset
+  CFG_REVIEWERS="$login:$pattern"; CFG_FLOOR="$floor"
+  comment "$login" "$pattern \`$prefix\`" >"$fixtures/comments.json"
+  threads false >"$fixtures/graphql.json"
+  run "[$login] clean comment + an unresolved thread" threads-open
+
+  reset
+  CFG_REVIEWERS="$login:$pattern"; CFG_FLOOR="$floor"
+  comment "$login" "$pattern \`$prefix\`" >"$fixtures/comments.json"
+  reviews_set "$(review "reviewer" CHANGES_REQUESTED)"
+  run "[$login] clean comment + changes-requested at head" changes-requested
+
+  # A transient read failure must reach NO verdict (exit 2), never
+  # "awaiting": acting on an API hiccup could flip a healthy PR's merge
+  # state.
+  reset
+  CFG_REVIEWERS="$login:$pattern"; CFG_FLOOR="$floor"
+  export GH_SHIM_FAIL=comments
+  run "[$login] comment read failure" "" 2
+  unset GH_SHIM_FAIL
+}
+
+# Approve/near-miss battery for one trusted check/status context, including
+# the pass-without-analysis (skip-pattern) filter.
+context_battery() { # context
+  local ctx="$1" pat
+
+  reset
+  status_ctx "$ctx" success "analysis complete"
+  run "[$ctx] clean commit status at head" approved
+
+  reset
+  status_ctx "$ctx (untrusted twin)" success "analysis complete"
+  run "[$ctx] status under a DIFFERENT context name" awaiting
+
+  reset
+  status_ctx "$ctx" pending "still running"
+  run "[$ctx] non-success status" awaiting
+
+  reset
+  checkrun "$ctx" success "0 findings"
+  run "[$ctx] clean check-run at head" approved
+
+  reset
+  checkrun "$ctx (untrusted twin)" success "0 findings"
+  run "[$ctx] check-run under a DIFFERENT name" awaiting
+
+  reset
+  checkrun "$ctx" neutral "analysis skipped"
+  run "[$ctx] non-success check-run" awaiting
+
+  # A trusted "pass" must prove analysis RAN: a success whose output matches
+  # a skip pattern performed no review, so it is NOT-EVIDENCE (awaiting, the
+  # silence path) — never a failure.
+  while IFS= read -r pat; do
+    [ -z "$pat" ] && continue
+    reset
+    checkrun "$ctx" success "Review $pat"
+    run "[$ctx] success check-run but output says '$pat' (not evidence)" awaiting
+    reset
+    status_ctx "$ctx" success "Review $pat"
+    run "[$ctx] success status but description says '$pat' (not evidence)" awaiting
+  done <<EOF
+$(list_items "$CFG_SKIPS")
+EOF
+}
+
+# ================================================================ mechanism ===
+# Env-forced configurations: these pin every engine behavior regardless of the
+# invoking repo's own trust settings.
+echo "--- mechanism layer (forced configuration)"
+
+# Guards the whole suite: if this ever says `approved`, some evidence source
+# has become unconditionally true and every case below is meaningless.
+reset
+run "no evidence at all" awaiting
+
+reset
+export GH_SHIM_FAIL=reviews
+run "review read failure" "" 2
+unset GH_SHIM_FAIL
+
+reset
+export GH_SHIM_FAIL=status
+run "combined-status read failure" "" 2
+unset GH_SHIM_FAIL
+
+reset
+export GH_SHIM_FAIL=checkruns
+run "check-run read failure" "" 2
+unset GH_SHIM_FAIL
+
+reset
+status_ctx "mech-ctx" success "analysis complete"
+CFG_CONTEXTS="mech-ctx"
+export GH_SHIM_FAIL=graphql
+run "thread read failure (with evidence present)" "" 2
+unset GH_SHIM_FAIL
+
+# >100 threads is a SUCCESSFUL read we cannot fully verify: fail closed to
+# threads-open, never open the gate.
+reset
+CFG_CONTEXTS="mech-ctx"
+status_ctx "mech-ctx" success "analysis complete"
+jq -n '{data:{repository:{pullRequest:{reviewThreads:{pageInfo:{hasNextPage:true},nodes:[]}}}}}' \
+  >"$fixtures/graphql.json"
+run "thread overflow (>100) fails closed" threads-open
+
+# A thread node whose isResolved is not a boolean (null/missing) must never
+# count as resolved — that direction is a false approval on a merge gate.
+reset
+CFG_CONTEXTS="mech-ctx"
+status_ctx "mech-ctx" success "analysis complete"
+jq -n '{data:{repository:{pullRequest:{reviewThreads:{pageInfo:{hasNextPage:false},nodes:[{isResolved:null},{isResolved:true}]}}}}}' \
+  >"$fixtures/graphql.json"
+run "malformed thread node (isResolved null) fails closed" threads-open
+
+# Review-object trust list: empty trusts any non-author (adoption-compatible
+# default); non-empty restricts evidence to the listed logins. An untrusted
+# login's review must NOT count — this is the boundary where any read-access
+# collaborator's drive-by review would otherwise satisfy the gate.
+reset
+CFG_TRUSTED_LOGINS=""
+reviews_set "$(review "rando" APPROVED)"
+run "empty trust list: any non-author review counts" approved
+
+reset
+CFG_TRUSTED_LOGINS="trusted-bot;other-bot"
+reviews_set "$(review "rando" APPROVED)"
+run "trust list set: UNTRUSTED login's review is not evidence" awaiting
+
+reset
+CFG_TRUSTED_LOGINS="trusted-bot;other-bot"
+reviews_set "$(review "trusted-bot" APPROVED)"
+run "trust list set: trusted login's review counts" approved
+
+reset
+CFG_TRUSTED_LOGINS="trusted-bot"
+reviews_set "$(review "$AUTHOR" APPROVED)"
+CFG_TRUSTED_LOGINS="trusted-bot;$AUTHOR"
+run "trust list set: the PR author is never evidence, even when listed" awaiting
+
+# min_state=approved: a body-only COMMENTED review stops satisfying the gate.
+reset
+CFG_TRUSTED_LOGINS=""; CFG_MIN_STATE="approved"
+reviews_set "$(review "reviewer" COMMENTED)"
+run "min_state=approved: COMMENTED-only review is not evidence" awaiting
+
+reset
+CFG_TRUSTED_LOGINS=""; CFG_MIN_STATE="approved"
+reviews_set "$(review "reviewer" APPROVED)"
+run "min_state=approved: APPROVED review counts" approved
+
+reset
+CFG_TRUSTED_LOGINS=""; CFG_MIN_STATE="any"
+reviews_set "$(review "reviewer" COMMENTED)"
+run "min_state=any: COMMENTED review counts (compatible default)" approved
+
+# NON-SUPERSESSION: a trailing COMMENTED from the same reviewer at the same
+# head must not mask its earlier APPROVED (observed live: APPROVED at
+# :47, COMMENTED at :50 on the same commit — a latest-review-per-reviewer
+# reduction reads that as "no approval").
+reset
+CFG_TRUSTED_LOGINS=""; CFG_MIN_STATE="approved"
+reviews_set "$(review "reviewer" APPROVED "2026-08-02T18:28:47Z")" \
+            "$(review "reviewer" COMMENTED "2026-08-02T18:28:50Z")"
+run "approval NOT superseded by a later COMMENTED (min_state=approved)" approved
+
+reset
+CFG_TRUSTED_LOGINS=""; CFG_MIN_STATE="any"
+reviews_set "$(review "reviewer" APPROVED "2026-08-02T18:28:47Z")" \
+            "$(review "reviewer" COMMENTED "2026-08-02T18:28:50Z")"
+run "approval NOT superseded by a later COMMENTED (min_state=any)" approved
+
+# ...but a LATER CHANGES_REQUESTED from the same login does supersede, and
+# fails the whole gate closed.
+reset
+CFG_TRUSTED_LOGINS=""; CFG_MIN_STATE="approved"
+reviews_set "$(review "reviewer" APPROVED "2026-08-02T18:28:47Z")" \
+            "$(review "reviewer" CHANGES_REQUESTED "2026-08-02T18:30:00Z")"
+run "APPROVED then later CHANGES_REQUESTED fails closed" changes-requested
+
+# ...and an APPROVED that POST-dates the CR clears it again.
+reset
+CFG_TRUSTED_LOGINS=""; CFG_MIN_STATE="approved"
+reviews_set "$(review "reviewer" CHANGES_REQUESTED "2026-08-02T18:28:47Z")" \
+            "$(review "reviewer" APPROVED "2026-08-02T18:30:00Z")"
+run "CHANGES_REQUESTED then later APPROVED re-opens" approved
+
+# Changes-requested fails closed regardless of the trust list: anyone's
+# standing objection blocks.
+reset
+CFG_TRUSTED_LOGINS="trusted-bot"
+reviews_set "$(review "trusted-bot" APPROVED)" "$(review "rando" CHANGES_REQUESTED)"
+run "trusted approval + untrusted changes-requested fails closed" changes-requested
+
+# The pass-without-analysis filter, pinned against the live fixture shape: a
+# rate-limited reviewer posted its own check as PASS with "Review rate
+# limited" and zero analysis performed.
+reset
+CFG_CONTEXTS="mech-ctx"; CFG_SKIPS="rate limited"
+printf '{"check_runs":[{"name":"mech-ctx","conclusion":"success","output":{"title":"mech-ctx","summary":"Review rate limited. 0 files reviewed."}}]}\n' \
+  >"$fixtures/checkruns.json"
+run "rate-limited 'pass' check-run is NOT evidence (live fixture)" awaiting
+
+reset
+CFG_CONTEXTS="mech-ctx"; CFG_SKIPS="rate limited"
+checkrun "mech-ctx" success "Reviewed 12 files, 0 findings"
+run "genuine clean pass still counts with skip patterns set" approved
+
+reset
+CFG_CONTEXTS="mech-ctx"; CFG_SKIPS=""
+checkrun "mech-ctx" success "Review rate limited. 0 files reviewed."
+run "empty skip patterns disable the filter (explicit repo choice)" approved
+
+# Skip-pattern matching is case-insensitive.
+reset
+CFG_CONTEXTS="mech-ctx"; CFG_SKIPS="rate limited"
+checkrun "mech-ctx" success "Review RATE LIMITED"
+run "skip patterns match case-insensitively" awaiting
+
+# Comment-form mechanism with a forced pair, including a regex-metacharacter
+# binding pattern: the pattern is a LITERAL, so metacharacters must not widen
+# the match.
+comment_battery "mech-bot[bot]" "Analysis (clean) for commit:" 7
+
+reset
+CFG_REVIEWERS=""
+comment "some-bot[bot]" "Reviewed commit: \`${HEAD:0:7}\`" >"$fixtures/comments.json"
+run "no comment reviewers configured: perfect binding line is not evidence" awaiting
+
+reset
+CFG_REVIEWERS="mech-bot[bot]:Reviewed commit:"
+comment "other-bot[bot]" "Reviewed commit: \`${HEAD:0:7}\`" >"$fixtures/comments.json"
+run "comment from a DIFFERENT bot than configured is not evidence" awaiting
+
+# Floor mechanism at a non-default value.
+reset
+CFG_REVIEWERS="mech-bot[bot]:Reviewed commit:"; CFG_FLOOR="10"
+comment "mech-bot[bot]" "Reviewed commit: \`${HEAD:0:7}\`" >"$fixtures/comments.json"
+run "floor=10: 7-char prefix is not evidence" awaiting
+
+reset
+CFG_REVIEWERS="mech-bot[bot]:Reviewed commit:"; CFG_FLOOR="10"
+comment "mech-bot[bot]" "Reviewed commit: \`${HEAD:0:10}\`" >"$fixtures/comments.json"
+run "floor=10: 10-char prefix counts" approved
+
+# Outage attestation substitutes for MISSING evidence only.
+reset
+CFG_OUTAGE="mech-outage"
+status_ctx "mech-outage" success "reviewer outage attested"
+run "outage attestation counts as evidence" approved
+
+reset
+CFG_OUTAGE="mech-outage"
+status_ctx "mech-outage" pending "attempting"
+run "non-success outage status is not evidence" awaiting
+
+reset
+CFG_OUTAGE="mech-outage"
+status_ctx "mech-outage" success "reviewer outage attested"
+threads false >"$fixtures/graphql.json"
+run "outage attestation + unresolved thread stays closed" threads-open
+
+reset
+CFG_OUTAGE=""
+status_ctx "vstack-reviewer-outage" success "reviewer outage attested"
+run "empty outage context disables the source" awaiting
+
+# Invalid configuration must reach NO verdict (exit 2) — a typo in trust
+# config must never quietly widen or narrow the gate.
+reset
+CFG_FLOOR="abc"
+run "non-numeric sha floor is a config error" "" 2
+
+reset
+CFG_FLOOR="3"
+run "sha floor below 4 is a config error" "" 2
+
+reset
+CFG_TRUSTED_LOGINS=""; CFG_MIN_STATE="bogus"
+run "unknown min_state is a config error" "" 2
+
+reset
+CFG_REVIEWERS="just-a-login-no-pattern"
+run "comment reviewer entry without a pattern is a config error" "" 2
+
+# ================================================================ configured ===
+# The same discipline against THIS repo's resolved trust settings.
+echo "--- configured layer (this repo's REVIEW_GATE_* settings)"
+
+reset
+reviews_set "$(review "$(trusted_reviewer)" APPROVED)"
+run "configured: accepted non-author review object" approved
+
+if [ -n "$ACTIVE_TRUSTED_LOGINS" ]; then
+  reset
+  reviews_set "$(review "not-on-the-trust-list" APPROVED)"
+  run "configured: login outside the repo trust list is not evidence" awaiting
+fi
+
+while IFS= read -r ctx; do
+  [ -z "$ctx" ] && continue
+  context_battery "$ctx"
+done <<EOF
+$(list_items "$ACTIVE_CONTEXTS")
+EOF
+
+while IFS= read -r pair; do
+  [ -z "$pair" ] && continue
+  comment_battery "${pair%%:*}" "${pair#*:}" "$ACTIVE_FLOOR"
+done <<EOF
+$(list_items "$ACTIVE_REVIEWERS")
+EOF
+
+if [ -n "$ACTIVE_OUTAGE" ]; then
+  reset
+  status_ctx "$ACTIVE_OUTAGE" success "reviewer outage attested"
+  run "configured: outage attestation ($ACTIVE_OUTAGE)" approved
+fi
+
+if [ "$failures" -ne 0 ]; then
+  echo "review-predicate selftest: $failures of $cases case(s) FAILED" >&2
+  exit 1
+fi
+echo "review-predicate selftest: $cases case(s), all pass"

--- a/skills/review-gate/scripts/review-predicate-selftest.sh
+++ b/skills/review-gate/scripts/review-predicate-selftest.sh
@@ -112,8 +112,8 @@ threads() { # isResolved values as args
   jq -n --argjson nodes "$nodes" \
     '{data:{repository:{pullRequest:{reviewThreads:{pageInfo:{hasNextPage:false},nodes:$nodes}}}}}'
 }
-review() { # login, state, submitted_at -> one review row (append with reviews_add)
-  jq -n --arg sha "$HEAD" --arg login "$1" --arg state "$2" --arg at "${3:-2026-01-01T00:00:00Z}" \
+review() { # login, state, submitted_at, [commit sha; default HEAD] -> one review row
+  jq -n --arg sha "${4:-$HEAD}" --arg login "$1" --arg state "$2" --arg at "${3:-2026-01-01T00:00:00Z}" \
     '{commit_id:$sha,state:$state,submitted_at:$at,user:{login:$login}}'
 }
 reviews_set() { # rows... -> reviews.json
@@ -446,6 +446,22 @@ CFG_TRUSTED_LOGINS=""; CFG_MIN_STATE="approved"
 reviews_set "$(review "reviewer" APPROVED "2026-08-02T19:00:00Z")" \
             "$(review "reviewer" CHANGES_REQUESTED "2026-08-02T18:00:00Z")"
 run "cleared CR fed in reversed array order stays cleared" approved
+
+# An objection persists ACROSS PUSHES: GitHub does not clear a
+# changes-requested when the author pushes a new head, so evidence on the
+# fresh head must not open the gate past it...
+reset
+CFG_TRUSTED_LOGINS=""; CFG_MIN_STATE="any"
+reviews_set "$(review "objector" CHANGES_REQUESTED "2026-08-02T18:00:00Z" "$OTHER")" \
+            "$(review "reviewer" APPROVED "2026-08-02T19:00:00Z")"
+run "CR on a previous commit still blocks a freshly-approved head" changes-requested
+
+# ...and a later APPROVED from the same reviewer (at the new head) clears it.
+reset
+CFG_TRUSTED_LOGINS=""; CFG_MIN_STATE="any"
+reviews_set "$(review "objector" CHANGES_REQUESTED "2026-08-02T18:00:00Z" "$OTHER")" \
+            "$(review "objector" APPROVED "2026-08-02T19:00:00Z")"
+run "the objector re-approving at the new head clears their old-commit CR" approved
 
 # An objection is never withdrawn by a later COMMENT — the mirror of the
 # approval-is-never-superseded rule. GitHub keeps requested changes standing

--- a/skills/review-gate/scripts/review-predicate.sh
+++ b/skills/review-gate/scripts/review-predicate.sh
@@ -151,14 +151,18 @@ reviews="$(jq -s 'add // []' <<<"$raw_reviews")" || {
   echo "::error::could not parse reviews for PR #$PR_NUMBER" >&2
   exit 2
 }
-# Changes-requested counts only each reviewer's LATEST non-dismissed review on
-# the head, so a superseded CR that the same reviewer later cleared can't pin
-# the PR red forever. Deliberately unfiltered by the trust list: anyone's
-# standing objection fails the gate closed. PENDING rows (unsubmitted drafts,
-# visible when the token authored them) are excluded EVERYWHERE: a draft is
-# not a review event — it must neither clear a standing CR here nor count as
-# evidence below.
-cr="$(jq --arg sha "$HEAD_SHA" '[.[] | select(.commit_id == $sha and .state != "DISMISSED" and .state != "PENDING")] | group_by(.user.login) | map(sort_by(.submitted_at // "") | .[-1]) | map(select(.state == "CHANGES_REQUESTED")) | length' <<<"$reviews")" || {
+# Changes-requested reduces each reviewer over their DECISIVE states only
+# (APPROVED / CHANGES_REQUESTED, ordered by submitted_at): a later APPROVED
+# clears that reviewer's objection, so a superseded CR can't pin the PR red
+# forever — but a trailing COMMENTED row never withdraws one (GitHub itself
+# keeps requested changes standing until re-approval or dismissal), the
+# mirror of the header's approval-is-never-superseded-by-a-comment rule.
+# Deliberately unfiltered by the trust list: anyone's standing objection
+# fails the gate closed. PENDING rows (unsubmitted drafts, visible when the
+# token authored them) are excluded EVERYWHERE: a draft is not a review
+# event — it must neither clear a standing CR here nor count as evidence
+# below.
+cr="$(jq --arg sha "$HEAD_SHA" '[.[] | select(.commit_id == $sha and .state != "DISMISSED" and .state != "PENDING") | select(.state == "APPROVED" or .state == "CHANGES_REQUESTED")] | group_by(.user.login) | map(sort_by(.submitted_at // "") | .[-1]) | map(select(.state == "CHANGES_REQUESTED")) | length' <<<"$reviews")" || {
   echo "::error::could not evaluate changes-requested reviews for PR #$PR_NUMBER" >&2
   exit 2
 }

--- a/skills/review-gate/scripts/review-predicate.sh
+++ b/skills/review-gate/scripts/review-predicate.sh
@@ -183,8 +183,17 @@ while IFS= read -r ctx; do
   ctx="$(printf '%s' "$ctx" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
   [ -z "$ctx" ] && continue
   ctx_uri="$(jq -rn --arg s "$ctx" '$s|@uri')"
-  checkruns_resp="$(gh api "repos/$GH_REPO/commits/$HEAD_SHA/check-runs?check_name=$ctx_uri&per_page=50")" || {
+  # --paginate emits one OBJECT per page for this endpoint; jq -s merges the
+  # pages' check_runs arrays so a success beyond the first page still counts
+  # (a missed run strands the gate at awaiting — wrong direction to lose).
+  # Fetch and merge are SEPARATE steps: a pipe would replace gh's exit status
+  # with jq's and turn a read failure into an empty-success (fail-open).
+  checkruns_pages="$(gh api "repos/$GH_REPO/commits/$HEAD_SHA/check-runs?check_name=$ctx_uri&per_page=100" --paginate)" || {
     echo "::error::could not read '$ctx' check-runs" >&2
+    exit 2
+  }
+  checkruns_resp="$(jq -s '{check_runs: (map(.check_runs) | add // [])}' <<<"$checkruns_pages")" || {
+    echo "::error::could not merge '$ctx' check-run pages" >&2
     exit 2
   }
   # Bind each skip pattern to a variable BEFORE testing containment: inside

--- a/skills/review-gate/scripts/review-predicate.sh
+++ b/skills/review-gate/scripts/review-predicate.sh
@@ -154,8 +154,11 @@ reviews="$(jq -s 'add // []' <<<"$raw_reviews")" || {
 # Changes-requested counts only each reviewer's LATEST non-dismissed review on
 # the head, so a superseded CR that the same reviewer later cleared can't pin
 # the PR red forever. Deliberately unfiltered by the trust list: anyone's
-# standing objection fails the gate closed.
-cr="$(jq --arg sha "$HEAD_SHA" '[.[] | select(.commit_id == $sha and .state != "DISMISSED")] | group_by(.user.login) | map(.[-1]) | map(select(.state == "CHANGES_REQUESTED")) | length' <<<"$reviews")" || {
+# standing objection fails the gate closed. PENDING rows (unsubmitted drafts,
+# visible when the token authored them) are excluded EVERYWHERE: a draft is
+# not a review event — it must neither clear a standing CR here nor count as
+# evidence below.
+cr="$(jq --arg sha "$HEAD_SHA" '[.[] | select(.commit_id == $sha and .state != "DISMISSED" and .state != "PENDING")] | group_by(.user.login) | map(.[-1]) | map(select(.state == "CHANGES_REQUESTED")) | length' <<<"$reviews")" || {
   echo "::error::could not evaluate changes-requested reviews for PR #$PR_NUMBER" >&2
   exit 2
 }
@@ -168,7 +171,7 @@ got="$(jq --arg sha "$HEAD_SHA" --arg author "$PR_AUTHOR" \
         --arg trusted "$TRUSTED_LOGINS" --arg minstate "$MIN_STATE" '
   ($trusted | split("[;,\n]+"; "") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0))) as $t
   | [ .[]
-      | select(.commit_id == $sha and .state != "DISMISSED" and .user.login != $author)
+      | select(.commit_id == $sha and .state != "DISMISSED" and .state != "PENDING" and .user.login != $author)
       | select(($t | length) == 0 or (.user.login as $l | ($t | index($l)) != null))
     ]
   | if $minstate == "approved" then

--- a/skills/review-gate/scripts/review-predicate.sh
+++ b/skills/review-gate/scripts/review-predicate.sh
@@ -158,7 +158,7 @@ reviews="$(jq -s 'add // []' <<<"$raw_reviews")" || {
 # visible when the token authored them) are excluded EVERYWHERE: a draft is
 # not a review event — it must neither clear a standing CR here nor count as
 # evidence below.
-cr="$(jq --arg sha "$HEAD_SHA" '[.[] | select(.commit_id == $sha and .state != "DISMISSED" and .state != "PENDING")] | group_by(.user.login) | map(.[-1]) | map(select(.state == "CHANGES_REQUESTED")) | length' <<<"$reviews")" || {
+cr="$(jq --arg sha "$HEAD_SHA" '[.[] | select(.commit_id == $sha and .state != "DISMISSED" and .state != "PENDING")] | group_by(.user.login) | map(sort_by(.submitted_at // "") | .[-1]) | map(select(.state == "CHANGES_REQUESTED")) | length' <<<"$reviews")" || {
   echo "::error::could not evaluate changes-requested reviews for PR #$PR_NUMBER" >&2
   exit 2
 }

--- a/skills/review-gate/scripts/review-predicate.sh
+++ b/skills/review-gate/scripts/review-predicate.sh
@@ -17,7 +17,10 @@
 #       login whose body binds the evidence to this head's sha;
 #   (d) the trusted reviewer-outage attestation status — substitutes for
 #       MISSING evidence only;
-# AND no changes-requested against the head AND zero unresolved review
+# AND no STANDING changes-requested (each reviewer's latest decisive review
+# across the WHOLE PR — GitHub keeps an objection standing across pushes
+# until re-approval or dismissal, so the reduction must not be scoped to the
+# head; positive evidence stays exact-head) AND zero unresolved review
 # threads. Changes-requested and unresolved threads always fail closed, even
 # with evidence present.
 #
@@ -152,17 +155,20 @@ reviews="$(jq -s 'add // []' <<<"$raw_reviews")" || {
   exit 2
 }
 # Changes-requested reduces each reviewer over their DECISIVE states only
-# (APPROVED / CHANGES_REQUESTED, ordered by submitted_at): a later APPROVED
-# clears that reviewer's objection, so a superseded CR can't pin the PR red
-# forever — but a trailing COMMENTED row never withdraws one (GitHub itself
-# keeps requested changes standing until re-approval or dismissal), the
-# mirror of the header's approval-is-never-superseded-by-a-comment rule.
-# Deliberately unfiltered by the trust list: anyone's standing objection
-# fails the gate closed. PENDING rows (unsubmitted drafts, visible when the
-# token authored them) are excluded EVERYWHERE: a draft is not a review
-# event — it must neither clear a standing CR here nor count as evidence
-# below.
-cr="$(jq --arg sha "$HEAD_SHA" '[.[] | select(.commit_id == $sha and .state != "DISMISSED" and .state != "PENDING") | select(.state == "APPROVED" or .state == "CHANGES_REQUESTED")] | group_by(.user.login) | map(sort_by(.submitted_at // "") | .[-1]) | map(select(.state == "CHANGES_REQUESTED")) | length' <<<"$reviews")" || {
+# (APPROVED / CHANGES_REQUESTED, ordered by submitted_at) across the WHOLE
+# PR — never scoped to the head: GitHub keeps an objection standing when the
+# author pushes new commits, so a head-scoped reduction would let any
+# evidence source on the fresh head open the gate past a standing human
+# objection. A later APPROVED from the same reviewer (on any commit) clears
+# it, so a superseded CR can't pin the PR red forever — but a trailing
+# COMMENTED row never withdraws one (GitHub itself keeps requested changes
+# standing until re-approval or dismissal), the mirror of the header's
+# approval-is-never-superseded-by-a-comment rule. Deliberately unfiltered by
+# the trust list: anyone's standing objection fails the gate closed. PENDING
+# rows (unsubmitted drafts, visible when the token authored them) are
+# excluded EVERYWHERE: a draft is not a review event — it must neither clear
+# a standing CR here nor count as evidence below.
+cr="$(jq '[.[] | select(.state != "DISMISSED" and .state != "PENDING") | select(.state == "APPROVED" or .state == "CHANGES_REQUESTED")] | group_by(.user.login) | map(sort_by(.submitted_at // "") | .[-1]) | map(select(.state == "CHANGES_REQUESTED")) | length' <<<"$reviews")" || {
   echo "::error::could not evaluate changes-requested reviews for PR #$PR_NUMBER" >&2
   exit 2
 }
@@ -366,7 +372,7 @@ unresolved="$(gh api graphql \
 echo "PR #$PR_NUMBER head $HEAD_SHA: reviews=$got clean-analysis=$check comment-form=$comment_hits outage-marker=$outageok changes-requested=$cr unresolved-threads=$unresolved" >&2
 
 if [ "$cr" != "0" ]; then
-  echo "verdict=changes-requested detail=review changes requested on the current head"
+  echo "verdict=changes-requested detail=standing review changes requested (persists across pushes until re-approval or dismissal)"
 elif [ "$got" = "0" ] && [ "$check" = "0" ] && [ "$comment_hits" = "0" ] && [ "$outageok" = "0" ]; then
   echo "verdict=awaiting detail=awaiting a non-author review for $HEAD_SHA"
 elif [ "$unresolved" != "0" ]; then

--- a/skills/review-gate/scripts/review-predicate.sh
+++ b/skills/review-gate/scripts/review-predicate.sh
@@ -1,0 +1,319 @@
+#!/usr/bin/env bash
+# Review-gate predicate — the single source of truth for "is this PR head
+# reviewed?". Shipped by the vstack review-gate skill and vendored into
+# consumers at .agents/skills/review-gate/scripts/. Callers: the repo's CI
+# gate job (posts the merge-blocking commit status from the verdict) and
+# approval-refire.sh (converges the status when review state changes).
+#
+# Predicate: review evidence present for the CURRENT head — any of
+#   (a) a review OBJECT at the exact head from a non-author, non-dismissed,
+#       trusted login (trust list empty = any non-author);
+#   (b) a trusted clean-analysis CHECK-RUN or legacy COMMIT STATUS succeeding
+#       on this head, whose title/summary/description carries no
+#       skip-pattern marker (a "pass" that says the analysis was rate
+#       limited, skipped or queued proves nothing ran — it is silence, not
+#       approval, and routes to NOT-EVIDENCE, never to failure);
+#   (c) a trusted comment-form clean pass: an issue comment by a trusted bot
+#       login whose body binds the evidence to this head's sha;
+#   (d) the trusted reviewer-outage attestation status — substitutes for
+#       MISSING evidence only;
+# AND no changes-requested against the head AND zero unresolved review
+# threads. Changes-requested and unresolved threads always fail closed, even
+# with evidence present.
+#
+# APPROVAL IS NEVER SUPERSEDED BY A LATER COMMENT. The evidence reduction is
+# "an accepted review row exists at head" — never "the latest review per
+# reviewer" — so a reviewer that posts APPROVED and then a trailing COMMENTED
+# on the same commit still counts as approval. Only a LATER
+# CHANGES_REQUESTED from the same login withdraws it (and the separate
+# changes-requested term fails the gate then anyway). The selftest pins this.
+#
+# TRUST MODEL: trust keys on NAMES ONLY GITHUB CONTROLS — the author login of
+# a review or comment (exact match on the app's bot login) or the exact
+# context/name of a check/status on repos where every publisher is trusted. A
+# comment BODY is never trusted to establish trust; it is read only to BIND
+# the evidence to a specific commit, so a stale comment cannot vouch for a
+# later push.
+#
+# Per-repo trust configuration comes from REVIEW_GATE_* settings — explicit
+# environment first, then the repo's vstack.settings.toml, then built-in
+# defaults (lib/settings.sh). Keys read here:
+#   REVIEW_GATE_TRUSTED_STATUS_CONTEXTS       (b) check/status names, ';'-separated
+#   REVIEW_GATE_CHECKRUN_SKIP_PATTERNS        (b) pass-without-analysis markers, ';'-separated,
+#                                             case-insensitive substrings; empty disables
+#   REVIEW_GATE_COMMENT_REVIEWERS             (c) 'login:binding-pattern' pairs, ';'-separated
+#                                             (first ':' splits; pattern is a literal prefix)
+#   REVIEW_GATE_SHA_PREFIX_FLOOR              (c) shortest sha prefix a comment may bind
+#   REVIEW_GATE_OUTAGE_CONTEXT                (d) attestation status context; empty disables
+#   REVIEW_GATE_REVIEW_OBJECT_TRUSTED_LOGINS  (a) trust list; empty = any non-author
+#   REVIEW_GATE_REVIEW_OBJECT_MIN_STATE       (a) "any" (any review row) or "approved"
+#                                             (an APPROVED row not withdrawn by a later
+#                                             CHANGES_REQUESTED from the same login)
+#
+# Env (required): GH_TOKEN (or ambient gh auth), GH_REPO, PR_NUMBER, HEAD_SHA
+# Env (optional): PR_AUTHOR — resolved from the PR when empty.
+#
+# Output: one machine-readable line on stdout:
+#   verdict=approved|awaiting|threads-open|changes-requested detail=<human text>
+# (diagnostic detail also echoed for logs). Exit codes:
+#   0 — evaluated (verdict line is authoritative)
+#   2 — an evidence read failed or the configuration is invalid; NO verdict
+#       was reached. Callers must treat this as "take no action", never as
+#       awaiting: acting on a transient API failure could flip a healthy PR's
+#       merge state.
+set -u
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$script_dir/lib/settings.sh"
+
+TRUSTED_CONTEXTS="$(rg_setting REVIEW_GATE_TRUSTED_STATUS_CONTEXTS "Devin Review")"
+SKIP_PATTERNS="$(rg_setting REVIEW_GATE_CHECKRUN_SKIP_PATTERNS "rate limited;skipped;queued")"
+COMMENT_REVIEWERS="$(rg_setting REVIEW_GATE_COMMENT_REVIEWERS "")"
+SHA_FLOOR="$(rg_setting REVIEW_GATE_SHA_PREFIX_FLOOR "7")"
+OUTAGE_CONTEXT="$(rg_setting REVIEW_GATE_OUTAGE_CONTEXT "vstack-reviewer-outage")"
+TRUSTED_LOGINS="$(rg_setting REVIEW_GATE_REVIEW_OBJECT_TRUSTED_LOGINS "")"
+MIN_STATE="$(rg_setting REVIEW_GATE_REVIEW_OBJECT_MIN_STATE "any")"
+
+# Configuration errors are exit 2 (no verdict), same contract as a failed
+# evidence read: a typo in trust config must never quietly widen or narrow
+# the gate.
+case "$SHA_FLOOR" in
+  ''|*[!0-9]*)
+    echo "::error::review-predicate: REVIEW_GATE_SHA_PREFIX_FLOOR must be an integer, got '$SHA_FLOOR'" >&2
+    exit 2
+    ;;
+esac
+if [ "$SHA_FLOOR" -lt 4 ] || [ "$SHA_FLOOR" -gt 40 ]; then
+  echo "::error::review-predicate: REVIEW_GATE_SHA_PREFIX_FLOOR must be 4..40, got '$SHA_FLOOR'" >&2
+  exit 2
+fi
+case "$MIN_STATE" in
+  any|approved) ;;
+  *)
+    echo "::error::review-predicate: REVIEW_GATE_REVIEW_OBJECT_MIN_STATE must be 'any' or 'approved', got '$MIN_STATE'" >&2
+    exit 2
+    ;;
+esac
+
+for required in GH_REPO PR_NUMBER HEAD_SHA; do
+  if [ -z "$(eval "echo \${$required:-}")" ]; then
+    echo "::error::review-predicate: $required is required" >&2
+    exit 2
+  fi
+done
+
+if [ -z "${PR_AUTHOR:-}" ]; then
+  PR_AUTHOR="$(gh api "repos/$GH_REPO/pulls/$PR_NUMBER" --jq .user.login)" || {
+    echo "::error::could not resolve PR #$PR_NUMBER author" >&2
+    exit 2
+  }
+fi
+
+# Two steps, not a pipe: `--paginate` emits ONE ARRAY PER PAGE, which the
+# count filters below would evaluate per-array (multi-line counts that can
+# never equal "0" past 100 reviews), and a mid-pipe gh failure must fail
+# loudly rather than hand jq a truncated page set.
+raw_reviews="$(gh api "repos/$GH_REPO/pulls/$PR_NUMBER/reviews" --paginate)" || {
+  echo "::error::could not read reviews for PR #$PR_NUMBER" >&2
+  exit 2
+}
+reviews="$(jq -s 'add // []' <<<"$raw_reviews")" || {
+  echo "::error::could not parse reviews for PR #$PR_NUMBER" >&2
+  exit 2
+}
+# Changes-requested counts only each reviewer's LATEST non-dismissed review on
+# the head, so a superseded CR that the same reviewer later cleared can't pin
+# the PR red forever. Deliberately unfiltered by the trust list: anyone's
+# standing objection fails the gate closed.
+cr="$(jq --arg sha "$HEAD_SHA" '[.[] | select(.commit_id == $sha and .state != "DISMISSED")] | group_by(.user.login) | map(.[-1]) | map(select(.state == "CHANGES_REQUESTED")) | length' <<<"$reviews")" || {
+  echo "::error::could not evaluate changes-requested reviews for PR #$PR_NUMBER" >&2
+  exit 2
+}
+# Review-object evidence. NOT a latest-review-per-reviewer reduction (see the
+# header): in "any" mode every accepted row counts; in "approved" mode a
+# login contributes evidence when its newest APPROVED at head is not followed
+# by a newer CHANGES_REQUESTED from that same login — a trailing COMMENTED
+# never withdraws an approval.
+got="$(jq --arg sha "$HEAD_SHA" --arg author "$PR_AUTHOR" \
+        --arg trusted "$TRUSTED_LOGINS" --arg minstate "$MIN_STATE" '
+  ($trusted | split("[;,\n]+"; "") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0))) as $t
+  | [ .[]
+      | select(.commit_id == $sha and .state != "DISMISSED" and .user.login != $author)
+      | select(($t | length) == 0 or (.user.login as $l | ($t | index($l)) != null))
+    ]
+  | if $minstate == "approved" then
+      group_by(.user.login)
+      | map(sort_by(.submitted_at // ""))
+      | map(select(
+          ([.[] | select(.state == "APPROVED")] | length) > 0
+          and (
+            ([.[] | select(.state == "CHANGES_REQUESTED")] | length) == 0
+            or (([.[] | select(.state == "APPROVED")] | last | .submitted_at // "") >
+                ([.[] | select(.state == "CHANGES_REQUESTED")] | last | .submitted_at // ""))
+          )
+        ))
+      | length
+    else
+      length
+    end' <<<"$reviews")" || {
+  echo "::error::could not evaluate review-object evidence for PR #$PR_NUMBER" >&2
+  exit 2
+}
+
+# Clean-analysis evidence: bots that submit a review OBJECT only when they
+# have findings pass their trusted check on a clean re-analysis and post no
+# review, so "review at head" would be forever unsatisfiable after a push
+# that fixes everything. Accept the trusted check-run OR legacy commit status
+# succeeding on THIS head (evidence lives in EITHER API depending on the
+# bot/repo; query both, either counts) — but only when the pass PROVES
+# ANALYSIS RAN: a success whose title/summary/description matches a skip
+# pattern (e.g. "Review rate limited") performed no review, so it is filtered
+# to not-evidence — the same as absent, never a failure. A read FAILURE here
+# must fail LOUDLY: treating it as absent evidence could flip a healthy PR's
+# merge state on a transient API hiccup.
+# The combined-status endpoint carries every context in one read; fetch it
+# once (fail loud) and evaluate each trusted context — and the outage
+# attestation below — against the same snapshot.
+status_resp="$(gh api "repos/$GH_REPO/commits/$HEAD_SHA/status")" || {
+  echo "::error::could not read the combined commit status for $HEAD_SHA" >&2
+  exit 2
+}
+check=0
+while IFS= read -r ctx; do
+  ctx="$(printf '%s' "$ctx" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+  [ -z "$ctx" ] && continue
+  ctx_uri="$(jq -rn --arg s "$ctx" '$s|@uri')"
+  checkruns_resp="$(gh api "repos/$GH_REPO/commits/$HEAD_SHA/check-runs?check_name=$ctx_uri&per_page=50")" || {
+    echo "::error::could not read '$ctx' check-runs" >&2
+    exit 2
+  }
+  # Bind each skip pattern to a variable BEFORE testing containment: inside
+  # `select($text | contains(.))` the dot would rebind to $text itself, so
+  # every clean pass would "match" and be filtered to not-evidence. Same
+  # rebinding trap as the comment-sha binding below; the selftest's
+  # genuine-clean-pass case is what catches it.
+  check_runs="$(jq --arg ctx "$ctx" --arg skips "$SKIP_PATTERNS" '
+      ($skips | split(";") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0)) | map(ascii_downcase)) as $sk
+      | [ .check_runs[]
+          | select(.name == $ctx and .conclusion == "success")
+          | (((.output.title // "") + " " + (.output.summary // "")) | ascii_downcase) as $text
+          | select(([ $sk[] | . as $p | select($text | contains($p)) ] | length) == 0)
+        ] | length' <<<"$checkruns_resp")" || {
+    echo "::error::could not evaluate '$ctx' check-runs" >&2
+    exit 2
+  }
+  check_status="$(jq --arg ctx "$ctx" --arg skips "$SKIP_PATTERNS" '
+      ($skips | split(";") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0)) | map(ascii_downcase)) as $sk
+      | [ .statuses[]
+          | select(.context == $ctx and .state == "success")
+          | ((.description // "") | ascii_downcase) as $text
+          | select(([ $sk[] | . as $p | select($text | contains($p)) ] | length) == 0)
+        ] | length' <<<"$status_resp")" || {
+    echo "::error::could not evaluate '$ctx' commit status" >&2
+    exit 2
+  }
+  check=$((check + check_runs + check_status))
+done <<EOF
+$(printf '%s' "$TRUSTED_CONTEXTS" | tr ';' '\n')
+EOF
+
+# Comment-form clean-pass evidence: some reviewers post NEITHER a review
+# object NOR a check/status on a clean pass — only an issue comment on the PR
+# conversation ("... Reviewed commit: `<sha>`"). Trust keys on the AUTHOR
+# LOGIN (exact match; only GitHub can set it); the body is read ONLY to bind
+# the evidence to a commit. The bound sha may be full or a backtick-quoted
+# short prefix: the match is "HEAD_SHA starts with the quoted sha",
+# case-insensitively, with a floor so a degenerate prefix cannot match every
+# head.
+comment_hits=0
+if [ -n "$COMMENT_REVIEWERS" ]; then
+  # Two steps, not a pipe — same pagination/fail-loud reason as the reviews
+  # read above.
+  raw_comments="$(gh api "repos/$GH_REPO/issues/$PR_NUMBER/comments" --paginate)" || {
+    echo "::error::could not read issue comments for PR #$PR_NUMBER" >&2
+    exit 2
+  }
+  comments="$(jq -s 'add // []' <<<"$raw_comments")" || {
+    echo "::error::could not parse issue comments for PR #$PR_NUMBER" >&2
+    exit 2
+  }
+  while IFS= read -r pair; do
+    pair="$(printf '%s' "$pair" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+    [ -z "$pair" ] && continue
+    login="${pair%%:*}"
+    pattern="${pair#*:}"
+    if [ -z "$login" ] || [ -z "$pattern" ] || [ "$login" = "$pair" ]; then
+      echo "::error::review-predicate: malformed REVIEW_GATE_COMMENT_REVIEWERS entry '$pair' (need 'login:binding-pattern')" >&2
+      exit 2
+    fi
+    # The binding pattern is a LITERAL prefix (regex-quoted here), not a
+    # regex: trust config must not be able to smuggle in a permissive match.
+    hits="$(jq --arg sha "$HEAD_SHA" --arg bot "$login" \
+               --arg pat "$pattern" --arg floor "$SHA_FLOOR" '
+      def requote: gsub("(?<c>[.^$|?*+()\\[\\]{}\\\\-])"; "\\" + .c);
+      (($pat | requote) + "[^0-9a-fA-F]*([0-9a-fA-F]{" + $floor + ",40})") as $re
+      | [ .[]
+          | select(.user.login == $bot)
+          | (.body // "")
+          | scan($re)
+          # Bind the claimed sha BEFORE comparing. Piping the head into
+          # startswith and referring to the scanned value as dot rebinds dot
+          # to the head inside that pipe, so every comment matches itself and
+          # ANY sha is accepted. That is a false approved, the only direction
+          # of this gate that fails silently; the different-sha case in the
+          # selftest is what caught it.
+          | (.[0] | ascii_downcase) as $claimed
+          | select(($sha | ascii_downcase) | startswith($claimed))
+        ] | length' <<<"$comments")" || {
+      echo "::error::could not evaluate '$login' review comments for PR #$PR_NUMBER" >&2
+      exit 2
+    }
+    comment_hits=$((comment_hits + hits))
+  done <<EOF
+$(printf '%s' "$COMMENT_REVIEWERS" | tr ';' '\n')
+EOF
+fi
+
+# Reviewer-outage attestation: a trusted orchestrator posts this context on
+# the head ONLY on genuine total reviewer silence (zero unresolved threads,
+# no review/check/status engagement, head re-confirmed at emit). It
+# substitutes for MISSING review evidence only — changes-requested and
+# unresolved threads still fail closed. SECURITY: deliberate, bounded
+# relaxation; trusted-publisher model identical to the trusted status
+# contexts above. See orch DEVELOPMENT.md "Reviewer-outage recognition".
+outageok=0
+if [ -n "$OUTAGE_CONTEXT" ]; then
+  outageok="$(jq --arg ctx "$OUTAGE_CONTEXT" \
+    '[.statuses[] | select(.context == $ctx and .state == "success")] | length' <<<"$status_resp")" || {
+    echo "::error::could not evaluate the reviewer-outage status" >&2
+    exit 2
+  }
+fi
+
+# A genuine GraphQL failure must NOT fall through as unresolved threads — fail
+# loudly instead. `pageInfo.hasNextPage` (>100 threads) is a SUCCESSFUL read
+# we cannot fully verify, so it reports "overflow" and fails closed to
+# threads-open. Same posture for a thread node whose isResolved is not a
+# boolean ("malformed"): null/missing nodes must never count as resolved —
+# that direction is a false approval on a merge gate.
+unresolved="$(gh api graphql \
+  -f query='query($owner:String!,$repo:String!,$number:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$number){reviewThreads(first:100){pageInfo{hasNextPage} nodes{isResolved}}}}}' \
+  -F owner="${GH_REPO%/*}" -F repo="${GH_REPO#*/}" -F number="$PR_NUMBER" \
+  --jq 'if .data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage then "overflow"
+        elif ([.data.repository.pullRequest.reviewThreads.nodes[] | select((.isResolved | type) != "boolean")] | length) > 0 then "malformed"
+        else ([.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length) end')" || {
+  echo "::error::could not read review threads" >&2
+  exit 2
+}
+
+echo "PR #$PR_NUMBER head $HEAD_SHA: reviews=$got clean-analysis=$check comment-form=$comment_hits outage-marker=$outageok changes-requested=$cr unresolved-threads=$unresolved" >&2
+
+if [ "$cr" != "0" ]; then
+  echo "verdict=changes-requested detail=review changes requested on the current head"
+elif [ "$got" = "0" ] && [ "$check" = "0" ] && [ "$comment_hits" = "0" ] && [ "$outageok" = "0" ]; then
+  echo "verdict=awaiting detail=awaiting a non-author review for $HEAD_SHA"
+elif [ "$unresolved" != "0" ]; then
+  echo "verdict=threads-open detail=$unresolved unresolved review thread(s)"
+else
+  echo "verdict=approved detail=reviewed at head with no unresolved threads"
+fi

--- a/skills/review-gate/scripts/review-predicate.sh
+++ b/skills/review-gate/scripts/review-predicate.sh
@@ -266,11 +266,15 @@ EOF
 # Comment-form clean-pass evidence: some reviewers post NEITHER a review
 # object NOR a check/status on a clean pass — only an issue comment on the PR
 # conversation ("... Reviewed commit: `<sha>`"). Trust keys on the AUTHOR
-# LOGIN (exact match; only GitHub can set it); the body is read ONLY to bind
-# the evidence to a commit. The bound sha may be full or a backtick-quoted
-# short prefix: the match is "HEAD_SHA starts with the quoted sha",
-# case-insensitively, with a floor so a degenerate prefix cannot match every
-# head.
+# LOGIN (exact match; only GitHub can set it) — and the PR author is
+# excluded even when configured as a comment reviewer, or a bot could
+# self-approve its own update PR; the body is read ONLY to bind the
+# evidence to a commit. The bound sha may be the full sha or a short prefix
+# (bare or backtick-quoted — decoration between the binding pattern and the
+# sha is ignored as non-hex): the match is "HEAD_SHA starts with the bound
+# sha", case-insensitively, with a floor so a degenerate prefix cannot
+# match every head. The trust anchor is the author login plus the LITERAL
+# binding pattern immediately preceding the sha slot, not the quoting.
 comment_hits=0
 if [ -n "$COMMENT_REVIEWERS" ]; then
   # Two steps, not a pipe — same pagination/fail-loud reason as the reviews
@@ -294,12 +298,12 @@ if [ -n "$COMMENT_REVIEWERS" ]; then
     fi
     # The binding pattern is a LITERAL prefix (regex-quoted here), not a
     # regex: trust config must not be able to smuggle in a permissive match.
-    hits="$(jq --arg sha "$HEAD_SHA" --arg bot "$login" \
+    hits="$(jq --arg sha "$HEAD_SHA" --arg bot "$login" --arg author "$PR_AUTHOR" \
                --arg pat "$pattern" --arg floor "$SHA_FLOOR" '
       def requote: gsub("(?<c>[.^$|?*+()\\[\\]{}\\\\-])"; "\\" + .c);
       (($pat | requote) + "[^0-9a-fA-F]*([0-9a-fA-F]{" + $floor + ",40})") as $re
       | [ .[]
-          | select(.user.login == $bot)
+          | select(.user.login == $bot and .user.login != $author)
           | (.body // "")
           | scan($re)
           # Bind the claimed sha BEFORE comparing. Piping the head into

--- a/skills/review-gate/scripts/review-predicate.sh
+++ b/skills/review-gate/scripts/review-predicate.sh
@@ -68,7 +68,7 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # `|| exit 2`: rg_setting fails on a present-but-unparseable assignment, and
 # that is a configuration error (no verdict), never an empty value.
-TRUSTED_CONTEXTS="$(rg_setting REVIEW_GATE_TRUSTED_STATUS_CONTEXTS "Devin Review")" || exit 2
+TRUSTED_CONTEXTS="$(rg_setting REVIEW_GATE_TRUSTED_STATUS_CONTEXTS "")" || exit 2
 SKIP_PATTERNS="$(rg_setting REVIEW_GATE_CHECKRUN_SKIP_PATTERNS "rate limited;skipped;queued")" || exit 2
 COMMENT_REVIEWERS="$(rg_setting REVIEW_GATE_COMMENT_REVIEWERS "")" || exit 2
 SHA_FLOOR="$(rg_setting REVIEW_GATE_SHA_PREFIX_FLOOR "7")" || exit 2

--- a/skills/review-gate/scripts/review-predicate.sh
+++ b/skills/review-gate/scripts/review-predicate.sh
@@ -97,6 +97,29 @@ case "$MIN_STATE" in
     ;;
 esac
 
+# The gate's own posted status must never be review evidence: with
+# REVIEW_GATE_CONTEXT listed as a trusted status context (or naming the
+# outage attestation), a previously posted gate success would satisfy the
+# predicate by itself — once green, the gate could never close again even
+# after the real review evidence is withdrawn. Fail configuration instead.
+GATE_CONTEXT_SELF="$(rg_setting REVIEW_GATE_CONTEXT "Review gate")" || exit 2
+if [ -n "$GATE_CONTEXT_SELF" ]; then
+  if [ "$OUTAGE_CONTEXT" = "$GATE_CONTEXT_SELF" ]; then
+    echo "::error::review-predicate: REVIEW_GATE_OUTAGE_CONTEXT equals REVIEW_GATE_CONTEXT ('$GATE_CONTEXT_SELF') — the gate's own status cannot attest a reviewer outage to itself" >&2
+    exit 2
+  fi
+  while IFS= read -r ctx; do
+    ctx="$(printf '%s' "$ctx" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+    [ -z "$ctx" ] && continue
+    if [ "$ctx" = "$GATE_CONTEXT_SELF" ]; then
+      echo "::error::review-predicate: REVIEW_GATE_TRUSTED_STATUS_CONTEXTS includes REVIEW_GATE_CONTEXT ('$GATE_CONTEXT_SELF') — the gate's own status cannot be its own review evidence" >&2
+      exit 2
+    fi
+  done <<EOF_GATE_CTX
+$(printf '%s' "$TRUSTED_CONTEXTS" | tr ';' '\n')
+EOF_GATE_CTX
+fi
+
 for required in GH_REPO PR_NUMBER HEAD_SHA; do
   if [ -z "$(eval "echo \${$required:-}")" ]; then
     echo "::error::review-predicate: $required is required" >&2

--- a/skills/review-gate/scripts/review-predicate.sh
+++ b/skills/review-gate/scripts/review-predicate.sh
@@ -66,13 +66,15 @@ set -u
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "$script_dir/lib/settings.sh"
 
-TRUSTED_CONTEXTS="$(rg_setting REVIEW_GATE_TRUSTED_STATUS_CONTEXTS "Devin Review")"
-SKIP_PATTERNS="$(rg_setting REVIEW_GATE_CHECKRUN_SKIP_PATTERNS "rate limited;skipped;queued")"
-COMMENT_REVIEWERS="$(rg_setting REVIEW_GATE_COMMENT_REVIEWERS "")"
-SHA_FLOOR="$(rg_setting REVIEW_GATE_SHA_PREFIX_FLOOR "7")"
-OUTAGE_CONTEXT="$(rg_setting REVIEW_GATE_OUTAGE_CONTEXT "vstack-reviewer-outage")"
-TRUSTED_LOGINS="$(rg_setting REVIEW_GATE_REVIEW_OBJECT_TRUSTED_LOGINS "")"
-MIN_STATE="$(rg_setting REVIEW_GATE_REVIEW_OBJECT_MIN_STATE "any")"
+# `|| exit 2`: rg_setting fails on a present-but-unparseable assignment, and
+# that is a configuration error (no verdict), never an empty value.
+TRUSTED_CONTEXTS="$(rg_setting REVIEW_GATE_TRUSTED_STATUS_CONTEXTS "Devin Review")" || exit 2
+SKIP_PATTERNS="$(rg_setting REVIEW_GATE_CHECKRUN_SKIP_PATTERNS "rate limited;skipped;queued")" || exit 2
+COMMENT_REVIEWERS="$(rg_setting REVIEW_GATE_COMMENT_REVIEWERS "")" || exit 2
+SHA_FLOOR="$(rg_setting REVIEW_GATE_SHA_PREFIX_FLOOR "7")" || exit 2
+OUTAGE_CONTEXT="$(rg_setting REVIEW_GATE_OUTAGE_CONTEXT "vstack-reviewer-outage")" || exit 2
+TRUSTED_LOGINS="$(rg_setting REVIEW_GATE_REVIEW_OBJECT_TRUSTED_LOGINS "")" || exit 2
+MIN_STATE="$(rg_setting REVIEW_GATE_REVIEW_OBJECT_MIN_STATE "any")" || exit 2
 
 # Configuration errors are exit 2 (no verdict), same contract as a failed
 # evidence read: a typo in trust config must never quietly widen or narrow
@@ -171,11 +173,18 @@ got="$(jq --arg sha "$HEAD_SHA" --arg author "$PR_AUTHOR" \
 # to not-evidence — the same as absent, never a failure. A read FAILURE here
 # must fail LOUDLY: treating it as absent evidence could flip a healthy PR's
 # merge state on a transient API hiccup.
-# The combined-status endpoint carries every context in one read; fetch it
-# once (fail loud) and evaluate each trusted context — and the outage
-# attestation below — against the same snapshot.
-status_resp="$(gh api "repos/$GH_REPO/commits/$HEAD_SHA/status")" || {
+# The combined-status endpoint paginates its statuses array (default 30
+# contexts per page), so fetch EVERY page (fail loud) and merge them into one
+# snapshot — each trusted context and the outage attestation below evaluate
+# against it. Fetch and merge are SEPARATE steps for the same reason as the
+# check-runs read: a pipe would replace gh's exit status with jq's and turn a
+# read failure into an empty-success (fail-open).
+status_pages="$(gh api "repos/$GH_REPO/commits/$HEAD_SHA/status?per_page=100" --paginate)" || {
   echo "::error::could not read the combined commit status for $HEAD_SHA" >&2
+  exit 2
+}
+status_resp="$(jq -s '{statuses: (map(.statuses) | add // [])}' <<<"$status_pages")" || {
+  echo "::error::could not merge the combined commit status pages for $HEAD_SHA" >&2
   exit 2
 }
 check=0

--- a/skills/review-gate/scripts/review-predicate.sh
+++ b/skills/review-gate/scripts/review-predicate.sh
@@ -103,22 +103,27 @@ esac
 # predicate by itself — once green, the gate could never close again even
 # after the real review evidence is withdrawn. Fail configuration instead.
 GATE_CONTEXT_SELF="$(rg_setting REVIEW_GATE_CONTEXT "Review gate")" || exit 2
-if [ -n "$GATE_CONTEXT_SELF" ]; then
-  if [ "$OUTAGE_CONTEXT" = "$GATE_CONTEXT_SELF" ]; then
-    echo "::error::review-predicate: REVIEW_GATE_OUTAGE_CONTEXT equals REVIEW_GATE_CONTEXT ('$GATE_CONTEXT_SELF') — the gate's own status cannot attest a reviewer outage to itself" >&2
+# Unlike the disable-able evidence sources, the gate context has no empty
+# form: it names the required status the CI wiring posts, so "" would make
+# that post malformed and leave the gate absent. Same refusal as the refire.
+if [ -z "$GATE_CONTEXT_SELF" ]; then
+  echo "::error::review-predicate: REVIEW_GATE_CONTEXT must not be empty" >&2
+  exit 2
+fi
+if [ "$OUTAGE_CONTEXT" = "$GATE_CONTEXT_SELF" ]; then
+  echo "::error::review-predicate: REVIEW_GATE_OUTAGE_CONTEXT equals REVIEW_GATE_CONTEXT ('$GATE_CONTEXT_SELF') — the gate's own status cannot attest a reviewer outage to itself" >&2
+  exit 2
+fi
+while IFS= read -r ctx; do
+  ctx="$(printf '%s' "$ctx" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+  [ -z "$ctx" ] && continue
+  if [ "$ctx" = "$GATE_CONTEXT_SELF" ]; then
+    echo "::error::review-predicate: REVIEW_GATE_TRUSTED_STATUS_CONTEXTS includes REVIEW_GATE_CONTEXT ('$GATE_CONTEXT_SELF') — the gate's own status cannot be its own review evidence" >&2
     exit 2
   fi
-  while IFS= read -r ctx; do
-    ctx="$(printf '%s' "$ctx" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
-    [ -z "$ctx" ] && continue
-    if [ "$ctx" = "$GATE_CONTEXT_SELF" ]; then
-      echo "::error::review-predicate: REVIEW_GATE_TRUSTED_STATUS_CONTEXTS includes REVIEW_GATE_CONTEXT ('$GATE_CONTEXT_SELF') — the gate's own status cannot be its own review evidence" >&2
-      exit 2
-    fi
-  done <<EOF_GATE_CTX
+done <<EOF_GATE_CTX
 $(printf '%s' "$TRUSTED_CONTEXTS" | tr ';' '\n')
 EOF_GATE_CTX
-fi
 
 for required in GH_REPO PR_NUMBER HEAD_SHA; do
   if [ -z "$(eval "echo \${$required:-}")" ]; then

--- a/skills/review-gate/templates/approval-rerun.yml
+++ b/skills/review-gate/templates/approval-rerun.yml
@@ -132,7 +132,13 @@ jobs:
           # the PR from the head sha instead; only a genuine no-open-PR
           # result (push-triggered analysis) exits.
           if [ -z "${PR_NUMBER:-}" ]; then
-            PR_NUMBER="$(gh api "repos/$GH_REPO/commits/$HEAD_SHA/pulls" --jq '[.[] | select(.state == "open")][0].number // empty')" || PR_NUMBER=""
+            # The lookup itself must fail LOUDLY: an API outage that lands in
+            # the no-op branch would silently drop a clean-case re-fire. Only
+            # a SUCCESSFUL empty response means "no open PR".
+            PR_NUMBER="$(gh api "repos/$GH_REPO/commits/$HEAD_SHA/pulls" --jq '[.[] | select(.state == "open")][0].number // empty')" || {
+              echo "::error::could not list open PRs for head $HEAD_SHA; taking no action"
+              exit 1
+            }
             if [ -z "${PR_NUMBER:-}" ]; then
               echo "no open PR associated with head $HEAD_SHA; nothing to do"
               exit 0

--- a/skills/review-gate/templates/approval-rerun.yml
+++ b/skills/review-gate/templates/approval-rerun.yml
@@ -1,0 +1,160 @@
+# SCAFFOLD from the vstack review-gate skill (templates/approval-rerun.yml).
+# Copy once into .github/workflows/ in the adoption PR; the file is REPO-OWNED
+# after the copy — `vstack refresh` does not sync workflow YAML. Lines marked
+# ADAPT reference trust values that live in vstack.settings.toml but cannot be
+# read from workflow `if:` expressions; keep them aligned with the repo's
+# REVIEW_GATE_* settings. A loose filter here costs a wasted run, never a
+# false approval — the predicate re-derives the verdict from scratch.
+name: Approval CI re-fire
+
+# Converges the review-gate commit status with the live review state (see
+# .agents/skills/review-gate/scripts/approval-refire.sh for the model). On
+# review submit/dismiss, on the trusted reviewer's clean-analysis evidence,
+# and on a comment-form reviewer's clean pass:
+#   - downward transitions (dismissal, changes-requested) post the
+#     pending/failure status directly — pending blocks merge on its own, so
+#     no check-run churn is needed;
+#   - the first awaiting→approved flip RE-RUNS the head's pull_request runs
+#     in place, so the new attempt opens the gate and executes the heavy
+#     jobs. Re-running in place (never a separate review-triggered run)
+#     matters to merge queues: enqueue counts every check-run on the head,
+#     and a stale failed/cancelled required check from a superseded run
+#     blocks it.
+#
+# Anti-loop: this workflow triggers only on review/evidence events; the
+# reruns it issues never re-trigger it. A genuinely-failing build after
+# approval is NOT retried automatically — the gate status stays success and
+# the red required contexts block on their own; re-run manually to retry.
+
+"on":
+  pull_request_review:
+    types: [submitted, dismissed]
+  # NOTE: `pull_request_review_thread` is a WEBHOOK event but NOT a GitHub
+  # Actions workflow trigger (per the "Events that trigger workflows"
+  # reference) — declaring it never fires on thread resolution; it only makes
+  # GitHub's push-time workflow validation log a phantom failed "workflow
+  # file issue" run on every push. The unresolved-threads condition therefore
+  # has no direct re-fire signal here; approval-sweep.yml covers it with a
+  # scheduled sweep over the same shared script.
+  # A CLEAN re-analysis by a check-run-publishing reviewer posts no review
+  # object and no review event — only its check-run. Without this trigger the
+  # re-fire never runs in the clean case and the pending gate status would
+  # stand forever. The job-level guard filters to the trusted check name.
+  check_run:
+    types: [completed]
+  # Some reviewers publish their clean-analysis evidence as a legacy commit
+  # STATUS instead of a check-run, and a status update is a `status` event -
+  # not check_run. Without this trigger the clean path still cannot re-fire
+  # the gate here.
+  status: {}
+  # Comment-form reviewers post NEITHER a review object NOR a check/status on
+  # a clean pass — only an ISSUE COMMENT on the PR. Its evidence is accepted
+  # by the predicate, but without this trigger nothing tells the gate to
+  # re-evaluate, so convergence would wait on the scheduled sweep — which,
+  # with every other reviewer out, would be the whole merge cadence. The
+  # job-level guard filters to the bot author and the commit-binding line.
+  # DELETE this trigger (and its guard below) on repos with no comment-form
+  # reviewer configured.
+  issue_comment:
+    types: [created]
+
+permissions:
+  # rerun of the head's pull_request runs
+  actions: write
+  # the gate predicate reads (reviews, PR author, PR conversation comments)
+  pull-requests: read
+  # PR conversation comments are ISSUE comments; comment-form clean-pass
+  # evidence is read through that API.
+  issues: read
+  # clean-analysis evidence read
+  checks: read
+  # read the current gate status + POST the converged one
+  statuses: write
+  # checkout of the shared re-fire script
+  contents: read
+
+concurrency:
+  # check_run events include the CHECK NAME in the group key: the job-level
+  # name filter runs AFTER concurrency slotting, so a skipped untrusted
+  # check_run would otherwise replace a queued trusted-reviewer re-fire in
+  # the shared pending slot and silently drop it. Same-name collisions are
+  # safe - the run re-reads current state.
+  group: approval-rerun-${{ github.event.issue.number || github.event.pull_request.number || format('{0}-{1}', github.event.check_run.head_sha || github.event.sha, github.event.check_run.name || github.event.context) }}
+  cancel-in-progress: false
+
+jobs:
+  rerun:
+    name: Re-fire CI after review
+    # check_run events: act only on the trusted reviewer's own check (exact
+    # name), and only when it has an associated PR (guarded again in-script).
+    # issue_comment fires on plain issues too, and on every human comment.
+    # Filter to a PR, to the trusted reviewer login, and to the commit-binding
+    # line — same trust model as the predicate: the AUTHOR is what is trusted,
+    # the body only narrows which comments are worth a re-fire.
+    # ADAPT: 'Devin Review' = REVIEW_GATE_TRUSTED_STATUS_CONTEXTS,
+    # 'vstack-reviewer-outage' = REVIEW_GATE_OUTAGE_CONTEXT,
+    # 'chatgpt-codex-connector[bot]' / 'Reviewed commit' =
+    # REVIEW_GATE_COMMENT_REVIEWERS login / binding pattern.
+    if: >-
+      (github.event_name != 'check_run' || github.event.check_run.name == 'Devin Review') &&
+      (github.event_name != 'status' || ((github.event.context == 'Devin Review' || github.event.context == 'vstack-reviewer-outage') && github.event.state == 'success')) &&
+      (github.event_name != 'issue_comment' || (github.event.issue.pull_request != null && github.event.comment.user.login == 'chatgpt-codex-connector[bot]' && contains(github.event.comment.body, 'Reviewed commit')))
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number || github.event.check_run.pull_requests[0].number }}
+      # issue_comment carries no head sha — the comment is on the conversation,
+      # not on a commit. Resolved from the PR in the step below, and resolved
+      # there rather than read out of the comment body deliberately: the gate
+      # must converge on what the PR head IS, not on what a comment says it was.
+      HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.check_run.head_sha || github.event.sha }}
+      # Empty on check_run and issue_comment events; resolved from the PR.
+      PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+    steps:
+      # The evaluate-and-converge logic lives in the shared vendored script
+      # (single source of truth with approval-sweep.yml). Checkout is pinned
+      # to the DEFAULT branch with credentials dropped: these trigger events
+      # must never execute a PR-controlled version of the re-fire logic, and
+      # jobs that execute repository code must not persist a token into it.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Converge the review gate for the PR head
+        run: |
+          set -u
+          # check_run.pull_requests[] is best-effort - it can be EMPTY even
+          # for same-repo PRs (notably app-created check runs), so an empty
+          # PR_NUMBER must not silently no-op the clean-case re-fire. Resolve
+          # the PR from the head sha instead; only a genuine no-open-PR
+          # result (push-triggered analysis) exits.
+          if [ -z "${PR_NUMBER:-}" ]; then
+            PR_NUMBER="$(gh api "repos/$GH_REPO/commits/$HEAD_SHA/pulls" --jq '[.[] | select(.state == "open")][0].number // empty')" || PR_NUMBER=""
+            if [ -z "${PR_NUMBER:-}" ]; then
+              echo "no open PR associated with head $HEAD_SHA; nothing to do"
+              exit 0
+            fi
+            echo "resolved PR #$PR_NUMBER from head sha (check_run payload had no pull_requests)"
+          fi
+          # issue_comment events carry no head sha (see the env note above).
+          if [ -z "${HEAD_SHA:-}" ]; then
+            HEAD_SHA="$(gh api "repos/$GH_REPO/pulls/$PR_NUMBER" --jq .head.sha)" || {
+              echo "::error::could not resolve head sha for PR #$PR_NUMBER"
+              exit 1
+            }
+            export HEAD_SHA
+            echo "resolved head $HEAD_SHA for PR #$PR_NUMBER (comment event carries no sha)"
+          fi
+          if [ ! -f .agents/skills/review-gate/scripts/approval-refire.sh ]; then
+            # Only reachable while the PR introducing the vendored skill is
+            # unmerged (these trigger events check out the default branch) —
+            # or if the skill was deleted from the default branch, which must
+            # stay loud.
+            echo "::error::.agents/skills/review-gate/scripts/approval-refire.sh is missing on the default branch (bootstrap PR? deleted?); no re-fire action taken"
+            exit 1
+          fi
+          export PR_NUMBER
+          exec .agents/skills/review-gate/scripts/approval-refire.sh

--- a/skills/review-gate/templates/approval-rerun.yml
+++ b/skills/review-gate/templates/approval-rerun.yml
@@ -74,12 +74,16 @@ permissions:
   contents: read
 
 concurrency:
-  # check_run events include the CHECK NAME in the group key: the job-level
-  # name filter runs AFTER concurrency slotting, so a skipped untrusted
-  # check_run would otherwise replace a queued trusted-reviewer re-fire in
-  # the shared pending slot and silently drop it. Same-name collisions are
-  # safe - the run re-reads current state.
-  group: approval-rerun-${{ github.event.issue.number || github.event.pull_request.number || format('{0}-{1}', github.event.check_run.head_sha || github.event.sha, github.event.check_run.name || github.event.context) }}
+  # ONE repo-wide group for EVERY gate writer (this workflow AND the sweep):
+  # per-event group keys let two writers evaluate different snapshots of the
+  # same head concurrently and post out of order — an older `approved`
+  # evaluation taking the prior-success fast path could overwrite a newer
+  # failure post. Serializing all writers removes that race. Events that get
+  # replaced in the single pending slot are converged, not lost: every run
+  # re-reads CURRENT review state at execution, and the scheduled sweep is
+  # the convergence backstop for any dropped trigger (latency, not
+  # correctness).
+  group: review-gate-writer
   cancel-in-progress: false
 
 jobs:

--- a/skills/review-gate/templates/approval-sweep.yml
+++ b/skills/review-gate/templates/approval-sweep.yml
@@ -1,0 +1,98 @@
+# SCAFFOLD from the vstack review-gate skill (templates/approval-sweep.yml).
+# Copy once into .github/workflows/ in the adoption PR; the file is REPO-OWNED
+# after the copy — `vstack refresh` does not sync workflow YAML.
+name: Approval gate sweep
+
+# Some gate-relevant transitions emit NO usable Actions event, so the
+# event-driven re-fire (approval-rerun.yml) can never see them. Chief case:
+# resolving (or REOPENING) the last unresolved review thread —
+# `pull_request_review_thread` is a webhook event but not an Actions trigger
+# — so a fully-addressed PR's pending gate status would stand until some
+# other trusted event happened. Late outage-marker timing has the same shape.
+#
+# This scheduled sweep closes those gaps. Every 15 minutes it re-evaluates
+# the gate predicate for every open PR via the shared vendored script
+# (.agents/skills/review-gate/scripts/approval-refire.sh — single source of
+# truth with approval-rerun.yml) and converges the gate commit status:
+# downward transitions are a direct status post; the first awaiting→approved
+# flip re-runs the head's pull_request runs, bounded by
+# REVIEW_GATE_MAX_RERUN_ATTEMPTS so an evidence-disagreement ping-pong can
+# never retry forever. A genuinely failing build is never retried by the
+# sweep — once an approved attempt has run, the gate status carries a
+# success entry and only direct posts happen.
+#
+# A read error for one PR is reported (::error) and the sweep continues to
+# the other PRs, then exits non-zero so the failure is visible in the run
+# list — fail loudly, never silently (matching the shared script's posture).
+
+"on":
+  schedule:
+    # Worst-case added latency for a thread-resolution-only transition.
+    - cron: "*/15 * * * *"
+  # Manual sweep for testing and for "I just resolved the last thread and
+  # don't want to wait" moments.
+  workflow_dispatch: {}
+
+permissions:
+  # rerun of the head's pull_request runs
+  actions: write
+  # PR list + reviews (gate predicate)
+  pull-requests: read
+  # PR conversation comments (comment-form clean-pass evidence)
+  issues: read
+  # clean-analysis evidence reads
+  checks: read
+  # read the current gate status + POST the converged one
+  statuses: write
+  # checkout of the shared script
+  contents: read
+
+concurrency:
+  group: approval-sweep
+  cancel-in-progress: false
+
+jobs:
+  sweep:
+    name: Converge review gates that drifted
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+    steps:
+      # Pinned to the DEFAULT branch with credentials dropped:
+      # `workflow_dispatch` follows the dispatched ref by default, which
+      # would let a branch-controlled copy of the script run under this
+      # job's `actions: write` token. Manual dispatch is for testing the
+      # MERGED sweep, same trust boundary as approval-rerun.yml's checkout.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Sweep open PRs
+        run: |
+          set -u
+          # Full pagination (one array per page, slurped flat) — a fixed page
+          # limit would silently leave PRs beyond it unswept forever.
+          raw_prs="$(gh api "repos/$GH_REPO/pulls?state=open&per_page=100" --paginate)" || {
+            echo "::error::could not list open PRs"
+            exit 1
+          }
+          prs="$(jq -s '[add // [] | .[] | {number, headRefOid: .head.sha, author: {login: (.user.login // "")}}]' <<<"$raw_prs")" || {
+            echo "::error::could not parse the open-PR list"
+            exit 1
+          }
+          count="$(jq length <<<"$prs")"
+          echo "sweeping $count open PR(s)"
+          failed=0
+          while read -r number head author; do
+            [ -z "$number" ] && continue
+            if ! PR_NUMBER="$number" HEAD_SHA="$head" PR_AUTHOR="$author" \
+                QUIESCE=0 \
+                .agents/skills/review-gate/scripts/approval-refire.sh; then
+              echo "::error::sweep failed for PR #$number (see log above)"
+              failed=1
+            fi
+          done < <(jq -r '.[] | "\(.number) \(.headRefOid) \(.author.login // "")"' <<<"$prs")
+          exit "$failed"

--- a/skills/review-gate/templates/approval-sweep.yml
+++ b/skills/review-gate/templates/approval-sweep.yml
@@ -48,7 +48,10 @@ permissions:
   contents: read
 
 concurrency:
-  group: approval-sweep
+  # Shares the single repo-wide gate-writer group with approval-rerun.yml: a
+  # sweep evaluating a stale snapshot must never interleave its posts with a
+  # newer event-driven write (see the rerun template's comment).
+  group: review-gate-writer
   cancel-in-progress: false
 
 jobs:

--- a/skills/review-gate/tests/approval-refire.test.sh
+++ b/skills/review-gate/tests/approval-refire.test.sh
@@ -34,6 +34,8 @@
 #   r16. non-integer rerun cap               -> exit 1
 #   r17. legacy MAX_ATTEMPTS env raises the  -> run at attempt 5 reruns under
 #        cap                                    MAX_ATTEMPTS=6
+#   r18. settings value with trailing TOML   -> value resolves, comment
+#        comment                                stripped
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -155,74 +157,74 @@ THREADS="verdict=threads-open detail=unresolved review threads on the current he
 
 echo "=== downward transitions are direct posts ==="
 
-out=$(run_refire STUB_VERDICT_LINE="$AWAITING" STUB_GATE_HISTORY='[]')
-assert_eq "$?" "0" "r1: awaiting exits 0"
+rc=0; out=$(run_refire STUB_VERDICT_LINE="$AWAITING" STUB_GATE_HISTORY='[]') || rc=$?
+assert_eq "$rc" "0" "r1: awaiting exits 0"
 assert_contains "$(cat "$POST_LOG")" "state=pending" "r1: awaiting posts pending"
 assert_contains "$(cat "$POST_LOG")" "context=Review gate" "r1: post carries the default gate context"
-assert_eq "$(wc -l < "$RERUN_LOG")" "0" "r1: no rerun on a downward transition"
+assert_eq "$(( $(wc -l < "$RERUN_LOG") ))" "0" "r1: no rerun on a downward transition"
 
 out=$(run_refire STUB_VERDICT_LINE="$AWAITING" \
   STUB_GATE_HISTORY='[{"context":"Review gate","state":"pending","description":"awaiting a non-author review for headsha"}]')
-assert_eq "$(wc -l < "$POST_LOG")" "0" "r2: already-pending same description posts nothing"
+assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "r2: already-pending same description posts nothing"
 assert_contains "$out" "nothing to do" "r2: reports the no-op"
 
 out=$(run_refire STUB_VERDICT_LINE="$CR" STUB_GATE_HISTORY='[]')
 assert_contains "$(cat "$POST_LOG")" "state=failure" "r3: changes-requested posts failure"
-assert_eq "$(wc -l < "$RERUN_LOG")" "0" "r3: no rerun on changes-requested"
+assert_eq "$(( $(wc -l < "$RERUN_LOG") ))" "0" "r3: no rerun on changes-requested"
 
-out=$(run_refire STUB_VERDICT_LINE="$THREADS" STUB_GATE_HISTORY='[]')
-assert_eq "$?" "0" "r13: threads-open exits 0"
+rc=0; out=$(run_refire STUB_VERDICT_LINE="$THREADS" STUB_GATE_HISTORY='[]') || rc=$?
+assert_eq "$rc" "0" "r13: threads-open exits 0"
 assert_contains "$(cat "$POST_LOG")" "state=pending" "r13: threads-open posts pending"
-assert_eq "$(wc -l < "$RERUN_LOG")" "0" "r13: no rerun on threads-open"
+assert_eq "$(( $(wc -l < "$RERUN_LOG") ))" "0" "r13: no rerun on threads-open"
 
 echo "=== upward flip: success needs proof ==="
 
-out=$(run_refire STUB_VERDICT_LINE="$APPROVED" \
-  STUB_GATE_HISTORY='[{"context":"Review gate","state":"success","description":"ok"}]')
-assert_eq "$?" "0" "r4: approved with current success exits 0"
-assert_eq "$(wc -l < "$POST_LOG")" "0" "r4: current success posts nothing"
-assert_eq "$(wc -l < "$RERUN_LOG")" "0" "r4: current success reruns nothing"
+rc=0; out=$(run_refire STUB_VERDICT_LINE="$APPROVED" \
+  STUB_GATE_HISTORY='[{"context":"Review gate","state":"success","description":"ok"}]') || rc=$?
+assert_eq "$rc" "0" "r4: approved with current success exits 0"
+assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "r4: current success posts nothing"
+assert_eq "$(( $(wc -l < "$RERUN_LOG") ))" "0" "r4: current success reruns nothing"
 
-out=$(run_refire STUB_VERDICT_LINE="$APPROVED" \
+rc=0; out=$(run_refire STUB_VERDICT_LINE="$APPROVED" \
   STUB_GATE_HISTORY='[{"context":"Review gate","state":"pending","description":"x"},{"context":"Review gate","state":"success","description":"ok"}]')
 assert_contains "$(cat "$POST_LOG")" "state=success" "r5: prior success on the sha allows a direct success post"
-assert_eq "$(wc -l < "$RERUN_LOG")" "0" "r5: proof fast path never reruns"
+assert_eq "$(( $(wc -l < "$RERUN_LOG") ))" "0" "r5: proof fast path never reruns"
 
-out=$(run_refire STUB_VERDICT_LINE="$APPROVED" STUB_GATE_HISTORY='[]' STUB_RUNS_MODE=completed)
-assert_eq "$?" "0" "r6: first approved flip exits 0"
+rc=0; out=$(run_refire STUB_VERDICT_LINE="$APPROVED" STUB_GATE_HISTORY='[]' STUB_RUNS_MODE=completed) || rc=$?
+assert_eq "$rc" "0" "r6: first approved flip exits 0"
 assert_eq "$(cat "$RERUN_LOG")" "rerun:111" "r6: full rerun of the completed pull_request run only (never the push run)"
-assert_eq "$(wc -l < "$POST_LOG")" "0" "r6: no direct success without proof"
+assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "r6: no direct success without proof"
 
-out=$(run_refire STUB_VERDICT_LINE="$APPROVED" STUB_GATE_HISTORY='[]' STUB_RUNS_MODE=high_attempt)
-assert_eq "$?" "0" "r7: attempt cap exits 0"
-assert_eq "$(wc -l < "$RERUN_LOG")" "0" "r7: run at MAX_ATTEMPTS is left alone"
+rc=0; out=$(run_refire STUB_VERDICT_LINE="$APPROVED" STUB_GATE_HISTORY='[]' STUB_RUNS_MODE=high_attempt) || rc=$?
+assert_eq "$rc" "0" "r7: attempt cap exits 0"
+assert_eq "$(( $(wc -l < "$RERUN_LOG") ))" "0" "r7: run at MAX_ATTEMPTS is left alone"
 assert_contains "$out" "cap 5" "r7: warns about the cap"
 
 out=$(run_refire STUB_VERDICT_LINE="$APPROVED" STUB_GATE_HISTORY='[]' \
   STUB_RUNS_MODE=high_attempt MAX_ATTEMPTS=6)
 assert_eq "$(cat "$RERUN_LOG")" "rerun:111" "r17: legacy MAX_ATTEMPTS env raises the cap (attempt 5 reruns under cap 6)"
 
-out=$(run_refire STUB_VERDICT_LINE="$APPROVED" STUB_GATE_HISTORY='[]' \
-  STUB_RUNS_MODE=in_progress QUIESCE=0)
-assert_eq "$?" "0" "r8: in-progress head under QUIESCE=0 exits 0"
-assert_eq "$(wc -l < "$RERUN_LOG")" "0" "r8: in-progress run is left to finish"
+rc=0; out=$(run_refire STUB_VERDICT_LINE="$APPROVED" STUB_GATE_HISTORY='[]' \
+  STUB_RUNS_MODE=in_progress QUIESCE=0) || rc=$?
+assert_eq "$rc" "0" "r8: in-progress head under QUIESCE=0 exits 0"
+assert_eq "$(( $(wc -l < "$RERUN_LOG") ))" "0" "r8: in-progress run is left to finish"
 assert_contains "$out" "still in progress" "r8: says why"
 
 echo "=== fail loud, act never ==="
 
 set +e
-out=$(run_refire STUB_PREDICATE_RC=2 STUB_GATE_HISTORY='[]')
+rc=0; out=$(run_refire STUB_PREDICATE_RC=2 STUB_GATE_HISTORY='[]')
 rc=$?
 set -e
 assert_eq "$rc" "1" "r9: predicate failure exits 1"
-assert_eq "$(wc -l < "$POST_LOG")$(wc -l < "$RERUN_LOG")" "00" "r9: no POST and no rerun on predicate failure"
+assert_eq "$(( $(wc -l < "$POST_LOG") ))$(( $(wc -l < "$RERUN_LOG") ))" "00" "r9: no POST and no rerun on predicate failure"
 
 set +e
 out=$(run_refire STUB_VERDICT_LINE="$APPROVED" STUB_GATE_HISTORY=fail)
 rc=$?
 set -e
 assert_eq "$rc" "1" "r10: status-history read failure exits 1"
-assert_eq "$(wc -l < "$POST_LOG")$(wc -l < "$RERUN_LOG")" "00" "r10: no action on history read failure"
+assert_eq "$(( $(wc -l < "$POST_LOG") ))$(( $(wc -l < "$RERUN_LOG") ))" "00" "r10: no action on history read failure"
 
 set +e
 out=$(env PATH="$TMP_ROOT/bin:$PATH" GH_REPO=acme/widgets HEAD_SHA=headsha \
@@ -246,7 +248,7 @@ out=$(run_refire STUB_VERDICT_LINE="$APPROVED" REVIEW_GATE_CONTEXT="CI Required"
   STUB_GATE_HISTORY='[{"context":"Review gate","state":"success","description":"ok"}]' \
   STUB_RUNS_MODE=completed)
 assert_eq "$(cat "$RERUN_LOG")" "rerun:111" "r12: another context's success is not proof - reruns instead"
-assert_eq "$(wc -l < "$POST_LOG")" "0" "r12: and posts no success"
+assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "r12: and posts no success"
 
 out=$(run_refire STUB_VERDICT_LINE="$AWAITING" REVIEW_GATE_CONTEXT="CI Required" STUB_GATE_HISTORY='[]')
 assert_contains "$(cat "$POST_LOG")" "context=CI Required" "r12: posts name the custom context"
@@ -254,10 +256,18 @@ assert_contains "$(cat "$POST_LOG")" "context=CI Required" "r12: posts name the 
 cat > "$TMP_ROOT/settings.toml" <<'EOF'
 REVIEW_GATE_CONTEXT = "File Gate"
 EOF
-out=$(run_refire STUB_VERDICT_LINE="$AWAITING" STUB_GATE_HISTORY='[]' \
-  REVIEW_GATE_SETTINGS_FILE="$TMP_ROOT/settings.toml")
-assert_eq "$?" "0" "r14: settings-file context exits 0"
+rc=0; out=$(run_refire STUB_VERDICT_LINE="$AWAITING" STUB_GATE_HISTORY='[]' \
+  REVIEW_GATE_SETTINGS_FILE="$TMP_ROOT/settings.toml") || rc=$?
+assert_eq "$rc" "0" "r14: settings-file context exits 0"
 assert_contains "$(cat "$POST_LOG")" "context=File Gate" "r14: posts name the settings-file context"
+
+cat > "$TMP_ROOT/commented-settings.toml" <<'EOF'
+REVIEW_GATE_CONTEXT = "File Gate" # inline TOML comment is valid
+EOF
+rc=0; out=$(run_refire STUB_VERDICT_LINE="$AWAITING" STUB_GATE_HISTORY='[]' \
+  REVIEW_GATE_SETTINGS_FILE="$TMP_ROOT/commented-settings.toml") || rc=$?
+assert_eq "$rc" "0" "r18: settings value with a trailing TOML comment exits 0"
+assert_contains "$(cat "$POST_LOG")" "context=File Gate" "r18: trailing comment does not pollute the value"
 
 cat > "$TMP_ROOT/bad-settings.toml" <<'EOF'
 REVIEW_GATE_CONTEXT = ["Review gate", "Other"]
@@ -269,7 +279,7 @@ rc=$?
 set -e
 assert_eq "$rc" "1" "r15: unparseable settings assignment exits 1"
 assert_contains "$out" "unsupported syntax" "r15: names the configuration error"
-assert_eq "$(wc -l < "$POST_LOG")$(wc -l < "$RERUN_LOG")" "00" "r15: no POST and no rerun on a config error"
+assert_eq "$(( $(wc -l < "$POST_LOG") ))$(( $(wc -l < "$RERUN_LOG") ))" "00" "r15: no POST and no rerun on a config error"
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/skills/review-gate/tests/approval-refire.test.sh
+++ b/skills/review-gate/tests/approval-refire.test.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+# Behavioral tests for the SHIPPED skills/review-gate/scripts/approval-refire.sh
+# (the orch test skills/orch/tests/approval_refire.sh exercises the legacy orch
+# copy; this one invokes the engine's own script, including its lib/settings.sh
+# resolution layer).
+#
+# The refire runs against a STUBBED review-predicate.sh placed next to it (it
+# resolves the predicate relative to itself), so these tests pin the
+# convergence branches independently of predicate behavior:
+#   r1.  awaiting, no gate status            -> posts pending, no rerun
+#   r2.  awaiting, already pending w/ same   -> no-op (no POST)
+#        description
+#   r3.  changes-requested                   -> posts failure
+#   r4.  approved, current status success    -> no-op (no POST, no rerun)
+#   r5.  approved, PRIOR success on the sha  -> direct success post, NO rerun
+#        (current pending)                      (success-needs-proof fast path)
+#   r6.  approved, no prior success          -> full rerun of the head's
+#                                               completed pull_request runs;
+#                                               NO direct success post
+#   r7.  approved, run at MAX_ATTEMPTS cap   -> left alone (no rerun), exit 0
+#   r8.  approved, QUIESCE=0, run in         -> no rerun (next sweep pass), exit 0
+#        progress
+#   r9.  predicate read failure              -> exit 1, NO POST, NO rerun
+#   r10. gate-status history read failure    -> exit 1, NO POST, NO rerun
+#   r11. missing required env (PR_NUMBER)    -> exit 1
+#   r12. custom REVIEW_GATE_CONTEXT: a       -> rerun, not direct success
+#        prior success under another            (proof is per-context), and
+#        context is not proof                   posts name the custom context
+#   r13. threads-open verdict                -> posts pending (downward path)
+#   r14. REVIEW_GATE_CONTEXT resolved from   -> posts name the file's context
+#        the settings file
+#   r15. unparseable settings assignment     -> exit 1, NO POST, NO rerun
+#        (TOML array syntax)                    (fail loud, never empty)
+#   r16. non-integer rerun cap               -> exit 1
+#   r17. legacy MAX_ATTEMPTS env raises the  -> run at attempt 5 reruns under
+#        cap                                    MAX_ATTEMPTS=6
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_ROOT="$(cd "$TEST_DIR/.." && pwd)"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local got="$1" want="$2" name="$3"
+  if [[ "$got" == "$want" ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$name" "$want" "$got"
+  fi
+}
+
+assert_contains() {
+  local haystack="$1" needle="$2" name="$3"
+  if grep -qF -- "$needle" <<<"$haystack"; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        wanted substring: %s\n        in: %s\n' "$name" "$needle" "$haystack"
+  fi
+}
+
+# Sandbox: the real refire + its real settings lib, next to a stubbed
+# predicate.
+mkdir -p "$TMP_ROOT/scripts/lib" "$TMP_ROOT/bin"
+cp "$SKILL_ROOT/scripts/approval-refire.sh" "$TMP_ROOT/scripts/"
+cp "$SKILL_ROOT/scripts/lib/settings.sh" "$TMP_ROOT/scripts/lib/"
+cat > "$TMP_ROOT/scripts/review-predicate.sh" <<'EOF'
+#!/usr/bin/env bash
+# Predicate stub: STUB_PREDICATE_RC != 0 simulates an evidence-read failure
+# (no verdict); otherwise STUB_VERDICT_LINE is the authoritative verdict.
+if [[ "${STUB_PREDICATE_RC:-0}" != "0" ]]; then
+  echo "::error::stubbed predicate failure" >&2
+  exit "${STUB_PREDICATE_RC}"
+fi
+printf '%s\n' "${STUB_VERDICT_LINE:?}"
+EOF
+chmod +x "$TMP_ROOT/scripts/review-predicate.sh" "$TMP_ROOT/scripts/approval-refire.sh"
+
+# Parametrized `gh` stub:
+#   STUB_GATE_HISTORY   JSON array (newest first) answered for
+#                       commits/<sha>/statuses; "fail" fails the read
+#   STUB_RUNS_MODE      completed|in_progress|empty|high_attempt — the
+#                       actions/runs?head_sha= listing
+#   STUB_POST_LOG       file collecting every status POST's args
+#   STUB_RERUN_LOG      file collecting every rerun POST's run id
+cat > "$TMP_ROOT/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -u
+[[ "${1:-}" == "api" ]] || { echo "unexpected gh command: $*" >&2; exit 1; }
+shift
+args="$*"
+case "$args" in
+  *"/rerun"*)
+    id="$(sed -n 's|.*actions/runs/\([0-9]*\)/rerun.*|\1|p' <<<"$args")"
+    echo "rerun:$id" >> "${STUB_RERUN_LOG:?}"
+    ;;
+  "-X POST "*"/statuses/"*)
+    echo "post:$args" >> "${STUB_POST_LOG:?}"
+    ;;
+  *"/commits/"*"/statuses"*)
+    if [[ "${STUB_GATE_HISTORY:-[]}" == "fail" ]]; then
+      echo "HTTP 500" >&2
+      exit 1
+    fi
+    printf '%s\n' "${STUB_GATE_HISTORY:-[]}"
+    ;;
+  *"/actions/runs?"*)
+    case "${STUB_RUNS_MODE:-completed}" in
+      completed)
+        echo '{"workflow_runs":[{"id":111,"name":"ci","status":"completed","conclusion":"success","event":"pull_request","run_attempt":1},{"id":222,"name":"push run","status":"completed","conclusion":"success","event":"push","run_attempt":1}]}' ;;
+      in_progress)
+        echo '{"workflow_runs":[{"id":111,"name":"ci","status":"in_progress","conclusion":null,"event":"pull_request","run_attempt":1}]}' ;;
+      empty)
+        echo '{"workflow_runs":[]}' ;;
+      high_attempt)
+        echo '{"workflow_runs":[{"id":111,"name":"ci","status":"completed","conclusion":"success","event":"pull_request","run_attempt":5}]}' ;;
+      *) echo "unknown STUB_RUNS_MODE" >&2; exit 1 ;;
+    esac
+    ;;
+  *)
+    echo "unexpected gh api call: $args" >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "$TMP_ROOT/bin/gh"
+
+# run_refire [ENV=val ...] — runs the refire under the stubs with the standard
+# identifiers and fresh POST/rerun logs; prints stdout, returns its exit code.
+# Settings resolve from /dev/null (built-in defaults) unless a case overrides
+# REVIEW_GATE_SETTINGS_FILE to exercise the file layer.
+POST_LOG="$TMP_ROOT/post.log"
+RERUN_LOG="$TMP_ROOT/rerun.log"
+run_refire() {
+  : > "$POST_LOG"
+  : > "$RERUN_LOG"
+  env PATH="$TMP_ROOT/bin:$PATH" \
+    GH_REPO=acme/widgets PR_NUMBER=7 HEAD_SHA=headsha PR_AUTHOR=pr-author \
+    REVIEW_GATE_SETTINGS_FILE=/dev/null \
+    STUB_POST_LOG="$POST_LOG" STUB_RERUN_LOG="$RERUN_LOG" \
+    "$@" bash "$TMP_ROOT/scripts/approval-refire.sh" 2>&1
+}
+
+AWAITING="verdict=awaiting detail=awaiting a non-author review for headsha"
+APPROVED="verdict=approved detail=reviewed at head with no unresolved threads"
+CR="verdict=changes-requested detail=review changes requested on the current head"
+THREADS="verdict=threads-open detail=unresolved review threads on the current head"
+
+echo "=== downward transitions are direct posts ==="
+
+out=$(run_refire STUB_VERDICT_LINE="$AWAITING" STUB_GATE_HISTORY='[]')
+assert_eq "$?" "0" "r1: awaiting exits 0"
+assert_contains "$(cat "$POST_LOG")" "state=pending" "r1: awaiting posts pending"
+assert_contains "$(cat "$POST_LOG")" "context=Review gate" "r1: post carries the default gate context"
+assert_eq "$(wc -l < "$RERUN_LOG")" "0" "r1: no rerun on a downward transition"
+
+out=$(run_refire STUB_VERDICT_LINE="$AWAITING" \
+  STUB_GATE_HISTORY='[{"context":"Review gate","state":"pending","description":"awaiting a non-author review for headsha"}]')
+assert_eq "$(wc -l < "$POST_LOG")" "0" "r2: already-pending same description posts nothing"
+assert_contains "$out" "nothing to do" "r2: reports the no-op"
+
+out=$(run_refire STUB_VERDICT_LINE="$CR" STUB_GATE_HISTORY='[]')
+assert_contains "$(cat "$POST_LOG")" "state=failure" "r3: changes-requested posts failure"
+assert_eq "$(wc -l < "$RERUN_LOG")" "0" "r3: no rerun on changes-requested"
+
+out=$(run_refire STUB_VERDICT_LINE="$THREADS" STUB_GATE_HISTORY='[]')
+assert_eq "$?" "0" "r13: threads-open exits 0"
+assert_contains "$(cat "$POST_LOG")" "state=pending" "r13: threads-open posts pending"
+assert_eq "$(wc -l < "$RERUN_LOG")" "0" "r13: no rerun on threads-open"
+
+echo "=== upward flip: success needs proof ==="
+
+out=$(run_refire STUB_VERDICT_LINE="$APPROVED" \
+  STUB_GATE_HISTORY='[{"context":"Review gate","state":"success","description":"ok"}]')
+assert_eq "$?" "0" "r4: approved with current success exits 0"
+assert_eq "$(wc -l < "$POST_LOG")" "0" "r4: current success posts nothing"
+assert_eq "$(wc -l < "$RERUN_LOG")" "0" "r4: current success reruns nothing"
+
+out=$(run_refire STUB_VERDICT_LINE="$APPROVED" \
+  STUB_GATE_HISTORY='[{"context":"Review gate","state":"pending","description":"x"},{"context":"Review gate","state":"success","description":"ok"}]')
+assert_contains "$(cat "$POST_LOG")" "state=success" "r5: prior success on the sha allows a direct success post"
+assert_eq "$(wc -l < "$RERUN_LOG")" "0" "r5: proof fast path never reruns"
+
+out=$(run_refire STUB_VERDICT_LINE="$APPROVED" STUB_GATE_HISTORY='[]' STUB_RUNS_MODE=completed)
+assert_eq "$?" "0" "r6: first approved flip exits 0"
+assert_eq "$(cat "$RERUN_LOG")" "rerun:111" "r6: full rerun of the completed pull_request run only (never the push run)"
+assert_eq "$(wc -l < "$POST_LOG")" "0" "r6: no direct success without proof"
+
+out=$(run_refire STUB_VERDICT_LINE="$APPROVED" STUB_GATE_HISTORY='[]' STUB_RUNS_MODE=high_attempt)
+assert_eq "$?" "0" "r7: attempt cap exits 0"
+assert_eq "$(wc -l < "$RERUN_LOG")" "0" "r7: run at MAX_ATTEMPTS is left alone"
+assert_contains "$out" "cap 5" "r7: warns about the cap"
+
+out=$(run_refire STUB_VERDICT_LINE="$APPROVED" STUB_GATE_HISTORY='[]' \
+  STUB_RUNS_MODE=high_attempt MAX_ATTEMPTS=6)
+assert_eq "$(cat "$RERUN_LOG")" "rerun:111" "r17: legacy MAX_ATTEMPTS env raises the cap (attempt 5 reruns under cap 6)"
+
+out=$(run_refire STUB_VERDICT_LINE="$APPROVED" STUB_GATE_HISTORY='[]' \
+  STUB_RUNS_MODE=in_progress QUIESCE=0)
+assert_eq "$?" "0" "r8: in-progress head under QUIESCE=0 exits 0"
+assert_eq "$(wc -l < "$RERUN_LOG")" "0" "r8: in-progress run is left to finish"
+assert_contains "$out" "still in progress" "r8: says why"
+
+echo "=== fail loud, act never ==="
+
+set +e
+out=$(run_refire STUB_PREDICATE_RC=2 STUB_GATE_HISTORY='[]')
+rc=$?
+set -e
+assert_eq "$rc" "1" "r9: predicate failure exits 1"
+assert_eq "$(wc -l < "$POST_LOG")$(wc -l < "$RERUN_LOG")" "00" "r9: no POST and no rerun on predicate failure"
+
+set +e
+out=$(run_refire STUB_VERDICT_LINE="$APPROVED" STUB_GATE_HISTORY=fail)
+rc=$?
+set -e
+assert_eq "$rc" "1" "r10: status-history read failure exits 1"
+assert_eq "$(wc -l < "$POST_LOG")$(wc -l < "$RERUN_LOG")" "00" "r10: no action on history read failure"
+
+set +e
+out=$(env PATH="$TMP_ROOT/bin:$PATH" GH_REPO=acme/widgets HEAD_SHA=headsha \
+  REVIEW_GATE_SETTINGS_FILE=/dev/null \
+  STUB_POST_LOG="$POST_LOG" STUB_RERUN_LOG="$RERUN_LOG" \
+  STUB_VERDICT_LINE="$AWAITING" bash "$TMP_ROOT/scripts/approval-refire.sh" 2>&1)
+rc=$?
+set -e
+assert_eq "$rc" "1" "r11: missing PR_NUMBER exits 1"
+
+set +e
+out=$(run_refire STUB_VERDICT_LINE="$AWAITING" STUB_GATE_HISTORY='[]' \
+  MAX_ATTEMPTS=lots)
+rc=$?
+set -e
+assert_eq "$rc" "1" "r16: non-integer rerun cap exits 1"
+
+echo "=== settings resolution (lib/settings.sh) ==="
+
+out=$(run_refire STUB_VERDICT_LINE="$APPROVED" REVIEW_GATE_CONTEXT="CI Required" \
+  STUB_GATE_HISTORY='[{"context":"Review gate","state":"success","description":"ok"}]' \
+  STUB_RUNS_MODE=completed)
+assert_eq "$(cat "$RERUN_LOG")" "rerun:111" "r12: another context's success is not proof - reruns instead"
+assert_eq "$(wc -l < "$POST_LOG")" "0" "r12: and posts no success"
+
+out=$(run_refire STUB_VERDICT_LINE="$AWAITING" REVIEW_GATE_CONTEXT="CI Required" STUB_GATE_HISTORY='[]')
+assert_contains "$(cat "$POST_LOG")" "context=CI Required" "r12: posts name the custom context"
+
+cat > "$TMP_ROOT/settings.toml" <<'EOF'
+REVIEW_GATE_CONTEXT = "File Gate"
+EOF
+out=$(run_refire STUB_VERDICT_LINE="$AWAITING" STUB_GATE_HISTORY='[]' \
+  REVIEW_GATE_SETTINGS_FILE="$TMP_ROOT/settings.toml")
+assert_eq "$?" "0" "r14: settings-file context exits 0"
+assert_contains "$(cat "$POST_LOG")" "context=File Gate" "r14: posts name the settings-file context"
+
+cat > "$TMP_ROOT/bad-settings.toml" <<'EOF'
+REVIEW_GATE_CONTEXT = ["Review gate", "Other"]
+EOF
+set +e
+out=$(run_refire STUB_VERDICT_LINE="$AWAITING" STUB_GATE_HISTORY='[]' \
+  REVIEW_GATE_SETTINGS_FILE="$TMP_ROOT/bad-settings.toml")
+rc=$?
+set -e
+assert_eq "$rc" "1" "r15: unparseable settings assignment exits 1"
+assert_contains "$out" "unsupported syntax" "r15: names the configuration error"
+assert_eq "$(wc -l < "$POST_LOG")$(wc -l < "$RERUN_LOG")" "00" "r15: no POST and no rerun on a config error"
+
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/skills/review-gate/tests/bash32-portability.test.sh
+++ b/skills/review-gate/tests/bash32-portability.test.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# The review-gate scripts run on consumer CI images and on macOS system Bash
+# 3.2, so shipped scripts may not use Bash 4+ builtins or syntax
+# (mapfile/readarray, associative arrays, automatic FD-allocation
+# redirections, case-conversion expansions).
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$TEST_DIR/../scripts" && pwd)"
+
+PATTERN='mapfile|readarray|declare -A|declare -gA|local -A'
+PATTERN="$PATTERN"'|(^|[^$])\{[A-Za-z_][A-Za-z0-9_]*\}[<>]'
+PATTERN="$PATTERN"'|\$\{[A-Za-z_][A-Za-z0-9_]*(\[[^]]*\])?(,,|\^\^)'
+
+violations="$(grep -rnE "$PATTERN" "$SCRIPTS_DIR" || true)"
+if [[ -n "$violations" ]]; then
+  echo "Bash 4+ constructs found in review-gate scripts (must run under Bash 3.2):" >&2
+  printf '%s\n' "$violations" >&2
+  exit 1
+fi
+
+# Syntax-check every shipped script while we are here.
+fail=0
+for f in "$SCRIPTS_DIR"/*.sh "$SCRIPTS_DIR"/lib/*.sh; do
+  if ! bash -n "$f"; then
+    echo "FAIL: bash -n $f"
+    fail=1
+  fi
+done
+[ "$fail" -eq 0 ] || exit 1
+
+echo "pass: bash32-portability"

--- a/skills/review-gate/tests/review-predicate-selftest.test.sh
+++ b/skills/review-gate/tests/review-predicate-selftest.test.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# The engine's core test: run the offline selftest end-to-end (it is
+# self-contained by design — gh shim + fixtures, no network) and prove both
+# of its layers:
+#   1. with no repo settings, the full decision table passes on the built-in
+#      defaults;
+#   2. with a repo-configured trust surface (different bot, different
+#      contexts, non-default floor/skip patterns/trust list), the configured
+#      layer regenerates its approve/near-miss battery from THOSE values —
+#      a repo trusting a different bot tests its own config, not defaults.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SELFTEST="$(cd "$TEST_DIR/../scripts" && pwd)/review-predicate-selftest.sh"
+
+fail=0
+note() { echo "FAIL: $1"; fail=1; }
+
+[ -x "$SELFTEST" ] || { echo "FAIL: not executable: $SELFTEST"; exit 1; }
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+# --- layer 1: built-in defaults (no settings file resolvable) ---------------
+mkdir -p "$work/defaults"
+if ! (cd "$work/defaults" && "$SELFTEST") >"$work/defaults.out" 2>&1; then
+  cat "$work/defaults.out"
+  note "selftest failed under built-in defaults"
+fi
+default_cases="$(sed -n 's/^review-predicate selftest: \([0-9]*\) case(s), all pass$/\1/p' "$work/defaults.out")"
+if [ -z "$default_cases" ] || [ "$default_cases" -lt 50 ]; then
+  note "expected >=50 default cases with a pass summary, got '${default_cases:-none}'"
+fi
+grep -q "rate-limited 'pass' check-run is NOT evidence" "$work/defaults.out" \
+  || note "rate-limited-pass fixture case missing"
+grep -q "approval NOT superseded by a later COMMENTED" "$work/defaults.out" \
+  || note "approval non-supersession case missing"
+grep -q "UNTRUSTED login's review is not evidence" "$work/defaults.out" \
+  || note "review-object trust-list case missing"
+
+# --- layer 2: the selftest must exercise CONFIGURED values ------------------
+mkdir -p "$work/configured"
+cat >"$work/configured/vstack.settings.toml" <<'EOF'
+[env]
+REVIEW_GATE_TRUSTED_STATUS_CONTEXTS = "Acme Review; Beta Scan"
+REVIEW_GATE_CHECKRUN_SKIP_PATTERNS = "quota exceeded"
+REVIEW_GATE_COMMENT_REVIEWERS = "acme-reviewer[bot]:Analysis (clean) for commit"
+REVIEW_GATE_SHA_PREFIX_FLOOR = "9"
+REVIEW_GATE_OUTAGE_CONTEXT = "acme-outage"
+REVIEW_GATE_REVIEW_OBJECT_TRUSTED_LOGINS = "acme-reviewer[bot];human-lead"
+REVIEW_GATE_REVIEW_OBJECT_MIN_STATE = "approved"
+EOF
+if ! (cd "$work/configured" && "$SELFTEST") >"$work/configured.out" 2>&1; then
+  cat "$work/configured.out"
+  note "selftest failed under a configured trust surface"
+fi
+configured_cases="$(sed -n 's/^review-predicate selftest: \([0-9]*\) case(s), all pass$/\1/p' "$work/configured.out")"
+if [ -z "$configured_cases" ] || [ "$configured_cases" -le "${default_cases:-0}" ]; then
+  note "configured run should add cases beyond the default run (default=${default_cases:-?}, configured=${configured_cases:-none})"
+fi
+# The battery must be generated FROM the configured values: each configured
+# context and the configured comment reviewer must appear as case subjects,
+# including their near-misses.
+grep -q '\[Acme Review\] clean commit status at head' "$work/configured.out" \
+  || note "configured context 'Acme Review' not exercised"
+grep -q '\[Beta Scan\] check-run under a DIFFERENT name' "$work/configured.out" \
+  || note "configured context 'Beta Scan' near-miss not exercised"
+grep -q "\[acme-reviewer\[bot\]\] SAME BODY, wrong author" "$work/configured.out" \
+  || note "configured comment reviewer near-miss battery not exercised"
+grep -q "success check-run but output says 'quota exceeded'" "$work/configured.out" \
+  || note "configured skip pattern not exercised"
+grep -q "login outside the repo trust list is not evidence" "$work/configured.out" \
+  || note "configured review-object trust list near-miss not exercised"
+grep -q "outage attestation (acme-outage)" "$work/configured.out" \
+  || note "configured outage context not exercised"
+
+if [ "$fail" -ne 0 ]; then
+  echo "review-predicate-selftest.test: FAIL"
+  exit 1
+fi
+echo "pass: review-predicate-selftest ($default_cases default / $configured_cases configured cases)"

--- a/skills/review-gate/tests/settings-example-sync.test.sh
+++ b/skills/review-gate/tests/settings-example-sync.test.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# The review-gate skill ships vstack.settings.toml.example so project
+# installs merge the engine's trust defaults. This test keeps that template
+# in lockstep with the repo-root vstack.settings.toml.example — every
+# REVIEW_GATE key must exist in BOTH files with IDENTICAL default values, so
+# the two places users learn the options can never drift.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_TEMPLATE="$SCRIPT_DIR/../vstack.settings.toml.example"
+ROOT_TEMPLATE="$SCRIPT_DIR/../../../vstack.settings.toml.example"
+
+GATE_KEYS="REVIEW_GATE_CONTEXT REVIEW_GATE_TRUSTED_STATUS_CONTEXTS REVIEW_GATE_CHECKRUN_SKIP_PATTERNS REVIEW_GATE_COMMENT_REVIEWERS REVIEW_GATE_SHA_PREFIX_FLOOR REVIEW_GATE_OUTAGE_CONTEXT REVIEW_GATE_REVIEW_OBJECT_TRUSTED_LOGINS REVIEW_GATE_REVIEW_OBJECT_MIN_STATE REVIEW_GATE_MAX_RERUN_ATTEMPTS REVIEW_GATE_TRUST_PR_WORKFLOWS"
+
+fail=0
+
+check() {
+  if ! eval "$2"; then
+    echo "FAIL: $1"
+    fail=1
+  fi
+}
+
+value_of() {
+  # First uncommented assignment of key $2 in file $1, value only.
+  sed -n "s/^$2 = \"\(.*\)\"$/\1/p" "$1" | head -1
+}
+
+check "review-gate skill template exists" "[ -f \"\$SKILL_TEMPLATE\" ]"
+check "root template exists (skip-safe in downstream installs)" "[ -f \"\$ROOT_TEMPLATE\" ] || exit 0"
+
+check "skill template declares [env]" "grep -q '^\[env\]' \"\$SKILL_TEMPLATE\""
+
+for key in $GATE_KEYS; do
+  skill_val="$(value_of "$SKILL_TEMPLATE" "$key")"
+  root_val="$(value_of "$ROOT_TEMPLATE" "$key")"
+  check "$key present in skill template" "grep -q \"^$key = \" \"\$SKILL_TEMPLATE\""
+  check "$key present in root template" "grep -q \"^$key = \" \"\$ROOT_TEMPLATE\""
+  if [ "$skill_val" != "$root_val" ]; then
+    echo "FAIL: $key default drift: skill='$skill_val' root='$root_val'"
+    fail=1
+  fi
+done
+
+# The security caveats must travel with the keys that need them: name-matched
+# evidence trust and the workflow trust posture.
+for caveat_key in REVIEW_GATE_TRUSTED_STATUS_CONTEXTS REVIEW_GATE_COMMENT_REVIEWERS REVIEW_GATE_OUTAGE_CONTEXT REVIEW_GATE_TRUST_PR_WORKFLOWS; do
+  check "$caveat_key carries the SECURITY caveat in the skill template" \
+    "grep -B12 \"^$caveat_key = \" \"\$SKILL_TEMPLATE\" | grep -qi 'SECURITY'"
+done
+
+if [ "$fail" -ne 0 ]; then
+  echo "settings-example-sync: FAIL"
+  exit 1
+fi
+echo "pass: settings-example-sync"

--- a/skills/review-gate/tests/settings-vars-documented.test.sh
+++ b/skills/review-gate/tests/settings-vars-documented.test.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Doc-contract lint: every REVIEW_GATE_* variable the engine's scripts or
+# templates reference must be documented — in SKILL.md (or
+# references/adoption.md) for readers, and in the skill's
+# vstack.settings.toml.example for installers. A knob that exists only in
+# code is a knob nobody can find.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
+
+fail=0
+
+vars="$(grep -rhoE 'REVIEW_GATE_[A-Z_]+' \
+  "$SKILL_DIR/scripts" "$SKILL_DIR/templates" | sort -u)"
+[ -n "$vars" ] || { echo "FAIL: no REVIEW_GATE_* variables found in scripts/"; exit 1; }
+
+for v in $vars; do
+  if ! grep -q "$v" "$SKILL_DIR/SKILL.md" "$SKILL_DIR/references/adoption.md" "$SKILL_DIR/references/settings.md"; then
+    echo "FAIL: $v is read by the engine but documented in none of SKILL.md, references/adoption.md, references/settings.md"
+    fail=1
+  fi
+  # REVIEW_GATE_SETTINGS_FILE is an env-only test/dev override, not a
+  # settings key — it must not appear as a settings assignment.
+  if [ "$v" = "REVIEW_GATE_SETTINGS_FILE" ]; then
+    continue
+  fi
+  if ! grep -q "^$v = " "$SKILL_DIR/vstack.settings.toml.example"; then
+    echo "FAIL: $v missing from the skill's vstack.settings.toml.example"
+    fail=1
+  fi
+done
+
+# Reverse direction: every key the example documents must be real — either
+# read by the scripts or an explicitly wiring-level key named in SKILL.md.
+for key in $(sed -n 's/^\(REVIEW_GATE_[A-Z_]*\) = .*/\1/p' "$SKILL_DIR/vstack.settings.toml.example"); do
+  if ! printf '%s\n' "$vars" | grep -qx "$key" && ! grep -q "$key" "$SKILL_DIR/SKILL.md" "$SKILL_DIR/references/settings.md"; then
+    echo "FAIL: $key is documented in the example but neither read by scripts nor described in SKILL.md/references/settings.md"
+    fail=1
+  fi
+done
+
+if [ "$fail" -ne 0 ]; then
+  echo "settings-vars-documented: FAIL"
+  exit 1
+fi
+echo "pass: settings-vars-documented"

--- a/skills/review-gate/vstack.settings.toml.example
+++ b/skills/review-gate/vstack.settings.toml.example
@@ -1,0 +1,79 @@
+[env]
+
+# REVIEW GATE — shared merge-gate engine (review-gate skill).
+# Project-scope `vstack add` / `vstack refresh` merge these defaults into
+# <project>/vstack.settings.toml (never overwriting existing keys). The
+# scripts resolve each key environment-first, then this file, then the
+# built-in default. List values pack into one string with ';' separators.
+# Full reference: review-gate SKILL.md and references/adoption.md.
+
+# Commit-status context the gate posts on PR heads — the required check name
+# in branch protection. Keep it stable: changing it strands the old required
+# context on open PRs until branch protection is updated to match.
+REVIEW_GATE_CONTEXT = "Review gate"
+
+# Clean-analysis evidence: exact names of the trusted reviewer's check-run
+# and/or legacy commit status; a success for a listed name on the current
+# head counts as review evidence (for bots that submit a review object only
+# when they have findings). Both APIs are queried; either counts. SECURITY:
+# check-runs and statuses are matched by NAME, and any GitHub App or Actions
+# workflow can publish under any name — list only names produced by trusted
+# bots, on repos where every publisher is trusted.
+REVIEW_GATE_TRUSTED_STATUS_CONTEXTS = "Devin Review"
+
+# A trusted "pass" must prove analysis RAN: a success whose check-run
+# output/status description contains one of these case-insensitive
+# substrings (e.g. a reviewer that posts its check as pass with "Review rate
+# limited" after doing nothing) is treated as NOT-EVIDENCE — the same as
+# absent, never a failure. Empty disables the filter (an explicit choice to
+# trust every success blindly).
+REVIEW_GATE_CHECKRUN_SKIP_PATTERNS = "rate limited;skipped;queued"
+
+# Comment-form reviewers: 'login:binding-pattern' pairs for bots whose clean
+# pass is only an issue comment on the PR conversation (no review object, no
+# check/status). The first ':' splits login from pattern; the pattern is a
+# LITERAL prefix that must precede the bound commit sha in the body (e.g.
+# "chatgpt-codex-connector[bot]:Reviewed commit:"). SECURITY: trust keys on
+# the author LOGIN (only GitHub can set it); the body is read only to bind
+# the evidence to a commit. Empty disables the source.
+REVIEW_GATE_COMMENT_REVIEWERS = ""
+
+# Shortest sha prefix (4–40) a comment-form reviewer may bind evidence to;
+# git's short-sha default. A degenerate prefix must not match every head.
+REVIEW_GATE_SHA_PREFIX_FLOOR = "7"
+
+# Reviewer-outage attestation: commit-status context a trusted orchestrator
+# posts on the head ONLY on genuine total reviewer silence. Substitutes for
+# MISSING review evidence only — changes-requested and unresolved threads
+# still fail closed. SECURITY: a deliberate, bounded relaxation with the
+# same trusted-publisher model as REVIEW_GATE_TRUSTED_STATUS_CONTEXTS; name
+# it only where every status publisher is trusted. Empty disables.
+REVIEW_GATE_OUTAGE_CONTEXT = "vstack-reviewer-outage"
+
+# Review-object trust list: logins whose review objects at the exact head
+# count as evidence. Empty = any non-author (the compatible default; on
+# repos with outside read-access collaborators this means any drive-by
+# COMMENTED review satisfies the gate — set the list to close that).
+REVIEW_GATE_REVIEW_OBJECT_TRUSTED_LOGINS = ""
+
+# Minimum review-object state that counts as evidence: "any" (any
+# non-dismissed row) or "approved" (an APPROVED at head not withdrawn by a
+# LATER CHANGES_REQUESTED from the same login; a trailing COMMENTED never
+# supersedes an approval).
+REVIEW_GATE_REVIEW_OBJECT_MIN_STATE = "any"
+
+# Rerun backstop for approval-refire.sh: runs at/above this attempt count
+# are left alone (gh run rerun retries manually). The cap exists for
+# pathological evidence ping-pong, not normal review cycles.
+REVIEW_GATE_MAX_RERUN_ATTEMPTS = "5"
+
+# Trust posture for the CI gate job (consumed by workflow WIRING, not by the
+# scripts — see references/adoption.md). SECURITY: "false" (default, safe) =
+# the gate job runs the predicate from the BASE revision with a read-only
+# token and posts the status from a separate minimal-permission step; a PR
+# cannot execute its own predicate copy under a write-capable token. "true"
+# = deliberately self-evaluating (PR-head predicate) for the bootstrap
+# property that a gate-fix PR can open its own gate — defensible only on
+# private, effectively single-author repos; this key makes that choice
+# explicit and visible.
+REVIEW_GATE_TRUST_PR_WORKFLOWS = "false"

--- a/skills/review-gate/vstack.settings.toml.example
+++ b/skills/review-gate/vstack.settings.toml.example
@@ -19,7 +19,11 @@ REVIEW_GATE_CONTEXT = "Review gate"
 # check-runs and statuses are matched by NAME, and any GitHub App or Actions
 # workflow can publish under any name — list only names produced by trusted
 # bots, on repos where every publisher is trusted.
-REVIEW_GATE_TRUSTED_STATUS_CONTEXTS = "Devin Review"
+# Default is EMPTY (source disabled): trust is opt-in per repo, never a
+# shipped vendor default. Example for a repo whose reviewer posts a
+# check/status under the name "Devin Review":
+# REVIEW_GATE_TRUSTED_STATUS_CONTEXTS = "Devin Review"
+REVIEW_GATE_TRUSTED_STATUS_CONTEXTS = ""
 
 # A trusted "pass" must prove analysis RAN: a success whose check-run
 # output/status description contains one of these case-insensitive

--- a/vstack.settings.toml.example
+++ b/vstack.settings.toml.example
@@ -186,6 +186,71 @@ VSTACK_GITHUB_AUTH_TIMEOUT = "10"
 VSTACK_GITHUB_PR_VIEW_TIMEOUT = "30"
 # Used by: github (`pr-view`).
 
+# REVIEW GATE (shared CI merge-gate engine)
+# The review-gate scripts resolve each key environment-first, then this file,
+# then the built-in default. List values pack into one string with ';'
+# separators. Full reference: review-gate SKILL.md / references/adoption.md.
+
+REVIEW_GATE_CONTEXT = "Review gate"
+# Used by: review-gate (`approval-refire.sh`, the CI gate job). Commit-status
+# context the gate posts on PR heads — the required check name in branch
+# protection. Keep it stable.
+
+REVIEW_GATE_TRUSTED_STATUS_CONTEXTS = "Devin Review"
+# Used by: review-gate (`review-predicate.sh`). Exact names of the trusted
+# reviewer's clean-analysis check-run and/or legacy commit status; a success
+# for a listed name on the current head counts as review evidence. SECURITY:
+# matched by NAME, and any GitHub App or workflow can publish under any name
+# — list only trusted bots' checks, on repos where all publishers are trusted.
+
+REVIEW_GATE_CHECKRUN_SKIP_PATTERNS = "rate limited;skipped;queued"
+# Used by: review-gate (`review-predicate.sh`). A trusted "pass" must prove
+# analysis RAN: a success whose output/description contains one of these
+# case-insensitive substrings is NOT-EVIDENCE (same as absent, never a
+# failure). Empty disables the filter.
+
+REVIEW_GATE_COMMENT_REVIEWERS = ""
+# Used by: review-gate (`review-predicate.sh`). 'login:binding-pattern' pairs
+# for bots whose clean pass is only an issue comment (no review object, no
+# check/status); the first ':' splits, the pattern is a LITERAL prefix that
+# must precede the bound commit sha. SECURITY: trust keys on the author
+# LOGIN; the body is read only to bind evidence to a commit. Empty disables.
+
+REVIEW_GATE_SHA_PREFIX_FLOOR = "7"
+# Used by: review-gate (`review-predicate.sh`). Shortest sha prefix (4–40) a
+# comment-form reviewer may bind evidence to.
+
+REVIEW_GATE_OUTAGE_CONTEXT = "vstack-reviewer-outage"
+# Used by: review-gate (`review-predicate.sh`) — and orch's
+# PR_REVIEW_OUTAGE_CONTEXT is the writer side of the same context.
+# Reviewer-outage attestation status; substitutes for MISSING review
+# evidence only. SECURITY: same trusted-publisher model as
+# REVIEW_GATE_TRUSTED_STATUS_CONTEXTS. Empty disables.
+
+REVIEW_GATE_REVIEW_OBJECT_TRUSTED_LOGINS = ""
+# Used by: review-gate (`review-predicate.sh`). Logins whose review objects
+# at the exact head count as evidence. Empty = any non-author (compatible
+# default; set the list to stop drive-by collaborator reviews satisfying the
+# gate).
+
+REVIEW_GATE_REVIEW_OBJECT_MIN_STATE = "any"
+# Used by: review-gate (`review-predicate.sh`). "any" or "approved"
+# (an APPROVED at head not withdrawn by a LATER CHANGES_REQUESTED from the
+# same login; a trailing COMMENTED never supersedes an approval).
+
+REVIEW_GATE_MAX_RERUN_ATTEMPTS = "5"
+# Used by: review-gate (`approval-refire.sh`). Rerun backstop for
+# pathological evidence ping-pong, not normal review cycles.
+
+REVIEW_GATE_TRUST_PR_WORKFLOWS = "false"
+# Used by: review-gate (workflow WIRING, not the scripts — see
+# references/adoption.md). SECURITY: "false" (default, safe) = the gate job
+# runs the predicate from the BASE revision with a read-only token and posts
+# the status from a separate minimal-permission step. "true" = deliberately
+# self-evaluating (a gate-fix PR can open its own gate) — defensible only on
+# private, effectively single-author repos; this key makes that choice
+# explicit.
+
 # SECOND OPINION
 
 SECOND_OPINION_TARGET = "codex"

--- a/vstack.settings.toml.example
+++ b/vstack.settings.toml.example
@@ -196,7 +196,7 @@ REVIEW_GATE_CONTEXT = "Review gate"
 # context the gate posts on PR heads — the required check name in branch
 # protection. Keep it stable.
 
-REVIEW_GATE_TRUSTED_STATUS_CONTEXTS = "Devin Review"
+REVIEW_GATE_TRUSTED_STATUS_CONTEXTS = ""
 # Used by: review-gate (`review-predicate.sh`). Exact names of the trusted
 # reviewer's clean-analysis check-run and/or legacy commit status; a success
 # for a listed name on the current head counts as review evidence. SECURITY:

--- a/vstack.toml
+++ b/vstack.toml
@@ -87,6 +87,7 @@ generalist = [
     "dev",
     "linear",
     "dep-radar",
+    "review-gate",
 ]
 
 planner = [


### PR DESCRIPTION
Part of #996 and #997 (owner-directed) — the vstack-side half; the issues close when the three consumer adoption PRs land.

Lifts memsira's review-gate machinery (the 2026-07-29 status-model redesign + the #387 comment-form carve-out and offline selftest) into a shared `review-gate` skill, with every per-repo literal promoted to a `REVIEW_GATE_*` settings variable (env > vstack.settings.toml > default):

- **`review-predicate.sh`** — the four-source evidence predicate (non-author review object at exact head with explicit non-supersession reduction; trusted check-run/status; comment-form carve-out with literal-bound binding pattern; outage attestation), fail-loud on every read, fail-closed on changes-requested, thread overflow, and config errors.
- **#997 add-ons in-engine:** `REVIEW_GATE_REVIEW_OBJECT_TRUSTED_LOGINS` (empty = any non-author, adoption-non-breaking) + `REVIEW_GATE_REVIEW_OBJECT_MIN_STATE` (any|approved); and trusted check-run passes must prove analysis ran — `REVIEW_GATE_CHECKRUN_SKIP_PATTERNS` routes rate-limited/skipped/queued 'passes' to not-evidence (default-on with the requirement's own list; the memsira-#384-observed "Review rate limited" success fixture is pinned).
- **Security posture (memsira #384 findings):** templates pin checkout to the default branch AND set persist-credentials:false (memsira's current copies lack the latter); adoption docs specify the read-only-evaluate / no-checkout-post two-job wiring; `REVIEW_GATE_TRUST_PR_WORKFLOWS` defaults false.
- **`review-predicate-selftest.sh`** — the portable decision-table proof: 59 cases at defaults + a generated 75-case battery under a foreign trust config, run by every consumer's CI ungated. It caught a real jq-scoping bug in this very build (a skip-pattern filter that would have silently degraded every genuine clean pass) before anything shipped.
- **Adoption:** `references/adoption.md` carries per-consumer PR shapes (memsira deletes local copies; drovr wires fresh incl. its no-sweep state; hyprtrade's different convergence architecture flagged), repo-side branch-protection wiring, and the per-repo variable table. Workflow YAML ships as one-time scaffolds in `templates/` per existing skill conventions — an alternative (vstack-hosted reusable workflows via workflow_call) is viable if you prefer zero YAML drift at the cost of a new cross-repo mechanism; flagging for owner preference.

Registered in vstack.toml (generalist agent-skills, same as the last skill addition) with the settings-example sync-test pattern orch/linear use. All 4 skill tests + both selftest layers green.

https://claude.ai/code/session_01Wbt7N7TTxEDPNxKFAC5jWC