### PR TITLE
fix(cli): anchor rendered vstack.toml pointer to the repository root

### DIFF
--- a/cli/src/harness/claude.rs
+++ b/cli/src/harness/claude.rs
@@ -80,7 +80,7 @@ pub fn generate_agent(
     }
 
     output.push_str("---\n\n");
-    output.push_str("> **Never edit this file directly.** To make additions or modifications, edit the appropriate section in `./vstack.toml`. Then run `vstack refresh`.\n\n");
+    output.push_str("> **Never edit this file directly.** To make additions or modifications, edit the appropriate section in `vstack.toml` at the repository root. Then run `vstack refresh`.\n\n");
 
     // Insert guidance + skills after first heading's intro
     let guidance = agent::guidance_section(extras.guidance.as_deref());

--- a/cli/src/harness/claude.rs
+++ b/cli/src/harness/claude.rs
@@ -80,7 +80,7 @@ pub fn generate_agent(
     }
 
     output.push_str("---\n\n");
-    output.push_str("> **Never edit this file directly.** To make additions or modifications, edit the appropriate section in `vstack.toml` at the repository root. Then run `vstack refresh`.\n\n");
+    output.push_str("> **Never edit this file directly.** To make additions or modifications, edit the appropriate section in the managing project's vstack config — `vstack.toml` at the vstack project root, or `vstack-local.toml` in a source-catalog checkout. Then run `vstack refresh`.\n\n");
 
     // Insert guidance + skills after first heading's intro
     let guidance = agent::guidance_section(extras.guidance.as_deref());

