### PR TITLE
fix(github): pr-threads --unresolved honors raw format; pr-merge short-circuits on MERGED/CLOSED (VST-269, VST-271)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,14 @@
 - review-gate: an errored bot review object is treated as silence, not
   approval evidence — the gate stays awaiting (VST-253; fail-open observed
   live). New selftest cases with pre-fix controls.
+- github: thread and merge state are reported honestly (VST-269, VST-271) —
+  `pr-threads --unresolved`/`--resolved` filter `--format=raw` as well as
+  `safe`, and `pr-merge` short-circuits a PR that has left OPEN: an
+  already-merged PR exits 0 with `ALREADY MERGED PR #N <mergedAt>`, a closed
+  unmerged PR exits 1 with `CLOSED (not merged) PR #N`, and `--check` carries
+  the lifecycle state in a new `state` field instead of reporting the
+  permanently-UNKNOWN mergeable value, post-merge CI, and post-merge comment
+  threads as blockers.
 - cli: `vstack add` without `-y` in a non-TTY session fails with an
   actionable message instead of `os error 6`, and no longer repoints the
   global source registry on that failure (VST-255).

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -170,10 +170,11 @@ BLOCKED is classified on stderr as **transient** (mergeable UNKNOWN,
 Callers read the `transient` field from `--check`:
 
 ```json
-{"can_merge": true, "issues": [], "warnings": [], "mergeable": "MERGEABLE", "review": "APPROVED", "transient": false, "state": "OPEN"}
+{"can_merge": true, "issues": [], "warnings": [], "mergeable": "MERGEABLE", "review": "APPROVED", "transient": false, "state": "OPEN", "merged_at": ""}
 ```
 
-`state` is the PR's lifecycle state (`OPEN`, `MERGED`, `CLOSED`, `UNKNOWN`).
+`state` is the PR's lifecycle state (`OPEN`, `MERGED`, `CLOSED`, `UNKNOWN`), and
+`merged_at` carries the merge timestamp when that state is `MERGED`.
 `can_merge: false` with an empty `issues` array means the PR is terminal — read
 `state` before treating a refusal as a blocker to clear.
 

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -29,7 +29,7 @@ output, bot account support, configurable issue ID extraction.
 |---------|---------|
 | `pr-data <N> [--actionable]` | Get PR with threads, comments, files. `--actionable`: unresolved non-outdated only. |
 | `pr-view [N] [--json FIELDS]` | View PR details (wraps gh pr view with bounded auth/no-PR errors) |
-| `pr-threads <N> [--unresolved]` | Complete paginated thread list/count, outdated included. See *PR blocked with no visible conversations*. |
+| `pr-threads <N> [--unresolved\|--resolved] [--format=safe\|raw]` | Complete paginated thread list/count, outdated included. Both filters apply in both formats. See *PR blocked with no visible conversations*. |
 | `pr-list-ready [--all] [--format=safe\|table]` | List PRs ready for merge |
 | `pr-list-failing [--all] [--format=safe\|table]` | List PRs with CI failures |
 | `pr-create [--title T] [--body B \| --body-file PATH] [--draft] [--dry-run] [--force]` | Create PR as bot. Safety checks: not main, has commits, pushed; `--force` skips them. |
@@ -126,9 +126,16 @@ parsing stderr:
 | Exit | Meaning | Stderr line | When |
 |------|---------|-------------|------|
 | `0`  | MERGED | `MERGED PR #N` | Merge completed immediately |
+| `0`  | MERGED | `ALREADY MERGED PR #N <mergedAt>` | PR was merged before the call; nothing attempted |
 | `75` | MERGE PENDING | `QUEUED IN MERGE QUEUE PR #N` | A required GitHub merge queue has an active entry |
 | `75` | MERGE PENDING | `AUTO-MERGE ENABLED PR #N` | Classic auto-merge is armed until protection clears |
 | `1`  | BLOCKED | `BLOCKED PR #N` | Nothing merged, queued, or armed |
+| `1`  | BLOCKED | `CLOSED (not merged) PR #N` | PR is closed unmerged; nothing attempted |
+
+A PR that has left `OPEN` is terminal and short-circuits every mode before any
+check, auth, or mutation: `mergeable` is permanently `UNKNOWN` after a merge,
+and post-merge CI runs and bot comments are not merge blockers. `--check`
+reports the same through its `state` field rather than inventing issues.
 
 Merge state is mutated only against the exact resolved head, via
 `--match-head-commit`. Queue membership is then read with GraphQL, because
@@ -163,8 +170,12 @@ BLOCKED is classified on stderr as **transient** (mergeable UNKNOWN,
 Callers read the `transient` field from `--check`:
 
 ```json
-{"can_merge": true, "issues": [], "warnings": [], "mergeable": "MERGEABLE", "review": "APPROVED", "transient": false}
+{"can_merge": true, "issues": [], "warnings": [], "mergeable": "MERGEABLE", "review": "APPROVED", "transient": false, "state": "OPEN"}
 ```
+
+`state` is the PR's lifecycle state (`OPEN`, `MERGED`, `CLOSED`, `UNKNOWN`).
+`can_merge: false` with an empty `issues` array means the PR is terminal — read
+`state` before treating a refusal as a blocker to clear.
 
 `transient: true` means every blocking issue is recoverable by waiting
 (prefixes `unknown:`, `ci_pending:`, `ci_unconfigured:`, `ci_fetch_failed:`).

--- a/skills/github/scripts/commands/pr-merge.sh
+++ b/skills/github/scripts/commands/pr-merge.sh
@@ -92,18 +92,50 @@ EOF
 # PR_STATE_JSON. Also validates that the PR exists — a bare number does not.
 # Every caller shares the single fetch; a failed read is not cached, so the
 # next caller retries rather than inheriting an empty state.
+#
+# On failure PR_STATE_ERROR carries a prefixed issue string. Only GitHub's
+# own "this PR does not exist" wording becomes `not_found:` — an auth, network,
+# rate-limit, or API failure keeps its own diagnostic instead of being
+# reported as a missing PR.
 PR_STATE_JSON=""
 PR_STATE_JSON_PR=""
+PR_STATE_ERROR=""
 load_pr_state_json() {
     local pr_num="$1"
     if [ -n "$PR_STATE_JSON_PR" ] && [ "$PR_STATE_JSON_PR" = "$pr_num" ]; then
         return 0
     fi
 
-    local state_json
-    state_json=$(gh pr view "$pr_num" --json state,mergedAt 2>/dev/null) || return 1
-    PR_STATE_JSON="$state_json"
-    PR_STATE_JSON_PR="$pr_num"
+    local err_file state_json status=0
+    if ! err_file=$(mktemp "${TMPDIR:-/tmp}/pr-merge-state.XXXXXX"); then
+        PR_STATE_ERROR="gh_error: could not create a temporary file for the PR state lookup"
+        return 1
+    fi
+
+    state_json=$(gh pr view "$pr_num" --json state,mergedAt 2>"$err_file") || status=$?
+    local detail
+    detail=$(grep -v '^[[:space:]]*$' "$err_file" | head -1)
+    rm -f "$err_file"
+
+    if [ "$status" -eq 0 ]; then
+        PR_STATE_JSON="$state_json"
+        PR_STATE_JSON_PR="$pr_num"
+        PR_STATE_ERROR=""
+        return 0
+    fi
+
+    case "$detail" in
+    *"Could not resolve to a PullRequest"* | *"o pull requests found"*)
+        PR_STATE_ERROR="not_found: PR #$pr_num not found"
+        ;;
+    "")
+        PR_STATE_ERROR="gh_error: gh pr view exited $status with no diagnostic"
+        ;;
+    *)
+        PR_STATE_ERROR="gh_error: $detail"
+        ;;
+    esac
+    return 1
 }
 
 # Run safety checks, output JSON
