### PR TITLE
fix(orch): post-merge sync proves which checkout owns the base branch before advancing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 ## Unreleased
 
+- **orch: the post-merge main sync proves which checkout owns the base branch
+  before advancing it, and reports a stale base as a warning.** `merge-pr.md`
+  § 5 step 4 ran `git -C [MAIN_REPO_ROOT] merge --ff-only origin/[BASE]`
+  unconditionally. `merge --ff-only` advances whatever branch the target
+  checkout has on `HEAD`, so a main checkout parked on a foreign branch got
+  THAT branch fast-forwarded, exited 0, and left local `[BASE]` untouched with
+  nothing reported — in one observed session the main checkout drifted 30
+  commits behind `origin/main` across four merges, a branch cut from it needed
+  a mid-flight rebase and full revalidation, two review agents produced false
+  findings from the stale tree (one filed issue needed a correction pass), and
+  a ten-reviewer fleet ran retired agent definitions including one `main` had
+  deleted. The step now reads `rev-parse --abbrev-ref HEAD` first and routes:
+  on the base branch it ff-merges in place; on any other branch (or detached
+  `HEAD`) it advances the local ref by name with
+  `fetch origin "[BASE]:[BASE]"`, which updates a non-checked-out branch and
+  refuses a non-fast-forward; when that refspec is refused because another
+  worktree holds the branch, it locates that worktree via `worktree list` and
+  ff-merges there. Three named blocking outcomes replace the old
+  "surface the divergence" note — a merge-blocking dirty tree (naming every
+  file git listed and its checkout), a non-fast-forward rejection (naming both
+  shas), and an unreachable base — and § 7 now always carries a `Base sync`
+  row, a WARNING with the stale local sha, the origin sha, and the cause
+  whenever local `[BASE]` could not be advanced. `start-worktree.md`'s existing
+  `base-freshness` gate needed no new machinery — it is reached by every
+  `start.md` § 5 route, and bare `worktree create` already cuts new branches
+  from a freshly fetched `origin/<default>` — so its wording was corrected to
+  stop reading as reuse-only. `workflow_helpers.sh` pins the precondition, both
+  non-ff-merge routes, the blocking dirty report, and the § 7 warning; the
+  retired sentence is pinned absent.
+
 - **reviewer: ground-up rewrite driven by 24-PR escape mining; new
   `preflight` skill; `reviewer-structure` retired.** A survey of the last 6
   PRs in each of four consuming repos classified every bug that escaped

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,10 @@
   deleted. The step now reads `rev-parse --abbrev-ref HEAD` first and routes:
   on the base branch it ff-merges in place; on any other branch (or detached
   `HEAD`) it advances the local ref by name with
-  `fetch origin "[BASE]:[BASE]"`, which updates a non-checked-out branch and
-  refuses a non-fast-forward; when that refspec is refused because another
+  `fetch . "refs/remotes/origin/[BASE]:refs/heads/[BASE]"`, which re-uses the
+  tracking ref the origin fetch already updated — no second network round trip
+  and no credential helper — while updating a non-checked-out branch and
+  refusing a non-fast-forward; when that refspec is refused because another
   worktree holds the branch, it locates that worktree via `worktree list` and
   ff-merges there. Three named blocking outcomes replace the old
   "surface the divergence" note — a merge-blocking dirty tree (naming every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 - **orch: the post-merge main sync proves which checkout owns the base branch
   before advancing it, and reports a stale base as a warning.** `merge-pr.md`
-  § 5 step 4 ran `git -C [MAIN_REPO_ROOT] merge --ff-only origin/[BASE]`
+  § 5 step 4 ran `git -C [MAIN_REPO_ROOT] merge --ff-only origin/[BASE_BRANCH]`
   unconditionally. `merge --ff-only` advances whatever branch the target
   checkout has on `HEAD`, so a main checkout parked on a foreign branch got
-  THAT branch fast-forwarded, exited 0, and left local `[BASE]` untouched with
-  nothing reported — in one observed session the main checkout drifted 30
+  THAT branch fast-forwarded, exited 0, and left local `[BASE_BRANCH]`
+  untouched with nothing reported — in one observed session the main checkout drifted 30
   commits behind `origin/main` across four merges, a branch cut from it needed
   a mid-flight rebase and full revalidation, two review agents produced false
   findings from the stale tree (one filed issue needed a correction pass), and
@@ -16,9 +16,10 @@
   deleted. The step now reads `rev-parse --abbrev-ref HEAD` first and routes:
   on the base branch it ff-merges in place; on any other branch (or detached
   `HEAD`) it advances the local ref by name with
-  `fetch . "refs/remotes/origin/[BASE]:refs/heads/[BASE]"`, which re-uses the
-  tracking ref the origin fetch already updated — no second network round trip
-  and no credential helper — while updating a non-checked-out branch and
+  `git -C [MAIN_REPO_ROOT] fetch .
+  "refs/remotes/origin/[BASE_BRANCH]:refs/heads/[BASE_BRANCH]"`, which re-uses
+  the tracking ref the origin fetch already updated — no second network round
+  trip and no credential helper — while updating a non-checked-out branch and
   refusing a non-fast-forward; when that refspec is refused because another
   worktree holds the branch, it locates that worktree via `worktree list` and
   ff-merges there. Three named blocking outcomes replace the old
@@ -26,8 +27,8 @@
   file git listed and its checkout), a non-fast-forward rejection (naming both
   shas), and an unreachable base — and § 7 now always carries a `Base sync`
   row, a WARNING with the stale local sha, the origin sha, and the cause
