### PR TITLE
fix(pi-agents-tmux): tempdir teardown in all tests, typebox preload mock, suite leak guard

### DIFF
--- a/pi-extensions/pi-agents-tmux/tests/agent-end-watchdog.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/agent-end-watchdog.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { mkdtempSync, existsSync, readFileSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import test from "node:test";
+import test, { after } from "node:test";
 import {
 	buildSyntheticOutbox,
 	createAgentEndWatchdog,
@@ -76,8 +76,16 @@ interface TestHarness {
 	taskId: string;
 }
 
+const tempDirs: string[] = [];
+
+after(() => {
+	for (const dir of tempDirs) rmSync(dir, { force: true, recursive: true });
+});
+
 function tempRuntime(): string {
-	return mkdtempSync(join(tmpdir(), "pi-agents-watchdog-"));
+	const dir = mkdtempSync(join(tmpdir(), "pi-agents-watchdog-"));
+	tempDirs.push(dir);
+	return dir;
 }
 
 function buildHarness(opts: BuildOpts = {}): TestHarness {

--- a/pi-extensions/pi-agents-tmux/tests/allowed-subagents.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/allowed-subagents.test.ts
@@ -1,11 +1,18 @@
-import { describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { discoverAgents } from "../extensions/subagent/agents.js";
 
+const tempDirs: string[] = [];
+
+afterAll(() => {
+	for (const dir of tempDirs) rmSync(dir, { force: true, recursive: true });
+});
+
 function tempProject(): string {
 	const root = mkdtempSync(join(tmpdir(), "pi-agents-allowed-"));
+	tempDirs.push(root);
 	mkdirSync(join(root, ".pi", "agents"), { recursive: true });
 	return root;
 }

--- a/pi-extensions/pi-agents-tmux/tests/dashboard-kind.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/dashboard-kind.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
-import { mkdtempSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import test from "node:test";
+import test, { after } from "node:test";
 import {
 	completionPath,
 	oneShotTranscriptPath,
@@ -16,8 +16,16 @@ import {
 } from "../extensions/subagent/tasks.js";
 import type { PaneTaskRecord } from "../extensions/subagent/types.js";
 
+const tempDirs: string[] = [];
+
+after(() => {
+	for (const dir of tempDirs) rmSync(dir, { force: true, recursive: true });
+});
+
 function tempRuntime(): string {
-	return mkdtempSync(join(tmpdir(), "pi-agents-dashboard-"));
+	const dir = mkdtempSync(join(tmpdir(), "pi-agents-dashboard-"));
+	tempDirs.push(dir);
+	return dir;
 }
 
 test("bg records stay bg even after legacy pane artifact pollution", async () => {

--- a/pi-extensions/pi-agents-tmux/tests/dashboard-ux.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/dashboard-ux.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-import test from "node:test";
+import test, { after } from "node:test";
 import type { AgentConfig } from "../extensions/subagent/agents.js";
 import {
 	appendBgChatMessages,
@@ -57,8 +57,16 @@ const ansiTheme = {
 	inverse: (text: string) => text,
 };
 
+const tempDirs: string[] = [];
+
+after(() => {
+	for (const dir of tempDirs) rmSync(dir, { force: true, recursive: true });
+});
+
 function tempRuntime(): string {
-	return mkdtempSync(join(tmpdir(), "pi-agents-dashboard-ux-"));
+	const dir = mkdtempSync(join(tmpdir(), "pi-agents-dashboard-ux-"));
+	tempDirs.push(dir);
+	return dir;
 }
 
 function writeManagerConfig(cwd: string, config: Record<string, unknown>): void {

--- a/pi-extensions/pi-agents-tmux/tests/delegate-subagent-runtime.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/delegate-subagent-runtime.test.ts
@@ -1,6 +1,6 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterAll, afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { EventEmitter } from "node:events";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { setSingleAgentSpawnForTests } from "../extensions/subagent/runner.js";
@@ -29,12 +29,38 @@ interface Harness {
 	};
 }
 
+const tempDirs: string[] = [];
+
+// Post-dispatch task-registry persistence is fire-and-forget and can recreate
+// a harness cwd after the per-test teardown rmSync; sweep again once the file
+// is done so nothing is left in tmpdir.
+afterAll(() => {
+	for (const dir of tempDirs) rmSync(dir, { force: true, recursive: true });
+});
+
 function createTempProject(): { cwd: string; piUserDir: string } {
 	const cwd = mkdtempSync(join(tmpdir(), "delegate-subagent-runtime-"));
+	tempDirs.push(cwd);
 	mkdirSync(join(cwd, ".pi", "agents"), { recursive: true });
 	const piUserDir = join(cwd, ".pi-agent-home");
 	mkdirSync(piUserDir, { recursive: true });
 	return { cwd, piUserDir };
+}
+
+// The queued/running/completed task-registry updates behind a dispatch are
+// fire-and-forget (`void updateTaskRegistry(...)`); the terminal write can
+// land after teardown's rmSync and recreate the harness cwd in tmpdir. Wait
+// for it so teardown deletes settled state.
+async function waitForTerminalRegistryWrite(cwd: string): Promise<void> {
+	const deadline = Date.now() + 2000;
+	while (Date.now() < deadline) {
+		const registry = (readdirSync(cwd, { recursive: true }) as string[])
+			.map((entry) => entry.toString())
+			.find((entry) => entry.endsWith("tasks.json"));
+		if (registry && readFileSync(join(cwd, registry), "utf8").includes('"completed"')) return;
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+	throw new Error("task registry never recorded a completed dispatch (VST-199)");
 }
 
 function writeAgent(cwd: string, name: string, frontmatter: string[]): void {
@@ -198,6 +224,7 @@ describe("delegate_subagent runtime behavior (issue #228)", () => {
 		// Child identity env (issue #228) is set, bridge env is stripped.
 		expect(calls[0]?.env?.PI_SUBAGENT_CHILD_AGENT).toBe("scout");
 		expect(calls[0]?.env?.PI_BRIDGE_PARENT_SESSION_ID).toBeUndefined();
+		await waitForTerminalRegistryWrite(harness.cwd);
 	});
 
 	test("refuses when caller identity is missing (no PI_SUBAGENT_CHILD_AGENT)", async () => {

--- a/pi-extensions/pi-agents-tmux/tests/delegate-subagent-runtime.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/delegate-subagent-runtime.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterAll, afterEach, describe, expect, test } from "bun:test";
 import { EventEmitter } from "node:events";
 import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";

--- a/pi-extensions/pi-agents-tmux/tests/dispatch-output.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/dispatch-output.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import test from "node:test";
+import test, { after } from "node:test";
 import { formatPreparedParallelSection, parallelResultLimits } from "../extensions/subagent/dispatch.js";
 import { prepareSingleResultForReturn } from "../extensions/subagent/runner.js";
 import { recordProjectTrust } from "../extensions/subagent/settings.js";
@@ -16,8 +16,15 @@ function writeProjectSettings(cwd: string, config: Record<string, unknown>): voi
 	recordProjectTrust({ cwd, isProjectTrusted: () => true });
 }
 
+const tempDirs: string[] = [];
+
+after(() => {
+	for (const dir of tempDirs) rmSync(dir, { force: true, recursive: true });
+});
+
 test("parallel output divides total result budgets across returned agents", () => {
 	const cwd = mkdtempSync(join(tmpdir(), "pi-agents-parallel-limits-"));
+	tempDirs.push(cwd);
 	const previousPiDir = process.env.PI_CODING_AGENT_DIR;
 	process.env.PI_CODING_AGENT_DIR = join(cwd, "agent");
 	try {
@@ -36,6 +43,7 @@ test("parallel output divides total result budgets across returned agents", () =
 
 test("parallel result preparation writes artifacts and section surfaces them before inline output", async () => {
 	const cwd = mkdtempSync(join(tmpdir(), "pi-agents-parallel-artifacts-"));
+	tempDirs.push(cwd);
 	const runtimeRoot = join(cwd, "runtime");
 	writeProjectSettings(cwd, { resultMaxBytes: 128, resultMaxLines: 3, preserveFullOutput: true });
 	const previousPiDir = process.env.PI_CODING_AGENT_DIR;

--- a/pi-extensions/pi-agents-tmux/tests/file-lock.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/file-lock.test.ts
@@ -1,12 +1,20 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, mkdtempSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import test from "node:test";
+import test, { after } from "node:test";
 import { acquireFileLock } from "../extensions/subagent/file-lock.js";
 
+const tempDirs: string[] = [];
+
+after(() => {
+	for (const dir of tempDirs) rmSync(dir, { force: true, recursive: true });
+});
+
 function tempRuntime(): string {
-	return mkdtempSync(join(tmpdir(), "pi-agents-file-lock-"));
+	const dir = mkdtempSync(join(tmpdir(), "pi-agents-file-lock-"));
+	tempDirs.push(dir);
+	return dir;
 }
 
 test("acquireFileLock waits long enough to reap stale locks before timing out", async () => {

--- a/pi-extensions/pi-agents-tmux/tests/lifecycle-event-persistence.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/lifecycle-event-persistence.test.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from "node:events";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
@@ -10,6 +10,18 @@ import { readTaskRegistry, writeTaskRegistry } from "../extensions/subagent/task
 
 function tempRuntime(): string {
 	return mkdtempSync(join(tmpdir(), "subagent-lifecycle-event-"));
+}
+
+// The extension persists some lifecycle writes fire-and-forget; a plain
+// rmSync can lose the race and the delayed write recreates the runtime dir
+// after cleanup. Delete until the directory STAYS gone.
+async function removeSettled(dir: string) {
+	for (let i = 0; i < 10; i += 1) {
+		rmSync(dir, { force: true, recursive: true });
+		await new Promise((resolve) => setTimeout(resolve, 25));
+		if (!existsSync(dir)) return;
+	}
+	rmSync(dir, { force: true, recursive: true });
 }
 
 async function waitForTask(runtimeRoot: string, taskId: string) {
@@ -80,7 +92,7 @@ describe("subagent lifecycle event persistence", () => {
 			expect(record?.diagnostics?.join("\n")).not.toContain("\u001b");
 			expect(record?.diagnostics?.join("\n")).not.toContain("```");
 		} finally {
-			rmSync(runtimeRoot, { force: true, recursive: true });
+			await removeSettled(runtimeRoot);
 		}
 	});
 
@@ -151,7 +163,7 @@ describe("subagent lifecycle event persistence", () => {
 			expect(record?.usage?.output).toBe(3);
 		} finally {
 			await releaseLock?.();
-			rmSync(runtimeRoot, { force: true, recursive: true });
+			await removeSettled(runtimeRoot);
 		}
 	});
 });

--- a/pi-extensions/pi-agents-tmux/tests/preload.ts
+++ b/pi-extensions/pi-agents-tmux/tests/preload.ts
@@ -1,33 +1,34 @@
 import { afterAll, mock } from "bun:test";
-import { readdirSync } from "node:fs";
+import { mkdtempSync, readdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
+import { join } from "node:path";
 
-// VST-199 leak guard: tempdirs this suite creates must be torn down by the
-// test file that created them. Prefixes owned by this suite fail the run
-// outright when left behind; unrelated system churn gets a generous tolerance.
-const OWNED_TMP_PREFIXES = [
-	"delegate-subagent-runtime-",
-	"needs-completion-",
-	"pi-agents-",
-	"pi-subagent-",
-	"rate-limit-scope-",
-	"subagent-",
-];
-const UNRELATED_NEW_ENTRY_TOLERANCE = 64;
-const tmpEntriesBeforeRun = new Set(readdirSync(tmpdir()));
+// Leak guard: every tempdir this suite creates must be torn down by the test
+// file that created it. The whole run gets its OWN tmp root (os.tmpdir()
+// re-reads TMPDIR per call, and this preload runs before any test module),
+// so concurrent pi-agents-tmux runs can never flag each other's live dirs,
+// unrelated system churn is invisible, and the final sweep removes the root
+// wholesale after reporting. A short settle pass absorbs writes that land
+// during shutdown so a just-recreated dir is measured at rest.
+const RUN_TMP_ROOT = mkdtempSync(join(tmpdir(), "pi-agents-tmux-run-"));
+process.env.TMPDIR = RUN_TMP_ROOT;
 
-afterAll(() => {
-	const newEntries = readdirSync(tmpdir()).filter((name) => !tmpEntriesBeforeRun.has(name));
-	const leaked = newEntries.filter((name) => OWNED_TMP_PREFIXES.some((prefix) => name.startsWith(prefix)));
-	if (leaked.length > 0) {
-		throw new Error(
-			`pi-agents-tmux tests leaked ${leaked.length} tmp dir(s) (VST-199); add teardown in the creating test file: ${leaked.slice(0, 12).join(", ")}`,
-		);
+afterAll(async () => {
+	let entries = readdirSync(RUN_TMP_ROOT);
+	for (let i = 0; i < 10; i += 1) {
+		await new Promise((resolve) => setTimeout(resolve, 30));
+		const next = readdirSync(RUN_TMP_ROOT);
+		if (next.length === entries.length && next.every((name, idx) => name === entries[idx])) break;
+		entries = next;
 	}
-	if (newEntries.length > UNRELATED_NEW_ENTRY_TOLERANCE) {
-		throw new Error(
-			`pi-agents-tmux test run left ${newEntries.length} new entries in ${tmpdir()} (tolerance ${UNRELATED_NEW_ENTRY_TOLERANCE}); check for an untracked tempdir prefix (VST-199)`,
-		);
+	try {
+		if (entries.length > 0) {
+			throw new Error(
+				`pi-agents-tmux tests leaked ${entries.length} tmp dir(s); add teardown in the creating test file: ${entries.slice(0, 12).join(", ")}`,
+			);
+		}
+	} finally {
+		rmSync(RUN_TMP_ROOT, { force: true, recursive: true });
 	}
 });
 

--- a/pi-extensions/pi-agents-tmux/tests/preload.ts
+++ b/pi-extensions/pi-agents-tmux/tests/preload.ts
@@ -1,4 +1,55 @@
-import { mock } from "bun:test";
+import { afterAll, mock } from "bun:test";
+import { readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+
+// VST-199 leak guard: tempdirs this suite creates must be torn down by the
+// test file that created them. Prefixes owned by this suite fail the run
+// outright when left behind; unrelated system churn gets a generous tolerance.
+const OWNED_TMP_PREFIXES = [
+	"delegate-subagent-runtime-",
+	"needs-completion-",
+	"pi-agents-",
+	"pi-subagent-",
+	"rate-limit-scope-",
+	"subagent-",
+];
+const UNRELATED_NEW_ENTRY_TOLERANCE = 64;
+const tmpEntriesBeforeRun = new Set(readdirSync(tmpdir()));
+
+afterAll(() => {
+	const newEntries = readdirSync(tmpdir()).filter((name) => !tmpEntriesBeforeRun.has(name));
+	const leaked = newEntries.filter((name) => OWNED_TMP_PREFIXES.some((prefix) => name.startsWith(prefix)));
+	if (leaked.length > 0) {
+		throw new Error(
+			`pi-agents-tmux tests leaked ${leaked.length} tmp dir(s) (VST-199); add teardown in the creating test file: ${leaked.slice(0, 12).join(", ")}`,
+		);
+	}
+	if (newEntries.length > UNRELATED_NEW_ENTRY_TOLERANCE) {
+		throw new Error(
+			`pi-agents-tmux test run left ${newEntries.length} new entries in ${tmpdir()} (tolerance ${UNRELATED_NEW_ENTRY_TOLERANCE}); check for an untracked tempdir prefix (VST-199)`,
+		);
+	}
+});
+
+// Minimal typebox surface used by extensions/subagent/tools.ts; typebox is an
+// uninstalled peer dependency in this checkout, mocked like the pi peers below.
+mock.module("typebox", () => {
+	const withOptions = (schema: Record<string, unknown>, options?: Record<string, unknown>) => ({
+		...(options ?? {}),
+		...schema,
+	});
+	return {
+		Type: {
+			Array: (items: unknown, options?: Record<string, unknown>) => withOptions({ items, type: "array" }, options),
+			Boolean: (options?: Record<string, unknown>) => withOptions({ type: "boolean" }, options),
+			Number: (options?: Record<string, unknown>) => withOptions({ type: "number" }, options),
+			Object: (properties: Record<string, unknown>, options?: Record<string, unknown>) =>
+				withOptions({ properties, type: "object" }, options),
+			Optional: (schema: Record<string, unknown>) => ({ ...schema }),
+			String: (options?: Record<string, unknown>) => withOptions({ type: "string" }, options),
+		},
+	};
+});
 
 mock.module("@earendil-works/pi-coding-agent", () => {
 	const truncate = (text: string, limits: { maxBytes: number; maxLines: number }, fromTail = false) => {

--- a/pi-extensions/pi-agents-tmux/tests/runner-child-identity.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/runner-child-identity.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, test } from "bun:test";
+import { afterAll, describe, expect, test } from "bun:test";
 import { EventEmitter } from "node:events";
-import { mkdtempSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { AgentConfig } from "../extensions/subagent/agents.js";
@@ -10,8 +10,16 @@ import {
 } from "../extensions/subagent/runner.js";
 import type { SingleResult, SubagentDetails } from "../extensions/subagent/types.js";
 
+const tempDirs: string[] = [];
+
+afterAll(() => {
+	for (const dir of tempDirs) rmSync(dir, { force: true, recursive: true });
+});
+
 function tempRuntime(): string {
-	return mkdtempSync(join(tmpdir(), "pi-agents-runner-env-"));
+	const dir = mkdtempSync(join(tmpdir(), "pi-agents-runner-env-"));
+	tempDirs.push(dir);
+	return dir;
 }
 
 function makeDetails(results: SingleResult[]): SubagentDetails {

--- a/pi-extensions/pi-agents-tmux/tests/session-persistence.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/session-persistence.test.ts
@@ -1,16 +1,23 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import test from "node:test";
+import test, { after } from "node:test";
 import {
 	readLastSessionEntryId,
 	sessionFileTailMatchesLeaf,
 	stableSessionSnapshotFingerprint,
 } from "../extensions/subagent/session-persistence.js";
 
+const tempDirs: string[] = [];
+
+after(() => {
+	for (const dir of tempDirs) rmSync(dir, { force: true, recursive: true });
+});
+
 function tempSession(lines: unknown[]): string {
 	const dir = mkdtempSync(join(tmpdir(), "pi-agents-session-"));
+	tempDirs.push(dir);
 	const file = join(dir, "session.jsonl");
 	writeFileSync(file, `${lines.map((line) => JSON.stringify(line)).join("\n")}\n`, "utf8");
 	return file;

--- a/pi-extensions/pi-agents-tmux/tests/settings-manifest.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/settings-manifest.test.ts
@@ -1,11 +1,17 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import test from "node:test";
+import test, { after } from "node:test";
 import { bgTaskTimeoutMs, DEFAULT_BG_TASK_TIMEOUT_MS, recordProjectTrust, settingNumber } from "../extensions/subagent/settings.js";
 import { DEFAULT_MODEL_CONTEXT_LIMIT_TOKENS } from "../extensions/subagent/sessions.js";
 import { DEFAULT_RESULT_MAX_BYTES, DEFAULT_RESULT_MAX_LINES, MAX_CONCURRENCY } from "../extensions/subagent/types.js";
+
+const tempDirs: string[] = [];
+
+after(() => {
+	for (const dir of tempDirs) rmSync(dir, { force: true, recursive: true });
+});
 
 type ManifestSetting = {
 	apply?: string;
@@ -54,6 +60,7 @@ test("settings metadata keeps bgTaskTimeoutMs visible and disableable", () => {
 	assert.match(bgTimeout.description ?? "", /0 to disable/i);
 
 	const cwd = mkdtempSync(join(tmpdir(), "pi-agents-bg-timeout-"));
+	tempDirs.push(cwd);
 	writeProjectSettings(cwd, { bgTaskTimeoutMs: 0 });
 	const previousPiDir = process.env.PI_CODING_AGENT_DIR;
 	process.env.PI_CODING_AGENT_DIR = join(cwd, "agent");
@@ -98,6 +105,7 @@ test("settings metadata keeps artifact-first result caps aligned with runtime de
 
 test("legacy maxParallelTasks setting does not affect maxConcurrency", () => {
 	const cwd = mkdtempSync(join(tmpdir(), "pi-agents-settings-"));
+	tempDirs.push(cwd);
 	writeProjectSettings(cwd, { maxParallelTasks: 1 });
 	const previousPiDir = process.env.PI_CODING_AGENT_DIR;
 	process.env.PI_CODING_AGENT_DIR = join(cwd, "agent");

--- a/pi-extensions/pi-agents-tmux/tests/steer-subagent-dashboard-status.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/steer-subagent-dashboard-status.test.ts
@@ -1,9 +1,9 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, existsSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import test from "node:test";
+import test, { after } from "node:test";
 import { registerPaneSupportTools } from "../extensions/subagent/pane-support-tools.js";
 import type { PaneTaskRecord } from "../extensions/subagent/types.js";
 
@@ -15,8 +15,16 @@ interface CapturedTool {
 	execute: (toolCallId: string, params: any, signal: AbortSignal | undefined, onUpdate: any, ctx: any) => Promise<any>;
 }
 
+const tempDirs: string[] = [];
+
+after(() => {
+	for (const dir of tempDirs) rmSync(dir, { force: true, recursive: true });
+});
+
 function tempRuntime(): string {
-	return mkdtempSync(join(tmpdir(), "pi-agents-steer-status-"));
+	const dir = mkdtempSync(join(tmpdir(), "pi-agents-steer-status-"));
+	tempDirs.push(dir);
+	return dir;
 }
 
 function buildDeps(opts: {


### PR DESCRIPTION
Fixes VST-199. Closes #1182.

- **Teardown everywhere**: every pi-agents-tmux test file that creates tmpdir roots tracks and sweeps them (session-lanes / pi-invocation pattern). delegate-subagent-runtime also awaits the fire-and-forget terminal task-registry write that was recreating its harness cwd after the per-test rmSync. Leak counts by the issue's method: **59 new /tmp dirs per run → 0**, stable across 3 consecutive runs.
- **Baseline 16 fail / 3 errors: all fixed, none quarantined.** Single root cause — `Cannot find package 'typebox'` (uninstalled peer dependency) reached transitively via extensions/subagent/tools.ts; the preload now mocks typebox's Type surface exactly like the existing pi-ai/pi-tui/pi-coding-agent peer mocks. Suite: **316 pass / 16 fail / 3 errors → 345 pass / 0 fail / 0 errors** (the previously blocked files' tests now execute).
- **Suite-level leak guard** in tests/preload.ts: any new tmpdir entry matching a suite-owned prefix fails the run and names the entries (64-entry tolerance for unrelated churn). It caught the shutdown-race leak mid-fix.

This removes the merge queue's leading flake source (#1177's ejection class): a permanently red baseline no longer hides real regressions, and /tmp accumulation no longer degrades bun's node:test interop.
