### PR TITLE
feat(preflight): reviewer-bot attribution lane — durable prose never credits a transient review pass (VST-284)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,13 @@
   the markdown side; URL spans and double-quoted strings are stripped
   before matching, and data files (JSON/TOML/YAML/lock) and test-named
   files are out of scope.
+- preflight: new `reviewer-attribution` lane — an added line crediting a
+  transient reviewer-bot pass (a fleet bot name coupled to a PR/review
+  reference: a parenthetical credit, a per-bot review credit, or a bot
+  review-of-#N form) fails with "state the rationale, drop the reviewer
+  credit". Naming a bot without the credit shape stays clean,
+  `CHANGELOG.md` is exempt (rationale lives there), and
+  `PREFLIGHT_BOT_NAMES` replaces the built-in fleet set (VST-284).
 - agents: the seven engineer/analyst agents (generalist, iced, planner,
   researcher, rust, scout, tpm) drop the house "never trust a green check"
   blockquote — the rule's canonical homes are `code-quality` § Prove Your

--- a/skills/preflight/README.md
+++ b/skills/preflight/README.md
@@ -3,7 +3,8 @@
 A diff-scoped, fail-only checker for the escape classes worth catching
 mechanically: fail-open bash, docs citing repo paths that do not exist,
 source files citing docs that do not exist, TODO markers with no issue
-behind them, and data files no parser accepts.
+behind them, reviewer-bot attributions in durable prose, and data files
+no parser accepts.
 It reports only on lines the change added, and every lane is tuned so a
 finding is worth a hard failure — a false positive costs more than a miss,
 so a lane that cannot decide stays quiet.

--- a/skills/preflight/SKILL.md
+++ b/skills/preflight/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: preflight
-description: "Diff-scoped deterministic pre-review checks, fail-only and precision-first: unparseable shell, shellcheck errors, masked return values on added lines, fail-open bash (unchecked mktemp without errexit, new scripts without strict mode), docs citing repo paths that do not exist, source files citing docs that do not exist, TODO/FIXME markers with no issue reference, reviewer-bot attributions added to durable prose, malformed JSON/TOML, and workflow run: blocks their shell cannot parse. Load when running, tuning, or debugging preflight or wiring it into validation/CI."
+description: "Diff-scoped deterministic pre-review checks, fail-only and precision-first: unparseable shell, shellcheck errors, masked return values on added lines, fail-open bash (unchecked mktemp without errexit, new scripts without strict mode), docs citing repo paths that do not exist, source files citing docs that do not exist, TODO/FIXME markers with no issue reference, reviewer-bot attributions in durable prose, malformed JSON/TOML, and workflow run: blocks their shell cannot parse. Load when running, tuning, or debugging preflight or wiring it into validation/CI."
 license: MIT
 user-invocable: true
 metadata:

--- a/skills/preflight/SKILL.md
+++ b/skills/preflight/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: preflight
-description: "Diff-scoped deterministic pre-review checks, fail-only and precision-first: unparseable shell, shellcheck errors, masked return values on added lines, fail-open bash (unchecked mktemp without errexit, new scripts without strict mode), docs citing repo paths that do not exist, source files citing docs that do not exist, TODO/FIXME markers with no issue reference, and malformed JSON/TOML. Load when running, tuning, or debugging preflight or wiring it into validation/CI."
+description: "Diff-scoped deterministic pre-review checks, fail-only and precision-first: unparseable shell, shellcheck errors, masked return values on added lines, fail-open bash (unchecked mktemp without errexit, new scripts without strict mode), docs citing repo paths that do not exist, source files citing docs that do not exist, TODO/FIXME markers with no issue reference, reviewer-bot attributions added to durable prose, malformed JSON/TOML, and workflow run: blocks their shell cannot parse. Load when running, tuning, or debugging preflight or wiring it into validation/CI."
 license: MIT
 user-invocable: true
 metadata:
@@ -41,6 +41,7 @@ clean empty diff.
 | `fail-open` | An `=$(mktemp …)` assignment added to a file without errexit; a new script that never sets `-e`, `-u` and `pipefail`. | built in |
 | `docs-cited-paths` | An added backticked path in a `.md` file, inside a directory the repo really has and the doc's own subtree, that names nothing tracked or on disk. Also the reverse pointer: an added source line citing a `.md` path that names nothing tracked or on disk — URL spans and double-quoted strings are stripped first, data files (JSON/TOML/YAML/lock) and test-named files are out of scope, and the same directory guards apply. | built in |
 | `todo-links` | An added `TODO:`/`FIXME(` marker — the word immediately followed by `:` or `(` — with no `#123`, `ABC-123`, or URL on the line. Prose that merely uses the word is not a marker. | built in |
+| `reviewer-attribution` | An added line crediting a transient reviewer-bot pass: a fleet bot name (qodo, copilot, coderabbit, codex, devin; `PREFLIGHT_BOT_NAMES` replaces the set) coupled to a PR/review reference — a parenthetical credit, `per <bot> review`, or `<bot> review of #N`. Naming a bot is not the shape: prose describing reviewer behavior stays clean. `CHANGELOG.md` is exempt — rationale lives there. | built in |
 | `data-syntax` | A changed `.json` or `.toml` file no parser accepts. | jq, taplo or python3 |
 | `workflow-run-syntax` | A `run:` block in a changed `.github/workflows/*.yml` that its shell cannot parse — `bash -n` for bash, `sh -n` for sh, by name or executable path; `${{ … }}` replaced by a placeholder; other shells skipped, and an undeclared shell counts as bash only on plain `ubuntu-*`/`macos-*` runners. Reported at the offending file line — a folded (`>`) block at its first line; a workflow file that is not valid YAML, at the parser's line; an unterminated `${{`, at its line. | python3 with PyYAML |
 

--- a/skills/preflight/scripts/preflight
+++ b/skills/preflight/scripts/preflight
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # preflight — diff-scoped, fail-only checks: fail-open bash, docs citing
 # repo paths that do not exist, source files citing docs that do not exist,
-# TODO markers with no issue behind them, malformed JSON/TOML, workflow
-# run: blocks bash cannot parse.
+# TODO markers with no issue behind them, reviewer-bot attributions in
+# durable prose, malformed JSON/TOML, workflow run: blocks bash cannot
+# parse.
 #
 # Precision before coverage: a lane that cannot decide says nothing. The
 # line-scoped lanes report only on lines this diff ADDED, so a pre-existing
@@ -33,7 +34,8 @@ non-ignored untracked files; --staged sees only the index.
   --repo PATH   run against the repository containing PATH (default: cwd)
 
 Lanes: shell-syntax, shellcheck-errors, masked-returns, fail-open,
-docs-cited-paths, todo-links, data-syntax, workflow-run-syntax.
+docs-cited-paths, todo-links, reviewer-attribution, data-syntax,
+workflow-run-syntax.
 
 Exit codes: 0 clean; 1 findings; 2 usage/environment error.
 EOF
@@ -524,6 +526,21 @@ MKTEMP_ASSIGN="=[\"']?\\\$\\(mktemp"
 # on them is a gate people route around.
 TODO_RE='(^|[^A-Za-z0-9_])(TODO|FIXME)[(:]'
 ISSUE_RE='(#[0-9]+|[A-Z][A-Z0-9]+-[0-9]+|http)'
+
+# The attribution shape only: a review-fleet bot name coupled to a PR/review
+# reference — a parenthetical credit, a per-bot review credit, a bot review
+# of #N. A bot pass is not a rationale: the credit rots as PRs renumber,
+# while prose that merely names a bot (reviewer docs, gate config) is
+# describing behavior and stays clean, so the reference word must end at a
+# word boundary — an account named after the reviewing is not a credit.
+# CHANGELOG.md is where rationale belongs and is exempt.
+BOT_ALT="$(printf '%s' "${PREFLIGHT_BOT_NAMES:-qodo copilot coderabbit codex devin}" | tr -cs 'A-Za-z0-9_-' '|')"
+BOT_ALT="${BOT_ALT#|}"
+BOT_ALT="${BOT_ALT%|}"
+[ -n "$BOT_ALT" ] || BOT_ALT='qodo|copilot|coderabbit|codex|devin'
+BOT_ATTR_RE="\\(($BOT_ALT)([^A-Za-z0-9_)][^)]*)?((pr ?)?#[0-9]+|[^A-Za-z0-9_]r[0-9]{6,}|review)([^A-Za-z0-9_)][^)]*)?\\)"
+BOT_ATTR_RE="$BOT_ATTR_RE|(^|[^A-Za-z0-9_])per +((the|a) +)?($BOT_ALT)('s)? +(review|pass|feedback|suggestion|comment|finding)"
+BOT_ATTR_RE="$BOT_ATTR_RE|(^|[^A-Za-z0-9_])($BOT_ALT)('s)? +review +of +(pr ?)?#[0-9]+"
 : >"$TMP/tok.ok"
 : >"$TMP/tok.bad"
 
@@ -633,6 +650,10 @@ while IFS= read -r f; do
         ;;
     esac
   fi
+  is_changelog=0
+  case "$f" in
+    CHANGELOG.md | */CHANGELOG.md) is_changelog=1 ;;
+  esac
 
   if [ "$is_sh" = 1 ]; then
     has_set_flag "$cpath" "$ERREXIT_RE" && has_ee=1
