### PR TITLE
fix(review-gate): carry-forward hardening (shebang, compare pages, doc renames)

### DIFF
--- a/skills/review-gate/scripts/review-predicate-selftest.sh
+++ b/skills/review-gate/scripts/review-predicate-selftest.sh
@@ -789,7 +789,13 @@ export GH_SHIM_FAIL=graphql
 run "threads=off: the reviewThreads read is skipped entirely (failing endpoint cannot matter)" approved
 unset GH_SHIM_FAIL
 cases=$((cases + 1))
-if grep -q '^graphql$' "$fixtures/.urls.log" 2>/dev/null; then
+# Fail-closed on the instrument itself: a missing/empty url log proves
+# nothing about the read being skipped (vstack#1097) — the run above made
+# other API reads, so the log must exist and be non-empty.
+if [ ! -s "$fixtures/.urls.log" ]; then
+  echo "FAIL  threads=off url log missing or empty - cannot prove the read was skipped" >&2
+  failures=$((failures + 1))
+elif grep -q '^graphql$' "$fixtures/.urls.log"; then
   echo "FAIL  threads=off issued a reviewThreads read anyway" >&2
   failures=$((failures + 1))
 else
@@ -1127,6 +1133,36 @@ CFG_CARRY="comments"
 compare_fix ahead "[$(delta_file "src/new.sh" added '@@ -0,0 +1 @@
 +# new file of comments')]"
 run "carry: an ADDED file refuses under 'comments' (modified-only)" awaiting
+
+# vstack#1097 negative controls: shebang lines, renames into .md, and
+# malformed later compare pages must all refuse or fail loud.
+reset
+carry_candidate
+CFG_CARRY="comments"
+compare_fix ahead "[$(delta_file "src/thing.sh" modified '@@ -1 +1 @@
+-#!/usr/bin/env bash
++#!/usr/bin/env dash')]"
+run "carry: a changed shebang line is an interpreter change, not a comment" awaiting
+
+reset
+carry_candidate
+CFG_CARRY="docs"
+compare_fix ahead "[$(jq -n '{filename:"notes.md",previous_filename:"src/thing.sh",status:"renamed",patch:"@@ -1 +1 @@\n-do_the_thing\n+do_the_thing"}')]"
+run "carry: a code file RENAMED to a .md name refuses under 'docs'" awaiting
+
+reset
+carry_candidate
+CFG_CARRY="docs"
+compare_fix ahead "[$DOCS_DELTA]"
+printf '{}\n' >"$fixtures/compare.page2.json"
+run "carry: a malformed later compare page is exit 2, never a partial classification" "" 2
+
+reset
+carry_candidate
+CFG_CARRY="docs"
+compare_fix ahead "[$DOCS_DELTA]"
+jq -n --argjson f "[$DOCS_DELTA]" '{status:"ahead",files:$f}' >"$fixtures/compare.page2.json"
+run "carry: a healthy later compare page merges into the classification" approved
 
 reset
 carry_candidate

--- a/skills/review-gate/scripts/review-predicate.sh
+++ b/skills/review-gate/scripts/review-predicate.sh
@@ -621,14 +621,15 @@ if [ -n "$CARRY_FORWARD" ] && [ "$got" = "0" ] && [ "$check" = "0" ] \
       echo "::error::comparison $base...$HEAD_SHA produced zero bytes (broken read)" >&2
       exit 2
     fi
-    # The first page of a healthy compare response ALWAYS carries a files
-    # array (possibly empty); its absence is a malformed or truncated
-    # response, and defaulting it to [] would read as an identical tree on
-    # the "ahead" path below — a carried approval from a broken read. Same
+    # EVERY page of a healthy compare response carries a files array
+    # (possibly empty); any page without one is a malformed or truncated
+    # response, and defaulting it to [] would hide that page's files from
+    # classification — a carried approval from a broken read (vstack#1097
+    # closed the later-page half of this; page 1 was always checked). Same
     # exit-2 contract as every other evidence read.
-    cmp="$(jq -s 'if ((.[0].files // null) | type) != "array"
-                  then error("no files array")
-                  else {status: (.[0].status // ""), files: (map(.files // []) | add)} end' \
+    cmp="$(jq -s 'if (length > 0) and all(type == "object" and ((.files | type) == "array"))
+                  then {status: (.[0].status // ""), files: (map(.files) | add)}
+                  else error("malformed compare page") end' \
               <<<"$cmp_pages" 2>/dev/null)" || {
       echo "::error::could not merge the comparison pages for $base...$HEAD_SHA (missing or malformed files array)" >&2
       exit 2
@@ -671,6 +672,8 @@ if [ -n "$CARRY_FORWARD" ] && [ "$got" = "0" ] && [ "$check" = "0" ] \
         | . as $f
         | (.filename // "") as $fn
         | if (($cl | index("docs")) != null)
+             and ($f.status != "renamed")
+             and (($f.previous_filename // "") == "")
              and ($fn | test("\\.(md|markdown)$"))
           then "docs"
           elif (($cl | index("comments")) != null)
@@ -682,7 +685,8 @@ if [ -n "$CARRY_FORWARD" ] && [ "$got" = "0" ] && [ "$check" = "0" ] \
                     | map(select(test("^[+-]")))
                     | map(sub("^[+-][[:space:]]*"; ""))
                     | map(select(length > 0))) as $chg
-                 | if ($chg | all(startswith($tok))) then "comments" else "refuse" end )
+                 | if ($chg | all(startswith($tok) and (startswith("#!") | not)))
+                   then "comments" else "refuse" end )
           else "refuse" end
       ] | all(. != "refuse")' <<<"$cmp")" || {
       echo "::error::could not classify the $base...$HEAD_SHA delta" >&2


### PR DESCRIPTION
Bot findings on hyprtrade#523's engine re-sync (vendored content ==
upstream, fixed here first per flow), all in the off-by-default
carry-forward path plus one selftest instrument:

- A changed shebang line counted as a comment ("#..." includes "#!"),
  so an interpreter change could classify comment-only and carry an
  ancestor's approval. Shebang-shaped lines now refuse.
- Paginated compare responses validated only page 1's files array;
  later pages defaulted to [] and a truncated page silently hid files
  from classification. Every page now requires the array or exit 2.
- The docs class tested only the NEW filename, so a code file renamed
  to *.md carried; renames (status or previous_filename) now refuse,
  matching the comments arm's modified-only posture.
- The threads=off url-log assertion treated a missing/empty log as
  proof of a skipped read; the instrument now fails closed.

Selftest: 165 cases green, including four new negative controls (all
three predicate controls verified failing against the old predicate).

Closes #1097

Claude-Session: https://claude.ai/code/session_01JkgbzCFdLGn9Kc1pZHcjCY

