### PR TITLE
fix(linear): route HTTP-400 RATELIMITED to the rate-limit path; propagate failed team lookups

### DIFF
--- a/skills/linear/scripts/lib/common.sh
+++ b/skills/linear/scripts/lib/common.sh
@@ -273,6 +273,16 @@ graphql_query() {
         http_code="${raw_output##*${delimiter}}"
         response="${raw_output%${delimiter}*}"
 
+        # Linear emits rate-limit rejections with an OUTER HTTP 400 (the body
+        # carries extensions.code RATELIMITED / extensions.statusCode 429), so
+        # normalize on the body marker: without this they fall into the
+        # generic branch and surface as "HTTP error: 400" — and callers like
+        # resolve_team_id then compound it into "Team not found".
+        if [ "$http_code" != "200" ] && echo "$response" | jq -e \
+            '[.errors[]? | select(.extensions.code == "RATELIMITED")] | length > 0' >/dev/null 2>&1; then
+            http_code=429
+        fi
+
         # Handle HTTP errors
         case "$http_code" in
         200)
@@ -330,7 +340,16 @@ graphql_query() {
                 attempt=$((attempt + 1))
                 continue
             fi
-            echo "{\"error\": \"HTTP error: $http_code\"}" >&2
+            # Carry the body's first error message: a bare status code hides
+            # the actionable reason (validation detail, quota text, ...).
+            local error_detail
+            error_detail=$(echo "$response" | jq -r '.errors[0].message // empty' 2>/dev/null || true)
+            if [ -n "$error_detail" ]; then
+                jq -cn --arg code "$http_code" --arg msg "$error_detail" \
+                    '{error: ("HTTP error: " + $code + ": " + $msg)}' >&2
+            else
+                echo "{\"error\": \"HTTP error: $http_code\"}" >&2
+            fi
             return 1
             ;;
         esac
@@ -630,10 +649,15 @@ resolve_team_id() {
         return 0
     fi
 
-    # Look up by name
+    # Look up by name. A FAILED query must propagate as the API failure it
+    # is (rate limit, outage) — "Team not found" is only true for a
+    # successful lookup that returned no match.
     local query='query GetTeam($name: String!) { teams(filter: {name: {eq: $name}}) { nodes { id } } }'
     local result
-    result=$(graphql_query "$query" "{\"name\": \"$team_ref\"}")
+    if ! result=$(graphql_query "$query" "{\"name\": \"$team_ref\"}"); then
+        echo "{\"error\": \"Could not resolve team '$team_ref': Linear API request failed (see previous error)\"}" >&2
+        return 1
+    fi
     local team_id
     team_id=$(echo "$result" | jq -r '.teams.nodes[0].id // empty')
 

--- a/skills/linear/scripts/lib/common.sh
+++ b/skills/linear/scripts/lib/common.sh
@@ -653,16 +653,20 @@ resolve_team_id() {
     # is (rate limit, outage) — "Team not found" is only true for a
     # successful lookup that returned no match.
     local query='query GetTeam($name: String!) { teams(filter: {name: {eq: $name}}) { nodes { id } } }'
-    local result
-    if ! result=$(graphql_query "$query" "{\"name\": \"$team_ref\"}"); then
-        echo "{\"error\": \"Could not resolve team '$team_ref': Linear API request failed (see previous error)\"}" >&2
+    # Build variables and diagnostics with jq: a team name containing a
+    # quote or backslash must neither break the request JSON nor the error.
+    local vars result
+    vars=$(jq -cn --arg name "$team_ref" '{name: $name}')
+    if ! result=$(graphql_query "$query" "$vars"); then
+        jq -cn --arg team "$team_ref" \
+            '{error: ("Could not resolve team '\''" + $team + "'\'': Linear API request failed (see previous error)")}' >&2
         return 1
     fi
     local team_id
     team_id=$(echo "$result" | jq -r '.teams.nodes[0].id // empty')
 
     if [ -z "$team_id" ]; then
-        echo "{\"error\": \"Team not found: $team_ref\"}" >&2
+        jq -cn --arg team "$team_ref" '{error: ("Team not found: " + $team)}' >&2
         return 1
     fi
 

--- a/skills/linear/tests/rate-limited-http-400.test.sh
+++ b/skills/linear/tests/rate-limited-http-400.test.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Regression test (#1018): Linear emits rate-limit rejections with an OUTER
+# HTTP 400 whose body carries extensions.code RATELIMITED. These must route
+# to the rate-limit path ("Rate limited. Try again later."), never surface as
+# the generic "HTTP error: 400" — and a failed team lookup must propagate the
+# API failure instead of reporting the misleading "Team not found".
+# A generic non-200 must carry the body's first error message.
+#
+# Runs fully offline against a mocked curl.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+TMP_BASE="$(mktemp -d)"
+trap 'rm -rf "$TMP_BASE"' EXIT
+
+PASS=0
+FAIL=0
+
+assert_contains() {
+  local haystack="$1" needle="$2" name="$3"
+  if grep -qF -- "$needle" <<<"$haystack"; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        wanted substring: %s\n        in: %s\n' "$name" "$needle" "$haystack"
+  fi
+}
+
+assert_not_contains() {
+  local haystack="$1" needle="$2" name="$3"
+  if grep -qF -- "$needle" <<<"$haystack"; then
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        must NOT contain: %s\n        in: %s\n' "$name" "$needle" "$haystack"
+  else
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  fi
+}
+
+# make_env <root> <http_code> <body-json>: isolated skill copy + a curl stub
+# that always answers with the given status/body (graphql_query appends the
+# status code after a NUL-ish delimiter via -w; emulate with %{http_code}).
+make_env() {
+  local root="$1" code="$2" body="$3"
+  mkdir -p "$root/.agents/skills" "$root/bin"
+  cp -R "$SKILL_DIR" "$root/.agents/skills/linear"
+  git -C "$root" init -q >/dev/null
+  printf '%s' "$body" > "$root/body.json"
+  cat >"$root/bin/curl" <<SH
+#!/usr/bin/env bash
+# Consume the -K - config from stdin like the real invocation.
+cat >/dev/null
+args=("\$@")
+w_fmt=""
+for ((i=0; i<\${#args[@]}; i++)); do
+  [[ "\${args[i]}" == "-w" ]] && w_fmt="\${args[i+1]}"
+done
+cat "$root/body.json"
+printf '%s' "\${w_fmt/\%\{http_code\}/$code}"
+SH
+  chmod +x "$root/bin/curl"
+}
+
+RL_BODY='{"errors":[{"message":"Rate limit exceeded. Only 2500 requests are allowed per 1 hour.","extensions":{"type":"ratelimited","code":"RATELIMITED","statusCode":429,"userError":true}}]}'
+GENERIC_BODY='{"errors":[{"message":"Argument Validation Error","extensions":{"code":"INVALID_INPUT"}}]}'
+
+run_linear() { # root, args...
+  local root="$1"; shift
+  (cd "$root" && env PATH="$root/bin:$PATH" \
+    LINEAR_API_KEY_OVERRIDE="lin_api_test" LINEAR_TEAM="Claude" \
+    "$root/.agents/skills/linear/scripts/linear.sh" "$@" 2>&1) || true
+}
+
+echo "=== RATELIMITED body on HTTP 400 routes to the rate-limit path ==="
+make_env "$TMP_BASE/rl" 400 "$RL_BODY"
+out="$(run_linear "$TMP_BASE/rl" statuses list)"
+assert_contains "$out" "Rate limited. Try again later." "rate-limited 400 reports the rate limit"
+assert_not_contains "$out" "HTTP error: 400" "rate-limited 400 is not a generic HTTP error"
+
+echo "=== failed team lookup propagates the API failure ==="
+unit="$(cd "$TMP_BASE/rl" && env PATH="$TMP_BASE/rl/bin:$PATH" bash -c '
+  set -u
+  LINEAR_API="https://api.linear.app/graphql"
+  LINEAR_API_KEY="lin_api_test"
+  source "$0/.agents/skills/linear/scripts/lib/common.sh"
+  resolve_team_id "Claude"
+' "$TMP_BASE/rl" 2>&1)" || true
+assert_contains "$unit" "Rate limited. Try again later." "team lookup surfaces the rate limit"
+assert_contains "$unit" "Could not resolve team 'Claude'" "team lookup names the failed resolution"
+assert_not_contains "$unit" "Team not found" "team lookup does not claim the team is missing"
+
+echo "=== generic non-200 carries the body's error message ==="
+make_env "$TMP_BASE/gen" 400 "$GENERIC_BODY"
+out="$(run_linear "$TMP_BASE/gen" statuses list)"
+assert_contains "$out" "HTTP error: 400: Argument Validation Error" "generic 400 includes the body message"
+
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Closes #1018.

Observed live when the key exhausted its hourly quota: `statuses list` reported `{"error": "HTTP error: 400"}` and `issues update` reported `{"error": "Team not found: vstack"}` while `auth-check` passed — the actual cause (RATELIMITED) was invisible because Linear wraps it in an outer HTTP 400 and `graphql_query` only recognized literal 429s.

Three changes in `lib/common.sh`:
- **Normalize on the body marker**: any non-200 whose body carries `extensions.code == "RATELIMITED"` routes to the existing 429 backoff path and finally reports `Rate limited. Try again later.`
- **Generic non-200s carry the body's first error message** (`HTTP error: 400: Argument Validation Error`) instead of a bare code.
- **`resolve_team_id` distinguishes a FAILED lookup from an empty result**: API failure propagates as `Could not resolve team '<name>'` after the underlying error; `Team not found` is reserved for a successful lookup with no match.

New offline regression test (`rate-limited-http-400.test.sh`, mocked curl, 6 assertions) pins all three; full linear suite green locally.
