### PR TITLE
fix(cli): fail loud when a refresh entry yields no harness install

### DIFF
--- a/cli/src/commands/refresh.rs
+++ b/cli/src/commands/refresh.rs
@@ -982,6 +982,7 @@ pub fn prune_hook_harnesses(
             continue;
         };
         let mut new_harnesses = Vec::new();
+        let mut uninstalled_known = false;
         for harness_id in &entry.harnesses {
             if hook.applies_to(harness_id) {
                 new_harnesses.push(harness_id.clone());
@@ -989,11 +990,19 @@ pub fn prune_hook_harnesses(
             }
 
             let Some(harness) = Harness::from_id(harness_id) else {
+                eprintln!(
+                    "Warning: hook {} records unrecognized harness id {harness_id}; \
+                     dropping it from the lock (nothing this binary can uninstall)",
+                    entry.name
+                );
                 pruned_any = true;
                 continue;
             };
             match installer::remove_hook_install(&entry.name, harness, global) {
-                Ok(_) => pruned_any = true,
+                Ok(_) => {
+                    pruned_any = true;
+                    uninstalled_known = true;
+                }
                 Err(err) => {
                     eprintln!(
                         "Warning: failed to remove hook {} from {} during refresh: {err}",
@@ -1004,18 +1013,19 @@ pub fn prune_hook_harnesses(
                 }
             }
         }
-        // Only an entry emptied by THIS run's allowlist pruning is a completed
-        // self-heal, safe to drop. An entry that arrived already empty was
-        // never emptied by an allowlist change — it is the VST-134 bug shape —
-        // and silently unmanaging it here would mask the stale install exactly
-        // like the summary bug did. Leave it in the lock so the refresh pass
-        // fails it loudly (`fail_no_installable_harness`).
+        // Only an entry emptied by a COMPLETED self-heal — this run's allowlist
+        // pruning actually uninstalled a recognized harness — is safe to drop.
+        // An entry that arrived already empty (the VST-134 bug shape), or that
+        // emptied solely by shedding unrecognized ids no uninstall ever ran
+        // for, stays in the lock so the refresh pass fails it loudly
+        // (`fail_no_installable_harness`) instead of silently unmanaging a
+        // possibly-stale install.
         let arrived_empty = entry.harnesses.is_empty();
         if new_harnesses != entry.harnesses {
             entry.harnesses = new_harnesses;
             pruned_any = true;
         }
-        if entry.harnesses.is_empty() && !arrived_empty {
+        if entry.harnesses.is_empty() && !arrived_empty && uninstalled_known {
             remove_hook_entries.push(entry.name.clone());
         }
     }

--- a/cli/src/commands/refresh.rs
+++ b/cli/src/commands/refresh.rs
@@ -99,6 +99,24 @@ impl RefreshStats {
     pub fn has_missing(&self) -> bool {
         !self.missing.is_empty()
     }
+
+    /// Record an entry whose harness list produced no install attempt at all
+    /// (empty list, or ids this binary does not recognize / the hook does not
+    /// apply to). Without this the entry fell through its refresh pass with no
+    /// success, no failure, and no missing state, and the summary echoed the
+    /// recorded source hash as both old and new — "(unchanged)" for an entry
+    /// that was never re-copied from its source (VST-134).
+    fn fail_no_installable_harness(&mut self, item: &str, harnesses: &[String]) {
+        self.fail(
+            item,
+            None,
+            format!(
+                "no installable harness (recorded harnesses: [{}]); \
+                 re-add the item or run `vstack remove` to drop the stale entry",
+                harnesses.join(", ")
+            ),
+        );
+    }
 }
 
 /// Content hash of an installed skill directory, resolving a symlinked install
@@ -348,6 +366,8 @@ pub fn refresh_items_in_scope(
             if content_changed {
                 stats.mark_content_changed(name);
             }
+        } else if succeeded == 0 && !failed {
+            stats.fail_no_installable_harness(name, &entry.harnesses);
         }
     }
 
@@ -421,6 +441,8 @@ pub fn refresh_items_in_scope(
             if content_changed {
                 stats.mark_content_changed(name);
             }
+        } else if succeeded == 0 && !failed {
+            stats.fail_no_installable_harness(name, &entry.harnesses);
         }
     }
 
@@ -473,6 +495,8 @@ pub fn refresh_items_in_scope(
         if succeeded > 0 && !failed {
             stats.hooks_refreshed += 1;
             stats.mark_success(name);
+        } else if succeeded == 0 && !failed {
+            stats.fail_no_installable_harness(name, &entry.harnesses);
         }
     }
 
@@ -1329,10 +1353,16 @@ fn run_one(global: bool, verbose: bool) -> Result<()> {
             .map(|(_, _, n, _, _)| n.len())
             .max()
             .unwrap_or(0);
+        let failed_items: HashSet<&str> = stats
+            .failures
+            .iter()
+            .map(|failure| failure.item.as_str())
+            .collect();
         for (_, kind, name, old, new) in &changes {
             let missing = stats.missing.contains_key(name);
-            let changed = !missing && is_updated(name, old, new);
-            let mark = if missing {
+            let failed = !missing && failed_items.contains(name.as_str());
+            let changed = !missing && !failed && is_updated(name, old, new);
+            let mark = if missing || failed {
                 "?"
             } else if changed {
                 "!"
@@ -1341,6 +1371,8 @@ fn run_one(global: bool, verbose: bool) -> Result<()> {
             };
             let label = if missing {
                 "missing"
+            } else if failed {
+                "failed"
             } else if changed {
                 "changed"
             } else {
@@ -1351,10 +1383,11 @@ fn run_one(global: bool, verbose: bool) -> Result<()> {
             } else {
                 old.chars().take(8).collect()
             };
-            // A missing item's stored hash is deliberately not echoed as the
-            // new value: printing "<hash> → <hash> (unchanged)" is exactly the
-            // masking this state exists to prevent.
-            let new_short: String = if missing {
+            // A missing or failed item's stored hash is deliberately not echoed
+            // as the new value: printing "<hash> → <hash> (unchanged)" is
+            // exactly the masking those states exist to prevent — an
+            // unrefreshed entry's record says nothing about the live source.
+            let new_short: String = if missing || failed {
                 "—".to_string()
             } else {
                 new.chars().take(8).collect()

--- a/cli/src/commands/refresh.rs
+++ b/cli/src/commands/refresh.rs
@@ -983,6 +983,7 @@ pub fn prune_hook_harnesses(
         };
         let mut new_harnesses = Vec::new();
         let mut uninstalled_known = false;
+        let mut shed_unknown = false;
         for harness_id in &entry.harnesses {
             if hook.applies_to(harness_id) {
                 new_harnesses.push(harness_id.clone());
@@ -990,11 +991,14 @@ pub fn prune_hook_harnesses(
             }
 
             let Some(harness) = Harness::from_id(harness_id) else {
+                // Debug-format the id: it comes from the lock file (untrusted
+                // input) and must not inject control characters into logs.
                 eprintln!(
-                    "Warning: hook {} records unrecognized harness id {harness_id}; \
+                    "Warning: hook {} records unrecognized harness id {harness_id:?}; \
                      dropping it from the lock (nothing this binary can uninstall)",
                     entry.name
                 );
+                shed_unknown = true;
                 pruned_any = true;
                 continue;
             };
@@ -1013,11 +1017,12 @@ pub fn prune_hook_harnesses(
                 }
             }
         }
-        // Only an entry emptied by a COMPLETED self-heal — this run's allowlist
-        // pruning actually uninstalled a recognized harness — is safe to drop.
-        // An entry that arrived already empty (the VST-134 bug shape), or that
-        // emptied solely by shedding unrecognized ids no uninstall ever ran
-        // for, stays in the lock so the refresh pass fails it loudly
+        // Only an entry emptied by a COMPLETED self-heal — every dropped id
+        // was a recognized harness that actually uninstalled this run — is
+        // safe to drop. An entry that arrived already empty (the VST-134 bug
+        // shape), or that shed ANY unrecognized id no uninstall ever ran for
+        // (even alongside successful recognized uninstalls), stays in the
+        // lock so the refresh pass fails it loudly
         // (`fail_no_installable_harness`) instead of silently unmanaging a
         // possibly-stale install.
         let arrived_empty = entry.harnesses.is_empty();
@@ -1025,7 +1030,7 @@ pub fn prune_hook_harnesses(
             entry.harnesses = new_harnesses;
             pruned_any = true;
         }
-        if entry.harnesses.is_empty() && !arrived_empty && uninstalled_known {
+        if entry.harnesses.is_empty() && !arrived_empty && uninstalled_known && !shed_unknown {
             remove_hook_entries.push(entry.name.clone());
         }
     }

--- a/cli/src/commands/refresh.rs
+++ b/cli/src/commands/refresh.rs
@@ -106,13 +106,18 @@ impl RefreshStats {
     /// success, no failure, and no missing state, and the summary echoed the
     /// recorded source hash as both old and new — "(unchanged)" for an entry
     /// that was never re-copied from its source (VST-134).
-    fn fail_no_installable_harness(&mut self, item: &str, harnesses: &[String]) {
+    fn fail_no_installable_harness(&mut self, item: &str, harnesses: &[String], global: bool) {
+        let remove_cmd = if global {
+            format!("vstack remove {item} --global")
+        } else {
+            format!("vstack remove {item}")
+        };
         self.fail(
             item,
             None,
             format!(
                 "no installable harness (recorded harnesses: [{}]); \
-                 re-add the item or run `vstack remove` to drop the stale entry",
+                 re-add the item or run `{remove_cmd}` to drop the stale entry",
                 harnesses.join(", ")
             ),
         );
@@ -367,7 +372,7 @@ pub fn refresh_items_in_scope(
                 stats.mark_content_changed(name);
             }
         } else if succeeded == 0 && !failed {
-            stats.fail_no_installable_harness(name, &entry.harnesses);
+            stats.fail_no_installable_harness(name, &entry.harnesses, global);
         }
     }
 
@@ -442,7 +447,7 @@ pub fn refresh_items_in_scope(
                 stats.mark_content_changed(name);
             }
         } else if succeeded == 0 && !failed {
-            stats.fail_no_installable_harness(name, &entry.harnesses);
+            stats.fail_no_installable_harness(name, &entry.harnesses, global);
         }
     }
 
@@ -496,7 +501,7 @@ pub fn refresh_items_in_scope(
             stats.hooks_refreshed += 1;
             stats.mark_success(name);
         } else if succeeded == 0 && !failed {
-            stats.fail_no_installable_harness(name, &entry.harnesses);
+            stats.fail_no_installable_harness(name, &entry.harnesses, global);
         }
     }
 
@@ -999,11 +1004,18 @@ pub fn prune_hook_harnesses(
                 }
             }
         }
+        // Only an entry emptied by THIS run's allowlist pruning is a completed
+        // self-heal, safe to drop. An entry that arrived already empty was
+        // never emptied by an allowlist change — it is the VST-134 bug shape —
+        // and silently unmanaging it here would mask the stale install exactly
+        // like the summary bug did. Leave it in the lock so the refresh pass
+        // fails it loudly (`fail_no_installable_harness`).
+        let arrived_empty = entry.harnesses.is_empty();
         if new_harnesses != entry.harnesses {
             entry.harnesses = new_harnesses;
             pruned_any = true;
         }
-        if entry.harnesses.is_empty() {
+        if entry.harnesses.is_empty() && !arrived_empty {
             remove_hook_entries.push(entry.name.clone());
         }
     }

--- a/cli/src/commands/refresh/tests.rs
+++ b/cli/src/commands/refresh/tests.rs
@@ -1051,6 +1051,50 @@ fn refresh_fails_loud_when_a_lock_entry_yields_no_harness_install() {
     let _ = std::fs::remove_dir_all(root);
 }
 
+/// Caller-level companion to the test above for the hook shape: production
+/// callers (`run_one`, the TUI) run [`prune_hook_harnesses`] before the
+/// refresh passes, and pruning used to DELETE a hook entry whose harness list
+/// was already empty on arrival — silently unmanaging the bug-shaped entry
+/// (VST-134) before the loud-failure guard could ever see it. Pruning must
+/// only drop an entry it emptied itself (a completed allowlist self-heal);
+/// an arrived-empty entry stays in the lock and fails the refresh pass.
+#[test]
+fn prune_preserves_arrived_empty_hook_entry_for_loud_refresh_failure() {
+    let root = tmpdir("arrived-empty-hook");
+    let project = root.join("project");
+    let source = make_source(&root, "source");
+    std::fs::create_dir_all(&project).unwrap();
+    write_colliding_source(&source, "2", "PreToolUse", "source-model");
+
+    let mut lock = LockFile::default();
+    lock.add(lock_entry("guard", ItemKind::Hook, &source, vec![]));
+    let sources = vec![RefreshSource::from_root(&source)];
+    let source_hooks = all_source_hooks(&sources);
+
+    // run_one ordering: prune first, then the refresh passes.
+    assert!(
+        !prune_hook_harnesses(false, &mut lock, &source_hooks, None),
+        "an arrived-empty entry was not pruned by this run and must not count as pruned"
+    );
+    assert!(
+        lock.entries.contains_key("guard"),
+        "pruning must not silently unmanage an arrived-empty hook entry"
+    );
+
+    let stats = crate::test_util::with_project_root(&project, || {
+        let mut project_config = ProjectConfig::default();
+        refresh_items_in_scope(false, &lock, &sources, &mut project_config, &project, None)
+    });
+    assert!(
+        stats.failures.iter().any(|failure| failure.item == "guard"),
+        "the surviving entry must fail the refresh pass loudly: {:?}",
+        stats.failures
+    );
+    assert_eq!(stats.hooks_refreshed, 0);
+
+    let _ = std::fs::remove_dir_all(root);
+}
+
 /// The single-source fallback must not silently reinstall an entry from a
 /// source it was never installed from — it reports missing instead.
 #[test]

--- a/cli/src/commands/refresh/tests.rs
+++ b/cli/src/commands/refresh/tests.rs
@@ -988,6 +988,69 @@ fn refresh_reports_items_missing_from_their_source_instead_of_skipping() {
     let _ = std::fs::remove_dir_all(root);
 }
 
+/// VST-134: an entry whose harness list yields no installable harness (empty,
+/// or ids this binary does not recognize) used to fall through its refresh pass
+/// silently — no success, no failure, no missing. `run_one` then echoed the
+/// recorded source hash as both old and new and printed "(unchanged)" while the
+/// installed bytes stayed stale after the source advanced. Field signature:
+/// `review-gate c9df07f6 → c9df07f6 (unchanged)` in a fresh consumer worktree
+/// whose copied lock carried such an entry, with the cache already fast-forwarded.
+/// "Unchanged" must mean bytes-identical to the resolved source; an entry that
+/// cannot be re-copied must fail loudly instead.
+#[test]
+fn refresh_fails_loud_when_a_lock_entry_yields_no_harness_install() {
+    let root = tmpdir("no-installable-harness");
+    let project = root.join("project");
+    let source = make_source(&root, "source");
+    std::fs::create_dir_all(&project).unwrap();
+    write_colliding_source(&source, "2", "PreToolUse", "source-model");
+
+    let mut lock = LockFile::default();
+    // The repro shape: empty harness list on a skill (seen in the wild from the
+    // pre-#1047 apply lock bug, carried into a fresh worktree by the lock copy).
+    lock.add(lock_entry("shared", ItemKind::Skill, &source, vec![]));
+    // Unrecognized harness ids are the same silent no-op for agents and hooks.
+    lock.add(lock_entry(
+        "rust",
+        ItemKind::Agent,
+        &source,
+        vec!["not-a-harness"],
+    ));
+    lock.add(lock_entry(
+        "guard",
+        ItemKind::Hook,
+        &source,
+        vec!["not-a-harness"],
+    ));
+    let sources = vec![RefreshSource::from_root(&source)];
+
+    let stats = crate::test_util::with_project_root(&project, || {
+        let mut project_config = ProjectConfig::default();
+        refresh_items_in_scope(false, &lock, &sources, &mut project_config, &project, None)
+    });
+
+    assert!(
+        stats.has_failures(),
+        "zero-install entries must fail loudly, not disappear from the report"
+    );
+    for name in ["shared", "rust", "guard"] {
+        assert!(
+            stats.failures.iter().any(|failure| failure.item == name),
+            "{name} must be reported as a failure: {:?}",
+            stats.failures
+        );
+        assert!(
+            !stats.successful_items.contains(name),
+            "{name} must not count as refreshed"
+        );
+    }
+    assert_eq!(stats.skills_refreshed, 0);
+    assert_eq!(stats.agents_refreshed, 0);
+    assert_eq!(stats.hooks_refreshed, 0);
+
+    let _ = std::fs::remove_dir_all(root);
+}
+
 /// The single-source fallback must not silently reinstall an entry from a
 /// source it was never installed from — it reports missing instead.
 #[test]

--- a/cli/src/commands/refresh/tests.rs
+++ b/cli/src/commands/refresh/tests.rs
@@ -1095,6 +1095,29 @@ fn prune_preserves_arrived_empty_hook_entry_for_loud_refresh_failure() {
     let _ = std::fs::remove_dir_all(root);
 }
 
+/// An entry emptied SOLELY by shedding unrecognized harness ids had no
+/// uninstall run for it — deleting it from the lock would silently unmanage a
+/// possibly-stale install with no cleanup ever attempted. It must survive
+/// pruning (with an empty list) so the refresh pass fails it loudly; only a
+/// completed self-heal (a recognized harness actually uninstalled) may drop
+/// the entry.
+#[test]
+fn prune_keeps_hook_entry_emptied_only_by_unrecognized_ids() {
+    let mut lock = LockFile::default();
+    lock.add(lock_hook("guard", vec!["not-a-harness"]));
+    let hooks = vec![source_hook("guard", Some(vec!["codex"]))];
+
+    assert!(prune_hook_harnesses(false, &mut lock, &hooks, None));
+    let entry = lock
+        .entries
+        .get("guard")
+        .expect("entry emptied without any uninstall must stay in the lock");
+    assert!(
+        entry.harnesses.is_empty(),
+        "the unrecognized id itself is still shed from the list"
+    );
+}
+
 /// The single-source fallback must not silently reinstall an entry from a
 /// source it was never installed from — it reports missing instead.
 #[test]

--- a/cli/src/commands/refresh/tests.rs
+++ b/cli/src/commands/refresh/tests.rs
@@ -1118,6 +1118,27 @@ fn prune_keeps_hook_entry_emptied_only_by_unrecognized_ids() {
     );
 }
 
+/// A MIXED list — a recognized harness that uninstalls fine plus an
+/// unrecognized id — must also survive entry removal: the successful pi
+/// uninstall says nothing about the unknown harness's install, which no
+/// cleanup ever ran for. Deleting the entry would silently unmanage it.
+#[test]
+fn prune_keeps_hook_entry_when_any_shed_id_was_unrecognized() {
+    let mut lock = LockFile::default();
+    lock.add(lock_hook("guard", vec!["pi", "not-a-harness"]));
+    let hooks = vec![source_hook("guard", Some(vec!["codex"]))];
+
+    assert!(prune_hook_harnesses(false, &mut lock, &hooks, None));
+    let entry = lock
+        .entries
+        .get("guard")
+        .expect("mixed-list entry must stay in the lock after shedding an unknown id");
+    assert!(
+        entry.harnesses.is_empty(),
+        "both ids are shed from the list; the entry itself survives for the loud failure"
+    );
+}
+
 /// The single-source fallback must not silently reinstall an entry from a
 /// source it was never installed from — it reports missing instead.
 #[test]


### PR DESCRIPTION
Fixes VST-134 (Linear): `vstack refresh` reported `review-gate c9df07f6 → c9df07f6 (unchanged)` in a fresh consumer worktree while the cache held materially newer bytes.

## Root cause

Not the hypothesized hash-comparison gate — refresh genuinely re-hashes resolved sources, and `install_skill` copies unconditionally. The actual defect: a lock entry whose harness list yields **no install attempt** (empty list — seen in the wild from the pre-#1047 apply lock bug, carried into fresh worktrees by the lock copy — or unrecognized/inapplicable harness ids) fell through its refresh pass with no success, no failure, and no missing state. `run_one` then echoed the recorded source hash as both old and new: the record compared against itself, printed as `(unchanged)`, exit 0, bytes stale.

## Fix

- Zero-install entries are recorded as failures naming the recorded harness list (`no installable harness (recorded harnesses: [...])`), so refresh exits non-zero with an actionable message instead of masking the stale install. Applied to all three passes (agents, skills, hooks); surfaces through the TUI path too.
- Verbose summary prints `<old> → — (failed)` for failed entries — a stored hash is never echoed as the new value for an entry that was not refreshed (mirrors the existing `missing` rationale).

## Verification

- New test `refresh_fails_loud_when_a_lock_entry_yields_no_harness_install` (failing pre-fix, passing post-fix): empty-harness skill + unknown-id agent and hook all reported as failures, none counted refreshed.
- End-to-end with the built binary: corrupt entry → `64704f7f → — (failed)`, exit 1; after repairing the harness list the same refresh re-copies and reports `(changed)`.
- Healthy shapes (lock copy present, lock-recovery via reconcile, `.agents` symlink worktree) verified to re-copy correctly before and after.
- `cargo test`: 517 + 17 passed, 0 failed. `cargo clippy --all-targets` clean.

https://claude.ai/code/session_015yN1mXbYpuKF4jTT5qY2Ck