@@ -750,6 +771,10 @@ while IFS= read -r f; do
 
     if [ "$own_rules" = 0 ] && printf '%s' "$content" | grep -Eq -- "$TODO_RE" && ! printf '%s' "$content" | grep -Eq -- "$ISSUE_RE"; then
       emit "$f" "$n" todo-links "TODO:/FIXME( marker without an issue reference (#123, ABC-123, or a URL)"
+    fi
+
+    if [ "$own_rules" = 0 ] && [ "$is_changelog" = 0 ] && printf '%s' "$content" | grep -Eiq -- "$BOT_ATTR_RE"; then
+      emit "$f" "$n" reviewer-attribution "credits a transient reviewer pass — state the rationale, drop the reviewer credit"
     fi
   done <"$REC"
 done <"$TMP/files.list"

--- a/skills/preflight/scripts/preflight
+++ b/skills/preflight/scripts/preflight
@@ -2,8 +2,8 @@
 # preflight — diff-scoped, fail-only checks: fail-open bash, docs citing
 # repo paths that do not exist, source files citing docs that do not exist,
 # TODO markers with no issue behind them, reviewer-bot attributions in
-# durable prose, malformed JSON/TOML, workflow run: blocks bash cannot
-# parse.
+# durable prose, malformed JSON/TOML, workflow run: blocks their shell
+# cannot parse.
 #
 # Precision before coverage: a lane that cannot decide says nothing. The
 # line-scoped lanes report only on lines this diff ADDED, so a pre-existing
