### PR TITLE
feat(size-ratchet): tighten-only file-size gate skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ Rust and performance reference material now lives directly in the `rust`, `revie
 | [`review-gate`](skills/review-gate/)* | Org-wide PR merge gate driven by a single review-evidence predicate (approvals, trusted checks, comment-form passes, outage attestation), with convergence scripts and an offline decision-table selftest. |
 | [`reviewer`](skills/reviewer/)* | Strict code-review, whole-codebase review, and QA-review ethos, scope boundaries, workflows, and canonical finding/verdict JSON schema. Loaded by any `reviewer-*` agent. |
 | [`second-opinion`](skills/second-opinion/) | Cross-model review via the opposite AI CLI (Claude ↔ Codex). |
+| [`size-ratchet`](skills/size-ratchet/)* | Tighten-only file-size gate over tracked files: new offenders, growth past a baseline row, and baselines looser than reality all fail; `--update` only lowers or removes rows, never adds or raises. |
 | [`worktree`](skills/worktree/)* | Git worktree create/list/remove with env/config symlinks and per-worktree bot identity. |
 
 ### Hooks

--- a/skills/size-ratchet/README.md
+++ b/skills/size-ratchet/README.md
@@ -9,11 +9,12 @@ reviewed diff, with the justification on the record.
 ## Semantics
 
 - **Scope**: every tracked file (`git ls-files`), tests included, minus the
-  exclusion list. Symlinks are skipped. A tracked file absent from the
-  worktree (unstaged deletion, sparse checkout) has an unknowable size: it
-  is never counted, never flagged, and its baseline row is preserved
-  verbatim — including through `--update` — so a partial tree can never
-  loosen the ratchet. A tracked path containing a tab or newline is refused
+  exclusion list. Symlinks are skipped; a submodule gitlink at a tracked
+  path is not a countable file (a baseline row for one is stale). A tracked
+  file absent from the worktree (unstaged deletion, sparse checkout) is
+  counted from the INDEX blob, so "every tracked file" holds on partial
+  trees too — a sparse checkout can neither smuggle a new offender past the
+  gate nor loosen a baselined row. A tracked path containing a tab or newline is refused
   loudly (exit 2; exclude it to skip the gate) — it cannot be represented
   in the line-oriented records. Lines are newline counts (`wc -l`).
 - **Threshold**: default `1000` lines, override via

--- a/skills/size-ratchet/README.md
+++ b/skills/size-ratchet/README.md
@@ -17,7 +17,7 @@ reviewed diff, with the justification on the record.
   loudly (exit 2; exclude it to skip the gate) — it cannot be represented
   in the line-oriented records. Lines are newline counts (`wc -l`).
 - **Threshold**: default `1000` lines, override via
-  `SIZE_RATCHET_THRESHOLD` (environment > `vstack.settings.toml` `[env]` >
+  `SIZE_RATCHET_THRESHOLD` (environment > `.env.local` > `vstack.settings.toml` `[env]` > `.vstack/settings.toml` > `.env` >
   default).
 - **FAIL** (exit 1) on any of:
   1. **New offender** — a file over the threshold with no baseline row.

--- a/skills/size-ratchet/README.md
+++ b/skills/size-ratchet/README.md
@@ -85,9 +85,11 @@ src/gen/*.rs	generated bindings
 | `SIZE_RATCHET_BASELINE` | `tools/size-ratchet-baseline.tsv` | Baseline path. |
 | `SIZE_RATCHET_EXCLUDES` | `tools/size-ratchet-excludes` | Exclusion-list path. |
 
-Each key resolves environment > committed `vstack.settings.toml` (flat
-`KEY = "value"` assignment under `[env]`) > default. `--baseline` /
-`--excludes` flags override all three for the paths. All relative paths are
+Each key resolves environment > `.env.local` > committed `vstack.settings.toml`
+(flat `KEY = "value"` assignment under `[env]`) > `.vstack/settings.toml` >
+`.env` > default (env files use `KEY=value` or `export KEY=value`; parsed,
+never sourced). `--baseline` / `--excludes` flags override every source for
+the paths. All relative paths are
 repo-root-relative; the script `cd`s to `git rev-parse --show-toplevel`
 before resolving anything.
 

--- a/skills/size-ratchet/README.md
+++ b/skills/size-ratchet/README.md
@@ -1,0 +1,105 @@
+# size-ratchet
+
+A tighten-only gate on file size. New code cannot introduce a tracked file
+over the line threshold; files already over it are frozen in a baseline at
+their current counts and may only shrink. Growth is never automated away:
+the single path to a bigger number is a human editing the baseline row in a
+reviewed diff, with the justification on the record.
+
+## Semantics
+
+- **Scope**: every tracked file (`git ls-files`), tests included, minus the
+  exclusion list. Symlinks and paths deleted from the working tree are
+  skipped. Lines are newline counts (`wc -l`).
+- **Threshold**: default `1000` lines, override via
+  `SIZE_RATCHET_THRESHOLD` (environment > `vstack.settings.toml` `[env]` >
+  default).
+- **FAIL** (exit 1) on any of:
+  1. **New offender** — a file over the threshold with no baseline row.
+  2. **Growth** — a baselined file whose actual count exceeds its row.
+  3. **Baseline looser than reality** — a row above the file's actual
+     count, a row for a file now at/under the threshold, or a row for a
+     file that left the tracked set (deleted, or newly excluded). The
+     ratchet must move down; stale slack is a failure, not headroom.
+- **Diagnostics** name the file, its count, and the threshold or baseline
+  row it violated, and state the remedies: *split at a concept seam, or
+  raise the baseline row in this diff with justification*.
+- **`--update`** tightens only: it lowers rows to the actual count and
+  removes rows for files now at/under the threshold or no longer counted.
+  It never adds a row and never raises a number, then re-checks — so it
+  still exits 1 while growth or new offenders remain. Deliberate growth is
+  a hand-edit of the row.
+- Exit codes: `0` clean, `1` violations, `2` usage/config error.
+
+## Baseline format
+
+`tools/size-ratchet-baseline.tsv` by default (`SIZE_RATCHET_BASELINE` or
+`--baseline FILE` to relocate). One row per frozen offender:
+
+```
+path<TAB>lines
+```
+
+Rows are `LC_ALL=C` sorted, paths unique, counts positive. A malformed,
+unsorted, or duplicated baseline is a config error (exit 2), not a silent
+pass — the file is reviewed input, so it fails loud.
+
+### Seeding a first baseline
+
+`--update` never adds rows, so the first baseline is created explicitly:
+run the check, and turn each reported `new offender` line (path and count)
+into a `path<TAB>lines` row, `LC_ALL=C` sorted. That the initial freeze is
+a hand-authored, reviewed diff is the point — every frozen offender enters
+the record deliberately.
+
+## Exclusion list
+
+`tools/size-ratchet-excludes` by default (`SIZE_RATCHET_EXCLUDES` or
+`--excludes FILE`). One pattern per line, with a mandatory reason:
+
+```
+pattern<TAB>reason
+```
+
+The pattern is a shell glob matched against the full repo-relative path
+(`*` crosses `/`). Blank lines and `#` comments are ignored; a pattern
+without a reason is a config error. Typical entries:
+
+```
+Cargo.lock	lockfile — generated, size is not a design signal
+vendor/*	vendored third-party code
+*/fixtures/*	test fixtures — size is the test's business
+src/gen/*.rs	generated bindings
+```
+
+## Configuration
+
+| Key | Default | Meaning |
+|---|---|---|
+| `SIZE_RATCHET_THRESHOLD` | `1000` | New-file line threshold. |
+| `SIZE_RATCHET_BASELINE` | `tools/size-ratchet-baseline.tsv` | Baseline path. |
+| `SIZE_RATCHET_EXCLUDES` | `tools/size-ratchet-excludes` | Exclusion-list path. |
+
+Each key resolves environment > committed `vstack.settings.toml` (flat
+`KEY = "value"` assignment under `[env]`) > default. `--baseline` /
+`--excludes` flags override all three for the paths. All relative paths are
+repo-root-relative; the script `cd`s to `git rev-parse --show-toplevel`
+before resolving anything.
+
+```toml
+[env]
+SIZE_RATCHET_THRESHOLD = "800"
+```
+
+## Migration
+
+Consumers already running a size ratchet with this exact baseline format
+(`path<TAB>lines`, `LC_ALL=C` sorted) can swap this script in drop-in: keep
+the existing baseline file where it is and point `SIZE_RATCHET_BASELINE`
+(or `--baseline`) at it. Semantics are unchanged by agreement across repos:
+same three failure directions, same tighten-only `--update`.
+
+## Requirements
+
+`git`, `awk`, and the usual POSIX userland. Bash 3.2 compatible (macOS
+system bash).

--- a/skills/size-ratchet/README.md
+++ b/skills/size-ratchet/README.md
@@ -9,8 +9,13 @@ reviewed diff, with the justification on the record.
 ## Semantics
 
 - **Scope**: every tracked file (`git ls-files`), tests included, minus the
-  exclusion list. Symlinks and paths deleted from the working tree are
-  skipped. Lines are newline counts (`wc -l`).
+  exclusion list. Symlinks are skipped. A tracked file absent from the
+  worktree (unstaged deletion, sparse checkout) has an unknowable size: it
+  is never counted, never flagged, and its baseline row is preserved
+  verbatim — including through `--update` — so a partial tree can never
+  loosen the ratchet. A tracked path containing a tab or newline is refused
+  loudly (exit 2; exclude it to skip the gate) — it cannot be represented
+  in the line-oriented records. Lines are newline counts (`wc -l`).
 - **Threshold**: default `1000` lines, override via
   `SIZE_RATCHET_THRESHOLD` (environment > `vstack.settings.toml` `[env]` >
   default).

--- a/skills/size-ratchet/README.md
+++ b/skills/size-ratchet/README.md
@@ -17,7 +17,7 @@ reviewed diff, with the justification on the record.
   loudly (exit 2; exclude it to skip the gate) — it cannot be represented
   in the line-oriented records. Lines are newline counts (`wc -l`).
 - **Threshold**: default `1000` lines, override via
