### PR TITLE
fix(ci,tests): unblock the merge queue — lease-test fork/exec race, ejection-alert syntax error, workflow-run-syntax lane

### DIFF
--- a/.github/workflows/merge-queue-ejection-alert.yml
+++ b/.github/workflows/merge-queue-ejection-alert.yml
@@ -90,10 +90,11 @@ jobs:
               | (if ($recent | length) > 0 then $recent else . end)
               | sort_by(.created_at)
               # ATTEMPT cluster: a re-armed unchanged PR reuses the branch
-              # name, so the window can span attempts. One attempt's runs
-              # start together — keep only runs within 30 minutes of the
-              # newest, excluding an earlier attempt's completed failure
-              # from ever shadowing the current one.
+              # name, so the window can span attempts. The runs of one
+              # attempt start together — keep only runs within 30 minutes
+              # of the newest, so the completed failure of an earlier
+              # attempt never shadows the current one. (No apostrophes in
+              # these comments: they sit inside a single-quoted jq program.)
               | (map(.created_at) | max) as $newest
               | map(select(.created_at >= ($newest | sub("Z$"; "") | strptime("%Y-%m-%dT%H:%M:%S") | mktime | . - 1800 | strftime("%Y-%m-%dT%H:%M:%SZ"))))
               # Selection within the attempt: newest failure-shaped run;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+- ci: the merge-queue ejection alert's comment/intake step never ran — an
+  apostrophe in a comment inside its single-quoted jq program ended the
+  quote and the step died on a bash syntax error. Fixed, and preflight
+  gains a `workflow-run-syntax` lane: `bash -n` over every `run:` block of
+  a changed workflow file (expressions placeholdered, non-shell steps
+  skipped), reported at the file line.
+- worktree tests: `worktree_remove_live_lease.sh` failed most merge-queue
+  runs and stalled the surviving ones five minutes. Signalling a
+  just-forked `sleep 300 &` raced its exec: the pre-exec child ran the
+  test's EXIT trap and deleted the fixture, or the signal was lost and the
+  sleeper lived out its timer. The dead pid now comes from a job that
+  exits on its own and the cleanup trap runs only in the test process.
+- project-management tests: `tracker-routing-contract` failed open on the
+  GitHub-route Linear-free check — its sed pattern was BRE (parens grouped,
+  never matched) and the extraction failure inside `$(...)` could not stop
+  the run. ERE now, and an empty region fails the assertion.
 - agents: the seven engineer/analyst agents (generalist, iced, planner,
   researcher, rust, scout, tpm) drop the house "never trust a green check"
   blockquote — the rule's canonical homes are `code-quality` § Prove Your

--- a/skills/preflight/SKILL.md
+++ b/skills/preflight/SKILL.md
@@ -42,6 +42,7 @@ clean empty diff.
 | `docs-cited-paths` | An added backticked path in a `.md` file, inside a directory the repo really has and the doc's own subtree, that names nothing tracked or on disk. | built in |
 | `todo-links` | An added `TODO:`/`FIXME(` marker — the word immediately followed by `:` or `(` — with no `#123`, `ABC-123`, or URL on the line. Prose that merely uses the word is not a marker. | built in |
 | `data-syntax` | A changed `.json` or `.toml` file no parser accepts. | jq, taplo or python3 |
+| `workflow-run-syntax` | A `run:` block in a changed `.github/workflows/*.yml` that bash cannot parse (`${{ … }}` replaced by a placeholder; steps with a non-shell `shell:` skipped). Reported at the offending file line. | python3 with PyYAML |
 
 Shell files are `*.sh`, `*.bash`, or anything with a `sh`/`bash` shebang.
 Deleted files, and files under `tests/` or `fixtures/`, are out of scope

--- a/skills/preflight/SKILL.md
+++ b/skills/preflight/SKILL.md
@@ -42,7 +42,7 @@ clean empty diff.
 | `docs-cited-paths` | An added backticked path in a `.md` file, inside a directory the repo really has and the doc's own subtree, that names nothing tracked or on disk. | built in |
 | `todo-links` | An added `TODO:`/`FIXME(` marker — the word immediately followed by `:` or `(` — with no `#123`, `ABC-123`, or URL on the line. Prose that merely uses the word is not a marker. | built in |
 | `data-syntax` | A changed `.json` or `.toml` file no parser accepts. | jq, taplo or python3 |
-| `workflow-run-syntax` | A `run:` block in a changed `.github/workflows/*.yml` that bash cannot parse (`${{ … }}` replaced by a placeholder; steps with a non-shell `shell:` skipped, as is an undeclared shell on a Windows or expression-valued runner), reported at the offending file line — a folded (`>`) block at its first line; a workflow file that is not valid YAML, at the parser's line. | python3 with PyYAML |
+| `workflow-run-syntax` | A `run:` block in a changed `.github/workflows/*.yml` that its shell cannot parse — `bash -n` for bash, `sh -n` for sh, by name or executable path; `${{ … }}` replaced by a placeholder; other shells skipped, and an undeclared shell counts as bash only on plain `ubuntu-*`/`macos-*` runners. Reported at the offending file line — a folded (`>`) block at its first line; a workflow file that is not valid YAML, at the parser's line. | python3 with PyYAML |
 
 Shell files are `*.sh`, `*.bash`, or anything with a `sh`/`bash` shebang.
 Deleted files, and files under `tests/` or `fixtures/`, are out of scope

