### PR TITLE
docs(linear-loops): Loop 3 scheduled backlog sweep; forbid agent:* at triage

### DIFF
--- a/docs/linear-loops.md
+++ b/docs/linear-loops.md
@@ -13,13 +13,16 @@ inside the instructions text are runtime values the loop substitutes per
 issue — leave those untouched. Your filled copy is the working document;
 this template only changes when the loop design changes.
 
-Scope boundary: Loops handle cheap per-issue hygiene only (labels, team
-routing, duplicate flagging, actionability nudges). Batch work — bundling,
-consolidation, cancellation, obsolete detection with code verification — stays
+Scope boundary: Loops handle cheap per-issue hygiene (labels, team
+routing, duplicate flagging, actionability nudges) plus — in the scheduled
+Loop 3 sweep only — comment-only FLAGGING of likely-obsolete issues via Code
+Intelligence. The line is flags versus decisions: every batch mutation —
+bundling, consolidation, cancellation, acting on an obsolete flag — stays
 with the audit workflow (`skills/project-management/workflows/audit-issues.md`
 — the user-facing wrapper that owns the approval gate and the mutations, with
 the repo-access analysis in `workflows/tpm-audit.md` underneath). Loops must
-never cancel, merge, or consolidate issues.
+never cancel, merge, or consolidate issues; Loop 3's obsolete check feeds
+that workflow, it never decides for it.
 
 ---
 
@@ -100,7 +103,9 @@ Apply missing labels from the existing label set of the issue's team after
 Task 1 (the destination team if you moved it). Never invent labels; if no
 existing label fits, skip. Read each label's description to decide fit
 against the issue's title and description. Never apply `agent:*` labels —
-that category is assigned when work is claimed, not at triage. Remove a
+that category is owned by the TPM pipeline (roadmap planning and issue
+audit derive and assign it; activation applies it when work is claimed) and
+is never a triage-time guess. Remove a
 label only when it is plainly contradicted by the issue content or invalid
 for the destination team; otherwise leave existing labels alone.
 
@@ -183,6 +188,7 @@ Requires workspace Code Intelligence enabled with Loops access.
 |---------|-------|
 | Event | On a **schedule** — [pick a weekly slot, e.g. Monday 09:00 workspace time] |
 | Teams | [Same teams as Loop 1] |
+| Eligibility | No UI filter exists for scheduled loops — the instructions text below enforces it: Backlog/Todo state, not updated in 60 days, oldest first, at most 10 issues per run, skip issues an agent session is actively working |
 
 ### Permissions
 
@@ -211,8 +217,11 @@ working.
   priority, or estimate.
 - Allowed mutations: comments, "related" relations, and adding the
   "re-triage" label. Nothing else.
