### PR TITLE
fix(review-gate): selftest probe-namespace collision + unchecked mktemp

### DIFF
--- a/skills/review-gate/scripts/review-predicate-selftest.sh
+++ b/skills/review-gate/scripts/review-predicate-selftest.sh
@@ -1813,13 +1813,19 @@ load_exclude_tracked() {
     # the exact fail-open this error flag exists to prevent. Stage the -z
     # output in a file (NUL bytes cannot ride a shell variable) and check
     # the producer's exit alone.
-    _elt_tmp="$(mktemp)"
-    if git ls-files -z >"$_elt_tmp" 2>/dev/null; then
-      EXCLUDE_TRACKED="$(tr '\0' '\n' <"$_elt_tmp")"
+    # mktemp checked too: with no staging file the tracked read cannot be
+    # VERIFIED, and unverifiable takes the same refuse-to-degrade branch as
+    # failed — never a silent slide into hermetic probing.
+    if _elt_tmp="$(mktemp)"; then
+      if git ls-files -z >"$_elt_tmp" 2>/dev/null; then
+        EXCLUDE_TRACKED="$(tr '\0' '\n' <"$_elt_tmp")"
+      else
+        EXCLUDE_TRACKED_ERROR=1
+      fi
+      rm -f "$_elt_tmp"
     else
       EXCLUDE_TRACKED_ERROR=1
     fi
-    rm -f "$_elt_tmp"
   fi
 }
 exclude_glob_probe() { # glob, ext... -> a carry-class path this glob matches
@@ -1886,8 +1892,14 @@ $EXCLUDE_TRACKED
 EOF_TRACKED_FREE
     return 1
   fi
+  # The two synthetic candidates deliberately share NO filename prefix: when
+  # both lived under `carry-probe*`, a committed glob matching that harness
+  # namespace (non-universal in any real tree — README.md still carries)
+  # matched every candidate and false-FAILed the over-broad guard. Distinct
+  # shapes mean only a genuinely class-universal exclusion set can exhaust
+  # them; finite probes still cannot PROVE universality — stated limitation.
   for ext in "$@"; do
-    for candidate in "carry-probe/unrelated$ext" "carry-probe-unrelated$ext"; do
+    for candidate in "carry-probe/unrelated$ext" "unexcluded-sample$ext"; do
       hit=""
       while IFS= read -r pat; do
         [ -z "$pat" ] && continue

--- a/skills/review-gate/tests/review-predicate-selftest.test.sh
+++ b/skills/review-gate/tests/review-predicate-selftest.test.sh
@@ -171,6 +171,51 @@ else
     || note "broken-ls-files failure does not carry the refusing-to-degrade diagnostic"
 fi
 
+# --- layer 2d: a failed mktemp is unverifiable, same refuse-to-degrade -----
+# A PATH shim fails only the NO-ARGUMENT mktemp (the staging-file call in
+# load_exclude_tracked) while delegating `mktemp -d` and every other form
+# (the selftest's own work dir needs -d at startup). No staging file means
+# the tracked read cannot be verified, and unverifiable must take the same
+# loud branch as failed — never a silent slide into hermetic probing.
+mkdir -p "$work/brokenmktemp/bin" "$work/brokenmktemp/repo"
+real_mktemp="$(command -v mktemp)"
+cat >"$work/brokenmktemp/bin/mktemp" <<BROKENMKTEMP
+#!/usr/bin/env bash
+if [ \$# -eq 0 ]; then
+  echo "mktemp: planted tmpdir failure" >&2
+  exit 1
+fi
+exec "$real_mktemp" "\$@"
+BROKENMKTEMP
+chmod +x "$work/brokenmktemp/bin/mktemp"
+(cd "$work/brokenmktemp/repo" && git init -q .)
+cp "$work/excludes/vstack.settings.toml" "$work/brokenmktemp/repo/vstack.settings.toml"
+if (cd "$work/brokenmktemp/repo" && PATH="$work/brokenmktemp/bin:$PATH" "$SELFTEST") \
+  >"$work/brokenmktemp.out" 2>&1; then
+  note "selftest passed with an unverifiable tracked read (mktemp failed) — the refuse-to-degrade branch no longer covers it"
+else
+  grep -q "refusing to degrade to synthetic probes" "$work/brokenmktemp.out" \
+    || note "broken-mktemp failure does not carry the refusing-to-degrade diagnostic"
+fi
+
+# --- layer 2e: the harness namespace is not the over-broad namespace --------
+# Hermetic fixture with `carry-probe*` as the ONLY exclusion: it matches one
+# synthetic candidate family but not the other, so the run must PASS with the
+# exclude-free carry case exercised. Reproduces the candidate-prefix
+# collision this suite hardened against — with both candidates under
+# `carry-probe*`, this fixture false-FAILed as "can never apply".
+mkdir -p "$work/probeglob"
+grep -v '^REVIEW_GATE_CARRY_FORWARD = ' "$work/configured/vstack.settings.toml" \
+  >"$work/probeglob/vstack.settings.toml"
+printf 'REVIEW_GATE_CARRY_FORWARD = "docs"\nREVIEW_GATE_CARRY_FORWARD_EXCLUDE = "carry-probe*"\n' \
+  >>"$work/probeglob/vstack.settings.toml"
+if ! (cd "$work/probeglob" && "$SELFTEST") >"$work/probeglob.out" 2>&1; then
+  cat "$work/probeglob.out"
+  note "selftest failed under a harness-namespace exclusion glob (carry-probe*) — the candidate-prefix collision is back"
+fi
+grep -q "outside every committed glob and still carries" "$work/probeglob.out" \
+  || note "harness-namespace fixture did not exercise the exclude-free carry case"
+
 # One combined FAILING run pins BOTH guards (each fixture run replays the
 # full decision table, so failure cases share a run): a leading-'/' glob can
 # never match a repository-relative compare filename (dead anchoring), and a


### PR DESCRIPTION
Two small selftest hardenings from the consumer propagation review rounds (hyprtrade-io#40, hyprtrade#579):

- **Probe-namespace collision (false FAIL, hermetic mode)**: `exclude_free_path`'s two synthetic candidates both lived under the `carry-probe` prefix, so a committed carry-exclude glob matching that harness namespace — non-universal in any real tree — exhausted every candidate and false-FAILed the over-broad guard. The candidates now share no prefix (`carry-probe/unrelated<ext>` / `unexcluded-sample<ext>`); finite probes still cannot PROVE universality, stated in the comment.
- **Unchecked mktemp**: `load_exclude_tracked` now branches on mktemp's status — no staging file means the tracked read is unverifiable, which takes the same refuse-to-degrade branch as a failed read, never a misattributed error from redirecting into an empty path.

Selftest (250 cases) and wrapper suite pass locally. Consumers pick this up on the next routine propagation — deliberately NOT re-vendored into the open propagation PRs (both defects are in the safe direction: loud false-fail, never fail-open).

https://claude.ai/code/session_01WNNdhxuyKbYro4bmFB1mqGp