### PR TITLE
fix(orch): #1284 bot-review triage — brief terminal condition, pattern-doc default, interface trigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- Post-merge bot triage of #1284: `open-terminal` now renders the
+  merged-and-cleaned terminal condition into every launched brief (the
+  handoff/oversee requirement previously reached only hand-minted briefs);
+  README's `GH_ISSUE_PATTERN` row documents the real built-in default
+  (`([A-Z]+-[0-9]+|issue-[0-9]+)` — the transcribed value would have
+  rejected `issue-N` branches if copied into settings); post-summary's
+  downstream-handoff trigger regains `interface` alongside `API`.
+
 - **orch/fleet simplification v2 — ablation-tested condensation.** Every
   contested SKILL.md section got an A/B answer from live drills on the private
   rig (claude arm: full cycle 13 min vs the 14 min CI+perf baseline, zero

--- a/skills/orch/README.md
+++ b/skills/orch/README.md
@@ -38,7 +38,7 @@ Invoke through your AI coding harness (`/orch <command>`, `/skill:orch <command>
 | Variable | Purpose | Default |
 |----------|---------|---------|
 | `ORCH_STATE_DIR` | State-file directory (the `--state-dir` flag wins when both are set) | `tmp` |
-| `GH_ISSUE_PATTERN` | Regex for issue IDs in branch names (matched case-insensitively, then canonicalized: `issue-N` lowercase, Linear-style uppercase) | `[A-Z]+-[0-9]+` |
+| `GH_ISSUE_PATTERN` | Regex for issue IDs in branch names (matched case-insensitively, then canonicalized: `issue-N` lowercase, Linear-style uppercase) | `([A-Z]+-[0-9]+\|issue-[0-9]+)` |
 | `CI_FIX_MAX_CYCLES` | Max automated ci-fix cycles per PR submission or merge recovery | `6` |
 | `REVIEWER_SLOT_BUDGET` | The runtime's total concurrent agent-session budget, counting the primary session; `0` = unlimited. On Codex, set it to the cap `spawn-adapter slots` reports | `0` |
 | `ORCH_DECISION_MODE` | `ask` presents decision points; `auto-recommended` executes the recommended option and logs `auto-selected: [option] — [reason]` in workflow-state `auto_decisions`. Review findings disposition is by rule in EVERY mode — no mode presents a selection menu over findings. The always-ask set in [SKILL.md § The Cycle](SKILL.md#the-cycle) applies in every mode | `ask` |

--- a/skills/orch/scripts/open-terminal
+++ b/skills/orch/scripts/open-terminal
@@ -273,15 +273,19 @@ start_cmd() {
       flags+="'$tok' "
     done
   fi
+  # Handoff lanes are unattended and some runtimes self-judge completion (a
+  # Codex one-shot has stopped at PR-open); every rendered brief therefore
+  # carries the terminal condition (handoff.md / oversee.md).
+  local tc=" — complete means the PR is MERGED and the worktree cleaned up, not merely opened"
   case "$TRACKER:$HARNESS" in
-    linear:claude)   printf "claude -n %q %s'/orch start %s'\n" "$item" "$flags" "$item" ;;
-    linear:codex)    printf "codex %s'Read .agents/skills/orch/SKILL.md and execute the orch start workflow for %s'\n" "$flags" "$item" ;;
-    linear:opencode) printf "opencode %s--prompt '/orch start %s'\n" "$flags" "$item" ;;
-    linear:pi)       printf "pi %s'/skill:orch start %s'\n" "$flags" "$item" ;;
-    github:claude)   printf "claude -n github-%q %s'/orch start github %s#%s'\n" "$item" "$flags" "$repo" "$item" ;;
-    github:codex)    printf "codex %s'Read .agents/skills/orch/SKILL.md and execute the orch start workflow for github %s#%s'\n" "$flags" "$repo" "$item" ;;
-    github:opencode) printf "opencode %s--prompt '/orch start github %s#%s'\n" "$flags" "$repo" "$item" ;;
-    github:pi)       printf "pi %s'/skill:orch start github %s#%s'\n" "$flags" "$repo" "$item" ;;
+    linear:claude)   printf "claude -n %q %s'/orch start %s%s'\n" "$item" "$flags" "$item" "$tc" ;;
+    linear:codex)    printf "codex %s'Read .agents/skills/orch/SKILL.md and execute the orch start workflow for %s%s'\n" "$flags" "$item" "$tc" ;;
+    linear:opencode) printf "opencode %s--prompt '/orch start %s%s'\n" "$flags" "$item" "$tc" ;;
+    linear:pi)       printf "pi %s'/skill:orch start %s%s'\n" "$flags" "$item" "$tc" ;;
+    github:claude)   printf "claude -n github-%q %s'/orch start github %s#%s%s'\n" "$item" "$flags" "$repo" "$item" "$tc" ;;
+    github:codex)    printf "codex %s'Read .agents/skills/orch/SKILL.md and execute the orch start workflow for github %s#%s%s'\n" "$flags" "$repo" "$item" "$tc" ;;
+    github:opencode) printf "opencode %s--prompt '/orch start github %s#%s%s'\n" "$flags" "$repo" "$item" "$tc" ;;
+    github:pi)       printf "pi %s'/skill:orch start github %s#%s%s'\n" "$flags" "$repo" "$item" "$tc" ;;
     *) echo "Error: unsupported harness: $HARNESS" >&2; exit 1 ;;
   esac
 }

--- a/skills/orch/tests/open-terminal-claude-handoff.sh
+++ b/skills/orch/tests/open-terminal-claude-handoff.sh
@@ -24,6 +24,9 @@
 # harness is ever launched.
 set -euo pipefail
 
+# The terminal-condition tail every rendered brief carries (open-terminal start_cmd).
+TC=" — complete means the PR is MERGED and the worktree cleaned up, not merely opened"
+
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPTS_DIR="$(cd "$TEST_DIR/.." && pwd)/scripts"
 SRC_OT="$SCRIPTS_DIR/open-terminal"
@@ -172,20 +175,20 @@ OT="$(make_ot_repo "$REPO")"
 # Pane screen where the brief appears ONLY inside the echoed launch command —
 # exactly what a first-run dialog leaves behind. The delivery check must treat
 # this as UNDELIVERED (the filter's failing input).
-ECHO_SCREEN="\$ claude -n CC-737 --dangerously-skip-permissions '/orch start CC-737'
+ECHO_SCREEN="\$ claude -n CC-737 --dangerously-skip-permissions '/orch start CC-737${TC}'
 ╭─ Enable browser integration? ─╮
 > "
 # Pane screen after the brief reached the TUI: the brief is visible on its own
 # transcript line, distinct from the echoed launch command, and the response
 # has begun (● transcript marker).
-DELIVERED_SCREEN="> /orch start CC-737
+DELIVERED_SCREEN="> /orch start CC-737${TC}
 ● Reading workflows/start.md"
 # Pane screen where the brief sits UNSENT in the composer's │-bordered input
 # box — visible outside the echoed launch command, but with no transcript
 # activity anywhere. Delivery means SUBMITTED, so this must count as
 # UNDELIVERED.
 COMPOSER_SCREEN="╭──────────────────────────────────────────╮
-│ > /orch start CC-737                      │
+│ > /orch start CC-737${TC} │
 ╰──────────────────────────────────────────╯
   ? for shortcuts"
 # Main TUI at a ready, EMPTY composer (the '? for shortcuts' footer is the
@@ -206,7 +209,7 @@ set -e
 assert_eq "$c1_code" "0" "linear:claude launch succeeds"
 if wait_capture "$CAP1"; then
   c1_cmd="$(cat "$CAP1")"
-  assert_contains "$c1_cmd" "'--model' 'opus[1m]' '--effort' 'max' '--dangerously-skip-permissions' '/orch start CC-737'" \
+  assert_contains "$c1_cmd" "'--model' 'opus[1m]' '--effort' 'max' '--dangerously-skip-permissions' '/orch start CC-737${TC}'" \
     "linear:claude renders the caller's launch flags before the brief"
 else
   FAIL=$((FAIL + 1))
@@ -224,7 +227,7 @@ set -e
 assert_eq "$c2_code" "0" "github:claude launch succeeds"
 if wait_capture "$CAP2"; then
   c2_cmd="$(cat "$CAP2")"
-  assert_contains "$c2_cmd" "'--effort' 'max' '--dangerously-skip-permissions' '/orch start github acme/widgets#42'" \
+  assert_contains "$c2_cmd" "'--effort' 'max' '--dangerously-skip-permissions' '/orch start github acme/widgets#42${TC}'" \
     "github:claude renders the caller's launch flags before the brief"
 else
   FAIL=$((FAIL + 1))
@@ -242,7 +245,7 @@ set -e
 assert_eq "$c3_code" "0" "a second launch with different flags succeeds"
 if wait_capture "$CAP3"; then
   c3_cmd="$(cat "$CAP3")"
-  assert_contains "$c3_cmd" "'--model' 'sonnet' '--permission-mode' 'bypassPermissions' '/orch start CC-737'" \
+  assert_contains "$c3_cmd" "'--model' 'sonnet' '--permission-mode' 'bypassPermissions' '/orch start CC-737${TC}'" \
     "the flags this launch passed are the flags rendered"
   assert_not_contains "$c3_cmd" "'--effort' 'max'" \
     "no flag leaks in from another launch or a stored default"
@@ -263,7 +266,7 @@ if wait_capture "$CAP3B"; then
   c3b_cmd="$(cat "$CAP3B")"
   # The launch command must end exactly at the brief: no model, effort, or
   # permission flag may appear from anywhere but --launch-flags.
-  assert_eq "${c3b_cmd##*&& }" "claude -n CC-737 '/orch start CC-737'" \
+  assert_eq "${c3b_cmd##*&& }" "claude -n CC-737 '/orch start CC-737${TC}'" \
     "an unflagged launch renders no model, effort, or permission default"
 else
   FAIL=$((FAIL + 1))
@@ -281,7 +284,7 @@ c4_code=$?
 set -e
 assert_eq "$c4_code" "0" "prompting flags still launch"
 if wait_capture "$CAP4"; then
-  assert_contains "$(cat "$CAP4")" "'--permission-mode' 'plan' '/orch start CC-737'" \
+  assert_contains "$(cat "$CAP4")" "'--permission-mode' 'plan' '/orch start CC-737${TC}'" \
     "prompting flags are rendered as given"
 fi
 c4_err="$(cat "$TMP_ROOT/c4.err")"
@@ -303,7 +306,7 @@ assert_eq "$c5_code" "0" "tmux delivered-first-pass exits 0"
 assert_contains "$c5_out" "Opened tmux window 'CC-737'" "tmux window opened"
 assert_not_contains "$c5_out" "Re-delivered" "no re-send when the brief is visible"
 c5_log="$(cat "$OT_TMUX_LOG")"
-assert_contains "$c5_log" "'--dangerously-skip-permissions' '/orch start CC-737'" \
+assert_contains "$c5_log" "'--dangerously-skip-permissions' '/orch start CC-737${TC}'" \
   "tmux-sent launch command carries the flags the caller chose"
 assert_contains "$c5_log" "capture-pane" "delivery was verified via capture-pane"
 assert_contains "$c5_log" "capture-pane -pJ -S - -t %7" \

--- a/skills/orch/tests/open-terminal-codex-prompt.sh
+++ b/skills/orch/tests/open-terminal-codex-prompt.sh
@@ -17,6 +17,9 @@
 # would launch.
 set -euo pipefail
 
+# The terminal-condition tail every rendered brief carries (open-terminal start_cmd).
+TC=" — complete means the PR is MERGED and the worktree cleaned up, not merely opened"
+
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPTS_DIR="$(cd "$TEST_DIR/.." && pwd)/scripts"
 SRC_OT="$SCRIPTS_DIR/open-terminal"
@@ -126,7 +129,7 @@ set -e
 assert_eq "$c1_code" "0" "linear:codex launch succeeds"
 if wait_capture "$CAP1"; then
   c1_cmd="$(cat "$CAP1")"
-  assert_contains "$c1_cmd" "codex 'Read .agents/skills/orch/SKILL.md and execute the orch start workflow for CC-737'" \
+  assert_contains "$c1_cmd" "codex 'Read .agents/skills/orch/SKILL.md and execute the orch start workflow for CC-737${TC}'" \
     "linear:codex emits the prose kickoff naming SKILL.md and the item"
   assert_not_contains "$c1_cmd" '$' "linear:codex command contains no \$"
   assert_not_contains "$c1_cmd" '`' "linear:codex command contains no backtick"
@@ -144,7 +147,7 @@ set -e
 assert_eq "$c2_code" "0" "github:codex launch succeeds"
 if wait_capture "$CAP2"; then
   c2_cmd="$(cat "$CAP2")"
-  assert_contains "$c2_cmd" "codex 'Read .agents/skills/orch/SKILL.md and execute the orch start workflow for github acme/widgets#42'" \
+  assert_contains "$c2_cmd" "codex 'Read .agents/skills/orch/SKILL.md and execute the orch start workflow for github acme/widgets#42${TC}'" \
     "github:codex emits the prose kickoff carrying repo#item"
   assert_not_contains "$c2_cmd" '$' "github:codex command contains no \$"
   assert_not_contains "$c2_cmd" '`' "github:codex command contains no backtick"

--- a/skills/orch/workflows/handoff.md
+++ b/skills/orch/workflows/handoff.md
@@ -44,7 +44,7 @@ Two handoff-specific rules follow from expanding items:
 
 ## 2. Launch
 
-**Every launched brief states the terminal condition**: the item is complete only when its PR is MERGED and its worktree cleaned up — an opened PR is not done.
+**Every launched brief states the terminal condition**: the item is complete only when its PR is MERGED and its worktree cleaned up — an opened PR is not done. `open-terminal` renders it into every brief; briefs minted by hand (codex-app threads, oversee's non-terminal surfaces) carry it explicitly.
 
 ### Terminal harnesses
 

--- a/skills/orch/workflows/post-summary.md
+++ b/skills/orch/workflows/post-summary.md
@@ -66,7 +66,7 @@ Omit empty sections. Created Issues comes from `audit_issues_created` plus `pr_c
 .agents/skills/linear/scripts/linear.sh cache issues get [ISSUE_ID]
 ```
 
-Read `.blocks`. Post a handoff comment to a downstream issue only when it earns one: its description references files this PR touched, a decision it should know about was created, or an API it depends on changed. Simply being unblocked — the common case — earns nothing.
+Read `.blocks`. Post a handoff comment to a downstream issue only when it earns one: its description references files this PR touched, a decision it should know about was created, or an API or interface it depends on changed. Simply being unblocked — the common case — earns nothing.
 
 ```bash
 .agents/skills/linear/scripts/linear.sh comments create [DOWNSTREAM_ISSUE_ID] --body "Handoff from [ISSUE_ID]:

--- a/vstack-local.toml
+++ b/vstack-local.toml
@@ -33,7 +33,10 @@
 # Adds a "## Launch Instructions" section near the top
 # of each agent file. Use this for startup tasks, required
 # reading, or project-specific operating notes.
+# The reserved key `all` applies to every agent, rendered
+# before that agent's own entry.
 # Examples:
+# all = "Run `just setup` before anything else."
 # rust = "Read docs/architecture.md before coding."
 # iced = """
 # Read docs/ui.md.


### PR DESCRIPTION
Post-merge triage of the macroscope findings on #1284 (admin merge skipped the bot round). Verified-real fixes only; rationale in CHANGELOG. Declined with recorded rationale: the workflow-state --state-dir worktree note (state is session-scoped; three live drills closed the loop worktree-locally) and the probe-to-release lease race (native git lock backstops all but a sub-second same-issue three-session window; conditional release is guard-level surgery — carried as an issue candidate).

Suites: orch run-all 34/34 after the change; open-terminal prompt pins updated in lockstep with a fired empty-tail control.

https://claude.ai/code/session_01WSWYV8EMQFeeF1nFLGRNNG