### PR TITLE
fix(review-gate): selftest diagnostics carry their cause; probe exhaustion honesty; empty cursor refused

### DIFF
--- a/skills/review-gate/scripts/review-predicate-selftest.sh
+++ b/skills/review-gate/scripts/review-predicate-selftest.sh
@@ -177,10 +177,18 @@ file="$GH_SHIM_FIXTURES/$name.json"
 if [ "$name" = "graphql" ] && [ -n "$graphql_after" ] && [ -f "$GH_SHIM_FIXTURES/graphql.cursor-$graphql_after.json" ]; then
   # Cursor-keyed page: the fixture named by the requested cursor wins, so a
   # case can lay out a distinct advancing page per cursor and walk the full
-  # page budget. Falls through to the single page-2 fixture when absent.
+  # page budget. Falls through to the single page-2 fixture when absent —
+  # the two-page pattern's shape.
   file="$GH_SHIM_FIXTURES/graphql.cursor-$graphql_after.json"
 elif [ "$name" = "graphql" ] && [ "$graphql_page2" = "1" ] && [ -f "$GH_SHIM_FIXTURES/graphql.page2.json" ]; then
   file="$GH_SHIM_FIXTURES/graphql.page2.json"
+elif [ "$name" = "graphql" ] && [ -n "$graphql_after" ]; then
+  # A follow-up request with NEITHER a cursor-keyed fixture NOR a page-2
+  # fixture would silently re-serve page one — a deep-walk case missing one
+  # of its files (a valid-looking cursor with a fixture gap) must refuse,
+  # not fabricate coverage.
+  echo "shim: follow-up page requested (after=$graphql_after) but no graphql.cursor-$graphql_after.json or graphql.page2.json fixture exists" >&2
+  exit 93
 fi
 [ -f "$file" ] || { echo "shim: no fixture $file" >&2; exit 91; }
 if [ -n "$filter" ]; then jq -r "$filter" <"$file"; else cat "$file"; fi
@@ -773,6 +781,10 @@ run "exactly 20 advancing resolved pages approve (bound is >20)" approved
 # distinguishes the guard's presence, not just "something failed".
 reset
 CFG_CONTEXTS="mech-ctx"; CFG_THREADS="enforce"
+# Single attempt, no delay: the refusal is deterministic, and under a
+# configured retry budget every re-attempt would just re-refuse after a
+# sleep — pure suite-runtime inflation.
+CFG_API_ATTEMPTS="1"; CFG_API_DELAY="0"
 status_ctx "mech-ctx" success "analysis complete"
 jq -n '{data:{repository:{pullRequest:{reviewThreads:{pageInfo:{hasNextPage:true,endCursor:"bad/value"},nodes:[{isResolved:true}]}}}}}' \
   >"$fixtures/graphql.json"

--- a/skills/review-gate/scripts/review-predicate-selftest.sh
+++ b/skills/review-gate/scripts/review-predicate-selftest.sh
@@ -2091,6 +2091,14 @@ EOF_EXCLUDE_BATTERY
       # non-empty path by construction, while two or more '?'s impose a
       # minimum length that one-character paths escape, and '?'-only
       # entries pin an exact length; neither is universal.
+      #
+      # PER-ENTRY only, deliberately: a SET of globs can be jointly
+      # universal ('?;??*' by length split, 'a*;[!a]*' by first-character
+      # partition), and detecting that in general is glob-coverage
+      # analysis with no bounded implementation. Such sets take the
+      # UNPROVEN note below — loud and fail-safe, never a silent green —
+      # and tracked mode (every run inside a real repository) judges the
+      # same set against real paths with no heuristic at all.
       probe_universal=""
       while IFS= read -r probe_pat_u; do
         [ -z "$probe_pat_u" ] && continue

