### PR TITLE
fix(cli): VST-252 — preserve and repair vstack.toml trailing newline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,12 @@
   `skills/review-gate/references/vendored-paths.md`, the bundle-import note moved to
   the pi-claude-bridge DEVELOPMENT.md); the retired in-repo mailbox path leaves
   .gitignore.
+
+- cli: `vstack add`/`refresh` no longer strip the trailing newline from
+  `vstack.toml` (the `[skill-instructions]`/`[agent-skills]` insert paths
+  did), and every `vstack.toml` writer now repairs a file that already lost
+  it on the first pass that reads it — one write, then stable — instead of
+  pinning the malformed file forever (VST-252).
 - orch: `PR_REVIEW_QUORUM` — approval-wait's multi-bot enqueue gate. When a
   repo lists its reviewer logins, no success emits (either mode) until every
   listed login has a non-dismissed review pinned to the current head AND

--- a/cli/src/project_config.rs
+++ b/cli/src/project_config.rs
@@ -2698,9 +2698,9 @@ fn update_project_config(path: &Path, agents: &[String], skills: &[String]) {
 /// unchanged config is never rewritten (no needless working-tree churn).
 /// The written text always ends in a newline: a file that lost its
 /// terminator is repaired by the first pass that reads it, and every later
-/// pass sees identical content and skips the write. A failed write is
-/// reported, never swallowed — the caller's update would otherwise vanish
-/// behind a successful exit.
+/// pass sees identical content and skips the write. A failed write prints a
+/// warning to stderr; the command still exits successfully, so that warning
+/// is the only signal.
 fn write_if_changed(path: &Path, mut out: String, existing: &str) {
     if !out.is_empty() && !out.ends_with('\n') {
         out.push('\n');

--- a/cli/src/project_config.rs
+++ b/cli/src/project_config.rs
@@ -2689,37 +2689,26 @@ fn update_project_config(path: &Path, agents: &[String], skills: &[String]) {
     out = ensure_value_section_entry_spacing(&out);
     out = ensure_agent_frontmatter_scaffold(&out);
 
-    // Only write if content actually changed to avoid bumping mtime,
-    // which would make staleness checks flag everything as outdated.
+    // Only write if content actually changed — a no-op rewrite would dirty
+    // a consumer's tracked vstack.toml for nothing.
     write_if_changed(path, out, &existing);
 }
 
 /// Write `out` to `path` only when it differs from `existing`, so an
-/// unchanged config never has its mtime bumped (staleness checks key on it).
-/// The written text always ends in a line terminator — `\r\n` when the
-/// content is CRLF throughout, `\n` otherwise — so a file that lost its
+/// unchanged config is never rewritten (no needless working-tree churn).
+/// The written text always ends in a newline: a file that lost its
 /// terminator is repaired by the first pass that reads it, and every later
 /// pass sees identical content and skips the write. A failed write is
 /// reported, never swallowed — the caller's update would otherwise vanish
 /// behind a successful exit.
 fn write_if_changed(path: &Path, mut out: String, existing: &str) {
     if !out.is_empty() && !out.ends_with('\n') {
-        out.push_str(line_terminator(&out));
+        out.push('\n');
     }
     if out != existing
         && let Err(e) = std::fs::write(path, out)
     {
         eprintln!("warning: could not write {}: {e}", path.display());
-    }
-}
-
-/// `"\r\n"` when every line of `text` ends in CRLF, else `"\n"`.
-fn line_terminator(text: &str) -> &'static str {
-    let crlf = text.matches("\r\n").count();
-    if crlf > 0 && crlf == text.matches('\n').count() {
-        "\r\n"
-    } else {
-        "\n"
     }
 }
 
@@ -4719,31 +4708,6 @@ command = \"./scripts/x.sh\"\n";
             std::fs::metadata(&path).unwrap().modified().unwrap(),
             past,
             "identical content must not be rewritten"
-        );
-
-        let _ = std::fs::remove_dir_all(&dir);
-    }
-
-    #[test]
-    fn write_if_changed_heals_crlf_file_with_crlf() {
-        let dir = std::env::temp_dir().join(format!(
-            "vstack_test_write_if_changed_crlf_{}",
-            std::process::id()
-        ));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).unwrap();
-        let path = dir.join("vstack.toml");
-
-        let existing = "[a]\r\nx = 1";
-        std::fs::write(&path, existing).unwrap();
-        write_if_changed(&path, "[a]\r\nx = 2".to_string(), existing);
-        assert_eq!(std::fs::read_to_string(&path).unwrap(), "[a]\r\nx = 2\r\n");
-
-        // Mixed endings are not CRLF-throughout: plain LF is appended.
-        write_if_changed(&path, "[a]\r\nx = 3\ny = 4".to_string(), "");
-        assert_eq!(
-            std::fs::read_to_string(&path).unwrap(),
-            "[a]\r\nx = 3\ny = 4\n"
         );
 
         let _ = std::fs::remove_dir_all(&dir);

