### PR TITLE
feat(worktree,linear): git-hook symlink auto-repair + full-resync guard for clobbered worktree caches

### DIFF
--- a/skills/linear/SKILL.md
+++ b/skills/linear/SKILL.md
@@ -95,6 +95,8 @@ linear.sh sync --full           # Full re-sync
 
 Cache and attachment files live under `.cache/linear` in the physical git worktree root reported by `git rev-parse --show-toplevel`, not under the path used to reach the skill script. This keeps `sync`, `cache`, and attachment reads consistent across symlinked checkout spellings, worktrees, and canonical source-path invocation. A missing-cache error includes the checked `cache_dir` and `meta_path`; inspect those fields before assuming a sync wrote somewhere else.
 
+In a linked git worktree whose `.cache` should be a `WORKTREE_SYMLINKS`-managed symlink into the main checkout but is a real directory (a git operation re-materialized it), any full or reconciling `sync` refuses before touching the API — a full re-sync into a worktree-local dir would silently re-pull the entire history and burn the shared API budget (vstack#1032). The refusal names the worktree, the expected symlink, and the repair: run `worktree fix-links <PATH>` from the main checkout, then re-run `sync`. Repos whose configured `WORKTREE_SYMLINKS` deliberately excludes `.cache` are exempt.
+
 ## Output Formats
 
 | Format | Description |

--- a/skills/linear/SKILL.md
+++ b/skills/linear/SKILL.md
@@ -95,7 +95,7 @@ linear.sh sync --full           # Full re-sync
 
 Cache and attachment files live under `.cache/linear` in the physical git worktree root reported by `git rev-parse --show-toplevel`, not under the path used to reach the skill script. This keeps `sync`, `cache`, and attachment reads consistent across symlinked checkout spellings, worktrees, and canonical source-path invocation. A missing-cache error includes the checked `cache_dir` and `meta_path`; inspect those fields before assuming a sync wrote somewhere else.
 
-In a linked git worktree whose `.cache` should be a `WORKTREE_SYMLINKS`-managed symlink into the main checkout but is a real directory (a git operation re-materialized it), any full or reconciling `sync` refuses before touching the API — a full re-sync into a worktree-local dir would silently re-pull the entire history and burn the shared API budget (vstack#1032). The refusal names the worktree, the expected symlink, and the repair: run `worktree fix-links <PATH>` from the main checkout, then re-run `sync`. Repos whose configured `WORKTREE_SYMLINKS` deliberately excludes `.cache` are exempt.
+In a linked git worktree whose `.cache` should be a `WORKTREE_SYMLINKS`-managed symlink into the main checkout but is a real directory (a git operation re-materialized it), any full or reconciling `sync` refuses before touching the API — a full re-sync into a worktree-local dir would silently re-pull the entire history and burn the shared API budget. The refusal names the worktree, the expected symlink, and the repair: run `worktree fix-links <PATH>` from the main checkout, then re-run `sync`. Repos whose configured `WORKTREE_SYMLINKS` deliberately excludes `.cache` are exempt.
 
 ## Output Formats
 

--- a/skills/linear/scripts/commands/sync.sh
+++ b/skills/linear/scripts/commands/sync.sh
@@ -518,6 +518,22 @@ main() {
         esac
     done
 
+    # Fail-closed budget guard (vstack#1032): when the cache dir is a
+    # clobbered worktree-local real directory, refuse before touching the lock
+    # or the API. Gated to syncs that would go full (--full, or no meta.json —
+    # exactly what a freshly re-materialized empty dir looks like) or
+    # reconciling (--reconcile, or the hourly stamp is missing/stale, which in
+    # the clobbered dir it always is). A bare sync on a healthy checkout never
+    # enters this branch: there `.cache` is either the intact symlink or the
+    # main checkout's own real directory.
+    if cache_worktree_cache_clobbered; then
+        if [[ "$full" == true || ! -f "$CACHE_DIR/meta.json" || "$force_reconcile" == true ]] \
+            || ! reconcile_is_fresh 60; then
+            cache_worktree_clobber_refusal
+            return 1
+        fi
+    fi
+
     # Check if sync needed when --if-stale specified
     if [[ -n "$if_stale" ]] && cache_is_fresh "$if_stale"; then
         echo "Cache fresh (< ${if_stale}m), skipped" >&2

--- a/skills/linear/scripts/lib/cache.sh
+++ b/skills/linear/scripts/lib/cache.sh
@@ -80,8 +80,22 @@ cache_worktree_clobber_refusal() {
         echo "  A git operation re-materialized the symlink. Syncing here would re-pull the full"
         echo "  Linear history into this worktree instead of the shared cache, silently burning"
         echo "  the shared API budget. Repair the link from the main checkout, then re-run sync:"
-        echo "    cd '$CACHE_WORKTREE_MAIN_ROOT' && .agents/skills/worktree/scripts/worktree fix-links '$CACHE_PROJECT_ROOT'"
+        echo "    cd '$CACHE_WORKTREE_MAIN_ROOT' && $(cache_worktree_repair_script) fix-links '$CACHE_PROJECT_ROOT'"
     } >&2
+}
+
+# The worktree script lives at .agents/skills/... in a consumer install and
+# at skills/... in the source repo — point the repair guidance at whichever
+# exists so it can be pasted as-is (consumer spelling when neither resolves).
+cache_worktree_repair_script() {
+    local rel=""
+    for rel in ".agents/skills/worktree/scripts/worktree" "skills/worktree/scripts/worktree"; do
+        if [[ -x "$CACHE_WORKTREE_MAIN_ROOT/$rel" ]]; then
+            printf '%s\n' "$rel"
+            return 0
+        fi
+    done
+    printf '%s\n' ".agents/skills/worktree/scripts/worktree"
 }
 
 # =============================================================================

--- a/skills/linear/scripts/lib/cache.sh
+++ b/skills/linear/scripts/lib/cache.sh
@@ -58,9 +58,13 @@ cache_worktree_cache_clobbered() {
     [[ "$main_root" != "$root" ]] || return 1
     [[ -e "$main_root/.cache" ]] || return 1
     if [[ -n "${WORKTREE_SYMLINKS:-}" ]]; then
-        local manages_cache=false
+        local manages_cache=false stripped=""
         for entry in ${WORKTREE_SYMLINKS}; do
-            if [[ "${entry%/}" == ".cache" ]]; then
+            # The worktree config normalizer strips ANY number of trailing
+            # slashes; match it, or ".cache//" would read as an opt-out.
+            stripped="$entry"
+            while [[ "$stripped" == */ ]]; do stripped="${stripped%/}"; done
+            if [[ "$stripped" == ".cache" ]]; then
                 manages_cache=true
                 break
             fi

--- a/skills/linear/scripts/lib/cache.sh
+++ b/skills/linear/scripts/lib/cache.sh
@@ -28,6 +28,63 @@ CACHE_PROJECT_ROOT="$(linear_cache_project_root)"
 CACHE_DIR="$CACHE_PROJECT_ROOT/.cache/linear"
 
 # =============================================================================
+# WORKTREE CLOBBER GUARD (vstack#1032)
+# =============================================================================
+# A git operation can re-materialize a WORKTREE_SYMLINKS-managed `.cache`
+# symlink in a linked worktree as a real, near-empty directory. The resolved
+# cache dir then looks exactly like a cold cache, and a full re-sync silently
+# re-pulls the entire issue/comment history into the worktree-local dir —
+# burning a large slice of the shared Linear API budget. These helpers detect
+# that state so sync can fail closed instead.
+
+# True when the resolved cache root is a linked worktree whose `.cache` is a
+# real directory while the main checkout's `.cache` exists — the symlink
+# convention is configured but broken here. When WORKTREE_SYMLINKS is set
+# (loaded from project config by common.sh) and does NOT manage `.cache`, the
+# repo has explicitly opted its worktrees into local caches and the guard
+# stands down. Sets CACHE_WORKTREE_MAIN_ROOT for the refusal message.
+CACHE_WORKTREE_MAIN_ROOT=""
+cache_worktree_cache_clobbered() {
+    local root="$CACHE_PROJECT_ROOT" common_dir="" main_root="" entry=""
+    CACHE_WORKTREE_MAIN_ROOT=""
+    [[ -n "$root" ]] || return 1
+    # Healthy states exit fast: `.cache` missing (a cold checkout) or a
+    # symlink (the convention is intact and writes reach the shared cache).
+    [[ -d "$root/.cache" && ! -L "$root/.cache" ]] || return 1
+    common_dir="$(git -C "$root" rev-parse --git-common-dir 2>/dev/null)" || return 1
+    [[ -n "$common_dir" ]] || return 1
+    [[ "$common_dir" == /* ]] || common_dir="$root/$common_dir"
+    main_root="$(linear_cache_canonical_existing_dir "$(dirname "$common_dir")")" || return 1
+    [[ "$main_root" != "$root" ]] || return 1
+    [[ -e "$main_root/.cache" ]] || return 1
+    if [[ -n "${WORKTREE_SYMLINKS:-}" ]]; then
+        local manages_cache=false
+        for entry in ${WORKTREE_SYMLINKS}; do
+            if [[ "${entry%/}" == ".cache" ]]; then
+                manages_cache=true
+                break
+            fi
+        done
+        [[ "$manages_cache" == true ]] || return 1
+    fi
+    CACHE_WORKTREE_MAIN_ROOT="$main_root"
+    return 0
+}
+
+cache_worktree_clobber_refusal() {
+    {
+        echo "Sync refused: cache dir is a worktree-local real directory (vstack#1032)."
+        echo "  Worktree:       $CACHE_PROJECT_ROOT"
+        echo "  Cache dir here: $CACHE_PROJECT_ROOT/.cache (real directory)"
+        echo "  Expected:       .cache -> $CACHE_WORKTREE_MAIN_ROOT/.cache (WORKTREE_SYMLINKS-managed symlink)"
+        echo "  A git operation re-materialized the symlink. Syncing here would re-pull the full"
+        echo "  Linear history into this worktree instead of the shared cache, silently burning"
+        echo "  the shared API budget. Repair the link from the main checkout, then re-run sync:"
+        echo "    cd '$CACHE_WORKTREE_MAIN_ROOT' && .agents/skills/worktree/scripts/worktree fix-links '$CACHE_PROJECT_ROOT'"
+    } >&2
+}
+
+# =============================================================================
 # DIRECTORY & LIFECYCLE
 # =============================================================================
 

--- a/skills/linear/tests/sync-worktree-cache-guard.test.sh
+++ b/skills/linear/tests/sync-worktree-cache-guard.test.sh
@@ -167,6 +167,17 @@ else
   note_fail "opt-out repo was refused or failed: rc=$rc_opt $err_opt"
 fi
 
+# --- trailing slashes: ".cache//" is the same managed entry, not an opt-out ---
+SLASH_ROOT="$TMP_BASE/slash"
+make_repo "$SLASH_ROOT" $'[env]\nWORKTREE_SYMLINKS = ".cache//"'
+set +e
+err_slash="$(run_sync "$SLASH_ROOT/wt" 2>&1 >/dev/null)"
+rc_slash=$?
+set -e
+[[ $rc_slash -ne 0 ]] && grep -q "Sync refused" <<<"$err_slash" \
+  && note_ok "'.cache//' still refuses (normalizer strips all trailing slashes)" \
+  || note_fail "'.cache//' was treated as an opt-out: rc=$rc_slash $err_slash"
+
 # --- no worktree config at all: the issue's bare prescription still refuses ----
 BARE_ROOT="$TMP_BASE/bare"
 make_repo "$BARE_ROOT" ""

--- a/skills/linear/tests/sync-worktree-cache-guard.test.sh
+++ b/skills/linear/tests/sync-worktree-cache-guard.test.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# Regression for vstack#1032: a git operation re-materialized a
+# WORKTREE_SYMLINKS-managed `.cache` symlink in a linked worktree as a real
+# directory holding only the tracked `.gitkeep`, and sync — seeing what looked
+# like a cold cache — silently re-pulled the entire ~21 MB Linear history into
+# the worktree-local dir, burning the shared API budget. Sync must fail closed
+# in that state: refuse loudly BEFORE any API call, naming the worktree, the
+# expected symlink, and the repair command.
+#
+# Controls: a bare sync on a healthy main checkout, a --full sync in a
+# worktree whose `.cache` symlink is intact, and a repo whose configured
+# WORKTREE_SYMLINKS deliberately does not manage `.cache` (opt-out) must all
+# be unaffected. A repo with no worktree config at all still refuses when the
+# main checkout's `.cache` exists — the issue's bare prescription.
+#
+# Runs fully offline against a mocked curl that records every invocation.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+LINEAR="$SKILL_DIR/scripts/linear.sh"
+TMP_BASE="$(mktemp -d)"
+trap 'rm -rf "$TMP_BASE"' EXIT
+
+CURL_LOG="$TMP_BASE/curl.log"
+
+# Every GraphQL query the sync path can issue, answered empty; each hit is
+# logged so the refusal case can assert the API was never touched.
+mkdir -p "$TMP_BASE/bin"
+cat >"$TMP_BASE/bin/curl" <<SH
+#!/usr/bin/env bash
+echo called >>"$CURL_LOG"
+config="\$(cat)"
+payload="\$(sed -n 's/^data = //p' <<<"\$config" | jq -r)"
+query="\$(jq -r '.query' <<<"\$payload")"
+case "\$query" in
+*"SyncIssues("*|*"ReconcileIssues("*)
+  printf '%s' '{"data":{"issues":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}___HTTP_CODE___200' ;;
+*"SyncProjects("*)
+  printf '%s' '{"data":{"projects":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}___HTTP_CODE___200' ;;
+*"SyncCycles("*)
+  printf '%s' '{"data":{"cycles":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}___HTTP_CODE___200' ;;
+*"SyncInitiatives("*)
+  printf '%s' '{"data":{"initiatives":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}___HTTP_CODE___200' ;;
+*"SyncLabels("*)
+  printf '%s' '{"data":{"issueLabels":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}___HTTP_CODE___200' ;;
+*)
+  printf '%s' '{"errors":[{"message":"unexpected query"}]}___HTTP_CODE___200' ;;
+esac
+SH
+chmod +x "$TMP_BASE/bin/curl"
+
+# make_repo <root> <settings-body-or-empty>
+# Main checkout tracking .cache/.gitkeep (the incident's generator: a tracked
+# file under the symlinked dir), plus a linked worktree that git therefore
+# materializes with a REAL .cache directory.
+make_repo() {
+  local root="$1" settings="$2"
+  mkdir -p "$root/main/.cache"
+  git -C "$root/main" init -q -b main
+  git -C "$root/main" config user.email test@example.com
+  git -C "$root/main" config user.name Test
+  git -C "$root/main" config commit.gpgsign false
+  printf '.cache/**\n!.cache/.gitkeep\n' >"$root/main/.gitignore"
+  : >"$root/main/.cache/.gitkeep"
+  git -C "$root/main" add .gitignore .cache/.gitkeep
+  if [[ -n "$settings" ]]; then
+    printf '%s\n' "$settings" >"$root/main/vstack.settings.toml"
+    git -C "$root/main" add vstack.settings.toml
+  fi
+  git -C "$root/main" commit -q -m base
+  git -C "$root/main" worktree add -q "$root/wt" -b issue-x
+}
+
+run_sync() {
+  local dir="$1"; shift
+  # env -u: the convention must come from the repo's own project files, never
+  # from whatever the invoking shell happens to export.
+  (cd "$dir" && PATH="$TMP_BASE/bin:$PATH" LINEAR_API_KEY=test-token \
+    env -u WORKTREE_SYMLINKS bash "$LINEAR" sync --no-attachments "$@")
+}
+
+fail=0
+note_fail() { echo "FAIL: $1"; fail=1; }
+note_ok() { echo "  ok: $1"; }
+
+# --- refusal: clobbered worktree cache with the convention configured ----------
+GUARD_ROOT="$TMP_BASE/guard"
+make_repo "$GUARD_ROOT" $'[env]\nWORKTREE_SYMLINKS = ".cache"'
+if [[ -d "$GUARD_ROOT/wt/.cache" && ! -L "$GUARD_ROOT/wt/.cache" ]]; then
+  note_ok "worktree add materialized .cache as a real directory (incident shape)"
+else
+  note_fail "test setup did not materialize a real .cache in the worktree"
+fi
+
+: >"$CURL_LOG"
+set +e
+err="$(run_sync "$GUARD_ROOT/wt" 2>&1 >/dev/null)"
+rc=$?
+set -e
+if [[ $rc -eq 0 ]]; then
+  note_fail "sync into a clobbered worktree cache unexpectedly succeeded: $err"
+else
+  note_ok "sync refused (rc=$rc)"
+fi
+grep -q "Sync refused" <<<"$err" || note_fail "refusal is not loud/greppable: $err"
+grep -qF "$GUARD_ROOT/wt" <<<"$err" || note_fail "refusal does not name the worktree: $err"
+grep -qF ".cache -> $(cd "$GUARD_ROOT/main" && pwd -P)/.cache" <<<"$err" \
+  || note_fail "refusal does not name the expected symlink: $err"
+grep -qF "worktree fix-links" <<<"$err" || note_fail "refusal does not name the repair command: $err"
+if [[ -s "$CURL_LOG" ]]; then
+  note_fail "refused sync still reached the API ($(wc -l <"$CURL_LOG") curl calls)"
+else
+  note_ok "no API call before the refusal"
+fi
+if [[ -e "$GUARD_ROOT/wt/.cache/linear" ]]; then
+  note_fail "refused sync still created a worktree-local cache dir"
+else
+  note_ok "no worktree-local cache dir was created"
+fi
+
+# --full must be refused just as hard
+set +e
+err_full="$(run_sync "$GUARD_ROOT/wt" --full 2>&1 >/dev/null)"
+rc_full=$?
+set -e
+[[ $rc_full -ne 0 ]] && grep -q "Sync refused" <<<"$err_full" \
+  && note_ok "--full refused too" \
+  || note_fail "--full was not refused: rc=$rc_full $err_full"
+
+# --- control: bare sync on the healthy main checkout ---------------------------
+: >"$CURL_LOG"
+set +e
+err_main="$(run_sync "$GUARD_ROOT/main" 2>&1 >/dev/null)"
+rc_main=$?
+set -e
+if [[ $rc_main -eq 0 && -f "$GUARD_ROOT/main/.cache/linear/meta.json" ]]; then
+  note_ok "bare sync on the main checkout unaffected"
+else
+  note_fail "bare sync on the main checkout broke: rc=$rc_main $err_main"
+fi
+[[ -s "$CURL_LOG" ]] || note_fail "main-checkout control did not exercise the API stub"
+
+# --- control: worktree with an intact .cache symlink ---------------------------
+rm -rf "$GUARD_ROOT/wt/.cache"
+ln -s "$GUARD_ROOT/main/.cache" "$GUARD_ROOT/wt/.cache"
+set +e
+err_wt="$(run_sync "$GUARD_ROOT/wt" --full 2>&1 >/dev/null)"
+rc_wt=$?
+set -e
+if [[ $rc_wt -eq 0 && -L "$GUARD_ROOT/wt/.cache" ]]; then
+  note_ok "--full in a healthy symlinked worktree unaffected"
+else
+  note_fail "--full in a healthy symlinked worktree broke: rc=$rc_wt $err_wt"
+fi
+
+# --- control: WORKTREE_SYMLINKS configured without .cache is an opt-out --------
+OPTOUT_ROOT="$TMP_BASE/optout"
+make_repo "$OPTOUT_ROOT" $'[env]\nWORKTREE_SYMLINKS = ".agents"'
+set +e
+err_opt="$(run_sync "$OPTOUT_ROOT/wt" 2>&1 >/dev/null)"
+rc_opt=$?
+set -e
+if [[ $rc_opt -eq 0 && -f "$OPTOUT_ROOT/wt/.cache/linear/meta.json" ]]; then
+  note_ok "worktree-local cache allowed when the convention excludes .cache"
+else
+  note_fail "opt-out repo was refused or failed: rc=$rc_opt $err_opt"
+fi
+
+# --- no worktree config at all: the issue's bare prescription still refuses ----
+BARE_ROOT="$TMP_BASE/bare"
+make_repo "$BARE_ROOT" ""
+set +e
+err_bare="$(run_sync "$BARE_ROOT/wt" 2>&1 >/dev/null)"
+rc_bare=$?
+set -e
+[[ $rc_bare -ne 0 ]] && grep -q "Sync refused" <<<"$err_bare" \
+  && note_ok "unconfigured repo with a main .cache still refuses" \
+  || note_fail "bare-prescription refusal missing: rc=$rc_bare $err_bare"
+
+if [[ $fail -ne 0 ]]; then
+  exit 1
+fi
+echo "all pass"

--- a/skills/worktree/README.md
+++ b/skills/worktree/README.md
@@ -21,6 +21,8 @@ Route by shape. `git checkout -- .agents` is **never** the recovery: the path ho
 
 `fix-links` is also the repair after anything that can replace a configured symlink with tracked content: a manual rebase, a partially-completed `remove`, or a restack replay. A worktree whose `.agents` is not a symlink cannot be trusted for local verification until it is fixed.
 
+Most clobbers now heal automatically: `create` and `fix-links` install shared `post-checkout`/`post-merge`/`post-rewrite` hooks in the main checkout's hooks directory that run `repair-links` after the git operations that materialize links. The auto-repair never destroys data git does not track — such a path is left in place with a loud warning pointing at manual `fix-links` — and the install is skipped (with a warning) when `core.hooksPath` is set. Details: `references/hooks.md`.
+
 ## Session guard
 
 `worktree-session-guard` records a session's claim on an issue worktree as a **native Git worktree lock** whose reason line carries the owner and heartbeat, so `git worktree remove [--force]` refuses it and `git worktree prune` leaves the registration alone. Using the native lock rather than a private marker file is deliberate: it needs no cooperation from whoever runs the cleanup.

--- a/skills/worktree/SKILL.md
+++ b/skills/worktree/SKILL.md
@@ -37,6 +37,7 @@ Issue IDs used to derive paths must match `[A-Za-z0-9][A-Za-z0-9._-]*` and must 
 | `exists` | Check if worktree exists for issue ID |
 | `check` | Pre-create git state check (JSON: uncommitted, unpushed) |
 | `push` | Push worktree branch with auto-rebase |
+| `fix-links` / `repair-links` | Restore configured symlinks in a worktree; `repair-links` is the git-hook-driven variant that never destroys untracked data — [references/hooks.md](references/hooks.md) |
 | `codex-setup` / `codex-branch` / `codex-cleanup` | Codex Desktop app-created worktree hooks — [references/hooks.md](references/hooks.md) |
 | `claude-setup` / `claude-cleanup` | Claude Code worktree hooks (`WorktreeCreate`) — [references/hooks.md](references/hooks.md) |
 
@@ -89,6 +90,8 @@ The configured symlinks (`WORKTREE_SYMLINKS`, typically `.agents`) point from a 
 | A genuinely modified or corrupt **tracked** file | `git checkout -- <path>` — run in the checkout the file really lives in |
 
 A tracked file *can* sit under a symlinked path — a project may symlink a directory it also tracks content in — and there `git checkout` from the worktree writes through the link into the main checkout while `assume-unchanged` keeps `git status` clean in both; recover at the real path in the owning checkout ([references/config.md](references/config.md)).
+
+Most of the time the links now heal themselves: `create` and `fix-links` install shared `post-checkout`/`post-merge`/`post-rewrite` hooks in the main checkout's hooks dir (worktrees resolve hooks there, so one install covers every worktree and every harness) that re-assert the configured symlinks after the git operations that clobber them. The auto-repair refuses to touch a materialized path holding data git does not track — it warns loudly and leaves the manual `fix-links` as the way out — and it is skipped entirely when `core.hooksPath` is set ([references/hooks.md](references/hooks.md)).
 
 **Run `fix-links` from the main checkout, not from the broken worktree** — the worktree's own copy of this script is reached *through* the link that is broken, so invoking it from there is the one place it may not exist. `fix-links` is also the repair after any operation that can replace a configured symlink with tracked content — a manual rebase or a partially-completed `remove`. Until the link is fixed, do not trust local verification from that tree: [references/recovery.md](references/recovery.md).
 

--- a/skills/worktree/references/hooks.md
+++ b/skills/worktree/references/hooks.md
@@ -1,4 +1,4 @@
-# App-created worktree hooks (Codex Desktop, Claude Code)
+# App-created worktree hooks (Codex Desktop, Claude Code) and git-hook auto-repair
 
 Installation-time wiring so app-created worktrees get the same env/config provisioning `create` applies. The everyday contract lives in [../SKILL.md](../SKILL.md).
 
@@ -9,6 +9,18 @@ Installation-time wiring so app-created worktrees get the same env/config provis
 | `codex-cleanup` | Non-destructive Codex Desktop cleanup hook; app owns deletion |
 | `claude-setup` | Apply env/config setup to a Claude Code-created worktree (`WorktreeCreate` hook) |
 | `claude-cleanup` | Non-destructive Claude Code cleanup hook; app owns deletion |
+| `repair-links` | Hook-driven symlink re-assertion; quiet no-op outside a managed worktree |
+
+## Git-hook auto-repair (`repair-links`)
+
+A rebase, merge, or branch checkout can re-materialize a `WORKTREE_SYMLINKS` entry as a real directory holding only the tracked files beneath it (vstack#1032 — the incident wrote a fresh multi-MB Linear cache into a worktree-local `.cache`). The clobber happens at git-operation time, mid-session, from any harness or a plain human shell, so the interception point is git itself.
+
+`create` and `fix-links` install shared `post-checkout`, `post-merge`, and `post-rewrite` hooks into the **main checkout's** hooks directory — worktrees resolve hooks there (`git rev-parse --git-path hooks`), so one installation covers every worktree and every harness. Mechanics:
+
+- The hook logic lives in an owned helper file, `hooks/vstack-worktree-autorepair`, rewritten on every install. The three stock hooks get one marked delegating line: an existing shell hook is **appended to**, never overwritten; a non-shell or non-executable (disabled) hook is left alone with a warning; the append is idempotent.
+- `core.hooksPath` is never used or modified — it replaces the hooks directory wholesale and would disable a consumer's own hooks. When it is set, the install is skipped with a warning; add a `repair-links` call to those hooks manually.
+- The helper no-ops in the main checkout and in repos without the skill installed, and never fails the git operation it runs after.
+- `repair-links` is cheap on the healthy path (one `readlink` per entry). Repair itself is the existing `fix-links` logic, with one extra guarantee: a materialized path holding files git does not track (untracked **or** ignored — a worktree-local cache is ignored data) is never clobbered; the hook warns loudly, names the files, and points at manual `fix-links` after the data has been moved or deleted.
 
 ## Codex Desktop hooks
 

--- a/skills/worktree/references/hooks.md
+++ b/skills/worktree/references/hooks.md
@@ -13,7 +13,7 @@ Installation-time wiring so app-created worktrees get the same env/config provis
 
 ## Git-hook auto-repair (`repair-links`)
 
-A rebase, merge, or branch checkout can re-materialize a `WORKTREE_SYMLINKS` entry as a real directory holding only the tracked files beneath it (vstack#1032 — the incident wrote a fresh multi-MB Linear cache into a worktree-local `.cache`). The clobber happens at git-operation time, mid-session, from any harness or a plain human shell, so the interception point is git itself.
+A rebase, merge, or branch checkout can re-materialize a `WORKTREE_SYMLINKS` entry as a real directory holding only the tracked files beneath it (the incident shape: a fresh multi-MB Linear cache written into a worktree-local `.cache`). The clobber happens at git-operation time, mid-session, from any harness or a plain human shell, so the interception point is git itself.
 
 `create` and `fix-links` install shared `post-checkout`, `post-merge`, and `post-rewrite` hooks into the **main checkout's** hooks directory — worktrees resolve hooks there (`git rev-parse --git-path hooks`), so one installation covers every worktree and every harness. Mechanics:
 

--- a/skills/worktree/scripts/worktree
+++ b/skills/worktree/scripts/worktree
@@ -1035,6 +1035,14 @@ install_worktree_autorepair_hooks() {
 
   for hook in $WORKTREE_AUTOREPAIR_HOOKS; do
     hook_path="$hooks_dir/$hook"
+    # A symlinked hook points at a shared or externally managed target —
+    # writing through it (live) or materializing its target (dangling, which
+    # passes `! -e`) would modify content this install does not own.
+    if [[ -L "$hook_path" ]]; then
+      echo "Warning: $hook_path is a symlink; not modifying its target." >&2
+      echo "  Have it run: $0 repair-links" >&2
+      continue
+    fi
     if [[ ! -e "$hook_path" ]]; then
       printf '#!/bin/sh\n%s\n' "$call_line" >"$hook_path" 2>/dev/null || {
         echo "Warning: could not write $hook_path; auto-repair will not run on $hook." >&2

--- a/skills/worktree/scripts/worktree
+++ b/skills/worktree/scripts/worktree
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Portable git worktree manager
-# Usage: worktree create|restack|list|remove|cleanup|path|exists|check|push|fix-links|codex-setup|codex-branch|codex-cleanup|claude-setup|claude-cleanup [ID] [options]
+# Usage: worktree create|restack|list|remove|cleanup|path|exists|check|push|fix-links|repair-links|codex-setup|codex-branch|codex-cleanup|claude-setup|claude-cleanup [ID] [options]
 #   create options:
 #     --base BRANCH   Checkout an existing remote branch into the worktree
 #     --from REF      Create a new branch starting from REF (branch, tag, or commit)
@@ -863,6 +863,9 @@ symlink_into_worktree() {
         printf '%s\n' "$shadowed" | sed 's/^/  - /'
         echo "  They are now assume-unchanged here, so git cannot write them in this worktree"
         echo "  (cherry-pick/checkout/merge will fail while 'git status' looks clean)."
+        echo "  Tracked files under a symlinked dir are the generator of link clobbering:"
+        echo "  a rebase/checkout that must write them WILL replace the '$path' symlink with"
+        echo "  a real directory until they are untracked (git rm --cached) in the project."
         echo "  If the project still tracks these, narrow the entry to the untracked subpaths."
       } >&2
       printf '%s\n' "$shadowed" | \
@@ -895,9 +898,11 @@ symlink_into_worktree() {
 # This is deliberately a WARNING, not a failure: the command the operator asked
 # for may not touch the affected paths, and a hard error would be a regression
 # for them. It runs at the points where materialization has just become likely
-# (post-rebase) rather than via a git hook — see the issue thread for why
-# `core.hooksPath` is the wrong mechanism: it replaces the hooks directory
-# wholesale and would disable the consumer's own hooks.
+# (post-rebase). Since #1032 the stock post-checkout/post-merge/post-rewrite
+# hooks also auto-repair (see install_worktree_autorepair_hooks); this warning
+# stays as the backstop for repos where the hooks could not be installed.
+# `core.hooksPath` remains the wrong mechanism either way: it replaces the
+# hooks directory wholesale and would disable the consumer's own hooks.
 warn_if_links_materialized() {
   local wt="$1" path="" materialized=""
   [[ -n "$wt" && -d "$wt" ]] || return 0
@@ -924,6 +929,180 @@ warn_if_links_materialized() {
     echo "    cd '$PROJECT_ROOT' && .agents/skills/worktree/scripts/worktree fix-links '$wt'"
   } >&2
   return 0
+}
+
+# ─── Git-hook auto-repair (#1032) ────────────────────────────────────────────
+#
+# The clobber that materializes a configured symlink happens at git-operation
+# time — rebase, merge, branch checkout — from any harness or a plain human
+# shell, so the use-time warning above only catches the flows this script sees.
+# The universal interception point is git itself: worktrees resolve hooks to
+# the MAIN checkout's hooks directory (`git rev-parse --git-path hooks` from a
+# worktree yields main's hooks dir), so one installation covers every worktree
+# and every harness.
+#
+# `core.hooksPath` is deliberately NOT used — it replaces the hooks directory
+# wholesale and would disable a consumer's own hooks. Instead the three stock
+# hooks that follow the destructive operations (post-checkout, post-merge,
+# post-rewrite) are created, or appended-to when they already exist, with one
+# marked delegating line; the actual logic lives in a helper file this script
+# owns outright and rewrites on every install.
+
+readonly WORKTREE_AUTOREPAIR_HELPER="vstack-worktree-autorepair"
+readonly WORKTREE_AUTOREPAIR_HOOKS="post-checkout post-merge post-rewrite"
+
+# The helper is POSIX sh and self-contained: it resolves the main checkout
+# from the common git dir, no-ops there, and otherwise delegates to this
+# script's repair-links from the main checkout (the worktree's own copy may be
+# among the clobbered files). stdin is redirected away because post-rewrite
+# feeds the rewritten-commit list on stdin and the repair must not consume it
+# from any hook content composed after ours. It never fails the git operation.
+write_worktree_autorepair_helper() {
+  local helper="$1"
+  cat >"$helper" <<'HELPER' || return 1
+#!/bin/sh
+# vstack worktree auto-repair (#1032). Managed by the worktree skill and
+# rewritten on every install — do not edit. Re-asserts configured
+# WORKTREE_SYMLINKS entries in a linked worktree after a git operation that
+# can re-materialize them as real directories. Never fails the git operation.
+common="$(git rev-parse --git-common-dir 2>/dev/null)" || exit 0
+[ -n "$common" ] || exit 0
+case "$common" in /*) ;; *) common="$PWD/$common" ;; esac
+main="$(dirname "$common")"
+top="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+[ -n "$top" ] || exit 0
+main_phys="$(cd "$main" 2>/dev/null && pwd -P)" || exit 0
+top_phys="$(cd "$top" 2>/dev/null && pwd -P)" || exit 0
+# The main checkout's configured paths are real directories by design.
+[ "$top_phys" = "$main_phys" ] && exit 0
+for script in "$main_phys/.agents/skills/worktree/scripts/worktree" \
+              "$main_phys/skills/worktree/scripts/worktree"; do
+  if [ -x "$script" ]; then
+    "$script" repair-links "$top_phys" </dev/null || :
+    break
+  fi
+done
+exit 0
+HELPER
+  chmod +x "$helper"
+}
+
+# Install (or refresh) the shared auto-repair hooks in the common hooks dir.
+# Best-effort by design: every failure is a warning and exit 0, because a repo
+# where the hooks cannot be written must still get a fully provisioned
+# worktree — it just keeps only the use-time materialization warning.
+install_worktree_autorepair_hooks() {
+  local hooks_dir="" hook="" hook_path="" custom_hooks=""
+  local call_line='vstack_wt_hooks_dir="$(git rev-parse --git-path hooks 2>/dev/null)" && [ -x "$vstack_wt_hooks_dir/vstack-worktree-autorepair" ] && "$vstack_wt_hooks_dir/vstack-worktree-autorepair" "$@" || :  # vstack-worktree-autorepair'
+
+  custom_hooks="$(git -C "$PROJECT_ROOT" config --get core.hooksPath 2>/dev/null || true)"
+  if [[ -n "$custom_hooks" ]]; then
+    echo "Warning: core.hooksPath is set ('$custom_hooks'); the worktree auto-repair git hooks were NOT installed." >&2
+    echo "  Have your post-checkout/post-merge/post-rewrite hooks run: $0 repair-links" >&2
+    return 0
+  fi
+
+  hooks_dir="$PROJECT_COMMON_GIT_DIR/hooks"
+  if ! mkdir -p "$hooks_dir" 2>/dev/null; then
+    echo "Warning: could not create $hooks_dir; the worktree auto-repair git hooks were NOT installed." >&2
+    return 0
+  fi
+  if ! write_worktree_autorepair_helper "$hooks_dir/$WORKTREE_AUTOREPAIR_HELPER"; then
+    echo "Warning: could not write $hooks_dir/$WORKTREE_AUTOREPAIR_HELPER; the worktree auto-repair git hooks were NOT installed." >&2
+    return 0
+  fi
+
+  for hook in $WORKTREE_AUTOREPAIR_HOOKS; do
+    hook_path="$hooks_dir/$hook"
+    if [[ ! -e "$hook_path" ]]; then
+      printf '#!/bin/sh\n%s\n' "$call_line" >"$hook_path" 2>/dev/null || {
+        echo "Warning: could not write $hook_path; auto-repair will not run on $hook." >&2
+        continue
+      }
+      chmod +x "$hook_path" 2>/dev/null || true
+      continue
+    fi
+    # Compose with existing hook content, never overwrite it. The marker makes
+    # the append idempotent across create/fix-links runs.
+    if grep -qF "$WORKTREE_AUTOREPAIR_HELPER" "$hook_path" 2>/dev/null; then
+      continue
+    fi
+    if [[ ! -x "$hook_path" ]]; then
+      echo "Warning: $hook_path exists but is not executable (a disabled hook); not appending the auto-repair line to it." >&2
+      continue
+    fi
+    if ! head -n 1 "$hook_path" | grep -qE '^#!.*(sh|bash|dash|ksh|zsh)([[:space:]]|$)'; then
+      echo "Warning: $hook_path is not a shell script; not appending the auto-repair line." >&2
+      echo "  Have it run: $0 repair-links" >&2
+      continue
+    fi
+    # Guarantee our line starts on its own line even when the existing hook
+    # has no trailing newline.
+    if [[ -s "$hook_path" && -n "$(tail -c 1 "$hook_path" 2>/dev/null)" ]]; then
+      printf '\n' >>"$hook_path"
+    fi
+    printf '%s\n' "$call_line" >>"$hook_path"
+  done
+  return 0
+}
+
+# Files present on disk under a configured path that git does not track — the
+# data an auto-repair would destroy. The tracked skeleton (e.g. a lone
+# .cache/.gitkeep) is exactly what a git operation re-materializes, so a real
+# directory holding ONLY tracked files is safe to re-link; anything beyond it
+# (untracked OR ignored — a worktree-local cache is ignored data) is not.
+worktree_path_untracked_disk_files() {
+  local wt="$1" path="$2" disk="" tracked=""
+  disk="$( (cd "$wt" 2>/dev/null && find "$path" \( -type f -o -type l \) 2>/dev/null) | LC_ALL=C sort)"
+  [[ -n "$disk" ]] || return 0
+  tracked="$(git -C "$wt" ls-files -- "$path" "$path/" 2>/dev/null | LC_ALL=C sort)"
+  LC_ALL=C comm -23 <(printf '%s\n' "$disk") <(printf '%s\n' "$tracked") | grep -v '^$' || true
+}
+
+# Re-assert configured WORKTREE_SYMLINKS in one worktree. Cheap on the healthy
+# path (one readlink per entry); repair is the existing fix-links logic
+# (symlink_into_worktree). A materialized path holding data git does not track
+# is never clobbered — it is reported loudly with the manual way out instead.
+repair_worktree_links() {
+  local wt="$1" path="" src="" dst="" extras="" extra_count=0 repaired="" blocked=false
+  validate_worktree_setup_config || return 1
+
+  split_worktree_config_words "${WORKTREE_SYMLINKS:-}"
+  for path in ${WORKTREE_CONFIG_WORDS[@]+"${WORKTREE_CONFIG_WORDS[@]}"}; do
+    path="$(normalize_worktree_config_path WORKTREE_SYMLINKS "$path" 2>/dev/null)" || continue
+    src="$PROJECT_ROOT/$path"
+    dst="$wt/$path"
+    [[ -e "$src" ]] || continue
+    if [[ -L "$dst" ]]; then
+      # Healthy steady state; also covers a link re-pointed at a moved main.
+      [[ "$(readlink "$dst" 2>/dev/null || true)" == "$src" ]] && continue
+    elif [[ -e "$dst" ]]; then
+      extras="$(worktree_path_untracked_disk_files "$wt" "$path")"
+      if [[ -n "$extras" ]]; then
+        blocked=true
+        extra_count="$(printf '%s\n' "$extras" | grep -c .)"
+        {
+          echo "Warning: '$path' in $wt should be a symlink to '$src' but is a real path holding $extra_count file(s) git does not track:"
+          printf '%s\n' "$extras" | head -n 10 | sed 's/^/  - /'
+          if [[ "$extra_count" -gt 10 ]]; then
+            echo "  ... and $((extra_count - 10)) more"
+          fi
+          echo "  Auto-repair refuses to destroy untracked data. Move it into '$src' (or delete it),"
+          echo "  then restore the link from the main checkout:"
+          echo "    cd '$PROJECT_ROOT' && $0 fix-links '$wt'"
+        } >&2
+        continue
+      fi
+    fi
+    if symlink_into_worktree "$path" "$wt"; then
+      repaired="$repaired $path"
+    fi
+  done
+
+  if [[ -n "$repaired" ]]; then
+    echo "worktree auto-repair: restored symlink(s) in $wt:$repaired" >&2
+  fi
+  [[ "$blocked" != true ]]
 }
 
 # Undo symlink shadowing so git can check out through the configured paths
@@ -1101,6 +1280,9 @@ setup_app_worktree() {
   setup_worktree_links "$wt" || return 1
   configure_worktree_git "$wt" || return 1
   install_worktree_dependencies "$wt" || return 1
+  # Best-effort by contract (#1032): a repo where the hooks cannot be written
+  # still gets a fully provisioned worktree.
+  install_worktree_autorepair_hooks
 }
 
 is_git_worktree_path() {
@@ -3027,7 +3209,32 @@ case "${1:-}" in
       exit 1
     fi
     setup_worktree_links "$WT_PATH"
+    # Re-assert the shared auto-repair hooks too (#1032): a fix-links run is
+    # the natural refresh point after upgrading the skill or the config.
+    install_worktree_autorepair_hooks
     echo "Restored symlinks in $WT_PATH"
+    ;;
+
+  repair-links)
+    # Hook-driven sibling of fix-links (#1032): re-assert configured
+    # WORKTREE_SYMLINKS after a git operation, refusing to destroy any data
+    # git does not track that a materialized path has accumulated. Exits 0
+    # quietly for the main checkout or an unregistered path because its
+    # callers are shared git hooks that fire for every checkout of the repo.
+    ARG="${2:-}"
+    if [[ -z "$ARG" ]]; then
+      WT_PATH="$PWD"
+    elif [[ "$ARG" == */* ]]; then
+      WT_PATH="$ARG"
+    else
+      WT_PATH="$(worktree_path_for_issue "$ARG")"
+    fi
+    if ! is_git_worktree_path "$WT_PATH" || \
+       ! is_registered_project_worktree "$WT_PATH" || \
+       same_canonical_dir "$WT_PATH" "$PROJECT_ROOT"; then
+      exit 0
+    fi
+    repair_worktree_links "$WT_PATH"
     ;;
 
   codex-setup)
@@ -3157,7 +3364,7 @@ case "${1:-}" in
     ;;
 
   *)
-    echo "Usage: $0 create|restack|list|remove|cleanup [--stale]|path|exists|check|push|fix-links|codex-setup|codex-branch|codex-cleanup|claude-setup|claude-cleanup [ID|/path] [options]" >&2
+    echo "Usage: $0 create|restack|list|remove|cleanup [--stale]|path|exists|check|push|fix-links|repair-links|codex-setup|codex-branch|codex-cleanup|claude-setup|claude-cleanup [ID|/path] [options]" >&2
     exit 1
     ;;
 esac

--- a/skills/worktree/scripts/worktree
+++ b/skills/worktree/scripts/worktree
@@ -1057,12 +1057,20 @@ install_worktree_autorepair_hooks() {
 # directory holding ONLY tracked files is safe to re-link; anything beyond it
 # (untracked OR ignored — a worktree-local cache is ignored data) is not.
 worktree_path_untracked_disk_files() {
-  local wt="$1" path="$2" disk="" tracked=""
+  local wt="$1" path="$2" raw="" disk="" tracked="" rc=0
   # ./ prefix: a configured path may begin with '-' (normalization does not
   # forbid it), which bare find would parse as an expression — the discarded
   # error would then read as "no files" and let the repair clobber real data.
   # The prefix is stripped again so the names compare against git ls-files.
-  disk="$( (cd "$wt" 2>/dev/null && find "./$path" \( -type f -o -type l \) 2>/dev/null) | sed 's|^\./||' | LC_ALL=C sort)"
+  raw="$(cd "$wt" 2>/dev/null && find "./$path" \( -type f -o -type l \) 2>/dev/null)" || rc=$?
+  if [[ "$rc" -ne 0 ]]; then
+    # Fail closed: a failed traversal (permissions, concurrent removal) must
+    # read as "cannot prove the path is safe to replace", never as "empty".
+    # The sentinel flows into the caller's warning as the blocking file list.
+    printf '[scan failed: could not enumerate files under %s (exit %s)]\n' "$path" "$rc"
+    return 0
+  fi
+  disk="$(printf '%s\n' "$raw" | sed 's|^\./||' | grep -v '^$' | LC_ALL=C sort)"
   [[ -n "$disk" ]] || return 0
   tracked="$(git -C "$wt" ls-files -- "$path" "$path/" 2>/dev/null | LC_ALL=C sort)"
   LC_ALL=C comm -23 <(printf '%s\n' "$disk") <(printf '%s\n' "$tracked") | grep -v '^$' || true

--- a/skills/worktree/scripts/worktree
+++ b/skills/worktree/scripts/worktree
@@ -993,7 +993,12 @@ HELPER
 # worktree — it just keeps only the use-time materialization warning.
 install_worktree_autorepair_hooks() {
   local hooks_dir="" hook="" hook_path="" custom_hooks=""
-  local call_line='vstack_wt_hooks_dir="$(git rev-parse --git-path hooks 2>/dev/null)" && [ -x "$vstack_wt_hooks_dir/vstack-worktree-autorepair" ] && "$vstack_wt_hooks_dir/vstack-worktree-autorepair" "$@" || :  # vstack-worktree-autorepair'
+  # The delegating line must be exit-status transparent when appended to an
+  # existing hook: post-checkout's exit status becomes git's, so a consumer
+  # hook whose final command deliberately returns nonzero must keep doing so.
+  # $? is captured first and re-asserted last (in a subshell, so hook content
+  # a later tool appends after this line still runs).
+  local call_line='vstack_wt_rc=$?; vstack_wt_hooks_dir="$(git rev-parse --git-path hooks 2>/dev/null)" && [ -x "$vstack_wt_hooks_dir/vstack-worktree-autorepair" ] && "$vstack_wt_hooks_dir/vstack-worktree-autorepair" "$@" || :; ( exit "$vstack_wt_rc" )  # vstack-worktree-autorepair'
 
   custom_hooks="$(git -C "$PROJECT_ROOT" config --get core.hooksPath 2>/dev/null || true)"
   if [[ -n "$custom_hooks" ]]; then

--- a/skills/worktree/scripts/worktree
+++ b/skills/worktree/scripts/worktree
@@ -1087,13 +1087,40 @@ worktree_quarantine_unsafe_entries() {
     return 0
   fi
   # An empty untracked directory is never part of the skeleton — git creates
-  # directories only to hold tracked files.
+  # directories only to hold tracked files. No regex: paths are stripped with
+  # literal parameter expansion (a path may contain sed metacharacters, and a
+  # broken sed expression would fail OPEN as an empty listing).
   if [[ -n "$empties" ]]; then
-    printf '%s\n' "$empties" | sed "s|^$qdir/|$path/|; s|\$| (empty untracked directory)|"
+    while IFS= read -r name; do
+      [[ -n "$name" ]] || continue
+      printf '%s/%s (empty untracked directory)\n' "$path" "${name#"$qdir"/}"
+    done <<<"$empties"
   fi
-  disk="$(printf '%s\n' "$raw" | sed "s|^$qdir/||" | grep -v '^$' | LC_ALL=C sort)"
-  tracked="$(git -C "$wt" ls-files -- "$path/" 2>/dev/null | sed "s|^$path/||" | LC_ALL=C sort)"
-  LC_ALL=C comm -23 <(printf '%s\n' "$disk") <(printf '%s\n' "$tracked") | grep -v '^$' | sed "s|^|$path/|" || true
+  disk="$(while IFS= read -r name; do
+    [[ -n "$name" ]] || continue
+    printf '%s\n' "${name#"$qdir"/}"
+  done <<<"$raw" | LC_ALL=C sort)"
+  # A filename containing a newline shreds a line-delimited inventory into
+  # fragments (or, for a pure-newline name, into nothing once command
+  # substitution strips trailing newlines). Cross-check the reconstructed
+  # entry count against a NUL-delimited pass — any mismatch blocks rather
+  # than risking a deletion decision on a listing that cannot represent the
+  # names it saw.
+  local n_disk=0 n_nul=0
+  n_disk="$(printf '%s' "$disk" | grep -c . || true)"
+  n_nul="$(find "$qdir" ! -type d -print0 2>/dev/null | tr -cd '\0' | wc -c | tr -d '[:space:]')" || n_nul=-1
+  if [[ "$n_disk" != "$n_nul" ]]; then
+    printf '[scan mismatch: %s entries by NUL count vs %s reconstructed line entries — a name this listing cannot represent]\n' "$n_nul" "$n_disk"
+    return 0
+  fi
+  tracked="$(git -C "$wt" ls-files -- "$path/" 2>/dev/null | while IFS= read -r name; do
+    [[ -n "$name" ]] || continue
+    printf '%s\n' "${name#"$path"/}"
+  done | LC_ALL=C sort)"
+  while IFS= read -r name; do
+    [[ -n "$name" ]] || continue
+    printf '%s/%s\n' "$path" "$name"
+  done < <(LC_ALL=C comm -23 <(printf '%s\n' "$disk") <(printf '%s\n' "$tracked"))
   # Tracked names present in the copy must match the index exactly.
   while IFS= read -r name; do
     [[ -n "$name" ]] || continue
@@ -1189,7 +1216,31 @@ repair_worktree_links() {
         } >&2
         continue
       fi
-      rm -rf "$qdir"
+      # An active by-path writer may have recreated the path while the old
+      # tree was inspected; linking now would delete that fresh data inside
+      # symlink_into_worktree. Leave the newcomer for the next hook firing.
+      # The quarantined copy is proven index-identical, so discarding it
+      # loses nothing git cannot restore.
+      if [[ -e "$dst" || -L "$dst" ]]; then
+        blocked=true
+        rm -rf "$qdir"
+        echo "Warning: '$path' in $wt reappeared while its materialized copy was being inspected (an active writer?); leaving the new path alone. The next git operation will re-attempt the repair." >&2
+        continue
+      fi
+      # The quarantined copy is deleted only after the link is in place —
+      # a failed relink restores it instead of leaving the path absent.
+      if symlink_into_worktree "$path" "$wt"; then
+        rm -rf "$qdir"
+        repaired="$repaired $path"
+      else
+        blocked=true
+        if [[ ! -e "$dst" && ! -L "$dst" ]] && mv "$qdir" "$dst" 2>/dev/null; then
+          echo "Warning: relinking '$path' in $wt failed; the materialized copy was restored. Repair manually: cd '$PROJECT_ROOT' && $0 fix-links '$wt'" >&2
+        else
+          echo "CRITICAL: relinking '$path' in $wt failed and the copy could not be restored — its content is preserved at '$qdir'." >&2
+        fi
+      fi
+      continue
     fi
     if symlink_into_worktree "$path" "$wt"; then
       repaired="$repaired $path"

--- a/skills/worktree/scripts/worktree
+++ b/skills/worktree/scripts/worktree
@@ -1182,7 +1182,22 @@ worktree_tracked_entry_mismatch() {
   fi
   case "$mode" in
     120000)
-      if [[ ! -L "$file" ]] || [[ "$(readlink "$file" 2>/dev/null)" != "$(git -C "$wt" cat-file blob "$oid" 2>/dev/null)" ]]; then
+      if [[ ! -L "$file" ]]; then
+        printf '%s (symlink differs from index)\n' "$label"
+        return 0
+      fi
+      # Sentinel-preserved comparison: bare command substitution strips ALL
+      # trailing newlines from both sides, so targets differing only by
+      # trailing newline bytes would compare equal and the difference would
+      # be discarded. readlink appends exactly one newline of its own;
+      # cat-file emits the blob verbatim.
+      local disk_target="" index_target=""
+      disk_target="$(readlink "$file" 2>/dev/null; printf x)"
+      disk_target="${disk_target%x}"
+      disk_target="${disk_target%$'\n'}"
+      index_target="$(git -C "$wt" cat-file blob "$oid" 2>/dev/null; printf x)"
+      index_target="${index_target%x}"
+      if [[ "$disk_target" != "$index_target" ]]; then
         printf '%s (symlink differs from index)\n' "$label"
       fi
       ;;

--- a/skills/worktree/scripts/worktree
+++ b/skills/worktree/scripts/worktree
@@ -1051,37 +1051,107 @@ install_worktree_autorepair_hooks() {
   return 0
 }
 
-# Files present on disk under a configured path that git does not track — the
-# data an auto-repair would destroy. The tracked skeleton (e.g. a lone
-# .cache/.gitkeep) is exactly what a git operation re-materializes, so a real
-# directory holding ONLY tracked files is safe to re-link; anything beyond it
-# (untracked OR ignored — a worktree-local cache is ignored data) is not.
-worktree_path_untracked_disk_files() {
-  local wt="$1" path="$2" raw="" disk="" tracked="" rc=0
-  # ./ prefix: a configured path may begin with '-' (normalization does not
-  # forbid it), which bare find would parse as an expression — the discarded
-  # error would then read as "no files" and let the repair clobber real data.
-  # The prefix is stripped again so the names compare against git ls-files.
-  raw="$(cd "$wt" 2>/dev/null && find "./$path" \( -type f -o -type l \) 2>/dev/null)" || rc=$?
-  if [[ "$rc" -ne 0 ]]; then
-    # Fail closed: a failed traversal (permissions, concurrent removal) must
-    # read as "cannot prove the path is safe to replace", never as "empty".
-    # The sentinel flows into the caller's warning as the blocking file list.
-    printf '[scan failed: could not enumerate files under %s (exit %s)]\n' "$path" "$rc"
+# Entries inside a quarantined (moved-aside) materialized path that forbid an
+# automatic re-link. The tracked skeleton (e.g. a lone .cache/.gitkeep) is
+# exactly what a git operation re-materializes, so a copy holding ONLY tracked
+# files at their index content is safe to discard; anything beyond it is not:
+#   - any entry git does not track, of ANY type — FIFOs, sockets, devices and
+#     empty untracked directories included (untracked OR ignored data — a
+#     worktree-local cache is ignored data);
+#   - a tracked name whose content, kind, or exec bit differs from the index
+#     (assume-unchanged hides such edits from git status, so only a direct
+#     compare sees them);
+#   - anything that could not be scanned or read — fail closed, never "empty".
+# Names print relative to the configured path; any output means blocked.
+worktree_quarantine_unsafe_entries() {
+  local wt="$1" path="$2" qdir="$3" rc=0 raw="" empties="" disk="" tracked=""
+  local name="" meta="" mode="" oid="" actual=""
+
+  if [[ ! -d "$qdir" || -L "$qdir" ]]; then
+    # The materialized path is a single non-directory entry: safe only when
+    # git tracks $path itself as a regular file with identical content.
+    if [[ "$(git -C "$wt" ls-files -- "$path" 2>/dev/null)" != "$path" ]]; then
+      printf '%s (untracked)\n' "$path"
+      return 0
+    fi
+    worktree_tracked_entry_mismatch "$wt" "$path" "$path" "$qdir"
     return 0
   fi
-  disk="$(printf '%s\n' "$raw" | sed 's|^\./||' | grep -v '^$' | LC_ALL=C sort)"
-  [[ -n "$disk" ]] || return 0
-  tracked="$(git -C "$wt" ls-files -- "$path" "$path/" 2>/dev/null | LC_ALL=C sort)"
-  LC_ALL=C comm -23 <(printf '%s\n' "$disk") <(printf '%s\n' "$tracked") | grep -v '^$' || true
+
+  raw="$(find "$qdir" ! -type d 2>/dev/null)" || rc=$?
+  if [[ "$rc" -eq 0 ]]; then
+    empties="$(find "$qdir" -mindepth 1 -type d -empty 2>/dev/null)" || rc=$?
+  fi
+  if [[ "$rc" -ne 0 ]]; then
+    printf '[scan failed: could not enumerate entries under %s (exit %s)]\n' "$path" "$rc"
+    return 0
+  fi
+  # An empty untracked directory is never part of the skeleton — git creates
+  # directories only to hold tracked files.
+  if [[ -n "$empties" ]]; then
+    printf '%s\n' "$empties" | sed "s|^$qdir/|$path/|; s|\$| (empty untracked directory)|"
+  fi
+  disk="$(printf '%s\n' "$raw" | sed "s|^$qdir/||" | grep -v '^$' | LC_ALL=C sort)"
+  tracked="$(git -C "$wt" ls-files -- "$path/" 2>/dev/null | sed "s|^$path/||" | LC_ALL=C sort)"
+  LC_ALL=C comm -23 <(printf '%s\n' "$disk") <(printf '%s\n' "$tracked") | grep -v '^$' | sed "s|^|$path/|" || true
+  # Tracked names present in the copy must match the index exactly.
+  while IFS= read -r name; do
+    [[ -n "$name" ]] || continue
+    worktree_tracked_entry_mismatch "$wt" "$path/$name" "$path/$name" "$qdir/$name"
+  done < <(LC_ALL=C comm -12 <(printf '%s\n' "$disk") <(printf '%s\n' "$tracked"))
+}
+
+# Print a blocking line iff the on-disk entry differs from the index record
+# for the tracked pathspec (content oid, symlink target, kind, or exec bit).
+worktree_tracked_entry_mismatch() {
+  local wt="$1" spec="$2" label="$3" file="$4" meta="" mode="" oid="" actual=""
+  meta="$(git -C "$wt" ls-files -s -- "$spec" 2>/dev/null | head -n 1)"
+  mode="${meta%% *}"
+  oid="$(printf '%s\n' "$meta" | awk '{print $2}')"
+  if [[ -z "$mode" || -z "$oid" ]]; then
+    printf '%s (index record unreadable)\n' "$label"
+    return 0
+  fi
+  case "$mode" in
+    120000)
+      if [[ ! -L "$file" ]] || [[ "$(readlink "$file" 2>/dev/null)" != "$(git -C "$wt" cat-file blob "$oid" 2>/dev/null)" ]]; then
+        printf '%s (symlink differs from index)\n' "$label"
+      fi
+      ;;
+    100644 | 100755)
+      if [[ ! -f "$file" || -L "$file" ]]; then
+        printf '%s (not the regular file the index records)\n' "$label"
+        return 0
+      fi
+      actual="$(git -C "$wt" hash-object -- "$file" 2>/dev/null)" || actual=""
+      if [[ -z "$actual" ]]; then
+        printf '%s (unreadable)\n' "$label"
+      elif [[ "$actual" != "$oid" ]]; then
+        printf '%s (local edits vs index)\n' "$label"
+      elif [[ "$mode" == 100755 && ! -x "$file" ]] || [[ "$mode" == 100644 && -x "$file" ]]; then
+        printf '%s (exec bit differs from index)\n' "$label"
+      fi
+      ;;
+    *)
+      printf '%s (unsupported index mode %s)\n' "$label" "$mode"
+      ;;
+  esac
 }
 
 # Re-assert configured WORKTREE_SYMLINKS in one worktree. Cheap on the healthy
 # path (one readlink per entry); repair is the existing fix-links logic
 # (symlink_into_worktree). A materialized path holding data git does not track
 # is never clobbered — it is reported loudly with the manual way out instead.
+#
+# The materialized path is atomically renamed aside BEFORE inspection: a
+# writer racing the scan by path lands in a freshly-created directory (or
+# fails with ENOENT), never in the tree being judged, and a blocked copy is
+# renamed back intact. A writer holding an already-open fd into the old tree
+# can still lose post-scan writes — that residual window is unclosable
+# without never deleting at all; the by-path race (the incident class: a
+# cache sync creating files while the hook runs) is what the rename closes.
 repair_worktree_links() {
-  local wt="$1" path="" src="" dst="" extras="" extra_count=0 repaired="" blocked=false
+  local wt="$1" path="" src="" dst="" qdir="" extras="" extra_count=0 repaired="" blocked=false
   validate_worktree_setup_config || return 1
 
   split_worktree_config_words "${WORKTREE_SYMLINKS:-}"
@@ -1094,12 +1164,21 @@ repair_worktree_links() {
       # Healthy steady state; also covers a link re-pointed at a moved main.
       [[ "$(readlink "$dst" 2>/dev/null || true)" == "$src" ]] && continue
     elif [[ -e "$dst" ]]; then
-      extras="$(worktree_path_untracked_disk_files "$wt" "$path")"
+      qdir="$dst.vstack-repair.$$"
+      if ! mv "$dst" "$qdir" 2>/dev/null; then
+        blocked=true
+        echo "Warning: '$path' in $wt is materialized but could not be moved aside for inspection; leaving it untouched. Repair manually: cd '$PROJECT_ROOT' && $0 fix-links '$wt'" >&2
+        continue
+      fi
+      extras="$(worktree_quarantine_unsafe_entries "$wt" "$path" "$qdir")"
       if [[ -n "$extras" ]]; then
         blocked=true
+        if ! mv "$qdir" "$dst" 2>/dev/null; then
+          echo "CRITICAL: '$path' data is preserved at '$qdir' but could not be moved back to '$dst' — restore it manually before anything else." >&2
+        fi
         extra_count="$(printf '%s\n' "$extras" | grep -c .)"
         {
-          echo "Warning: '$path' in $wt should be a symlink to '$src' but is a real path holding $extra_count file(s) git does not track:"
+          echo "Warning: '$path' in $wt should be a symlink to '$src' but is a real path holding $extra_count entr(y/ies) git does not track or that differ from the index:"
           printf '%s\n' "$extras" | head -n 10 | sed 's/^/  - /'
           if [[ "$extra_count" -gt 10 ]]; then
             echo "  ... and $((extra_count - 10)) more"
@@ -1110,6 +1189,7 @@ repair_worktree_links() {
         } >&2
         continue
       fi
+      rm -rf "$qdir"
     fi
     if symlink_into_worktree "$path" "$wt"; then
       repaired="$repaired $path"

--- a/skills/worktree/scripts/worktree
+++ b/skills/worktree/scripts/worktree
@@ -1058,7 +1058,11 @@ install_worktree_autorepair_hooks() {
 # (untracked OR ignored — a worktree-local cache is ignored data) is not.
 worktree_path_untracked_disk_files() {
   local wt="$1" path="$2" disk="" tracked=""
-  disk="$( (cd "$wt" 2>/dev/null && find "$path" \( -type f -o -type l \) 2>/dev/null) | LC_ALL=C sort)"
+  # ./ prefix: a configured path may begin with '-' (normalization does not
+  # forbid it), which bare find would parse as an expression — the discarded
+  # error would then read as "no files" and let the repair clobber real data.
+  # The prefix is stripped again so the names compare against git ls-files.
+  disk="$( (cd "$wt" 2>/dev/null && find "./$path" \( -type f -o -type l \) 2>/dev/null) | sed 's|^\./||' | LC_ALL=C sort)"
   [[ -n "$disk" ]] || return 0
   tracked="$(git -C "$wt" ls-files -- "$path" "$path/" 2>/dev/null | LC_ALL=C sort)"
   LC_ALL=C comm -23 <(printf '%s\n' "$disk") <(printf '%s\n' "$tracked") | grep -v '^$' || true

--- a/skills/worktree/scripts/worktree
+++ b/skills/worktree/scripts/worktree
@@ -958,8 +958,21 @@ readonly WORKTREE_AUTOREPAIR_HOOKS="post-checkout post-merge post-rewrite"
 # feeds the rewritten-commit list on stdin and the repair must not consume it
 # from any hook content composed after ours. It never fails the git operation.
 write_worktree_autorepair_helper() {
-  local helper="$1"
-  cat >"$helper" <<'HELPER' || return 1
+  local helper="$1" tmp=""
+  # The name is vstack-namespaced, but the non-destructive contract holds
+  # even against a collision: never write through a symlink, never replace a
+  # non-regular file, and never overwrite content missing our marker. Our
+  # own helper is rewritten on every install, via atomic rename.
+  if [[ -L "$helper" ]] || [[ -e "$helper" && ! -f "$helper" ]]; then
+    echo "Warning: $helper exists and is not a regular file; refusing to replace it." >&2
+    return 1
+  fi
+  if [[ -f "$helper" ]] && ! grep -q "vstack worktree auto-repair" "$helper" 2>/dev/null; then
+    echo "Warning: $helper exists but was not written by the worktree skill; refusing to overwrite it." >&2
+    return 1
+  fi
+  tmp="$helper.tmp.$$"
+  cat >"$tmp" <<'HELPER' || { rm -f "$tmp"; return 1; }
 #!/bin/sh
 # vstack worktree auto-repair (#1032). Managed by the worktree skill and
 # rewritten on every install — do not edit. Re-asserts configured
@@ -984,7 +997,10 @@ for script in "$main_phys/.agents/skills/worktree/scripts/worktree" \
 done
 exit 0
 HELPER
-  chmod +x "$helper"
+  chmod +x "$tmp" 2>/dev/null && mv -f "$tmp" "$helper" || {
+    rm -f "$tmp"
+    return 1
+  }
 }
 
 # Install (or refresh) the shared auto-repair hooks in the common hooks dir.
@@ -1099,7 +1115,10 @@ worktree_quarantine_unsafe_entries() {
   disk="$(while IFS= read -r name; do
     [[ -n "$name" ]] || continue
     printf '%s\n' "${name#"$qdir"/}"
-  done <<<"$raw" | LC_ALL=C sort)"
+  done <<<"$raw" | LC_ALL=C sort)" || {
+    printf '[scan failed: could not sort the inventory]\n'
+    return 0
+  }
   # A filename containing a newline shreds a line-delimited inventory into
   # fragments (or, for a pure-newline name, into nothing once command
   # substitution strips trailing newlines). Cross-check the reconstructed
@@ -1113,19 +1132,33 @@ worktree_quarantine_unsafe_entries() {
     printf '[scan mismatch: %s entries by NUL count vs %s reconstructed line entries — a name this listing cannot represent]\n' "$n_nul" "$n_disk"
     return 0
   fi
+  # A failed tracked-listing sort collapses to an empty set, which reads as
+  # "everything is untracked" — fail-closed on its own. The comm calls are
+  # NOT: a failed comm yields empty output in both directions, which reads
+  # as "nothing extra and nothing to verify" — so their exit status must be
+  # checked explicitly.
   tracked="$(git -C "$wt" ls-files -- "$path/" 2>/dev/null | while IFS= read -r name; do
     [[ -n "$name" ]] || continue
     printf '%s\n' "${name#"$path"/}"
-  done | LC_ALL=C sort)"
+  done | LC_ALL=C sort)" || tracked=""
+  local untracked="" present_tracked="" cmp_rc=0
+  untracked="$(LC_ALL=C comm -23 <(printf '%s\n' "$disk") <(printf '%s\n' "$tracked") 2>/dev/null)" || cmp_rc=$?
+  if [[ "$cmp_rc" -eq 0 ]]; then
+    present_tracked="$(LC_ALL=C comm -12 <(printf '%s\n' "$disk") <(printf '%s\n' "$tracked") 2>/dev/null)" || cmp_rc=$?
+  fi
+  if [[ "$cmp_rc" -ne 0 ]]; then
+    printf '[scan failed: name-set comparison failed (exit %s)]\n' "$cmp_rc"
+    return 0
+  fi
   while IFS= read -r name; do
     [[ -n "$name" ]] || continue
     printf '%s/%s\n' "$path" "$name"
-  done < <(LC_ALL=C comm -23 <(printf '%s\n' "$disk") <(printf '%s\n' "$tracked"))
+  done <<<"$untracked"
   # Tracked names present in the copy must match the index exactly.
   while IFS= read -r name; do
     [[ -n "$name" ]] || continue
     worktree_tracked_entry_mismatch "$wt" "$path/$name" "$path/$name" "$qdir/$name"
-  done < <(LC_ALL=C comm -12 <(printf '%s\n' "$disk") <(printf '%s\n' "$tracked"))
+  done <<<"$present_tracked"
 }
 
 # Print a blocking line iff the on-disk entry differs from the index record

--- a/skills/worktree/tests/worktree_autorepair_hooks.sh
+++ b/skills/worktree/tests/worktree_autorepair_hooks.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# #1032: a git operation (rebase/merge/checkout) can re-materialize a
+# WORKTREE_SYMLINKS-managed symlink as a real directory holding only the
+# tracked skeleton, and nothing re-asserted the links automatically — the
+# damage surfaced later (e.g. a 21 MB Linear cache re-synced into a
+# worktree-local `.cache`). `create`/`fix-links` now install shared
+# post-checkout/post-merge/post-rewrite hooks in the MAIN checkout's hooks dir
+# (worktrees resolve hooks there, so one install covers every worktree and
+# every harness) that run `repair-links`.
+#
+# Asserted here:
+#   1. create installs the three hooks plus the owned helper, composing with
+#      existing shell hook content instead of overwriting, skipping non-shell
+#      hooks, and staying idempotent across repeated installs;
+#   2. a materialized symlink holding ONLY the tracked skeleton is silently
+#      re-linked by the next git operation;
+#   3. a materialized path holding data git does not track is NEVER clobbered —
+#      the hook warns loudly and names fix-links instead;
+#   4. repair-links is quiet and safe when addressed at the main checkout.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
+WORKTREE_SCRIPT="${WORKTREE_SCRIPT:-$SKILL_DIR/scripts/worktree}"
+TMP_ROOT="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+PASS=0
+FAIL=0
+ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
+
+assert_contains() {
+  local haystack="$1" needle="$2" name="$3"
+  if grep -qF -- "$needle" <<<"$haystack"; then ok "$name"; else bad "$name" "wanted: $needle"; fi
+}
+assert_lacks() {
+  local haystack="$1" needle="$2" name="$3"
+  if grep -qF -- "$needle" <<<"$haystack"; then bad "$name" "unexpected: $needle"; else ok "$name"; fi
+}
+assert_file_contains() {
+  local file="$1" needle="$2" name="$3"
+  if grep -qF -- "$needle" "$file" 2>/dev/null; then ok "$name"; else bad "$name" "wanted '$needle' in $file"; fi
+}
+
+mkdir -p "$TMP_ROOT/bin"
+cat >"$TMP_ROOT/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+chmod +x "$TMP_ROOT/bin/gh"
+export PATH="$TMP_ROOT/bin:$PATH"
+
+ROOT="$TMP_ROOT/repo"
+MAIN="$ROOT/main"
+mkdir -p "$MAIN"
+git -C "$MAIN" init -q -b main
+git -C "$MAIN" config user.email test@example.com
+git -C "$MAIN" config user.name Test
+git -C "$MAIN" config commit.gpgsign false
+printf 'base\n' >"$MAIN/base.txt"
+git -C "$MAIN" add base.txt
+git -C "$MAIN" commit -q -m base
+git init -q --bare "$ROOT/origin.git"
+git -C "$MAIN" remote add origin "$ROOT/origin.git"
+git -C "$MAIN" push -q -u origin main
+
+# harness/ mirrors the incident shape: mostly ignored runtime content with one
+# tracked file underneath — the tracked skeleton git re-materializes.
+mkdir -p "$MAIN/harness/skills"
+printf 'harness/**\n!harness/tracked.md\n' >"$MAIN/.gitignore"
+printf 'installed\n' >"$MAIN/harness/skills/installed.txt"
+printf 'tracked\n' >"$MAIN/harness/tracked.md"
+printf 'WORKTREE_SYMLINKS="harness"\n' >"$MAIN/.env"
+git -C "$MAIN" add .gitignore harness/tracked.md
+git -C "$MAIN" commit -q -m harness
+git -C "$MAIN" push -q origin main
+
+# The hook helper resolves this script through the main checkout's installed
+# skill path, exactly like a consumer repo.
+mkdir -p "$MAIN/.agents/skills"
+ln -s "$SKILL_DIR" "$MAIN/.agents/skills/worktree"
+
+HOOKS_DIR="$MAIN/.git/hooks"
+MARKER="vstack-worktree-autorepair"
+
+# Pre-existing hooks: a shell post-merge that must be composed with, and a
+# non-shell post-rewrite that must be left alone.
+cat >"$HOOKS_DIR/post-merge" <<'SH'
+#!/bin/sh
+echo consumer-post-merge-ran
+SH
+chmod +x "$HOOKS_DIR/post-merge"
+cat >"$HOOKS_DIR/post-rewrite" <<'PY'
+#!/usr/bin/env python3
+pass
+PY
+chmod +x "$HOOKS_DIR/post-rewrite"
+
+echo "=== create installs the shared auto-repair hooks ==="
+set +e
+create_err="$( (cd "$MAIN" && "$WORKTREE_SCRIPT" create hook-check >"$TMP_ROOT/create.out") 2>&1)"
+set -e
+WT="$(tail -1 "$TMP_ROOT/create.out")"
+if [[ -L "$WT/harness" ]]; then ok "worktree created with harness symlink"; else bad "worktree created with harness symlink" "WT=$WT"; fi
+
+if [[ -x "$HOOKS_DIR/$MARKER" ]]; then ok "helper installed and executable"; else bad "helper installed and executable"; fi
+if [[ -x "$HOOKS_DIR/post-checkout" ]]; then ok "post-checkout created executable"; else bad "post-checkout created executable"; fi
+assert_file_contains "$HOOKS_DIR/post-checkout" "$MARKER" "post-checkout carries the marker line"
+assert_file_contains "$HOOKS_DIR/post-merge" "$MARKER" "existing shell post-merge was composed with"
+assert_file_contains "$HOOKS_DIR/post-merge" "consumer-post-merge-ran" "existing post-merge content preserved"
+if grep -qF "$MARKER" "$HOOKS_DIR/post-rewrite"; then
+  bad "non-shell post-rewrite left alone" "marker was appended to a python hook"
+else
+  ok "non-shell post-rewrite left alone"
+fi
+assert_contains "$create_err" "post-rewrite is not a shell script" "install warns about the skipped non-shell hook"
+
+echo "=== repeated install is idempotent ==="
+(cd "$MAIN" && "$WORKTREE_SCRIPT" fix-links "$WT" >/dev/null 2>&1)
+marker_count="$(grep -cF "$MARKER" "$HOOKS_DIR/post-merge" || true)"
+if [[ "$marker_count" -eq 1 ]]; then ok "fix-links does not duplicate the marker line"; else bad "fix-links does not duplicate the marker line" "count=$marker_count"; fi
+
+echo "=== a git operation auto-repairs a materialized tracked-skeleton dir ==="
+rm -f "$WT/harness"
+mkdir -p "$WT/harness"
+printf 'tracked\n' >"$WT/harness/tracked.md"
+set +e
+repair_out="$(git -C "$WT" checkout -q --detach 2>&1; git -C "$WT" checkout -q hook-check 2>&1)"
+set -e
+if [[ -L "$WT/harness" ]]; then ok "post-checkout re-linked the materialized dir"; else bad "post-checkout re-linked the materialized dir" "$repair_out"; fi
+if [[ -f "$WT/harness/skills/installed.txt" ]]; then ok "installed content reachable through the restored link"; else bad "installed content reachable through the restored link"; fi
+assert_contains "$repair_out" "auto-repair: restored symlink" "the repair is reported"
+
+echo "=== untracked data under a materialized dir is never clobbered ==="
+rm -f "$WT/harness"
+mkdir -p "$WT/harness"
+printf 'tracked\n' >"$WT/harness/tracked.md"
+printf 'precious\n' >"$WT/harness/user-data.txt"
+set +e
+refuse_out="$(git -C "$WT" checkout -q --detach 2>&1; git -C "$WT" checkout -q hook-check 2>&1)"
+set -e
+if [[ -d "$WT/harness" && ! -L "$WT/harness" ]]; then ok "materialized dir with untracked data left in place"; else bad "materialized dir with untracked data left in place"; fi
+if [[ "$(cat "$WT/harness/user-data.txt" 2>/dev/null)" == "precious" ]]; then ok "untracked data intact"; else bad "untracked data intact"; fi
+assert_contains "$refuse_out" "harness/user-data.txt" "the warning names the untracked file"
+assert_contains "$refuse_out" "refuses to destroy untracked data" "the warning states the refusal"
+assert_contains "$refuse_out" "fix-links" "the warning names the manual recovery command"
+
+echo "=== hook does not break the git operation it runs after ==="
+set +e
+git -C "$WT" checkout -q hook-check 2>/dev/null
+checkout_rc=$?
+set -e
+if [[ "$checkout_rc" -eq 0 ]]; then ok "checkout exits 0 despite the blocked repair"; else bad "checkout exits 0 despite the blocked repair" "rc=$checkout_rc"; fi
+
+echo "=== repair-links is quiet and safe on the main checkout ==="
+set +e
+main_out="$(cd "$MAIN" && "$WORKTREE_SCRIPT" repair-links "$MAIN" 2>&1)"
+main_rc=$?
+set -e
+if [[ "$main_rc" -eq 0 && -z "$main_out" ]]; then ok "repair-links no-ops quietly for main"; else bad "repair-links no-ops quietly for main" "rc=$main_rc out=$main_out"; fi
+if [[ -d "$MAIN/harness" && ! -L "$MAIN/harness" ]]; then ok "main harness untouched"; else bad "main harness untouched"; fi
+
+echo "=== manual fix-links remains the way out of the blocked state ==="
+rm -rf "$WT/harness"
+(cd "$MAIN" && "$WORKTREE_SCRIPT" fix-links "$WT" >/dev/null 2>&1)
+if [[ -L "$WT/harness" ]]; then ok "fix-links restores the link after the data is dealt with"; else bad "fix-links restores the link after the data is dealt with"; fi
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/skills/worktree/tests/worktree_autorepair_hooks.sh
+++ b/skills/worktree/tests/worktree_autorepair_hooks.sh
@@ -25,6 +25,12 @@ WORKTREE_SCRIPT="${WORKTREE_SCRIPT:-$SKILL_DIR/scripts/worktree}"
 TMP_ROOT="$(cd "$(mktemp -d)" && pwd -P)"
 trap 'rm -rf "$TMP_ROOT"' EXIT
 
+# Isolate fixtures from system AND developer git configuration: hook
+# installation is the behavior under test, and an ambient core.hooksPath
+# would legitimately skip it (by design) and fail the suite.
+export GIT_CONFIG_NOSYSTEM=1
+export GIT_CONFIG_GLOBAL=/dev/null
+
 PASS=0
 FAIL=0
 ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
@@ -182,6 +188,38 @@ echo "=== manual fix-links remains the way out of the blocked state ==="
 rm -rf "$WT/harness"
 (cd "$MAIN" && "$WORKTREE_SCRIPT" fix-links "$WT" >/dev/null 2>&1)
 if [[ -L "$WT/harness" ]]; then ok "fix-links restores the link after the data is dealt with"; else bad "fix-links restores the link after the data is dealt with"; fi
+
+echo "=== a '-'-leading configured path cannot bypass the untracked-data guard ==="
+# Config normalization permits an entry beginning with '-'; a bare find would
+# parse it as an expression, discard the error, and report "no untracked
+# files" — letting the repair clobber real data. The ./ prefix pins this.
+DASH_MAIN="$TMP_ROOT/dash-main"
+mkdir -p "$DASH_MAIN/-dash"
+git -C "$DASH_MAIN" init -q -b main
+git -C "$DASH_MAIN" config user.email test@example.com
+git -C "$DASH_MAIN" config user.name Test
+git -C "$DASH_MAIN" config commit.gpgsign false
+printf -- '-dash/**\n!-dash/tracked.md\n' >"$DASH_MAIN/.gitignore"
+printf 'tracked\n' >"$DASH_MAIN/-dash/tracked.md"
+printf 'WORKTREE_SYMLINKS="-dash"\n' >"$DASH_MAIN/.env"
+git -C "$DASH_MAIN" add .gitignore -- ./-dash/tracked.md
+git -C "$DASH_MAIN" commit -q -m base
+git -C "$DASH_MAIN" worktree add -q "$TMP_ROOT/dash-wt" -b dash-probe
+printf 'precious\n' >"$TMP_ROOT/dash-wt/-dash/user-data.txt"
+set +e
+dash_out="$(cd "$DASH_MAIN" && "$WORKTREE_SCRIPT" repair-links "$TMP_ROOT/dash-wt" 2>&1)"
+set -e
+if [[ -d "$TMP_ROOT/dash-wt/-dash" && ! -L "$TMP_ROOT/dash-wt/-dash" ]]; then
+  ok "dash-path dir with untracked data left in place"
+else
+  bad "dash-path dir with untracked data left in place" "$dash_out"
+fi
+if [[ "$(cat "$TMP_ROOT/dash-wt/-dash/user-data.txt" 2>/dev/null)" == "precious" ]]; then
+  ok "dash-path untracked data intact"
+else
+  bad "dash-path untracked data intact"
+fi
+assert_contains "$dash_out" "user-data.txt" "dash-path warning names the untracked file"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/skills/worktree/tests/worktree_autorepair_hooks.sh
+++ b/skills/worktree/tests/worktree_autorepair_hooks.sh
@@ -266,6 +266,25 @@ assert_contains "$edit_out" "local edits vs index" "warning names the divergence
 rm -rf "$WT/harness"
 (cd "$MAIN" && "$WORKTREE_SCRIPT" fix-links "$WT" >/dev/null 2>&1)
 
+echo "=== a newline-named file cannot slip through the line inventory ==="
+# A filename that is (or contains) a newline shreds the line-delimited
+# listing; the NUL-count cross-check must block rather than read it as empty.
+rm -f "$WT/harness"
+mkdir -p "$WT/harness"
+printf 'tracked\n' >"$WT/harness/tracked.md"
+printf 'sneaky\n' >"$WT/harness/"$'\n'
+set +e
+nl_out="$(cd "$MAIN" && "$WORKTREE_SCRIPT" repair-links "$WT" 2>&1)"
+set -e
+if [[ -d "$WT/harness" && ! -L "$WT/harness" && -f "$WT/harness/"$'\n' ]]; then
+  ok "newline-named file blocks and survives"
+else
+  bad "newline-named file blocks and survives" "$nl_out"
+fi
+assert_contains "$nl_out" "scan mismatch" "warning names the representation mismatch"
+rm -rf "$WT/harness"
+(cd "$MAIN" && "$WORKTREE_SCRIPT" fix-links "$WT" >/dev/null 2>&1)
+
 echo "=== a failed scan blocks the repair instead of reading as empty ==="
 # find exiting nonzero (unreadable subdirectory) must fail closed: "cannot
 # prove safe to replace", never "no untracked files". Root sees through

--- a/skills/worktree/tests/worktree_autorepair_hooks.sh
+++ b/skills/worktree/tests/worktree_autorepair_hooks.sh
@@ -221,5 +221,33 @@ else
 fi
 assert_contains "$dash_out" "user-data.txt" "dash-path warning names the untracked file"
 
+echo "=== a failed scan blocks the repair instead of reading as empty ==="
+# find exiting nonzero (unreadable subdirectory) must fail closed: "cannot
+# prove safe to replace", never "no untracked files". Root sees through
+# permission bits, so skip there (CI runners and dev shells are non-root).
+if [[ "$EUID" -eq 0 ]]; then
+  ok "skipped: running as root, permission-based scan failure cannot be simulated"
+else
+  rm -f "$TMP_ROOT/dash-wt/-dash/user-data.txt"
+  mkdir -p "$TMP_ROOT/dash-wt/-dash/noperm"
+  printf 'hidden\n' >"$TMP_ROOT/dash-wt/-dash/noperm/data.txt"
+  chmod 000 "$TMP_ROOT/dash-wt/-dash/noperm"
+  set +e
+  scan_out="$(cd "$DASH_MAIN" && "$WORKTREE_SCRIPT" repair-links "$TMP_ROOT/dash-wt" 2>&1)"
+  set -e
+  chmod 755 "$TMP_ROOT/dash-wt/-dash/noperm"
+  if [[ -d "$TMP_ROOT/dash-wt/-dash" && ! -L "$TMP_ROOT/dash-wt/-dash" ]]; then
+    ok "unreadable subdir: dir left in place"
+  else
+    bad "unreadable subdir: dir left in place" "$scan_out"
+  fi
+  if [[ "$(cat "$TMP_ROOT/dash-wt/-dash/noperm/data.txt" 2>/dev/null)" == "hidden" ]]; then
+    ok "unreadable subdir: data intact"
+  else
+    bad "unreadable subdir: data intact"
+  fi
+  assert_contains "$scan_out" "scan failed" "warning names the failed scan"
+fi
+
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/skills/worktree/tests/worktree_autorepair_hooks.sh
+++ b/skills/worktree/tests/worktree_autorepair_hooks.sh
@@ -127,6 +127,32 @@ echo "=== repeated install is idempotent ==="
 marker_count="$(grep -cF "$MARKER" "$HOOKS_DIR/post-merge" || true)"
 if [[ "$marker_count" -eq 1 ]]; then ok "fix-links does not duplicate the marker line"; else bad "fix-links does not duplicate the marker line" "count=$marker_count"; fi
 
+echo "=== a symlinked hook is never written through ==="
+# Live or dangling, a symlink points at content the install does not own —
+# a dangling one even passes `! -e` and would otherwise materialize its
+# target via the fresh-write branch.
+printf '#!/bin/sh\nexternal-managed\n' >"$TMP_ROOT/external-hook"
+external_before="$(cat "$TMP_ROOT/external-hook")"
+mv "$HOOKS_DIR/post-checkout" "$TMP_ROOT/post-checkout.real"
+ln -s "$TMP_ROOT/external-hook" "$HOOKS_DIR/post-checkout"
+sym_out="$( (cd "$MAIN" && "$WORKTREE_SCRIPT" fix-links "$WT") 2>&1 || true)"
+if [[ "$(cat "$TMP_ROOT/external-hook")" == "$external_before" ]]; then
+  ok "live symlink target untouched"
+else
+  bad "live symlink target untouched" "$(cat "$TMP_ROOT/external-hook")"
+fi
+assert_contains "$sym_out" "is a symlink; not modifying its target" "warning names the symlinked hook"
+rm -f "$HOOKS_DIR/post-checkout"
+ln -s "$TMP_ROOT/does-not-exist" "$HOOKS_DIR/post-checkout"
+(cd "$MAIN" && "$WORKTREE_SCRIPT" fix-links "$WT" >/dev/null 2>&1 || true)
+if [[ ! -e "$TMP_ROOT/does-not-exist" ]]; then
+  ok "dangling symlink target not materialized"
+else
+  bad "dangling symlink target not materialized"
+fi
+rm -f "$HOOKS_DIR/post-checkout"
+mv "$TMP_ROOT/post-checkout.real" "$HOOKS_DIR/post-checkout"
+
 echo "=== composed line is exit-status transparent ==="
 # post-checkout's exit status becomes git's exit status, so the appended line
 # must re-assert the consumer hook's own final status — nonzero stays nonzero,

--- a/skills/worktree/tests/worktree_autorepair_hooks.sh
+++ b/skills/worktree/tests/worktree_autorepair_hooks.sh
@@ -221,6 +221,51 @@ else
 fi
 assert_contains "$dash_out" "user-data.txt" "dash-path warning names the untracked file"
 
+echo "=== non-file entries and modified tracked files block the repair ==="
+# FIFOs/sockets/devices and empty untracked dirs are data the old file-only
+# inventory missed; a tracked file with local edits (hidden from git status
+# by assume-unchanged) is data a name-only comparison missed.
+rm -f "$WT/harness"
+mkdir -p "$WT/harness/empty-sub"
+printf 'tracked\n' >"$WT/harness/tracked.md"
+set +e
+empty_out="$(cd "$MAIN" && "$WORKTREE_SCRIPT" repair-links "$WT" 2>&1)"
+empty_rc=$?
+set -e
+if [[ -d "$WT/harness" && ! -L "$WT/harness" && -d "$WT/harness/empty-sub" ]]; then
+  ok "empty untracked subdir blocks and survives"
+else
+  bad "empty untracked subdir blocks and survives" "$empty_out"
+fi
+assert_contains "$empty_out" "empty untracked directory" "warning names the empty dir"
+
+rm -rf "$WT/harness"
+mkdir -p "$WT/harness"
+printf 'tracked\n' >"$WT/harness/tracked.md"
+if mkfifo "$WT/harness/pipe.fifo" 2>/dev/null; then
+  set +e
+  fifo_out="$(cd "$MAIN" && "$WORKTREE_SCRIPT" repair-links "$WT" 2>&1)"
+  set -e
+  if [[ -p "$WT/harness/pipe.fifo" ]]; then ok "FIFO blocks and survives"; else bad "FIFO blocks and survives" "$fifo_out"; fi
+  assert_contains "$fifo_out" "pipe.fifo" "warning names the FIFO"
+  rm -f "$WT/harness/pipe.fifo"
+else
+  ok "skipped: mkfifo unavailable"
+fi
+
+printf 'tracked WITH LOCAL EDITS\n' >"$WT/harness/tracked.md"
+set +e
+edit_out="$(cd "$MAIN" && "$WORKTREE_SCRIPT" repair-links "$WT" 2>&1)"
+set -e
+if [[ "$(cat "$WT/harness/tracked.md")" == "tracked WITH LOCAL EDITS" ]]; then
+  ok "locally-edited tracked file blocks and survives"
+else
+  bad "locally-edited tracked file blocks and survives" "$edit_out"
+fi
+assert_contains "$edit_out" "local edits vs index" "warning names the divergence"
+rm -rf "$WT/harness"
+(cd "$MAIN" && "$WORKTREE_SCRIPT" fix-links "$WT" >/dev/null 2>&1)
+
 echo "=== a failed scan blocks the repair instead of reading as empty ==="
 # find exiting nonzero (unreadable subdirectory) must fail closed: "cannot
 # prove safe to replace", never "no untracked files". Root sees through

--- a/skills/worktree/tests/worktree_autorepair_hooks.sh
+++ b/skills/worktree/tests/worktree_autorepair_hooks.sh
@@ -238,6 +238,7 @@ else
   bad "empty untracked subdir blocks and survives" "$empty_out"
 fi
 assert_contains "$empty_out" "empty untracked directory" "warning names the empty dir"
+if [[ "$empty_rc" -ne 0 ]]; then ok "blocked repair exits nonzero"; else bad "blocked repair exits nonzero" "rc=0"; fi
 
 rm -rf "$WT/harness"
 mkdir -p "$WT/harness"

--- a/skills/worktree/tests/worktree_autorepair_hooks.sh
+++ b/skills/worktree/tests/worktree_autorepair_hooks.sh
@@ -121,6 +121,23 @@ echo "=== repeated install is idempotent ==="
 marker_count="$(grep -cF "$MARKER" "$HOOKS_DIR/post-merge" || true)"
 if [[ "$marker_count" -eq 1 ]]; then ok "fix-links does not duplicate the marker line"; else bad "fix-links does not duplicate the marker line" "count=$marker_count"; fi
 
+echo "=== composed line is exit-status transparent ==="
+# post-checkout's exit status becomes git's exit status, so the appended line
+# must re-assert the consumer hook's own final status — nonzero stays nonzero,
+# zero stays zero. Exercise the exact line the installer wrote.
+installed_line="$(grep -F "$MARKER" "$HOOKS_DIR/post-merge")"
+printf '#!/bin/sh\nfalse\n%s\n' "$installed_line" >"$TMP_ROOT/failing-hook"
+printf '#!/bin/sh\ntrue\n%s\n' "$installed_line" >"$TMP_ROOT/passing-hook"
+chmod +x "$TMP_ROOT/failing-hook" "$TMP_ROOT/passing-hook"
+set +e
+(cd "$WT" && "$TMP_ROOT/failing-hook" >/dev/null 2>&1)
+failing_rc=$?
+(cd "$WT" && "$TMP_ROOT/passing-hook" >/dev/null 2>&1)
+passing_rc=$?
+set -e
+if [[ "$failing_rc" -ne 0 ]]; then ok "a consumer hook ending nonzero still exits nonzero"; else bad "a consumer hook ending nonzero still exits nonzero" "rc=0 after composition"; fi
+if [[ "$passing_rc" -eq 0 ]]; then ok "a consumer hook ending zero still exits zero"; else bad "a consumer hook ending zero still exits zero" "rc=$passing_rc"; fi
+
 echo "=== a git operation auto-repairs a materialized tracked-skeleton dir ==="
 rm -f "$WT/harness"
 mkdir -p "$WT/harness"


### PR DESCRIPTION
Closes #1032 (also fixes VST-26 on Linear — completed there after merge). Implements all three prescribed layers; the incident was a git op re-materializing a worktree's `WORKTREE_SYMLINKS`-managed `.cache` as a real dir, followed by a silent full Linear re-sync into it burning the shared 2500/hr API budget.

**1. Git-hook auto-repair (worktree skill).** `create`/`fix-links` install shared `post-checkout`/`post-merge`/`post-rewrite` hooks into the main checkout's hooks dir (where worktrees resolve them), each delegating one marked line to an owned helper. Composition is safe: existing shell hooks are appended-to idempotently, never overwritten; non-shell/disabled hooks and `core.hooksPath` repos get a loud warning + manual instruction; the helper always exits 0 (a git operation can never fail on it). The new `repair-links` subcommand is a cheap readlink pass; a materialized path is auto-repaired **only when it holds nothing beyond the tracked skeleton** (disk files vs `git ls-files`, so ignored data — the incident's 21MB cache shape — counts as data); otherwise it names the files and points at manual `fix-links`.

**2. Guidance escalation.** The shadows-tracked-files warning now states the generator: a rebase/checkout that must write the tracked files WILL replace the symlink until they're untracked. The stronger `--untrack-shadowed` option (skill running `git rm --cached` in consumer repos) is deliberately **not** included — that's an owner scope call, noted for follow-up.

**3. Budget guard (linear skill).** `sync` refuses **before the lock and any API call** when the cache root is a linked worktree with a real `.cache` while the main checkout's exists and the sync would go full/reconciling. The refusal names the worktree, the expected target, and the exact repair command. Controls pinned by tests: healthy main-checkout syncs, healthy symlinked-worktree `--full`, and configs that deliberately exclude `.cache` from `WORKTREE_SYMLINKS` are all unaffected.

**Verification**: both halves' new tests were demonstrated failing against the unfixed code (the linear one reproduces the incident exactly — full sync + 5 API calls into the clobbered dir — via a real `git worktree add` materialization, not a hand-faked shape). Full suites re-run independently by the reviewer: worktree 19/19 files, linear 33/33 files, Bash 3.2 lint green over the new code.

Related local state: vstack's own checkout carries the uncommitted `.cache` `WORKTREE_SYMLINKS` addition — committing that is a separate settings decision (flagged to the owner).

https://claude.ai/code/session_01QtoqnDR32zLWZPoznpcxfc
