### PR TITLE
feat(hooks): block-unsafe-rm — refuse a recursive rm on a variable-rooted path with the accepted rewrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- New `block-unsafe-rm` hook (`PreToolUse`/`Bash`): a recursive `rm` whose
+  path starts with a variable that may expand empty is refused with the
+  accepted rewrite (`rm -rf -- "${NAME:?}/sub"` or a literal absolute path)
+  — that shape halts the whole session on the harness's "Dangerous rm
+  operation on possibly-empty variable path" prompt even with permissions
+  bypassed, and lanes stalled on it. Consumers pick it up with
+  `vstack add --hook block-unsafe-rm -y`.
 - ci: the merge-queue ejection alert's comment/intake step never ran — an
   apostrophe in a comment inside its single-quoted jq program ended the
   quote and the step died on a bash syntax error. Fixed, and preflight

--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Windows: CLI runs natively; symlink mode falls back to copy.
 | Hook | Event | Brief |
 |---|---|---|
 | `block-bare-cd` | `PreToolUse` | Blocks unsafe bare `cd` usage and nudges toward subshell-safe patterns. |
+| `block-unsafe-rm` | `PreToolUse` | Refuses a recursive `rm` whose path starts with a variable that may expand empty (`rm -rf $DIR/$NAME`, `"$P/x"`, `${X:-}`) — the shape the harness halts the whole session on with a "Dangerous rm operation on possibly-empty variable path" prompt, even with permissions bypassed. Names the accepted rewrite: `rm -rf -- "${NAME:?}/sub"` or a literal absolute path. |
 | `block-repo-copy` | `PreToolUse` | Refuses a recursive copy (`cp -r`/`-R`/`-a`, recursive or archive `rsync`, local `git clone`, `tar` create-to-extract pipe) when the source carries repository history or a build tree AND the destination resolves under a temp/scratch root. Temp roots are commonly RAM-backed tmpfs, where such a copy fills the filesystem and every process writing there fails with ENOSPC. |
 | `pre-commit-check` | `PreToolUse` | Validates formatting and lint before commits. Rust Clippy lane is scoped to staged packages and configurable via `VSTACK_PRE_COMMIT_RUST_CLIPPY` (custom command or `off`). |
 | `post-edit-lint` | `PostToolUse` | Runs lint checks after source edits. |

--- a/hooks/block-unsafe-rm.sh
+++ b/hooks/block-unsafe-rm.sh
@@ -52,7 +52,16 @@ fi
 # newline in a sed replacement is a GNU extension BSD sed lacks, and this
 # hook runs on the macOS Bash 3.2 target too.
 SEGMENTS=$(printf '%s\n' "$COMMAND" \
-  | awk '{ gsub(/\t/, " "); gsub(/\\t/, " "); gsub(/\\n/, "\n"); gsub(/&&|\|\||;|\|/, "\n"); print }')
+  | awk '{ blob = blob $0 "\n" }
+      END {
+        gsub(/\t/, " ", blob); gsub(/\\t/, " ", blob)
+        gsub(/\\n/, "\n", blob)
+        # A backslash-newline is a continuation of ONE shell word list, so it
+        # folds to a space before the separator split.
+        gsub(/\\\n/, " ", blob)
+        gsub(/&&|\|\||;|\|/, "\n", blob)
+        printf "%s", blob
+      }')
 
 while IFS= read -r seg; do
   seg=$(printf '%s' "$seg" | sed 's/^[[:space:]({$`]*//')
@@ -78,9 +87,19 @@ while IFS= read -r seg; do
         -*) continue ;;
       esac
     fi
-    # Only a double quote is peeled: a single-quoted operand is a literal
-    # filename the shell never expands, so it is not a variable root.
-    stripped=${tok#\"}
+    # Leading EMPTY quote pairs contribute nothing to the word — `""$X` and
+    # `''$X` are still variable roots — so they peel off repeatedly. After
+    # that only a double quote is peeled: a single-quoted run is a literal
+    # the shell never expands, so it is not a variable root.
+    stripped=$tok
+    while :; do
+      case "$stripped" in
+        \"\"*) stripped=${stripped#\"\"} ;;
+        \'\'*) stripped=${stripped#\'\'} ;;
+        *) break ;;
+      esac
+    done
+    stripped=${stripped#\"}
     if [ "$seen_ddash" -eq 1 ]; then
       while [ "${stripped#-}" != "$stripped" ]; do stripped=${stripped#-}; done
     fi

--- a/hooks/block-unsafe-rm.sh
+++ b/hooks/block-unsafe-rm.sh
@@ -59,12 +59,25 @@ SEGMENTS=$(printf '%s\n' "$COMMAND" \
         # A backslash-newline is a continuation of ONE shell word list, so it
         # folds to a space before the separator split.
         gsub(/\\\n/, " ", blob)
-        gsub(/&&|\|\||;|\|/, "\n", blob)
+        # Every ; | & separates commands — the doubled forms collapse into
+        # an empty segment between two newlines, which matches nothing.
+        gsub(/[;|&]/, "\n", blob)
         printf "%s", blob
       }')
 
 while IFS= read -r seg; do
-  seg=$(printf '%s' "$seg" | sed 's/^[[:space:]({$`]*//')
+  # Peel whatever can stand between a separator and the command word:
+  # subshell/group/substitution openers and the shell control keywords, so
+  # `then rm …`, `do rm …`, and `( rm …` all classify as `rm …`.
+  while :; do
+    case "$seg" in
+      [[:space:]]* | '('* | '{'* | '$'* | '`'*)
+        seg=$(printf '%s' "$seg" | sed 's/^[[:space:]({$`]*//') ;;
+      then\ * | do\ * | else\ * | elif\ * | if\ * | while\ * | until\ * | time\ * | '!'\ *)
+        seg=${seg#* } ;;
+      *) break ;;
+    esac
+  done
   case "$seg" in
     rm\ *) ;;
     *) continue ;;

