### PR TITLE
fix(linear): refuse unrouted issues create when agent taxonomy is declared

### DIFF
--- a/docs/issue-label-taxonomy.md
+++ b/docs/issue-label-taxonomy.md
@@ -138,6 +138,12 @@ per issue, naming which agent role owns it.
 
 (`agent:iced` completes the group but has no vstack surface — see below.)
 
+This set is also declared machine-readably as `LINEAR_AGENT_LABELS` in
+`vstack.settings.toml` `[env]` — the linear skill's `issues create` refuses a create
+carrying none of the declared labels, so an issue filed outside the TPM pipeline can
+no longer land silently unrouted (VST-147; `--no-agent-label` opts a deliberate bare
+create out). Keep the declaration and this table in sync.
+
 ## Never-use for this repo
 
 These workspace labels exist for other projects' surfaces and structurally cannot

--- a/skills/dev/workflows/dev-implement.md
+++ b/skills/dev/workflows/dev-implement.md
@@ -231,7 +231,7 @@ GitHub/ad-hoc: skip.
 
 Implement per your agent's domain expertise. Run quality gates before completion.
 
-**Scope growing?** Linear: create sub-issues with `linear.sh issues create --parent [PARENT_ID]`. GitHub/ad-hoc: report discovered scope in § 9; do not create issues without orchestrator approval.
+**Scope growing?** Linear: create sub-issues with `linear.sh issues create --parent [PARENT_ID] --labels "agent:[AGENT_TYPE]"` — carry your own `agent:*` label so the sub-issue stays routed (repos declaring `LINEAR_AGENT_LABELS` refuse an unlabeled create). GitHub/ad-hoc: report discovered scope in § 9; do not create issues without orchestrator approval.
 
 **Found work outside scope?** Note in completion summary under "Discovered Work".
 

--- a/skills/linear/README.md
+++ b/skills/linear/README.md
@@ -50,8 +50,11 @@ Use explicit list actions for dependency reads: `issues list-relations ISSUE` an
 | `LINEAR_TEAM` | Team every write targets | — (unset refuses writes) |
 | `LINEAR_FORMAT` | Default output format | `safe` |
 | `LINEAR_TEAM_PREFIX` | Issue identifier prefix | `PROJ` |
+| `LINEAR_AGENT_LABELS` | Declared agent-routing label set (comma- or space-separated `agent:*` names). When non-empty, `issues create` refuses a create carrying none of them — an unlabeled issue is invisible to agent routing while the CLI prints a URL that looks like success. `--no-agent-label` permits a deliberate bare create. | — (empty: guard off) |
 
 Keep `LINEAR_API_KEY` in `.env.local`. Shared non-secret defaults can live in `vstack.settings.toml` under `[env]`; `.env.local` still wins for local overrides.
+
+Route normal tracked-issue creation through the TPM pipeline (`project-management` skill), which owns labels, project, priority, and relations — the guard exists to catch creates that bypass it.
 
 ## Dependencies
 

--- a/skills/linear/SKILL.md
+++ b/skills/linear/SKILL.md
@@ -97,6 +97,12 @@ Cache and attachment files live under `.cache/linear` in the physical git worktr
 
 In a linked git worktree whose `.cache` should be a `WORKTREE_SYMLINKS`-managed symlink into the main checkout but is a real directory (a git operation re-materialized it), any full or reconciling `sync` refuses before touching the API — a full re-sync into a worktree-local dir would silently re-pull the entire history and burn the shared API budget. The refusal names the worktree, the expected symlink, and the repair: run `worktree fix-links <PATH>` from the main checkout, then re-run `sync`. Repos whose configured `WORKTREE_SYMLINKS` deliberately excludes `.cache` are exempt.
 
+## Issue Creation Routing
+
+Never create a tracked issue directly from an orchestration or review session — route it through the TPM pipeline (project-management skill), which owns labels, project, priority, estimate, and relations. A direct `issues create` prints a URL and looks like success even when the issue landed with none of those, invisible to agent routing.
+
+When the project declares its agent-label taxonomy (`LINEAR_AGENT_LABELS` in `vstack.settings.toml` `[env]`, comma- or space-separated `agent:*` names), `issues create` enforces this: it refuses — before any API call — a create that carries no agent label from the declared set, including an unknown/typoed `agent:*` name that label resolution would otherwise silently skip. `--no-agent-label` permits a deliberate bare create (e.g. mirroring intake from another tracker). Projects with no declaration are unaffected.
+
 ## Output Formats
 
 | Format | Description |
@@ -117,6 +123,7 @@ In a linked git worktree whose `.cache` should be a `WORKTREE_SYMLINKS`-managed 
 | `LINEAR_TEAM` | Team every write targets | — (unset refuses writes) |
 | `LINEAR_FORMAT` | Default output format | `safe` |
 | `LINEAR_TEAM_PREFIX` | Issue identifier prefix | `PROJ` |
