### PR TITLE
docs(review-gate): vendored-path findings route by remedy locus, never a path exclusion

### DIFF
--- a/docs/cross-repo.md
+++ b/docs/cross-repo.md
@@ -58,6 +58,30 @@ Agreed shape for drovr, memsira, and hyprtrade, settled by live testing on real 
 - **Unresolved threads can become unreachable in the UI while still blocking the merge.** After a rebase or force-push the commented commits are gone, the conversation link 404s, and the PR shows zero visible conversations yet refuses to merge. GraphQL still sees them: list with `github.sh pr-threads <N>`, resolve by id with `github.sh resolve-thread <PRRT_...>`.
 - **Date-stamp measured state, and re-measure before relying on it.** With several sessions reading and mutating the same repos concurrently, an unreproducible measurement is worthless — capture the command output with a timestamp or treat the value as unknown.
 
+## A Vendored Tree Is Reviewed Once, Upstream
+
+Consuming repos merge re-vendor PRs whose entire delta is bytes already reviewed
+upstream. Every reviewer re-reviews them in every consumer, and each inline
+comment opens a thread that blocks that repo's merge until someone answers it —
+one upstream finding becomes one blocking thread per reviewer per repo, and the
+sessions answering them carry the argument back upstream as though it were new.
+
+- **Route a finding by where its fix would land, not by which file it sits on.**
+  A remedy in a repo-owned file (the vendor pin, settings, CI wiring) is local
+  and belongs inline — a re-vendor that moves pinned bytes without updating the
+  pin is a real defect. A remedy in the vendored bytes belongs in the review
+  summary body, which creates no thread.
+- **Do not silence the reviewer by excluding the path.** A pure re-vendor PR is
+  nothing but vendored files, so a reviewer that skips them produces no review
+  object and the review gate's evidence term starves with no reviewer that can
+  ever clear it. Constrain what a reviewer SAYS, never whether it reviews.
+- **File upstream once, from one consumer.** Reviewers have no cross-repo memory
+  and restate the same finding in every repo; the first session to see it files
+  it, the rest cite that issue.
+
+Mechanism, wiring, and the per-repo verification protocol:
+`skills/review-gate/references/vendored-paths.md`.
+
 ## Do Not Restate Another Repo's Status From A Stale Check
 
 - **Re-verify a cross-repo status claim at send time, or attribute it.** "As of my check at 11:40" is honest; a bare "still pending" asserts current state you have not observed.

--- a/docs/cross-repo.md
+++ b/docs/cross-repo.md
@@ -70,7 +70,9 @@ sessions answering them carry the argument back upstream as though it were new.
   A remedy in a repo-owned file (the vendor pin, settings, CI wiring) is local
   and belongs inline — a re-vendor that moves pinned bytes without updating the
   pin is a real defect. A remedy in the vendored bytes belongs in the review
-  summary body, which creates no thread.
+  summary body, which creates no thread — or, for a reviewer that can only
+  anchor findings to file locations, in ONE consolidated comment for the whole
+  PR rather than one per finding.
 - **Do not silence the reviewer by excluding the path.** A pure re-vendor PR is
   nothing but vendored files, so a reviewer that skips them produces no review
   object and the review gate's evidence term starves with no reviewer that can

--- a/skills/review-gate/README.md
+++ b/skills/review-gate/README.md
@@ -134,9 +134,11 @@ Paths are as installed in a consuming repo, under
 | `.agents/skills/review-gate/scripts/pr-watch.sh` | The agent-side reducer: "does any open PR need attention right now?" — unresolved threads (queued PRs annotated), standing objections, a gate the writer hasn't converged (`--heal` dispatches it once), a mergeable PR nothing will merge, reviewer silence past the quiet period. Silence on stdout + exit 0 means nothing needs you, which makes it a one-line loop/cron predicate. |
 | `.agents/skills/review-gate/scripts/review-predicate-selftest.sh` | Offline proof of the decision table; runs ungated in CI so a broken predicate reds its own job instead of approving everything. |
 | `.agents/skills/review-gate/templates/review-gate-writer.yml` | The one workflow to copy in. Repo-owned after copying. |
+| `.agents/skills/review-gate/templates/vendored-paths.instructions.md` | Reviewer instruction for a byte-pinned vendored tree, so re-vendor PRs stop collecting duplicate blocking threads. Copy and fill; repo-owned after copying. |
 | `.agents/skills/review-gate/tests/e2e-sandbox.sh` | Live replay against a throwaway repo — re-run it before changing the engine. |
 | `.agents/skills/review-gate/references/adoption.md` | Wiring, branch rules, per-repo settings. |
 | `.agents/skills/review-gate/references/settings.md` | Every `REVIEW_GATE_*` key and the security reasoning behind the trust ones. |
+| `.agents/skills/review-gate/references/vendored-paths.md` | Why reviewer path exclusions starve the gate, and the remedy-locus rule that suppresses duplicate findings without doing so. |
 
 Nothing repo-specific is hard-coded: consumers vendor the skill at
 `.agents/skills/review-gate/` via `vstack refresh` and configure trust in

--- a/skills/review-gate/SKILL.md
+++ b/skills/review-gate/SKILL.md
@@ -213,3 +213,10 @@ context in the ruleset alongside the test aggregate. Full wiring:
 [references/adoption.md](references/adoption.md). An adoption PR deletes the
 local machinery it supersedes in the same PR — a redesign removes what it
 replaces, never leaves it dormant.
+
+A consumer also merges re-vendor PRs whose entire delta is bytes already
+reviewed upstream. Suppress the duplicate findings with the remedy-locus
+reviewer instruction, never a reviewer path exclusion — excluding the vendored
+tree leaves a pure re-vendor PR with nothing to review, no review object, and a
+gate that starves:
+[references/vendored-paths.md](references/vendored-paths.md).

--- a/skills/review-gate/references/adoption.md
+++ b/skills/review-gate/references/adoption.md
@@ -42,6 +42,11 @@ trusting an adoption.
    scripts, local predicate copies, duplicated gate steps. A redesign
    removes what it replaces, never leaves it dormant.
 6. **Repo-side wiring** (below): rulesets, merge queue, bypass actor.
+7. **Reviewer instruction for the vendored tree** — the repo now merges
+   re-vendor PRs whose whole delta is bytes already reviewed upstream, and
+   every reviewer will re-review them into merge-blocking threads. Wire the
+   remedy-locus rule from [vendored-paths.md](vendored-paths.md) rather than a
+   reviewer path exclusion, which starves the gate on exactly this PR class.
 
 ## Recommended CI shape — the fast/full split
 