--- a/skills/preflight/SKILL.md
+++ b/skills/preflight/SKILL.md
@@ -42,7 +42,7 @@ clean empty diff.
 | `docs-cited-paths` | An added backticked path in a `.md` file, inside a directory the repo really has and the doc's own subtree, that names nothing tracked or on disk. | built in |
 | `todo-links` | An added `TODO:`/`FIXME(` marker — the word immediately followed by `:` or `(` — with no `#123`, `ABC-123`, or URL on the line. Prose that merely uses the word is not a marker. | built in |
 | `data-syntax` | A changed `.json` or `.toml` file no parser accepts. | jq, taplo or python3 |
-| `workflow-run-syntax` | A `run:` block in a changed `.github/workflows/*.yml` that bash cannot parse (`${{ … }}` replaced by a placeholder; steps with a non-shell `shell:` skipped). Reported at the offending file line. | python3 with PyYAML |
+| `workflow-run-syntax` | A `run:` block in a changed `.github/workflows/*.yml` that bash cannot parse (`${{ … }}` replaced by a placeholder; steps with a non-shell `shell:` skipped), reported at the offending file line — a folded (`>`) block at its first line; a workflow file that is not valid YAML, at the parser's line. | python3 with PyYAML |
 
 Shell files are `*.sh`, `*.bash`, or anything with a `sh`/`bash` shebang.
 Deleted files, and files under `tests/` or `fixtures/`, are out of scope

--- a/skills/preflight/SKILL.md
+++ b/skills/preflight/SKILL.md
@@ -42,7 +42,7 @@ clean empty diff.
 | `docs-cited-paths` | An added backticked path in a `.md` file, inside a directory the repo really has and the doc's own subtree, that names nothing tracked or on disk. | built in |
 | `todo-links` | An added `TODO:`/`FIXME(` marker — the word immediately followed by `:` or `(` — with no `#123`, `ABC-123`, or URL on the line. Prose that merely uses the word is not a marker. | built in |
 | `data-syntax` | A changed `.json` or `.toml` file no parser accepts. | jq, taplo or python3 |
-| `workflow-run-syntax` | A `run:` block in a changed `.github/workflows/*.yml` that bash cannot parse (`${{ … }}` replaced by a placeholder; steps with a non-shell `shell:` skipped), reported at the offending file line — a folded (`>`) block at its first line; a workflow file that is not valid YAML, at the parser's line. | python3 with PyYAML |
+| `workflow-run-syntax` | A `run:` block in a changed `.github/workflows/*.yml` that bash cannot parse (`${{ … }}` replaced by a placeholder; steps with a non-shell `shell:` skipped, as is an undeclared shell on a Windows or expression-valued runner), reported at the offending file line — a folded (`>`) block at its first line; a workflow file that is not valid YAML, at the parser's line. | python3 with PyYAML |
 
 Shell files are `*.sh`, `*.bash`, or anything with a `sh`/`bash` shebang.
 Deleted files, and files under `tests/` or `fixtures/`, are out of scope

--- a/skills/preflight/scripts/preflight
+++ b/skills/preflight/scripts/preflight
@@ -405,7 +405,7 @@ for _, job in jobs.items():
                 sys.stdout.write("%d\t%s\n" % (first, raw.strip()))
 '
 HAVE_WORKFLOW_PY=0
-have python3 && python3 -c 'import yaml' >/dev/null 2>&1 && HAVE_WORKFLOW_PY=1
+have python3 && python3 -c 'import sys, yaml; sys.exit(0 if sys.version_info >= (3, 7) else 1)' >/dev/null 2>&1 && HAVE_WORKFLOW_PY=1
 HAVE_SHELLCHECK=0
 have shellcheck && HAVE_SHELLCHECK=1
 HAVE_TOML=none

--- a/skills/preflight/scripts/preflight
+++ b/skills/preflight/scripts/preflight
@@ -324,9 +324,30 @@ def shell_of(node):
     s = scalar(m.get("shell"))
     return s
 def is_bash(shell):
-    if shell is None:
-        return True
     return re.match(r"^(bash|sh)(\s|$)", shell.strip()) is not None
