### PR TITLE
feat(preflight): docs-cited-paths covers source-file citations of doc paths (VST-285)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,13 @@
   so the last assistant text a consumer extracts is the last one written —
   the out-of-order case surfaced as a merge-queue flake in
   `session-lanes.test.ts`.
+- preflight: the `docs-cited-paths` lane covers the reverse direction too —
+  an added source line citing a `.md` path (the "read this doc first"
+  pointer a doc reorganization leaves dangling) fails when the path names
+  nothing tracked or on disk. Same shared existence and directory guards as
+  the markdown side; URL spans and double-quoted strings are stripped
+  before matching, and data files (JSON/TOML/YAML/lock) and test-named
+  files are out of scope.
 - agents: the seven engineer/analyst agents (generalist, iced, planner,
   researcher, rust, scout, tpm) drop the house "never trust a green check"
   blockquote — the rule's canonical homes are `code-quality` § Prove Your

--- a/skills/preflight/README.md
+++ b/skills/preflight/README.md
@@ -2,7 +2,8 @@
 
 A diff-scoped, fail-only checker for the escape classes worth catching
 mechanically: fail-open bash, docs citing repo paths that do not exist,
-TODO markers with no issue behind them, and data files no parser accepts.
+source files citing docs that do not exist, TODO markers with no issue
+behind them, and data files no parser accepts.
 It reports only on lines the change added, and every lane is tuned so a
 finding is worth a hard failure — a false positive costs more than a miss,
 so a lane that cannot decide stays quiet.

--- a/skills/preflight/SKILL.md
+++ b/skills/preflight/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: preflight
-description: "Diff-scoped deterministic pre-review checks, fail-only and precision-first: unparseable shell, shellcheck errors, masked return values on added lines, fail-open bash (unchecked mktemp without errexit, new scripts without strict mode), docs citing repo paths that do not exist, TODO/FIXME markers with no issue reference, and malformed JSON/TOML. Load when running, tuning, or debugging preflight or wiring it into validation/CI."
+description: "Diff-scoped deterministic pre-review checks, fail-only and precision-first: unparseable shell, shellcheck errors, masked return values on added lines, fail-open bash (unchecked mktemp without errexit, new scripts without strict mode), docs citing repo paths that do not exist, source files citing docs that do not exist, TODO/FIXME markers with no issue reference, and malformed JSON/TOML. Load when running, tuning, or debugging preflight or wiring it into validation/CI."
 license: MIT
 user-invocable: true
 metadata:
@@ -39,7 +39,7 @@ clean empty diff.
 | `shellcheck-errors` | Any error-severity finding, anywhere in a changed shell file. | shellcheck |
 | `masked-returns` | SC2155/SC2311 on an added line — a declaration whose exit status hides the command's. | shellcheck |
 | `fail-open` | An `=$(mktemp …)` assignment added to a file without errexit; a new script that never sets `-e`, `-u` and `pipefail`. | built in |
-| `docs-cited-paths` | An added backticked path in a `.md` file, inside a directory the repo really has and the doc's own subtree, that names nothing tracked or on disk. | built in |
+| `docs-cited-paths` | An added backticked path in a `.md` file, inside a directory the repo really has and the doc's own subtree, that names nothing tracked or on disk. Also the reverse pointer: an added source line citing a `.md` path that names nothing tracked or on disk — URL spans and double-quoted strings are stripped first, data files (JSON/TOML/YAML/lock) and test-named files are out of scope, and the same directory guards apply. | built in |
 | `todo-links` | An added `TODO:`/`FIXME(` marker — the word immediately followed by `:` or `(` — with no `#123`, `ABC-123`, or URL on the line. Prose that merely uses the word is not a marker. | built in |
 | `data-syntax` | A changed `.json` or `.toml` file no parser accepts. | jq, taplo or python3 |
 | `workflow-run-syntax` | A `run:` block in a changed `.github/workflows/*.yml` that its shell cannot parse — `bash -n` for bash, `sh -n` for sh, by name or executable path; `${{ … }}` replaced by a placeholder; other shells skipped, and an undeclared shell counts as bash only on plain `ubuntu-*`/`macos-*` runners. Reported at the offending file line — a folded (`>`) block at its first line; a workflow file that is not valid YAML, at the parser's line; an unterminated `${{`, at its line. | python3 with PyYAML |

