### PR TITLE
feat(hooks): refuse recursive copies of repo/build trees into scratch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 ## Unreleased
 
+- **New `block-repo-copy` hook: a recursive copy of a repository or build tree
+  into a temp/scratch destination is refused before the command runs.** An agent
+  told to sanity-check behavior against a real consumer repo "read-only, under
+  `~/dev`" reasoned that copying it somewhere safe first was how to make it
+  read-only, and ran a recursive copy of that repo — a ~29GB `target/` build
+  tree plus a large `.git` — into its scratchpad, twice. `/tmp` on that machine
+  is a tmpfs at the kernel default of half of RAM (63GB), so the copy consumed
+  roughly half of system memory, filled the filesystem to 100%, and every
+  process writing there began failing with ENOSPC, which broke tool output
+  across the whole session until it was cleaned up by hand. Prose instructions
+  did not prevent it and cannot be relied on to: the reasoning that produced it
+  was locally sensible, so the rule has to be enforced by the harness before the
+  command runs. `hooks/block-repo-copy.sh` is a `PreToolUse`/`Bash` hook that
+  refuses `cp -r`/`-R`/`-a`, recursive or archive `rsync`, `git clone` of a
+  local path, and `tar` create-to-extract pipes when BOTH halves hold: the
+  source is itself named `.git`/`target`/`node_modules` or carries one of
+  `.git`, `target`, `node_modules`, `vendor`, `.venv`, `venv`, `.next`,
+  `.cache`, `.gradle`, `Pods` one level down, AND the destination resolves under
+  `/tmp`, `/var/tmp`, `$TMPDIR`, `$CLAUDE_CODE_TMPDIR`, a `mktemp -d`, or any
+  path containing `scratchpad`. Requiring both halves is what keeps false
+  positives near zero — an expensive tree copied to an ordinary destination and
+  an ordinary directory copied into scratch both pass, as does a
+  non-recursive copy, `rsync -R` (which is `--relative`, not recursion), and a
+  repository subdirectory that carries no marker of its own (the source check
+  never walks upward). The refusal names the source, the marker that made it
+  expensive, the destination, and the two alternatives: read the source in
+  place, since reading does not mutate it, or build a minimal synthetic fixture
+  in `mktemp -d`. The hook fires on every Bash call, so a non-copy command
+  exits through a bash-builtin regex before any subprocess or filesystem work
+  and the source check uses `-e` existence tests only — never `du` or a
+  traversal; the suite pins the fast exit with a PATH shim log that must stay
+  empty for a non-copy command and must record tool use when a copy is actually
+  evaluated. Registration needed no config change: `[hook-events]`'s existing
+  `"PreToolUse:Bash" = "all"` is matched by the hook's frontmatter, so consuming
+  repos pick it up on the next `vstack refresh`.
+
 - **orch: the post-merge main sync proves which checkout owns the base branch
   before advancing it, and reports a stale base as a warning.** `merge-pr.md`
   § 5 step 4 ran `git -C [MAIN_REPO_ROOT] merge --ff-only origin/[BASE_BRANCH]`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,21 @@
   empty for a non-copy command and must record tool use when a copy is actually
   evaluated. Registration needed no config change: `[hook-events]`'s existing
   `"PreToolUse:Bash" = "all"` is matched by the hook's frontmatter, so consuming
-  repos pick it up on the next `vstack refresh`.
+  repos pick it up on the next `vstack refresh`. Operand parsing decides the
+  destination the shell would actually write to rather than assuming the last
+  word: an earlier `cd` sets the base a relative destination resolves against,
+  `cp -t DIR`/`--target-directory=DIR` inverts source and destination, options
+  that consume an argument (`--depth 1`, `--exclude PAT`) no longer shift the
+  operand count, quoted paths containing spaces stay one operand, and a
+  destination variable assigned `$(mktemp -d)` earlier in the same command is
+  resolved. The JSON decode is escape-aware, so an embedded `\"` no longer
+  truncates the command on a host without `jq`, and a payload that names a
+  command the decoder cannot recover is refused rather than allowed — a guard
+  that cannot read its input must not wave the call through, while a
+  well-formed payload carrying no command still passes. Per the Pi hook parity
+  rule (AGENTS.md § Repository conventions), the same predicate ships for Pi in
+  `pi-extensions/pi-hooks` as the `blockRepoCopy` setting (default on), with
+  its own 30-case suite; the package goes to 0.3.0.
 
 - **orch: the post-merge main sync proves which checkout owns the base branch
   before advancing it, and reports a stale base as a warning.** `merge-pr.md`

