### PR TITLE
agents+docs: non-reviewer agents pass, must-fail controls at authoring time (VST-266), docs audit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,10 +61,6 @@ Thumbs.db
 # config (no machine-specific paths) and is only separate from vstack.toml
 # because that file is the source catalog consumers read. See its header.
 
-# Cross-repo mailbox log — machine-local session coordination, never committed
-# (docs/cross-repo.md, the curated contract, IS tracked on purpose)
-docs/cross-repo-notes.md
-
 # Filled workspace copies of portable doc templates — never committed (vstack
 # is portable/public). Pattern: tracked template docs/<name>.md, untracked
 # filled copy docs/<name>-local.md, gist-backed per the file's own header.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
   sync; cross-repo.md is cut to the cross-repo contracts (generic epistemics
   removed, the vendored-tree section is a pointer to
   `review-gate/references/vendored-paths.md`, the bundle-import note moved to
-  the pi-claude-bridge README); the retired in-repo mailbox path leaves
+  the pi-claude-bridge DEVELOPMENT.md); the retired in-repo mailbox path leaves
   .gitignore.
 - orch: `PR_REVIEW_QUORUM` — approval-wait's multi-bot enqueue gate. When a
   repo lists its reviewer logins, no success emits (either mode) until every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+- agents: the seven engineer/analyst agents (generalist, iced, planner,
+  researcher, rust, scout, tpm) drop the house "never trust a green check"
+  blockquote — the rule's canonical homes are `code-quality` § Prove Your
+  Guards (engineers) and the reviewer skill (reviewers); rust drops
+  project-owned Build/Portability opinions; planner's discipline is cut to
+  what its output format does not already require.
+- code-quality/dev: must-fail controls are required where code is written,
+  not only where it is reviewed (VST-266) — dev-implement § Validate requires
+  a red-once control for every added or modified check, and Prove Your Guards
+  names the source-text shapes a pattern-matching guard must be proven
+  against.
+- docs: issue-label-taxonomy states the one-way GitHub → Linear creation
+  sync; cross-repo.md is cut to the cross-repo contracts (generic epistemics
+  removed, the vendored-tree section is a pointer to
+  `review-gate/references/vendored-paths.md`, the bundle-import note moved to
+  the pi-claude-bridge README); the retired in-repo mailbox path leaves
+  .gitignore.
 - orch: `PR_REVIEW_QUORUM` — approval-wait's multi-bot enqueue gate. When a
   repo lists its reviewer logins, no success emits (either mode) until every
   listed login has a non-dismissed review pinned to the current head AND

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - docs: issue-label-taxonomy states the one-way GitHub → Linear creation
   sync; cross-repo.md is cut to the cross-repo contracts (generic epistemics
   removed, the vendored-tree section is a pointer to
-  `review-gate/references/vendored-paths.md`, the bundle-import note moved to
+  `skills/review-gate/references/vendored-paths.md`, the bundle-import note moved to
   the pi-claude-bridge DEVELOPMENT.md); the retired in-repo mailbox path leaves
   .gitignore.
 - orch: `PR_REVIEW_QUORUM` — approval-wait's multi-bot enqueue gate. When a

--- a/agents/generalist.md
+++ b/agents/generalist.md
@@ -13,8 +13,6 @@ Handles cross-cutting maintenance: documentation accuracy, stale references, bro
 
 > ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in VStack-owned assets through `vstack report` — verify ownership in the asset's own file first. Full routing, attribution, and filing rules: `{{VSTACK_FAILURE_REF}}`.
 
-> ***Never trust a green check you have not seen fail.*** Before trusting any instrument — a grep scope, a substitution, a measurement, a test assertion — prove it on a control input that must fail (or, for a substitution, visibly transform).
-
 ## Scope
 
 Changes whose correctness is settled by reading: doc claims, references, links, file and config organization. Work needing domain judgment — core logic, performance-critical code, architecture decisions — goes back to the caller with what you found, not with a patch.

--- a/agents/iced.md
+++ b/agents/iced.md
@@ -13,8 +13,6 @@ Implements the Iced view layer: widget composition, Canvas and Shader rendering,
 
 > ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in VStack-owned assets through `vstack report` — verify ownership in the asset's own file first. Full routing, attribution, and filing rules: `{{VSTACK_FAILURE_REF}}`.
 