--- a/skills/review-gate/scripts/review-predicate-selftest.sh
+++ b/skills/review-gate/scripts/review-predicate-selftest.sh
@@ -124,9 +124,13 @@ while [ $# -gt 0 ]; do
           # authors is [A-Za-z0-9_-]. Anything else would silently fall
           # back to the page-2/default fixture and a case could claim a
           # deep walk it never drove — refuse loudly instead.
+          # Empty is refused with the same teeth: an empty after= cannot
+          # select a cursor fixture and would silently fall through to the
+          # page-2/default fixture — the false coverage this guard exists
+          # to prevent.
           case "$graphql_after" in
-            *[!A-Za-z0-9_-]*)
-              echo "shim: cursor value unusable as a fixture key (allowed: A-Za-z0-9_-): $graphql_after" >&2
+            '' | *[!A-Za-z0-9_-]*)
+              echo "shim: cursor value unusable as a fixture key (allowed: non-empty A-Za-z0-9_-): $graphql_after" >&2
               exit 92
               ;;
           esac
@@ -1845,15 +1849,18 @@ load_exclude_tracked() {
     # mktemp checked too: with no staging file the tracked read cannot be
     # VERIFIED, and unverifiable takes the same refuse-to-degrade branch as
     # failed — never a silent slide into hermetic probing.
+    # The flag carries the CAUSE: its one consumer prints it, and telling
+    # an operator to fix git when mktemp failed sends them at the wrong
+    # subsystem.
     if _elt_tmp="$(mktemp)"; then
       if git ls-files -z >"$_elt_tmp" 2>/dev/null; then
         EXCLUDE_TRACKED="$(tr '\0' '\n' <"$_elt_tmp")"
       else
-        EXCLUDE_TRACKED_ERROR=1
+        EXCLUDE_TRACKED_ERROR="'git ls-files' failed (fix git, or run the harness outside a repository)"
       fi
       rm -f "$_elt_tmp"
     else
-      EXCLUDE_TRACKED_ERROR=1
+      EXCLUDE_TRACKED_ERROR="staging file creation failed (mktemp) — the tracked read cannot be verified"
     fi
   fi
 }
@@ -1968,7 +1975,7 @@ if [ -n "$ACTIVE_CARRY" ]; then
     load_exclude_tracked
     if [ -n "$EXCLUDE_TRACKED_ERROR" ]; then
       cases=$((cases + 1))
-      echo "FAIL  configured: carry-exclude — this IS a git repository but 'git ls-files' failed; refusing to degrade to synthetic probes (fix git, or run the harness outside a repository)" >&2
+      echo "FAIL  configured: carry-exclude — this IS a git repository but the tracked-tree read is unusable: $EXCLUDE_TRACKED_ERROR; refusing to degrade to synthetic probes" >&2
       failures=$((failures + 1))
     fi
     # Probe extensions span EVERY enabled class — docs alone must not leave
@@ -2043,11 +2050,28 @@ EOF_EXCLUDE_BATTERY
       compare_fix ahead "[$(delta_file "$probe_free" modified "$(probe_patch_for "$probe_free")")]"
       run "configured: carry-exclude — '$probe_free' is outside every committed glob and still carries" approved
     elif [ -z "$EXCLUDE_TRACKED" ]; then
-      # Hermetic mode with every synthetic candidate matched: only a
-      # universal exclusion does that — dead config, FAIL.
-      cases=$((cases + 1))
-      echo "FAIL  configured: carry-exclude — the committed exclusions match every carry-class ($probe_exts) path; the enabled carry class can never apply (over-broad exclusion set, or disable REVIEW_GATE_CARRY_FORWARD instead)" >&2
-      failures=$((failures + 1))
+      # Hermetic mode with every synthetic candidate matched. Finite probes
+      # cannot PROVE universality — a glob set that merely spans both
+      # harness namespaces exhausts the candidates while ordinary paths
+      # still carry — so only a STRUCTURALLY universal entry (a literal '*'
+      # or '**', which matches every path by construction) is a FAIL here;
+      # anything else is reported unproven, out loud, never silently green.
+      probe_universal=""
+      while IFS= read -r probe_pat_u; do
+        [ -z "$probe_pat_u" ] && continue
+        case "$probe_pat_u" in
+          '*' | '**') probe_universal="$probe_pat_u" ;;
+        esac
+      done <<EOF_UNIVERSAL
+$(list_items "$ACTIVE_CARRY_EXCLUDE")
+EOF_UNIVERSAL
+      if [ -n "$probe_universal" ]; then
+        cases=$((cases + 1))
+        echo "FAIL  configured: carry-exclude — '$probe_universal' matches every path; the enabled carry class can never apply (over-broad exclusion set, or disable REVIEW_GATE_CARRY_FORWARD instead)" >&2
+        failures=$((failures + 1))
+      else
+        echo "note  configured: carry-exclude — every synthetic carry-class ($probe_exts) probe is excluded but no committed glob is structurally universal: universality is UNPROVEN by synthetic probes (run inside the repository for tracked-path evidence); positive carry case not exercised here"
+      fi
     else
       # Tracked mode: the CURRENT tree has no carry-free carry-class file,
       # but future files outside the globs can still carry (a repo whose

