### PR TITLE
feat(pi-task-panel): restore last panel mode on toggle, add cycle option

### DIFF
--- a/pi-extensions/pi-task-panel/CHANGELOG.md
+++ b/pi-extensions/pi-task-panel/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## Consumer-impacting changes
 
-### 1.4.0
+### 2.0.0
 
 - The panel toggle (`alternateShortcut`, `takeoverCtrlT`, `/tasks toggle`) now hides the panel and restores the last visible mode when toggling back in: a compact panel reopens compact instead of expanded. Previously the toggle stepped compact → expanded → hidden, so a hidden compact panel always reopened expanded. (#1152)
 - New `toggleBehavior` setting (enum `toggle`/`cycle`, default `toggle`): `cycle` steps hidden → compact → expanded → hidden for users who want the shortcut to reach every state.
-- Renamed export in `extensions/visibility.ts`: `cycleTaskPanelVisibility(state)` → `toggleTaskPanelVisibility(state, behavior)`; added `PanelToggleBehavior` and `normalizePanelToggleBehavior`.
+- **Breaking** (hence the major bump): the `extensions/visibility.ts` export `cycleTaskPanelVisibility(state)` is renamed to `toggleTaskPanelVisibility(state, behavior)` with no compatibility alias — this repo ships clean breaks with changelog notes, never shims. Also added: `PanelToggleBehavior`, `normalizePanelToggleBehavior`.
 
 ### 1.3.1
 

--- a/pi-extensions/pi-task-panel/CHANGELOG.md
+++ b/pi-extensions/pi-task-panel/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Consumer-impacting changes
 
+### 1.4.0
+
+- The panel toggle (`alternateShortcut`, `takeoverCtrlT`, `/tasks toggle`) now hides the panel and restores the last visible mode when toggling back in: a compact panel reopens compact instead of expanded. Previously the toggle stepped compact → expanded → hidden, so a hidden compact panel always reopened expanded. (#1152)
+- New `toggleBehavior` setting (enum `toggle`/`cycle`, default `toggle`): `cycle` steps hidden → compact → expanded → hidden for users who want the shortcut to reach every state.
+- Renamed export in `extensions/visibility.ts`: `cycleTaskPanelVisibility(state)` → `toggleTaskPanelVisibility(state, behavior)`; added `PanelToggleBehavior` and `normalizePanelToggleBehavior`.
+
 ### 1.3.1
 
 - Baseline: changelog introduced at this version. Consumer-impacting changes — behavior deltas, new/renamed/removed exports, settings and config changes, protocol/audit-shape changes — are recorded here from this version forward.

--- a/pi-extensions/pi-task-panel/README.md
+++ b/pi-extensions/pi-task-panel/README.md
@@ -48,6 +48,7 @@ Restart Pi after installation.
 | `/tasks hide` | Hide the panel. |
 | `/tasks show` | Show the compact panel. |
 | `/tasks show-all` | Show the expanded panel. |
+| `/tasks:toggle` | Hide/restore the panel, or cycle all states with `toggleBehavior=cycle`. |
 | `/tasks:clear-completed` | Remove completed tasks. |
 | `/tasks:export <path>` | Write tasks to a markdown file. |
 | `/tasks:import <path>` | Load tasks from a markdown file. |
@@ -68,9 +69,9 @@ Bulk edit format:
 
 Status suffixes: `(active)`, `(done)`, `(dropped)`.
 
-## Visibility cycle
+## Visibility toggle
 
-The panel toggle cycles visible modes and hides the panel; toggling back in restores the last visible mode. After `/tasks hide` or a hide shortcut, task mutations stay hidden until `/tasks show`, `/tasks show-all`, or an explicit toggle-in. The manager popup opens with its own shortcut and documents its keys in the footer. All bindings are configurable via `/extensions:settings`; Pi's thinking-visibility binding is preserved unless you opt in to taking it over.
+The panel toggle (`alt+t` by default, `/tasks:toggle`) hides the panel and restores the last visible mode when toggling back in — a compact panel reopens compact, an expanded panel reopens expanded. Set `toggleBehavior` to `cycle` to step through hidden → compact → expanded → hidden instead. After `/tasks hide` or a hide shortcut, task mutations stay hidden until `/tasks show`, `/tasks show-all`, or an explicit toggle-in. The manager popup opens with its own shortcut and documents its keys in the footer. All bindings are configurable via `/extensions:settings`; Pi's thinking-visibility binding is preserved unless you opt in to taking it over.
 
 ## Settings
 
@@ -96,6 +97,7 @@ Glyph style: each package exposes `glyphStyle` (`unicode` default, `ascii` for t
 | --- | --- |
 | Take over thinking-visibility binding | Repurpose Pi's thinking-visibility binding for the task-panel toggle. |
 | Alternate shortcut | Always-available toggle. Configurable. |
+| Toggle behavior | `toggle` (default) hides/restores the last visible mode; `cycle` steps hidden → compact → expanded → hidden. |
 | Manager popup shortcut | Configurable. |
 
 ### Tool output

--- a/pi-extensions/pi-task-panel/README.md
+++ b/pi-extensions/pi-task-panel/README.md
@@ -48,7 +48,7 @@ Restart Pi after installation.
 | `/tasks hide` | Hide the panel. |
 | `/tasks show` | Show the compact panel. |
 | `/tasks show-all` | Show the expanded panel. |
-| `/tasks:toggle` | Hide/restore the panel, or cycle all states with `toggleBehavior=cycle`. |
+| `/tasks toggle` | Hide/restore the panel, or cycle all states with `toggleBehavior=cycle`. |
 | `/tasks:clear-completed` | Remove completed tasks. |
 | `/tasks:export <path>` | Write tasks to a markdown file. |
 | `/tasks:import <path>` | Load tasks from a markdown file. |
@@ -71,7 +71,7 @@ Status suffixes: `(active)`, `(done)`, `(dropped)`.
 
 ## Visibility toggle
 
-The panel toggle (`alt+t` by default, `/tasks:toggle`) hides the panel and restores the last visible mode when toggling back in — a compact panel reopens compact, an expanded panel reopens expanded. Set `toggleBehavior` to `cycle` to step through hidden → compact → expanded → hidden instead. After `/tasks hide` or a hide shortcut, task mutations stay hidden until `/tasks show`, `/tasks show-all`, or an explicit toggle-in. The manager popup opens with its own shortcut and documents its keys in the footer. All bindings are configurable via `/extensions:settings`; Pi's thinking-visibility binding is preserved unless you opt in to taking it over.
+The panel toggle (`alt+t` by default, `/tasks toggle`) hides the panel and restores the last visible mode when toggling back in — a compact panel reopens compact, an expanded panel reopens expanded. Set `toggleBehavior` to `cycle` to step through hidden → compact → expanded → hidden instead. After `/tasks hide` or a hide shortcut, task mutations stay hidden until `/tasks show`, `/tasks show-all`, or an explicit toggle-in. The manager popup opens with its own shortcut and documents its keys in the footer. All bindings are configurable via `/extensions:settings`; Pi's thinking-visibility binding is preserved unless you opt in to taking it over.
 
 ## Settings
 

--- a/pi-extensions/pi-task-panel/extensions/task-panel.ts
+++ b/pi-extensions/pi-task-panel/extensions/task-panel.ts
@@ -11,15 +11,17 @@ import { MINI_DASHBOARD_RANK, setMiniDashboardWidget } from "./stacked-widget.js
 import {
 	applyTaskPanelContentVisibility,
 	createTaskPanelVisibility,
-	cycleTaskPanelVisibility,
 	ensureTaskPanelVisibility,
 	normalizePanelState,
+	normalizePanelToggleBehavior,
 	rememberTaskPanelVisibility,
 	restoreTaskPanelVisibility,
+	toggleTaskPanelVisibility,
 	userHideTaskPanel,
 	userShowTaskPanel,
 	visiblePanelFor,
 	type PanelState,
+	type PanelToggleBehavior,
 	type VisiblePanelState,
 } from "./visibility.js";
 import { reportTaskPanelPersistenceFailure } from "./diagnostics.js";
@@ -316,6 +318,10 @@ function defaultPanelState(cwd?: string): PanelState {
 	return normalizePanelState(settingString("panelDefaultState", "compact", cwd), "compact");
 }
 
+function panelToggleBehavior(cwd?: string): PanelToggleBehavior {
+	return normalizePanelToggleBehavior(settingString("toggleBehavior", "toggle", cwd));
+}
+
 function emptyState(cwd?: string): TaskPanelState {
 	const visibility = createTaskPanelVisibility(defaultPanelState(cwd));
 	return { ...visibility, phases: [], tasks: [], updatedAt: new Date().toISOString(), version: 1 };
@@ -424,7 +430,7 @@ function panelToggleHint(cwd: string): string {
 	const toggle = settingString("alternateShortcut", "alt+t", cwd);
 	const manager = settingString("managerShortcut", "alt+shift+t", cwd);
 	const parts: string[] = [];
-	if (toggle !== "none") parts.push(`${formatShortcutHint(toggle)} toggle`);
+	if (toggle !== "none") parts.push(`${formatShortcutHint(toggle)} ${panelToggleBehavior(cwd)}`);
 	if (manager !== "none") parts.push(`${formatShortcutHint(manager)} manage`);
 	return parts.join(glyphs(cwd).dot);
 }
@@ -1120,7 +1126,7 @@ export default function taskPanel(pi: ExtensionAPI): void {
 			case "show": message = mutate(ctx, () => { userShowTaskPanel(state, "compact"); return `Task panel showing ${Math.max(1, Math.floor(settingNumber("maxCompactTasks", 4, ctx.cwd)))} task(s)`; }); break;
 			case "show-all": message = mutate(ctx, () => { userShowTaskPanel(state, "expanded"); return "Task panel showing all tasks"; }); break;
 			case "toggle": message = mutate(ctx, () => {
-				cycleTaskPanelVisibility(state);
+				toggleTaskPanelVisibility(state, panelToggleBehavior(ctx.cwd));
 				if (state.panel === "hidden") return "Task panel hidden";
 				return state.panel === "expanded" ? "Task panel showing all tasks" : `Task panel showing ${Math.max(1, Math.floor(settingNumber("maxCompactTasks", 4, ctx.cwd)))} task(s)`;
 			}); break;
@@ -1151,7 +1157,7 @@ export default function taskPanel(pi: ExtensionAPI): void {
 		{ sub: "edit", description: "Bulk edit tasks as plain text" },
 		{ sub: "manage", description: "Open the interactive task manager" },
 		{ sub: "clear-completed", description: "Remove completed tasks" },
-		{ sub: "toggle", description: "Show or hide the mini task panel" },
+		{ sub: "toggle", description: "Show or hide the mini task panel (cycles all states with toggleBehavior=cycle)" },
 	] as const;
 	for (const { sub, description } of noArgSubs) {
 		pi.registerCommand(`tasks:${sub}`, {
@@ -1288,7 +1294,7 @@ export default function taskPanel(pi: ExtensionAPI): void {
 	pi.on("session_shutdown", (_event, ctx) => setMiniDashboardWidget(ctx, WIDGET_KEY, MINI_DASHBOARD_RANK.TASKS, undefined));
 
 	const toggle = async (ctx: ExtensionContext) => {
-		cycleTaskPanelVisibility(state);
+		toggleTaskPanelVisibility(state, panelToggleBehavior(ctx.cwd));
 		persist();
 		syncWidget(ctx);
 	};

--- a/pi-extensions/pi-task-panel/extensions/visibility.ts
+++ b/pi-extensions/pi-task-panel/extensions/visibility.ts
@@ -1,5 +1,6 @@
 export type PanelState = "hidden" | "compact" | "expanded";
 export type VisiblePanelState = Exclude<PanelState, "hidden">;
+export type PanelToggleBehavior = "toggle" | "cycle";
 
 export interface TaskPanelVisibilityState {
 	panel: PanelState;
@@ -96,9 +97,18 @@ export function applyTaskPanelContentVisibility(
 	if (options.remainingTasks > 0) autoShowTaskPanelOnce(state, options);
 }
 
-export function cycleTaskPanelVisibility(state: TaskPanelVisibilityState): void {
+export function normalizePanelToggleBehavior(value: unknown, fallback: PanelToggleBehavior = "toggle"): PanelToggleBehavior {
+	return value === "toggle" || value === "cycle" ? value : fallback;
+}
+
+export function toggleTaskPanelVisibility(state: TaskPanelVisibilityState, behavior: PanelToggleBehavior = "toggle"): void {
 	ensureTaskPanelVisibility(state);
+	if (behavior === "cycle") {
+		if (state.panel === "hidden") userShowTaskPanel(state, "compact");
+		else if (state.panel === "compact") userShowTaskPanel(state, "expanded");
+		else userHideTaskPanel(state);
+		return;
+	}
 	if (state.panel === "hidden") userShowTaskPanel(state);
-	else if (state.panel === "compact") userShowTaskPanel(state, "expanded");
 	else userHideTaskPanel(state);
 }

--- a/pi-extensions/pi-task-panel/package.json
+++ b/pi-extensions/pi-task-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vanillagreen/pi-task-panel",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Persistent Claude-style tasks panel for Pi with slash commands and a structured tasks_write tool.",
   "license": "MIT",
   "keywords": [
@@ -80,6 +80,19 @@
           "category": "Keyboard",
           "apply": "reload",
           "requiresReload": true
+        },
+        {
+          "key": "toggleBehavior",
+          "label": "Toggle behavior",
+          "description": "What the panel shortcut and /tasks toggle do. toggle hides the panel and restores the last visible mode when toggling back in; cycle steps hidden → compact → expanded → hidden.",
+          "type": "enum",
+          "enumValues": [
+            "toggle",
+            "cycle"
+          ],
+          "default": "toggle",
+          "category": "Keyboard",
+          "apply": "live"
         },
         {
           "key": "managerShortcut",

--- a/pi-extensions/pi-task-panel/package.json
+++ b/pi-extensions/pi-task-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vanillagreen/pi-task-panel",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "description": "Persistent Claude-style tasks panel for Pi with slash commands and a structured tasks_write tool.",
   "license": "MIT",
   "keywords": [

--- a/pi-extensions/pi-task-panel/tests/visibility.test.ts
+++ b/pi-extensions/pi-task-panel/tests/visibility.test.ts
@@ -3,9 +3,10 @@ import test from "node:test";
 import {
 	applyTaskPanelContentVisibility,
 	createTaskPanelVisibility,
-	cycleTaskPanelVisibility,
+	normalizePanelToggleBehavior,
 	rememberTaskPanelVisibility,
 	restoreTaskPanelVisibility,
+	toggleTaskPanelVisibility,
 	userHideTaskPanel,
 	userShowTaskPanel,
 	type TaskPanelVisibilityState,
@@ -66,7 +67,52 @@ test("task panel all-done auto-hide is distinct from user hide", () => {
 test("task panel explicit toggle-in restores last visible mode", () => {
 	const panel = createTaskPanelVisibility("expanded");
 	userHideTaskPanel(panel);
-	cycleTaskPanelVisibility(panel);
+	toggleTaskPanelVisibility(panel);
 	assert.equal(panel.panel, "expanded");
 	assert.equal(panel.hiddenByUser, false);
+});
+
+test("toggle from compact hides, then reopens compact", () => {
+	const panel = createTaskPanelVisibility("compact");
+	toggleTaskPanelVisibility(panel);
+	assert.equal(panel.panel, "hidden");
+	assert.equal(panel.hiddenByUser, true);
+	toggleTaskPanelVisibility(panel);
+	assert.equal(panel.panel, "compact");
+	assert.equal(panel.hiddenByUser, false);
+});
+
+test("toggle from expanded hides, then reopens expanded", () => {
+	const panel = createTaskPanelVisibility("expanded");
+	toggleTaskPanelVisibility(panel);
+	assert.equal(panel.panel, "hidden");
+	toggleTaskPanelVisibility(panel);
+	assert.equal(panel.panel, "expanded");
+});
+
+test("toggle on a fresh hidden panel opens compact", () => {
+	const panel = createTaskPanelVisibility("hidden");
+	toggleTaskPanelVisibility(panel);
+	assert.equal(panel.panel, "compact");
+});
+
+test("cycle behavior walks hidden, compact, expanded, hidden regardless of last visible mode", () => {
+	const panel = createTaskPanelVisibility("expanded");
+	userHideTaskPanel(panel);
+	toggleTaskPanelVisibility(panel, "cycle");
+	assert.equal(panel.panel, "compact");
+	toggleTaskPanelVisibility(panel, "cycle");
+	assert.equal(panel.panel, "expanded");
+	toggleTaskPanelVisibility(panel, "cycle");
+	assert.equal(panel.panel, "hidden");
+	assert.equal(panel.hiddenByUser, true);
+	toggleTaskPanelVisibility(panel, "cycle");
+	assert.equal(panel.panel, "compact");
+});
+
+test("toggle behavior setting values normalize with a toggle default", () => {
+	assert.equal(normalizePanelToggleBehavior("cycle"), "cycle");
+	assert.equal(normalizePanelToggleBehavior("toggle"), "toggle");
+	assert.equal(normalizePanelToggleBehavior("bogus"), "toggle");
+	assert.equal(normalizePanelToggleBehavior(undefined), "toggle");
 });


### PR DESCRIPTION
Closes #1152.

Root cause of the report: the shortcut's old step order (`compact → expanded → hidden`) routed every hide THROUGH expanded, and `userShowTaskPanel(state, "expanded")` overwrote `lastVisiblePanel` — so the existing restore machinery could never restore compact. The cycle order destroyed it, not a missing feature.

- **Default (`toggle`)**: hidden → restore the last visible mode; visible → hide. A compact panel now survives hide/reopen as compact (the reported pain). Fresh installs still open compact.
- **New `toggleBehavior` setting** (`toggle` | `cycle`, live-apply): `cycle` walks `hidden → compact → expanded → hidden`, the user's requested three-state cycle. Applies to `alt+t`/`ctrl+t` and `/tasks toggle`; the panel hint shows "cycle" when active.
- Deliberate behavior delta, recorded in the CHANGELOG: pressing the shortcut while compact now hides (previously expanded) — inherent to restoring rather than escalating; cycle mode covers reach-every-state.
- Version 1.4.0, CHANGELOG entry, README settings/commands docs; `cycleTaskPanelVisibility` renamed to `toggleTaskPanelVisibility(state, behavior)`.

Verification: 5 new visibility tests (restore-compact, restore-expanded, fresh-install default, full cycle order, setting normalization) — `bun test`: 16 pass / 0 fail. Typecheck delta vs main: zero introduced errors (12 pre-existing peer-typing mismatches identical on both).

https://claude.ai/code/session_015yN1mXbYpuKF4jTT5qY2Ck