-> ***Never trust a green check you have not seen fail.*** Before trusting any instrument — a grep scope, a substitution, a measurement, a test assertion — prove it on a control input that must fail (or, for a substitution, visibly transform).
-
 ## Scope
 
 The view and the messages that drive it. Domain logic, data sourcing, and persistence stay with their owners — take the state as given and render it.

--- a/agents/planner.md
+++ b/agents/planner.md
@@ -13,8 +13,6 @@ Converts requirements, recon findings, and code context into an ordered implemen
 
 > ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in VStack-owned assets through `vstack report` — verify ownership in the asset's own file first. Full routing, attribution, and filing rules: `{{VSTACK_FAILURE_REF}}`.
 
-> ***Never trust a green check you have not seen fail.*** Before trusting any instrument — a grep scope, a substitution, a measurement, a test assertion — prove it on a control input that must fail (or, for a substitution, visibly transform).
-
 ## Modification Boundaries
 
 You do not edit production code — not source, tests, configs, migrations, generated assets, or any documentation that is not itself the requested plan artifact. No dependency installs or lockfile changes. Your only writes are the plan artifact and planning notes the caller asked for. Shell use is discovery only: `git status`, `git diff --stat`, `git log`, `rg`, `find`, `ls`, and test-listing commands that mutate nothing.
@@ -26,9 +24,6 @@ The technical plan: what to build, in what order, and how each step is proven. P
 ## Discipline
 
 - Read the provided files, project instructions, and prior findings before widening the search. Explore until the design is grounded, not exhaustively.
-- Ground every step in a file, symbol, doc, or cited source. A step the implementer cannot locate is not a step.
-- Prefer small reversible changes over rewrites, and name the point you would roll back to.
-- State assumptions and required confirmations outright. Uncertainty declared is cheap; uncertainty buried becomes a failed implementation.
 - Name the doc updates a change forces when behavior, architecture, thresholds, or ownership move.
 - Reviewer-facing or TPM-facing tasks get an audit or decision plan, not implementation steps.
 

--- a/agents/researcher.md
+++ b/agents/researcher.md
@@ -13,8 +13,6 @@ Executes delegated research prompts and produces evidence-backed findings report
 
 > ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in VStack-owned assets through `vstack report` — verify ownership in the asset's own file first. Full routing, attribution, and filing rules: `{{VSTACK_FAILURE_REF}}`.
 
-> ***Never trust a green check you have not seen fail.*** Before trusting any instrument — a grep scope, a substitution, a measurement, a test assertion — prove it on a control input that must fail (or, for a substitution, visibly transform).
-
 ## Scope
 
 Provider-backed research and the report it produces. Not production code, not architecture decisions beyond the recommendation the evidence supports, not creating or reshaping tracked work unless the delegation instructs it, and never coordinating other agents.

--- a/agents/rust.md
+++ b/agents/rust.md
@@ -13,8 +13,6 @@ Implements performance-critical Rust: zero-allocation hot paths, lock-free data 
 
 > ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in VStack-owned assets through `vstack report` — verify ownership in the asset's own file first. Full routing, attribution, and filing rules: `{{VSTACK_FAILURE_REF}}`.
 
-> ***Never trust a green check you have not seen fail.*** Before trusting any instrument — a grep scope, a substitution, a measurement, a test assertion — prove it on a control input that must fail (or, for a substitution, visibly transform).
-
 ## Scope
 
 Systems-level implementation and the benchmarks that justify it. Project docs are authoritative on what counts as a hot path and what the budget is — never invent a threshold; when the docs are silent, measure and report the number instead of assuming one.
@@ -24,8 +22,6 @@ Systems-level implementation and the benchmarks that justify it. Project docs ar
 - **Hot paths**: no heap allocation, string formatting, dynamic dispatch, locks, map lookups, syscalls, or I/O unless project docs allow it and a benchmark justifies it.
 - **Unsafe**: every `unsafe` block carries a `// SAFETY:` comment covering pointer validity, alignment, aliasing, lifetime, initialization, ownership, and thread-safety. Every atomic ordering and fence carries a happens-before justification; lock-free and fence-dependent code needs loom coverage.
 - **Async**: no detached task without shutdown ownership; `select!` branches must be cancellation-safe; no large buffer held across an `.await`; no boxed async trait in a hot loop outside a plugin or I/O boundary.