-- At most one comment per issue per run; if you commented on an issue in a
-  previous run and nothing changed, skip it entirely.
+- At most one comment per issue per run — when several checks match the
+  same issue, combine them into that single comment (Check 1's obsolete
+  finding first, then Check 3's duplicate note as a second line). If you
+  commented on an issue in a previous run and nothing changed, skip it
+  entirely.
 - Edits and comments on issues synced from an external tracker propagate to
   that tracker.
 

--- a/docs/linear-loops.md
+++ b/docs/linear-loops.md
@@ -99,9 +99,10 @@ team and ask for confirmation.
 Apply missing labels from the existing label set of the issue's team after
 Task 1 (the destination team if you moved it). Never invent labels; if no
 existing label fits, skip. Read each label's description to decide fit
-against the issue's title and description. Remove a label only when it is
-plainly contradicted by the issue content or invalid for the destination
-team; otherwise leave existing labels alone.
+against the issue's title and description. Never apply `agent:*` labels —
+that category is assigned when work is claimed, not at triage. Remove a
+label only when it is plainly contradicted by the issue content or invalid
+for the destination team; otherwise leave existing labels alone.
 
 ## Task 3 — Duplicate flagging
 
@@ -128,8 +129,9 @@ Comments are short, factual, and neutral. No greetings, no sign-offs.
 
 ## Loop 2 — Re-triage on demand
 
-Manual re-run handle: apply the `re-triage` label to any issue to get one
-janitor pass. Create the workspace label `re-triage` first.
+Re-run handle: apply the `re-triage` label to any issue to get one janitor
+pass. Sources of the label: manual (an operator or a local agent) and
+Loop 3's weekly sweep. Create the workspace label `re-triage` first.
 
 ### Trigger
 
@@ -169,12 +171,85 @@ happens.
 
 ---
 
+## Loop 3 — Backlog sweep (scheduled, flag-only)
+
+Weekly repo-grounded staleness sweep. Flags; never fixes or cancels. Chains
+Loop 2 by applying `re-triage` instead of duplicating the janitor logic.
+Requires workspace Code Intelligence enabled with Loops access.
+
+### Trigger
+
+| Setting | Value |
+|---------|-------|
+| Event | On a **schedule** — [pick a weekly slot, e.g. Monday 09:00 workspace time] |
+| Teams | [Same teams as Loop 1] |
+
+### Permissions
+
+| Setting | Value | Why |
+|---------|-------|-----|
+| Team access | All public teams | Duplicate check needs cross-team view |
+| Allow changes outside triggering issue | ON | Scheduled loop touches multiple issues |
+| Web search | OFF | Not needed |
+| Externally synced issues and comments | ON | Same trade-off as Loop 1 |
+| Code Intelligence | ON | The obsolete check reads workspace-connected repos |
+| Coding sessions | OFF | Flag-only; no code changes |
+
+### Instructions
+
+```text
+You are a weekly backlog auditor. You flag; you never fix, cancel, or close.
+Work through at most 10 issues per run: Backlog or Todo state, not updated
+in the last 60 days, oldest first. Skip issues an agent session is actively
+working.
+
+## Hard limits
+
+- Never cancel, close, archive, merge, or delete any issue.
+- Never create new issues.
+- Never edit any issue's title, description, assignees, cycles, projects,
+  priority, or estimate.
+- Allowed mutations: comments, "related" relations, and adding the
+  "re-triage" label. Nothing else.
+- At most one comment per issue per run; if you commented on an issue in a
+  previous run and nothing changed, skip it entirely.
+- Edits and comments on issues synced from an external tracker propagate to
+  that tracker.
+
+## Check 1 — Likely obsolete
+
+Using code intelligence on the workspace-connected repositories, check
+whether the issue's described deliverable already exists in the owning
+repo (named function, component, config, or behavior). If it clearly does,
+comment: "Likely obsolete — <file or symbol you found>. Flagged for local
+audit confirmation; not closing." Do not cancel the issue yourself.
+
+## Check 2 — Stale or incomplete metadata
+
+If the issue lacks a type label, has labels contradicted by its content, or
+clearly belongs to another team, add the "re-triage" label — the re-triage
+loop performs the actual cleanup. Do not fix the metadata inline.
+
+## Check 3 — Duplicates
+
+If another issue (any state, any accessible team) describes the same
+problem, add a "related" relation and comment: "Possible duplicate of
+<ID> — <one-line reason>", substituting the issue you found and why.
+
+## Tone
+
+Comments are short, factual, and neutral. No greetings, no sign-offs.
+```
+
+---
+
 ## Deliberate non-loops
 
 - **No per-team loop copies** — the ownership map inside one instructions
   text covers team differences; copies drift.
 - **No "updated" catch-all loop** — tracker sync and orchestration churn
   would fire it constantly.
-- **No consolidation/cancel/bundle loop** — stays with tpm audit (repo
-  verification, batch view, review gate).
+- **No consolidation/cancel/bundle loop** — the scheduled sweep FLAGS
+  obsolete candidates, but cancellation stays with the gated audit workflow
+  (batch view, approval, deterministic repo verification).
 - **No priority/estimate loop** — orchestration and cycle planning own those.


### PR DESCRIPTION
Adds the scheduled flag-only backlog sweep (Code Intelligence, chains Loop 2 via re-triage, 10-issue cap) to the portable template, and excludes `agent:*` from janitor labeling — live audit of the running loop showed it applying `agent:generalist` at triage, which our convention reserves for activation.

https://claude.ai/code/session_017oEvfywD7ovRd53KBExGGz