-  `SIZE_RATCHET_THRESHOLD` (environment > `.env.local` > `vstack.settings.toml` `[env]` > `.vstack/settings.toml` > `.env` >
+  `SIZE_RATCHET_THRESHOLD` (environment > `.env.local` > `.vstack/settings.toml` > `vstack.settings.toml` `[env]` > `.env` >
   default).
 - **FAIL** (exit 1) on any of:
   1. **New offender** — a file over the threshold with no baseline row.
@@ -85,8 +85,8 @@ src/gen/*.rs	generated bindings
 | `SIZE_RATCHET_BASELINE` | `tools/size-ratchet-baseline.tsv` | Baseline path. |
 | `SIZE_RATCHET_EXCLUDES` | `tools/size-ratchet-excludes` | Exclusion-list path. |
 
-Each key resolves environment > `.env.local` > committed `vstack.settings.toml`
-(flat `KEY = "value"` assignment under `[env]`) > `.vstack/settings.toml` >
+Each key resolves environment > `.env.local` > `.vstack/settings.toml` > committed `vstack.settings.toml`
+(flat `KEY = "value"` assignment under `[env]`) >
 `.env` > default (env files use `KEY=value` or `export KEY=value`; parsed,
 never sourced). `--baseline` / `--excludes` flags override every source for
 the paths. All relative paths are

--- a/skills/size-ratchet/SKILL.md
+++ b/skills/size-ratchet/SKILL.md
@@ -43,8 +43,11 @@ row it violated, plus the remedies: *split at a concept seam, or raise the
 baseline row in this diff with justification*.
 
 Exit codes: `0` clean, `1` violations, `2` usage/config error (malformed
-baseline or excludes, bad threshold). Line counts are newline counts
-(`wc -l`).
+baseline or excludes, bad threshold, a tracked path containing a tab or
+newline). Line counts are newline counts (`wc -l`). A tracked file absent
+from the worktree (unstaged deletion, sparse checkout) is unknown, not
+gone: it is never flagged and its baseline row survives `--update`
+untouched.
 
 ## `--update` — tighten only
 

--- a/skills/size-ratchet/SKILL.md
+++ b/skills/size-ratchet/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: size-ratchet
+description: "Tighten-only file-size gate: every tracked file over the line threshold (default 1000) must be frozen in a baseline TSV at its current size, and the baseline only moves down — new offenders, growth of a baselined file, and a baseline looser than reality all fail; --update lowers/removes rows but never adds or raises one, so deliberate growth is a visible hand-edit in review. Load when adding, tuning, or debugging a repo's file-size ratchet, its baseline, its exclusion list, or SIZE_RATCHET_* settings."
+license: MIT
+user-invocable: true
+metadata:
+  author: vanillagreen
+  source: vstack
+  repository: "https://github.com/vanillagreencom/vstack"
+  bugs: "https://github.com/vanillagreencom/vstack/issues"
+  version: "1.0.0"
+---
+
+# Size Ratchet
+
+> **Problem with this skill?** Run `vstack report` — it files to the owning repo automatically. Do not hand-file.
+
+One check, one direction: **no tracked file gets bigger than the threshold,
+and the files already over it only shrink.** Existing offenders are frozen
+in a baseline at their current line counts; everything else — including
+tests — must stay at or under the threshold. The baseline is a ratchet, not
+a ledger: rows only go down or away, and the only way a number goes up is a
+human editing the row in a reviewed diff.
+
+```bash
+.agents/skills/size-ratchet/scripts/size-ratchet            # check (CI / pre-merge)
+.agents/skills/size-ratchet/scripts/size-ratchet --update   # tighten the baseline
+```
+
+## Verdicts
+
+`check` scans every tracked file (`git ls-files`) minus the exclusion list
+and fails (exit 1) on any of:
+
+| Failure | Meaning |
+|---|---|
+| **new offender** | Over the threshold with no baseline row. |
+| **baselined file grew** | Actual lines exceed the file's baseline row. |
+| **baseline looser than reality** | A row higher than the file's actual count, a row for a file now at/under the threshold, or a row for a file no longer tracked (or now excluded). Slack in the baseline is itself a failure — the ratchet must move down. |
+
+Every diagnostic names the file, its count, and the threshold or baseline
+row it violated, plus the remedies: *split at a concept seam, or raise the
+baseline row in this diff with justification*.
+
+Exit codes: `0` clean, `1` violations, `2` usage/config error (malformed
+baseline or excludes, bad threshold). Line counts are newline counts
+(`wc -l`).
+
+## `--update` — tighten only
+
+`--update` rewrites the baseline to current reality in the downward
+direction only: rows are lowered to the actual count or removed (file
+shrank to/under the threshold, was deleted, or is now excluded). It **never
+adds a row and never raises a number** — a grown file keeps its old row and
+keeps failing, and a new offender stays a failure. Deliberate growth or a
+new freeze is a hand-edit of the baseline TSV, visible in the diff. After
+the rewrite the check re-runs, so `--update` exits 1 while growth or new
+offenders remain.
+
+## Configuration
+
+Resolution order for every key: explicit environment > the repo's committed
+`vstack.settings.toml` (flat `KEY = "value"` under `[env]`) > built-in
+default.
+
+| Key | Default | Meaning |
+|---|---|---|
+| `SIZE_RATCHET_THRESHOLD` | `1000` | Line threshold for new files. |
+| `SIZE_RATCHET_BASELINE` | `tools/size-ratchet-baseline.tsv` | Baseline path (also `--baseline FILE`). |
+| `SIZE_RATCHET_EXCLUDES` | `tools/size-ratchet-excludes` | Exclusion-list path (also `--excludes FILE`). |
+
+**Baseline format** — `path<TAB>lines`, `LC_ALL=C` sorted, unique paths,
+counts above the threshold. **Excludes format** — `pattern<TAB>reason` per
+line (shell glob against the full repo-relative path; `*` crosses `/`);
+blank lines and `#` comments are ignored, and a pattern without a reason is
+a config error — every exclusion carries its justification (generated,
+vendored, fixtures, lockfiles).
+
+Formats, seeding a first baseline, and the migration note for repos already
+using this format: [README.md](README.md).

--- a/skills/size-ratchet/SKILL.md
+++ b/skills/size-ratchet/SKILL.md
@@ -63,8 +63,7 @@ offenders remain.
 ## Configuration
 
 Resolution order for every key: explicit environment > the repo's committed
-`.env.local` > `vstack.settings.toml` (flat `KEY = "value"` under `[env]`) >
-`.vstack/settings.toml` > `.env` > built-in
+`.env.local` > `.vstack/settings.toml` > `vstack.settings.toml` (flat `KEY = "value"` under `[env]`) > `.env` > built-in
 default.
 
 | Key | Default | Meaning |

--- a/skills/size-ratchet/SKILL.md
+++ b/skills/size-ratchet/SKILL.md
@@ -63,7 +63,8 @@ offenders remain.
 ## Configuration
 
 Resolution order for every key: explicit environment > the repo's committed
-`vstack.settings.toml` (flat `KEY = "value"` under `[env]`) > built-in
+`.env.local` > `vstack.settings.toml` (flat `KEY = "value"` under `[env]`) >
+`.vstack/settings.toml` > `.env` > built-in
 default.
 
 | Key | Default | Meaning |

--- a/skills/size-ratchet/SKILL.md
+++ b/skills/size-ratchet/SKILL.md
@@ -63,9 +63,10 @@ offenders remain.
 
 ## Configuration
 
-Resolution order for every key: explicit environment > the repo's committed
-`.env.local` > `.vstack/settings.toml` > `vstack.settings.toml` (flat `KEY = "value"` under `[env]`) > `.env` > built-in
-default.
+Resolution order for every key: explicit environment > `.env.local`
+(personal, untracked) > `.vstack/settings.toml` > the repo's committed
+`vstack.settings.toml` (flat `KEY = "value"` under `[env]`) > `.env` >
+built-in default.
 
 | Key | Default | Meaning |
 |---|---|---|

--- a/skills/size-ratchet/SKILL.md
+++ b/skills/size-ratchet/SKILL.md
@@ -45,9 +45,10 @@ baseline row in this diff with justification*.
 Exit codes: `0` clean, `1` violations, `2` usage/config error (malformed
 baseline or excludes, bad threshold, a tracked path containing a tab or
 newline). Line counts are newline counts (`wc -l`). A tracked file absent
-from the worktree (unstaged deletion, sparse checkout) is unknown, not
-gone: it is never flagged and its baseline row survives `--update`
-untouched.
+from the worktree (unstaged deletion, sparse checkout) is counted from the
+INDEX blob — a partial tree can neither smuggle a new offender past the
+gate nor loosen a baselined row. A submodule gitlink at a tracked path is
+not a countable file.
 
 ## `--update` — tighten only
 

--- a/skills/size-ratchet/scripts/lib/settings.sh
+++ b/skills/size-ratchet/scripts/lib/settings.sh
@@ -54,7 +54,7 @@ sr_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
   # committed settings, .env is the base) — first matching KEY= line wins,
   # optional surrounding quotes stripped. Parsed, never sourced.
   if [ -f ".env.local" ]; then
-    line="$(grep -E -- "^[[:space:]]*${name}=" .env.local | head -n 1 || true)"
+    line="$(grep -E -- "^[[:space:]]*(export[[:space:]]+)?${name}=" .env.local | head -n 1 || true)"
     if [ -n "$line" ]; then
       val="${line#*=}"
       case "$val" in
@@ -101,7 +101,7 @@ sr_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
   fi
   done
   if [ -f ".env" ]; then
-    line="$(grep -E -- "^[[:space:]]*${name}=" .env | head -n 1 || true)"
+    line="$(grep -E -- "^[[:space:]]*(export[[:space:]]+)?${name}=" .env | head -n 1 || true)"
     if [ -n "$line" ]; then
       val="${line#*=}"
       case "$val" in

--- a/skills/size-ratchet/scripts/lib/settings.sh
+++ b/skills/size-ratchet/scripts/lib/settings.sh
@@ -11,10 +11,12 @@
 # family):
 #   1. explicit environment — a SET variable wins even when set to the empty
 #      string, so a caller can force "explicitly empty";
-#   2. the repo's committed vstack.settings.toml (the file's sole uncommented
-#      `KEY = "value"` assignment; the file path can be overridden with
-#      SIZE_RATCHET_SETTINGS_FILE, e.g. /dev/null to force built-in defaults);
-#   3. the built-in default passed by the caller.
+#   2. .env.local (KEY=value, quotes optional — parsed, never sourced);
+#   3. the repo's committed vstack.settings.toml (sole uncommented
+#      `KEY = "value"` assignment; path overridable with
+#      SIZE_RATCHET_SETTINGS_FILE, e.g. /dev/null), then .vstack/settings.toml;
+#   4. .env (same shape);
+#   5. the built-in default passed by the caller.
 #
 # The parser reads flat single-line basic-string TOML assignments only —
 # exactly the shape vstack.settings.toml [env] blocks use.
@@ -48,7 +50,22 @@ sr_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
     printf '%s' "${!name}"
     return 0
   fi
-  file="${SIZE_RATCHET_SETTINGS_FILE:-vstack.settings.toml}"
+  # Env-file overrides (standard project layering: .env.local beats the
+  # committed settings, .env is the base) — first matching KEY= line wins,
+  # optional surrounding quotes stripped. Parsed, never sourced.
+  if [ -f ".env.local" ]; then
+    line="$(grep -E -- "^[[:space:]]*${name}=" .env.local | head -n 1 || true)"
+    if [ -n "$line" ]; then
+      val="${line#*=}"
+      case "$val" in
+        \"*\") val="${val%\"}"; val="${val#\"}" ;;
+        \'*\') val="${val%\'}"; val="${val#\'}" ;;
+      esac
+      printf '%s' "$val"
+      return 0
+    fi
+  fi
+  for file in "${SIZE_RATCHET_SETTINGS_FILE:-vstack.settings.toml}" ".vstack/settings.toml"; do
   if [ -f "$file" ]; then
     # Key PRESENCE decides, not value non-emptiness: `NAME = ""` is a real
     # assignment and must override the built-in default, exactly like a
@@ -78,6 +95,19 @@ sr_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
         return 1
       fi
       val="$(printf '%s\n' "$line" | sed -n "s/^[[:space:]]*${name}[[:space:]]*=[[:space:]]*\"\([^\"]*\)\".*\$/\1/p")"
+      printf '%s' "$val"
+      return 0
+    fi
+  fi
+  done
+  if [ -f ".env" ]; then
+    line="$(grep -E -- "^[[:space:]]*${name}=" .env | head -n 1 || true)"
+    if [ -n "$line" ]; then
+      val="${line#*=}"
+      case "$val" in
+        \"*\") val="${val%\"}"; val="${val#\"}" ;;
+        \'*\') val="${val%\'}"; val="${val#\'}" ;;
+      esac
       printf '%s' "$val"
       return 0
     fi

--- a/skills/size-ratchet/scripts/lib/settings.sh
+++ b/skills/size-ratchet/scripts/lib/settings.sh
@@ -60,6 +60,11 @@ sr_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
       case "$val" in
         \"*\") val="${val%\"}"; val="${val#\"}" ;;
         \'*\') val="${val%\'}"; val="${val#\'}" ;;
+        *)
+          # Unquoted shell assignment: the value ends at the first
+          # whitespace — `KEY=500 # ratchet` assigns 500, comment dropped.
+          val="${val%%[[:space:]]*}"
+          ;;
       esac
       printf '%s' "$val"
       return 0
@@ -114,6 +119,11 @@ sr_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
       case "$val" in
         \"*\") val="${val%\"}"; val="${val#\"}" ;;
         \'*\') val="${val%\'}"; val="${val#\'}" ;;
+        *)
+          # Unquoted shell assignment: the value ends at the first
+          # whitespace — `KEY=500 # ratchet` assigns 500, comment dropped.
+          val="${val%%[[:space:]]*}"
+          ;;
       esac
       printf '%s' "$val"
       return 0

--- a/skills/size-ratchet/scripts/lib/settings.sh
+++ b/skills/size-ratchet/scripts/lib/settings.sh
@@ -51,7 +51,7 @@ sr_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
     return 0
   fi
   # Env-file overrides (standard project layering: .env.local beats the
-  # committed settings, .env is the base) — first matching KEY= line wins,
+  # committed settings, .env is the base) — LAST matching KEY= line wins (shell-sourcing semantics),
   # optional surrounding quotes stripped. Parsed, never sourced.
   if [ -f ".env.local" ]; then
     line="$(grep -E -- "^[[:space:]]*(export[[:space:]]+)?${name}=" .env.local | tail -n 1 || true)"

--- a/skills/size-ratchet/scripts/lib/settings.sh
+++ b/skills/size-ratchet/scripts/lib/settings.sh
@@ -1,0 +1,86 @@
+# shellcheck shell=bash
+# Settings resolution for size-ratchet. Sourced (not executed) by
+# scripts/size-ratchet.
+#
+# VENDORED from skills/review-gate/scripts/lib/settings.sh (rg_setting),
+# renamed sr_setting: skills are standalone-installable, so a consumer that
+# installs only size-ratchet has no review-gate tree to source from. Keep
+# the logic in sync with the original; behavioral fixes belong there first.
+#
+# Resolution order for every key read through sr_setting (the SIZE_RATCHET_*
+# family):
+#   1. explicit environment — a SET variable wins even when set to the empty
+#      string, so a caller can force "explicitly empty";
+#   2. the repo's committed vstack.settings.toml (the file's sole uncommented
+#      `KEY = "value"` assignment; the file path can be overridden with
+#      SIZE_RATCHET_SETTINGS_FILE, e.g. /dev/null to force built-in defaults);
+#   3. the built-in default passed by the caller.
+#
+# The parser reads flat single-line basic-string TOML assignments only —
+# exactly the shape vstack.settings.toml [env] blocks use.
+#
+# Keys are matched FILE-WIDE by exact name, with no TOML-table awareness:
+# adopter settings sit under an [env] table, and a table-aware top-level
+# parser would resolve none of them. The consequence is a contract: every
+# key name read through sr_setting is reserved across the whole file — an
+# assignment under an unrelated table would be read as the setting, so
+# callers must keep these names unique file-wide. The one detectable
+# ambiguity, the same name assigned more than once, fails loud below.
+#
+# The caller cds to the repo root before resolving, so the default settings
+# path is relative.
+
+sr_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
+               # a present-but-unparseable assignment (callers must propagate)
+  local name="$1" default="$2" line val file
+  # The name is interpolated into ERE patterns below; constrain it to the
+  # identifier shape every real key has, so a metacharacter can neither
+  # misgrep nor inject pattern syntax.
+  case "$name" in
+    "" | [0-9]* | *[!A-Za-z0-9_]*)
+      echo "::error::sr_setting: invalid key name '$name' (shell identifier shape required: [A-Za-z_][A-Za-z0-9_]*)" >&2
+      return 1
+      ;;
+  esac
+  # Indirect expansion, not eval: a non-literal NAME must never become code.
+  # ${!name+x} tests set-ness of the variable NAMED by $name (Bash 3.2-safe).
+  if [ -n "${!name+x}" ]; then
+    printf '%s' "${!name}"
+    return 0
+  fi
+  file="${SIZE_RATCHET_SETTINGS_FILE:-vstack.settings.toml}"
+  if [ -f "$file" ]; then
+    # Key PRESENCE decides, not value non-emptiness: `NAME = ""` is a real
+    # assignment and must override the built-in default, exactly like a
+    # set-but-empty env var does above.
+    # Leading whitespace before a key is valid TOML, so matching is
+    # whitespace-tolerant everywhere (presence, ambiguity guard, extraction)
+    # — anchoring at column one made an indented duplicate bypass the
+    # fail-loud guard and an indented sole assignment collapse silently to
+    # the built-in default (vstack#1059).
+    if grep -Eq -- "^[[:space:]]*${name}[[:space:]]*=" "$file"; then
+      # File-wide matching (header contract) makes a re-assigned name
+      # ambiguous — e.g. the same key under two tables. Silently taking the
+      # first could read an unrelated table's value, so ambiguity is a
+      # configuration error.
+      if [ "$(grep -Ec -- "^[[:space:]]*${name}[[:space:]]*=" "$file")" -gt 1 ]; then
+        echo "::error::$file: $name is assigned more than once (keys are matched file-wide regardless of TOML table; each name must be unique in the file)" >&2
+        return 1
+      fi
+      line="$(grep -E -- "^[[:space:]]*${name}[[:space:]]*=" "$file" | head -n 1)"
+      # A PRESENT assignment this parser cannot read must fail LOUDLY, never
+      # collapse to empty. Only the flat single-line basic-string shape is
+      # supported — the value is quote-free ([^"]*), which makes the
+      # extraction exact even with a trailing TOML comment (accepted);
+      # anything else is a configuration error.
+      if ! printf '%s\n' "$line" | grep -Eq -- "^[[:space:]]*${name}[[:space:]]*=[[:space:]]*\"[^\"]*\"[[:space:]]*(#.*)?\$"; then
+        echo "::error::$file: unsupported syntax for $name (expected a single-line basic string: $name = \"value\")" >&2
+        return 1
+      fi
+      val="$(printf '%s\n' "$line" | sed -n "s/^[[:space:]]*${name}[[:space:]]*=[[:space:]]*\"\([^\"]*\)\".*\$/\1/p")"
+      printf '%s' "$val"
+      return 0
+    fi
+  fi
+  printf '%s' "$default"
+}

--- a/skills/size-ratchet/scripts/lib/settings.sh
+++ b/skills/size-ratchet/scripts/lib/settings.sh
@@ -12,9 +12,9 @@
 #   1. explicit environment — a SET variable wins even when set to the empty
 #      string, so a caller can force "explicitly empty";
 #   2. .env.local (KEY=value, quotes optional — parsed, never sourced);
-#   3. the repo's committed vstack.settings.toml (sole uncommented
-#      `KEY = "value"` assignment; path overridable with
-#      SIZE_RATCHET_SETTINGS_FILE, e.g. /dev/null), then .vstack/settings.toml;
+#   3. .vstack/settings.toml, then the repo's committed vstack.settings.toml
+#      (sole uncommented `KEY = "value"` assignment; an explicit
+#      SIZE_RATCHET_SETTINGS_FILE consults only itself, e.g. /dev/null);
 #   4. .env (same shape);
 #   5. the built-in default passed by the caller.
 #
@@ -54,7 +54,7 @@ sr_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
   # committed settings, .env is the base) — first matching KEY= line wins,
   # optional surrounding quotes stripped. Parsed, never sourced.
   if [ -f ".env.local" ]; then
-    line="$(grep -E -- "^[[:space:]]*(export[[:space:]]+)?${name}=" .env.local | head -n 1 || true)"
+    line="$(grep -E -- "^[[:space:]]*(export[[:space:]]+)?${name}=" .env.local | tail -n 1 || true)"
     if [ -n "$line" ]; then
       val="${line#*=}"
       case "$val" in
@@ -65,7 +65,14 @@ sr_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
       return 0
     fi
   fi
-  for file in "${SIZE_RATCHET_SETTINGS_FILE:-vstack.settings.toml}" ".vstack/settings.toml"; do
+  # Nested project settings override the root file (the standard loader
+  # order); an explicit SIZE_RATCHET_SETTINGS_FILE consults only itself.
+  if [ -n "${SIZE_RATCHET_SETTINGS_FILE+x}" ]; then
+    set -- "$SIZE_RATCHET_SETTINGS_FILE"
+  else
+    set -- ".vstack/settings.toml" "vstack.settings.toml"
+  fi
+  for file in "$@"; do
   if [ -f "$file" ]; then
     # Key PRESENCE decides, not value non-emptiness: `NAME = ""` is a real
     # assignment and must override the built-in default, exactly like a
@@ -101,7 +108,7 @@ sr_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
   fi
   done
   if [ -f ".env" ]; then
-    line="$(grep -E -- "^[[:space:]]*(export[[:space:]]+)?${name}=" .env | head -n 1 || true)"
+    line="$(grep -E -- "^[[:space:]]*(export[[:space:]]+)?${name}=" .env | tail -n 1 || true)"
     if [ -n "$line" ]; then
       val="${line#*=}"
       case "$val" in

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -196,13 +196,20 @@ else
 fi
 
 # --- count every tracked, non-excluded, regular file -------------------------
-git ls-files -z >"$TMP/files.z" || config_error "git ls-files failed"
+# -s carries the index MODE per entry: 120000 = tracked symlink (skip),
+# 160000 = submodule gitlink (never countable; a baseline row for one is
+# stale), 100xxx = regular file. The worktree state (shadowing symlink or
+# directory, sparse absence) never decides what a path IS — the index does.
+git ls-files -sz >"$TMP/files.z" || config_error "git ls-files failed"
 NL='
 '
 checked=0
 : >"$TMP/counts.raw"
 : >"$TMP/absent.raw"
-while IFS= read -r -d '' f; do
+while IFS= read -r -d '' rec; do
+  # Record shape: "<mode> <sha> <stage>\t<path>".
+  mode="${rec%% *}"
+  f="${rec#*"$TAB"}"
   is_excluded "$f" && continue
   # Every record downstream (counts, baseline, absent list) is line- and
   # tab-oriented; a path carrying either separator would silently split into
@@ -211,21 +218,19 @@ while IFS= read -r -d '' f; do
     *"$NL"*) config_error "tracked path contains a newline, unrepresentable in line-oriented records (exclude it to skip the gate): '$f'" ;;
     *"$TAB"*) config_error "tracked path contains a tab, unrepresentable in the baseline TSV (exclude it to skip the gate): '$f'" ;;
   esac
-  [ -h "$f" ] && continue # a symlink's own content has no meaningful line count
-  if [ ! -f "$f" ]; then
-    # Not a regular file in the worktree (unstaged deletion, sparse
-    # checkout, or a directory shadowing the tracked path): count the INDEX
-    # blob so the "every tracked file" contract holds without the worktree
-    # copy. A path whose index entry is not a blob (a submodule gitlink)
-    # cannot be shown and falls through to the absent list — a sparse checkout cannot smuggle a
-    # new offender past the gate, and baselined rows evaluate against real
-    # content instead of being skipped as unknown. A path git cannot show
-    # (e.g. a gitlink) falls back to the absent list.
-    # Blob TYPE required, not mere existence: a submodule gitlink's target
-    # commit can be present locally, and `git show`/`cat-file -e` would
-    # happily render it as countable "content".
-    if [ "$(git cat-file -t ":$f" 2>/dev/null)" = "blob" ] \
-      && n="$(git show ":$f" 2>/dev/null | wc -l)"; then
+  case "$mode" in
+    120000) continue ;; # tracked symlink — no meaningful line count
+    160000) continue ;; # submodule gitlink — never countable; a baseline
+                        # row for one reads as gone/stale, not absent
+  esac
+  if [ ! -f "$f" ] || [ -h "$f" ]; then
+    # The index says regular file but the worktree disagrees (unstaged
+    # deletion, sparse checkout, or a shadowing symlink/directory): count
+    # the INDEX blob so the "every tracked file" contract holds — a sparse
+    # tree cannot smuggle a new offender past the gate, and baselined rows
+    # evaluate against real content. Only an unshowable blob (index/object
+    # store trouble) falls to the absent list.
+    if n="$(git show ":$f" 2>/dev/null | wc -l)"; then
       case "$n" in *[!0-9\ ]*) n="" ;; esac
     else
       n=""

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -104,10 +104,33 @@ if [ -n "$EXCLUDES_OPT" ]; then
 else
   EXCLUDES_FILE="$(sr_setting SIZE_RATCHET_EXCLUDES "tools/size-ratchet-excludes")" || exit 2
 fi
-# Normalize leading ./ segments: git ls-files records canonical relative
-# paths, and every literal comparison against them must agree.
-while [ "${BASELINE_FILE#./}" != "$BASELINE_FILE" ]; do BASELINE_FILE="${BASELINE_FILE#./}"; done
-while [ "${EXCLUDES_FILE#./}" != "$EXCLUDES_FILE" ]; do EXCLUDES_FILE="${EXCLUDES_FILE#./}"; done
+# Lexically normalize configured paths (leading ./, internal ./ and ..
+# segments): git ls-files records canonical relative paths, and every
+# literal comparison against them must agree. Pure string surgery — no
+# symlink resolution, Bash 3.2-safe.
+normalize_rel_path() { # PATH -> normalized on stdout; nonzero if it escapes
+  local input="$1" out="" seg rest
+  rest="$input"
+  while [ -n "$rest" ]; do
+    seg="${rest%%/*}"
+    if [ "$seg" = "$rest" ]; then rest=""; else rest="${rest#*/}"; fi
+    case "$seg" in
+      "" | ".") ;;
+      "..")
+        case "$out" in
+          "") return 1 ;;
+          */*) out="${out%/*}" ;;
+          *) out="" ;;
+        esac
+        ;;
+      *) out="${out:+$out/}$seg" ;;
+    esac
+  done
+  [ -n "$out" ] || return 1
+  printf '%s' "$out"
+}
+BASELINE_FILE="$(normalize_rel_path "$BASELINE_FILE")" || config_error "baseline path escapes the repository or normalizes empty"
+EXCLUDES_FILE="$(normalize_rel_path "$EXCLUDES_FILE")" || config_error "excludes path escapes the repository or normalizes empty"
 [ -n "$BASELINE_FILE" ] || config_error "baseline path resolved empty"
 [ -n "$EXCLUDES_FILE" ] || config_error "excludes path resolved empty"
 # A path beginning with '-' would read as an option to the line utilities

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -1,0 +1,273 @@
+#!/usr/bin/env bash
+# size-ratchet — tighten-only file-size gate over tracked files.
+#
+# check (default): every tracked file (git ls-files) minus the exclusion
+# list must be at or under the line threshold, unless a baseline row freezes
+# it at its current size. FAIL on:
+#   (a) a new offender — over the threshold with no baseline row;
+#   (b) growth of a baselined file — actual lines > its baseline row;
+#   (c) a baseline looser than reality — row > actual lines, the file shrank
+#       to/under the threshold, or the file left the tracked set. The
+#       ratchet only moves down, so a loose or stale row is itself a
+#       failure, never slack.
+#
+# --update: rewrite the baseline TIGHTENING ONLY — lower rows to current
+# reality, remove rows for files now at/under the threshold or no longer
+# counted; never add a row, never raise a number. Deliberate growth is a
+# human hand-edit of the row, visible in review. After the rewrite the
+# check re-runs against the new baseline, so remaining growth and new
+# offenders still fail.
+#
+# Lines are newline counts (`wc -l`). Baseline: `path<TAB>lines`, LC_ALL=C
+# sorted, unique paths, counts above the threshold. Excludes:
+# `pattern<TAB>reason` per line (shell glob matched against the full
+# repo-relative path; `*` crosses `/`), blank lines and `#` comments
+# ignored, a missing reason is a config error.
+#
+# Exit codes: 0 clean; 1 violations; 2 usage/config error.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/settings.sh
+source "$SCRIPT_DIR/lib/settings.sh"
+
+TAB="$(printf '\t')"
+
+usage() {
+  cat <<'EOF'
+usage: size-ratchet [--update] [--baseline FILE] [--excludes FILE]
+
+Tighten-only file-size gate: tracked files over the line threshold must be
+frozen in the baseline at their current size, and the baseline may only
+move down. --update lowers/removes rows to current reality (never adds,
+never raises) and then re-checks.
+
+Configuration (env > vstack.settings.toml [env] > default):
+  SIZE_RATCHET_THRESHOLD   line threshold           (default 1000)
+  SIZE_RATCHET_BASELINE    baseline path            (default tools/size-ratchet-baseline.tsv)
+  SIZE_RATCHET_EXCLUDES    exclusion-list path      (default tools/size-ratchet-excludes)
+Flags override both for the path settings.
+
+Exit codes: 0 clean; 1 violations; 2 usage/config error.
+EOF
+}
+
+config_error() {
+  echo "::error::size-ratchet: $*" >&2
+  exit 2
+}
+
+MODE="check"
+BASELINE_OPT=""
+EXCLUDES_OPT=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --update) MODE="update" ;;
+    --baseline)
+      [ $# -ge 2 ] || config_error "--baseline requires a path"
+      shift
+      BASELINE_OPT="$1"
+      ;;
+    --baseline=*) BASELINE_OPT="${1#--baseline=}" ;;
+    --excludes)
+      [ $# -ge 2 ] || config_error "--excludes requires a path"
+      shift
+      EXCLUDES_OPT="$1"
+      ;;
+    --excludes=*) EXCLUDES_OPT="${1#--excludes=}" ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *) config_error "unknown argument '$1' (see --help)" ;;
+  esac
+  shift
+done
+
+# All configured paths (settings file, baseline, excludes) are repo-relative.
+REPO_ROOT="$(git rev-parse --show-toplevel)" || config_error "not inside a git repository"
+cd "$REPO_ROOT"
+
+THRESHOLD="$(sr_setting SIZE_RATCHET_THRESHOLD 1000)" || exit 2
+case "$THRESHOLD" in
+  "" | *[!0-9]* | 0*[0-9] | 0) config_error "SIZE_RATCHET_THRESHOLD must be a positive integer, got '$THRESHOLD'" ;;
+esac
+
+if [ -n "$BASELINE_OPT" ]; then
+  BASELINE_FILE="$BASELINE_OPT"
+else
+  BASELINE_FILE="$(sr_setting SIZE_RATCHET_BASELINE "tools/size-ratchet-baseline.tsv")" || exit 2
+fi
+if [ -n "$EXCLUDES_OPT" ]; then
+  EXCLUDES_FILE="$EXCLUDES_OPT"
+else
+  EXCLUDES_FILE="$(sr_setting SIZE_RATCHET_EXCLUDES "tools/size-ratchet-excludes")" || exit 2
+fi
+[ -n "$BASELINE_FILE" ] || config_error "baseline path resolved empty"
+[ -n "$EXCLUDES_FILE" ] || config_error "excludes path resolved empty"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# --- exclusion list: pattern<TAB>reason, reason mandatory --------------------
+EXCLUDE_PATTERNS=()
+if [ -f "$EXCLUDES_FILE" ]; then
+  lineno=0
+  while IFS= read -r line || [ -n "$line" ]; do
+    lineno=$((lineno + 1))
+    case "$line" in
+      "" | "#"*) continue ;;
+    esac
+    pat="${line%%"$TAB"*}"
+    reason="${line#*"$TAB"}"
+    if [ "$pat" = "$line" ] || [ -z "$pat" ] || [ -z "$reason" ]; then
+      config_error "$EXCLUDES_FILE:$lineno: expected 'pattern<TAB>reason' (every exclusion carries its justification)"
+    fi
+    EXCLUDE_PATTERNS+=("$pat")
+  done <"$EXCLUDES_FILE"
+fi
+
+is_excluded() { # PATH — 0 when some exclusion glob matches the full path
+  local path="$1" pat
+  # Guarded expansion: an empty array is an unbound variable under Bash 3.2
+  # with set -u.
+  for pat in ${EXCLUDE_PATTERNS[@]+"${EXCLUDE_PATTERNS[@]}"}; do
+    # shellcheck disable=SC2254 -- $pat must expand unquoted to act as a glob
+    case "$path" in
+      $pat) return 0 ;;
+    esac
+  done
+  return 1
+}
+
+# --- baseline: path<TAB>lines, LC_ALL=C sorted, unique paths -----------------
+if [ -f "$BASELINE_FILE" ]; then
+  bad_rows="$(grep -nEv "^[^${TAB}]+${TAB}[1-9][0-9]*\$" "$BASELINE_FILE" || true)"
+  if [ -n "$bad_rows" ]; then
+    printf '%s\n' "$bad_rows" >&2
+    config_error "$BASELINE_FILE: malformed row(s) above (expected 'path<TAB>lines' with a positive line count)"
+  fi
+  if ! LC_ALL=C sort -c "$BASELINE_FILE" 2>/dev/null; then
+    config_error "$BASELINE_FILE: rows must be LC_ALL=C sorted (LC_ALL=C sort -o $BASELINE_FILE $BASELINE_FILE)"
+  fi
+  dup_paths="$(cut -f1 "$BASELINE_FILE" | LC_ALL=C uniq -d)"
+  if [ -n "$dup_paths" ]; then
+    printf '%s\n' "$dup_paths" >&2
+    config_error "$BASELINE_FILE: duplicate path row(s) above"
+  fi
+  cp "$BASELINE_FILE" "$TMP/baseline.tsv"
+else
+  : >"$TMP/baseline.tsv"
+fi
+
+# --- count every tracked, non-excluded, regular file -------------------------
+git ls-files -z >"$TMP/files.z" || config_error "git ls-files failed"
+checked=0
+: >"$TMP/counts.raw"
+while IFS= read -r -d '' f; do
+  [ -h "$f" ] && continue # a symlink's own content has no meaningful line count
+  [ -f "$f" ] || continue # tracked but deleted in the working tree
+  is_excluded "$f" && continue
+  case "$f" in
+    *"$TAB"*) config_error "tracked path contains a tab, unrepresentable in the baseline TSV: $f" ;;
+  esac
+  n="$(wc -l <"$f")"
+  n=$((n)) # strip wc's leading whitespace (BSD wc pads)
+  printf '%s\t%s\n' "$f" "$n" >>"$TMP/counts.raw"
+  checked=$((checked + 1))
+done <"$TMP/files.z"
+LC_ALL=C sort "$TMP/counts.raw" >"$TMP/counts.tsv"
+
+# --- evaluate a baseline against the counts ----------------------------------
+evaluate() { # BASELINE-TSV — violations on stdout, one per line, tab-separated
+  awk -F'\t' -v OFS='\t' -v thr="$THRESHOLD" -v basefile="$1" '
+    FILENAME == basefile { base[$1] = $2 + 0; border[++bn] = $1; next }
+    {
+      p = $1; n = $2 + 0; seen[p] = 1
+      if (n > thr) {
+        if (!(p in base))      print "NEW",   p, n, thr
+        else if (n > base[p])  print "GROW",  p, n, base[p]
+        else if (n < base[p])  print "LOOSE", p, n, base[p]
+      } else if (p in base) {
+        print "STALE", p, n, base[p]
+      }
+    }
+    END {
+      for (i = 1; i <= bn; i++) {
+        p = border[i]
+        if (!(p in seen)) print "GONE", p, "", base[p]
+      }
+    }
+  ' "$1" "$TMP/counts.tsv"
+}
+
+report() { # VIOLATIONS-FILE — human diagnostics on stdout
+  local kind path n b
+  while IFS="$TAB" read -r kind path n b; do
+    case "$kind" in
+      NEW)
+        echo "size-ratchet FAIL new offender: $path — $n lines > threshold $b, no baseline row"
+        echo "  remedies: split at a concept seam, or raise the baseline row in this diff with justification"
+        ;;
+      GROW)
+        echo "size-ratchet FAIL baselined file grew: $path — $n lines > baseline $b (threshold $THRESHOLD)"
+        echo "  remedies: split at a concept seam, or raise the baseline row in this diff with justification"
+        ;;
+      LOOSE)
+        echo "size-ratchet FAIL baseline looser than reality: $path — baseline $b > actual $n lines; the ratchet only moves down"
+        echo "  remedy: run size-ratchet --update to tighten the row"
+        ;;
+      STALE)
+        echo "size-ratchet FAIL stale baseline row: $path — $n lines is at/under threshold $THRESHOLD, the row ($b) must go"
+        echo "  remedy: run size-ratchet --update to drop the row"
+        ;;
+      GONE)
+        echo "size-ratchet FAIL stale baseline row: $path — no longer in the tracked, non-excluded set, the row ($b) must go"
+        echo "  remedy: run size-ratchet --update to drop the row"
+        ;;
+    esac
+  done <"$1"
+}
+
+# --- --update: tighten only ---------------------------------------------------
+if [ "$MODE" = "update" ]; then
+  awk -F'\t' -v OFS='\t' -v thr="$THRESHOLD" -v basefile="$TMP/baseline.tsv" '
+    FILENAME == basefile { base[$1] = $2 + 0; border[++bn] = $1; next }
+    { act[$1] = $2 + 0 }
+    END {
+      for (i = 1; i <= bn; i++) {
+        p = border[i]; b = base[p]
+        if (!(p in act) || act[p] <= thr) {
+          printf "removed: %s (row %d)\n", p, b > "/dev/stderr"
+          continue
+        }
+        if (act[p] < b) {
+          printf "tightened: %s %d -> %d\n", p, b, act[p] > "/dev/stderr"
+          print p, act[p]
+        } else {
+          if (act[p] > b) printf "kept (grew %d > %d — growth is a hand-edit, never --update): %s\n", act[p], b, p > "/dev/stderr"
+          print p, b
+        }
+      }
+    }
+  ' "$TMP/baseline.tsv" "$TMP/counts.tsv" | LC_ALL=C sort >"$TMP/baseline.new"
+  if [ -f "$BASELINE_FILE" ]; then
+    mv "$TMP/baseline.new" "$BASELINE_FILE"
+    cp "$BASELINE_FILE" "$TMP/baseline.tsv"
+    echo "size-ratchet --update: baseline tightened at $BASELINE_FILE ($(grep -c . "$BASELINE_FILE" || true) row(s))"
+  else
+    # No baseline exists and --update never adds rows, so there is nothing
+    # to write; fall through to the plain check.
+    echo "size-ratchet --update: no baseline at $BASELINE_FILE and --update never adds rows; nothing written"
+  fi
+fi
+
+# --- verdict -------------------------------------------------------------------
+evaluate "$TMP/baseline.tsv" >"$TMP/violations.tsv"
+violations="$(grep -c . "$TMP/violations.tsv" || true)"
+report "$TMP/violations.tsv"
+if [ "$violations" -gt 0 ]; then
+  echo "size-ratchet: $violations violation(s) — threshold $THRESHOLD, baseline $BASELINE_FILE"
+  exit 1
+fi
+echo "size-ratchet: OK — $checked tracked file(s) checked, threshold $THRESHOLD"

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -105,6 +105,11 @@ else
 fi
 [ -n "$BASELINE_FILE" ] || config_error "baseline path resolved empty"
 [ -n "$EXCLUDES_FILE" ] || config_error "excludes path resolved empty"
+# A path beginning with '-' would read as an option to the line utilities
+# that touch it — refuse it as configuration rather than trusting every
+# call site's `--` guard forever.
+case "$BASELINE_FILE" in -*) config_error "baseline path must not begin with '-': $BASELINE_FILE" ;; esac
+case "$EXCLUDES_FILE" in -*) config_error "excludes path must not begin with '-': $EXCLUDES_FILE" ;; esac
 
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
@@ -142,20 +147,20 @@ is_excluded() { # PATH — 0 when some exclusion glob matches the full path
 
 # --- baseline: path<TAB>lines, LC_ALL=C sorted, unique paths -----------------
 if [ -f "$BASELINE_FILE" ]; then
-  bad_rows="$(grep -nEv "^[^${TAB}]+${TAB}[1-9][0-9]*\$" "$BASELINE_FILE" || true)"
+  bad_rows="$(grep -nEv "^[^${TAB}]+${TAB}[1-9][0-9]*\$" -- "$BASELINE_FILE" || true)"
   if [ -n "$bad_rows" ]; then
     printf '%s\n' "$bad_rows" >&2
     config_error "$BASELINE_FILE: malformed row(s) above (expected 'path<TAB>lines' with a positive line count)"
   fi
-  if ! LC_ALL=C sort -c "$BASELINE_FILE" 2>/dev/null; then
+  if ! LC_ALL=C sort -c -- "$BASELINE_FILE" 2>/dev/null; then
     config_error "$BASELINE_FILE: rows must be LC_ALL=C sorted (LC_ALL=C sort -o $BASELINE_FILE $BASELINE_FILE)"
   fi
-  dup_paths="$(cut -f1 "$BASELINE_FILE" | LC_ALL=C uniq -d)"
+  dup_paths="$(cut -f1 -- "$BASELINE_FILE" | LC_ALL=C uniq -d)"
   if [ -n "$dup_paths" ]; then
     printf '%s\n' "$dup_paths" >&2
     config_error "$BASELINE_FILE: duplicate path row(s) above"
   fi
-  cp "$BASELINE_FILE" "$TMP/baseline.tsv"
+  cp -- "$BASELINE_FILE" "$TMP/baseline.tsv"
 else
   : >"$TMP/baseline.tsv"
 fi
@@ -281,9 +286,17 @@ if [ "$MODE" = "update" ]; then
     }
   ' "$TMP/baseline.tsv" "$TMP/absent.lst" "$TMP/counts.tsv" | LC_ALL=C sort >"$TMP/baseline.new"
   if [ -f "$BASELINE_FILE" ]; then
-    mv "$TMP/baseline.new" "$BASELINE_FILE"
-    cp "$BASELINE_FILE" "$TMP/baseline.tsv"
-    echo "size-ratchet --update: baseline tightened at $BASELINE_FILE ($(grep -c . "$BASELINE_FILE" || true) row(s))"
+    mv -- "$TMP/baseline.new" "$BASELINE_FILE"
+    cp -- "$BASELINE_FILE" "$TMP/baseline.tsv"
+    echo "size-ratchet --update: baseline tightened at $BASELINE_FILE ($(grep -c . -- "$BASELINE_FILE" || true) row(s))"
+    # The baseline file is itself a tracked file whose length just changed;
+    # refresh its counts row so the post-update verdict sees reality, not
+    # the pre-rewrite length.
+    if grep -q "^${BASELINE_FILE}${TAB}" -- "$TMP/counts.tsv"; then
+      new_n="$(wc -l <"$BASELINE_FILE" | tr -d ' ')"
+      awk -F'\t' -v OFS='\t' -v p="$BASELINE_FILE" -v n="$new_n" '$1 == p { print p, n; next } { print }' "$TMP/counts.tsv" >"$TMP/counts.rewrite"
+      mv "$TMP/counts.rewrite" "$TMP/counts.tsv"
+    fi
   else
     # No baseline exists and --update never adds rows, so there is nothing
     # to write; fall through to the plain check.

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -42,8 +42,8 @@ frozen in the baseline at their current size, and the baseline may only
 move down. --update lowers/removes rows to current reality (never adds,
 never raises) and then re-checks.
 
-Configuration (env > .env.local > vstack.settings.toml [env] >
-.vstack/settings.toml > .env > default):
+Configuration (env > .env.local > .vstack/settings.toml >
+vstack.settings.toml [env] > .env > default):
   SIZE_RATCHET_THRESHOLD   line threshold           (default 1000)
   SIZE_RATCHET_BASELINE    baseline path            (default tools/size-ratchet-baseline.tsv)
   SIZE_RATCHET_EXCLUDES    exclusion-list path      (default tools/size-ratchet-excludes)
@@ -104,6 +104,10 @@ if [ -n "$EXCLUDES_OPT" ]; then
 else
   EXCLUDES_FILE="$(sr_setting SIZE_RATCHET_EXCLUDES "tools/size-ratchet-excludes")" || exit 2
 fi
+# Normalize leading ./ segments: git ls-files records canonical relative
+# paths, and every literal comparison against them must agree.
+while [ "${BASELINE_FILE#./}" != "$BASELINE_FILE" ]; do BASELINE_FILE="${BASELINE_FILE#./}"; done
+while [ "${EXCLUDES_FILE#./}" != "$EXCLUDES_FILE" ]; do EXCLUDES_FILE="${EXCLUDES_FILE#./}"; done
 [ -n "$BASELINE_FILE" ] || config_error "baseline path resolved empty"
 [ -n "$EXCLUDES_FILE" ] || config_error "excludes path resolved empty"
 # A path beginning with '-' would read as an option to the line utilities

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -136,8 +136,8 @@ EXCLUDES_FILE="$(normalize_rel_path "$EXCLUDES_FILE")" || config_error "excludes
 # A path beginning with '-' would read as an option to the line utilities
 # that touch it — refuse it as configuration rather than trusting every
 # call site's `--` guard forever.
-case "$BASELINE_FILE" in -*) config_error "baseline path must not begin with '-': $BASELINE_FILE" ;; esac
-case "$EXCLUDES_FILE" in -*) config_error "excludes path must not begin with '-': $EXCLUDES_FILE" ;; esac
+case "$BASELINE_FILE" in -*) config_error "baseline path must not begin with '-': $BASELINE_FILE" ;; /*) config_error "baseline path must be repo-root-relative, got absolute: $BASELINE_FILE" ;; esac
+case "$EXCLUDES_FILE" in -*) config_error "excludes path must not begin with '-': $EXCLUDES_FILE" ;; /*) config_error "excludes path must be repo-root-relative, got absolute: $EXCLUDES_FILE" ;; esac
 
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
@@ -210,16 +210,12 @@ while IFS= read -r -d '' f; do
     *"$TAB"*) config_error "tracked path contains a tab, unrepresentable in the baseline TSV (exclude it to skip the gate): '$f'" ;;
   esac
   [ -h "$f" ] && continue # a symlink's own content has no meaningful line count
-  if [ -d "$f" ]; then
-    # A directory at a tracked file path is a submodule gitlink — not a
-    # countable file. Its baseline row (if any) is stale by definition and
-    # the evaluate pass flags it through the absent list's stale side.
-    continue
-  fi
   if [ ! -f "$f" ]; then
-    # In the index but absent from the worktree (unstaged deletion, sparse
-    # checkout): count the INDEX blob so the "every tracked file" contract
-    # holds without the worktree copy — a sparse checkout cannot smuggle a
+    # Not a regular file in the worktree (unstaged deletion, sparse
+    # checkout, or a directory shadowing the tracked path): count the INDEX
+    # blob so the "every tracked file" contract holds without the worktree
+    # copy. A path whose index entry is not a blob (a submodule gitlink)
+    # cannot be shown and falls through to the absent list — a sparse checkout cannot smuggle a
     # new offender past the gate, and baselined rows evaluate against real
     # content instead of being skipped as unknown. A path git cannot show
     # (e.g. a gitlink) falls back to the absent list.

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -162,26 +162,42 @@ fi
 
 # --- count every tracked, non-excluded, regular file -------------------------
 git ls-files -z >"$TMP/files.z" || config_error "git ls-files failed"
+NL='
+'
 checked=0
 : >"$TMP/counts.raw"
+: >"$TMP/absent.raw"
 while IFS= read -r -d '' f; do
-  [ -h "$f" ] && continue # a symlink's own content has no meaningful line count
-  [ -f "$f" ] || continue # tracked but deleted in the working tree
   is_excluded "$f" && continue
+  # Every record downstream (counts, baseline, absent list) is line- and
+  # tab-oriented; a path carrying either separator would silently split into
+  # garbage rows. Refuse loudly — excluding the path is the escape hatch.
   case "$f" in
-    *"$TAB"*) config_error "tracked path contains a tab, unrepresentable in the baseline TSV: $f" ;;
+    *"$NL"*) config_error "tracked path contains a newline, unrepresentable in line-oriented records (exclude it to skip the gate): '$f'" ;;
+    *"$TAB"*) config_error "tracked path contains a tab, unrepresentable in the baseline TSV (exclude it to skip the gate): '$f'" ;;
   esac
+  [ -h "$f" ] && continue # a symlink's own content has no meaningful line count
+  if [ ! -f "$f" ]; then
+    # In the index but absent from the worktree (unstaged deletion, sparse
+    # checkout): the size is unknowable. Never classify as gone — that would
+    # fail the check as stale and let --update drop the row, silently
+    # loosening the ratchet on a tree that merely hasn't materialized it.
+    printf '%s\n' "$f" >>"$TMP/absent.raw"
+    continue
+  fi
   n="$(wc -l <"$f")"
   n=$((n)) # strip wc's leading whitespace (BSD wc pads)
   printf '%s\t%s\n' "$f" "$n" >>"$TMP/counts.raw"
   checked=$((checked + 1))
 done <"$TMP/files.z"
 LC_ALL=C sort "$TMP/counts.raw" >"$TMP/counts.tsv"
+LC_ALL=C sort "$TMP/absent.raw" >"$TMP/absent.lst"
 
 # --- evaluate a baseline against the counts ----------------------------------
 evaluate() { # BASELINE-TSV — violations on stdout, one per line, tab-separated
-  awk -F'\t' -v OFS='\t' -v thr="$THRESHOLD" -v basefile="$1" '
+  awk -F'\t' -v OFS='\t' -v thr="$THRESHOLD" -v basefile="$1" -v absentfile="$TMP/absent.lst" '
     FILENAME == basefile { base[$1] = $2 + 0; border[++bn] = $1; next }
+    FILENAME == absentfile { absent[$1] = 1; next }
     {
       p = $1; n = $2 + 0; seen[p] = 1
       if (n > thr) {
@@ -195,10 +211,15 @@ evaluate() { # BASELINE-TSV — violations on stdout, one per line, tab-separate
     END {
       for (i = 1; i <= bn; i++) {
         p = border[i]
-        if (!(p in seen)) print "GONE", p, "", base[p]
+        if (p in seen) continue
+        if (p in absent) continue # size unknown: neither gone nor grown
+        # "-" placeholder, never an empty field: report() reads these rows
+        # with tab-IFS, and whitespace IFS collapses consecutive tabs, which
+        # would shift the baseline count into the wrong column.
+        print "GONE", p, "-", base[p]
       }
     }
-  ' "$1" "$TMP/counts.tsv"
+  ' "$1" "$TMP/absent.lst" "$TMP/counts.tsv"
 }
 
 report() { # VIOLATIONS-FILE — human diagnostics on stdout
@@ -231,12 +252,20 @@ report() { # VIOLATIONS-FILE — human diagnostics on stdout
 
 # --- --update: tighten only ---------------------------------------------------
 if [ "$MODE" = "update" ]; then
-  awk -F'\t' -v OFS='\t' -v thr="$THRESHOLD" -v basefile="$TMP/baseline.tsv" '
+  awk -F'\t' -v OFS='\t' -v thr="$THRESHOLD" -v basefile="$TMP/baseline.tsv" -v absentfile="$TMP/absent.lst" '
     FILENAME == basefile { base[$1] = $2 + 0; border[++bn] = $1; next }
+    FILENAME == absentfile { absent[$1] = 1; next }
     { act[$1] = $2 + 0 }
     END {
       for (i = 1; i <= bn; i++) {
         p = border[i]; b = base[p]
+        if (p in absent) {
+          # Tracked but not in the worktree: size unknown, row preserved
+          # verbatim — dropping it here would loosen the ratchet.
+          printf "preserved (tracked but absent from worktree): %s\n", p > "/dev/stderr"
+          print p, b
+          continue
+        }
         if (!(p in act) || act[p] <= thr) {
           printf "removed: %s (row %d)\n", p, b > "/dev/stderr"
           continue
@@ -250,7 +279,7 @@ if [ "$MODE" = "update" ]; then
         }
       }
     }
-  ' "$TMP/baseline.tsv" "$TMP/counts.tsv" | LC_ALL=C sort >"$TMP/baseline.new"
+  ' "$TMP/baseline.tsv" "$TMP/absent.lst" "$TMP/counts.tsv" | LC_ALL=C sort >"$TMP/baseline.new"
   if [ -f "$BASELINE_FILE" ]; then
     mv "$TMP/baseline.new" "$BASELINE_FILE"
     cp "$BASELINE_FILE" "$TMP/baseline.tsv"

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -129,6 +129,8 @@ normalize_rel_path() { # PATH -> normalized on stdout; nonzero if it escapes
   [ -n "$out" ] || return 1
   printf '%s' "$out"
 }
+case "$BASELINE_FILE" in /*) config_error "baseline path must be repo-root-relative, got absolute: $BASELINE_FILE" ;; esac
+case "$EXCLUDES_FILE" in /*) config_error "excludes path must be repo-root-relative, got absolute: $EXCLUDES_FILE" ;; esac
 BASELINE_FILE="$(normalize_rel_path "$BASELINE_FILE")" || config_error "baseline path escapes the repository or normalizes empty"
 EXCLUDES_FILE="$(normalize_rel_path "$EXCLUDES_FILE")" || config_error "excludes path escapes the repository or normalizes empty"
 [ -n "$BASELINE_FILE" ] || config_error "baseline path resolved empty"
@@ -219,12 +221,16 @@ while IFS= read -r -d '' f; do
     # new offender past the gate, and baselined rows evaluate against real
     # content instead of being skipped as unknown. A path git cannot show
     # (e.g. a gitlink) falls back to the absent list.
-    if n="$(git show ":$f" 2>/dev/null | wc -l)"; then
+    # Blob TYPE required, not mere existence: a submodule gitlink's target
+    # commit can be present locally, and `git show`/`cat-file -e` would
+    # happily render it as countable "content".
+    if [ "$(git cat-file -t ":$f" 2>/dev/null)" = "blob" ] \
+      && n="$(git show ":$f" 2>/dev/null | wc -l)"; then
       case "$n" in *[!0-9\ ]*) n="" ;; esac
     else
       n=""
     fi
-    if [ -n "$n" ] && git cat-file -e ":$f" 2>/dev/null; then
+    if [ -n "$n" ]; then
       n=$((n))
       printf '%s\t%s\n' "$f" "$n" >>"$TMP/counts.raw"
       checked=$((checked + 1))

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -187,11 +187,30 @@ while IFS= read -r -d '' f; do
     *"$TAB"*) config_error "tracked path contains a tab, unrepresentable in the baseline TSV (exclude it to skip the gate): '$f'" ;;
   esac
   [ -h "$f" ] && continue # a symlink's own content has no meaningful line count
+  if [ -d "$f" ]; then
+    # A directory at a tracked file path is a submodule gitlink — not a
+    # countable file. Its baseline row (if any) is stale by definition and
+    # the evaluate pass flags it through the absent list's stale side.
+    continue
+  fi
   if [ ! -f "$f" ]; then
     # In the index but absent from the worktree (unstaged deletion, sparse
-    # checkout): the size is unknowable. Never classify as gone — that would
-    # fail the check as stale and let --update drop the row, silently
-    # loosening the ratchet on a tree that merely hasn't materialized it.
+    # checkout): count the INDEX blob so the "every tracked file" contract
+    # holds without the worktree copy — a sparse checkout cannot smuggle a
+    # new offender past the gate, and baselined rows evaluate against real
+    # content instead of being skipped as unknown. A path git cannot show
+    # (e.g. a gitlink) falls back to the absent list.
+    if n="$(git show ":$f" 2>/dev/null | wc -l)"; then
+      case "$n" in *[!0-9\ ]*) n="" ;; esac
+    else
+      n=""
+    fi
+    if [ -n "$n" ] && git cat-file -e ":$f" 2>/dev/null; then
+      n=$((n))
+      printf '%s\t%s\n' "$f" "$n" >>"$TMP/counts.raw"
+      checked=$((checked + 1))
+      continue
+    fi
     printf '%s\n' "$f" >>"$TMP/absent.raw"
     continue
   fi
@@ -299,9 +318,9 @@ if [ "$MODE" = "update" ]; then
     # the pre-rewrite length.
     # Literal path match (awk string equality, never a grep regex): a
     # baseline path with regex-significant characters must still recount.
-    if awk -F'\t' -v p="$BASELINE_FILE" '$1 == p { found = 1 } END { exit found ? 0 : 1 }' "$TMP/counts.tsv"; then
+    if BASELINE_PATH="$BASELINE_FILE" awk -F'\t' 'BEGIN { p = ENVIRON["BASELINE_PATH"] } $1 == p { found = 1 } END { exit found ? 0 : 1 }' "$TMP/counts.tsv"; then
       new_n="$(wc -l <"$BASELINE_FILE" | tr -d ' ')"
-      awk -F'\t' -v OFS='\t' -v p="$BASELINE_FILE" -v n="$new_n" '$1 == p { print p, n; next } { print }' "$TMP/counts.tsv" >"$TMP/counts.rewrite"
+      BASELINE_PATH="$BASELINE_FILE" NEW_N="$new_n" awk -F'\t' -v OFS='\t' 'BEGIN { p = ENVIRON["BASELINE_PATH"]; n = ENVIRON["NEW_N"] } $1 == p { print p, n; next } { print }' "$TMP/counts.tsv" >"$TMP/counts.rewrite"
       mv "$TMP/counts.rewrite" "$TMP/counts.tsv"
     fi
   else

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -42,7 +42,8 @@ frozen in the baseline at their current size, and the baseline may only
 move down. --update lowers/removes rows to current reality (never adds,
 never raises) and then re-checks.
 
-Configuration (env > vstack.settings.toml [env] > default):
+Configuration (env > .env.local > vstack.settings.toml [env] >
+.vstack/settings.toml > .env > default):
   SIZE_RATCHET_THRESHOLD   line threshold           (default 1000)
   SIZE_RATCHET_BASELINE    baseline path            (default tools/size-ratchet-baseline.tsv)
   SIZE_RATCHET_EXCLUDES    exclusion-list path      (default tools/size-ratchet-excludes)
@@ -292,7 +293,9 @@ if [ "$MODE" = "update" ]; then
     # The baseline file is itself a tracked file whose length just changed;
     # refresh its counts row so the post-update verdict sees reality, not
     # the pre-rewrite length.
-    if grep -q "^${BASELINE_FILE}${TAB}" -- "$TMP/counts.tsv"; then
+    # Literal path match (awk string equality, never a grep regex): a
+    # baseline path with regex-significant characters must still recount.
+    if awk -F'\t' -v p="$BASELINE_FILE" '$1 == p { found = 1 } END { exit found ? 0 : 1 }' "$TMP/counts.tsv"; then
       new_n="$(wc -l <"$BASELINE_FILE" | tr -d ' ')"
       awk -F'\t' -v OFS='\t' -v p="$BASELINE_FILE" -v n="$new_n" '$1 == p { print p, n; next } { print }' "$TMP/counts.tsv" >"$TMP/counts.rewrite"
       mv "$TMP/counts.rewrite" "$TMP/counts.tsv"

--- a/skills/size-ratchet/tests/bash32-portability.test.sh
+++ b/skills/size-ratchet/tests/bash32-portability.test.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# size-ratchet runs on consumer CI images and on macOS system Bash 3.2, so
+# shipped scripts may not use Bash 4+ builtins or syntax (mapfile/readarray,
+# associative arrays, automatic FD-allocation redirections, case-conversion
+# expansions).
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$TEST_DIR/../scripts" && pwd)"
+
+PATTERN='mapfile|readarray|declare -A|declare -gA|local -A'
+PATTERN="$PATTERN"'|(^|[^$])\{[A-Za-z_][A-Za-z0-9_]*\}[<>]'
+PATTERN="$PATTERN"'|\$\{[A-Za-z_][A-Za-z0-9_]*(\[[^]]*\])?(,,|\^\^)'
+
+violations="$(grep -rnE "$PATTERN" "$SCRIPTS_DIR" || true)"
+if [[ -n "$violations" ]]; then
+  echo "Bash 4+ constructs found in size-ratchet scripts (must run under Bash 3.2):" >&2
+  printf '%s\n' "$violations" >&2
+  exit 1
+fi
+
+# Syntax-check every shipped script while we are here.
+fail=0
+for f in "$SCRIPTS_DIR"/size-ratchet "$SCRIPTS_DIR"/lib/*.sh; do
+  if ! bash -n "$f"; then
+    echo "FAIL: bash -n $f"
+    fail=1
+  fi
+done
+[ "$fail" -eq 0 ] || exit 1
+
+echo "pass: bash32-portability"

--- a/skills/size-ratchet/tests/ratchet-directions.test.sh
+++ b/skills/size-ratchet/tests/ratchet-directions.test.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Pins for every check direction of scripts/size-ratchet. Both failure
+# directions (new offender, baselined growth) AND the looser-than-reality
+# direction must fire, with a passing control first so a green run is
+# evidence, not a check that cannot fail.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
+SR="$SKILL_DIR/scripts/size-ratchet"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# Hermetic: a leaked setting would mask every case below.
+unset SIZE_RATCHET_THRESHOLD SIZE_RATCHET_BASELINE SIZE_RATCHET_EXCLUDES SIZE_RATCHET_SETTINGS_FILE 2>/dev/null || true
+
+PASS=0
+FAIL=0
+ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
+
+REMEDY="split at a concept seam, or raise the baseline row in this diff with justification"
+
+new_repo() { # NAME — fresh fixture repo in $R
+  R="$TMP/$1"
+  mkdir -p "$R"
+  git -C "$R" -c init.defaultBranch=main init -q
+  git -C "$R" config user.email test@example.com
+  git -C "$R" config user.name test
+}
+
+mkfile() { # PATH LINES — file of LINES lines under $R
+  mkdir -p "$R/$(dirname "$1")"
+  awk -v n="$2" 'BEGIN { for (i = 1; i <= n; i++) print "line " i }' >"$R/$1"
+}
+
+run_sr() { # [args...] — run in $R at threshold 10; sets OUT and RC
+  OUT=""
+  RC=0
+  OUT="$(cd "$R" && SIZE_RATCHET_THRESHOLD=10 "$SR" "$@" 2>&1)" || RC=$?
+}
+
+echo "=== control: a clean repo passes, including a file exactly AT the threshold ==="
+new_repo clean
+mkfile a.txt 5
+mkfile at-threshold.txt 10
+git -C "$R" add -A
+run_sr
+[ "$RC" -eq 0 ] && case "$OUT" in *"size-ratchet: OK"*) true ;; *) false ;; esac \
+  && ok "clean repo passes; 10 lines at threshold 10 is not an offender" \
+  || bad "clean repo passes; 10 lines at threshold 10 is not an offender" "rc=$RC out=$OUT"
+
+echo "=== failure direction 1: new offender ==="
+new_repo newoff
+mkfile big.txt 11
+git -C "$R" add -A
+run_sr
+[ "$RC" -eq 1 ] && case "$OUT" in *"new offender: big.txt — 11 lines > threshold 10"*) true ;; *) false ;; esac \
+  && ok "one line over the threshold fails as a new offender, naming file/count/threshold" \
+  || bad "one line over the threshold fails as a new offender" "rc=$RC out=$OUT"
+case "$OUT" in *"$REMEDY"*) ok "new-offender diagnostic carries the two remedies verbatim" ;; *) bad "new-offender diagnostic carries the two remedies verbatim" "$OUT" ;; esac
+
+echo "=== a baseline row at the current count freezes the offender ==="
+new_repo frozen
+mkfile big.txt 15
+mkdir -p "$R/tools"
+printf 'big.txt\t15\n' >"$R/tools/size-ratchet-baseline.tsv"
+git -C "$R" add -A
+run_sr
+[ "$RC" -eq 0 ] && ok "baselined offender at exactly its row passes" || bad "baselined offender at exactly its row passes" "rc=$RC out=$OUT"
+
+echo "=== failure direction 2: baselined file grows ==="
+mkfile big.txt 20
+git -C "$R" add -A
+run_sr
+[ "$RC" -eq 1 ] && case "$OUT" in *"baselined file grew: big.txt — 20 lines > baseline 15"*) true ;; *) false ;; esac \
+  && ok "growth past the row fails, naming file/count/baseline" \
+  || bad "growth past the row fails" "rc=$RC out=$OUT"
+case "$OUT" in *"$REMEDY"*) ok "growth diagnostic carries the two remedies verbatim" ;; *) bad "growth diagnostic carries the two remedies verbatim" "$OUT" ;; esac
+
+echo "=== failure direction 3: baseline looser than reality ==="
+printf 'big.txt\t30\n' >"$R/tools/size-ratchet-baseline.tsv"
+git -C "$R" add -A
+run_sr
+[ "$RC" -eq 1 ] && case "$OUT" in *"baseline looser than reality: big.txt — baseline 30 > actual 20"*) true ;; *) false ;; esac \
+  && ok "a row above the actual count fails — the ratchet must move down" \
+  || bad "a row above the actual count fails" "rc=$RC out=$OUT"
+
+new_repo stale
+mkfile small.txt 5
+mkdir -p "$R/tools"
+printf 'gone.txt\t42\nsmall.txt\t15\n' >"$R/tools/size-ratchet-baseline.tsv"
+git -C "$R" add -A
+run_sr
+[ "$RC" -eq 1 ] && case "$OUT" in *"stale baseline row: small.txt"*) true ;; *) false ;; esac \
+  && ok "a row for a file now under the threshold fails as stale" \
+  || bad "a row for a file now under the threshold fails as stale" "rc=$RC out=$OUT"
+case "$OUT" in *"stale baseline row: gone.txt"*) ok "a row for a deleted file fails as stale" ;; *) bad "a row for a deleted file fails as stale" "$OUT" ;; esac
+
+echo "=== exclusions remove files from the counted set ==="
+new_repo excl
+mkfile vendor/big.txt 50
+mkfile generated.lock 50
+mkfile src/real.txt 5
+mkdir -p "$R/tools"
+printf 'vendor/*\tvendored third-party code\ngenerated.lock\tlockfile\n' >"$R/tools/size-ratchet-excludes"
+git -C "$R" add -A
+run_sr
+[ "$RC" -eq 0 ] && ok "excluded offenders (dir glob and exact path) pass" || bad "excluded offenders pass" "rc=$RC out=$OUT"
+
+printf 'vendor/big.txt\t50\n' >"$R/tools/size-ratchet-baseline.tsv"
+git -C "$R" add -A
+run_sr
+[ "$RC" -eq 1 ] && case "$OUT" in *"stale baseline row: vendor/big.txt"*) true ;; *) false ;; esac \
+  && ok "a baseline row for an excluded file is stale — excluded files leave the counted set" \
+  || bad "a baseline row for an excluded file is stale" "rc=$RC out=$OUT"
+
+echo "=== --baseline flag relocates the baseline ==="
+new_repo flagpath
+mkfile big.txt 15
+printf 'big.txt\t15\n' >"$R/custom-baseline.tsv"
+git -C "$R" add -A
+run_sr --baseline custom-baseline.tsv
+[ "$RC" -eq 0 ] && ok "--baseline points the check at a custom path" || bad "--baseline points the check at a custom path" "rc=$RC out=$OUT"
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/skills/size-ratchet/tests/ratchet-directions.test.sh
+++ b/skills/size-ratchet/tests/ratchet-directions.test.sh
@@ -96,6 +96,48 @@ run_sr
   && ok "a row for a file now under the threshold fails as stale" \
   || bad "a row for a file now under the threshold fails as stale" "rc=$RC out=$OUT"
 case "$OUT" in *"stale baseline row: gone.txt"*) ok "a row for a deleted file fails as stale" ;; *) bad "a row for a deleted file fails as stale" "$OUT" ;; esac
+case "$OUT" in *"the row (42) must go"*) ok "the gone-file diagnostic keeps its fields aligned (names the row's own count)" ;; *) bad "the gone-file diagnostic keeps its fields aligned" "$OUT" ;; esac
+
+echo "=== tracked-but-absent files are unknown, never stale ==="
+# In `git ls-files` but missing from the worktree (unstaged deletion, sparse
+# checkout): the size is unknowable, so the row must be preserved — treating
+# it as gone would let --update silently loosen the ratchet.
+new_repo absent
+mkfile big.txt 15
+mkdir -p "$R/tools"
+printf 'big.txt\t15\n' >"$R/tools/size-ratchet-baseline.tsv"
+git -C "$R" add -A
+rm "$R/big.txt" # unstaged: the index still lists big.txt
+run_sr
+[ "$RC" -eq 0 ] && ok "an unstaged-deleted baselined file is preserved, not stale" \
+  || bad "an unstaged-deleted baselined file is preserved, not stale" "rc=$RC out=$OUT"
+git -C "$R" add -A # stage the deletion: now it truly left the tracked set
+run_sr
+[ "$RC" -eq 1 ] && case "$OUT" in *"stale baseline row: big.txt"*) true ;; *) false ;; esac \
+  && ok "control: the STAGED deletion is stale — only index-listed-but-absent is preserved" \
+  || bad "control: the STAGED deletion is stale" "rc=$RC out=$OUT"
+
+echo "=== newline-containing tracked paths are refused loudly ==="
+new_repo nl
+mkfile ok.txt 3
+printf 'x\n' >"$R/"$'bad\nname.txt'
+git -C "$R" add -A
+run_sr
+[ "$RC" -eq 2 ] && case "$OUT" in *newline*) true ;; *) false ;; esac \
+  && ok "a tracked path containing a newline is a loud refusal, not a silently split record" \
+  || bad "a tracked path containing a newline is a loud refusal" "rc=$RC out=$OUT"
+
+echo "=== exclusion patterns reach matching intact (no word-split, no glob expansion) ==="
+new_repo intact
+mkfile "foo bqq.txt" 20   # excluded only if 'foo b*' survives as ONE pattern
+mkfile sub/ax-big.txt 20  # excluded only if '*ax-big.txt' is NOT glob-expanded
+mkfile zax-big.txt 3      # glob bait in the repo root: an expanding build rewrites the pattern to this
+mkdir -p "$R/tools"
+printf 'foo b*\tspace-containing pattern\n*ax-big.txt\tglob-bait pattern\n' >"$R/tools/size-ratchet-excludes"
+git -C "$R" add -A
+run_sr
+[ "$RC" -eq 0 ] && ok "space-containing and glob-bait patterns both exclude their targets verbatim" \
+  || bad "space-containing and glob-bait patterns both exclude their targets verbatim" "rc=$RC out=$OUT"
 
 echo "=== exclusions remove files from the counted set ==="
 new_repo excl

--- a/skills/size-ratchet/tests/settings-and-config.test.sh
+++ b/skills/size-ratchet/tests/settings-and-config.test.sh
@@ -142,5 +142,26 @@ echo "=== usage errors ==="
 run_raw SIZE_RATCHET_THRESHOLD=10 -- --no-such-flag || true
 [ "$RC" -eq 2 ] && ok "unknown flag is exit 2" || bad "unknown flag is exit 2" "rc=$RC out=$OUT"
 
+echo "=== env-file layering: .env.local > settings > .vstack > .env ==="
+new_repo layering
+mkfile f.txt 20
+git -C "$R" add -A
+printf 'SIZE_RATCHET_THRESHOLD=7\n' > "$R/.env"
+run_raw || true
+case "$OUT" in *"threshold 7"*) ok "SIZE_RATCHET_THRESHOLD from .env applies" ;; *) bad ".env layering" "rc=$RC out=$OUT" ;; esac
+printf 'SIZE_RATCHET_THRESHOLD = "9"\n' > "$R/vstack.settings.toml"
+run_raw || true
+case "$OUT" in *"threshold 9"*) ok "vstack.settings.toml beats .env" ;; *) bad "settings-over-.env layering" "rc=$RC out=$OUT" ;; esac
+printf 'SIZE_RATCHET_THRESHOLD="11"\n' > "$R/.env.local"
+run_raw || true
+case "$OUT" in *"threshold 11"*) ok ".env.local beats vstack.settings.toml (quotes stripped)" ;; *) bad ".env.local layering" "rc=$RC out=$OUT" ;; esac
+
+echo "=== option-like configured paths ==="
+new_repo optpath
+mkfile f.txt 20
+git -C "$R" add -A
+run_raw SIZE_RATCHET_BASELINE=-b || true
+if [ "$RC" -eq 2 ]; then ok "option-like baseline path refuses as config (no cut/sort option injection)"; else bad "option-like baseline path" "rc=$RC out=$OUT"; fi
+
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/skills/size-ratchet/tests/settings-and-config.test.sh
+++ b/skills/size-ratchet/tests/settings-and-config.test.sh
@@ -155,6 +155,9 @@ case "$OUT" in *"threshold 9"*) ok "vstack.settings.toml beats .env" ;; *) bad "
 printf 'SIZE_RATCHET_THRESHOLD="11"\n' > "$R/.env.local"
 run_raw || true
 case "$OUT" in *"threshold 11"*) ok ".env.local beats vstack.settings.toml (quotes stripped)" ;; *) bad ".env.local layering" "rc=$RC out=$OUT" ;; esac
+printf 'export SIZE_RATCHET_THRESHOLD=13\n' > "$R/.env.local"
+run_raw || true
+case "$OUT" in *"threshold 13"*) ok "export-form dotenv assignment is recognized" ;; *) bad "export-form dotenv" "rc=$RC out=$OUT" ;; esac
 
 echo "=== option-like configured paths ==="
 new_repo optpath

--- a/skills/size-ratchet/tests/settings-and-config.test.sh
+++ b/skills/size-ratchet/tests/settings-and-config.test.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Pins for configuration resolution (env > vstack.settings.toml > default
+# 1000) and for the fail-loud config errors: malformed excludes (reason is
+# mandatory), malformed/unsorted/duplicated baseline, bad threshold. Config
+# problems are exit 2, never a silent pass or a silent default.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
+SR="$SKILL_DIR/scripts/size-ratchet"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+unset SIZE_RATCHET_THRESHOLD SIZE_RATCHET_BASELINE SIZE_RATCHET_EXCLUDES SIZE_RATCHET_SETTINGS_FILE 2>/dev/null || true
+
+PASS=0
+FAIL=0
+ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
+
+new_repo() { # NAME
+  R="$TMP/$1"
+  mkdir -p "$R"
+  git -C "$R" -c init.defaultBranch=main init -q
+  git -C "$R" config user.email test@example.com
+  git -C "$R" config user.name test
+}
+
+mkfile() { # PATH LINES
+  mkdir -p "$R/$(dirname "$1")"
+  awk -v n="$2" 'BEGIN { for (i = 1; i <= n; i++) print "line " i }' >"$R/$1"
+}
+
+run_raw() { # [VAR=val ...] [-- script-args...] — run $SR in $R; sets OUT, RC
+  local envs=() args=()
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --)
+        shift
+        args=("$@")
+        break
+        ;;
+      *) envs+=("$1") ;;
+    esac
+    shift
+  done
+  OUT=""
+  RC=0
+  OUT="$(cd "$R" && env ${envs[@]+"${envs[@]}"} "$SR" ${args[@]+"${args[@]}"} 2>&1)" || RC=$?
+}
+
+echo "=== threshold resolution: env > settings > default 1000 ==="
+new_repo thr
+mkfile f.txt 20
+git -C "$R" add -A
+
+run_raw
+[ "$RC" -eq 0 ] && case "$OUT" in *"threshold 1000"*) true ;; *) false ;; esac \
+  && ok "no env, no settings: 20 lines passes under the built-in default 1000" \
+  || bad "built-in default is 1000" "rc=$RC out=$OUT"
+
+mkfile huge.txt 1005
+git -C "$R" add -A
+run_raw
+[ "$RC" -eq 1 ] && case "$OUT" in *"huge.txt — 1005 lines > threshold 1000"*) true ;; *) false ;; esac \
+  && ok "default 1000 can fail (1005-line file) — the default is real, not vacuous" \
+  || bad "default 1000 can fail" "rc=$RC out=$OUT"
+rm "$R/huge.txt"
+git -C "$R" add -A
+
+printf '[env]\nSIZE_RATCHET_THRESHOLD = "15"\n' >"$R/vstack.settings.toml"
+run_raw
+[ "$RC" -eq 1 ] && case "$OUT" in *"threshold 15"*) true ;; *) false ;; esac \
+  && ok "settings file overrides the default (20 > 15 fails; 1000 would have passed)" \
+  || bad "settings file overrides the default" "rc=$RC out=$OUT"
+
+run_raw SIZE_RATCHET_THRESHOLD=25
+[ "$RC" -eq 0 ] && ok "environment overrides the settings file (25 passes where settings' 15 failed)" \
+  || bad "environment overrides the settings file" "rc=$RC out=$OUT"
+
+echo "=== invalid thresholds are config errors ==="
+run_raw SIZE_RATCHET_THRESHOLD=abc
+[ "$RC" -eq 2 ] && ok "non-numeric threshold is exit 2" || bad "non-numeric threshold is exit 2" "rc=$RC out=$OUT"
+run_raw SIZE_RATCHET_THRESHOLD=0
+[ "$RC" -eq 2 ] && ok "zero threshold is exit 2" || bad "zero threshold is exit 2" "rc=$RC out=$OUT"
+rm "$R/vstack.settings.toml"
+
+echo "=== excludes: the reason column is mandatory ==="
+new_repo exc
+mkfile ok.txt 3
+mkdir -p "$R/tools"
+printf 'vendor/*\n' >"$R/tools/size-ratchet-excludes"
+git -C "$R" add -A
+run_raw SIZE_RATCHET_THRESHOLD=10
+[ "$RC" -eq 2 ] && case "$OUT" in *"pattern<TAB>reason"*) true ;; *) false ;; esac \
+  && ok "a pattern without a tab-separated reason is exit 2" \
+  || bad "a pattern without a tab-separated reason is exit 2" "rc=$RC out=$OUT"
+
+printf '# lockfiles are generated\n\nvendor/*\tvendored third-party code\n' >"$R/tools/size-ratchet-excludes"
+git -C "$R" add -A
+run_raw SIZE_RATCHET_THRESHOLD=10
+[ "$RC" -eq 0 ] && ok "comments and blank lines in the excludes file are ignored (control)" \
+  || bad "comments and blank lines are ignored" "rc=$RC out=$OUT"
+
+echo "=== baseline hygiene is enforced, not repaired silently ==="
+new_repo base
+mkfile a.txt 15
+mkfile b.txt 15
+mkdir -p "$R/tools"
+
+printf 'b.txt\t15\na.txt\t15\n' >"$R/tools/size-ratchet-baseline.tsv"
+git -C "$R" add -A
+run_raw SIZE_RATCHET_THRESHOLD=10
+[ "$RC" -eq 2 ] && case "$OUT" in *"LC_ALL=C sorted"*) true ;; *) false ;; esac \
+  && ok "unsorted baseline is exit 2" || bad "unsorted baseline is exit 2" "rc=$RC out=$OUT"
+
+printf 'a.txt\t15\na.txt\t20\nb.txt\t15\n' >"$R/tools/size-ratchet-baseline.tsv"
+git -C "$R" add -A
+run_raw SIZE_RATCHET_THRESHOLD=10
+[ "$RC" -eq 2 ] && case "$OUT" in *"duplicate"*) true ;; *) false ;; esac \
+  && ok "duplicate baseline path is exit 2" || bad "duplicate baseline path is exit 2" "rc=$RC out=$OUT"
+
+printf 'a.txt\tnot-a-number\n' >"$R/tools/size-ratchet-baseline.tsv"
+git -C "$R" add -A
+run_raw SIZE_RATCHET_THRESHOLD=10
+[ "$RC" -eq 2 ] && case "$OUT" in *"malformed row"*) true ;; *) false ;; esac \
+  && ok "non-numeric baseline count is exit 2" || bad "non-numeric baseline count is exit 2" "rc=$RC out=$OUT"
+
+printf 'a.txt 15\n' >"$R/tools/size-ratchet-baseline.tsv"
+git -C "$R" add -A
+run_raw SIZE_RATCHET_THRESHOLD=10
+[ "$RC" -eq 2 ] && ok "space-separated (tab-less) baseline row is exit 2" \
+  || bad "space-separated baseline row is exit 2" "rc=$RC out=$OUT"
+
+printf 'a.txt\t15\nb.txt\t15\n' >"$R/tools/size-ratchet-baseline.tsv"
+git -C "$R" add -A
+run_raw SIZE_RATCHET_THRESHOLD=10
+[ "$RC" -eq 0 ] && ok "well-formed sorted baseline passes (control for the hygiene gates)" \
+  || bad "well-formed sorted baseline passes" "rc=$RC out=$OUT"
+
+echo "=== usage errors ==="
+run_raw SIZE_RATCHET_THRESHOLD=10 -- --no-such-flag || true
+[ "$RC" -eq 2 ] && ok "unknown flag is exit 2" || bad "unknown flag is exit 2" "rc=$RC out=$OUT"
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/skills/size-ratchet/tests/update-tightens.test.sh
+++ b/skills/size-ratchet/tests/update-tightens.test.sh
@@ -79,6 +79,25 @@ run_sr
 [ "$RC" -eq 0 ] && ok "hand-edited acceptance rows pass (control: growth is a reviewed human edit)" \
   || bad "hand-edited acceptance rows pass" "rc=$RC out=$OUT"
 
+# A tracked-but-absent file (unstaged deletion / sparse checkout) has an
+# unknowable size: --update must preserve its row verbatim, never drop it —
+# dropping would loosen the ratchet with a green exit.
+R="$TMP/upd-absent"
+mkdir -p "$R"
+git -C "$R" -c init.defaultBranch=main init -q
+git -C "$R" config user.email test@example.com
+git -C "$R" config user.name test
+mkfile keep.txt 15
+mkdir -p "$R/tools"
+printf 'keep.txt\t15\n' >"$R/tools/size-ratchet-baseline.tsv"
+git -C "$R" add -A
+rm "$R/keep.txt" # unstaged: keep.txt stays in git ls-files
+run_sr --update
+row="$(cat "$R/tools/size-ratchet-baseline.tsv")"
+[ "$RC" -eq 0 ] && [ "$row" = "$(printf 'keep.txt\t15')" ] && case "$OUT" in *"preserved"*) true ;; *) false ;; esac \
+  && ok "--update preserves the row of a tracked-but-absent file verbatim and says so" \
+  || bad "--update preserves the row of a tracked-but-absent file" "rc=$RC row=$row out=$OUT"
+
 # --update with no baseline file: never creates one (it cannot add rows).
 R="$TMP/upd2"
 mkdir -p "$R"

--- a/skills/size-ratchet/tests/update-tightens.test.sh
+++ b/skills/size-ratchet/tests/update-tightens.test.sh
@@ -79,9 +79,10 @@ run_sr
 [ "$RC" -eq 0 ] && ok "hand-edited acceptance rows pass (control: growth is a reviewed human edit)" \
   || bad "hand-edited acceptance rows pass" "rc=$RC out=$OUT"
 
-# A tracked-but-absent file (unstaged deletion / sparse checkout) has an
-# unknowable size: --update must preserve its row verbatim, never drop it —
-# dropping would loosen the ratchet with a green exit.
+# A tracked-but-absent file (unstaged deletion / sparse checkout) counts
+# from the INDEX blob — "every tracked file" holds without the worktree
+# copy. An over-threshold baselined row therefore survives --update at its
+# real size, and a sparse tree cannot smuggle a new offender past the gate.
 R="$TMP/upd-absent"
 mkdir -p "$R"
 git -C "$R" -c init.defaultBranch=main init -q
@@ -91,12 +92,26 @@ mkfile keep.txt 15
 mkdir -p "$R/tools"
 printf 'keep.txt\t15\n' >"$R/tools/size-ratchet-baseline.tsv"
 git -C "$R" add -A
-rm "$R/keep.txt" # unstaged: keep.txt stays in git ls-files
+rm "$R/keep.txt" # unstaged: keep.txt stays in git ls-files; index holds 15 lines
 run_sr --update
 row="$(cat "$R/tools/size-ratchet-baseline.tsv")"
-[ "$RC" -eq 0 ] && [ "$row" = "$(printf 'keep.txt\t15')" ] && case "$OUT" in *"preserved"*) true ;; *) false ;; esac \
-  && ok "--update preserves the row of a tracked-but-absent file verbatim and says so" \
-  || bad "--update preserves the row of a tracked-but-absent file" "rc=$RC row=$row out=$OUT"
+[ "$RC" -eq 0 ] && [ "$row" = "$(printf 'keep.txt\t15')" ] \
+  && ok "--update keeps a tracked-but-absent over-threshold row at its index-counted size" \
+  || bad "--update keeps the tracked-but-absent row (index count)" "rc=$RC row=$row out=$OUT"
+
+# Sparse fail-open guard: a tracked-but-absent NEW offender still fails.
+R="$TMP/sparse-offender"
+mkdir -p "$R"
+git -C "$R" -c init.defaultBranch=main init -q
+git -C "$R" config user.email test@example.com
+git -C "$R" config user.name test
+mkfile huge.txt 40
+git -C "$R" add -A
+rm "$R/huge.txt"
+run_sr
+[ "$RC" -eq 1 ] && case "$OUT" in *"huge.txt"*) true ;; *) false ;; esac \
+  && ok "a tracked-but-absent new offender is counted from the index and fails" \
+  || bad "sparse new offender fails" "rc=$RC out=$OUT"
 
 # --update with no baseline file: never creates one (it cannot add rows).
 R="$TMP/upd2"

--- a/skills/size-ratchet/tests/update-tightens.test.sh
+++ b/skills/size-ratchet/tests/update-tightens.test.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Pins for --update's tighten-only contract: rows are lowered or removed to
+# match reality, NEVER added and NEVER raised — a grown file keeps its old
+# row (and keeps failing), a new offender stays out of the baseline, and
+# deliberate growth is a hand-edit that then passes (control).
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
+SR="$SKILL_DIR/scripts/size-ratchet"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+unset SIZE_RATCHET_THRESHOLD SIZE_RATCHET_BASELINE SIZE_RATCHET_EXCLUDES SIZE_RATCHET_SETTINGS_FILE 2>/dev/null || true
+
+PASS=0
+FAIL=0
+ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
+
+mkfile() { # PATH LINES
+  mkdir -p "$R/$(dirname "$1")"
+  awk -v n="$2" 'BEGIN { for (i = 1; i <= n; i++) print "line " i }' >"$R/$1"
+}
+
+run_sr() { # [args...] — run in $R at threshold 10; sets OUT and RC
+  OUT=""
+  RC=0
+  OUT="$(cd "$R" && SIZE_RATCHET_THRESHOLD=10 "$SR" "$@" 2>&1)" || RC=$?
+}
+
+R="$TMP/upd"
+mkdir -p "$R"
+git -C "$R" -c init.defaultBranch=main init -q
+git -C "$R" config user.email test@example.com
+git -C "$R" config user.name test
+
+# One fixture exercising every row fate at once (threshold 10):
+#   grown.txt   actual 20, row 12  -> kept at 12 (never raised), still fails
+#   loose.txt   actual 15, row 30  -> lowered to 15
+#   shrunk.txt  actual  5, row 12  -> removed (under threshold)
+#   gone.txt    no file,   row 40  -> removed (left the tracked set)
+#   newoff.txt  actual 25, no row  -> NOT added, still fails
+mkfile grown.txt 20
+mkfile loose.txt 15
+mkfile shrunk.txt 5
+mkfile newoff.txt 25
+mkdir -p "$R/tools"
+printf 'gone.txt\t40\ngrown.txt\t12\nloose.txt\t30\nshrunk.txt\t12\n' >"$R/tools/size-ratchet-baseline.tsv"
+git -C "$R" add -A
+
+run_sr --update
+[ "$RC" -eq 1 ] && ok "--update still exits 1 while growth and a new offender remain" \
+  || bad "--update still exits 1 while growth and a new offender remain" "rc=$RC out=$OUT"
+
+expected="$(printf 'grown.txt\t12\nloose.txt\t15\n')"
+actual="$(cat "$R/tools/size-ratchet-baseline.tsv")"
+[ "$actual" = "$expected" ] && ok "rewritten baseline is byte-exact: grown kept at 12, loose lowered to 15, shrunk+gone removed, newoff NOT added" \
+  || bad "rewritten baseline is byte-exact" "$(printf 'expected:\n%s\ngot:\n%s' "$expected" "$actual")"
+
+LC_ALL=C sort -c "$R/tools/size-ratchet-baseline.tsv" \
+  && ok "rewritten baseline is LC_ALL=C sorted" || bad "rewritten baseline is LC_ALL=C sorted" "$actual"
+
+case "$OUT" in *"tightened: loose.txt 30 -> 15"*) ok "tightening is announced with old -> new" ;; *) bad "tightening is announced with old -> new" "$OUT" ;; esac
+case "$OUT" in *"kept (grew"*) ok "the kept grown row is called out as a hand-edit, never --update" ;; *) bad "the kept grown row is called out" "$OUT" ;; esac
+case "$OUT" in *"new offender: newoff.txt"*) ok "the surviving new offender still fails after --update" ;; *) bad "the surviving new offender still fails after --update" "$OUT" ;; esac
+case "$OUT" in *"baselined file grew: grown.txt — 20 lines > baseline 12"*) ok "the surviving growth still fails after --update" ;; *) bad "the surviving growth still fails after --update" "$OUT" ;; esac
+
+run_sr --update
+actual2="$(cat "$R/tools/size-ratchet-baseline.tsv")"
+[ "$RC" -eq 1 ] && [ "$actual2" = "$expected" ] && ok "--update is idempotent: second run changes nothing" \
+  || bad "--update is idempotent" "rc=$RC got: $actual2"
+
+# Control: deliberate growth accepted by HAND-EDITING the rows makes the
+# repo pass — proving the failures above were the ratchet, not noise.
+printf 'grown.txt\t20\nloose.txt\t15\nnewoff.txt\t25\n' >"$R/tools/size-ratchet-baseline.tsv"
+git -C "$R" add -A
+run_sr
+[ "$RC" -eq 0 ] && ok "hand-edited acceptance rows pass (control: growth is a reviewed human edit)" \
+  || bad "hand-edited acceptance rows pass" "rc=$RC out=$OUT"
+
+# --update with no baseline file: never creates one (it cannot add rows).
+R="$TMP/upd2"
+mkdir -p "$R"
+git -C "$R" -c init.defaultBranch=main init -q
+git -C "$R" config user.email test@example.com
+git -C "$R" config user.name test
+mkfile big.txt 20
+git -C "$R" add -A
+run_sr --update
+[ "$RC" -eq 1 ] && [ ! -e "$R/tools/size-ratchet-baseline.tsv" ] && case "$OUT" in *"never adds rows"*) true ;; *) false ;; esac \
+  && ok "--update without a baseline writes nothing and the new offender still fails" \
+  || bad "--update without a baseline writes nothing" "rc=$RC out=$OUT"
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Fixes VST-190. Closes #1171.

New `skills/size-ratchet`: a tighten-only file-size gate, per the cross-repo agreed semantics (drop-in swap for the local scripts consumers already run):

- Every tracked file (`git ls-files`) minus a reasoned exclusion list (`pattern<TAB>reason`) must sit at/under the threshold (default 1000; `SIZE_RATCHET_THRESHOLD` env > `vstack.settings.toml` > default) unless a baseline row (`path<TAB>lines`, `LC_ALL=C` sorted) freezes it.
- FAIL on new offenders, baselined growth, and any baseline looser than reality (row above actual, file shrunk under threshold, file gone) — the ratchet only moves down, both directions checked.
- `--update` lowers/removes rows only — never adds, never raises; deliberate growth stays a hand-edited baseline row visible in review.
- Diagnostic names file, count, threshold/baseline, and both remedies (split at a concept seam, or raise the baseline row in this diff with justification).
- Bash 3.2 compatible; fixtures prove all three failure directions and the tighten-only rewrite byte-exact (4 test files, all green).
