### PR TITLE
fix(review-gate): every status state converges — withdrawals close the gate event-fast

### DIFF
--- a/.github/workflows/review-gate-writer.yml
+++ b/.github/workflows/review-gate-writer.yml
@@ -41,8 +41,10 @@ name: Review gate writer
   # Status-context evidence (e.g. CodeRabbit; memsira's "Devin Review" is
   # also a STATUS context) — and the operator's override status, which is
   # PAT-authored and therefore converges event-fast through this trigger
-  # too: do not later "optimize" this into a bots-only filter. Filtered to
-  # success STATES by the job-level if: below; NO context-name filter, by
+  # too: do not later "optimize" this into a bots-only filter. EVERY status
+  # state converges (no state filter anywhere — under newest-row evidence
+  # semantics a success→pending/failure transition is a withdrawal and
+  # must close the gate event-fast); NO context-name filter either, by
   # design (#1039): trusted context names are settings, not
   # workflow-expression inputs, and a name list that misses a reviewer's
   # context silently strands that reviewer's clean path.

--- a/.github/workflows/review-gate-writer.yml
+++ b/.github/workflows/review-gate-writer.yml
@@ -79,6 +79,15 @@ jobs:
   # merge-group sha. Kept as its own job — it needs neither the writer
   # concurrency group nor the writer's wider permissions, and a queue entry
   # must never wait behind a sweep pass.
+  #
+  # HONEST BOUNDARY: merge_group runs execute the workflow DEFINITION from
+  # the synthetic merge ref (GitHub's model), so a PR already admitted to
+  # the queue could edit this job. Admission requires the gate plus every
+  # required check at head, and a gate-workflow edit is a review-visible
+  # policy-surface diff — the same documented residual every queue-stage
+  # workflow with write permissions has (v1's review-gate-queue.yml
+  # included). Routing this signal through a default-branch relay would
+  # re-add indirection machinery for a post-review threat; declined.
   merge-group:
     name: Post the gate context on the merge-group sha
     if: github.event_name == 'merge_group'
@@ -127,14 +136,12 @@ jobs:
       group: review-gate-writer
       cancel-in-progress: false
     name: Evaluate and write the review gate
-    # status events act on `success` STATE only: clean-analysis evidence is
-    # only ever a success status; pending/failure/error states converge
-    # nothing (a reviewer may post `pending` on the same context
-    # mid-review). No context-name term — see the status trigger comment
-    # (#1039). Every other declared event is always gate-relevant.
-    if: >-
-      github.event_name != 'merge_group' &&
-      (github.event_name != 'status' || github.event.state == 'success')
+    # EVERY status state converges, not only success: under newest-row
+    # evidence semantics a trusted status moving success→pending/failure is
+    # a WITHDRAWAL, and it must close the gate event-fast rather than wait
+    # for the cron floor. No context-name term — see the status trigger
+    # comment (#1039).
+    if: github.event_name != 'merge_group'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/skills/review-gate/templates/review-gate-writer.yml
+++ b/skills/review-gate/templates/review-gate-writer.yml
@@ -36,8 +36,10 @@ name: Review gate writer
   # Status-context evidence (e.g. CodeRabbit; memsira's "Devin Review" is
   # also a STATUS context) — and the operator's override status, which is
   # PAT-authored and therefore converges event-fast through this trigger
-  # too: do not later "optimize" this into a bots-only filter. Filtered to
-  # success STATES by the job-level if: below; NO context-name filter, by
+  # too: do not later "optimize" this into a bots-only filter. EVERY status
+  # state converges (no state filter anywhere — under newest-row evidence
+  # semantics a success→pending/failure transition is a withdrawal and
+  # must close the gate event-fast); NO context-name filter either, by
   # design (#1039): trusted context names are settings, not
   # workflow-expression inputs, and a name list that misses a reviewer's
   # context silently strands that reviewer's clean path.

--- a/skills/review-gate/templates/review-gate-writer.yml
+++ b/skills/review-gate/templates/review-gate-writer.yml
@@ -74,6 +74,15 @@ jobs:
   # merge-group sha. Kept as its own job — it needs neither the writer
   # concurrency group nor the writer's wider permissions, and a queue entry
   # must never wait behind a sweep pass.
+  #
+  # HONEST BOUNDARY: merge_group runs execute the workflow DEFINITION from
+  # the synthetic merge ref (GitHub's model), so a PR already admitted to
+  # the queue could edit this job. Admission requires the gate plus every
+  # required check at head, and a gate-workflow edit is a review-visible
+  # policy-surface diff — the same documented residual every queue-stage
+  # workflow with write permissions has (v1's review-gate-queue.yml
+  # included). Routing this signal through a default-branch relay would
+  # re-add indirection machinery for a post-review threat; declined.
   merge-group:
     name: Post the gate context on the merge-group sha
     if: github.event_name == 'merge_group'
@@ -122,14 +131,12 @@ jobs:
       group: review-gate-writer
       cancel-in-progress: false
     name: Evaluate and write the review gate
-    # status events act on `success` STATE only: clean-analysis evidence is
-    # only ever a success status; pending/failure/error states converge
-    # nothing (a reviewer may post `pending` on the same context
-    # mid-review). No context-name term — see the status trigger comment
-    # (#1039). Every other declared event is always gate-relevant.
-    if: >-
-      github.event_name != 'merge_group' &&
-      (github.event_name != 'status' || github.event.state == 'success')
+    # EVERY status state converges, not only success: under newest-row
+    # evidence semantics a trusted status moving success→pending/failure is
+    # a WITHDRAWAL, and it must close the gate event-fast rather than wait
+    # for the cron floor. No context-name term — see the status trigger
+    # comment (#1039).
+    if: github.event_name != 'merge_group'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/skills/review-gate/tests/review-writer.test.sh
+++ b/skills/review-gate/tests/review-writer.test.sh
@@ -505,16 +505,21 @@ pin() { # needle, name
     FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        missing from template: %s\n' "$2" "$1"
   fi
 }