@@ -534,11 +534,11 @@ ISSUE_RE='(#[0-9]+|[A-Z][A-Z0-9]+-[0-9]+|http)'
 # describing behavior and stays clean, so the reference word must end at a
 # word boundary — an account named after the reviewing is not a credit.
 # CHANGELOG.md is where rationale belongs and is exempt.
-BOT_ALT="$(printf '%s' "${PREFLIGHT_BOT_NAMES:-qodo copilot coderabbit codex devin}" | tr -cs 'A-Za-z0-9_-' '|')"
+BOT_ALT="$(printf '%s' "${PREFLIGHT_BOT_NAMES:-qodo copilot coderabbit codex devin}" | LC_ALL=C tr -cs 'A-Za-z0-9_-' '|')"
 BOT_ALT="${BOT_ALT#|}"
 BOT_ALT="${BOT_ALT%|}"
 [ -n "$BOT_ALT" ] || BOT_ALT='qodo|copilot|coderabbit|codex|devin'
-BOT_ATTR_RE="\\(($BOT_ALT)([^A-Za-z0-9_)][^)]*)?((pr ?)?#[0-9]+|[^A-Za-z0-9_]r[0-9]{6,}|review)([^A-Za-z0-9_)][^)]*)?\\)"
+BOT_ATTR_RE="\\(($BOT_ALT)([^A-Za-z0-9_)][^)]*)?((pr ?)?#[0-9]+|[^A-Za-z0-9_]r[0-9]{6,})([^A-Za-z0-9_)][^)]*)?\\)"
 BOT_ATTR_RE="$BOT_ATTR_RE|(^|[^A-Za-z0-9_])per +((the|a) +)?($BOT_ALT)('s)? +(review|pass|feedback|suggestion|comment|finding)"
 BOT_ATTR_RE="$BOT_ATTR_RE|(^|[^A-Za-z0-9_])($BOT_ALT)('s)? +review +of +(pr ?)?#[0-9]+"
 : >"$TMP/tok.ok"

--- a/skills/preflight/scripts/preflight
+++ b/skills/preflight/scripts/preflight
@@ -539,7 +539,7 @@ BOT_ALT="${BOT_ALT#|}"
 BOT_ALT="${BOT_ALT%|}"
 [ -n "$BOT_ALT" ] || BOT_ALT='qodo|copilot|coderabbit|codex|devin'
 BOT_ATTR_RE="\\(($BOT_ALT)([^A-Za-z0-9_)-][^)]*)?((pr ?)?#[0-9]+|[^A-Za-z0-9_]r[0-9]{6,})([^A-Za-z0-9_)][^)]*)?\\)"
-BOT_ATTR_RE="$BOT_ATTR_RE|(^|[^A-Za-z0-9_])per +((the|a) +)?($BOT_ALT)('s)? +(review|pass|feedback|suggestion|comment|finding)"
+BOT_ATTR_RE="$BOT_ATTR_RE|(^|[^A-Za-z0-9_])per +((the|a) +)?($BOT_ALT)('s)? +(review|pass|feedback|suggestion|comment|finding)s?[[:punct:]]*[[:space:]]*\$"
 BOT_ATTR_RE="$BOT_ATTR_RE|(^|[^A-Za-z0-9_])($BOT_ALT)('s)? +review +of +(pr ?)?#[0-9]+"
 : >"$TMP/tok.ok"
 : >"$TMP/tok.bad"
