### PR TITLE
orch: delegation mints reviewer artifact paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- orch review-pr mints each reviewer's artifact path at delegation time
+  (`review-artifact-check --path`) and passes it as the delegation's
+  `Artifact:` line; reviewers write to that exact path instead of
+  hand-formatting filename timestamps (two of four drill-2 reviewers still
+  wrote placeholder clocks under the mint-it-yourself contract).
+
 - **orch + dev: six determinism/efficiency fixes from a live end-to-end drill**
   (a fake issue run through the full stack on a low-effort lane, watched phase
   by phase; every fix is a deletion, a short-circuit, or a tool — no added

--- a/skills/orch/workflows/review-pr.md
+++ b/skills/orch/workflows/review-pr.md
@@ -128,11 +128,18 @@ Stamp the freshness boundary immediately before the delegation batch — it gate
 
 Delegate to every reviewer in the active set in parallel. When `EXTERNAL_REVIEW_REQUESTED=true`, launch the external review in the same batch — it is a shell command, not an agent session, so it consumes no slot and joins only the cycle's first wave.
 
+Mint each reviewer's artifact path immediately before its delegation — one command per reviewer, its output filling `[ARTIFACT_PATH]`:
+
+```bash
+.agents/skills/orch/scripts/review-artifact-check --path [WORKTREE_PATH] [AGENT]
+```
+
 <delegation_format>
 Follow workflow: .agents/skills/reviewer/workflows/review.md
 
 Worktree: [WORKTREE_PATH]
 Branch: [BRANCH]
+Artifact: [ARTIFACT_PATH]
 
 Decisions:
 [For each verified decision: "- [DECISION_ID]: [ONE_LINE_SUMMARY] — [DECISION_FILE_PATH]"]

--- a/skills/reviewer/SKILL.md
+++ b/skills/reviewer/SKILL.md
@@ -38,7 +38,7 @@ Shared contract for every review specialist. Each agent's domain and probes live
 
 ## Output Contract
 
-Findings are a JSON artifact per [`schemas/review-finding.md`](./schemas/review-finding.md), written with the harness file-write tool — never shell redirection — to the exact path this prints (`[AGENT]` = your full agent name):
+Findings are a JSON artifact per [`schemas/review-finding.md`](./schemas/review-finding.md), written with the harness file-write tool — never shell redirection — to the delegation's `Artifact:` path. When the delegation carries no `Artifact:` line, mint the path yourself (`[AGENT]` = your full agent name):
 
 ```bash
 .agents/skills/orch/scripts/review-artifact-check --path [WORKTREE_PATH] [AGENT]


### PR DESCRIPTION
Follow-up to #1273 (drill finding D4): 2 of 4 drill-2 reviewers still hand-formatted placeholder timestamps. The orchestrator now mints each path with review-artifact-check --path and passes it in the delegation; the reviewer contract points at the Artifact: line, minting only as fallback. orch 33/33 + reviewer suites green.

https://claude.ai/code/session_01D2S3tFC6pWZCUokNWVQugB