### PR TITLE
feat(ci): alert on merge-queue ejection — PR comment + intake issue, never auto-re-arm

### DIFF
--- a/.github/workflows/merge-queue-ejection-alert.yml
+++ b/.github/workflows/merge-queue-ejection-alert.yml
@@ -12,13 +12,19 @@
 # de-duplicate against the existing open issue.
 name: Merge queue ejection alert
 
+# pull_request_target, not pull_request: a fork PR's dequeue would hand a
+# plain pull_request workflow a read-only GITHUB_TOKEN, silencing both the
+# comment and the intake issue. This workflow never checks out or executes
+# PR-controlled code (same posture as review-gate-writer.yml), so the
+# base-repository context is safe.
 "on":
-  pull_request:
+  pull_request_target:
     types: [dequeued]
 
 permissions:
   contents: read
   actions: read
+  checks: read
   issues: write
   pull-requests: write
 
@@ -43,8 +49,12 @@ jobs:
           # The ejecting failure ran on the merge-group ref, not the PR head:
           # gh-readonly-queue/<base>/pr-<N>-<sha>. Newest failed merge_group
           # run for this PR is the ejection's evidence.
-          run_json="$(gh api "/repos/${GH_REPO}/actions/runs?event=merge_group&status=failure&per_page=50" \
-            --jq "[.workflow_runs[] | select(.head_branch | test(\"/pr-${PR_NUMBER}-\"))] | sort_by(.created_at) | last // empty")"
+          # --paginate: an active queue can push the ejecting run past the
+          # first page. head_branch is null-guarded (jq test() on a null
+          # errors out the whole step under set -e).
+          run_json="$(gh api --paginate "/repos/${GH_REPO}/actions/runs?event=merge_group&status=failure&per_page=100" \
+            --jq "[.workflow_runs[] | select(.head_branch | strings | test(\"/pr-${PR_NUMBER}-\"))]" \
+            | jq -s 'add | sort_by(.created_at) | last // empty')"
 
           run_id=""; run_url=""; run_name=""
           if [ -n "$run_json" ]; then
@@ -68,13 +78,21 @@ jobs:
             head_checks="$(gh api "/repos/${GH_REPO}/commits/${PR_HEAD_SHA}/check-runs?per_page=100" \
               --jq '[.check_runs[] | {name, conclusion}]')"
             failed_names="$(gh api "/repos/${GH_REPO}/actions/runs/${run_id}/jobs?per_page=100" \
-              --jq '[.jobs[] | select(.conclusion == "failure") | .name]')"
-            overlap_red="$(jq -cn --argjson head "$head_checks" --argjson failed "$failed_names" \
-              '[$failed[] as $n | $head[] | select(.name == $n and .conclusion != "success")] | length')"
-            if [ "$overlap_red" = "0" ] && [ "$(printf '%s' "$failed_names" | jq 'length')" != "0" ]; then
-              hint="The same-named check(s) are green on the PR's own head — this looks like a queue-only flake; re-arming \`--auto\` once is plausibly safe. Never re-arm past a check that is also red on the PR head."
-            else
+              --jq '[.jobs[] | select(.conclusion == "failure" or .conclusion == "cancelled") | .name]')"
+            # Flake requires POSITIVE evidence: every ejecting job name must
+            # have a same-named SUCCESSFUL check on the PR head. Queue-only
+            # jobs (this repo's normal heavy-suite shape) have no head
+            # counterpart — that is "no comparison", never a flake claim.
+            all_green_on_head="$(jq -cn --argjson head "$head_checks" --argjson failed "$failed_names" \
+              '($failed | length > 0) and ([$failed[] as $n | ($head | map(select(.name == $n and .conclusion == "success")) | length > 0)] | all)')"
+            any_red_on_head="$(jq -cn --argjson head "$head_checks" --argjson failed "$failed_names" \
+              '[$failed[] as $n | $head[] | select(.name == $n and .conclusion != "success")] | length > 0')"
+            if [ "$all_green_on_head" = "true" ]; then
+              hint="Every ejecting check has a same-named GREEN check on the PR's own head — this looks like a queue-only flake; re-arming \`--auto\` once is plausibly safe. Never re-arm past a check that is also red on the PR head."
+            elif [ "$any_red_on_head" = "true" ]; then
               hint="At least one ejecting check is not green on the PR's own head — fix before re-arming."
+            else
+              hint="The ejecting check(s) run only in the merge queue (no same-named check on the PR head) — no flake-vs-genuine comparison is available; inspect the failing run before re-arming."
             fi
           fi
 
@@ -94,7 +112,9 @@ jobs:
           gh pr comment "$PR_NUMBER" --body-file "$body_file"
 
           # Intake issue (deduped per PR + ejection run).
-          marker="ejection-alert:pr-${PR_NUMBER}:run-${run_id:-unknown}"
+          # An unidentified ejecting run must not collapse successive
+          # ejections into one marker: fall back to this alert run's own id.
+          marker="ejection-alert:pr-${PR_NUMBER}:run-${run_id:-alert-${GITHUB_RUN_ID}}"
           existing="$(gh issue list --search "\"$marker\" in:body" --state open --json number --jq 'length')"
           if [ "$existing" = "0" ]; then
             issue_file="$(mktemp)"

--- a/.github/workflows/merge-queue-ejection-alert.yml
+++ b/.github/workflows/merge-queue-ejection-alert.yml
@@ -1,0 +1,118 @@
+# Merge-queue ejections are SILENT: GitHub drops the auto-merge arm,
+# notifies nobody, and the review-gate wiring only writes commit statuses —
+# vstack#1166 sat CLEAN-but-unqueued for ~9 hours before a human asked why
+# nothing had merged (VST-196 / vstack#1177). This workflow turns the
+# ejection into two durable signals:
+#   1. a PR comment naming the dequeue reason and the failing merge-group
+#      run, with a flake-vs-genuine hint (same-named check state on the PR's
+#      own head) — informational only, it NEVER re-arms auto-merge;
+#   2. an intake issue, so the ejection enters the triage queue (the
+#      GH→Linear creation sync mirrors it) instead of vanishing.
+# One issue per PR per ejection run id; re-runs and duplicate deliveries
+# de-duplicate against the existing open issue.
+name: Merge queue ejection alert
+
+"on":
+  pull_request:
+    types: [dequeued]
+
+permissions:
+  contents: read
+  actions: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  alert:
+    # DEQUEUE reason "MERGE" means the queue finished with the PR (normal
+    # merge path) — only failure-shaped removals alert.
+    if: ${{ github.event.reason != 'MERGE' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Comment on the PR and file the intake issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          DEQUEUE_REASON: ${{ github.event.reason }}
+        run: |
+          set -euo pipefail
+
+          # The ejecting failure ran on the merge-group ref, not the PR head:
+          # gh-readonly-queue/<base>/pr-<N>-<sha>. Newest failed merge_group
+          # run for this PR is the ejection's evidence.
+          run_json="$(gh api "/repos/${GH_REPO}/actions/runs?event=merge_group&status=failure&per_page=50" \
+            --jq "[.workflow_runs[] | select(.head_branch | test(\"/pr-${PR_NUMBER}-\"))] | sort_by(.created_at) | last // empty")"
+
+          run_id=""; run_url=""; run_name=""
+          if [ -n "$run_json" ]; then
+            run_id="$(printf '%s' "$run_json" | jq -r '.id')"
+            run_url="$(printf '%s' "$run_json" | jq -r '.html_url')"
+            run_name="$(printf '%s' "$run_json" | jq -r '.name')"
+          fi
+
+          failing_jobs="(failing run not identified — the dequeue may predate run completion; check the queue insights page)"
+          if [ -n "$run_id" ]; then
+            failing_jobs="$(gh api "/repos/${GH_REPO}/actions/runs/${run_id}/jobs?per_page=100" \
+              --jq '[.jobs[] | select(.conclusion == "failure" or .conclusion == "cancelled") | "- `\(.name)` (\(.conclusion)): \(.html_url)"] | join("\n")')"
+            [ -n "$failing_jobs" ] || failing_jobs="(run $run_id failed with no per-job failure recorded)"
+          fi
+
+          # Flake hint: the same-named jobs' state on the PR's OWN head.
+          # Green there suggests queue-only flake (re-arm plausibly safe);
+          # red there means fix before re-arming. Informational only.
+          hint="No same-named check comparison available for the PR head."
+          if [ -n "$run_id" ]; then
+            head_checks="$(gh api "/repos/${GH_REPO}/commits/${PR_HEAD_SHA}/check-runs?per_page=100" \
+              --jq '[.check_runs[] | {name, conclusion}]')"
+            failed_names="$(gh api "/repos/${GH_REPO}/actions/runs/${run_id}/jobs?per_page=100" \
+              --jq '[.jobs[] | select(.conclusion == "failure") | .name]')"
+            overlap_red="$(jq -cn --argjson head "$head_checks" --argjson failed "$failed_names" \
+              '[$failed[] as $n | $head[] | select(.name == $n and .conclusion != "success")] | length')"
+            if [ "$overlap_red" = "0" ] && [ "$(printf '%s' "$failed_names" | jq 'length')" != "0" ]; then
+              hint="The same-named check(s) are green on the PR's own head — this looks like a queue-only flake; re-arming \`--auto\` once is plausibly safe. Never re-arm past a check that is also red on the PR head."
+            else
+              hint="At least one ejecting check is not green on the PR's own head — fix before re-arming."
+            fi
+          fi
+
+          body_file="$(mktemp)"
+          cat > "$body_file" <<BODY
+          **Merge queue ejected this PR** (\`removed_from_merge_queue\`, reason: \`${DEQUEUE_REASON}\`). The auto-merge arm is now DROPPED — nothing will merge this PR until someone re-arms it.
+
+          Ejecting merge-group run: ${run_url:-not identified}${run_name:+ (\`${run_name}\`)}
+
+          Failing job(s):
+          ${failing_jobs}
+
+          ${hint}
+
+          _Automated by merge-queue-ejection-alert (VST-196). This alert never re-arms auto-merge._
+          BODY
+          gh pr comment "$PR_NUMBER" --body-file "$body_file"
+
+          # Intake issue (deduped per PR + ejection run).
+          marker="ejection-alert:pr-${PR_NUMBER}:run-${run_id:-unknown}"
+          existing="$(gh issue list --search "\"$marker\" in:body" --state open --json number --jq 'length')"
+          if [ "$existing" = "0" ]; then
+            issue_file="$(mktemp)"
+            cat > "$issue_file" <<BODY
+          PR #${PR_NUMBER} was ejected from the merge queue (reason: \`${DEQUEUE_REASON}\`); its auto-merge arm is dropped and it will sit unmerged until re-armed.
+
+          Ejecting run: ${run_url:-not identified}
+
+          Failing job(s):
+          ${failing_jobs}
+
+          ${hint}
+
+          <!-- ${marker} -->
+          BODY
+            gh issue create \
+              --title "merge-queue ejection: PR #${PR_NUMBER} — ${run_name:-failing required check}" \
+              --body-file "$issue_file"
+          else
+            echo "intake issue for $marker already open; skipping create"
+          fi


### PR DESCRIPTION
Fixes VST-196. Closes #1177.

Merge-queue ejections are silent: GitHub drops the auto-merge arm and notifies nobody (vstack#1166 sat CLEAN-but-unqueued ~9h). This adds a `pull_request: dequeued` workflow that:

1. **Comments on the PR** with the dequeue reason, the ejecting `merge_group` run (matched via the `gh-readonly-queue/<base>/pr-<N>-<sha>` head branch), and its failing jobs.
2. **Files a deduped intake issue** (one per PR + ejection run id, marker in body) so the ejection enters the triage queue via the GH→Linear creation sync.
3. **Flake-vs-genuine hint**: compares the same-named checks on the PR's own head — green there reads "queue-only flake, one re-arm plausibly safe"; red reads "fix before re-arming". Informational only — the workflow never re-arms auto-merge past a red check (issue ask 3).

Normal-merge dequeues (`reason: MERGE`) don't alert.
