### PR TITLE
test(review-gate): selftest exercises committed carry-exclude globs

### DIFF
--- a/skills/review-gate/scripts/review-predicate-selftest.sh
+++ b/skills/review-gate/scripts/review-predicate-selftest.sh
@@ -1700,14 +1700,18 @@ glob_matches() { # path, glob — the predicate's exact `case` matcher
 # repository, not merely the string the probe itself manufactured from that
 # same glob (a typo'd `skils/*` matches `skils/probe.md` forever). Empty in
 # hermetic harnesses — the manufactured fallback keeps those deterministic.
-EXCLUDE_TRACKED="$(
-  _selftest_repo_root="$(git -C "$(cd "$(dirname "$0")" && pwd)" rev-parse --show-toplevel 2>/dev/null)" &&
-    git -C "$_selftest_repo_root" ls-files 2>/dev/null || true
-)"
+# Resolved from the INVOKING directory's repository — the settings under
+# test belong to that repo, so its tracked tree is the evidence base. Empty
+# when the selftest runs outside a repository (hermetic harnesses): only
+# there do manufactured probe paths apply.
+EXCLUDE_TRACKED="$(git ls-files --full-name 2>/dev/null || true)"
 exclude_glob_probe() { # glob, ext... -> a carry-class path this glob matches
-  # Real tracked matches first (non-circular evidence the glob is alive in
-  # this repository); manufactured '*'-filler paths only as fallback, and
-  # the concrete path is always re-proven against its source glob.
+  # Tracked mode (a real repository): ONLY real tracked matches count — a
+  # synthetic filler manufactured from the glob under test would let a
+  # typo'd `skils/*` verify itself against its own fabrication. No tracked
+  # match returns 2 so the caller can say so out loud. Hermetic mode (no
+  # repository): the '*'-filler fallback keeps harness runs deterministic,
+  # and the concrete path is still re-proven against its source glob.
   local pat="$1" ext candidate
   shift
   if [ -n "$EXCLUDE_TRACKED" ]; then
@@ -1723,6 +1727,7 @@ exclude_glob_probe() { # glob, ext... -> a carry-class path this glob matches
     done <<EOF_TRACKED_PROBE
 $EXCLUDE_TRACKED
 EOF_TRACKED_PROBE
+    return 2
   fi
   case "$pat" in *'?'*|*'['*|*'\'*) return 1 ;; esac
   for ext in "$@"; do
@@ -1738,10 +1743,32 @@ EOF_TRACKED_PROBE
   return 1
 }
 exclude_free_path() { # ext... -> a path NO committed glob matches
-  # Every carry-class extension gets candidates: an exclude list covering
-  # all .md probe paths while .markdown stays carry-eligible must still
-  # prove the positive (non-matching deltas carry).
+  # Tracked mode: a REAL tracked carry-class file outside every glob is the
+  # positive proof (a committed `carry-probe*` exclusion must not read as
+  # "nothing can carry" while README.md still carries). Hermetic mode:
+  # synthetic candidates per extension.
   local ext candidate pat hit
+  if [ -n "$EXCLUDE_TRACKED" ]; then
+    while IFS= read -r candidate; do
+      [ -z "$candidate" ] && continue
+      hit=""
+      for ext in "$@"; do
+        case "$candidate" in *"$ext") hit=ext-ok ;; esac
+      done
+      [ "$hit" = "ext-ok" ] || continue
+      hit=""
+      while IFS= read -r pat; do
+        [ -z "$pat" ] && continue
+        if glob_matches "$candidate" "$pat"; then hit=1; break; fi
+      done <<EOF_FREE_TRACKED
+$(list_items "$ACTIVE_CARRY_EXCLUDE")
+EOF_FREE_TRACKED
+      if [ -z "$hit" ]; then printf '%s\n' "$candidate"; return 0; fi
+    done <<EOF_TRACKED_FREE
+$EXCLUDE_TRACKED
+EOF_TRACKED_FREE
+    return 1
+  fi
   for ext in "$@"; do
     for candidate in "carry-probe/unrelated$ext" "carry-probe-unrelated$ext"; do
       hit=""
@@ -1780,19 +1807,27 @@ if [ -n "$ACTIVE_CARRY" ]; then
   # every committed glob must still carry (the exclusion neither dead nor
   # over-broad).
   if [ -n "$ACTIVE_CARRY_EXCLUDE" ]; then
-    if carry_class_has docs; then
-      # Both docs-class extensions: a `*.markdown`-targeted glob must not
-      # ride green on an `.md`-only probe (and vice versa).
-      probe_exts=".md .markdown"
-      probe_patch='@@ -1 +1 @@
--old prose
-+new prose'
-    else
-      probe_exts=".sh"
-      probe_patch='@@ -1 +1 @@
+    # Probe extensions span EVERY enabled class — docs alone must not leave
+    # a comments-class exclusion (`src/*.sh`) untested, and an exclusion set
+    # covering all Markdown is not "carry disabled" while comment-only
+    # changes still carry.
+    probe_exts=""
+    carry_class_has docs && probe_exts=".md .markdown"
+    carry_class_has comments && probe_exts="${probe_exts:+$probe_exts }.sh"
+    [ -n "$probe_exts" ] || probe_exts=".md .markdown"
+    # Per-extension patches: a docs probe changes prose, a comments probe
+    # changes a comment line, so the delta classifies into its class and the
+    # refusal below is attributable to the exclusion alone.
+    probe_patch_for() {
+      case "$1" in
+      *.sh) printf '%s' '@@ -1 +1 @@
 -# old comment
-+# new comment'
-    fi
++# new comment' ;;
+      *) printf '%s' '@@ -1 +1 @@
+-old prose
++new prose' ;;
+      esac
+    }
     # shellcheck disable=SC2086 # probe_exts is a controlled word list
     probe_free="$(exclude_free_path $probe_exts)" || probe_free=""
 