--- a/skills/review-gate/scripts/review-predicate-selftest.sh
+++ b/skills/review-gate/scripts/review-predicate-selftest.sh
@@ -198,6 +198,19 @@ fi
 SHIM
 chmod +x "$shim/gh"
 
+# Shim refusal self-check, red-first: the three fixture-integrity refusals
+# must fire before any case relies on them — deleting a refusal arm fails
+# the whole run HERE, instead of leaving a case green against a fixture it
+# never drove. Each exit code is pinned exactly.
+_shimcheck_dir="$(mktemp -d)"
+GH_SHIM_FIXTURES="$_shimcheck_dir" "$shim/gh" api graphql -f query=q -f after=bad/value >/dev/null 2>&1
+[ $? -eq 92 ] || { echo "FATAL: shim did not refuse an out-of-namespace cursor (want exit 92)" >&2; exit 1; }
+GH_SHIM_FIXTURES="$_shimcheck_dir" "$shim/gh" api graphql -f query=q -f after= >/dev/null 2>&1
+[ $? -eq 92 ] || { echo "FATAL: shim did not refuse an EMPTY cursor (want exit 92)" >&2; exit 1; }
+GH_SHIM_FIXTURES="$_shimcheck_dir" "$shim/gh" api graphql -f query=q -f after=C9 >/dev/null 2>&1
+[ $? -eq 93 ] || { echo "FATAL: shim did not refuse a fixture-less follow-up page (want exit 93)" >&2; exit 1; }
+rm -rf "$_shimcheck_dir"
+
 # ------------------------------------------------------------------ helpers ---
 list_items() { # ';'-separated string -> one trimmed non-empty item per line
   printf '%s' "$1" | tr ';' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -v '^$' || true
@@ -2065,14 +2078,19 @@ EOF_EXCLUDE_BATTERY
       # Hermetic mode with every synthetic candidate matched. Finite probes
       # cannot PROVE universality — a glob set that merely spans both
       # harness namespaces exhausts the candidates while ordinary paths
-      # still carry — so only a STRUCTURALLY universal entry (a literal '*'
-      # or '**', which matches every path by construction) is a FAIL here;
-      # anything else is reported unproven, out loud, never silently green.
+      # still carry — so only a STRUCTURALLY universal entry is a FAIL
+      # here; anything else is reported unproven, out loud, never silently
+      # green. Structurally universal under the predicate's bash-case
+      # matcher: an entry built ONLY of '*'/'?' wildcards that contains at
+      # least one '*' — '*', '**', '***', '?*', '*?' all match every
+      # non-empty path by construction ('?'-only entries pin a length and
+      # are NOT universal).
       probe_universal=""
       while IFS= read -r probe_pat_u; do
         [ -z "$probe_pat_u" ] && continue
         case "$probe_pat_u" in
-          '*' | '**') probe_universal="$probe_pat_u" ;;
+          *[!*?]*) : ;;
+          *'*'*) probe_universal="$probe_pat_u" ;;
         esac
       done <<EOF_UNIVERSAL
 $(list_items "$ACTIVE_CARRY_EXCLUDE")

--- a/skills/review-gate/scripts/review-predicate-selftest.sh
+++ b/skills/review-gate/scripts/review-predicate-selftest.sh
@@ -202,14 +202,19 @@ chmod +x "$shim/gh"
 # must fire before any case relies on them — deleting a refusal arm fails
 # the whole run HERE, instead of leaving a case green against a fixture it
 # never drove. Each exit code is pinned exactly.
