### PR TITLE
fix(review-gate): evidence reads validate page shape — vacuous bodies are broken reads, never empty evidence

### DIFF
--- a/skills/review-gate/scripts/review-predicate-selftest.sh
+++ b/skills/review-gate/scripts/review-predicate-selftest.sh
@@ -1018,10 +1018,15 @@ CFG_CONTEXTS="mech-ctx"
 printf '\n   \n' >"$fixtures/checkruns.json"
 run "whitespace-only check-runs response is exit 2, not silence" "" 2
 
+# OBJECT without check_runs, deliberately: an array fixture failed under
+# the OLD merger too (`.check_runs` on an array is a jq error), proving
+# nothing. `{}` collapsed through the old `map(.check_runs) | add // []`
+# to an EMPTY run set — silence built from a broken read; only the new
+# shape guard turns it into exit 2.
 reset
 CFG_CONTEXTS="mech-ctx"
-printf '[]\n' >"$fixtures/checkruns.json"
-run "check-runs page without a check_runs array is exit 2" "" 2
+printf '{}\n' >"$fixtures/checkruns.json"
+run "check-runs page without a check_runs array is exit 2 (the old merger read it as silence)" "" 2
 
 reset
 CFG_REVIEWERS="mech-bot[bot]:Reviewed commit:"

--- a/skills/review-gate/scripts/review-predicate-selftest.sh
+++ b/skills/review-gate/scripts/review-predicate-selftest.sh
@@ -1000,6 +1000,34 @@ export GH_SHIM_EMPTY=comments
 run "zero-byte comments producer is a failed read" "" 2
 unset GH_SHIM_EMPTY
 
+# Vacuous and non-array pages (the whitespace shape passes the zero-byte
+# guard yet slurps to nothing): the reviews case is the dangerous one — []
+# built from a broken read erases a standing CHANGES_REQUESTED while other
+# evidence satisfies the positive side. Check-run and comment pages get the
+# same contract; wrong-shaped pages are exit 2, never empty evidence.
+reset
+printf '\n   \n' >"$fixtures/reviews.json"
+run "whitespace-only reviews response is exit 2, not an empty review set" "" 2
+
+reset
+printf '{"message":"Server Error"}\n' >"$fixtures/reviews.json"
+run "error-object reviews page is exit 2, not an empty review set" "" 2
+
+reset
+CFG_CONTEXTS="mech-ctx"
+printf '\n   \n' >"$fixtures/checkruns.json"
+run "whitespace-only check-runs response is exit 2, not silence" "" 2
+
+reset
+CFG_CONTEXTS="mech-ctx"
+printf '[]\n' >"$fixtures/checkruns.json"
+run "check-runs page without a check_runs array is exit 2" "" 2
+
+reset
+CFG_REVIEWERS="mech-bot[bot]:Reviewed commit:"
+printf '\n   \n' >"$fixtures/comments.json"
+run "whitespace-only comments response is exit 2, not absent evidence" "" 2
+
 # Status-snapshot seam (VST-35): a caller that already holds the head's
 # LIST-endpoint status rows hands them in (wrapped {sha, statuses}); the
 # predicate must evaluate against them WITHOUT its own statuses read

--- a/skills/review-gate/scripts/review-predicate.sh
+++ b/skills/review-gate/scripts/review-predicate.sh
@@ -278,7 +278,11 @@ fi
 # reviews read specifically an empty result can erase a standing
 # CHANGES_REQUESTED while other evidence still satisfies the positive side —
 # a false approved. An intentionally empty page set from a real API response