-- **Build**: workspace dependencies, explicit capability features, committed target configuration, and release profiles that keep debuginfo wherever production debugging matters.
-- **Portability**: prefer rustls over OpenSSL for cross builds; exercise weak-memory-sensitive code on ARM64; treat absent `std` as the base path with `alloc` and `std` as opt-in tiers.
 - **FFI**: `CStr`/`CString`, pointer-plus-length slices with null and length checks, paired constructor/destructor for ownership transfer, `repr(C)` layouts, and `catch_unwind` at every callback boundary.
 - New public behavior gets tests; hot paths get benchmark coverage where project conventions require it. A removed test needs its rationale in the commit message.
 

--- a/agents/scout.md
+++ b/agents/scout.md
@@ -13,8 +13,6 @@ Reconnaissance specialist. Find the smallest set of facts another agent needs to
 
 > ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in VStack-owned assets through `vstack report` — verify ownership in the asset's own file first. Full routing, attribution, and filing rules: `{{VSTACK_FAILURE_REF}}`.
 
-> ***Never trust a green check you have not seen fail.*** Before trusting any instrument — a grep scope, a substitution, a measurement, a test assertion — prove it on a control input that must fail (or, for a substitution, visibly transform).
-
 ## Report-Only Contract
 
 You explore; you do not change the workspace. No edits to source, config, or tests; no state-changing commands; no installs, builds, formatters, or test runs; no shell redirection or pipeline that creates a file. Shell use is discovery only — `ls`, `find`, `rg`, `git log`, `git diff`, and their kin. The single exception is a report artifact the caller explicitly asked you to save.

--- a/agents/tpm.md
+++ b/agents/tpm.md
@@ -13,8 +13,6 @@ Analyzes roadmaps, cycles, backlogs, and cross-project dependencies. Recommends;
 
 > ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in VStack-owned assets through `vstack report` — verify ownership in the asset's own file first. Full routing, attribution, and filing rules: `{{VSTACK_FAILURE_REF}}`.
 
-> ***Never trust a green check you have not seen fail.*** Before trusting any instrument — a grep scope, a substitution, a measurement, a test assertion — prove it on a control input that must fail (or, for a substitution, visibly transform).
-
 ## Scope
 
 What gets built and in what order: cycle planning, backlog prioritization, dependency and blocking analysis, cross-project health, progress reporting. Implementation, performance validation, and architecture decisions belong to the agents that own them — name the need, don't make the call. You do not mutate tracker state; the calling agent acts on your output.

--- a/docs/cross-repo.md
+++ b/docs/cross-repo.md
@@ -60,29 +60,7 @@ Agreed shape for drovr, memsira, and hyprtrade, settled by live testing on real 
 
 ## A Vendored Tree Is Reviewed Once, Upstream
 
-Consuming repos merge re-vendor PRs whose entire delta is bytes already reviewed
-upstream. Every reviewer re-reviews them in every consumer, and each inline
-comment opens a thread that blocks that repo's merge until someone answers it —
-one upstream finding becomes one blocking thread per reviewer per repo, and the
-sessions answering them carry the argument back upstream as though it were new.
-
-- **Route a finding by where its fix would land, not by which file it sits on.**
-  A remedy in a repo-owned file (the vendor pin, settings, CI wiring) is local
-  and belongs inline — a re-vendor that moves pinned bytes without updating the
-  pin is a real defect. A remedy in the vendored bytes belongs in the review
-  summary body, which creates no thread — or, for a reviewer that can only
-  anchor findings to file locations, in ONE consolidated comment for the whole
-  PR rather than one per finding.
-- **Do not silence the reviewer by excluding the path.** A pure re-vendor PR is
-  nothing but vendored files, so a reviewer that skips them produces no review
-  object and the review gate's evidence term starves with no reviewer that can
-  ever clear it. Constrain what a reviewer SAYS, never whether it reviews.
-- **File upstream once, from one consumer.** Reviewers have no cross-repo memory
-  and restate the same finding in every repo; the first session to see it files
-  it, the rest cite that issue.
-
-Mechanism, wiring, and the per-repo verification protocol:
-`skills/review-gate/references/vendored-paths.md`.
+Consuming repos merge re-vendor PRs whose delta is bytes already reviewed upstream. Route each finding by where its fix would land, never by which file it sits on, and never silence a reviewer by excluding the path — mechanism, wiring, and the per-repo verification protocol: `skills/review-gate/references/vendored-paths.md`.
 
 ## Do Not Restate Another Repo's Status From A Stale Check
 
