### PR TITLE
review-gate: template cost line matches #1280

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- review-gate: the writer template header now counts the retry path's second
+  content-creating request, matching the #1280 adoption.md correction (the
+  two had diverged); adopted consumer copies inherit it at their next writer
+  migration.
+
 - **review-gate docs: a compression in #1277 INVERTED the gate's central
   safety caveat** — README claimed "Two greens prove no review" where the
   contract is "two greens do NOT prove a review happened" (they attest only

--- a/skills/review-gate/templates/review-gate-writer.yml
+++ b/skills/review-gate/templates/review-gate-writer.yml
@@ -39,7 +39,8 @@
 # — and the relay is unconditional and group-less, so unlike the writer
 # group it coalesces nothing: that is one billed-minimum run per event,
 # including every status transition from every CI provider on every open
-# head. Each run also spends one content-creating API request against the
+# head. Each run also spends one content-creating API request — two when the
+# retry path fires its bounded second attempt — against the
 # repo's SHARED secondary-limit budget; exhausting that budget degrades
 # every event to the cron floor rather than breaking convergence. A run
 # that has to back off holds its runner longer — worst modeled case ~4.2


### PR DESCRIPTION
prop-vendor-md follow-up: #1280 corrected adoption.md's relay cost sentence but not the workflow template header that mirrors it. One line; template suite green. Adopted copies inherit at each repo's next writer migration — deliberately not a six-repo rollout for a header comment.

https://claude.ai/code/session_01D2S3tFC6pWZCUokNWVQugB