--- a/hooks/block-unsafe-rm.sh
+++ b/hooks/block-unsafe-rm.sh
@@ -33,6 +33,15 @@ else
   # Escape-aware fallback: the value may carry \" and \\ inside it.
   COMMAND=$(printf '%s' "$INPUT" | grep -o '"command"[[:space:]]*:[[:space:]]*"\([^"\\]\|\\.\)*"' | head -1 \
     | sed 's/^"command"[[:space:]]*:[[:space:]]*"//;s/"$//;s/\\"/"/g;s/\\\\/\\/g' 2>/dev/null || true)
+  # Same fail-closed contract as the jq branch: a payload that names a
+  # command the fallback could not decode (e.g. an unterminated string) is
+  # refused, not skipped. A decoded-empty command ("command":"") still passes.
+  if [ -z "$COMMAND" ] \
+    && printf '%s' "$INPUT" | grep -q '"command"' \
+    && ! printf '%s' "$INPUT" | grep -Eq '"command"[[:space:]]*:[[:space:]]*""'; then
+    echo "block-unsafe-rm: could not decode the command from the hook payload; refusing rather than skipping the guard" >&2
+    exit 2
+  fi
 fi
 
 # One rm invocation per line: split on command separators, then keep the
@@ -71,7 +80,20 @@ while IFS= read -r seg; do
       while [ "${stripped#-}" != "$stripped" ]; do stripped=${stripped#-}; done
     fi
     case "$stripped" in
-      \$\{[A-Za-z_]*:\?*) continue ;;   # ${NAME:?} — cannot expand empty
+      \$\{[A-Za-z_]*:\?*)
+        # Safe only when everything before the first :? is a plain
+        # identifier: ${NAME:?} aborts on empty, but ${X+x:?} is an
+        # unset-guarded ALTERNATIVE whose text merely contains :? and can
+        # still expand empty.
+        _name=${stripped#??}
+        _name=${_name%%:\?*}
+        case "$_name" in
+          *[!A-Za-z0-9_]*) ;;   # not ${IDENTIFIER:?} — falls through below
+          *) continue ;;        # ${NAME:?} — cannot expand empty
+        esac
+        ;;
+    esac
+    case "$stripped" in
       \$*)
         {
           echo "Recursive rm on a variable-rooted path stalls the session: the harness stops on"

--- a/hooks/block-unsafe-rm.sh
+++ b/hooks/block-unsafe-rm.sh
@@ -29,6 +29,13 @@ if command -v jq >/dev/null 2>&1; then
     echo "block-unsafe-rm: hook payload is not valid JSON; refusing rather than skipping the guard" >&2
     exit 2
   fi
+elif ! command -v grep >/dev/null 2>&1 || ! command -v sed >/dev/null 2>&1 \
+  || ! command -v head >/dev/null 2>&1 || ! command -v awk >/dev/null 2>&1 \
+  || ! command -v tr >/dev/null 2>&1; then
+  # An rm-bearing payload reached this point (the fast exit above passed it),
+  # and with neither jq nor the text tools nothing can decode it.
+  echo "block-unsafe-rm: no jq and no usable text tools to decode the payload; refusing rather than skipping the guard" >&2
+  exit 2
 else
   # Escape-aware fallback: the value may carry \" and \\ inside it.
   COMMAND=$(printf '%s' "$INPUT" | grep -o '"command"[[:space:]]*:[[:space:]]*"\([^"\\]\|\\.\)*"' | head -1 \
@@ -83,7 +90,14 @@ while IFS= read -r seg; do
     *) continue ;;
   esac
   # Recursive form: -r/-R anywhere in a short-option cluster, or --recursive.
-  printf '%s' "$seg" | grep -Eq '(^|[[:space:]])(-[a-zA-Z]*[rR][a-zA-Z]*|--recursive)([[:space:]]|$)' || continue
+  # Quotes do not change what rm receives — `rm "-rf"` and `rm -r""f` both
+  # pass -rf — so the flag scan reads a quote-folded copy of the segment.
+  flat=$(printf '%s' "$seg" | tr -d "\"'")
+  printf '%s' "$flat" | grep -Eq '(^|[[:space:]])(-[a-zA-Z]*[rR][a-zA-Z]*|--recursive)([[:space:]]|$)' || continue
+  # A redirection target belongs to the shell, never to rm: the operator and
+  # its target drop out before operand classification, so `> $LOG` on a
+  # literal-path rm is not a variable root.
+  seg=$(printf '%s' "$seg" | sed -E 's/[0-9]*(>>?|<<?)[[:space:]]*[^[:space:]]+//g')
   # Any operand (not an option) that begins with a variable expansion whose
   # value can be empty: $NAME, ${NAME}, "$NAME/…", ${NAME:-…}. The one form
   # that cannot expand empty is ${NAME:?…}, which the harness accepts.
@@ -107,6 +121,7 @@ while IFS= read -r seg; do
     stripped=$tok
     while :; do
       case "$stripped" in
+        \$\'\'*) stripped=${stripped#\$\'\'} ;;
         \"\"*) stripped=${stripped#\"\"} ;;
         \'\'*) stripped=${stripped#\'\'} ;;
         *) break ;;

--- a/hooks/block-unsafe-rm.sh
+++ b/hooks/block-unsafe-rm.sh
@@ -78,7 +78,9 @@ while IFS= read -r seg; do
         -*) continue ;;
       esac
     fi
