### PR TITLE
feat(orch): budget local pre-PR review passes per pushed head

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- **orch: local pre-PR review passes are budgeted per pushed head, not per
+  submission** (VST-153, follow-up to the vstack#1141 `reviewed_head` artifact
+  stamp). `submit-pr` § 1.2 checks the budget through the new
+  `local-review-budget` helper: `pr_local_review.passes` now counts against
+  `pr_local_review.reviewed_head` (recorded from the review artifact's
+  `qa_metadata.reviewed_head` after each counted pass), and a head change
+  resets the round — GitHub bots re-review every push, so a new head is a new
+  round; the 2-pass cap binds only within a single head.
+
 - **orch (breaking, removal): the legacy consumer script pair is gone.**
   `skills/orch/scripts/ci/{review-predicate.sh,approval-refire.sh}` and
   their tests existed only for pre-v2 hyprtrade, which completed its v2

--- a/skills/orch/SKILL.md
+++ b/skills/orch/SKILL.md
@@ -93,6 +93,7 @@ Reference workflows (no command): `workflows/agent-sequencing.md` — cross-doma
 | `queue-wait` | Block until a PR's merge-queue / auto-merge outcome is decided — the merge-pr § 3.2 queue watch. Contract: [references/gates.md](references/gates.md) |
 | `orch-env` | Effective value of a vstack `[env]` setting (process env > `vstack.settings.toml` > supplied default) |
 | `refix-route` | Decide whether a fix round needs re-review; prints `{decision, class, reason, …}`. Route on `class`, never on `scope` alone (`review-pr` § 4 / § 7 / § 10) |
+| `local-review-budget` | Effective local pre-PR review pass count for the worktree's current head; prints `{passes, max_passes, exhausted, head, reviewed_head, reset}` and atomically restarts the counter when the head moved — the budget is per pushed head, never per submission (`submit-pr` § 1.2). Contract: `--help` |
 | `session-init` | Initialize session state for a new worktree (called by `initialize.md`) |
 | `spawn-adapter` | Resolve Codex spawn parameters (`spawn`) and the runtime thread budget (`slots`) — see the Codex runtime notes above |
 | `open-terminal` | Launch-only terminal handoff for Linear/GitHub worktrees; `--lane auto[:<harness>]` picks the account with the most headroom via `lanes` and resolves the lane before any worktree is created. Flags: `--help` |

--- a/skills/orch/schemas/workflow-state.md
+++ b/skills/orch/schemas/workflow-state.md
@@ -76,7 +76,8 @@ Persistent state file for orch workflows. Survives context compaction.
     "replied": []
   },
   "pr_local_review": {
-    "passes": 0
+    "passes": 0,
+    "reviewed_head": "0a1b2c3d4e5f60718293a4b5c6d7e8f901234567"
   },
   "pr_approval": {
     "forced": false,
@@ -120,7 +121,7 @@ Persistent state file for orch workflows. Survives context compaction.
 | `rebase_map` | object | Old→new commit SHA map accumulated from `worktree push` auto-rebase output (`rebase-map:` lines — vstack#728). Keys are pre-rebase SHAs; values are post-rebase SHAs, or the literal `"dropped"` when the replayed commit vanished. SHAs stored elsewhere in state are rewritten at push time (`submit-pr.md` § 2 step 1); the map remains for artifact-sourced references (e.g. perf QA `benchmark_commit`) — resolve through it repeatedly until no key matches, since a later rebase maps new → newer |
 | `pr_review_baseline` | object | Baseline for PR comment loop detection |
 | `pr_comment_review` | object | PR comment review tracking: `iterations`, `fixes[]`, `issues_created[]`, `skipped[]`, `replied[]` (thread IDs answered) |
-| `pr_local_review` | object | Local pre-PR review tracking: `passes` (max 2 per submission) |
+| `pr_local_review` | object | Local pre-PR review tracking, budgeted per pushed head (VST-153): `passes` (local review passes counted against `reviewed_head`; max 2 per head) and `reviewed_head` (the head commit those passes reviewed — stamped by `local-review-budget` when the worktree head moves, then overwritten with the artifact's `qa_metadata.reviewed_head` after each counted pass). GitHub bots re-review every push, so a new head is a new round: `local-review-budget` resets `passes` to 0 when the worktree HEAD no longer matches `reviewed_head`; the cap binds only within a single head (`submit-pr.md` § 1.2) |
 | `pr_approval` | object | Approval merge-gate tracking: `forced` (user explicitly chose Force merge past a missing gate verdict), `reviewer_down` (the `PR_REVIEW_ON_TIMEOUT=proceed` degrade auto-proceeded past the deadline because every reviewer was silent — zero reviewer evidence and zero unresolved threads; kept distinct from `forced` so an automated reviewer-down proceed is never confused with a deliberate user override), `gate` (legacy field, still recorded: "off" when the reviewer gate is disabled for a reviewer-less repo) |
 | `pr_review` | object | Reviewer-gate mode tracking: `mode` ("approval"/"review"/"off" as printed by `approval-wait --resolve-mode` from `PR_REVIEW_GATE`, or derived from legacy `PR_APPROVAL_GATE`) |
 

--- a/skills/orch/scripts/local-review-budget
+++ b/skills/orch/scripts/local-review-budget
@@ -43,12 +43,22 @@ ISSUE_ID=""
 WORKTREE=""
 HEAD_ARG=""
 
+# Explicit value checks (not ${2:?}) keep every malformed invocation on the
+# documented exit-2 usage path — a bare flag must not abort with bash's own
+# exit 1.
+require_value() {
+  if [[ $# -lt 2 || -z "$2" ]]; then
+    echo "local-review-budget: $1 requires a value" >&2
+    exit 2
+  fi
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --state-dir) STATE_DIR="${2:?--state-dir requires a path}"; shift 2 ;;
+    --state-dir) require_value "$1" "${2-}"; STATE_DIR="$2"; shift 2 ;;
     --state-dir=*) STATE_DIR="${1#--state-dir=}"; shift ;;
-    --worktree) WORKTREE="${2:?--worktree requires a path}"; shift 2 ;;
-    --head) HEAD_ARG="${2:?--head requires a commit SHA}"; shift 2 ;;
+    --worktree) require_value "$1" "${2-}"; WORKTREE="$2"; shift 2 ;;
+    --head) require_value "$1" "${2-}"; HEAD_ARG="$2"; shift 2 ;;
     -h|--help) sed -n '2,34p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 0 ;;
     -*) echo "local-review-budget: unknown argument: $1" >&2; exit 2 ;;
     *)
@@ -75,6 +85,11 @@ else
   HEAD_SHA="$HEAD_ARG"
 fi
 
