### PR TITLE
docs: sweep the last v1 instruction residue (engine headers, approval-wait, settings examples)

### DIFF
--- a/skills/orch/scripts/approval-wait
+++ b/skills/orch/scripts/approval-wait
@@ -90,9 +90,10 @@
 # merges on review evidence, the orch-side "proceeded" alone does not unblock
 # the merge — that gate runs on events, not on orch's wait deadline. When this
 # names a commit-status context, a review-mode proceed posts that context as
-# `success` on the proceeded head, giving such a gate a signal to accept (as an
-# extra review-evidence surface) and its status re-fire bridge an event to re-run
-# on. Approval mode never posts it (its silence signal excludes reviewer checks,
+# `success` on the proceeded head, giving such a gate a signal to accept (the
+# review-gate predicate's override term) — the review-gate writer converges the
+# gate on the attestation's own status event.
+# Approval mode never posts it (its silence signal excludes reviewer checks,
 # and a status cannot satisfy native required-approvals).
 # It is a branch-protection relaxation bounded by the same genuine-silence
 # predicate as the proceed itself and by bot-only status trust; match-by-context,
@@ -276,9 +277,9 @@ esac
 # a signal it can accept — CI runs on events,
 # not on a wait deadline, so it has no notion of "orch hit the deadline". If
 # this names a commit-status context, orch posts that context as `success` on
-# the proceeded head (below): the repo's CI gate can add it as an accepted
-# review-evidence surface, and its status re-fire bridge re-runs the gate on the
-# status event, turning the required check green. SECURITY: this is a
+# the proceeded head (below): the review-gate predicate accepts it as its
+# override evidence term, and the review-gate writer converges the required
+# gate status on the attestation's status event. SECURITY: this is a
 # branch-protection relaxation — the status lets a merge proceed with no review.
 # It is bounded by the same hardened predicate that gates the proceed itself
 # (genuine silence only) and by the bot-only trust of the status API, and it is
