### PR TITLE
feat(growth-guards): TODO ban, byte ceiling, suppression bans, commit-msg — the shared check family beside size-ratchet (VST-214)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,17 @@
   provenance on their first refresh where the comment still matches the
   template; a pre-ledger comment that already drifted from the incoming
   template stays untouched (indistinguishable from a hand edit) (VST-260).
+- growth-guards: new skill — the shared check family beside size-ratchet
+  (VST-214): `todo-ban` (flat work-marker ban, marker-shape scoped so prose
+  naming a marker never fires), `byte-ceiling` (newly added tracked files
+  over N KB fail, default 200; staged/base/full-sweep modes, lockfiles
+  exempt), `suppression-ban` (blanket lint suppressions fail flat; bare
+  rust dead_code/unused allows ratchet against a tighten-only baseline),
+  and `commit-msg` (conventional gate; uppercase issue keys and
+  git-generated messages pass). Dispatcher `growth-guards [all|CHECK]`,
+  each check independently invocable; exit 2 on anything unmeasurable. The
+  vstack repo seeds its own excludes lists, and the `vstack init` hook
+  scaffold no longer plants a work marker in generated hooks.
 - orch: `queue-wait` default budget is 2400s, sized to the merge-group suite
   (VST-249); the budget-exhausted `queued` verdict now carries `progressing`
   and a `cause` of `still_progressing` vs `stalled` from merge-queue-entry

--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ Windows: CLI runs natively; symlink mode falls back to copy.
 | [`review-gate`](skills/review-gate/)* | Org-wide PR merge gate driven by a single review-evidence predicate (approvals, trusted checks, comment-form passes, outage attestation), with convergence scripts and an offline decision-table selftest. |
 | [`reviewer`](skills/reviewer/) | Strict code-review, whole-codebase review, and QA-review ethos, scope boundaries, workflows, and canonical finding/verdict JSON schema. Loaded by any `reviewer-*` agent. |
 | [`second-opinion`](skills/second-opinion/) | Cross-model review via the opposite AI CLI (Claude ↔ Codex). |
+| [`growth-guards`](skills/growth-guards/)* | Four repo growth checks beside `size-ratchet`: flat work-marker ban, byte ceiling on newly added files, blanket lint-suppression ban with a tighten-only bare-allow baseline, and a conventional commit-message gate. Each check independently invocable. |
 | [`size-ratchet`](skills/size-ratchet/)* | Tighten-only file-size gate over tracked files: new offenders, growth past a baseline row, and baselines looser than reality all fail; `--update` only lowers or removes rows, never adds or raises. |
 | [`worktree`](skills/worktree/)* | Git worktree create/list/remove with env/config symlinks and per-worktree bot identity. |
 

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -103,7 +103,7 @@ fn init_hook(name: &str) -> Result<()> {
     }
     std::fs::create_dir_all("hooks")?;
     let body = format!(
-        "#!/usr/bin/env bash\n# ---\n# name: {name}\n# event: PreToolUse       # PreToolUse | PostToolUse | PostCompact | TaskCompleted | Stop | SessionStart | UserPromptSubmit | PermissionRequest\n# matcher: Bash           # Bash | Edit|Write | (empty for all)\n# description: TODO — describe what this hook does and when it fires\n# safety: TODO — explain what risk this hook prevents\n# # harnesses: [claude-code, codex]   # optional allowlist; default = all\n# ---\n\nset -euo pipefail\n\nINPUT=$(cat)\n\n# TODO — implement hook logic. Read tool input from $INPUT (JSON), exit 0 to\n# allow the tool call, exit non-zero with a message on stderr to block it.\n\nexit 0\n",
+        "#!/usr/bin/env bash\n# ---\n# name: {name}\n# event: PreToolUse       # PreToolUse | PostToolUse | PostCompact | TaskCompleted | Stop | SessionStart | UserPromptSubmit | PermissionRequest\n# matcher: Bash           # Bash | Edit|Write | (empty for all)\n# description: TODO — describe what this hook does and when it fires\n# safety: TODO — explain what risk this hook prevents\n# # harnesses: [claude-code, codex]   # optional allowlist; default = all\n# ---\n\nset -euo pipefail\n\nINPUT=$(cat)\n\n# Implement the hook logic here: read tool input from $INPUT (JSON), exit 0 to\n# allow the tool call, exit non-zero with a message on stderr to block it.\n\nexit 0\n",
     );
     std::fs::write(&path, body)?;
     #[cfg(unix)]

--- a/skills/growth-guards/README.md
+++ b/skills/growth-guards/README.md
@@ -1,0 +1,178 @@
+# growth-guards
+
+Four checks that stop quiet repo decay, one family beside `size-ratchet`:
+work markers, oversized additions, blanket lint suppression, and
+non-conventional commit messages. Same idiom throughout — language-agnostic
+where possible, tighten-only baselines only where legacy counts exist,
+every failure carries its remediation, every exclusion carries its reason —
+and the same exit contract: `0` clean, `1` violations, `2`
+usage/config/collection error. A measurement that fails (unreadable file, a
+git/grep execution failure) is a loud exit 2, never a silent pass.
+
+All scans read INDEX content (`git grep --cached` / staged blobs): the gate
+judges what is being committed, and a sparse checkout cannot hide a tracked
+file from it. Binary files are skipped by the text scans.
+
+## Invocation
+
+```bash
+scripts/growth-guards               # batch: every enabled repo check
+scripts/growth-guards all           # ditto
+scripts/growth-guards CHECK [ARGS]  # one check, flags passed through
+scripts/CHECK [ARGS]                # each check is a standalone executable
+```
+
+The batch runs `GROWTH_GUARDS_CHECKS` (default
+`todo-ban byte-ceiling suppression-ban`) and fails closed: exit 2 if any
+check could not complete, else 1 if any found violations. `commit-msg`
+reads a message, so it never runs in the batch.
+
+Typical wiring:
+
+```bash
+# .git/hooks/commit-msg
+.agents/skills/growth-guards/scripts/commit-msg "$1"
+
+# pre-commit shim / CI
+.agents/skills/growth-guards/scripts/todo-ban
+.agents/skills/growth-guards/scripts/byte-ceiling            # staged additions
+.agents/skills/growth-guards/scripts/byte-ceiling --base origin/main   # CI on a PR
+.agents/skills/growth-guards/scripts/suppression-ban
+```
+
+## todo-ban
+
+Flat ban on work markers in first-party tracked files — the words TODO,
+FIXME, HACK, XXX in comment-marker shapes. No baseline: consumer repos are
+at or near zero, so the count starts frozen at nothing.
+
+A marker word counts only in marker shapes, so prose that quotes or names
+a marker does not fire:
+
+- the word at line start, after whitespace, or after a comment leader,
+  immediately followed by `:` or `(` — the classic annotated forms
+  (`MARKER: fix this`, `MARKER(owner): fix this`);
+- the bare word directly after a comment leader (only whitespace between),
+  followed by whitespace or end of line.
+
+Comment leaders: `//`, `#`, `;`, `/*`, `<!--`. A marker preceded by a
+backtick, a quote, or joined text (documentation quoting the word, a regex
+listing the words, `\n` inside a string literal) matches neither shape.
+Matching is case-sensitive — lowercase uses of the words are prose.
+
+Remediation: do the work now, or move it to the tracker and delete the
+marker. Vendored/generated trees go in the excludes list with a reason.
+
+## byte-ceiling
+
+Newly added tracked files over the ceiling (default 200 KB, KB = 1024
+bytes) fail. Growth-oriented like size-ratchet: legacy files already in
+history are not gated by the default modes, so adoption needs no cleanup
+first.
+
+- `--staged` (default) — files added in the staged diff (pre-commit).
+- `--base REF` — files added since the merge-base with REF (CI on a PR).
+- `--all` — every tracked file (audits; pair with excludes rows for known
+  legacy assets).
+
+Sizes are object sizes (`git cat-file -s` of the added blob): the bytes
+that actually enter history, independent of worktree state. Rename
+detection is pinned on, so moving an existing large file is not an
+addition; a copy is one (it duplicates the bytes in the tree). Symlinks and
+submodule gitlinks are not sized content.
+
+Exempt built-in (exact basename): `Cargo.lock`, `package-lock.json`,
+`npm-shrinkwrap.json`, `yarn.lock`, `pnpm-lock.yaml`, `bun.lock`,
+`bun.lockb`, `flake.lock`, `poetry.lock`, `uv.lock`, `Pipfile.lock`,
+`Gemfile.lock`, `composer.lock`, `go.sum`, `gradle.lockfile`,
+`packages.lock.json`, `Package.resolved`. Declared asset trees go in the
+excludes list with a reason.
+
+## suppression-ban
+
+Two gates, both scanned language-scoped by pathspec (so docs and scripts
+that quote a pragma never fire):
+
+**Blanket suppressions fail flat** — the pragmas that turn a linter off
+wholesale:
+
+| Language | Pathspec | Banned shape |
+|---|---|---|
+| Rust | `*.rs` | module/crate-wide inner attribute `#![allow(...)]` at line start |
+| Python | `*.py` | file-level `# ruff: noqa` / `# flake8: noqa` (own-line, with or without codes) |
+| JS/TS | `*.js *.jsx *.ts *.tsx *.mjs *.cjs *.mts *.cts *.vue *.svelte` | bare block `/* eslint-disable */` with no rules named |
+| Go | `*.go` | `//nolint` with nothing after it, or `//nolint:all` |
+
+A per-line suppression that names its lint and states its reason stays
+legal (`// eslint-disable-next-line rule -- why`, `# noqa: E501`,
+`//nolint:gosec // why`, a per-item rust attribute).
+
+**Bare-allow ratchet (Rust)** — reasonless `#[allow(dead_code)]` /
+`#[allow(unused…)]` attributes are counted per file (matching lines).
+An attribute carrying `reason = "..."` does not count — stating the reason
+is the legal form. Repos with legacy counts freeze them in a tighten-only
+baseline: new bare allows, growth past a row, and a baseline looser than
+reality all fail. `--update` lowers/removes rows to current reality and
+re-checks; it never adds a row and never raises a number — deliberate
+growth is a hand-edit of the row, visible in review.
+
+### Seeding a first baseline
+
+`--update` never adds rows, so the first baseline is created explicitly:
+run the check and turn each reported `new bare allow` line (path and
+count) into a `path<TAB>count` row, `LC_ALL=C` sorted. The initial freeze
+being a hand-authored, reviewed diff is the point.
+
+## commit-msg
+
+Conventional-commit gate over one message, shaped for the git
+`commit-msg` hook (`commit-msg FILE`, or stdin when FILE is absent/`-`).
+The header — the first non-blank, non-comment line — must match:
+
+```
+type(scope)!: subject        # scope and '!' optional
+```
+
+- Types: `GROWTH_GUARDS_COMMIT_TYPES` (default
+  `build chore ci docs feat fix perf refactor revert style test`).
+- Scope class: `[#A-Za-z0-9 _.,/-]+` — uppercase issue keys
+  (`fix(ABC-123): ...`) and issue numbers (`fix(#123): ...`) pass.
+- Git-generated messages pass unchanged: headers starting `Merge `,
+  `Revert `, `Reapply `, `fixup! `, `squash! `, `amend! `.
+
+## Configuration
+
+| Key | Default | Meaning |
+|---|---|---|
+| `GROWTH_GUARDS_CHECKS` | `todo-ban byte-ceiling suppression-ban` | Batch check list. |
+| `GROWTH_GUARDS_TODO_EXCLUDES` | `tools/todo-ban-excludes` | todo-ban exclusion list. |
+| `GROWTH_GUARDS_BYTE_CEILING_KB` | `200` | Ceiling in KB. |
+| `GROWTH_GUARDS_BYTE_EXCLUDES` | `tools/byte-ceiling-excludes` | byte-ceiling exclusion list. |
+| `GROWTH_GUARDS_SUPPRESSION_EXCLUDES` | `tools/suppression-ban-excludes` | suppression-ban exclusion list. |
+| `GROWTH_GUARDS_SUPPRESSION_BASELINE` | `tools/suppression-baseline.tsv` | Bare-allow baseline. |
+| `GROWTH_GUARDS_COMMIT_TYPES` | `build chore ci docs feat fix perf refactor revert style test` | Accepted types. |
+
+Each key resolves environment > `.env.local` > `.vstack/settings.toml` >
+committed `vstack.settings.toml` (flat `KEY = "value"` under `[env]`) >
+`.env` > default (env files use `KEY=value` or `export KEY=value`; parsed,
+never sourced). Per-check flags (`--excludes`, `--baseline`) override
+every source for the paths. All relative paths are repo-root-relative; the
+scripts `cd` to `git rev-parse --show-toplevel` before resolving anything.
+
+```toml
+[env]
+GROWTH_GUARDS_BYTE_CEILING_KB = "500"
+GROWTH_GUARDS_CHECKS = "todo-ban suppression-ban"
+```
+
+**Excludes format** (all three lists): `pattern<TAB>reason` per line —
+shell glob matched against the full repo-relative path (`*` crosses `/`);
+blank lines and `#` comments ignored; a pattern without a reason is a
+config error. **Baseline format**: `path<TAB>count`, `LC_ALL=C` sorted,
+unique paths, positive counts; malformed, unsorted, or duplicated rows are
+config errors (exit 2), never repaired silently.
+
+## Requirements
+
+`git`, `awk`, and the usual POSIX userland. Bash 3.2 compatible (macOS
+system bash).

--- a/skills/growth-guards/SKILL.md
+++ b/skills/growth-guards/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: growth-guards
+description: "Four repo growth guards beside size-ratchet: todo-ban (flat ban on work markers — the TODO/FIXME/HACK/XXX comment shapes — in first-party tracked files), byte-ceiling (newly added files over N KB fail, default 200; lockfiles and declared asset trees exempt), suppression-ban (blanket lint suppressions fail flat; bare rust allow(dead_code)/allow(unused) attributes ratchet against a tighten-only baseline), and commit-msg (conventional-commit gate that accepts uppercase issue keys and git-generated messages). Load when adding, tuning, or debugging any of these checks, their exclusion lists, the suppression baseline, or GROWTH_GUARDS_* settings — or when a change trips one of them."
+license: MIT
+user-invocable: true
+metadata:
+  author: vanillagreen
+  source: vstack
+  repository: "https://github.com/vanillagreencom/vstack"
+  bugs: "https://github.com/vanillagreencom/vstack/issues"
+  version: "1.0.0"
+---
+
+# Growth Guards
+
+> **Problem with this skill?** Run `vstack report` — it files to the owning repo automatically. Do not hand-file.
+
+Four checks that stop quiet repo decay, one family beside `size-ratchet`:
+same idiom (language-agnostic where possible, tighten-only baselines only
+where legacy counts exist, every failure names its remediation, exclusion
+rows carry their reasons) and the same exit contract.
+
+```bash
+.agents/skills/growth-guards/scripts/growth-guards              # batch: every enabled repo check
+.agents/skills/growth-guards/scripts/growth-guards todo-ban     # one check by name, flags pass through
+.agents/skills/growth-guards/scripts/commit-msg "$1"            # the commit-msg hook line
+```
+
+Every check is also independently invocable as `scripts/CHECK` — wire
+pre-commit shims and CI at whichever grain fits.
+
+## The checks
+
+| Check | Verdict |
+|---|---|
+| **todo-ban** | Any work marker (the words TODO, FIXME, HACK, XXX in comment-marker shapes) in a tracked, non-excluded file fails. No baseline. Prose that quotes or names a marker word does not fire. |
+| **byte-ceiling** | A newly added tracked file over the ceiling (default 200 KB) fails. `--staged` (default) gates the staged diff, `--base REF` the additions since merge-base, `--all` sweeps every tracked file. Lockfiles are exempt built-in. |
+| **suppression-ban** | Blanket lint suppressions fail flat: module-wide rust `allow` inner attributes, file-level ruff/flake8 noqa, the bare `eslint-disable` block form, bare or `all` nolint. Bare rust `allow(dead_code)`/`allow(unused*)` attributes are counted per file against a tighten-only baseline; `--update` lowers/removes rows, never adds or raises one. A per-line suppression naming its lint with a stated reason stays legal. |
+| **commit-msg** | Header must be `type(scope)!: subject` (scope and `!` optional). Uppercase issue keys (`fix(ABC-123)`) and `#`-number scopes pass; git-generated messages (Merge/Revert/Reapply, fixup!/squash!/amend!) pass unchanged. Takes the message file or stdin. |
+
+Exit codes everywhere: `0` clean, `1` violations, `2`
+usage/config/collection error. The gates distinguish "measured and fine"
+from "could not measure": any failure to collect (an unreadable file, a
+git/grep execution failure) is a loud exit 2, never a silent pass. The
+batch dispatcher exits 2 if any check could not complete.
+
+Scans read INDEX content (`git grep --cached`, staged blobs): what is
+staged is what gets committed, and a sparse checkout cannot hide a tracked
+file from a gate.
+
+## Configuration
+
+Resolution order for every key: explicit environment > `.env.local`
+(personal, untracked) > `.vstack/settings.toml` > the repo's committed
+`vstack.settings.toml` (flat `KEY = "value"` under `[env]`) > `.env` >
+built-in default.
+
+| Key | Default | Meaning |
+|---|---|---|
+| `GROWTH_GUARDS_CHECKS` | `todo-ban byte-ceiling suppression-ban` | Batch check list (`commit-msg` never batches). |
+| `GROWTH_GUARDS_TODO_EXCLUDES` | `tools/todo-ban-excludes` | todo-ban exclusion list. |
+| `GROWTH_GUARDS_BYTE_CEILING_KB` | `200` | Byte ceiling in KB. |
+| `GROWTH_GUARDS_BYTE_EXCLUDES` | `tools/byte-ceiling-excludes` | byte-ceiling exclusion list (declared asset trees). |
+| `GROWTH_GUARDS_SUPPRESSION_EXCLUDES` | `tools/suppression-ban-excludes` | suppression-ban exclusion list. |
+| `GROWTH_GUARDS_SUPPRESSION_BASELINE` | `tools/suppression-baseline.tsv` | Bare-allow ratchet baseline. |
+| `GROWTH_GUARDS_COMMIT_TYPES` | `build chore ci docs feat fix perf refactor revert style test` | Accepted commit types. |
+
+**Excludes format** — `pattern<TAB>reason` per line (shell glob against the
+full repo-relative path; `*` crosses `/`); blank lines and `#` comments are
+ignored, and a pattern without a reason is a config error — every exclusion
+carries its justification (vendored, generated, assets, fixtures).
+**Baseline format** — `path<TAB>count`, `LC_ALL=C` sorted, unique paths,
+positive counts; the only way a number goes up is a human editing the row
+in a reviewed diff.
+
+Marker shapes, per-language suppression patterns, seeding a first baseline,
+and hook/CI wiring: [README.md](README.md).