@@ -772,7 +772,7 @@ while IFS= read -r f; do
       emit "$f" "$n" todo-links "TODO:/FIXME( marker without an issue reference (#123, ABC-123, or a URL)"
     fi
 
-    if [ "$own_rules" = 0 ] && [ "$is_changelog" = 0 ] && [ "$is_testname" = 0 ] && printf '%s' "$content" | grep -Eiq -- "$BOT_ATTR_RE"; then
+    if [ "$own_rules" = 0 ] && [ "$is_changelog" = 0 ] && [ "$is_testname" = 0 ] && printf '%s' "$content" | LC_ALL=C grep -Eiq -- "$BOT_ATTR_RE"; then
       emit "$f" "$n" reviewer-attribution "credits a transient reviewer pass — state the rationale, drop the reviewer credit"
     fi
   done <"$REC"

--- a/skills/preflight/scripts/preflight
+++ b/skills/preflight/scripts/preflight
@@ -538,7 +538,7 @@ BOT_ALT="$(printf '%s' "${PREFLIGHT_BOT_NAMES:-qodo copilot coderabbit codex dev
 BOT_ALT="${BOT_ALT#|}"
 BOT_ALT="${BOT_ALT%|}"
 [ -n "$BOT_ALT" ] || BOT_ALT='qodo|copilot|coderabbit|codex|devin'
-BOT_ATTR_RE="\\(($BOT_ALT)([^A-Za-z0-9_)][^)]*)?((pr ?)?#[0-9]+|[^A-Za-z0-9_]r[0-9]{6,})([^A-Za-z0-9_)][^)]*)?\\)"
+BOT_ATTR_RE="\\(($BOT_ALT)([^A-Za-z0-9_)-][^)]*)?((pr ?)?#[0-9]+|[^A-Za-z0-9_]r[0-9]{6,})([^A-Za-z0-9_)][^)]*)?\\)"
 BOT_ATTR_RE="$BOT_ATTR_RE|(^|[^A-Za-z0-9_])per +((the|a) +)?($BOT_ALT)('s)? +(review|pass|feedback|suggestion|comment|finding)"
 BOT_ATTR_RE="$BOT_ATTR_RE|(^|[^A-Za-z0-9_])($BOT_ALT)('s)? +review +of +(pr ?)?#[0-9]+"
 : >"$TMP/tok.ok"
@@ -638,16 +638,15 @@ while IFS= read -r f; do
   # paths as configuration values and carry generated example comments, and
   # test-named files plant fixture paths on purpose — either would be a
   # false positive, not a dead pointer.
+  is_testname=0
+  case "${f##*/}" in
+    tests.rs | *_test.* | *_tests.* | *.test.* | *.spec.* | test_*) is_testname=1 ;;
+  esac
   cites_docs=0
-  if [ "$is_md" = 0 ] && [ "$own_rules" = 0 ]; then
+  if [ "$is_md" = 0 ] && [ "$own_rules" = 0 ] && [ "$is_testname" = 0 ]; then
     case "$f" in
       *.json | *.toml | *.yml | *.yaml | *.lock) ;;
-      *)
-        case "${f##*/}" in
-          tests.rs | *_test.* | *_tests.* | *.test.* | *.spec.* | test_*) ;;
-          *) cites_docs=1 ;;
-        esac
-        ;;
+      *) cites_docs=1 ;;
     esac
   fi
   is_changelog=0
@@ -773,7 +772,7 @@ while IFS= read -r f; do
       emit "$f" "$n" todo-links "TODO:/FIXME( marker without an issue reference (#123, ABC-123, or a URL)"
     fi
 
-    if [ "$own_rules" = 0 ] && [ "$is_changelog" = 0 ] && printf '%s' "$content" | grep -Eiq -- "$BOT_ATTR_RE"; then
+    if [ "$own_rules" = 0 ] && [ "$is_changelog" = 0 ] && [ "$is_testname" = 0 ] && printf '%s' "$content" | grep -Eiq -- "$BOT_ATTR_RE"; then
       emit "$f" "$n" reviewer-attribution "credits a transient reviewer pass — state the rationale, drop the reviewer credit"
     fi
   done <"$REC"

--- a/skills/preflight/scripts/preflight
+++ b/skills/preflight/scripts/preflight
@@ -539,8 +539,8 @@ BOT_ALT="${BOT_ALT#|}"
 BOT_ALT="${BOT_ALT%|}"
 [ -n "$BOT_ALT" ] || BOT_ALT='qodo|copilot|coderabbit|codex|devin'
 BOT_ATTR_RE="\\(($BOT_ALT)([^A-Za-z0-9_)-][^)]*)?((pr ?)?#[0-9]+|[^A-Za-z0-9_]r[0-9]{6,})([^A-Za-z0-9_)][^)]*)?\\)"
