### PR TITLE
feat(tools): validate-changed — diff-scoped local validation mirroring CI lanes (VST-237)

### DIFF
--- a/.github/workflows/skill-tests.yml
+++ b/.github/workflows/skill-tests.yml
@@ -101,8 +101,15 @@ jobs:
               echo "not executable in git: $f"
               fail=1
             fi
-          done < <(git ls-files -- 'skills/*/tests/*.sh' 'skills/*/scripts/*' 'hooks/tests/*.sh' | grep -v '/scripts/lib/')
+          done < <(git ls-files -- 'skills/*/tests/*.sh' 'skills/*/scripts/*' 'hooks/tests/*.sh' 'tools/tests/*.sh' 'tools/validate-changed' | grep -v '/scripts/lib/')
           exit "$fail"
+
+      # tools/validate-changed mirrors THIS workflow's lanes for local runs;
+      # its test pins the path->lane table so the local half cannot drift
+      # silently from the shards below.
+      - name: validate-changed lane derivation
+        if: matrix.shard == 'shell'
+        run: bash tools/tests/validate-changed.test.sh
 
       # Every skill must route problem reports through `vstack report`. The
       # ownership guard is a backstop for issues that bypassed it, so a skill

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -260,7 +260,11 @@ cli/scripts/integration-check.sh         # integration check in a throwaway temp
 - The gate answers review-only; CI is branch protection's job. The heavy
   suite jobs run only in the merge queue (fast/full split — see
   `.github/workflows/skill-tests.yml`); the queue runs the full suite once,
-  on the merged result, and refuses the merge if it fails. The refusal is
+  on the merged result, and refuses the merge if it fails. Locally,
+  `tools/validate-changed` validates the changed surface — it derives the
+  suite lanes from the diff, mirroring the workflow's shards, and prints
+  them before running (`--all` for the full sweep) — so a one-skill diff
+  never re-runs the whole suite that the queue will run once. The refusal is
   enforced by the queue ruleset's required contexts: `Review gate`,
   `CLI (cargo test + integration check)`, and
   `Skill suites (shell + node)`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,22 @@
   Guards (engineers) and the reviewer skill (reviewers); rust drops
   project-owned Build/Portability opinions; planner's discipline is cut to
   what its output format does not already require.
+- preflight: the default and `--base` scopes include every non-ignored
+  untracked file as a new file — the dev validate step and
+  `tools/validate-changed` run before the commit, so a brand-new file was
+  invisible to every lane until staged; `--staged` still sees only the
+  index. The workflow lane's expression placeholder is expression-aware
+  (a `}}` inside a single-quoted literal no longer ends it).
+- tools: `validate-changed` — diff-scoped local validation that mirrors CI's
+  lanes (skill/hook/cli/pi-extension suites plus the always-on cheap checks),
+  printing its derived lane list first; suites whose tests read another
+  area's files (orch's repo-wide doc lints, github/reviewer reading orch,
+  project-management reading linear, pi-agents-tmux importing
+  pi-session-bridge) run for changes there too; the shell lints cover
+  untracked files and the working-tree executable bit; `--all` for the full sweep;
+  dev-implement reads the project validation command from settings
+  (`DEV_VALIDATE_CMD`; VST-237).
+
 - code-quality/dev: must-fail controls are required where code is written,
   not only where it is reviewed (VST-266) — dev-implement § Validate requires
   a red-once control for every added or modified check, and Prove Your Guards

--- a/skills/dev/README.md
+++ b/skills/dev/README.md
@@ -17,6 +17,8 @@ Install with `vstack add dev`; `vstack refresh` picks up updates. It needs `orch
 
 Agent-type names, the commit prefix, and QA-label triggers are project-configurable — see SKILL.md § Configuration and the project's label application guide.
 
+`DEV_VALIDATE_CMD` (`vstack.settings.toml` `[env]`, read via `orch-env`) names the project's validation command for the Validate step of both workflows — point it at a diff-scoped validator where one exists (vstack itself sets `tools/validate-changed`); unset, the workflows fall back to the project's documented build/test/lint command.
+
 ## Tests
 
 ```bash

--- a/skills/dev/SKILL.md
+++ b/skills/dev/SKILL.md
@@ -57,4 +57,4 @@ A full suite can outlast a turn. **Invariant, every harness:** the completion ta
 
 ## Configuration
 
-Agent-type placeholders are project-configurable: `[AGENT_TYPE]` (dev agents receiving implementation delegations), `[REVIEW_AGENT]`, `[QA_AGENT]`. Commit format: `[PREFIX]([ISSUE_ID]): [DESCRIPTION]`.
+Agent-type placeholders are project-configurable: `[AGENT_TYPE]` (dev agents receiving implementation delegations), `[REVIEW_AGENT]`, `[QA_AGENT]`. Commit format: `[PREFIX]([ISSUE_ID]): [DESCRIPTION]`. `DEV_VALIDATE_CMD` (`vstack.settings.toml` `[env]`) names the project's validation command for the Validate step; unset → the project's documented build/test/lint command.

--- a/skills/dev/workflows/dev-fix.md
+++ b/skills/dev/workflows/dev-fix.md
@@ -34,7 +34,7 @@ Note anything a fix revealed about deeper problems, and cite the decision ID or 
 
 ## 3. Validate And Commit
 
-Run the project's validation command (`.agents/skills/orch/scripts/orch-env DEV_VALIDATE_CMD ""`, from the worktree root; unset → the project's documented build/test/lint command); failure handling and the rule for a run that outlasts your turn are in [dev SKILL.md § Validation](../SKILL.md#validation).
+Run the project's validation command — the one `.agents/skills/orch/scripts/orch-env DEV_VALIDATE_CMD ""` prints (empty → the project's documented build/test/lint command) — from the worktree root; failure handling and the rule for a run that outlasts your turn are in [dev SKILL.md § Validation](../SKILL.md#validation).
 
 **Visual QA** — **skip if** the issue has no `design` label or the fix touches no UI code. Otherwise confirm what the fix changes renders correctly, not the full checklist.
 

--- a/skills/dev/workflows/dev-fix.md
+++ b/skills/dev/workflows/dev-fix.md
@@ -34,7 +34,7 @@ Note anything a fix revealed about deeper problems, and cite the decision ID or 
 
 ## 3. Validate And Commit
 
-Run the project's build/test/lint validation command; failure handling and the rule for a run that outlasts your turn are in [dev SKILL.md § Validation](../SKILL.md#validation).
+Run the project's validation command (`.agents/skills/orch/scripts/orch-env DEV_VALIDATE_CMD ""`, from the worktree root; unset → the project's documented build/test/lint command); failure handling and the rule for a run that outlasts your turn are in [dev SKILL.md § Validation](../SKILL.md#validation).
 
 **Visual QA** — **skip if** the issue has no `design` label or the fix touches no UI code. Otherwise confirm what the fix changes renders correctly, not the full checklist.
 

--- a/skills/dev/workflows/dev-implement.md
+++ b/skills/dev/workflows/dev-implement.md
@@ -151,7 +151,7 @@ Deterministic gates first — every finding is fixed here, never carried into re
 .agents/skills/size-ratchet/scripts/size-ratchet
 ```
 
-Then the project's build/test/lint validation command, plus the delegation's required verification commands in their § 2.4 normalized form. Failure handling, and the invariant for a run that outlasts your turn, are in [dev SKILL.md § Validation](../SKILL.md#validation).
+Then the project's validation command (`.agents/skills/orch/scripts/orch-env DEV_VALIDATE_CMD ""`, run from the worktree root; unset → the project's documented build/test/lint command), plus the delegation's required verification commands in their § 2.4 normalized form. Failure handling, and the invariant for a run that outlasts your turn, are in [dev SKILL.md § Validation](../SKILL.md#validation).
 
 Every check, guard, assertion, or test this change adds or modifies must have a must-fail control that runs red once ([code-quality § Prove Your Guards](../../code-quality/SKILL.md#prove-your-guards)); a guard without one is not validated.
 

--- a/skills/dev/workflows/dev-implement.md
+++ b/skills/dev/workflows/dev-implement.md
@@ -151,7 +151,7 @@ Deterministic gates first — every finding is fixed here, never carried into re
 .agents/skills/size-ratchet/scripts/size-ratchet
 ```
 
-Then the project's validation command (`.agents/skills/orch/scripts/orch-env DEV_VALIDATE_CMD ""`, run from the worktree root; unset → the project's documented build/test/lint command), plus the delegation's required verification commands in their § 2.4 normalized form. Failure handling, and the invariant for a run that outlasts your turn, are in [dev SKILL.md § Validation](../SKILL.md#validation).
+Then the project's validation command — the one `.agents/skills/orch/scripts/orch-env DEV_VALIDATE_CMD ""` prints (empty → the project's documented build/test/lint command), run from the worktree root — plus the delegation's required verification commands in their § 2.4 normalized form. Failure handling, and the invariant for a run that outlasts your turn, are in [dev SKILL.md § Validation](../SKILL.md#validation).
 
 Every check, guard, assertion, or test this change adds or modifies must have a must-fail control that runs red once ([code-quality § Prove Your Guards](../../code-quality/SKILL.md#prove-your-guards)); a guard without one is not validated.
 

--- a/skills/preflight/README.md
+++ b/skills/preflight/README.md
@@ -15,6 +15,7 @@ preflight: 1 finding(s) across 3 changed file(s)
 
 Exit codes: `0` clean, `1` findings, `2` usage or environment error.
 Requirements: `git`, `awk`, and the usual POSIX userland; `shellcheck`,
-`jq`, `taplo` and `python3` are each optional and each enable one lane.
+`jq`, `taplo` and `python3` (with PyYAML for the workflow lane) are each
+optional and each enable one lane.
 Bash 3.2 compatible. Lane table, scope rules, and wiring into validation,
 hooks and CI: [SKILL.md](SKILL.md).

--- a/skills/preflight/SKILL.md
+++ b/skills/preflight/SKILL.md
@@ -42,7 +42,7 @@ clean empty diff.
 | `docs-cited-paths` | An added backticked path in a `.md` file, inside a directory the repo really has and the doc's own subtree, that names nothing tracked or on disk. | built in |
 | `todo-links` | An added `TODO:`/`FIXME(` marker — the word immediately followed by `:` or `(` — with no `#123`, `ABC-123`, or URL on the line. Prose that merely uses the word is not a marker. | built in |
 | `data-syntax` | A changed `.json` or `.toml` file no parser accepts. | jq, taplo or python3 |
-| `workflow-run-syntax` | A `run:` block in a changed `.github/workflows/*.yml` that its shell cannot parse — `bash -n` for bash, `sh -n` for sh, by name or executable path; `${{ … }}` replaced by a placeholder; other shells skipped, and an undeclared shell counts as bash only on plain `ubuntu-*`/`macos-*` runners. Reported at the offending file line — a folded (`>`) block at its first line; a workflow file that is not valid YAML, at the parser's line. | python3 with PyYAML |
+| `workflow-run-syntax` | A `run:` block in a changed `.github/workflows/*.yml` that its shell cannot parse — `bash -n` for bash, `sh -n` for sh, by name or executable path; `${{ … }}` replaced by a placeholder; other shells skipped, and an undeclared shell counts as bash only on plain `ubuntu-*`/`macos-*` runners. Reported at the offending file line — a folded (`>`) block at its first line; a workflow file that is not valid YAML, at the parser's line; an unterminated `${{`, at its line. | python3 with PyYAML |
 
 Shell files are `*.sh`, `*.bash`, or anything with a `sh`/`bash` shebang.
 Deleted files, and files under `tests/` or `fixtures/`, are out of scope

--- a/skills/preflight/SKILL.md
+++ b/skills/preflight/SKILL.md
@@ -56,8 +56,8 @@ not a git repository, unresolvable base). Findings print as
 ## Wiring
 
 Dev agents run `preflight` in the validate step, **before** the project's
-own validation command. Untracked files are outside every diff scope:
-stage new files before expecting them to be checked.
+own validation command. The default and `--base` scopes include every
+non-ignored untracked file as a new file; `--staged` sees only the index.
 
 The commit-time surface is vstack's managed `pre-commit-check` harness
 hook (PreToolUse on `git commit`), which runs `preflight --staged` when

--- a/skills/preflight/scripts/preflight
+++ b/skills/preflight/scripts/preflight
@@ -22,10 +22,12 @@ usage() {
 usage: preflight [--staged | --base REF | --all] [--repo PATH]
 
 Diff-scoped deterministic checks. Default scope is the merge base of HEAD
-and the default branch (origin/HEAD, else origin/main, else main).
+and the default branch (origin/HEAD, else origin/main, else main), plus
+non-ignored untracked files; --staged sees only the index.
 
   --staged      staged changes only (pre-commit scope)
-  --base REF    changes since the merge base of HEAD and REF
+  --base REF    changes since the merge base of HEAD and REF, plus every
+                non-ignored untracked file (a new file, every line added)
   --all         every tracked file, every line treated as added
   --repo PATH   run against the repository containing PATH (default: cwd)
 
@@ -114,8 +116,13 @@ case "$MODE" in
     git_diff --name-only --diff-filter=d -z "$BASE" -- >"$TMP/files.z" || env_error "git diff against $BASE failed"
     git_diff --unified=0 --no-color --no-renames --diff-filter=d "$BASE" -- >"$TMP/patch" || env_error "git diff against $BASE failed"
     git_diff --name-only --diff-filter=A "$BASE" -- >"$TMP/newfiles.list" || true
+    # A file never added is invisible to `git diff` yet is part of the change
+    # the author is about to commit: every non-ignored untracked file is a new
+    # file with every line added, exactly what it will be at the PR.
+    git -c core.quotePath=false ls-files --others --exclude-standard -z >"$TMP/untracked.z" || env_error "git ls-files --others failed"
     ;;
 esac
+[ -f "$TMP/untracked.z" ] || : >"$TMP/untracked.z"
 
 # Newline- and tab-free paths are a precondition for every record below, and
 # for the positional map that pairs a path with its added lines. Refuse the
@@ -165,6 +172,16 @@ else
       ln++
     }
   ' "$TMP/patch"
+  while IFS= read -r -d '' f; do
+    case "$f" in
+      *"$TAB"* | *"$NL"*) env_error "untracked path contains a tab or newline, unrepresentable in this tool's records: '$f'" ;;
+    esac
+    printf '%s\n' "$f" >>"$TMP/files.list"
+    printf '%s\n' "$f" >>"$TMP/newfiles.list"
+    [ -f "$f" ] && [ ! -h "$f" ] || continue
+    grep -Iq . -- "$f" 2>/dev/null || continue
+    PF="$f" awk 'BEGIN { p = ENVIRON["PF"] } { print p "\t" FNR "\t" $0 }' "$f" >>"$TMP/added.tsv"
+  done <"$TMP/untracked.z"
 fi
 
 # Split the added lines into one `line<TAB>content` file per changed file,

