### PR TITLE
feat(review-gate): trust qodo-code-review[bot] review objects

### DIFF
--- a/vstack.settings.toml
+++ b/vstack.settings.toml
@@ -63,8 +63,10 @@ WORKTREE_SYMLINKS = ".env.local opencode.json .agents .cursor .codex .opencode .
 # The evaluate job is self-evaluating (PR merge ref) per this posture, so
 # a predicate-repair PR can open its own gate; the read-only/write job
 # split and the default-branch sweep (writer of record) are the controls.
-# Review-object trust is pinned to the two reviewer bots + the owner
-# (closes the any-collaborator-COMMENTED gap).
+# Review-object trust is pinned to the reviewer bots + the owner
+# (closes the any-collaborator-COMMENTED gap). qodo posts review objects
+# as qodo-code-review[bot]; trusted early as a review source ahead of the
+# trial decision (~2026-08-16).
 # Evidence: CodeRabbit (status/check + review objects) and Copilot's
 # clean-analysis check-run (it never APPROVES, so min_state stays "any" —
 # the same review-mode semantics as the legacy PR_REVIEW_* gate above).
@@ -74,7 +76,7 @@ REVIEW_GATE_CHECKRUN_SKIP_PATTERNS = "rate limited;skipped;queued"
 REVIEW_GATE_COMMENT_REVIEWERS = ""
 REVIEW_GATE_SHA_PREFIX_FLOOR = "7"
 REVIEW_GATE_OUTAGE_CONTEXT = "vstack-reviewer-outage"
-REVIEW_GATE_REVIEW_OBJECT_TRUSTED_LOGINS = "coderabbitai[bot];copilot-pull-request-reviewer[bot];bmethod"
+REVIEW_GATE_REVIEW_OBJECT_TRUSTED_LOGINS = "coderabbitai[bot];copilot-pull-request-reviewer[bot];qodo-code-review[bot];bmethod"
 REVIEW_GATE_REVIEW_OBJECT_MIN_STATE = "any"
 REVIEW_GATE_MAX_RERUN_ATTEMPTS = "5"
 REVIEW_GATE_TRUST_PR_WORKFLOWS = "true"


### PR DESCRIPTION
Owner decision (2026-08-05): adopt qodo as a trusted review source ahead
of the trial decision (~Aug 16). qodo posts PR review objects under the
login qodo-code-review[bot] (verified on #1033's review list), so it
joins REVIEW_GATE_REVIEW_OBJECT_TRUSTED_LOGINS; the status-context and
comment-reviewer keys are unaffected because qodo posts neither.

Full review-gate test suite green (7/7).

Claude-Session: https://claude.ai/code/session_01JkgbzCFdLGn9Kc1pZHcjCY

