### PR TITLE
docs: Linear Loops triage-janitor definitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,7 +63,7 @@ Thumbs.db
 # (docs/cross-repo.md, the curated contract, IS tracked on purpose)
 docs/cross-repo-notes.md
 
-# Workspace-specific Linear Loop config — never committed (vstack is portable);
-# backed up as a secret gist, see the file's own header. The portable template
-# (docs/linear-loops.md) IS tracked on purpose.
-docs/linear-loops-local.md
+# Filled workspace copies of portable doc templates — never committed (vstack
+# is portable/public). Pattern: tracked template docs/<name>.md, untracked
+# filled copy docs/<name>-local.md, gist-backed per the file's own header.
+docs/*-local.md

--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,8 @@ Thumbs.db
 # Cross-repo mailbox log — machine-local session coordination, never committed
 # (docs/cross-repo.md, the curated contract, IS tracked on purpose)
 docs/cross-repo-notes.md
+
+# Workspace-specific Linear Loop config — never committed (vstack is portable);
+# backed up as a secret gist, see the file's own header. The portable template
+# (docs/linear-loops.md) IS tracked on purpose.
+docs/linear-loops-local.md

--- a/docs/issue-label-taxonomy.md
+++ b/docs/issue-label-taxonomy.md
@@ -1,8 +1,10 @@
 # vstack issue-label taxonomy
 
 Linear team `vstack` (VST). GitHub `vanillagreencom/vstack` is the code and PR surface;
-issues sync GitHub → Linear one-way, so a label applied at file time arrives in Linear
-with the synced issue.
+issues sync GitHub ↔ Linear, so a label applied at file time arrives in Linear with the
+synced issue. Linear's per-link direction setting governs issue CREATION only (owner
+decision 2026-08-08: two-way creation for all teams/repos); updates and comments on an
+already-synced issue always propagate in both directions regardless of that setting.
 
 This is the project-side taxonomy the upstream
 [label-management contract](../skills/project-management/references/labels.md) expects

--- a/docs/issue-label-taxonomy.md
+++ b/docs/issue-label-taxonomy.md
@@ -108,6 +108,7 @@ Classify what the work *is*; pair one with the routing label.
 | `needs-review` | Explicit review gate required before execution, merge, or close |
 | `critical-path` | Blocks or enables major project progress; align priority |
 | `owner-gated` | Needs an owner decision or owner-only action to proceed |
+| `re-triage` | Trigger handle for the Linear Loop triage janitor (`docs/linear-loops.md`): apply to any issue to request one triage pass; the loop removes it as its first action |
 
 ### Steward labels (team VST)
 

--- a/docs/linear-loops.md
+++ b/docs/linear-loops.md
@@ -1,0 +1,167 @@
+# Linear Loops — Triage Janitor
+
+Source of truth for our Linear Loop definitions. Loops have no public GraphQL
+API (verified 2026-08-08 by schema introspection: no `loop*`/`agentAutomation*`
+CRUD; only leaked enums `AgentAutomationUsageLimitScope`, `WorkflowTrigger`,
+`WorkflowTriggerType`), so they are configured manually in the Linear UI at
+**Loops → New loop**. When this file changes, re-paste the affected sections
+into the UI.
+
+Scope boundary: Loops handle cheap per-issue hygiene only (labels, team
+routing, duplicate flagging, actionability nudges). Batch work — bundling,
+consolidation, cancellation, obsolete detection with code verification — stays
+with the tpm audit workflow (`skills/project-management/workflows/tpm-audit.md`),
+which has repo access and a review gate. Loops must never cancel, merge, or
+consolidate issues.
+
+---
+
+## Loop 1 — Triage Janitor
+
+Runs once per newly created issue.
+
+### Trigger
+
+| Setting | Value |
+|---------|-------|
+| Event | An issue is **created** (NOT "created or updated") |
+| Teams | drovr, hyprtrade, memsira, vg-shell, vstack |
+| Filter: Status | Triage, Backlog, Todo |
+| Filter: Agent Session (if available) | none — skip issues an agent is actively working |
+
+Created-only is deliberate: an "updated" trigger fires on every GitHub-sync
+refresh, every `linear.sh` mutation from orch/tpm, and the loop's own edits.
+Re-triage is handled by Loop 2.
+
+Do not add a Creator filter — GitHub-synced issues have an integration
+creator, and those are exactly the ones needing triage.
+
+### Permissions
+
+| Setting | Value | Why |
+|---------|-------|-----|
+| Team access | All public teams | Duplicate check needs cross-team view |
+| Allow changes outside triggering issue | ON | Needed only for `related` relations and duplicate comments; instructions hard-limit everything else |
+| Web search | OFF | Not needed |
+| Externally synced issues and comments | ON | Instructions forbid title/description edits on synced issues; sync is one-way GitHub→Linear so Linear-side comments don't propagate back |
+| Coding sessions | OFF | Loops get no repo access; code-verified work belongs to tpm audit |
+
+### Instructions
+
+```text
+You are a triage janitor. You perform single-issue hygiene on the issue that
+triggered you. You are conservative: when unsure, add a comment instead of
+making a change, and never take destructive action.
+
+## Hard limits
+
+- Never cancel, close, archive, merge, or delete any issue.
+- Never create new issues.
+- Never edit the title or description of any issue other than the triggering
+  issue. Never edit the title or description of the triggering issue if it is
+  synced from GitHub (has a GitHub link/attachment) — for synced issues,
+  restrict yourself to labels, team, priority, relations, and comments.
+- Never change assignees, cycles, or projects.
+- On issues other than the triggering issue, you may only add "related"
+  relations and comments — no field edits of any kind.
+- If nothing needs changing, do nothing at all. Do not post repeat comments.
+
+## Team ownership map
+
+Use this map for routing decisions. It overrides guesses from team names.
+
+- vstack (VST): the agent-stack infrastructure repo — skills/, agents/,
+  hooks/, pi-extensions, the Rust vstack CLI (add/refresh/report,
+  vstack.toml), and propagation into consuming repos.
+- hyprtrade (HT): the hyprtrade trading application itself. NOT the
+  hyprtrade.io marketing website — website work belongs to vg-shell.
+- vg-shell (VGS): the shell/capture pipeline repo and the hyprtrade.io
+  website.
+- drovr (DRO): the drovr product.
+- memsira (MEM): the memsira product.
+
+An issue about agent workflows, skills, hooks, CI harness behavior, or the
+vstack CLI belongs in vstack even if it was filed on a product team, and vice
+versa: product bugs filed on vstack belong on the product team.
+
+## Task 1 — Labels
+
+Apply missing labels from the issue's team's existing label set only. Never
+invent labels; if no existing label fits, skip. Read each label's description
+to decide fit against the issue's title and description. Remove a label only
+when it is plainly contradicted by the issue content; otherwise leave
+existing labels alone.
+
+## Task 2 — Team routing
+
+If the issue clearly belongs to a different team per the ownership map, move
+it to that team and add a one-sentence comment stating why. If ownership is
+ambiguous, do not move it — add a comment naming the candidate team and ask
+for confirmation.
+
+## Task 3 — Duplicate flagging
+
+Search existing issues (all states, all accessible teams) for issues
+describing the same problem or the same component change. Match on component
+or module names, not just title keywords. If a likely duplicate exists:
+- Add a "related" relation between the two issues.
+- Comment on the triggering issue: "Possible duplicate of [ID] — [one-line
+  reason]."
+Do not close, merge, or mark either issue as a duplicate yourself. Flag only.
+
+## Task 4 — Actionability nudge
+
+If the issue lacks clear scope, acceptance criteria, or a concrete
+deliverable (for example a vague one-line description with no target
+component), add one comment listing what is missing. One comment maximum.
+
+## Tone
+
+Comments are short, factual, and neutral. No greetings, no sign-offs.
+```
+
+---
+
+## Loop 2 — Re-triage on demand
+
+Manual re-run handle: apply the `re-triage` label to any issue to get one
+janitor pass. Requires the workspace label `re-triage` to exist.
+
+### Trigger
+
+| Setting | Value |
+|---------|-------|
+| Event | An issue is **updated** |
+| Teams | drovr, hyprtrade, memsira, vg-shell, vstack |
+| Filter: Labels | contains `re-triage` |
+| Filter: Status | Triage, Backlog, Todo |
+
+Self-disarming: the loop removes the label when done; label absent means the
+filter fails, so its own final update does not re-fire it.
+
+### Permissions
+
+Identical to Loop 1.
+
+### Instructions
+
+The full Loop 1 instructions text, with this section appended at the end:
+
+```text
+## Completion
+
+When finished, remove the "re-triage" label from the triggering issue. This
+is mandatory — the label is the trigger, and removing it prevents re-runs.
+```
+
+---
+
+## Deliberate non-loops
+
+- **No per-team loop copies** — the ownership map inside one instructions
+  text covers team differences; five copies drift.
+- **No "updated" catch-all loop** — sync and orchestration churn would fire
+  it constantly.
+- **No consolidation/cancel/bundle loop** — stays with tpm audit (repo
+  verification, batch view, review gate).
+- **No priority/estimate loop** — orch and cycle planning own those.

--- a/docs/linear-loops.md
+++ b/docs/linear-loops.md
@@ -50,7 +50,7 @@ integration creator, and those are exactly the ones needing triage.
 | Team access | All public teams | Duplicate check needs cross-team view |
 | Allow changes outside triggering issue | ON | Needed only for `related` relations and duplicate comments; instructions hard-limit everything else |
 | Web search | OFF | Not needed |
-| Externally synced issues and comments | ON | Instructions forbid title/description edits on synced issues; verify your sync direction before enabling — with a one-way external→Linear sync, Linear-side comments do not propagate back |
+| Externally synced issues and comments | ON | Updates to synced issues always sync both ways (Linear's creation-direction setting only affects creation), so janitor comments and edits WILL appear on the external tracker — acceptable for short factual triage comments |
 | Coding sessions | OFF | Loops get no repo access; code-verified work belongs to tpm audit |
 
 ### Instructions
@@ -65,10 +65,8 @@ making a change, and never take destructive action.
 - Never cancel, close, archive, merge, or delete any issue.
 - Never create new issues.
 - Never edit the title or description of any issue other than the triggering
-  issue. Never edit the title or description of the triggering issue if it is
-  synced from an external tracker (has an external link/attachment) — for
-  synced issues, restrict yourself to labels, team, priority, relations, and
-  comments.
+  issue. Remember that edits and comments on issues synced from an external
+  tracker propagate to that tracker.
 - Never change assignees, cycles, or projects.
 - On issues other than the triggering issue, you may only add "related"
   relations and comments — no field edits of any kind.

--- a/docs/linear-loops.md
+++ b/docs/linear-loops.md
@@ -14,9 +14,10 @@ working document; this template only changes when the loop design changes.
 Scope boundary: Loops handle cheap per-issue hygiene only (labels, team
 routing, duplicate flagging, actionability nudges). Batch work — bundling,
 consolidation, cancellation, obsolete detection with code verification — stays
-with the tpm audit workflow (`skills/project-management/workflows/tpm-audit.md`),
-which has repo access and returns recommendations only; a reviewing caller
-applies them. Loops must never cancel, merge, or consolidate issues.
+with the audit workflow (`skills/project-management/workflows/audit-issues.md`
+— the user-facing wrapper that owns the approval gate and the mutations, with
+the repo-access analysis in `workflows/tpm-audit.md` underneath). Loops must
+never cancel, merge, or consolidate issues.
 
 ---
 

--- a/docs/linear-loops.md
+++ b/docs/linear-loops.md
@@ -15,8 +15,8 @@ Scope boundary: Loops handle cheap per-issue hygiene only (labels, team
 routing, duplicate flagging, actionability nudges). Batch work — bundling,
 consolidation, cancellation, obsolete detection with code verification — stays
 with the tpm audit workflow (`skills/project-management/workflows/tpm-audit.md`),
-which has repo access and a review gate. Loops must never cancel, merge, or
-consolidate issues.
+which has repo access and returns recommendations only; a reviewing caller
+applies them. Loops must never cancel, merge, or consolidate issues.
 
 ---
 
@@ -83,20 +83,22 @@ cross-cutting rules, for example: "An issue about agent workflows, CI
 harness behavior, or shared tooling belongs on the infrastructure team even
 if filed on a product team, and vice versa."]
 
-## Task 1 — Labels
+## Task 1 — Team routing
 
-Apply missing labels from the issue's team's existing label set only. Never
-invent labels; if no existing label fits, skip. Read each label's description
-to decide fit against the issue's title and description. Remove a label only
-when it is plainly contradicted by the issue content; otherwise leave
-existing labels alone.
+Route first, before labeling: labels must come from the team the issue ends
+up on. If the issue clearly belongs to a different team per the ownership
+map, move it to that team and add a one-sentence comment stating why. If
+ownership is ambiguous, do not move it — add a comment naming the candidate
+team and ask for confirmation.
 
-## Task 2 — Team routing
+## Task 2 — Labels
 
-If the issue clearly belongs to a different team per the ownership map, move
-it to that team and add a one-sentence comment stating why. If ownership is
-ambiguous, do not move it — add a comment naming the candidate team and ask
-for confirmation.
+Apply missing labels from the existing label set of the issue's team after
+Task 1 (the destination team if you moved it). Never invent labels; if no
+existing label fits, skip. Read each label's description to decide fit
+against the issue's title and description. Remove a label only when it is
+plainly contradicted by the issue content or invalid for the destination
+team; otherwise leave existing labels alone.
 
 ## Task 3 — Duplicate flagging
 
@@ -133,11 +135,14 @@ janitor pass. Create the workspace label `re-triage` first.
 | Event | An issue is **updated** |
 | Teams | [Same teams as Loop 1] |
 | Filter: Labels | contains `re-triage` |
-| Filter: Status | Triage, Backlog, Todo |
 | Filter: Agent Session | "is not Active" if the filter supports negation — avoids re-triaging an issue an agent is mid-flight on; omit if only inclusion is supported |
 
-Self-disarming: the loop removes the label when done; label absent means the
-filter fails, so its own final update does not re-fire it.
+No Status filter: the label is an explicit operator request, valid on active
+issues (In Progress, In Review) too.
+
+Self-disarming: the loop removes the label FIRST, before any other mutation —
+label absent means the filter fails, so neither its intermediate edits nor
+its final update can schedule another run.
 
 ### Permissions
 
@@ -149,10 +154,14 @@ The full Loop 1 instructions text (with your ownership map filled in), plus
 this section appended at the end:
 
 ```text
-## Completion
+## First action — disarm the trigger
 
-When finished, remove the "re-triage" label from the triggering issue. This
-is mandatory — the label is the trigger, and removing it prevents re-runs.
+Before anything else, remove the "re-triage" label from the triggering
+issue. This is mandatory and unconditional: the label is this loop's
+trigger, and removing it before any other change prevents your own edits
+from scheduling another run. The "do nothing if nothing needs changing"
+rule applies to the janitor tasks, not to this removal — the removal always
+happens.
 ```
 
 ---

--- a/docs/linear-loops.md
+++ b/docs/linear-loops.md
@@ -1,11 +1,17 @@
-# Linear Loops — Triage Janitor
+# Linear Loops — Triage Janitor (portable template)
 
-Source of truth for our Linear Loop definitions. Loops have no public GraphQL
-API (verified 2026-08-08 by schema introspection: no `loop*`/`agentAutomation*`
-CRUD; only leaked enums `AgentAutomationUsageLimitScope`, `WorkflowTrigger`,
-`WorkflowTriggerType`), so they are configured manually in the Linear UI at
-**Loops → New loop**. When this file changes, re-paste the affected sections
-into the UI.
+Source-of-truth template for Linear Loop definitions. Loops have no public
+GraphQL API (verified 2026-08-08 by schema introspection: no
+`loop*`/`agentAutomation*` CRUD; only leaked enums
+`AgentAutomationUsageLimitScope`, `WorkflowTrigger`, `WorkflowTriggerType`),
+so they are configured manually in the Linear UI at **Loops → New loop**.
+When this file changes, re-paste the affected sections into the UI.
+
+This file is portable — it contains no workspace-specific team names,
+products, or integration details. Workspace specifics (team list, ownership
+map, sync direction notes) live in `docs/linear-loops-local.md`, which is
+untracked (see `.gitignore`). Fill the `[BRACKETED]` placeholders from that
+local file when pasting into Linear.
 
 Scope boundary: Loops handle cheap per-issue hygiene only (labels, team
 routing, duplicate flagging, actionability nudges). Batch work — bundling,
@@ -25,16 +31,19 @@ Runs once per newly created issue.
 | Setting | Value |
 |---------|-------|
 | Event | An issue is **created** (NOT "created or updated") |
-| Teams | drovr, hyprtrade, memsira, vg-shell, vstack |
+| Teams | [ALL WORKSPACE TEAMS] |
 | Filter: Status | Triage, Backlog, Todo |
-| Filter: Agent Session (if available) | none — skip issues an agent is actively working |
 
-Created-only is deliberate: an "updated" trigger fires on every GitHub-sync
-refresh, every `linear.sh` mutation from orch/tpm, and the loop's own edits.
-Re-triage is handled by Loop 2.
+No Agent Session filter: its options (Active/Error/Dismissed/Merged) only
+match issues that HAVE a session, and a just-created issue almost never does —
+the filter would exclude nearly everything or nothing useful.
 
-Do not add a Creator filter — GitHub-synced issues have an integration
-creator, and those are exactly the ones needing triage.
+Created-only is deliberate: an "updated" trigger fires on every issue-tracker
+sync refresh, every CLI mutation from orchestration agents, and the loop's own
+edits. Re-triage is handled by Loop 2.
+
+Do not add a Creator filter — issues synced from an external tracker have an
+integration creator, and those are exactly the ones needing triage.
 
 ### Permissions
 
@@ -43,7 +52,7 @@ creator, and those are exactly the ones needing triage.
 | Team access | All public teams | Duplicate check needs cross-team view |
 | Allow changes outside triggering issue | ON | Needed only for `related` relations and duplicate comments; instructions hard-limit everything else |
 | Web search | OFF | Not needed |
-| Externally synced issues and comments | ON | Instructions forbid title/description edits on synced issues; sync is one-way GitHub→Linear so Linear-side comments don't propagate back |
+| Externally synced issues and comments | ON | Instructions forbid title/description edits on synced issues; verify your sync direction before enabling — with a one-way external→Linear sync, Linear-side comments do not propagate back |
 | Coding sessions | OFF | Loops get no repo access; code-verified work belongs to tpm audit |
 
 ### Instructions
@@ -59,8 +68,9 @@ making a change, and never take destructive action.
 - Never create new issues.
 - Never edit the title or description of any issue other than the triggering
   issue. Never edit the title or description of the triggering issue if it is
-  synced from GitHub (has a GitHub link/attachment) — for synced issues,
-  restrict yourself to labels, team, priority, relations, and comments.
+  synced from an external tracker (has an external link/attachment) — for
+  synced issues, restrict yourself to labels, team, priority, relations, and
+  comments.
 - Never change assignees, cycles, or projects.
 - On issues other than the triggering issue, you may only add "related"
   relations and comments — no field edits of any kind.
@@ -70,19 +80,9 @@ making a change, and never take destructive action.
 
 Use this map for routing decisions. It overrides guesses from team names.
 
-- vstack (VST): the agent-stack infrastructure repo — skills/, agents/,
-  hooks/, pi-extensions, the Rust vstack CLI (add/refresh/report,
-  vstack.toml), and propagation into consuming repos.
-- hyprtrade (HT): the hyprtrade trading application itself. NOT the
-  hyprtrade.io marketing website — website work belongs to vg-shell.
-- vg-shell (VGS): the shell/capture pipeline repo and the hyprtrade.io
-  website.
-- drovr (DRO): the drovr product.
-- memsira (MEM): the memsira product.
-
-An issue about agent workflows, skills, hooks, CI harness behavior, or the
-vstack CLI belongs in vstack even if it was filed on a product team, and vice
-versa: product bugs filed on vstack belong on the product team.
+[PASTE WORKSPACE OWNERSHIP MAP FROM docs/linear-loops-local.md — one bullet
+per team: team name (KEY): what it owns, plus any NOT-this disambiguations
+and cross-cutting routing rules.]
 
 ## Task 1 — Labels
 
@@ -132,9 +132,10 @@ janitor pass. Requires the workspace label `re-triage` to exist.
 | Setting | Value |
 |---------|-------|
 | Event | An issue is **updated** |
-| Teams | drovr, hyprtrade, memsira, vg-shell, vstack |
+| Teams | [ALL WORKSPACE TEAMS] |
 | Filter: Labels | contains `re-triage` |
 | Filter: Status | Triage, Backlog, Todo |
+| Filter: Agent Session | "is not Active" if the filter supports negation — avoids re-triaging an issue an agent is mid-flight on; omit if only inclusion is supported |
 
 Self-disarming: the loop removes the label when done; label absent means the
 filter fails, so its own final update does not re-fire it.
@@ -159,9 +160,9 @@ is mandatory — the label is the trigger, and removing it prevents re-runs.
 ## Deliberate non-loops
 
 - **No per-team loop copies** — the ownership map inside one instructions
-  text covers team differences; five copies drift.
-- **No "updated" catch-all loop** — sync and orchestration churn would fire
-  it constantly.
+  text covers team differences; copies drift.
+- **No "updated" catch-all loop** — tracker sync and orchestration churn
+  would fire it constantly.
 - **No consolidation/cancel/bundle loop** — stays with tpm audit (repo
   verification, batch view, review gate).
-- **No priority/estimate loop** — orch and cycle planning own those.
+- **No priority/estimate loop** — orchestration and cycle planning own those.

--- a/docs/linear-loops.md
+++ b/docs/linear-loops.md
@@ -1,17 +1,15 @@
-# Linear Loops — Triage Janitor (portable template)
+# Linear Loops — Triage Janitor (template)
 
-Source-of-truth template for Linear Loop definitions. Loops have no public
-GraphQL API (verified 2026-08-08 by schema introspection: no
-`loop*`/`agentAutomation*` CRUD; only leaked enums
+Loops have no public GraphQL API (verified 2026-08-08 by schema
+introspection: no `loop*`/`agentAutomation*` CRUD; only leaked enums
 `AgentAutomationUsageLimitScope`, `WorkflowTrigger`, `WorkflowTriggerType`),
 so they are configured manually in the Linear UI at **Loops → New loop**.
-When this file changes, re-paste the affected sections into the UI.
 
-This file is portable — it contains no workspace-specific team names,
-products, or integration details. Workspace specifics (team list, ownership
-map, sync direction notes) live in `docs/linear-loops-local.md`, which is
-untracked (see `.gitignore`). Fill the `[BRACKETED]` placeholders from that
-local file when pasting into Linear.
+**How to use this template:** copy this file to `docs/linear-loops-local.md`
+(the `docs/*-local.md` gitignore rule keeps it out of version control), fill
+in every `[BRACKETED]` placeholder — each one says what to put there — and
+paste the finished sections into the Linear UI. Your filled copy is the
+working document; this template only changes when the loop design changes.
 
 Scope boundary: Loops handle cheap per-issue hygiene only (labels, team
 routing, duplicate flagging, actionability nudges). Batch work — bundling,
@@ -31,7 +29,7 @@ Runs once per newly created issue.
 | Setting | Value |
 |---------|-------|
 | Event | An issue is **created** (NOT "created or updated") |
-| Teams | [ALL WORKSPACE TEAMS] |
+| Teams | [Every team the janitor should cover — usually all public teams] |
 | Filter: Status | Triage, Backlog, Todo |
 
 No Agent Session filter: its options (Active/Error/Dismissed/Merged) only
@@ -80,9 +78,12 @@ making a change, and never take destructive action.
 
 Use this map for routing decisions. It overrides guesses from team names.
 
-[PASTE WORKSPACE OWNERSHIP MAP FROM docs/linear-loops-local.md — one bullet
-per team: team name (KEY): what it owns, plus any NOT-this disambiguations
-and cross-cutting routing rules.]
+[One bullet per team, format: "- <team name> (<KEY>): <what it owns —
+repos, components, work types>". Where two teams sound alike or share a
+product name, add an explicit "NOT ..." disambiguation. Close with any
+cross-cutting rules, for example: "An issue about agent workflows, CI
+harness behavior, or shared tooling belongs on the infrastructure team even
+if filed on a product team, and vice versa."]
 
 ## Task 1 — Labels
 
@@ -125,14 +126,14 @@ Comments are short, factual, and neutral. No greetings, no sign-offs.
 ## Loop 2 — Re-triage on demand
 
 Manual re-run handle: apply the `re-triage` label to any issue to get one
-janitor pass. Requires the workspace label `re-triage` to exist.
+janitor pass. Create the workspace label `re-triage` first.
 
 ### Trigger
 
 | Setting | Value |
 |---------|-------|
 | Event | An issue is **updated** |
-| Teams | [ALL WORKSPACE TEAMS] |
+| Teams | [Same teams as Loop 1] |
 | Filter: Labels | contains `re-triage` |
 | Filter: Status | Triage, Backlog, Todo |
 | Filter: Agent Session | "is not Active" if the filter supports negation — avoids re-triaging an issue an agent is mid-flight on; omit if only inclusion is supported |
@@ -146,7 +147,8 @@ Identical to Loop 1.
 
 ### Instructions
 
-The full Loop 1 instructions text, with this section appended at the end:
+The full Loop 1 instructions text (with your ownership map filled in), plus
+this section appended at the end:
 
 ```text
 ## Completion


### PR DESCRIPTION
Source-of-truth doc for our two Linear Loops (per-issue triage janitor + re-triage label handle). Loops have no public GraphQL API — verified by schema introspection on 2026-08-08 (no `loop*`/`agentAutomation*` CRUD, only leaked enums) — so definitions are versioned here and pasted into the Linear UI on change.

Contents:
- Loop 1: created-only trigger, status filter, permissions table, full instructions text (hard limits, team ownership map, labels/routing/dupe-flag/actionability tasks)
- Loop 2: `re-triage` label as manual re-run handle, self-disarming
- Deliberate non-loops: no consolidation/cancel loop — batch work stays with tpm audit (repo verification + review gate)

https://claude.ai/code/session_017oEvfywD7ovRd53KBExGGz