### PR TITLE
fix(review-gate): reject multi-value snapshots and whitespace-only status reads

### DIFF
--- a/skills/review-gate/scripts/review-predicate-selftest.sh
+++ b/skills/review-gate/scripts/review-predicate-selftest.sh
@@ -967,6 +967,27 @@ jq -n '{statuses:[{context:"mech-ctx",state:"success",description:"analysis comp
 CFG_SNAPSHOT="$fixtures/unbound-snapshot.json"
 run "snapshot seam: snapshot with NO top-level sha is exit 2 (binding required)" "" 2
 
+# Multi-value snapshots (vstack#1086): a caller that concatenates page
+# responses instead of merging their statuses used to yield one normalized
+# object per value; downstream per-value jq reads then emitted multi-line
+# counts ("0\n0") that dodge every string comparison — with no trusted
+# contexts that fell through to verdict=approved on zero evidence. The
+# snapshot contract is exactly ONE head-bound object; anything else is a
+# broken caller handoff.
+reset
+CFG_CONTEXTS="mech-ctx"
+{ jq -n --arg sha "$HEAD" '{sha:$sha,statuses:[{context:"mech-ctx",state:"success",description:"analysis complete",creator:null}]}'
+  jq -n --arg sha "$HEAD" '{sha:$sha,statuses:[]}'; } >"$fixtures/multi-snapshot.json"
+CFG_SNAPSHOT="$fixtures/multi-snapshot.json"
+run "snapshot seam: multi-value snapshot (concatenated pages) is exit 2" "" 2
+
+reset
+CFG_CONTEXTS=""
+CFG_OUTAGE="mech-outage"
+printf '{"sha":"%s","statuses":[]}\n{"sha":"%s","statuses":[]}\n' "$HEAD" "$HEAD" >"$fixtures/multi-snapshot.json"
+CFG_SNAPSHOT="$fixtures/multi-snapshot.json"
+run "snapshot seam: multi-value snapshot with NO trusted contexts is exit 2 (was approved on zero evidence)" "" 2
+
 # Combined-status page validation (VST-71): a nonempty NON-STATUS page (`{}`,
 # an error object) survives the zero-byte guard, and the old merge collapsed
 # its missing statuses into an empty list — a verdict from broken evidence.
@@ -979,6 +1000,10 @@ run "combined-status page without a statuses array is exit 2, not empty evidence
 reset
 printf '[]\n' >"$fixtures/status.json"
 run "non-object combined-status page is exit 2" "" 2
+
+reset
+printf '\n   \n' >"$fixtures/status.json"
+run "whitespace-only combined-status response is exit 2, not a vacuous empty status set (vstack#1086)" "" 2
 
 reset
 CFG_CONTEXTS="mech-ctx"

--- a/skills/review-gate/scripts/review-predicate.sh
+++ b/skills/review-gate/scripts/review-predicate.sh
@@ -351,22 +351,25 @@ if [ -n "${REVIEW_GATE_STATUS_SNAPSHOT_FILE:-}" ]; then
   # head sha at top level and satisfies the binding as-is; paginating
   # callers must merge all pages' statuses into the one array first (a
   # first-page-only snapshot silently drops later-page evidence).
-  status_resp="$(jq --arg sha "$HEAD_SHA" '
-                     if (type == "object") and ((.statuses | type) == "array")
-                        and (.sha == $sha)
-                     then {statuses: .statuses}
-                     else error("not a combined-status snapshot for this head") end' \
+  #
+  # Slurped, requiring exactly ONE value: a caller that hands over
+  # concatenated page responses would otherwise yield one normalized object
+  # per value, and every downstream per-value jq read would emit multi-line
+  # counts ("0\n0") that fail the string comparisons in the verdict logic —
+  # with no trusted contexts configured that fell through to an approval
+  # with zero evidence (vstack#1086). Slurping also makes a zero-value
+  # (empty or whitespace-only) file hit the error branch instead of jq's
+  # silent empty-output success.
+  status_resp="$(jq -s --arg sha "$HEAD_SHA" '
+                     if (length == 1) and (.[0]
+                        | (type == "object") and ((.statuses | type) == "array")
+                          and (.sha == $sha))
+                     then {statuses: .[0].statuses}
+                     else error("not a single combined-status snapshot for this head") end' \
                     "$REVIEW_GATE_STATUS_SNAPSHOT_FILE" 2>/dev/null)" || {
-    echo "::error::REVIEW_GATE_STATUS_SNAPSHOT_FILE '$REVIEW_GATE_STATUS_SNAPSHOT_FILE' is not a readable combined-status snapshot bound to $HEAD_SHA (JSON object with a statuses array and top-level sha == HEAD_SHA)" >&2
+    echo "::error::REVIEW_GATE_STATUS_SNAPSHOT_FILE '$REVIEW_GATE_STATUS_SNAPSHOT_FILE' is not a readable combined-status snapshot bound to $HEAD_SHA (exactly one JSON object with a statuses array and top-level sha == HEAD_SHA)" >&2
     exit 2
   }