@@ -102,33 +80,6 @@ Sessions send into each other's tmux panes. The failure modes are not obvious.
 - **Send ONE LINE. A multi-line `send-keys -l` becomes a paste, and a paste does not submit.** Claude Code collapses multi-line input to `[Pasted text #1]`, and neither `Enter` nor `C-m` submits it. Newlines are the trigger, not length — a very long single line is fine.
 - **A collapsed paste also defeats fragment verification**, because `capture-pane` only ever shows `[Pasted text #1]` and never the body. One more reason single-line is the only reliable form.
 - **Clear a stuck composer with `C-u` rather than leaving it.** Text abandoned there can later be submitted glued to the other session's own message. `C-u` doubles as the power check: if it clears the composer, keystrokes *are* registering, so "Enter did not submit" is a real finding rather than a dead pane.
-
-## An Export Surface Is A Security Surface — Re-vendor Before You Re-export
-
-- **A latent defect becomes reachable the moment you export it.** Making an API genuinely callable makes its inputs genuinely untrusted, even when the code has been unchanged for many merges.
-- **Fix and export in the same change**, so no merged state is ever simultaneously reachable and vulnerable. The dangerous window otherwise exists in intermediate branch pushes — the concrete argument for never vendoring from an unmerged branch.
-
-## A Bundled Package With Externals Will Not Import From An Arbitrary Directory
-
-`pi-claude-bridge`'s `bundle/index.js` keeps `@earendil-works/pi-ai` and `@earendil-works/pi-coding-agent` as externals, so importing the package root only works from a tree where those resolve — inside the consuming app, not from a repo root or a scratch directory.
-
-**The failure mode is a false negative that looks exactly like a real one.** A root import from the wrong directory returns `ERR_MODULE_NOT_FOUND`, which reads as "the export is missing" and invites an upstream bug report. Run the import from the directory that declares the dependency before concluding anything about the export.
-
-## When A Grep Surprises You, The Pattern Is The First Suspect
-
-- **When a grep result surprises you, re-measure a different way before writing it down.** Read the actual site. A surprising result is far more often a broken pattern than surprising code.
-- **A result that CONFIRMS what you expected deserves the same suspicion, and gets less.** Confirmation is where the check is skipped.
-- **A whole-artifact grep answers a question about the artifact, not about the site you care about.** Scope the search to the call site, or read it.
-- **Appearing, being exported, and being resolvable are three different properties.** Verify the specific one your claim depends on.
-
-## A Probe That Cannot Produce A Positive Proves Nothing
-
-- **Before trusting a negative, say what a positive would have looked like in that exact output.** If you cannot point at the line, count, or field that would have differed, the probe has no power and its zero means nothing.
-- **Prefer an output where a positive has a known shape** — e.g. a debug log line whose success form is already known from a rig where it works.
-- **Build the power check into the probe's own output.** Report the corroborating counts next to the answer so a later reader can judge a negative without re-running anything. A probe that reports only its verdict asks to be trusted; one that reports its own reach can be checked.
-- **An underpowered probe is worse than no probe**, because it launders an assumption into evidence and then eliminates the candidates that would have found the real cause.
-
-Same failure as `[live]` tone-upgrading above, one layer earlier: there the tag outran the observation, here the observation could not have existed. Related, for probes whose results other repos store: the Capability Probe Contract below.
 
 ## Installed Connectors Are Not Attached Connectors
 

--- a/docs/cross-repo.md
+++ b/docs/cross-repo.md
@@ -60,7 +60,14 @@ Agreed shape for drovr, memsira, and hyprtrade, settled by live testing on real 
 
 ## A Vendored Tree Is Reviewed Once, Upstream
 