--- a/skills/preflight/scripts/preflight
+++ b/skills/preflight/scripts/preflight
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # preflight — diff-scoped, fail-only checks: fail-open bash, docs citing
-# repo paths that do not exist, TODO markers with no issue behind them,
-# malformed JSON/TOML, workflow run: blocks bash cannot parse.
+# repo paths that do not exist, source files citing docs that do not exist,
+# TODO markers with no issue behind them, malformed JSON/TOML, workflow
+# run: blocks bash cannot parse.
 #
 # Precision before coverage: a lane that cannot decide says nothing. The
 # line-scoped lanes report only on lines this diff ADDED, so a pre-existing
@@ -569,6 +570,27 @@ doc_token_is_dead() { # TOKEN DOC-SUBTREE — 0 when the token names a path that
   return 0
 }
 
+# Candidate doc citations on a source line: maximal path-charset runs ending
+# in `.md`, one per output line. Double-quoted spans and URL spans go first —
+# a quoted path is a program's working data or an example string, and a
+# GitHub URL containing /docs/x.md names a web page, not a repo path — and a
+# sentence-final dot is punctuation, not part of the name. Placeholders,
+# globs and interpolations never survive: their delimiters sit outside the
+# charset, so they arrive as fragments the shared guards in
+# doc_token_is_dead already reject.
+md_tokens_of() { # LINE -> candidate tokens on stdout
+  printf '%s\n' "$1" | awk '{
+    gsub(/"([^"\\]|\\.)*"/, " ")
+    gsub(/[A-Za-z][A-Za-z0-9+.-]*:\/\/[^ \t]*/, " ")
+    while (match($0, /[A-Za-z0-9_.\/-]+/)) {
+      tok = substr($0, RSTART, RLENGTH)
+      $0 = substr($0, RSTART + RLENGTH)
+      sub(/\.+$/, "", tok)
+      if (tok ~ /\.md$/) print tok
+    }
+  }'
+}
+
 # --- lanes, one changed file at a time ---------------------------------------
 FILE_COUNT=0
 IDX=0
@@ -594,6 +616,22 @@ while IFS= read -r f; do
       case "$f" in */*) subtree="${f%%/*}" ;; esac
       ;;
   esac
+  # Source files whose doc citations are worth judging. Data formats cite
+  # paths as configuration values and carry generated example comments, and
+  # test-named files plant fixture paths on purpose — either would be a
+  # false positive, not a dead pointer.
+  cites_docs=0
+  if [ "$is_md" = 0 ] && [ "$own_rules" = 0 ]; then
+    case "$f" in
+      *.json | *.toml | *.yml | *.yaml | *.lock) ;;
+      *)
+        case "${f##*/}" in
+          tests.rs | *_test.* | *_tests.* | *.test.* | *.spec.* | test_*) ;;
+          *) cites_docs=1 ;;
+        esac
+        ;;
+    esac
+  fi
 
   if [ "$is_sh" = 1 ]; then
     has_set_flag "$cpath" "$ERREXIT_RE" && has_ee=1
@@ -691,6 +729,22 @@ while IFS= read -r f; do
           emit "$f" "$n" docs-cited-paths "cites a path that does not exist: $tok"
         fi
       done
+    elif [ "$cites_docs" = 1 ]; then
+      # The reverse pointer: a source line naming a `.md` file is a citation
+      # whose only job is to be followed, so one a doc reorganization left
+      # dead actively misleads. Only doc targets are judged — other path-like
+      # strings in code are working material — and code cites docs from
+      # anywhere in the tree, so its subtree is the repo itself.
+      case "$content" in
+        *".md"*)
+          while IFS= read -r tok; do
+            [ -n "$tok" ] || continue
+            if doc_token_is_dead "$tok" ""; then
+              emit "$f" "$n" docs-cited-paths "cites a path that does not exist: $tok"
+            fi
+          done <<<"$(md_tokens_of "$content")"
+          ;;
+      esac
     fi
 
     if [ "$own_rules" = 0 ] && printf '%s' "$content" | grep -Eq -- "$TODO_RE" && ! printf '%s' "$content" | grep -Eq -- "$ISSUE_RE"; then

