### PR TITLE
fix(review-gate): anomaly status rows mask, they never revive an older success

### DIFF
--- a/skills/review-gate/scripts/review-predicate-selftest.sh
+++ b/skills/review-gate/scripts/review-predicate-selftest.sh
@@ -504,6 +504,33 @@ CFG_CONTEXTS="mech-ctx"; CFG_PUBLISHER_REJECT="github-actions[bot]"
 status_ctx "mech-ctx" success "analysis complete" ""
 run "publisher filter set: a status with NO creator login is not evidence" awaiting
 
+# Anomaly rows MASK, they never REVIVE: a login-less row is not-evidence,
+# but dropping it from the sequence before newest-row selection would let
+# an OLDER success on the same context decide — stale approval built from
+# malformed current evidence. The anomalous newest row must read as
+# SILENCE. (Rejected-creator rows keep the opposite, deliberate semantics:
+# they are dropped before selection so a minted row can never mask real
+# rows — PR content cannot produce a login-less row, so no such lever
+# exists here.)
+reset
+CFG_CONTEXTS="mech-ctx"; CFG_PUBLISHER_REJECT="github-actions[bot]"
+jq -n '[{context:"mech-ctx",state:"success",description:"analysis complete",created_at:"2026-01-02T00:00:00Z",creator:null},
+        {context:"mech-ctx",state:"success",description:"analysis complete",created_at:"2026-01-01T00:00:00Z",creator:{login:"trusted-publisher"}}]' >"$fixtures/statuses.json"
+run "publisher filter set: a login-less NEWEST row is silence — the older success does not revive" awaiting
+
+reset
+CFG_CONTEXTS=""
+CFG_OUTAGE="mech-outage"; CFG_PUBLISHER_REJECT="github-actions[bot]"
+jq -n '[{context:"mech-outage",state:"success",description:"reviewer down",created_at:"2026-01-02T00:00:00Z",creator:null},
+        {context:"mech-outage",state:"success",description:"reviewer down",created_at:"2026-01-01T00:00:00Z",creator:{login:"operator"}}]' >"$fixtures/statuses.json"
+run "publisher filter set: a login-less newest OVERRIDE row is silence — the older attestation does not revive" awaiting
+
+reset
+CFG_CONTEXTS="mech-ctx"; CFG_PUBLISHER_REJECT=""
+jq -n '[{context:"mech-ctx",state:"success",description:"analysis complete",created_at:"2026-01-02T00:00:00Z",creator:null},
+        {context:"mech-ctx",state:"success",description:"analysis complete",created_at:"2026-01-01T00:00:00Z",creator:{login:"trusted-publisher"}}]' >"$fixtures/statuses.json"
+run "publisher filter unset: the login-less newest row itself counts (filter off, default unchanged)" approved
+
 reset
 CFG_CONTEXTS="mech-ctx"; CFG_PUBLISHER_REJECT=""
 status_ctx "mech-ctx" success "analysis complete" "github-actions[bot]"

--- a/skills/review-gate/scripts/review-predicate.sh
+++ b/skills/review-gate/scripts/review-predicate.sh
@@ -506,10 +506,18 @@ while IFS= read -r ctx; do
   # choosing the newest — a rejected creator is "not evidence either way",
   # and letting a minted row mask real rows would hand PR content a
   # close-the-gate lever it should not have (only toward closed, but still
-  # not its call). The newest ACCEPTED row must then itself be a clean
-  # success: a newest row that is pending/failure, or a skip-filtered
-  # success ("rate limited"), is silence — exactly what the combined
-  # endpoint's projection used to yield.
+  # not its call). Login-less ANOMALY rows are the opposite: they are NOT
+  # dropped from the sequence — dropped-before-newest they would revive an
+  # OLDER success (stale approval from malformed current evidence); kept,
+  # an anomalous NEWEST row reads as silence. Safe against the minting
+  # lever because PR content cannot produce a login-less row (its statuses
+  # carry github-actions[bot], which is what the reject list names), and a
+  # GitHub-side anomaly (a ghost/deleted creator) masks toward CLOSED, and
+  # only until a real row supersedes it. The newest ACCEPTED row must then
+  # itself be a clean success: a newest row that is pending/failure, a
+  # skip-filtered success ("rate limited"), or — while the reject list is
+  # configured — a login-less anomaly, is silence — exactly what the
+  # combined endpoint's projection used to yield.
   check_status="$(jq --arg ctx "$ctx" --arg skips "$SKIP_PATTERNS" --arg reject "$PUBLISHER_REJECT" '
       ($skips | split(";") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0)) | map(ascii_downcase)) as $sk
       | ($reject | split(";") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0))) as $rj
