### PR TITLE
fix(deps): hono 4.13.1 in the bridge lock (clears 4 Dependabot alerts)

### DIFF
--- a/pi-extensions/pi-claude-bridge/package-lock.json
+++ b/pi-extensions/pi-claude-bridge/package-lock.json
@@ -2731,9 +2731,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.33",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.33.tgz",
-      "integrity": "sha512-+SwvkaiJtxsiPjhy9LivY/1m7UsNqCJetM1BrZl9A5DkQhlbHQDU730mMiDPWjnoCYOM8Chf3WrCJw27kNTPFQ==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
+      "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
       "license": "MIT",
       "peer": true,
       "engines": {


### PR DESCRIPTION
Clears all open Dependabot alerts on main (71–74: CORS ReDoS, language-middleware algorithmic-complexity DoS, `memo()` SSR cross-user disclosure — all medium — and the Connection-header proxy leak, low). hono is transitive via `@modelcontextprotocol/sdk`; the fix is lockfile-only — hono is not part of the committed esbuild bundles (rebuild produced zero diff).

Bridge test suite: identical pass/fail profile to main (the one failing provider smoke test is pre-existing/environmental).

This was the parked owner flag carried across the last three handoffs.

https://claude.ai/code/session_01BHYaNFGaZXpW2tg1YwxLeV