+# With no shell declared anywhere, GitHub runs bash on Linux/macOS runners and
+# PowerShell on Windows ones. An implicit shell is bash only when every
+# runs-on label is a plain, non-Windows string; an expression or a Windows
+# label leaves the default unresolved and the step is skipped.
+def implicit_shell_is_bash(jm):
+    ro = jm.get("runs-on")
+    labels = []
+    if isinstance(ro, yaml.ScalarNode):
+        labels = [ro.value]
+    elif isinstance(ro, yaml.SequenceNode):
+        labels = [n.value for n in ro.value if isinstance(n, yaml.ScalarNode)]
+    elif isinstance(ro, yaml.MappingNode):
+        lab = mapping(ro).get("labels")
+        if isinstance(lab, yaml.ScalarNode):
+            labels = [lab.value]
+        elif isinstance(lab, yaml.SequenceNode):
+            labels = [n.value for n in lab.value if isinstance(n, yaml.ScalarNode)]
+    if not labels:
+        return False
+    for label in labels:
+        if "${{" in label or "windows" in label.lower():
+            return False
+    return True
 top = mapping(root)
 default_shell = shell_of(mapping(top.get("defaults")).get("run")) if "defaults" in top else None
 jobs = mapping(top.get("jobs"))
@@ -342,7 +363,11 @@ for _, job in jobs.items():
         if not isinstance(run, yaml.ScalarNode):
             continue
         shell = scalar(sm.get("shell"))
-        if not is_bash(shell if shell is not None else job_shell):
+        effective = shell if shell is not None else job_shell
+        if effective is None:
+            if not implicit_shell_is_bash(jm):
+                continue
+        elif not is_bash(effective):
             continue
         # Block scalars (| >) start their content on the line after the key;
         # flow/plain scalars start on the key line itself. A folded scalar

--- a/skills/preflight/scripts/preflight
+++ b/skills/preflight/scripts/preflight
@@ -323,12 +323,16 @@ def shell_of(node):
     m = mapping(node)
     s = scalar(m.get("shell"))
     return s
-def is_bash(shell):
-    return re.match(r"^(bash|sh)(\s|$)", shell.strip()) is not None
+# The interpreter that will parse the block: bash or sh, given as a bare name
+# or an executable path (`/bin/bash {0}`); anything else is out of scope.
+def interpreter_of(shell):
+    m = re.match(r"^(?:.*/)?(bash|sh)(?:\s|$)", shell.strip())
+    return m.group(1) if m else None
 # With no shell declared anywhere, GitHub runs bash on Linux/macOS runners and
 # PowerShell on Windows ones. An implicit shell is bash only when every
-# runs-on label is a plain, non-Windows string; an expression or a Windows
-# label leaves the default unresolved and the step is skipped.
+# runs-on label is a plain ubuntu-* or macos-* label; an expression, a
+# Windows label, or a custom/self-hosted label leaves the default unresolved
+# and the step is skipped.
 def implicit_shell_is_bash(jm):
     ro = jm.get("runs-on")
     labels = []
@@ -345,7 +349,7 @@ def implicit_shell_is_bash(jm):
     if not labels:
         return False
     for label in labels:
-        if "${{" in label or "windows" in label.lower():
+        if "${{" in label or not re.match(r"^(ubuntu|macos)([-_]|$)", label.lower()):
             return False
     return True
 top = mapping(root)
@@ -353,7 +357,7 @@ default_shell = shell_of(mapping(top.get("defaults")).get("run")) if "defaults" 
 jobs = mapping(top.get("jobs"))
 for _, job in jobs.items():
     jm = mapping(job)
-    job_shell = shell_of(mapping(jm.get("defaults")).get("run")) if "defaults" in jm else default_shell
+    job_shell = (shell_of(mapping(jm.get("defaults")).get("run")) or default_shell) if "defaults" in jm else default_shell
     steps = jm.get("steps")
     if not isinstance(steps, yaml.SequenceNode):
         continue
@@ -367,8 +371,11 @@ for _, job in jobs.items():
         if effective is None:
             if not implicit_shell_is_bash(jm):
                 continue
-        elif not is_bash(effective):
-            continue
+            interp = "bash"
+        else:
+            interp = interpreter_of(effective)
+            if interp is None:
+                continue
         # Block scalars (| >) start their content on the line after the key;
         # flow/plain scalars start on the key line itself. A folded scalar
         # (>) has had its newlines collapsed before bash sees it, so its
@@ -384,7 +391,7 @@ for _, job in jobs.items():
             t.write(body)
             tmp = t.name
         try:
-            res = subprocess.run(["bash", "-n", tmp], capture_output=True, text=True)
+            res = subprocess.run([interp, "-n", tmp], capture_output=True, text=True)
         finally:
             os.unlink(tmp)
         if res.returncode == 0:
