### PR TITLE
fix(github): git-diff-summary panic scan fails closed on git failure; nested-brace item boundary (VST-233, VST-254)

### DIFF
--- a/skills/github/scripts/git-diff-summary
+++ b/skills/github/scripts/git-diff-summary
@@ -197,22 +197,22 @@ scan_decl_records() {
         # leave attribute tokens to swallow the declaration that follows.
         # Quoted brackets are inert: the scan runs on the mask. 0 when the
         # attribute is not closed in this buffer yet (it continues next line).
-        # Offset of the first item boundary in the masked buffer. Braces
-        # bound an item at any depth, as before; a SEMICOLON does not when it
-        # sits inside a ( ) or [ ] token group — the length in an array type
-        # ([u8; 4]) is not the end of the item, and splitting there would
-        # drop the pending attribute gate and record what follows as ungated.
-        # 0 when the item has no boundary in this buffer yet.
+        # Offset of the first item boundary in the masked buffer: a ; { or }
+        # at token-group depth 0. Inside a ( ) or [ ] group none of them ends
+        # the item — the length in an array type ([u8; 4]) is not a statement
+        # end, and a brace there opens a block EXPRESSION, not an item body.
+        # Splitting at either would drop the pending attribute gate and
+        # record what follows as an ungated production route. 0 when the item
+        # has no boundary in this buffer yet.
         function item_boundary(ms,   i, n, c, pd, bd) {
             n = length(ms); pd = 0; bd = 0
             for (i = 1; i <= n; i++) {
                 c = substr(ms, i, 1)
-                if (c == "{" || c == "}") return i
                 if (c == "(") pd++
                 else if (c == ")") { if (pd > 0) pd-- }
                 else if (c == "[") bd++
                 else if (c == "]") { if (bd > 0) bd-- }
-                else if (c == ";" && pd == 0 && bd == 0) return i
+                else if (pd == 0 && bd == 0 && (c == ";" || c == "{" || c == "}")) return i
             }
             return 0
         }

--- a/skills/github/scripts/git-diff-summary
+++ b/skills/github/scripts/git-diff-summary
@@ -862,7 +862,7 @@ main() {
     done <<<"$test_paths"
     if [ ${#test_path_args[@]} -gt 0 ]; then
         local test_diff=""
-        scan_diff test_diff "panic paths" "$diff_ref" -- "${test_path_args[@]}"
+        scan_diff test_diff "test panic paths" "$diff_ref" -- "${test_path_args[@]}"
         test_diff=$(printf '%s\n' "$test_diff" | grep -E '^\+' || true)
         if echo "$test_diff" | grep -qE '^\+.*(panic!|unwrap\(\))'; then test_panic=1; fi
     fi

--- a/skills/github/scripts/git-diff-summary
+++ b/skills/github/scripts/git-diff-summary
@@ -613,6 +613,28 @@ scan_dir_declaring_files() {
     done < <(new_side_rs_siblings "$1")
 }
 
+# panic_scan_diff <out-var> <diff-ref> <path>...
+# `git diff <diff-ref> -- <path>...` for a panic-path scan, failing closed and
+# loud when git fails (an unreadable tracked file in the diff, exit 128): a
+# bare death under pipefail or an empty diff would both read downstream as
+# "no panics". Stdout lands in <out-var>; git's stderr is kept out of it (a
+# warning must not shift hunk line numbers) and quoted in the diagnostic.
+panic_scan_diff() {
+    local __out_var="$1" __diff_ref="$2"; shift 2
+    local __err __rc=0 __out
+    __err=$(mktemp -t git-diff-summary-err.XXXXXX)
+    __out=$(git diff "$__diff_ref" -- "$@" 2>"$__err") || __rc=$?
+    if [ "$__rc" -ne 0 ]; then
+        printf 'git-diff-summary: git diff failed (exit %d) while scanning panic paths for %s: %s\n' \
+            "$__rc" "$(printf '%s' "$*" | head -c 300)" \
+            "$(tr '\n' ' ' <"$__err" | head -c 300)" >&2
+        rm -f "$__err"
+        exit 1
+    fi
+    rm -f "$__err"
+    printf -v "$__out_var" '%s' "$__out"
+}
+
 is_cfg_test_declared() {
     local candidate="$1"
     local basefile dir d relevant_dirs routes
@@ -759,9 +781,9 @@ main() {
     done <<<"$prod_paths"
     if [ ${#prod_path_args[@]} -gt 0 ]; then
         # path<TAB>new-side line number of each added panic-pattern line
-        local panic_lines
-        # shellcheck disable=SC2086
-        panic_lines=$(git diff "$diff_ref" -- "${prod_path_args[@]}" 2>/dev/null | awk '
+        local prod_diff="" panic_lines
+        panic_scan_diff prod_diff "$diff_ref" "${prod_path_args[@]}"
+        panic_lines=$(printf '%s\n' "$prod_diff" | awk '
             /^diff --git / { path = ""; inhunk = 0 }
             /^\+\+\+ b\//  { path = substr($0, 7); next }
             /^@@/ {
@@ -836,9 +858,9 @@ main() {
         [ -n "$p" ] && test_path_args+=("$p")
     done <<<"$test_paths"
     if [ ${#test_path_args[@]} -gt 0 ]; then
-        local test_diff
-        # shellcheck disable=SC2086
-        test_diff=$(git diff "$diff_ref" -- "${test_path_args[@]}" 2>/dev/null | grep -E '^\+' || true)
+        local test_diff=""
+        panic_scan_diff test_diff "$diff_ref" "${test_path_args[@]}"
+        test_diff=$(printf '%s\n' "$test_diff" | grep -E '^\+' || true)
         if echo "$test_diff" | grep -qE '^\+.*(panic!|unwrap\(\))'; then test_panic=1; fi
     fi
     if [ "$test_panic" -eq 1 ]; then flags+=("test_panic_path_added"); fi

--- a/skills/github/scripts/git-diff-summary
+++ b/skills/github/scripts/git-diff-summary
@@ -613,20 +613,21 @@ scan_dir_declaring_files() {
     done < <(new_side_rs_siblings "$1")
 }
 
-# panic_scan_diff <out-var> <diff-ref> <path>...
-# `git diff <diff-ref> -- <path>...` for a panic-path scan, failing closed and
+# scan_diff <out-var> <label> <git-diff-arg>...
+# `git diff <git-diff-arg>...` for a scan named <label>, failing closed and
 # loud when git fails (an unreadable tracked file in the diff, exit 128): a
-# bare death under pipefail or an empty diff would both read downstream as
-# "no panics". Stdout lands in <out-var>; git's stderr is kept out of it (a
-# warning must not shift hunk line numbers) and quoted in the diagnostic.
-panic_scan_diff() {
-    local __out_var="$1" __diff_ref="$2"; shift 2
+# bare death under pipefail, an empty diff, or a placeholder stat would each
+# read downstream as "nothing found". Stdout lands in <out-var>; git's stderr
+# is kept out of it (a warning must not shift hunk line numbers) and quoted
+# in the diagnostic.
+scan_diff() {
+    local __out_var="$1" __label="$2"; shift 2
     local __err __rc=0 __out
     __err=$(mktemp -t git-diff-summary-err.XXXXXX)
-    __out=$(git diff "$__diff_ref" -- "$@" 2>"$__err") || __rc=$?
+    __out=$(git diff "$@" 2>"$__err") || __rc=$?
     if [ "$__rc" -ne 0 ]; then
-        printf 'git-diff-summary: git diff failed (exit %d) while scanning panic paths for %s: %s\n' \
-            "$__rc" "$(printf '%s' "$*" | head -c 300)" \
+        printf 'git-diff-summary: git diff failed (exit %d) while scanning %s (git diff %s): %s\n' \
+            "$__rc" "$__label" "$(printf '%s' "$*" | head -c 300)" \
             "$(tr '\n' ' ' <"$__err" | head -c 300)" >&2
         rm -f -- "$__err"
         exit 1
@@ -733,14 +734,16 @@ main() {
     fi
 
     # Get stats
-    local stats
-    stats=$(git diff --stat --stat-count=999 "$diff_ref" 2>/dev/null | tail -1 || echo "0 files changed")
+    local stat_out="" stats
+    scan_diff stat_out "stats" --stat --stat-count=999 "$diff_ref"
+    stats=$(printf '%s\n' "$stat_out" | tail -1)
 
     # Detect risk flags via grep (avoids passing huge diffs through jq)
     local risk_flags="[]"
     local flags=()
-    local rust_diff_added
-    rust_diff_added=$(git diff "$diff_ref" -- '*.rs' 2>/dev/null | grep -E '^\+' || true)
+    local rust_diff_added=""
+    scan_diff rust_diff_added "risk flags" "$diff_ref" -- '*.rs'
+    rust_diff_added=$(printf '%s\n' "$rust_diff_added" | grep -E '^\+' || true)
 
     if echo "$rust_diff_added" | grep -qE '^\+.*unsafe '; then flags+=("unsafe_code_added"); fi
     if echo "$rust_diff_added" | grep -qE '^\+.*#\[repr\(C\)\]'; then flags+=("repr_c_struct_changed"); fi
@@ -782,7 +785,7 @@ main() {
     if [ ${#prod_path_args[@]} -gt 0 ]; then
         # path<TAB>new-side line number of each added panic-pattern line
         local prod_diff="" panic_lines
-        panic_scan_diff prod_diff "$diff_ref" "${prod_path_args[@]}"
+        scan_diff prod_diff "panic paths" "$diff_ref" -- "${prod_path_args[@]}"
         panic_lines=$(printf '%s\n' "$prod_diff" | awk '
             /^diff --git / { path = ""; inhunk = 0 }
             /^\+\+\+ b\//  { path = substr($0, 7); next }
@@ -859,7 +862,7 @@ main() {
     done <<<"$test_paths"
     if [ ${#test_path_args[@]} -gt 0 ]; then
         local test_diff=""
-        panic_scan_diff test_diff "$diff_ref" "${test_path_args[@]}"
+        scan_diff test_diff "panic paths" "$diff_ref" -- "${test_path_args[@]}"
         test_diff=$(printf '%s\n' "$test_diff" | grep -E '^\+' || true)
         if echo "$test_diff" | grep -qE '^\+.*(panic!|unwrap\(\))'; then test_panic=1; fi
     fi

--- a/skills/github/scripts/git-diff-summary
+++ b/skills/github/scripts/git-diff-summary
@@ -628,10 +628,10 @@ panic_scan_diff() {
         printf 'git-diff-summary: git diff failed (exit %d) while scanning panic paths for %s: %s\n' \
             "$__rc" "$(printf '%s' "$*" | head -c 300)" \
             "$(tr '\n' ' ' <"$__err" | head -c 300)" >&2
-        rm -f "$__err"
+        rm -f -- "$__err"
         exit 1
     fi
-    rm -f "$__err"
+    rm -f -- "$__err"
     printf -v "$__out_var" '%s' "$__out"
 }
 

--- a/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
+++ b/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
@@ -373,6 +373,54 @@ RUST
         '["panic_path_added"]' "$(jq -c '.risk_flags' <<<"$unreadable_json")"
     assert_eq "unreadable declaring module fails closed to production scope" \
         "production" "$(jq -r '.scope' <<<"$unreadable_json")"
+
+    # VST-233: an unreadable tracked file INSIDE the diff makes the panic-scan
+    # `git diff` itself fail (exit 128). That must be a named diagnostic and a
+    # non-zero exit — never a bare pipefail death, and never an empty diff that
+    # reads as "no panics". No assume-unchanged here: the failure is the point.
+    unreadable_diff_repo="$SANDBOX/unreadable-diff"
+    init_repo "$unreadable_diff_repo"
+    mkdir -p "$unreadable_diff_repo/src"
+    printf 'pub fn parse(s: &str) -> u32 {\n    s.len() as u32\n}\n' > "$unreadable_diff_repo/src/lib.rs"
+    git -C "$unreadable_diff_repo" add src
+    git -C "$unreadable_diff_repo" commit -q -m lib
+    cat > "$unreadable_diff_repo/src/lib.rs" <<'RUST'
+pub fn parse(s: &str) -> u32 {
+    s.parse().unwrap()
+}
+RUST
+    chmod 000 "$unreadable_diff_repo/src/lib.rs"
+    unreadable_diff_rc=0
+    unreadable_diff_out="$($SUMMARY -C "$unreadable_diff_repo" --head 2>"$SANDBOX/unreadable-diff.err")" || unreadable_diff_rc=$?
+    unreadable_diff_err="$(cat "$SANDBOX/unreadable-diff.err")"
+    chmod 644 "$unreadable_diff_repo/src/lib.rs"
+    assert_eq "unreadable diff member: production panic scan exits non-zero" \
+        "1" "$unreadable_diff_rc"
+    assert_eq "unreadable diff member: production panic scan names git diff and the path on stderr" \
+        "yes" "$(grep -qE 'git diff failed .*src/lib\.rs' <<<"$unreadable_diff_err" && echo yes || echo no)"
+    assert_eq "unreadable diff member: production panic scan prints no summary" \
+        "" "$unreadable_diff_out"
+
+    # The test-path scan on the same failure used to degrade to an empty diff
+    # (fail-open: test_panic_path_added silently never set). Same contract.
+    unreadable_test_repo="$SANDBOX/unreadable-test-diff"
+    init_repo "$unreadable_test_repo"
+    mkdir -p "$unreadable_test_repo/tests"
+    printf '#[test]\nfn t() {}\n' > "$unreadable_test_repo/tests/it.rs"
+    git -C "$unreadable_test_repo" add tests
+    git -C "$unreadable_test_repo" commit -q -m tests
+    printf '#[test]\nfn t() {\n    let v: u32 = "1".parse().unwrap();\n    assert_eq!(v, 1);\n}\n' > "$unreadable_test_repo/tests/it.rs"
+    chmod 000 "$unreadable_test_repo/tests/it.rs"
+    unreadable_test_rc=0
+    unreadable_test_out="$($SUMMARY -C "$unreadable_test_repo" --head 2>"$SANDBOX/unreadable-test-diff.err")" || unreadable_test_rc=$?
+    unreadable_test_err="$(cat "$SANDBOX/unreadable-test-diff.err")"
+    chmod 644 "$unreadable_test_repo/tests/it.rs"
+    assert_eq "unreadable diff member: test panic scan exits non-zero" \
+        "1" "$unreadable_test_rc"
+    assert_eq "unreadable diff member: test panic scan names git diff and the path on stderr" \
+        "yes" "$(grep -qE 'git diff failed .*tests/it\.rs' <<<"$unreadable_test_err" && echo yes || echo no)"
+    assert_eq "unreadable diff member: test panic scan prints no summary" \
+        "" "$unreadable_test_out"
 else
     printf '  SKIP: unreadable-module cases (running as root)\n'
 fi

--- a/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
+++ b/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
@@ -363,9 +363,9 @@ RUST
     git -C "$unreadable_repo" add src/x/cand.rs
     chmod 000 "$unreadable_repo/src/x/other.rs"
     # Keep the unreadable file out of the diff itself: chmod invalidates its
-    # cached stat, and a pre-existing (unguarded) `git diff -- <prod paths>`
-    # pipeline dies on unreadable diff members. This case targets the
-    # declaration scanner's fail-closed read, not that pipeline.
+    # cached stat, and every content `git diff` scan fails closed (loud exit)
+    # on unreadable diff members. This case targets the declaration scanner's
+    # fail-closed read, not those scans.
     git -C "$unreadable_repo" update-index --assume-unchanged src/x/other.rs
     unreadable_json="$($SUMMARY -C "$unreadable_repo" --head)"
     chmod 644 "$unreadable_repo/src/x/other.rs"
@@ -374,10 +374,13 @@ RUST
     assert_eq "unreadable declaring module fails closed to production scope" \
         "production" "$(jq -r '.scope' <<<"$unreadable_json")"
 
-    # VST-233: an unreadable tracked file INSIDE the diff makes the panic-scan
-    # `git diff` itself fail (exit 128). That must be a named diagnostic and a
-    # non-zero exit — never a bare pipefail death, and never an empty diff that
-    # reads as "no panics". No assume-unchanged here: the failure is the point.
+    # VST-233: an unreadable tracked file INSIDE the diff makes every content
+    # `git diff` scan fail (exit 128) — stats, `*.rs` risk flags, and both
+    # panic-path scans. Whichever scan touches it first (stats runs first)
+    # must exit non-zero with a diagnostic naming `git diff` and, through
+    # git's own stderr, the path — never a bare pipefail death, an empty diff
+    # read as "no panics", or a placeholder stat line. No assume-unchanged
+    # here: the failure is the point.
     unreadable_diff_repo="$SANDBOX/unreadable-diff"
     init_repo "$unreadable_diff_repo"
     mkdir -p "$unreadable_diff_repo/src"
@@ -394,11 +397,11 @@ RUST
     unreadable_diff_out="$($SUMMARY -C "$unreadable_diff_repo" --head 2>"$SANDBOX/unreadable-diff.err")" || unreadable_diff_rc=$?
     unreadable_diff_err="$(cat "$SANDBOX/unreadable-diff.err")"
     chmod 644 "$unreadable_diff_repo/src/lib.rs"
-    assert_eq "unreadable diff member: production panic scan exits non-zero" \
+    assert_eq "unreadable prod-path diff member: exits non-zero" \
         "1" "$unreadable_diff_rc"
-    assert_eq "unreadable diff member: production panic scan names git diff and the path on stderr" \
+    assert_eq "unreadable prod-path diff member: names git diff and the path on stderr" \
         "yes" "$(grep -qE 'git diff failed .*src/lib\.rs' <<<"$unreadable_diff_err" && echo yes || echo no)"
-    assert_eq "unreadable diff member: production panic scan prints no summary" \
+    assert_eq "unreadable prod-path diff member: prints no summary" \
         "" "$unreadable_diff_out"
 
     # The test-path scan on the same failure fails closed too: an unreadable
@@ -415,15 +418,92 @@ RUST
     unreadable_test_out="$($SUMMARY -C "$unreadable_test_repo" --head 2>"$SANDBOX/unreadable-test-diff.err")" || unreadable_test_rc=$?
     unreadable_test_err="$(cat "$SANDBOX/unreadable-test-diff.err")"
     chmod 644 "$unreadable_test_repo/tests/it.rs"
-    assert_eq "unreadable diff member: test panic scan exits non-zero" \
+    assert_eq "unreadable test-path diff member: exits non-zero" \
         "1" "$unreadable_test_rc"
-    assert_eq "unreadable diff member: test panic scan names git diff and the path on stderr" \
+    assert_eq "unreadable test-path diff member: names git diff and the path on stderr" \
         "yes" "$(grep -qE 'git diff failed .*tests/it\.rs' <<<"$unreadable_test_err" && echo yes || echo no)"
-    assert_eq "unreadable diff member: test panic scan prints no summary" \
+    assert_eq "unreadable test-path diff member: prints no summary" \
         "" "$unreadable_test_out"
+
+    # A .rs file outside every panic-scan path (not src/, lib/, tests/) is
+    # read only by the stats and `*.rs` risk-flag scans — the two that used to
+    # swallow git failures into "0 files changed" and "no unsafe/repr(C)/
+    # extern/atomics" respectively.
+    unreadable_bin_repo="$SANDBOX/unreadable-bin-diff"
+    init_repo "$unreadable_bin_repo"
+    mkdir -p "$unreadable_bin_repo/bin"
+    printf 'fn main() {}\n' > "$unreadable_bin_repo/bin/main.rs"
+    git -C "$unreadable_bin_repo" add bin
+    git -C "$unreadable_bin_repo" commit -q -m bin
+    printf 'fn main() {\n    unsafe { core::ptr::null::<u8>().read() };\n}\n' > "$unreadable_bin_repo/bin/main.rs"
+    chmod 000 "$unreadable_bin_repo/bin/main.rs"
+    unreadable_bin_rc=0
+    unreadable_bin_out="$($SUMMARY -C "$unreadable_bin_repo" --head 2>"$SANDBOX/unreadable-bin-diff.err")" || unreadable_bin_rc=$?
+    unreadable_bin_err="$(cat "$SANDBOX/unreadable-bin-diff.err")"
+    chmod 644 "$unreadable_bin_repo/bin/main.rs"
+    assert_eq "unreadable non-panic-path .rs diff member: exits non-zero" \
+        "1" "$unreadable_bin_rc"
+    assert_eq "unreadable non-panic-path .rs diff member: names git diff and the path on stderr" \
+        "yes" "$(grep -qE 'git diff failed .*bin/main\.rs' <<<"$unreadable_bin_err" && echo yes || echo no)"
+    assert_eq "unreadable non-panic-path .rs diff member: prints no summary" \
+        "" "$unreadable_bin_out"
 else
     printf '  SKIP: unreadable-module cases (running as root)\n'
 fi
+
+# Per-scan isolation: a git shim fails exactly the `git diff` invocation whose
+# argument list contains $FAIL_ON_ARG and execs the real git otherwise, so
+# each of the four scans is proven to fail closed under its own label even
+# though on a real unreadable file the stats scan always reports first.
+shim_repo="$SANDBOX/shim"
+init_repo "$shim_repo"
+mkdir -p "$shim_repo/src" "$shim_repo/tests"
+printf 'pub fn a() {}\n' > "$shim_repo/src/lib.rs"
+printf '#[test]\nfn t() {}\n' > "$shim_repo/tests/it.rs"
+git -C "$shim_repo" add src tests
+git -C "$shim_repo" commit -q -m base
+printf 'pub fn a() {\n    panic!("x");\n}\n' > "$shim_repo/src/lib.rs"
+printf '#[test]\nfn t() {\n    let v: u32 = "1".parse().unwrap();\n    assert_eq!(v, 1);\n}\n' > "$shim_repo/tests/it.rs"
+shim_dir="$SANDBOX/git-shim"
+mkdir -p "$shim_dir"
+cat > "$shim_dir/git" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = diff ] && [ -n "${FAIL_ON_ARG:-}" ]; then
+    for a in "$@"; do
+        if [ "$a" = "$FAIL_ON_ARG" ]; then
+            printf 'fatal: shim: injected failure for %s\n' "$FAIL_ON_ARG" >&2
+            exit 128
+        fi
+    done
+fi
+exec "$REAL_GIT" "$@"
+SH
+chmod +x "$shim_dir/git"
+REAL_GIT="$(command -v git)"
+# Control: the shim is transparent when no failure is injected.
+shim_ctrl_json="$(PATH="$shim_dir:$PATH" REAL_GIT="$REAL_GIT" FAIL_ON_ARG= $SUMMARY -C "$shim_repo" --head)"
+assert_eq "git shim without injection is transparent" \
+    '["panic_path_added","test_panic_path_added"]' "$(jq -c '.risk_flags' <<<"$shim_ctrl_json")"
+while IFS='|' read -r shim_label shim_arg; do
+    shim_rc=0
+    shim_out="$(PATH="$shim_dir:$PATH" REAL_GIT="$REAL_GIT" FAIL_ON_ARG="$shim_arg" \
+        $SUMMARY -C "$shim_repo" --head 2>"$SANDBOX/shim.err")" || shim_rc=$?
+    shim_err="$(cat "$SANDBOX/shim.err")"
+    assert_eq "injected git diff failure in the $shim_label scan ($shim_arg): exits non-zero" \
+        "1" "$shim_rc"
+    assert_eq "injected git diff failure in the $shim_label scan ($shim_arg): diagnostic names the scan and the arguments" \
+        "yes" "$(grep -qF "git diff failed (exit 128) while scanning $shim_label (git diff " <<<"$shim_err" \
+            && grep -qF -- "$shim_arg" <<<"$shim_err" && echo yes || echo no)"
+    assert_eq "injected git diff failure in the $shim_label scan ($shim_arg): quotes git's stderr" \
+        "yes" "$(grep -qF 'shim: injected failure' <<<"$shim_err" && echo yes || echo no)"
+    assert_eq "injected git diff failure in the $shim_label scan ($shim_arg): prints no summary" \
+        "" "$shim_out"
+done <<'CASES'
+stats|--stat
+risk flags|*.rs
+panic paths|src/lib.rs
+panic paths|tests/it.rs
+CASES
 
 # --head content reads are tracked-only, like the sibling listing: an
 # UNTRACKED 2018-style parent file carrying a gated declaration must not

--- a/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
+++ b/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
@@ -401,8 +401,8 @@ RUST
     assert_eq "unreadable diff member: production panic scan prints no summary" \
         "" "$unreadable_diff_out"
 
-    # The test-path scan on the same failure used to degrade to an empty diff
-    # (fail-open: test_panic_path_added silently never set). Same contract.
+    # The test-path scan on the same failure fails closed too: an unreadable
+    # diff member is never read as "no test panics".
     unreadable_test_repo="$SANDBOX/unreadable-test-diff"
     init_repo "$unreadable_test_repo"
     mkdir -p "$unreadable_test_repo/tests"

--- a/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
+++ b/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
@@ -502,7 +502,7 @@ done <<'CASES'
 stats|--stat
 risk flags|*.rs
 panic paths|src/lib.rs
-panic paths|tests/it.rs
+test panic paths|tests/it.rs
 CASES
 
 # --head content reads are tracked-only, like the sibling listing: an

--- a/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
+++ b/skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh
@@ -1971,5 +1971,30 @@ dangling_json="$($SUMMARY -C "$dangling_repo" --head)"
 assert_eq "dangling symlink declaring module fails closed to production"     '["panic_path_added"]' "$(jq -c '.risk_flags' <<<"$dangling_json")"
 assert_eq "dangling symlink keeps production scope"     "production" "$(jq -r '.scope' <<<"$dangling_json")"
 
+# A brace nested in a ( ) or [ ] group opens a block EXPRESSION, not an item
+# body: it must not end the item and drop the pending gate. Only a brace at
+# token-group depth 0 opens a skip region.
+brace_repo="$SANDBOX/nested-brace-group"
+init_repo "$brace_repo"
+mkdir -p "$brace_repo/src"
+cat > "$brace_repo/src/lib.rs" <<'RUST'
+#[cfg(test)]
+const B: [fn(); { 1 }] = [include!("cand.rs"); 1];
+RUST
+git -C "$brace_repo" add src
+git -C "$brace_repo" commit -q -m lib
+cat > "$brace_repo/src/cand.rs" <<'RUST'
+{
+    fn helper() {
+        panic!("boom");
+    }
+    helper as fn()
+}
+RUST
+git -C "$brace_repo" add src/cand.rs
+brace_json="$($SUMMARY -C "$brace_repo" --staged)"
+assert_eq "brace in a nested group keeps the item gate"     '["test_panic_path_added"]' "$(jq -c '.risk_flags' <<<"$brace_json")"
+assert_eq "nested-brace fixture stays support scope"     "support" "$(jq -r '.scope' <<<"$brace_json")"
+
 printf '\nPASS=%d FAIL=%d\n' "$PASS" "$FAIL"
 if [ "$FAIL" -ne 0 ]; then exit 1; fi


### PR DESCRIPTION
## Summary

Two `git-diff-summary` defects, same script:

- **VST-233** — the two panic-scan pipelines were unguarded under `set -euo pipefail`. A `git diff` failure (unreadable tracked file in the diff → exit 128) killed the script with exit 128 and no diagnostic on the production scan, and — worse — the test scan's `|| true` turned the same failure into an empty diff, so `test_panic_path_added` was silently never set (fail-open). All four `git diff` scans (stats, `*.rs` risk flags, prod panic paths, test panic paths) now route through `scan_diff`: git's stdout to a variable, stderr to a temp file, and a loud `exit 1` naming `git diff`, the exit code, the path list and git's stderr. The awk program is byte-identical; `|| true` survives only on the grep step.
- **VST-254** — braces nested inside `( )`/`[ ]` groups ended an item early (`const B: [fn(); { 1 }] = [include!("cand.rs"); 1];`); item boundaries are now token-group depth-aware for braces as they already were for semicolons. Cherry-pick of `377b124b` from `vst-213-followup-nested-brace-boundary` (138/138 there).

## Verification

- `git-diff-summary-cfg-test-declaration.test.sh` 144/0 (two new non-root cases: unreadable file in a prod path and in a `tests/` path — exit 1, stderr names `git diff` + path, no summary printed), `risk-flags` 8/0, `default-base` 5/0.
- Must-fail control: the new cases run against HEAD's script fail with exactly the pre-fix shapes (prod scan exit 128 with no stderr; test scan exit 0 with a JSON summary).
- Out of scope, noted: the `--stat` / `'*.rs'` pipelines still swallow git failures.

Fixes VST-233, VST-254