@@ -119,7 +151,7 @@ run_checks() {
 
     local pr_state
     if ! load_pr_state_json "$pr_num"; then
-        jq -n '{can_merge: false, issues: ["not_found: PR #'"$pr_num"' not found"], warnings: [], mergeable: "UNKNOWN", review: "", transient: false, state: "UNKNOWN"}'
+        jq -n --arg issue "$PR_STATE_ERROR" '{can_merge: false, issues: [$issue], warnings: [], mergeable: "UNKNOWN", review: "", transient: false, state: "UNKNOWN"}'
         return 0 # Return 0 so JSON is output, caller checks can_merge
     fi
     pr_state=$(jq -r '.state // "UNKNOWN"' <<<"$PR_STATE_JSON")

--- a/skills/github/scripts/commands/pr-merge.sh
+++ b/skills/github/scripts/commands/pr-merge.sh
@@ -138,29 +138,54 @@ load_pr_state_json() {
     return 1
 }
 
+# Report a PR that has left OPEN and exit. Every mode routes its terminal
+# states through here so the outcome lines and exit codes cannot diverge.
+# Any other state returns and lets the caller continue.
+exit_terminal_state() {
+    local state="$1" pr_num="$2" merged_at="${3:-}"
+
+    case "$state" in
+    MERGED)
+        if [ -n "$merged_at" ]; then
+            echo "ALREADY MERGED PR #$pr_num $merged_at" >&2
+        else
+            echo "ALREADY MERGED PR #$pr_num" >&2
+        fi
+        exit 0
+        ;;
+    CLOSED)
+        echo "CLOSED (not merged) PR #$pr_num" >&2
+        echo "  No merge attempted, none queued. Reopen the PR or supersede it." >&2
+        exit 1
+        ;;
+    esac
+}
+
 # Run safety checks, output JSON
 # JSON shape:
 #   {can_merge, issues, warnings, mergeable, review,
 #    transient: bool,     # true when only TRANSIENT issues are blocking
-#    state}               # PR lifecycle state: OPEN, MERGED, CLOSED, UNKNOWN
+#    state,               # PR lifecycle state: OPEN, MERGED, CLOSED, UNKNOWN
+#    merged_at}           # merge timestamp, "" unless state is MERGED
 run_checks() {
     local pr_num="$1"
     local can_merge=true
     local issues=()
     local warnings=()
 
-    local pr_state
+    local pr_state pr_merged_at
     if ! load_pr_state_json "$pr_num"; then
-        jq -n --arg issue "$PR_STATE_ERROR" '{can_merge: false, issues: [$issue], warnings: [], mergeable: "UNKNOWN", review: "", transient: false, state: "UNKNOWN"}'
+        jq -n --arg issue "$PR_STATE_ERROR" '{can_merge: false, issues: [$issue], warnings: [], mergeable: "UNKNOWN", review: "", transient: false, state: "UNKNOWN", merged_at: ""}'
         return 0 # Return 0 so JSON is output, caller checks can_merge
     fi
     pr_state=$(jq -r '.state // "UNKNOWN"' <<<"$PR_STATE_JSON")
+    pr_merged_at=$(jq -r '.mergedAt // ""' <<<"$PR_STATE_JSON")
 
     # A terminal PR is unmergeable for a reason no caller can act on, and its
     # check data is meaningless: `mergeable` is permanently UNKNOWN, post-merge
     # CI runs and bot comments are not blockers. Report the state, no issues.
     if [ "$pr_state" = "MERGED" ] || [ "$pr_state" = "CLOSED" ]; then
-        jq -n --arg state "$pr_state" '{can_merge: false, issues: [], warnings: [], mergeable: "UNKNOWN", review: "", transient: false, state: $state}'
+        jq -n --arg state "$pr_state" --arg merged_at "$pr_merged_at" '{can_merge: false, issues: [], warnings: [], mergeable: "UNKNOWN", review: "", transient: false, state: $state, merged_at: $merged_at}'
         return 0
     fi
 
@@ -294,7 +319,8 @@ run_checks() {
         --arg review "$review" \
         --argjson transient "$transient" \
         --arg state "$pr_state" \
-        '{can_merge: $can_merge, issues: $issues, warnings: $warnings, mergeable: $mergeable, review: $review, transient: $transient, state: $state}'
+        --arg merged_at "$pr_merged_at" \
+        '{can_merge: $can_merge, issues: $issues, warnings: $warnings, mergeable: $mergeable, review: $review, transient: $transient, state: $state, merged_at: $merged_at}'
 }
 
 # Print BLOCKED breakdown to stderr, distinguishing transient vs permanent.
@@ -465,26 +491,11 @@ main() {
     # mutation. Retrying a merge on a PR that already left OPEN can only
     # produce false diagnostics, and there is nothing left to mutate.
     # An unreadable state is not terminal — fall through to the normal path.
-    local terminal_state
     if load_pr_state_json "$pr_num"; then
-        terminal_state=$(jq -r '.state // ""' <<<"$PR_STATE_JSON")
-        case "$terminal_state" in
-        MERGED)
-            local merged_at
-            merged_at=$(jq -r '.mergedAt // ""' <<<"$PR_STATE_JSON")
-            if [ -n "$merged_at" ]; then
-                echo "ALREADY MERGED PR #$pr_num $merged_at" >&2
-            else
-                echo "ALREADY MERGED PR #$pr_num" >&2
-            fi
-            exit 0
-            ;;
-        CLOSED)
-            echo "CLOSED (not merged) PR #$pr_num" >&2
-            echo "  No merge attempted, none queued. Reopen the PR or supersede it." >&2
-            exit 1
-            ;;
-        esac
+        exit_terminal_state \
+            "$(jq -r '.state // ""' <<<"$PR_STATE_JSON")" \
+            "$pr_num" \
+            "$(jq -r '.mergedAt // ""' <<<"$PR_STATE_JSON")"
     fi
 
     local token
@@ -493,8 +504,17 @@ main() {
     # Unless --force, run checks
     local check_result=""
     if [ "$force" = false ]; then
-        local can_merge
+        local can_merge checked_state checked_merged_at
         check_result=$(run_checks "$pr_num")
+
+        # The checks re-read a state the up-front lookup could not resolve, so
+        # a PR that is terminal by now must be reported here too. Otherwise
+        # `--auto`, which defers every non-thread blocker, arms a merge on a PR
+        # that has already left OPEN.
+        checked_state=$(echo "$check_result" | jq -r '.state // ""')
+        checked_merged_at=$(echo "$check_result" | jq -r '.merged_at // ""')
+        exit_terminal_state "$checked_state" "$pr_num" "$checked_merged_at"
+
         can_merge=$(echo "$check_result" | jq -r '.can_merge')
 
         if [ "$can_merge" != "true" ]; then

--- a/skills/github/scripts/commands/pr-merge.sh
+++ b/skills/github/scripts/commands/pr-merge.sh
@@ -4,8 +4,14 @@
 #
 # Outcomes (distinct exit codes + messages):
 #   0   MERGED                 — merge completed immediately
+#   0   ALREADY MERGED         — PR was already merged; nothing attempted
 #   75  QUEUED / AUTO-MERGE     — merge queue entry or classic auto-merge is active
 #   1   BLOCKED                — checks failed; no merge attempted, none queued
+#   1   CLOSED (not merged)    — PR is closed unmerged; nothing attempted
+#
+# A PR that has left OPEN is terminal and short-circuits before any check or
+# mutation: `mergeable` stays UNKNOWN forever once a PR is merged or closed, so
+# running the checks against it manufactures blockers that can never clear.
 #
 # Actionable unresolved review threads are a local hard gate: neither an
 # immediate merge nor `--auto` may mutate merge state while they remain. Only
@@ -70,9 +76,9 @@ Modes:
   --auto           Enable auto-merge when immediate merge is blocked
 
 Exit codes:
-  0    MERGED                 — merge completed immediately
+  0    MERGED / ALREADY MERGED — merge completed now, or the PR was already merged
   75   QUEUED / AUTO-MERGE     — merge queue entry or classic auto-merge is active
-  1    BLOCKED                — checks failed; nothing queued
+  1    BLOCKED / CLOSED        — checks failed or the PR is closed unmerged; nothing queued
 
 Examples:
   github.sh pr-merge 42 --check          # Check only, JSON output
@@ -82,20 +88,36 @@ Examples:
 EOF
 }
 
+# One authoritative read of the PR's lifecycle state. Also validates that the
+# PR exists — a bare number does not.
+pr_state_json() {
+    gh pr view "$1" --json state,mergedAt 2>/dev/null
+}
+
 # Run safety checks, output JSON
 # JSON shape:
 #   {can_merge, issues, warnings, mergeable, review,