+# Normalize case before validating: git accepts uppercase SHAs, and an
+# unnormalized compare would treat AAAA… and aaaa… as different heads,
+# resetting the round on every check.
+HEAD_SHA="$(printf '%s' "$HEAD_SHA" | tr '[:upper:]' '[:lower:]')"
+
 # The SHA is embedded in a jq program below — accept only a full hex SHA so
 # the embedding cannot break out of the string literal.
 if ! [[ "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
@@ -84,21 +99,28 @@ fi
 WS=("$SCRIPT_DIR/workflow-state")
 [[ -n "$STATE_DIR" ]] && WS+=(--state-dir "$STATE_DIR")
 
-# ensure_state_exists inside workflow-state errors (exit 1) when no state file
-# exists for the key — this check never creates state, init owns that.
-RECORDED_HEAD="$("${WS[@]}" get "$ISSUE_ID" '.pr_local_review.reviewed_head // ""')"
-
-RESET=false
-if [[ "$RECORDED_HEAD" != "$HEAD_SHA" ]]; then
-  # New head (or nothing recorded): the round budget restarts. Stamp the
-  # current head so the passes counted from here on are attributed to it;
-  # the post-pass record overwrites with the artifact's reviewed_head.
-  "${WS[@]}" update "$ISSUE_ID" \
-    ".pr_local_review = (.pr_local_review // {}) + {passes: 0, reviewed_head: \"$HEAD_SHA\"}"
-  RESET=true
-fi
+# Compare-and-reset in ONE workflow-state update, so the decision and the
+# write happen under the same state lock: a separate read-then-write could
+# interleave with another caller's counted pass and zero it. The update
+# returns the post-decision object; `reset`/`reviewed_head` are derived from
+# the prior head it embeds. ensure_state_exists inside workflow-state errors
+# (exit 1) when no state file exists — this check never creates state, init
+# owns that.
+"${WS[@]}" update "$ISSUE_ID" \
+  ".pr_local_review = (
+     (.pr_local_review // {}) as \$prev
+     | if (\$prev.reviewed_head // \"\") == \"$HEAD_SHA\"
+       then \$prev + {prior_head: (\$prev.reviewed_head // \"\")}
+       else \$prev + {passes: 0, reviewed_head: \"$HEAD_SHA\", prior_head: (\$prev.reviewed_head // \"\")}
+       end)"
 
 PASSES="$("${WS[@]}" get "$ISSUE_ID" '.pr_local_review.passes // 0')"
+RECORDED_HEAD="$("${WS[@]}" get "$ISSUE_ID" '.pr_local_review.prior_head // ""')"
+RESET=false
+[[ "$RECORDED_HEAD" != "$HEAD_SHA" ]] && RESET=true
+
+# prior_head is a transient of this check, not part of the schema — strip it.
+"${WS[@]}" update "$ISSUE_ID" '.pr_local_review |= del(.prior_head)'
 
 jq -n -c \
   --argjson passes "$PASSES" \

--- a/skills/orch/scripts/local-review-budget
+++ b/skills/orch/scripts/local-review-budget
@@ -1,34 +1,42 @@
 #!/usr/bin/env bash
-# Effective local pre-PR review pass count for the worktree's CURRENT head
-# (VST-153, round parity with GitHub review bots).
+# Local pre-PR review pass budget, counted per pushed head (VST-153, round
+# parity with GitHub review bots).
 #
 # GitHub bots re-review every push: a new head is a new review round. The
 # local pre-PR drain (submit-pr.md § 1.2) budgets its passes the same way —
 # `pr_local_review.passes` counts passes against ONE head, recorded in
-# `pr_local_review.reviewed_head` (stamped from the review artifact's
-# `qa_metadata.reviewed_head` after each counted pass). When the worktree
-# head no longer matches the recorded head — new commits since the last
-# counted pass, or nothing recorded yet — the round budget resets: this
-# check atomically zeroes the counter and stamps the new head, so the
-# 2-pass cap applies within a single head, never across pushes.
+# `pr_local_review.reviewed_head`. When the worktree head no longer matches
+# the recorded head — new commits since the last counted pass, or nothing
+# recorded yet — the round budget resets, so the 2-pass cap applies within a
+# single head, never across pushes.
 #
 # Usage:
 #   local-review-budget [--state-dir DIR] ISSUE_ID (--worktree PATH | --head SHA)
+#   local-review-budget [--state-dir DIR] ISSUE_ID --count SHA
 #
 #   --state-dir DIR   forwarded to workflow-state (flag > ORCH_STATE_DIR > tmp/)
 #   --worktree PATH   read the current head from this worktree's HEAD
 #   --head SHA        use this commit as the current head (testing / callers
 #                     that already resolved it); full 40-hex SHA required
+#   --count SHA       count ONE completed pass against SHA (the review
+#                     artifact's qa_metadata.reviewed_head): increments when
+#                     SHA matches the recorded head, otherwise initializes
+#                     the new head at one pass — a new head never inherits
+#                     the prior head's count. Validates SHA before any state
+#                     write, so callers never embed artifact content in jq.
 #
-# Prints one JSON object:
-#   {passes, max_passes, exhausted, head, reviewed_head, reset}
-#
+# Check mode prints: {passes, max_passes, exhausted, head, reviewed_head, reset}
 #   passes:        effective pass count for the current head (0 after a reset)
 #   max_passes:    the cap (2)
 #   exhausted:     passes >= max_passes — caller skips the local review
 #   head:          the current head the budget was evaluated against
 #   reviewed_head: recorded head BEFORE this check ("" when none)
 #   reset:         true when the counter restarted under a new head
+# Count mode prints: {passes, reviewed_head} (post-count attribution).
+#
+# Every decision executes as ONE workflow-state update-report — the compare,
+# the write, and the printed evidence happen under the same state lock, so
+# concurrent invocations serialize instead of clobbering each other.
 #
 # Exit 0 on success (exhausted or not — read the JSON); 1 on missing state
 # (run workflow-state init first); 2 on usage errors.
@@ -42,10 +50,12 @@ STATE_DIR=""
 ISSUE_ID=""
 WORKTREE=""
 HEAD_ARG=""
+COUNT_ARG=""
 
 # Explicit value checks (not ${2:?}) keep every malformed invocation on the
 # documented exit-2 usage path — a bare flag must not abort with bash's own
-# exit 1.
+# exit 1. Empty equals-form values (--state-dir=) are rejected the same way:
+# silently dropping an intended override would read/write the wrong state dir.
 require_value() {
   if [[ $# -lt 2 || -z "$2" ]]; then
     echo "local-review-budget: $1 requires a value" >&2
@@ -56,10 +66,14 @@ require_value() {
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --state-dir) require_value "$1" "${2-}"; STATE_DIR="$2"; shift 2 ;;
-    --state-dir=*) STATE_DIR="${1#--state-dir=}"; shift ;;
+    --state-dir=*) STATE_DIR="${1#--state-dir=}"; require_value "--state-dir" "$STATE_DIR"; shift ;;
     --worktree) require_value "$1" "${2-}"; WORKTREE="$2"; shift 2 ;;
+    --worktree=*) WORKTREE="${1#--worktree=}"; require_value "--worktree" "$WORKTREE"; shift ;;
     --head) require_value "$1" "${2-}"; HEAD_ARG="$2"; shift 2 ;;
-    -h|--help) sed -n '2,34p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    --head=*) HEAD_ARG="${1#--head=}"; require_value "--head" "$HEAD_ARG"; shift ;;
+    --count) require_value "$1" "${2-}"; COUNT_ARG="$2"; shift 2 ;;
+    --count=*) COUNT_ARG="${1#--count=}"; require_value "--count" "$COUNT_ARG"; shift ;;
+    -h|--help) sed -n '2,43p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 0 ;;
     -*) echo "local-review-budget: unknown argument: $1" >&2; exit 2 ;;
     *)
       if [[ -n "$ISSUE_ID" ]]; then
