### PR TITLE
fix(pi-claude-bridge): non-fatal debug formatting + honest integrity-toast diagnostics (3.1.5)

### DIFF
--- a/pi-extensions/pi-claude-bridge/CHANGELOG.md
+++ b/pi-extensions/pi-claude-bridge/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Consumer-impacting changes
 
+### 3.1.5
+
+Two follow-ons from the 3.1.4 release (vstack#1041), verified against the shipped bundle.
+
+- **A throwing debug argument no longer escapes `debug()`.** The lazy-thunk evaluation and `JSON.stringify` introduced for VST-15 ran OUTSIDE the try that makes logging best-effort, so a thunk that throws — or a stringify failure on a circular structure or BigInt — propagated out of `debug()`. One such call site sits inside the SDK stream loop (`consumeQuery`'s per-managed-message trace), where the escape aborted the user's turn exactly when they had enabled debugging. Formatting failures now degrade that argument to an `[unprintable: <error message>]` placeholder; the remaining arguments still log.
+- **Integrity toasts no longer point at a diag log that was never written.** 3.1.4 gated `diagDump` on `CLAUDE_BRIDGE_DEBUG` (VST-15) but left the tool-result integrity notifications unconditionally saying "see `<diag log path>`" — a file that does not exist in a default run. Without the debug flag those toasts now advise re-running with `CLAUDE_BRIDGE_DEBUG=1` to capture a diagnostic dump; with it, they keep pointing at the real log.
+
 ### 3.1.4
 
 All three found by memsira while re-vendoring 3.1.3 (VST-14, VST-15, VST-16), verified against the shipped bundle at `90f246ed`.

--- a/pi-extensions/pi-claude-bridge/bundle/index.js
+++ b/pi-extensions/pi-claude-bridge/bundle/index.js
@@ -26974,16 +26974,19 @@ function debug(...args) {
     return JSON.stringify(a);
   };
   const safeFmt = (a) => {
+    let out;
     try {
-      return fmt(a);
+      out = fmt(a);
     } catch (error51) {
       let reason = "formatting failed";
       try {
-        reason = error51 instanceof Error ? error51.message : String(error51);
+        reason = String(error51 instanceof Error ? error51.message : error51);
       } catch {
       }
       return `[unprintable: ${reason}]`;
     }
+    if (out !== void 0) return out;
+    return typeof a === "function" ? "undefined" : String(a);
   };
   const msg = args.map(safeFmt).join(" ");
   try {

--- a/pi-extensions/pi-claude-bridge/bundle/index.js
+++ b/pi-extensions/pi-claude-bridge/bundle/index.js
@@ -26977,7 +26977,12 @@ function debug(...args) {
     try {
       return fmt(a);
     } catch (error51) {
-      return `[unprintable: ${error51 instanceof Error ? error51.message : String(error51)}]`;
+      let reason = "formatting failed";
+      try {
+        reason = error51 instanceof Error ? error51.message : String(error51);
+      } catch {
+      }
+      return `[unprintable: ${reason}]`;
     }
   };
   const msg = args.map(safeFmt).join(" ");

--- a/pi-extensions/pi-claude-bridge/bundle/index.js
+++ b/pi-extensions/pi-claude-bridge/bundle/index.js
@@ -26986,7 +26986,12 @@ function debug(...args) {
       return `[unprintable: ${reason}]`;
     }
     if (out !== void 0) return out;
-    return typeof a === "function" ? "undefined" : String(a);
+    if (typeof a === "function") return "undefined";
+    try {
+      return String(a);
+    } catch {
+      return "[unprintable: formatting failed]";
+    }
   };
   const msg = args.map(safeFmt).join(" ");
   try {

--- a/pi-extensions/pi-claude-bridge/bundle/index.js
+++ b/pi-extensions/pi-claude-bridge/bundle/index.js
@@ -26951,6 +26951,9 @@ var DEBUG_LOG_PATH = process.env.CLAUDE_BRIDGE_DEBUG_PATH || join2(piUserDir(), 
 function diagLogPath() {
   return process.env.CLAUDE_BRIDGE_DIAG_PATH || join2(piUserDir(), "claude-bridge-diag.log");
 }
+function diagGuidance() {
+  return DEBUG ? `see ${diagLogPath()}` : "re-run with CLAUDE_BRIDGE_DEBUG=1 to capture a diagnostic dump";
+}
 if (DEBUG) {
   try {
     mkdirSync2(dirname(DEBUG_LOG_PATH), { recursive: true, mode: 448 });
@@ -26970,7 +26973,14 @@ function debug(...args) {
     if (typeof a === "function") return fmt(a());
     return JSON.stringify(a);
   };
-  const msg = args.map(fmt).join(" ");
+  const safeFmt = (a) => {
+    try {
+      return fmt(a);
+    } catch (error51) {
+      return `[unprintable: ${error51 instanceof Error ? error51.message : String(error51)}]`;
+    }
+  };
+  const msg = args.map(safeFmt).join(" ");
   try {
     appendFileSync2(DEBUG_LOG_PATH, `[${ts2}] [${moduleInstanceId}] ${msg}
 `, { mode: 384 });
@@ -28656,7 +28666,7 @@ function reportSyntheticToolResultRepair(missing, context) {
       sampledToolCallIds: sampledToolCallIds.slice(0, 12)
     });
     safeNotify(
-      `Claude bridge: ${missing.length} missing tool result(s) repaired with an explicit error placeholder${toolNameSummary.length ? ` for ${toolNameSummary.join(", ")}` : ""}. Real tool output was lost before Claude session import; see ${diagLogPath()}.`,
+      `Claude bridge: ${missing.length} missing tool result(s) repaired with an explicit error placeholder${toolNameSummary.length ? ` for ${toolNameSummary.join(", ")}` : ""}. Real tool output was lost before Claude session import; ${diagGuidance()}.`,
       "error"
     );
   } catch (error51) {
@@ -28702,7 +28712,7 @@ function reportToolResultMismatch(queryCtx, reason, cwd, opts = {}) {
       unmatchedResultIds: progress.unmatchedResultIds
     });
     safeNotify(
-      `Claude bridge: tool result delivery interrupted during ${reason}; delivered ${progress.deliveredCount}/${progress.expectedCount}, resolved ${progress.resolvedCount}/${progress.expectedCount}, waiting=${progress.waitingCount}, queued=${progress.queuedCount}, unmatched=${progress.unmatchedResultCount}${toolNameSummary.length ? `, tools=${toolNameSummary.join(", ")}` : ""}. ` + (queryCtx.detachedFromSharedSession ? `Detached one-shot query \u2014 shared Claude session record left untouched; see ${diagLogPath()}.` : `Claude session will rebuild before the next turn; see ${diagLogPath()}.`),
+      `Claude bridge: tool result delivery interrupted during ${reason}; delivered ${progress.deliveredCount}/${progress.expectedCount}, resolved ${progress.resolvedCount}/${progress.expectedCount}, waiting=${progress.waitingCount}, queued=${progress.queuedCount}, unmatched=${progress.unmatchedResultCount}${toolNameSummary.length ? `, tools=${toolNameSummary.join(", ")}` : ""}. ` + (queryCtx.detachedFromSharedSession ? `Detached one-shot query \u2014 shared Claude session record left untouched; ${diagGuidance()}.` : `Claude session will rebuild before the next turn; ${diagGuidance()}.`),
       "error"
     );
     return true;

--- a/pi-extensions/pi-claude-bridge/package-lock.json
+++ b/pi-extensions/pi-claude-bridge/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vanillagreen/pi-claude-bridge",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vanillagreen/pi-claude-bridge",
-      "version": "3.1.4",
+      "version": "3.1.5",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.220",

--- a/pi-extensions/pi-claude-bridge/package.json
+++ b/pi-extensions/pi-claude-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vanillagreen/pi-claude-bridge",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "description": "Pi provider bridge that runs Claude Code through the Claude Agent SDK, with opt-in forwarding for Pi prompt context.",
   "type": "module",
   "keywords": [

--- a/pi-extensions/pi-claude-bridge/src/bridge-state.ts
+++ b/pi-extensions/pi-claude-bridge/src/bridge-state.ts
@@ -1,5 +1,5 @@
 import { type ExtensionAPI, type ExtensionUIContext } from "@earendil-works/pi-coding-agent";
-import { debug, diagDump, diagLogPath } from "./debug.js";
+import { debug, diagDump, diagGuidance } from "./debug.js";
 import { type QueryContext } from "./query-state.js";
 import { summarizeMissingToolNames, type MissingToolResult } from "./tool-pairing-audit.js";
 
@@ -141,7 +141,7 @@ export function reportSyntheticToolResultRepair(missing: MissingToolResult[], co
 		safeNotify(
 			`Claude bridge: ${missing.length} missing tool result(s) repaired with an explicit error placeholder` +
 			`${toolNameSummary.length ? ` for ${toolNameSummary.join(", ")}` : ""}. ` +
-			`Real tool output was lost before Claude session import; see ${diagLogPath()}.`,
+			`Real tool output was lost before Claude session import; ${diagGuidance()}.`,
 			"error",
 		);
 	} catch (error) {
@@ -212,8 +212,8 @@ export function reportToolResultMismatch(
 			`waiting=${progress.waitingCount}, queued=${progress.queuedCount}, unmatched=${progress.unmatchedResultCount}` +
 			`${toolNameSummary.length ? `, tools=${toolNameSummary.join(", ")}` : ""}. ` +
 			(queryCtx.detachedFromSharedSession
-				? `Detached one-shot query — shared Claude session record left untouched; see ${diagLogPath()}.`
-				: `Claude session will rebuild before the next turn; see ${diagLogPath()}.`),
+				? `Detached one-shot query — shared Claude session record left untouched; ${diagGuidance()}.`
+				: `Claude session will rebuild before the next turn; ${diagGuidance()}.`),
 			"error",
 		);
 		return true;

--- a/pi-extensions/pi-claude-bridge/src/debug.ts
+++ b/pi-extensions/pi-claude-bridge/src/debug.ts
@@ -13,6 +13,16 @@ export function diagLogPath(): string {
 	return process.env.CLAUDE_BRIDGE_DIAG_PATH || join(piUserDir(), "claude-bridge-diag.log");
 }
 
+/** Trailing clause for user-facing integrity notifications. With DEBUG on the
+ *  diag log exists and is worth pointing at; without it the file was never
+ *  written (diagDump early-returns), so point at the switch that would have
+ *  captured a dump instead of at a path that does not exist. */
+export function diagGuidance(): string {
+	return DEBUG
+		? `see ${diagLogPath()}`
+		: "re-run with CLAUDE_BRIDGE_DEBUG=1 to capture a diagnostic dump";
+}
+
 // Ensure log directories exist when debug is enabled. 0o700/0o600 throughout:
 // these logs carry prompt previews and session metadata and belong to the user
 // alone — same discipline as diagDump.
@@ -44,7 +54,18 @@ export function debug(...args: unknown[]) {
 		if (typeof a === "function") return fmt((a as () => unknown)());
 		return JSON.stringify(a);
 	};
-	const msg = args.map(fmt).join(" ");
+	// A throwing thunk or JSON.stringify (circular structure, BigInt) must not
+	// escape debug() — one call site sits inside the SDK stream loop, where a
+	// formatting failure would abort the user's turn exactly when they enabled
+	// debugging. A failed arg degrades to a placeholder; the rest still log.
+	const safeFmt = (a: unknown): string => {
+		try {
+			return fmt(a);
+		} catch (error) {
+			return `[unprintable: ${error instanceof Error ? error.message : String(error)}]`;
+		}
+	};
+	const msg = args.map(safeFmt).join(" ");
 	try { appendFileSync(DEBUG_LOG_PATH, `[${ts}] [${moduleInstanceId}] ${msg}\n`, { mode: 0o600 }); } catch { /* debug is best effort */ }
 }
 

--- a/pi-extensions/pi-claude-bridge/src/debug.ts
+++ b/pi-extensions/pi-claude-bridge/src/debug.ts
@@ -59,18 +59,27 @@ export function debug(...args: unknown[]) {
 	// formatting failure would abort the user's turn exactly when they enabled
 	// debugging. A failed arg degrades to a placeholder; the rest still log.
 	const safeFmt = (a: unknown): string => {
+		let out: string | undefined;
 		try {
-			return fmt(a);
+			out = fmt(a);
 		} catch (error) {
 			// The caught value's own conversion can throw too (a thrown
-			// null-prototype object, a throwing toString) — degrade to a
-			// constant rather than let the placeholder itself escape.
+			// null-prototype object, a throwing toString, an Error whose
+			// message is a Symbol — template interpolation would rethrow) —
+			// degrade to a constant rather than let the placeholder escape.
 			let reason = "formatting failed";
 			try {
-				reason = error instanceof Error ? error.message : String(error);
+				reason = String(error instanceof Error ? error.message : error);
 			} catch { /* keep the constant */ }
 			return `[unprintable: ${reason}]`;
 		}
+		// JSON.stringify returns undefined (not a string) for undefined and
+		// Symbol arguments; render them explicitly instead of letting join()
+		// silently drop the slot. (A non-function arg here can only be
+		// undefined or a Symbol — String() is safe on both; a thunk that
+		// returned one of those renders as plain "undefined".)
+		if (out !== undefined) return out;
+		return typeof a === "function" ? "undefined" : String(a);
 	};
 	const msg = args.map(safeFmt).join(" ");
 	try { appendFileSync(DEBUG_LOG_PATH, `[${ts}] [${moduleInstanceId}] ${msg}\n`, { mode: 0o600 }); } catch { /* debug is best effort */ }

--- a/pi-extensions/pi-claude-bridge/src/debug.ts
+++ b/pi-extensions/pi-claude-bridge/src/debug.ts
@@ -62,7 +62,14 @@ export function debug(...args: unknown[]) {
 		try {
 			return fmt(a);
 		} catch (error) {
-			return `[unprintable: ${error instanceof Error ? error.message : String(error)}]`;
+			// The caught value's own conversion can throw too (a thrown
+			// null-prototype object, a throwing toString) — degrade to a
+			// constant rather than let the placeholder itself escape.
+			let reason = "formatting failed";
+			try {
+				reason = error instanceof Error ? error.message : String(error);
+			} catch { /* keep the constant */ }
+			return `[unprintable: ${reason}]`;
 		}
 	};
 	const msg = args.map(safeFmt).join(" ");

--- a/pi-extensions/pi-claude-bridge/src/debug.ts
+++ b/pi-extensions/pi-claude-bridge/src/debug.ts
@@ -73,13 +73,20 @@ export function debug(...args: unknown[]) {
 			} catch { /* keep the constant */ }
 			return `[unprintable: ${reason}]`;
 		}
-		// JSON.stringify returns undefined (not a string) for undefined and
-		// Symbol arguments; render them explicitly instead of letting join()
-		// silently drop the slot. (A non-function arg here can only be
-		// undefined or a Symbol — String() is safe on both; a thunk that
-		// returned one of those renders as plain "undefined".)
+		// JSON.stringify returns undefined (not a string) for undefined,
+		// Symbol, AND objects whose toJSON returns undefined — render the
+		// slot explicitly instead of letting join() silently drop it. That
+		// last shape means `a` can be an arbitrary object here, and its
+		// toString can throw, so this conversion needs the same guard as the
+		// catch path. (A thunk that returned one of these renders as plain
+		// "undefined".)
 		if (out !== undefined) return out;
-		return typeof a === "function" ? "undefined" : String(a);
+		if (typeof a === "function") return "undefined";
+		try {
+			return String(a);
+		} catch {
+			return "[unprintable: formatting failed]";
+		}
 	};
 	const msg = args.map(safeFmt).join(" ");
 	try { appendFileSync(DEBUG_LOG_PATH, `[${ts}] [${moduleInstanceId}] ${msg}\n`, { mode: 0o600 }); } catch { /* debug is best effort */ }

--- a/pi-extensions/pi-claude-bridge/tests/unit-debug-discipline.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-debug-discipline.mjs
@@ -26,7 +26,7 @@ import assert from "node:assert/strict";
 
 // In-process modules must load with DEBUG off regardless of the runner's env.
 delete process.env.CLAUDE_BRIDGE_DEBUG;
-const { DEBUG } = await import("../src/debug.ts");
+const { DEBUG, diagGuidance, diagLogPath } = await import("../src/debug.ts");
 const { summarizeDroppedUserMessages } = await import("../src/query-state.ts");
 const { consumeQuery } = await import("../src/consume-query.ts");
 
@@ -57,6 +57,48 @@ function runProbeChild({ debugOn }) {
 	else delete env.CLAUDE_BRIDGE_DEBUG;
 	execFileSync(process.execPath, ["--import", "tsx", scriptPath], { cwd: pkgRoot, env });
 }
+
+// Run a child (DEBUG on) whose debug() call mixes healthy args with args whose
+// formatting throws: a throwing thunk, a circular structure, and a BigInt
+// (JSON.stringify throws on the last two). vstack#1041: the formatting used to
+// run outside debug()'s try, so any of these aborted the caller — including
+// the consumeQuery stream loop.
+function runThrowingArgsProbeChild() {
+	const scriptPath = join(dir, "probe-throwing-args.mjs");
+	writeFileSync(scriptPath, [
+		`import { debug } from ${JSON.stringify(pathToFileURL(join(pkgRoot, "src/debug.ts")).href)};`,
+		`const circular = {}; circular.self = circular;`,
+		`debug("before-args", () => { throw new Error("thunk boom"); }, circular, 10n, "after-args");`,
+	].join("\n"));
+	const env = { ...process.env, PI_CODING_AGENT_DIR: join(dir, "agent") };
+	env.CLAUDE_BRIDGE_DIAG_PATH = join(dir, "diag.log");
+	env.CLAUDE_BRIDGE_DEBUG_PATH = join(dir, "debug.log");
+	env.CLAUDE_BRIDGE_DEBUG = "1";
+	execFileSync(process.execPath, ["--import", "tsx", scriptPath], { cwd: pkgRoot, env });
+}
+
+describe("debug() formatting failures are non-fatal (vstack#1041)", () => {
+	it("a throwing thunk / circular arg / BigInt degrade to placeholders and the other args still log", () => {
+		// execFileSync throws on a non-zero exit, so reaching the assertions
+		// proves debug() did not let the formatting failures escape.
+		runThrowingArgsProbeChild();
+		const log = readFileSync(join(dir, "debug.log"), "utf8");
+		assert.match(log, /before-args/);
+		assert.match(log, /after-args/, "args after a failed one must still log");
+		assert.match(log, /\[unprintable: thunk boom\]/);
+		assert.match(log, /\[unprintable: [^[]*circular[\s\S]*?\]/i);
+		assert.match(log, /\[unprintable: [^[]*BigInt[\s\S]*?\]/);
+	});
+});
+
+describe("diagGuidance (vstack#1041)", () => {
+	it("with DEBUG off points at the debug env var, never at the unwritten diag log", () => {
+		assert.equal(DEBUG, false, "precondition: this test process must run with DEBUG off");
+		const guidance = diagGuidance();
+		assert.match(guidance, /CLAUDE_BRIDGE_DEBUG=1/);
+		assert.ok(!guidance.includes(diagLogPath()), "no pointer to a diag file that was never written");
+	});
+});
 
 describe("diagDump gating (VST-15)", () => {
 	it("writes nothing to disk when CLAUDE_BRIDGE_DEBUG is off", () => {

--- a/pi-extensions/pi-claude-bridge/tests/unit-debug-discipline.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-debug-discipline.mjs
@@ -72,6 +72,12 @@ function runThrowingArgsProbeChild() {
 		`// The thrown value itself can defeat String(): a null-prototype object`,
 		`// has no toString at all. The placeholder must degrade to its constant.`,
 		`debug("second-line", () => { throw Object.create(null); }, "still-logs");`,
+		`// JSON.stringify returns undefined (not a string) for undefined and`,
+		`// Symbol args — they must render, not silently blank the slot; and an`,
+		`// Error whose message is a Symbol would make template interpolation of`,
+		`// the placeholder itself throw without String() around the reason.`,
+		`const symErr = new Error(); symErr.message = Symbol("sym-reason");`,
+		`debug("third-line", undefined, Symbol("naked-symbol"), () => { throw symErr; }, "tail");`,
 	].join("\n"));
 	const env = { ...process.env, PI_CODING_AGENT_DIR: join(dir, "agent") };
 	env.CLAUDE_BRIDGE_DIAG_PATH = join(dir, "diag.log");
@@ -94,6 +100,10 @@ describe("debug() formatting failures are non-fatal (vstack#1041)", () => {
 		// Thrown null-prototype object: String(error) itself throws, so the
 		// placeholder degrades to its constant and the line still logs whole.
 		assert.match(log, /second-line \[unprintable: formatting failed\] still-logs/);
+		// undefined and Symbol args render (JSON.stringify yields undefined for
+		// both — join() must not silently blank the slot), and an Error carrying
+		// a Symbol message cannot make the placeholder interpolation throw.
+		assert.match(log, /third-line undefined Symbol\(naked-symbol\) \[unprintable: Symbol\(sym-reason\)\] tail/);
 	});
 });
 

--- a/pi-extensions/pi-claude-bridge/tests/unit-debug-discipline.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-debug-discipline.mjs
@@ -69,6 +69,9 @@ function runThrowingArgsProbeChild() {
 		`import { debug } from ${JSON.stringify(pathToFileURL(join(pkgRoot, "src/debug.ts")).href)};`,
 		`const circular = {}; circular.self = circular;`,
 		`debug("before-args", () => { throw new Error("thunk boom"); }, circular, 10n, "after-args");`,
+		`// The thrown value itself can defeat String(): a null-prototype object`,
+		`// has no toString at all. The placeholder must degrade to its constant.`,
+		`debug("second-line", () => { throw Object.create(null); }, "still-logs");`,
 	].join("\n"));
 	const env = { ...process.env, PI_CODING_AGENT_DIR: join(dir, "agent") };
 	env.CLAUDE_BRIDGE_DIAG_PATH = join(dir, "diag.log");
@@ -88,6 +91,9 @@ describe("debug() formatting failures are non-fatal (vstack#1041)", () => {
 		assert.match(log, /\[unprintable: thunk boom\]/);
 		assert.match(log, /\[unprintable: [^[]*circular[\s\S]*?\]/i);
 		assert.match(log, /\[unprintable: [^[]*BigInt[\s\S]*?\]/);
+		// Thrown null-prototype object: String(error) itself throws, so the
+		// placeholder degrades to its constant and the line still logs whole.
+		assert.match(log, /second-line \[unprintable: formatting failed\] still-logs/);
 	});
 });
 

--- a/pi-extensions/pi-claude-bridge/tests/unit-debug-discipline.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-debug-discipline.mjs
@@ -78,6 +78,10 @@ function runThrowingArgsProbeChild() {
 		`// the placeholder itself throw without String() around the reason.`,
 		`const symErr = new Error(); symErr.message = Symbol("sym-reason");`,
 		`debug("third-line", undefined, Symbol("naked-symbol"), () => { throw symErr; }, "tail");`,
+		`// JSON.stringify also returns undefined for an object whose toJSON`,
+		`// returns undefined — and that object's own toString can throw, so the`,
+		`// explicit-render fallback needs its own guard too.`,
+		`debug("fourth-line", { toJSON: () => undefined, toString: () => { throw new Error("hostile toString"); } }, "end");`,
 	].join("\n"));
 	const env = { ...process.env, PI_CODING_AGENT_DIR: join(dir, "agent") };
 	env.CLAUDE_BRIDGE_DIAG_PATH = join(dir, "diag.log");
@@ -104,6 +108,9 @@ describe("debug() formatting failures are non-fatal (vstack#1041)", () => {
 		// both — join() must not silently blank the slot), and an Error carrying
 		// a Symbol message cannot make the placeholder interpolation throw.
 		assert.match(log, /third-line undefined Symbol\(naked-symbol\) \[unprintable: Symbol\(sym-reason\)\] tail/);
+		// An object whose toJSON returns undefined reaches the explicit-render
+		// fallback as an arbitrary object; its hostile toString must not escape.
+		assert.match(log, /fourth-line \[unprintable: formatting failed\] end/);
 	});
 });
 

--- a/pi-extensions/pi-claude-bridge/tests/unit-integrity-reporting.mjs
+++ b/pi-extensions/pi-claude-bridge/tests/unit-integrity-reporting.mjs
@@ -55,6 +55,10 @@ describe("tool-result integrity reporting", () => {
 		assert.equal(notifications.length, 1);
 		assert.equal(notifications[0].level, "error");
 		assert.match(notifications[0].message, /delivered 2\/2, resolved 1\/2/);
+		// vstack#1041: with DEBUG on the diag log is real, so the toast points at
+		// it — and not at the DEBUG-off guidance to re-run with the env var.
+		assert.ok(notifications[0].message.includes(`see ${diagPath}`), "DEBUG-on toast points at the diag log");
+		assert.ok(!notifications[0].message.includes("CLAUDE_BRIDGE_DEBUG=1"), "no env-var guidance when the log exists");
 		const entries = readDiagEntries();
 		assert.equal(entries.length, 1);
 		assert.equal(entries[0].label, "tool_result_delivery_mismatch");


### PR DESCRIPTION
Closes #1041. Two follow-ons from the 3.1.4 release, both verified against source before fixing.

**1. A throwing debug thunk escaped `debug()`** — the lazy-thunk evaluation and `JSON.stringify` sat outside the try; a thunk that throws or a stringify failure (circular structure, BigInt) propagated to the caller. The sharp call site is inside the SDK stream loop (`consumeQuery` managed-message trace), so the escape aborted the user's turn precisely when they had enabled debugging. Fix: per-arg `safeFmt` degrades a failed argument to `[unprintable: <message>]` while the remaining args still log — logging stays best-effort like everywhere else in the file.

**2. Integrity toasts pointed at a diag log that a default run never writes** — `diagDump` is DEBUG-gated (3.1.4, correct) but three unconditional notification strings still said "see ${diagLogPath()}". New `diagGuidance()`: DEBUG on → the real path; DEBUG off → "re-run with `CLAUDE_BRIDGE_DEBUG=1` to capture a diagnostic dump".

Version 3.1.5, CHANGELOG entry, bundle rebuilt (both fixes verified present in `bundle/index.js`).

**Tests**: probe child mixing healthy args with a throwing thunk / circular structure / BigInt (all degrade, neighbors still log); `diagGuidance()` asserted in both DEBUG states; DEBUG-on integrity toast pins the diag path and excludes the env-var guidance. Full bridge suite: 15/16 green; `int-session-compact.mjs` failed once in the batch and passes standalone (live-model integration flake, unrelated surface).

Note for vendors: only drovr and memsira vendor the bridge.

https://claude.ai/code/session_01QVk3NR98DgTTA8rmgEzwsT