-#    transient: bool}     # true when only TRANSIENT issues are blocking
+#    transient: bool,     # true when only TRANSIENT issues are blocking
+#    state}               # PR lifecycle state: OPEN, MERGED, CLOSED, UNKNOWN
 run_checks() {
     local pr_num="$1"
     local can_merge=true
     local issues=()
     local warnings=()
 
-    # Check PR exists first (use title - number alone doesn't validate)
-    if ! gh pr view "$pr_num" --json title >/dev/null 2>&1; then
-        jq -n '{can_merge: false, issues: ["not_found: PR #'"$pr_num"' not found"], warnings: [], mergeable: "UNKNOWN", review: "", transient: false}'
+    local state_json pr_state
+    if ! state_json=$(pr_state_json "$pr_num"); then
+        jq -n '{can_merge: false, issues: ["not_found: PR #'"$pr_num"' not found"], warnings: [], mergeable: "UNKNOWN", review: "", transient: false, state: "UNKNOWN"}'
         return 0 # Return 0 so JSON is output, caller checks can_merge
+    fi
+    pr_state=$(jq -r '.state // "UNKNOWN"' <<<"$state_json")
+
+    # A terminal PR is unmergeable for a reason no caller can act on, and its
+    # check data is meaningless: `mergeable` is permanently UNKNOWN, post-merge
+    # CI runs and bot comments are not blockers. Report the state, no issues.
+    if [ "$pr_state" = "MERGED" ] || [ "$pr_state" = "CLOSED" ]; then
+        jq -n --arg state "$pr_state" '{can_merge: false, issues: [], warnings: [], mergeable: "UNKNOWN", review: "", transient: false, state: $state}'
+        return 0
     fi
 
     # 1. Check mergeable status
@@ -227,7 +249,8 @@ run_checks() {
         --arg mergeable "$mergeable" \
         --arg review "$review" \
         --argjson transient "$transient" \
-        '{can_merge: $can_merge, issues: $issues, warnings: $warnings, mergeable: $mergeable, review: $review, transient: $transient}'
+        --arg state "$pr_state" \
+        '{can_merge: $can_merge, issues: $issues, warnings: $warnings, mergeable: $mergeable, review: $review, transient: $transient, state: $state}'
 }
 
 # Print BLOCKED breakdown to stderr, distinguishing transient vs permanent.
@@ -392,6 +415,32 @@ main() {
     if [ "$check_only" = true ]; then
         run_checks "$pr_num"
         exit 0
+    fi
+
+    # Terminal-state short-circuit, ahead of every mode's checks, auth, and
+    # mutation. Retrying a merge on a PR that already left OPEN can only
+    # produce false diagnostics, and there is nothing left to mutate.
+    # An unreadable state is not terminal — fall through to the normal path.
+    local terminal_state_json terminal_state
+    if terminal_state_json=$(pr_state_json "$pr_num"); then
+        terminal_state=$(jq -r '.state // ""' <<<"$terminal_state_json")
+        case "$terminal_state" in
+        MERGED)
+            local merged_at
+            merged_at=$(jq -r '.mergedAt // ""' <<<"$terminal_state_json")
+            if [ -n "$merged_at" ]; then
+                echo "ALREADY MERGED PR #$pr_num $merged_at" >&2
+            else
+                echo "ALREADY MERGED PR #$pr_num" >&2
+            fi
+            exit 0
+            ;;
+        CLOSED)
+            echo "CLOSED (not merged) PR #$pr_num — no merge attempted, none queued" >&2
+            echo "  Reopen the PR or supersede it; merge flags cannot act on a closed PR." >&2
+            exit 1
+            ;;
+        esac
     fi
 
     local token

--- a/skills/github/scripts/commands/pr-merge.sh
+++ b/skills/github/scripts/commands/pr-merge.sh
@@ -88,10 +88,22 @@ Examples:
 EOF
 }
 
-# One authoritative read of the PR's lifecycle state. Also validates that the
-# PR exists — a bare number does not.
-pr_state_json() {
-    gh pr view "$1" --json state,mergedAt 2>/dev/null
+# One authoritative read of the PR's lifecycle state, published in
+# PR_STATE_JSON. Also validates that the PR exists — a bare number does not.
+# Every caller shares the single fetch; a failed read is not cached, so the
+# next caller retries rather than inheriting an empty state.
+PR_STATE_JSON=""
+PR_STATE_JSON_PR=""
+load_pr_state_json() {
+    local pr_num="$1"
+    if [ -n "$PR_STATE_JSON_PR" ] && [ "$PR_STATE_JSON_PR" = "$pr_num" ]; then
+        return 0
+    fi
+
+    local state_json
+    state_json=$(gh pr view "$pr_num" --json state,mergedAt 2>/dev/null) || return 1
+    PR_STATE_JSON="$state_json"
+    PR_STATE_JSON_PR="$pr_num"
 }
 
 # Run safety checks, output JSON
@@ -105,12 +117,12 @@ run_checks() {
     local issues=()
     local warnings=()
 
-    local state_json pr_state
-    if ! state_json=$(pr_state_json "$pr_num"); then
+    local pr_state
+    if ! load_pr_state_json "$pr_num"; then
         jq -n '{can_merge: false, issues: ["not_found: PR #'"$pr_num"' not found"], warnings: [], mergeable: "UNKNOWN", review: "", transient: false, state: "UNKNOWN"}'
         return 0 # Return 0 so JSON is output, caller checks can_merge
     fi
-    pr_state=$(jq -r '.state // "UNKNOWN"' <<<"$state_json")
+    pr_state=$(jq -r '.state // "UNKNOWN"' <<<"$PR_STATE_JSON")
 
     # A terminal PR is unmergeable for a reason no caller can act on, and its
     # check data is meaningless: `mergeable` is permanently UNKNOWN, post-merge
@@ -421,13 +433,13 @@ main() {
     # mutation. Retrying a merge on a PR that already left OPEN can only
     # produce false diagnostics, and there is nothing left to mutate.
     # An unreadable state is not terminal — fall through to the normal path.
-    local terminal_state_json terminal_state
-    if terminal_state_json=$(pr_state_json "$pr_num"); then
-        terminal_state=$(jq -r '.state // ""' <<<"$terminal_state_json")
+    local terminal_state
+    if load_pr_state_json "$pr_num"; then
+        terminal_state=$(jq -r '.state // ""' <<<"$PR_STATE_JSON")
         case "$terminal_state" in
         MERGED)
             local merged_at
-            merged_at=$(jq -r '.mergedAt // ""' <<<"$terminal_state_json")
+            merged_at=$(jq -r '.mergedAt // ""' <<<"$PR_STATE_JSON")
             if [ -n "$merged_at" ]; then
                 echo "ALREADY MERGED PR #$pr_num $merged_at" >&2
             else
@@ -436,8 +448,8 @@ main() {
             exit 0
             ;;
         CLOSED)
-            echo "CLOSED (not merged) PR #$pr_num — no merge attempted, none queued" >&2
-            echo "  Reopen the PR or supersede it; merge flags cannot act on a closed PR." >&2
+            echo "CLOSED (not merged) PR #$pr_num" >&2
+            echo "  No merge attempted, none queued. Reopen the PR or supersede it." >&2
             exit 1
             ;;
         esac

--- a/skills/github/scripts/commands/pr-threads.sh
+++ b/skills/github/scripts/commands/pr-threads.sh
@@ -231,22 +231,28 @@ query($owner: String!, $repo: String!, $number: Int!, $cursor: String!) {
         }
     }') || exit 1
 
+    # Resolution filter is format-independent: a filter that applied to one
+    # output shape only would report resolved threads as still outstanding.
+    local jq_filter
+    if [ "$filter_unresolved" = "true" ]; then
+        jq_filter='select(.isResolved == false)'
+    elif [ "$filter_resolved" = "true" ]; then
+        jq_filter='select(.isResolved == true)'
+    else
+        jq_filter='.'
+    fi
+
     # Apply format and filters
     case "$FORMAT" in
         raw)
-            echo "$result"
+            # Filter the thread nodes in place. Raw callers walk the GitHub
+            # response shape, and it carries no count field to keep in sync.
+            echo "$result" | jq -c '
+                .repository.pullRequest.reviewThreads.nodes |= [.[] | '"$jq_filter"']
+            '
             ;;
         safe)