--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ Rust and performance reference material now lives directly in the `rust`, `revie
 | Hook | Event | Brief |
 |---|---|---|
 | `block-bare-cd` | `PreToolUse` | Blocks unsafe bare `cd` usage and nudges toward subshell-safe patterns. |
+| `block-repo-copy` | `PreToolUse` | Refuses a recursive copy (`cp -r`/`-R`/`-a`, recursive or archive `rsync`, local `git clone`, `tar` create-to-extract pipe) when the source carries repository history or a build tree AND the destination resolves under a temp/scratch root. Temp roots are commonly RAM-backed tmpfs, where such a copy fills the filesystem and every process writing there fails with ENOSPC. |
 | `pre-commit-check` | `PreToolUse` | Validates formatting and lint before commits. Rust Clippy lane is scoped to staged packages and configurable via `VSTACK_PRE_COMMIT_RUST_CLIPPY` (custom command or `off`). |
 | `post-edit-lint` | `PostToolUse` | Runs lint checks after source edits. |
 | `task-completed-check` | `TaskCompleted` | Runs final lint checks before marking work complete. Claude-Code-only — codex has no clean equivalent event. |

--- a/hooks/block-repo-copy.sh
+++ b/hooks/block-repo-copy.sh
@@ -1,0 +1,308 @@
+#!/usr/bin/env bash
+# ---
+# name: block-repo-copy
+# event: PreToolUse
+# matcher: Bash
+# description: Block recursive copies (cp -r/-R/-a, rsync, local git clone, tar pipes) of a source carrying repository history or a build tree into a temp/scratch destination. Suggests reading the source in place or building a minimal fixture.
+# safety: Temp destinations are commonly RAM-backed tmpfs; a multi-gigabyte tree copy fills the filesystem and every process writing there then fails with ENOSPC.
+# ---
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+# Fast exit on every non-copy Bash call, using bash's builtin regex so the
+# common case forks nothing and touches no filesystem.
+COPY_VERB_RE='(^|[^[:alnum:]_-])(cp|rsync|tar)([^[:alnum:]_-]|$)|git[[:space:]]+clone'
+if [[ ! $INPUT =~ $COPY_VERB_RE ]]; then
+  exit 0
+fi
+
+if command -v jq >/dev/null 2>&1; then
+  COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // .command // ""' 2>/dev/null || true)
+else
+  COMMAND=$(echo "$INPUT" | grep -o '"command"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"command"[[:space:]]*:[[:space:]]*"//;s/"$//' 2>/dev/null || true)
+fi
+[ -n "$COMMAND" ] || exit 0
+
+# Directory names whose presence one level inside the source proves the tree is
+# expensive by construction. Checked with -e only: no traversal, no du.
+DANGER_MARKERS='.git target node_modules vendor .venv venv .next .cache .gradle Pods'
+
+expand_path() {
+  local p="$1"
+  case "$p" in
+    '~') p="$HOME" ;;
+    '~/'*) p="$HOME/${p#\~/}" ;;
+  esac
+  case "$p" in
+    /*) ;;
+    *) p="$PWD/$p" ;;
+  esac
+  printf '%s' "$p"
+}
+
+# A path is scratch when it names a temp root literally (including an
+# unexpanded variable reference the shell would resolve at run time) or
+# resolves under one.
+is_scratch() {
+  local raw="$1" p base
+  case "$raw" in
+    *scratchpad*|*'$TMP'*|*'${TMP'*|*mktemp*) return 0 ;;
+  esac
+  p="$(expand_path "$raw")"
+  for base in /tmp /var/tmp "${TMPDIR:-}" "${CLAUDE_CODE_TMPDIR:-}"; do
+    [ -n "$base" ] || continue
+    base="${base%/}"
+    case "$p" in "$base" | "$base"/*) return 0 ;; esac
+  done
+  return 1
+}
+
+# Print the markers that make a source expensive, or return 1 when it has none.
+dangerous_markers() {
+  local raw="$1" p m found=''
+  p="$(expand_path "${raw%/}")"
+  [ -d "$p" ] || return 1
+  case "${p##*/}" in
+    .git | target | node_modules)
+      printf '%s' "${p##*/}"
+      return 0
+      ;;
+  esac
+  for m in $DANGER_MARKERS; do
+    if [ -e "$p/$m" ]; then found="$found, $m"; fi
+  done
+  if [ -z "$found" ]; then return 1; fi
+  printf '%s' "${found#, }"
+}
+
+refuse() {
+  local src="$1" markers="$2" dest="$3"
+  {
+    echo "Refusing a recursive copy of an expensive tree into scratch space."
+    echo "  command:     $COMMAND"
+    echo "  source:      $(expand_path "${src%/}") (contains $markers)"
+    echo "  destination: $dest (temp/scratch)"
+    echo
+    echo "A source carrying repository history or a build tree is large by construction,"
+    echo "and temp/scratch filesystems are commonly RAM-backed tmpfs — the copy can fill"
+    echo "the filesystem, after which every process writing there fails with ENOSPC."
+    echo
+    echo "Do one of these instead:"
+    echo "  - Read the source in place. Reading does not mutate it, so no copy is needed"
+    echo "    to leave it unchanged."
+    echo "  - Build a MINIMAL synthetic fixture:"
+    echo '      d=$(mktemp -d); mkdir -p "$d/repo/.git" "$d/repo/target"; touch "$d/repo/f"'
+  } >&2
+  exit 2
+}
+
+verdict() {
+  local dest="$1" srcs="$2" src markers
+  is_scratch "$dest" || return 0
+  while IFS= read -r src; do
+    [ -n "$src" ] || continue
+    markers="$(dangerous_markers "$src")" || continue
+    refuse "$src" "$markers" "$dest"
+  done <<EOF
+$srcs
+EOF
+}
+
+# Strip quoting and grouping so operands split on whitespace. A path containing
+# a space splits into fragments that resolve to nothing and are skipped.
+tokenize() {
+  printf '%s\n' "$1" | tr -d "\"'" | tr '()' '  ' | tr -s ' \t' '\n' | sed '/^$/d'
+}
+
+last_line() { printf '%s' "$1" | sed -n '$p'; }
+drop_last_line() { printf '%s' "$1" | sed '$d'; }
+
+# Recognize one cp / rsync / git clone invocation and split it into operands.
+# Sets SEG_VERB, SEG_RECURSIVE, SEG_OPERANDS; returns 1 for anything else.
+classify_segment() {
+  SEG_VERB=''
+  SEG_RECURSIVE=0
+  SEG_OPERANDS=''
+  local tok base pending_git=0 skip_next=0
+  while IFS= read -r tok; do
+    [ -n "$tok" ] || continue
+    if [ "$skip_next" = 1 ]; then
+      skip_next=0
+      continue
+    fi
+    if [ -z "$SEG_VERB" ]; then
+      if [ "$pending_git" = 1 ]; then
+        case "$tok" in
+          clone)
+            SEG_VERB=git-clone
+            SEG_RECURSIVE=1
+            ;;
+          -C)
+            skip_next=1
+            ;;
+          -*) ;;
+          *) return 1 ;;
+        esac
+        continue
+      fi
+      case "$tok" in
+        *=*) continue ;;
+        sudo | command | env | nohup | time) continue ;;
+      esac
+      base="${tok##*/}"
+      case "$base" in
+        cp) SEG_VERB=cp ;;
+        rsync) SEG_VERB=rsync ;;
+        git) pending_git=1 ;;
+        *) return 1 ;;
+      esac
+      continue
+    fi
+    case "$tok" in
+      --recursive | --archive) SEG_RECURSIVE=1 ;;
+      --*) ;;
+      -?*)
+        # Short clusters. rsync's -R is --relative, not recursion.
+        case "$SEG_VERB" in
+          cp) case "$tok" in *[rRa]*) SEG_RECURSIVE=1 ;; esac ;;
+          rsync) case "$tok" in *[ra]*) SEG_RECURSIVE=1 ;; esac ;;
+        esac
+        ;;
+      *) SEG_OPERANDS="$SEG_OPERANDS$tok
+" ;;
+    esac
+  done <<EOF
+$(tokenize "$1")
+EOF
+  [ -n "$SEG_VERB" ] || return 1
+  return 0
+}
+
+check_copy_segments() {
+  local seg dest srcs count
+  while IFS= read -r seg; do
+    [ -n "$seg" ] || continue
+    classify_segment "$seg" || continue
+    [ "$SEG_RECURSIVE" = 1 ] || continue
+    count=$(printf '%s' "$SEG_OPERANDS" | grep -c . || true)
+    if [ "$SEG_VERB" = git-clone ] && [ "$count" = 1 ]; then
+      dest="$PWD"
+      srcs="$SEG_OPERANDS"
+    else
+      [ "${count:-0}" -ge 2 ] || continue
+      dest="$(last_line "$SEG_OPERANDS")"
+      srcs="$(drop_last_line "$SEG_OPERANDS")"
+    fi
+    verdict "$dest" "$srcs"
+  done <<EOF
+$(printf '%s' "$1" | sed 's/&&/\n/g; s/||/\n/g; s/;/\n/g; s/|/\n/g')
+EOF
+}
+
+# One piped tar stage: its mode (create/extract), its working directory
+# (-C or a leading cd), and its non-flag operands.
+tar_stage() {
+  STAGE_MODE=''
+  STAGE_DIR=''
+  STAGE_OPERANDS=''
+  local tok in_tar=0 want_dir=0 want_file=0 want_cd=0
+  while IFS= read -r tok; do
+    [ -n "$tok" ] || continue
+    if [ "$want_cd" = 1 ]; then
+      STAGE_DIR="$tok"
+      want_cd=0
+      continue
+    fi
+    if [ "$in_tar" = 0 ]; then
+      case "${tok##*/}" in
+        cd) want_cd=1 ;;
+        tar) in_tar=1 ;;
+      esac
+      continue
+    fi
+    if [ "$want_dir" = 1 ]; then
+      STAGE_DIR="$tok"
+      want_dir=0
+      continue
+    fi
+    if [ "$want_file" = 1 ]; then
+      want_file=0
+      continue
+    fi
+    case "$tok" in
+      -C) want_dir=1 ;;
+      --directory=*) STAGE_DIR="${tok#*=}" ;;
+      --create) STAGE_MODE=c ;;
+      --extract | --get) STAGE_MODE=x ;;
+      --*) ;;
+      -?*)
+        case "$tok" in *c*) STAGE_MODE=c ;; esac
+        case "$tok" in *x*) STAGE_MODE=x ;; esac
+        case "$tok" in *f*) want_file=1 ;; esac
+        ;;
+      # Old-style bundled flags carry no leading dash.
+      [cxtrudA]*)
+        if [ -z "$STAGE_MODE" ] && [ -z "$(printf '%s' "$tok" | tr -d 'cxvfzjJtC')" ]; then
+          case "$tok" in *c*) STAGE_MODE=c ;; esac
+          case "$tok" in *x*) STAGE_MODE=x ;; esac
+          case "$tok" in *f*) want_file=1 ;; esac
+          continue
+        fi
+        STAGE_OPERANDS="$STAGE_OPERANDS$tok
+"
+        ;;
+      *) STAGE_OPERANDS="$STAGE_OPERANDS$tok
+" ;;
+    esac
+  done <<EOF
+$(tokenize "$1")
+EOF
+  [ -n "$STAGE_MODE" ]
+}
+
+check_tar_pipe() {
+  local cmd="$1" stage srcs='' dest='' src_dir='' line
+  case "$cmd" in *'|'*) ;; *) return 0 ;; esac
+  while IFS= read -r stage; do
+    [ -n "$stage" ] || continue
+    tar_stage "$stage" || continue
+    case "$STAGE_MODE" in
+      c)
+        src_dir="$STAGE_DIR"
+        srcs="$STAGE_OPERANDS"
+        ;;
+      x) dest="${STAGE_DIR:-$PWD}" ;;
+    esac
+  done <<EOF
+$(printf '%s' "$cmd" | sed 's/||/\n/g; s/|/\n/g')
+EOF
+  { [ -n "$srcs" ] || [ -n "$src_dir" ]; } && [ -n "$dest" ] || return 0
+  if [ -n "$src_dir" ]; then
+    if [ -z "$srcs" ]; then
+      srcs="$src_dir
+"
+    else
+      local resolved=''
+      while IFS= read -r line; do
+        [ -n "$line" ] || continue
+        case "$line" in
+          /* | '~'*) resolved="$resolved$line
+" ;;
+          *) resolved="$resolved${src_dir%/}/$line
+" ;;
+        esac
+      done <<EOF
+$srcs
+EOF
+      srcs="$resolved"
+    fi
+  fi
+  verdict "$dest" "$srcs"
+}
+
+check_tar_pipe "$COMMAND"
+check_copy_segments "$COMMAND"
+
+exit 0

--- a/hooks/block-repo-copy.sh
+++ b/hooks/block-repo-copy.sh
@@ -9,10 +9,15 @@
 
 set -euo pipefail
 
-INPUT=$(cat)
+# Read stdin with the shell builtin so the fast exit below reaches no
+# subprocess at all. Payload newlines are JSON-escaped, so joining is lossless.
+INPUT=''
+_line=''
+while IFS= read -r _line || [ -n "$_line" ]; do
+  INPUT="$INPUT$_line"
+done
 
-# Fast exit on every non-copy Bash call, using bash's builtin regex so the
-# common case forks nothing and touches no filesystem.
+# Fast exit on every non-copy Bash call, using bash's builtin regex.
 COPY_VERB_RE='(^|[^[:alnum:]_-])(cp|rsync|tar)([^[:alnum:]_-]|$)|git[[:space:]]+clone'
 if [[ ! $INPUT =~ $COPY_VERB_RE ]]; then
   exit 0
@@ -21,48 +26,111 @@ fi
 if command -v jq >/dev/null 2>&1; then
   COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // .command // ""' 2>/dev/null || true)
 else
-  COMMAND=$(echo "$INPUT" | grep -o '"command"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"command"[[:space:]]*:[[:space:]]*"//;s/"$//' 2>/dev/null || true)
+  # Escape-aware: the value runs to the first quote not preceded by a
+  # backslash, so an embedded \" no longer truncates the command.
+  COMMAND=$(printf '%s' "$INPUT" \
+    | grep -oE '"command"[[:space:]]*:[[:space:]]*"(\\.|[^"\\])*"' \
+    | head -1 \
+    | sed 's/.*"command"[[:space:]]*:[[:space:]]*"//; s/"$//' \
+    | sed 's/\\n/ /g; s/\\t/ /g; s/\\"/"/g; s/\\\\/\\/g' 2>/dev/null || true)
 fi
-[ -n "$COMMAND" ] || exit 0
+# A guard that cannot read its own input must not allow the call. A payload
+# that carries no command at all is not a copy and passes; one that names a
+# command the decoder could not recover is refused, because the destination
+# can never be established.
+if [ -z "$COMMAND" ]; then
+  case "$INPUT" in
+    *'"command"'*)
+      {
+        echo "Refusing a Bash call whose payload could not be read."
+        echo "  payload: $INPUT"
+        echo
+        echo "The payload names a command but it could not be decoded, so this hook"
+        echo "cannot tell whether it copies a repository or build tree into scratch"
+        echo "space. Re-issue the command with a well-formed payload."
+      } >&2
+      exit 2
+      ;;
+    *) exit 0 ;;
+  esac
+fi
 
 # Directory names whose presence one level inside the source proves the tree is
 # expensive by construction. Checked with -e only: no traversal, no du.
 DANGER_MARKERS='.git target node_modules vendor .venv venv .next .cache .gradle Pods'
 
+# Options that consume the following token, per verb. Without these a value
+# like the 1 in `--depth 1` is counted as an operand and shifts which token is
+# read as the destination.
+CP_ARG_OPTS='-t -S --suffix --target-directory'
+RSYNC_ARG_OPTS='-e -f -B -T -M --rsh --exclude --include --exclude-from --include-from --files-from --filter --chmod --log-file --bwlimit --partial-dir --link-dest --copy-dest --compare-dest --timeout --contimeout --port --block-size --modify-window --max-size --min-size --out-format --suffix --backup-dir --temp-dir --address --sockopts --write-batch --read-batch --protocol --iconv --checksum-seed --max-delete --skip-compress --compress-level --info --debug --usermap --groupmap --chown --remote-option'
+GIT_ARG_OPTS='-b -o -j -c -u --depth --branch --origin --reference --reference-if-able --separate-git-dir --jobs --filter --config --upload-pack --template --shallow-since --shallow-exclude --server-option --bundle-uri --revision'
+
+in_list() {
+  local needle="$1" item
+  for item in $2; do
+    [ "$needle" = "$item" ] && return 0
+  done
+  return 1
+}
+
 expand_path() {
-  local p="$1"
+  local p="$1" base="${2:-$PWD}"
+  # Temp roots named by variable resolve to the directory they stand for.
+  p="${p//\$\{CLAUDE_CODE_TMPDIR\}/${CLAUDE_CODE_TMPDIR:-/tmp}}"
+  p="${p//\$CLAUDE_CODE_TMPDIR/${CLAUDE_CODE_TMPDIR:-/tmp}}"
+  p="${p//\$\{TMPDIR\}/${TMPDIR:-/tmp}}"
+  p="${p//\$TMPDIR/${TMPDIR:-/tmp}}"
   case "$p" in
     '~') p="$HOME" ;;
     '~/'*) p="$HOME/${p#\~/}" ;;
   esac
   case "$p" in
     /*) ;;
-    *) p="$PWD/$p" ;;
+    *) p="${base%/}/$p" ;;
   esac
   printf '%s' "$p"
 }
 
-# A path is scratch when it names a temp root literally (including an
-# unexpanded variable reference the shell would resolve at run time) or
-# resolves under one.
+# Variables assigned a scratch path earlier in the same command, so a
+# destination written as "$d" is classified by what $d was set to.
+SCRATCH_VARS=''
+
+# A path is scratch when it names a temp root literally, is written as a
+# variable that resolves to one, or resolves under one.
 is_scratch() {
-  local raw="$1" p base
+  local raw="$1" base="${2:-$PWD}" p root name
   case "$raw" in
-    *scratchpad*|*'$TMP'*|*'${TMP'*|*mktemp*) return 0 ;;
+    *scratchpad* | *mktemp* | *'$TMP'* | *'${TMP'*) return 0 ;;
   esac
-  p="$(expand_path "$raw")"
-  for base in /tmp /var/tmp "${TMPDIR:-}" "${CLAUDE_CODE_TMPDIR:-}"; do
-    [ -n "$base" ] || continue
-    base="${base%/}"
-    case "$p" in "$base" | "$base"/*) return 0 ;; esac
+  name="$raw"
+  case "$name" in
+    '${'*)
+      name="${name#\$\{}"
+      name="${name%%\}*}"
+      ;;
+    '$'*)
+      name="${name#\$}"
+      name="${name%%/*}"
+      ;;
+    *) name='' ;;
+  esac
+  if [ -n "$name" ] && in_list "$name" "$SCRATCH_VARS"; then
+    return 0
+  fi
+  p="$(expand_path "$raw" "$base")"
+  for root in /tmp /var/tmp "${TMPDIR:-}" "${CLAUDE_CODE_TMPDIR:-}"; do
+    [ -n "$root" ] || continue
+    root="${root%/}"
+    case "$p" in "$root" | "$root"/*) return 0 ;; esac
   done
   return 1
 }
 
 # Print the markers that make a source expensive, or return 1 when it has none.
 dangerous_markers() {
-  local raw="$1" p m found=''
-  p="$(expand_path "${raw%/}")"
+  local raw="$1" base="${2:-$PWD}" p m found=''
+  p="$(expand_path "${raw%/}" "$base")"
   [ -d "$p" ] || return 1
   case "${p##*/}" in
     .git | target | node_modules)
@@ -78,12 +146,12 @@ dangerous_markers() {
 }
 
 refuse() {
-  local src="$1" markers="$2" dest="$3"
+  local src="$1" markers="$2" dest="$3" base="$4"
   {
     echo "Refusing a recursive copy of an expensive tree into scratch space."
     echo "  command:     $COMMAND"
-    echo "  source:      $(expand_path "${src%/}") (contains $markers)"
-    echo "  destination: $dest (temp/scratch)"
+    echo "  source:      $(expand_path "${src%/}" "$base") (contains $markers)"
+    echo "  destination: $(expand_path "$dest" "$base") (temp/scratch)"
     echo
     echo "A source carrying repository history or a build tree is large by construction,"
     echo "and temp/scratch filesystems are commonly RAM-backed tmpfs — the copy can fill"
@@ -99,33 +167,127 @@ refuse() {
 }
 
 verdict() {
-  local dest="$1" srcs="$2" src markers
-  is_scratch "$dest" || return 0
+  local dest="$1" srcs="$2" base="$3" src markers
+  is_scratch "$dest" "$base" || return 0
   while IFS= read -r src; do
     [ -n "$src" ] || continue
-    markers="$(dangerous_markers "$src")" || continue
-    refuse "$src" "$markers" "$dest"
+    markers="$(dangerous_markers "$src" "$base")" || continue
+    refuse "$src" "$markers" "$dest" "$base"
   done <<EOF
 $srcs
 EOF
 }
 
-# Strip quoting and grouping so operands split on whitespace. A path containing
-# a space splits into fragments that resolve to nothing and are skipped.
+# --- tokenizer ---------------------------------------------------------------
+# Split the command into tokens honoring quotes, so a path containing a space
+# stays one operand instead of splitting into fragments that resolve to
+# nothing. Command substitutions are kept whole so an inline $(mktemp -d) stays
+# visible. List and pipeline separators become SEP lines, which is what lets a
+# leading `cd` be attributed to the commands that follow it.
+SEP=$'\001'
+
 tokenize() {
-  printf '%s\n' "$1" | tr -d "\"'" | tr '()' '  ' | tr -s ' \t' '\n' | sed '/^$/d'
+  local s="$1" n i ch tok='' out='' q='' depth
+  n=${#s}
+  i=0
+  while [ "$i" -lt "$n" ]; do
+    ch="${s:i:1}"
+    if [ "$q" = "'" ]; then
+      if [ "$ch" = "'" ]; then q=''; else tok="$tok$ch"; fi
+      i=$((i + 1))
+      continue
+    fi
+    if [ "$q" = '"' ]; then
+      if [ "$ch" = '"' ]; then
+        q=''
+      elif [ "$ch" = '\' ]; then
+        i=$((i + 1))
+        tok="$tok${s:i:1}"
+      else
+        tok="$tok$ch"
+      fi
+      i=$((i + 1))
+      continue
+    fi
+    case "$ch" in
+      "'" | '"') q="$ch" ;;
+      '\')
+        i=$((i + 1))
+        tok="$tok${s:i:1}"
+        ;;
+      '$')
+        if [ "${s:i+1:1}" = '(' ]; then
+          depth=1
+          tok="$tok\$("
+          i=$((i + 2))
+          while [ "$i" -lt "$n" ] && [ "$depth" -gt 0 ]; do
+            ch="${s:i:1}"
+            case "$ch" in
+              '(') depth=$((depth + 1)) ;;
+              ')') depth=$((depth - 1)) ;;
+            esac
+            if [ "$depth" -gt 0 ]; then tok="$tok$ch"; fi
+            i=$((i + 1))
+          done
+          tok="$tok)"
+          continue
+        fi
+        tok="$tok$ch"
+        ;;
+      ' ' | $'\t')
+        if [ -n "$tok" ]; then
+          out="$out$tok"$'\n'
+          tok=''
+        fi
+        ;;
+      '&' | '|' | ';' | $'\n' | '(' | ')')
+        if [ -n "$tok" ]; then
+          out="$out$tok"$'\n'
+          tok=''
+        fi
+        out="$out$SEP"$'\n'
+        ;;
+      *) tok="$tok$ch" ;;
+    esac
+    i=$((i + 1))
+  done
+  if [ -n "$tok" ]; then out="$out$tok"$'\n'; fi
+  printf '%s' "$out"
 }
+
+TOKENS="$(tokenize "$COMMAND")"
+
+# Any variable assigned a scratch path is itself a scratch name from here on.
+while IFS= read -r tok; do
+  case "$tok" in
+    [A-Za-z_]*=*)
+      name="${tok%%=*}"
+      value="${tok#*=}"
+      case "$name" in
+        *[!A-Za-z0-9_]*) continue ;;
+      esac
+      if [ -n "$value" ] && is_scratch "$value"; then
+        SCRATCH_VARS="$SCRATCH_VARS $name"
+      fi
+      ;;
+  esac
+done <<EOF
+$TOKENS
+EOF
 
 last_line() { printf '%s' "$1" | sed -n '$p'; }
 drop_last_line() { printf '%s' "$1" | sed '$d'; }
 
-# Recognize one cp / rsync / git clone invocation and split it into operands.
-# Sets SEG_VERB, SEG_RECURSIVE, SEG_OPERANDS; returns 1 for anything else.
+# --- cp / rsync / git clone --------------------------------------------------
+# Recognize one invocation and split it into operands. Sets SEG_VERB,
+# SEG_RECURSIVE, SEG_OPERANDS, SEG_DEST (set only by an explicit
+# target-directory option); returns 1 for anything else.
 classify_segment() {
   SEG_VERB=''
   SEG_RECURSIVE=0
   SEG_OPERANDS=''
-  local tok base pending_git=0 skip_next=0
+  SEG_DEST=''
+  local tok base pending_git=0 skip_next=0 arg_opts=''
   while IFS= read -r tok; do
     [ -n "$tok" ] || continue
     if [ "$skip_next" = 1 ]; then
@@ -138,69 +300,80 @@ classify_segment() {
           clone)
             SEG_VERB=git-clone
             SEG_RECURSIVE=1
+            arg_opts="$GIT_ARG_OPTS"
             ;;
-          -C)
-            skip_next=1
-            ;;
+          -C) skip_next=1 ;;
           -*) ;;
           *) return 1 ;;
         esac
         continue
       fi
       case "$tok" in
-        *=*) continue ;;
+        [A-Za-z_]*=*) continue ;;
         sudo | command | env | nohup | time) continue ;;
       esac
       base="${tok##*/}"
       case "$base" in
-        cp) SEG_VERB=cp ;;
-        rsync) SEG_VERB=rsync ;;
+        cp)
+          SEG_VERB=cp
+          arg_opts="$CP_ARG_OPTS"
+          ;;
+        rsync)
+          SEG_VERB=rsync
+          arg_opts="$RSYNC_ARG_OPTS"
+          ;;
         git) pending_git=1 ;;
         *) return 1 ;;
       esac
       continue
     fi
     case "$tok" in
+      --target-directory=*) SEG_DEST="${tok#*=}" ;;
       --recursive | --archive) SEG_RECURSIVE=1 ;;
-      --*) ;;
+      --*)
+        if in_list "$tok" "$arg_opts"; then skip_next=1; fi
+        ;;
       -?*)
-        # Short clusters. rsync's -R is --relative, not recursion.
+        # cp -t DIR: every operand is a source and DIR is the destination.
+        # rsync's -t is --times and its -R is --relative, so neither applies.
+        if [ "$SEG_VERB" = cp ] && [ "$tok" = "-t" ]; then
+          SEG_DEST='@next@'
+          continue
+        fi
+        if in_list "$tok" "$arg_opts"; then
+          skip_next=1
+          continue
+        fi
         case "$SEG_VERB" in
           cp) case "$tok" in *[rRa]*) SEG_RECURSIVE=1 ;; esac ;;
           rsync) case "$tok" in *[ra]*) SEG_RECURSIVE=1 ;; esac ;;
         esac
+        # A cp short cluster can carry the target flag, as in -rt DIR.
+        if [ "$SEG_VERB" = cp ]; then
+          case "$tok" in
+            --*) ;;
+            *t*) SEG_DEST='@next@' ;;
+          esac
+        fi
         ;;
-      *) SEG_OPERANDS="$SEG_OPERANDS$tok
-" ;;
+      *)
+        if [ "$SEG_DEST" = '@next@' ]; then
+          SEG_DEST="$tok"
+        else
+          SEG_OPERANDS="$SEG_OPERANDS$tok
+"
+        fi
+        ;;
     esac
   done <<EOF
-$(tokenize "$1")
+$1
 EOF
   [ -n "$SEG_VERB" ] || return 1
+  [ "$SEG_DEST" != '@next@' ] || SEG_DEST=''
   return 0
 }
 
-check_copy_segments() {
-  local seg dest srcs count
-  while IFS= read -r seg; do
-    [ -n "$seg" ] || continue
-    classify_segment "$seg" || continue
-    [ "$SEG_RECURSIVE" = 1 ] || continue
-    count=$(printf '%s' "$SEG_OPERANDS" | grep -c . || true)
-    if [ "$SEG_VERB" = git-clone ] && [ "$count" = 1 ]; then
-      dest="$PWD"
-      srcs="$SEG_OPERANDS"
-    else
-      [ "${count:-0}" -ge 2 ] || continue
-      dest="$(last_line "$SEG_OPERANDS")"
-      srcs="$(drop_last_line "$SEG_OPERANDS")"
-    fi
-    verdict "$dest" "$srcs"
-  done <<EOF
-$(printf '%s' "$1" | sed 's/&&/\n/g; s/||/\n/g; s/;/\n/g; s/|/\n/g')
-EOF
-}
-
+# --- tar stages --------------------------------------------------------------
 # One piped tar stage: its mode (create/extract), its working directory
 # (-C or a leading cd), and its non-flag operands.
 tar_stage() {
@@ -257,52 +430,82 @@ tar_stage() {
 " ;;
     esac
   done <<EOF
-$(tokenize "$1")
+$1
 EOF
   [ -n "$STAGE_MODE" ]
 }
 
-check_tar_pipe() {
-  local cmd="$1" stage srcs='' dest='' src_dir='' line
-  case "$cmd" in *'|'*) ;; *) return 0 ;; esac
-  while IFS= read -r stage; do
-    [ -n "$stage" ] || continue
-    tar_stage "$stage" || continue
+# --- walk the command --------------------------------------------------------
+# Segments are visited in order so a `cd` updates the base directory that later
+# relative operands resolve against.
+BASE_DIR="$PWD"
+SEGMENT=''
+TAR_SRCS=''
+TAR_SRC_DIR=''
+TAR_SRC_BASE=''
+TAR_DEST=''
+
+flush_segment() {
+  local seg="$1" first target dest srcs count
+  [ -n "$seg" ] || return 0
+
+  first="$(printf '%s' "$seg" | sed -n '1p')"
+  if [ "${first##*/}" = cd ]; then
+    target="$(printf '%s' "$seg" | sed -n '2p')"
+    if [ -n "$target" ]; then BASE_DIR="$(expand_path "$target" "$BASE_DIR")"; fi
+  fi
+
+  if tar_stage "$seg"; then
     case "$STAGE_MODE" in
       c)
-        src_dir="$STAGE_DIR"
-        srcs="$STAGE_OPERANDS"
+        TAR_SRC_DIR="$STAGE_DIR"
+        TAR_SRCS="$STAGE_OPERANDS"
+        TAR_SRC_BASE="$BASE_DIR"
         ;;
-      x) dest="${STAGE_DIR:-$PWD}" ;;
+      x) TAR_DEST="$(expand_path "${STAGE_DIR:-.}" "$BASE_DIR")" ;;
     esac
-  done <<EOF
-$(printf '%s' "$cmd" | sed 's/||/\n/g; s/|/\n/g')
-EOF
-  { [ -n "$srcs" ] || [ -n "$src_dir" ]; } && [ -n "$dest" ] || return 0
-  if [ -n "$src_dir" ]; then
-    if [ -z "$srcs" ]; then
-      srcs="$src_dir
-"
-    else
-      local resolved=''
-      while IFS= read -r line; do
-        [ -n "$line" ] || continue
-        case "$line" in
-          /* | '~'*) resolved="$resolved$line
-" ;;
-          *) resolved="$resolved${src_dir%/}/$line
-" ;;
-        esac
-      done <<EOF
-$srcs
-EOF
-      srcs="$resolved"
-    fi
   fi
-  verdict "$dest" "$srcs"
+
+  classify_segment "$seg" || return 0
+  [ "$SEG_RECURSIVE" = 1 ] || return 0
+
+  count=$(printf '%s' "$SEG_OPERANDS" | grep -c . || true)
+  if [ -n "$SEG_DEST" ]; then
+    dest="$SEG_DEST"
+    srcs="$SEG_OPERANDS"
+  elif [ "$SEG_VERB" = git-clone ] && [ "${count:-0}" = 1 ]; then
+    dest="$BASE_DIR"
+    srcs="$SEG_OPERANDS"
+  else
+    [ "${count:-0}" -ge 2 ] || return 0
+    dest="$(last_line "$SEG_OPERANDS")"
+    srcs="$(drop_last_line "$SEG_OPERANDS")"
+  fi
+  verdict "$dest" "$srcs" "$BASE_DIR"
 }
 
-check_tar_pipe "$COMMAND"
-check_copy_segments "$COMMAND"
+while IFS= read -r tok; do
+  if [ "$tok" = "$SEP" ]; then
+    flush_segment "$SEGMENT"
+    SEGMENT=''
+    continue
+  fi
+  SEGMENT="$SEGMENT$tok
+"
+done <<EOF
+$TOKENS
+EOF
+flush_segment "$SEGMENT"
+
+# A tar create stage feeding a tar extract stage is one copy across two
+# segments, so it is judged after the whole command has been walked.
+if [ -n "$TAR_DEST" ] && { [ -n "$TAR_SRCS" ] || [ -n "$TAR_SRC_DIR" ]; }; then
+  SRC_BASE="${TAR_SRC_BASE:-$PWD}"
+  if [ -n "$TAR_SRC_DIR" ]; then
+    SRC_BASE="$(expand_path "$TAR_SRC_DIR" "$SRC_BASE")"
+  fi
+  if [ -z "$TAR_SRCS" ]; then TAR_SRCS="$SRC_BASE"$'\n'; fi
+  verdict "$TAR_DEST" "$TAR_SRCS" "$SRC_BASE"
+fi
 
 exit 0

--- a/hooks/tests/block-repo-copy.test.sh
+++ b/hooks/tests/block-repo-copy.test.sh
@@ -63,6 +63,43 @@ run_hook() {
   shims="$(cat "$SHIM_LOG" 2>/dev/null || true)"
 }
 
+# Feed a payload to the hook verbatim, so a malformed one reaches the parser
+# exactly as written. Captures stderr in $err and the exit code in $rc.
+run_hook_raw() {
+  local payload="$1"
+  shift
+  : >"$SHIM_LOG"
+  set +e
+  env -u CLAUDE_CODE_TMPDIR TMPDIR=/tmp PATH="$BIN_DIR:$PATH" SHIM_LOG="$SHIM_LOG" "$@" \
+    "$BASH_BIN" "$HOOK" <<<"$payload" >/dev/null 2>"$ERR_FILE"
+  rc=$?
+  set -e
+  err="$(cat "$ERR_FILE")"
+}
+
+# A PATH carrying the real binaries but no jq, for the fallback JSON decode.
+NOJQ_BIN="$TMP_ROOT/nojq"
+mkdir -p "$NOJQ_BIN"
+for tool in cat tr sed grep head; do
+  real="$(command -v "$tool" 2>/dev/null || true)"
+  [ -n "$real" ] || continue
+  ln -sf "$real" "$NOJQ_BIN/$tool"
+done
+BASH_BIN="$(command -v bash)"
+
+# Run the hook under an exact PATH, so a case can remove jq or every external
+# tool. Sets $rc only.
+run_hook_path() {
+  local path="$1" command_json
+  command_json=$(printf '%s' "$2" | sed 's/\\/\\\\/g; s/"/\\"/g')
+  set +e
+  env -i HOME="$HOME" PWD="$PWD" TMPDIR=/tmp PATH="$path" \
+    "$BASH_BIN" "$HOOK" <<<"{\"tool_input\":{\"command\":\"$command_json\"}}" \
+    >/dev/null 2>&1
+  rc=$?
+  set -e
+}
+
 assert_eq() {
   local got="$1" want="$2" name="$3"
   if [[ "$got" == "$want" ]]; then
@@ -99,6 +136,8 @@ mkdir -p "$FIX/nodetree/node_modules" "$FIX/nodetree/src"
 # A git worktree: `.git` is a FILE pointing at the common dir, not a directory.
 mkdir -p "$FIX/worktree/src"
 printf 'gitdir: /elsewhere/.git/worktrees/wt\n' >"$FIX/worktree/.git"
+# A repository whose path contains a space.
+mkdir -p "$FIX/spaced dir/.git"
 # The same shape with none of the markers.
 mkdir -p "$FIX/plain/docs"
 touch "$FIX/plain/docs/notes.md" "$FIX/plain/README.md"
@@ -215,6 +254,75 @@ else
   FAIL=$((FAIL + 1))
   printf '  FAIL  %s\n' "the shim log records tool use when the hook does evaluate a copy"
 fi
+
+echo "=== block-repo-copy: operand parsing that decides the destination ==="
+
+run_hook 'cp -r '"$FIX"'/gitrepo $CLAUDE_CODE_TMPDIR/x' CLAUDE_CODE_TMPDIR=/srv/agent-tmp
+assert_eq "$rc" "2" "an unexpanded \$CLAUDE_CODE_TMPDIR destination is a scratch destination"
+
+run_hook "cd /tmp && cp -r $FIX/gitrepo x"
+assert_eq "$rc" "2" "a relative destination resolves against an earlier cd, not the hook's cwd"
+
+run_hook "cd $NON_SCRATCH && cp -r $FIX/gitrepo copy"
+assert_eq "$rc" "0" "a cd to an ordinary directory leaves a relative destination ordinary"
+
+run_hook "cp -r -t /tmp $FIX/gitrepo"
+assert_eq "$rc" "2" "cp -t DIR names the destination, which is not the last operand"
+
+run_hook "cp -r --target-directory=/tmp $FIX/gitrepo"
+assert_eq "$rc" "2" "cp --target-directory=DIR names the destination"
+
+run_hook "cp -r --target-directory=$NON_SCRATCH $FIX/gitrepo"
+assert_eq "$rc" "0" "a target-directory outside scratch is allowed"
+
+run_hook "git clone --depth 1 $FIX/gitrepo $SCRATCH"
+assert_eq "$rc" "2" "a git clone option argument is not counted as an operand"
+
+run_hook "rsync -a --exclude target $FIX/gitrepo $SCRATCH"
+assert_eq "$rc" "2" "an rsync option argument is not counted as an operand"
+
+run_hook "cp -r \"$FIX/spaced dir\" $SCRATCH"
+assert_eq "$rc" "2" "a quoted source path containing a space stays one operand"
+
+run_hook "d=\$(mktemp -d); cp -r $FIX/gitrepo \"\$d\""
+assert_eq "$rc" "2" "a destination variable assigned mktemp -d earlier in the command is scratch"
+
+echo "=== block-repo-copy: enforcement without jq, and the cost of the fast exit ==="
+
+run_hook_path "$NOJQ_BIN" "cp -r \"$FIX/gitrepo\" $SCRATCH"
+assert_eq "$rc" "2" "without jq, a command whose JSON carries escaped quotes is still decoded and refused"
+
+run_hook_path "$NOJQ_BIN" "cp -r \"$FIX/plain\" $SCRATCH"
+assert_eq "$rc" "0" "without jq, an ordinary copy still passes"
+
+# An empty PATH leaves no external tool reachable. A non-copy command must
+# still exit 0, which is only possible if it forks nothing.
+run_hook_path "/nonexistent" "git status --short"
+assert_eq "$rc" "0" "a non-copy command completes with no external tool reachable"
+
+
+echo "=== block-repo-copy: an unreadable payload is refused, not waved through ==="
+
+# The payload names a copy verb but the JSON is truncated, so the destination
+# can never be established. A guard that cannot read its input must not allow
+# the call.
+TRUNCATED='{"tool_name":"Bash","tool_input":{"command":"cp -r '"$FIX"'/gitrepo '"$SCRATCH"
+
+run_hook_raw "$TRUNCATED"
+assert_eq "$rc" "2" "a payload jq cannot parse is refused"
+assert_contains "$err" "could not be read" "the refusal names the payload as the cause"
+
+run_hook_raw "$TRUNCATED" PATH="$NOJQ_BIN"
+assert_eq "$rc" "2" "a payload the builtin reader cannot decode is refused"
+
+# The must-pass control: a well-formed payload that simply carries no command
+# is not a copy, so it passes. Without this, refusing everything would score.
+run_hook_raw '{"tool_name":"Bash","tool_input":{},"cwd":"/home/agent/tar"}'
+assert_eq "$rc" "0" "a well-formed payload carrying no command passes"
+
+run_hook_raw '{"tool_name":"Bash","tool_input":{},"cwd":"/home/agent/tar"}' PATH="$NOJQ_BIN"
+assert_eq "$rc" "0" "a well-formed payload carrying no command passes without jq"
+
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/hooks/tests/block-repo-copy.test.sh
+++ b/hooks/tests/block-repo-copy.test.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# Tests for the block-repo-copy hook.
+#
+# The hook refuses a recursive copy of a source carrying repository history or
+# a build tree into a temp/scratch destination. These cases pin both halves of
+# that predicate independently — an expensive source with a non-scratch
+# destination passes, and a scratch destination with an ordinary source passes
+# — plus the fast exit that keeps every non-copy Bash call free of subprocess
+# work.
+#
+# Fixtures are marker directories created with mkdir/touch.
+#
+# HOOK_UNDER_TEST overrides the script under test so the must-fail controls
+# (a no-op hook, an always-block hook) can be run against these same
+# assertions.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="${HOOK_UNDER_TEST:-$(cd "$TEST_DIR/.." && pwd)/block-repo-copy.sh}"
+
+PASS=0
+FAIL=0
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+ERR_FILE="$TMP_ROOT/stderr"
+SHIM_LOG="$TMP_ROOT/shim.log"
+
+# --- PATH shims that record every external tool the hook reaches for ---------
+# Each wrapper logs its own name and then execs the real binary, so a run's
+# behavior is unchanged while the log proves whether any work happened past
+# the fast exit. `cat` is deliberately not shimmed: it reads stdin before any
+# decision and would log on every call.
+BIN_DIR="$TMP_ROOT/bin"
+mkdir -p "$BIN_DIR"
+for tool in jq sed grep tr git rsync cp tar; do
+  real="$(command -v "$tool" 2>/dev/null || true)"
+  [ -n "$real" ] || continue
+  cat >"$BIN_DIR/$tool" <<EOF
+#!/usr/bin/env bash
+echo "$tool" >>"\$SHIM_LOG"
+exec "$real" "\$@"
+EOF
+  chmod +x "$BIN_DIR/$tool"
+done
+
+# Run the hook with a Bash tool-call payload on stdin. The temp roots are
+# pinned so scratch classification does not depend on the caller's
+# environment; individual cases re-add a root via extra VAR=value args.
+# Captures stderr in $err and the exit code in $rc.
+run_hook() {
+  local command_json
+  command_json=$(printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g')
+  shift
+  : >"$SHIM_LOG"
+  set +e
+  env -u CLAUDE_CODE_TMPDIR TMPDIR=/tmp PATH="$BIN_DIR:$PATH" SHIM_LOG="$SHIM_LOG" "$@" \
+    bash "$HOOK" <<<"{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"$command_json\"}}" \
+    >/dev/null 2>"$ERR_FILE"
+  rc=$?
+  set -e
+  err="$(cat "$ERR_FILE")"
+  shims="$(cat "$SHIM_LOG" 2>/dev/null || true)"
+}
+
+assert_eq() {
+  local got="$1" want="$2" name="$3"
+  if [[ "$got" == "$want" ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$name" "$want" "$got"
+  fi
+}
+
+assert_contains() {
+  local got="$1" needle="$2" name="$3"
+  if [[ "$got" == *"$needle"* ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected to contain: %s\n        got:      %s\n' "$name" "$needle" "$got"
+  fi
+}
+
+# --- Fixtures ----------------------------------------------------------------
+FIX="$TMP_ROOT/fixtures"
+# A git repository.
+mkdir -p "$FIX/gitrepo/src"
+mkdir -p "$FIX/gitrepo/.git"
+touch "$FIX/gitrepo/src/main.rs"
+# A Rust build tree, no repository history.
+mkdir -p "$FIX/buildtree/target" "$FIX/buildtree/src"
+touch "$FIX/buildtree/src/lib.rs"
+# A Node dependency tree.
+mkdir -p "$FIX/nodetree/node_modules" "$FIX/nodetree/src"
+# A git worktree: `.git` is a FILE pointing at the common dir, not a directory.
+mkdir -p "$FIX/worktree/src"
+printf 'gitdir: /elsewhere/.git/worktrees/wt\n' >"$FIX/worktree/.git"
+# The same shape with none of the markers.
+mkdir -p "$FIX/plain/docs"
+touch "$FIX/plain/docs/notes.md" "$FIX/plain/README.md"
+# A subdirectory OF a repository, itself carrying no markers.
+SUBDIR="$FIX/gitrepo/src"
+
+SCRATCH=/tmp/block-repo-copy-dest
+NON_SCRATCH=/srv/archive/keepme
+
+echo "=== block-repo-copy: blocked copy shapes ==="
+
+run_hook "cp -r $FIX/gitrepo $SCRATCH"
+assert_eq "$rc" "2" "cp -r of a git repo into /tmp is refused"
+
+run_hook "cp -R $FIX/buildtree $SCRATCH"
+assert_eq "$rc" "2" "cp -R of a build tree into /tmp is refused"
+
+run_hook "cp -a $FIX/nodetree $SCRATCH"
+assert_eq "$rc" "2" "cp -a of a node_modules tree into /tmp is refused"
+
+run_hook "cp -rv $FIX/gitrepo $SCRATCH"
+assert_eq "$rc" "2" "a combined short-flag cluster still counts as recursive"
+
+run_hook "rsync -a $FIX/gitrepo/ $SCRATCH"
+assert_eq "$rc" "2" "rsync -a of a git repo into /tmp is refused"
+
+run_hook "rsync --archive $FIX/buildtree $SCRATCH"
+assert_eq "$rc" "2" "rsync --archive of a build tree into /tmp is refused"
+
+run_hook "git clone $FIX/gitrepo $SCRATCH"
+assert_eq "$rc" "2" "git clone of a local repo into /tmp is refused"
+
+run_hook "tar -cf - -C $FIX gitrepo | tar -xf - -C $SCRATCH"
+assert_eq "$rc" "2" "a tar create-to-extract pipe into /tmp is refused"
+
+run_hook "(cd $FIX && tar cf - buildtree) | (cd $SCRATCH && tar xf -)"
+assert_eq "$rc" "2" "a tar pipe using cd for both ends is refused"
+
+run_hook "mkdir -p $SCRATCH && cp -a $FIX/gitrepo $SCRATCH"
+assert_eq "$rc" "2" "the copy is found in a chained command"
+
+run_hook "cp -r $FIX/worktree $SCRATCH"
+assert_eq "$rc" "2" "a worktree whose .git is a file is still a repository"
+
+echo "=== block-repo-copy: scratch destination forms ==="
+
+run_hook "cp -r $FIX/gitrepo /var/tmp/keep"
+assert_eq "$rc" "2" "/var/tmp is a scratch destination"
+
+run_hook 'cp -r '"$FIX"'/gitrepo $TMPDIR/keep'
+assert_eq "$rc" "2" "an unexpanded \$TMPDIR destination is a scratch destination"
+
+run_hook 'cp -r '"$FIX"'/gitrepo $(mktemp -d)'
+assert_eq "$rc" "2" "a mktemp -d destination is a scratch destination"
+
+run_hook "cp -r $FIX/gitrepo /home/agent/scratchpad/copy"
+assert_eq "$rc" "2" "a path containing scratchpad is a scratch destination"
+
+run_hook "cp -r $FIX/gitrepo /srv/agent-tmp/copy" CLAUDE_CODE_TMPDIR=/srv/agent-tmp
+assert_eq "$rc" "2" "CLAUDE_CODE_TMPDIR names a scratch root"
+
+echo "=== block-repo-copy: the refusal names the cause and the alternatives ==="
+
+run_hook "cp -r $FIX/buildtree $SCRATCH"
+assert_contains "$err" "$FIX/buildtree (contains target)" "the refusal names the source and the marker that made it expensive"
+assert_contains "$err" "$SCRATCH (temp/scratch)" "the refusal names the destination"
+assert_contains "$err" "ENOSPC" "the refusal names the failure the copy causes"
+assert_contains "$err" "Read the source in place" "the refusal offers reading in place"
+assert_contains "$err" "MINIMAL synthetic fixture" "the refusal offers a minimal fixture"
+assert_contains "$err" 'mktemp -d' "the refusal shows how to build the fixture"
+
+echo "=== block-repo-copy: commands that must pass ==="
+
+# Same destination, same command shape, source without any marker: the source
+# half of the predicate is what decides.
+run_hook "cp -r $FIX/plain $SCRATCH"
+assert_eq "$rc" "0" "a source with no repository or build tree is copied freely"
+
+# Same source, same command shape, ordinary destination: the destination half
+# of the predicate is what decides.
+run_hook "cp -r $FIX/buildtree $NON_SCRATCH"
+assert_eq "$rc" "0" "a build tree copied to a non-scratch destination is allowed"
+
+run_hook "cp -r $SUBDIR $SCRATCH"
+assert_eq "$rc" "0" "a repository subdirectory carrying no markers is not treated as the repository"
+
+run_hook "cp $FIX/plain/README.md $SCRATCH/README.md"
+assert_eq "$rc" "0" "a non-recursive single-file copy is allowed"
+
+run_hook "cp -r $FIX/plain/docs $SCRATCH/docs"
+assert_eq "$rc" "0" "a small legitimate directory copy into scratch is allowed"
+
+run_hook "rsync -R $FIX/gitrepo $SCRATCH"
+assert_eq "$rc" "0" "rsync -R is --relative, not recursion, so it is not a tree copy"
+
+run_hook "git status --short"
+assert_eq "$rc" "0" "a non-copy command passes"
+
+run_hook "ls -la $FIX/gitrepo $SCRATCH"
+assert_eq "$rc" "0" "reading a repository next to a scratch path is not a copy"
+
+echo "=== block-repo-copy: the fast exit does no work ==="
+
+# A non-copy command must reach no external tool at all. The shim log is the
+# instrument; the case below proves it records when work does happen.
+run_hook "git status --short"
+assert_eq "$shims" "" "a non-copy command invokes no external tool"
+
+run_hook "cp -r $FIX/gitrepo $SCRATCH"
+if [ -n "$shims" ]; then
+  PASS=$((PASS + 1))
+  printf '  ok    %s\n' "the shim log records tool use when the hook does evaluate a copy"
+else
+  FAIL=$((FAIL + 1))
+  printf '  FAIL  %s\n' "the shim log records tool use when the hook does evaluate a copy"
+fi
+
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/pi-extensions/pi-hooks/CHANGELOG.md
+++ b/pi-extensions/pi-hooks/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Consumer-impacting changes
 
+### 0.3.0
+
+- New `blockRepoCopy` setting (default on, category Bash): refuses a recursive copy — `cp -r`/`-R`/`-a`, recursive or archive `rsync`, `git clone` of a local path, or a `tar` create-to-extract pipe — when the source carries repository history or a build tree AND the destination resolves under a temp/scratch root (`/tmp`, `/var/tmp`, `$TMPDIR`, `$CLAUDE_CODE_TMPDIR`, a `mktemp -d`, or any path containing `scratchpad`). Temp roots are commonly RAM-backed tmpfs, where such a copy fills the filesystem and every process writing there fails with ENOSPC. Both halves of the predicate are required, so an expensive tree copied elsewhere and an ordinary directory copied into scratch both pass. New exports from `extensions/repo-copy-guard.ts`: `repoCopyRefusal`, `refusalReason`, `isScratch`, `dangerousMarkers`, `classifySegment`. Mirrors `hooks/block-repo-copy.sh` for Pi.
+
 ### 0.1.6
 
 - Baseline: changelog introduced at this version. Consumer-impacting changes — behavior deltas, new/renamed/removed exports, settings and config changes, protocol/audit-shape changes — are recorded here from this version forward.

--- a/pi-extensions/pi-hooks/README.md
+++ b/pi-extensions/pi-hooks/README.md
@@ -9,6 +9,7 @@ First-class Pi port of the vstack safety hooks. Each hook is independently toggl
 | Hook | Pi event | Behavior |
 | --- | --- | --- |
 | Block bare `cd` | `tool_call` (bash) | Blocks bare `cd /path` commands with no subshell or chaining. Use `(cd /path && command)` instead. |
+| Block repo copy into scratch | `tool_call` (bash) | Refuses a recursive copy (`cp -r`/`-R`/`-a`, recursive or archive `rsync`, `git clone` of a local path, `tar` create-to-extract pipe) when the source carries repository history or a build tree AND the destination resolves under a temp/scratch root. Temp roots are commonly RAM-backed tmpfs, where such a copy fills the filesystem and every process writing there fails with ENOSPC. |
 | Pre-commit fmt + clippy | `tool_call` (bash) | When `git commit` targets the active project repo, runs `cargo fmt --check` then `cargo clippy` in async child processes so Pi stays responsive. Blocks on failure. Skips commits targeting other repos and only fires when `.rs` files are staged or modified; if the bash command contains `git add`, untracked `.rs` files are treated conservatively as possibly staged by that command. |
 | Post-edit clippy | `tool_result` (edit/write of `.rs`) | Runs workspace clippy after `.rs` edits and appends issues mentioning the edited file. Advisory only — doesn't undo the edit. |
 | End-of-turn clippy | `turn_end` | If `.rs` files were touched during the turn, runs workspace clippy and surfaces errors via UI notification. Advisory only. |
@@ -39,6 +40,7 @@ Project settings in `.pi/settings.json` apply only after Pi marks the workspace 
 | --- | --- |
 | Enable hooks | Master toggle. Disable to make the extension inert without uninstalling. |
 | Block bare cd | Toggle the bare-cd block hook. |
+| Block repo copy into scratch | Toggle the recursive-copy-into-scratch block. |
 | Pre-commit fmt + clippy | Toggle the pre-commit hook. |
 | Post-edit clippy | Toggle the post-edit advisory hook. |
 | End-of-turn clippy | Toggle the end-of-turn advisory hook. |

--- a/pi-extensions/pi-hooks/extensions/config.ts
+++ b/pi-extensions/pi-hooks/extensions/config.ts
@@ -16,6 +16,7 @@ export type VstackConfig = Record<string, unknown>;
 export const DEFAULTS = {
 	enabled: true,
 	blockBareCd: true,
+	blockRepoCopy: true,
 	preCommitCheck: true,
 	postEditLint: true,
 	taskCompletedCheck: true,

--- a/pi-extensions/pi-hooks/extensions/hooks.ts
+++ b/pi-extensions/pi-hooks/extensions/hooks.ts
@@ -2,6 +2,7 @@ import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-a
 import { isAbsolute, resolve } from "node:path";
 
 import { isBareCd, runPreCommitCheck } from "./bash-guards.js";
+import { refusalReason, repoCopyRefusal } from "./repo-copy-guard.js";
 import { invalidateClippyCache } from "./cargo.js";
 import { getBool, getNumber, readConfig, recordProjectTrust } from "./config.js";
 import { clippyIssuesForFile, workspaceClippyErrors } from "./lint-hooks.js";
@@ -45,6 +46,13 @@ export default function piHooks(pi: ExtensionAPI): void {
 				reason:
 					"Bare 'cd' changes working directory permanently across tool calls. Use a subshell instead: (cd /path && command)",
 			};
+		}
+
+		if (getBool(cfg, "blockRepoCopy")) {
+			const refusal = repoCopyRefusal(command, ctx.cwd);
+			if (refusal) {
+				return { block: true, reason: refusalReason(command, refusal) };
+			}
 		}
 
 		if (getBool(cfg, "preCommitCheck")) {

--- a/pi-extensions/pi-hooks/extensions/repo-copy-guard.ts
+++ b/pi-extensions/pi-hooks/extensions/repo-copy-guard.ts
@@ -1,0 +1,460 @@
+import { existsSync, statSync } from "node:fs";
+import { isAbsolute, join, resolve } from "node:path";
+import { homedir } from "node:os";
+
+/**
+ * Mirrors `hooks/block-repo-copy.sh`.
+ *
+ * Refuses a recursive copy (cp -r/-R/-a, recursive or archive rsync, git clone
+ * of a local path, tar create-to-extract pipe) when BOTH halves hold: the
+ * source carries repository history or a build tree, AND the destination
+ * resolves under a temp/scratch root.
+ */
+
+/** Directory names whose presence one level inside the source proves the tree is expensive. */
+const DANGER_MARKERS = [
+	".git",
+	"target",
+	"node_modules",
+	"vendor",
+	".venv",
+	"venv",
+	".next",
+	".cache",
+	".gradle",
+	"Pods",
+];
+
+/** Names that are themselves the expensive tree, not merely a container of one. */
+const SELF_MARKERS = new Set([".git", "target", "node_modules"]);
+
+/** Cheap pre-filter: no copy verb, no work. */
+const COPY_VERB = /(^|[^A-Za-z0-9_-])(cp|rsync|tar)([^A-Za-z0-9_-]|$)|git\s+clone/;
+
+/** A variable reference whose NAME means a temp root; the shell expands it at run time. */
+const SCRATCH_VAR = /\$\{?[A-Z_]*(TMP|TEMP|SCRATCH)/;
+
+type Verb = "cp" | "rsync" | "git-clone";
+
+interface Segment {
+	verb: Verb;
+	recursive: boolean;
+	operands: string[];
+	/** cp's -t/--target-directory: every operand is a source and this is the destination. */
+	target: string;
+}
+
+/**
+ * Split into tokens honoring quotes, so a path containing a space stays one
+ * operand instead of splitting into fragments that resolve to nothing. Command
+ * substitutions are kept whole so an inline $(mktemp -d) stays visible.
+ */
+function tokenize(segment: string): string[] {
+	const out: string[] = [];
+	let tok = "";
+	let quote = "";
+	for (let i = 0; i < segment.length; i++) {
+		const ch = segment[i];
+		if (quote === "'") {
+			if (ch === "'") quote = "";
+			else tok += ch;
+			continue;
+		}
+		if (quote === '"') {
+			if (ch === '"') quote = "";
+			else if (ch === "\\" && i + 1 < segment.length) tok += segment[++i];
+			else tok += ch;
+			continue;
+		}
+		if (ch === '"' || ch === "'") {
+			quote = ch;
+			continue;
+		}
+		if (ch === "\\" && i + 1 < segment.length) {
+			tok += segment[++i];
+			continue;
+		}
+		if (ch === "$" && segment[i + 1] === "(") {
+			let depth = 1;
+			let sub = "$(";
+			i += 2;
+			for (; i < segment.length && depth > 0; i++) {
+				const c = segment[i];
+				if (c === "(") depth++;
+				else if (c === ")") depth--;
+				if (depth > 0) sub += c;
+			}
+			i--;
+			tok += `${sub})`;
+			continue;
+		}
+		if (ch === " " || ch === "\t" || ch === "(" || ch === ")") {
+			if (tok) {
+				out.push(tok);
+				tok = "";
+			}
+			continue;
+		}
+		tok += ch;
+	}
+	if (tok) out.push(tok);
+	return out;
+}
+
+/**
+ * Variables assigned a scratch path earlier in the same command, so a
+ * destination written as "$d" is classified by what $d was set to. Reset per
+ * evaluated command.
+ */
+let scratchVars = new Set<string>();
+
+/** The variable a token names, for `$d`, `${d}` and `$d/sub`. */
+function varName(raw: string): string {
+	if (raw.startsWith("${")) return raw.slice(2).split("}")[0];
+	if (raw.startsWith("$")) return raw.slice(1).split("/")[0];
+	return "";
+}
+
+function collectScratchVars(command: string, cwd: string): Set<string> {
+	const names = new Set<string>();
+	for (const seg of command.split(/&&|\|\||;|\|/)) {
+		for (const tok of tokenize(seg)) {
+			const eq = tok.indexOf("=");
+			if (eq <= 0) continue;
+			const name = tok.slice(0, eq);
+			if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) continue;
+			const value = tok.slice(eq + 1);
+			if (value && isScratch(value, cwd)) names.add(name);
+		}
+	}
+	return names;
+}
+
+function expandPath(raw: string, cwd: string): string {
+	let p = raw;
+	const home = homedir();
+	if (p === "~") p = home;
+	else if (p.startsWith("~/")) p = join(home, p.slice(2));
+	return isAbsolute(p) ? p : resolve(cwd, p);
+}
+
+function scratchRoots(): string[] {
+	const roots = ["/tmp", "/var/tmp", process.env.TMPDIR ?? "", process.env.CLAUDE_CODE_TMPDIR ?? ""];
+	return roots.filter((r) => r.length > 0).map((r) => (r.length > 1 ? r.replace(/\/+$/, "") : r));
+}
+
+export function isScratch(raw: string, cwd: string): boolean {
+	const lower = raw.toLowerCase();
+	if (lower.includes("scratchpad") || lower.includes("mktemp")) return true;
+	if (SCRATCH_VAR.test(raw.toUpperCase())) return true;
+	const name = varName(raw);
+	if (name && scratchVars.has(name)) return true;
+	const p = expandPath(raw, cwd);
+	return scratchRoots().some((base) => p === base || p.startsWith(`${base}/`));
+}
+
+function isDirectory(p: string): boolean {
+	try {
+		return statSync(p).isDirectory();
+	} catch {
+		return false;
+	}
+}
+
+/** The markers that make a source expensive, or an empty array when it has none. */
+export function dangerousMarkers(raw: string, cwd: string): string[] {
+	const trimmed = raw.length > 1 ? raw.replace(/\/+$/, "") : raw;
+	const p = expandPath(trimmed, cwd);
+	if (!isDirectory(p)) return [];
+	const base = p.slice(p.lastIndexOf("/") + 1);
+	if (SELF_MARKERS.has(base)) return [base];
+	// `existsSync` only: no traversal, no directory sizing.
+	return DANGER_MARKERS.filter((m) => existsSync(join(p, m)));
+}
+
+/** A leading `cd` in this segment changes what later relative operands mean. */
+function segmentCd(segment: string, cwd: string): string | undefined {
+	const toks = tokenize(segment);
+	if (toks.length === 0) return undefined;
+	if (toks[0].split("/").pop() !== "cd") return undefined;
+	const arg = toks[1];
+	if (arg === undefined) return homedir();
+	if (arg === "-") return undefined;
+	return expandPath(arg, cwd);
+}
+
+/** Recognize one cp / rsync / git clone invocation, or undefined for anything else. */
+export function classifySegment(segment: string): Segment | undefined {
+	let verb: Verb | undefined;
+	let recursive = false;
+	let target = "";
+	const operands: string[] = [];
+	let pendingGit = false;
+	let skipNext = false;
+	let wantTarget = false;
+
+	for (const tok of tokenize(segment)) {
+		if (skipNext) {
+			skipNext = false;
+			continue;
+		}
+		if (wantTarget) {
+			target = tok;
+			wantTarget = false;
+			continue;
+		}
+		if (verb === undefined) {
+			if (pendingGit) {
+				if (tok === "clone") {
+					verb = "git-clone";
+					recursive = true;
+				} else if (tok === "-C") {
+					skipNext = true;
+				} else if (!tok.startsWith("-")) {
+					return undefined;
+				}
+				continue;
+			}
+			if (tok.includes("=")) continue;
+			if (["sudo", "command", "env", "nohup", "time"].includes(tok)) continue;
+			const base = tok.split("/").pop() ?? tok;
+			if (base === "cp") verb = "cp";
+			else if (base === "rsync") verb = "rsync";
+			else if (base === "git") pendingGit = true;
+			else return undefined;
+			continue;
+		}
+
+		if (tok === "--recursive" || tok === "--archive") {
+			recursive = true;
+			continue;
+		}
+		// cp's -t/--target-directory inverts operand order. rsync's -t is
+		// --times, so target parsing is scoped to cp.
+		if (verb === "cp" && tok.startsWith("--target-directory=")) {
+			target = tok.slice("--target-directory=".length);
+			continue;
+		}
+		if (verb === "cp" && tok === "--target-directory") {
+			wantTarget = true;
+			continue;
+		}
+		if (tok.startsWith("--")) continue;
+		if (tok.startsWith("-") && tok.length > 1) {
+			// Short clusters. rsync's -R is --relative, not recursion.
+			if (verb === "cp") {
+				if (/[rRa]/.test(tok)) recursive = true;
+				const t = tok.indexOf("t", 1);
+				if (t === tok.length - 1) wantTarget = true;
+				else if (t > 0) target = tok.slice(t + 1);
+			} else if (verb === "rsync") {
+				if (/[ra]/.test(tok)) recursive = true;
+			}
+			continue;
+		}
+		operands.push(tok);
+	}
+
+	if (verb === undefined) return undefined;
+	return { verb, recursive, operands, target };
+}
+
+function countChar(s: string, ch: string): number {
+	let n = 0;
+	for (const c of s) if (c === ch) n += 1;
+	return n;
+}
+
+export interface Refusal {
+	source: string;
+	markers: string[];
+	destination: string;
+}
+
+function verdict(dest: string, srcs: string[], cwd: string): Refusal | undefined {
+	if (!isScratch(dest, cwd)) return undefined;
+	for (const src of srcs) {
+		if (!src) continue;
+		const markers = dangerousMarkers(src, cwd);
+		if (markers.length === 0) continue;
+		return { source: expandPath(src.replace(/\/+$/, ""), cwd), markers, destination: dest };
+	}
+	return undefined;
+}
+
+function checkCopySegments(command: string, startCwd: string): Refusal | undefined {
+	let cwd = startCwd;
+	let depth = 0;
+	let savedCwd = "";
+	let held = false;
+
+	for (const seg of command.split(/&&|\|\||;|\|/)) {
+		if (!seg.trim()) continue;
+		const opens = countChar(seg, "(");
+		const closes = countChar(seg, ")");
+		if (depth === 0 && opens > 0 && !held) {
+			savedCwd = cwd;
+			held = true;
+		}
+		depth += opens - closes;
+
+		const moved = segmentCd(seg, cwd);
+		if (moved !== undefined) cwd = moved;
+
+		const parsed = classifySegment(seg);
+		if (parsed && parsed.recursive) {
+			let dest = "";
+			let srcs: string[] = [];
+			if (parsed.target && parsed.operands.length >= 1) {
+				dest = parsed.target;
+				srcs = parsed.operands;
+			} else if (parsed.verb === "git-clone" && parsed.operands.length === 1) {
+				dest = cwd;
+				srcs = parsed.operands;
+			} else if (parsed.operands.length >= 2) {
+				dest = parsed.operands[parsed.operands.length - 1];
+				srcs = parsed.operands.slice(0, -1);
+			}
+			if (dest) {
+				const refusal = verdict(dest, srcs, cwd);
+				if (refusal) return refusal;
+			}
+		}
+
+		if (depth <= 0) {
+			depth = 0;
+			if (held) {
+				cwd = savedCwd;
+				held = false;
+			}
+		}
+	}
+	return undefined;
+}
+
+interface TarStage {
+	mode: "c" | "x";
+	dir: string;
+	operands: string[];
+}
+
+/** One piped tar stage: its mode, its working directory (-C or a leading cd), its operands. */
+function tarStage(stage: string): TarStage | undefined {
+	let mode: "c" | "x" | "" = "";
+	let dir = "";
+	const operands: string[] = [];
+	let inTar = false;
+	let wantDir = false;
+	let wantFile = false;
+	let wantCd = false;
+
+	for (const tok of tokenize(stage)) {
+		if (wantCd) {
+			dir = tok;
+			wantCd = false;
+			continue;
+		}
+		if (!inTar) {
+			const base = tok.split("/").pop() ?? tok;
+			if (base === "cd") wantCd = true;
+			else if (base === "tar") inTar = true;
+			continue;
+		}
+		if (wantDir) {
+			dir = tok;
+			wantDir = false;
+			continue;
+		}
+		if (wantFile) {
+			wantFile = false;
+			continue;
+		}
+		if (tok === "-C") {
+			wantDir = true;
+			continue;
+		}
+		if (tok.startsWith("--directory=")) {
+			dir = tok.slice("--directory=".length);
+			continue;
+		}
+		if (tok === "--create") {
+			mode = "c";
+			continue;
+		}
+		if (tok === "--extract" || tok === "--get") {
+			mode = "x";
+			continue;
+		}
+		if (tok.startsWith("--")) continue;
+		if (tok.startsWith("-") && tok.length > 1) {
+			if (tok.includes("c")) mode = "c";
+			if (tok.includes("x")) mode = "x";
+			if (tok.includes("f")) wantFile = true;
+			continue;
+		}
+		// Old-style bundled flags carry no leading dash.
+		if (!mode && /^[cxtrudA]/.test(tok) && /^[cxvfzjJtC]+$/.test(tok)) {
+			if (tok.includes("c")) mode = "c";
+			if (tok.includes("x")) mode = "x";
+			if (tok.includes("f")) wantFile = true;
+			continue;
+		}
+		operands.push(tok);
+	}
+
+	if (!mode) return undefined;
+	return { mode, dir, operands };
+}
+
+function checkTarPipe(command: string, cwd: string): Refusal | undefined {
+	if (!command.includes("|")) return undefined;
+	let srcs: string[] = [];
+	let srcDir = "";
+	let dest = "";
+
+	for (const stage of command.split(/\|\||\|/)) {
+		if (!stage.trim()) continue;
+		const parsed = tarStage(stage);
+		if (!parsed) continue;
+		if (parsed.mode === "c") {
+			srcDir = parsed.dir;
+			srcs = parsed.operands;
+		} else {
+			dest = parsed.dir || cwd;
+		}
+	}
+
+	if ((srcs.length === 0 && !srcDir) || !dest) return undefined;
+	if (srcDir) {
+		srcs = srcs.length === 0
+			? [srcDir]
+			: srcs.map((s) => (isAbsolute(s) || s.startsWith("~") ? s : join(srcDir, s)));
+	}
+	return verdict(dest, srcs, cwd);
+}
+
+export function repoCopyRefusal(command: string, cwd: string): Refusal | undefined {
+	if (!COPY_VERB.test(command)) return undefined;
+	scratchVars = new Set();
+	scratchVars = collectScratchVars(command, cwd);
+	return checkTarPipe(command, cwd) ?? checkCopySegments(command, cwd);
+}
+
+export function refusalReason(command: string, refusal: Refusal): string {
+	return [
+		"Refusing a recursive copy of an expensive tree into scratch space.",
+		`  command:     ${command}`,
+		`  source:      ${refusal.source} (contains ${refusal.markers.join(", ")})`,
+		`  destination: ${refusal.destination} (temp/scratch)`,
+		"",
+		"A source carrying repository history or a build tree is large by construction,",
+		"and temp/scratch filesystems are commonly RAM-backed tmpfs — the copy can fill",
+		"the filesystem, after which every process writing there fails with ENOSPC.",
+		"",
+		"Do one of these instead:",
+		"  - Read the source in place. Reading does not mutate it, so no copy is needed",
+		"    to leave it unchanged.",
+		"  - Build a MINIMAL synthetic fixture:",
+		'      d=$(mktemp -d); mkdir -p "$d/repo/.git" "$d/repo/target"; touch "$d/repo/f"',
+	].join("\n");
+}

--- a/pi-extensions/pi-hooks/package.json
+++ b/pi-extensions/pi-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vanillagreen/pi-hooks",
-  "version": "0.1.6",
+  "version": "0.3.0",
   "description": "First-class Pi port of the vstack safety hooks: bare-cd blocking, pre-commit fmt+clippy, post-edit clippy, end-of-turn lint. Per-hook toggles via pi-extension-manager.",
   "license": "MIT",
   "keywords": [
@@ -42,6 +42,15 @@
           "apply": "live"
         },
         {
+          "key": "blockRepoCopy",
+          "label": "Block repo copy into scratch",
+          "description": "Refuse a recursive copy (`cp -r`/`-R`/`-a`, recursive or archive `rsync`, `git clone` of a local path, `tar` create-to-extract pipe) when the source carries repository history or a build tree AND the destination resolves under a temp/scratch root (`/tmp`, `/var/tmp`, `$TMPDIR`, `$CLAUDE_CODE_TMPDIR`, a `mktemp -d`, or any path containing `scratchpad`). Temp roots are commonly RAM-backed tmpfs, where such a copy fills the filesystem and every process writing there fails with ENOSPC. Both halves of the predicate are required, so an expensive tree copied elsewhere and an ordinary directory copied into scratch both pass. Mirrors hooks/block-repo-copy.sh.",
+          "type": "boolean",
+          "default": true,
+          "category": "Bash",
+          "apply": "live"
+        },
+        {
           "key": "preCommitCheck",
           "label": "Pre-commit fmt + clippy",
           "description": "When the agent runs `git commit` in the project repo, run `cargo fmt --check` and `cargo clippy --workspace --all-targets -- -D warnings` first using async child processes. Block the commit if either fails. Skips commits targeting other repos and only fires when staged or modified .rs files exist; if the bash command contains `git add`, untracked .rs files are treated conservatively as possibly staged by that command. Cost: only paid at commit time.",
@@ -53,7 +62,7 @@
         {
           "key": "postEditLint",
           "label": "Post-edit clippy",
-          "description": "After every edit/write of a .rs file, run `cargo clippy --workspace --all-targets -- -D warnings` and append any issues that mention the edited file to the tool result. Advisory only — does not undo the edit. Cost: full workspace clippy on every Rust edit.",
+          "description": "After every edit/write of a .rs file, run `cargo clippy --workspace --all-targets -- -D warnings` and append any issues that mention the edited file to the tool result. Advisory only \u2014 does not undo the edit. Cost: full workspace clippy on every Rust edit.",
           "type": "boolean",
           "default": true,
           "category": "Rust",

--- a/pi-extensions/pi-hooks/tests/repo-copy-guard.test.ts
+++ b/pi-extensions/pi-hooks/tests/repo-copy-guard.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { repoCopyRefusal } from "../extensions/repo-copy-guard.ts";
+
+/**
+ * Parity suite for `hooks/block-repo-copy.sh`. Fixtures are marker directories
+ * built with mkdir/touch — nothing is ever copied or cloned.
+ */
+
+const FIX = mkdtempSync(join(tmpdir(), "pi-hooks-repo-copy-"));
+
+// A git repository.
+mkdirSync(join(FIX, "gitrepo/src"), { recursive: true });
+mkdirSync(join(FIX, "gitrepo/.git"), { recursive: true });
+// A Rust build tree, no repository history.
+mkdirSync(join(FIX, "buildtree/target"), { recursive: true });
+// A Node dependency tree.
+mkdirSync(join(FIX, "nodetree/node_modules"), { recursive: true });
+// A git worktree: `.git` is a FILE pointing at the common dir.
+mkdirSync(join(FIX, "worktree"), { recursive: true });
+writeFileSync(join(FIX, "worktree/.git"), "gitdir: /elsewhere/.git/worktrees/wt\n");
+// The same shape with none of the markers.
+mkdirSync(join(FIX, "plain/docs"), { recursive: true });
+// A path whose name contains a space.
+mkdirSync(join(FIX, "spaced dir/.git"), { recursive: true });
+
+const CWD = "/home/agent/project";
+const SCRATCH = "/tmp/block-repo-copy-dest";
+const NON_SCRATCH = "/srv/archive/keepme";
+
+function blocked(command: string, cwd = CWD): boolean {
+	return repoCopyRefusal(command, cwd) !== undefined;
+}
+
+describe("blocked copy shapes", () => {
+	test("cp -r of a git repo into /tmp", () => {
+		expect(blocked(`cp -r ${FIX}/gitrepo ${SCRATCH}`)).toBe(true);
+	});
+	test("cp -R of a build tree into /tmp", () => {
+		expect(blocked(`cp -R ${FIX}/buildtree ${SCRATCH}`)).toBe(true);
+	});
+	test("cp -a of a node_modules tree into /tmp", () => {
+		expect(blocked(`cp -a ${FIX}/nodetree ${SCRATCH}`)).toBe(true);
+	});
+	test("a combined short-flag cluster still counts as recursive", () => {
+		expect(blocked(`cp -rv ${FIX}/gitrepo ${SCRATCH}`)).toBe(true);
+	});
+	test("rsync -a of a git repo into /tmp", () => {
+		expect(blocked(`rsync -a ${FIX}/gitrepo/ ${SCRATCH}`)).toBe(true);
+	});
+	test("rsync --archive of a build tree into /tmp", () => {
+		expect(blocked(`rsync --archive ${FIX}/buildtree ${SCRATCH}`)).toBe(true);
+	});
+	test("git clone of a local repo into /tmp", () => {
+		expect(blocked(`git clone ${FIX}/gitrepo ${SCRATCH}`)).toBe(true);
+	});
+	test("a tar create-to-extract pipe into /tmp", () => {
+		expect(blocked(`tar -cf - -C ${FIX} gitrepo | tar -xf - -C ${SCRATCH}`)).toBe(true);
+	});
+	test("a tar pipe using cd for both ends", () => {
+		expect(blocked(`(cd ${FIX} && tar cf - buildtree) | (cd ${SCRATCH} && tar xf -)`)).toBe(true);
+	});
+	test("the copy is found in a chained command", () => {
+		expect(blocked(`mkdir -p ${SCRATCH} && cp -a ${FIX}/gitrepo ${SCRATCH}`)).toBe(true);
+	});
+	test("a worktree whose .git is a file is still a repository", () => {
+		expect(blocked(`cp -r ${FIX}/worktree ${SCRATCH}`)).toBe(true);
+	});
+});
+
+describe("scratch destination forms", () => {
+	test("/var/tmp is scratch", () => {
+		expect(blocked(`cp -r ${FIX}/gitrepo /var/tmp/keep`)).toBe(true);
+	});
+	test("an unexpanded $TMPDIR destination is scratch", () => {
+		expect(blocked(`cp -r ${FIX}/gitrepo $TMPDIR/keep`)).toBe(true);
+	});
+	test("an unexpanded $CLAUDE_CODE_TMPDIR destination is scratch", () => {
+		expect(blocked(`cp -r ${FIX}/gitrepo $CLAUDE_CODE_TMPDIR/keep`)).toBe(true);
+	});
+	test("a mktemp -d destination is scratch", () => {
+		expect(blocked(`cp -r ${FIX}/gitrepo $(mktemp -d)`)).toBe(true);
+	});
+	test("a path containing scratchpad is scratch", () => {
+		expect(blocked(`cp -r ${FIX}/gitrepo /home/agent/scratchpad/copy`)).toBe(true);
+	});
+	test("an unexpanded variable naming no temp root is not scratch", () => {
+		expect(blocked(`cp -r ${FIX}/gitrepo $HOME/keep`)).toBe(false);
+	});
+});
+
+describe("the destination the shell would actually write to", () => {
+	test("cp -t names the destination, which is not the last operand", () => {
+		expect(blocked(`cp -r -t ${SCRATCH} ${FIX}/gitrepo`)).toBe(true);
+	});
+	test("cp --target-directory=DIR names the destination", () => {
+		expect(blocked(`cp -r --target-directory=${SCRATCH} ${FIX}/gitrepo`)).toBe(true);
+	});
+	test("cp -rt DIR carries the target inside the short cluster", () => {
+		expect(blocked(`cp -rt ${SCRATCH} ${FIX}/gitrepo`)).toBe(true);
+	});
+	test("a target-directory outside scratch is allowed", () => {
+		expect(blocked(`cp -r --target-directory=${NON_SCRATCH} ${FIX}/gitrepo`)).toBe(false);
+	});
+	test("rsync -t is --times, so the last operand stays the destination", () => {
+		expect(blocked(`rsync -rt ${FIX}/gitrepo ${SCRATCH}`)).toBe(true);
+	});
+	test("a relative destination resolves against an earlier cd", () => {
+		expect(blocked(`cd ${SCRATCH} && cp -r ${FIX}/gitrepo copy`)).toBe(true);
+	});
+	test("cd then git clone with no destination", () => {
+		expect(blocked(`cd /tmp && git clone ${FIX}/gitrepo`)).toBe(true);
+	});
+	test("a cd to an ordinary directory leaves relative copies alone", () => {
+		expect(blocked(`cd ${NON_SCRATCH} && cp -r ${FIX}/gitrepo copy`)).toBe(false);
+	});
+	test("a cd inside a subshell group does not leak past the group", () => {
+		expect(blocked(`(cd ${SCRATCH} && ls) && cp -r ${FIX}/gitrepo copy`)).toBe(false);
+	});
+	test("a quoted source path containing a space stays one operand", () => {
+		expect(blocked(`cp -r "${FIX}/spaced dir" ${SCRATCH}`)).toBe(true);
+	});
+	test("a variable assigned mktemp -d earlier in the command is scratch", () => {
+		expect(blocked(`d=$(mktemp -d); cp -r ${FIX}/gitrepo "$d"`)).toBe(true);
+	});
+	test("an option argument is not counted as an operand", () => {
+		expect(blocked(`git clone --depth 1 ${FIX}/gitrepo ${SCRATCH}`)).toBe(true);
+	});
+	test("an rsync option argument is not counted as an operand", () => {
+		expect(blocked(`rsync -a --exclude target ${FIX}/gitrepo ${SCRATCH}`)).toBe(true);
+	});
+});
+
+describe("commands that must pass", () => {
+	test("a source with no repository or build tree", () => {
+		expect(blocked(`cp -r ${FIX}/plain ${SCRATCH}`)).toBe(false);
+	});
+	test("an expensive tree copied to a non-scratch destination", () => {
+		expect(blocked(`cp -r ${FIX}/buildtree ${NON_SCRATCH}`)).toBe(false);
+	});
+	test("a repository subdirectory carrying no markers of its own", () => {
+		expect(blocked(`cp -r ${FIX}/gitrepo/src ${SCRATCH}`)).toBe(false);
+	});
+	test("a non-recursive single-file copy", () => {
+		expect(blocked(`cp ${FIX}/plain/README.md ${SCRATCH}/README.md`)).toBe(false);
+	});
+	test("a small legitimate directory copy into scratch", () => {
+		expect(blocked(`cp -r ${FIX}/plain/docs ${SCRATCH}/docs`)).toBe(false);
+	});
+	test("rsync -R is --relative, not recursion", () => {
+		expect(blocked(`rsync -R ${FIX}/gitrepo ${SCRATCH}`)).toBe(false);
+	});
+	test("a non-copy command", () => {
+		expect(blocked("git status --short")).toBe(false);
+	});
+	test("reading a repository next to a scratch path is not a copy", () => {
+		expect(blocked(`ls -la ${FIX}/gitrepo ${SCRATCH}`)).toBe(false);
+	});
+});
+
+describe("the refusal names the cause", () => {
+	test("source, marker, and destination", () => {
+		const refusal = repoCopyRefusal(`cp -r ${FIX}/buildtree ${SCRATCH}`, CWD);
+		expect(refusal).toBeDefined();
+		expect(refusal?.source).toBe(join(FIX, "buildtree"));
+		expect(refusal?.markers).toEqual(["target"]);
+		expect(refusal?.destination).toBe(SCRATCH);
+	});
+});
+
+describe("cleanup", () => {
+	test("fixtures removed", () => {
+		rmSync(FIX, { recursive: true, force: true });
+		expect(true).toBe(true);
+	});
+});


### PR DESCRIPTION
## The incident this prevents

An agent was told to sanity-check behavior against a real consumer repo "read-only, under `~/dev`". It interpreted that as "copy it somewhere safe first" and ran a recursive copy of `~/dev/memsira` into its scratchpad — twice. That repo carries a ~29GB `target/` build tree plus a large `.git`. `/tmp` on that machine is a tmpfs (kernel default: 50% of RAM = 63GB), so the copy consumed roughly half of system RAM, filled the filesystem to 100%, and every process writing there began failing with ENOSPC — which broke tool output across the whole session until it was cleaned up manually.

Prose instructions did not prevent it and cannot be relied on to: the agent's reasoning ("copying makes it read-only") was locally sensible. This needs to be enforced by the harness, before the command runs.

## What this adds

`hooks/block-repo-copy.sh` — a `PreToolUse` / `Bash` hook following `hooks/block-bare-cd.sh`'s conventions (same frontmatter block, same input parsing, same fast-exit-first structure, same explain-and-suggest refusal).

It refuses a recursive copy when **both** halves hold:

| half | matches |
|---|---|
| **shape** | `cp -r`/`-R`/`-a` (incl. clusters like `-rv`), `rsync` with `-r`/`-a`/`--recursive`/`--archive`, `git clone` of a local path, `tar` create-to-extract pipes (`-C` or a leading `cd` on either end) |
| **source** | itself named `.git`/`target`/`node_modules`, or carrying one of `.git`, `target`, `node_modules`, `vendor`, `.venv`, `venv`, `.next`, `.cache`, `.gradle`, `Pods` one level down |
| **destination** | resolves under `/tmp`, `/var/tmp`, `$TMPDIR`, `$CLAUDE_CODE_TMPDIR`; or is a `mktemp -d`; or contains `scratchpad` |

The marker set was picked by surveying `~/dev` rather than guessed. `.git` is checked with `-e`, so a worktree (where `.git` is a *file*) counts as a repository.

### Refusal message

```
Refusing a recursive copy of an expensive tree into scratch space.
  command:     cp -r /home/method/dev/memsira /tmp/x
  source:      /home/method/dev/memsira (contains .git, target, node_modules, vendor, .cache)
  destination: /tmp/x (temp/scratch)

