### PR TITLE
fix(review-gate): whitespace-tolerant settings-key matching

### DIFF
--- a/skills/review-gate/scripts/lib/settings.sh
+++ b/skills/review-gate/scripts/lib/settings.sh
@@ -39,16 +39,21 @@ rg_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
     # Key PRESENCE decides, not value non-emptiness: `NAME = ""` is a real
     # assignment ("empty disables" per the settings docs) and must override the
     # built-in default, exactly like a set-but-empty env var does above.
-    if grep -q "^${name}[[:space:]]*=" "$file"; then
+    # Leading whitespace before a key is valid TOML, so matching is
+    # whitespace-tolerant everywhere (presence, ambiguity guard, extraction)
+    # — anchoring at column one made an indented duplicate bypass the
+    # fail-loud guard and an indented sole assignment collapse silently to
+    # the built-in default (vstack#1059).
+    if grep -Eq "^[[:space:]]*${name}[[:space:]]*=" "$file"; then
       # File-wide matching (header contract) makes a re-assigned name
       # ambiguous — e.g. the same key under two tables. Silently taking the
       # first could read an unrelated table's value on a security-sensitive
       # path, so ambiguity is a configuration error.
-      if [ "$(grep -c "^${name}[[:space:]]*=" "$file")" -gt 1 ]; then
+      if [ "$(grep -Ec "^[[:space:]]*${name}[[:space:]]*=" "$file")" -gt 1 ]; then
         echo "::error::$file: $name is assigned more than once (keys are matched file-wide regardless of TOML table; each name must be unique in the file)" >&2
         return 1
       fi
-      line="$(grep "^${name}[[:space:]]*=" "$file" | head -n 1)"
+      line="$(grep -E "^[[:space:]]*${name}[[:space:]]*=" "$file" | head -n 1)"
       # A PRESENT assignment this parser cannot read (e.g. TOML array syntax
       # for a list key) must fail LOUDLY, never collapse to empty: an empty
       # value can silently widen the gate (empty trusted-logins = any
@@ -56,11 +61,11 @@ rg_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
       # supported — the value is quote-free ([^"]*), which makes the
       # extraction exact even with a trailing TOML comment (accepted);
       # anything else is a configuration error.
-      if ! printf '%s\n' "$line" | grep -Eq "^${name}[[:space:]]*=[[:space:]]*\"[^\"]*\"[[:space:]]*(#.*)?\$"; then
+      if ! printf '%s\n' "$line" | grep -Eq "^[[:space:]]*${name}[[:space:]]*=[[:space:]]*\"[^\"]*\"[[:space:]]*(#.*)?\$"; then
         echo "::error::$file: unsupported syntax for $name (expected a single-line basic string: $name = \"value\"; list keys pack items with ';' separators)" >&2
         return 1
       fi
-      val="$(printf '%s\n' "$line" | sed -n "s/^${name}[[:space:]]*=[[:space:]]*\"\([^\"]*\)\".*\$/\1/p")"
+      val="$(printf '%s\n' "$line" | sed -n "s/^[[:space:]]*${name}[[:space:]]*=[[:space:]]*\"\([^\"]*\)\".*\$/\1/p")"
       printf '%s' "$val"
       return 0
     fi

--- a/skills/review-gate/scripts/lib/settings.sh
+++ b/skills/review-gate/scripts/lib/settings.sh
@@ -28,6 +28,15 @@
 rg_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
                # a present-but-unparseable assignment (callers must propagate)
   local name="$1" default="$2" line val file
+  # The name is interpolated into ERE patterns below; constrain it to the
+  # identifier shape every real key has, so a metacharacter can neither
+  # misgrep nor inject pattern syntax.
+  case "$name" in
+    "" | *[!A-Za-z0-9_]*)
+      echo "::error::rg_setting: invalid key name '$name' (A-Za-z0-9_ only)" >&2
+      return 1
+      ;;
+  esac
   # Indirect expansion, not eval: a non-literal NAME must never become code.
   # ${!name+x} tests set-ness of the variable NAMED by $name (Bash 3.2-safe).
   if [ -n "${!name+x}" ]; then

--- a/skills/review-gate/scripts/lib/settings.sh
+++ b/skills/review-gate/scripts/lib/settings.sh
@@ -32,8 +32,8 @@ rg_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
   # identifier shape every real key has, so a metacharacter can neither
   # misgrep nor inject pattern syntax.
   case "$name" in
-    "" | *[!A-Za-z0-9_]*)
-      echo "::error::rg_setting: invalid key name '$name' (A-Za-z0-9_ only)" >&2
+    "" | [0-9]* | *[!A-Za-z0-9_]*)
+      echo "::error::rg_setting: invalid key name '$name' (shell identifier shape required: [A-Za-z_][A-Za-z0-9_]*)" >&2
       return 1
       ;;
   esac