@@ -1812,13 +1847,16 @@ if [ -n "$ACTIVE_CARRY" ]; then
         ;;
       esac
       # shellcheck disable=SC2086 # probe_exts is a controlled word list
-      probe_match="$(exclude_glob_probe "$probe_pat" $probe_exts)" || probe_match=""
-      if [ -n "$probe_match" ]; then
+      probe_match="$(exclude_glob_probe "$probe_pat" $probe_exts)"
+      probe_rc=$?
+      if [ "$probe_rc" -eq 0 ] && [ -n "$probe_match" ]; then
         reset
         CFG_TRUSTED_LOGINS="$ACTIVE_TRUSTED_LOGINS"
         reviews_set "$(review "$(trusted_reviewer)" APPROVED "2026-01-01T00:00:00Z" "$OTHER")"
-        compare_fix ahead "[$(delta_file "$probe_match" modified "$probe_patch")]"
+        compare_fix ahead "[$(delta_file "$probe_match" modified "$(probe_patch_for "$probe_match")")]"
         run "configured: carry-exclude — '$probe_pat' matches '$probe_match', refusing the carry" awaiting
+      elif [ "$probe_rc" -eq 2 ]; then
+        echo "note  configured: carry-exclude — '$probe_pat' matches NO tracked carry-class ($probe_exts) path in this repository: prophylactic, or a typo/wrong anchor — verify the spelling; not exercised here"
       else
         echo "note  configured: carry-exclude — '$probe_pat' derives no carry-class ($probe_exts) probe: it guards paths the enabled carry class never carries, or uses ?/[/\\ metacharacters; not exercised here"
       fi
@@ -1830,15 +1868,17 @@ EOF_EXCLUDE_BATTERY
       reset
       CFG_TRUSTED_LOGINS="$ACTIVE_TRUSTED_LOGINS"
       reviews_set "$(review "$(trusted_reviewer)" APPROVED "2026-01-01T00:00:00Z" "$OTHER")"
-      compare_fix ahead "[$(delta_file "$probe_free" modified "$probe_patch")]"
+      compare_fix ahead "[$(delta_file "$probe_free" modified "$(probe_patch_for "$probe_free")")]"
       run "configured: carry-exclude — '$probe_free' is outside every committed glob and still carries" approved
     else
-      # Exclusions swallowing EVERY carry-class candidate mean no docs/
-      # comments delta can ever carry — the enabled class is dead config,
-      # exactly the over-broadness this battery exists to catch. FAIL, not
-      # a note: a repo intending that posture should disable the class.
+      # No carry-class path escapes the exclusions — tracked mode proved it
+      # against the repository's real tree (a committed `carry-probe*` glob
+      # cannot trip this while README.md still carries), hermetic mode
+      # against every synthetic candidate. Either way the enabled classes
+      # are dead config: FAIL, not a note — a repo intending that posture
+      # should disable the class.
       cases=$((cases + 1))
-      echo "FAIL  configured: carry-exclude — the committed exclusions match every carry-class probe path ($probe_exts); the enabled carry class can never apply (over-broad exclusion set, or disable REVIEW_GATE_CARRY_FORWARD instead)" >&2
+      echo "FAIL  configured: carry-exclude — the committed exclusions match every carry-class ($probe_exts) path; the enabled carry class can never apply (over-broad exclusion set, or disable REVIEW_GATE_CARRY_FORWARD instead)" >&2
       failures=$((failures + 1))
     fi
   fi