--- a/skills/growth-guards/scripts/byte-ceiling
+++ b/skills/growth-guards/scripts/byte-ceiling
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# byte-ceiling — newly added tracked files over the byte ceiling fail
+# (default 200 KB). Growth-oriented like size-ratchet: legacy files already
+# in history are not gated by the default modes — only what a change ADDS —
+# so adoption needs no cleanup first. A full sweep over every tracked file
+# is available for audits.
+#
+# Modes (mutually exclusive):
+#   --staged (default)  files added in the staged diff (pre-commit shim)
+#   --base REF          files added since merge-base with REF (CI on a PR)
+#   --all               every tracked file (full sweep)
+#
+# Sizes are OBJECT sizes (git cat-file -s of the added blob): the bytes
+# that actually enter history, filters applied, independent of worktree
+# state. Renames are detected (-c diff.renames pinned on), so moving an
+# existing large file is not an "addition"; a copy is one — it duplicates
+# the bytes in the tree, and that growth is what the gate is for. Known
+# lockfile
+# basenames are exempt built-in; asset trees are declared in the excludes
+# list with a reason.
+#
+# Exit codes: 0 clean; 1 violations; 2 usage/config/collection error. A
+# blob whose size cannot be read is a collection error — never a skip.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GG_CHECK="byte-ceiling"
+# shellcheck source=lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+# shellcheck source=lib/settings.sh
+source "$SCRIPT_DIR/lib/settings.sh"
+
+usage() {
+  cat <<'EOF'
+usage: byte-ceiling [--staged | --base REF | --all] [--excludes FILE]
+
+Newly added tracked files over the byte ceiling fail. --staged (default)
+checks the staged additions; --base REF checks files added since the
+merge-base with REF; --all sweeps every tracked file. Lockfiles are exempt
+built-in; declared asset trees live in the excludes list.
+
+Configuration (env > .env.local > .vstack/settings.toml >
+vstack.settings.toml [env] > .env > default):
+  GROWTH_GUARDS_BYTE_CEILING_KB   ceiling in KB        (default 200)
+  GROWTH_GUARDS_BYTE_EXCLUDES     exclusion-list path  (default tools/byte-ceiling-excludes)
+Flag --excludes overrides the path setting.
+
+Exit codes: 0 clean; 1 violations; 2 usage/config/collection error.
+EOF
+}
+
+MODE="staged"
+BASE_REF=""
+EXCLUDES_OPT=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --staged) MODE="staged" ;;
+    --all) MODE="all" ;;
+    --base)
+      [ $# -ge 2 ] || gg_config_error "--base requires a ref"
+      shift
+      MODE="base"
+      BASE_REF="$1"
+      ;;
+    --base=*)
+      MODE="base"
+      BASE_REF="${1#--base=}"
+      ;;
+    --excludes)
+      [ $# -ge 2 ] || gg_config_error "--excludes requires a path"
+      shift
+      EXCLUDES_OPT="$1"
+      ;;
+    --excludes=*) EXCLUDES_OPT="${1#--excludes=}" ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *) gg_config_error "unknown argument '$1' (see --help)" ;;
+  esac
+  shift
+done
+
+gg_repo_root_cd
+
+CEILING_KB="$(gg_setting GROWTH_GUARDS_BYTE_CEILING_KB 200)" || exit 2
+gg_positive_int "$CEILING_KB" "GROWTH_GUARDS_BYTE_CEILING_KB"
+CEILING_BYTES=$((CEILING_KB * 1024))
+
+if [ -n "$EXCLUDES_OPT" ]; then
+  EXCLUDES_FILE="$EXCLUDES_OPT"
+else
+  EXCLUDES_FILE="$(gg_setting GROWTH_GUARDS_BYTE_EXCLUDES "tools/byte-ceiling-excludes")" || exit 2
+fi
+EXCLUDES_FILE="$(gg_config_path "$EXCLUDES_FILE" "excludes")" || exit 2
+gg_load_excludes "$EXCLUDES_FILE"
+
+# Lockfiles are generated whole-file by package managers; their size is not
+# a design signal. Exempt by exact basename.
+LOCKFILE_BASENAMES="Cargo.lock package-lock.json npm-shrinkwrap.json yarn.lock pnpm-lock.yaml bun.lock bun.lockb flake.lock poetry.lock uv.lock Pipfile.lock Gemfile.lock composer.lock go.sum gradle.lockfile packages.lock.json Package.resolved"
+
+is_lockfile() { # PATH
+  local base="${1##*/}" l
+  for l in $LOCKFILE_BASENAMES; do
+    [ "$base" = "$l" ] && return 0
+  done
+  return 1
+}
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# Candidate records land as 'sha<TAB>path' NUL-free per record is
+# impossible for arbitrary paths, so the file holds alternating
+# NUL-terminated fields: sha NUL path NUL. The sha is the added blob
+# itself, so measuring needs no path re-quoting.
+: >"$TMP/candidates.z"
+
+emit_candidate() { # SHA PATH
+  printf '%s\0%s\0' "$1" "$2" >>"$TMP/candidates.z"
+}
+
+case "$MODE" in
+  staged)
+    git -c diff.renames=true diff --cached --raw --no-abbrev -z --diff-filter=A >"$TMP/raw.z" || gg_collection_error "git diff --cached failed collecting staged additions"
+    ;;
+  base)
+    git rev-parse --verify --quiet "$BASE_REF^{commit}" >/dev/null || gg_config_error "--base ref '$BASE_REF' does not name a commit"
+    git -c diff.renames=true diff --raw --no-abbrev -z --diff-filter=A "$BASE_REF...HEAD" >"$TMP/raw.z" || gg_collection_error "git diff $BASE_REF...HEAD failed collecting added files (no merge base?)"
+    ;;
+  all)
+    git ls-files -sz >"$TMP/files.z" || gg_collection_error "git ls-files failed"
+    while IFS= read -r -d '' rec; do
+      # Record shape: "<mode> <sha> <stage>\t<path>".
+      mode="${rec%% *}"
+      rest="${rec#* }"
+      sha="${rest%% *}"
+      f="${rec#*"$GG_TAB"}"
+      case "$mode" in
+        120000 | 160000) continue ;; # symlink / submodule gitlink — not sized content
+      esac
+      emit_candidate "$sha" "$f"
+    done <"$TMP/files.z"
+    ;;
+esac
+
+if [ "$MODE" != "all" ]; then
+  # --raw -z records alternate "meta NUL path NUL"; meta is
+  # ":srcmode dstmode srcsha dstsha status". Only status A survives the
+  # diff-filter, so each record carries exactly one path.
+  while IFS= read -r -d '' meta && IFS= read -r -d '' f; do
+    set -- $meta
+    dstmode="$2"
+    dstsha="$4"
+    case "$dstmode" in
+      120000 | 160000) continue ;; # symlink / submodule gitlink
+    esac
+    case "$dstsha" in
+      *[!0]*) ;;
+      *) gg_collection_error "added file '$f' has no destination blob in the diff record — cannot measure it" ;;
+    esac
+    emit_candidate "$dstsha" "$f"
+  done <"$TMP/raw.z"
+fi
+
+checked=0
+violations=0
+while IFS= read -r -d '' sha && IFS= read -r -d '' f; do
+  is_lockfile "$f" && continue
+  gg_is_excluded "$f" && continue
+  size="$(git cat-file -s "$sha")" || gg_collection_error "cannot read blob $sha for '$f' — its size is unmeasurable, refusing to skip it"
+  checked=$((checked + 1))
+  if [ "$size" -gt "$CEILING_BYTES" ]; then
+    kb=$(((size + 1023) / 1024))
+    echo "byte-ceiling FAIL oversized file: $f — $size bytes (~$kb KB) > ceiling $CEILING_KB KB"
+    echo "  remedies: keep big artifacts out of the repo (asset store, Git LFS, build-time generation); a file that genuinely belongs gets a row in $EXCLUDES_FILE with its reason"
+    violations=$((violations + 1))
+  fi
+done <"$TMP/candidates.z"
+
+case "$MODE" in
+  staged) SCOPE_DESC="staged addition(s)" ;;
+  base) SCOPE_DESC="file(s) added since $BASE_REF" ;;
+  all) SCOPE_DESC="tracked file(s) (full sweep)" ;;
+esac
+
+if [ "$violations" -gt 0 ]; then
+  echo "byte-ceiling: $violations violation(s) — ceiling $CEILING_KB KB, $checked $SCOPE_DESC checked"
+  exit 1
+fi
+echo "byte-ceiling: OK — $checked $SCOPE_DESC checked, ceiling $CEILING_KB KB"

--- a/skills/growth-guards/scripts/commit-msg
+++ b/skills/growth-guards/scripts/commit-msg
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# commit-msg — conventional-commit format gate over a commit message,
+# built to sit directly in .git/hooks/commit-msg (it takes the message
+# file git passes, or stdin).
+#
+# The header (first non-blank, non-comment line) must be
+# `type(scope)!: subject` — scope and `!` optional. The scope class
+# accepts uppercase issue keys (fix(ABC-123): ...) and `#`-prefixed issue
+# numbers (fix(#123): ...). Git-generated messages pass unchanged: Merge,
+# Revert, Reapply, fixup!, squash!, amend!.
+#
+# Exit codes: 0 pass; 1 violation; 2 usage/config/collection error (an
+# unreadable message file is a collection error, never a pass).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GG_CHECK="commit-msg"
+# shellcheck source=lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+# shellcheck source=lib/settings.sh
+source "$SCRIPT_DIR/lib/settings.sh"
+
+usage() {
+  cat <<'EOF'
+usage: commit-msg [FILE]
+
+Checks the commit message in FILE (or on stdin when FILE is absent or '-')
+against the conventional format `type(scope)!: subject`. Scope and '!' are
+optional; uppercase issue keys (fix(ABC-123): ...) are accepted;
+git-generated messages (Merge/Revert/Reapply, fixup!/squash!/amend!) pass
+unchanged. Wire it as .git/hooks/commit-msg: `commit-msg "$1"`.
+
+Configuration (env > .env.local > .vstack/settings.toml >
+vstack.settings.toml [env] > .env > default):
+  GROWTH_GUARDS_COMMIT_TYPES   space-separated type list
+                               (default "build chore ci docs feat fix perf refactor revert style test")
+
+Exit codes: 0 pass; 1 violation; 2 usage/config/collection error.
+EOF
+}
+
+MSG_FILE=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    --*) gg_config_error "unknown argument '$1' (see --help)" ;;
+    *)
+      [ -z "$MSG_FILE" ] || gg_config_error "at most one message file (see --help)"
+      MSG_FILE="$1"
+      ;;
+  esac
+  shift
+done
+
+# Read the message BEFORE cd-ing to the repo root: the FILE argument (git
+# passes .git/COMMIT_EDITMSG) is relative to the caller's directory.
+if [ -z "$MSG_FILE" ] || [ "$MSG_FILE" = "-" ]; then
+  MSG="$(cat)" || gg_collection_error "could not read the commit message from stdin"
+else
+  [ -f "$MSG_FILE" ] || gg_config_error "no such message file: $MSG_FILE"
+  MSG="$(cat -- "$MSG_FILE")" || gg_collection_error "could not read the commit message file: $MSG_FILE"
+fi
+
+gg_repo_root_cd
+
+TYPES="$(gg_setting GROWTH_GUARDS_COMMIT_TYPES "build chore ci docs feat fix perf refactor revert style test")" || exit 2
+TYPE_ALT=""
+for t in $TYPES; do
+  case "$t" in
+    "" | *[!a-z0-9-]*) gg_config_error "GROWTH_GUARDS_COMMIT_TYPES entry '$t' is not a lowercase type name" ;;
+  esac
+  TYPE_ALT="${TYPE_ALT:+$TYPE_ALT|}$t"
+done
+[ -n "$TYPE_ALT" ] || gg_config_error "GROWTH_GUARDS_COMMIT_TYPES resolved empty — at least one type is required"
+
+# Header = first line that is neither blank nor a '#' comment (git strips
+# comment lines before recording the message).
+HEADER=""
+while IFS= read -r ln || [ -n "$ln" ]; do
+  ln="${ln%$'\r'}"
+  case "$ln" in
+    "" | "#"*) continue ;;
+  esac
+  HEADER="$ln"
+  break
+done <<EOF
+$MSG
+EOF
+
+if [ -z "$HEADER" ]; then
+  echo "commit-msg FAIL empty commit message (no non-comment content)"
+  exit 1
+fi
+
+case "$HEADER" in
+  "Merge "* | "Revert "* | "Reapply "* | "fixup! "* | "squash! "* | "amend! "*)
+    echo "commit-msg: OK — git-generated header accepted: $HEADER"
+    exit 0
+    ;;
+esac
+
+HEADER_ERE="^($TYPE_ALT)(\([#A-Za-z0-9 _.,/-]+\))?!?: [^[:space:]]"
+match_status=0
+printf '%s\n' "$HEADER" | grep -qE "$HEADER_ERE" || match_status=$?
+[ "$match_status" -le 1 ] || gg_collection_error "grep failed matching the header (exit $match_status)"
+
+if [ "$match_status" -eq 0 ]; then
+  echo "commit-msg: OK — conventional header: $HEADER"
+  exit 0
+fi
+
+echo "commit-msg FAIL non-conventional header: $HEADER"
+echo "  expected: type(scope)!: subject — scope and '!' optional; types: $TYPES"
+echo "  scope accepts uppercase issue keys and issue numbers, e.g. fix(ABC-123): tighten the gate / fix(#123): case-fold IDs"
+echo "  git-generated headers (Merge/Revert/Reapply, fixup!/squash!/amend!) pass unchanged"
+exit 1