--- a/skills/preflight/scripts/preflight
+++ b/skills/preflight/scripts/preflight
@@ -199,8 +199,10 @@ awk -F'\t' -v dir="$TMP" -v listfile="$TMP/files.list" '
 ' "$TMP/files.list" "$TMP/added.tsv"
 
 git ls-files >"$TMP/tracked.list" || env_error "git ls-files failed"
-# Every directory that holds tracked files, at every depth.
-awk -F/ '{ p = ""; for (i = 1; i < NF; i++) { p = (i == 1 ? $i : p "/" $i); print p } }' "$TMP/tracked.list" | LC_ALL=C sort -u >"$TMP/trackeddirs"
+# Every directory that holds tracked files, at every depth — plus the
+# directories of the untracked files in scope, so a new doc under a new
+# directory is judged as it will be once committed.
+{ cat "$TMP/tracked.list"; tr '\0' '\n' <"$TMP/untracked.z"; } | awk -F/ '{ p = ""; for (i = 1; i < NF; i++) { p = (i == 1 ? $i : p "/" $i); print p } }' | LC_ALL=C sort -u >"$TMP/trackeddirs"
 
 # --- shared helpers ----------------------------------------------------------
 content_of() { # IDX PATH -> inspectable content path on stdout; nonzero if unavailable
@@ -381,6 +383,39 @@ def strip_expressions(text):
         out.append("X")
         i = k
     return "".join(out)
+# The line (1-based, within the block) of the first `${{` that never
+# closes, else 0. Detected separately so the placeholder pass stays simple.
+def unterminated_expression_line(text):
+    i = 0
+    n = len(text)
+    while i < n:
+        j = text.find("${{", i)
+        if j < 0:
+            return 0
+        k = j + 3
+        closed = False
+        while k < n:
+            c = text[k]
+            if c == "\x27":
+                k += 1
+                while k < n:
+                    if text[k] == "\x27":
+                        if k + 1 < n and text[k + 1] == "\x27":
+                            k += 2
+                            continue
+                        break
+                    k += 1
+                k += 1
+                continue
+            if text.startswith("}}", k):
+                closed = True
+                k += 2
+                break
+            k += 1
+        if not closed:
+            return text.count("\n", 0, j) + 1
+        i = k
+    return 0
 # With no shell declared anywhere, GitHub runs bash on Linux/macOS runners and
 # PowerShell on Windows ones. An implicit shell is bash only when every
 # runs-on label is a plain ubuntu-* or macos-* label; an expression, a
@@ -439,6 +474,11 @@ for _, job in jobs.items():
         if run.style in ("|", ">"):
             first += 1
         folded = run.style == ">"
+        bad = unterminated_expression_line(run.value)
+        if bad:
+            at = first if folded else first + bad - 1
+            sys.stdout.write("%d\tunterminated GitHub expression: ${{ without a closing }}\n" % at)
+            continue
         body = strip_expressions(run.value)
         with tempfile.NamedTemporaryFile("w", suffix=".sh", delete=False) as t:
             t.write(body)

--- a/skills/preflight/scripts/preflight
+++ b/skills/preflight/scripts/preflight
@@ -140,7 +140,7 @@ if [ "$MODE" = "all" ]; then
   while IFS= read -r f; do
     [ -f "$f" ] && [ ! -h "$f" ] || continue
     grep -Iq . -- "$f" 2>/dev/null || continue
-    PF="$f" awk 'BEGIN { p = ENVIRON["PF"] } { print p "\t" FNR "\t" $0 }' "$f" >>"$TMP/added.tsv"
+    PF="$f" awk 'BEGIN { p = ENVIRON["PF"] } { print p "\t" FNR "\t" $0 }' "./$f" >>"$TMP/added.tsv"
   done <"$TMP/files.list"
 else
   awk -v out="$TMP/added.tsv" '
@@ -180,7 +180,7 @@ else
     printf '%s\n' "$f" >>"$TMP/newfiles.list"
     [ -f "$f" ] && [ ! -h "$f" ] || continue
     grep -Iq . -- "$f" 2>/dev/null || continue
-    PF="$f" awk 'BEGIN { p = ENVIRON["PF"] } { print p "\t" FNR "\t" $0 }' "$f" >>"$TMP/added.tsv"
+    PF="$f" awk 'BEGIN { p = ENVIRON["PF"] } { print p "\t" FNR "\t" $0 }' "./$f" >>"$TMP/added.tsv"
   done <"$TMP/untracked.z"
 fi
 

--- a/skills/preflight/scripts/preflight
+++ b/skills/preflight/scripts/preflight
@@ -345,6 +345,42 @@ def shell_of(node):
 def interpreter_of(shell):
     m = re.match(r"^(?:.*/)?(bash|sh)(?:\s|$)", shell.strip())
     return m.group(1) if m else None
+# GitHub expressions are replaced by a placeholder before parsing. Their
+# string literals are single-quoted with a doubled quote as the escape, so a
+# closing brace pair inside a literal (format with braces) does not end the
+# expression; a naive shortest-match regex would leave the tail of the
+# literal behind as shell text.
+def strip_expressions(text):
+    out = []
+    i = 0
+    n = len(text)
+    while i < n:
+        j = text.find("${{", i)
+        if j < 0:
+            out.append(text[i:])
+            break
+        out.append(text[i:j])
+        k = j + 3
+        while k < n:
+            c = text[k]
+            if c == "\x27":
+                k += 1
+                while k < n:
+                    if text[k] == "\x27":
+                        if k + 1 < n and text[k + 1] == "\x27":
+                            k += 2
+                            continue
+                        break
+                    k += 1
+                k += 1
+                continue
+            if text.startswith("}}", k):
+                k += 2
+                break
+            k += 1
+        out.append("X")
+        i = k
+    return "".join(out)
 # With no shell declared anywhere, GitHub runs bash on Linux/macOS runners and
 # PowerShell on Windows ones. An implicit shell is bash only when every
 # runs-on label is a plain ubuntu-* or macos-* label; an expression, a
@@ -403,7 +439,7 @@ for _, job in jobs.items():
         if run.style in ("|", ">"):
             first += 1
         folded = run.style == ">"
-        body = re.sub(r"\$\{\{.*?\}\}", "X", run.value, flags=re.S)
+        body = strip_expressions(run.value)
         with tempfile.NamedTemporaryFile("w", suffix=".sh", delete=False) as t:
             t.write(body)
             tmp = t.name

--- a/skills/preflight/tests/lanes-must-fail.test.sh
+++ b/skills/preflight/tests/lanes-must-fail.test.sh
@@ -161,7 +161,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: fine
-        run: echo "${{ github.sha }}"
+        run: echo "${{ github.sha }}" ${{ format('{{Hello {0}!}}', github.actor) }}
       - name: broken
         run: |
           set -euo pipefail

--- a/skills/preflight/tests/lanes-must-fail.test.sh
+++ b/skills/preflight/tests/lanes-must-fail.test.sh
@@ -203,6 +203,13 @@ jobs:
       - name: sh step
         shell: sh
         run: echo "unterminated
+  openexpr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: expression never closes
+        run: |
+          echo start
+          echo ${{ github.sha
 YML
   # A workflow-level non-bash default survives a job-level `defaults` that
   # only sets working-directory.
@@ -231,6 +238,7 @@ YML
   fires "a workflow file that is not valid YAML is a finding at the parser's line" ".github/workflows/bad.yml:4: [workflow-run-syntax] workflow YAML did not parse"
   fires "a bash given as an executable path (/bin/bash {0}) is in scope" ".github/workflows/ci.yml:43: [workflow-run-syntax]"
   fires "a shell: sh step is parsed too" ".github/workflows/ci.yml:49: [workflow-run-syntax]"
+  fires "an unterminated \${{ is a finding at its line, never a swallowed tail" ".github/workflows/ci.yml:56: [workflow-run-syntax] unterminated GitHub expression"
   case "$OUT" in
     *"ci.yml:8: "* | *"ci.yml:18: "* | *"ci.yml:27: "* | *"ci.yml:32: "* | *"ci.yml:37: "* | *"defaults.yml"*)
       bad "clean (8), python (18), implicit-pwsh Windows (27), expression runner (32), self-hosted runner (37) and inherited-pwsh (defaults.yml) steps contribute no findings" "out=$OUT" ;;

--- a/skills/preflight/tests/modes.test.sh
+++ b/skills/preflight/tests/modes.test.sh
@@ -67,6 +67,25 @@ else
   bad "the default scope is base-to-worktree, so it sees both" "rc=$RC out=$OUT"
 fi
 
+echo "=== untracked files are new files in the default scope, invisible to --staged ==="
+seed untracked
+printf '# Never added\n\nTODO: untracked and unreferenced.\n' >"$R/docs/never-added.md"
+mkdir -p "$R/scratch"
+printf 'scratch/\n' >"$R/.gitignore"
+printf '# Ignored\n\nTODO: ignored and unreferenced.\n' >"$R/scratch/ignored.md"
+run_pf
+if [ "$RC" -eq 1 ] && has "docs/never-added.md:3: [todo-links]" && ! has "scratch/ignored.md"; then
+  ok "a non-ignored untracked file is in scope; an ignored one is not"
+else
+  bad "a non-ignored untracked file is in scope; an ignored one is not" "rc=$RC out=$OUT"
+fi
+run_pf --staged
+if [ "$RC" -eq 0 ] && ! has "never-added.md"; then
+  ok "--staged sees only the index, so the untracked file is out of scope"
+else
+  bad "--staged sees only the index, so the untracked file is out of scope" "rc=$RC out=$OUT"
+fi
+
 echo "=== --staged judges staged bytes even when the worktree has moved on ==="
 seed rewound
 printf '# Staged\n\nTODO: staged and unreferenced.\n' >"$R/docs/staged.md"

--- a/skills/preflight/tests/modes.test.sh
+++ b/skills/preflight/tests/modes.test.sh
@@ -85,6 +85,18 @@ if [ "$RC" -eq 0 ] && ! has "never-added.md"; then
 else
   bad "--staged sees only the index, so the untracked file is out of scope" "rc=$RC out=$OUT"
 fi
+# A new doc under a NEW directory is judged as it will be once committed:
+# its citation of a missing sibling fires even though nothing tracked lives
+# in that directory yet.
+seed newdir
+mkdir -p "$R/docs/new"
+printf '# New\n\nSee `docs/new/missing.md`.\n' >"$R/docs/new/guide.md"
+run_pf
+if [ "$RC" -eq 1 ] && has "docs/new/guide.md:3: [docs-cited-paths] cites a path that does not exist: docs/new/missing.md"; then
+  ok "an untracked doc in an untracked directory has its dead citation reported"
+else
+  bad "an untracked doc in an untracked directory has its dead citation reported" "rc=$RC out=$OUT"
+fi
 
 echo "=== --staged judges staged bytes even when the worktree has moved on ==="
 seed rewound

--- a/tools/tests/validate-changed.test.sh
+++ b/tools/tests/validate-changed.test.sh
@@ -102,6 +102,12 @@ mkexec skills/preflight/tests/a.test.sh '#!/usr/bin/env bash
 exit 0'
 mkexec skills/linear/tests/a.test.sh '#!/usr/bin/env bash
 exit 0'
+mkexec skills/github/tests/a.test.sh '#!/usr/bin/env bash
+exit 0'
+mkexec skills/reviewer/tests/a.test.sh '#!/usr/bin/env bash
+exit 0'
+mkexec skills/project-management/tests/a.test.sh '#!/usr/bin/env bash
+exit 0'
 mkfile skills/deep-research/tests/deep-research.test.mjs '// stub'
 mkfile skills/deep-research/SKILL.md 'report via vstack report'
 mkexec hooks/tests/h.test.sh '#!/usr/bin/env bash
@@ -155,7 +161,6 @@ touch_path docs/guide.md
 touch_path README.md
 touch_path CHANGELOG.md
 touch_path AGENTS.md
-touch_path agents/rust.md
 touch_path .github/instructions/x.md
 mkfile docs/new-untracked.md 'new'
 run --dry-run
@@ -163,10 +168,17 @@ assert_rc "docs-only" 0
 assert_only_always "docs-only"
 assert_line "docs-only" "no suite lane: docs/guide.md"
 assert_line "docs-only" "no suite lane: docs/new-untracked.md"
-assert_line "docs-only" "no suite lane: agents/rust.md"
 assert_line "docs-only" "no suite lane: .github/instructions/x.md"
 assert_no_line "docs-only" "all lanes:"
-assert_line "docs-only" "7 changed path(s)"
+assert_line "docs-only" "6 changed path(s)"
+reset_tree
+
+# A changed path containing a newline cannot be derived from: fail closed.
+mkfile "docs/bad
+name.md" 'x'
+run --dry-run
+assert_rc "newline in path" 2
+assert_line "newline in path" "a changed path contains a newline"
 reset_tree
 
 # --- 2. skills/<name>/** with tests -----------------------------------------
@@ -175,6 +187,8 @@ run --dry-run
 assert_lane "skill with tests" "skill:withtests"
 assert_line "skill with tests" "bash skills/withtests/tests/*.sh (1 file(s))"
 assert_lane "skill with tests" "lint:shell"
+assert_lane "skill with tests" "skill:orch"
+assert_no_lane "skill with tests" "skill:(github|reviewer|project-management)"
 assert_no_lane "skill with tests" "hooks"
 assert_no_lane "skill with tests" "cli:"
 assert_no_lane "skill with tests" "pi:"
@@ -185,7 +199,8 @@ reset_tree
 # --- 3. skills/<name>/** without tests -> no suite lane -----------------------
 touch_path skills/notests/SKILL.md
 run --dry-run
-assert_no_lane "skill without tests" "skill:"
+assert_no_lane "skill without tests" "skill:notests"
+assert_lane "skill without tests" "skill:orch"
 assert_lane "skill without tests" "lint:shell"
 assert_line "skill without tests" "no suite lane: skills/notests/SKILL.md (skills/notests has no tests)"
 reset_tree
@@ -204,6 +219,9 @@ run --dry-run
 assert_lane "orch" "skill:orch"
 assert_line "orch" "bash skills/orch/tests/run-all.sh"
 assert_no_line "orch" "bash skills/orch/tests/*.sh"
+assert_lane "orch" "skill:github"
+assert_lane "orch" "skill:reviewer"
+assert_no_lane "orch" "skill:project-management"
 reset_tree
 
 # --- 5. review-gate -> its tests/*.sh -----------------------------------------
@@ -279,12 +297,38 @@ assert_lane "root template" "skill:review-gate"
 assert_no_lane "root template" "skill:withtests"
 reset_tree
 
+# --- 11b. cross-suite reads: agents/** -> orch + reviewer; linear -> pm ------
+touch_path agents/rust.md
+run --dry-run
+assert_lane "agents" "skill:orch"
+assert_lane "agents" "skill:reviewer"
+assert_no_lane "agents" "lint:shell"
+assert_no_lane "agents" "skill:(github|project-management|withtests)"
+assert_no_line "agents" "no suite lane:"
+reset_tree
+
+touch_path skills/linear/tests/a.test.sh
+run --dry-run
+assert_lane "linear" "skill:linear"
+assert_lane "linear" "skill:project-management"
+assert_lane "linear" "skill:orch"
+assert_no_lane "linear" "skill:(github|reviewer)"
+reset_tree
+
+# A mapped suite with no tests is a lane that fails, never a silent skip.
+rm -r "$REPO/skills/reviewer"
+touch_path agents/rust.md
+run
+assert_rc "mapped suite missing" 1
+assert_line "mapped suite missing" "FAILED: skill:reviewer — no suite files matched"
+reset_tree
+
 # --- 12. CONTROL: .github/workflows/** -> every lane -------------------------
 touch_path .github/workflows/skill-tests.yml
 run --dry-run
 assert_rc "workflow change" 0
 assert_line "workflow change" "all lanes: .github/workflows/skill-tests.yml changed"
-for id in always:preflight always:gate-selftest lint:shell skill:withtests skill:orch skill:review-gate node:deep-research skill:preflight skill:linear hooks tools cli:cargo-test cli:integration-check pi:pi-qol pi:pi-output-policy pi:pi-agents-tmux pi:pi-codex-minimal-tools pi:pi-questions pi:pi-claude-bridge; do
+for id in always:preflight always:gate-selftest lint:shell skill:withtests skill:orch skill:review-gate node:deep-research skill:preflight skill:linear skill:github skill:reviewer skill:project-management hooks tools cli:cargo-test cli:integration-check pi:pi-qol pi:pi-output-policy pi:pi-agents-tmux pi:pi-codex-minimal-tools pi:pi-questions pi:pi-claude-bridge; do
   assert_lane "workflow change" "$id"
 done
 assert_no_lane "workflow change" "skill:notests"
@@ -349,7 +393,7 @@ assert_line "runner pass" "===== lane: always:preflight"
 assert_line "runner pass" "preflight-stub --base main"
 assert_line "runner pass" "selftest-stub"
 assert_line "runner pass" "=== skills/withtests/tests/a.test.sh"
-assert_line "runner pass" "all 4 lane(s) passed"
+assert_line "runner pass" "all 5 lane(s) passed"
 assert_no_line "runner pass" "FAILED"
 reset_tree
 
@@ -404,6 +448,21 @@ printf 'no routing here\n' >"$REPO/skills/withtests/SKILL.md"
 run
 assert_rc "vstack report lint" 1
 assert_line "vstack report lint" "missing \`vstack report\` guidance: skills/withtests/SKILL.md"
+reset_tree
+
+# Untracked files are linted by their filesystem mode / content: a new 0644
+# script and a new SKILL.md without routing fail before they are ever added.
+mkfile skills/withtests/scripts/new-script '#!/usr/bin/env bash'
+mkfile skills/newskill/SKILL.md 'no routing here'
+run
+assert_rc "untracked lint" 1
+assert_line "untracked lint" "not executable (untracked): skills/withtests/scripts/new-script"
+assert_line "untracked lint" "missing \`vstack report\` guidance: skills/newskill/SKILL.md"
+chmod +x "$REPO/skills/withtests/scripts/new-script"
+printf 'report via vstack report\n' >"$REPO/skills/newskill/SKILL.md"
+run
+assert_rc "untracked lint fixed" 0
+assert_no_line "untracked lint fixed" "not executable"
 reset_tree
 
 # --- 20. --help ------------------------------------------------------------------

--- a/tools/tests/validate-changed.test.sh
+++ b/tools/tests/validate-changed.test.sh
@@ -526,6 +526,33 @@ assert_line "bundle drifting from a fresh build" "FAILED LANE: pi:pi-claude-brid
 reset_tree
 git -C "$REPO" reset -q --hard HEAD~1
 
+# --- 19c. root vstack.toml -> the integration check; lints fail closed -------
+touch_path vstack.toml
+run --dry-run
+assert_lane "vstack.toml" "cli:integration-check"
+assert_no_line "vstack.toml" "no suite lane:"
+reset_tree
+
+# A git failure while listing lint inputs is a lint failure, never an empty
+# list that passes: shadow `git` so `ls-files --cached --others` fails.
+GITSTUB="$TMP/gitstub"
+mkdir -p "$GITSTUB"
+REAL_GIT="$(command -v git)"
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'case "$*" in\n'
+  printf '  *"ls-files --cached --others"*) echo "fatal: index file corrupt" >&2; exit 128 ;;\n'
+  printf 'esac\n'
+  printf 'exec %s "$@"\n' "$REAL_GIT"
+} >"$GITSTUB/git"
+chmod +x "$GITSTUB/git"
+touch_path skills/withtests/SKILL.md
+PATH="$GITSTUB:$PATH" run
+assert_rc "lint list failure" 1
+assert_line "lint list failure" "FAILED: git ls-files failed while listing scripts for the exec-bit lint"
+assert_line "lint list failure" "FAILED LANE: lint:shell"
+reset_tree
+
 # --- 20. --help ------------------------------------------------------------------
 run --help
 assert_rc "--help" 0

--- a/tools/tests/validate-changed.test.sh
+++ b/tools/tests/validate-changed.test.sh
@@ -553,6 +553,14 @@ assert_line "lint list failure" "FAILED: git ls-files failed while listing scrip
 assert_line "lint list failure" "FAILED LANE: lint:shell"
 reset_tree
 
+# A skill removed from the working tree (deletion not yet staged) is a
+# pending deletion, not a doc missing its routing line.
+touch_path skills/withtests/SKILL.md
+rm "$REPO/skills/notests/SKILL.md"
+run
+assert_no_line "deleted SKILL.md" "missing \`vstack report\` guidance: skills/notests/SKILL.md"
+reset_tree
+
 # --- 20. --help ------------------------------------------------------------------
 run --help
 assert_rc "--help" 0

--- a/tools/tests/validate-changed.test.sh
+++ b/tools/tests/validate-changed.test.sh
@@ -496,6 +496,36 @@ assert_rc "untracked lint fixed" 0
 assert_no_line "untracked lint fixed" "not executable"
 reset_tree
 
+# --- 19b. runner: the bridge bundle check judges the pending bytes ------------
+# A rebuilt-but-unstaged bundle is exactly what the dev flow validates before
+# its `git add -A`: the working-tree bundle must equal a fresh build, and the
+# index is not consulted. `npm` is stubbed; `build` rewrites the bundle only
+# when BUNDLE_DRIFT is set.
+STUBBIN="$TMP/stubbin"
+mkdir -p "$STUBBIN"
+cat >"$STUBBIN/npm" <<'NPM'
+#!/usr/bin/env bash
+case "$*" in
+  "run build") [ -n "${BUNDLE_DRIFT:-}" ] && printf 'drifted\n' >bundle/index.js ;;
+esac
+exit 0
+NPM
+chmod +x "$STUBBIN/npm"
+mkfile pi-extensions/pi-claude-bridge/bundle/index.js 'old build'
+git -C "$REPO" add pi-extensions/pi-claude-bridge/bundle/index.js
+git -C "$REPO" commit -qm bundle
+printf 'new build\n' >"$REPO/pi-extensions/pi-claude-bridge/bundle/index.js"
+touch_path pi-extensions/pi-claude-bridge/index.ts
+PATH="$STUBBIN:$PATH" run
+assert_rc "pending bundle equals a fresh build" 0
+assert_no_line "pending bundle equals a fresh build" "does not match a fresh build"
+BUNDLE_DRIFT=1 PATH="$STUBBIN:$PATH" run
+assert_rc "bundle drifting from a fresh build" 1
+assert_line "bundle drifting from a fresh build" "bundle/ does not match a fresh build"
+assert_line "bundle drifting from a fresh build" "FAILED LANE: pi:pi-claude-bridge"
+reset_tree
+git -C "$REPO" reset -q --hard HEAD~1
+
 # --- 20. --help ------------------------------------------------------------------
 run --help
 assert_rc "--help" 0