-            local jq_filter
-            if [ "$filter_unresolved" = "true" ]; then
-                jq_filter='select(.isResolved == false)'
-            elif [ "$filter_resolved" = "true" ]; then
-                jq_filter='select(.isResolved == true)'
-            else
-                jq_filter='.'
-            fi
-
-            echo "$result" | jq --arg filter "$jq_filter" '{
+            echo "$result" | jq '{
                 count: ([.repository.pullRequest.reviewThreads.nodes[] | '"$jq_filter"'] | length),
                 unresolved_count: ([.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length),
                 threads: [.repository.pullRequest.reviewThreads.nodes[] | '"$jq_filter"' | {

--- a/skills/github/scripts/commands/pr-threads.sh
+++ b/skills/github/scripts/commands/pr-threads.sh
@@ -245,11 +245,15 @@ query($owner: String!, $repo: String!, $number: Int!, $cursor: String!) {
     # Apply format and filters
     case "$FORMAT" in
         raw)
-            # Filter the thread nodes in place. Raw callers walk the GitHub
-            # response shape, and it carries no count field to keep in sync.
-            echo "$result" | jq -c '
-                .repository.pullRequest.reviewThreads.nodes |= [.[] | '"$jq_filter"']
-            '
+            if [ "$filter_unresolved" = "true" ] || [ "$filter_resolved" = "true" ]; then
+                # Filter the thread nodes in place. Raw callers walk the GitHub
+                # response shape, and it carries no count field to keep in sync.
+                echo "$result" | jq -c '
+                    .repository.pullRequest.reviewThreads.nodes |= [.[] | '"$jq_filter"']
+                '
+            else
+                echo "$result"
+            fi
             ;;
         safe)
             echo "$result" | jq '{

--- a/skills/github/tests/pr-merge-terminal-state.test.sh
+++ b/skills/github/tests/pr-merge-terminal-state.test.sh
@@ -109,6 +109,12 @@ case "${1:-}" in
                     if [[ "${STUB_STATE_SILENT_FAIL:-false}" == "true" ]]; then
                         exit "${STUB_STATE_EXIT:-1}"
                     fi
+                    # Transient failure: only the first lookup of a run fails.
+                    if [[ -n "${STUB_STATE_FAIL_ONCE:-}" && ! -f "$STUB_STATE_FAIL_ONCE" ]]; then
+                        : >"$STUB_STATE_FAIL_ONCE"
+                        echo "error connecting to api.github.com" >&2
+                        exit 1
+                    fi
                     if [[ "${STUB_PR_MISSING:-false}" == "true" ]]; then
                         echo "no pull requests found" >&2
                         exit 1
@@ -152,9 +158,11 @@ EOF
 chmod +x "$TMPDIR/bin/gh"
 
 call_log="$TMPDIR/calls.log"
+fail_once_marker="$TMPDIR/state-lookup-failed-once"
 
 run_pr_merge() { # env assignments come from the caller's environment
     : >"$call_log"
+    rm -f "$fail_once_marker"
     (cd "$TMPDIR/repo" && PATH="$TMPDIR/bin:$PATH" env -u GH_TOKEN -u GITHUB_TOKEN \
         STUB_CALL_LOG="$call_log" "$PR_MERGE" 123 "$@" 2>&1)
 }
@@ -219,6 +227,7 @@ echo "=== --check reports the terminal state instead of issues ==="
 
 out=$(STUB_STATE=MERGED STUB_MERGED_AT=2026-08-15T09:41:12Z run_pr_merge --check)
 assert_eq "$(jq -r .state <<<"$out")" "MERGED" "--check reports state MERGED"
+assert_eq "$(jq -r .merged_at <<<"$out")" "2026-08-15T09:41:12Z" "--check carries the merge timestamp"
 assert_eq "$(jq -r .can_merge <<<"$out")" "false" "--check on a merged PR cannot merge"
 assert_eq "$(jq -r '.issues | length' <<<"$out")" "0" "--check on a merged PR reports no issues"
 assert_eq "$(jq -r '.warnings | length' <<<"$out")" "0" "--check on a merged PR reports no warnings"
@@ -267,6 +276,42 @@ assert_eq "$status" "1" "a failed state lookup blocks the merge"
 assert_contains "$out" "gh_error: gh: Bad credentials (HTTP 401)" "the merge path reports the real cause"
 assert_not_contains "$out" "not_found" "the merge path never reports a missing PR for an auth failure"
 assert_not_contains "$out" "ALREADY MERGED" "an unreadable state is never treated as merged"
+
+echo
+echo "=== a state resolved only on the retry still short-circuits ==="
+
+# The up-front lookup fails on a network blip; the readiness checks re-read and
+# find the PR terminal. `--auto` defers every non-thread blocker, so without a
+# second branch on the checked state it arms a merge on a landed PR.
+set +e
+out=$(STUB_STATE=MERGED STUB_MERGED_AT=2026-08-15T09:41:12Z \
+    STUB_STATE_FAIL_ONCE="$fail_once_marker" run_pr_merge --auto --keep-branch)
+status=$?
+set -e
+assert_eq "$status" "0" "--auto exits MERGED (0) when only the retry resolves the state"
+assert_contains "$out" "ALREADY MERGED PR #123 2026-08-15T09:41:12Z" \
+    "the retried state still reports the already-merged outcome with its timestamp"
+assert_not_contains "$out" "BLOCKED" "the retried state never reports BLOCKED"
+assert_not_contains "$(cat "$call_log")" "pr merge" "a state resolved on retry still blocks the mutation"
+assert_eq "$(grep -c -- '--json state,mergedAt' "$call_log")" "2" \
+    "the failed lookup is retried rather than cached"
+
+set +e
+out=$(STUB_STATE=CLOSED STUB_STATE_FAIL_ONCE="$fail_once_marker" run_pr_merge --auto --keep-branch)
+status=$?
+set -e
+assert_eq "$status" "1" "--auto exits 1 when only the retry finds the PR closed"
+assert_eq "$(head -1 <<<"$out")" "CLOSED (not merged) PR #123" \
+    "the retried closed state keeps the exact state line"
+assert_not_contains "$(cat "$call_log")" "pr merge" "a closed PR found on retry blocks the mutation"
+
+set +e
+out=$(STUB_STATE=MERGED STUB_MERGED_AT=2026-08-15T09:41:12Z \
+    STUB_STATE_FAIL_ONCE="$fail_once_marker" run_pr_merge --keep-branch)
+status=$?
+set -e
+assert_eq "$status" "0" "immediate mode exits MERGED (0) on a retry-resolved state"
+assert_not_contains "$(cat "$call_log")" "pr merge" "immediate mode attempts no mutation either"
 
 echo
 echo "=== an open PR is unaffected ==="

--- a/skills/github/tests/pr-merge-terminal-state.test.sh
+++ b/skills/github/tests/pr-merge-terminal-state.test.sh
@@ -102,6 +102,13 @@ case "${1:-}" in
         case "${2:-}" in
             view)
                 if [[ "$*" == *"--json state,mergedAt"* ]]; then
+                    if [[ -n "${STUB_STATE_STDERR:-}" ]]; then
+                        printf '%s\n' "$STUB_STATE_STDERR" >&2
+                        exit "${STUB_STATE_EXIT:-1}"
+                    fi
+                    if [[ "${STUB_STATE_SILENT_FAIL:-false}" == "true" ]]; then
+                        exit "${STUB_STATE_EXIT:-1}"
+                    fi
                     if [[ "${STUB_PR_MISSING:-false}" == "true" ]]; then
                         echo "no pull requests found" >&2
                         exit 1
@@ -225,6 +232,41 @@ assert_eq "$(jq -r '.issues | length' <<<"$out")" "0" "--check on a closed PR re
 out=$(STUB_PR_MISSING=true run_pr_merge --check)
 assert_eq "$(jq -r .state <<<"$out")" "UNKNOWN" "--check on a missing PR reports UNKNOWN state"
 assert_contains "$(jq -r '.issues[]' <<<"$out")" "not_found: PR #123 not found" "--check still reports a missing PR"
+
+echo
+echo "=== a failed state lookup names its real cause ==="
+
+out=$(STUB_STATE_STDERR="GraphQL: Could not resolve to a PullRequest with the number of 123. (repository.pullRequest)" \
+    run_pr_merge --check)
+assert_contains "$(jq -r '.issues[]' <<<"$out")" "not_found: PR #123 not found" \
+    "GitHub's own missing-PR wording stays not_found"
+
+out=$(STUB_STATE_STDERR="gh: Bad credentials (HTTP 401)" STUB_STATE_EXIT=1 run_pr_merge --check)
+assert_contains "$(jq -r '.issues[]' <<<"$out")" "gh_error: gh: Bad credentials (HTTP 401)" \
+    "an auth failure is reported as gh_error with its diagnostic"
+assert_not_contains "$(jq -r '.issues[]' <<<"$out")" "not_found" \
+    "an auth failure is never reported as a missing PR"
+assert_eq "$(jq -r '.issues | length' <<<"$out")" "1" "a failed state lookup emits one issue"
+assert_eq "$(jq -r .state <<<"$out")" "UNKNOWN" "a failed state lookup reports UNKNOWN state"
+
+out=$(STUB_STATE_STDERR="API rate limit exceeded for user ID 1." STUB_STATE_EXIT=1 run_pr_merge --check)
+assert_contains "$(jq -r '.issues[]' <<<"$out")" "gh_error: API rate limit exceeded" \
+    "a rate-limit failure keeps its own diagnostic"
+
+out=$(STUB_STATE_SILENT_FAIL=true STUB_STATE_EXIT=4 run_pr_merge --check)
+assert_contains "$(jq -r '.issues[]' <<<"$out")" "gh_error: gh pr view exited 4 with no diagnostic" \
+    "a silent failure still names gh and its exit code"
+
+# The merge path must see the same cause: a failed lookup is not cached, so the
+# checks re-read it instead of inheriting an empty state and inventing issues.
+set +e
+out=$(STUB_STATE_STDERR="gh: Bad credentials (HTTP 401)" run_pr_merge --keep-branch)
+status=$?
+set -e
+assert_eq "$status" "1" "a failed state lookup blocks the merge"
+assert_contains "$out" "gh_error: gh: Bad credentials (HTTP 401)" "the merge path reports the real cause"
+assert_not_contains "$out" "not_found" "the merge path never reports a missing PR for an auth failure"
+assert_not_contains "$out" "ALREADY MERGED" "an unreadable state is never treated as merged"
 
 echo
 echo "=== an open PR is unaffected ==="

--- a/skills/github/tests/pr-merge-terminal-state.test.sh
+++ b/skills/github/tests/pr-merge-terminal-state.test.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+# Regression tests for pr-merge on a PR that has already left OPEN.
+#
+# `mergeable` is permanently UNKNOWN after a merge, so running the readiness
+# checks against a merged PR invented blockers — `unknown:`, `ci_pending:` from
+# post-merge runs, `unresolved_threads:` from post-merge bot comments — and
+# returned BLOCKED, which drives a caller to re-arm a merge that already
+# happened. A merged or closed PR is terminal and short-circuits every mode.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../.." && pwd)"
+PR_MERGE="$REPO_ROOT/skills/github/scripts/commands/pr-merge.sh"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local got="$1" want="$2" name="$3"
+    if [[ "$got" == "$want" ]]; then
+        PASS=$((PASS + 1))
+        printf '  ok    %s\n' "$name"
+    else
+        FAIL=$((FAIL + 1))
+        printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$name" "$want" "$got"
+    fi
+}
+
+assert_contains() {
+    local haystack="$1" needle="$2" name="$3"
+    if grep -qF -- "$needle" <<<"$haystack"; then
+        PASS=$((PASS + 1))
+        printf '  ok    %s\n' "$name"
+    else
+        FAIL=$((FAIL + 1))
+        printf '  FAIL  %s\n        wanted substring: %s\n        in: %s\n' "$name" "$needle" "$haystack"
+    fi
+}
+
+assert_not_contains() {
+    local haystack="$1" needle="$2" name="$3"
+    if ! grep -qF -- "$needle" <<<"$haystack"; then
+        PASS=$((PASS + 1))
+        printf '  ok    %s\n' "$name"
+    else
+        FAIL=$((FAIL + 1))
+        printf '  FAIL  %s\n        unwanted substring: %s\n        in: %s\n' "$name" "$needle" "$haystack"
+    fi
+}
+
+mkdir -p "$TMPDIR/bin" "$TMPDIR/repo"
+git -C "$TMPDIR/repo" init -q
+
+# Stub gh. The post-merge shapes are the real ones a merged PR returns:
+# mergeable UNKNOWN, a still-running post-merge workflow, and an unresolved
+# thread from a bot comment posted after the merge.
+cat >"$TMPDIR/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -n "${STUB_CALL_LOG:-}" ]]; then
+    printf '%s\n' "$*" >>"$STUB_CALL_LOG"
+fi
+
+case "${1:-}" in
+    auth)
+        if [[ "${2:-}" == "status" ]]; then
+            echo "Logged in"
+            exit 0
+        fi
+        ;;
+    repo)
+        if [[ "${2:-}" == "view" ]]; then
+            echo '{"owner":{"login":"owner"},"name":"repo"}'
+            exit 0
+        fi
+        ;;
+    api)
+        if [[ "${2:-}" == "graphql" ]]; then
+            if [[ "$*" == *"mergeQueueEntry"* ]]; then
+                jq -cn \
+                    --arg state "${STUB_POST_STATE:-OPEN}" \
+                    --arg head "${STUB_HEAD:-test-head}" \
+                    '{data:{repository:{pullRequest:{state:$state,headRefOid:$head,headRefName:"issue-123",mergeCommit:null,autoMergeRequest:null,isInMergeQueue:false,mergeQueueEntry:null}}}}'
+                exit 0
+            fi
+            jq -cn '{data:{repository:{pullRequest:{reviewThreads:{
+                nodes:[{id:"PRRT_post_merge_bot",isResolved:false,isOutdated:false,path:"src/lib.rs",line:3,
+                        comments:{nodes:[{author:{login:"review-bot"},body:"post-merge nit"}]}}],
+                pageInfo:{hasNextPage:false,endCursor:null}}}}}}'
+            exit 0
+        fi
+        ;;
+    pr)
+        case "${2:-}" in
+            view)
+                if [[ "$*" == *"--json state,mergedAt"* ]]; then
+                    if [[ "${STUB_PR_MISSING:-false}" == "true" ]]; then
+                        echo "no pull requests found" >&2
+                        exit 1
+                    fi
+                    jq -cn \
+                        --arg state "${STUB_STATE:-OPEN}" \
+                        --arg merged_at "${STUB_MERGED_AT:-}" \
+                        '{state:$state,mergedAt:(if $merged_at == "" then null else $merged_at end)}'
+                    exit 0
+                fi
+                if [[ "$*" == *"--json headRefOid"* ]]; then
+                    echo "${STUB_HEAD:-test-head}"
+                    exit 0
+                fi
+                if [[ "$*" == *"--json mergeable"* ]]; then
+                    echo "${STUB_MERGEABLE:-UNKNOWN}"
+                    exit 0
+                fi
+                if [[ "$*" == *"--json reviewDecision,latestReviews"* ]]; then
+                    echo '{"reviewDecision":"APPROVED","latestReviews":[{"state":"APPROVED"}]}'
+                    exit 0
+                fi
+                ;;
+            merge)
+                echo "merge command accepted"
+                exit 0
+                ;;
+            checks)
+                # Required: a terminal PR must never reach this call, so an
+                # unset value fails the run instead of passing silently.
+                printf '%s\n' "${STUB_CHECKS:?}"
+                exit "${STUB_CHECKS_EXIT:-8}"
+                ;;
+        esac
+        ;;
+esac
+
+printf 'unexpected gh call: %s\n' "$*" >&2
+exit 1
+EOF
+chmod +x "$TMPDIR/bin/gh"
+
+call_log="$TMPDIR/calls.log"
+
+run_pr_merge() { # env assignments come from the caller's environment
+    : >"$call_log"
+    (cd "$TMPDIR/repo" && PATH="$TMPDIR/bin:$PATH" env -u GH_TOKEN -u GITHUB_TOKEN \
+        STUB_CALL_LOG="$call_log" "$PR_MERGE" 123 "$@" 2>&1)
+}
+
+echo "=== already-merged PR short-circuits every merge mode ==="
+
+set +e
+out=$(STUB_STATE=MERGED STUB_MERGED_AT=2026-08-15T09:41:12Z run_pr_merge --auto --keep-branch)
+status=$?
+set -e
+assert_eq "$status" "0" "--auto on a merged PR exits MERGED (0)"
+assert_contains "$out" "ALREADY MERGED PR #123 2026-08-15T09:41:12Z" "--auto reports the already-merged outcome with mergedAt"
+assert_not_contains "$out" "BLOCKED" "--auto on a merged PR never reports BLOCKED"
+assert_not_contains "$out" "unknown:" "no invented mergeable-UNKNOWN issue"
+assert_not_contains "$out" "ci_pending:" "no post-merge CI run reported as a blocker"
+assert_not_contains "$out" "unresolved_threads" "no post-merge comment thread reported as a blocker"
+assert_not_contains "$(cat "$call_log")" "pr merge" "merged PR never reaches gh pr merge"
+assert_not_contains "$(cat "$call_log")" "pr checks" "merged PR never fetches CI checks"
+assert_not_contains "$(cat "$call_log")" "graphql" "merged PR never fetches threads or queue state"
+
+set +e
+out=$(STUB_STATE=MERGED STUB_MERGED_AT=2026-08-15T09:41:12Z run_pr_merge --keep-branch)
+status=$?
+set -e
+assert_eq "$status" "0" "immediate merge on a merged PR exits MERGED (0)"
+assert_contains "$out" "ALREADY MERGED PR #123" "immediate mode reports the already-merged outcome"
+assert_not_contains "$(cat "$call_log")" "pr merge" "immediate mode attempts no mutation"
+
+set +e
+out=$(STUB_STATE=MERGED STUB_MERGED_AT=2026-08-15T09:41:12Z run_pr_merge --force --keep-branch)
+status=$?
+set -e
+assert_eq "$status" "0" "--force on a merged PR exits MERGED (0)"
+assert_contains "$out" "ALREADY MERGED PR #123" "--force reports the already-merged outcome"
+assert_not_contains "$(cat "$call_log")" "pr merge" "--force attempts no mutation on a merged PR"
+
+set +e
+out=$(STUB_STATE=MERGED run_pr_merge --auto --keep-branch)
+status=$?
+set -e
+assert_eq "$status" "0" "merged PR without a mergedAt timestamp still exits 0"
+assert_eq "$out" "ALREADY MERGED PR #123" "missing mergedAt emits the bare line, no trailing field"
+
+echo
+echo "=== closed-unmerged PR is a distinct terminal refusal ==="
+
+set +e
+out=$(STUB_STATE=CLOSED run_pr_merge --auto --keep-branch)
+status=$?
+set -e
+assert_eq "$status" "1" "--auto on a closed PR exits 1"
+assert_contains "$out" "CLOSED (not merged) PR #123" "closed PR names its state"
+assert_not_contains "$out" "unknown:" "closed PR reports no mergeable-UNKNOWN issue"
+assert_not_contains "$out" "ci_pending:" "closed PR reports no CI issue"
+assert_not_contains "$out" "unresolved_threads" "closed PR reports no thread issue"
+assert_not_contains "$out" "ALREADY MERGED" "closed PR is never reported as merged"
+assert_not_contains "$(cat "$call_log")" "pr merge" "closed PR never reaches gh pr merge"
+
+echo
+echo "=== --check reports the terminal state instead of issues ==="
+
+out=$(STUB_STATE=MERGED STUB_MERGED_AT=2026-08-15T09:41:12Z run_pr_merge --check)
+assert_eq "$(jq -r .state <<<"$out")" "MERGED" "--check reports state MERGED"
+assert_eq "$(jq -r .can_merge <<<"$out")" "false" "--check on a merged PR cannot merge"
+assert_eq "$(jq -r '.issues | length' <<<"$out")" "0" "--check on a merged PR reports no issues"
+assert_eq "$(jq -r '.warnings | length' <<<"$out")" "0" "--check on a merged PR reports no warnings"
+assert_eq "$(jq -r .transient <<<"$out")" "false" "--check on a merged PR is not transient"
+assert_not_contains "$(cat "$call_log")" "pr checks" "--check on a merged PR fetches no CI"
+
+out=$(STUB_STATE=CLOSED run_pr_merge --check)
+assert_eq "$(jq -r .state <<<"$out")" "CLOSED" "--check reports state CLOSED"
+assert_eq "$(jq -r '.issues | length' <<<"$out")" "0" "--check on a closed PR reports no issues"
+
+out=$(STUB_PR_MISSING=true run_pr_merge --check)
+assert_eq "$(jq -r .state <<<"$out")" "UNKNOWN" "--check on a missing PR reports UNKNOWN state"
+assert_contains "$(jq -r '.issues[]' <<<"$out")" "not_found: PR #123 not found" "--check still reports a missing PR"
+
+echo
+echo "=== an open PR is unaffected ==="
+
+checks='[{"name":"CI Required","state":"SUCCESS","bucket":"pass"}]'
+
+out=$(STUB_STATE=OPEN STUB_MERGEABLE=MERGEABLE STUB_CHECKS="$checks" STUB_CHECKS_EXIT=0 run_pr_merge --check)
+assert_eq "$(jq -r .state <<<"$out")" "OPEN" "--check reports state OPEN for a live PR"
+assert_eq "$(jq -r .mergeable <<<"$out")" "MERGEABLE" "--check still reports the live mergeable value"
+assert_contains "$(jq -r '.issues[]' <<<"$out")" "unresolved_threads" "--check still gates a live PR on its open thread"
+
+set +e
+out=$(STUB_STATE=OPEN STUB_POST_STATE=MERGED STUB_MERGEABLE=MERGEABLE \
+    STUB_CHECKS="$checks" STUB_CHECKS_EXIT=0 run_pr_merge --force --keep-branch)
+status=$?
+set -e
+assert_eq "$status" "0" "an open PR still merges"
+assert_contains "$out" "MERGED PR #123" "open PR reports the live merge outcome"
+assert_not_contains "$out" "ALREADY MERGED" "a live merge is not reported as already merged"
+assert_contains "$(cat "$call_log")" "pr merge" "open PR still reaches gh pr merge"
+
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/skills/github/tests/pr-merge-terminal-state.test.sh
+++ b/skills/github/tests/pr-merge-terminal-state.test.sh
@@ -86,6 +86,11 @@ case "${1:-}" in
                     '{data:{repository:{pullRequest:{state:$state,headRefOid:$head,headRefName:"issue-123",mergeCommit:null,autoMergeRequest:null,isInMergeQueue:false,mergeQueueEntry:null}}}}'
                 exit 0
             fi
