### PR TITLE
fix(review-gate): reject github-actions-published check runs as trusted-context evidence (VST-19)

### DIFF
--- a/skills/review-gate/scripts/review-predicate-selftest.sh
+++ b/skills/review-gate/scripts/review-predicate-selftest.sh
@@ -121,9 +121,12 @@ reviews_set() { # rows... -> reviews.json
   for row in "$@"; do rows="$(jq -c --argjson r "$row" '. + [$r]' <<<"$rows")"; done
   printf '%s\n' "$rows" >"$fixtures/reviews.json"
 }
-checkrun() { # name, conclusion, summary -> checkruns.json
-  jq -n --arg name "$1" --arg conclusion "$2" --arg summary "${3:-}" \
-    '{check_runs:[{name:$name,conclusion:$conclusion,output:{title:null,summary:$summary}}]}' \
+checkrun() { # name, conclusion, summary, [app slug] -> checkruns.json
+  # Real check runs always carry a publishing app; the default models a
+  # trusted reviewer's own app. Pass "github-actions" for the near-miss:
+  # a PR workflow can publish under ANY NAME through that shared app.
+  jq -n --arg name "$1" --arg conclusion "$2" --arg summary "${3:-}" --arg app "${4:-trusted-reviewer-app}" \
+    '{check_runs:[{name:$name,conclusion:$conclusion,app:{slug:$app},output:{title:null,summary:$summary}}]}' \
     >"$fixtures/checkruns.json"
 }
 status_ctx() { # context, state, description -> status.json
@@ -344,6 +347,21 @@ CFG_CONTEXTS="mech-ctx"
 export GH_SHIM_FAIL=graphql
 run "thread read failure (with evidence present)" "" 2
 unset GH_SHIM_FAIL
+
+# Check-run names are not reserved: any PR workflow with checks:write can
+# publish under ANY name through the shared github-actions app, while real
+# reviewer bots publish under their own app slug. A github-actions-published
+# name-match must stay not-evidence (VST-19) — the paired trusted-app case
+# proves the rejection is what separates them.
+reset
+CFG_CONTEXTS="mech-ctx"
+checkrun "mech-ctx" success "analysis complete"
+run "trusted-app check-run success is evidence" approved
+
+reset
+CFG_CONTEXTS="mech-ctx"
+checkrun "mech-ctx" success "analysis complete" "github-actions"
+run "github-actions-published check-run under a trusted name is not evidence" awaiting
 
 # >100 threads is a SUCCESSFUL read we cannot fully verify: fail closed to
 # threads-open, never open the gate.

--- a/skills/review-gate/scripts/review-predicate-selftest.sh
+++ b/skills/review-gate/scripts/review-predicate-selftest.sh
@@ -363,6 +363,13 @@ CFG_CONTEXTS="mech-ctx"
 checkrun "mech-ctx" success "analysis complete" "github-actions"
 run "github-actions-published check-run under a trusted name is not evidence" awaiting
 
+# Fail closed on provenance too: a check run with NO app slug at all has
+# unprovable provenance and is not evidence either.
+reset
+CFG_CONTEXTS="mech-ctx"
+jq -n '{check_runs:[{name:"mech-ctx",conclusion:"success",output:{title:null,summary:"analysis complete"}}]}' >"$fixtures/checkruns.json"
+run "check-run with no app slug (unprovable provenance) is not evidence" awaiting
+
 # >100 threads is a SUCCESSFUL read we cannot fully verify: fail closed to
 # threads-open, never open the gate.
 reset

--- a/skills/review-gate/scripts/review-predicate.sh
+++ b/skills/review-gate/scripts/review-predicate.sh
@@ -251,10 +251,18 @@ while IFS= read -r ctx; do
   # every clean pass would "match" and be filtered to not-evidence. Same
   # rebinding trap as the comment-sha binding below; the selftest's
   # genuine-clean-pass case is what catches it.
+  # Check-runs are matched by NAME, but names are not reserved: any PR
+  # workflow with `checks: write` can publish a check run under ANY name
+  # through the shared `github-actions` app — trusted reviewer bots publish
+  # under their own app slug. A github-actions-published name-match is
+  # therefore never clean-analysis evidence (VST-19); rejecting it here is
+  # the mechanical half of the settings doc's "only names produced by
+  # trusted bots" precondition.
   check_runs="$(jq --arg ctx "$ctx" --arg skips "$SKIP_PATTERNS" '
       ($skips | split(";") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0)) | map(ascii_downcase)) as $sk
       | [ .check_runs[]
           | select(.name == $ctx and .conclusion == "success")
+          | select((.app.slug // "") != "github-actions")
           | (((.output.title // "") + " " + (.output.summary // "")) | ascii_downcase) as $text
           | select(([ $sk[] | . as $p | select($text | contains($p)) ] | length) == 0)
         ] | length' <<<"$checkruns_resp")" || {

--- a/skills/review-gate/scripts/review-predicate.sh
+++ b/skills/review-gate/scripts/review-predicate.sh
@@ -262,7 +262,7 @@ while IFS= read -r ctx; do
       ($skips | split(";") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0)) | map(ascii_downcase)) as $sk
       | [ .check_runs[]
           | select(.name == $ctx and .conclusion == "success")
-          | select((.app.slug // "") != "github-actions")
+          | select(((.app.slug // "") != "") and ((.app.slug // "") != "github-actions"))
           | (((.output.title // "") + " " + (.output.summary // "")) | ascii_downcase) as $text
           | select(([ $sk[] | . as $p | select($text | contains($p)) ] | length) == 0)
         ] | length' <<<"$checkruns_resp")" || {

--- a/skills/review-gate/vstack.settings.toml.example
+++ b/skills/review-gate/vstack.settings.toml.example
@@ -19,6 +19,10 @@ REVIEW_GATE_CONTEXT = "Review gate"
 # check-runs and statuses are matched by NAME, and any GitHub App or Actions
 # workflow can publish under any name — list only names produced by trusted
 # bots, on repos where every publisher is trusted.
+# Check-runs published by the shared github-actions app are rejected
+# automatically (any PR workflow can mint those; real reviewer bots publish
+# under their own app slug); legacy commit STATUSES still rely on the
+# publisher-trust precondition above.
 # Default is EMPTY (source disabled): trust is opt-in per repo, never a
 # shipped vendor default. Example for a repo whose reviewer posts a
 # check/status under the name "Devin Review":

--- a/vstack.settings.toml.example
+++ b/vstack.settings.toml.example
@@ -202,6 +202,10 @@ REVIEW_GATE_TRUSTED_STATUS_CONTEXTS = ""
 # for a listed name on the current head counts as review evidence. SECURITY:
 # matched by NAME, and any GitHub App or workflow can publish under any name
 # — list only trusted bots' checks, on repos where all publishers are trusted.
+# Check-runs published by the shared github-actions app are rejected
+# automatically (any PR workflow can mint those; real reviewer bots publish
+# under their own app slug); legacy commit STATUSES still rely on the
+# publisher-trust precondition above.
 
 REVIEW_GATE_CHECKRUN_SKIP_PATTERNS = "rate limited;skipped;queued"
 # Used by: review-gate (`review-predicate.sh`). A trusted "pass" must prove


### PR DESCRIPTION
Fixes [VST-19](https://linear.app/vanillagreen/issue/VST-19/review-gate-reject-github-actions-published-check-runs-as-trusted) (Linear-only issue, filed from Copilot's review of the archetype-R consumer's adoption wiring).

`REVIEW_GATE_TRUSTED_STATUS_CONTEXTS` matches check-runs by name alone, and names are not reserved: any PR workflow granted `checks: write` can publish a check run under any name via the shared `github-actions` app — so on `TRUST_PR_WORKFLOWS="false"` repos (the posture the safe two-job wiring exists for), a malicious PR could mint name-matched clean-analysis evidence. Real reviewer bots publish under their own app slug.

The predicate's check-run evaluation now rejects candidates whose `app.slug == "github-actions"` — the cheap mechanical half of the settings doc's existing "only names produced by trusted bots" precondition. The selftest pins the near-miss (a `github-actions`-published success under a trusted name stays `awaiting`) against its trusted-app twin, so the rejection is provably what separates them. Both settings examples' SECURITY caveats now state the automatic rejection and that legacy commit statuses still rely on the documented publisher-trust precondition.

Per vendoring policy nothing is patched in consumers here — they pick this up on their next refresh.

https://claude.ai/code/session_01QtoqnDR32zLWZPoznpcxfc