@@ -172,6 +177,9 @@ reducer they and harness monitors share.
 - The offline selftest passes from the repo root (configured layer =
   this repo's trust values).
 - The consumer's vendored-copy drift check passes.
+- The first PURE re-vendor PR after adoption carries a trusted non-author
+  review object at head with no unresolved thread on a vendored path
+  ([vendored-paths.md](vendored-paths.md) § Verifying on a real re-vendor PR).
 - For engine changes (not adoptions): the live sandbox replay
   (`.agents/skills/review-gate/tests/e2e-sandbox.sh`) against the org
   sandbox, which mirrors the fleet ruleset shape.

--- a/skills/review-gate/references/adoption.md
+++ b/skills/review-gate/references/adoption.md
@@ -178,8 +178,11 @@ reducer they and harness monitors share.
   this repo's trust values).
 - The consumer's vendored-copy drift check passes.
 - The first PURE re-vendor PR after adoption carries a trusted non-author
-  review object at head with no unresolved thread on a vendored path
-  ([vendored-paths.md](vendored-paths.md) § Verifying on a real re-vendor PR).
+  review object at head, and on the vendored tree no unresolved thread from a
+  summary-capable reviewer plus at most one consolidated thread from each
+  location-bound one — read before resolving anything
+  ([vendored-paths.md](vendored-paths.md) § Verifying on a real re-vendor PR,
+  whose pass rule this mirrors).
 - For engine changes (not adoptions): the live sandbox replay
   (`.agents/skills/review-gate/tests/e2e-sandbox.sh`) against the org
   sandbox, which mirrors the fleet ruleset shape.

--- a/skills/review-gate/references/adoption.md
+++ b/skills/review-gate/references/adoption.md
@@ -179,10 +179,9 @@ reducer they and harness monitors share.
 - The consumer's vendored-copy drift check passes.
 - The first PURE re-vendor PR after adoption carries a trusted non-author
   review object at head, and on the vendored tree no unresolved thread from a
-  summary-capable reviewer plus at most one consolidated thread from each
-  location-bound one — read before resolving anything
-  ([vendored-paths.md](vendored-paths.md) § Verifying on a real re-vendor PR,
-  whose pass rule this mirrors).
+  summary-capable reviewer — read before resolving anything. A location-bound
+  reviewer's threads are recorded, not graded ([vendored-paths.md](vendored-paths.md)
+  § Verifying on a real re-vendor PR, whose pass rule this mirrors).
 - For engine changes (not adoptions): the live sandbox replay
   (`.agents/skills/review-gate/tests/e2e-sandbox.sh`) against the org
   sandbox, which mirrors the fleet ruleset shape.

--- a/skills/review-gate/references/adoption.md
+++ b/skills/review-gate/references/adoption.md
@@ -179,9 +179,11 @@ reducer they and harness monitors share.
 - The consumer's vendored-copy drift check passes.
 - The first PURE re-vendor PR after adoption carries a trusted non-author
   review object at head, and on the vendored tree no unresolved thread from a
-  summary-capable reviewer — read before resolving anything. A location-bound
-  reviewer's threads are recorded, not graded ([vendored-paths.md](vendored-paths.md)
-  § Verifying on a real re-vendor PR, whose pass rule this mirrors).
+  summary-capable reviewer, except one raising a carve-out regression, which
+  blocks the re-vendor and is a correct outcome — read before resolving
+  anything. A location-bound reviewer's threads are recorded, not graded
+  ([vendored-paths.md](vendored-paths.md) § Verifying on a real re-vendor PR,
+  whose pass rule this mirrors).
 - For engine changes (not adoptions): the live sandbox replay
   (`.agents/skills/review-gate/tests/e2e-sandbox.sh`) against the org
   sandbox, which mirrors the fleet ruleset shape.

--- a/skills/review-gate/references/vendored-paths.md
+++ b/skills/review-gate/references/vendored-paths.md
@@ -102,9 +102,24 @@ per-repo:
 
 For a location-bound reviewer the rule is a BOUND, not a surface change: at
 most ONE consolidated comment per PR carrying every upstream-remedy finding
-together, anchored anywhere in the vendored tree. That is inside its output
-contract, and it converts a cost that grows with the finding count into a
-constant one thread, which the verification below can check.
+together, anchored anywhere in the vendored tree.
+
+**Accepted residual — the bound is an instruction, not a mechanism.** A
+reviewer whose output schema binds one finding to one location cannot merge
+unrelated defects however the instruction is worded, and will still emit one
+thread per finding. Expect that: read the thread count as an observable, not as
+compliance, and answer and resolve those threads like any others. What this doc
+buys for that reviewer class does not come from thread count at all — it comes
+from remedy-locus routing, which states each upstream-remedy finding once as
+upstream's to fix, so it is not re-litigated in the next consumer or argued
+back into the upstream repo. **A location-bound reviewer exceeding one thread
+is not by itself a failed rollout.**
+
+Recorded so it is not re-opened: the rejected alternative is an adapter or
+post-processing transport that collects such findings and republishes them as a
+summary. That is new engine machinery — a second publisher on the review
+surface, carrying its own trust and ordering questions — and deliberately out
+of scope for a reviewer-instruction change.
 
 Classify each of the repo's reviewers before wiring, by reading a review body
 it posted on a recent PR: a body identical across PRs is a template, and that
@@ -202,10 +217,12 @@ compare on the base name, or read the same reviews from the REST
 `commit_id`.
 
 **Pass**: a trusted non-author review object at the current head; on the
-vendored tree, no unresolved thread from a summary-capable reviewer and at most
-one consolidated thread from each location-bound one; gate `success`. A
-repo-owned finding still arriving inline is the control that proves the
-reviewer is still reading rather than merely silent.
+vendored tree, no unresolved thread from a summary-capable reviewer; gate
+`success`. A repo-owned finding still arriving inline is the control that
+proves the reviewer is still reading rather than merely silent. Threads from a
+location-bound reviewer are counted and recorded, not graded — one consolidated
+thread is what the instruction asks for, and more than one is the accepted
+residual above, not a failure.
 
 **Suspect, not proven**: threads at zero with `body_chars` also at zero. Body
 length cannot establish whether anything was examined — a reviewer with

--- a/skills/review-gate/references/vendored-paths.md
+++ b/skills/review-gate/references/vendored-paths.md
@@ -121,9 +121,10 @@ cross-repo memory and will restate the same finding in every one.
 ## Wiring a repo
 
 1. Copy [`../templates/vendored-paths.instructions.md`](../templates/vendored-paths.instructions.md)
