### PR TITLE
fix(review-gate): newest status row decides; writer fails loud on zero-byte pagination

### DIFF
--- a/skills/review-gate/scripts/review-predicate-selftest.sh
+++ b/skills/review-gate/scripts/review-predicate-selftest.sh
@@ -373,20 +373,23 @@ context_battery() { # context
   run "[$ctx] non-success status" awaiting
 
   # THE NEWEST ROW DECIDES. The statuses LIST endpoint returns the full
-  # history — an older success must never outlive a newer non-success on
-  # the same context (a reviewer opening a fresh round posts pending over
-  # its own earlier success), and the reverse order must still count.
+  # history NEWEST-FIRST (fixtures model that order — the predicate takes
+  # the first accepted row, because created_at ties at one-second
+  # precision and a sort would be stable the wrong way): an older success
+  # must never outlive a newer non-success on the same context (a reviewer
+  # opening a fresh round posts pending over its own earlier success), and
+  # the reverse order must still count.
   reset
   jq -n --arg ctx "$ctx" '[
-    {context:$ctx,state:"success",description:"analysis complete",created_at:"2026-01-01T00:00:00Z",creator:{login:"trusted-publisher"}},
-    {context:$ctx,state:"failure",description:"issues found",created_at:"2026-01-02T00:00:00Z",creator:{login:"trusted-publisher"}}
+    {context:$ctx,state:"failure",description:"issues found",created_at:"2026-01-02T00:00:00Z",creator:{login:"trusted-publisher"}},
+    {context:$ctx,state:"success",description:"analysis complete",created_at:"2026-01-01T00:00:00Z",creator:{login:"trusted-publisher"}}
   ]' >"$fixtures/statuses.json"
   run "[$ctx] older success under a NEWER failure (stale history is not evidence)" awaiting
 
   reset
   jq -n --arg ctx "$ctx" '[
-    {context:$ctx,state:"failure",description:"issues found",created_at:"2026-01-01T00:00:00Z",creator:{login:"trusted-publisher"}},
-    {context:$ctx,state:"success",description:"analysis complete",created_at:"2026-01-02T00:00:00Z",creator:{login:"trusted-publisher"}}
+    {context:$ctx,state:"success",description:"analysis complete",created_at:"2026-01-02T00:00:00Z",creator:{login:"trusted-publisher"}},
+    {context:$ctx,state:"failure",description:"issues found",created_at:"2026-01-01T00:00:00Z",creator:{login:"trusted-publisher"}}
   ]' >"$fixtures/statuses.json"
   run "[$ctx] newest success over an older failure still counts" approved
 
@@ -719,12 +722,12 @@ status_ctx "mech-outage" pending "attempting"
 run "non-success outage status is not evidence" awaiting
 
 # Withdrawal must work: an operator posting pending over their own earlier
-# override retracts it — the newest row decides on the history endpoint.
+# override retracts it — the newest row (listed first; API order) decides.
 reset
 CFG_OUTAGE="mech-outage"
 jq -n '[
-  {context:"mech-outage",state:"success",description:"outage attested",created_at:"2026-01-01T00:00:00Z",creator:{login:"trusted-publisher"}},
-  {context:"mech-outage",state:"pending",description:"withdrawn",created_at:"2026-01-02T00:00:00Z",creator:{login:"trusted-publisher"}}
+  {context:"mech-outage",state:"pending",description:"withdrawn",created_at:"2026-01-02T00:00:00Z",creator:{login:"trusted-publisher"}},
+  {context:"mech-outage",state:"success",description:"outage attested",created_at:"2026-01-01T00:00:00Z",creator:{login:"trusted-publisher"}}
 ]' >"$fixtures/statuses.json"
 run "override withdrawn by a newer non-success row is not evidence" awaiting
 

--- a/skills/review-gate/scripts/review-predicate-selftest.sh
+++ b/skills/review-gate/scripts/review-predicate-selftest.sh
@@ -372,6 +372,24 @@ context_battery() { # context
   status_ctx "$ctx" pending "still running"
   run "[$ctx] non-success status" awaiting
 
+  # THE NEWEST ROW DECIDES. The statuses LIST endpoint returns the full
+  # history — an older success must never outlive a newer non-success on
+  # the same context (a reviewer opening a fresh round posts pending over
+  # its own earlier success), and the reverse order must still count.
+  reset
+  jq -n --arg ctx "$ctx" '[
+    {context:$ctx,state:"success",description:"analysis complete",created_at:"2026-01-01T00:00:00Z",creator:{login:"trusted-publisher"}},
+    {context:$ctx,state:"failure",description:"issues found",created_at:"2026-01-02T00:00:00Z",creator:{login:"trusted-publisher"}}
+  ]' >"$fixtures/statuses.json"
+  run "[$ctx] older success under a NEWER failure (stale history is not evidence)" awaiting
+
+  reset
+  jq -n --arg ctx "$ctx" '[
+    {context:$ctx,state:"failure",description:"issues found",created_at:"2026-01-01T00:00:00Z",creator:{login:"trusted-publisher"}},
+    {context:$ctx,state:"success",description:"analysis complete",created_at:"2026-01-02T00:00:00Z",creator:{login:"trusted-publisher"}}
+  ]' >"$fixtures/statuses.json"
+  run "[$ctx] newest success over an older failure still counts" approved
+
   reset
   checkrun "$ctx" success "0 findings"
   run "[$ctx] clean check-run at head" approved