--- a/skills/review-gate/scripts/review-predicate-selftest.sh
+++ b/skills/review-gate/scripts/review-predicate-selftest.sh
@@ -1707,11 +1707,19 @@ glob_matches() { # path, glob — the predicate's exact `case` matcher
 # battery (the only consumer), not at script start, and via -z so quoted
 # unusual pathnames round-trip instead of mis-probing globs.
 EXCLUDE_TRACKED=""
+EXCLUDE_TRACKED_ERROR=""
 exclude_tracked_loaded=""
 load_exclude_tracked() {
   [ -n "$exclude_tracked_loaded" ] && return 0
   exclude_tracked_loaded=1
-  EXCLUDE_TRACKED="$(git ls-files -z 2>/dev/null | tr '\0' '\n' || true)"
+  # A real repository whose ls-files FAILS must not silently degrade into
+  # hermetic synthetic probing — that would shrink coverage exactly when
+  # git is broken. Only a genuinely-not-a-repo cwd is hermetic.
+  if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    if ! EXCLUDE_TRACKED="$(git ls-files -z 2>/dev/null | tr '\0' '\n')"; then
+      EXCLUDE_TRACKED_ERROR=1
+    fi
+  fi
 }
 exclude_glob_probe() { # glob, ext... -> a carry-class path this glob matches
   # Tracked mode (a real repository): ONLY real tracked matches count — a
@@ -1816,20 +1824,33 @@ if [ -n "$ACTIVE_CARRY" ]; then
   # over-broad).
   if [ -n "$ACTIVE_CARRY_EXCLUDE" ]; then
     load_exclude_tracked
+    if [ -n "$EXCLUDE_TRACKED_ERROR" ]; then
+      cases=$((cases + 1))
+      echo "FAIL  configured: carry-exclude — this IS a git repository but 'git ls-files' failed; refusing to degrade to synthetic probes (fix git, or run the harness outside a repository)" >&2
+      failures=$((failures + 1))
+    fi
     # Probe extensions span EVERY enabled class — docs alone must not leave
     # a comments-class exclusion (`src/*.sh`) untested, and an exclusion set
     # covering all Markdown is not "carry disabled" while comment-only
     # changes still carry.
     probe_exts=""
     carry_class_has docs && probe_exts=".md .markdown"
-    carry_class_has comments && probe_exts="${probe_exts:+$probe_exts }.sh"
+    # Every extension the predicate's comment-token table classifies —
+    # both the '#' and the '//' families — so an exclusion like
+    # cli/src/*.rs is exercised, not skipped as "no probe".
+    carry_class_has comments && probe_exts="${probe_exts:+$probe_exts }.sh .bash .py .rb .toml .yml .yaml .js .mjs .cjs .ts .tsx .jsx .rs .go .c .h .cc .cpp .hpp .java .kt .swift"
     [ -n "$probe_exts" ] || probe_exts=".md .markdown"
     # Per-extension patches: a docs probe changes prose, a comments probe
     # changes a comment line, so the delta classifies into its class and the
     # refusal below is attributable to the exclusion alone.
     probe_patch_for() {
       case "$1" in
-      *.sh) printf '%s' '@@ -1 +1 @@
+      *.js | *.mjs | *.cjs | *.ts | *.tsx | *.jsx | *.rs | *.go | *.c | *.h | *.cc | *.cpp | *.hpp | *.java | *.kt | *.swift)
+        printf '%s' '@@ -1 +1 @@
+-// old comment
++// new comment' ;;
+      *.sh | *.bash | *.py | *.rb | *.toml | *.yml | *.yaml)
+        printf '%s' '@@ -1 +1 @@
 -# old comment
 +# new comment' ;;
       *) printf '%s' '@@ -1 +1 @@
@@ -1879,16 +1900,18 @@ EOF_EXCLUDE_BATTERY
       reviews_set "$(review "$(trusted_reviewer)" APPROVED "2026-01-01T00:00:00Z" "$OTHER")"
       compare_fix ahead "[$(delta_file "$probe_free" modified "$(probe_patch_for "$probe_free")")]"
       run "configured: carry-exclude — '$probe_free' is outside every committed glob and still carries" approved
-    else
-      # No carry-class path escapes the exclusions — tracked mode proved it
-      # against the repository's real tree (a committed `carry-probe*` glob
-      # cannot trip this while README.md still carries), hermetic mode
-      # against every synthetic candidate. Either way the enabled classes
-      # are dead config: FAIL, not a note — a repo intending that posture
-      # should disable the class.
+    elif [ -z "$EXCLUDE_TRACKED" ]; then
+      # Hermetic mode with every synthetic candidate matched: only a
+      # universal exclusion does that — dead config, FAIL.
       cases=$((cases + 1))
       echo "FAIL  configured: carry-exclude — the committed exclusions match every carry-class ($probe_exts) path; the enabled carry class can never apply (over-broad exclusion set, or disable REVIEW_GATE_CARRY_FORWARD instead)" >&2
       failures=$((failures + 1))
+    else
+      # Tracked mode: the CURRENT tree has no carry-free carry-class file,
+      # but future files outside the globs can still carry (a repo whose
+      # only Markdown is an intentionally excluded README is legitimate).
+      # Loud note, not a FAIL — the current tree cannot prove universality.
+      echo "note  configured: carry-exclude — no TRACKED carry-class ($probe_exts) file escapes the committed exclusions today; the positive carry case is unproven against this tree (future non-excluded files still carry)"
     fi
   fi
 fi

--- a/skills/review-gate/scripts/review-predicate-selftest.sh
+++ b/skills/review-gate/scripts/review-predicate-selftest.sh
@@ -1695,16 +1695,37 @@ glob_matches() { # path, glob — the predicate's exact `case` matcher
   case "$1" in $2) return 0 ;; esac
   return 1
 }
-exclude_match_path() { # ext -> a path the first usable committed glob matches
-  # Usable: '*'-only globs (no '?'/'['/escape metacharacters) whose derived
-  # path can end in ext, so the path classifies into the enabled carry class
-  # and the refusal below is attributable to the exclusion alone. Every '*'
-  # becomes a literal filler; the concrete path is then re-proven against
-  # its source glob before use, never assumed.
-  local ext="$1" pat candidate
-  while IFS= read -r pat; do
-    [ -z "$pat" ] && continue
-    case "$pat" in *'?'*|*'['*|*'\'*) continue ;; esac
+# The invoking repo's tracked tree, when this script lives inside one:
+# probes derived from REAL tracked paths prove a committed glob matches the
+# repository, not merely the string the probe itself manufactured from that
+# same glob (a typo'd `skils/*` matches `skils/probe.md` forever). Empty in
+# hermetic harnesses — the manufactured fallback keeps those deterministic.
+EXCLUDE_TRACKED="$(
+  _selftest_repo_root="$(git -C "$(cd "$(dirname "$0")" && pwd)" rev-parse --show-toplevel 2>/dev/null)" &&
+    git -C "$_selftest_repo_root" ls-files 2>/dev/null || true
+)"
+exclude_glob_probe() { # glob, ext... -> a carry-class path this glob matches
+  # Real tracked matches first (non-circular evidence the glob is alive in
+  # this repository); manufactured '*'-filler paths only as fallback, and
+  # the concrete path is always re-proven against its source glob.
+  local pat="$1" ext candidate
+  shift
+  if [ -n "$EXCLUDE_TRACKED" ]; then
+    while IFS= read -r candidate; do
+      [ -z "$candidate" ] && continue
+      glob_matches "$candidate" "$pat" || continue
+      for ext in "$@"; do
+        case "$candidate" in *"$ext")
+          printf '%s\n' "$candidate"
+          return 0 ;;
+        esac
+      done
+    done <<EOF_TRACKED_PROBE
+$EXCLUDE_TRACKED
+EOF_TRACKED_PROBE
+  fi
+  case "$pat" in *'?'*|*'['*|*'\'*) return 1 ;; esac
+  for ext in "$@"; do
     case "$pat" in
       *"$ext") candidate="${pat//\*/probe}" ;;
       *'*')    candidate="${pat//\*/probe}$ext" ;;