--- a/tools/tests/validate-changed.test.sh
+++ b/tools/tests/validate-changed.test.sh
@@ -249,12 +249,12 @@ assert_lane "hooks" "lint:shell"
 assert_no_lane "hooks" "skill:"
 reset_tree
 
-# --- 8. cli/** -> cargo test only (integration check is --all only) ------------
+# --- 8. cli/** -> cargo test + integration check (AGENTS.md requires both) -----
 touch_path cli/src/main.rs
 run --dry-run
 assert_lane "cli" "cli:cargo-test"
 assert_line "cli" "cargo test --manifest-path cli/Cargo.toml"
-assert_no_lane "cli" "cli:integration-check"
+assert_lane "cli" "cli:integration-check"
 assert_no_lane "cli" "lint:shell"
 reset_tree
 

--- a/tools/tests/validate-changed.test.sh
+++ b/tools/tests/validate-changed.test.sh
@@ -465,6 +465,16 @@ assert_line "working-tree exec-bit lint" "not executable in working tree: skills
 assert_no_line "working-tree exec-bit lint" "not executable in git:"
 reset_tree
 
+# The reverse: index still 100644 while the working tree already carries the
+# bit (chmod +x after staging) passes — the `git add` that follows validation
+# records 100755, the state CI will see.
+touch_path skills/withtests/SKILL.md
+git -C "$REPO" update-index --chmod=-x skills/withtests/tests/a.test.sh
+chmod +x "$REPO/skills/withtests/tests/a.test.sh"
+run
+assert_no_line "stale-index exec-bit lint" "not executable"
+reset_tree
+
 printf 'no routing here\n' >"$REPO/skills/withtests/SKILL.md"
 run
 assert_rc "vstack report lint" 1

