### PR TITLE
chore: adopt the fleet handoff-dir pattern — track only docs/handoff/README.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,10 @@ tmp/
 trees/
 docs/work-in-progress/
 docs/plans/
-# Session handoff files — machine-local steward state, never committed
-docs/handoff/
+# Session handoffs (docs/handoff/README.md). Local operator state: exactly one
+# untracked HANDOFF.md; only the README documenting the pattern is tracked.
+/docs/handoff/*
+!/docs/handoff/README.md
 
 # Harness install/runtime mirrors; canonical source lives elsewhere.
 # Match files, directories, and symlinks so worktree links stay invisible.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Reviewing a PR as a review bot? Follow `review-bots.md` (repo root) — reviewer
 
 ## Session handoffs
 
-Session handoff files live ONLY in `docs/handoff/` (git-ignored) — exactly one file, pruned each update to the minimum context a fresh session needs (no history/prose). Read it only when the user asks or starts a session from a handoff.
+Session handoff files live ONLY in `docs/handoff/` — exactly one untracked file named `HANDOFF.md`, pruned each update to the minimum context a fresh session needs (no history/prose). The only tracked file there is `docs/handoff/README.md`, which documents the pattern; everything else is git-ignored. Read the handoff only when the user asks or starts a session from a handoff.
 
 ## Repo Layout
 

--- a/docs/handoff/README.md
+++ b/docs/handoff/README.md
@@ -1,0 +1,7 @@
+# Session handoffs
+
+| Rule | Enforced in | Status |
+| --- | --- | --- |
+| Handoff content stays untracked; only this README is tracked | `.gitignore` (`/docs/handoff/*` + README negation) — advisory like all gitignore rules: a forced `git add -f` bypasses it, nothing in CI blocks that | Advisory |
+| Exactly ONE file (`HANDOFF.md`), pruned to clean-continuation context — no history, no prose | AGENTS.md § Session handoffs | Not enforced |
+| Read only when the user asks, or when a session starts from a user-delivered handoff | AGENTS.md § Session handoffs | Not enforced |


### PR DESCRIPTION
AGENTS.md §Session handoffs already mandates docs/handoff/ as the sole handoff location, but .gitignore blanketed the entire directory — unlike drovr/memsira/hyprtrade, where the pattern README is tracked and only the operator-local HANDOFF.md is ignored. This aligns vstack to the fleet pattern: /docs/handoff/* + !/docs/handoff/README.md, and adds the README (drovr's, with section references adapted). Repos stay consistent in handoff file patterns per owner direction.

https://claude.ai/code/session_019FKRouqRHJkXvNRXvZehgg