@@ -1713,9 +1734,7 @@ exclude_match_path() { # ext -> a path the first usable committed glob matches
     glob_matches "$candidate" "$pat" || continue
     printf '%s\n' "$candidate"
     return 0
-  done <<EOF_MATCH_PROBE
-$(list_items "$ACTIVE_CARRY_EXCLUDE")
-EOF_MATCH_PROBE
+  done
   return 1
 }
 exclude_free_path() { # ext -> a path NO committed glob matches
@@ -1757,28 +1776,49 @@ if [ -n "$ACTIVE_CARRY" ]; then
   # over-broad).
   if [ -n "$ACTIVE_CARRY_EXCLUDE" ]; then
     if carry_class_has docs; then
-      probe_ext=".md"
+      # Both docs-class extensions: a `*.markdown`-targeted glob must not
+      # ride green on an `.md`-only probe (and vice versa).
+      probe_exts=".md .markdown"
       probe_patch='@@ -1 +1 @@
 -old prose
 +new prose'
     else
-      probe_ext=".sh"
+      probe_exts=".sh"
       probe_patch='@@ -1 +1 @@
 -# old comment
 +# new comment'
     fi
-    probe_match="$(exclude_match_path "$probe_ext")" || probe_match=""
-    probe_free="$(exclude_free_path "$probe_ext")" || probe_free=""
+    probe_free="$(exclude_free_path "${probe_exts%% *}")" || probe_free=""
 
-    if [ -n "$probe_match" ]; then
-      reset
-      CFG_TRUSTED_LOGINS="$ACTIVE_TRUSTED_LOGINS"
-      reviews_set "$(review "$(trusted_reviewer)" APPROVED "2026-01-01T00:00:00Z" "$OTHER")"
-      compare_fix ahead "[$(delta_file "$probe_match" modified "$probe_patch")]"
-      run "configured: carry-exclude — a committed glob matches '$probe_match', refusing the carry" awaiting
-    else
-      echo "note  configured: carry-exclude — no committed glob can derive a carry-class path; match case skipped"
-    fi
+    # EVERY committed glob is exercised, not just the first usable one: a
+    # later typo'd or wrongly-anchored addition must not hide behind an
+    # earlier glob's green. Compare filenames are repository-relative, so a
+    # leading-'/' glob can never match any real delta — structurally dead,
+    # and a FAIL rather than a skip.
+    while IFS= read -r probe_pat; do
+      [ -z "$probe_pat" ] && continue
+      case "$probe_pat" in
+      /*)
+        cases=$((cases + 1))
+        echo "FAIL  configured: carry-exclude glob '$probe_pat' is anchored with a leading '/' — compare filenames are repository-relative, so this exclusion can never match and is dead" >&2
+        failures=$((failures + 1))
+        continue
+        ;;
+      esac
+      # shellcheck disable=SC2086 # probe_exts is a controlled word list
+      probe_match="$(exclude_glob_probe "$probe_pat" $probe_exts)" || probe_match=""
+      if [ -n "$probe_match" ]; then
+        reset
+        CFG_TRUSTED_LOGINS="$ACTIVE_TRUSTED_LOGINS"
+        reviews_set "$(review "$(trusted_reviewer)" APPROVED "2026-01-01T00:00:00Z" "$OTHER")"
+        compare_fix ahead "[$(delta_file "$probe_match" modified "$probe_patch")]"
+        run "configured: carry-exclude — '$probe_pat' matches '$probe_match', refusing the carry" awaiting
+      else
+        echo "note  configured: carry-exclude — '$probe_pat' derives no carry-class ($probe_exts) probe: it guards paths the enabled carry class never carries, or uses ?/[/\\ metacharacters; not exercised here"
+      fi
+    done <<EOF_EXCLUDE_BATTERY
+$(list_items "$ACTIVE_CARRY_EXCLUDE")
+EOF_EXCLUDE_BATTERY
 
     if [ -n "$probe_free" ]; then
       reset

--- a/skills/review-gate/scripts/review-predicate-selftest.sh
+++ b/skills/review-gate/scripts/review-predicate-selftest.sh
@@ -1703,8 +1703,16 @@ glob_matches() { # path, glob — the predicate's exact `case` matcher
 # Resolved from the INVOKING directory's repository — the settings under
 # test belong to that repo, so its tracked tree is the evidence base. Empty
 # when the selftest runs outside a repository (hermetic harnesses): only
-# there do manufactured probe paths apply.
-EXCLUDE_TRACKED="$(git ls-files --full-name 2>/dev/null || true)"
+# there do manufactured probe paths apply. Loaded LAZILY at the exclude
+# battery (the only consumer), not at script start, and via -z so quoted
+# unusual pathnames round-trip instead of mis-probing globs.
+EXCLUDE_TRACKED=""
+exclude_tracked_loaded=""
+load_exclude_tracked() {
+  [ -n "$exclude_tracked_loaded" ] && return 0
+  exclude_tracked_loaded=1
+  EXCLUDE_TRACKED="$(git ls-files -z 2>/dev/null | tr '\0' '\n' || true)"
+}
 exclude_glob_probe() { # glob, ext... -> a carry-class path this glob matches
   # Tracked mode (a real repository): ONLY real tracked matches count — a
   # synthetic filler manufactured from the glob under test would let a
@@ -1807,6 +1815,7 @@ if [ -n "$ACTIVE_CARRY" ]; then
   # every committed glob must still carry (the exclusion neither dead nor
   # over-broad).
   if [ -n "$ACTIVE_CARRY_EXCLUDE" ]; then
+    load_exclude_tracked
     # Probe extensions span EVERY enabled class — docs alone must not leave
     # a comments-class exclusion (`src/*.sh`) untested, and an exclusion set
     # covering all Markdown is not "carry disabled" while comment-only

--- a/skills/review-gate/scripts/review-predicate-selftest.sh
+++ b/skills/review-gate/scripts/review-predicate-selftest.sh
@@ -1737,17 +1737,22 @@ EOF_TRACKED_PROBE
   done
   return 1
 }
-exclude_free_path() { # ext -> a path NO committed glob matches
-  local ext="$1" candidate pat hit
-  for candidate in "carry-probe/unrelated$ext" "carry-probe-unrelated$ext"; do
-    hit=""
-    while IFS= read -r pat; do
-      [ -z "$pat" ] && continue
-      if glob_matches "$candidate" "$pat"; then hit=1; break; fi
-    done <<EOF_FREE_PROBE
+exclude_free_path() { # ext... -> a path NO committed glob matches
+  # Every carry-class extension gets candidates: an exclude list covering
+  # all .md probe paths while .markdown stays carry-eligible must still
+  # prove the positive (non-matching deltas carry).
+  local ext candidate pat hit
+  for ext in "$@"; do
+    for candidate in "carry-probe/unrelated$ext" "carry-probe-unrelated$ext"; do
+      hit=""
+      while IFS= read -r pat; do
+        [ -z "$pat" ] && continue
+        if glob_matches "$candidate" "$pat"; then hit=1; break; fi
+      done <<EOF_FREE_PROBE
 $(list_items "$ACTIVE_CARRY_EXCLUDE")
 EOF_FREE_PROBE
-    if [ -z "$hit" ]; then printf '%s\n' "$candidate"; return 0; fi
+      if [ -z "$hit" ]; then printf '%s\n' "$candidate"; return 0; fi
+    done
   done
   return 1
 }
@@ -1788,7 +1793,8 @@ if [ -n "$ACTIVE_CARRY" ]; then
 -# old comment
 +# new comment'
     fi
-    probe_free="$(exclude_free_path "${probe_exts%% *}")" || probe_free=""
+    # shellcheck disable=SC2086 # probe_exts is a controlled word list
+    probe_free="$(exclude_free_path $probe_exts)" || probe_free=""
 
     # EVERY committed glob is exercised, not just the first usable one: a
     # later typo'd or wrongly-anchored addition must not hide behind an
@@ -1827,7 +1833,13 @@ EOF_EXCLUDE_BATTERY
       compare_fix ahead "[$(delta_file "$probe_free" modified "$probe_patch")]"
       run "configured: carry-exclude — '$probe_free' is outside every committed glob and still carries" approved
     else
-      echo "note  configured: carry-exclude — every probe path matched a committed glob; carry case skipped"
+      # Exclusions swallowing EVERY carry-class candidate mean no docs/
+      # comments delta can ever carry — the enabled class is dead config,
+      # exactly the over-broadness this battery exists to catch. FAIL, not
+      # a note: a repo intending that posture should disable the class.
+      cases=$((cases + 1))
+      echo "FAIL  configured: carry-exclude — the committed exclusions match every carry-class probe path ($probe_exts); the enabled carry class can never apply (over-broad exclusion set, or disable REVIEW_GATE_CARRY_FORWARD instead)" >&2
+      failures=$((failures + 1))
     fi
   fi
 fi

--- a/skills/review-gate/scripts/review-predicate-selftest.sh
+++ b/skills/review-gate/scripts/review-predicate-selftest.sh
@@ -1683,6 +1683,56 @@ else
   run "configured: unresolved thread fails closed (threads=enforce)" threads-open
 fi
 
+# Carry-exclude probes (vstack#1174). Both use the predicate's matcher shape
+# — an unquoted pattern in a bash `case` — so the probes pin the real glob
+# semantics ('*' crosses '/', whole-path anchoring, ';' separators) against
+# the repo's COMMITTED exclude list, not a hardcoded example.
+carry_class_has() { # is this class among the repo's enabled carry classes?
+  printf '%s' "$ACTIVE_CARRY" | tr ';|' '\n\n' \
+    | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -qx "$1"
+}
+glob_matches() { # path, glob — the predicate's exact `case` matcher
+  case "$1" in $2) return 0 ;; esac
+  return 1
+}
+exclude_match_path() { # ext -> a path the first usable committed glob matches
+  # Usable: '*'-only globs (no '?'/'['/escape metacharacters) whose derived
+  # path can end in ext, so the path classifies into the enabled carry class
+  # and the refusal below is attributable to the exclusion alone. Every '*'
+  # becomes a literal filler; the concrete path is then re-proven against
+  # its source glob before use, never assumed.
+  local ext="$1" pat candidate
+  while IFS= read -r pat; do
+    [ -z "$pat" ] && continue
+    case "$pat" in *'?'*|*'['*|*'\'*) continue ;; esac
+    case "$pat" in
+      *"$ext") candidate="${pat//\*/probe}" ;;
+      *'*')    candidate="${pat//\*/probe}$ext" ;;
+      *)       continue ;;
+    esac
+    glob_matches "$candidate" "$pat" || continue
+    printf '%s\n' "$candidate"
+    return 0
+  done <<EOF_MATCH_PROBE
+$(list_items "$ACTIVE_CARRY_EXCLUDE")
+EOF_MATCH_PROBE
+  return 1
+}
+exclude_free_path() { # ext -> a path NO committed glob matches
+  local ext="$1" candidate pat hit
+  for candidate in "carry-probe/unrelated$ext" "carry-probe-unrelated$ext"; do
+    hit=""
+    while IFS= read -r pat; do
+      [ -z "$pat" ] && continue
+      if glob_matches "$candidate" "$pat"; then hit=1; break; fi
+    done <<EOF_FREE_PROBE
+$(list_items "$ACTIVE_CARRY_EXCLUDE")
+EOF_FREE_PROBE
+    if [ -z "$hit" ]; then printf '%s\n' "$candidate"; return 0; fi
+  done
+  return 1
+}
+
 # The repo's carry-forward posture: with classes enabled, an identical tree
 # must carry and a code delta must still refuse (the conservative floor no
 # class configuration may widen).
