### PR TITLE
fix(linear): --search emptiness check covers the full whitespace class

### DIFF
--- a/skills/linear/scripts/commands/issues.sh
+++ b/skills/linear/scripts/commands/issues.sh
@@ -338,11 +338,18 @@ list_issues() {
 
     # A given-but-empty pattern must refuse, not degrade to an unfiltered
     # list: the dedupe preflight reads "rows came back" as "search ran".
-    # Whitespace counts as empty — "a | b" searches trimmed terms, and
-    # " | " has none, so it fails closed rather than matching broadly.
-    if [ "$search_given" = "true" ] && [ -z "$(printf '%s' "$search_pattern" | tr -d '|[:space:]')" ]; then
-        echo '{"error": "--search requires a non-empty value"}' >&2
-        return 1
+    # Emptiness is judged by the SAME jq normalization that builds the
+    # filter below — tr sees bytes, so a multibyte Unicode space (U+00A0)
+    # would pass a tr check and then normalize into an empty or-clause.
+    if [ "$search_given" = "true" ]; then
+        term_count=$(jq -rn --arg pattern "$search_pattern" '
+            $pattern | split("|")
+                | map(gsub("^[[:space:]]+|[[:space:]]+$"; ""))
+                | map(select(length > 0)) | length')
+        if [ "$term_count" = "0" ]; then
+            echo '{"error": "--search requires a non-empty value"}' >&2
+            return 1
+        fi
     fi
 
     parse_filter ${args[@]+"${args[@]}"}

--- a/skills/linear/scripts/commands/issues.sh
+++ b/skills/linear/scripts/commands/issues.sh
@@ -340,7 +340,7 @@ list_issues() {
     # list: the dedupe preflight reads "rows came back" as "search ran".
     # Whitespace counts as empty — "a | b" searches trimmed terms, and
     # " | " has none, so it fails closed rather than matching broadly.
-    if [ "$search_given" = "true" ] && [ -z "$(printf '%s' "$search_pattern" | tr -d '| \t')" ]; then
+    if [ "$search_given" = "true" ] && [ -z "$(printf '%s' "$search_pattern" | tr -d '|[:space:]')" ]; then
         echo '{"error": "--search requires a non-empty value"}' >&2
         return 1
     fi

--- a/skills/linear/tests/issues-list-search-server-filter.test.sh
+++ b/skills/linear/tests/issues-list-search-server-filter.test.sh
@@ -208,7 +208,7 @@ fi
 # The full whitespace class, not just space/tab: a CR- or LF-only pattern
 # passed the old check, the jq trim then emptied every term, and an
 # 'or: []' filter reached Linear.
-for ws_pat in "$(printf '\r')" "$(printf '\n|\n')" "$(printf '\302\240')"; do
+for ws_pat in $'\r' $'\n' $'\n|\n' $'\302\240'; do
   if run_list "$log7b" --format=raw --search "$ws_pat" >/dev/null 2>&1; then
     echo "FAIL --search CR/LF-only pattern must exit non-zero"
     exit 1

--- a/skills/linear/tests/issues-list-search-server-filter.test.sh
+++ b/skills/linear/tests/issues-list-search-server-filter.test.sh
@@ -208,7 +208,7 @@ fi
 # The full whitespace class, not just space/tab: a CR- or LF-only pattern
 # passed the old check, the jq trim then emptied every term, and an
 # 'or: []' filter reached Linear.
-for ws_pat in "$(printf '\r')" "$(printf '\n|\n')"; do
+for ws_pat in "$(printf '\r')" "$(printf '\n|\n')" "$(printf '\302\240')"; do
   if run_list "$log7b" --format=raw --search "$ws_pat" >/dev/null 2>&1; then
     echo "FAIL --search CR/LF-only pattern must exit non-zero"
     exit 1

--- a/skills/linear/tests/issues-list-search-server-filter.test.sh
+++ b/skills/linear/tests/issues-list-search-server-filter.test.sh
@@ -205,6 +205,20 @@ if [ -s "$log7b" ]; then
   cat "$log7b"
   exit 1
 fi
+# The full whitespace class, not just space/tab: a CR- or LF-only pattern
+# passed the old check, the jq trim then emptied every term, and an
+# 'or: []' filter reached Linear.
+for ws_pat in "$(printf '\r')" "$(printf '\n|\n')"; do
+  if run_list "$log7b" --format=raw --search "$ws_pat" >/dev/null 2>&1; then
+    echo "FAIL --search CR/LF-only pattern must exit non-zero"
+    exit 1
+  fi
+  if [ -s "$log7b" ]; then
+    echo "FAIL --search CR/LF-only pattern must not reach the API"
+    cat "$log7b"
+    exit 1
+  fi
+done
 
 # --- Case 7c: padded terms are trimmed before matching ------------------------
 log7c="$TMP_ROOT/trimmed-terms.jsonl"


### PR DESCRIPTION
Follow-up to #1184's remaining review thread (the CR/LF whitespace-class gap in the --search emptiness check) — that PR queued before the finding landed. tr now deletes `|[:space:]` so a CR- or LF-only pattern fails closed before any API call; regression test covers both.
