### PR TITLE
fix(review-gate): paginate thread counting past 100 accumulated threads

### DIFF
--- a/skills/review-gate/SKILL.md
+++ b/skills/review-gate/SKILL.md
@@ -93,7 +93,9 @@ Changes-requested and unresolved threads always fail closed. Every evidence
 read fails LOUD (exit 2, no verdict) — a transient API error must never flip
 a healthy PR's state; reads retry in-process up to `REVIEW_GATE_API_ATTEMPTS`
 (default 1), and a zero-byte producer is a failed read, not an empty page
-set. Over 100 review threads reports overflow and fails closed to
+set. Review threads are counted across pages (100 per page, bound 20
+pages / 2000 threads); past the bound — or when pagination metadata
+cannot advance — the count reports overflow and fails closed to
 `threads-open`.
 
 **Trust model.** Trust keys on names only GitHub controls: the author login

--- a/skills/review-gate/scripts/pr-watch.sh
+++ b/skills/review-gate/scripts/pr-watch.sh
@@ -353,14 +353,25 @@ for number in $pr_numbers; do
       overflow=true
       break
     fi
-    t_after=""
+    # The cursor rides a proper GraphQL VARIABLE, never string
+    # interpolation — an opaque cursor must not be able to break query
+    # syntax. $after:String is nullable: on the first page it is simply
+    # not passed and resolves to null (page one).
     if [ -n "$t_cursor" ]; then
-      t_after=",after:\"$t_cursor\""
+      threads_resp="$(gh api graphql \
+        -f query='query($owner:String!,$name:String!,$number:Int!,$after:String){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewThreads(first:100,after:$after){pageInfo{hasNextPage endCursor} nodes{isResolved}}}}}' \
+        -f owner="${GH_REPO%%/*}" -f name="${GH_REPO#*/}" -F number="$number" -f after="$t_cursor" 2>/dev/null)" || {
+        t_error="thread read failed"
+        break
+      }
+    else
+      threads_resp="$(gh api graphql \
+        -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewThreads(first:100){pageInfo{hasNextPage endCursor} nodes{isResolved}}}}}' \
+        -f owner="${GH_REPO%%/*}" -f name="${GH_REPO#*/}" -F number="$number" 2>/dev/null)" || {
+        t_error="thread read failed"
+        break
+      }
     fi
-    threads_resp="$(gh api graphql -f query="query{repository(owner:\"${GH_REPO%%/*}\",name:\"${GH_REPO#*/}\"){pullRequest(number:$number){reviewThreads(first:100${t_after}){pageInfo{hasNextPage endCursor} nodes{isResolved}}}}}" 2>/dev/null)" || {
-      t_error="thread read failed"
-      break
-    }
     if [ -z "$threads_resp" ]; then
       t_error="thread read produced zero bytes (broken read)"
       break
@@ -386,13 +397,16 @@ for number in $pr_numbers; do
     }
     unresolved=$((unresolved + page_unresolved))
     [ "$page_next" = "true" ] || break
-    t_cursor="$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor // empty' <<<"$threads_resp" 2>/dev/null)"
-    if [ -z "$t_cursor" ]; then
-      # hasNextPage with no advancing cursor: cannot verify the remainder —
-      # the fail-closed overflow posture, not silent trust of a partial count.
+    t_cursor_next="$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor // empty' <<<"$threads_resp" 2>/dev/null)"
+    if [ -z "$t_cursor_next" ] || [ "$t_cursor_next" = "$t_cursor" ]; then
+      # hasNextPage with no ADVANCING cursor (missing, or identical to the
+      # page just read): cannot verify the remainder — fail closed as
+      # overflow immediately instead of burning the page budget on
+      # re-reads of the same page.
       overflow=true
       break
     fi
+    t_cursor="$t_cursor_next"
   done
   if [ -n "$t_error" ]; then
     emit "$number" "$head" error "$t_error"

