### PR TITLE
fix(review-gate): consumer-review batch — guard re-read shape validation; wording accuracy; test teeth

### DIFF
--- a/.github/workflows/review-gate-writer.yml
+++ b/.github/workflows/review-gate-writer.yml
@@ -186,10 +186,11 @@ jobs:
         with:
           # `|| 'main'` fallback: if the default_branch expression ever
           # resolved empty on some event leg, actions/checkout would fall
-          # back to its own default ref — on this job's pull_request_target
-          # leg that is the PR MERGE ref, i.e. PR-controlled code under the
-          # writer's write-capable token. 'main' is this repo's default
-          # branch (repo-owned ADAPT).
+          # back to the EVENT's own default ref, which is not necessarily
+          # the default branch — e.g. the PR's BASE branch on the
+          # pull_request_target leg (a PR targeting a non-default branch
+          # would run THAT branch's engine under the writer's write-capable
+          # token). 'main' is this repo's default branch (repo-owned ADAPT).
           ref: ${{ github.event.repository.default_branch || 'main' }}
           persist-credentials: false
 

--- a/skills/review-gate/scripts/review-predicate-selftest.sh
+++ b/skills/review-gate/scripts/review-predicate-selftest.sh
@@ -973,18 +973,19 @@ export GH_SHIM_EMPTY=comments
 run "zero-byte comments producer is a failed read" "" 2
 unset GH_SHIM_EMPTY
 
-# Status-snapshot seam (VST-35): a caller that already holds the combined
-# status hands it in; the predicate must evaluate against it WITHOUT its own
-# combined-status read (proven by failing that endpoint), and an unreadable
-# or malformed snapshot gets the read contract: exit 2. The snapshot must be
-# BOUND to this head (top-level sha == HEAD_SHA, VST-71): a snapshot for
-# another head passing shape validation would evaluate stale evidence.
+# Status-snapshot seam (VST-35): a caller that already holds the head's
+# LIST-endpoint status rows hands them in (wrapped {sha, statuses}); the
+# predicate must evaluate against them WITHOUT its own statuses read
+# (proven by failing that endpoint), and an unreadable or malformed
+# snapshot gets the read contract: exit 2. The snapshot must be BOUND to
+# this head (top-level sha == HEAD_SHA, VST-71): a snapshot for another
+# head passing shape validation would evaluate stale evidence.
 reset
 CFG_CONTEXTS="mech-ctx"
 jq -n --arg sha "$HEAD" '{sha:$sha,statuses:[{context:"mech-ctx",state:"success",description:"analysis complete",created_at:"2026-01-01T00:00:00Z",creator:{login:"trusted-publisher"}}]}' >"$fixtures/snapshot.json"
 CFG_SNAPSHOT="$fixtures/snapshot.json"
 export GH_SHIM_FAIL=statuses
-run "snapshot seam: caller-supplied combined status (sha-bound) is evaluated, duplicate read skipped" approved
+run "snapshot seam: caller-supplied list-endpoint snapshot (sha-bound) is evaluated, duplicate read skipped" approved
 unset GH_SHIM_FAIL
 
 reset
@@ -1229,12 +1230,18 @@ compare_fix ahead "[$DOCS_DELTA]"
 printf '[]\n' >"$fixtures/compare.page2.json"
 run "carry: a non-object later compare page is exit 2, never a partial classification" "" 2
 
+# Files ride page one ONLY (the real API shape — compare pagination
+# paginates commits, never files), so a files array on a later page is
+# deliberately ignored, not merged: this pins that a later-page "files"
+# entry cannot smuggle rows into the classification. The fixture plants a
+# CODE file there — if a regression ever merged later pages, the docs-only
+# carry below would flip to awaiting and this case would catch it.
 reset
 carry_candidate
 CFG_CARRY="docs"
 compare_fix ahead "[$DOCS_DELTA]"
-jq -n --argjson f "[$DOCS_DELTA]" '{status:"ahead",files:$f}' >"$fixtures/compare.page2.json"
-run "carry: a healthy later compare page merges into the classification" approved
+jq -n '{status:"ahead",files:[{filename:"src/smuggled.sh",status:"modified",patch:"@@ -1 +1 @@\n-a\n+b"}]}' >"$fixtures/compare.page2.json"
+run "carry: a later-page files array is ignored, never merged (files ride page one only)" approved
 
 reset
 carry_candidate

