### PR TITLE
review-gate: un-invert the two-greens safety caveat (+2 doc corrections)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- **review-gate docs: a compression in #1277 INVERTED the gate's central
+  safety caveat** — README claimed "Two greens prove no review" where the
+  contract is "two greens do NOT prove a review happened" (they attest only
+  that the gate is off). Caught by both bot reviewers on all five consumer
+  vendor PRs, held unmerged by the propagation agent, fixed upstream here and
+  re-vendored. Also: the relay cost line now counts the retry path's second
+  content-creating request, and the rate-limit table row states the real
+  beyond-cap behavior (skip, not clamp).
+
 - **Bot-review triage across #1272-#1277 scripts** (admin merges skip bot
   rounds; this closes the loop): linear `issues update --labels` now refuses
   an unknown label instead of silently shipping a partial set (new

--- a/skills/review-gate/README.md
+++ b/skills/review-gate/README.md
@@ -66,9 +66,10 @@ keeping the two separate is what makes this small enough to trust.
                     └────────────────────────────┘
 ```
 
-\* Two greens prove no review. With `REVIEW_GATE_MODE = "off"` the writer
-posts green with a "gate disabled by settings" description; and merge-group
-(queue) statuses bypass the predicate entirely, always posting green as
+\* Two greens do NOT prove a review happened. With `REVIEW_GATE_MODE = "off"`
+the writer posts green with a "gate disabled by settings" description — it
+attests only that the gate is off; and merge-group (queue) statuses bypass
+the predicate entirely, always posting green as
 "merge-queue entry: post-approval by construction". Caveats:
 [references/settings.md](references/settings.md) § `REVIEW_GATE_MODE`.
 

--- a/skills/review-gate/references/adoption.md
+++ b/skills/review-gate/references/adoption.md
@@ -190,7 +190,7 @@ each repo takes it as its own PR. What changed in the template:
 
   | Answer | Wait | Recognized by |
   |---|---|---|
-  | Rate limit | The named window, floored at 60s and capped at 120s, plus bounded jitter | `retry-after`; `x-ratelimit-reset` *only when `x-ratelimit-remaining` is 0*; a header-less secondary limit, from its body or an HTTP 429 |
+  | Rate limit | The named window, floored at 60s, plus bounded jitter — a window beyond 120s skips the retry instead of waiting | `retry-after`; `x-ratelimit-reset` *only when `x-ratelimit-remaining` is 0*; a header-less secondary limit, from its body or an HTTP 429 |
   | Transient | 5s | Anything else retryable — the minute is for rate limits, not blips |
   | Permanent | Not retried | 400; 404 (renamed workflow file); 405; 422 (bad ref); 401 (revoked token); 403 carrying no rate-limit evidence — the `Resource not accessible by integration` shape a trimmed permissions block or an org token policy produces |
 
@@ -215,8 +215,9 @@ attempt), which still fits inside the job's 5-minute budget. The relay is
 unconditional and group-less, so unlike the writer group it coalesces nothing
 — that is one run per event, including every `status` transition every CI
 provider posts on every open head. Each run also spends one content-creating
-API request against the repo's shared secondary-limit budget; exhausting that
-budget degrades events to the cron floor rather than breaking convergence.
+API request against the repo's shared secondary-limit budget — two when the
+retry path fires its bounded second attempt; exhausting that budget degrades
+events to the cron floor rather than breaking convergence.
 Event-fast latency grows by a whole extra run lifecycle — two queue and
 runner-allocation waits instead of one, typically seconds and well inside the
 cron floor's period. When runner allocation exceeds that period the scheduled


### PR DESCRIPTION
The #1277 de-triplication inverted README's central safety caveat ('Two greens prove no review.' — backwards). Both bot reviewers flagged it on all five consumer vendor PRs; the propagation agent held the queues. Fixed to the SKILL.md-consistent form; retry-path cost and rate-limit beyond-cap behavior corrected alongside. review-gate md tests green.

https://claude.ai/code/session_01D2S3tFC6pWZCUokNWVQugB