--- a/cli/src/project_config.rs
+++ b/cli/src/project_config.rs
@@ -2645,9 +2645,9 @@ fn create_project_config(path: &Path, agents: &[String], skills: &[String]) {
     out.push_str("# description = \"What this hook does\"     # inlined as instructions in non-Claude-Code harnesses\n");
     out.push_str("# agents = \"all\"             # \"all\", a role (\"engineer\"), or a list [\"rust\", \"iced\"]\n");
 
-    if let Err(e) = std::fs::write(path, out) {
-        eprintln!("warning: could not write {}: {e}", path.display());
-    }
+    // `path` does not exist here (`ensure_project_config` branches on that),
+    // so the existing content is empty and the write always happens.
+    write_if_changed(path, out, "");
 }
 
 fn update_project_config(path: &Path, agents: &[String], skills: &[String]) {
@@ -2696,7 +2696,7 @@ fn update_project_config(path: &Path, agents: &[String], skills: &[String]) {
 
 /// Write `out` to `path` only when it differs from `existing`, so an
 /// unchanged config is never rewritten (no needless working-tree churn).
-/// The written text always ends in a newline: a file that lost its
+/// Non-empty written text always ends in a newline: a file that lost its
 /// terminator is repaired by the first pass that reads it, and every later
 /// pass sees identical content and skips the write. A failed write prints a
 /// warning to stderr; the command still exits successfully, so that warning

--- a/cli/src/project_config.rs
+++ b/cli/src/project_config.rs
@@ -608,10 +608,7 @@ fn upsert_agent_value_in_section(
         i += 1;
     }
 
-    let mut out = result.join("\n");
-    if content.ends_with('\n') && !out.ends_with('\n') {
-        out.push('\n');
-    }
+    let mut out = join_like(content, &result);
 
     if !found_any {
         // Section didn't have an entry yet — append one.
@@ -1012,11 +1009,7 @@ fn upsert_agent_frontmatter_field(
         ));
     }
 
-    let mut out = result.join("\n");
-    if content.ends_with('\n') && !out.ends_with('\n') {
-        out.push('\n');
-    }
-    out
+    join_like(content, &result)
 }
 
 /// Write computed agent→skill mappings into the project vstack.toml.
@@ -1116,12 +1109,7 @@ fn replace_toml_array_value(
         i += 1;
     }
 
-    let mut out = result.join("\n");
-    // Preserve trailing newline if original had one
-    if content.ends_with('\n') && !out.ends_with('\n') {
-        out.push('\n');
-    }
-    out
+    join_like(content, &result)
 }
 
 /// For each agent: if the project toml already has an `[agent-skills]` entry,
@@ -1268,11 +1256,7 @@ fn remove_agent_frontmatter_base_section(content: &str) -> String {
         }
     }
 
-    let mut rendered = out.join("\n");
-    if content.ends_with('\n') && !rendered.ends_with('\n') {
-        rendered.push('\n');
-    }
-    rendered
+    join_like(content, &out)
 }
 
 fn remove_agent_colors_section(content: &str) -> String {
@@ -1294,11 +1278,7 @@ fn remove_agent_colors_section(content: &str) -> String {
         }
     }
 