--- a/skills/review-gate/scripts/review-predicate.sh
+++ b/skills/review-gate/scripts/review-predicate.sh
@@ -351,15 +351,16 @@ got="$(jq --arg sha "$HEAD_SHA" --arg author "$PR_AUTHOR" \
 # to not-evidence — the same as absent, never a failure. A read FAILURE here
 # must fail LOUDLY: treating it as absent evidence could flip a healthy PR's
 # merge state on a transient API hiccup.
-# The combined-status endpoint paginates its statuses array (default 30
-# contexts per page), so fetch EVERY page (fail loud) and merge them into one
-# snapshot — each trusted context and the outage attestation below evaluate
-# against it. Fetch and merge are SEPARATE steps for the same reason as the
-# check-runs read: a pipe would replace gh's exit status with jq's and turn a
-# read failure into an empty-success (fail-open). A caller that already holds
-# the combined status (a converge-style sweep projecting required statuses
-# per head) hands it in via REVIEW_GATE_STATUS_SNAPSHOT_FILE instead, and
-# this read is skipped entirely.
+# The statuses LIST endpoint paginates (100 rows per page here), so fetch
+# EVERY page (fail loud) and merge them into one snapshot — each trusted
+# context and the outage attestation below evaluate against it. Fetch and
+# merge are SEPARATE steps for the same reason as the check-runs read: a
+# pipe would replace gh's exit status with jq's and turn a read failure
+# into an empty-success (fail-open). A caller that already holds the
+# LIST-endpoint rows (a converge-style sweep projecting required statuses
+# per head) hands them in via REVIEW_GATE_STATUS_SNAPSHOT_FILE instead
+# (wrapped {sha, statuses} per the header contract), and this read is
+# skipped entirely.
 if [ -n "${REVIEW_GATE_STATUS_SNAPSHOT_FILE:-}" ]; then
   # The snapshot substitutes for a READ, so it gets the read contract: not a
   # file, zero bytes, unparseable, missing the statuses array, or not bound

--- a/skills/review-gate/scripts/review-writer.sh
+++ b/skills/review-gate/scripts/review-writer.sh
@@ -249,9 +249,13 @@ fi
 # state. Fetch and filter are SEPARATE steps: a pipe would replace gh's exit
 # status with jq's, so a failed or truncated re-read could slurp to an empty
 # array and report newer=0 — the exact stale-success fail-open this guard
-# closes. A failed re-read defers too. And `>=`, not `>`: both timestamps
-# have one-second resolution, so a write landing later within the evaluation
-# second compares EQUAL — deferring on equality self-heals.
+# closes. A failed re-read defers too — and so does a MALFORMED one: the
+# same non-vacuous all-arrays validation as the projection read above,
+# because a whitespace-only success slurps to [] and a non-array page
+# collapses through `add`, both reporting newer=0 and permitting exactly
+# the stale success this guard exists to block. And `>=`, not `>`: both
+# timestamps have one-second resolution, so a write landing later within
+# the evaluation second compares EQUAL — deferring on equality self-heals.
 #
 # The re-read deliberately uses bare `gh api`, not a retry wrapper (the
 # predicate's gh_read is predicate-internal): every failure mode here lands
