### PR TITLE
chore(deps): clear the 3 high Dependabot alerts (pi family floors, undici 8.9.0)

### DIFF
--- a/pi-extensions/pi-claude-bridge/package-lock.json
+++ b/pi-extensions/pi-claude-bridge/package-lock.json
@@ -15,8 +15,8 @@
         "change-case": "^5.4.4"
       },
       "devDependencies": {
-        "@earendil-works/pi-ai": "^0.82.1",
-        "@earendil-works/pi-coding-agent": "^0.82.1",
+        "@earendil-works/pi-ai": "^0.84.0",
+        "@earendil-works/pi-coding-agent": "^0.84.0",
         "@types/node": "^24.3.0",
         "esbuild": "^0.28.0",
         "tsx": "^4.21.0",
@@ -668,16 +668,17 @@
       }
     },
     "node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.82.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.82.1.tgz",
-      "integrity": "sha512-Z3kloziJIE2dmrisRckZX8zDca/gIv9/YdFAzeoqpHiLV2wsni6bL4hInNSjVKLbqT+4kqLIkph2JQLKvSepjg==",
+      "version": "0.84.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.84.0.tgz",
+      "integrity": "sha512-L1lw0lwR5LXCzGEeHD9XNEruU2bg0H8clOA8ySdGMHvxutp8GC+yZL6MZp4tqQRnLKP3gHmY7TrWzQ3YnFdJYQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.82.1",
+        "@earendil-works/pi-ai": "^0.84.0",
+        "@earendil-works/pi-telemetry": "^0.84.0",
         "diff": "8.0.4",
         "ignore": "7.0.5",
-        "typebox": "1.1.38",
+        "typebox": "1.3.7",
         "yaml": "2.9.0"
       },
       "engines": {
@@ -685,14 +686,15 @@
       }
     },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.82.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.82.1.tgz",
-      "integrity": "sha512-3WFYRhEp3lQB3444EhPMBcM7zSaEUE3eJgHOR7s4081NLqbw/FsWilIKWXSua0Gv3sRr7m9xMidR3pPDE7jI/A==",
+      "version": "0.84.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.0.tgz",
+      "integrity": "sha512-N9RDk8q0eglGiy+NqTZ3Ev2j+6oFNXSAJa8b0CYhvWB9HGiKZjsoCESXkUvMDLybrn0wXp75sdsoBzEtHxk9kA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
         "@aws-sdk/client-bedrock-runtime": "3.1048.0",
+        "@earendil-works/pi-telemetry": "^0.84.0",
         "@google/genai": "1.52.0",
         "@mistralai/mistralai": "2.2.6",
         "@opentelemetry/api": "1.9.0",
@@ -701,7 +703,7 @@
         "https-proxy-agent": "7.0.6",
         "openai": "6.26.0",
         "partial-json": "0.1.7",
-        "typebox": "1.1.38"
+        "typebox": "1.3.7"
       },
       "bin": {
         "pi-ai": "dist/cli.js"
@@ -731,21 +733,37 @@
         }
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.82.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.82.1.tgz",
-      "integrity": "sha512-zbkAhoIuDPMF3pKuja0ajZabrMWU29FUMV9A/XMXT/XC1yXs5xt6t6t13GogQFsDrDqbFP4DkZQO1w8rWRAzYA==",
+    "node_modules/@earendil-works/pi-client": {
+      "version": "0.84.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-client/-/pi-client-0.84.0.tgz",
+      "integrity": "sha512-fHXgw1FdLDh+uw42SvTkJRBfgc3nsrslghvbRFEAxdjfcOxJt7hPsTj4HHNK96wMy1f+zvQYL8Y2znvFoZ8JDA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.82.1",
-        "@earendil-works/pi-ai": "^0.82.1",
-        "@earendil-works/pi-tui": "^0.82.1",
+        "@earendil-works/pi-protocol": "^0.84.0"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent": {
+      "version": "0.84.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.84.0.tgz",
+      "integrity": "sha512-oxEU7BT9xuVT6UKNwUNDzNP5dVGb+DZRGfaEyMyAab8dRlqTSxxyhSlMAxmYsu//YOeasj9E8n2+px1BzIai0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/pi-agent-core": "^0.84.0",
+        "@earendil-works/pi-ai": "^0.84.0",
+        "@earendil-works/pi-client": "^0.84.0",
+        "@earendil-works/pi-protocol": "^0.84.0",
+        "@earendil-works/pi-tui": "^0.84.0",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
         "diff": "8.0.4",
         "glob": "13.0.6",
+        "grok-mermaid": "0.2.2",
         "highlight.js": "10.7.3",
         "hosted-git-info": "9.0.3",
         "ignore": "7.0.5",
@@ -753,8 +771,8 @@
         "minimatch": "10.2.5",
         "proper-lockfile": "4.1.2",
         "semver": "7.8.0",
-        "typebox": "1.1.38",
-        "undici": "8.5.0",
+        "typebox": "1.3.7",
+        "undici": "8.9.0",
         "yaml": "2.9.0"
       },
       "bin": {
@@ -767,10 +785,33 @@
         "@mariozechner/clipboard": "0.3.9"
       }
     },