-    let mut rendered = out.join("\n");
-    if content.ends_with('\n') && !rendered.ends_with('\n') {
-        rendered.push('\n');
-    }
-    rendered
+    join_like(content, &out)
 }
 
 fn harness_frontmatter_defaults(
@@ -2325,10 +2305,7 @@ fn migrate_agent_colors_to_frontmatter(content: &str) -> String {
         i += 1;
     }
 
-    let mut rendered = out.join("\n");
-    if content.ends_with('\n') && !rendered.ends_with('\n') {
-        rendered.push('\n');
-    }
+    let mut rendered = join_like(content, &out);
 
     for (agent, color) in colors {
         if !agent_frontmatter_has_field(&rendered, &agent, "color") {
@@ -2606,7 +2583,7 @@ fn migrate_section_names(path: &Path) {
         }
     }
     if changed {
-        let _ = std::fs::write(path, out);
+        write_if_changed(path, out, &content);
     }
 }
 
@@ -2742,14 +2719,29 @@ fn update_project_config(path: &Path, agents: &[String], skills: &[String]) {
 /// unchanged config never has its mtime bumped (staleness checks key on it).
 /// The written text always ends in a newline: a file that lost its
 /// terminator is repaired by the first pass that reads it, and every later
-/// pass sees identical content and skips the write.
+/// pass sees identical content and skips the write. A failed write is
+/// reported, never swallowed — the caller's update would otherwise vanish
+/// behind a successful exit.
 fn write_if_changed(path: &Path, mut out: String, existing: &str) {
     if !out.is_empty() && !out.ends_with('\n') {
         out.push('\n');
     }
-    if out != existing {
-        let _ = std::fs::write(path, out);
+    if out != existing
+        && let Err(e) = std::fs::write(path, out)
+    {
+        eprintln!("warning: could not write {}: {e}", path.display());
     }
+}
+
+/// Rejoin edited lines, restoring the final newline iff `content` had one.
+/// Every section transform that splits on `lines()` rebuilds through this so
+/// none can drop the terminator on its own.
+fn join_like(content: &str, lines: &[String]) -> String {
+    let mut out = lines.join("\n");
+    if content.ends_with('\n') && !out.ends_with('\n') {
+        out.push('\n');
+    }
+    out
 }
 
 /// Returns true if a name does NOT appear as a TOML key in the file.
@@ -2834,11 +2826,7 @@ fn insert_keys_into_section(content: &str, section_header: &str, new_keys: &[&St
         }
     }
 
-    let mut out = result.join("\n");
-    if content.ends_with('\n') && !out.ends_with('\n') {
-        out.push('\n');
-    }
-    out
+    join_like(content, &result)
 }
 
 /// Insert raw TOML text after existing keys in a `[section]`, preserving all
@@ -2894,11 +2882,7 @@ fn insert_entries_into_section(content: &str, section_header: &str, entries: &st
         }
     }
 
-    let mut out = result.join("\n");
-    if content.ends_with('\n') && !out.ends_with('\n') {
-        out.push('\n');
-    }
-    out
+    join_like(content, &result)
 }
 
 fn strip_skills_reference(content: &str) -> String {
@@ -4673,6 +4657,73 @@ command = \"./scripts/x.sh\"\n";
     }
 
     #[test]
