### PR TITLE
test(review-gate): selftest shim refuses cursor values unusable as fixture keys

### DIFF
--- a/skills/review-gate/scripts/review-predicate-selftest.sh
+++ b/skills/review-gate/scripts/review-predicate-selftest.sh
@@ -115,7 +115,23 @@ while [ $# -gt 0 ]; do
       # cursor VALUE is kept so cursor-keyed fixtures
       # (graphql.cursor-<value>.json) can drive an arbitrarily deep walk —
       # the page-budget bound cannot be proven with a single follow-up page.
-      case "$1" in after=*) graphql_page2=1; graphql_after="${1#after=}" ;; esac
+      case "$1" in
+        after=*)
+          graphql_page2=1
+          graphql_after="${1#after=}"
+          # Cursor-keyed fixtures embed the cursor in a pathname, so the
+          # namespace is enforced, not assumed: every cursor this suite
+          # authors is [A-Za-z0-9_-]. Anything else would silently fall
+          # back to the page-2/default fixture and a case could claim a
+          # deep walk it never drove — refuse loudly instead.
+          case "$graphql_after" in
+            *[!A-Za-z0-9_-]*)
+              echo "shim: cursor value unusable as a fixture key (allowed: A-Za-z0-9_-): $graphql_after" >&2
+              exit 92
+              ;;
+          esac
+          ;;
+      esac
       ;;
     --jq) shift; filter="$1" ;;
     graphql) url="graphql" ;;

--- a/skills/review-gate/scripts/review-predicate-selftest.sh
+++ b/skills/review-gate/scripts/review-predicate-selftest.sh
@@ -761,6 +761,19 @@ jq -n '{data:{repository:{pullRequest:{reviewThreads:{pageInfo:{hasNextPage:fals
   >"$fixtures/graphql.cursor-C20.json"
 run "exactly 20 advancing resolved pages approve (bound is >20)" approved
 
+# The shim's cursor-namespace refusal, red-first: a page-1 endCursor outside
+# [A-Za-z0-9_-] must abort the walk as a loud read failure (the shim exits
+# 92, the gh read fails, the predicate exits 2). With the refusal deleted,
+# the slash cursor keys no fixture, the shim silently falls back to page 1,
+# and the non-advancing guard answers threads-open instead — so this case
+# distinguishes the guard's presence, not just "something failed".
+reset
+CFG_CONTEXTS="mech-ctx"; CFG_THREADS="enforce"
+status_ctx "mech-ctx" success "analysis complete"
+jq -n '{data:{repository:{pullRequest:{reviewThreads:{pageInfo:{hasNextPage:true,endCursor:"bad/value"},nodes:[{isResolved:true}]}}}}}' \
+  >"$fixtures/graphql.json"
+run "cursor outside the fixture-key namespace is a loud read failure" "" 2
+
 # Zero bytes from the thread read is a BROKEN READ (VST-46 family), never an
 # authoritative verdict in either direction — pr-watch parity.
 reset


### PR DESCRIPTION
Closes the last open item of #1223 (raised by qodo on hyprtrade#579).

The selftest's gh shim keys deep-walk fixtures by cursor value embedded in a pathname (`graphql.cursor-<value>.json`). A cursor containing `/` or any other character outside `[A-Za-z0-9_-]` silently fell back to the page-2/default fixture — a mistyped case could claim a deep walk it never drove. The shim now refuses such a cursor loudly (exit 92) with a diagnostic naming the allowed namespace.

Items 1 and 3 of #1223 already landed: the broken-`ls-files` negative control shipped in #1222 (wrapper layer 2c, verified red-first against the pre-fix selftest), and the mktemp status check shipped in #1224 (with wrapper layer 2d pinning the refuse-to-degrade contract).

Selftest (250 cases) and wrapper suite pass locally.

Fixes #1223

https://claude.ai/code/session_01WNNdhxuyKbYro4mFB1mqGp