### PR TITLE
fix(review-gate): settings grep operand order; LIST-shaped snapshot seam; template ref fallback

### DIFF
--- a/.github/workflows/review-gate-writer.yml
+++ b/.github/workflows/review-gate-writer.yml
@@ -110,7 +110,14 @@ jobs:
       # queued may run under this job's write-capable token.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          # `|| 'main'` fallback: if the default_branch expression ever
+          # resolved empty here, actions/checkout would fall back to its
+          # own default ref — on this job's only event (merge_group, per
+          # the job-level if:) that is the merge group's synthetic ref,
+          # i.e. queued code instead of MAIN's config under this job's
+          # write-capable token. 'main' is this repo's default branch
+          # (repo-owned ADAPT).
+          ref: ${{ github.event.repository.default_branch || 'main' }}
           persist-credentials: false
       - name: Post success (queue entries are post-approval by construction)
         run: |
@@ -177,7 +184,13 @@ jobs:
       # and reads PR data only through the API (see the security note).
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          # `|| 'main'` fallback: if the default_branch expression ever
+          # resolved empty on some event leg, actions/checkout would fall
+          # back to its own default ref — on this job's pull_request_target
+          # leg that is the PR MERGE ref, i.e. PR-controlled code under the
+          # writer's write-capable token. 'main' is this repo's default
+          # branch (repo-owned ADAPT).
+          ref: ${{ github.event.repository.default_branch || 'main' }}
           persist-credentials: false
 
       - name: Evaluate and converge the gate

--- a/skills/review-gate/references/settings.md
+++ b/skills/review-gate/references/settings.md
@@ -38,20 +38,28 @@ Two env-only PER-INVOCATION seams are deliberately NOT settings keys:
   file to resolve from is a property of one invocation, never of the repo
   the file itself describes — a settings key naming its own settings file
   would be circular.
-- `REVIEW_GATE_STATUS_SNAPSHOT_FILE` — path to a combined-status snapshot
-  (JSON object with a `statuses` array and a top-level `sha` equal to the
-  invocation's `HEAD_SHA` — a single-page raw combined-status API response
-  carries both; a caller that paginated merges every page's statuses into
-  the one array first, since a first-page-only snapshot silently drops
-  later-page evidence) the CALLER already holds. When set, the predicate evaluates
-  trusted-context and outage evidence against it instead of fetching the
-  combined status itself — a converge-style sweep that reads the combined
-  status for its own required-status projection stops paying that read
-  twice per head. The snapshot is bound to one head at one moment, which is
-  why it can never be a repo setting — and the `sha` requirement enforces
-  that binding: a snapshot for another head is refused. An unreadable,
-  malformed, or wrong-head snapshot gets the read contract: exit 2, no
-  verdict.
+- `REVIEW_GATE_STATUS_SNAPSHOT_FILE` — path to a status snapshot (JSON
+  object with a `statuses` array and a top-level `sha` equal to the
+  invocation's `HEAD_SHA`) the CALLER already holds. The rows must come
+  from the per-commit statuses LIST endpoint (`/commits/<sha>/statuses`) —
+  the same endpoint the predicate's own fetch path uses: full per-context
+  history, real `creator.login` on every row. The combined endpoint
+  (`/commits/<sha>/status`) is NOT a valid source — it projects
+  latest-per-context and serializes `creator` as null for App-posted rows,
+  which `REVIEW_GATE_STATUS_PUBLISHER_REJECT`'s anomaly rule treats as
+  not-evidence; while that reject list is configured, the seam refuses a
+  snapshot containing login-less rows (exit 2) rather than silently
+  dropping real evidence. The caller wraps the rows itself: merge every
+  page's rows into one `statuses` array under a top-level `sha` (a
+  first-page-only snapshot silently drops later-page evidence). When set,
+  the predicate evaluates trusted-context and outage evidence against it
+  instead of fetching the statuses itself — a converge-style sweep that
+  reads the status list for its own required-status projection stops
+  paying that read twice per head. The snapshot is bound to one head at
+  one moment, which is why it can never be a repo setting — and the `sha`
+  requirement enforces that binding: a snapshot for another head is
+  refused. An unreadable, malformed, or wrong-head snapshot gets the read
+  contract: exit 2, no verdict.
 
 # Security posture
 