-Consuming repos merge re-vendor PRs whose delta is bytes already reviewed upstream. Route each finding by where its fix would land, never by which file it sits on, and never silence a reviewer by excluding the path — mechanism, wiring, and the per-repo verification protocol: `skills/review-gate/references/vendored-paths.md`.
+Consuming repos merge re-vendor PRs whose delta is bytes already reviewed
+upstream.
+
+- **Route each finding by where its fix would land, never by which file it sits on.**
+- **Never silence a reviewer by excluding the path.**
+
+Mechanism, wiring, and the per-repo verification protocol:
+`skills/review-gate/references/vendored-paths.md`.
 
 ## Do Not Restate Another Repo's Status From A Stale Check
 

--- a/docs/issue-label-taxonomy.md
+++ b/docs/issue-label-taxonomy.md
@@ -1,7 +1,7 @@
 # vstack issue-label taxonomy
 
-Linear team `vstack` (VST). GitHub `vanillagreencom/vstack` is the code and PR surface;
-issue CREATION syncs one way, GitHub → Linear, so a label applied at file time arrives in
+Linear team `vstack` (VST). GitHub `vanillagreencom/vstack` is the code and PR surface.
+Issue creation syncs one way, GitHub → Linear, so a label applied at file time arrives in
 Linear with the synced issue. Updates and comments on an already-synced issue propagate in
 both directions.
 

--- a/docs/issue-label-taxonomy.md
+++ b/docs/issue-label-taxonomy.md
@@ -1,10 +1,9 @@
 # vstack issue-label taxonomy
 
 Linear team `vstack` (VST). GitHub `vanillagreencom/vstack` is the code and PR surface;
-issues sync GitHub ↔ Linear, so a label applied at file time arrives in Linear with the
-synced issue. Linear's per-link direction setting governs issue CREATION only (owner
-decision 2026-08-08: two-way creation for all teams/repos); updates and comments on an
-already-synced issue always propagate in both directions regardless of that setting.
+issue CREATION syncs one way, GitHub → Linear, so a label applied at file time arrives in
+Linear with the synced issue. Updates and comments on an already-synced issue propagate in
+both directions.
 
 This is the project-side taxonomy the upstream
 [label-management contract](../skills/project-management/references/labels.md) expects

--- a/pi-extensions/pi-claude-bridge/DEVELOPMENT.md
+++ b/pi-extensions/pi-claude-bridge/DEVELOPMENT.md
@@ -133,3 +133,9 @@ The `./connector-inventory` entry point is a separate build output. It cannot co
 - Integrity diagnostics are written to `<piUserDir>/claude-bridge-diag.log` (`PI_CODING_AGENT_DIR` when set, else `~/.pi/agent`) with counts, affected tool names, and sampled tool-call IDs — only when `CLAUDE_BRIDGE_DEBUG=1`, the same gate as the debug log, and never with user-authored message content (VST-15).
 - `CLAUDE_BRIDGE_ISOLATED=1` (embedding hosts) disables all `AGENTS.md` discovery and all extension-manager/project config overlays, so bridge settings come only from `<piUserDir>/claude-bridge.json`. It also disables project `APPEND_SYSTEM.md` and the `$PATH` Claude executable search. This matters when an in-process host must share `PI_CODING_AGENT_DIR` with Pi but still needs an authoritative executable/connector policy. See `isolatedFromEnv` in `src/config.ts`.
 - Startup preflight failures preserve the underlying `code`, `errno`, `syscall`, `path`, `cwd`, and detected executable file type before handing the error back to the SDK.
+
+## Importing the package root
+
+`pi-claude-bridge`'s `bundle/index.js` keeps `@earendil-works/pi-ai` and `@earendil-works/pi-coding-agent` as externals, so importing the package root only works from a tree where those resolve — inside the consuming app, not from a repo root or a scratch directory.
+
+**The failure mode is a false negative that looks exactly like a real one.** A root import from the wrong directory returns `ERR_MODULE_NOT_FOUND`, which reads as "the export is missing" and invites an upstream bug report. Run the import from the directory that declares the dependency before concluding anything about the export.

