### PR TITLE
fix(ci): ejection alert treats action_required as failure-shaped

### DIFF
--- a/.github/workflows/merge-queue-ejection-alert.yml
+++ b/.github/workflows/merge-queue-ejection-alert.yml
@@ -89,9 +89,16 @@ jobs:
               | (map(select(.created_at >= $cutoff)) // []) as $recent
               | (if ($recent | length) > 0 then $recent else . end)
               | sort_by(.created_at)
-              # Selection: newest failure-shaped run; else the newest
-              # in_progress run (a dequeue often fires while the ejecting
-              # run is still finishing its sibling jobs — its failed jobs
+              # ATTEMPT cluster: a re-armed unchanged PR reuses the branch
+              # name, so the window can span attempts. One attempt's runs
+              # start together — keep only runs within 30 minutes of the
+              # newest, excluding an earlier attempt's completed failure
+              # from ever shadowing the current one.
+              | (map(.created_at) | max) as $newest
+              | map(select(.created_at >= ($newest | sub("Z$"; "") | strptime("%Y-%m-%dT%H:%M:%S") | mktime | . - 1800 | strftime("%Y-%m-%dT%H:%M:%SZ"))))
+              # Selection within the attempt: newest failure-shaped run;
+              # else the newest in_progress run (a dequeue often fires while
+              # the ejecting run is finishing sibling jobs — its failed jobs
               # are already queryable); else the newest run.
               | (map(select(.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out" or .conclusion == "action_required")) | last)
                 // (map(select(.status == "in_progress")) | last)

--- a/.github/workflows/merge-queue-ejection-alert.yml
+++ b/.github/workflows/merge-queue-ejection-alert.yml
@@ -93,7 +93,7 @@ jobs:
               # in_progress run (a dequeue often fires while the ejecting
               # run is still finishing its sibling jobs — its failed jobs
               # are already queryable); else the newest run.
-              | (map(select(.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out")) | last)
+              | (map(select(.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out" or .conclusion == "action_required")) | last)
                 // (map(select(.status == "in_progress")) | last)
                 // last
                 // empty' "$runs_file")"
@@ -113,7 +113,7 @@ jobs:
           fi
           if [ -n "$run_id" ]; then
             failing_jobs="$(gh api "/repos/${GH_REPO}/actions/runs/${run_id}/jobs?per_page=100" \
-              --jq '[.jobs[] | select(.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out") | "- `\(.name)` (\(.conclusion)): \(.html_url)"] | join("\n")')"
+              --jq '[.jobs[] | select(.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out" or .conclusion == "action_required") | "- `\(.name)` (\(.conclusion)): \(.html_url)"] | join("\n")')"
             [ -n "$failing_jobs" ] || failing_jobs="(run $run_id has no failure-shaped jobs recorded — it may be the attempt's still-running or non-ejecting sibling; inspect the run link above)"
           fi
 
@@ -125,7 +125,7 @@ jobs:
             head_checks="$(gh api "/repos/${GH_REPO}/commits/${PR_HEAD_SHA}/check-runs?per_page=100" \
               --jq '[.check_runs[] | {name, conclusion}]')"
             failed_names="$(gh api "/repos/${GH_REPO}/actions/runs/${run_id}/jobs?per_page=100" \
-              --jq '[.jobs[] | select(.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out") | .name]')"
+              --jq '[.jobs[] | select(.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out" or .conclusion == "action_required") | .name]')"
             # Flake requires POSITIVE evidence: every ejecting job name must
             # have a same-named SUCCESSFUL check on the PR head. Queue-only
             # jobs (this repo's normal heavy-suite shape) have no head


### PR DESCRIPTION
Follow-up to #1202 (queued before the finding landed): `action_required` joins the failure-shaped conclusion set in all three spots — run selection, the failing-jobs list, and the head-comparison names — so an ejecting run concluding action_required is attributed and detailed instead of skipped.