+# The scratch dir is removed BEFORE the assertions so a failed exit-code
+# check cannot leak it — the recorded rcs carry the evidence.
 _shimcheck_dir="$(mktemp -d)"
 GH_SHIM_FIXTURES="$_shimcheck_dir" "$shim/gh" api graphql -f query=q -f after=bad/value >/dev/null 2>&1
-[ $? -eq 92 ] || { echo "FATAL: shim did not refuse an out-of-namespace cursor (want exit 92)" >&2; exit 1; }
+_shimcheck_ns=$?
 GH_SHIM_FIXTURES="$_shimcheck_dir" "$shim/gh" api graphql -f query=q -f after= >/dev/null 2>&1
-[ $? -eq 92 ] || { echo "FATAL: shim did not refuse an EMPTY cursor (want exit 92)" >&2; exit 1; }
+_shimcheck_empty=$?
 GH_SHIM_FIXTURES="$_shimcheck_dir" "$shim/gh" api graphql -f query=q -f after=C9 >/dev/null 2>&1
-[ $? -eq 93 ] || { echo "FATAL: shim did not refuse a fixture-less follow-up page (want exit 93)" >&2; exit 1; }
+_shimcheck_gap=$?
 rm -rf "$_shimcheck_dir"
+[ "$_shimcheck_ns" -eq 92 ] || { echo "FATAL: shim did not refuse an out-of-namespace cursor (want exit 92, got $_shimcheck_ns)" >&2; exit 1; }
+[ "$_shimcheck_empty" -eq 92 ] || { echo "FATAL: shim did not refuse an EMPTY cursor (want exit 92, got $_shimcheck_empty)" >&2; exit 1; }
+[ "$_shimcheck_gap" -eq 93 ] || { echo "FATAL: shim did not refuse a fixture-less follow-up page (want exit 93, got $_shimcheck_gap)" >&2; exit 1; }
 
 # ------------------------------------------------------------------ helpers ---
 list_items() { # ';'-separated string -> one trimmed non-empty item per line
@@ -2081,16 +2086,22 @@ EOF_EXCLUDE_BATTERY
       # still carry — so only a STRUCTURALLY universal entry is a FAIL
       # here; anything else is reported unproven, out loud, never silently
       # green. Structurally universal under the predicate's bash-case
-      # matcher: an entry built ONLY of '*'/'?' wildcards that contains at
-      # least one '*' — '*', '**', '***', '?*', '*?' all match every
-      # non-empty path by construction ('?'-only entries pin a length and
-      # are NOT universal).
+      # matcher: an entry built ONLY of '*'/'?' wildcards, with at least
+      # one '*' and AT MOST one '?' — '*', '***', '?*', '*?' match every
+      # non-empty path by construction, while two or more '?'s impose a
+      # minimum length that one-character paths escape, and '?'-only
+      # entries pin an exact length; neither is universal.
       probe_universal=""
       while IFS= read -r probe_pat_u; do
         [ -z "$probe_pat_u" ] && continue
         case "$probe_pat_u" in
           *[!*?]*) : ;;
-          *'*'*) probe_universal="$probe_pat_u" ;;
+          *'*'*)
+            probe_pat_u_qs="${probe_pat_u//\*/}"
+            case "$probe_pat_u_qs" in
+              '' | '?') probe_universal="$probe_pat_u" ;;
+            esac
+            ;;
         esac
       done <<EOF_UNIVERSAL
 $(list_items "$ACTIVE_CARRY_EXCLUDE")

--- a/skills/review-gate/tests/review-predicate-selftest.test.sh
+++ b/skills/review-gate/tests/review-predicate-selftest.test.sh
@@ -216,6 +216,23 @@ fi
 grep -q "outside every committed glob and still carries" "$work/probeglob.out" \
   || note "harness-namespace fixture did not exercise the exclude-free carry case"
 