-  whenever local `[BASE]` could not be advanced. `start-worktree.md`'s existing
-  `base-freshness` gate needed no new machinery — it is reached by every
+  whenever local `[BASE_BRANCH]` could not be advanced. `start-worktree.md`'s
+  existing `base-freshness` gate needed no new machinery — it is reached by every
   `start.md` § 5 route, and bare `worktree create` already cuts new branches
   from a freshly fetched `origin/<default>` — so its wording was corrected to
   stop reading as reuse-only. `workflow_helpers.sh` pins the precondition, both

--- a/skills/orch/tests/workflow_helpers.sh
+++ b/skills/orch/tests/workflow_helpers.sh
@@ -292,12 +292,14 @@ assert_file_contains "$merge_workflow" 'git -C [MAIN_REPO_ROOT] merge --ff-only 
 # routes, the blocking dirty outcome, and the § 7 stale WARNING are pinned.
 assert_file_contains "$merge_workflow" 'git -C [MAIN_REPO_ROOT] rev-parse --abbrev-ref HEAD' "merge-pr sync resolves the main checkout's HEAD branch before advancing the base"
 assert_file_contains "$merge_workflow" 'Use the output as `MAIN_HEAD_BRANCH` and route on it' "merge-pr sync routes on MAIN_HEAD_BRANCH instead of ff-merging unconditionally"
-assert_file_contains "$merge_workflow" 'git -C [MAIN_REPO_ROOT] fetch origin "[BASE_BRANCH]:[BASE_BRANCH]"' "merge-pr sync advances a non-checked-out base by name with a refusing refspec"
+assert_file_contains "$merge_workflow" 'git -C [MAIN_REPO_ROOT] fetch . "refs/remotes/origin/[BASE_BRANCH]:refs/heads/[BASE_BRANCH]"' "merge-pr sync advances a non-checked-out base by name from the already-fetched tracking ref, with a refusing refspec"
 assert_file_contains "$merge_workflow" 'refusing to fetch into branch ... checked out at ...' "merge-pr sync routes the by-name fetch refusal to the worktree owning the base branch"
 assert_file_contains "$merge_workflow" 'git -C [BASE_WORKTREE] merge --ff-only "origin/[BASE_BRANCH]"' "merge-pr sync fast-forwards the base in its own worktree"
 assert_file_contains "$merge_workflow" '**Blocking** post-merge condition naming every file git listed' "merge-pr reports a merge-blocking dirty tree as blocking, naming the files"
+assert_file_contains "$merge_workflow" 'the in-place ff-merge, the by-name update, or the `[BASE_WORKTREE]` ff-merge — is rejected as non-fast-forward' "merge-pr treats a non-fast-forward as blocking on every update route, not only the by-name one"
 assert_file_contains "$merge_workflow" 'The `Base sync` row is never omitted' "merge-pr § 7 always reports the base sync outcome"
 assert_file_contains "$merge_workflow" '⚠️ local [BASE_BRANCH] STALE at' "merge-pr § 7 warns with the stale local base sha when the sync could not advance it"
