### PR TITLE
fix(cli): refresh seeds settings into source repos and refreshes unedited seeded comments (VST-260)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,15 @@
   GitHub-route Linear-free check — its sed pattern was BRE (parens grouped,
   never matched) and the extraction failure inside `$(...)` could not stop
   the run. ERE now, and an empty region fails the assertion.
+- cli: `vstack refresh` now seeds missing skill-settings keys into a repo
+  that is its own package source (previously such repos silently received
+  none and drifted on every settings addition), and refreshes a seeded
+  key's comment block when the skill template revises it — gated by a new
+  `settings_seeds` provenance ledger in `.vstack-lock.json`, so a comment
+  the user edited is never rewritten. Installs predating the ledger pick up
+  provenance on their first refresh where the comment still matches the
+  template; a pre-ledger comment that already drifted from the incoming
+  template stays untouched (indistinguishable from a hand edit) (VST-260).
 - orch: `queue-wait` default budget is 2400s, sized to the merge-group suite
   (VST-249); the budget-exhausted `queued` verdict now carries `progressing`
   and a `cause` of `still_progressing` vs `stalled` from merge-queue-entry

--- a/cli/src/commands/add.rs
+++ b/cli/src/commands/add.rs
@@ -1126,7 +1126,7 @@ role: engineer
 
     #[cfg(unix)]
     #[test]
