### PR TITLE
fix(review-gate): correct the eviction rationale, success-state status guard, test hardening (memsira#431 round)

### DIFF
--- a/.github/workflows/approval-rerun.yml
+++ b/.github/workflows/approval-rerun.yml
@@ -91,28 +91,33 @@ jobs:
       # event shape either had. No shape keeps a single-PR fast path — the
       # workflow's own token-authored status posts cannot re-trigger it (GitHub
       # suppresses token-authored events), so a "PR-specific survivor +
-      # trailing healing pass" design cannot exist here. With this repo's
-      # triggers every run executes, so the sweep backstops only external
-      # oddities — bounded at its 15-minute cadence.
+      # trailing healing pass" design cannot exist here. A run the job-level
+      # guard skips never claims this group (job concurrency is claimed only
+      # after the job-level `if:` evaluates), so a skip evicts nothing; the
+      # sweep backstops the transitions that emit no usable event at all —
+      # bounded at its 15-minute cadence.
       group: review-gate-writer
       cancel-in-progress: false
     name: Re-fire CI after review
-    # NO job-level guard (#1039): the only triggers are pull_request_review
-    # (always gate-relevant to its own PR) and status. A status filter here
-    # would run AFTER concurrency slotting — a skipped status run would still
-    # have evicted the pending writer it replaced while converging nothing,
-    # silently dropping another PR's changes-requested convergence. Status
-    # runs therefore always execute — and every executing run, status or
-    # review-shaped, converges ALL open PRs (the routing below): the
-    # workflow's token-authored posts cannot re-trigger it, so an evicted
-    # writer's work is only recovered by the run that evicted it doing
-    # everything. (The group itself sits at job level, claimed only by jobs
-    # that actually run.) The predicate re-derives every verdict from
-    # scratch, so a missing filter can never cause a false approval, only
-    # work. No
-    # comment-form reviewer in this repo (the scaffold's issue_comment
-    # trigger is deliberately dropped, and so is check_run — see the trigger
-    # comment above).
+    # The guard filters status events to `success` STATE only, and nothing
+    # else: pull_request_review is always gate-relevant to its own PR, and
+    # clean-analysis evidence is only ever a success status — converging on
+    # `pending`/`failure` states would act before a verdict exists
+    # (CodeRabbit posts `pending` on the same context mid-review). No
+    # CONTEXT-NAME term, by design (#1039): trusted context names are
+    # config, not workflow-expression inputs, and a name list that misses a
+    # reviewer's context silently strands that reviewer's clean path. None
+    # of this is an eviction argument — the group sits at job level, so a
+    # guard-skipped run never claims the writer slot and the skip costs
+    # nothing; every executing run still converges ALL open PRs (the
+    # routing below), because the workflow's token-authored posts cannot
+    # re-trigger it and the pending slot REPLACES, so the run that
+    # displaced a writer must do everything. The predicate re-derives every
+    # verdict from scratch, so a loose guard can never cause a false
+    # approval, only work. No comment-form reviewer in this repo (the
+    # scaffold's issue_comment trigger is deliberately dropped, and so is
+    # check_run — see the trigger comment above).
+    if: github.event_name != 'status' || github.event.state == 'success'
     #
     # Cost bound: an all-PRs pass costs one paginated PR listing plus ~6-8
     # API reads per open PR (the same bill as one scheduled sweep); rerun

--- a/.github/workflows/approval-rerun.yml
+++ b/.github/workflows/approval-rerun.yml
@@ -54,8 +54,11 @@ name: Approval CI re-fire
   # Some reviewers publish their clean-analysis evidence as a legacy commit
   # STATUS instead of a check-run, and a status update is a `status` event -
   # not check_run. Without this trigger the clean path still cannot re-fire
-  # the gate here. Status events run UNFILTERED and converge all open PRs —
-  # see the event routing in the job (#1039).
+  # the gate here. Status events carry NO context-name filter (#1039) but
+  # ARE restricted to success states by the job's if: — clean-analysis
+  # evidence is only ever a `success` status; pending/failure/error states
+  # converge nothing. Executing runs converge all open PRs — see the event
+  # routing in the job.
   status: {}
 
 permissions:

--- a/skills/review-gate/scripts/approval-refire.sh
+++ b/skills/review-gate/scripts/approval-refire.sh
@@ -34,8 +34,11 @@
 #     (GitHub suppresses token-authored events), so no later pass exists to
 #     recover the evicted work — the evictor does everything (#1039).
 #   - approval-sweep.yml (scheduled backstop)                 ALL_OPEN_PRS=1
-#     Also the only recovery for evictions by runs the job-level trust
-#     guards skip (which never execute the script at all).
+#     Backstop for transitions that emit no usable workflow event at all
+#     (thread resolution fires no trigger; dismissal residue coalesced away
+#     by pending-slot replacement). NOT an eviction-recovery path: a run the
+#     job-level trust guards skip never claims the job-level writer group,
+#     so it evicts nothing and there is nothing to recover.
 #   Single-PR mode (PR_NUMBER/HEAD_SHA) remains for direct invocation.
 #
 # Env (required): GH_TOKEN (or ambient gh auth), GH_REPO; PR_NUMBER and

--- a/skills/review-gate/scripts/lib/settings.sh
+++ b/skills/review-gate/scripts/lib/settings.sh
@@ -53,16 +53,16 @@ rg_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
     # — anchoring at column one made an indented duplicate bypass the
     # fail-loud guard and an indented sole assignment collapse silently to
     # the built-in default (vstack#1059).
-    if grep -Eq "^[[:space:]]*${name}[[:space:]]*=" "$file"; then
+    if grep -Eq "^[[:space:]]*${name}[[:space:]]*=" -- "$file"; then
       # File-wide matching (header contract) makes a re-assigned name
       # ambiguous — e.g. the same key under two tables. Silently taking the
       # first could read an unrelated table's value on a security-sensitive
       # path, so ambiguity is a configuration error.
-      if [ "$(grep -Ec "^[[:space:]]*${name}[[:space:]]*=" "$file")" -gt 1 ]; then
+      if [ "$(grep -Ec "^[[:space:]]*${name}[[:space:]]*=" -- "$file")" -gt 1 ]; then
         echo "::error::$file: $name is assigned more than once (keys are matched file-wide regardless of TOML table; each name must be unique in the file)" >&2
         return 1
       fi
-      line="$(grep -E "^[[:space:]]*${name}[[:space:]]*=" "$file" | head -n 1)"
+      line="$(grep -E "^[[:space:]]*${name}[[:space:]]*=" -- "$file" | head -n 1)"
       # A PRESENT assignment this parser cannot read (e.g. TOML array syntax
       # for a list key) must fail LOUDLY, never collapse to empty: an empty
       # value can silently widen the gate (empty trusted-logins = any

--- a/skills/review-gate/templates/approval-rerun.yml
+++ b/skills/review-gate/templates/approval-rerun.yml
@@ -100,10 +100,14 @@ jobs:
       # event shape either had. No shape keeps a single-PR fast path — the
       # workflow's own token-authored status posts cannot re-trigger it (GitHub
       # suppresses token-authored events), so a "PR-specific survivor + trailing
-      # healing pass" design cannot exist here. The scheduled sweep remains the
-      # only guaranteed backstop for the one residue: a run whose job-level
-      # trust guard skips it still evicts and converges nothing — bounded at
-      # the sweep's 15-minute cadence.
+      # healing pass" design cannot exist here. A run the job-level trust guard
+      # skips never claims this group at all — job concurrency is claimed only
+      # after the job-level `if:` evaluates — so a skip evicts nothing and
+      # needs no recovery. The scheduled sweep remains the backstop for the
+      # transitions that emit no usable workflow event in the first place
+      # (thread resolution fires no trigger; dismissal residue coalesced away
+      # by pending-slot replacement) — bounded at the sweep's 15-minute
+      # cadence.
       group: review-gate-writer
       cancel-in-progress: false
     name: Re-fire CI after review
@@ -114,21 +118,24 @@ jobs:
     # line — same trust model as the predicate: the AUTHOR is what is trusted,
     # the body only narrows which comments are worth a re-fire.
     #
-    # `status` is deliberately ABSENT from this guard (#1039): the workflow
-    # enters the shared writer concurrency group BEFORE any job-level filter,
-    # so a status run skipped here would still have evicted the pending
-    # writer it replaced while converging nothing — an irrelevant status
-    # context could silently drop another PR's changes-requested convergence.
-    # Every run that executes — whatever its event shape — converges ALL
-    # open PRs (the routing below): the workflow's token-authored posts
-    # cannot re-trigger it, so an evicted writer's work is only recovered by
-    # the run that evicted it doing everything. The predicate re-derives
-    # every verdict from scratch, so a loose gate here can never cause a
-    # false approval, only work. The check_run/issue_comment guards stay:
-    # their event volume (every CI job completion, every human comment)
-    # makes running on all of them unaffordable — and with the group at job
-    # level a guard-skipped run never claims the writer slot, so the skip
-    # costs nothing.
+    # `status` carries NO context-name term (#1039), by design rather than
+    # omission: trusted status context names are repo-specific ADAPT values
+    # this expression cannot read from vstack.settings.toml, and a name list
+    # that misses a reviewer's context silently strands that reviewer's
+    # clean path forever — the exact stuck-gate #1039 closed. Filtering on
+    # STATE is a different thing and is kept generic below: clean-analysis
+    # evidence is only ever a `success` status, and converging on `pending`
+    # or `failure` states would act before a verdict exists (CodeRabbit
+    # posts `pending` on the same context mid-review), so the success term
+    # cannot strand anyone and drops the churn shapes. None of this is an
+    # eviction argument: with this group at JOB level, a guard-skipped run
+    # never claims the writer slot (job concurrency is claimed only after
+    # the job-level `if:` evaluates), so every term here is priced on API
+    # cost alone. The predicate re-derives every verdict from scratch, so a
+    # loose guard can never cause a false approval, only work; the
+    # check_run/issue_comment terms stay because their event volume (every
+    # CI job completion, every human comment) makes running on all of them
+    # unaffordable.
     #
     # Cost bound: an executing pass costs one paginated PR listing plus
     # ~6-8 API reads per open PR (the same bill as one scheduled sweep);
@@ -143,6 +150,7 @@ jobs:
     # 'chatgpt-codex-connector[bot]' / 'Reviewed commit' =
     # REVIEW_GATE_COMMENT_REVIEWERS login / binding pattern.
     if: >-
+      (github.event_name != 'status' || github.event.state == 'success') &&
       (github.event_name != 'check_run' || github.event.check_run.name == 'Devin Review') &&
       (github.event_name != 'issue_comment' || (github.event.issue.pull_request != null && github.event.comment.user.login == 'chatgpt-codex-connector[bot]' && contains(github.event.comment.body, 'Reviewed commit')))
     runs-on: ubuntu-latest

--- a/skills/review-gate/templates/approval-rerun.yml
+++ b/skills/review-gate/templates/approval-rerun.yml
@@ -53,8 +53,11 @@ name: Approval CI re-fire
   # Some reviewers publish their clean-analysis evidence as a legacy commit
   # STATUS instead of a check-run, and a status update is a `status` event -
   # not check_run. Without this trigger the clean path still cannot re-fire
-  # the gate here. Status events run UNFILTERED and converge all open PRs —
-  # see the event routing in the job (#1039).
+  # the gate here. Status events carry NO context-name filter (#1039) but
+  # ARE restricted to success states by the job's if: — clean-analysis
+  # evidence is only ever a `success` status; pending/failure/error states
+  # converge nothing. Executing runs converge all open PRs — see the event
+  # routing in the job.
   status: {}
   # Comment-form reviewers post NEITHER a review object NOR a check/status on
   # a clean pass — only an ISSUE COMMENT on the PR. Its evidence is accepted
@@ -120,13 +123,13 @@ jobs:
     #
     # `status` carries NO context-name term (#1039), by design rather than
     # omission: trusted status context names are repo-specific ADAPT values
-    # this expression cannot read from vstack.settings.toml, and a name list
+    # this expression cannot read from the settings file, and a name list
     # that misses a reviewer's context silently strands that reviewer's
     # clean path forever — the exact stuck-gate #1039 closed. Filtering on
     # STATE is a different thing and is kept generic below: clean-analysis
     # evidence is only ever a `success` status, and converging on `pending`
-    # or `failure` states would act before a verdict exists (CodeRabbit
-    # posts `pending` on the same context mid-review), so the success term
+    # or `failure` states would act before a verdict exists (a reviewer may
+    # post `pending` on the same context mid-review), so the success term
     # cannot strand anyone and drops the churn shapes. None of this is an
     # eviction argument: with this group at JOB level, a guard-skipped run
     # never claims the writer slot (job concurrency is claimed only after

--- a/skills/review-gate/tests/approval-refire.test.sh
+++ b/skills/review-gate/tests/approval-refire.test.sh
@@ -254,7 +254,7 @@ assert_eq "$rc" "1" "r10: status-history read failure exits 1"
 assert_eq "$(( $(wc -l < "$POST_LOG") ))$(( $(wc -l < "$RERUN_LOG") ))" "00" "r10: no action on history read failure"
 
 set +e
-out=$(env PATH="$TMP_ROOT/bin:$PATH" GH_REPO=acme/widgets HEAD_SHA=headsha \
+out=$(env -u PR_NUMBER PATH="$TMP_ROOT/bin:$PATH" GH_REPO=acme/widgets HEAD_SHA=headsha \
   REVIEW_GATE_SETTINGS_FILE=/dev/null \
   STUB_POST_LOG="$POST_LOG" STUB_RERUN_LOG="$RERUN_LOG" \
   STUB_VERDICT_LINE="$AWAITING" bash "$TMP_ROOT/scripts/approval-refire.sh" 2>&1)
@@ -330,12 +330,18 @@ echo "=== all-PRs mode (ALL_OPEN_PRS=1) ==="
 # No PR_NUMBER/HEAD_SHA/PR_AUTHOR: all-PRs mode enumerates them itself. The
 # timeout guard (where available) bounds the damage if the QUIESCE=0 default
 # regresses — a QUIESCE=1 all-PRs pass would sleep 30s per poll.
+# `env -u` scrubs QUIESCE and the single-PR identifiers from the INHERITED
+# environment: `env` alone passes them through, so a leaked QUIESCE from the
+# invoking shell would decide the unset-default cases instead of the
+# production default. Explicit cases still override via "$@" — assignments
+# are applied after removals.
 run_refire_all() {
   : > "$POST_LOG"
   : > "$RERUN_LOG"
   local -a runner=()
   command -v timeout >/dev/null 2>&1 && runner=(timeout 90)
-  env PATH="$TMP_ROOT/bin:$PATH" \
+  env -u QUIESCE -u PR_NUMBER -u HEAD_SHA -u PR_AUTHOR \
+    PATH="$TMP_ROOT/bin:$PATH" \
     GH_REPO=acme/widgets \
     REVIEW_GATE_SETTINGS_FILE=/dev/null \
     STUB_POST_LOG="$POST_LOG" STUB_RERUN_LOG="$RERUN_LOG" \

--- a/skills/review-gate/tests/approval-refire.test.sh
+++ b/skills/review-gate/tests/approval-refire.test.sh
@@ -254,7 +254,7 @@ assert_eq "$rc" "1" "r10: status-history read failure exits 1"
 assert_eq "$(( $(wc -l < "$POST_LOG") ))$(( $(wc -l < "$RERUN_LOG") ))" "00" "r10: no action on history read failure"
 
 set +e
-out=$(env -u PR_NUMBER PATH="$TMP_ROOT/bin:$PATH" GH_REPO=acme/widgets HEAD_SHA=headsha \
+out=$(env -u PR_NUMBER -u ALL_OPEN_PRS -u QUIESCE PATH="$TMP_ROOT/bin:$PATH" GH_REPO=acme/widgets HEAD_SHA=headsha \
   REVIEW_GATE_SETTINGS_FILE=/dev/null \
   STUB_POST_LOG="$POST_LOG" STUB_RERUN_LOG="$RERUN_LOG" \
   STUB_VERDICT_LINE="$AWAITING" bash "$TMP_ROOT/scripts/approval-refire.sh" 2>&1)

--- a/skills/review-gate/tests/settings-parsing.test.sh
+++ b/skills/review-gate/tests/settings-parsing.test.sh
@@ -63,5 +63,19 @@ run_setting 'REVIEW_GATE_T8 = ["array"]' REVIEW_GATE_T8 "dflt"
 run_setting '  REVIEW_GATE_T9 = ["array"]' REVIEW_GATE_T9 "dflt"
 [[ "$RC" -ne 0 ]] && grep -q "unsupported syntax" "$TMP/err" && ok "indented array syntax is a config error, not a silent default" || bad "indented array syntax is a config error, not a silent default" "rc=$RC out=$OUT"
 
+echo "=== invalid key names are refused before any interpolation ==="
+# The name reaches indirect expansion and is interpolated into ERE and sed
+# patterns; the identifier-shape rejection is the only thing standing between
+# a metacharacter name and pattern injection. Red-first: both refusal cases
+# fail against a build with the `case` guard deleted.
+run_setting 'REVIEW_GATE_OK = "x"' 9BADNAME "dflt"
+[[ "$RC" -ne 0 ]] && grep -q "invalid key name" "$TMP/err" && ok "leading-digit name is refused" || bad "leading-digit name is refused" "rc=$RC out=$OUT"
+
+run_setting 'REVIEW_GATE_OK = "x"' 'REVIEW_GATE.DOT' "dflt"
+[[ "$RC" -ne 0 ]] && grep -q "invalid key name" "$TMP/err" && ok "regex-metacharacter name is refused (never reaches ERE interpolation)" || bad "regex-metacharacter name is refused (never reaches ERE interpolation)" "rc=$RC out=$OUT"
+
+run_setting '_REVIEW_GATE_U = "u1"' _REVIEW_GATE_U "dflt"
+[[ "$RC" -eq 0 && "$OUT" == "u1" ]] && ok "underscore-prefixed name stays valid (control)" || bad "underscore-prefixed name stays valid (control)" "rc=$RC out=$OUT"
+
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/skills/review-gate/tests/settings-parsing.test.sh
+++ b/skills/review-gate/tests/settings-parsing.test.sh
@@ -77,5 +77,15 @@ run_setting 'REVIEW_GATE_OK = "x"' 'REVIEW_GATE.DOT' "dflt"
 run_setting '_REVIEW_GATE_U = "u1"' _REVIEW_GATE_U "dflt"
 [[ "$RC" -eq 0 && "$OUT" == "u1" ]] && ok "underscore-prefixed name stays valid (control)" || bad "underscore-prefixed name stays valid (control)" "rc=$RC out=$OUT"
 
+echo "=== dash-prefixed settings path is a filename, never grep options ==="
+# Without `--` before "$file", a relative path like "-e" parses as a grep
+# OPTION: the presence probe errors, and the reader silently falls back to the
+# caller default — fail-open on permissive defaults (hyprtrade#515 review,
+# qodo). Red-first: fails against a build without the -- terminators.
+printf 'REVIEW_GATE_TD = "dashfile"\n' > "$TMP/-e"
+OUT=""; RC=0
+OUT="$(cd "$TMP" && unset REVIEW_GATE_TD 2>/dev/null; REVIEW_GATE_SETTINGS_FILE="-e" rg_setting REVIEW_GATE_TD "dflt" 2>"$TMP/err")" || RC=$?
+[[ "$RC" -eq 0 && "$OUT" == "dashfile" ]] && ok "dash-prefixed settings path reads its value (no option-injection fallback)" || bad "dash-prefixed settings path reads its value (no option-injection fallback)" "rc=$RC out=$OUT"
+
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/skills/review-gate/tests/workflow-eviction-routing.test.sh
+++ b/skills/review-gate/tests/workflow-eviction-routing.test.sh
@@ -84,10 +84,11 @@ rerun_job_if() {
     injob && /^    if:/ {
       line = $0
       sub(/^    if:[[:space:]]*/, "", line)
+      sub(/[[:space:]]#.*$/, "", line)
       if (line !~ /^(>-?|\|-?)?[[:space:]]*$/) print line
       inif = 1; next
     }
-    inif && /^      / { print; next }
+    inif && /^      / { line = $0; sub(/[[:space:]]#.*$/, "", line); print line; next }
     inif { inif = 0 }
   ' "$file"
 }

--- a/skills/review-gate/tests/workflow-eviction-routing.test.sh
+++ b/skills/review-gate/tests/workflow-eviction-routing.test.sh
@@ -68,7 +68,14 @@ check_rerun() {
   assert_grep "$file" 'group: review-gate-writer' "w1[$label]: shared writer group"
   assert_grep "$file" 'cancel-in-progress: false' "w1[$label]: replace, never cancel the executing writer"
   assert_job_level_group "$file" "$label"
-  assert_not_grep "$file" "github.event_name != 'status'" "w2[$label]: no job-level status filter (a skipped run still evicts)"
+  # A guard-skipped run never claims the job-level writer group, so status
+  # terms are priced on API cost, not eviction. The generic success-state
+  # term is REQUIRED (pending/failure statuses converge nothing and would
+  # act before a verdict exists); a CONTEXT-NAME term is FORBIDDEN (names
+  # are repo-specific ADAPT values, and a list that misses a reviewer's
+  # context strands that reviewer's clean path — the #1039 stuck gate).
+  assert_grep "$file" "github.event.state == 'success'" "w2[$label]: status arm filters to success states"
+  assert_not_grep "$file" 'github.event.context ==' "w2[$label]: no context-name filter on the status arm (#1039)"
   assert_grep "$file" 'export ALL_OPEN_PRS=1' "w3[$label]: every executing run converges all open PRs"
   assert_not_grep "$file" 'GITHUB_EVENT_NAME' "w3[$label]: no event-shape routing — every executing run takes the all-PRs path (the bootstrap fallback is the only PR-scoped branch)"
   assert_not_grep "$file" 'trailing all-PRs pass' "w3[$label]: no comment may claim a self-triggered trailing pass"
@@ -83,11 +90,22 @@ assert_job_level_group() {
   local file="$1" label="$2"
   # Order-independent: a top-level `concurrency:` (column one) is forbidden
   # anywhere in the file — YAML allows top-level keys after `jobs:` — and an
-  # indented (job-level) block must exist.
+  # indented (job-level) block must exist. The group line must sit INSIDE
+  # that block by indentation: deeper than the `concurrency:` key, with the
+  # block closed by the first non-comment line at the key's indent or
+  # shallower. A line-distance window accepted a `group:` belonging to a
+  # different job or a different mapping entirely.
   if grep -q '^concurrency:' "$file"; then
     FAIL=$((FAIL + 1))
     printf '  FAIL  w1[%s]: workflow-level concurrency block present (must sit at JOB level)\n' "$label"
-  elif ! awk '/^[[:space:]]+concurrency:/{c=NR} /group: review-gate-writer/{if (c && NR-c<=20) found=1} END{exit !found}' "$file"; then
+  elif ! awk '
+      /^[[:space:]]*(#|$)/ { next }
+      { match($0, /[^[:space:]]/); ind = RSTART - 1 }
+      inblk && ind <= cind { inblk = 0 }
+      inblk && /^[[:space:]]*group:[[:space:]]*review-gate-writer[[:space:]]*$/ { found = 1 }
+      /^[[:space:]]+concurrency:[[:space:]]*$/ { inblk = 1; cind = ind }
+      END { exit !found }
+    ' "$file"; then
     FAIL=$((FAIL + 1))
     printf '  FAIL  w1[%s]: the review-gate-writer group is not under a job-level concurrency block\n' "$label"
   else

--- a/skills/review-gate/tests/workflow-eviction-routing.test.sh
+++ b/skills/review-gate/tests/workflow-eviction-routing.test.sh
@@ -1,17 +1,23 @@
 #!/usr/bin/env bash
 # Pins the eviction-safe event routing of the review-gate writer workflows
 # (#1039). Both rerun workflows (shipped template + vstack's live
-# self-adoption copy) enter the repo-wide `review-gate-writer` concurrency
-# group at the WORKFLOW level, before any job-level filter; with
-# cancel-in-progress:false GitHub keeps ONE pending run per group and
-# REPLACES it, so an arriving run EVICTS whatever writer was pending. The
-# invariants pinned here make that replacement lossless:
+# self-adoption copy) claim the repo-wide `review-gate-writer` concurrency
+# group at the JOB level — job concurrency is claimed only after the
+# job-level `if:` evaluates, so a guard-skipped run never touches the
+# writer slot. With cancel-in-progress:false GitHub keeps ONE pending run
+# per group and REPLACES it, so an arriving EXECUTING run EVICTS whatever
+# writer was pending. The invariants pinned here make that replacement
+# lossless:
 #
-#   w1. every writer workflow shares the single group with
-#       cancel-in-progress: false (the out-of-order-writer race guard)
-#   w2. `status` events are NOT filtered at the job level — a skipped
-#       status job would still evict the pending writer while converging
-#       nothing
+#   w1. every writer workflow claims the single shared group at JOB level
+#       with cancel-in-progress: false (the out-of-order-writer race
+#       guard); a workflow-level group would let guard-skipped runs evict
+#   w2. the `status` arm filters on STATE only (success — clean-analysis
+#       evidence is only ever a `success` status; pending/failure converge
+#       nothing) and never on CONTEXT NAME (names are repo-specific ADAPT
+#       values; a list that misses a reviewer's context strands that
+#       reviewer's clean path — the #1039 stuck gate). With the group at
+#       job level the filter is priced on API cost, not eviction.
 #   w3. EVERY executing run routes to ALL_OPEN_PRS=1 (sweep-style full
 #       convergence: surviving in the slot subsumes whatever was evicted).
 #       No single-PR fast path exists: the workflows run on GITHUB_TOKEN,
@@ -22,8 +28,8 @@
 #   w5. the `status` trigger stays declared — legacy-status reviewer
 #       evidence has no other re-fire signal
 #   w6. the scaffold keeps its check_run / issue_comment trust guards
-#       (volume control; a guard-skipped run's eviction is recovered only
-#       by the scheduled sweep, and the comments must say so)
+#       (volume control; a guard-skipped run claims no slot and evicts
+#       nothing, so the guards cost only run starts)
 #   w7. both sweep workflows delegate enumeration to the shared script's
 #       all-PRs mode — no duplicated open-PR listing in workflow YAML; the
 #       script is the single source of truth for it
@@ -63,6 +69,29 @@ assert_not_grep() {
   fi
 }
 
+# Extract the rerun job's `if:` condition — single-line (`if: expr`) or
+# block-scalar (`if: >-` + indented lines) form — with comments stripped.
+# The w2 terms are asserted against THIS text only: a comment or another
+# job mentioning the success term must not satisfy the check, and any
+# `github.event.context` reference in the condition (equality OR
+# contains()) must fail it.
+rerun_job_if() {
+  local file="$1"
+  awk '
+    /^[[:space:]]*#/ { next }
+    /^  rerun:[[:space:]]*$/ { injob = 1; next }
+    injob && /^  [^[:space:]]/ { injob = 0 }
+    injob && /^    if:/ {
+      line = $0
+      sub(/^    if:[[:space:]]*/, "", line)
+      if (line !~ /^(>-?|\|-?)?[[:space:]]*$/) print line
+      inif = 1; next
+    }
+    inif && /^      / { print; next }
+    inif { inif = 0 }
+  ' "$file"
+}
+
 check_rerun() {
   local file="$1" label="$2"
   assert_grep "$file" 'group: review-gate-writer' "w1[$label]: shared writer group"
@@ -74,8 +103,28 @@ check_rerun() {
   # act before a verdict exists); a CONTEXT-NAME term is FORBIDDEN (names
   # are repo-specific ADAPT values, and a list that misses a reviewer's
   # context strands that reviewer's clean path — the #1039 stuck gate).
-  assert_grep "$file" "github.event.state == 'success'" "w2[$label]: status arm filters to success states"
-  assert_not_grep "$file" 'github.event.context ==' "w2[$label]: no context-name filter on the status arm (#1039)"
+  # Both terms are checked inside the rerun job's own if: condition.
+  local rerun_if
+  rerun_if="$(rerun_job_if "$file")"
+  if [ -z "$rerun_if" ]; then
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  w2[%s]: rerun job has no if: condition\n' "$label"
+  else
+    if printf '%s\n' "$rerun_if" | grep -qF "github.event.state == 'success'"; then
+      PASS=$((PASS + 1))
+      printf '  ok    w2[%s]: rerun if: filters status arm to success states\n' "$label"
+    else
+      FAIL=$((FAIL + 1))
+      printf '  FAIL  w2[%s]: rerun if: missing the success-state status term\n' "$label"
+    fi
+    if printf '%s\n' "$rerun_if" | grep -q 'github\.event\.context'; then
+      FAIL=$((FAIL + 1))
+      printf '  FAIL  w2[%s]: rerun if: references github.event.context — no context-name filter on the status arm (#1039)\n' "$label"
+    else
+      PASS=$((PASS + 1))
+      printf '  ok    w2[%s]: no context-name reference in the rerun if: (#1039)\n' "$label"
+    fi
+  fi
   assert_grep "$file" 'export ALL_OPEN_PRS=1' "w3[$label]: every executing run converges all open PRs"
   assert_not_grep "$file" 'GITHUB_EVENT_NAME' "w3[$label]: no event-shape routing — every executing run takes the all-PRs path (the bootstrap fallback is the only PR-scoped branch)"
   assert_not_grep "$file" 'trailing all-PRs pass' "w3[$label]: no comment may claim a self-triggered trailing pass"


### PR DESCRIPTION
Disposes all 8 review threads on memsira#431 (vendored engine files, upstream-first). For the vstack steward.

**Rationale corrections (comments in both rerun workflows + refire header):** job-level concurrency is claimed only after the job-level \`if:\` evaluates — a guard-skipped run never claims the writer slot and cannot evict a pending writer. The files asserted the reverse in their status-guard paragraphs while stating the correct rule in their group comments. ALL_OPEN_PRS stands on the real grounds: pending-slot replacement among guard-passing runs + token-authored posts never re-triggering.

**Behavior change (small):** status arms gain the generic \`state == 'success'\` guard term — clean evidence is only ever a success status; converging on pending/failure acts before a verdict exists (CodeRabbit posts pending mid-review on the same context). Context-NAME filters remain banned (#1039 stuck-clean-path trap); the routing test now pins both directions (success term required, context term forbidden).

**Test hardening:** indentation-bound job-level-group check with block reset (old 20-line window measured passing a group under a different job; new check fails that counterexample and passes both real files); \`env -u\` scrubbing of inherited QUIESCE/PR identifiers in the refire test harnesses (measured: 3 failures under a hostile env unscrubbed, 62/62 after); red-first key-name rejection cases for settings.sh (measured failing against a guard-deleted build).

All 7 review-gate suites green: refire 62/62 (clean AND hostile env), routing 35/35, settings-parsing 12/12, bash32-portability, predicate selftest 69/100-case, example-sync, vars-documented.

After merge: memsira picks this up at next re-vendor (MEM-215); hyprtrade's audit (HT-1708 comment) already established its adapted equivalents are unaffected.

https://claude.ai/code/session_0132xg8a1VcNCqXYjnAi2nrS