### PR TITLE
chore: docs/handoff/ — single git-ignored home for session handoff files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ tmp/
 trees/
 docs/work-in-progress/
 docs/plans/
+# Session handoff files — machine-local steward state, never committed
+docs/handoff/
 
 # Harness install/runtime mirrors; canonical source lives elsewhere.
 # Match files, directories, and symlinks so worktree links stay invisible.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,10 @@
 
 Cross-harness distribution system for AI coding skills, agents, hooks, and Pi extensions. Installs into Claude Code, Cursor, OpenCode, Codex, and Pi via a Rust CLI.
 
+## Session handoffs
+
+Session handoff files live ONLY in `docs/handoff/` (git-ignored) — exactly one file, pruned each update to the minimum context a fresh session needs (no history/prose). Read it only when the user asks or starts a session from a handoff.
+
 ## Repo Layout
 
 ```


### PR DESCRIPTION
Owner-directed. Adds `docs/handoff/` to .gitignore and a three-line AGENTS.md note: handoff files live only there, exactly one at a time, pruned to minimum continuation context, read only on user request or handoff-started sessions.

https://claude.ai/code/session_01QVk3NR98DgTTA8rmgEzwsT