+assert_file_contains "$merge_workflow" '`⚠️ local [BASE_BRANCH] STALE at [LOCAL_SHA] (origin/[BASE_BRANCH] at [ORIGIN_SHA]) — [CAUSE]`' "merge-pr batch shape names both shas in the stale-base warning, matching the single-PR shape"
 assert_file_not_contains "$merge_workflow" 'divergence for manual handling' "merge-pr replaces the informational sync-failure note with defined blocking outcomes"
 
 # start-worktree's base-freshness gate is reached by every start.md § 5 route,

--- a/skills/orch/tests/workflow_helpers.sh
+++ b/skills/orch/tests/workflow_helpers.sh
@@ -284,7 +284,27 @@ assert_file_contains "$merge_workflow" 'Treat `CHECK.transient` as the' "merge-p
 assert_file_contains "$merge_workflow" '.agents/skills/orch/scripts/ci-wait [PR_NUMBER] 15 600' "merge-pr uses bounded CI wait for pending checks"
 assert_file_contains "$merge_workflow" 'Do not repeat § 3.1 indefinitely' "merge-pr forbids unbounded transient wait loops"
 assert_file_contains "$merge_workflow" 'git-https-auth -C [MAIN_REPO_ROOT] fetch --prune origin "+refs/heads/[BASE_BRANCH]:refs/remotes/origin/[BASE_BRANCH]"' "merge-pr sync fetches explicit origin base branch through HTTPS auth helper"
-assert_file_contains "$merge_workflow" 'git -C [MAIN_REPO_ROOT] merge --ff-only "origin/[BASE_BRANCH]"' "merge-pr sync fast-forwards to quoted fetched origin base branch with plain git"
+assert_file_contains "$merge_workflow" 'git -C [MAIN_REPO_ROOT] merge --ff-only "origin/[BASE_BRANCH]"' "merge-pr sync fast-forwards in place with plain git when the main checkout is on the base branch"
+
+# The post-merge sync must prove WHICH branch the ff-merge would advance before
+# running it: on a foreign HEAD the merge succeeds against that branch and local
+# base stays stale with nothing reported. Precondition, both non-ff-merge
+# routes, the blocking dirty outcome, and the § 7 stale WARNING are pinned.
+assert_file_contains "$merge_workflow" 'git -C [MAIN_REPO_ROOT] rev-parse --abbrev-ref HEAD' "merge-pr sync resolves the main checkout's HEAD branch before advancing the base"
+assert_file_contains "$merge_workflow" 'Use the output as `MAIN_HEAD_BRANCH` and route on it' "merge-pr sync routes on MAIN_HEAD_BRANCH instead of ff-merging unconditionally"
+assert_file_contains "$merge_workflow" 'git -C [MAIN_REPO_ROOT] fetch origin "[BASE_BRANCH]:[BASE_BRANCH]"' "merge-pr sync advances a non-checked-out base by name with a refusing refspec"
+assert_file_contains "$merge_workflow" 'refusing to fetch into branch ... checked out at ...' "merge-pr sync routes the by-name fetch refusal to the worktree owning the base branch"
+assert_file_contains "$merge_workflow" 'git -C [BASE_WORKTREE] merge --ff-only "origin/[BASE_BRANCH]"' "merge-pr sync fast-forwards the base in its own worktree"
+assert_file_contains "$merge_workflow" '**Blocking** post-merge condition naming every file git listed' "merge-pr reports a merge-blocking dirty tree as blocking, naming the files"
+assert_file_contains "$merge_workflow" 'The `Base sync` row is never omitted' "merge-pr § 7 always reports the base sync outcome"
+assert_file_contains "$merge_workflow" '⚠️ local [BASE_BRANCH] STALE at' "merge-pr § 7 warns with the stale local base sha when the sync could not advance it"
+assert_file_not_contains "$merge_workflow" 'divergence for manual handling' "merge-pr replaces the informational sync-failure note with defined blocking outcomes"
+
+# start-worktree's base-freshness gate is reached by every start.md § 5 route,
+# so it must not read as reuse-only.
+start_worktree_workflow="$REPO_ROOT/skills/orch/workflows/start-worktree.md"
+assert_file_contains "$start_worktree_workflow" '.agents/skills/orch/scripts/base-freshness [WORKTREE_PATH]' "start-worktree gates on the base-freshness script"
+assert_file_contains "$start_worktree_workflow" 'a worktree just created in `start.md` § 4 and one reused from an earlier session' "start-worktree's freshness gate covers freshly created worktrees, not only reused ones"
 assert_file_not_contains "$merge_workflow" 'branch -D "$PR_BRANCH"' "merge-pr § 5a no longer force-deletes the PR branch unconditionally"
 assert_file_contains "$merge_workflow" 'branch refs/heads/[PR_BRANCH]' "merge-pr § 5a guards branch delete against worktree checkout"
 assert_file_contains "$merge_workflow" 'a GitHub-native approval verdict is required' "merge-pr treats not_approved as a merge gate in approval mode"

