### PR TITLE
fix(cli): TUI Updates tab lists every stale install and refreshes each from its own source (#1310)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,18 @@
   and merge-pr routes it to comment triage and re-enqueue. Default on;
   `--no-guard` opts out. Failed reads are never quiet; failed dequeues are
   loud and distinct.
+- cli: the TUI's Updates tab lists every stale install in either scope —
+  the same set `vstack check` reports — whatever source is selected, and
+  updating from it refreshes each item from its own recorded source (per
+  scope, as `vstack refresh` does), recording that source's identity; an
+  item whose source is gone is reported instead of silently skipped, and a
+  recorded source that vanished is reported missing rather than silently
+  rebound to the only other source (in `vstack refresh` too, whose lock
+  repair now applies only to entries that never recorded a usable source);
+  a stale extra picked there is reported as re-applied via `vstack apply`,
+  not silently skipped. The source registry also drops per-project choices
+  whose project root no longer exists, including Windows drive-letter and
+  UNC roots (#1310).
 - orch oversee: unattended by default (#1290). Minted briefs route blocking
   questions to the overseer via harness session-messaging where available
   (local question tool still used); the watch checks tmux lanes for pending

--- a/cli/src/commands/refresh.rs
+++ b/cli/src/commands/refresh.rs
@@ -160,7 +160,13 @@ fn observed_source_repo_for_lock_entry(
     config::parse_github_slug(&entry.source).map(Some)
 }
 
-fn sync_lock_entry_source_repo(source_records: &[ResolvedSource], entry: &mut config::LockEntry) {
+/// Record the durable repo identity of the source `entry` was just refreshed
+/// from — its own source, never whichever source a caller happened to have
+/// selected.
+pub(crate) fn sync_lock_entry_source_repo(
+    source_records: &[ResolvedSource],
+    entry: &mut config::LockEntry,
+) {
     if let Some(source_repo) = observed_source_repo_for_lock_entry(source_records, entry) {
         entry.source_repo = source_repo;
     }

--- a/cli/src/commands/refresh.rs
+++ b/cli/src/commands/refresh.rs
@@ -83,12 +83,23 @@ impl RefreshStats {
         });
     }
 
-    /// Record that `item` has no asset to refresh from. `source` is the source
-    /// root it resolved to, or `None` when no source resolved at all.
-    fn mark_missing(&mut self, item: &str, source: Option<&Path>) {
-        let reason = match source {
-            Some(root) => format!("not found in source {}", root.display()),
-            None => "source not found".to_string(),
+    /// Record that `item` has no asset to refresh from: its source resolved
+    /// to `root` but does not carry the asset.
+    fn mark_missing(&mut self, item: &str, root: &Path) {
+        self.missing.insert(
+            item.to_string(),
+            format!("not found in source {}", root.display()),
+        );
+    }
+
+    /// Record that `item`'s recorded source did not resolve to any loaded
+    /// source. The reason names what the lock recorded so the user can see
+    /// which source vanished (or that none was ever recorded).
+    fn mark_source_missing(&mut self, item: &str, recorded_source: &str) {
+        let reason = if recorded_source.trim().is_empty() {
+            "source not found (none recorded)".to_string()
+        } else {
+            format!("source not found: {recorded_source}")
         };
         self.missing.insert(item.to_string(), reason);
     }
@@ -284,11 +295,11 @@ pub fn refresh_items_in_scope(
             continue;
         }
         let Some(source) = refresh_source_for_entry(sources, entry) else {
-            stats.mark_missing(name, None);
+            stats.mark_source_missing(name, &entry.source);
             continue;
         };
         let Some(agent) = source.agents.iter().find(|a| &a.name == name) else {
-            stats.mark_missing(name, Some(&source.root));
+            stats.mark_missing(name, &source.root);
             continue;
         };
 
@@ -411,11 +422,11 @@ pub fn refresh_items_in_scope(
         .filter(|(n, _)| pass(n))
     {
         let Some(source) = refresh_source_for_entry(sources, entry) else {
-            stats.mark_missing(name, None);
+            stats.mark_source_missing(name, &entry.source);
             continue;
         };
         let Some(skill) = source.skills.iter().find(|s| &s.name == name) else {
-            stats.mark_missing(name, Some(&source.root));
+            stats.mark_missing(name, &source.root);
             continue;
         };
 
@@ -487,11 +498,11 @@ pub fn refresh_items_in_scope(
         .filter(|(n, _)| pass(n))
     {
         let Some(source) = refresh_source_for_entry(sources, entry) else {
-            stats.mark_missing(name, None);
+            stats.mark_source_missing(name, &entry.source);
             continue;
         };
         let Some(hook) = source.hooks.iter().find(|hook| hook.name == entry.name) else {
-            stats.mark_missing(name, Some(&source.root));
+            stats.mark_missing(name, &source.root);
             continue;
         };
         let mut succeeded = 0usize;
@@ -526,11 +537,11 @@ pub fn refresh_items_in_scope(
         .filter(|(n, _)| pass(n))
     {
         let Some(source) = refresh_source_for_entry(sources, entry) else {
-            stats.mark_missing(name, None);
+            stats.mark_source_missing(name, &entry.source);
             continue;
         };
         let Some(ext) = source_pi_extension_for_lock_name(&source.pi_extensions, name) else {
-            stats.mark_missing(name, Some(&source.root));
+            stats.mark_missing(name, &source.root);
             continue;
         };
         match crate::pi_extension::install_pi_extension(ext, global) {
@@ -1260,10 +1271,10 @@ fn run_one(global: bool, verbose: bool) -> Result<()> {
         }
     }
 
-    // Update lock file timestamps and content hashes. Also repair stale source
-    // paths: if an entry's recorded source no longer resolves but we found a
-    // working source via CWD/registry fallback, rewrite the entry's source so
-    // future refresh/staleness checks use the valid path.
+    // Update lock file timestamps and content hashes. Also repair legacy
+    // placeholder sources: an entry that recorded no usable source (see
+    // `may_rebind_to_fallback_source`) is pointed at the source we found via
+    // CWD/registry fallback so future refresh/staleness checks use a real path.
     let mut lock = config::LockFile::load(&lock_path)?;
     let now = config::now_iso();
     let fallback_source = source_dirs.first().map(|p| p.display().to_string());
@@ -1287,13 +1298,14 @@ fn run_one(global: bool, verbose: bool) -> Result<()> {
         let source_resolved = source_records
             .iter()
             .any(|source| source.aliases.iter().any(|alias| alias == &entry.source));
-        // Repair only a source that has genuinely gone away. An entry whose
-        // recorded source still exists keeps it even when nothing else in the
+        // Repair only a legacy placeholder. A recorded path or remote keeps
+        // its source even when it no longer resolves or nothing else in the
         // lock references it: rewriting it here is what silently re-pointed
-        // alternate-source entries at the majority source and undid every
-        // hand-correction of the lock.
+        // entries at the majority source, undid every hand-correction of the
+        // lock, and would refresh a vanished-source entry from a source it was
+        // never installed from on the next run.
         if !source_resolved
-            && !crate::refresh_sources::recorded_source_exists(&entry.source)
+            && crate::refresh_sources::may_rebind_to_fallback_source(&entry.source)
             && let Some(replacement) = &fallback_source
             && &entry.source != replacement
         {

--- a/cli/src/commands/refresh/tests.rs
+++ b/cli/src/commands/refresh/tests.rs
@@ -1178,11 +1178,118 @@ fn refresh_reports_missing_when_the_recorded_source_is_not_loaded() {
     assert_eq!(stats.skills_refreshed, 0);
     assert_eq!(
         stats.missing.get("shared").map(String::as_str),
-        Some("source not found")
+        Some(format!("source not found: {}", alternate.display()).as_str())
     );
     assert!(
         !project.join(".claude/skills/shared/SKILL.md").exists(),
         "must not install from a source the entry was never installed from"
+    );
+
+    let _ = std::fs::remove_dir_all(root);
+}
+
+/// A recorded source that vanished is not a legacy placeholder: with exactly
+/// one other source loaded that carries a same-named asset, the entry must be
+/// reported missing (naming the vanished source), never refreshed from the
+/// unrelated source — that would silently replace the real asset.
+#[test]
+fn refresh_reports_missing_instead_of_rebinding_a_vanished_source() {
+    let root = tmpdir("vanished-source");
+    let project = root.join("project");
+    let loaded = make_source(&root, "loaded");
+    let gone = root.join("gone");
+    std::fs::create_dir_all(&project).unwrap();
+    write_colliding_source(&loaded, "1", "PreToolUse", "source-model");
+
+    let mut lock = LockFile::default();
+    lock.add(lock_entry(
+        "shared",
+        ItemKind::Skill,
+        &gone,
+        vec!["claude-code"],
+    ));
+    let sources = vec![RefreshSource::from_root(&loaded)];
+
+    let stats = crate::test_util::with_project_root(&project, || {
+        let mut project_config = ProjectConfig::default();
+        refresh_items_in_scope(false, &lock, &sources, &mut project_config, &project, None)
+    });
+
+    assert_eq!(stats.skills_refreshed, 0);
+    assert!(!stats.successful_items.contains("shared"));
+    assert_eq!(
+        stats.missing.get("shared").map(String::as_str),
+        Some(format!("source not found: {}", gone.display()).as_str())
+    );
+    assert!(
+        !project.join(".claude/skills/shared/SKILL.md").exists(),
+        "must not install the same-named asset from a source the entry was never installed from"
+    );
+
+    let _ = std::fs::remove_dir_all(root);
+}
+
+/// `vstack refresh`'s lock repair must follow the same rule: a vanished
+/// recorded source keeps its recorded value (the run reports it missing) —
+/// rewriting it to the sole other source would refresh the entry from that
+/// source on the very next run.
+#[test]
+fn refresh_command_keeps_a_vanished_source_recorded_instead_of_repairing_it_away() {
+    let root = tmpdir("vanished-source-no-repair");
+    let project = root.join("project");
+    let live = make_source(&root, "live");
+    let gone = root.join("gone");
+    std::fs::create_dir_all(&project).unwrap();
+    // `live` carries a hook named `guard` too — the same-named asset a rebind
+    // would have installed.
+    write_colliding_source(&live, "1", "PreToolUse", "source-model");
+
+    let mut lock = LockFile::default();
+    lock.add(lock_entry(
+        "shared",
+        ItemKind::Skill,
+        &live,
+        vec!["claude-code"],
+    ));
+    lock.add(lock_entry(
+        "guard",
+        ItemKind::Hook,
+        &gone,
+        vec!["claude-code"],
+    ));
+    lock.save(&project.join(".vstack-lock.json")).unwrap();
+
+    // Canonical dir for the live entry so lock/disk reconciliation keeps it
+    // in the lock (it is what makes `live` the sole resolved source).
+    std::fs::create_dir_all(project.join(".agents/skills/shared")).unwrap();
+
+    let result = crate::test_util::with_project_root(&project, || {
+        run(crate::scope::ScopeFilter::Project, false)
+    });
+    assert!(result.is_err(), "a missing entry must fail the run");
+
+    let after = LockFile::load(&project.join(".vstack-lock.json")).unwrap();
+    assert_eq!(
+        after.entries["guard"].source,
+        gone.to_string_lossy(),
+        "vanished source must stay recorded, not be repaired to the other source"
+    );
+    assert!(
+        after.entries["guard"].source_hash.is_empty(),
+        "an entry that was not refreshed must not be stamped"
+    );
+    assert!(
+        project.join(".claude/skills/shared/SKILL.md").exists(),
+        "the live entry still refreshes"
+    );
+    let settings = project.join(".claude/settings.json");
+    let hook_installed = settings.exists()
+        && std::fs::read_to_string(&settings)
+            .unwrap()
+            .contains("guard");
+    assert!(
+        !hook_installed,
+        "the same-named hook must not be installed from the unrelated source"
     );
 
     let _ = std::fs::remove_dir_all(root);

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -184,8 +184,9 @@ impl SourceRegistry {
 
     /// Drop entries that look like local filesystem paths but no longer exist.
     /// Remote shorthand entries (e.g. "owner/repo", "https://...") are
-    /// preserved unconditionally — they're not paths to check. Returns the
-    /// number of entries removed.
+    /// preserved unconditionally — they're not paths to check. A per-project
+    /// choice is dropped when either side is a dead path: its source, or the
+    /// project root it was recorded for. Returns the number of entries removed.
     pub fn prune_dead_paths(&mut self) -> usize {
         let before = self.entries.len();
         self.entries.retain(|entry| !is_dead_local_path(entry));
@@ -196,7 +197,7 @@ impl SourceRegistry {
         }
         let before_project = self.project_current.len();
         self.project_current
-            .retain(|_, source| !is_dead_local_path(source));
+            .retain(|project, source| !is_dead_local_path(project) && !is_dead_local_path(source));
         before - self.entries.len() + before_project - self.project_current.len()
     }
 
@@ -2388,6 +2389,42 @@ mod source_registry_tests {
         assert!(reg.entries.contains(&"owner/b".to_string()));
         let _ = fs::remove_dir_all(&project_a);
         let _ = fs::remove_dir_all(&project_b);
+    }
+
+    /// A per-project source choice outlives its project (deleted worktree,
+    /// vanished temp checkout): the KEY is a dead path even when the value is
+    /// a remote shorthand that never dies. Both sides are checked; a live
+    /// project keeps its remote choice untouched.
+    #[test]
+    fn prune_drops_project_current_keys_for_vanished_projects() {
+        let dir = sandbox("prune_project_current_keys");
+        let live_project = dir.join("live-project");
+        fs::create_dir_all(&live_project).unwrap();
+        let dead_project = dir.join("dead-project");
+        // dead_project is intentionally not created.
+
+        let mut reg = SourceRegistry::default();
+        reg.remember_for_project(&live_project, "vanillagreencom/vstack");
+        reg.project_current.insert(
+            dead_project.display().to_string(),
+            "vanillagreencom/vstack".to_string(),
+        );
+
+        let pruned = reg.prune_dead_paths();
+
+        assert_eq!(pruned, 1);
+        assert_eq!(
+            reg.current_for_project(&live_project),
+            Some("vanillagreencom/vstack")
+        );
+        assert!(
+            !reg.project_current
+                .contains_key(&dead_project.display().to_string()),
+            "vanished project key must be dropped: {:?}",
+            reg.project_current
+        );
+        assert_eq!(reg.entries, vec!["vanillagreencom/vstack".to_string()]);
+        let _ = fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -343,8 +343,13 @@ pub(crate) fn is_project_self_non_source(entry: &str, project_root: &Path) -> bo
         && !crate::resolve::has_vstack_source_content(project_root)
 }
 
+/// The local-path shapes a registry entry or project key can take: absolute
+/// for the running platform (`/…` on Unix; `C:\…` and `\\server\share\…` on
+/// Windows), `~`-tilde, or relative starting with `.`. Remote shorthand
+/// (`owner/repo`) and URLs are never paths.
 fn expanded_local_path(entry: &str) -> Option<PathBuf> {
-    let looks_like_path = entry.starts_with('/')
+    let looks_like_path = Path::new(entry).is_absolute()
+        || entry.starts_with('/')
         || entry.starts_with('~')
         || entry.starts_with("./")
         || entry.starts_with("../");
@@ -2424,6 +2429,63 @@ mod source_registry_tests {
             reg.project_current
         );
         assert_eq!(reg.entries, vec!["vanillagreencom/vstack".to_string()]);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// Path-likeness follows the running platform's notion of an absolute
+    /// path, so a dead Windows drive-letter or UNC key/source is pruned like a
+    /// dead `/…` one. Remote shorthand and URLs are never paths on any platform.
+    #[test]
+    fn prune_recognizes_platform_absolute_paths_and_never_prunes_remotes() {
+        #[cfg(windows)]
+        {
+            let mut reg = SourceRegistry::default();
+            reg.entries.push(r"C:\vanished-source".to_string());
+            reg.project_current.insert(
+                r"C:\vanished-project".to_string(),
+                "vanillagreencom/vstack".to_string(),
+            );
+            reg.project_current.insert(
+                r"\\server\share\vanished-project".to_string(),
+                "vanillagreencom/vstack".to_string(),
+            );
+            assert_eq!(reg.prune_dead_paths(), 3);
+            assert!(reg.entries.is_empty(), "{:?}", reg.entries);
+            assert!(reg.project_current.is_empty(), "{:?}", reg.project_current);
+        }
+        #[cfg(unix)]
+        {
+            assert!(expanded_local_path("/vanished").is_some());
+            assert!(is_dead_local_path("/vanished/never/existed"));
+        }
+        for remote in [
+            "vanillagreencom/vstack",
+            "https://example.com/repo",
+            "git@github.com:owner/repo.git",
+        ] {
+            assert!(
+                expanded_local_path(remote).is_none(),
+                "{remote:?} is not a path"
+            );
+        }
+
+        let dir = sandbox("prune_remotes_untouched");
+        let mut reg = SourceRegistry {
+            current: Some("vanillagreencom/vstack".to_string()),
+            entries: vec![
+                "vanillagreencom/vstack".to_string(),
+                "https://example.com/repo".to_string(),
+                "git@github.com:owner/repo.git".to_string(),
+            ],
+            ..Default::default()
+        };
+        reg.remember_for_project(&dir, "https://example.com/repo");
+        let before = reg.clone();
+
+        assert_eq!(reg.prune_dead_paths(), 0);
+        assert_eq!(reg.entries, before.entries);
+        assert_eq!(reg.current, before.current);
+        assert_eq!(reg.project_current, before.project_current);
         let _ = fs::remove_dir_all(&dir);
     }
 

--- a/cli/src/refresh_sources.rs
+++ b/cli/src/refresh_sources.rs
@@ -162,17 +162,41 @@ pub(crate) fn refresh_source_for_entry<'a>(
         return Some(source);
     }
 
-    // Legacy/moved-source fallback: an old lock may record a source string
-    // that no longer names anything on disk (a renamed repo, or a pre-1.0 lock
-    // with no meaningful source). Those may fall back to the sole loaded
-    // source. An entry whose own recorded source still exists must never be
-    // rebound to a different one — that silently reinstalled such entries from
-    // the wrong repo and masked the real source's edits.
-    if sources.len() == 1 && !recorded_source_exists(&entry.source) {
+    // Legacy fallback: an entry that recorded no usable source at all may bind
+    // to the sole loaded source. A recorded path or remote that merely no
+    // longer resolves must not — see `may_rebind_to_fallback_source`.
+    if sources.len() == 1 && may_rebind_to_fallback_source(&entry.source) {
         sources.first()
     } else {
         None
     }
+}
+
+/// Whether an entry may be bound to a source it did not record.
+///
+/// Only a legacy placeholder qualifies: an empty source, or a bare token that
+/// is neither path-like (`/…`, `~…`, `.`, `./…`, `../…`) nor remote-like
+/// (`owner/repo`, a URL) — the shapes pre-1.0 locks and disk recovery wrote
+/// when no source was known — and only while that token does not name a live
+/// project-relative directory. A recorded path or remote that no longer
+/// resolves stays bound to what it recorded and is reported missing:
+/// rebinding it would refresh the entry from a source it was never installed
+/// from, and a same-named asset there would silently replace the real one.
+pub(crate) fn may_rebind_to_fallback_source(source: &str) -> bool {
+    is_legacy_placeholder_source(source) && !recorded_source_exists(source)
+}
+
+fn is_legacy_placeholder_source(source: &str) -> bool {
+    let source = source.trim();
+    if source.is_empty() {
+        return true;
+    }
+    let path_like = Path::new(source).is_absolute()
+        || source.starts_with('~')
+        || is_explicit_relative_local_source(source)
+        || source == "..";
+    let remote_like = source.contains('/') || source.contains("://") || source.contains('@');
+    !path_like && !remote_like
 }
 
 pub(crate) fn all_source_hooks(sources: &[RefreshSource]) -> Vec<Hook> {
@@ -596,11 +620,12 @@ mod tests {
         let _ = std::fs::remove_dir_all(root);
     }
 
-    /// An entry whose own source still exists must never be silently rebound to
-    /// the sole other loaded source; that reinstalled it from the wrong repo.
-    /// The fallback stays available for a source that has genuinely gone away.
+    /// An entry that recorded a real source — live or vanished — must never be
+    /// silently rebound to the sole other loaded source; that reinstalled it
+    /// from a repo it was never installed from (a same-named asset there
+    /// replaced the real one). A vanished source is reported missing instead.
     #[test]
-    fn refresh_source_for_entry_only_falls_back_when_the_recorded_source_is_gone() {
+    fn refresh_source_for_entry_never_rebinds_a_recorded_source() {
         let root = tmpdir("no-rebind");
         let alternate = root.join(".agents");
         std::fs::create_dir_all(alternate.join("skills/demo")).unwrap();
@@ -614,10 +639,90 @@ mod tests {
         );
 
         let vanished = lock_entry("demo", &root.join("deleted-repo").to_string_lossy());
-        assert_eq!(
-            refresh_source_for_entry(&sources, &vanished).map(|s| s.root.clone()),
-            Some(only_source),
-            "legacy lock with a missing source keeps the single-source fallback"
+        assert!(
+            refresh_source_for_entry(&sources, &vanished).is_none(),
+            "a recorded absolute source that vanished must not bind to a different source"
+        );
+
+        let uncached_remote = lock_entry("demo", "owner/repo");
+        assert!(
+            refresh_source_for_entry(&sources, &uncached_remote).is_none(),
+            "a recorded remote that did not resolve must not bind to a local source"
+        );
+
+        let project = root.join("project");
+        std::fs::create_dir_all(&project).unwrap();
+        let vanished_relative = lock_entry("demo", "./vendor/gone");
+        crate::test_util::with_project_root(&project, || {
+            assert!(
+                refresh_source_for_entry(&sources, &vanished_relative).is_none(),
+                "a recorded relative source that vanished must not bind to a different source"
+            );
+        });
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    /// The fallback exists for locks that recorded no usable source at all:
+    /// an empty source (disk recovery into an empty lock) or a bare
+    /// placeholder token (pre-1.0 hash/reconcile paths). Even those bind only
+    /// while exactly one source is loaded and the token names no live
+    /// project-relative directory.
+    #[test]
+    fn refresh_source_for_entry_falls_back_only_for_legacy_placeholder_sources() {
+        let root = tmpdir("legacy-placeholder");
+        let project = root.join("project");
+        std::fs::create_dir_all(&project).unwrap();
+        let only_source = make_vstack_source(&root, "other");
+        let sources = vec![RefreshSource::from_root(&only_source)];
+
+        crate::test_util::with_project_root(&project, || {
+            for placeholder in ["", "source"] {
+                assert_eq!(
+                    refresh_source_for_entry(&sources, &lock_entry("demo", placeholder))
+                        .map(|s| s.root.clone()),
+                    Some(only_source.clone()),
+                    "legacy placeholder {placeholder:?} keeps the single-source fallback"
+                );
+            }
+
+            std::fs::create_dir_all(project.join("source")).unwrap();
+            assert!(
+                refresh_source_for_entry(&sources, &lock_entry("demo", "source")).is_none(),
+                "a bare token that names a live project-relative dir is a real source"
+            );
+
+            for legacy in ["", "  ", "local"] {
+                assert!(
+                    may_rebind_to_fallback_source(legacy),
+                    "{legacy:?} is a legacy placeholder"
+                );
+            }
+            for recorded in [
+                "/gone/checkout",
+                "~/gone",
+                ".",
+                "./gone",
+                "../gone",
+                "owner/repo",
+                "https://github.com/owner/repo.git",
+                "git@github.com:owner/repo.git",
+            ] {
+                assert!(
+                    !may_rebind_to_fallback_source(recorded),
+                    "{recorded:?} is a recorded source, never rebound"
+                );
+            }
+        });
+
+        let second = make_vstack_source(&root, "second");
+        let two_sources = vec![
+            RefreshSource::from_root(&only_source),
+            RefreshSource::from_root(&second),
+        ];
+        assert!(
+            refresh_source_for_entry(&two_sources, &lock_entry("demo", "")).is_none(),
+            "no fallback when more than one source is loaded"
         );
 
         let _ = std::fs::remove_dir_all(root);

--- a/cli/src/tui/disk_mutations.rs
+++ b/cli/src/tui/disk_mutations.rs
@@ -30,6 +30,15 @@ impl DiskMutationReport {
     fn fail(&mut self, item: &str, err: impl std::fmt::Display) {
         self.failed.push(format!("{item}: {err}"));
     }
+
+    /// Record an item that was deliberately not attempted. A skip is a
+    /// notice, never a failure: it must not veto follow-up work gated on
+    /// `failed` (the CLI update behind an "Update All"), and it leaves
+    /// `attempted` so the completed/attempted ratio counts only real tries.
+    fn skip(&mut self, item: &str, why: impl std::fmt::Display) {
+        self.attempted = self.attempted.saturating_sub(1);
+        self.notices.push(format!("skipped {item}: {why}"));
+    }
 }
 
 /// Resolve a lock entry's harness id list to the set that actually supports
@@ -557,7 +566,10 @@ pub(super) fn perform_inline_update(names: &[String]) -> DiskMutationReport {
         };
         // Extras are applied, not installed: the refresh pass has no branch
         // for them, so a requested extra would count as neither done nor
-        // failed. Say so, and keep it out of the refresh below.
+        // failed. Skip it with a notice — not a failure: a failure would
+        // veto the CLI update queued behind the same "Update All", and a
+        // stale extra stays stale until re-applied, so it would veto every
+        // one after it too.
         let is_extra = |name: &String| {
             lock.entries
                 .get(name)
@@ -565,9 +577,9 @@ pub(super) fn perform_inline_update(names: &[String]) -> DiskMutationReport {
         };
         for name in names.iter().filter(|name| is_extra(name)) {
             if extras_reported.insert(name.clone()) {
-                report.fail(
+                report.skip(
                     name,
-                    format!("extras are not refreshed here — reapply with `vstack apply {name}`"),
+                    format!("extras are reapplied with `vstack apply {name}`"),
                 );
             }
         }

--- a/cli/src/tui/disk_mutations.rs
+++ b/cli/src/tui/disk_mutations.rs
@@ -643,9 +643,18 @@ pub(super) fn perform_inline_update(names: &[String]) -> DiskMutationReport {
         }
         // An entry whose source is gone (or no longer carries it) is not
         // refreshed; without this it would count as neither done nor failed
-        // and the flash would read "Updated 0 item(s)".
+        // and the flash would read "Updated 0 item(s)". Agents the hook
+        // update pulled in on its own are named as such — the user never
+        // asked for them, but their stale payload is a real outcome.
         for (item, reason) in &stats.missing {
-            report.fail(item, format!("not refreshed: {reason}"));
+            if names.contains(item) {
+                report.fail(item, format!("not refreshed: {reason}"));
+            } else {
+                report.fail(
+                    item,
+                    format!("agent not regenerated after hook update: {reason}"),
+                );
+            }
         }
 
         let now = config::now_iso();

--- a/cli/src/tui/disk_mutations.rs
+++ b/cli/src/tui/disk_mutations.rs
@@ -547,6 +547,7 @@ fn reinstall_codex_hooks_for_moved_agents(
 pub(super) fn perform_inline_update(names: &[String]) -> DiskMutationReport {
     let mut report = DiskMutationReport::new(names.len());
     let mut completed_names = std::collections::HashSet::new();
+    let mut extras_reported = std::collections::HashSet::new();
     let project_root = config::project_root();
 
     for scope_global in [false, true] {
@@ -554,6 +555,28 @@ pub(super) fn perform_inline_update(names: &[String]) -> DiskMutationReport {
         let Ok(mut lock) = config::LockFile::load(&lock_path) else {
             continue;
         };
+        // Extras are applied, not installed: the refresh pass has no branch
+        // for them, so a requested extra would count as neither done nor
+        // failed. Say so, and keep it out of the refresh below.
+        let is_extra = |name: &String| {
+            lock.entries
+                .get(name)
+                .is_some_and(|entry| entry.kind == ItemKind::Extra)
+        };
+        for name in names.iter().filter(|name| is_extra(name)) {
+            if extras_reported.insert(name.clone()) {
+                report.fail(
+                    name,
+                    format!("extras are not refreshed here — reapply with `vstack apply {name}`"),
+                );
+            }
+        }
+        let names: Vec<String> = names
+            .iter()
+            .filter(|name| !is_extra(name))
+            .cloned()
+            .collect();
+        let names = names.as_slice();
         if !names.iter().any(|n| lock.entries.contains_key(n)) {
             continue;
         }

--- a/cli/src/tui/disk_mutations.rs
+++ b/cli/src/tui/disk_mutations.rs
@@ -539,35 +539,15 @@ fn reinstall_codex_hooks_for_moved_agents(
     Ok(())
 }
 
-pub(super) fn perform_inline_update(
-    names: &[String],
-    items: &DiscoveredItems,
-) -> DiskMutationReport {
+/// Refresh the named installs in place, each from its own recorded source.
+///
+/// Sources are resolved per scope from that scope's lock, exactly as
+/// `vstack refresh` does — never from whichever source the picker has
+/// selected — so an entry recorded from any source refreshes.
+pub(super) fn perform_inline_update(names: &[String]) -> DiskMutationReport {
     let mut report = DiskMutationReport::new(names.len());
     let mut completed_names = std::collections::HashSet::new();
     let project_root = config::project_root();
-    let source_dir = source_dir_for_items(items);
-    let mapping = source_dir
-        .as_deref()
-        .map(crate::mapping::MappingConfig::load)
-        .unwrap_or_default();
-    let refresh_sources: Vec<crate::refresh_sources::RefreshSource> = source_dir
-        .as_deref()
-        .map(|root| crate::refresh_sources::RefreshSource {
-            root: root.to_path_buf(),
-            aliases: vec![root.to_string_lossy().into_owned()],
-            source_repo: config::source_repo_for_source(Some(root), &root.to_string_lossy()),
-            mapping: mapping.clone(),
-            agents: items.agents.clone(),
-            skills: items.skills.clone(),
-            hooks: items.hooks.clone(),
-            pi_extensions: items.pi_extensions.clone(),
-        })
-        .into_iter()
-        .collect();
-    let selected_source_repo = refresh_sources
-        .first()
-        .map(|source| source.source_repo.clone());
 
     for scope_global in [false, true] {
         let lock_path = config::lock_file_path(scope_global);
@@ -608,10 +588,14 @@ pub(super) fn perform_inline_update(
                 .is_some_and(|entry| entry.kind == ItemKind::Hook)
         });
 
+        let source_records = crate::refresh_sources::resolve_source_records(&lock);
+        let sources = crate::refresh_sources::load_refresh_sources(&source_records);
+        let source_hooks = crate::refresh_sources::all_source_hooks(&sources);
+
         let pruned = crate::commands::refresh::prune_hook_harnesses(
             scope_global,
             &mut lock,
-            &items.hooks,
+            &source_hooks,
             Some(names),
         );
         if pruned && let Err(err) = lock.save(&lock_path) {
@@ -637,7 +621,7 @@ pub(super) fn perform_inline_update(
         let stats = crate::commands::refresh::refresh_items_in_scope(
             scope_global,
             &lock,
-            &refresh_sources,
+            &sources,
             &mut project_config,
             &project_root,
             Some(&refresh_names),
@@ -657,14 +641,18 @@ pub(super) fn perform_inline_update(
                 format!("refresh failed{harness}: {}", failure.error),
             );
         }
+        // An entry whose source is gone (or no longer carries it) is not
+        // refreshed; without this it would count as neither done nor failed
+        // and the flash would read "Updated 0 item(s)".
+        for (item, reason) in &stats.missing {
+            report.fail(item, format!("not refreshed: {reason}"));
+        }
 
         let now = config::now_iso();
         for (name, entry) in lock.entries.iter_mut() {
             if stats.successful_items.contains(name) {
+                crate::commands::refresh::sync_lock_entry_source_repo(&source_records, entry);
                 entry.installed_at = now.clone();
-                if let Some(source_repo) = &selected_source_repo {
-                    entry.source_repo = source_repo.clone();
-                }
                 entry.source_hash = config::compute_source_hash(entry);
             }
         }

--- a/cli/src/tui/disk_mutations/tests.rs
+++ b/cli/src/tui/disk_mutations/tests.rs
@@ -710,13 +710,56 @@ fn perform_remove_plans_reports_corrupt_lock() {
     let _ = std::fs::remove_dir_all(root);
 }
 
+/// Write `hook` into `source/hooks/<name>.sh` in the on-disk hook format, so
+/// the update path discovers it from the source the way `vstack refresh` does.
+fn write_source_hook(source: &std::path::Path, hook: &crate::hook::Hook) {
+    let matcher = hook
+        .matcher
+        .as_deref()
+        .map(|m| format!("# matcher: {m}\n"))
+        .unwrap_or_default();
+    std::fs::create_dir_all(source.join("hooks")).unwrap();
+    std::fs::write(
+        source.join("hooks").join(format!("{}.sh", hook.name)),
+        format!(
+            "#!/usr/bin/env bash\n# ---\n# name: {}\n# event: {}\n{matcher}# description: {} hook\n# ---\nexit 0\n",
+            hook.name, hook.event, hook.name
+        ),
+    )
+    .unwrap();
+}
+
+fn write_source_agent(source: &std::path::Path, agent: &Agent) {
+    std::fs::create_dir_all(source.join("agents")).unwrap();
+    std::fs::write(
+        source.join("agents").join(format!("{}.md", agent.name)),
+        format!(
+            "---\nname: {}\ndescription: {}\nmodel: {}\nrole: engineer\n---\n# {}\n",
+            agent.name, agent.description, agent.model, agent.name
+        ),
+    )
+    .unwrap();
+}
+
+fn hook_lock_entry(name: &str, source: &std::path::Path) -> LockEntry {
+    LockEntry {
+        name: name.into(),
+        kind: ItemKind::Hook,
+        source: source.to_string_lossy().into_owned(),
+        source_repo: None,
+        harnesses: vec!["claude-code".into()],
+        method: InstallMethod::Copy,
+        installed_at: "2026-07-03T00:00:00Z".into(),
+        source_hash: String::new(),
+    }
+}
+
 #[test]
 fn inline_update_refreshes_hook_config_and_agents() {
     let root = tmpdir("inline-update-hook");
     let project = root.join("project");
     let source = root.join("source");
-    std::fs::create_dir_all(source.join("agents")).unwrap();
-    std::fs::create_dir_all(source.join("hooks")).unwrap();
+    std::fs::create_dir_all(&source).unwrap();
     std::fs::create_dir_all(&project).unwrap();
     init_git_origin(&source, "git@github.com:vanillagreencom/vstack.git");
     std::fs::write(
@@ -727,12 +770,14 @@ fn inline_update_refreshes_hook_config_and_agents() {
 
     let mut agent = agent_fixture("rust");
     agent.source_path = source.join("agents/rust.md");
+    write_source_agent(&source, &agent);
     let mut old_hook = hook_fixture("guard", None);
     old_hook.source_path = source.join("hooks/guard.sh");
     old_hook.script = "#!/usr/bin/env bash\nexit 0\n".into();
     let mut new_hook = old_hook.clone();
     new_hook.event = "PostCompact".into();
     new_hook.matcher = None;
+    write_source_hook(&source, &new_hook);
 
     let mut lock = LockFile::default();
     lock.add(LockEntry {
@@ -745,25 +790,8 @@ fn inline_update_refreshes_hook_config_and_agents() {
         installed_at: "2026-07-03T00:00:00Z".into(),
         source_hash: String::new(),
     });
-    lock.add(LockEntry {
-        name: "guard".into(),
-        kind: ItemKind::Hook,
-        source: source.to_string_lossy().into_owned(),
-        source_repo: None,
-        harnesses: vec!["claude-code".into()],
-        method: InstallMethod::Copy,
-        installed_at: "2026-07-03T00:00:00Z".into(),
-        source_hash: String::new(),
-    });
+    lock.add(hook_lock_entry("guard", &source));
     lock.save(&project.join(".vstack-lock.json")).unwrap();
-
-    let items = DiscoveredItems {
-        agents: vec![agent.clone()],
-        skills: Vec::new(),
-        hooks: vec![new_hook],
-        pi_extensions: Vec::new(),
-        extras: Vec::new(),
-    };
 
     crate::test_util::with_project_root(&project, || {
         crate::installer::install_hook(&old_hook, Harness::ClaudeCode, false, &[]).unwrap();
@@ -777,7 +805,7 @@ fn inline_update_refreshes_hook_config_and_agents() {
             )
             .unwrap();
 
-        let report = perform_inline_update(&["guard".to_string()], &items);
+        let report = perform_inline_update(&["guard".to_string()]);
         assert_eq!(report.completed, 1, "report: {report:?}");
         assert!(report.failed.is_empty(), "report: {report:?}");
     });
@@ -821,43 +849,145 @@ fn inline_update_clears_stale_source_repo_for_local_source_without_origin() {
     let root = tmpdir("inline-update-source-repo-clear");
     let project = root.join("project");
     let source = root.join("source");
-    std::fs::create_dir_all(source.join("hooks")).unwrap();
     std::fs::create_dir_all(&project).unwrap();
 
     let mut hook = hook_fixture("guard", None);
     hook.source_path = source.join("hooks/guard.sh");
     hook.script = "#!/usr/bin/env bash\nexit 0\n".into();
+    write_source_hook(&source, &hook);
 
     let mut lock = LockFile::default();
-    lock.add(LockEntry {
-        name: "guard".into(),
-        kind: ItemKind::Hook,
-        source: source.to_string_lossy().into_owned(),
-        source_repo: Some("vanillagreencom/vstack".to_string()),
-        harnesses: vec!["claude-code".into()],
-        method: InstallMethod::Copy,
-        installed_at: "2026-07-03T00:00:00Z".into(),
-        source_hash: String::new(),
-    });
+    let mut entry = hook_lock_entry("guard", &source);
+    entry.source_repo = Some("vanillagreencom/vstack".to_string());
+    lock.add(entry);
     lock.save(&project.join(".vstack-lock.json")).unwrap();
-
-    let items = DiscoveredItems {
-        agents: Vec::new(),
-        skills: Vec::new(),
-        hooks: vec![hook.clone()],
-        pi_extensions: Vec::new(),
-        extras: Vec::new(),
-    };
 
     crate::test_util::with_project_root(&project, || {
         crate::installer::install_hook(&hook, Harness::ClaudeCode, false, &[]).unwrap();
-        let report = perform_inline_update(&["guard".to_string()], &items);
+        let report = perform_inline_update(&["guard".to_string()]);
         assert_eq!(report.completed, 1, "report: {report:?}");
         assert!(report.failed.is_empty(), "report: {report:?}");
     });
 
     let lock = LockFile::load(&project.join(".vstack-lock.json")).unwrap();
     assert_eq!(lock.entries.get("guard").unwrap().source_repo, None);
+
+    let _ = std::fs::remove_dir_all(root);
+}
+
+/// Two stale installs recorded from two different sources, updated together:
+/// each refreshes from its own source and records that source's identity —
+/// whichever source the picker has selected.
+#[test]
+fn inline_update_refreshes_each_entry_from_its_own_source() {
+    let root = tmpdir("inline-update-two-sources");
+    let project = root.join("project");
+    let source_a = root.join("source-a");
+    let source_b = root.join("source-b");
+    std::fs::create_dir_all(&project).unwrap();
+    std::fs::create_dir_all(&source_a).unwrap();
+    std::fs::create_dir_all(&source_b).unwrap();
+    init_git_origin(&source_a, "git@github.com:example/alpha.git");
+    init_git_origin(&source_b, "git@github.com:example/beta.git");
+
+    // Installed copies carry the old event; each source now publishes a new one.
+    let mut old_a = hook_fixture("guard-a", None);
+    old_a.script = "#!/usr/bin/env bash\nexit 0\n".into();
+    old_a.source_path = source_a.join("hooks/guard-a.sh");
+    let mut old_b = hook_fixture("guard-b", None);
+    old_b.script = "#!/usr/bin/env bash\nexit 0\n".into();
+    old_b.source_path = source_b.join("hooks/guard-b.sh");
+    let mut new_a = old_a.clone();
+    new_a.event = "PostCompact".into();
+    new_a.matcher = None;
+    let mut new_b = old_b.clone();
+    new_b.event = "SessionStart".into();
+    new_b.matcher = None;
+    write_source_hook(&source_a, &new_a);
+    write_source_hook(&source_b, &new_b);
+
+    let mut lock = LockFile::default();
+    lock.add(hook_lock_entry("guard-a", &source_a));
+    lock.add(hook_lock_entry("guard-b", &source_b));
+    lock.save(&project.join(".vstack-lock.json")).unwrap();
+
+    crate::test_util::with_project_root(&project, || {
+        crate::installer::install_hook(&old_a, Harness::ClaudeCode, false, &[]).unwrap();
+        crate::installer::install_hook(&old_b, Harness::ClaudeCode, false, &[]).unwrap();
+
+        let names = vec!["guard-a".to_string(), "guard-b".to_string()];
+        let report = perform_inline_update(&names);
+        assert_eq!(report.completed, 2, "report: {report:?}");
+        assert!(report.failed.is_empty(), "report: {report:?}");
+    });
+
+    let settings = std::fs::read_to_string(project.join(".claude/settings.json")).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&settings).unwrap();
+    assert!(
+        parsed.pointer("/hooks/PreToolUse").is_none(),
+        "stale PreToolUse settings: {settings}"
+    );
+    assert!(
+        parsed.pointer("/hooks/PostCompact").is_some(),
+        "guard-a not refreshed from source-a: {settings}"
+    );
+    assert!(
+        parsed.pointer("/hooks/SessionStart").is_some(),
+        "guard-b not refreshed from source-b: {settings}"
+    );
+
+    let lock = LockFile::load(&project.join(".vstack-lock.json")).unwrap();
+    assert_eq!(
+        lock.entries["guard-a"].source_repo.as_deref(),
+        Some("example/alpha")
+    );
+    assert_eq!(
+        lock.entries["guard-b"].source_repo.as_deref(),
+        Some("example/beta")
+    );
+    assert!(
+        !lock.entries["guard-a"].source_hash.is_empty()
+            && !lock.entries["guard-b"].source_hash.is_empty(),
+        "both entries re-hashed against their own source"
+    );
+
+    let _ = std::fs::remove_dir_all(root);
+}
+
+/// A stale entry whose source has vanished cannot refresh; the report must
+/// say so instead of counting it as neither done nor failed.
+#[test]
+fn inline_update_reports_an_entry_whose_source_is_gone() {
+    let root = tmpdir("inline-update-source-gone");
+    let project = root.join("project");
+    let live = root.join("live-source");
+    let gone = root.join("gone-source");
+    std::fs::create_dir_all(&project).unwrap();
+
+    let mut live_hook = hook_fixture("guard-live", None);
+    live_hook.script = "#!/usr/bin/env bash\nexit 0\n".into();
+    live_hook.source_path = live.join("hooks/guard-live.sh");
+    write_source_hook(&live, &live_hook);
+    let mut gone_hook = hook_fixture("guard-gone", None);
+    gone_hook.script = "#!/usr/bin/env bash\nexit 0\n".into();
+
+    let mut lock = LockFile::default();
+    lock.add(hook_lock_entry("guard-live", &live));
+    lock.add(hook_lock_entry("guard-gone", &gone));
+    lock.save(&project.join(".vstack-lock.json")).unwrap();
+
+    let report = crate::test_util::with_project_root(&project, || {
+        crate::installer::install_hook(&live_hook, Harness::ClaudeCode, false, &[]).unwrap();
+        crate::installer::install_hook(&gone_hook, Harness::ClaudeCode, false, &[]).unwrap();
+        perform_inline_update(&["guard-live".to_string(), "guard-gone".to_string()])
+    });
+
+    assert_eq!(report.completed, 1, "report: {report:?}");
+    assert_eq!(report.failed.len(), 1, "report: {report:?}");
+    assert!(
+        report.failed[0].starts_with("guard-gone: not refreshed:"),
+        "report: {report:?}"
+    );
 
     let _ = std::fs::remove_dir_all(root);
 }

--- a/cli/src/tui/disk_mutations/tests.rs
+++ b/cli/src/tui/disk_mutations/tests.rs
@@ -983,9 +983,79 @@ fn inline_update_reports_an_entry_whose_source_is_gone() {
     });
 
     assert_eq!(report.completed, 1, "report: {report:?}");
-    assert_eq!(report.failed.len(), 1, "report: {report:?}");
-    assert!(
-        report.failed[0].starts_with("guard-gone: not refreshed:"),
+    assert_eq!(
+        report.failed,
+        vec![format!(
+            "guard-gone: not refreshed: source not found: {}",
+            gone.display()
+        )],
+        "a requested item names its vanished source: {report:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(root);
+}
+
+/// Updating a hook regenerates every installed agent so its hook payload
+/// stays current. An agent that cannot be regenerated is a real outcome the
+/// user must see, but it is not an item they asked to update — the message
+/// says what happened instead of reading like a failed request.
+#[test]
+fn inline_update_names_agents_it_could_not_regenerate_after_a_hook_update() {
+    let root = tmpdir("inline-update-expanded-agent-missing");
+    let project = root.join("project");
+    let source = root.join("source");
+    std::fs::create_dir_all(&project).unwrap();
+    std::fs::create_dir_all(source.join("agents")).unwrap();
+
+    let mut old_hook = hook_fixture("guard", None);
+    old_hook.script = "#!/usr/bin/env bash\nexit 0\n".into();
+    old_hook.source_path = source.join("hooks/guard.sh");
+    let mut new_hook = old_hook.clone();
+    new_hook.event = "PostCompact".into();
+    new_hook.matcher = None;
+    write_source_hook(&source, &new_hook);
+    // `rust` is locked as installed from this source, but the source no
+    // longer carries agents/rust.md.
+    let agent = agent_fixture("rust");
+
+    let mut lock = LockFile::default();
+    lock.add(hook_lock_entry("guard", &source));
+    lock.add(LockEntry {
+        name: "rust".into(),
+        kind: ItemKind::Agent,
+        source: source.to_string_lossy().into_owned(),
+        source_repo: None,
+        harnesses: vec!["claude-code".into()],
+        method: InstallMethod::Copy,
+        installed_at: "2026-07-03T00:00:00Z".into(),
+        source_hash: String::new(),
+    });
+    lock.save(&project.join(".vstack-lock.json")).unwrap();
+
+    let report = crate::test_util::with_project_root(&project, || {
+        crate::installer::install_hook(&old_hook, Harness::ClaudeCode, false, &[]).unwrap();
+        Harness::ClaudeCode
+            .generate_agent(
+                &agent,
+                false,
+                &[],
+                &[old_hook.clone()],
+                &crate::agent::AgentExtras::default(),
+            )
+            .unwrap();
+        perform_inline_update(&["guard".to_string()])
+    });
+
+    assert_eq!(
+        report.completed, 1,
+        "the requested hook updates: {report:?}"
+    );
+    assert_eq!(
+        report.failed,
+        vec![format!(
+            "rust: agent not regenerated after hook update: not found in source {}",
+            source.display()
+        )],
         "report: {report:?}"
     );
 

--- a/cli/src/tui/disk_mutations/tests.rs
+++ b/cli/src/tui/disk_mutations/tests.rs
@@ -997,11 +997,12 @@ fn inline_update_reports_an_entry_whose_source_is_gone() {
 
 /// Extras are applied, not installed — the refresh pass has no branch for
 /// them, so a stale extra picked from the Updates tab used to count as
-/// neither done nor failed ("Updated 0 item(s)"). It must be reported with
-/// the command that actually re-applies it, and the rest of the request must
-/// still refresh.
+/// neither done nor failed ("Updated 0 item(s)"). It is skipped with a
+/// notice naming the command that re-applies it — a notice, not a failure,
+/// so it cannot veto the CLI update batched behind the same "Update All" —
+/// and the rest of the request still refreshes.
 #[test]
-fn inline_update_reports_extras_as_not_refreshable_and_refreshes_the_rest() {
+fn inline_update_skips_extras_with_a_notice_and_refreshes_the_rest() {
     let root = tmpdir("inline-update-extra");
     let project = root.join("project");
     let source = root.join("source");
@@ -1031,15 +1032,22 @@ fn inline_update_reports_extras_as_not_refreshable_and_refreshes_the_rest() {
         perform_inline_update(&["guard".to_string(), "vanillagreen-themes".to_string()])
     });
 
-    assert_eq!(report.attempted, 2);
-    assert_eq!(report.completed, 1, "the hook still refreshes: {report:?}");
+    assert!(
+        report.failed.is_empty(),
+        "a skipped extra is not a failure (it must not veto the CLI update): {report:?}"
+    );
     assert_eq!(
-        report.failed,
+        report.notices,
         vec![
-            "vanillagreen-themes: extras are not refreshed here — reapply with `vstack apply vanillagreen-themes`"
+            "skipped vanillagreen-themes: extras are reapplied with `vstack apply vanillagreen-themes`"
                 .to_string()
         ],
         "report: {report:?}"
+    );
+    assert_eq!(report.completed, 1, "the hook still refreshes: {report:?}");
+    assert_eq!(
+        report.attempted, 1,
+        "a skipped extra was never attempted: {report:?}"
     );
 
     let _ = std::fs::remove_dir_all(root);

--- a/cli/src/tui/disk_mutations/tests.rs
+++ b/cli/src/tui/disk_mutations/tests.rs
@@ -995,6 +995,56 @@ fn inline_update_reports_an_entry_whose_source_is_gone() {
     let _ = std::fs::remove_dir_all(root);
 }
 
+/// Extras are applied, not installed — the refresh pass has no branch for
+/// them, so a stale extra picked from the Updates tab used to count as
+/// neither done nor failed ("Updated 0 item(s)"). It must be reported with
+/// the command that actually re-applies it, and the rest of the request must
+/// still refresh.
+#[test]
+fn inline_update_reports_extras_as_not_refreshable_and_refreshes_the_rest() {
+    let root = tmpdir("inline-update-extra");
+    let project = root.join("project");
+    let source = root.join("source");
+    std::fs::create_dir_all(&project).unwrap();
+
+    let mut hook = hook_fixture("guard", None);
+    hook.script = "#!/usr/bin/env bash\nexit 0\n".into();
+    hook.source_path = source.join("hooks/guard.sh");
+    write_source_hook(&source, &hook);
+
+    let mut lock = LockFile::default();
+    lock.add(hook_lock_entry("guard", &source));
+    lock.add(LockEntry {
+        name: "vanillagreen-themes".into(),
+        kind: ItemKind::Extra,
+        source: source.to_string_lossy().into_owned(),
+        source_repo: None,
+        harnesses: Vec::new(),
+        method: InstallMethod::Copy,
+        installed_at: "2026-07-03T00:00:00Z".into(),
+        source_hash: "stale".into(),
+    });
+    lock.save(&project.join(".vstack-lock.json")).unwrap();
+
+    let report = crate::test_util::with_project_root(&project, || {
+        crate::installer::install_hook(&hook, Harness::ClaudeCode, false, &[]).unwrap();
+        perform_inline_update(&["guard".to_string(), "vanillagreen-themes".to_string()])
+    });
+
+    assert_eq!(report.attempted, 2);
+    assert_eq!(report.completed, 1, "the hook still refreshes: {report:?}");
+    assert_eq!(
+        report.failed,
+        vec![
+            "vanillagreen-themes: extras are not refreshed here — reapply with `vstack apply vanillagreen-themes`"
+                .to_string()
+        ],
+        "report: {report:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(root);
+}
+
 /// Updating a hook regenerates every installed agent so its hook payload
 /// stays current. An agent that cannot be regenerated is a real outcome the
 /// user must see, but it is not an item they asked to update — the message

--- a/cli/src/tui/install_flow.rs
+++ b/cli/src/tui/install_flow.rs
@@ -2206,6 +2206,13 @@ fn spawn_disk_work<F>(
     );
 }
 
+/// The CLI binary update queued behind a mixed "Update All" runs only when
+/// every attempted content update succeeded. Skipped items are notices, not
+/// failures — a stale extra must not veto the CLI update it was batched with.
+fn cli_update_may_follow(report: &DiskMutationReport) -> bool {
+    report.failed.is_empty()
+}
+
 fn format_disk_mutation_flash(report: &DiskMutationReport, action: &str, suffix: &str) -> String {
     // Worker threads never print (raw-mode terminal is the TUI's); anything
     // they collected as a notice surfaces here on the main thread instead.
@@ -2333,7 +2340,7 @@ fn apply_post_work(state: &mut FlowState<'_>, post: PostWork) -> Result<Option<I
                     }
                     state.select.flash_message =
                         Some(format_disk_mutation_flash(&report, &action, &suffix));
-                    if then_cli_update && report.failed.is_empty() {
+                    if then_cli_update && cli_update_may_follow(&report) {
                         run_cli_update_inline()?;
                     }
                 }
@@ -2617,5 +2624,36 @@ mod tests {
             Some(&false)
         );
         assert_eq!(state.select.harness_selection.get("pi"), Some(&true));
+    }
+
+    /// "Update All" with a stale extra AND the `vstack (cli)` row: the extra
+    /// is skipped (a notice), so the CLI update queued behind the batch still
+    /// runs and the flash reports the honest count with the skip on its own
+    /// segment. A real failure still vetoes the CLI update.
+    #[test]
+    fn skipped_extra_does_not_block_the_queued_cli_update() {
+        // The report shape `perform_inline_update` yields for
+        // [hook, stale extra] (see disk_mutations tests).
+        let report = DiskMutationReport {
+            attempted: 1,
+            completed: 1,
+            failed: Vec::new(),
+            notices: vec![
+                "skipped vanillagreen-themes: extras are reapplied with `vstack apply vanillagreen-themes`"
+                    .to_string(),
+            ],
+        };
+
+        assert!(cli_update_may_follow(&report));
+        assert_eq!(
+            format_disk_mutation_flash(&report, "Updated", ""),
+            "Updated 1 item(s) \u{2014} skipped vanillagreen-themes: extras are reapplied with `vstack apply vanillagreen-themes`"
+        );
+
+        let failed = DiskMutationReport {
+            failed: vec!["guard: refresh failed: boom".to_string()],
+            ..report
+        };
+        assert!(!cli_update_may_follow(&failed));
     }
 }

--- a/cli/src/tui/install_flow.rs
+++ b/cli/src/tui/install_flow.rs
@@ -2056,7 +2056,6 @@ fn execute_action(
                 return run_cli_update_inline().map(|_| None);
             }
             let n = content_names.len();
-            let items_clone = state.items.clone();
             let label = format!("Updating {n} item(s)…");
             spawn_disk_work(
                 state,
@@ -2065,7 +2064,7 @@ fn execute_action(
                 String::new(),
                 has_cli,
                 None,
-                move || perform_inline_update(&content_names, &items_clone),
+                move || perform_inline_update(&content_names),
             );
             Ok(None)
         }

--- a/cli/src/tui/state.rs
+++ b/cli/src/tui/state.rs
@@ -321,21 +321,7 @@ pub(super) fn build_item_tabs(
         tabs.push(installed_tab);
     }
 
-    let mut update_items: Vec<SelectItem> = Vec::new();
-    for tab in &tabs {
-        if tab.kind != TabKind::Source {
-            continue;
-        }
-        for group in &tab.groups {
-            for item in &group.items {
-                if item.outdated {
-                    let mut clone = item.clone();
-                    clone.selected = false;
-                    update_items.push(clone);
-                }
-            }
-        }
-    }
+    let mut update_items = build_update_items(&tabs, installed);
 
     if let Some(info) = cli_update {
         update_items.push(SelectItem {
@@ -433,6 +419,54 @@ fn kind_bucket(kind: Option<crate::config::ItemKind>) -> &'static str {
 
 const KIND_ORDER: &[&str] = &["Agents", "Skills", "Hooks", "Pi Packages", "Extras"];
 
+/// Row for an installed entry that has no source-tab counterpart: the lock
+/// record is all that is known about it.
+fn installed_row(name: &str, info: &InstalledInfo) -> SelectItem {
+    SelectItem {
+        label: name.to_string(),
+        description: format!("[{}]", info.harnesses.join(", ")),
+        selected: false,
+        suffix: None,
+        locked: false,
+        installed: true,
+        installed_scope: Some(info.scope),
+        outdated: info.outdated,
+        kind: info.kind,
+        search_haystack: String::new(),
+    }
+}
+
+/// One row per stale install in either scope, whatever source is selected —
+/// the same set `vstack check` reports. A name the selected source also
+/// lists reuses that source row (it carries the description and kind); every
+/// other stale entry is synthesized from its lock record.
+fn build_update_items(tabs: &[Tab], installed: &InstalledState) -> Vec<SelectItem> {
+    let mut source_rows: HashMap<&str, &SelectItem> = HashMap::new();
+    for item in tabs
+        .iter()
+        .filter(|tab| tab.kind == TabKind::Source)
+        .flat_map(|tab| &tab.groups)
+        .flat_map(|group| &group.items)
+    {
+        source_rows.entry(item.label.as_str()).or_insert(item);
+    }
+
+    let mut stale: Vec<(&String, &InstalledInfo)> =
+        installed.iter().filter(|(_, info)| info.outdated).collect();
+    stale.sort_by_key(|(name, _)| name.as_str());
+    stale
+        .into_iter()
+        .map(|(name, info)| {
+            let mut row = source_rows
+                .get(name.as_str())
+                .map(|item| (*item).clone())
+                .unwrap_or_else(|| installed_row(name, info));
+            row.selected = false;
+            row
+        })
+        .collect()
+}
+
 fn build_installed_tab(installed: &InstalledState) -> Option<Tab> {
     if installed.is_empty() {
         return None;
@@ -444,24 +478,10 @@ fn build_installed_tab(installed: &InstalledState) -> Option<Tab> {
     sorted.sort_by_key(|(name, _)| name.as_str());
 
     for (name, info) in sorted {
-        let h = info.harnesses.join(", ");
-        let scope_str = info.scope.title_label();
-        let item = SelectItem {
-            label: name.clone(),
-            description: format!("[{h}]"),
-            selected: false,
-            suffix: None,
-            locked: false,
-            installed: true,
-            installed_scope: Some(info.scope),
-            outdated: info.outdated,
-            kind: info.kind,
-            search_haystack: String::new(),
-        };
         buckets
-            .entry((scope_str, kind_bucket(info.kind)))
+            .entry((info.scope.title_label(), kind_bucket(info.kind)))
             .or_default()
-            .push(item);
+            .push(installed_row(name, info));
     }
 
     let mut groups = Vec::new();
@@ -660,6 +680,105 @@ mod tests {
             },
             source_dir: std::path::PathBuf::from("/tmp/vanillagreen-themes"),
         }
+    }
+
+    fn installed_info(
+        name: &str,
+        kind: crate::config::ItemKind,
+        source: &str,
+        outdated: bool,
+    ) -> InstalledInfo {
+        let entry = crate::config::LockEntry {
+            name: name.into(),
+            kind,
+            source: source.into(),
+            source_repo: None,
+            harnesses: vec!["claude-code".into(), "codex".into()],
+            method: crate::config::InstallMethod::Copy,
+            installed_at: "2026-07-03T00:00:00Z".into(),
+            source_hash: "abc".into(),
+        };
+        InstalledInfo {
+            scope: Scope::Project,
+            harnesses: entry.harnesses.clone(),
+            kind: Some(kind),
+            installed_at: entry.installed_at.clone(),
+            lock_entry: entry.clone(),
+            project_entry: Some(entry),
+            global_entry: None,
+            outdated,
+        }
+    }
+
+    fn skill_fixture(name: &str, description: &str) -> Skill {
+        Skill {
+            name: name.into(),
+            description: description.into(),
+            license: None,
+            user_invocable: None,
+            dependencies: None,
+            body: String::new(),
+            source_dir: std::path::PathBuf::from("/tmp/selected-source/skills").join(name),
+            resolved_deps: Vec::new(),
+        }
+    }
+
+    /// The Updates tab is the set `vstack check` reports: every stale install
+    /// in either scope, not just the ones the selected source happens to list.
+    #[test]
+    fn updates_tab_lists_stale_installs_recorded_from_other_sources() {
+        let mut items = discovered(Vec::new());
+        items.skills = vec![skill_fixture("alpha", "Alpha from the selected source")];
+
+        let mut installed = InstalledState::new();
+        installed.insert(
+            "alpha".into(),
+            installed_info(
+                "alpha",
+                crate::config::ItemKind::Skill,
+                "/tmp/selected-source",
+                true,
+            ),
+        );
+        installed.insert(
+            "beta".into(),
+            installed_info(
+                "beta",
+                crate::config::ItemKind::Agent,
+                "/tmp/other-source",
+                true,
+            ),
+        );
+        installed.insert(
+            "gamma".into(),
+            installed_info(
+                "gamma",
+                crate::config::ItemKind::Hook,
+                "/tmp/other-source",
+                false,
+            ),
+        );
+
+        let tabs = build_item_tabs(&items, &HashMap::new(), &installed, None);
+        let updates = tabs
+            .iter()
+            .find(|tab| tab.kind == TabKind::Updates)
+            .expect("updates tab present");
+        let rows: Vec<&SelectItem> = updates.groups.iter().flat_map(|g| &g.items).collect();
+        let labels: Vec<&str> = rows.iter().map(|row| row.label.as_str()).collect();
+
+        assert_eq!(updates.name, "Updates (2)");
+        assert_eq!(labels, vec!["alpha", "beta"]);
+
+        let alpha = rows[0];
+        assert_eq!(alpha.description, "Alpha from the selected source");
+        assert_eq!(alpha.kind, Some(crate::config::ItemKind::Skill));
+
+        let beta = rows[1];
+        assert_eq!(beta.description, "[claude-code, codex]");
+        assert_eq!(beta.kind, Some(crate::config::ItemKind::Agent));
+        assert_eq!(beta.installed_scope, Some(Scope::Project));
+        assert!(beta.installed && beta.outdated && !beta.selected);
     }
 
     #[test]


### PR DESCRIPTION
## Why

Inside a project the TUI's Installed tab marks packages yellow/`outdated` while the Updates tab lists only a subset — in the vstack repo, `vstack check` reports 10 project + 16 global outdated items, the Installed tab shows them all yellow, the Updates tab says `Updates (1)`. The Updates tab was built only from the **currently selected source's** items, and the inline update loaded a single `RefreshSource` from that source, so an entry recorded from any other source could neither be listed nor refreshed there.

## What

- `tui/state.rs` — the Updates tab is every installed entry whose lock hash is stale, in either scope, whatever source the picker has selected (the `vstack check` set); a name the selected source also lists reuses that row, every other stale entry is synthesized from its lock record (`build_update_items` / `installed_row`, shared with the Installed tab).
- `tui/disk_mutations.rs` — `perform_inline_update(names)` resolves sources per scope from that scope's lock exactly as `vstack refresh` does (`resolve_source_records` → `load_refresh_sources`), refreshes each entry from its own recorded source, records that source's repo identity via the CLI's own `sync_lock_entry_source_repo`, and reports source-gone entries as failures instead of "neither done nor failed" (which flashed `Updated 0 item(s)`).
- `config.rs` — `SourceRegistry::prune_dead_paths` also drops `project_current` keys whose project root no longer exists (the owner's registry carried ~120 vanished `/tmp/tmp.*` test projects).

Closes #1310

## Verification

- 4 new tests, each run against the pre-fix code first (fails) then after (passes): cross-source stale entry appears in Updates with the count; the source-tab row is reused when present; the update path resolves both sources from the lock and refreshes each from its own; dead `project_current` keys are pruned.
- `cargo test`: green (588 + 2 + 17). `cli/scripts/integration-check.sh`: 29 pass / 0 fail. Clippy/fmt clean for the touched code (one pre-existing `collapsible_if` in `installer.rs` on main is untouched).

https://claude.ai/code/session_01BZkcou9yGoEPVijZUaQiTr