@@ -518,8 +526,10 @@ while IFS= read -r ctx; do
           # Bind the login BEFORE index(): inside index(...) the dot rebinds
           # to $rj, so `.creator` would index the reject ARRAY, not the
           # status. Same rebinding trap the comment-form matcher documents.
+          # Only LISTED creators are dropped; login-less rows stay in the
+          # sequence (see the anomaly rationale above).
           | (.creator.login // "") as $cl
-          | select(($rj | length) == 0 or ($cl != "" and ($rj | index($cl)) == null))
+          | select(($rj | length) == 0 or ($cl == "") or (($cl | type) != "string") or (($rj | index($cl)) == null))
         ]
       # FIRST accepted row, not sort_by(created_at)|last: the API lists
       # statuses newest-first (the writer and driver already rely on it),
@@ -528,6 +538,11 @@ while IFS= read -r ctx; do
       # reintroduce exactly the stale-evidence read this projection closes.
       | first
       | if . == null then 0
+        elif ($rj | length) > 0
+             and (((.creator | type) != "object")
+                  or ((.creator.login | type) != "string")
+                  or ((.creator.login | length) == 0))
+        then 0
         elif .state == "success"
              and ((((.description // "") | ascii_downcase) as $text
                    | [ $sk[] | . as $p | select($text | contains($p)) ] | length) == 0)
@@ -622,7 +637,10 @@ if [ -n "$OUTAGE_CONTEXT" ]; then
   # read above: on the LIST endpoint every real publisher (Apps included)
   # carries a creator login, so while the reject list is configured a
   # status with NO login is an anomaly and is not evidence — trusting
-  # anomalies is the fail-open direction. List empty (the default) = filter
+  # anomalies is the fail-open direction. And same SEQUENCE semantics:
+  # anomaly rows stay in the newest-row selection (an anomalous newest row
+  # is silence, never a hole an older success shines through), only listed
+  # creators are dropped before it. List empty (the default) = filter
   # off = unchanged behavior.
   # The REASON is mandatory (plan Change 2, finding 9, carried from the
   # outage semantics): an override with an empty description is not an
@@ -640,12 +658,17 @@ if [ -n "$OUTAGE_CONTEXT" ]; then
     | [ .statuses[]
         | select(.context == $ctx)
         | (.creator.login // "") as $cl
-        | select(($rj | length) == 0 or ($cl != "" and ($rj | index($cl)) == null))
+        | select(($rj | length) == 0 or ($cl == "") or (($cl | type) != "string") or (($rj | index($cl)) == null))
       ]
     # FIRST accepted row — same newest-first API-order reliance and
     # second-precision tie rationale as the trusted-context read above.
     | first
     | if . == null then "0\t"
+      elif ($rj | length) > 0
+           and (((.creator | type) != "object")
+                or ((.creator.login | type) != "string")
+                or ((.creator.login | length) == 0))
+      then "0\t"
       elif .state == "success"
            and (((.description // "") | gsub("^\\s+|\\s+$"; "") | length) > 0)
       then "1\t\((.description // "") | gsub("[\n\r\t]"; " "))"


### PR DESCRIPTION
qodo finding on hyprtrade#525 (thread bqoz): with a configured publisher reject list, the live status readers dropped login-less rows before newest-row selection, so an older success on the same trusted/override context could resurface — stale approval from malformed current evidence. Anomaly rows now stay in the newest-row sequence and an anomalous newest row reads as silence, in both readers. Rejected-creator rows keep their deliberate drop-before-selection semantics (PR content can mint those; it cannot produce a login-less row). Reject-list-off default unchanged. Selftest +3 cases (205/205): both revival shapes plus the filter-off control.

https://claude.ai/code/session_016SCZMUvpr37gc8s4zUfvfK