-# is a NON-EMPTY `[]` body, so only a bytes-empty producer is refused.
+# is a NON-EMPTY `[]` body, so only a bytes-empty producer is refused — and
+# the merge validates page SHAPE, not just parse success: a whitespace-only
+# body passes the zero-byte check yet slurps to [] (vacuously "no reviews"),
+# and an error-object page would collapse through `add` — both erase a
+# standing CHANGES_REQUESTED. A broken read is exit 2, never empty evidence.
 raw_reviews="$(gh_read "repos/$GH_REPO/pulls/$PR_NUMBER/reviews?per_page=100" --paginate)" || {
   echo "::error::could not read reviews for PR #$PR_NUMBER" >&2
   exit 2
@@ -287,8 +291,10 @@ if [ -z "$raw_reviews" ]; then
   echo "::error::reviews read for PR #$PR_NUMBER produced zero bytes (broken read, not an empty page set)" >&2
   exit 2
 fi
-reviews="$(jq -s 'add // []' <<<"$raw_reviews")" || {
-  echo "::error::could not parse reviews for PR #$PR_NUMBER" >&2
+reviews="$(jq -s 'if (length > 0) and all(type == "array")
+                  then add
+                  else error("review pages are not arrays") end' <<<"$raw_reviews" 2>/dev/null)" || {
+  echo "::error::reviews read for PR #$PR_NUMBER returned non-array pages or a vacuous body (broken read)" >&2
   exit 2
 }
 # Changes-requested reduces each reviewer over their DECISIVE states only
@@ -456,8 +462,14 @@ while IFS= read -r ctx; do
     echo "::error::'$ctx' check-runs read produced zero bytes (broken read)" >&2
     exit 2
   fi
-  checkruns_resp="$(jq -s '{check_runs: (map(.check_runs) | add // [])}' <<<"$checkruns_pages")" || {
-    echo "::error::could not merge '$ctx' check-run pages" >&2
+  # Page-shape validation, same reasoning as the reviews read: a
+  # whitespace-only body slurps to [] and a non-object page (or one with no
+  # check_runs array) would collapse to an empty run set — silence built
+  # from a broken read. Exit 2 instead.
+  checkruns_resp="$(jq -s 'if (length > 0) and all((type == "object") and ((.check_runs | type) == "array"))
+                           then {check_runs: (map(.check_runs) | add)}
+                           else error("check-run pages are malformed") end' <<<"$checkruns_pages" 2>/dev/null)" || {
+    echo "::error::'$ctx' check-run pages are malformed or vacuous (broken read)" >&2
     exit 2
   }
   # Bind each skip pattern to a variable BEFORE testing containment: inside
@@ -580,8 +592,14 @@ if [ -n "$COMMENT_REVIEWERS" ]; then
     echo "::error::issue-comments read for PR #$PR_NUMBER produced zero bytes (broken read, not an empty page set)" >&2
     exit 2
   fi
-  comments="$(jq -s 'add // []' <<<"$raw_comments")" || {
-    echo "::error::could not parse issue comments for PR #$PR_NUMBER" >&2
+  # Same page-shape validation as the reviews read: whitespace slurps to
+  # [] and an error-object page collapses through `add` — either would
+  # vaporize comment-form evidence (wrong direction: strands at awaiting)
+  # on a broken read that should be exit 2.
+  comments="$(jq -s 'if (length > 0) and all(type == "array")
+                     then add
+                     else error("comment pages are not arrays") end' <<<"$raw_comments" 2>/dev/null)" || {
+    echo "::error::issue-comments read for PR #$PR_NUMBER returned non-array pages or a vacuous body (broken read)" >&2
     exit 2
   }
   while IFS= read -r pair; do


### PR DESCRIPTION
Copilot finding on hyprtrade#525: the reviews merge (`jq -s 'add // []'`) accepted a whitespace-only successful response — passes the zero-byte guard, slurps to [], erases a standing CHANGES_REQUESTED → false approved with another evidence source present. Same shape on the issue-comments and check-runs merges. All three now enforce the non-vacuous correctly-shaped-pages contract (#1105 gave the statuses read, #1109 the writer's guard re-read); broken reads are exit 2. Selftest +5 cases (210/210).

https://claude.ai/code/session_016SCZMUvpr37gc8s4zUfvfK