### PR TITLE
review-gate: post-bundle hardening — status-page validation, snapshot sha binding, seam docs/tests, dead probe

### DIFF
--- a/skills/review-gate/references/settings.md
+++ b/skills/review-gate/references/settings.md
@@ -44,8 +44,10 @@ Two env-only PER-INVOCATION seams are deliberately NOT settings keys:
   would be circular.
 - `REVIEW_GATE_STATUS_SNAPSHOT_FILE` — path to a combined-status snapshot
   (JSON object with a `statuses` array and a top-level `sha` equal to the
-  invocation's `HEAD_SHA` — the raw combined-status API response carries
-  both) the CALLER already holds. When set, the predicate evaluates
+  invocation's `HEAD_SHA` — a single-page raw combined-status API response
+  carries both; a caller that paginated merges every page's statuses into
+  the one array first, since a first-page-only snapshot silently drops
+  later-page evidence) the CALLER already holds. When set, the predicate evaluates
   trusted-context and outage evidence against it instead of fetching the
   combined status itself — a converge-style sweep that reads the combined
   status for its own required-status projection stops paying that read

--- a/skills/review-gate/references/settings.md
+++ b/skills/review-gate/references/settings.md
@@ -35,18 +35,25 @@ reserved all the same.
 | `REVIEW_GATE_MAX_RERUN_ATTEMPTS` | `5` | Refire rerun backstop for pathological ping-pong. |
 | `REVIEW_GATE_TRUST_PR_WORKFLOWS` | `false` | Trust posture for the CI gate job (see Security below). Consumed by workflow wiring, not by the scripts. |
 
-Two env-only PER-INVOCATION seams are deliberately NOT settings keys (like
-`REVIEW_GATE_SETTINGS_FILE`, which overrides the settings-file path in
-tests):
+Two env-only PER-INVOCATION seams are deliberately NOT settings keys:
 
+- `REVIEW_GATE_SETTINGS_FILE` — overrides the settings-file path (e.g. in
+  tests, or a caller resolving settings for a different checkout). Which
+  file to resolve from is a property of one invocation, never of the repo
+  the file itself describes — a settings key naming its own settings file
+  would be circular.
 - `REVIEW_GATE_STATUS_SNAPSHOT_FILE` — path to a combined-status snapshot
-  (JSON object with a `statuses` array) the CALLER already holds. When set,
-  the predicate evaluates trusted-context and outage evidence against it
-  instead of fetching the combined status itself — a converge-style sweep
-  that reads the combined status for its own required-status projection
-  stops paying that read twice per head. The snapshot is bound to one head
-  at one moment, which is why it can never be a repo setting. An unreadable
-  or malformed snapshot gets the read contract: exit 2, no verdict.
+  (JSON object with a `statuses` array and a top-level `sha` equal to the
+  invocation's `HEAD_SHA` — the raw combined-status API response carries
+  both) the CALLER already holds. When set, the predicate evaluates
+  trusted-context and outage evidence against it instead of fetching the
+  combined status itself — a converge-style sweep that reads the combined
+  status for its own required-status projection stops paying that read
+  twice per head. The snapshot is bound to one head at one moment, which is
+  why it can never be a repo setting — and the `sha` requirement enforces
+  that binding: a snapshot for another head is refused. An unreadable,
+  malformed, or wrong-head snapshot gets the read contract: exit 2, no
+  verdict.
 
 # Security posture
 

--- a/skills/review-gate/scripts/review-predicate-selftest.sh
+++ b/skills/review-gate/scripts/review-predicate-selftest.sh
@@ -951,6 +951,11 @@ CFG_SNAPSHOT="$fixtures/array-snapshot.json"
 run "snapshot seam: snapshot without a statuses array is exit 2" "" 2
 
 reset
+: >"$fixtures/empty-snapshot.json"
+CFG_SNAPSHOT="$fixtures/empty-snapshot.json"
+run "snapshot seam: EMPTY snapshot file is exit 2 (jq emits nothing yet exits 0)" "" 2
+
+reset
 CFG_CONTEXTS="mech-ctx"
 jq -n --arg sha "$OTHER" '{sha:$sha,statuses:[{context:"mech-ctx",state:"success",description:"analysis complete",creator:null}]}' >"$fixtures/stale-snapshot.json"
 CFG_SNAPSHOT="$fixtures/stale-snapshot.json"