-  # A zero-value input (empty file) makes jq exit 0 WITHOUT output — the
-  # error() branch never runs because there is no value to run it on — so
-  # emptiness is checked on the result, same contract as the fetched path.
-  if [ -z "$status_resp" ]; then
-    echo "::error::REVIEW_GATE_STATUS_SNAPSHOT_FILE '$REVIEW_GATE_STATUS_SNAPSHOT_FILE' contains no JSON value (empty snapshot — broken caller handoff)" >&2
-    exit 2
-  fi
 else
   status_pages="$(gh_read "repos/$GH_REPO/commits/$HEAD_SHA/status?per_page=100" --paginate)" || {
     echo "::error::could not read the combined commit status for $HEAD_SHA" >&2
@@ -380,8 +383,10 @@ else
   # object, `{}`, a truncated body) would survive the zero-byte guard, then
   # `map(.statuses) | add // []` collapses its null into an empty status list
   # and the predicate reaches a verdict on broken evidence. A broken read is
-  # exit 2, never an empty-evidence verdict.
-  status_resp="$(jq -s 'if all(type == "object" and ((.statuses | type) == "array"))
+  # exit 2, never an empty-evidence verdict. `length > 0` guards the vacuous
+  # case: a whitespace-only response passes the -z check yet slurps to [],
+  # where all(...) is trivially true (vstack#1086).
+  status_resp="$(jq -s 'if (length > 0) and all(type == "object" and ((.statuses | type) == "array"))
                         then {statuses: (map(.statuses) | add // [])}
                         else error("not a combined-status page") end' \
                     <<<"$status_pages" 2>/dev/null)" || {

--- a/skills/review-gate/tests/settings-vars-documented.test.sh
+++ b/skills/review-gate/tests/settings-vars-documented.test.sh
@@ -11,6 +11,12 @@ SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 
 fail=0
 
+# Shared by the forbidden-assignment guard below and its failing-direction
+# self-check, so the self-check exercises the real matcher, not a copy.
+forbidden_assignment_matches() { # key, file
+  grep -qE "^[[:space:]]*(\"?${1}\"?|'${1}')[[:space:]]*=" "$2"
+}
+
 vars="$(grep -rhoE 'REVIEW_GATE_[A-Z_]+' \
   "$SKILL_DIR/scripts" "$SKILL_DIR/templates" | sort -u)"
 [ -n "$vars" ] || { echo "FAIL: no REVIEW_GATE_* variables found in scripts/"; exit 1; }
@@ -33,7 +39,7 @@ for v in $vars; do
         [ -f "$example" ] || continue
         # Whitespace/quote-tolerant: any TOML spelling of an assignment for
         # this name must fail, not just the canonical `KEY = ` shape.
-        if grep -qE "^[[:space:]]*(\"?${v}\"?|'${v}')[[:space:]]*=" "$example"; then
+        if forbidden_assignment_matches "$v" "$example"; then
           echo "FAIL: $v is an env-only per-invocation seam but is assigned in $example"
           fail=1
         fi
@@ -54,6 +60,26 @@ for key in $(sed -n 's/^\(REVIEW_GATE_[A-Z_]*\) = .*/\1/p' "$SKILL_DIR/vstack.se
     fail=1
   fi
 done
+
+# Failing-direction self-check: the forbidden-assignment guard above only
+# ever runs against examples where the keys are absent, so it would stay
+# green even if the matcher stopped recognizing assignments. Prove each
+# TOML spelling actually trips the matcher (vstack#1086).
+matcher_fixture="$(mktemp)"
+while IFS= read -r spelling; do
+  printf '%s\n' "$spelling" >"$matcher_fixture"
+  if ! forbidden_assignment_matches "REVIEW_GATE_SETTINGS_FILE" "$matcher_fixture"; then
+    echo "FAIL: forbidden-assignment matcher misses spelling: $spelling"
+    fail=1
+  fi
+done <<'SPELLINGS'
+REVIEW_GATE_SETTINGS_FILE = "x"
+REVIEW_GATE_SETTINGS_FILE="x"
+"REVIEW_GATE_SETTINGS_FILE" = "x"
+'REVIEW_GATE_SETTINGS_FILE' = "x"
+   REVIEW_GATE_SETTINGS_FILE = "x"
+SPELLINGS
+rm -f "$matcher_fixture"
 
 if [ "$fail" -ne 0 ]; then
   echo "settings-vars-documented: FAIL"


### PR DESCRIPTION
Two predicate holes found by Copilot review on a propagation PR
(memsira#436), fixed upstream per flow:

- The snapshot path parsed REVIEW_GATE_STATUS_SNAPSHOT_FILE without
  slurping, so a file of concatenated page responses produced one
  normalized object per value; downstream per-value jq reads then
  emitted multi-line counts ("0\n0") that dodge every string comparison
  in the verdict logic — with no trusted contexts configured the
  predicate fell through to verdict=approved on zero evidence. The
  contract is now exactly one head-bound object (slurped, length == 1);
  anything else is exit 2. The separate empty-file check is folded into
  the same guard (slurping makes jq's silent zero-value success
  impossible).
- The fetched path's page validation used all(...) alone, which is
  vacuously true for the [] a whitespace-only response slurps to,
  turning a broken read into an empty status set. Now (length > 0) is
  required.

Selftest gains three cases (multi-value snapshot; multi-value with no
trusted contexts — the exact bypass; whitespace-only status response),
each verified to fail against the old predicate and pass now.
settings-vars-documented.test.sh's forbidden-assignment guard gains a
failing-direction self-check exercising the real matcher against bare,
quoted, and indented spellings.

Closes #1086

Claude-Session: https://claude.ai/code/session_01JkgbzCFdLGn9Kc1pZHcjCY