-BOT_ATTR_RE="$BOT_ATTR_RE|(^|[^A-Za-z0-9_])per +((the|a) +)?($BOT_ALT)('s)? +(review|pass|feedback|suggestion|comment|finding)s?[[:punct:]]*[[:space:]]*\$"
-BOT_ATTR_RE="$BOT_ATTR_RE|(^|[^A-Za-z0-9_])($BOT_ALT)('s)? +review +of +(pr ?)?#[0-9]+"
+BOT_ATTR_RE="$BOT_ATTR_RE|(^|[^A-Za-z0-9_-])per +((the|a) +)?($BOT_ALT)('s)? +(review|pass|feedback|suggestion|comment|finding)s?[[:punct:]]*[[:space:]]*\$"
+BOT_ATTR_RE="$BOT_ATTR_RE|(^|[^A-Za-z0-9_-])($BOT_ALT)('s)? +review +of +(pr ?)?#[0-9]+"
 : >"$TMP/tok.ok"
 : >"$TMP/tok.bad"
 

--- a/skills/preflight/tests/lanes-must-fail.test.sh
+++ b/skills/preflight/tests/lanes-must-fail.test.sh
@@ -133,6 +133,32 @@ run_pf
 fires "the owner-in-parentheses form fails too" "docs/guide.md:5: [todo-links]"
 fires "FIXME is judged exactly as TODO is" "docs/guide.md:6: [todo-links]"
 
+echo "=== lane reviewer-attribution: durable prose crediting a transient review pass ==="
+seed attribution
+printf '# Guide\n\nNothing here yet.\n\nClamped in review (qodo PR #431).\nHardened (Copilot review of #212).\nRenamed (CodeRabbit r3402103393).\nQuoted per codex review.\n' >"$R/docs/guide.md"
+printf '#!/usr/bin/env bash\nset -euo pipefail\necho existing\n# tightened per devin review\n' >"$R/scripts/existing.sh"
+git -C "$R" add -A
+run_pf
+fires "a parenthetical bot-and-PR credit fails" "docs/guide.md:5: [reviewer-attribution]"
+fires "a parenthetical review-of-PR credit fails" "docs/guide.md:6: [reviewer-attribution]"
+fires "a parenthetical review-id credit fails" "docs/guide.md:7: [reviewer-attribution]"
+fires "a per-bot prose credit fails" "docs/guide.md:8: [reviewer-attribution]"
+fires "a code comment carries the same rule as docs" "scripts/existing.sh:4: [reviewer-attribution]"
+
+# PREFLIGHT_BOT_NAMES replaces the fleet default rather than extending it:
+# only the named bots are attributions.
+seed botnames
+printf '# Guide\n\nNothing here yet.\n\nTuned (renovate PR #12).\nTuned (qodo PR #34).\n' >"$R/docs/guide.md"
+git -C "$R" add -A
+OUT=""
+RC=0
+OUT="$(cd "$R" && PREFLIGHT_BOT_NAMES='renovate dependabot' "$PF" 2>&1)" || RC=$?
+fires "an overridden bot set flags its own bots" "docs/guide.md:5: [reviewer-attribution]"
+case "$OUT" in
+  *"docs/guide.md:6"*) bad "an overridden bot set replaces the default set" "out=$OUT" ;;
+  *) ok "an overridden bot set replaces the default set" ;;
+esac
+
 echo "=== lane data-syntax: malformed JSON ==="
 seed json
 if command -v jq >/dev/null 2>&1; then

--- a/skills/preflight/tests/lanes-must-fail.test.sh
+++ b/skills/preflight/tests/lanes-must-fail.test.sh
@@ -155,7 +155,7 @@ RC=0
 OUT="$(cd "$R" && PREFLIGHT_BOT_NAMES='renovate dependabot' "$PF" 2>&1)" || RC=$?
 fires "an overridden bot set flags its own bots" "docs/guide.md:5: [reviewer-attribution]"
 case "$OUT" in
-  *"docs/guide.md:6"*) bad "an overridden bot set replaces the default set" "out=$OUT" ;;
+  *"docs/guide.md:6: [reviewer-attribution]"*) bad "an overridden bot set replaces the default set" "out=$OUT" ;;
   *) ok "an overridden bot set replaces the default set" ;;
 esac
 

--- a/skills/preflight/tests/precision.test.sh
+++ b/skills/preflight/tests/precision.test.sh
@@ -95,7 +95,7 @@ DOC='docs/gone.md'
 echo "$MSG" "$DOC"
 EOF
 # Test-named source files plant fixture paths on purpose.
