### PR TITLE
fix(review-gate): compare files ride page one only; writer rejects non-array pages; selftest owns exit codes

### DIFF
--- a/skills/review-gate/scripts/review-predicate-selftest.sh
+++ b/skills/review-gate/scripts/review-predicate-selftest.sh
@@ -1188,12 +1188,22 @@ CFG_CARRY="docs"
 compare_fix ahead "[$(jq -n '{filename:"notes.md",previous_filename:"src/thing.sh",status:"renamed",patch:"@@ -1 +1 @@\n-do_the_thing\n+do_the_thing"}')]"
 run "carry: a code file RENAMED to a .md name refuses under 'docs'" awaiting
 
+# Real API shape (compare pagination paginates COMMITS): a later page is a
+# healthy OBJECT with no files array — files ride page one only. Carry must
+# still work across it, and a non-object later page must fail loud.
 reset
 carry_candidate
 CFG_CARRY="docs"
 compare_fix ahead "[$DOCS_DELTA]"
-printf '{}\n' >"$fixtures/compare.page2.json"
-run "carry: a malformed later compare page is exit 2, never a partial classification" "" 2
+printf '{"commits": []}\n' >"$fixtures/compare.page2.json"
+run "carry: a fileless later compare page (real pagination shape) still carries" approved
+
+reset
+carry_candidate
+CFG_CARRY="docs"
+compare_fix ahead "[$DOCS_DELTA]"
+printf '[]\n' >"$fixtures/compare.page2.json"
+run "carry: a non-object later compare page is exit 2, never a partial classification" "" 2
 
 reset
 carry_candidate
@@ -1382,6 +1392,7 @@ if [ -n "$ACTIVE_OUTAGE" ]; then
   reset
   status_ctx "$ACTIVE_OUTAGE" success "internal review loop clean (attested by the operator)"
   cases=$((cases + 1))
+  detail_rc=0
   detail_line="$(PATH="$shim:$PATH" GH_SHIM_FIXTURES="$fixtures" \
     REVIEW_GATE_SETTINGS_FILE=/dev/null \
     REVIEW_GATE_TRUSTED_STATUS_CONTEXTS="$CFG_CONTEXTS" \
@@ -1392,14 +1403,21 @@ if [ -n "$ACTIVE_OUTAGE" ]; then
     REVIEW_GATE_CONTEXT="$CFG_GATE_CONTEXT" REVIEW_GATE_THREADS="$CFG_THREADS" \
     REVIEW_GATE_CARRY_FORWARD="$CFG_CARRY" \
     GH_REPO="owner/repo" PR_NUMBER=1 HEAD_SHA="$HEAD" PR_AUTHOR="$CFG_PR_AUTHOR" \
-    "$predicate" 2>/dev/null | head -n 1)"
+    "$predicate" 2>/dev/null)" || detail_rc=$?
+  detail_line="$(head -n 1 <<<"$detail_line")"
   case "$detail_line" in
     *"operator override"*"internal review loop clean"*)
-      echo "ok    configured: the override reason rides out in the verdict detail (approved)" ;;
+      if [ "${detail_rc:-0}" -ne 0 ]; then
+        echo "FAIL  configured: the override-detail case exited ${detail_rc} despite the expected line" >&2
+        failures=$((failures + 1))
+      else
+        echo "ok    configured: the override reason rides out in the verdict detail (approved)"
+      fi ;;
     *)
       echo "FAIL  configured: override reason missing from the detail: $detail_line" >&2
       failures=$((failures + 1)) ;;
   esac
+  detail_rc=0
 
   # The v2 key name is resolved by the PREDICATE (every live gate read
   # honors it), not only by the writer — an adopter setting just the v2 key
@@ -1408,6 +1426,7 @@ if [ -n "$ACTIVE_OUTAGE" ]; then
   CFG_OUTAGE="legacy-name"
   status_ctx "v2-override-name" success "attested via the v2 key"
   cases=$((cases + 1))
+  alias_rc=0
   alias_line="$(PATH="$shim:$PATH" GH_SHIM_FIXTURES="$fixtures" \
     REVIEW_GATE_SETTINGS_FILE=/dev/null \
     REVIEW_GATE_TRUSTED_STATUS_CONTEXTS="" REVIEW_GATE_COMMENT_REVIEWERS="" \
@@ -1416,12 +1435,20 @@ if [ -n "$ACTIVE_OUTAGE" ]; then
     REVIEW_GATE_REVIEW_OBJECT_TRUSTED_LOGINS="" REVIEW_GATE_CONTEXT="$CFG_GATE_CONTEXT" \
     REVIEW_GATE_THREADS="$CFG_THREADS" REVIEW_GATE_CARRY_FORWARD="" \
     GH_REPO="owner/repo" PR_NUMBER=1 HEAD_SHA="$HEAD" PR_AUTHOR="$CFG_PR_AUTHOR" \
