### PR TITLE
fix(review-gate): check-runs get the newest-run projection (closes #1110)

### DIFF
--- a/.github/workflows/review-gate-writer.yml
+++ b/.github/workflows/review-gate-writer.yml
@@ -64,14 +64,19 @@ name: Review gate writer
   workflow_dispatch: {}
   # NO check_run trigger here, deliberately — per-repo OPT-IN only (plan
   # round-2 finding R3): every ordinary CI job completion fires
-  # check_run.completed, and an early-exit that needs the settings file
+  # check_run events, and an early-exit that needs the settings file
   # needs a checkout, which bills the 1-minute minimum per run on private
   # repos. A repo whose reviewer publishes check-runs AND NOTHING ELSE adds:
   #   check_run:
-  #     types: [completed]
+  #     types: [created, completed]
   # plus a job-level guard on the write job's if: matching the reviewer's
   # check name literally (the file is repo-owned after copy, so the
-  # hardcoded name is config); a job-level skip bills nothing.
+  # hardcoded name is config); a job-level skip bills nothing. `created`
+  # matters under newest-run semantics: a reviewer STARTING a fresh round
+  # withdraws its own older clean success, and without the created leg that
+  # downward transition waits for the run's completion or the cron floor.
+  # Repos without the opt-in converge withdrawals on the cron floor — the
+  # same accepted class as thread resolution.
 
 permissions:
   contents: read

--- a/skills/review-gate/README.md
+++ b/skills/review-gate/README.md
@@ -74,7 +74,11 @@ Different reviewers signal differently, so the predicate accepts any of:
 - a **review approval** at the exact head from a trusted login;
 - a **clean-analysis check or status** succeeding on that head — for bots that
   only file a review when they have complaints (a "pass" that says *rate
-  limited* or *skipped* is treated as silence, not approval);
+  limited* or *skipped* is treated as silence, not approval). On both
+  surfaces only the NEWEST row/run per name is considered: a reviewer
+  starting a fresh round withdraws its own older clean success, so a newer
+  pending, failed, or skip-marked run reads as silence, never as the old
+  approval;
 - a **comment-form pass** binding a trusted bot's comment to that head's sha;
 - an **operator override** status carrying a written reason — the escape
   hatch for when every reviewer is down. It substitutes for *missing*

--- a/skills/review-gate/SKILL.md
+++ b/skills/review-gate/SKILL.md
@@ -60,6 +60,9 @@ Evidence for the CURRENT head is any of:
    pass must prove analysis RAN: a success matching
    `REVIEW_GATE_CHECKRUN_SKIP_PATTERNS` (e.g. "rate limited") is
    NOT-EVIDENCE, never a failure. It is silence, which `awaiting` handles.