@@ -650,8 +651,8 @@ post_nudge() {
 # Attest a reviewer-outage on the proceeded head (PR_REVIEW_OUTAGE_CONTEXT).
 # Called only from the proceed path, so it inherits that path's guarantee of
 # genuine reviewer silence. Posts the configured context as `success` on the
-# exact head so a repo whose CI gate reads it can turn its required check green
-# and its status re-fire bridge can re-run the gate; head-pinned, so a later
+# exact head so the review-gate writer can converge the required gate status
+# on the attestation's status event; head-pinned, so a later
 # force-push (a new head with no marker) never rides a stale attestation. A
 # failure warns but never blocks the proceed verdict — the orch-side degrade
 # stands regardless; the marker is best-effort plumbing for repo-side CI.

--- a/skills/orch/vstack.settings.toml.example
+++ b/skills/orch/vstack.settings.toml.example
@@ -49,8 +49,8 @@ PR_REVIEW_ON_TIMEOUT = "block"
 # merges on review evidence (that gate runs on events, not on orch's wait
 # deadline, so the orch-side "proceeded" alone cannot unblock it). When this
 # names a commit-status context, a review-mode proceed posts that context as `success` on
-# the proceeded head; the repo's CI gate can accept it as an extra
-# review-evidence surface, and its status re-fire bridge re-runs the gate on
+# the proceeded head; the review-gate predicate accepts it as its override
+# evidence term, and the review-gate writer converges the gate status on
 # the event. Empty (default) = post nothing (orch-side-only opt-in — the
 # repo-side gate is untouched). SECURITY: this is a branch-protection
 # relaxation — the status lets a merge proceed with no review. It is bounded by

--- a/skills/orch/vstack.settings.toml.example
+++ b/skills/orch/vstack.settings.toml.example
@@ -51,8 +51,12 @@ PR_REVIEW_ON_TIMEOUT = "block"
 # names a commit-status context, a review-mode proceed posts that context as `success` on
 # the proceeded head; the review-gate predicate accepts it as its override
 # evidence term, and the review-gate writer converges the gate status on
-# the event. Empty (default) = post nothing (orch-side-only opt-in — the
-# repo-side gate is untouched). SECURITY: this is a branch-protection
+# the event. PAIRING REQUIRED: the predicate reads its own
+# REVIEW_GATE_OVERRIDE_CONTEXT (legacy alias REVIEW_GATE_OUTAGE_CONTEXT) —
+# it never reads this key — so both settings must carry the SAME exact
+# context value or the posted marker is ignored and the gate stays
+# awaiting review. Empty (default) = post nothing (orch-side-only opt-in —
+# the repo-side gate is untouched). SECURITY: this is a branch-protection
 # relaxation — the status lets a merge proceed with no review. It is bounded by
 # the same genuine-silence predicate as the proceed and by bot-only status
 # trust, and matched by context, so name it ONLY where every status publisher

--- a/skills/review-gate/scripts/lib/settings.sh
+++ b/skills/review-gate/scripts/lib/settings.sh
@@ -1,6 +1,6 @@
 # shellcheck shell=bash
 # Settings resolution for the review-gate engine. Sourced (not executed) by
-# review-predicate.sh, approval-refire.sh and the selftest.
+# review-predicate.sh, review-writer.sh and the selftest.
 #
 # Resolution order for every REVIEW_GATE_* key:
 #   1. explicit environment — a SET variable wins even when set to the empty

--- a/skills/review-gate/scripts/review-predicate.sh
+++ b/skills/review-gate/scripts/review-predicate.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # Review-gate predicate — the single source of truth for "is this PR head
 # reviewed?". Shipped by the vstack review-gate skill and vendored into
-# consumers at .agents/skills/review-gate/scripts/. Callers: the repo's CI
-# gate job (posts the merge-blocking commit status from the verdict) and
-# approval-refire.sh (converges the status when review state changes).
+# consumers at .agents/skills/review-gate/scripts/. Callers: review-writer.sh
+# (the single writer, which converges the merge-blocking commit status to
+# this verdict on every leg) and the repo's ungated selftest CI job.
 #
 # Predicate: review evidence present for the CURRENT head — any of
 #   (a) a review OBJECT at the exact head from a non-author, non-dismissed,

--- a/skills/review-gate/scripts/review-predicate.sh
+++ b/skills/review-gate/scripts/review-predicate.sh
@@ -3,7 +3,10 @@
 # reviewed?". Shipped by the vstack review-gate skill and vendored into
 # consumers at .agents/skills/review-gate/scripts/. Callers: review-writer.sh
 # (the single writer, which converges the merge-blocking commit status to
-# this verdict on every leg) and the repo's ungated selftest CI job.
+# this verdict on its evaluating legs — its merge_group leg posts success
+# without evaluation, post-approval by construction, and its fork
+# pull_request_review leg is a read-only no-op) and the repo's ungated
+# selftest CI job.
 #
 # Predicate: review evidence present for the CURRENT head — any of
 #   (a) a review OBJECT at the exact head from a non-author, non-dismissed,

--- a/skills/review-gate/tests/review-writer.test.sh
+++ b/skills/review-gate/tests/review-writer.test.sh
@@ -537,8 +537,8 @@ assert_contains "$(cat "$ENV_LOG")" "OUTAGE=<unset>" "w30b: absent key leaves th
 
 echo "=== workflow template pins (review-gate-writer.yml) ==="
 
-# Grep-pins on the shipped template (precedent: workflow-eviction-routing
-# pins approval-rerun.yml). Runtime behavior of workflow-level expressions
+# Grep-pins on the shipped template (precedent: the retired
+# workflow-eviction-routing suite pinned approval-rerun.yml the same way). Runtime behavior of workflow-level expressions
 # is offline-untestable — the job-level if: evaluates on GitHub — so F4's
 # billing behavior is asserted in Layer 2 (the sandbox observes push/
 # merge-group completions as SKIPPED writer runs); these pins keep the

--- a/vstack.settings.toml.example
+++ b/vstack.settings.toml.example
@@ -126,7 +126,11 @@ PR_REVIEW_OUTAGE_CONTEXT = ""
 # merges on review evidence. When this names a commit-status context, a
 # review-mode proceed posts that context as `success` on the proceeded head; the review-gate
 # predicate accepts it as its override evidence term and the review-gate
-# writer converges the gate status on the event. Empty (default) = orch-side-only (no marker; the repo-side
+# writer converges the gate status on the event. PAIRING REQUIRED: the
+# predicate reads its own REVIEW_GATE_OVERRIDE_CONTEXT (legacy alias
+# REVIEW_GATE_OUTAGE_CONTEXT), never this key — both settings must carry
+# the SAME exact context value or the posted marker is ignored and the
+# gate stays awaiting review. Empty (default) = orch-side-only (no marker; the repo-side
 # gate is untouched). SECURITY: a branch-protection relaxation — the status
 # lets a merge proceed with no review; bounded by the genuine-silence proceed
 # predicate + bot-only status trust, matched by context, so name it ONLY where

--- a/vstack.settings.toml.example
+++ b/vstack.settings.toml.example
@@ -124,9 +124,9 @@ PR_REVIEW_OUTAGE_CONTEXT = ""
 # Used by: orch (`approval-wait`, review mode). Makes PR_REVIEW_ON_TIMEOUT=proceed
 # end-to-end on repos whose CI/branch-protection gate independently blocks
 # merges on review evidence. When this names a commit-status context, a
-# review-mode proceed posts that context as `success` on the proceeded head; the repo's CI gate can
-# accept it as an extra review-evidence surface and its status re-fire bridge
-# re-runs the gate. Empty (default) = orch-side-only (no marker; the repo-side
+# review-mode proceed posts that context as `success` on the proceeded head; the review-gate
+# predicate accepts it as its override evidence term and the review-gate
+# writer converges the gate status on the event. Empty (default) = orch-side-only (no marker; the repo-side
 # gate is untouched). SECURITY: a branch-protection relaxation — the status
 # lets a merge proceed with no review; bounded by the genuine-silence proceed
 # predicate + bot-only status trust, matched by context, so name it ONLY where


### PR DESCRIPTION
Prompted by an owner question — a systematic grep for v1-era terms across all four repos. Everything else found was legitimately historical (changelogs, decision records, migration instructions, ratchet tests); these eight passages were LIVE text still teaching deleted machinery: the engine's settings.sh/predicate headers naming approval-refire.sh as caller, approval-wait's three outage comments + both settings examples describing the retired status-re-fire bridge, and one test comment citing a retired suite in present tense. Comments/docs only. Consumer vendored copies pick the two header lines up on their next routine refresh.

https://claude.ai/code/session_016SCZMUvpr37gc8s4zUfvfK