### PR TITLE
chore: check in AI-reviewer config for CodeRabbit and Qodo Merge

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -92,13 +92,18 @@ reviews:
     - path: "skills/**/{scripts,tests}/**"
       instructions: >-
         Shell here must stay Bash 3.2-compatible — flag mapfile, declare -A,
-        "${var,,}" and other Bash 4+ constructs as real defects. New scripts
-        and tests must carry the executable bit (CI lints this); flag files
-        added without it.
+        "${var,,}" and other Bash 4+ constructs as real defects. New shell
+        tests (tests/*.sh) and scripts/* files must carry the executable bit
+        (CI lints this) — sourced scripts/lib/ libraries are the exception,
+        and non-shell tests (e.g. .mjs) need no executable bit; flag only
+        those in-scope shapes added without it.
     - path: "cli/**"
       instructions: >-
         Rust workspace; repo convention runs cargo test and clippy. Code that
         writes vstack.toml or vstack.settings.toml must never reformat content
         inside TOML string values — flag any line-oriented pass over TOML text
         that is not aware of string state; this has corrupted user config
-        before.
+        before. Inline #[cfg(test)] modules deliberately use the OS tempdir
+        (std::env::temp_dir) with cleanup — the repo's "<worktree>/tmp/" rule
+        governs agent working artifacts, not test-runtime fixtures; do not
+        flag OS-tempdir use inside test code.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,104 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+#
+# Checked-in CodeRabbit config. A committed .coderabbit.yaml SUPERSEDES org and
+# repo UI settings entirely, so this file encodes the full intended state —
+# never treat it as a delta on top of the dashboard.
+#
+# Review-completion evidence surfaces:
+#   - Formal PR review (review_status + request_changes_workflow below): the
+#     surface our merge tooling consumes — skills/github pr-review-status and
+#     pr-merge read login-attributed formal reviews and review threads.
+#   - Commit status named "CodeRabbit" (commit_status below): consumed only
+#     name-agnostically via `gh pr checks` in pr-merge, where a pending review
+#     blocks merge like any other pending context.
+# Manual `@coderabbitai review` may be deferred under rate windows; the merge
+# flow tolerates that latency (pending status just holds the merge gate).
+
+reviews:
+  # Formal-review surfaces pinned on. request_changes_workflow makes CodeRabbit
+  # approve on its own once its change requests are resolved, which is what
+  # converges a changes-requested verdict without human dismissal.
+  review_status: true
+  commit_status: true
+  request_changes_workflow: true
+
+  # One PR summary max across all bots: all duplicative decoration off.
+  high_level_summary: false
+  high_level_summary_in_walkthrough: false
+  changed_files_summary: false
+  sequence_diagrams: false
+  estimate_code_review_effort: false
+  assess_linked_issues: false
+  related_issues: false
+  related_prs: false
+  suggested_labels: false
+  auto_apply_labels: false
+  suggested_reviewers: false
+  poem: false
+  in_progress_fortune: false
+
+  auto_review:
+    enabled: true
+    # Review PRs against any base branch: avoids base-branch mis-detection and
+    # covers stacked PRs.
+    base_branches: [".*"]
+    drafts: false
+
+  # Exclude only zero-review-value machine blobs. Bundles and vendored code
+  # stay in review scope.
+  path_filters:
+    - "!**/package-lock.json"
+    - "!cli/Cargo.lock"
+    - "!**/.test-output/**"
+
+  path_instructions:
+    - path: "{skills,pi-extensions,cli}/**/tests/**"
+      instructions: >-
+        Tests deliberately use the OS tempdir (mktemp, os.tmpdir,
+        std::env::temp_dir) with cleanup so fixtures cannot dirty the git
+        tree. The repo's "<worktree>/tmp/" rule governs agent working
+        artifacts, not test-runtime fixtures — do not flag OS-tempdir use in
+        tests as a violation of it.
+    - path: "pi-extensions/*/bundle/**"
+      instructions: >-
+        Files here are committed esbuild artifacts of the extension's src/.
+        Findings in bundle output are legitimate, but frame every finding
+        against the corresponding src/ file and never propose patching the
+        bundle itself — bundles are rebuilt from src/, not edited.
+    - path: "{pi-extensions,skills}/**"
+      instructions: >-
+        Consumer repos vendor these extensions and skills and re-vendor in
+        deliberate batches; each extension's CHANGELOG.md is the
+        consumer-facing delta contract. Treat cross-repo consumer-sync
+        observations as coordination notes, not merge blockers.
+    - path: "skills/**/schemas/**/*.md"
+      instructions: >-
+        Schema and reference docs carry issue-number provenance by established
+        convention. Do not flag issue citations here — the repo ban on
+        issue-number citations applies to instruction-flow skill/agent
+        markdown, not schema/reference docs.
+    - path: "skills/**/SKILL.md"
+      instructions: >-
+        Skills follow mechanism-over-prose. Do not propose adding defensive
+        caveat paragraphs, history, or editorializing to always-loaded
+        SKILL.md content — propose a concrete mechanism (validation, script,
+        schema) or nothing.
+    - path: "hooks/**"
+      instructions: >-
+        Security containment here is deliberately fail-closed allowlisting
+        (e.g. the connectors-mode PreToolUse hook). The allowlist design is
+        intended — do not recommend switching to denylists or loosening the
+        fail-closed posture.
+    - path: "skills/**/{scripts,tests}/**"
+      instructions: >-
+        Shell here must stay Bash 3.2-compatible — flag mapfile, declare -A,
+        "${var,,}" and other Bash 4+ constructs as real defects. New scripts
+        and tests must carry the executable bit (CI lints this); flag files
+        added without it.
+    - path: "cli/**"
+      instructions: >-
+        Rust workspace; repo convention runs cargo test and clippy. Code that
+        writes vstack.toml or vstack.settings.toml must never reformat content
+        inside TOML string values — flag any line-oriented pass over TOML text
+        that is not aware of string state; this has corrupted user config
+        before.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,18 @@
+# VStack
+
+VStack is a distribution of agent-stack assets: reusable skills (`skills/`,
+Bash 3.2 scripts plus markdown), agent definitions (`agents/`), lifecycle
+hooks (`hooks/`), Pi extensions (`pi-extensions/`, TypeScript with committed
+esbuild bundles), and a Rust CLI (`cli/`) that installs and refreshes these
+into consuming repositories. Working conventions live in the root `AGENTS.md`.
+
+## Review norms
+
+- Tests deliberately use the OS tempdir (`mktemp`, `os.tmpdir`,
+  `std::env::temp_dir`) with cleanup so fixtures cannot dirty the git tree.
+  The repo's `<worktree>/tmp/` scratch rule governs agent working artifacts,
+  not test fixtures — do not flag OS-tempdir use in tests.
+- Consumer repos vendor the skills and Pi extensions and re-vendor in
+  deliberate batches. Cross-repo consumer-sync impacts are coordination
+  notes, not merge blockers; each extension's `CHANGELOG.md` is the
+  consumer-facing delta contract.

--- a/.github/instructions/cli.instructions.md
+++ b/.github/instructions/cli.instructions.md
@@ -6,3 +6,7 @@ Rust workspace; repo convention runs `cargo test` and `cargo clippy`. Code
 that writes `vstack.toml` or `vstack.settings.toml` must never reformat
 content inside TOML string values — flag any line-oriented pass over TOML
 text that is not string-state-aware; this has corrupted user config before.
+Inline `#[cfg(test)]` modules deliberately use the OS tempdir
+(`std::env::temp_dir`) with cleanup — the repo's `<worktree>/tmp/` rule
+governs agent working artifacts, not test-runtime fixtures; do not flag
+OS-tempdir use inside test code.

--- a/.github/instructions/cli.instructions.md
+++ b/.github/instructions/cli.instructions.md
@@ -1,0 +1,8 @@
+---
+applyTo: "cli/**"
+---
+
+Rust workspace; repo convention runs `cargo test` and `cargo clippy`. Code
+that writes `vstack.toml` or `vstack.settings.toml` must never reformat
+content inside TOML string values — flag any line-oriented pass over TOML
+text that is not string-state-aware; this has corrupted user config before.

--- a/.github/instructions/hooks.instructions.md
+++ b/.github/instructions/hooks.instructions.md
@@ -1,0 +1,7 @@
+---
+applyTo: "hooks/**"
+---
+
+Security containment here is deliberately fail-closed allowlisting (e.g. the
+connectors-mode PreToolUse hook). The allowlist design is intended — do not
+recommend switching to denylists or loosening the fail-closed posture.

--- a/.github/instructions/pi-extension-bundles.instructions.md
+++ b/.github/instructions/pi-extension-bundles.instructions.md
@@ -1,0 +1,8 @@
+---
+applyTo: "pi-extensions/*/bundle/**"
+---
+
+Files here are committed esbuild artifacts of the extension's `src/`.
+Findings in bundle output are legitimate, but frame each finding against the
+corresponding `src/` file and never propose patching the bundle itself —
+bundles are rebuilt from `src/`, not edited.

--- a/.github/instructions/skills-and-agents.instructions.md
+++ b/.github/instructions/skills-and-agents.instructions.md
@@ -10,7 +10,9 @@ applyTo: "skills/**,agents/**"
   but `skills/*/schemas/*.md` reference docs carry issue provenance by
   established convention — do not flag citations there.
 - Shell scripts and tests must stay Bash 3.2-compatible: flag `mapfile`,
-  `declare -A`, `${var,,}` and other Bash 4+ constructs as real defects. New
+  `declare -A`, `${var,,}` and other Bash 4+ constructs as real defects —
+  unless the skill's own SKILL.md documents a newer-Bash dependency (e.g.
+  `skills/linear` requires Bash 4.0+; its lint tests reflect that). New
   `tests/*.sh` and `scripts/*` files must carry the executable bit (CI lints
   this) — sourced `scripts/lib/` libraries are the exception, and non-shell
   tests (e.g. `.mjs`) need none; flag only those in-scope shapes added