@@ -1698,6 +1748,48 @@ if [ -n "$ACTIVE_CARRY" ]; then
   reviews_set "$(review "$(trusted_reviewer)" APPROVED "2026-01-01T00:00:00Z" "$OTHER")"
   compare_fix ahead "[$CODE_DELTA]"
   run "configured: carry-forward — a code delta still refuses" awaiting
+
+  # The repo's exclude list must be shown to MATCH (vstack#1174): a typo'd
+  # or wrongly-anchored committed glob leaves the exclusion dead while every
+  # case above stays green in both directions. So: a carry-class path a
+  # committed glob matches must refuse the carry, and a sibling path outside
+  # every committed glob must still carry (the exclusion neither dead nor
+  # over-broad).
+  if [ -n "$ACTIVE_CARRY_EXCLUDE" ]; then
+    if carry_class_has docs; then
+      probe_ext=".md"
+      probe_patch='@@ -1 +1 @@
+-old prose
++new prose'
+    else
+      probe_ext=".sh"
+      probe_patch='@@ -1 +1 @@
+-# old comment
++# new comment'
+    fi
+    probe_match="$(exclude_match_path "$probe_ext")" || probe_match=""
+    probe_free="$(exclude_free_path "$probe_ext")" || probe_free=""
+
+    if [ -n "$probe_match" ]; then
+      reset
+      CFG_TRUSTED_LOGINS="$ACTIVE_TRUSTED_LOGINS"
+      reviews_set "$(review "$(trusted_reviewer)" APPROVED "2026-01-01T00:00:00Z" "$OTHER")"
+      compare_fix ahead "[$(delta_file "$probe_match" modified "$probe_patch")]"
+      run "configured: carry-exclude — a committed glob matches '$probe_match', refusing the carry" awaiting
+    else
+      echo "note  configured: carry-exclude — no committed glob can derive a carry-class path; match case skipped"
+    fi
+
+    if [ -n "$probe_free" ]; then
+      reset
+      CFG_TRUSTED_LOGINS="$ACTIVE_TRUSTED_LOGINS"
+      reviews_set "$(review "$(trusted_reviewer)" APPROVED "2026-01-01T00:00:00Z" "$OTHER")"
+      compare_fix ahead "[$(delta_file "$probe_free" modified "$probe_patch")]"
+      run "configured: carry-exclude — '$probe_free' is outside every committed glob and still carries" approved
+    else
+      echo "note  configured: carry-exclude — every probe path matched a committed glob; carry case skipped"
+    fi
+  fi
 fi
 
 # The repo's retry budget: a read failing (attempts - 1) times must still

