### PR TITLE
fix(pi-output-policy): stop runaway model streams

### DIFF
--- a/.github/workflows/skill-tests.yml
+++ b/.github/workflows/skill-tests.yml
@@ -197,6 +197,7 @@ jobs:
           bun test ./tests
 
       - name: pi-output-policy suite
+        if: matrix.shard == 'node'
         working-directory: pi-extensions/pi-output-policy
         run: bun test ./tests
 

--- a/.github/workflows/skill-tests.yml
+++ b/.github/workflows/skill-tests.yml
@@ -196,6 +196,10 @@ jobs:
           npm install --no-save --no-package-lock --ignore-scripts --no-audit --no-fund @earendil-works/pi-agent-core@0.80.5 @earendil-works/pi-ai@0.80.5 @earendil-works/pi-coding-agent@0.80.5 @earendil-works/pi-tui@0.80.5
           bun test ./tests
 
+      - name: pi-output-policy suite
+        working-directory: pi-extensions/pi-output-policy
+        run: bun test ./tests
+
       # Pi 0.84.x is the release the extensions are audited against, so the
       # suites that assert 0.84 wire-format parity install that line rather
       # than the 0.80.5 floor above.

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ If a Pi extension declares production dependencies (`dependencies` or `optionalD
 | [`pi-codex-minimal-tools`](pi-extensions/pi-codex-minimal-tools/README.md) | Codex-style image, patch, and image-generation tools alongside Pi natives. |
 | [`pi-extension-manager`](pi-extensions/pi-extension-manager/README.md) | Pi-styled package manager and inline settings editor. |
 | [`pi-hooks`](pi-extensions/pi-hooks/README.md) | First-class Pi port of the vstack safety hooks: bare-cd blocking, pre-commit fmt+clippy, post-edit clippy, end-of-turn lint. |
-| [`pi-output-policy`](pi-extensions/pi-output-policy/README.md) | Large-output policy with transcript-budget-aware truncation, spill-file preservation, and balanced/compact/compat modes. |
+| [`pi-output-policy`](pi-extensions/pi-output-policy/README.md) | Large-output policy with runaway model-response interruption, transcript-budget-aware tool truncation, spill-file preservation, and balanced/compact/compat modes. |
 | [`pi-prompt-stash`](pi-extensions/pi-prompt-stash/README.md) | Per-session prompt stash history with stash/pop editor. |
 | [`pi-qol`](pi-extensions/pi-qol/README.md) | Compact statusline, multiline input, image chips, session naming and search. |
 | [`pi-questions`](pi-extensions/pi-questions/README.md) | Structured multi-tab popup questions with bridge-driven replies. |

--- a/pi-extensions/pi-output-policy/CHANGELOG.md
+++ b/pi-extensions/pi-output-policy/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Added a default-on streaming model-output guard. It aborts assistant responses after 24 consecutive repeated substantial lines / 1,536 repeated characters, or after 96,000 total streamed characters, preventing degenerate provider output from overwhelming Pi's TUI and session.
 - Added live `modelOutputGuard.*` settings for master enablement, independent repetition/character-cap enablement, and all thresholds. Settings are snapshotted once per assistant message, so changes apply to the next message without adding synchronous file reads to each streamed delta.
-- Repetition streaks now survive only blank and recognized syntax-only lines; distinct short semantic content resets them, preventing repeated report headings or separators from becoming false positives.
+- Repetition streaks now survive only blank and recognized syntax-only lines, including CommonMark backtick and tilde fences with spaced info strings; distinct short semantic content resets them, preventing repeated report headings or separators from becoming false positives.
 - Exported `createModelOutputGuardState()` and `inspectModelOutputDelta()` for integrations and tests.
 
 ### 1.1.1

--- a/pi-extensions/pi-output-policy/CHANGELOG.md
+++ b/pi-extensions/pi-output-policy/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added a default-on streaming model-output guard. It aborts assistant responses after 24 consecutive repeated substantial lines / 1,536 repeated characters, or after 96,000 total streamed characters, preventing degenerate provider output from overwhelming Pi's TUI and session.
 - Added live `modelOutputGuard.*` settings for master enablement, independent repetition/character-cap enablement, and all thresholds. Settings are snapshotted once per assistant message, so changes apply to the next message without adding synchronous file reads to each streamed delta.
+- Repetition streaks now survive only blank and recognized syntax-only lines; distinct short semantic content resets them, preventing repeated report headings or separators from becoming false positives.
 - Exported `createModelOutputGuardState()` and `inspectModelOutputDelta()` for integrations and tests.
 
 ### 1.1.1

--- a/pi-extensions/pi-output-policy/CHANGELOG.md
+++ b/pi-extensions/pi-output-policy/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### 1.2.0
 
 - Added a default-on streaming model-output guard. It aborts assistant responses after 24 consecutive repeated substantial lines / 1,536 repeated characters, or after 96,000 total streamed characters, preventing degenerate provider output from overwhelming Pi's TUI and session.
-- Added live `modelOutputGuard.*` settings for master enablement, independent repetition/character-cap enablement, and all thresholds.
+- Added live `modelOutputGuard.*` settings for master enablement, independent repetition/character-cap enablement, and all thresholds. Settings are snapshotted once per assistant message, so changes apply to the next message without adding synchronous file reads to each streamed delta.
 - Exported `createModelOutputGuardState()` and `inspectModelOutputDelta()` for integrations and tests.
 
 ### 1.1.1

--- a/pi-extensions/pi-output-policy/CHANGELOG.md
+++ b/pi-extensions/pi-output-policy/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Consumer-impacting changes
 
+### 1.2.0
+
+- Added a default-on streaming model-output guard. It aborts assistant responses after 24 consecutive repeated substantial lines / 1,536 repeated characters, or after 96,000 total streamed characters, preventing degenerate provider output from overwhelming Pi's TUI and session.
+- Added live `modelOutputGuard.*` settings for master enablement, independent repetition/character-cap enablement, and all thresholds.
+- Exported `createModelOutputGuardState()` and `inspectModelOutputDelta()` for integrations and tests.
+
 ### 1.1.1
 
 - Baseline: changelog introduced at this version. Consumer-impacting changes — behavior deltas, new/renamed/removed exports, settings and config changes, protocol/audit-shape changes — are recorded here from this version forward.

--- a/pi-extensions/pi-output-policy/README.md
+++ b/pi-extensions/pi-output-policy/README.md
@@ -11,7 +11,7 @@ Streaming assistant responses are aborted when either safety condition fires:
 - the same substantial line repeats 24 times and contributes at least 1,536 repeated characters; or
 - one response reaches 96,000 streamed characters.
 
-This targets model decoding collapse such as thousands of identical planning sentences or malformed tool tags. Short repeated syntax lines do not reset or trigger repetition streaks, but still count toward the hard response-size cap. Pi keeps the partial response and marks it interrupted; Output Policy shows a warning telling the user to retry or switch models. All thresholds are live settings; changes apply to the next assistant message. The whole model-output guard, repetition detection, and the hard character cap can each be disabled independently.
+This targets model decoding collapse such as thousands of identical planning sentences or malformed tool tags. Blank lines and recognized syntax-only lines (tool/XML tags, code fences, and Markdown separators) do not reset or trigger repetition streaks; other short content resets the streak. All lines still count toward the hard response-size cap. Pi keeps the partial response and marks it interrupted; Output Policy shows a warning telling the user to retry or switch models. All thresholds are live settings; changes apply to the next assistant message. The whole model-output guard, repetition detection, and the hard character cap can each be disabled independently.
 
 ## Two budgets, one policy
 
@@ -85,7 +85,7 @@ Project settings in `.pi/settings.json` apply only after Pi marks the workspace 
 | Maximum streamed characters | Abort one assistant response at this character count; `0` disables only this cap. |
 | Detect repeated output | Enable repetition detection independently from the hard character cap. |
 | Maximum repeated blocks | Consecutive identical substantial lines required before aborting. |
-| Minimum repeated block length | Exclude shorter lines from repetition streaks without resetting a substantial repeated block. |
+| Minimum repeated block length | Exclude shorter lines from repetition detection; only blank or recognized syntax-only lines preserve an existing substantial streak. |
 | Minimum repeated characters | Repeated-text floor that must also be reached before aborting. |
 
 ### Truncation

--- a/pi-extensions/pi-output-policy/README.md
+++ b/pi-extensions/pi-output-policy/README.md
@@ -11,7 +11,7 @@ Streaming assistant responses are aborted when either safety condition fires:
 - the same substantial line repeats 24 times and contributes at least 1,536 repeated characters; or
 - one response reaches 96,000 streamed characters.
 
-This targets model decoding collapse such as thousands of identical planning sentences or malformed tool tags. Short repeated syntax lines do not reset or trigger repetition streaks, but still count toward the hard response-size cap. Pi keeps the partial response and marks it interrupted; Output Policy shows a warning telling the user to retry or switch models. All thresholds are live settings. The whole model-output guard, repetition detection, and the hard character cap can each be disabled independently.
+This targets model decoding collapse such as thousands of identical planning sentences or malformed tool tags. Short repeated syntax lines do not reset or trigger repetition streaks, but still count toward the hard response-size cap. Pi keeps the partial response and marks it interrupted; Output Policy shows a warning telling the user to retry or switch models. All thresholds are live settings; changes apply to the next assistant message. The whole model-output guard, repetition detection, and the hard character cap can each be disabled independently.
 
 ## Two budgets, one policy
 

--- a/pi-extensions/pi-output-policy/README.md
+++ b/pi-extensions/pi-output-policy/README.md
@@ -2,7 +2,16 @@
 
 ![Output Policy settings panel](https://raw.githubusercontent.com/vanillagreencom/vstack/main/pi-extensions/pi-output-policy/assets/settings-panel.png)
 
-Large-output policy for Pi tool results: minimization, bounded truncation, and full-output preservation. Tuned to keep long autonomous runs under provider request-buffer limits without losing the full tool output (it lands on disk).
+Large-output policy for Pi model responses and tool results: runaway-response interruption, minimization, bounded truncation, and full-output preservation. Tuned to keep degenerate model streams from overwhelming the TUI and long autonomous runs under provider request-buffer limits without losing full tool output (it lands on disk).
+
+## Runaway model output guard
+
+Streaming assistant responses are aborted when either safety condition fires:
+
+- the same substantial line repeats 24 times and contributes at least 1,536 repeated characters; or
+- one response reaches 96,000 streamed characters.
+
+This targets model decoding collapse such as thousands of identical planning sentences or malformed tool tags. Short repeated syntax lines do not reset or trigger repetition streaks, but still count toward the hard response-size cap. Pi keeps the partial response and marks it interrupted; Output Policy shows a warning telling the user to retry or switch models. All thresholds are live settings. The whole model-output guard, repetition detection, and the hard character cap can each be disabled independently.
 
 ## Two budgets, one policy
 
@@ -29,6 +38,7 @@ Any per-knob value you set in `vstack.extensionManager.config["@vanillagreen/pi-
 
 ## Highlights
 
+- Stops degenerate streaming model responses before repeated prose or tool tags overwhelm the TUI/session.
 - Preserves oversized tool output to disk and includes the artifact path in results.
 - Head truncation for search/listing tools; tail truncation for command/log tools.
 - Explicit truncation notices show size, line count, direction, artifact path, per-turn/session bytes saved, and continuation guidance.
@@ -66,6 +76,17 @@ Project settings in `.pi/settings.json` apply only after Pi marks the workspace 
 | --- | --- |
 | Enable output policy | Master toggle. |
 | Policy mode | `balanced` (default), `compact`, or `compat`. See [Policy modes](#policy-modes). |
+
+### Model output guard
+
+| Setting | What it does |
+| --- | --- |
+| Stop runaway model output | Enable repetition detection and the hard response-size cap. |
+| Maximum streamed characters | Abort one assistant response at this character count; `0` disables only this cap. |
+| Detect repeated output | Enable repetition detection independently from the hard character cap. |
+| Maximum repeated blocks | Consecutive identical substantial lines required before aborting. |
+| Minimum repeated block length | Exclude shorter lines from repetition streaks without resetting a substantial repeated block. |
+| Minimum repeated characters | Repeated-text floor that must also be reached before aborting. |
 
 ### Truncation
 

--- a/pi-extensions/pi-output-policy/extensions/output-policy.ts
+++ b/pi-extensions/pi-output-policy/extensions/output-policy.ts
@@ -129,6 +129,11 @@ export interface ModelOutputGuardDetection {
 	totalChars: number;
 }
 
+interface ModelOutputGuardConfigSnapshot {
+	enabled: boolean;
+	options: ModelOutputGuardOptions;
+}
+
 const SESSION_COUNTERS = new Map<string, SessionCounters>();
 
 function counters(sessionId: string): SessionCounters {
@@ -306,6 +311,17 @@ function settingString(key: string, fallback: string, cwd?: string): string {
 	return typeof value === "string" ? value : fallback;
 }
 
+function configNumber(config: VstackConfig, key: string, fallback: number): number {
+	const value = config[key];
+	const parsed = typeof value === "number" ? value : typeof value === "string" ? Number(value) : Number.NaN;
+	return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function configBoolean(config: VstackConfig, key: string, fallback: boolean): boolean {
+	const value = config[key];
+	return typeof value === "boolean" ? value : fallback;
+}
+
 export function resolvePolicyMode(cwd?: string): PolicyMode {
 	const raw = settingString("policyMode", DEFAULT_POLICY_MODE, cwd).toLowerCase().trim();
 	if (raw === "compat" || raw === "balanced" || raw === "compact") return raw;
@@ -392,13 +408,17 @@ export function inspectModelOutputDelta(
 	return undefined;
 }
 
-function modelOutputGuardOptions(cwd?: string): ModelOutputGuardOptions {
+function modelOutputGuardConfigSnapshot(cwd?: string): ModelOutputGuardConfigSnapshot {
+	const config = readVstackConfig(cwd);
 	return {
-		maxChars: Math.max(0, Math.floor(settingNumber("modelOutputGuard.maxChars", DEFAULT_MODEL_OUTPUT_MAX_CHARS, cwd))),
-		maxConsecutiveRepeats: Math.max(2, Math.floor(settingNumber("modelOutputGuard.maxConsecutiveRepeats", DEFAULT_MODEL_OUTPUT_MAX_CONSECUTIVE_REPEATS, cwd))),
-		repetitionEnabled: settingBoolean("modelOutputGuard.repetition.enabled", true, cwd),
-		minRepeatBlockChars: Math.max(8, Math.floor(settingNumber("modelOutputGuard.minRepeatBlockChars", DEFAULT_MODEL_OUTPUT_MIN_REPEAT_BLOCK_CHARS, cwd))),
-		minRepeatedChars: Math.max(64, Math.floor(settingNumber("modelOutputGuard.minRepeatedChars", DEFAULT_MODEL_OUTPUT_MIN_REPEATED_CHARS, cwd))),
+		enabled: configBoolean(config, "enabled", true) && configBoolean(config, "modelOutputGuard.enabled", true),
+		options: {
+			maxChars: Math.max(0, Math.floor(configNumber(config, "modelOutputGuard.maxChars", DEFAULT_MODEL_OUTPUT_MAX_CHARS))),
+			maxConsecutiveRepeats: Math.max(2, Math.floor(configNumber(config, "modelOutputGuard.maxConsecutiveRepeats", DEFAULT_MODEL_OUTPUT_MAX_CONSECUTIVE_REPEATS))),
+			repetitionEnabled: configBoolean(config, "modelOutputGuard.repetition.enabled", true),
+			minRepeatBlockChars: Math.max(8, Math.floor(configNumber(config, "modelOutputGuard.minRepeatBlockChars", DEFAULT_MODEL_OUTPUT_MIN_REPEAT_BLOCK_CHARS))),
+			minRepeatedChars: Math.max(64, Math.floor(configNumber(config, "modelOutputGuard.minRepeatedChars", DEFAULT_MODEL_OUTPUT_MIN_REPEATED_CHARS))),
+		},
 	};
 }
 
@@ -688,10 +708,20 @@ export default function outputPolicy(pi: ExtensionAPI): void {
 	const guard = pi as unknown as Record<PropertyKey, unknown>;
 	if (guard[INSTALL_SYMBOL]) return;
 	guard[INSTALL_SYMBOL] = true;
+	// Pi tears down and rebinds extension instances when replacing sessions, so
+	// this closure is already scoped to one active session runtime.
 	let modelOutputState = createModelOutputGuardState();
+	let modelOutputConfig: ModelOutputGuardConfigSnapshot | undefined;
 
 	const resetModelOutputState = () => {
 		modelOutputState = createModelOutputGuardState();
+		modelOutputConfig = undefined;
+	};
+
+	const snapshotModelOutputConfig = (ctx: ExtensionContext) => {
+		recordProjectTrust(ctx);
+		modelOutputConfig = modelOutputGuardConfigSnapshot(ctx.cwd);
+		return modelOutputConfig;
 	};
 
 	pi.on("session_start", async (_event, ctx: ExtensionContext) => {
@@ -714,16 +744,18 @@ export default function outputPolicy(pi: ExtensionAPI): void {
 		SESSION_COUNTERS.delete(sessionIdForContext(ctx));
 	});
 
-	pi.on("message_start", (event: any) => {
-		if (event?.message?.role === "assistant") resetModelOutputState();
+	pi.on("message_start", (event: any, ctx: ExtensionContext) => {
+		if (event?.message?.role !== "assistant") return;
+		resetModelOutputState();
+		snapshotModelOutputConfig(ctx);
 	});
 
 	pi.on("message_update", (event: any, ctx: ExtensionContext) => {
-		recordProjectTrust(ctx);
-		if (!settingBoolean("enabled", true, ctx.cwd) || !settingBoolean("modelOutputGuard.enabled", true, ctx.cwd)) return;
 		const delta = assistantStreamDelta(event);
 		if (delta === undefined) return;
-		const detection = inspectModelOutputDelta(modelOutputState, delta, modelOutputGuardOptions(ctx.cwd));
+		const config = modelOutputConfig ?? snapshotModelOutputConfig(ctx);
+		if (!config.enabled) return;
+		const detection = inspectModelOutputDelta(modelOutputState, delta, config.options);
 		if (!detection || modelOutputState.aborted) return;
 		modelOutputState.aborted = true;
 		const detail = detection.reason === "repetition"

--- a/pi-extensions/pi-output-policy/extensions/output-policy.ts
+++ b/pi-extensions/pi-output-policy/extensions/output-policy.ts
@@ -361,6 +361,21 @@ function normalizedRepeatBlock(line: string): string {
 	return line.trim().replace(/\s+/g, " ");
 }
 
+function isIgnorableRepeatSyntaxBlock(block: string): boolean {
+	// Preserve a substantial repetition streak only across syntax-only lines
+	// produced by common model/tool protocols. Short prose, labels, values, and
+	// headings are semantic content and must break the streak.
+	return /^<\/?[A-Za-z][A-Za-z0-9:._-]*(?:\s+[^<>]*)?\/?>$/.test(block)
+		|| /^(?:`{3,}|~{3,})(?:[A-Za-z0-9_.+-]+)?$/.test(block)
+		|| /^(?:(?:-\s*){3,}|(?:\*\s*){3,}|(?:_\s*){3,})$/.test(block);
+}
+
+function resetModelOutputRepeatStreak(state: ModelOutputGuardState): void {
+	state.lastBlock = undefined;
+	state.consecutiveRepeats = 0;
+	state.repeatedChars = 0;
+}
+
 export function inspectModelOutputDelta(
 	state: ModelOutputGuardState,
 	delta: string,
@@ -380,7 +395,11 @@ export function inspectModelOutputDelta(
 		state.pending = state.pending.slice(newline + 1);
 		newline = state.pending.indexOf("\n");
 		if (!block) continue;
-		if (block.length < options.minRepeatBlockChars) continue;
+		if (isIgnorableRepeatSyntaxBlock(block)) continue;
+		if (block.length < options.minRepeatBlockChars) {
+			resetModelOutputRepeatStreak(state);
+			continue;
+		}
 		if (block === state.lastBlock) {
 			state.consecutiveRepeats += 1;
 			state.repeatedChars += block.length;
@@ -708,8 +727,9 @@ export default function outputPolicy(pi: ExtensionAPI): void {
 	const guard = pi as unknown as Record<PropertyKey, unknown>;
 	if (guard[INSTALL_SYMBOL]) return;
 	guard[INSTALL_SYMBOL] = true;
-	// Pi tears down and rebinds extension instances when replacing sessions, so
-	// this closure is already scoped to one active session runtime.
+	// Pi 0.84.1 invokes the extension factory once per loaded session runtime.
+	// Session replacement emits shutdown, invalidates the old runner, and loads a
+	// new ExtensionAPI/factory closure, so this state cannot cross session runtimes.
 	let modelOutputState = createModelOutputGuardState();
 	let modelOutputConfig: ModelOutputGuardConfigSnapshot | undefined;
 
@@ -753,6 +773,10 @@ export default function outputPolicy(pi: ExtensionAPI): void {
 	pi.on("message_update", (event: any, ctx: ExtensionContext) => {
 		const delta = assistantStreamDelta(event);
 		if (delta === undefined) return;
+		// Pi 0.84.1 agent-core guarantees one assistant message_start before any
+		// message_update. This lazy snapshot only supports isolated direct/mock
+		// event injection; delta events expose no safe boundary to infer if start is
+		// absent, so do not reset via timing, contentIndex, or delta-shape heuristics.
 		const config = modelOutputConfig ?? snapshotModelOutputConfig(ctx);
 		if (!config.enabled) return;
 		const detection = inspectModelOutputDelta(modelOutputState, delta, config.options);

--- a/pi-extensions/pi-output-policy/extensions/output-policy.ts
+++ b/pi-extensions/pi-output-policy/extensions/output-policy.ts
@@ -8,6 +8,11 @@ const INSTALL_SYMBOL = Symbol.for("vstack.pi-output-policy.installed");
 const CONFIG_ID = "@vanillagreen/pi-output-policy";
 const DEFAULT_MINIMIZER_MAX_CAPTURE_BYTES = 1024 * 1024;
 const DEFAULT_SHELL_MINIMIZER_ENABLED = true;
+const DEFAULT_MODEL_OUTPUT_MAX_CHARS = 96_000;
+const DEFAULT_MODEL_OUTPUT_MAX_CONSECUTIVE_REPEATS = 24;
+const DEFAULT_MODEL_OUTPUT_MIN_REPEAT_BLOCK_CHARS = 32;
+const DEFAULT_MODEL_OUTPUT_MIN_REPEATED_CHARS = 1_536;
+const MAX_PENDING_MODEL_OUTPUT_CHARS = 16_384;
 
 // Tools whose `details` carry state-bearing data (task lists, background-task
 // snapshots, subagent run records). Sanitization would corrupt restore
@@ -98,6 +103,30 @@ interface TruncationMeta {
 interface SessionCounters {
 	turnSavedBytes: number;
 	sessionSavedBytes: number;
+}
+
+export interface ModelOutputGuardState {
+	aborted: boolean;
+	consecutiveRepeats: number;
+	lastBlock?: string;
+	pending: string;
+	repeatedChars: number;
+	totalChars: number;
+}
+
+export interface ModelOutputGuardOptions {
+	maxChars: number;
+	maxConsecutiveRepeats: number;
+	minRepeatBlockChars: number;
+	minRepeatedChars: number;
+	repetitionEnabled?: boolean;
+}
+
+export interface ModelOutputGuardDetection {
+	block?: string;
+	consecutiveRepeats?: number;
+	reason: "max-chars" | "repetition";
+	totalChars: number;
 }
 
 const SESSION_COUNTERS = new Map<string, SessionCounters>();
@@ -300,6 +329,84 @@ export function isSanitizeExceptTool(toolName: string, cwd?: string): boolean {
 
 export function __resetSessionCountersForTests(): void {
 	SESSION_COUNTERS.clear();
+}
+
+export function createModelOutputGuardState(): ModelOutputGuardState {
+	return {
+		aborted: false,
+		consecutiveRepeats: 0,
+		pending: "",
+		repeatedChars: 0,
+		totalChars: 0,
+	};
+}
+
+function normalizedRepeatBlock(line: string): string {
+	return line.trim().replace(/\s+/g, " ");
+}
+
+export function inspectModelOutputDelta(
+	state: ModelOutputGuardState,
+	delta: string,
+	options: ModelOutputGuardOptions,
+): ModelOutputGuardDetection | undefined {
+	if (state.aborted || delta.length === 0) return undefined;
+	state.totalChars += delta.length;
+	if (options.maxChars > 0 && state.totalChars >= options.maxChars) {
+		return { reason: "max-chars", totalChars: state.totalChars };
+	}
+
+	if (options.repetitionEnabled === false) return undefined;
+	state.pending = `${state.pending}${delta.replace(/\r\n?/g, "\n")}`;
+	let newline = state.pending.indexOf("\n");
+	while (newline >= 0) {
+		const block = normalizedRepeatBlock(state.pending.slice(0, newline));
+		state.pending = state.pending.slice(newline + 1);
+		newline = state.pending.indexOf("\n");
+		if (!block) continue;
+		if (block.length < options.minRepeatBlockChars) continue;
+		if (block === state.lastBlock) {
+			state.consecutiveRepeats += 1;
+			state.repeatedChars += block.length;
+		} else {
+			state.lastBlock = block;
+			state.consecutiveRepeats = 1;
+			state.repeatedChars = block.length;
+		}
+		if (
+			state.consecutiveRepeats >= options.maxConsecutiveRepeats
+			&& state.repeatedChars >= options.minRepeatedChars
+		) {
+			return {
+				block,
+				consecutiveRepeats: state.consecutiveRepeats,
+				reason: "repetition",
+				totalChars: state.totalChars,
+			};
+		}
+	}
+
+	if (state.pending.length > MAX_PENDING_MODEL_OUTPUT_CHARS) {
+		state.pending = state.pending.slice(-MAX_PENDING_MODEL_OUTPUT_CHARS);
+	}
+	return undefined;
+}
+
+function modelOutputGuardOptions(cwd?: string): ModelOutputGuardOptions {
+	return {
+		maxChars: Math.max(0, Math.floor(settingNumber("modelOutputGuard.maxChars", DEFAULT_MODEL_OUTPUT_MAX_CHARS, cwd))),
+		maxConsecutiveRepeats: Math.max(2, Math.floor(settingNumber("modelOutputGuard.maxConsecutiveRepeats", DEFAULT_MODEL_OUTPUT_MAX_CONSECUTIVE_REPEATS, cwd))),
+		repetitionEnabled: settingBoolean("modelOutputGuard.repetition.enabled", true, cwd),
+		minRepeatBlockChars: Math.max(8, Math.floor(settingNumber("modelOutputGuard.minRepeatBlockChars", DEFAULT_MODEL_OUTPUT_MIN_REPEAT_BLOCK_CHARS, cwd))),
+		minRepeatedChars: Math.max(64, Math.floor(settingNumber("modelOutputGuard.minRepeatedChars", DEFAULT_MODEL_OUTPUT_MIN_REPEATED_CHARS, cwd))),
+	};
+}
+
+function assistantStreamDelta(event: any): string | undefined {
+	const update = event?.assistantMessageEvent ?? event;
+	if (!update || typeof update.delta !== "string") return undefined;
+	if (!["text", "text_delta", "thinking", "thinking_delta", "toolcall_delta"].includes(String(update.type ?? ""))) return undefined;
+	return update.delta;
 }
 
 function byteLength(text: string): number {
@@ -581,8 +688,14 @@ export default function outputPolicy(pi: ExtensionAPI): void {
 	const guard = pi as unknown as Record<PropertyKey, unknown>;
 	if (guard[INSTALL_SYMBOL]) return;
 	guard[INSTALL_SYMBOL] = true;
+	let modelOutputState = createModelOutputGuardState();
+
+	const resetModelOutputState = () => {
+		modelOutputState = createModelOutputGuardState();
+	};
 
 	pi.on("session_start", async (_event, ctx: ExtensionContext) => {
+		resetModelOutputState();
 		recordProjectTrust(ctx);
 		SESSION_COUNTERS.delete(sessionIdForContext(ctx));
 		if (settingBoolean("enabled", true, ctx.cwd)) {
@@ -592,11 +705,36 @@ export default function outputPolicy(pi: ExtensionAPI): void {
 	});
 
 	pi.on("turn_start", async (_event, ctx: ExtensionContext) => {
+		resetModelOutputState();
 		counters(sessionIdForContext(ctx)).turnSavedBytes = 0;
 	});
 
 	pi.on("session_shutdown", async (_event, ctx: ExtensionContext) => {
+		resetModelOutputState();
 		SESSION_COUNTERS.delete(sessionIdForContext(ctx));
+	});
+
+	pi.on("message_start", (event: any) => {
+		if (event?.message?.role === "assistant") resetModelOutputState();
+	});
+
+	pi.on("message_update", (event: any, ctx: ExtensionContext) => {
+		recordProjectTrust(ctx);
+		if (!settingBoolean("enabled", true, ctx.cwd) || !settingBoolean("modelOutputGuard.enabled", true, ctx.cwd)) return;
+		const delta = assistantStreamDelta(event);
+		if (delta === undefined) return;
+		const detection = inspectModelOutputDelta(modelOutputState, delta, modelOutputGuardOptions(ctx.cwd));
+		if (!detection || modelOutputState.aborted) return;
+		modelOutputState.aborted = true;
+		const detail = detection.reason === "repetition"
+			? `${detection.consecutiveRepeats} consecutive repeated blocks`
+			: `${detection.totalChars.toLocaleString()} streamed characters`;
+		ctx.abort();
+		try {
+			ctx.ui.notify(`Model output stopped: ${detail}. Retry or switch model.`, "warning");
+		} catch (error) {
+			console.warn(`pi-output-policy: model-output warning failed (${stringifyError(error)})`);
+		}
 	});
 
 	pi.on("tool_result", async (event: any, ctx: ExtensionContext) => {

--- a/pi-extensions/pi-output-policy/extensions/output-policy.ts
+++ b/pi-extensions/pi-output-policy/extensions/output-policy.ts
@@ -361,12 +361,22 @@ function normalizedRepeatBlock(line: string): string {
 	return line.trim().replace(/\s+/g, " ");
 }
 
-function isIgnorableRepeatSyntaxBlock(block: string): boolean {
+function isCommonMarkFenceLine(line: string): boolean {
+	// CommonMark permits up to three leading spaces and an optional info string.
+	// Backtick-fence info strings cannot contain backticks; tilde-fence info
+	// strings have no equivalent character restriction.
+	const match = /^(?: {0,3})(`{3,}|~{3,})(.*)$/.exec(line);
+	if (!match) return false;
+	return match[1].startsWith("~") || !match[2].includes("`");
+}
+
+function isIgnorableRepeatSyntaxBlock(line: string): boolean {
 	// Preserve a substantial repetition streak only across syntax-only lines
 	// produced by common model/tool protocols. Short prose, labels, values, and
 	// headings are semantic content and must break the streak.
+	const block = normalizedRepeatBlock(line);
 	return /^<\/?[A-Za-z][A-Za-z0-9:._-]*(?:\s+[^<>]*)?\/?>$/.test(block)
-		|| /^(?:`{3,}|~{3,})(?:[A-Za-z0-9_.+-]+)?$/.test(block)
+		|| isCommonMarkFenceLine(line)
 		|| /^(?:(?:-\s*){3,}|(?:\*\s*){3,}|(?:_\s*){3,})$/.test(block);
 }
 
@@ -391,11 +401,12 @@ export function inspectModelOutputDelta(
 	state.pending = `${state.pending}${delta.replace(/\r\n?/g, "\n")}`;
 	let newline = state.pending.indexOf("\n");
 	while (newline >= 0) {
-		const block = normalizedRepeatBlock(state.pending.slice(0, newline));
+		const line = state.pending.slice(0, newline);
+		const block = normalizedRepeatBlock(line);
 		state.pending = state.pending.slice(newline + 1);
 		newline = state.pending.indexOf("\n");
 		if (!block) continue;
-		if (isIgnorableRepeatSyntaxBlock(block)) continue;
+		if (isIgnorableRepeatSyntaxBlock(line)) continue;
 		if (block.length < options.minRepeatBlockChars) {
 			resetModelOutputRepeatStreak(state);
 			continue;

--- a/pi-extensions/pi-output-policy/package.json
+++ b/pi-extensions/pi-output-policy/package.json
@@ -68,7 +68,7 @@
         {
           "key": "modelOutputGuard.minRepeatBlockChars",
           "label": "Minimum repeated block length",
-          "description": "Ignore shorter repeated lines for repetition streaks. They still count toward the hard response-size cap.",
+          "description": "Exclude shorter lines from repetition detection. Blank and recognized syntax-only lines preserve an existing streak; other short content resets it. All lines still count toward the hard response-size cap.",
           "type": "number",
           "default": 32,
           "category": "Model Output Guard",

--- a/pi-extensions/pi-output-policy/package.json
+++ b/pi-extensions/pi-output-policy/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vanillagreen/pi-output-policy",
-  "version": "1.1.1",
-  "description": "OMP-style large-output policy for Pi tool results: minimization, bounded truncation, and spill-file preservation.",
+  "version": "1.2.0",
+  "description": "Large-output policy for Pi: runaway model-output guards plus tool-result minimization, truncation, and spill preservation.",
   "license": "MIT",
   "keywords": [
     "pi-package",
@@ -23,10 +23,64 @@
         {
           "key": "enabled",
           "label": "Enable output policy",
-          "description": "Apply minimization, spill, truncation, and UI safety caps to tool results.",
+          "description": "Apply runaway model-output guards plus minimization, spill, truncation, and UI safety caps to tool results.",
           "type": "boolean",
           "default": true,
           "category": "General",
+          "apply": "live"
+        },
+        {
+          "key": "modelOutputGuard.enabled",
+          "label": "Stop runaway model output",
+          "description": "Abort a streaming assistant response when it repeats the same substantial block too many times or exceeds the hard character budget.",
+          "type": "boolean",
+          "default": true,
+          "category": "Model Output Guard",
+          "apply": "live"
+        },
+        {
+          "key": "modelOutputGuard.maxChars",
+          "label": "Maximum streamed characters",
+          "description": "Hard fallback cap for one assistant response. Set 0 to disable the character cap while keeping repetition detection.",
+          "type": "number",
+          "default": 96000,
+          "category": "Model Output Guard",
+          "apply": "live"
+        },
+        {
+          "key": "modelOutputGuard.repetition.enabled",
+          "label": "Detect repeated output",
+          "description": "Enable consecutive substantial-block repetition detection independently from the hard character cap.",
+          "type": "boolean",
+          "default": true,
+          "category": "Model Output Guard",
+          "apply": "live"
+        },
+        {
+          "key": "modelOutputGuard.maxConsecutiveRepeats",
+          "label": "Maximum repeated blocks",
+          "description": "Abort after this many consecutive identical substantial lines, once the repeated-character floor is also reached.",
+          "type": "number",
+          "default": 24,
+          "category": "Model Output Guard",
+          "apply": "live"
+        },
+        {
+          "key": "modelOutputGuard.minRepeatBlockChars",
+          "label": "Minimum repeated block length",
+          "description": "Ignore shorter repeated lines for repetition streaks. They still count toward the hard response-size cap.",
+          "type": "number",
+          "default": 32,
+          "category": "Model Output Guard",
+          "apply": "live"
+        },
+        {
+          "key": "modelOutputGuard.minRepeatedChars",
+          "label": "Minimum repeated characters",
+          "description": "Require at least this much repeated text before aborting, reducing false positives on short intentional repetition.",
+          "type": "number",
+          "default": 1536,
+          "category": "Model Output Guard",
           "apply": "live"
         },
         {

--- a/pi-extensions/pi-output-policy/package.json
+++ b/pi-extensions/pi-output-policy/package.json
@@ -23,7 +23,7 @@
         {
           "key": "enabled",
           "label": "Enable output policy",
-          "description": "Apply runaway model-output guards plus minimization, spill, truncation, and UI safety caps to tool results.",
+          "description": "Apply runaway model-output guards plus minimization, spill, truncation, and UI safety caps to tool results. Guard changes take effect on the next assistant message.",
           "type": "boolean",
           "default": true,
           "category": "General",
@@ -32,7 +32,7 @@
         {
           "key": "modelOutputGuard.enabled",
           "label": "Stop runaway model output",
-          "description": "Abort a streaming assistant response when it repeats the same substantial block too many times or exceeds the hard character budget.",
+          "description": "Abort a streaming assistant response when it repeats the same substantial block too many times or exceeds the hard character budget. Changes take effect on the next assistant message.",
           "type": "boolean",
           "default": true,
           "category": "Model Output Guard",

--- a/pi-extensions/pi-output-policy/tests/output-policy.test.ts
+++ b/pi-extensions/pi-output-policy/tests/output-policy.test.ts
@@ -5,6 +5,8 @@ import { join } from "node:path";
 
 import outputPolicy, {
 	__resetSessionCountersForTests,
+	createModelOutputGuardState,
+	inspectModelOutputDelta,
 	isSanitizeExceptTool,
 	minimizeShellOutput,
 	processText,
@@ -29,6 +31,20 @@ function withConfig(config: Record<string, unknown>, run: (cwd: string) => void)
 	}
 }
 
+async function withConfigAsync(config: Record<string, unknown>, run: (cwd: string) => Promise<void>): Promise<void> {
+	const dir = mkdtempSync(join(tmpdir(), "pi-output-policy-test-"));
+	try {
+		mkdirSync(join(dir, ".pi"), { recursive: true });
+		writeFileSync(join(dir, ".pi", "settings.json"), JSON.stringify({
+			vstack: { extensionManager: { config: { [CONFIG_ID]: config } } },
+		}, null, 2));
+		recordProjectTrust({ cwd: dir, isProjectTrusted: () => true });
+		await run(dir);
+	} finally {
+		rmSync(dir, { force: true, recursive: true });
+	}
+}
+
 let testSeq = 0;
 function fakeCtx(cwd: string): any {
 	testSeq += 1;
@@ -45,6 +61,70 @@ function fakeCtx(cwd: string): any {
 
 beforeEach(() => {
 	__resetSessionCountersForTests();
+});
+
+describe("model output guard", () => {
+	const options = {
+		maxChars: 96_000,
+		maxConsecutiveRepeats: 24,
+		minRepeatBlockChars: 32,
+		minRepeatedChars: 1_536,
+	};
+
+	test("detects the DeepSeek-style repeated paragraph loop across stream chunks and short malformed tags", () => {
+		const state = createModelOutputGuardState();
+		const block = "Let me launch it in background and check config dirs after a few seconds.";
+		const spam = Array.from({ length: 40 }, () => `${block}\n</invoke>\n\n`).join("");
+		let detection;
+		for (let offset = 0; offset < spam.length && !detection; offset += 17) {
+			detection = inspectModelOutputDelta(state, spam.slice(offset, offset + 17), options);
+		}
+		expect(detection?.reason).toBe("repetition");
+		expect(detection?.consecutiveRepeats).toBe(24);
+		expect(detection?.totalChars ?? 0).toBeLessThan(spam.length);
+	});
+
+	test("does not flag varied output or repeated short syntax lines", () => {
+		const state = createModelOutputGuardState();
+		const varied = Array.from({ length: 100 }, (_, i) => `Useful distinct result ${i}: ${"x".repeat(40)}\n`).join("");
+		expect(inspectModelOutputDelta(state, varied, options)).toBeUndefined();
+		const shortState = createModelOutputGuardState();
+		expect(inspectModelOutputDelta(shortState, Array.from({ length: 100 }, () => "</invoke>\n").join(""), options)).toBeUndefined();
+	});
+
+	test("fires exactly at repetition count and repeated-character boundaries", () => {
+		const block = `Repeated substantial block ${"r".repeat(40)}`;
+		const blockChars = block.length;
+		const thresholdOptions = { ...options, maxConsecutiveRepeats: 3, minRepeatedChars: blockChars * 3 };
+		const state = createModelOutputGuardState();
+		expect(inspectModelOutputDelta(state, `${block}\n${block}\n`, thresholdOptions)).toBeUndefined();
+		expect(inspectModelOutputDelta(state, `${block}\n`, thresholdOptions)?.reason).toBe("repetition");
+
+		const charFloor = createModelOutputGuardState();
+		expect(inspectModelOutputDelta(charFloor, `${block}\n${block}\n${block}\n`, { ...thresholdOptions, minRepeatedChars: blockChars * 3 + 1 })).toBeUndefined();
+	});
+
+	test("minimum block length boundary and substantial different blocks reset streaks", () => {
+		const block = "b".repeat(32);
+		const boundaryOptions = { ...options, maxConsecutiveRepeats: 2, minRepeatedChars: 64, minRepeatBlockChars: 32 };
+		expect(inspectModelOutputDelta(createModelOutputGuardState(), `${"a".repeat(31)}\n${"a".repeat(31)}\n`, boundaryOptions)).toBeUndefined();
+		expect(inspectModelOutputDelta(createModelOutputGuardState(), `${block}\n${block}\n`, boundaryOptions)?.reason).toBe("repetition");
+
+		const interrupted = createModelOutputGuardState();
+		const different = `Different substantial block ${"d".repeat(40)}`;
+		expect(inspectModelOutputDelta(interrupted, `${block}\n${different}\n${block}\n`, boundaryOptions)).toBeUndefined();
+	});
+
+	test("hard character cap fires at exact boundary, zero disables it, and repetition can be disabled", () => {
+		const below = createModelOutputGuardState();
+		expect(inspectModelOutputDelta(below, "x".repeat(899), { ...options, maxChars: 900 })).toBeUndefined();
+		expect(inspectModelOutputDelta(below, "x", { ...options, maxChars: 900 })).toEqual({ reason: "max-chars", totalChars: 900 });
+		const uncapped = createModelOutputGuardState();
+		expect(inspectModelOutputDelta(uncapped, "x".repeat(100_000), { ...options, maxChars: 0 })).toBeUndefined();
+		const repetitionOff = createModelOutputGuardState();
+		const repeated = Array.from({ length: 100 }, () => `${"repeat ".repeat(10)}\n`).join("");
+		expect(inspectModelOutputDelta(repetitionOff, repeated, { ...options, maxChars: 0, repetitionEnabled: false })).toBeUndefined();
+	});
 });
 
 describe("shell minimizer", () => {
@@ -317,6 +397,121 @@ function createFakePi(): FakePi {
 		},
 	};
 }
+
+describe("model output guard handler", () => {
+	function guardCtx(cwd: string, notify: (message: string) => void = () => {}) {
+		let aborts = 0;
+		return {
+			ctx: {
+				...fakeCtx(cwd),
+				abort: () => { aborts += 1; },
+				ui: { notify },
+			},
+			aborts: () => aborts,
+		};
+	}
+
+	test("aborts once and warns when streamed assistant text degenerates", async () => {
+		await withConfigAsync({
+			"modelOutputGuard.maxConsecutiveRepeats": 3,
+			"modelOutputGuard.minRepeatedChars": 90,
+		}, async (cwd) => {
+			const fake = createFakePi();
+			outputPolicy(fake.pi);
+			const notices: string[] = [];
+			const guard = guardCtx(cwd, (message) => notices.push(message));
+			const delta = Array.from({ length: 8 }, () => `${"repeat me ".repeat(5)}\n`).join("");
+			await fake.fire("message_update", { assistantMessageEvent: { type: "text_delta", delta } }, guard.ctx);
+			await fake.fire("message_update", { assistantMessageEvent: { type: "text_delta", delta } }, guard.ctx);
+			expect(guard.aborts()).toBe(1);
+			expect(notices).toHaveLength(1);
+			expect(notices[0]).toContain("Model output stopped");
+		});
+	});
+
+	test("counts thinking and tool-call argument deltas toward the hard cap", async () => {
+		for (const type of ["thinking_delta", "toolcall_delta"]) {
+			await withConfigAsync({ "modelOutputGuard.maxChars": 100 }, async (cwd) => {
+				const fake = createFakePi();
+				outputPolicy(fake.pi);
+				const guard = guardCtx(cwd);
+				await fake.fire("message_update", { assistantMessageEvent: { type, delta: "x".repeat(100) } }, guard.ctx);
+				expect(guard.aborts()).toBe(1);
+			});
+		}
+	});
+
+	test("notification failures cannot prevent abort", async () => {
+		await withConfigAsync({ "modelOutputGuard.maxChars": 100 }, async (cwd) => {
+			const fake = createFakePi();
+			outputPolicy(fake.pi);
+			const guard = guardCtx(cwd, () => { throw new Error("no UI"); });
+			await fake.fire("message_update", { assistantMessageEvent: { type: "text_delta", delta: "x".repeat(101) } }, guard.ctx);
+			expect(guard.aborts()).toBe(1);
+		});
+	});
+
+	test("all lifecycle resets clear partial streaks and re-arm after abort", async () => {
+		await withConfigAsync({
+			"modelOutputGuard.maxConsecutiveRepeats": 3,
+			"modelOutputGuard.minRepeatedChars": 90,
+		}, async (cwd) => {
+			const cases = [
+				["message_start", { message: { role: "assistant" } }],
+				["turn_start", { turnIndex: 1 }],
+				["session_start", { reason: "new" }],
+				["session_shutdown", { reason: "quit" }],
+			] as const;
+			for (const [resetEvent, payload] of cases) {
+				const fake = createFakePi();
+				outputPolicy(fake.pi);
+				const guard = guardCtx(cwd);
+				const block = `${"repeat me ".repeat(5)}\n`;
+				await fake.fire("message_update", { assistantMessageEvent: { type: "text_delta", delta: block.repeat(2) } }, guard.ctx);
+				await fake.fire(resetEvent, payload, guard.ctx);
+				await fake.fire("message_update", { assistantMessageEvent: { type: "text_delta", delta: block.repeat(2) } }, guard.ctx);
+				expect(guard.aborts()).toBe(0);
+			}
+
+			const fake = createFakePi();
+			outputPolicy(fake.pi);
+			const guard = guardCtx(cwd);
+			const spam = `${"repeat me ".repeat(5)}\n`.repeat(3);
+			await fake.fire("message_update", { assistantMessageEvent: { type: "text_delta", delta: spam } }, guard.ctx);
+			expect(guard.aborts()).toBe(1);
+			await fake.fire("message_start", { message: { role: "assistant" } }, guard.ctx);
+			await fake.fire("message_update", { assistantMessageEvent: { type: "text_delta", delta: spam } }, guard.ctx);
+			expect(guard.aborts()).toBe(2);
+		});
+	});
+
+	test("repetition can be disabled while the hard cap remains active", async () => {
+		await withConfigAsync({
+			"modelOutputGuard.maxChars": 500,
+			"modelOutputGuard.repetition.enabled": false,
+		}, async (cwd) => {
+			const fake = createFakePi();
+			outputPolicy(fake.pi);
+			const guard = guardCtx(cwd);
+			const block = `${"repeat me ".repeat(5)}\n`;
+			await fake.fire("message_update", { assistantMessageEvent: { type: "text_delta", delta: block.repeat(8) } }, guard.ctx);
+			expect(guard.aborts()).toBe(0);
+			await fake.fire("message_update", { assistantMessageEvent: { type: "text_delta", delta: "x".repeat(500) } }, guard.ctx);
+			expect(guard.aborts()).toBe(1);
+		});
+	});
+
+	test("can be disabled independently from tool output policy", async () => {
+		await withConfigAsync({ "modelOutputGuard.enabled": false }, async (cwd) => {
+			const fake = createFakePi();
+			outputPolicy(fake.pi);
+			const guard = guardCtx(cwd);
+			const delta = Array.from({ length: 100 }, () => `${"repeat me ".repeat(5)}\n`).join("");
+			await fake.fire("message_update", { assistantMessageEvent: { type: "text_delta", delta } }, guard.ctx);
+			expect(guard.aborts()).toBe(0);
+		});
+	});
+});
 
 describe("tool_result handler (default-on sanitization & metadata)", () => {
 	test("oversized non-allowlisted details are sanitized and carry a marker", async () => {

--- a/pi-extensions/pi-output-policy/tests/output-policy.test.ts
+++ b/pi-extensions/pi-output-policy/tests/output-policy.test.ts
@@ -93,6 +93,47 @@ describe("model output guard", () => {
 		expect(inspectModelOutputDelta(shortState, Array.from({ length: 100 }, () => "</invoke>\n").join(""), options)).toBeUndefined();
 	});
 
+	test("distinct short semantic lines reset a repeated substantial heading across arbitrary chunks", () => {
+		const state = createModelOutputGuardState();
+		const heading = `Repeated report heading ${"h".repeat(48)}`;
+		const report = Array.from({ length: 40 }, (_, i) => `${heading}\nvalue ${i}\n`).join("");
+		let detection;
+		for (let offset = 0; offset < report.length && !detection; offset += 11) {
+			detection = inspectModelOutputDelta(state, report.slice(offset, offset + 11), options);
+		}
+		expect(heading.length * 24).toBeGreaterThanOrEqual(options.minRepeatedChars);
+		expect(detection).toBeUndefined();
+		expect(state.lastBlock).toBeUndefined();
+		expect(state.consecutiveRepeats).toBe(0);
+		expect(state.repeatedChars).toBe(0);
+	});
+
+	test("blank and recognized syntax-only lines preserve a substantial repetition streak", () => {
+		const block = `Repeated substantial block ${"r".repeat(40)}`;
+		const syntaxOptions = {
+			...options,
+			maxConsecutiveRepeats: 3,
+			minRepeatedChars: block.length * 3,
+		};
+		const state = createModelOutputGuardState();
+		const output = `${block}\n\n</invoke>\n\`\`\`ts\n---\n${"-".repeat(80)}\n${block}\n<parameter name="path-to-a-long-tool-argument">\n~~~\n${block}\n`;
+		expect(inspectModelOutputDelta(state, output, syntaxOptions)?.reason).toBe("repetition");
+	});
+
+	test("short semantic content breaks a substantial repetition streak", () => {
+		const block = `Repeated substantial block ${"r".repeat(40)}`;
+		const semanticOptions = {
+			...options,
+			maxConsecutiveRepeats: 3,
+			minRepeatedChars: block.length * 3,
+		};
+		const state = createModelOutputGuardState();
+		expect(inspectModelOutputDelta(state, `${block}\n${block}\nOK\n${block}\n`, semanticOptions)).toBeUndefined();
+		expect(state.lastBlock).toBe(block);
+		expect(state.consecutiveRepeats).toBe(1);
+		expect(state.repeatedChars).toBe(block.length);
+	});
+
 	test("fires exactly at repetition count and repeated-character boundaries", () => {
 		const block = `Repeated substantial block ${"r".repeat(40)}`;
 		const blockChars = block.length;
@@ -505,7 +546,23 @@ describe("model output guard handler", () => {
 		});
 	});
 
-	test("lazy fallback snapshots once when message_start is unavailable", async () => {
+	test("message_start prevents the hard cap from carrying across assistant messages", async () => {
+		await withConfigAsync({ "modelOutputGuard.maxChars": 100 }, async (cwd) => {
+			const fake = createFakePi();
+			outputPolicy(fake.pi);
+			const guard = guardCtx(cwd);
+			await fake.fire("message_start", { message: { role: "assistant" } }, guard.ctx);
+			await fake.fire("message_update", { assistantMessageEvent: { type: "text_delta", delta: "x".repeat(60) } }, guard.ctx);
+			expect(guard.aborts()).toBe(0);
+			await fake.fire("message_start", { message: { role: "assistant" } }, guard.ctx);
+			await fake.fire("message_update", { assistantMessageEvent: { type: "text_delta", delta: "x".repeat(60) } }, guard.ctx);
+			expect(guard.aborts()).toBe(0);
+			await fake.fire("message_update", { assistantMessageEvent: { type: "text_delta", delta: "x".repeat(40) } }, guard.ctx);
+			expect(guard.aborts()).toBe(1);
+		});
+	});
+
+	test("lazy snapshot supports isolated direct event injection without boundary inference", async () => {
 		await withConfigAsync({ "modelOutputGuard.maxChars": 100 }, async (cwd) => {
 			const fake = createFakePi();
 			outputPolicy(fake.pi);
@@ -517,7 +574,7 @@ describe("model output guard handler", () => {
 		});
 	});
 
-	test("session runtime instances keep independent guard state", async () => {
+	test("separate session runtime closures isolate stream state and lifecycle resets", async () => {
 		await withConfigAsync({
 			"modelOutputGuard.maxConsecutiveRepeats": 3,
 			"modelOutputGuard.minRepeatedChars": 90,
@@ -531,6 +588,7 @@ describe("model output guard handler", () => {
 			const block = `${"repeat me ".repeat(5)}\n`;
 			await firstPi.fire("message_update", { assistantMessageEvent: { type: "text_delta", delta: block.repeat(2) } }, first.ctx);
 			await secondPi.fire("message_update", { assistantMessageEvent: { type: "text_delta", delta: block } }, second.ctx);
+			await secondPi.fire("session_start", { reason: "resume" }, second.ctx);
 			expect(first.aborts()).toBe(0);
 			expect(second.aborts()).toBe(0);
 			await firstPi.fire("message_update", { assistantMessageEvent: { type: "text_delta", delta: block } }, first.ctx);

--- a/pi-extensions/pi-output-policy/tests/output-policy.test.ts
+++ b/pi-extensions/pi-output-policy/tests/output-policy.test.ts
@@ -120,6 +120,35 @@ describe("model output guard", () => {
 		expect(inspectModelOutputDelta(state, output, syntaxOptions)?.reason).toBe("repetition");
 	});
 
+	test("CommonMark fences with spaced info strings preserve a substantial repetition streak", () => {
+		const block = `Repeated substantial block ${"r".repeat(40)}`;
+		const fenceOptions = {
+			...options,
+			maxConsecutiveRepeats: 3,
+			minRepeatedChars: block.length * 3,
+		};
+		for (const fence of ["``` ts", "~~~ shell session"]) {
+			const state = createModelOutputGuardState();
+			const output = `${block}\n${fence}\n${block}\n${fence}\n${block}\n`;
+			expect(inspectModelOutputDelta(state, output, fenceOptions)?.reason).toBe("repetition");
+		}
+	});
+
+	test("fence-like semantic content and invalid backtick info reset a repetition streak", () => {
+		const block = `Repeated substantial block ${"r".repeat(40)}`;
+		const fenceOptions = {
+			...options,
+			maxConsecutiveRepeats: 3,
+			minRepeatedChars: block.length * 3,
+		};
+		for (const line of ["note: ``` ts", "    ``` ts", "``` ts `invalid`"]) {
+			const state = createModelOutputGuardState();
+			const output = `${block}\n${block}\n${line}\n${block}\n`;
+			expect(inspectModelOutputDelta(state, output, fenceOptions)).toBeUndefined();
+			expect(state.consecutiveRepeats).toBe(1);
+		}
+	});
+
 	test("short semantic content breaks a substantial repetition streak", () => {
 		const block = `Repeated substantial block ${"r".repeat(40)}`;
 		const semanticOptions = {

--- a/pi-extensions/pi-output-policy/tests/output-policy.test.ts
+++ b/pi-extensions/pi-output-policy/tests/output-policy.test.ts
@@ -17,13 +17,17 @@ import outputPolicy, {
 
 const CONFIG_ID = "@vanillagreen/pi-output-policy";
 
+function writeConfig(cwd: string, config: Record<string, unknown>): void {
+	mkdirSync(join(cwd, ".pi"), { recursive: true });
+	writeFileSync(join(cwd, ".pi", "settings.json"), JSON.stringify({
+		vstack: { extensionManager: { config: { [CONFIG_ID]: config } } },
+	}, null, 2));
+}
+
 function withConfig(config: Record<string, unknown>, run: (cwd: string) => void): void {
 	const dir = mkdtempSync(join(tmpdir(), "pi-output-policy-test-"));
 	try {
-		mkdirSync(join(dir, ".pi"), { recursive: true });
-		writeFileSync(join(dir, ".pi", "settings.json"), JSON.stringify({
-			vstack: { extensionManager: { config: { [CONFIG_ID]: config } } },
-		}, null, 2));
+		writeConfig(dir, config);
 		recordProjectTrust({ cwd: dir, isProjectTrusted: () => true });
 		run(dir);
 	} finally {
@@ -34,10 +38,7 @@ function withConfig(config: Record<string, unknown>, run: (cwd: string) => void)
 async function withConfigAsync(config: Record<string, unknown>, run: (cwd: string) => Promise<void>): Promise<void> {
 	const dir = mkdtempSync(join(tmpdir(), "pi-output-policy-test-"));
 	try {
-		mkdirSync(join(dir, ".pi"), { recursive: true });
-		writeFileSync(join(dir, ".pi", "settings.json"), JSON.stringify({
-			vstack: { extensionManager: { config: { [CONFIG_ID]: config } } },
-		}, null, 2));
+		writeConfig(dir, config);
 		recordProjectTrust({ cwd: dir, isProjectTrusted: () => true });
 		await run(dir);
 	} finally {
@@ -482,6 +483,59 @@ describe("model output guard handler", () => {
 			await fake.fire("message_start", { message: { role: "assistant" } }, guard.ctx);
 			await fake.fire("message_update", { assistantMessageEvent: { type: "text_delta", delta: spam } }, guard.ctx);
 			expect(guard.aborts()).toBe(2);
+		});
+	});
+
+	test("snapshots settings once per assistant message and refreshes on the next message", async () => {
+		await withConfigAsync({ "modelOutputGuard.maxChars": 100 }, async (cwd) => {
+			const fake = createFakePi();
+			outputPolicy(fake.pi);
+			const guard = guardCtx(cwd);
+			await fake.fire("message_start", { message: { role: "assistant" } }, guard.ctx);
+			writeConfig(cwd, { "modelOutputGuard.maxChars": 200 });
+			await fake.fire("message_update", { assistantMessageEvent: { type: "text_delta", delta: "x".repeat(60) } }, guard.ctx);
+			await fake.fire("message_update", { assistantMessageEvent: { type: "text_delta", delta: "x".repeat(40) } }, guard.ctx);
+			expect(guard.aborts()).toBe(1);
+
+			await fake.fire("message_start", { message: { role: "assistant" } }, guard.ctx);
+			await fake.fire("message_update", { assistantMessageEvent: { type: "text_delta", delta: "x".repeat(100) } }, guard.ctx);
+			expect(guard.aborts()).toBe(1);
+			await fake.fire("message_update", { assistantMessageEvent: { type: "text_delta", delta: "x".repeat(100) } }, guard.ctx);
+			expect(guard.aborts()).toBe(2);
+		});
+	});
+
+	test("lazy fallback snapshots once when message_start is unavailable", async () => {
+		await withConfigAsync({ "modelOutputGuard.maxChars": 100 }, async (cwd) => {
+			const fake = createFakePi();
+			outputPolicy(fake.pi);
+			const guard = guardCtx(cwd);
+			await fake.fire("message_update", { assistantMessageEvent: { type: "text_delta", delta: "x".repeat(60) } }, guard.ctx);
+			writeConfig(cwd, { "modelOutputGuard.maxChars": 200 });
+			await fake.fire("message_update", { assistantMessageEvent: { type: "text_delta", delta: "x".repeat(40) } }, guard.ctx);
+			expect(guard.aborts()).toBe(1);
+		});
+	});
+
+	test("session runtime instances keep independent guard state", async () => {
+		await withConfigAsync({
+			"modelOutputGuard.maxConsecutiveRepeats": 3,
+			"modelOutputGuard.minRepeatedChars": 90,
+		}, async (cwd) => {
+			const firstPi = createFakePi();
+			const secondPi = createFakePi();
+			outputPolicy(firstPi.pi);
+			outputPolicy(secondPi.pi);
+			const first = guardCtx(cwd);
+			const second = guardCtx(cwd);
+			const block = `${"repeat me ".repeat(5)}\n`;
+			await firstPi.fire("message_update", { assistantMessageEvent: { type: "text_delta", delta: block.repeat(2) } }, first.ctx);
+			await secondPi.fire("message_update", { assistantMessageEvent: { type: "text_delta", delta: block } }, second.ctx);
+			expect(first.aborts()).toBe(0);
+			expect(second.aborts()).toBe(0);
+			await firstPi.fire("message_update", { assistantMessageEvent: { type: "text_delta", delta: block } }, first.ctx);
+			expect(first.aborts()).toBe(1);
+			expect(second.aborts()).toBe(0);
 		});
 	});
 


### PR DESCRIPTION
Closes #1253

## What changed

- add default-on streaming guard for repetitive or oversized assistant output
- count text, thinking, and tool-call argument deltas
- expose independent master, repetition, and character-cap controls
- add captured-session regression coverage and run package suite in CI
- bump `@vanillagreen/pi-output-policy` to 1.2.0 with README/changelog updates

## Diagnosis

Existing Output Policy did not cause the failure: it intercepted `tool_result` only. DeepSeek V4 Flash returned degenerate assistant streams through Vercel AI Gateway, and stock Pi 0.84.1 has no live assistant repetition/size circuit breaker. The model catalog permits up to 384K output tokens.

## Validation

- `bun test ./tests` — 40/40 pass
- stability — 10/10 at concurrency 40 (reviewer validation)
- replayed captured session spam — guard trips at 3,700 chars and 10,027 chars instead of 73K/230K
- live Pi 0.84.1 + Vercel DeepSeek print-mode probe — response aborted by extension
- `git diff --check`
- Node strip-only syntax checks for changed TypeScript
- `actionlint`
- correctness and test specialist reviews — pass

Known unrelated failure: repo-wide `pi-extensions/package-policy.test.mjs` currently fails on pre-existing `pi-claude-bridge/src/account-router.ts` constructor parameter-property parsing, tracked in #1244.