+   On BOTH surfaces the NEWEST row/run per name decides (statuses by list
+   order, check-runs by run id — vstack#1110): an older clean success never
+   outlives its reviewer's newer pending/failed/skip-marked round.
 3. **Comment-form clean pass** (`REVIEW_GATE_COMMENT_REVIEWERS`): an issue
    comment by a trusted bot login — never the PR author, even if configured —
    binding the evidence to this head's sha (floor

--- a/skills/review-gate/SKILL.md
+++ b/skills/review-gate/SKILL.md
@@ -61,8 +61,8 @@ Evidence for the CURRENT head is any of:
    `REVIEW_GATE_CHECKRUN_SKIP_PATTERNS` (e.g. "rate limited") is
    NOT-EVIDENCE, never a failure. It is silence, which `awaiting` handles.
    On BOTH surfaces the NEWEST row/run per name decides (statuses by list
-   order, check-runs by run id — vstack#1110): an older clean success never
-   outlives its reviewer's newer pending/failed/skip-marked round.
+   order, check-runs by run id): an older clean success never outlives its
+   reviewer's newer pending/failed/skip-marked round.
 3. **Comment-form clean pass** (`REVIEW_GATE_COMMENT_REVIEWERS`): an issue
    comment by a trusted bot login — never the PR author, even if configured —
    binding the evidence to this head's sha (floor

--- a/skills/review-gate/references/settings.md
+++ b/skills/review-gate/references/settings.md
@@ -17,7 +17,7 @@ ambiguity — the same name assigned more than once anywhere in the file.
 | Key | Default | Meaning |
 |---|---|---|
 | `REVIEW_GATE_CONTEXT` | `Review gate` | Gate commit-status context (the required check name). |
-| `REVIEW_GATE_TRUSTED_STATUS_CONTEXTS` | (empty) | Clean-analysis check-run/status names; either API counts. Empty disables the source — trust is opt-in per repo, never a shipped vendor default. |
+| `REVIEW_GATE_TRUSTED_STATUS_CONTEXTS` | (empty) | Clean-analysis check-run/status names; either API counts, and on both the NEWEST row/run per name decides (a newer pending/failed/skip-marked round withdraws the older success). Empty disables the source — trust is opt-in per repo, never a shipped vendor default. |
 | `REVIEW_GATE_CHECKRUN_SKIP_PATTERNS` | `rate limited;skipped;queued` | Case-insensitive substrings marking a trusted "pass" as analysis-not-run → not evidence. Empty disables. |
 | `REVIEW_GATE_COMMENT_REVIEWERS` | (empty) | `login:binding-pattern` pairs; first `:` splits; pattern is a literal prefix. Empty disables the source. |
 | `REVIEW_GATE_SHA_PREFIX_FLOOR` | `7` | Shortest sha prefix a comment may bind (4–40). |

--- a/skills/review-gate/scripts/review-predicate-selftest.sh
+++ b/skills/review-gate/scripts/review-predicate-selftest.sh
@@ -478,6 +478,62 @@ CFG_CONTEXTS="mech-ctx"
 jq -n '{check_runs:[{name:"mech-ctx",conclusion:"success",output:{title:null,summary:"analysis complete"}}]}' >"$fixtures/checkruns.json"
 run "check-run with no app slug (unprovable provenance) is not evidence" awaiting
 
+# NEWEST RUN DECIDES per name (vstack#1110), ordered by run id — the
+# check-run mirror of the status surface's newest-row projection. A
+# reviewer starting a fresh analysis round must withdraw its own older
+# clean success on the same head; counting "any clean success" would open
+# the gate on stale evidence.
+reset
+CFG_CONTEXTS="mech-ctx"
+jq -n '{check_runs:[
+  {id:1,name:"mech-ctx",conclusion:"success",app:{slug:"trusted-reviewer-app"},output:{title:null,summary:"analysis complete"}},
+  {id:2,name:"mech-ctx",conclusion:null,status:"in_progress",app:{slug:"trusted-reviewer-app"},output:{title:null,summary:null}}
+]}' >"$fixtures/checkruns.json"
+run "newer in-progress run masks its older clean success (newest run decides)" awaiting
+
+# The skip marker comes from the ACTIVE pattern list, not a literal, so the
+# configured layer (which replaces the default patterns) still exercises it.
+reset
+CFG_CONTEXTS="mech-ctx"
+first_skip="$(list_items "$ACTIVE_SKIPS" | head -1)"
+jq -n --arg skip "Review $first_skip. 0 files reviewed." '{check_runs:[
+  {id:1,name:"mech-ctx",conclusion:"success",app:{slug:"trusted-reviewer-app"},output:{title:null,summary:"analysis complete"}},
+  {id:2,name:"mech-ctx",conclusion:"success",app:{slug:"trusted-reviewer-app"},output:{title:null,summary:$skip}}
+]}' >"$fixtures/checkruns.json"
+run "newer skip-marked 'pass' masks its older clean success" awaiting
+
+reset
+CFG_CONTEXTS="mech-ctx"
+jq -n '{check_runs:[
+  {id:1,name:"mech-ctx",conclusion:"failure",app:{slug:"trusted-reviewer-app"},output:{title:null,summary:"findings posted"}},
+  {id:2,name:"mech-ctx",conclusion:"success",app:{slug:"trusted-reviewer-app"},output:{title:null,summary:"analysis complete"}}
+]}' >"$fixtures/checkruns.json"
+run "newest clean success over an older failed run is evidence" approved
+
+# The minting lever stays closed under the projection: a github-actions-
+# published row is dropped BEFORE choosing the newest, so PR content cannot
+# post a newer run under the trusted name to mask the reviewer's real
+# success — closing the gate is not its call either (the status branch
+# documents the same rule for its reject list).
+reset
+CFG_CONTEXTS="mech-ctx"
+jq -n '{check_runs:[
+  {id:1,name:"mech-ctx",conclusion:"success",app:{slug:"trusted-reviewer-app"},output:{title:null,summary:"analysis complete"}},
+  {id:2,name:"mech-ctx",conclusion:null,status:"queued",app:{slug:"github-actions"},output:{title:null,summary:null}}
+]}' >"$fixtures/checkruns.json"
+run "github-actions-published newer run cannot mask the reviewer's clean success" approved
+
+# Slugless ANOMALY rows are the opposite of the minting lever: kept in the
+# sequence, so an anomalous NEWEST row masks toward closed rather than
+# reviving an older success from malformed current evidence.
+reset
+CFG_CONTEXTS="mech-ctx"
+jq -n '{check_runs:[
+  {id:1,name:"mech-ctx",conclusion:"success",app:{slug:"trusted-reviewer-app"},output:{title:null,summary:"analysis complete"}},
+  {id:2,name:"mech-ctx",conclusion:"success",output:{title:null,summary:"analysis complete"}}
+]}' >"$fixtures/checkruns.json"
+run "slugless anomaly as the newest run masks toward closed (never revives the older success)" awaiting
+
 # Legacy commit STATUSES carry no app slug, only a creator — and on repos
 # whose PR workflows hold statuses:write, PR content can mint one under any
 # context through github-actions[bot]. The OPT-IN publisher reject-list