--- a/skills/review-gate/tests/review-predicate-selftest.test.sh
+++ b/skills/review-gate/tests/review-predicate-selftest.test.sh
@@ -114,6 +114,35 @@ grep -q "configured: carry-forward (docs) — identical tree carries" "$work/con
 grep -q "carry off (default): the same docs delta does NOT carry" "$work/defaults.out" \
   || note "carry-forward off-default near-miss missing"
 
+# --- layer 2b: EVERY committed carry-exclude glob is exercised --------------
+# One battery case per committed glob — a later typo'd addition must not
+# hide behind an earlier glob's green — and a leading-'/' glob (which can
+# never match a repository-relative compare filename) must FAIL the suite,
+# not skip silently.
+mkdir -p "$work/excludes"
+sed 's/^REVIEW_GATE_CARRY_FORWARD = .*/REVIEW_GATE_CARRY_FORWARD = "docs"\nREVIEW_GATE_CARRY_FORWARD_EXCLUDE = "*AGENTS.md;guides\/*"/' \
+  "$work/configured/vstack.settings.toml" >"$work/excludes/vstack.settings.toml"
+if ! (cd "$work/excludes" && "$SELFTEST") >"$work/excludes.out" 2>&1; then
+  cat "$work/excludes.out"
+  note "selftest failed under a committed carry-exclude list"
+fi
+grep -q "carry-exclude — '\*AGENTS.md' matches" "$work/excludes.out" \
+  || note "committed glob '*AGENTS.md' not exercised"
+grep -q "carry-exclude — 'guides/\*' matches" "$work/excludes.out" \
+  || note "committed glob 'guides/*' not exercised (every glob must probe, not just the first)"
+grep -q "outside every committed glob and still carries" "$work/excludes.out" \
+  || note "committed exclude-free carry case not exercised"
+
+mkdir -p "$work/deadglob"
+sed 's/^REVIEW_GATE_CARRY_FORWARD = .*/REVIEW_GATE_CARRY_FORWARD = "docs"\nREVIEW_GATE_CARRY_FORWARD_EXCLUDE = "\/docs\/*"/' \
+  "$work/configured/vstack.settings.toml" >"$work/deadglob/vstack.settings.toml"
+if (cd "$work/deadglob" && "$SELFTEST") >"$work/deadglob.out" 2>&1; then
+  note "selftest passed with a leading-'/' carry-exclude glob — the dead-anchoring guard no longer fires"
+else
+  grep -q "leading '/'" "$work/deadglob.out" \
+    || note "the dead-glob failure does not explain the leading-'/' anchoring"
+fi
+
 if [ "$fail" -ne 0 ]; then
   echo "review-predicate-selftest.test: FAIL"
   exit 1