--- a/skills/review-gate/scripts/lib/settings.sh
+++ b/skills/review-gate/scripts/lib/settings.sh
@@ -53,16 +53,16 @@ rg_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
     # — anchoring at column one made an indented duplicate bypass the
     # fail-loud guard and an indented sole assignment collapse silently to
     # the built-in default (vstack#1059).
-    if grep -Eq "^[[:space:]]*${name}[[:space:]]*=" -- "$file"; then
+    if grep -Eq -- "^[[:space:]]*${name}[[:space:]]*=" "$file"; then
       # File-wide matching (header contract) makes a re-assigned name
       # ambiguous — e.g. the same key under two tables. Silently taking the
       # first could read an unrelated table's value on a security-sensitive
       # path, so ambiguity is a configuration error.
-      if [ "$(grep -Ec "^[[:space:]]*${name}[[:space:]]*=" -- "$file")" -gt 1 ]; then
+      if [ "$(grep -Ec -- "^[[:space:]]*${name}[[:space:]]*=" "$file")" -gt 1 ]; then
         echo "::error::$file: $name is assigned more than once (keys are matched file-wide regardless of TOML table; each name must be unique in the file)" >&2
         return 1
       fi
-      line="$(grep -E "^[[:space:]]*${name}[[:space:]]*=" -- "$file" | head -n 1)"
+      line="$(grep -E -- "^[[:space:]]*${name}[[:space:]]*=" "$file" | head -n 1)"
       # A PRESENT assignment this parser cannot read (e.g. TOML array syntax
       # for a list key) must fail LOUDLY, never collapse to empty: an empty
       # value can silently widen the gate (empty trusted-logins = any
@@ -70,7 +70,7 @@ rg_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
       # supported — the value is quote-free ([^"]*), which makes the
       # extraction exact even with a trailing TOML comment (accepted);
       # anything else is a configuration error.
-      if ! printf '%s\n' "$line" | grep -Eq "^[[:space:]]*${name}[[:space:]]*=[[:space:]]*\"[^\"]*\"[[:space:]]*(#.*)?\$"; then
+      if ! printf '%s\n' "$line" | grep -Eq -- "^[[:space:]]*${name}[[:space:]]*=[[:space:]]*\"[^\"]*\"[[:space:]]*(#.*)?\$"; then
         echo "::error::$file: unsupported syntax for $name (expected a single-line basic string: $name = \"value\"; list keys pack items with ';' separators)" >&2
         return 1
       fi

--- a/skills/review-gate/scripts/review-predicate-selftest.sh
+++ b/skills/review-gate/scripts/review-predicate-selftest.sh
@@ -1081,6 +1081,12 @@ run "snapshot seam: null-creator row with the reject list EMPTY still evaluates 
 unset GH_SHIM_FAIL
 
 reset
+CFG_CONTEXTS="mech-ctx"; CFG_PUBLISHER_REJECT="github-actions[bot]"
+jq -n --arg sha "$HEAD" '{sha:$sha,statuses:[{context:"mech-ctx",state:"success",description:"analysis complete",created_at:"2026-01-01T00:00:00Z",creator:{login:{}}}]}' >"$fixtures/objlogin-snapshot.json"
+CFG_SNAPSHOT="$fixtures/objlogin-snapshot.json"
+run "snapshot seam: NON-STRING creator login under a configured reject list is exit 2 (// \"\" would let an object through)" "" 2
+
+reset
 CFG_CONTEXTS="mech-ctx"
 status_ctx "mech-ctx" success "analysis complete"
 printf '{}\n' >"$fixtures/statuses.page2.json"

--- a/skills/review-gate/scripts/review-predicate-selftest.sh
+++ b/skills/review-gate/scripts/review-predicate-selftest.sh
@@ -1062,6 +1062,24 @@ jq -n --arg sha "$HEAD" '{sha:$sha,statuses:{}}' >"$fixtures/objstat-snapshot.js
 CFG_SNAPSHOT="$fixtures/objstat-snapshot.json"
 run "snapshot seam: snapshot with non-array statuses is exit 2" "" 2
 