--- a/skills/review-gate/scripts/review-predicate-selftest.sh
+++ b/skills/review-gate/scripts/review-predicate-selftest.sh
@@ -925,13 +925,15 @@ unset GH_SHIM_EMPTY
 # Status-snapshot seam (VST-35): a caller that already holds the combined
 # status hands it in; the predicate must evaluate against it WITHOUT its own
 # combined-status read (proven by failing that endpoint), and an unreadable
-# or malformed snapshot gets the read contract: exit 2.
+# or malformed snapshot gets the read contract: exit 2. The snapshot must be
+# BOUND to this head (top-level sha == HEAD_SHA, VST-71): a snapshot for
+# another head passing shape validation would evaluate stale evidence.
 reset
 CFG_CONTEXTS="mech-ctx"
-jq -n '{statuses:[{context:"mech-ctx",state:"success",description:"analysis complete",creator:null}]}' >"$fixtures/snapshot.json"
+jq -n --arg sha "$HEAD" '{sha:$sha,statuses:[{context:"mech-ctx",state:"success",description:"analysis complete",creator:null}]}' >"$fixtures/snapshot.json"
 CFG_SNAPSHOT="$fixtures/snapshot.json"
 export GH_SHIM_FAIL=status
-run "snapshot seam: caller-supplied combined status is evaluated, duplicate read skipped" approved
+run "snapshot seam: caller-supplied combined status (sha-bound) is evaluated, duplicate read skipped" approved
 unset GH_SHIM_FAIL
 
 reset
@@ -947,6 +949,37 @@ reset
 printf '[]\n' >"$fixtures/array-snapshot.json"
 CFG_SNAPSHOT="$fixtures/array-snapshot.json"
 run "snapshot seam: snapshot without a statuses array is exit 2" "" 2
+
+reset
+CFG_CONTEXTS="mech-ctx"
+jq -n --arg sha "$OTHER" '{sha:$sha,statuses:[{context:"mech-ctx",state:"success",description:"analysis complete",creator:null}]}' >"$fixtures/stale-snapshot.json"
+CFG_SNAPSHOT="$fixtures/stale-snapshot.json"
+run "snapshot seam: snapshot bound to a DIFFERENT head is exit 2 (never stale evidence)" "" 2
+
+reset
+CFG_CONTEXTS="mech-ctx"
+jq -n '{statuses:[{context:"mech-ctx",state:"success",description:"analysis complete",creator:null}]}' >"$fixtures/unbound-snapshot.json"
+CFG_SNAPSHOT="$fixtures/unbound-snapshot.json"
+run "snapshot seam: snapshot with NO top-level sha is exit 2 (binding required)" "" 2
+
+# Combined-status page validation (VST-71): a nonempty NON-STATUS page (`{}`,
+# an error object) survives the zero-byte guard, and the old merge collapsed
+# its missing statuses into an empty list — a verdict from broken evidence.
+# Every page must be an object with a statuses array; anything else is a
+# broken read: exit 2, never an empty-evidence verdict.
+reset
+printf '{}\n' >"$fixtures/status.json"
+run "combined-status page without a statuses array is exit 2, not empty evidence" "" 2
+
+reset
+printf '[]\n' >"$fixtures/status.json"
+run "non-object combined-status page is exit 2" "" 2
+
+reset
+CFG_CONTEXTS="mech-ctx"
+status_ctx "mech-ctx" success "analysis complete"
+printf '{}\n' >"$fixtures/status.page2.json"
+run "malformed combined-status page 2 poisons the merge: exit 2" "" 2
 
 # Read shapes (VST-35): the reviews and comments endpoints must request
 # per_page=100 — the 30-item default paginates long PRs into pure overhead.

--- a/skills/review-gate/scripts/review-predicate.sh
+++ b/skills/review-gate/scripts/review-predicate.sh
@@ -84,13 +84,16 @@
 # Env (required): GH_TOKEN (or ambient gh auth), GH_REPO, PR_NUMBER, HEAD_SHA
 # Env (optional): PR_AUTHOR — resolved from the PR when empty.
 # Env (optional): REVIEW_GATE_STATUS_SNAPSHOT_FILE — path to a combined-status