--- a/skills/review-gate/tests/review-predicate-selftest.test.sh
+++ b/skills/review-gate/tests/review-predicate-selftest.test.sh
@@ -120,8 +120,12 @@ grep -q "carry off (default): the same docs delta does NOT carry" "$work/default
 # never match a repository-relative compare filename) must FAIL the suite,
 # not skip silently.
 mkdir -p "$work/excludes"
-sed 's/^REVIEW_GATE_CARRY_FORWARD = .*/REVIEW_GATE_CARRY_FORWARD = "docs"\nREVIEW_GATE_CARRY_FORWARD_EXCLUDE = "*AGENTS.md;guides\/*"/' \
-  "$work/configured/vstack.settings.toml" >"$work/excludes/vstack.settings.toml"
+# BSD/macOS sed has no \n replacement extension — build fixtures with
+# grep -v + printf instead.
+grep -v '^REVIEW_GATE_CARRY_FORWARD = ' "$work/configured/vstack.settings.toml" \
+  >"$work/excludes/vstack.settings.toml"
+printf 'REVIEW_GATE_CARRY_FORWARD = "docs"\nREVIEW_GATE_CARRY_FORWARD_EXCLUDE = "*AGENTS.md;guides/*"\n' \
+  >>"$work/excludes/vstack.settings.toml"
 if ! (cd "$work/excludes" && "$SELFTEST") >"$work/excludes.out" 2>&1; then
   cat "$work/excludes.out"
   note "selftest failed under a committed carry-exclude list"
@@ -137,8 +141,10 @@ grep -q "outside every committed glob and still carries" "$work/excludes.out" \
 # enabled class can never apply — that over-broadness must FAIL the suite,
 # not print a note.
 mkdir -p "$work/overbroad"
-sed 's/^REVIEW_GATE_CARRY_FORWARD = .*/REVIEW_GATE_CARRY_FORWARD = "docs"\nREVIEW_GATE_CARRY_FORWARD_EXCLUDE = "*"/' \
-  "$work/configured/vstack.settings.toml" >"$work/overbroad/vstack.settings.toml"
+grep -v '^REVIEW_GATE_CARRY_FORWARD = ' "$work/configured/vstack.settings.toml" \
+  >"$work/overbroad/vstack.settings.toml"
+printf 'REVIEW_GATE_CARRY_FORWARD = "docs"\nREVIEW_GATE_CARRY_FORWARD_EXCLUDE = "*"\n' \
+  >>"$work/overbroad/vstack.settings.toml"
 if (cd "$work/overbroad" && "$SELFTEST") >"$work/overbroad.out" 2>&1; then
   note "selftest passed with a '*' carry-exclude — the over-broad-exclusion guard no longer fires"
 else
@@ -147,8 +153,10 @@ else
 fi
 
 mkdir -p "$work/deadglob"
-sed 's/^REVIEW_GATE_CARRY_FORWARD = .*/REVIEW_GATE_CARRY_FORWARD = "docs"\nREVIEW_GATE_CARRY_FORWARD_EXCLUDE = "\/docs\/*"/' \
-  "$work/configured/vstack.settings.toml" >"$work/deadglob/vstack.settings.toml"
+grep -v '^REVIEW_GATE_CARRY_FORWARD = ' "$work/configured/vstack.settings.toml" \
+  >"$work/deadglob/vstack.settings.toml"
+printf 'REVIEW_GATE_CARRY_FORWARD = "docs"\nREVIEW_GATE_CARRY_FORWARD_EXCLUDE = "/docs/*"\n' \
+  >>"$work/deadglob/vstack.settings.toml"
 if (cd "$work/deadglob" && "$SELFTEST") >"$work/deadglob.out" 2>&1; then
   note "selftest passed with a leading-'/' carry-exclude glob — the dead-anchoring guard no longer fires"
 else

