### PR TITLE
fix(review-gate): file-wide settings-key contract + duplicate-assignment guard; align stale refire fixtures

### DIFF
--- a/skills/review-gate/references/settings.md
+++ b/skills/review-gate/references/settings.md
@@ -6,6 +6,14 @@ path, e.g. in tests). List values pack into one string with `;` separators.
 Commented defaults ship in this skill's `vstack.settings.toml.example`;
 per-repo wiring and values: [adoption.md](adoption.md).
 
+Keys are matched file-wide by exact name, regardless of the enclosing TOML
+table — that is how assignments under an adopter's `[env]` table resolve at
+all. Every key name below is therefore reserved across the whole file: a
+same-named key under an unrelated table would be read as the gate setting,
+so keeping these names out of unrelated tables is the adopter's
+responsibility. The parser fails loud on the one detectable ambiguity — the
+same name assigned more than once anywhere in the file.
+
 | Key | Default | Meaning |
 |---|---|---|
 | `REVIEW_GATE_CONTEXT` | `Review gate` | Gate commit-status context (the required check name). |

--- a/skills/review-gate/references/settings.md
+++ b/skills/review-gate/references/settings.md
@@ -6,13 +6,16 @@ path, e.g. in tests). List values pack into one string with `;` separators.
 Commented defaults ship in this skill's `vstack.settings.toml.example`;
 per-repo wiring and values: [adoption.md](adoption.md).
 
-Keys are matched file-wide by exact name, regardless of the enclosing TOML
-table — that is how assignments under an adopter's `[env]` table resolve at
-all. Every key name below is therefore reserved across the whole file: a
-same-named key under an unrelated table would be read as the gate setting,
-so keeping these names out of unrelated tables is the adopter's
-responsibility. The parser fails loud on the one detectable ambiguity — the
-same name assigned more than once anywhere in the file.
+Script-consumed keys are matched file-wide by exact name, regardless of the
+enclosing TOML table — that is how assignments under an adopter's `[env]`
+table resolve at all. Every such key name is therefore reserved across the
+whole file: a same-named key under an unrelated table would be read as the
+gate setting, so keeping these names out of unrelated tables is the
+adopter's responsibility. The parser fails loud on the one detectable
+ambiguity — the same name assigned more than once anywhere in the file.
+Exception: `REVIEW_GATE_TRUST_PR_WORKFLOWS` is consumed by workflow wiring,
+not by these scripts, so it gets no parser guard — treat its name as
+reserved all the same.
 
 | Key | Default | Meaning |
 |---|---|---|

--- a/skills/review-gate/scripts/lib/settings.sh
+++ b/skills/review-gate/scripts/lib/settings.sh
@@ -5,7 +5,7 @@
 # Resolution order for every REVIEW_GATE_* key:
 #   1. explicit environment — a SET variable wins even when set to the empty
 #      string, so a caller (or the selftest) can force "explicitly empty";
-#   2. the repo's committed vstack.settings.toml (first uncommented
+#   2. the repo's committed vstack.settings.toml (the file's sole uncommented
 #      `KEY = "value"` assignment; the file path can be overridden with
 #      REVIEW_GATE_SETTINGS_FILE, e.g. /dev/null to force built-in defaults);
 #   3. the built-in default passed by the caller.
@@ -13,6 +13,14 @@
 # The parser reads flat single-line basic-string TOML assignments only —
 # exactly the shape vstack.settings.toml [env] blocks use. List-valued keys
 # therefore pack multiple items into one string with ';' separators.
+#
+# Keys are matched FILE-WIDE by exact name, with no TOML-table awareness:
+# adopter settings sit under an [env] table, and a table-aware top-level
+# parser would resolve none of them. The consequence is a contract: every
+# key name read through rg_setting is reserved across the whole file — an
+# assignment under an unrelated table would be read as the setting, so
+# callers must keep these names unique file-wide. The one detectable
+# ambiguity, the same name assigned more than once, fails loud below.
 #
 # Scripts run from the repo root in CI (workflow working directory), so the
 # default settings path is relative.
@@ -32,6 +40,14 @@ rg_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
     # assignment ("empty disables" per the settings docs) and must override the
     # built-in default, exactly like a set-but-empty env var does above.
     if grep -q "^${name}[[:space:]]*=" "$file"; then