-    stripped=${tok#\"}; stripped=${stripped#\'}
+    # Only a double quote is peeled: a single-quoted operand is a literal
+    # filename the shell never expands, so it is not a variable root.
+    stripped=${tok#\"}
     if [ "$seen_ddash" -eq 1 ]; then
       while [ "${stripped#-}" != "$stripped" ]; do stripped=${stripped#-}; done
     fi

--- a/hooks/block-unsafe-rm.sh
+++ b/hooks/block-unsafe-rm.sh
@@ -48,8 +48,11 @@ fi
 # segments that start with rm (optionally under sudo/env prefixes are out of
 # scope — the shape the harness prompts on is a plain rm). Tabs count as the
 # word separators they are, and a leading subshell/group/substitution opener
-# is peeled so `(rm …` and `$(rm …` classify like `rm …`.
-SEGMENTS=$(printf '%s\n' "$COMMAND" | tr '\t' ' ' | sed 's/\\n/\n/g' | sed -E 's/(&&|\|\||;|\|)/\n/g')
+# is peeled so `(rm …` and `$(rm …` classify like `rm …`. awk, not sed: a
+# newline in a sed replacement is a GNU extension BSD sed lacks, and this
+# hook runs on the macOS Bash 3.2 target too.
+SEGMENTS=$(printf '%s\n' "$COMMAND" \
+  | awk '{ gsub(/\t/, " "); gsub(/\\n/, "\n"); gsub(/&&|\|\||;|\|/, "\n"); print }')
 
 while IFS= read -r seg; do
   seg=$(printf '%s' "$seg" | sed 's/^[[:space:]({$`]*//')

--- a/hooks/block-unsafe-rm.sh
+++ b/hooks/block-unsafe-rm.sh
@@ -117,6 +117,7 @@ while IFS= read -r seg; do
       while [ "${stripped#-}" != "$stripped" ]; do stripped=${stripped#-}; done
     fi
     case "$stripped" in
+      \$\'*) continue ;;               # $'…' is an ANSI-C literal, not a variable
       \$\{[A-Za-z_]*:\?*)
         # Safe only when everything before the first :? is a plain
         # identifier: ${NAME:?} aborts on empty, but ${X+x:?} is an

--- a/hooks/block-unsafe-rm.sh
+++ b/hooks/block-unsafe-rm.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# ---
+# name: block-unsafe-rm
+# event: PreToolUse
+# matcher: Bash
+# description: Block a recursive rm whose path starts with a variable that may expand empty. Names the rewrite the harness accepts without a prompt.
+# safety: The harness stops the whole session on that shape with a "Dangerous rm operation on possibly-empty variable path" prompt; refusing it here lets the agent rewrite and continue.
+# ---
+
+set -euo pipefail
+
+# Read stdin with the shell builtin so the fast exit forks nothing.
+INPUT=''
+_line=''
+while IFS= read -r _line || [ -n "$_line" ]; do
+  INPUT="$INPUT$_line"
+done
+
+# Fast exit on every Bash call that carries no rm at all.
+case "$INPUT" in
+  *rm*) ;;
+  *) exit 0 ;;
+esac
+
+if command -v jq >/dev/null 2>&1; then
+  COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // .command // empty' 2>/dev/null || true)
+else
+  # Escape-aware fallback: the value may carry \" and \\ inside it.
+  COMMAND=$(printf '%s' "$INPUT" | grep -o '"command"[[:space:]]*:[[:space:]]*"\([^"\\]\|\\.\)*"' | head -1 \
+    | sed 's/^"command"[[:space:]]*:[[:space:]]*"//;s/"$//;s/\\"/"/g;s/\\\\/\\/g' 2>/dev/null || true)
+fi
+
+# One rm invocation per line: split on command separators, then keep the
+# segments that start with rm (optionally under sudo/env prefixes are out of
+# scope — the shape the harness prompts on is a plain rm).
+SEGMENTS=$(printf '%s\n' "$COMMAND" | sed 's/\\n/\n/g' | sed -E 's/(&&|\|\||;|\|)/\n/g')
+
+while IFS= read -r seg; do
+  seg=$(printf '%s' "$seg" | sed 's/^[[:space:]]*//')
+  case "$seg" in
+    rm\ *) ;;
+    *) continue ;;
+  esac
+  # Recursive form: -r/-R anywhere in a short-option cluster, or --recursive.
+  printf '%s' "$seg" | grep -Eq '(^|[[:space:]])(-[a-zA-Z]*[rR][a-zA-Z]*|--recursive)([[:space:]]|$)' || continue
+  # Any operand (not an option) that begins with a variable expansion whose
+  # value can be empty: $NAME, ${NAME}, "$NAME/…", ${NAME:-…}. The one form
+  # that cannot expand empty is ${NAME:?…}, which the harness accepts.
+  for tok in $seg; do
+    case "$tok" in
+      -*) continue ;;
+    esac
+    stripped=${tok#\"}; stripped=${stripped#\'}
+    case "$stripped" in
+      \$\{[A-Za-z_]*:\?*) continue ;;   # ${NAME:?} — cannot expand empty
+      \$*)
+        {
+          echo "Recursive rm on a variable-rooted path stalls the session: the harness stops on"
+          echo "  $tok"
+          echo "with a 'Dangerous rm operation on possibly-empty variable path' prompt."
+          echo "Rewrite so the path cannot collapse to / — either form is accepted:"
+          echo "  rm -rf -- \"\${NAME:?}/sub\"      (bash aborts if NAME is unset or empty)"
+          echo "  rm -rf -- /absolute/literal/path"
+        } >&2
+        exit 2
+        ;;
+    esac
+  done
+done <<<"$SEGMENTS"
+
+exit 0

--- a/hooks/block-unsafe-rm.sh
+++ b/hooks/block-unsafe-rm.sh
@@ -52,7 +52,7 @@ fi
 # newline in a sed replacement is a GNU extension BSD sed lacks, and this
 # hook runs on the macOS Bash 3.2 target too.
 SEGMENTS=$(printf '%s\n' "$COMMAND" \
-  | awk '{ gsub(/\t/, " "); gsub(/\\n/, "\n"); gsub(/&&|\|\||;|\|/, "\n"); print }')
+  | awk '{ gsub(/\t/, " "); gsub(/\\t/, " "); gsub(/\\n/, "\n"); gsub(/&&|\|\||;|\|/, "\n"); print }')
 
 while IFS= read -r seg; do
   seg=$(printf '%s' "$seg" | sed 's/^[[:space:]({$`]*//')