-#   snapshot (JSON object with a `statuses` array) supplied by the CALLER; when
-#   set, the predicate evaluates trusted-context and outage evidence against it
-#   instead of fetching the combined status itself. A converge-style caller that
-#   already read the combined status for its own projection hands it in here and
-#   the duplicate per-head read disappears. Per-invocation env seam (like
-#   REVIEW_GATE_SETTINGS_FILE), never a settings key: the snapshot is bound to
-#   one head at one moment. An unreadable/malformed snapshot is exit 2.
+#   snapshot (JSON object with a `statuses` array and a top-level `sha` equal
+#   to HEAD_SHA) supplied by the CALLER; when set, the predicate evaluates
+#   trusted-context and outage evidence against it instead of fetching the
+#   combined status itself. A converge-style caller that already read the
+#   combined status for its own projection hands it in here and the duplicate
+#   per-head read disappears — the API response carries the head sha at top
+#   level, so the raw response satisfies the binding as-is. Per-invocation env
+#   seam (like REVIEW_GATE_SETTINGS_FILE), never a settings key: the snapshot
+#   is bound to one head at one moment, and the `sha` requirement enforces
+#   that binding. An unreadable/malformed/wrong-head snapshot is exit 2.
 #
 # Output: one machine-readable line on stdout:
 #   verdict=approved|awaiting|threads-open|changes-requested detail=<human text>
@@ -337,13 +340,19 @@ got="$(jq --arg sha "$HEAD_SHA" --arg author "$PR_AUTHOR" \
 # this read is skipped entirely.
 if [ -n "${REVIEW_GATE_STATUS_SNAPSHOT_FILE:-}" ]; then
   # The snapshot substitutes for a READ, so it gets the read contract: not a
-  # file, zero bytes, unparseable, or missing the statuses array is exit 2 —
-  # never an empty-evidence verdict.
-  status_resp="$(jq 'if (type == "object") and ((.statuses | type) == "array")
+  # file, zero bytes, unparseable, missing the statuses array, or not bound
+  # to THIS head (top-level sha != HEAD_SHA — a snapshot for another head
+  # would pass shape validation and evaluate stale evidence) is exit 2 —
+  # never an empty-evidence verdict. The combined-status API response
+  # carries the head sha at top level, so a caller handing in the raw
+  # response satisfies the binding for free.
+  status_resp="$(jq --arg sha "$HEAD_SHA" '
+                     if (type == "object") and ((.statuses | type) == "array")
+                        and (.sha == $sha)
                      then {statuses: .statuses}
-                     else error("not a combined-status snapshot") end' \
+                     else error("not a combined-status snapshot for this head") end' \
                     "$REVIEW_GATE_STATUS_SNAPSHOT_FILE" 2>/dev/null)" || {
-    echo "::error::REVIEW_GATE_STATUS_SNAPSHOT_FILE '$REVIEW_GATE_STATUS_SNAPSHOT_FILE' is not a readable combined-status snapshot (JSON object with a statuses array)" >&2
+    echo "::error::REVIEW_GATE_STATUS_SNAPSHOT_FILE '$REVIEW_GATE_STATUS_SNAPSHOT_FILE' is not a readable combined-status snapshot bound to $HEAD_SHA (JSON object with a statuses array and top-level sha == HEAD_SHA)" >&2
     exit 2
   }
 else
@@ -355,8 +364,16 @@ else
     echo "::error::combined-status read for $HEAD_SHA produced zero bytes (broken read)" >&2
     exit 2
   fi
