### PR TITLE
fix(github): judge statusCheckRollup StatusContext nodes by .state in pr-list-ready (VST-9)

### DIFF
--- a/skills/github/scripts/commands/pr-list-ready.sh
+++ b/skills/github/scripts/commands/pr-list-ready.sh
@@ -116,9 +116,26 @@ main() {
         unknown_prs=$(echo "$prs" | jq '[.[] | select(.mergeable == "UNKNOWN")] | length')
     done
 
-    # Enrich with ready status
+    # Enrich with ready status.
+    # statusCheckRollup mixes two node shapes: CheckRun nodes carry
+    # .conclusion (empty/null while running), while StatusContext nodes
+    # (classic commit statuses) have NO conclusion at all — their result is
+    # .state (SUCCESS/PENDING/ERROR/FAILURE/EXPECTED). jq reads a missing
+    # field as null, so a conclusion-only predicate counts every
+    # StatusContext — including pending and failing ones — as passing.
+    # Judge each node by its own shape; anything neither passing nor failing
+    # (in-progress runs, PENDING/EXPECTED statuses) classifies as pending.
     local enriched
     enriched=$(echo "$prs" | jq '
+        def is_status_context: .__typename == "StatusContext" or (has("state") and .state != null);
+        def node_passing:
+            if is_status_context then .state == "SUCCESS"
+            else .conclusion == "SUCCESS" or .conclusion == "SKIPPED" or .conclusion == "CANCELLED"
+            end;
+        def node_failing:
+            if is_status_context then .state == "ERROR" or .state == "FAILURE"
+            else .conclusion == "FAILURE"
+            end;
         map({
             number,
             title,
@@ -127,8 +144,8 @@ main() {
             has_approved_review: ([.latestReviews[] | select(.state == "APPROVED")] | length > 0),
             has_changes_requested: ([.latestReviews[] | select(.state == "CHANGES_REQUESTED")] | length > 0),
             ci: (if (.statusCheckRollup | length) == 0 then "no_checks"
-                 elif (.statusCheckRollup | all(.conclusion == "SUCCESS" or .conclusion == "SKIPPED" or .conclusion == "CANCELLED" or .conclusion == null)) then "passing"
-                 elif (.statusCheckRollup | any(.conclusion == "FAILURE")) then "failing"
+                 elif (.statusCheckRollup | all(node_passing)) then "passing"
+                 elif (.statusCheckRollup | any(node_failing)) then "failing"
                  else "pending" end),
             mergeable: .mergeable,
             ready: (
@@ -136,7 +153,7 @@ main() {
                 ([.latestReviews[] | select(.state == "CHANGES_REQUESTED")] | length == 0) and
                 (.reviewDecision == "APPROVED" or ([.latestReviews[] | select(.state == "APPROVED")] | length > 0)) and
                 .mergeable == "MERGEABLE" and
-                ((.statusCheckRollup | length) == 0 or (.statusCheckRollup | all(.conclusion == "SUCCESS" or .conclusion == "SKIPPED" or .conclusion == "CANCELLED" or .conclusion == null)))
+                ((.statusCheckRollup | length) == 0 or (.statusCheckRollup | all(node_passing)))
             )
         })
     ')

--- a/skills/github/tests/pr-list-ready-rollup.test.sh
+++ b/skills/github/tests/pr-list-ready-rollup.test.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Regression tests for pr-list-ready's statusCheckRollup classification
+# (VST-9): StatusContext nodes (classic commit statuses) carry .state, not
+# .conclusion — a conclusion-only predicate reads their missing conclusion as
+# null and counts every one of them, pending and failing included, as
+# passing. Also pins: an in-progress CheckRun (null/empty conclusion) is
+# pending, never passing.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CMD="$TEST_DIR/../scripts/commands/pr-list-ready.sh"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local got="$1" want="$2" name="$3"
+  if [[ "$got" == "$want" ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$name" "$want" "$got"
+  fi
+}
+
+# Stub gh: `api user` returns a login; `pr list` returns the fixture. All PRs
+# are MERGEABLE with an APPROVED review so readiness turns on CI alone.
+mkdir -p "$TMP_ROOT/bin"
+cat > "$TMP_ROOT/bin/gh" <<EOF
+#!/usr/bin/env bash
+case "\$1 \$2" in
+  "api user") echo '{"login":"tester"}' | jq -r "\${4:-.login}" 2>/dev/null || echo tester ;;
+  "pr list") cat "$TMP_ROOT/fixture.json" ;;
+  *) echo "unexpected gh call: \$*" >&2; exit 1 ;;
+esac
+EOF
+chmod +x "$TMP_ROOT/bin/gh"
+
+approved='[{"state":"APPROVED"}]'
+mk_pr() { # number rollup-json
+  jq -n --argjson n "$1" --argjson rollup "$2" --argjson reviews "$approved" \
+    '{number: $n, title: "pr \($n)", headRefName: "b\($n)",
+      reviewDecision: "APPROVED", latestReviews: $reviews,
+      statusCheckRollup: $rollup, mergeable: "MERGEABLE"}'
+}
+
+jq -s '.' \
+  <(mk_pr 1 '[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"},{"__typename":"StatusContext","context":"gate","state":"SUCCESS"}]') \
+  <(mk_pr 2 '[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"},{"__typename":"StatusContext","context":"gate","state":"PENDING"}]') \
+  <(mk_pr 3 '[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"},{"__typename":"StatusContext","context":"gate","state":"FAILURE"}]') \
+  <(mk_pr 4 '[{"__typename":"StatusContext","context":"gate","state":"ERROR"}]') \
+  <(mk_pr 5 '[{"__typename":"CheckRun","status":"IN_PROGRESS","conclusion":null}]') \
+  <(mk_pr 6 '[]') \
+  > "$TMP_ROOT/fixture.json"
+
+out="$(PATH="$TMP_ROOT/bin:$PATH" bash "$CMD" --all)"
+
+ci_of()    { jq -r --argjson n "$1" '.[] | select(.number == $n) | .ci' <<<"$out"; }
+ready_of() { jq -r --argjson n "$1" '.[] | select(.number == $n) | .ready' <<<"$out"; }
+
+echo "=== StatusContext nodes are judged by .state ==="
+assert_eq "$(ci_of 1)"    "passing" "pr1: SUCCESS status + SUCCESS run is passing"
+assert_eq "$(ready_of 1)" "true"    "pr1: and ready"
+assert_eq "$(ci_of 2)"    "pending" "pr2: PENDING status is pending, not passing"
+assert_eq "$(ready_of 2)" "false"   "pr2: and not ready"
+assert_eq "$(ci_of 3)"    "failing" "pr3: FAILURE status is failing"
+assert_eq "$(ready_of 3)" "false"   "pr3: and not ready"
+assert_eq "$(ci_of 4)"    "failing" "pr4: ERROR status is failing"
+
+echo "=== CheckRun nodes: null conclusion is pending ==="
+assert_eq "$(ci_of 5)"    "pending" "pr5: in-progress run is pending, not passing"
+assert_eq "$(ready_of 5)" "false"   "pr5: and not ready"
+
+echo "=== no checks ==="
+assert_eq "$(ci_of 6)"    "no_checks" "pr6: empty rollup is no_checks"
+assert_eq "$(ready_of 6)" "true"      "pr6: no checks does not block readiness"
+
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Fixes [VST-9](https://linear.app/vanillagreen/issue/VST-9/pr-list-ready-statuscheckrollup-predicate-counts-statuscontext-nodes) (Linear-only issue; no GitHub twin).

`pr-list-ready` classified CI from `statusCheckRollup` with a predicate keyed solely on `.conclusion`, accepting `null` as passing. `gh` returns two node shapes in that array: **CheckRun** nodes (which carry `conclusion`) and **StatusContext** nodes (classic commit statuses), which have no `conclusion` field at all — their result lives in `.state`. jq reads the missing field as `null`, so every StatusContext node — `PENDING`, `ERROR`, and `FAILURE` included — counted as passing, and a repo whose required checks report as commit statuses (external CI, the review-gate engine's pending gate status, bot integrations) had blocked PRs listed as `ready`.

Both the `ci` classification and the `ready` filter now share typed predicates:

- **StatusContext** judged by `.state`: `SUCCESS` passes, `ERROR`/`FAILURE` fails, `PENDING`/`EXPECTED` pends.
- **CheckRun** judged by `.conclusion`: `SUCCESS`/`SKIPPED`/`CANCELLED` pass (unchanged), `FAILURE` fails, and a null/empty conclusion (run still in progress) is **pending**, never passing.

New regression test `skills/github/tests/pr-list-ready-rollup.test.sh` (11 assertions, stubbed `gh`) pins all of the above, including the headline case: an otherwise-green PR with a `PENDING` commit status classifies `pending`/not-ready.

Verified against live `gh pr list --json statusCheckRollup` output in this repo (which now carries a StatusContext node per PR).

https://claude.ai/code/session_01QtoqnDR32zLWZPoznpcxfc