@@ -559,10 +566,13 @@ while IFS= read -r f; do
       ;;
     .github/workflows/*.yml | .github/workflows/*.yaml)
       if [ "$HAVE_WORKFLOW_PY" = 1 ]; then
+        # The tool is present, so a crash is an environment error, never an
+        # empty (clean-looking) result.
+        wf_out="$(python3 -c "$WORKFLOW_PY" "$cpath" 2>"$TMP/wf.err")" || env_error "workflow-run-syntax lane failed on $f: $(first_line "$(cat "$TMP/wf.err")")"
         while IFS="$TAB" read -r n msg; do
           [ -n "$msg" ] || continue
           emit "$f" "$n" workflow-run-syntax "$msg"
-        done <<<"$(python3 -c "$WORKFLOW_PY" "$cpath" 2>/dev/null)"
+        done <<<"$wf_out"
       fi
       ;;
   esac

--- a/skills/preflight/scripts/preflight
+++ b/skills/preflight/scripts/preflight
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 # preflight — diff-scoped, fail-only checks: fail-open bash, docs citing
 # repo paths that do not exist, TODO markers with no issue behind them,
-# malformed JSON/TOML.
+# malformed JSON/TOML, workflow run: blocks bash cannot parse.
 #
 # Precision before coverage: a lane that cannot decide says nothing. The
 # line-scoped lanes report only on lines this diff ADDED, so a pre-existing
 # violation on an untouched line never fails somebody else's change. A
-# missing optional tool (shellcheck, jq, taplo, python3) skips its lane
+# missing optional tool (shellcheck, jq, taplo, python3, PyYAML) skips its lane
 # silently — the run never fails because a tool is absent, and a lane never
 # degrades into a warning: it fails or it says nothing.
 #
@@ -30,7 +30,7 @@ and the default branch (origin/HEAD, else origin/main, else main).
   --repo PATH   run against the repository containing PATH (default: cwd)
 
 Lanes: shell-syntax, shellcheck-errors, masked-returns, fail-open,
-docs-cited-paths, todo-links, data-syntax.
+docs-cited-paths, todo-links, data-syntax, workflow-run-syntax.
 
 Exit codes: 0 clean; 1 findings; 2 usage/environment error.
 EOF
@@ -292,6 +292,78 @@ except Exception as exc:
     sys.stdout.write(str(exc) + "\n")
     sys.exit(1)
 '
+# Workflow `run:` blocks are shell that no shell lane sees: bash -n each block
+# (GitHub expressions replaced by a placeholder, non-shell `shell:` steps
+# skipped) and report file line numbers, mapped through the block scalar's
+# position. Output: TAB-separated `line<TAB>message` per finding.
+WORKFLOW_PY='import re, subprocess, sys, tempfile, os
+import yaml
+path = sys.argv[1]
+with open(path, "r", encoding="utf-8") as fh:
+    text = fh.read()
+try:
+    root = yaml.compose(text)
+except Exception:
+    sys.exit(0)
+def mapping(node):
+    if not isinstance(node, yaml.MappingNode):
+        return {}
+    out = {}
+    for k, v in node.value:
+        if isinstance(k, yaml.ScalarNode):
+            out[k.value] = v
+    return out
+def scalar(node):
+    return node.value if isinstance(node, yaml.ScalarNode) else None
+def shell_of(node):
+    m = mapping(node)
+    s = scalar(m.get("shell"))
+    return s
+def is_bash(shell):
+    if shell is None:
+        return True
+    return re.match(r"^(bash|sh)(\s|$)", shell.strip()) is not None
+top = mapping(root)
+default_shell = shell_of(mapping(top.get("defaults")).get("run")) if "defaults" in top else None
+jobs = mapping(top.get("jobs"))
+for _, job in jobs.items():
+    jm = mapping(job)
+    job_shell = shell_of(mapping(jm.get("defaults")).get("run")) if "defaults" in jm else default_shell
+    steps = jm.get("steps")
+    if not isinstance(steps, yaml.SequenceNode):
+        continue
+    for step in steps.value:
+        sm = mapping(step)
+        run = sm.get("run")
+        if not isinstance(run, yaml.ScalarNode):
+            continue
+        shell = scalar(sm.get("shell"))
+        if not is_bash(shell if shell is not None else job_shell):
+            continue
+        # Block scalars (| >) start their content on the line after the key;
+        # flow/plain scalars start on the key line itself.
+        first = run.start_mark.line + 1
+        if run.style in ("|", ">"):
+            first += 1
+        body = re.sub(r"\$\{\{.*?\}\}", "X", run.value, flags=re.S)
+        with tempfile.NamedTemporaryFile("w", suffix=".sh", delete=False) as t:
+            t.write(body)
+            tmp = t.name
+        try:
+            res = subprocess.run(["bash", "-n", tmp], capture_output=True, text=True)
+        finally:
+            os.unlink(tmp)
+        if res.returncode == 0:
+            continue
+        for raw in res.stderr.splitlines():
+            m = re.match(r"^.*?: line (\d+): (.*)$", raw)
+            if m:
+                sys.stdout.write("%d\t%s\n" % (first + int(m.group(1)) - 1, m.group(2)))
+            elif raw.strip():
+                sys.stdout.write("%d\t%s\n" % (first, raw.strip()))
+'
+HAVE_WORKFLOW_PY=0
+have python3 && python3 -c 'import yaml' >/dev/null 2>&1 && HAVE_WORKFLOW_PY=1
 HAVE_SHELLCHECK=0
 have shellcheck && HAVE_SHELLCHECK=1
 HAVE_TOML=none
@@ -448,6 +520,14 @@ while IFS= read -r f; do
     *.toml)
       if ! out="$(check_toml "$cpath")"; then
         emit "$f" "$(line_hint "$out")" data-syntax "invalid TOML: $(first_line "$out")"
+      fi
+      ;;
+    .github/workflows/*.yml | .github/workflows/*.yaml)
+      if [ "$HAVE_WORKFLOW_PY" = 1 ]; then
+        while IFS="$TAB" read -r n msg; do
+          [ -n "$msg" ] || continue
+          emit "$f" "$n" workflow-run-syntax "$msg"
+        done <<<"$(python3 -c "$WORKFLOW_PY" "$cpath" 2>/dev/null)"
       fi
       ;;
   esac

--- a/skills/preflight/scripts/preflight
+++ b/skills/preflight/scripts/preflight
@@ -303,7 +303,11 @@ with open(path, "r", encoding="utf-8") as fh:
     text = fh.read()
 try:
     root = yaml.compose(text)
-except Exception:
+except yaml.YAMLError as exc:
+    mark = getattr(exc, "problem_mark", None)
+    line = mark.line + 1 if mark is not None else 1
+    problem = getattr(exc, "problem", None) or str(exc).splitlines()[0]
+    sys.stdout.write("%d\tworkflow YAML did not parse: %s\n" % (line, problem))
     sys.exit(0)
 def mapping(node):
     if not isinstance(node, yaml.MappingNode):
@@ -341,10 +345,15 @@ for _, job in jobs.items():
         if not is_bash(shell if shell is not None else job_shell):
             continue
         # Block scalars (| >) start their content on the line after the key;
-        # flow/plain scalars start on the key line itself.
+        # flow/plain scalars start on the key line itself. A folded scalar
+        # (>) has had its newlines collapsed before bash sees it, so its
+        # diagnostics cannot be mapped to a source line: they land on the
+        # first line of the block. (No apostrophes here: this Python lives in
+        # a single-quoted bash string.)
         first = run.start_mark.line + 1
         if run.style in ("|", ">"):
             first += 1
+        folded = run.style == ">"
         body = re.sub(r"\$\{\{.*?\}\}", "X", run.value, flags=re.S)
         with tempfile.NamedTemporaryFile("w", suffix=".sh", delete=False) as t:
             t.write(body)
@@ -358,7 +367,8 @@ for _, job in jobs.items():
         for raw in res.stderr.splitlines():
             m = re.match(r"^.*?: line (\d+): (.*)$", raw)
             if m:
-                sys.stdout.write("%d\t%s\n" % (first + int(m.group(1)) - 1, m.group(2)))
+                at = first if folded else first + int(m.group(1)) - 1
+                sys.stdout.write("%d\t%s\n" % (at, m.group(2)))
             elif raw.strip():
                 sys.stdout.write("%d\t%s\n" % (first, raw.strip()))
 '

--- a/skills/preflight/tests/lanes-must-fail.test.sh
+++ b/skills/preflight/tests/lanes-must-fail.test.sh
@@ -147,7 +147,7 @@ fi
 
 echo "=== lane workflow-run-syntax: a run: block bash cannot parse ==="
 seed workflow
-if command -v python3 >/dev/null 2>&1 && python3 -c 'import yaml' >/dev/null 2>&1; then
+if command -v python3 >/dev/null 2>&1 && python3 -c 'import sys, yaml; sys.exit(0 if sys.version_info >= (3, 7) else 1)' >/dev/null 2>&1; then
   mkdir -p "$R/.github/workflows"
   # The defect that motivated the lane: an apostrophe in a comment INSIDE a
   # single-quoted jq program ends the quote, and the next `|` line is a bash

--- a/skills/preflight/tests/lanes-must-fail.test.sh
+++ b/skills/preflight/tests/lanes-must-fail.test.sh
@@ -172,10 +172,18 @@ jobs:
       - name: not shell
         shell: python
         run: print("this isn't bash")
+      - name: folded
+        run: >
+          echo one
+          echo "unterminated
 YML
+  # Invalid YAML is a finding at the parser's line, never a silent skip.
+  printf 'name: bad\non: push\njobs:\n\tx: 1\n' >"$R/.github/workflows/bad.yml"
   git -C "$R" add -A
   run_pf
   fires "an unparseable run: block fails, attributed to workflow-run-syntax at the offending file line" ".github/workflows/ci.yml:14: [workflow-run-syntax]"
+  fires "a folded (>) block reports at its first line, since bash never sees its source lines" ".github/workflows/ci.yml:21: [workflow-run-syntax]"
+  fires "a workflow file that is not valid YAML is a finding at the parser's line" ".github/workflows/bad.yml:4: [workflow-run-syntax] workflow YAML did not parse"
   case "$OUT" in
     *"ci.yml:8: "* | *"ci.yml:18: "*)
       bad "the clean step (line 8) and the python step (line 18) contribute no findings" "out=$OUT" ;;

--- a/skills/preflight/tests/lanes-must-fail.test.sh
+++ b/skills/preflight/tests/lanes-must-fail.test.sh
@@ -145,6 +145,46 @@ else
   skipped "data-syntax TOML must-fail control" "no taplo and no python3 with tomllib"
 fi
 
+echo "=== lane workflow-run-syntax: a run: block bash cannot parse ==="
+seed workflow
+if command -v python3 >/dev/null 2>&1 && python3 -c 'import yaml' >/dev/null 2>&1; then
+  mkdir -p "$R/.github/workflows"
+  # The defect that motivated the lane: an apostrophe in a comment INSIDE a
+  # single-quoted jq program ends the quote, and the next `|` line is a bash
+  # syntax error. A GitHub expression sits on a clean line so the placeholder
+  # substitution is exercised too; a python step must be left alone.
+  cat >"$R/.github/workflows/ci.yml" <<'YML'
+name: ci
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: fine
+        run: echo "${{ github.sha }}"
+      - name: broken
+        run: |
+          set -euo pipefail
+          out="$(jq -n 'add
+            # one attempt's runs
+            | length')"
+          echo "$out"
+      - name: not shell
+        shell: python
+        run: print("this isn't bash")
+YML
+  git -C "$R" add -A
+  run_pf
+  fires "an unparseable run: block fails, attributed to workflow-run-syntax at the offending file line" ".github/workflows/ci.yml:14: [workflow-run-syntax]"
+  case "$OUT" in
+    *"ci.yml:8: "* | *"ci.yml:18: "*)
+      bad "the clean step (line 8) and the python step (line 18) contribute no findings" "out=$OUT" ;;
+    *) ok "the clean step (line 8) and the python step (line 18) contribute no findings" ;;
+  esac
+else
+  skipped "workflow-run-syntax must-fail control" "no python3 with PyYAML"
+fi
+
 echo "=== the verdict line counts findings and changed files ==="
 seed verdict
 printf '# Guide\n\nNothing here yet.\n\nTODO: one.\nTODO: two.\n' >"$R/docs/guide.md"

--- a/skills/preflight/tests/lanes-must-fail.test.sh
+++ b/skills/preflight/tests/lanes-must-fail.test.sh
@@ -186,6 +186,41 @@ jobs:
     steps:
       - name: unresolved default shell
         run: if ($true) { Write-Host "not bash" }
+  hosted:
+    runs-on: [self-hosted, linux]
+    steps:
+      - name: custom runner, unresolved default
+        run: if ($true) { Write-Host "not bash" }
+  pathshell:
+    runs-on: windows-latest
+    steps:
+      - name: bash by path
+        shell: /bin/bash {0}
+        run: echo "unterminated
+  posix:
+    runs-on: ubuntu-latest
+    steps:
+      - name: sh step
+        shell: sh
+        run: echo "unterminated
+YML
+  # A workflow-level non-bash default survives a job-level `defaults` that
+  # only sets working-directory.
+  cat >"$R/.github/workflows/defaults.yml" <<'YML'
+name: d
+on: push
+defaults:
+  run:
+    shell: pwsh
+jobs:
+  x:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: src
+    steps:
+      - name: pwsh inherited
+        run: if ($true) { Write-Host "not bash" }
 YML
   # Invalid YAML is a finding at the parser's line, never a silent skip.
   printf 'name: bad\non: push\njobs:\n\tx: 1\n' >"$R/.github/workflows/bad.yml"
@@ -194,10 +229,12 @@ YML
   fires "an unparseable run: block fails, attributed to workflow-run-syntax at the offending file line" ".github/workflows/ci.yml:14: [workflow-run-syntax]"
   fires "a folded (>) block reports at its first line, since bash never sees its source lines" ".github/workflows/ci.yml:21: [workflow-run-syntax]"
   fires "a workflow file that is not valid YAML is a finding at the parser's line" ".github/workflows/bad.yml:4: [workflow-run-syntax] workflow YAML did not parse"
+  fires "a bash given as an executable path (/bin/bash {0}) is in scope" ".github/workflows/ci.yml:43: [workflow-run-syntax]"
+  fires "a shell: sh step is parsed too" ".github/workflows/ci.yml:49: [workflow-run-syntax]"
   case "$OUT" in
-    *"ci.yml:8: "* | *"ci.yml:18: "* | *"ci.yml:27: "* | *"ci.yml:32: "*)
-      bad "the clean step (8), the python step (18), the implicit-pwsh Windows step (27) and the unresolved-runner step (32) contribute no findings" "out=$OUT" ;;
-    *) ok "the clean step (8), the python step (18), the implicit-pwsh Windows step (27) and the unresolved-runner step (32) contribute no findings" ;;
+    *"ci.yml:8: "* | *"ci.yml:18: "* | *"ci.yml:27: "* | *"ci.yml:32: "* | *"ci.yml:37: "* | *"defaults.yml"*)
+      bad "clean (8), python (18), implicit-pwsh Windows (27), expression runner (32), self-hosted runner (37) and inherited-pwsh (defaults.yml) steps contribute no findings" "out=$OUT" ;;
+    *) ok "clean (8), python (18), implicit-pwsh Windows (27), expression runner (32), self-hosted runner (37) and inherited-pwsh (defaults.yml) steps contribute no findings" ;;
   esac
 else
   skipped "workflow-run-syntax must-fail control" "no python3 with PyYAML"

--- a/skills/preflight/tests/lanes-must-fail.test.sh
+++ b/skills/preflight/tests/lanes-must-fail.test.sh
@@ -176,6 +176,16 @@ jobs:
         run: >
           echo one
           echo "unterminated
+  win:
+    runs-on: windows-latest
+    steps:
+      - name: implicit pwsh
+        run: if ($true) { Write-Host "not bash" }
+  matrix:
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: unresolved default shell
+        run: if ($true) { Write-Host "not bash" }
 YML
   # Invalid YAML is a finding at the parser's line, never a silent skip.
   printf 'name: bad\non: push\njobs:\n\tx: 1\n' >"$R/.github/workflows/bad.yml"
@@ -185,9 +195,9 @@ YML
   fires "a folded (>) block reports at its first line, since bash never sees its source lines" ".github/workflows/ci.yml:21: [workflow-run-syntax]"
   fires "a workflow file that is not valid YAML is a finding at the parser's line" ".github/workflows/bad.yml:4: [workflow-run-syntax] workflow YAML did not parse"
   case "$OUT" in
-    *"ci.yml:8: "* | *"ci.yml:18: "*)
-      bad "the clean step (line 8) and the python step (line 18) contribute no findings" "out=$OUT" ;;
-    *) ok "the clean step (line 8) and the python step (line 18) contribute no findings" ;;
+    *"ci.yml:8: "* | *"ci.yml:18: "* | *"ci.yml:27: "* | *"ci.yml:32: "*)
+      bad "the clean step (8), the python step (18), the implicit-pwsh Windows step (27) and the unresolved-runner step (32) contribute no findings" "out=$OUT" ;;
+    *) ok "the clean step (8), the python step (18), the implicit-pwsh Windows step (27) and the unresolved-runner step (32) contribute no findings" ;;
   esac
 else
   skipped "workflow-run-syntax must-fail control" "no python3 with PyYAML"

--- a/skills/project-management/tests/tracker-routing-contract.test.sh
+++ b/skills/project-management/tests/tracker-routing-contract.test.sh
@@ -29,17 +29,20 @@ require_fixed() {
   grep -Fq -- "$needle" "$file" || fail "$desc missing in ${file#"$SKILL_DIR"/}"
 }
 
-# extract <file> <start-pattern> <end-pattern> <label> → prints scratch path
+# extract <file> <start-pattern> <end-pattern> <label> → prints scratch path.
+# ERE, like `require`: `\(` and `\)` are literal parentheses in both.
 extract() {
   local file="$1" start="$2" end="$3" label="$4"
   local out="$tmp/$label.md"
-  sed -n "/$start/,/$end/p" "$file" >"$out"
-  [[ -s "$out" ]] || fail "could not extract $label from ${file#"$SKILL_DIR"/}"
+  sed -En "/$start/,/$end/p" "$file" >"$out"
   printf '%s' "$out"
 }
 
+# An empty region is a failed extraction, never a vacuously Linear-free one:
+# `fail` inside the caller's $(...) only leaves that subshell.
 assert_linear_free() {
   local region="$1" label="$2"
+  [[ -s "$region" ]] || fail "could not extract the $label region"
   ! grep -Fq 'linear.sh' "$region" || fail "$label contains a Linear command"
 }
 

--- a/skills/project-management/tests/tracker-routing-contract.test.sh
+++ b/skills/project-management/tests/tracker-routing-contract.test.sh
@@ -29,13 +29,15 @@ require_fixed() {
   grep -Fq -- "$needle" "$file" || fail "$desc missing in ${file#"$SKILL_DIR"/}"
 }
 
-# extract <file> <start-pattern> <end-pattern> <label> → prints scratch path.
-# ERE, like `require`: `\(` and `\)` are literal parentheses in both.
+# extract <file> <start-pattern> <end-pattern> <label> → prints scratch path;
+# nonzero when the region is empty. Patterns are ERE (`sed -E`), the same
+# dialect as `require`'s `grep -E`: write `\(` for a literal parenthesis.
 extract() {
   local file="$1" start="$2" end="$3" label="$4"
   local out="$tmp/$label.md"
   sed -En "/$start/,/$end/p" "$file" >"$out"
   printf '%s' "$out"
+  [[ -s "$out" ]]
 }
 
 # An empty region is a failed extraction, never a vacuously Linear-free one:

--- a/skills/project-management/tests/tracker-routing-contract.test.sh
+++ b/skills/project-management/tests/tracker-routing-contract.test.sh
@@ -35,7 +35,7 @@ require_fixed() {
 extract() {
   local file="$1" start="$2" end="$3" label="$4"
   local out="$tmp/$label.md"
-  sed -En "/$start/,/$end/p" "$file" >"$out"
+  sed -En "/$start/,/$end/p" -- "$file" >"$out"
   printf '%s' "$out"
   [[ -s "$out" ]]
 }

--- a/skills/worktree/tests/worktree_remove_live_lease.sh
+++ b/skills/worktree/tests/worktree_remove_live_lease.sh
@@ -16,7 +16,12 @@ GUARD_SCRIPT="$WORKTREE_PACKAGE_DIR/scripts/worktree-session-guard"
 
 TMP_ROOT="$(cd "$(mktemp -d)" && pwd -P)"
 SLEEPER_PID=""
+# A backgrounded external command is a forked copy of this shell until it
+# execs; a signal that lands in that window makes the CHILD run this EXIT
+# trap and delete TMP_ROOT under the running test. Only the test process
+# itself may clean up.
 cleanup() {
+  [[ "$BASHPID" == "$$" ]] || return 0
   [[ -n "$SLEEPER_PID" ]] && kill "$SLEEPER_PID" 2>/dev/null
   rm -rf "$TMP_ROOT"
 }
@@ -187,9 +192,11 @@ make_repo "$DEAD_ROOT/main"
 git -C "$DEAD_ROOT/main" worktree add -q -b issue-dead "$DEAD_ROOT/trees/issue-dead" main
 DEAD_WT="$DEAD_ROOT/trees/issue-dead"
 "$GUARD_SCRIPT" claim "$DEAD_WT" --owner issue-dead >/dev/null
-sleep 300 &
+# A pid that died on its own: signalling a just-forked job races its exec —
+# the signal either hits the pre-exec child (which then runs this shell's
+# EXIT trap) or is lost, leaving the sleeper alive for its full duration.
+sleep 0 &
 DEAD_PID=$!
-kill "$DEAD_PID"
 wait "$DEAD_PID" 2>/dev/null || true
 plant_lease_pid "$DEAD_ROOT/main/.git/worktrees/issue-dead/locked" "$DEAD_PID"
 

--- a/skills/worktree/tests/worktree_remove_live_lease.sh
+++ b/skills/worktree/tests/worktree_remove_live_lease.sh
@@ -21,7 +21,7 @@ SLEEPER_PID=""
 # trap and delete TMP_ROOT under the running test. Only the test process
 # itself may clean up.
 cleanup() {
-  [[ "$BASHPID" == "$$" ]] || return 0
+  [[ "${BASHPID:-$$}" == "$$" ]] || return 0
   [[ -n "$SLEEPER_PID" ]] && kill "$SLEEPER_PID" 2>/dev/null
   rm -rf "$TMP_ROOT"
 }


### PR DESCRIPTION
## Why

Every PR entering the merge queue since #1284 has been ejected (#1300 twice, #1301, #1285; #1299 needed a second attempt): `skills/worktree/tests/worktree_remove_live_lease.sh` fails in 4 of 5 merge-group runs and stalls the fifth for five minutes. The ejection alert that should have explained it never posted — its own step dies on a bash syntax error. Nothing merges until both are fixed.

## What

**Lease test — a bash fork/exec race, CI-only.** The dead-pid scenario ran `sleep 300 & kill $!`. On the runner the SIGTERM lands while the forked child is still bash (pre-exec); the child runs the test's inherited `trap cleanup EXIT` and `rm -rf`s `TMP_ROOT` under the running test → `locked.planted: No such file or directory` at line 85. When the signal is instead lost in that window, `sleep 300` survives and `wait` blocks 300 s (the 5m01s "pass"). Trace from a runner probe:

```
+ DEAD_PID=4472
+ kill 4472
+ sleep 300
+ wait 4472
++ cleanup
++ rm -rf /tmp/tmp.YXpvhEkwKy
```

Fix: the dead pid comes from a job that exits on its own (`sleep 0 & wait`), and `cleanup` returns unless `$BASHPID == $$`. Probe on `ubuntu-latest`: 4/5 fail before → 8/8 pass after, 27 s total.

**Ejection alert.** `attempt's` inside a comment inside the single-quoted jq program ended the quote; the next `|` line is `syntax error near unexpected token '|'`. Reworded without apostrophes.

**Preflight `workflow-run-syntax` lane.** `bash -n` over every `run:` block of a changed `.github/workflows/*.yml` (`${{ }}` placeholdered, non-shell `shell:` steps skipped), reported at the offending file line. Must-fail control planted in `lanes-must-fail.test.sh` (fires on the exact defect above at line 14; clean and python steps contribute nothing).

**Side finding fixed.** `project-management/tests/tracker-routing-contract.test.sh` printed `FAIL: could not extract github-route` and then `all pass` — sed BRE treated `\(TRACKER=github\)` as a group so the start pattern never matched, and `fail` inside `$(...)` only left the subshell. ERE now (matching `require`), and an empty region fails the assertion. Control: a planted `linear.sh` line in the GitHub route now fails the run.

## Verification

- `worktree_remove_live_lease.sh` ×3 local, ×8 on a runner probe (all pass, no stall).
- `bash -n` over every `run:` block in `.github/workflows/*.yml`: clean.
- `skills/preflight/tests/*` 14/14; `tracker-routing-contract` passes and its must-fail control fires.
- `preflight --staged` on this diff: clean.

https://claude.ai/code/session_01BZkcou9yGoEPVijZUaQiTr