--- a/skills/orch/workflows/merge-pr.md
+++ b/skills/orch/workflows/merge-pr.md
@@ -391,9 +391,9 @@ merge. Detach them first.
    | `MAIN_HEAD_BRANCH` | Action |
    |--------------------|--------|
    | `[BASE_BRANCH]` | Advance in place: `git -C [MAIN_REPO_ROOT] merge --ff-only "origin/[BASE_BRANCH]"` |
-   | Any other branch, or `HEAD` (detached) | Do NOT ff-merge — advance the local ref by name instead: `git -C [MAIN_REPO_ROOT] fetch origin "[BASE_BRANCH]:[BASE_BRANCH]"`. That refspec form updates a branch no checkout has on `HEAD` and REFUSES a non-fast-forward, which is exactly the wanted semantics. |
+   | Any other branch, or `HEAD` (detached) | Do NOT ff-merge — advance the local ref by name instead: `git -C [MAIN_REPO_ROOT] fetch . "refs/remotes/origin/[BASE_BRANCH]:refs/heads/[BASE_BRANCH]"`. Fetching from `.` re-uses the tracking ref the origin fetch above already updated, so it needs no second network round trip and no credential helper; the refspec form updates a branch no checkout has on `HEAD` and REFUSES a non-fast-forward, which is exactly the wanted semantics. |
 
-   The by-name fetch fails when `[BASE_BRANCH]` is checked out in another
+   The by-name update fails when `[BASE_BRANCH]` is checked out in another
    worktree (`refusing to fetch into branch ... checked out at ...`). That is
    not a stale outcome — locate that worktree and advance it there:
    ```bash
@@ -413,9 +413,9 @@ merge. Detach them first.
 
    | Outcome | Report |
    |---------|--------|
-   | The ff-merge refuses on uncommitted changes (`Your local changes to the following files would be overwritten by merge`) | **Blocking** post-merge condition naming every file git listed and the checkout it sits in — not an informational note |
-   | The by-name fetch is rejected as non-fast-forward | **Blocking** — local `[BASE_BRANCH]` has diverged from `origin/[BASE_BRANCH]`; name both shas |
-   | `[BASE_BRANCH]` is checked out in no reachable worktree and the by-name fetch failed for any other reason | **Blocking** — name the sha `origin/[BASE_BRANCH]` now points at and the git error |
+   | Either ff-merge refuses on uncommitted changes (`Your local changes to the following files would be overwritten by merge`) | **Blocking** post-merge condition naming every file git listed and the checkout it sits in — not an informational note |
+   | Any of the three updates — the in-place ff-merge, the by-name update, or the `[BASE_WORKTREE]` ff-merge — is rejected as non-fast-forward | **Blocking** — local `[BASE_BRANCH]` has diverged from `origin/[BASE_BRANCH]`; name both shas |
+   | `[BASE_BRANCH]` is checked out in no reachable worktree and the by-name update failed for any other reason | **Blocking** — name the sha `origin/[BASE_BRANCH]` now points at and the git error |
 
    **Report the result in § 7 either way.** When local `[BASE_BRANCH]` advanced,
    § 7 records the new sha. When it could NOT be advanced, § 7 must carry a
@@ -545,8 +545,8 @@ error). Report it the same way in the batch shape below.
 | ⏭️ | #[P] | [ISSUE_ID] - [TITLE] | Review threads |
 | ❌ | #[Q] | [ISSUE_ID] - [TITLE] | Merge conflicts |
 
-Total: [N] PRs merged | Base sync: local `[BASE_BRANCH]` → [NEW_SHA]
-(or `⚠️ local [BASE_BRANCH] STALE at [LOCAL_SHA] — [CAUSE]`)
+Total: [N] PRs merged | Base sync: local `[BASE_BRANCH]` → [NEW_SHA], or
+`⚠️ local [BASE_BRANCH] STALE at [LOCAL_SHA] (origin/[BASE_BRANCH] at [ORIGIN_SHA]) — [CAUSE]`
 
 ### 🧹 STALE CLEANUP
 

--- a/skills/orch/workflows/merge-pr.md
+++ b/skills/orch/workflows/merge-pr.md
@@ -367,20 +367,62 @@ merge. Detach them first.
 
    ```bash
    [MAIN_REPO_ROOT]/.agents/skills/github/scripts/git-https-auth -C [MAIN_REPO_ROOT] fetch --prune origin "+refs/heads/[BASE_BRANCH]:refs/remotes/origin/[BASE_BRANCH]"
