### PR TITLE
feat(pi-questions): RPC fallback via native select/input dialogs (1.6.0)

### DIFF
--- a/.github/workflows/skill-tests.yml
+++ b/.github/workflows/skill-tests.yml
@@ -162,6 +162,13 @@ jobs:
           npm install --no-save --no-package-lock --ignore-scripts --no-audit --no-fund @earendil-works/pi-ai@0.84.1 @earendil-works/pi-coding-agent@0.84.1 @earendil-works/pi-tui@0.84.1 typebox 'undici@^7.25.0'
           npm test
 
+      # pi-questions unit tests are dependency-free by design (question-model
+      # and rpc-fallback import nothing outside the package), so unlike the
+      # suites above no npm install is needed.
+      - name: pi-questions suite
+        working-directory: pi-extensions/pi-questions
+        run: bun test ./extensions/__tests__
+
       # The bridge ships ~256 unit tests that nothing in CI ran until now, so
       # "tests pass" on a bridge PR meant "passed on the author's machine".
       # Build first: one suite loads bundle/connector-inventory.js rather than

--- a/pi-extensions/pi-questions/CHANGELOG.md
+++ b/pi-extensions/pi-questions/CHANGELOG.md
@@ -4,9 +4,11 @@
 
 ### 1.6.0
 
-- RPC fallback: in `ctx.mode === "rpc"` hosts (Paseo, pi-web, VS Code bridges), or when `ctx.ui.custom()` resolves `undefined` without completing the request, the questionnaire now walks questions sequentially through native `ctx.ui.select()`/`ctx.ui.input()` dialogs instead of the custom TUI. Multi-select falls back to a comma-separated numbers input with a free-text custom answer. The `question` tool's `QuestionResult` shape is unchanged in both modes.
+- RPC fallback: in `ctx.mode === "rpc"` hosts (Paseo, pi-web, VS Code bridges), or when `ctx.ui.custom()` resolves `undefined` without completing the request, the questionnaire now walks questions sequentially through native `ctx.ui.select()`/`ctx.ui.input()` dialogs instead of the custom TUI. Multi-select falls back to a comma-separated numbers input with a free-text custom answer; the option list (including the free-text fallback row) is always shown in full. The `question` tool's `QuestionResult` shape is unchanged in both modes.
+- Blank custom answers and out-of-range option numbers re-prompt with an error note instead of submitting an empty or silently-trimmed answer; persistent invalid input cancels after a bounded number of attempts. The dialog walker stops silently when the request is completed elsewhere (bridge reply/rejection/shutdown) mid-walk.
 - When neither the custom TUI nor native select/input dialogs are available, the `question` tool now returns a clear cancelled-with-error result instead of hanging or refusing generically.
-- New module `extensions/rpc-fallback.ts` (exports `isRpcMode`, `rpcDialogUI`, `presentQuestion`, `runRpcQuestionnaire`); headless non-RPC contexts still leave requests pending for bridge/API replies.
+- Completing a question request now verifies request identity, not just id membership: a stale completer can no longer close a newer request that reused the same id.
+- New module `extensions/rpc-fallback.ts` (exports `isRpcMode`, `rpcDialogUI`, `noDialogRouteError`, `presentQuestion`, `runRpcQuestionnaire`, `formatOptionRows`, `parseMultiSelection`); headless non-RPC contexts still leave requests pending for bridge/API replies.
 
 ### 1.5.0
 

--- a/pi-extensions/pi-questions/CHANGELOG.md
+++ b/pi-extensions/pi-questions/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 1.6.0
 
 - RPC fallback: in `ctx.mode === "rpc"` hosts (Paseo, pi-web, VS Code bridges), or when `ctx.ui.custom()` resolves `undefined` without completing the request, the questionnaire now walks questions sequentially through native `ctx.ui.select()`/`ctx.ui.input()` dialogs instead of the custom TUI. Multi-select falls back to a comma-separated numbers input with a free-text custom answer; the option list (including the free-text fallback row) is always shown in full. The `question` tool's `QuestionResult` shape is unchanged in both modes.
+- Empty-selection parity with the TUI: multi-question (or any-multi-select) requests add a "Skip (no selection)" row to single-select dialogs and accept empty multi-select input, matching the TUI confirm tab's ability to submit an unanswered tab; single-question single-select offers no skip, as in the TUI.
 - Blank custom answers and out-of-range option numbers re-prompt with an error note instead of submitting an empty or silently-trimmed answer; persistent invalid input cancels after a bounded number of attempts. The dialog walker stops silently when the request is completed elsewhere (bridge reply/rejection/shutdown) mid-walk.
 - When neither the custom TUI nor native select/input dialogs are available, the `question` tool now returns a clear cancelled-with-error result instead of hanging or refusing generically.
 - Completing a question request now verifies request identity, not just id membership: a stale completer can no longer close a newer request that reused the same id.

--- a/pi-extensions/pi-questions/CHANGELOG.md
+++ b/pi-extensions/pi-questions/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Consumer-impacting changes
 
+### 1.6.0
+
+- RPC fallback: in `ctx.mode === "rpc"` hosts (Paseo, pi-web, VS Code bridges), or when `ctx.ui.custom()` resolves `undefined` without completing the request, the questionnaire now walks questions sequentially through native `ctx.ui.select()`/`ctx.ui.input()` dialogs instead of the custom TUI. Multi-select falls back to a comma-separated numbers input with a free-text custom answer. The `question` tool's `QuestionResult` shape is unchanged in both modes.
+- When neither the custom TUI nor native select/input dialogs are available, the `question` tool now returns a clear cancelled-with-error result instead of hanging or refusing generically.
+- New module `extensions/rpc-fallback.ts` (exports `isRpcMode`, `rpcDialogUI`, `presentQuestion`, `runRpcQuestionnaire`); headless non-RPC contexts still leave requests pending for bridge/API replies.
+
 ### 1.5.0
 
 - Baseline: changelog introduced at this version. Consumer-impacting changes — behavior deltas, new/renamed/removed exports, settings and config changes, protocol/audit-shape changes — are recorded here from this version forward.