A source carrying repository history or a build tree is large by construction,
and temp/scratch filesystems are commonly RAM-backed tmpfs — the copy can fill
the filesystem, after which every process writing there fails with ENOSPC.

Do one of these instead:
  - Read the source in place. Reading does not mutate it, so no copy is needed
    to leave it unchanged.
  - Build a MINIMAL synthetic fixture:
      d=$(mktemp -d); mkdir -p "$d/repo/.git" "$d/repo/target"; touch "$d/repo/f"
```

### False positives and hot-path cost

Requiring both halves is what keeps false positives near zero. These all pass: an expensive tree copied to an ordinary destination; an ordinary directory copied into scratch; a non-recursive single-file `cp`; `rsync -R` (that's `--relative`, not recursion); a repository *subdirectory* carrying no marker of its own (the source check never walks upward); and any non-copy command.

The hook fires on every Bash call, so the non-copy path exits through a **bash-builtin regex** — no fork, no filesystem access. The source check is `-e` existence tests only; nothing shells out to `du` or traverses a tree.

## Registration

**No config change was needed.** `[hook-events]` in `vstack.toml` maps `event:matcher` → roles, and `hooks_for_agent` (`cli/src/mapping.rs`) resolves each hook by its own frontmatter. The existing `"PreToolUse:Bash" = "all"` already matches this hook's `event: PreToolUse` / `matcher: Bash`, and hooks are discovered from the `hooks/` catalog. Consuming repos pick it up on the next `vstack refresh`.

## Tests — red-first

`hooks/tests/block-repo-copy.test.sh`, 32 assertions, following `pre-commit-check.test.sh`'s conventions. Fixtures are marker directories built with `mkdir`/`touch`; **nothing in the suite copies a real tree.**

Every assertion was proven to fail before it passed. `HOOK_UNDER_TEST` swaps the script under test, so the must-fail controls are reproducible:

| control | stands in for | assertions that FAIL |
|---|---|---|
| `noop.sh` (`exit 0`) | the pre-hook state — no hook installed | 23 — every blocked shape, every scratch-destination form, all 6 refusal-text assertions, and the shim-log-records case |
| `block.sh` (`exit 2`) | a hook that refuses everything | 15 — all 8 must-pass commands, the 6 refusal-text assertions, the shim-log case |
| `eager.sh` (forks `jq`, then `exit 0`) | a hook that works before deciding | the fast-exit assertion |

Union: **all 32 assertions** fail under at least one control. Against the real hook: 32/32 pass.

The fast exit is pinned by a PATH shim that logs every external tool the hook reaches for: the log must be **empty** for a non-copy command, and must be **non-empty** when a copy is actually evaluated (that second case is the control proving the log instrument works — it caught a genuinely broken assertion during development, where the shim dir had not been put on `PATH` and the emptiness check was passing vacuously).

## Suite results (all foreground)

| suite | result |
|---|---|
| `hooks/tests/*.sh` | **87 pass, 0 fail** (block-repo-copy 32, pre-commit-check 55) |
| `skills/orch/tests/run-all.sh` | **37/37 files pass** |
| all other skill suites (117 files) | **0 failures** |
| review-gate suites (8 of 9) | **all pass** |
| exec-bit check (CI shell shard) | pass |
| `preflight --base origin/main` | clean |
| `review-predicate-selftest.sh` (CI `gate-selftest` job) | **251 cases, all pass** (13s) |

**One suite was not completed locally:** `skills/review-gate/tests/review-predicate-selftest.test.sh` — the wrapper battery that spawns a full ~250-case selftest per fixture — exceeds this harness's 10-minute foreground cap, producing zero output at 240s and at 600s. It was verified pre-existing: `git stash`ed to the unmodified `origin/main` tree, it behaves identically (zero output, timeout at 240s). This diff adds only two files under `hooks/` and touches nothing under `skills/review-gate/`. CI runs it with a 25-minute shard budget.


https://claude.ai/code/session_016J7UX4mMMMJeqXAg8d6NHB