--- a/skills/review-gate/tests/review-predicate-selftest.test.sh
+++ b/skills/review-gate/tests/review-predicate-selftest.test.sh
@@ -137,31 +137,23 @@ grep -q "carry-exclude — 'guides/\*' matches" "$work/excludes.out" \
 grep -q "outside every committed glob and still carries" "$work/excludes.out" \
   || note "committed exclude-free carry case not exercised"
 
-# An exclusion set that swallows every carry-class probe path means the
-# enabled class can never apply — that over-broadness must FAIL the suite,
-# not print a note.
-mkdir -p "$work/overbroad"
-grep -v '^REVIEW_GATE_CARRY_FORWARD = ' "$work/configured/vstack.settings.toml" \
-  >"$work/overbroad/vstack.settings.toml"
-printf 'REVIEW_GATE_CARRY_FORWARD = "docs"\nREVIEW_GATE_CARRY_FORWARD_EXCLUDE = "*"\n' \
-  >>"$work/overbroad/vstack.settings.toml"
-if (cd "$work/overbroad" && "$SELFTEST") >"$work/overbroad.out" 2>&1; then
-  note "selftest passed with a '*' carry-exclude — the over-broad-exclusion guard no longer fires"
-else
-  grep -q "can never apply" "$work/overbroad.out" \
-    || note "the over-broad failure does not explain that the carry class is dead"
-fi
-
+# One combined FAILING run pins BOTH guards (each fixture run replays the
+# full decision table, so failure cases share a run): a leading-'/' glob can
+# never match a repository-relative compare filename (dead anchoring), and a
+# '*' exclusion swallowing every carry-class probe path means the enabled
+# class can never apply (over-broad).
 mkdir -p "$work/deadglob"
 grep -v '^REVIEW_GATE_CARRY_FORWARD = ' "$work/configured/vstack.settings.toml" \
   >"$work/deadglob/vstack.settings.toml"
-printf 'REVIEW_GATE_CARRY_FORWARD = "docs"\nREVIEW_GATE_CARRY_FORWARD_EXCLUDE = "/docs/*"\n' \
+printf 'REVIEW_GATE_CARRY_FORWARD = "docs"\nREVIEW_GATE_CARRY_FORWARD_EXCLUDE = "/docs/*;*"\n' \
   >>"$work/deadglob/vstack.settings.toml"
 if (cd "$work/deadglob" && "$SELFTEST") >"$work/deadglob.out" 2>&1; then
-  note "selftest passed with a leading-'/' carry-exclude glob — the dead-anchoring guard no longer fires"
+  note "selftest passed with dead ('/docs/*') and over-broad ('*') carry-excludes — the guards no longer fire"
 else
   grep -q "leading '/'" "$work/deadglob.out" \
     || note "the dead-glob failure does not explain the leading-'/' anchoring"
+  grep -q "can never apply" "$work/deadglob.out" \
+    || note "the over-broad failure does not explain that the carry class is dead"
 fi
 
 if [ "$fail" -ne 0 ]; then

--- a/skills/review-gate/tests/review-predicate-selftest.test.sh
+++ b/skills/review-gate/tests/review-predicate-selftest.test.sh
@@ -133,6 +133,19 @@ grep -q "carry-exclude — 'guides/\*' matches" "$work/excludes.out" \
 grep -q "outside every committed glob and still carries" "$work/excludes.out" \
   || note "committed exclude-free carry case not exercised"
 
+# An exclusion set that swallows every carry-class probe path means the
+# enabled class can never apply — that over-broadness must FAIL the suite,
+# not print a note.
+mkdir -p "$work/overbroad"
+sed 's/^REVIEW_GATE_CARRY_FORWARD = .*/REVIEW_GATE_CARRY_FORWARD = "docs"\nREVIEW_GATE_CARRY_FORWARD_EXCLUDE = "*"/' \
+  "$work/configured/vstack.settings.toml" >"$work/overbroad/vstack.settings.toml"
+if (cd "$work/overbroad" && "$SELFTEST") >"$work/overbroad.out" 2>&1; then
+  note "selftest passed with a '*' carry-exclude — the over-broad-exclusion guard no longer fires"
+else
+  grep -q "can never apply" "$work/overbroad.out" \
+    || note "the over-broad failure does not explain that the carry class is dead"
+fi
+
 mkdir -p "$work/deadglob"
 sed 's/^REVIEW_GATE_CARRY_FORWARD = .*/REVIEW_GATE_CARRY_FORWARD = "docs"\nREVIEW_GATE_CARRY_FORWARD_EXCLUDE = "\/docs\/*"/' \
   "$work/configured/vstack.settings.toml" >"$work/deadglob/vstack.settings.toml"


### PR DESCRIPTION
Closes #1174 (Linear VST-193).

The configured-settings selftest block tested REVIEW_GATE_CARRY_FORWARD but never REVIEW_GATE_CARRY_FORWARD_EXCLUDE matching — typo'd or never-matching exclude globs stayed green in both directions. Two new parameterized cases derive their probe paths from the CONSUMER's committed exclude list (first usable glob → matching path, re-proven against the predicate's exact case-matcher shape; unrelated candidates → non-matching path), so every downstream repo's actual excludes get exercised: a matched docs-only delta must refuse carry-forward, an unmatched one must carry. Graceful skips when a repo has no excludes or no derivable glob.

Red-proven both directions against a temporarily broken matcher (dead: case 1 red; over-broad: case 2 red). Suite 236 → 238 cases, exit 0; all 7 review-gate test files green; offline and deterministic (existing gh shim fixtures + committed settings only).

https://claude.ai/code/session_019FKRouqRHJkXvNRXvZehgg