-printf '// fixture cite: docs/gone.md\n' >"$R/scripts/widget.test.ts"
+printf '// fixture cite: docs/gone.md\nconst s = "Hardened per codex review.";\n' >"$R/scripts/widget.test.ts"
 # Data files cite paths as values and generated example comments.
 printf '# rust = "Read docs/gone.md before coding."\n# Read docs/gone.md.\nkey = 1\n' >"$R/data/example.toml"
 {
@@ -122,6 +122,7 @@ printf '# rust = "Read docs/gone.md before coding."\n# Read docs/gone.md.\nkey =
   printf 'Reviewer gate: Copilot (copilot-pull-request-reviewer) auto-reviews every PR.\n'
   printf 'Auth is Codex OAuth (Codex OAuth, no openai key).\n'
   printf 'Rules live in .github/copilot-instructions.md, per copilot instructions convention.\n'
+  printf 'The option landed upstream (codex-cli PR #123), not here.\n'
 } >"$R/README.md"
 # The changelog is the sanctioned home for rationale, and a test tree sets
 # its own rules — an attribution in either is nobody's finding.
@@ -141,9 +142,9 @@ printf 'Hardened per qodo review.\n' >>"$R/README.md"
 printf '# and a source line whose citation is dead: docs/gone.md\n' >>"$R/scripts/cites.sh"
 git -C "$R" add -A
 run_pf
-fires "the benign fixture is not clean because nothing ran" "README.md:21: [docs-cited-paths] cites a path that does not exist: docs/gone.md"
+fires "the benign fixture is not clean because nothing ran" "README.md:22: [docs-cited-paths] cites a path that does not exist: docs/gone.md"
 fires "the benign source file is not clean because nothing ran" "scripts/cites.sh:11: [docs-cited-paths] cites a path that does not exist: docs/gone.md"
-fires "the same benign bot mentions do not shield a real credit beside them" "README.md:22: [reviewer-attribution]"
+fires "the same benign bot mentions do not shield a real credit beside them" "README.md:23: [reviewer-attribution]"
 
 echo "=== violations on lines this diff did not touch stay invisible ==="
 seed untouched

--- a/skills/preflight/tests/precision.test.sh
+++ b/skills/preflight/tests/precision.test.sh
@@ -124,6 +124,7 @@ printf '# rust = "Read docs/gone.md before coding."\n# Read docs/gone.md.\nkey =
   printf 'Rules live in .github/copilot-instructions.md, per copilot instructions convention.\n'
   printf 'The option landed upstream (codex-cli PR #123), not here.\n'
   printf 'The gate records one status per Codex review before it queues anything.\n'
+  printf 'See the open-codex review of #12 for the upstream fix.\n'
 } >"$R/README.md"
 # The changelog is the sanctioned home for rationale, and a test tree sets
 # its own rules — an attribution in either is nobody's finding.
@@ -143,9 +144,9 @@ printf 'Hardened per qodo review.\n' >>"$R/README.md"
 printf '# and a source line whose citation is dead: docs/gone.md\n' >>"$R/scripts/cites.sh"
 git -C "$R" add -A
 run_pf
-fires "the benign fixture is not clean because nothing ran" "README.md:23: [docs-cited-paths] cites a path that does not exist: docs/gone.md"
+fires "the benign fixture is not clean because nothing ran" "README.md:24: [docs-cited-paths] cites a path that does not exist: docs/gone.md"
 fires "the benign source file is not clean because nothing ran" "scripts/cites.sh:11: [docs-cited-paths] cites a path that does not exist: docs/gone.md"
-fires "the same benign bot mentions do not shield a real credit beside them" "README.md:24: [reviewer-attribution]"
+fires "the same benign bot mentions do not shield a real credit beside them" "README.md:25: [reviewer-attribution]"
 
 echo "=== violations on lines this diff did not touch stay invisible ==="
 seed untouched

--- a/skills/preflight/tests/precision.test.sh
+++ b/skills/preflight/tests/precision.test.sh
@@ -141,9 +141,9 @@ printf 'Hardened per qodo review.\n' >>"$R/README.md"
 printf '# and a source line whose citation is dead: docs/gone.md\n' >>"$R/scripts/cites.sh"
 git -C "$R" add -A
 run_pf
-fires "the benign fixture is not clean because nothing ran" "[docs-cited-paths] cites a path that does not exist: docs/gone.md"
+fires "the benign fixture is not clean because nothing ran" "README.md:21: [docs-cited-paths] cites a path that does not exist: docs/gone.md"
 fires "the benign source file is not clean because nothing ran" "scripts/cites.sh:11: [docs-cited-paths] cites a path that does not exist: docs/gone.md"