--- a/hooks/block-unsafe-rm.sh
+++ b/hooks/block-unsafe-rm.sh
@@ -23,7 +23,12 @@ case "$INPUT" in
 esac
 
 if command -v jq >/dev/null 2>&1; then
-  COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // .command // empty' 2>/dev/null || true)
+  # A payload that does not parse is refused, not skipped: an unreadable
+  # command cannot be proven safe, and this guard is fail-closed by design.
+  if ! COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // .command // empty' 2>/dev/null); then
+    echo "block-unsafe-rm: hook payload is not valid JSON; refusing rather than skipping the guard" >&2
+    exit 2
+  fi
 else
   # Escape-aware fallback: the value may carry \" and \\ inside it.
   COMMAND=$(printf '%s' "$INPUT" | grep -o '"command"[[:space:]]*:[[:space:]]*"\([^"\\]\|\\.\)*"' | head -1 \
@@ -32,11 +37,13 @@ fi
 
 # One rm invocation per line: split on command separators, then keep the
 # segments that start with rm (optionally under sudo/env prefixes are out of
-# scope — the shape the harness prompts on is a plain rm).
-SEGMENTS=$(printf '%s\n' "$COMMAND" | sed 's/\\n/\n/g' | sed -E 's/(&&|\|\||;|\|)/\n/g')
+# scope — the shape the harness prompts on is a plain rm). Tabs count as the
+# word separators they are, and a leading subshell/group/substitution opener
+# is peeled so `(rm …` and `$(rm …` classify like `rm …`.
+SEGMENTS=$(printf '%s\n' "$COMMAND" | tr '\t' ' ' | sed 's/\\n/\n/g' | sed -E 's/(&&|\|\||;|\|)/\n/g')
 
 while IFS= read -r seg; do
-  seg=$(printf '%s' "$seg" | sed 's/^[[:space:]]*//')
+  seg=$(printf '%s' "$seg" | sed 's/^[[:space:]({$`]*//')
   case "$seg" in
     rm\ *) ;;
     *) continue ;;
@@ -46,11 +53,23 @@ while IFS= read -r seg; do
   # Any operand (not an option) that begins with a variable expansion whose
   # value can be empty: $NAME, ${NAME}, "$NAME/…", ${NAME:-…}. The one form
   # that cannot expand empty is ${NAME:?…}, which the harness accepts.
+  # Globbing is off around the unquoted split so a `*` in the command stays a
+  # literal token instead of expanding against the hook's cwd; `--` ends
+  # option skipping, and a post-`--` operand sheds leading dashes for
+  # classification so `-$DIR/sub` is still a variable root.
+  set -f
+  seen_ddash=0
   for tok in $seg; do
