### PR TITLE
fix(github): git-diff-summary reads declaration sites for cfg(test)-gated siblings

### DIFF
--- a/skills/github/DEVELOPMENT.md
+++ b/skills/github/DEVELOPMENT.md
@@ -17,3 +17,43 @@
 3. Add a `show_help()` function
 4. Add the command to the case statement in `scripts/github.sh`
 5. Update the Commands table in `SKILL.md`
+
+## Declaration-site test scoping (`git-diff-summary`)
+
+A `.rs` file with no file-local test marker can still be test-only when its
+gate lives at the declaration site in the declaring module. Classification
+therefore reads the modules that could declare the file, on the diff's new
+side: `HEAD` for a `base...HEAD` diff, the index for `--staged`, the worktree
+for `--head` — tracked files only, so an untracked file never reclassifies a
+tracked change. Every `.rs` file in the candidate's own directory and its
+ancestor directories is scanned once, emitting candidate-agnostic route
+records that the per-candidate evaluator filters afterwards.
+
+**Lexing.** Source is masked before matching: line-comment precedence, nested
+block comments, and the contents of string, raw-string, byte/C-string and
+char literals blanked, so quoted braces, `//` and `/*` cannot corrupt
+structure. Item matching runs on the mask and values are read from the
+original at the same offsets. A leading UTF-8 BOM and a crate shebang are
+first-line preambles, dropped ahead of the first item.
+
+**Routes.** A route is a `mod` declaration or an `include!` of the target,
+each carrying its own attribute gate. Bare `mod name;` emits both legal forms
+(`name.rs` and `name/mod.rs`) and resolves in the declaring file's module
+directory — its own directory for `mod.rs`/`lib.rs`/`main.rs`, its directory
+plus its file stem otherwise. `#[path]` values and `include!` literals
+resolve in the containing file's directory, per the Rust reference. Targets
+are lexically normalized so equivalent spellings compare equal. `include!` is
+evaluated at the invocation site for every delimiter form, and only when its
+argument IS a direct string literal.
+
+**Skip regions.** Braced bodies — inline modules, `macro_rules!` definitions,
+macro invocations, and fn/impl/struct bodies — emit no records at all, and
+nested macro token trees are jumped over rather than scanned, so an
+`include!` that Rust never expands fabricates nothing.
+
+**Verdict.** A candidate whose every found route is `#[cfg(test)]`-gated is
+test scope. Any ungated route, no route found, a `bin/` segment or
+`lib.rs`/`main.rs` crate root, or a read failure keeps the file-local
+classification: every shape the scanner cannot resolve fails toward no
+record rather than a guessed one. The residual limits of this model are
+enumerated in the `git-diff-summary` header.

--- a/skills/github/DEVELOPMENT.md
+++ b/skills/github/DEVELOPMENT.md
@@ -53,7 +53,8 @@ nested macro token trees are jumped over rather than scanned, so an
 
 **Verdict.** A candidate whose every found route is `#[cfg(test)]`-gated is
 test scope. Any ungated route, no route found, a `bin/` segment or
-`lib.rs`/`main.rs` crate root, or a read failure keeps the file-local
-classification: every shape the scanner cannot resolve fails toward no
+`lib.rs`/`main.rs` crate root, or a read failure — including a symlinked
+declaring module, whose blob is link text rather than source — keeps the
+file-local classification: every shape the scanner cannot resolve fails toward no
 record rather than a guessed one. The residual limits of this model are
 enumerated in the `git-diff-summary` header.

--- a/skills/github/README.md
+++ b/skills/github/README.md
@@ -119,30 +119,14 @@ informational `test_panic_path_added` flag instead: a test assertion is not a
 production panic path, so `refix-route` treats that flag as non-risk and the
 round falls through to blockers/size/small handling.
 
-A file with no file-local test marker is still test-only when the gate lives
-at its declaration site — `#[cfg(test)] #[path = "..."] mod x;` in the
-declaring module, the shared-test-fixture shape. `git-diff-summary` resolves
-that by reading declaring modules on the diff's new side (HEAD for a
-`base...HEAD` diff, the index for `--staged`, the worktree for `--head`,
-tracked files only): every `.rs` file in the candidate's directory and its
-ancestor directories is scanned once with comment- and string-aware
-lexing (line-comment precedence, nested block comments, string/char
-literal contents masked so quoted braces or `//` cannot corrupt parsing),
-and each `mod` declaration — bare (`name.rs` and `name/mod.rs` forms,
-raw identifiers accepted) or `#[path]` — plus each `include!` whose
-argument is a direct string literal is resolved to a lexically
-normalized repo-relative target; bare
-`mod name;` declarations resolve in the declaring file's module directory —
-its own directory for `mod.rs`/`lib.rs`/`main.rs`, its directory plus its
-file stem otherwise — while `#[path]` values (plain or raw strings) and
-`include!` literals resolve in the containing file's directory, per the
-Rust reference; declarations inside braced bodies (inline modules, macro
-definitions and invocations, fn and other item bodies) are skipped
-entirely. A candidate whose every matching route is
-`#[cfg(test)]`-gated classifies as test; anything else keeps production
-classification — an ungated declaration or `include!` of the file, no route
-found, a `bin/` or `lib.rs`/`main.rs` crate root, or an unreadable
-declaring module (read failures fail closed).
+A file carrying no test marker of its own is still treated as a test surface
+when the gate lives at its declaration site — the shared-fixture shape
+`#[cfg(test)] #[path = "..."] mod x;` in the module that declares it — so
+panics added to such a file also emit `test_panic_path_added`. A file
+declared or `include!`d anywhere without the gate, one whose declaration is
+not found, and a crate root all keep their file-local classification, as does
+any file whose declaring module cannot be read. See
+[DEVELOPMENT.md](./DEVELOPMENT.md) for how declarations are resolved.
 
 ## Verification (pr-cross-check --verify)
 

--- a/skills/github/README.md
+++ b/skills/github/README.md
@@ -122,15 +122,19 @@ round falls through to blockers/size/small handling.
 A file with no file-local test marker is still test-only when the gate lives
 at its declaration site — `#[cfg(test)] #[path = "..."] mod x;` in the
 declaring module, the shared-test-fixture shape. `git-diff-summary` resolves
-that by reading the modules that could declare the file on the diff's new
-side (HEAD for a `base...HEAD` diff, the index for `--staged`, the worktree
-for `--head`, tracked files only): same-directory siblings for `#[path]`
-declarations, plus `mod.rs`/`lib.rs`/`main.rs` and the 2018-style parent
-file for bare `mod name;` declarations, with block comments skipped. A file
-whose every found declaration is `#[cfg(test)]`-gated classifies as test;
-anything else keeps production classification — an ungated declaration or
-`include!` of the file, no declaration found, a `bin/` crate-root path, or
-an unreadable declaring module (read failures fail closed).
+that by reading declaring modules on the diff's new side (HEAD for a
+`base...HEAD` diff, the index for `--staged`, the worktree for `--head`,
+tracked files only): every `.rs` file in the candidate's directory and its
+ancestor directories is scanned once, comments stripped (line-comment
+precedence, nested block comments), and each `mod` declaration — bare
+(`name.rs` and `name/mod.rs` forms) or `#[path]` — plus each `include!`
+call is resolved to a lexically normalized repo-relative target; `mod`
+declarations resolve in the declaring module's directory, `include!` in the
+containing file's. A candidate whose every matching route is
+`#[cfg(test)]`-gated classifies as test; anything else keeps production
+classification — an ungated declaration or `include!` of the file, no route
+found, a `bin/` or `lib.rs`/`main.rs` crate root, or an unreadable
+declaring module (read failures fail closed).
 
 ## Verification (pr-cross-check --verify)
 

--- a/skills/github/README.md
+++ b/skills/github/README.md
@@ -117,7 +117,7 @@ surface — `#[cfg(test)]` modules (found by brace-tracking the block the
 attribute opens), `tests/` dirs, or `*_tests.rs` files — emit the distinct
 informational `test_panic_path_added` flag instead: a test assertion is not a
 production panic path, so `refix-route` treats that flag as non-risk and the
-round falls through to blockers/size/small handling (vstack#944).
+round falls through to blockers/size/small handling.
 
 A file with no file-local test marker is still test-only when the gate lives
 at its declaration site — `#[cfg(test)] #[path = "..."] mod x;` in the
@@ -130,7 +130,7 @@ file for bare `mod name;` declarations, with block comments skipped. A file
 whose every found declaration is `#[cfg(test)]`-gated classifies as test;
 anything else keeps production classification — an ungated declaration or
 `include!` of the file, no declaration found, a `bin/` crate-root path, or
-an unreadable declaring module (read failures fail closed) (vstack#1217).
+an unreadable declaring module (read failures fail closed).
 
 ## Verification (pr-cross-check --verify)
 

--- a/skills/github/README.md
+++ b/skills/github/README.md
@@ -131,10 +131,10 @@ precedence, nested block comments), and each `mod` declaration — bare
 call is resolved to a lexically normalized repo-relative target; bare
 `mod name;` declarations resolve in the declaring file's module directory —
 its own directory for `mod.rs`/`lib.rs`/`main.rs`, its directory plus its
-file stem otherwise — while `#[path]` values (plain or `r"..."` raw
-strings) and `include!` literals resolve in the containing file's
-directory, per the Rust reference. A candidate whose every matching route
-is
+file stem otherwise — while `#[path]` values (plain or raw strings) and
+`include!` literals resolve in the containing file's directory, per the
+Rust reference; declarations inside inline module blocks are skipped
+entirely. A candidate whose every matching route is
 `#[cfg(test)]`-gated classifies as test; anything else keeps production
 classification — an ungated declaration or `include!` of the file, no route
 found, a `bin/` or `lib.rs`/`main.rs` crate root, or an unreadable

--- a/skills/github/README.md
+++ b/skills/github/README.md
@@ -128,11 +128,13 @@ tracked files only): every `.rs` file in the candidate's directory and its
 ancestor directories is scanned once, comments stripped (line-comment
 precedence, nested block comments), and each `mod` declaration — bare
 (`name.rs` and `name/mod.rs` forms) or `#[path]` — plus each `include!`
-call is resolved to a lexically normalized repo-relative target; `mod` and
-`#[path]` declarations resolve in the declaring file's module directory —
+call is resolved to a lexically normalized repo-relative target; bare
+`mod name;` declarations resolve in the declaring file's module directory —
 its own directory for `mod.rs`/`lib.rs`/`main.rs`, its directory plus its
-file stem otherwise — while `include!` resolves in the containing file's
-directory. A candidate whose every matching route is
+file stem otherwise — while `#[path]` values (plain or `r"..."` raw
+strings) and `include!` literals resolve in the containing file's
+directory, per the Rust reference. A candidate whose every matching route
+is
 `#[cfg(test)]`-gated classifies as test; anything else keeps production
 classification — an ungated declaration or `include!` of the file, no route
 found, a `bin/` or `lib.rs`/`main.rs` crate root, or an unreadable

--- a/skills/github/README.md
+++ b/skills/github/README.md
@@ -136,7 +136,8 @@ normalized repo-relative target; bare
 its own directory for `mod.rs`/`lib.rs`/`main.rs`, its directory plus its
 file stem otherwise — while `#[path]` values (plain or raw strings) and
 `include!` literals resolve in the containing file's directory, per the
-Rust reference; declarations inside inline module blocks are skipped
+Rust reference; declarations inside braced bodies (inline modules, macro
+definitions and invocations, fn and other item bodies) are skipped
 entirely. A candidate whose every matching route is
 `#[cfg(test)]`-gated classifies as test; anything else keeps production
 classification — an ungated declaration or `include!` of the file, no route

--- a/skills/github/README.md
+++ b/skills/github/README.md
@@ -119,6 +119,19 @@ informational `test_panic_path_added` flag instead: a test assertion is not a
 production panic path, so `refix-route` treats that flag as non-risk and the
 round falls through to blockers/size/small handling (vstack#944).
 
+A file with no file-local test marker is still test-only when the gate lives
+at its declaration site — `#[cfg(test)] #[path = "..."] mod x;` in the
+declaring module, the shared-test-fixture shape. `git-diff-summary` resolves
+that by reading the modules that could declare the file on the diff's new
+side (HEAD for a `base...HEAD` diff, the index for `--staged`, the worktree
+for `--head`, tracked files only): same-directory siblings for `#[path]`
+declarations, plus `mod.rs`/`lib.rs`/`main.rs` and the 2018-style parent
+file for bare `mod name;` declarations, with block comments skipped. A file
+whose every found declaration is `#[cfg(test)]`-gated classifies as test;
+anything else keeps production classification — an ungated declaration or
+`include!` of the file, no declaration found, a `bin/` crate-root path, or
+an unreadable declaring module (read failures fail closed) (vstack#1217).
+
 ## Verification (pr-cross-check --verify)
 
 `verify-lib.sh` auto-detects the build system. Override order:

--- a/skills/github/README.md
+++ b/skills/github/README.md
@@ -128,9 +128,11 @@ tracked files only): every `.rs` file in the candidate's directory and its
 ancestor directories is scanned once, comments stripped (line-comment
 precedence, nested block comments), and each `mod` declaration — bare
 (`name.rs` and `name/mod.rs` forms) or `#[path]` — plus each `include!`
-call is resolved to a lexically normalized repo-relative target; `mod`
-declarations resolve in the declaring module's directory, `include!` in the
-containing file's. A candidate whose every matching route is
+call is resolved to a lexically normalized repo-relative target; `mod` and
+`#[path]` declarations resolve in the declaring file's module directory —
+its own directory for `mod.rs`/`lib.rs`/`main.rs`, its directory plus its
+file stem otherwise — while `include!` resolves in the containing file's
+directory. A candidate whose every matching route is
 `#[cfg(test)]`-gated classifies as test; anything else keeps production
 classification — an ungated declaration or `include!` of the file, no route
 found, a `bin/` or `lib.rs`/`main.rs` crate root, or an unreadable

--- a/skills/github/README.md
+++ b/skills/github/README.md
@@ -125,10 +125,13 @@ declaring module, the shared-test-fixture shape. `git-diff-summary` resolves
 that by reading declaring modules on the diff's new side (HEAD for a
 `base...HEAD` diff, the index for `--staged`, the worktree for `--head`,
 tracked files only): every `.rs` file in the candidate's directory and its
-ancestor directories is scanned once, comments stripped (line-comment
-precedence, nested block comments), and each `mod` declaration — bare
-(`name.rs` and `name/mod.rs` forms) or `#[path]` — plus each `include!`
-call is resolved to a lexically normalized repo-relative target; bare
+ancestor directories is scanned once with comment- and string-aware
+lexing (line-comment precedence, nested block comments, string/char
+literal contents masked so quoted braces or `//` cannot corrupt parsing),
+and each `mod` declaration — bare (`name.rs` and `name/mod.rs` forms,
+raw identifiers accepted) or `#[path]` — plus each `include!` whose
+argument is a direct string literal is resolved to a lexically
+normalized repo-relative target; bare
 `mod name;` declarations resolve in the declaring file's module directory —
 its own directory for `mod.rs`/`lib.rs`/`main.rs`, its directory plus its
 file stem otherwise — while `#[path]` values (plain or raw strings) and

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -110,9 +110,11 @@ insert/delete stats, and `risk_flags`. Rust-specific flags
 docs, and other non-Rust files can discuss those tokens without triggering a
 Rust risk route. Panic patterns (`panic!`/`unwrap()`) added in production
 source emit `panic_path_added`; the same patterns whose enclosing context is
-a test surface (`#[cfg(test)]` modules, `tests/` dirs, `*_tests.rs`) emit
-the distinct informational `test_panic_path_added` flag instead, which
-`refix-route` treats as non-risk.
+a test surface (`#[cfg(test)]` modules, `tests/` dirs, `*_tests.rs`, or
+files reachable only through a `#[cfg(test)]`-gated `mod` declaration in
+their declaring module, including `#[path]` siblings) emit the distinct
+informational `test_panic_path_added` flag instead, which `refix-route`
+treats as non-risk.
 
 ### PR Merge Outcomes
 