--- a/skills/growth-guards/scripts/growth-guards
+++ b/skills/growth-guards/scripts/growth-guards
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# growth-guards — dispatcher for the check family. One check by name, or
+# the whole enabled batch:
+#
+#   growth-guards                 run every enabled repo check (same as 'all')
+#   growth-guards all             ditto
+#   growth-guards CHECK [ARGS..]  run one check, flags passed through
+#
+# The batch runs the checks named by GROWTH_GUARDS_CHECKS (default:
+# todo-ban byte-ceiling suppression-ban). commit-msg reads a message, so
+# it never runs in the batch — the commit-msg hook invokes it directly.
+#
+# Batch aggregation fails closed: exit 2 if ANY check could not complete
+# (its own exit 2, or any unexpected status), else exit 1 if any check
+# found violations, else 0. Every check also remains independently
+# invocable as scripts/CHECK for pre-commit shims and CI.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GG_CHECK="growth-guards"
+# shellcheck source=lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+# shellcheck source=lib/settings.sh
+source "$SCRIPT_DIR/lib/settings.sh"
+
+KNOWN_CHECKS="todo-ban byte-ceiling suppression-ban commit-msg"
+BATCH_DEFAULT="todo-ban byte-ceiling suppression-ban"
+
+usage() {
+  cat <<EOF
+usage: growth-guards [all | CHECK [ARGS...]]
+
+Checks: $KNOWN_CHECKS
+
+With no argument (or 'all'), runs every check named by
+GROWTH_GUARDS_CHECKS (default: $BATCH_DEFAULT).
+commit-msg reads a message file/stdin and only runs by name.
+
+Exit codes: 0 clean; 1 violations; 2 usage/config/collection error, or
+any check that could not complete.
+EOF
+}
+
+if [ $# -ge 1 ]; then
+  case "$1" in
+    -h | --help)
+      usage
+      exit 0
+      ;;
+  esac
+fi
+
+if [ $# -ge 1 ] && [ "$1" != "all" ]; then
+  CHECK="$1"
+  shift
+  case " $KNOWN_CHECKS " in
+    *" $CHECK "*) exec "$SCRIPT_DIR/$CHECK" "$@" ;;
+  esac
+  gg_config_error "unknown check '$CHECK' (known: $KNOWN_CHECKS)"
+fi
+
+[ $# -le 1 ] || gg_config_error "'all' takes no extra arguments; invoke a single check to pass flags"
+
+gg_repo_root_cd
+CHECKS="$(gg_setting GROWTH_GUARDS_CHECKS "$BATCH_DEFAULT")" || exit 2
+case "$CHECKS" in
+  *[!\ ]*) ;;
+  *) gg_config_error "GROWTH_GUARDS_CHECKS resolved empty — name at least one check or unset it" ;;
+esac
+for c in $CHECKS; do
+  case "$c" in
+    commit-msg) gg_config_error "commit-msg reads a message and cannot run in the batch; wire 'growth-guards commit-msg \"\$1\"' into the commit-msg hook instead" ;;
+  esac
+  case " $KNOWN_CHECKS " in
+    *" $c "*) ;;
+    *) gg_config_error "GROWTH_GUARDS_CHECKS names unknown check '$c' (known: $KNOWN_CHECKS)" ;;
+  esac
+done
+
+had_violations=0
+had_errors=0
+for c in $CHECKS; do
+  echo "=== growth-guards: $c"
+  check_status=0
+  "$SCRIPT_DIR/$c" || check_status=$?
+  case "$check_status" in
+    0) ;;
+    1) had_violations=1 ;;
+    *)
+      had_errors=1
+      echo "growth-guards: check '$c' did not complete (exit $check_status)"
+      ;;
+  esac
+done
+
+if [ "$had_errors" -eq 1 ]; then
+  echo "growth-guards: could not complete every check — fix the errors above before trusting any verdict"
+  exit 2
+fi
+if [ "$had_violations" -eq 1 ]; then
+  echo "growth-guards: violations — see the failures above"
+  exit 1
+fi
+echo "growth-guards: OK — enabled checks clean ($CHECKS)"