-   git -C [MAIN_REPO_ROOT] merge --ff-only "origin/[BASE_BRANCH]"
-   git -C [MAIN_REPO_ROOT] worktree prune
    ```
    Target `origin` only. Optional secondary remotes must not block closure of
    the current PR. The fetch uses `git-https-auth`, which preserves normal SSH
    behavior unless a GitHub SSH remote is present and `gh` auth is valid; then
    it applies a per-command HTTPS/`gh auth git-credential` fallback. Fetch the
    base branch with an explicit refspec so narrowed `remote.origin.fetch`
-   config cannot leave `origin/[BASE_BRANCH]` stale or missing. Keep the local
-   fast-forward merge on plain `git` so credential helper config is not exposed
-   to merge-time repository hooks. Sync to the explicit fetched
-   `origin/[BASE_BRANCH]` ref with `--ff-only` so local main never gains
-   merge-bubble commits; if the fast-forward fails, stop and surface the
-   divergence for manual handling.
+   config cannot leave `origin/[BASE_BRANCH]` stale or missing. Keep every
+   local ref update below on plain `git` so credential helper config is not
+   exposed to merge-time repository hooks.
+
+   **Precondition — resolve which checkout owns `[BASE_BRANCH]` before
+   advancing it.** `merge --ff-only` advances whatever branch the target
+   checkout currently has on `HEAD`, not `[BASE_BRANCH]` by name: run in a
+   `[MAIN_REPO_ROOT]` sitting on a foreign branch it fast-forwards THAT branch
+   and exits 0, leaving local `[BASE_BRANCH]` exactly where it was with nothing
+   reported.
+   ```bash
+   git -C [MAIN_REPO_ROOT] rev-parse --abbrev-ref HEAD
+   ```
+   Use the output as `MAIN_HEAD_BRANCH` and route on it:
+
+   | `MAIN_HEAD_BRANCH` | Action |
+   |--------------------|--------|
+   | `[BASE_BRANCH]` | Advance in place: `git -C [MAIN_REPO_ROOT] merge --ff-only "origin/[BASE_BRANCH]"` |
+   | Any other branch, or `HEAD` (detached) | Do NOT ff-merge — advance the local ref by name instead: `git -C [MAIN_REPO_ROOT] fetch origin "[BASE_BRANCH]:[BASE_BRANCH]"`. That refspec form updates a branch no checkout has on `HEAD` and REFUSES a non-fast-forward, which is exactly the wanted semantics. |
+
+   The by-name fetch fails when `[BASE_BRANCH]` is checked out in another
+   worktree (`refusing to fetch into branch ... checked out at ...`). That is
+   not a stale outcome — locate that worktree and advance it there:
+   ```bash
+   git -C [MAIN_REPO_ROOT] worktree list
+   ```
+   Read the path whose bracketed branch is `[BASE_BRANCH]` as `BASE_WORKTREE`,
+   then `git -C [BASE_WORKTREE] merge --ff-only "origin/[BASE_BRANCH]"`.
+
+   Then prune stale worktree registrations:
+   ```bash
+   git -C [MAIN_REPO_ROOT] worktree prune
+   ```
+
+   **Blocking outcomes.** Each of these leaves local `[BASE_BRANCH]` behind
+   `origin/[BASE_BRANCH]`. Never record the sync as done on any of them, and
+   carry the named cause into § 7:
+
+   | Outcome | Report |
+   |---------|--------|
+   | The ff-merge refuses on uncommitted changes (`Your local changes to the following files would be overwritten by merge`) | **Blocking** post-merge condition naming every file git listed and the checkout it sits in — not an informational note |
+   | The by-name fetch is rejected as non-fast-forward | **Blocking** — local `[BASE_BRANCH]` has diverged from `origin/[BASE_BRANCH]`; name both shas |
+   | `[BASE_BRANCH]` is checked out in no reachable worktree and the by-name fetch failed for any other reason | **Blocking** — name the sha `origin/[BASE_BRANCH]` now points at and the git error |
+
+   **Report the result in § 7 either way.** When local `[BASE_BRANCH]` advanced,
+   § 7 records the new sha. When it could NOT be advanced, § 7 must carry a
+   WARNING naming the stale local sha, the `origin/[BASE_BRANCH]` sha, and the
+   cause — a stale main checkout is what later manual branch cuts start from
+   and what any agent reading `[MAIN_REPO_ROOT]` for repo facts will answer
+   from.
 
 5. **Sweep stale branches & worktrees** (after all PRs merged and synced). Default: scoped to current PR only — do not enumerate unrelated branches or sibling worktrees.
 
@@ -469,11 +511,18 @@ For each file flagged as overlapping in § 2.1:
 | Branch | [BRANCH_NAME] (deleted) |
 | Worktree | cleaned up |
 | Issue Tracker | [ISSUE_ID] → Done (via magic words) |
+| Base sync | local `[BASE_BRANCH]` → [NEW_SHA] |
 
 Include a `Review gate` row only when the merge did not proceed on a plain
 `approved`/`reviewed` verdict — surface `⚠️ reviewer-down proceed (no reviewer
 posted; PR_REVIEW_ON_TIMEOUT=proceed)` or `⚠️ forced (user override)` so a
 non-organic gate is visible in the record.
+
+The `Base sync` row is never omitted. When § 5 step 4 hit a blocking outcome,
+it carries the WARNING instead of a sha: `⚠️ local [BASE_BRANCH] STALE at
+[LOCAL_SHA] (origin/[BASE_BRANCH] at [ORIGIN_SHA]) — [CAUSE]`, where `[CAUSE]`
+is the named blocking outcome (the dirty files, the divergence, or the git
+error). Report it the same way in the batch shape below.
 </output_format>
 
 ### Multiple PRs (`all`)
@@ -496,7 +545,8 @@ non-organic gate is visible in the record.
 | ⏭️ | #[P] | [ISSUE_ID] - [TITLE] | Review threads |
 | ❌ | #[Q] | [ISSUE_ID] - [TITLE] | Merge conflicts |
 
-Total: [N] PRs merged | Synced: origin fetch via git-https-auth + local ff-only merge
+Total: [N] PRs merged | Base sync: local `[BASE_BRANCH]` → [NEW_SHA]
+(or `⚠️ local [BASE_BRANCH] STALE at [LOCAL_SHA] — [CAUSE]`)
 
 ### 🧹 STALE CLEANUP
 

--- a/skills/orch/workflows/start-worktree.md
+++ b/skills/orch/workflows/start-worktree.md
@@ -36,7 +36,7 @@ If invoked as `start github OWNER/REPO#N`, parse it before initialization:
    - `tracker`: `[TRACKER]` when parsed
    - `github_repo`: `[GITHUB_REPO]` when parsed
 
