### PR TITLE
fix(orch): #1287 triage — restore the GFM-escaped pipe, pin the re-sent brief tail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@
 - Post-merge bot triage of #1284: `open-terminal` now renders the
   merged-and-cleaned terminal condition into every launched brief — including
   the tmux delivery/re-send copy, which first shipped without it (caught by
-  three bots on the triage PR itself); the README pattern row uses the
-  GFM-safe pipe entity so the copyable value is a working regex;
+  three bots on the triage PR itself); the README pattern row keeps the
+  GFM table-escaped pipe (`\|` renders as `|` inside table code spans, the
+  form this README already uses) so the copyable value is a working regex;
   README's `GH_ISSUE_PATTERN` row documents the real built-in default
   (`([A-Z]+-[0-9]+|issue-[0-9]+)` — the transcribed value would have
   rejected `issue-N` branches if copied into settings); post-summary's

--- a/skills/orch/README.md
+++ b/skills/orch/README.md
@@ -38,7 +38,7 @@ Invoke through your AI coding harness (`/orch <command>`, `/skill:orch <command>
 | Variable | Purpose | Default |
 |----------|---------|---------|
 | `ORCH_STATE_DIR` | State-file directory (the `--state-dir` flag wins when both are set) | `tmp` |
-| `GH_ISSUE_PATTERN` | Regex for issue IDs in branch names (matched case-insensitively, then canonicalized: `issue-N` lowercase, Linear-style uppercase) | `([A-Z]+-[0-9]+&#124;issue-[0-9]+)` |
+| `GH_ISSUE_PATTERN` | Regex for issue IDs in branch names (matched case-insensitively, then canonicalized: `issue-N` lowercase, Linear-style uppercase) | `([A-Z]+-[0-9]+\|issue-[0-9]+)` |
 | `CI_FIX_MAX_CYCLES` | Max automated ci-fix cycles per PR submission or merge recovery | `6` |
 | `REVIEWER_SLOT_BUDGET` | The runtime's total concurrent agent-session budget, counting the primary session; `0` = unlimited. On Codex, set it to the cap `spawn-adapter slots` reports | `0` |
 | `ORCH_DECISION_MODE` | `ask` presents decision points; `auto-recommended` executes the recommended option and logs `auto-selected: [option] — [reason]` in workflow-state `auto_decisions`. Review findings disposition is by rule in EVERY mode — no mode presents a selection menu over findings. The always-ask set in [SKILL.md § The Cycle](SKILL.md#the-cycle) applies in every mode | `ask` |

--- a/skills/orch/scripts/open-terminal
+++ b/skills/orch/scripts/open-terminal
@@ -287,10 +287,10 @@ start_cmd() {
   esac
 }
 
-# Handoff lanes are unattended and some runtimes self-judge completion (a
-# Codex one-shot has stopped at PR-open); every rendered brief — the launch
-# command's prompt AND the tmux delivery/re-send copy — carries the terminal
-# condition (handoff.md / oversee.md).
+# Handoff lanes are unattended and some runtimes self-judge completion, so
+# every rendered brief — the launch command's prompt AND the tmux
+# delivery/re-send copy — carries the terminal condition (handoff.md /
+# oversee.md).
 readonly BRIEF_TERMINAL_CONDITION=" — complete means the PR is MERGED and the worktree cleaned up, not merely opened"
 
 # Delivered means SUBMITTED, not merely present: the brief echoed in the

--- a/skills/orch/tests/open-terminal-claude-handoff.sh
+++ b/skills/orch/tests/open-terminal-claude-handoff.sh
@@ -330,6 +330,8 @@ assert_contains "$c6_out" "Re-delivered brief to 'CC-737'" "re-delivery is repor
 c6_log="$(cat "$OT_TMUX_LOG")"
 c6_resends="$(grep -cF "send-keys -t %7 -l /orch start CC-737" "$OT_TMUX_LOG")"
 assert_eq "$c6_resends" "1" "brief is re-sent exactly once"
+c6_full_resends="$(grep -cF "send-keys -t %7 -l /orch start CC-737${TC}" "$OT_TMUX_LOG")"
+assert_eq "$c6_full_resends" "1" "the re-sent brief carries the terminal condition"
 
 # Case 6b: TWO dialog screens before the composer is ready — each
 # wait-composer pass sends one dismissing Enter, and the brief goes in only


### PR DESCRIPTION
Round-3 triage. The bots contradicted each other across rounds on the README pipe: GFM's table extension consumes \\| inside code spans (the form this README's own command table already uses), so #1286's original complaint was wrong and #1287's entity was the actual regression — restored to \\|, CHANGELOG corrected. Also: the tmux re-send assertion now pins the complete brief including the terminal condition (control fired against a tail-less re-send), and the open-terminal comment drops its narration clause per house style. orch open-terminal suites 3/3.

Stop-line: further findings on this chain that do not change behavior will be declined per the review-loop discipline.

https://claude.ai/code/session_01WSWYV8EMQFeeF1nFLGRNNG