+    fn write_if_changed_terminates_and_skips_identical() {
+        let dir = std::env::temp_dir().join(format!(
+            "vstack_test_write_if_changed_{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("vstack.toml");
+
+        std::fs::write(&path, "[a]\nx = 1").unwrap();
+        write_if_changed(&path, "[a]\nx = 2".to_string(), "[a]\nx = 1");
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "[a]\nx = 2\n");
+
+        let past = std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_000_000);
+        std::fs::File::options()
+            .write(true)
+            .open(&path)
+            .unwrap()
+            .set_modified(past)
+            .unwrap();
+        write_if_changed(&path, "[a]\nx = 2".to_string(), "[a]\nx = 2\n");
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().modified().unwrap(),
+            past,
+            "identical content must not be rewritten"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn write_agent_skills_heals_missing_trailing_newline_once() {
+        let dir = std::env::temp_dir().join(format!(
+            "vstack_test_agent_skills_heal_{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("vstack.toml");
+        std::fs::write(&path, "[agent-skills]\ngeneralist = [\"github\"]").unwrap();
+
+        let mut skills = std::collections::HashMap::new();
+        skills.insert("rust".to_string(), vec!["github".to_string()]);
+        write_agent_skills(&dir, &skills);
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert!(after.contains("rust = [\n    \"github\",\n]"), "{after:?}");
+        assert!(after.ends_with('\n'), "{after:?}");
+
+        let past = std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_000_000);
+        std::fs::File::options()
+            .write(true)
+            .open(&path)
+            .unwrap()
+            .set_modified(past)
+            .unwrap();
+        write_agent_skills(&dir, &skills);
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), after);
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().modified().unwrap(),
+            past,
+            "second identical pass must not rewrite"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
     fn insert_keys_into_section_preserves_trailing_newline() {
         let content = "[agent-skills]\ngeneralist = [\"github\"]\n";
         let key = "github".to_string();
@@ -4706,10 +4757,8 @@ command = \"./scripts/x.sh\"\n";
 
     #[test]
     fn refresh_heals_missing_trailing_newline_once() {
-        let dir = std::env::temp_dir().join(format!(
-            "vstack_test_newline_only_skip_{}",
-            std::process::id()
-        ));
+        let dir =
+            std::env::temp_dir().join(format!("vstack_test_newline_heal_{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
         let path = dir.join("vstack.toml");
@@ -4724,6 +4773,15 @@ command = \"./scripts/x.sh\"\n";
 
         let no_newline = stable.strip_suffix('\n').unwrap().to_string();
         std::fs::write(&path, &no_newline).unwrap();
+        // Pin the mtime well into the past so a repair write is
+        // distinguishable regardless of the filesystem's timestamp grain.
+        let past = std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_000_000);
+        std::fs::File::options()
+            .write(true)
+            .open(&path)
+            .unwrap()
+            .set_modified(past)
+            .unwrap();
         let mtime_before = std::fs::metadata(&path).unwrap().modified().unwrap();
 
         ensure_project_config(&dir, &agents, &skills);

--- a/cli/src/project_config.rs
+++ b/cli/src/project_config.rs
@@ -536,9 +536,7 @@ impl ProjectConfig {
 
         out = dedupe_agent_frontmatter_sections(&out);
 
-        if !same_ignoring_trailing_newline(&out, &existing) {
-            let _ = std::fs::write(&path, out);
-        }
+        write_if_changed(&path, out, &existing);
     }
 }
 
@@ -1059,9 +1057,7 @@ pub fn merge_upstream_agent_skills(project_root: &Path, updates: &HashMap<String
     }
 
     out = ensure_value_section_entry_spacing(&out);
-    if !same_ignoring_trailing_newline(&out, &content) {
-        let _ = std::fs::write(&path, out);
-    }
+    write_if_changed(&path, out, &content);
 }
 
 /// Replace a TOML array value for a key within a specific section.
@@ -1174,9 +1170,7 @@ pub fn write_agent_skills(project_root: &Path, agent_skill_map: &HashMap<String,
         "[agent-skills]",
         &new_entries,
     ));
-    if !same_ignoring_trailing_newline(&out, &existing) {
-        let _ = std::fs::write(&path, out);
-    }
+    write_if_changed(&path, out, &existing);
 }
 
 /// Deprecated compatibility shim. Default colors now live in each
@@ -1246,9 +1240,7 @@ pub fn write_agent_frontmatter_defaults(
     }
 
     content = ensure_value_section_entry_spacing(&dedupe_agent_frontmatter_sections(&content));
