### PR TITLE
fix(pi-claude-bridge): replace constructor parameter properties with explicit fields

### DIFF
--- a/pi-extensions/pi-claude-bridge/bundle/index.js
+++ b/pi-extensions/pi-claude-bridge/bundle/index.js
@@ -44488,16 +44488,16 @@ function commitsVisibleOutput(event) {
   return event.type === "toolcall_end";
 }
 var RetryEventBuffer = class {
-  constructor(target, onCommit) {
-    this.target = target;
-    this.onCommit = onCommit;
-  }
-  target;
-  onCommit;
   pending = [];
   committed = false;
   ended = false;
   discarded = false;
+  target;
+  onCommit;
+  constructor(target, onCommit) {
+    this.target = target;
+    this.onCommit = onCommit;
+  }
   push(event) {
     if (this.discarded) return;
     if (this.committed) {

--- a/pi-extensions/pi-claude-bridge/src/account-router.ts
+++ b/pi-extensions/pi-claude-bridge/src/account-router.ts
@@ -153,11 +153,13 @@ export class RetryEventBuffer {
 	private committed = false;
 	private ended = false;
 	private discarded = false;
+	private readonly target: AssistantMessageEventStream;
+	private readonly onCommit?: () => void;
 
-	constructor(
-		private readonly target: AssistantMessageEventStream,
-		private readonly onCommit?: () => void,
-	) {}
+	constructor(target: AssistantMessageEventStream, onCommit?: () => void) {
+		this.target = target;
+		this.onCommit = onCommit;
+	}
 
 	push(event: AssistantMessageEvent): void {
 		if (this.discarded) return;


### PR DESCRIPTION
Fixes #1244. `package-policy.test.mjs` was red on main (pre-existing since 728837b1/#999): `RetryEventBuffer` used constructor parameter properties, which the Node strip-only parsing policy forbids — a policy test red on main protects nothing.

Mechanical conversion to explicit `private readonly` fields + constructor assignments; bundle regenerated from the strict lockfile build per the clean-build rule (diff is exactly the class-field reordering). Policy suite 4/4 (demonstrably 3/4 before); bridge unit suite 507/507.

Tiny mechanical diff reviewed inline; skipping the cross-model lane for proportionality.

https://claude.ai/code/session_01L7fubfyViYcy7zUNL6uLPf