### PR TITLE
fix(ci): ejection alert — current-attempt attribution, two-step pagination, honest head comparison

### DIFF
--- a/.github/workflows/merge-queue-ejection-alert.yml
+++ b/.github/workflows/merge-queue-ejection-alert.yml
@@ -80,12 +80,21 @@ jobs:
             # failure-shaped run (sorted; API order is not a contract),
             # falling back to the newest run of the group.
             cutoff="$(date -u -d '4 hours ago' +%Y-%m-%dT%H:%M:%SZ)"
-            run_json="$(jq -s --arg cutoff "$cutoff" 'add
+          run_json="$(jq -s --arg cutoff "$cutoff" 'add
               | group_by(.head_branch)
               | (max_by(map(.created_at) | max) // [])
-              | map(select(.created_at >= $cutoff))
+              # SOFT recency bound: prefer runs from the current window (a
+              # re-armed unchanged PR reuses the branch name), but never
+              # empty the group — an all-old group still identifies the run.
+              | (map(select(.created_at >= $cutoff)) // []) as $recent
+              | (if ($recent | length) > 0 then $recent else . end)
               | sort_by(.created_at)
+              # Selection: newest failure-shaped run; else the newest
+              # in_progress run (a dequeue often fires while the ejecting
+              # run is still finishing its sibling jobs — its failed jobs
+              # are already queryable); else the newest run.
               | (map(select(.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out")) | last)
+                // (map(select(.status == "in_progress")) | last)
                 // last
                 // empty' "$runs_file")"
           fi

--- a/.github/workflows/merge-queue-ejection-alert.yml
+++ b/.github/workflows/merge-queue-ejection-alert.yml
@@ -56,12 +56,29 @@ jobs:
           # pattern; head_branch is null-guarded (jq test() on a null errors
           # the step under set -e).
           runs_file="$(mktemp)"
-          gh api --paginate "/repos/${GH_REPO}/actions/runs?event=merge_group&per_page=100" \
+          lookup_failed=""
+          if ! gh api --paginate "/repos/${GH_REPO}/actions/runs?event=merge_group&per_page=100" \
             --jq "[.workflow_runs[] | select(.head_branch | strings | test(\"/pr-${PR_NUMBER}-\"))]" \
-            > "$runs_file" || true
+            > "$runs_file"; then
+            lookup_failed=1
+          fi
+          if [ ! -s "$runs_file" ] && [ -z "$lookup_failed" ]; then
+            # Zero bytes from a successful paginated read is a broken read,
+            # not an empty result set — treat it like a failed lookup.
+            lookup_failed=1
+          fi
           run_json=""
-          if [ -s "$runs_file" ]; then
-            run_json="$(jq -s 'add | sort_by(.created_at) | last // empty' "$runs_file")"
+          if [ -z "$lookup_failed" ]; then
+            # One queue ATTEMPT triggers several workflows sharing one
+            # merge-group ref (identical head_branch): take the newest
+            # attempt's group, and within it the failure-shaped run —
+            # never a sibling workflow that merely started latest.
+            run_json="$(jq -s 'add
+              | group_by(.head_branch)
+              | (max_by(map(.created_at) | max) // [])
+              | (map(select(.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out")) | last)
+                // (sort_by(.created_at) | last)
+                // empty' "$runs_file")"
           fi
 
           run_id=""; run_url=""; run_name=""
@@ -71,11 +88,15 @@ jobs:
             run_name="$(printf '%s' "$run_json" | jq -r '.name')"
           fi
 
-          failing_jobs="(failing run not identified — the dequeue may predate run completion; check the queue insights page)"
+          if [ -n "$lookup_failed" ]; then
+            failing_jobs="(merge-group run lookup FAILED — API error or broken read; inspect the queue insights page and this alert run's logs)"
+          else
+            failing_jobs="(failing run not identified — the dequeue may predate run completion; check the queue insights page)"
+          fi
           if [ -n "$run_id" ]; then
             failing_jobs="$(gh api "/repos/${GH_REPO}/actions/runs/${run_id}/jobs?per_page=100" \
               --jq '[.jobs[] | select(.conclusion == "failure" or .conclusion == "cancelled") | "- `\(.name)` (\(.conclusion)): \(.html_url)"] | join("\n")')"
-            [ -n "$failing_jobs" ] || failing_jobs="(run $run_id failed with no per-job failure recorded)"
+            [ -n "$failing_jobs" ] || failing_jobs="(run $run_id has no failure-shaped jobs recorded — it may be the attempt's still-running or non-ejecting sibling; inspect the run link above)"
           fi
 
           # Flake hint: the same-named jobs' state on the PR's OWN head.
@@ -105,7 +126,7 @@ jobs:
             elif [ "$any_red_on_head" = "true" ]; then
               hint="At least one ejecting check is not green on the PR's own head — fix before re-arming."
             else
-              hint="The ejecting check(s) run only in the merge queue (no same-named check on the PR head) — no flake-vs-genuine comparison is available; inspect the failing run before re-arming."
+              hint="No usable same-named comparison on the PR head (checks absent, skipped, or still running) — no flake-vs-genuine call is available; inspect the failing run before re-arming."
             fi
           fi
 

--- a/.github/workflows/merge-queue-ejection-alert.yml
+++ b/.github/workflows/merge-queue-ejection-alert.yml
@@ -73,11 +73,20 @@ jobs:
             # merge-group ref (identical head_branch): take the newest
             # attempt's group, and within it the failure-shaped run —
             # never a sibling workflow that merely started latest.
-            run_json="$(jq -s 'add
+            # Attempt scoping: a re-armed unchanged PR reuses the same
+            # merge-group branch name, so the head_branch group can span
+            # attempts. The dequeue fired moments ago — bound to runs
+            # created in the last 4 hours, then take the NEWEST
+            # failure-shaped run (sorted; API order is not a contract),
+            # falling back to the newest run of the group.
+            cutoff="$(date -u -d '4 hours ago' +%Y-%m-%dT%H:%M:%SZ)"
+            run_json="$(jq -s --arg cutoff "$cutoff" 'add
               | group_by(.head_branch)
               | (max_by(map(.created_at) | max) // [])
+              | map(select(.created_at >= $cutoff))
+              | sort_by(.created_at)
               | (map(select(.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out")) | last)
-                // (sort_by(.created_at) | last)
+                // last
                 // empty' "$runs_file")"
           fi
 
@@ -95,7 +104,7 @@ jobs:
           fi
           if [ -n "$run_id" ]; then
             failing_jobs="$(gh api "/repos/${GH_REPO}/actions/runs/${run_id}/jobs?per_page=100" \
-              --jq '[.jobs[] | select(.conclusion == "failure" or .conclusion == "cancelled") | "- `\(.name)` (\(.conclusion)): \(.html_url)"] | join("\n")')"
+              --jq '[.jobs[] | select(.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out") | "- `\(.name)` (\(.conclusion)): \(.html_url)"] | join("\n")')"
             [ -n "$failing_jobs" ] || failing_jobs="(run $run_id has no failure-shaped jobs recorded — it may be the attempt's still-running or non-ejecting sibling; inspect the run link above)"
           fi
 
@@ -107,7 +116,7 @@ jobs:
             head_checks="$(gh api "/repos/${GH_REPO}/commits/${PR_HEAD_SHA}/check-runs?per_page=100" \
               --jq '[.check_runs[] | {name, conclusion}]')"
             failed_names="$(gh api "/repos/${GH_REPO}/actions/runs/${run_id}/jobs?per_page=100" \
-              --jq '[.jobs[] | select(.conclusion == "failure" or .conclusion == "cancelled") | .name]')"
+              --jq '[.jobs[] | select(.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out") | .name]')"
             # Flake requires POSITIVE evidence: every ejecting job name must
             # have a same-named SUCCESSFUL check on the PR head. Queue-only
             # jobs (this repo's normal heavy-suite shape) have no head

--- a/.github/workflows/merge-queue-ejection-alert.yml
+++ b/.github/workflows/merge-queue-ejection-alert.yml
@@ -47,14 +47,22 @@ jobs:
           set -euo pipefail
 
           # The ejecting failure ran on the merge-group ref, not the PR head:
-          # gh-readonly-queue/<base>/pr-<N>-<sha>. Newest failed merge_group
-          # run for this PR is the ejection's evidence.
-          # --paginate: an active queue can push the ejecting run past the
-          # first page. head_branch is null-guarded (jq test() on a null
-          # errors out the whole step under set -e).
-          run_json="$(gh api --paginate "/repos/${GH_REPO}/actions/runs?event=merge_group&status=failure&per_page=100" \
+          # gh-readonly-queue/<base>/pr-<N>-<sha>. The NEWEST matching
+          # merge_group run is the current attempt — no status filter, so a
+          # still-running or cancelled current attempt is never passed over
+          # for an older historical failure (which would also reuse its
+          # dedupe marker and suppress the new intake issue). Two-step
+          # paginated capture with a zero-byte guard, per the pagination-read
+          # pattern; head_branch is null-guarded (jq test() on a null errors
+          # the step under set -e).
+          runs_file="$(mktemp)"
+          gh api --paginate "/repos/${GH_REPO}/actions/runs?event=merge_group&per_page=100" \
             --jq "[.workflow_runs[] | select(.head_branch | strings | test(\"/pr-${PR_NUMBER}-\"))]" \
-            | jq -s 'add | sort_by(.created_at) | last // empty')"
+            > "$runs_file" || true
+          run_json=""
+          if [ -s "$runs_file" ]; then
+            run_json="$(jq -s 'add | sort_by(.created_at) | last // empty' "$runs_file")"
+          fi
 
           run_id=""; run_url=""; run_name=""
           if [ -n "$run_json" ]; then
@@ -83,10 +91,15 @@ jobs:
             # have a same-named SUCCESSFUL check on the PR head. Queue-only
             # jobs (this repo's normal heavy-suite shape) have no head
             # counterpart — that is "no comparison", never a flake claim.
+            # "Red on head" means a failure-shaped conclusion ONLY —
+            # skipped same-named PR-head jobs (this repo's heavy suites
+            # run real work only in the queue) and still-running checks
+            # (null conclusion) are "no comparison available", never a
+            # fix-before-re-arm claim.
             all_green_on_head="$(jq -cn --argjson head "$head_checks" --argjson failed "$failed_names" \
               '($failed | length > 0) and ([$failed[] as $n | ($head | map(select(.name == $n and .conclusion == "success")) | length > 0)] | all)')"
             any_red_on_head="$(jq -cn --argjson head "$head_checks" --argjson failed "$failed_names" \
-              '[$failed[] as $n | $head[] | select(.name == $n and .conclusion != "success")] | length > 0')"
+              '[$failed[] as $n | $head[] | select(.name == $n and (.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "cancelled" or .conclusion == "action_required"))] | length > 0')"
             if [ "$all_green_on_head" = "true" ]; then
               hint="Every ejecting check has a same-named GREEN check on the PR's own head — this looks like a queue-only flake; re-arming \`--auto\` once is plausibly safe. Never re-arm past a check that is also red on the PR head."
             elif [ "$any_red_on_head" = "true" ]; then


### PR DESCRIPTION
Follow-up to #1194's queued-round review threads (that PR entered the merge queue before the findings landed):

- **Current-attempt attribution**: the run lookup drops `status=failure` and takes the newest matching `merge_group` run — a still-running or cancelled current attempt is never passed over for an older historical failure (which would also have reused its dedupe marker and suppressed the new intake issue).
- **Two-step pagination**: `gh api --paginate` output is captured to a file with a zero-byte guard before jq, per the mandated pagination-read pattern.
- **Honest head comparison**: "red on head" now requires a failure-shaped conclusion (`failure`/`timed_out`/`cancelled`/`action_required`); skipped same-named head jobs (this repo's queue-only heavy suites) and still-running checks read as "no comparison available", never "fix before re-arming".
