### PR TITLE
fix(orch): worktree-claim preflights jq and states what it does not guarantee (VST-270)

### DIFF
--- a/skills/orch/scripts/worktree-claim
+++ b/skills/orch/scripts/worktree-claim
@@ -5,10 +5,20 @@
 # The guard's lease is keyed to the owner string, which is the issue id, so two
 # sessions working the same issue match each other's lease and an owner
 # comparison alone cannot refuse a sibling writer. The lease's per-claim
-# generation token can. This binds a caller to the token it took possession
-# under and refuses, exit 75, once any other holder — a different issue's
-# lease, a lock taken outside the guard, a sibling's re-claim, or a lease
-# released underneath the expectation — would make the caller a second writer.
+# generation token narrows that: a caller is bound to the token it took
+# possession under, and exits 75 once a different issue's lease, a lock taken
+# outside the guard, or a re-claim since that token was minted would make it a
+# second writer.
+#
+# What it does NOT do is identify the caller. Two orchestrators on one issue
+# share both the lease and the workflow state file that records the token, and
+# no per-session identity is available to tell them apart — a harness tool call
+# is its own session leader and exits with the call, so the pid the guard
+# records is never a live holder, and `refresh` rewrites it to whichever
+# process refreshed. The guarantee here is that they cannot both proceed
+# unaware: the second claim mints a new generation, and the displaced session's
+# next stamp exits 75. Refusing a second implementer outright is
+# `worktree create <ID>`, which surveys worktrees, refs and open PRs.
 #
 # Usage:
 #   worktree-claim --worktree PATH --issue ID [--state-dir DIR]