--- a/cli/src/harness/codex.rs
+++ b/cli/src/harness/codex.rs
@@ -65,7 +65,7 @@ pub fn generate_agent(
 
     // Build TOML manually to control format (triple-quoted developer_instructions)
     let mut output = String::new();
-    output.push_str("# Never edit this file directly. To make additions or modifications, edit the appropriate section in vstack.toml at the repository root. Then run `vstack refresh`.\n\n");
+    output.push_str("# Never edit this file directly. To make additions or modifications, edit the appropriate section in the managing project's vstack config — vstack.toml at the vstack project root, or vstack-local.toml in a source-catalog checkout. Then run `vstack refresh`.\n\n");
     output.push_str(&format!("name = \"{}\"\n", escape_toml(&agent.name)));
     output.push_str(&format!(
         "nickname_candidates = {}\n",

--- a/cli/src/harness/codex.rs
+++ b/cli/src/harness/codex.rs
@@ -65,7 +65,7 @@ pub fn generate_agent(
 
     // Build TOML manually to control format (triple-quoted developer_instructions)
     let mut output = String::new();
-    output.push_str("# Never edit this file directly. To make additions or modifications, edit the appropriate section in ./vstack.toml. Then run `vstack refresh`.\n\n");
+    output.push_str("# Never edit this file directly. To make additions or modifications, edit the appropriate section in vstack.toml at the repository root. Then run `vstack refresh`.\n\n");
     output.push_str(&format!("name = \"{}\"\n", escape_toml(&agent.name)));
     output.push_str(&format!(
         "nickname_candidates = {}\n",

--- a/cli/src/harness/cursor.rs
+++ b/cli/src/harness/cursor.rs
@@ -26,7 +26,7 @@ pub fn generate_agent(
     ));
     output.push_str("alwaysApply: false\n");
     output.push_str("---\n\n");
-    output.push_str("> **Never edit this file directly.** To make additions or modifications, edit the appropriate section in `./vstack.toml`. Then run `vstack refresh`.\n\n");
+    output.push_str("> **Never edit this file directly.** To make additions or modifications, edit the appropriate section in `vstack.toml` at the repository root. Then run `vstack refresh`.\n\n");
 
     let guidance = agent::guidance_section(extras.guidance.as_deref());
     let skills_section = agent::load_skills_section();

--- a/cli/src/harness/cursor.rs
+++ b/cli/src/harness/cursor.rs
@@ -26,7 +26,7 @@ pub fn generate_agent(
     ));
     output.push_str("alwaysApply: false\n");
     output.push_str("---\n\n");
-    output.push_str("> **Never edit this file directly.** To make additions or modifications, edit the appropriate section in `vstack.toml` at the repository root. Then run `vstack refresh`.\n\n");
+    output.push_str("> **Never edit this file directly.** To make additions or modifications, edit the appropriate section in the managing project's vstack config — `vstack.toml` at the vstack project root, or `vstack-local.toml` in a source-catalog checkout. Then run `vstack refresh`.\n\n");
 
     let guidance = agent::guidance_section(extras.guidance.as_deref());
     let skills_section = agent::load_skills_section();

--- a/cli/src/harness/opencode.rs
+++ b/cli/src/harness/opencode.rs
@@ -54,7 +54,7 @@ pub fn generate_agent(
     }
 
     output.push_str("---\n\n");
-    output.push_str("> **Never edit this file directly.** To make additions or modifications, edit the appropriate section in `vstack.toml` at the repository root. Then run `vstack refresh`.\n\n");
+    output.push_str("> **Never edit this file directly.** To make additions or modifications, edit the appropriate section in the managing project's vstack config — `vstack.toml` at the vstack project root, or `vstack-local.toml` in a source-catalog checkout. Then run `vstack refresh`.\n\n");
 
     let guidance = agent::guidance_section(extras.guidance.as_deref());
     let skills_section = agent::load_skills_section();

--- a/cli/src/harness/opencode.rs
+++ b/cli/src/harness/opencode.rs
@@ -54,7 +54,7 @@ pub fn generate_agent(
     }
 
     output.push_str("---\n\n");
-    output.push_str("> **Never edit this file directly.** To make additions or modifications, edit the appropriate section in `./vstack.toml`. Then run `vstack refresh`.\n\n");
+    output.push_str("> **Never edit this file directly.** To make additions or modifications, edit the appropriate section in `vstack.toml` at the repository root. Then run `vstack refresh`.\n\n");
 
     let guidance = agent::guidance_section(extras.guidance.as_deref());
     let skills_section = agent::load_skills_section();

--- a/cli/src/harness/pi.rs
+++ b/cli/src/harness/pi.rs
@@ -73,7 +73,7 @@ pub fn generate_agent(
     }
     output.push_str("---\n\n");
 
-    output.push_str("> **Never edit this file directly.** To make additions or modifications, edit the appropriate section in `vstack.toml` at the repository root. Then run `vstack refresh`.\n\n");
+    output.push_str("> **Never edit this file directly.** To make additions or modifications, edit the appropriate section in the managing project's vstack config — `vstack.toml` at the vstack project root, or `vstack-local.toml` in a source-catalog checkout. Then run `vstack refresh`.\n\n");
 
     let guidance = agent::guidance_section(extras.guidance.as_deref());
     let skills_section = agent::load_skills_section();

--- a/cli/src/harness/pi.rs
+++ b/cli/src/harness/pi.rs
@@ -73,7 +73,7 @@ pub fn generate_agent(
     }
     output.push_str("---\n\n");
 
-    output.push_str("> **Never edit this file directly.** To make additions or modifications, edit the appropriate section in `./vstack.toml`. Then run `vstack refresh`.\n\n");
+    output.push_str("> **Never edit this file directly.** To make additions or modifications, edit the appropriate section in `vstack.toml` at the repository root. Then run `vstack refresh`.\n\n");
 
     let guidance = agent::guidance_section(extras.guidance.as_deref());
     let skills_section = agent::load_skills_section();

--- a/cli/src/skill.rs
+++ b/cli/src/skill.rs
@@ -103,7 +103,7 @@ pub fn inject_vstack_notice(skill_md_path: &Path) {
         return;
     };
 
-    let notice = "> **Never edit this file directly.** To make additions or modifications, edit the appropriate section in `vstack.toml` at the repository root. Then run `vstack refresh`.";
+    let notice = "> **Never edit this file directly.** To make additions or modifications, edit the appropriate section in the managing project's vstack config — `vstack.toml` at the vstack project root, or `vstack-local.toml` in a source-catalog checkout. Then run `vstack refresh`.";
 
     // Already present? Skip.
     if content.contains("Never edit this file directly") {

--- a/cli/src/skill.rs
+++ b/cli/src/skill.rs
@@ -103,7 +103,7 @@ pub fn inject_vstack_notice(skill_md_path: &Path) {
         return;
     };
 
-    let notice = "> **Never edit this file directly.** To make additions or modifications, edit the appropriate section in `./vstack.toml`. Then run `vstack refresh`.";
+    let notice = "> **Never edit this file directly.** To make additions or modifications, edit the appropriate section in `vstack.toml` at the repository root. Then run `vstack refresh`.";
 
     // Already present? Skip.
     if content.contains("Never edit this file directly") {

--- a/skills/dev/workflows/dev-fix.md
+++ b/skills/dev/workflows/dev-fix.md
@@ -44,7 +44,7 @@ For each item in `Review items:`:
    - If review item contradicts an active decision, skip with decision reference (e.g., "Skipped — contradicts D010")
    - Expanding scope is OK if it relates to the parent issue/PR
 
-4. **Update architecture docs** if fix changes documented behavior. If it reveals project-specific insights, add to `./vstack.toml` under `[agent-launch-instructions]`, `[agent-additional-instructions]`, or `[skill-instructions]`.
+4. **Update architecture docs** if fix changes documented behavior. If it reveals project-specific insights, add to `vstack.toml` at the repository root under `[agent-launch-instructions]`, `[agent-additional-instructions]`, or `[skill-instructions]`.
 
 5. **For UI lifecycle/cache fixes**: If you introduce cached/mirrored UI state or change window/event handling, trace all invalidation and event-entry paths before returning. Prefer extending existing listeners over adding parallel subscriptions for the same event family, and add regression coverage for the non-obvious paths you touched.
 
@@ -108,7 +108,7 @@ If validation failures exist, append: `[validate: FAILING_CHECK]`
 **Action**: Update the relevant documentation:
 
 - **Architecture docs** → Update if patterns, APIs, or documented behavior changed.
-- **Project config** → Add to `./vstack.toml` (`[skill-instructions]`, `[agent-additional-instructions]`, or `[agent-launch-instructions]`). Run `vstack refresh` to apply.
+- **Project config** → Add to `vstack.toml` at the repository root (`[skill-instructions]`, `[agent-additional-instructions]`, or `[agent-launch-instructions]`). Run `vstack refresh` to apply.
 
 Criteria: Would this save 5+ minutes in a future session? If yes, update. One surgical addition per lesson. No verbose examples.
 

--- a/skills/dev/workflows/dev-fix.md
+++ b/skills/dev/workflows/dev-fix.md
@@ -44,7 +44,7 @@ For each item in `Review items:`:
    - If review item contradicts an active decision, skip with decision reference (e.g., "Skipped — contradicts D010")
    - Expanding scope is OK if it relates to the parent issue/PR
 
-4. **Update architecture docs** if fix changes documented behavior. If it reveals project-specific insights, add to `vstack.toml` at the repository root under `[agent-launch-instructions]`, `[agent-additional-instructions]`, or `[skill-instructions]`.
+4. **Update architecture docs** if fix changes documented behavior. If it reveals project-specific insights, add to the managing project's vstack config (`vstack.toml` at the vstack project root; `vstack-local.toml` in a source-catalog checkout) under `[agent-launch-instructions]`, `[agent-additional-instructions]`, or `[skill-instructions]`.
 
 5. **For UI lifecycle/cache fixes**: If you introduce cached/mirrored UI state or change window/event handling, trace all invalidation and event-entry paths before returning. Prefer extending existing listeners over adding parallel subscriptions for the same event family, and add regression coverage for the non-obvious paths you touched.
 
@@ -108,7 +108,7 @@ If validation failures exist, append: `[validate: FAILING_CHECK]`
 **Action**: Update the relevant documentation:
 
 - **Architecture docs** → Update if patterns, APIs, or documented behavior changed.
-- **Project config** → Add to `vstack.toml` at the repository root (`[skill-instructions]`, `[agent-additional-instructions]`, or `[agent-launch-instructions]`). Run `vstack refresh` to apply.
+- **Project config** → Add to the managing project's vstack config (`vstack.toml` at the vstack project root; `vstack-local.toml` in a source-catalog checkout) (`[skill-instructions]`, `[agent-additional-instructions]`, or `[agent-launch-instructions]`). Run `vstack refresh` to apply.
 
 Criteria: Would this save 5+ minutes in a future session? If yes, update. One surgical addition per lesson. No verbose examples.
 

--- a/skills/dev/workflows/dev-implement.md
+++ b/skills/dev/workflows/dev-implement.md
@@ -299,7 +299,7 @@ Use visual QA skills to validate that UI changes render correctly. Focus on what
 **Action**: Update the relevant documentation:
 
 - **Architecture docs** → Update if patterns, APIs, or documented behavior changed.
-- **Project config** → Add to `./vstack.toml` (`[skill-instructions]`, `[agent-additional-instructions]`, or `[agent-launch-instructions]`). Run `vstack refresh` to apply.
+- **Project config** → Add to `vstack.toml` at the repository root (`[skill-instructions]`, `[agent-additional-instructions]`, or `[agent-launch-instructions]`). Run `vstack refresh` to apply.
 
 Criteria: Would this save 5+ minutes in a future session? If yes, update. One surgical addition per lesson. No verbose examples.
 

--- a/skills/dev/workflows/dev-implement.md
+++ b/skills/dev/workflows/dev-implement.md
@@ -299,7 +299,7 @@ Use visual QA skills to validate that UI changes render correctly. Focus on what
 **Action**: Update the relevant documentation:
 
 - **Architecture docs** → Update if patterns, APIs, or documented behavior changed.
-- **Project config** → Add to `vstack.toml` at the repository root (`[skill-instructions]`, `[agent-additional-instructions]`, or `[agent-launch-instructions]`). Run `vstack refresh` to apply.
+- **Project config** → Add to the managing project's vstack config (`vstack.toml` at the vstack project root; `vstack-local.toml` in a source-catalog checkout) (`[skill-instructions]`, `[agent-additional-instructions]`, or `[agent-launch-instructions]`). Run `vstack refresh` to apply.
 
 Criteria: Would this save 5+ minutes in a future session? If yes, update. One surgical addition per lesson. No verbose examples.
 

--- a/skills/project-management/workflows/research-complete.md
+++ b/skills/project-management/workflows/research-complete.md
@@ -292,7 +292,7 @@ For each blocked issue:
 **Implement changes** from agent reports:
 - Update architecture docs as described
 - Add DXXX references to affected files
-- If agents reported reusable rules or project-specific insights, add to `./vstack.toml` (`[skill-instructions]` for skill-level context, `[agent-additional-instructions]` for persistent agent rules, `[agent-launch-instructions]` for launch/startup instructions)
+- If agents reported reusable rules or project-specific insights, add to `vstack.toml` at the repository root (`[skill-instructions]` for skill-level context, `[agent-additional-instructions]` for persistent agent rules, `[agent-launch-instructions]` for launch/startup instructions)
 - Run `vstack refresh` to apply config
 - For Pervasive: combine updates from all domain agents
 

--- a/skills/project-management/workflows/research-complete.md
+++ b/skills/project-management/workflows/research-complete.md
@@ -292,7 +292,7 @@ For each blocked issue:
 **Implement changes** from agent reports:
 - Update architecture docs as described
 - Add DXXX references to affected files
-- If agents reported reusable rules or project-specific insights, add to `vstack.toml` at the repository root (`[skill-instructions]` for skill-level context, `[agent-additional-instructions]` for persistent agent rules, `[agent-launch-instructions]` for launch/startup instructions)
+- If agents reported reusable rules or project-specific insights, add to the managing project's vstack config (`vstack.toml` at the vstack project root; `vstack-local.toml` in a source-catalog checkout) (`[skill-instructions]` for skill-level context, `[agent-additional-instructions]` for persistent agent rules, `[agent-launch-instructions]` for launch/startup instructions)
 - Run `vstack refresh` to apply config
 - For Pervasive: combine updates from all domain agents
 


### PR DESCRIPTION
Closes #1181 (Linear VST-198).

The header rendered into every managed SKILL.md said "edit ... `./vstack.toml`" — relative prose that dangles when a consumer re-vendors the mirror into a tracked subtree (VGS's third_party/review-gate). All 6 render sites (skill.rs + five harness renderers) now say "`vstack.toml` at the repository root", and the same relative spelling is synced out of 3 workflow docs that mirror into consumers. Repo-wide grep for ./vstack.toml: zero hits. 10-line diff, no behavior change; no test pinned the old wording.

https://claude.ai/code/session_019FKRouqRHJkXvNRXvZehgg