+# --- layer 2f: probe exhaustion without a structurally universal glob ------
+# A glob set spanning BOTH harness namespaces exhausts every synthetic
+# candidate while ordinary paths still carry — that is UNPROVEN universality,
+# not an over-broad failure. The run must PASS and say so out loud; only a
+# literal '*'/'**' entry may fail as "can never apply" (layer below).
+mkdir -p "$work/bothns"
+grep -v '^REVIEW_GATE_CARRY_FORWARD = ' "$work/configured/vstack.settings.toml" \
+  >"$work/bothns/vstack.settings.toml"
+printf 'REVIEW_GATE_CARRY_FORWARD = "docs"\nREVIEW_GATE_CARRY_FORWARD_EXCLUDE = "carry-probe*;unexcluded-sample*"\n' \
+  >>"$work/bothns/vstack.settings.toml"
+if ! (cd "$work/bothns" && "$SELFTEST") >"$work/bothns.out" 2>&1; then
+  cat "$work/bothns.out"
+  note "selftest failed under a both-namespaces exclusion set — probe exhaustion is being read as proof of universality again"
+fi
+grep -q "universality is UNPROVEN" "$work/bothns.out" \
+  || note "both-namespaces fixture did not report the unproven-universality note"
+
 # One combined FAILING run pins BOTH guards (each fixture run replays the
 # full decision table, so failure cases share a run): a leading-'/' glob can
 # never match a repository-relative compare filename (dead anchoring), and a

--- a/skills/review-gate/tests/review-predicate-selftest.test.sh
+++ b/skills/review-gate/tests/review-predicate-selftest.test.sh
@@ -233,6 +233,22 @@ fi
 grep -q "universality is UNPROVEN" "$work/bothns.out" \
   || note "both-namespaces fixture did not report the unproven-universality note"
 
+# Structural universality is not spelled '*' alone: any all-wildcard entry
+# with at least one asterisk ('***' here) matches every non-empty path under
+# the predicate's bash-case matcher and must FAIL as over-broad, never be
+# downgraded to the unproven note.
+mkdir -p "$work/allstars"
+grep -v '^REVIEW_GATE_CARRY_FORWARD = ' "$work/configured/vstack.settings.toml" \
+  >"$work/allstars/vstack.settings.toml"
+printf 'REVIEW_GATE_CARRY_FORWARD = "docs"\nREVIEW_GATE_CARRY_FORWARD_EXCLUDE = "***"\n' \
+  >>"$work/allstars/vstack.settings.toml"
+if (cd "$work/allstars" && "$SELFTEST") >"$work/allstars.out" 2>&1; then
+  note "selftest passed with a '***' exclusion — the all-wildcard universal shape is being read as unproven"
+else
+  grep -q "can never apply" "$work/allstars.out" \
+    || note "the '***' failure does not carry the can-never-apply diagnostic"
+fi
+
 # One combined FAILING run pins BOTH guards (each fixture run replays the
 # full decision table, so failure cases share a run): a leading-'/' glob can
 # never match a repository-relative compare filename (dead anchoring), and a


### PR DESCRIPTION
Three findings from the selftest propagation wave (hyprtrade-io#41, hyprtrade#582, and duplicates on drovr#477/vg#6):

- **Cause-carrying tracked-read errors**: `EXCLUDE_TRACKED_ERROR` now carries WHICH subsystem failed; the battery's FAIL line prints it, so a mktemp staging failure no longer diagnoses as "'git ls-files' failed; fix git".
- **Probe-exhaustion honesty**: in hermetic mode, exhausting both synthetic candidates proves nothing — a glob set spanning the two harness namespaces (e.g. `carry-probe*;unexcluded-sample*`) matches every probe while ordinary paths still carry. Only a structurally universal entry (literal `*`/`**`) FAILs as "can never apply"; anything else reports UNPROVEN universality loudly. New wrapper layer 2f pins the note path; the existing deadglob fixture still fails via its literal `*`.
- **Empty cursor refused**: the shim's cursor-namespace guard now rejects an empty `after=` value (exit 92) — empty selects no cursor fixture and would silently fall through to the default, the false-coverage shape the guard exists to prevent.

The mktemp negative control raised on hyprtrade#582 already exists upstream (wrapper layer 2d, shipped in #1224) — noted on that thread rather than duplicated here.

Selftest 251 cases pass; wrapper suite 186 default / 224 configured; all 8 review-gate suites green. The open propagation PRs get re-vendored from this once merged.

https://claude.ai/code/session_01WNNdhxuyKbYro4mFB1mqGp