-fires "the same benign bot mentions do not shield a real credit beside them" "[reviewer-attribution]"
+fires "the same benign bot mentions do not shield a real credit beside them" "README.md:22: [reviewer-attribution]"
 
 echo "=== violations on lines this diff did not touch stay invisible ==="
 seed untouched

--- a/skills/preflight/tests/precision.test.sh
+++ b/skills/preflight/tests/precision.test.sh
@@ -35,6 +35,7 @@ seed() { # NAME — fixture in $R: committed baseline, origin/main, feature bran
   printf '#!/usr/bin/env bash\nset -euo pipefail\necho hook\n' >"$R/hooks/real.sh"
   # Pre-existing violations, committed: untouched lines must stay invisible.
   printf '# Legacy\n\nTODO: ancient and unreferenced.\n' >"$R/docs/legacy.md"
+  printf '# History\n\nClamped in review (qodo PR #431).\n' >"$R/docs/history.md"
   printf '#!/usr/bin/env bash\necho old\nTMP="$(mktemp -d)"\n' >"$R/scripts/old.sh"
   printf '#!/usr/bin/env bash\nset -euo pipefail\n# See docs/gone.md for background.\necho old\n' >"$R/scripts/pointer.sh"
   git -C "$R" add -A
@@ -113,26 +114,41 @@ printf '# rust = "Read docs/gone.md before coding."\n# Read docs/gone.md.\nkey =
   printf 'TODO hygiene is preflight job now, so reviewers stop chasing it.\n'
   printf 'Scaffolding placeholders are not work items either: description: TODO - describe this agent.\n'
   printf 'Nor is a bare - TODO bullet, nor TODOS as a heading word.\n'
+  # Naming a bot is not crediting one: reviewer docs, gate config naming the
+  # bot account, and a product name sharing the word are all prose about
+  # behavior, not provenance.
+  printf 'Copilot and Codex are the flat-rate reviewers now; qodo was dropped.\n'
+  printf 'The merge gate waits for the copilot review to land, then queues.\n'
+  printf 'Reviewer gate: Copilot (copilot-pull-request-reviewer) auto-reviews every PR.\n'
+  printf 'Auth is Codex OAuth (Codex OAuth, no openai key).\n'
+  printf 'Rules live in .github/copilot-instructions.md, per copilot instructions convention.\n'
 } >"$R/README.md"
+# The changelog is the sanctioned home for rationale, and a test tree sets
+# its own rules — an attribution in either is nobody's finding.
+printf '# Changelog\n\n- clamp tightened; drops the flaky retry (qodo PR #431)\n' >"$R/CHANGELOG.md"
+printf '# Notes\n\nReworked (Copilot review of #212).\n' >"$R/tests/notes.md"
 # A doc outside the root speaks about another subtree, not about our files.
 printf '# Notes\n\nThe installer writes `hooks/vstack-autorepair` into the consumer.\n' >"$R/docs/notes.md"
 printf '{\n  "ok": true\n}\n' >"$R/data/ok.json"
 printf '{\n  // a comment: this dialect is real and jq is right to reject it\n  "strict": true\n}\n' >"$R/tsconfig.json"
 git -C "$R" add -A
 run_pf
-clean "no lane fires on placeholders, URLs, quoted or data-file or test-file doc cites, foreign subtrees, referenced TODOs, strict scripts, or JSON-with-comments"
+clean "no lane fires on placeholders, URLs, quoted or data-file or test-file doc cites, foreign subtrees, referenced TODOs, strict scripts, bot mentions, exempt changelogs, or JSON-with-comments"
 
 echo "=== control: the same fixture still fails on a real defect ==="
 printf 'And a citation that is dead: `docs/gone.md`.\n' >>"$R/README.md"
+printf 'Hardened per qodo review.\n' >>"$R/README.md"
 printf '# and a source line whose citation is dead: docs/gone.md\n' >>"$R/scripts/cites.sh"
 git -C "$R" add -A
 run_pf
-fires "the benign fixture is not clean because nothing ran" "README.md:16: [docs-cited-paths] cites a path that does not exist: docs/gone.md"
+fires "the benign fixture is not clean because nothing ran" "[docs-cited-paths] cites a path that does not exist: docs/gone.md"
 fires "the benign source file is not clean because nothing ran" "scripts/cites.sh:11: [docs-cited-paths] cites a path that does not exist: docs/gone.md"
+fires "the same benign bot mentions do not shield a real credit beside them" "[reviewer-attribution]"
 
 echo "=== violations on lines this diff did not touch stay invisible ==="
 seed untouched
 printf '# Legacy\n\nTODO: ancient and unreferenced.\n\nA new paragraph.\n' >"$R/docs/legacy.md"