+            if [[ -n "${STUB_THREADS_JSON:-}" ]]; then
+                jq -cn --argjson nodes "$STUB_THREADS_JSON" \
+                    '{data:{repository:{pullRequest:{reviewThreads:{nodes:$nodes,pageInfo:{hasNextPage:false,endCursor:null}}}}}}'
+                exit 0
+            fi
             jq -cn '{data:{repository:{pullRequest:{reviewThreads:{
                 nodes:[{id:"PRRT_post_merge_bot",isResolved:false,isOutdated:false,path:"src/lib.rs",line:3,
                         comments:{nodes:[{author:{login:"review-bot"},body:"post-merge nit"}]}}],
@@ -194,7 +199,8 @@ out=$(STUB_STATE=CLOSED run_pr_merge --auto --keep-branch)
 status=$?
 set -e
 assert_eq "$status" "1" "--auto on a closed PR exits 1"
-assert_contains "$out" "CLOSED (not merged) PR #123" "closed PR names its state"
+assert_eq "$(head -1 <<<"$out")" "CLOSED (not merged) PR #123" \
+    "closed PR's first line is exactly the machine-readable state line"
 assert_not_contains "$out" "unknown:" "closed PR reports no mergeable-UNKNOWN issue"
 assert_not_contains "$out" "ci_pending:" "closed PR reports no CI issue"
 assert_not_contains "$out" "unresolved_threads" "closed PR reports no thread issue"