-3. **Gate on base freshness.** This expedited path reuses a worktree created earlier, so prove the base is current before any agent spends budget on it:
+3. **Gate on base freshness.** Every § 5 route out of `start.md` — continue-here, handoff, manual — lands here, so this one gate covers both a worktree just created in `start.md` § 4 and one reused from an earlier session. Prove the base is current before any agent spends budget on it:
    ```bash
    .agents/skills/orch/scripts/base-freshness [WORKTREE_PATH]
    ```


### PR DESCRIPTION
## Problem

`skills/orch/workflows/merge-pr.md` § 5 step 4 ("Sync main repo — ALWAYS runs after merge") ran, unconditionally:

```
git -C [MAIN_REPO_ROOT] merge --ff-only "origin/[BASE_BRANCH]"
```

`merge --ff-only` advances whatever branch the target checkout has on `HEAD` — **not `[BASE_BRANCH]` by name**. When `[MAIN_REPO_ROOT]` is parked on a foreign branch, it fast-forwards *that* branch, exits `0`, and leaves local `[BASE_BRANCH]` exactly where it was. Nothing is reported, because nothing failed. The step's only failure guidance — "if the fast-forward fails, stop and surface the divergence for manual handling" — never fires on this path, and on the dirty-tree path it produced an informational note that a merge report carries once and no one acts on.

Reproduced in a sandbox (`D` control): main checkout on `feature`, `origin/main` ahead.