--- a/skills/review-gate/scripts/pr-watch.sh
+++ b/skills/review-gate/scripts/pr-watch.sh
@@ -16,7 +16,10 @@
 #                      REVIEW_GATE_THREADS=off gets approved verdicts with
 #                      threads open, and thread transitions have no webhook
 #                      anywhere — seeing them is this tool's reason to
-#                      exist). Over 100 threads fails CLOSED as attention.
+#                      exist). Counted across pages (bound: 20 pages / 2000
+#                      threads); past the bound, or on pagination metadata
+#                      that cannot advance, the count fails CLOSED as
+#                      attention.
 #                      QUEUED PRs are annotated — a queued PR needs a
 #                      DEQUEUE before any fix push, GitHub rejects pushes
 #                      to queued branches

--- a/skills/review-gate/scripts/pr-watch.sh
+++ b/skills/review-gate/scripts/pr-watch.sh
@@ -334,42 +334,71 @@ for number in $pr_numbers; do
   # the predicate with threads open (thread hygiene is server-side there),
   # and the watcher's whole reason to exist is that thread transitions have
   # no webhook — the reducer must see them regardless of the repo's
-  # enforcement point. Over 100 threads fails CLOSED as attention, the same
-  # posture as the predicate's own overflow.
-  threads_resp="$(gh api graphql -f query="query{repository(owner:\"${GH_REPO%%/*}\",name:\"${GH_REPO#*/}\"){pullRequest(number:$number){reviewThreads(first:100){pageInfo{hasNextPage} nodes{isResolved}}}}}" 2>/dev/null)" || {
-    emit "$number" "$head" error "thread read failed"
-    errored=1
-    continue
-  }
-  if [ -z "$threads_resp" ]; then
-    emit "$number" "$head" error "thread read produced zero bytes (broken read)"
+  # enforcement point. The count PAGINATES (long-lived PRs accumulate
+  # hundreds of RESOLVED threads; failing closed at 100 total made
+  # attention permanent regardless of unresolved count) — the fail-closed
+  # overflow posture now starts at the 20-page/2000-thread bound, or at a
+  # truthy hasNextPage whose cursor cannot advance, matching the predicate.
+  unresolved=0
+  overflow=false
+  t_cursor=""
+  t_pages=0
+  t_error=""
+  while :; do
+    t_pages=$((t_pages + 1))
+    if [ "$t_pages" -gt 20 ]; then
+      overflow=true
+      break
+    fi
+    t_after=""
+    if [ -n "$t_cursor" ]; then
+      t_after=",after:\"$t_cursor\""
+    fi
+    threads_resp="$(gh api graphql -f query="query{repository(owner:\"${GH_REPO%%/*}\",name:\"${GH_REPO#*/}\"){pullRequest(number:$number){reviewThreads(first:100${t_after}){pageInfo{hasNextPage endCursor} nodes{isResolved}}}}}" 2>/dev/null)" || {
+      t_error="thread read failed"
+      break
+    }
+    if [ -z "$threads_resp" ]; then
+      t_error="thread read produced zero bytes (broken read)"
+      break
+    fi
+    # Predicate-parity validation: a node whose isResolved is not a boolean
+    # (or a non-boolean hasNextPage) is a malformed response — counting it
+    # as resolved would report health from untrustworthy data.
+    page_unresolved="$(jq -r 'if ((.errors? // []) | length) > 0 then error("graphql errors present")
+        elif (.data.repository.pullRequest.reviewThreads | type) != "object"
+           or (.data.repository.pullRequest.reviewThreads.nodes | type) != "array"
+        then error("malformed thread container")
+        elif ([.data.repository.pullRequest.reviewThreads.nodes[] | select((.isResolved | type) != "boolean")] | length) > 0
+        then error("malformed thread node")
+        else [.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved==false)] | length end' <<<"$threads_resp" 2>/dev/null)" || {
+      t_error="thread response malformed (non-boolean isResolved) or unparsable"
+      break
+    }
+    page_next="$(jq -r 'if (.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage | type) != "boolean"
+        then error("malformed pageInfo")
+        else .data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage end' <<<"$threads_resp" 2>/dev/null)" || {
+      t_error="thread pagination metadata malformed (non-boolean hasNextPage)"
+      break
+    }
+    unresolved=$((unresolved + page_unresolved))
+    [ "$page_next" = "true" ] || break
+    t_cursor="$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor // empty' <<<"$threads_resp" 2>/dev/null)"
+    if [ -z "$t_cursor" ]; then
+      # hasNextPage with no advancing cursor: cannot verify the remainder —
+      # the fail-closed overflow posture, not silent trust of a partial count.
+      overflow=true
+      break
+    fi
+  done
+  if [ -n "$t_error" ]; then
+    emit "$number" "$head" error "$t_error"
     errored=1
     continue
   fi
