### PR TITLE
fix(pi-agents-tmux): oneshot transcript appends are ordered (#1311)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,20 @@
   GitHub-route Linear-free check — its sed pattern was BRE (parens grouped,
   never matched) and the extraction failure inside `$(...)` could not stop
   the run. ERE now, and an empty region fails the assertion.
+- orch: `queue-wait` default budget is 2400s, sized to the merge-group suite
+  (VST-249); the budget-exhausted `queued` verdict now carries `progressing`
+  and a `cause` of `still_progressing` vs `stalled` from merge-queue-entry
+  movement or a still-running check-run on the merge-group head, so a caller
+  never re-arms a merge that is about to land.
+
+- github: every `git diff` scan in `git-diff-summary` — stats, `*.rs` risk
+  flags, and both panic-path scans — fails closed and loud when git fails
+  (unreadable tracked file, exit 128): a diagnostic naming the scan, the
+  arguments, and git's stderr, exit 1, no summary. Previously the panic scan
+  died bare, the test-path scan degraded to "no test panics", the risk-flag
+  scan to no unsafe/repr(C)/extern/atomics flags, and stats to a fabricated
+  "0 files changed" (VST-233); nested `{ }` inside `( )`/`[ ]` groups no
+  longer end an item early (VST-254).
 - pi-agents-tmux 2.8.2: oneshot transcript records are appended in event
   order (one ordered write chain instead of concurrent `appendFile` calls),
   so the last assistant text a consumer extracts is the last one written —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@
   GitHub-route Linear-free check — its sed pattern was BRE (parens grouped,
   never matched) and the extraction failure inside `$(...)` could not stop
   the run. ERE now, and an empty region fails the assertion.
+- pi-agents-tmux 2.8.2: oneshot transcript records are appended in event
+  order (one ordered write chain instead of concurrent `appendFile` calls),
+  so the last assistant text a consumer extracts is the last one written —
+  the out-of-order case surfaced as a merge-queue flake in
+  `session-lanes.test.ts`.
 - agents: the seven engineer/analyst agents (generalist, iced, planner,
   researcher, rust, scout, tpm) drop the house "never trust a green check"
   blockquote — the rule's canonical homes are `code-quality` § Prove Your

--- a/pi-extensions/pi-agents-tmux/CHANGELOG.md
+++ b/pi-extensions/pi-agents-tmux/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Consumer-impacting changes
 
+### 2.8.2
+
+- Oneshot transcript records are written strictly in event order. Each record was a separate concurrent `appendFile`, which land in any order under load, so a transcript could carry an earlier `message_end` after the final buffered partial and `getFinalOutput`/last-assistant-text extraction reported the wrong message (vstack#1311). Appends now run through one ordered chain (`createTranscriptAppender`); a failed write never blocks the next record.
+
 ### 2.8.1
 
 - Child spawning no longer trusts `process.argv[1]` as the pi entry (vstack#192). Previously any existing script in `argv[1]` was re-invoked as if it were pi, so a standalone harness/test that imported `runner.ts` directly and dispatched a subagent re-ran the harness recursively — an unbounded fork bomb. Self-re-invocation now requires a pi entry basename (`pi`, `pi.js`, `pi.mjs`, `pi.ts`, `cli.js`, `cli.mjs`, `cli.ts`) AND proven pi package identity: the nearest `package.json` above the realpathed entry must have `name` `@earendil-works/pi-coding-agent`, or its `pi` bin entry (object form, or string form on a package named `pi`) must itself resolve to the realpathed entry script — merely declaring a `pi` bin does not qualify. A missing manifest continues the walk upward; any other manifest read failure (EACCES etc.) rejects immediately. Anything else — including a harness literally named `cli.ts` — falls back to resolving `pi` on PATH. Compiled-binary (`/$bunfs`) and pi dev-mode behavior are unchanged.

--- a/pi-extensions/pi-agents-tmux/CHANGELOG.md
+++ b/pi-extensions/pi-agents-tmux/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 2.8.2
 
-- Oneshot transcript records are written strictly in event order. Each record was a separate concurrent `appendFile` call; such calls land in any order under load, so a transcript could carry an earlier `message_end` after the final buffered partial and `getFinalOutput`/last-assistant-text extraction reported the wrong message (vstack#1311). Appends now run through one ordered chain (`createTranscriptAppender`); a failed write never blocks the next record.
+- Oneshot transcript records are written strictly in event order. Each record was a separate concurrent `appendFile` call; such calls land in any order under load, so a transcript could carry an earlier `message_end` after the final buffered partial and `getFinalOutput`/last-assistant-text extraction reported the wrong message (vstack#1311). Appends now run through one ordered chain (`createTranscriptAppender`); a failed write never blocks the next record and surfaces on the result as a `transcript write failed` diagnostic instead of being dropped.
 
 ### 2.8.1
 

--- a/pi-extensions/pi-agents-tmux/CHANGELOG.md
+++ b/pi-extensions/pi-agents-tmux/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 2.8.2
 
-- Oneshot transcript records are written strictly in event order. Each record was a separate concurrent `appendFile`, which land in any order under load, so a transcript could carry an earlier `message_end` after the final buffered partial and `getFinalOutput`/last-assistant-text extraction reported the wrong message (vstack#1311). Appends now run through one ordered chain (`createTranscriptAppender`); a failed write never blocks the next record.
+- Oneshot transcript records are written strictly in event order. Each record was a separate concurrent `appendFile` call; such calls land in any order under load, so a transcript could carry an earlier `message_end` after the final buffered partial and `getFinalOutput`/last-assistant-text extraction reported the wrong message (vstack#1311). Appends now run through one ordered chain (`createTranscriptAppender`); a failed write never blocks the next record.
 
 ### 2.8.1
 

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/runner.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/runner.ts
@@ -408,6 +408,27 @@ export function detailsWithTruncation(details: SubagentDetails, prepared: Prepar
 	};
 }
 
+/**
+ * Append-only JSONL writer for one transcript. Records are written strictly in
+ * call order: each append starts after the previous one settles, because
+ * concurrent `appendFile` calls on one path complete in any order and a
+ * transcript whose records are out of order misreports the last assistant
+ * text (vstack#1311). A failed write never blocks the next one.
+ */
+export function createTranscriptAppender(
+	transcriptPath: string,
+	appendFile: (path: string, data: string) => Promise<void> = (p, data) => fs.promises.appendFile(p, data, { encoding: "utf-8" }),
+): { append: (record: Record<string, unknown>) => void; settled: () => Promise<void> } {
+	let chain: Promise<void> = Promise.resolve();
+	return {
+		append(record) {
+			const line = `${JSON.stringify({ ts: new Date().toISOString(), ...record })}\n`;
+			chain = chain.then(() => appendFile(transcriptPath, line)).catch(() => undefined);
+		},
+		settled: () => chain,
+	};
+}
+
 export async function runSingleAgent(
 	defaultCwd: string,
 	runtimeRoot: string,
@@ -588,15 +609,8 @@ async function runSingleAgentAttempt(
 	let tmpPromptPath: string | null = null;
 	const oneShotTaskId = createTaskId(agent.name);
 	const transcriptPath = oneShotTranscriptPath(runtimeRoot, agent.name, oneShotTaskId);
-	const transcriptWrites: Promise<unknown>[] = [];
-
-	const appendTranscript = (record: Record<string, unknown>) => {
-		transcriptWrites.push(
-			fs.promises
-				.appendFile(transcriptPath, `${JSON.stringify({ ts: new Date().toISOString(), ...record })}\n`, { encoding: "utf-8" })
-				.catch(() => undefined),
-		);
-	};
+	const transcript = createTranscriptAppender(transcriptPath);
+	const appendTranscript = transcript.append;
 
 	const currentResult: SingleResult = {
 		agent: agentName,
@@ -798,7 +812,7 @@ async function runSingleAgentAttempt(
 				clearSettledCloseTimer();
 				clearAbortCloseTimer();
 				if (signal && abortListener) signal.removeEventListener("abort", abortListener);
-				Promise.allSettled(transcriptWrites).finally(() => resolve(code));
+				transcript.settled().finally(() => resolve(code));
 			};
 
 			const scheduleKillEscalation = (onSignal?: (outcomes: SignalOutcome[]) => void) => {
@@ -1299,7 +1313,7 @@ async function runSingleAgentAttempt(
 		});
 		return currentResult;
 	} finally {
-		await Promise.allSettled(transcriptWrites);
+		await transcript.settled();
 		// vstack#192: recursive+force removal so the session tmp dir is reclaimed
 		// on child failure/refusal paths too, not only after a clean unlink.
 		if (tmpPromptDir) removePromptTempDir(tmpPromptDir);

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/runner.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/runner.ts
@@ -418,12 +418,13 @@ export function detailsWithTruncation(details: SubagentDetails, prepared: Prepar
 export function createTranscriptAppender(
 	transcriptPath: string,
 	appendFile: (path: string, data: string) => Promise<void> = (p, data) => fs.promises.appendFile(p, data, { encoding: "utf-8" }),
+	onError: (error: unknown) => void = () => undefined,
 ): { append: (record: Record<string, unknown>) => void; settled: () => Promise<void> } {
 	let chain: Promise<void> = Promise.resolve();
 	return {
 		append(record) {
 			const line = `${JSON.stringify({ ts: new Date().toISOString(), ...record })}\n`;
-			chain = chain.then(() => appendFile(transcriptPath, line)).catch(() => undefined);
+			chain = chain.then(() => appendFile(transcriptPath, line)).catch((error) => onError(error));
 		},
 		settled: () => chain,
 	};
@@ -609,7 +610,11 @@ async function runSingleAgentAttempt(
 	let tmpPromptPath: string | null = null;
 	const oneShotTaskId = createTaskId(agent.name);
 	const transcriptPath = oneShotTranscriptPath(runtimeRoot, agent.name, oneShotTaskId);
-	const transcript = createTranscriptAppender(transcriptPath);
+	// A dropped record leaves the transcript incomplete for whoever reads the
+	// final answer out of it, so a write failure surfaces on the result.
+	const transcript = createTranscriptAppender(transcriptPath, undefined, (error) =>
+		appendResultDiagnostic(currentResult, `transcript write failed (${transcriptPath}): ${stringifyError(error)}`),
+	);
 	const appendTranscript = transcript.append;
 
 	const currentResult: SingleResult = {
@@ -929,8 +934,9 @@ async function runSingleAgentAttempt(
 				// format moved -- skipping it on any path restores the silent failure this
 				// accumulator exists to prevent.
 				const diagnostic = partialAssistantMessageDiagnostic(partialMessageState);
-				// Route through result diagnostics, not the transcript alone: appendTranscript drops
-				// write failures, so a transcript-only signal has no second chance to surface.
+				// Route through result diagnostics, not the transcript alone: a failed
+				// transcript write is itself only a diagnostic, so a transcript-only
+				// signal has no second chance to surface.
 				const emitDiagnostic = () => {
 					if (!diagnostic) return;
 					appendResultDiagnostic(currentResult, diagnostic);

--- a/pi-extensions/pi-agents-tmux/package.json
+++ b/pi-extensions/pi-agents-tmux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vanillagreen/pi-agents-tmux",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "description": "Pi extension for delegating work to project or user agents, including persistent tmux agent panes.",
   "license": "MIT",
   "keywords": [

--- a/pi-extensions/pi-agents-tmux/tests/transcript-appender.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/transcript-appender.test.ts
@@ -30,18 +30,20 @@ test("transcript records land in call order when an earlier write finishes late"
 	assert.deepEqual(order, [1, 2]);
 });
 
-test("a failed write does not block the next record", async () => {
+test("a failed write is reported and does not block the next record", async () => {
 	let landed = "";
 	let call = 0;
+	const errors: string[] = [];
 	const appendFile = (_path: string, data: string): Promise<void> => {
 		call += 1;
 		if (call === 1) return Promise.reject(new Error("disk full"));
 		landed += data;
 		return Promise.resolve();
 	};
-	const appender = createTranscriptAppender("/dev/null", appendFile);
+	const appender = createTranscriptAppender("/dev/null", appendFile, (error) => errors.push(String(error)));
 	appender.append({ n: 1 });
 	appender.append({ n: 2 });
 	await appender.settled();
 	assert.deepEqual(landed.trim().split("\n").map((line) => JSON.parse(line).n), [2]);
+	assert.deepEqual(errors, ["Error: disk full"]);
 });

--- a/pi-extensions/pi-agents-tmux/tests/transcript-appender.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/transcript-appender.test.ts
@@ -20,8 +20,10 @@ test("transcript records land in call order when an earlier write finishes late"
 	const appender = createTranscriptAppender("/dev/null", appendFile);
 	appender.append({ n: 1 });
 	appender.append({ n: 2 });
-	// No wall-clock wait: a non-serialized appender issues write 2 synchronously
-	// inside append(), so it has already landed by the time write 1 is released.
+	// A macrotask boundary drains every queued promise callback deterministically:
+	// the ordered appender has now issued write 1 (and only write 1); a
+	// non-serialized one issued both synchronously and write 2 already landed.
+	await new Promise((resolve) => setImmediate(resolve));
 	for (const r of release) r();
 	await appender.settled();
 	const order = landed.trim().split("\n").map((line) => JSON.parse(line).n);

--- a/pi-extensions/pi-agents-tmux/tests/transcript-appender.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/transcript-appender.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { test } from "bun:test";
+import { createTranscriptAppender } from "../extensions/subagent/runner.js";
+
+// Concurrent appendFile calls on one path land in any order; the appender must
+// write records strictly in call order even when an earlier write is slow.
+test("transcript records land in call order when an earlier write finishes late", async () => {
+	let landed = "";
+	let call = 0;
+	const release: Array<() => void> = [];
+	const appendFile = (_path: string, data: string): Promise<void> => {
+		call += 1;
+		if (call === 1) {
+			// The first write stalls until released after the second was requested.
+			return new Promise<void>((resolve) => release.push(() => { landed += data; resolve(); }));
+		}
+		landed += data;
+		return Promise.resolve();
+	};
+	const appender = createTranscriptAppender("/dev/null", appendFile);
+	appender.append({ n: 1 });
+	appender.append({ n: 2 });
+	// Let the microtask queue run so a non-serialized appender would have issued both writes.
+	await new Promise((resolve) => setTimeout(resolve, 5));
+	for (const r of release) r();
+	await appender.settled();
+	const order = landed.trim().split("\n").map((line) => JSON.parse(line).n);
+	assert.deepEqual(order, [1, 2]);
+});
+
+test("a failed write does not block the next record", async () => {
+	let landed = "";
+	let call = 0;
+	const appendFile = (_path: string, data: string): Promise<void> => {
+		call += 1;
+		if (call === 1) return Promise.reject(new Error("disk full"));
+		landed += data;
+		return Promise.resolve();
+	};
+	const appender = createTranscriptAppender("/dev/null", appendFile);
+	appender.append({ n: 1 });
+	appender.append({ n: 2 });
+	await appender.settled();
+	assert.deepEqual(landed.trim().split("\n").map((line) => JSON.parse(line).n), [2]);
+});

--- a/pi-extensions/pi-agents-tmux/tests/transcript-appender.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/transcript-appender.test.ts
@@ -20,8 +20,8 @@ test("transcript records land in call order when an earlier write finishes late"
 	const appender = createTranscriptAppender("/dev/null", appendFile);
 	appender.append({ n: 1 });
 	appender.append({ n: 2 });
-	// Let the microtask queue run so a non-serialized appender would have issued both writes.
-	await new Promise((resolve) => setTimeout(resolve, 5));
+	// No wall-clock wait: a non-serialized appender issues write 2 synchronously
+	// inside append(), so it has already landed by the time write 1 is released.
 	for (const r of release) r();
 	await appender.settled();
 	const order = landed.trim().split("\n").map((line) => JSON.parse(line).n);


### PR DESCRIPTION
## Why

Merge-queue run 31919418872 (a group for #1309) failed the node shard at `pi-agents-tmux/tests/session-lanes.test.ts:488`: the buffered partial (`second message`) was present and correct, yet the last-assistant-text extraction returned `first message`. Passes locally 5/5 and passed the previous queue run — a scheduling race, and a real product defect: the transcript is what consumers read to extract a oneshot's final answer.

## What

`appendTranscript` (`extensions/subagent/runner.ts`) issued one concurrent `fs.promises.appendFile` per record and only collected the promises. Concurrent appends to one path complete in any order, so under load an earlier `message_end` could land after the final buffered partial. Records now go through one ordered chain — `createTranscriptAppender(path, appendFile?)` — awaited where the write list was awaited before; a failed write never blocks the next.

- `tests/transcript-appender.test.ts`: order is preserved when an earlier write finishes late (control: against the parallel shape it fails with `[2,1]` vs `[1,2]`); a failed write does not block the next record.
- pi-agents-tmux 2.8.2 + CHANGELOG (consumer-impacting: transcript order); root CHANGELOG entry.

Closes #1311

## Verification

`bun test` (pi-agents-tmux): 347 pass, 0 fail. `preflight --staged`: clean.

https://claude.ai/code/session_01BZkcou9yGoEPVijZUaQiTr
