### PR TITLE
fix(github): pr-merge exit 75 states its volatility and names the watcher (VST-295)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
   once at `start-worktree` and never checked again, and a concurrent writer
   could reset the tree, rewrite round artifacts, and move the PR head
   underneath a live round with nothing failing.
+- github: `pr-merge` exit 75 (queued / auto-merge armed) now states on stderr
+  that the state is volatile — a merge-group ejection disarms it silently —
+  and names the watcher (`queue-wait`, `pr-watch.sh`) and the re-arm; the
+  SKILL.md outcomes table says the same, and that `await-mergeable` is not
+  that watcher (VST-295).
 - ci: `CHANGELOG.md` joins the size-ratchet excludes — an append-only log
   grows every PR by design and its seam is release rotation, not a code
   split; the gate was about to block every open PR at 1000 lines.

--- a/skills/github/README.md
+++ b/skills/github/README.md
@@ -64,6 +64,11 @@ the current diff and cannot be acted on.
 It is also policy, not mechanism — the gate binds only merges routed through
 `pr-merge`, so a raw `gh pr merge` or the GitHub UI still bypasses it.
 
+`pr-merge --auto` exits 75 when the PR is queued or auto-merge is armed. That
+state is volatile — an ejection or a failed protection check disarms it
+silently — so the caller keeps re-running a watcher until the PR is `MERGED`
+and re-arms after repairing what ejected it (SKILL.md § PR Merge Outcomes).
+
 Where branch protection *is* enabled, the opposite problem appears: after a
 rebase or force-push an outdated thread can become unreachable in the UI —
 the link 404s and the PR shows no conversations while still refusing to merge.

--- a/skills/github/README.md
+++ b/skills/github/README.md
@@ -64,10 +64,27 @@ the current diff and cannot be acted on.
 It is also policy, not mechanism — the gate binds only merges routed through
 `pr-merge`, so a raw `gh pr merge` or the GitHub UI still bypasses it.
 
+## Exit 75 recovery
+
 `pr-merge --auto` exits 75 when the PR is queued or auto-merge is armed. That
 state is volatile — an ejection or a failed protection check disarms it
-silently — so the caller keeps re-running a watcher until the PR is `MERGED`
-and re-arms after repairing what ejected it (SKILL.md § PR Merge Outcomes).
+silently — so the caller keeps re-running a watcher until the PR is `MERGED`;
+neither watcher is durable, and both live in sibling skills (install orch and
+review-gate beside this one):
+
+- `.agents/skills/orch/scripts/queue-wait <N>` polls to a bounded budget and
+  returns `ejected`/`disarmed` with its cause, or `queued` (run it again). A
+  re-run carries no memory of the earlier run, so an ejection between two runs
+  comes back as `not_queued`/`never_armed`.
+- `GH_REPO=<owner/repo> .agents/skills/review-gate/scripts/pr-watch.sh` is one
+  pass that prints `disarmed … (re-arm)` lines.
+
+Route the verdict: re-arm on `ejected`, `disarmed` and the memoryless
+`not_queued` — after repairing what the cause names (a
+`merge_group_failed`/`check_failed` cause is a CI repair first, else the same
+head ejects again); `dequeued` means late review findings — triage them first;
+`closed` and `unknown` are terminal. Re-arm with
+`.agents/skills/github/scripts/github.sh pr-merge <N> --auto`.
 
 Where branch protection *is* enabled, the opposite problem appears: after a
 rebase or force-push an outdated thread can become unreachable in the UI —

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -127,10 +127,18 @@ parsing stderr:
 |------|---------|-------------|------|
 | `0`  | MERGED | `MERGED PR #N` | Merge completed immediately |
 | `0`  | MERGED | `ALREADY MERGED PR #N <mergedAt>` | PR was merged before the call; nothing attempted |
-| `75` | MERGE PENDING | `QUEUED IN MERGE QUEUE PR #N` | A required GitHub merge queue has an active entry |
-| `75` | MERGE PENDING | `AUTO-MERGE ENABLED PR #N` | Classic auto-merge is armed until protection clears |
+| `75` | MERGE PENDING (volatile) | `QUEUED IN MERGE QUEUE PR #N` | A required GitHub merge queue has an active entry — an ejection disarms it silently; keep watching until MERGED |
+| `75` | MERGE PENDING (volatile) | `AUTO-MERGE ENABLED PR #N` | Classic auto-merge is armed until protection clears — a protection failure disarms it silently; keep watching until MERGED |
 | `1`  | BLOCKED | `BLOCKED PR #N` | Nothing merged, queued, or armed |
 | `1`  | BLOCKED | `CLOSED (not merged) PR #N` | PR is closed unmerged; nothing attempted |
+
+Exit `75` is not a resting state. A merge-group failure ejects the queue entry
+and GitHub disarms auto-merge with it — the PR sits open, gate-clear, and
+merges nothing. The caller that armed it keeps a watcher running until the PR
+is `MERGED`: the orch skill's `queue-wait <N>` (returns `ejected`/`disarmed`
+with its cause) or the review-gate reducer `pr-watch.sh` (`disarmed … (re-arm)`
+lines), then re-arms with `pr-merge <N> --auto`. `await-mergeable` is not that
+watcher — it returns as soon as GitHub computes a merge state.
 
 A PR that has left `OPEN` is terminal and short-circuits every mode before any
 check, auth, or mutation: `mergeable` is permanently `UNKNOWN` after a merge,

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -132,25 +132,15 @@ parsing stderr:
 | `1`  | BLOCKED | `BLOCKED PR #N` | Nothing merged, queued, or armed |
 | `1`  | BLOCKED | `CLOSED (not merged) PR #N` | PR is closed unmerged; nothing attempted |
 
-Exit `75` is not a resting state. A merge-group failure ejects the queue entry
-and GitHub disarms auto-merge with it — the PR sits open, gate-clear, and
-merges nothing. The caller that armed it keeps watching until the PR is
-`MERGED`, re-running the watcher because neither call is durable (both live
-in sibling skills — install orch and review-gate beside this one):
-`.agents/skills/orch/scripts/queue-wait <N>` polls to a bounded budget and
-returns `ejected`/`disarmed` with its cause, or `queued` (run it again); a
-re-run carries no memory of the earlier run, so an ejection between two runs
-comes back as `not_queued`/`never_armed`. Re-arm on `ejected`, `disarmed` and
-that memoryless `not_queued` — after repairing what the cause names (a
-`merge_group_failed`/`check_failed` cause is a CI repair first, else the same
-head ejects again); `dequeued` means late review findings — triage them
-first; `closed` and `unknown` are terminal, not a re-arm. The review-gate
-reducer
-`GH_REPO=<owner/repo> .agents/skills/review-gate/scripts/pr-watch.sh` is one
-pass that prints `disarmed … (re-arm)` lines. On a disarm, re-arm with
-`.agents/skills/github/scripts/github.sh pr-merge <N> --auto`.
-`await-mergeable` is not that watcher — it returns as soon as GitHub computes
-a merge state.
+Exit `75` is not a resting state: an ejection or a failed protection check
+disarms it silently and the PR sits open, gate-clear, merging nothing. The
+caller that armed it keeps re-running a watcher until the PR is `MERGED`
+(`.agents/skills/orch/scripts/queue-wait <N>` or the review-gate reducer
+`GH_REPO=<owner/repo> .agents/skills/review-gate/scripts/pr-watch.sh` — neither
+is durable) and re-arms with `.agents/skills/github/scripts/github.sh pr-merge
+<N> --auto` after repairing what the cause names; verdict routing is in
+README.md § Exit 75 recovery. `await-mergeable` is not that watcher — it
+returns as soon as GitHub computes a merge state.
 
 A PR that has left `OPEN` is terminal and short-circuits every mode before any
 check, auth, or mutation: `mergeable` is permanently `UNKNOWN` after a merge,

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -134,12 +134,14 @@ parsing stderr:
 
 Exit `75` is not a resting state. A merge-group failure ejects the queue entry
 and GitHub disarms auto-merge with it — the PR sits open, gate-clear, and