--- a/tools/tests/validate-changed.test.sh
+++ b/tools/tests/validate-changed.test.sh
@@ -128,6 +128,7 @@ mkfile pi-extensions/pi-codex-minimal-tools/index.ts 'x'
 mkfile pi-extensions/pi-questions/index.ts 'x'
 mkfile pi-extensions/pi-claude-bridge/index.ts 'x'
 mkfile pi-extensions/pi-nosuite/index.ts 'x'
+mkfile pi-extensions/pi-session-bridge/extensions/child-session-id.ts 'x'
 mkfile pi-extensions/package-policy.test.mjs 'x'
 mkfile docs/guide.md 'x'
 mkfile agents/rust.md 'x'
@@ -277,6 +278,15 @@ for ext in pi-output-policy pi-agents-tmux pi-codex-minimal-tools pi-questions p
   assert_lane "pi $ext" "pi:$ext"
 done
 assert_no_lane "pi five" "pi:pi-qol"
+reset_tree
+
+# pi-session-bridge has no suite of its own, but pi-agents-tmux's suite
+# imports it: the change selects that lane.
+touch_path pi-extensions/pi-session-bridge/extensions/child-session-id.ts
+run --dry-run
+assert_lane "pi-session-bridge" "pi:pi-agents-tmux"
+assert_no_lane "pi-session-bridge" "pi:(pi-qol|pi-output-policy|pi-codex-minimal-tools|pi-questions|pi-claude-bridge)"
+assert_line "pi-session-bridge" "no suite lane: pi-extensions/pi-session-bridge/extensions/child-session-id.ts (CI runs no suite for pi-extensions/pi-session-bridge)"
 reset_tree
 
 # --- 10. tools/** -> tools tests (not --all) -----------------------------------
@@ -442,6 +452,16 @@ run
 assert_rc "exec-bit lint" 1
 assert_line "exec-bit lint" "not executable in git: skills/withtests/tests/a.test.sh"
 assert_line "exec-bit lint" "FAILED LANE: lint:shell"
+reset_tree
+
+# A tracked executable whose bit was dropped only in the working tree (index
+# still 100755) fails too: `git add` would record the missing bit.
+touch_path skills/withtests/SKILL.md
+chmod -x "$REPO/skills/withtests/tests/a.test.sh"
+run
+assert_rc "working-tree exec-bit lint" 1
+assert_line "working-tree exec-bit lint" "not executable in working tree: skills/withtests/tests/a.test.sh"
+assert_no_line "working-tree exec-bit lint" "not executable in git:"
 reset_tree
 
 printf 'no routing here\n' >"$REPO/skills/withtests/SKILL.md"