--- a/pi-extensions/pi-questions/README.md
+++ b/pi-extensions/pi-questions/README.md
@@ -15,6 +15,7 @@ Structured inline questions for Pi. Multi-tab categories, built-in free-text fal
 - When the bridge is loaded, question opened/answered/rejected lifecycle points publish structured `question.*` activity broker events without adding chat messages.
 - Optional **Answers as user message** setting (off by default) mirrors each answered question into the conversation as a steer-delivered user message for observer extensions such as [pi-automode](https://github.com/czottmann/pi-automode).
 - `pi-qol` notification hook fires before prompts open.
+- RPC hosts without custom TUI support (Paseo, pi-web, VS Code bridges) get a sequential native-dialog fallback. See [RPC hosts](#rpc-hosts).
 
 ## Install
 
@@ -75,6 +76,17 @@ When the user types fallback text, the result uses the same answer shape as fixe
 ```
 
 Do not include a final `Confirm`, `Submit`, `Review`, or `Done` question tab in the payload; the UI adds its own submit tab when needed.
+
+## RPC hosts
+
+Interactive Pi sessions render the questionnaire with the custom TUI described above. RPC hosts (Paseo, pi-web, VS Code-based bridges) cannot render custom TUI components, so when `ctx.mode === "rpc"` — or when `ctx.ui.custom()` resolves without producing a result — the extension walks the questions one at a time through the host's native dialogs instead:
+
+- **Single-select** questions open a native select dialog listing the numbered options plus the free-text fallback row; picking the fallback row opens a text input for the custom answer.
+- **Multi-select** questions open a text input with the numbered option list folded into the prompt. Answer with comma-separated option numbers (e.g. `1,3`). Including the fallback row's number opens a follow-up input for the custom text; any non-numeric answer is taken whole as a custom answer. Out-of-range numbers re-prompt with an error note, and the option list (including the fallback row) is always shown in full.
+- Blank custom answers re-show the question rather than submitting an empty answer; repeated invalid input cancels after a few attempts.
+- Dismissing any dialog cancels the whole questionnaire, matching Escape in the TUI. Answers keep the same `QuestionResult` shape in both modes.
+
+If the host supports neither custom TUI components nor native select/input dialogs, the `question` tool returns a clear error instead of hanging. Headless non-RPC contexts (e.g. bridge-driven sessions) still leave requests pending for `pi-bridge` replies.
 
 ## Settings
 

--- a/pi-extensions/pi-questions/README.md
+++ b/pi-extensions/pi-questions/README.md
@@ -84,6 +84,7 @@ Interactive Pi sessions render the questionnaire with the custom TUI described a
 - **Single-select** questions open a native select dialog listing the numbered options plus the free-text fallback row; picking the fallback row opens a text input for the custom answer.
 - **Multi-select** questions open a text input with the numbered option list folded into the prompt. Answer with comma-separated option numbers (e.g. `1,3`). Including the fallback row's number opens a follow-up input for the custom text; any non-numeric answer is taken whole as a custom answer. Out-of-range numbers re-prompt with an error note, and the option list (including the fallback row) is always shown in full.
 - Blank custom answers re-show the question rather than submitting an empty answer; repeated invalid input cancels after a few attempts.
+- Requests with several questions (or any multi-select) add a `Skip (no selection)` row to single-select dialogs and accept empty multi-select input — the same tabs the TUI lets you leave unanswered via its confirm tab. A lone single-select question cannot be skipped, matching the TUI.
 - Dismissing any dialog cancels the whole questionnaire, matching Escape in the TUI. Answers keep the same `QuestionResult` shape in both modes.
 
 If the host supports neither custom TUI components nor native select/input dialogs, the `question` tool returns a clear error instead of hanging. Headless non-RPC contexts (e.g. bridge-driven sessions) still leave requests pending for `pi-bridge` replies.

--- a/pi-extensions/pi-questions/extensions/__tests__/rpc-fallback.test.ts
+++ b/pi-extensions/pi-questions/extensions/__tests__/rpc-fallback.test.ts
@@ -219,6 +219,19 @@ describe("rpc questionnaire walker", () => {
 		expect(lines[13]).toBe("13. Something else (type your own answer)");
 	});
 
+	test("control-state words typed as custom answers arrive as answers, not control states", async () => {
+		const customRow = "3. Something else (type your own answer)";
+		for (const word of ["cancelled", "abandoned", "blank", "external", "answers", "text"]) {
+			const single = await runRpcQuestionnaire(fakeDialogs([customRow, word]), singleRequest());
+			expect(single).toEqual({ answers: [[word]], kind: "answered" });
+		}
+		const multi = await runRpcQuestionnaire(
+			fakeDialogs(["1. A", "1,3", "cancelled", "2. Slow"]),
+			multiTabRequest(),
+		);
+		expect(multi).toEqual({ answers: [["A"], ["Docs", "cancelled"], ["Slow"]], kind: "answered" });
+	});
+
 	test("repeated invocations are independent", async () => {
 		const request = singleRequest();
 		const first = await runRpcQuestionnaire(fakeDialogs([undefined]), request);

--- a/pi-extensions/pi-questions/extensions/__tests__/rpc-fallback.test.ts
+++ b/pi-extensions/pi-questions/extensions/__tests__/rpc-fallback.test.ts
@@ -232,6 +232,27 @@ describe("rpc questionnaire walker", () => {
 		expect(multi).toEqual({ answers: [["A"], ["Docs", "cancelled"], ["Slow"]], kind: "answered" });
 	});
 
+	test("multi-question requests offer a skip row; skipping yields an empty answer like the TUI confirm tab", async () => {
+		const request = multiTabRequest();
+		const dialogs = fakeDialogs(["4. Skip (no selection)", "", "1. Fast"]);
+		const outcome = await runRpcQuestionnaire(dialogs, request);
+
+		expect(outcome).toEqual({ answers: [[], [], ["Fast"]], kind: "answered" });
+		expect(dialogs.calls[0].options).toEqual([
+			"1. A",
+			"2. B",
+			"3. Something else (type your own answer)",
+			"4. Skip (no selection)",
+		]);
+	});
+
+	test("single-question single-select offers no skip row, matching the TUI which cannot submit empty there", async () => {
+		const dialogs = fakeDialogs(["2. B"]);
+		await runRpcQuestionnaire(dialogs, singleRequest());
+
+		expect(dialogs.calls[0].options).toEqual(["1. A — keep going", "2. B", "3. Something else (type your own answer)"]);
+	});
+
 	test("repeated invocations are independent", async () => {
 		const request = singleRequest();
 		const first = await runRpcQuestionnaire(fakeDialogs([undefined]), request);

--- a/pi-extensions/pi-questions/extensions/__tests__/rpc-fallback.test.ts
+++ b/pi-extensions/pi-questions/extensions/__tests__/rpc-fallback.test.ts
@@ -145,6 +145,80 @@ describe("rpc questionnaire walker", () => {
 		expect(outcome).toEqual({ kind: "cancelled" });
 	});
 
+	test("abandons silently when the request settles externally mid-walk", async () => {
+		const request = multiTabRequest();
+		let settled = false;
+		const base = fakeDialogs(["1. A"]);
+		const dialogs: FakeDialogs = {
+			calls: base.calls,
+			input: base.input,
+			select: async (title, options) => {
+				const choice = await base.select(title, options);
+				settled = true;
+				return choice;
+			},
+		};
+		const outcome = await runRpcQuestionnaire(dialogs, request, () => settled);
+
+		expect(outcome).toEqual({ kind: "external" });
+		expect(dialogs.calls).toHaveLength(1);
+	});
+
+	test("never opens a dialog when the request is already settled", async () => {
+		const dialogs = fakeDialogs([]);
+		const outcome = await runRpcQuestionnaire(dialogs, singleRequest(), () => true);
+
+		expect(outcome).toEqual({ kind: "external" });
+		expect(dialogs.calls).toHaveLength(0);
+	});
+
+	test("blank custom text re-shows the question instead of answering blank", async () => {
+		const request = singleRequest();
+		const customRow = "3. Something else (type your own answer)";
+		const dialogs = fakeDialogs([customRow, "   ", customRow, "Real answer"]);
+		const outcome = await runRpcQuestionnaire(dialogs, request);
+
+		expect(outcome).toEqual({ answers: [["Real answer"]], kind: "answered" });
+		expect(dialogs.calls[2].title).toBe("Custom answer cannot be empty — Path: Which path?");
+	});
+
+	test("persistent blank input cancels after bounded re-prompts, never a false answer", async () => {
+		const customRow = "3. Something else (type your own answer)";
+		const dialogs = fakeDialogs([customRow, "", customRow, "", customRow, "", customRow, "", customRow, ""]);
+		const outcome = await runRpcQuestionnaire(dialogs, singleRequest());
+
+		expect(outcome).toEqual({ kind: "cancelled" });
+		expect(dialogs.calls).toHaveLength(10);
+	});
+
+	test("out-of-range multi-select numbers re-prompt with an error note", async () => {
+		const request = multiTabRequest();
+		const dialogs = fakeDialogs(["1. A", "9", "1,2", "2. Slow"]);
+		const outcome = await runRpcQuestionnaire(dialogs, request);
+
+		expect(outcome).toEqual({ answers: [["A"], ["Docs", "Tests"], ["Slow"]], kind: "answered" });
+		expect(dialogs.calls[2].title.startsWith("Option numbers must be between 1 and 3 — Targets")).toBe(true);
+	});
+
+	test("multi-select option list is never truncated away, custom row included", async () => {
+		const request = normalizeRequest({
+			id: "que_rpc_long",
+			questions: [{
+				header: "Pick",
+				multiple: true,
+				options: Array.from({ length: 12 }, (_, i) => ({ description: "x".repeat(300), label: `Option ${i + 1}` })),
+				question: `Long question ${"y".repeat(700)}`,
+			}],
+		});
+		const dialogs = fakeDialogs(["1,12"]);
+		const outcome = await runRpcQuestionnaire(dialogs, request);
+
+		expect(outcome).toEqual({ answers: [["Option 1", "Option 12"]], kind: "answered" });
+		const lines = dialogs.calls[0].title.split("\n");
+		expect(lines).toHaveLength(14);
+		expect(lines[13]).toBe("13. Something else (type your own answer)");
+	});
+
 	test("repeated invocations are independent", async () => {
 		const request = singleRequest();
 		const first = await runRpcQuestionnaire(fakeDialogs([undefined]), request);
@@ -165,9 +239,14 @@ describe("multi-select parsing", () => {
 		expect(parseMultiSelection(" 2 1 ", tab())).toEqual({ labels: ["Tests", "Docs"], wantsCustom: false });
 	});
 
-	test("custom row number requests the follow-up input; out-of-range numbers are ignored", () => {
+	test("custom row number requests the follow-up input", () => {
 		expect(parseMultiSelection("1,3", tab())).toEqual({ labels: ["Docs"], wantsCustom: true });
-		expect(parseMultiSelection("9", tab())).toEqual({ labels: [], wantsCustom: false });
+	});
+
+	test("out-of-range or ambiguous numbers are an error, never a silent empty answer", () => {
+		expect(parseMultiSelection("9", tab())).toEqual({ error: "Option numbers must be between 1 and 3" });
+		expect(parseMultiSelection("0", tab())).toEqual({ error: "Option numbers must be between 1 and 3" });
+		expect(parseMultiSelection("12", tab())).toEqual({ error: "Option numbers must be between 1 and 3" });
 	});
 
 	test("non-numeric input becomes a whole free-text custom answer", () => {

--- a/pi-extensions/pi-questions/extensions/__tests__/rpc-fallback.test.ts
+++ b/pi-extensions/pi-questions/extensions/__tests__/rpc-fallback.test.ts
@@ -1,0 +1,270 @@
+import { describe, expect, test } from "bun:test";
+
+import { normalizeRequest } from "../question-model.js";
+import {
+	formatOptionRows,
+	isRpcMode,
+	parseMultiSelection,
+	presentQuestion,
+	rpcDialogUI,
+	runRpcQuestionnaire,
+	type PresentOutcome,
+	type RpcDialogUI,
+} from "../rpc-fallback.js";
+
+interface DialogCall {
+	method: "select" | "input";
+	title: string;
+	options?: string[];
+	placeholder?: string;
+}
+
+interface FakeDialogs extends RpcDialogUI {
+	calls: DialogCall[];
+}
+
+function fakeDialogs(responses: Array<string | undefined>): FakeDialogs {
+	const queue = [...responses];
+	const calls: DialogCall[] = [];
+	return {
+		calls,
+		input(title, placeholder) {
+			calls.push({ method: "input", placeholder, title });
+			if (queue.length === 0) throw new Error("fake dialog queue exhausted");
+			return Promise.resolve(queue.shift());
+		},
+		select(title, options) {
+			calls.push({ method: "select", options, title });
+			if (queue.length === 0) throw new Error("fake dialog queue exhausted");
+			return Promise.resolve(queue.shift());
+		},
+	};
+}
+
+function singleRequest() {
+	return normalizeRequest({
+		id: "que_rpc_single",
+		questions: [{
+			header: "Path",
+			options: [{ description: "keep going", label: "A" }, { label: "B" }],
+			question: "Which path?",
+		}],
+	});
+}
+
+function multiTabRequest() {
+	return normalizeRequest({
+		id: "que_rpc_multi",
+		questions: [
+			{ header: "Path", options: [{ label: "A" }, { label: "B" }], question: "Which path?" },
+			{ header: "Targets", multiple: true, options: [{ label: "Docs" }, { label: "Tests" }], question: "Which targets?" },
+			{ header: "Speed", options: [{ label: "Fast" }, { label: "Slow" }], question: "How fast?" },
+		],
+	});
+}
+
+describe("rpc mode detection", () => {
+	test("isRpcMode detects explicit rpc mode only", () => {
+		expect(isRpcMode({ mode: "rpc" })).toBe(true);
+		expect(isRpcMode({ mode: "interactive" })).toBe(false);
+		expect(isRpcMode({})).toBe(false);
+		expect(isRpcMode(undefined)).toBe(false);
+	});
+
+	test("rpcDialogUI requires callable select and input", () => {
+		expect(rpcDialogUI(undefined)).toBeUndefined();
+		expect(rpcDialogUI({ select: () => Promise.resolve(undefined) })).toBeUndefined();
+		expect(rpcDialogUI({ input: () => Promise.resolve(undefined) })).toBeUndefined();
+		const ui = { input: () => Promise.resolve(undefined), select: () => Promise.resolve(undefined) };
+		expect(rpcDialogUI(ui)).toBe(ui as RpcDialogUI);
+	});
+});
+
+describe("rpc questionnaire walker", () => {
+	test("single select answers with the chosen option label", async () => {
+		const request = singleRequest();
+		const dialogs = fakeDialogs(["1. A — keep going"]);
+		const outcome = await runRpcQuestionnaire(dialogs, request);
+
+		expect(outcome).toEqual({ answers: [["A"]], kind: "answered" });
+		expect(dialogs.calls).toEqual([{
+			method: "select",
+			options: ["1. A — keep going", "2. B", "3. Something else (type your own answer)"],
+			title: "Path: Which path?",
+		}]);
+	});
+
+	test("choosing the custom row prompts for free text", async () => {
+		const request = singleRequest();
+		const dialogs = fakeDialogs(["3. Something else (type your own answer)", "  Use C instead  "]);
+		const outcome = await runRpcQuestionnaire(dialogs, request);
+
+		expect(outcome).toEqual({ answers: [["Use C instead"]], kind: "answered" });
+		expect(dialogs.calls[1]).toEqual({
+			method: "input",
+			placeholder: "Type your answer, then press enter.",
+			title: "Path: Something else",
+		});
+	});
+
+	test("walks multiple questions in order and preserves the answers shape", async () => {
+		const request = multiTabRequest();
+		const dialogs = fakeDialogs(["1. A", "1,2", "2. Slow"]);
+		const outcome = await runRpcQuestionnaire(dialogs, request);
+
+		expect(outcome).toEqual({ answers: [["A"], ["Docs", "Tests"], ["Slow"]], kind: "answered" });
+		expect(dialogs.calls.map((call) => call.method)).toEqual(["select", "input", "select"]);
+		expect(dialogs.calls[0].title).toBe("Path (1/3): Which path?");
+		expect(dialogs.calls[1].title).toContain("Targets (2/3): Which targets?");
+		expect(dialogs.calls[1].title).toContain("1. Docs");
+		expect(dialogs.calls[2].title).toBe("Speed (3/3): How fast?");
+	});
+
+	test("multi-select custom number triggers a follow-up text input", async () => {
+		const request = multiTabRequest();
+		const dialogs = fakeDialogs(["2. B", "1,3", "Release notes", "1. Fast"]);
+		const outcome = await runRpcQuestionnaire(dialogs, request);
+
+		expect(outcome).toEqual({ answers: [["B"], ["Docs", "Release notes"], ["Fast"]], kind: "answered" });
+	});
+
+	test("dismissing a dialog cancels the questionnaire without further dialogs", async () => {
+		const request = multiTabRequest();
+		const dialogs = fakeDialogs(["1. A", undefined]);
+		const outcome = await runRpcQuestionnaire(dialogs, request);
+
+		expect(outcome).toEqual({ kind: "cancelled" });
+		expect(dialogs.calls).toHaveLength(2);
+	});
+
+	test("dismissing the custom-text follow-up cancels too", async () => {
+		const request = singleRequest();
+		const dialogs = fakeDialogs(["3. Something else (type your own answer)", undefined]);
+		const outcome = await runRpcQuestionnaire(dialogs, request);
+
+		expect(outcome).toEqual({ kind: "cancelled" });
+	});
+
+	test("repeated invocations are independent", async () => {
+		const request = singleRequest();
+		const first = await runRpcQuestionnaire(fakeDialogs([undefined]), request);
+		const second = await runRpcQuestionnaire(fakeDialogs(["2. B"]), request);
+		const third = await runRpcQuestionnaire(fakeDialogs(["1. A — keep going"]), request);
+
+		expect(first).toEqual({ kind: "cancelled" });
+		expect(second).toEqual({ answers: [["B"]], kind: "answered" });
+		expect(third).toEqual({ answers: [["A"]], kind: "answered" });
+	});
+});
+
+describe("multi-select parsing", () => {
+	const tab = () => multiTabRequest().questions[1];
+
+	test("comma or space separated numbers map to option labels, deduped", () => {
+		expect(parseMultiSelection("1,2,1", tab())).toEqual({ labels: ["Docs", "Tests"], wantsCustom: false });
+		expect(parseMultiSelection(" 2 1 ", tab())).toEqual({ labels: ["Tests", "Docs"], wantsCustom: false });
+	});
+
+	test("custom row number requests the follow-up input; out-of-range numbers are ignored", () => {
+		expect(parseMultiSelection("1,3", tab())).toEqual({ labels: ["Docs"], wantsCustom: true });
+		expect(parseMultiSelection("9", tab())).toEqual({ labels: [], wantsCustom: false });
+	});
+
+	test("non-numeric input becomes a whole free-text custom answer", () => {
+		expect(parseMultiSelection("Docs and a migration guide", tab())).toEqual({
+			labels: ["Docs and a migration guide"],
+			wantsCustom: false,
+		});
+		expect(parseMultiSelection("   ", tab())).toEqual({ labels: [], wantsCustom: false });
+	});
+});
+
+describe("presentQuestion routing", () => {
+	test("explicit rpc mode uses the dialog walker even without custom UI", async () => {
+		const request = singleRequest();
+		const dialogs = fakeDialogs(["2. B"]);
+		const outcome = await presentQuestion(request, {
+			dialogs,
+			hasUI: false,
+			isSettled: () => false,
+			rpcMode: true,
+		});
+
+		expect(outcome).toEqual({ answers: [["B"]], kind: "answered" });
+	});
+
+	test("rpc mode without dialogs is a clear error, not a hang", async () => {
+		const outcome = await presentQuestion(singleRequest(), {
+			dialogs: undefined,
+			hasUI: false,
+			isSettled: () => false,
+			rpcMode: true,
+		});
+
+		expect(outcome?.kind).toBe("unavailable");
+		expect((outcome as Extract<PresentOutcome, { kind: "unavailable" }>).error).toContain("select/input");
+	});
+
+	test("custom() resolving undefined falls back to the dialog walker", async () => {
+		const request = singleRequest();
+		const dialogs = fakeDialogs(["1. A — keep going"]);
+		let customOpened = 0;
+		const outcome = await presentQuestion(request, {
+			dialogs,
+			hasUI: true,
+			isSettled: () => false,
+			openCustom: () => {
+				customOpened += 1;
+				return Promise.resolve(undefined);
+			},
+			rpcMode: false,
+		});
+
+		expect(customOpened).toBe(1);
+		expect(outcome).toEqual({ answers: [["A"]], kind: "answered" });
+	});
+
+	test("custom() resolving undefined without dialogs is a clear error", async () => {
+		const outcome = await presentQuestion(singleRequest(), {
+			dialogs: undefined,
+			hasUI: true,
+			isSettled: () => false,
+			openCustom: () => Promise.resolve(undefined),
+			rpcMode: false,
+		});
+
+		expect(outcome?.kind).toBe("unavailable");
+	});
+
+	test("custom() completing the request stays on the custom path", async () => {
+		const dialogs = fakeDialogs([]);
+		const outcome = await presentQuestion(singleRequest(), {
+			dialogs,
+			hasUI: true,
+			isSettled: () => true,
+			openCustom: () => Promise.resolve({ answers: [["A"]], requestId: "que_rpc_single" }),
+			rpcMode: false,
+		});
+
+		expect(outcome).toEqual({ kind: "external" });
+		expect(dialogs.calls).toHaveLength(0);
+	});
+
+	test("headless non-rpc contexts leave the request pending for bridge replies", async () => {
+		const outcome = await presentQuestion(singleRequest(), {
+			dialogs: fakeDialogs([]),
+			hasUI: false,
+			isSettled: () => false,
+			rpcMode: false,
+		});
+
+		expect(outcome).toBeUndefined();
+	});
+});
+
+describe("option row formatting", () => {
+	test("rows are numbered with descriptions folded in and the custom row last", () => {
+		const rows = formatOptionRows(singleRequest().questions[0]);
+		expect(rows).toEqual(["1. A — keep going", "2. B", "3. Something else (type your own answer)"]);
+	});
+});

--- a/pi-extensions/pi-questions/extensions/questions.ts
+++ b/pi-extensions/pi-questions/extensions/questions.ts
@@ -28,7 +28,7 @@ import {
 	type QuestionRequest,
 	type QuestionTab,
 } from "./question-model.js";
-import { isRpcMode, presentQuestion, rpcDialogUI } from "./rpc-fallback.js";
+import { isRpcMode, noDialogRouteError, presentQuestion, rpcDialogUI } from "./rpc-fallback.js";
 
 const INSTALL_SYMBOL = Symbol.for("vstack.pi-questions.installed");
 const CONFIG_ID = "@vanillagreen/pi-questions";
@@ -563,7 +563,10 @@ class QuestionServiceImpl implements QuestionService {
 
 		const pending: PendingQuestion = {
 			complete: (result, completeSource) => {
-				if (!this.pending.has(request.id)) return;
+				// Identity check, not just membership: a stale completer (e.g. an
+				// abandoned RPC dialog) must not delete a newer request that
+				// reused the same request id after this one settled.
+				if (this.pending.get(request.id) !== pending) return;
 				this.pending.delete(request.id);
 				const finalResult = "answers" in result ? { requestId: request.id, answers: result.answers } : { ...result, requestId: request.id };
 				resolvePromise(finalResult);
@@ -592,7 +595,7 @@ class QuestionServiceImpl implements QuestionService {
 		void presentQuestion(request, {
 			dialogs: rpcDialogUI(ctx.ui),
 			hasUI: ctx.hasUI,
-			isSettled: () => !this.pending.has(request.id),
+			isSettled: () => this.pending.get(request.id) !== pending,
 			openCustom: ctx.hasUI ? () => openQuestionUi(ctx, pending) : undefined,
 			rpcMode: isRpcMode(ctx),
 		}).then((outcome) => {
@@ -1071,9 +1074,7 @@ export default function questions(pi: ExtensionAPI): void {
 				return makeQuestionToolResult(toolCallId, result);
 			}
 			if (!runCtx.hasUI && !(isRpcMode(runCtx) && rpcDialogUI(runCtx.ui))) {
-				const error = isRpcMode(runCtx)
-					? "No question UI available: this RPC host renders neither custom TUI components nor native select/input dialogs"
-					: "No interactive UI available for question prompt";
+				const error = isRpcMode(runCtx) ? noDialogRouteError(true) : "No interactive UI available for question prompt";
 				const result: QuestionCancelResult = { cancelled: true, error, requestId: typeof params.id === "string" ? params.id : "que_unavailable" };
 				return makeQuestionToolResult(toolCallId, result);
 			}

--- a/pi-extensions/pi-questions/extensions/questions.ts
+++ b/pi-extensions/pi-questions/extensions/questions.ts
@@ -28,6 +28,7 @@ import {
 	type QuestionRequest,
 	type QuestionTab,
 } from "./question-model.js";
+import { isRpcMode, presentQuestion, rpcDialogUI } from "./rpc-fallback.js";
 
 const INSTALL_SYMBOL = Symbol.for("vstack.pi-questions.installed");
 const CONFIG_ID = "@vanillagreen/pi-questions";
@@ -588,11 +589,22 @@ class QuestionServiceImpl implements QuestionService {
 		notifyQuestionOpened(ctx, openedEvent);
 		this.publish(openedEvent);
 
-		if (ctx.hasUI) {
-			void openQuestionUi(ctx, pending).catch((error) => {
-				pending.complete({ cancelled: true, error: stringifyError(error), requestId: request.id }, "ui_error");
-			});
-		}
+		void presentQuestion(request, {
+			dialogs: rpcDialogUI(ctx.ui),
+			hasUI: ctx.hasUI,
+			isSettled: () => !this.pending.has(request.id),
+			openCustom: ctx.hasUI ? () => openQuestionUi(ctx, pending) : undefined,
+			rpcMode: isRpcMode(ctx),
+		}).then((outcome) => {
+			// undefined: no UI route; leave the request pending for bridge/API
+			// replies. "external": the custom TUI or a bridge reply completed it.
+			if (!outcome || outcome.kind === "external") return;
+			if (outcome.kind === "answered") pending.complete({ answers: outcome.answers, requestId: request.id }, "ui");
+			else if (outcome.kind === "cancelled") pending.complete({ cancelled: true, requestId: request.id }, "ui");
+			else pending.complete({ cancelled: true, error: outcome.error, requestId: request.id }, "ui_error");
+		}).catch((error) => {
+			pending.complete({ cancelled: true, error: stringifyError(error), requestId: request.id }, "ui_error");
+		});
 
 		return promise;
 	}
@@ -661,12 +673,12 @@ function attachContext(ctx: ExtensionContext | undefined, service: QuestionServi
 	});
 }
 
-async function openQuestionUi(ctx: ExtensionContext, pending: PendingQuestion): Promise<void> {
+async function openQuestionUi(ctx: ExtensionContext, pending: PendingQuestion): Promise<QuestionResult | undefined> {
 	if (isVstackModalActive()) {
 		ctx.ui.notify("Question queued until the current popup closes.", "info");
 		while (isVstackModalActive()) {
 			const completed = await Promise.race([pending.promise.then(() => true), sleep(100).then(() => false)]);
-			if (completed) return;
+			if (completed) return pending.promise;
 		}
 	}
 	const releaseModalLock = acquireVstackModalLock();
@@ -748,7 +760,7 @@ async function openQuestionUi(ctx: ExtensionContext, pending: PendingQuestion): 
 		pending.requestRender?.();
 	};
 
-	await ctx.ui.custom<QuestionResult>(
+	return await ctx.ui.custom<QuestionResult>(
 		(tui, theme, _keybindings, done) => {
 			pending.uiDone = done;
 			pending.requestRender = () => tui.requestRender();
@@ -1058,8 +1070,11 @@ export default function questions(pi: ExtensionAPI): void {
 				const result: QuestionCancelResult = { cancelled: true, error: "No active Pi context", requestId: "que_unavailable" };
 				return makeQuestionToolResult(toolCallId, result);
 			}
-			if (!runCtx.hasUI) {
-				const result: QuestionCancelResult = { cancelled: true, error: "No interactive UI available for question prompt", requestId: typeof params.id === "string" ? params.id : "que_unavailable" };
+			if (!runCtx.hasUI && !(isRpcMode(runCtx) && rpcDialogUI(runCtx.ui))) {
+				const error = isRpcMode(runCtx)
+					? "No question UI available: this RPC host renders neither custom TUI components nor native select/input dialogs"
+					: "No interactive UI available for question prompt";
+				const result: QuestionCancelResult = { cancelled: true, error, requestId: typeof params.id === "string" ? params.id : "que_unavailable" };
 				return makeQuestionToolResult(toolCallId, result);
 			}
 			activeCtx = runCtx;

--- a/pi-extensions/pi-questions/extensions/rpc-fallback.ts
+++ b/pi-extensions/pi-questions/extensions/rpc-fallback.ts
@@ -9,6 +9,9 @@ import type { QuestionRequest, QuestionTab } from "./question-model.js";
 
 const TITLE_MAX_CHARS = 600;
 const ROW_MAX_CHARS = 200;
+// Bounds re-prompt loops (blank custom text, out-of-range numbers) so a host
+// that mechanically replays the same bad answer cancels instead of spinning.
+const MAX_PROMPT_ATTEMPTS = 5;
 
 export interface RpcDialogUI {
 	select(title: string, options: string[]): Promise<string | undefined>;
@@ -20,6 +23,13 @@ export type PresentOutcome =
 	| { kind: "cancelled" }
 	| { kind: "unavailable"; error: string }
 	| { kind: "external" };
+
+export type WalkOutcome = Extract<PresentOutcome, { kind: "answered" | "cancelled" | "external" }>;
+
+// Per-question step results: an answers array, or a marker. "cancelled" is a
+// user dismissal; "abandoned" means the request settled elsewhere (bridge
+// reply, rejection, shutdown) and the walker must stop silently.
+type StepResult = string[] | "cancelled" | "abandoned";
 
 export interface QuestionHost {
 	rpcMode: boolean;
@@ -54,12 +64,13 @@ export function noDialogRouteError(rpcMode: boolean): string {
  * Returns undefined when no UI route applies and the request should stay
  * pending for bridge/API replies (the pre-fallback behavior for headless
  * contexts). All other outcomes are terminal and the caller must complete
- * the pending request with them.
+ * the pending request with them — except "external", which means the request
+ * was already completed elsewhere and must not be completed again.
  */
 export async function presentQuestion(request: QuestionRequest, host: QuestionHost): Promise<PresentOutcome | undefined> {
 	if (host.rpcMode) {
 		if (!host.dialogs) return { error: noDialogRouteError(true), kind: "unavailable" };
-		return runRpcQuestionnaire(host.dialogs, request);
+		return runRpcQuestionnaire(host.dialogs, request, host.isSettled);
 	}
 	if (host.hasUI && host.openCustom) {
 		const uiResult = await host.openCustom();
@@ -68,7 +79,7 @@ export async function presentQuestion(request: QuestionRequest, host: QuestionHo
 		// custom() resolved undefined without completing the request: the host
 		// accepted the call but cannot render the component. Fall back.
 		if (!host.dialogs) return { error: noDialogRouteError(false), kind: "unavailable" };
-		return runRpcQuestionnaire(host.dialogs, request);
+		return runRpcQuestionnaire(host.dialogs, request, host.isSettled);
 	}
 	return undefined;
 }
@@ -76,25 +87,28 @@ export async function presentQuestion(request: QuestionRequest, host: QuestionHo
 export async function runRpcQuestionnaire(
 	ui: RpcDialogUI,
 	request: QuestionRequest,
-): Promise<{ kind: "answered"; answers: string[][] } | { kind: "cancelled" }> {
+	isSettled: () => boolean = () => false,
+): Promise<WalkOutcome> {
 	const answers: string[][] = [];
 	for (const [index, tab] of request.questions.entries()) {
 		const tabAnswers = tab.multiple
-			? await askMultiSelect(ui, request, tab, index)
-			: await askSingleSelect(ui, request, tab, index);
-		if (tabAnswers === undefined) return { kind: "cancelled" };
+			? await askMultiSelect(ui, request, tab, index, isSettled)
+			: await askSingleSelect(ui, request, tab, index, isSettled);
+		if (tabAnswers === "abandoned") return { kind: "external" };
+		if (tabAnswers === "cancelled") return { kind: "cancelled" };
 		answers.push(tabAnswers);
 	}
-	return { answers, kind: "answered" };
+	return isSettled() ? { kind: "external" } : { answers, kind: "answered" };
 }
 
 function truncateChars(text: string, max: number): string {
 	return text.length > max ? `${text.slice(0, Math.max(0, max - 1))}…` : text;
 }
 
-function tabTitle(request: QuestionRequest, tab: QuestionTab, index: number): string {
+function tabTitle(request: QuestionRequest, tab: QuestionTab, index: number, note = ""): string {
 	const position = request.questions.length > 1 ? ` (${index + 1}/${request.questions.length})` : "";
-	return truncateChars(`${tab.header}${position}: ${tab.question}`, TITLE_MAX_CHARS);
+	const prefix = note ? `${note} — ` : "";
+	return truncateChars(`${prefix}${tab.header}${position}: ${tab.question}`, TITLE_MAX_CHARS);
 }
 
 function customRowNumber(tab: QuestionTab): number {
@@ -110,29 +124,52 @@ export function formatOptionRows(tab: QuestionTab): string[] {
 	return rows;
 }
 
-async function askCustomText(ui: RpcDialogUI, tab: QuestionTab): Promise<string[] | undefined> {
+// The option list is never truncated as a block: every row (including the
+// custom row, whose number must stay actionable) is individually capped and
+// always present. Only the question text itself is length-limited.
+function multiSelectTitle(request: QuestionRequest, tab: QuestionTab, index: number, note: string): string {
+	return [tabTitle(request, tab, index, note), ...formatOptionRows(tab)].join("\n");
+}
+
+async function askCustomText(ui: RpcDialogUI, tab: QuestionTab, isSettled: () => boolean): Promise<string | "blank" | "cancelled" | "abandoned"> {
+	if (isSettled()) return "abandoned";
 	const text = await ui.input(truncateChars(`${tab.header}: ${tab.customLabel}`, TITLE_MAX_CHARS), tab.customPlaceholder);
-	if (text === undefined) return undefined;
+	if (isSettled()) return "abandoned";
+	if (text === undefined) return "cancelled";
 	const trimmed = text.trim();
-	return trimmed ? [trimmed] : [];
+	return trimmed || "blank";
 }
 
-async function askSingleSelect(ui: RpcDialogUI, request: QuestionRequest, tab: QuestionTab, index: number): Promise<string[] | undefined> {
+async function askSingleSelect(ui: RpcDialogUI, request: QuestionRequest, tab: QuestionTab, index: number, isSettled: () => boolean): Promise<StepResult> {
 	const rows = formatOptionRows(tab);
-	const choice = await ui.select(tabTitle(request, tab, index), rows);
-	if (choice === undefined) return undefined;
-	const rowIndex = rows.indexOf(choice);
-	if (rowIndex === -1) {
-		// Host returned something other than a listed row: treat non-empty text
-		// as a custom answer, matching the always-available free-text fallback.
-		const trimmed = choice.trim();
-		return trimmed ? [trimmed] : [];
+	let note = "";
+	for (let attempt = 0; attempt < MAX_PROMPT_ATTEMPTS; attempt += 1) {
+		if (isSettled()) return "abandoned";
+		const choice = await ui.select(tabTitle(request, tab, index, note), rows);
+		if (isSettled()) return "abandoned";
+		if (choice === undefined) return "cancelled";
+		const rowIndex = rows.indexOf(choice);
+		if (rowIndex === -1) {
+			// Host returned something other than a listed row: treat non-empty
+			// text as a custom answer, matching the free-text fallback row.
+			const trimmed = choice.trim();
+			if (trimmed) return [trimmed];
+			note = "Answer cannot be empty";
+			continue;
+		}
+		if (rowIndex < tab.options.length) return [tab.options[rowIndex].label];
+		const custom = await askCustomText(ui, tab, isSettled);
+		if (custom === "abandoned" || custom === "cancelled") return custom;
+		if (custom === "blank") {
+			note = "Custom answer cannot be empty";
+			continue;
+		}
+		return [custom];
 	}
-	if (rowIndex >= tab.options.length) return askCustomText(ui, tab);
-	return [tab.options[rowIndex].label];
+	return "cancelled";
 }
 
-export function parseMultiSelection(raw: string, tab: QuestionTab): { labels: string[]; wantsCustom: boolean } {
+export function parseMultiSelection(raw: string, tab: QuestionTab): { labels: string[]; wantsCustom: boolean } | { error: string } {
 	const trimmed = raw.trim();
 	if (!trimmed) return { labels: [], wantsCustom: false };
 	const tokens = trimmed.split(/[\s,]+/).filter(Boolean);
@@ -144,24 +181,40 @@ export function parseMultiSelection(raw: string, tab: QuestionTab): { labels: st
 	let wantsCustom = false;
 	for (const token of tokens) {
 		const row = Number(token);
-		if (row >= 1 && row <= tab.options.length) {
+		if (row < 1 || row > customRowNumber(tab)) {
+			return { error: `Option numbers must be between 1 and ${customRowNumber(tab)}` };
+		}
+		if (row <= tab.options.length) {
 			const label = tab.options[row - 1].label;
 			if (!labels.includes(label)) labels.push(label);
-		} else if (row === customRowNumber(tab)) {
+		} else {
 			wantsCustom = true;
 		}
 	}
 	return { labels, wantsCustom };
 }
 
-async function askMultiSelect(ui: RpcDialogUI, request: QuestionRequest, tab: QuestionTab, index: number): Promise<string[] | undefined> {
-	const title = truncateChars(`${tabTitle(request, tab, index)}\n${formatOptionRows(tab).join("\n")}`, TITLE_MAX_CHARS);
+async function askMultiSelect(ui: RpcDialogUI, request: QuestionRequest, tab: QuestionTab, index: number, isSettled: () => boolean): Promise<StepResult> {
 	const placeholder = `Comma-separated numbers (e.g. 1,3); ${customRowNumber(tab)} or free text for a custom answer`;
-	const raw = await ui.input(title, placeholder);
-	if (raw === undefined) return undefined;
-	const { labels, wantsCustom } = parseMultiSelection(raw, tab);
-	if (!wantsCustom) return labels;
-	const custom = await askCustomText(ui, tab);
-	if (custom === undefined) return undefined;
-	return [...labels, ...custom.filter((answer) => !labels.includes(answer))];
+	let note = "";
+	for (let attempt = 0; attempt < MAX_PROMPT_ATTEMPTS; attempt += 1) {
+		if (isSettled()) return "abandoned";
+		const raw = await ui.input(multiSelectTitle(request, tab, index, note), placeholder);
+		if (isSettled()) return "abandoned";
+		if (raw === undefined) return "cancelled";
+		const parsed = parseMultiSelection(raw, tab);
+		if ("error" in parsed) {
+			note = parsed.error;
+			continue;
+		}
+		if (!parsed.wantsCustom) return parsed.labels;
+		const custom = await askCustomText(ui, tab, isSettled);
+		if (custom === "abandoned" || custom === "cancelled") return custom;
+		if (custom === "blank") {
+			note = "Custom answer cannot be empty";
+			continue;
+		}
+		return parsed.labels.includes(custom) ? parsed.labels : [...parsed.labels, custom];
+	}
+	return "cancelled";
 }

--- a/pi-extensions/pi-questions/extensions/rpc-fallback.ts
+++ b/pi-extensions/pi-questions/extensions/rpc-fallback.ts
@@ -1,0 +1,167 @@
+import type { QuestionRequest, QuestionTab } from "./question-model.js";
+
+// RPC hosts (Paseo, pi-web, VS Code bridges) cannot render ctx.ui.custom()
+// components; they bridge Pi's standard dialog methods instead. This module
+// walks a question request sequentially through native select()/input()
+// dialogs and reproduces the QuestionResult answers shape of the custom TUI.
+// Trade-offs versus the TUI: no tabbed review step, and multi-select is a
+// free-text numbers input instead of checkbox rows.
+
+const TITLE_MAX_CHARS = 600;
+const ROW_MAX_CHARS = 200;
+
+export interface RpcDialogUI {
+	select(title: string, options: string[]): Promise<string | undefined>;
+	input(title: string, placeholder?: string): Promise<string | undefined>;
+}
+
+export type PresentOutcome =
+	| { kind: "answered"; answers: string[][] }
+	| { kind: "cancelled" }
+	| { kind: "unavailable"; error: string }
+	| { kind: "external" };
+
+export interface QuestionHost {
+	rpcMode: boolean;
+	hasUI: boolean;
+	dialogs: RpcDialogUI | undefined;
+	/** Opens the custom TUI questionnaire; resolves with ctx.ui.custom()'s result. */
+	openCustom?: () => Promise<unknown>;
+	/** Whether the pending question was already completed elsewhere (bridge/API reply). */
+	isSettled: () => boolean;
+}
+
+export function isRpcMode(ctx: unknown): boolean {
+	return typeof ctx === "object" && ctx !== null && (ctx as { mode?: unknown }).mode === "rpc";
+}
+
+export function rpcDialogUI(ui: unknown): RpcDialogUI | undefined {
+	if (!ui || typeof ui !== "object") return undefined;
+	const candidate = ui as { select?: unknown; input?: unknown };
+	if (typeof candidate.select !== "function" || typeof candidate.input !== "function") return undefined;
+	return ui as RpcDialogUI;
+}
+
+export function noDialogRouteError(rpcMode: boolean): string {
+	return rpcMode
+		? "No question UI available: this RPC host renders neither custom TUI components nor native select/input dialogs"
+		: "No question UI available: custom TUI resolved without a result and the host provides no native select/input dialogs";
+}
+
+/**
+ * Route a question request to the best available UI.
+ *
+ * Returns undefined when no UI route applies and the request should stay
+ * pending for bridge/API replies (the pre-fallback behavior for headless
+ * contexts). All other outcomes are terminal and the caller must complete
+ * the pending request with them.
+ */
+export async function presentQuestion(request: QuestionRequest, host: QuestionHost): Promise<PresentOutcome | undefined> {
+	if (host.rpcMode) {
+		if (!host.dialogs) return { error: noDialogRouteError(true), kind: "unavailable" };
+		return runRpcQuestionnaire(host.dialogs, request);
+	}
+	if (host.hasUI && host.openCustom) {
+		const uiResult = await host.openCustom();
+		if (host.isSettled()) return { kind: "external" };
+		if (uiResult !== undefined) return { kind: "external" };
+		// custom() resolved undefined without completing the request: the host
+		// accepted the call but cannot render the component. Fall back.
+		if (!host.dialogs) return { error: noDialogRouteError(false), kind: "unavailable" };
+		return runRpcQuestionnaire(host.dialogs, request);
+	}
+	return undefined;
+}
+
+export async function runRpcQuestionnaire(
+	ui: RpcDialogUI,
+	request: QuestionRequest,
+): Promise<{ kind: "answered"; answers: string[][] } | { kind: "cancelled" }> {
+	const answers: string[][] = [];
+	for (const [index, tab] of request.questions.entries()) {
+		const tabAnswers = tab.multiple
+			? await askMultiSelect(ui, request, tab, index)
+			: await askSingleSelect(ui, request, tab, index);
+		if (tabAnswers === undefined) return { kind: "cancelled" };
+		answers.push(tabAnswers);
+	}
+	return { answers, kind: "answered" };
+}
+
+function truncateChars(text: string, max: number): string {
+	return text.length > max ? `${text.slice(0, Math.max(0, max - 1))}…` : text;
+}
+
+function tabTitle(request: QuestionRequest, tab: QuestionTab, index: number): string {
+	const position = request.questions.length > 1 ? ` (${index + 1}/${request.questions.length})` : "";
+	return truncateChars(`${tab.header}${position}: ${tab.question}`, TITLE_MAX_CHARS);
+}
+
+function customRowNumber(tab: QuestionTab): number {
+	return tab.options.length + 1;
+}
+
+export function formatOptionRows(tab: QuestionTab): string[] {
+	const rows = tab.options.map((option, index) => {
+		const description = option.description ? ` — ${option.description}` : "";
+		return truncateChars(`${index + 1}. ${option.label}${description}`, ROW_MAX_CHARS);
+	});
+	rows.push(truncateChars(`${customRowNumber(tab)}. ${tab.customLabel} (type your own answer)`, ROW_MAX_CHARS));
+	return rows;
+}
+
+async function askCustomText(ui: RpcDialogUI, tab: QuestionTab): Promise<string[] | undefined> {
+	const text = await ui.input(truncateChars(`${tab.header}: ${tab.customLabel}`, TITLE_MAX_CHARS), tab.customPlaceholder);
+	if (text === undefined) return undefined;
+	const trimmed = text.trim();
+	return trimmed ? [trimmed] : [];
+}
+
+async function askSingleSelect(ui: RpcDialogUI, request: QuestionRequest, tab: QuestionTab, index: number): Promise<string[] | undefined> {
+	const rows = formatOptionRows(tab);
+	const choice = await ui.select(tabTitle(request, tab, index), rows);
+	if (choice === undefined) return undefined;
+	const rowIndex = rows.indexOf(choice);
+	if (rowIndex === -1) {
+		// Host returned something other than a listed row: treat non-empty text
+		// as a custom answer, matching the always-available free-text fallback.
+		const trimmed = choice.trim();
+		return trimmed ? [trimmed] : [];
+	}
+	if (rowIndex >= tab.options.length) return askCustomText(ui, tab);
+	return [tab.options[rowIndex].label];
+}
+
+export function parseMultiSelection(raw: string, tab: QuestionTab): { labels: string[]; wantsCustom: boolean } {
+	const trimmed = raw.trim();
+	if (!trimmed) return { labels: [], wantsCustom: false };
+	const tokens = trimmed.split(/[\s,]+/).filter(Boolean);
+	if (!tokens.every((token) => /^\d+$/.test(token))) {
+		// Any non-numeric input is a whole free-text custom answer.
+		return { labels: [trimmed], wantsCustom: false };
+	}
+	const labels: string[] = [];
+	let wantsCustom = false;
+	for (const token of tokens) {
+		const row = Number(token);
+		if (row >= 1 && row <= tab.options.length) {
+			const label = tab.options[row - 1].label;
+			if (!labels.includes(label)) labels.push(label);
+		} else if (row === customRowNumber(tab)) {
+			wantsCustom = true;
+		}
+	}
+	return { labels, wantsCustom };
+}
+
+async function askMultiSelect(ui: RpcDialogUI, request: QuestionRequest, tab: QuestionTab, index: number): Promise<string[] | undefined> {
+	const title = truncateChars(`${tabTitle(request, tab, index)}\n${formatOptionRows(tab).join("\n")}`, TITLE_MAX_CHARS);
+	const placeholder = `Comma-separated numbers (e.g. 1,3); ${customRowNumber(tab)} or free text for a custom answer`;
+	const raw = await ui.input(title, placeholder);
+	if (raw === undefined) return undefined;
+	const { labels, wantsCustom } = parseMultiSelection(raw, tab);
+	if (!wantsCustom) return labels;
+	const custom = await askCustomText(ui, tab);
+	if (custom === undefined) return undefined;
+	return [...labels, ...custom.filter((answer) => !labels.includes(answer))];
+}

--- a/pi-extensions/pi-questions/extensions/rpc-fallback.ts
+++ b/pi-extensions/pi-questions/extensions/rpc-fallback.ts
@@ -144,6 +144,15 @@ function multiSelectTitle(request: QuestionRequest, tab: QuestionTab, index: num
 	return [tabTitle(request, tab, index, note), ...formatOptionRows(tab)].join("\n");
 }
 
+// Mirrors the TUI's empty-selection contract: the custom TUI can submit an
+// empty single-select answer only through its synthetic confirm tab, which
+// exists exactly when the request has multiple questions or any multi-select
+// tab (hasConfirmTab in questions.ts). Single-question single-select requests
+// cannot submit empty there, so the walker offers no skip row for them either.
+function allowsEmptySelection(request: QuestionRequest): boolean {
+	return request.questions.length > 1 || request.questions.some((question) => question.multiple);
+}
+
 async function askCustomText(ui: RpcDialogUI, tab: QuestionTab, isSettled: () => boolean): Promise<CustomTextResult> {
 	if (isSettled()) return { kind: "abandoned" };
 	const text = await ui.input(truncateChars(`${tab.header}: ${tab.customLabel}`, TITLE_MAX_CHARS), tab.customPlaceholder);
@@ -155,12 +164,15 @@ async function askCustomText(ui: RpcDialogUI, tab: QuestionTab, isSettled: () =>
 
 async function askSingleSelect(ui: RpcDialogUI, request: QuestionRequest, tab: QuestionTab, index: number, isSettled: () => boolean): Promise<StepResult> {
 	const rows = formatOptionRows(tab);
+	const skipRow = allowsEmptySelection(request) ? `${customRowNumber(tab) + 1}. Skip (no selection)` : undefined;
+	if (skipRow) rows.push(skipRow);
 	let note = "";
 	for (let attempt = 0; attempt < MAX_PROMPT_ATTEMPTS; attempt += 1) {
 		if (isSettled()) return { kind: "abandoned" };
 		const choice = await ui.select(tabTitle(request, tab, index, note), rows);
 		if (isSettled()) return { kind: "abandoned" };
 		if (choice === undefined) return { kind: "cancelled" };
+		if (skipRow && choice === skipRow) return { kind: "answers", values: [] };
 		const rowIndex = rows.indexOf(choice);
 		if (rowIndex === -1) {
 			// Host returned something other than a listed row: treat non-empty
@@ -208,7 +220,7 @@ export function parseMultiSelection(raw: string, tab: QuestionTab): { labels: st
 }
 
 async function askMultiSelect(ui: RpcDialogUI, request: QuestionRequest, tab: QuestionTab, index: number, isSettled: () => boolean): Promise<StepResult> {
-	const placeholder = `Comma-separated numbers (e.g. 1,3); ${customRowNumber(tab)} or free text for a custom answer`;
+	const placeholder = `Comma-separated numbers (e.g. 1,3); ${customRowNumber(tab)} or free text for a custom answer; empty for no selection`;
 	let note = "";
 	for (let attempt = 0; attempt < MAX_PROMPT_ATTEMPTS; attempt += 1) {
 		if (isSettled()) return { kind: "abandoned" };

--- a/pi-extensions/pi-questions/extensions/rpc-fallback.ts
+++ b/pi-extensions/pi-questions/extensions/rpc-fallback.ts
@@ -26,10 +26,23 @@ export type PresentOutcome =
 
 export type WalkOutcome = Extract<PresentOutcome, { kind: "answered" | "cancelled" | "external" }>;
 
-// Per-question step results: an answers array, or a marker. "cancelled" is a
-// user dismissal; "abandoned" means the request settled elsewhere (bridge
-// reply, rejection, shutdown) and the walker must stop silently.
-type StepResult = string[] | "cancelled" | "abandoned";
+// Per-question step results. Discriminated objects, never bare strings: a
+// custom answer whose text happens to be "cancelled" or "abandoned" must stay
+// a valid answer, not a control state. "cancelled" is a user dismissal;
+// "abandoned" means the request settled elsewhere (bridge reply, rejection,
+// shutdown) and the walker must stop silently.
+type StepResult =
+	| { kind: "answers"; values: string[] }
+	| { kind: "cancelled" }
+	| { kind: "abandoned" };
+
+// Custom-text dialog results; "blank" sends the caller back to re-show the
+// question rather than submitting an empty answer.
+type CustomTextResult =
+	| { kind: "text"; value: string }
+	| { kind: "blank" }
+	| { kind: "cancelled" }
+	| { kind: "abandoned" };
 
 export interface QuestionHost {
 	rpcMode: boolean;
@@ -91,12 +104,12 @@ export async function runRpcQuestionnaire(
 ): Promise<WalkOutcome> {
 	const answers: string[][] = [];
 	for (const [index, tab] of request.questions.entries()) {
-		const tabAnswers = tab.multiple
+		const step = tab.multiple
 			? await askMultiSelect(ui, request, tab, index, isSettled)
 			: await askSingleSelect(ui, request, tab, index, isSettled);
-		if (tabAnswers === "abandoned") return { kind: "external" };
-		if (tabAnswers === "cancelled") return { kind: "cancelled" };
-		answers.push(tabAnswers);
+		if (step.kind === "abandoned") return { kind: "external" };
+		if (step.kind === "cancelled") return { kind: "cancelled" };
+		answers.push(step.values);
 	}
 	return isSettled() ? { kind: "external" } : { answers, kind: "answered" };
 }
@@ -131,42 +144,42 @@ function multiSelectTitle(request: QuestionRequest, tab: QuestionTab, index: num
 	return [tabTitle(request, tab, index, note), ...formatOptionRows(tab)].join("\n");
 }
 
-async function askCustomText(ui: RpcDialogUI, tab: QuestionTab, isSettled: () => boolean): Promise<string | "blank" | "cancelled" | "abandoned"> {
-	if (isSettled()) return "abandoned";
+async function askCustomText(ui: RpcDialogUI, tab: QuestionTab, isSettled: () => boolean): Promise<CustomTextResult> {
+	if (isSettled()) return { kind: "abandoned" };
 	const text = await ui.input(truncateChars(`${tab.header}: ${tab.customLabel}`, TITLE_MAX_CHARS), tab.customPlaceholder);
-	if (isSettled()) return "abandoned";
-	if (text === undefined) return "cancelled";
+	if (isSettled()) return { kind: "abandoned" };
+	if (text === undefined) return { kind: "cancelled" };
 	const trimmed = text.trim();
-	return trimmed || "blank";
+	return trimmed ? { kind: "text", value: trimmed } : { kind: "blank" };
 }
 
 async function askSingleSelect(ui: RpcDialogUI, request: QuestionRequest, tab: QuestionTab, index: number, isSettled: () => boolean): Promise<StepResult> {
 	const rows = formatOptionRows(tab);
 	let note = "";
 	for (let attempt = 0; attempt < MAX_PROMPT_ATTEMPTS; attempt += 1) {
-		if (isSettled()) return "abandoned";
+		if (isSettled()) return { kind: "abandoned" };
 		const choice = await ui.select(tabTitle(request, tab, index, note), rows);
-		if (isSettled()) return "abandoned";
-		if (choice === undefined) return "cancelled";
+		if (isSettled()) return { kind: "abandoned" };
+		if (choice === undefined) return { kind: "cancelled" };
 		const rowIndex = rows.indexOf(choice);
 		if (rowIndex === -1) {
 			// Host returned something other than a listed row: treat non-empty
 			// text as a custom answer, matching the free-text fallback row.
 			const trimmed = choice.trim();
-			if (trimmed) return [trimmed];
+			if (trimmed) return { kind: "answers", values: [trimmed] };
 			note = "Answer cannot be empty";
 			continue;
 		}
-		if (rowIndex < tab.options.length) return [tab.options[rowIndex].label];
+		if (rowIndex < tab.options.length) return { kind: "answers", values: [tab.options[rowIndex].label] };
 		const custom = await askCustomText(ui, tab, isSettled);
-		if (custom === "abandoned" || custom === "cancelled") return custom;
-		if (custom === "blank") {
+		if (custom.kind === "abandoned" || custom.kind === "cancelled") return { kind: custom.kind };
+		if (custom.kind === "blank") {
 			note = "Custom answer cannot be empty";
 			continue;
 		}
-		return [custom];
+		return { kind: "answers", values: [custom.value] };
 	}
-	return "cancelled";
+	return { kind: "cancelled" };
 }
 
 export function parseMultiSelection(raw: string, tab: QuestionTab): { labels: string[]; wantsCustom: boolean } | { error: string } {
@@ -198,23 +211,23 @@ async function askMultiSelect(ui: RpcDialogUI, request: QuestionRequest, tab: Qu
 	const placeholder = `Comma-separated numbers (e.g. 1,3); ${customRowNumber(tab)} or free text for a custom answer`;
 	let note = "";
 	for (let attempt = 0; attempt < MAX_PROMPT_ATTEMPTS; attempt += 1) {
-		if (isSettled()) return "abandoned";
+		if (isSettled()) return { kind: "abandoned" };
 		const raw = await ui.input(multiSelectTitle(request, tab, index, note), placeholder);
-		if (isSettled()) return "abandoned";
-		if (raw === undefined) return "cancelled";
+		if (isSettled()) return { kind: "abandoned" };
+		if (raw === undefined) return { kind: "cancelled" };
 		const parsed = parseMultiSelection(raw, tab);
 		if ("error" in parsed) {
 			note = parsed.error;
 			continue;
 		}
-		if (!parsed.wantsCustom) return parsed.labels;
+		if (!parsed.wantsCustom) return { kind: "answers", values: parsed.labels };
 		const custom = await askCustomText(ui, tab, isSettled);
-		if (custom === "abandoned" || custom === "cancelled") return custom;
-		if (custom === "blank") {
+		if (custom.kind === "abandoned" || custom.kind === "cancelled") return { kind: custom.kind };
+		if (custom.kind === "blank") {
 			note = "Custom answer cannot be empty";
 			continue;
 		}
-		return parsed.labels.includes(custom) ? parsed.labels : [...parsed.labels, custom];
+		return { kind: "answers", values: parsed.labels.includes(custom.value) ? parsed.labels : [...parsed.labels, custom.value] };
 	}
-	return "cancelled";
+	return { kind: "cancelled" };
 }

--- a/pi-extensions/pi-questions/package.json
+++ b/pi-extensions/pi-questions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vanillagreen/pi-questions",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Pi extension for structured multi-tab inline questions and bridge-driven replies.",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
Fixes #1237 / VST-226 (external request). RPC hosts (Paseo, pi-web, VS Code bridges) cannot render `ctx.ui.custom()`, leaving questionnaires unanswerable there.

- New dependency-free `rpc-fallback.ts`: `ctx.mode === "rpc"` (or `custom()` resolving undefined) routes to a sequential walker over native `select()`/`input()` dialogs — single-select, multi-select (comma-separated numbers), custom text; `QuestionResult` shape unchanged; cancellation completes the pending request.
- Hardened per cross-model review: settle-checks around every dialog step with object-identity completion (a stale walker can never delete a newer request reusing the id); blank custom input and out-of-range numbers re-prompt with a note (bounded, 5 attempts, then cancel — never a false answered); option rows are never truncated away; clear error when neither UI route exists.
- Discovered en route: pi-questions tests were never wired into CI (skill-tests.yml runs explicit per-package steps) — added the suite step, dependency-free by design.
- README RPC section, CHANGELOG 1.6.0, version bump per package policy.

Evidence: bun test 46/0 (mutation-checked on the settle guards); tsc strict adds zero errors vs HEAD. Pre-existing repo-wide package-policy red filed separately as #1244.

https://claude.ai/code/session_01L7fubfyViYcy7zUNL6uLPf