-merges nothing. The caller that armed it keeps a watcher running until the PR
-is `MERGED`: `.agents/skills/orch/scripts/queue-wait <N>` (returns
-`ejected`/`disarmed` with its cause) or the review-gate reducer
-`.agents/skills/review-gate/scripts/pr-watch.sh` (`disarmed … (re-arm)` lines),
-then re-arms with `pr-merge <N> --auto`. `await-mergeable` is not that
-watcher — it returns as soon as GitHub computes a merge state.
+merges nothing. The caller that armed it keeps watching until the PR is
+`MERGED`, re-running the watcher because neither call is durable:
+`.agents/skills/orch/scripts/queue-wait <N>` polls to a bounded budget and
+returns `ejected`/`disarmed` with its cause (or `queued` — run it again); the
+review-gate reducer `.agents/skills/review-gate/scripts/pr-watch.sh` is one
+pass that prints `disarmed … (re-arm)` lines. On a disarm, re-arm with
+`pr-merge <N> --auto`. `await-mergeable` is not that watcher — it returns as
+soon as GitHub computes a merge state.
 
 A PR that has left `OPEN` is terminal and short-circuits every mode before any
 check, auth, or mutation: `mergeable` is permanently `UNKNOWN` after a merge,

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -140,8 +140,10 @@ in sibling skills — install orch and review-gate beside this one):
 `.agents/skills/orch/scripts/queue-wait <N>` polls to a bounded budget and
 returns `ejected`/`disarmed` with its cause, or `queued` (run it again); a
 re-run carries no memory of the earlier run, so an ejection between two runs
-comes back as `not_queued`/`never_armed` — treat every verdict that is not
-`merged` and not `queued` as a disarm. The review-gate reducer
+comes back as `not_queued`/`never_armed`. Re-arm on `ejected`, `disarmed` and
+that memoryless `not_queued`; `dequeued` means late review findings — triage
+them first; `closed` and `unknown` are terminal, not a re-arm. The review-gate
+reducer
 `GH_REPO=<owner/repo> .agents/skills/review-gate/scripts/pr-watch.sh` is one
 pass that prints `disarmed … (re-arm)` lines. On a disarm, re-arm with
 `.agents/skills/github/scripts/github.sh pr-merge <N> --auto`.

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -135,11 +135,15 @@ parsing stderr:
 Exit `75` is not a resting state. A merge-group failure ejects the queue entry
 and GitHub disarms auto-merge with it — the PR sits open, gate-clear, and
 merges nothing. The caller that armed it keeps watching until the PR is
-`MERGED`, re-running the watcher because neither call is durable:
+`MERGED`, re-running the watcher because neither call is durable (both live
+in sibling skills — install orch and review-gate beside this one):
 `.agents/skills/orch/scripts/queue-wait <N>` polls to a bounded budget and
-returns `ejected`/`disarmed` with its cause (or `queued` — run it again); the
-review-gate reducer `GH_REPO=<owner/repo> .agents/skills/review-gate/scripts/pr-watch.sh`
-is one pass that prints `disarmed … (re-arm)` lines. On a disarm, re-arm with
+returns `ejected`/`disarmed` with its cause, or `queued` (run it again); a
+re-run carries no memory of the earlier run, so an ejection between two runs
+comes back as `not_queued`/`never_armed` — treat every verdict that is not
+`merged` and not `queued` as a disarm. The review-gate reducer
+`GH_REPO=<owner/repo> .agents/skills/review-gate/scripts/pr-watch.sh` is one
+pass that prints `disarmed … (re-arm)` lines. On a disarm, re-arm with
 `.agents/skills/github/scripts/github.sh pr-merge <N> --auto`.
 `await-mergeable` is not that watcher — it returns as soon as GitHub computes
 a merge state.

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -140,8 +140,8 @@ merges nothing. The caller that armed it keeps watching until the PR is
 returns `ejected`/`disarmed` with its cause (or `queued` — run it again); the
 review-gate reducer `.agents/skills/review-gate/scripts/pr-watch.sh` is one
 pass that prints `disarmed … (re-arm)` lines. On a disarm, re-arm with
-`pr-merge <N> --auto`. `await-mergeable` is not that watcher — it returns as
-soon as GitHub computes a merge state.
+`.agents/skills/github/scripts/github.sh pr-merge <N> --auto`. `await-mergeable`
+is not that watcher — it returns as soon as GitHub computes a merge state.
 
 A PR that has left `OPEN` is terminal and short-circuits every mode before any
 check, auth, or mutation: `mergeable` is permanently `UNKNOWN` after a merge,

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -141,8 +141,10 @@ in sibling skills — install orch and review-gate beside this one):
 returns `ejected`/`disarmed` with its cause, or `queued` (run it again); a
 re-run carries no memory of the earlier run, so an ejection between two runs
 comes back as `not_queued`/`never_armed`. Re-arm on `ejected`, `disarmed` and
-that memoryless `not_queued`; `dequeued` means late review findings — triage
-them first; `closed` and `unknown` are terminal, not a re-arm. The review-gate
+that memoryless `not_queued` — after repairing what the cause names (a
+`merge_group_failed`/`check_failed` cause is a CI repair first, else the same
+head ejects again); `dequeued` means late review findings — triage them
+first; `closed` and `unknown` are terminal, not a re-arm. The review-gate
 reducer
 `GH_REPO=<owner/repo> .agents/skills/review-gate/scripts/pr-watch.sh` is one
 pass that prints `disarmed … (re-arm)` lines. On a disarm, re-arm with

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -135,9 +135,10 @@ parsing stderr:
 Exit `75` is not a resting state. A merge-group failure ejects the queue entry
 and GitHub disarms auto-merge with it — the PR sits open, gate-clear, and
 merges nothing. The caller that armed it keeps a watcher running until the PR
-is `MERGED`: the orch skill's `queue-wait <N>` (returns `ejected`/`disarmed`
-with its cause) or the review-gate reducer `pr-watch.sh` (`disarmed … (re-arm)`
-lines), then re-arms with `pr-merge <N> --auto`. `await-mergeable` is not that
+is `MERGED`: `.agents/skills/orch/scripts/queue-wait <N>` (returns
+`ejected`/`disarmed` with its cause) or the review-gate reducer
+`.agents/skills/review-gate/scripts/pr-watch.sh` (`disarmed … (re-arm)` lines),
+then re-arms with `pr-merge <N> --auto`. `await-mergeable` is not that
 watcher — it returns as soon as GitHub computes a merge state.
 
 A PR that has left `OPEN` is terminal and short-circuits every mode before any

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -138,8 +138,8 @@ merges nothing. The caller that armed it keeps watching until the PR is
 `MERGED`, re-running the watcher because neither call is durable:
 `.agents/skills/orch/scripts/queue-wait <N>` polls to a bounded budget and
 returns `ejected`/`disarmed` with its cause (or `queued` — run it again); the
-review-gate reducer `.agents/skills/review-gate/scripts/pr-watch.sh` is one
-pass that prints `disarmed … (re-arm)` lines. On a disarm, re-arm with
+review-gate reducer `GH_REPO=<owner/repo> .agents/skills/review-gate/scripts/pr-watch.sh`
+is one pass that prints `disarmed … (re-arm)` lines. On a disarm, re-arm with
 `.agents/skills/github/scripts/github.sh pr-merge <N> --auto`.
 `await-mergeable` is not that watcher — it returns as soon as GitHub computes
 a merge state.

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -140,8 +140,9 @@ merges nothing. The caller that armed it keeps watching until the PR is
 returns `ejected`/`disarmed` with its cause (or `queued` — run it again); the
 review-gate reducer `.agents/skills/review-gate/scripts/pr-watch.sh` is one
 pass that prints `disarmed … (re-arm)` lines. On a disarm, re-arm with
-`.agents/skills/github/scripts/github.sh pr-merge <N> --auto`. `await-mergeable`
-is not that watcher — it returns as soon as GitHub computes a merge state.
+`.agents/skills/github/scripts/github.sh pr-merge <N> --auto`.
+`await-mergeable` is not that watcher — it returns as soon as GitHub computes
+a merge state.
 
 A PR that has left `OPEN` is terminal and short-circuits every mode before any
 check, auth, or mutation: `mergeable` is permanently `UNKNOWN` after a merge,