-   into the repo's path-scoped reviewer instruction directory, set `applyTo` to
-   the repo's actual vendored glob, and fill the placeholders. Repo-owned after
-   the copy, like the writer workflow.
+   into the repo's path-scoped reviewer instruction directory —
+   `.github/instructions/`, as a `*.instructions.md` file — set `applyTo` to the
+   repo's actual vendored glob, and fill the placeholders. Repo-owned after the
+   copy, like the writer workflow.
 2. Check the glob against the paths a real re-vendor PR touches. An `applyTo`
    that does not match the vendored tree is dead config that lints green.
 3. Classify each reviewer the repo runs as summary-capable or location-bound

--- a/skills/review-gate/references/vendored-paths.md
+++ b/skills/review-gate/references/vendored-paths.md
@@ -1,0 +1,135 @@
+# Reviewing byte-pinned vendored paths
+
+For consumers that vendor an upstream tree byte-for-byte and merge re-vendor
+PRs. The delta on such a PR is bytes already reviewed upstream, yet every
+reviewer re-reviews them, and every inline comment opens a review thread the
+merge cannot clear until someone answers it. One upstream finding becomes one
+merge-blocking thread per reviewer per consumer, and the answering sessions
+carry the argument back into the upstream repo.
+
+Suppressing that duplication is a reviewer-instruction problem. The
+configuration answers break the gate.
+
+## What suppression must not break
+
+**Evidence.** The gate's evidence term needs a trusted non-author review object
+at the exact head, or one of the other forms in [settings.md](settings.md).
+Nothing manufactures it: `REVIEW_GATE_CARRY_FORWARD` extends evidence that
+already exists to a later head, so it can never open a PR that was never
+reviewed — and the vendored tree normally sits in
+`REVIEW_GATE_CARRY_FORWARD_EXCLUDE`, because vendored markdown is
+agent-instruction content that is obeyed mechanically. That exclusion forces
+fresh evidence on exactly this PR class, by design.
+
+**Threads.** The predicate counts `reviewThreads`, and the zero-bypass
+`required_review_thread_resolution` ruleset enforces the same threads
+server-side. Threads come from INLINE review comments. A review submitted with
+a body and no inline comments is full evidence and creates no thread — that is
+the target shape, and it is what a reviewer already produces when it has
+nothing file-specific to say.
+
+**Honesty.** A review that examined nothing is not evidence that a review
+happened. Never engineer a hollow review object to feed the gate. Where there
+is genuinely nothing to review, the operator override is the term that says so
+out loud, with a reason.
+
+## The trap: reviewer path exclusion
+
+Excluding the vendored tree in the reviewer's own configuration — content
+exclusion, ignore-paths, a path filter on the review trigger — is the obvious
+answer and the one that starves the gate:
+
+- A pure re-vendor PR has no other files. With the tree excluded the reviewer
+  has nothing to review and either posts no review object at all (the gate sits
+  at `awaiting` with no reviewer that can ever clear it), or posts a
+  reviewed-nothing pass on a check-run or status surface, which
+  `REVIEW_GATE_CHECKRUN_SKIP_PATTERNS` correctly classifies as not-evidence.
+- Mixed PRs still carry a repo-owned file, so the reviewer still produces a
+  review and the configuration looks healthy. The starvation appears only on
+  the pure class, after the change has shipped.
+
+**Never exclude a path that can constitute an entire PR's diff.** The same rule
+rules out narrowing a review trigger by path, for the same reason.
+
+## The rule: route by remedy locus, not by path
+
+Not every finding on a vendored file has an upstream remedy. Classify by where
+the fix would land, and pick the surface from that:
+
+| Where the fix lands | Surface |
+|---|---|
+| A repo-owned file — the vendor pin or checksum manifest, settings, CI wiring, adoption glue | Inline comment. In scope, keep it. |
+| The vendored bytes themselves | Review body only. Upstream's call. |
+| The upstream repo's own docs, config, or conventions | Review body only, or omit. |
+
+The first row is the class worth protecting. A re-vendor PR that moves the
+pinned bytes without updating the repo-owned checksum manifest is broken, and
+that finding is repo-local, actionable, and a duplicate of nothing upstream. A
+path-based silence rule suppresses it along with the noise; a remedy-based rule
+keeps it.
+
+The other two rows are the duplication. They are not wrong — they are
+un-actionable HERE: any local edit forks the pinned surface, which the
+byte-identity check exists to prevent. Stating them in the review body keeps
+the signal, costs no thread, and leaves one place to harvest them from.
+
+An instruction that constrains only the REMEDY ("flag it, but do not ask for
+local edits") does not suppress anything: the reviewer still opens the thread,
+and the thread still blocks the merge. Constrain the surface.
+
+## The consumer session's half
+
+The reviewer routes; the session captures. Once per re-vendor train, read the
+review bodies on ONE consumer PR and file anything upstream-remedy at the
+upstream repo — `vstack report` routes vstack-owned assets. Do not fix it
+locally, and do not file the same finding from each consumer: reviewers have no
+cross-repo memory and will restate the same finding in every one.
+
+## Wiring a repo
+
+1. Copy [`../templates/vendored-paths.instructions.md`](../templates/vendored-paths.instructions.md)
+   into the repo's path-scoped reviewer instruction directory, set `applyTo` to
+   the repo's actual vendored glob, and fill the placeholders. Repo-owned after
+   the copy, like the writer workflow.
+2. Check the glob against the paths a real re-vendor PR touches. An `applyTo`
+   that does not match the vendored tree is dead config that lints green.
+3. Mirror the rule in the repo's reviewer-guidance file, for reviewers that do
+   not read path-scoped instructions.
+4. Change no gate settings. Do not add the vendored tree to a carry class, do
+   not remove it from `REVIEW_GATE_CARRY_FORWARD_EXCLUDE`, and do not widen
+   `REVIEW_GATE_TRUSTED_STATUS_CONTEXTS` to a CI check as a substitute for
+   review — a context trusted for this PR class is trusted for every PR class.
+
+Instruction text constrains what a reviewer says, never whether it reviews, so
+this wiring cannot starve the gate. That is the reason to prefer it over every
+configuration answer.
+
+## Verifying on a real re-vendor PR
+
+Instructions are advisory — a reviewer may ignore them — so the wiring is not
+done until a real PR shows it took. Verify per repo, on the first re-vendor PR
+after the change, and use a PURE one (vendored files only): the mixed class
+hides every failure mode this check exists to catch.
+
+```bash
+# 1. Evidence at head: at least one trusted non-author review object.
+gh pr view [PR] --repo [OWNER/REPO] --json reviews
+
+# 2. Threads: expect none whose path is under the vendored tree.
+.agents/skills/github/scripts/github.sh pr-threads [PR] --unresolved
+
+# 3. The gate's own answer for this head.
+gh pr checks [PR] --repo [OWNER/REPO]
+```
+
+**Pass**: a trusted non-author review object at head, no unresolved thread on a
+vendored path, gate `success`. A repo-owned finding still arriving inline is
+the control that proves the reviewer is still reading — not merely silent.
+
+**Not a pass**: zero threads AND an empty review body. That is the exclusion
+failure wearing a green badge; the review object may be evidence the gate
+accepts while nothing was examined.
+
+**On failure**, revert the instruction file and merge the PR through the
+documented review path. A starved gate is a worse outcome than duplicate
+threads, and the override exists for the gap, not for a standing posture.

--- a/skills/review-gate/references/vendored-paths.md
+++ b/skills/review-gate/references/vendored-paths.md
@@ -112,11 +112,28 @@ reviewer is location-bound.
 
 ## The consumer session's half
 
-The reviewer routes; the session captures. Once per re-vendor train, read the
-review bodies on ONE consumer PR and file anything upstream-remedy at the
-upstream repo — `vstack report` routes vstack-owned assets. Do not fix it
-locally, and do not file the same finding from each consumer: reviewers have no
-cross-repo memory and will restate the same finding in every one.
+The reviewer routes; the session captures. Once per re-vendor train, on ONE
+consumer PR, collect upstream-remedy findings from BOTH surfaces: the review
+bodies, AND any consolidated vendored-path thread a location-bound reviewer
+left. Reading only the bodies drops that class's entire output — its findings
+are never anywhere else.
+
+`vstack report --skill review-gate` routes the report upstream. Two
+preconditions, each silent when unmet:
+
+- **The selector is required.** With no `--skill`/`--agent`/`--hook`/`--asset`,
+  the CLI warns once that ownership could not be determined and files against
+  the LOCAL repo.
+- **For a skill, only the installed `SKILL.md` frontmatter decides.** A lock
+  entry never opts a skill upstream — skills are self-attributing by design, so
+  routing needs the vendored `SKILL.md` present at the install path and
+  carrying `source: vstack` (or the upstream `repository` slug). A repo that
+  vendored only the scripts subtree has no frontmatter to read and files
+  locally. Check before relying on it, or open the upstream issue by hand.
+
+Do not fix it locally, and do not file the same finding from each consumer:
+reviewers have no cross-repo memory and will restate the same finding in every
+one.
 
 ## Wiring a repo
 
@@ -127,13 +144,20 @@ cross-repo memory and will restate the same finding in every one.
    copy, like the writer workflow.
 2. Check the glob against the paths a real re-vendor PR touches. An `applyTo`
    that does not match the vendored tree is dead config that lints green.
-3. Classify each reviewer the repo runs as summary-capable or location-bound
+3. **Replace any existing instruction scoped to the same tree — do not add
+   alongside it.** A repo that already carries a vendored-tree clause almost
+   certainly carries a remedy-only one ("flag them, but do not ask for local
+   edits"), which permits exactly the inline comments this replaces. Two
+   instructions over one glob leave the reviewer to pick, and it picks the
+   permissive one. Merge any repo-specific carve-outs the old clause held into
+   the new body rather than keeping both files.
+4. Classify each reviewer the repo runs as summary-capable or location-bound
    (above). A repo whose reviewers are ALL location-bound gets a bounded
    improvement, not silence — decide whether that is worth the wiring before
    doing it.
-4. Mirror the rule in the repo's reviewer-guidance file, for reviewers that do
+5. Mirror the rule in the repo's reviewer-guidance file, for reviewers that do
    not read path-scoped instructions.
-5. Change no gate settings. Do not add the vendored tree to a carry class, do
+6. Change no gate settings. Do not add the vendored tree to a carry class, do
    not remove it from `REVIEW_GATE_CARRY_FORWARD_EXCLUDE`, and do not widen
    `REVIEW_GATE_TRUSTED_STATUS_CONTEXTS` to a CI check as a substitute for
    review — a context trusted for this PR class is trusted for every PR class.
@@ -154,13 +178,20 @@ hides every failure mode this check exists to catch.
 #    fresh one, so read the head in the same call and compare per review.
 gh pr view [PR] --repo [OWNER/REPO] --json reviews,headRefOid --jq '.headRefOid as $head | .reviews[] | {login: .author.login, state: .state, at_head: (.commit.oid == $head), body_chars: (.body | length)}'
 
-# 2. Threads: at most the bounded per-reviewer allowance below, on the
-#    vendored tree.
+# 2. Threads on the vendored tree, BEFORE resolving any of them: the flag
+#    filters to isResolved == false, so a reviewer that ignored the
+#    one-comment bound reads as zero once its threads have been answered.
 .agents/skills/github/scripts/github.sh pr-threads [PR] --unresolved
 
 # 3. The gate's own answer for this head.
 gh pr checks [PR] --repo [OWNER/REPO]
 ```
+
+**Steps 2 and 3 cannot come from the same snapshot** wherever threads are
+enforced — server-side or via `REVIEW_GATE_THREADS`. The gate cannot reach
+`success` while threads are open, and resolving them to reach it empties step
+2. Record step 2's threads and their authors first, resolve them, then read
+step 3.
 
 Step 1 answers the evidence question only for rows with `at_head` true whose
 login is non-author AND in the repo's
@@ -176,12 +207,18 @@ one consolidated thread from each location-bound one; gate `success`. A
 repo-owned finding still arriving inline is the control that proves the
 reviewer is still reading rather than merely silent.
 
-**Not a pass**: threads down to zero with `body_chars` also at zero. That is
-the exclusion failure wearing a green badge — a review object the gate accepts
-while nothing was examined. Its check-run twin is a trusted context passing
-with a reviewed-nothing summary; the skip patterns do not catch that (see the
-trap above), so read the check's own output rather than trusting the green.
+**Suspect, not proven**: threads at zero with `body_chars` also at zero. Body
+length cannot establish whether anything was examined — a reviewer with
+genuinely nothing to say reads the same, and the gate accepts a trusted review
+at head without inspecting its body at all. Treat it as a prompt to check, not
+a verdict, and confirm with a signal that actually distinguishes exclusion:
+a summary-capable reviewer states its own reviewed-file count in the body
+(reviewed N of N changed files), and the reviewer's configuration either
+carries a path exclusion over the vendored tree or does not. The check-run twin
+is a trusted context passing with a reviewed-nothing summary; the skip patterns
+do not catch that (see the trap above), so read the check's own output rather
+than trusting the green.
 
-**On failure**, revert the instruction file and merge the PR through the
-documented review path. A starved gate is a worse outcome than duplicate
+**On confirmed failure**, revert the instruction file and merge the PR through
+the documented review path. A starved gate is a worse outcome than duplicate
 threads, and the override exists for the gap, not for a standing posture.

--- a/skills/review-gate/references/vendored-paths.md
+++ b/skills/review-gate/references/vendored-paths.md
@@ -40,13 +40,22 @@ exclusion, ignore-paths, a path filter on the review trigger — is the obvious
 answer and the one that starves the gate:
 
 - A pure re-vendor PR has no other files. With the tree excluded the reviewer
-  has nothing to review and either posts no review object at all (the gate sits
-  at `awaiting` with no reviewer that can ever clear it), or posts a
-  reviewed-nothing pass on a check-run or status surface, which
-  `REVIEW_GATE_CHECKRUN_SKIP_PATTERNS` correctly classifies as not-evidence.
+  has nothing to review, and both of its remaining outcomes are bad. It posts
+  no review object at all — the gate sits at `awaiting` with no reviewer that
+  can ever clear it. Or it posts a reviewed-nothing pass on a trusted
+  check-run or status context, which the gate accepts as evidence and turns
+  green.
+- **`REVIEW_GATE_CHECKRUN_SKIP_PATTERNS` does not close the second outcome.**
+  It is a literal, case-insensitive substring match of the configured markers
+  against the check's title plus summary; the shipped defaults are `rate
+  limited`, `skipped`, and `queued`. A pass whose summary says only that it
+  reviewed no files matches none of them and counts as full evidence. The
+  filter catches a reviewer that announces WHY it did nothing, not a reviewer
+  with nothing to do — so path exclusion trades a starved gate for a hollow
+  green one, which is worse: nothing looks wrong.
 - Mixed PRs still carry a repo-owned file, so the reviewer still produces a
-  review and the configuration looks healthy. The starvation appears only on
-  the pure class, after the change has shipped.
+  review and the configuration looks healthy. Both failures appear only on the
+  pure class, after the change has shipped.
 
 **Never exclude a path that can constitute an entire PR's diff.** The same rule
 rules out narrowing a review trigger by path, for the same reason.
@@ -77,6 +86,30 @@ An instruction that constrains only the REMEDY ("flag it, but do not ask for
 local edits") does not suppress anything: the reviewer still opens the thread,
 and the thread still blocks the merge. Constrain the surface.
 
+### Reviewer classes — where a review body exists, and where it does not
+
+The routing above assumes the reviewer can put a finding somewhere other than a
+file location. Not every one can, and the difference is per-reviewer, not
+per-repo:
+
+- **Summary-capable** — it authors its own review body: an overview, a per-file
+  table, its own finding prose. An upstream-remedy finding goes there and costs
+  no thread.
+- **Location-bound** — every finding it emits is anchored to a file and line,
+  and its review body, where it has one, is a fixed template it does not author
+  findings into. Told to "use the summary body", such a reviewer can only drop
+  the finding or leave it inline — and dropping it is the worse outcome.
+
+For a location-bound reviewer the rule is a BOUND, not a surface change: at
+most ONE consolidated comment per PR carrying every upstream-remedy finding
+together, anchored anywhere in the vendored tree. That is inside its output
+contract, and it converts a cost that grows with the finding count into a
+constant one thread, which the verification below can check.
+
+Classify each of the repo's reviewers before wiring, by reading a review body
+it posted on a recent PR: a body identical across PRs is a template, and that
+reviewer is location-bound.
+
 ## The consumer session's half
 
 The reviewer routes; the session captures. Once per re-vendor train, read the
@@ -93,9 +126,13 @@ cross-repo memory and will restate the same finding in every one.
    the copy, like the writer workflow.
 2. Check the glob against the paths a real re-vendor PR touches. An `applyTo`
    that does not match the vendored tree is dead config that lints green.
-3. Mirror the rule in the repo's reviewer-guidance file, for reviewers that do
+3. Classify each reviewer the repo runs as summary-capable or location-bound
+   (above). A repo whose reviewers are ALL location-bound gets a bounded
+   improvement, not silence — decide whether that is worth the wiring before
+   doing it.
+4. Mirror the rule in the repo's reviewer-guidance file, for reviewers that do
    not read path-scoped instructions.
-4. Change no gate settings. Do not add the vendored tree to a carry class, do
+5. Change no gate settings. Do not add the vendored tree to a carry class, do
    not remove it from `REVIEW_GATE_CARRY_FORWARD_EXCLUDE`, and do not widen
    `REVIEW_GATE_TRUSTED_STATUS_CONTEXTS` to a CI check as a substitute for
    review — a context trusted for this PR class is trusted for every PR class.
@@ -112,23 +149,37 @@ after the change, and use a PURE one (vendored files only): the mixed class
 hides every failure mode this check exists to catch.
 
 ```bash
-# 1. Evidence at head: at least one trusted non-author review object.
-gh pr view [PR] --repo [OWNER/REPO] --json reviews
+# 1. Evidence AT HEAD. The reviews list shows a stale round exactly like a
+#    fresh one, so read the head in the same call and compare per review.
+gh pr view [PR] --repo [OWNER/REPO] --json reviews,headRefOid --jq '.headRefOid as $head | .reviews[] | {login: .author.login, state: .state, at_head: (.commit.oid == $head), body_chars: (.body | length)}'
 
-# 2. Threads: expect none whose path is under the vendored tree.
+# 2. Threads: at most the bounded per-reviewer allowance below, on the
+#    vendored tree.
 .agents/skills/github/scripts/github.sh pr-threads [PR] --unresolved
 
 # 3. The gate's own answer for this head.
 gh pr checks [PR] --repo [OWNER/REPO]
 ```
 
-**Pass**: a trusted non-author review object at head, no unresolved thread on a
-vendored path, gate `success`. A repo-owned finding still arriving inline is
-the control that proves the reviewer is still reading — not merely silent.
+Step 1 answers the evidence question only for rows with `at_head` true whose
+login is non-author AND in the repo's
+`REVIEW_GATE_REVIEW_OBJECT_TRUSTED_LOGINS` (empty list = any non-author). This
+view reports bot logins WITHOUT the `[bot]` suffix the trusted list carries —
+compare on the base name, or read the same reviews from the REST
+`pulls/[PR]/reviews` endpoint, which returns the suffixed login and
+`commit_id`.
 
-**Not a pass**: zero threads AND an empty review body. That is the exclusion
-failure wearing a green badge; the review object may be evidence the gate
-accepts while nothing was examined.
+**Pass**: a trusted non-author review object at the current head; on the
+vendored tree, no unresolved thread from a summary-capable reviewer and at most
+one consolidated thread from each location-bound one; gate `success`. A
+repo-owned finding still arriving inline is the control that proves the
+reviewer is still reading rather than merely silent.
+
+**Not a pass**: threads down to zero with `body_chars` also at zero. That is
+the exclusion failure wearing a green badge — a review object the gate accepts
+while nothing was examined. Its check-run twin is a trusted context passing
+with a reviewed-nothing summary; the skip patterns do not catch that (see the
+trap above), so read the check's own output rather than trusting the green.
 
 **On failure**, revert the instruction file and merge the PR through the
 documented review path. A starved gate is a worse outcome than duplicate

--- a/skills/review-gate/references/vendored-paths.md
+++ b/skills/review-gate/references/vendored-paths.md
@@ -129,12 +129,17 @@ reviewer is location-bound.
 
 The reviewer routes; the session captures. Once per re-vendor train, on ONE
 consumer PR, collect upstream-remedy findings from BOTH surfaces: the review
-bodies, AND any consolidated vendored-path thread a location-bound reviewer
-left. Reading only the bodies drops that class's entire output — its findings
-are never anywhere else.
+bodies, AND EVERY vendored-path thread a location-bound reviewer left — one
+consolidated thread where it honored the bound, one thread per finding where
+its schema could not (the accepted residual above), which is why this is not
+scoped to a consolidated thread. Reading only the bodies drops that class's
+entire output — its findings are never anywhere else.
 
-`vstack report --skill review-gate` routes the report upstream. Two
-preconditions, each silent when unmet:
+`vstack report --skill review-gate --title [TITLE] --body-file [PATH]` routes
+the report upstream. The command is non-interactive and validates arguments
+before doing anything: `--title` is required, and exactly one of `--body` or
+`--body-file` must be given — with neither (or both) it exits without filing.
+Two further preconditions, each silent when unmet:
 
 - **The selector is required.** With no `--skill`/`--agent`/`--hook`/`--asset`,
   the CLI warns once that ownership could not be determined and files against
@@ -218,7 +223,15 @@ the only thing step 3 reads.
 
 Step 1 answers the evidence question only for rows with `at_head` true whose
 login is non-author AND in the repo's
-`REVIEW_GATE_REVIEW_OBJECT_TRUSTED_LOGINS` (empty list = any non-author). This
+`REVIEW_GATE_REVIEW_OBJECT_TRUSTED_LOGINS` (empty list = any non-author), and
+only at the repo's `REVIEW_GATE_REVIEW_OBJECT_MIN_STATE`. Under the `any`
+default every such row counts. Under `approved` a login contributes evidence
+only when its newest `APPROVED` at head is not followed by a newer
+`CHANGES_REQUESTED` from that same login — a trailing `COMMENTED` never
+withdraws an approval, but a `COMMENTED` row on its own is not evidence there.
+Read the `state` field against the repo's setting: counting a bare `COMMENTED`
+as evidence under `approved` passes a verification the predicate's review-object
+term fails, while the gate is green off a different evidence surface. This
 view reports bot logins WITHOUT the `[bot]` suffix the trusted list carries —
 compare on the base name, or read the same reviews from the REST
 `pulls/[PR]/reviews` endpoint, which returns the suffixed login and

--- a/skills/review-gate/references/vendored-paths.md
+++ b/skills/review-gate/references/vendored-paths.md
@@ -69,6 +69,7 @@ the fix would land, and pick the surface from that:
 |---|---|
 | A repo-owned file — the vendor pin or checksum manifest, settings, CI wiring, adoption glue | Inline comment. In scope, keep it. |
 | The vendored bytes themselves | Review body only. Upstream's call. |
+| The vendored bytes, where the bump introduces a production-impacting regression that runs HERE — correctness, security, data loss | Inline comment, and it may block. See the carve-out below. |
 | The upstream repo's own docs, config, or conventions | Review body only, or omit. |
 
 The first row is the class worth protecting. A re-vendor PR that moves the
@@ -77,10 +78,20 @@ that finding is repo-local, actionable, and a duplicate of nothing upstream. A
 path-based silence rule suppresses it along with the noise; a remedy-based rule
 keeps it.
 
-The other two rows are the duplication. They are not wrong — they are
+The review-body rows are the duplication. They are not wrong — they are
 un-actionable HERE: any local edit forks the pinned surface, which the
 byte-identity check exists to prevent. Stating them in the review body keeps
 the signal, costs no thread, and leaves one place to harvest them from.
+
+The regression row is that reasoning applied honestly, not an exception to it.
+"The remedy cannot happen in this PR" is TRUE for a defect whose only fix is an
+upstream edit, and FALSE for one the bump introduces into what runs here:
+holding or reverting the bump until upstream fixes it is a repo-owned action on
+the pin, exercised by blocking the PR. Routing that to a non-blocking surface
+ships a known defect. Keep the bar at a defect you would hold a release for —
+correctness, security, data loss — because every softer reading (style, naming,
+duplication, test layout, missing coverage) is exactly the inline traffic the
+rule exists to stop, and a carve-out that admits them repeals it.
 
 An instruction that constrains only the REMEDY ("flag it, but do not ask for
 local edits") does not suppress anything: the reviewer still opens the thread,
@@ -240,10 +251,13 @@ compare on the base name, or read the same reviews from the REST
 **Pass**: a trusted non-author review object at the current head; on the
 vendored tree, no unresolved thread from a summary-capable reviewer; gate
 `success`. A repo-owned finding still arriving inline is the control that
-proves the reviewer is still reading rather than merely silent. Threads from a
-location-bound reviewer are counted and recorded, not graded — one consolidated
-thread is what the instruction asks for, and more than one is the accepted
-residual above, not a failure.
+proves the reviewer is still reading rather than merely silent — and so is an
+inline thread raising a carve-out regression: read what a thread SAYS before
+grading it, because that one is the rule working. Hold or revert the bump, or
+resolve it on an upstream fix, then re-read; it is a blocked re-vendor, never a
+failed rollout. Threads from a location-bound reviewer are counted and
+recorded, not graded — one consolidated thread is what the instruction asks
+for, and more than one is the accepted residual above, not a failure.
 
 **Suspect, not proven**: threads at zero with `body_chars` also at zero. Body
 length cannot establish whether anything was examined — a reviewer with

--- a/skills/review-gate/references/vendored-paths.md
+++ b/skills/review-gate/references/vendored-paths.md
@@ -202,11 +202,19 @@ gh pr view [PR] --repo [OWNER/REPO] --json reviews,headRefOid --jq '.headRefOid 
 gh pr checks [PR] --repo [OWNER/REPO]
 ```
 
-**Steps 2 and 3 cannot come from the same snapshot** wherever threads are
-enforced — server-side or via `REVIEW_GATE_THREADS`. The gate cannot reach
-`success` while threads are open, and resolving them to reach it empties step
-2. Record step 2's threads and their authors first, resolve them, then read
-step 3.
+**Steps 2 and 3 cannot come from the same snapshot under
+`REVIEW_GATE_THREADS=enforce`** (the default): the predicate reads
+`reviewThreads` and fails closed on any unresolved one, so the gate cannot
+reach `success` while threads are open, and resolving them to reach it empties
+step 2. Record step 2's threads and their authors first, resolve them, then
+read step 3.
+
+Under `REVIEW_GATE_THREADS=off` the predicate skips that read entirely and
+never emits `threads-open`, so step 3 is already green independent of step 2:
+read both from ONE snapshot and resolve nothing. Do not clear real repo-owned
+threads merely to finish a verification. A server-side thread ruleset is not
+the trigger either — it blocks the MERGE, never this status context, which is
+the only thing step 3 reads.
 
 Step 1 answers the evidence question only for rows with `at_head` true whose
 login is non-author AND in the repo's

--- a/skills/review-gate/templates/vendored-paths.instructions.md
+++ b/skills/review-gate/templates/vendored-paths.instructions.md
@@ -43,6 +43,12 @@ upstream-remedy finding together, anchored anywhere in this tree. One thread
 per reviewer per PR is the bound; one thread per finding is what this
 instruction exists to prevent.
 
+If your output contract binds one finding to one comment and consolidation is
+genuinely unavailable to you, every comment you post must still state plainly
+that the remedy is upstream and must not ask for a local edit. That part is not
+optional: it is what stops the same finding being re-litigated in the next
+consuming repo.
+
 **Do not stay silent instead.** Review the PR and submit a review: the merge
 gate needs a review object at this head, so a skipped review blocks the merge
 as hard as an unanswered thread does.

--- a/skills/review-gate/templates/vendored-paths.instructions.md
+++ b/skills/review-gate/templates/vendored-paths.instructions.md
@@ -1,0 +1,46 @@
+---
+applyTo: "[VENDORED_GLOB]"
+---
+
+<!-- Copy to the repo's path-scoped reviewer instruction directory and fill:
+     [VENDORED_GLOB] the vendored tree, verified against a real re-vendor PR's
+     file list; [UPSTREAM_REPO] the owning repository; [PIN_CHECK] the
+     repo-owned control that fails on byte drift. Delete this comment.
+     Rationale and the verification protocol: review-gate
+     references/vendored-paths.md. -->
+
+This tree is vendored BYTE-PINNED from [UPSTREAM_REPO] — the bytes reviewed
+upstream are the bytes that run here, and [PIN_CHECK] fails if they drift. The
+same reviewers see this content upstream before it ever arrives.
+
+**Route every finding by where its fix would land, and pick the surface from
+that.**
+
+- **The fix lands in a repo-owned file** — the vendor pin or checksum manifest,
+  settings, CI wiring, adoption glue: comment inline as normal. A re-vendor
+  that moves these bytes without updating the repo-owned pin is a real defect,
+  and the most valuable finding on this PR class.
+- **The fix lands in these vendored bytes**: put it in the REVIEW SUMMARY BODY,
+  not an inline comment. Name the file and what is wrong; do not propose a
+  diff. A local edit here forks the pinned surface, which is what the pin check
+  exists to prevent — the remedy is upstream-then-re-vendor and cannot happen
+  in this PR.
+- **The fix lands in [UPSTREAM_REPO]'s own docs, config, or conventions** (its
+  README, its settings tables, its test layout): summary body, or omit. This
+  repo cannot act on it.
+
+Every inline comment opens a review thread that blocks the merge until someone
+answers it, and this PR class lands in several consuming repos at once — one
+upstream finding costs one blocking thread per reviewer per repo. The summary
+body carries the same finding at no such cost and is harvested upstream once
+per re-vendor train.
+
+**Do not stay silent instead.** Review the PR and submit a review: the merge
+gate needs a review object at this head, so a skipped review blocks the merge
+as hard as an unanswered thread does.
+
+Also out of scope here, on any surface: local restructuring of this tree
+(splitting files, style or naming changes, line-count limits, test
+reorganization), requests for repo-local test suites over it, and cross-repo
+sync timing — an upstream fix not yet re-vendored is a coordination note, never
+a merge blocker.

--- a/skills/review-gate/templates/vendored-paths.instructions.md
+++ b/skills/review-gate/templates/vendored-paths.instructions.md
@@ -2,10 +2,11 @@
 applyTo: "[VENDORED_GLOB]"
 ---
 
-<!-- Copy to the repo's path-scoped reviewer instruction directory and fill:
-     [VENDORED_GLOB] the vendored tree, verified against a real re-vendor PR's
-     file list; [UPSTREAM_REPO] the owning repository; [PIN_CHECK] the
-     repo-owned control that fails on byte drift. Delete this comment.
+<!-- Copy to .github/instructions/ as a *.instructions.md file, and fill:
+     [VENDORED_GLOB] the vendored tree, whose root is per-repo — verify it
+     against a real re-vendor PR's file list rather than assuming an install
+     path; [UPSTREAM_REPO] the owning repository; [PIN_CHECK] the repo-owned
+     control that fails on byte drift. Delete this comment.
      Rationale and the verification protocol: review-gate
      references/vendored-paths.md. -->
 

--- a/skills/review-gate/templates/vendored-paths.instructions.md
+++ b/skills/review-gate/templates/vendored-paths.instructions.md
@@ -30,6 +30,16 @@ that.**
   README, its settings tables, its test layout): summary body, or omit. This
   repo cannot act on it.
 