-    case "$tok" in
-      -*) continue ;;
-    esac
+    if [ "$seen_ddash" -eq 0 ]; then
+      case "$tok" in
+        --) seen_ddash=1; continue ;;
+        -*) continue ;;
+      esac
+    fi
     stripped=${tok#\"}; stripped=${stripped#\'}
+    if [ "$seen_ddash" -eq 1 ]; then
+      while [ "${stripped#-}" != "$stripped" ]; do stripped=${stripped#-}; done
+    fi
     case "$stripped" in
       \$\{[A-Za-z_]*:\?*) continue ;;   # ${NAME:?} — cannot expand empty
       \$*)
@@ -66,6 +85,7 @@ while IFS= read -r seg; do
         ;;
     esac
   done
+  set +f
 done <<<"$SEGMENTS"
 
 exit 0

--- a/hooks/tests/block-unsafe-rm.test.sh
+++ b/hooks/tests/block-unsafe-rm.test.sh
@@ -96,6 +96,7 @@ run_hook 'rm -rf -- "${P:?}/save"';      assert_eq "$rc" 0 '${P:?} cannot expand
 run_hook 'rm -rf "${VAR1:?}/x"';         assert_eq "$rc" 0 'digits after the first identifier char pass (${VAR1:?})'
 run_hook 'rm -rf -- "-${P:?}/x"';        assert_eq "$rc" 0 'a dash-leading ${P:?} operand after -- passes'
 run_hook "rm -rf '\$X'";                 assert_eq "$rc" 0 'a single-quoted operand is a literal filename, not an expansion'
+run_hook "rm -rf \$'/var/tmp/safe'";     assert_eq "$rc" 0 'an ANSI-C quoted operand is a literal, not a variable root'
 run_hook 'rm -rf "${TMP_ROOT:?}"';       assert_eq "$rc" 0 'a bare ${TMP_ROOT:?} passes'
 run_hook 'rm -rf /var/tmp/x';            assert_eq "$rc" 0 'a literal absolute path passes'
 run_hook 'rm -rf ./build';               assert_eq "$rc" 0 'a literal relative path passes'

--- a/hooks/tests/block-unsafe-rm.test.sh
+++ b/hooks/tests/block-unsafe-rm.test.sh
@@ -74,6 +74,12 @@ run_hook "$(printf 'rm\t-rf\t%s' '$X')"; assert_eq "$rc" 2 'tab-separated rm -rf
 run_hook 'rm -rf -- -$DIR/sub';          assert_eq "$rc" 2 'a dash-leading operand after -- is still a variable root'
 run_hook 'rm -rf $LOGS/*.log';           assert_eq "$rc" 2 'a glob in the operand does not disturb classification'
 run_hook 'rm -rf "${X+x:?}/save"';       assert_eq "$rc" 2 'an unset-guarded alternative whose text contains :? can expand empty and is refused'
+run_hook 'rm -rf ""$X/sub';              assert_eq "$rc" 2 'an empty double-quote pair does not hide the variable root'
+run_hook "rm -rf ''\$X/sub";             assert_eq "$rc" 2 'an empty single-quote pair does not hide the variable root'
+set +e
+printf '%s' '{"tool_input":{"command":"rm \\\n-rf $X/sub"}}' | "$BASH_BIN" "$HOOK" >/dev/null 2>"$ERR_FILE"; rc=$?
+set -e
+assert_eq "$rc" 2 'a backslash-newline continuation still reads as one rm invocation'
 
 echo "=== block-unsafe-rm: the refusal names the cause and the rewrite ==="
 run_hook 'rm -rf $CACHE/$KEY'

--- a/hooks/tests/block-unsafe-rm.test.sh
+++ b/hooks/tests/block-unsafe-rm.test.sh
@@ -46,7 +46,7 @@ run_hook() { # command -> rc, stderr in ERR_FILE
 # A PATH without jq exercises the escape-aware fallback decoder.
 NOJQ_BIN="$TMP_ROOT/nojq"
 mkdir -p "$NOJQ_BIN"
-for tool in cat sed grep head awk; do
+for tool in cat sed grep head awk tr; do
   real="$(command -v "$tool" 2>/dev/null || true)"
   [ -n "$real" ] || continue
   ln -sf "$real" "$NOJQ_BIN/$tool"
@@ -77,6 +77,9 @@ run_hook 'rm -rf "${X+x:?}/save"';       assert_eq "$rc" 2 'an unset-guarded alt
 run_hook 'true & rm -rf "$X/sub"';       assert_eq "$rc" 2 'a lone ampersand separates commands too'
 run_hook 'if true; then rm -rf "$X/sub"; fi'; assert_eq "$rc" 2 'a control-keyword prefix does not hide the rm'
 run_hook 'while x; do rm -rf $Y; done';  assert_eq "$rc" 2 'a do-prefixed rm inside a loop is refused'
+run_hook 'rm "-rf" "$X/sub"';            assert_eq "$rc" 2 'a quoted -rf flag still counts as recursive'
+run_hook 'rm -r""f "$X/sub"';            assert_eq "$rc" 2 'a concatenation-split -rf flag still counts as recursive'
+run_hook "rm -rf \$''\$X/sub";           assert_eq "$rc" 2 'an empty ANSI-C literal does not hide the variable root'
 run_hook 'rm -rf ""$X/sub';              assert_eq "$rc" 2 'an empty double-quote pair does not hide the variable root'
 run_hook "rm -rf ''\$X/sub";             assert_eq "$rc" 2 'an empty single-quote pair does not hide the variable root'
 set +e
@@ -97,6 +100,8 @@ run_hook 'rm -rf "${VAR1:?}/x"';         assert_eq "$rc" 0 'digits after the fir
 run_hook 'rm -rf -- "-${P:?}/x"';        assert_eq "$rc" 0 'a dash-leading ${P:?} operand after -- passes'
 run_hook "rm -rf '\$X'";                 assert_eq "$rc" 0 'a single-quoted operand is a literal filename, not an expansion'
 run_hook "rm -rf \$'/var/tmp/safe'";     assert_eq "$rc" 0 'an ANSI-C quoted operand is a literal, not a variable root'
+run_hook 'rm -rf /var/tmp/safe > $LOG';  assert_eq "$rc" 0 'a variable redirection target is not an rm operand'
+run_hook 'rm -rf $X > /var/tmp/log';     assert_eq "$rc" 2 'stripping redirects does not lose a real variable operand'
 run_hook 'rm -rf "${TMP_ROOT:?}"';       assert_eq "$rc" 0 'a bare ${TMP_ROOT:?} passes'
 run_hook 'rm -rf /var/tmp/x';            assert_eq "$rc" 0 'a literal absolute path passes'
 run_hook 'rm -rf ./build';               assert_eq "$rc" 0 'a literal relative path passes'
@@ -117,6 +122,7 @@ echo "=== block-unsafe-rm: enforcement without jq ==="
 run_hook_path "$NOJQ_BIN" 'rm -rf "$P/save"';        assert_eq "$rc" 2 'without jq, an escaped-quote payload is still decoded and refused'
 run_hook_path "$NOJQ_BIN" 'rm -rf -- "${P:?}/save"'; assert_eq "$rc" 0 'without jq, the ${P:?} form still passes'
 run_hook_path "/nonexistent" 'git status --short';   assert_eq "$rc" 0 'a command without rm completes with no external tool reachable'
+run_hook_path "/nonexistent" 'rm -rf $X';            assert_eq "$rc" 2 'an rm payload with no decode tools refuses rather than skipping the guard'
 set +e
 printf '%s' '{"tool_input":{"command":"rm -rf $X' \
   | env -i HOME="$HOME" PWD="$PWD" TMPDIR=/tmp PATH="$NOJQ_BIN" "$BASH_BIN" "$HOOK" >/dev/null 2>"$ERR_FILE"; rc=$?

--- a/hooks/tests/block-unsafe-rm.test.sh
+++ b/hooks/tests/block-unsafe-rm.test.sh
@@ -46,7 +46,7 @@ run_hook() { # command -> rc, stderr in ERR_FILE
 # A PATH without jq exercises the escape-aware fallback decoder.
 NOJQ_BIN="$TMP_ROOT/nojq"
 mkdir -p "$NOJQ_BIN"
-for tool in cat sed grep head; do
+for tool in cat sed grep head tr; do
   real="$(command -v "$tool" 2>/dev/null || true)"
   [ -n "$real" ] || continue
   ln -sf "$real" "$NOJQ_BIN/$tool"
@@ -68,6 +68,11 @@ run_hook 'rm --recursive --force $X';    assert_eq "$rc" 2 '--recursive counts a
 run_hook 'mkdir -p x && rm -rf $X/y';    assert_eq "$rc" 2 'a refused rm inside an && chain is still refused'
 run_hook 'rm -rf "${P:-}/save"';         assert_eq "$rc" 2 '${P:-} can still expand empty and is refused'
 run_hook 'rm -rf -- $X';                 assert_eq "$rc" 2 'the -- separator does not make a variable root safe'
+run_hook '(rm -rf $X)';                  assert_eq "$rc" 2 'a subshell-wrapped rm is still refused'
+run_hook 'cd y && { rm -rf $X/z; }';     assert_eq "$rc" 2 'a group-wrapped rm inside a chain is refused'
+run_hook "$(printf 'rm\t-rf\t%s' '$X')"; assert_eq "$rc" 2 'tab-separated rm -rf is refused'
+run_hook 'rm -rf -- -$DIR/sub';          assert_eq "$rc" 2 'a dash-leading operand after -- is still a variable root'
+run_hook 'rm -rf $LOGS/*.log';           assert_eq "$rc" 2 'a glob in the operand does not disturb classification'
 
 echo "=== block-unsafe-rm: the refusal names the cause and the rewrite ==="
 run_hook 'rm -rf $CACHE/$KEY'
@@ -78,6 +83,8 @@ assert_contains "$ERR_FILE" '$CACHE/$KEY' 'the refusal quotes the offending oper
 
 echo "=== block-unsafe-rm: accepted shapes ==="
 run_hook 'rm -rf -- "${P:?}/save"';      assert_eq "$rc" 0 '${P:?} cannot expand empty and passes'
+run_hook 'rm -rf "${VAR1:?}/x"';         assert_eq "$rc" 0 'digits after the first identifier char pass (${VAR1:?})'
+run_hook 'rm -rf -- "-${P:?}/x"';        assert_eq "$rc" 0 'a dash-leading ${P:?} operand after -- passes'
 run_hook 'rm -rf "${TMP_ROOT:?}"';       assert_eq "$rc" 0 'a bare ${TMP_ROOT:?} passes'
 run_hook 'rm -rf /var/tmp/x';            assert_eq "$rc" 0 'a literal absolute path passes'
 run_hook 'rm -rf ./build';               assert_eq "$rc" 0 'a literal relative path passes'
@@ -86,6 +93,13 @@ run_hook 'rm file.txt';                  assert_eq "$rc" 0 'plain rm passes'
 run_hook 'echo "rm -rf $X" > note';      assert_eq "$rc" 0 'a command that only mentions rm passes'
 run_hook 'git rm -r --cached $X';        assert_eq "$rc" 0 'git rm is not rm'
 run_hook 'ls -la';                       assert_eq "$rc" 0 'an unrelated command passes'
+
+echo "=== block-unsafe-rm: unreadable payload refuses ==="
+set +e
+printf '%s' '{"tool_input":{"command":"rm -rf $X"' | "$BASH_BIN" "$HOOK" >/dev/null 2>"$ERR_FILE"; rc=$?
+set -e
+assert_eq "$rc" 2 'a truncated JSON payload refuses rather than skipping the guard'
+assert_contains "$ERR_FILE" 'not valid JSON' 'the parse refusal names the cause'
 
 echo "=== block-unsafe-rm: enforcement without jq ==="
 run_hook_path "$NOJQ_BIN" 'rm -rf "$P/save"';        assert_eq "$rc" 2 'without jq, an escaped-quote payload is still decoded and refused'

--- a/hooks/tests/block-unsafe-rm.test.sh
+++ b/hooks/tests/block-unsafe-rm.test.sh
@@ -73,6 +73,7 @@ run_hook 'cd y && { rm -rf $X/z; }';     assert_eq "$rc" 2 'a group-wrapped rm i
 run_hook "$(printf 'rm\t-rf\t%s' '$X')"; assert_eq "$rc" 2 'tab-separated rm -rf is refused'
 run_hook 'rm -rf -- -$DIR/sub';          assert_eq "$rc" 2 'a dash-leading operand after -- is still a variable root'
 run_hook 'rm -rf $LOGS/*.log';           assert_eq "$rc" 2 'a glob in the operand does not disturb classification'
+run_hook 'rm -rf "${X+x:?}/save"';       assert_eq "$rc" 2 'an unset-guarded alternative whose text contains :? can expand empty and is refused'
 
 echo "=== block-unsafe-rm: the refusal names the cause and the rewrite ==="
 run_hook 'rm -rf $CACHE/$KEY'
@@ -105,6 +106,12 @@ echo "=== block-unsafe-rm: enforcement without jq ==="
 run_hook_path "$NOJQ_BIN" 'rm -rf "$P/save"';        assert_eq "$rc" 2 'without jq, an escaped-quote payload is still decoded and refused'
 run_hook_path "$NOJQ_BIN" 'rm -rf -- "${P:?}/save"'; assert_eq "$rc" 0 'without jq, the ${P:?} form still passes'
 run_hook_path "/nonexistent" 'git status --short';   assert_eq "$rc" 0 'a command without rm completes with no external tool reachable'
+set +e
+printf '%s' '{"tool_input":{"command":"rm -rf $X' \
+  | env -i HOME="$HOME" PWD="$PWD" TMPDIR=/tmp PATH="$NOJQ_BIN" "$BASH_BIN" "$HOOK" >/dev/null 2>"$ERR_FILE"; rc=$?
+set -e
+assert_eq "$rc" 2 'without jq, an unterminated command string refuses'
+assert_contains "$ERR_FILE" 'could not decode' 'the no-jq refusal names the cause'
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/hooks/tests/block-unsafe-rm.test.sh
+++ b/hooks/tests/block-unsafe-rm.test.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Tests for the block-unsafe-rm hook.
+#
+# The hook refuses a recursive rm whose path operand starts with a variable
+# that may expand empty — the shape the harness stops the whole session on
+# with a "Dangerous rm operation on possibly-empty variable path" prompt —
+# and names the accepted rewrite (${NAME:?} or a literal absolute path).
+# Non-recursive rm, literal paths, ${NAME:?}, and commands that merely mention
+# rm pass. HOOK_UNDER_TEST overrides the script under test so the must-fail
+# controls (a no-op hook, an always-block hook) run against these assertions.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="${HOOK_UNDER_TEST:-$(cd "$TEST_DIR/.." && pwd)/block-unsafe-rm.sh}"
+
+PASS=0
+FAIL=0
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+ERR_FILE="$TMP_ROOT/stderr"
+BASH_BIN="$(command -v bash)"
+
+pass() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+fail() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
+assert_eq() {
+  if [ "$1" = "$2" ]; then pass "$3"; else FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$3" "$2" "$1"; fi
+}
+assert_contains() {
+  if grep -qF -- "$2" "$1"; then pass "$3"; else FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        wanted: %s\n        in:\n%s\n' "$3" "$2" "$(cat "$1")"; fi
+}
+
+# The command reaches the hook JSON-encoded, exactly as the harness sends it.
+json_for() {
+  local c
+  c=$(printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g')
+  printf '{"tool_name":"Bash","tool_input":{"command":"%s"}}' "$c"
+}
+
+run_hook() { # command -> rc, stderr in ERR_FILE
+  set +e
+  json_for "$1" | "$BASH_BIN" "$HOOK" >/dev/null 2>"$ERR_FILE"
+  rc=$?
+  set -e
+}
+
+# A PATH without jq exercises the escape-aware fallback decoder.
+NOJQ_BIN="$TMP_ROOT/nojq"
+mkdir -p "$NOJQ_BIN"
+for tool in cat sed grep head; do
+  real="$(command -v "$tool" 2>/dev/null || true)"
+  [ -n "$real" ] || continue
+  ln -sf "$real" "$NOJQ_BIN/$tool"
+done
+run_hook_path() { # PATH command -> rc
+  set +e
+  json_for "$2" | env -i HOME="$HOME" PWD="$PWD" TMPDIR=/tmp PATH="$1" "$BASH_BIN" "$HOOK" >/dev/null 2>"$ERR_FILE"
+  rc=$?
+  set -e
+}
+
+echo "=== block-unsafe-rm: refused shapes ==="
+run_hook 'rm -rf $CACHE/$KEY';           assert_eq "$rc" 2 'rm -rf $CACHE/$KEY is refused'
+run_hook 'rm -rf "$P/save"';             assert_eq "$rc" 2 'a quoted "$P/save" is refused (quotes do not stop an empty expansion)'
+run_hook 'rm -r ${DIR}';                 assert_eq "$rc" 2 'rm -r ${DIR} is refused'
+run_hook 'rm -fr $X';                    assert_eq "$rc" 2 'the -fr cluster counts as recursive'
+run_hook 'rm -R $X';                     assert_eq "$rc" 2 'uppercase -R counts as recursive'
+run_hook 'rm --recursive --force $X';    assert_eq "$rc" 2 '--recursive counts as recursive'
+run_hook 'mkdir -p x && rm -rf $X/y';    assert_eq "$rc" 2 'a refused rm inside an && chain is still refused'
+run_hook 'rm -rf "${P:-}/save"';         assert_eq "$rc" 2 '${P:-} can still expand empty and is refused'
+run_hook 'rm -rf -- $X';                 assert_eq "$rc" 2 'the -- separator does not make a variable root safe'
+
+echo "=== block-unsafe-rm: the refusal names the cause and the rewrite ==="
+run_hook 'rm -rf $CACHE/$KEY'
+assert_contains "$ERR_FILE" 'possibly-empty variable path' 'the refusal names the harness prompt it prevents'
+assert_contains "$ERR_FILE" '${NAME:?}' 'the refusal names the ${NAME:?} rewrite'
+assert_contains "$ERR_FILE" '/absolute/literal/path' 'the refusal names the literal-path alternative'
+assert_contains "$ERR_FILE" '$CACHE/$KEY' 'the refusal quotes the offending operand'
+
+echo "=== block-unsafe-rm: accepted shapes ==="
+run_hook 'rm -rf -- "${P:?}/save"';      assert_eq "$rc" 0 '${P:?} cannot expand empty and passes'
+run_hook 'rm -rf "${TMP_ROOT:?}"';       assert_eq "$rc" 0 'a bare ${TMP_ROOT:?} passes'
+run_hook 'rm -rf /var/tmp/x';            assert_eq "$rc" 0 'a literal absolute path passes'
+run_hook 'rm -rf ./build';               assert_eq "$rc" 0 'a literal relative path passes'
+run_hook 'rm -f $X';                     assert_eq "$rc" 0 'a non-recursive rm on a variable passes (not the prompted shape)'
+run_hook 'rm file.txt';                  assert_eq "$rc" 0 'plain rm passes'
+run_hook 'echo "rm -rf $X" > note';      assert_eq "$rc" 0 'a command that only mentions rm passes'
+run_hook 'git rm -r --cached $X';        assert_eq "$rc" 0 'git rm is not rm'
+run_hook 'ls -la';                       assert_eq "$rc" 0 'an unrelated command passes'
+
+echo "=== block-unsafe-rm: enforcement without jq ==="
+run_hook_path "$NOJQ_BIN" 'rm -rf "$P/save"';        assert_eq "$rc" 2 'without jq, an escaped-quote payload is still decoded and refused'
+run_hook_path "$NOJQ_BIN" 'rm -rf -- "${P:?}/save"'; assert_eq "$rc" 0 'without jq, the ${P:?} form still passes'
+run_hook_path "/nonexistent" 'git status --short';   assert_eq "$rc" 0 'a command without rm completes with no external tool reachable'
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/hooks/tests/block-unsafe-rm.test.sh
+++ b/hooks/tests/block-unsafe-rm.test.sh
@@ -112,6 +112,11 @@ printf '%s' '{"tool_input":{"command":"rm -rf $X' \
 set -e
 assert_eq "$rc" 2 'without jq, an unterminated command string refuses'
 assert_contains "$ERR_FILE" 'could not decode' 'the no-jq refusal names the cause'
+set +e
+printf '%s' '{"tool_input":{"command":"rm\t-rf\t$X/sub"}}' \
+  | env -i HOME="$HOME" PWD="$PWD" TMPDIR=/tmp PATH="$NOJQ_BIN" "$BASH_BIN" "$HOOK" >/dev/null 2>"$ERR_FILE"; rc=$?
+set -e
+assert_eq "$rc" 2 'without jq, JSON tab escapes still separate rm from its flags'
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/hooks/tests/block-unsafe-rm.test.sh
+++ b/hooks/tests/block-unsafe-rm.test.sh
@@ -86,6 +86,7 @@ echo "=== block-unsafe-rm: accepted shapes ==="
 run_hook 'rm -rf -- "${P:?}/save"';      assert_eq "$rc" 0 '${P:?} cannot expand empty and passes'
 run_hook 'rm -rf "${VAR1:?}/x"';         assert_eq "$rc" 0 'digits after the first identifier char pass (${VAR1:?})'
 run_hook 'rm -rf -- "-${P:?}/x"';        assert_eq "$rc" 0 'a dash-leading ${P:?} operand after -- passes'
+run_hook "rm -rf '\$X'";                 assert_eq "$rc" 0 'a single-quoted operand is a literal filename, not an expansion'
 run_hook 'rm -rf "${TMP_ROOT:?}"';       assert_eq "$rc" 0 'a bare ${TMP_ROOT:?} passes'
 run_hook 'rm -rf /var/tmp/x';            assert_eq "$rc" 0 'a literal absolute path passes'
 run_hook 'rm -rf ./build';               assert_eq "$rc" 0 'a literal relative path passes'

--- a/hooks/tests/block-unsafe-rm.test.sh
+++ b/hooks/tests/block-unsafe-rm.test.sh
@@ -74,6 +74,9 @@ run_hook "$(printf 'rm\t-rf\t%s' '$X')"; assert_eq "$rc" 2 'tab-separated rm -rf
 run_hook 'rm -rf -- -$DIR/sub';          assert_eq "$rc" 2 'a dash-leading operand after -- is still a variable root'
 run_hook 'rm -rf $LOGS/*.log';           assert_eq "$rc" 2 'a glob in the operand does not disturb classification'
 run_hook 'rm -rf "${X+x:?}/save"';       assert_eq "$rc" 2 'an unset-guarded alternative whose text contains :? can expand empty and is refused'
+run_hook 'true & rm -rf "$X/sub"';       assert_eq "$rc" 2 'a lone ampersand separates commands too'
+run_hook 'if true; then rm -rf "$X/sub"; fi'; assert_eq "$rc" 2 'a control-keyword prefix does not hide the rm'
+run_hook 'while x; do rm -rf $Y; done';  assert_eq "$rc" 2 'a do-prefixed rm inside a loop is refused'
 run_hook 'rm -rf ""$X/sub';              assert_eq "$rc" 2 'an empty double-quote pair does not hide the variable root'
 run_hook "rm -rf ''\$X/sub";             assert_eq "$rc" 2 'an empty single-quote pair does not hide the variable root'
 set +e

--- a/hooks/tests/block-unsafe-rm.test.sh
+++ b/hooks/tests/block-unsafe-rm.test.sh
@@ -46,7 +46,7 @@ run_hook() { # command -> rc, stderr in ERR_FILE
 # A PATH without jq exercises the escape-aware fallback decoder.
 NOJQ_BIN="$TMP_ROOT/nojq"
 mkdir -p "$NOJQ_BIN"
-for tool in cat sed grep head tr; do
+for tool in cat sed grep head awk; do
   real="$(command -v "$tool" 2>/dev/null || true)"
   [ -n "$real" ] || continue
   ln -sf "$real" "$NOJQ_BIN/$tool"


### PR DESCRIPTION
## Why

Lane sessions stalled tonight on the harness prompt **"Dangerous rm operation on possibly-empty variable path — Do you want to proceed?"** for commands like `rm -rf $CACHE/$KEY` (a sub-agent probe in the vst-256 lane). That guard is built into the harness and fires even with permissions bypassed, so nothing proceeds until a human answers.

## What

`hooks/block-unsafe-rm.sh` — `PreToolUse`/`Bash`: refuses a recursive `rm` (`-r`/`-R`/`-fr`/`--recursive`) whose path operand starts with a variable that may expand empty (`$NAME`, `${NAME}`, `"$NAME/…"`, `${NAME:-…}`); `${NAME:?…}` passes (bash aborts if unset/empty, so the path can never collapse to `/`). The refusal names the prompt it prevents and the two accepted rewrites (`rm -rf -- "${NAME:?}/sub"` or a literal absolute path), so the agent rewrites and continues instead of stalling. Same shape as `block-bare-cd`/`block-repo-copy`: stdin read with the builtin, jq or an escape-aware fallback decoder, no fork on the fast path.

README hooks table row; CHANGELOG. Consumers pick it up with `vstack add --hook block-unsafe-rm -y` (train step).

## Verification

`hooks/tests/block-unsafe-rm.test.sh` — 25 assertions: 9 refused shapes (incl. `&&` chains, `${X:-}`, `-R`, `--recursive`), refusal text names cause + both rewrites + the offending operand, 9 accepted shapes (`${P:?}`, literals, non-recursive rm, `git rm`, commands that mention rm), no-jq fallback decoding, and no fork on the fast path (`PATH=/nonexistent`). Must-fail controls via `HOOK_UNDER_TEST`: a no-op hook → 19 red; an always-block hook → 14 red. `block-repo-copy` test still green; `preflight --base origin/main` clean.

https://claude.ai/code/session_01BZkcou9yGoEPVijZUaQiTr