-  # Predicate-parity validation: a node whose isResolved is not a boolean
-  # (or a non-boolean hasNextPage) is a malformed response — counting it as
-  # resolved would report health from untrustworthy data.
-  unresolved="$(jq -r 'if ((.errors? // []) | length) > 0 then error("graphql errors present")
-      elif (.data.repository.pullRequest.reviewThreads | type) != "object"
-         or (.data.repository.pullRequest.reviewThreads.nodes | type) != "array"
-      then error("malformed thread container")
-      elif ([.data.repository.pullRequest.reviewThreads.nodes[] | select((.isResolved | type) != "boolean")] | length) > 0
-      then error("malformed thread node")
-      else [.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved==false)] | length end' <<<"$threads_resp" 2>/dev/null)" || {
-    emit "$number" "$head" error "thread response malformed (non-boolean isResolved) or unparsable"
-    errored=1
-    continue
-  }
-  overflow="$(jq -r 'if (.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage | type) != "boolean"
-      then error("malformed pageInfo")
-      else .data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage end' <<<"$threads_resp" 2>/dev/null)" || {
-    emit "$number" "$head" error "thread pagination metadata malformed (non-boolean hasNextPage)"
-    errored=1
-    continue
-  }
   if [ "$overflow" = "true" ] || [ "$unresolved" -gt 0 ]; then
     if [ "$overflow" = "true" ]; then
-      emit "$number" "$head" threads-open "over 100 review threads (count overflow — fail closed)$queued"
+      emit "$number" "$head" threads-open "review threads beyond the pagination bound (count overflow — fail closed)$queued"
     else
       emit "$number" "$head" threads-open "$unresolved unresolved review thread(s)$queued"
     fi

--- a/skills/review-gate/scripts/review-predicate-selftest.sh
+++ b/skills/review-gate/scripts/review-predicate-selftest.sh
@@ -103,12 +103,17 @@ mkdir -p "$fixtures" "$shim"
 cat >"$shim/gh" <<'SHIM'
 #!/usr/bin/env bash
 set -u
-url=""; filter=""; paginate=0
+url=""; filter=""; paginate=0; graphql_page2=0
 while [ $# -gt 0 ]; do
   case "$1" in
     api|--slurp) ;;
     --paginate) paginate=1 ;;
-    -f|-F) shift ;;
+    -f|-F)
+      shift
+      # A cursor variable marks a follow-up thread page: serve the page-2
+      # fixture (when present) so pagination is exercised for real.
+      case "$1" in after=*) graphql_page2=1 ;; esac
+      ;;
     --jq) shift; filter="$1" ;;
     graphql) url="graphql" ;;
     *) [ -z "$url" ] && url="$1" ;;
@@ -146,6 +151,9 @@ if [ -n "${GH_SHIM_EMPTY:-}" ] && [ "$GH_SHIM_EMPTY" = "$name" ]; then
   exit 0
 fi
 file="$GH_SHIM_FIXTURES/$name.json"
+if [ "$name" = "graphql" ] && [ "$graphql_page2" = "1" ] && [ -f "$GH_SHIM_FIXTURES/graphql.page2.json" ]; then
+  file="$GH_SHIM_FIXTURES/graphql.page2.json"
+fi
 [ -f "$file" ] || { echo "shim: no fixture $file" >&2; exit 91; }
 if [ -n "$filter" ]; then jq -r "$filter" <"$file"; else cat "$file"; fi
 if [ "$paginate" = "1" ] && [ -f "$GH_SHIM_FIXTURES/$name.page2.json" ] && [ -z "$filter" ]; then