--- a/skills/growth-guards/scripts/lib/common.sh
+++ b/skills/growth-guards/scripts/lib/common.sh
@@ -1,0 +1,152 @@
+# shellcheck shell=bash
+# Shared plumbing for the growth-guards check family. Sourced (not executed)
+# by every scripts/* check. Bash 3.2-safe throughout: no Bash 4+ builtins
+# or array kinds, guarded expansion for possibly-empty arrays.
+#
+# Family contract carried here: exit 0 clean, 1 violations, 2
+# usage/config/collection error. The gates distinguish "measured and fine"
+# from "could not measure": any failure to collect (an unreadable file, a
+# git or grep execution failure) goes through gg_collection_error — a loud
+# exit 2, never a silent pass.
+#
+# Each check sets GG_CHECK to its own name before calling any helper, so
+# every diagnostic names the check that produced it.
+
+set -euo pipefail
+
+GG_TAB="$(printf '\t')"
+
+gg_config_error() {
+  echo "::error::${GG_CHECK:-growth-guards}: $*" >&2
+  exit 2
+}
+
+# Same loud exit as a config error, distinct name so call sites read as
+# what they are: a measurement that failed, never a verdict.
+gg_collection_error() {
+  echo "::error::${GG_CHECK:-growth-guards}: $*" >&2
+  exit 2
+}
+
+gg_repo_root_cd() { # cd to the repository root; all configured paths are repo-relative
+  local root
+  root="$(git rev-parse --show-toplevel)" || gg_config_error "not inside a git repository"
+  cd "$root" || gg_config_error "cannot cd to repository root '$root'"
+}
+
+gg_positive_int() { # VALUE NAME — config error unless VALUE is a positive integer
+  case "$1" in
+    "" | *[!0-9]* | 0*[0-9] | 0) gg_config_error "$2 must be a positive integer, got '$1'" ;;
+  esac
+}
+
+# Lexically normalize a configured repo-relative path (leading ./, internal
+# ./ and .. segments): git records canonical relative paths, and every
+# literal comparison against them must agree. Pure string surgery — no
+# symlink resolution.
+gg_normalize_rel_path() { # PATH -> normalized on stdout; nonzero if it escapes
+  local input="$1" out="" seg rest
+  rest="$input"
+  while [ -n "$rest" ]; do
+    seg="${rest%%/*}"
+    if [ "$seg" = "$rest" ]; then rest=""; else rest="${rest#*/}"; fi
+    case "$seg" in
+      "" | ".") ;;
+      "..")
+        case "$out" in
+          "") return 1 ;;
+          */*) out="${out%/*}" ;;
+          *) out="" ;;
+        esac
+        ;;
+      *) out="${out:+$out/}$seg" ;;
+    esac
+  done
+  [ -n "$out" ] || return 1
+  printf '%s' "$out"
+}
+
+# Validate + normalize one configured path. Absolute paths and paths that
+# escape the repository are configuration errors; a path beginning with '-'
+# would read as an option to the line utilities that touch it — refuse it
+# as configuration rather than trusting every call site's `--` guard.
+gg_config_path() { # RAW LABEL — normalized on stdout; nonzero + ::error on stderr
+  local raw="$1" label="$2" norm
+  case "$raw" in
+    /*)
+      echo "::error::${GG_CHECK:-growth-guards}: $label path must be repo-root-relative, got absolute: $raw" >&2
+      return 1
+      ;;
+  esac
+  if ! norm="$(gg_normalize_rel_path "$raw")"; then
+    echo "::error::${GG_CHECK:-growth-guards}: $label path escapes the repository or normalizes empty: $raw" >&2
+    return 1
+  fi
+  case "$norm" in
+    -*)
+      echo "::error::${GG_CHECK:-growth-guards}: $label path must not begin with '-': $norm" >&2
+      return 1
+      ;;
+  esac
+  printf '%s' "$norm"
+}
+
+# --- exclusion list: pattern<TAB>reason, reason mandatory --------------------
+# Shell glob matched against the full repo-relative path (`*` crosses `/`);
+# blank lines and `#` comments are ignored; a pattern without a reason is a
+# config error — every exclusion carries its justification. A missing file
+# is an empty list.
+GG_EXCLUDE_PATTERNS=()
+
+gg_load_excludes() { # FILE — fills GG_EXCLUDE_PATTERNS
+  local file="$1" line lineno pat reason content
+  GG_EXCLUDE_PATTERNS=()
+  # The scans read the INDEX, so the exclusion list comes from the index
+  # too: staged edits to it govern staged scans, and a sparse checkout
+  # that omits the tracked file from disk still applies it. The worktree
+  # copy is only the fallback for an untracked list; absent both places
+  # is an empty list.
+  if git ls-files --error-unmatch -- "$file" >/dev/null 2>&1; then
+    content="$(git show ":$file")" || gg_collection_error "could not read the staged copy of $file"
+  elif [ -f "$file" ]; then
+    content="$(cat -- "$file")" || gg_collection_error "could not read $file"
+  else
+    return 0
+  fi
+  lineno=0
+  while IFS= read -r line || [ -n "$line" ]; do
+    lineno=$((lineno + 1))
+    case "$line" in
+      "" | "#"*) continue ;;
+    esac
+    pat="${line%%"$GG_TAB"*}"
+    reason="${line#*"$GG_TAB"}"
+    if [ "$pat" = "$line" ] || [ -z "$pat" ] || [ -z "$reason" ]; then
+      gg_config_error "$file:$lineno: expected 'pattern<TAB>reason' (every exclusion carries its justification)"
+    fi
+    GG_EXCLUDE_PATTERNS+=("$pat")
+  done <<<"$content"
+}
+
+gg_is_excluded() { # PATH — 0 when some exclusion glob matches the full path
+  local path="$1" pat
+  # Guarded expansion: an empty array is an unbound variable under Bash 3.2
+  # with set -u.
+  for pat in ${GG_EXCLUDE_PATTERNS[@]+"${GG_EXCLUDE_PATTERNS[@]}"}; do
+    # $pat must expand unquoted to act as a glob.
+    # shellcheck disable=SC2254
+    case "$path" in
+      $pat) return 0 ;;
+    esac
+  done
+  return 1
+}
+
+gg_count_nonempty_lines() { # FILE — count on stdout; loud exit if grep cannot read it
+  # grep -c exits 1 on zero matches but still prints 0 — only exit >= 2
+  # (execution/read failure) means the count is unknown.
+  local n status=0
+  n="$(grep -c . -- "$1")" || status=$?
+  [ "$status" -le 1 ] || gg_collection_error "could not count lines in $1 (grep exit $status)"
+  printf '%s\n' "$n"
+}

--- a/skills/growth-guards/scripts/lib/settings.sh
+++ b/skills/growth-guards/scripts/lib/settings.sh
@@ -1,0 +1,189 @@
+# shellcheck shell=bash
+# Settings resolution for the growth-guards check family. Sourced (not
+# executed) by every scripts/* check.
+#
+# VENDORED from skills/review-gate/scripts/lib/settings.sh (rg_setting),
+# renamed gg_setting: skills are standalone-installable, so a consumer that
+# installs only growth-guards has no review-gate tree to source from. Keep
+# the logic in sync with the original; behavioral fixes belong there first.
+#
+# Resolution order for every key read through gg_setting (the GROWTH_GUARDS_*
+# family):
+#   1. explicit environment — a SET variable wins even when set to the empty
+#      string, so a caller can force "explicitly empty";
+#   2. .env.local (KEY=value, quotes optional — parsed, never sourced);
+#   3. .vstack/settings.toml, then the repo's committed vstack.settings.toml
+#      (sole uncommented `KEY = "value"` assignment; an explicit
+#      GROWTH_GUARDS_SETTINGS_FILE consults only itself, e.g. /dev/null);
+#   4. .env (same shape);
+#   5. the built-in default passed by the caller.
+#
+# The parser reads flat single-line basic-string TOML assignments only —
+# exactly the shape vstack.settings.toml [env] blocks use.
+#
+# Keys are matched FILE-WIDE by exact name, with no TOML-table awareness:
+# adopter settings sit under an [env] table, and a table-aware top-level
+# parser would resolve none of them. The consequence is a contract: every
+# key name read through gg_setting is reserved across the whole file — an
+# assignment under an unrelated table would be read as the setting, so
+# callers must keep these names unique file-wide. The one detectable
+# ambiguity, the same name assigned more than once, fails loud below.
+#
+# The caller cds to the repo root before resolving, so the default settings
+# path is relative.
+
+# Extract the value of one parsed dotenv assignment (text after `KEY=`).
+# Quoted values end at the FIRST closing delimiter — dotenv/shell
+# semantics; an embedded delimiter would need escaping, which this parser
+# does not support — so a quote inside a trailing comment can never leak
+# into the value: KEY="500" # say "ceiling" assigns 500. Anything else
+# after the closing quote (an adjacent segment like KEY="tools/base".tsv)
+# is a shape this parser cannot read and fails NONZERO — truncating it
+# would silently load the wrong value. Unquoted values end at the first
+# whitespace: KEY=500 # ceiling assigns 500.
+set -euo pipefail
+
+gg_dotenv_value() { # RAW — value on stdout; nonzero on an unsupported shape
+  local val="$1" rest
+  case "$val" in
+    \"*\"*)
+      val="${val#\"}"
+      rest="${val#*\"}"
+      val="${val%%\"*}"
+      ;;
+    \'*\'*)
+      val="${val#\'}"
+      rest="${val#*\'}"
+      val="${val%%\'*}"
+      ;;
+    *)
+      printf '%s' "${val%%[[:space:]]*}"
+      return 0
+      ;;
+  esac
+  # Only whitespace, or whitespace followed by a #comment, may follow the
+  # closing quote. An ADJACENT # (KEY="abc"#def) is not a comment in shell
+  # semantics — it is an adjacent segment, and truncating it would load an
+  # unintended value, so it fails like any other unsupported shape.
+  case "$rest" in
+    "") printf '%s' "$val"; return 0 ;;
+    [[:space:]]*)
+      rest="${rest#"${rest%%[![:space:]]*}"}"
+      case "$rest" in
+        "" | "#"*) printf '%s' "$val"; return 0 ;;
+      esac
+      ;;
+  esac
+  return 1
+}
+
+# One read discipline for every settings probe: grep exits 0/1 are
+# measurements, anything else is an unreadable source and fails loud —
+# falling through to a lower-precedence layer would silently change the
+# resolved value.
+gg_settings_grep() { # REGEX FILE — matching lines on stdout; 1 = no match
+  local status=0
+  grep -E -- "$1" "$2" || status=$?
+  if [ "$status" -gt 1 ]; then
+    echo "::error::$2: unreadable while resolving a setting (grep exit $status)" >&2
+    return 2
+  fi
+  return "$status"
+}
+
+gg_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
+               # a present-but-unparseable assignment (callers must propagate)
+  local name="$1" default="$2" line val file status matches
+  # The name is interpolated into ERE patterns below; constrain it to the
+  # identifier shape every real key has, so a metacharacter can neither
+  # misgrep nor inject pattern syntax.
+  case "$name" in
+    "" | [0-9]* | *[!A-Za-z0-9_]*)
+      echo "::error::gg_setting: invalid key name '$name' (shell identifier shape required: [A-Za-z_][A-Za-z0-9_]*)" >&2
+      return 1
+      ;;
+  esac
+  # Indirect expansion, not eval: a non-literal NAME must never become code.
+  # ${!name+x} tests set-ness of the variable NAMED by $name (Bash 3.2-safe).
+  if [ -n "${!name+x}" ]; then
+    printf '%s' "${!name}"
+    return 0
+  fi
+  # Env-file overrides (standard project layering: .env.local beats the
+  # committed settings, .env is the base) — LAST matching KEY= line wins (shell-sourcing semantics),
+  # optional surrounding quotes stripped. Parsed, never sourced.
+  if [ -f ".env.local" ]; then
+    status=0
+    matches="$(gg_settings_grep "^[[:space:]]*(export[[:space:]]+)?${name}=" .env.local)" || status=$?
+    [ "$status" -le 1 ] || return 1
+    line="$(printf '%s\n' "$matches" | tail -n 1)"
+    if [ -n "$line" ]; then
+      if ! val="$(gg_dotenv_value "${line#*=}")"; then
+        echo "::error::.env.local: unsupported syntax for $name (a quoted value must end at its closing quote, optionally followed by a comment)" >&2
+        return 1
+      fi
+      printf '%s' "$val"
+      return 0
+    fi
+  fi
+  # Nested project settings override the root file (the standard loader
+  # order); an explicit GROWTH_GUARDS_SETTINGS_FILE consults only itself.
+  if [ -n "${GROWTH_GUARDS_SETTINGS_FILE+x}" ]; then
+    set -- "$GROWTH_GUARDS_SETTINGS_FILE"
+  else
+    set -- ".vstack/settings.toml" "vstack.settings.toml"
+  fi
+  for file in "$@"; do
+  if [ -f "$file" ]; then
+    # Key PRESENCE decides, not value non-emptiness: `NAME = ""` is a real
+    # assignment and must override the built-in default, exactly like a
+    # set-but-empty env var does above.
+    # Leading whitespace before a key is valid TOML, so matching is
+    # whitespace-tolerant everywhere (presence, ambiguity guard, extraction)
+    # — anchoring at column one made an indented duplicate bypass the
+    # fail-loud guard and an indented sole assignment collapse silently to
+    # the built-in default (vstack#1059).
+    status=0
+    matches="$(gg_settings_grep "^[[:space:]]*${name}[[:space:]]*=" "$file")" || status=$?
+    [ "$status" -le 1 ] || return 1
+    if [ "$status" -eq 0 ]; then
+      # File-wide matching (header contract) makes a re-assigned name
+      # ambiguous — e.g. the same key under two tables. Silently taking the
+      # first could read an unrelated table's value, so ambiguity is a
+      # configuration error.
+      if [ "$(printf '%s\n' "$matches" | grep -c .)" -gt 1 ]; then
+        echo "::error::$file: $name is assigned more than once (keys are matched file-wide regardless of TOML table; each name must be unique in the file)" >&2
+        return 1
+      fi
+      line="$(printf '%s\n' "$matches" | head -n 1)"
+      # A PRESENT assignment this parser cannot read must fail LOUDLY, never
+      # collapse to empty. Only the flat single-line basic-string shape is
+      # supported — the value is quote-free ([^"]*), which makes the
+      # extraction exact even with a trailing TOML comment (accepted);
+      # anything else is a configuration error.
+      if ! printf '%s\n' "$line" | grep -Eq -- "^[[:space:]]*${name}[[:space:]]*=[[:space:]]*\"[^\"]*\"[[:space:]]*(#.*)?\$"; then
+        echo "::error::$file: unsupported syntax for $name (expected a single-line basic string: $name = \"value\")" >&2
+        return 1
+      fi
+      val="$(printf '%s\n' "$line" | sed -n "s/^[[:space:]]*${name}[[:space:]]*=[[:space:]]*\"\([^\"]*\)\".*\$/\1/p")"
+      printf '%s' "$val"
+      return 0
+    fi
+  fi
+  done
+  if [ -f ".env" ]; then
+    status=0
+    matches="$(gg_settings_grep "^[[:space:]]*(export[[:space:]]+)?${name}=" .env)" || status=$?
+    [ "$status" -le 1 ] || return 1
+    line="$(printf '%s\n' "$matches" | tail -n 1)"
+    if [ -n "$line" ]; then
+      if ! val="$(gg_dotenv_value "${line#*=}")"; then
+        echo "::error::.env: unsupported syntax for $name (a quoted value must end at its closing quote, optionally followed by a comment)" >&2
+        return 1
+      fi
+      printf '%s' "$val"
+      return 0
+    fi
+  fi
+  printf '%s' "$default"
+}

--- a/skills/growth-guards/scripts/suppression-ban
+++ b/skills/growth-guards/scripts/suppression-ban
@@ -1,0 +1,306 @@
+#!/usr/bin/env bash
+# suppression-ban — two gates over lint suppression in tracked files:
+#
+# 1. BLANKET suppressions fail flat (no baseline): the file- or
+#    module-wide pragmas that turn a linter off wholesale —
+#      rust        crate/module-wide inner allow attribute  #![allow(...)]
+#      python      file-level directives  ruff: noqa / flake8: noqa
+#      eslint      the bare block form  /* eslint-disable */  (no rules named)
+#      golangci    nolint with no linter named, or nolint:all
+#    A PER-LINE suppression that names its lint and states its reason
+#    stays legal — the ban is on suppressing everything at once.
+#
+# 2. BARE ALLOW RATCHET (rust): reasonless per-item attributes for
+#    dead_code / unused lints are counted per file; a repo with legacy
+#    counts freezes them in a tighten-only baseline TSV (path<TAB>count).
+#    Rows only go down or away: new bare allows, growth past a row, and a
+#    baseline looser than reality all fail; --update lowers/removes rows
+#    but never adds or raises one, so deliberate growth is a visible
+#    hand-edit in review. An attribute carrying `reason = "..."` does not
+#    count — stating the reason is the legal form.
+#
+# Scans INDEX content (git grep --cached), language-scoped by pathspec, so
+# documentation and scripts that QUOTE these pragmas never fire. Exit
+# codes: 0 clean; 1 violations; 2 usage/config/collection error; any git
+# or grep execution failure (exit >= 2) is a collection error, never a
+# silent pass.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GG_CHECK="suppression-ban"
+# shellcheck source=lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+# shellcheck source=lib/settings.sh
+source "$SCRIPT_DIR/lib/settings.sh"
+
+usage() {
+  cat <<'EOF'
+usage: suppression-ban [--update] [--baseline FILE] [--excludes FILE]
+
+Blanket lint suppressions (module-wide rust allow, file-level noqa, bare
+eslint-disable, bare/`all` nolint) fail flat. Bare rust allow(dead_code)/
+allow(unused*) attributes are counted per file against a tighten-only
+baseline; --update lowers/removes rows to current reality (never adds,
+never raises) and then re-checks.
+
+Configuration (env > .env.local > .vstack/settings.toml >
+vstack.settings.toml [env] > .env > default):
+  GROWTH_GUARDS_SUPPRESSION_BASELINE   baseline path        (default tools/suppression-baseline.tsv)
+  GROWTH_GUARDS_SUPPRESSION_EXCLUDES   exclusion-list path  (default tools/suppression-ban-excludes)
+Flags override both for the path settings.
+
+Exit codes: 0 clean; 1 violations; 2 usage/config/collection error.
+EOF
+}
+
+MODE="check"
+BASELINE_OPT=""
+EXCLUDES_OPT=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --update) MODE="update" ;;
+    --baseline)
+      [ $# -ge 2 ] || gg_config_error "--baseline requires a path"
+      shift
+      BASELINE_OPT="$1"
+      ;;
+    --baseline=*) BASELINE_OPT="${1#--baseline=}" ;;
+    --excludes)
+      [ $# -ge 2 ] || gg_config_error "--excludes requires a path"
+      shift
+      EXCLUDES_OPT="$1"
+      ;;
+    --excludes=*) EXCLUDES_OPT="${1#--excludes=}" ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *) gg_config_error "unknown argument '$1' (see --help)" ;;
+  esac
+  shift
+done
+
+gg_repo_root_cd
+
+if [ -n "$BASELINE_OPT" ]; then
+  BASELINE_FILE="$BASELINE_OPT"
+else
+  BASELINE_FILE="$(gg_setting GROWTH_GUARDS_SUPPRESSION_BASELINE "tools/suppression-baseline.tsv")" || exit 2
+fi
+if [ -n "$EXCLUDES_OPT" ]; then
+  EXCLUDES_FILE="$EXCLUDES_OPT"
+else
+  EXCLUDES_FILE="$(gg_setting GROWTH_GUARDS_SUPPRESSION_EXCLUDES "tools/suppression-ban-excludes")" || exit 2
+fi
+BASELINE_FILE="$(gg_config_path "$BASELINE_FILE" "baseline")" || exit 2
+EXCLUDES_FILE="$(gg_config_path "$EXCLUDES_FILE" "excludes")" || exit 2
+gg_load_excludes "$EXCLUDES_FILE"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# --- gate 1: blanket suppressions, flat fail ---------------------------------
+BLANKET_VIOLATIONS=0
+
+run_lane() { # LABEL ERE REMEDY PATHSPEC... — numbered violations on stdout
+  local label="$1" ere="$2" remedy="$3" status f hit_status hit
+  shift 3
+  status=0
+  git grep --cached -lIzE "$ere" -- "$@" >"$TMP/lane.z" || status=$?
+  [ "$status" -le 1 ] || gg_collection_error "git grep failed scanning for $label (exit $status)"
+  while IFS= read -r -d '' f; do
+    gg_is_excluded "$f" && continue
+    hit_status=0
+    git grep --cached -nIE "$ere" -- ":(literal)$f" >"$TMP/lane.hits" || hit_status=$?
+    [ "$hit_status" -eq 0 ] || gg_collection_error "git grep could not detail the $label hits in '$f' (exit $hit_status)"
+    while IFS= read -r hit; do
+      echo "suppression-ban FAIL $label: $f:${hit#"$f":}"
+      echo "  remedies: $remedy"
+      BLANKET_VIOLATIONS=$((BLANKET_VIOLATIONS + 1))
+    done <"$TMP/lane.hits"
+  done <"$TMP/lane.z"
+}
+
+run_lane "module-wide rust allow" \
+  '^[[:space:]]*#!\[allow\(' \
+  "delete the module-wide attribute and fix the findings, or annotate the surviving sites per line with a stated reason; vendored trees belong in $EXCLUDES_FILE with a reason" \
+  '*.rs'
+
+run_lane "file-level noqa" \
+  '^[[:space:]]*#[[:space:]]*(ruff|flake8):[[:space:]]*noqa' \
+  "drop the file-level directive; a per-line noqa naming its specific codes stays legal" \
+  '*.py'
+
+run_lane "blanket eslint-disable" \
+  '/\*[[:space:]]*eslint-disable[[:space:]]*\*/' \
+  "name the rules being disabled (and why), or fix the findings; the bare block form turns the linter off wholesale" \
+  '*.js' '*.jsx' '*.ts' '*.tsx' '*.mjs' '*.cjs' '*.mts' '*.cts' '*.vue' '*.svelte'
+
+run_lane "blanket nolint" \
+  '//[[:space:]]*nolint([[:space:]]*$|:[[:space:]]*all([^a-z]|$))' \
+  "name the linter per line (nolint:lintname with the reason alongside), or fix the finding" \
+  '*.go'
+
+# --- gate 2: bare-allow ratchet (rust) ---------------------------------------
+# The whole parenthesized span must be lint names (paths like `clippy::x`
+# included), commas, and spaces — a `reason = "…"` component carries `=`
+# and quotes and keeps the attribute out of the bare count, so the reasoned
+# form is the legal one.
+BARE_ERE='#\[allow\([[:space:]]*([a-z_:]+[[:space:]]*,[[:space:]]*)*(dead_code|unused(_[a-z_]+)?)([[:space:]]*,[[:space:]]*[a-z_:]+)*[[:space:]]*\)\]'
+
+# Tracked *.rs paths carrying a tab or newline cannot be represented in the
+# line- and tab-oriented records below; refuse loudly (exclude the path to
+# skip the gate) rather than silently splitting into garbage rows.
+NL='
+'
+git ls-files -z -- '*.rs' >"$TMP/rs.z" || gg_collection_error "git ls-files failed enumerating *.rs"
+while IFS= read -r -d '' f; do
+  case "$f" in
+    *"$NL"*) gg_config_error "tracked path contains a newline, unrepresentable in line-oriented records (exclude it to skip the gate): '$f'" ;;
+    *"$GG_TAB"*) gg_config_error "tracked path contains a tab, unrepresentable in the baseline TSV (exclude it to skip the gate): '$f'" ;;
+  esac
+done <"$TMP/rs.z"
+
+status=0
+git grep --cached -cIE "$BARE_ERE" -- '*.rs' >"$TMP/bare.raw" || status=$?
+[ "$status" -le 1 ] || gg_collection_error "git grep failed counting bare allows (exit $status)"
+
+: >"$TMP/counts.raw"
+while IFS= read -r row; do
+  cnt="${row##*:}"
+  f="${row%:*}"
+  case "$cnt" in
+    "" | *[!0-9]*) gg_collection_error "unparseable count row from git grep: '$row'" ;;
+  esac
+  gg_is_excluded "$f" && continue
+  printf '%s\t%s\n' "$f" "$cnt" >>"$TMP/counts.raw"
+done <"$TMP/bare.raw"
+LC_ALL=C sort "$TMP/counts.raw" >"$TMP/counts.tsv"
+
+# Baseline load + hygiene: worktree file first; a tracked-but-absent
+# baseline (sparse checkout) is read from the index so it cannot degrade to
+# empty; otherwise the baseline is empty. Hygiene is enforced, not repaired:
+# rows are 'path<TAB>count' with positive counts, LC_ALL=C sorted, unique.
+validate_baseline() { # FILE LABEL
+  local file="$1" label="$2" grep_status=0 bad_rows dup_paths
+  bad_rows="$(grep -nEv "^[^${GG_TAB}]+${GG_TAB}[1-9][0-9]*\$" -- "$file")" || grep_status=$?
+  [ "$grep_status" -le 1 ] || gg_collection_error "could not validate $label (grep exit $grep_status)"
+  if [ -n "$bad_rows" ]; then
+    printf '%s\n' "$bad_rows" >&2
+    gg_config_error "$label: malformed row(s) above (expected 'path<TAB>count' with a positive count)"
+  fi
+  if ! LC_ALL=C sort -c -- "$file" 2>/dev/null; then
+    gg_config_error "$label: rows must be LC_ALL=C sorted (LC_ALL=C sort -o $BASELINE_FILE $BASELINE_FILE)"
+  fi
+  dup_paths="$(cut -f1 -- "$file" | LC_ALL=C uniq -d)"
+  if [ -n "$dup_paths" ]; then
+    printf '%s\n' "$dup_paths" >&2
+    gg_config_error "$label: duplicate path row(s) above"
+  fi
+}
+
+BASELINE_FROM_INDEX=0
+if [ -f "$BASELINE_FILE" ]; then
+  validate_baseline "$BASELINE_FILE" "$BASELINE_FILE"
+  cp -- "$BASELINE_FILE" "$TMP/baseline.tsv"
+elif [ "$(git cat-file -t ":$BASELINE_FILE" 2>/dev/null)" = "blob" ]; then
+  BASELINE_FROM_INDEX=1
+  git show ":$BASELINE_FILE" >"$TMP/baseline.tsv" || gg_config_error "failed to read tracked baseline from the index: $BASELINE_FILE"
+  validate_baseline "$TMP/baseline.tsv" "$BASELINE_FILE (index copy)"
+else
+  : >"$TMP/baseline.tsv"
+fi
+
+evaluate() { # BASELINE-TSV — violations on stdout, one per line, tab-separated
+  awk -F'\t' -v OFS='\t' -v basefile="$1" '
+    FILENAME == basefile { base[$1] = $2 + 0; border[++bn] = $1; next }
+    {
+      p = $1; n = $2 + 0; seen[p] = 1
+      if (!(p in base))      print "NEW",   p, n, "-"
+      else if (n > base[p])  print "GROW",  p, n, base[p]
+      else if (n < base[p])  print "LOOSE", p, n, base[p]
+    }
+    END {
+      for (i = 1; i <= bn; i++) {
+        p = border[i]
+        if (p in seen) continue
+        # "-" placeholder, never an empty field: the report loop reads
+        # these rows with tab-IFS, and whitespace IFS collapses
+        # consecutive tabs, shifting columns.
+        print "STALE", p, "-", base[p]
+      }
+    }
+  ' "$1" "$TMP/counts.tsv"
+}
+
+# --- --update: tighten only ---------------------------------------------------
+if [ "$MODE" = "update" ]; then
+  awk -F'\t' -v OFS='\t' -v basefile="$TMP/baseline.tsv" '
+    FILENAME == basefile { base[$1] = $2 + 0; border[++bn] = $1; next }
+    { act[$1] = $2 + 0 }
+    END {
+      for (i = 1; i <= bn; i++) {
+        p = border[i]; b = base[p]
+        if (!(p in act)) {
+          printf "removed: %s (row %d)\n", p, b > "/dev/stderr"
+          continue
+        }
+        if (act[p] < b) {
+          printf "tightened: %s %d -> %d\n", p, b, act[p] > "/dev/stderr"
+          print p, act[p]
+        } else {
+          if (act[p] > b) printf "kept (grew %d > %d — growth is a hand-edit, never --update): %s\n", act[p], b, p > "/dev/stderr"
+          print p, b
+        }
+      }
+    }
+  ' "$TMP/baseline.tsv" "$TMP/counts.tsv" | LC_ALL=C sort >"$TMP/baseline.new"
+  if [ "$BASELINE_FROM_INDEX" = "1" ]; then
+    BASELINE_QUOTED="$(printf '%q' "$BASELINE_FILE")"
+    gg_config_error "--update cannot rewrite an index-only baseline (sparse checkout omits $BASELINE_FILE); materialize it with: git update-index --no-skip-worktree -- $BASELINE_QUOTED && git checkout-index -- $BASELINE_QUOTED, then rerun"
+  fi
+  if [ -f "$BASELINE_FILE" ]; then
+    # Every recount runs against the candidate BEFORE it replaces the real
+    # baseline, so a collection failure aborts with the reviewed baseline
+    # byte-identical; the replace is the last step, and its own failure
+    # carries honest sidedness.
+    rows="$(gg_count_nonempty_lines "$TMP/baseline.new")"
+    mv -- "$TMP/baseline.new" "$BASELINE_FILE" || gg_collection_error "could not replace the baseline at $BASELINE_FILE (mv failed) — inspect the file before trusting it"
+    cp -- "$BASELINE_FILE" "$TMP/baseline.tsv" || gg_collection_error "could not re-read the replaced baseline at $BASELINE_FILE (cp failed) — the baseline WAS replaced; rerun suppression-ban to verify it"
+    echo "suppression-ban --update: baseline tightened at $BASELINE_FILE ($rows row(s))"
+  else
+    echo "suppression-ban --update: no baseline at $BASELINE_FILE and --update never adds rows; nothing written"
+  fi
+fi
+
+# --- ratchet verdict ----------------------------------------------------------
+evaluate "$TMP/baseline.tsv" >"$TMP/violations.tsv"
+ratchet_violations="$(gg_count_nonempty_lines "$TMP/violations.tsv")"
+
+while IFS="$GG_TAB" read -r kind path n b; do
+  case "$kind" in
+    NEW)
+      echo "suppression-ban FAIL new bare allow: $path — $n reasonless allow(dead_code)/allow(unused) attribute(s), no baseline row"
+      echo "  remedies: state a reason on each attribute or fix the code; freezing a legacy count is a hand-added baseline row in this diff with justification"
+      ;;
+    GROW)
+      echo "suppression-ban FAIL bare allows grew: $path — $n attribute(s) > baseline $b"
+      echo "  remedies: state a reason on each new attribute or fix the code; raising the row is a hand-edit in this diff with justification"
+      ;;
+    LOOSE)
+      echo "suppression-ban FAIL baseline looser than reality: $path — baseline $b > actual $n; the ratchet only moves down"
+      echo "  remedy: run suppression-ban --update to tighten the row"
+      ;;
+    STALE)
+      echo "suppression-ban FAIL stale baseline row: $path — no bare allows remain (or the file left the tracked, non-excluded set); the row ($b) must go"
+      echo "  remedy: run suppression-ban --update to drop the row"
+      ;;
+  esac
+done <"$TMP/violations.tsv"
+
+total=$((BLANKET_VIOLATIONS + ratchet_violations))
+if [ "$total" -gt 0 ]; then
+  echo "suppression-ban: $total violation(s) — $BLANKET_VIOLATIONS blanket, $ratchet_violations ratchet (baseline $BASELINE_FILE)"
+  exit 1
+fi
+echo "suppression-ban: OK — no blanket suppressions, bare allows within baseline $BASELINE_FILE"

