### PR TITLE
fix(review-gate): post success directly for fork heads in convergence

### DIFF
--- a/skills/review-gate/scripts/approval-refire.sh
+++ b/skills/review-gate/scripts/approval-refire.sh
@@ -245,6 +245,26 @@ if [ "$ever_succeeded" -gt 0 ]; then
   exit 0
 fi
 
+# Fork heads cannot self-post: a pull_request run from a fork holds a
+# read-only GITHUB_TOKEN, so the PR-side post job 403s and the rerun loop
+# below could never land the success status (vstack#1094). The predicate
+# just evaluated approved HERE, in a write-capable run — post directly.
+# CI job contexts are unaffected: they already execute on fork heads; only
+# the status write is privilege-gated. A null head repo (deleted fork) is
+# treated as a fork for the same reason.
+pr_resp="$(gh api "repos/$GH_REPO/pulls/$PR_NUMBER")" || {
+  echo "::error::could not read PR #$PR_NUMBER to determine its head repo; taking no action"
+  exit 1
+}
+head_repo="$(jq -r '.head.repo.full_name // ""' <<<"$pr_resp")" || {
+  echo "::error::could not parse the head repo for PR #$PR_NUMBER; taking no action"
+  exit 1
+}
+if [ "$(printf '%s' "$head_repo" | tr '[:upper:]' '[:lower:]')" != "$(printf '%s' "$GH_REPO" | tr '[:upper:]' '[:lower:]')" ]; then
+  post_status success "$detail — posted by convergence (fork head cannot self-post)"
+  exit 0
+fi
+
 # First awaiting→approved flip for this head: rerun its completed
 # pull_request runs so the new attempt opens the gate and executes the jobs.
 # A run cannot be rerun while in progress; in QUIESCE mode wait (bounded) for

--- a/skills/review-gate/tests/approval-refire.test.sh
+++ b/skills/review-gate/tests/approval-refire.test.sh
@@ -170,6 +170,16 @@ case "$args" in
     fi
     printf '%s\n' "${STUB_GATE_HISTORY:-[]}"
     ;;
+  *"/pulls/"[0-9]*)
+    # Single-PR read used by the fork detection on the success path
+    # (vstack#1094). STUB_HEAD_REPO overrides; default is the base repo
+    # (same-repo head). "null" yields a deleted-fork null head repo.
+    if [[ "${STUB_HEAD_REPO:-acme/widgets}" == "null" ]]; then
+      printf '{"head":{"repo":null}}\n'
+    else
+      printf '{"head":{"repo":{"full_name":"%s"}}}\n' "${STUB_HEAD_REPO:-acme/widgets}"
+    fi
+    ;;
   *"pulls?state=open"*)
     if [[ "${STUB_OPEN_PRS:-[]}" == "fail" ]]; then
       echo "HTTP 500" >&2
@@ -261,6 +271,30 @@ rc=0; out=$(run_refire STUB_VERDICT_LINE="$APPROVED" STUB_GATE_HISTORY='[]' STUB
 assert_eq "$rc" "0" "r6: first approved flip exits 0"
 assert_eq "$(cat "$RERUN_LOG")" "rerun:111" "r6: full rerun of the completed pull_request run only (never the push run)"
 assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "r6: no direct success without proof"
+
+# Fork heads (vstack#1094): the rerun path can never land success — the
+# PR-side post job holds a read-only fork token — so approved posts
+# directly from the write-capable convergence run instead of rerunning.
+rc=0; out=$(run_refire STUB_VERDICT_LINE="$APPROVED" STUB_GATE_HISTORY='[]' \
+  STUB_RUNS_MODE=completed STUB_HEAD_REPO=contributor/widgets) || rc=$?
+assert_eq "$rc" "0" "r20: approved fork head exits 0"
+assert_contains "$(cat "$POST_LOG")" "state=success" "r20: fork head gets a direct success post"
+assert_contains "$(cat "$POST_LOG")" "fork head cannot self-post" "r20: post says why it was direct"
+assert_eq "$(( $(wc -l < "$RERUN_LOG") ))" "0" "r20: fork head never takes the rerun path"
+
+rc=0; out=$(run_refire STUB_VERDICT_LINE="$APPROVED" STUB_GATE_HISTORY='[]' \
+  STUB_RUNS_MODE=completed STUB_HEAD_REPO=null) || rc=$?
+assert_eq "$rc" "0" "r21: deleted-fork null head repo exits 0"
+assert_contains "$(cat "$POST_LOG")" "state=success" "r21: null head repo is treated as a fork (direct post)"
+assert_eq "$(( $(wc -l < "$RERUN_LOG") ))" "0" "r21: null head repo never takes the rerun path"
+
+# Same-repo heads must be unaffected: case-differing spellings of the base
+# repo still take the rerun path, not the fork direct post.
+rc=0; out=$(run_refire STUB_VERDICT_LINE="$APPROVED" STUB_GATE_HISTORY='[]' \
+  STUB_RUNS_MODE=completed STUB_HEAD_REPO=Acme/Widgets) || rc=$?
+assert_eq "$rc" "0" "r22: case-differing same-repo head exits 0"
+assert_eq "$(cat "$RERUN_LOG")" "rerun:111" "r22: case-differing same-repo head still reruns"
+assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "r22: case-differing same-repo head gets no direct post"
 
 rc=0; out=$(run_refire STUB_VERDICT_LINE="$APPROVED" STUB_GATE_HISTORY='[]' STUB_RUNS_MODE=high_attempt) || rc=$?
 assert_eq "$rc" "0" "r7: attempt cap exits 0"


### PR DESCRIPTION
A fork PR's pull_request run holds a read-only GITHUB_TOKEN, so the
PR-side post job 403s — and the refire's awaiting→approved path, which
delegates the success post to a rerun of those workflows, could never
land the required status: sweep evaluates approved → reruns → 403 →
still absent, forever. Found shepherding #1081, the repo's first
external fork PR.

The refire now reads the PR's head repo on the success path; a head
repo differing from the base (or null — deleted fork) gets the success
posted directly from the write-capable convergence run, with the detail
noting why. Same-repo heads keep the rerun path (bootstrap property
unchanged); comparison is case-insensitive. Non-success verdicts were
already posted directly and are unaffected.

Refire suite grows fork/deleted-fork/case-differing-same-repo cases
(r20-r22); 90 ok / 0 fail; full review-gate suite green.

Closes #1094

Claude-Session: https://claude.ai/code/session_01JkgbzCFdLGn9Kc1pZHcjCY