--- a/.github/instructions/skills-and-agents.instructions.md
+++ b/.github/instructions/skills-and-agents.instructions.md
@@ -11,5 +11,7 @@ applyTo: "skills/**,agents/**"
   established convention — do not flag citations there.
 - Shell scripts and tests must stay Bash 3.2-compatible: flag `mapfile`,
   `declare -A`, `${var,,}` and other Bash 4+ constructs as real defects. New
-  scripts and tests must carry the executable bit (CI lints this) — flag
-  files added without it.
+  `tests/*.sh` and `scripts/*` files must carry the executable bit (CI lints
+  this) — sourced `scripts/lib/` libraries are the exception, and non-shell
+  tests (e.g. `.mjs`) need none; flag only those in-scope shapes added
+  without it.

--- a/.github/instructions/skills-and-agents.instructions.md
+++ b/.github/instructions/skills-and-agents.instructions.md
@@ -1,0 +1,15 @@
+---
+applyTo: "skills/**,agents/**"
+---
+
+- Skill and agent markdown follows mechanism-over-prose: do not propose
+  defensive caveat paragraphs, history notes, or editorializing in
+  always-loaded content (`SKILL.md`, agent definitions) — propose a concrete
+  mechanism (validation, script, schema) or nothing.
+- Issue-number citations are banned in instruction-flow skill/agent markdown,
+  but `skills/*/schemas/*.md` reference docs carry issue provenance by
+  established convention — do not flag citations there.
+- Shell scripts and tests must stay Bash 3.2-compatible: flag `mapfile`,
+  `declare -A`, `${var,,}` and other Bash 4+ constructs as real defects. New
+  scripts and tests must carry the executable bit (CI lints this) — flag
+  files added without it.

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,0 +1,42 @@
+# Qodo Merge (14-day trial) — secondary reviewer. Keep this file minimal and
+# self-contained: nothing else in the repo references Qodo, and no merge
+# tooling or trusted-evidence config names it, so ending the trial is exactly
+# `git rm .pr_agent.toml`.
+
+[github_app]
+# Auto-review only. /agentic_describe is deliberately absent: CodeRabbit's
+# review comment is the single PR summary; Qodo posts no describe/summary
+# decoration.
+pr_commands = ["/agentic_review"]
+# Re-review pushed commits so follow-up batches get covered, matching
+# CodeRabbit's incremental reviews.
+handle_push_trigger = true
+
+[review_agent]
+issues_user_guidelines = """
+- Tests under skills/, pi-extensions/, and cli/ deliberately use the OS
+  tempdir (mktemp, os.tmpdir, std::env::temp_dir) with cleanup. That is not a
+  violation of the repo's "<worktree>/tmp/" scratch rule, which governs agent
+  working artifacts only.
+- pi-extensions/*/bundle/ files are committed esbuild artifacts of src/:
+  report findings against the corresponding src/ file and never propose
+  editing the bundle — it is rebuilt, not patched.
+- Fail-closed allowlists in hooks/ (e.g. the connectors-mode PreToolUse hook)
+  are the intended security design; do not propose denylists or loosening.
+- Skill scripts and tests must be Bash 3.2-compatible (no mapfile, declare -A,
+  "${var,,}") and new scripts/tests need the executable bit — these are real
+  defects, report them.
+- In cli/ (Rust), writers of vstack.toml / vstack.settings.toml must never
+  reformat content inside TOML string values; report any line-oriented TOML
+  pass that is not string-state-aware.
+"""
+compliance_user_guidelines = """
+- Issue-number citations are banned in instruction-flow skill/agent markdown,
+  but skills/*/schemas/*.md reference docs carry issue provenance by
+  established convention — do not flag citations there.
+- Cross-repo consumer-sync impacts (consumer repos vendor the extensions and
+  skills) are coordination notes, not merge blockers; each extension's
+  CHANGELOG.md is the consumer-facing delta contract.
+- SKILL.md files follow mechanism-over-prose: do not request defensive caveat
+  paragraphs or history notes; request a concrete mechanism or nothing.
+"""

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -24,8 +24,10 @@ issues_user_guidelines = """
 - Fail-closed allowlists in hooks/ (e.g. the connectors-mode PreToolUse hook)
   are the intended security design; do not propose denylists or loosening.
 - Skill scripts and tests must be Bash 3.2-compatible (no mapfile, declare -A,
-  "${var,,}") and new scripts/tests need the executable bit — these are real
-  defects, report them.
+  "${var,,}") — these are real defects, report them. New tests/*.sh and
+  scripts/* files need the executable bit (CI lints this); sourced
+  scripts/lib/ libraries are the exception, and non-shell tests (e.g. .mjs)
+  need none.
 - In cli/ (Rust), writers of vstack.toml / vstack.settings.toml must never
   reformat content inside TOML string values; report any line-oriented TOML
   pass that is not string-state-aware.


### PR DESCRIPTION
Checked-in reviewer-behavior config, shipped as review-policy through the normal gate.

**`.coderabbit.yaml`** (primary, paid): full intended state — a committed file supersedes the UI entirely, so nothing lives only in the dashboard. Formal-review surfaces pinned on (`review_status`, `commit_status`, `request_changes_workflow` — the last now defaults false upstream, so pinning is load-bearing; its resolve-then-auto-approve behavior is what converged #995 without human dismissal). All decoration off (one PR summary max across bots). `auto_review.base_branches: [".*"]` sidesteps the base-branch mis-detection failure mode and covers stacked PRs. `path_filters` exclude only lockfiles and test output — bundles and vendored code stay reviewable (a bundle-read has found a real bug). Eight `path_instructions` blocks, each grounded in a recurring misfire from this repo's own review history across ~15 PRs on 2026-08-02: the OS-tempdir-in-tests false positive (hit 4×), bundle-artifact framing, consumer-sync findings as coordination notes, schema-doc issue-provenance convention vs the instruction-md citation ban, mechanism-over-prose for SKILL.md, fail-closed allowlists as design, real Bash-3.2/exec-bit violations to flag hard, and the cli/ TOML string-state corruption class (#1006).

**`.pr_agent.toml`** (Qodo, 14-day trial): minimal and deletable — `[github_app] pr_commands=["/agentic_review"]` (no describe/summary), `[review_agent]` guidelines carrying the same top misfire rules. Zero coupling anywhere: trial teardown is `git rm .pr_agent.toml`. Qodo's name appears in no trusted-evidence config.

**Evidence-surface audit** (the forgery question): our merge tooling consumes only login-attributed surfaces — formal reviews, sticky comments, reactions, review threads (`pr-review-status`/`bot_review_status`), plus `gh pr checks` name-agnostically. Nothing trusts a commit status by the name "CodeRabbit", so a `github-actions[bot]`-forged status cannot fake review approval; a pending CodeRabbit status simply holds the merge, which is the desired rate-window latency tolerance.

Schema verified against https://coderabbit.ai/integrations/schema.v2.json (fetched today; structural check clean); Qodo keys verified against current docs.qodo.ai (v2 — guidelines moved from `[pr_reviewer]` to `[review_agent]`).

https://claude.ai/code/session_01Wbt7N7TTxEDPNxKFAC5jWC

---

**Second commit — GitHub Copilot code review** (owner follow-up, verified against current GitHub docs): Copilot code review reads three repo surfaces — `.github/copilot-instructions.md` (repo-wide, added: one-paragraph repo description serving all Copilot surfaces + the two cross-cutting review norms), root `AGENTS.md` (already exists — covered for free), and path-scoped `.github/instructions/*.instructions.md` with `applyTo` globs (four added, mirroring the CodeRabbit path_instructions: skills/agents norms, bundle framing, hooks allowlist design, cli TOML string-state rule). All terse — docs cap repo-wide instructions at ~2 pages and long files degrade.

**Repo-side wiring (settings, not files):** enable auto-review via a branch ruleset — Settings → Rules → Rulesets → new Active ruleset targeting the default branch → "Automatically request Copilot code review" + "Review new pushes", drafts off (matches CodeRabbit). An org-level ruleset variant exists if we want it once for all repos.

**Evidence note:** Copilot submits Comment-only reviews — never approve/request-changes — so it cannot satisfy or block required approvals and must NOT be added to BOT_REVIEWERS (it would never produce a terminal verdict). Nothing to guard in pr-merge/pr-review-status.