--- a/skills/github/scripts/git-diff-summary
+++ b/skills/github/scripts/git-diff-summary
@@ -68,10 +68,11 @@ resolve_default_base() {
 # direct string literal (concat!/env!/consts — even concatenations of
 # literals) emit no record; #[path]/include! declarations living in a
 # directory that is neither the candidate's own nor one of its ancestors
-# are not consulted; declarations inside inline module blocks are skipped
-# outright (no records — never a mis-resolved one); and declarations
-# produced by macro expansion (macro_rules!/proc-macro bodies) are
-# invisible. Every one of these fails toward NO record for the shape, so
+# are not consulted; declarations inside inline module blocks and
+# macro_rules! definition bodies are skipped outright (no records — never
+# a mis-resolved one); and declarations produced by macro EXPANSION
+# (invoking a macro_rules! or proc macro) are invisible by construction.
+# Every one of these fails toward NO record for the shape, so
 # a file that is production-reachable only through one of them while also
 # carrying a #[cfg(test)]-gated declaration still classifies as test —
 # that is the declared trade-off, and the only one.
@@ -179,8 +180,7 @@ scan_decl_records() {
                     else if (c == "\"") { instr = 0; o = o c; m = m c; i++ }
                     else { o = o c; m = m "."; i++ }
                 } else if (instr == 2) {
-                    hs = mkhashes(rawh)
-                    if (c == "\"" && substr(s, i + 1, rawh) == hs) {
+                    if (c == "\"" && substr(s, i + 1, rawh) == rawhs) {
                         o = o substr(s, i, rawh + 1); m = m substr(s, i, rawh + 1)
                         i += rawh + 1; instr = 0
                     } else { o = o c; m = m "."; i++ }
@@ -193,6 +193,10 @@ scan_decl_records() {
                 } else if (c == "r" && (i == 1 || substr(s, i - 1, 1) !~ /[A-Za-z0-9_]/) \
                            && match(substr(s, i), /^r#*"/)) {
                     rawh = RLENGTH - 2
+                    # closing-hash sequence computed once per raw string,
+                    # not per character (raw strings can span lines, so
+                    # rawh/rawhs persist across mask_line calls)
+                    rawhs = mkhashes(rawh)
                     o = o substr(s, i, RLENGTH); m = m substr(s, i, RLENGTH)
                     i += RLENGTH; instr = 2
                 } else if (c == "\047") {
@@ -249,22 +253,24 @@ scan_decl_records() {
             if (buf == "") { buf = ml_orig; mbuf = ml_mask }
             else { buf = buf " " ml_orig; mbuf = mbuf " " ml_mask }
             for (;;) {
-                # Inside an inline module block (mod name { ... }): Rust
-                # resolves nested declarations into the inline chain, which
-                # this scanner does not model — a shape it cannot
-                # faithfully parse must produce NO record, never a
-                # mis-resolved one. Consume by brace depth on the MASK
-                # (quoted braces are invisible), emit nothing.
-                if (inline_depth > 0) {
+                # Inside a skip region (inline module block or macro_rules!
+                # definition body): Rust resolves inline-module contents
+                # into the inline chain and macro token trees only exist
+                # after expansion — neither is a top-level item stream this
+                # scanner can faithfully parse, so it must produce NO
+                # record, never a mis-resolved one. Consume by delimiter
+                # depth on the MASK (quoted delimiters are invisible),
+                # emit nothing.
+                if (skip_depth > 0) {
                     blen = length(mbuf); bi = 1
-                    while (bi <= blen && inline_depth > 0) {
+                    while (bi <= blen && skip_depth > 0) {
                         bc = substr(mbuf, bi, 1)
-                        if (bc == "{") inline_depth++
-                        else if (bc == "}") inline_depth--
+                        if (bc == skip_open) skip_depth++
+                        else if (bc == skip_close) skip_depth--
                         bi++
                     }
                     buf = substr(buf, bi); mbuf = substr(mbuf, bi)
-                    if (inline_depth > 0) { buf = ""; mbuf = ""; break }
+                    if (skip_depth > 0) { buf = ""; mbuf = ""; break }
                     continue
                 }
                 if (match(mbuf, /^[[:space:]]+/)) {
@@ -315,7 +321,18 @@ scan_decl_records() {
                 # attributes, gated or not, apply to the skipped block).
                 if (match(mbuf, /^(pub([(][^)]*[)])?[[:space:]]+)?mod[[:space:]]+(r#)?[A-Za-z_][A-Za-z0-9_]*[[:space:]]*\{/)) {
                     buf = substr(buf, RLENGTH + 1); mbuf = substr(mbuf, RLENGTH + 1)
-                    inline_depth = 1
+                    skip_open = "{"; skip_close = "}"; skip_depth = 1
+                    gated = 0; pathattr = ""
+                    continue
+                }
+                # macro_rules! definition opener: the body is a token tree,
+                # not items — skip it whole. Bodies may use any delimiter
+                # pair; the opener determines which one is depth-tracked.
+                if (match(mbuf, /^macro_rules![[:space:]]*(r#)?[A-Za-z_][A-Za-z0-9_]*[[:space:]]*[([{]/)) {
+                    skip_open = substr(mbuf, RLENGTH, 1)
+                    skip_close = (skip_open == "{") ? "}" : (skip_open == "(" ? ")" : "]")
+                    skip_depth = 1
+                    buf = substr(buf, RLENGTH + 1); mbuf = substr(mbuf, RLENGTH + 1)
                     gated = 0; pathattr = ""
                     continue
                 }

--- a/skills/github/scripts/git-diff-summary
+++ b/skills/github/scripts/git-diff-summary
@@ -119,10 +119,11 @@ new_side_rs_siblings() {
 
 # Emit one candidate-agnostic record per finding in the declaring module on
 # stdin, so a file is parsed once no matter how many candidates consult it:
-#   G<TAB><target>   mod declaration with #[cfg(test)] among its attributes
-#   U<TAB><target>   mod declaration without the gate
-#   I<TAB><target>   include! of the target file (an include compiles in the
-#                    includer's cfg context — an ungated production route)
+#   G<TAB><target>   route with #[cfg(test)] among its attributes
+#   U<TAB><target>   route without the gate
+# A route is a mod declaration or an include! of the target file; both
+# carry their attribute gate (#[cfg(test)] include!("x.rs") is a gated
+# route, an unattributed include an ungated production one).
 # <target> is the repo-relative file the declaration resolves to, lexically
 # normalized (`.`/`..` segments folded) so equivalent spellings compare
 # equal. A bare `mod name;` emits both of its legal forms, name.rs and
@@ -222,13 +223,14 @@ scan_decl_records() {
             }
             ml_orig = o; ml_mask = m
         }
-        # include! routes in one consumed chunk (mc masked, oc original).
-        # Token boundary: a preceding identifier character means a
-        # different macro. The argument must BE a string literal (any
-        # bracket form); a computed expression (concat!/env!/const) emits
-        # nothing — even one whose parts are all literals — per the
-        # fail-closed rule for shapes the scanner cannot evaluate.
-        function emit_includes(mc, oc,   ioff, iq, iap, mrest, orest) {
+        # include! routes in one consumed chunk (mc masked, oc original),
+        # emitted with the chunk item attribute gate (inc_gated). Token
+        # boundary: a preceding identifier character means a different
+        # macro. The argument must BE a string literal (any bracket form);
+        # a computed expression (concat!/env!/const) emits nothing — even
+        # one whose parts are all literals — per the fail-closed rule for
+        # shapes the scanner cannot evaluate.
+        function emit_includes(mc, oc, inc_gated,   ioff, iq, iap, mrest, orest) {
             ioff = 0
             while ((iq = index(substr(mc, ioff + 1), "include!")) > 0) {
                 iap = ioff + iq
@@ -237,7 +239,8 @@ scan_decl_records() {
                     orest = substr(oc, iap)
                     if (match(mrest, /^include![[:space:]]*[([{][[:space:]]*(r#*)?"[^"]*"/) \
                         && match(mrest, /"[^"]*"/))
-                        printf "I\t%s\n", normpath(join(fdir, substr(orest, RSTART + 1, RLENGTH - 2)))
+                        printf "%s\t%s\n", (inc_gated ? "G" : "U"), \
+                            normpath(join(fdir, substr(orest, RSTART + 1, RLENGTH - 2)))
                 }
                 ioff = iap + 7
             }
@@ -336,6 +339,27 @@ scan_decl_records() {
                     gated = 0; pathattr = ""
                     continue
                 }
+                # Macro INVOCATION opener (ident! or path::to::ident! plus
+                # any delimiter): the token tree only becomes items after
+                # expansion, which the scanner does not evaluate — skip it
+                # whole so item-like tokens (`discard! { mod cand; }`)
+                # fabricate nothing. include! is the one macro the scanner
+                # DOES evaluate; it falls through to the chunk scan.
+                if (match(mbuf, /^(r#)?[A-Za-z_][A-Za-z0-9_]*(::(r#)?[A-Za-z_][A-Za-z0-9_]*)*![[:space:]]*[([{]/)) {
+                    mname = substr(mbuf, 1, RLENGTH)
+                    mdelim = substr(mbuf, RLENGTH, 1)
+                    sub(/![[:space:]]*[([{]$/, "", mname)
+                    sub(/^.*::/, "", mname)
+                    sub(/^r#/, "", mname)
+                    if (mname != "include") {
+                        skip_open = mdelim
+                        skip_close = (mdelim == "{") ? "}" : (mdelim == "(" ? ")" : "]")
+                        skip_depth = 1
+                        buf = substr(buf, RLENGTH + 1); mbuf = substr(mbuf, RLENGTH + 1)
+                        gated = 0; pathattr = ""
+                        continue
+                    }
+                }
                 # Any other item: consume to the next boundary (; { or })
                 # on the mask, scanning the chunk for include! routes. A
                 # multiline include! completes when its statement boundary
@@ -345,7 +369,7 @@ scan_decl_records() {
                     mchunk = substr(mbuf, 1, RSTART)
                     ochunk = substr(buf, 1, RSTART)
                     buf = substr(buf, RSTART + 1); mbuf = substr(mbuf, RSTART + 1)
-                    emit_includes(mchunk, ochunk)
+                    emit_includes(mchunk, ochunk, gated)
                     gated = 0; pathattr = ""
                     continue
                 }
@@ -449,7 +473,7 @@ is_cfg_test_declared() {
         $3 == "ERR" { if ($2 in rd) print "err"; next }
         $4 != cand { next }
         $3 == "G" { print "gated"; next }
-        $3 == "U" || $3 == "I" { print "ungated" }
+        $3 == "U" { print "ungated" }
     ')
     case "$routes" in *err*) return 1 ;; esac
     case "$routes" in *ungated*) return 1 ;; esac
@@ -646,6 +670,9 @@ main() {
         split("\n") | map(select(length > 0)) | map(
             capture("^(?<status>[AMDRC])[0-9]*\t(?<path>.+)$") // null
         ) | map(select(. != null)) |
+        # Rename rows carry "old<TAB>new": keep the DESTINATION — it is what
+        # exists on the new side and what scope classification keys on.
+        map(.path = (.path | split("\t") | last)) |
 
         # Classify each file into domain + scope
         map(. + {

--- a/skills/github/scripts/git-diff-summary
+++ b/skills/github/scripts/git-diff-summary
@@ -193,6 +193,18 @@ scan_decl_records() {
                     cdepth = 1; o = o "  "; m = m "  "; i += 2
                 } else if (c == "\"") {
                     instr = 1; o = o c; m = m c; i++
+                } else if (c == "b" && (i == 1 || substr(s, i - 1, 1) !~ /[A-Za-z0-9_]/) \
+                           && match(substr(s, i), /^br#*"/)) {
+                    # byte raw string: same raw machinery, prefix is br
+                    rawh = RLENGTH - 3
+                    rawhs = mkhashes(rawh)
+                    o = o substr(s, i, RLENGTH); m = m substr(s, i, RLENGTH)
+                    i += RLENGTH; instr = 2
+                } else if (c == "b" && (i == 1 || substr(s, i - 1, 1) !~ /[A-Za-z0-9_]/) \
+                           && substr(s, i + 1, 1) ~ /["\047]/) {
+                    # byte string or byte char: consume the b, let the
+                    # quote branch on the next pass open the literal
+                    o = o c; m = m c; i++
                 } else if (c == "r" && (i == 1 || substr(s, i - 1, 1) !~ /[A-Za-z0-9_]/) \
                            && match(substr(s, i), /^r#*"/)) {
                     rawh = RLENGTH - 2
@@ -234,12 +246,12 @@ scan_decl_records() {
         # shapes the scanner cannot evaluate.
         function emit_includes(mc, oc, inc_gated,   ioff, iq, iap, mrest, orest) {
             ioff = 0
-            while ((iq = index(substr(mc, ioff + 1), "include!")) > 0) {
+            while ((iq = index(substr(mc, ioff + 1), "include")) > 0) {
                 iap = ioff + iq
                 if (iap == 1 || substr(mc, iap - 1, 1) !~ /[A-Za-z0-9_]/) {
                     mrest = substr(mc, iap)
                     orest = substr(oc, iap)
-                    if (match(mrest, /^include![[:space:]]*[([{][[:space:]]*(r#*)?"[^"]*"/) \
+                    if (match(mrest, /^include[[:space:]]*![[:space:]]*[([{][[:space:]]*(b?r#*)?"[^"]*"/) \
                         && match(mrest, /"[^"]*"/))
                         printf "%s\t%s\n", (inc_gated ? "G" : "U"), \
                             normpath(join(fdir, substr(orest, RSTART + 1, RLENGTH - 2)))
@@ -286,8 +298,8 @@ scan_decl_records() {
                 # module, not to what follows — consumed on its own,
                 # contributing nothing to the pending outer-attribute gate
                 # state, so the next declaration still scans.
-                if (mbuf ~ /^#!\[/) {
-                    if (match(mbuf, /^#!\[[^]]*\][[:space:]]*/)) {
+                if (mbuf ~ /^#[[:space:]]*![[:space:]]*\[/) {
+                    if (match(mbuf, /^#[[:space:]]*![[:space:]]*\[[^]]*\][[:space:]]*/)) {
                         buf = substr(buf, RLENGTH + 1); mbuf = substr(mbuf, RLENGTH + 1)
                         continue
                     }
@@ -295,19 +307,19 @@ scan_decl_records() {
                 }
                 # Attribute item. An opened-but-unclosed one waits for the
                 # next line (rustc accepts attributes split across lines).
-                if (mbuf ~ /^#\[/) {
-                    if (match(mbuf, /^#\[[^]]*\][[:space:]]*/)) {
+                if (mbuf ~ /^#[[:space:]]*\[/) {
+                    if (match(mbuf, /^#[[:space:]]*\[[^]]*\][[:space:]]*/)) {
                         alen = RLENGTH
                         mattr = substr(mbuf, 1, alen)
                         oattr = substr(buf, 1, alen)
                         # rustc accepts whitespace between attribute tokens
                         # and a trailing comma after the predicate (both
                         # verified: #[cfg ( test )] and #[cfg(test,)]).
-                        if (mattr ~ /^#\[[[:space:]]*cfg[[:space:]]*\([[:space:]]*test[[:space:]]*,?[[:space:]]*\)[[:space:]]*\]/) gated = 1
+                        if (mattr ~ /^#[[:space:]]*\[[[:space:]]*cfg[[:space:]]*\([[:space:]]*test[[:space:]]*,?[[:space:]]*\)[[:space:]]*\]/) gated = 1
                         # Plain and raw string values, including hash-raw:
                         # the literal is located on the mask (its interior
                         # can hide no quote) and read from the original.
-                        if (mattr ~ /^#\[[[:space:]]*path[[:space:]]*=[[:space:]]*(r#*)?"/ \
+                        if (mattr ~ /^#[[:space:]]*\[[[:space:]]*path[[:space:]]*=[[:space:]]*(b?r#*)?"/ \
                             && match(mattr, /"[^"]*"/))
                             pathattr = substr(oattr, RSTART + 1, RLENGTH - 2)
                         buf = substr(buf, alen + 1); mbuf = substr(mbuf, alen + 1)
@@ -317,10 +329,10 @@ scan_decl_records() {
                 }
                 # File-module declaration item (raw identifiers accepted:
                 # `mod r#type;` declares module type -> type.rs).
-                if (match(mbuf, /^(pub([(][^)]*[)])?[[:space:]]+)?mod[[:space:]]+(r#)?[A-Za-z_][A-Za-z0-9_]*[[:space:]]*;/)) {
+                if (match(mbuf, /^(pub([[:space:]]*[(][^)]*[)][[:space:]]*|[[:space:]]+))?mod[[:space:]]+(r#)?([A-Za-z_]|[^\001-\177])([A-Za-z0-9_]|[^\001-\177])*[[:space:]]*;/)) {
                     name = substr(mbuf, 1, RLENGTH)
                     buf = substr(buf, RLENGTH + 1); mbuf = substr(mbuf, RLENGTH + 1)
-                    sub(/^pub([(][^)]*[)])?[[:space:]]+/, "", name)
+                    sub(/^pub([[:space:]]*[(][^)]*[)][[:space:]]*|[[:space:]]+)/, "", name)
                     sub(/^mod[[:space:]]+/, "", name)
                     sub(/^r#/, "", name)
                     sub(/[[:space:]]*;.*$/, "", name)
@@ -338,7 +350,7 @@ scan_decl_records() {
                 }
                 # Inline-module opener: enter the skip region (its own
                 # attributes, gated or not, apply to the skipped block).
-                if (match(mbuf, /^(pub([(][^)]*[)])?[[:space:]]+)?mod[[:space:]]+(r#)?[A-Za-z_][A-Za-z0-9_]*[[:space:]]*\{/)) {
+                if (match(mbuf, /^(pub([[:space:]]*[(][^)]*[)][[:space:]]*|[[:space:]]+))?mod[[:space:]]+(r#)?([A-Za-z_]|[^\001-\177])([A-Za-z0-9_]|[^\001-\177])*[[:space:]]*\{/)) {
                     buf = substr(buf, RLENGTH + 1); mbuf = substr(mbuf, RLENGTH + 1)
                     skip_open = "{"; skip_close = "}"; skip_depth = 1
                     gated = 0; pathattr = ""
@@ -347,7 +359,7 @@ scan_decl_records() {
                 # macro_rules! definition opener: the body is a token tree,
                 # not items — skip it whole. Bodies may use any delimiter
                 # pair; the opener determines which one is depth-tracked.
-                if (match(mbuf, /^macro_rules![[:space:]]*(r#)?[A-Za-z_][A-Za-z0-9_]*[[:space:]]*[([{]/)) {
+                if (match(mbuf, /^macro_rules[[:space:]]*![[:space:]]*(r#)?([A-Za-z_]|[^\001-\177])([A-Za-z0-9_]|[^\001-\177])*[[:space:]]*[([{]/)) {
                     skip_open = substr(mbuf, RLENGTH, 1)
                     skip_close = (skip_open == "{") ? "}" : (skip_open == "(" ? ")" : "]")
                     skip_depth = 1
@@ -361,11 +373,11 @@ scan_decl_records() {
                 # whole so item-like tokens (`discard! { mod cand; }`)
                 # fabricate nothing. include! is the one macro the scanner
                 # DOES evaluate; it falls through to the chunk scan.
-                if (match(mbuf, /^(r#)?[A-Za-z_][A-Za-z0-9_]*(::(r#)?[A-Za-z_][A-Za-z0-9_]*)*![[:space:]]*[([{]/)) {
+                if (match(mbuf, /^(r#)?([A-Za-z_]|[^\001-\177])([A-Za-z0-9_]|[^\001-\177])*([[:space:]]*::[[:space:]]*(r#)?([A-Za-z_]|[^\001-\177])([A-Za-z0-9_]|[^\001-\177])*)*[[:space:]]*![[:space:]]*[([{]/)) {
                     mname = substr(mbuf, 1, RLENGTH)
                     mdelim = substr(mbuf, RLENGTH, 1)
-                    sub(/![[:space:]]*[([{]$/, "", mname)
-                    sub(/^.*::/, "", mname)
+                    sub(/[[:space:]]*![[:space:]]*[([{]$/, "", mname)
+                    sub(/^.*::[[:space:]]*/, "", mname)
                     sub(/^r#/, "", mname)
                     if (mname != "include") {
                         skip_open = mdelim

--- a/skills/github/scripts/git-diff-summary
+++ b/skills/github/scripts/git-diff-summary
@@ -68,11 +68,13 @@ resolve_default_base() {
 # direct string literal (concat!/env!/consts — even concatenations of
 # literals) emit no record; #[path]/include! declarations living in a
 # directory that is neither the candidate's own nor one of its ancestors
-# are not consulted; declarations inside inline module blocks and
-# macro_rules! definition bodies are skipped outright (no records — never
-# a mis-resolved one); and declarations produced by macro EXPANSION
-# (invoking a macro_rules! or proc macro) are invisible by construction.
-# Every one of these fails toward NO record for the shape, so
+# are not consulted; declarations inside any braced body — inline
+# modules, macro definitions and invocations, and non-module item bodies
+# (fn/impl/struct/...) — are skipped outright (no records — never a
+# mis-resolved one), which also makes block-level #[path] modules and
+# includes inside bodies invisible; and declarations produced by macro
+# EXPANSION (invoking a macro_rules! or proc macro) are invisible by
+# construction. Every one of these fails toward NO record for the shape, so
 # a file that is production-reachable only through one of them while also
 # carrying a #[cfg(test)]-gated declaration still classifies as test —
 # that is the declared trade-off, and the only one.
@@ -287,11 +289,14 @@ scan_decl_records() {
                         alen = RLENGTH
                         mattr = substr(mbuf, 1, alen)
                         oattr = substr(buf, 1, alen)
-                        if (mattr ~ /^#\[cfg\(test\)\]/) gated = 1
+                        # rustc accepts whitespace between attribute tokens
+                        # and a trailing comma after the predicate (both
+                        # verified: #[cfg ( test )] and #[cfg(test,)]).
+                        if (mattr ~ /^#\[[[:space:]]*cfg[[:space:]]*\([[:space:]]*test[[:space:]]*,?[[:space:]]*\)[[:space:]]*\]/) gated = 1
                         # Plain and raw string values, including hash-raw:
                         # the literal is located on the mask (its interior
                         # can hide no quote) and read from the original.
-                        if (mattr ~ /^#\[path[[:space:]]*=[[:space:]]*(r#*)?"/ \
+                        if (mattr ~ /^#\[[[:space:]]*path[[:space:]]*=[[:space:]]*(r#*)?"/ \
                             && match(mattr, /"[^"]*"/))
                             pathattr = substr(oattr, RSTART + 1, RLENGTH - 2)
                         buf = substr(buf, alen + 1); mbuf = substr(mbuf, alen + 1)
@@ -364,13 +369,22 @@ scan_decl_records() {
                 # on the mask, scanning the chunk for include! routes. A
                 # multiline include! completes when its statement boundary
                 # arrives. Without a boundary the item continues on the
-                # next line.
+                # next line. A { boundary opens the body of a non-module
+                # item (fn/impl/struct/...): a body is not a top-level
+                # item stream — block-level #[path] modules resolve by
+                # block-chain rules and includes there compile in the
+                # enclosing cfg context — so it is a skip region like the
+                # others, emitting nothing (declared limitation).
                 if (match(mbuf, /[;{}]/)) {
+                    bchar = substr(mbuf, RSTART, 1)
                     mchunk = substr(mbuf, 1, RSTART)
                     ochunk = substr(buf, 1, RSTART)
                     buf = substr(buf, RSTART + 1); mbuf = substr(mbuf, RSTART + 1)
                     emit_includes(mchunk, ochunk, gated)
                     gated = 0; pathattr = ""
+                    if (bchar == "{") {
+                        skip_open = "{"; skip_close = "}"; skip_depth = 1
+                    }
                     continue
                 }
                 break

--- a/skills/github/scripts/git-diff-summary
+++ b/skills/github/scripts/git-diff-summary
@@ -64,15 +64,17 @@ resolve_default_base() {
 # Residual limitations: production routes the scanner cannot see can still
 # let a gated declaration win. Crate roots are only recognized by the bin/
 # directory convention (candidates under a bin/ segment are skipped), not
-# via Cargo.toml `path =` wiring; include! calls with computed paths
-# (concat!/env!) are not matched; #[path]/include! declarations living in
-# a directory that is neither the candidate's own nor one of its ancestors
+# via Cargo.toml `path =` wiring; include! calls whose argument is not a
+# direct string literal (concat!/env!/consts — even concatenations of
+# literals) emit no record; #[path]/include! declarations living in a
+# directory that is neither the candidate's own nor one of its ancestors
 # are not consulted; declarations inside inline module blocks are skipped
-# outright (no records — never a mis-resolved one); and a /* opener inside
-# a string literal reads as a comment and can hide a later ungated
-# declaration. A file that is production-reachable only through one of
-# those shapes while also carrying a #[cfg(test)]-gated declaration still
-# classifies as test.
+# outright (no records — never a mis-resolved one); and declarations
+# produced by macro expansion (macro_rules!/proc-macro bodies) are
+# invisible. Every one of these fails toward NO record for the shape, so
+# a file that is production-reachable only through one of them while also
+# carrying a #[cfg(test)]-gated declaration still classifies as test —
+# that is the declared trade-off, and the only one.
 
 # Emits the new-side content of a file: HEAD for a base...HEAD diff, the
 # index for --staged, the worktree for --head. Reads main()'s diff_ref.
@@ -149,34 +151,89 @@ scan_decl_records() {
             for (i = 1; i <= top; i++) out = out (i > 1 ? "/" : "") stack[i]
             return out
         }
-        # Comment stripping with Rust semantics the coarse version missed:
-        # // takes precedence over /* on the same line, and block comments
-        # nest (depth counter, carried across lines). A /* inside a string
-        # literal still reads as a comment — stated limitation.
-        function strip_comments(s,   out, i, n, two) {
-            out = ""; i = 1; n = length(s)
-            while (i <= n) {
-                two = substr(s, i, 2)
-                if (cdepth > 0) {
-                    if (two == "*/") { cdepth--; i += 2 }
-                    else if (two == "/*") { cdepth++; i += 2 }
-                    else i++
-                } else if (two == "//") break
-                else if (two == "/*") { cdepth = 1; i += 2 }
-                else { out = out substr(s, i, 1); i++ }
+        function mkhashes(k,   h) { h = ""; while (k-- > 0) h = h "#"; return h }
+        # Lex one line into two SAME-LENGTH strings: ml_orig (comment bytes
+        # blanked to spaces, literals intact) and ml_mask (literal interiors
+        # additionally blanked to "."). Item/brace/boundary matching runs on
+        # the mask, so quoted braces, quoted //, and quoted /* are inert;
+        # value extraction reads the same offsets from ml_orig. Handles
+        # nested block comments, // precedence, "..." with escapes, r"..."
+        # and r#*"..."#* raw strings (both may span lines), and char
+        # literals vs lifetimes (a quote not forming a char literal is kept).
+        function mask_line(s,   n, i, c, c2, o, m, j, seg, k, hs) {
+            n = length(s); o = ""; m = ""; i = 1
+            # Fast path: nothing that opens a comment, string, or char
+            # literal, and no open cross-line state.
+            if (cdepth == 0 && instr == 0 && s !~ /["\047\/]/) {
+                ml_orig = s; ml_mask = s; return
             }
-            return out
+            while (i <= n) {
+                c = substr(s, i, 1)
+                c2 = substr(s, i, 2)
+                if (cdepth > 0) {
+                    if (c2 == "*/") { cdepth--; o = o "  "; m = m "  "; i += 2 }
+                    else if (c2 == "/*") { cdepth++; o = o "  "; m = m "  "; i += 2 }
+                    else { o = o " "; m = m " "; i++ }
+                } else if (instr == 1) {
+                    if (c == "\\" && i < n) { o = o substr(s, i, 2); m = m ".."; i += 2 }
+                    else if (c == "\"") { instr = 0; o = o c; m = m c; i++ }
+                    else { o = o c; m = m "."; i++ }
+                } else if (instr == 2) {
+                    hs = mkhashes(rawh)
+                    if (c == "\"" && substr(s, i + 1, rawh) == hs) {
+                        o = o substr(s, i, rawh + 1); m = m substr(s, i, rawh + 1)
+                        i += rawh + 1; instr = 0
+                    } else { o = o c; m = m "."; i++ }
+                } else if (c2 == "//") {
+                    while (i <= n) { o = o " "; m = m " "; i++ }
+                } else if (c2 == "/*") {
+                    cdepth = 1; o = o "  "; m = m "  "; i += 2
+                } else if (c == "\"") {
+                    instr = 1; o = o c; m = m c; i++
+                } else if (c == "r" && (i == 1 || substr(s, i - 1, 1) !~ /[A-Za-z0-9_]/) \
+                           && match(substr(s, i), /^r#*"/)) {
+                    rawh = RLENGTH - 2
+                    o = o substr(s, i, RLENGTH); m = m substr(s, i, RLENGTH)
+                    i += RLENGTH; instr = 2
+                } else if (c == "\047") {
+                    if (substr(s, i + 1, 1) == "\\") {
+                        # escaped char literal: consume to its closing quote
+                        j = i + 3
+                        while (j <= n && substr(s, j, 1) != "\047") j++
+                        if (j > n) j = n
+                        seg = j - i + 1
+                        o = o substr(s, i, seg)
+                        m = m "\047"
+                        for (k = 2; k < seg; k++) m = m "."
+                        if (seg >= 2) m = m "\047"
+                        i = j + 1
+                    } else if (substr(s, i + 2, 1) == "\047") {
+                        # plain char literal (may hold { } ; / ")
+                        o = o substr(s, i, 3); m = m "\047.\047"; i += 3
+                    } else {
+                        # lifetime: keep the quote, no literal opened
+                        o = o c; m = m c; i++
+                    }
+                } else { o = o c; m = m c; i++ }
+            }
+            ml_orig = o; ml_mask = m
         }
-        # Every include! route in one consumed chunk (token boundary: a
-        # preceding identifier character means a different macro).
-        function emit_includes(chunk,   ioff, iq, iap, irest) {
+        # include! routes in one consumed chunk (mc masked, oc original).
+        # Token boundary: a preceding identifier character means a
+        # different macro. The argument must BE a string literal (any
+        # bracket form); a computed expression (concat!/env!/const) emits
+        # nothing — even one whose parts are all literals — per the
+        # fail-closed rule for shapes the scanner cannot evaluate.
+        function emit_includes(mc, oc,   ioff, iq, iap, mrest, orest) {
             ioff = 0
-            while ((iq = index(substr(chunk, ioff + 1), "include!")) > 0) {
+            while ((iq = index(substr(mc, ioff + 1), "include!")) > 0) {
                 iap = ioff + iq
-                if (iap == 1 || substr(chunk, iap - 1, 1) !~ /[A-Za-z0-9_]/) {
-                    irest = substr(chunk, iap)
-                    if (match(irest, /"[^"]*"/))
-                        printf "I\t%s\n", normpath(join(fdir, substr(irest, RSTART + 1, RLENGTH - 2)))
+                if (iap == 1 || substr(mc, iap - 1, 1) !~ /[A-Za-z0-9_]/) {
+                    mrest = substr(mc, iap)
+                    orest = substr(oc, iap)
+                    if (match(mrest, /^include![[:space:]]*[([{][[:space:]]*(r#*)?"[^"]*"/) \
+                        && match(mrest, /"[^"]*"/))
+                        printf "I\t%s\n", normpath(join(fdir, substr(orest, RSTART + 1, RLENGTH - 2)))
                 }
                 ioff = iap + 7
             }
@@ -188,56 +245,59 @@ scan_decl_records() {
         # An incomplete tail (open attribute, unterminated statement,
         # unclosed inline block) stays in the buffer for the next line.
         {
-            line = strip_comments($0)
-            if (buf == "") buf = line
-            else buf = buf " " line
+            mask_line($0)
+            if (buf == "") { buf = ml_orig; mbuf = ml_mask }
+            else { buf = buf " " ml_orig; mbuf = mbuf " " ml_mask }
             for (;;) {
                 # Inside an inline module block (mod name { ... }): Rust
                 # resolves nested declarations into the inline chain, which
                 # this scanner does not model — a shape it cannot
                 # faithfully parse must produce NO record, never a
-                # mis-resolved one. Consume by brace depth, emit nothing.
+                # mis-resolved one. Consume by brace depth on the MASK
+                # (quoted braces are invisible), emit nothing.
                 if (inline_depth > 0) {
-                    blen = length(buf); bi = 1
+                    blen = length(mbuf); bi = 1
                     while (bi <= blen && inline_depth > 0) {
-                        bc = substr(buf, bi, 1)
+                        bc = substr(mbuf, bi, 1)
                         if (bc == "{") inline_depth++
                         else if (bc == "}") inline_depth--
                         bi++
                     }
-                    buf = substr(buf, bi)
-                    if (inline_depth > 0) { buf = ""; break }
+                    buf = substr(buf, bi); mbuf = substr(mbuf, bi)
+                    if (inline_depth > 0) { buf = ""; mbuf = ""; break }
                     continue
                 }
-                sub(/^[[:space:]]*/, "", buf)
-                if (buf == "") break
+                if (match(mbuf, /^[[:space:]]+/)) {
+                    buf = substr(buf, RLENGTH + 1); mbuf = substr(mbuf, RLENGTH + 1)
+                }
+                if (mbuf == "") break
                 # Attribute item. An opened-but-unclosed one waits for the
                 # next line (rustc accepts attributes split across lines).
-                if (buf ~ /^#\[/) {
-                    if (match(buf, /^#\[[^]]*\][[:space:]]*/)) {
-                        attr = substr(buf, 1, RLENGTH)
-                        if (attr ~ /^#\[cfg\(test\)\]/) gated = 1
-                        # Plain and raw string values, including hash-raw
-                        # (r"...", r#"..."#); a literal quote INSIDE a
-                        # hash-raw value would cut early — pathological
-                        # for a file path.
-                        if (attr ~ /^#\[path[[:space:]]*=[[:space:]]*(r#*)?"/) {
-                            p = attr
-                            sub(/^#\[path[[:space:]]*=[[:space:]]*(r#*)?"/, "", p)
-                            sub(/".*/, "", p)
-                            pathattr = p
-                        }
-                        buf = substr(buf, RLENGTH + 1)
+                if (mbuf ~ /^#\[/) {
+                    if (match(mbuf, /^#\[[^]]*\][[:space:]]*/)) {
+                        alen = RLENGTH
+                        mattr = substr(mbuf, 1, alen)
+                        oattr = substr(buf, 1, alen)
+                        if (mattr ~ /^#\[cfg\(test\)\]/) gated = 1
+                        # Plain and raw string values, including hash-raw:
+                        # the literal is located on the mask (its interior
+                        # can hide no quote) and read from the original.
+                        if (mattr ~ /^#\[path[[:space:]]*=[[:space:]]*(r#*)?"/ \
+                            && match(mattr, /"[^"]*"/))
+                            pathattr = substr(oattr, RSTART + 1, RLENGTH - 2)
+                        buf = substr(buf, alen + 1); mbuf = substr(mbuf, alen + 1)
                         continue
                     }
                     break
                 }
-                # File-module declaration item.
-                if (match(buf, /^(pub([(][^)]*[)])?[[:space:]]+)?mod[[:space:]]+[A-Za-z_][A-Za-z0-9_]*[[:space:]]*;/)) {
-                    name = substr(buf, 1, RLENGTH)
-                    buf = substr(buf, RLENGTH + 1)
+                # File-module declaration item (raw identifiers accepted:
+                # `mod r#type;` declares module type -> type.rs).
+                if (match(mbuf, /^(pub([(][^)]*[)])?[[:space:]]+)?mod[[:space:]]+(r#)?[A-Za-z_][A-Za-z0-9_]*[[:space:]]*;/)) {
+                    name = substr(mbuf, 1, RLENGTH)
+                    buf = substr(buf, RLENGTH + 1); mbuf = substr(mbuf, RLENGTH + 1)
                     sub(/^pub([(][^)]*[)])?[[:space:]]+/, "", name)
                     sub(/^mod[[:space:]]+/, "", name)
+                    sub(/^r#/, "", name)
                     sub(/[[:space:]]*;.*$/, "", name)
                     kind = (gated ? "G" : "U")
                     if (pathattr != "")
@@ -253,22 +313,22 @@ scan_decl_records() {
                 }
                 # Inline-module opener: enter the skip region (its own
                 # attributes, gated or not, apply to the skipped block).
-                if (match(buf, /^(pub([(][^)]*[)])?[[:space:]]+)?mod[[:space:]]+[A-Za-z_][A-Za-z0-9_]*[[:space:]]*\{/)) {
-                    buf = substr(buf, RLENGTH + 1)
+                if (match(mbuf, /^(pub([(][^)]*[)])?[[:space:]]+)?mod[[:space:]]+(r#)?[A-Za-z_][A-Za-z0-9_]*[[:space:]]*\{/)) {
+                    buf = substr(buf, RLENGTH + 1); mbuf = substr(mbuf, RLENGTH + 1)
                     inline_depth = 1
                     gated = 0; pathattr = ""
                     continue
                 }
-                # Any other item: consume to the next boundary (; { or }),
-                # scanning the chunk for include! routes. A multiline
-                # include! (literal on a later line) completes when its
-                # statement boundary arrives; a closed call with no
-                # literal (computed path) emits nothing. Without a
-                # boundary the item continues on the next line.
-                if (match(buf, /[;{}]/)) {
-                    chunk = substr(buf, 1, RSTART)
-                    buf = substr(buf, RSTART + 1)
-                    emit_includes(chunk)
+                # Any other item: consume to the next boundary (; { or })
+                # on the mask, scanning the chunk for include! routes. A
+                # multiline include! completes when its statement boundary
+                # arrives. Without a boundary the item continues on the
+                # next line.
+                if (match(mbuf, /[;{}]/)) {
+                    mchunk = substr(mbuf, 1, RSTART)
+                    ochunk = substr(buf, 1, RSTART)
+                    buf = substr(buf, RSTART + 1); mbuf = substr(mbuf, RSTART + 1)
+                    emit_includes(mchunk, ochunk)
                     gated = 0; pathattr = ""
                     continue
                 }

--- a/skills/github/scripts/git-diff-summary
+++ b/skills/github/scripts/git-diff-summary
@@ -168,23 +168,37 @@ scan_decl_records() {
             # Blank and comment-only lines keep pending attributes (attrs
             # may precede their item across lines).
             if (line == "") next
-            # include! routes resolve their string-literal argument like
-            # module declarations do. A literal on a later line (formatted
-            # call) is tracked across lines until the closing paren; a call
-            # with no literal at all (computed path) stays unmatched —
-            # stated limitation.
+            # An attribute opened but not closed on the previous line
+            # (rustc accepts `#[path =` split from its value) continues
+            # here; rejoin before parsing.
+            if (pending_attr != "") {
+                line = pending_attr " " line
+                pending_attr = ""
+            }
+            # include! routes resolve their string-literal argument. A
+            # literal on a later line (formatted call left open) is tracked
+            # across lines until the closing paren; a call that CLOSES
+            # without a literal (computed path) sets no pending state and
+            # stays unmatched — stated limitation.
             if (pending_include) {
                 if (match(line, /"[^"]*"/)) {
                     printf "I\t%s\n", normpath(join(fdir, substr(line, RSTART + 1, RLENGTH - 2)))
                     pending_include = 0
                 } else if (index(line, ")") > 0) pending_include = 0
             }
-            pos = index(line, "include!")
-            if (pos > 0) {
-                rest = substr(line, pos)
+            # A real include! token only: a preceding identifier character
+            # means a different macro (my_include!).
+            ipos = 0; off = 0
+            while ((q = index(substr(line, off + 1), "include!")) > 0) {
+                ap = off + q
+                if (ap == 1 || substr(line, ap - 1, 1) !~ /[A-Za-z0-9_]/) { ipos = ap; break }
+                off = ap + 7
+            }
+            if (ipos > 0) {
+                rest = substr(line, ipos)
                 if (match(rest, /"[^"]*"/))
                     printf "I\t%s\n", normpath(join(fdir, substr(rest, RSTART + 1, RLENGTH - 2)))
-                else pending_include = 1
+                else if (index(rest, ")") == 0) pending_include = 1
             }
             # Consume leading attributes; several may share the decl line.
             while (match(line, /^#\[[^]]*\][[:space:]]*/)) {
@@ -199,6 +213,12 @@ scan_decl_records() {
                 line = substr(line, RLENGTH + 1)
             }
             if (line == "") next
+            # Attribute opened but not closed on this line: carry it (and
+            # any attrs already consumed stay pending in gated/pathattr).
+            if (line ~ /^#\[/ && index(line, "]") == 0) {
+                pending_attr = line
+                next
+            }
             if (line ~ /^(pub([(][^)]*[)])?[[:space:]]+)?mod[[:space:]]+[A-Za-z_][A-Za-z0-9_]*[[:space:]]*;/) {
                 name = line
                 sub(/^pub([(][^)]*[)])?[[:space:]]+/, "", name)
@@ -404,11 +424,18 @@ main() {
         prod_paths=$(grep -Fxv -f <(printf '%s' "$cfg_test_declared") <<<"$prod_paths" || true)
     fi
     local prod_panic=0 test_panic=0
-    if [ -n "$prod_paths" ]; then
+    # Pathspecs are passed as a quoted array — word splitting must not shred
+    # paths containing whitespace into bogus pathspecs.
+    local p
+    local prod_path_args=()
+    while IFS= read -r p; do
+        [ -n "$p" ] && prod_path_args+=("$p")
+    done <<<"$prod_paths"
+    if [ ${#prod_path_args[@]} -gt 0 ]; then
         # path<TAB>new-side line number of each added panic-pattern line
         local panic_lines
         # shellcheck disable=SC2086
-        panic_lines=$(git diff $diff_ref -- $prod_paths 2>/dev/null | awk '
+        panic_lines=$(git diff $diff_ref -- "${prod_path_args[@]}" 2>/dev/null | awk '
             /^diff --git / { path = ""; inhunk = 0 }
             /^\+\+\+ b\//  { path = substr($0, 7); next }
             /^@@/ {
@@ -424,7 +451,8 @@ main() {
             { lineno++ }
         ')
         local panic_file file_lines file_content counts pcount tcount
-        for panic_file in $(echo "$panic_lines" | cut -f1 | sort -u); do
+        while IFS= read -r panic_file; do
+            [ -n "$panic_file" ] || continue
             file_lines=$(echo "$panic_lines" | awk -F'\t' -v f="$panic_file" '$1 == f {print $2}' | paste -sd, -)
             # New-side content of the file: HEAD for a base...HEAD diff, the
             # index for --staged, the worktree for --head.
@@ -467,7 +495,7 @@ main() {
             read -r pcount tcount <<< "$counts"
             if [ "$pcount" -gt 0 ]; then prod_panic=1; fi
             if [ "$tcount" -gt 0 ]; then test_panic=1; fi
-        done
+        done < <(echo "$panic_lines" | cut -f1 | sort -u)
     fi
     if [ "$prod_panic" -eq 1 ]; then flags+=("panic_path_added"); fi
 
@@ -477,10 +505,14 @@ main() {
     test_paths=$(echo "$files" | awk -F'\t' '{print $NF}' \
         | grep -E '(^|/)tests?/|_tests?\.rs$' || true)
     test_paths=$(printf '%s\n%s' "$test_paths" "$cfg_test_declared" | grep -v '^$' | sort -u || true)
-    if [ -n "$test_paths" ]; then
+    local test_path_args=()
+    while IFS= read -r p; do
+        [ -n "$p" ] && test_path_args+=("$p")
+    done <<<"$test_paths"
+    if [ ${#test_path_args[@]} -gt 0 ]; then
         local test_diff
         # shellcheck disable=SC2086
-        test_diff=$(git diff $diff_ref -- $test_paths 2>/dev/null | grep -E '^\+' || true)
+        test_diff=$(git diff $diff_ref -- "${test_path_args[@]}" 2>/dev/null | grep -E '^\+' || true)
         if echo "$test_diff" | grep -qE '^\+.*(panic!|unwrap\(\))'; then test_panic=1; fi
     fi
     if [ "$test_panic" -eq 1 ]; then flags+=("test_panic_path_added"); fi

--- a/skills/github/scripts/git-diff-summary
+++ b/skills/github/scripts/git-diff-summary
@@ -387,13 +387,14 @@ scan_decl_records() {
                     gated = 0; pathattr = ""
                     continue
                 }
-                # Macro INVOCATION opener (ident! or path::to::ident! plus
-                # any delimiter): the token tree only becomes items after
+                # Macro INVOCATION opener (ident!, path::to::ident! or the
+                # absolutely-qualified ::path::to::ident!, plus any
+                # delimiter): the token tree only becomes items after
                 # expansion, which the scanner does not evaluate — skip it
                 # whole so item-like tokens (`discard! { mod cand; }`)
                 # fabricate nothing. include! is the one macro the scanner
                 # DOES evaluate; it falls through to the chunk scan.
-                if (match(mbuf, /^(r#)?([A-Za-z_]|[^\001-\177])([A-Za-z0-9_]|[^\001-\177])*([[:space:]]*::[[:space:]]*(r#)?([A-Za-z_]|[^\001-\177])([A-Za-z0-9_]|[^\001-\177])*)*[[:space:]]*![[:space:]]*[([{]/)) {
+                if (match(mbuf, /^(::[[:space:]]*)?(r#)?([A-Za-z_]|[^\001-\177])([A-Za-z0-9_]|[^\001-\177])*([[:space:]]*::[[:space:]]*(r#)?([A-Za-z_]|[^\001-\177])([A-Za-z0-9_]|[^\001-\177])*)*[[:space:]]*![[:space:]]*[([{]/)) {
                     mname = substr(mbuf, 1, RLENGTH)
                     mdelim = substr(mbuf, RLENGTH, 1)
                     sub(/[[:space:]]*![[:space:]]*[([{]$/, "", mname)
@@ -427,7 +428,7 @@ scan_decl_records() {
                     }
                     if (idepth > 0) break
                     iseg = substr(mbuf, idelim + 1, ipos - idelim - 2)
-                    if (match(iseg, /^[[:space:]]*(r#*)?"[^"]*"[[:space:]]*$/) \
+                    if (match(iseg, /^[[:space:]]*(r#*)?"[^"]*"#*[[:space:]]*$/) \
                         && match(iseg, /"[^"]*"/))
                         printf "%s\t%s\n", (gated ? "G" : "U"), \
                             normpath(join(fdir, substr(substr(buf, idelim + 1, ipos - idelim - 2), RSTART + 1, RLENGTH - 2)))
@@ -501,6 +502,11 @@ scan_declaring_file() {
         DECL_CACHE="$DECL_CACHE$1"$'\t'"$fdir"$'\t'ERR$'\n'
         return 0
     fi
+    # A UTF-8 BOM is an encoding preamble rustc accepts ahead of everything
+    # else (including a shebang), not part of the first item. Stripped
+    # byte-exactly here so the anchored item matchers see the real first
+    # token instead of falling through to the generic-item branch.
+    content=${content#$'\xef\xbb\xbf'}
     records=$(printf '%s\n' "$content" | scan_decl_records "$moddir" "$fdir" \
         | awk -v f="$1" -v d="$fdir" '{print f "\t" d "\t" $0}')
     [ -n "$records" ] && DECL_CACHE="$DECL_CACHE$records"$'\n'

--- a/skills/github/scripts/git-diff-summary
+++ b/skills/github/scripts/git-diff-summary
@@ -94,11 +94,27 @@ resolve_default_base() {
 # masking but never qualify as path/include VALUES — they are not valid
 # in those positions in Rust.
 
+# Mode of a path's new-side entry, empty when it has none. Reads main()'s
+# diff_ref.
+new_side_mode() {
+    case "$diff_ref" in
+        --staged|HEAD) git ls-files -s -- "$1" 2>/dev/null ;;
+        *)             git ls-tree HEAD -- "$1" 2>/dev/null ;;
+    esac | awk 'NR == 1 { print $1 }'
+}
+
 # Emits the new-side content of a file: HEAD for a base...HEAD diff, the
 # index for --staged, the worktree for --head. Reads main()'s diff_ref.
 # Exit 0 with content when readable, 2 when the file does not exist on the
 # new side, 1 on a read failure — callers must fail closed on 1.
 new_side_content() {
+    # A symlink entry (mode 120000) stores its TARGET PATH as the blob, so
+    # reading it yields link text instead of Rust — an empty parse that
+    # would silently drop every declaration the linked module holds while
+    # rustc compiles through the link and honours them. Reported unreadable
+    # so consulting candidates fail closed, never scanned as a module that
+    # happens to declare nothing.
+    if [ "$(new_side_mode "$1")" = 120000 ]; then return 1; fi
     case "$diff_ref" in
         --staged)
             git ls-files --error-unmatch -- "$1" >/dev/null 2>&1 || return 2
@@ -110,6 +126,7 @@ new_side_content() {
             # declarations that reclassify a tracked change.
             git ls-files --error-unmatch -- "$1" >/dev/null 2>&1 || return 2
             [ -e "$1" ] || return 2
+            [ -L "$1" ] && return 1
             cat "$1" 2>/dev/null || return 1
             ;;
         *)

--- a/skills/github/scripts/git-diff-summary
+++ b/skills/github/scripts/git-diff-summary
@@ -121,12 +121,13 @@ new_side_rs_siblings() {
 # <target> is the repo-relative file the declaration resolves to, lexically
 # normalized (`.`/`..` segments folded) so equivalent spellings compare
 # equal. A bare `mod name;` emits both of its legal forms, name.rs and
-# name/mod.rs. moddir is where mod declarations land: for mod-rs files
-# (mod.rs, lib.rs, main.rs) their own directory; for any other file its
-# directory plus its stem as a subdirectory — both bare `mod name;` and
-# #[path] values resolve there, per the Rust reference's module path rules.
-# fdir is the file's own directory: include! literals resolve there (the
-# std docs anchor them to the containing FILE), not in moddir.
+# name/mod.rs. moddir is where bare `mod name;` declarations land: for
+# mod-rs files (mod.rs, lib.rs, main.rs) their own directory; for any other
+# file its directory plus its stem as a subdirectory. fdir is the file's
+# own directory: per the Rust reference, #[path] values on modules NOT
+# inside inline module blocks resolve there (the mod-rs distinction only
+# changes #[path] inside inline blocks, which this scanner does not parse —
+# stated limitation), and the std docs anchor include! literals there too.
 scan_decl_records() {
     awk -v moddir="$1" -v fdir="$2" '
         function join(d, b) { return d == "." ? b : d "/" b }
@@ -204,9 +205,11 @@ scan_decl_records() {
             while (match(line, /^#\[[^]]*\][[:space:]]*/)) {
                 attr = substr(line, 1, RLENGTH)
                 if (attr ~ /^#\[cfg\(test\)\]/) gated = 1
-                if (attr ~ /^#\[path[[:space:]]*=[[:space:]]*"/) {
+                # Plain and raw (r"...") string values; r#"..."# stays a
+                # stated limitation.
+                if (attr ~ /^#\[path[[:space:]]*=[[:space:]]*r?"/) {
                     p = attr
-                    sub(/^#\[path[[:space:]]*=[[:space:]]*"/, "", p)
+                    sub(/^#\[path[[:space:]]*=[[:space:]]*r?"/, "", p)
                     sub(/".*/, "", p)
                     pathattr = p
                 }
@@ -226,7 +229,7 @@ scan_decl_records() {
                 sub(/[[:space:]]*;.*$/, "", name)
                 kind = (gated ? "G" : "U")
                 if (pathattr != "")
-                    printf "%s\t%s\n", kind, normpath(join(moddir, pathattr))
+                    printf "%s\t%s\n", kind, normpath(join(fdir, pathattr))
                 else {
                     # Both legal forms of a bare declaration: name.rs and
                     # the directory form name/mod.rs.

--- a/skills/github/scripts/git-diff-summary
+++ b/skills/github/scripts/git-diff-summary
@@ -171,6 +171,22 @@ scan_decl_records() {
             return out
         }
         function mkhashes(k,   h) { h = ""; while (k-- > 0) h = h "#"; return h }
+        # Length of the attribute item opening the masked buffer, through its
+        # matching ]. An attribute body is a token tree that may nest bracket
+        # groups (#[cfg_attr(any(), allow([dead_code]))]), so the close is
+        # found by delimiter depth, not by the first ] — stopping early would
+        # leave attribute tokens to swallow the declaration that follows.
+        # Quoted brackets are inert: the scan runs on the mask. 0 when the
+        # attribute is not closed in this buffer yet (it continues next line).
+        function attr_len(ms,   i, n, c, depth) {
+            n = length(ms); depth = 0
+            for (i = index(ms, "["); i > 0 && i <= n; i++) {
+                c = substr(ms, i, 1)
+                if (c == "[") depth++
+                else if (c == "]" && --depth == 0) return i
+            }
+            return 0
+        }
         # Lex one line into two SAME-LENGTH strings: ml_orig (comment bytes
         # blanked to spaces, literals intact) and ml_mask (literal interiors
         # additionally blanked to "."). Item/brace/boundary matching runs on
@@ -252,26 +268,58 @@ scan_decl_records() {
             }
             ml_orig = o; ml_mask = m
         }
+        # The direct string-literal argument of an include! call, read from
+        # the original at the offsets located on the mask; "" when the
+        # argument is anything else. The literal must BE the whole argument
+        # (raw hashes and a rustc-accepted trailing comma allowed); a
+        # computed expression (concat!/env!/const) yields nothing — even one
+        # whose parts are all literals — per the fail-closed rule for shapes
+        # the scanner cannot evaluate. Byte/C-prefixed literals never match:
+        # they are not valid in this position.
+        function include_value(ms, os) {
+            if (match(ms, /^[[:space:]]*(r#*)?"[^"]*"#*[[:space:]]*,?[[:space:]]*$/) \
+                && match(ms, /"[^"]*"/))
+                return substr(os, RSTART + 1, RLENGTH - 2)
+            return ""
+        }
         # include! routes in one consumed chunk (mc masked, oc original),
-        # emitted with the chunk item attribute gate (inc_gated). Token
-        # boundary: a preceding identifier character means a different
-        # macro. The argument must BE a string literal (any bracket form);
-        # a computed expression (concat!/env!/const) emits nothing — even
-        # one whose parts are all literals — per the fail-closed rule for
-        # shapes the scanner cannot evaluate.
-        function emit_includes(mc, oc, inc_gated,   ioff, iq, iap, mrest, orest) {
-            ioff = 0
-            while ((iq = index(substr(mc, ioff + 1), "include")) > 0) {
-                iap = ioff + iq
-                if (iap == 1 || substr(mc, iap - 1, 1) !~ /[A-Za-z0-9_]/) {
-                    mrest = substr(mc, iap)
-                    orest = substr(oc, iap)
-                    if (match(mrest, /^include[[:space:]]*![[:space:]]*[([{][[:space:]]*(r#*)?"[^"]*"/) \
-                        && match(mrest, /"[^"]*"/))
-                        printf "%s\t%s\n", (inc_gated ? "G" : "U"), \
-                            normpath(join(fdir, substr(orest, RSTART + 1, RLENGTH - 2)))
+        # emitted with the chunk item attribute gate (inc_gated). The chunk
+        # is walked as TOKENS: the argument tree of every macro invocation
+        # is jumped over whole, because Rust expands nothing inside the
+        # tokens of another macro — an include! nested there (stringify!
+        # (include!("cand.rs"))) is not a route and must fabricate no
+        # record. Only an include! reached at chunk level emits. A tree left
+        # unclosed by the chunk boundary stops the walk (no record).
+        function emit_includes(mc, oc, inc_gated,   n, ip, mrest, mlen, mname, dopen, dclose, dstart, dend, depth, val) {
+            n = length(mc); ip = 1
+            while (ip <= n) {
+                if (ip > 1 && substr(mc, ip - 1, 1) ~ /[A-Za-z0-9_]/) { ip++; continue }
+                mrest = substr(mc, ip)
+                if (!match(mrest, /^(r#)?([A-Za-z_]|[^\001-\177])([A-Za-z0-9_]|[^\001-\177])*([[:space:]]*::[[:space:]]*(r#)?([A-Za-z_]|[^\001-\177])([A-Za-z0-9_]|[^\001-\177])*)*[[:space:]]*![[:space:]]*[([{]/)) {
+                    ip++; continue
                 }
-                ioff = iap + 7
+                mlen = RLENGTH
+                mname = substr(mrest, 1, mlen)
+                dopen = substr(mrest, mlen, 1)
+                dclose = (dopen == "{") ? "}" : (dopen == "(" ? ")" : "]")
+                sub(/[[:space:]]*![[:space:]]*[([{]$/, "", mname)
+                sub(/^.*::[[:space:]]*/, "", mname)
+                sub(/^r#/, "", mname)
+                dstart = ip + mlen - 1
+                depth = 1; dend = dstart + 1
+                while (dend <= n && depth > 0) {
+                    if (substr(mc, dend, 1) == dopen) depth++
+                    else if (substr(mc, dend, 1) == dclose) depth--
+                    dend++
+                }
+                if (depth > 0) return
+                if (mname == "include") {
+                    val = include_value(substr(mc, dstart + 1, dend - dstart - 2), \
+                                        substr(oc, dstart + 1, dend - dstart - 2))
+                    if (val != "")
+                        printf "%s\t%s\n", (inc_gated ? "G" : "U"), normpath(join(fdir, val))
+                }
+                ip = dend
             }
         }
         # Lines are NOT items: source is accumulated into a cross-line
@@ -319,8 +367,9 @@ scan_decl_records() {
                 # contributing nothing to the pending outer-attribute gate
                 # state, so the next declaration still scans.
                 if (mbuf ~ /^#[[:space:]]*![[:space:]]*\[/) {
-                    if (match(mbuf, /^#[[:space:]]*![[:space:]]*\[[^]]*\][[:space:]]*/)) {
-                        buf = substr(buf, RLENGTH + 1); mbuf = substr(mbuf, RLENGTH + 1)
+                    alen = attr_len(mbuf)
+                    if (alen > 0) {
+                        buf = substr(buf, alen + 1); mbuf = substr(mbuf, alen + 1)
                         continue
                     }
                     break
@@ -328,8 +377,8 @@ scan_decl_records() {
                 # Attribute item. An opened-but-unclosed one waits for the
                 # next line (rustc accepts attributes split across lines).
                 if (mbuf ~ /^#[[:space:]]*\[/) {
-                    if (match(mbuf, /^#[[:space:]]*\[[^]]*\][[:space:]]*/)) {
-                        alen = RLENGTH
+                    alen = attr_len(mbuf)
+                    if (alen > 0) {
                         mattr = substr(mbuf, 1, alen)
                         oattr = substr(buf, 1, alen)
                         # rustc accepts whitespace between attribute tokens
@@ -427,11 +476,10 @@ scan_decl_records() {
                         ipos++
                     }
                     if (idepth > 0) break
-                    iseg = substr(mbuf, idelim + 1, ipos - idelim - 2)
-                    if (match(iseg, /^[[:space:]]*(r#*)?"[^"]*"#*[[:space:]]*$/) \
-                        && match(iseg, /"[^"]*"/))
-                        printf "%s\t%s\n", (gated ? "G" : "U"), \
-                            normpath(join(fdir, substr(substr(buf, idelim + 1, ipos - idelim - 2), RSTART + 1, RLENGTH - 2)))
+                    ival = include_value(substr(mbuf, idelim + 1, ipos - idelim - 2), \
+                                         substr(buf, idelim + 1, ipos - idelim - 2))
+                    if (ival != "")
+                        printf "%s\t%s\n", (gated ? "G" : "U"), normpath(join(fdir, ival))
                     buf = substr(buf, ipos); mbuf = substr(mbuf, ipos)
                     if (mbuf ~ /^[[:space:]]*;/) {
                         sub(/^[[:space:]]*;/, "", buf); sub(/^[[:space:]]*;/, "", mbuf)

--- a/skills/github/scripts/git-diff-summary
+++ b/skills/github/scripts/git-diff-summary
@@ -67,10 +67,12 @@ resolve_default_base() {
 # via Cargo.toml `path =` wiring; include! calls with computed paths
 # (concat!/env!) are not matched; #[path]/include! declarations living in
 # a directory that is neither the candidate's own nor one of its ancestors
-# are not consulted; and a /* opener inside a string literal reads as a
-# comment and can hide a later ungated declaration. A file that is
-# production-reachable only through one of those shapes while also
-# carrying a #[cfg(test)]-gated declaration still classifies as test.
+# are not consulted; declarations inside inline module blocks are skipped
+# outright (no records — never a mis-resolved one); and a /* opener inside
+# a string literal reads as a comment and can hide a later ungated
+# declaration. A file that is production-reachable only through one of
+# those shapes while also carrying a #[cfg(test)]-gated declaration still
+# classifies as test.
 
 # Emits the new-side content of a file: HEAD for a base...HEAD diff, the
 # index for --staged, the worktree for --head. Reads main()'s diff_ref.
@@ -125,9 +127,11 @@ new_side_rs_siblings() {
 # mod-rs files (mod.rs, lib.rs, main.rs) their own directory; for any other
 # file its directory plus its stem as a subdirectory. fdir is the file's
 # own directory: per the Rust reference, #[path] values on modules NOT
-# inside inline module blocks resolve there (the mod-rs distinction only
-# changes #[path] inside inline blocks, which this scanner does not parse —
-# stated limitation), and the std docs anchor include! literals there too.
+# inside inline module blocks resolve there, and the std docs anchor
+# include! literals there too. Inline module blocks (mod name { ... })
+# resolve into the inline chain instead, which this scanner does not
+# model — everything inside them is skipped by brace depth, emitting no
+# records at all.
 scan_decl_records() {
     awk -v moddir="$1" -v fdir="$2" '
         function join(d, b) { return d == "." ? b : d "/" b }
@@ -169,12 +173,37 @@ scan_decl_records() {
             # Blank and comment-only lines keep pending attributes (attrs
             # may precede their item across lines).
             if (line == "") next
+            # Declarations inside inline module blocks (mod name { ... })
+            # resolve into the inline module chain, which this scanner does
+            # not model. A shape it cannot faithfully parse must produce NO
+            # record — never a mis-resolved one — so the whole block is
+            # skipped by brace depth, and pending state cannot leak across
+            # the boundary.
+            if (inline_depth > 0) {
+                tmp = line
+                inline_depth += gsub(/\{/, "{", tmp) - gsub(/\}/, "}", tmp)
+                if (inline_depth < 0) inline_depth = 0
+                gated = 0; pathattr = ""; pending_attr = ""; pending_include = 0
+                next
+            }
             # An attribute opened but not closed on the previous line
             # (rustc accepts `#[path =` split from its value) continues
             # here; rejoin before parsing.
             if (pending_attr != "") {
                 line = pending_attr " " line
                 pending_attr = ""
+            }
+            # An inline-module opener left open at end of line starts a
+            # skip region (a single-line `mod m { ... }` nets zero and
+            # stays inert — its inner declarations never anchor at ^).
+            if (line ~ /^(pub([(][^)]*[)])?[[:space:]]+)?mod[[:space:]]+[A-Za-z_][A-Za-z0-9_]*[[:space:]]*\{/) {
+                tmp = line
+                delta = gsub(/\{/, "{", tmp) - gsub(/\}/, "}", tmp)
+                if (delta > 0) {
+                    inline_depth = delta
+                    gated = 0; pathattr = ""; pending_include = 0
+                    next
+                }
             }
             # include! routes resolve their string-literal argument. A
             # literal on a later line (formatted call left open) is tracked
@@ -205,11 +234,12 @@ scan_decl_records() {
             while (match(line, /^#\[[^]]*\][[:space:]]*/)) {
                 attr = substr(line, 1, RLENGTH)
                 if (attr ~ /^#\[cfg\(test\)\]/) gated = 1
-                # Plain and raw (r"...") string values; r#"..."# stays a
-                # stated limitation.
-                if (attr ~ /^#\[path[[:space:]]*=[[:space:]]*r?"/) {
+                # Plain and raw string values, including hash-raw
+                # (r"...", r#"..."#); a literal quote INSIDE a hash-raw
+                # value would cut early — pathological for a file path.
+                if (attr ~ /^#\[path[[:space:]]*=[[:space:]]*(r#*)?"/) {
                     p = attr
-                    sub(/^#\[path[[:space:]]*=[[:space:]]*r?"/, "", p)
+                    sub(/^#\[path[[:space:]]*=[[:space:]]*(r#*)?"/, "", p)
                     sub(/".*/, "", p)
                     pathattr = p
                 }

--- a/skills/github/scripts/git-diff-summary
+++ b/skills/github/scripts/git-diff-summary
@@ -281,6 +281,11 @@ scan_decl_records() {
         # An incomplete tail (open attribute, unterminated statement,
         # unclosed inline block) stays in the buffer for the next line.
         {
+            # Crate shebang: Rust permits #! followed by anything but [ as
+            # the FIRST LINE only — a preamble, not an item. Dropped here,
+            # or the generic-item branch would consume it together with
+            # the next declaration through its semicolon.
+            if (NR == 1 && $0 ~ /^#!/ && $0 !~ /^#![[:space:]]*\[/) next
             mask_line($0)
             if (buf == "") { buf = ml_orig; mbuf = ml_mask }
             else { buf = buf " " ml_orig; mbuf = mbuf " " ml_mask }

--- a/skills/github/scripts/git-diff-summary
+++ b/skills/github/scripts/git-diff-summary
@@ -57,38 +57,85 @@ resolve_default_base() {
 # File-local heuristics cannot see that, so classification also reads the
 # modules that could declare the file on the diff's new side: a file whose
 # every found declaration is #[cfg(test)]-gated is test scope; any ungated
-# declaration, or none found, keeps the file-local classification.
+# declaration or `include!` of the file, or none found, keeps the file-local
+# classification. Any read failure during scanning also keeps it (fail
+# closed: an unreadable declaring module could have held an ungated route).
+#
+# Residual limitations: production routes the scanner cannot see can still
+# let a gated declaration win. Crate roots are only recognized by the bin/
+# directory convention (candidates under a bin/ segment are skipped), not
+# via Cargo.toml `path =` wiring; include! calls with computed paths
+# (concat!/env!) are not matched; and a /* opener inside a string literal
+# reads as a comment and can hide a later ungated declaration. A file that
+# is production-reachable only through one of those shapes while also
+# carrying a #[cfg(test)]-gated declaration still classifies as test.
 
-# New-side content of a file: HEAD for a base...HEAD diff, the index for
-# --staged, the worktree for --head. Reads main()'s diff_ref.
+# Emits the new-side content of a file: HEAD for a base...HEAD diff, the
+# index for --staged, the worktree for --head. Reads main()'s diff_ref.
+# Exit 0 with content when readable, 2 when the file does not exist on the
+# new side, 1 on a read failure — callers must fail closed on 1.
 new_side_content() {
     case "$diff_ref" in
-        --staged) git show ":$1" 2>/dev/null || true ;;
-        HEAD)     cat "$1" 2>/dev/null || true ;;
-        *)        git show "HEAD:$1" 2>/dev/null || true ;;
+        --staged)
+            git ls-files --error-unmatch -- "$1" >/dev/null 2>&1 || return 2
+            git show ":$1" 2>/dev/null || return 1
+            ;;
+        HEAD)
+            [ -e "$1" ] || return 2
+            cat "$1" 2>/dev/null || return 1
+            ;;
+        *)
+            git cat-file -e "HEAD:$1" 2>/dev/null || return 2
+            git show "HEAD:$1" 2>/dev/null || return 1
+            ;;
     esac
 }
 
-# New-side .rs files directly inside a directory (no recursion).
+# New-side tracked .rs files directly inside a directory (no recursion).
+# --head reads the index too: git diff HEAD never surfaces untracked files,
+# and an untracked declaration must not reclassify a tracked change.
 new_side_rs_siblings() {
     case "$diff_ref" in
-        --staged) git ls-files -- "$1" 2>/dev/null ;;
-        HEAD)     find "$1" -maxdepth 1 -name '*.rs' 2>/dev/null ;;
-        *)        git ls-tree --name-only HEAD -- "$1/" 2>/dev/null ;;
+        --staged|HEAD) git ls-files -- "$1" 2>/dev/null ;;
+        *)             git ls-tree --name-only HEAD -- "$1/" 2>/dev/null ;;
     esac | awk -v d="$1/" 'index($0, d) == 1 && substr($0, length(d) + 1) !~ /\// && /\.rs$/'
 }
 
 # Print one line per `mod name;` declaration on stdin that resolves to the
 # candidate file: "gated" when #[cfg(test)] is among its attributes, else
-# "ungated". stem/rel: candidate module name and path relative to the
-# declaring file's directory. allow_name: whether a bare `mod stem;` resolves
-# to the candidate (true for mod.rs/lib.rs/main.rs siblings and the 2018-style
-# parent file; other siblings resolve `mod x;` into their own subdirectory).
+# "ungated". An include! naming the candidate's file also prints "ungated":
+# included content compiles in the includer's cfg context, so it is a
+# production route. stem/rel/basefile: candidate module name, path relative
+# to the declaring file's directory, and bare file name. allow_name: whether
+# a bare `mod stem;` resolves to the candidate (true for mod.rs/lib.rs/
+# main.rs siblings and the 2018-style parent file; other siblings resolve
+# `mod x;` into their own subdirectory).
 scan_mod_decls() {
-    awk -v stem="$1" -v rel="$2" -v allow_name="$3" '
+    awk -v stem="$1" -v rel="$2" -v allow_name="$3" -v basefile="$4" '
         {
             line = $0
+            # Coarse /* */ tracker: declaration text inside a block comment
+            # must not read as a real declaration (a commented-out
+            # #[cfg(test)] mod could otherwise downgrade production code).
+            if (incomment) {
+                i = index(line, "*/")
+                if (i == 0) next
+                line = substr(line, i + 2)
+                incomment = 0
+            }
+            while ((i = index(line, "/*")) > 0) {
+                rest = substr(line, i + 2)
+                j = index(rest, "*/")
+                if (j == 0) {
+                    line = substr(line, 1, i - 1)
+                    incomment = 1
+                    break
+                }
+                line = substr(line, 1, i - 1) substr(rest, j + 2)
+            }
             sub(/^[[:space:]]*/, "", line)
+            if (index(line, "include!") > 0 && index(line, basefile) > 0)
+                print "ungated"
             # Consume leading attributes; several may share the decl line.
             while (match(line, /^#\[[^]]*\][[:space:]]*/)) {
                 attr = substr(line, 1, RLENGTH)
@@ -120,11 +167,15 @@ scan_mod_decls() {
 
 is_cfg_test_declared() {
     local candidate="$1"
-    local base stem dir parent pdirname parent_file f fdir rel allow out decls=""
+    local basefile stem dir parent pdirname parent_file f fdir rel allow
+    local content rc out decls=""
     case "$candidate" in */*) ;; *) return 1 ;; esac
-    base=${candidate##*/}
-    case "$base" in mod.rs|lib.rs|main.rs) return 1 ;; esac
-    stem=${base%.rs}
+    # A bin/ segment marks crate roots: reachable by the build without any
+    # mod declaration, so a gated declaration does not make them test-only.
+    case "$candidate" in bin/*|*/bin/*) return 1 ;; esac
+    basefile=${candidate##*/}
+    case "$basefile" in mod.rs|lib.rs|main.rs) return 1 ;; esac
+    stem=${basefile%.rs}
     dir=${candidate%/*}
     parent=$(dirname "$dir")
     pdirname=${dir##*/}
@@ -138,8 +189,14 @@ is_cfg_test_declared() {
         esac
         fdir=${f%/*}
         [ "$f" = "${f#*/}" ] && fdir="."
-        if [ "$fdir" = "$dir" ]; then rel="$base"; else rel="$pdirname/$base"; fi
-        out=$(new_side_content "$f" | scan_mod_decls "$stem" "$rel" "$allow")
+        if [ "$fdir" = "$dir" ]; then rel="$basefile"; else rel="$pdirname/$basefile"; fi
+        rc=0
+        content=$(new_side_content "$f") || rc=$?
+        # Absent on the new side: nothing to scan. Unreadable: fail closed —
+        # the file could have held an ungated route.
+        if [ "$rc" -eq 2 ]; then continue; fi
+        if [ "$rc" -ne 0 ]; then return 1; fi
+        out=$(printf '%s\n' "$content" | scan_mod_decls "$stem" "$rel" "$allow" "$basefile")
         decls="$decls$out"$'\n'
     done
     case "$decls" in *ungated*) return 1 ;; esac

--- a/skills/github/scripts/git-diff-summary
+++ b/skills/github/scripts/git-diff-summary
@@ -407,6 +407,36 @@ scan_decl_records() {
                         gated = 0; pathattr = ""
                         continue
                     }
+                    # include! handled HERE for every delimiter form: the
+                    # generic boundary would cut a brace-form argument at
+                    # the opening brace and then skip it as a body, losing
+                    # the route. Find the matching close at depth 0 on the
+                    # mask; a direct string-literal argument emits with
+                    # the pending gate, anything else is a computed
+                    # argument (declared no-record) consumed silently. No
+                    # close in the buffer yet means the call continues on
+                    # a later line: wait for it.
+                    idelim = RLENGTH
+                    iclose = (mdelim == "{") ? "}" : (mdelim == "(" ? ")" : "]")
+                    idepth = 1; ipos = idelim + 1; blen2 = length(mbuf)
+                    while (ipos <= blen2 && idepth > 0) {
+                        ic = substr(mbuf, ipos, 1)
+                        if (ic == mdelim) idepth++
+                        else if (ic == iclose) idepth--
+                        ipos++
+                    }
+                    if (idepth > 0) break
+                    iseg = substr(mbuf, idelim + 1, ipos - idelim - 2)
+                    if (match(iseg, /^[[:space:]]*(r#*)?"[^"]*"[[:space:]]*$/) \
+                        && match(iseg, /"[^"]*"/))
+                        printf "%s\t%s\n", (gated ? "G" : "U"), \
+                            normpath(join(fdir, substr(substr(buf, idelim + 1, ipos - idelim - 2), RSTART + 1, RLENGTH - 2)))
+                    buf = substr(buf, ipos); mbuf = substr(mbuf, ipos)
+                    if (mbuf ~ /^[[:space:]]*;/) {
+                        sub(/^[[:space:]]*;/, "", buf); sub(/^[[:space:]]*;/, "", mbuf)
+                    }
+                    gated = 0; pathattr = ""
+                    continue
                 }
                 # Any other item: consume to the next boundary (; { or })
                 # on the mask, scanning the chunk for include! routes. A

--- a/skills/github/scripts/git-diff-summary
+++ b/skills/github/scripts/git-diff-summary
@@ -65,9 +65,11 @@ resolve_default_base() {
 # let a gated declaration win. Crate roots are only recognized by the bin/
 # directory convention (candidates under a bin/ segment are skipped), not
 # via Cargo.toml `path =` wiring; include! calls with computed paths
-# (concat!/env!) are not matched; and a /* opener inside a string literal
-# reads as a comment and can hide a later ungated declaration. A file that
-# is production-reachable only through one of those shapes while also
+# (concat!/env!) are not matched; #[path]/include! declarations living in
+# a directory that is neither the candidate's own nor one of its ancestors
+# are not consulted; and a /* opener inside a string literal reads as a
+# comment and can hide a later ungated declaration. A file that is
+# production-reachable only through one of those shapes while also
 # carrying a #[cfg(test)]-gated declaration still classifies as test.
 
 # Emits the new-side content of a file: HEAD for a base...HEAD diff, the
@@ -102,16 +104,20 @@ new_side_rs_siblings() {
     case "$diff_ref" in
         --staged|HEAD) git ls-files -- "$1" 2>/dev/null ;;
         *)             git ls-tree --name-only HEAD -- "$1/" 2>/dev/null ;;
-    esac | awk -v d="$1/" 'index($0, d) == 1 && substr($0, length(d) + 1) !~ /\// && /\.rs$/'
+    esac | awk -v d="$1" '
+        !/\.rs$/ { next }
+        d == "." { if ($0 !~ /\//) print; next }
+        { p = d "/" }
+        index($0, p) == 1 && substr($0, length(p) + 1) !~ /\// { print }
+    '
 }
 
 # Emit one candidate-agnostic record per finding in the declaring module on
 # stdin, so a file is parsed once no matter how many candidates consult it:
 #   G<TAB><target>   mod declaration with #[cfg(test)] among its attributes
 #   U<TAB><target>   mod declaration without the gate
-#   I<TAB><line>     line calling include! (matched per candidate later; an
-#                    include compiles in the includer's cfg context, so it
-#                    is an ungated production route)
+#   I<TAB><target>   include! of the target file (an include compiles in the
+#                    includer's cfg context — an ungated production route)
 # <target> is the repo-relative file the declaration resolves to. moddir is
 # where this file's declarations land: for mod-rs files (mod.rs, lib.rs,
 # main.rs) their own directory; for any other file its directory plus its
@@ -144,7 +150,24 @@ scan_decl_records() {
             # Blank and comment-only lines keep pending attributes (attrs
             # may precede their item across lines).
             if (line == "") next
-            if (index(line, "include!") > 0) printf "I\t%s\n", line
+            # include! routes resolve their string-literal argument like
+            # module declarations do. A literal on a later line (formatted
+            # call) is tracked across lines until the closing paren; a call
+            # with no literal at all (computed path) stays unmatched —
+            # stated limitation.
+            if (pending_include) {
+                if (match(line, /"[^"]*"/)) {
+                    printf "I\t%s\n", join(moddir, substr(line, RSTART + 1, RLENGTH - 2))
+                    pending_include = 0
+                } else if (index(line, ")") > 0) pending_include = 0
+            }
+            pos = index(line, "include!")
+            if (pos > 0) {
+                rest = substr(line, pos)
+                if (match(rest, /"[^"]*"/))
+                    printf "I\t%s\n", join(moddir, substr(rest, RSTART + 1, RLENGTH - 2))
+                else pending_include = 1
+            }
             # Consume leading attributes; several may share the decl line.
             while (match(line, /^#\[[^]]*\][[:space:]]*/)) {
                 attr = substr(line, 1, RLENGTH)
@@ -174,17 +197,21 @@ scan_decl_records() {
 
 # Scan caches (Bash 3.2-safe string accumulators, no associative arrays):
 # DECL_CACHE holds one `<file><TAB><filedir><TAB><record...>` line per
-# scanned finding (kind ERR marks an unreadable file); SCANNED_FILES and
-# LISTED_DIRS are newline-delimited membership sets.
+# scanned finding (kind ERR marks an unreadable file); SCANNED_DIRS is a
+# newline-delimited membership set checked by exact line match, so paths
+# never meet glob interpretation. Scan state is tracked per DIRECTORY —
+# each directory's files are read once, and membership is consulted a
+# handful of times per candidate instead of once per file.
 DECL_CACHE=""
-SCANNED_FILES=$'\n'
-DIR_LIST_CACHE=""
-LISTED_DIRS=$'\n'
+SCANNED_DIRS=""
 
-# Scan a declaring module once, appending its records to DECL_CACHE.
+set_contains() {
+    printf '%s' "$2" | grep -Fxq -- "$1"
+}
+
+# Scan one declaring module, appending its records to DECL_CACHE. Called
+# only from scan_dir_declaring_files, which guarantees once-per-file.
 scan_declaring_file() {
-    case "$SCANNED_FILES" in *$'\n'"$1"$'\n'*) return 0 ;; esac
-    SCANNED_FILES="$SCANNED_FILES$1"$'\n'
     local fdir fbase fstem moddir rc content records
     fdir=${1%/*}
     [ "$1" = "${1#*/}" ] && fdir="."
@@ -209,23 +236,22 @@ scan_declaring_file() {
     return 0
 }
 
-# Tracked .rs files directly inside a directory, listed once per directory.
-rs_siblings_cached() {
-    case "$LISTED_DIRS" in
-        *$'\n'"$1"$'\n'*) ;;
-        *)
-            LISTED_DIRS="$LISTED_DIRS$1"$'\n'
-            local listing
-            listing=$(new_side_rs_siblings "$1" | awk -v d="$1" '{print d "\t" $0}')
-            [ -n "$listing" ] && DIR_LIST_CACHE="$DIR_LIST_CACHE$listing"$'\n'
-            ;;
-    esac
-    printf '%s\n' "$DIR_LIST_CACHE" | awk -F'\t' -v d="$1" '$1 == d {print $2}'
+# Scan every tracked .rs file directly inside a directory, once per
+# directory; the per-candidate evaluator filters the records afterwards
+# (including dropping the candidate's own).
+scan_dir_declaring_files() {
+    set_contains "$1" "$SCANNED_DIRS" && return 0
+    SCANNED_DIRS="$SCANNED_DIRS$1"$'\n'
+    local f
+    while IFS= read -r f; do
+        [ -n "$f" ] || continue
+        scan_declaring_file "$f"
+    done < <(new_side_rs_siblings "$1")
 }
 
 is_cfg_test_declared() {
     local candidate="$1"
-    local basefile dir parent pdirname parent_file f routes
+    local basefile dir d relevant_dirs routes
     case "$candidate" in */*) ;; *) return 1 ;; esac
     # A bin/ segment marks crate roots: reachable by the build without any
     # mod declaration, so a gated declaration does not make them test-only.
@@ -233,25 +259,34 @@ is_cfg_test_declared() {
     basefile=${candidate##*/}
     case "$basefile" in mod.rs|lib.rs|main.rs) return 1 ;; esac
     dir=${candidate%/*}
-    parent=$(dirname "$dir")
-    pdirname=${dir##*/}
-    parent_file="$parent/$pdirname.rs"
-    [ "$parent" = "." ] && parent_file="$pdirname.rs"
-    for f in $(rs_siblings_cached "$dir") "$parent_file"; do
-        [ "$f" = "$candidate" ] && continue
-        scan_declaring_file "$f"
+    # Declaring modules are consulted from the candidate's own directory and
+    # every ancestor directory up to the repo root: same-dir siblings, the
+    # 2018-style parent file, and crate roots declaring nested files through
+    # an out-of-directory #[path]. Non-ancestor declarers are the stated
+    # header limitation.
+    relevant_dirs="$dir"
+    d="$dir"
+    while [ "$d" != "${d%/*}" ]; do
+        d="${d%/*}"
+        relevant_dirs="$relevant_dirs"$'\n'"$d"
     done
-    # Evaluate the cached records this candidate's declaring set produced:
-    # same-directory siblings plus the 2018-style parent file.
+    [ "$d" != "." ] && relevant_dirs="$relevant_dirs"$'\n'"."
+    while IFS= read -r d; do
+        [ -n "$d" ] || continue
+        scan_dir_declaring_files "$d"
+    done < <(printf '%s\n' "$relevant_dirs")
+    # Evaluate the cached records. Declarations and includes match on their
+    # RESOLVED target, so a route discovered by any scan is genuine no
+    # matter which candidate prompted it; ERR (unreadable module) fails this
+    # candidate closed only when the file sits in its consulted set.
     routes=$(printf '%s\n' "$DECL_CACHE" | awk -F'\t' \
-        -v cand="$candidate" -v basefile="$basefile" -v dir="$dir" -v pfile="$parent_file" '
+        -v cand="$candidate" -v dirs="$relevant_dirs" '
+        BEGIN { n = split(dirs, a, "\n"); for (i = 1; i <= n; i++) rd[a[i]] = 1 }
         $1 == cand { next }
-        $2 != dir && $1 != pfile { next }
-        $3 == "ERR" { print "err"; next }
-        $3 == "I" { if (index($4, basefile) > 0) print "ungated"; next }
+        $3 == "ERR" { if ($2 in rd) print "err"; next }
         $4 != cand { next }
-        $3 == "G" { print "gated" }
-        $3 == "U" { print "ungated" }
+        $3 == "G" { print "gated"; next }
+        $3 == "U" || $3 == "I" { print "ungated" }
     ')
     case "$routes" in *err*) return 1 ;; esac
     case "$routes" in *ungated*) return 1 ;; esac
@@ -324,13 +359,14 @@ main() {
     # Changed .rs files that carry no file-local test markers but are reached
     # only through #[cfg(test)]-gated declarations are test scope (vstack#1217).
     local cfg_test_declared="" rs_candidate
-    for rs_candidate in $(echo "$files" | awk -F'\t' '{print $NF}' \
-            | grep -E '\.rs$' \
-            | grep -vE '(/tests?/|/benches/|/fixtures/|_tests?\.rs$)' || true); do
+    while IFS= read -r rs_candidate; do
+        [ -n "$rs_candidate" ] || continue
         if is_cfg_test_declared "$rs_candidate"; then
             cfg_test_declared="$cfg_test_declared$rs_candidate"$'\n'
         fi
-    done
+    done < <(echo "$files" | awk -F'\t' '{print $NF}' \
+        | grep -E '\.rs$' \
+        | grep -vE '(/tests?/|/benches/|/fixtures/|_tests?\.rs$)' || true)
 
     local prod_paths
     prod_paths=$(echo "$files" | awk -F'\t' '{print $NF}' \

--- a/skills/github/scripts/git-diff-summary
+++ b/skills/github/scripts/git-diff-summary
@@ -118,14 +118,32 @@ new_side_rs_siblings() {
 #   U<TAB><target>   mod declaration without the gate
 #   I<TAB><target>   include! of the target file (an include compiles in the
 #                    includer's cfg context — an ungated production route)
-# <target> is the repo-relative file the declaration resolves to. moddir is
-# where this file's declarations land: for mod-rs files (mod.rs, lib.rs,
-# main.rs) their own directory; for any other file its directory plus its
-# stem as a subdirectory — both bare `mod name;` and #[path] values resolve
-# there, per the Rust reference's module path rules.
+# <target> is the repo-relative file the declaration resolves to, lexically
+# normalized (`.`/`..` segments folded) so equivalent spellings compare
+# equal. A bare `mod name;` emits both of its legal forms, name.rs and
+# name/mod.rs. moddir is where mod declarations land: for mod-rs files
+# (mod.rs, lib.rs, main.rs) their own directory; for any other file its
+# directory plus its stem as a subdirectory — both bare `mod name;` and
+# #[path] values resolve there, per the Rust reference's module path rules.
+# fdir is the file's own directory: include! literals resolve there (the
+# std docs anchor them to the containing FILE), not in moddir.
 scan_decl_records() {
-    awk -v moddir="$1" '
+    awk -v moddir="$1" -v fdir="$2" '
         function join(d, b) { return d == "." ? b : d "/" b }
+        # Lexical cleanup only — no symlink resolution. A path that escapes
+        # the repo root normalizes to "" and can never match a candidate.
+        function normpath(p,   parts, n, i, top, stack, out) {
+            n = split(p, parts, "/")
+            top = 0
+            for (i = 1; i <= n; i++) {
+                if (parts[i] == "" || parts[i] == ".") continue
+                if (parts[i] == "..") { if (top > 0) top--; else return "" }
+                else stack[++top] = parts[i]
+            }
+            out = ""
+            for (i = 1; i <= top; i++) out = out (i > 1 ? "/" : "") stack[i]
+            return out
+        }
         # Comment stripping with Rust semantics the coarse version missed:
         # // takes precedence over /* on the same line, and block comments
         # nest (depth counter, carried across lines). A /* inside a string
@@ -157,7 +175,7 @@ scan_decl_records() {
             # stated limitation.
             if (pending_include) {
                 if (match(line, /"[^"]*"/)) {
-                    printf "I\t%s\n", join(moddir, substr(line, RSTART + 1, RLENGTH - 2))
+                    printf "I\t%s\n", normpath(join(fdir, substr(line, RSTART + 1, RLENGTH - 2)))
                     pending_include = 0
                 } else if (index(line, ")") > 0) pending_include = 0
             }
@@ -165,7 +183,7 @@ scan_decl_records() {
             if (pos > 0) {
                 rest = substr(line, pos)
                 if (match(rest, /"[^"]*"/))
-                    printf "I\t%s\n", join(moddir, substr(rest, RSTART + 1, RLENGTH - 2))
+                    printf "I\t%s\n", normpath(join(fdir, substr(rest, RSTART + 1, RLENGTH - 2)))
                 else pending_include = 1
             }
             # Consume leading attributes; several may share the decl line.
@@ -186,8 +204,15 @@ scan_decl_records() {
                 sub(/^pub([(][^)]*[)])?[[:space:]]+/, "", name)
                 sub(/^mod[[:space:]]+/, "", name)
                 sub(/[[:space:]]*;.*$/, "", name)
-                target = (pathattr != "") ? join(moddir, pathattr) : join(moddir, name ".rs")
-                printf "%s\t%s\n", (gated ? "G" : "U"), target
+                kind = (gated ? "G" : "U")
+                if (pathattr != "")
+                    printf "%s\t%s\n", kind, normpath(join(moddir, pathattr))
+                else {
+                    # Both legal forms of a bare declaration: name.rs and
+                    # the directory form name/mod.rs.
+                    printf "%s\t%s\n", kind, normpath(join(moddir, name ".rs"))
+                    printf "%s\t%s\n", kind, normpath(join(moddir, name "/mod.rs"))
+                }
             }
             gated = 0
             pathattr = ""
@@ -230,7 +255,7 @@ scan_declaring_file() {
         DECL_CACHE="$DECL_CACHE$1"$'\t'"$fdir"$'\t'ERR$'\n'
         return 0
     fi
-    records=$(printf '%s\n' "$content" | scan_decl_records "$moddir" \
+    records=$(printf '%s\n' "$content" | scan_decl_records "$moddir" "$fdir" \
         | awk -v f="$1" -v d="$fdir" '{print f "\t" d "\t" $0}')
     [ -n "$records" ] && DECL_CACHE="$DECL_CACHE$records"$'\n'
     return 0
@@ -257,7 +282,10 @@ is_cfg_test_declared() {
     # mod declaration, so a gated declaration does not make them test-only.
     case "$candidate" in bin/*|*/bin/*) return 1 ;; esac
     basefile=${candidate##*/}
-    case "$basefile" in mod.rs|lib.rs|main.rs) return 1 ;; esac
+    # lib.rs/main.rs are crate roots — reachable without a declaration. A
+    # mod.rs is NOT skipped: the directory form of `mod name;` legitimately
+    # resolves to name/mod.rs, and its declaration site can carry the gate.
+    case "$basefile" in lib.rs|main.rs) return 1 ;; esac
     dir=${candidate%/*}
     # Declaring modules are consulted from the candidate's own directory and
     # every ancestor directory up to the repo root: same-dir siblings, the

--- a/skills/github/scripts/git-diff-summary
+++ b/skills/github/scripts/git-diff-summary
@@ -81,6 +81,10 @@ new_side_content() {
             git show ":$1" 2>/dev/null || return 1
             ;;
         HEAD)
+            # Tracked-only, like the sibling listing: an untracked file in
+            # the worktree (e.g. the 2018-style parent path) must not carry
+            # declarations that reclassify a tracked change.
+            git ls-files --error-unmatch -- "$1" >/dev/null 2>&1 || return 2
             [ -e "$1" ] || return 2
             cat "$1" 2>/dev/null || return 1
             ;;
@@ -101,41 +105,46 @@ new_side_rs_siblings() {
     esac | awk -v d="$1/" 'index($0, d) == 1 && substr($0, length(d) + 1) !~ /\// && /\.rs$/'
 }
 
-# Print one line per `mod name;` declaration on stdin that resolves to the
-# candidate file: "gated" when #[cfg(test)] is among its attributes, else
-# "ungated". An include! naming the candidate's file also prints "ungated":
-# included content compiles in the includer's cfg context, so it is a
-# production route. stem/rel/basefile: candidate module name, path relative
-# to the declaring file's directory, and bare file name. allow_name: whether
-# a bare `mod stem;` resolves to the candidate (true for mod.rs/lib.rs/
-# main.rs siblings and the 2018-style parent file; other siblings resolve
-# `mod x;` into their own subdirectory).
-scan_mod_decls() {
-    awk -v stem="$1" -v rel="$2" -v allow_name="$3" -v basefile="$4" '
+# Emit one candidate-agnostic record per finding in the declaring module on
+# stdin, so a file is parsed once no matter how many candidates consult it:
+#   G<TAB><target>   mod declaration with #[cfg(test)] among its attributes
+#   U<TAB><target>   mod declaration without the gate
+#   I<TAB><line>     line calling include! (matched per candidate later; an
+#                    include compiles in the includer's cfg context, so it
+#                    is an ungated production route)
+# <target> is the repo-relative file the declaration resolves to. moddir is
+# where this file's declarations land: for mod-rs files (mod.rs, lib.rs,
+# main.rs) their own directory; for any other file its directory plus its
+# stem as a subdirectory — both bare `mod name;` and #[path] values resolve
+# there, per the Rust reference's module path rules.
+scan_decl_records() {
+    awk -v moddir="$1" '
+        function join(d, b) { return d == "." ? b : d "/" b }
+        # Comment stripping with Rust semantics the coarse version missed:
+        # // takes precedence over /* on the same line, and block comments
+        # nest (depth counter, carried across lines). A /* inside a string
+        # literal still reads as a comment — stated limitation.
+        function strip_comments(s,   out, i, n, two) {
+            out = ""; i = 1; n = length(s)
+            while (i <= n) {
+                two = substr(s, i, 2)
+                if (cdepth > 0) {
+                    if (two == "*/") { cdepth--; i += 2 }
+                    else if (two == "/*") { cdepth++; i += 2 }
+                    else i++
+                } else if (two == "//") break
+                else if (two == "/*") { cdepth = 1; i += 2 }
+                else { out = out substr(s, i, 1); i++ }
+            }
+            return out
+        }
         {
-            line = $0
-            # Coarse /* */ tracker: declaration text inside a block comment
-            # must not read as a real declaration (a commented-out
-            # #[cfg(test)] mod could otherwise downgrade production code).
-            if (incomment) {
-                i = index(line, "*/")
-                if (i == 0) next
-                line = substr(line, i + 2)
-                incomment = 0
-            }
-            while ((i = index(line, "/*")) > 0) {
-                rest = substr(line, i + 2)
-                j = index(rest, "*/")
-                if (j == 0) {
-                    line = substr(line, 1, i - 1)
-                    incomment = 1
-                    break
-                }
-                line = substr(line, 1, i - 1) substr(rest, j + 2)
-            }
+            line = strip_comments($0)
             sub(/^[[:space:]]*/, "", line)
-            if (index(line, "include!") > 0 && index(line, basefile) > 0)
-                print "ungated"
+            # Blank and comment-only lines keep pending attributes (attrs
+            # may precede their item across lines).
+            if (line == "") next
+            if (index(line, "include!") > 0) printf "I\t%s\n", line
             # Consume leading attributes; several may share the decl line.
             while (match(line, /^#\[[^]]*\][[:space:]]*/)) {
                 attr = substr(line, 1, RLENGTH)
@@ -148,16 +157,14 @@ scan_mod_decls() {
                 }
                 line = substr(line, RLENGTH + 1)
             }
-            # Blank/comment lines keep pending attributes (attrs may precede
-            # the item across lines).
-            if (line == "" || line ~ /^\/\//) next
+            if (line == "") next
             if (line ~ /^(pub([(][^)]*[)])?[[:space:]]+)?mod[[:space:]]+[A-Za-z_][A-Za-z0-9_]*[[:space:]]*;/) {
                 name = line
                 sub(/^pub([(][^)]*[)])?[[:space:]]+/, "", name)
                 sub(/^mod[[:space:]]+/, "", name)
                 sub(/[[:space:]]*;.*$/, "", name)
-                if (pathattr != "" ? pathattr == rel : (allow_name != 0 && name == stem))
-                    print (gated ? "gated" : "ungated")
+                target = (pathattr != "") ? join(moddir, pathattr) : join(moddir, name ".rs")
+                printf "%s\t%s\n", (gated ? "G" : "U"), target
             }
             gated = 0
             pathattr = ""
@@ -165,42 +172,90 @@ scan_mod_decls() {
     '
 }
 
+# Scan caches (Bash 3.2-safe string accumulators, no associative arrays):
+# DECL_CACHE holds one `<file><TAB><filedir><TAB><record...>` line per
+# scanned finding (kind ERR marks an unreadable file); SCANNED_FILES and
+# LISTED_DIRS are newline-delimited membership sets.
+DECL_CACHE=""
+SCANNED_FILES=$'\n'
+DIR_LIST_CACHE=""
+LISTED_DIRS=$'\n'
+
+# Scan a declaring module once, appending its records to DECL_CACHE.
+scan_declaring_file() {
+    case "$SCANNED_FILES" in *$'\n'"$1"$'\n'*) return 0 ;; esac
+    SCANNED_FILES="$SCANNED_FILES$1"$'\n'
+    local fdir fbase fstem moddir rc content records
+    fdir=${1%/*}
+    [ "$1" = "${1#*/}" ] && fdir="."
+    fbase=${1##*/}
+    fstem=${fbase%.rs}
+    case "$fbase" in
+        mod.rs|lib.rs|main.rs) moddir="$fdir" ;;
+        *) if [ "$fdir" = "." ]; then moddir="$fstem"; else moddir="$fdir/$fstem"; fi ;;
+    esac
+    rc=0
+    content=$(new_side_content "$1") || rc=$?
+    # Absent on the new side: nothing to record. Unreadable: an ERR record —
+    # every candidate consulting this file must fail closed.
+    if [ "$rc" -eq 2 ]; then return 0; fi
+    if [ "$rc" -ne 0 ]; then
+        DECL_CACHE="$DECL_CACHE$1"$'\t'"$fdir"$'\t'ERR$'\n'
+        return 0
+    fi
+    records=$(printf '%s\n' "$content" | scan_decl_records "$moddir" \
+        | awk -v f="$1" -v d="$fdir" '{print f "\t" d "\t" $0}')
+    [ -n "$records" ] && DECL_CACHE="$DECL_CACHE$records"$'\n'
+    return 0
+}
+
+# Tracked .rs files directly inside a directory, listed once per directory.
+rs_siblings_cached() {
+    case "$LISTED_DIRS" in
+        *$'\n'"$1"$'\n'*) ;;
+        *)
+            LISTED_DIRS="$LISTED_DIRS$1"$'\n'
+            local listing
+            listing=$(new_side_rs_siblings "$1" | awk -v d="$1" '{print d "\t" $0}')
+            [ -n "$listing" ] && DIR_LIST_CACHE="$DIR_LIST_CACHE$listing"$'\n'
+            ;;
+    esac
+    printf '%s\n' "$DIR_LIST_CACHE" | awk -F'\t' -v d="$1" '$1 == d {print $2}'
+}
+
 is_cfg_test_declared() {
     local candidate="$1"
-    local basefile stem dir parent pdirname parent_file f fdir rel allow
-    local content rc out decls=""
+    local basefile dir parent pdirname parent_file f routes
     case "$candidate" in */*) ;; *) return 1 ;; esac
     # A bin/ segment marks crate roots: reachable by the build without any
     # mod declaration, so a gated declaration does not make them test-only.
     case "$candidate" in bin/*|*/bin/*) return 1 ;; esac
     basefile=${candidate##*/}
     case "$basefile" in mod.rs|lib.rs|main.rs) return 1 ;; esac
-    stem=${basefile%.rs}
     dir=${candidate%/*}
     parent=$(dirname "$dir")
     pdirname=${dir##*/}
     parent_file="$parent/$pdirname.rs"
     [ "$parent" = "." ] && parent_file="$pdirname.rs"
-    for f in $(new_side_rs_siblings "$dir") "$parent_file"; do
+    for f in $(rs_siblings_cached "$dir") "$parent_file"; do
         [ "$f" = "$candidate" ] && continue
-        case "$f" in
-            "$dir/mod.rs"|"$dir/lib.rs"|"$dir/main.rs"|"$parent_file") allow=1 ;;
-            *) allow=0 ;;
-        esac
-        fdir=${f%/*}
-        [ "$f" = "${f#*/}" ] && fdir="."
-        if [ "$fdir" = "$dir" ]; then rel="$basefile"; else rel="$pdirname/$basefile"; fi
-        rc=0
-        content=$(new_side_content "$f") || rc=$?
-        # Absent on the new side: nothing to scan. Unreadable: fail closed —
-        # the file could have held an ungated route.
-        if [ "$rc" -eq 2 ]; then continue; fi
-        if [ "$rc" -ne 0 ]; then return 1; fi
-        out=$(printf '%s\n' "$content" | scan_mod_decls "$stem" "$rel" "$allow" "$basefile")
-        decls="$decls$out"$'\n'
+        scan_declaring_file "$f"
     done
-    case "$decls" in *ungated*) return 1 ;; esac
-    case "$decls" in *gated*) return 0 ;; esac
+    # Evaluate the cached records this candidate's declaring set produced:
+    # same-directory siblings plus the 2018-style parent file.
+    routes=$(printf '%s\n' "$DECL_CACHE" | awk -F'\t' \
+        -v cand="$candidate" -v basefile="$basefile" -v dir="$dir" -v pfile="$parent_file" '
+        $1 == cand { next }
+        $2 != dir && $1 != pfile { next }
+        $3 == "ERR" { print "err"; next }
+        $3 == "I" { if (index($4, basefile) > 0) print "ungated"; next }
+        $4 != cand { next }
+        $3 == "G" { print "gated" }
+        $3 == "U" { print "ungated" }
+    ')
+    case "$routes" in *err*) return 1 ;; esac
+    case "$routes" in *ungated*) return 1 ;; esac
+    case "$routes" in *gated*) return 0 ;; esac
     return 1
 }
 

--- a/skills/github/scripts/git-diff-summary
+++ b/skills/github/scripts/git-diff-summary
@@ -125,8 +125,10 @@ new_side_content() {
             # the worktree (e.g. the 2018-style parent path) must not carry
             # declarations that reclassify a tracked change.
             git ls-files --error-unmatch -- "$1" >/dev/null 2>&1 || return 2
+            # Before -e, which follows the link: a DANGLING symlink is
+            # unreadable, not absent, and absent emits no record at all.
+            if [ -L "$1" ]; then return 1; fi
             [ -e "$1" ] || return 2
-            [ -L "$1" ] && return 1
             cat "$1" 2>/dev/null || return 1
             ;;
         *)
@@ -195,6 +197,25 @@ scan_decl_records() {
         # leave attribute tokens to swallow the declaration that follows.
         # Quoted brackets are inert: the scan runs on the mask. 0 when the
         # attribute is not closed in this buffer yet (it continues next line).
+        # Offset of the first item boundary in the masked buffer. Braces
+        # bound an item at any depth, as before; a SEMICOLON does not when it
+        # sits inside a ( ) or [ ] token group — the length in an array type
+        # ([u8; 4]) is not the end of the item, and splitting there would
+        # drop the pending attribute gate and record what follows as ungated.
+        # 0 when the item has no boundary in this buffer yet.
+        function item_boundary(ms,   i, n, c, pd, bd) {
+            n = length(ms); pd = 0; bd = 0
+            for (i = 1; i <= n; i++) {
+                c = substr(ms, i, 1)
+                if (c == "{" || c == "}") return i
+                if (c == "(") pd++
+                else if (c == ")") { if (pd > 0) pd-- }
+                else if (c == "[") bd++
+                else if (c == "]") { if (bd > 0) bd-- }
+                else if (c == ";" && pd == 0 && bd == 0) return i
+            }
+            return 0
+        }
         function attr_len(ms,   i, n, c, depth) {
             n = length(ms); depth = 0
             for (i = index(ms, "["); i > 0 && i <= n; i++) {
@@ -514,11 +535,12 @@ scan_decl_records() {
                 # block-chain rules and includes there compile in the
                 # enclosing cfg context — so it is a skip region like the
                 # others, emitting nothing (declared limitation).
-                if (match(mbuf, /[;{}]/)) {
-                    bchar = substr(mbuf, RSTART, 1)
-                    mchunk = substr(mbuf, 1, RSTART)
-                    ochunk = substr(buf, 1, RSTART)
-                    buf = substr(buf, RSTART + 1); mbuf = substr(mbuf, RSTART + 1)
+                bpos = item_boundary(mbuf)
+                if (bpos > 0) {
+                    bchar = substr(mbuf, bpos, 1)
+                    mchunk = substr(mbuf, 1, bpos)
+                    ochunk = substr(buf, 1, bpos)
+                    buf = substr(buf, bpos + 1); mbuf = substr(mbuf, bpos + 1)
                     emit_includes(mchunk, ochunk, gated)
                     gated = 0; pathattr = ""
                     if (bchar == "{") {

--- a/skills/github/scripts/git-diff-summary
+++ b/skills/github/scripts/git-diff-summary
@@ -77,7 +77,22 @@ resolve_default_base() {
 # construction. Every one of these fails toward NO record for the shape, so
 # a file that is production-reachable only through one of them while also
 # carrying a #[cfg(test)]-gated declaration still classifies as test —
-# that is the declared trade-off, and the only one.
+# that is the declared trade-off.
+#
+# Deliberately unmodeled SPELLING SEMANTICS, direction stated: string
+# ESCAPES in path/include literals are recorded as their source spelling,
+# not decoded ("cand\x2ers" does not match cand.rs); cfg_attr-conditional
+# path attributes are consumed as ordinary attributes (the declaration
+# resolves by its alias); a local macro_rules! shadowing `include` is
+# still read as the built-in. Each can, in a deliberately crafted
+# dual-declaration file, hide a production route and downgrade — but each
+# requires the AUTHOR writing pathological spellings of their own code,
+# and this scanner is review-flag hygiene, not an adversarial control: an
+# author evading their own review flags has simpler routes than escape
+# obfuscation, and the spellings themselves are what a human review
+# flags. Byte/C string literals (b"", br#""#, c"", cr#""#) are lexed for
+# masking but never qualify as path/include VALUES — they are not valid
+# in those positions in Rust.
 
 # Emits the new-side content of a file: HEAD for a base...HEAD diff, the
 # index for --staged, the worktree for --head. Reads main()'s diff_ref.
@@ -193,17 +208,17 @@ scan_decl_records() {
                     cdepth = 1; o = o "  "; m = m "  "; i += 2
                 } else if (c == "\"") {
                     instr = 1; o = o c; m = m c; i++
-                } else if (c == "b" && (i == 1 || substr(s, i - 1, 1) !~ /[A-Za-z0-9_]/) \
-                           && match(substr(s, i), /^br#*"/)) {
-                    # byte raw string: same raw machinery, prefix is br
+                } else if (c ~ /[bc]/ && (i == 1 || substr(s, i - 1, 1) !~ /[A-Za-z0-9_]/) \
+                           && match(substr(s, i), /^[bc]r#*"/)) {
+                    # byte/C raw string: same raw machinery, prefix br or cr
                     rawh = RLENGTH - 3
                     rawhs = mkhashes(rawh)
                     o = o substr(s, i, RLENGTH); m = m substr(s, i, RLENGTH)
                     i += RLENGTH; instr = 2
-                } else if (c == "b" && (i == 1 || substr(s, i - 1, 1) !~ /[A-Za-z0-9_]/) \
+                } else if (c ~ /[bc]/ && (i == 1 || substr(s, i - 1, 1) !~ /[A-Za-z0-9_]/) \
                            && substr(s, i + 1, 1) ~ /["\047]/) {
-                    # byte string or byte char: consume the b, let the
-                    # quote branch on the next pass open the literal
+                    # byte/C string or byte char: consume the prefix, let
+                    # the quote branch on the next pass open the literal
                     o = o c; m = m c; i++
                 } else if (c == "r" && (i == 1 || substr(s, i - 1, 1) !~ /[A-Za-z0-9_]/) \
                            && match(substr(s, i), /^r#*"/)) {
@@ -251,7 +266,7 @@ scan_decl_records() {
                 if (iap == 1 || substr(mc, iap - 1, 1) !~ /[A-Za-z0-9_]/) {
                     mrest = substr(mc, iap)
                     orest = substr(oc, iap)
-                    if (match(mrest, /^include[[:space:]]*![[:space:]]*[([{][[:space:]]*(b?r#*)?"[^"]*"/) \
+                    if (match(mrest, /^include[[:space:]]*![[:space:]]*[([{][[:space:]]*(r#*)?"[^"]*"/) \
                         && match(mrest, /"[^"]*"/))
                         printf "%s\t%s\n", (inc_gated ? "G" : "U"), \
                             normpath(join(fdir, substr(orest, RSTART + 1, RLENGTH - 2)))
@@ -319,7 +334,7 @@ scan_decl_records() {
                         # Plain and raw string values, including hash-raw:
                         # the literal is located on the mask (its interior
                         # can hide no quote) and read from the original.
-                        if (mattr ~ /^#[[:space:]]*\[[[:space:]]*path[[:space:]]*=[[:space:]]*(b?r#*)?"/ \
+                        if (mattr ~ /^#[[:space:]]*\[[[:space:]]*path[[:space:]]*=[[:space:]]*(r#*)?"/ \
                             && match(mattr, /"[^"]*"/))
                             pathattr = substr(oattr, RSTART + 1, RLENGTH - 2)
                         buf = substr(buf, alen + 1); mbuf = substr(mbuf, alen + 1)

--- a/skills/github/scripts/git-diff-summary
+++ b/skills/github/scripts/git-diff-summary
@@ -282,6 +282,17 @@ scan_decl_records() {
                     buf = substr(buf, RLENGTH + 1); mbuf = substr(mbuf, RLENGTH + 1)
                 }
                 if (mbuf == "") break
+                # Inner attribute item (#![...]): binds to the ENCLOSING
+                # module, not to what follows — consumed on its own,
+                # contributing nothing to the pending outer-attribute gate
+                # state, so the next declaration still scans.
+                if (mbuf ~ /^#!\[/) {
+                    if (match(mbuf, /^#!\[[^]]*\][[:space:]]*/)) {
+                        buf = substr(buf, RLENGTH + 1); mbuf = substr(mbuf, RLENGTH + 1)
+                        continue
+                    }
+                    break
+                }
                 # Attribute item. An opened-but-unclosed one waits for the
                 # next line (rustc accepts attributes split across lines).
                 if (mbuf ~ /^#\[/) {

--- a/skills/github/scripts/git-diff-summary
+++ b/skills/github/scripts/git-diff-summary
@@ -48,6 +48,105 @@ resolve_default_base() {
     echo "main"
 }
 
+# --- declaration-site test scoping (vstack#1217) ----------------------------
+# A .rs file with no file-local test markers is still test-only when its gate
+# lives at the declaration site in the declaring module:
+#     #[cfg(test)]
+#     #[path = "scan_fixtures.rs"]
+#     mod scan_fixtures;
+# File-local heuristics cannot see that, so classification also reads the
+# modules that could declare the file on the diff's new side: a file whose
+# every found declaration is #[cfg(test)]-gated is test scope; any ungated
+# declaration, or none found, keeps the file-local classification.
+
+# New-side content of a file: HEAD for a base...HEAD diff, the index for
+# --staged, the worktree for --head. Reads main()'s diff_ref.
+new_side_content() {
+    case "$diff_ref" in
+        --staged) git show ":$1" 2>/dev/null || true ;;
+        HEAD)     cat "$1" 2>/dev/null || true ;;
+        *)        git show "HEAD:$1" 2>/dev/null || true ;;
+    esac
+}
+
+# New-side .rs files directly inside a directory (no recursion).
+new_side_rs_siblings() {
+    case "$diff_ref" in
+        --staged) git ls-files -- "$1" 2>/dev/null ;;
+        HEAD)     find "$1" -maxdepth 1 -name '*.rs' 2>/dev/null ;;
+        *)        git ls-tree --name-only HEAD -- "$1/" 2>/dev/null ;;
+    esac | awk -v d="$1/" 'index($0, d) == 1 && substr($0, length(d) + 1) !~ /\// && /\.rs$/'
+}
+
+# Print one line per `mod name;` declaration on stdin that resolves to the
+# candidate file: "gated" when #[cfg(test)] is among its attributes, else
+# "ungated". stem/rel: candidate module name and path relative to the
+# declaring file's directory. allow_name: whether a bare `mod stem;` resolves
+# to the candidate (true for mod.rs/lib.rs/main.rs siblings and the 2018-style
+# parent file; other siblings resolve `mod x;` into their own subdirectory).
+scan_mod_decls() {
+    awk -v stem="$1" -v rel="$2" -v allow_name="$3" '
+        {
+            line = $0
+            sub(/^[[:space:]]*/, "", line)
+            # Consume leading attributes; several may share the decl line.
+            while (match(line, /^#\[[^]]*\][[:space:]]*/)) {
+                attr = substr(line, 1, RLENGTH)
+                if (attr ~ /^#\[cfg\(test\)\]/) gated = 1
+                if (attr ~ /^#\[path[[:space:]]*=[[:space:]]*"/) {
+                    p = attr
+                    sub(/^#\[path[[:space:]]*=[[:space:]]*"/, "", p)
+                    sub(/".*/, "", p)
+                    pathattr = p
+                }
+                line = substr(line, RLENGTH + 1)
+            }
+            # Blank/comment lines keep pending attributes (attrs may precede
+            # the item across lines).
+            if (line == "" || line ~ /^\/\//) next
+            if (line ~ /^(pub([(][^)]*[)])?[[:space:]]+)?mod[[:space:]]+[A-Za-z_][A-Za-z0-9_]*[[:space:]]*;/) {
+                name = line
+                sub(/^pub([(][^)]*[)])?[[:space:]]+/, "", name)
+                sub(/^mod[[:space:]]+/, "", name)
+                sub(/[[:space:]]*;.*$/, "", name)
+                if (pathattr != "" ? pathattr == rel : (allow_name != 0 && name == stem))
+                    print (gated ? "gated" : "ungated")
+            }
+            gated = 0
+            pathattr = ""
+        }
+    '
+}
+
+is_cfg_test_declared() {
+    local candidate="$1"
+    local base stem dir parent pdirname parent_file f fdir rel allow out decls=""
+    case "$candidate" in */*) ;; *) return 1 ;; esac
+    base=${candidate##*/}
+    case "$base" in mod.rs|lib.rs|main.rs) return 1 ;; esac
+    stem=${base%.rs}
+    dir=${candidate%/*}
+    parent=$(dirname "$dir")
+    pdirname=${dir##*/}
+    parent_file="$parent/$pdirname.rs"
+    [ "$parent" = "." ] && parent_file="$pdirname.rs"
+    for f in $(new_side_rs_siblings "$dir") "$parent_file"; do
+        [ "$f" = "$candidate" ] && continue
+        case "$f" in
+            "$dir/mod.rs"|"$dir/lib.rs"|"$dir/main.rs"|"$parent_file") allow=1 ;;
+            *) allow=0 ;;
+        esac
+        fdir=${f%/*}
+        [ "$f" = "${f#*/}" ] && fdir="."
+        if [ "$fdir" = "$dir" ]; then rel="$base"; else rel="$pdirname/$base"; fi
+        out=$(new_side_content "$f" | scan_mod_decls "$stem" "$rel" "$allow")
+        decls="$decls$out"$'\n'
+    done
+    case "$decls" in *ungated*) return 1 ;; esac
+    case "$decls" in *gated*) return 0 ;; esac
+    return 1
+}
+
 main() {
     local base=""
     local diff_args=""
@@ -110,10 +209,24 @@ main() {
     # dirs, *_tests.rs files, or #[cfg(test)] modules inside production files —
     # are the distinct informational `test_panic_path_added` flag instead: a
     # test assertion is not a production panic path (vstack#944).
+    # Changed .rs files that carry no file-local test markers but are reached
+    # only through #[cfg(test)]-gated declarations are test scope (vstack#1217).
+    local cfg_test_declared="" rs_candidate
+    for rs_candidate in $(echo "$files" | awk -F'\t' '{print $NF}' \
+            | grep -E '\.rs$' \
+            | grep -vE '(/tests?/|/benches/|/fixtures/|_tests?\.rs$)' || true); do
+        if is_cfg_test_declared "$rs_candidate"; then
+            cfg_test_declared="$cfg_test_declared$rs_candidate"$'\n'
+        fi
+    done
+
     local prod_paths
     prod_paths=$(echo "$files" | awk -F'\t' '{print $NF}' \
         | grep -E '(^|/)src/|(^|/)lib/' \
         | grep -vE '(/tests/|/benches/|/test/|/fixtures/|_tests?\.rs$|\.test\.[jt]sx?$|\.spec\.[jt]sx?$)' || true)
+    if [ -n "$cfg_test_declared" ] && [ -n "$prod_paths" ]; then
+        prod_paths=$(grep -Fxv -f <(printf '%s' "$cfg_test_declared") <<<"$prod_paths" || true)
+    fi
     local prod_panic=0 test_panic=0
     if [ -n "$prod_paths" ]; then
         # path<TAB>new-side line number of each added panic-pattern line
@@ -187,6 +300,7 @@ main() {
     local test_paths
     test_paths=$(echo "$files" | awk -F'\t' '{print $NF}' \
         | grep -E '(^|/)tests?/|_tests?\.rs$' || true)
+    test_paths=$(printf '%s\n%s' "$test_paths" "$cfg_test_declared" | grep -v '^$' | sort -u || true)
     if [ -n "$test_paths" ]; then
         local test_diff
         # shellcheck disable=SC2086
@@ -201,7 +315,10 @@ main() {
 
     # Classify files into domains and build output.
     # Domain = top-level directory name. Standard infrastructure dirs are grouped.
-    echo "$files" | jq -Rs --arg stats "$stats" --argjson risk_flags "$risk_flags" '
+    local cfg_test_json
+    cfg_test_json=$(printf '%s' "$cfg_test_declared" | jq -Rs 'split("\n") | map(select(length > 0))')
+    echo "$files" | jq -Rs --arg stats "$stats" --argjson risk_flags "$risk_flags" \
+        --argjson cfg_test_declared "$cfg_test_json" '
         # Parse file list
         split("\n") | map(select(length > 0)) | map(
             capture("^(?<status>[AMDRC])[0-9]*\t(?<path>.+)$") // null
@@ -219,7 +336,9 @@ main() {
                 end
             ),
             file_scope: (
-                if .path | test("(/tests?/|/benches?/|/fixtures/|_tests?\\.rs$|\\.test\\.[jt]sx?$|\\.spec\\.[jt]sx?$)")
+                if (.path as $p | $cfg_test_declared | index($p)) != null
+                    then "test"
+                elif .path | test("(/tests?/|/benches?/|/fixtures/|_tests?\\.rs$|\\.test\\.[jt]sx?$|\\.spec\\.[jt]sx?$)")
                     then "test"
                 elif .path | test("^docs/")
                     then "docs"

--- a/skills/github/scripts/git-diff-summary
+++ b/skills/github/scripts/git-diff-summary
@@ -167,108 +167,113 @@ scan_decl_records() {
             }
             return out
         }
+        # Every include! route in one consumed chunk (token boundary: a
+        # preceding identifier character means a different macro).
+        function emit_includes(chunk,   ioff, iq, iap, irest) {
+            ioff = 0
+            while ((iq = index(substr(chunk, ioff + 1), "include!")) > 0) {
+                iap = ioff + iq
+                if (iap == 1 || substr(chunk, iap - 1, 1) !~ /[A-Za-z0-9_]/) {
+                    irest = substr(chunk, iap)
+                    if (match(irest, /"[^"]*"/))
+                        printf "I\t%s\n", normpath(join(fdir, substr(irest, RSTART + 1, RLENGTH - 2)))
+                }
+                ioff = iap + 7
+            }
+        }
+        # Lines are NOT items: source is accumulated into a cross-line
+        # buffer and consumed one ITEM at a time (attribute, file-module
+        # declaration, inline-module block, other statement), so several
+        # items on one line and one item across several lines both parse.
+        # An incomplete tail (open attribute, unterminated statement,
+        # unclosed inline block) stays in the buffer for the next line.
         {
             line = strip_comments($0)
-            sub(/^[[:space:]]*/, "", line)
-            # Blank and comment-only lines keep pending attributes (attrs
-            # may precede their item across lines).
-            if (line == "") next
-            # Declarations inside inline module blocks (mod name { ... })
-            # resolve into the inline module chain, which this scanner does
-            # not model. A shape it cannot faithfully parse must produce NO
-            # record — never a mis-resolved one — so the whole block is
-            # skipped by brace depth, and pending state cannot leak across
-            # the boundary.
-            if (inline_depth > 0) {
-                tmp = line
-                inline_depth += gsub(/\{/, "{", tmp) - gsub(/\}/, "}", tmp)
-                if (inline_depth < 0) inline_depth = 0
-                gated = 0; pathattr = ""; pending_attr = ""; pending_include = 0
-                next
-            }
-            # An attribute opened but not closed on the previous line
-            # (rustc accepts `#[path =` split from its value) continues
-            # here; rejoin before parsing.
-            if (pending_attr != "") {
-                line = pending_attr " " line
-                pending_attr = ""
-            }
-            # An inline-module opener left open at end of line starts a
-            # skip region (a single-line `mod m { ... }` nets zero and
-            # stays inert — its inner declarations never anchor at ^).
-            if (line ~ /^(pub([(][^)]*[)])?[[:space:]]+)?mod[[:space:]]+[A-Za-z_][A-Za-z0-9_]*[[:space:]]*\{/) {
-                tmp = line
-                delta = gsub(/\{/, "{", tmp) - gsub(/\}/, "}", tmp)
-                if (delta > 0) {
-                    inline_depth = delta
-                    gated = 0; pathattr = ""; pending_include = 0
-                    next
+            if (buf == "") buf = line
+            else buf = buf " " line
+            for (;;) {
+                # Inside an inline module block (mod name { ... }): Rust
+                # resolves nested declarations into the inline chain, which
+                # this scanner does not model — a shape it cannot
+                # faithfully parse must produce NO record, never a
+                # mis-resolved one. Consume by brace depth, emit nothing.
+                if (inline_depth > 0) {
+                    blen = length(buf); bi = 1
+                    while (bi <= blen && inline_depth > 0) {
+                        bc = substr(buf, bi, 1)
+                        if (bc == "{") inline_depth++
+                        else if (bc == "}") inline_depth--
+                        bi++
+                    }
+                    buf = substr(buf, bi)
+                    if (inline_depth > 0) { buf = ""; break }
+                    continue
                 }
-            }
-            # include! routes resolve their string-literal argument. A
-            # literal on a later line (formatted call left open) is tracked
-            # across lines until the closing paren; a call that CLOSES
-            # without a literal (computed path) sets no pending state and
-            # stays unmatched — stated limitation.
-            if (pending_include) {
-                if (match(line, /"[^"]*"/)) {
-                    printf "I\t%s\n", normpath(join(fdir, substr(line, RSTART + 1, RLENGTH - 2)))
-                    pending_include = 0
-                } else if (index(line, ")") > 0) pending_include = 0
-            }
-            # A real include! token only: a preceding identifier character
-            # means a different macro (my_include!).
-            ipos = 0; off = 0
-            while ((q = index(substr(line, off + 1), "include!")) > 0) {
-                ap = off + q
-                if (ap == 1 || substr(line, ap - 1, 1) !~ /[A-Za-z0-9_]/) { ipos = ap; break }
-                off = ap + 7
-            }
-            if (ipos > 0) {
-                rest = substr(line, ipos)
-                if (match(rest, /"[^"]*"/))
-                    printf "I\t%s\n", normpath(join(fdir, substr(rest, RSTART + 1, RLENGTH - 2)))
-                else if (index(rest, ")") == 0) pending_include = 1
-            }
-            # Consume leading attributes; several may share the decl line.
-            while (match(line, /^#\[[^]]*\][[:space:]]*/)) {
-                attr = substr(line, 1, RLENGTH)
-                if (attr ~ /^#\[cfg\(test\)\]/) gated = 1
-                # Plain and raw string values, including hash-raw
-                # (r"...", r#"..."#); a literal quote INSIDE a hash-raw
-                # value would cut early — pathological for a file path.
-                if (attr ~ /^#\[path[[:space:]]*=[[:space:]]*(r#*)?"/) {
-                    p = attr
-                    sub(/^#\[path[[:space:]]*=[[:space:]]*(r#*)?"/, "", p)
-                    sub(/".*/, "", p)
-                    pathattr = p
+                sub(/^[[:space:]]*/, "", buf)
+                if (buf == "") break
+                # Attribute item. An opened-but-unclosed one waits for the
+                # next line (rustc accepts attributes split across lines).
+                if (buf ~ /^#\[/) {
+                    if (match(buf, /^#\[[^]]*\][[:space:]]*/)) {
+                        attr = substr(buf, 1, RLENGTH)
+                        if (attr ~ /^#\[cfg\(test\)\]/) gated = 1
+                        # Plain and raw string values, including hash-raw
+                        # (r"...", r#"..."#); a literal quote INSIDE a
+                        # hash-raw value would cut early — pathological
+                        # for a file path.
+                        if (attr ~ /^#\[path[[:space:]]*=[[:space:]]*(r#*)?"/) {
+                            p = attr
+                            sub(/^#\[path[[:space:]]*=[[:space:]]*(r#*)?"/, "", p)
+                            sub(/".*/, "", p)
+                            pathattr = p
+                        }
+                        buf = substr(buf, RLENGTH + 1)
+                        continue
+                    }
+                    break
                 }
-                line = substr(line, RLENGTH + 1)
-            }
-            if (line == "") next
-            # Attribute opened but not closed on this line: carry it (and
-            # any attrs already consumed stay pending in gated/pathattr).
-            if (line ~ /^#\[/ && index(line, "]") == 0) {
-                pending_attr = line
-                next
-            }
-            if (line ~ /^(pub([(][^)]*[)])?[[:space:]]+)?mod[[:space:]]+[A-Za-z_][A-Za-z0-9_]*[[:space:]]*;/) {
-                name = line
-                sub(/^pub([(][^)]*[)])?[[:space:]]+/, "", name)
-                sub(/^mod[[:space:]]+/, "", name)
-                sub(/[[:space:]]*;.*$/, "", name)
-                kind = (gated ? "G" : "U")
-                if (pathattr != "")
-                    printf "%s\t%s\n", kind, normpath(join(fdir, pathattr))
-                else {
-                    # Both legal forms of a bare declaration: name.rs and
-                    # the directory form name/mod.rs.
-                    printf "%s\t%s\n", kind, normpath(join(moddir, name ".rs"))
-                    printf "%s\t%s\n", kind, normpath(join(moddir, name "/mod.rs"))
+                # File-module declaration item.
+                if (match(buf, /^(pub([(][^)]*[)])?[[:space:]]+)?mod[[:space:]]+[A-Za-z_][A-Za-z0-9_]*[[:space:]]*;/)) {
+                    name = substr(buf, 1, RLENGTH)
+                    buf = substr(buf, RLENGTH + 1)
+                    sub(/^pub([(][^)]*[)])?[[:space:]]+/, "", name)
+                    sub(/^mod[[:space:]]+/, "", name)
+                    sub(/[[:space:]]*;.*$/, "", name)
+                    kind = (gated ? "G" : "U")
+                    if (pathattr != "")
+                        printf "%s\t%s\n", kind, normpath(join(fdir, pathattr))
+                    else {
+                        # Both legal forms of a bare declaration: name.rs
+                        # and the directory form name/mod.rs.
+                        printf "%s\t%s\n", kind, normpath(join(moddir, name ".rs"))
+                        printf "%s\t%s\n", kind, normpath(join(moddir, name "/mod.rs"))
+                    }
+                    gated = 0; pathattr = ""
+                    continue
                 }
+                # Inline-module opener: enter the skip region (its own
+                # attributes, gated or not, apply to the skipped block).
+                if (match(buf, /^(pub([(][^)]*[)])?[[:space:]]+)?mod[[:space:]]+[A-Za-z_][A-Za-z0-9_]*[[:space:]]*\{/)) {
+                    buf = substr(buf, RLENGTH + 1)
+                    inline_depth = 1
+                    gated = 0; pathattr = ""
+                    continue
+                }
+                # Any other item: consume to the next boundary (; { or }),
+                # scanning the chunk for include! routes. A multiline
+                # include! (literal on a later line) completes when its
+                # statement boundary arrives; a closed call with no
+                # literal (computed path) emits nothing. Without a
+                # boundary the item continues on the next line.
+                if (match(buf, /[;{}]/)) {
+                    chunk = substr(buf, 1, RSTART)
+                    buf = substr(buf, RSTART + 1)
+                    emit_includes(chunk)
+                    gated = 0; pathattr = ""
+                    continue
+                }
+                break
             }
-            gated = 0
-            pathattr = ""
         }
     '
 }

--- a/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
+++ b/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
@@ -1085,5 +1085,193 @@ assert_eq "torture line: ungated routes win for shared/inc_b, gated for onlygate
 assert_eq "torture line: scope is production" \
     "production" "$(jq -r '.scope' <<<"$torture_json")"
 
+# A quoted "{" inside an inline block must not inflate brace depth and
+# swallow the ungated declaration that follows the block (gated twin lives
+# in a second declaring file).
+quoted_open_repo="$SANDBOX/quoted-open-brace"
+init_repo "$quoted_open_repo"
+mkdir -p "$quoted_open_repo/src"
+cat > "$quoted_open_repo/src/lib.rs" <<'RUST'
+mod wrapper { const OPEN: &str = "{"; } pub mod cand;
+RUST
+cat > "$quoted_open_repo/src/other.rs" <<'RUST'
+#[cfg(test)]
+#[path = "cand.rs"]
+mod cand_fixtures;
+RUST
+git -C "$quoted_open_repo" add src
+git -C "$quoted_open_repo" commit -q -m lib
+cat > "$quoted_open_repo/src/cand.rs" <<'RUST'
+pub fn parse(s: &str) -> u32 {
+    s.parse().unwrap()
+}
+RUST
+git -C "$quoted_open_repo" add src/cand.rs
+quoted_open_json="$($SUMMARY -C "$quoted_open_repo" --staged)"
+assert_eq "quoted { does not swallow the following ungated declaration" \
+    '["panic_path_added"]' "$(jq -c '.risk_flags' <<<"$quoted_open_json")"
+assert_eq "quoted { keeps production scope" \
+    "production" "$(jq -r '.scope' <<<"$quoted_open_json")"
+
+# A quoted "}" inside an inline block must not end the skip region early
+# and expose a nested gated declaration as a top-level route.
+quoted_close_repo="$SANDBOX/quoted-close-brace"
+init_repo "$quoted_close_repo"
+mkdir -p "$quoted_close_repo/src"
+cat > "$quoted_close_repo/src/lib.rs" <<'RUST'
+mod outer {
+    const CLOSE: &str = "}";
+    #[cfg(test)]
+    #[path = "cand.rs"]
+    mod cand_fixtures;
+}
+pub fn real() -> u32 {
+    1
+}
+RUST
+git -C "$quoted_close_repo" add src
+git -C "$quoted_close_repo" commit -q -m lib
+cat > "$quoted_close_repo/src/cand.rs" <<'RUST'
+pub fn parse(s: &str) -> u32 {
+    s.parse().unwrap()
+}
+RUST
+git -C "$quoted_close_repo" add src/cand.rs
+quoted_close_json="$($SUMMARY -C "$quoted_close_repo" --staged)"
+assert_eq "quoted } does not expose a nested gated declaration" \
+    '["panic_path_added"]' "$(jq -c '.risk_flags' <<<"$quoted_close_json")"
+assert_eq "quoted } keeps production scope" \
+    "production" "$(jq -r '.scope' <<<"$quoted_close_json")"
+
+# A quoted URL's // is not a comment: the constant's statement must not
+# swallow the following ungated declaration.
+url_repo="$SANDBOX/quoted-url"
+init_repo "$url_repo"
+mkdir -p "$url_repo/src"
+cat > "$url_repo/src/lib.rs" <<'RUST'
+const URL: &str = "https://example.com";
+pub mod cand;
+
+#[cfg(test)]
+#[path = "cand.rs"]
+mod cand_fixtures;
+RUST
+git -C "$url_repo" add src
+git -C "$url_repo" commit -q -m lib
+cat > "$url_repo/src/cand.rs" <<'RUST'
+pub fn parse(s: &str) -> u32 {
+    s.parse().unwrap()
+}
+RUST
+git -C "$url_repo" add src/cand.rs
+url_json="$($SUMMARY -C "$url_repo" --staged)"
+assert_eq "quoted // keeps the following ungated declaration alive" \
+    '["panic_path_added"]' "$(jq -c '.risk_flags' <<<"$url_json")"
+assert_eq "quoted // keeps production scope" \
+    "production" "$(jq -r '.scope' <<<"$url_json")"
+
+# include! with a computed argument emits NO route, even when the parts are
+# string literals — the scanner does not evaluate macros (declared
+# limitation, fail-closed as no-record), so the gated route wins.
+computed_include_repo="$SANDBOX/computed-include"
+init_repo "$computed_include_repo"
+mkdir -p "$computed_include_repo/src"
+cat > "$computed_include_repo/src/lib.rs" <<'RUST'
+include!(concat!("cand.rs", ""));
+
+#[cfg(test)]
+#[path = "cand.rs"]
+mod cand_fixtures;
+RUST
+git -C "$computed_include_repo" add src
+git -C "$computed_include_repo" commit -q -m lib
+cat > "$computed_include_repo/src/cand.rs" <<'RUST'
+pub fn sample() -> u32 {
+    "3".parse().unwrap()
+}
+RUST
+git -C "$computed_include_repo" add src/cand.rs
+computed_include_json="$($SUMMARY -C "$computed_include_repo" --staged)"
+assert_eq "computed include! argument emits no route; gated decl wins" \
+    '["test_panic_path_added"]' "$(jq -c '.risk_flags' <<<"$computed_include_json")"
+assert_eq "computed include! argument is not production scope" \
+    "support" "$(jq -r '.scope' <<<"$computed_include_json")"
+
+# Raw identifiers are valid module names: mod r#type; declares module
+# `type`, and its ungated #[path] route must be recorded.
+rawident_repo="$SANDBOX/raw-ident"
+init_repo "$rawident_repo"
+mkdir -p "$rawident_repo/src"
+cat > "$rawident_repo/src/lib.rs" <<'RUST'
+#[path = "cand.rs"]
+pub mod r#type;
+
+#[cfg(test)]
+#[path = "cand.rs"]
+mod cand_fixtures;
+RUST
+git -C "$rawident_repo" add src
+git -C "$rawident_repo" commit -q -m lib
+cat > "$rawident_repo/src/cand.rs" <<'RUST'
+pub fn parse(s: &str) -> u32 {
+    s.parse().unwrap()
+}
+RUST
+git -C "$rawident_repo" add src/cand.rs
+rawident_json="$($SUMMARY -C "$rawident_repo" --staged)"
+assert_eq "raw-identifier declaration keeps panic_path_added" \
+    '["panic_path_added"]' "$(jq -c '.risk_flags' <<<"$rawident_json")"
+assert_eq "raw-identifier declaration stays production scope" \
+    "production" "$(jq -r '.scope' <<<"$rawident_json")"
+
+# String-awareness torture: quoted braces and a URL, a decoy literal in the
+# statement before a real include!, and a raw-identifier #[path] declaration
+# — ungated routes must survive for inc.rs and target.rs (production) while
+# onlygated.rs keeps only its gated route (test).
+strtorture_repo="$SANDBOX/string-torture"
+init_repo "$strtorture_repo"
+mkdir -p "$strtorture_repo/src"
+cat > "$strtorture_repo/src/lib.rs" <<'RUST'
+const URL: &str = "https://example.com/{}";
+mod wrapper { const OPEN: &str = "{"; }
+const DECOY: &str = "decoy.rs"; include!("inc.rs");
+#[path = "target.rs"] pub mod r#kind;
+
+#[cfg(test)]
+#[path = "inc.rs"]
+mod inc_fx;
+
+#[cfg(test)]
+#[path = "target.rs"]
+mod t_fx;
+
+#[cfg(test)]
+#[path = "onlygated.rs"]
+mod og;
+RUST
+git -C "$strtorture_repo" add src
+git -C "$strtorture_repo" commit -q -m lib
+cat > "$strtorture_repo/src/inc.rs" <<'RUST'
+pub fn decode(s: &str) -> u32 {
+    s.parse().unwrap()
+}
+RUST
+cat > "$strtorture_repo/src/target.rs" <<'RUST'
+pub fn parse(s: &str) -> u32 {
+    s.parse().unwrap()
+}
+RUST
+cat > "$strtorture_repo/src/onlygated.rs" <<'RUST'
+pub fn fixture() -> u32 {
+    "7".parse().unwrap()
+}
+RUST
+git -C "$strtorture_repo" add src/inc.rs src/target.rs src/onlygated.rs
+strtorture_json="$($SUMMARY -C "$strtorture_repo" --staged)"
+assert_eq "string torture: ungated routes survive, gated-only stays test" \
+    '["panic_path_added","test_panic_path_added"]' "$(jq -c '.risk_flags' <<<"$strtorture_json")"
+assert_eq "string torture: scope is production" \
+    "production" "$(jq -r '.scope' <<<"$strtorture_json")"
+
 printf '\nPASS=%d FAIL=%d\n' "$PASS" "$FAIL"
 if [ "$FAIL" -ne 0 ]; then exit 1; fi

--- a/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
+++ b/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
@@ -1812,5 +1812,77 @@ rawinc_json="$($SUMMARY -C "$rawinc_repo" --staged)"
 assert_eq "hash-raw brace include emits its production route"     '["panic_path_added"]' "$(jq -c '.risk_flags' <<<"$rawinc_json")"
 assert_eq "hash-raw brace include fixture keeps production scope"     "production" "$(jq -r '.scope' <<<"$rawinc_json")"
 
+# An include! token nested in ANOTHER macro's argument tree is never expanded
+# by Rust (stringify! keeps it as tokens), so it must fabricate no route:
+# nested macro token trees emit nothing, never a mis-resolved record.
+nestinc_repo="$SANDBOX/nested-include"
+init_repo "$nestinc_repo"
+mkdir -p "$nestinc_repo/src"
+cat > "$nestinc_repo/src/lib.rs" <<'RUST'
+#[cfg(test)]
+#[path = "cand.rs"]
+mod fixtures;
+const TOKENS: &str = stringify!(include!("cand.rs"));
+RUST
+git -C "$nestinc_repo" add src
+git -C "$nestinc_repo" commit -q -m lib
+cat > "$nestinc_repo/src/cand.rs" <<'RUST'
+pub fn parse(s: &str) -> u32 {
+    s.parse().unwrap()
+}
+RUST
+git -C "$nestinc_repo" add src/cand.rs
+nestinc_json="$($SUMMARY -C "$nestinc_repo" --staged)"
+assert_eq "include nested in another macro fabricates no production route"     '["test_panic_path_added"]' "$(jq -c '.risk_flags' <<<"$nestinc_json")"
+assert_eq "nested-include fixture stays support scope"     "support" "$(jq -r '.scope' <<<"$nestinc_json")"
+
+# rustc accepts a trailing comma in an include! argument list; the direct
+# string literal is still the argument and its route must emit.
+comma_repo="$SANDBOX/include-trailing-comma"
+init_repo "$comma_repo"
+mkdir -p "$comma_repo/src"
+cat > "$comma_repo/src/lib.rs" <<'RUST'
+#[cfg(test)]
+#[path = "cand.rs"]
+mod fixtures;
+include!("cand.rs",);
+RUST
+git -C "$comma_repo" add src
+git -C "$comma_repo" commit -q -m lib
+cat > "$comma_repo/src/cand.rs" <<'RUST'
+pub fn parse(s: &str) -> u32 {
+    s.parse().unwrap()
+}
+RUST
+git -C "$comma_repo" add src/cand.rs
+comma_json="$($SUMMARY -C "$comma_repo" --staged)"
+assert_eq "trailing-comma include emits its production route"     '["panic_path_added"]' "$(jq -c '.risk_flags' <<<"$comma_json")"
+assert_eq "trailing-comma include fixture keeps production scope"     "production" "$(jq -r '.scope' <<<"$comma_json")"
+
+# An attribute's token tree may nest bracket groups: consumption must balance
+# delimiters, not stop at the first closing bracket, or the leftover tokens
+# swallow the declaration that follows.
+nestattr_repo="$SANDBOX/nested-attr-brackets"
+init_repo "$nestattr_repo"
+mkdir -p "$nestattr_repo/src"
+cat > "$nestattr_repo/src/lib.rs" <<'RUST'
+#[cfg_attr(any(), allow([dead_code]))]
+mod cand;
+#[cfg(test)]
+#[path = "cand.rs"]
+mod fixtures;
+RUST
+git -C "$nestattr_repo" add src
+git -C "$nestattr_repo" commit -q -m lib
+cat > "$nestattr_repo/src/cand.rs" <<'RUST'
+pub fn parse(s: &str) -> u32 {
+    s.parse().unwrap()
+}
+RUST
+git -C "$nestattr_repo" add src/cand.rs
+nestattr_json="$($SUMMARY -C "$nestattr_repo" --staged)"
+assert_eq "nested attribute brackets do not swallow the declaration"     '["panic_path_added"]' "$(jq -c '.risk_flags' <<<"$nestattr_json")"
+assert_eq "nested-attribute fixture keeps production scope"     "production" "$(jq -r '.scope' <<<"$nestattr_json")"
+
 printf '\nPASS=%d FAIL=%d\n' "$PASS" "$FAIL"
 if [ "$FAIL" -ne 0 ]; then exit 1; fi

--- a/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
+++ b/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
@@ -1273,5 +1273,94 @@ assert_eq "string torture: ungated routes survive, gated-only stays test" \
 assert_eq "string torture: scope is production" \
     "production" "$(jq -r '.scope' <<<"$strtorture_json")"
 
+# macro_rules! bodies are token trees, not item streams. Direction one: an
+# ungated `mod cand;` inside a macro DEFINITION must not destroy the real
+# gated route (rustc keeps cand.rs test-only when the macro is never
+# invoked).
+macro_ungated_repo="$SANDBOX/macro-ungated"
+init_repo "$macro_ungated_repo"
+mkdir -p "$macro_ungated_repo/src"
+cat > "$macro_ungated_repo/src/lib.rs" <<'RUST'
+macro_rules! demo {
+    () => {
+        mod cand;
+    };
+}
+
+#[cfg(test)]
+#[path = "cand.rs"]
+mod cand_fixtures;
+RUST
+git -C "$macro_ungated_repo" add src
+git -C "$macro_ungated_repo" commit -q -m lib
+cat > "$macro_ungated_repo/src/cand.rs" <<'RUST'
+pub fn sample() -> u32 {
+    "3".parse().unwrap()
+}
+RUST
+git -C "$macro_ungated_repo" add src/cand.rs
+macro_ungated_json="$($SUMMARY -C "$macro_ungated_repo" --staged)"
+assert_eq "ungated decl in a macro body does not destroy the gated route" \
+    '["test_panic_path_added"]' "$(jq -c '.risk_flags' <<<"$macro_ungated_json")"
+assert_eq "ungated decl in a macro body is not production scope" \
+    "support" "$(jq -r '.scope' <<<"$macro_ungated_json")"
+
+# Direction two: a gated declaration inside a macro body must not create a
+# route (the file has no real declaration at all).
+macro_gated_repo="$SANDBOX/macro-gated"
+init_repo "$macro_gated_repo"
+mkdir -p "$macro_gated_repo/src"
+cat > "$macro_gated_repo/src/lib.rs" <<'RUST'
+macro_rules! demo {
+    () => {
+        #[cfg(test)]
+        mod cand;
+    };
+}
+RUST
+git -C "$macro_gated_repo" add src
+git -C "$macro_gated_repo" commit -q -m lib
+cat > "$macro_gated_repo/src/cand.rs" <<'RUST'
+pub fn parse(s: &str) -> u32 {
+    s.parse().unwrap()
+}
+RUST
+git -C "$macro_gated_repo" add src/cand.rs
+macro_gated_json="$($SUMMARY -C "$macro_gated_repo" --staged)"
+assert_eq "gated decl in a macro body does not create a route" \
+    '["panic_path_added"]' "$(jq -c '.risk_flags' <<<"$macro_gated_json")"
+assert_eq "gated decl in a macro body keeps production scope" \
+    "production" "$(jq -r '.scope' <<<"$macro_gated_json")"
+
+# Macro bodies may use paren delimiters (with brace groups inside): the
+# skip must track the opener's delimiter pair.
+macro_paren_repo="$SANDBOX/macro-paren"
+init_repo "$macro_paren_repo"
+mkdir -p "$macro_paren_repo/src"
+cat > "$macro_paren_repo/src/lib.rs" <<'RUST'
+macro_rules! demo (
+    () => {
+        mod cand;
+    };
+);
+
+#[cfg(test)]
+#[path = "cand.rs"]
+mod cand_fixtures;
+RUST
+git -C "$macro_paren_repo" add src
+git -C "$macro_paren_repo" commit -q -m lib
+cat > "$macro_paren_repo/src/cand.rs" <<'RUST'
+pub fn sample() -> u32 {
+    "3".parse().unwrap()
+}
+RUST
+git -C "$macro_paren_repo" add src/cand.rs
+macro_paren_json="$($SUMMARY -C "$macro_paren_repo" --staged)"
+assert_eq "paren-bodied macro body is skipped whole" \
+    '["test_panic_path_added"]' "$(jq -c '.risk_flags' <<<"$macro_paren_json")"
+assert_eq "paren-bodied macro body is not production scope" \
+    "support" "$(jq -r '.scope' <<<"$macro_paren_json")"
+
 printf '\nPASS=%d FAIL=%d\n' "$PASS" "$FAIL"
 if [ "$FAIL" -ne 0 ]; then exit 1; fi

--- a/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
+++ b/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
@@ -185,5 +185,197 @@ assert_eq "committed gated #[path] sibling classifies as test_panic_path_added" 
 assert_eq "committed gated #[path] sibling is not production scope" \
     "support" "$(jq -r '.scope' <<<"$branch_json")"
 
+# 2018-style parent file: src/scan.rs gates `mod fixtures;` resolving to
+# src/scan/fixtures.rs.
+parent_repo="$SANDBOX/parent-style"
+init_repo "$parent_repo"
+mkdir -p "$parent_repo/src/scan"
+cat > "$parent_repo/src/scan.rs" <<'RUST'
+pub fn scan() -> u32 {
+    1
+}
+
+#[cfg(test)]
+mod fixtures;
+RUST
+git -C "$parent_repo" add src
+git -C "$parent_repo" commit -q -m modules
+cat > "$parent_repo/src/scan/fixtures.rs" <<'RUST'
+pub fn fixture() -> u32 {
+    "7".parse().unwrap()
+}
+RUST
+git -C "$parent_repo" add src/scan/fixtures.rs
+parent_json="$($SUMMARY -C "$parent_repo" --staged)"
+assert_eq "2018-style parent-file gated mod classifies as test_panic_path_added" \
+    '["test_panic_path_added"]' "$(jq -c '.risk_flags' <<<"$parent_json")"
+assert_eq "2018-style parent-file gated mod is not production scope" \
+    "support" "$(jq -r '.scope' <<<"$parent_json")"
+
+# --head mode resolves declaring modules from tracked files. The gated
+# declaration is committed; the fixture file is staged but uncommitted.
+head_repo="$SANDBOX/head-mode"
+init_repo "$head_repo"
+mkdir -p "$head_repo/src/module_scan"
+cat > "$head_repo/src/module_scan/mod.rs" <<'RUST'
+#[cfg(test)]
+#[path = "scan_fixtures.rs"]
+mod scan_fixtures;
+RUST
+git -C "$head_repo" add src
+git -C "$head_repo" commit -q -m modules
+cat > "$head_repo/src/module_scan/scan_fixtures.rs" <<'RUST'
+pub fn fixture() -> u32 {
+    "7".parse().unwrap()
+}
+RUST
+git -C "$head_repo" add src/module_scan/scan_fixtures.rs
+head_json="$($SUMMARY -C "$head_repo" --head)"
+assert_eq "--head gated #[path] sibling classifies as test_panic_path_added" \
+    '["test_panic_path_added"]' "$(jq -c '.risk_flags' <<<"$head_json")"
+
+# An UNTRACKED sibling carrying a gated declaration must not reclassify a
+# tracked production change (git diff HEAD never surfaces untracked files).
+untracked_repo="$SANDBOX/untracked-decl"
+init_repo "$untracked_repo"
+mkdir -p "$untracked_repo/src"
+cat > "$untracked_repo/src/util.rs" <<'RUST'
+pub fn parse(s: &str) -> u32 {
+    s.parse().unwrap()
+}
+RUST
+cat > "$untracked_repo/src/scratch.rs" <<'RUST'
+#[cfg(test)]
+#[path = "util.rs"]
+mod util_fixtures;
+RUST
+git -C "$untracked_repo" add src/util.rs
+untracked_json="$($SUMMARY -C "$untracked_repo" --head)"
+assert_eq "untracked gated declaration does not downgrade tracked change" \
+    '["panic_path_added"]' "$(jq -c '.risk_flags' <<<"$untracked_json")"
+assert_eq "untracked gated declaration keeps production scope" \
+    "production" "$(jq -r '.scope' <<<"$untracked_json")"
+
+# bin/ path segments are crate roots: reachable without any mod declaration,
+# so a gated declaration does not make them test-only.
+bin_repo="$SANDBOX/bin-root"
+init_repo "$bin_repo"
+mkdir -p "$bin_repo/src/bin"
+cat > "$bin_repo/src/bin/cli.rs" <<'RUST'
+#[cfg(test)]
+#[path = "extra.rs"]
+mod extra;
+
+fn main() {}
+RUST
+git -C "$bin_repo" add src
+git -C "$bin_repo" commit -q -m bins
+cat > "$bin_repo/src/bin/extra.rs" <<'RUST'
+fn main() {
+    let _v: u32 = "7".parse().unwrap();
+}
+RUST
+git -C "$bin_repo" add src/bin/extra.rs
+bin_json="$($SUMMARY -C "$bin_repo" --staged)"
+assert_eq "bin/ crate root keeps panic_path_added despite gated declaration" \
+    '["panic_path_added"]' "$(jq -c '.risk_flags' <<<"$bin_json")"
+assert_eq "bin/ crate root stays production scope" \
+    "production" "$(jq -r '.scope' <<<"$bin_json")"
+
+# A gated declaration inside a /* block comment */ is not a declaration —
+# commented-out text must not downgrade production code.
+comment_repo="$SANDBOX/block-comment"
+init_repo "$comment_repo"
+mkdir -p "$comment_repo/src"
+cat > "$comment_repo/src/lib.rs" <<'RUST'
+/*
+#[cfg(test)]
+#[path = "shadow.rs"]
+mod shadow;
+*/
+pub fn real() -> u32 {
+    1
+}
+RUST
+git -C "$comment_repo" add src
+git -C "$comment_repo" commit -q -m lib
+cat > "$comment_repo/src/shadow.rs" <<'RUST'
+pub fn parse(s: &str) -> u32 {
+    s.parse().unwrap()
+}
+RUST
+git -C "$comment_repo" add src/shadow.rs
+comment_json="$($SUMMARY -C "$comment_repo" --staged)"
+assert_eq "block-commented gated declaration keeps panic_path_added" \
+    '["panic_path_added"]' "$(jq -c '.risk_flags' <<<"$comment_json")"
+assert_eq "block-commented gated declaration stays production scope" \
+    "production" "$(jq -r '.scope' <<<"$comment_json")"
+
+# include! of the candidate is an ungated production route: the content
+# compiles in the includer's cfg context, so it outweighs a gated #[path].
+include_repo="$SANDBOX/include-route"
+init_repo "$include_repo"
+mkdir -p "$include_repo/src"
+cat > "$include_repo/src/lib.rs" <<'RUST'
+include!("shared_impl.rs");
+
+#[cfg(test)]
+#[path = "shared_impl.rs"]
+mod shared_fixtures;
+RUST
+git -C "$include_repo" add src
+git -C "$include_repo" commit -q -m lib
+cat > "$include_repo/src/shared_impl.rs" <<'RUST'
+pub fn parse(s: &str) -> u32 {
+    s.parse().unwrap()
+}
+RUST
+git -C "$include_repo" add src/shared_impl.rs
+include_json="$($SUMMARY -C "$include_repo" --staged)"
+assert_eq "include! route keeps panic_path_added despite gated #[path]" \
+    '["panic_path_added"]' "$(jq -c '.risk_flags' <<<"$include_json")"
+assert_eq "include! route stays production scope" \
+    "production" "$(jq -r '.scope' <<<"$include_json")"
+
+# A read failure while scanning declaring modules fails closed: the
+# unreadable file could have held an ungated route, so the candidate keeps
+# production classification. Needs non-root (root reads through chmod 000).
+if [ "$(id -u)" -ne 0 ]; then
+    unreadable_repo="$SANDBOX/unreadable"
+    init_repo "$unreadable_repo"
+    mkdir -p "$unreadable_repo/src/x"
+    cat > "$unreadable_repo/src/x/mod.rs" <<'RUST'
+#[cfg(test)]
+#[path = "cand.rs"]
+mod cand_fixtures;
+RUST
+    cat > "$unreadable_repo/src/x/other.rs" <<'RUST'
+#[path = "cand.rs"]
+mod cand;
+RUST
+    git -C "$unreadable_repo" add src
+    git -C "$unreadable_repo" commit -q -m modules
+    cat > "$unreadable_repo/src/x/cand.rs" <<'RUST'
+pub fn parse(s: &str) -> u32 {
+    s.parse().unwrap()
+}
+RUST
+    git -C "$unreadable_repo" add src/x/cand.rs
+    chmod 000 "$unreadable_repo/src/x/other.rs"
+    # Keep the unreadable file out of the diff itself: chmod invalidates its
+    # cached stat, and a pre-existing (unguarded) `git diff -- <prod paths>`
+    # pipeline dies on unreadable diff members. This case targets the
+    # declaration scanner's fail-closed read, not that pipeline.
+    git -C "$unreadable_repo" update-index --assume-unchanged src/x/other.rs
+    unreadable_json="$($SUMMARY -C "$unreadable_repo" --head)"
+    chmod 644 "$unreadable_repo/src/x/other.rs"
+    assert_eq "unreadable declaring module fails closed to panic_path_added" \
+        '["panic_path_added"]' "$(jq -c '.risk_flags' <<<"$unreadable_json")"
+    assert_eq "unreadable declaring module fails closed to production scope" \
+        "production" "$(jq -r '.scope' <<<"$unreadable_json")"
+else
+    printf '  SKIP: unreadable-module cases (running as root)\n'
+fi
+
 printf '\nPASS=%d FAIL=%d\n' "$PASS" "$FAIL"
 if [ "$FAIL" -ne 0 ]; then exit 1; fi

--- a/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
+++ b/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
@@ -922,5 +922,168 @@ assert_eq "hash-raw #[path] ungated declaration keeps panic_path_added" \
 assert_eq "hash-raw #[path] ungated declaration stays production scope" \
     "production" "$(jq -r '.scope' <<<"$hashraw_json")"
 
+# An attribute-prefixed inline opener on one line (#[cfg(test)] mod outer {)
+# must still enter the skip region: its inner ungated declaration must not
+# fabricate a route that cancels the real gated one.
+attr_opener_repo="$SANDBOX/attr-opener"
+init_repo "$attr_opener_repo"
+mkdir -p "$attr_opener_repo/src"
+cat > "$attr_opener_repo/src/lib.rs" <<'RUST'
+#[cfg(test)] mod outer {
+    pub mod cand;
+}
+
+#[cfg(test)]
+#[path = "cand.rs"]
+mod cand_fixtures;
+RUST
+git -C "$attr_opener_repo" add src
+git -C "$attr_opener_repo" commit -q -m lib
+cat > "$attr_opener_repo/src/cand.rs" <<'RUST'
+pub fn sample() -> u32 {
+    "3".parse().unwrap()
+}
+RUST
+git -C "$attr_opener_repo" add src/cand.rs
+attr_opener_json="$($SUMMARY -C "$attr_opener_repo" --staged)"
+assert_eq "attribute-prefixed inline opener still skips its block" \
+    '["test_panic_path_added"]' "$(jq -c '.risk_flags' <<<"$attr_opener_json")"
+assert_eq "attribute-prefixed inline opener is not production scope" \
+    "support" "$(jq -r '.scope' <<<"$attr_opener_json")"
+
+# Every include! on a line is a route, not just the first.
+multi_include_repo="$SANDBOX/multi-include"
+init_repo "$multi_include_repo"
+mkdir -p "$multi_include_repo/src"
+cat > "$multi_include_repo/src/lib.rs" <<'RUST'
+include!("first.rs"); include!("shared_impl.rs");
+
+#[cfg(test)]
+#[path = "shared_impl.rs"]
+mod shared_fixtures;
+RUST
+cat > "$multi_include_repo/src/first.rs" <<'RUST'
+pub const FIRST: u32 = 1;
+RUST
+git -C "$multi_include_repo" add src
+git -C "$multi_include_repo" commit -q -m lib
+cat > "$multi_include_repo/src/shared_impl.rs" <<'RUST'
+pub fn parse(s: &str) -> u32 {
+    s.parse().unwrap()
+}
+RUST
+git -C "$multi_include_repo" add src/shared_impl.rs
+multi_include_json="$($SUMMARY -C "$multi_include_repo" --staged)"
+assert_eq "second include! on a line keeps panic_path_added" \
+    '["panic_path_added"]' "$(jq -c '.risk_flags' <<<"$multi_include_json")"
+assert_eq "second include! on a line keeps production scope" \
+    "production" "$(jq -r '.scope' <<<"$multi_include_json")"
+
+# Every declaration on a line is recorded, not just the first.
+multi_decl_repo="$SANDBOX/multi-decl"
+init_repo "$multi_decl_repo"
+mkdir -p "$multi_decl_repo/src"
+cat > "$multi_decl_repo/src/lib.rs" <<'RUST'
+mod first; pub mod shared;
+
+#[cfg(test)]
+#[path = "shared.rs"]
+mod shared_fixtures;
+RUST
+cat > "$multi_decl_repo/src/first.rs" <<'RUST'
+pub const FIRST: u32 = 1;
+RUST
+git -C "$multi_decl_repo" add src
+git -C "$multi_decl_repo" commit -q -m lib
+cat > "$multi_decl_repo/src/shared.rs" <<'RUST'
+pub fn parse(s: &str) -> u32 {
+    s.parse().unwrap()
+}
+RUST
+git -C "$multi_decl_repo" add src/shared.rs
+multi_decl_json="$($SUMMARY -C "$multi_decl_repo" --staged)"
+assert_eq "second declaration on a line keeps panic_path_added" \
+    '["panic_path_added"]' "$(jq -c '.risk_flags' <<<"$multi_decl_json")"
+assert_eq "second declaration on a line keeps production scope" \
+    "production" "$(jq -r '.scope' <<<"$multi_decl_json")"
+
+# A single-line inline block (mod m { include!("cand.rs") }) emits nothing:
+# the include inside must not cancel the real gated route.
+oneline_inline_repo="$SANDBOX/oneline-inline"
+init_repo "$oneline_inline_repo"
+mkdir -p "$oneline_inline_repo/src"
+cat > "$oneline_inline_repo/src/lib.rs" <<'RUST'
+mod m { include!("cand.rs") }
+
+#[cfg(test)]
+#[path = "cand.rs"]
+mod cand_fixtures;
+RUST
+git -C "$oneline_inline_repo" add src
+git -C "$oneline_inline_repo" commit -q -m lib
+cat > "$oneline_inline_repo/src/cand.rs" <<'RUST'
+pub fn sample() -> u32 {
+    "3".parse().unwrap()
+}
+RUST
+git -C "$oneline_inline_repo" add src/cand.rs
+oneline_inline_json="$($SUMMARY -C "$oneline_inline_repo" --staged)"
+assert_eq "single-line inline block include! emits no route" \
+    '["test_panic_path_added"]' "$(jq -c '.risk_flags' <<<"$oneline_inline_json")"
+assert_eq "single-line inline block is not production scope" \
+    "support" "$(jq -r '.scope' <<<"$oneline_inline_json")"
+
+# Torture line: several declarations, an attributed inline block, and two
+# include! calls share ONE line; gated twins exist for each interesting
+# target. shared.rs and inc_b.rs have ungated routes on that line
+# (production), onlygated.rs has only its gated route (test).
+torture_repo="$SANDBOX/torture"
+init_repo "$torture_repo"
+mkdir -p "$torture_repo/src"
+cat > "$torture_repo/src/lib.rs" <<'RUST'
+mod first; pub mod shared; #[cfg(test)] mod outer { mod inner; } include!("inc_a.rs"); include!("inc_b.rs");
+
+#[cfg(test)]
+#[path = "shared.rs"]
+mod shared_fx;
+
+#[cfg(test)]
+#[path = "inc_b.rs"]
+mod inc_fx;
+
+#[cfg(test)]
+#[path = "onlygated.rs"]
+mod og;
+RUST
+cat > "$torture_repo/src/first.rs" <<'RUST'
+pub const FIRST: u32 = 1;
+RUST
+cat > "$torture_repo/src/inc_a.rs" <<'RUST'
+pub const INC_A: u32 = 1;
+RUST
+git -C "$torture_repo" add src
+git -C "$torture_repo" commit -q -m lib
+cat > "$torture_repo/src/shared.rs" <<'RUST'
+pub fn parse(s: &str) -> u32 {
+    s.parse().unwrap()
+}
+RUST
+cat > "$torture_repo/src/inc_b.rs" <<'RUST'
+pub fn decode(s: &str) -> u32 {
+    s.parse().unwrap()
+}
+RUST
+cat > "$torture_repo/src/onlygated.rs" <<'RUST'
+pub fn fixture() -> u32 {
+    "7".parse().unwrap()
+}
+RUST
+git -C "$torture_repo" add src/shared.rs src/inc_b.rs src/onlygated.rs
+torture_json="$($SUMMARY -C "$torture_repo" --staged)"
+assert_eq "torture line: ungated routes win for shared/inc_b, gated for onlygated" \
+    '["panic_path_added","test_panic_path_added"]' "$(jq -c '.risk_flags' <<<"$torture_json")"
+assert_eq "torture line: scope is production" \
+    "production" "$(jq -r '.scope' <<<"$torture_json")"
+
 printf '\nPASS=%d FAIL=%d\n' "$PASS" "$FAIL"
 if [ "$FAIL" -ne 0 ]; then exit 1; fi

--- a/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
+++ b/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
@@ -377,5 +377,110 @@ else
     printf '  SKIP: unreadable-module cases (running as root)\n'
 fi
 
+# --head content reads are tracked-only, like the sibling listing: an
+# UNTRACKED 2018-style parent file carrying a gated declaration must not
+# reclassify a tracked candidate.
+untracked_parent_repo="$SANDBOX/untracked-parent"
+init_repo "$untracked_parent_repo"
+mkdir -p "$untracked_parent_repo/src/scan"
+cat > "$untracked_parent_repo/src/scan/fixtures.rs" <<'RUST'
+pub fn parse(s: &str) -> u32 {
+    s.parse().unwrap()
+}
+RUST
+cat > "$untracked_parent_repo/src/scan.rs" <<'RUST'
+#[cfg(test)]
+mod fixtures;
+RUST
+git -C "$untracked_parent_repo" add src/scan/fixtures.rs
+untracked_parent_json="$($SUMMARY -C "$untracked_parent_repo" --head)"
+assert_eq "untracked parent-file gated declaration does not downgrade in --head" \
+    '["panic_path_added"]' "$(jq -c '.risk_flags' <<<"$untracked_parent_json")"
+assert_eq "untracked parent-file gated declaration keeps production scope" \
+    "production" "$(jq -r '.scope' <<<"$untracked_parent_json")"
+
+# Line comments take precedence over block-comment openers: `// ... /*` must
+# not open block state and swallow a following real ungated declaration.
+line_comment_repo="$SANDBOX/line-comment-precedence"
+init_repo "$line_comment_repo"
+mkdir -p "$line_comment_repo/src/m"
+cat > "$line_comment_repo/src/m/mod.rs" <<'RUST'
+// docs: /* example opener inside a line comment
+pub mod cand;
+/* a real block comment */
+#[cfg(test)]
+#[path = "cand.rs"]
+mod cand_fixtures;
+RUST
+git -C "$line_comment_repo" add src
+git -C "$line_comment_repo" commit -q -m modules
+cat > "$line_comment_repo/src/m/cand.rs" <<'RUST'
+pub fn parse(s: &str) -> u32 {
+    s.parse().unwrap()
+}
+RUST
+git -C "$line_comment_repo" add src/m/cand.rs
+line_comment_json="$($SUMMARY -C "$line_comment_repo" --staged)"
+assert_eq "ungated decl after a line-commented /* keeps panic_path_added" \
+    '["panic_path_added"]' "$(jq -c '.risk_flags' <<<"$line_comment_json")"
+assert_eq "ungated decl after a line-commented /* stays production scope" \
+    "production" "$(jq -r '.scope' <<<"$line_comment_json")"
+
+# Rust block comments nest: an inner */ must not close the outer comment and
+# expose a commented-out gated declaration as real.
+nested_comment_repo="$SANDBOX/nested-comment"
+init_repo "$nested_comment_repo"
+mkdir -p "$nested_comment_repo/src"
+cat > "$nested_comment_repo/src/lib.rs" <<'RUST'
+/*
+/* nested */
+#[cfg(test)]
+#[path = "shadow.rs"]
+mod shadow;
+*/
+pub fn real() -> u32 {
+    1
+}
+RUST
+git -C "$nested_comment_repo" add src
+git -C "$nested_comment_repo" commit -q -m lib
+cat > "$nested_comment_repo/src/shadow.rs" <<'RUST'
+pub fn parse(s: &str) -> u32 {
+    s.parse().unwrap()
+}
+RUST
+git -C "$nested_comment_repo" add src/shadow.rs
+nested_comment_json="$($SUMMARY -C "$nested_comment_repo" --staged)"
+assert_eq "nested-comment gated declaration keeps panic_path_added" \
+    '["panic_path_added"]' "$(jq -c '.risk_flags' <<<"$nested_comment_json")"
+assert_eq "nested-comment gated declaration stays production scope" \
+    "production" "$(jq -r '.scope' <<<"$nested_comment_json")"
+
+# A commented-out include! is not a production route: the real gated
+# declaration must still classify the candidate as test.
+commented_include_repo="$SANDBOX/commented-include"
+init_repo "$commented_include_repo"
+mkdir -p "$commented_include_repo/src"
+cat > "$commented_include_repo/src/lib.rs" <<'RUST'
+// include!("shared_impl.rs");
+
+#[cfg(test)]
+#[path = "shared_impl.rs"]
+mod shared_fixtures;
+RUST
+git -C "$commented_include_repo" add src
+git -C "$commented_include_repo" commit -q -m lib
+cat > "$commented_include_repo/src/shared_impl.rs" <<'RUST'
+pub fn sample() -> u32 {
+    "3".parse().unwrap()
+}
+RUST
+git -C "$commented_include_repo" add src/shared_impl.rs
+commented_include_json="$($SUMMARY -C "$commented_include_repo" --staged)"
+assert_eq "commented-out include! still classifies as test_panic_path_added" \
+    '["test_panic_path_added"]' "$(jq -c '.risk_flags' <<<"$commented_include_json")"
+assert_eq "commented-out include! is not production scope" \
+    "support" "$(jq -r '.scope' <<<"$commented_include_json")"
+
 printf '\nPASS=%d FAIL=%d\n' "$PASS" "$FAIL"
 if [ "$FAIL" -ne 0 ]; then exit 1; fi

--- a/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
+++ b/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
@@ -1740,5 +1740,77 @@ binc_json="$($SUMMARY -C "$binc_repo" --staged)"
 assert_eq "brace-delimited include emits its production route"     '["panic_path_added"]' "$(jq -c '.risk_flags' <<<"$binc_json")"
 assert_eq "brace-include fixture keeps production scope"     "production" "$(jq -r '.scope' <<<"$binc_json")"
 
+# A leading UTF-8 BOM is an encoding preamble rustc accepts before the first
+# item — like the shebang it must not be consumed together with the ungated
+# declaration that follows it.
+bom_repo="$SANDBOX/bom"
+init_repo "$bom_repo"
+mkdir -p "$bom_repo/src"
+printf '\xef\xbb\xbf' > "$bom_repo/src/lib.rs"
+cat >> "$bom_repo/src/lib.rs" <<'RUST'
+mod cand;
+#[cfg(test)]
+#[path = "cand.rs"]
+mod fixtures;
+RUST
+git -C "$bom_repo" add src
+git -C "$bom_repo" commit -q -m lib
+cat > "$bom_repo/src/cand.rs" <<'RUST'
+pub fn parse(s: &str) -> u32 {
+    s.parse().unwrap()
+}
+RUST
+git -C "$bom_repo" add src/cand.rs
+bom_json="$($SUMMARY -C "$bom_repo" --staged)"
+assert_eq "BOM does not swallow the following declaration"     '["panic_path_added"]' "$(jq -c '.risk_flags' <<<"$bom_json")"
+assert_eq "BOM fixture keeps production scope"     "production" "$(jq -r '.scope' <<<"$bom_json")"
+
+# An absolutely-qualified macro path (::std::include!) is the same invocation:
+# the leading :: must not push it onto the generic boundary path, where a
+# brace argument is cut at the opening brace and skipped as a body.
+absinc_repo="$SANDBOX/abs-include"
+init_repo "$absinc_repo"
+mkdir -p "$absinc_repo/src"
+cat > "$absinc_repo/src/lib.rs" <<'RUST'
+#[cfg(test)]
+#[path = "cand.rs"]
+mod fixtures;
+::std::include! { "cand.rs" }
+RUST
+git -C "$absinc_repo" add src
+git -C "$absinc_repo" commit -q -m lib
+cat > "$absinc_repo/src/cand.rs" <<'RUST'
+pub fn parse(s: &str) -> u32 {
+    s.parse().unwrap()
+}
+RUST
+git -C "$absinc_repo" add src/cand.rs
+absinc_json="$($SUMMARY -C "$absinc_repo" --staged)"
+assert_eq "absolute-path include emits its production route"     '["panic_path_added"]' "$(jq -c '.risk_flags' <<<"$absinc_json")"
+assert_eq "absolute-path include fixture keeps production scope"     "production" "$(jq -r '.scope' <<<"$absinc_json")"
+
+# A hash-raw literal argument to a brace-delimited include! is still a direct
+# string literal: its closing hashes must not disqualify the route.
+rawinc_repo="$SANDBOX/raw-brace-include"
+init_repo "$rawinc_repo"
+mkdir -p "$rawinc_repo/src"
+cat > "$rawinc_repo/src/lib.rs" <<'RUST'
+#[cfg(test)]
+#[path = "cand.rs"]
+mod fixtures;
+include! { r#"cand.rs"# }
+RUST
+git -C "$rawinc_repo" add src
+git -C "$rawinc_repo" commit -q -m lib
+cat > "$rawinc_repo/src/cand.rs" <<'RUST'
+pub fn parse(s: &str) -> u32 {
+    s.parse().unwrap()
+}
+RUST
+git -C "$rawinc_repo" add src/cand.rs
+rawinc_json="$($SUMMARY -C "$rawinc_repo" --staged)"
+assert_eq "hash-raw brace include emits its production route"     '["panic_path_added"]' "$(jq -c '.risk_flags' <<<"$rawinc_json")"
+assert_eq "hash-raw brace include fixture keeps production scope"     "production" "$(jq -r '.scope' <<<"$rawinc_json")"
+
 printf '\nPASS=%d FAIL=%d\n' "$PASS" "$FAIL"
 if [ "$FAIL" -ne 0 ]; then exit 1; fi

--- a/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
+++ b/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
@@ -1626,5 +1626,45 @@ assert_eq "inner cfg(test) does not gate the next declaration" \
 assert_eq "inner cfg(test) keeps production scope" \
     "production" "$(jq -r '.scope' <<<"$inner_cfg_json")"
 
+# Token-spelling completeness: whitespace at every token boundary rustc
+# accepts, byte-string prefixes, and Unicode identifiers. One repo, one
+# torture lib.rs: every route below is UNGATED and must keep production
+# scope against a gated twin declaration for the same file.
+tokens_repo="$SANDBOX/token-spellings"
+init_repo "$tokens_repo"
+mkdir -p "$tokens_repo/src"
+cat > "$tokens_repo/src/lib.rs" <<'RUST'
+const RAW: &[u8] = br#"\"{"#;
+pub ( crate ) mod cand;
+include ! ("cand2.rs");
+# [path = "cand3.rs"] pub mod alias3;
+pub mod 模块;
+#[cfg(test)]
+#[path = "cand.rs"]
+mod f1;
+#[cfg(test)]
+#[path = "cand2.rs"]
+mod f2;
+#[cfg(test)]
+#[path = "cand3.rs"]
+mod f3;
+#[cfg(test)]
+#[path = "模块.rs"]
+mod f4;
+RUST
+git -C "$tokens_repo" add src
+git -C "$tokens_repo" commit -q -m lib
+for f in cand cand2 cand3 模块; do
+cat > "$tokens_repo/src/$f.rs" <<'RUST'
+pub fn parse(s: &str) -> u32 {
+    s.parse().unwrap()
+}
+RUST
+git -C "$tokens_repo" add "src/$f.rs"
+done
+tokens_json="$($SUMMARY -C "$tokens_repo" --staged)"
+assert_eq "token spellings: byte raw string, spaced visibility/include/attr, unicode ident all keep production"     '["panic_path_added"]' "$(jq -c '.risk_flags' <<<"$tokens_json")"
+assert_eq "token spellings keep production scope"     "production" "$(jq -r '.scope' <<<"$tokens_json")"
+
 printf '\nPASS=%d FAIL=%d\n' "$PASS" "$FAIL"
 if [ "$FAIL" -ne 0 ]; then exit 1; fi

--- a/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
+++ b/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
@@ -1362,5 +1362,96 @@ assert_eq "paren-bodied macro body is skipped whole" \
 assert_eq "paren-bodied macro body is not production scope" \
     "support" "$(jq -r '.scope' <<<"$macro_paren_json")"
 
+# A #[cfg(test)]-gated include! is a GATED route: when every route to the
+# file is gated, it is test-only. (The ungated direction is covered by the
+# earlier "include! route keeps panic_path_added" case.)
+gated_include_repo="$SANDBOX/gated-include"
+init_repo "$gated_include_repo"
+mkdir -p "$gated_include_repo/src"
+cat > "$gated_include_repo/src/lib.rs" <<'RUST'
+#[cfg(test)]
+include!("cand.rs");
+
+#[cfg(test)]
+#[path = "cand.rs"]
+mod cand_fixtures;
+RUST
+git -C "$gated_include_repo" add src
+git -C "$gated_include_repo" commit -q -m lib
+cat > "$gated_include_repo/src/cand.rs" <<'RUST'
+pub fn sample() -> u32 {
+    "3".parse().unwrap()
+}
+RUST
+git -C "$gated_include_repo" add src/cand.rs
+gated_include_json="$($SUMMARY -C "$gated_include_repo" --staged)"
+assert_eq "cfg(test)-gated include! is a gated route" \
+    '["test_panic_path_added"]' "$(jq -c '.risk_flags' <<<"$gated_include_json")"
+assert_eq "cfg(test)-gated include! is not production scope" \
+    "support" "$(jq -r '.scope' <<<"$gated_include_json")"
+
+# A macro INVOCATION's token tree only becomes items after expansion: an
+# item-like body (discard! { mod cand; }) must fabricate no route.
+invocation_repo="$SANDBOX/macro-invocation"
+init_repo "$invocation_repo"
+mkdir -p "$invocation_repo/src"
+cat > "$invocation_repo/src/lib.rs" <<'RUST'
+discard! { mod cand; }
+
+#[cfg(test)]
+#[path = "cand.rs"]
+mod cand_fixtures;
+RUST
+git -C "$invocation_repo" add src
+git -C "$invocation_repo" commit -q -m lib
+cat > "$invocation_repo/src/cand.rs" <<'RUST'
+pub fn sample() -> u32 {
+    "3".parse().unwrap()
+}
+RUST
+git -C "$invocation_repo" add src/cand.rs
+invocation_json="$($SUMMARY -C "$invocation_repo" --staged)"
+assert_eq "macro invocation token tree fabricates no ungated route" \
+    '["test_panic_path_added"]' "$(jq -c '.risk_flags' <<<"$invocation_json")"
+assert_eq "macro invocation token tree is not production scope" \
+    "support" "$(jq -r '.scope' <<<"$invocation_json")"
+
+# Rename rows key on the DESTINATION path: a renamed gated fixture must
+# classify by its new name, and no tab-joined path may leak into output.
+rename_repo="$SANDBOX/rename-dest"
+init_repo "$rename_repo"
+mkdir -p "$rename_repo/src"
+cat > "$rename_repo/src/lib.rs" <<'RUST'
+#[cfg(test)]
+#[path = "new_fix.rs"]
+mod fixtures;
+RUST
+cat > "$rename_repo/src/old_fix.rs" <<'RUST'
+pub fn fixture_one() -> u32 { 1 }
+pub fn fixture_two() -> u32 { 2 }
+pub fn fixture_three() -> u32 { 3 }
+pub fn fixture_four() -> u32 { 4 }
+pub fn fixture_five() -> u32 { 5 }
+pub fn fixture_six() -> u32 { 6 }
+pub fn fixture_seven() -> u32 { 7 }
+pub fn fixture_eight() -> u32 { 8 }
+RUST
+git -C "$rename_repo" add src
+git -C "$rename_repo" commit -q -m base
+git -C "$rename_repo" mv src/old_fix.rs src/new_fix.rs
+cat >> "$rename_repo/src/new_fix.rs" <<'RUST'
+pub fn parse(s: &str) -> u32 {
+    s.parse().unwrap()
+}
+RUST
+git -C "$rename_repo" add src/new_fix.rs
+rename_json="$($SUMMARY -C "$rename_repo" --staged)"
+assert_eq "renamed gated fixture classifies by destination" \
+    '["test_panic_path_added"]' "$(jq -c '.risk_flags' <<<"$rename_json")"
+assert_eq "renamed gated fixture is not production scope" \
+    "support" "$(jq -r '.scope' <<<"$rename_json")"
+assert_eq "no tab-joined rename path leaks into domains" \
+    "false" "$(jq -r '[.domains[].files[]] | map(test("\t")) | any' <<<"$rename_json")"
+
 printf '\nPASS=%d FAIL=%d\n' "$PASS" "$FAIL"
 if [ "$FAIL" -ne 0 ]; then exit 1; fi

--- a/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
+++ b/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
@@ -1691,5 +1691,30 @@ cstr_json="$($SUMMARY -C "$cstr_repo" --staged)"
 assert_eq "c-string raw literal does not corrupt structure; ungated route survives"     '["panic_path_added"]' "$(jq -c '.risk_flags' <<<"$cstr_json")"
 assert_eq "c-string fixture keeps production scope"     "production" "$(jq -r '.scope' <<<"$cstr_json")"
 
+# A crate shebang is a first-line preamble, not an item — it must not be
+# consumed together with the following ungated declaration.
+shebang_repo="$SANDBOX/shebang"
+init_repo "$shebang_repo"
+mkdir -p "$shebang_repo/src"
+cat > "$shebang_repo/src/main.rs" <<'RUST'
+#!/usr/bin/env rustx
+mod cand;
+#[cfg(test)]
+#[path = "cand.rs"]
+mod fixtures;
+fn main() {}
+RUST
+git -C "$shebang_repo" add src
+git -C "$shebang_repo" commit -q -m lib
+cat > "$shebang_repo/src/cand.rs" <<'RUST'
+pub fn parse(s: &str) -> u32 {
+    s.parse().unwrap()
+}
+RUST
+git -C "$shebang_repo" add src/cand.rs
+shebang_json="$($SUMMARY -C "$shebang_repo" --staged)"
+assert_eq "shebang does not swallow the following declaration"     '["panic_path_added"]' "$(jq -c '.risk_flags' <<<"$shebang_json")"
+assert_eq "shebang fixture keeps production scope"     "production" "$(jq -r '.scope' <<<"$shebang_json")"
+
 printf '\nPASS=%d FAIL=%d\n' "$PASS" "$FAIL"
 if [ "$FAIL" -ne 0 ]; then exit 1; fi

--- a/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
+++ b/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
@@ -839,5 +839,88 @@ assert_eq "raw-string #[path] ungated declaration keeps panic_path_added" \
 assert_eq "raw-string #[path] ungated declaration stays production scope" \
     "production" "$(jq -r '.scope' <<<"$rawstring_json")"
 
+# Declarations inside inline module blocks resolve into the inline chain
+# (mod outer { mod cand; } reaches outer/cand.rs) — the scanner skips them
+# rather than mis-resolving. Direction one: a gated inline declaration must
+# not fabricate a gated route for an unrelated same-name file.
+inline_gated_repo="$SANDBOX/inline-gated"
+init_repo "$inline_gated_repo"
+mkdir -p "$inline_gated_repo/src"
+cat > "$inline_gated_repo/src/lib.rs" <<'RUST'
+mod outer {
+    #[cfg(test)]
+    mod cand;
+}
+RUST
+git -C "$inline_gated_repo" add src
+git -C "$inline_gated_repo" commit -q -m lib
+cat > "$inline_gated_repo/src/cand.rs" <<'RUST'
+pub fn parse(s: &str) -> u32 {
+    s.parse().unwrap()
+}
+RUST
+git -C "$inline_gated_repo" add src/cand.rs
+inline_gated_json="$($SUMMARY -C "$inline_gated_repo" --staged)"
+assert_eq "inline gated declaration does not downgrade an unrelated file" \
+    '["panic_path_added"]' "$(jq -c '.risk_flags' <<<"$inline_gated_json")"
+assert_eq "inline gated declaration keeps production scope" \
+    "production" "$(jq -r '.scope' <<<"$inline_gated_json")"
+
+# Direction two: an ungated inline declaration must not fabricate an
+# ungated route that destroys a real gated one.
+inline_ungated_repo="$SANDBOX/inline-ungated"
+init_repo "$inline_ungated_repo"
+mkdir -p "$inline_ungated_repo/src"
+cat > "$inline_ungated_repo/src/lib.rs" <<'RUST'
+mod outer {
+    pub mod cand;
+}
+
+#[cfg(test)]
+#[path = "cand.rs"]
+mod cand_fixtures;
+RUST
+git -C "$inline_ungated_repo" add src
+git -C "$inline_ungated_repo" commit -q -m lib
+cat > "$inline_ungated_repo/src/cand.rs" <<'RUST'
+pub fn sample() -> u32 {
+    "3".parse().unwrap()
+}
+RUST
+git -C "$inline_ungated_repo" add src/cand.rs
+inline_ungated_json="$($SUMMARY -C "$inline_ungated_repo" --staged)"
+assert_eq "inline ungated declaration does not destroy the real gated route" \
+    '["test_panic_path_added"]' "$(jq -c '.risk_flags' <<<"$inline_ungated_json")"
+assert_eq "inline ungated declaration is not production scope" \
+    "support" "$(jq -r '.scope' <<<"$inline_ungated_json")"
+
+# Hash-raw #[path = r#"target.rs"#] is valid Rust: the attribute must be
+# parsed, not dropped into bare-mod alias resolution that loses the
+# ungated route.
+hashraw_repo="$SANDBOX/hash-raw"
+init_repo "$hashraw_repo"
+mkdir -p "$hashraw_repo/src"
+cat > "$hashraw_repo/src/lib.rs" <<'RUST'
+#[path = r#"target.rs"#]
+pub mod t;
+
+#[cfg(test)]
+#[path = "target.rs"]
+mod target_fixtures;
+RUST
+git -C "$hashraw_repo" add src
+git -C "$hashraw_repo" commit -q -m lib
+cat > "$hashraw_repo/src/target.rs" <<'RUST'
+pub fn parse(s: &str) -> u32 {
+    s.parse().unwrap()
+}
+RUST
+git -C "$hashraw_repo" add src/target.rs
+hashraw_json="$($SUMMARY -C "$hashraw_repo" --staged)"
+assert_eq "hash-raw #[path] ungated declaration keeps panic_path_added" \
+    '["panic_path_added"]' "$(jq -c '.risk_flags' <<<"$hashraw_json")"
+assert_eq "hash-raw #[path] ungated declaration stays production scope" \
+    "production" "$(jq -r '.scope' <<<"$hashraw_json")"
+
 printf '\nPASS=%d FAIL=%d\n' "$PASS" "$FAIL"
 if [ "$FAIL" -ne 0 ]; then exit 1; fi

--- a/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
+++ b/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
@@ -590,6 +590,8 @@ git -C "$space_repo" add "src/sub dir/cand.rs"
 space_json="$($SUMMARY -C "$space_repo" --staged)"
 assert_eq "whitespace path with gated declaration is not production scope" \
     "support" "$(jq -r '.scope' <<<"$space_json")"
+assert_eq "whitespace path still carries test_panic_path_added" \
+    '["test_panic_path_added"]' "$(jq -c '.risk_flags' <<<"$space_json")"
 
 # Lexically equivalent #[path] spellings resolve to the same target: an
 # ungated "./shared.rs" must cancel a gated "shared.rs".
@@ -695,6 +697,87 @@ assert_eq "include! from a non-mod-rs file resolves in the file's directory" \
     '["panic_path_added"]' "$(jq -c '.risk_flags' <<<"$filedir_include_json")"
 assert_eq "include! from a non-mod-rs file keeps production scope" \
     "production" "$(jq -r '.scope' <<<"$filedir_include_json")"
+
+# An include! that CLOSES without a string literal (computed path) must not
+# leave pending state that swallows a later unrelated literal as its target.
+stale_include_repo="$SANDBOX/stale-include"
+init_repo "$stale_include_repo"
+mkdir -p "$stale_include_repo/src"
+cat > "$stale_include_repo/src/lib.rs" <<'RUST'
+include!(GENERATED_PATH);
+const NOTE: &str = "shared_impl.rs";
+
+#[cfg(test)]
+#[path = "shared_impl.rs"]
+mod shared_fixtures;
+RUST
+git -C "$stale_include_repo" add src
+git -C "$stale_include_repo" commit -q -m lib
+cat > "$stale_include_repo/src/shared_impl.rs" <<'RUST'
+pub fn sample() -> u32 {
+    "3".parse().unwrap()
+}
+RUST
+git -C "$stale_include_repo" add src/shared_impl.rs
+stale_include_json="$($SUMMARY -C "$stale_include_repo" --staged)"
+assert_eq "closed computed include! leaves no stale route; gated decl wins" \
+    '["test_panic_path_added"]' "$(jq -c '.risk_flags' <<<"$stale_include_json")"
+assert_eq "closed computed include! is not production scope" \
+    "support" "$(jq -r '.scope' <<<"$stale_include_json")"
+
+# A #[path] attribute split across lines (rustc accepts the split) is still
+# an ungated production route — it must not be discarded and lose to a
+# conventional gated declaration of the same file.
+multiline_attr_repo="$SANDBOX/multiline-attr"
+init_repo "$multiline_attr_repo"
+mkdir -p "$multiline_attr_repo/src"
+cat > "$multiline_attr_repo/src/lib.rs" <<'RUST'
+#[path =
+"shared.rs"] pub mod production_alias;
+
+#[cfg(test)]
+#[path = "shared.rs"]
+mod shared_fixtures;
+RUST
+git -C "$multiline_attr_repo" add src
+git -C "$multiline_attr_repo" commit -q -m lib
+cat > "$multiline_attr_repo/src/shared.rs" <<'RUST'
+pub fn parse(s: &str) -> u32 {
+    s.parse().unwrap()
+}
+RUST
+git -C "$multiline_attr_repo" add src/shared.rs
+multiline_attr_json="$($SUMMARY -C "$multiline_attr_repo" --staged)"
+assert_eq "multiline #[path] ungated declaration keeps panic_path_added" \
+    '["panic_path_added"]' "$(jq -c '.risk_flags' <<<"$multiline_attr_json")"
+assert_eq "multiline #[path] ungated declaration stays production scope" \
+    "production" "$(jq -r '.scope' <<<"$multiline_attr_json")"
+
+# include! needs a token boundary: my_include!("...") is a different macro
+# and must not fabricate an ungated route.
+tokenboundary_repo="$SANDBOX/token-boundary"
+init_repo "$tokenboundary_repo"
+mkdir -p "$tokenboundary_repo/src"
+cat > "$tokenboundary_repo/src/lib.rs" <<'RUST'
+my_include!("shared_impl.rs");
+
+#[cfg(test)]
+#[path = "shared_impl.rs"]
+mod shared_fixtures;
+RUST
+git -C "$tokenboundary_repo" add src
+git -C "$tokenboundary_repo" commit -q -m lib
+cat > "$tokenboundary_repo/src/shared_impl.rs" <<'RUST'
+pub fn sample() -> u32 {
+    "3".parse().unwrap()
+}
+RUST
+git -C "$tokenboundary_repo" add src/shared_impl.rs
+tokenboundary_json="$($SUMMARY -C "$tokenboundary_repo" --staged)"
+assert_eq "my_include! is not an include! route; gated decl wins" \
+    '["test_panic_path_added"]' "$(jq -c '.risk_flags' <<<"$tokenboundary_json")"
+assert_eq "my_include! candidate is not production scope" \
+    "support" "$(jq -r '.scope' <<<"$tokenboundary_json")"
 
 printf '\nPASS=%d FAIL=%d\n' "$PASS" "$FAIL"
 if [ "$FAIL" -ne 0 ]; then exit 1; fi

--- a/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
+++ b/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# vstack#1217: a .rs file with no file-local test markers is still test scope
+# when its gate lives at the declaration site in the declaring module:
+#
+#     #[cfg(test)]
+#     #[path = "scan_fixtures.rs"]
+#     mod scan_fixtures;
+#
+# File-local heuristics (tests/ dirs, *_tests.rs, in-file #[cfg(test)]) cannot
+# see that, so the classifier reads the declaring module on the diff's new
+# side: a file whose every found declaration is #[cfg(test)]-gated classifies
+# as test (test_panic_path_added, support scope); any ungated declaration, or
+# none found, keeps production classification.
+#
+# Run: bash skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../.." && pwd)"
+SUMMARY="$REPO_ROOT/skills/github/scripts/git-diff-summary"
+
+SANDBOX="$(mktemp -d -t gh-diff-summary-cfgdecl-XXXXXX)"
+PASS=0
+FAIL=0
+
+cleanup() { rm -rf "$SANDBOX" 2>/dev/null || true; }
+trap cleanup EXIT
+
+assert_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if [ "$expected" = "$actual" ]; then
+        printf '  PASS: %s\n' "$label"
+        PASS=$((PASS + 1))
+    else
+        printf '  FAIL: %s\n    expected: %s\n    actual:   %s\n' "$label" "$expected" "$actual" >&2
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+init_repo() {
+    local repo="$1"
+    mkdir -p "$repo"
+    git -C "$repo" init -q -b main
+    git -C "$repo" config user.email test@example.com
+    git -C "$repo" config user.name test
+    git -C "$repo" config commit.gpgsign false
+    printf 'base\n' > "$repo/README.md"
+    git -C "$repo" add README.md
+    git -C "$repo" commit -q -m init
+}
+
+# The reported shape: #[cfg(test)]-gated #[path] sibling (D010 shared-fixture
+# pattern). The declaring mod.rs is committed at base; only the fixture file
+# is in the diff.
+path_sibling_repo="$SANDBOX/path-sibling"
+init_repo "$path_sibling_repo"
+mkdir -p "$path_sibling_repo/src/module_scan"
+cat > "$path_sibling_repo/src/module_scan/mod.rs" <<'RUST'
+pub fn scan() -> u32 {
+    1
+}
+
+#[cfg(test)]
+#[path = "scan_fixtures.rs"]
+mod scan_fixtures;
+RUST
+git -C "$path_sibling_repo" add src
+git -C "$path_sibling_repo" commit -q -m modules
+cat > "$path_sibling_repo/src/module_scan/scan_fixtures.rs" <<'RUST'
+pub fn fixture() -> u32 {
+    let v: u32 = "7".parse().unwrap();
+    if v == 0 {
+        panic!("unreachable");
+    }
+    v
+}
+RUST
+git -C "$path_sibling_repo" add src/module_scan/scan_fixtures.rs
+path_sibling_json="$($SUMMARY -C "$path_sibling_repo" --staged)"
+assert_eq "cfg(test)-gated #[path] sibling panic classifies as test_panic_path_added" \
+    '["test_panic_path_added"]' "$(jq -c '.risk_flags' <<<"$path_sibling_json")"
+assert_eq "cfg(test)-gated #[path] sibling is not production scope" \
+    "support" "$(jq -r '.scope' <<<"$path_sibling_json")"
+
+# Bare `#[cfg(test)] mod name;` gate (no #[path]) from a declaring lib.rs.
+bare_mod_repo="$SANDBOX/bare-mod"
+init_repo "$bare_mod_repo"
+mkdir -p "$bare_mod_repo/src"
+cat > "$bare_mod_repo/src/lib.rs" <<'RUST'
+pub fn add(a: u32, b: u32) -> u32 {
+    a + b
+}
+
+#[cfg(test)] mod helpers;
+RUST
+git -C "$bare_mod_repo" add src
+git -C "$bare_mod_repo" commit -q -m lib
+cat > "$bare_mod_repo/src/helpers.rs" <<'RUST'
+pub fn sample() -> u32 {
+    "3".parse().unwrap()
+}
+RUST
+git -C "$bare_mod_repo" add src/helpers.rs
+bare_mod_json="$($SUMMARY -C "$bare_mod_repo" --staged)"
+assert_eq "cfg(test)-gated bare mod sibling panic classifies as test_panic_path_added" \
+    '["test_panic_path_added"]' "$(jq -c '.risk_flags' <<<"$bare_mod_json")"
+assert_eq "cfg(test)-gated bare mod sibling is not production scope" \
+    "support" "$(jq -r '.scope' <<<"$bare_mod_json")"
+
+# Control: an ungated declaration keeps production classification — the
+# declaration-site check must not over-classify.
+ungated_repo="$SANDBOX/ungated"
+init_repo "$ungated_repo"
+mkdir -p "$ungated_repo/src"
+cat > "$ungated_repo/src/lib.rs" <<'RUST'
+pub mod util;
+RUST
+git -C "$ungated_repo" add src
+git -C "$ungated_repo" commit -q -m lib
+cat > "$ungated_repo/src/util.rs" <<'RUST'
+pub fn parse(s: &str) -> u32 {
+    s.parse().unwrap()
+}
+RUST
+git -C "$ungated_repo" add src/util.rs
+ungated_json="$($SUMMARY -C "$ungated_repo" --staged)"
+assert_eq "ungated mod sibling keeps panic_path_added" \
+    '["panic_path_added"]' "$(jq -c '.risk_flags' <<<"$ungated_json")"
+assert_eq "ungated mod sibling stays production scope" \
+    "production" "$(jq -r '.scope' <<<"$ungated_json")"
+
+# Control: a file reachable both through a gated #[path] declaration and an
+# ungated one is production — any ungated route wins.
+dual_repo="$SANDBOX/dual"
+init_repo "$dual_repo"
+mkdir -p "$dual_repo/src"
+cat > "$dual_repo/src/lib.rs" <<'RUST'
+pub mod shared;
+
+#[cfg(test)]
+#[path = "shared.rs"]
+mod shared_fixtures;
+RUST
+git -C "$dual_repo" add src
+git -C "$dual_repo" commit -q -m lib
+cat > "$dual_repo/src/shared.rs" <<'RUST'
+pub fn parse(s: &str) -> u32 {
+    s.parse().unwrap()
+}
+RUST
+git -C "$dual_repo" add src/shared.rs
+dual_json="$($SUMMARY -C "$dual_repo" --staged)"
+assert_eq "gated + ungated dual declaration stays panic_path_added" \
+    '["panic_path_added"]' "$(jq -c '.risk_flags' <<<"$dual_json")"
+assert_eq "gated + ungated dual declaration stays production scope" \
+    "production" "$(jq -r '.scope' <<<"$dual_json")"
+
+# The base...HEAD diff path resolves declaring modules from HEAD, not the
+# index or worktree.
+branch_repo="$SANDBOX/branch"
+init_repo "$branch_repo"
+mkdir -p "$branch_repo/src/module_scan"
+cat > "$branch_repo/src/module_scan/mod.rs" <<'RUST'
+pub fn scan() -> u32 {
+    1
+}
+
+#[cfg(test)]
+#[path = "scan_fixtures.rs"]
+mod scan_fixtures;
+RUST
+git -C "$branch_repo" add src
+git -C "$branch_repo" commit -q -m modules
+git -C "$branch_repo" checkout -q -b feature
+cat > "$branch_repo/src/module_scan/scan_fixtures.rs" <<'RUST'
+pub fn fixture() -> u32 {
+    "7".parse().unwrap()
+}
+RUST
+git -C "$branch_repo" add src/module_scan/scan_fixtures.rs
+git -C "$branch_repo" commit -q -m fixtures
+branch_json="$($SUMMARY -C "$branch_repo" main)"
+assert_eq "committed gated #[path] sibling classifies as test_panic_path_added" \
+    '["test_panic_path_added"]' "$(jq -c '.risk_flags' <<<"$branch_json")"
+assert_eq "committed gated #[path] sibling is not production scope" \
+    "support" "$(jq -r '.scope' <<<"$branch_json")"
+
+printf '\nPASS=%d FAIL=%d\n' "$PASS" "$FAIL"
+if [ "$FAIL" -ne 0 ]; then exit 1; fi

--- a/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
+++ b/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
@@ -1912,5 +1912,64 @@ symlink_json="$($SUMMARY -C "$symlink_repo" --staged)"
 assert_eq "symlinked declaring module fails closed to production"     '["panic_path_added"]' "$(jq -c '.risk_flags' <<<"$symlink_json")"
 assert_eq "symlinked declaring module keeps production scope"     "production" "$(jq -r '.scope' <<<"$symlink_json")"
 
+# A semicolon nested in a token group (the length of an array type) is not an
+# item boundary: splitting there would drop the pending #[cfg(test)] gate and
+# record the include that follows as an ungated production route.
+semi_repo="$SANDBOX/nested-semicolon"
+init_repo "$semi_repo"
+mkdir -p "$semi_repo/src"
+cat > "$semi_repo/src/lib.rs" <<'RUST'
+#[cfg(test)]
+const BUF: [u8; 4] = include!("cand.rs");
+RUST
+git -C "$semi_repo" add src
+git -C "$semi_repo" commit -q -m lib
+cat > "$semi_repo/src/cand.rs" <<'RUST'
+[
+    1u8,
+    2,
+    3,
+    if false { panic!("unreachable") } else { 4 },
+]
+RUST
+git -C "$semi_repo" add src/cand.rs
+semi_json="$($SUMMARY -C "$semi_repo" --staged)"
+assert_eq "semicolon in a nested group keeps the item gate"     '["test_panic_path_added"]' "$(jq -c '.risk_flags' <<<"$semi_json")"
+assert_eq "nested-semicolon fixture stays support scope"     "support" "$(jq -r '.scope' <<<"$semi_json")"
+
+# A DANGLING worktree symlink is unreadable, not absent: the symlink guard
+# must be reached before the existence probe, which follows the link and
+# would otherwise report the declaring module as missing (no record).
+dangling_repo="$SANDBOX/dangling-symlink"
+init_repo "$dangling_repo"
+mkdir -p "$dangling_repo/src"
+cat > "$dangling_repo/src/lib.rs" <<'RUST'
+pub fn unrelated() -> u32 {
+    0
+}
+RUST
+cat > "$dangling_repo/src/gate.rs" <<'RUST'
+#[cfg(test)]
+#[path = "cand.rs"]
+mod fixtures;
+RUST
+cat > "$dangling_repo/src/cand.rs" <<'RUST'
+pub fn ok() -> u32 {
+    1
+}
+RUST
+git -C "$dangling_repo" add src
+git -C "$dangling_repo" commit -q -m lib
+cat > "$dangling_repo/src/cand.rs" <<'RUST'
+pub fn parse(s: &str) -> u32 {
+    s.parse().unwrap()
+}
+RUST
+rm "$dangling_repo/src/lib.rs"
+ln -s ../nowhere/missing.rs "$dangling_repo/src/lib.rs"
+dangling_json="$($SUMMARY -C "$dangling_repo" --head)"
+assert_eq "dangling symlink declaring module fails closed to production"     '["panic_path_added"]' "$(jq -c '.risk_flags' <<<"$dangling_json")"
+assert_eq "dangling symlink keeps production scope"     "production" "$(jq -r '.scope' <<<"$dangling_json")"
+
 printf '\nPASS=%d FAIL=%d\n' "$PASS" "$FAIL"
 if [ "$FAIL" -ne 0 ]; then exit 1; fi

--- a/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
+++ b/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
@@ -1666,5 +1666,30 @@ tokens_json="$($SUMMARY -C "$tokens_repo" --staged)"
 assert_eq "token spellings: byte raw string, spaced visibility/include/attr, unicode ident all keep production"     '["panic_path_added"]' "$(jq -c '.risk_flags' <<<"$tokens_json")"
 assert_eq "token spellings keep production scope"     "production" "$(jq -r '.scope' <<<"$tokens_json")"
 
+# C-string literals (Rust 2021+): cr#"..."# with an embedded quote must
+# lex as a raw string (not an ordinary string closing early and
+# corrupting structure), and byte/C forms never qualify as route values.
+cstr_repo="$SANDBOX/c-strings"
+init_repo "$cstr_repo"
+mkdir -p "$cstr_repo/src"
+cat > "$cstr_repo/src/lib.rs" <<'RUST'
+#[cfg(test)]
+#[path = "cand.rs"]
+mod fixtures;
+const C: &core::ffi::CStr = cr#"a"b{"#;
+pub mod cand;
+RUST
+git -C "$cstr_repo" add src
+git -C "$cstr_repo" commit -q -m lib
+cat > "$cstr_repo/src/cand.rs" <<'RUST'
+pub fn parse(s: &str) -> u32 {
+    s.parse().unwrap()
+}
+RUST
+git -C "$cstr_repo" add src/cand.rs
+cstr_json="$($SUMMARY -C "$cstr_repo" --staged)"
+assert_eq "c-string raw literal does not corrupt structure; ungated route survives"     '["panic_path_added"]' "$(jq -c '.risk_flags' <<<"$cstr_json")"
+assert_eq "c-string fixture keeps production scope"     "production" "$(jq -r '.scope' <<<"$cstr_json")"
+
 printf '\nPASS=%d FAIL=%d\n' "$PASS" "$FAIL"
 if [ "$FAIL" -ne 0 ]; then exit 1; fi

--- a/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
+++ b/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
@@ -1884,5 +1884,33 @@ nestattr_json="$($SUMMARY -C "$nestattr_repo" --staged)"
 assert_eq "nested attribute brackets do not swallow the declaration"     '["panic_path_added"]' "$(jq -c '.risk_flags' <<<"$nestattr_json")"
 assert_eq "nested-attribute fixture keeps production scope"     "production" "$(jq -r '.scope' <<<"$nestattr_json")"
 
+# A tracked declaring module that is a SYMLINK stores its target path as the
+# blob, so reading it yields link text, not Rust: no declarations parse and a
+# gated sibling would win. Cargo compiles through the link, so the route is
+# real — the entry must be treated as unreadable and fail closed.
+symlink_repo="$SANDBOX/symlink-declaring-module"
+init_repo "$symlink_repo"
+mkdir -p "$symlink_repo/real" "$symlink_repo/src"
+cat > "$symlink_repo/real/lib_src.rs" <<'RUST'
+mod cand;
+RUST
+ln -s ../real/lib_src.rs "$symlink_repo/src/lib.rs"
+cat > "$symlink_repo/src/gate.rs" <<'RUST'
+#[cfg(test)]
+#[path = "cand.rs"]
+mod fixtures;
+RUST
+git -C "$symlink_repo" add real src
+git -C "$symlink_repo" commit -q -m lib
+cat > "$symlink_repo/src/cand.rs" <<'RUST'
+pub fn parse(s: &str) -> u32 {
+    s.parse().unwrap()
+}
+RUST
+git -C "$symlink_repo" add src/cand.rs
+symlink_json="$($SUMMARY -C "$symlink_repo" --staged)"
+assert_eq "symlinked declaring module fails closed to production"     '["panic_path_added"]' "$(jq -c '.risk_flags' <<<"$symlink_json")"
+assert_eq "symlinked declaring module keeps production scope"     "production" "$(jq -r '.scope' <<<"$symlink_json")"
+
 printf '\nPASS=%d FAIL=%d\n' "$PASS" "$FAIL"
 if [ "$FAIL" -ne 0 ]; then exit 1; fi

--- a/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
+++ b/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
@@ -1453,5 +1453,124 @@ assert_eq "renamed gated fixture is not production scope" \
 assert_eq "no tab-joined rename path leaks into domains" \
     "false" "$(jq -r '[.domains[].files[]] | map(test("\t")) | any' <<<"$rename_json")"
 
+# Braced non-module item bodies are skip regions. Direction one: a decl
+# nested in a gated fn body must not surface as an UNGATED top-level route
+# that cancels the real gated declaration.
+gated_body_repo="$SANDBOX/gated-fn-body"
+init_repo "$gated_body_repo"
+mkdir -p "$gated_body_repo/src"
+cat > "$gated_body_repo/src/lib.rs" <<'RUST'
+#[cfg(test)]
+fn setup() {
+    #[path = "cand.rs"]
+    mod nested;
+}
+
+#[cfg(test)]
+#[path = "cand.rs"]
+mod cand_fixtures;
+RUST
+git -C "$gated_body_repo" add src
+git -C "$gated_body_repo" commit -q -m lib
+cat > "$gated_body_repo/src/cand.rs" <<'RUST'
+pub fn sample() -> u32 {
+    "3".parse().unwrap()
+}
+RUST
+git -C "$gated_body_repo" add src/cand.rs
+gated_body_json="$($SUMMARY -C "$gated_body_repo" --staged)"
+assert_eq "decl nested in a gated fn body does not cancel the gated route" \
+    '["test_panic_path_added"]' "$(jq -c '.risk_flags' <<<"$gated_body_json")"
+assert_eq "decl nested in a gated fn body is not production scope" \
+    "support" "$(jq -r '.scope' <<<"$gated_body_json")"
+
+# Direction two: a gated declaration inside an fn body must not fabricate a
+# gated route either — the body emits nothing at all.
+body_fabricate_repo="$SANDBOX/body-fabricate"
+init_repo "$body_fabricate_repo"
+mkdir -p "$body_fabricate_repo/src"
+cat > "$body_fabricate_repo/src/lib.rs" <<'RUST'
+fn setup() {
+    #[cfg(test)]
+    #[path = "cand.rs"]
+    mod nested;
+}
+RUST
+git -C "$body_fabricate_repo" add src
+git -C "$body_fabricate_repo" commit -q -m lib
+cat > "$body_fabricate_repo/src/cand.rs" <<'RUST'
+pub fn parse(s: &str) -> u32 {
+    s.parse().unwrap()
+}
+RUST
+git -C "$body_fabricate_repo" add src/cand.rs
+body_fabricate_json="$($SUMMARY -C "$body_fabricate_repo" --staged)"
+assert_eq "gated decl in an fn body does not fabricate a route" \
+    '["panic_path_added"]' "$(jq -c '.risk_flags' <<<"$body_fabricate_json")"
+assert_eq "gated decl in an fn body keeps production scope" \
+    "production" "$(jq -r '.scope' <<<"$body_fabricate_json")"
+
+# The include! variant: an include inside a gated fn body must not surface
+# as an ungated route.
+body_include_repo="$SANDBOX/body-include"
+init_repo "$body_include_repo"
+mkdir -p "$body_include_repo/src"
+cat > "$body_include_repo/src/lib.rs" <<'RUST'
+#[cfg(test)]
+fn cases() {
+    include!("cand.rs");
+}
+
+#[cfg(test)]
+#[path = "cand.rs"]
+mod cand_fixtures;
+RUST
+git -C "$body_include_repo" add src
+git -C "$body_include_repo" commit -q -m lib
+cat > "$body_include_repo/src/cand.rs" <<'RUST'
+pub fn sample() -> u32 {
+    "3".parse().unwrap()
+}
+RUST
+git -C "$body_include_repo" add src/cand.rs
+body_include_json="$($SUMMARY -C "$body_include_repo" --staged)"
+assert_eq "include! in a gated fn body does not surface ungated" \
+    '["test_panic_path_added"]' "$(jq -c '.risk_flags' <<<"$body_include_json")"
+assert_eq "include! in a gated fn body is not production scope" \
+    "support" "$(jq -r '.scope' <<<"$body_include_json")"
+
+# rustc-accepted cfg spellings: whitespace between tokens and a trailing
+# comma after the predicate both gate.
+cfg_spelling_repo="$SANDBOX/cfg-spellings"
+init_repo "$cfg_spelling_repo"
+mkdir -p "$cfg_spelling_repo/src"
+cat > "$cfg_spelling_repo/src/lib.rs" <<'RUST'
+#[cfg ( test )]
+#[path = "cand_a.rs"]
+mod fixture_a;
+
+#[cfg(test,)]
+#[path = "cand_b.rs"]
+mod fixture_b;
+RUST
+git -C "$cfg_spelling_repo" add src
+git -C "$cfg_spelling_repo" commit -q -m lib
+cat > "$cfg_spelling_repo/src/cand_a.rs" <<'RUST'
+pub fn a() -> u32 {
+    "1".parse().unwrap()
+}
+RUST
+cat > "$cfg_spelling_repo/src/cand_b.rs" <<'RUST'
+pub fn b() -> u32 {
+    "2".parse().unwrap()
+}
+RUST
+git -C "$cfg_spelling_repo" add src/cand_a.rs src/cand_b.rs
+cfg_spelling_json="$($SUMMARY -C "$cfg_spelling_repo" --staged)"
+assert_eq "whitespace and trailing-comma cfg spellings both gate" \
+    '["test_panic_path_added"]' "$(jq -c '.risk_flags' <<<"$cfg_spelling_json")"
+assert_eq "whitespace and trailing-comma cfg spellings are not production" \
+    "support" "$(jq -r '.scope' <<<"$cfg_spelling_json")"
+
 printf '\nPASS=%d FAIL=%d\n' "$PASS" "$FAIL"
 if [ "$FAIL" -ne 0 ]; then exit 1; fi

--- a/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
+++ b/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
@@ -779,5 +779,65 @@ assert_eq "my_include! is not an include! route; gated decl wins" \
 assert_eq "my_include! candidate is not production scope" \
     "support" "$(jq -r '.scope' <<<"$tokenboundary_json")"
 
+# Per the Rust reference, #[path] on a module NOT inside an inline block
+# resolves relative to the SOURCE FILE's directory — also for non-mod-rs
+# files. An ungated #[path = "target.rs"] in src/outer.rs reaches
+# src/target.rs and must cancel a gated declaration of that file.
+filedir_path_repo="$SANDBOX/filedir-path"
+init_repo "$filedir_path_repo"
+mkdir -p "$filedir_path_repo/src"
+cat > "$filedir_path_repo/src/outer.rs" <<'RUST'
+#[path = "target.rs"]
+pub mod t;
+RUST
+cat > "$filedir_path_repo/src/lib.rs" <<'RUST'
+pub mod outer;
+
+#[cfg(test)]
+#[path = "target.rs"]
+mod target_fixtures;
+RUST
+git -C "$filedir_path_repo" add src
+git -C "$filedir_path_repo" commit -q -m lib
+cat > "$filedir_path_repo/src/target.rs" <<'RUST'
+pub fn parse(s: &str) -> u32 {
+    s.parse().unwrap()
+}
+RUST
+git -C "$filedir_path_repo" add src/target.rs
+filedir_path_json="$($SUMMARY -C "$filedir_path_repo" --staged)"
+assert_eq "non-mod-rs #[path] resolves in the file's directory" \
+    '["panic_path_added"]' "$(jq -c '.risk_flags' <<<"$filedir_path_json")"
+assert_eq "non-mod-rs #[path] keeps production scope" \
+    "production" "$(jq -r '.scope' <<<"$filedir_path_json")"
+
+# Raw-string #[path = r"target.rs"] is valid Rust; the attribute must not be
+# dropped (which would resolve the module by alias and lose the ungated
+# route to a gated declaration).
+rawstring_repo="$SANDBOX/raw-string"
+init_repo "$rawstring_repo"
+mkdir -p "$rawstring_repo/src"
+cat > "$rawstring_repo/src/lib.rs" <<'RUST'
+#[path = r"target.rs"]
+pub mod t;
+
+#[cfg(test)]
+#[path = "target.rs"]
+mod target_fixtures;
+RUST
+git -C "$rawstring_repo" add src
+git -C "$rawstring_repo" commit -q -m lib
+cat > "$rawstring_repo/src/target.rs" <<'RUST'
+pub fn parse(s: &str) -> u32 {
+    s.parse().unwrap()
+}
+RUST
+git -C "$rawstring_repo" add src/target.rs
+rawstring_json="$($SUMMARY -C "$rawstring_repo" --staged)"
+assert_eq "raw-string #[path] ungated declaration keeps panic_path_added" \
+    '["panic_path_added"]' "$(jq -c '.risk_flags' <<<"$rawstring_json")"
+assert_eq "raw-string #[path] ungated declaration stays production scope" \
+    "production" "$(jq -r '.scope' <<<"$rawstring_json")"
+
 printf '\nPASS=%d FAIL=%d\n' "$PASS" "$FAIL"
 if [ "$FAIL" -ne 0 ]; then exit 1; fi

--- a/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
+++ b/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
@@ -1572,5 +1572,59 @@ assert_eq "whitespace and trailing-comma cfg spellings both gate" \
 assert_eq "whitespace and trailing-comma cfg spellings are not production" \
     "support" "$(jq -r '.scope' <<<"$cfg_spelling_json")"
 
+# An inner attribute is its own item: it must not be consumed together
+# with the following declaration (which would swallow an ungated route).
+inner_attr_repo="$SANDBOX/inner-attr"
+init_repo "$inner_attr_repo"
+mkdir -p "$inner_attr_repo/src"
+cat > "$inner_attr_repo/src/lib.rs" <<'RUST'
+#![allow(dead_code)]
+pub mod cand;
+
+#[cfg(test)]
+#[path = "cand.rs"]
+mod cand_fixtures;
+RUST
+git -C "$inner_attr_repo" add src
+git -C "$inner_attr_repo" commit -q -m lib
+cat > "$inner_attr_repo/src/cand.rs" <<'RUST'
+pub fn parse(s: &str) -> u32 {
+    s.parse().unwrap()
+}
+RUST
+git -C "$inner_attr_repo" add src/cand.rs
+inner_attr_json="$($SUMMARY -C "$inner_attr_repo" --staged)"
+assert_eq "inner attribute does not swallow the following declaration" \
+    '["panic_path_added"]' "$(jq -c '.risk_flags' <<<"$inner_attr_json")"
+assert_eq "inner attribute keeps production scope" \
+    "production" "$(jq -r '.scope' <<<"$inner_attr_json")"
+
+# An inner #![cfg(test)] binds to the enclosing module, not the next item:
+# the following declaration stays ungated.
+inner_cfg_repo="$SANDBOX/inner-cfg"
+init_repo "$inner_cfg_repo"
+mkdir -p "$inner_cfg_repo/src"
+cat > "$inner_cfg_repo/src/lib.rs" <<'RUST'
+#![cfg(test)]
+pub mod cand;
+
+#[cfg(test)]
+#[path = "cand.rs"]
+mod cand_fixtures;
+RUST
+git -C "$inner_cfg_repo" add src
+git -C "$inner_cfg_repo" commit -q -m lib
+cat > "$inner_cfg_repo/src/cand.rs" <<'RUST'
+pub fn parse(s: &str) -> u32 {
+    s.parse().unwrap()
+}
+RUST
+git -C "$inner_cfg_repo" add src/cand.rs
+inner_cfg_json="$($SUMMARY -C "$inner_cfg_repo" --staged)"
+assert_eq "inner cfg(test) does not gate the next declaration" \
+    '["panic_path_added"]' "$(jq -c '.risk_flags' <<<"$inner_cfg_json")"
+assert_eq "inner cfg(test) keeps production scope" \
+    "production" "$(jq -r '.scope' <<<"$inner_cfg_json")"
+
 printf '\nPASS=%d FAIL=%d\n' "$PASS" "$FAIL"
 if [ "$FAIL" -ne 0 ]; then exit 1; fi

--- a/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
+++ b/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
@@ -482,5 +482,114 @@ assert_eq "commented-out include! still classifies as test_panic_path_added" \
 assert_eq "commented-out include! is not production scope" \
     "support" "$(jq -r '.scope' <<<"$commented_include_json")"
 
+# A formatted include! whose string literal sits on a later line is still an
+# ungated production route — it must not be lost to line-based scanning.
+multiline_include_repo="$SANDBOX/multiline-include"
+init_repo "$multiline_include_repo"
+mkdir -p "$multiline_include_repo/src"
+cat > "$multiline_include_repo/src/lib.rs" <<'RUST'
+include!(
+    "shared_impl.rs"
+);
+
+#[cfg(test)]
+#[path = "shared_impl.rs"]
+mod shared_fixtures;
+RUST
+git -C "$multiline_include_repo" add src
+git -C "$multiline_include_repo" commit -q -m lib
+cat > "$multiline_include_repo/src/shared_impl.rs" <<'RUST'
+pub fn parse(s: &str) -> u32 {
+    s.parse().unwrap()
+}
+RUST
+git -C "$multiline_include_repo" add src/shared_impl.rs
+multiline_include_json="$($SUMMARY -C "$multiline_include_repo" --staged)"
+assert_eq "multiline include! route keeps panic_path_added" \
+    '["panic_path_added"]' "$(jq -c '.risk_flags' <<<"$multiline_include_json")"
+assert_eq "multiline include! route stays production scope" \
+    "production" "$(jq -r '.scope' <<<"$multiline_include_json")"
+
+# include! matches on its RESOLVED target, not a basename substring: an
+# include of a different file whose name merely contains the candidate's
+# basename is not a route to the candidate.
+substr_include_repo="$SANDBOX/substr-include"
+init_repo "$substr_include_repo"
+mkdir -p "$substr_include_repo/src"
+cat > "$substr_include_repo/src/lib.rs" <<'RUST'
+include!("gen_shared_impl.rs");
+
+#[cfg(test)]
+#[path = "shared_impl.rs"]
+mod shared_fixtures;
+RUST
+cat > "$substr_include_repo/src/gen_shared_impl.rs" <<'RUST'
+pub const GENERATED: u32 = 1;
+RUST
+git -C "$substr_include_repo" add src
+git -C "$substr_include_repo" commit -q -m lib
+cat > "$substr_include_repo/src/shared_impl.rs" <<'RUST'
+pub fn sample() -> u32 {
+    "3".parse().unwrap()
+}
+RUST
+git -C "$substr_include_repo" add src/shared_impl.rs
+substr_include_json="$($SUMMARY -C "$substr_include_repo" --staged)"
+assert_eq "basename-substring include! still classifies as test_panic_path_added" \
+    '["test_panic_path_added"]' "$(jq -c '.risk_flags' <<<"$substr_include_json")"
+assert_eq "basename-substring include! is not production scope" \
+    "support" "$(jq -r '.scope' <<<"$substr_include_json")"
+
+# An ungated out-of-directory #[path] declaration from an ancestor (here the
+# crate root) outweighs a gated same-directory one.
+crossdir_repo="$SANDBOX/cross-directory"
+init_repo "$crossdir_repo"
+mkdir -p "$crossdir_repo/src/m"
+cat > "$crossdir_repo/src/lib.rs" <<'RUST'
+#[path = "m/cand.rs"]
+pub mod cand;
+RUST
+cat > "$crossdir_repo/src/m/mod.rs" <<'RUST'
+#[cfg(test)]
+#[path = "cand.rs"]
+mod cand_fixtures;
+RUST
+git -C "$crossdir_repo" add src
+git -C "$crossdir_repo" commit -q -m modules
+cat > "$crossdir_repo/src/m/cand.rs" <<'RUST'
+pub fn parse(s: &str) -> u32 {
+    s.parse().unwrap()
+}
+RUST
+git -C "$crossdir_repo" add src/m/cand.rs
+crossdir_json="$($SUMMARY -C "$crossdir_repo" --staged)"
+assert_eq "ancestor ungated #[path] outweighs local gated declaration" \
+    '["panic_path_added"]' "$(jq -c '.risk_flags' <<<"$crossdir_json")"
+assert_eq "ancestor ungated #[path] keeps production scope" \
+    "production" "$(jq -r '.scope' <<<"$crossdir_json")"
+
+# Candidate paths containing whitespace survive the scan iteration (word
+# splitting must not shred them). The gated declaration lives in the crate
+# root; the candidate sits in a directory with a space.
+space_repo="$SANDBOX/space-path"
+init_repo "$space_repo"
+mkdir -p "$space_repo/src/sub dir"
+cat > "$space_repo/src/lib.rs" <<'RUST'
+#[cfg(test)]
+#[path = "sub dir/cand.rs"]
+mod fixtures;
+RUST
+git -C "$space_repo" add src
+git -C "$space_repo" commit -q -m lib
+cat > "$space_repo/src/sub dir/cand.rs" <<'RUST'
+pub fn parse(s: &str) -> u32 {
+    s.parse().unwrap()
+}
+RUST
+git -C "$space_repo" add "src/sub dir/cand.rs"
+space_json="$($SUMMARY -C "$space_repo" --staged)"
+assert_eq "whitespace path with gated declaration is not production scope" \
+    "support" "$(jq -r '.scope' <<<"$space_json")"
+
 printf '\nPASS=%d FAIL=%d\n' "$PASS" "$FAIL"
 if [ "$FAIL" -ne 0 ]; then exit 1; fi

--- a/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
+++ b/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
@@ -1716,5 +1716,29 @@ shebang_json="$($SUMMARY -C "$shebang_repo" --staged)"
 assert_eq "shebang does not swallow the following declaration"     '["panic_path_added"]' "$(jq -c '.risk_flags' <<<"$shebang_json")"
 assert_eq "shebang fixture keeps production scope"     "production" "$(jq -r '.scope' <<<"$shebang_json")"
 
+# Brace-delimited include invocation: include! { "cand.rs" } is a valid
+# production route and must emit, not be cut at the opening brace and
+# skipped as a body.
+binc_repo="$SANDBOX/brace-include"
+init_repo "$binc_repo"
+mkdir -p "$binc_repo/src"
+cat > "$binc_repo/src/lib.rs" <<'RUST'
+#[cfg(test)]
+#[path = "cand.rs"]
+mod fixtures;
+include! { "cand.rs" }
+RUST
+git -C "$binc_repo" add src
+git -C "$binc_repo" commit -q -m lib
+cat > "$binc_repo/src/cand.rs" <<'RUST'
+pub fn parse(s: &str) -> u32 {
+    s.parse().unwrap()
+}
+RUST
+git -C "$binc_repo" add src/cand.rs
+binc_json="$($SUMMARY -C "$binc_repo" --staged)"
+assert_eq "brace-delimited include emits its production route"     '["panic_path_added"]' "$(jq -c '.risk_flags' <<<"$binc_json")"
+assert_eq "brace-include fixture keeps production scope"     "production" "$(jq -r '.scope' <<<"$binc_json")"
+
 printf '\nPASS=%d FAIL=%d\n' "$PASS" "$FAIL"
 if [ "$FAIL" -ne 0 ]; then exit 1; fi

--- a/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
+++ b/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
@@ -591,5 +591,110 @@ space_json="$($SUMMARY -C "$space_repo" --staged)"
 assert_eq "whitespace path with gated declaration is not production scope" \
     "support" "$(jq -r '.scope' <<<"$space_json")"
 
+# Lexically equivalent #[path] spellings resolve to the same target: an
+# ungated "./shared.rs" must cancel a gated "shared.rs".
+dotpath_repo="$SANDBOX/dot-path"
+init_repo "$dotpath_repo"
+mkdir -p "$dotpath_repo/src"
+cat > "$dotpath_repo/src/lib.rs" <<'RUST'
+#[path = "./shared.rs"]
+pub mod shared;
+
+#[cfg(test)]
+#[path = "shared.rs"]
+mod shared_fixtures;
+RUST
+git -C "$dotpath_repo" add src
+git -C "$dotpath_repo" commit -q -m lib
+cat > "$dotpath_repo/src/shared.rs" <<'RUST'
+pub fn parse(s: &str) -> u32 {
+    s.parse().unwrap()
+}
+RUST
+git -C "$dotpath_repo" add src/shared.rs
+dotpath_json="$($SUMMARY -C "$dotpath_repo" --staged)"
+assert_eq "dot-prefixed ungated #[path] cancels gated declaration" \
+    '["panic_path_added"]' "$(jq -c '.risk_flags' <<<"$dotpath_json")"
+assert_eq "dot-prefixed ungated #[path] keeps production scope" \
+    "production" "$(jq -r '.scope' <<<"$dotpath_json")"
+
+# The directory form of a bare declaration: #[cfg(test)] mod helpers;
+# resolving through helpers/mod.rs classifies the mod.rs as test.
+dirform_repo="$SANDBOX/dir-form"
+init_repo "$dirform_repo"
+mkdir -p "$dirform_repo/src/helpers"
+cat > "$dirform_repo/src/lib.rs" <<'RUST'
+pub fn add(a: u32, b: u32) -> u32 {
+    a + b
+}
+
+#[cfg(test)]
+mod helpers;
+RUST
+git -C "$dirform_repo" add src
+git -C "$dirform_repo" commit -q -m lib
+cat > "$dirform_repo/src/helpers/mod.rs" <<'RUST'
+pub fn sample() -> u32 {
+    "3".parse().unwrap()
+}
+RUST
+git -C "$dirform_repo" add src/helpers/mod.rs
+dirform_json="$($SUMMARY -C "$dirform_repo" --staged)"
+assert_eq "gated directory-form mod.rs classifies as test_panic_path_added" \
+    '["test_panic_path_added"]' "$(jq -c '.risk_flags' <<<"$dirform_json")"
+assert_eq "gated directory-form mod.rs is not production scope" \
+    "support" "$(jq -r '.scope' <<<"$dirform_json")"
+
+# Control: an ungated directory-form module stays production.
+dirform_prod_repo="$SANDBOX/dir-form-prod"
+init_repo "$dirform_prod_repo"
+mkdir -p "$dirform_prod_repo/src/util"
+cat > "$dirform_prod_repo/src/lib.rs" <<'RUST'
+pub mod util;
+RUST
+git -C "$dirform_prod_repo" add src
+git -C "$dirform_prod_repo" commit -q -m lib
+cat > "$dirform_prod_repo/src/util/mod.rs" <<'RUST'
+pub fn parse(s: &str) -> u32 {
+    s.parse().unwrap()
+}
+RUST
+git -C "$dirform_prod_repo" add src/util/mod.rs
+dirform_prod_json="$($SUMMARY -C "$dirform_prod_repo" --staged)"
+assert_eq "ungated directory-form mod.rs keeps panic_path_added" \
+    '["panic_path_added"]' "$(jq -c '.risk_flags' <<<"$dirform_prod_json")"
+assert_eq "ungated directory-form mod.rs stays production scope" \
+    "production" "$(jq -r '.scope' <<<"$dirform_prod_json")"
+
+# include! resolves in the containing FILE's directory, not the module
+# directory: include!("shared_impl.rs") in src/outer.rs reaches
+# src/shared_impl.rs and must cancel a gated declaration of that file.
+filedir_include_repo="$SANDBOX/filedir-include"
+init_repo "$filedir_include_repo"
+mkdir -p "$filedir_include_repo/src"
+cat > "$filedir_include_repo/src/outer.rs" <<'RUST'
+include!("shared_impl.rs");
+RUST
+cat > "$filedir_include_repo/src/lib.rs" <<'RUST'
+pub mod outer;
+
+#[cfg(test)]
+#[path = "shared_impl.rs"]
+mod shared_fixtures;
+RUST
+git -C "$filedir_include_repo" add src
+git -C "$filedir_include_repo" commit -q -m lib
+cat > "$filedir_include_repo/src/shared_impl.rs" <<'RUST'
+pub fn parse(s: &str) -> u32 {
+    s.parse().unwrap()
+}
+RUST
+git -C "$filedir_include_repo" add src/shared_impl.rs
+filedir_include_json="$($SUMMARY -C "$filedir_include_repo" --staged)"
+assert_eq "include! from a non-mod-rs file resolves in the file's directory" \
+    '["panic_path_added"]' "$(jq -c '.risk_flags' <<<"$filedir_include_json")"
+assert_eq "include! from a non-mod-rs file keeps production scope" \
+    "production" "$(jq -r '.scope' <<<"$filedir_include_json")"
+
 printf '\nPASS=%d FAIL=%d\n' "$PASS" "$FAIL"
 if [ "$FAIL" -ne 0 ]; then exit 1; fi


### PR DESCRIPTION
Fixes #1217 / VST-213. A `#[cfg(test)] #[path = "…"] mod …;`-gated sibling carries no file-local test markers, so the classifier read it as production — emitting `panic_path_added` and production scope for test-only code.

Classification now also reads the modules that could declare a candidate on the diff's new side (same-dir siblings for `#[path]`, mod.rs/lib.rs/main.rs, and the 2018-style parent file): every found declaration gated → test scope; any ungated declaration, none found, or any ambiguity → production stays (conservative).

Hardened per cross-model review: read failures during declaration scanning keep production (fail-closed); `--head` discovery is tracked-only via git ls-files (no GNU find, no untracked-file downgrades); bin/ crate roots skipped and sibling `include!` counts as an ungated route; coarse block-comment tracking in the scanner; residual limitations documented honestly in the script header; SKILL.md/README.md mechanism docs updated per the docs-ship-with-behavior rule.

Evidence: new regression suite 23/23 (each new-behavior assertion verified red against the pre-fix script); all 18 skills/github suites green. Pre-existing unguarded panic-scan pipeline filed as #1248.

https://claude.ai/code/session_01L7fubfyViYcy7zUNL6uLPf