+**Carve-out — a production-impacting regression these bytes introduce.** If
+this bump brings in a correctness, security, or data-loss defect that will run
+here, comment inline and say it blocks. That is the first rule, not an
+exception to it: the remedy IS repo-owned — holding or reverting this vendor
+bump until upstream fixes it acts on the pin, and blocking this PR is how that
+remedy gets exercised. The bar is a defect you would hold a release for.
+Style, naming, duplication, test layout, missing coverage, and "this could be
+cleaner" never qualify, however severe they look — those are the summary-body
+case above, and using this carve-out for them is what it exists to prevent.
+
 Every inline comment opens a review thread that blocks the merge until someone
 answers it, and this PR class lands in several consuming repos at once — one
 upstream finding costs one blocking thread per reviewer per repo. The summary

--- a/skills/review-gate/templates/vendored-paths.instructions.md
+++ b/skills/review-gate/templates/vendored-paths.instructions.md
@@ -35,6 +35,13 @@ upstream finding costs one blocking thread per reviewer per repo. The summary
 body carries the same finding at no such cost and is harvested upstream once
 per re-vendor train.
 
+**If every finding you emit is anchored to a file location** — you have no
+review body you author, only a fixed template — then do not drop the finding
+and do not spread it. Post ONE consolidated comment for this PR carrying every
+upstream-remedy finding together, anchored anywhere in this tree. One thread
+per reviewer per PR is the bound; one thread per finding is what this
+instruction exists to prevent.
+
 **Do not stay silent instead.** Review the PR and submit a review: the merge
 gate needs a review object at this head, so a skipped review blocks the merge
 as hard as an unanswered thread does.


