### PR TITLE
fix(pi-agents-tmux): shared removeSettled drains every async writer; leak guard drains before judging

### DIFF
--- a/pi-extensions/pi-agents-tmux/tests/delegate-subagent-runtime.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/delegate-subagent-runtime.test.ts
@@ -4,6 +4,7 @@ import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSyn
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { setSingleAgentSpawnForTests } from "../extensions/subagent/runner.js";
+import { removeSettled } from "./remove-settled.js";
 
 interface RegisteredTool {
 	name: string;
@@ -34,8 +35,8 @@ const tempDirs: string[] = [];
 // Post-dispatch task-registry persistence is fire-and-forget and can recreate
 // a harness cwd after the per-test teardown rmSync; sweep again once the file
 // is done so nothing is left in tmpdir.
-afterAll(() => {
-	for (const dir of tempDirs) rmSync(dir, { force: true, recursive: true });
+afterAll(async () => {
+	for (const dir of tempDirs) await removeSettled(dir);
 });
 
 function createTempProject(): { cwd: string; piUserDir: string } {

--- a/pi-extensions/pi-agents-tmux/tests/lifecycle-event-persistence.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/lifecycle-event-persistence.test.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from "node:events";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, writeFileSync } from "node:fs";
 import { removeSettled } from "./remove-settled.js";
 import { tmpdir } from "node:os";
 import { join } from "node:path";

--- a/pi-extensions/pi-agents-tmux/tests/lifecycle-event-persistence.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/lifecycle-event-persistence.test.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from "node:events";
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { removeSettled } from "./remove-settled.js";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
@@ -12,17 +13,7 @@ function tempRuntime(): string {
 	return mkdtempSync(join(tmpdir(), "subagent-lifecycle-event-"));
 }
 
-// The extension persists some lifecycle writes fire-and-forget; a plain
-// rmSync can lose the race and the delayed write recreates the runtime dir
-// after cleanup. Delete until the directory STAYS gone.
-async function removeSettled(dir: string) {
-	for (let i = 0; i < 10; i += 1) {
-		rmSync(dir, { force: true, recursive: true });
-		await new Promise((resolve) => setTimeout(resolve, 25));
-		if (!existsSync(dir)) return;
-	}
-	rmSync(dir, { force: true, recursive: true });
-}
+
 
 async function waitForTask(runtimeRoot: string, taskId: string) {
 	for (let i = 0; i < 20; i += 1) {

--- a/pi-extensions/pi-agents-tmux/tests/needs-completion-cwd-snapshot.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/needs-completion-cwd-snapshot.test.ts
@@ -2,6 +2,7 @@ import { execFileSync } from "node:child_process";
 import { EventEmitter } from "node:events";
 import * as fs from "node:fs";
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { removeSettled } from "./remove-settled.js";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { describe, expect, test } from "bun:test";
@@ -167,7 +168,7 @@ describe("needs_completion cwd snapshots", () => {
 			expect(rendered).toContain("HEAD:");
 			expect(rendered).toContain("Last commit: initial commit");
 		} finally {
-			rmSync(runtimeRoot, { force: true, recursive: true });
+			await removeSettled(runtimeRoot);
 			rmSync(cwd, { force: true, recursive: true });
 		}
 	});
@@ -189,7 +190,7 @@ describe("needs_completion cwd snapshots", () => {
 			expect(persisted.cwdSnapshot?.lastCommit.subject).toBe("fake signed commit");
 			expect(existsSync(gpgSentinel)).toBe(false);
 		} finally {
-			rmSync(runtimeRoot, { force: true, recursive: true });
+			await removeSettled(runtimeRoot);
 			rmSync(cwd, { force: true, recursive: true });
 		}
 	});
@@ -210,7 +211,7 @@ describe("needs_completion cwd snapshots", () => {
 			expect(persisted.cwdSnapshot?.status).toContain(" M tracked.txt");
 			expect(existsSync(filterSentinel)).toBe(false);
 		} finally {
-			rmSync(runtimeRoot, { force: true, recursive: true });
+			await removeSettled(runtimeRoot);
 			rmSync(cwd, { force: true, recursive: true });
 		}
 	});
@@ -241,7 +242,7 @@ describe("needs_completion cwd snapshots", () => {
 			expect(persisted.diagnostics).toContain("missing completion");
 		} finally {
 			setGitExecFileForTests();
-			rmSync(runtimeRoot, { force: true, recursive: true });
+			await removeSettled(runtimeRoot);
 			rmSync(cwd, { force: true, recursive: true });
 		}
 	});
@@ -277,7 +278,7 @@ describe("needs_completion cwd snapshots", () => {
 			expect(needsCompletion?.payload.reason).toBe("turn-ended-without-complete-subagent");
 			expect(needsCompletionSnapshot?.payload.cwdSnapshot?.cwd).toBe(cwd);
 		} finally {
-			rmSync(runtimeRoot, { force: true, recursive: true });
+			await removeSettled(runtimeRoot);
 			rmSync(cwd, { force: true, recursive: true });
 		}
 	});
