### PR TITLE
orch: oversee fleet mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+- **orch: `oversee` fleet mode.** A standing session that burns down the
+  unblocked queue: one orch session per item, shepherded to merge. The launch
+  surface resolves once — tmux lanes via `open-terminal`; otherwise the
+  harness's own session/thread launching (Codex threads, agent teams, app
+  session tools) carrying the same brief; with neither, the queue runs
+  sequentially in-session. `ORCH_OVERSEER_LANES` caps concurrent lanes
+  (default 3). pr-watch is the fleet's single PR reducer where installed.
+  The settings-parity test now enrolls new orch keys, so template drift
+  between the skill and root examples fails the suite.
+
 - finding-disposition: a decline is terminal — it appears as its one-line
   summary entry and is never re-presented as a "file it anyway?" question
   (drill 3: an orchestrator improvised exactly that ask after a correct

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Windows: CLI runs natively; symlink mode falls back to copy.
 | [`github`](skills/github/)* | Bash CLI over the GitHub API for PR operations: threads, comments, reviews, CI logs, merging, and cross-PR analysis. |
 | [`dev`](skills/dev/)* | Delegated implementation and review-fix issue workflows for dev agents. |
 | [`linear`](skills/linear/)* | Bash CLI over Linear's GraphQL API with local cache, mutation syncing, and structured output (issues, cycles, milestones, projects). |
-| [`orch`](skills/orch/)* | Primary-agent single work-item orchestration for Linear/GitHub issues: prepare, delegate, review, submit, merge, and launch handoff. Sub-agents do NOT load this directly. |
+| [`orch`](skills/orch/)* | Primary-agent orchestration for Linear/GitHub issues: prepare, delegate, review, submit, merge, launch handoff, and oversee session fleets. Sub-agents do NOT load this directly. |
 | [`code-quality`](skills/code-quality/) | Generic code-authoring standards for dev agents: no fail-open branches, prove-your-guards, comment rules, over-engineering and cleanup discipline. |
 | [`preflight`](skills/preflight/) | Diff-scoped deterministic pre-review checks: shell syntax/fail-open lint, dead doc citations, unlinked TODOs, JSON/TOML syntax. |
 | [`project-management`](skills/project-management/)* | TPM-driven planning, audits, roadmaps, and research-backed decomposition. |

--- a/skills/orch/SKILL.md
+++ b/skills/orch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: orch
-description: "PRIMARY AGENT ONLY — single work-item orchestration for Linear or GitHub issues: prepare, delegate implementation, review, submit, merge, and hand off."
+description: "PRIMARY AGENT ONLY — work-item orchestration for Linear or GitHub issues: prepare, delegate implementation, review, submit, merge, hand off, and oversee fleets of sessions."
 license: MIT
 user-invocable: true
 dependencies:
@@ -53,6 +53,7 @@ Route `<command> [args]` to its workflow and follow [Workflow Execution](#workfl
 | `submit-pr` | `[PR_NUMBER]` | `workflows/submit-pr.md` | Push, create PR, triage, review gate, CI, merge gates |
 | `merge-pr` | `PR_NUMBER` \| `all` | `workflows/merge-pr.md` | Verify conditions and merge |
 | `post-summary` | `[ISSUE_ID]` | `workflows/post-summary.md` | Post summary and handoff comments |
+| `oversee` | — | `workflows/oversee.md` | Fleet mode: launch one session per unblocked item and shepherd every PR to merge |
 
 **`start` routing.** Parse explicit args first: `github OWNER/REPO#N` → `TRACKER=github`, `ISSUE_ID=issue-N`, keep `OWNER/REPO` for the API; otherwise Linear unless the id already starts with `issue-`. A cwd whose git common dir differs from `.git` is a worktree → `workflows/start-worktree.md`; otherwise `workflows/start.md`.
 
@@ -114,6 +115,7 @@ Non-secret settings go in committed `vstack.settings.toml` under `[env]`; `.env.
 | `REVIEWER_SLOT_BUDGET` | The runtime's total concurrent agent-session budget, counting the primary session; `0` = unlimited. On Codex, set it to the cap `spawn-adapter slots` reports | `0` |
 | `ORCH_DECISION_MODE` | `ask` presents every workflow decision; `auto-recommended` executes the recommended option and logs `auto-selected: [option] — [reason]` in workflow-state `auto_decisions`. The always-ask set in [The Cycle](#the-cycle) applies in every mode | `ask` |
 | `ORCH_MERGE_AUTONOMY` | `auto` merges without asking once every merge gate is green; `ask` presents the merge decision. A `MERGE_READY = false` state never auto-merges | `ask` |
+| `ORCH_OVERSEER_LANES` | Max concurrent lanes `oversee` keeps in flight | `3` |
 | Review-gate settings | `REVIEW_GATE_MODE`, `PR_REVIEW_GATE`, `PR_REVIEW_CHECK`, `PR_REVIEW_ON_TIMEOUT`, `PR_REVIEW_NUDGE*`, `PR_REVIEW_WAIT_SECS` — [references/gates.md](references/gates.md) | — |
 | Lane settings | `ORCH_LANE_DIRS`, `ORCH_LANE_ALIASES`, `ORCH_LANE_MAX_PCT`, `ORCH_TMUX_VERIFY_SECS` — `lanes --help`, `open-terminal --help` | — |
 

--- a/skills/orch/tests/settings-example-sync.test.sh
+++ b/skills/orch/tests/settings-example-sync.test.sh
@@ -14,7 +14,7 @@ ROOT_TEMPLATE="$SCRIPT_DIR/../../../vstack.settings.toml.example"
 # REVIEW_GATE_MODE's owning skill is review-gate (its settings-example-sync
 # test pins the same key); orch lists it too because orch consumes the
 # one-switch gate disable even where the review-gate engine is not installed.
-ORCH_KEYS="PR_REVIEW_GATE REVIEW_GATE_MODE PR_REVIEW_WAIT_SECS PR_REVIEW_NUDGE_SECS PR_REVIEW_NUDGE PR_REVIEW_CHECK PR_REVIEW_ON_TIMEOUT CI_WAIT_NO_CHECKS_GRACE CI_FIX_MAX_CYCLES REVIEWER_SLOT_BUDGET ORCH_DECISION_MODE ORCH_TMUX_VERIFY_SECS"
+ORCH_KEYS="PR_REVIEW_GATE REVIEW_GATE_MODE PR_REVIEW_WAIT_SECS PR_REVIEW_NUDGE_SECS PR_REVIEW_NUDGE PR_REVIEW_CHECK PR_REVIEW_ON_TIMEOUT CI_WAIT_NO_CHECKS_GRACE CI_FIX_MAX_CYCLES REVIEWER_SLOT_BUDGET ORCH_DECISION_MODE ORCH_MERGE_AUTONOMY ORCH_OVERSEER_LANES ORCH_TMUX_VERIFY_SECS"
 
 # Opt-in keys with no shipped default: the skill template carries a COMMENTED
 # example (nothing to merge, so no uncommented assignment) so the option is

--- a/skills/orch/vstack.settings.toml.example
+++ b/skills/orch/vstack.settings.toml.example
@@ -106,3 +106,7 @@ ORCH_TMUX_VERIFY_SECS = "15"
 # discovery already found. ORCH_LANE_DIRS (colon-separated) covers a layout
 # discovery cannot reach.
 # ORCH_LANE_ALIASES = "eclaude=work,mclaude=overflow"
+
+# Used by: orch (`oversee`). Max concurrent lanes the overseer keeps in
+# flight.
+ORCH_OVERSEER_LANES = "3"

--- a/skills/orch/workflows/oversee.md
+++ b/skills/orch/workflows/oversee.md
@@ -1,0 +1,35 @@
+# Oversee
+
+Standing fleet mode: burn down unblocked work items by launching one orch session per item and shepherding every PR to merge. The overseer launches, watches, unblocks, and merges — it never implements or reviews.
+
+## 1. Resolve The Launch Surface
+
+Once per session, first match wins:
+
+1. `$TMUX` set → tmux lanes: launch each item with `open-terminal` (`lanes pick` chooses the account lane; launch flags sized per item — `handoff.md` § 2).
+2. The harness ships session or thread launching (Codex threads, Claude Code agent teams, a desktop app's session tool or bundled skill) → use it: one managed session per item, carrying the same brief `open-terminal` would render.
+3. Neither → no parallel surface. Say so once and work the queue sequentially in this session: `start [ISSUE_ID]` per item, § 2 selection between items.
+
+## 2. Select Work
+
+Unblocked, non-terminal items from the tracker, gated exactly as `start.md` gates them (ancestor chain, blocker union, container rules). Ownership is settled by tooling, not judgment: an item whose `worktree create` exits 75 belongs to another session — skip it. Keep at most `ORCH_OVERSEER_LANES` items in flight.
+
+## 3. Launch
+
+Per item, mint the brief `/orch start [ISSUE_ID]` (or `/orch start github [OWNER/REPO]#[N]`), size launch flags to the item, and launch on the § 1 surface. Record the lane:
+
+```bash
+.agents/skills/orch/scripts/workflow-state append oversee lanes '{"issue":"[ISSUE_ID]","surface":"[SURFACE]","launched_at":"[NOW]"}'
+```
+
+## 4. Watch And Advance
+
+When `.agents/skills/review-gate/scripts/pr-watch.sh` exists, run it as the single state reducer across every open PR; otherwise fall back to per-PR `approval-wait`/`queue-wait` ([references/gates.md](../references/gates.md)). Never hand-roll a transition-keyed monitor.
+
+- A lane's PR merges → mark the lane done, launch the next unblocked item.
+- A lane's session ends with no merged PR → inspect its worktree and PR state, re-launch once with the same brief; a second death is surfaced to the user, not retried.
+- A lane blocks on something only its own session can answer → that is the lane's report to surface, not the overseer's to answer.
+
+## 5. Stop
+
+Queue empty, or the user stops it. Report one line per lane: merged SHAs, still-open PRs, items skipped as owned or blocked.

--- a/vstack.settings.toml.example
+++ b/vstack.settings.toml.example
@@ -49,6 +49,10 @@ ORCH_MERGE_AUTONOMY = "ask"
 # decision; "auto" merges without asking once every merge gate is green.
 # MERGE_READY = false never auto-merges.
 
+ORCH_OVERSEER_LANES = "3"
+# Used by: orch (`oversee`). Max concurrent lanes the overseer keeps in
+# flight.
+
 ORCH_DECISION_MODE = "ask"
 # Used by: orch (`review-pr` § 4/§ 7, `dev-fix` § 1). How workflow decision
 # points behave. "ask" (default) presents every decision to the user.


### PR DESCRIPTION
Owner-requested: the manual overseer tmux panes become a first-class orch mode. workflows/oversee.md (44 lines): launch-surface resolution (tmux → open-terminal/lanes; app harness threads → same brief; neither → sequential in-session), start-gated work selection with tooling-settled ownership (worktree exit 75 = skip), pr-watch as the fleet reducer, bounded re-launch, one-line-per-lane stop report. ORCH_MERGE_AUTONOMY + ORCH_OVERSEER_LANES enrolled in the settings-parity guard (teeth proven). orch 33/33 green.

https://claude.ai/code/session_01D2S3tFC6pWZCUokNWVQugB