+      # File-wide matching (header contract) makes a re-assigned name
+      # ambiguous — e.g. the same key under two tables. Silently taking the
+      # first could read an unrelated table's value on a security-sensitive
+      # path, so ambiguity is a configuration error.
+      if [ "$(grep -c "^${name}[[:space:]]*=" "$file")" -gt 1 ]; then
+        echo "::error::$file: $name is assigned more than once (keys are matched file-wide regardless of TOML table; each name must be unique in the file)" >&2
+        return 1
+      fi
       line="$(grep "^${name}[[:space:]]*=" "$file" | head -n 1)"
       # A PRESENT assignment this parser cannot read (e.g. TOML array syntax
       # for a list key) must fail LOUDLY, never collapse to empty: an empty

--- a/skills/review-gate/tests/approval-refire.test.sh
+++ b/skills/review-gate/tests/approval-refire.test.sh
@@ -36,6 +36,9 @@
 #        cap                                    MAX_ATTEMPTS=6
 #   r18. settings value with trailing TOML   -> value resolves, comment
 #        comment                                stripped
+#   r19. same key assigned twice in the      -> exit 1, NO POST, NO rerun
+#        settings file (file-wide matching      (ambiguous, fail loud)
+#        makes it ambiguous)
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -152,8 +155,8 @@ run_refire() {
 
 AWAITING="verdict=awaiting detail=awaiting a non-author review for headsha"
 APPROVED="verdict=approved detail=reviewed at head with no unresolved threads"
-CR="verdict=changes-requested detail=review changes requested on the current head"
-THREADS="verdict=threads-open detail=unresolved review threads on the current head"
+CR="verdict=changes-requested detail=standing review changes requested (persists across pushes until re-approval or dismissal)"
+THREADS="verdict=threads-open detail=2 unresolved review thread(s)"
 
 echo "=== downward transitions are direct posts ==="
 
@@ -280,6 +283,23 @@ set -e
 assert_eq "$rc" "1" "r15: unparseable settings assignment exits 1"
 assert_contains "$out" "unsupported syntax" "r15: names the configuration error"
 assert_eq "$(( $(wc -l < "$POST_LOG") ))$(( $(wc -l < "$RERUN_LOG") ))" "00" "r15: no POST and no rerun on a config error"
+
+# Keys are matched file-wide regardless of TOML table (the settings contract),
+# so a second assignment of the same name — here under an unrelated table —
+# is ambiguous and must fail loud, never silently resolve to either value.
+cat > "$TMP_ROOT/dup-settings.toml" <<'EOF'
+REVIEW_GATE_CONTEXT = "File Gate"
+[unrelated]
+REVIEW_GATE_CONTEXT = "Other Gate"
+EOF
+set +e
+out=$(run_refire STUB_VERDICT_LINE="$AWAITING" STUB_GATE_HISTORY='[]' \
+  REVIEW_GATE_SETTINGS_FILE="$TMP_ROOT/dup-settings.toml")
+rc=$?
+set -e
+assert_eq "$rc" "1" "r19: duplicate key assignment exits 1"
+assert_contains "$out" "assigned more than once" "r19: names the ambiguity"
+assert_eq "$(( $(wc -l < "$POST_LOG") ))$(( $(wc -l < "$RERUN_LOG") ))" "00" "r19: no POST and no rerun on a duplicate-key config error"
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"


### PR DESCRIPTION
Closes #1027 (both parts; also fixes VST-20 on Linear — completed there after merge).

**Part 1 — the contract, defined and enforced where detectable.** `rg_setting`'s file-wide `^NAME =` matching is deliberate and load-bearing — every adopter's keys sit under an `[env]` table, so a table-aware top-level parser would resolve none of them. The lib header and `references/settings.md` now state the consequence plainly: every key name read through `rg_setting` is reserved across the whole file, and an assignment under an unrelated table would be read as the setting. The one mechanically detectable ambiguity — the same name assigned more than once anywhere in the file — now fails loud through the existing config-error shape instead of silently taking the first match on a security-sensitive path. New refire test r19 pins it (duplicate `REVIEW_GATE_CONTEXT` under an `[unrelated]` table → exit 1, named error, no POST/no rerun), demonstrated failing against the unguarded parser first (3 assertions red, then green after the guard).

**Part 2 — fixture realism.** The refire test's CR constant now carries the shipped predicate wording ("standing review changes requested (persists across pushes until re-approval or dismissal)"), and the THREADS constant — same staleness class in the same block — is aligned too. The refire parses `verdict=` only, so these are fixture-realism fixes; nothing asserted on the old text.

All five review-gate suites green (refire 45/45 incl. r19; selftest 61 default / 89 configured; Bash-3.2 lint clean — the guard uses `grep -c`).

https://claude.ai/code/session_01QtoqnDR32zLWZPoznpcxfc