### PR DESCRIPTION
## Summary

- Adds `skills/review-gate/references/vendored-paths.md` — the spec for suppressing duplicate consumer-repo findings on vendored vstack paths **without** starving the review gate, plus `templates/vendored-paths.instructions.md`, a paste-in path-scoped reviewer instruction.
- Core rule: **route findings by remedy locus, never silence by path.** Every *configuration* answer (Copilot content exclusion, ignore-paths, path-filtered triggers) removes the vendored tree from the reviewer's view — a pure re-vendor PR then has no reviewable files, so no review object exists and the gate starves at `awaiting`, or a "reviewed 0 files" pass trips `REVIEW_GATE_CHECKRUN_SKIP_PATTERNS`. Instruction text constrains what a reviewer *says*, never *whether it reviews*, so it structurally cannot starve the gate.
- Inline comments stay for repo-owned remedies (the vendor pin, settings, CI wiring); remedies living in the vendored bytes go in the review **summary body** — full evidence, zero threads, zero merge cost.
- Reviewers split into two classes, because they differ in what they can emit: **summary-capable** (Copilot authors a real 1761-char body) and **location-bound** (the Codex connector posts a fixed template body, so its findings can only be inline). The location-bound class gets a bound that fits its actual output contract — one consolidated upstream-remedy comment per PR, not one thread per finding. Per-repo success is therefore "zero Copilot threads and at most one consolidated Codex thread", not zero threads outright.
- Fleet convention documented in `docs/cross-repo.md` ("A Vendored Tree Is Reviewed Once, Upstream"); adoption step 7 + a verification row added to `references/adoption.md`.