-  status_resp="$(jq -s '{statuses: (map(.statuses) | add // [])}' <<<"$status_pages")" || {
-    echo "::error::could not merge the combined commit status pages for $HEAD_SHA" >&2
+  # Validate every page BEFORE merging: a nonempty non-status page (an error
+  # object, `{}`, a truncated body) would survive the zero-byte guard, then
+  # `map(.statuses) | add // []` collapses its null into an empty status list
+  # and the predicate reaches a verdict on broken evidence. A broken read is
+  # exit 2, never an empty-evidence verdict.
+  status_resp="$(jq -s 'if all(type == "object" and ((.statuses | type) == "array"))
+                        then {statuses: (map(.statuses) | add // [])}
+                        else error("not a combined-status page") end' \
+                    <<<"$status_pages" 2>/dev/null)" || {
+    echo "::error::could not merge the combined commit status pages for $HEAD_SHA (each page must be an object with a statuses array)" >&2
     exit 2
   }
 fi

--- a/skills/review-gate/scripts/review-predicate.sh
+++ b/skills/review-gate/scripts/review-predicate.sh
@@ -90,7 +90,11 @@
 #   combined status itself. A converge-style caller that already read the
 #   combined status for its own projection hands it in here and the duplicate
 #   per-head read disappears — the API response carries the head sha at top
-#   level, so the raw response satisfies the binding as-is. Per-invocation env
+#   level, so a SINGLE-PAGE response satisfies the binding as-is. The
+#   snapshot must contain the COMPLETE status set for the head: a caller
+#   that paginated (heads with >100 statuses) merges every page's statuses
+#   into one array under one top-level sha before handing it in — a
+#   first-page-only snapshot would silently drop later-page evidence. Per-invocation env
 #   seam (like REVIEW_GATE_SETTINGS_FILE), never a settings key: the snapshot
 #   is bound to one head at one moment, and the `sha` requirement enforces
 #   that binding. An unreadable/malformed/wrong-head snapshot is exit 2.
@@ -343,9 +347,10 @@ if [ -n "${REVIEW_GATE_STATUS_SNAPSHOT_FILE:-}" ]; then
   # file, zero bytes, unparseable, missing the statuses array, or not bound
   # to THIS head (top-level sha != HEAD_SHA — a snapshot for another head
   # would pass shape validation and evaluate stale evidence) is exit 2 —
-  # never an empty-evidence verdict. The combined-status API response
-  # carries the head sha at top level, so a caller handing in the raw
-  # response satisfies the binding for free.
+  # never an empty-evidence verdict. A single-page API response carries the
+  # head sha at top level and satisfies the binding as-is; paginating
+  # callers must merge all pages' statuses into the one array first (a
+  # first-page-only snapshot silently drops later-page evidence).
   status_resp="$(jq --arg sha "$HEAD_SHA" '
                      if (type == "object") and ((.statuses | type) == "array")
                         and (.sha == $sha)
@@ -355,6 +360,13 @@ if [ -n "${REVIEW_GATE_STATUS_SNAPSHOT_FILE:-}" ]; then
     echo "::error::REVIEW_GATE_STATUS_SNAPSHOT_FILE '$REVIEW_GATE_STATUS_SNAPSHOT_FILE' is not a readable combined-status snapshot bound to $HEAD_SHA (JSON object with a statuses array and top-level sha == HEAD_SHA)" >&2
     exit 2
   }
+  # A zero-value input (empty file) makes jq exit 0 WITHOUT output — the
+  # error() branch never runs because there is no value to run it on — so
+  # emptiness is checked on the result, same contract as the fetched path.
+  if [ -z "$status_resp" ]; then
+    echo "::error::REVIEW_GATE_STATUS_SNAPSHOT_FILE '$REVIEW_GATE_STATUS_SNAPSHOT_FILE' contains no JSON value (empty snapshot — broken caller handoff)" >&2
+    exit 2
+  fi
 else
   status_pages="$(gh_read "repos/$GH_REPO/commits/$HEAD_SHA/status?per_page=100" --paginate)" || {
     echo "::error::could not read the combined commit status for $HEAD_SHA" >&2

--- a/skills/review-gate/tests/settings-vars-documented.test.sh
+++ b/skills/review-gate/tests/settings-vars-documented.test.sh
@@ -31,7 +31,9 @@ for v in $vars; do
       for example in "$SKILL_DIR/vstack.settings.toml.example" \
                      "$SKILL_DIR/../../vstack.settings.toml.example"; do
         [ -f "$example" ] || continue
-        if grep -q "^$v = " "$example"; then
+        # Whitespace/quote-tolerant: any TOML spelling of an assignment for
+        # this name must fail, not just the canonical `KEY = ` shape.
+        if grep -qE "^[[:space:]]*(\"?${v}\"?|'${v}')[[:space:]]*=" "$example"; then
           echo "FAIL: $v is an env-only per-invocation seam but is assigned in $example"
           fail=1
         fi

--- a/skills/review-gate/tests/settings-vars-documented.test.sh
+++ b/skills/review-gate/tests/settings-vars-documented.test.sh
@@ -23,9 +23,20 @@ for v in $vars; do
   # Env-only per-invocation seams, not settings keys — they must not appear
   # as settings assignments (REVIEW_GATE_SETTINGS_FILE overrides the file
   # path in tests; REVIEW_GATE_STATUS_SNAPSHOT_FILE hands one head's
-  # combined-status snapshot in from a converge-style caller).
+  # combined-status snapshot in from a converge-style caller). The absence
+  # is the contract: an assignment in either example would advertise a
+  # per-invocation seam as a repo setting, so it must FAIL here.
   case "$v" in
-    REVIEW_GATE_SETTINGS_FILE|REVIEW_GATE_STATUS_SNAPSHOT_FILE) continue ;;
+    REVIEW_GATE_SETTINGS_FILE|REVIEW_GATE_STATUS_SNAPSHOT_FILE)
+      for example in "$SKILL_DIR/vstack.settings.toml.example" \
+                     "$SKILL_DIR/../../vstack.settings.toml.example"; do
+        [ -f "$example" ] || continue
+        if grep -q "^$v = " "$example"; then
+          echo "FAIL: $v is an env-only per-invocation seam but is assigned in $example"
+          fail=1
+        fi
+      done
+      continue ;;
   esac
   if ! grep -q "^$v = " "$SKILL_DIR/vstack.settings.toml.example"; then
     echo "FAIL: $v missing from the skill's vstack.settings.toml.example"