@@ -654,14 +662,39 @@ CFG_CONTEXTS="mech-ctx"; CFG_PUBLISHER_REJECT=""
 status_ctx "mech-ctx" success "analysis complete" "github-actions[bot]"
 run "publisher filter unset: github-actions-minted status counts (default unchanged)" approved
 
-# >100 threads is a SUCCESSFUL read we cannot fully verify: fail closed to
-# threads-open, never open the gate.
+# A truthy hasNextPage whose cursor cannot advance is a read we cannot fully
+# verify: fail closed to threads-open, never open the gate. (The old
+# first-page ">100 threads" overflow is gone — pages are walked and summed
+# up to a 20-page/2000-thread bound, where the same posture applies.)
 reset
 CFG_CONTEXTS="mech-ctx"; CFG_THREADS="enforce"
 status_ctx "mech-ctx" success "analysis complete"
 jq -n '{data:{repository:{pullRequest:{reviewThreads:{pageInfo:{hasNextPage:true},nodes:[]}}}}}' \
   >"$fixtures/graphql.json"
-run "thread overflow (>100) fails closed" threads-open
+run "thread pagination without an advancing cursor fails closed" threads-open
+
+# Resolved history spanning pages must APPROVE: page one advances by cursor
+# to page two, whose resolved remainder ends the walk — pagination sums,
+# never truncates at the first page.
+reset
+CFG_CONTEXTS="mech-ctx"; CFG_THREADS="enforce"
+status_ctx "mech-ctx" success "analysis complete"
+jq -n '{data:{repository:{pullRequest:{reviewThreads:{pageInfo:{hasNextPage:true,endCursor:"P2"},nodes:[{isResolved:true},{isResolved:true}]}}}}}' \
+  >"$fixtures/graphql.json"
+jq -n '{data:{repository:{pullRequest:{reviewThreads:{pageInfo:{hasNextPage:false},nodes:[{isResolved:true}]}}}}}' \
+  >"$fixtures/graphql.page2.json"
+run "resolved threads across pages approve" approved
+
+# An unresolved thread on a LATER page must still fail closed — proves the
+# walk actually counts follow-up pages instead of trusting page one.
+reset
+CFG_CONTEXTS="mech-ctx"; CFG_THREADS="enforce"
+status_ctx "mech-ctx" success "analysis complete"
+jq -n '{data:{repository:{pullRequest:{reviewThreads:{pageInfo:{hasNextPage:true,endCursor:"P2"},nodes:[{isResolved:true},{isResolved:true}]}}}}}' \
+  >"$fixtures/graphql.json"
+jq -n '{data:{repository:{pullRequest:{reviewThreads:{pageInfo:{hasNextPage:false},nodes:[{isResolved:false}]}}}}}' \
+  >"$fixtures/graphql.page2.json"
+run "unresolved thread on a later page fails closed" threads-open
 
 # A thread node whose isResolved is not a boolean (null/missing) must never
 # count as resolved — that direction is a false approval on a merge gate.

--- a/skills/review-gate/scripts/review-predicate.sh
+++ b/skills/review-gate/scripts/review-predicate.sh
@@ -1000,8 +1000,9 @@ EOF_CARRY
 fi
 
 # A genuine GraphQL failure must NOT fall through as unresolved threads — fail
-# loudly instead. `pageInfo.hasNextPage` (>100 threads) is a SUCCESSFUL read
-# we cannot fully verify, so it reports "overflow" and fails closed to
+# loudly instead. Thread pages are WALKED and summed (100 per page, 20-page/
+# 2000-thread bound); past the bound, or on a truthy hasNextPage whose cursor
+# cannot advance, the count reports "overflow" and fails closed to
 # threads-open. Same posture for a thread node whose isResolved is not a
 # boolean ("malformed"): null/missing nodes must never count as resolved —
 # that direction is a false approval on a merge gate.