@@ -48,7 +58,7 @@ GUARD_UNMANAGED=4
 GEN_GRAMMAR='^[0-9]+-[0-9a-f]+$'
 
 usage() {
-	sed -n '2,35p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+	sed -n '2,43p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
 }
 
 fail() {
@@ -103,8 +113,12 @@ done
 
 # A guard that cannot run leaves possession unproven, which is the one outcome
 # this gate exists to prevent — so it is a hard failure, never a pass-through.
+# jq reads every lease field this gate compares, so a missing jq is the same
+# unproven state; catching it here keeps the exit contract at 1, not 127.
 [[ -x "$GUARD" ]] \
 	|| fail "worktree-session-guard is not executable at $GUARD; possession cannot be verified"
+command -v jq >/dev/null 2>&1 \
+	|| fail "jq is required to read the guard's lease; possession cannot be verified"
 
 worktree_abs="$(cd -P -- "$worktree" 2>/dev/null && pwd -P)" \
 	|| fail "not a directory: $worktree"

--- a/skills/orch/scripts/worktree-claim
+++ b/skills/orch/scripts/worktree-claim
@@ -15,10 +15,13 @@
 # no per-session identity is available to tell them apart — a harness tool call
 # is its own session leader and exits with the call, so the pid the guard
 # records is never a live holder, and `refresh` rewrites it to whichever
-# process refreshed. The guarantee here is that they cannot both proceed
-# unaware: the second claim mints a new generation, and the displaced session's
-# next stamp exits 75. Refusing a second implementer outright is
-# `worktree create <ID>`, which surveys worktrees, refs and open PRs.
+# process refreshed. A second orchestrator that reads the same stored token
+# therefore continues the round beside the first and neither is refused.
+# What is caught is a writer that takes the tree WITHOUT that token — a fresh
+# claim, a reused worktree, a different issue — since it mints a new generation
+# and the displaced session's next stamp exits 75. Refusing a second
+# implementer outright is `worktree create <ID>`, which surveys worktrees,
+# local and remote refs, and open PRs.
 #
 # Usage:
 #   worktree-claim --worktree PATH --issue ID [--state-dir DIR]
@@ -57,8 +60,10 @@ GUARD_UNMANAGED=4
 
 GEN_GRAMMAR='^[0-9]+-[0-9a-f]+$'
 
+# The leading comment block is the contract, printed by shape rather than by
+# line number so --help cannot drift as that block grows.
 usage() {
-	sed -n '2,43p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+	awk 'NR == 1 { next } /^#/ { sub(/^# ?/, ""); print; next } { exit }' "${BASH_SOURCE[0]}"
 }
 
 fail() {

--- a/skills/orch/tests/worktree_claim.sh
+++ b/skills/orch/tests/worktree_claim.sh
@@ -89,8 +89,8 @@ no_jq_path="$TMP_ROOT/no-jq"
 mkdir -p "$no_jq_path"
 ln -s "$(command -v dirname)" "$no_jq_path/dirname"
 no_jq_rc=0
-PATH="$no_jq_path" "$(command -v bash)" "$CLAIM" --worktree "$wt_a" --issue VST-1 \
-  >"$run_out" 2>"$run_err" || no_jq_rc=$?
+env "WORKTREE_SESSION_GUARD=$GUARD" "PATH=$no_jq_path" "$(command -v bash)" "$CLAIM" \
+  --worktree "$wt_a" --issue VST-1 >"$run_out" 2>"$run_err" || no_jq_rc=$?
 assert_eq "$no_jq_rc" "1" "a missing jq fails closed with exit 1, not 127"
 assert_eq "$(grep -c 'jq is required' "$run_err")" "1" "the missing-jq refusal names jq"
 
@@ -282,6 +282,23 @@ tok_d3="$(cat "$run_out")"
 assert_eq "$(lease_gen "$wt_d" VST-4)" "$tok_d3" "the repossession minted the lease it reports"
 assert_eq "$(jq -r '.worktree_gen' "$state_file")" "$tok_d3" \
   "the repossession records the new token in workflow state"
+
+echo
+echo "=== --help prints the whole contract ==="
+
+help_out="$("$CLAIM" --help)"
+for phrase in "possession gate for an issue worktree" "--expect-gen TOKEN" "Exit codes:" "75   refused"; do
+  if grep -Fq -- "$phrase" <<<"$help_out"; then
+    pass "--help carries: $phrase"
+  else
+    fail "--help dropped: $phrase"
+  fi
+done
+if grep -q '^#' <<<"$help_out"; then
+  fail "--help leaked a raw comment marker"
+else
+  pass "--help strips the comment markers"
+fi
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/skills/orch/tests/worktree_claim.sh
+++ b/skills/orch/tests/worktree_claim.sh
@@ -79,6 +79,21 @@ assert_eq "$RUN_RC" "1" "main checkout is refused (guard is actually consulted)"
 WORKTREE_SESSION_GUARD="$TMP_ROOT/no-such-guard" run_claim --worktree "$wt_a" --issue VST-1
 assert_eq "$RUN_RC" "1" "unrunnable guard fails closed with exit 1"
 
+# jq reads every lease field the gate compares, so its absence is the same
+# unproven state — and must stay inside the documented 0/1/75 contract rather
+# than escaping as a 127 from the first pipeline that reaches for it.
+# A PATH holding only what the script needs to reach the preflight starves it
+# of jq alone — an empty PATH would starve it of its own interpreter instead,
+# and prove nothing about this check.
+no_jq_path="$TMP_ROOT/no-jq"
+mkdir -p "$no_jq_path"
+ln -s "$(command -v dirname)" "$no_jq_path/dirname"
+no_jq_rc=0
+PATH="$no_jq_path" "$(command -v bash)" "$CLAIM" --worktree "$wt_a" --issue VST-1 \
+  >"$run_out" 2>"$run_err" || no_jq_rc=$?
+assert_eq "$no_jq_rc" "1" "a missing jq fails closed with exit 1, not 127"
+assert_eq "$(grep -c 'jq is required' "$run_err")" "1" "the missing-jq refusal names jq"
+
 echo
 echo "=== usage ==="
 


### PR DESCRIPTION
## Summary

Two review findings on #1351 landed after it had already merged. Both are addressed here.

## What changed

**jq is preflighted.** Every lease field `worktree-claim` compares is read through `jq`, but nothing checked it was installed — on a host without it the script escaped as a `127` from the first pipeline that reached for it, outside its documented `0`/`1`/`75` contract. It is now a precondition failure alongside an unrunnable guard, with the same diagnostic shape.

**The header states what the mechanism does not guarantee.** It previously read as though the generation token refused any second writer. It does not: two orchestrators on one issue share both the lease and the workflow state file that records the token, and no per-session identity is available to separate them — a harness tool call is its own session leader and exits with the call (measured: two consecutive calls reported `sess` 3573495 then 3574806, the first already gone), and the guard's `refresh` rewrites pid/host to whichever process refreshed. #1351 removed an attempted holder comparison for exactly that reason; this records the limit where the next reader of the script will see it, next to the guarantee that does hold — a second claim mints a new generation, so the displaced session's next stamp exits 75 and neither session proceeds unaware. Refusing a second implementer outright remains `worktree create <ID>`.

## Proof

`tools/validate-changed` — all lanes pass. `size-ratchet` OK, `preflight --base origin/main` clean. `skills/orch/tests/worktree_claim.sh` is 52 assertions.

### Red-once

Removing the jq preflight turns `a missing jq fails closed with exit 1, not 127` into a bare exit-1 with no diagnostic, and the paired `the missing-jq refusal names jq` assertion goes RED. The pin reaches the preflight through a PATH holding only `dirname` — an empty PATH would starve the script of its own interpreter and prove nothing about this check, which is how the first draft of the pin passed vacuously.

Follows up VST-270 / #1351

https://claude.ai/code/session_01RqdGH7w3Qz8EoYU2yS8z8X