--- a/skills/growth-guards/scripts/todo-ban
+++ b/skills/growth-guards/scripts/todo-ban
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# todo-ban — flat ban on work markers in first-party tracked files: the
+# words TODO, FIXME, HACK and XXX in comment-marker shapes. No baseline —
+# all consumer repos are at or near zero; vendored, generated and asset
+# trees are excluded with a reason.
+#
+# A marker is matched only in marker SHAPES, so prose that names or quotes
+# a marker word does not fire:
+#   (a) the word at line start, after whitespace, or after a comment
+#       leader, immediately followed by ':' or '(' — the classic annotated
+#       forms;
+#   (b) the bare word directly after a comment leader (only whitespace
+#       between), followed by whitespace or end of line.
+# Comment leaders: //, #, ;, /*, <!--. A word preceded by a backtick,
+# quote, or other joined text (documentation quoting a marker, a regex
+# that lists the words) matches neither shape.
+#
+# Scans INDEX content (git grep --cached): what is staged is what gets
+# committed, and a sparse checkout cannot hide a tracked file from the
+# gate. Binary files are skipped (-I) — markers are a source-comment
+# concern. Exit codes: 0 clean; 1 violations; 2 usage/config/collection
+# error; any git grep execution failure (exit >= 2) is a collection error,
+# never a silent pass.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GG_CHECK="todo-ban"
+# shellcheck source=lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+# shellcheck source=lib/settings.sh
+source "$SCRIPT_DIR/lib/settings.sh"
+
+usage() {
+  cat <<'EOF'
+usage: todo-ban [--excludes FILE]
+
+Flat ban on work markers (the words TODO, FIXME, HACK, XXX in
+comment-marker shapes) across all tracked files, scanned from the index.
+Prose that quotes or names a marker word does not fire.
+
+Configuration (env > .env.local > .vstack/settings.toml >
+vstack.settings.toml [env] > .env > default):
+  GROWTH_GUARDS_TODO_EXCLUDES   exclusion-list path (default tools/todo-ban-excludes)
+Flag --excludes overrides the path setting.
+
+Exit codes: 0 clean; 1 violations; 2 usage/config/collection error.
+EOF
+}
+
+EXCLUDES_OPT=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --excludes)
+      [ $# -ge 2 ] || gg_config_error "--excludes requires a path"
+      shift
+      EXCLUDES_OPT="$1"
+      ;;
+    --excludes=*) EXCLUDES_OPT="${1#--excludes=}" ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *) gg_config_error "unknown argument '$1' (see --help)" ;;
+  esac
+  shift
+done
+
+gg_repo_root_cd
+
+if [ -n "$EXCLUDES_OPT" ]; then
+  EXCLUDES_FILE="$EXCLUDES_OPT"
+else
+  EXCLUDES_FILE="$(gg_setting GROWTH_GUARDS_TODO_EXCLUDES "tools/todo-ban-excludes")" || exit 2
+fi
+EXCLUDES_FILE="$(gg_config_path "$EXCLUDES_FILE" "excludes")" || exit 2
+gg_load_excludes "$EXCLUDES_FILE"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# A comment leader counts only at line start or after whitespace, so the
+# `//` inside a URL or a path segment is never a boundary.
+MARKER_ERE='(^|[[:space:]])(TODO|FIXME|HACK|XXX)[:(]|(^|[[:space:]])(//|#|;|<!--|/\*)[[:space:]]*(TODO|FIXME|HACK|XXX)([:(]|[[:space:]]|$)'
+
+# Two phases: first the offending FILES (-l -z, so a path containing ':'
+# cannot garble parsing), then the numbered hits per file, where the known
+# path prefix strips exactly. The per-file pass is line-oriented, so a
+# path embedding a newline is out of scope for the DETAIL lines (the file
+# still fails via phase one).
+status=0
+git grep --cached -lIzE "$MARKER_ERE" -- . >"$TMP/files.z" || status=$?
+[ "$status" -le 1 ] || gg_collection_error "git grep failed scanning tracked files (exit $status)"
+
+violations=0
+while IFS= read -r -d '' f; do
+  gg_is_excluded "$f" && continue
+  hit_status=0
+  git grep --cached -nIE "$MARKER_ERE" -- ":(literal)$f" >"$TMP/hits" || hit_status=$?
+  # This file just listed as containing hits; anything but a clean re-scan
+  # (including "no matches") means the measurement is broken.
+  [ "$hit_status" -eq 0 ] || gg_collection_error "git grep could not detail the hits in '$f' (exit $hit_status)"
+  while IFS= read -r hit; do
+    echo "todo-ban FAIL work marker: $f:${hit#"$f":}"
+    echo "  remedies: do the work now, or move it to the tracker and delete the marker; vendored/generated trees belong in $EXCLUDES_FILE with a reason"
+    violations=$((violations + 1))
+  done <"$TMP/hits"
+done <"$TMP/files.z"
+
+if [ "$violations" -gt 0 ]; then
+  echo "todo-ban: $violations work marker(s) — excludes $EXCLUDES_FILE"
+  exit 1
+fi
+echo "todo-ban: OK — no work markers in tracked files"