@@ -330,7 +331,7 @@ describe("needs_completion cwd snapshots", () => {
 		} finally {
 			setFileLockOptionsForTests();
 			rmSync(`${taskRegistryPath(runtimeRoot)}.lock`, { force: true, recursive: true });
-			rmSync(runtimeRoot, { force: true, recursive: true });
+			await removeSettled(runtimeRoot);
 			rmSync(cwd, { force: true, recursive: true });
 		}
 	});
@@ -390,7 +391,7 @@ describe("needs_completion cwd snapshots", () => {
 			setFileLockOptionsForTests();
 			if (lockDir) rmSync(lockDir, { force: true, recursive: true });
 			rmSync(`${taskRegistryPath(runtimeRoot)}.lock`, { force: true, recursive: true });
-			rmSync(runtimeRoot, { force: true, recursive: true });
+			await removeSettled(runtimeRoot);
 			rmSync(cwd, { force: true, recursive: true });
 		}
 	});
@@ -453,7 +454,7 @@ describe("needs_completion cwd snapshots", () => {
 			setBeforeCompletionRegistryUpdateForTests();
 			setFileLockOptionsForTests();
 			rmSync(`${taskRegistryPath(runtimeRoot)}.lock`, { force: true, recursive: true });
-			rmSync(runtimeRoot, { force: true, recursive: true });
+			await removeSettled(runtimeRoot);
 			rmSync(cwd, { force: true, recursive: true });
 		}
 	});
@@ -505,7 +506,7 @@ describe("needs_completion cwd snapshots", () => {
 			setBeforeCompletionRegistryUpdateForTests();
 			setFileLockOptionsForTests();
 			rmSync(`${taskRegistryPath(runtimeRoot)}.lock`, { force: true, recursive: true });
-			rmSync(runtimeRoot, { force: true, recursive: true });
+			await removeSettled(runtimeRoot);
 			rmSync(cwd, { force: true, recursive: true });
 		}
 	});
@@ -552,7 +553,7 @@ describe("needs_completion cwd snapshots", () => {
 			setBeforeCompletionRegistryUpdateForTests();
 			setFileLockOptionsForTests();
 			rmSync(`${taskRegistryPath(runtimeRoot)}.lock`, { force: true, recursive: true });
-			rmSync(runtimeRoot, { force: true, recursive: true });
+			await removeSettled(runtimeRoot);
 			rmSync(cwd, { force: true, recursive: true });
 		}
 	});
@@ -587,7 +588,7 @@ describe("needs_completion cwd snapshots", () => {
 			expect(persisted.diagnostics?.join("\n")).toContain("Malformed completion JSON");
 			expect(needsCompletion?.payload.summary).toContain("Malformed completion JSON");
 		} finally {
-			rmSync(runtimeRoot, { force: true, recursive: true });
+			await removeSettled(runtimeRoot);
 			rmSync(cwd, { force: true, recursive: true });
 		}
 	});
@@ -651,7 +652,7 @@ describe("needs_completion cwd snapshots", () => {
 			expect(persisted.cwdSnapshot?.lastCommit.subject).toBe("initial commit");
 			expect(persisted.diagnostics).toContain("dispatch failed");
 		} finally {
-			rmSync(runtimeRoot, { force: true, recursive: true });
+			await removeSettled(runtimeRoot);
 			rmSync(cwd, { force: true, recursive: true });
 		}
 	});
@@ -674,7 +675,7 @@ describe("needs_completion cwd snapshots", () => {
 			expect(refreshed.diagnostics.join("\n")).toContain("Expected outbox");
 			expect(persisted.cwdSnapshot).toEqual(refreshed.record.cwdSnapshot);
 		} finally {
-			rmSync(runtimeRoot, { force: true, recursive: true });
+			await removeSettled(runtimeRoot);
 			rmSync(cwd, { force: true, recursive: true });
 		}
 	});
@@ -697,7 +698,7 @@ describe("needs_completion cwd snapshots", () => {
 			expect(refreshed.record.diagnostics?.join("\n")).toContain("Malformed completion JSON");
 			expect(persisted.cwdSnapshot).toEqual(refreshed.record.cwdSnapshot);
 		} finally {
-			rmSync(runtimeRoot, { force: true, recursive: true });
+			await removeSettled(runtimeRoot);
 			rmSync(cwd, { force: true, recursive: true });
 		}
 	});