@@ -70,19 +84,24 @@ while [[ $# -gt 0 ]]; do
 done
 
 [[ -n "$ISSUE_ID" ]] || { echo "local-review-budget: ISSUE_ID is required" >&2; exit 2; }
-if [[ -n "$WORKTREE" && -n "$HEAD_ARG" ]]; then
-  echo "local-review-budget: pass --worktree or --head, not both" >&2; exit 2
-fi
-if [[ -z "$WORKTREE" && -z "$HEAD_ARG" ]]; then
-  echo "local-review-budget: one of --worktree or --head is required" >&2; exit 2
+
+MODES=0
+[[ -n "$WORKTREE" ]] && MODES=$((MODES + 1))
+[[ -n "$HEAD_ARG" ]] && MODES=$((MODES + 1))
+[[ -n "$COUNT_ARG" ]] && MODES=$((MODES + 1))
+if [[ "$MODES" -ne 1 ]]; then
+  echo "local-review-budget: pass exactly one of --worktree, --head, or --count" >&2
+  exit 2
 fi
 
 if [[ -n "$WORKTREE" ]]; then
   HEAD_SHA="$(git -C "$WORKTREE" rev-parse HEAD)" || {
     echo "local-review-budget: could not resolve HEAD in $WORKTREE" >&2; exit 2
   }
-else
+elif [[ -n "$HEAD_ARG" ]]; then
   HEAD_SHA="$HEAD_ARG"
+else
+  HEAD_SHA="$COUNT_ARG"
 fi
 
 # Normalize case before validating: git accepts uppercase SHAs, and an
@@ -91,7 +110,9 @@ fi
 HEAD_SHA="$(printf '%s' "$HEAD_SHA" | tr '[:upper:]' '[:lower:]')"
 
 # The SHA is embedded in a jq program below — accept only a full hex SHA so
-# the embedding cannot break out of the string literal.
+# the embedding cannot break out of the string literal. In count mode this is
+# also the input-validation boundary for artifact-sourced heads: a malformed
+# qa_metadata.reviewed_head is refused here, never embedded by the caller.
 if ! [[ "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
   echo "local-review-budget: not a full 40-hex commit SHA: $HEAD_SHA" >&2; exit 2
 fi
@@ -99,28 +120,42 @@ fi
 WS=("$SCRIPT_DIR/workflow-state")
 [[ -n "$STATE_DIR" ]] && WS+=(--state-dir "$STATE_DIR")
 
-# Compare-and-reset in ONE workflow-state update, so the decision and the
-# write happen under the same state lock: a separate read-then-write could
-# interleave with another caller's counted pass and zero it. The update
-# returns the post-decision object; `reset`/`reviewed_head` are derived from
-# the prior head it embeds. ensure_state_exists inside workflow-state errors
-# (exit 1) when no state file exists — this check never creates state, init
-# owns that.
-"${WS[@]}" update "$ISSUE_ID" \
-  ".pr_local_review = (
-     (.pr_local_review // {}) as \$prev
-     | if (\$prev.reviewed_head // \"\") == \"$HEAD_SHA\"
-       then \$prev + {prior_head: (\$prev.reviewed_head // \"\")}
-       else \$prev + {passes: 0, reviewed_head: \"$HEAD_SHA\", prior_head: (\$prev.reviewed_head // \"\")}
-       end)"
+if [[ -n "$COUNT_ARG" ]]; then
+  # Count one completed pass, attributed in the same locked step that decides
+  # whether the head matches: increment on match, initialize the new head at
+  # one pass on mismatch (merging over the previous object — sibling keys
+  # survive). A new head never inherits the prior head's count.
+  REPORT="$("${WS[@]}" update-report "$ISSUE_ID" "
+    (.pr_local_review // {}) as \$prev
+    | (if (\$prev.reviewed_head // \"\") == \"$HEAD_SHA\"
+       then \$prev + {passes: ((\$prev.passes // 0) + 1)}
+       else \$prev + {passes: 1, reviewed_head: \"$HEAD_SHA\"}
+       end) as \$next
+    | {state: (.pr_local_review = \$next),
+       report: {passes: \$next.passes, reviewed_head: \$next.reviewed_head}}")"
+  printf '%s\n' "$REPORT"
+  exit 0
+fi
 
-PASSES="$("${WS[@]}" get "$ISSUE_ID" '.pr_local_review.passes // 0')"
-RECORDED_HEAD="$("${WS[@]}" get "$ISSUE_ID" '.pr_local_review.prior_head // ""')"
+# Check mode: compare-and-reset and its evidence in ONE locked step. The
+# report carries the prior recorded head, so no transient ever lands in
+# state and no follow-up read can observe another writer's interleaving.
+# ensure_state_exists inside workflow-state errors (exit 1) when no state
+# file exists for the key — this check never creates state, init owns that.
+REPORT="$("${WS[@]}" update-report "$ISSUE_ID" "
+  (.pr_local_review // {}) as \$prev
+  | (\$prev.reviewed_head // \"\") as \$recorded
+  | (if \$recorded == \"$HEAD_SHA\"
+     then \$prev
+     else \$prev + {passes: 0, reviewed_head: \"$HEAD_SHA\"}
+     end) as \$next
+  | {state: (.pr_local_review = \$next),
+     report: {passes: (\$next.passes // 0), recorded: \$recorded}}")"
+
+PASSES="$(jq -r '.passes' <<<"$REPORT")"
+RECORDED_HEAD="$(jq -r '.recorded' <<<"$REPORT")"
 RESET=false
 [[ "$RECORDED_HEAD" != "$HEAD_SHA" ]] && RESET=true
-
-# prior_head is a transient of this check, not part of the schema — strip it.
-"${WS[@]}" update "$ISSUE_ID" '.pr_local_review |= del(.prior_head)'
 
 jq -n -c \
   --argjson passes "$PASSES" \

--- a/skills/orch/scripts/local-review-budget
+++ b/skills/orch/scripts/local-review-budget
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Effective local pre-PR review pass count for the worktree's CURRENT head
+# (VST-153, round parity with GitHub review bots).
+#
+# GitHub bots re-review every push: a new head is a new review round. The
+# local pre-PR drain (submit-pr.md § 1.2) budgets its passes the same way —
+# `pr_local_review.passes` counts passes against ONE head, recorded in
+# `pr_local_review.reviewed_head` (stamped from the review artifact's
+# `qa_metadata.reviewed_head` after each counted pass). When the worktree
+# head no longer matches the recorded head — new commits since the last
+# counted pass, or nothing recorded yet — the round budget resets: this
+# check atomically zeroes the counter and stamps the new head, so the
+# 2-pass cap applies within a single head, never across pushes.
+#
+# Usage:
+#   local-review-budget [--state-dir DIR] ISSUE_ID (--worktree PATH | --head SHA)
+#
+#   --state-dir DIR   forwarded to workflow-state (flag > ORCH_STATE_DIR > tmp/)
+#   --worktree PATH   read the current head from this worktree's HEAD
+#   --head SHA        use this commit as the current head (testing / callers
+#                     that already resolved it); full 40-hex SHA required
+#
+# Prints one JSON object:
+#   {passes, max_passes, exhausted, head, reviewed_head, reset}
+#
+#   passes:        effective pass count for the current head (0 after a reset)
+#   max_passes:    the cap (2)
+#   exhausted:     passes >= max_passes — caller skips the local review
+#   head:          the current head the budget was evaluated against
+#   reviewed_head: recorded head BEFORE this check ("" when none)
+#   reset:         true when the counter restarted under a new head
+#
+# Exit 0 on success (exhausted or not — read the JSON); 1 on missing state
+# (run workflow-state init first); 2 on usage errors.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+MAX_PASSES=2
+
+STATE_DIR=""
+ISSUE_ID=""
+WORKTREE=""
+HEAD_ARG=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --state-dir) STATE_DIR="${2:?--state-dir requires a path}"; shift 2 ;;
+    --state-dir=*) STATE_DIR="${1#--state-dir=}"; shift ;;
+    --worktree) WORKTREE="${2:?--worktree requires a path}"; shift 2 ;;
+    --head) HEAD_ARG="${2:?--head requires a commit SHA}"; shift 2 ;;
+    -h|--help) sed -n '2,34p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    -*) echo "local-review-budget: unknown argument: $1" >&2; exit 2 ;;
+    *)
+      if [[ -n "$ISSUE_ID" ]]; then
+        echo "local-review-budget: unexpected argument: $1" >&2; exit 2
+      fi
+      ISSUE_ID="$1"; shift ;;
+  esac
+done
+
+[[ -n "$ISSUE_ID" ]] || { echo "local-review-budget: ISSUE_ID is required" >&2; exit 2; }
+if [[ -n "$WORKTREE" && -n "$HEAD_ARG" ]]; then
+  echo "local-review-budget: pass --worktree or --head, not both" >&2; exit 2
+fi
+if [[ -z "$WORKTREE" && -z "$HEAD_ARG" ]]; then
+  echo "local-review-budget: one of --worktree or --head is required" >&2; exit 2
+fi
+
+if [[ -n "$WORKTREE" ]]; then
+  HEAD_SHA="$(git -C "$WORKTREE" rev-parse HEAD)" || {
+    echo "local-review-budget: could not resolve HEAD in $WORKTREE" >&2; exit 2
+  }
+else
+  HEAD_SHA="$HEAD_ARG"
+fi
+
+# The SHA is embedded in a jq program below — accept only a full hex SHA so
+# the embedding cannot break out of the string literal.
+if ! [[ "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "local-review-budget: not a full 40-hex commit SHA: $HEAD_SHA" >&2; exit 2
+fi
+
+WS=("$SCRIPT_DIR/workflow-state")
+[[ -n "$STATE_DIR" ]] && WS+=(--state-dir "$STATE_DIR")
+
+# ensure_state_exists inside workflow-state errors (exit 1) when no state file
+# exists for the key — this check never creates state, init owns that.
+RECORDED_HEAD="$("${WS[@]}" get "$ISSUE_ID" '.pr_local_review.reviewed_head // ""')"
+
+RESET=false
+if [[ "$RECORDED_HEAD" != "$HEAD_SHA" ]]; then
+  # New head (or nothing recorded): the round budget restarts. Stamp the
+  # current head so the passes counted from here on are attributed to it;
+  # the post-pass record overwrites with the artifact's reviewed_head.
+  "${WS[@]}" update "$ISSUE_ID" \
+    ".pr_local_review = (.pr_local_review // {}) + {passes: 0, reviewed_head: \"$HEAD_SHA\"}"
+  RESET=true
+fi
+
+PASSES="$("${WS[@]}" get "$ISSUE_ID" '.pr_local_review.passes // 0')"
+
+jq -n -c \
+  --argjson passes "$PASSES" \
+  --argjson max "$MAX_PASSES" \
+  --arg head "$HEAD_SHA" \
+  --arg recorded "$RECORDED_HEAD" \
+  --argjson reset "$RESET" \
+  '{passes: $passes, max_passes: $max, exhausted: ($passes >= $max),
+    head: $head, reviewed_head: $recorded, reset: $reset}'

--- a/skills/orch/scripts/workflow-state
+++ b/skills/orch/scripts/workflow-state
@@ -167,6 +167,44 @@ cmd_update() {
     atomic_update "$state_file" "$jq_expr"
 }
 
+# Atomic read-modify-write-report: the expression must evaluate to
+# {state: <new full state>, report: <any>}. The write of .state and the
+# capture of .report happen under the same lock, so the printed report is
+# the evidence of exactly the transition this call performed — a follow-up
+# `get` could instead observe another writer's interleaved change.
+cmd_update_report() {
+    local issue_id="$1"
+    local jq_expr="$2"
+
+    local state_file
+    state_file=$(resolve_state_file "$issue_id")
+    ensure_state_exists "$state_file"
+
+    local lock_file="${state_file}.lock"
+    local tmp_file="${state_file}.tmp"
+    local report_file="${state_file}.report"
+
+    (
+        flock -w 10 200 || { echo "Error: could not acquire lock on $lock_file" >&2; exit 1; }
+
+        local combined
+        if ! combined=$(jq -c "$jq_expr" "$state_file" 2>&1); then
+            echo "Error: jq expression failed: $jq_expr" >&2
+            exit 1
+        fi
+        if ! jq -e '(.state | type == "object") and has("report")' >/dev/null 2>&1 <<<"$combined"; then
+            echo "Error: update-report expression must produce {state: <object>, report: <any>}" >&2
+            exit 1
+        fi
+        jq -c '.state' <<<"$combined" > "$tmp_file"
+        jq -c '.report' <<<"$combined" > "$report_file"
+        mv "$tmp_file" "$state_file"
+    ) 200>"$lock_file" || return 1
+
+    cat "$report_file"
+    rm -f "$report_file"
+}
+
 cmd_append() {
     local issue_id="$1"
     local field="$2"
@@ -328,6 +366,16 @@ Commands:
 
   get <issue_id> [jq_path]      Read value (default: entire state)
   update <issue_id> <jq_expr>   Run arbitrary jq expression
+  update-report <issue_id> <jq_expr>
+                                Atomic read-modify-write-report: the jq expr
+                                runs against the current state under the same
+                                lock as update and must produce
+                                {state: <new full state>, report: <any>} —
+                                .state is written back, .report printed
+                                compactly. Use when a caller needs a decision
+                                and its evidence from the SAME locked step
+                                (a separate get after update can interleave
+                                with another writer)
   append <issue_id> <field> <value>   Append to array field
   increment <issue_id> <field>  Increment numeric field
   set <issue_id> <field> <value>  Set field value ({/[ prefix, null/true/false,
@@ -407,6 +455,7 @@ case "${1:-help}" in
     init)      shift; cmd_init "$@" ;;
     get)       shift; cmd_get "$@" ;;
     update)    shift; cmd_update "$@" ;;
+    update-report) shift; cmd_update_report "$@" ;;
     append)    shift; cmd_append "$@" ;;
     increment) shift; cmd_increment "$@" ;;
     set)       shift; cmd_set "$@" ;;

--- a/skills/orch/scripts/workflow-state
+++ b/skills/orch/scripts/workflow-state
@@ -182,8 +182,10 @@ cmd_update_report() {
 
     local lock_file="${state_file}.lock"
     local tmp_file="${state_file}.tmp"
-    local report_file="${state_file}.report"
 
+    # The report prints from INSIDE the locked section — no shared report
+    # file exists to race on, so concurrent calls for the same issue each
+    # return exactly their own transition's evidence.
     (
         flock -w 10 200 || { echo "Error: could not acquire lock on $lock_file" >&2; exit 1; }
 
@@ -192,17 +194,16 @@ cmd_update_report() {
             echo "Error: jq expression failed: $jq_expr" >&2
             exit 1
         fi
-        if ! jq -e '(.state | type == "object") and has("report")' >/dev/null 2>&1 <<<"$combined"; then
-            echo "Error: update-report expression must produce {state: <object>, report: <any>}" >&2
+        # Exactly ONE {state, report} object: a stream of several would write
+        # multiple top-level documents into the state file.
+        if ! jq -e -s 'length == 1 and (.[0].state | type == "object") and (.[0] | has("report"))' >/dev/null 2>&1 <<<"$combined"; then
+            echo "Error: update-report expression must produce exactly one {state: <object>, report: <any>}" >&2
             exit 1
         fi
         jq -c '.state' <<<"$combined" > "$tmp_file"
-        jq -c '.report' <<<"$combined" > "$report_file"
         mv "$tmp_file" "$state_file"
-    ) 200>"$lock_file" || return 1
-
-    cat "$report_file"
-    rm -f "$report_file"
+        jq -c '.report' <<<"$combined"
+    ) 200>"$lock_file"
 }
 
 cmd_append() {

--- a/skills/orch/tests/local-review-budget.test.sh
+++ b/skills/orch/tests/local-review-budget.test.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Regression tests for `local-review-budget` (VST-153).
+#
+# The local pre-PR review budget was counted per SUBMISSION: two passes ever,
+# regardless of how many heads the branch went through. GitHub bots re-review
+# every push — a new head is a new round — so the budget is now counted per
+# pushed head: `pr_local_review.passes` is attributed to
+# `pr_local_review.reviewed_head`, and the check resets the counter when the
+# worktree head no longer matches the recorded one.
+#
+# These tests pin the reset-on-new-head behavior, the within-head cap, and the
+# usage/error contract.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
+BUDGET="$SKILL_DIR/scripts/local-review-budget"
+WS="$SKILL_DIR/scripts/workflow-state"
+TMP_ROOT="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+SD="$TMP_ROOT/state"
+ISSUE="VST-153"
+
+PASS=0
+FAIL=0
+pass() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+fail() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
+
+assert_field() {
+  local out="$1" field="$2" want="$3" name="$4" got
+  got="$(jq -r ".$field" <<<"$out")"
+  if [[ "$got" == "$want" ]]; then pass "$name"
+  else fail "$name (want $field=$want, got $got)"; fi
+}
+
+assert_status() {
+  local got="$1" want="$2" name="$3"
+  if [[ "$got" -eq "$want" ]]; then pass "$name"
+  else fail "$name (want exit $want, got $got)"; fi
+}
+
+HEAD_A="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+HEAD_B="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+echo "=== usage and error contract ==="
+
+set +e
+"$BUDGET" --state-dir "$SD" --head "$HEAD_A" >/dev/null 2>&1
+no_issue=$?
+"$BUDGET" --state-dir "$SD" "$ISSUE" >/dev/null 2>&1
+no_source=$?
+"$BUDGET" --state-dir "$SD" "$ISSUE" --worktree "$TMP_ROOT" --head "$HEAD_A" >/dev/null 2>&1
+both_sources=$?
+"$BUDGET" --state-dir "$SD" "$ISSUE" --head "not-a-sha" >/dev/null 2>&1
+bad_sha=$?
+"$BUDGET" --state-dir "$SD" "$ISSUE" --head "$HEAD_A" >/dev/null 2>&1
+no_state=$?
+set -e
+assert_status "$no_issue" 2 "missing ISSUE_ID is rejected"
+assert_status "$no_source" 2 "missing --worktree/--head is rejected"
+assert_status "$both_sources" 2 "--worktree plus --head is rejected"
+assert_status "$bad_sha" 2 "a non-SHA head is rejected"
+assert_status "$no_state" 1 "missing state file errors instead of creating state"
+
+echo "=== first check on fresh state starts round 0 under the current head ==="
+
+"$WS" --state-dir "$SD" init "$ISSUE" --worktree "$TMP_ROOT" --branch issue-vst-153 >/dev/null
+
+OUT="$("$BUDGET" --state-dir "$SD" "$ISSUE" --head "$HEAD_A")"
+assert_field "$OUT" passes "0" "fresh state reports 0 passes"
+assert_field "$OUT" exhausted "false" "…and is not exhausted"
+assert_field "$OUT" reset "true" "…and reports the round reset (nothing was recorded)"
+assert_field "$OUT" reviewed_head "" "…with an empty prior recorded head"
+
+recorded="$("$WS" --state-dir "$SD" get "$ISSUE" '.pr_local_review.reviewed_head')"
+assert_status "$([[ "$recorded" == "$HEAD_A" ]]; echo $?)" 0 "the current head is stamped into state"
+
+echo "=== the 2-pass cap binds within a single head ==="
+
+"$WS" --state-dir "$SD" increment "$ISSUE" pr_local_review.passes >/dev/null
+OUT="$("$BUDGET" --state-dir "$SD" "$ISSUE" --head "$HEAD_A")"
+assert_field "$OUT" passes "1" "one counted pass at the same head reports 1"
+assert_field "$OUT" exhausted "false" "…still under the cap"
+assert_field "$OUT" reset "false" "…with no reset"
+
+"$WS" --state-dir "$SD" increment "$ISSUE" pr_local_review.passes >/dev/null
+OUT="$("$BUDGET" --state-dir "$SD" "$ISSUE" --head "$HEAD_A")"
+assert_field "$OUT" passes "2" "two counted passes at the same head report 2"
+assert_field "$OUT" exhausted "true" "…and the budget is exhausted"
+assert_field "$OUT" max_passes "2" "…against the documented cap of 2"
+
+echo "=== a new head is a new round: the counter resets ==="
+
+# Per-SUBMISSION accounting would keep passes=2 here — this is the assertion
+# that fails against the pre-VST-153 behavior.
+OUT="$("$BUDGET" --state-dir "$SD" "$ISSUE" --head "$HEAD_B")"
+assert_field "$OUT" passes "0" "a different head restarts the counter at 0"
+assert_field "$OUT" exhausted "false" "…so the budget is available again"
+assert_field "$OUT" reset "true" "…and the reset is reported"
+assert_field "$OUT" reviewed_head "$HEAD_A" "…naming the previously recorded head"
+
+recorded="$("$WS" --state-dir "$SD" get "$ISSUE" '.pr_local_review.reviewed_head')"
+assert_status "$([[ "$recorded" == "$HEAD_B" ]]; echo $?)" 0 "state now records the new head"
+passes_state="$("$WS" --state-dir "$SD" get "$ISSUE" '.pr_local_review.passes')"
+assert_status "$([[ "$passes_state" == "0" ]]; echo $?)" 0 "state counter restarted at 0"
+
+echo "=== the reset merges, never clobbers, sibling pr_local_review keys ==="
+
+"$WS" --state-dir "$SD" set "$ISSUE" pr_local_review.extra keepme >/dev/null
+"$BUDGET" --state-dir "$SD" "$ISSUE" --head "$HEAD_A" >/dev/null
+extra="$("$WS" --state-dir "$SD" get "$ISSUE" '.pr_local_review.extra')"
+assert_status "$([[ "$extra" == "keepme" ]]; echo $?)" 0 "sibling keys survive a round reset"
+
+echo "=== --worktree reads the real HEAD ==="
+
+REPO="$TMP_ROOT/repo"
+git init -q "$REPO"
+git -C "$REPO" -c user.email=t@t -c user.name=t commit -q --allow-empty -m one
+OUT="$("$BUDGET" --state-dir "$SD" "$ISSUE" --worktree "$REPO")"
+head1="$(git -C "$REPO" rev-parse HEAD)"
+assert_field "$OUT" head "$head1" "--worktree resolves the worktree's HEAD"
+assert_field "$OUT" reset "true" "…and a real-HEAD change resets the round"
+
+"$WS" --state-dir "$SD" increment "$ISSUE" pr_local_review.passes >/dev/null
+git -C "$REPO" -c user.email=t@t -c user.name=t commit -q --allow-empty -m two
+OUT="$("$BUDGET" --state-dir "$SD" "$ISSUE" --worktree "$REPO")"
+assert_field "$OUT" passes "0" "a new commit in the worktree restarts the counter"
+assert_field "$OUT" reviewed_head "$head1" "…reporting the superseded head"
+
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/skills/orch/tests/local-review-budget.test.sh
+++ b/skills/orch/tests/local-review-budget.test.sh
@@ -128,6 +128,30 @@ OUT="$("$BUDGET" --state-dir "$SD" "$ISSUE" --worktree "$REPO")"
 assert_field "$OUT" passes "0" "a new commit in the worktree restarts the counter"
 assert_field "$OUT" reviewed_head "$head1" "…reporting the superseded head"
 
+echo "=== uppercase SHAs normalize instead of resetting the round ==="
+
+HEAD_C="cccccccccccccccccccccccccccccccccccccccc"
+HEAD_C_UPPER="CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"
+"$BUDGET" --state-dir "$SD" "$ISSUE" --head "$HEAD_C" >/dev/null
+"$WS" --state-dir "$SD" increment "$ISSUE" pr_local_review.passes >/dev/null
+OUT="$("$BUDGET" --state-dir "$SD" "$ISSUE" --head "$HEAD_C_UPPER")"
+assert_field "$OUT" reset "false" "an uppercase spelling of the same head is not a new round"
+assert_field "$OUT" passes "1" "…and keeps the counted pass"
+assert_field "$OUT" head "$HEAD_C" "…reporting the normalized head"
+
+echo "=== transient bookkeeping never leaks into state ==="
+
+prior="$("$WS" --state-dir "$SD" get "$ISSUE" '.pr_local_review | has("prior_head")')"
+assert_status "$([[ "$prior" == "false" ]]; echo $?)" 0 "prior_head transient is stripped after the check"
+
+echo "=== bare flags stay on the documented exit-2 usage path ==="
+
+for flag in --state-dir --worktree --head; do
+  rc=0
+  "$BUDGET" "$ISSUE" "$flag" >/dev/null 2>&1 || rc=$?
+  assert_status "$rc" 2 "bare $flag exits 2, not a bash expansion abort"
+done
+
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/skills/orch/tests/local-review-budget.test.sh
+++ b/skills/orch/tests/local-review-budget.test.sh
@@ -180,6 +180,29 @@ rc=0
 "$BUDGET" --state-dir "$SD" "$ISSUE" --count "$HEAD_D" --head "$HEAD_E" >/dev/null 2>&1 || rc=$?
 assert_status "$rc" 2 "--count combined with --head is a usage error"
 
+echo "=== update-report: concurrent calls each get exactly their own evidence ==="
+
+# Ten overlapping update-report calls increment one counter; the lock must
+# serialize them so the state lands at 10 and the ten printed reports are a
+# permutation of 1..10 — no lost update, no cross-read report.
+"$WS" --state-dir "$SD" set "$ISSUE" race_counter 0 >/dev/null
+RACE_OUT="$TMP_ROOT/race-reports"
+: >"$RACE_OUT"
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  "$WS" --state-dir "$SD" update-report "$ISSUE" \
+    '((.race_counter // 0) + 1) as $n | {state: (.race_counter = $n), report: {n: $n}}' \
+    >>"$RACE_OUT" &
+done
+wait
+final="$("$WS" --state-dir "$SD" get "$ISSUE" '.race_counter')"
+assert_status "$([[ "$final" == "10" ]]; echo $?)" 0 "ten concurrent update-reports serialize to a final count of 10"
+distinct="$(jq -r '.n' "$RACE_OUT" | sort -n | uniq | wc -l | tr -d ' ')"
+assert_status "$([[ "$distinct" == "10" ]]; echo $?)" 0 "each call reported a distinct transition (no report cross-read)"
+
+rc=0
+"$WS" --state-dir "$SD" update-report "$ISSUE" '{state: ., report: 1}, {state: ., report: 2}' >/dev/null 2>&1 || rc=$?
+assert_status "$rc" 1 "a multi-object update-report stream is rejected, not written"
+
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/skills/orch/tests/local-review-budget.test.sh
+++ b/skills/orch/tests/local-review-budget.test.sh
@@ -142,15 +142,43 @@ assert_field "$OUT" head "$HEAD_C" "…reporting the normalized head"
 echo "=== transient bookkeeping never leaks into state ==="
 
 prior="$("$WS" --state-dir "$SD" get "$ISSUE" '.pr_local_review | has("prior_head")')"
-assert_status "$([[ "$prior" == "false" ]]; echo $?)" 0 "prior_head transient is stripped after the check"
+assert_status "$([[ "$prior" == "false" ]]; echo $?)" 0 "no transient keys land in state"
 
 echo "=== bare flags stay on the documented exit-2 usage path ==="
 
-for flag in --state-dir --worktree --head; do
+for flag in --state-dir --worktree --head --count; do
   rc=0
   "$BUDGET" "$ISSUE" "$flag" >/dev/null 2>&1 || rc=$?
   assert_status "$rc" 2 "bare $flag exits 2, not a bash expansion abort"
 done
+
+rc=0
+"$BUDGET" --state-dir= "$ISSUE" --head "$HEAD_C" >/dev/null 2>&1 || rc=$?
+assert_status "$rc" 2 "empty equals-form --state-dir= exits 2 instead of silently dropping the override"
+
+echo "=== --count attributes a completed pass atomically ==="
+
+HEAD_D="dddddddddddddddddddddddddddddddddddddddd"
+HEAD_E="eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+"$BUDGET" --state-dir "$SD" "$ISSUE" --head "$HEAD_D" >/dev/null
+"$WS" --state-dir "$SD" set "$ISSUE" pr_local_review.extra keepme2 >/dev/null
+OUT="$("$BUDGET" --state-dir "$SD" "$ISSUE" --count "$HEAD_D")"
+assert_field "$OUT" passes "1" "matching head increments to one pass"
+assert_field "$OUT" reviewed_head "$HEAD_D" "…attributed to the counted head"
+OUT="$("$BUDGET" --state-dir "$SD" "$ISSUE" --count "$HEAD_D")"
+assert_field "$OUT" passes "2" "second count on the same head increments"
+OUT="$("$BUDGET" --state-dir "$SD" "$ISSUE" --count "$HEAD_E")"
+assert_field "$OUT" passes "1" "a different artifact head initializes at one pass, never inheriting"
+assert_field "$OUT" reviewed_head "$HEAD_E" "…and re-attributes to the new head"
+extra="$("$WS" --state-dir "$SD" get "$ISSUE" '.pr_local_review.extra')"
+assert_status "$([[ "$extra" == "keepme2" ]]; echo $?)" 0 "count-mode re-attribution preserves sibling keys"
+
+rc=0
+"$BUDGET" --state-dir "$SD" "$ISSUE" --count 'bad"; .x = 1; "' >/dev/null 2>&1 || rc=$?
+assert_status "$rc" 2 "malformed artifact head is refused before any state write"
+rc=0
+"$BUDGET" --state-dir "$SD" "$ISSUE" --count "$HEAD_D" --head "$HEAD_E" >/dev/null 2>&1 || rc=$?
+assert_status "$rc" 2 "--count combined with --head is a usage error"
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/skills/orch/workflows/submit-pr.md
+++ b/skills/orch/workflows/submit-pr.md
@@ -68,11 +68,11 @@ Bot reviews are **asynchronous** in this workflow: GitHub review bots post on th
 - A PR number argument was provided — the PR already exists; arrived comments are triaged in § 3.
 - `.agents/skills/second-opinion/scripts/second-opinion` does not exist (skill not installed).
 
-1. **Check pass budget** (max 2 local review passes per submission):
+1. **Check pass budget** (max 2 local review passes per pushed head — GitHub bots re-review every push, so a new head is a new round, not a spend against a per-submission cap; VST-153):
    ```bash
-   .agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.pr_local_review.passes // 0'
+   .agents/skills/orch/scripts/local-review-budget [ISSUE_ID] --worktree "[WORKTREE_PATH]"
    ```
-   Use the output as `LOCAL_PASSES`. If `LOCAL_PASSES >= 2` → § 2.
+   The output is a JSON object: `{passes, max_passes, exhausted, head, reviewed_head, reset}` — the effective pass count for the worktree's **current** HEAD. When the recorded `pr_local_review.reviewed_head` differs from that HEAD (or nothing is recorded yet), the check atomically resets the counter to 0 and stamps the new head before printing (`reset: true`), so the cap applies within a single head. If `exhausted == true` → § 2.
 
 2. **Run the local review** (advisory — on script failure, report and continue to § 2). Capture an epoch freshness boundary *before* the review writes the artifact so step 3 can reject a stale or misdated file the way glob mode does:
    ```bash
@@ -90,10 +90,17 @@ Bot reviews are **asynchronous** in this workflow: GitHub review bots post on th
    ```bash
    .agents/skills/orch/scripts/review-artifact-check --file "$LOCAL_OUTPUT" [LOCAL_STARTED_AT]
    ```
-   Count the pass:
+   If `ok == true`, count the pass and record the head the artifact actually reviewed (`qa_metadata.reviewed_head`, pinned at scope derivation — vstack#1141):
    ```bash
    .agents/skills/orch/scripts/workflow-state increment [ISSUE_ID] pr_local_review.passes
+   jq -r '.qa_metadata.reviewed_head // empty' "$LOCAL_OUTPUT"
    ```
+   If the jq output is non-empty, record it — the artifact's pin wins over the step 1 stamp:
+   ```bash
+   .agents/skills/orch/scripts/workflow-state update [ISSUE_ID] '.pr_local_review.reviewed_head = "[REVIEWED_HEAD_FROM_PREVIOUS_COMMAND]"'
+   ```
+   If it is empty (an older artifact without the stamp), skip the record — the step 1 budget check already stamped the worktree HEAD, and the counted pass stays attributed to it.
+
    If `ok == false`, report the `reason` and continue to § 2 — local review is advisory, never a submission blocker. This includes reason `no_review` (the artifact self-reports no review happened), reason `incomplete` (the artifact declares `qa_metadata` but its findings are unusable — arrays lost, or a present `blockers[]`/`suggestions[]` item omits a required `review-finding` field such as `category`; a `detail` field pinpoints it), and script exits 3 (no diff scope) / 4 (model reported no review, or the response stayed schema-incomplete after the one-shot retry) / 5 (the external CLI never produced a review — non-zero exit, timeout, or empty response — partial output preserved as `<output>.failed.json`): none of these is a pass.
 
 4. **Route findings** from the JSON (`../../reviewer/schemas/review-finding.md` schema):
@@ -108,7 +115,7 @@ Bot reviews are **asynchronous** in this workflow: GitHub review bots post on th
      - `source`: `local-review`
    - `suggestions[]` with `category: "issue"` → build the audit-input file and invoke `⤵ .agents/skills/project-management/workflows/audit-issues.md --issues [FILE_PATH] § 1-9 → § 1.2 step 5` (same path as `review-pr-comments.md` § 6.2). Include created issue IDs in the PR body (§ 2 step 3).
 
-5. **Re-verify after fixes**: if dev-fix applied commits, return to step 1 for one confirming pass over the updated diff. If nothing was applied, → § 2.
+5. **Re-verify after fixes**: if dev-fix applied commits, return to step 1 for one confirming pass over the updated diff — the fix commits moved HEAD, so the step 1 check starts a fresh round for the new head. If nothing was applied, → § 2.
 
 ---
 

--- a/skills/orch/workflows/submit-pr.md
+++ b/skills/orch/workflows/submit-pr.md
@@ -68,7 +68,7 @@ Bot reviews are **asynchronous** in this workflow: GitHub review bots post on th
 - A PR number argument was provided — the PR already exists; arrived comments are triaged in § 3.
 - `.agents/skills/second-opinion/scripts/second-opinion` does not exist (skill not installed).
 
-1. **Check pass budget** (max 2 local review passes per pushed head — GitHub bots re-review every push, so a new head is a new round, not a spend against a per-submission cap; VST-153):
+1. **Check pass budget** (max 2 local review passes per pushed head — GitHub bots re-review every push, so a new head is a new round, not a spend against a per-submission cap):
    ```bash
    .agents/skills/orch/scripts/local-review-budget [ISSUE_ID] --worktree "[WORKTREE_PATH]"
    ```
@@ -90,16 +90,14 @@ Bot reviews are **asynchronous** in this workflow: GitHub review bots post on th
    ```bash
    .agents/skills/orch/scripts/review-artifact-check --file "$LOCAL_OUTPUT" [LOCAL_STARTED_AT]
    ```
-   If `ok == true`, count the pass and record the head the artifact actually reviewed (`qa_metadata.reviewed_head`, pinned at scope derivation — vstack#1141):
+   If `ok == true`, count the pass against the head the artifact actually reviewed (`qa_metadata.reviewed_head`, pinned at scope derivation). Read the artifact head first:
    ```bash
-   .agents/skills/orch/scripts/workflow-state increment [ISSUE_ID] pr_local_review.passes
    jq -r '.qa_metadata.reviewed_head // empty' "$LOCAL_OUTPUT"
    ```
-   If the jq output is non-empty, record it — the artifact's pin wins over the step 1 stamp:
+   If the output is non-empty, use it as `[ARTIFACT_HEAD]`; if empty (an older artifact without the stamp), use the `head` value the step 1 check printed. Then count and attribute in ONE update — increment only when the recorded head already matches; a mismatch (HEAD moved between step 1 and the review) initializes the artifact's head at one pass instead of letting a new head inherit the old head's count:
    ```bash
-   .agents/skills/orch/scripts/workflow-state update [ISSUE_ID] '.pr_local_review.reviewed_head = "[REVIEWED_HEAD_FROM_PREVIOUS_COMMAND]"'
+   .agents/skills/orch/scripts/workflow-state update [ISSUE_ID] '.pr_local_review = (if (.pr_local_review.reviewed_head // "") == "[ARTIFACT_HEAD]" then (.pr_local_review + {passes: ((.pr_local_review.passes // 0) + 1)}) else ((.pr_local_review // {}) + {passes: 1, reviewed_head: "[ARTIFACT_HEAD]"}) end)'
    ```
-   If it is empty (an older artifact without the stamp), skip the record — the step 1 budget check already stamped the worktree HEAD, and the counted pass stays attributed to it.
 
    If `ok == false`, report the `reason` and continue to § 2 — local review is advisory, never a submission blocker. This includes reason `no_review` (the artifact self-reports no review happened), reason `incomplete` (the artifact declares `qa_metadata` but its findings are unusable — arrays lost, or a present `blockers[]`/`suggestions[]` item omits a required `review-finding` field such as `category`; a `detail` field pinpoints it), and script exits 3 (no diff scope) / 4 (model reported no review, or the response stayed schema-incomplete after the one-shot retry) / 5 (the external CLI never produced a review — non-zero exit, timeout, or empty response — partial output preserved as `<output>.failed.json`): none of these is a pass.
 
@@ -115,7 +113,7 @@ Bot reviews are **asynchronous** in this workflow: GitHub review bots post on th
      - `source`: `local-review`
    - `suggestions[]` with `category: "issue"` → build the audit-input file and invoke `⤵ .agents/skills/project-management/workflows/audit-issues.md --issues [FILE_PATH] § 1-9 → § 1.2 step 5` (same path as `review-pr-comments.md` § 6.2). Include created issue IDs in the PR body (§ 2 step 3).
 
-5. **Re-verify after fixes**: if dev-fix applied commits, return to step 1 for one confirming pass over the updated diff — the fix commits moved HEAD, so the step 1 check starts a fresh round for the new head. If nothing was applied, → § 2.
+5. **Re-verify after fixes**: if dev-fix applied commits, return to step 1 for **one** confirming pass over the updated diff — the fix commits moved HEAD, so the step 1 check starts a fresh round for the new head. The loop bound is this step's one-confirming-pass rule, not the per-head budget (which by design refills on every new head, exactly as GitHub bots re-review every push): after the confirming pass, → § 2 regardless of findings routed. If nothing was applied, → § 2.
 
 ---
 

--- a/skills/orch/workflows/submit-pr.md
+++ b/skills/orch/workflows/submit-pr.md
@@ -94,9 +94,9 @@ Bot reviews are **asynchronous** in this workflow: GitHub review bots post on th
    ```bash
    jq -r '.qa_metadata.reviewed_head // empty' "$LOCAL_OUTPUT"
    ```
-   If the output is non-empty, use it as `[ARTIFACT_HEAD]`; if empty (an older artifact without the stamp), use the `head` value the step 1 check printed. Then count and attribute in ONE update — increment only when the recorded head already matches; a mismatch (HEAD moved between step 1 and the review) initializes the artifact's head at one pass instead of letting a new head inherit the old head's count:
+   If the output is non-empty, use it as `[ARTIFACT_HEAD]`; if empty (an older artifact without the stamp), use the `head` value the step 1 check printed. Then count the pass — the helper validates the SHA (a malformed artifact value is refused, never embedded in a state expression) and attributes atomically: increment when the recorded head matches, else the new head initializes at one pass rather than inheriting the old head's count:
    ```bash
-   .agents/skills/orch/scripts/workflow-state update [ISSUE_ID] '.pr_local_review = (if (.pr_local_review.reviewed_head // "") == "[ARTIFACT_HEAD]" then (.pr_local_review + {passes: ((.pr_local_review.passes // 0) + 1)}) else ((.pr_local_review // {}) + {passes: 1, reviewed_head: "[ARTIFACT_HEAD]"}) end)'
+   .agents/skills/orch/scripts/local-review-budget [ISSUE_ID] --count "[ARTIFACT_HEAD]"
    ```
 
    If `ok == false`, report the `reason` and continue to § 2 — local review is advisory, never a submission blocker. This includes reason `no_review` (the artifact self-reports no review happened), reason `incomplete` (the artifact declares `qa_metadata` but its findings are unusable — arrays lost, or a present `blockers[]`/`suggestions[]` item omits a required `review-finding` field such as `category`; a `detail` field pinpoints it), and script exits 3 (no diff scope) / 4 (model reported no review, or the response stayed schema-incomplete after the one-shot retry) / 5 (the external CLI never produced a review — non-zero exit, timeout, or empty response — partial output preserved as `<output>.failed.json`): none of these is a pass.


### PR DESCRIPTION
Fixes VST-153 (Linear): the second half of VST-124's round parity. vstack#1141 gave second-opinion artifacts `qa_metadata.reviewed_head`; this PR makes orch's local pre-PR review budget consume it — passes are counted **per pushed head** (a new head is a new round, matching GitHub bots' re-review-every-push behavior), not per submission.

- New `local-review-budget` helper (contract in `--help`): effective pass count for the worktree's current HEAD; atomically resets the counter and stamps the new head when HEAD moved, merging into `pr_local_review` without clobbering sibling keys. Validates a full 40-hex SHA before jq embedding.
- `submit-pr` § 1.2 routes the budget check through the helper; after each counted pass the artifact's pinned `reviewed_head` is recorded (winning over the pre-check stamp); pre-#1141 artifacts without the stamp keep the pre-check attribution.
- `workflow-state.md` schema row documents both fields and the per-head semantics; CHANGELOG entry included.

Verification: new `local-review-budget.test.sh` (27 assertions: reset-on-new-head, within-head cap, sibling-key preservation, real-worktree HEAD resolution and reset on a new commit, usage/error contract); full orch suite green (32 files); shellcheck clean.

Note: this branch's fix agent completed the work but went idle before reporting (known harness issue); the steward reviewed the staged diff, ran the suites, and committed.

https://claude.ai/code/session_015yN1mXbYpuKF4jTT5qY2Ck