--- a/skills/review-gate/tests/workflow-eviction-routing.test.sh
+++ b/skills/review-gate/tests/workflow-eviction-routing.test.sh
@@ -267,9 +267,12 @@ echo "=== shared script owns the enumeration ==="
 assert_grep "$SKILL_ROOT/scripts/approval-refire.sh" 'pulls?state=open' "w7[script]: open-PR enumeration lives in approval-refire.sh"
 assert_grep "$SKILL_ROOT/scripts/approval-refire.sh" 'ALL_OPEN_PRS' "w7[script]: all-PRs mode exists"
 
-# Live self-adoption copies: only present in the vstack repo layout.
+# Live self-adoption copies: only present in the vstack repo layout —
+# vendored consumers keep their skill under .agents/skills/, so the
+# ../../.github/workflows probe resolves outside the repo there and the
+# rerun/sweep files are absent.
 LIVE_DIR="$(cd "$SKILL_ROOT/../.." && pwd)/.github/workflows"
-if [ -f "$LIVE_DIR/approval-rerun.yml" ] && [ -d "$SKILL_ROOT/../../skills/review-gate" ]; then
+if [ -f "$LIVE_DIR/approval-rerun.yml" ]; then
   echo "=== live self-adoption copies ==="
   check_rerun "$LIVE_DIR/approval-rerun.yml" "live"
   check_sweep "$LIVE_DIR/approval-sweep.yml" "live"


### PR DESCRIPTION
Fixes VST-71
Fixes #1079

Five small review-gate hardening items from the consumer-propagation review round, all fail-closed:

1. **review-predicate.sh — combined-status page shape validation.** A nonempty non-status page like `{}` survived the zero-byte guard and `map(.statuses) | add // []` collapsed it into an empty status list — a verdict from a broken read. Every page is now validated as an object with a `statuses` array before merging; anything else is exit 2. Selftest: non-status page, non-object page, and malformed-page-2 cases.

2. **review-predicate.sh — `REVIEW_GATE_STATUS_SNAPSHOT_FILE` bound to the head.** A snapshot for another head passed shape validation. The snapshot must now carry a top-level `sha` equal to `HEAD_SHA`; mismatch or absence is exit 2. Contract change (header docs + `references/settings.md` updated): callers must include `sha` — free when handing in the raw combined-status API response, which carries it; there are no production writers yet. Selftest: sha-bound snapshot still approves, wrong-head and sha-less snapshots exit 2.

3. **references/settings.md — both env-only seams as bullets.** "Two env-only PER-INVOCATION seams" was followed by one bullet with `REVIEW_GATE_SETTINGS_FILE` buried in a parenthetical; both seams are now bullets.

4. **tests/settings-vars-documented.test.sh — absence assertion.** Assigning either env-only seam in the skill's or repo-root `vstack.settings.toml.example` now fails the doc-contract test (verified: an injected assignment fails it).

5. **tests/workflow-eviction-routing.test.sh — dead guard probe removed.** The second probe `[ -d "$SKILL_ROOT/../../skills/review-gate" ]` was vacuously true in both layouts; `LIVE_DIR`'s file probe is the real discriminator. Behavior identical in both layouts.

All 7 review-gate test suites pass (selftest: 130 default / 164 configured cases); a stash-revert of the predicate confirms the new selftest cases fail against the old code.