--- a/tools/tests/validate-changed.test.sh
+++ b/tools/tests/validate-changed.test.sh
@@ -1,0 +1,415 @@
+#!/usr/bin/env bash
+# Pins tools/validate-changed: the changed-path -> lane derivation for every
+# row of its table (via --dry-run against a scratch git repo), the base
+# resolution (committed + uncommitted + untracked; --base REF; --all), and
+# the runner's fail-closed contract (every selected lane runs, failures are
+# named in a FAILED LANES block, a missing suite path is a failure).
+#
+# Controls: a docs-only change derives NO suite lane; a workflow change
+# derives every lane.
+#
+# errexit is on: a broken fixture step aborts loudly instead of cascading
+# into misleading assertion failures; the helpers below never fail the
+# script themselves.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$HERE/../validate-changed"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+pass=0
+fail=0
+ok() { pass=$((pass + 1)); }
+ko() { fail=$((fail + 1)); echo "FAIL: $*"; }
+
+# --- assertion helpers -------------------------------------------------------
+# $OUT holds the last run's stdout; $RC its exit status.
+OUT=""
+RC=0
+run() { # args... -> OUT/RC from the script run inside the scratch repo
+  RC=0
+  OUT="$(cd "$REPO" && bash "$SCRIPT" "$@" 2>&1)" || RC=$?
+}
+has_lane() { # id -> the plan lists lane id
+  printf '%s\n' "$OUT" | grep -Eq "^  lane: $1( |\$)"
+}
+assert_lane() { # case id
+  if has_lane "$2"; then ok; else ko "$1: expected lane '$2' in:"$'\n'"$OUT"; fi
+}
+assert_no_lane() { # case id-or-prefix-regex
+  if printf '%s\n' "$OUT" | grep -Eq "^  lane: $2"; then ko "$1: unexpected lane matching '$2' in:"$'\n'"$OUT"; else ok; fi
+}
+assert_line() { # case fixed-string
+  if printf '%s\n' "$OUT" | grep -qF -- "$2"; then ok; else ko "$1: expected line '$2' in:"$'\n'"$OUT"; fi
+}
+assert_no_line() { # case fixed-string
+  if printf '%s\n' "$OUT" | grep -qF -- "$2"; then ko "$1: unexpected line '$2' in:"$'\n'"$OUT"; else ok; fi
+}
+assert_rc() { # case expected
+  if [ "$RC" -eq "$2" ]; then ok; else ko "$1: expected exit $2, got $RC:"$'\n'"$OUT"; fi
+}
+# Only the always-on lanes: exactly two `lane:` lines, both always:*.
+assert_only_always() { # case
+  local n
+  n="$(printf '%s\n' "$OUT" | grep -c '^  lane: ' || true)"
+  if [ "$n" -eq 2 ] && has_lane always:preflight && has_lane always:gate-selftest; then ok; else ko "$1: expected only the two always-on lanes, got:"$'\n'"$OUT"; fi
+}
+
+# --- scratch repo --------------------------------------------------------------
+REPO="$TMP/repo"
+mkdir -p "$REPO"
+git -C "$REPO" init -q
+git -C "$REPO" symbolic-ref HEAD refs/heads/main
+git -C "$REPO" config user.email t@example.com
+git -C "$REPO" config user.name t
+git -C "$REPO" config commit.gpgsign false
+
+mkfile() { # path [content] -> writes a file, creating parents
+  mkdir -p "$(dirname "$REPO/$1")"
+  printf '%s\n' "${2:-x}" >"$REPO/$1"
+}
+mkexec() { # path content -> executable file
+  mkfile "$1" "$2"
+  chmod +x "$REPO/$1"
+}
+
+# Fixture tree: one skill with tests, one without, the name-keyed skills
+# (orch runner, review-gate, deep-research node), hooks, cli, tools, one pi
+# extension with a CI suite and one without, docs, workflows. The always-on
+# checks and every suite are stubs that exit 0 so the runner cases can pass.
+mkexec skills/withtests/tests/a.test.sh '#!/usr/bin/env bash
+exit 0'
+mkfile skills/withtests/SKILL.md 'report via vstack report'
+mkfile skills/notests/SKILL.md 'report via vstack report'
+mkfile skills/notests/scripts/lib/helper.sh 'x'
+mkexec skills/orch/tests/run-all.sh '#!/usr/bin/env bash
+exit 0'
+mkexec skills/orch/tests/a.sh '#!/usr/bin/env bash
+exit 0'
+mkfile skills/orch/scripts/thing 'x'
+chmod +x "$REPO/skills/orch/scripts/thing"
+mkexec skills/review-gate/tests/a.sh '#!/usr/bin/env bash
+exit 0'
+mkexec skills/review-gate/scripts/review-predicate-selftest.sh '#!/usr/bin/env bash
+echo selftest-stub
+exit 0'
+mkexec skills/preflight/scripts/preflight '#!/usr/bin/env bash
+echo "preflight-stub $*"
+exit 0'
+mkexec skills/preflight/tests/a.test.sh '#!/usr/bin/env bash
+exit 0'
+mkexec skills/linear/tests/a.test.sh '#!/usr/bin/env bash
+exit 0'
+mkfile skills/deep-research/tests/deep-research.test.mjs '// stub'
+mkfile skills/deep-research/SKILL.md 'report via vstack report'
+mkexec hooks/tests/h.test.sh '#!/usr/bin/env bash
+exit 0'
+mkfile hooks/some-hook.sh 'x'
+mkfile cli/Cargo.toml '[package]'
+mkfile cli/src/main.rs 'fn main() {}'
+mkexec cli/scripts/integration-check.sh '#!/usr/bin/env bash
+exit 0'
+mkexec tools/tests/t.test.sh '#!/usr/bin/env bash
+exit 0'
+mkexec tools/validate-changed '#!/usr/bin/env bash
+# placeholder for the tool itself'
+mkfile pi-extensions/pi-qol/index.ts 'x'
+mkfile pi-extensions/pi-output-policy/index.ts 'x'
+mkfile pi-extensions/pi-agents-tmux/index.ts 'x'
+mkfile pi-extensions/pi-codex-minimal-tools/index.ts 'x'
+mkfile pi-extensions/pi-questions/index.ts 'x'
+mkfile pi-extensions/pi-claude-bridge/index.ts 'x'
+mkfile pi-extensions/pi-nosuite/index.ts 'x'
+mkfile pi-extensions/package-policy.test.mjs 'x'
+mkfile docs/guide.md 'x'
+mkfile agents/rust.md 'x'
+mkfile README.md 'x'
+mkfile CHANGELOG.md 'x'
+mkfile AGENTS.md 'x'
+mkfile vstack.settings.toml.example '[env]'
+mkfile vstack.settings.toml '[env]'
+mkfile .github/workflows/skill-tests.yml 'name: x'
+mkfile .github/workflows/other.yml 'name: y'
+mkfile .github/instructions/x.md 'x'
+git -C "$REPO" add -A
+git -C "$REPO" commit -qm base
+
+touch_path() { printf 'changed\n' >>"$REPO/$1"; }
+reset_tree() {
+  git -C "$REPO" reset -q --hard
+  git -C "$REPO" clean -fdq
+  git -C "$REPO" checkout -q main
+}
+
+# --- 0. clean tree: nothing changed -> only the always-on lanes -----------
+run --dry-run
+assert_rc "clean tree" 0
+assert_only_always "clean tree"
+assert_line "clean tree" "0 changed path(s)"
+assert_no_line "clean tree" "all lanes:"
+
+# --- 1. CONTROL: docs-only change derives NO suite lane -----------------
+touch_path docs/guide.md
+touch_path README.md
+touch_path CHANGELOG.md
+touch_path AGENTS.md
+touch_path agents/rust.md
+touch_path .github/instructions/x.md
+mkfile docs/new-untracked.md 'new'
+run --dry-run
+assert_rc "docs-only" 0
+assert_only_always "docs-only"
+assert_line "docs-only" "no suite lane: docs/guide.md"
+assert_line "docs-only" "no suite lane: docs/new-untracked.md"
+assert_line "docs-only" "no suite lane: agents/rust.md"
+assert_line "docs-only" "no suite lane: .github/instructions/x.md"
+assert_no_line "docs-only" "all lanes:"
+assert_line "docs-only" "7 changed path(s)"
+reset_tree
+
+# --- 2. skills/<name>/** with tests -----------------------------------------
+touch_path skills/withtests/SKILL.md
+run --dry-run
+assert_lane "skill with tests" "skill:withtests"
+assert_line "skill with tests" "bash skills/withtests/tests/*.sh (1 file(s))"
+assert_lane "skill with tests" "lint:shell"
+assert_no_lane "skill with tests" "hooks"
+assert_no_lane "skill with tests" "cli:"
+assert_no_lane "skill with tests" "pi:"
+assert_no_lane "skill with tests" "tools"
+assert_no_line "skill with tests" "no suite lane:"
+reset_tree
+
+# --- 3. skills/<name>/** without tests -> no suite lane -----------------------
+touch_path skills/notests/SKILL.md
+run --dry-run
+assert_no_lane "skill without tests" "skill:"
+assert_lane "skill without tests" "lint:shell"
+assert_line "skill without tests" "no suite lane: skills/notests/SKILL.md (skills/notests has no tests)"
+reset_tree
+
+# A new, untracked test file makes the skill testable — the derivation reads
+# the working tree, not just the index.
+mkexec skills/notests/tests/new.test.sh '#!/usr/bin/env bash
+exit 0'
+run --dry-run
+assert_lane "untracked new test file" "skill:notests"
+reset_tree
+
+# --- 4. orch -> its runner, never the bare glob --------------------------------
+touch_path skills/orch/scripts/thing
+run --dry-run
+assert_lane "orch" "skill:orch"
+assert_line "orch" "bash skills/orch/tests/run-all.sh"
+assert_no_line "orch" "bash skills/orch/tests/*.sh"
+reset_tree
+
+# --- 5. review-gate -> its tests/*.sh -----------------------------------------
+touch_path skills/review-gate/tests/a.sh
+run --dry-run
+assert_lane "review-gate" "skill:review-gate"
+assert_line "review-gate" "bash skills/review-gate/tests/*.sh (1 file(s))"
+reset_tree
+
+# --- 6. deep-research -> node suite -------------------------------------------
+touch_path skills/deep-research/SKILL.md
+run --dry-run
+assert_lane "deep-research" "node:deep-research"
+assert_line "deep-research" "node --test skills/deep-research/tests/deep-research.test.mjs"
+assert_no_lane "deep-research" "skill:deep-research"
+reset_tree
+
+# --- 7. hooks/** ---------------------------------------------------------------
+touch_path hooks/some-hook.sh
+run --dry-run
+assert_lane "hooks" "hooks"
+assert_line "hooks" "bash hooks/tests/*.sh"
+assert_lane "hooks" "lint:shell"
+assert_no_lane "hooks" "skill:"
+reset_tree
+
+# --- 8. cli/** -> cargo test only (integration check is --all only) ------------
+touch_path cli/src/main.rs
+run --dry-run
+assert_lane "cli" "cli:cargo-test"
+assert_line "cli" "cargo test --manifest-path cli/Cargo.toml"
+assert_no_lane "cli" "cli:integration-check"
+assert_no_lane "cli" "lint:shell"
+reset_tree
+
+# --- 9. pi-extensions/<name>/** ------------------------------------------------
+touch_path pi-extensions/pi-qol/index.ts
+touch_path pi-extensions/pi-nosuite/index.ts
+touch_path pi-extensions/package-policy.test.mjs
+run --dry-run
+assert_lane "pi-qol" "pi:pi-qol"
+assert_line "pi-qol" "[pi-extensions/pi-qol]"
+assert_no_lane "pi-qol" "pi:pi-output-policy"
+assert_line "pi no suite" "no suite lane: pi-extensions/pi-nosuite/index.ts (CI runs no suite for pi-extensions/pi-nosuite)"
+assert_line "pi top-level file" "no suite lane: pi-extensions/package-policy.test.mjs"
+reset_tree
+
+for ext in pi-output-policy pi-agents-tmux pi-codex-minimal-tools pi-questions pi-claude-bridge; do
+  touch_path "pi-extensions/$ext/index.ts"
+done
+run --dry-run
+for ext in pi-output-policy pi-agents-tmux pi-codex-minimal-tools pi-questions pi-claude-bridge; do
+  assert_lane "pi $ext" "pi:$ext"
+done
+assert_no_lane "pi five" "pi:pi-qol"
+reset_tree
+
+# --- 10. tools/** -> tools tests (not --all) -----------------------------------
+touch_path tools/tests/t.test.sh
+run --dry-run
+assert_lane "tools tests" "tools"
+assert_line "tools tests" "bash tools/tests/*.sh"
+assert_no_line "tools tests" "all lanes:"
+assert_no_lane "tools tests" "cli:"
+reset_tree
+
+# --- 11. vstack.settings.toml.example -> settings-example-sync owners ---------
+touch_path vstack.settings.toml.example
+run --dry-run
+assert_lane "root template" "skill:orch"
+assert_lane "root template" "skill:linear"
+assert_lane "root template" "skill:review-gate"
+assert_no_lane "root template" "skill:withtests"
+reset_tree
+
+# --- 12. CONTROL: .github/workflows/** -> every lane -------------------------
+touch_path .github/workflows/skill-tests.yml
+run --dry-run
+assert_rc "workflow change" 0
+assert_line "workflow change" "all lanes: .github/workflows/skill-tests.yml changed"
+for id in always:preflight always:gate-selftest lint:shell skill:withtests skill:orch skill:review-gate node:deep-research skill:preflight skill:linear hooks tools cli:cargo-test cli:integration-check pi:pi-qol pi:pi-output-policy pi:pi-agents-tmux pi:pi-codex-minimal-tools pi:pi-questions pi:pi-claude-bridge; do
+  assert_lane "workflow change" "$id"
+done
+assert_no_lane "workflow change" "skill:notests"
+assert_no_line "workflow change" "no suite lane:"
+reset_tree
+
+touch_path .github/workflows/other.yml
+run --dry-run
+assert_line "other workflow" "all lanes: .github/workflows/other.yml changed"
+reset_tree
+
+# --- 13. tools/validate-changed itself -> every lane -------------------------
+touch_path tools/validate-changed
+run --dry-run
+assert_line "tool itself" "all lanes: tools/validate-changed changed"
+assert_lane "tool itself" "cli:integration-check"
+reset_tree
+
+# --- 14. --all on a clean tree -------------------------------------------------
+run --dry-run --all
+assert_rc "--all" 0
+assert_line "--all" "all lanes: --all"
+assert_lane "--all" "cli:integration-check"
+assert_lane "--all" "pi:pi-claude-bridge"
+assert_lane "--all" "skill:withtests"
+
+# --- 15. base resolution: committed on a branch + uncommitted + --base --------
+git -C "$REPO" checkout -q -b feature
+touch_path skills/withtests/SKILL.md
+git -C "$REPO" commit -qam "feat: skill change"
+run --dry-run
+assert_lane "committed on branch" "skill:withtests"
+assert_line "committed on branch" "merge base of HEAD and main"
+touch_path hooks/some-hook.sh
+run --dry-run
+assert_lane "committed + uncommitted" "skill:withtests"
+assert_lane "committed + uncommitted" "hooks"
+# --base HEAD scopes to the uncommitted change only.
+run --dry-run --base HEAD
+assert_lane "--base HEAD" "hooks"
+assert_no_lane "--base HEAD" "skill:withtests"
+assert_line "--base HEAD" "preflight --base HEAD"
+run --dry-run --base does-not-exist
+assert_rc "--base unresolvable" 2
+assert_line "--base unresolvable" "does not resolve"
+run --dry-run --bogus
+assert_rc "unknown flag" 2
+reset_tree
+git -C "$REPO" branch -q -D feature
+
+# origin/main wins over main when it exists.
+git -C "$REPO" update-ref refs/remotes/origin/main main
+run --dry-run
+assert_line "origin/main preferred" "merge base of HEAD and origin/main"
+git -C "$REPO" update-ref -d refs/remotes/origin/main
+
+# --- 16. runner: every lane runs, passes -> exit 0 -----------------------------
+touch_path skills/withtests/SKILL.md
+run
+assert_rc "runner pass" 0
+assert_line "runner pass" "===== lane: always:preflight"
+assert_line "runner pass" "preflight-stub --base main"
+assert_line "runner pass" "selftest-stub"
+assert_line "runner pass" "=== skills/withtests/tests/a.test.sh"
+assert_line "runner pass" "all 4 lane(s) passed"
+assert_no_line "runner pass" "FAILED"
+reset_tree
+
+# --- 17. runner: a failing suite is named twice, later lanes still run ---------
+touch_path skills/withtests/SKILL.md
+touch_path hooks/some-hook.sh
+printf '#!/usr/bin/env bash\nexit 1\n' >"$REPO/skills/withtests/tests/a.test.sh"
+run
+assert_rc "runner fail" 1
+assert_line "runner fail" "FAILED: skills/withtests/tests/a.test.sh"
+assert_line "runner fail" "FAILED LANE: skill:withtests"
+assert_line "runner fail" "FAILED LANES: skill:withtests"
+assert_line "runner fail" "===== lane: hooks"
+assert_no_line "runner fail" "lane(s) passed"
+reset_tree
+
+# --- 18. runner: a missing suite path fails closed ---------------------------
+touch_path skills/orch/scripts/thing
+rm "$REPO/skills/orch/tests/run-all.sh"
+run
+assert_rc "missing runner" 1
+assert_line "missing runner" "FAILED: missing or not executable: skills/orch/tests/run-all.sh"
+assert_line "missing runner" "FAILED LANES: skill:orch"
+reset_tree
+
+touch_path hooks/some-hook.sh
+rm "$REPO/hooks/tests/h.test.sh"
+run
+assert_rc "missing hook suite" 1
+assert_line "missing hook suite" "no suite files matched"
+assert_line "missing hook suite" "FAILED LANES: hooks"
+reset_tree
+
+# A missing always-on check is a failure too, never a skip.
+rm "$REPO/skills/review-gate/scripts/review-predicate-selftest.sh"
+run
+assert_rc "missing selftest" 1
+assert_line "missing selftest" "FAILED LANES: always:gate-selftest"
+reset_tree
+
+# --- 19. runner: the shell lints run (exec bit + vstack report) --------------
+touch_path skills/withtests/SKILL.md
+chmod -x "$REPO/skills/withtests/tests/a.test.sh"
+git -C "$REPO" update-index --chmod=-x skills/withtests/tests/a.test.sh
+run
+assert_rc "exec-bit lint" 1
+assert_line "exec-bit lint" "not executable in git: skills/withtests/tests/a.test.sh"
+assert_line "exec-bit lint" "FAILED LANE: lint:shell"
+reset_tree
+
+printf 'no routing here\n' >"$REPO/skills/withtests/SKILL.md"
+run
+assert_rc "vstack report lint" 1
+assert_line "vstack report lint" "missing \`vstack report\` guidance: skills/withtests/SKILL.md"
+reset_tree
+
+# --- 20. --help ------------------------------------------------------------------
+run --help
+assert_rc "--help" 0
+assert_line "--help" "usage: tools/validate-changed"
+
+echo "pass: $pass   fail: $fail"
+[ "$fail" -eq 0 ]

--- a/tools/tests/validate-changed.test.sh
+++ b/tools/tests/validate-changed.test.sh
@@ -255,6 +255,7 @@ run --dry-run
 assert_lane "cli" "cli:cargo-test"
 assert_line "cli" "cargo test --manifest-path cli/Cargo.toml"
 assert_lane "cli" "cli:integration-check"
+assert_line "cli" "cli/scripts/integration-check.sh"
 assert_no_lane "cli" "lint:shell"
 reset_tree
 

--- a/tools/validate-changed
+++ b/tools/validate-changed
@@ -286,7 +286,7 @@ for name in "${PI_SUITES[@]}"; do
     pi-agents-tmux) add_lane "pi:pi-agents-tmux" "npm install (pinned pi 0.84.1) && bun test ./tests ./extensions/subagent/__tests__  [pi-extensions/pi-agents-tmux]" ;;
     pi-codex-minimal-tools) add_lane "pi:pi-codex-minimal-tools" "npm install (pinned pi 0.84.1, undici@^7.25.0) && npm test  [pi-extensions/pi-codex-minimal-tools]" ;;
     pi-questions) add_lane "pi:pi-questions" "bun test ./extensions/__tests__  [pi-extensions/pi-questions]" ;;