--- a/skills/review-gate/scripts/review-predicate-selftest.sh
+++ b/skills/review-gate/scripts/review-predicate-selftest.sh
@@ -482,31 +482,40 @@ run "check-run with no app slug (unprovable provenance) is not evidence" awaitin
 # check-run mirror of the status surface's newest-row projection. A
 # reviewer starting a fresh analysis round must withdraw its own older
 # clean success on the same head; counting "any clean success" would open
-# the gate on stale evidence.
+# the gate on stale evidence. Every multi-row fixture lists the NEWER run
+# (higher id) FIRST — the API's usual newest-first shape — so an
+# implementation that skipped the id sort and took the last array row
+# would fail these cases instead of passing by row order.
 reset
 CFG_CONTEXTS="mech-ctx"
 jq -n '{check_runs:[
-  {id:1,name:"mech-ctx",conclusion:"success",app:{slug:"trusted-reviewer-app"},output:{title:null,summary:"analysis complete"}},
-  {id:2,name:"mech-ctx",conclusion:null,status:"in_progress",app:{slug:"trusted-reviewer-app"},output:{title:null,summary:null}}
+  {id:2,name:"mech-ctx",conclusion:null,status:"in_progress",app:{slug:"trusted-reviewer-app"},output:{title:null,summary:null}},
+  {id:1,name:"mech-ctx",conclusion:"success",app:{slug:"trusted-reviewer-app"},output:{title:null,summary:"analysis complete"}}
 ]}' >"$fixtures/checkruns.json"
 run "newer in-progress run masks its older clean success (newest run decides)" awaiting
 
 # The skip marker comes from the ACTIVE pattern list, not a literal, so the
 # configured layer (which replaces the default patterns) still exercises it.
-reset
-CFG_CONTEXTS="mech-ctx"
+# Guarded on a non-empty list: empty REVIEW_GATE_CHECKRUN_SKIP_PATTERNS
+# legitimately disables the filter, and this case would then assert the
+# wrong verdict — the masking property it proves is already covered for
+# that shape by the in-progress case above.
 first_skip="$(list_items "$ACTIVE_SKIPS" | head -1)"