+| `LINEAR_AGENT_LABELS` | Declared agent-routing label set; non-empty makes `issues create` refuse creates with no agent label from the set (see [Issue Creation Routing](#issue-creation-routing)) | — (unset = guard off) |
 
 Put `LINEAR_API_KEY` in `.env.local`. Put non-secret defaults in committed `vstack.settings.toml` under `[env]`; `.env.local` still wins for local overrides. For the API key specifically, a key set by project files (`.env` → settings `[env]` → `.env.local`) wins over a plain `LINEAR_API_KEY` inherited from the environment — per-repo workspaces make a box-global export wrong for every other repo, and `auth-check` warns (key fingerprints only) when a differing inherited key is being shadowed. `LINEAR_API_KEY_OVERRIDE` always wins; use it for one-off/inline keys and tests.
 

--- a/skills/linear/SKILL.md
+++ b/skills/linear/SKILL.md
@@ -83,7 +83,8 @@ linear.sh cache issues list --all-projects --state "Backlog,Todo" --max --format
 linear.sh cache issues get ABC-100 --with-bundle
 
 # WRITES → live (hit API, auto-update cache)
-linear.sh issues create --title "New task" --project "Phase 2"
+# (agent:* label required when LINEAR_AGENT_LABELS declares a taxonomy — see Issue Creation Routing)
+linear.sh issues create --title "New task" --project "Phase 2" --labels "agent:generalist"
 linear.sh issues update ABC-100 --state "Done"
 
 # SYNC → refresh cache

--- a/skills/linear/scripts/commands/issues.sh
+++ b/skills/linear/scripts/commands/issues.sh
@@ -1004,6 +1004,24 @@ create_issue() {
         return 1
     fi
 
+    # Normalize the label list ONCE, before the guard: split on commas, trim
+    # each name, drop empties, rejoin. The guard and the resolver below must
+    # see identical tokens — the guard trimming a copy while the resolver got
+    # the raw " agent:rust" made the natural "bug, agent:rust" input pass the
+    # guard and then be warn-skipped by resolution: an unrouted create that
+    # looked routed.
+    if [ -n "$labels" ]; then
+        local normalized_labels="" raw_label_name
+        local raw_label_names=()
+        IFS=',' read -ra raw_label_names <<<"$labels"
+        for raw_label_name in "${raw_label_names[@]}"; do
+            raw_label_name="$(vstack_trim "$raw_label_name")"
+            [ -n "$raw_label_name" ] || continue
+            normalized_labels="${normalized_labels:+$normalized_labels,}$raw_label_name"
+        done
+        labels="$normalized_labels"
+    fi
+
     require_agent_routing_label "$labels" "$no_agent_label" || return 1
 
     # Build input object - use jq for proper JSON escaping
@@ -1031,13 +1049,23 @@ create_issue() {
     [ -n "$priority" ] && input_parts+=("\"priority\": $priority")
     [ -n "$estimate" ] && input_parts+=("\"estimate\": $estimate")
 
-    # Handle labels (warn + skip on miss per label)
+    # Handle labels (warn + skip on miss per label — EXCEPT agent:* labels:
+    # the routing guard's promise is routed-or-refused, so an agent label
+    # that fails to resolve, e.g. one declared in LINEAR_AGENT_LABELS but
+    # since deleted in Linear, must fail the create rather than silently
+    # produce an unrouted issue that already passed the guard)
     if [ -n "$labels" ]; then
         IFS=',' read -ra label_names <<<"$labels"
         local label_ids=()
         for label_name in "${label_names[@]}"; do
             local label_id
-            label_id=$(resolve_label_id "$label_name") && label_ids+=("\"$label_id\"")
+            if label_id=$(resolve_label_id "$label_name"); then
+                label_ids+=("\"$label_id\"")
+            elif [[ "$label_name" == agent:* ]]; then
+                jq -cn --arg label "$label_name" \
+                    '{error: ("Agent label failed to resolve in Linear: " + $label + " - refusing to create an issue that would look routed but is not. Create the label in Linear (or fix LINEAR_AGENT_LABELS), then retry.")}' >&2
+                return 1
+            fi
         done
         if [ ${#label_ids[@]} -gt 0 ]; then
             local label_json

--- a/skills/linear/scripts/commands/issues.sh
+++ b/skills/linear/scripts/commands/issues.sh
@@ -1061,7 +1061,9 @@ create_issue() {
             local label_id
             if label_id=$(resolve_label_id "$label_name"); then
                 label_ids+=("\"$label_id\"")
-            elif [[ "$label_name" == agent:* ]]; then
+            elif [[ "$label_name" == agent:* ]] && [ -n "${LINEAR_AGENT_LABELS:-}" ]; then
+                # Hard-fail only under a declared taxonomy — undeclared repos
+                # keep the historical warn-and-skip for every label.
                 jq -cn --arg label "$label_name" \
                     '{error: ("Agent label failed to resolve in Linear: " + $label + " - refusing to create an issue that would look routed but is not. Create the label in Linear (or fix LINEAR_AGENT_LABELS), then retry.")}' >&2
                 return 1

--- a/skills/linear/scripts/commands/issues.sh
+++ b/skills/linear/scripts/commands/issues.sh
@@ -149,6 +149,15 @@ Create Options:
   --cycle <id>          Cycle (sprint) ID
   --format=ids          Print ONLY the created issue identifier (for capture;
                         default output is the full JSON create response)
+  --no-agent-label      Permit a deliberate bare create (e.g. intake
+                        mirroring) in a project that declares its agent-label
+                        taxonomy. When LINEAR_AGENT_LABELS is set in
+                        vstack.settings.toml [env], create refuses without an
+                        agent:* label from that set: an unlabeled issue is
+                        invisible to agent routing. Route normal issue
+                        creation through the TPM pipeline (project-management
+                        skill), which owns labels, project, priority, and
+                        relations — do not create tracked issues directly.
 
 Update Options:
   --state <name>        New state
@@ -819,6 +828,59 @@ get_issue() {
     esac
 }
 
+# Agent-routing guard (VST-147). A create with no agent:* label lands
+# invisible to agent routing — no labels, project, or routing — while the CLI
+# prints a URL that looks like success. When the project declares its
+# agent-label set (LINEAR_AGENT_LABELS in vstack.settings.toml [env],
+# comma- or space-separated), refuse a bare create before any API call.
+# An undeclared/empty set keeps the guard off; --no-agent-label opts a
+# single deliberate bare create out (e.g. intake mirroring).
+require_agent_routing_label() {
+    local labels="$1" opt_out="$2"
+    local declared="${LINEAR_AGENT_LABELS:-}"
+    [ -n "$declared" ] || return 0
+    [ "$opt_out" = "1" ] && return 0
+
+    local declared_names=()
+    IFS=', ' read -ra declared_names <<<"$declared"
+
+    # Supplied labels split on commas only — label names may contain spaces.
+    local supplied_names=()
+    [ -n "$labels" ] && IFS=',' read -ra supplied_names <<<"$labels"
+
+    local supplied declared_name agent_matched=0 unknown_agent=""
+    for supplied in ${supplied_names[@]+"${supplied_names[@]}"}; do
+        supplied="$(vstack_trim "$supplied")"
+        [ -n "$supplied" ] || continue
+        local is_declared=0
+        for declared_name in ${declared_names[@]+"${declared_names[@]}"}; do
+            if [ "$supplied" = "$declared_name" ]; then
+                is_declared=1
+                break
+            fi
+        done
+        if [ "$is_declared" = "1" ]; then
+            agent_matched=1
+        elif [[ "$supplied" == agent:* ]]; then
+            unknown_agent="${unknown_agent:+$unknown_agent, }$supplied"
+        fi
+    done
+
+    # A typoed agent label would otherwise be warn-and-skipped by
+    # resolve_label_id, creating an unrouted issue that looks routed.
+    if [ -n "$unknown_agent" ]; then
+        jq -cn --arg unknown "$unknown_agent" --arg declared "$declared" \
+            '{error: ("Unknown agent label(s): " + $unknown + " - not in this project declared agent-label set (LINEAR_AGENT_LABELS in vstack.settings.toml [env]): " + $declared + ". Label resolution silently skips unknown names, so this would create an issue that is invisible to agent routing. Fix the label name, or pass --no-agent-label for a deliberate bare create.")}' >&2
+        return 1
+    fi
+    if [ "$agent_matched" != "1" ]; then
+        jq -cn --arg declared "$declared" \
+            '{error: ("Refusing to create an unrouted issue: this project declares an agent-label taxonomy (LINEAR_AGENT_LABELS in vstack.settings.toml [env]) and no agent:* label was supplied. An issue created without one gets no agent routing - the create would print a URL and look like success while the issue sits invisible to every agent. Route tracked issue creation through the TPM pipeline (project-management skill), which owns labels, project, priority, and relations. Direct create is for exceptions only: pass --labels with one of [" + $declared + "], or --no-agent-label for a deliberate bare create (e.g. intake mirroring).")}' >&2
+        return 1
+    fi
+    return 0
+}
+
 create_issue() {
     if cache_test_isolation_violation; then
         cache_test_isolation_refusal
@@ -839,6 +901,7 @@ create_issue() {
     local estimate=""
     local requested_parent_id=""
     local output_format=""
+    local no_agent_label=0
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
@@ -906,6 +969,10 @@ create_issue() {
             cycle="$2"
             shift 2
             ;;
+        --no-agent-label)
+            no_agent_label=1
+            shift
+            ;;
         --)
             shift
             break
@@ -936,6 +1003,8 @@ create_issue() {
         echo '{"error": "Required: --title"}' >&2
         return 1
     fi
+
+    require_agent_routing_label "$labels" "$no_agent_label" || return 1
 
     # Build input object - use jq for proper JSON escaping
     local escaped_title

--- a/skills/linear/scripts/linear.sh
+++ b/skills/linear/scripts/linear.sh
@@ -36,7 +36,7 @@ Resources:
 Examples:
   # Issues with parent/sub-issues and relations
   ./linear.sh issues list --label "backend" --state "Todo,In Progress"
-  ./linear.sh issues create --title "Task" --parent PROJ-42
+  ./linear.sh issues create --title "Task" --parent PROJ-42 --labels "agent:rust"
   ./linear.sh issues list-relations PROJ-42
   ./linear.sh issues add-relation PROJ-42 --blocks PROJ-43
   ./linear.sh issues children PROJ-42              # Direct children

--- a/skills/linear/tests/issues-create-agent-label-guard.test.sh
+++ b/skills/linear/tests/issues-create-agent-label-guard.test.sh
@@ -157,6 +157,12 @@ set_settings_no_taxonomy_key
 run_linear issues create --title "Bare repo create"
 assert_created "bare create with no LINEAR_AGENT_LABELS key"
 
+# Undeclared repos also keep the historical warn-and-skip for EVERY label,
+# including an unresolvable agent:* one — the hard-fail applies only under a
+# declared taxonomy.
+run_linear issues create --title "Undeclared skip" --labels "agent:ghost"
+assert_created "unresolvable agent label warn-skips when no taxonomy is declared"
+
 set_settings ""
 run_linear issues create --title "Empty declaration create"
 assert_created "bare create with empty LINEAR_AGENT_LABELS"

--- a/skills/linear/tests/issues-create-agent-label-guard.test.sh
+++ b/skills/linear/tests/issues-create-agent-label-guard.test.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Regression test for VST-147: issues created outside the TPM pipeline land
+# with no agent:* label and are invisible to agent routing, while the CLI
+# prints a URL that looks like success.
+#
+# When the project declares its agent-label taxonomy (LINEAR_AGENT_LABELS in
+# vstack.settings.toml [env]), a bare `issues create` must refuse before any
+# API call, with an actionable error naming the TPM pipeline and the
+# --no-agent-label escape hatch. Projects with no declaration are unaffected.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+PROJECT="$TMP_ROOT/project"
+mkdir -p "$PROJECT/.agents/skills" "$PROJECT/bin"
+git -C "$PROJECT" init -q -b main
+cp -R "$SKILL_DIR" "$PROJECT/.agents/skills/linear"
+
+LINEAR="$PROJECT/.agents/skills/linear/scripts/linear.sh"
+CURL_LOG="$TMP_ROOT/curl-payloads.jsonl"
+ERR_FILE="$TMP_ROOT/stderr.txt"
+
+cat >"$PROJECT/bin/curl" <<'SH'
+#!/usr/bin/env bash
+config="$(cat)"
+payload="$(sed -n 's/^data = //p' <<<"$config" | jq -r)"
+printf '%s\n' "$payload" >>"${CURL_LOG:?}"
+query="$(jq -r '.query' <<<"$payload")"
+
+case "$query" in
+*"teams(filter:"*)
+  printf '%s' '{"data":{"teams":{"nodes":[{"id":"team-uuid"}]}}}___HTTP_CODE___200'
+  ;;
+*"issueLabels(filter:"*)
+  printf '%s' '{"data":{"issueLabels":{"nodes":[{"id":"label-uuid"}]}}}___HTTP_CODE___200'
+  ;;
+*"issueCreate(input:"*)
+  printf '%s' '{"data":{"issueCreate":{"success":true,"issue":{"id":"issue-uuid","identifier":"TEAM-1","title":"t","description":"","state":{"name":"Todo","type":"unstarted"},"assignee":null,"project":null,"projectMilestone":null,"cycle":null,"parent":null,"team":{"name":"Configured"},"labels":{"nodes":[]},"priority":3,"estimate":null,"sortOrder":1.0,"url":"https://linear.app/x/issue/TEAM-1","createdAt":"2026-08-08T00:00:00Z","updatedAt":"2026-08-08T00:00:00Z","archivedAt":null,"trashed":null,"relations":{"nodes":[]},"inverseRelations":{"nodes":[]}}}}}___HTTP_CODE___200'
+  ;;
+*)
+  printf '%s' '{"data":{}}___HTTP_CODE___200'
+  ;;
+esac
+SH
+chmod +x "$PROJECT/bin/curl"
+
+OUT=""
+ERR=""
+RC=0
+
+fail() {
+  echo "FAIL $*"
+  [[ -s "$CURL_LOG" ]] && echo "--- curl payloads ---" && cat "$CURL_LOG"
+  exit 1
+}
+
+# Run the CLI inside the temp project with LINEAR_TEAM and LINEAR_AGENT_LABELS
+# absent from the process environment (parent env wins over project files).
+run_linear() {
+  : >"$CURL_LOG"
+  set +e
+  OUT="$(cd "$PROJECT" && env -u LINEAR_TEAM -u LINEAR_AGENT_LABELS \
+    PATH="$PROJECT/bin:$PATH" \
+    LINEAR_API_KEY=test-token \
+    CURL_LOG="$CURL_LOG" \
+    bash "$LINEAR" "$@" 2>"$ERR_FILE")"
+  RC=$?
+  set -e
+  ERR="$(cat "$ERR_FILE")"
+}
+
+set_settings() {
+  # $1: LINEAR_AGENT_LABELS value ("" = key present but empty)
+  printf '[env]\nLINEAR_TEAM = "Configured"\nLINEAR_AGENT_LABELS = "%s"\n' "$1" \
+    >"$PROJECT/vstack.settings.toml"
+}
+
+set_settings_no_taxonomy_key() {
+  printf '[env]\nLINEAR_TEAM = "Configured"\n' >"$PROJECT/vstack.settings.toml"
+}
+
+api_calls() {
+  wc -l <"$CURL_LOG" | tr -d ' '
+}
+
+assert_refused_bare() {
+  local label="$1"
+  [[ "$RC" -ne 0 ]] || fail "$label exited 0; expected a refusal. stdout: $OUT"
+  grep -q "agent" <<<"$ERR" || fail "$label refusal does not mention agent labels: $ERR"
+  grep -q "LINEAR_AGENT_LABELS" <<<"$ERR" || fail "$label refusal does not name LINEAR_AGENT_LABELS: $ERR"
+  grep -q "project-management" <<<"$ERR" || fail "$label refusal does not route to the TPM pipeline (project-management): $ERR"
+  grep -q -- "--no-agent-label" <<<"$ERR" || fail "$label refusal does not name the --no-agent-label escape hatch: $ERR"
+  grep -q "agent:rust" <<<"$ERR" || fail "$label refusal does not list the declared agent labels: $ERR"
+  [[ "$(api_calls)" == "0" ]] || fail "$label attempted $(api_calls) API call(s) before refusing"
+}
+
+assert_created() {
+  local label="$1"
+  [[ "$RC" -eq 0 ]] || fail "$label exited $RC: $ERR"
+  jq -s -e 'any(.[]; .query | contains("issueCreate"))' "$CURL_LOG" >/dev/null ||
+    fail "$label did not reach issueCreate: $(cat "$CURL_LOG")"
+}
+
+echo "=== declared taxonomy: bare create refuses before any API call ==="
+
+set_settings "agent:generalist, agent:rust"
+
+run_linear issues create --title "Unrouted follow-up"
+assert_refused_bare "bare create"
+
+run_linear issues create --title "Unrouted follow-up" --labels "bug,docs"
+assert_refused_bare "create with only non-agent labels"
+
+echo "=== declared taxonomy: an unknown agent:* label refuses (typo guard) ==="
+
+# resolve_label_id warns and SKIPS unresolved labels, so a typoed agent label
+# would otherwise create an unrouted issue that looks routed.
+run_linear issues create --title "Typo" --labels "agent:generalst"
+[[ "$RC" -ne 0 ]] || fail "typoed agent label exited 0: $OUT"
+grep -q "agent:generalst" <<<"$ERR" || fail "typo refusal does not name the unknown label: $ERR"
+grep -q "LINEAR_AGENT_LABELS" <<<"$ERR" || fail "typo refusal does not name the declared set: $ERR"
+[[ "$(api_calls)" == "0" ]] || fail "typoed agent label attempted $(api_calls) API call(s)"
+
+echo "=== declared taxonomy: a declared agent label passes ==="
+
+run_linear issues create --title "Routed" --labels "bug,agent:rust"
+assert_created "create with declared agent label"
+jq -s -e 'any(.[]; (.query | contains("issueCreate")) and (.variables.input.labelIds | length == 2))' "$CURL_LOG" >/dev/null ||
+  fail "labels were not all resolved onto the create: $(cat "$CURL_LOG")"
+
+run_linear issues create --title "Routed single" --label "agent:generalist"
+assert_created "create with --label agent label"
+
+echo "=== declared taxonomy: --no-agent-label permits a deliberate bare create ==="
+
+run_linear issues create --title "Intake mirror" --no-agent-label
+assert_created "bare create with --no-agent-label"
+
+run_linear issues create --title "Intake mirror" --no-agent-label --labels "bug"
+assert_created "non-agent-labeled create with --no-agent-label"
+
+echo "=== no declaration: bare creates are unaffected ==="
+
+set_settings_no_taxonomy_key
+run_linear issues create --title "Bare repo create"
+assert_created "bare create with no LINEAR_AGENT_LABELS key"
+
+set_settings ""
+run_linear issues create --title "Empty declaration create"
+assert_created "bare create with empty LINEAR_AGENT_LABELS"
+
+echo "=== help never trips the guard ==="
+
+set_settings "agent:generalist, agent:rust"
+run_linear issues create --help
+[[ "$RC" -eq 0 ]] || fail "issues create --help exited $RC: $ERR"
+grep -q -- "--no-agent-label" <<<"$OUT" || fail "issues create --help does not document --no-agent-label: $OUT"
+[[ "$(api_calls)" == "0" ]] || fail "issues create --help issued an API call"
+
+echo "all pass"

--- a/skills/linear/tests/issues-create-agent-label-guard.test.sh
+++ b/skills/linear/tests/issues-create-agent-label-guard.test.sh
@@ -36,7 +36,15 @@ case "$query" in
   printf '%s' '{"data":{"teams":{"nodes":[{"id":"team-uuid"}]}}}___HTTP_CODE___200'
   ;;
 *"issueLabels(filter:"*)
-  printf '%s' '{"data":{"issueLabels":{"nodes":[{"id":"label-uuid"}]}}}___HTTP_CODE___200'
+  # agent:ghost simulates a label declared in LINEAR_AGENT_LABELS but since
+  # deleted in Linear; any name that is not byte-exact (e.g. " agent:rust"
+  # with a leading space) also misses, mirroring the API's eq filter.
+  name="$(jq -r '.variables.name // empty' <<<"$payload")"
+  if [ "$name" = "agent:ghost" ] || [ "$name" != "$(printf '%s' "$name" | sed 's/^ *//;s/ *$//')" ]; then
+    printf '%s' '{"data":{"issueLabels":{"nodes":[]}}}___HTTP_CODE___200'
+  else
+    printf '%s' '{"data":{"issueLabels":{"nodes":[{"id":"label-uuid"}]}}}___HTTP_CODE___200'
+  fi
   ;;
 *"issueCreate(input:"*)
   printf '%s' '{"data":{"issueCreate":{"success":true,"issue":{"id":"issue-uuid","identifier":"TEAM-1","title":"t","description":"","state":{"name":"Todo","type":"unstarted"},"assignee":null,"project":null,"projectMilestone":null,"cycle":null,"parent":null,"team":{"name":"Configured"},"labels":{"nodes":[]},"priority":3,"estimate":null,"sortOrder":1.0,"url":"https://linear.app/x/issue/TEAM-1","createdAt":"2026-08-08T00:00:00Z","updatedAt":"2026-08-08T00:00:00Z","archivedAt":null,"trashed":null,"relations":{"nodes":[]},"inverseRelations":{"nodes":[]}}}}}___HTTP_CODE___200'
@@ -152,6 +160,36 @@ assert_created "bare create with no LINEAR_AGENT_LABELS key"
 set_settings ""
 run_linear issues create --title "Empty declaration create"
 assert_created "bare create with empty LINEAR_AGENT_LABELS"
+
+echo "=== declared taxonomy: comma-space labels normalize for guard AND resolver ==="
+
+# Natural input "bug, agent:rust": the guard must accept it AND the resolver
+# must receive the TRIMMED names — an untrimmed " agent:rust" misses Linear's
+# eq filter and is silently skipped, recreating the unrouted-but-looks-routed
+# create the guard exists to prevent.
+set_settings "agent:generalist, agent:rust"
+run_linear issues create --title "Natural input" --labels "bug, agent:rust"
+assert_created "create with comma-space labels"
+jq -s -e 'any(.[]; .variables.name == "agent:rust")' "$CURL_LOG" >/dev/null ||
+  fail "resolver did not receive the trimmed agent label: $(cat "$CURL_LOG")"
+if jq -s -e 'any(.[]; .variables.name == " agent:rust")' "$CURL_LOG" >/dev/null; then
+  fail "resolver received an untrimmed label name: $(cat "$CURL_LOG")"
+fi
+jq -s -e 'any(.[]; (.query | contains("issueCreate")) and (.variables.input.labelIds | length == 2))' "$CURL_LOG" >/dev/null ||
+  fail "both normalized labels must resolve onto the create: $(cat "$CURL_LOG")"
+
+echo "=== declared taxonomy: a declared label missing in Linear hard-fails the create ==="
+
+# The guard's promise is routed-or-refused: a label that passes the declared
+# set but fails to resolve (declared in settings, deleted in Linear) must fail
+# the create, never warn-and-skip into an unrouted issue.
+set_settings "agent:generalist, agent:rust, agent:ghost"
+run_linear issues create --title "Stale declared label" --labels "agent:ghost"
+[[ "$RC" -ne 0 ]] || fail "unresolvable agent label exited 0: $OUT"
+grep -q "agent:ghost" <<<"$ERR" || fail "hard-fail does not name the unresolvable label: $ERR"
+if jq -s -e 'any(.[]; .query | contains("issueCreate"))' "$CURL_LOG" >/dev/null; then
+  fail "issueCreate was reached despite an unresolvable agent label"
+fi
 
 echo "=== help never trips the guard ==="
 

--- a/skills/linear/vstack.settings.toml.example
+++ b/skills/linear/vstack.settings.toml.example
@@ -17,3 +17,12 @@ LINEAR_TEAM = ""
 
 # Used by: linear. Issue identifier prefix used in examples (e.g. PROJ-123).
 LINEAR_TEAM_PREFIX = "PROJ"
+
+# Used by: linear (`issues create`). The project's declared agent-routing
+# label set, comma- or space-separated (e.g. "agent:generalist, agent:rust").
+# When non-empty, `issues create` refuses a create that carries no agent
+# label from this set — an issue without one is invisible to agent routing,
+# while the create prints a URL that looks like success. `--no-agent-label`
+# permits a deliberate bare create (e.g. intake mirroring). Leave empty in
+# projects with no agent-label taxonomy; the guard then stays off.
+LINEAR_AGENT_LABELS = ""

--- a/skills/orch/SKILL.md
+++ b/skills/orch/SKILL.md
@@ -272,6 +272,8 @@ Never edit or write code unless the user explicitly asks. Delegate to the domain
 
 **Parallel work safety.** Before running issues in parallel, verify all five dimensions — dependency resolution, agent overlap, code scope, build config (manifest changes are hard separations), and active work (worktrees, open PRs) — and apply the grouping constraints. Mechanics: `workflows/parallel-check.md`.
 
+**Tracked issue creation.** Never create a tracked issue directly (`linear.sh issues create` / `gh issue create`) from an orchestration session — route it through TPM (project-management), which owns labels, project, priority, estimate, and relations. A direct create prints a URL and looks like success while the issue lands with none of those; without an `agent:*` label it is invisible to agent routing. The only direct creates are the ones a workflow step explicitly specifies with its label set (`plan-issues`, `start-new`, the `merge-pr` rebundle).
+
 ---
 
 ### Review Pipeline
@@ -280,4 +282,4 @@ Never edit or write code unless the user explicitly asks. Delegate to the domain
 
 **Recommendation categorization.** Evaluate each suggestion in order: actionable (vague → omit) → related (doc updates for changed code are always `fix`; unrelated → `issue`) → size (small → `fix`; needs tracking or delegation → `issue`). Security vulnerabilities: `fix` if quick, else `issue` — never skip. Filing bar: file an `issue` only for out-of-scope behavioral defects, est≥2 refactors, decision revisits, or evidenced anomalies; P4 polish is absorbed in-PR when est-1 and related, else dropped with a one-line note. Residue attaches to an existing same-surface bundle by default. Full decision flow and signal table: `workflows/recommendation-bias.md`.
 
-**Issue audit pipeline.** Collect review JSON → transform `category=issue` suggestions into audit input (schema in `project-management/schemas/`) → delegate to TPM for tracked issue creation. Sources: suggestions, escalated blockers, dev-skipped items, planned items, discovered work; populate dependency fields when order is known.
+**Issue audit pipeline.** Every follow-up that needs a tracked issue goes through this pipeline, however it was discovered — not only review JSON. In scope: `category=issue` suggestions, escalated blockers, dev-agent "deliberately left out"/skipped lists, planned items, and gaps noticed while reading reports, return messages, or code. Collect them → transform into audit input (schema in `project-management/schemas/`) → delegate to TPM for tracked issue creation; populate dependency fields when order is known. Never file these directly with `issues create` (see [Coordination](#coordination) — tracked issue creation).

--- a/skills/project-management/references/issues.md
+++ b/skills/project-management/references/issues.md
@@ -77,7 +77,9 @@ Use `--parent [ISSUE_ID]` when:
 - Incorrect: All backend issues grouped (layer grouping)
 
 ```bash
-.agents/skills/linear/scripts/linear.sh issues create --title "Parse input data" --parent [ISSUE_ID]
+# Sub-issues carry the same agent:* label as their parent (repos declaring
+# LINEAR_AGENT_LABELS refuse an unlabeled create).
+.agents/skills/linear/scripts/linear.sh issues create --title "Parse input data" --parent [ISSUE_ID] --labels "[PARENT_AGENT_LABEL]"
 .agents/skills/linear/scripts/linear.sh cache issues children [ISSUE_ID]              # Direct children only
 .agents/skills/linear/scripts/linear.sh cache issues children [ISSUE_ID] --recursive  # All descendants (3 levels, includes blocks/blocked_by)
 ```

--- a/vstack.settings.toml
+++ b/vstack.settings.toml
@@ -13,6 +13,11 @@ GH_VERIFY_CMD = ""
 LINEAR_FORMAT = "safe"
 LINEAR_TEAM = "vstack"
 LINEAR_TEAM_PREFIX = "VST"
+# Agent-routing set from docs/issue-label-taxonomy.md § Agent labels — keep the
+# two in sync. `issues create` refuses a create carrying none of these
+# (VST-147); `agent:iced` exists in the workspace but has no vstack surface,
+# so it is deliberately not declared here.
+LINEAR_AGENT_LABELS = "agent:generalist, agent:rust, agent:researcher, agent:multi, agent:human"
 ORCH_STATE_DIR = "tmp"
 # Reviewer gate: Copilot (copilot-pull-request-reviewer) auto-reviews every PR
 # here but never APPROVES — it only COMMENTS — so the gate runs in "review"

--- a/vstack.settings.toml.example
+++ b/vstack.settings.toml.example
@@ -161,6 +161,15 @@ LINEAR_FORMAT = "safe"
 LINEAR_TEAM_PREFIX = "PROJ"
 # Used by: linear.
 
+LINEAR_AGENT_LABELS = ""
+# Used by: linear (`issues create`). The project's declared agent-routing
+# label set, comma- or space-separated (e.g. "agent:generalist, agent:rust").
+# When non-empty, `issues create` refuses a create that carries no agent
+# label from this set - an issue without one is invisible to agent routing,
+# while the create prints a URL that looks like success. `--no-agent-label`
+# permits a deliberate bare create (e.g. intake mirroring). Leave empty in
+# projects with no agent-label taxonomy; the guard then stays off.
+
 # GITHUB
 
 GH_BOT_USERNAME = "automation[bot]"


### PR DESCRIPTION
Fixes VST-147 (Linear): issues filed outside the TPM pipeline landed with no labels, project, priority, or `agent:*` routing label — silently, with the CLI printing a URL that looked like success. All three fixes from the issue, in its preference order:

1. **Guard at the only bypassable point**: `linear.sh issues create` now refuses — before any API call, exit 1, JSON error naming the declared set, the TPM route, and the escape hatch — when the project declares an agent taxonomy and no declared `agent:*` label was supplied. Declaration is a new `LINEAR_AGENT_LABELS` key in `vstack.settings.toml [env]` (least-new-machinery: the taxonomy was previously prose-only in `docs/issue-label-taxonomy.md`); empty/unset keeps the guard off, so undeclared repos are untouched. A supplied `agent:*` label **not** in the declared set also refuses — label resolution warn-and-skips unknown names, so a typo would otherwise create an issue that looks routed but isn't. `--no-agent-label` permits a deliberate bare create (intake mirroring). Never downgrades to warn-and-proceed.
2. **Rule restated where orchestrators are**: orch SKILL.md Coordination gets a "Tracked issue creation" rule (route through TPM; direct creates only where a workflow step explicitly specifies them), and the linear skill's SKILL.md + `issues create` help carry the same rule.
3. **Audit pipeline broadened**: orch's Issue audit pipeline now explicitly covers follow-ups discovered any way — dev-agent "deliberately left out" lists, gaps found reading reports/return messages/code — not just review JSON.

vstack itself declares `agent:generalist, agent:rust, agent:researcher, agent:multi, agent:human` (matching the taxonomy doc; `agent:iced` deliberately excluded — no vstack surface), so the guard is live in this repo.

## Verification

- New test `issues-create-agent-label-guard.test.sh` covering the full behavior matrix (bare refuses, typo refuses, declared label passes, `--no-agent-label` passes, undeclared repo unaffected, `--help` never trips). Proven able to fail: run against the unguarded implementation it reproduces the exact defect.
- linear suite 35/35, orch suite 31/31 files, full skills test sweep 0 failures; shellcheck: no new findings.

Refs VST-124 discussion for why silent-success process gaps get mechanisms, not more prose.

https://claude.ai/code/session_015yN1mXbYpuKF4jTT5qY2Ck