### PR TITLE
fix(size-ratchet): sparse baseline reads from the index; quoted dotenv values tolerate inline comments

### DIFF
--- a/skills/size-ratchet/scripts/lib/settings.sh
+++ b/skills/size-ratchet/scripts/lib/settings.sh
@@ -58,8 +58,16 @@ sr_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
     if [ -n "$line" ]; then
       val="${line#*=}"
       case "$val" in
-        \"*\") val="${val%\"}"; val="${val#\"}" ;;
-        \'*\') val="${val%\'}"; val="${val#\'}" ;;
+        \"*\"*)
+          # Quoted value, possibly followed by an inline comment:
+          # KEY="500" # ratchet. Content is everything inside the quotes.
+          val="${val#\"}"
+          val="${val%%\"*}"
+          ;;
+        \'*\'*)
+          val="${val#\'}"
+          val="${val%%\'*}"
+          ;;
         *)
           # Unquoted shell assignment: the value ends at the first
           # whitespace — `KEY=500 # ratchet` assigns 500, comment dropped.
@@ -117,8 +125,16 @@ sr_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
     if [ -n "$line" ]; then
       val="${line#*=}"
       case "$val" in
-        \"*\") val="${val%\"}"; val="${val#\"}" ;;
-        \'*\') val="${val%\'}"; val="${val#\'}" ;;
+        \"*\"*)
+          # Quoted value, possibly followed by an inline comment:
+          # KEY="500" # ratchet. Content is everything inside the quotes.
+          val="${val#\"}"
+          val="${val%%\"*}"
+          ;;
+        \'*\'*)
+          val="${val#\'}"
+          val="${val%%\'*}"
+          ;;
         *)
           # Unquoted shell assignment: the value ends at the first
           # whitespace — `KEY=500 # ratchet` assigns 500, comment dropped.

--- a/skills/size-ratchet/scripts/lib/settings.sh
+++ b/skills/size-ratchet/scripts/lib/settings.sh
@@ -60,14 +60,17 @@ sr_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
       case "$val" in
         \"*\"*)
           # Quoted value, possibly followed by an inline comment:
-          # KEY="500" # ratchet. Content runs to the LAST closing quote so
-          # embedded quotes survive.
+          # KEY="500" # ratchet. The value ends at the FIRST closing
+          # quote (dotenv/shell semantics — an embedded delimiter would
+          # need escaping, which this parser does not support), so a
+          # quote inside the trailing comment can never leak into the
+          # value: KEY="500" # say "ratchet" assigns 500.
           val="${val#\"}"
-          val="${val%\"*}"
+          val="${val%%\"*}"
           ;;
         \'*\'*)
           val="${val#\'}"
-          val="${val%\'*}"
+          val="${val%%\'*}"
           ;;
         *)
           # Unquoted shell assignment: the value ends at the first
@@ -128,14 +131,17 @@ sr_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
       case "$val" in
         \"*\"*)
           # Quoted value, possibly followed by an inline comment:
-          # KEY="500" # ratchet. Content runs to the LAST closing quote so
-          # embedded quotes survive.
+          # KEY="500" # ratchet. The value ends at the FIRST closing
+          # quote (dotenv/shell semantics — an embedded delimiter would
+          # need escaping, which this parser does not support), so a
+          # quote inside the trailing comment can never leak into the
+          # value: KEY="500" # say "ratchet" assigns 500.
           val="${val#\"}"
-          val="${val%\"*}"
+          val="${val%%\"*}"
           ;;
         \'*\'*)
           val="${val#\'}"
-          val="${val%\'*}"
+          val="${val%%\'*}"
           ;;
         *)
           # Unquoted shell assignment: the value ends at the first

--- a/skills/size-ratchet/scripts/lib/settings.sh
+++ b/skills/size-ratchet/scripts/lib/settings.sh
@@ -60,13 +60,14 @@ sr_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
       case "$val" in
         \"*\"*)
           # Quoted value, possibly followed by an inline comment:
-          # KEY="500" # ratchet. Content is everything inside the quotes.
+          # KEY="500" # ratchet. Content runs to the LAST closing quote so
+          # embedded quotes survive.
           val="${val#\"}"
-          val="${val%%\"*}"
+          val="${val%\"*}"
           ;;
         \'*\'*)
           val="${val#\'}"
-          val="${val%%\'*}"
+          val="${val%\'*}"
           ;;
         *)
           # Unquoted shell assignment: the value ends at the first
@@ -127,13 +128,14 @@ sr_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
       case "$val" in
         \"*\"*)
           # Quoted value, possibly followed by an inline comment:
-          # KEY="500" # ratchet. Content is everything inside the quotes.
+          # KEY="500" # ratchet. Content runs to the LAST closing quote so
+          # embedded quotes survive.
           val="${val#\"}"
-          val="${val%%\"*}"
+          val="${val%\"*}"
           ;;
         \'*\'*)
           val="${val#\'}"
-          val="${val%%\'*}"
+          val="${val%\'*}"
           ;;
         *)
           # Unquoted shell assignment: the value ends at the first

--- a/skills/size-ratchet/scripts/lib/settings.sh
+++ b/skills/size-ratchet/scripts/lib/settings.sh
@@ -32,6 +32,41 @@
 # The caller cds to the repo root before resolving, so the default settings
 # path is relative.
 
+# Extract the value of one parsed dotenv assignment (text after `KEY=`).
+# Quoted values end at the FIRST closing delimiter — dotenv/shell
+# semantics; an embedded delimiter would need escaping, which this parser
+# does not support — so a quote inside a trailing comment can never leak
+# into the value: KEY="500" # say "ratchet" assigns 500. Anything else
+# after the closing quote (an adjacent segment like KEY="tools/base".tsv)
+# is a shape this parser cannot read and fails NONZERO — truncating it
+# would silently load the wrong value. Unquoted values end at the first
+# whitespace: KEY=500 # ratchet assigns 500.
+sr_dotenv_value() { # RAW — value on stdout; nonzero on an unsupported shape
+  local val="$1" rest
+  case "$val" in
+    \"*\"*)
+      val="${val#\"}"
+      rest="${val#*\"}"
+      val="${val%%\"*}"
+      ;;
+    \'*\'*)
+      val="${val#\'}"
+      rest="${val#*\'}"
+      val="${val%%\'*}"
+      ;;
+    *)
+      printf '%s' "${val%%[[:space:]]*}"
+      return 0
+      ;;
+  esac
+  # Only whitespace and/or a #comment may follow the closing quote.
+  rest="${rest#"${rest%%[![:space:]]*}"}"
+  case "$rest" in
+    "" | "#"*) printf '%s' "$val"; return 0 ;;
+  esac
+  return 1
+}
+
 sr_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
                # a present-but-unparseable assignment (callers must propagate)
   local name="$1" default="$2" line val file
@@ -56,28 +91,10 @@ sr_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
   if [ -f ".env.local" ]; then
     line="$(grep -E -- "^[[:space:]]*(export[[:space:]]+)?${name}=" .env.local | tail -n 1 || true)"
     if [ -n "$line" ]; then