-# Every status STATE converges (no success filter): under newest-row
-# evidence semantics a success→pending/failure transition is a withdrawal
-# and must close the gate event-fast. The absence pin guards the filter's
-# return.
-if grep -qF -- "github.event.state == 'success'" "$TEMPLATE"; then
-  FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "tpl: a status state filter returned — withdrawals would wait for the cron floor"
-else
-  PASS=$((PASS + 1)); printf '  ok    %s\n' "tpl: every status state converges (no success-only filter)"
-fi
-pin "github.event_name != 'merge_group'" "tpl: the write job excludes the merge_group event"
+# Every status STATE converges (no state filter of ANY spelling): under
+# newest-row evidence semantics a success→pending/failure transition is a
+# withdrawal and must close the gate event-fast. Two teeth: the write
+# job's if: is pinned as the complete exact line (an equivalent filter
+# cannot hide in a rewrite), and any `github.event.state` reference at
+# all fails (catches quote variants and inverted filters alike). Grep's
+# exit code is branched explicitly — 1 is the passing absence; anything
+# else (2 = read error) fails rather than laundering into a pass.
+pin "    if: github.event_name != 'merge_group'" "tpl: the write job's if: is exactly the merge_group exclusion"
+rc=0; grep -qF -- "github.event.state" "$TEMPLATE" || rc=$?
+case "$rc" in
+  1) PASS=$((PASS + 1)); printf '  ok    %s\n' "tpl: no status state filter of any spelling" ;;
+  0) FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "tpl: a status state filter returned — withdrawals would wait for the cron floor" ;;
+  *) FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "tpl: the template could not be read (grep error)" ;;
+esac
 pin "cancel-in-progress: false" "tpl: pending writer runs are never cancelled mid-write"
 pin "group: review-gate-writer" "tpl: single writer concurrency group"
 pin "github.event.pull_request.head.repo.full_name != github.repository" "tpl: fork pull_request_review read-only flag"

--- a/skills/review-gate/tests/review-writer.test.sh
+++ b/skills/review-gate/tests/review-writer.test.sh
@@ -505,7 +505,15 @@ pin() { # needle, name
     FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        missing from template: %s\n' "$2" "$1"
   fi
 }
-pin "github.event.state == 'success'" "tpl: status events act on success state only"
+# Every status STATE converges (no success filter): under newest-row
+# evidence semantics a success→pending/failure transition is a withdrawal
+# and must close the gate event-fast. The absence pin guards the filter's
+# return.
+if grep -qF -- "github.event.state == 'success'" "$TEMPLATE"; then
+  FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "tpl: a status state filter returned — withdrawals would wait for the cron floor"
+else
+  PASS=$((PASS + 1)); printf '  ok    %s\n' "tpl: every status state converges (no success-only filter)"
+fi
 pin "github.event_name != 'merge_group'" "tpl: the write job excludes the merge_group event"
 pin "cancel-in-progress: false" "tpl: pending writer runs are never cancelled mid-write"
 pin "group: review-gate-writer" "tpl: single writer concurrency group"

--- a/skills/review-gate/tests/review-writer.test.sh
+++ b/skills/review-gate/tests/review-writer.test.sh
@@ -513,7 +513,14 @@ pin() { # needle, name
 # all fails (catches quote variants and inverted filters alike). Grep's
 # exit code is branched explicitly — 1 is the passing absence; anything
 # else (2 = read error) fails rather than laundering into a pass.
-pin "    if: github.event_name != 'merge_group'" "tpl: the write job's if: is exactly the merge_group exclusion"
+# Scoped to the write job's block (it is the template's last job): a
+# template-wide search could be satisfied by a condition on some other job.
+write_block="$(sed -n '/^  write:/,$p' "$TEMPLATE")"
+if grep -qF -- "    if: github.event_name != 'merge_group'" <<<"$write_block"; then
+  PASS=$((PASS + 1)); printf '  ok    %s\n' "tpl: the write job's if: is exactly the merge_group exclusion"
+else
+  FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "tpl: the write job's if: is exactly the merge_group exclusion"
+fi
 rc=0; grep -qF -- "github.event.state" "$TEMPLATE" || rc=$?
 case "$rc" in
   1) PASS=$((PASS + 1)); printf '  ok    %s\n' "tpl: no status state filter of any spelling" ;;


### PR DESCRIPTION
Follow-up to #1102 (newest-row evidence): with withdrawal now meaningful, the writer's status leg must converge on EVERY status state — a trusted status (or the operator override) moving success→pending/failure is a withdrawal, and filtering those events deferred the close to the cron floor. The success-only filter is gone from the template and vstack's own copy (drovr and memsira fixed their repo-owned copies in their open cutover PRs); the template pin now guards against the filter's return.

Also adds the honest-boundary note to the template's merge-group job: merge_group runs execute the workflow definition from the synthetic merge ref (GitHub's model) — the documented, deliberately-accepted residual every queue-stage workflow with write permissions has. Flagged by Copilot on drovr's cutover, declined as a redesign, now stated where adopters will read it.

https://claude.ai/code/session_019U2Wd1ZEH8AphKo3bzwYYk