## Context

No `REVIEW_GATE_*` value changes. Notably `.agents/*` stays in every consumer's `REVIEW_GATE_CARRY_FORWARD_EXCLUDE` (vendored markdown is mechanically-obeyed agent instruction), and `REVIEW_GATE_TRUSTED_STATUS_CONTEXTS` is not widened to a CI check — a context trusted for this PR class would be trusted for every PR class.

## Completed Issues

- Closes #1242 - Propagation: consumer reviewers skip vendored vstack paths without starving the review-gate evidence

## Measured state — 2026-08-11, the #1235 train

Threads counted via the `reviewThreads` GraphQL read on each repo's open re-vendor PR.

| Repo | Vendored tree | Path-scoped instruction today | Open threads on the #1235 PR |
|---|---|---|---|
| drovr | `.agents/skills/review-gate/**` | present, glob correct | 5 (PR #479) |
| memsira | `.agents/skills/review-gate/**` | present, glob correct | 2 (PR #470) |
| hyprtrade | `tools/review-gate/**` | present, glob correct | 6 (PR #587) |
| hyprtrade-io | `.agents/skills/review-gate/**` | none | 0 (PR #43, merged) |
| vg | `.agents/skills/review-gate/**` | none | 2 (PR #8) |

15 open threads across four consumers, all on vendored paths (Copilot, qodo, Codex connector).

Two findings that shape the rollout:

- **13 of the 15 threads came from the three repos that already carry a vendored-tree instruction.** Their existing clause constrains the *remedy* ("flag them, but do not ask for local edits") and leaves the comment surface alone — which is exactly why it never suppressed anything. Rewriting that clause is the work; adding one where it is missing is the smaller half.
- **hyprtrade-io#43 merged with a Copilot `COMMENTED` review carrying a 1771-char body and zero review threads.** That is the target shape, already observed in production: evidence present, nothing blocking.

## Deviations from the issue's deliverable list

- **No qodo configuration.** qodo drops at trial end (~2026-08-16) and produced roughly a third of the observed threads, so a qodo-side config would be written and retired in the same week. Copilot and the Codex connector are the targets.
- **The per-repo wiring plan is not in this commit.** vstack is portable and public, so the five consumer repo names stay out of tracked files; the filled plan lives untracked at `docs/vendored-review-rollout-local.md` (gitignored via `docs/*-local.md`).
- **`vgs`** was named in the issue but is not one of the five gate-enforcing consumers measured here; whether it vendors a byte-pinned tree at all needs confirming before wiring it.

## Review Round

Three reviewer findings applied in `6fd0c639`:

1. **Location-bound reviewers cannot use a summary body** (codex-connector) — spec and template now split reviewers by class and bound the location-bound class to one consolidated comment per PR. An adapter (new engine machinery) and a summary-capable-only rollout (which would exclude the reviewer producing most of the threads) were both rejected deliberately.
2. **Exact-head verification was unverifiable as documented** (codex-connector) — the command now requests `reviews,headRefOid` and reports `at_head` per review, proven to return both true and false on live PRs (drovr#475 has three reviews at superseded commits; hyprtrade#585 has none at head). Also documents that this view drops the `[bot]` login suffix the trusted-login lists carry.
3. **Skip-pattern protection was overstated** (Copilot) — `REVIEW_GATE_CHECKRUN_SKIP_PATTERNS` is literal-substring `contains()` over title + summary, so a "0 files reviewed" success is full evidence. Both passages corrected; path exclusion risks a hollow **green** gate rather than a starved one, which is the worse failure because nothing looks wrong.

## Test Plan

- 43/43 shell suites pass, 0 fail (the CI shell portion of `skill-tests.yml`: executable-bit lint, `vstack report` guidance lint, orch run-all, all other skill suites, hook suites).
- The doc-contract lint was first proven capable of failing on the new template (an injected `REVIEW_GATE_BOGUS_CONTROL` made `settings-vars-documented.test.sh` fail; removed and re-verified pass) before its pass was trusted.
- Rollout verification is per-repo and out of this PR's reach: five PRs through five separate merge queues, each verified on that repo's own next pure re-vendor PR. Recommended order `hyprtrade → drovr → memsira → vg → hyprtrade-io`, not batched — if the first repo's re-vendor PR starves its gate, the other four are avoided rather than reverted.