--- a/skills/github/scripts/commands/pr-merge.sh
+++ b/skills/github/scripts/commands/pr-merge.sh
@@ -370,19 +370,30 @@ gh_with_token() {
 # silently either way — it can sit open, gate-clear, and unwatched. Every 75
 # exit says so and names runnable watchers.
 volatile_note() {
-    local pr_num="$1" repo="${GH_REPO:-}" remote
+    local pr_num="$1" repo="${GH_REPO:-}" remote resolved
     # pr-watch.sh requires GH_REPO; print the reducer with the repository it
     # will need. Resolved LOCALLY (env, else the origin remote) — no network
     # request may stand between a queued/armed PR and its exit 75. When
     # nothing local names it the placeholder keeps the shape and says so.
+    local remote_name="origin"
     if [ -z "$repo" ]; then
         # gh's configured default (`gh repo set-default`) is stored as
         # remote.<name>.gh-resolved: an OWNER/REPO value names the repository
-        # gh operates on when origin is a fork; "base" means origin itself.
-        repo="$(git config --get-regexp '^remote\..*\.gh-resolved$' 2>/dev/null | awk 'NF == 2 && $2 != "base" { print $2; exit }' || true)"
+        # gh operates on when the checkout is a fork; "base" means that
+        # remote's own repository — resolve that remote's URL, not origin's.
+        resolved="$(git config --get-regexp '^remote\..*\.gh-resolved$' 2>/dev/null | awk 'NF == 2 { print $1, $2; exit }' || true)"
+        if [ -n "$resolved" ]; then
+            if [ "${resolved##* }" = "base" ]; then
+                remote_name="${resolved% *}"
+                remote_name="${remote_name#remote.}"
+                remote_name="${remote_name%.gh-resolved}"
+            else
+                repo="${resolved##* }"
+            fi
+        fi
     fi
     if [ -z "$repo" ]; then
-        remote="$(git config --get remote.origin.url 2>/dev/null || true)"
+        remote="$(git config --get "remote.$remote_name.url" 2>/dev/null || true)"
         case "$remote" in
             *github.com[:/]*/*)
                 repo="${remote##*github.com[:/]}"
@@ -391,9 +402,12 @@ volatile_note() {
                 ;;
         esac
     fi
-    # Only an OWNER/REPO-shaped value is printed into a pasteable command.
+    # Only an OWNER/REPO-shaped value (one slash, plain segments) is printed
+    # into a pasteable command.
     case "$repo" in
         */*/* | */ | /* | "" | *[!A-Za-z0-9._/-]*) repo="" ;;
+        */*) ;;
+        *) repo="" ;;
     esac
     echo "  NOTE: queue/auto-merge state is VOLATILE — an ejection or a failed protection check disarms it silently; keep watching until MERGED" >&2
     echo "  Watch, re-running until MERGED (neither call is durable — queue-wait exits at its poll budget, pr-watch.sh is one pass), with the orch and review-gate skills installed: .agents/skills/orch/scripts/queue-wait $pr_num (re-arm on ejected/disarmed/not_queued after repairing what the cause names — a failed merge-group/check is a CI repair first; dequeued = triage the late findings first; closed/unknown = stop) or GH_REPO=${repo:-<owner/repo — repository read failed>} .agents/skills/review-gate/scripts/pr-watch.sh (disarmed lines); re-arm with .agents/skills/github/scripts/github.sh pr-merge $pr_num --auto" >&2

--- a/skills/github/scripts/commands/pr-merge.sh
+++ b/skills/github/scripts/commands/pr-merge.sh
@@ -5,7 +5,9 @@
 # Outcomes (distinct exit codes + messages):
 #   0   MERGED                 — merge completed immediately
 #   0   ALREADY MERGED         — PR was already merged; nothing attempted
-#   75  QUEUED / AUTO-MERGE     — merge queue entry or classic auto-merge is active
+#   75  QUEUED / AUTO-MERGE     — merge queue entry or classic auto-merge is active;
+#                                 VOLATILE: a queue ejection disarms it silently,
+#                                 so the caller keeps watching until MERGED
 #   1   BLOCKED                — checks failed; no merge attempted, none queued
 #   1   CLOSED (not merged)    — PR is closed unmerged; nothing attempted
 #
@@ -78,6 +80,7 @@ Modes:
 Exit codes:
   0    MERGED / ALREADY MERGED — merge completed now, or the PR was already merged
   75   QUEUED / AUTO-MERGE     — merge queue entry or classic auto-merge is active
+                                 (volatile: an ejection disarms it silently — keep watching)
   1    BLOCKED / CLOSED        — checks failed or the PR is closed unmerged; nothing queued
 
 Examples:
@@ -362,6 +365,15 @@ gh_with_token() {
     fi
 }
 
+# Exit 75 is not a resting state: a merge-group failure ejects the entry and
+# GitHub disarms auto-merge with it, silently — an armed PR can sit open,
+# gate-clear, and unwatched. Every 75 exit says so and names the watchers.
+volatile_note() {
+    local pr_num="$1"
+    echo "  NOTE: queue/auto-merge state is VOLATILE — an ejection disarms it silently; keep watching until MERGED" >&2
+    echo "  Watch with: orch queue-wait $pr_num (verdict ejected/disarmed) or review-gate pr-watch.sh (disarmed lines); re-arm with pr-merge $pr_num --auto" >&2
+}
+
 # Read one authoritative post-mutation snapshot. `gh pr view --json` does not
 # expose merge-queue membership, so required-queue repositories need GraphQL.
 # Fall back to the classic `gh pr view` fields when the queue query itself is