+# LIST-shape at the seam: while the publisher reject list is configured, the
+# downstream anomaly rule drops login-less rows as not-evidence — so a
+# combined-endpoint snapshot (null creators on App rows) would silently
+# erase real evidence. The seam refuses it loudly instead. With the list
+# empty (shipped default) the filter is off and null creators still pass.
+reset
+CFG_CONTEXTS="mech-ctx"; CFG_PUBLISHER_REJECT="github-actions[bot]"
+jq -n --arg sha "$HEAD" '{sha:$sha,statuses:[{context:"mech-ctx",state:"success",description:"analysis complete",created_at:"2026-01-01T00:00:00Z",creator:null}]}' >"$fixtures/nullcreator-snapshot.json"
+CFG_SNAPSHOT="$fixtures/nullcreator-snapshot.json"
+run "snapshot seam: null-creator row under a configured reject list is exit 2, not silent erasure" "" 2
+
+reset
+CFG_CONTEXTS="mech-ctx"; CFG_PUBLISHER_REJECT=""
+CFG_SNAPSHOT="$fixtures/nullcreator-snapshot.json"
+export GH_SHIM_FAIL=statuses
+run "snapshot seam: null-creator row with the reject list EMPTY still evaluates (filter off)" approved
+unset GH_SHIM_FAIL
+
 reset
 CFG_CONTEXTS="mech-ctx"
 status_ctx "mech-ctx" success "analysis complete"