-    if !same_ignoring_trailing_newline(&content, &existing) {
-        let _ = std::fs::write(path, content);
-    }
+    write_if_changed(&path, content, &existing);
 }
 
 fn project_config_from_content(content: &str) -> ProjectConfig {
@@ -1871,9 +1863,7 @@ fn repair_project_config_structure(path: &Path) {
     // ours to keep in sync.
     let preserve_header = path.file_name().and_then(|n| n.to_str()) == Some("vstack-local.toml");
     let out = repair_project_config_content(&existing, preserve_header);
-    if !same_ignoring_trailing_newline(&out, &existing) {
-        let _ = std::fs::write(path, out);
-    }
+    write_if_changed(path, out, &existing);
 }
 
 fn repair_project_config_content(existing: &str, preserve_header: bool) -> String {
@@ -2745,19 +2735,21 @@ fn update_project_config(path: &Path, agents: &[String], skills: &[String]) {
 
     // Only write if content actually changed to avoid bumping mtime,
     // which would make staleness checks flag everything as outdated.
-    if !same_ignoring_trailing_newline(&out, &existing) {
-        let _ = std::fs::write(path, out);
-    }
+    write_if_changed(path, out, &existing);
 }
 
-/// True when the two contents differ at most by the presence of a single
-/// trailing newline. Refresh writers must skip the write in that case:
-/// consumers commit `vstack.toml` without a final newline, and a write whose
-/// only effect is normalizing that newline dirties their working tree on
-/// every refresh (vstack#987). A real content change still writes — and may
-/// normalize the newline along the way.
-fn same_ignoring_trailing_newline(a: &str, b: &str) -> bool {
-    a.strip_suffix('\n').unwrap_or(a) == b.strip_suffix('\n').unwrap_or(b)
+/// Write `out` to `path` only when it differs from `existing`, so an
+/// unchanged config never has its mtime bumped (staleness checks key on it).
+/// The written text always ends in a newline: a file that lost its
+/// terminator is repaired by the first pass that reads it, and every later
+/// pass sees identical content and skips the write.
+fn write_if_changed(path: &Path, mut out: String, existing: &str) {
+    if !out.is_empty() && !out.ends_with('\n') {
+        out.push('\n');
+    }
+    if out != existing {
+        let _ = std::fs::write(path, out);
+    }
 }
 
 /// Returns true if a name does NOT appear as a TOML key in the file.
@@ -2842,7 +2834,11 @@ fn insert_keys_into_section(content: &str, section_header: &str, new_keys: &[&St
         }
     }
 
-    result.join("\n")
+    let mut out = result.join("\n");
+    if content.ends_with('\n') && !out.ends_with('\n') {
+        out.push('\n');
+    }
+    out
 }
 
 /// Insert raw TOML text after existing keys in a `[section]`, preserving all
@@ -2898,7 +2894,11 @@ fn insert_entries_into_section(content: &str, section_header: &str, entries: &st
         }
     }
 
-    result.join("\n")
+    let mut out = result.join("\n");
+    if content.ends_with('\n') && !out.ends_with('\n') {
+        out.push('\n');
+    }
+    out
 }
 
 fn strip_skills_reference(content: &str) -> String {
@@ -4673,7 +4673,39 @@ command = \"./scripts/x.sh\"\n";
     }
 
     #[test]