+    "node_modules/@earendil-works/pi-protocol": {
+      "version": "0.84.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-protocol/-/pi-protocol-0.84.0.tgz",
+      "integrity": "sha512-Fc28cCYGg5+aRnMzbAD7QAi6Xl//kbETyFroLHCs3Zf4oaXH9L2gzBqVLVAwrKIKeS0uffUrmihocGTECfKW6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "typebox": "1.3.7"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-telemetry": {
+      "version": "0.84.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.0.tgz",
+      "integrity": "sha512-g6hLxEfAUk3zJlDmFWhWHJNcYXYiNGeWuJC9YkcHpkdkj0gxD4uaMNNNU3QsAEJXW9Qcxnl21+U8GfhVsc8C5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
     "node_modules/@earendil-works/pi-tui": {
-      "version": "0.82.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.82.1.tgz",
-      "integrity": "sha512-9yN8hALfKaxZq7n54EMxqhFCWnMi6LHkraMJ/1YjHiATq75XrI6XDMVppn9EDtiK7Fks8hUe1SDXUTrIvwRWfQ==",
+      "version": "0.84.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.0.tgz",
+      "integrity": "sha512-nbs0FeZJ5rWDD6VpKfXXmYbEHnHqb40V9glE2l9f8ftoWpsP8nw0WcXK8jOjfRsDPnT9dJHy3dItOHdn/AFGjA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2643,6 +2684,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/grok-mermaid": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/grok-mermaid/-/grok-mermaid-0.2.2.tgz",
+      "integrity": "sha512-XcJEP5dDC8liHBh52mlLjU18fNvu1ckFsu0QpIG3+APZ270fsj9wxpiA6cOURmbUEuoMVgjbC2+UYgTdCqqgzA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -3659,9 +3710,9 @@
       }
     },
     "node_modules/typebox": {
-      "version": "1.1.38",
-      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
-      "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.7.tgz",
+      "integrity": "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==",
       "dev": true,
       "license": "MIT"
     },
@@ -3680,9 +3731,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
-      "integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.9.0.tgz",
+      "integrity": "sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/pi-extensions/pi-claude-bridge/package.json
+++ b/pi-extensions/pi-claude-bridge/package.json
@@ -143,8 +143,8 @@
     "@earendil-works/pi-coding-agent": ">=0.81.0"
   },
   "devDependencies": {
-    "@earendil-works/pi-ai": "^0.82.1",
-    "@earendil-works/pi-coding-agent": "^0.82.1",
+    "@earendil-works/pi-ai": "^0.84.0",
+    "@earendil-works/pi-coding-agent": "^0.84.0",
     "@types/node": "^24.3.0",
     "esbuild": "^0.28.0",
     "tsx": "^4.21.0",

--- a/pi-extensions/pi-codex-minimal-tools/package.json
+++ b/pi-extensions/pi-codex-minimal-tools/package.json
@@ -174,9 +174,9 @@
     "undici": "^7.25.0"
   },
   "devDependencies": {
-    "@earendil-works/pi-ai": "^0.75.0",
-    "@earendil-works/pi-coding-agent": "^0.75.0",
-    "@earendil-works/pi-tui": "^0.75.0",
+    "@earendil-works/pi-ai": "^0.79.0",
+    "@earendil-works/pi-coding-agent": "^0.79.0",
+    "@earendil-works/pi-tui": "^0.79.0",
     "@types/node": "^24.10.1",
     "tsx": "^4.20.6",
     "typebox": "^1.1.24",

--- a/pi-extensions/pi-web-tools/package.json
+++ b/pi-extensions/pi-web-tools/package.json
@@ -199,9 +199,9 @@
   },
   "devDependencies": {
     "@types/node": "^24.10.1",
-    "@earendil-works/pi-ai": "^0.75.0",
-    "@earendil-works/pi-coding-agent": "^0.75.0",
-    "@earendil-works/pi-tui": "^0.75.0",
+    "@earendil-works/pi-ai": "^0.79.0",
+    "@earendil-works/pi-coding-agent": "^0.79.0",
+    "@earendil-works/pi-tui": "^0.79.0",
     "tsx": "^4.20.6",
     "typebox": "^1.1.24",
     "typescript": "^5.9.3"


### PR DESCRIPTION
- pi-web-tools, pi-codex-minimal-tools: raise the @earendil-works pi
  devDependency floors ^0.75.0 → ^0.79.0. The vulnerable pi-coding-agent
  range is >=0.74.0 <0.78.1 (high) and <0.79.0 (moderate); these packages
  have no lockfile, so the manifest floor is the alert surface. pi-ai and
  pi-tui move in lockstep with the family.
- pi-claude-bridge: bump pi-coding-agent/pi-ai devDeps ^0.82.1 → ^0.84.0,
  pulling transitive undici 8.5.0 → 8.9.0 (patched; undici <8.9.0 is the
  third high). Bundle rebuilt — no diff (undici is not bundled; src never
  imports it).

Verified: bridge tsc --noEmit clean + 501 unit tests pass; web-tools
98 tests pass; codex-minimal-tools 73 tests pass.

Closes Dependabot alerts 41, 43, 66 (and same-dep alerts 33/35/37/39/45/47
and 67-70 incidentally).

Claude-Session: https://claude.ai/code/session_01JkgbzCFdLGn9Kc1pZHcjCY