-jq -n --arg skip "Review $first_skip. 0 files reviewed." '{check_runs:[
-  {id:1,name:"mech-ctx",conclusion:"success",app:{slug:"trusted-reviewer-app"},output:{title:null,summary:"analysis complete"}},
-  {id:2,name:"mech-ctx",conclusion:"success",app:{slug:"trusted-reviewer-app"},output:{title:null,summary:$skip}}
-]}' >"$fixtures/checkruns.json"
-run "newer skip-marked 'pass' masks its older clean success" awaiting
+if [ -n "$first_skip" ]; then
+  reset
+  CFG_CONTEXTS="mech-ctx"
+  jq -n --arg skip "Review $first_skip. 0 files reviewed." '{check_runs:[
+    {id:2,name:"mech-ctx",conclusion:"success",app:{slug:"trusted-reviewer-app"},output:{title:null,summary:$skip}},
+    {id:1,name:"mech-ctx",conclusion:"success",app:{slug:"trusted-reviewer-app"},output:{title:null,summary:"analysis complete"}}
+  ]}' >"$fixtures/checkruns.json"
+  run "newer skip-marked 'pass' masks its older clean success" awaiting
+fi
 
 reset
 CFG_CONTEXTS="mech-ctx"
 jq -n '{check_runs:[
-  {id:1,name:"mech-ctx",conclusion:"failure",app:{slug:"trusted-reviewer-app"},output:{title:null,summary:"findings posted"}},
-  {id:2,name:"mech-ctx",conclusion:"success",app:{slug:"trusted-reviewer-app"},output:{title:null,summary:"analysis complete"}}
+  {id:2,name:"mech-ctx",conclusion:"success",app:{slug:"trusted-reviewer-app"},output:{title:null,summary:"analysis complete"}},
+  {id:1,name:"mech-ctx",conclusion:"failure",app:{slug:"trusted-reviewer-app"},output:{title:null,summary:"findings posted"}}
 ]}' >"$fixtures/checkruns.json"
 run "newest clean success over an older failed run is evidence" approved
 
@@ -518,8 +527,8 @@ run "newest clean success over an older failed run is evidence" approved
 reset
 CFG_CONTEXTS="mech-ctx"
 jq -n '{check_runs:[
-  {id:1,name:"mech-ctx",conclusion:"success",app:{slug:"trusted-reviewer-app"},output:{title:null,summary:"analysis complete"}},
-  {id:2,name:"mech-ctx",conclusion:null,status:"queued",app:{slug:"github-actions"},output:{title:null,summary:null}}
+  {id:2,name:"mech-ctx",conclusion:null,status:"queued",app:{slug:"github-actions"},output:{title:null,summary:null}},
+  {id:1,name:"mech-ctx",conclusion:"success",app:{slug:"trusted-reviewer-app"},output:{title:null,summary:"analysis complete"}}
 ]}' >"$fixtures/checkruns.json"
 run "github-actions-published newer run cannot mask the reviewer's clean success" approved
 
@@ -529,8 +538,8 @@ run "github-actions-published newer run cannot mask the reviewer's clean success
 reset
 CFG_CONTEXTS="mech-ctx"
 jq -n '{check_runs:[
-  {id:1,name:"mech-ctx",conclusion:"success",app:{slug:"trusted-reviewer-app"},output:{title:null,summary:"analysis complete"}},
-  {id:2,name:"mech-ctx",conclusion:"success",output:{title:null,summary:"analysis complete"}}
+  {id:2,name:"mech-ctx",conclusion:"success",output:{title:null,summary:"analysis complete"}},
+  {id:1,name:"mech-ctx",conclusion:"success",app:{slug:"trusted-reviewer-app"},output:{title:null,summary:"analysis complete"}}
 ]}' >"$fixtures/checkruns.json"
 run "slugless anomaly as the newest run masks toward closed (never revives the older success)" awaiting
 

--- a/skills/review-gate/scripts/review-predicate.sh
+++ b/skills/review-gate/scripts/review-predicate.sh
@@ -488,6 +488,18 @@ while IFS= read -r ctx; do
   # the mechanical half of the settings doc's "only names produced by
   # trusted bots" precondition.
   #