--- a/skills/preflight/scripts/preflight
+++ b/skills/preflight/scripts/preflight
@@ -571,16 +571,17 @@ doc_token_is_dead() { # TOKEN DOC-SUBTREE — 0 when the token names a path that
 }
 
 # Candidate doc citations on a source line: maximal path-charset runs ending
-# in `.md`, one per output line. Double-quoted spans and URL spans go first —
-# a quoted path is a program's working data or an example string, and a
-# GitHub URL containing /docs/x.md names a web page, not a repo path — and a
+# in `.md`, one per output line. Quoted spans (either kind) and URL spans go
+# first — a quoted path is a program's working data or an example string, and
+# a GitHub URL containing /docs/x.md names a web page, not a repo path — and a
 # sentence-final dot is punctuation, not part of the name. Placeholders,
 # globs and interpolations never survive: their delimiters sit outside the
 # charset, so they arrive as fragments the shared guards in
 # doc_token_is_dead already reject.
 md_tokens_of() { # LINE -> candidate tokens on stdout
-  printf '%s\n' "$1" | awk '{
+  printf '%s\n' "$1" | LC_ALL=C awk -v q="'" '{
     gsub(/"([^"\\]|\\.)*"/, " ")
+    gsub(q "[^" q "]*" q, " ")
     gsub(/[A-Za-z][A-Za-z0-9+.-]*:\/\/[^ \t]*/, " ")
     while (match($0, /[A-Za-z0-9_.\/-]+/)) {
       tok = substr($0, RSTART, RLENGTH)

--- a/skills/preflight/tests/lanes-must-fail.test.sh
+++ b/skills/preflight/tests/lanes-must-fail.test.sh
@@ -108,6 +108,16 @@ git -C "$R" add -A
 run_pf
 fires "a citation of a missing file under a real directory fails" "README.md:4: [docs-cited-paths] cites a path that does not exist: docs/gone.md"
 
+echo "=== lane docs-cited-paths: a source line citing a doc that does not exist ==="
+seed srccite
+mkdir -p "$R/src"
+printf '#!/usr/bin/env bash\nset -euo pipefail\n# Read docs/gone.md before editing this.\necho run\n' >"$R/scripts/cite.sh"
+printf 'fn main() {\n    // The mode table lives in docs/gone.md.\n}\n' >"$R/src/main.rs"
+git -C "$R" add -A
+run_pf
+fires "a shell comment citing a missing doc fails at its line" "scripts/cite.sh:3: [docs-cited-paths] cites a path that does not exist: docs/gone.md"
+fires "a non-shell source comment is judged the same way" "src/main.rs:2: [docs-cited-paths] cites a path that does not exist: docs/gone.md"
+
 echo "=== lane todo-links: a TODO marker with no issue behind it ==="
 seed todo
 printf '# Guide\n\nNothing here yet.\n\nTODO: wire this up.\n' >"$R/docs/guide.md"

--- a/skills/preflight/tests/precision.test.sh
+++ b/skills/preflight/tests/precision.test.sh
@@ -36,6 +36,7 @@ seed() { # NAME — fixture in $R: committed baseline, origin/main, feature bran
   # Pre-existing violations, committed: untouched lines must stay invisible.
   printf '# Legacy\n\nTODO: ancient and unreferenced.\n' >"$R/docs/legacy.md"
   printf '#!/usr/bin/env bash\necho old\nTMP="$(mktemp -d)"\n' >"$R/scripts/old.sh"
+  printf '#!/usr/bin/env bash\nset -euo pipefail\n# See docs/gone.md for background.\necho old\n' >"$R/scripts/pointer.sh"
   git -C "$R" add -A
   git -C "$R" commit -qm init
   git clone -q --bare "$R" "$R.git"
@@ -77,8 +78,24 @@ echo "=== benign patterns across every lane stay clean ==="
 seed benign
 # mktemp is fine under errexit; a new script that declares strict mode is fine.
 printf '#!/usr/bin/env bash\nset -euo pipefail\nTMP="$(mktemp -d)"\necho "$TMP"\n' >"$R/scripts/strict.sh"
-# A test-tree script sets its own rules.
-printf '#!/usr/bin/env bash\necho helper\n' >"$R/tests/helper.sh"
+# A test-tree script sets its own rules — including the fixture path it cites.
+printf '#!/usr/bin/env bash\n# fixture: docs/gone.md\necho helper\n' >"$R/tests/helper.sh"
+# Every benign doc-citation shape a source file can carry.
+cat >"$R/scripts/cites.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+# A live citation: docs/guide.md is real.
+# A URL is not a repo path: https://github.com/acme/acme/blob/main/docs/gone.md
+# Placeholders and globs are fragments: docs/<area>/file.md, docs/*.md.
+# Interpolations too: $DOCS_ROOT/gone.md, ${DOCS}/gone.md, {docs_root}/gone.md.
+# Another repo layout is not ours: notes/gone.md has no directory here.
+MSG="a quoted path is data, not a citation: docs/gone.md"
+echo "$MSG"
+EOF
+# Test-named source files plant fixture paths on purpose.
+printf '// fixture cite: docs/gone.md\n' >"$R/scripts/widget.test.ts"
+# Data files cite paths as values and generated example comments.
+printf '# rust = "Read docs/gone.md before coding."\n# Read docs/gone.md.\nkey = 1\n' >"$R/data/example.toml"
 {
   printf '# Fixture\n\n'
   printf 'Placeholders are not paths: `skills/<name>/SKILL.md`, `src/*.rs`.\n'
@@ -102,29 +119,34 @@ printf '{\n  "ok": true\n}\n' >"$R/data/ok.json"
 printf '{\n  // a comment: this dialect is real and jq is right to reject it\n  "strict": true\n}\n' >"$R/tsconfig.json"
 git -C "$R" add -A
 run_pf
-clean "no lane fires on placeholders, URLs, foreign subtrees, referenced TODOs, strict scripts, or JSON-with-comments"
+clean "no lane fires on placeholders, URLs, quoted or data-file or test-file doc cites, foreign subtrees, referenced TODOs, strict scripts, or JSON-with-comments"
 
 echo "=== control: the same fixture still fails on a real defect ==="
 printf 'And a citation that is dead: `docs/gone.md`.\n' >>"$R/README.md"
+printf '# and a source line whose citation is dead: docs/gone.md\n' >>"$R/scripts/cites.sh"
 git -C "$R" add -A
 run_pf
-fires "the benign fixture is not clean because nothing ran" "[docs-cited-paths] cites a path that does not exist: docs/gone.md"
+fires "the benign fixture is not clean because nothing ran" "README.md:16: [docs-cited-paths] cites a path that does not exist: docs/gone.md"
+fires "the benign source file is not clean because nothing ran" "scripts/cites.sh:10: [docs-cited-paths] cites a path that does not exist: docs/gone.md"
 
 echo "=== violations on lines this diff did not touch stay invisible ==="
 seed untouched
 printf '# Legacy\n\nTODO: ancient and unreferenced.\n\nA new paragraph.\n' >"$R/docs/legacy.md"
 printf '#!/usr/bin/env bash\necho old\nTMP="$(mktemp -d)"\necho "$TMP"\n' >"$R/scripts/old.sh"
+printf '#!/usr/bin/env bash\nset -euo pipefail\n# See docs/gone.md for background.\necho old\necho more\n' >"$R/scripts/pointer.sh"
 git -C "$R" add -A
 run_pf
-clean "appending to a file whose older lines violate two lanes reports nothing"
+clean "appending to files whose older lines violate three lanes reports nothing"
 
 echo "=== control: touching those same lines makes them this diff's problem ==="
 printf '# Legacy\n\nTODO: ancient, reworded, still unreferenced.\n\nA new paragraph.\n' >"$R/docs/legacy.md"
 printf '#!/usr/bin/env bash\necho old\nTMP="$(mktemp -d -t x)"\necho "$TMP"\n' >"$R/scripts/old.sh"
+printf '#!/usr/bin/env bash\nset -euo pipefail\n# See docs/gone.md for background, still.\necho old\necho more\n' >"$R/scripts/pointer.sh"
 git -C "$R" add -A
 run_pf
 fires "the reworded TODO line fires" "docs/legacy.md:3: [todo-links]"
 fires "the reworked mktemp line fires" "scripts/old.sh:3: [fail-open] unchecked mktemp"
+fires "the reworked dead-citation line fires" "scripts/pointer.sh:3: [docs-cited-paths] cites a path that does not exist: docs/gone.md"
 
 echo "=== a deleted file is not a finding ==="
 seed deleted

--- a/skills/preflight/tests/precision.test.sh
+++ b/skills/preflight/tests/precision.test.sh
@@ -90,7 +90,8 @@ set -euo pipefail
 # Interpolations too: $DOCS_ROOT/gone.md, ${DOCS}/gone.md, {docs_root}/gone.md.
 # Another repo layout is not ours: notes/gone.md has no directory here.
 MSG="a quoted path is data, not a citation: docs/gone.md"
-echo "$MSG"
+DOC='docs/gone.md'
+echo "$MSG" "$DOC"
 EOF
 # Test-named source files plant fixture paths on purpose.
 printf '// fixture cite: docs/gone.md\n' >"$R/scripts/widget.test.ts"
@@ -127,7 +128,7 @@ printf '# and a source line whose citation is dead: docs/gone.md\n' >>"$R/script
 git -C "$R" add -A
 run_pf
 fires "the benign fixture is not clean because nothing ran" "README.md:16: [docs-cited-paths] cites a path that does not exist: docs/gone.md"
-fires "the benign source file is not clean because nothing ran" "scripts/cites.sh:10: [docs-cited-paths] cites a path that does not exist: docs/gone.md"
+fires "the benign source file is not clean because nothing ran" "scripts/cites.sh:11: [docs-cited-paths] cites a path that does not exist: docs/gone.md"
 
 echo "=== violations on lines this diff did not touch stay invisible ==="
 seed untouched


### PR DESCRIPTION
## What

The preflight `docs-cited-paths` lane now judges the reverse direction: an ADDED line in a source file that cites a `.md` path fails when the path names nothing tracked or on disk. Candidates are maximal path-charset runs ending in `.md` — double-quoted string spans and URL spans stripped first, sentence-final dots trimmed — fed through the existing `doc_token_is_dead` guards unchanged, with the whole repo as the citing file's subtree.

Out of scope by design (precision over recall): markdown files (existing lane unchanged), `tests/`/`fixtures/` trees, test-named basenames, and data formats (json/toml/yml/yaml/lock — they cite paths as configuration values and carry generated example comments).

## Calibration

Repo-wide probe: first pass 7 hits, all false positives (Rust test fixtures and generated launch-instruction example strings, plus their TOML-comment materialization that would have fired fleet-wide on `vstack add` diffs); the quote-stripping and data-format guards remove all of them; second probe zero source-file hits, zero real dangles.

## Proof

Full preflight suite green (must-fail 21, modes 19, precision 8, bash32); `tools/validate-changed` all lanes pass. New must-fail controls: shell and Rust comments citing a missing doc fire at file:line; a planted dead-cite control proves the benign fixture can fail; the untouched-lines section proves a pre-existing dead cite stays invisible until its line is reworked.

Fixes VST-285

Claude-Session: https://claude.ai/code/session_01YCF7qAqiVFuAHPDMXLxV1r