--- a/skills/growth-guards/tests/bash32-portability.test.sh
+++ b/skills/growth-guards/tests/bash32-portability.test.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# growth-guards runs on consumer CI images and on macOS system Bash 3.2, so
+# shipped scripts may not use Bash 4+ builtins or syntax (mapfile/readarray,
+# associative arrays, automatic FD-allocation redirections, case-conversion
+# expansions).
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$TEST_DIR/../scripts" && pwd)"
+
+PATTERN='mapfile|readarray|declare -A|declare -gA|local -A'
+PATTERN="$PATTERN"'|(^|[^$])\{[A-Za-z_][A-Za-z0-9_]*\}[<>]'
+PATTERN="$PATTERN"'|\$\{[A-Za-z_][A-Za-z0-9_]*(\[[^]]*\])?(,,|\^\^)'
+
+violations="$(grep -rnE "$PATTERN" "$SCRIPTS_DIR" || true)"
+if [[ -n "$violations" ]]; then
+  echo "Bash 4+ constructs found in growth-guards scripts (must run under Bash 3.2):" >&2
+  printf '%s\n' "$violations" >&2
+  exit 1
+fi
+
+# Syntax-check every shipped script while we are here.
+fail=0
+for f in "$SCRIPTS_DIR"/growth-guards "$SCRIPTS_DIR"/todo-ban "$SCRIPTS_DIR"/byte-ceiling \
+  "$SCRIPTS_DIR"/suppression-ban "$SCRIPTS_DIR"/commit-msg "$SCRIPTS_DIR"/lib/*.sh; do
+  if ! bash -n "$f"; then
+    echo "FAIL: bash -n $f"
+    fail=1
+  fi
+done
+[ "$fail" -eq 0 ] || exit 1
+
+echo "pass: bash32-portability"

--- a/skills/growth-guards/tests/byte-ceiling.test.sh
+++ b/skills/growth-guards/tests/byte-ceiling.test.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# Pins for scripts/byte-ceiling: additions over the ceiling fail in every
+# mode, diff-scoping really is addition-only (modifications and renames
+# pass), lockfiles and excluded trees are exempt (each with a control
+# proving the exemption is what passed it), configuration resolves, and a
+# broken measurement is a collection error — never a pass.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
+BC="$SKILL_DIR/scripts/byte-ceiling"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+unset GROWTH_GUARDS_BYTE_CEILING_KB GROWTH_GUARDS_BYTE_EXCLUDES GROWTH_GUARDS_SETTINGS_FILE 2>/dev/null || true
+
+PASS=0
+FAIL=0
+ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
+
+new_repo() { # NAME
+  R="$TMP/$1"
+  mkdir -p "$R"
+  git -C "$R" -c init.defaultBranch=main init -q
+  git -C "$R" config user.email test@example.com
+  git -C "$R" config user.name test
+}
+
+mkbytes() { # PATH KB — file of KB*1024 bytes under $R
+  mkdir -p "$R/$(dirname "$1")"
+  dd if=/dev/zero of="$R/$1" bs=1024 count="$2" 2>/dev/null
+}
+
+run_bc() { # [args...] — run in $R at ceiling 1 KB; sets OUT and RC
+  OUT=""
+  RC=0
+  OUT="$(cd "$R" && GROWTH_GUARDS_BYTE_CEILING_KB=1 "$BC" "$@" 2>&1)" || RC=$?
+}
+
+run_bc_default() { # [args...] — run in $R at the built-in default ceiling
+  OUT=""
+  RC=0
+  OUT="$(cd "$R" && "$BC" "$@" 2>&1)" || RC=$?
+}
+
+echo "=== staged mode: additions over the ceiling fail; at-ceiling passes ==="
+new_repo staged
+mkbytes small.bin 1
+git -C "$R" add -A
+run_bc
+[ "$RC" -eq 0 ] && case "$OUT" in *"1 staged addition(s) checked"*) true ;; *) false ;; esac \
+  && ok "a 1 KB addition at ceiling 1 KB passes (at-ceiling is not over)" \
+  || bad "at-ceiling addition passes" "rc=$RC out=$OUT"
+
+mkbytes big.bin 2
+git -C "$R" add -A
+run_bc
+[ "$RC" -eq 1 ] && case "$OUT" in *"oversized file: big.bin — 2048 bytes"*"> ceiling 1 KB"*) true ;; *) false ;; esac \
+  && ok "a 2 KB addition at ceiling 1 KB fails, naming file/bytes/ceiling" \
+  || bad "oversized addition fails with bytes and ceiling" "rc=$RC out=$OUT"
+case "$OUT" in *"asset store, Git LFS, build-time generation"*) ok "diagnostic carries the remediation" ;; *) bad "diagnostic carries the remediation" "$OUT" ;; esac
+
+echo "=== the built-in default 200 KB is real, not vacuous ==="
+new_repo defreal
+mkbytes big.bin 205
+git -C "$R" add -A
+run_bc_default
+[ "$RC" -eq 1 ] && case "$OUT" in *"ceiling 200 KB"*) true ;; *) false ;; esac \
+  && ok "a 205 KB addition fails under the built-in default 200" \
+  || bad "default 200 can fail" "rc=$RC out=$OUT"
+rm "$R/big.bin"
+mkbytes ok.bin 100
+git -C "$R" add -A
+run_bc_default
+[ "$RC" -eq 0 ] && ok "a 100 KB addition passes under the default (control)" \
+  || bad "100 KB passes under the default" "rc=$RC out=$OUT"
+
+echo "=== diff-scoping: modification and rename are not additions ==="
+new_repo grown
+mkbytes seed.bin 3
+git -C "$R" add -A
+git -C "$R" commit -qm "seed: legacy file over any future ceiling"
+mkbytes seed.bin 5
+git -C "$R" add -A
+run_bc
+[ "$RC" -eq 0 ] && case "$OUT" in *"0 staged addition(s)"*) true ;; *) false ;; esac \
+  && ok "growing an existing tracked file is not an addition (staged mode)" \
+  || bad "modification is not an addition" "rc=$RC out=$OUT"
+git -C "$R" mv seed.bin moved.bin
+run_bc
+[ "$RC" -eq 0 ] && ok "renaming an existing large file is not an addition (rename detection pinned on)" \
+  || bad "rename is not an addition" "rc=$RC out=$OUT"
+cp "$R/moved.bin" "$R/second-copy.bin" 2>/dev/null || true
+printf 'x' >>"$R/second-copy.bin"
+git -C "$R" add -A
+run_bc
+[ "$RC" -eq 1 ] && case "$OUT" in *"second-copy.bin"*) true ;; *) false ;; esac \
+  && ok "control: a genuinely new large file beside the rename still fails" \
+  || bad "control: new large file fails beside the rename" "rc=$RC out=$OUT"
+new_repo copy
+mkbytes big.bin 3
+git -C "$R" add -A
+git -C "$R" commit -qm "seed: an oversized tracked file"
+cp "$R/big.bin" "$R/twin.bin"
+git -C "$R" add -A
+run_bc
+[ "$RC" -eq 1 ] && case "$OUT" in *"twin.bin"*) true ;; *) false ;; esac \
+  && ok "an exact copy of an oversized tracked file IS an addition (it duplicates the bytes; only renames are followed)" \
+  || bad "an exact copy is an addition" "rc=$RC out=$OUT"
+
+echo "=== --all: the full sweep gates legacy files the staged mode skips ==="
+new_repo legacy
+mkbytes old.bin 4
+git -C "$R" add -A
+git -C "$R" commit -qm "seed: legacy oversized file"
+run_bc
+[ "$RC" -eq 0 ] && ok "staged mode passes with nothing staged (legacy untouched)" \
+  || bad "staged mode passes on the legacy repo" "rc=$RC out=$OUT"
+run_bc --all
+[ "$RC" -eq 1 ] && case "$OUT" in *"old.bin"*"full sweep"*) true ;; *) false ;; esac \
+  && ok "--all fails on the legacy oversized file" || bad "--all fails on legacy" "rc=$RC out=$OUT"
+
+echo "=== --base REF: additions since the merge-base ==="
+git -C "$R" checkout -qb feature
+mkbytes feat.bin 2
+git -C "$R" add -A
+git -C "$R" commit -qm "feature adds an oversized file"
+run_bc --base main
+[ "$RC" -eq 1 ] && case "$OUT" in *"feat.bin"*"added since main"*) true ;; *) false ;; esac \
+  && ok "--base main fails on the branch's added file" || bad "--base fails on the added file" "rc=$RC out=$OUT"
+git -C "$R" checkout -q main
+run_bc --base main
+[ "$RC" -eq 0 ] && ok "control: --base main on main itself has no additions" \
+  || bad "control: --base with no additions passes" "rc=$RC out=$OUT"
+run_bc --base no-such-ref
+[ "$RC" -eq 2 ] && ok "an unknown --base ref is exit 2" || bad "unknown --base ref is exit 2" "rc=$RC out=$OUT"
+
+echo "=== lockfiles are exempt by basename; same bytes elsewhere are not ==="
+new_repo lock
+mkbytes package-lock.json 2
+git -C "$R" add -A
+run_bc
+[ "$RC" -eq 0 ] && ok "an oversized package-lock.json passes (built-in lockfile exemption)" \
+  || bad "lockfile exemption" "rc=$RC out=$OUT"
+cp "$R/package-lock.json" "$R/data.json"
+git -C "$R" add -A
+run_bc
+[ "$RC" -eq 1 ] && case "$OUT" in *"data.json"*) true ;; *) false ;; esac \
+  && ok "control: the same bytes as data.json fail — the exemption is the basename, not the size" \
+  || bad "control: non-lockfile with same bytes fails" "rc=$RC out=$OUT"
+
+echo "=== excludes: declared asset trees, reason mandatory ==="
+new_repo assets
+mkdir -p "$R/tools"
+mkbytes assets/demo.gif 2
+git -C "$R" add -A
+run_bc
+[ "$RC" -eq 1 ] && ok "control: the asset fails without an excludes row" \
+  || bad "control: asset fails without excludes" "rc=$RC out=$OUT"
+printf 'assets/*\tdemo media\n' >"$R/tools/byte-ceiling-excludes"
+git -C "$R" add -A
+run_bc
+[ "$RC" -eq 0 ] && ok "the excludes row exempts the declared asset tree" \
+  || bad "excludes row exempts the asset tree" "rc=$RC out=$OUT"
+printf 'assets/*\n' >"$R/tools/byte-ceiling-excludes"
+git -C "$R" add -A
+run_bc
+[ "$RC" -eq 2 ] && ok "a pattern without a reason is exit 2" || bad "pattern without a reason is exit 2" "rc=$RC out=$OUT"
+
+echo "=== configuration errors ==="
+new_repo cfg
+printf 'x\n' >"$R/f.txt"
+git -C "$R" add -A
+OUT="$(cd "$R" && GROWTH_GUARDS_BYTE_CEILING_KB=abc "$BC" 2>&1)" && RC=0 || RC=$?
+[ "$RC" -eq 2 ] && ok "non-numeric ceiling is exit 2" || bad "non-numeric ceiling is exit 2" "rc=$RC out=$OUT"
+OUT="$(cd "$R" && GROWTH_GUARDS_BYTE_CEILING_KB=0 "$BC" 2>&1)" && RC=0 || RC=$?
+[ "$RC" -eq 2 ] && ok "zero ceiling is exit 2" || bad "zero ceiling is exit 2" "rc=$RC out=$OUT"
+run_bc --no-such-flag
+[ "$RC" -eq 2 ] && ok "unknown flag is exit 2" || bad "unknown flag is exit 2" "rc=$RC out=$OUT"
+
+echo "=== settings file resolution ==="
+printf '[env]\nGROWTH_GUARDS_BYTE_CEILING_KB = "3"\n' >"$R/vstack.settings.toml"
+mkbytes big.bin 4
+git -C "$R" add -A
+run_bc_default
+[ "$RC" -eq 1 ] && case "$OUT" in *"ceiling 3 KB"*) true ;; *) false ;; esac \
+  && ok "vstack.settings.toml overrides the default (4 KB > 3 fails; 200 would have passed)" \
+  || bad "settings file overrides the default" "rc=$RC out=$OUT"
+OUT="$(cd "$R" && GROWTH_GUARDS_BYTE_CEILING_KB=5 "$BC" 2>&1)" && RC=0 || RC=$?
+[ "$RC" -eq 0 ] && ok "environment overrides the settings file (5 passes where 3 failed)" \
+  || bad "environment overrides the settings file" "rc=$RC out=$OUT"
+
+echo "=== settings: an unreadable source fails loud, never falls through ==="
+if [ "$(id -u)" -eq 0 ]; then
+  printf '  skip  unreadable-source pins need a non-root reader (chmod 000 cannot deny root)\n'
+else
+  printf 'GROWTH_GUARDS_BYTE_CEILING_KB=5\n' >"$R/.env.local"
+  chmod 000 "$R/.env.local"
+  run_bc_default
+  [ "$RC" -eq 2 ] && case "$OUT" in *"unreadable while resolving a setting"*) true ;; *) false ;; esac \
+    && ok "an unreadable .env.local is exit 2 (falling through would have read 3 from the settings file and exited 1)" \
+    || bad "unreadable .env.local is exit 2" "rc=$RC out=$OUT"
+  chmod 600 "$R/.env.local"
+  run_bc_default
+  [ "$RC" -eq 0 ] && ok "control: the same .env.local, readable, supplies 5 and the 4 KB file passes" \
+    || bad "control: readable .env.local supplies the value" "rc=$RC out=$OUT"
+  rm "$R/.env.local"
+fi
+
+echo "=== fail-closed: a broken blob measurement terminates, never passes ==="
+new_repo measure
+mkbytes big.bin 2
+git -C "$R" add -A
+run_bc
+[ "$RC" -eq 1 ] && ok "shim-free control: the oversized staged file really fails" \
+  || bad "shim-free control fails on the oversized file" "rc=$RC out=$OUT"
+REAL_GIT="$(command -v git)"
+GIT_SHIM="$TMP/git-shim"
+mkdir -p "$GIT_SHIM"
+cat >"$GIT_SHIM/git" <<EOF
+#!/usr/bin/env bash
+if [ "\${1:-}" = "cat-file" ] && [ "\${2:-}" = "-s" ]; then
+  echo "fatal: simulated object read failure" >&2
+  exit 128
+fi
+exec "$REAL_GIT" "\$@"
+EOF
+chmod +x "$GIT_SHIM/git"
+OUT="$(cd "$R" && PATH="$GIT_SHIM:$PATH" GROWTH_GUARDS_BYTE_CEILING_KB=1 "$BC" 2>&1)" && RC=0 || RC=$?
+[ "$RC" -eq 2 ] && case "$OUT" in *"cannot read blob"*"big.bin"*) true ;; *) false ;; esac \
+  && ok "an unmeasurable blob is a collection error: exit 2, diagnostic names the file" \
+  || bad "an unmeasurable blob is a collection error naming the file" "rc=$RC out=$OUT"
+case "$OUT" in *"byte-ceiling: OK"*) bad "no OK verdict may accompany a broken measurement" "$OUT" ;; *) ok "no OK verdict accompanies the broken measurement" ;; esac
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/skills/growth-guards/tests/commit-msg.test.sh
+++ b/skills/growth-guards/tests/commit-msg.test.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Pins for scripts/commit-msg: the conventional header shape in both
+# directions, the two MUSTs from the family contract — uppercase issue
+# keys in scopes pass, git-generated messages pass — plus header
+# extraction, type-list configuration, and the exit-2 usage/collection
+# lanes.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
+CM="$SKILL_DIR/scripts/commit-msg"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+unset GROWTH_GUARDS_COMMIT_TYPES GROWTH_GUARDS_SETTINGS_FILE 2>/dev/null || true
+
+PASS=0
+FAIL=0
+ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
+
+R="$TMP/repo"
+mkdir -p "$R"
+git -C "$R" -c init.defaultBranch=main init -q
+git -C "$R" config user.email test@example.com
+git -C "$R" config user.name test
+
+run_stdin() { # MESSAGE [env-assignment] — feed via stdin; sets OUT and RC
+  OUT=""
+  RC=0
+  OUT="$(cd "$R" && printf '%s\n' "$1" | env ${2:+"$2"} "$CM" 2>&1)" || RC=$?
+}
+
+expect_pass() { # HEADER DESC [env]
+  run_stdin "$1" "${3:-}"
+  [ "$RC" -eq 0 ] && ok "$2" || bad "$2" "rc=$RC out=$OUT"
+}
+
+expect_fail() { # HEADER DESC [env]
+  run_stdin "$1" "${3:-}"
+  [ "$RC" -eq 1 ] && ok "$2" || bad "$2" "rc=$RC out=$OUT"
+}
+
+echo "=== conventional headers pass ==="
+expect_pass 'feat: add the gate' "bare type"
+expect_pass 'fix(cli): repair the trailing newline' "lowercase scope"
+expect_pass 'fix(ABC-123): tighten the gate' "MUST: uppercase issue key in the scope"
+expect_pass 'fix(#123): case-fold open-terminal issue IDs' "issue-number scope"
+expect_pass 'feat(api)!: drop the legacy endpoint' "breaking-change marker"
+expect_pass 'chore(deps, ci): bump the runner image' "multi-part scope with comma and space"
+expect_pass 'refactor(tui/render): split the paint pass' "slashed scope"
+
+echo "=== git-generated headers pass unchanged (MUST) ==="
+expect_pass 'Merge branch feature into main' "Merge"
+expect_pass 'Revert "feat: add the gate"' "Revert"
+expect_pass 'Reapply "feat: add the gate"' "Reapply"
+expect_pass 'fixup! fix(cli): repair the newline' "fixup!"
+expect_pass 'squash! fix(cli): repair the newline' "squash!"
+expect_pass 'amend! fix(cli): repair the newline' "amend!"
+
+echo "=== non-conventional headers fail ==="
+expect_fail 'Add stuff' "bare imperative subject"
+expect_fail 'Feat: uppercase type' "uppercase type"
+expect_fail 'feat add the gate' "missing colon"
+expect_fail 'feat:no space after colon' "missing space after the colon"
+expect_fail 'feat: ' "empty subject"
+expect_fail 'wip: not a known type' "unknown type"
+expect_fail 'feat(): empty scope' "empty scope parens"
+run_stdin 'Add stuff'
+case "$OUT" in *"expected: type(scope)!: subject"*"types: build chore ci docs feat fix perf refactor revert style test"*) ok "diagnostic names the shape and the type list" ;; *) bad "diagnostic names the shape and types" "$OUT" ;; esac
+case "$OUT" in *"fix(ABC-123)"*) ok "diagnostic shows the uppercase-key example" ;; *) bad "diagnostic shows the uppercase-key example" "$OUT" ;; esac
+
+echo "=== header extraction ==="
+expect_pass "$(printf 'feat: subject line\n\nbody paragraph\nmore body')" "multi-line message: only the header is judged"
+expect_pass "$(printf '# comment from the template\n\nfeat: subject after comments')" "comment and blank lines before the header are skipped"
+expect_fail '' "empty message fails"
+run_stdin "$(printf 'feat: crlf subject\r')"
+[ "$RC" -eq 0 ] && ok "a CRLF header is stripped before matching" || bad "CRLF header passes" "rc=$RC out=$OUT"
+
+echo "=== file mode (the git hook contract) ==="
+printf 'fix(VST-214): ship the check family\n' >"$TMP/msg"
+OUT="$(cd "$R" && "$CM" "$TMP/msg" 2>&1)" && RC=0 || RC=$?
+[ "$RC" -eq 0 ] && ok "a message FILE argument is read like the hook passes it" || bad "file mode passes" "rc=$RC out=$OUT"
+OUT="$(cd "$R" && "$CM" "$TMP/no-such-msg" 2>&1)" && RC=0 || RC=$?
+[ "$RC" -eq 2 ] && ok "a missing message file is exit 2" || bad "missing message file is exit 2" "rc=$RC out=$OUT"
+OUT="$(cd "$R" && "$CM" "$TMP/msg" extra 2>&1)" && RC=0 || RC=$?
+[ "$RC" -eq 2 ] && ok "two positional arguments are exit 2" || bad "two positionals are exit 2" "rc=$RC out=$OUT"
+
+echo "=== the type list is configuration, and it is validated ==="
+expect_pass 'release: cut 2.6.6' "custom type list admits its types" "GROWTH_GUARDS_COMMIT_TYPES=feat release"
+expect_fail 'fix: no longer a type' "custom type list rejects everything else (control)" "GROWTH_GUARDS_COMMIT_TYPES=feat release"
+run_stdin 'feat: x' "GROWTH_GUARDS_COMMIT_TYPES=Feat"
+[ "$RC" -eq 2 ] && ok "a non-lowercase type entry is exit 2" || bad "bad type entry is exit 2" "rc=$RC out=$OUT"
+run_stdin 'feat: x' "GROWTH_GUARDS_COMMIT_TYPES= "
+[ "$RC" -eq 2 ] && ok "an empty type list is exit 2" || bad "empty type list is exit 2" "rc=$RC out=$OUT"
+
+echo "=== settings file resolution ==="
+printf '[env]\nGROWTH_GUARDS_COMMIT_TYPES = "docs"\n' >"$R/vstack.settings.toml"
+run_stdin 'docs: settings-admitted type'
+[ "$RC" -eq 0 ] && ok "vstack.settings.toml supplies the type list" || bad "settings file supplies the types" "rc=$RC out=$OUT"
+run_stdin 'feat: settings-rejected type'
+[ "$RC" -eq 1 ] && ok "control: the settings-restricted list really rejects other types" \
+  || bad "control: settings-restricted list rejects" "rc=$RC out=$OUT"
+rm "$R/vstack.settings.toml"
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/skills/growth-guards/tests/dispatcher.test.sh
+++ b/skills/growth-guards/tests/dispatcher.test.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Pins for scripts/growth-guards (the dispatcher): the batch runs exactly
+# the enabled checks and aggregates fail-closed (any incomplete check is
+# exit 2, any violation exit 1), single-check invocation passes flags and
+# exit codes through, and the check-list configuration is validated.
+#
+# Marker words are assembled from split tokens so this file never contains
+# a marker shape itself.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
+GG="$SKILL_DIR/scripts/growth-guards"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+unset GROWTH_GUARDS_CHECKS GROWTH_GUARDS_TODO_EXCLUDES GROWTH_GUARDS_BYTE_CEILING_KB \
+  GROWTH_GUARDS_BYTE_EXCLUDES GROWTH_GUARDS_SUPPRESSION_EXCLUDES \
+  GROWTH_GUARDS_SUPPRESSION_BASELINE GROWTH_GUARDS_COMMIT_TYPES \
+  GROWTH_GUARDS_SETTINGS_FILE 2>/dev/null || true
+
+TD="TO""DO"
+
+PASS=0
+FAIL=0
+ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
+
+new_repo() { # NAME
+  R="$TMP/$1"
+  mkdir -p "$R"
+  git -C "$R" -c init.defaultBranch=main init -q
+  git -C "$R" config user.email test@example.com
+  git -C "$R" config user.name test
+}
+
+run_gg() { # [VAR=val] -- [args...] — run in $R; sets OUT and RC
+  local envs=() args=()
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --)
+        shift
+        args=("$@")
+        break
+        ;;
+      *) envs+=("$1") ;;
+    esac
+    shift
+  done
+  OUT=""
+  RC=0
+  OUT="$(cd "$R" && env ${envs[@]+"${envs[@]}"} "$GG" ${args[@]+"${args[@]}"} 2>&1)" || RC=$?
+}
+
+echo "=== batch: a clean repo runs every default check and passes ==="
+new_repo clean
+printf 'fn main() {}\n' >"$R/ok.rs"
+git -C "$R" add -A
+run_gg
+[ "$RC" -eq 0 ] \
+  && case "$OUT" in *"growth-guards: todo-ban"*"growth-guards: byte-ceiling"*"growth-guards: suppression-ban"*"growth-guards: OK"*) true ;; *) false ;; esac \
+  && ok "the batch runs todo-ban, byte-ceiling, suppression-ban and reports OK" \
+  || bad "batch runs the three default checks" "rc=$RC out=$OUT"
+run_gg -- all
+[ "$RC" -eq 0 ] && ok "'all' is the same batch" || bad "'all' is the same batch" "rc=$RC out=$OUT"
+
+echo "=== batch: one violating check makes the batch exit 1 ==="
+printf '// %s: planted for the dispatcher\n' "$TD" >"$R/planted.rs"
+git -C "$R" add -A
+run_gg
+[ "$RC" -eq 1 ] && case "$OUT" in *"growth-guards: violations"*) true ;; *) false ;; esac \
+  && ok "a todo-ban violation aggregates to batch exit 1" \
+  || bad "violation aggregates to exit 1" "rc=$RC out=$OUT"
+
+echo "=== GROWTH_GUARDS_CHECKS narrows the batch (and that is provable) ==="
+run_gg GROWTH_GUARDS_CHECKS=byte-ceiling --
+[ "$RC" -eq 0 ] && case "$OUT" in *todo-ban*) false ;; *"growth-guards: byte-ceiling"*) true ;; *) false ;; esac \
+  && ok "with only byte-ceiling enabled, the planted marker no longer fails the batch" \
+  || bad "narrowed batch skips todo-ban" "rc=$RC out=$OUT"
+run_gg
+[ "$RC" -eq 1 ] && ok "control: the default batch still fails on the same fixture" \
+  || bad "control: default batch fails on the fixture" "rc=$RC out=$OUT"
+git -C "$R" rm -q --cached planted.rs
+rm "$R/planted.rs"
+
+echo "=== check-list validation fails loud ==="
+run_gg GROWTH_GUARDS_CHECKS=commit-msg --
+[ "$RC" -eq 2 ] && case "$OUT" in *"cannot run in the batch"*) true ;; *) false ;; esac \
+  && ok "commit-msg in the batch list is exit 2 with the hook pointer" \
+  || bad "commit-msg in the batch list is exit 2" "rc=$RC out=$OUT"
+run_gg GROWTH_GUARDS_CHECKS=no-such-check --
+[ "$RC" -eq 2 ] && case "$OUT" in *"unknown check 'no-such-check'"*) true ;; *) false ;; esac \
+  && ok "an unknown name in the check list is exit 2" \
+  || bad "unknown name in the check list is exit 2" "rc=$RC out=$OUT"
+run_gg "GROWTH_GUARDS_CHECKS= " --
+[ "$RC" -eq 2 ] && ok "an empty check list is exit 2" || bad "empty check list is exit 2" "rc=$RC out=$OUT"
+
+echo "=== batch aggregation is fail-closed: an incomplete check is exit 2 ==="
+run_gg GROWTH_GUARDS_BYTE_CEILING_KB=abc --
+[ "$RC" -eq 2 ] && case "$OUT" in *"did not complete (exit 2)"*"could not complete every check"*) true ;; *) false ;; esac \
+  && ok "a check that exits 2 makes the whole batch exit 2, named in the summary" \
+  || bad "incomplete check aggregates to exit 2" "rc=$RC out=$OUT"
+
+echo "=== single-check invocation: exit codes and flags pass through ==="
+run_gg -- todo-ban
+[ "$RC" -eq 0 ] && case "$OUT" in "todo-ban: OK"*) true ;; *) false ;; esac \
+  && ok "a single check runs alone with its own output" || bad "single check runs alone" "rc=$RC out=$OUT"
+run_gg -- byte-ceiling --all
+[ "$RC" -eq 0 ] && case "$OUT" in *"full sweep"*) true ;; *) false ;; esac \
+  && ok "flags pass through to the named check (--all reached byte-ceiling)" \
+  || bad "flags pass through" "rc=$RC out=$OUT"
+OUT="$(cd "$R" && printf 'feat: dispatched\n' | "$GG" commit-msg 2>&1)" && RC=0 || RC=$?
+[ "$RC" -eq 0 ] && ok "commit-msg IS invocable by name (only the batch refuses it)" \
+  || bad "commit-msg invocable by name" "rc=$RC out=$OUT"
+run_gg -- no-such-check
+[ "$RC" -eq 2 ] && case "$OUT" in *"unknown check 'no-such-check'"*) true ;; *) false ;; esac \
+  && ok "an unknown check name is exit 2 naming the known set" \
+  || bad "unknown check name is exit 2" "rc=$RC out=$OUT"
+run_gg -- all --extra
+[ "$RC" -eq 2 ] && ok "'all' with extra arguments is exit 2" || bad "'all' with extras is exit 2" "rc=$RC out=$OUT"
+run_gg -- --help
+[ "$RC" -eq 0 ] && case "$OUT" in *"usage: growth-guards"*) true ;; *) false ;; esac \
+  && ok "--help prints usage at exit 0" || bad "--help prints usage" "rc=$RC out=$OUT"
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/skills/growth-guards/tests/suppression-ban.test.sh
+++ b/skills/growth-guards/tests/suppression-ban.test.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+# Pins for scripts/suppression-ban: every blanket lane fires with its legal
+# per-line counterpart proven to pass, the bare-allow ratchet fails in all
+# directions (new, grow, loose, stale), --update tightens only, baseline
+# hygiene is enforced, and a broken scan is a collection error — never a
+# pass.
+#
+# Suppression pragmas appear verbatim in fixtures below: the check is
+# pathspec-scoped to language extensions, so this .sh file is never
+# scanned by it.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
+SB="$SKILL_DIR/scripts/suppression-ban"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+unset GROWTH_GUARDS_SUPPRESSION_EXCLUDES GROWTH_GUARDS_SUPPRESSION_BASELINE GROWTH_GUARDS_SETTINGS_FILE 2>/dev/null || true
+
+PASS=0
+FAIL=0
+ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
+
+new_repo() { # NAME
+  R="$TMP/$1"
+  mkdir -p "$R"
+  git -C "$R" -c init.defaultBranch=main init -q
+  git -C "$R" config user.email test@example.com
+  git -C "$R" config user.name test
+}
+
+run_sb() { # [args...] — run in $R; sets OUT and RC
+  OUT=""
+  RC=0
+  OUT="$(cd "$R" && "$SB" "$@" 2>&1)" || RC=$?
+}
+
+echo "=== control: a clean multi-language repo passes ==="
+new_repo clean
+printf 'fn main() {}\n' >"$R/ok.rs"
+printf 'x = 1\n' >"$R/ok.py"
+printf 'const x = 1;\n' >"$R/ok.ts"
+printf 'package main\n' >"$R/ok.go"
+git -C "$R" add -A
+run_sb
+[ "$RC" -eq 0 ] && case "$OUT" in *"suppression-ban: OK"*) true ;; *) false ;; esac \
+  && ok "clean repo passes" || bad "clean repo passes" "rc=$RC out=$OUT"
+
+echo "=== rust: module-wide inner allow fails; per-item forms stay legal ==="
+printf '#![allow(dead_code)]\nfn main() {}\n' >"$R/ok.rs"
+git -C "$R" add -A
+run_sb
+[ "$RC" -eq 1 ] && case "$OUT" in *"module-wide rust allow: ok.rs:1:"*) true ;; *) false ;; esac \
+  && ok "a crate/module-wide inner allow fails, naming file:line" \
+  || bad "module-wide inner allow fails" "rc=$RC out=$OUT"
+case "$OUT" in *"annotate the surviving sites per line with a stated reason"*) ok "diagnostic carries the remediation" ;; *) bad "diagnostic carries the remediation" "$OUT" ;; esac
+
+printf '#[allow(clippy::too_many_arguments)]\nfn f() {}\n' >"$R/ok.rs"
+git -C "$R" add -A
+run_sb
+[ "$RC" -eq 0 ] && ok "a per-item outer attribute for a named lint passes" \
+  || bad "per-item outer attribute passes" "rc=$RC out=$OUT"
+
+printf '#[allow(dead_code, reason = "kept for the public API surface")]\nfn f() {}\n' >"$R/ok.rs"
+git -C "$R" add -A
+run_sb
+[ "$RC" -eq 0 ] && ok "a dead_code allow WITH a stated reason passes (the reasoned form is the legal one)" \
+  || bad "reasoned dead_code allow passes" "rc=$RC out=$OUT"
+
+echo "=== rust ratchet: compound and spaced bare allows count; a reason anywhere exempts ==="
+printf '#[allow(dead_code, unused_variables)]\nfn f() {}\n#[allow( dead_code )]\nfn g() {}\n#[allow(clippy::too_many_arguments , dead_code)]\nfn h() {}\n' >"$R/ok.rs"
+git -C "$R" add -A
+run_sb
+[ "$RC" -eq 1 ] && case "$OUT" in *"new bare allow: ok.rs — 3 reasonless"*) true ;; *) false ;; esac \
+  && ok "compound, spaced, and lint-path-compound bare allows each count once (3 reasonless)" \
+  || bad "compound/spaced bare allows count" "rc=$RC out=$OUT"
+printf '#[allow(dead_code, unused_variables, reason = "both kept for the trait surface")]\nfn f() {}\n' >"$R/ok.rs"
+git -C "$R" add -A
+run_sb
+[ "$RC" -eq 0 ] && ok "a compound allow carrying a reason stays exempt" \
+  || bad "compound allow with a reason is exempt" "rc=$RC out=$OUT"
+
+echo "=== rust ratchet: bare allows fail as NEW without a baseline row ==="
+printf '#[allow(dead_code)]\nfn f() {}\n#[allow(unused_variables)]\nfn g() {}\n' >"$R/ok.rs"
+git -C "$R" add -A
+run_sb
+[ "$RC" -eq 1 ] && case "$OUT" in *"new bare allow: ok.rs — 2 reasonless"*) true ;; *) false ;; esac \
+  && ok "bare dead_code/unused allows fail as NEW with their count" \
+  || bad "bare allows fail as NEW" "rc=$RC out=$OUT"
+case "$OUT" in *"hand-added baseline row in this diff"*) ok "NEW diagnostic names the freeze remedy" ;; *) bad "NEW diagnostic names the freeze remedy" "$OUT" ;; esac
+
+echo "=== rust ratchet: a baseline row freezes the count; every direction fires ==="
+mkdir -p "$R/tools"
+printf 'ok.rs\t2\n' >"$R/tools/suppression-baseline.tsv"
+git -C "$R" add -A
+run_sb
+[ "$RC" -eq 0 ] && ok "the frozen count at exactly its row passes" || bad "frozen count passes" "rc=$RC out=$OUT"
+
+printf '#[allow(dead_code)]\nfn f() {}\n#[allow(unused_variables)]\nfn g() {}\n#[allow(unused)]\nfn h() {}\n' >"$R/ok.rs"
+git -C "$R" add -A
+run_sb
+[ "$RC" -eq 1 ] && case "$OUT" in *"bare allows grew: ok.rs — 3 attribute(s) > baseline 2"*) true ;; *) false ;; esac \
+  && ok "growth past the row fails (GROW)" || bad "growth past the row fails" "rc=$RC out=$OUT"
+
+printf '#[allow(dead_code)]\nfn f() {}\n' >"$R/ok.rs"
+git -C "$R" add -A
+run_sb
+[ "$RC" -eq 1 ] && case "$OUT" in *"baseline looser than reality: ok.rs — baseline 2 > actual 1"*) true ;; *) false ;; esac \
+  && ok "a loose row fails (LOOSE) — slack is a failure, not headroom" \
+  || bad "loose row fails" "rc=$RC out=$OUT"
+
+run_sb --update
+[ "$RC" -eq 0 ] && [ "$(cat "$R/tools/suppression-baseline.tsv")" = "$(printf 'ok.rs\t1')" ] \
+  && ok "--update tightens 2 -> 1 and the re-check passes" \
+  || bad "--update tightens 2 -> 1" "rc=$RC row=$(cat "$R/tools/suppression-baseline.tsv") out=$OUT"
+
+printf 'fn f() {}\n' >"$R/ok.rs"
+git -C "$R" add -A
+run_sb
+[ "$RC" -eq 1 ] && case "$OUT" in *"stale baseline row: ok.rs"*) true ;; *) false ;; esac \
+  && ok "a row with no bare allows left fails (STALE)" || bad "stale row fails" "rc=$RC out=$OUT"
+run_sb --update
+[ "$RC" -eq 0 ] && [ ! -s "$R/tools/suppression-baseline.tsv" ] \
+  && ok "--update drops the stale row" || bad "--update drops the stale row" "rc=$RC out=$OUT"
+
+echo "=== --update never raises: a grown count keeps its row and keeps failing ==="
+printf '#[allow(dead_code)]\nfn f() {}\n#[allow(dead_code)]\nfn g() {}\n' >"$R/ok.rs"
+printf 'ok.rs\t1\n' >"$R/tools/suppression-baseline.tsv"
+git -C "$R" add -A
+run_sb --update
+[ "$RC" -eq 1 ] && [ "$(cat "$R/tools/suppression-baseline.tsv")" = "$(printf 'ok.rs\t1')" ] \
+  && case "$OUT" in *"growth is a hand-edit, never --update"*) true ;; *) false ;; esac \
+  && ok "--update keeps the grown row at 1 and still exits 1" \
+  || bad "--update never raises a row" "rc=$RC row=$(cat "$R/tools/suppression-baseline.tsv") out=$OUT"
+printf 'fn f() {}\n' >"$R/ok.rs"
+rm "$R/tools/suppression-baseline.tsv"
+git -C "$R" add -A
+
+echo "=== python: file-level noqa fails; per-line with codes passes ==="
+printf '# ruff: noqa\nx = 1\n' >"$R/ok.py"
+git -C "$R" add -A
+run_sb
+[ "$RC" -eq 1 ] && case "$OUT" in *"file-level noqa: ok.py:1:"*) true ;; *) false ;; esac \
+  && ok "a file-level ruff noqa fails" || bad "file-level ruff noqa fails" "rc=$RC out=$OUT"
+printf '# flake8: noqa\nx = 1\n' >"$R/ok.py"
+git -C "$R" add -A
+run_sb
+[ "$RC" -eq 1 ] && ok "a file-level flake8 noqa fails" || bad "file-level flake8 noqa fails" "rc=$RC out=$OUT"
+printf 'import os  # noqa: F401 -- re-exported for the package API\n' >"$R/ok.py"
+git -C "$R" add -A
+run_sb
+[ "$RC" -eq 0 ] && ok "a per-line noqa naming its code passes" || bad "per-line noqa with codes passes" "rc=$RC out=$OUT"
+
+echo "=== eslint: the bare block form fails; named rules pass ==="
+printf '/* eslint-disable */\nconst x = 1;\n' >"$R/ok.ts"
+git -C "$R" add -A
+run_sb
+[ "$RC" -eq 1 ] && case "$OUT" in *"blanket eslint-disable: ok.ts:1:"*) true ;; *) false ;; esac \
+  && ok "the bare eslint-disable block fails" || bad "bare eslint-disable fails" "rc=$RC out=$OUT"
+printf '/* eslint-disable no-console -- CLI entry point logs by design */\nconsole.log(1);\n' >"$R/ok.ts"
+git -C "$R" add -A
+run_sb
+[ "$RC" -eq 0 ] && ok "eslint-disable naming its rule passes" || bad "named eslint-disable passes" "rc=$RC out=$OUT"
+
+echo "=== go: bare nolint and nolint:all fail; a named linter passes ==="
+printf 'package main //nolint:all\n' >"$R/ok.go"
+git -C "$R" add -A
+run_sb
+[ "$RC" -eq 1 ] && case "$OUT" in *"blanket nolint: ok.go:1:"*) true ;; *) false ;; esac \
+  && ok "nolint:all fails" || bad "nolint:all fails" "rc=$RC out=$OUT"
+printf 'package main //nolint\n' >"$R/ok.go"
+git -C "$R" add -A
+run_sb
+[ "$RC" -eq 1 ] && ok "bare nolint (no linter named) fails" || bad "bare nolint fails" "rc=$RC out=$OUT"
+printf 'package main //nolint:gosec // fixture path is test-local\n' >"$R/ok.go"
+git -C "$R" add -A
+run_sb
+[ "$RC" -eq 0 ] && ok "nolint naming its linter with a reason passes" || bad "named nolint passes" "rc=$RC out=$OUT"
+
+echo "=== excludes: vendored trees, reason mandatory ==="
+new_repo exc
+mkdir -p "$R/vendor" "$R/tools"
+printf '#![allow(dead_code)]\nfn v() {}\n' >"$R/vendor/lib.rs"
+git -C "$R" add -A
+run_sb
+[ "$RC" -eq 1 ] && ok "control: the vendored blanket allow fails without an excludes row" \
+  || bad "control: vendored blanket fails without excludes" "rc=$RC out=$OUT"
+printf 'vendor/*\tvendored third-party code\n' >"$R/tools/suppression-ban-excludes"
+git -C "$R" add -A
+run_sb
+[ "$RC" -eq 0 ] && ok "the excludes row silences the vendored tree (blanket and ratchet)" \
+  || bad "excludes row silences the vendored tree" "rc=$RC out=$OUT"
+printf 'vendor/*\n' >"$R/tools/suppression-ban-excludes"
+git -C "$R" add -A
+run_sb
+[ "$RC" -eq 2 ] && ok "a pattern without a reason is exit 2" || bad "pattern without a reason is exit 2" "rc=$RC out=$OUT"
+
+echo "=== baseline hygiene is enforced, not repaired silently ==="
+new_repo hygiene
+printf '#[allow(dead_code)]\nfn f() {}\n' >"$R/a.rs"
+printf '#[allow(dead_code)]\nfn f() {}\n' >"$R/b.rs"
+mkdir -p "$R/tools"
+printf 'b.rs\t1\na.rs\t1\n' >"$R/tools/suppression-baseline.tsv"
+git -C "$R" add -A
+run_sb
+[ "$RC" -eq 2 ] && case "$OUT" in *"LC_ALL=C sorted"*) true ;; *) false ;; esac \
+  && ok "unsorted baseline is exit 2" || bad "unsorted baseline is exit 2" "rc=$RC out=$OUT"
+printf 'a.rs\t1\na.rs\t2\nb.rs\t1\n' >"$R/tools/suppression-baseline.tsv"
+run_sb
+[ "$RC" -eq 2 ] && case "$OUT" in *"duplicate"*) true ;; *) false ;; esac \
+  && ok "duplicate baseline path is exit 2" || bad "duplicate baseline path is exit 2" "rc=$RC out=$OUT"
+printf 'a.rs\tnope\n' >"$R/tools/suppression-baseline.tsv"
+run_sb
+[ "$RC" -eq 2 ] && case "$OUT" in *"malformed row"*) true ;; *) false ;; esac \
+  && ok "non-numeric baseline count is exit 2" || bad "non-numeric count is exit 2" "rc=$RC out=$OUT"
+printf 'a.rs\t1\nb.rs\t1\n' >"$R/tools/suppression-baseline.tsv"
+run_sb
+[ "$RC" -eq 0 ] && ok "well-formed sorted baseline passes (control for the hygiene gates)" \
+  || bad "well-formed baseline passes" "rc=$RC out=$OUT"
+
+echo "=== fail-closed: a broken scan terminates, never passes ==="
+REAL_GIT="$(command -v git)"
+GIT_SHIM="$TMP/git-shim"
+mkdir -p "$GIT_SHIM"
+cat >"$GIT_SHIM/git" <<EOF
+#!/usr/bin/env bash
+for a in "\$@"; do
+  if [ "\$a" = "grep" ]; then
+    echo "git grep: simulated execution failure" >&2
+    exit 128
+  fi
+done
+exec "$REAL_GIT" "\$@"
+EOF
+chmod +x "$GIT_SHIM/git"
+OUT="$(cd "$R" && PATH="$GIT_SHIM:$PATH" "$SB" 2>&1)" && RC=0 || RC=$?
+[ "$RC" -eq 2 ] && case "$OUT" in *"git grep failed"*) true ;; *) false ;; esac \
+  && ok "a git grep execution failure is a collection error: exit 2" \
+  || bad "a git grep execution failure is a collection error" "rc=$RC out=$OUT"
+case "$OUT" in *"suppression-ban: OK"*) bad "no OK verdict may accompany a broken scan" "$OUT" ;; *) ok "no OK verdict accompanies the broken scan" ;; esac
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/skills/growth-guards/tests/todo-ban.test.sh
+++ b/skills/growth-guards/tests/todo-ban.test.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# Pins for scripts/todo-ban: both marker shapes fire, prose that quotes or
+# names a marker word does not, excludes need reasons, and a broken scan is
+# a collection error — never a pass. Every green assertion is paired with a
+# control that proves it can fail.
+#
+# Marker words are assembled from split tokens throughout so this test
+# file never contains a marker shape itself — the vstack repo runs
+# todo-ban over its own tree, tests included.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
+TB="$SKILL_DIR/scripts/todo-ban"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# Hermetic: a leaked setting would mask every case below.
+unset GROWTH_GUARDS_TODO_EXCLUDES GROWTH_GUARDS_SETTINGS_FILE 2>/dev/null || true
+
+TD="TO""DO"
+FX="FIX""ME"
+HK="HA""CK"
+XX="XX""X"
+
+PASS=0
+FAIL=0
+ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
+
+new_repo() { # NAME — fresh fixture repo in $R
+  R="$TMP/$1"
+  mkdir -p "$R"
+  git -C "$R" -c init.defaultBranch=main init -q
+  git -C "$R" config user.email test@example.com
+  git -C "$R" config user.name test
+}
+
+run_tb() { # [args...] — run in $R; sets OUT and RC
+  OUT=""
+  RC=0
+  OUT="$(cd "$R" && "$TB" "$@" 2>&1)" || RC=$?
+}
+
+echo "=== control: a clean repo passes ==="
+new_repo clean
+printf 'fn main() {}\n' >"$R/ok.rs"
+git -C "$R" add -A
+run_tb
+[ "$RC" -eq 0 ] && case "$OUT" in *"todo-ban: OK"*) true ;; *) false ;; esac \
+  && ok "clean repo passes" || bad "clean repo passes" "rc=$RC out=$OUT"
+
+echo "=== shape (a): annotated markers fire ==="
+new_repo shapes
+printf '// %s: wire this up\n' "$TD" >"$R/a.rs"
+git -C "$R" add -A
+run_tb
+[ "$RC" -eq 1 ] && case "$OUT" in *"work marker: a.rs:1:"*) true ;; *) false ;; esac \
+  && ok "colon-annotated marker in a comment fails, naming file:line" \
+  || bad "colon-annotated marker fails" "rc=$RC out=$OUT"
+case "$OUT" in *"move it to the tracker and delete the marker"*) ok "diagnostic carries the remediation" ;; *) bad "diagnostic carries the remediation" "$OUT" ;; esac
+
+printf '%s(alice): assigned marker\n' "$FX" >"$R/a.rs"
+git -C "$R" add -A
+run_tb
+[ "$RC" -eq 1 ] && ok "attributed marker at line start fails" || bad "attributed marker at line start fails" "rc=$RC out=$OUT"
+
+printf 'code(); /* %s: inline block */\n' "$HK" >"$R/a.rs"
+git -C "$R" add -A
+run_tb
+[ "$RC" -eq 1 ] && ok "block-comment annotated marker fails" || bad "block-comment annotated marker fails" "rc=$RC out=$OUT"
+
+echo "=== shape (b): bare marker directly after a comment leader fires ==="
+printf '# %s implement the frobnicator\n' "$TD" >"$R/a.rs"
+git -C "$R" add -A
+run_tb
+[ "$RC" -eq 1 ] && ok "bare marker after hash leader fails" || bad "bare marker after hash leader fails" "rc=$RC out=$OUT"
+
+printf '//%s no space before the word\n' "$XX" >"$R/a.rs"
+git -C "$R" add -A
+run_tb
+[ "$RC" -eq 1 ] && ok "bare marker glued to a slash leader fails" || bad "bare marker glued to a slash leader fails" "rc=$RC out=$OUT"
+
+echo "=== prose that names or quotes a marker does not fire ==="
+printf 'The %s marker is banned in this repo.\n' "$TD" >"$R/a.rs"
+git -C "$R" add -A
+run_tb
+[ "$RC" -eq 0 ] && ok "bare word mid-prose (no colon, no adjacent leader) passes" \
+  || bad "bare word mid-prose passes" "rc=$RC out=$OUT"
+
+printf 'the `%s:` shape and `%s(` shape are banned\n' "$TD" "$FX" >"$R/a.md"
+git -C "$R" add -A
+run_tb
+[ "$RC" -eq 0 ] && ok "backtick-quoted marker shapes in docs pass" \
+  || bad "backtick-quoted marker shapes pass" "rc=$RC out=$OUT"
+
+printf 'emit "%s:/%s( marker without an issue reference"\n' "$TD" "$FX" >"$R/a.sh"
+git -C "$R" add -A
+run_tb
+[ "$RC" -eq 0 ] && ok "quote- and slash-joined marker names in a string pass" \
+  || bad "joined marker names in a string pass" "rc=$RC out=$OUT"
+
+printf 'printf "then\\n%s: inside a literal"\n' "$TD" >"$R/a.sh"
+git -C "$R" add -A
+run_tb
+[ "$RC" -eq 0 ] && ok "marker joined to an escape sequence in a literal passes" \
+  || bad "escape-joined marker passes" "rc=$RC out=$OUT"
+
+printf '// %s: lowercase is prose, not a marker\n' "todo" >"$R/a.rs"
+git -C "$R" add -A
+run_tb
+[ "$RC" -eq 0 ] && ok "lowercase word is never a marker (case-sensitive match)" \
+  || bad "lowercase word passes" "rc=$RC out=$OUT"
+
+echo "=== excludes: vendored trees are excluded WITH a reason ==="
+new_repo exc
+mkdir -p "$R/vendor" "$R/tools"
+printf '// %s: vendored upstream marker\n' "$TD" >"$R/vendor/lib.rs"
+git -C "$R" add -A
+run_tb
+[ "$RC" -eq 1 ] && ok "control: the vendored marker fails without an excludes row" \
+  || bad "control: vendored marker fails without excludes" "rc=$RC out=$OUT"
+
+printf 'vendor/*\tvendored third-party code\n' >"$R/tools/todo-ban-excludes"
+git -C "$R" add -A
+run_tb
+[ "$RC" -eq 0 ] && ok "the excludes row silences exactly the vendored tree" \
+  || bad "excludes row silences the vendored tree" "rc=$RC out=$OUT"
+
+printf 'vendor/*\n' >"$R/tools/todo-ban-excludes"
+git -C "$R" add -A
+run_tb
+[ "$RC" -eq 2 ] && case "$OUT" in *"pattern<TAB>reason"*) true ;; *) false ;; esac \
+  && ok "a pattern without a tab-separated reason is exit 2" \
+  || bad "a pattern without a reason is exit 2" "rc=$RC out=$OUT"
+
+echo "=== configuration: GROWTH_GUARDS_TODO_EXCLUDES and --excludes ==="
+printf 'vendor/*\tvendored third-party code\n' >"$R/alt-excludes"
+rm "$R/tools/todo-ban-excludes"
+git -C "$R" add -A
+OUT="$(cd "$R" && GROWTH_GUARDS_TODO_EXCLUDES=alt-excludes "$TB" 2>&1)" && RC=0 || RC=$?
+[ "$RC" -eq 0 ] && ok "excludes path resolves through the environment key" \
+  || bad "excludes path resolves through the environment key" "rc=$RC out=$OUT"
+run_tb --excludes alt-excludes
+[ "$RC" -eq 0 ] && ok "--excludes flag points at the same list" || bad "--excludes flag" "rc=$RC out=$OUT"
+run_tb
+[ "$RC" -eq 1 ] && ok "control: without either, the vendored marker still fails" \
+  || bad "control: default excludes path has no file, marker fails" "rc=$RC out=$OUT"
+
+run_tb --no-such-flag
+[ "$RC" -eq 2 ] && ok "unknown flag is exit 2" || bad "unknown flag is exit 2" "rc=$RC out=$OUT"
+
+echo "=== fail-closed: a broken scan terminates, never passes ==="
+new_repo grepfail
+printf 'clean file\n' >"$R/ok.txt"
+git -C "$R" add -A
+run_tb
+[ "$RC" -eq 0 ] && ok "shim-free control: the fixture passes with the real git" \
+  || bad "shim-free control passes" "rc=$RC out=$OUT"
+
+REAL_GIT="$(command -v git)"
+GIT_SHIM="$TMP/git-shim"
+mkdir -p "$GIT_SHIM"
+cat >"$GIT_SHIM/git" <<EOF
+#!/usr/bin/env bash
+for a in "\$@"; do
+  if [ "\$a" = "grep" ]; then
+    echo "git grep: simulated execution failure" >&2
+    exit 128
+  fi
+done
+exec "$REAL_GIT" "\$@"
+EOF
+chmod +x "$GIT_SHIM/git"
+OUT="$(cd "$R" && PATH="$GIT_SHIM:$PATH" "$TB" 2>&1)" && RC=0 || RC=$?
+[ "$RC" -eq 2 ] && case "$OUT" in *"git grep failed scanning tracked files"*) true ;; *) false ;; esac \
+  && ok "a git grep execution failure is a collection error: exit 2, never OK" \
+  || bad "a git grep execution failure is a collection error" "rc=$RC out=$OUT"
+case "$OUT" in *"todo-ban: OK"*) bad "no OK verdict may accompany a broken scan" "$OUT" ;; *) ok "no OK verdict accompanies the broken scan" ;; esac
+
+
+echo "=== a URL is not a comment leader ==="
+new_repo url
+printf 'see http://%s:8080/path for the mock\n' "$TD" >"$R/u.md"
+git -C "$R" add -A
+run_tb
+[ "$RC" -eq 0 ] && ok "a marker word inside a URL authority does not fire" \
+  || bad "a marker word inside a URL authority does not fire" "rc=$RC out=$OUT"
+# Control: the same word after real whitespace still fires.
+printf 'left in: %s: cleanup\n' "$TD" >>"$R/u.md"
+git -C "$R" add -A
+run_tb
+[ "$RC" -eq 1 ] && ok "control: the same marker after whitespace fires" \
+  || bad "control: the same marker after whitespace fires" "rc=$RC out=$OUT"
+
+echo "=== the exclusion list is read from the index ==="
+new_repo stagedx
+printf '// %s: vendored\n' "$TD" >"$R/v.rs"
+printf 'v.rs\tvendored fixture\n' >"$R/tools/growth-guards-todo-excludes" 2>/dev/null || { mkdir -p "$R/tools"; printf 'v.rs\tvendored fixture\n' >"$R/tools/growth-guards-todo-excludes"; }
+git -C "$R" add -A
+# Worktree copy now DROPS the exclusion; the staged copy must still govern.
+: >"$R/tools/growth-guards-todo-excludes"
+OUT="$(cd "$R" && GROWTH_GUARDS_TODO_EXCLUDES=tools/growth-guards-todo-excludes "$TB" 2>&1)" && RC=0 || RC=$?
+[ "$RC" -eq 0 ] && ok "staged exclusion list governs a staged scan" \
+  || bad "staged exclusion list governs a staged scan" "rc=$RC out=$OUT"
+# Control: staging the emptied list re-exposes the marker.
+git -C "$R" add tools/growth-guards-todo-excludes
+OUT="$(cd "$R" && GROWTH_GUARDS_TODO_EXCLUDES=tools/growth-guards-todo-excludes "$TB" 2>&1)" && RC=0 || RC=$?
+[ "$RC" -eq 1 ] && ok "control: staging the emptied list re-exposes the marker" \
+  || bad "control: staging the emptied list re-exposes the marker" "rc=$RC out=$OUT"
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/tools/byte-ceiling-excludes
+++ b/tools/byte-ceiling-excludes
@@ -1,0 +1,5 @@
+docs/assets/*	documentation screenshots
+pi-extensions/*/assets/*	demo media for extension READMEs (gifs, screenshots)
+pi-extensions/*/bundle/*	generated extension bundles
+skills/iced-rs/examples/*	vendored upstream iced examples (textures, screenshots, gifs)
+skills/iced-rs/iced_wgpu/*	vendored upstream iced_wgpu source

--- a/tools/suppression-ban-excludes
+++ b/tools/suppression-ban-excludes
@@ -1,0 +1,2 @@
+skills/iced-rs/examples/*	vendored upstream iced examples
+skills/iced-rs/iced_wgpu/*	vendored upstream iced_wgpu source

--- a/tools/todo-ban-excludes
+++ b/tools/todo-ban-excludes
@@ -1,0 +1,2 @@
+skills/iced-rs/iced_wgpu/*	vendored upstream iced_wgpu source — upstream markers are upstream business
+skills/iced-rs/examples/*	vendored upstream iced examples


### PR DESCRIPTION
## What

A `growth-guards` skill: the four portable checks every 2026-08-10 fleet audit found missing, in size-ratchet's idiom (exit 0/1/2, loud exit 2 on any unmeasurable collection, excludes rows carrying reasons, tighten-only baselines only where legacy counts exist, every failure naming its remediation). Dispatcher `growth-guards [all|CHECK]` batches fail-closed; each check runs standalone for pre-commit shims and CI.

- **todo-ban** — flat work-marker ban, comment-marker shapes only, so prose that quotes a marker never fires.
- **byte-ceiling** — newly added tracked files over N KB (default 200) fail; `--staged`/`--base REF`/`--all`; lockfiles exempt built-in.
- **suppression-ban** — blanket pragmas fail flat (module-wide rust allow, file-level noqa, bare eslint-disable, bare/`:all` nolint); bare rust dead_code/unused allows ratchet per file, tighten-only `--update`.
- **commit-msg** — conventional header gate; uppercase issue keys and `#N` scopes pass; git-generated messages pass.

Registration is directory discovery — `vstack add --skill growth-guards -y` verified end-to-end on a scratch project.

## Calibration

Repo-wide against this repository: vendored iced trees and demo/bundle assets seeded into the excludes with reasons; the `vstack init` hook scaffold no longer plants a work marker into generated hooks; suppression-ban correctly reports the two legacy crate-root `#![allow(dead_code)]` in cli (left in place, a CLI dead-code cleanup is its own change).

## Proof

129 assertions across six suites (per-check, dispatcher, Bash 3.2 portability), each with paired must-fail controls and a red-once neutered run; size-ratchet untouched and re-verified green; preflight clean over the 21-file diff; full validate-changed battery green.

Fixes VST-214

Claude-Session: https://claude.ai/code/session_01YCF7qAqiVFuAHPDMXLxV1r