+  # SUPERSESSION IS PER SURFACE, deliberately: the check-run and commit-
+  # status surfaces are independent evidence sources ("either counts" is the
+  # documented contract), so a newer run on one surface does not withdraw an
+  # older row on the OTHER. Cross-surface ordering has no sound key — run
+  # ids and status ids live in different id spaces, and timestamps carry the
+  # one-second-tie hazard both projections were built to avoid — and no
+  # known reviewer publishes both surfaces under one name on one head (the
+  # migration case lands as a name change or a repo settings change, both of
+  # which reset trust config). A repo listing a name its reviewer publishes
+  # on both surfaces accepts that either surface's newest clean row
+  # satisfies the term.
+  #
   # NEWEST RUN DECIDES, per name (vstack#1110) — the check-run mirror of the
   # status branch's newest-row projection below. Counting "any clean
   # success" would let a reviewer's older clean run outlive its own NEWER

--- a/skills/review-gate/scripts/review-predicate.sh
+++ b/skills/review-gate/scripts/review-predicate.sh
@@ -12,7 +12,10 @@
 #       on this head, whose title/summary/description carries no
 #       skip-pattern marker (a "pass" that says the analysis was rate
 #       limited, skipped or queued proves nothing ran — it is silence, not
-#       approval, and routes to NOT-EVIDENCE, never to failure);
+#       approval, and routes to NOT-EVIDENCE, never to failure). On BOTH
+#       surfaces the NEWEST row/run per name decides (statuses by list
+#       order, check-runs by run id — vstack#1110): an older clean success
+#       never outlives its reviewer's newer pending/failed round;
 #   (c) a trusted comment-form clean pass: an issue comment by a trusted bot
 #       login whose body binds the evidence to this head's sha;
 #   (d) the trusted reviewer-outage attestation status — substitutes for
@@ -484,14 +487,41 @@ while IFS= read -r ctx; do
   # therefore never clean-analysis evidence (VST-19); rejecting it here is
   # the mechanical half of the settings doc's "only names produced by
   # trusted bots" precondition.