@@ -239,6 +245,18 @@ assert_eq "$status" "0" "an open PR still merges"
 assert_contains "$out" "MERGED PR #123" "open PR reports the live merge outcome"
 assert_not_contains "$out" "ALREADY MERGED" "a live merge is not reported as already merged"
 assert_contains "$(cat "$call_log")" "pr merge" "open PR still reaches gh pr merge"
+
+# The state read is shared: the terminal-state guard and the readiness checks
+# must not each spend a round trip on the same field.
+set +e
+out=$(STUB_STATE=OPEN STUB_POST_STATE=MERGED STUB_MERGEABLE=MERGEABLE \
+    STUB_THREADS_JSON='[]' STUB_CHECKS="$checks" STUB_CHECKS_EXIT=0 \
+    run_pr_merge --keep-branch)
+status=$?
+set -e
+assert_eq "$status" "0" "a checked open PR still merges"
+assert_eq "$(grep -c -- '--json state,mergedAt' "$call_log")" "1" \
+    "an open PR reads its state exactly once"
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/skills/github/tests/pr-merge.sh
+++ b/skills/github/tests/pr-merge.sh
@@ -136,8 +136,11 @@ case "${1:-}" in
     pr)
         case "${2:-}" in
             view)
-                if [[ "$*" == *"--json title"* ]]; then
-                    echo '{"title":"Test PR"}'
+                if [[ "$*" == *"--json state,mergedAt"* ]]; then
+                    jq -cn \
+                        --arg state "${STUB_STATE:-OPEN}" \
+                        --arg merged_at "${STUB_MERGED_AT:-}" \
+                        '{state:$state,mergedAt:(if $merged_at == "" then null else $merged_at end)}'
                     exit 0
                 fi
                 if [[ "$*" == *"--json headRefName"* ]]; then