-    "$predicate" 2>/dev/null | head -n 1)"
+    "$predicate" 2>/dev/null)" || alias_rc=$?
+  alias_line="$(head -n 1 <<<"$alias_line")"
   case "$alias_line" in
-    verdict=approved*) echo "ok    configured: REVIEW_GATE_OVERRIDE_CONTEXT wins over the legacy key in the predicate itself (approved)" ;;
+    verdict=approved*)
+      if [ "${alias_rc:-0}" -ne 0 ]; then
+        echo "FAIL  configured: the override-alias case exited ${alias_rc} despite the expected line" >&2
+        failures=$((failures + 1))
+      else
+        echo "ok    configured: REVIEW_GATE_OVERRIDE_CONTEXT wins over the legacy key in the predicate itself (approved)"
+      fi ;;
     *) echo "FAIL  configured: the v2 override key was not honored by the predicate: $alias_line" >&2
        failures=$((failures + 1)) ;;
   esac
+  alias_rc=0
   CFG_OUTAGE="$ACTIVE_OUTAGE"
 
   if [ -n "$ACTIVE_PUBLISHER_REJECT" ]; then

--- a/skills/review-gate/scripts/review-predicate.sh
+++ b/skills/review-gate/scripts/review-predicate.sh
@@ -697,17 +697,21 @@ if [ -n "$CARRY_FORWARD" ] && [ "$got" = "0" ] && [ "$check" = "0" ] \
       echo "::error::comparison $base...$HEAD_SHA produced zero bytes (broken read)" >&2
       exit 2
     fi