--- a/pi-extensions/pi-claude-bridge/README.md
+++ b/pi-extensions/pi-claude-bridge/README.md
@@ -231,3 +231,9 @@ Tool-result integrity problems always surface as a Pi error notification plus a 
 Startup failures include the resolved Claude executable and working directory, which makes missing binaries and wrong launch directories easier to fix.
 
 Contributor-facing stream, tool-result, and startup diagnostics are documented in [`DEVELOPMENT.md`](./DEVELOPMENT.md).
+
+## Importing the bundle
+
+`pi-claude-bridge`'s `bundle/index.js` keeps `@earendil-works/pi-ai` and `@earendil-works/pi-coding-agent` as externals, so importing the package root only works from a tree where those resolve — inside the consuming app, not from a repo root or a scratch directory.
+
+**The failure mode is a false negative that looks exactly like a real one.** A root import from the wrong directory returns `ERR_MODULE_NOT_FOUND`, which reads as "the export is missing" and invites an upstream bug report. Run the import from the directory that declares the dependency before concluding anything about the export.

--- a/pi-extensions/pi-claude-bridge/README.md
+++ b/pi-extensions/pi-claude-bridge/README.md
@@ -231,9 +231,3 @@ Tool-result integrity problems always surface as a Pi error notification plus a 
 Startup failures include the resolved Claude executable and working directory, which makes missing binaries and wrong launch directories easier to fix.
 
 Contributor-facing stream, tool-result, and startup diagnostics are documented in [`DEVELOPMENT.md`](./DEVELOPMENT.md).
-
-## Importing the package root
-
-`pi-claude-bridge`'s `bundle/index.js` keeps `@earendil-works/pi-ai` and `@earendil-works/pi-coding-agent` as externals, so importing the package root only works from a tree where those resolve — inside the consuming app, not from a repo root or a scratch directory.
-
-**The failure mode is a false negative that looks exactly like a real one.** A root import from the wrong directory returns `ERR_MODULE_NOT_FOUND`, which reads as "the export is missing" and invites an upstream bug report. Run the import from the directory that declares the dependency before concluding anything about the export.

--- a/pi-extensions/pi-claude-bridge/README.md
+++ b/pi-extensions/pi-claude-bridge/README.md
@@ -232,7 +232,7 @@ Startup failures include the resolved Claude executable and working directory, w
 
 Contributor-facing stream, tool-result, and startup diagnostics are documented in [`DEVELOPMENT.md`](./DEVELOPMENT.md).
 
-## Importing the bundle
+## Importing the package root
 
 `pi-claude-bridge`'s `bundle/index.js` keeps `@earendil-works/pi-ai` and `@earendil-works/pi-coding-agent` as externals, so importing the package root only works from a tree where those resolve — inside the consuming app, not from a repo root or a scratch directory.
 

--- a/skills/code-quality/SKILL.md
+++ b/skills/code-quality/SKILL.md
@@ -31,7 +31,7 @@ A loud failure beats a silent wrong answer. Handle every error, check invariants
 
 ## Prove Your Guards
 
-A new test, assertion, or guard arm must be seen failing once — a planted defect, a red-first run, or a temporary mutation — before its green counts as evidence. Assertions loose enough to match a skip note, and fixtures that never reach the guarded bound, ship real bugs behind green suites.
+A new or modified check, guard, assertion, or test ships with a must-fail control: plant the defect it exists to catch (a red-first run or a temporary mutation) and see it go red before its green counts as evidence. A guard that pattern-matches source text also gets controls for the shapes that satisfy the match without the property — comments, string and template-literal interiors, nested occurrences, alternate quoting, a braceless statement. Assertions loose enough to match a skip note, fixtures that never reach the guarded bound, and harness code that keeps alive what the implementation should, ship real bugs behind green suites.
 
 ## Language Discipline
 