-    fn refresh_skips_write_when_only_trailing_newline_differs() {
+    fn insert_keys_into_section_preserves_trailing_newline() {
+        let content = "[agent-skills]\ngeneralist = [\"github\"]\n";
+        let key = "github".to_string();
+        let out = insert_keys_into_section(content, "[skill-instructions]", &[&key]);
+        assert!(
+            out.ends_with("[skill-instructions]\ngithub = \"\"\n"),
+            "{out:?}"
+        );
+
+        let existing = "[skill-instructions]\nfoo = \"\"\n";
+        let out = insert_keys_into_section(existing, "[skill-instructions]", &[&key]);
+        assert!(out.ends_with("github = \"\"\n"), "{out:?}");
+
+        // A file with no terminator keeps none — the helper is shape-preserving.
+        let out = insert_keys_into_section("[a]\nx = 1", "[skill-instructions]", &[&key]);
+        assert!(out.ends_with("github = \"\""), "{out:?}");
+    }
+
+    #[test]
+    fn insert_entries_into_section_preserves_trailing_newline() {
+        let content = "[agent-skills]\ngeneralist = [\"github\"]\n";
+        let out = insert_entries_into_section(content, "[agent-skills]", "rust = [\"github\"]");
+        assert!(out.ends_with("rust = [\"github\"]\n"), "{out:?}");
+
+        let out = insert_entries_into_section("[other]\nx = 1\n", "[agent-skills]", "rust = []");
+        assert!(out.ends_with("[agent-skills]\nrust = []\n"), "{out:?}");
+
+        let out = insert_entries_into_section("[other]\nx = 1", "[agent-skills]", "rust = []");
+        assert!(out.ends_with("rust = []"), "{out:?}");
+    }
+
+    #[test]
+    fn refresh_heals_missing_trailing_newline_once() {
         let dir = std::env::temp_dir().join(format!(
             "vstack_test_newline_only_skip_{}",
             std::process::id()
@@ -4696,13 +4728,20 @@ command = \"./scripts/x.sh\"\n";
 
         ensure_project_config(&dir, &agents, &skills);
 
+        // First pass repairs the terminator (a real write)...
         let after = std::fs::read_to_string(&path).unwrap();
-        assert_eq!(
-            after, no_newline,
-            "newline-only normalization must not touch the file"
-        );
+        assert_eq!(after, stable, "missing final newline must be repaired");
         let mtime_after = std::fs::metadata(&path).unwrap().modified().unwrap();
-        assert_eq!(mtime_before, mtime_after, "no write should have occurred");
+        assert_ne!(mtime_before, mtime_after, "the repair is a write");
+
+        // ...and every later pass sees identical content and skips.
+        ensure_project_config(&dir, &agents, &skills);
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), stable);
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().modified().unwrap(),
+            mtime_after,
+            "no write should occur once the file is healed"
+        );
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/cli/src/project_config.rs
+++ b/cli/src/project_config.rs
@@ -1788,11 +1788,7 @@ fn upsert_missing_inline_table_fields(
         ));
     }
 
-    let mut rendered = result.join("\n");
-    if content.ends_with('\n') {
-        rendered.push('\n');
-    }
-    rendered
+    join_keep_blank_tail(content, &result)
 }
 
 /// Create or update vstack.toml at the project root.
@@ -2010,11 +2006,7 @@ fn normalize_attached_section_headers(content: &str) -> String {
             }
         }
     }
-    let mut rendered = out.join("\n");
-    if content.ends_with('\n') {
-        rendered.push('\n');
-    }
-    rendered
+    join_keep_blank_tail(content, &out)
 }
 
 fn repair_instruction_multiline_values(content: &str) -> String {
@@ -2093,11 +2085,7 @@ fn repair_instruction_multiline_values(content: &str) -> String {
         out.push(lines[i].to_string());
         i += 1;
     }
-    let mut rendered = out.join("\n");
-    if content.ends_with('\n') {
-        rendered.push('\n');
-    }
-    rendered
+    join_keep_blank_tail(content, &out)
 }
 
 fn ensure_value_section_entry_spacing(content: &str) -> String {
@@ -2162,10 +2150,7 @@ fn ensure_value_section_entry_spacing(content: &str) -> String {
         i += 1;
     }
 
-    let mut rendered = out.join("\n");
-    if content.ends_with('\n') {
-        rendered.push('\n');
-    }
+    let rendered = join_keep_blank_tail(content, &out);
     ensure_blank_line_before_section_headers(&rendered)
 }
 
@@ -2184,11 +2169,7 @@ fn ensure_blank_line_before_section_headers(content: &str) -> String {
         out.push(line.to_string());
     }
 
