### PR TITLE
fix(orch): #1286 triage — terminal condition survives the tmux re-send; README pattern copyable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,10 @@
 ## Unreleased
 
 - Post-merge bot triage of #1284: `open-terminal` now renders the
-  merged-and-cleaned terminal condition into every launched brief (the
-  handoff/oversee requirement previously reached only hand-minted briefs);
+  merged-and-cleaned terminal condition into every launched brief — including
+  the tmux delivery/re-send copy, which first shipped without it (caught by
+  three bots on the triage PR itself); the README pattern row uses the
+  GFM-safe pipe entity so the copyable value is a working regex;
   README's `GH_ISSUE_PATTERN` row documents the real built-in default
   (`([A-Z]+-[0-9]+|issue-[0-9]+)` — the transcribed value would have
   rejected `issue-N` branches if copied into settings); post-summary's

--- a/skills/orch/README.md
+++ b/skills/orch/README.md
@@ -38,7 +38,7 @@ Invoke through your AI coding harness (`/orch <command>`, `/skill:orch <command>
 | Variable | Purpose | Default |
 |----------|---------|---------|
 | `ORCH_STATE_DIR` | State-file directory (the `--state-dir` flag wins when both are set) | `tmp` |
-| `GH_ISSUE_PATTERN` | Regex for issue IDs in branch names (matched case-insensitively, then canonicalized: `issue-N` lowercase, Linear-style uppercase) | `([A-Z]+-[0-9]+\|issue-[0-9]+)` |
+| `GH_ISSUE_PATTERN` | Regex for issue IDs in branch names (matched case-insensitively, then canonicalized: `issue-N` lowercase, Linear-style uppercase) | `([A-Z]+-[0-9]+&#124;issue-[0-9]+)` |
 | `CI_FIX_MAX_CYCLES` | Max automated ci-fix cycles per PR submission or merge recovery | `6` |
 | `REVIEWER_SLOT_BUDGET` | The runtime's total concurrent agent-session budget, counting the primary session; `0` = unlimited. On Codex, set it to the cap `spawn-adapter slots` reports | `0` |
 | `ORCH_DECISION_MODE` | `ask` presents decision points; `auto-recommended` executes the recommended option and logs `auto-selected: [option] — [reason]` in workflow-state `auto_decisions`. Review findings disposition is by rule in EVERY mode — no mode presents a selection menu over findings. The always-ask set in [SKILL.md § The Cycle](SKILL.md#the-cycle) applies in every mode | `ask` |

--- a/skills/orch/scripts/open-terminal
+++ b/skills/orch/scripts/open-terminal
@@ -273,10 +273,7 @@ start_cmd() {
       flags+="'$tok' "
     done
   fi
-  # Handoff lanes are unattended and some runtimes self-judge completion (a
-  # Codex one-shot has stopped at PR-open); every rendered brief therefore
-  # carries the terminal condition (handoff.md / oversee.md).
-  local tc=" — complete means the PR is MERGED and the worktree cleaned up, not merely opened"
+  local tc="$BRIEF_TERMINAL_CONDITION"
   case "$TRACKER:$HARNESS" in
     linear:claude)   printf "claude -n %q %s'/orch start %s%s'\n" "$item" "$flags" "$item" "$tc" ;;
     linear:codex)    printf "codex %s'Read .agents/skills/orch/SKILL.md and execute the orch start workflow for %s%s'\n" "$flags" "$item" "$tc" ;;
@@ -289,6 +286,12 @@ start_cmd() {
     *) echo "Error: unsupported harness: $HARNESS" >&2; exit 1 ;;
   esac
 }
+
+# Handoff lanes are unattended and some runtimes self-judge completion (a
+# Codex one-shot has stopped at PR-open); every rendered brief — the launch
+# command's prompt AND the tmux delivery/re-send copy — carries the terminal
+# condition (handoff.md / oversee.md).
+readonly BRIEF_TERMINAL_CONDITION=" — complete means the PR is MERGED and the worktree cleaned up, not merely opened"
 
 # Delivered means SUBMITTED, not merely present: the brief echoed in the
 # launch command (`claude -n` line) or sitting unsent in the composer's
@@ -447,7 +450,7 @@ for raw in "${ITEMS[@]}"; do
   # custom --cmd templates, which disables the check.
   brief=""
   if [[ -z "$CMD_TEMPLATE" && "$HARNESS" == "claude" ]]; then
-    if [[ "$TRACKER" == "linear" ]]; then brief="/orch start $item"; else brief="/orch start github $repo#$item"; fi
+    if [[ "$TRACKER" == "linear" ]]; then brief="/orch start $item$BRIEF_TERMINAL_CONDITION"; else brief="/orch start github $repo#$item$BRIEF_TERMINAL_CONDITION"; fi
   fi
   # The lane is recorded in the launched command itself, so `ps` and the tmux
   # window both show which account a stalled session belongs to. The value is


### PR DESCRIPTION
Three bots (Copilot, Codex, qodo) flagged the #1286 triage itself: the terminal condition lived only in start_cmd's launch prompt, so the tmux first-run-dialog re-send delivered a brief without it — the brief is now built from one script-scope constant used by launch, verification, and re-send (suite pins already assert the full text); and the README GH_ISSUE_PATTERN row used a backslash-escaped pipe that renders literally inside a code span, making the copyable value a broken regex — now the GFM pipe entity. orch open-terminal suites 3/3 green.

https://claude.ai/code/session_01WSWYV8EMQFeeF1nFLGRNNG