-    pi-claude-bridge) add_lane "pi:pi-claude-bridge" "npm ci && npm run build && npm run test:unit && git diff --exit-code -- bundle/  [pi-extensions/pi-claude-bridge]" ;;
+    pi-claude-bridge) add_lane "pi:pi-claude-bridge" "npm ci && npm run build && npm run test:unit && bundle/ matches a fresh build  [pi-extensions/pi-claude-bridge]" ;;
   esac
 done
 
@@ -450,11 +450,20 @@ run_lane() { # id -> exit status of the lane
       run_in pi-extensions/pi-questions bun test ./extensions/__tests__
       ;;
     pi:pi-claude-bridge)
+      # The bundle the author is about to commit — the working-tree bytes,
+      # not the index — must equal a fresh build. `git diff -- bundle/` would
+      # compare against the index and reject a legitimately rebuilt, not yet
+      # staged bundle; CI's clean checkout makes the two identical.
       run_in pi-extensions/pi-claude-bridge bash -c '
-        npm ci --no-audit --no-fund &&
-        npm run build &&
-        npm run test:unit &&
-        git diff --exit-code -- bundle/'
+        before="$(mktemp -d)" || exit 1
+        cp -R bundle/. "$before"/ || { rm -rf "$before"; exit 1; }
+        rc=0
+        { npm ci --no-audit --no-fund &&
+          npm run build &&
+          npm run test:unit &&
+          { diff -r "$before" bundle || { echo "bundle/ does not match a fresh build — rebuild and stage it"; false; }; }; } || rc=$?
+        rm -rf "$before"
+        exit "$rc"'
       ;;
     *)
       echo "FAILED: unknown lane id '$id' (derivation/runner desync)"

--- a/tools/validate-changed
+++ b/tools/validate-changed
@@ -352,20 +352,23 @@ lint_files() { # pathspec... -> tracked + untracked matches
 run_lint_shell() {
   local fail=0 f mode
   # executable bits on skill tests and scripts (+ tools). CI reads the index
-  # mode; locally the working-tree bit is checked too, since `git add`
-  # records it (an untracked file has no index mode at all).
+  # mode; locally the working-tree bit decides, since the `git add` that
+  # follows validation records it — a stale 100644 in the index under an
+  # executable file is what that add corrects. The index mode only names
+  # which side dropped the bit; a path gone from the working tree is a
+  # deletion, not a lint subject.
   while IFS= read -r f; do
+    [ -e "$f" ] || continue
+    [ -x "$f" ] && continue
     mode="$(git ls-files -s -- "$f" | cut -d' ' -f1)"
     if [ "$mode" = "100644" ]; then
       echo "not executable in git: $f"
-      fail=1
-    elif [ -z "$mode" ] && [ ! -x "$f" ]; then
+    elif [ -z "$mode" ]; then
       echo "not executable (untracked): $f"
-      fail=1
-    elif [ -e "$f" ] && [ ! -x "$f" ]; then
+    else
       echo "not executable in working tree: $f"
-      fail=1
     fi
+    fail=1
   done < <(lint_files 'skills/*/tests/*.sh' 'skills/*/scripts/*' 'hooks/tests/*.sh' 'tools/tests/*.sh' 'tools/validate-changed' | grep -v '/scripts/lib/' || true)
   # skills point reports at `vstack report`
   while IFS= read -r f; do

--- a/tools/validate-changed
+++ b/tools/validate-changed
@@ -20,7 +20,7 @@
 #   hooks/**                bash hooks/tests/*.sh
 #   tools/**                bash tools/tests/*.sh
 #   cli/**                  cargo test --manifest-path cli/Cargo.toml
-#                           (cli/scripts/integration-check.sh only under --all)
+#                           (plus cli/scripts/integration-check.sh — AGENTS.md requires it after CLI changes)
 #   pi-extensions/<name>/** that extension's CI suite, install steps included
 #   skills/ hooks/ tools/   the shell shard's lints (executable bits,
 #                           `vstack report` guidance)
@@ -215,6 +215,7 @@ else
         ;;
       cli/*)
         want_cli=1
+        want_cli_integration=1
         ;;
       pi-extensions/*/*)
         name="${path#pi-extensions/}"
@@ -276,7 +277,7 @@ done
 [ "$want_hooks" -eq 1 ] && add_lane "hooks" "bash hooks/tests/*.sh"
 [ "$want_tools" -eq 1 ] && add_lane "tools" "bash tools/tests/*.sh"
 [ "$want_cli" -eq 1 ] && add_lane "cli:cargo-test" "cargo test --manifest-path cli/Cargo.toml"
-[ "$want_cli_integration" -eq 1 ] && add_lane "cli:integration-check" "cli/scripts/integration-check.sh (slow; --all only)"
+[ "$want_cli_integration" -eq 1 ] && add_lane "cli:integration-check" "cli/scripts/integration-check.sh"
 for name in "${PI_SUITES[@]}"; do
   in_list "$name" "${want_pis[@]+"${want_pis[@]}"}" || continue
   case "$name" in

--- a/tools/validate-changed
+++ b/tools/validate-changed
@@ -391,6 +391,8 @@ EOF_EXEC
     || { echo "FAILED: git ls-files failed while listing SKILL.md files for the vstack-report lint"; return 1; }
   while IFS= read -r f; do
     [ -n "$f" ] || continue
+    # An index entry whose file is gone is a pending deletion, not a doc.
+    [ -f "$f" ] || continue
     if ! grep -qF 'vstack report' "$f"; then
       echo "missing \`vstack report\` guidance: $f"
       fail=1

--- a/tools/validate-changed
+++ b/tools/validate-changed
@@ -27,6 +27,8 @@
 #   vstack.settings.toml.example
 #                           the suites whose settings-example-sync tests read
 #                           the root template (orch, linear, review-gate)
+#   vstack.toml             cli/scripts/integration-check.sh (it installs from
+#                           this repository root)
 #   cross-suite reads — a suite whose tests read another area's files runs
 #   for changes there too (a mapped suite with no tests is a failure):
 #     skills/**, agents/**  skill:orch (repo-wide doc lints over skills/*/
@@ -231,6 +233,11 @@ else
           want_skill "$name" || NO_LANE+=("$path (skills/$name has no tests)")
         done
         ;;
+      vstack.toml)
+        # The integration check installs from this repository root, so the
+        # source catalog and its mappings are exercised there.
+        want_cli_integration=1
+        ;;
       *)
         NO_LANE+=("$path")
         ;;
@@ -357,7 +364,14 @@ run_lint_shell() {
   # executable file is what that add corrects. The index mode only names
   # which side dropped the bit; a path gone from the working tree is a
   # deletion, not a lint subject.
+  # Both scans read their file lists first: a `git ls-files` failure is a
+  # lint failure, never an empty list that passes.
+  local exec_list report_list
+  exec_list="$(lint_files 'skills/*/tests/*.sh' 'skills/*/scripts/*' 'hooks/tests/*.sh' 'tools/tests/*.sh' 'tools/validate-changed')" \
+    || { echo "FAILED: git ls-files failed while listing scripts for the exec-bit lint"; return 1; }
+  exec_list="$(printf '%s\n' "$exec_list" | grep -v '/scripts/lib/' || true)"
   while IFS= read -r f; do
+    [ -n "$f" ] || continue
     [ -e "$f" ] || continue
     [ -x "$f" ] && continue
     mode="$(git ls-files -s -- "$f" | cut -d' ' -f1)"
@@ -369,14 +383,21 @@ run_lint_shell() {
       echo "not executable in working tree: $f"
     fi
     fail=1
-  done < <(lint_files 'skills/*/tests/*.sh' 'skills/*/scripts/*' 'hooks/tests/*.sh' 'tools/tests/*.sh' 'tools/validate-changed' | grep -v '/scripts/lib/' || true)
+  done <<EOF_EXEC
+$exec_list
+EOF_EXEC
   # skills point reports at `vstack report`
+  report_list="$(lint_files 'skills/*/SKILL.md')" \
+    || { echo "FAILED: git ls-files failed while listing SKILL.md files for the vstack-report lint"; return 1; }
   while IFS= read -r f; do
+    [ -n "$f" ] || continue
     if ! grep -qF 'vstack report' "$f"; then
       echo "missing \`vstack report\` guidance: $f"
       fail=1
     fi
-  done < <(lint_files 'skills/*/SKILL.md')
+  done <<EOF_REPORT
+$report_list
+EOF_REPORT
   return "$fail"
 }
 

--- a/tools/validate-changed
+++ b/tools/validate-changed
@@ -36,6 +36,9 @@
 #     skills/orch/**        skill:github, skill:reviewer
 #     skills/linear/**      skill:project-management
 #     agents/**             skill:reviewer
+#     pi-extensions/pi-session-bridge/**
+#                           pi:pi-agents-tmux (its suite imports
+#                           child-session-id.ts)
 #   .github/workflows/** or tools/validate-changed
 #                           every lane (--all)
 #   any change              review-predicate selftest + preflight --base REF
@@ -217,6 +220,9 @@ else
         name="${path#pi-extensions/}"
         name="${name%%/*}"
         want_pi "$name" || NO_LANE+=("$path (CI runs no suite for pi-extensions/$name)")
+        case "$name" in
+          pi-session-bridge) want_pi pi-agents-tmux ;;
+        esac
         ;;
       vstack.settings.toml.example)
         # Read by these skills' settings-example-sync tests.