-    fn project_add_skips_project_settings_when_source_is_same_checkout_via_symlink() {
+    fn project_add_seeds_settings_but_not_config_when_source_is_same_checkout_via_symlink() {
         use std::os::unix::fs::symlink;
 
         let root = tmpdir("source-alias");
@@ -1165,9 +1165,11 @@ role: engineer
             std::fs::read_to_string(source.join("vstack.toml")).unwrap(),
             "[role-skills]\n"
         );
+        let settings = std::fs::read_to_string(source.join("vstack.settings.toml"))
+            .expect("settings seeding runs for a repo that is its own source");
         assert!(
-            !source.join("vstack.settings.toml").exists(),
-            "installing a source into itself through a symlink alias must not seed project settings"
+            settings.contains("DEMO_TIMEOUT"),
+            "the installed skill's settings keys are seeded: {settings}"
         );
 
         let _ = std::fs::remove_dir_all(root);
@@ -2570,13 +2572,18 @@ source (e.g. switching vstack repos, or starting clean), pass --clobber:
     // make every item appear outdated on next launch).
     if writes_project_config {
         crate::project_config::write_agent_skills(&project_root, &agent_skill_map);
-        if let Some(result) = crate::project_settings::ensure_skill_settings(
+    }
+    // Settings seeding is per-checkout runtime state with no catalog
+    // counterpart, so it runs for self-source repos too — same rule as
+    // refresh.
+    if !global
+        && let Some(result) = crate::project_settings::ensure_skill_settings(
             &project_root,
             &selected_skills,
             &mut lock.settings_seeds,
-        )? {
-            settings_note = Some(format!("Project settings: {}", result.summary()));
-        }
+        )?
+    {
+        settings_note = Some(format!("Project settings: {}", result.summary()));
     }
 
     // Update lock file

--- a/cli/src/commands/add.rs
+++ b/cli/src/commands/add.rs
@@ -2582,16 +2582,17 @@ source (e.g. switching vstack repos, or starting clean), pass --clobber:
         let selected_names: std::collections::HashSet<&str> =
             selected_skills.iter().map(|s| s.name.as_str()).collect();
         let mut settings_skills: Vec<Skill> = selected_skills.clone();
-        for skill in crate::catalog::discover_skills(&source_dir).unwrap_or_default() {
+        for skill in crate::catalog::discover_skills(&source_dir)? {
             if !selected_names.contains(skill.name.as_str())
-                && lock
-                    .entries
-                    .get(&skill.name)
-                    .is_some_and(|e| e.kind == config::ItemKind::Skill)
+                && lock.entries.get(&skill.name).is_some_and(|e| {
+                    e.kind == config::ItemKind::Skill && e.source == resolved_source.source
+                })
             {
                 settings_skills.push(skill);
             }
         }
+        // Same first-wins order refresh derives from the lock's BTreeMap.
+        settings_skills.sort_by(|a, b| a.name.cmp(&b.name));
         if let Some(result) = crate::project_settings::ensure_skill_settings(
             &project_root,
             &settings_skills,

--- a/cli/src/commands/add.rs
+++ b/cli/src/commands/add.rs
@@ -2575,15 +2575,30 @@ source (e.g. switching vstack repos, or starting clean), pass --clobber:
     }
     // Settings seeding is per-checkout runtime state with no catalog
     // counterpart, so it runs for self-source repos too — same rule as
-    // refresh.
-    if !global
-        && let Some(result) = crate::project_settings::ensure_skill_settings(
+    // refresh. It reads the FULL installed set (lock ∪ this selection), not
+    // the selection alone: the seeder dedups same-key templates first-wins,
+    // and a filtered add must not reorder that against what refresh sees.
+    if !global {
+        let selected_names: std::collections::HashSet<&str> =
+            selected_skills.iter().map(|s| s.name.as_str()).collect();
+        let mut settings_skills: Vec<Skill> = selected_skills.clone();
+        for skill in crate::catalog::discover_skills(&source_dir).unwrap_or_default() {
+            if !selected_names.contains(skill.name.as_str())
+                && lock
+                    .entries
+                    .get(&skill.name)
+                    .is_some_and(|e| e.kind == config::ItemKind::Skill)
+            {
+                settings_skills.push(skill);
+            }
+        }
+        if let Some(result) = crate::project_settings::ensure_skill_settings(
             &project_root,
-            &selected_skills,
+            &settings_skills,
             &mut lock.settings_seeds,
-        )?
-    {
-        settings_note = Some(format!("Project settings: {}", result.summary()));
+        )? {
+            settings_note = Some(format!("Project settings: {}", result.summary()));
+        }
     }
 
     // Update lock file

--- a/cli/src/commands/add.rs
+++ b/cli/src/commands/add.rs
@@ -2561,22 +2561,25 @@ source (e.g. switching vstack repos, or starting clean), pass --clobber:
         }
     }
 
+    let lock_path = config::lock_file_path(global);
+    let mut lock = LockFile::load(&lock_path).unwrap_or_default();
+
     // Write computed agent→skill mappings to project vstack.toml.
     // Must happen BEFORE lock timestamps are captured so that the
     // vstack.toml mtime doesn't post-date installed_at (which would
     // make every item appear outdated on next launch).
     if writes_project_config {
         crate::project_config::write_agent_skills(&project_root, &agent_skill_map);
-        if let Some(result) =
-            crate::project_settings::ensure_skill_settings(&project_root, &selected_skills)?
-        {
+        if let Some(result) = crate::project_settings::ensure_skill_settings(
+            &project_root,
+            &selected_skills,
+            &mut lock.settings_seeds,
+        )? {
             settings_note = Some(format!("Project settings: {}", result.summary()));
         }
     }
 
     // Update lock file
-    let lock_path = config::lock_file_path(global);
-    let mut lock = LockFile::load(&lock_path).unwrap_or_default();
     lock.version = 1;
     for legacy in &migrated_pi_extensions {
         lock.remove(legacy);

--- a/cli/src/commands/refresh.rs
+++ b/cli/src/commands/refresh.rs
@@ -1111,6 +1111,45 @@ pub fn run(scope: crate::scope::ScopeFilter, verbose: bool) -> Result<()> {
     Ok(())
 }
 
+/// Seed missing skill-settings keys into `<project>/vstack.settings.toml`
+/// and refresh seeded comments whose template text changed (hand-edited
+/// comments are never rewritten — see `project_settings`). Runs for repos
+/// that are their own package source too: unlike `vstack.toml`, whose
+/// source-catalog form is shielded by the `vstack-local.toml` redirect in
+/// `project_config_path`, `vstack.settings.toml` is per-checkout runtime
+/// state with no catalog counterpart, so skipping source repos only lets
+/// them drift from the documented keys. Returns whether the
+/// lock's `settings_seeds` ledger changed and needs saving.
+fn seed_installed_skill_settings(
+    project_root: &Path,
+    lock: &mut config::LockFile,
+    sources: &[RefreshSource],
+) -> Result<bool> {
+    let installed_settings_skills: Vec<Skill> = lock
+        .entries
+        .iter()
+        .filter(|(_, entry)| entry.kind == ItemKind::Skill)
+        .filter_map(|(name, entry)| {
+            refresh_source_for_entry(sources, entry).and_then(|source| {
+                source
+                    .skills
+                    .iter()
+                    .find(|skill| &skill.name == name)
+                    .cloned()
+            })
+        })
+        .collect();
+    let seeds_before = lock.settings_seeds.clone();
+    if let Some(result) = crate::project_settings::ensure_skill_settings(
+        project_root,
+        &installed_settings_skills,
+        &mut lock.settings_seeds,
+    )? {
+        eprintln!("  + {}", result.summary());
+    }
+    Ok(lock.settings_seeds != seeds_before)
+}
+
 fn run_one(global: bool, verbose: bool) -> Result<()> {
     let lock_path = config::lock_file_path(global);
     let lock_existed = lock_path.exists();
@@ -1180,33 +1219,8 @@ fn run_one(global: bool, verbose: bool) -> Result<()> {
     let all_pi_extensions = all_source_pi_extensions(&sources);
 
     if !global && !lock.entries.is_empty() {
-        let project_canon = project_root
-            .canonicalize()
-            .unwrap_or_else(|_| project_root.clone());
-        let project_is_source = source_dirs
-            .iter()
-            .any(|dir| dir.canonicalize().unwrap_or_else(|_| dir.clone()) == project_canon);
-        if !project_is_source {
-            let installed_settings_skills: Vec<Skill> = lock
-                .entries
-                .iter()
-                .filter(|(_, entry)| entry.kind == ItemKind::Skill)
-                .filter_map(|(name, entry)| {
-                    refresh_source_for_entry(&sources, entry).and_then(|source| {
-                        source
-                            .skills
-                            .iter()
-                            .find(|skill| &skill.name == name)
-                            .cloned()
-                    })
-                })
-                .collect();
-            if let Some(result) = crate::project_settings::ensure_skill_settings(
-                &project_root,
-                &installed_settings_skills,
-            )? {
-                eprintln!("  + {}", result.summary());
-            }
+        if seed_installed_skill_settings(&project_root, &mut lock, &sources)? {
+            lock.save(&lock_path)?;
         }
 
         let harnesses_by_agent: HashMap<String, Vec<Harness>> = lock

--- a/cli/src/commands/refresh/tests.rs
+++ b/cli/src/commands/refresh/tests.rs
@@ -1503,3 +1503,83 @@ fn refresh_rejects_project_skills_dir_inside_agents() {
 
     let _ = std::fs::remove_dir_all(root);
 }
+
+fn write_settings_skill(source: &Path, name: &str, template: &str) {
+    let skill_dir = source.join("skills").join(name);
+    std::fs::create_dir_all(&skill_dir).unwrap();
+    std::fs::write(
+        skill_dir.join("SKILL.md"),
+        format!("---\nname: {name}\ndescription: Settings {name}\nlicense: MIT\n---\n# {name}\n\nBody.\n"),
+    )
+    .unwrap();
+    std::fs::write(skill_dir.join("vstack.settings.toml.example"), template).unwrap();
+}
+
+#[test]
+fn seed_installed_skill_settings_covers_project_that_is_its_own_source() {
+    // VST-260: a repo that is its own package source must still receive
+    // seeded settings keys for its installed skills.
+    let root = tmpdir("seed-self-source");
+    let project = root.join("project");
+    write_settings_skill(
+        &project,
+        "tuner",
+        "[env]\n\n# Used by: tuner.\nTUNER_MODE = \"ask\"\n",
+    );
+
+    let mut lock = LockFile::default();
+    lock.add(lock_entry(
+        "tuner",
+        ItemKind::Skill,
+        &project,
+        vec!["claude-code"],
+    ));
+    let sources = vec![RefreshSource::from_root(&project)];
+
+    let seeds_changed = seed_installed_skill_settings(&project, &mut lock, &sources).unwrap();
+
+    let settings = std::fs::read_to_string(project.join("vstack.settings.toml"))
+        .expect("no settings seeded in a repo that is its own package source");
+    assert!(
+        settings.contains("TUNER_MODE = \"ask\""),
+        "seeded key missing: {settings}"
+    );
+    assert!(seeds_changed, "seeded comment not recorded in the ledger");
+    assert!(lock.settings_seeds.contains_key("TUNER_MODE"));
+
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn seed_installed_skill_settings_seeds_consumer_projects() {
+    let root = tmpdir("seed-consumer");
+    let source = root.join("source");
+    let project = root.join("project");
+    std::fs::create_dir_all(&project).unwrap();
+    write_settings_skill(
+        &source,
+        "tuner",
+        "[env]\n\n# Used by: tuner.\nTUNER_MODE = \"ask\"\n",
+    );
+
+    let mut lock = LockFile::default();
+    lock.add(lock_entry(
+        "tuner",
+        ItemKind::Skill,
+        &source,
+        vec!["claude-code"],
+    ));
+    let sources = vec![RefreshSource::from_root(&source)];
+
+    let seeds_changed = seed_installed_skill_settings(&project, &mut lock, &sources).unwrap();
+
+    let settings = std::fs::read_to_string(project.join("vstack.settings.toml")).unwrap();
+    assert!(
+        settings.contains("TUNER_MODE = \"ask\""),
+        "seeded key missing: {settings}"
+    );
+    assert!(seeds_changed);
+    assert!(lock.settings_seeds.contains_key("TUNER_MODE"));
+
+    let _ = std::fs::remove_dir_all(root);
+}

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -103,6 +103,13 @@ impl std::fmt::Display for InstallMethod {
 pub struct LockFile {
     pub version: u32,
     pub entries: BTreeMap<String, LockEntry>,
+    /// Per settings key, the FNV-1a hash of the comment block last seeded
+    /// into `vstack.settings.toml`. A key's comment is refreshed from the
+    /// skill template only while its current text still hashes to this
+    /// value — a comment the user edited stops matching and is never
+    /// rewritten. Project-scope locks only.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub settings_seeds: BTreeMap<String, String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -601,7 +608,7 @@ pub fn now_iso() -> String {
 const FNV_OFFSET: u64 = 0xcbf29ce484222325;
 const FNV_PRIME: u64 = 0x00000100000001B3;
 
-fn fnv1a(data: &[u8]) -> u64 {
+pub(crate) fn fnv1a(data: &[u8]) -> u64 {
     let mut h = FNV_OFFSET;
     for &b in data {
         h ^= b as u64;
@@ -2879,6 +2886,7 @@ mod source_registry_tests {
         let mut lock = LockFile {
             version: 1,
             entries: std::collections::BTreeMap::new(),
+            settings_seeds: std::collections::BTreeMap::new(),
         };
 
         let modified = recover_hook_lock_entries_at(
@@ -3091,6 +3099,7 @@ mod source_registry_tests {
         let mut lock = LockFile {
             version: 1,
             entries: std::collections::BTreeMap::new(),
+            settings_seeds: std::collections::BTreeMap::new(),
         };
 
         assert!(recover_hook_lock_entries_at(
@@ -3129,6 +3138,7 @@ echo foreign
         let mut lock = LockFile {
             version: 1,
             entries: std::collections::BTreeMap::new(),
+            settings_seeds: std::collections::BTreeMap::new(),
         };
 
         let modified = recover_hook_lock_entries_at(
@@ -3166,6 +3176,7 @@ echo foreign
         let mut lock = LockFile {
             version: 1,
             entries: std::collections::BTreeMap::new(),
+            settings_seeds: std::collections::BTreeMap::new(),
         };
 
         assert!(recover_hook_lock_entries_at(
@@ -3204,6 +3215,7 @@ echo foreign
         let mut lock = LockFile {
             version: 1,
             entries: std::collections::BTreeMap::new(),
+            settings_seeds: std::collections::BTreeMap::new(),
         };
         let modified = recover_hook_lock_entries_at_with_cursor_global_rules(
             &mut lock,
@@ -3253,6 +3265,7 @@ echo foreign
         let mut lock = LockFile {
             version: 1,
             entries: std::collections::BTreeMap::new(),
+            settings_seeds: std::collections::BTreeMap::new(),
         };
 
         assert!(recover_hook_lock_entries_at(
@@ -3354,6 +3367,7 @@ echo foreign
         let mut lock = LockFile {
             version: 1,
             entries: std::collections::BTreeMap::new(),
+            settings_seeds: std::collections::BTreeMap::new(),
         };
         assert!(recover_hook_lock_entries_at(
             &mut lock,
@@ -3459,6 +3473,7 @@ echo foreign
         let mut lock = LockFile {
             version: 1,
             entries: std::collections::BTreeMap::new(),
+            settings_seeds: std::collections::BTreeMap::new(),
         };
         assert!(!recover_hook_lock_entries_at(
             &mut lock,
@@ -3507,6 +3522,7 @@ echo foreign
         let mut lock = LockFile {
             version: 1,
             entries: std::collections::BTreeMap::new(),
+            settings_seeds: std::collections::BTreeMap::new(),
         };
         assert!(recover_hook_lock_entries_at(
             &mut lock,

--- a/cli/src/project_settings.rs
+++ b/cli/src/project_settings.rs
@@ -125,8 +125,10 @@ pub fn ensure_skill_settings(
 
 fn record_seeds(seeds: &mut BTreeMap<String, String>, entries: &[EnvEntry]) {
     for entry in entries {
-        let comment = trim_blank_edges(&entry.lines[..entry.lines.len() - 1]);
-        seeds.insert(entry.key.clone(), comment_hash(comment));
+        let Some((_, comment)) = entry.lines.split_last() else {
+            continue;
+        };
+        seeds.insert(entry.key.clone(), comment_hash(trim_blank_edges(comment)));
     }
 }
 
@@ -200,7 +202,10 @@ fn refresh_seeded_comments(
             hi -= 1;
         }
         let current: Vec<String> = block[lo..hi].iter().map(|&i| lines[i].clone()).collect();
-        let incoming = trim_blank_edges(&template.lines[..template.lines.len() - 1]);
+        let Some((_, incoming)) = template.lines.split_last() else {
+            continue;
+        };
+        let incoming = trim_blank_edges(incoming);
         if current == incoming {
             seeds.insert(key, comment_hash(&current));
             continue;
@@ -448,7 +453,10 @@ fn assignment_key(line: &str) -> Option<String> {
     if key.is_empty() {
         return None;
     }
-    Some(key.trim_matches('"').to_string())
+    if !key.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+        return None;
+    }
+    Some(key.to_string())
 }
 
 #[cfg(test)]
@@ -730,10 +738,10 @@ TUNER_MODE = "ask"
 
     #[test]
     fn matching_comment_without_ledger_gains_provenance_then_updates() {
-        // Installs that predate the settings_seeds ledger: the first refresh
-        // finds the comment still matching its template and records
-        // provenance without touching the file; the next template revision
-        // then propagates.
+        // Installs that predate the settings_seeds ledger: a refresh that
+        // finds the comment still matching its template records provenance
+        // without touching the file, and template revisions from that point
+        // propagate.
         let root = temp_root("comment_bootstrap");
         let skill_dir = root.join("source").join("skills").join("tuner");
         write_template(&skill_dir, TUNER_V1);

--- a/cli/src/project_settings.rs
+++ b/cli/src/project_settings.rs
@@ -393,9 +393,8 @@ fn assigned_keys(content: &str) -> BTreeSet<String> {
         .lines()
         .filter(|line| !is_table_header(line))
         .filter_map(|line| {
-            // Raw key, before any quote handling: assignment_key trims
-            // quotes, which would make `"KEY" = ...` (invisible to the
-            // shell reader) indistinguishable from a bare `KEY = ...`.
+            // Same bare-identifier rule as assignment_key, spelled out here
+            // so the mirrored shell-reader semantics stay in one screenful.
             let trimmed = line.trim_start();
             if trimmed.is_empty() || trimmed.starts_with('#') {
                 return None;

--- a/cli/src/project_settings.rs
+++ b/cli/src/project_settings.rs
@@ -1,6 +1,6 @@
 use crate::skill::Skill;
 use anyhow::{Context, Result};
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
 const SETTINGS_FILE: &str = "vstack.settings.toml";
@@ -11,17 +11,37 @@ pub struct SettingsMergeResult {
     pub path: PathBuf,
     pub created: bool,
     pub added_keys: Vec<String>,
+    /// Keys whose seeded comment block was refreshed to the template's
+    /// revised text (the key's value line is never touched).
+    pub updated_keys: Vec<String>,
 }
 
 impl SettingsMergeResult {
     pub fn summary(&self) -> String {
-        let action = if self.created { "created" } else { "updated" };
-        format!(
-            "{action} {} with {} setting(s): {}",
-            self.path.display(),
-            self.added_keys.len(),
-            self.added_keys.join(", ")
-        )
+        if self.created {
+            return format!(
+                "created {} with {} setting(s): {}",
+                self.path.display(),
+                self.added_keys.len(),
+                self.added_keys.join(", ")
+            );
+        }
+        let mut parts = Vec::new();
+        if !self.added_keys.is_empty() {
+            parts.push(format!(
+                "{} setting(s): {}",
+                self.added_keys.len(),
+                self.added_keys.join(", ")
+            ));
+        }
+        if !self.updated_keys.is_empty() {
+            parts.push(format!(
+                "{} refreshed comment(s): {}",
+                self.updated_keys.len(),
+                self.updated_keys.join(", ")
+            ));
+        }
+        format!("updated {} with {}", self.path.display(), parts.join("; "))
     }
 }
 
@@ -31,9 +51,20 @@ struct EnvEntry {
     lines: Vec<String>,
 }
 
+/// Seed missing skill-settings keys into `<project>/vstack.settings.toml` and
+/// refresh seeded comment blocks whose upstream template text changed.
+///
+/// `seeds` is the provenance ledger (normally the project lock's
+/// `settings_seeds`): per key, the hash of the comment block last written by
+/// seeding. A comment is rewritten only while its current text still hashes
+/// to that value — any other text is a user edit and is preserved. The map
+/// can change even when the file does not (a block matching the incoming
+/// template is recorded so the next upstream revision can propagate); callers
+/// persist it when it changed.
 pub fn ensure_skill_settings(
     project_root: &Path,
     skills: &[Skill],
+    seeds: &mut BTreeMap<String, String>,
 ) -> Result<Option<SettingsMergeResult>> {
     let entries = settings_entries_from_skills(skills)?;
     if entries.is_empty() {
@@ -41,7 +72,6 @@ pub fn ensure_skill_settings(
     }
 
     let path = project_root.join(SETTINGS_FILE);
-    let added_keys: Vec<String> = entries.iter().map(|entry| entry.key.clone()).collect();
 
     if !path.exists() {
         if let Some(parent) = path.parent() {
@@ -50,38 +80,162 @@ pub fn ensure_skill_settings(
         }
         std::fs::write(&path, render_new_settings_file(&entries))
             .with_context(|| format!("writing {}", path.display()))?;
+        record_seeds(seeds, &entries);
         return Ok(Some(SettingsMergeResult {
             path,
             created: true,
-            added_keys,
+            added_keys: entries.iter().map(|entry| entry.key.clone()).collect(),
+            updated_keys: Vec::new(),
         }));
     }
 
     let original =
         std::fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
+    let (refreshed, updated_keys) = refresh_seeded_comments(&original, &entries, seeds);
     // File-wide, not [env]-scoped: the review-gate settings contract enforces key
     // uniqueness across the whole file (its shell-side reader is not TOML-table-aware),
     // so a key assigned under any table must block a duplicate append just the same.
-    let existing_keys = assigned_keys(&original);
+    let existing_keys = assigned_keys(&refreshed);
     let missing: Vec<EnvEntry> = entries
         .into_iter()
         .filter(|entry| !existing_keys.contains(&entry.key))
         .collect();
-    if missing.is_empty() {
-        return Ok(None);
-    }
 
     let added_keys: Vec<String> = missing.iter().map(|entry| entry.key.clone()).collect();
-    let merged = merge_missing_entries(&original, &missing);
+    let merged = if missing.is_empty() {
+        refreshed
+    } else {
+        merge_missing_entries(&refreshed, &missing)
+    };
+    record_seeds(seeds, &missing);
     if merged != original {
         std::fs::write(&path, merged).with_context(|| format!("writing {}", path.display()))?;
     }
 
+    if added_keys.is_empty() && updated_keys.is_empty() {
+        return Ok(None);
+    }
     Ok(Some(SettingsMergeResult {
         path,
         created: false,
         added_keys,
+        updated_keys,
     }))
+}
+
+fn record_seeds(seeds: &mut BTreeMap<String, String>, entries: &[EnvEntry]) {
+    for entry in entries {
+        let comment = trim_blank_edges(&entry.lines[..entry.lines.len() - 1]);
+        seeds.insert(entry.key.clone(), comment_hash(comment));
+    }
+}
+
+/// Blank separators around a comment block are layout, not content: trim
+/// them off both edges before comparing or hashing. Interior blanks stay.
+fn trim_blank_edges(lines: &[String]) -> &[String] {
+    let mut lo = 0;
+    let mut hi = lines.len();
+    while lo < hi && lines[lo].trim().is_empty() {
+        lo += 1;
+    }
+    while hi > lo && lines[hi - 1].trim().is_empty() {
+        hi -= 1;
+    }
+    &lines[lo..hi]
+}
+
+fn comment_hash(lines: &[String]) -> String {
+    format!("{:016x}", crate::config::fnv1a(lines.join("\n").as_bytes()))
+}
+
+/// Rewrite `[env]` comment blocks whose upstream template text changed,
+/// gated by the `seeds` ledger (see [`ensure_skill_settings`]). A block
+/// already matching the incoming template is recorded in the ledger without
+/// a file change, which is how installs predating the ledger pick up
+/// provenance. Returns the (possibly rewritten) content and the refreshed
+/// keys. Assignment lines are never touched.
+fn refresh_seeded_comments(
+    original: &str,
+    entries: &[EnvEntry],
+    seeds: &mut BTreeMap<String, String>,
+) -> (String, Vec<String>) {
+    let lines: Vec<String> = original.lines().map(str::to_string).collect();
+    let Some(env_start) = lines.iter().position(|line| is_env_header(line)) else {
+        return (original.to_string(), Vec::new());
+    };
+    let env_end = lines
+        .iter()
+        .enumerate()
+        .skip(env_start + 1)
+        .find_map(|(idx, line)| is_table_header(line).then_some(idx))
+        .unwrap_or(lines.len());
+
+    // (start, end, replacement) line spans, spliced back-to-front below so
+    // earlier spans keep their indices.
+    let mut replacements: Vec<(usize, usize, Vec<String>)> = Vec::new();
+    let mut updated_keys = Vec::new();
+    let mut pending: Vec<usize> = Vec::new();
+    for idx in env_start + 1..env_end {
+        let line = &lines[idx];
+        if line.trim().is_empty() || line.trim_start().starts_with('#') {
+            pending.push(idx);
+            continue;
+        }
+        let key = assignment_key(line);
+        let block = std::mem::take(&mut pending);
+        // A line that is neither comment, blank, nor assignment breaks the
+        // block: never splice across it (the drained run is discarded).
+        let Some(key) = key else {
+            continue;
+        };
+        let Some(template) = entries.iter().find(|entry| entry.key == key) else {
+            continue;
+        };
+        let mut lo = 0;
+        let mut hi = block.len();
+        while lo < hi && lines[block[lo]].trim().is_empty() {
+            lo += 1;
+        }
+        while hi > lo && lines[block[hi - 1]].trim().is_empty() {
+            hi -= 1;
+        }
+        let current: Vec<String> = block[lo..hi].iter().map(|&i| lines[i].clone()).collect();
+        let incoming = trim_blank_edges(&template.lines[..template.lines.len() - 1]);
+        if current == incoming {
+            seeds.insert(key, comment_hash(&current));
+            continue;
+        }
+        if seeds.get(&key).map(String::as_str) != Some(comment_hash(&current).as_str()) {
+            continue;
+        }
+        let (start, end) = if lo < hi {
+            (block[lo], block[hi - 1] + 1)
+        } else {
+            // No existing comment: insert directly above the assignment.
+            (idx, idx)
+        };
+        seeds.insert(key.clone(), comment_hash(incoming));
+        replacements.push((start, end, incoming.to_vec()));
+        updated_keys.push(key);
+    }
+
+    if replacements.is_empty() {
+        return (original.to_string(), updated_keys);
+    }
+    let mut lines = lines;
+    for (start, end, mut block) in replacements.into_iter().rev() {
+        if start == end
+            && start > 0
+            && !lines[start - 1].trim().is_empty()
+            && !is_table_header(&lines[start - 1])
+        {
+            block.insert(0, String::new());
+        }
+        lines.splice(start..end, block);
+    }
+    let mut out = lines.join("\n");
+    out.push('\n');
+    (out, updated_keys)
 }
 
 fn settings_entries_from_skills(skills: &[Skill]) -> Result<Vec<EnvEntry>> {
@@ -342,9 +496,13 @@ SECOND_OPINION_CODEX_CMD = "codex exec -m gpt-5.6-sol"
         .unwrap();
 
         let project = root.join("project");
-        let result = ensure_skill_settings(&project, &[skill("second-opinion", skill_dir)])
-            .unwrap()
-            .unwrap();
+        let result = ensure_skill_settings(
+            &project,
+            &[skill("second-opinion", skill_dir)],
+            &mut BTreeMap::new(),
+        )
+        .unwrap()
+        .unwrap();
 
         assert!(result.created);
         assert_eq!(
@@ -388,9 +546,13 @@ value = true
         )
         .unwrap();
 
-        let result = ensure_skill_settings(&project, &[skill("second-opinion", skill_dir)])
-            .unwrap()
-            .unwrap();
+        let result = ensure_skill_settings(
+            &project,
+            &[skill("second-opinion", skill_dir)],
+            &mut BTreeMap::new(),
+        )
+        .unwrap()
+        .unwrap();
 
         assert!(!result.created);
         assert_eq!(result.added_keys, vec!["SECOND_OPINION_CODEX_CMD"]);
@@ -435,9 +597,13 @@ REVIEW_GATE_STATUS_PUBLISHER_REJECT = "github-actions[bot]"
         )
         .unwrap();
 
-        let result = ensure_skill_settings(&project, &[skill("review-gate", skill_dir)])
-            .unwrap()
-            .unwrap();
+        let result = ensure_skill_settings(
+            &project,
+            &[skill("review-gate", skill_dir)],
+            &mut BTreeMap::new(),
+        )
+        .unwrap()
+        .unwrap();
 
         assert!(!result.created);
         assert_eq!(result.added_keys, vec!["REVIEW_GATE_CONTEXT"]);
@@ -467,10 +633,167 @@ REVIEW_GATE_STATUS_PUBLISHER_REJECT = "github-actions[bot]"
         std::fs::create_dir_all(&skill_dir).unwrap();
         let project = root.join("project");
 
-        let result = ensure_skill_settings(&project, &[skill("plain", skill_dir)]).unwrap();
+        let result =
+            ensure_skill_settings(&project, &[skill("plain", skill_dir)], &mut BTreeMap::new())
+                .unwrap();
 
         assert!(result.is_none());
         assert!(!project.join(SETTINGS_FILE).exists());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    const TUNER_V1: &str = r#"[env]
+
+# Used by: tuner. Old guidance about the knob.
+TUNER_MODE = "ask"
+"#;
+
+    const TUNER_V2: &str = r#"[env]
+
+# Used by: tuner. Revised guidance: the knob now also
+# governs merges.
+TUNER_MODE = "ask"
+"#;
+
+    fn write_template(skill_dir: &Path, content: &str) {
+        std::fs::create_dir_all(skill_dir).unwrap();
+        std::fs::write(skill_dir.join(SETTINGS_TEMPLATE), content).unwrap();
+    }
+
+    #[test]
+    fn refreshes_unedited_seeded_comment_when_template_revises_it() {
+        let root = temp_root("comment_refresh");
+        let skill_dir = root.join("source").join("skills").join("tuner");
+        write_template(&skill_dir, TUNER_V1);
+        let project = root.join("project");
+        let mut seeds = BTreeMap::new();
+
+        ensure_skill_settings(&project, &[skill("tuner", skill_dir.clone())], &mut seeds)
+            .unwrap()
+            .unwrap();
+        // A hand-set VALUE must survive a comment refresh untouched.
+        let path = project.join(SETTINGS_FILE);
+        let hand_valued = std::fs::read_to_string(&path)
+            .unwrap()
+            .replace("TUNER_MODE = \"ask\"", "TUNER_MODE = \"auto\"");
+        std::fs::write(&path, hand_valued).unwrap();
+
+        write_template(&skill_dir, TUNER_V2);
+        let result = ensure_skill_settings(&project, &[skill("tuner", skill_dir)], &mut seeds)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(result.updated_keys, vec!["TUNER_MODE"]);
+        assert!(result.added_keys.is_empty());
+        let settings = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            settings.contains("Revised guidance") && !settings.contains("Old guidance"),
+            "stale seeded comment survived the template revision: {settings}"
+        );
+        assert!(
+            settings.contains("TUNER_MODE = \"auto\""),
+            "comment refresh touched the value line: {settings}"
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn never_rewrites_hand_edited_comment() {
+        let root = temp_root("comment_hand_edit");
+        let skill_dir = root.join("source").join("skills").join("tuner");
+        write_template(&skill_dir, TUNER_V1);
+        let project = root.join("project");
+        let mut seeds = BTreeMap::new();
+
+        ensure_skill_settings(&project, &[skill("tuner", skill_dir.clone())], &mut seeds)
+            .unwrap()
+            .unwrap();
+        let path = project.join(SETTINGS_FILE);
+        let edited = std::fs::read_to_string(&path).unwrap().replace(
+            "Old guidance about the knob.",
+            "our fork pins this to ask — do not change.",
+        );
+        std::fs::write(&path, &edited).unwrap();
+
+        write_template(&skill_dir, TUNER_V2);
+        let result =
+            ensure_skill_settings(&project, &[skill("tuner", skill_dir)], &mut seeds).unwrap();
+
+        assert!(result.is_none(), "hand-edited comment reported as changed");
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            edited,
+            "hand-edited comment was rewritten"
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn matching_comment_without_ledger_gains_provenance_then_updates() {
+        // Installs that predate the settings_seeds ledger: the first refresh
+        // finds the comment still matching its template and records
+        // provenance without touching the file; the next template revision
+        // then propagates.
+        let root = temp_root("comment_bootstrap");
+        let skill_dir = root.join("source").join("skills").join("tuner");
+        write_template(&skill_dir, TUNER_V1);
+        let project = root.join("project");
+
+        ensure_skill_settings(
+            &project,
+            &[skill("tuner", skill_dir.clone())],
+            &mut BTreeMap::new(),
+        )
+        .unwrap()
+        .unwrap();
+        let path = project.join(SETTINGS_FILE);
+        let seeded = std::fs::read_to_string(&path).unwrap();
+
+        let mut seeds = BTreeMap::new();
+        let result =
+            ensure_skill_settings(&project, &[skill("tuner", skill_dir.clone())], &mut seeds)
+                .unwrap();
+        assert!(result.is_none());
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), seeded);
+        assert!(
+            seeds.contains_key("TUNER_MODE"),
+            "matching comment did not bootstrap provenance: {seeds:?}"
+        );
+
+        write_template(&skill_dir, TUNER_V2);
+        let result = ensure_skill_settings(&project, &[skill("tuner", skill_dir)], &mut seeds)
+            .unwrap()
+            .unwrap();
+        assert_eq!(result.updated_keys, vec!["TUNER_MODE"]);
+        assert!(
+            std::fs::read_to_string(&path)
+                .unwrap()
+                .contains("Revised guidance")
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn stale_comment_without_ledger_is_preserved() {
+        // No provenance and the comment differs from the incoming template:
+        // indistinguishable from a hand edit, so it must stay.
+        let root = temp_root("comment_no_ledger");
+        let skill_dir = root.join("source").join("skills").join("tuner");
+        write_template(&skill_dir, TUNER_V2);
+        let project = root.join("project");
+        std::fs::create_dir_all(&project).unwrap();
+        let existing =
+            "[env]\n\n# Guidance from an older template revision.\nTUNER_MODE = \"ask\"\n";
+        let path = project.join(SETTINGS_FILE);
+        std::fs::write(&path, existing).unwrap();
+
+        let mut seeds = BTreeMap::new();
+        let result =
+            ensure_skill_settings(&project, &[skill("tuner", skill_dir)], &mut seeds).unwrap();
+
+        assert!(result.is_none());
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), existing);
+        assert!(!seeds.contains_key("TUNER_MODE"));
         let _ = std::fs::remove_dir_all(root);
     }
 }

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -1,5 +1,5 @@
 cli/src/agent.rs	1074
-cli/src/commands/add.rs	3006
+cli/src/commands/add.rs	3013
 cli/src/commands/apply.rs	2778
 cli/src/commands/refresh.rs	1505
 cli/src/commands/refresh/tests.rs	1585

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -1,10 +1,10 @@
 cli/src/agent.rs	1074
-cli/src/commands/add.rs	3003
+cli/src/commands/add.rs	3006
 cli/src/commands/apply.rs	2778
-cli/src/commands/refresh.rs	1491
-cli/src/commands/refresh/tests.rs	1505
+cli/src/commands/refresh.rs	1505
+cli/src/commands/refresh/tests.rs	1585
 cli/src/commands/report.rs	1872
-cli/src/config.rs	3829
+cli/src/config.rs	3845
 cli/src/installer.rs	3784
 cli/src/pi_extension.rs	2858
 cli/src/project_config.rs	4892

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -1,5 +1,5 @@
 cli/src/agent.rs	1074
-cli/src/commands/add.rs	3028
+cli/src/commands/add.rs	3029
 cli/src/commands/apply.rs	2778
 cli/src/commands/refresh.rs	1505
 cli/src/commands/refresh/tests.rs	1585

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -1,5 +1,5 @@
 cli/src/agent.rs	1074
-cli/src/commands/add.rs	3013
+cli/src/commands/add.rs	3028
 cli/src/commands/apply.rs	2778
 cli/src/commands/refresh.rs	1505
 cli/src/commands/refresh/tests.rs	1585


### PR DESCRIPTION
## What

Two `vstack refresh` settings-seeding gaps:

1. A repo that is its own package source received NO seeded settings keys — seeding was wrapped in a project-is-source guard whose original purpose (protecting the source catalog's `vstack.toml` from project-customization writes) is served by the `vstack-local.toml` redirect; `vstack.settings.toml` has no catalog counterpart, so the guard only caused drift. Seeding now runs unconditionally for project-scope refreshes.
2. Seeded comment blocks now refresh when a skill template revises them, gated by a `settings_seeds` provenance ledger in `.vstack-lock.json` (per key, the FNV-1a hash of the last-seeded comment block). A comment is rewritten only while its text still hashes to the ledger value; anything else is a hand edit and is preserved; value lines are never touched. Pre-ledger installs bootstrap provenance on the first refresh where the comment still matches the incoming template; one that already drifted is indistinguishable from a hand edit and stays (the conservative side).

The four grown cli files carry hand-raised size-ratchet rows in this diff, per the gate's remediation.

## Proof

cargo fmt + clippy (-D warnings) + test green; all four changed behaviors have tests run red against the pre-fix semantics (source-repo seeding, comment refresh, ledger bootstrap, hand-edit preservation); size-ratchet clean at 1435 files.

Fixes VST-260

Claude-Session: https://claude.ai/code/session_01YCF7qAqiVFuAHPDMXLxV1r