@@ -644,13 +656,13 @@ main() {
 
     if [ "$post_in_queue" = "true" ] || [ "$post_queue_entry" = "true" ]; then
         echo "QUEUED IN MERGE QUEUE PR #$pr_num — queueState=${post_queue_state:-active}" >&2
-        echo "  Track with: github.sh await-mergeable $pr_num" >&2
+        volatile_note "$pr_num"
         exit 75
     fi
 
     if [ "$post_auto" = "true" ]; then
         echo "AUTO-MERGE ENABLED PR #$pr_num — will fire when CI + branch protection clear" >&2
-        echo "  Track with: github.sh await-mergeable $pr_num" >&2
+        volatile_note "$pr_num"
         exit 75
     fi
 

--- a/skills/github/scripts/commands/pr-merge.sh
+++ b/skills/github/scripts/commands/pr-merge.sh
@@ -372,7 +372,7 @@ gh_with_token() {
 volatile_note() {
     local pr_num="$1"
     echo "  NOTE: queue/auto-merge state is VOLATILE — an ejection or a failed protection check disarms it silently; keep watching until MERGED" >&2
-    echo "  Watch with: .agents/skills/orch/scripts/queue-wait $pr_num (verdict ejected/disarmed) or .agents/skills/review-gate/scripts/pr-watch.sh (disarmed lines); re-arm with github.sh pr-merge $pr_num --auto" >&2
+    echo "  Watch, re-running until MERGED (neither call is durable — queue-wait exits at its poll budget, pr-watch.sh is one pass): .agents/skills/orch/scripts/queue-wait $pr_num (verdict ejected/disarmed) or .agents/skills/review-gate/scripts/pr-watch.sh (disarmed lines); re-arm with .agents/skills/github/scripts/github.sh pr-merge $pr_num --auto" >&2
 }
 
 # Read one authoritative post-mutation snapshot. `gh pr view --json` does not

--- a/skills/github/scripts/commands/pr-merge.sh
+++ b/skills/github/scripts/commands/pr-merge.sh
@@ -365,13 +365,14 @@ gh_with_token() {
     fi
 }
 
-# Exit 75 is not a resting state: a merge-group failure ejects the entry and
-# GitHub disarms auto-merge with it, silently — an armed PR can sit open,
-# gate-clear, and unwatched. Every 75 exit says so and names the watchers.
+# Exit 75 is not a resting state: a merge-group failure ejects the entry, a
+# failed protection check drops classic auto-merge, and GitHub disarms the PR
+# silently either way — it can sit open, gate-clear, and unwatched. Every 75
+# exit says so and names runnable watchers.
 volatile_note() {
     local pr_num="$1"
-    echo "  NOTE: queue/auto-merge state is VOLATILE — an ejection disarms it silently; keep watching until MERGED" >&2
-    echo "  Watch with: orch queue-wait $pr_num (verdict ejected/disarmed) or review-gate pr-watch.sh (disarmed lines); re-arm with pr-merge $pr_num --auto" >&2
+    echo "  NOTE: queue/auto-merge state is VOLATILE — an ejection or a failed protection check disarms it silently; keep watching until MERGED" >&2
+    echo "  Watch with: .agents/skills/orch/scripts/queue-wait $pr_num (verdict ejected/disarmed) or .agents/skills/review-gate/scripts/pr-watch.sh (disarmed lines); re-arm with github.sh pr-merge $pr_num --auto" >&2
 }
 
 # Read one authoritative post-mutation snapshot. `gh pr view --json` does not

--- a/skills/github/scripts/commands/pr-merge.sh
+++ b/skills/github/scripts/commands/pr-merge.sh
@@ -370,9 +370,12 @@ gh_with_token() {
 # silently either way — it can sit open, gate-clear, and unwatched. Every 75
 # exit says so and names runnable watchers.
 volatile_note() {
-    local pr_num="$1"
+    local pr_num="$1" repo
+    # pr-watch.sh requires GH_REPO; print the reducer with the repository it
+    # will need, resolved the way this script's own reads resolve it.
+    repo="$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)"
     echo "  NOTE: queue/auto-merge state is VOLATILE — an ejection or a failed protection check disarms it silently; keep watching until MERGED" >&2
-    echo "  Watch, re-running until MERGED (neither call is durable — queue-wait exits at its poll budget, pr-watch.sh is one pass): .agents/skills/orch/scripts/queue-wait $pr_num (verdict ejected/disarmed) or .agents/skills/review-gate/scripts/pr-watch.sh (disarmed lines); re-arm with .agents/skills/github/scripts/github.sh pr-merge $pr_num --auto" >&2
+    echo "  Watch, re-running until MERGED (neither call is durable — queue-wait exits at its poll budget, pr-watch.sh is one pass): .agents/skills/orch/scripts/queue-wait $pr_num (verdict ejected/disarmed) or GH_REPO=${repo:-OWNER/REPO} .agents/skills/review-gate/scripts/pr-watch.sh (disarmed lines); re-arm with .agents/skills/github/scripts/github.sh pr-merge $pr_num --auto" >&2
 }
 
 # Read one authoritative post-mutation snapshot. `gh pr view --json` does not

--- a/skills/github/scripts/commands/pr-merge.sh
+++ b/skills/github/scripts/commands/pr-merge.sh
@@ -370,12 +370,13 @@ gh_with_token() {
 # silently either way — it can sit open, gate-clear, and unwatched. Every 75
 # exit says so and names runnable watchers.
 volatile_note() {
-    local pr_num="$1" repo
+    local pr_num="$1" auth_token="${2:-}" repo
     # pr-watch.sh requires GH_REPO; print the reducer with the repository it
-    # will need, resolved the way this script's own reads resolve it.
-    repo="$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)"
+    # will need, read under the same identity as the merge mutation. When the
+    # read fails the placeholder keeps the shape and says so.
+    repo="$(gh_with_token "$auth_token" repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)"
     echo "  NOTE: queue/auto-merge state is VOLATILE — an ejection or a failed protection check disarms it silently; keep watching until MERGED" >&2
-    echo "  Watch, re-running until MERGED (neither call is durable — queue-wait exits at its poll budget, pr-watch.sh is one pass): .agents/skills/orch/scripts/queue-wait $pr_num (verdict ejected/disarmed) or GH_REPO=${repo:-OWNER/REPO} .agents/skills/review-gate/scripts/pr-watch.sh (disarmed lines); re-arm with .agents/skills/github/scripts/github.sh pr-merge $pr_num --auto" >&2
+    echo "  Watch, re-running until MERGED (neither call is durable — queue-wait exits at its poll budget, pr-watch.sh is one pass), with the orch and review-gate skills installed: .agents/skills/orch/scripts/queue-wait $pr_num (any verdict that is not merged and not queued means re-arm) or GH_REPO=${repo:-<owner/repo — repository read failed>} .agents/skills/review-gate/scripts/pr-watch.sh (disarmed lines); re-arm with .agents/skills/github/scripts/github.sh pr-merge $pr_num --auto" >&2
 }
 
 # Read one authoritative post-mutation snapshot. `gh pr view --json` does not
@@ -660,13 +661,13 @@ main() {
 
     if [ "$post_in_queue" = "true" ] || [ "$post_queue_entry" = "true" ]; then
         echo "QUEUED IN MERGE QUEUE PR #$pr_num — queueState=${post_queue_state:-active}" >&2
-        volatile_note "$pr_num"
+        volatile_note "$pr_num" "$token"
         exit 75
     fi
 
     if [ "$post_auto" = "true" ]; then
         echo "AUTO-MERGE ENABLED PR #$pr_num — will fire when CI + branch protection clear" >&2
-        volatile_note "$pr_num"
+        volatile_note "$pr_num" "$token"
         exit 75
     fi
 

--- a/skills/github/scripts/commands/pr-merge.sh
+++ b/skills/github/scripts/commands/pr-merge.sh
@@ -376,7 +376,7 @@ volatile_note() {
     # read fails the placeholder keeps the shape and says so.
     repo="$(gh_with_token "$auth_token" repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)"
     echo "  NOTE: queue/auto-merge state is VOLATILE — an ejection or a failed protection check disarms it silently; keep watching until MERGED" >&2
-    echo "  Watch, re-running until MERGED (neither call is durable — queue-wait exits at its poll budget, pr-watch.sh is one pass), with the orch and review-gate skills installed: .agents/skills/orch/scripts/queue-wait $pr_num (re-arm on ejected/disarmed/not_queued; dequeued = triage the late findings first; closed/unknown = stop) or GH_REPO=${repo:-<owner/repo — repository read failed>} .agents/skills/review-gate/scripts/pr-watch.sh (disarmed lines); re-arm with .agents/skills/github/scripts/github.sh pr-merge $pr_num --auto" >&2
+    echo "  Watch, re-running until MERGED (neither call is durable — queue-wait exits at its poll budget, pr-watch.sh is one pass), with the orch and review-gate skills installed: .agents/skills/orch/scripts/queue-wait $pr_num (re-arm on ejected/disarmed/not_queued after repairing what the cause names — a failed merge-group/check is a CI repair first; dequeued = triage the late findings first; closed/unknown = stop) or GH_REPO=${repo:-<owner/repo — repository read failed>} .agents/skills/review-gate/scripts/pr-watch.sh (disarmed lines); re-arm with .agents/skills/github/scripts/github.sh pr-merge $pr_num --auto" >&2
 }
 
 # Read one authoritative post-mutation snapshot. `gh pr view --json` does not

--- a/skills/github/scripts/commands/pr-merge.sh
+++ b/skills/github/scripts/commands/pr-merge.sh
@@ -370,7 +370,7 @@ gh_with_token() {
 # silently either way — it can sit open, gate-clear, and unwatched. Every 75
 # exit says so and names runnable watchers.
 volatile_note() {
-    local pr_num="$1" repo="${GH_REPO:-}" remote resolved
+    local pr_num="$1" repo="${GH_REPO:-}" remote resolved reducer
     # pr-watch.sh requires GH_REPO; print the reducer with the repository it
     # will need. Resolved LOCALLY (env, else the origin remote) — no network
     # request may stand between a queued/armed PR and its exit 75. When
@@ -410,7 +410,9 @@ volatile_note() {
         *) repo="" ;;
     esac
     echo "  NOTE: queue/auto-merge state is VOLATILE — an ejection or a failed protection check disarms it silently; keep watching until MERGED" >&2
-    echo "  Watch, re-running until MERGED (neither call is durable — queue-wait exits at its poll budget, pr-watch.sh is one pass), with the orch and review-gate skills installed: .agents/skills/orch/scripts/queue-wait $pr_num (re-arm on ejected/disarmed/not_queued after repairing what the cause names — a failed merge-group/check is a CI repair first; dequeued = triage the late findings first; closed/unknown = stop) or GH_REPO=${repo:-<owner/repo — repository read failed>} .agents/skills/review-gate/scripts/pr-watch.sh (disarmed lines); re-arm with .agents/skills/github/scripts/github.sh pr-merge $pr_num --auto" >&2
+    local reducer="GH_REPO=$repo .agents/skills/review-gate/scripts/pr-watch.sh (disarmed lines)"
+    [ -n "$repo" ] || reducer=".agents/skills/review-gate/scripts/pr-watch.sh with GH_REPO set to the repository (not resolvable locally here)"
+    echo "  Watch, re-running until MERGED (neither call is durable — queue-wait exits at its poll budget, pr-watch.sh is one pass), with the orch and review-gate skills installed: .agents/skills/orch/scripts/queue-wait $pr_num (re-arm on ejected/disarmed/not_queued after repairing what the cause names — a failed merge-group/check is a CI repair first; dequeued = triage the late findings first; closed/unknown = stop) or $reducer; re-arm with .agents/skills/github/scripts/github.sh pr-merge $pr_num --auto" >&2
 }
 
 # Read one authoritative post-mutation snapshot. `gh pr view --json` does not

--- a/skills/github/scripts/commands/pr-merge.sh
+++ b/skills/github/scripts/commands/pr-merge.sh
@@ -370,11 +370,21 @@ gh_with_token() {
 # silently either way — it can sit open, gate-clear, and unwatched. Every 75
 # exit says so and names runnable watchers.
 volatile_note() {
-    local pr_num="$1" auth_token="${2:-}" repo
+    local pr_num="$1" repo="${GH_REPO:-}" remote
     # pr-watch.sh requires GH_REPO; print the reducer with the repository it
-    # will need, read under the same identity as the merge mutation. When the
-    # read fails the placeholder keeps the shape and says so.
-    repo="$(gh_with_token "$auth_token" repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)"
+    # will need. Resolved LOCALLY (env, else the origin remote) — no network
+    # request may stand between a queued/armed PR and its exit 75. When
+    # nothing local names it the placeholder keeps the shape and says so.
+    if [ -z "$repo" ]; then
+        remote="$(git config --get remote.origin.url 2>/dev/null || true)"
+        case "$remote" in
+            *github.com[:/]*/*)
+                repo="${remote##*github.com[:/]}"
+                repo="${repo%.git}"
+                repo="${repo%/}"
+                ;;
+        esac
+    fi
     echo "  NOTE: queue/auto-merge state is VOLATILE — an ejection or a failed protection check disarms it silently; keep watching until MERGED" >&2
     echo "  Watch, re-running until MERGED (neither call is durable — queue-wait exits at its poll budget, pr-watch.sh is one pass), with the orch and review-gate skills installed: .agents/skills/orch/scripts/queue-wait $pr_num (re-arm on ejected/disarmed/not_queued after repairing what the cause names — a failed merge-group/check is a CI repair first; dequeued = triage the late findings first; closed/unknown = stop) or GH_REPO=${repo:-<owner/repo — repository read failed>} .agents/skills/review-gate/scripts/pr-watch.sh (disarmed lines); re-arm with .agents/skills/github/scripts/github.sh pr-merge $pr_num --auto" >&2
 }
@@ -661,13 +671,13 @@ main() {
 
     if [ "$post_in_queue" = "true" ] || [ "$post_queue_entry" = "true" ]; then
         echo "QUEUED IN MERGE QUEUE PR #$pr_num — queueState=${post_queue_state:-active}" >&2
-        volatile_note "$pr_num" "$token"
+        volatile_note "$pr_num"
         exit 75
     fi
 
     if [ "$post_auto" = "true" ]; then
         echo "AUTO-MERGE ENABLED PR #$pr_num — will fire when CI + branch protection clear" >&2
-        volatile_note "$pr_num" "$token"
+        volatile_note "$pr_num"
         exit 75
     fi
 

--- a/skills/github/scripts/commands/pr-merge.sh
+++ b/skills/github/scripts/commands/pr-merge.sh
@@ -376,6 +376,12 @@ volatile_note() {
     # request may stand between a queued/armed PR and its exit 75. When
     # nothing local names it the placeholder keeps the shape and says so.
     if [ -z "$repo" ]; then
+        # gh's configured default (`gh repo set-default`) is stored as
+        # remote.<name>.gh-resolved: an OWNER/REPO value names the repository
+        # gh operates on when origin is a fork; "base" means origin itself.
+        repo="$(git config --get-regexp '^remote\..*\.gh-resolved$' 2>/dev/null | awk 'NF == 2 && $2 != "base" { print $2; exit }' || true)"
+    fi
+    if [ -z "$repo" ]; then
         remote="$(git config --get remote.origin.url 2>/dev/null || true)"
         case "$remote" in
             *github.com[:/]*/*)
@@ -385,6 +391,10 @@ volatile_note() {
                 ;;
         esac
     fi
+    # Only an OWNER/REPO-shaped value is printed into a pasteable command.
+    case "$repo" in
+        */*/* | */ | /* | "" | *[!A-Za-z0-9._/-]*) repo="" ;;
+    esac
     echo "  NOTE: queue/auto-merge state is VOLATILE — an ejection or a failed protection check disarms it silently; keep watching until MERGED" >&2
     echo "  Watch, re-running until MERGED (neither call is durable — queue-wait exits at its poll budget, pr-watch.sh is one pass), with the orch and review-gate skills installed: .agents/skills/orch/scripts/queue-wait $pr_num (re-arm on ejected/disarmed/not_queued after repairing what the cause names — a failed merge-group/check is a CI repair first; dequeued = triage the late findings first; closed/unknown = stop) or GH_REPO=${repo:-<owner/repo — repository read failed>} .agents/skills/review-gate/scripts/pr-watch.sh (disarmed lines); re-arm with .agents/skills/github/scripts/github.sh pr-merge $pr_num --auto" >&2
 }

--- a/skills/github/scripts/commands/pr-merge.sh
+++ b/skills/github/scripts/commands/pr-merge.sh
@@ -376,7 +376,7 @@ volatile_note() {
     # read fails the placeholder keeps the shape and says so.
     repo="$(gh_with_token "$auth_token" repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)"
     echo "  NOTE: queue/auto-merge state is VOLATILE — an ejection or a failed protection check disarms it silently; keep watching until MERGED" >&2
-    echo "  Watch, re-running until MERGED (neither call is durable — queue-wait exits at its poll budget, pr-watch.sh is one pass), with the orch and review-gate skills installed: .agents/skills/orch/scripts/queue-wait $pr_num (any verdict that is not merged and not queued means re-arm) or GH_REPO=${repo:-<owner/repo — repository read failed>} .agents/skills/review-gate/scripts/pr-watch.sh (disarmed lines); re-arm with .agents/skills/github/scripts/github.sh pr-merge $pr_num --auto" >&2
+    echo "  Watch, re-running until MERGED (neither call is durable — queue-wait exits at its poll budget, pr-watch.sh is one pass), with the orch and review-gate skills installed: .agents/skills/orch/scripts/queue-wait $pr_num (re-arm on ejected/disarmed/not_queued; dequeued = triage the late findings first; closed/unknown = stop) or GH_REPO=${repo:-<owner/repo — repository read failed>} .agents/skills/review-gate/scripts/pr-watch.sh (disarmed lines); re-arm with .agents/skills/github/scripts/github.sh pr-merge $pr_num --auto" >&2
 }
 
 # Read one authoritative post-mutation snapshot. `gh pr view --json` does not

--- a/skills/github/tests/pr-merge-volatile-75-docs.test.sh
+++ b/skills/github/tests/pr-merge-volatile-75-docs.test.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Exit 75 (queued / auto-merge armed) is volatile: an ejection disarms it
+# silently. The script says so on every 75 exit and the SKILL.md outcome table
+# names the watcher a caller must keep running; these pins keep the two from
+# drifting apart.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../.." && pwd)"
+SKILL_MD="$REPO_ROOT/skills/github/SKILL.md"
+PR_MERGE="$REPO_ROOT/skills/github/scripts/commands/pr-merge.sh"
+
+PASS=0
+FAIL=0
+
+assert_matches() {
+  local got="$1" pattern="$2" name="$3"
+  if grep -qE -- "$pattern" <<<"$got"; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected to match: %s\n' "$name" "$pattern"
+  fi
+}
+
+assert_count() { # GOT PATTERN EXPECTED NAME
+  local got="$1" pattern="$2" expected="$3" name="$4" n
+  n=$(grep -cE -- "$pattern" <<<"$got" || true)
+  if [ "$n" -eq "$expected" ]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected %s match(es) of: %s (got %s)\n' "$name" "$expected" "$pattern" "$n"
+  fi
+}
+
+echo "=== pr-merge exit 75 is documented as volatile, in the script and the SKILL ==="
+
+script_src=$(cat "$PR_MERGE")
+# Both 75 exits route through the one note (queued and classic auto-merge).
+assert_count "$script_src" '^[[:space:]]*volatile_note "\$pr_num"$' 2 \
+  "both exit-75 paths emit the volatility note"
+assert_matches "$script_src" 'VOLATILE.*disarms it silently' \
+  "the note states an ejection disarms silently"
+assert_matches "$script_src" 'queue-wait \$pr_num' \
+  "the note names queue-wait as the watcher"
+assert_matches "$script_src" 'pr-watch\.sh' \
+  "the note names the pr-watch reducer"
+
+table=$(sed -n '/^### PR Merge Outcomes$/,/^### /p' "$SKILL_MD")
+assert_count "$table" '^\| `75` \| MERGE PENDING \(volatile\)' 2 \
+  "both 75 rows of the outcomes table are marked volatile"
+assert_matches "$table" 'keep watching until MERGED' \
+  "the 75 rows say the caller keeps watching until MERGED"
+assert_matches "$table" 'queue-wait <N>' \
+  "the outcomes section names queue-wait as the required follow-up"
+assert_matches "$table" 'await-mergeable. is not that' \
+  "the outcomes section states await-mergeable is not the ejection watcher"
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/skills/github/tests/pr-merge-volatile-75-docs.test.sh
+++ b/skills/github/tests/pr-merge-volatile-75-docs.test.sh
@@ -64,8 +64,10 @@ assert_matches "$table" 'queue-wait <N>' \
   "the outcomes section names queue-wait as the required follow-up"
 assert_matches "$table" 'github\.sh pr-merge <N> --auto' \
   "the outcomes section names the re-arm by its installed entry point"
-assert_matches "$table" 'treat every verdict that is not' \
-  "the outcomes section states a re-run without queue memory still routes to re-arm"
+assert_matches "$table" 'Re-arm on `ejected`, `disarmed` and' \
+  "the outcomes section routes only genuine disarm verdicts to re-arm"
+assert_matches "$table" '`dequeued` means late review findings' \
+  "the outcomes section routes dequeued to findings triage, not re-arm"
 assert_matches "$table" 'await-mergeable` is not that' \
   "the outcomes section states await-mergeable is not the ejection watcher"
 

--- a/skills/github/tests/pr-merge-volatile-75-docs.test.sh
+++ b/skills/github/tests/pr-merge-volatile-75-docs.test.sh
@@ -46,8 +46,8 @@ assert_matches "$script_src" 'VOLATILE.*an ejection or a failed protection check
   "the note states an ejection or a failed protection check disarms silently"
 assert_matches "$script_src" '\.agents/skills/orch/scripts/queue-wait \$pr_num' \
   "the note names queue-wait by its runnable path"
-assert_matches "$script_src" '\.agents/skills/review-gate/scripts/pr-watch\.sh' \
-  "the note names the pr-watch reducer by its runnable path"
+assert_matches "$script_src" 'GH_REPO=\$\{repo:-OWNER/REPO\} \.agents/skills/review-gate/scripts/pr-watch\.sh' \
+  "the note names the pr-watch reducer by its runnable path, with the GH_REPO it requires"
 
 table=$(sed -n '/^### PR Merge Outcomes$/,/^### /p' "$SKILL_MD")
 assert_count "$table" '^\| `75` \| MERGE PENDING \(volatile\)' 2 \

--- a/skills/github/tests/pr-merge-volatile-75-docs.test.sh
+++ b/skills/github/tests/pr-merge-volatile-75-docs.test.sh
@@ -46,8 +46,10 @@ assert_matches "$script_src" 'VOLATILE.*an ejection or a failed protection check
   "the note states an ejection or a failed protection check disarms silently"
 assert_matches "$script_src" '\.agents/skills/orch/scripts/queue-wait \$pr_num' \
   "the note names queue-wait by its runnable path"
-assert_matches "$script_src" 'GH_REPO=\$\{repo:-<owner/repo — repository read failed>\} \.agents/skills/review-gate/scripts/pr-watch\.sh' \
-  "the note names the pr-watch reducer by its runnable path, with the GH_REPO it requires (failure named, never a bare placeholder)"
+assert_matches "$script_src" 'reducer="GH_REPO=\$repo \.agents/skills/review-gate/scripts/pr-watch\.sh' \
+  "the note names the pr-watch reducer by its runnable path, with the GH_REPO it requires"
+assert_matches "$script_src" 'with GH_REPO set to the repository \(not resolvable locally here\)' \
+  "an unresolvable repository yields a plain instruction, never a pasteable placeholder"
 assert_matches "$script_src" 'git config --get "remote\.\$remote_name\.url"' \
   "the repository is resolved locally (the resolved remote), never by a network read on the exit path"
 assert_matches "$script_src" 'gh-resolved' \
@@ -67,7 +69,7 @@ assert_count "$table" '^\| `75` \| MERGE PENDING \(volatile\)' 2 \
   "both 75 rows of the outcomes table are marked volatile"
 assert_matches "$table" 'keep watching until MERGED' \
   "the 75 rows say the caller keeps watching until MERGED"
-assert_matches "$table" 'neither\s*$|neither$|— neither' \
+assert_matches "$table" '— neither' \
   "the outcomes section states no watcher is durable"
 assert_matches "$script_src" 're-running until MERGED' \
   "the note says to re-run the watcher until MERGED"

--- a/skills/github/tests/pr-merge-volatile-75-docs.test.sh
+++ b/skills/github/tests/pr-merge-volatile-75-docs.test.sh
@@ -48,12 +48,14 @@ assert_matches "$script_src" '\.agents/skills/orch/scripts/queue-wait \$pr_num' 
   "the note names queue-wait by its runnable path"
 assert_matches "$script_src" 'GH_REPO=\$\{repo:-<owner/repo — repository read failed>\} \.agents/skills/review-gate/scripts/pr-watch\.sh' \
   "the note names the pr-watch reducer by its runnable path, with the GH_REPO it requires (failure named, never a bare placeholder)"
-assert_matches "$script_src" 'remote\.origin\.url' \
-  "the repository is resolved locally (origin remote), never by a network read on the exit path"
+assert_matches "$script_src" 'git config --get "remote\.\$remote_name\.url"' \
+  "the repository is resolved locally (the resolved remote), never by a network read on the exit path"
 assert_matches "$script_src" 'gh-resolved' \
   "gh's configured default repository (a fork's upstream) wins over origin"
 assert_matches "$script_src" '\*\[!A-Za-z0-9\._/-\]\*\) repo=""' \
   "only an OWNER/REPO-shaped value is printed into the pasteable command"
+assert_matches "$script_src" '^[[:space:]]*\*\) repo="" ;;' \
+  "a slash-less value is refused too"
 if grep -qE 'repo view|gh api|gh pr' <<<"$(sed -n '/^volatile_note() {/,/^}/p' "$PR_MERGE")"; then
   FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "volatile_note makes no gh request"
 else
@@ -65,23 +67,25 @@ assert_count "$table" '^\| `75` \| MERGE PENDING \(volatile\)' 2 \
   "both 75 rows of the outcomes table are marked volatile"
 assert_matches "$table" 'keep watching until MERGED' \
   "the 75 rows say the caller keeps watching until MERGED"
-assert_matches "$table" 're-running the watcher because neither call is durable' \
-  "the outcomes section states the watcher must be re-run (no durable watcher)"
+assert_matches "$table" 'neither\s*$|neither$|— neither' \
+  "the outcomes section states no watcher is durable"
 assert_matches "$script_src" 're-running until MERGED' \
   "the note says to re-run the watcher until MERGED"
 assert_matches "$table" 'queue-wait <N>' \
   "the outcomes section names queue-wait as the required follow-up"
-assert_matches "$table" 'github\.sh pr-merge <N> --auto' \
+assert_matches "$(tr '\n' ' ' <<<"$table")" 'github\.sh pr-merge <N> --auto' \
   "the outcomes section names the re-arm by its installed entry point"
-assert_matches "$table" 'Re-arm on `ejected`, `disarmed` and' \
-  "the outcomes section routes only genuine disarm verdicts to re-arm"
-assert_matches "$table" '`dequeued` means late review findings' \
-  "the outcomes section routes dequeued to findings triage, not re-arm"
-assert_matches "$table" 'is a CI repair first' \
-  "the outcomes section requires the CI repair before re-arming an ejected head"
-readme_src=$(cat "$REPO_ROOT/skills/github/README.md")
+assert_matches "$table" 'README\.md § Exit 75 recovery' \
+  "the outcomes section points at the README recovery section (progressive disclosure)"
+readme_src=$(sed -n '/^## Exit 75 recovery$/,/^## /p' "$REPO_ROOT/skills/github/README.md")
 assert_matches "$readme_src" 'exits 75 when the PR is queued or auto-merge is armed' \
   "README states the volatile 75 contract"
+assert_matches "$readme_src" 're-arm on `ejected`, `disarmed` and' \
+  "README routes only genuine disarm verdicts to re-arm"
+assert_matches "$readme_src" '`dequeued` means late review findings' \
+  "README routes dequeued to findings triage, not re-arm"
+assert_matches "$readme_src" 'is a CI repair first' \
+  "README requires the CI repair before re-arming an ejected head"
 assert_matches "$table" 'await-mergeable` is not that' \
   "the outcomes section states await-mergeable is not the ejection watcher"
 

--- a/skills/github/tests/pr-merge-volatile-75-docs.test.sh
+++ b/skills/github/tests/pr-merge-volatile-75-docs.test.sh
@@ -40,7 +40,7 @@ echo "=== pr-merge exit 75 is documented as volatile, in the script and the SKIL
 
 script_src=$(cat "$PR_MERGE")
 # Both 75 exits route through the one note (queued and classic auto-merge).
-assert_count "$script_src" '^[[:space:]]*volatile_note "\$pr_num" "\$token"$' 2 \
+assert_count "$script_src" '^[[:space:]]*volatile_note "\$pr_num"$' 2 \
   "both exit-75 paths emit the volatility note"
 assert_matches "$script_src" 'VOLATILE.*an ejection or a failed protection check disarms it silently' \
   "the note states an ejection or a failed protection check disarms silently"
@@ -48,8 +48,13 @@ assert_matches "$script_src" '\.agents/skills/orch/scripts/queue-wait \$pr_num' 
   "the note names queue-wait by its runnable path"
 assert_matches "$script_src" 'GH_REPO=\$\{repo:-<owner/repo — repository read failed>\} \.agents/skills/review-gate/scripts/pr-watch\.sh' \
   "the note names the pr-watch reducer by its runnable path, with the GH_REPO it requires (failure named, never a bare placeholder)"
-assert_matches "$script_src" 'gh_with_token "\$auth_token" repo view' \
-  "the repository read runs under the merge identity"
+assert_matches "$script_src" 'remote\.origin\.url' \
+  "the repository is resolved locally (origin remote), never by a network read on the exit path"
+if grep -qE 'gh(_with_token[^\n]*)? repo view' <<<"$(sed -n '/^volatile_note() {/,/^}/p' "$PR_MERGE")"; then
+  FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "volatile_note makes no gh request"
+else
+  PASS=$((PASS + 1)); printf '  ok    %s\n' "volatile_note makes no gh request"
+fi
 
 table=$(sed -n '/^### PR Merge Outcomes$/,/^### /p' "$SKILL_MD")
 assert_count "$table" '^\| `75` \| MERGE PENDING \(volatile\)' 2 \

--- a/skills/github/tests/pr-merge-volatile-75-docs.test.sh
+++ b/skills/github/tests/pr-merge-volatile-75-docs.test.sh
@@ -54,6 +54,10 @@ assert_count "$table" '^\| `75` \| MERGE PENDING \(volatile\)' 2 \
   "both 75 rows of the outcomes table are marked volatile"
 assert_matches "$table" 'keep watching until MERGED' \
   "the 75 rows say the caller keeps watching until MERGED"
+assert_matches "$table" 're-running the watcher because neither call is durable' \
+  "the outcomes section states the watcher must be re-run (no durable watcher)"
+assert_matches "$script_src" 're-running until MERGED' \
+  "the note says to re-run the watcher until MERGED"
 assert_matches "$table" 'queue-wait <N>' \
   "the outcomes section names queue-wait as the required follow-up"
 assert_matches "$table" 'await-mergeable` is not that' \

--- a/skills/github/tests/pr-merge-volatile-75-docs.test.sh
+++ b/skills/github/tests/pr-merge-volatile-75-docs.test.sh
@@ -42,12 +42,12 @@ script_src=$(cat "$PR_MERGE")
 # Both 75 exits route through the one note (queued and classic auto-merge).
 assert_count "$script_src" '^[[:space:]]*volatile_note "\$pr_num"$' 2 \
   "both exit-75 paths emit the volatility note"
-assert_matches "$script_src" 'VOLATILE.*disarms it silently' \
-  "the note states an ejection disarms silently"
-assert_matches "$script_src" 'queue-wait \$pr_num' \
-  "the note names queue-wait as the watcher"
-assert_matches "$script_src" 'pr-watch\.sh' \
-  "the note names the pr-watch reducer"
+assert_matches "$script_src" 'VOLATILE.*an ejection or a failed protection check disarms it silently' \
+  "the note states an ejection or a failed protection check disarms silently"
+assert_matches "$script_src" '\.agents/skills/orch/scripts/queue-wait \$pr_num' \
+  "the note names queue-wait by its runnable path"
+assert_matches "$script_src" '\.agents/skills/review-gate/scripts/pr-watch\.sh' \
+  "the note names the pr-watch reducer by its runnable path"
 
 table=$(sed -n '/^### PR Merge Outcomes$/,/^### /p' "$SKILL_MD")
 assert_count "$table" '^\| `75` \| MERGE PENDING \(volatile\)' 2 \
@@ -56,7 +56,7 @@ assert_matches "$table" 'keep watching until MERGED' \
   "the 75 rows say the caller keeps watching until MERGED"
 assert_matches "$table" 'queue-wait <N>' \
   "the outcomes section names queue-wait as the required follow-up"
-assert_matches "$table" 'await-mergeable. is not that' \
+assert_matches "$table" 'await-mergeable` is not that' \
   "the outcomes section states await-mergeable is not the ejection watcher"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"

--- a/skills/github/tests/pr-merge-volatile-75-docs.test.sh
+++ b/skills/github/tests/pr-merge-volatile-75-docs.test.sh
@@ -68,6 +68,11 @@ assert_matches "$table" 'Re-arm on `ejected`, `disarmed` and' \
   "the outcomes section routes only genuine disarm verdicts to re-arm"
 assert_matches "$table" '`dequeued` means late review findings' \
   "the outcomes section routes dequeued to findings triage, not re-arm"
+assert_matches "$table" 'is a CI repair first' \
+  "the outcomes section requires the CI repair before re-arming an ejected head"
+readme_src=$(cat "$REPO_ROOT/skills/github/README.md")
+assert_matches "$readme_src" 'exits 75 when the PR is queued or auto-merge is armed' \
+  "README states the volatile 75 contract"
 assert_matches "$table" 'await-mergeable` is not that' \
   "the outcomes section states await-mergeable is not the ejection watcher"
 

--- a/skills/github/tests/pr-merge-volatile-75-docs.test.sh
+++ b/skills/github/tests/pr-merge-volatile-75-docs.test.sh
@@ -60,6 +60,8 @@ assert_matches "$script_src" 're-running until MERGED' \
   "the note says to re-run the watcher until MERGED"
 assert_matches "$table" 'queue-wait <N>' \
   "the outcomes section names queue-wait as the required follow-up"
+assert_matches "$table" 'github\.sh pr-merge <N> --auto' \
+  "the outcomes section names the re-arm by its installed entry point"
 assert_matches "$table" 'await-mergeable` is not that' \
   "the outcomes section states await-mergeable is not the ejection watcher"
 

--- a/skills/github/tests/pr-merge-volatile-75-docs.test.sh
+++ b/skills/github/tests/pr-merge-volatile-75-docs.test.sh
@@ -40,14 +40,16 @@ echo "=== pr-merge exit 75 is documented as volatile, in the script and the SKIL
 
 script_src=$(cat "$PR_MERGE")
 # Both 75 exits route through the one note (queued and classic auto-merge).
-assert_count "$script_src" '^[[:space:]]*volatile_note "\$pr_num"$' 2 \
+assert_count "$script_src" '^[[:space:]]*volatile_note "\$pr_num" "\$token"$' 2 \
   "both exit-75 paths emit the volatility note"
 assert_matches "$script_src" 'VOLATILE.*an ejection or a failed protection check disarms it silently' \
   "the note states an ejection or a failed protection check disarms silently"
 assert_matches "$script_src" '\.agents/skills/orch/scripts/queue-wait \$pr_num' \
   "the note names queue-wait by its runnable path"
-assert_matches "$script_src" 'GH_REPO=\$\{repo:-OWNER/REPO\} \.agents/skills/review-gate/scripts/pr-watch\.sh' \
-  "the note names the pr-watch reducer by its runnable path, with the GH_REPO it requires"
+assert_matches "$script_src" 'GH_REPO=\$\{repo:-<owner/repo — repository read failed>\} \.agents/skills/review-gate/scripts/pr-watch\.sh' \
+  "the note names the pr-watch reducer by its runnable path, with the GH_REPO it requires (failure named, never a bare placeholder)"
+assert_matches "$script_src" 'gh_with_token "\$auth_token" repo view' \
+  "the repository read runs under the merge identity"
 
 table=$(sed -n '/^### PR Merge Outcomes$/,/^### /p' "$SKILL_MD")
 assert_count "$table" '^\| `75` \| MERGE PENDING \(volatile\)' 2 \
@@ -62,6 +64,8 @@ assert_matches "$table" 'queue-wait <N>' \
   "the outcomes section names queue-wait as the required follow-up"
 assert_matches "$table" 'github\.sh pr-merge <N> --auto' \
   "the outcomes section names the re-arm by its installed entry point"
+assert_matches "$table" 'treat every verdict that is not' \
+  "the outcomes section states a re-run without queue memory still routes to re-arm"
 assert_matches "$table" 'await-mergeable` is not that' \
   "the outcomes section states await-mergeable is not the ejection watcher"
 

--- a/skills/github/tests/pr-merge-volatile-75-docs.test.sh
+++ b/skills/github/tests/pr-merge-volatile-75-docs.test.sh
@@ -50,7 +50,11 @@ assert_matches "$script_src" 'GH_REPO=\$\{repo:-<owner/repo — repository read 
   "the note names the pr-watch reducer by its runnable path, with the GH_REPO it requires (failure named, never a bare placeholder)"
 assert_matches "$script_src" 'remote\.origin\.url' \
   "the repository is resolved locally (origin remote), never by a network read on the exit path"
-if grep -qE 'gh(_with_token[^\n]*)? repo view' <<<"$(sed -n '/^volatile_note() {/,/^}/p' "$PR_MERGE")"; then
+assert_matches "$script_src" 'gh-resolved' \
+  "gh's configured default repository (a fork's upstream) wins over origin"
+assert_matches "$script_src" '\*\[!A-Za-z0-9\._/-\]\*\) repo=""' \
+  "only an OWNER/REPO-shaped value is printed into the pasteable command"
+if grep -qE 'repo view|gh api|gh pr' <<<"$(sed -n '/^volatile_note() {/,/^}/p' "$PR_MERGE")"; then
   FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "volatile_note makes no gh request"
 else
   PASS=$((PASS + 1)); printf '  ok    %s\n' "volatile_note makes no gh request"

--- a/skills/github/tests/pr-merge.sh
+++ b/skills/github/tests/pr-merge.sh
@@ -458,7 +458,7 @@ assert_contains "$out" "QUEUED IN MERGE QUEUE PR #123" "merge-queue outcome is e
 assert_contains "$out" "queueState=QUEUED" "merge-queue state is preserved"
 assert_contains "$out" "VOLATILE" "queued exit 75 states the state is volatile"
 assert_contains "$out" ".agents/skills/orch/scripts/queue-wait 123" "queued exit 75 names the ejection watcher by runnable path"
-assert_contains "$out" "github.sh pr-merge 123 --auto" "queued exit 75 names the re-arm"
+assert_contains "$out" ".agents/skills/github/scripts/github.sh pr-merge 123 --auto" "queued exit 75 names the re-arm by runnable path"
 
 set +e
 out=$(STUB_CHECKS="$checks" \

--- a/skills/github/tests/pr-merge.sh
+++ b/skills/github/tests/pr-merge.sh
@@ -457,8 +457,8 @@ assert_eq "$status" "75" "active mergeQueueEntry is success-pending"
 assert_contains "$out" "QUEUED IN MERGE QUEUE PR #123" "merge-queue outcome is explicit"
 assert_contains "$out" "queueState=QUEUED" "merge-queue state is preserved"
 assert_contains "$out" "VOLATILE" "queued exit 75 states the state is volatile"
-assert_contains "$out" "queue-wait 123" "queued exit 75 names the ejection watcher"
-assert_contains "$out" "pr-merge 123 --auto" "queued exit 75 names the re-arm"
+assert_contains "$out" ".agents/skills/orch/scripts/queue-wait 123" "queued exit 75 names the ejection watcher by runnable path"
+assert_contains "$out" "github.sh pr-merge 123 --auto" "queued exit 75 names the re-arm"
 
 set +e
 out=$(STUB_CHECKS="$checks" \
@@ -472,7 +472,7 @@ set -e
 assert_eq "$status" "75" "classic auto-merge remains success-pending"
 assert_contains "$out" "AUTO-MERGE ENABLED PR #123" "classic auto-merge outcome is distinct"
 assert_contains "$out" "VOLATILE" "auto-merge exit 75 states the state is volatile"
-assert_contains "$out" "queue-wait 123" "auto-merge exit 75 names the ejection watcher"
+assert_contains "$out" ".agents/skills/orch/scripts/queue-wait 123" "auto-merge exit 75 names the ejection watcher by runnable path"
 
 set +e
 out=$(STUB_CHECKS="$checks" \

--- a/skills/github/tests/pr-merge.sh
+++ b/skills/github/tests/pr-merge.sh
@@ -456,6 +456,9 @@ set -e
 assert_eq "$status" "75" "active mergeQueueEntry is success-pending"
 assert_contains "$out" "QUEUED IN MERGE QUEUE PR #123" "merge-queue outcome is explicit"
 assert_contains "$out" "queueState=QUEUED" "merge-queue state is preserved"
+assert_contains "$out" "VOLATILE" "queued exit 75 states the state is volatile"
+assert_contains "$out" "queue-wait 123" "queued exit 75 names the ejection watcher"
+assert_contains "$out" "pr-merge 123 --auto" "queued exit 75 names the re-arm"
 
 set +e
 out=$(STUB_CHECKS="$checks" \
@@ -468,6 +471,8 @@ status=$?
 set -e
 assert_eq "$status" "75" "classic auto-merge remains success-pending"
 assert_contains "$out" "AUTO-MERGE ENABLED PR #123" "classic auto-merge outcome is distinct"
+assert_contains "$out" "VOLATILE" "auto-merge exit 75 states the state is volatile"
+assert_contains "$out" "queue-wait 123" "auto-merge exit 75 names the ejection watcher"
 
 set +e
 out=$(STUB_CHECKS="$checks" \


### PR DESCRIPTION
## Summary

`pr-merge` exit 75 (queued / auto-merge armed) is volatile — a merge-group ejection disarms it silently — and nothing said so. Three PRs armed overnight sat open, gate-clear, and unwatched for hours because the caller treated 75 as fire-and-forget.

## What changed

- `pr-merge`: both exit-75 paths print one `NOTE` line stating the volatility and naming the watchers (`queue-wait <N>` → `ejected`/`disarmed` verdict; `pr-watch.sh` → `disarmed … (re-arm)` lines) and the re-arm (`pr-merge <N> --auto`). The old `Track with: await-mergeable` hint is removed: `await-mergeable` returns as soon as GitHub computes a merge state and never observes an ejection.
- `SKILL.md` § PR Merge Outcomes: both `75` rows are `MERGE PENDING (volatile)` with "keep watching until MERGED"; a paragraph names the required watcher and states `await-mergeable` is not it.
- CHANGELOG entry.

## Proof

- `tools/validate-changed`: 5 lanes (preflight, gate-selftest, shell lints, github suite ×21, orch run-all) all green; `preflight --base origin/main` clean.
- Pins: `tests/pr-merge.sh` asserts the NOTE, the watcher, and the re-arm on both 75 paths; new `tests/pr-merge-volatile-75-docs.test.sh` pins both table rows and the watcher wording to the script. Red once against origin/main's `pr-merge.sh` + `SKILL.md`: 8/8 docs pins fail, 5/5 script pins fail; green with the change.

Closes VST-295 (GitHub #1347)

https://claude.ai/code/session_01RqdGH7w3Qz8EoYU2yS8z8X