--- a/skills/dev/workflows/dev-implement.md
+++ b/skills/dev/workflows/dev-implement.md
@@ -153,7 +153,7 @@ Deterministic gates first — every finding is fixed here, never carried into re
 
 Then the project's build/test/lint validation command, plus the delegation's required verification commands in their § 2.4 normalized form. Failure handling, and the invariant for a run that outlasts your turn, are in [dev SKILL.md § Validation](../SKILL.md#validation).
 
-Every check, guard, assertion, or test this change adds or modifies has its must-fail control run red once ([code-quality § Prove Your Guards](../../code-quality/SKILL.md#prove-your-guards)); a guard without one is not validated.
+Every check, guard, assertion, or test this change adds or modifies must have a must-fail control that runs red once ([code-quality § Prove Your Guards](../../code-quality/SKILL.md#prove-your-guards)); a guard without one is not validated.
 
 **Visual QA** — **skip if** the issue has no `design` label. Otherwise use the project's visual QA skills to confirm what your change affects renders correctly, not the full checklist. Do NOT capture golden baselines; that happens at submit-pr time.
 

--- a/skills/dev/workflows/dev-implement.md
+++ b/skills/dev/workflows/dev-implement.md
@@ -153,6 +153,8 @@ Deterministic gates first — every finding is fixed here, never carried into re
 
 Then the project's build/test/lint validation command, plus the delegation's required verification commands in their § 2.4 normalized form. Failure handling, and the invariant for a run that outlasts your turn, are in [dev SKILL.md § Validation](../SKILL.md#validation).
 
+Every check, guard, assertion, or test this change adds or modifies has its must-fail control run red once ([code-quality § Prove Your Guards](../../code-quality/SKILL.md#prove-your-guards)); a guard without one is not validated.
+
 **Visual QA** — **skip if** the issue has no `design` label. Otherwise use the project's visual QA skills to confirm what your change affects renders correctly, not the full checklist. Do NOT capture golden baselines; that happens at submit-pr time.
 
 ---


### PR DESCRIPTION
## Summary

Three owner-directed items in one docs/agents change (no code paths):

1. **Non-reviewer agents pass** — the seven engineer/analyst agents (generalist, iced, planner, researcher, rust, scout, tpm) drop the house "never trust a green check you have not seen fail" blockquote. The reviewer agents already lost it in #1261/#1272 (canonical home: `skills/reviewer/SKILL.md`); for engineers the canonical home is `code-quality` § Prove Your Guards, which every engineer-role agent loads via `[agent-skills]`. Analysts (planner/researcher/scout/tpm) carry role-specific negative-result rules already (scout: "say where you looked and which patterns failed"). `rust` drops the Build/Portability bullets (project-owned decisions — its own Scope line says project docs are authoritative); `planner`'s discipline drops the three bullets its Output format already requires (grounded steps, assumptions, rollback point).
2. **VST-266 (#1291)** — must-fail controls at authoring time. `dev-implement.md` § 5 Validate now requires a red-once control for every added/modified check (a guard without one is not validated); `code-quality` § Prove Your Guards names the source-text shapes a pattern-matching guard must be proven against (comments, string/template interiors, nested occurrences, alternate quoting, braceless statements) and the harness-keeps-it-alive shape — the twelve vgs instances were all "the pattern matched text where the property does not hold". Note: `Prove Your Guards` already existed (#1261) and vgs's engineers load it; the fix moves the requirement into the workflow step the agent walks and adds the clause that would have caught most of the twelve.
3. **docs/ audit** — every tracked md under `docs/`:
   | File | Verdict |
   |---|---|
   | `cross-repo.md` | load-bearing: drovr and memsira `AGENTS.md` cite it as the Claude Bridge / review-gate contract (last edit 08-11, mailbox last used 08-10). Cut the four generic-epistemics sections (export-surface, grep-surprises, probe-positive) that carry no cross-repo dependency; the vendored-tree section becomes a pointer to `review-gate/references/vendored-paths.md` (one canonical home); the bundle-import note moves to the pi-claude-bridge README. |
   | `issue-label-taxonomy.md` | stale claim fixed: creation sync is one-way GitHub → Linear (two-way tried 08-08, reverted 08-09). |
   | `linear-loops.md` | load-bearing template for the local companion; current (08-09). Keep. |
   | `skill-failure-reporting.md` | `include_str!` in the CLI. Keep. |
   | `handoff/README.md` | keep. |
   | `.gitignore` `docs/cross-repo-notes.md` | retired in-repo mailbox path (moved outside every repo per memsira's AGENTS.md); ignore rule removed. |

## Verification

- All four `skills/dev/tests/*.test.sh` pass; no test pins the removed blockquote (grepped cli/, skills/*/tests, hooks/tests).
- Every markdown link written resolves.

Fixes #1291