--- a/skills/review-gate/tests/settings-parsing.test.sh
+++ b/skills/review-gate/tests/settings-parsing.test.sh
@@ -24,6 +24,9 @@ bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
 # run_setting FIXTURE-CONTENT NAME DEFAULT -> sets OUT and RC
 run_setting() {
   printf '%s\n' "$1" >"$TMP/settings.toml"
+  # Hermetic: rg_setting resolves a SET env var before the file, so a leaked
+  # variable from the invoking shell would mask every file-parsing case.
+  unset "$2" 2>/dev/null || true
   OUT=""
   RC=0
   OUT="$(REVIEW_GATE_SETTINGS_FILE="$TMP/settings.toml" rg_setting "$2" "$3" 2>"$TMP/err")" || RC=$?

--- a/skills/review-gate/tests/settings-parsing.test.sh
+++ b/skills/review-gate/tests/settings-parsing.test.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Unit pins for lib/settings.sh's rg_setting contract (vstack#1059):
+# leading whitespace before a key is valid TOML, so matching must be
+# whitespace-tolerant EVERYWHERE — presence, the duplicate-key ambiguity
+# guard, and extraction. Column-one anchoring let an indented duplicate
+# bypass the fail-loud guard (the reader silently used the column-one
+# value on a security-sensitive key) and made an indented sole assignment
+# collapse silently to the built-in default.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# shellcheck source=../scripts/lib/settings.sh
+source "$SKILL_DIR/scripts/lib/settings.sh"
+
+PASS=0
+FAIL=0
+ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
+
+# run_setting FIXTURE-CONTENT NAME DEFAULT -> sets OUT and RC
+run_setting() {
+  printf '%s\n' "$1" >"$TMP/settings.toml"
+  OUT=""
+  RC=0
+  OUT="$(REVIEW_GATE_SETTINGS_FILE="$TMP/settings.toml" rg_setting "$2" "$3" 2>"$TMP/err")" || RC=$?
+}
+
+echo "=== whitespace-tolerant reads ==="
+run_setting 'REVIEW_GATE_T1 = "col1"' REVIEW_GATE_T1 "dflt"
+[[ "$RC" -eq 0 && "$OUT" == "col1" ]] && ok "column-one assignment reads" || bad "column-one assignment reads" "rc=$RC out=$OUT"
+
+run_setting '  REVIEW_GATE_T2 = "indented"' REVIEW_GATE_T2 "dflt"
+[[ "$RC" -eq 0 && "$OUT" == "indented" ]] && ok "indented sole assignment reads (not the silent default)" || bad "indented sole assignment reads (not the silent default)" "rc=$RC out=$OUT"
+
+run_setting $'[env]\nREVIEW_GATE_T3 = ""' REVIEW_GATE_T3 "dflt"
+[[ "$RC" -eq 0 && "$OUT" == "" ]] && ok "explicit empty assignment overrides the default (empty-disables contract)" || bad "explicit empty assignment overrides the default" "rc=$RC out=$OUT"
+
+run_setting 'REVIEW_GATE_T4 = "file"' REVIEW_GATE_T4 "dflt"
+env_out="$(REVIEW_GATE_T4="env" REVIEW_GATE_SETTINGS_FILE="$TMP/settings.toml" rg_setting REVIEW_GATE_T4 "dflt")"
+[[ "$env_out" == "env" ]] && ok "explicit environment still wins over the file" || bad "explicit environment still wins over the file" "$env_out"
+
+echo "=== ambiguity fails loud regardless of indentation ==="
+run_setting $'REVIEW_GATE_T5 = "a"\nREVIEW_GATE_T5 = "b"' REVIEW_GATE_T5 "dflt"
+[[ "$RC" -ne 0 ]] && grep -q "assigned more than once" "$TMP/err" && ok "column-one duplicate is a config error (control)" || bad "column-one duplicate is a config error (control)" "rc=$RC"
+
+run_setting $'REVIEW_GATE_T6 = "a"\n  REVIEW_GATE_T6 = "b"' REVIEW_GATE_T6 "dflt"
+[[ "$RC" -ne 0 ]] && grep -q "assigned more than once" "$TMP/err" && ok "INDENTED duplicate is a config error (was invisible to the guard)" || bad "INDENTED duplicate is a config error (was invisible to the guard)" "rc=$RC out=$OUT"
+
+run_setting $'  REVIEW_GATE_T7 = "a"\n  REVIEW_GATE_T7 = "b"' REVIEW_GATE_T7 "dflt"
+[[ "$RC" -ne 0 ]] && ok "two indented duplicates are a config error" || bad "two indented duplicates are a config error" "rc=$RC out=$OUT"
+
+echo "=== unparseable stays loud ==="
+run_setting 'REVIEW_GATE_T8 = ["array"]' REVIEW_GATE_T8 "dflt"
+[[ "$RC" -ne 0 ]] && grep -q "unsupported syntax" "$TMP/err" && ok "array syntax is a config error (control)" || bad "array syntax is a config error (control)" "rc=$RC"
+
+run_setting '  REVIEW_GATE_T9 = ["array"]' REVIEW_GATE_T9 "dflt"
+[[ "$RC" -ne 0 ]] && grep -q "unsupported syntax" "$TMP/err" && ok "indented array syntax is a config error, not a silent default" || bad "indented array syntax is a config error, not a silent default" "rc=$RC out=$OUT"
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Closes #1059 (surfaced by qodo on memsira#419's vendored copy).

Every `rg_setting` matching site anchored keys at column one, but leading whitespace before a key is valid TOML — so an INDENTED duplicate bypassed the fail-loud ambiguity guard while the reader silently used the column-one value (on security-sensitive keys), and an indented SOLE assignment was invisible entirely, collapsing to the built-in default. All five sites (presence check, duplicate-count guard, line extraction, syntax validator, sed capture) are now whitespace-tolerant, so indented assignments are honored and duplicates fail loud regardless of indentation.

New `tests/settings-parsing.test.sh` (9 cases) pins: indented sole assignment reads; indented duplicate → config error; column-one controls; env precedence; empty-disables; unparseable-loud (including indented array syntax). Negative proof: 4 cases fail against the pre-fix parser. Full review-gate suite + repo-root selftest green.

Post-merge: refresh memsira#419's branch (its open thread cites this fix).

https://claude.ai/code/session_01QVk3NR98DgTTA8rmgEzwsT