-    let mut rendered = out.join("\n");
-    if content.ends_with('\n') {
-        rendered.push('\n');
-    }
-    rendered
+    join_keep_blank_tail(content, &out)
 }
 
 fn starts_multiline_array_value(trimmed_line: &str) -> bool {
@@ -2236,11 +2217,7 @@ fn dedupe_agent_frontmatter_sections(content: &str) -> String {
         out.push(line.to_string());
     }
 
-    let mut rendered = out.join("\n");
-    if content.ends_with('\n') {
-        rendered.push('\n');
-    }
-    rendered
+    join_keep_blank_tail(content, &out)
 }
 
 fn skip_orphan_duplicate_multiline_body(lines: &[&str], i: usize) -> usize {
@@ -2668,7 +2645,9 @@ fn create_project_config(path: &Path, agents: &[String], skills: &[String]) {
     out.push_str("# description = \"What this hook does\"     # inlined as instructions in non-Claude-Code harnesses\n");
     out.push_str("# agents = \"all\"             # \"all\", a role (\"engineer\"), or a list [\"rust\", \"iced\"]\n");
 
-    let _ = std::fs::write(path, out);
+    if let Err(e) = std::fs::write(path, out) {
+        eprintln!("warning: could not write {}: {e}", path.display());
+    }
 }
 
 fn update_project_config(path: &Path, agents: &[String], skills: &[String]) {
@@ -2717,14 +2696,15 @@ fn update_project_config(path: &Path, agents: &[String], skills: &[String]) {
 
 /// Write `out` to `path` only when it differs from `existing`, so an
 /// unchanged config never has its mtime bumped (staleness checks key on it).
-/// The written text always ends in a newline: a file that lost its
+/// The written text always ends in a line terminator — `\r\n` when the
+/// content is CRLF throughout, `\n` otherwise — so a file that lost its
 /// terminator is repaired by the first pass that reads it, and every later
 /// pass sees identical content and skips the write. A failed write is
 /// reported, never swallowed — the caller's update would otherwise vanish
 /// behind a successful exit.
 fn write_if_changed(path: &Path, mut out: String, existing: &str) {
     if !out.is_empty() && !out.ends_with('\n') {
-        out.push('\n');
+        out.push_str(line_terminator(&out));
     }
     if out != existing
         && let Err(e) = std::fs::write(path, out)
@@ -2733,12 +2713,38 @@ fn write_if_changed(path: &Path, mut out: String, existing: &str) {
     }
 }
 
-/// Rejoin edited lines, restoring the final newline iff `content` had one.
-/// Every section transform that splits on `lines()` rebuilds through this so
-/// none can drop the terminator on its own.
+/// `"\r\n"` when every line of `text` ends in CRLF, else `"\n"`.
+fn line_terminator(text: &str) -> &'static str {
+    let crlf = text.matches("\r\n").count();
+    if crlf > 0 && crlf == text.matches('\n').count() {
+        "\r\n"
+    } else {
+        "\n"
+    }
+}
+
+/// Rejoin edited lines with `\n`, restoring a final newline iff `content`
+/// had one. This is the terminator convention for the section transforms
+/// that split on `lines()` and rebuild by key/entry (`insert_*`,
+/// `replace_toml_array_value`, `upsert_*`); a trailing blank line in
+/// `content` collapses into the terminator. Transforms that must round-trip
+/// a trailing blank line use [`join_keep_blank_tail`] instead.
 fn join_like(content: &str, lines: &[String]) -> String {
     let mut out = lines.join("\n");
     if content.ends_with('\n') && !out.ends_with('\n') {
+        out.push('\n');
+    }
+    out
+}
+
+/// Rejoin edited lines with `\n`, appending a final newline iff `content`
+/// had one — even when the last element is empty, so a trailing blank line
+/// survives the round trip. Used by the whole-file layout transforms
+/// (spacing, header, dedupe, scaffold) whose output must be byte-stable
+/// across passes.
+fn join_keep_blank_tail(content: &str, lines: &[String]) -> String {
+    let mut out = lines.join("\n");
+    if content.ends_with('\n') {
         out.push('\n');
     }
     out
@@ -3285,6 +3291,37 @@ trading-design = "Dark theme."
         let on_disk = std::fs::read_to_string(dir.join("vstack.toml")).unwrap();
         assert!(on_disk.contains("rust = \"mine\""), "on disk: {on_disk}");
         assert!(!on_disk.contains("Old shared."), "on disk: {on_disk}");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn save_extracted_new_agent_entry_keeps_trailing_newline() {
+        let dir = std::env::temp_dir().join(format!(
+            "vstack_test_save_extracted_newline_{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("vstack.toml"),
+            "[agent-launch-instructions]\nother = \"x\"\n",
+        )
+        .unwrap();
+        let mut config = ProjectConfig::load(&dir);
+
+        // No entry for `rust` yet: the value is inserted as a new entry.
+        let extracted = crate::agent::AgentExtras {
+            guidance: Some("mine".to_string()),
+            ..Default::default()
+        };
+        config.save_extracted(&dir, "rust", &extracted);
+        let on_disk = std::fs::read_to_string(dir.join("vstack.toml")).unwrap();
+        assert!(on_disk.contains("rust = \"mine\""), "on disk: {on_disk:?}");
+        assert!(
+            on_disk.ends_with('\n') && !on_disk.ends_with("\n\n"),
+            "exactly one final newline expected: {on_disk:?}"
+        );
 
         let _ = std::fs::remove_dir_all(&dir);
     }
@@ -4688,6 +4725,31 @@ command = \"./scripts/x.sh\"\n";
     }
 
     #[test]
+    fn write_if_changed_heals_crlf_file_with_crlf() {
+        let dir = std::env::temp_dir().join(format!(
+            "vstack_test_write_if_changed_crlf_{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("vstack.toml");
+
+        let existing = "[a]\r\nx = 1";
+        std::fs::write(&path, existing).unwrap();
+        write_if_changed(&path, "[a]\r\nx = 2".to_string(), existing);
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "[a]\r\nx = 2\r\n");
+
+        // Mixed endings are not CRLF-throughout: plain LF is appended.
+        write_if_changed(&path, "[a]\r\nx = 3\ny = 4".to_string(), "");
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            "[a]\r\nx = 3\ny = 4\n"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
     fn write_agent_skills_heals_missing_trailing_newline_once() {
         let dir = std::env::temp_dir().join(format!(
             "vstack_test_agent_skills_heal_{}",
@@ -4855,6 +4917,10 @@ command = \"./scripts/x.sh\"\n";
         assert!(
             after.contains("extra-skill"),
             "new skill entry missing: {after}"
+        );
+        assert!(
+            after.ends_with('\n') && !after.ends_with("\n\n"),
+            "exactly one final newline expected: {after:?}"
         );
 
         let _ = std::fs::remove_dir_all(&dir);


### PR DESCRIPTION
## Summary

- `vstack add`/`refresh` no longer strip the trailing newline from a project `vstack.toml`: the two section-insert helpers (`insert_keys_into_section`, `insert_entries_into_section`) now preserve the input's terminator like their siblings.
- `same_ignoring_trailing_newline` is replaced by `write_if_changed` — the written text always ends in a newline and the skip guard is exact equality, so a consumer file that already lost its terminator (e.g. `hyprtrade`'s committed `vstack.toml`) is repaired by the first `add`/`refresh` and never rewritten again.
- Follow-on hardening from review: one `join_like` / `join_keep_blank_tail` pair replaces ~23 hand-rolled join+restore copies (the class of bug that caused this), `create_project_config` and `write_if_changed` report a failed config write on stderr instead of discarding it, and `migrate_section_names` routes through the same single writer.

## Completed Issues

- Closes VST-252 - vstack add strips the trailing newline from vstack.toml

## Test Plan

- `cd cli && cargo test` — 589 + 2 + 17 pass, 0 fail.
- `cli/scripts/integration-check.sh` — 29/29 pass.
- New tests fail against `main`'s code: `write_if_changed_terminates_and_skips_identical`, `write_agent_skills_heals_missing_trailing_newline_once`, `refresh_heals_missing_trailing_newline_once`, `save_extracted_new_agent_entry_keeps_trailing_newline`, plus the two `insert_*` helper tests.
- Real binary: `vstack add` preserves an existing terminator; `refresh` heals a newline-less file and inserts in the same pass; a second `refresh` leaves the file's mtime untouched.

## Notes

Reviewed by nine internal reviewers plus an external cross-model pass over three fix cycles (13 findings applied). Declined, with rationale, as out of scope for this bug: propagating config-write failures into a non-zero exit code (the write failure is reported on stderr; changing exit semantics across `add`/`refresh`/`init` is a separate behaviour change), non-atomic `vstack.toml` writes (pre-existing, needs concurrent `vstack` runs to hit), and two P4 test-shape nits.