-      val="${line#*=}"
-      case "$val" in
-        \"*\"*)
-          # Quoted value, possibly followed by an inline comment:
-          # KEY="500" # ratchet. The value ends at the FIRST closing
-          # quote (dotenv/shell semantics — an embedded delimiter would
-          # need escaping, which this parser does not support), so a
-          # quote inside the trailing comment can never leak into the
-          # value: KEY="500" # say "ratchet" assigns 500.
-          val="${val#\"}"
-          val="${val%%\"*}"
-          ;;
-        \'*\'*)
-          val="${val#\'}"
-          val="${val%%\'*}"
-          ;;
-        *)
-          # Unquoted shell assignment: the value ends at the first
-          # whitespace — `KEY=500 # ratchet` assigns 500, comment dropped.
-          val="${val%%[[:space:]]*}"
-          ;;
-      esac
+      if ! val="$(sr_dotenv_value "${line#*=}")"; then
+        echo "::error::.env.local: unsupported syntax for $name (a quoted value must end at its closing quote, optionally followed by a comment)" >&2
+        return 1
+      fi
       printf '%s' "$val"
       return 0
     fi
@@ -127,28 +144,10 @@ sr_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
   if [ -f ".env" ]; then
     line="$(grep -E -- "^[[:space:]]*(export[[:space:]]+)?${name}=" .env | tail -n 1 || true)"
     if [ -n "$line" ]; then
-      val="${line#*=}"
-      case "$val" in
-        \"*\"*)
-          # Quoted value, possibly followed by an inline comment:
-          # KEY="500" # ratchet. The value ends at the FIRST closing
-          # quote (dotenv/shell semantics — an embedded delimiter would
-          # need escaping, which this parser does not support), so a
-          # quote inside the trailing comment can never leak into the
-          # value: KEY="500" # say "ratchet" assigns 500.
-          val="${val#\"}"
-          val="${val%%\"*}"
-          ;;
-        \'*\'*)
-          val="${val#\'}"
-          val="${val%%\'*}"
-          ;;
-        *)
-          # Unquoted shell assignment: the value ends at the first
-          # whitespace — `KEY=500 # ratchet` assigns 500, comment dropped.
-          val="${val%%[[:space:]]*}"
-          ;;
-      esac
+      if ! val="$(sr_dotenv_value "${line#*=}")"; then
+        echo "::error::.env: unsupported syntax for $name (a quoted value must end at its closing quote, optionally followed by a comment)" >&2
+        return 1
+      fi
       printf '%s' "$val"
       return 0
     fi

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -191,6 +191,16 @@ if [ -f "$BASELINE_FILE" ]; then
     config_error "$BASELINE_FILE: duplicate path row(s) above"
   fi
   cp -- "$BASELINE_FILE" "$TMP/baseline.tsv"
+elif [ "$(git cat-file -t ":$BASELINE_FILE" 2>/dev/null)" = "blob" ]; then
+  # Sparse checkout: the accepted baseline is tracked but not materialized —
+  # read it from the index rather than degrading to an empty baseline (which
+  # would report every frozen offender as new).
+  git show ":$BASELINE_FILE" >"$TMP/baseline.tsv" || config_error "failed to read tracked baseline from the index: $BASELINE_FILE"
+  bad_rows="$(grep -nEv "^[^${TAB}]+${TAB}[1-9][0-9]*\$" -- "$TMP/baseline.tsv" || true)"
+  if [ -n "$bad_rows" ]; then
+    printf '%s\n' "$bad_rows" >&2
+    config_error "$BASELINE_FILE (index copy): malformed row(s) above"
+  fi
 else
   : >"$TMP/baseline.tsv"
 fi

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -176,6 +176,7 @@ is_excluded() { # PATH — 0 when some exclusion glob matches the full path
 }
 
 # --- baseline: path<TAB>lines, LC_ALL=C sorted, unique paths -----------------
+BASELINE_FROM_INDEX=0
 if [ -f "$BASELINE_FILE" ]; then
   bad_rows="$(grep -nEv "^[^${TAB}]+${TAB}[1-9][0-9]*\$" -- "$BASELINE_FILE" || true)"
   if [ -n "$bad_rows" ]; then
@@ -194,12 +195,22 @@ if [ -f "$BASELINE_FILE" ]; then
 elif [ "$(git cat-file -t ":$BASELINE_FILE" 2>/dev/null)" = "blob" ]; then
   # Sparse checkout: the accepted baseline is tracked but not materialized —
   # read it from the index rather than degrading to an empty baseline (which
-  # would report every frozen offender as new).
+  # would report every frozen offender as new). Full hygiene applies: an
+  # index baseline must satisfy exactly what a materialized one must.
+  BASELINE_FROM_INDEX=1
   git show ":$BASELINE_FILE" >"$TMP/baseline.tsv" || config_error "failed to read tracked baseline from the index: $BASELINE_FILE"
   bad_rows="$(grep -nEv "^[^${TAB}]+${TAB}[1-9][0-9]*\$" -- "$TMP/baseline.tsv" || true)"
   if [ -n "$bad_rows" ]; then
     printf '%s\n' "$bad_rows" >&2
     config_error "$BASELINE_FILE (index copy): malformed row(s) above"
+  fi
+  if ! LC_ALL=C sort -c -- "$TMP/baseline.tsv" 2>/dev/null; then
+    config_error "$BASELINE_FILE (index copy): rows must be LC_ALL=C sorted"
+  fi
+  dup_paths="$(cut -f1 -- "$TMP/baseline.tsv" | LC_ALL=C uniq -d)"
+  if [ -n "$dup_paths" ]; then
+    printf '%s\n' "$dup_paths" >&2
+    config_error "$BASELINE_FILE (index copy): duplicate path row(s) above"
   fi
 else
   : >"$TMP/baseline.tsv"
@@ -349,6 +360,9 @@ if [ "$MODE" = "update" ]; then
       }
     }
   ' "$TMP/baseline.tsv" "$TMP/absent.lst" "$TMP/counts.tsv" | LC_ALL=C sort >"$TMP/baseline.new"
+  if [ "$BASELINE_FROM_INDEX" = "1" ]; then
+    config_error "--update cannot rewrite an index-only baseline (sparse checkout omits $BASELINE_FILE); materialize the file (git sparse-checkout add / checkout) and rerun"
+  fi
   if [ -f "$BASELINE_FILE" ]; then
     mv -- "$TMP/baseline.new" "$BASELINE_FILE"
     cp -- "$BASELINE_FILE" "$TMP/baseline.tsv"