+  #
+  # NEWEST RUN DECIDES, per name (vstack#1110) — the check-run mirror of the
+  # status branch's newest-row projection below. Counting "any clean
+  # success" would let a reviewer's older clean run outlive its own NEWER
+  # in-progress/failed round on the same head (a bot starting a fresh
+  # analysis creates a new run; the default filter=latest projects per
+  # check SUITE, and a fresh analysis is a fresh suite) and open the gate
+  # on stale evidence. Ordering keys on the run id — assigned monotonically
+  # at creation, present on every real API row, and immune to the
+  # one-second created_at ties the status branch documents; started_at is
+  # NOT used (null on queued runs, which would sort a queued fresh round
+  # oldest and revive the stale success). Mirroring the status branch's
+  # publisher handling: github-actions-published rows are dropped BEFORE
+  # the projection (the one identity PR content can wield — a minted newer
+  # row must not mask real rows, not even toward closed), while rows with
+  # NO app slug at all are KEPT in the sequence — an anomalous newest row
+  # reads as silence, and dropping it pre-projection would revive an older
+  # success from malformed current evidence. PR content cannot produce a
+  # slugless row (its runs carry the github-actions slug). The newest
+  # accepted row must then itself be a clean, non-skip-filtered success;
+  # anything else — in-progress (null conclusion), failure, a skip-marked
+  # "pass", or a slugless anomaly — is silence, never a gate failure.
   check_runs="$(jq --arg ctx "$ctx" --arg skips "$SKIP_PATTERNS" '
       ($skips | split(";") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0)) | map(ascii_downcase)) as $sk
       | [ .check_runs[]
-          | select(.name == $ctx and .conclusion == "success")
-          | select(((.app.slug // "") != "") and ((.app.slug // "") != "github-actions"))
-          | (((.output.title // "") + " " + (.output.summary // "")) | ascii_downcase) as $text
-          | select(([ $sk[] | . as $p | select($text | contains($p)) ] | length) == 0)
-        ] | length' <<<"$checkruns_resp")" || {
+          | select(.name == $ctx)
+          | select((.app.slug // "") != "github-actions")
+        ]
+      | sort_by(.id // 0) | last
+      | if . == null then 0
+        elif ((.app.slug // "") == "") then 0
+        elif (.conclusion == "success")
+             and ((((.output.title // "") + " " + (.output.summary // "")) | ascii_downcase) as $text
+                  | ([ $sk[] | . as $p | select($text | contains($p)) ] | length) == 0)
+        then 1 else 0 end' <<<"$checkruns_resp")" || {
     echo "::error::could not evaluate '$ctx' check-runs" >&2
     exit 2
   }

--- a/skills/review-gate/templates/review-gate-writer.yml
+++ b/skills/review-gate/templates/review-gate-writer.yml
@@ -59,14 +59,19 @@ name: Review gate writer
   workflow_dispatch: {}
   # NO check_run trigger here, deliberately — per-repo OPT-IN only (plan
   # round-2 finding R3): every ordinary CI job completion fires
-  # check_run.completed, and an early-exit that needs the settings file
+  # check_run events, and an early-exit that needs the settings file
   # needs a checkout, which bills the 1-minute minimum per run on private
   # repos. A repo whose reviewer publishes check-runs AND NOTHING ELSE adds:
   #   check_run:
-  #     types: [completed]
+  #     types: [created, completed]
   # plus a job-level guard on the write job's if: matching the reviewer's
   # check name literally (the file is repo-owned after copy, so the
-  # hardcoded name is config); a job-level skip bills nothing.
+  # hardcoded name is config); a job-level skip bills nothing. `created`
+  # matters under newest-run semantics (vstack#1110): a reviewer STARTING a
+  # fresh round withdraws its own older clean success, and without the
+  # created leg that downward transition waits for the run's completion or
+  # the cron floor. Repos without the opt-in converge withdrawals on the
+  # cron floor — the same accepted class as thread resolution.
 
 permissions:
   contents: read

--- a/skills/review-gate/vstack.settings.toml.example
+++ b/skills/review-gate/vstack.settings.toml.example
@@ -15,7 +15,9 @@ REVIEW_GATE_CONTEXT = "Review gate"
 # Clean-analysis evidence: exact names of the trusted reviewer's check-run
 # and/or legacy commit status; a success for a listed name on the current
 # head counts as review evidence (for bots that submit a review object only
-# when they have findings). Both APIs are queried; either counts. SECURITY:
+# when they have findings). Both APIs are queried; either counts, and on
+# both the NEWEST row/run per name decides (a newer pending/failed/
+# skip-marked round withdraws the reviewer's own older success). SECURITY:
 # check-runs and statuses are matched by NAME, and any GitHub App or Actions
 # workflow can publish under any name — list only names produced by trusted
 # bots, on repos where every publisher is trusted.


### PR DESCRIPTION
Resolves the #1110 open question in favor of **projection** (over documenting the asymmetry): the check-run evidence branch counted ANY clean success for a trusted name, letting a reviewer's older clean run outlive its own newer in-progress/failed round on the same head — the exact stale-evidence read the status surface's newest-row projection exists to close. Surfaced by Copilot on drovr#448; qodo independently flagged the same hole on vgs#72 today ("Action required"), which settles the narrower-than-it-looks question — live reviewers do re-run per head.

**Semantics** (mirrors the status branch exactly):
- Newest run per name decides, ordered by run id (monotonic at creation, on every real API row; `started_at` is null on queued runs and would sort a fresh round oldest, reviving the stale success — deliberately not used).
- `github-actions`-published rows drop BEFORE the projection: the one identity PR content can wield must not mask real rows, not even toward closed.
- Slugless anomaly rows stay in the sequence: an anomalous newest masks toward closed; dropping it pre-projection would revive an older success from malformed current evidence.
- The newest accepted row must itself be a clean, non-skip-filtered success; in-progress/failure/skip-marked/anomaly = silence, never gate failure.

**Tests**: five new selftest cases (incl. the skip-marker case deriving from the ACTIVE pattern list so the configured layer exercises it). Full engine suite green: selftest 215/215 repo-configured, meta 161/199, writer 110/0, settings-parsing 13/0, bash32 + example-sync + vars-documented pass. Live sandbox replay running; result posted before merge.

Consumers pick this up at their next `vstack refresh`; vgs#72 folds it into the cutover re-vendor directly.

https://claude.ai/code/session_011Lihbw4tcMNRChPFWVKBMM