--- a/skills/review-gate/scripts/review-predicate.sh
+++ b/skills/review-gate/scripts/review-predicate.sh
@@ -1072,8 +1072,10 @@ while :; do
   esac
   unresolved=$((unresolved + t_count))
   [ "$t_next" = "true" ] || break
-  if [ "$t_cursor_next" = "END" ] || [ -z "$t_cursor_next" ]; then
-    # hasNextPage with no advancing cursor: cannot verify the remainder.
+  if [ "$t_cursor_next" = "END" ] || [ -z "$t_cursor_next" ] || [ "$t_cursor_next" = "$t_cursor" ]; then
+    # hasNextPage with no ADVANCING cursor (missing, or identical to the
+    # page just read): cannot verify the remainder — fail closed now
+    # instead of burning the page budget on re-reads of the same page.
     unresolved="overflow"
     break
   fi

--- a/skills/review-gate/scripts/review-predicate.sh
+++ b/skills/review-gate/scripts/review-predicate.sh
@@ -1016,15 +1016,68 @@ fi
 # fail closed exactly as before.
 unresolved=0
 if [ "$THREADS_MODE" = "enforce" ]; then
-unresolved="$(gh_read graphql \
-  -f query='query($owner:String!,$repo:String!,$number:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$number){reviewThreads(first:100){pageInfo{hasNextPage} nodes{isResolved}}}}}' \
-  -F owner="${GH_REPO%/*}" -F repo="${GH_REPO#*/}" -F number="$PR_NUMBER" \
-  --jq 'if .data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage then "overflow"
-        elif ([.data.repository.pullRequest.reviewThreads.nodes[] | select((.isResolved | type) != "boolean")] | length) > 0 then "malformed"
-        else ([.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length) end')" || {
-  echo "::error::could not read review threads" >&2
-  exit 2
-}
+# Threads are counted across PAGES: long-lived PRs accumulate hundreds of
+# resolved threads, and failing closed at the first page's hasNextPage made
+# the gate permanently red once total threads passed 100 — regardless of
+# how many were unresolved. The bound moves to 20 pages (2000 threads);
+# past it, and on a truthy hasNextPage with no advancing cursor, the old
+# fail-closed "overflow" posture still applies. Malformed nodes keep
+# failing closed per page exactly as before.
+t_threads_page_jq='if ((.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage | type) != "boolean")
+    or ([.data.repository.pullRequest.reviewThreads.nodes[] | select((.isResolved | type) != "boolean")] | length) > 0
+  then "malformed"
+  else ([.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length | tostring)
+    + " " + (.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage | tostring)
+    + " " + (.data.repository.pullRequest.reviewThreads.pageInfo.endCursor // "END")
+  end'
+t_cursor=""
+t_pages=0
+while :; do
+  t_pages=$((t_pages + 1))
+  if [ "$t_pages" -gt 20 ]; then
+    unresolved="overflow"
+    break
+  fi
+  if [ -n "$t_cursor" ]; then
+    t_page="$(gh_read graphql \
+      -f query='query($owner:String!,$repo:String!,$number:Int!,$after:String){repository(owner:$owner,name:$repo){pullRequest(number:$number){reviewThreads(first:100,after:$after){pageInfo{hasNextPage endCursor} nodes{isResolved}}}}}' \
+      -F owner="${GH_REPO%/*}" -F repo="${GH_REPO#*/}" -F number="$PR_NUMBER" -f after="$t_cursor" \
+      --jq "$t_threads_page_jq")" || {
+      echo "::error::could not read review threads" >&2
+      exit 2
+    }
+  else
+    t_page="$(gh_read graphql \
+      -f query='query($owner:String!,$repo:String!,$number:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$number){reviewThreads(first:100){pageInfo{hasNextPage endCursor} nodes{isResolved}}}}}' \
+      -F owner="${GH_REPO%/*}" -F repo="${GH_REPO#*/}" -F number="$PR_NUMBER" \
+      --jq "$t_threads_page_jq")" || {
+      echo "::error::could not read review threads" >&2
+      exit 2
+    }
+  fi
+  if [ "$t_page" = "malformed" ]; then
+    unresolved="malformed"
+    break
+  fi
+  t_count="${t_page%% *}"
+  t_rest="${t_page#* }"
+  t_next="${t_rest%% *}"
+  t_cursor_next="${t_rest#* }"
+  case "$t_count" in
+    '' | *[!0-9]*)
+      unresolved="malformed"
+      break
+      ;;
+  esac
+  unresolved=$((unresolved + t_count))
+  [ "$t_next" = "true" ] || break
+  if [ "$t_cursor_next" = "END" ] || [ -z "$t_cursor_next" ]; then
+    # hasNextPage with no advancing cursor: cannot verify the remainder.
+    unresolved="overflow"
+    break
+  fi
+  t_cursor="$t_cursor_next"
+done
 fi
 
 echo "PR #$PR_NUMBER head $HEAD_SHA: reviews=$got clean-analysis=$check comment-form=$comment_hits outage-marker=$outageok carried=$carried changes-requested=$cr unresolved-threads=$unresolved (threads=$THREADS_MODE)" >&2

--- a/skills/review-gate/tests/pr-watch.test.sh
+++ b/skills/review-gate/tests/pr-watch.test.sh
@@ -141,6 +141,12 @@ case "$args" in
       exit 1
     fi
     if [[ "${STUB_THREADS_RAW:-}" == "emptybytes" ]]; then exit 0; fi
+    if [[ "$args" == *after:* && -n "${STUB_THREADS_PAGE2:-}" ]]; then
+      # Cursor-dependent page: a query carrying after:"..." gets page two,
+      # so tests prove the walk advances instead of refetching page one.
+      printf '%s\n' "$STUB_THREADS_PAGE2"
+      exit 0
+    fi
     if [[ -n "${STUB_THREADS_RAW:-}" ]]; then
       printf '%s\n' "$STUB_THREADS_RAW"
       exit 0
@@ -460,6 +466,31 @@ rc=$?
 set -e
 assert_eq "$rc" "1" "pw17b: bounded pagination exits 1"
 assert_contains "$out" "overflow" "pw17b: bound reached reads as overflow (fail closed)"
+
+# pw17c: an unresolved thread on page TWO is counted — the walk advances by
+# cursor and sums across pages instead of trusting page one.
+set +e
+out=$(run_watch STUB_OPEN_PRS="$(jq -cn --argjson r "$(pr_row 7)" '[$r]')" \
+  STUB_THREADS_RAW='{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":true,"endCursor":"CUR1"},"nodes":[{"isResolved":true},{"isResolved":true}]}}}}}' \
+  STUB_THREADS_PAGE2='{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false},"nodes":[{"isResolved":false}]}}}}}' \
+  STUB_VERDICT_LINE="verdict=approved detail=unused")
+rc=$?
+set -e
+assert_eq "$rc" "1" "pw17c: later-page unresolved thread exits 1"
+assert_contains "$out" "1 unresolved review thread(s)" "pw17c: page-two thread counted"
+
+# pw17d: resolved history spanning pages is HEALTHY — over-one-page totals
+# must not read as overflow when every thread is resolved.
+set +e
+out=$(run_watch STUB_OPEN_PRS="$(jq -cn --argjson r "$(pr_row 7)" '[$r]')" \
+  STUB_THREADS_RAW='{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":true,"endCursor":"CUR1"},"nodes":[{"isResolved":true},{"isResolved":true}]}}}}}' \
+  STUB_THREADS_PAGE2='{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false},"nodes":[{"isResolved":true}]}}}}}' \
+  STUB_VERDICT_LINE="verdict=approved detail=review evidence at head" \
+  STUB_GATE_HISTORY='[{"context":"Review gate","state":"success"}]')
+rc=$?
+set -e
+assert_eq "$rc" "0" "pw17d: resolved multi-page history exits 0"
+assert_eq "$out" "" "pw17d: and prints nothing"
 
 # pw18: a failed queue-membership read is a loud error, never "not queued".
 set +e

--- a/skills/review-gate/tests/pr-watch.test.sh
+++ b/skills/review-gate/tests/pr-watch.test.sh
@@ -141,7 +141,7 @@ case "$args" in
       exit 1
     fi
     if [[ "${STUB_THREADS_RAW:-}" == "emptybytes" ]]; then exit 0; fi
-    if [[ "$args" == *after:* && -n "${STUB_THREADS_PAGE2:-}" ]]; then
+    if [[ "$args" == *"after="* && -n "${STUB_THREADS_PAGE2:-}" ]]; then
       # Cursor-dependent page: a query carrying after:"..." gets page two,
       # so tests prove the walk advances instead of refetching page one.
       printf '%s\n' "$STUB_THREADS_PAGE2"

--- a/skills/review-gate/tests/pr-watch.test.sh
+++ b/skills/review-gate/tests/pr-watch.test.sh
@@ -142,8 +142,10 @@ case "$args" in
     fi
     if [[ "${STUB_THREADS_RAW:-}" == "emptybytes" ]]; then exit 0; fi
     if [[ "$args" == *"after="* && -n "${STUB_THREADS_PAGE2:-}" ]]; then
-      # Cursor-dependent page: a query carrying after:"..." gets page two,
-      # so tests prove the walk advances instead of refetching page one.
+      # Cursor-dependent page: a call passing the after= CLI variable
+      # (`-f after=CURSOR` — the watcher sends the cursor as a GraphQL
+      # variable, never interpolated) gets page two, so tests prove the
+      # walk advances instead of refetching page one.
       printf '%s\n' "$STUB_THREADS_PAGE2"
       exit 0
     fi

--- a/skills/review-gate/tests/pr-watch.test.sh
+++ b/skills/review-gate/tests/pr-watch.test.sh
@@ -449,6 +449,18 @@ set -e
 assert_eq "$rc" "1" "pw17: thread overflow exits 1"
 assert_contains "$out" "overflow" "pw17: named as overflow (fail closed)"
 
+# pw17b: a pageable response that never advances (same page, same cursor,
+# hasNextPage=true every time) must terminate at the pagination bound as
+# overflow — proves the paging loop is bounded and cannot hang the watcher.
+set +e
+out=$(run_watch STUB_OPEN_PRS="$(jq -cn --argjson r "$(pr_row 7)" '[$r]')" \
+  STUB_THREADS_RAW='{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":true,"endCursor":"CUR1"},"nodes":[{"isResolved":false}]}}}}}' \
+  STUB_VERDICT_LINE="verdict=approved detail=unused")
+rc=$?
+set -e
+assert_eq "$rc" "1" "pw17b: bounded pagination exits 1"
+assert_contains "$out" "overflow" "pw17b: bound reached reads as overflow (fail closed)"
+
 # pw18: a failed queue-membership read is a loud error, never "not queued".
 set +e
 out=$(run_watch STUB_OPEN_PRS="$(jq -cn --argjson r "$(pr_row 7)" '[$r]')" \


### PR DESCRIPTION
Long-lived PRs accumulate hundreds of RESOLVED review threads. Both thread readers (`review-predicate.sh`, `pr-watch.sh`) fetched only the first 100 and failed closed on `hasNextPage`, so a PR with >100 total threads could never pass the Review gate again — even with zero unresolved. Live case: #1180 (34 review rounds, 0 unresolved, gate permanently pending; pr-watch exits 1 with overflow attention on every cycle).

- Both readers now paginate (100/page) and sum unresolved across pages.
- Fail-closed posture preserved: overflow at the 20-page/2000-thread bound, or a truthy `hasNextPage` whose cursor cannot advance; per-page malformed-node/pageInfo validation unchanged.
- New pw17b test pins bounded termination on a never-advancing page; all 7 review-gate suites pass.

Unblocks #1180's Review gate (the workflow runs the default-branch engine, so this must land on main first).

https://claude.ai/code/session_01QvkSwqV8RhQLbpnwujphBr