### PR TITLE
feat(linear): --attach file uploads on issues create/update and comments create

### DIFF
--- a/skills/linear/README.md
+++ b/skills/linear/README.md
@@ -32,6 +32,8 @@ Read-only cache queries (`./scripts/linear.sh cache ...` except `cache attachmen
 
 Use `comments create ISSUE --body-file tmp/comment.md` for Markdown or multi-line comments. Inline `--body` is intended for short plain strings.
 
+Use `--attach <path>` (repeatable) on `issues create`, `issues update`, and `comments create` to upload local files via Linear's `fileUpload` flow. Images embed as `![name](assetUrl)` markdown in the description/body; other files become Linear attachments on issues (`attachmentCreate`) or `[name](assetUrl)` links on comments. A missing/unreadable path refuses before any API call; a failed attachment after a successful issue write reports the identifier with `partial: true` on stderr and exits nonzero.
+
 Use `issues activate ISSUE --agent NAME` to claim an issue: it sets "In Progress" and applies the exclusive `agent:NAME` label in a single update (replacing any existing `agent:*` label), and fails without changing state when the label does not exist.
 
 Use `issues complete ISSUE --summary-file tmp/summary.md` (or `--summary "text"`) to post the completion summary comment and then transition to "Done". The comment is posted first, so a failed post leaves the issue state unchanged; unknown or trailing arguments are rejected before any mutation.

--- a/skills/linear/SKILL.md
+++ b/skills/linear/SKILL.md
@@ -41,8 +41,8 @@ CLI wrapper for Linear's GraphQL API with local cache, bulk operations, and stru
 
 | Resource | Actions |
 |----------|---------|
-| `issues` | list, get, create, update, children, list-relations, add-relation, remove-relation, bulk-get, bulk-update, activate (`--agent <name>` applies the exclusive `agent:<name>` label), block, unblock, complete (`--summary <text>` / `--summary-file <path>` post the completion comment before the Done transition), validate-completion |
-| `comments` | list, create (`--body` or `--body-file`) |
+| `issues` | list, get, create, update (create and update take a repeatable `--attach <path>` file upload — see [Attachment Uploads](#attachment-uploads)), children, list-relations, add-relation, remove-relation, bulk-get, bulk-update, activate (`--agent <name>` applies the exclusive `agent:<name>` label), block, unblock, complete (`--summary <text>` / `--summary-file <path>` post the completion comment before the Done transition), validate-completion |
+| `comments` | list, create (`--body`, `--body-file`, repeatable `--attach <path>`) |
 | `projects` | list, get, create, update, list-dependencies, add-dependency, remove-dependency, post-update, list-updates |
 | `initiatives` | list, get, create, add-project |
 | `milestones` | list, get, create |
@@ -97,6 +97,15 @@ linear.sh sync --full           # Full re-sync
 Cache and attachment files live under `.cache/linear` in the physical git worktree root reported by `git rev-parse --show-toplevel`, not under the path used to reach the skill script. This keeps `sync`, `cache`, and attachment reads consistent across symlinked checkout spellings, worktrees, and canonical source-path invocation. A missing-cache error includes the checked `cache_dir` and `meta_path`; inspect those fields before assuming a sync wrote somewhere else.
 
 In a linked git worktree whose `.cache` should be a `WORKTREE_SYMLINKS`-managed symlink into the main checkout but is a real directory (a git operation re-materialized it), any full or reconciling `sync` refuses before touching the API — a full re-sync into a worktree-local dir would silently re-pull the entire history and burn the shared API budget. The refusal names the worktree, the expected symlink, and the repair: run `worktree fix-links <PATH>` from the main checkout, then re-run `sync`. Repos whose configured `WORKTREE_SYMLINKS` deliberately excludes `.cache` are exempt.
+
+## Attachment Uploads
+
+`issues create`, `issues update`, and `comments create` take a repeatable `--attach <path>`. Each file is uploaded through Linear's `fileUpload` flow: the mutation returns `uploadUrl`, `assetUrl`, and the exact headers the storage PUT must carry — the CLI PUTs the bytes with those headers verbatim (plus Content-Type from the file extension; unknown extensions upload as `application/octet-stream`).
+
+- Images (`image/*`) embed into the description/body being written as `![<filename>](<assetUrl>)`. On `issues update` without `--description`/`--description-file`, the embed appends to the issue's existing description.
+- Non-image files on issues become real Linear attachments (`attachmentCreate`) after the issue write; `issues update --attach` alone (no other fields) is valid and skips the `issueUpdate` mutation. On comments they append a `[<filename>](<assetUrl>)` markdown link instead — comments have no attachment surface.
+- `--attach` composes with `--description-file`/`--body-file`. A missing or unreadable path refuses before any API call. If the issue write succeeded but an attachment step failed, the command reports the issue identifier with `partial: true` on stderr and exits non-zero — never a zero exit with a silent gap.
+- Embedded assetUrls point at `uploads.linear.app`, so the attachment cache downloads them on write-through and picks them up on sync like any other attachment.
 
 ## Issue Creation Routing
 

--- a/skills/linear/scripts/commands/comments.sh
+++ b/skills/linear/scripts/commands/comments.sh
@@ -128,7 +128,14 @@ create_comment() {
             --body) body="$2"; shift 2 ;;
             --body-file) body_file="$2"; shift 2 ;;
             --parent) parent_id="$2"; shift 2 ;;
-            --attach) attach_paths+=("$2"); shift 2 ;;
+            --attach)
+                if [ -z "${2-}" ]; then
+                    echo '{"error": "--attach requires a path argument"}' >&2
+                    return 1
+                fi
+                attach_paths+=("$2")
+                shift 2
+                ;;
             --attach=*) attach_paths+=("${1#*=}"); shift ;;
             --) shift; break ;;
             -*) echo "{\"error\": \"Unknown option: $1. Run --help for valid options.\"}" >&2; return 1 ;;
@@ -165,10 +172,12 @@ create_comment() {
         attach_url=$(echo "$attach_info" | jq -r '.assetUrl')
         attach_name=$(echo "$attach_info" | jq -r '.filename')
         attach_type=$(echo "$attach_info" | jq -r '.contentType')
+        local attach_label
+        attach_label="$(attach_markdown_label "$attach_name")"
         if [[ "$attach_type" == image/* ]]; then
-            body="${body:+${body}${attach_sep}}![${attach_name}](${attach_url})"
+            body="${body:+${body}${attach_sep}}![${attach_label}](${attach_url})"
         else
-            body="${body:+${body}${attach_sep}}[${attach_name}](${attach_url})"
+            body="${body:+${body}${attach_sep}}[${attach_label}](${attach_url})"
         fi
     done
 

--- a/skills/linear/scripts/commands/comments.sh
+++ b/skills/linear/scripts/commands/comments.sh
@@ -25,9 +25,14 @@ List:
   comments.sh list <issue-id>
 
 Create Options:
-  --body <text>         Comment body (required unless --body-file is set)
+  --body <text>         Comment body (required unless --body-file or --attach is set)
   --body-file <path>    Read comment body from file (preferred for markdown)
   --parent <id>         Parent comment ID for replies
+  --attach <path>       Upload a file to Linear and reference it in the body
+                        (repeatable). Images embed as ![name](assetUrl); other
+                        files append a [name](assetUrl) markdown link. Composes
+                        with --body/--body-file; missing/unreadable paths
+                        refuse before any API call.
 
 Update Options:
   --body <text>         New comment body (required unless --body-file is set)
@@ -37,6 +42,7 @@ Examples:
   comments.sh list PROJ-42
   comments.sh create PROJ-42 --body "Starting work on this task"
   comments.sh create PROJ-42 --body-file tmp/comment.md
+  comments.sh create PROJ-42 --body "See capture" --attach tmp/screenshot.png
   comments.sh update <comment-id> --body "Updated comment text"
   comments.sh delete <comment-id>
 EOF
@@ -115,12 +121,15 @@ create_comment() {
     local body=""
     local body_file=""
     local parent_id=""
+    local attach_paths=()
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
             --body) body="$2"; shift 2 ;;
             --body-file) body_file="$2"; shift 2 ;;
             --parent) parent_id="$2"; shift 2 ;;
+            --attach) attach_paths+=("$2"); shift 2 ;;
+            --attach=*) attach_paths+=("${1#*=}"); shift ;;
             --) shift; break ;;
             -*) echo "{\"error\": \"Unknown option: $1. Run --help for valid options.\"}" >&2; return 1 ;;
             *) break ;;
@@ -135,10 +144,33 @@ create_comment() {
         read_body_file "$body_file"
     fi
 
-    if [ -z "$body" ]; then
-        echo '{"error": "Required: --body or --body-file"}' >&2
+    # --attach: refuse unreadable paths before any API call.
+    if [ ${#attach_paths[@]} -gt 0 ]; then
+        attach_preflight_files "${attach_paths[@]}" || return 1
+    fi
+
+    if [ -z "$body" ] && [ ${#attach_paths[@]} -eq 0 ]; then
+        echo '{"error": "Required: --body, --body-file, or --attach"}' >&2
         return 1
     fi
+
+    # Upload --attach files and reference them from the comment body: images
+    # embed as markdown, other files get a markdown link (comments have no
+    # attachmentCreate surface, so the link IS the attachment). An upload
+    # failure refuses here, before the comment exists — nothing partial.
+    local attach_path attach_info attach_sep=$'\n\n'
+    for attach_path in ${attach_paths[@]+"${attach_paths[@]}"}; do
+        attach_info=$(attach_upload_file "$attach_path") || return 1
+        local attach_url attach_name attach_type
+        attach_url=$(echo "$attach_info" | jq -r '.assetUrl')
+        attach_name=$(echo "$attach_info" | jq -r '.filename')
+        attach_type=$(echo "$attach_info" | jq -r '.contentType')
+        if [[ "$attach_type" == image/* ]]; then
+            body="${body:+${body}${attach_sep}}![${attach_name}](${attach_url})"
+        else
+            body="${body:+${body}${attach_sep}}[${attach_name}](${attach_url})"
+        fi
+    done
 
     # Escape body for JSON (handle newlines and quotes)
     local escaped_body

--- a/skills/linear/scripts/commands/issues.sh
+++ b/skills/linear/scripts/commands/issues.sh
@@ -147,6 +147,14 @@ Create Options:
   --parent <id>         Parent issue ID (creates sub-issue)
   --milestone <name|uuid> Project milestone (name or UUID)
   --cycle <id>          Cycle (sprint) ID
+  --attach <path>       Upload a file to Linear and attach it (repeatable).
+                        Images (png/jpg/jpeg/gif/webp/svg) embed into the
+                        description as ![name](assetUrl); other files become
+                        Linear attachments (attachmentCreate) on the created
+                        issue. Composes with --description/--description-file.
+                        Missing/unreadable paths refuse before any API call;
+                        an attachment failure after the create reports the
+                        created identifier and exits non-zero.
   --format=ids          Print ONLY the created issue identifier (for capture;
                         default output is the full JSON create response)
   --no-agent-label      Permit a deliberate bare create (e.g. intake
@@ -175,6 +183,13 @@ Update Options:
   --milestone <name|uuid> Set project milestone (name or UUID)
   --cycle <id>          Set cycle (sprint) ID
   --clear-cycle         Remove cycle assignment
+  --attach <path>       Upload a file to Linear and attach it (repeatable).
+                        Images embed as ![name](assetUrl) appended to the
+                        description being written (with no --description on
+                        this update, appended to the existing description);
+                        other files become Linear attachments. --attach alone
+                        is a valid update. Partial failures after the update
+                        report the identifier and exit non-zero.
   --sort-order <float>  Manual sort position (lower = higher; parent/standalone only)
   --format <fmt>        Output format for the updated issue: safe | compact | ids |
                         raw. When omitted, emits the mutation summary
@@ -881,6 +896,52 @@ require_agent_routing_label() {
     return 0
 }
 
+# Create pending non-image attachments on an issue that already exists.
+# Entries are "assetUrl<TAB>title" strings from the upload loop. A failure
+# here is a partial write: the issue mutation succeeded but an attachment is
+# missing, so each failure emits a JSON error naming the issue with
+# partial: true (same posture as bulk-update), and the caller must exit
+# non-zero. Usage: apply_pending_attachments <uuid> <identifier> <entry>...
+apply_pending_attachments() {
+    local issue_uuid="$1" issue_identifier="$2"
+    shift 2
+    local failed=0 entry
+    for entry in "$@"; do
+        local pending_url="${entry%%$'\t'*}"
+        local pending_name="${entry#*$'\t'}"
+        if [[ -z "$issue_uuid" ]] ||
+            ! attach_create_issue_attachment "$issue_uuid" "$pending_url" "$pending_name"; then
+            jq -cn --arg id "${issue_identifier:-$issue_uuid}" --arg name "$pending_name" --arg url "$pending_url" \
+                '{error: ("attachmentCreate failed for " + $name + " on issue " + $id + " - the issue write succeeded but this attachment is missing (uploaded asset: " + $url + ")"), identifier: $id, partial: true}' >&2
+            failed=1
+        fi
+    done
+    return "$failed"
+}
+
+# Upload every --attach path, embedding images into the description variable
+# of the caller and queueing non-images for apply_pending_attachments.
+# Usage: upload_attach_paths <path>...
+# Caller contract: `description` and `attach_pending` are the CALLER's
+# variables (description grows ![name](assetUrl) embeds; attach_pending grows
+# "assetUrl<TAB>filename" entries). Returns 1 on any upload failure.
+upload_attach_paths() {
+    local attach_path attach_info
+    local attach_sep=$'\n\n'
+    for attach_path in "$@"; do
+        attach_info=$(attach_upload_file "$attach_path") || return 1
+        local attach_url attach_name attach_type
+        attach_url=$(echo "$attach_info" | jq -r '.assetUrl')
+        attach_name=$(echo "$attach_info" | jq -r '.filename')
+        attach_type=$(echo "$attach_info" | jq -r '.contentType')
+        if [[ "$attach_type" == image/* ]]; then
+            description="${description:+${description}${attach_sep}}![${attach_name}](${attach_url})"
+        else
+            attach_pending+=("${attach_url}"$'\t'"${attach_name}")
+        fi
+    done
+}
+
 create_issue() {
     if cache_test_isolation_violation; then
         cache_test_isolation_refusal
@@ -902,12 +963,22 @@ create_issue() {
     local requested_parent_id=""
     local output_format=""
     local no_agent_label=0
+    local attach_paths=()
+    local attach_pending=()
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
         --title)
             title="$2"
             shift 2
+            ;;
+        --attach)
+            attach_paths+=("$2")
+            shift 2
+            ;;
+        --attach=*)
+            attach_paths+=("${1#*=}")
+            shift
             ;;
         --format)
             output_format="$2"
@@ -1023,6 +1094,15 @@ create_issue() {
     fi
 
     require_agent_routing_label "$labels" "$no_agent_label" || return 1
+
+    # --attach: refuse unreadable paths before any API call, then upload
+    # (uploads run only after the routing guard above has passed). Images
+    # embed into the description; other files become Linear attachments on
+    # the created issue after the create (attachmentCreate needs its id).
+    if [ ${#attach_paths[@]} -gt 0 ]; then
+        attach_preflight_files "${attach_paths[@]}" || return 1
+        upload_attach_paths "${attach_paths[@]}" || return 1
+    fi
 
     # Build input object - use jq for proper JSON escaping
     local escaped_title
@@ -1225,6 +1305,22 @@ create_issue() {
         _desc=$(echo "$created_issue" | jq -r '.description // empty')
         attach_download_from_text "$_desc" "$_id" "description" &
     fi
+    # Non-image --attach files: attachmentCreate against the created issue.
+    # The issue already exists here, so a failure must surface the created
+    # identifier AND exit non-zero — never a zero exit with a silent gap.
+    local attach_failed=0
+    if [ ${#attach_pending[@]} -gt 0 ]; then
+        if [[ -n "$created_issue" && "$created_issue" != "null" ]]; then
+            local created_uuid created_identifier
+            created_uuid=$(echo "$created_issue" | jq -r '.id // empty')
+            created_identifier=$(echo "$created_issue" | jq -r '.identifier // empty')
+            apply_pending_attachments "$created_uuid" "$created_identifier" \
+                "${attach_pending[@]}" || attach_failed=1
+        else
+            echo '{"error": "Issue was created but the response omitted the issue object; uploaded files could not be attached", "partial": true}' >&2
+            attach_failed=1
+        fi
+    fi
     local normalized
     normalized=$(normalize_mutation_response "$result" "issueCreate" "issue")
     emit_linear_issue_activity "linear.issue_created" "info" "$normalized"
@@ -1235,6 +1331,9 @@ create_issue() {
         echo "$normalized" | jq -r '.identifier // empty'
     else
         echo "$normalized"
+    fi
+    if [ "$attach_failed" = "1" ]; then
+        return 1
     fi
 }
 
@@ -1263,9 +1362,19 @@ update_issue() {
     local clear_estimate="false"
     local sort_order=""
     local output_format=""
+    local attach_paths=()
+    local attach_pending=()
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
+        --attach)
+            attach_paths+=("$2")
+            shift 2
+            ;;
+        --attach=*)
+            attach_paths+=("${1#*=}")
+            shift
+            ;;
         --format)
             output_format="$2"
             shift 2
@@ -1410,6 +1519,11 @@ update_issue() {
         read_description_file "$description_file"
     fi
 
+    # --attach: refuse unreadable paths before any API call.
+    if [ ${#attach_paths[@]} -gt 0 ]; then
+        attach_preflight_files "${attach_paths[@]}" || return 1
+    fi
+
     local input_parts=()
 
     # Get issue to find team ID (needed for state lookup) - use raw format
@@ -1417,6 +1531,25 @@ update_issue() {
     issue_result=$(get_issue "$issue_id" --format=raw)
     local team_name
     team_name=$(echo "$issue_result" | jq -r '.issue.team.name // empty')
+
+    # Upload --attach files. Image embeds append to the description being
+    # written; when this update does not itself rewrite the description,
+    # seed it from the issue's current one so the embed is an append, not a
+    # wipe. Non-images queue for attachmentCreate after the update.
+    if [ ${#attach_paths[@]} -gt 0 ]; then
+        if [[ -z "$description" && -z "$description_file" ]]; then
+            local has_image_attach=0 attach_probe
+            for attach_probe in "${attach_paths[@]}"; do
+                case "$(attach_upload_content_type "$attach_probe")" in
+                image/*) has_image_attach=1 ;;
+                esac
+            done
+            if [ "$has_image_attach" = "1" ]; then
+                description=$(echo "$issue_result" | jq -r '.issue.description // empty')
+            fi
+        fi
+        upload_attach_paths "${attach_paths[@]}" || return 1
+    fi
 
     if [ -n "$title" ]; then
         local escaped_title
@@ -1545,9 +1678,34 @@ update_issue() {
         input_parts+=("\"cycleId\": \"$cycle\"")
     fi
 
-    if [ ${#input_parts[@]} -eq 0 ]; then
+    if [ ${#input_parts[@]} -eq 0 ] && [ ${#attach_pending[@]} -eq 0 ]; then
         echo '{"error": "No update options provided"}' >&2
         return 1
+    fi
+
+    # Attach-only update (non-image --attach, no field changes): there is
+    # nothing to send through issueUpdate, so skip the mutation and only
+    # create the attachments against the resolved issue.
+    if [ ${#input_parts[@]} -eq 0 ]; then
+        local attach_only_uuid attach_only_identifier attach_only_url
+        attach_only_uuid=$(echo "$issue_result" | jq -r '.issue.id // empty')
+        attach_only_identifier=$(echo "$issue_result" | jq -r '.issue.identifier // empty')
+        attach_only_url=$(echo "$issue_result" | jq -r '.issue.url // empty')
+        if [[ -z "$attach_only_uuid" ]]; then
+            jq -cn --arg id "$issue_id" '{error: ("Issue not found: " + $id)}' >&2
+            return 1
+        fi
+        local attach_only_failed=0
+        apply_pending_attachments "$attach_only_uuid" "$attach_only_identifier" \
+            "${attach_pending[@]}" || attach_only_failed=1
+        jq -cn --arg identifier "$attach_only_identifier" --arg url "$attach_only_url" \
+            --argjson ok "$([ "$attach_only_failed" = "0" ] && echo true || echo false)" \
+            --argjson count "${#attach_pending[@]}" \
+            '{success: $ok, identifier: $identifier, url: (if $url == "" then null else $url end), attachments_requested: $count}'
+        if [ "$attach_only_failed" = "1" ]; then
+            return 1
+        fi
+        return 0
     fi
 
     local input_json
@@ -1624,6 +1782,22 @@ update_issue() {
         echo "$normalized"
         ;;
     esac
+
+    # Non-image --attach files: attachmentCreate after the update. The update
+    # itself succeeded (and was reported above), so a failure here must name
+    # the issue and exit non-zero — never a zero exit with a silent gap.
+    if [ ${#attach_pending[@]} -gt 0 ]; then
+        local attach_target_uuid attach_target_identifier
+        if [[ -n "$updated_issue" && "$updated_issue" != "null" ]]; then
+            attach_target_uuid=$(echo "$updated_issue" | jq -r '.id // empty')
+            attach_target_identifier=$(echo "$updated_issue" | jq -r '.identifier // empty')
+        else
+            attach_target_uuid=$(echo "$issue_result" | jq -r '.issue.id // empty')
+            attach_target_identifier=$(echo "$issue_result" | jq -r '.issue.identifier // empty')
+        fi
+        apply_pending_attachments "$attach_target_uuid" "$attach_target_identifier" \
+            "${attach_pending[@]}" || return 1
+    fi
 }
 
 # IssueArchivePayload.success reports the request was processed, not that the

--- a/skills/linear/scripts/commands/issues.sh
+++ b/skills/linear/scripts/commands/issues.sh
@@ -582,12 +582,14 @@ bulk_update_issues() {
             from_stdin="true"
             shift
             ;;
-        --state | --status | --labels | --label | --title | --description | --project | --parent | --milestone | --priority | --estimate | --assignee | --cycle | --sort-order)
+        --state | --status | --labels | --label | --title | --description | --project | --parent | --milestone | --priority | --estimate | --assignee | --cycle | --sort-order | --attach)
             # These are update options - collect with their values
+            # (--attach re-uploads per issue: Linear assets are issue-agnostic
+            # but each issue gets its own embed/attachment)
             update_args+=("$1" "$2")
             shift 2
             ;;
-        --state=* | --status=* | --labels=* | --label=* | --title=* | --description=* | --project=* | --parent=* | --milestone=* | --priority=* | --estimate=* | --assignee=* | --cycle=* | --sort-order=*)
+        --state=* | --status=* | --labels=* | --label=* | --title=* | --description=* | --project=* | --parent=* | --milestone=* | --priority=* | --estimate=* | --assignee=* | --cycle=* | --sort-order=* | --attach=*)
             # Support --key=value syntax (AI agents often use this)
             local _key="${1%%=*}" _val="${1#*=}"
             update_args+=("$_key" "$_val")
@@ -935,7 +937,9 @@ upload_attach_paths() {
         attach_name=$(echo "$attach_info" | jq -r '.filename')
         attach_type=$(echo "$attach_info" | jq -r '.contentType')
         if [[ "$attach_type" == image/* ]]; then
-            description="${description:+${description}${attach_sep}}![${attach_name}](${attach_url})"
+            local attach_label
+            attach_label="$(attach_markdown_label "$attach_name")"
+            description="${description:+${description}${attach_sep}}![${attach_label}](${attach_url})"
         else
             attach_pending+=("${attach_url}"$'\t'"${attach_name}")
         fi
@@ -973,6 +977,10 @@ create_issue() {
             shift 2
             ;;
         --attach)
+            if [ -z "${2-}" ]; then
+                echo '{"error": "--attach requires a path argument"}' >&2
+                return 1
+            fi
             attach_paths+=("$2")
             shift 2
             ;;
@@ -1101,6 +1109,25 @@ create_issue() {
     # the created issue after the create (attachmentCreate needs its id).
     if [ ${#attach_paths[@]} -gt 0 ]; then
         attach_preflight_files "${attach_paths[@]}" || return 1
+        # Resolve declared agent labels BEFORE uploading: under a declared
+        # taxonomy an unresolvable agent label refuses the create later
+        # (routed-or-refused), and uploads done first would strand orphaned
+        # assets in Linear storage.
+        if [ -n "$labels" ] && [ -n "${LINEAR_AGENT_LABELS:-}" ]; then
+            local pre_label_names=() pre_label_name
+            IFS=',' read -ra pre_label_names <<<"$labels"
+            for pre_label_name in "${pre_label_names[@]}"; do
+                case "$pre_label_name" in
+                agent:*)
+                    if ! resolve_label_id "$pre_label_name" >/dev/null; then
+                        jq -cn --arg label "$pre_label_name" \
+                            '{error: ("Agent label failed to resolve in Linear: " + $label + " - refusing before uploading attachments (the create would be refused as unrouted). Create the label in Linear (or fix LINEAR_AGENT_LABELS), then retry.")}' >&2
+                        return 1
+                    fi
+                    ;;
+                esac
+            done
+        fi
         upload_attach_paths "${attach_paths[@]}" || return 1
     fi
 
@@ -1242,6 +1269,14 @@ create_issue() {
 
     local result
     result=$(graphql_query "$mutation" "{\"input\": $input_json}")
+    # graphql_query treats any HTTP-200 payload as a completed request — a
+    # payload-level rejection (issueCreate.success == false) must fail HERE,
+    # before anything downstream claims a created issue or attaches uploads
+    # to whatever object a failed payload happened to include.
+    if [ "$(echo "$result" | jq -r '.issueCreate.success // false')" != "true" ]; then
+        echo "$result" | jq -c '{error: "issueCreate was rejected (success != true) - no issue was created; uploaded files (if any) were not attached", data: (.issueCreate // {})}' >&2
+        return 1
+    fi
     # Write-through: upsert new issue into cache
     local created_issue
     created_issue=$(echo "$result" | jq '.issueCreate.issue // empty')
@@ -1368,6 +1403,10 @@ update_issue() {
     while [[ $# -gt 0 ]]; do
         case "$1" in
         --attach)
+            if [ -z "${2-}" ]; then
+                echo '{"error": "--attach requires a path argument"}' >&2
+                return 1
+            fi
             attach_paths+=("$2")
             shift 2
             ;;
@@ -1726,6 +1765,13 @@ update_issue() {
 
     local result
     result=$(graphql_query "$mutation" "{\"id\": \"$issue_id\", \"input\": $input_json}")
+    # Payload-level rejection (issueUpdate.success == false) must fail HERE —
+    # falling through would report the pre-update issue and still attach
+    # queued uploads to an issue the rejected update never touched.
+    if [ "$(echo "$result" | jq -r '.issueUpdate.success // false')" != "true" ]; then
+        echo "$result" | jq -c --arg id "$issue_id" '{error: ("issueUpdate was rejected (success != true) for " + $id + " - nothing was updated; uploaded files (if any) were not attached"), data: (.issueUpdate // {})}' >&2
+        return 1
+    fi
     # Write-through: upsert updated issue into cache
     local updated_issue
     updated_issue=$(echo "$result" | jq '.issueUpdate.issue // empty')

--- a/skills/linear/scripts/lib/attachments.sh
+++ b/skills/linear/scripts/lib/attachments.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
-# Linear Attachment Cache Library
-# Downloads and caches files/images from uploads.linear.app URLs
-# found in issue descriptions and comment bodies.
+# Linear Attachment Library
+# Download side: caches files/images from uploads.linear.app URLs found in
+# issue descriptions and comment bodies.
+# Upload side: fileUpload mutation + storage PUT for --attach flags
+# (see "Upload path" section below).
 #
 # Auth: Linear upload URLs require `Authorization: $LINEAR_API_KEY` (raw key, no Bearer prefix).
 #
@@ -340,6 +342,148 @@ attach_download_from_text() {
         attach_download_url "$url" "$source_id" "$context" 2>/dev/null || _rc=$?
         # rc 0 = downloaded, rc 2 = already cached, rc 1 = failed (non-fatal)
     done <<< "$urls"
+}
+
+# -----------------------------------------------------------------------------
+# Upload path (issues create/update --attach, comments create --attach)
+# -----------------------------------------------------------------------------
+# Linear's upload flow:
+#   1. fileUpload(contentType, filename, size) returns uploadUrl, assetUrl and
+#      the exact headers the storage PUT must carry.
+#   2. PUT the file bytes to uploadUrl with those headers verbatim (plus
+#      Content-Type) — synthesized headers are rejected by the store.
+#   3. Reference assetUrl from markdown, or attach it via attachmentCreate.
+# These functions need common.sh (graphql_query, curl_config_quote) loaded.
+
+# Content type from the file extension: the type must be declared at
+# fileUpload time, before any bytes exist server-side to sniff.
+attach_upload_content_type() {
+    local filename ext
+    filename="$(basename "$1")"
+    ext="${filename##*.}"
+    [[ "$ext" == "$filename" ]] && ext=""
+    case "$(printf '%s' "$ext" | tr '[:upper:]' '[:lower:]')" in
+    png) echo "image/png" ;;
+    jpg | jpeg) echo "image/jpeg" ;;
+    gif) echo "image/gif" ;;
+    webp) echo "image/webp" ;;
+    svg) echo "image/svg+xml" ;;
+    pdf) echo "application/pdf" ;;
+    txt) echo "text/plain" ;;
+    *) echo "application/octet-stream" ;;
+    esac
+}
+
+# Refuse before any API call: every --attach path must be a readable regular
+# file. Usage: attach_preflight_files <path>...
+attach_preflight_files() {
+    local path
+    for path in "$@"; do
+        if [[ -z "$path" ]]; then
+            echo '{"error": "--attach requires a non-empty path argument"}' >&2
+            return 1
+        fi
+        if [[ ! -f "$path" || ! -r "$path" ]]; then
+            jq -cn --arg path "$path" '{error: ("--attach path not readable: " + $path)}' >&2
+            return 1
+        fi
+    done
+}
+
+# Upload one local file to Linear storage.
+# Usage: attach_upload_file <path>
+# stdout on success: {"assetUrl": "...", "filename": "...", "contentType": "..."}
+# On failure: JSON error on stderr, rc 1, nothing on stdout.
+attach_upload_file() {
+    local file_path="$1"
+    local filename content_type size
+    filename="$(basename "$file_path")"
+    content_type="$(attach_upload_content_type "$file_path")"
+    if ! size=$(stat -c%s "$file_path" 2>/dev/null || stat -f%z "$file_path" 2>/dev/null); then
+        jq -cn --arg path "$file_path" \
+            '{error: ("Could not determine file size for --attach path: " + $path)}' >&2
+        return 1
+    fi
+
+    # shellcheck disable=SC2016  # GraphQL variables, not shell expansions
+    local mutation='
+    mutation FileUpload($contentType: String!, $filename: String!, $size: Int!) {
+        fileUpload(contentType: $contentType, filename: $filename, size: $size) {
+            success
+            uploadFile {
+                uploadUrl
+                assetUrl
+                headers { key value }
+            }
+        }
+    }'
+    local variables result
+    variables=$(jq -cn --arg contentType "$content_type" --arg filename "$filename" \
+        --argjson size "$size" '{contentType: $contentType, filename: $filename, size: $size}')
+    if ! result=$(graphql_query "$mutation" "$variables"); then
+        jq -cn --arg path "$file_path" \
+            '{error: ("fileUpload request failed for --attach path: " + $path + " (see previous error)")}' >&2
+        return 1
+    fi
+
+    local upload_url asset_url
+    upload_url=$(echo "$result" | jq -r '.fileUpload.uploadFile.uploadUrl // empty')
+    asset_url=$(echo "$result" | jq -r '.fileUpload.uploadFile.assetUrl // empty')
+    if [[ -z "$upload_url" || -z "$asset_url" ]]; then
+        jq -cn --arg path "$file_path" \
+            '{error: ("fileUpload returned no uploadUrl/assetUrl for --attach path: " + $path)}' >&2
+        return 1
+    fi
+
+    # PUT the bytes with EXACTLY the returned headers (plus Content-Type),
+    # over the same curl-config-on-stdin transport graphql_query uses so
+    # header values never touch process argv.
+    local put_config_lines=(
+        "url = $(curl_config_quote "$upload_url")"
+        'request = "PUT"'
+        "upload-file = $(curl_config_quote "$file_path")"
+        "header = $(curl_config_quote "Content-Type: $content_type")"
+    )
+    local header_line
+    while IFS= read -r header_line; do
+        [[ -n "$header_line" ]] || continue
+        put_config_lines+=("header = $(curl_config_quote "$header_line")")
+    done < <(echo "$result" | jq -r '.fileUpload.uploadFile.headers // [] | .[] | "\(.key): \(.value)"')
+
+    local http_code
+    if ! http_code=$(printf '%s\n' "${put_config_lines[@]}" | curl -s -o /dev/null -w "%{http_code}" -K -); then
+        http_code=000
+    fi
+    case "$http_code" in
+    2??) ;;
+    *)
+        jq -cn --arg path "$file_path" --arg code "$http_code" \
+            '{error: ("Upload PUT failed for --attach path: " + $path + " (HTTP " + $code + ")")}' >&2
+        return 1
+        ;;
+    esac
+
+    jq -cn --arg assetUrl "$asset_url" --arg filename "$filename" --arg contentType "$content_type" \
+        '{assetUrl: $assetUrl, filename: $filename, contentType: $contentType}'
+}
+
+# Attach an uploaded asset URL to an issue as a real Linear attachment.
+# Usage: attach_create_issue_attachment <issue-uuid> <url> <title>
+attach_create_issue_attachment() {
+    local issue_uuid="$1" url="$2" title="$3"
+    # shellcheck disable=SC2016  # GraphQL variables, not shell expansions
+    local mutation='
+    mutation AttachmentCreate($input: AttachmentCreateInput!) {
+        attachmentCreate(input: $input) {
+            success
+            attachment { id url title }
+        }
+    }'
+    local variables result
+    variables=$(jq -cn --arg issueId "$issue_uuid" --arg url "$url" --arg title "$title" \
+        '{input: {issueId: $issueId, url: $url, title: $title}}')
+    result=$(graphql_query "$mutation" "$variables") || return 1
+    echo "$result" | jq -e '.attachmentCreate.success == true' >/dev/null || return 1
 }
 
 # Prune manifest entries where local file is missing

--- a/skills/linear/scripts/lib/attachments.sh
+++ b/skills/linear/scripts/lib/attachments.sh
@@ -355,6 +355,14 @@ attach_download_from_text() {
 #   3. Reference assetUrl from markdown, or attach it via attachmentCreate.
 # These functions need common.sh (graphql_query, curl_config_quote) loaded.
 
+# Escape a filename for use inside a markdown image/link LABEL: backslashes
+# and square brackets escape, newlines collapse to spaces — a name like
+# "report].png" must not terminate the label early and mis-reference the
+# uploaded asset. Only the label needs this; URLs come from Linear.
+attach_markdown_label() {
+    printf '%s' "$1" | tr '\n' ' ' | sed -e 's/\\/\\\\/g' -e 's/\[/\\[/g' -e 's/\]/\\]/g'
+}
+
 # Content type from the file extension: the type must be declared at
 # fileUpload time, before any bytes exist server-side to sniff.
 attach_upload_content_type() {
@@ -438,11 +446,15 @@ attach_upload_file() {
     # PUT the bytes with EXACTLY the returned headers (plus Content-Type),
     # over the same curl-config-on-stdin transport graphql_query uses so
     # header values never touch process argv.
+    # Content-Type and Cache-Control mirror Linear's documented upload
+    # example (linear.app/developers/how-to-upload-a-file-to-linear); the
+    # response headers below are copied verbatim on top.
     local put_config_lines=(
         "url = $(curl_config_quote "$upload_url")"
         'request = "PUT"'
         "upload-file = $(curl_config_quote "$file_path")"
         "header = $(curl_config_quote "Content-Type: $content_type")"
+        "header = $(curl_config_quote "Cache-Control: public, max-age=31536000")"
     )
     local header_line
     while IFS= read -r header_line; do

--- a/skills/linear/tests/comments-create-attach.test.sh
+++ b/skills/linear/tests/comments-create-attach.test.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# VST-126: `comments create <ID> --attach <PATH>`. Files upload through
+# Linear's fileUpload flow and are referenced from the comment body: images
+# embed as ![name](assetUrl), other files append a [name](assetUrl) markdown
+# link (comments have no attachmentCreate surface). --attach composes with
+# --body/--body-file, permits a body-less comment, and a missing/unreadable
+# path refuses before any API call.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+PROJECT="$TMP_ROOT/project"
+mkdir -p "$PROJECT/.agents/skills" "$PROJECT/bin"
+git -C "$PROJECT" init -q -b main
+cp -R "$SKILL_DIR" "$PROJECT/.agents/skills/linear"
+
+LINEAR="$PROJECT/.agents/skills/linear/scripts/linear.sh"
+CURL_LOG="$TMP_ROOT/curl-payloads.jsonl"
+ERR_FILE="$TMP_ROOT/stderr.txt"
+
+cat >"$PROJECT/bin/curl" <<'SH'
+#!/usr/bin/env bash
+has_config=0
+for a in "$@"; do [ "$a" = "-K" ] && has_config=1; done
+if [ "$has_config" = "0" ]; then
+  printf '404'
+  exit 0
+fi
+config="$(cat)"
+
+if grep -q '^upload-file = ' <<<"$config"; then
+  url="$(sed -n 's/^url = //p' <<<"$config" | jq -r)"
+  file="$(sed -n 's/^upload-file = //p' <<<"$config" | jq -r)"
+  headers="$(sed -n 's/^header = //p' <<<"$config" | jq -s .)"
+  jq -cn --arg url "$url" --arg file "$file" --argjson headers "$headers" \
+    '{put: {url: $url, file: $file, headers: $headers}}' >>"${CURL_LOG:?}"
+  printf '200'
+  exit 0
+fi
+
+payload="$(sed -n 's/^data = //p' <<<"$config" | jq -r)"
+printf '%s\n' "$payload" >>"${CURL_LOG:?}"
+query="$(jq -r '.query' <<<"$payload")"
+
+case "$query" in
+*"fileUpload("*)
+  filename="$(jq -r '.variables.filename' <<<"$payload")"
+  printf '%s' "{\"data\":{\"fileUpload\":{\"success\":true,\"uploadFile\":{\"uploadUrl\":\"https://uploads.linear.app/put/$filename\",\"assetUrl\":\"https://uploads.linear.app/asset/$filename\",\"headers\":[{\"key\":\"x-linear-upload\",\"value\":\"signed-$filename\"}]}}}}___HTTP_CODE___200"
+  ;;
+*"commentCreate("*)
+  body="$(jq -c '.variables.input.body' <<<"$payload")"
+  printf '%s' "{\"data\":{\"commentCreate\":{\"success\":true,\"comment\":{\"id\":\"comment-uuid\",\"body\":$body,\"createdAt\":\"2026-08-08T00:00:00Z\",\"updatedAt\":\"2026-08-08T00:00:00Z\",\"user\":{\"name\":\"tester\"},\"issue\":{\"identifier\":\"TEAM-1\",\"updatedAt\":\"2026-08-08T00:00:00Z\"}}}}}___HTTP_CODE___200"
+  ;;
+*)
+  printf '%s' '{"data":{}}___HTTP_CODE___200'
+  ;;
+esac
+SH
+chmod +x "$PROJECT/bin/curl"
+
+printf '[env]\nLINEAR_TEAM = "Configured"\n' >"$PROJECT/vstack.settings.toml"
+
+printf 'PNGDATA' >"$TMP_ROOT/shot.png"
+printf '%%PDF-1.4' >"$TMP_ROOT/notes.pdf"
+printf 'Body from file.' >"$TMP_ROOT/body.md"
+
+OUT=""
+ERR=""
+RC=0
+
+fail() {
+  echo "FAIL $*"
+  [[ -s "$CURL_LOG" ]] && echo "--- curl payloads ---" && cat "$CURL_LOG"
+  exit 1
+}
+
+run_linear() {
+  : >"$CURL_LOG"
+  set +e
+  OUT="$(cd "$PROJECT" && env -u LINEAR_TEAM -u LINEAR_AGENT_LABELS \
+    PATH="$PROJECT/bin:$PATH" \
+    LINEAR_API_KEY=test-token \
+    CURL_LOG="$CURL_LOG" \
+    bash "$LINEAR" "$@" </dev/null 2>"$ERR_FILE")"
+  RC=$?
+  set -e
+  ERR="$(cat "$ERR_FILE")"
+}
+
+api_calls() {
+  wc -l <"$CURL_LOG" | tr -d ' '
+}
+
+echo "=== image attach embeds into the comment body after --body text ==="
+
+run_linear comments create TEAM-1 --body "Note" --attach "$TMP_ROOT/shot.png"
+[[ "$RC" -eq 0 ]] || fail "image attach comment exited $RC: $ERR"
+jq -s -e 'any(.[]; (.query? // "" | contains("fileUpload"))
+    and .variables.contentType == "image/png"
+    and .variables.size == 7)' "$CURL_LOG" >/dev/null ||
+  fail "fileUpload not called with contentType/size from the file"
+jq -s -e 'any(.[]; .put?.url == "https://uploads.linear.app/put/shot.png"
+    and (.put.headers | index("x-linear-upload: signed-shot.png"))
+    and (.put.headers | index("Content-Type: image/png")))' "$CURL_LOG" >/dev/null ||
+  fail "PUT did not carry the returned headers plus Content-Type"
+jq -s -e 'any(.[]; (.query? // "" | contains("commentCreate"))
+    and .variables.input.body == "Note\n\n![shot.png](https://uploads.linear.app/asset/shot.png)\n")' \
+  "$CURL_LOG" >/dev/null || fail "image embed missing from comment body"
+
+echo "=== non-image attach appends a markdown link, never attachmentCreate ==="
+
+run_linear comments create TEAM-1 --body "Report" --attach "$TMP_ROOT/notes.pdf"
+[[ "$RC" -eq 0 ]] || fail "pdf attach comment exited $RC: $ERR"
+jq -s -e 'any(.[]; (.query? // "" | contains("commentCreate"))
+    and .variables.input.body == "Report\n\n[notes.pdf](https://uploads.linear.app/asset/notes.pdf)\n")' \
+  "$CURL_LOG" >/dev/null || fail "markdown link missing from comment body"
+if jq -s -e 'any(.[]; .query? // "" | contains("attachmentCreate"))' "$CURL_LOG" >/dev/null; then
+  fail "comments must never call attachmentCreate"
+fi
+
+echo "=== --attach alone is a valid comment (body is the embed) ==="
+
+run_linear comments create TEAM-1 --attach "$TMP_ROOT/shot.png"
+[[ "$RC" -eq 0 ]] || fail "attach-only comment exited $RC: $ERR"
+jq -s -e 'any(.[]; (.query? // "" | contains("commentCreate"))
+    and .variables.input.body == "![shot.png](https://uploads.linear.app/asset/shot.png)\n")' \
+  "$CURL_LOG" >/dev/null || fail "attach-only body is not the bare embed"
+
+echo "=== --attach composes with --body-file ==="
+
+run_linear comments create TEAM-1 --body-file "$TMP_ROOT/body.md" --attach "$TMP_ROOT/notes.pdf"
+[[ "$RC" -eq 0 ]] || fail "body-file + attach comment exited $RC: $ERR"
+jq -s -e 'any(.[]; (.query? // "" | contains("commentCreate"))
+    and .variables.input.body == "Body from file.\n\n[notes.pdf](https://uploads.linear.app/asset/notes.pdf)\n")' \
+  "$CURL_LOG" >/dev/null || fail "link did not append to --body-file content"
+
+echo "=== missing file refuses before any API call ==="
+
+run_linear comments create TEAM-1 --attach "$TMP_ROOT/nope.png"
+[[ "$RC" -ne 0 ]] || fail "missing --attach path exited 0: $OUT"
+grep -q "not readable" <<<"$ERR" || fail "missing-path refusal lacks 'not readable': $ERR"
+[[ "$(api_calls)" == "0" ]] || fail "missing --attach path attempted $(api_calls) API call(s)"
+
+echo "=== no body and no attach still refuses ==="
+
+run_linear comments create TEAM-1
+[[ "$RC" -ne 0 ]] || fail "body-less, attach-less comment exited 0: $OUT"
+grep -q -- "--attach" <<<"$ERR" || fail "refusal does not mention --attach as an option: $ERR"
+
+echo "all pass"

--- a/skills/linear/tests/comments-create-attach.test.sh
+++ b/skills/linear/tests/comments-create-attach.test.sh
@@ -151,4 +151,12 @@ run_linear comments create TEAM-1
 [[ "$RC" -ne 0 ]] || fail "body-less, attach-less comment exited 0: $OUT"
 grep -q -- "--attach" <<<"$ERR" || fail "refusal does not mention --attach as an option: $ERR"
 
+echo "=== markdown label escaping in comment embeds ==="
+
+printf 'PNG' >"$TMP_ROOT/re]port.png"
+run_linear comments create TEAM-1 --body "See:" --attach "$TMP_ROOT/re]port.png"
+[[ "$RC" -eq 0 ]] || fail "bracket-name comment attach failed: $ERR"
+jq -s -e 'any(.[]; (.query? // "" | contains("commentCreate")) and (.variables.input.body | contains("![re\\]port.png](")))' "$CURL_LOG" >/dev/null ||
+  fail "comment body does not escape the bracket filename: $(cat "$CURL_LOG")"
+
 echo "all pass"

--- a/skills/linear/tests/issues-create-attach.test.sh
+++ b/skills/linear/tests/issues-create-attach.test.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# VST-126: `issues create --attach <PATH>` uploads local files through
+# Linear's fileUpload flow (mutation -> PUT to uploadUrl with EXACTLY the
+# returned headers) and references them from the created issue: images embed
+# as ![name](assetUrl) in the description, other files become Linear
+# attachments via attachmentCreate after the create.
+#
+# Fail-loud contract under test: a missing/unreadable path refuses before
+# any API call; a PUT failure refuses before the issue exists; an
+# attachmentCreate failure AFTER the create reports the created identifier
+# with partial: true and exits non-zero.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+PROJECT="$TMP_ROOT/project"
+mkdir -p "$PROJECT/.agents/skills" "$PROJECT/bin"
+git -C "$PROJECT" init -q -b main
+cp -R "$SKILL_DIR" "$PROJECT/.agents/skills/linear"
+
+LINEAR="$PROJECT/.agents/skills/linear/scripts/linear.sh"
+CURL_LOG="$TMP_ROOT/curl-payloads.jsonl"
+ERR_FILE="$TMP_ROOT/stderr.txt"
+
+# The fake curl mirrors the script's two transports: GraphQL POSTs and the
+# storage PUT both arrive as curl-config-on-stdin (-K -); the attachment
+# cache's background asset download uses direct args (no -K) and is not
+# under test here.
+cat >"$PROJECT/bin/curl" <<'SH'
+#!/usr/bin/env bash
+has_config=0
+for a in "$@"; do [ "$a" = "-K" ] && has_config=1; done
+if [ "$has_config" = "0" ]; then
+  # background attachment-cache download — out of scope, never logged
+  printf '404'
+  exit 0
+fi
+config="$(cat)"
+
+if grep -q '^upload-file = ' <<<"$config"; then
+  url="$(sed -n 's/^url = //p' <<<"$config" | jq -r)"
+  file="$(sed -n 's/^upload-file = //p' <<<"$config" | jq -r)"
+  headers="$(sed -n 's/^header = //p' <<<"$config" | jq -s .)"
+  jq -cn --arg url "$url" --arg file "$file" --argjson headers "$headers" \
+    '{put: {url: $url, file: $file, headers: $headers}}' >>"${CURL_LOG:?}"
+  case "$file" in
+  *put-fail*) printf '500' ;;
+  *) printf '200' ;;
+  esac
+  exit 0
+fi
+
+payload="$(sed -n 's/^data = //p' <<<"$config" | jq -r)"
+printf '%s\n' "$payload" >>"${CURL_LOG:?}"
+query="$(jq -r '.query' <<<"$payload")"
+
+case "$query" in
+*"fileUpload("*)
+  filename="$(jq -r '.variables.filename' <<<"$payload")"
+  printf '%s' "{\"data\":{\"fileUpload\":{\"success\":true,\"uploadFile\":{\"uploadUrl\":\"https://uploads.linear.app/put/$filename\",\"assetUrl\":\"https://uploads.linear.app/asset/$filename\",\"headers\":[{\"key\":\"x-linear-upload\",\"value\":\"signed-$filename\"},{\"key\":\"x-amz-acl\",\"value\":\"private\"}]}}}}___HTTP_CODE___200"
+  ;;
+*"attachmentCreate("*)
+  title="$(jq -r '.variables.input.title' <<<"$payload")"
+  if [ "$title" = "boom.pdf" ]; then
+    printf '%s' '{"data":{"attachmentCreate":{"success":false,"attachment":null}}}___HTTP_CODE___200'
+  else
+    printf '%s' '{"data":{"attachmentCreate":{"success":true,"attachment":{"id":"att-uuid","url":"u","title":"t"}}}}___HTTP_CODE___200'
+  fi
+  ;;
+*"teams(filter:"*)
+  printf '%s' '{"data":{"teams":{"nodes":[{"id":"team-uuid"}]}}}___HTTP_CODE___200'
+  ;;
+*"issueLabels(filter:"*)
+  printf '%s' '{"data":{"issueLabels":{"nodes":[{"id":"label-uuid"}]}}}___HTTP_CODE___200'
+  ;;
+*"issueCreate(input:"*)
+  printf '%s' '{"data":{"issueCreate":{"success":true,"issue":{"id":"issue-uuid","identifier":"TEAM-1","title":"t","description":"","state":{"name":"Todo","type":"unstarted"},"assignee":null,"project":null,"projectMilestone":null,"cycle":null,"parent":null,"team":{"name":"Configured"},"labels":{"nodes":[]},"priority":3,"estimate":null,"sortOrder":1.0,"url":"https://linear.app/x/issue/TEAM-1","createdAt":"2026-08-08T00:00:00Z","updatedAt":"2026-08-08T00:00:00Z","archivedAt":null,"trashed":null,"relations":{"nodes":[]},"inverseRelations":{"nodes":[]}}}}}___HTTP_CODE___200'
+  ;;
+*)
+  printf '%s' '{"data":{}}___HTTP_CODE___200'
+  ;;
+esac
+SH
+chmod +x "$PROJECT/bin/curl"
+
+printf '[env]\nLINEAR_TEAM = "Configured"\n' >"$PROJECT/vstack.settings.toml"
+
+printf 'PNGDATA' >"$TMP_ROOT/shot.png" # 7 bytes, image/png
+printf '%%PDF-1.4' >"$TMP_ROOT/notes.pdf"
+printf 'x' >"$TMP_ROOT/boom.pdf"
+printf 'x' >"$TMP_ROOT/put-fail.png"
+printf 'Body from file.' >"$TMP_ROOT/desc.md"
+
+OUT=""
+ERR=""
+RC=0
+
+fail() {
+  echo "FAIL $*"
+  [[ -s "$CURL_LOG" ]] && echo "--- curl payloads ---" && cat "$CURL_LOG"
+  exit 1
+}
+
+run_linear() {
+  : >"$CURL_LOG"
+  set +e
+  OUT="$(cd "$PROJECT" && env -u LINEAR_TEAM -u LINEAR_AGENT_LABELS \
+    PATH="$PROJECT/bin:$PATH" \
+    LINEAR_API_KEY=test-token \
+    CURL_LOG="$CURL_LOG" \
+    bash "$LINEAR" "$@" </dev/null 2>"$ERR_FILE")"
+  RC=$?
+  set -e
+  ERR="$(cat "$ERR_FILE")"
+}
+
+api_calls() {
+  wc -l <"$CURL_LOG" | tr -d ' '
+}
+
+echo "=== image attach: fileUpload -> PUT with returned headers -> embed in description ==="
+
+run_linear issues create --title "With image" --attach "$TMP_ROOT/shot.png"
+[[ "$RC" -eq 0 ]] || fail "image attach create exited $RC: $ERR"
+
+jq -s -e 'any(.[]; (.query? // "" | contains("fileUpload"))
+    and .variables.contentType == "image/png"
+    and .variables.filename == "shot.png"
+    and .variables.size == 7)' "$CURL_LOG" >/dev/null ||
+  fail "fileUpload not called with contentType/filename/size from the file"
+
+jq -s -e 'any(.[]; .put?.url == "https://uploads.linear.app/put/shot.png"
+    and (.put.headers | index("x-linear-upload: signed-shot.png"))
+    and (.put.headers | index("x-amz-acl: private"))
+    and (.put.headers | index("Content-Type: image/png")))' "$CURL_LOG" >/dev/null ||
+  fail "PUT did not carry the returned headers plus Content-Type"
+
+# The PUT must precede the create — bytes exist before anything references them.
+jq -s -e '([to_entries[] | select(.value | has("put")) | .key] | first)
+    < ([to_entries[] | select(.value.query? // "" | contains("issueCreate")) | .key] | first)' \
+  "$CURL_LOG" >/dev/null || fail "PUT did not happen before issueCreate"
+
+jq -s -e 'any(.[]; (.query? // "" | contains("issueCreate"))
+    and .variables.input.description == "![shot.png](https://uploads.linear.app/asset/shot.png)")' \
+  "$CURL_LOG" >/dev/null || fail "image embed missing from created description"
+
+if jq -s -e 'any(.[]; .query? // "" | contains("attachmentCreate"))' "$CURL_LOG" >/dev/null; then
+  fail "image attach must embed, not attachmentCreate"
+fi
+
+echo "=== non-image attach: attachmentCreate with the created issue id ==="
+
+run_linear issues create --title "With pdf" --attach "$TMP_ROOT/notes.pdf"
+[[ "$RC" -eq 0 ]] || fail "pdf attach create exited $RC: $ERR"
+
+jq -s -e 'any(.[]; (.query? // "" | contains("fileUpload"))
+    and .variables.contentType == "application/pdf")' "$CURL_LOG" >/dev/null ||
+  fail "fileUpload not called with application/pdf"
+
+jq -s -e 'any(.[]; (.query? // "" | contains("attachmentCreate"))
+    and .variables.input.issueId == "issue-uuid"
+    and .variables.input.url == "https://uploads.linear.app/asset/notes.pdf"
+    and .variables.input.title == "notes.pdf")' "$CURL_LOG" >/dev/null ||
+  fail "attachmentCreate not called with the created issue id and asset url"
+
+jq -s -e 'any(.[]; (.query? // "" | contains("issueCreate"))
+    and (.variables.input | has("description") | not))' "$CURL_LOG" >/dev/null ||
+  fail "non-image attach must not inject a description"
+
+echo "=== --attach composes with --description-file ==="
+
+run_linear issues create --title "Compose" \
+  --description-file "$TMP_ROOT/desc.md" --attach "$TMP_ROOT/shot.png"
+[[ "$RC" -eq 0 ]] || fail "composed create exited $RC: $ERR"
+
+jq -s -e 'any(.[]; (.query? // "" | contains("issueCreate"))
+    and .variables.input.description == "Body from file.\n\n![shot.png](https://uploads.linear.app/asset/shot.png)")' \
+  "$CURL_LOG" >/dev/null || fail "embed did not append to --description-file content"
+
+echo "=== missing file refuses before any API call ==="
+
+run_linear issues create --title "Missing" --attach "$TMP_ROOT/nope.png"
+[[ "$RC" -ne 0 ]] || fail "missing --attach path exited 0: $OUT"
+grep -q "not readable" <<<"$ERR" || fail "missing-path refusal lacks 'not readable': $ERR"
+grep -q "nope.png" <<<"$ERR" || fail "missing-path refusal does not name the path: $ERR"
+[[ "$(api_calls)" == "0" ]] || fail "missing --attach path attempted $(api_calls) API call(s)"
+
+echo "=== PUT failure refuses before the issue exists ==="
+
+run_linear issues create --title "PutFail" --attach "$TMP_ROOT/put-fail.png"
+[[ "$RC" -ne 0 ]] || fail "failed PUT exited 0: $OUT"
+grep -q "Upload PUT failed" <<<"$ERR" || fail "failed PUT lacks the PUT error: $ERR"
+if jq -s -e 'any(.[]; .query? // "" | contains("issueCreate"))' "$CURL_LOG" >/dev/null; then
+  fail "issueCreate was reached despite a failed upload PUT"
+fi
+
+echo "=== attachmentCreate failure AFTER create: names the issue, exits non-zero ==="
+
+run_linear issues create --title "Partial" --attach "$TMP_ROOT/boom.pdf"
+[[ "$RC" -ne 0 ]] || fail "failed attachmentCreate exited 0: $OUT"
+jq -s -e 'any(.[]; .query? // "" | contains("issueCreate"))' "$CURL_LOG" >/dev/null ||
+  fail "issue was not created before the attachment failure"
+grep -q "TEAM-1" <<<"$ERR" || fail "partial failure does not name the created issue: $ERR"
+grep -q '"partial":true' <<<"$ERR" || fail "partial failure lacks partial: true: $ERR"
+grep -q "TEAM-1" <<<"$OUT" || fail "created identifier missing from stdout: $OUT"
+
+echo "=== agent-label guard still refuses BEFORE any upload ==="
+
+printf '[env]\nLINEAR_TEAM = "Configured"\nLINEAR_AGENT_LABELS = "agent:generalist"\n' \
+  >"$PROJECT/vstack.settings.toml"
+run_linear issues create --title "Guarded" --attach "$TMP_ROOT/shot.png"
+[[ "$RC" -ne 0 ]] || fail "bare create with --attach passed the routing guard: $OUT"
+grep -q "LINEAR_AGENT_LABELS" <<<"$ERR" || fail "guard refusal missing: $ERR"
+[[ "$(api_calls)" == "0" ]] || fail "guarded create attempted $(api_calls) API call(s)"
+
+echo "all pass"

--- a/skills/linear/tests/issues-create-attach.test.sh
+++ b/skills/linear/tests/issues-create-attach.test.sh
@@ -75,9 +75,19 @@ case "$query" in
   printf '%s' '{"data":{"teams":{"nodes":[{"id":"team-uuid"}]}}}___HTTP_CODE___200'
   ;;
 *"issueLabels(filter:"*)
-  printf '%s' '{"data":{"issueLabels":{"nodes":[{"id":"label-uuid"}]}}}___HTTP_CODE___200'
+  name="$(jq -r '.variables.name // empty' <<<"$payload")"
+  if [ "$name" = "agent:ghost" ]; then
+    printf '%s' '{"data":{"issueLabels":{"nodes":[]}}}___HTTP_CODE___200'
+  else
+    printf '%s' '{"data":{"issueLabels":{"nodes":[{"id":"label-uuid"}]}}}___HTTP_CODE___200'
+  fi
   ;;
 *"issueCreate(input:"*)
+  title_in="$(jq -r '.variables.input.title // empty' <<<"$payload")"
+  if [ "$title_in" = "REJECT-CREATE" ]; then
+    printf '%s' '{"data":{"issueCreate":{"success":false,"issue":null}}}___HTTP_CODE___200'
+    exit 0
+  fi
   printf '%s' '{"data":{"issueCreate":{"success":true,"issue":{"id":"issue-uuid","identifier":"TEAM-1","title":"t","description":"","state":{"name":"Todo","type":"unstarted"},"assignee":null,"project":null,"projectMilestone":null,"cycle":null,"parent":null,"team":{"name":"Configured"},"labels":{"nodes":[]},"priority":3,"estimate":null,"sortOrder":1.0,"url":"https://linear.app/x/issue/TEAM-1","createdAt":"2026-08-08T00:00:00Z","updatedAt":"2026-08-08T00:00:00Z","archivedAt":null,"trashed":null,"relations":{"nodes":[]},"inverseRelations":{"nodes":[]}}}}}___HTTP_CODE___200'
   ;;
 *)
@@ -216,5 +226,40 @@ run_linear issues create --title "Guarded" --attach "$TMP_ROOT/shot.png"
 [[ "$RC" -ne 0 ]] || fail "bare create with --attach passed the routing guard: $OUT"
 grep -q "LINEAR_AGENT_LABELS" <<<"$ERR" || fail "guard refusal missing: $ERR"
 [[ "$(api_calls)" == "0" ]] || fail "guarded create attempted $(api_calls) API call(s)"
+
+echo "=== markdown label escaping: bracket filename cannot break the embed ==="
+
+printf '[env]\nLINEAR_TEAM = "Configured"\n' >"$PROJECT/vstack.settings.toml"
+printf 'PNG' >"$TMP_ROOT/re]port.png"
+run_linear issues create --title "Escaped" --attach "$TMP_ROOT/re]port.png"
+[[ "$RC" -eq 0 ]] || fail "bracket-name attach failed: $ERR"
+jq -s -e 'any(.[]; (.query? // "" | contains("issueCreate")) and (.variables.input.description | contains("![re\\]port.png](")))' "$CURL_LOG" >/dev/null ||
+  fail "description embed does not escape the bracket filename: $(cat "$CURL_LOG")"
+
+echo "=== issueCreate payload rejection: no attach, non-zero, no created claim ==="
+
+run_linear issues create --title "REJECT-CREATE" --attach "$TMP_ROOT/notes.pdf"
+[[ "$RC" -ne 0 ]] || fail "rejected issueCreate exited 0: $OUT"
+grep -q "rejected" <<<"$ERR" || fail "rejection error missing: $ERR"
+if jq -s -e 'any(.[]; .query? // "" | contains("attachmentCreate"))' "$CURL_LOG" >/dev/null; then
+  fail "attachmentCreate was reached after a rejected create"
+fi
+
+echo "=== declared taxonomy: unresolvable agent label refuses BEFORE uploads ==="
+
+printf '[env]\nLINEAR_TEAM = "Configured"\nLINEAR_AGENT_LABELS = "agent:generalist, agent:ghost"\n' \
+  >"$PROJECT/vstack.settings.toml"
+run_linear issues create --title "Orphan guard" --labels "agent:ghost" --attach "$TMP_ROOT/shot.png"
+[[ "$RC" -ne 0 ]] || fail "unresolvable agent label with --attach exited 0: $OUT"
+if jq -s -e 'any(.[]; .query? // "" | contains("fileUpload"))' "$CURL_LOG" >/dev/null; then
+  fail "fileUpload ran before the routed-or-refused check — orphaned upload"
+fi
+
+echo "=== bare --attach is a structured usage error, not a set -u abort ==="
+
+printf '[env]\nLINEAR_TEAM = "Configured"\n' >"$PROJECT/vstack.settings.toml"
+run_linear issues create --title "Bare" --attach
+[[ "$RC" -ne 0 ]] || fail "bare --attach exited 0: $OUT"
+grep -q "requires a path" <<<"$ERR" || fail "bare --attach lacks the structured error: $ERR"
 
 echo "all pass"

--- a/skills/linear/tests/issues-update-attach.test.sh
+++ b/skills/linear/tests/issues-update-attach.test.sh
@@ -66,7 +66,12 @@ case "$query" in
   fi
   ;;
 *"issueUpdate("*)
-  printf '%s' "{\"data\":{\"issueUpdate\":{\"success\":true,\"issue\":$ISSUE_JSON}}}___HTTP_CODE___200"
+  title_in="$(jq -r '.variables.input.title // empty' <<<"$payload")"
+  if [ "$title_in" = "REJECT-UPDATE" ]; then
+    printf '%s' '{"data":{"issueUpdate":{"success":false,"issue":null}}}___HTTP_CODE___200'
+  else
+    printf '%s' "{\"data\":{\"issueUpdate\":{\"success\":true,\"issue\":$ISSUE_JSON}}}___HTTP_CODE___200"
+  fi
   ;;
 *"issue(id:"*)
   printf '%s' "{\"data\":{\"issue\":$ISSUE_JSON}}___HTTP_CODE___200"
@@ -162,5 +167,21 @@ run_linear issues update TEAM-9 --attach "$TMP_ROOT/nope.png"
 [[ "$RC" -ne 0 ]] || fail "missing --attach path exited 0: $OUT"
 grep -q "not readable" <<<"$ERR" || fail "missing-path refusal lacks 'not readable': $ERR"
 [[ "$(api_calls)" == "0" ]] || fail "missing --attach path attempted $(api_calls) API call(s)"
+
+echo "=== issueUpdate payload rejection: nothing attached, non-zero ==="
+
+run_linear issues update TEAM-9 --title "REJECT-UPDATE" --attach "$TMP_ROOT/notes.pdf"
+[[ "$RC" -ne 0 ]] || fail "rejected issueUpdate exited 0: $OUT"
+grep -q "rejected" <<<"$ERR" || fail "rejection error missing: $ERR"
+if jq -s -e 'any(.[]; .query? // "" | contains("attachmentCreate"))' "$CURL_LOG" >/dev/null; then
+  fail "attachmentCreate was reached after a rejected update"
+fi
+
+echo "=== bulk-update forwards --attach to each issue ==="
+
+run_linear issues bulk-update TEAM-9 --attach "$TMP_ROOT/shot.png"
+[[ "$RC" -eq 0 ]] || fail "bulk-update --attach failed: $ERR"
+jq -s -e 'any(.[]; .query? // "" | contains("fileUpload"))' "$CURL_LOG" >/dev/null ||
+  fail "bulk-update --attach never uploaded: $(cat "$CURL_LOG")"
 
 echo "all pass"

--- a/skills/linear/tests/issues-update-attach.test.sh
+++ b/skills/linear/tests/issues-update-attach.test.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# VST-126: `issues update <ID> --attach <PATH>`. Image embeds append to the
+# description being written — and, when the update carries no
+# --description/--description-file, to the issue's EXISTING description
+# (append, never wipe). Non-image files become Linear attachments via
+# attachmentCreate after the update; `--attach` alone is a valid update that
+# skips the issueUpdate mutation entirely. Partial failures after a
+# successful write name the issue and exit non-zero.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+PROJECT="$TMP_ROOT/project"
+mkdir -p "$PROJECT/.agents/skills" "$PROJECT/bin"
+git -C "$PROJECT" init -q -b main
+cp -R "$SKILL_DIR" "$PROJECT/.agents/skills/linear"
+
+LINEAR="$PROJECT/.agents/skills/linear/scripts/linear.sh"
+CURL_LOG="$TMP_ROOT/curl-payloads.jsonl"
+ERR_FILE="$TMP_ROOT/stderr.txt"
+
+ISSUE_JSON='{"id":"issue-uuid-9","identifier":"TEAM-9","title":"t","description":"Existing text.","state":{"name":"Todo","type":"unstarted"},"assignee":null,"project":null,"projectMilestone":null,"cycle":null,"parent":null,"team":{"name":"Configured"},"labels":{"nodes":[]},"priority":3,"estimate":null,"sortOrder":1.0,"url":"https://linear.app/x/issue/TEAM-9","createdAt":"2026-08-08T00:00:00Z","updatedAt":"2026-08-08T00:00:00Z","archivedAt":null,"trashed":null,"relations":{"nodes":[]},"inverseRelations":{"nodes":[]}}'
+
+cat >"$PROJECT/bin/curl" <<SH
+#!/usr/bin/env bash
+ISSUE_JSON='$ISSUE_JSON'
+SH
+cat >>"$PROJECT/bin/curl" <<'SH'
+has_config=0
+for a in "$@"; do [ "$a" = "-K" ] && has_config=1; done
+if [ "$has_config" = "0" ]; then
+  printf '404'
+  exit 0
+fi
+config="$(cat)"
+
+if grep -q '^upload-file = ' <<<"$config"; then
+  url="$(sed -n 's/^url = //p' <<<"$config" | jq -r)"
+  file="$(sed -n 's/^upload-file = //p' <<<"$config" | jq -r)"
+  headers="$(sed -n 's/^header = //p' <<<"$config" | jq -s .)"
+  jq -cn --arg url "$url" --arg file "$file" --argjson headers "$headers" \
+    '{put: {url: $url, file: $file, headers: $headers}}' >>"${CURL_LOG:?}"
+  printf '200'
+  exit 0
+fi
+
+payload="$(sed -n 's/^data = //p' <<<"$config" | jq -r)"
+printf '%s\n' "$payload" >>"${CURL_LOG:?}"
+query="$(jq -r '.query' <<<"$payload")"
+
+case "$query" in
+*"fileUpload("*)
+  filename="$(jq -r '.variables.filename' <<<"$payload")"
+  printf '%s' "{\"data\":{\"fileUpload\":{\"success\":true,\"uploadFile\":{\"uploadUrl\":\"https://uploads.linear.app/put/$filename\",\"assetUrl\":\"https://uploads.linear.app/asset/$filename\",\"headers\":[{\"key\":\"x-linear-upload\",\"value\":\"signed-$filename\"}]}}}}___HTTP_CODE___200"
+  ;;
+*"attachmentCreate("*)
+  title="$(jq -r '.variables.input.title' <<<"$payload")"
+  if [ "$title" = "boom.pdf" ]; then
+    printf '%s' '{"data":{"attachmentCreate":{"success":false,"attachment":null}}}___HTTP_CODE___200'
+  else
+    printf '%s' '{"data":{"attachmentCreate":{"success":true,"attachment":{"id":"att-uuid","url":"u","title":"t"}}}}___HTTP_CODE___200'
+  fi
+  ;;
+*"issueUpdate("*)
+  printf '%s' "{\"data\":{\"issueUpdate\":{\"success\":true,\"issue\":$ISSUE_JSON}}}___HTTP_CODE___200"
+  ;;
+*"issue(id:"*)
+  printf '%s' "{\"data\":{\"issue\":$ISSUE_JSON}}___HTTP_CODE___200"
+  ;;
+*"teams(filter:"*)
+  printf '%s' '{"data":{"teams":{"nodes":[{"id":"team-uuid"}]}}}___HTTP_CODE___200'
+  ;;
+*)
+  printf '%s' '{"data":{}}___HTTP_CODE___200'
+  ;;
+esac
+SH
+chmod +x "$PROJECT/bin/curl"
+
+printf '[env]\nLINEAR_TEAM = "Configured"\n' >"$PROJECT/vstack.settings.toml"
+
+printf 'PNGDATA' >"$TMP_ROOT/shot.png"
+printf '%%PDF-1.4' >"$TMP_ROOT/notes.pdf"
+printf 'x' >"$TMP_ROOT/boom.pdf"
+
+OUT=""
+ERR=""
+RC=0
+
+fail() {
+  echo "FAIL $*"
+  [[ -s "$CURL_LOG" ]] && echo "--- curl payloads ---" && cat "$CURL_LOG"
+  exit 1
+}
+
+run_linear() {
+  : >"$CURL_LOG"
+  set +e
+  OUT="$(cd "$PROJECT" && env -u LINEAR_TEAM -u LINEAR_AGENT_LABELS \
+    PATH="$PROJECT/bin:$PATH" \
+    LINEAR_API_KEY=test-token \
+    CURL_LOG="$CURL_LOG" \
+    bash "$LINEAR" "$@" </dev/null 2>"$ERR_FILE")"
+  RC=$?
+  set -e
+  ERR="$(cat "$ERR_FILE")"
+}
+
+api_calls() {
+  wc -l <"$CURL_LOG" | tr -d ' '
+}
+
+echo "=== image attach with no --description appends to the EXISTING description ==="
+
+run_linear issues update TEAM-9 --attach "$TMP_ROOT/shot.png"
+[[ "$RC" -eq 0 ]] || fail "image attach update exited $RC: $ERR"
+jq -s -e 'any(.[]; (.query? // "" | contains("issueUpdate"))
+    and .variables.id == "TEAM-9"
+    and .variables.input.description == "Existing text.\n\n![shot.png](https://uploads.linear.app/asset/shot.png)")' \
+  "$CURL_LOG" >/dev/null || fail "embed did not append to the existing description"
+
+echo "=== image attach with --description appends to the NEW description ==="
+
+run_linear issues update TEAM-9 --description "New body" --attach "$TMP_ROOT/shot.png"
+[[ "$RC" -eq 0 ]] || fail "image attach + --description update exited $RC: $ERR"
+jq -s -e 'any(.[]; (.query? // "" | contains("issueUpdate"))
+    and .variables.input.description == "New body\n\n![shot.png](https://uploads.linear.app/asset/shot.png)")' \
+  "$CURL_LOG" >/dev/null || fail "embed did not append to the new description"
+
+echo "=== non-image --attach alone is a valid update: attachmentCreate only ==="
+
+run_linear issues update TEAM-9 --attach "$TMP_ROOT/notes.pdf"
+[[ "$RC" -eq 0 ]] || fail "attach-only update exited $RC: $ERR"
+if jq -s -e 'any(.[]; .query? // "" | contains("issueUpdate"))' "$CURL_LOG" >/dev/null; then
+  fail "attach-only update must not run issueUpdate"
+fi
+jq -s -e 'any(.[]; (.query? // "" | contains("attachmentCreate"))
+    and .variables.input.issueId == "issue-uuid-9"
+    and .variables.input.url == "https://uploads.linear.app/asset/notes.pdf"
+    and .variables.input.title == "notes.pdf")' "$CURL_LOG" >/dev/null ||
+  fail "attachmentCreate not called with the issue uuid and asset url"
+jq -e '.success == true and .identifier == "TEAM-9"' <<<"$OUT" >/dev/null ||
+  fail "attach-only update output lacks success/identifier: $OUT"
+
+echo "=== attachmentCreate failure after a successful update: names issue, non-zero ==="
+
+run_linear issues update TEAM-9 --title "New title" --attach "$TMP_ROOT/boom.pdf"
+[[ "$RC" -ne 0 ]] || fail "failed attachmentCreate exited 0: $OUT"
+jq -s -e 'any(.[]; .query? // "" | contains("issueUpdate"))' "$CURL_LOG" >/dev/null ||
+  fail "issueUpdate did not run before the attachment failure"
+grep -q "TEAM-9" <<<"$ERR" || fail "partial failure does not name the issue: $ERR"
+grep -q '"partial":true' <<<"$ERR" || fail "partial failure lacks partial: true: $ERR"
+grep -q "TEAM-9" <<<"$OUT" || fail "update summary missing from stdout: $OUT"
+
+echo "=== missing file refuses before any API call ==="
+
+run_linear issues update TEAM-9 --attach "$TMP_ROOT/nope.png"
+[[ "$RC" -ne 0 ]] || fail "missing --attach path exited 0: $OUT"
+grep -q "not readable" <<<"$ERR" || fail "missing-path refusal lacks 'not readable': $ERR"
+[[ "$(api_calls)" == "0" ]] || fail "missing --attach path attempted $(api_calls) API call(s)"
+
+echo "all pass"


### PR DESCRIPTION
Fixes VST-126 (Linear): the linear skill's attachment support was download-only — no way to put a screenshot, design reference, or log onto an issue or comment at create time. This adds Linear's first-class upload path as a repeatable `--attach <path>` flag on `issues create`, `issues update`, and `comments create`.

## Mechanism

- `fileUpload(contentType, filename, size)` mutation → PUT the bytes to the returned `uploadUrl` with **exactly** the returned headers plus a computed `Content-Type` (never synthesized), over the same curl-config-on-stdin transport `graphql_query` uses so header values never touch argv → reference `assetUrl`.
- Images (png/jpg/jpeg/gif/webp/svg) embed as `![name](assetUrl)` appended to the description/body being written; `issues update` with no `--description` appends to the *existing* description (append, never wipe). Non-images become Linear attachments via `attachmentCreate` on issues; comments append a `[name](assetUrl)` link (no attachment surface there).
- Composes with `--description-file`/`--body-file`; `--attach` alone is a valid update/comment.
- Fail-loud contract: unreadable paths refuse with zero API calls; a failed PUT refuses before the issue exists; an `attachmentCreate` failure after a successful write reports the created identifier with `partial: true` and exits non-zero (bulk-update's posture). The agent-label routing guard (#1143) still runs before any upload.
- Cache pickup verified by reading the code, not assumed: `attach_extract_urls` matches `uploads.linear.app` URLs in bodies, and the write-through paths call `attach_download_from_text` on the final body — inline embeds download immediately and on sync.

## Verification

- 3 new hermetic test files (fake curl intercepts both GraphQL POSTs and the storage PUT, asserting the PUT carries the returned headers and orders before `issueCreate`): create/update/comments × image, non-image, composition, missing-file (0 API calls), PUT-500, post-write partial failure, guard-still-first. Suite: 38/38 green. Proven falsifiable (dropping the returned headers in the upload helper fails the suite).
- shellcheck: zero delta vs main on all three modified scripts; new tests clean.

https://claude.ai/code/session_015yN1mXbYpuKF4jTT5qY2Ck