@@ -344,8 +350,9 @@ lint_files() { # pathspec... -> tracked + untracked matches
 
 run_lint_shell() {
   local fail=0 f mode
-  # executable bits on skill tests and scripts (+ tools); an untracked file
-  # has no index mode, and git records its filesystem mode on add
+  # executable bits on skill tests and scripts (+ tools). CI reads the index
+  # mode; locally the working-tree bit is checked too, since `git add`
+  # records it (an untracked file has no index mode at all).
   while IFS= read -r f; do
     mode="$(git ls-files -s -- "$f" | cut -d' ' -f1)"
     if [ "$mode" = "100644" ]; then
@@ -353,6 +360,9 @@ run_lint_shell() {
       fail=1
     elif [ -z "$mode" ] && [ ! -x "$f" ]; then
       echo "not executable (untracked): $f"
+      fail=1
+    elif [ -e "$f" ] && [ ! -x "$f" ]; then
+      echo "not executable in working tree: $f"
       fail=1
     fi
   done < <(lint_files 'skills/*/tests/*.sh' 'skills/*/scripts/*' 'hooks/tests/*.sh' 'tools/tests/*.sh' 'tools/validate-changed' | grep -v '/scripts/lib/' || true)

--- a/tools/validate-changed
+++ b/tools/validate-changed
@@ -27,6 +27,15 @@
 #   vstack.settings.toml.example
 #                           the suites whose settings-example-sync tests read
 #                           the root template (orch, linear, review-gate)
+#   cross-suite reads — a suite whose tests read another area's files runs
+#   for changes there too (a mapped suite with no tests is a failure):
+#     skills/**, agents/**  skill:orch (repo-wide doc lints over skills/*/
+#                           SKILL.md and agents/*.md, dev/github/reviewer/
+#                           project-management doc contracts, cross-skill
+#                           reference integrity)
+#     skills/orch/**        skill:github, skill:reviewer
+#     skills/linear/**      skill:project-management
+#     agents/**             skill:reviewer
 #   .github/workflows/** or tools/validate-changed
 #                           every lane (--all)
 #   any change              review-predicate selftest + preflight --base REF
@@ -83,14 +92,21 @@ BASE="$(git merge-base HEAD "$BASE_REF" 2>/dev/null)" || die "no merge base betw
 # `git diff <merge-base>` (no `..`) covers committed AND uncommitted changes;
 # untracked files come from ls-files. --no-renames lists both ends of a move
 # so the source area is validated too. Sorted and deduplicated.
+RAW_FILE="$(mktemp)"
 CHANGED_FILE="$(mktemp)"
-trap 'rm -f "$CHANGED_FILE"' EXIT
+trap 'rm -f "$RAW_FILE" "$CHANGED_FILE"' EXIT
 {
   git -c core.quotePath=false diff --name-only --no-renames -z "$BASE" -- \
     || die "git diff against $BASE failed"
   git -c core.quotePath=false ls-files --others --exclude-standard -z \
     || die "git ls-files failed"
-} | tr '\0' '\n' | LC_ALL=C sort -u >"$CHANGED_FILE"
+} >"$RAW_FILE"
+# The NUL-delimited stream carries a newline only inside a path; such a path
+# would split into fragments below, so refuse rather than derive from them.
+if [ "$(tr -cd '\n' <"$RAW_FILE" | wc -c)" -gt 0 ]; then
+  die "a changed path contains a newline; lanes cannot be derived from it (see: git status --porcelain=v1 -z)"
+fi
+tr '\0' '\n' <"$RAW_FILE" | LC_ALL=C sort -u >"$CHANGED_FILE"
 
 # --- derivation ------------------------------------------------------------
 # Selection flags and lists first, then the lane list is emitted in a fixed
@@ -134,6 +150,10 @@ want_skill() { # name -> 0 when the skill has a suite, 1 otherwise
   in_list "$1" "${want_skills[@]+"${want_skills[@]}"}" || want_skills+=("$1")
 }
 
+want_suite() { # name -> selects the skill's suite unconditionally (cross-suite reads)
+  in_list "$1" "${want_skills[@]+"${want_skills[@]}"}" || want_skills+=("$1")
+}
+
 want_pi() { # name -> 0 when CI runs a suite for it, 1 otherwise
   in_list "$1" "${PI_SUITES[@]}" || return 1
   in_list "$1" "${want_pis[@]+"${want_pis[@]}"}" || want_pis+=("$1")
@@ -172,6 +192,15 @@ else
         name="${path#skills/}"
         name="${name%%/*}"
         want_skill "$name" || NO_LANE+=("$path (skills/$name has no tests)")
+        want_suite orch
+        case "$name" in
+          orch) want_suite github; want_suite reviewer ;;
+          linear) want_suite project-management ;;
+        esac
+        ;;
+      agents/*)
+        want_suite orch
+        want_suite reviewer
         ;;
       hooks/*)
         want_lint=1
@@ -307,23 +336,33 @@ run_file() { # path args... -> the path must exist and be executable
   "$f" "$@"
 }
 
+# Tracked AND untracked (non-ignored) files, since the change set includes
+# untracked paths and CI will see them once committed.
+lint_files() { # pathspec... -> tracked + untracked matches
+  git ls-files --cached --others --exclude-standard -- "$@"
+}
+
 run_lint_shell() {
   local fail=0 f mode
-  # executable bits on skill tests and scripts (+ tools)
+  # executable bits on skill tests and scripts (+ tools); an untracked file
+  # has no index mode, and git records its filesystem mode on add
   while IFS= read -r f; do
     mode="$(git ls-files -s -- "$f" | cut -d' ' -f1)"
     if [ "$mode" = "100644" ]; then
       echo "not executable in git: $f"
       fail=1
+    elif [ -z "$mode" ] && [ ! -x "$f" ]; then
+      echo "not executable (untracked): $f"
+      fail=1
     fi
-  done < <(git ls-files -- 'skills/*/tests/*.sh' 'skills/*/scripts/*' 'hooks/tests/*.sh' 'tools/tests/*.sh' 'tools/validate-changed' | grep -v '/scripts/lib/' || true)
+  done < <(lint_files 'skills/*/tests/*.sh' 'skills/*/scripts/*' 'hooks/tests/*.sh' 'tools/tests/*.sh' 'tools/validate-changed' | grep -v '/scripts/lib/' || true)
   # skills point reports at `vstack report`
   while IFS= read -r f; do
     if ! grep -qF 'vstack report' "$f"; then
       echo "missing \`vstack report\` guidance: $f"
       fail=1
     fi
-  done < <(git ls-files -- 'skills/*/SKILL.md')
+  done < <(lint_files 'skills/*/SKILL.md')
   return "$fail"
 }
 