```
before: main=81efaa4 feature=5fa13ac
$ git merge --ff-only origin/main
Updating 5fa13ac..419839e   → ff-merge exit=0 (SUCCEEDS)
after:  main=81efaa4 feature=419839e origin/main=419839e
```

`feature` advanced. `main` stayed stale. Exit 0.

## Observed harm (one session)

- The main checkout sat **30 commits behind `origin/main` across four merges**.
- A branch cut from that stale base needed a mid-flight rebase and full revalidation before its PR could open.
- Two review agents read the stale checkout and produced **false findings** — one claimed a check "isn't wired anywhere" when it is wired on `main`; a filed issue got a wrong paragraph that needed a correction pass.
- A ten-reviewer fleet ran retired/old agent definitions, including an agent `main` had deleted.

## Change

§ 5 step 4 now resolves the owning checkout before advancing anything:

1. `git -C [MAIN_REPO_ROOT] rev-parse --abbrev-ref HEAD` → `MAIN_HEAD_BRANCH`.
2. Route:
   - `MAIN_HEAD_BRANCH == [BASE_BRANCH]` → ff-merge in place (unchanged behavior).
   - Any other branch, or detached `HEAD` → **do not ff-merge**; advance the local ref by name with `git -C [MAIN_REPO_ROOT] fetch origin "[BASE_BRANCH]:[BASE_BRANCH]"`.
3. When that refspec is refused because another worktree holds the branch, locate it via `worktree list` and ff-merge in `[BASE_WORKTREE]`.

Three **blocking** outcomes replace the informational note — merge-blocking dirty tree (naming every file git listed and its checkout), non-fast-forward rejection (naming both shas), unreachable base — and § 7 now always carries a `Base sync` row: the new sha, or `⚠️ local [BASE_BRANCH] STALE at [LOCAL_SHA] (origin/[BASE_BRANCH] at [ORIGIN_SHA]) — [CAUSE]`.

### Git semantics verified, not assumed

| Probe | Result |
|---|---|
| by-name fetch while on a foreign branch | exit 0, `main` advances `5fa13ac..81efaa4`, `HEAD` stays on `feature` |
| by-name fetch with local `main` genuinely diverged | `! [rejected] main -> main (non-fast-forward)`, exit 1, `main` unchanged |
| by-name fetch with `main` checked out in another worktree | `fatal: refusing to fetch into branch 'refs/heads/main' checked out at '<path>'`, exit 128 |

(First divergence probe was a false green — `branch -f main HEAD` set `main` to an *ancestor*, still a fast-forward. Redone with a real local-only commit; the table shows the corrected run.)

## start-worktree

No gap to close. `skills/orch/scripts/base-freshness` is already wired at `start-worktree.md` § 1 step 3, and per `start.md` § 5 **every** route (continue-here, handoff, manual) reaches it; bare `worktree create` cuts new branches from a freshly fetched `origin/<default>` (`skills/worktree/scripts/worktree`, `worktree add --no-track -b "$BRANCH" "$WT_PATH" "origin/$DEFAULT_BRANCH"` after `fetch_origin`). Only the step's wording was corrected — it read as reuse-only ("This expedited path reuses a worktree created earlier"), which invites a future reader to conclude fresh worktrees are ungated.

## Tests

`skills/orch/tests/workflow_helpers.sh` — the pre-existing ff-merge pin was rescoped to "when the main checkout is on the base branch"; added pins for the precondition, both non-ff-merge routes, the other-worktree refusal routing, the blocking dirty report, the § 7 warning, and the retired sentence pinned absent.

**Must-fail control:** every new assertion was run against the pre-change docs — **10 of 11 failed**, as required. The 11th (`base-freshness [WORKTREE_PATH]`) intentionally pins pre-existing wiring so the citation cannot be dropped. Two assertions were caught *toothless* by that control and tightened: `git -C [MAIN_REPO_ROOT] worktree list` already existed in § 5a, and `stop and surface the divergence for manual handling` is line-wrapped in the source so `grep -F` could never observe it.

| Suite | Result |
|---|---|
| `skills/orch/tests/workflow_helpers.sh` | pass: 403  fail: 0 |
| `skills/orch/tests/run-all.sh` (foreground) | all 37 files passed |
| all other `skills/*/tests/*.sh` | 0 failures |

CHANGELOG entry added. No second-opinion/external review run, per owner instruction.

https://claude.ai/code/session_016J7UX4mMMMJeqXAg8d6NHB
