### PR TITLE
orch: declines are terminal — no re-ask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- finding-disposition: a decline is terminal — it appears as its one-line
+  summary entry and is never re-presented as a "file it anyway?" question
+  (drill 3: an orchestrator improvised exactly that ask after a correct
+  decline).
+
 - orch review-pr mints each reviewer's artifact path at delegation time
   (`review-artifact-check --path`) and passes it as the delegation's
   `Artifact:` line; reviewers write to that exact path instead of

--- a/skills/orch/references/finding-disposition.md
+++ b/skills/orch/references/finding-disposition.md
@@ -37,7 +37,7 @@ An `issue` signal is necessary but not sufficient. File only for:
 
 The audit pipeline applies project-management's creation bar (its SKILL.md § Disposition) as the final authority; these classes describe what clears it.
 
-Everything else is absorbed or declined. P4 polish never files: absorb it when it is est-1 and related, otherwise drop it with a one-line note in the review summary. A finding that cannot affect real usage is declined with one line of rationale — neither fixed nor filed. Vague items are noise, not visibility.
+Everything else is absorbed or declined. P4 polish never files: absorb it when it is est-1 and related, otherwise drop it with a one-line note in the review summary. A finding that cannot affect real usage is declined with one line of rationale — neither fixed nor filed. A decline is terminal: it appears as its summary line and is never re-presented as a question ("file it anyway?"). Vague items are noise, not visibility.
 
 When a same-surface bundle or umbrella parent already exists, residue attaches to it as a child or related issue; a standalone filing needs a stated reason.
 


### PR DESCRIPTION
Drill-3 finding D7: after finding-disposition correctly declined a benchmark-infra issue, the session improvised a 'file it anyway?' question. One clause makes declines terminal: summary line, never a re-ask. orch 33/33 green.

https://claude.ai/code/session_01D2S3tFC6pWZCUokNWVQugB