--- a/tools/validate-changed
+++ b/tools/validate-changed
@@ -1,0 +1,428 @@
+#!/usr/bin/env bash
+# tools/validate-changed — diff-scoped local validation that mirrors CI.
+#
+# Derives the suites to run from the changed paths (commits since the merge
+# base, plus uncommitted and untracked files), prints the derived lane list,
+# then runs the lanes exactly as .github/workflows/skill-tests.yml runs them.
+# That workflow is the source of truth: every lane here is a step there, and
+# a path CI does not test maps to no suite lane beyond the always-on checks.
+#
+# usage: tools/validate-changed [--base REF] [--all] [--dry-run] [--help]
+#
+#   --base REF   diff against the merge base of HEAD and REF
+#                (default: origin/main, falling back to main)
+#   --all        run every lane, including the slow CLI integration check
+#   --dry-run    print the derived lane list and exit
+#
+# Lane derivation (changed path -> lane):
+#   skills/<name>/**        bash skills/<name>/tests/*.sh (skills with tests;
+#                           orch: tests/run-all.sh; deep-research: node --test)
+#   hooks/**                bash hooks/tests/*.sh
+#   tools/**                bash tools/tests/*.sh
+#   cli/**                  cargo test --manifest-path cli/Cargo.toml
+#                           (cli/scripts/integration-check.sh only under --all)
+#   pi-extensions/<name>/** that extension's CI suite, install steps included
+#   skills/ hooks/ tools/   the shell shard's lints (executable bits,
+#                           `vstack report` guidance)
+#   vstack.settings.toml.example
+#                           the suites whose settings-example-sync tests read
+#                           the root template (orch, linear, review-gate)
+#   .github/workflows/** or tools/validate-changed
+#                           every lane (--all)
+#   any change              review-predicate selftest + preflight --base REF
+#
+# Every selected lane runs even after a failure; failures are announced
+# inline and again in a FAILED LANES block at the end (CI's convention), and
+# the exit status is non-zero. A selected lane whose suite path is missing is
+# a failure, never a skip.
+set -euo pipefail
+
+usage() {
+  awk 'NR > 1 { if ($0 !~ /^#/) exit; sub(/^# ?/, ""); print }' "$0"
+}
+
+die() {
+  printf 'validate-changed: %s\n' "$*" >&2
+  exit 2
+}
+
+BASE_REF=""
+ALL=0
+DRY_RUN=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --base) [ $# -ge 2 ] || die "--base requires a ref"; shift; BASE_REF="$1" ;;
+    --base=*) BASE_REF="${1#--base=}" ;;
+    --all) ALL=1 ;;
+    --dry-run) DRY_RUN=1 ;;
+    -h | --help) usage; exit 0 ;;
+    *) die "unknown argument '$1' (see --help)" ;;
+  esac
+  shift
+done
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || die "not inside a git repository"
+cd "$REPO_ROOT"
+git rev-parse --verify --quiet HEAD >/dev/null || die "the repository has no commits yet"
+
+# --- base ------------------------------------------------------------------
+if [ -n "$BASE_REF" ]; then
+  git rev-parse --verify --quiet "$BASE_REF^{commit}" >/dev/null || die "--base ref does not resolve to a commit: $BASE_REF"
+else
+  for cand in origin/main main; do
+    if git rev-parse --verify --quiet "$cand^{commit}" >/dev/null; then
+      BASE_REF="$cand"
+      break
+    fi
+  done
+  [ -n "$BASE_REF" ] || die "neither origin/main nor main resolves — pass --base REF"
+fi
+BASE="$(git merge-base HEAD "$BASE_REF" 2>/dev/null)" || die "no merge base between HEAD and $BASE_REF"
+
+# --- change set ------------------------------------------------------------
+# `git diff <merge-base>` (no `..`) covers committed AND uncommitted changes;
+# untracked files come from ls-files. --no-renames lists both ends of a move
+# so the source area is validated too. Sorted and deduplicated.
+CHANGED_FILE="$(mktemp)"
+trap 'rm -f "$CHANGED_FILE"' EXIT
+{
+  git -c core.quotePath=false diff --name-only --no-renames -z "$BASE" -- \
+    || die "git diff against $BASE failed"
+  git -c core.quotePath=false ls-files --others --exclude-standard -z \
+    || die "git ls-files failed"
+} | tr '\0' '\n' | LC_ALL=C sort -u >"$CHANGED_FILE"
+
+# --- derivation ------------------------------------------------------------
+# Selection flags and lists first, then the lane list is emitted in a fixed
+# order (always-on, lints, skills, hooks, tools, cli, pi) so the printed plan
+# does not depend on path sort order. Indexed (not associative) arrays keep
+# this runnable on bash 3.2.
+LINT_SHELL_DESC="executable bits + \`vstack report\` guidance (shell shard lints)"
+PI_SUITES=(pi-qol pi-output-policy pi-agents-tmux pi-codex-minimal-tools pi-questions pi-claude-bridge)
+
+want_lint=0
+want_hooks=0
+want_tools=0
+want_cli=0
+want_cli_integration=0
+want_skills=()   # skill names (deduplicated below)
+want_pis=()      # pi extension names with a CI suite
+NO_LANE=()
+
+in_list() { # needle list...
+  local x needle="$1"
+  shift
+  for x in "$@"; do
+    [ "$x" = "$needle" ] && return 0
+  done
+  return 1
+}
+
+# A skill has a suite when it is orch (its runner), deep-research (node), or
+# owns tests/*.sh files — the same shapes the shards run.
+skill_has_suite() { # name
+  local f
+  case "$1" in orch | deep-research) return 0 ;; esac
+  for f in "skills/$1/tests/"*.sh; do
+    [ -e "$f" ] && return 0
+  done
+  return 1
+}
+
+want_skill() { # name -> 0 when the skill has a suite, 1 otherwise
+  skill_has_suite "$1" || return 1
+  in_list "$1" "${want_skills[@]+"${want_skills[@]}"}" || want_skills+=("$1")
+}
+
+want_pi() { # name -> 0 when CI runs a suite for it, 1 otherwise
+  in_list "$1" "${PI_SUITES[@]}" || return 1
+  in_list "$1" "${want_pis[@]+"${want_pis[@]}"}" || want_pis+=("$1")
+}
+
+ALL_REASON=""
+if [ "$ALL" -eq 1 ]; then
+  ALL_REASON="--all"
+else
+  while IFS= read -r path; do
+    case "$path" in
+      .github/workflows/* | tools/validate-changed) ALL_REASON="$path changed"; break ;;
+    esac
+  done <"$CHANGED_FILE"
+fi
+
+if [ -n "$ALL_REASON" ]; then
+  want_lint=1
+  want_hooks=1
+  want_tools=1
+  want_cli=1
+  want_cli_integration=1
+  for d in skills/*/; do
+    [ -d "$d" ] || continue
+    name="${d#skills/}"
+    want_skill "${name%/}" || true
+  done
+  for name in "${PI_SUITES[@]}"; do
+    want_pi "$name"
+  done
+else
+  while IFS= read -r path; do
+    case "$path" in
+      skills/*/*)
+        want_lint=1
+        name="${path#skills/}"
+        name="${name%%/*}"
+        want_skill "$name" || NO_LANE+=("$path (skills/$name has no tests)")
+        ;;
+      hooks/*)
+        want_lint=1
+        want_hooks=1
+        ;;
+      tools/*)
+        want_lint=1
+        want_tools=1
+        ;;
+      cli/*)
+        want_cli=1
+        ;;
+      pi-extensions/*/*)
+        name="${path#pi-extensions/}"
+        name="${name%%/*}"
+        want_pi "$name" || NO_LANE+=("$path (CI runs no suite for pi-extensions/$name)")
+        ;;
+      vstack.settings.toml.example)
+        # Read by these skills' settings-example-sync tests.
+        for name in orch linear review-gate; do
+          want_skill "$name" || NO_LANE+=("$path (skills/$name has no tests)")
+        done
+        ;;
+      *)
+        NO_LANE+=("$path")
+        ;;
+    esac
+  done <"$CHANGED_FILE"
+fi
+
+# --- lane list -------------------------------------------------------------
+# LANE_IDS is the ordered lane list; LANE_DESC[i] its printed command
+# summary. Ids name the workflow step they mirror; run_lane dispatches on id.
+LANE_IDS=()
+LANE_DESC=()
+
+add_lane() { # id desc
+  LANE_IDS+=("$1")
+  LANE_DESC+=("$2")
+}
+
+count_glob() { # glob... -> number of existing matches
+  local f n=0
+  for f in "$@"; do
+    [ -e "$f" ] && n=$((n + 1))
+  done
+  echo "$n"
+}
+
+add_lane "always:preflight" "skills/preflight/scripts/preflight --base $BASE_REF"
+add_lane "always:gate-selftest" "skills/review-gate/scripts/review-predicate-selftest.sh"
+[ "$want_lint" -eq 1 ] && add_lane "lint:shell" "$LINT_SHELL_DESC"
+for name in $(printf '%s\n' "${want_skills[@]+"${want_skills[@]}"}" | LC_ALL=C sort); do
+  case "$name" in
+    orch) add_lane "skill:orch" "bash skills/orch/tests/run-all.sh" ;;
+    deep-research)
+      add_lane "node:deep-research" "node --test skills/deep-research/tests/deep-research.test.mjs"
+      n="$(count_glob "skills/$name/tests/"*.sh)"
+      [ "$n" -gt 0 ] && add_lane "skill:$name" "bash skills/$name/tests/*.sh ($n file(s))"
+      ;;
+    *)
+      n="$(count_glob "skills/$name/tests/"*.sh)"
+      add_lane "skill:$name" "bash skills/$name/tests/*.sh ($n file(s))"
+      ;;
+  esac
+done
+[ "$want_hooks" -eq 1 ] && add_lane "hooks" "bash hooks/tests/*.sh"
+[ "$want_tools" -eq 1 ] && add_lane "tools" "bash tools/tests/*.sh"
+[ "$want_cli" -eq 1 ] && add_lane "cli:cargo-test" "cargo test --manifest-path cli/Cargo.toml"
+[ "$want_cli_integration" -eq 1 ] && add_lane "cli:integration-check" "cli/scripts/integration-check.sh (slow; --all only)"
+for name in "${PI_SUITES[@]}"; do
+  in_list "$name" "${want_pis[@]+"${want_pis[@]}"}" || continue
+  case "$name" in
+    pi-qol) add_lane "pi:pi-qol" "npm install (pinned pi 0.80.5) && bun test ./tests  [pi-extensions/pi-qol]" ;;
+    pi-output-policy) add_lane "pi:pi-output-policy" "bun test ./tests  [pi-extensions/pi-output-policy]" ;;
+    pi-agents-tmux) add_lane "pi:pi-agents-tmux" "npm install (pinned pi 0.84.1) && bun test ./tests ./extensions/subagent/__tests__  [pi-extensions/pi-agents-tmux]" ;;
+    pi-codex-minimal-tools) add_lane "pi:pi-codex-minimal-tools" "npm install (pinned pi 0.84.1, undici@^7.25.0) && npm test  [pi-extensions/pi-codex-minimal-tools]" ;;
+    pi-questions) add_lane "pi:pi-questions" "bun test ./extensions/__tests__  [pi-extensions/pi-questions]" ;;
+    pi-claude-bridge) add_lane "pi:pi-claude-bridge" "npm ci && npm run build && npm run test:unit && git diff --exit-code -- bundle/  [pi-extensions/pi-claude-bridge]" ;;
+  esac
+done
+
+# --- print the plan --------------------------------------------------------
+n_changed="$(grep -c . "$CHANGED_FILE" || true)"
+printf 'validate-changed: base %s (merge base of HEAD and %s), %s changed path(s)\n' \
+  "$(git rev-parse --short "$BASE")" "$BASE_REF" "$n_changed"
+if [ -n "$ALL_REASON" ]; then
+  printf 'all lanes: %s\n' "$ALL_REASON"
+fi
+printf 'lanes:\n'
+i=0
+while [ "$i" -lt "${#LANE_IDS[@]}" ]; do
+  printf '  lane: %-24s %s\n' "${LANE_IDS[$i]}" "${LANE_DESC[$i]}"
+  i=$((i + 1))
+done
+for p in "${NO_LANE[@]+"${NO_LANE[@]}"}"; do
+  printf '  no suite lane: %s\n' "$p"
+done
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  exit 0
+fi
+
+# --- run -------------------------------------------------------------------
+# Each lane runs from the repo root and returns its own status. Suite loops
+# mirror the workflow: every file runs, failures are announced inline.
+run_glob() { # label glob... -> runs `bash` on each match; no match is a failure
+  local label="$1" f fail=0 n=0
+  shift
+  for f in "$@"; do
+    [ -e "$f" ] || continue
+    n=$((n + 1))
+    echo "=== $f"
+    if ! bash "$f"; then
+      echo "FAILED: $f"
+      fail=1
+    fi
+  done
+  if [ "$n" -eq 0 ]; then
+    echo "FAILED: $label — no suite files matched (a missing suite path is a failure, not a skip)"
+    return 1
+  fi
+  return "$fail"
+}
+
+run_file() { # path args... -> the path must exist and be executable
+  local f="$1"
+  shift
+  if [ ! -x "$f" ]; then
+    echo "FAILED: missing or not executable: $f"
+    return 1
+  fi
+  "$f" "$@"
+}
+
+run_lint_shell() {
+  local fail=0 f mode
+  # executable bits on skill tests and scripts (+ tools)
+  while IFS= read -r f; do
+    mode="$(git ls-files -s -- "$f" | cut -d' ' -f1)"
+    if [ "$mode" = "100644" ]; then
+      echo "not executable in git: $f"
+      fail=1
+    fi
+  done < <(git ls-files -- 'skills/*/tests/*.sh' 'skills/*/scripts/*' 'hooks/tests/*.sh' 'tools/tests/*.sh' 'tools/validate-changed' | grep -v '/scripts/lib/' || true)
+  # skills point reports at `vstack report`
+  while IFS= read -r f; do
+    if ! grep -qF 'vstack report' "$f"; then
+      echo "missing \`vstack report\` guidance: $f"
+      fail=1
+    fi
+  done < <(git ls-files -- 'skills/*/SKILL.md')
+  return "$fail"
+}
+
+run_in() { # dir cmd... -> run a command in a subdirectory (CI's working-directory)
+  local dir="$1"
+  shift
+  if [ ! -d "$dir" ]; then
+    echo "FAILED: missing directory: $dir"
+    return 1
+  fi
+  (cd "$dir" && "$@")
+}
+
+run_lane() { # id -> exit status of the lane
+  local id="$1" name
+  case "$id" in
+    always:preflight)
+      run_file skills/preflight/scripts/preflight --base "$BASE_REF"
+      ;;
+    always:gate-selftest)
+      run_file skills/review-gate/scripts/review-predicate-selftest.sh
+      ;;
+    lint:shell)
+      run_lint_shell
+      ;;
+    skill:orch)
+      run_file skills/orch/tests/run-all.sh
+      ;;
+    node:deep-research)
+      if [ ! -e skills/deep-research/tests/deep-research.test.mjs ]; then
+        echo "FAILED: missing suite path: skills/deep-research/tests/deep-research.test.mjs"
+        return 1
+      fi
+      node --test skills/deep-research/tests/deep-research.test.mjs
+      ;;
+    skill:*)
+      name="${id#skill:}"
+      run_glob "$id" "skills/$name/tests/"*.sh
+      ;;
+    hooks)
+      run_glob "$id" hooks/tests/*.sh
+      ;;
+    tools)
+      run_glob "$id" tools/tests/*.sh
+      ;;
+    cli:cargo-test)
+      cargo test --manifest-path cli/Cargo.toml
+      ;;
+    cli:integration-check)
+      run_file cli/scripts/integration-check.sh
+      ;;
+    pi:pi-qol)
+      run_in pi-extensions/pi-qol bash -c '
+        npm install --no-save --no-package-lock --ignore-scripts --no-audit --no-fund @earendil-works/pi-agent-core@0.80.5 @earendil-works/pi-ai@0.80.5 @earendil-works/pi-coding-agent@0.80.5 @earendil-works/pi-tui@0.80.5 &&
+        bun test ./tests'
+      ;;
+    pi:pi-output-policy)
+      run_in pi-extensions/pi-output-policy bun test ./tests
+      ;;
+    pi:pi-agents-tmux)
+      run_in pi-extensions/pi-agents-tmux bash -c '
+        npm install --no-save --no-package-lock --ignore-scripts --no-audit --no-fund @earendil-works/pi-agent-core@0.84.1 @earendil-works/pi-ai@0.84.1 @earendil-works/pi-coding-agent@0.84.1 @earendil-works/pi-tui@0.84.1 typebox &&
+        bun test ./tests ./extensions/subagent/__tests__'
+      ;;
+    pi:pi-codex-minimal-tools)
+      run_in pi-extensions/pi-codex-minimal-tools bash -c '
+        npm install --no-save --no-package-lock --ignore-scripts --no-audit --no-fund @earendil-works/pi-ai@0.84.1 @earendil-works/pi-coding-agent@0.84.1 @earendil-works/pi-tui@0.84.1 typebox "undici@^7.25.0" &&
+        npm test'
+      ;;
+    pi:pi-questions)
+      run_in pi-extensions/pi-questions bun test ./extensions/__tests__
+      ;;
+    pi:pi-claude-bridge)
+      run_in pi-extensions/pi-claude-bridge bash -c '
+        npm ci --no-audit --no-fund &&
+        npm run build &&
+        npm run test:unit &&
+        git diff --exit-code -- bundle/'
+      ;;
+    *)
+      echo "FAILED: unknown lane id '$id' (derivation/runner desync)"
+      return 1
+      ;;
+  esac
+}
+
+failed=""
+for id in "${LANE_IDS[@]}"; do
+  echo
+  echo "===== lane: $id"
+  if ! run_lane "$id"; then
+    echo "FAILED LANE: $id"
+    failed="$failed $id"
+  fi
+done
+
+echo
+if [ -n "$failed" ]; then
+  echo "FAILED LANES:$failed"
+  exit 1
+fi
+echo "validate-changed: all ${#LANE_IDS[@]} lane(s) passed"

--- a/vstack.settings.toml
+++ b/vstack.settings.toml
@@ -7,6 +7,9 @@ BOT_NAME = ""
 BOT_REMOTE_NAME = ""
 CI_FIX_MAX_CYCLES = "6"
 DECISIONS_DIR = "docs/decisions"
+# Diff-scoped local validation mirroring skill-tests.yml's lanes; the merge
+# queue runs the full suite once on the merged result.
+DEV_VALIDATE_CMD = "tools/validate-changed"
 GH_BOT_USERNAME = ""
 GH_ISSUE_PATTERN = "vst-[0-9]+"
 GH_VERIFY_CMD = ""

--- a/vstack.settings.toml.example
+++ b/vstack.settings.toml.example
@@ -165,6 +165,15 @@ BOT_EMAIL = "you+bot@example.com"
 BOT_REMOTE_NAME = "bot-remote"
 # Used by: worktree.
 
+# DEV
+
+DEV_VALIDATE_CMD = ""
+# Used by: dev (`dev-implement` § 5, `dev-fix` § 3). The project's validation
+# command, run from the worktree root after the deterministic gates — point it
+# at a diff-scoped validator where one exists (vstack itself uses
+# "tools/validate-changed") so a one-skill diff does not mirror the whole CI
+# suite. Empty = the project's documented build/test/lint command.
+
 # DECIDER
 
 DECISIONS_DIR = "docs/decisions"


### PR DESCRIPTION
## Summary

VST-237: no repo-owned command answered "what do I run to validate this diff?", so dev agents mirrored the full ~15-min CI suite for a one-skill change.

- `tools/validate-changed` — derives suite lanes from `git diff <merge-base>` plus untracked files, prints the derived lane list first, then runs each lane exactly as `.github/workflows/skill-tests.yml` runs it (per-skill suites incl. orch `run-all.sh` and deep-research's node suite; hooks; tools; `cargo test`; each pi-extension's CI suite; the shell shard's lints; the always-on review-predicate selftest + preflight). `--all` for the full sweep (incl. the slow CLI integration check); `--dry-run`; `--base REF`. Every selected lane runs even after a failure; `FAILED LANES:` block at the end; a missing suite path is a failure, never a skip; a workflow or self change forces `--all`.
- `tools/tests/validate-changed.test.sh` — 129 assertions over a scratch repo covering every path→lane row (docs-only → no suite lane; workflows → all), base resolution, and fail-closed running; wired into the shell shard; exec-bit guard extended to `tools/`.
- `DEV_VALIDATE_CMD` (dev skill, `vstack.settings.toml [env]`, read via `orch-env`) names the project's validation command in dev-implement § 5 / dev-fix § 3; vstack sets it to `tools/validate-changed`. `AGENTS.md` states the local half of the fast/full split.

## Verification

- Test 129/0; must-fail controls: a stub printing only always-on lanes fails 94 assertions, a silent stub fails 100, three targeted mutations each caught.
- shellcheck / bash -n / actionlint clean; preflight clean; dev tests, orch prose lints, settings-example-sync suites pass.
- Real diff-scoped run in a scratch clone: 5 lanes in 16.5 s; a broken suite yields the FAILED LANES block, exit 1.

Fixes VST-237