--- a/skills/github/tests/pr-threads-raw-filter.test.sh
+++ b/skills/github/tests/pr-threads-raw-filter.test.sh
@@ -65,6 +65,20 @@ exit 1
 EOF
 chmod +x "$TMP_ROOT/bin/gh"
 
+# Shim jq to record every program it is handed, then run the real one. Raw
+# output must reach the caller as the API returned it, so the unfiltered path
+# has to skip the filter pass rather than re-serialize through it.
+REAL_JQ="$(command -v jq)"
+jq_log="$TMP_ROOT/jq-programs.log"
+cat >"$TMP_ROOT/bin/jq" <<EOF
+#!/usr/bin/env bash
+if [ -n "\${STUB_JQ_LOG:-}" ]; then
+    printf '%s\n' "\$*" >>"\$STUB_JQ_LOG"
+fi
+exec "$REAL_JQ" "\$@"
+EOF
+chmod +x "$TMP_ROOT/bin/jq"
+
 mk_thread() { # id isResolved
     jq -cn --arg id "$1" --argjson resolved "$2" \
         '{id:$id,isResolved:$resolved,isOutdated:false,path:"src/lib.rs",line:7,
@@ -77,9 +91,15 @@ threads=$(jq -sc '.' \
     <(mk_thread PRRT_open false))
 
 run_threads() {
+    : >"$jq_log"
     (cd "$TMP_ROOT/repo" && PATH="$TMP_ROOT/bin:$PATH" env -u GH_TOKEN -u GITHUB_TOKEN \
-        STUB_THREADS_JSON="$threads" "${STUB_PAGE2_ENV[@]+"${STUB_PAGE2_ENV[@]}"}" \
+        STUB_THREADS_JSON="$threads" STUB_JQ_LOG="$jq_log" \
+        "${STUB_PAGE2_ENV[@]+"${STUB_PAGE2_ENV[@]}"}" \
         "$PR_THREADS" 123 "$@")
+}
+
+filter_passes() { # count jq runs that rewrite the thread node array
+    grep -c -- 'reviewThreads.nodes |=' "$jq_log" || true
 }
 
 STUB_PAGE2_ENV=()
@@ -100,9 +120,16 @@ assert_eq "$(jq '.repository.pullRequest.reviewThreads.nodes | length' <<<"$out"
 assert_eq "$(jq '[.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length' <<<"$out")" "0" \
     "raw --resolved emits no unresolved node"
 
+assert_eq "$(filter_passes)" "1" "raw --resolved runs exactly one filter pass"
+
 out=$(run_threads --format=raw)
 assert_eq "$(jq '.repository.pullRequest.reviewThreads.nodes | length' <<<"$out")" "3" \
     "raw without a filter still returns every thread"
+assert_eq "$out" \
+    "$("$REAL_JQ" -cn --argjson nodes "$threads" \
+        '{repository:{pullRequest:{reviewThreads:{nodes:$nodes,pageInfo:{hasNextPage:false,endCursor:null}}}}}')" \
+    "unfiltered raw is the API payload byte for byte"
+assert_eq "$(filter_passes)" "0" "unfiltered raw is never re-serialized through a filter pass"
 
 echo
 echo "=== raw structure is preserved for callers that walk it ==="

--- a/skills/github/tests/pr-threads-raw-filter.test.sh
+++ b/skills/github/tests/pr-threads-raw-filter.test.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Regression tests for pr-threads resolution filters in --format=raw.
+#
+# The raw branch echoed the GraphQL result unfiltered, so
+# `--unresolved --format=raw` returned resolved threads and a verification
+# workflow counting raw nodes read "all resolved" as "nothing resolved".
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../.." && pwd)"
+PR_THREADS="$REPO_ROOT/skills/github/scripts/commands/pr-threads.sh"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local got="$1" want="$2" name="$3"
+    if [[ "$got" == "$want" ]]; then
+        PASS=$((PASS + 1))
+        printf '  ok    %s\n' "$name"
+    else
+        FAIL=$((FAIL + 1))
+        printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$name" "$want" "$got"
+    fi
+}
+
+mkdir -p "$TMP_ROOT/bin" "$TMP_ROOT/repo"
+git -C "$TMP_ROOT/repo" init -q
+
+# Stub gh: auth passes, repo resolves, GraphQL serves one or two thread pages.
+cat >"$TMP_ROOT/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-} ${2:-}" in
+    "auth status")
+        echo "Logged in"
+        exit 0
+        ;;
+    "repo view")
+        echo '{"owner":{"login":"owner"},"name":"repo"}'
+        exit 0
+        ;;
+    "api graphql")
+        if [[ "$*" == *"cursor=cursor-page-2"* ]]; then
+            jq -cn --argjson nodes "${STUB_THREADS_PAGE2_JSON:-[]}" \
+                '{data:{repository:{pullRequest:{reviewThreads:{nodes:$nodes,pageInfo:{hasNextPage:false,endCursor:null}}}}}}'
+            exit 0
+        fi
+        if [[ -n "${STUB_THREADS_PAGE2_JSON:-}" ]]; then
+            jq -cn --argjson nodes "${STUB_THREADS_JSON:-[]}" \
+                '{data:{repository:{pullRequest:{reviewThreads:{nodes:$nodes,pageInfo:{hasNextPage:true,endCursor:"cursor-page-2"}}}}}}'
+            exit 0
+        fi
+        jq -cn --argjson nodes "${STUB_THREADS_JSON:-[]}" \
+            '{data:{repository:{pullRequest:{reviewThreads:{nodes:$nodes,pageInfo:{hasNextPage:false,endCursor:null}}}}}}'
+        exit 0
+        ;;
+esac
+
+printf 'unexpected gh call: %s\n' "$*" >&2
+exit 1
+EOF
+chmod +x "$TMP_ROOT/bin/gh"
+
+mk_thread() { # id isResolved
+    jq -cn --arg id "$1" --argjson resolved "$2" \
+        '{id:$id,isResolved:$resolved,isOutdated:false,path:"src/lib.rs",line:7,
+          comments:{nodes:[{author:{login:"reviewer"},body:"note"}]}}'
+}
+
+threads=$(jq -sc '.' \
+    <(mk_thread PRRT_done_a true) \
+    <(mk_thread PRRT_done_b true) \
+    <(mk_thread PRRT_open false))
+
+run_threads() {
+    (cd "$TMP_ROOT/repo" && PATH="$TMP_ROOT/bin:$PATH" env -u GH_TOKEN -u GITHUB_TOKEN \
+        STUB_THREADS_JSON="$threads" "${STUB_PAGE2_ENV[@]+"${STUB_PAGE2_ENV[@]}"}" \
+        "$PR_THREADS" 123 "$@")
+}
+
+STUB_PAGE2_ENV=()
+
+echo "=== pr-threads --format=raw honors the resolution filters ==="
+
+out=$(run_threads --unresolved --format=raw)
+assert_eq "$(jq '.repository.pullRequest.reviewThreads.nodes | length' <<<"$out")" "1" \
+    "raw --unresolved returns only the unresolved node"
+assert_eq "$(jq '[.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == true)] | length' <<<"$out")" "0" \
+    "raw --unresolved emits no resolved node"
+assert_eq "$(jq -r '.repository.pullRequest.reviewThreads.nodes[0].id' <<<"$out")" "PRRT_open" \
+    "raw --unresolved keeps the matching thread's id"
+
+out=$(run_threads --resolved --format=raw)
+assert_eq "$(jq '.repository.pullRequest.reviewThreads.nodes | length' <<<"$out")" "2" \
+    "raw --resolved returns only resolved nodes"
+assert_eq "$(jq '[.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length' <<<"$out")" "0" \
+    "raw --resolved emits no unresolved node"
+
+out=$(run_threads --format=raw)
+assert_eq "$(jq '.repository.pullRequest.reviewThreads.nodes | length' <<<"$out")" "3" \
+    "raw without a filter still returns every thread"
+
+echo
+echo "=== raw structure is preserved for callers that walk it ==="
+
+out=$(run_threads --unresolved --format=raw)
+assert_eq "$(jq '[.. | objects | select(has("isResolved"))] | length' <<<"$out")" "1" \
+    "raw --unresolved counts one thread through the generic object walk"
+assert_eq "$(jq -r '.repository.pullRequest.reviewThreads.pageInfo.hasNextPage' <<<"$out")" "false" \
+    "raw --unresolved keeps the pageInfo envelope"
+assert_eq "$(jq -r '.repository.pullRequest.reviewThreads.nodes[0].comments.nodes[0].author.login' <<<"$out")" "reviewer" \
+    "raw --unresolved keeps the untouched GitHub node shape"
+
+echo
+echo "=== the filter applies across every fetched page ==="
+
+page2=$(jq -sc '.' <(mk_thread PRRT_page2_open false) <(mk_thread PRRT_page2_done true))
+STUB_PAGE2_ENV=(STUB_THREADS_PAGE2_JSON="$page2")
+out=$(run_threads --unresolved --format=raw)
+assert_eq "$(jq '.repository.pullRequest.reviewThreads.nodes | length' <<<"$out")" "2" \
+    "raw --unresolved filters the merged multi-page node list"
+assert_eq "$(jq -r '[.repository.pullRequest.reviewThreads.nodes[].id] | sort | join(",")' <<<"$out")" \
+    "PRRT_open,PRRT_page2_open" \
+    "raw --unresolved keeps unresolved threads from both pages"
+assert_eq "$(jq -r '.repository.pullRequest.reviewThreads.pageInfo.hasNextPage' <<<"$out")" "false" \
+    "raw pagination stays complete after filtering"
+STUB_PAGE2_ENV=()
+
+echo
+echo "=== safe format counts are unchanged ==="
+
+out=$(run_threads --unresolved)
+assert_eq "$(jq '.count' <<<"$out")" "1" "safe --unresolved counts the filtered set"
+assert_eq "$(jq '.unresolved_count' <<<"$out")" "1" "safe --unresolved reports the PR's unresolved total"
+assert_eq "$(jq '.threads | length' <<<"$out")" "1" "safe --unresolved lists only unresolved threads"
+
+out=$(run_threads --resolved)
+assert_eq "$(jq '.count' <<<"$out")" "2" "safe --resolved counts the filtered set"
+assert_eq "$(jq '.unresolved_count' <<<"$out")" "1" "safe --resolved still reports the PR's unresolved total"
+
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/skills/orch/workflows/merge-pr.md
+++ b/skills/orch/workflows/merge-pr.md
@@ -50,6 +50,8 @@ High-severity findings (conflicts) abort early with the issues shown. Otherwise 
 
 ### 3.2 Act On The Result
 