--- a/skills/size-ratchet/tests/settings-and-config.test.sh
+++ b/skills/size-ratchet/tests/settings-and-config.test.sh
@@ -161,10 +161,16 @@ case "$OUT" in *"threshold 13"*) ok "export-form dotenv assignment is recognized
 printf 'SIZE_RATCHET_THRESHOLD="17" # ratchet\n' > "$R/.env.local"
 run_raw || true
 case "$OUT" in *"threshold 17"*) ok "double-quoted dotenv value with inline comment extracts the content" ;; *) bad "quoted+comment dotenv (.env.local)" "rc=$RC out=$OUT" ;; esac
+printf 'SIZE_RATCHET_THRESHOLD="23" # say "ratchet"\n' > "$R/.env.local"
+run_raw || true
+case "$OUT" in *"threshold 23"*) ok "quote inside the trailing comment never leaks into the value" ;; *) bad "comment-quote dotenv (.env.local)" "rc=$RC out=$OUT" ;; esac
 rm -f "$R/.env.local" "$R/vstack.settings.toml"
 printf "SIZE_RATCHET_THRESHOLD='19' # note\n" > "$R/.env"
 run_raw || true
 case "$OUT" in *"threshold 19"*) ok "single-quoted .env value with inline comment extracts the content" ;; *) bad "quoted+comment dotenv (.env)" "rc=$RC out=$OUT" ;; esac
+printf "SIZE_RATCHET_THRESHOLD='29' # don't raise\n" > "$R/.env"
+run_raw || true
+case "$OUT" in *"threshold 29"*) ok "apostrophe in the trailing comment never leaks into a single-quoted value" ;; *) bad "comment-apostrophe dotenv (.env)" "rc=$RC out=$OUT" ;; esac
 
 echo "=== option-like configured paths ==="
 new_repo optpath

--- a/skills/size-ratchet/tests/settings-and-config.test.sh
+++ b/skills/size-ratchet/tests/settings-and-config.test.sh
@@ -158,6 +158,13 @@ case "$OUT" in *"threshold 11"*) ok ".env.local beats vstack.settings.toml (quot
 printf 'export SIZE_RATCHET_THRESHOLD=13\n' > "$R/.env.local"
 run_raw || true
 case "$OUT" in *"threshold 13"*) ok "export-form dotenv assignment is recognized" ;; *) bad "export-form dotenv" "rc=$RC out=$OUT" ;; esac
+printf 'SIZE_RATCHET_THRESHOLD="17" # ratchet\n' > "$R/.env.local"
+run_raw || true
+case "$OUT" in *"threshold 17"*) ok "double-quoted dotenv value with inline comment extracts the content" ;; *) bad "quoted+comment dotenv (.env.local)" "rc=$RC out=$OUT" ;; esac
+rm -f "$R/.env.local" "$R/vstack.settings.toml"
+printf "SIZE_RATCHET_THRESHOLD='19' # note\n" > "$R/.env"
+run_raw || true
+case "$OUT" in *"threshold 19"*) ok "single-quoted .env value with inline comment extracts the content" ;; *) bad "quoted+comment dotenv (.env)" "rc=$RC out=$OUT" ;; esac
 
 echo "=== option-like configured paths ==="
 new_repo optpath

--- a/skills/size-ratchet/tests/settings-and-config.test.sh
+++ b/skills/size-ratchet/tests/settings-and-config.test.sh
@@ -171,6 +171,10 @@ case "$OUT" in *"threshold 19"*) ok "single-quoted .env value with inline commen
 printf "SIZE_RATCHET_THRESHOLD='29' # don't raise\n" > "$R/.env"
 run_raw || true
 case "$OUT" in *"threshold 29"*) ok "apostrophe in the trailing comment never leaks into a single-quoted value" ;; *) bad "comment-apostrophe dotenv (.env)" "rc=$RC out=$OUT" ;; esac
+printf 'SIZE_RATCHET_THRESHOLD="17".5\n' > "$R/.env"
+run_raw || true
+if [ "$RC" -ne 0 ] && case "$OUT" in *"unsupported syntax"*) true ;; *) false ;; esac; then ok "adjacent segment after a quoted value fails loud, never truncates"; else bad "adjacent-segment dotenv (.env)" "rc=$RC out=$OUT"; fi
+rm -f "$R/.env"
 
 echo "=== option-like configured paths ==="
 new_repo optpath


### PR DESCRIPTION
Follow-up to #1200's two post-queue review threads (it entered the merge queue before they landed):

- **Sparse baseline from the index**: a tracked-but-unmaterialized baseline file loads from its index blob (with the same malformed-row hygiene) instead of degrading to an empty baseline that reports every frozen offender as new.
- **Quoted dotenv values with inline comments**: `KEY="500" # ratchet` extracts `500` (content inside the quotes); unquoted values already ended at the first whitespace.
