### PR TITLE
fix(cli): keep worktree-run refresh from anchoring main-checkout skill links in the worktree

### DIFF
--- a/cli/src/commands/add.rs
+++ b/cli/src/commands/add.rs
@@ -909,7 +909,8 @@ role: engineer
 
         assert!(
             err.to_string()
-                .contains("refusing")
+                .contains("refusing .agents path outside project root"),
+            "expected linked-.agents containment refusal, got: {err:#}"
         );
         assert!(
             !outside_agents.join("skills/demo/SKILL.md").exists(),
@@ -1013,7 +1014,8 @@ role: engineer
 
         assert!(
             err.to_string()
-                .contains("refusing")
+                .contains("refusing .agents path outside project root"),
+            "expected linked-.agents containment refusal, got: {err:#}"
         );
         assert!(!outside_agents.join("skills/demo/SKILL.md").exists());
         assert!(!project.join(".claude/skills/demo/SKILL.md").exists());
@@ -1065,7 +1067,8 @@ role: engineer
 
         assert!(
             err.to_string()
-                .contains("refusing")
+                .contains("refusing .agents path outside project root"),
+            "expected linked-.agents containment refusal, got: {err:#}"
         );
         assert!(!project.join(".vstack-lock.json").exists());
         assert!(!project.join("vstack.toml").exists());

--- a/cli/src/commands/add.rs
+++ b/cli/src/commands/add.rs
@@ -909,7 +909,7 @@ role: engineer
 
         assert!(
             err.to_string()
-                .contains("refusing project-owned skills path outside project root")
+                .contains("refusing")
         );
         assert!(
             !outside_agents.join("skills/demo/SKILL.md").exists(),
@@ -1013,7 +1013,7 @@ role: engineer
 
         assert!(
             err.to_string()
-                .contains("refusing project-owned skills path outside project root")
+                .contains("refusing")
         );
         assert!(!outside_agents.join("skills/demo/SKILL.md").exists());
         assert!(!project.join(".claude/skills/demo/SKILL.md").exists());
@@ -1065,7 +1065,7 @@ role: engineer
 
         assert!(
             err.to_string()
-                .contains("refusing project-owned skills path outside project root")
+                .contains("refusing")
         );
         assert!(!project.join(".vstack-lock.json").exists());
         assert!(!project.join("vstack.toml").exists());

--- a/cli/src/commands/refresh.rs
+++ b/cli/src/commands/refresh.rs
@@ -721,6 +721,11 @@ fn link_relocated_project_skills(
 /// refresh that is not applying local `[skill-instructions]` must reject an
 /// existing `.agents` ancestor that resolves outside the selected project.
 pub fn preflight_project_refresh(project_root: &Path) -> Result<()> {
+    // The strict canonical-root identity check runs HERE, before any
+    // reconciliation writes: an aliased in-repo `.agents` must refuse the
+    // whole refresh, not slip past the broad containment check only to be
+    // caught (after lock mutation) at an individual install.
+    crate::path_safety::ensure_agents_dir_within_project(project_root)?;
     resolve_project_owned_skills_root(project_root).map(|_| ())
 }
 

--- a/cli/src/commands/remove.rs
+++ b/cli/src/commands/remove.rs
@@ -72,8 +72,15 @@ pub fn run(names: &[String], scope: ScopeFilter) -> Result<()> {
             let remove_result = if remove_as_pi_extension {
                 crate::pi_extension::remove_pi_extension(name, global)
             } else {
-                installer::remove_item(name, kind, &harnesses, global)
-                    .map(|outcome| outcome.removed)
+                installer::remove_item(name, kind, &harnesses, global).map(|outcome| {
+                    for anchored in &outcome.anchored_left {
+                        println!(
+                            "  Anchored canonical left in place (another checkout's): {}",
+                            anchored.display()
+                        );
+                    }
+                    outcome.removed
+                })
             };
             match remove_result {
                 Ok(paths) => removed.extend(paths),

--- a/cli/src/commands/remove.rs
+++ b/cli/src/commands/remove.rs
@@ -74,7 +74,7 @@ pub fn run(names: &[String], scope: ScopeFilter) -> Result<()> {
             } else {
                 installer::remove_item(name, kind, &harnesses, global).map(|outcome| {
                     for anchored in &outcome.anchored_left {
-                        println!(
+                        eprintln!(
                             "  Anchored canonical left in place (another checkout's): {}",
                             anchored.display()
                         );

--- a/cli/src/commands/remove.rs
+++ b/cli/src/commands/remove.rs
@@ -73,6 +73,7 @@ pub fn run(names: &[String], scope: ScopeFilter) -> Result<()> {
                 crate::pi_extension::remove_pi_extension(name, global)
             } else {
                 installer::remove_item(name, kind, &harnesses, global)
+                    .map(|outcome| outcome.removed)
             };
             match remove_result {
                 Ok(paths) => removed.extend(paths),

--- a/cli/src/commands/remove.rs
+++ b/cli/src/commands/remove.rs
@@ -64,6 +64,7 @@ pub fn run(names: &[String], scope: ScopeFilter) -> Result<()> {
             // Pi packages live in a separate location; route to the dedicated
             // helper. Also catches stale/manual installs missing from the lock.
             let mut removed = Vec::new();
+            let mut anchored_left_notices: Vec<std::path::PathBuf> = Vec::new();
             let remove_as_pi_extension = matches!(
                 lock_entry.as_ref().map(|e| e.kind),
                 Some(crate::config::ItemKind::PiExtension)
@@ -73,12 +74,9 @@ pub fn run(names: &[String], scope: ScopeFilter) -> Result<()> {
                 crate::pi_extension::remove_pi_extension(name, global)
             } else {
                 installer::remove_item(name, kind, &harnesses, global).map(|outcome| {
-                    for anchored in &outcome.anchored_left {
-                        eprintln!(
-                            "  Anchored canonical left in place (another checkout's): {}",
-                            anchored.display()
-                        );
-                    }
+                    // Deferred below the scope header — printing here would
+                    // land indented notices before any scope context.
+                    anchored_left_notices.extend(outcome.anchored_left);
                     outcome.removed
                 })
             };
@@ -100,6 +98,12 @@ pub fn run(names: &[String], scope: ScopeFilter) -> Result<()> {
                     if !printed_scope_header {
                         eprintln!("\n{scope_label}:");
                         printed_scope_header = true;
+                    }
+                    for anchored in anchored_left_notices.drain(..) {
+                        eprintln!(
+                            "  Anchored canonical left in place (another checkout's): {}",
+                            anchored.display()
+                        );
                     }
                     eprintln!("  removed stale lock entry for {name}");
                     lock.remove(name);
@@ -123,6 +127,12 @@ pub fn run(names: &[String], scope: ScopeFilter) -> Result<()> {
                 if !printed_scope_header {
                     eprintln!("\n{scope_label}:");
                     printed_scope_header = true;
+                }
+                for anchored in anchored_left_notices.drain(..) {
+                    eprintln!(
+                        "  Anchored canonical left in place (another checkout's): {}",
+                        anchored.display()
+                    );
                 }
                 let pi_settings_path = config::pi_settings_path(global);
                 for path in &removed {

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1127,9 +1127,20 @@ pub fn scan_installed_skills_on_disk(global: bool) -> Vec<DiskItem> {
                 continue;
             };
             if let Some(sharing) = &gate {
-                let referenced = sharing.iter().any(|harness| {
-                    let link = harness.skills_dir(false).join(name);
-                    link.exists() || link.is_symlink()
+                // A reference must RESOLVE to this canonical dir. A
+                // same-named copy-mode dir in a harness dir is that
+                // harness's own install, not a reference — recovering
+                // through it would re-type the skill as symlink-mode and
+                // let the next refresh replace the copy.
+                let canonical = path.canonicalize().ok();
+                let referenced = canonical.is_some_and(|canonical| {
+                    sharing.iter().any(|harness| {
+                        harness
+                            .skills_dir(false)
+                            .join(name)
+                            .canonicalize()
+                            .is_ok_and(|resolved| resolved == canonical)
+                    })
                 });
                 if !referenced {
                     continue;

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1134,6 +1134,16 @@ pub fn scan_installed_skills_on_disk(global: bool) -> Vec<DiskItem> {
             if gate.is_none() && !path.join(".vstack-refreshed").exists() {
                 continue;
             }
+            // An UNMARKED anchored canonical is admitted only when it also
+            // LOOKS like a skill: reference evidence alone would let a
+            // manually maintained same-named directory (no SKILL.md) be
+            // recovered into the lock as a vstack install.
+            if gate.is_some()
+                && !path.join(".vstack-refreshed").exists()
+                && !path.join("SKILL.md").exists()
+            {
+                continue;
+            }
             let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
                 continue;
             };
@@ -1198,7 +1208,34 @@ pub fn scan_installed_skills_on_disk(global: bool) -> Vec<DiskItem> {
                             Err(_) => continue,
                         }
                     } else {
-                        None
+                        // Plain LOCAL canonical: when a same-named harness
+                        // artifact resolves somewhere ELSE (an independent
+                        // install in another checkout), an unscoped entry
+                        // would let recovery claim it. Scope to the
+                        // harnesses actually resolving here in that case;
+                        // otherwise keep the legacy full detection.
+                        let local_canonical = path.canonicalize().ok();
+                        let mut resolving: Vec<String> = Vec::new();
+                        let mut foreign_resolving = false;
+                        for harness in crate::harness::Harness::ALL.iter() {
+                            let artifact = harness.skills_dir(false).join(name);
+                            if std::fs::symlink_metadata(&artifact)
+                                .is_ok_and(|meta| meta.file_type().is_symlink())
+                            {
+                                match (artifact.canonicalize().ok(), &local_canonical) {
+                                    (Some(resolved), Some(local)) if resolved == *local => {
+                                        resolving.push(harness.id().to_string());
+                                    }
+                                    (Some(_), _) => foreign_resolving = true,
+                                    _ => {}
+                                }
+                            }
+                        }
+                        if foreign_resolving {
+                            Some(resolving)
+                        } else {
+                            None
+                        }
                     }
                 }
             };

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1896,7 +1896,18 @@ pub fn reconcile_lock_with_disk(lock: &mut LockFile, global: bool, source: &str)
                 .iter()
                 .filter_map(|id| crate::harness::Harness::from_id(id))
                 .collect();
-            let exists = own_root.join(&name).exists()
+            // A fully shared `.agents` makes own_root resolve into the
+            // OTHER checkout — its contents are anchored evidence (gated
+            // per-harness/per-name below), not unconditional local proof:
+            // counting them here would keep any stale entry alive merely
+            // because the main checkout has a same-named canonical.
+            let own_root_is_local = global
+                || own_root
+                    .canonicalize()
+                    .ok()
+                    .zip(std::fs::canonicalize(project_root()).ok())
+                    .is_none_or(|(root, project)| root.starts_with(&project));
+            let exists = (own_root_is_local && own_root.join(&name).exists())
                 || anchored.iter().any(|(root, sharing)| {
                     // Child-link evidence is per-skill: an anchored root
                     // keeps an entry alive only when it is evidenced for

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1085,14 +1085,16 @@ struct DiskHookItem {
 pub fn scan_installed_skills_on_disk(global: bool) -> Vec<DiskItem> {
     let mut items = Vec::new();
 
-    // Canonical skill location: .agents/skills/<name>/
+    // Canonical skill location: .agents/skills/<name>/. Project scope also
+    // consults checkout-anchored roots so a copy anchored in the main
+    // checkout by a worktree-run install (VST-195) is still discovered.
     let canonical_skills = if global {
         vec![
             global_state_dir().join("skills"),
             codex_home_dir().join("skills"),
         ]
     } else {
-        vec![project_root().join(".agents").join("skills")]
+        crate::installer::project_canonical_skill_roots()
     };
 
     let mut seen = std::collections::HashSet::new();
@@ -1649,17 +1651,20 @@ pub fn reconcile_lock_with_disk(lock: &mut LockFile, global: bool, source: &str)
         .filter(|(_, e)| e.kind == ItemKind::Skill && !disk_names.contains(e.name.as_str()))
         .map(|(name, _)| name.clone())
         .collect();
-    for name in stale_skills {
-        // Verify the canonical dir is actually gone (not just missing the marker)
-        let canonical = if global {
-            global_state_dir().join("skills").join(&name)
+    if !stale_skills.is_empty() {
+        // Verify the canonical dir is actually gone (not just missing the
+        // marker) in every root a copy may live in.
+        let canonical_roots = if global {
+            vec![global_state_dir().join("skills")]
         } else {
-            project_root().join(".agents").join("skills").join(&name)
+            crate::installer::project_canonical_skill_roots()
         };
-        if !canonical.exists() {
-            eprintln!("  Removed stale lock entry (files missing): {name}");
-            lock.remove(&name);
-            modified = true;
+        for name in stale_skills {
+            if !canonical_roots.iter().any(|root| root.join(&name).exists()) {
+                eprintln!("  Removed stale lock entry (files missing): {name}");
+                lock.remove(&name);
+                modified = true;
+            }
         }
     }
 

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1889,6 +1889,13 @@ pub fn reconcile_lock_with_disk(lock: &mut LockFile, global: bool, source: &str)
         } else {
             project_root().join(".agents").join("skills")
         };
+        // Invariant across the loop — resolve once, not per stale entry.
+        let own_root_is_local = global
+            || own_root
+                .canonicalize()
+                .ok()
+                .zip(std::fs::canonicalize(project_root()).ok())
+                .is_none_or(|(root, project)| root.starts_with(&project));
         for (name, entry_harnesses) in stale_skills {
             // Entry ids may use supported aliases ("claude" for claude-code);
             // normalize through the same resolution the rest of the CLI uses.
@@ -1901,12 +1908,6 @@ pub fn reconcile_lock_with_disk(lock: &mut LockFile, global: bool, source: &str)
             // per-harness/per-name below), not unconditional local proof:
             // counting them here would keep any stale entry alive merely
             // because the main checkout has a same-named canonical.
-            let own_root_is_local = global
-                || own_root
-                    .canonicalize()
-                    .ok()
-                    .zip(std::fs::canonicalize(project_root()).ok())
-                    .is_none_or(|(root, project)| root.starts_with(&project));
             let exists = (own_root_is_local && own_root.join(&name).exists())
                 || anchored.iter().any(|(root, sharing)| {
                     // Child-link evidence is per-skill: an anchored root

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1231,7 +1231,15 @@ pub fn scan_installed_skills_on_disk(global: bool) -> Vec<DiskItem> {
                                 (Some(resolved), Some(local)) if resolved == *local => {
                                     resolving.push(harness.id().to_string());
                                 }
-                                (Some(_), _) if meta.file_type().is_symlink() => {
+                                // A symlink resolving elsewhere OR a real
+                                // copy-mode directory at a different
+                                // physical place — both are independent
+                                // installs the recovered entry must not
+                                // claim.
+                                (Some(_), _)
+                                    if meta.file_type().is_symlink()
+                                        || meta.file_type().is_dir() =>
+                                {
                                     foreign_resolving = true;
                                 }
                                 _ => {}

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1103,7 +1103,27 @@ pub fn scan_installed_skills_on_disk(global: bool) -> Vec<DiskItem> {
             (codex_home_dir().join("skills"), None),
         ]
     } else {
-        let mut roots = vec![(project_root().join(".agents").join("skills"), None)];
+        // The project-spelled canonical root can PHYSICALLY live in another
+        // checkout (fully shared .agents): scanning it ungated would treat
+        // the owner's canonicals as local. Gate it by reference like any
+        // anchored root in that case.
+        let own_skills = project_root().join(".agents").join("skills");
+        let own_skills_shared = own_skills
+            .canonicalize()
+            .ok()
+            .zip(project_root().canonicalize().ok())
+            .is_some_and(|(skills, root)| !skills.starts_with(&root));
+        let local_gate: Option<crate::installer::AnchorSharing> = if own_skills_shared {
+            Some(
+                crate::harness::Harness::ALL
+                    .iter()
+                    .map(|harness| (*harness, crate::installer::AnchorEvidence::SharedDir))
+                    .collect(),
+            )
+        } else {
+            None
+        };
+        let mut roots = vec![(own_skills, local_gate)];
         for (root, sharing) in
             crate::installer::anchored_canonical_skill_roots(crate::harness::Harness::ALL)
         {
@@ -1134,14 +1154,17 @@ pub fn scan_installed_skills_on_disk(global: bool) -> Vec<DiskItem> {
                 continue;
             }
             // An UNMARKED anchored canonical is admitted only when it also
-            // LOOKS like a skill: reference evidence alone would let a
-            // manually maintained same-named directory (no SKILL.md) be
-            // recovered into the lock as a vstack install.
-            if gate.is_some()
-                && !path.join(".vstack-refreshed").exists()
-                && !path.join("SKILL.md").exists()
-            {
-                continue;
+            // LOOKS like a vstack-managed install: a REAL directory with
+            // SKILL.md. Reference evidence alone would adopt a manually
+            // maintained same-named directory, and a SYMLINK canonical is
+            // the owner's project-skills-dir wiring (every project-owned
+            // skill has SKILL.md too) — neither is vstack's to claim.
+            if gate.is_some() && !path.join(".vstack-refreshed").exists() {
+                let is_symlink = std::fs::symlink_metadata(&path)
+                    .is_ok_and(|meta| meta.file_type().is_symlink());
+                if is_symlink || !path.join("SKILL.md").exists() {
+                    continue;
+                }
             }
             let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
                 continue;

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1160,7 +1160,42 @@ pub fn scan_installed_skills_on_disk(global: bool) -> Vec<DiskItem> {
                     }
                     Some(referencing)
                 }
-                None => None,
+                None => {
+                    // Child-level anchor in the ungated local root: a real
+                    // `.agents/skills` whose `<name>` entry is a symlink into
+                    // another checkout (partial sharing). This root scans
+                    // FIRST, so an unscoped entry here would win `seen` and
+                    // recovery would claim every same-named harness artifact
+                    // — retyping an independent copy-mode install as
+                    // Symlink. Scope it to the resolving harnesses, exactly
+                    // like root-level anchors.
+                    let is_link = std::fs::symlink_metadata(&path)
+                        .is_ok_and(|meta| meta.file_type().is_symlink());
+                    if is_link {
+                        match path.canonicalize() {
+                            Ok(canonical) => {
+                                let referencing: Vec<String> = crate::harness::Harness::ALL
+                                    .iter()
+                                    .filter(|harness| {
+                                        harness
+                                            .skills_dir(false)
+                                            .join(name)
+                                            .canonicalize()
+                                            .is_ok_and(|resolved| resolved == canonical)
+                                    })
+                                    .map(|harness| harness.id().to_string())
+                                    .collect();
+                                if referencing.is_empty() {
+                                    continue;
+                                }
+                                Some(referencing)
+                            }
+                            Err(_) => continue,
+                        }
+                    } else {
+                        None
+                    }
+                }
             };
             if seen.insert(name.to_string()) {
                 items.push(DiskItem {

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1112,7 +1112,6 @@ pub fn scan_installed_skills_on_disk(global: bool) -> Vec<DiskItem> {
         roots
     };
 
-    let mut seen = std::collections::HashSet::new();
     for (skills_dir, gate) in canonical_skills {
         if !skills_dir.is_dir() {
             continue;
@@ -1212,26 +1211,36 @@ pub fn scan_installed_skills_on_disk(global: bool) -> Vec<DiskItem> {
                         // artifact resolves somewhere ELSE (an independent
                         // install in another checkout), an unscoped entry
                         // would let recovery claim it. Scope to the
-                        // harnesses actually resolving here in that case;
-                        // otherwise keep the legacy full detection.
+                        // harnesses actually attached here in that case —
+                        // symlink artifacts resolving to this canonical AND
+                        // direct-canonical harnesses (Codex/Pi, whose
+                        // artifact IS this directory). No locally attached
+                        // harness at all means the foreign install owns
+                        // every artifact: skip rather than mint a
+                        // zero-harness entry. Without a foreign-resolving
+                        // artifact, keep the legacy full detection.
                         let local_canonical = path.canonicalize().ok();
                         let mut resolving: Vec<String> = Vec::new();
                         let mut foreign_resolving = false;
                         for harness in crate::harness::Harness::ALL.iter() {
                             let artifact = harness.skills_dir(false).join(name);
-                            if std::fs::symlink_metadata(&artifact)
-                                .is_ok_and(|meta| meta.file_type().is_symlink())
-                            {
-                                match (artifact.canonicalize().ok(), &local_canonical) {
-                                    (Some(resolved), Some(local)) if resolved == *local => {
-                                        resolving.push(harness.id().to_string());
-                                    }
-                                    (Some(_), _) => foreign_resolving = true,
-                                    _ => {}
+                            let Ok(meta) = std::fs::symlink_metadata(&artifact) else {
+                                continue;
+                            };
+                            match (artifact.canonicalize().ok(), &local_canonical) {
+                                (Some(resolved), Some(local)) if resolved == *local => {
+                                    resolving.push(harness.id().to_string());
                                 }
+                                (Some(_), _) if meta.file_type().is_symlink() => {
+                                    foreign_resolving = true;
+                                }
+                                _ => {}
                             }
                         }
                         if foreign_resolving {
+                            if resolving.is_empty() {
+                                continue;
+                            }
                             Some(resolving)
                         } else {
                             None
@@ -1239,7 +1248,27 @@ pub fn scan_installed_skills_on_disk(global: bool) -> Vec<DiskItem> {
                     }
                 }
             };
-            if seen.insert(name.to_string()) {
+            // A skill can hold canonicals in MORE than one root (split
+            // layout: Codex/Pi local, Claude anchored in main): merge
+            // harness scopes across roots instead of first-root-wins. An
+            // unscoped (None) side means full legacy detection and absorbs
+            // any scoped one.
+            if let Some(existing) = items
+                .iter_mut()
+                .find(|item: &&mut DiskItem| item.name == name && item.kind == ItemKind::Skill)
+            {
+                match (&mut existing.anchored_harnesses, anchored_harnesses) {
+                    (Some(current), Some(mut incoming)) => {
+                        for harness_id in incoming.drain(..) {
+                            if !current.contains(&harness_id) {
+                                current.push(harness_id);
+                            }
+                        }
+                    }
+                    (current @ Some(_), None) => *current = None,
+                    (None, _) => {}
+                }
+            } else {
                 items.push(DiskItem {
                     name: name.to_string(),
                     kind: ItemKind::Skill,

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1178,15 +1178,21 @@ pub fn scan_installed_skills_on_disk(global: bool) -> Vec<DiskItem> {
                     // let the next refresh replace the copy. Only the
                     // resolving harnesses are recorded, so recovery cannot
                     // attach that independent install to the anchored entry.
+                    // Only SYMLINK artifacts are references: a direct
+                    // Codex/Pi artifact in a shared layout IS the canonical
+                    // dir itself, and counting that self-identity would let
+                    // a lockless worktree recover every main-checkout
+                    // canonical as its own install.
                     let referencing: Vec<String> = match path.canonicalize() {
                         Ok(canonical) => sharing
                             .iter()
                             .filter(|(harness, _)| {
-                                harness
-                                    .skills_dir(false)
-                                    .join(name)
-                                    .canonicalize()
-                                    .is_ok_and(|resolved| resolved == canonical)
+                                let artifact = harness.skills_dir(false).join(name);
+                                std::fs::symlink_metadata(&artifact)
+                                    .is_ok_and(|meta| meta.file_type().is_symlink())
+                                    && artifact
+                                        .canonicalize()
+                                        .is_ok_and(|resolved| resolved == canonical)
                             })
                             .map(|(harness, _)| harness.id().to_string())
                             .collect(),

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1070,6 +1070,12 @@ pub fn is_source_changed(entry: &LockEntry) -> bool {
 pub struct DiskItem {
     pub name: String,
     pub kind: ItemKind,
+    /// For a skill admitted through an anchored root's gate: the harnesses
+    /// whose artifacts resolve to that canonical. Recovery must scope the
+    /// entry to exactly these — a same-named non-resolving harness dir is an
+    /// independent copy-mode install, and recording it under the recovered
+    /// Symlink entry would let the next refresh replace the copy.
+    pub anchored_harnesses: Option<Vec<String>>,
 }
 
 /// Discovered hook artifacts on disk that match hooks available in the source.
@@ -1126,30 +1132,41 @@ pub fn scan_installed_skills_on_disk(global: bool) -> Vec<DiskItem> {
             let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
                 continue;
             };
-            if let Some(sharing) = &gate {
-                // A reference must RESOLVE to this canonical dir. A
-                // same-named copy-mode dir in a harness dir is that
-                // harness's own install, not a reference — recovering
-                // through it would re-type the skill as symlink-mode and
-                // let the next refresh replace the copy.
-                let canonical = path.canonicalize().ok();
-                let referenced = canonical.is_some_and(|canonical| {
-                    sharing.iter().any(|(harness, _)| {
-                        harness
-                            .skills_dir(false)
-                            .join(name)
-                            .canonicalize()
-                            .is_ok_and(|resolved| resolved == canonical)
-                    })
-                });
-                if !referenced {
-                    continue;
+            let anchored_harnesses = match &gate {
+                Some(sharing) => {
+                    // A reference must RESOLVE to this canonical dir. A
+                    // same-named copy-mode dir in a harness dir is that
+                    // harness's own install, not a reference — recovering
+                    // through it would re-type the skill as symlink-mode and
+                    // let the next refresh replace the copy. Only the
+                    // resolving harnesses are recorded, so recovery cannot
+                    // attach that independent install to the anchored entry.
+                    let referencing: Vec<String> = match path.canonicalize() {
+                        Ok(canonical) => sharing
+                            .iter()
+                            .filter(|(harness, _)| {
+                                harness
+                                    .skills_dir(false)
+                                    .join(name)
+                                    .canonicalize()
+                                    .is_ok_and(|resolved| resolved == canonical)
+                            })
+                            .map(|(harness, _)| harness.id().to_string())
+                            .collect(),
+                        Err(_) => Vec::new(),
+                    };
+                    if referencing.is_empty() {
+                        continue;
+                    }
+                    Some(referencing)
                 }
-            }
+                None => None,
+            };
             if seen.insert(name.to_string()) {
                 items.push(DiskItem {
                     name: name.to_string(),
                     kind: ItemKind::Skill,
+                    anchored_harnesses,
                 });
             }
         }
@@ -1665,18 +1682,27 @@ pub fn reconcile_lock_with_disk(lock: &mut LockFile, global: bool, source: &str)
     let now = now_iso();
     for item in &disk_skills {
         if !lock.entries.contains_key(&item.name) {
-            // Determine which harnesses have this skill by checking dirs
-            let mut harnesses = Vec::new();
-            for harness in crate::harness::Harness::ALL {
-                let skill_path = harness.skills_dir(global).join(&item.name);
-                if skill_path.exists() || skill_path.is_symlink() {
-                    harnesses.push(harness.id().to_string());
+            // Determine which harnesses have this skill by checking dirs.
+            // An anchored item carries the harnesses that resolve to its
+            // canonical; a same-named artifact for any OTHER harness is an
+            // independent install this entry must not claim.
+            let harnesses = match &item.anchored_harnesses {
+                Some(referencing) => referencing.clone(),
+                None => {
+                    let mut harnesses = Vec::new();
+                    for harness in crate::harness::Harness::ALL {
+                        let skill_path = harness.skills_dir(global).join(&item.name);
+                        if skill_path.exists() || skill_path.is_symlink() {
+                            harnesses.push(harness.id().to_string());
+                        }
+                    }
+                    if harnesses.is_empty() {
+                        // At minimum it's in the canonical location
+                        harnesses.push("claude-code".to_string());
+                    }
+                    harnesses
                 }
-            }
-            if harnesses.is_empty() {
-                // At minimum it's in the canonical location
-                harnesses.push("claude-code".to_string());
-            }
+            };
             let mut entry = LockEntry {
                 name: item.name.clone(),
                 kind: item.kind,

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1447,8 +1447,33 @@ fn prune_broken_skill_symlinks_in_dirs(dirs: &[PathBuf], managed_roots: &[PathBu
 }
 
 fn prune_broken_skill_symlinks(global: bool) -> bool {
-    let dirs = harness_skill_dirs(global);
-    let roots = managed_skill_roots(global);
+    let mut dirs = harness_skill_dirs(global);
+    let mut roots = managed_skill_roots(global);
+    if !global {
+        // Also sweep the harness dirs of same-repo checkouts that shared
+        // harness dirs anchor into: a link dangling in a main-side dir the
+        // worktree does NOT share is invisible to the local walk, and their
+        // canonical roots must count as managed targets.
+        let project_root = project_root();
+        for (anchored_root, _) in
+            crate::installer::anchored_canonical_skill_roots(crate::harness::Harness::ALL)
+        {
+            let Some(checkout_root) = anchored_root.parent().and_then(Path::parent) else {
+                continue;
+            };
+            for harness in crate::harness::Harness::ALL {
+                if let Ok(rel) = harness.skills_dir(false).strip_prefix(&project_root) {
+                    let dir = checkout_root.join(rel);
+                    if !dirs.contains(&dir) {
+                        dirs.push(dir);
+                    }
+                }
+            }
+            if !roots.contains(&anchored_root) {
+                roots.push(anchored_root);
+            }
+        }
+    }
     prune_broken_skill_symlinks_in_dirs(&dirs, &roots)
 }
 
@@ -1685,11 +1710,17 @@ pub fn reconcile_lock_with_disk(lock: &mut LockFile, global: bool, source: &str)
             project_root().join(".agents").join("skills")
         };
         for (name, entry_harnesses) in stale_skills {
+            // Entry ids may use supported aliases ("claude" for claude-code);
+            // normalize through the same resolution the rest of the CLI uses.
+            let entry_harnesses: Vec<crate::harness::Harness> = entry_harnesses
+                .iter()
+                .filter_map(|id| crate::harness::Harness::from_id(id))
+                .collect();
             let exists = own_root.join(&name).exists()
                 || anchored.iter().any(|(root, sharing)| {
                     sharing
                         .iter()
-                        .any(|harness| entry_harnesses.iter().any(|id| id == harness.id()))
+                        .any(|harness| entry_harnesses.contains(harness))
                         && root.join(&name).exists()
                 });
             if !exists {

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1087,18 +1087,27 @@ pub fn scan_installed_skills_on_disk(global: bool) -> Vec<DiskItem> {
 
     // Canonical skill location: .agents/skills/<name>/. Project scope also
     // consults checkout-anchored roots so a copy anchored in the main
-    // checkout by a worktree-run install (VST-195) is still discovered.
-    let canonical_skills = if global {
+    // checkout by a worktree-run install (VST-195) is still discovered — but
+    // a copy there belongs to this project's view only when a harness that
+    // shares into that checkout actually references it, so anchored roots
+    // carry the sharing harnesses as a gate.
+    let canonical_skills: Vec<(PathBuf, Option<Vec<crate::harness::Harness>>)> = if global {
         vec![
-            global_state_dir().join("skills"),
-            codex_home_dir().join("skills"),
+            (global_state_dir().join("skills"), None),
+            (codex_home_dir().join("skills"), None),
         ]
     } else {
-        crate::installer::project_canonical_skill_roots()
+        let mut roots = vec![(project_root().join(".agents").join("skills"), None)];
+        for (root, sharing) in
+            crate::installer::anchored_canonical_skill_roots(crate::harness::Harness::ALL)
+        {
+            roots.push((root, Some(sharing)));
+        }
+        roots
     };
 
     let mut seen = std::collections::HashSet::new();
-    for skills_dir in canonical_skills {
+    for (skills_dir, gate) in canonical_skills {
         if !skills_dir.is_dir() {
             continue;
         }
@@ -1114,9 +1123,19 @@ pub fn scan_installed_skills_on_disk(global: bool) -> Vec<DiskItem> {
             if !path.join(".vstack-refreshed").exists() {
                 continue;
             }
-            if let Some(name) = path.file_name().and_then(|n| n.to_str())
-                && seen.insert(name.to_string())
-            {
+            let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+                continue;
+            };
+            if let Some(sharing) = &gate {
+                let referenced = sharing.iter().any(|harness| {
+                    let link = harness.skills_dir(false).join(name);
+                    link.exists() || link.is_symlink()
+                });
+                if !referenced {
+                    continue;
+                }
+            }
+            if seen.insert(name.to_string()) {
                 items.push(DiskItem {
                     name: name.to_string(),
                     kind: ItemKind::Skill,
@@ -1645,22 +1664,35 @@ pub fn reconcile_lock_with_disk(lock: &mut LockFile, global: bool, source: &str)
     // Remove lock entries for skills whose files no longer exist on disk
     let disk_names: std::collections::HashSet<&str> =
         disk_skills.iter().map(|d| d.name.as_str()).collect();
-    let stale_skills: Vec<String> = lock
+    let stale_skills: Vec<(String, Vec<String>)> = lock
         .entries
         .iter()
         .filter(|(_, e)| e.kind == ItemKind::Skill && !disk_names.contains(e.name.as_str()))
-        .map(|(name, _)| name.clone())
+        .map(|(name, e)| (name.clone(), e.harnesses.clone()))
         .collect();
     if !stale_skills.is_empty() {
         // Verify the canonical dir is actually gone (not just missing the
-        // marker) in every root a copy may live in.
-        let canonical_roots = if global {
-            vec![global_state_dir().join("skills")]
+        // marker) in every root a copy may live in — anchored roots count
+        // for an entry only when one of ITS harnesses shares into them.
+        let anchored = if global {
+            Vec::new()
         } else {
-            crate::installer::project_canonical_skill_roots()
+            crate::installer::anchored_canonical_skill_roots(crate::harness::Harness::ALL)
         };
-        for name in stale_skills {
-            if !canonical_roots.iter().any(|root| root.join(&name).exists()) {
+        let own_root = if global {
+            global_state_dir().join("skills")
+        } else {
+            project_root().join(".agents").join("skills")
+        };
+        for (name, entry_harnesses) in stale_skills {
+            let exists = own_root.join(&name).exists()
+                || anchored.iter().any(|(root, sharing)| {
+                    sharing
+                        .iter()
+                        .any(|harness| entry_harnesses.iter().any(|id| id == harness.id()))
+                        && root.join(&name).exists()
+                });
+            if !exists {
                 eprintln!("  Removed stale lock entry (files missing): {name}");
                 lock.remove(&name);
                 modified = true;

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1091,7 +1091,7 @@ pub fn scan_installed_skills_on_disk(global: bool) -> Vec<DiskItem> {
     // a copy there belongs to this project's view only when a harness that
     // shares into that checkout actually references it, so anchored roots
     // carry the sharing harnesses as a gate.
-    let canonical_skills: Vec<(PathBuf, Option<Vec<crate::harness::Harness>>)> = if global {
+    let canonical_skills: Vec<(PathBuf, Option<crate::installer::AnchorSharing>)> = if global {
         vec![
             (global_state_dir().join("skills"), None),
             (codex_home_dir().join("skills"), None),
@@ -1134,7 +1134,7 @@ pub fn scan_installed_skills_on_disk(global: bool) -> Vec<DiskItem> {
                 // let the next refresh replace the copy.
                 let canonical = path.canonicalize().ok();
                 let referenced = canonical.is_some_and(|canonical| {
-                    sharing.iter().any(|harness| {
+                    sharing.iter().any(|(harness, _)| {
                         harness
                             .skills_dir(false)
                             .join(name)
@@ -1729,10 +1729,12 @@ pub fn reconcile_lock_with_disk(lock: &mut LockFile, global: bool, source: &str)
                 .collect();
             let exists = own_root.join(&name).exists()
                 || anchored.iter().any(|(root, sharing)| {
-                    sharing
-                        .iter()
-                        .any(|harness| entry_harnesses.contains(harness))
-                        && root.join(&name).exists()
+                    // Child-link evidence is per-skill: an anchored root
+                    // keeps an entry alive only when it is evidenced for
+                    // THIS name, not by an unrelated skill's child link.
+                    sharing.iter().any(|(harness, evidence)| {
+                        entry_harnesses.contains(harness) && evidence.covers(&name)
+                    }) && root.join(&name).exists()
                 });
             if !exists {
                 eprintln!("  Removed stale lock entry (files missing): {name}");

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1125,8 +1125,13 @@ pub fn scan_installed_skills_on_disk(global: bool) -> Vec<DiskItem> {
             if !path.is_dir() {
                 continue;
             }
-            // Only count directories with a .vstack-refreshed marker
-            if !path.join(".vstack-refreshed").exists() {
+            // Local roots require the managed marker. Anchored roots admit
+            // an UNMARKED canonical too — a foreign worktree's removal
+            // deliberately clears the marker while the owning checkout's
+            // references survive, and those references (checked below) are
+            // the recovery evidence; requiring the marker there made
+            // `vstack check` report a still-installed skill as missing.
+            if gate.is_none() && !path.join(".vstack-refreshed").exists() {
                 continue;
             }
             let Some(name) = path.file_name().and_then(|n| n.to_str()) else {

--- a/cli/src/installer.rs
+++ b/cli/src/installer.rs
@@ -160,7 +160,12 @@ pub fn install_skill(
                     .parent()
                     .and_then(|parent| parent.canonicalize().ok())
                     .is_some_and(|parent| !parent.starts_with(&project_checkout));
-            let mut foreign_existing = !canonical_physical.starts_with(&project_checkout)
+            // Global installs live under user homes by definition — the
+            // anchoring/write-shy machinery is project-scope only, and a
+            // global Codex canonical (canonical == dest, outside any
+            // project) must keep refreshing.
+            let mut foreign_existing = !global
+                && !canonical_physical.starts_with(&project_checkout)
                 && !dest_references_canonical
                 && canonical.exists();
             if foreign_existing
@@ -478,17 +483,26 @@ pub fn remove_item(
             let survives_this_removal = candidate_parent_canon
                 .as_ref()
                 .is_some_and(|parent| !removing_parent_canons.contains(parent));
-            // Only a SYMLINK is affirmative owner evidence: for harnesses
-            // whose project artifact IS the canonical directory (Codex/Pi
-            // under .agents/skills), the canonical would otherwise count as
-            // referencing itself and no marker could ever clear.
+            // A SYMLINK is affirmative owner evidence. For harnesses whose
+            // project artifact IS the canonical directory (Codex/Pi), the
+            // path would count as referencing itself, so DIRECT ownership
+            // is evidenced by the owner's LOCK instead (checked below).
             survives_this_removal
                 && std::fs::symlink_metadata(&candidate)
                     .is_ok_and(|meta| meta.file_type().is_symlink())
                 && candidate
                     .canonicalize()
                     .is_ok_and(|resolved| resolved == anchored_resolved)
-        });
+        }) || {
+            // Direct-canonical owner evidence: the owning checkout's lock
+            // names this skill — its Codex/Pi install IS the canonical dir
+            // and must keep its recovery marker through our removal.
+            let owner_lock = owning_root.join(".vstack-lock.json");
+            std::fs::read_to_string(&owner_lock)
+                .ok()
+                .and_then(|raw| serde_json::from_str::<crate::config::LockFile>(&raw).ok())
+                .is_some_and(|lock| lock.entries.contains_key(name.to_str().unwrap_or_default()))
+        };
         if owner_still_references {
             continue;
         }

--- a/cli/src/installer.rs
+++ b/cli/src/installer.rs
@@ -570,6 +570,14 @@ fn canonicalize_allowing_missing(path: &Path) -> Option<PathBuf> {
             }
         }
     }
+    // Exhausting the hop bound is a genuine resolution failure (a dangling or
+    // cyclic symlink chain), not the ordinary "no indirection" case — say so,
+    // since the caller's None silently skips anchoring (VST-195).
+    eprintln!(
+        "  Warning: could not resolve {} within {} symlink hops; treating as unanchored (VST-195)",
+        path.display(),
+        40
+    );
     None
 }
 

--- a/cli/src/installer.rs
+++ b/cli/src/installer.rs
@@ -72,14 +72,17 @@ pub fn install_skill(
     instructions: Option<&str>,
 ) -> Result<InstallResult> {
     validate_new_item_name(&skill.name)?;
-    if !global && method == InstallMethod::Symlink {
-        // The containment preflight must also cover the invoking checkout's
-        // own canonical writes (link_home == None): without it, an aliased
-        // in-repo `.agents` (e.g. `.agents -> cli/src`) makes install create
-        // — and refresh later recursively replace — repository sources.
-        // Copy-mode installs never write through `.agents`, so they skip it
-        // (a copy install must keep working beside an unrelated linked
-        // agents root). In-project validation is pure path comparison.
+    // The containment preflight must cover every install that writes
+    // through `.agents`: all project-scope symlink installs (their
+    // canonical lives there), and ANY install whose harness dest itself
+    // sits under `.agents` (Codex/Pi copy mode included — the TUI
+    // global→project move calls install_skill with no other preflight).
+    // Copy installs into non-.agents harness dirs skip it: they must keep
+    // working beside an unrelated linked agents root.
+    let dest_under_agents = harness
+        .skills_dir(global)
+        .starts_with(crate::config::project_root().join(".agents"));
+    if !global && (method == InstallMethod::Symlink || dest_under_agents) {
         crate::path_safety::ensure_agents_dir_within_project(&crate::config::project_root())?;
     }
     let dest = harness.install_skill(skill, global)?;

--- a/cli/src/installer.rs
+++ b/cli/src/installer.rs
@@ -406,11 +406,21 @@ pub fn install_skill(
 
                 #[cfg(unix)]
                 {
-                    let rel = match &link_home {
+                    // Where the new link ACTUALLY lands. Parent-level sharing:
+                    // dest's parent resolves into the other checkout, so the
+                    // link is physically created at home.physical_parent.
+                    // Child-level sharing: the parent is LOCAL (the old child
+                    // symlink was just removed above), so the link lands in
+                    // this checkout — a spelling computed at the foreign
+                    // parent (`github`) would be self-referential here.
+                    let creation_parent = dest
+                        .parent()
+                        .and_then(|parent| parent.canonicalize().ok());
+                    let rel = match (&link_home, creation_parent) {
                         // The repo layout is identical in every checkout, so
                         // the relative spelling computed at the link's
                         // physical home resolves there — worktree-independent.
-                        Some(home) => {
+                        (Some(home), Some(created_in)) if created_in == home.physical_parent => {
                             let rel = lexical_relative(&home.physical_parent, &canonical);
                             if home.physical_parent.join(&rel).is_dir() {
                                 rel
@@ -428,7 +438,15 @@ pub fn install_skill(
                                 abs
                             }
                         }
-                        None => relative_path(dest.parent().unwrap(), &canonical)?,
+                        // Child-level sharing: recreate the layout's shape —
+                        // a local child link pointing at the other checkout's
+                        // canonical. The target is absolute: it lives in the
+                        // OWNING checkout (stable), while this link dies with
+                        // the worktree; a cross-checkout ../ chain would
+                        // depend on where the worktree happens to sit.
+                        (Some(_), _) => std::fs::canonicalize(&canonical)
+                            .unwrap_or_else(|_| canonical.clone()),
+                        (None, _) => relative_path(dest.parent().unwrap(), &canonical)?,
                     };
                     std::os::unix::fs::symlink(&rel, &dest).with_context(|| {
                         format!("symlinking {} → {}", dest.display(), rel.display())
@@ -3288,6 +3306,15 @@ mod tests {
                 .file_type()
                 .is_symlink(),
             "the child link into main must be preserved, not materialized"
+        );
+        // The link must actually RESOLVE to main's copy — a spelling
+        // computed at the foreign parent (`github`) would be a
+        // self-referential loop in the local dir and a symlink-only
+        // assertion would miss it.
+        assert_eq!(
+            std::fs::canonicalize(&child).unwrap(),
+            std::fs::canonicalize(&main_copy).unwrap(),
+            "the recreated child link must canonicalize to the shared canonical in main"
         );
         assert_eq!(
             std::fs::read_to_string(main_copy.join("SKILL.md")).unwrap(),

--- a/cli/src/installer.rs
+++ b/cli/src/installer.rs
@@ -155,7 +155,12 @@ pub fn install_skill(
                 .parent()
                 .and_then(|parent| parent.canonicalize().ok())
                 .is_some_and(|parent| !parent.starts_with(&project_checkout));
+            // A symlink AT the canonical location is project-skills-dir
+            // wiring wherever it is referenced from — never refresh-owned.
+            let canonical_is_symlink = std::fs::symlink_metadata(&canonical)
+                .is_ok_and(|meta| meta.file_type().is_symlink());
             let dest_references_canonical = dest_parent_shared
+                && !canonical_is_symlink
                 && dest
                     .canonicalize()
                     .is_ok_and(|resolved| resolved == canonical_physical)

--- a/cli/src/installer.rs
+++ b/cli/src/installer.rs
@@ -158,9 +158,31 @@ pub fn install_skill(
                     .as_ref()
                     .map(|home| home.checkout_root.clone())
                     .unwrap_or_else(|| {
+                        // Probe the SELECTED harness's skills dir first: a
+                        // partially shared layout (real `.claude/skills`,
+                        // each child linked out) with a LOCAL `.agents`
+                        // leaves no evidence under `.agents/skills`, and a
+                        // new skill must still follow its harness siblings
+                        // into the owning checkout.
                         let own_skills =
                             crate::config::project_root().join(".agents").join("skills");
-                        child_level_anchored_roots(&own_skills)
+                        let mut anchored: Vec<(PathBuf, AnchorEvidence)> = dest
+                            .parent()
+                            .map(child_level_anchored_roots)
+                            .unwrap_or_default();
+                        anchored.extend(child_level_anchored_roots(&own_skills));
+                        // Deterministic selection when children point at
+                        // multiple checkouts: strongest evidence (most
+                        // children) wins, path order breaks ties —
+                        // read_dir order must never pick the anchor.
+                        anchored.sort_by(|(a_root, a_ev), (b_root, b_ev)| {
+                            let count = |ev: &AnchorEvidence| match ev {
+                                AnchorEvidence::Children(names) => names.len(),
+                                AnchorEvidence::SharedDir => usize::MAX,
+                            };
+                            count(b_ev).cmp(&count(a_ev)).then(a_root.cmp(b_root))
+                        });
+                        anchored
                             .into_iter()
                             .next()
                             .and_then(|(root, _)| {
@@ -320,13 +342,17 @@ pub fn install_skill(
             // at the canonical copy — we're done. Linking a physically
             // canonical dest would replace the copy with a self-referential
             // symlink.
-            let physically_canonical = link_home.as_ref().is_some_and(|home| {
-                // Compare physical locations, not spellings: the constructed
-                // canonical path may run through a symlinked `.agents` while
-                // physical_parent is already resolved.
-                let canonical_physical = canonicalize_allowing_missing(&canonical)
-                    .unwrap_or_else(|| normalize_absolute_path(&canonical));
-                home.physical_parent.join(&skill.name) == canonical_physical
+            let physically_canonical = link_home.as_ref().is_some_and(|_| {
+                // Compare where DEST itself physically resolves, not a
+                // reconstructed `<physical parent>/<name>`: a stale child
+                // link `foo -> .../bar` shares the canonical's parent, and
+                // the reconstruction would call it canonical while it points
+                // at the wrong skill. A symlink at dest is never physically
+                // canonical — it is an artifact to (re)point in Step 3.
+                !std::fs::symlink_metadata(&dest)
+                    .is_ok_and(|meta| meta.file_type().is_symlink())
+                    && canonicalize_allowing_missing(&dest)
+                        .is_some_and(|resolved| resolved == canonical_physical)
             });
             if dest == canonical || physically_canonical {
                 format!(
@@ -581,7 +607,26 @@ pub fn remove_item(
                 .is_some_and(|lock| {
                     lock.entries
                         .get(name.to_str().unwrap_or_default())
-                        .is_some_and(|entry| entry.kind == crate::config::ItemKind::Skill)
+                        .is_some_and(|entry| {
+                            // Only a symlink-mode install for a
+                            // direct-canonical harness (Codex/Pi: the
+                            // project artifact IS the canonical dir) makes
+                            // the lock entry ownership evidence for THIS
+                            // path. A copy-mode entry (or one for
+                            // link-artifact harnesses only, whose evidence
+                            // is the symlink checked above) never
+                            // references the canonical, and preserving the
+                            // marker on its word would let reconciliation
+                            // later adopt a stale foreign copy.
+                            entry.kind == crate::config::ItemKind::Skill
+                                && entry.method == crate::config::InstallMethod::Symlink
+                                && entry.harnesses.iter().any(|id| {
+                                    matches!(
+                                        Harness::from_id(id),
+                                        Some(Harness::Codex | Harness::Pi)
+                                    )
+                                })
+                        })
                 })
         };
         if owner_still_references {
@@ -1027,9 +1072,24 @@ fn anchored_link_home(physical_parent: PathBuf) -> Option<LinkHome> {
         probe = probe.parent()?;
     }
     let project_common = crate::path_safety::git_common_dir(&crate::config::project_root())?;
-    let (probe_common, checkout_root) = crate::path_safety::git_repo_identity(probe)?;
+    let (probe_common, mut checkout_root) = crate::path_safety::git_repo_identity(probe)?;
     if probe_common != project_common {
         return None;
+    }
+    // The project root may sit BELOW the git toplevel (a project marker in a
+    // subdirectory). The anchor must land at the other checkout's copy of
+    // THAT directory, not its toplevel — anchoring at the toplevel would
+    // collide the nested project's canonicals with sibling projects' .agents.
+    // The repo layout is identical in every checkout, so the repo-relative
+    // suffix transfers verbatim; a suffix that cannot be derived fails closed
+    // (no anchoring) rather than guessing a root.
+    let own_toplevel = crate::path_safety::git_toplevel(&crate::config::project_root())?;
+    let project_physical = std::fs::canonicalize(crate::config::project_root())
+        .unwrap_or_else(|_| normalize_absolute_path(&crate::config::project_root()));
+    match project_physical.strip_prefix(&own_toplevel) {
+        Ok(suffix) if suffix.as_os_str().is_empty() => {}
+        Ok(suffix) => checkout_root = checkout_root.join(suffix),
+        Err(_) => return None,
     }
     // Anchoring writes beneath the other checkout's .agents, so it gets the
     // same containment boundary the project's own .agents writes get. An
@@ -1090,6 +1150,9 @@ fn canonicalize_allowing_missing(path: &Path) -> Option<PathBuf> {
     None
 }
 
+/// Compute the path to spell a symlink target from `from` to `to`:
+/// relative for ordinary directories, absolute when `from` sits behind
+/// symlink indirection (see body).
 #[cfg(unix)]
 fn relative_path(from: &Path, to: &Path) -> Result<PathBuf> {
     let from_lexical = normalize_absolute_path(from);

--- a/cli/src/installer.rs
+++ b/cli/src/installer.rs
@@ -109,11 +109,23 @@ pub fn install_skill(
             // Step 1: Copy to canonical location (refresh from source).
             // Use a marker file to avoid re-copying if another harness
             // already refreshed the canonical in this process.
+            //
+            // Foreign canonicals are write-shy: an existing canonical in
+            // another checkout is linked to AS-IS — its content and marker
+            // belong to that checkout's installs, and refreshing it is the
+            // owning checkout's job.
+            let foreign_existing = link_home.is_some() && canonical.exists();
+            if foreign_existing && !canonical.join("SKILL.md").is_file() {
+                eprintln!(
+                    "  Warning: existing canonical {} has no SKILL.md; leaving it for its own checkout's refresh (VST-195)",
+                    canonical.display()
+                );
+            }
             let marker = canonical.join(".vstack-refreshed");
             let current_pid = std::process::id().to_string();
             let already_refreshed = marker.exists()
                 && std::fs::read_to_string(&marker).is_ok_and(|s| s.trim() == current_pid);
-            if !already_refreshed {
+            if !foreign_existing && !already_refreshed {
                 remove_existing(&canonical)?;
                 copy_dir(&skill.source_dir, &canonical)?;
 
@@ -282,7 +294,18 @@ pub fn remove_item(
                     .join(".agents")
                     .join("skills")
                     .join(name);
-                if !canonicals.contains(&canonical) {
+                // Only an artifact OF THIS SKILL resolving to that canonical
+                // makes this removal an owner there. A parent-level share
+                // alone proves where a NEW link would land, not that one
+                // exists — a same-named install belonging to the other
+                // checkout must keep its marker (its disk-recovery
+                // evidence) untouched.
+                let owned = dest.canonicalize().is_ok_and(|resolved| {
+                    canonicalize_allowing_missing(&canonical)
+                        .unwrap_or_else(|| normalize_absolute_path(&canonical))
+                        == resolved
+                });
+                if owned && !canonicals.contains(&canonical) {
                     canonicals.push(canonical);
                 }
             }
@@ -515,18 +538,44 @@ fn normalize_absolute_path(path: &Path) -> PathBuf {
 /// removal and reconciliation must scope root derivation to the harness set
 /// actually in play — an unscoped derivation would let a worktree operation
 /// reach a main-checkout install that exists only for other harnesses.
+/// How a harness's project skill dir evidences an anchored root. Child-link
+/// evidence is per-skill: one linked child proves nothing about OTHER names
+/// in the foreign root.
+#[derive(Clone, Debug)]
+pub(crate) enum AnchorEvidence {
+    /// The whole harness dir is shared; every skill name is in scope.
+    SharedDir,
+    /// Only these individually linked children are shared.
+    Children(Vec<String>),
+}
+
+impl AnchorEvidence {
+    pub(crate) fn covers(&self, name: &str) -> bool {
+        match self {
+            AnchorEvidence::SharedDir => true,
+            AnchorEvidence::Children(names) => names.iter().any(|child| child == name),
+        }
+    }
+}
+
+/// Harnesses evidencing an anchored root, with how each one evidences it.
+pub(crate) type AnchorSharing = Vec<(Harness, AnchorEvidence)>;
+
 pub(crate) fn anchored_canonical_skill_roots(
     harnesses: &[Harness],
-) -> Vec<(PathBuf, Vec<Harness>)> {
-    let mut anchored: Vec<(PathBuf, Vec<Harness>)> = Vec::new();
-    let mut probed: Vec<(PathBuf, Vec<PathBuf>)> = Vec::new();
+) -> Vec<(PathBuf, AnchorSharing)> {
+    let mut anchored: Vec<(PathBuf, AnchorSharing)> = Vec::new();
+    let mut probed: Vec<(PathBuf, Vec<(PathBuf, AnchorEvidence)>)> = Vec::new();
     for harness in harnesses {
         let dir = harness.skills_dir(false);
         let roots = match probed.iter().find(|(probed_dir, _)| *probed_dir == dir) {
             Some((_, cached)) => cached.clone(),
             None => {
                 let roots = match same_repo_link_home(&dir) {
-                    Some(home) => vec![home.checkout_root.join(".agents").join("skills")],
+                    Some(home) => vec![(
+                        home.checkout_root.join(".agents").join("skills"),
+                        AnchorEvidence::SharedDir,
+                    )],
                     // Partial sharing keeps the dir real and links each
                     // skill CHILD into the shared checkout; the children
                     // are then the only evidence of the anchor.
@@ -536,17 +585,17 @@ pub(crate) fn anchored_canonical_skill_roots(
                 roots
             }
         };
-        for root in roots {
+        for (root, evidence) in roots {
             match anchored
                 .iter_mut()
                 .find(|(anchored_root, _)| *anchored_root == root)
             {
                 Some((_, sharing)) => {
-                    if !sharing.contains(harness) {
-                        sharing.push(*harness);
+                    if !sharing.iter().any(|(shared, _)| shared == harness) {
+                        sharing.push((*harness, evidence));
                     }
                 }
-                None => anchored.push((root, vec![*harness])),
+                None => anchored.push((root, vec![(*harness, evidence)])),
             }
         }
     }
@@ -557,11 +606,12 @@ pub(crate) fn anchored_canonical_skill_roots(
 /// including DANGLING children whose canonical is already gone — pruning
 /// must still classify those under a managed root. Non-symlink children are
 /// skipped without any git probing, so ordinary layouts pay one read_dir.
-fn child_level_anchored_roots(dir: &Path) -> Vec<PathBuf> {
-    let mut roots: Vec<PathBuf> = Vec::new();
+/// Each root carries the child NAMES that evidence it.
+fn child_level_anchored_roots(dir: &Path) -> Vec<(PathBuf, AnchorEvidence)> {
+    let mut roots: Vec<(PathBuf, Vec<String>)> = Vec::new();
     let mut probed_parents: Vec<(PathBuf, Option<PathBuf>)> = Vec::new();
     let Ok(entries) = std::fs::read_dir(dir) else {
-        return roots;
+        return Vec::new();
     };
     for entry in entries.flatten() {
         let child = entry.path();
@@ -571,6 +621,9 @@ fn child_level_anchored_roots(dir: &Path) -> Vec<PathBuf> {
         if !meta.file_type().is_symlink() {
             continue;
         }
+        let Some(name) = child.file_name().and_then(|n| n.to_str()).map(String::from) else {
+            continue;
+        };
         let lexical = normalize_absolute_path(&child);
         let Some(physical) = canonicalize_allowing_missing(&child) else {
             continue;
@@ -590,13 +643,16 @@ fn child_level_anchored_roots(dir: &Path) -> Vec<PathBuf> {
                 root
             }
         };
-        if let Some(root) = root
-            && !roots.contains(&root)
-        {
-            roots.push(root);
+        let Some(root) = root else { continue };
+        match roots.iter_mut().find(|(known, _)| *known == root) {
+            Some((_, names)) => names.push(name),
+            None => roots.push((root, vec![name])),
         }
     }
     roots
+        .into_iter()
+        .map(|(root, names)| (root, AnchorEvidence::Children(names)))
+        .collect()
 }
 
 /// The physical home of a project-scope harness link whose parent directory
@@ -1389,6 +1445,180 @@ mod tests {
         let _ = std::fs::remove_dir_all(&root);
     }
 
+    /// Child-link evidence is per-skill: one legitimate child link must not
+    /// turn the whole foreign root into evidence for OTHER skills — a stale
+    /// lock entry whose skill has no artifact in this worktree must not be
+    /// kept alive by an unrelated skill's child link.
+    #[cfg(unix)]
+    #[test]
+    fn reconcile_drops_stale_entry_not_evidenced_by_child_links() {
+        use std::os::unix::fs::symlink;
+
+        let root = std::env::temp_dir().join(format!(
+            "vstack_worktree_unrelated_child_{}_{}",
+            std::process::id(),
+            crate::config::now_iso().replace([':', '-'], "")
+        ));
+        let main = root.join("main");
+        let wt = root.join("wt");
+        std::fs::create_dir_all(&main).unwrap();
+        if !init_repo_with_commit(&main) {
+            let _ = std::fs::remove_dir_all(&root);
+            return; // git unavailable on this host
+        }
+        assert!(git_ok(&main, &["worktree", "add", "-q", wt.to_str().unwrap()]));
+
+        // Legitimate child link for skill X; skill Y exists only in main.
+        for name in ["x-linked", "y-mainonly"] {
+            let copy = main.join(".agents").join("skills").join(name);
+            std::fs::create_dir_all(&copy).unwrap();
+            std::fs::write(copy.join("SKILL.md"), format!("# {name}\n")).unwrap();
+            std::fs::write(copy.join(".vstack-refreshed"), "0").unwrap();
+        }
+        std::fs::create_dir_all(wt.join(".agents").join("skills")).unwrap();
+        symlink(
+            main.join(".agents").join("skills").join("x-linked"),
+            wt.join(".agents").join("skills").join("x-linked"),
+        )
+        .unwrap();
+
+        let mut lock = LockFile::default();
+        lock.add(LockEntry {
+            name: "y-mainonly".into(),
+            kind: ItemKind::Skill,
+            source: "source".into(),
+            source_repo: None,
+            harnesses: vec![Harness::Codex.id().to_string()],
+            method: InstallMethod::Symlink,
+            installed_at: "2026-08-10T00:00:00Z".into(),
+            source_hash: String::new(),
+        });
+        crate::test_util::with_project_root(&wt, || {
+            crate::config::reconcile_lock_with_disk(&mut lock, false, "source")
+        });
+
+        assert!(
+            !lock.entries.contains_key("y-mainonly"),
+            "an unrelated child link must not keep another skill's stale entry alive"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// Marker operations only on canonicals the operation owned: a removal
+    /// whose harness never had a link for THIS skill must not clear the
+    /// managed marker of a same-named install belonging to the other
+    /// checkout — that marker is its disk-recovery evidence.
+    #[cfg(unix)]
+    #[test]
+    fn remove_item_leaves_unowned_same_named_marker_intact() {
+        use std::os::unix::fs::symlink;
+
+        let root = std::env::temp_dir().join(format!(
+            "vstack_worktree_unowned_marker_{}_{}",
+            std::process::id(),
+            crate::config::now_iso().replace([':', '-'], "")
+        ));
+        let main = root.join("main");
+        let wt = root.join("wt");
+        std::fs::create_dir_all(&main).unwrap();
+        if !init_repo_with_commit(&main) {
+            let _ = std::fs::remove_dir_all(&root);
+            return; // git unavailable on this host
+        }
+        assert!(git_ok(&main, &["worktree", "add", "-q", wt.to_str().unwrap()]));
+
+        let main_skills = main.join(".claude").join("skills");
+        std::fs::create_dir_all(&main_skills).unwrap();
+        std::fs::create_dir_all(wt.join(".claude")).unwrap();
+        symlink(&main_skills, wt.join(".claude").join("skills")).unwrap();
+        std::fs::create_dir_all(wt.join(".agents")).unwrap();
+
+        // Main-only install named "dupe"; Claude never had a link for it.
+        let dupe = main.join(".agents").join("skills").join("dupe");
+        std::fs::create_dir_all(&dupe).unwrap();
+        std::fs::write(dupe.join("SKILL.md"), "# dupe\n").unwrap();
+        std::fs::write(dupe.join(".vstack-refreshed"), "0").unwrap();
+
+        crate::test_util::with_project_root(&wt, || {
+            remove_item("dupe", Some(ItemKind::Skill), &[Harness::ClaudeCode], false).unwrap()
+        });
+
+        assert!(dupe.join("SKILL.md").is_file());
+        assert!(
+            dupe.join(".vstack-refreshed").is_file(),
+            "an unowned install's managed marker must survive a foreign removal"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// Write-shy foreign canonicals: an install whose link lands in another
+    /// checkout must LINK to that checkout's existing canonical as-is —
+    /// rewriting its content would clobber the install it backs there;
+    /// refreshing it is the owning checkout's job.
+    #[cfg(unix)]
+    #[test]
+    fn install_skill_links_to_existing_foreign_canonical_without_rewriting() {
+        use std::os::unix::fs::symlink;
+
+        let root = std::env::temp_dir().join(format!(
+            "vstack_worktree_write_shy_{}_{}",
+            std::process::id(),
+            crate::config::now_iso().replace([':', '-'], "")
+        ));
+        let main = root.join("main");
+        let wt = root.join("wt");
+        std::fs::create_dir_all(&main).unwrap();
+        if !init_repo_with_commit(&main) {
+            let _ = std::fs::remove_dir_all(&root);
+            return; // git unavailable on this host
+        }
+        assert!(git_ok(&main, &["worktree", "add", "-q", wt.to_str().unwrap()]));
+
+        let main_skills = main.join(".claude").join("skills");
+        std::fs::create_dir_all(&main_skills).unwrap();
+        std::fs::create_dir_all(wt.join(".claude")).unwrap();
+        symlink(&main_skills, wt.join(".claude").join("skills")).unwrap();
+        std::fs::create_dir_all(wt.join(".agents")).unwrap();
+
+        // Main's canonical pre-exists with its own content and marker.
+        let canonical = main.join(".agents").join("skills").join("github");
+        std::fs::create_dir_all(&canonical).unwrap();
+        std::fs::write(canonical.join("SKILL.md"), "owned by main\n").unwrap();
+        std::fs::write(canonical.join(".vstack-refreshed"), "main\n").unwrap();
+
+        let skill = write_skill_source(&root, "github");
+        crate::test_util::with_project_root(&wt, || {
+            install_skill(
+                &skill,
+                Harness::ClaudeCode,
+                false,
+                InstallMethod::Symlink,
+                None,
+            )
+            .unwrap()
+        });
+
+        assert_eq!(
+            std::fs::read_to_string(canonical.join("SKILL.md")).unwrap(),
+            "owned by main\n",
+            "the foreign canonical's content must not be rewritten"
+        );
+        assert_eq!(
+            std::fs::read_to_string(canonical.join(".vstack-refreshed")).unwrap(),
+            "main\n",
+            "the foreign canonical's marker must not be rewritten"
+        );
+        let link = main_skills.join("github");
+        assert!(
+            link.canonicalize().unwrap().join("SKILL.md").is_file(),
+            "the link must resolve to the existing canonical"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
     /// A canonical copy that existed SOLELY for this worktree's install must
     /// not resurrect after removal: the owning checkout's reconciliation
     /// adopts any marked dir in its own root (deliberately — see
@@ -1867,9 +2097,11 @@ mod tests {
 
     /// Partial sharing links each skill CHILD into main while `.agents/skills`
     /// stays real (worktree config.md). Install must resolve the child-level
-    /// symlink when selecting the canonical home: refresh main's copy through
-    /// the anchor and keep the child link — materializing a real directory
-    /// over the link would fork the skill from the shared copy.
+    /// symlink when selecting the canonical home and keep the child link —
+    /// materializing a real directory over the link would fork the skill
+    /// from the shared copy. The existing foreign canonical is linked to
+    /// AS-IS (write-shy): its content belongs to the owning checkout's
+    /// refresh, so the pre-existing content stays.
     #[cfg(unix)]
     #[test]
     fn install_skill_resolves_child_level_symlink_to_shared_canonical() {
@@ -1908,10 +2140,10 @@ mod tests {
                 .is_symlink(),
             "the child link into main must be preserved, not materialized"
         );
-        let refreshed = std::fs::read_to_string(main_copy.join("SKILL.md")).unwrap();
-        assert!(
-            refreshed.contains("Test skill"),
-            "main's shared copy must be refreshed through the child anchor, got: {refreshed}"
+        assert_eq!(
+            std::fs::read_to_string(main_copy.join("SKILL.md")).unwrap(),
+            "stale\n",
+            "main's copy is the owning checkout's to refresh — not rewritten from here"
         );
 
         let _ = std::fs::remove_dir_all(&root);

--- a/cli/src/installer.rs
+++ b/cli/src/installer.rs
@@ -80,11 +80,7 @@ pub fn install_skill(
             // harness dirs into the main checkout (vstack#886), so this can
             // be a different checkout of the same repository than the
             // project root the command ran from.
-            let link_home = if global {
-                None
-            } else {
-                dest.parent().and_then(same_repo_link_home)
-            };
+            let link_home = if global { None } else { skill_link_home(&dest) };
 
             // Canonical location: .agents/skills/<name>/ (universal, like
             // Vercel npx skills). For project scope the copy must live in
@@ -254,38 +250,6 @@ pub fn remove_item(
     let remove_skills = kind.is_none_or(|kind| kind == ItemKind::Skill);
     let remove_hooks = kind.is_none_or(|kind| kind == ItemKind::Hook);
 
-    // Snapshot canonical deletion targets BEFORE harness links are removed:
-    // an anchored root's copy is deletable only while a requested harness's
-    // link still proves this entry uses that root for this skill — a
-    // same-named install belonging to another harness in the other checkout
-    // must not be reached just because the requested harness shares there.
-    let canonical_skill_paths: Vec<PathBuf> = if !remove_skills {
-        Vec::new()
-    } else if global {
-        vec![
-            crate::config::global_state_dir().join("skills").join(name),
-            crate::config::codex_home_dir().join("skills").join(name),
-        ]
-    } else {
-        let mut paths = vec![
-            crate::config::project_root()
-                .join(".agents")
-                .join("skills")
-                .join(name),
-        ];
-        for (root, sharing) in anchored_canonical_skill_roots(harnesses) {
-            let referenced = sharing.iter().any(|harness| {
-                let link = harness.skills_dir(false).join(name);
-                link.exists() || link.is_symlink()
-            });
-            let path = root.join(name);
-            if referenced && !paths.contains(&path) {
-                paths.push(path);
-            }
-        }
-        paths
-    };
-
     for harness in harnesses {
         // Agent files
         if remove_agents {
@@ -339,6 +303,20 @@ pub fn remove_item(
     }
 
     if remove_skills {
+        let canonical_skill_paths = if global {
+            vec![
+                crate::config::global_state_dir().join("skills").join(name),
+                crate::config::codex_home_dir().join("skills").join(name),
+            ]
+        } else {
+            vec![
+                crate::config::project_root()
+                    .join(".agents")
+                    .join("skills")
+                    .join(name),
+            ]
+        };
+
         for path in canonical_skill_paths {
             match remove_expected_path(&path, ExpectedArtifact::Any) {
                 Ok(true) => removed.push(path),
@@ -348,6 +326,23 @@ pub fn remove_item(
                     if global { "global" } else { "project" },
                     path.display()
                 )),
+            }
+        }
+
+        // A canonical copy anchored in another checkout is shared per-skill
+        // across ALL of that checkout's harnesses — a Codex/Pi install there
+        // IS the canonical dir itself, indistinguishable on disk from a
+        // leftover. Never delete it from a foreign worktree; that checkout's
+        // own remove collects it.
+        if !global {
+            for (root, _) in anchored_canonical_skill_roots(harnesses) {
+                let anchored = root.join(name);
+                if anchored.exists() {
+                    eprintln!(
+                        "  Note: leaving canonical copy {} in place — it may back that checkout's own installs; remove it from that checkout to delete it (VST-195)",
+                        anchored.display()
+                    );
+                }
             }
         }
     }
@@ -489,20 +484,6 @@ pub(crate) fn anchored_canonical_skill_roots(
     anchored
 }
 
-/// Every `.agents/skills` root a canonical copy for `harnesses` may live in:
-/// the project's own, plus the anchored roots those harnesses land in.
-/// Install anchors per harness link; removal and lock reconciliation consult
-/// this set so all three agree on where a canonical copy may live.
-pub(crate) fn project_canonical_skill_roots(harnesses: &[Harness]) -> Vec<PathBuf> {
-    let mut roots = vec![crate::config::project_root().join(".agents").join("skills")];
-    for (root, _) in anchored_canonical_skill_roots(harnesses) {
-        if !roots.contains(&root) {
-            roots.push(root);
-        }
-    }
-    roots
-}
-
 /// The physical home of a project-scope harness link whose parent directory
 /// is symlinked into another checkout of the same repository.
 struct LinkHome {
@@ -526,9 +507,32 @@ fn same_repo_link_home(dest_parent: &Path) -> Option<LinkHome> {
     if physical == lexical {
         return None;
     }
+    anchored_link_home(physical)
+}
+
+/// Child-level variant for a skill dir itself: partial-sharing layouts keep
+/// the harness dir real and symlink each skill CHILD into the shared
+/// checkout (worktree config.md), so parent-level probing alone would
+/// mis-select a worktree-local canonical and materialize a real directory
+/// over the child link.
+fn skill_link_home(dest: &Path) -> Option<LinkHome> {
+    if let Some(home) = dest.parent().and_then(same_repo_link_home) {
+        return Some(home);
+    }
+    let lexical = normalize_absolute_path(dest);
+    let physical = canonicalize_allowing_missing(dest)?;
+    if physical == lexical {
+        return None;
+    }
+    anchored_link_home(physical.parent()?.to_path_buf())
+}
+
+/// Validate that `physical_parent` lies in a same-repository checkout whose
+/// `.agents` passes containment, and name that checkout's root.
+fn anchored_link_home(physical_parent: PathBuf) -> Option<LinkHome> {
     // git needs an existing directory; the harness dir itself may not exist
     // on the physical side yet.
-    let mut probe = physical.as_path();
+    let mut probe = physical_parent.as_path();
     while !probe.is_dir() {
         probe = probe.parent()?;
     }
@@ -548,7 +552,7 @@ fn same_repo_link_home(dest_parent: &Path) -> Option<LinkHome> {
         return None;
     }
     Some(LinkHome {
-        physical_parent: physical,
+        physical_parent,
         checkout_root,
     })
 }
@@ -1021,75 +1025,6 @@ mod tests {
         let _ = std::fs::remove_dir_all(&root);
     }
 
-    /// Removal must be symmetric with install's anchoring: a skill installed
-    /// from a worktree in the split layout places the canonical copy in the
-    /// MAIN checkout, so removal from the worktree must clear the main-side
-    /// canonical copy (and the worktree's own, if any) along with the link —
-    /// leaving nothing behind in either checkout.
-    #[cfg(unix)]
-    #[test]
-    fn remove_item_clears_canonical_copies_in_every_anchored_checkout() {
-        use std::os::unix::fs::symlink;
-
-        let root = std::env::temp_dir().join(format!(
-            "vstack_worktree_remove_symmetry_{}_{}",
-            std::process::id(),
-            crate::config::now_iso().replace([':', '-'], "")
-        ));
-        let main = root.join("main");
-        let wt = root.join("wt");
-        std::fs::create_dir_all(&main).unwrap();
-        if !init_repo_with_commit(&main) {
-            let _ = std::fs::remove_dir_all(&root);
-            return; // git unavailable on this host
-        }
-        assert!(git_ok(&main, &["worktree", "add", "-q", wt.to_str().unwrap()]));
-
-        let main_skills = main.join(".claude").join("skills");
-        std::fs::create_dir_all(&main_skills).unwrap();
-        std::fs::create_dir_all(wt.join(".claude")).unwrap();
-        symlink(&main_skills, wt.join(".claude").join("skills")).unwrap();
-        std::fs::create_dir_all(wt.join(".agents")).unwrap();
-
-        let skill = write_skill_source(&root, "github");
-        crate::test_util::with_project_root(&wt, || {
-            install_skill(
-                &skill,
-                Harness::ClaudeCode,
-                false,
-                InstallMethod::Symlink,
-                None,
-            )
-            .unwrap()
-        });
-        assert!(main.join(".agents/skills/github/SKILL.md").is_file());
-
-        crate::test_util::with_project_root(&wt, || {
-            remove_item(
-                "github",
-                Some(ItemKind::Skill),
-                &[Harness::ClaudeCode],
-                false,
-            )
-            .unwrap()
-        });
-
-        assert!(
-            std::fs::symlink_metadata(main_skills.join("github")).is_err(),
-            "harness link must be removed"
-        );
-        assert!(
-            std::fs::symlink_metadata(main.join(".agents/skills/github")).is_err(),
-            "main checkout's canonical copy must be removed"
-        );
-        assert!(
-            std::fs::symlink_metadata(wt.join(".agents/skills/github")).is_err(),
-            "worktree's canonical copy must be removed"
-        );
-
-        let _ = std::fs::remove_dir_all(&root);
-    }
-
     /// Anchoring in another checkout must apply the same `.agents`
     /// containment boundary the project's own writes get: when that
     /// checkout's `.agents` symlinks outside the repository, no write may
@@ -1279,6 +1214,66 @@ mod tests {
         let _ = std::fs::remove_dir_all(&root);
     }
 
+    /// The stale-entry gate must normalize lock-entry harness ids the way
+    /// the rest of the CLI does (`Harness::from_id`, which accepts aliases
+    /// like "claude"): an alias spelling must still match the sharing
+    /// harness of an anchored root, or the entry is wrongly dropped while
+    /// its anchored copy exists.
+    #[cfg(unix)]
+    #[test]
+    fn reconcile_keeps_alias_harness_entry_for_anchored_copy() {
+        use std::os::unix::fs::symlink;
+
+        let root = std::env::temp_dir().join(format!(
+            "vstack_worktree_alias_gate_{}_{}",
+            std::process::id(),
+            crate::config::now_iso().replace([':', '-'], "")
+        ));
+        let main = root.join("main");
+        let wt = root.join("wt");
+        std::fs::create_dir_all(&main).unwrap();
+        if !init_repo_with_commit(&main) {
+            let _ = std::fs::remove_dir_all(&root);
+            return; // git unavailable on this host
+        }
+        assert!(git_ok(&main, &["worktree", "add", "-q", wt.to_str().unwrap()]));
+
+        let main_skills = main.join(".claude").join("skills");
+        std::fs::create_dir_all(&main_skills).unwrap();
+        std::fs::create_dir_all(wt.join(".claude")).unwrap();
+        symlink(&main_skills, wt.join(".claude").join("skills")).unwrap();
+        std::fs::create_dir_all(wt.join(".agents")).unwrap();
+
+        // Anchored copy exists; no harness link anywhere, so the recovery
+        // scan skips it and the entry reaches the stale gate.
+        let copy = main.join(".agents").join("skills").join("github");
+        std::fs::create_dir_all(&copy).unwrap();
+        std::fs::write(copy.join("SKILL.md"), "# github\n").unwrap();
+        std::fs::write(copy.join(".vstack-refreshed"), "0").unwrap();
+
+        let mut lock = LockFile::default();
+        lock.add(LockEntry {
+            name: "github".into(),
+            kind: ItemKind::Skill,
+            source: "source".into(),
+            source_repo: None,
+            harnesses: vec!["claude".into()], // alias for claude-code
+            method: InstallMethod::Symlink,
+            installed_at: "2026-08-10T00:00:00Z".into(),
+            source_hash: String::new(),
+        });
+        crate::test_util::with_project_root(&wt, || {
+            crate::config::reconcile_lock_with_disk(&mut lock, false, "source")
+        });
+
+        assert!(
+            lock.entries.contains_key("github"),
+            "alias-spelled harness must still match the anchored root's sharing harness"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
     /// The physically-canonical guard must compare physical locations, not
     /// spellings: with `.agents` itself a symlink (`main/.agents ->
     /// main/agents-store`), the constructed canonical spelling and the
@@ -1380,6 +1375,186 @@ mod tests {
             "reconciliation from the worktree must not claim main's Codex-only install"
         );
         assert!(solo.join("SKILL.md").is_file());
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// The canonical copy is shared per-skill across all harnesses within
+    /// its checkout: main's Codex install of X IS main/.agents/skills/X.
+    /// A foreign worktree removing X for a shared harness must remove the
+    /// link but leave the anchored canonical for that checkout's own
+    /// operations to collect — deleting it would strand main's install.
+    #[cfg(unix)]
+    #[test]
+    fn remove_item_preserves_anchored_canonical_shared_by_other_checkout_installs() {
+        use std::os::unix::fs::symlink;
+
+        let root = std::env::temp_dir().join(format!(
+            "vstack_worktree_shared_canonical_{}_{}",
+            std::process::id(),
+            crate::config::now_iso().replace([':', '-'], "")
+        ));
+        let main = root.join("main");
+        let wt = root.join("wt");
+        std::fs::create_dir_all(&main).unwrap();
+        if !init_repo_with_commit(&main) {
+            let _ = std::fs::remove_dir_all(&root);
+            return; // git unavailable on this host
+        }
+        assert!(git_ok(&main, &["worktree", "add", "-q", wt.to_str().unwrap()]));
+
+        let main_skills = main.join(".claude").join("skills");
+        std::fs::create_dir_all(&main_skills).unwrap();
+        std::fs::create_dir_all(wt.join(".claude")).unwrap();
+        symlink(&main_skills, wt.join(".claude").join("skills")).unwrap();
+        std::fs::create_dir_all(wt.join(".agents")).unwrap();
+
+        // wt installs for Claude: link in main, canonical anchored in main.
+        // That same canonical dir IS main's own Codex install of the skill.
+        let skill = write_skill_source(&root, "github");
+        crate::test_util::with_project_root(&wt, || {
+            install_skill(
+                &skill,
+                Harness::ClaudeCode,
+                false,
+                InstallMethod::Symlink,
+                None,
+            )
+            .unwrap()
+        });
+        let canonical = main.join(".agents").join("skills").join("github");
+        assert!(canonical.join("SKILL.md").is_file());
+
+        crate::test_util::with_project_root(&wt, || {
+            remove_item(
+                "github",
+                Some(ItemKind::Skill),
+                &[Harness::ClaudeCode],
+                false,
+            )
+            .unwrap()
+        });
+        assert!(
+            std::fs::symlink_metadata(main_skills.join("github")).is_err(),
+            "the Claude link must be removed"
+        );
+        assert!(
+            canonical.join("SKILL.md").is_file(),
+            "the anchored canonical backs the checkout's own installs and must survive"
+        );
+
+        // The owning checkout's own removal collects it.
+        crate::test_util::with_project_root(&main, || {
+            remove_item("github", Some(ItemKind::Skill), &[Harness::Codex], false).unwrap()
+        });
+        assert!(
+            std::fs::symlink_metadata(&canonical).is_err(),
+            "the owning checkout's removal must delete its canonical copy"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// Partial sharing links each skill CHILD into main while `.agents/skills`
+    /// stays real (worktree config.md). Install must resolve the child-level
+    /// symlink when selecting the canonical home: refresh main's copy through
+    /// the anchor and keep the child link — materializing a real directory
+    /// over the link would fork the skill from the shared copy.
+    #[cfg(unix)]
+    #[test]
+    fn install_skill_resolves_child_level_symlink_to_shared_canonical() {
+        use std::os::unix::fs::symlink;
+
+        let root = std::env::temp_dir().join(format!(
+            "vstack_worktree_child_link_{}_{}",
+            std::process::id(),
+            crate::config::now_iso().replace([':', '-'], "")
+        ));
+        let main = root.join("main");
+        let wt = root.join("wt");
+        std::fs::create_dir_all(&main).unwrap();
+        if !init_repo_with_commit(&main) {
+            let _ = std::fs::remove_dir_all(&root);
+            return; // git unavailable on this host
+        }
+        assert!(git_ok(&main, &["worktree", "add", "-q", wt.to_str().unwrap()]));
+
+        let main_copy = main.join(".agents").join("skills").join("github");
+        std::fs::create_dir_all(&main_copy).unwrap();
+        std::fs::write(main_copy.join("SKILL.md"), "stale\n").unwrap();
+        std::fs::create_dir_all(wt.join(".agents").join("skills")).unwrap();
+        symlink(&main_copy, wt.join(".agents").join("skills").join("github")).unwrap();
+
+        let skill = write_skill_source(&root, "github");
+        crate::test_util::with_project_root(&wt, || {
+            install_skill(&skill, Harness::Codex, false, InstallMethod::Symlink, None).unwrap()
+        });
+
+        let child = wt.join(".agents").join("skills").join("github");
+        assert!(
+            std::fs::symlink_metadata(&child)
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "the child link into main must be preserved, not materialized"
+        );
+        let refreshed = std::fs::read_to_string(main_copy.join("SKILL.md")).unwrap();
+        assert!(
+            refreshed.contains("Test skill"),
+            "main's shared copy must be refreshed through the child anchor, got: {refreshed}"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// Broken-link pruning must also sweep the anchored checkout's harness
+    /// dirs: a dangling link in a main-side dir the worktree does NOT share
+    /// (main's own `.cursor/rules` here) is invisible to a prune that walks
+    /// only the invoking checkout's dirs.
+    #[cfg(unix)]
+    #[test]
+    fn reconcile_prunes_dangling_links_in_anchored_checkout_harness_dirs() {
+        use std::os::unix::fs::symlink;
+
+        let root = std::env::temp_dir().join(format!(
+            "vstack_worktree_anchored_prune_{}_{}",
+            std::process::id(),
+            crate::config::now_iso().replace([':', '-'], "")
+        ));
+        let main = root.join("main");
+        let wt = root.join("wt");
+        std::fs::create_dir_all(&main).unwrap();
+        if !init_repo_with_commit(&main) {
+            let _ = std::fs::remove_dir_all(&root);
+            return; // git unavailable on this host
+        }
+        assert!(git_ok(&main, &["worktree", "add", "-q", wt.to_str().unwrap()]));
+
+        let main_skills = main.join(".claude").join("skills");
+        std::fs::create_dir_all(&main_skills).unwrap();
+        std::fs::create_dir_all(wt.join(".claude")).unwrap();
+        symlink(&main_skills, wt.join(".claude").join("skills")).unwrap();
+        std::fs::create_dir_all(wt.join(".agents")).unwrap();
+
+        // Dangling link in a main dir the worktree does not share; its
+        // target points at main's managed canonical root.
+        let cursor_rules = main.join(".cursor").join("rules");
+        std::fs::create_dir_all(&cursor_rules).unwrap();
+        symlink(
+            Path::new("../../.agents/skills/gone"),
+            cursor_rules.join("gone"),
+        )
+        .unwrap();
+
+        let mut lock = LockFile::default();
+        crate::test_util::with_project_root(&wt, || {
+            crate::config::reconcile_lock_with_disk(&mut lock, false, "source")
+        });
+
+        assert!(
+            std::fs::symlink_metadata(cursor_rules.join("gone")).is_err(),
+            "dangling link in the anchored checkout's unshared harness dir must be pruned"
+        );
 
         let _ = std::fs::remove_dir_all(&root);
     }

--- a/cli/src/installer.rs
+++ b/cli/src/installer.rs
@@ -254,6 +254,38 @@ pub fn remove_item(
     let remove_skills = kind.is_none_or(|kind| kind == ItemKind::Skill);
     let remove_hooks = kind.is_none_or(|kind| kind == ItemKind::Hook);
 
+    // Snapshot canonical deletion targets BEFORE harness links are removed:
+    // an anchored root's copy is deletable only while a requested harness's
+    // link still proves this entry uses that root for this skill — a
+    // same-named install belonging to another harness in the other checkout
+    // must not be reached just because the requested harness shares there.
+    let canonical_skill_paths: Vec<PathBuf> = if !remove_skills {
+        Vec::new()
+    } else if global {
+        vec![
+            crate::config::global_state_dir().join("skills").join(name),
+            crate::config::codex_home_dir().join("skills").join(name),
+        ]
+    } else {
+        let mut paths = vec![
+            crate::config::project_root()
+                .join(".agents")
+                .join("skills")
+                .join(name),
+        ];
+        for (root, sharing) in anchored_canonical_skill_roots(harnesses) {
+            let referenced = sharing.iter().any(|harness| {
+                let link = harness.skills_dir(false).join(name);
+                link.exists() || link.is_symlink()
+            });
+            let path = root.join(name);
+            if referenced && !paths.contains(&path) {
+                paths.push(path);
+            }
+        }
+        paths
+    };
+
     for harness in harnesses {
         // Agent files
         if remove_agents {
@@ -307,23 +339,6 @@ pub fn remove_item(
     }
 
     if remove_skills {
-        let canonical_skill_paths = if global {
-            vec![
-                crate::config::global_state_dir().join("skills").join(name),
-                crate::config::codex_home_dir().join("skills").join(name),
-            ]
-        } else {
-            // Symmetric with install_skill's anchoring: the canonical copy
-            // lives in the checkout where each harness link physically lands,
-            // so removal from a worktree must also clear a copy anchored in
-            // the main checkout — scoped to the requested harnesses, so a
-            // main-checkout install for other harnesses stays untouched.
-            project_canonical_skill_roots(harnesses)
-                .into_iter()
-                .map(|root| root.join(name))
-                .collect()
-        };
-
         for path in canonical_skill_paths {
             match remove_expected_path(&path, ExpectedArtifact::Any) {
                 Ok(true) => removed.push(path),
@@ -1365,6 +1380,76 @@ mod tests {
             "reconciliation from the worktree must not claim main's Codex-only install"
         );
         assert!(solo.join("SKILL.md").is_file());
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// Same-name collision across harnesses: scoping by harness set alone is
+    /// not enough when the REQUESTED harness shares into main but never
+    /// installed this skill — main's same-named copy belongs to another
+    /// harness's install. An anchored root's copy is deletable only while
+    /// the requesting harness's link proves this entry uses that root for
+    /// this skill.
+    #[cfg(unix)]
+    #[test]
+    fn remove_item_leaves_same_named_install_of_other_harness_in_main() {
+        use std::os::unix::fs::symlink;
+
+        let root = std::env::temp_dir().join(format!(
+            "vstack_worktree_name_collision_{}_{}",
+            std::process::id(),
+            crate::config::now_iso().replace([':', '-'], "")
+        ));
+        let main = root.join("main");
+        let wt = root.join("wt");
+        std::fs::create_dir_all(&main).unwrap();
+        if !init_repo_with_commit(&main) {
+            let _ = std::fs::remove_dir_all(&root);
+            return; // git unavailable on this host
+        }
+        assert!(git_ok(&main, &["worktree", "add", "-q", wt.to_str().unwrap()]));
+
+        let main_skills = main.join(".claude").join("skills");
+        std::fs::create_dir_all(&main_skills).unwrap();
+        std::fs::create_dir_all(wt.join(".claude")).unwrap();
+        symlink(&main_skills, wt.join(".claude").join("skills")).unwrap();
+        std::fs::create_dir_all(wt.join(".agents")).unwrap();
+
+        // Main-only Cursor install named "dupe": canonical copy + marker;
+        // Claude never installed it, so no link exists in the shared dir.
+        let dupe = main.join(".agents").join("skills").join("dupe");
+        std::fs::create_dir_all(&dupe).unwrap();
+        std::fs::write(dupe.join("SKILL.md"), "# dupe\n").unwrap();
+        std::fs::write(dupe.join(".vstack-refreshed"), "0").unwrap();
+
+        crate::test_util::with_project_root(&wt, || {
+            remove_item("dupe", Some(ItemKind::Skill), &[Harness::ClaudeCode], false).unwrap()
+        });
+        assert!(
+            dupe.join("SKILL.md").is_file(),
+            "a sharing harness that never installed this skill must not delete main's same-named copy"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// A cyclic dangling symlink chain must exhaust the resolution bound and
+    /// report failure rather than spinning or silently mis-resolving.
+    #[cfg(unix)]
+    #[test]
+    fn canonicalize_allowing_missing_fails_closed_on_cyclic_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let root = std::env::temp_dir().join(format!(
+            "vstack_cyclic_symlinks_{}_{}",
+            std::process::id(),
+            crate::config::now_iso().replace([':', '-'], "")
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        symlink(root.join("b"), root.join("a")).unwrap();
+        symlink(root.join("a"), root.join("b")).unwrap();
+
+        assert!(canonicalize_allowing_missing(&root.join("a").join("child")).is_none());
 
         let _ = std::fs::remove_dir_all(&root);
     }

--- a/cli/src/installer.rs
+++ b/cli/src/installer.rs
@@ -131,10 +131,15 @@ pub fn install_skill(
             // first install.
             let project_checkout = std::fs::canonicalize(crate::config::project_root())
                 .unwrap_or_else(|_| normalize_absolute_path(&crate::config::project_root()));
-            let mut foreign_existing = link_home
-                .as_ref()
-                .is_some_and(|home| home.checkout_root != project_checkout)
-                && canonical.exists();
+            // Foreignness is a property of where the canonical PHYSICALLY
+            // resolves, not of the harness link: with a shared `.agents` but
+            // a local harness dir, link_home is None while the canonical
+            // still lives in the main checkout — treating it as own would
+            // remove_existing another checkout's copy.
+            let canonical_physical = canonicalize_allowing_missing(&canonical)
+                .unwrap_or_else(|| normalize_absolute_path(&canonical));
+            let mut foreign_existing =
+                !canonical_physical.starts_with(&project_checkout) && canonical.exists();
             if foreign_existing
                 && std::fs::symlink_metadata(&canonical)
                     .is_ok_and(|meta| meta.file_type().is_symlink())
@@ -152,14 +157,26 @@ pub fn install_skill(
                 foreign_existing = false;
             }
             if foreign_existing && !canonical.join("SKILL.md").is_file() {
-                // Write-shy protects the owning checkout's valid installs; a
-                // canonical without SKILL.md was never one, and linking to it
-                // AS-IS ships a broken skill. Repair it from source instead.
-                eprintln!(
-                    "  Warning: existing canonical {} has no SKILL.md; repairing it from source (VST-195)",
-                    canonical.display()
-                );
-                foreign_existing = false;
+                if canonical.join(".vstack-refreshed").exists() {
+                    // Write-shy protects the owning checkout's valid
+                    // installs; a MARKED canonical without SKILL.md was a
+                    // vstack install that lost its payload — repair it from
+                    // source rather than linking to it AS-IS.
+                    eprintln!(
+                        "  Warning: existing canonical {} has no SKILL.md; repairing it from source (VST-195)",
+                        canonical.display()
+                    );
+                    foreign_existing = false;
+                } else {
+                    // No SKILL.md AND no managed marker: this directory in
+                    // another checkout is not provably a vstack install —
+                    // deleting it could destroy manually maintained data
+                    // that merely shares the skill's name. Refuse loudly.
+                    anyhow::bail!(
+                        "existing directory {} in another checkout has neither SKILL.md nor a vstack marker — refusing to replace what may not be a vstack install; remove or rename it there first",
+                        canonical.display()
+                    );
+                }
             }
             let marker = canonical.join(".vstack-refreshed");
             let current_pid = std::process::id().to_string();
@@ -397,7 +414,10 @@ pub fn remove_item(
         .iter()
         .filter_map(|harness| harness.skills_dir(false).canonicalize().ok())
         .collect();
-    let project_rel_skills: Vec<PathBuf> = harnesses
+    // EVERY harness's relative dir, not only the ones being removed: the
+    // owner may reference the canonical through a harness absent from this
+    // removal (or from this worktree's lock entirely).
+    let project_rel_skills: Vec<PathBuf> = Harness::ALL
         .iter()
         .filter_map(|harness| {
             harness
@@ -422,8 +442,13 @@ pub fn remove_item(
             let survives_this_removal = candidate_parent_canon
                 .as_ref()
                 .is_some_and(|parent| !removing_parent_canons.contains(parent));
+            // Only a SYMLINK is affirmative owner evidence: for harnesses
+            // whose project artifact IS the canonical directory (Codex/Pi
+            // under .agents/skills), the canonical would otherwise count as
+            // referencing itself and no marker could ever clear.
             survives_this_removal
-                && std::fs::symlink_metadata(&candidate).is_ok()
+                && std::fs::symlink_metadata(&candidate)
+                    .is_ok_and(|meta| meta.file_type().is_symlink())
                 && candidate
                     .canonicalize()
                     .is_ok_and(|resolved| resolved == anchored_resolved)
@@ -470,7 +495,11 @@ pub fn remove_item(
         // Skill directories
         if remove_skills {
             let skill_path = harness.skills_dir(global).join(name);
-            // An anchored path is the preservation pass's to report and keep.
+            // An anchored path is the preservation pass's to report and
+            // keep. A shared-dir LINK is deliberately removable from the
+            // worktree: the owner's lock entry and canonical both survive,
+            // and its next refresh recreates the link — preserving it here
+            // would turn worktree removal into a silent no-op.
             if !resolves_to_anchored(&skill_path) {
                 match remove_expected_path(&skill_path, ExpectedArtifact::Any) {
                     Ok(true) => removed.push(skill_path),
@@ -2432,6 +2461,67 @@ mod tests {
         let _ = std::fs::remove_dir_all(&root);
     }
 
+    /// An UNMARKED same-named directory in another checkout is not provably
+    /// a vstack install — install must refuse rather than recursively
+    /// replace what may be manually maintained data.
+    #[cfg(unix)]
+    #[test]
+    fn install_skill_refuses_unmarked_foreign_name_collision() {
+        use std::os::unix::fs::symlink;
+
+        let root = std::env::temp_dir().join(format!(
+            "vstack_unmarked_foreign_{}_{}",
+            std::process::id(),
+            crate::config::now_iso().replace([':', '-'], "")
+        ));
+        let main = root.join("main");
+        let wt = root.join("wt");
+        std::fs::create_dir_all(&main).unwrap();
+        if !init_repo_with_commit(&main) {
+            let _ = std::fs::remove_dir_all(&root);
+            return; // git unavailable on this host
+        }
+        assert!(git_ok(&main, &["worktree", "add", "-q", wt.to_str().unwrap()]));
+
+        let main_skills = main.join(".claude").join("skills");
+        std::fs::create_dir_all(&main_skills).unwrap();
+        std::fs::create_dir_all(wt.join(".claude")).unwrap();
+        symlink(&main_skills, wt.join(".claude").join("skills")).unwrap();
+        std::fs::create_dir_all(wt.join(".agents")).unwrap();
+
+        // Manually maintained data in main that merely shares the name:
+        // no SKILL.md, no marker.
+        let canonical = main.join(".agents").join("skills").join("github");
+        std::fs::create_dir_all(&canonical).unwrap();
+        std::fs::write(canonical.join("precious.txt"), "handmade\n").unwrap();
+
+        let skill = write_skill_source(&root, "github");
+        let result = crate::test_util::with_project_root(&wt, || {
+            install_skill(
+                &skill,
+                Harness::ClaudeCode,
+                false,
+                InstallMethod::Symlink,
+                None,
+            )
+        });
+        let err = match result {
+            Ok(_) => panic!("expected the unmarked-collision refusal, got success"),
+            Err(err) => err,
+        };
+        assert!(
+            err.to_string().contains("refusing to replace"),
+            "expected the unmarked-collision refusal, got: {err}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(canonical.join("precious.txt")).unwrap(),
+            "handmade\n",
+            "the foreign directory must be untouched"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
     /// A "foreign canonical" whose final component is a SYMLINK is malformed:
     /// `exists()`/`is_file()` follow it, so the write-shy fast path would
     /// link through it to wherever it points (potentially outside the
@@ -2660,10 +2750,13 @@ mod tests {
         symlink(&main_skills, wt.join(".claude").join("skills")).unwrap();
         std::fs::create_dir_all(wt.join(".agents")).unwrap();
 
-        // Main's canonical pre-exists but is not a valid skill install.
+        // Main's canonical pre-exists MARKED but lost its payload — a
+        // vstack install to repair (an unmarked stranger refuses instead;
+        // see install_skill_refuses_unmarked_foreign_name_collision).
         let canonical = main.join(".agents").join("skills").join("github");
         std::fs::create_dir_all(&canonical).unwrap();
         std::fs::write(canonical.join("notes.txt"), "junk\n").unwrap();
+        std::fs::write(canonical.join(".vstack-refreshed"), "0").unwrap();
 
         let skill = write_skill_source(&root, "github");
         crate::test_util::with_project_root(&wt, || {

--- a/cli/src/installer.rs
+++ b/cli/src/installer.rs
@@ -58,9 +58,10 @@ pub fn install_agent(
 
 /// Install a skill directory to a specific harness.
 ///
-/// Symlink mode: copy to a canonical dir (`.agents/skills/<name>/`) within the
-/// project, then symlink from each harness-specific dir to the canonical copy.
-/// All paths stay within the project root — no external symlinks.
+/// Symlink mode: copy to a canonical dir (`.agents/skills/<name>/`) in the
+/// checkout where the harness link physically lands — the project root, or
+/// the same-repository checkout a worktree setup shares its harness dirs
+/// with — then symlink from each harness-specific dir to the canonical copy.
 ///
 /// Copy mode: copy directly to each harness dir.
 pub fn install_skill(
@@ -73,24 +74,42 @@ pub fn install_skill(
     validate_new_item_name(&skill.name)?;
     let dest = harness.install_skill(skill, global)?;
 
-    // Canonical location: .agents/skills/<name>/ (universal, like Vercel npx skills)
-    let canonical = if global && matches!(harness, Harness::Codex) {
-        crate::config::codex_home_dir()
-            .join("skills")
-            .join(&skill.name)
-    } else if global {
-        crate::config::global_state_dir()
-            .join("skills")
-            .join(&skill.name)
-    } else {
-        crate::config::project_root()
-            .join(".agents")
-            .join("skills")
-            .join(&skill.name)
-    };
-
     let detail = match method {
         InstallMethod::Symlink => {
+            // Where the link physically lands. Worktree setups symlink
+            // harness dirs into the main checkout (vstack#886), so this can
+            // be a different checkout of the same repository than the
+            // project root the command ran from.
+            let link_home = if global {
+                None
+            } else {
+                dest.parent().and_then(same_repo_link_home)
+            };
+
+            // Canonical location: .agents/skills/<name>/ (universal, like
+            // Vercel npx skills). For project scope the copy must live in
+            // the checkout where the link physically lands: the link's
+            // relative spelling resolves from there, and a copy left in the
+            // worktree would leave the main checkout's link pointing at
+            // state that dies with the worktree (VST-195).
+            let canonical = if global && matches!(harness, Harness::Codex) {
+                crate::config::codex_home_dir()
+                    .join("skills")
+                    .join(&skill.name)
+            } else if global {
+                crate::config::global_state_dir()
+                    .join("skills")
+                    .join(&skill.name)
+            } else {
+                link_home
+                    .as_ref()
+                    .map(|home| home.checkout_root.clone())
+                    .unwrap_or_else(crate::config::project_root)
+                    .join(".agents")
+                    .join("skills")
+                    .join(&skill.name)
+            };
+
             // Step 1: Copy to canonical location (refresh from source).
             // Use a marker file to avoid re-copying if another harness
             // already refreshed the canonical in this process.
@@ -113,8 +132,15 @@ pub fn install_skill(
                 let _ = std::fs::write(&marker, std::process::id().to_string());
             }
 
-            // Step 2: If this harness IS the canonical path, we're done
-            if dest == canonical {
+            // Step 2: If this harness IS the canonical path — by spelling,
+            // or physically because a shared `.agents` already places dest
+            // at the canonical copy — we're done. Linking a physically
+            // canonical dest would replace the copy with a self-referential
+            // symlink.
+            let physically_canonical = link_home
+                .as_ref()
+                .is_some_and(|home| home.physical_parent.join(&skill.name) == canonical);
+            if dest == canonical || physically_canonical {
                 format!(
                     "{} → {} (canonical, {})",
                     skill.name,
@@ -128,12 +154,36 @@ pub fn install_skill(
                 }
                 remove_existing(&dest)?;
 
-                let repo_anchor = (!global).then(crate::config::project_root);
-                let rel = relative_path(dest.parent().unwrap(), &canonical, repo_anchor.as_deref())?;
                 #[cfg(unix)]
-                std::os::unix::fs::symlink(&rel, &dest).with_context(|| {
-                    format!("symlinking {} → {}", dest.display(), rel.display())
-                })?;
+                {
+                    let rel = match &link_home {
+                        // The repo layout is identical in every checkout, so
+                        // the relative spelling computed at the link's
+                        // physical home resolves there — worktree-independent.
+                        Some(home) => {
+                            let rel = lexical_relative(&home.physical_parent, &canonical);
+                            if home.physical_parent.join(&rel).is_dir() {
+                                rel
+                            } else {
+                                // Never emit a relative spelling whose target
+                                // does not exist from the link's physical
+                                // landing point.
+                                let abs = std::fs::canonicalize(&canonical)
+                                    .unwrap_or_else(|_| canonical.clone());
+                                eprintln!(
+                                    "  Warning: skill link {} cannot anchor inside its own checkout (VST-195); using absolute target {}",
+                                    dest.display(),
+                                    abs.display()
+                                );
+                                abs
+                            }
+                        }
+                        None => relative_path(dest.parent().unwrap(), &canonical)?,
+                    };
+                    std::os::unix::fs::symlink(&rel, &dest).with_context(|| {
+                        format!("symlinking {} → {}", dest.display(), rel.display())
+                    })?;
+                }
 
                 #[cfg(not(unix))]
                 copy_dir(&canonical, &dest)?;
@@ -383,47 +433,57 @@ fn normalize_absolute_path(path: &Path) -> PathBuf {
     normalized
 }
 
-/// Symlink target spelling for a link created in `from` pointing at `to`.
-///
-/// `repo_anchor` is the root whose repository the link must stay inside —
-/// the project root for project-scope installs, `None` for global scope.
-/// Worktree setups symlink shared harness dirs into the main checkout
-/// (vstack#886), so `from` may physically live in a different checkout than
-/// its apparent path. The repo layout is identical in every worktree, so as
-/// long as an endpoint's physical home is a worktree of the anchor's own
-/// repository, the lexical relative spelling resolves correctly from
-/// whichever checkout the link physically lands in. A canonicalized target
-/// here would anchor shared main-checkout state to the worktree that ran the
-/// refresh and dangle when that worktree is removed (VST-195).
-///
-/// An endpoint that escapes to an unrelated tree (for example a `.claude`
-/// dir symlinked into a dotfiles checkout) keeps the previous behavior: an
-/// absolute physical target rather than a relative path computed across
-/// unrelated roots.
-fn relative_path(from: &Path, to: &Path, repo_anchor: Option<&Path>) -> Result<PathBuf> {
+/// The physical home of a project-scope harness link whose parent directory
+/// is symlinked into another checkout of the same repository.
+struct LinkHome {
+    /// Canonical directory the link is physically created in.
+    physical_parent: PathBuf,
+    /// Root of the same-repository checkout containing `physical_parent`.
+    checkout_root: PathBuf,
+}
+
+/// Detect worktree indirection under `dest_parent`. Worktree setups symlink
+/// shared harness dirs into the main checkout (vstack#886), so a link created
+/// at an apparent worktree path may physically land in another checkout of
+/// the project's repository. Returns `None` for the ordinary case (no symlink
+/// indirection) and for indirection into unrelated trees (for example a
+/// `.claude` dir symlinked into a dotfiles checkout), both of which keep
+/// `relative_path`'s behavior.
+fn same_repo_link_home(dest_parent: &Path) -> Option<LinkHome> {
+    let lexical = normalize_absolute_path(dest_parent);
+    let physical = std::fs::canonicalize(dest_parent).ok()?;
+    if physical == lexical {
+        return None;
+    }
+    let project_root = crate::config::project_root();
+    if !crate::path_safety::is_same_repository_worktree(&project_root, &physical) {
+        return None;
+    }
+    let checkout_root = crate::path_safety::git_worktree_root(&physical)?;
+    Some(LinkHome {
+        physical_parent: physical,
+        checkout_root,
+    })
+}
+
+#[cfg(unix)]
+fn relative_path(from: &Path, to: &Path) -> Result<PathBuf> {
     let from_lexical = normalize_absolute_path(from);
     let from_canonical = std::fs::canonicalize(from).unwrap_or_else(|_| from_lexical.clone());
-    let to_lexical = normalize_absolute_path(to);
-    let to_canonical = std::fs::canonicalize(to).unwrap_or_else(|_| to_lexical.clone());
+    let to = std::fs::canonicalize(to).unwrap_or_else(|_| normalize_absolute_path(to));
 
-    let stays_in_repo = |lexical: &Path, canonical: &Path| {
-        lexical == canonical
-            || repo_anchor.is_some_and(|anchor| {
-                crate::path_safety::is_same_repository_worktree(anchor, canonical)
-            })
-    };
-
-    if !stays_in_repo(&from_lexical, &from_canonical) {
-        return Ok(to_canonical);
+    // If the apparent parent path differs from the real containing directory
+    // (for example because an ancestor is a symlink), prefer an absolute
+    // target over a confusing relative path that is computed from the real
+    // path. Same-repository worktree indirection never reaches this branch:
+    // install_skill resolves those links against their physical home first.
+    if from_canonical != from_lexical {
+        return Ok(to);
     }
-    let to = if stays_in_repo(&to_lexical, &to_canonical) {
-        to_lexical
-    } else {
-        to_canonical
-    };
     Ok(lexical_relative(&from_lexical, &to))
 }
 
+#[cfg(unix)]
 fn lexical_relative(from: &Path, to: &Path) -> PathBuf {
     let from_parts: Vec<_> = from.components().collect();
     let to_parts: Vec<_> = to.components().collect();
@@ -697,6 +757,7 @@ mod tests {
         let _ = std::fs::remove_dir_all(&root);
     }
 
+    #[cfg(unix)]
     #[test]
     fn relative_path_uses_relative_target_for_normal_directories() {
         let root = std::env::temp_dir().join(format!(
@@ -709,7 +770,7 @@ mod tests {
         std::fs::create_dir_all(&from).unwrap();
         std::fs::create_dir_all(&to).unwrap();
 
-        let rel = relative_path(&from, &to, None).unwrap();
+        let rel = relative_path(&from, &to).unwrap();
         assert_eq!(rel, PathBuf::from("../../config/skills/rust-runtime"));
 
         let _ = std::fs::remove_dir_all(&root);
@@ -734,7 +795,7 @@ mod tests {
         std::fs::create_dir_all(&target).unwrap();
         symlink(&real_parent, &apparent_parent).unwrap();
 
-        let rel = relative_path(&apparent_parent, &target, None).unwrap();
+        let rel = relative_path(&apparent_parent, &target).unwrap();
         assert!(
             rel.is_absolute(),
             "expected absolute symlink target, got {rel:?}"
@@ -787,17 +848,16 @@ mod tests {
         }
     }
 
-    /// A parent symlinked into another worktree of the anchor's repository
-    /// must keep the lexical relative spelling instead of bailing to an
-    /// absolute target — the repo-relative layout is identical in every
-    /// checkout, so the relative link resolves wherever it physically lands.
+    /// A harness dir symlinked into the main checkout must be detected as
+    /// same-repo indirection, resolving to main's physical dir and checkout
+    /// root; a real (non-symlinked) dir has no separate physical home.
     #[cfg(unix)]
     #[test]
-    fn relative_path_stays_lexical_when_parent_symlinks_into_same_repo_worktree() {
+    fn same_repo_link_home_resolves_worktree_parent_to_main_checkout() {
         use std::os::unix::fs::symlink;
 
         let root = std::env::temp_dir().join(format!(
-            "vstack_relative_path_worktree_{}_{}",
+            "vstack_link_home_worktree_{}_{}",
             std::process::id(),
             crate::config::now_iso().replace([':', '-'], "")
         ));
@@ -814,20 +874,72 @@ mod tests {
         std::fs::create_dir_all(&main_skills).unwrap();
         std::fs::create_dir_all(wt.join(".claude")).unwrap();
         symlink(&main_skills, wt.join(".claude").join("skills")).unwrap();
-        let target = wt.join(".agents").join("skills").join("github");
-        std::fs::create_dir_all(&target).unwrap();
+        std::fs::create_dir_all(wt.join(".agents").join("skills")).unwrap();
 
-        let rel = relative_path(&wt.join(".claude").join("skills"), &target, Some(&wt)).unwrap();
-        assert_eq!(rel, PathBuf::from("../../.agents/skills/github"));
+        let shared = crate::test_util::with_project_root(&wt, || {
+            same_repo_link_home(&wt.join(".claude").join("skills"))
+        })
+        .expect("shared harness dir must resolve to a same-repo link home");
+        assert_eq!(shared.physical_parent, main_skills.canonicalize().unwrap());
+        assert_eq!(shared.checkout_root, main.canonicalize().unwrap());
+
+        let local = crate::test_util::with_project_root(&wt, || {
+            same_repo_link_home(&wt.join(".agents").join("skills"))
+        });
+        assert!(local.is_none(), "real dir must not get a link home");
 
         let _ = std::fs::remove_dir_all(&root);
     }
 
-    /// VST-195: a refresh run from a git worktree whose `.claude/skills` is
-    /// symlinked into the main checkout must not anchor the main checkout's
-    /// skill links in the worktree — those links dangle the moment the
-    /// worktree is removed. The link physically lands in main, so its target
-    /// must be the repo-relative spelling that resolves inside main.
+    /// Fully shared `.agents`: for Codex/Pi the harness dest IS the canonical
+    /// copy, just spelled through the worktree's `.agents` symlink. Install
+    /// must recognize the physical identity and keep the real directory — a
+    /// naive dest != canonical comparison would replace the copy with a
+    /// self-referential symlink.
+    #[cfg(unix)]
+    #[test]
+    fn install_skill_does_not_self_link_a_physically_canonical_dest() {
+        use std::os::unix::fs::symlink;
+
+        let root = std::env::temp_dir().join(format!(
+            "vstack_worktree_self_link_{}_{}",
+            std::process::id(),
+            crate::config::now_iso().replace([':', '-'], "")
+        ));
+        let main = root.join("main");
+        let wt = root.join("wt");
+        std::fs::create_dir_all(&main).unwrap();
+        if !init_repo_with_commit(&main) {
+            let _ = std::fs::remove_dir_all(&root);
+            return; // git unavailable on this host
+        }
+        assert!(git_ok(&main, &["worktree", "add", "-q", wt.to_str().unwrap()]));
+
+        std::fs::create_dir_all(main.join(".agents").join("skills")).unwrap();
+        symlink(main.join(".agents"), wt.join(".agents")).unwrap();
+
+        let skill = write_skill_source(&root, "github");
+        crate::test_util::with_project_root(&wt, || {
+            install_skill(&skill, Harness::Codex, false, InstallMethod::Symlink, None).unwrap()
+        });
+
+        let canonical = main.join(".agents").join("skills").join("github");
+        let meta = std::fs::symlink_metadata(&canonical).unwrap();
+        assert!(
+            meta.file_type().is_dir(),
+            "canonical copy must stay a real directory, not a symlink"
+        );
+        assert!(canonical.join("SKILL.md").is_file());
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// VST-195, split layout (worktree config.md "Symlink entries that shadow
+    /// tracked content"): `.agents` holds tracked content, so it stays a REAL
+    /// directory in the worktree while `.claude/skills` is shared into the
+    /// main checkout. The harness link physically lands in main, so both the
+    /// link spelling and the canonical copy backing it must anchor in main —
+    /// a copy left in the worktree dies with the worktree.
     #[cfg(unix)]
     #[test]
     fn install_skill_from_worktree_keeps_main_checkout_links_repo_local() {
@@ -847,9 +959,6 @@ mod tests {
         }
         assert!(git_ok(&main, &["worktree", "add", "-q", wt.to_str().unwrap()]));
 
-        // Provision the worktree the way the `worktree` skill does: the
-        // harness skills dir is shared into the main checkout. `.agents`
-        // stays a real directory here — the failure mode observed downstream.
         let main_skills = main.join(".claude").join("skills");
         std::fs::create_dir_all(&main_skills).unwrap();
         std::fs::create_dir_all(wt.join(".claude")).unwrap();
@@ -879,6 +988,22 @@ mod tests {
             target,
             PathBuf::from("../../.agents/skills/github"),
             "main-checkout link must use the repo-relative spelling"
+        );
+        assert!(
+            main.join(".agents/skills/github/SKILL.md").is_file(),
+            "canonical copy must land in the checkout where the link landed"
+        );
+        let resolved = link.canonicalize().unwrap();
+        assert!(
+            resolved.starts_with(main.canonicalize().unwrap()),
+            "link must resolve inside the main checkout, got {resolved:?}"
+        );
+
+        // Everything must keep resolving after the worktree is gone.
+        std::fs::remove_dir_all(&wt).unwrap();
+        assert!(
+            link.canonicalize().unwrap().join("SKILL.md").is_file(),
+            "main-checkout link must survive worktree removal"
         );
 
         let _ = std::fs::remove_dir_all(&root);

--- a/cli/src/installer.rs
+++ b/cli/src/installer.rs
@@ -376,6 +376,21 @@ pub fn remove_item(
         // own remove collects it.
         for anchored in &anchored_canonicals {
             if anchored.exists() {
+                // Clear the managed marker so the owning checkout's
+                // reconciliation does not adopt (resurrect) a copy that may
+                // have existed solely for this worktree's install. A
+                // checkout that still references the skill re-marks it on
+                // its next refresh; its lock entries survive regardless,
+                // since the stale gate checks existence, not the marker.
+                let marker = anchored.join(".vstack-refreshed");
+                if let Err(err) = std::fs::remove_file(&marker)
+                    && err.kind() != std::io::ErrorKind::NotFound
+                {
+                    eprintln!(
+                        "  Warning: could not clear managed marker {}: {err}",
+                        marker.display()
+                    );
+                }
                 eprintln!(
                     "  Note: leaving canonical copy {} in place — it may back that checkout's own installs; remove it from that checkout to delete it (VST-195)",
                     anchored.display()
@@ -504,25 +519,84 @@ pub(crate) fn anchored_canonical_skill_roots(
     harnesses: &[Harness],
 ) -> Vec<(PathBuf, Vec<Harness>)> {
     let mut anchored: Vec<(PathBuf, Vec<Harness>)> = Vec::new();
-    let mut probed: Vec<(PathBuf, Option<PathBuf>)> = Vec::new();
+    let mut probed: Vec<(PathBuf, Vec<PathBuf>)> = Vec::new();
     for harness in harnesses {
         let dir = harness.skills_dir(false);
-        let root = match probed.iter().find(|(probed_dir, _)| *probed_dir == dir) {
+        let roots = match probed.iter().find(|(probed_dir, _)| *probed_dir == dir) {
             Some((_, cached)) => cached.clone(),
             None => {
-                let root = same_repo_link_home(&dir)
-                    .map(|home| home.checkout_root.join(".agents").join("skills"));
-                probed.push((dir, root.clone()));
-                root
+                let roots = match same_repo_link_home(&dir) {
+                    Some(home) => vec![home.checkout_root.join(".agents").join("skills")],
+                    // Partial sharing keeps the dir real and links each
+                    // skill CHILD into the shared checkout; the children
+                    // are then the only evidence of the anchor.
+                    None => child_level_anchored_roots(&dir),
+                };
+                probed.push((dir, roots.clone()));
+                roots
             }
         };
-        let Some(root) = root else { continue };
-        match anchored.iter_mut().find(|(anchored_root, _)| *anchored_root == root) {
-            Some((_, sharing)) => sharing.push(*harness),
-            None => anchored.push((root, vec![*harness])),
+        for root in roots {
+            match anchored
+                .iter_mut()
+                .find(|(anchored_root, _)| *anchored_root == root)
+            {
+                Some((_, sharing)) => {
+                    if !sharing.contains(harness) {
+                        sharing.push(*harness);
+                    }
+                }
+                None => anchored.push((root, vec![*harness])),
+            }
         }
     }
     anchored
+}
+
+/// Anchored roots reachable through child-level skill links in `dir`,
+/// including DANGLING children whose canonical is already gone — pruning
+/// must still classify those under a managed root. Non-symlink children are
+/// skipped without any git probing, so ordinary layouts pay one read_dir.
+fn child_level_anchored_roots(dir: &Path) -> Vec<PathBuf> {
+    let mut roots: Vec<PathBuf> = Vec::new();
+    let mut probed_parents: Vec<(PathBuf, Option<PathBuf>)> = Vec::new();
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return roots;
+    };
+    for entry in entries.flatten() {
+        let child = entry.path();
+        let Ok(meta) = std::fs::symlink_metadata(&child) else {
+            continue;
+        };
+        if !meta.file_type().is_symlink() {
+            continue;
+        }
+        let lexical = normalize_absolute_path(&child);
+        let Some(physical) = canonicalize_allowing_missing(&child) else {
+            continue;
+        };
+        if physical == lexical {
+            continue;
+        }
+        let Some(parent) = physical.parent().map(Path::to_path_buf) else {
+            continue;
+        };
+        let root = match probed_parents.iter().find(|(probed, _)| *probed == parent) {
+            Some((_, cached)) => cached.clone(),
+            None => {
+                let root = anchored_link_home(parent.clone())
+                    .map(|home| home.checkout_root.join(".agents").join("skills"));
+                probed_parents.push((parent, root.clone()));
+                root
+            }
+        };
+        if let Some(root) = root
+            && !roots.contains(&root)
+        {
+            roots.push(root);
+        }
+    }
+    roots
 }
 
 /// The physical home of a project-scope harness link whose parent directory
@@ -1310,6 +1384,121 @@ mod tests {
             outcome.anchored_left.contains(&expected),
             "the anchor must be resolved before unlinking destroys the evidence, got {:?}",
             outcome.anchored_left
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// A canonical copy that existed SOLELY for this worktree's install must
+    /// not resurrect after removal: the owning checkout's reconciliation
+    /// adopts any marked dir in its own root (deliberately — see
+    /// reconcile_does_not_attribute_orphaned_skill_to_source_hint), so the
+    /// foreign remover must clear the managed marker on the copy it leaves
+    /// behind. A checkout that still references the skill re-marks it on its
+    /// next refresh.
+    #[cfg(unix)]
+    #[test]
+    fn foreign_removal_does_not_let_owning_checkout_resurrect_the_skill() {
+        use std::os::unix::fs::symlink;
+
+        let root = std::env::temp_dir().join(format!(
+            "vstack_worktree_resurrect_{}_{}",
+            std::process::id(),
+            crate::config::now_iso().replace([':', '-'], "")
+        ));
+        let main = root.join("main");
+        let wt = root.join("wt");
+        std::fs::create_dir_all(&main).unwrap();
+        if !init_repo_with_commit(&main) {
+            let _ = std::fs::remove_dir_all(&root);
+            return; // git unavailable on this host
+        }
+        assert!(git_ok(&main, &["worktree", "add", "-q", wt.to_str().unwrap()]));
+
+        let main_skills = main.join(".claude").join("skills");
+        std::fs::create_dir_all(&main_skills).unwrap();
+        std::fs::create_dir_all(wt.join(".claude")).unwrap();
+        symlink(&main_skills, wt.join(".claude").join("skills")).unwrap();
+        std::fs::create_dir_all(wt.join(".agents")).unwrap();
+
+        // Skill exists only for the worktree's Claude install, anchored in
+        // main; then the worktree removes it.
+        let skill = write_skill_source(&root, "github");
+        crate::test_util::with_project_root(&wt, || {
+            install_skill(
+                &skill,
+                Harness::ClaudeCode,
+                false,
+                InstallMethod::Symlink,
+                None,
+            )
+            .unwrap()
+        });
+        crate::test_util::with_project_root(&wt, || {
+            remove_item(
+                "github",
+                Some(ItemKind::Skill),
+                &[Harness::ClaudeCode],
+                false,
+            )
+            .unwrap()
+        });
+        assert!(
+            main.join(".agents/skills/github/SKILL.md").is_file(),
+            "conservative rule leaves the copy in place"
+        );
+
+        // The owning checkout's reconciliation must not adopt it back.
+        let mut lock = LockFile::default();
+        crate::test_util::with_project_root(&main, || {
+            crate::config::reconcile_lock_with_disk(&mut lock, false, "source")
+        });
+        assert!(
+            !lock.entries.contains_key("github"),
+            "owning checkout must not resurrect the removed skill"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// Anchored-root discovery must see child-level anchors: in the
+    /// partial-sharing layout a dangling child link (its external canonical
+    /// already deleted) is the ONLY evidence of the anchor, and without it
+    /// the pruning pass cannot classify the link under a managed root.
+    #[cfg(unix)]
+    #[test]
+    fn reconcile_prunes_dangling_child_link_after_canonical_removal() {
+        use std::os::unix::fs::symlink;
+
+        let root = std::env::temp_dir().join(format!(
+            "vstack_worktree_dangling_child_{}_{}",
+            std::process::id(),
+            crate::config::now_iso().replace([':', '-'], "")
+        ));
+        let main = root.join("main");
+        let wt = root.join("wt");
+        std::fs::create_dir_all(&main).unwrap();
+        if !init_repo_with_commit(&main) {
+            let _ = std::fs::remove_dir_all(&root);
+            return; // git unavailable on this host
+        }
+        assert!(git_ok(&main, &["worktree", "add", "-q", wt.to_str().unwrap()]));
+
+        // Partial sharing: real .agents/skills, child linked into main —
+        // whose canonical has since been deleted, dangling the child.
+        std::fs::create_dir_all(main.join(".agents").join("skills")).unwrap();
+        std::fs::create_dir_all(wt.join(".agents").join("skills")).unwrap();
+        let child = wt.join(".agents").join("skills").join("github");
+        symlink(main.join(".agents").join("skills").join("github"), &child).unwrap();
+
+        let mut lock = LockFile::default();
+        crate::test_util::with_project_root(&wt, || {
+            crate::config::reconcile_lock_with_disk(&mut lock, false, "source")
+        });
+
+        assert!(
+            std::fs::symlink_metadata(&child).is_err(),
+            "dangling child link must be pruned once its anchor is classified"
         );
 
         let _ = std::fs::remove_dir_all(&root);

--- a/cli/src/installer.rs
+++ b/cli/src/installer.rs
@@ -137,9 +137,14 @@ pub fn install_skill(
             // at the canonical copy — we're done. Linking a physically
             // canonical dest would replace the copy with a self-referential
             // symlink.
-            let physically_canonical = link_home
-                .as_ref()
-                .is_some_and(|home| home.physical_parent.join(&skill.name) == canonical);
+            let physically_canonical = link_home.as_ref().is_some_and(|home| {
+                // Compare physical locations, not spellings: the constructed
+                // canonical path may run through a symlinked `.agents` while
+                // physical_parent is already resolved.
+                let canonical_physical = canonicalize_allowing_missing(&canonical)
+                    .unwrap_or_else(|| normalize_absolute_path(&canonical));
+                home.physical_parent.join(&skill.name) == canonical_physical
+            });
             if dest == canonical || physically_canonical {
                 format!(
                     "{} → {} (canonical, {})",
@@ -308,12 +313,14 @@ pub fn remove_item(
                 crate::config::codex_home_dir().join("skills").join(name),
             ]
         } else {
-            vec![
-                crate::config::project_root()
-                    .join(".agents")
-                    .join("skills")
-                    .join(name),
-            ]
+            // Symmetric with install_skill's anchoring: the canonical copy
+            // lives in the checkout where each harness link physically lands,
+            // so removal from a worktree must also clear a copy anchored in
+            // the main checkout — not just the project-rooted one.
+            project_canonical_skill_roots()
+                .into_iter()
+                .map(|root| root.join(name))
+                .collect()
         };
 
         for path in canonical_skill_paths {
@@ -433,6 +440,30 @@ fn normalize_absolute_path(path: &Path) -> PathBuf {
     normalized
 }
 
+/// Every `.agents/skills` root a project-scope canonical skill copy may live
+/// in: the project's own, plus the anchored root of any same-repository
+/// checkout a shared harness dir physically lands in (VST-195). Install
+/// anchors per harness link; removal and lock reconciliation consult this
+/// full set so all three agree on where a canonical copy may live.
+pub(crate) fn project_canonical_skill_roots() -> Vec<PathBuf> {
+    let mut roots = vec![crate::config::project_root().join(".agents").join("skills")];
+    let mut probed: Vec<PathBuf> = Vec::new();
+    for harness in Harness::ALL {
+        let dir = harness.skills_dir(false);
+        if probed.contains(&dir) {
+            continue;
+        }
+        probed.push(dir.clone());
+        if let Some(home) = same_repo_link_home(&dir) {
+            let root = home.checkout_root.join(".agents").join("skills");
+            if !roots.contains(&root) {
+                roots.push(root);
+            }
+        }
+    }
+    roots
+}
+
 /// The physical home of a project-scope harness link whose parent directory
 /// is symlinked into another checkout of the same repository.
 struct LinkHome {
@@ -446,24 +477,76 @@ struct LinkHome {
 /// shared harness dirs into the main checkout (vstack#886), so a link created
 /// at an apparent worktree path may physically land in another checkout of
 /// the project's repository. Returns `None` for the ordinary case (no symlink
-/// indirection) and for indirection into unrelated trees (for example a
-/// `.claude` dir symlinked into a dotfiles checkout), both of which keep
+/// indirection), for indirection into unrelated trees (for example a
+/// `.claude` dir symlinked into a dotfiles checkout), and for a checkout
+/// whose `.agents` fails the containment boundary — all of which keep
 /// `relative_path`'s behavior.
 fn same_repo_link_home(dest_parent: &Path) -> Option<LinkHome> {
     let lexical = normalize_absolute_path(dest_parent);
-    let physical = std::fs::canonicalize(dest_parent).ok()?;
+    let physical = canonicalize_allowing_missing(dest_parent)?;
     if physical == lexical {
         return None;
     }
-    let project_root = crate::config::project_root();
-    if !crate::path_safety::is_same_repository_worktree(&project_root, &physical) {
+    // git needs an existing directory; the harness dir itself may not exist
+    // on the physical side yet.
+    let mut probe = physical.as_path();
+    while !probe.is_dir() {
+        probe = probe.parent()?;
+    }
+    let project_common = crate::path_safety::git_common_dir(&crate::config::project_root())?;
+    let (probe_common, checkout_root) = crate::path_safety::git_repo_identity(probe)?;
+    if probe_common != project_common {
         return None;
     }
-    let checkout_root = crate::path_safety::git_worktree_root(&physical)?;
+    // Anchoring writes beneath the other checkout's .agents, so it gets the
+    // same containment boundary the project's own .agents writes get. An
+    // escaping .agents must never be written through.
+    if let Err(err) = crate::path_safety::ensure_agents_dir_within_project(&checkout_root) {
+        eprintln!(
+            "  Warning: not anchoring skills in {}: {err} (VST-195)",
+            checkout_root.display()
+        );
+        return None;
+    }
     Some(LinkHome {
         physical_parent: physical,
         checkout_root,
     })
+}
+
+/// Canonicalize `path`, tolerating missing trailing components: the nearest
+/// resolvable ancestor is canonicalized and the missing remainder re-appended.
+/// Symlinked ancestors still redirect — a shared `.claude` whose `skills`
+/// child does not exist yet must resolve to the shared side, and a dangling
+/// symlink is followed by hand rather than mistaken for its apparent path.
+fn canonicalize_allowing_missing(path: &Path) -> Option<PathBuf> {
+    let mut missing: Vec<std::ffi::OsString> = Vec::new();
+    let mut current = path.to_path_buf();
+    // Bounded like the kernel's symlink-resolution limit so a dangling
+    // symlink cycle cannot spin forever.
+    for _ in 0..40 {
+        match std::fs::canonicalize(&current) {
+            Ok(mut resolved) => {
+                for name in missing.iter().rev() {
+                    resolved.push(name);
+                }
+                return Some(resolved);
+            }
+            Err(_) => {
+                if let Ok(target) = std::fs::read_link(&current) {
+                    current = if target.is_absolute() {
+                        target
+                    } else {
+                        current.parent()?.join(target)
+                    };
+                    continue;
+                }
+                missing.push(current.file_name()?.to_os_string());
+                current = current.parent()?.to_path_buf();
+            }
+        }
+    }
+    None
 }
 
 #[cfg(unix)]
@@ -887,6 +970,311 @@ mod tests {
             same_repo_link_home(&wt.join(".agents").join("skills"))
         });
         assert!(local.is_none(), "real dir must not get a link home");
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// Removal must be symmetric with install's anchoring: a skill installed
+    /// from a worktree in the split layout places the canonical copy in the
+    /// MAIN checkout, so removal from the worktree must clear the main-side
+    /// canonical copy (and the worktree's own, if any) along with the link —
+    /// leaving nothing behind in either checkout.
+    #[cfg(unix)]
+    #[test]
+    fn remove_item_clears_canonical_copies_in_every_anchored_checkout() {
+        use std::os::unix::fs::symlink;
+
+        let root = std::env::temp_dir().join(format!(
+            "vstack_worktree_remove_symmetry_{}_{}",
+            std::process::id(),
+            crate::config::now_iso().replace([':', '-'], "")
+        ));
+        let main = root.join("main");
+        let wt = root.join("wt");
+        std::fs::create_dir_all(&main).unwrap();
+        if !init_repo_with_commit(&main) {
+            let _ = std::fs::remove_dir_all(&root);
+            return; // git unavailable on this host
+        }
+        assert!(git_ok(&main, &["worktree", "add", "-q", wt.to_str().unwrap()]));
+
+        let main_skills = main.join(".claude").join("skills");
+        std::fs::create_dir_all(&main_skills).unwrap();
+        std::fs::create_dir_all(wt.join(".claude")).unwrap();
+        symlink(&main_skills, wt.join(".claude").join("skills")).unwrap();
+        std::fs::create_dir_all(wt.join(".agents")).unwrap();
+
+        let skill = write_skill_source(&root, "github");
+        crate::test_util::with_project_root(&wt, || {
+            install_skill(
+                &skill,
+                Harness::ClaudeCode,
+                false,
+                InstallMethod::Symlink,
+                None,
+            )
+            .unwrap()
+        });
+        assert!(main.join(".agents/skills/github/SKILL.md").is_file());
+
+        crate::test_util::with_project_root(&wt, || {
+            remove_item(
+                "github",
+                Some(ItemKind::Skill),
+                &[Harness::ClaudeCode],
+                false,
+            )
+            .unwrap()
+        });
+
+        assert!(
+            std::fs::symlink_metadata(main_skills.join("github")).is_err(),
+            "harness link must be removed"
+        );
+        assert!(
+            std::fs::symlink_metadata(main.join(".agents/skills/github")).is_err(),
+            "main checkout's canonical copy must be removed"
+        );
+        assert!(
+            std::fs::symlink_metadata(wt.join(".agents/skills/github")).is_err(),
+            "worktree's canonical copy must be removed"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// Anchoring in another checkout must apply the same `.agents`
+    /// containment boundary the project's own writes get: when that
+    /// checkout's `.agents` symlinks outside the repository, no write may
+    /// follow it — install falls back to the unanchored path.
+    #[cfg(unix)]
+    #[test]
+    fn install_skill_never_writes_through_an_escaping_agents_in_the_link_checkout() {
+        use std::os::unix::fs::symlink;
+
+        let root = std::env::temp_dir().join(format!(
+            "vstack_worktree_escaping_agents_{}_{}",
+            std::process::id(),
+            crate::config::now_iso().replace([':', '-'], "")
+        ));
+        let main = root.join("main");
+        let wt = root.join("wt");
+        let outside = root.join("outside");
+        std::fs::create_dir_all(&main).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        if !init_repo_with_commit(&main) {
+            let _ = std::fs::remove_dir_all(&root);
+            return; // git unavailable on this host
+        }
+        assert!(git_ok(&main, &["worktree", "add", "-q", wt.to_str().unwrap()]));
+
+        let main_skills = main.join(".claude").join("skills");
+        std::fs::create_dir_all(&main_skills).unwrap();
+        std::fs::create_dir_all(wt.join(".claude")).unwrap();
+        symlink(&main_skills, wt.join(".claude").join("skills")).unwrap();
+        std::fs::create_dir_all(wt.join(".agents")).unwrap();
+        // Main's .agents escapes the repository entirely.
+        symlink(&outside, main.join(".agents")).unwrap();
+
+        let skill = write_skill_source(&root, "github");
+        crate::test_util::with_project_root(&wt, || {
+            install_skill(
+                &skill,
+                Harness::ClaudeCode,
+                false,
+                InstallMethod::Symlink,
+                None,
+            )
+            .unwrap()
+        });
+
+        assert_eq!(
+            std::fs::read_dir(&outside).unwrap().count(),
+            0,
+            "no write may land outside the repository"
+        );
+        // Fallback taken: unanchored canonical in the worktree, absolute link
+        // target (the pre-anchoring behavior, with a warning on stderr).
+        assert!(wt.join(".agents/skills/github/SKILL.md").is_file());
+        let target = std::fs::read_link(main_skills.join("github")).unwrap();
+        assert!(
+            target.is_absolute() && target.starts_with(&wt),
+            "expected absolute fallback target into the worktree, got {target:?}"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// Sharing the whole `.claude` dir leaves `main/.claude/skills` absent
+    /// until first install; the redirect must still be detected by resolving
+    /// through the nearest existing ancestor, and the install must create and
+    /// anchor everything on the main side.
+    #[cfg(unix)]
+    #[test]
+    fn install_skill_resolves_link_home_through_missing_harness_dir() {
+        use std::os::unix::fs::symlink;
+
+        let root = std::env::temp_dir().join(format!(
+            "vstack_worktree_missing_leaf_{}_{}",
+            std::process::id(),
+            crate::config::now_iso().replace([':', '-'], "")
+        ));
+        let main = root.join("main");
+        let wt = root.join("wt");
+        std::fs::create_dir_all(&main).unwrap();
+        if !init_repo_with_commit(&main) {
+            let _ = std::fs::remove_dir_all(&root);
+            return; // git unavailable on this host
+        }
+        assert!(git_ok(&main, &["worktree", "add", "-q", wt.to_str().unwrap()]));
+
+        // Whole .claude shared; skills subdir does not exist yet anywhere.
+        std::fs::create_dir_all(main.join(".claude")).unwrap();
+        symlink(main.join(".claude"), wt.join(".claude")).unwrap();
+        std::fs::create_dir_all(wt.join(".agents")).unwrap();
+
+        let skill = write_skill_source(&root, "github");
+        crate::test_util::with_project_root(&wt, || {
+            install_skill(
+                &skill,
+                Harness::ClaudeCode,
+                false,
+                InstallMethod::Symlink,
+                None,
+            )
+            .unwrap()
+        });
+
+        assert!(
+            main.join(".agents/skills/github/SKILL.md").is_file(),
+            "canonical copy must anchor in the main checkout"
+        );
+        let link = main.join(".claude").join("skills").join("github");
+        assert_eq!(
+            std::fs::read_link(&link).unwrap(),
+            PathBuf::from("../../.agents/skills/github")
+        );
+        assert!(link.canonicalize().unwrap().join("SKILL.md").is_file());
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// Reconciliation must agree with install's anchoring: a skill installed
+    /// only for a shared-into-main harness has its sole canonical copy in the
+    /// MAIN checkout, and a reconcile pass run from the worktree must not
+    /// treat it as missing and drop the lock entry.
+    #[cfg(unix)]
+    #[test]
+    fn reconcile_keeps_lock_entry_for_skill_anchored_in_main_checkout() {
+        use std::os::unix::fs::symlink;
+
+        let root = std::env::temp_dir().join(format!(
+            "vstack_worktree_reconcile_{}_{}",
+            std::process::id(),
+            crate::config::now_iso().replace([':', '-'], "")
+        ));
+        let main = root.join("main");
+        let wt = root.join("wt");
+        std::fs::create_dir_all(&main).unwrap();
+        if !init_repo_with_commit(&main) {
+            let _ = std::fs::remove_dir_all(&root);
+            return; // git unavailable on this host
+        }
+        assert!(git_ok(&main, &["worktree", "add", "-q", wt.to_str().unwrap()]));
+
+        let main_skills = main.join(".claude").join("skills");
+        std::fs::create_dir_all(&main_skills).unwrap();
+        std::fs::create_dir_all(wt.join(".claude")).unwrap();
+        symlink(&main_skills, wt.join(".claude").join("skills")).unwrap();
+        std::fs::create_dir_all(wt.join(".agents")).unwrap();
+
+        let skill = write_skill_source(&root, "github");
+        crate::test_util::with_project_root(&wt, || {
+            install_skill(
+                &skill,
+                Harness::ClaudeCode,
+                false,
+                InstallMethod::Symlink,
+                None,
+            )
+            .unwrap()
+        });
+        assert!(main.join(".agents/skills/github/.vstack-refreshed").is_file());
+        assert!(
+            !wt.join(".agents/skills/github").exists(),
+            "split layout: no worktree-local canonical copy"
+        );
+
+        let mut lock = LockFile::default();
+        lock.add(LockEntry {
+            name: "github".into(),
+            kind: ItemKind::Skill,
+            source: "source".into(),
+            source_repo: None,
+            harnesses: vec![Harness::ClaudeCode.id().to_string()],
+            method: InstallMethod::Symlink,
+            installed_at: "2026-08-10T00:00:00Z".into(),
+            source_hash: String::new(),
+        });
+        crate::test_util::with_project_root(&wt, || {
+            crate::config::reconcile_lock_with_disk(&mut lock, false, "source")
+        });
+
+        assert!(
+            lock.entries.contains_key("github"),
+            "lock entry must survive reconciliation from the worktree"
+        );
+        assert!(
+            main.join(".agents/skills/github/SKILL.md").is_file(),
+            "main checkout's canonical copy must survive reconciliation"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// The physically-canonical guard must compare physical locations, not
+    /// spellings: with `.agents` itself a symlink (`main/.agents ->
+    /// main/agents-store`), the constructed canonical spelling and the
+    /// resolved dest differ as strings while naming the same directory. Raw
+    /// equality misses, and install would delete the canonical copy and
+    /// self-link it.
+    #[cfg(unix)]
+    #[test]
+    fn install_skill_does_not_self_link_through_a_symlinked_agents_spelling() {
+        use std::os::unix::fs::symlink;
+
+        let root = std::env::temp_dir().join(format!(
+            "vstack_worktree_agents_spelling_{}_{}",
+            std::process::id(),
+            crate::config::now_iso().replace([':', '-'], "")
+        ));
+        let main = root.join("main");
+        let wt = root.join("wt");
+        std::fs::create_dir_all(&main).unwrap();
+        if !init_repo_with_commit(&main) {
+            let _ = std::fs::remove_dir_all(&root);
+            return; // git unavailable on this host
+        }
+        assert!(git_ok(&main, &["worktree", "add", "-q", wt.to_str().unwrap()]));
+
+        // Main spells its .agents through a symlink to a real store inside
+        // the checkout; the worktree chains through it.
+        std::fs::create_dir_all(main.join("agents-store").join("skills")).unwrap();
+        symlink(main.join("agents-store"), main.join(".agents")).unwrap();
+        symlink(main.join(".agents"), wt.join(".agents")).unwrap();
+
+        let skill = write_skill_source(&root, "github");
+        crate::test_util::with_project_root(&wt, || {
+            install_skill(&skill, Harness::Codex, false, InstallMethod::Symlink, None).unwrap()
+        });
+
+        let canonical = main.join("agents-store").join("skills").join("github");
+        let meta = std::fs::symlink_metadata(&canonical).unwrap();
+        assert!(
+            meta.file_type().is_dir(),
+            "canonical copy must stay a real directory, not a symlink"
+        );
+        assert!(canonical.join("SKILL.md").is_file());
 
         let _ = std::fs::remove_dir_all(&root);
     }

--- a/cli/src/installer.rs
+++ b/cli/src/installer.rs
@@ -595,8 +595,28 @@ pub fn remove_item(
             // The project-spelled canonical resolves to a FOREIGN anchored
             // canonical when `.agents` itself is symlinked into the shared
             // checkout; deleting through that ancestor would destroy the copy
-            // the preservation pass below promises to leave in place.
+            // the preservation pass below promises to leave in place. The
+            // same shield covers a final-component SYMLINK whose parent
+            // physically lives in the other checkout: that entry is the
+            // owner's project-skills-dir canonical wiring, not ours to
+            // unlink (unlike harness links, no owner refresh recreates a
+            // hand-authored canonical spelling).
             if resolves_to_anchored(&path) {
+                continue;
+            }
+            let parent_foreign = path
+                .parent()
+                .and_then(|parent| parent.canonicalize().ok())
+                .is_some_and(|parent| {
+                    let project_checkout = std::fs::canonicalize(crate::config::project_root())
+                        .unwrap_or_else(|_| normalize_absolute_path(&crate::config::project_root()));
+                    !parent.starts_with(&project_checkout)
+                });
+            if parent_foreign && std::fs::symlink_metadata(&path).is_ok() {
+                eprintln!(
+                    "  Note: leaving {} in place — it lives in another checkout's .agents; remove it from that checkout to delete it (VST-195)",
+                    path.display()
+                );
                 continue;
             }
             match remove_expected_path(&path, ExpectedArtifact::Any) {
@@ -771,6 +791,12 @@ pub(crate) type AnchorSharing = Vec<(Harness, AnchorEvidence)>;
 pub(crate) fn anchored_canonical_skill_roots(
     harnesses: &[Harness],
 ) -> Vec<(PathBuf, AnchorSharing)> {
+    // Contract: OTHER checkouts' roots only. An ordinary child link
+    // (`.claude/skills/foo -> ../../.agents/skills/foo`) resolves to the
+    // CURRENT checkout and must not report the project's own canonical
+    // root as anchored.
+    let own_root = std::fs::canonicalize(crate::config::project_root())
+        .unwrap_or_else(|_| normalize_absolute_path(&crate::config::project_root()));
     let mut anchored: Vec<(PathBuf, AnchorSharing)> = Vec::new();
     let mut probed: Vec<(PathBuf, Vec<(PathBuf, AnchorEvidence)>)> = Vec::new();
     for harness in harnesses {
@@ -793,6 +819,11 @@ pub(crate) fn anchored_canonical_skill_roots(
             }
         };
         for (root, evidence) in roots {
+            let root_physical = canonicalize_allowing_missing(&root)
+                .unwrap_or_else(|| normalize_absolute_path(&root));
+            if root_physical.starts_with(&own_root) {
+                continue;
+            }
             match anchored
                 .iter_mut()
                 .find(|(anchored_root, _)| *anchored_root == root)

--- a/cli/src/installer.rs
+++ b/cli/src/installer.rs
@@ -316,8 +316,9 @@ pub fn remove_item(
             // Symmetric with install_skill's anchoring: the canonical copy
             // lives in the checkout where each harness link physically lands,
             // so removal from a worktree must also clear a copy anchored in
-            // the main checkout — not just the project-rooted one.
-            project_canonical_skill_roots()
+            // the main checkout — scoped to the requested harnesses, so a
+            // main-checkout install for other harnesses stays untouched.
+            project_canonical_skill_roots(harnesses)
                 .into_iter()
                 .map(|root| root.join(name))
                 .collect()
@@ -440,25 +441,48 @@ fn normalize_absolute_path(path: &Path) -> PathBuf {
     normalized
 }
 
-/// Every `.agents/skills` root a project-scope canonical skill copy may live
-/// in: the project's own, plus the anchored root of any same-repository
-/// checkout a shared harness dir physically lands in (VST-195). Install
-/// anchors per harness link; removal and lock reconciliation consult this
-/// full set so all three agree on where a canonical copy may live.
-pub(crate) fn project_canonical_skill_roots() -> Vec<PathBuf> {
-    let mut roots = vec![crate::config::project_root().join(".agents").join("skills")];
-    let mut probed: Vec<PathBuf> = Vec::new();
-    for harness in Harness::ALL {
+/// Anchored `.agents/skills` roots for `harnesses`' project skill dirs: each
+/// same-repository checkout root one of those dirs physically lands in
+/// (VST-195), paired with the harnesses that land there. The project's own
+/// root is not included. A copy in another checkout is part of this
+/// project's view only through a harness that shares into that checkout, so
+/// removal and reconciliation must scope root derivation to the harness set
+/// actually in play — an unscoped derivation would let a worktree operation
+/// reach a main-checkout install that exists only for other harnesses.
+pub(crate) fn anchored_canonical_skill_roots(
+    harnesses: &[Harness],
+) -> Vec<(PathBuf, Vec<Harness>)> {
+    let mut anchored: Vec<(PathBuf, Vec<Harness>)> = Vec::new();
+    let mut probed: Vec<(PathBuf, Option<PathBuf>)> = Vec::new();
+    for harness in harnesses {
         let dir = harness.skills_dir(false);
-        if probed.contains(&dir) {
-            continue;
-        }
-        probed.push(dir.clone());
-        if let Some(home) = same_repo_link_home(&dir) {
-            let root = home.checkout_root.join(".agents").join("skills");
-            if !roots.contains(&root) {
-                roots.push(root);
+        let root = match probed.iter().find(|(probed_dir, _)| *probed_dir == dir) {
+            Some((_, cached)) => cached.clone(),
+            None => {
+                let root = same_repo_link_home(&dir)
+                    .map(|home| home.checkout_root.join(".agents").join("skills"));
+                probed.push((dir, root.clone()));
+                root
             }
+        };
+        let Some(root) = root else { continue };
+        match anchored.iter_mut().find(|(anchored_root, _)| *anchored_root == root) {
+            Some((_, sharing)) => sharing.push(*harness),
+            None => anchored.push((root, vec![*harness])),
+        }
+    }
+    anchored
+}
+
+/// Every `.agents/skills` root a canonical copy for `harnesses` may live in:
+/// the project's own, plus the anchored roots those harnesses land in.
+/// Install anchors per harness link; removal and lock reconciliation consult
+/// this set so all three agree on where a canonical copy may live.
+pub(crate) fn project_canonical_skill_roots(harnesses: &[Harness]) -> Vec<PathBuf> {
+    let mut roots = vec![crate::config::project_root().join(".agents").join("skills")];
+    for (root, _) in anchored_canonical_skill_roots(harnesses) {
+        if !roots.contains(&root) {
+            roots.push(root);
         }
     }
     roots
@@ -1275,6 +1299,64 @@ mod tests {
             "canonical copy must stay a real directory, not a symlink"
         );
         assert!(canonical.join("SKILL.md").is_file());
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// Anchored roots must be scoped to the harnesses actually in play: with
+    /// only `.claude/skills` shared, a main-checkout skill that exists solely
+    /// for Codex (whose project dir is worktree-local) is main's own install.
+    /// Removing that name from the worktree scoped to Codex must not reach
+    /// into main, and a reconcile pass from the worktree must not claim it.
+    #[cfg(unix)]
+    #[test]
+    fn worktree_operations_leave_other_harness_installs_in_main_untouched() {
+        use std::os::unix::fs::symlink;
+
+        let root = std::env::temp_dir().join(format!(
+            "vstack_worktree_harness_scope_{}_{}",
+            std::process::id(),
+            crate::config::now_iso().replace([':', '-'], "")
+        ));
+        let main = root.join("main");
+        let wt = root.join("wt");
+        std::fs::create_dir_all(&main).unwrap();
+        if !init_repo_with_commit(&main) {
+            let _ = std::fs::remove_dir_all(&root);
+            return; // git unavailable on this host
+        }
+        assert!(git_ok(&main, &["worktree", "add", "-q", wt.to_str().unwrap()]));
+
+        let main_skills = main.join(".claude").join("skills");
+        std::fs::create_dir_all(&main_skills).unwrap();
+        std::fs::create_dir_all(wt.join(".claude")).unwrap();
+        symlink(&main_skills, wt.join(".claude").join("skills")).unwrap();
+        std::fs::create_dir_all(wt.join(".agents")).unwrap();
+
+        // Main's own Codex-only install: canonical copy with marker, no
+        // harness link visible through any shared dir, nothing in the wt.
+        let solo = main.join(".agents").join("skills").join("solo");
+        std::fs::create_dir_all(&solo).unwrap();
+        std::fs::write(solo.join("SKILL.md"), "# solo\n").unwrap();
+        std::fs::write(solo.join(".vstack-refreshed"), "0").unwrap();
+
+        crate::test_util::with_project_root(&wt, || {
+            remove_item("solo", Some(ItemKind::Skill), &[Harness::Codex], false).unwrap()
+        });
+        assert!(
+            solo.join("SKILL.md").is_file(),
+            "removal scoped to a non-sharing harness must not delete main's install"
+        );
+
+        let mut lock = LockFile::default();
+        crate::test_util::with_project_root(&wt, || {
+            crate::config::reconcile_lock_with_disk(&mut lock, false, "source")
+        });
+        assert!(
+            !lock.entries.contains_key("solo"),
+            "reconciliation from the worktree must not claim main's Codex-only install"
+        );
+        assert!(solo.join("SKILL.md").is_file());
 
         let _ = std::fs::remove_dir_all(&root);
     }

--- a/cli/src/installer.rs
+++ b/cli/src/installer.rs
@@ -138,23 +138,59 @@ pub fn install_skill(
             // remove_existing another checkout's copy.
             let canonical_physical = canonicalize_allowing_missing(&canonical)
                 .unwrap_or_else(|| normalize_absolute_path(&canonical));
-            let mut foreign_existing =
-                !canonical_physical.starts_with(&project_checkout) && canonical.exists();
+            // ... but a canonical THIS project already references is OURS to
+            // refresh wherever it physically lives: the worktree that
+            // installed through a shared layout must keep receiving source
+            // updates (write-shy is for canonicals we find, not ones we
+            // made). The dest artifact resolving to the canonical is that
+            // ownership evidence.
+            // Ownership evidence follows the anchor TYPE: SharedDir — the
+            // dest's PARENT directory itself resolves into the other
+            // checkout, so this project operates inside the shared surface
+            // and the canonical it references there is its own install to
+            // refresh. Children — a local parent whose final component
+            // links out — stays write-shy: that linked copy is the owning
+            // checkout's.
+            let dest_references_canonical = std::fs::symlink_metadata(&dest)
+                .is_ok_and(|meta| meta.file_type().is_symlink())
+                && dest
+                    .canonicalize()
+                    .is_ok_and(|resolved| resolved == canonical_physical)
+                && dest
+                    .parent()
+                    .and_then(|parent| parent.canonicalize().ok())
+                    .is_some_and(|parent| !parent.starts_with(&project_checkout));
+            let mut foreign_existing = !canonical_physical.starts_with(&project_checkout)
+                && !dest_references_canonical
+                && canonical.exists();
             if foreign_existing
                 && std::fs::symlink_metadata(&canonical)
                     .is_ok_and(|meta| meta.file_type().is_symlink())
             {
-                // exists()/is_file() follow symlinks: a malformed "canonical"
-                // whose final component is a symlink could smuggle the link
-                // target (possibly outside the repository) past the write-shy
-                // fast path and containment. A real canonical is a directory;
-                // a symlink there is repaired from source (remove_existing
-                // unlinks the symlink itself, never its target).
-                eprintln!(
-                    "  Warning: existing canonical {} is a symlink, not a directory; repairing it from source (VST-195)",
-                    canonical.display()
-                );
-                foreign_existing = false;
+                // A symlink canonical is legitimate when it stays inside its
+                // OWN checkout — the supported project-skills-dir layout
+                // spells `.agents/skills/<name>` as a link to the tracked
+                // project-owned skill. Only a link escaping its checkout is
+                // the smuggle case (exists()/is_file() would follow it past
+                // containment): that one is repaired from source
+                // (remove_existing unlinks the symlink itself, never its
+                // target).
+                let owning_checkout = canonical
+                    .parent()
+                    .and_then(Path::parent)
+                    .and_then(Path::parent)
+                    .and_then(|root| root.canonicalize().ok());
+                let escapes_checkout = match owning_checkout {
+                    Some(root) => !canonical_physical.starts_with(&root),
+                    None => true,
+                };
+                if escapes_checkout {
+                    eprintln!(
+                        "  Warning: existing canonical {} is a symlink escaping its checkout; repairing it from source (VST-195)",
+                        canonical.display()
+                    );
+                    foreign_existing = false;
+                }
             }
             if foreign_existing && !canonical.join("SKILL.md").is_file() {
                 if canonical.join(".vstack-refreshed").exists() {
@@ -2517,6 +2553,76 @@ mod tests {
             std::fs::read_to_string(canonical.join("precious.txt")).unwrap(),
             "handmade\n",
             "the foreign directory must be untouched"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// A worktree that INSTALLED through a fully shared harness dir owns
+    /// that anchored canonical: a second refresh must copy updated source,
+    /// not ride the write-shy fast path forever (SharedDir ownership
+    /// evidence — the dest's parent resolves into the shared checkout).
+    #[cfg(unix)]
+    #[test]
+    fn install_skill_refreshes_own_anchored_canonical_through_shared_dir() {
+        use std::os::unix::fs::symlink;
+
+        let root = std::env::temp_dir().join(format!(
+            "vstack_shared_refresh_{}_{}",
+            std::process::id(),
+            crate::config::now_iso().replace([':', '-'], "")
+        ));
+        let main = root.join("main");
+        let wt = root.join("wt");
+        std::fs::create_dir_all(&main).unwrap();
+        if !init_repo_with_commit(&main) {
+            let _ = std::fs::remove_dir_all(&root);
+            return; // git unavailable on this host
+        }
+        assert!(git_ok(&main, &["worktree", "add", "-q", wt.to_str().unwrap()]));
+
+        let main_skills = main.join(".claude").join("skills");
+        std::fs::create_dir_all(&main_skills).unwrap();
+        std::fs::create_dir_all(wt.join(".claude")).unwrap();
+        symlink(&main_skills, wt.join(".claude").join("skills")).unwrap();
+        std::fs::create_dir_all(wt.join(".agents")).unwrap();
+
+        let skill = write_skill_source(&root, "github");
+        crate::test_util::with_project_root(&wt, || {
+            install_skill(
+                &skill,
+                Harness::ClaudeCode,
+                false,
+                InstallMethod::Symlink,
+                None,
+            )
+            .unwrap()
+        });
+        let canonical = main.join(".agents").join("skills").join("github");
+        assert!(canonical.join("SKILL.md").is_file());
+
+        // Source changes; a NEW process refreshes (fresh PID → marker miss).
+        std::fs::write(
+            skill.source_dir.join("SKILL.md"),
+            "---\nname: github\ndescription: Updated\n---\n\n# github v2\n",
+        )
+        .unwrap();
+        let marker = canonical.join(".vstack-refreshed");
+        std::fs::write(&marker, "0").unwrap();
+        crate::test_util::with_project_root(&wt, || {
+            install_skill(
+                &skill,
+                Harness::ClaudeCode,
+                false,
+                InstallMethod::Symlink,
+                None,
+            )
+            .unwrap()
+        });
+        let refreshed = std::fs::read_to_string(canonical.join("SKILL.md")).unwrap();
+        assert!(
+            refreshed.contains("github v2"),
+            "the worktree's own anchored canonical must receive source updates, got: {refreshed}"
         );
 
         let _ = std::fs::remove_dir_all(&root);

--- a/cli/src/installer.rs
+++ b/cli/src/installer.rs
@@ -1072,17 +1072,23 @@ fn corresponding_project_root_in(checkout_toplevel: &Path) -> Option<PathBuf> {
 /// an alias, and treating it as a link home would delete/replace its
 /// children as if they were skill artifacts.
 fn is_recognized_skills_surface(checkout_root: &Path, physical_parent: &Path) -> bool {
+    // Compare against the LITERAL expected paths under the physically
+    // resolved checkout root — never canonicalize the candidates. Following
+    // a candidate symlink would make the alias validate itself: with
+    // `.claude/skills -> cli/src`, resolving `checkout/.claude/skills`
+    // yields exactly the aliased physical_parent being questioned.
+    let root_physical = std::fs::canonicalize(checkout_root)
+        .unwrap_or_else(|_| normalize_absolute_path(checkout_root));
     let project_root = crate::config::project_root();
-    let mut candidates = vec![checkout_root.join(".agents").join("skills")];
+    let mut expected = vec![root_physical.join(".agents").join("skills")];
     for harness in Harness::ALL {
         if let Ok(rel) = harness.skills_dir(false).strip_prefix(&project_root) {
-            candidates.push(checkout_root.join(rel));
+            expected.push(root_physical.join(rel));
         }
     }
-    candidates.into_iter().any(|candidate| {
-        canonicalize_allowing_missing(&candidate)
-            .is_some_and(|resolved| resolved == *physical_parent)
-    })
+    expected
+        .into_iter()
+        .any(|candidate| candidate == *physical_parent)
 }
 
 /// The physical home of a project-scope harness link whose parent directory

--- a/cli/src/installer.rs
+++ b/cli/src/installer.rs
@@ -151,15 +151,21 @@ pub fn install_skill(
             // refresh. Children — a local parent whose final component
             // links out — stays write-shy: that linked copy is the owning
             // checkout's.
-            let dest_references_canonical = std::fs::symlink_metadata(&dest)
-                .is_ok_and(|meta| meta.file_type().is_symlink())
+            let dest_parent_shared = dest
+                .parent()
+                .and_then(|parent| parent.canonicalize().ok())
+                .is_some_and(|parent| !parent.starts_with(&project_checkout));
+            let dest_references_canonical = dest_parent_shared
                 && dest
                     .canonicalize()
                     .is_ok_and(|resolved| resolved == canonical_physical)
-                && dest
-                    .parent()
-                    .and_then(|parent| parent.canonicalize().ok())
-                    .is_some_and(|parent| !parent.starts_with(&project_checkout));
+                && std::fs::symlink_metadata(&dest).is_ok_and(|meta| {
+                    // A symlink artifact in the shared surface, OR the
+                    // direct-canonical shape (Codex/Pi: dest IS the real
+                    // canonical dir reached through the shared `.agents`) —
+                    // both are this project's install to refresh.
+                    meta.file_type().is_symlink() || meta.file_type().is_dir()
+                });
             // Global installs live under user homes by definition — the
             // anchoring/write-shy machinery is project-scope only, and a
             // global Codex canonical (canonical == dest, outside any
@@ -180,11 +186,16 @@ pub fn install_skill(
                 // containment): that one is repaired from source
                 // (remove_existing unlinks the symlink itself, never its
                 // target).
+                // The owning root comes from the PARENT's physical home —
+                // the spelled path may run through this worktree's shared
+                // `.agents`, and spelled-parent canonicalization would name
+                // the worktree, misreading main's project-skills-dir
+                // symlink as escaping.
                 let owning_checkout = canonical
                     .parent()
-                    .and_then(Path::parent)
-                    .and_then(Path::parent)
-                    .and_then(|root| root.canonicalize().ok());
+                    .and_then(|parent| parent.canonicalize().ok())
+                    .and_then(|skills| skills.parent().map(Path::to_path_buf))
+                    .and_then(|agents| agents.parent().map(Path::to_path_buf));
                 let escapes_checkout = match owning_checkout {
                     Some(root) => !canonical_physical.starts_with(&root),
                     None => true,

--- a/cli/src/installer.rs
+++ b/cli/src/installer.rs
@@ -312,13 +312,20 @@ pub fn remove_item(
     } else {
         let mut canonicals: Vec<PathBuf> = Vec::new();
         let mut probed: Vec<PathBuf> = Vec::new();
+        // Anchored preservation is for OTHER checkouts' canonicals only: an
+        // ordinary project-scope child link also yields a LinkHome, but its
+        // checkout IS this project — admitting it would make every normal
+        // `vstack remove` skip deleting its own canonical (and clear its
+        // marker) while reporting success.
+        let project_checkout = std::fs::canonicalize(crate::config::project_root())
+            .unwrap_or_else(|_| normalize_absolute_path(&crate::config::project_root()));
         for harness in harnesses {
             let dest = harness.skills_dir(false).join(name);
             if probed.contains(&dest) {
                 continue;
             }
             probed.push(dest.clone());
-            if let Some(home) = skill_link_home(&dest) {
+            if let Some(home) = skill_link_home(&dest).filter(|home| home.checkout_root != project_checkout) {
                 let canonical = home
                     .checkout_root
                     .join(".agents")
@@ -2233,6 +2240,61 @@ mod tests {
         assert!(
             outcome.anchored_left.contains(&expected),
             "the surviving canonical must be reported, got {:?}",
+            outcome.anchored_left
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// An ordinary project-scope remove must DELETE its own canonical: the
+    /// child link's LinkHome names this project as checkout, and admitting
+    /// that into the anchored-preservation set would skip the canonical,
+    /// clear its marker, and still report success.
+    #[cfg(unix)]
+    #[test]
+    fn remove_item_deletes_own_canonical_for_ordinary_install() {
+        let root = std::env::temp_dir().join(format!(
+            "vstack_own_remove_{}_{}",
+            std::process::id(),
+            crate::config::now_iso().replace([':', '-'], "")
+        ));
+        let project = root.join("project");
+        std::fs::create_dir_all(&project).unwrap();
+        if !init_repo_with_commit(&project) {
+            let _ = std::fs::remove_dir_all(&root);
+            return; // git unavailable on this host
+        }
+
+        let skill = write_skill_source(&root, "github");
+        crate::test_util::with_project_root(&project, || {
+            install_skill(
+                &skill,
+                Harness::ClaudeCode,
+                false,
+                InstallMethod::Symlink,
+                None,
+            )
+            .unwrap()
+        });
+        let canonical = project.join(".agents").join("skills").join("github");
+        assert!(canonical.join("SKILL.md").is_file());
+
+        let outcome = crate::test_util::with_project_root(&project, || {
+            remove_item(
+                "github",
+                Some(ItemKind::Skill),
+                &[Harness::ClaudeCode],
+                false,
+            )
+            .unwrap()
+        });
+        assert!(
+            !canonical.exists(),
+            "an ordinary remove must delete the project's own canonical"
+        );
+        assert!(
+            outcome.anchored_left.is_empty(),
+            "nothing is anchored elsewhere in an ordinary remove, got {:?}",
             outcome.anchored_left
         );
 

--- a/cli/src/installer.rs
+++ b/cli/src/installer.rs
@@ -793,10 +793,9 @@ pub fn remove_item(
                     !parent.starts_with(&project_checkout)
                 });
             if parent_foreign && std::fs::symlink_metadata(&path).is_ok() {
-                eprintln!(
-                    "  Note: leaving {} in place — it lives in another checkout's .agents; remove it from that checkout to delete it (VST-195)",
-                    path.display()
-                );
+                // Recorded, never printed: remove_item runs on the TUI's
+                // worker thread in raw mode — callers render anchored_left.
+                anchored_left.push(path.clone());
                 continue;
             }
             match remove_expected_path(&path, ExpectedArtifact::Any) {

--- a/cli/src/installer.rs
+++ b/cli/src/installer.rs
@@ -539,7 +539,11 @@ pub fn remove_item(
             std::fs::read_to_string(&owner_lock)
                 .ok()
                 .and_then(|raw| serde_json::from_str::<crate::config::LockFile>(&raw).ok())
-                .is_some_and(|lock| lock.entries.contains_key(name.to_str().unwrap_or_default()))
+                .is_some_and(|lock| {
+                    lock.entries
+                        .get(name.to_str().unwrap_or_default())
+                        .is_some_and(|entry| entry.kind == crate::config::ItemKind::Skill)
+                })
         };
         if owner_still_references {
             continue;

--- a/cli/src/installer.rs
+++ b/cli/src/installer.rs
@@ -113,13 +113,27 @@ pub fn install_skill(
             // Foreign canonicals are write-shy: an existing canonical in
             // another checkout is linked to AS-IS — its content and marker
             // belong to that checkout's installs, and refreshing it is the
-            // owning checkout's job.
-            let foreign_existing = link_home.is_some() && canonical.exists();
+            // owning checkout's job. A LinkHome alone does not make the
+            // canonical foreign: an ordinary existing child link
+            // (`.claude/skills/<name>` → `../../.agents/skills/<name>`)
+            // resolves to a LinkHome whose checkout IS this project, and
+            // treating that as foreign would skip every refresh after the
+            // first install.
+            let project_checkout = std::fs::canonicalize(crate::config::project_root())
+                .unwrap_or_else(|_| normalize_absolute_path(&crate::config::project_root()));
+            let mut foreign_existing = link_home
+                .as_ref()
+                .is_some_and(|home| home.checkout_root != project_checkout)
+                && canonical.exists();
             if foreign_existing && !canonical.join("SKILL.md").is_file() {
+                // Write-shy protects the owning checkout's valid installs; a
+                // canonical without SKILL.md was never one, and linking to it
+                // AS-IS ships a broken skill. Repair it from source instead.
                 eprintln!(
-                    "  Warning: existing canonical {} has no SKILL.md; leaving it for its own checkout's refresh (VST-195)",
+                    "  Warning: existing canonical {} has no SKILL.md; repairing it from source (VST-195)",
                     canonical.display()
                 );
+                foreign_existing = false;
             }
             let marker = canonical.join(".vstack-refreshed");
             let current_pid = std::process::id().to_string();
@@ -313,6 +327,23 @@ pub fn remove_item(
         canonicals
     };
 
+    // A skill path whose final component is not itself a symlink can still
+    // RESOLVE to a snapshotted anchored canonical through a symlinked
+    // ancestor (a fully shared `.agents`): remove_expected_path would follow
+    // that ancestor and recursively delete the other checkout's copy before
+    // the preservation pass below could report it. Unlinking a symlink final
+    // component only removes the link itself and stays allowed.
+    let anchored_resolved: Vec<PathBuf> = anchored_canonicals
+        .iter()
+        .filter_map(|path| canonicalize_allowing_missing(path))
+        .collect();
+    let resolves_to_anchored = |path: &Path| -> bool {
+        !anchored_resolved.is_empty()
+            && !std::fs::symlink_metadata(path).is_ok_and(|meta| meta.file_type().is_symlink())
+            && canonicalize_allowing_missing(path)
+                .is_some_and(|resolved| anchored_resolved.contains(&resolved))
+    };
+
     for harness in harnesses {
         // Agent files
         if remove_agents {
@@ -341,15 +372,18 @@ pub fn remove_item(
         // Skill directories
         if remove_skills {
             let skill_path = harness.skills_dir(global).join(name);
-            match remove_expected_path(&skill_path, ExpectedArtifact::Any) {
-                Ok(true) => removed.push(skill_path),
-                Ok(false) => {}
-                Err(err) => cleanup_errors.push(format!(
-                    "skill {name} removal failed for {} {} scope at {}: {err:#}",
-                    harness.name(),
-                    if global { "global" } else { "project" },
-                    skill_path.display()
-                )),
+            // An anchored path is the preservation pass's to report and keep.
+            if !resolves_to_anchored(&skill_path) {
+                match remove_expected_path(&skill_path, ExpectedArtifact::Any) {
+                    Ok(true) => removed.push(skill_path),
+                    Ok(false) => {}
+                    Err(err) => cleanup_errors.push(format!(
+                        "skill {name} removal failed for {} {} scope at {}: {err:#}",
+                        harness.name(),
+                        if global { "global" } else { "project" },
+                        skill_path.display()
+                    )),
+                }
             }
         }
 
@@ -381,6 +415,13 @@ pub fn remove_item(
         };
 
         for path in canonical_skill_paths {
+            // The project-spelled canonical resolves to a FOREIGN anchored
+            // canonical when `.agents` itself is symlinked into the shared
+            // checkout; deleting through that ancestor would destroy the copy
+            // the preservation pass below promises to leave in place.
+            if resolves_to_anchored(&path) {
+                continue;
+            }
             match remove_expected_path(&path, ExpectedArtifact::Any) {
                 Ok(true) => removed.push(path),
                 Ok(false) => {}
@@ -2090,6 +2131,283 @@ mod tests {
         assert!(
             std::fs::symlink_metadata(&canonical).is_err(),
             "the owning checkout's removal must delete its canonical copy"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// Fully shared layout: the worktree's `.agents` is itself a symlink into
+    /// the main checkout, so the project-spelled canonical (and Codex/Pi's
+    /// skill dir, which is the same path) RESOLVES to the anchored canonical
+    /// through the symlinked ancestor. Deletion must not follow it —
+    /// `remove_dir_all` through that spelling destroys the main checkout's
+    /// copy before the preservation pass can report it.
+    #[cfg(unix)]
+    #[test]
+    fn remove_item_does_not_delete_foreign_canonical_through_shared_agents() {
+        use std::os::unix::fs::symlink;
+
+        let root = std::env::temp_dir().join(format!(
+            "vstack_worktree_shared_agents_remove_{}_{}",
+            std::process::id(),
+            crate::config::now_iso().replace([':', '-'], "")
+        ));
+        let main = root.join("main");
+        let wt = root.join("wt");
+        std::fs::create_dir_all(&main).unwrap();
+        if !init_repo_with_commit(&main) {
+            let _ = std::fs::remove_dir_all(&root);
+            return; // git unavailable on this host
+        }
+        assert!(git_ok(&main, &["worktree", "add", "-q", wt.to_str().unwrap()]));
+
+        let main_skills = main.join(".claude").join("skills");
+        std::fs::create_dir_all(&main_skills).unwrap();
+        std::fs::create_dir_all(wt.join(".claude")).unwrap();
+        symlink(&main_skills, wt.join(".claude").join("skills")).unwrap();
+        std::fs::create_dir_all(main.join(".agents").join("skills")).unwrap();
+        symlink(main.join(".agents"), wt.join(".agents")).unwrap();
+
+        let skill = write_skill_source(&root, "github");
+        crate::test_util::with_project_root(&wt, || {
+            install_skill(
+                &skill,
+                Harness::ClaudeCode,
+                false,
+                InstallMethod::Symlink,
+                None,
+            )
+            .unwrap()
+        });
+        let canonical = main.join(".agents").join("skills").join("github");
+        assert!(canonical.join("SKILL.md").is_file());
+
+        let outcome = crate::test_util::with_project_root(&wt, || {
+            remove_item(
+                "github",
+                Some(ItemKind::Skill),
+                &[Harness::ClaudeCode, Harness::Codex],
+                false,
+            )
+            .unwrap()
+        });
+
+        assert!(
+            std::fs::symlink_metadata(main_skills.join("github")).is_err(),
+            "the Claude link must be removed"
+        );
+        assert!(
+            canonical.join("SKILL.md").is_file(),
+            "deletion must not follow the shared .agents into the main checkout's canonical"
+        );
+        let expected = main
+            .canonicalize()
+            .unwrap()
+            .join(".agents")
+            .join("skills")
+            .join("github");
+        assert!(
+            outcome.anchored_left.contains(&expected),
+            "the surviving canonical must be reported, got {:?}",
+            outcome.anchored_left
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// An ordinary existing child link (`.claude/skills/<name>` →
+    /// `../../.agents/skills/<name>`) resolves to a LinkHome whose checkout
+    /// IS this project. That must not be mistaken for a foreign canonical:
+    /// write-shyness there would skip every refresh after the first install
+    /// while still reporting success.
+    #[cfg(unix)]
+    #[test]
+    fn install_skill_refreshes_own_canonical_behind_existing_child_link() {
+        let root = std::env::temp_dir().join(format!(
+            "vstack_own_canonical_refresh_{}_{}",
+            std::process::id(),
+            crate::config::now_iso().replace([':', '-'], "")
+        ));
+        let project = root.join("project");
+        std::fs::create_dir_all(&project).unwrap();
+        if !init_repo_with_commit(&project) {
+            let _ = std::fs::remove_dir_all(&root);
+            return; // git unavailable on this host
+        }
+
+        let skill = write_skill_source(&root, "github");
+        crate::test_util::with_project_root(&project, || {
+            install_skill(
+                &skill,
+                Harness::ClaudeCode,
+                false,
+                InstallMethod::Symlink,
+                None,
+            )
+            .unwrap()
+        });
+        let canonical = project.join(".agents").join("skills").join("github");
+        assert!(canonical.join("SKILL.md").is_file());
+
+        // A later run: the source changed and the same-process marker no
+        // longer matches.
+        std::fs::write(
+            skill.source_dir.join("SKILL.md"),
+            "---\nname: github\ndescription: Test skill\n---\n\n# github\n\nupdated body\n",
+        )
+        .unwrap();
+        std::fs::write(canonical.join(".vstack-refreshed"), "0").unwrap();
+
+        crate::test_util::with_project_root(&project, || {
+            install_skill(
+                &skill,
+                Harness::ClaudeCode,
+                false,
+                InstallMethod::Symlink,
+                None,
+            )
+            .unwrap()
+        });
+
+        let refreshed = std::fs::read_to_string(canonical.join("SKILL.md")).unwrap();
+        assert!(
+            refreshed.contains("updated body"),
+            "the project's own canonical must refresh from source, got: {refreshed}"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// Write-shyness protects the owning checkout's VALID installs. A foreign
+    /// canonical without SKILL.md was never one — linking to it AS-IS ships a
+    /// broken skill — so install must repair it from source instead.
+    #[cfg(unix)]
+    #[test]
+    fn install_skill_repairs_foreign_canonical_missing_skill_md() {
+        use std::os::unix::fs::symlink;
+
+        let root = std::env::temp_dir().join(format!(
+            "vstack_worktree_repair_canonical_{}_{}",
+            std::process::id(),
+            crate::config::now_iso().replace([':', '-'], "")
+        ));
+        let main = root.join("main");
+        let wt = root.join("wt");
+        std::fs::create_dir_all(&main).unwrap();
+        if !init_repo_with_commit(&main) {
+            let _ = std::fs::remove_dir_all(&root);
+            return; // git unavailable on this host
+        }
+        assert!(git_ok(&main, &["worktree", "add", "-q", wt.to_str().unwrap()]));
+
+        let main_skills = main.join(".claude").join("skills");
+        std::fs::create_dir_all(&main_skills).unwrap();
+        std::fs::create_dir_all(wt.join(".claude")).unwrap();
+        symlink(&main_skills, wt.join(".claude").join("skills")).unwrap();
+        std::fs::create_dir_all(wt.join(".agents")).unwrap();
+
+        // Main's canonical pre-exists but is not a valid skill install.
+        let canonical = main.join(".agents").join("skills").join("github");
+        std::fs::create_dir_all(&canonical).unwrap();
+        std::fs::write(canonical.join("notes.txt"), "junk\n").unwrap();
+
+        let skill = write_skill_source(&root, "github");
+        crate::test_util::with_project_root(&wt, || {
+            install_skill(
+                &skill,
+                Harness::ClaudeCode,
+                false,
+                InstallMethod::Symlink,
+                None,
+            )
+            .unwrap()
+        });
+
+        assert!(
+            canonical.join("SKILL.md").is_file(),
+            "an invalid foreign canonical must be repaired from source"
+        );
+        assert!(
+            !canonical.join("notes.txt").exists(),
+            "repair replaces the invalid directory wholesale"
+        );
+        let link = main_skills.join("github");
+        assert!(link.canonicalize().unwrap().join("SKILL.md").is_file());
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// Anchored recovery must scope the entry to the harnesses whose
+    /// artifacts RESOLVE to the canonical: a same-named copy-mode directory
+    /// for another harness is an independent install, and claiming it under
+    /// the recovered Symlink entry would let the next refresh replace the
+    /// copy with a link.
+    #[cfg(unix)]
+    #[test]
+    fn reconcile_scopes_anchored_recovery_to_resolving_harnesses() {
+        use std::os::unix::fs::symlink;
+
+        let root = std::env::temp_dir().join(format!(
+            "vstack_worktree_mixed_copy_recovery_{}_{}",
+            std::process::id(),
+            crate::config::now_iso().replace([':', '-'], "")
+        ));
+        let main = root.join("main");
+        let wt = root.join("wt");
+        std::fs::create_dir_all(&main).unwrap();
+        if !init_repo_with_commit(&main) {
+            let _ = std::fs::remove_dir_all(&root);
+            return; // git unavailable on this host
+        }
+        assert!(git_ok(&main, &["worktree", "add", "-q", wt.to_str().unwrap()]));
+
+        let main_skills = main.join(".claude").join("skills");
+        std::fs::create_dir_all(&main_skills).unwrap();
+        std::fs::create_dir_all(wt.join(".claude")).unwrap();
+        symlink(&main_skills, wt.join(".claude").join("skills")).unwrap();
+        std::fs::create_dir_all(wt.join(".agents").join("skills")).unwrap();
+
+        // Anchored canonical in main, referenced by the shared Claude link.
+        let canonical = main.join(".agents").join("skills").join("github");
+        std::fs::create_dir_all(&canonical).unwrap();
+        std::fs::write(canonical.join("SKILL.md"), "# github\n").unwrap();
+        std::fs::write(canonical.join(".vstack-refreshed"), "0").unwrap();
+        symlink(
+            PathBuf::from("../../.agents/skills/github"),
+            main_skills.join("github"),
+        )
+        .unwrap();
+
+        // Independent same-named copy-mode install for Cursor in the worktree.
+        let cursor_copy = wt.join(".cursor").join("rules").join("github");
+        std::fs::create_dir_all(&cursor_copy).unwrap();
+        std::fs::write(cursor_copy.join("SKILL.md"), "cursor copy\n").unwrap();
+        std::fs::write(cursor_copy.join(".vstack-refreshed"), "0").unwrap();
+
+        let mut lock = LockFile::default();
+        crate::test_util::with_project_root(&wt, || {
+            crate::config::reconcile_lock_with_disk(&mut lock, false, "source")
+        });
+
+        let entry = lock
+            .entries
+            .get("github")
+            .expect("anchored skill must be recovered");
+        assert!(
+            entry
+                .harnesses
+                .contains(&Harness::ClaudeCode.id().to_string()),
+            "the resolving harness must be recorded, got {:?}",
+            entry.harnesses
+        );
+        assert!(
+            !entry.harnesses.contains(&Harness::Cursor.id().to_string()),
+            "the independent copy install must not be claimed by the anchored entry, got {:?}",
+            entry.harnesses
+        );
+        assert_eq!(
+            std::fs::read_to_string(cursor_copy.join("SKILL.md")).unwrap(),
+            "cursor copy\n"
         );
 
         let _ = std::fs::remove_dir_all(&root);

--- a/cli/src/installer.rs
+++ b/cli/src/installer.rs
@@ -120,10 +120,10 @@ pub fn install_skill(
                     // or absent) says nothing about it.
                     let corresponding = corresponding_project_root_in(&checkout_toplevel);
                     match corresponding {
-                        Some(root) if root == project_canon => {}
                         Some(root) => {
-                            if crate::path_safety::ensure_agents_dir_within_project(&root)
-                                .is_err()
+                            if root != project_canon
+                                && crate::path_safety::ensure_agents_dir_within_project(&root)
+                                    .is_err()
                             {
                                 anyhow::bail!(
                                     "refusing to install {} through {}: that same-repository checkout's .agents fails validation, and falling back to an ordinary link would write a worktree-absolute target into it",
@@ -131,11 +131,14 @@ pub fn install_skill(
                                     root.display()
                                 );
                             }
-                            // Same-repository indirection whose landing
-                            // parent is NOT a recognized skills surface is an
-                            // alias (e.g. `.claude/skills -> <main>/cli/src`):
-                            // installing would remove_existing/replace
-                            // children of an arbitrary repository directory.
+                            // Symlink indirection whose landing parent is NOT
+                            // a recognized skills surface is an alias (e.g.
+                            // `.claude/skills -> cli/src`, same checkout or
+                            // another): installing would remove_existing/
+                            // replace children of an arbitrary repository
+                            // directory. Current-checkout indirection gets
+                            // the same gate — the fallback path would delete
+                            // through the alias just as readily.
                             if let Some(parent) = physical.parent()
                                 && !is_recognized_skills_surface(&root, parent)
                             {
@@ -799,11 +802,11 @@ pub fn remove_item(
                 // Marker already cleared before the unlink phase (a checkout
                 // that still references the skill re-marks it on its next
                 // refresh; lock entries survive regardless, since the stale
-                // gate checks existence, not the marker).
-                eprintln!(
-                    "  Note: leaving canonical copy {} in place — it may back that checkout's own installs; remove it from that checkout to delete it (VST-195)",
-                    anchored.display()
-                );
+                // gate checks existence, not the marker). No printing here:
+                // callers (CLI remove, TUI report) render anchored_left
+                // themselves — a direct eprintln would duplicate the notice
+                // and, from the TUI's worker thread, write into a raw-mode
+                // terminal.
                 anchored_left.push(anchored.clone());
             }
         }
@@ -1237,8 +1240,11 @@ fn relative_path(from: &Path, to: &Path) -> Result<PathBuf> {
     // If the apparent parent path differs from the real containing directory
     // (for example because an ancestor is a symlink), prefer an absolute
     // target over a confusing relative path that is computed from the real
-    // path. Same-repository worktree indirection never reaches this branch:
-    // install_skill resolves those links against their physical home first.
+    // path. Same-repository worktree indirection never reaches this branch —
+    // install_skill resolves those links against their physical home first —
+    // but the no-link_home case still does: unrelated-tree indirection (e.g.
+    // `.claude` symlinked into a dotfiles checkout) is exactly what this
+    // absolute fallback serves.
     if from_canonical != from_lexical {
         return Ok(to);
     }

--- a/cli/src/installer.rs
+++ b/cli/src/installer.rs
@@ -72,6 +72,16 @@ pub fn install_skill(
     instructions: Option<&str>,
 ) -> Result<InstallResult> {
     validate_new_item_name(&skill.name)?;
+    if !global && method == InstallMethod::Symlink {
+        // The containment preflight must also cover the invoking checkout's
+        // own canonical writes (link_home == None): without it, an aliased
+        // in-repo `.agents` (e.g. `.agents -> cli/src`) makes install create
+        // — and refresh later recursively replace — repository sources.
+        // Copy-mode installs never write through `.agents`, so they skip it
+        // (a copy install must keep working beside an unrelated linked
+        // agents root). In-project validation is pure path comparison.
+        crate::path_safety::ensure_agents_dir_within_project(&crate::config::project_root())?;
+    }
     let dest = harness.install_skill(skill, global)?;
 
     let detail = match method {
@@ -374,7 +384,53 @@ pub fn remove_item(
     // unlinked, the anchor evidence needed to rediscover these canonicals is
     // gone, so a post-unlink failure would be unrepairable by retry. Failing
     // here aborts with every link intact: fix the marker, run remove again.
+    //
+    // EXCEPT when the OWNING checkout itself still references the canonical
+    // (its own harness artifact resolves there): that install survives this
+    // removal, and clearing its marker would drop it from the owner's next
+    // disk recovery. This worktree's own links live under this project root,
+    // never the owning root, so they cannot count as survivors.
+    // Artifact dirs THIS removal will unlink (by physical parent): a shared
+    // dir means the owning root's spelling and our dest name the same file,
+    // which must not read as a surviving owner reference.
+    let removing_parent_canons: Vec<PathBuf> = harnesses
+        .iter()
+        .filter_map(|harness| harness.skills_dir(false).canonicalize().ok())
+        .collect();
+    let project_rel_skills: Vec<PathBuf> = harnesses
+        .iter()
+        .filter_map(|harness| {
+            harness
+                .skills_dir(false)
+                .strip_prefix(crate::config::project_root())
+                .ok()
+                .map(Path::to_path_buf)
+        })
+        .collect();
     for anchored in &anchored_canonicals {
+        let (Some(name), Some(owning_root)) = (
+            anchored.file_name(),
+            anchored.parent().and_then(Path::parent).and_then(Path::parent),
+        ) else {
+            continue;
+        };
+        let anchored_resolved = canonicalize_allowing_missing(anchored)
+            .unwrap_or_else(|| normalize_absolute_path(anchored));
+        let owner_still_references = project_rel_skills.iter().any(|rel| {
+            let candidate = owning_root.join(rel).join(name);
+            let candidate_parent_canon = owning_root.join(rel).canonicalize().ok();
+            let survives_this_removal = candidate_parent_canon
+                .as_ref()
+                .is_some_and(|parent| !removing_parent_canons.contains(parent));
+            survives_this_removal
+                && std::fs::symlink_metadata(&candidate).is_ok()
+                && candidate
+                    .canonicalize()
+                    .is_ok_and(|resolved| resolved == anchored_resolved)
+        });
+        if owner_still_references {
+            continue;
+        }
         let marker = anchored.join(".vstack-refreshed");
         if let Err(err) = std::fs::remove_file(&marker)
             && err.kind() != std::io::ErrorKind::NotFound
@@ -2011,10 +2067,13 @@ mod tests {
         }
         assert!(git_ok(&main, &["worktree", "add", "-q", wt.to_str().unwrap()]));
 
-        // Main spells its .agents through a symlink to a real store inside
-        // the checkout; the worktree chains through it.
-        std::fs::create_dir_all(main.join("agents-store").join("skills")).unwrap();
-        symlink(main.join("agents-store"), main.join(".agents")).unwrap();
+        // The worktree spells its .agents through the shared symlink into
+        // main's real .agents: the constructed canonical spelling
+        // (wt/.agents/skills/github) and the resolved dest differ as
+        // strings while naming the same directory. (An .agents aliased to
+        // an arbitrary in-repo store is NOT a supported layout — the
+        // canonical root identity gates in path_safety refuse it.)
+        std::fs::create_dir_all(main.join(".agents").join("skills")).unwrap();
         symlink(main.join(".agents"), wt.join(".agents")).unwrap();
 
         let skill = write_skill_source(&root, "github");
@@ -2022,7 +2081,7 @@ mod tests {
             install_skill(&skill, Harness::Codex, false, InstallMethod::Symlink, None).unwrap()
         });
 
-        let canonical = main.join("agents-store").join("skills").join("github");
+        let canonical = main.join(".agents").join("skills").join("github");
         let meta = std::fs::symlink_metadata(&canonical).unwrap();
         assert!(
             meta.file_type().is_dir(),
@@ -2295,6 +2354,78 @@ mod tests {
         assert!(
             outcome.anchored_left.is_empty(),
             "nothing is anchored elsewhere in an ordinary remove, got {:?}",
+            outcome.anchored_left
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// A canonical still referenced by the OWNING checkout's own artifact
+    /// keeps its marker through a foreign worktree's removal — clearing it
+    /// would drop the surviving install from the owner's next disk recovery.
+    #[cfg(unix)]
+    #[test]
+    fn remove_item_keeps_marker_when_owner_still_references_canonical() {
+        use std::os::unix::fs::symlink;
+
+        let root = std::env::temp_dir().join(format!(
+            "vstack_marker_survivor_{}_{}",
+            std::process::id(),
+            crate::config::now_iso().replace([':', '-'], "")
+        ));
+        let main = root.join("main");
+        let wt = root.join("wt");
+        std::fs::create_dir_all(&main).unwrap();
+        if !init_repo_with_commit(&main) {
+            let _ = std::fs::remove_dir_all(&root);
+            return; // git unavailable on this host
+        }
+        assert!(git_ok(&main, &["worktree", "add", "-q", wt.to_str().unwrap()]));
+
+        // Main owns the canonical AND references it via its own child link;
+        // the worktree shares per-child (partial sharing), so its dest is a
+        // distinct artifact.
+        std::fs::create_dir_all(main.join(".agents").join("skills")).unwrap();
+        let canonical = main.join(".agents").join("skills").join("github");
+        std::fs::create_dir_all(&canonical).unwrap();
+        std::fs::write(canonical.join("SKILL.md"), "# github\n").unwrap();
+        std::fs::write(canonical.join(".vstack-refreshed"), "0").unwrap();
+        let main_skills = main.join(".claude").join("skills");
+        std::fs::create_dir_all(&main_skills).unwrap();
+        symlink(
+            PathBuf::from("../../.agents/skills/github"),
+            main_skills.join("github"),
+        )
+        .unwrap();
+        let wt_skills = wt.join(".claude").join("skills");
+        std::fs::create_dir_all(&wt_skills).unwrap();
+        symlink(&canonical, wt_skills.join("github")).unwrap();
+
+        let outcome = crate::test_util::with_project_root(&wt, || {
+            remove_item(
+                "github",
+                Some(ItemKind::Skill),
+                &[Harness::ClaudeCode],
+                false,
+            )
+            .unwrap()
+        });
+
+        assert!(
+            std::fs::symlink_metadata(wt_skills.join("github")).is_err(),
+            "the worktree's own link is removed"
+        );
+        assert!(
+            std::fs::symlink_metadata(main_skills.join("github")).is_ok(),
+            "the owner's link is untouched"
+        );
+        assert!(
+            canonical.join(".vstack-refreshed").is_file(),
+            "the marker survives — the owner still references this canonical"
+        );
+        assert!(
+            outcome.anchored_left.iter().any(|p| p.ends_with("github")),
+            "the surviving canonical is reported, got {:?}",
             outcome.anchored_left
         );
 

--- a/cli/src/installer.rs
+++ b/cli/src/installer.rs
@@ -102,24 +102,57 @@ pub fn install_skill(
                     }
                     probe = dir.parent();
                 }
-                if let Some(probe_dir) = probe {
-                    if let (Some(project_common), Some((probe_common, checkout_root))) = (
+                if let Some(probe_dir) = probe
+                    && let (Some(project_common), Some((probe_common, checkout_toplevel))) = (
                         crate::path_safety::git_common_dir(&crate::config::project_root()),
                         crate::path_safety::git_repo_identity(probe_dir),
-                    ) && probe_common == project_common
-                        && checkout_root
-                            != std::fs::canonicalize(crate::config::project_root())
-                                .unwrap_or_else(|_| {
-                                    normalize_absolute_path(&crate::config::project_root())
-                                })
-                        && crate::path_safety::ensure_agents_dir_within_project(&checkout_root)
-                            .is_err()
-                    {
-                        anyhow::bail!(
-                            "refusing to install {} through {}: that same-repository checkout's .agents fails validation, and falling back to an ordinary link would write a worktree-absolute target into it",
+                    )
+                    && probe_common == project_common
+                {
+                    let project_canon = std::fs::canonicalize(crate::config::project_root())
+                        .unwrap_or_else(|_| {
+                            normalize_absolute_path(&crate::config::project_root())
+                        });
+                    // Validate the CORRESPONDING nested project root, not the
+                    // toplevel: for a project below the git toplevel, the
+                    // shared surface lives at the other checkout's copy of
+                    // that directory, and its toplevel `.agents` (unrelated
+                    // or absent) says nothing about it.
+                    let corresponding = corresponding_project_root_in(&checkout_toplevel);
+                    match corresponding {
+                        Some(root) if root == project_canon => {}
+                        Some(root) => {
+                            if crate::path_safety::ensure_agents_dir_within_project(&root)
+                                .is_err()
+                            {
+                                anyhow::bail!(
+                                    "refusing to install {} through {}: that same-repository checkout's .agents fails validation, and falling back to an ordinary link would write a worktree-absolute target into it",
+                                    skill.name,
+                                    root.display()
+                                );
+                            }
+                            // Same-repository indirection whose landing
+                            // parent is NOT a recognized skills surface is an
+                            // alias (e.g. `.claude/skills -> <main>/cli/src`):
+                            // installing would remove_existing/replace
+                            // children of an arbitrary repository directory.
+                            if let Some(parent) = physical.parent()
+                                && !is_recognized_skills_surface(&root, parent)
+                            {
+                                anyhow::bail!(
+                                    "refusing to install {} through {}: it resolves into {}, which is not a recognized skills directory of {}",
+                                    skill.name,
+                                    dest.display(),
+                                    parent.display(),
+                                    root.display()
+                                );
+                            }
+                        }
+                        None => anyhow::bail!(
+                            "refusing to install {} through {}: cannot derive the corresponding project root in that same-repository checkout",
                             skill.name,
-                            checkout_root.display()
-                        );
+                            checkout_toplevel.display()
+                        ),
                     }
                 }
             }
@@ -1019,6 +1052,39 @@ fn child_level_anchored_roots(dir: &Path) -> Vec<(PathBuf, AnchorEvidence)> {
         .collect()
 }
 
+/// The other checkout's copy of this project's root: the repo layout is
+/// identical in every checkout, so the project's repo-relative suffix (empty
+/// for a toplevel project) transfers verbatim onto `checkout_toplevel`.
+/// `None` when the suffix cannot be derived — callers fail closed rather
+/// than guessing a root.
+fn corresponding_project_root_in(checkout_toplevel: &Path) -> Option<PathBuf> {
+    let own_toplevel = crate::path_safety::git_toplevel(&crate::config::project_root())?;
+    let project_physical = std::fs::canonicalize(crate::config::project_root())
+        .unwrap_or_else(|_| normalize_absolute_path(&crate::config::project_root()));
+    let suffix = project_physical.strip_prefix(&own_toplevel).ok()?;
+    Some(checkout_toplevel.join(suffix))
+}
+
+/// Is `physical_parent` a recognized skills surface of the checkout rooted
+/// at `checkout_root` — its `.agents/skills` or one of its project-scope
+/// harness skills dirs? Link homes and anchor evidence must come only from
+/// these: any other same-repository directory reached through a symlink is
+/// an alias, and treating it as a link home would delete/replace its
+/// children as if they were skill artifacts.
+fn is_recognized_skills_surface(checkout_root: &Path, physical_parent: &Path) -> bool {
+    let project_root = crate::config::project_root();
+    let mut candidates = vec![checkout_root.join(".agents").join("skills")];
+    for harness in Harness::ALL {
+        if let Ok(rel) = harness.skills_dir(false).strip_prefix(&project_root) {
+            candidates.push(checkout_root.join(rel));
+        }
+    }
+    candidates.into_iter().any(|candidate| {
+        canonicalize_allowing_missing(&candidate)
+            .is_some_and(|resolved| resolved == *physical_parent)
+    })
+}
+
 /// The physical home of a project-scope harness link whose parent directory
 /// is symlinked into another checkout of the same repository.
 struct LinkHome {
@@ -1080,16 +1146,19 @@ fn anchored_link_home(physical_parent: PathBuf) -> Option<LinkHome> {
     // subdirectory). The anchor must land at the other checkout's copy of
     // THAT directory, not its toplevel — anchoring at the toplevel would
     // collide the nested project's canonicals with sibling projects' .agents.
-    // The repo layout is identical in every checkout, so the repo-relative
-    // suffix transfers verbatim; a suffix that cannot be derived fails closed
-    // (no anchoring) rather than guessing a root.
-    let own_toplevel = crate::path_safety::git_toplevel(&crate::config::project_root())?;
-    let project_physical = std::fs::canonicalize(crate::config::project_root())
-        .unwrap_or_else(|_| normalize_absolute_path(&crate::config::project_root()));
-    match project_physical.strip_prefix(&own_toplevel) {
-        Ok(suffix) if suffix.as_os_str().is_empty() => {}
-        Ok(suffix) => checkout_root = checkout_root.join(suffix),
-        Err(_) => return None,
+    checkout_root = corresponding_project_root_in(&checkout_root)?;
+    // Anchor evidence must come from a recognized skills surface of that
+    // checkout. Git identity alone would admit an ALIAS — e.g.
+    // `.claude/skills -> <main>/cli/src` — and installing through it would
+    // remove_existing/replace children of an arbitrary repository directory
+    // as if they were skill artifacts.
+    if !is_recognized_skills_surface(&checkout_root, &physical_parent) {
+        eprintln!(
+            "  Warning: not anchoring through {}: not a recognized skills directory of {} (VST-195)",
+            physical_parent.display(),
+            checkout_root.display()
+        );
+        return None;
     }
     // Anchoring writes beneath the other checkout's .agents, so it gets the
     // same containment boundary the project's own .agents writes get. An

--- a/cli/src/installer.rs
+++ b/cli/src/installer.rs
@@ -107,10 +107,29 @@ pub fn install_skill(
                     .join("skills")
                     .join(&skill.name)
             } else {
-                link_home
+                // No link evidence for THIS skill (fresh install). In a
+                // per-child sharing layout — a real skills dir whose
+                // EXISTING children symlink into another checkout — a new
+                // skill follows its siblings' anchor so one layout does not
+                // split canonicals across two checkouts.
+                let home_root = link_home
                     .as_ref()
                     .map(|home| home.checkout_root.clone())
-                    .unwrap_or_else(crate::config::project_root)
+                    .unwrap_or_else(|| {
+                        let own_skills =
+                            crate::config::project_root().join(".agents").join("skills");
+                        child_level_anchored_roots(&own_skills)
+                            .into_iter()
+                            .next()
+                            .and_then(|(root, _)| {
+                                // root is <checkout>/.agents/skills
+                                root.parent()
+                                    .and_then(Path::parent)
+                                    .map(Path::to_path_buf)
+                            })
+                            .unwrap_or_else(crate::config::project_root)
+                    });
+                home_root
                     .join(".agents")
                     .join("skills")
                     .join(&skill.name)

--- a/cli/src/installer.rs
+++ b/cli/src/installer.rs
@@ -128,7 +128,8 @@ pub fn install_skill(
                 }
                 remove_existing(&dest)?;
 
-                let rel = relative_path(dest.parent().unwrap(), &canonical)?;
+                let repo_anchor = (!global).then(crate::config::project_root);
+                let rel = relative_path(dest.parent().unwrap(), &canonical, repo_anchor.as_deref())?;
                 #[cfg(unix)]
                 std::os::unix::fs::symlink(&rel, &dest).with_context(|| {
                     format!("symlinking {} → {}", dest.display(), rel.display())
@@ -349,7 +350,6 @@ pub fn record_install(
     }
 }
 
-/// Compute relative path from `from` to `to`
 fn remove_existing(path: &Path) -> Result<()> {
     if path.is_symlink() {
         std::fs::remove_file(path)?;
@@ -383,19 +383,49 @@ fn normalize_absolute_path(path: &Path) -> PathBuf {
     normalized
 }
 
-fn relative_path(from: &Path, to: &Path) -> Result<PathBuf> {
+/// Symlink target spelling for a link created in `from` pointing at `to`.
+///
+/// `repo_anchor` is the root whose repository the link must stay inside —
+/// the project root for project-scope installs, `None` for global scope.
+/// Worktree setups symlink shared harness dirs into the main checkout
+/// (vstack#886), so `from` may physically live in a different checkout than
+/// its apparent path. The repo layout is identical in every worktree, so as
+/// long as an endpoint's physical home is a worktree of the anchor's own
+/// repository, the lexical relative spelling resolves correctly from
+/// whichever checkout the link physically lands in. A canonicalized target
+/// here would anchor shared main-checkout state to the worktree that ran the
+/// refresh and dangle when that worktree is removed (VST-195).
+///
+/// An endpoint that escapes to an unrelated tree (for example a `.claude`
+/// dir symlinked into a dotfiles checkout) keeps the previous behavior: an
+/// absolute physical target rather than a relative path computed across
+/// unrelated roots.
+fn relative_path(from: &Path, to: &Path, repo_anchor: Option<&Path>) -> Result<PathBuf> {
     let from_lexical = normalize_absolute_path(from);
     let from_canonical = std::fs::canonicalize(from).unwrap_or_else(|_| from_lexical.clone());
-    let to = std::fs::canonicalize(to).unwrap_or_else(|_| normalize_absolute_path(to));
+    let to_lexical = normalize_absolute_path(to);
+    let to_canonical = std::fs::canonicalize(to).unwrap_or_else(|_| to_lexical.clone());
 
-    // If the apparent parent path differs from the real containing directory
-    // (for example because an ancestor is a symlink), prefer an absolute
-    // target over a confusing relative path that is computed from the real path.
-    if from_canonical != from_lexical {
-        return Ok(to);
+    let stays_in_repo = |lexical: &Path, canonical: &Path| {
+        lexical == canonical
+            || repo_anchor.is_some_and(|anchor| {
+                crate::path_safety::is_same_repository_worktree(anchor, canonical)
+            })
+    };
+
+    if !stays_in_repo(&from_lexical, &from_canonical) {
+        return Ok(to_canonical);
     }
+    let to = if stays_in_repo(&to_lexical, &to_canonical) {
+        to_lexical
+    } else {
+        to_canonical
+    };
+    Ok(lexical_relative(&from_lexical, &to))
+}
 
-    let from_parts: Vec<_> = from_lexical.components().collect();
+fn lexical_relative(from: &Path, to: &Path) -> PathBuf {
+    let from_parts: Vec<_> = from.components().collect();
     let to_parts: Vec<_> = to.components().collect();
 
     let common = from_parts
@@ -412,7 +442,7 @@ fn relative_path(from: &Path, to: &Path) -> Result<PathBuf> {
         rel.push(part);
     }
 
-    Ok(rel)
+    rel
 }
 
 /// Recursively copy a directory.
@@ -679,7 +709,7 @@ mod tests {
         std::fs::create_dir_all(&from).unwrap();
         std::fs::create_dir_all(&to).unwrap();
 
-        let rel = relative_path(&from, &to).unwrap();
+        let rel = relative_path(&from, &to, None).unwrap();
         assert_eq!(rel, PathBuf::from("../../config/skills/rust-runtime"));
 
         let _ = std::fs::remove_dir_all(&root);
@@ -704,12 +734,205 @@ mod tests {
         std::fs::create_dir_all(&target).unwrap();
         symlink(&real_parent, &apparent_parent).unwrap();
 
-        let rel = relative_path(&apparent_parent, &target).unwrap();
+        let rel = relative_path(&apparent_parent, &target, None).unwrap();
         assert!(
             rel.is_absolute(),
             "expected absolute symlink target, got {rel:?}"
         );
         assert_eq!(rel, std::fs::canonicalize(&target).unwrap());
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// Run a git command in `dir`, reporting only whether it succeeded. Tests
+    /// that need a real repository skip themselves when git is unavailable
+    /// rather than failing a host that simply has no git.
+    fn git_ok(dir: &Path, args: &[&str]) -> bool {
+        std::process::Command::new("git")
+            .arg("-C")
+            .arg(dir)
+            .args(args)
+            .output()
+            .map(|out| out.status.success())
+            .unwrap_or(false)
+    }
+
+    fn init_repo_with_commit(dir: &Path) -> bool {
+        git_ok(dir, &["init", "-q", "-b", "main"])
+            && git_ok(dir, &["config", "user.email", "test@example.com"])
+            && git_ok(dir, &["config", "user.name", "Test"])
+            && git_ok(dir, &["config", "commit.gpgsign", "false"])
+            && std::fs::write(dir.join(".vstack-test-base"), "base\n").is_ok()
+            && git_ok(dir, &["add", "-A"])
+            && git_ok(dir, &["commit", "-q", "-m", "base"])
+    }
+
+    fn write_skill_source(root: &Path, name: &str) -> Skill {
+        let source = root.join("source").join(name);
+        std::fs::create_dir_all(&source).unwrap();
+        std::fs::write(
+            source.join("SKILL.md"),
+            format!("---\nname: {name}\ndescription: Test skill\n---\n\n# {name}\n\nBody.\n"),
+        )
+        .unwrap();
+        Skill {
+            name: name.into(),
+            description: "Test skill".into(),
+            license: None,
+            user_invocable: None,
+            dependencies: None,
+            body: String::new(),
+            source_dir: source,
+            resolved_deps: Vec::new(),
+        }
+    }
+
+    /// A parent symlinked into another worktree of the anchor's repository
+    /// must keep the lexical relative spelling instead of bailing to an
+    /// absolute target — the repo-relative layout is identical in every
+    /// checkout, so the relative link resolves wherever it physically lands.
+    #[cfg(unix)]
+    #[test]
+    fn relative_path_stays_lexical_when_parent_symlinks_into_same_repo_worktree() {
+        use std::os::unix::fs::symlink;
+
+        let root = std::env::temp_dir().join(format!(
+            "vstack_relative_path_worktree_{}_{}",
+            std::process::id(),
+            crate::config::now_iso().replace([':', '-'], "")
+        ));
+        let main = root.join("main");
+        let wt = root.join("wt");
+        std::fs::create_dir_all(&main).unwrap();
+        if !init_repo_with_commit(&main) {
+            let _ = std::fs::remove_dir_all(&root);
+            return; // git unavailable on this host
+        }
+        assert!(git_ok(&main, &["worktree", "add", "-q", wt.to_str().unwrap()]));
+
+        let main_skills = main.join(".claude").join("skills");
+        std::fs::create_dir_all(&main_skills).unwrap();
+        std::fs::create_dir_all(wt.join(".claude")).unwrap();
+        symlink(&main_skills, wt.join(".claude").join("skills")).unwrap();
+        let target = wt.join(".agents").join("skills").join("github");
+        std::fs::create_dir_all(&target).unwrap();
+
+        let rel = relative_path(&wt.join(".claude").join("skills"), &target, Some(&wt)).unwrap();
+        assert_eq!(rel, PathBuf::from("../../.agents/skills/github"));
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// VST-195: a refresh run from a git worktree whose `.claude/skills` is
+    /// symlinked into the main checkout must not anchor the main checkout's
+    /// skill links in the worktree — those links dangle the moment the
+    /// worktree is removed. The link physically lands in main, so its target
+    /// must be the repo-relative spelling that resolves inside main.
+    #[cfg(unix)]
+    #[test]
+    fn install_skill_from_worktree_keeps_main_checkout_links_repo_local() {
+        use std::os::unix::fs::symlink;
+
+        let root = std::env::temp_dir().join(format!(
+            "vstack_worktree_skill_link_{}_{}",
+            std::process::id(),
+            crate::config::now_iso().replace([':', '-'], "")
+        ));
+        let main = root.join("main");
+        let wt = root.join("wt");
+        std::fs::create_dir_all(&main).unwrap();
+        if !init_repo_with_commit(&main) {
+            let _ = std::fs::remove_dir_all(&root);
+            return; // git unavailable on this host
+        }
+        assert!(git_ok(&main, &["worktree", "add", "-q", wt.to_str().unwrap()]));
+
+        // Provision the worktree the way the `worktree` skill does: the
+        // harness skills dir is shared into the main checkout. `.agents`
+        // stays a real directory here — the failure mode observed downstream.
+        let main_skills = main.join(".claude").join("skills");
+        std::fs::create_dir_all(&main_skills).unwrap();
+        std::fs::create_dir_all(wt.join(".claude")).unwrap();
+        symlink(&main_skills, wt.join(".claude").join("skills")).unwrap();
+        std::fs::create_dir_all(wt.join(".agents")).unwrap();
+
+        let skill = write_skill_source(&root, "github");
+        crate::test_util::with_project_root(&wt, || {
+            install_skill(
+                &skill,
+                Harness::ClaudeCode,
+                false,
+                InstallMethod::Symlink,
+                None,
+            )
+            .unwrap()
+        });
+
+        let link = main_skills.join("github");
+        assert!(link.is_symlink(), "expected symlink at {link:?}");
+        let target = std::fs::read_link(&link).unwrap();
+        assert!(
+            !target.starts_with(&wt),
+            "main-checkout link must not point into the worktree: {target:?}"
+        );
+        assert_eq!(
+            target,
+            PathBuf::from("../../.agents/skills/github"),
+            "main-checkout link must use the repo-relative spelling"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// The fully shared layout: both `.claude/skills` and `.agents` are
+    /// symlinked into the main checkout. The generated link must resolve to a
+    /// real directory inside the main checkout, independent of the worktree.
+    #[cfg(unix)]
+    #[test]
+    fn install_skill_from_worktree_resolves_inside_main_checkout() {
+        use std::os::unix::fs::symlink;
+
+        let root = std::env::temp_dir().join(format!(
+            "vstack_worktree_skill_resolve_{}_{}",
+            std::process::id(),
+            crate::config::now_iso().replace([':', '-'], "")
+        ));
+        let main = root.join("main");
+        let wt = root.join("wt");
+        std::fs::create_dir_all(&main).unwrap();
+        if !init_repo_with_commit(&main) {
+            let _ = std::fs::remove_dir_all(&root);
+            return; // git unavailable on this host
+        }
+        assert!(git_ok(&main, &["worktree", "add", "-q", wt.to_str().unwrap()]));
+
+        let main_skills = main.join(".claude").join("skills");
+        std::fs::create_dir_all(&main_skills).unwrap();
+        std::fs::create_dir_all(wt.join(".claude")).unwrap();
+        symlink(&main_skills, wt.join(".claude").join("skills")).unwrap();
+        std::fs::create_dir_all(main.join(".agents")).unwrap();
+        symlink(main.join(".agents"), wt.join(".agents")).unwrap();
+
+        let skill = write_skill_source(&root, "github");
+        crate::test_util::with_project_root(&wt, || {
+            install_skill(
+                &skill,
+                Harness::ClaudeCode,
+                false,
+                InstallMethod::Symlink,
+                None,
+            )
+            .unwrap()
+        });
+
+        let link = main_skills.join("github");
+        assert!(link.is_symlink(), "expected symlink at {link:?}");
+        let resolved = link.canonicalize().unwrap();
+        assert!(
+            resolved.starts_with(main.canonicalize().unwrap()),
+            "link must resolve inside the main checkout, got {resolved:?}"
+        );
+        assert!(resolved.join("SKILL.md").is_file());
 
         let _ = std::fs::remove_dir_all(&root);
     }

--- a/cli/src/installer.rs
+++ b/cli/src/installer.rs
@@ -232,6 +232,16 @@ pub fn install_skill(
     })
 }
 
+/// What [`remove_item`] did and deliberately did not do.
+#[derive(Debug)]
+pub struct RemoveOutcome {
+    /// Paths deleted from disk.
+    pub removed: Vec<PathBuf>,
+    /// Anchored canonical copies left in place (noted on stderr) for their
+    /// own checkout's removal to collect.
+    pub anchored_left: Vec<PathBuf>,
+}
+
 /// Remove an installed item.
 ///
 /// Agent/skill deletion and hook cleanup are attempted for every requested
@@ -242,13 +252,43 @@ pub fn remove_item(
     kind: Option<ItemKind>,
     harnesses: &[Harness],
     global: bool,
-) -> Result<Vec<PathBuf>> {
+) -> Result<RemoveOutcome> {
     validate_item_name(name)?;
     let mut removed = Vec::new();
+    let mut anchored_left = Vec::new();
     let mut cleanup_errors = Vec::new();
     let remove_agents = kind.is_none_or(|kind| kind == ItemKind::Agent);
     let remove_skills = kind.is_none_or(|kind| kind == ItemKind::Skill);
     let remove_hooks = kind.is_none_or(|kind| kind == ItemKind::Hook);
+
+    // Resolve anchored canonical homes for every requested dest BEFORE any
+    // unlinking: removal destroys the evidence it needs (deleting a
+    // child-level link makes the parent look purely local), so anchored-side
+    // bookkeeping must act on a snapshot.
+    let anchored_canonicals: Vec<PathBuf> = if global || !remove_skills {
+        Vec::new()
+    } else {
+        let mut canonicals: Vec<PathBuf> = Vec::new();
+        let mut probed: Vec<PathBuf> = Vec::new();
+        for harness in harnesses {
+            let dest = harness.skills_dir(false).join(name);
+            if probed.contains(&dest) {
+                continue;
+            }
+            probed.push(dest.clone());
+            if let Some(home) = skill_link_home(&dest) {
+                let canonical = home
+                    .checkout_root
+                    .join(".agents")
+                    .join("skills")
+                    .join(name);
+                if !canonicals.contains(&canonical) {
+                    canonicals.push(canonical);
+                }
+            }
+        }
+        canonicals
+    };
 
     for harness in harnesses {
         // Agent files
@@ -334,15 +374,13 @@ pub fn remove_item(
         // IS the canonical dir itself, indistinguishable on disk from a
         // leftover. Never delete it from a foreign worktree; that checkout's
         // own remove collects it.
-        if !global {
-            for (root, _) in anchored_canonical_skill_roots(harnesses) {
-                let anchored = root.join(name);
-                if anchored.exists() {
-                    eprintln!(
-                        "  Note: leaving canonical copy {} in place — it may back that checkout's own installs; remove it from that checkout to delete it (VST-195)",
-                        anchored.display()
-                    );
-                }
+        for anchored in &anchored_canonicals {
+            if anchored.exists() {
+                eprintln!(
+                    "  Note: leaving canonical copy {} in place — it may back that checkout's own installs; remove it from that checkout to delete it (VST-195)",
+                    anchored.display()
+                );
+                anchored_left.push(anchored.clone());
             }
         }
     }
@@ -351,7 +389,10 @@ pub fn remove_item(
         anyhow::bail!(cleanup_errors.join("; "));
     }
 
-    Ok(removed)
+    Ok(RemoveOutcome {
+        removed,
+        anchored_left,
+    })
 }
 
 #[derive(Clone, Copy)]
@@ -814,7 +855,9 @@ mod tests {
         std::fs::write(&legacy_agent, "# all\n").unwrap();
 
         let removed = crate::test_util::with_project_root(&project, || {
-            remove_item("all", Some(ItemKind::Agent), &[Harness::ClaudeCode], false).unwrap()
+            remove_item("all", Some(ItemKind::Agent), &[Harness::ClaudeCode], false)
+                .unwrap()
+                .removed
         });
         assert!(removed.contains(&legacy_agent), "removed: {removed:?}");
         assert!(!legacy_agent.exists());
@@ -1209,6 +1252,184 @@ mod tests {
         assert!(
             main.join(".agents/skills/github/SKILL.md").is_file(),
             "main checkout's canonical copy must survive reconciliation"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// Partial-sharing layout: the only evidence of the anchor is the child
+    /// link removal is about to delete, so the anchor must be resolved
+    /// BEFORE any unlinking — a post-unlink probe sees a purely local parent
+    /// and the anchored-side bookkeeping (the surviving-copy note) misfires.
+    #[cfg(unix)]
+    #[test]
+    fn remove_item_snapshots_child_link_anchor_before_unlinking() {
+        use std::os::unix::fs::symlink;
+
+        let root = std::env::temp_dir().join(format!(
+            "vstack_worktree_remove_snapshot_{}_{}",
+            std::process::id(),
+            crate::config::now_iso().replace([':', '-'], "")
+        ));
+        let main = root.join("main");
+        let wt = root.join("wt");
+        std::fs::create_dir_all(&main).unwrap();
+        if !init_repo_with_commit(&main) {
+            let _ = std::fs::remove_dir_all(&root);
+            return; // git unavailable on this host
+        }
+        assert!(git_ok(&main, &["worktree", "add", "-q", wt.to_str().unwrap()]));
+
+        let main_copy = main.join(".agents").join("skills").join("github");
+        std::fs::create_dir_all(&main_copy).unwrap();
+        std::fs::write(main_copy.join("SKILL.md"), "# github\n").unwrap();
+        std::fs::write(main_copy.join(".vstack-refreshed"), "0").unwrap();
+        std::fs::create_dir_all(wt.join(".agents").join("skills")).unwrap();
+        let child = wt.join(".agents").join("skills").join("github");
+        symlink(&main_copy, &child).unwrap();
+
+        let outcome = crate::test_util::with_project_root(&wt, || {
+            remove_item("github", Some(ItemKind::Skill), &[Harness::Codex], false).unwrap()
+        });
+
+        assert!(
+            std::fs::symlink_metadata(&child).is_err(),
+            "the child link must be removed"
+        );
+        assert!(
+            main_copy.join("SKILL.md").is_file(),
+            "main's shared copy must survive"
+        );
+        let expected = main
+            .canonicalize()
+            .unwrap()
+            .join(".agents")
+            .join("skills")
+            .join("github");
+        assert!(
+            outcome.anchored_left.contains(&expected),
+            "the anchor must be resolved before unlinking destroys the evidence, got {:?}",
+            outcome.anchored_left
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// Containment must extend to `.agents/skills`: a real in-repo `.agents`
+    /// whose `skills` subdir symlinks OUTSIDE the repository must fail the
+    /// anchored-side validation, or install deletes/overwrites the external
+    /// directory through it.
+    #[cfg(unix)]
+    #[test]
+    fn install_skill_never_writes_through_an_escaping_agents_skills_subdir() {
+        use std::os::unix::fs::symlink;
+
+        let root = std::env::temp_dir().join(format!(
+            "vstack_worktree_escaping_skills_{}_{}",
+            std::process::id(),
+            crate::config::now_iso().replace([':', '-'], "")
+        ));
+        let main = root.join("main");
+        let wt = root.join("wt");
+        let outside = root.join("outside");
+        std::fs::create_dir_all(&main).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        if !init_repo_with_commit(&main) {
+            let _ = std::fs::remove_dir_all(&root);
+            return; // git unavailable on this host
+        }
+        assert!(git_ok(&main, &["worktree", "add", "-q", wt.to_str().unwrap()]));
+
+        let main_skills = main.join(".claude").join("skills");
+        std::fs::create_dir_all(&main_skills).unwrap();
+        std::fs::create_dir_all(wt.join(".claude")).unwrap();
+        symlink(&main_skills, wt.join(".claude").join("skills")).unwrap();
+        std::fs::create_dir_all(wt.join(".agents")).unwrap();
+        // Main's .agents is a REAL in-repo dir; only its skills subdir
+        // escapes the repository.
+        std::fs::create_dir_all(main.join(".agents")).unwrap();
+        symlink(&outside, main.join(".agents").join("skills")).unwrap();
+
+        let skill = write_skill_source(&root, "github");
+        crate::test_util::with_project_root(&wt, || {
+            install_skill(
+                &skill,
+                Harness::ClaudeCode,
+                false,
+                InstallMethod::Symlink,
+                None,
+            )
+            .unwrap()
+        });
+
+        assert_eq!(
+            std::fs::read_dir(&outside).unwrap().count(),
+            0,
+            "no write may follow the escaping .agents/skills"
+        );
+        assert!(
+            wt.join(".agents/skills/github/SKILL.md").is_file(),
+            "install must fall back to the unanchored worktree canonical"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// A reference must RESOLVE to the canonical dir it gates: a same-named
+    /// COPY-mode harness dir is that harness's own install, not a reference
+    /// to the canonical — recovering through it would re-type the skill as
+    /// symlink-mode and let the next refresh replace the copy.
+    #[cfg(unix)]
+    #[test]
+    fn reconcile_does_not_count_copy_mode_artifact_as_canonical_reference() {
+        use std::os::unix::fs::symlink;
+
+        let root = std::env::temp_dir().join(format!(
+            "vstack_worktree_copy_mode_gate_{}_{}",
+            std::process::id(),
+            crate::config::now_iso().replace([':', '-'], "")
+        ));
+        let main = root.join("main");
+        let wt = root.join("wt");
+        std::fs::create_dir_all(&main).unwrap();
+        if !init_repo_with_commit(&main) {
+            let _ = std::fs::remove_dir_all(&root);
+            return; // git unavailable on this host
+        }
+        assert!(git_ok(&main, &["worktree", "add", "-q", wt.to_str().unwrap()]));
+
+        let main_skills = main.join(".claude").join("skills");
+        std::fs::create_dir_all(&main_skills).unwrap();
+        std::fs::create_dir_all(wt.join(".claude")).unwrap();
+        symlink(&main_skills, wt.join(".claude").join("skills")).unwrap();
+        std::fs::create_dir_all(wt.join(".agents")).unwrap();
+
+        // Canonical copy backing main's own Codex install.
+        let canonical = main.join(".agents").join("skills").join("github");
+        std::fs::create_dir_all(&canonical).unwrap();
+        std::fs::write(canonical.join("SKILL.md"), "# github\n").unwrap();
+        std::fs::write(canonical.join(".vstack-refreshed"), "0").unwrap();
+        // Same-named Claude COPY-mode install: a real dir, not a symlink.
+        let copy_mode = main_skills.join("github");
+        std::fs::create_dir_all(&copy_mode).unwrap();
+        std::fs::write(copy_mode.join("SKILL.md"), "# github copy\n").unwrap();
+        std::fs::write(copy_mode.join(".vstack-refreshed"), "0").unwrap();
+
+        let mut lock = LockFile::default();
+        crate::test_util::with_project_root(&wt, || {
+            crate::config::reconcile_lock_with_disk(&mut lock, false, "source")
+        });
+
+        assert!(
+            !lock.entries.contains_key("github"),
+            "a copy-mode artifact must not count as a reference to the canonical"
+        );
+        assert!(
+            std::fs::symlink_metadata(&copy_mode)
+                .unwrap()
+                .file_type()
+                .is_dir(),
+            "the copy-mode install must be left untouched"
         );
 
         let _ = std::fs::remove_dir_all(&root);

--- a/cli/src/installer.rs
+++ b/cli/src/installer.rs
@@ -86,6 +86,45 @@ pub fn install_skill(
         crate::path_safety::ensure_agents_dir_within_project(&crate::config::project_root())?;
     }
     let dest = harness.install_skill(skill, global)?;
+    if !global && method == InstallMethod::Symlink {
+        // A dest that physically lives in a same-repository checkout whose
+        // .agents FAILS validation must refuse outright: falling back to
+        // ordinary relative linking writes a worktree-absolute target into
+        // the other checkout — the dangling-link hazard once this worktree
+        // is removed.
+        let lexical = normalize_absolute_path(&dest);
+        if let Some(physical) = canonicalize_allowing_missing(&dest) {
+            if physical != lexical {
+                let mut probe = physical.parent();
+                while let Some(dir) = probe {
+                    if dir.is_dir() {
+                        break;
+                    }
+                    probe = dir.parent();
+                }
+                if let Some(probe_dir) = probe {
+                    if let (Some(project_common), Some((probe_common, checkout_root))) = (
+                        crate::path_safety::git_common_dir(&crate::config::project_root()),
+                        crate::path_safety::git_repo_identity(probe_dir),
+                    ) && probe_common == project_common
+                        && checkout_root
+                            != std::fs::canonicalize(crate::config::project_root())
+                                .unwrap_or_else(|_| {
+                                    normalize_absolute_path(&crate::config::project_root())
+                                })
+                        && crate::path_safety::ensure_agents_dir_within_project(&checkout_root)
+                            .is_err()
+                    {
+                        anyhow::bail!(
+                            "refusing to install {} through {}: that same-repository checkout's .agents fails validation, and falling back to an ordinary link would write a worktree-absolute target into it",
+                            skill.name,
+                            checkout_root.display()
+                        );
+                    }
+                }
+            }
+        }
+    }
 
     let detail = match method {
         InstallMethod::Symlink => {
@@ -1512,7 +1551,7 @@ mod tests {
         symlink(&outside, main.join(".agents")).unwrap();
 
         let skill = write_skill_source(&root, "github");
-        crate::test_util::with_project_root(&wt, || {
+        let result = crate::test_util::with_project_root(&wt, || {
             install_skill(
                 &skill,
                 Harness::ClaudeCode,
@@ -1520,21 +1559,26 @@ mod tests {
                 InstallMethod::Symlink,
                 None,
             )
-            .unwrap()
         });
-
+        // Fail CLOSED: the softer fallback (absolute link into the
+        // worktree, warning on stderr) left a link in the other checkout
+        // that dangles the moment this disposable worktree is removed.
+        let err = match result {
+            Ok(_) => panic!("expected refusal for an escaping link-checkout .agents"),
+            Err(err) => err,
+        };
+        assert!(
+            err.to_string().contains("refusing to install"),
+            "expected the fail-closed refusal, got: {err}"
+        );
         assert_eq!(
             std::fs::read_dir(&outside).unwrap().count(),
             0,
             "no write may land outside the repository"
         );
-        // Fallback taken: unanchored canonical in the worktree, absolute link
-        // target (the pre-anchoring behavior, with a warning on stderr).
-        assert!(wt.join(".agents/skills/github/SKILL.md").is_file());
-        let target = std::fs::read_link(main_skills.join("github")).unwrap();
         assert!(
-            target.is_absolute() && target.starts_with(&wt),
-            "expected absolute fallback target into the worktree, got {target:?}"
+            std::fs::symlink_metadata(main_skills.join("github")).is_err(),
+            "no link may be written into the other checkout"
         );
 
         let _ = std::fs::remove_dir_all(&root);
@@ -2050,7 +2094,7 @@ mod tests {
         symlink(&outside, main.join(".agents").join("skills")).unwrap();
 
         let skill = write_skill_source(&root, "github");
-        crate::test_util::with_project_root(&wt, || {
+        let result = crate::test_util::with_project_root(&wt, || {
             install_skill(
                 &skill,
                 Harness::ClaudeCode,
@@ -2058,17 +2102,20 @@ mod tests {
                 InstallMethod::Symlink,
                 None,
             )
-            .unwrap()
         });
-
+        // Fail CLOSED, matching the link-checkout variant above.
+        let err = match result {
+            Ok(_) => panic!("expected refusal for an escaping .agents/skills in the link checkout"),
+            Err(err) => err,
+        };
+        assert!(
+            err.to_string().contains("refusing to install"),
+            "expected the fail-closed refusal, got: {err}"
+        );
         assert_eq!(
             std::fs::read_dir(&outside).unwrap().count(),
             0,
             "no write may follow the escaping .agents/skills"
-        );
-        assert!(
-            wt.join(".agents/skills/github/SKILL.md").is_file(),
-            "install must fall back to the unanchored worktree canonical"
         );
 
         let _ = std::fs::remove_dir_all(&root);

--- a/cli/src/installer.rs
+++ b/cli/src/installer.rs
@@ -125,6 +125,22 @@ pub fn install_skill(
                 .as_ref()
                 .is_some_and(|home| home.checkout_root != project_checkout)
                 && canonical.exists();
+            if foreign_existing
+                && std::fs::symlink_metadata(&canonical)
+                    .is_ok_and(|meta| meta.file_type().is_symlink())
+            {
+                // exists()/is_file() follow symlinks: a malformed "canonical"
+                // whose final component is a symlink could smuggle the link
+                // target (possibly outside the repository) past the write-shy
+                // fast path and containment. A real canonical is a directory;
+                // a symlink there is repaired from source (remove_existing
+                // unlinks the symlink itself, never its target).
+                eprintln!(
+                    "  Warning: existing canonical {} is a symlink, not a directory; repairing it from source (VST-195)",
+                    canonical.display()
+                );
+                foreign_existing = false;
+            }
             if foreign_existing && !canonical.join("SKILL.md").is_file() {
                 // Write-shy protects the owning checkout's valid installs; a
                 // canonical without SKILL.md was never one, and linking to it
@@ -344,6 +360,25 @@ pub fn remove_item(
                 .is_some_and(|resolved| anchored_resolved.contains(&resolved))
     };
 
+    // Clear the anchored canonicals' managed markers BEFORE any unlinking.
+    // A marker that survives past this removal lets the owning checkout's
+    // disk recovery adopt (resurrect) a copy that may have existed solely
+    // for this worktree's install — and once the child links below are
+    // unlinked, the anchor evidence needed to rediscover these canonicals is
+    // gone, so a post-unlink failure would be unrepairable by retry. Failing
+    // here aborts with every link intact: fix the marker, run remove again.
+    for anchored in &anchored_canonicals {
+        let marker = anchored.join(".vstack-refreshed");
+        if let Err(err) = std::fs::remove_file(&marker)
+            && err.kind() != std::io::ErrorKind::NotFound
+        {
+            anyhow::bail!(
+                "could not clear managed marker {} — aborting removal before any unlinking so it stays retryable: {err}",
+                marker.display()
+            );
+        }
+    }
+
     for harness in harnesses {
         // Agent files
         if remove_agents {
@@ -440,21 +475,10 @@ pub fn remove_item(
         // own remove collects it.
         for anchored in &anchored_canonicals {
             if anchored.exists() {
-                // Clear the managed marker so the owning checkout's
-                // reconciliation does not adopt (resurrect) a copy that may
-                // have existed solely for this worktree's install. A
-                // checkout that still references the skill re-marks it on
-                // its next refresh; its lock entries survive regardless,
-                // since the stale gate checks existence, not the marker.
-                let marker = anchored.join(".vstack-refreshed");
-                if let Err(err) = std::fs::remove_file(&marker)
-                    && err.kind() != std::io::ErrorKind::NotFound
-                {
-                    eprintln!(
-                        "  Warning: could not clear managed marker {}: {err}",
-                        marker.display()
-                    );
-                }
+                // Marker already cleared before the unlink phase (a checkout
+                // that still references the skill re-marks it on its next
+                // refresh; lock entries survive regardless, since the stale
+                // gate checks existence, not the marker).
                 eprintln!(
                     "  Note: leaving canonical copy {} in place — it may back that checkout's own installs; remove it from that checkout to delete it (VST-195)",
                     anchored.display()
@@ -2211,6 +2235,143 @@ mod tests {
             "the surviving canonical must be reported, got {:?}",
             outcome.anchored_left
         );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// A "foreign canonical" whose final component is a SYMLINK is malformed:
+    /// `exists()`/`is_file()` follow it, so the write-shy fast path would
+    /// link through it to wherever it points (potentially outside the
+    /// repository), bypassing containment. It must be repaired into a real
+    /// directory instead, without touching the symlink's target.
+    #[cfg(unix)]
+    #[test]
+    fn install_skill_repairs_symlinked_foreign_canonical() {
+        use std::os::unix::fs::symlink;
+
+        let root = std::env::temp_dir().join(format!(
+            "vstack_symlinked_canonical_{}_{}",
+            std::process::id(),
+            crate::config::now_iso().replace([':', '-'], "")
+        ));
+        let main = root.join("main");
+        let wt = root.join("wt");
+        std::fs::create_dir_all(&main).unwrap();
+        if !init_repo_with_commit(&main) {
+            let _ = std::fs::remove_dir_all(&root);
+            return; // git unavailable on this host
+        }
+        assert!(git_ok(&main, &["worktree", "add", "-q", wt.to_str().unwrap()]));
+
+        let main_skills = main.join(".claude").join("skills");
+        std::fs::create_dir_all(&main_skills).unwrap();
+        std::fs::create_dir_all(wt.join(".claude")).unwrap();
+        symlink(&main_skills, wt.join(".claude").join("skills")).unwrap();
+        std::fs::create_dir_all(wt.join(".agents")).unwrap();
+
+        // Main's "canonical" is a symlink smuggling an external directory
+        // that even carries a plausible SKILL.md.
+        let external = root.join("external-target");
+        std::fs::create_dir_all(&external).unwrap();
+        std::fs::write(external.join("SKILL.md"), "# smuggled\n").unwrap();
+        std::fs::create_dir_all(main.join(".agents").join("skills")).unwrap();
+        let canonical = main.join(".agents").join("skills").join("github");
+        symlink(&external, &canonical).unwrap();
+
+        let skill = write_skill_source(&root, "github");
+        crate::test_util::with_project_root(&wt, || {
+            install_skill(
+                &skill,
+                Harness::ClaudeCode,
+                false,
+                InstallMethod::Symlink,
+                None,
+            )
+            .unwrap()
+        });
+
+        let meta = std::fs::symlink_metadata(&canonical).unwrap();
+        assert!(
+            meta.file_type().is_dir(),
+            "the symlinked canonical must be replaced with a real directory"
+        );
+        assert!(canonical.join("SKILL.md").is_file());
+        assert_eq!(
+            std::fs::read_to_string(external.join("SKILL.md")).unwrap(),
+            "# smuggled\n",
+            "repair must unlink the symlink itself, never write through to its target"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// A managed-marker clear that fails must abort the removal BEFORE any
+    /// unlinking: past that point the anchor evidence is gone, the caller
+    /// drops the lock entry, and the still-marked canonical would be adopted
+    /// back (resurrected) by the owning checkout's recovery.
+    #[cfg(unix)]
+    #[test]
+    fn remove_item_aborts_before_unlink_when_marker_clear_fails() {
+        use std::os::unix::fs::symlink;
+
+        let root = std::env::temp_dir().join(format!(
+            "vstack_marker_clear_abort_{}_{}",
+            std::process::id(),
+            crate::config::now_iso().replace([':', '-'], "")
+        ));
+        let main = root.join("main");
+        let wt = root.join("wt");
+        std::fs::create_dir_all(&main).unwrap();
+        if !init_repo_with_commit(&main) {
+            let _ = std::fs::remove_dir_all(&root);
+            return; // git unavailable on this host
+        }
+        assert!(git_ok(&main, &["worktree", "add", "-q", wt.to_str().unwrap()]));
+
+        let main_skills = main.join(".claude").join("skills");
+        std::fs::create_dir_all(&main_skills).unwrap();
+        std::fs::create_dir_all(wt.join(".claude")).unwrap();
+        symlink(&main_skills, wt.join(".claude").join("skills")).unwrap();
+        std::fs::create_dir_all(wt.join(".agents")).unwrap();
+
+        let skill = write_skill_source(&root, "github");
+        crate::test_util::with_project_root(&wt, || {
+            install_skill(
+                &skill,
+                Harness::ClaudeCode,
+                false,
+                InstallMethod::Symlink,
+                None,
+            )
+            .unwrap()
+        });
+        let canonical = main.join(".agents").join("skills").join("github");
+        assert!(canonical.join("SKILL.md").is_file());
+
+        // Make the marker un-removable via remove_file: a non-empty
+        // directory in its place fails with EISDIR.
+        let marker = canonical.join(".vstack-refreshed");
+        std::fs::remove_file(&marker).unwrap();
+        std::fs::create_dir_all(marker.join("block")).unwrap();
+
+        let err = crate::test_util::with_project_root(&wt, || {
+            remove_item(
+                "github",
+                Some(ItemKind::Skill),
+                &[Harness::ClaudeCode],
+                false,
+            )
+            .unwrap_err()
+        });
+        assert!(
+            err.to_string().contains("managed marker"),
+            "expected the marker-clear abort, got: {err}"
+        );
+        assert!(
+            std::fs::symlink_metadata(main_skills.join("github")).is_ok(),
+            "the child link must survive an aborted removal (retryable)"
+        );
+        assert!(canonical.join("SKILL.md").is_file());
 
         let _ = std::fs::remove_dir_all(&root);
     }

--- a/cli/src/path_safety.rs
+++ b/cli/src/path_safety.rs
@@ -70,6 +70,25 @@ pub(crate) fn write_file_no_follow(path: &Path, contents: impl AsRef<[u8]>) -> R
     write_result
 }
 
+/// Interpret one line of `git rev-parse` output as a path, preserving raw
+/// bytes on Unix: a non-UTF-8 checkout path must not be lossy-mangled into
+/// U+FFFD (canonicalize would then fail and same-repository detection would
+/// silently collapse to None). Trims ASCII whitespace at both ends.
+fn git_output_path(bytes: &[u8]) -> Option<PathBuf> {
+    let start = bytes.iter().position(|b| !b.is_ascii_whitespace())?;
+    let end = bytes.iter().rposition(|b| !b.is_ascii_whitespace())? + 1;
+    let trimmed = &bytes[start..end];
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt;
+        Some(PathBuf::from(std::ffi::OsStr::from_bytes(trimmed)))
+    }
+    #[cfg(not(unix))]
+    {
+        Some(PathBuf::from(String::from_utf8_lossy(trimmed).into_owned()))
+    }
+}
+
 /// `git rev-parse --show-toplevel` for `dir`, canonicalized. `None` when `dir`
 /// is not inside a Git repository or the answer cannot be resolved — callers
 /// fail closed.
@@ -86,11 +105,7 @@ pub(crate) fn git_toplevel(dir: &Path) -> Option<PathBuf> {
     if !output.status.success() {
         return None;
     }
-    let raw = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if raw.is_empty() {
-        return None;
-    }
-    Path::new(&raw).canonicalize().ok()
+    git_output_path(&output.stdout)?.canonicalize().ok()
 }
 
 /// `git rev-parse --git-common-dir` for `dir`, canonicalized. `None` when `dir`
@@ -106,16 +121,12 @@ pub(crate) fn git_common_dir(dir: &Path) -> Option<PathBuf> {
     if !output.status.success() {
         return None;
     }
-    let raw = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if raw.is_empty() {
-        return None;
-    }
+    let reported = git_output_path(&output.stdout)?;
     // `--git-common-dir` is relative to the queried directory unless git is new
     // enough to have been asked for an absolute path, so resolve it against
     // `dir` rather than the process cwd.
-    let reported = Path::new(&raw);
     let absolute = if reported.is_absolute() {
-        reported.to_path_buf()
+        reported
     } else {
         dir.join(reported)
     };
@@ -137,23 +148,18 @@ pub(crate) fn git_repo_identity(dir: &Path) -> Option<(PathBuf, PathBuf)> {
     if !output.status.success() {
         return None;
     }
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let mut lines = stdout.lines();
-    let common_raw = lines.next()?.trim();
-    let toplevel_raw = lines.next()?.trim();
-    if common_raw.is_empty() || toplevel_raw.is_empty() {
-        return None;
-    }
+    let mut lines = output.stdout.splitn(2, |b| *b == b'\n');
+    let common_reported = git_output_path(lines.next()?)?;
+    let toplevel_reported = git_output_path(lines.next()?)?;
     // `--git-common-dir` may be reported relative to the queried directory;
     // resolve it against `dir` rather than the process cwd.
-    let common_reported = Path::new(common_raw);
     let common_absolute = if common_reported.is_absolute() {
-        common_reported.to_path_buf()
+        common_reported
     } else {
         dir.join(common_reported)
     };
     let common = common_absolute.canonicalize().ok()?;
-    let toplevel = Path::new(toplevel_raw).canonicalize().ok()?;
+    let toplevel = toplevel_reported.canonicalize().ok()?;
     Some((common, toplevel))
 }
 

--- a/cli/src/path_safety.rs
+++ b/cli/src/path_safety.rs
@@ -220,6 +220,39 @@ pub(crate) fn ensure_agents_dir_within_project(project_root: &Path) -> Result<()
             agents_dir.display()
         );
     }
+    // `.agents` itself must be a checkout-owned canonical root BEFORE the
+    // skills child is considered: an alias like `.agents -> cli/src` with no
+    // `skills` child yet would otherwise ride the NotFound early-return
+    // below, and the subsequent install creates (and later recursively
+    // replaces) `<aliased-dir>/skills/<name>` inside repository sources.
+    if agents_dir_canon.starts_with(&project_root_canon) {
+        if agents_dir_canon != project_root_canon.join(".agents") {
+            bail!(
+                "refusing .agents that resolves to a non-canonical in-project directory: {} -> {}",
+                agents_dir.display(),
+                agents_dir_canon.display()
+            );
+        }
+    } else {
+        let claimed_checkout = agents_dir_canon
+            .parent()
+            .map(Path::to_path_buf)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "cannot derive a checkout root from {}",
+                    agents_dir_canon.display()
+                )
+            })?;
+        if !agents_dir_canon.ends_with(Path::new(".agents"))
+            || git_toplevel(&claimed_checkout).as_deref() != Some(claimed_checkout.as_path())
+        {
+            bail!(
+                "refusing .agents that does not resolve to a checkout toplevel's .agents: {} -> {}",
+                agents_dir.display(),
+                agents_dir_canon.display()
+            );
+        }
+    }
     // Same boundary one level down: a real in-repo .agents whose skills
     // subdir symlinks outside the repository would otherwise pass, and every
     // skill write goes through .agents/skills.
@@ -397,6 +430,37 @@ mod tests {
                 .contains("refusing to write through symlink")
         );
         assert_eq!(std::fs::read_to_string(&outside).unwrap(), "keep");
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// `.agents` aliased to an arbitrary in-repo directory must refuse even
+    /// when its `skills` child does not exist yet — the NotFound early
+    /// return must not skip root validation, or install creates (and later
+    /// recursively replaces) `<aliased>/skills/<name>` inside sources.
+    #[cfg(unix)]
+    #[test]
+    fn agents_alias_without_skills_child_is_rejected() {
+        use std::os::unix::fs::symlink;
+
+        let root = std::env::temp_dir().join(format!(
+            "vstack_agents_alias_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        let decoy = root.join("src");
+        std::fs::create_dir_all(&decoy).unwrap();
+        symlink(&decoy, root.join(".agents")).unwrap();
+
+        let err = ensure_agents_dir_within_project(&root).unwrap_err();
+        assert!(
+            err.to_string().contains("non-canonical in-project"),
+            "expected the .agents alias refusal, got: {err}"
+        );
 
         let _ = std::fs::remove_dir_all(&root);
     }

--- a/cli/src/path_safety.rs
+++ b/cli/src/path_safety.rs
@@ -223,6 +223,21 @@ pub(crate) fn ensure_agents_dir_within_project(project_root: &Path) -> Result<()
             skills_dir.display()
         );
     }
+    // Same-repository containment is necessary but not sufficient: a
+    // `.agents/skills` symlinked to an arbitrary in-repo directory (e.g.
+    // `../cli/src`) would make install treat `<target>/<name>` as canonical
+    // and recursively DELETE it on refresh. The resolved target must itself
+    // be an `.agents/skills` root — either this `.agents`'s own subdir or an
+    // approved checkout's.
+    if skills_dir_canon != agents_dir_canon.join("skills")
+        && !skills_dir_canon.ends_with(Path::new(".agents/skills"))
+    {
+        bail!(
+            "refusing .agents/skills that resolves to a non-skills-root directory: {} -> {}",
+            skills_dir.display(),
+            skills_dir_canon.display()
+        );
+    }
     if !skills_dir_canon.is_dir() {
         bail!(
             "project .agents/skills path is not a directory: {}",
@@ -324,6 +339,44 @@ mod tests {
                 .contains("refusing to write through symlink")
         );
         assert_eq!(std::fs::read_to_string(&outside).unwrap(), "keep");
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// Same-repository containment alone must not admit a `.agents/skills`
+    /// symlinked to an arbitrary in-repo directory: install would treat
+    /// `<target>/<name>` as canonical and recursively delete it on refresh
+    /// (e.g. `.agents/skills -> ../cli/src` destroying `cli/src/<name>`).
+    #[cfg(unix)]
+    #[test]
+    fn agents_skills_resolving_to_non_skills_root_is_rejected() {
+        use std::os::unix::fs::symlink;
+
+        let root = std::env::temp_dir().join(format!(
+            "vstack_skills_nonroot_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        let agents = root.join(".agents");
+        let decoy = root.join("src");
+        std::fs::create_dir_all(&agents).unwrap();
+        std::fs::create_dir_all(&decoy).unwrap();
+        symlink(&decoy, agents.join("skills")).unwrap();
+
+        let err = ensure_agents_dir_within_project(&root).unwrap_err();
+        assert!(
+            err.to_string().contains("non-skills-root"),
+            "expected the non-skills-root refusal, got: {err}"
+        );
+
+        // The ordinary real layout stays accepted.
+        std::fs::remove_file(agents.join("skills")).unwrap();
+        std::fs::create_dir_all(agents.join("skills")).unwrap();
+        ensure_agents_dir_within_project(&root).unwrap();
 
         let _ = std::fs::remove_dir_all(&root);
     }

--- a/cli/src/path_safety.rs
+++ b/cli/src/path_safety.rs
@@ -73,7 +73,7 @@ pub(crate) fn write_file_no_follow(path: &Path, contents: impl AsRef<[u8]>) -> R
 /// `git rev-parse --git-common-dir` for `dir`, canonicalized. `None` when `dir`
 /// is not inside a Git repository, when git is unavailable, or when the answer
 /// cannot be resolved — every one of which must fail closed at the call site.
-fn git_common_dir(dir: &Path) -> Option<PathBuf> {
+pub(crate) fn git_common_dir(dir: &Path) -> Option<PathBuf> {
     let output = std::process::Command::new("git")
         .args(["-C", dir.to_str()?, "rev-parse", "--git-common-dir"])
         .output()
@@ -97,23 +97,43 @@ fn git_common_dir(dir: &Path) -> Option<PathBuf> {
     absolute.canonicalize().ok()
 }
 
-/// `git rev-parse --show-toplevel` for `dir`, canonicalized: the root of the
-/// working tree that physically contains `dir`. `None` when `dir` is not
-/// inside a working tree, when git is unavailable, or when the answer cannot
-/// be resolved — callers must fail closed.
-pub(crate) fn git_worktree_root(dir: &Path) -> Option<PathBuf> {
+/// Repository identity of the working tree physically containing `dir`, from
+/// a single `git rev-parse` invocation: `(--git-common-dir, --show-toplevel)`,
+/// both canonicalized. `None` when `dir` is not inside a working tree, when
+/// git is unavailable, or when either answer cannot be resolved — callers
+/// must fail closed.
+pub(crate) fn git_repo_identity(dir: &Path) -> Option<(PathBuf, PathBuf)> {
     let output = std::process::Command::new("git")
-        .args(["-C", dir.to_str()?, "rev-parse", "--show-toplevel"])
+        .args([
+            "-C",
+            dir.to_str()?,
+            "rev-parse",
+            "--git-common-dir",
+            "--show-toplevel",
+        ])
         .output()
         .ok()?;
     if !output.status.success() {
         return None;
     }
-    let raw = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if raw.is_empty() {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut lines = stdout.lines();
+    let common_raw = lines.next()?.trim();
+    let toplevel_raw = lines.next()?.trim();
+    if common_raw.is_empty() || toplevel_raw.is_empty() {
         return None;
     }
-    Path::new(&raw).canonicalize().ok()
+    // `--git-common-dir` may be reported relative to the queried directory;
+    // resolve it against `dir` rather than the process cwd.
+    let common_reported = Path::new(common_raw);
+    let common_absolute = if common_reported.is_absolute() {
+        common_reported.to_path_buf()
+    } else {
+        dir.join(common_reported)
+    };
+    let common = common_absolute.canonicalize().ok()?;
+    let toplevel = Path::new(toplevel_raw).canonicalize().ok()?;
+    Some((common, toplevel))
 }
 
 /// Positive proof that `target` lives in a working tree of the SAME repository

--- a/cli/src/path_safety.rs
+++ b/cli/src/path_safety.rs
@@ -74,8 +74,13 @@ pub(crate) fn write_file_no_follow(path: &Path, contents: impl AsRef<[u8]>) -> R
 /// is not inside a Git repository or the answer cannot be resolved — callers
 /// fail closed.
 pub(crate) fn git_toplevel(dir: &Path) -> Option<PathBuf> {
+    // `.arg(dir)` passes the path as raw OS bytes — a non-UTF-8 path must
+    // not silently skip repository detection (to_str() would return None
+    // and defeat anchoring on a perfectly valid Unix path).
     let output = std::process::Command::new("git")
-        .args(["-C", dir.to_str()?, "rev-parse", "--show-toplevel"])
+        .arg("-C")
+        .arg(dir)
+        .args(["rev-parse", "--show-toplevel"])
         .output()
         .ok()?;
     if !output.status.success() {
@@ -93,7 +98,9 @@ pub(crate) fn git_toplevel(dir: &Path) -> Option<PathBuf> {
 /// cannot be resolved — every one of which must fail closed at the call site.
 pub(crate) fn git_common_dir(dir: &Path) -> Option<PathBuf> {
     let output = std::process::Command::new("git")
-        .args(["-C", dir.to_str()?, "rev-parse", "--git-common-dir"])
+        .arg("-C")
+        .arg(dir)
+        .args(["rev-parse", "--git-common-dir"])
         .output()
         .ok()?;
     if !output.status.success() {
@@ -122,13 +129,9 @@ pub(crate) fn git_common_dir(dir: &Path) -> Option<PathBuf> {
 /// must fail closed.
 pub(crate) fn git_repo_identity(dir: &Path) -> Option<(PathBuf, PathBuf)> {
     let output = std::process::Command::new("git")
-        .args([
-            "-C",
-            dir.to_str()?,
-            "rev-parse",
-            "--git-common-dir",
-            "--show-toplevel",
-        ])
+        .arg("-C")
+        .arg(dir)
+        .args(["rev-parse", "--git-common-dir", "--show-toplevel"])
         .output()
         .ok()?;
     if !output.status.success() {

--- a/cli/src/path_safety.rs
+++ b/cli/src/path_safety.rs
@@ -202,6 +202,33 @@ pub(crate) fn ensure_agents_dir_within_project(project_root: &Path) -> Result<()
             agents_dir.display()
         );
     }
+    // Same boundary one level down: a real in-repo .agents whose skills
+    // subdir symlinks outside the repository would otherwise pass, and every
+    // skill write goes through .agents/skills.
+    let skills_dir = agents_dir.join("skills");
+    match std::fs::symlink_metadata(&skills_dir) {
+        // Missing is fine: create_dir_all will make it inside the project.
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(err) => bail!("failed to inspect project .agents/skills directory: {err}"),
+        Ok(_) => {}
+    }
+    let skills_dir_canon = skills_dir
+        .canonicalize()
+        .map_err(|err| anyhow::anyhow!("failed to resolve .agents/skills directory: {err}"))?;
+    if !skills_dir_canon.starts_with(&project_root_canon)
+        && !is_same_repository_worktree(&project_root_canon, &skills_dir_canon)
+    {
+        bail!(
+            "refusing .agents/skills path outside project root: {}",
+            skills_dir.display()
+        );
+    }
+    if !skills_dir_canon.is_dir() {
+        bail!(
+            "project .agents/skills path is not a directory: {}",
+            skills_dir.display()
+        );
+    }
     Ok(())
 }
 

--- a/cli/src/path_safety.rs
+++ b/cli/src/path_safety.rs
@@ -97,6 +97,25 @@ fn git_common_dir(dir: &Path) -> Option<PathBuf> {
     absolute.canonicalize().ok()
 }
 
+/// `git rev-parse --show-toplevel` for `dir`, canonicalized: the root of the
+/// working tree that physically contains `dir`. `None` when `dir` is not
+/// inside a working tree, when git is unavailable, or when the answer cannot
+/// be resolved — callers must fail closed.
+pub(crate) fn git_worktree_root(dir: &Path) -> Option<PathBuf> {
+    let output = std::process::Command::new("git")
+        .args(["-C", dir.to_str()?, "rev-parse", "--show-toplevel"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let raw = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if raw.is_empty() {
+        return None;
+    }
+    Path::new(&raw).canonicalize().ok()
+}
+
 /// Positive proof that `target` lives in a working tree of the SAME repository
 /// as `project_root` — both resolve to one `--git-common-dir`.
 ///

--- a/cli/src/path_safety.rs
+++ b/cli/src/path_safety.rs
@@ -185,6 +185,26 @@ pub(crate) fn is_same_repository_worktree(project_root: &Path, target: &Path) ->
     }
 }
 
+/// Is `claimed_checkout` the OTHER checkout's copy of this project's root?
+/// The project root may sit below the git toplevel (a project marker in a
+/// subdirectory); the repo layout is identical in every checkout, so the
+/// legitimate shared `.agents` parent is `<other toplevel>/<this project's
+/// repo-relative suffix>` — for a toplevel project that degenerates to the
+/// toplevel itself. Anything else (a nested decoy, a sibling project's
+/// root) is refused; unresolvable answers fail closed.
+fn is_corresponding_project_root(project_root_canon: &Path, claimed_checkout: &Path) -> bool {
+    let Some(own_toplevel) = git_toplevel(project_root_canon) else {
+        return false;
+    };
+    let Ok(suffix) = project_root_canon.strip_prefix(&own_toplevel) else {
+        return false;
+    };
+    let Some(claimed_toplevel) = git_toplevel(claimed_checkout) else {
+        return false;
+    };
+    claimed_toplevel.join(suffix) == *claimed_checkout
+}
+
 /// Reject a project `.agents` directory that resolves outside the project
 /// root before anything is written beneath it. [`write_file_no_follow`] only
 /// guards the final path component; this closes the symlinked-ancestor escape
@@ -244,10 +264,10 @@ pub(crate) fn ensure_agents_dir_within_project(project_root: &Path) -> Result<()
                 )
             })?;
         if !agents_dir_canon.ends_with(Path::new(".agents"))
-            || git_toplevel(&claimed_checkout).as_deref() != Some(claimed_checkout.as_path())
+            || !is_corresponding_project_root(&project_root_canon, &claimed_checkout)
         {
             bail!(
-                "refusing .agents that does not resolve to a checkout toplevel's .agents: {} -> {}",
+                "refusing .agents that does not resolve to the corresponding project root's .agents in another checkout: {} -> {}",
                 agents_dir.display(),
                 agents_dir_canon.display()
             );
@@ -279,9 +299,9 @@ pub(crate) fn ensure_agents_dir_within_project(project_root: &Path) -> Result<()
     // `../cli/src`, or `.agents -> .` making it the project's own `skills/`
     // source) would make install treat `<target>/<name>` as canonical and
     // recursively DELETE it on refresh. The resolved target must be exactly
-    // `<checkout toplevel>/.agents/skills` of a checkout sharing this
-    // project's Git common directory — the spelling suffix alone would still
-    // admit a nested decoy like `<repo>/decoy/.agents/skills`.
+    // the corresponding project root's `.agents/skills` in a checkout
+    // sharing this project's Git common directory — the spelling suffix
+    // alone would still admit a nested decoy like `<repo>/decoy/.agents/skills`.
     if skills_dir_canon.starts_with(&project_root_canon) {
         // In-project, the ONLY legitimate resolution is this project's own
         // `.agents/skills` — an alias like `.agents -> .` (making it the
@@ -297,8 +317,9 @@ pub(crate) fn ensure_agents_dir_within_project(project_root: &Path) -> Result<()
         }
     } else {
         // Out-of-project (same-repository worktree sharing): the target must
-        // be exactly `<checkout toplevel>/.agents/skills` — the spelling
-        // suffix alone would still admit a nested decoy in that worktree.
+        // be exactly the corresponding project root's `.agents/skills` in
+        // the other checkout — the spelling suffix alone would still admit
+        // a nested decoy in that worktree.
         if !skills_dir_canon.ends_with(Path::new(".agents/skills")) {
             bail!(
                 "refusing .agents/skills that resolves to a non-skills-root directory: {} -> {}",
@@ -316,16 +337,12 @@ pub(crate) fn ensure_agents_dir_within_project(project_root: &Path) -> Result<()
                     skills_dir_canon.display()
                 )
             })?;
-        let claimed_toplevel = git_toplevel(&claimed_checkout);
-        if claimed_toplevel.as_deref() != Some(claimed_checkout.as_path()) {
+        if !is_corresponding_project_root(&project_root_canon, &claimed_checkout) {
             bail!(
-                "refusing .agents/skills whose parent is not a checkout toplevel: {} -> {} (toplevel: {})",
+                "refusing .agents/skills whose parent is not the corresponding project root in another checkout: {} -> {} (expected {} at the checkout's copy of this project's repo-relative root)",
                 skills_dir.display(),
                 skills_dir_canon.display(),
-                claimed_toplevel
-                    .as_deref()
-                    .map(|p| p.display().to_string())
-                    .unwrap_or_else(|| "none".to_string())
+                claimed_checkout.display()
             );
         }
     }
@@ -460,6 +477,69 @@ mod tests {
         assert!(
             err.to_string().contains("non-canonical in-project"),
             "expected the .agents alias refusal, got: {err}"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// The supported sharing layout must keep working when the vstack
+    /// project root sits BELOW the git toplevel: `<wt>/apps/foo/.agents ->
+    /// <main>/apps/foo/.agents` is the corresponding project root's
+    /// `.agents`, while a SIBLING project's `.agents` in the same checkout
+    /// is not and must refuse.
+    #[cfg(unix)]
+    #[test]
+    fn nested_project_agents_shared_with_corresponding_checkout_root() {
+        use std::os::unix::fs::symlink;
+
+        let root = std::env::temp_dir().join(format!(
+            "vstack_nested_share_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        let main = root.join("main");
+        std::fs::create_dir_all(main.join("apps/foo/.agents/skills")).unwrap();
+        std::fs::create_dir_all(main.join("apps/bar/.agents")).unwrap();
+        std::fs::write(main.join("apps/foo/keep.txt"), "x").unwrap();
+        let git = |args: &[&str], cwd: &Path| {
+            let status = std::process::Command::new("git")
+                .args(args)
+                .current_dir(cwd)
+                .status()
+                .unwrap();
+            assert!(status.success(), "git {args:?} failed");
+        };
+        git(&["init", "-q"], &main);
+        git(&["add", "."], &main);
+        git(
+            &[
+                "-c",
+                "user.name=t",
+                "-c",
+                "user.email=t@t",
+                "commit",
+                "-qm",
+                "init",
+            ],
+            &main,
+        );
+        git(&["worktree", "add", "-q", "--detach", "../wt"], &main);
+        let wt_project = root.join("wt/apps/foo");
+        // `.agents` dirs are untracked, so the worktree has none — share
+        // the main checkout's, exactly as the worktree skill provisions.
+        symlink(main.join("apps/foo/.agents"), wt_project.join(".agents")).unwrap();
+        ensure_agents_dir_within_project(&wt_project).unwrap();
+
+        std::fs::remove_file(wt_project.join(".agents")).unwrap();
+        symlink(main.join("apps/bar/.agents"), wt_project.join(".agents")).unwrap();
+        let err = ensure_agents_dir_within_project(&wt_project).unwrap_err();
+        assert!(
+            err.to_string().contains("corresponding project root"),
+            "expected the corresponding-root refusal, got: {err}"
         );
 
         let _ = std::fs::remove_dir_all(&root);

--- a/cli/src/path_safety.rs
+++ b/cli/src/path_safety.rs
@@ -70,6 +70,24 @@ pub(crate) fn write_file_no_follow(path: &Path, contents: impl AsRef<[u8]>) -> R
     write_result
 }
 
+/// `git rev-parse --show-toplevel` for `dir`, canonicalized. `None` when `dir`
+/// is not inside a Git repository or the answer cannot be resolved — callers
+/// fail closed.
+pub(crate) fn git_toplevel(dir: &Path) -> Option<PathBuf> {
+    let output = std::process::Command::new("git")
+        .args(["-C", dir.to_str()?, "rev-parse", "--show-toplevel"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let raw = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if raw.is_empty() {
+        return None;
+    }
+    Path::new(&raw).canonicalize().ok()
+}
+
 /// `git rev-parse --git-common-dir` for `dir`, canonicalized. `None` when `dir`
 /// is not inside a Git repository, when git is unavailable, or when the answer
 /// cannot be resolved — every one of which must fail closed at the call site.
@@ -225,18 +243,58 @@ pub(crate) fn ensure_agents_dir_within_project(project_root: &Path) -> Result<()
     }
     // Same-repository containment is necessary but not sufficient: a
     // `.agents/skills` symlinked to an arbitrary in-repo directory (e.g.
-    // `../cli/src`) would make install treat `<target>/<name>` as canonical
-    // and recursively DELETE it on refresh. The resolved target must itself
-    // be an `.agents/skills` root — either this `.agents`'s own subdir or an
-    // approved checkout's.
-    if skills_dir_canon != agents_dir_canon.join("skills")
-        && !skills_dir_canon.ends_with(Path::new(".agents/skills"))
-    {
-        bail!(
-            "refusing .agents/skills that resolves to a non-skills-root directory: {} -> {}",
-            skills_dir.display(),
-            skills_dir_canon.display()
-        );
+    // `../cli/src`, or `.agents -> .` making it the project's own `skills/`
+    // source) would make install treat `<target>/<name>` as canonical and
+    // recursively DELETE it on refresh. The resolved target must be exactly
+    // `<checkout toplevel>/.agents/skills` of a checkout sharing this
+    // project's Git common directory — the spelling suffix alone would still
+    // admit a nested decoy like `<repo>/decoy/.agents/skills`.
+    if skills_dir_canon.starts_with(&project_root_canon) {
+        // In-project, the ONLY legitimate resolution is this project's own
+        // `.agents/skills` — an alias like `.agents -> .` (making it the
+        // project's `skills/` source dir) or a nested decoy such as
+        // `<root>/decoy/.agents/skills` would otherwise become a canonical
+        // destination that refresh recursively deletes.
+        if skills_dir_canon != project_root_canon.join(".agents").join("skills") {
+            bail!(
+                "refusing .agents/skills that resolves to a non-canonical in-project directory: {} -> {}",
+                skills_dir.display(),
+                skills_dir_canon.display()
+            );
+        }
+    } else {
+        // Out-of-project (same-repository worktree sharing): the target must
+        // be exactly `<checkout toplevel>/.agents/skills` — the spelling
+        // suffix alone would still admit a nested decoy in that worktree.
+        if !skills_dir_canon.ends_with(Path::new(".agents/skills")) {
+            bail!(
+                "refusing .agents/skills that resolves to a non-skills-root directory: {} -> {}",
+                skills_dir.display(),
+                skills_dir_canon.display()
+            );
+        }
+        let claimed_checkout = skills_dir_canon
+            .parent()
+            .and_then(Path::parent)
+            .map(Path::to_path_buf)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "cannot derive a checkout root from {}",
+                    skills_dir_canon.display()
+                )
+            })?;
+        let claimed_toplevel = git_toplevel(&claimed_checkout);
+        if claimed_toplevel.as_deref() != Some(claimed_checkout.as_path()) {
+            bail!(
+                "refusing .agents/skills whose parent is not a checkout toplevel: {} -> {} (toplevel: {})",
+                skills_dir.display(),
+                skills_dir_canon.display(),
+                claimed_toplevel
+                    .as_deref()
+                    .map(|p| p.display().to_string())
+                    .unwrap_or_else(|| "none".to_string())
+            );
+        }
     }
     if !skills_dir_canon.is_dir() {
         bail!(
@@ -369,8 +427,8 @@ mod tests {
 
         let err = ensure_agents_dir_within_project(&root).unwrap_err();
         assert!(
-            err.to_string().contains("non-skills-root"),
-            "expected the non-skills-root refusal, got: {err}"
+            err.to_string().contains("non-canonical in-project"),
+            "expected the in-project refusal, got: {err}"
         );
 
         // The ordinary real layout stays accepted.

--- a/cli/src/path_safety.rs
+++ b/cli/src/path_safety.rs
@@ -73,11 +73,20 @@ pub(crate) fn write_file_no_follow(path: &Path, contents: impl AsRef<[u8]>) -> R
 /// Interpret one line of `git rev-parse` output as a path, preserving raw
 /// bytes on Unix: a non-UTF-8 checkout path must not be lossy-mangled into
 /// U+FFFD (canonicalize would then fail and same-repository detection would
-/// silently collapse to None). Trims ASCII whitespace at both ends.
+/// silently collapse to None). Strips ONLY the record terminator (`\n` /
+/// `\r\n`) — a path legitimately ending in a space or tab must survive.
 fn git_output_path(bytes: &[u8]) -> Option<PathBuf> {
-    let start = bytes.iter().position(|b| !b.is_ascii_whitespace())?;
-    let end = bytes.iter().rposition(|b| !b.is_ascii_whitespace())? + 1;
-    let trimmed = &bytes[start..end];
+    let mut end = bytes.len();
+    if end > 0 && bytes[end - 1] == b'\n' {
+        end -= 1;
+    }
+    if end > 0 && bytes[end - 1] == b'\r' {
+        end -= 1;
+    }
+    let trimmed = &bytes[..end];
+    if trimmed.is_empty() {
+        return None;
+    }
     #[cfg(unix)]
     {
         use std::os::unix::ffi::OsStrExt;

--- a/cli/src/tui/disk_mutations.rs
+++ b/cli/src/tui/disk_mutations.rs
@@ -10,6 +10,11 @@ pub(super) struct DiskMutationReport {
     pub attempted: usize,
     pub completed: usize,
     pub failed: Vec<String>,
+    /// Non-failure information the user must still see (e.g. anchored
+    /// canonicals left in another checkout). Collected here — never printed
+    /// from the worker thread, which runs while the TUI owns the terminal
+    /// in raw mode — and rendered by the main thread's flash line.
+    pub notices: Vec<String>,
 }
 
 impl DiskMutationReport {
@@ -18,6 +23,7 @@ impl DiskMutationReport {
             attempted,
             completed: 0,
             failed: Vec::new(),
+            notices: Vec::new(),
         }
     }
 
@@ -80,13 +86,13 @@ pub(super) fn perform_remove_plans(plans: &[RemovePlan]) -> DiskMutationReport {
         let mut removed_any = false;
         let mut failures = Vec::new();
         if plan.from_project {
-            match remove_one(&plan.name, false) {
+            match remove_one(&plan.name, false, &mut report.notices) {
                 Ok(removed) => removed_any |= removed,
                 Err(err) => failures.push(format!("project scope: {err:#}")),
             }
         }
         if plan.from_global {
-            match remove_one(&plan.name, true) {
+            match remove_one(&plan.name, true, &mut report.notices) {
                 Ok(removed) => removed_any |= removed,
                 Err(err) => failures.push(format!("global scope: {err:#}")),
             }
@@ -102,7 +108,11 @@ pub(super) fn perform_remove_plans(plans: &[RemovePlan]) -> DiskMutationReport {
     report
 }
 
-fn remove_one(name: &str, scope_global: bool) -> anyhow::Result<bool> {
+fn remove_one(
+    name: &str,
+    scope_global: bool,
+    notices: &mut Vec<String>,
+) -> anyhow::Result<bool> {
     let lock_path = config::lock_file_path(scope_global);
     let mut lock = config::LockFile::load(&lock_path)
         .map_err(|err| anyhow::anyhow!("failed to load lock {}: {err:#}", lock_path.display()))?;
@@ -134,10 +144,10 @@ fn remove_one(name: &str, scope_global: bool) -> anyhow::Result<bool> {
         let outcome =
             crate::installer::remove_item(name, Some(entry.kind), &harnesses, scope_global)?;
         for anchored in &outcome.anchored_left {
-            eprintln!(
-                "  Anchored canonical left in place (another checkout's): {}",
+            notices.push(format!(
+                "{name}: anchored canonical left in place (another checkout's): {}",
                 anchored.display()
-            );
+            ));
         }
     }
     lock.remove(name);
@@ -411,7 +421,7 @@ pub(super) fn perform_move_plans(
     // Remove files + lock entries at the source scope only for items that
     // actually made it to the destination.
     for name in &moved_names {
-        match remove_one(name, from_global) {
+        match remove_one(name, from_global, &mut report.notices) {
             Ok(true) => report.completed += 1,
             Ok(false) => report.fail(name, "source lock entry missing after destination install"),
             Err(err) => report.fail(name, format!("failed to remove source install: {err:#}")),

--- a/cli/src/tui/disk_mutations.rs
+++ b/cli/src/tui/disk_mutations.rs
@@ -60,7 +60,16 @@ fn rollback_destination_install(
         return String::new();
     }
     match crate::installer::remove_item(name, Some(kind), harnesses, scope_global) {
-        Ok(_) => String::new(),
+        Ok(outcome) if outcome.anchored_left.is_empty() => String::new(),
+        Ok(outcome) => format!(
+            "; rollback left anchored canonical(s) in place (another checkout's): {}",
+            outcome
+                .anchored_left
+                .iter()
+                .map(|path| path.display().to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
         Err(err) => format!("; rollback failed: {err:#}"),
     }
 }
@@ -122,7 +131,14 @@ fn remove_one(name: &str, scope_global: bool) -> anyhow::Result<bool> {
             .iter()
             .filter_map(|h| Harness::from_id(h))
             .collect();
-        crate::installer::remove_item(name, Some(entry.kind), &harnesses, scope_global)?;
+        let outcome =
+            crate::installer::remove_item(name, Some(entry.kind), &harnesses, scope_global)?;
+        for anchored in &outcome.anchored_left {
+            eprintln!(
+                "  Anchored canonical left in place (another checkout's): {}",
+                anchored.display()
+            );
+        }
     }
     lock.remove(name);
     lock.save(&lock_path)?;

--- a/cli/src/tui/disk_mutations/tests.rs
+++ b/cli/src/tui/disk_mutations/tests.rs
@@ -927,7 +927,7 @@ fn tui_remove_hook_refreshes_claude_agent_frontmatter() {
             )
             .unwrap();
 
-        assert!(remove_one("guard", false).unwrap());
+        assert!(remove_one("guard", false, &mut Vec::new()).unwrap());
     });
 
     let agent_body = std::fs::read_to_string(project.join(".claude/agents/rust.md")).unwrap();

--- a/cli/src/tui/install_flow.rs
+++ b/cli/src/tui/install_flow.rs
@@ -2207,8 +2207,18 @@ fn spawn_disk_work<F>(
 }
 
 fn format_disk_mutation_flash(report: &DiskMutationReport, action: &str, suffix: &str) -> String {
+    // Worker threads never print (raw-mode terminal is the TUI's); anything
+    // they collected as a notice surfaces here on the main thread instead.
+    let notice_suffix = if report.notices.is_empty() {
+        String::new()
+    } else {
+        format!(" \u{2014} {}", report.notices.join(" / "))
+    };
     if report.failed.is_empty() {
-        return format!("{action} {} item(s){suffix}", report.completed);
+        return format!(
+            "{action} {} item(s){suffix}{notice_suffix}",
+            report.completed
+        );
     }
 
     let first_failure = report
@@ -2222,13 +2232,13 @@ fn format_disk_mutation_flash(report: &DiskMutationReport, action: &str, suffix:
             report.completed,
             report.attempted,
             report.failed.len()
-        )
+        ) + &notice_suffix
     } else {
         format!(
             "Failed: {action} 0/{} item(s){suffix}; {} failed: {first_failure}",
             report.attempted,
             report.failed.len()
-        )
+        ) + &notice_suffix
     }
 }
 


### PR DESCRIPTION
Closes #1176 (Linear VST-195).

A `vstack refresh` run inside a git worktree rewrote the MAIN checkout's .claude/skills/* symlinks to absolute paths anchored in that worktree — remove the worktree and every skill link dangles, silently bricking skill discovery for the main checkout and every sibling worktree chained through it.

Root cause: install_skill's symlink method computed targets via relative_path, which bailed to an ABSOLUTE canonicalized target whenever the link's parent was behind a symlink. Provisioned worktrees symlink .claude/skills into the main checkout, so the link physically landed in main while the target canonicalized into the worktree that happened to run the refresh.

Fix: relative_path now takes a repo anchor. When a link endpoint's apparent path diverges from its physical home but that home is a worktree of the anchor's own repository (existing git-common-dir logic in path_safety), it writes the LEXICAL relative spelling — identical repo layout in every worktree means the link resolves inside whichever checkout it physically lands in. Endpoints escaping to unrelated trees (e.g. .claude symlinked into a dotfiles repo) keep the absolute fallback, pinned by the pre-existing test. git is spawned only when an endpoint is actually behind a symlink.

New tests reproduce the exact reported symptom (failing pre-fix): main-checkout link stays repo-local when refresh runs from a worktree; canonicalizes to a real SKILL.md inside main; unit-level anchor behavior. Suite 548+17 green, clippy clean, integration 29/29.

https://claude.ai/code/session_019FKRouqRHJkXvNRXvZehgg