+`CHECK.state` decides first: `MERGED` → the PR already landed, skip to § 5 step 2 for sync and cleanup; `CLOSED` → report that it was closed unmerged and stop. Neither is a blocker to clear, and both arrive with an empty `issues` array.
+
 `can_merge: true` → § 4, showing any warnings. `false` → show the issues with their suggested fixes and ask: `Skip` | `Fix and retry` | `Force merge`.
 
 Two warnings are merge gates, not advice:

--- a/skills/orch/workflows/merge-pr.md
+++ b/skills/orch/workflows/merge-pr.md
@@ -50,7 +50,7 @@ High-severity findings (conflicts) abort early with the issues shown. Otherwise 
 
 ### 3.2 Act On The Result
 
-`CHECK.state` decides first: `MERGED` → the PR already landed, skip to § 5 step 2 for sync and cleanup; `CLOSED` → report that it was closed unmerged and stop. Neither is a blocker to clear, and both arrive with an empty `issues` array.
+`CHECK.state` decides first: `MERGED` → the PR already landed — run § 4 (`ISSUE`, worktree, token) and § 5's preamble (`MAIN_REPO_ROOT`) as for a fresh merge, then continue at § 5 step 2 for sync and cleanup, skipping step 1; `CLOSED` → report that it was closed unmerged and stop. Neither is a blocker to clear, and both arrive with an empty `issues` array.
 
 `can_merge: true` → § 4, showing any warnings. `false` → show the issues with their suggested fixes and ask: `Skip` | `Fix and retry` | `Force merge`.
 

--- a/skills/orch/workflows/merge-pr.md
+++ b/skills/orch/workflows/merge-pr.md
@@ -50,7 +50,7 @@ High-severity findings (conflicts) abort early with the issues shown. Otherwise 
 
 ### 3.2 Act On The Result
 
-`CHECK.state` decides first: `MERGED` → the PR already landed — run § 4 (`ISSUE`, worktree, token) and § 5's preamble (`MAIN_REPO_ROOT`) as for a fresh merge, then continue at § 5 step 2 for sync and cleanup, skipping step 1; `CLOSED` → report that it was closed unmerged and stop. Neither is a blocker to clear, and both arrive with an empty `issues` array.
+`CHECK.state` decides first: `MERGED` → the PR already landed — run § 4 EXCEPT § 4.1 (`ISSUE`, worktree, token; § 4.1 guards a merge that has not happened yet, so it has nothing to detach here) and § 5's preamble (`MAIN_REPO_ROOT`), then continue at § 5 step 2 for sync and cleanup, skipping step 1; `CLOSED` → report that it was closed unmerged and stop. Neither is a blocker to clear, and both arrive with an empty `issues` array.
 
 `can_merge: true` → § 4, showing any warnings. `false` → show the issues with their suggested fixes and ask: `Skip` | `Fix and retry` | `Force merge`.
 


### PR DESCRIPTION
## Why

Two github-skill defects observed in a drovr session (2026-08-15/16):

- `pr-threads <N> --unresolved --format=raw` silently ignored `--unresolved`: the raw branch echoed the GraphQL result unfiltered, so a verifier that trusts the raw listing after resolving every thread still saw all of them (`isResolved: true`) and read it as "resolution failed".
- `pr-merge <N>` did not short-circuit on an already-merged PR: `mergeable` is permanently UNKNOWN post-merge, so a follow-up `pr-merge N --auto` after an auto-merge returned exit 1 BLOCKED with `unknown: GitHub still computing mergeable status`, `ci_pending: Review gate (PENDING)` and a stray `unresolved_threads` — inviting a re-arm/retry of a merge that already happened.

## What

- `pr-threads`: the resolved/unresolved filter is applied before the format switch; raw emits `reviewThreads.nodes |= [.[] | <filter>]` — structure untouched, so `.. | objects | select(has("isResolved"))` walkers keep working. Both filters apply in both formats (SKILL.md row updated).
- `pr-merge`: the precheck reads `state` first — `MERGED` → `ALREADY MERGED PR #N <mergedAt>` on stderr, exit 0 (the table's 0 = MERGED; every downstream step is identical for "merged now" and "merged earlier"); `CLOSED` (not merged) → `CLOSED (not merged) PR #N`, exit 1, with no mergeable/CI diagnostics. `--check` JSON gains `state` and carries no bogus issues for a terminal PR. SKILL.md *PR Merge Outcomes* + `--check` example, `pr-merge --help`, and orch `merge-pr.md` § 3.2 (one routing line for `CHECK.state`) move in lockstep.

Closes #1304
Closes #1306

## Verification

New `pr-threads-raw-filter.test.sh` and `pr-merge-terminal-state.test.sh`, each run against the pre-fix script first: 8 and 22 assertions red (raw `--unresolved` returned resolved nodes; merged PR returned BLOCKED, called `gh pr merge`, `--check` reported `state: null` with a bogus issue), then 17/17 and 41/41 green. All 20 `skills/github/tests/*.sh` pass; `bash -n`, `shellcheck -S warning`, `preflight --staged` clean; orch `workflow_helpers.sh` (merge-pr.md pin) 61/0.

https://claude.ai/code/session_01BZkcou9yGoEPVijZUaQiTr