@@ -699,6 +717,16 @@ reset
 CFG_OUTAGE="mech-outage"
 status_ctx "mech-outage" pending "attempting"
 run "non-success outage status is not evidence" awaiting
+
+# Withdrawal must work: an operator posting pending over their own earlier
+# override retracts it — the newest row decides on the history endpoint.
+reset
+CFG_OUTAGE="mech-outage"
+jq -n '[
+  {context:"mech-outage",state:"success",description:"outage attested",created_at:"2026-01-01T00:00:00Z",creator:{login:"trusted-publisher"}},
+  {context:"mech-outage",state:"pending",description:"withdrawn",created_at:"2026-01-02T00:00:00Z",creator:{login:"trusted-publisher"}}
+]' >"$fixtures/statuses.json"
+run "override withdrawn by a newer non-success row is not evidence" awaiting
 
 reset
 CFG_OUTAGE="mech-outage"; CFG_THREADS="enforce"

--- a/skills/review-gate/scripts/review-predicate.sh
+++ b/skills/review-gate/scripts/review-predicate.sh
@@ -474,19 +474,36 @@ while IFS= read -r ctx; do
   # fail-open direction this engine exists to avoid. With the list empty
   # (the shipped default) the filter is off entirely and behavior is
   # unchanged.
+  # NEWEST ROW DECIDES, per context. The LIST endpoint returns the full
+  # status HISTORY, not the combined endpoint's latest-per-context
+  # projection — filtering for "any success" would let an old success
+  # outlive a NEWER pending/failure on the same context and open the gate
+  # on stale evidence (a reviewer starting a fresh round posts pending over
+  # its own earlier success). Publisher-rejected rows are dropped BEFORE
+  # choosing the newest — a rejected creator is "not evidence either way",
+  # and letting a minted row mask real rows would hand PR content a
+  # close-the-gate lever it should not have (only toward closed, but still
+  # not its call). The newest ACCEPTED row must then itself be a clean
+  # success: a newest row that is pending/failure, or a skip-filtered
+  # success ("rate limited"), is silence — exactly what the combined
+  # endpoint's projection used to yield.
   check_status="$(jq --arg ctx "$ctx" --arg skips "$SKIP_PATTERNS" --arg reject "$PUBLISHER_REJECT" '
       ($skips | split(";") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0)) | map(ascii_downcase)) as $sk
       | ($reject | split(";") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0))) as $rj
       | [ .statuses[]
-          | select(.context == $ctx and .state == "success")
+          | select(.context == $ctx)
           # Bind the login BEFORE index(): inside index(...) the dot rebinds
           # to $rj, so `.creator` would index the reject ARRAY, not the
           # status. Same rebinding trap the comment-form matcher documents.
           | (.creator.login // "") as $cl
           | select(($rj | length) == 0 or ($cl != "" and ($rj | index($cl)) == null))
-          | ((.description // "") | ascii_downcase) as $text
-          | select(([ $sk[] | . as $p | select($text | contains($p)) ] | length) == 0)
-        ] | length' <<<"$status_resp")" || {
+        ]
+      | sort_by(.created_at // "") | last
+      | if . == null then 0
+        elif .state == "success"
+             and ((((.description // "") | ascii_downcase) as $text
+                   | [ $sk[] | . as $p | select($text | contains($p)) ] | length) == 0)
+        then 1 else 0 end' <<<"$status_resp")" || {
     echo "::error::could not evaluate '$ctx' commit status" >&2
     exit 2
   }
@@ -586,18 +603,23 @@ if [ -n "$OUTAGE_CONTEXT" ]; then
   # documented. The reason rides out in the verdict detail below, flattened
   # at the source because it is API text travelling through a one-line
   # contract and a one-line status description.
+  # Same newest-accepted-row semantics as the trusted-context read above
+  # (the LIST endpoint is a history): an operator withdrawing an override
+  # by posting pending/failure on the same context must actually withdraw
+  # it — an older success may not outlive the newer row.
   outageok_out="$(jq -r --arg ctx "$OUTAGE_CONTEXT" --arg reject "$PUBLISHER_REJECT" '
     ($reject | split(";") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0))) as $rj
     | [ .statuses[]
-        | select(.context == $ctx and .state == "success")
+        | select(.context == $ctx)
         | (.creator.login // "") as $cl
         | select(($rj | length) == 0 or ($cl != "" and ($rj | index($cl)) == null))
-        | select(((.description // "") | gsub("^\\s+|\\s+$"; "") | length) > 0)
       ]
-    | [ length,
-        (if length == 0 then ""
-         else (sort_by(.created_at // "") | last | (.description // "") | gsub("[\n\r\t]"; " ")) end) ]
-    | "\(.[0])\t\(.[1])"' <<<"$status_resp")" || {
+    | sort_by(.created_at // "") | last
+    | if . == null then "0\t"
+      elif .state == "success"
+           and (((.description // "") | gsub("^\\s+|\\s+$"; "") | length) > 0)
+      then "1\t\((.description // "") | gsub("[\n\r\t]"; " "))"
+      else "0\t" end' <<<"$status_resp")" || {
     echo "::error::could not evaluate the operator-override status" >&2
     exit 2
   }

--- a/skills/review-gate/scripts/review-predicate.sh
+++ b/skills/review-gate/scripts/review-predicate.sh
@@ -498,7 +498,12 @@ while IFS= read -r ctx; do
           | (.creator.login // "") as $cl
           | select(($rj | length) == 0 or ($cl != "" and ($rj | index($cl)) == null))
         ]
-      | sort_by(.created_at // "") | last
+      # FIRST accepted row, not sort_by(created_at)|last: the API lists
+      # statuses newest-first (the writer and driver already rely on it),
+      # and created_at has one-second precision — jq sort is stable, so two
+      # rows tied within a second would sort with the OLDER one last and
+      # reintroduce exactly the stale-evidence read this projection closes.
+      | first
       | if . == null then 0
         elif .state == "success"
              and ((((.description // "") | ascii_downcase) as $text
@@ -614,7 +619,9 @@ if [ -n "$OUTAGE_CONTEXT" ]; then
         | (.creator.login // "") as $cl
         | select(($rj | length) == 0 or ($cl != "" and ($rj | index($cl)) == null))
       ]
-    | sort_by(.created_at // "") | last
+    # FIRST accepted row — same newest-first API-order reliance and
+    # second-precision tie rationale as the trusted-context read above.
+    | first
     | if . == null then "0\t"
       elif .state == "success"
            and (((.description // "") | gsub("^\\s+|\\s+$"; "") | length) > 0)

--- a/skills/review-gate/scripts/review-writer.sh
+++ b/skills/review-gate/scripts/review-writer.sh
@@ -129,6 +129,14 @@ if [ -z "${PR_NUMBER:-}" ]; then
     echo "::error::could not list open PRs"
     exit 1
   }
+  # A SUCCESSFUL call that produced zero bytes is a broken read, not an
+  # empty repo — a truly-empty PR list is the two-byte page `[]`. Slurping
+  # nothing to [] would report "converging 0 open PR(s)" and exit green,
+  # silently stranding every gate until the next pass.
+  if [ -z "$raw_prs" ]; then
+    echo "::error::open-PR listing produced zero bytes (broken read); taking no action"
+    exit 1
+  fi
   prs="$(jq -s '[add // [] | .[] | {number, headRefOid: .head.sha, author: {login: (.user.login // "")}}]' <<<"$raw_prs")" || {
     echo "::error::could not parse the open-PR list"
     exit 1
@@ -184,6 +192,13 @@ raw_statuses="$(gh api "repos/$GH_REPO/commits/$HEAD_SHA/statuses" --paginate)" 
   echo "::error::could not read commit statuses for $HEAD_SHA; taking no action"
   exit 1
 }
+# Zero bytes from a successful read is broken, not "no statuses" (that is
+# `[]`): slurped to an empty list it would read as gate-absent and trigger
+# a redundant post at best, a misread current state at worst.
+if [ -z "$raw_statuses" ]; then
+  echo "::error::commit-statuses read for $HEAD_SHA produced zero bytes (broken read); taking no action"
+  exit 1
+fi
 gate_statuses="$(jq -s --arg ctx "$GATE_CONTEXT" '[add // [] | .[] | select(.context == $ctx)]' <<<"$raw_statuses")" || {
   echo "::error::could not parse commit statuses for $HEAD_SHA; taking no action"
   exit 1

--- a/skills/review-gate/tests/review-writer.test.sh
+++ b/skills/review-gate/tests/review-writer.test.sh
@@ -165,6 +165,9 @@ case "$args" in
       echo "HTTP 500" >&2
       exit 1
     fi
+    # "emptybytes": a SUCCESSFUL call producing zero bytes — the broken-read
+    # shape the writer must fail loud on, distinct from the empty page `[]`.
+    if [[ "${STUB_GATE_HISTORY:-[]}" == "emptybytes" ]]; then exit 0; fi
     printf '%s\n' "${STUB_GATE_HISTORY:-[]}"
     if [[ -n "${STUB_GATE_HISTORY_PAGE2:-}" ]]; then printf '%s\n' "$STUB_GATE_HISTORY_PAGE2"; fi
     ;;
@@ -173,6 +176,7 @@ case "$args" in
       echo "HTTP 500" >&2
       exit 1
     fi
+    if [[ "${STUB_OPEN_PRS:-[]}" == "emptybytes" ]]; then exit 0; fi
     printf '%s\n' "${STUB_OPEN_PRS:-[]}"
     if [[ -n "${STUB_OPEN_PRS_PAGE2:-}" ]]; then printf '%s\n' "$STUB_OPEN_PRS_PAGE2"; fi
     ;;
@@ -329,6 +333,16 @@ set -e
 assert_eq "$rc" "1" "w22: status-history read failure exits 1"
 assert_eq "$(( $(wc -l < "$POST_LOG") ))$(( $(wc -l < "$RERUN_LOG") ))" "00" "w22: no action on history read failure"
 
+# A SUCCESSFUL read that produced zero bytes is a broken read, not an empty
+# page (`[]`) — slurped silently it would misread current state (here) or
+# report a green zero-PR convergence (w22c below).
+set +e
+out=$(run_writer STUB_VERDICT_LINE="$APPROVED" STUB_GATE_HISTORY=emptybytes)
+rc=$?
+set -e
+assert_eq "$rc" "1" "w22b: zero-byte status-history read exits 1"
+assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "w22b: no POST past a zero-byte read"
+
 set +e
 out=$(env -u HEAD_SHA PATH="$TMP_ROOT/bin:$PATH" \
   GH_REPO=acme/widgets PR_NUMBER=7 EVENT_NAME=pull_request_target \
@@ -412,6 +426,14 @@ rc=0; out=$(run_writer_all workflow_run STUB_VERDICT_LINE="$APPROVED" STUB_OPEN_
 assert_eq "$rc" "0" "w29: zero open PRs exits 0"
 assert_contains "$out" "converging 0 open PR(s)" "w29: names the empty pass"
 assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "w29: posts nothing (a superseded sha's completion converges nothing, naturally)"
+
+# w22c: the empty-page case above is exactly why zero BYTES must fail loud —
+# the two are adjacent shapes with opposite meanings (`[]` = truly no open
+# PRs; nothing at all = a broken read that would strand every gate green).
+rc=0; out=$(run_writer_all workflow_run STUB_VERDICT_LINE="$APPROVED" STUB_OPEN_PRS=emptybytes 2>&1) || rc=$?
+assert_eq "$rc" "1" "w22c: zero-byte open-PR listing exits 1"
+assert_contains "$out" "zero bytes" "w22c: names the broken read"
+assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "w22c: posts nothing on a broken listing"
 
 # A ghost-authored PR (user serialized null) enumerates with an empty
 # author; the predicate resolves the real author itself downstream.


### PR DESCRIPTION
Two engine defects surfaced by bot review on memsira's cutover PR (vanillagreencom/memsira#441) — fixed at the source before the consumer cutovers land.

**1. Stale-history evidence (predicate).** The statuses LIST endpoint (adopted for the publisher-reject fix in #1100) returns the full status history, unlike the combined endpoint's latest-per-context projection. Filtering it for "any success" let an older success outlive a newer pending/failure on the same context — e.g. a reviewer starting a fresh round posts pending over its own earlier success and the gate stayed open on stale evidence. Both status evidence reads (trusted contexts + operator override) now take the newest publisher-accepted row per context and require that row itself to be a clean success. Rejected creators are dropped before the projection, so a workflow-minted row cannot mask real ones. +8 selftest cases pin the ordering both ways and override withdrawal.

**2. Zero-byte pagination (writer).** A successful `gh api --paginate` call that produces zero bytes was slurped into an empty PR list — "converging 0 open PR(s)", exit green, every gate silently stranded until the next pass. An empty repo is `[]`; zero bytes is a broken read. Both writer reads now fail loud.

Full offline sweep green (selftest 176 cases, writer 86, meta/portability/docs suites). Consumers revendor this with their cutover PRs.

https://claude.ai/code/session_019U2Wd1ZEH8AphKo3bzwYYk