+printf '# History\n\nClamped in review (qodo PR #431).\n\nMore history.\n' >"$R/docs/history.md"
 printf '#!/usr/bin/env bash\necho old\nTMP="$(mktemp -d)"\necho "$TMP"\n' >"$R/scripts/old.sh"
 printf '#!/usr/bin/env bash\nset -euo pipefail\n# See docs/gone.md for background.\necho old\necho more\n' >"$R/scripts/pointer.sh"
 git -C "$R" add -A
@@ -141,11 +157,13 @@ clean "appending to files whose older lines violate three lanes reports nothing"
 
 echo "=== control: touching those same lines makes them this diff's problem ==="
 printf '# Legacy\n\nTODO: ancient, reworded, still unreferenced.\n\nA new paragraph.\n' >"$R/docs/legacy.md"
+printf '# History\n\nReworked in review (qodo PR #431).\n\nMore history.\n' >"$R/docs/history.md"
 printf '#!/usr/bin/env bash\necho old\nTMP="$(mktemp -d -t x)"\necho "$TMP"\n' >"$R/scripts/old.sh"
 printf '#!/usr/bin/env bash\nset -euo pipefail\n# See docs/gone.md for background, still.\necho old\necho more\n' >"$R/scripts/pointer.sh"
 git -C "$R" add -A
 run_pf
 fires "the reworded TODO line fires" "docs/legacy.md:3: [todo-links]"
+fires "the reworded attribution line fires" "docs/history.md:3: [reviewer-attribution]"
 fires "the reworked mktemp line fires" "scripts/old.sh:3: [fail-open] unchecked mktemp"
 fires "the reworked dead-citation line fires" "scripts/pointer.sh:3: [docs-cited-paths] cites a path that does not exist: docs/gone.md"
 

--- a/skills/preflight/tests/precision.test.sh
+++ b/skills/preflight/tests/precision.test.sh
@@ -123,6 +123,7 @@ printf '# rust = "Read docs/gone.md before coding."\n# Read docs/gone.md.\nkey =
   printf 'Auth is Codex OAuth (Codex OAuth, no openai key).\n'
   printf 'Rules live in .github/copilot-instructions.md, per copilot instructions convention.\n'
   printf 'The option landed upstream (codex-cli PR #123), not here.\n'
+  printf 'The gate records one status per Codex review before it queues anything.\n'
 } >"$R/README.md"
 # The changelog is the sanctioned home for rationale, and a test tree sets
 # its own rules — an attribution in either is nobody's finding.
@@ -142,9 +143,9 @@ printf 'Hardened per qodo review.\n' >>"$R/README.md"
 printf '# and a source line whose citation is dead: docs/gone.md\n' >>"$R/scripts/cites.sh"
 git -C "$R" add -A
 run_pf
-fires "the benign fixture is not clean because nothing ran" "README.md:22: [docs-cited-paths] cites a path that does not exist: docs/gone.md"
+fires "the benign fixture is not clean because nothing ran" "README.md:23: [docs-cited-paths] cites a path that does not exist: docs/gone.md"
 fires "the benign source file is not clean because nothing ran" "scripts/cites.sh:11: [docs-cited-paths] cites a path that does not exist: docs/gone.md"
-fires "the same benign bot mentions do not shield a real credit beside them" "README.md:23: [reviewer-attribution]"
+fires "the same benign bot mentions do not shield a real credit beside them" "README.md:24: [reviewer-attribution]"
 
 echo "=== violations on lines this diff did not touch stay invisible ==="
 seed untouched


### PR DESCRIPTION
## What

New diff-scoped preflight lane `reviewer-attribution`: an ADDED line in durable prose crediting a transient reviewer-bot pass — a fleet bot name (qodo, copilot, coderabbit, codex, devin; `PREFLIGHT_BOT_NAMES` replaces the set) coupled to a PR/review reference as a parenthetical credit, a per-bot review credit, or a bot review-of-#N form — fails with "state the rationale, drop the reviewer credit".

Naming a bot without the credit shape stays clean (reviewer docs, gate config naming the bot account); the reference word must end at a word boundary, so `(copilot-pull-request-reviewer)` — a live false positive of the pattern this generalizes — stays clean. `CHANGELOG.md` is exempt as the sanctioned home for rationale; tests/fixtures keep their existing exemption.

## Calibration

Zero hits across the repo at HEAD (`preflight --all`) — the gate lands zero-pinned, the same posture as drovr's repo-local original.

## Proof

Full preflight suite green (must-fail 28, modes 19, precision 10, bash32). Five planted attribution variants plus the bot-set override in lanes-must-fail; benign-mention/exemption/diff-scoping pins with paired must-fail controls in precision; every new firing assertion proven red against a neutered copy of the lane.

Fixes VST-284

Claude-Session: https://claude.ai/code/session_01YCF7qAqiVFuAHPDMXLxV1r