@@ -262,9 +266,11 @@ guard_newer=""
 if guard_pages="$(gh api "repos/$GH_REPO/commits/$HEAD_SHA/statuses?per_page=100" --paginate)" \
    && [ -n "$guard_pages" ]; then
   guard_newer="$(jq -rs --arg ctx "$GATE_CONTEXT" --arg since "$evaluated_at" \
-      '[add // [] | .[] | select(.context == $ctx
-        and (($since | length) > 0) and ((.created_at // "") >= $since))] | length' \
-      <<<"$guard_pages")" || guard_newer=""
+      'if (length > 0) and all(type == "array")
+       then [add | .[] | select(.context == $ctx
+         and (($since | length) > 0) and ((.created_at // "") >= $since))] | length
+       else error("guard re-read pages are not arrays") end' \
+      <<<"$guard_pages" 2>/dev/null)" || guard_newer=""
 fi
 if [ "$guard_newer" != "0" ]; then
   echo "::warning::deferring the success post: $GATE_CONTEXT was re-written (or unreadable) after this run's evaluation at $evaluated_at — a newer writer run's verdict stands; the next pass converges"

--- a/skills/review-gate/templates/review-gate-writer.yml
+++ b/skills/review-gate/templates/review-gate-writer.yml
@@ -181,10 +181,12 @@ jobs:
         with:
           # `|| 'main'` fallback: if the default_branch expression ever
           # resolved empty on some event leg, actions/checkout would fall
-          # back to its own default ref — on this job's pull_request_target
-          # leg that is the PR MERGE ref, i.e. PR-controlled code under the
-          # writer's write-capable token. The fallback value is repo-owned
-          # config: ADAPT it to the repo's default branch on copy.
+          # back to the EVENT's own default ref, which is not necessarily
+          # the default branch — e.g. the PR's BASE branch on the
+          # pull_request_target leg (a PR targeting a non-default branch
+          # would run THAT branch's engine under the writer's write-capable
+          # token). The fallback value is repo-owned config: ADAPT it to
+          # the repo's default branch on copy.
           ref: ${{ github.event.repository.default_branch || 'main' }}
           persist-credentials: false
 

--- a/skills/review-gate/tests/review-writer.test.sh
+++ b/skills/review-gate/tests/review-writer.test.sh
@@ -314,6 +314,22 @@ assert_eq "$rc" "0" "w11: failed guard re-read defers with exit 0 (fail-safe sid
 assert_contains "$out" "deferring the success post" "w11: names the deferral"
 assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "w11: no post on an unreadable re-read"
 
+# A MALFORMED re-read must land on the same fail-safe side as a failed one:
+# a whitespace-only success slurps to [] and an error-object page collapses
+# through `add` — both would report newer=0 and permit exactly the stale
+# success the guard exists to block.
+rc=0; out=$(run_writer STUB_VERDICT_LINE="$APPROVED" STUB_GATE_HISTORY="$PENDING_OLD" \
+  STUB_GUARD_HISTORY=$' \n  \n') || rc=$?
+assert_eq "$rc" "0" "w11b: whitespace-only guard re-read defers with exit 0"
+assert_contains "$out" "deferring the success post" "w11b: names the deferral"
+assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "w11b: no post past a vacuous guard re-read"
+
+rc=0; out=$(run_writer STUB_VERDICT_LINE="$APPROVED" STUB_GATE_HISTORY="$PENDING_OLD" \
+  STUB_GUARD_HISTORY='{"message":"Server Error"}') || rc=$?
+assert_eq "$rc" "0" "w11c: error-object guard re-read defers with exit 0"
+assert_contains "$out" "deferring the success post" "w11c: names the deferral"
+assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "w11c: no post past a malformed guard re-read"
+
 rc=0; out=$(run_writer STUB_VERDICT_LINE="$CR" STUB_GATE_HISTORY="$PENDING_OLD" \
   STUB_GUARD_HISTORY='[{"context":"Review gate","state":"pending","description":"newer","created_at":"'"$FUTURE"'"}]') || rc=$?
 assert_contains "$(cat "$POST_LOG")" "state=failure" "w12: downward posts never consult the guard"
@@ -452,7 +468,13 @@ assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "w22e: posts nothing"
 
 rc=0; out=$(run_writer STUB_VERDICT_LINE="$APPROVED" STUB_GATE_HISTORY='{"message":"Server Error"}' 2>&1) || rc=$?
 assert_eq "$rc" "1" "w22f: an error-object status page exits 1"
+assert_contains "$out" "not arrays" "w22f: names the shape violation (a red for another reason is not this guard)"
 assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "w22f: no post past a malformed status page"
+
+rc=0; out=$(run_writer STUB_VERDICT_LINE="$APPROVED" STUB_GATE_HISTORY=$' \n  \n' 2>&1) || rc=$?
+assert_eq "$rc" "1" "w22g: a whitespace-only status-history read exits 1 (slurps to [], not an empty status set)"
+assert_contains "$out" "not arrays" "w22g: names the shape violation"
+assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "w22g: posts nothing"
 
 # A ghost-authored PR (user serialized null) enumerates with an empty
 # author; the predicate resolves the real author itself downstream.
@@ -557,10 +579,11 @@ else
   PASS=$((PASS + 1)); printf '  ok    %s\n' "tpl: no actions:write — the writer never re-runs CI"
 fi
 # The || 'main' arm keeps an empty default_branch expression from letting
-# actions/checkout fall back to its own default ref — the merge-group job
-# would get the queue's synthetic ref, the write job's pull_request_target
-# leg the PR merge ref, both under a write-capable token. BOTH checkouts
-# are counted: a one-match pin would stay green if either job regressed to
+# actions/checkout fall back to the event's own default ref — the
+# merge-group job would get the queue's synthetic ref, the write job's
+# pull_request_target leg the PR's BASE branch (not necessarily the
+# default branch), both under a write-capable token. BOTH checkouts are
+# counted: a one-match pin would stay green if either job regressed to
 # the bare expression.
 fallback_ref_count="$(grep -cF -- "ref: \${{ github.event.repository.default_branch || 'main' }}" "$TEMPLATE" || true)"
 if [[ "$fallback_ref_count" == "2" ]]; then

--- a/skills/review-gate/tests/review-writer.test.sh
+++ b/skills/review-gate/tests/review-writer.test.sh
@@ -324,9 +324,14 @@ assert_eq "$rc" "0" "w11b: whitespace-only guard re-read defers with exit 0"
 assert_contains "$out" "deferring the success post" "w11b: names the deferral"
 assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "w11b: no post past a vacuous guard re-read"
 
+# EMPTY object, deliberately: `{"message":...}` would have deferred under
+# the OLD filter too (`.[]` yields the string, `.context` on a string is a
+# jq error → guard_newer="" → defer), proving nothing. `{}` collapses
+# through the old `add // [] | .[]` to zero rows → newer=0 → stale success
+# POSTS under the old code; only the all-arrays validation defers it.
 rc=0; out=$(run_writer STUB_VERDICT_LINE="$APPROVED" STUB_GATE_HISTORY="$PENDING_OLD" \
-  STUB_GUARD_HISTORY='{"message":"Server Error"}') || rc=$?
-assert_eq "$rc" "0" "w11c: error-object guard re-read defers with exit 0"
+  STUB_GUARD_HISTORY='{}') || rc=$?
+assert_eq "$rc" "0" "w11c: empty-object guard re-read defers with exit 0 (the old filter posted through it)"
 assert_contains "$out" "deferring the success post" "w11c: names the deferral"
 assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "w11c: no post past a malformed guard re-read"
 

--- a/skills/review-gate/tests/settings-vars-documented.test.sh
+++ b/skills/review-gate/tests/settings-vars-documented.test.sh
@@ -29,7 +29,7 @@ for v in $vars; do
   # Env-only per-invocation seams, not settings keys — they must not appear
   # as settings assignments (REVIEW_GATE_SETTINGS_FILE overrides the file
   # path in tests; REVIEW_GATE_STATUS_SNAPSHOT_FILE hands one head's
-  # combined-status snapshot in from a converge-style caller). The absence is the contract: an
+  # LIST-endpoint status snapshot in from a converge-style caller). The absence is the contract: an
   # assignment in either example would advertise a per-invocation seam as a
   # repo setting, so it must FAIL here.
   case "$v" in


### PR DESCRIPTION
Engine-side findings surfaced by the consumer refresh reviews (drovr#447/#448, memsira#445), fixed at the source:

- **Guard re-read shape validation** (real fail-open, Copilot on memsira#445): the ordering guard's status re-read accepted a whitespace-only success (slurps to `[]` → newer=0 → stale success posts). Same non-vacuous all-arrays validation as the projection read; malformed re-reads now defer. Tests w11b/w11c/w22g + a message assertion on w22f.
- **Accurate checkout-fallback comments**: `pull_request_target`'s native checkout default is the PR's BASE branch, not the merge ref — reworded event-dependent in the template, deployed workflow, and test so adopters aren't taught the wrong model.
- **LIST-endpoint wording**: fetch-path comment, selftest seam block/case name, settings-vars-documented note aligned with the #1106 seam contract.
- **Selftest de-vacuation**: the later-compare-page merge case couldn't fail since #1105 made files page-one-only; replaced with a smuggled-code-file fixture that pins later-page files as ignored.

All local suites pass. Consumers pick this up in their open refresh PRs.

https://claude.ai/code/session_016SCZMUvpr37gc8s4zUfvfK