-    # EVERY page of a healthy compare response carries a files array
-    # (possibly empty); any page without one is a malformed or truncated
-    # response, and defaulting it to [] would hide that page's files from
-    # classification — a carried approval from a broken read (vstack#1097
-    # closed the later-page half of this; page 1 was always checked). Same
-    # exit-2 contract as every other evidence read.
-    cmp="$(jq -s 'if (length > 0) and all(type == "object" and ((.files | type) == "array"))
-                  then {status: (.[0].status // ""), files: (map(.files) | add)}
+    # THE FILES LIST RIDES PAGE ONE ONLY: compare pagination paginates the
+    # COMMITS array — later pages are healthy objects that carry no files
+    # (demanding one there, as the first vstack#1097 fix did, made every
+    # multi-page compare exit 2 and hard-failed the predicate). So: page
+    # one must be an object WITH a files array (a page-one without it is a
+    # malformed or truncated response — defaulting to [] would carry an
+    # approval from a broken read), later pages need only be objects, and
+    # the classification reads files from page one alone. The 300-entry
+    # API cap still refuses carry below (completeness unprovable at the
+    # cap). Same exit-2 contract as every other evidence read.
+    cmp="$(jq -s 'if (length > 0) and all(type == "object") and ((.[0].files | type) == "array")
+                  then {status: (.[0].status // ""), files: .[0].files}
                   else error("malformed compare page") end' \
               <<<"$cmp_pages" 2>/dev/null)" || {
-      echo "::error::could not merge the comparison pages for $base...$HEAD_SHA (missing or malformed files array)" >&2
+      echo "::error::could not merge the comparison pages for $base...$HEAD_SHA (non-object page, or page one without a files array)" >&2
       exit 2
     }
     cmp_status="$(jq -r .status <<<"$cmp")"

--- a/skills/review-gate/scripts/review-writer.sh
+++ b/skills/review-gate/scripts/review-writer.sh
@@ -137,8 +137,14 @@ if [ -z "${PR_NUMBER:-}" ]; then
     echo "::error::open-PR listing produced zero bytes (broken read); taking no action"
     exit 1
   fi
-  prs="$(jq -s '[add // [] | .[] | {number, headRefOid: .head.sha, author: {login: (.user.login // "")}}]' <<<"$raw_prs")" || {
-    echo "::error::could not parse the open-PR list"
+  # Page-shape validation, not just parse success: a whitespace-only body
+  # slurps to [] and an error-object page slurps to {} — both would read
+  # as "zero open PRs" and exit green with every gate silently stranded.
+  # A healthy page is an ARRAY (an empty repo is the two-byte page []).
+  prs="$(jq -s 'if (length > 0) and all(type == "array")
+                then [add | .[] | {number, headRefOid: .head.sha, author: {login: (.user.login // "")}}]
+                else error("not an array page") end' <<<"$raw_prs" 2>/dev/null)" || {
+    echo "::error::open-PR listing pages are not arrays (broken read); taking no action"
     exit 1
   }
   count="$(jq length <<<"$prs")"
@@ -199,8 +205,10 @@ if [ -z "$raw_statuses" ]; then
   echo "::error::commit-statuses read for $HEAD_SHA produced zero bytes (broken read); taking no action"
   exit 1
 fi
-gate_statuses="$(jq -s --arg ctx "$GATE_CONTEXT" '[add // [] | .[] | select(.context == $ctx)]' <<<"$raw_statuses")" || {
-  echo "::error::could not parse commit statuses for $HEAD_SHA; taking no action"
+gate_statuses="$(jq -s --arg ctx "$GATE_CONTEXT" 'if (length > 0) and all(type == "array")
+                  then [add | .[] | select(.context == $ctx)]
+                  else error("not an array page") end' <<<"$raw_statuses" 2>/dev/null)" || {
+  echo "::error::commit-status pages for $HEAD_SHA are not arrays (broken read); taking no action"
   exit 1
 }
 current_state="$(jq -r '.[0].state // "absent"' <<<"$gate_statuses")"

--- a/skills/review-gate/tests/review-writer.test.sh
+++ b/skills/review-gate/tests/review-writer.test.sh
@@ -168,6 +168,7 @@ case "$args" in
     # "emptybytes": a SUCCESSFUL call producing zero bytes — the broken-read
     # shape the writer must fail loud on, distinct from the empty page `[]`.
     if [[ "${STUB_GATE_HISTORY:-[]}" == "emptybytes" ]]; then exit 0; fi
+    if [[ "${STUB_GATE_HISTORY:-[]}" == "whitespace" ]]; then printf '   \n'; exit 0; fi
     printf '%s\n' "${STUB_GATE_HISTORY:-[]}"
     if [[ -n "${STUB_GATE_HISTORY_PAGE2:-}" ]]; then printf '%s\n' "$STUB_GATE_HISTORY_PAGE2"; fi
     ;;
@@ -177,6 +178,7 @@ case "$args" in
       exit 1
     fi
     if [[ "${STUB_OPEN_PRS:-[]}" == "emptybytes" ]]; then exit 0; fi
+    if [[ "${STUB_OPEN_PRS:-[]}" == "whitespace" ]]; then printf '   \n'; exit 0; fi
     printf '%s\n' "${STUB_OPEN_PRS:-[]}"
     if [[ -n "${STUB_OPEN_PRS_PAGE2:-}" ]]; then printf '%s\n' "$STUB_OPEN_PRS_PAGE2"; fi
     ;;
@@ -434,6 +436,23 @@ rc=0; out=$(run_writer_all workflow_run STUB_VERDICT_LINE="$APPROVED" STUB_OPEN_
 assert_eq "$rc" "1" "w22c: zero-byte open-PR listing exits 1"
 assert_contains "$out" "zero bytes" "w22c: names the broken read"
 assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "w22c: posts nothing on a broken listing"
+
+# The two adjacent shapes the -z guard cannot see: whitespace-only slurps to
+# [] and an error-object page to {} — both used to read as "zero open PRs"
+# and exit green.
+rc=0; out=$(run_writer_all workflow_run STUB_VERDICT_LINE="$APPROVED" STUB_OPEN_PRS=whitespace 2>&1) || rc=$?
+assert_eq "$rc" "1" "w22d: whitespace-only open-PR listing exits 1"
+assert_contains "$out" "not arrays" "w22d: names the shape violation"
+assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "w22d: posts nothing"
+
+rc=0; out=$(run_writer_all workflow_run STUB_VERDICT_LINE="$APPROVED" STUB_OPEN_PRS='{"message":"Server Error"}' 2>&1) || rc=$?
+assert_eq "$rc" "1" "w22e: an error-object page exits 1"
+assert_contains "$out" "not arrays" "w22e: names the shape violation"
+assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "w22e: posts nothing"
+
+rc=0; out=$(run_writer STUB_VERDICT_LINE="$APPROVED" STUB_GATE_HISTORY='{"message":"Server Error"}' 2>&1) || rc=$?
+assert_eq "$rc" "1" "w22f: an error-object status page exits 1"
+assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "w22f: no post past a malformed status page"
 
 # A ghost-authored PR (user serialized null) enumerates with an empty
 # author; the predicate resolves the real author itself downstream.


### PR DESCRIPTION
Three engine findings from bot review on hyprtrade#525, fixed at the source (details in the commit message): compare-pagination files ride page one only (any multi-page compare used to hard-fail the predicate when carry-forward was enabled), the writer now rejects whitespace/object pages that previously read as zero open PRs and exited green, and two selftest cases now own their exit codes. Full sweep green; selftest 177 cases.

https://claude.ai/code/session_019U2Wd1ZEH8AphKo3bzwYYk