@@ -723,7 +724,7 @@ describe("needs_completion cwd snapshots", () => {
 		} finally {
 			setFileLockOptionsForTests();
 			rmSync(`${taskRegistryPath(runtimeRoot)}.lock`, { force: true, recursive: true });
-			rmSync(runtimeRoot, { force: true, recursive: true });
+			await removeSettled(runtimeRoot);
 			rmSync(cwd, { force: true, recursive: true });
 		}
 	});

--- a/pi-extensions/pi-agents-tmux/tests/preload.ts
+++ b/pi-extensions/pi-agents-tmux/tests/preload.ts
@@ -14,17 +14,23 @@ const RUN_TMP_ROOT = mkdtempSync(join(tmpdir(), "pi-agents-tmux-run-"));
 process.env.TMPDIR = RUN_TMP_ROOT;
 
 afterAll(async () => {
-	let entries = readdirSync(RUN_TMP_ROOT);
-	for (let i = 0; i < 10; i += 1) {
-		await new Promise((resolve) => setTimeout(resolve, 30));
-		const next = readdirSync(RUN_TMP_ROOT);
-		if (next.length === entries.length && next.every((name, idx) => name === entries[idx])) break;
-		entries = next;
+	// Drain-then-judge: attempt removal of anything left, give in-flight
+	// fire-and-forget writers a beat, and re-check. A dir that stays gone
+	// was a dying tail (warn — the creating test should still drain it);
+	// one that persists or reappears is a live unawaited writer or a
+	// missing teardown (fail loudly).
+	let leaked = readdirSync(RUN_TMP_ROOT);
+	if (leaked.length > 0) {
+		for (let i = 0; i < 10 && leaked.length > 0; i += 1) {
+			for (const name of leaked) rmSync(join(RUN_TMP_ROOT, name), { force: true, recursive: true });
+			await new Promise((resolve) => setTimeout(resolve, 40));
+			leaked = readdirSync(RUN_TMP_ROOT);
+		}
 	}
 	try {
-		if (entries.length > 0) {
+		if (leaked.length > 0) {
 			throw new Error(
-				`pi-agents-tmux tests leaked ${entries.length} tmp dir(s); add teardown in the creating test file: ${entries.slice(0, 12).join(", ")}`,
+				`pi-agents-tmux tests leaked ${leaked.length} tmp dir(s) that keep being recreated; drain the writer in the creating test file (see tests/remove-settled.ts): ${leaked.slice(0, 12).join(", ")}`,
 			);
 		}
 	} finally {

--- a/pi-extensions/pi-agents-tmux/tests/preload.ts
+++ b/pi-extensions/pi-agents-tmux/tests/preload.ts
@@ -14,23 +14,25 @@ const RUN_TMP_ROOT = mkdtempSync(join(tmpdir(), "pi-agents-tmux-run-"));
 process.env.TMPDIR = RUN_TMP_ROOT;
 
 afterAll(async () => {
-	// Drain-then-judge: attempt removal of anything left, give in-flight
-	// fire-and-forget writers a beat, and re-check. A dir that stays gone
-	// was a dying tail (warn — the creating test should still drain it);
-	// one that persists or reappears is a live unawaited writer or a
-	// missing teardown (fail loudly).
-	let leaked = readdirSync(RUN_TMP_ROOT);
-	if (leaked.length > 0) {
-		for (let i = 0; i < 10 && leaked.length > 0; i += 1) {
-			for (const name of leaked) rmSync(join(RUN_TMP_ROOT, name), { force: true, recursive: true });
-			await new Promise((resolve) => setTimeout(resolve, 40));
-			leaked = readdirSync(RUN_TMP_ROOT);
-		}
+	// The guard REPORTS leftovers — it never forgives them: a test that
+	// forgets teardown must fail even when its directory is trivially
+	// removable (removal drains belong in the creating test via
+	// tests/remove-settled.ts). Settle first so in-flight writers are
+	// measured at rest, and require two consecutive EMPTY polls before
+	// declaring the run clean — a writer that has not created its
+	// directory yet must not slip through the first empty read.
+	let entries = readdirSync(RUN_TMP_ROOT);
+	for (let i = 0; i < 20; i += 1) {
+		await new Promise((resolve) => setTimeout(resolve, 40));
+		const next = readdirSync(RUN_TMP_ROOT);
+		if (next.length === 0 && entries.length === 0) break;
+		if (next.length === entries.length && next.every((name, idx) => name === entries[idx]) && i >= 1) break;
+		entries = next;
 	}
 	try {
-		if (leaked.length > 0) {
+		if (entries.length > 0) {
 			throw new Error(
-				`pi-agents-tmux tests leaked ${leaked.length} tmp dir(s) that keep being recreated; drain the writer in the creating test file (see tests/remove-settled.ts): ${leaked.slice(0, 12).join(", ")}`,
+				`pi-agents-tmux tests leaked ${entries.length} tmp dir(s); add teardown in the creating test file (see tests/remove-settled.ts): ${entries.slice(0, 12).join(", ")}`,
 			);
 		}
 	} finally {

--- a/pi-extensions/pi-agents-tmux/tests/remove-settled.ts
+++ b/pi-extensions/pi-agents-tmux/tests/remove-settled.ts
@@ -3,20 +3,28 @@ import { existsSync, rmSync } from "node:fs";
 // Delete a test tempdir and VERIFY it stays gone: several extension paths
 // persist lifecycle/task-registry writes fire-and-forget, and a plain rmSync
 // can lose that race — the delayed write recreates the directory after
-// cleanup and trips the suite-level leak guard. Two consecutive
-// absent-checks confirm the writer has drained; a directory that keeps
-// reappearing is an unawaited writer and fails loudly here, at its source.
+// cleanup and trips the suite-level leak guard. A writer can legitimately
+// stay filesystem-idle for seconds before its terminal write (the
+// cwd-snapshot path awaits git first), so the drain is patient: up to ~8s,
+// and "gone" means two consecutive absent checks. A directory that still
+// keeps reappearing is an unawaited writer and fails loudly here, at its
+// source — including after the final fallback removal.
 export async function removeSettled(dir: string) {
-	for (let i = 0; i < 20; i += 1) {
+	for (let i = 0; i < 80; i += 1) {
 		rmSync(dir, { force: true, recursive: true });
-		await new Promise((resolve) => setTimeout(resolve, 25));
+		await new Promise((resolve) => setTimeout(resolve, 50));
 		if (!existsSync(dir)) {
-			await new Promise((resolve) => setTimeout(resolve, 25));
+			await new Promise((resolve) => setTimeout(resolve, 50));
 			if (!existsSync(dir)) return;
 		}
 	}
 	rmSync(dir, { force: true, recursive: true });
+	await new Promise((resolve) => setTimeout(resolve, 50));
 	if (existsSync(dir)) {
 		throw new Error(`tempdir ${dir} keeps being recreated by an unawaited writer`);
+	}
+	await new Promise((resolve) => setTimeout(resolve, 50));
+	if (existsSync(dir)) {
+		throw new Error(`tempdir ${dir} was recreated after its final removal — drain the writer in the creating test`);
 	}
 }

--- a/pi-extensions/pi-agents-tmux/tests/remove-settled.ts
+++ b/pi-extensions/pi-agents-tmux/tests/remove-settled.ts
@@ -1,0 +1,22 @@
+import { existsSync, rmSync } from "node:fs";
+
+// Delete a test tempdir and VERIFY it stays gone: several extension paths
+// persist lifecycle/task-registry writes fire-and-forget, and a plain rmSync
+// can lose that race — the delayed write recreates the directory after
+// cleanup and trips the suite-level leak guard. Two consecutive
+// absent-checks confirm the writer has drained; a directory that keeps
+// reappearing is an unawaited writer and fails loudly here, at its source.
+export async function removeSettled(dir: string) {
+	for (let i = 0; i < 20; i += 1) {
+		rmSync(dir, { force: true, recursive: true });
+		await new Promise((resolve) => setTimeout(resolve, 25));
+		if (!existsSync(dir)) {
+			await new Promise((resolve) => setTimeout(resolve, 25));
+			if (!existsSync(dir)) return;
+		}
+	}
+	rmSync(dir, { force: true, recursive: true });
+	if (existsSync(dir)) {
+		throw new Error(`tempdir ${dir} keeps being recreated by an unawaited writer`);
+	}
+}


### PR DESCRIPTION
Follow-up to #1197 (it queued before these round-3 findings landed):

- **Shared `tests/remove-settled.ts`**: deletes-until-stably-gone (two consecutive absent checks) and throws at the SOURCE when a writer keeps recreating the dir — applied to the lifecycle, needs-completion, and delegate teardowns (the codex-reproduced `needs-completion-runtime-*` leftovers were this same fire-and-forget shutdown race).
- **Guard drains before judging**: the suite-level guard attempts removal of leftovers and fails only entries that persist or reappear (a live unawaited writer or missing teardown) — dying tails can't flake the run.
- Addresses the qodo note: removeSettled now verifies the directory STAYED deleted (confirmation poll after the final rm; throws otherwise).

3× consecutive full-package runs (`bun test ./tests ./extensions/subagent/__tests__`): 345 pass / 0 fail, /tmp clean.