--- a/skills/review-gate/scripts/review-predicate.sh
+++ b/skills/review-gate/scripts/review-predicate.sh
@@ -394,7 +394,10 @@ if [ -n "${REVIEW_GATE_STATUS_SNAPSHOT_FILE:-}" ]; then
                         | (type == "object") and ((.statuses | type) == "array")
                           and (.sha == $sha)
                           and (($rj | length) == 0
-                               or (.statuses | all((.creator.login // "") != ""))))
+                               or (.statuses | all(
+                                    ((.creator | type) == "object")
+                                    and ((.creator.login | type) == "string")
+                                    and ((.creator.login | length) > 0)))))
                      then {statuses: .[0].statuses}
                      else error("not a single list-endpoint status snapshot for this head") end' \
                     "$REVIEW_GATE_STATUS_SNAPSHOT_FILE" 2>/dev/null)" || {

--- a/skills/review-gate/scripts/review-predicate.sh
+++ b/skills/review-gate/scripts/review-predicate.sh
@@ -83,21 +83,28 @@
 #
 # Env (required): GH_TOKEN (or ambient gh auth), GH_REPO, PR_NUMBER, HEAD_SHA
 # Env (optional): PR_AUTHOR — resolved from the PR when empty.
-# Env (optional): REVIEW_GATE_STATUS_SNAPSHOT_FILE — path to a combined-status
-#   snapshot (JSON object with a `statuses` array and a top-level `sha` equal
-#   to HEAD_SHA) supplied by the CALLER; when set, the predicate evaluates
+# Env (optional): REVIEW_GATE_STATUS_SNAPSHOT_FILE — path to a status snapshot
+#   (JSON object with a `statuses` array and a top-level `sha` equal to
+#   HEAD_SHA) supplied by the CALLER; when set, the predicate evaluates
 #   trusted-context and outage evidence against it instead of fetching the
-#   combined status itself. A converge-style caller that already read the
-#   combined status for its own projection hands it in here and the duplicate
-#   per-head read disappears — the API response carries the head sha at top
-#   level, so a SINGLE-PAGE response satisfies the binding as-is. The
-#   snapshot must contain the COMPLETE status set for the head: a caller
-#   that paginated (heads with >100 statuses) merges every page's statuses
-#   into one array under one top-level sha before handing it in — a
-#   first-page-only snapshot would silently drop later-page evidence. Per-invocation env
-#   seam (like REVIEW_GATE_SETTINGS_FILE), never a settings key: the snapshot
-#   is bound to one head at one moment, and the `sha` requirement enforces
-#   that binding. An unreadable/malformed/wrong-head snapshot is exit 2.
+#   statuses itself. LIST-ENDPOINT ROWS ONLY: the rows must come from the
+#   per-commit statuses LIST endpoint (/commits/<sha>/statuses), the same
+#   endpoint the fetch path below uses — full per-context HISTORY, real
+#   `creator.login` on every row. The combined endpoint
+#   (/commits/<sha>/status) is NOT a valid source: it projects
+#   latest-per-context (masking newer-row supersession) and serializes
+#   `creator` as null for App-posted rows, which the
+#   REVIEW_GATE_STATUS_PUBLISHER_REJECT anomaly rule would then silently
+#   drop as not-evidence. While the reject list is configured, a row without
+#   a creator login is refused AT THE SEAM (exit 2) rather than silently
+#   erased downstream. The snapshot must contain the COMPLETE status set for
+#   the head: a caller that paginated (heads with >100 rows) merges every
+#   page's rows into one array under one top-level `sha` before handing it
+#   in — a first-page-only snapshot would silently drop later-page
+#   evidence. Per-invocation env seam (like REVIEW_GATE_SETTINGS_FILE),
+#   never a settings key: the snapshot is bound to one head at one moment,
+#   and the `sha` requirement enforces that binding. An
+#   unreadable/malformed/wrong-head snapshot is exit 2.
 #
 # Output: one machine-readable line on stdout:
 #   verdict=approved|awaiting|threads-open|changes-requested detail=<human text>
@@ -371,14 +378,27 @@ if [ -n "${REVIEW_GATE_STATUS_SNAPSHOT_FILE:-}" ]; then
   # with zero evidence (vstack#1086). Slurping also makes a zero-value
   # (empty or whitespace-only) file hit the error branch instead of jq's
   # silent empty-output success.
-  status_resp="$(jq -s --arg sha "$HEAD_SHA" '
-                     if (length == 1) and (.[0]
+  #
+  # LIST-endpoint rows only (see the env contract in the header): while the
+  # publisher reject list is configured, every row must carry a real
+  # creator login — on the LIST endpoint every real publisher has one, and
+  # the downstream anomaly rule drops login-less rows as not-evidence. A
+  # combined-endpoint snapshot (null creators on App rows) under a
+  # configured reject list would therefore silently erase real evidence;
+  # refusing it here turns that erasure into a loud contract error. With
+  # the reject list empty (the shipped default) the filter is off and no
+  # creator requirement applies.
+  status_resp="$(jq -s --arg sha "$HEAD_SHA" --arg reject "$PUBLISHER_REJECT" '
+                     ($reject | split(";") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0))) as $rj
+                     | if (length == 1) and (.[0]
                         | (type == "object") and ((.statuses | type) == "array")
-                          and (.sha == $sha))
+                          and (.sha == $sha)
+                          and (($rj | length) == 0
+                               or (.statuses | all((.creator.login // "") != ""))))
                      then {statuses: .[0].statuses}
-                     else error("not a single combined-status snapshot for this head") end' \
+                     else error("not a single list-endpoint status snapshot for this head") end' \
                     "$REVIEW_GATE_STATUS_SNAPSHOT_FILE" 2>/dev/null)" || {
-    echo "::error::REVIEW_GATE_STATUS_SNAPSHOT_FILE '$REVIEW_GATE_STATUS_SNAPSHOT_FILE' is not a readable combined-status snapshot bound to $HEAD_SHA (exactly one JSON object with a statuses array and top-level sha == HEAD_SHA)" >&2
+    echo "::error::REVIEW_GATE_STATUS_SNAPSHOT_FILE '$REVIEW_GATE_STATUS_SNAPSHOT_FILE' is not a readable list-endpoint status snapshot bound to $HEAD_SHA (exactly one JSON object with a statuses array and top-level sha == HEAD_SHA; with REVIEW_GATE_STATUS_PUBLISHER_REJECT configured every row must carry a creator login — combined-endpoint snapshots null App creators and are not a valid source)" >&2
     exit 2
   }
 else

--- a/skills/review-gate/templates/review-gate-writer.yml
+++ b/skills/review-gate/templates/review-gate-writer.yml
@@ -105,7 +105,13 @@ jobs:
       # queued may run under this job's write-capable token.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          # `|| 'main'` fallback: if the default_branch expression ever
+          # resolves empty on some event leg, actions/checkout would fall
+          # back to its own default ref — on pull_request_target that is
+          # the PR MERGE ref, i.e. PR-controlled code under this job's
+          # write-capable token. The fallback value is repo-owned config:
+          # ADAPT it to the repo's default branch on copy.
+          ref: ${{ github.event.repository.default_branch || 'main' }}
           persist-credentials: false
       - name: Post success (queue entries are post-approval by construction)
         run: |
@@ -172,7 +178,13 @@ jobs:
       # and reads PR data only through the API (see the security note).
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          # `|| 'main'` fallback: if the default_branch expression ever
+          # resolves empty on some event leg, actions/checkout would fall
+          # back to its own default ref — on pull_request_target that is
+          # the PR MERGE ref, i.e. PR-controlled code under this job's
+          # write-capable token. The fallback value is repo-owned config:
+          # ADAPT it to the repo's default branch on copy.
+          ref: ${{ github.event.repository.default_branch || 'main' }}
           persist-credentials: false
 
       - name: Evaluate and converge the gate

--- a/skills/review-gate/templates/review-gate-writer.yml
+++ b/skills/review-gate/templates/review-gate-writer.yml
@@ -106,9 +106,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # `|| 'main'` fallback: if the default_branch expression ever
-          # resolves empty on some event leg, actions/checkout would fall
-          # back to its own default ref — on pull_request_target that is
-          # the PR MERGE ref, i.e. PR-controlled code under this job's
+          # resolved empty here, actions/checkout would fall back to its
+          # own default ref — on this job's only event (merge_group, per
+          # the job-level if:) that is the merge group's synthetic ref,
+          # i.e. queued code instead of MAIN's config under this job's
           # write-capable token. The fallback value is repo-owned config:
           # ADAPT it to the repo's default branch on copy.
           ref: ${{ github.event.repository.default_branch || 'main' }}
@@ -179,11 +180,11 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # `|| 'main'` fallback: if the default_branch expression ever
-          # resolves empty on some event leg, actions/checkout would fall
-          # back to its own default ref — on pull_request_target that is
-          # the PR MERGE ref, i.e. PR-controlled code under this job's
-          # write-capable token. The fallback value is repo-owned config:
-          # ADAPT it to the repo's default branch on copy.
+          # resolved empty on some event leg, actions/checkout would fall
+          # back to its own default ref — on this job's pull_request_target
+          # leg that is the PR MERGE ref, i.e. PR-controlled code under the
+          # writer's write-capable token. The fallback value is repo-owned
+          # config: ADAPT it to the repo's default branch on copy.
           ref: ${{ github.event.repository.default_branch || 'main' }}
           persist-credentials: false
 

--- a/skills/review-gate/tests/review-writer.test.sh
+++ b/skills/review-gate/tests/review-writer.test.sh
@@ -556,7 +556,10 @@ if grep -qF -- "actions: write" "$TEMPLATE"; then
 else
   PASS=$((PASS + 1)); printf '  ok    %s\n' "tpl: no actions:write — the writer never re-runs CI"
 fi
-pin 'ref: ${{ github.event.repository.default_branch }}' "tpl: engine runs from the default branch"
+# The || 'main' arm keeps an empty default_branch expression from letting
+# actions/checkout fall back to its own default ref — on pull_request_target
+# that is the PR merge ref under a write-capable token.
+pin "ref: \${{ github.event.repository.default_branch || 'main' }}" "tpl: engine runs from the default branch (empty-expression fallback pinned)"
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/skills/review-gate/tests/review-writer.test.sh
+++ b/skills/review-gate/tests/review-writer.test.sh
@@ -557,9 +557,22 @@ else
   PASS=$((PASS + 1)); printf '  ok    %s\n' "tpl: no actions:write — the writer never re-runs CI"
 fi
 # The || 'main' arm keeps an empty default_branch expression from letting
-# actions/checkout fall back to its own default ref — on pull_request_target
-# that is the PR merge ref under a write-capable token.
-pin "ref: \${{ github.event.repository.default_branch || 'main' }}" "tpl: engine runs from the default branch (empty-expression fallback pinned)"
+# actions/checkout fall back to its own default ref — the merge-group job
+# would get the queue's synthetic ref, the write job's pull_request_target
+# leg the PR merge ref, both under a write-capable token. BOTH checkouts
+# are counted: a one-match pin would stay green if either job regressed to
+# the bare expression.
+fallback_ref_count="$(grep -cF -- "ref: \${{ github.event.repository.default_branch || 'main' }}" "$TEMPLATE" || true)"
+if [[ "$fallback_ref_count" == "2" ]]; then
+  PASS=$((PASS + 1)); printf '  ok    %s\n' "tpl: BOTH checkouts pin the default branch with the empty-expression fallback"
+else
+  FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        expected exactly 2 fallback refs, found %s\n' "tpl: BOTH checkouts pin the default branch with the empty-expression fallback" "$fallback_ref_count"
+fi
+if grep -qF -- 'ref: ${{ github.event.repository.default_branch }}' "$TEMPLATE"; then
+  FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "tpl: a checkout regressed to the bare default_branch expression (empty resolution would reach actions/checkout's own fallback)"
+else
+  PASS=$((PASS + 1)); printf '  ok    %s\n' "tpl: no checkout uses the bare default_branch expression"
+fi
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"


### PR DESCRIPTION
Consumer-review findings from hyprtrade#525's fresh CodeRabbit round, fixed at the source (threads bOND, bONE, and the template half of bONB there):

## lib/settings.sh — grep operand order (bOND)

BSD grep stops option parsing at the first non-option operand, so `grep -Eq "pattern" -- "$file"` can read the trailing `--` as a filename. The presence check then fails and `rg_setting` silently returns the caller default — on the predicate's trusted-logins path that default is empty, i.e. "any non-author review counts". All four rg_setting greps now place `--` before the pattern.

## Snapshot seam bound to the LIST endpoint shape (bONE)

The `REVIEW_GATE_STATUS_SNAPSHOT_FILE` contract (predicate header + `references/settings.md`) previously pointed callers at the combined-status endpoint — the exact endpoint the fetch path abandoned because it serializes `creator` as null for App-posted rows. Under a configured `REVIEW_GATE_STATUS_PUBLISHER_REJECT`, the downstream anomaly rule drops login-less rows as not-evidence, so a combined-shape snapshot would silently erase real evidence (fail-closed, no forgery — but wrongly rejected legit rows).

The seam is now documented as LIST-endpoint shaped, and while the reject list is configured it refuses login-less rows loudly (exit 2) instead of silently evaluating publisher-blind evidence. With the reject list empty (the shipped default) behavior is unchanged. Selftest grows two cases — the refusal and the filter-off control — 201 total.

## Template checkout ref fallback (bONB, template half)

Both default-branch checkouts in `templates/review-gate-writer.yml` get `ref: ${{ github.event.repository.default_branch || 'main' }}`: if the expression ever resolves empty on some event leg, actions/checkout falls back to its own default ref — on `pull_request_target` that is the PR merge ref, i.e. PR-controlled code under the writer's write-capable token. The fallback value is repo-owned config (ADAPT on copy). The template pin in `review-writer.test.sh` moved with it.

## Validation

- settings-parsing, review-predicate-selftest (201/201), review-writer (99), settings-vars-documented, settings-example-sync, bash32-portability: all PASS
- Sandbox e2e replay against this tree: result posted on this PR before merge

After merge this revendors into hyprtrade#525 (the last fleet cutover PR) and propagates to drovr/memsira with the #1105 refresh.

https://claude.ai/code/session_016SCZMUvpr37gc8s4zUfvfK
