### PR TITLE
fix(review-gate): settings matchers accept indented TOML keys

### DIFF
--- a/skills/review-gate/scripts/lib/settings.sh
+++ b/skills/review-gate/scripts/lib/settings.sh
@@ -22,6 +22,13 @@
 # callers must keep these names unique file-wide. The one detectable
 # ambiguity, the same name assigned more than once, fails loud below.
 #
+# Assignments may be indented (TOML permits leading whitespace, and keys
+# under a table often are), so every matcher below allows it. Missing that
+# made an indented assignment invisible to BOTH the value read (silently
+# resolving a configured key to the built-in default — silent gate
+# divergence on a security key) and the duplicate guard (an indented
+# re-assignment lost silently to the column-0 copy).
+#
 # Scripts run from the repo root in CI (workflow working directory), so the
 # default settings path is relative.
 
@@ -39,16 +46,16 @@ rg_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
     # Key PRESENCE decides, not value non-emptiness: `NAME = ""` is a real
     # assignment ("empty disables" per the settings docs) and must override the
     # built-in default, exactly like a set-but-empty env var does above.
-    if grep -q "^${name}[[:space:]]*=" "$file"; then
+    if grep -q "^[[:space:]]*${name}[[:space:]]*=" "$file"; then
       # File-wide matching (header contract) makes a re-assigned name
       # ambiguous — e.g. the same key under two tables. Silently taking the
       # first could read an unrelated table's value on a security-sensitive
       # path, so ambiguity is a configuration error.
-      if [ "$(grep -c "^${name}[[:space:]]*=" "$file")" -gt 1 ]; then
+      if [ "$(grep -c "^[[:space:]]*${name}[[:space:]]*=" "$file")" -gt 1 ]; then
         echo "::error::$file: $name is assigned more than once (keys are matched file-wide regardless of TOML table; each name must be unique in the file)" >&2
         return 1
       fi
-      line="$(grep "^${name}[[:space:]]*=" "$file" | head -n 1)"
+      line="$(grep "^[[:space:]]*${name}[[:space:]]*=" "$file" | head -n 1)"
       # A PRESENT assignment this parser cannot read (e.g. TOML array syntax
       # for a list key) must fail LOUDLY, never collapse to empty: an empty
       # value can silently widen the gate (empty trusted-logins = any
@@ -56,11 +63,11 @@ rg_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
       # supported — the value is quote-free ([^"]*), which makes the
       # extraction exact even with a trailing TOML comment (accepted);
       # anything else is a configuration error.
-      if ! printf '%s\n' "$line" | grep -Eq "^${name}[[:space:]]*=[[:space:]]*\"[^\"]*\"[[:space:]]*(#.*)?\$"; then
+      if ! printf '%s\n' "$line" | grep -Eq "^[[:space:]]*${name}[[:space:]]*=[[:space:]]*\"[^\"]*\"[[:space:]]*(#.*)?\$"; then
         echo "::error::$file: unsupported syntax for $name (expected a single-line basic string: $name = \"value\"; list keys pack items with ';' separators)" >&2
         return 1
       fi
-      val="$(printf '%s\n' "$line" | sed -n "s/^${name}[[:space:]]*=[[:space:]]*\"\([^\"]*\)\".*\$/\1/p")"
+      val="$(printf '%s\n' "$line" | sed -n "s/^[[:space:]]*${name}[[:space:]]*=[[:space:]]*\"\([^\"]*\)\".*\$/\1/p")"
       printf '%s' "$val"
       return 0
     fi

--- a/skills/review-gate/tests/approval-refire.test.sh
+++ b/skills/review-gate/tests/approval-refire.test.sh
@@ -301,6 +301,35 @@ assert_eq "$rc" "1" "r19: duplicate key assignment exits 1"
 assert_contains "$out" "assigned more than once" "r19: names the ambiguity"
 assert_eq "$(( $(wc -l < "$POST_LOG") ))$(( $(wc -l < "$RERUN_LOG") ))" "00" "r19: no POST and no rerun on a duplicate-key config error"
 
+# TOML permits leading whitespace before a key, and keys under a table are
+# often indented. An indented re-assignment is the SAME ambiguity as r19 and
+# must fail identically — before this guard matched leading whitespace, the
+# indented copy lost silently to the column-0 copy.
+cat > "$TMP_ROOT/indented-dup-settings.toml" <<'EOF'
+REVIEW_GATE_CONTEXT = "File Gate"
+[unrelated]
+  REVIEW_GATE_CONTEXT = "Other Gate"
+EOF
+set +e
+out=$(run_refire STUB_VERDICT_LINE="$AWAITING" STUB_GATE_HISTORY='[]' \
+  REVIEW_GATE_SETTINGS_FILE="$TMP_ROOT/indented-dup-settings.toml")
+rc=$?
+set -e
+assert_eq "$rc" "1" "r20: indented duplicate key assignment exits 1"
+assert_contains "$out" "assigned more than once" "r20: names the ambiguity"
+
+# A key assigned ONLY with indentation is a real TOML assignment and must be
+# READ — silently resolving it to the built-in default is silent gate
+# divergence on a security-sensitive key.
+cat > "$TMP_ROOT/indented-only-settings.toml" <<'EOF'
+[env]
+  REVIEW_GATE_CONTEXT = "Indented Gate"
+EOF
+rc=0; out=$(run_refire STUB_VERDICT_LINE="$AWAITING" STUB_GATE_HISTORY='[]' \
+  REVIEW_GATE_SETTINGS_FILE="$TMP_ROOT/indented-only-settings.toml") || rc=$?
+assert_eq "$rc" "0" "r21: indented-only assignment exits 0"
+assert_contains "$(cat "$POST_LOG")" "context=Indented Gate" "r21: the indented value is read, not the default"
+
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## What

`rg_setting`'s five matcher sites (presence check, duplicate-key guard, line extraction, syntax validation, value extraction) all anchored at column 0, so an **indented** TOML assignment — legal TOML, and the natural shape for keys under a table — was invisible to all of them.

Two concrete failure modes, both on security-sensitive paths:

1. **Silent default fallback**: a key assigned only with indentation (e.g. `  REVIEW_GATE_REVIEW_OBJECT_TRUSTED_LOGINS = "..."` under `[env]`) resolved to the built-in default with no error — the adopter's configured trust value silently ignored.
2. **Duplicate guard evasion**: the header contract says "the same name assigned more than once fails loud," but an indented re-assignment evaded the guard and lost silently to the column-0 copy — exactly the ambiguity r19 exists to reject.

## Fix

Optional leading whitespace (`^[[:space:]]*`) added to all five sites **together**, so presence, ambiguity detection, validation, and extraction stay consistent. Commented lines remain excluded (`#` is not `[[:space:]]`). Header comment records the contract.

## Tests

- **r20**: indented duplicate fails loud (exit 1, names the ambiguity).
- **r21**: indented-only assignment is read, not defaulted.

Instrument proven both ways: against the previous `settings.sh` exactly the 3 new asserts fail; with the fix the suite is 49/49. All five review-gate suites pass.

## Provenance

Reported by Qodo on memsira#419's vendored engine copy (2026-08-03 07:01Z thread); routed here per the vendored-engine upstream-first policy. memsira's #419 gate is blocked on this thread — consumers (memsira #419, hyprtrade HT-1708) re-vendor after merge.

https://claude.ai/code/session_01P7iGeM6PKmU43TyjehLCzd
