### PR TITLE
fix(review-gate,size-ratchet): unreadable settings source fails closed; batched wc collection (VST-239)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,11 @@
   grep exit >= 2 as an unreadable source and refuses by name (the discipline
   growth-guards already carried). This retires review-predicate-selftest's
   own unreadable-settings guard: the resolver refuses first, for the live
-  predicate and writer as much as for the selftest. Repos vendoring
-  review-gate or size-ratchet must re-vendor.
+  predicate and writer as much as for the selftest. The same "only an
+  ABSENT source is skipped" rule now covers the `.env.local` and `.env`
+  lanes, which still fell through on a directory, FIFO, socket, device or
+  unresolvable symlink. Repos vendoring review-gate, size-ratchet or
+  growth-guards must re-vendor.
 - size-ratchet: the collection loop measures worktree files in batched `wc`
   invocations instead of one process per file — 6.3s -> 0.8s on a tree
   measuring 9,325 files, 0.86s -> 0.09s on one measuring 1,454, with the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## Unreleased
 
+- review-gate/size-ratchet: settings resolution fails closed on a source it
+  cannot read. `-f` and `-e` both pass on an existing mode-000 file, so only
+  the read itself sees it: `grep` failed, the resolver read that as "no
+  match", and resolution fell through to a lower-precedence source or to the
+  built-in default — a configured value silently replaced by another one, on
+  the gate a permissive default nobody set. Every settings probe now treats
+  grep exit >= 2 as an unreadable source and refuses by name (the discipline
+  growth-guards already carried). This retires review-predicate-selftest's
+  own unreadable-settings guard: the resolver refuses first, for the live
+  predicate and writer as much as for the selftest. Repos vendoring
+  review-gate or size-ratchet must re-vendor.
+- size-ratchet: the collection loop measures worktree files in batched `wc`
+  invocations instead of one process per file — 6.3s -> 0.8s on a tree
+  measuring 9,325 files, 0.86s -> 0.09s on one measuring 1,454, with the
+  verdict byte-identical on both. Counts are matched to inputs by position,
+  so a batch that comes back short, out of order or non-numeric is discarded
+  and re-measured one file at a time: an unreadable or vanished file still
+  fails loud naming that file, and a count row is required for every file
+  selected.
 - second-opinion: a multi-lane review run without `--output` no longer keeps
   its lane reviews in shared system temp (VST-241), and the lane umask no
   longer governs the external model CLI's own files (VST-243). Each lane's

--- a/skills/growth-guards/README.md
+++ b/skills/growth-guards/README.md
@@ -155,8 +155,11 @@ type(scope)!: subject        # scope and '!' optional
 Each key resolves environment > `.env.local` > `.vstack/settings.toml` >
 committed `vstack.settings.toml` (flat `KEY = "value"` under `[env]`) >
 `.env` > default (env files use `KEY=value` or `export KEY=value`; parsed,
-never sourced). Per-check flags (`--excludes`, `--baseline`) override
-every source for the paths. All relative paths are repo-root-relative; the
+never sourced). Only an ABSENT source is skipped: a source that exists but
+is unusable — unreadable, a directory, FIFO, socket or device, or a symlink
+that does not resolve — is a config error (exit 2), never a fall-through to
+the next layer; `/dev/null` forces the built-in defaults. Per-check flags
+(`--excludes`, `--baseline`) override every source for the paths. All relative paths are repo-root-relative; the
 scripts `cd` to `git rev-parse --show-toplevel` before resolving anything.
 
 ```toml

--- a/skills/growth-guards/SKILL.md
+++ b/skills/growth-guards/SKILL.md
@@ -53,7 +53,10 @@ file from a gate.
 Resolution order for every key: explicit environment > `.env.local`
 (personal, untracked) > `.vstack/settings.toml` > the repo's committed
 `vstack.settings.toml` (flat `KEY = "value"` under `[env]`) > `.env` >
-built-in default.
+built-in default. Only an ABSENT source is skipped: a source that exists
+but is unusable — unreadable, a directory, FIFO, socket or device, or a
+symlink that does not resolve — is a config error (exit 2), never a
+fall-through to the next layer. `/dev/null` forces the built-in defaults.
 
 | Key | Default | Meaning |
 |---|---|---|

--- a/skills/growth-guards/scripts/lib/settings.sh
+++ b/skills/growth-guards/scripts/lib/settings.sh
@@ -77,6 +77,24 @@ gg_dotenv_value() { # RAW — value on stdout; nonzero on an unsupported shape
   return 1
 }
 
+# A source is skipped only when it is ABSENT. A path that exists as
+# something else — directory, FIFO, socket, device — fails -f exactly like
+# an absent one, and a symlink that does not resolve fails -e as well as -f,
+# so -L is what sees it at all: either shape would skip a configured source
+# with nothing said and let a lower-precedence value decide. /dev/null is
+# the documented force-defaults handle and stays exempt.
+gg_settings_usable() { # PATH — 0 = readable-shaped or absent; 1 + ::error otherwise
+  [ "$1" != "/dev/null" ] || return 0
+  { [ -e "$1" ] || [ -L "$1" ]; } || return 0
+  [ ! -f "$1" ] || return 0
+  if [ ! -e "$1" ]; then
+    echo "::error::$1: settings source is a symlink that does not resolve (dangling target, cycle, or over-long chain); a source is skipped only when it is absent" >&2
+  else
+    echo "::error::$1: settings source exists but is not a regular file (directory, FIFO, socket or device); a source is skipped only when it is absent" >&2
+  fi
+  return 1
+}
+
 # One read discipline for every settings probe: grep exits 0/1 are
 # measurements, anything else is an unreadable source and fails loud —
 # falling through to a lower-precedence layer would silently change the
@@ -112,6 +130,7 @@ gg_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
   # Env-file overrides (standard project layering: .env.local beats the
   # committed settings, .env is the base) — LAST matching KEY= line wins (shell-sourcing semantics),
   # optional surrounding quotes stripped. Parsed, never sourced.
+  gg_settings_usable ".env.local" || return 1
   if [ -f ".env.local" ]; then
     status=0
     matches="$(gg_settings_grep "^[[:space:]]*(export[[:space:]]+)?${name}=" .env.local)" || status=$?
@@ -134,21 +153,7 @@ gg_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
     set -- ".vstack/settings.toml" "vstack.settings.toml"
   fi
   for file in "$@"; do
-  # The fall-back past this file covers an ABSENT PLAIN FILE only. A path
-  # that EXISTS as something else — directory, FIFO, socket, device — fails
-  # -f exactly like an absent one, so the configured settings would be
-  # skipped with nothing said and the built-in default would decide. A
-  # symlink that does not resolve fails -e as well as -f, so -L is what sees
-  # it at all. /dev/null is the documented force-defaults handle and stays
-  # exempt.
-  if [ "$file" != "/dev/null" ] && { [ -e "$file" ] || [ -L "$file" ]; } && [ ! -f "$file" ]; then
-    if [ ! -e "$file" ]; then
-      echo "::error::$file: settings path is a symlink that does not resolve (dangling target, cycle, or over-long chain); the fall-back to built-in defaults covers an absent plain file only" >&2
-    else
-      echo "::error::$file: settings path exists but is not a regular file (directory, FIFO, socket or device); the fall-back to built-in defaults covers an absent plain file only" >&2
-    fi
-    return 1
-  fi
+  gg_settings_usable "$file" || return 1
   if [ -f "$file" ]; then
     # Key PRESENCE decides, not value non-emptiness: `NAME = ""` is a real
     # assignment and must override the built-in default, exactly like a
@@ -186,6 +191,7 @@ gg_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
     fi
   fi
   done
+  gg_settings_usable ".env" || return 1
   if [ -f ".env" ]; then
     status=0
     matches="$(gg_settings_grep "^[[:space:]]*(export[[:space:]]+)?${name}=" .env)" || status=$?

--- a/skills/growth-guards/tests/byte-ceiling.test.sh
+++ b/skills/growth-guards/tests/byte-ceiling.test.sh
@@ -262,6 +262,29 @@ else
   rm "$R/.env.local"
 fi
 
+echo "=== an EXISTING non-regular ENV-FILE source never falls through ==="
+# .env.local and .env are probed with -f like the settings file, so a
+# directory or an unresolvable symlink there is skipped exactly like an
+# absent one and a lower-precedence value silently decides.
+mkdir -p "$R/.env.local"
+run_bc_default
+[ "$RC" -eq 2 ] && case "$OUT" in *".env.local: settings source exists but is not a regular file"*) true ;; *) false ;; esac \
+  && ok "a DIRECTORY at .env.local is exit 2 (falling through would have read 3 from the settings file)" \
+  || bad "a DIRECTORY at .env.local is exit 2" "rc=$RC out=$OUT"
+rmdir "$R/.env.local"
+
+ln -s missing.env "$R/.env"
+run_bc_default
+[ "$RC" -eq 2 ] && case "$OUT" in *".env: settings source is a symlink that does not resolve"*) true ;; *) false ;; esac \
+  && ok "a DANGLING .env symlink is exit 2, not a silent skip" \
+  || bad "a DANGLING .env symlink is exit 2" "rc=$RC out=$OUT"
+rm -f "$R/.env"
+
+run_bc_default
+[ "$RC" -eq 1 ] && case "$OUT" in *"ceiling 3 KB"*) true ;; *) false ;; esac \
+  && ok "control: with both env files absent the settings file still supplies 3" \
+  || bad "control: absent env files fall through to the settings file" "rc=$RC out=$OUT"
+
 echo "=== fail-closed: a broken blob measurement terminates, never passes ==="
 new_repo measure
 mkbytes big.bin 2

--- a/skills/review-gate/references/settings.md
+++ b/skills/review-gate/references/settings.md
@@ -45,9 +45,11 @@ Two env-only PER-INVOCATION seams are deliberately NOT settings keys:
   would be circular. Falling back to built-in defaults covers an ABSENT
   PLAIN FILE only: a path that exists as a directory, FIFO, socket or
   device, or a symlink that does not resolve (dangling target, cycle,
-  over-long chain), is a configuration error every reader fails loud on. A
-  symlink that DOES resolve to a regular file reads normally. `/dev/null`
-  is the one exempt path — the documented handle for forcing defaults.
+  over-long chain), is a configuration error every reader fails loud on —
+  as is a file that exists but cannot be READ, which `-f` and `-e` both
+  accept and only the read itself catches. A symlink that DOES resolve to a
+  readable regular file reads normally. `/dev/null` is the one exempt path
+  — the documented handle for forcing defaults.
 - `REVIEW_GATE_STATUS_SNAPSHOT_FILE` — path to a status snapshot (JSON
   object with a `statuses` array and a top-level `sha` equal to the
   invocation's `HEAD_SHA`) the CALLER already holds. The rows must come

--- a/skills/review-gate/scripts/lib/settings.sh
+++ b/skills/review-gate/scripts/lib/settings.sh
@@ -26,9 +26,23 @@
 # Scripts run from the repo root in CI (workflow working directory), so the
 # default settings path is relative.
 
+# One read discipline for every settings probe: grep exits 0/1 are
+# measurements, anything else is an unreadable source and fails loud —
+# falling through to a lower-precedence layer would silently change the
+# resolved value.
+rg_settings_grep() { # REGEX FILE — matching lines on stdout; 1 = no match
+  local status=0
+  grep -E -- "$1" "$2" || status=$?
+  if [ "$status" -gt 1 ]; then
+    echo "::error::$2: unreadable while resolving a setting (grep exit $status)" >&2
+    return 2
+  fi
+  return "$status"
+}
+
 rg_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
                # a present-but-unparseable assignment (callers must propagate)
-  local name="$1" default="$2" line val file
+  local name="$1" default="$2" line val file status matches
   # The name is interpolated into ERE patterns below; constrain it to the
   # identifier shape every real key has, so a metacharacter can neither
   # misgrep nor inject pattern syntax.
@@ -69,16 +83,19 @@ rg_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
     # — anchoring at column one made an indented duplicate bypass the
     # fail-loud guard and an indented sole assignment collapse silently to
     # the built-in default (vstack#1059).
-    if grep -Eq -- "^[[:space:]]*${name}[[:space:]]*=" "$file"; then
+    status=0
+    matches="$(rg_settings_grep "^[[:space:]]*${name}[[:space:]]*=" "$file")" || status=$?
+    [ "$status" -le 1 ] || return 1
+    if [ "$status" -eq 0 ]; then
       # File-wide matching (header contract) makes a re-assigned name
       # ambiguous — e.g. the same key under two tables. Silently taking the
       # first could read an unrelated table's value on a security-sensitive
       # path, so ambiguity is a configuration error.
-      if [ "$(grep -Ec -- "^[[:space:]]*${name}[[:space:]]*=" "$file")" -gt 1 ]; then
+      if [ "$(printf '%s\n' "$matches" | grep -c .)" -gt 1 ]; then
         echo "::error::$file: $name is assigned more than once (keys are matched file-wide regardless of TOML table; each name must be unique in the file)" >&2
         return 1
       fi
-      line="$(grep -E -- "^[[:space:]]*${name}[[:space:]]*=" "$file" | head -n 1)"
+      line="$(printf '%s\n' "$matches" | head -n 1)"
       # A PRESENT assignment this parser cannot read (e.g. TOML array syntax
       # for a list key) must fail LOUDLY, never collapse to empty: an empty
       # value can silently widen the gate (empty trusted-logins = any

--- a/skills/review-gate/scripts/lib/settings.sh
+++ b/skills/review-gate/scripts/lib/settings.sh
@@ -26,6 +26,24 @@
 # Scripts run from the repo root in CI (workflow working directory), so the
 # default settings path is relative.
 
+# A source is skipped only when it is ABSENT. A path that exists as
+# something else — directory, FIFO, socket, device — fails -f exactly like
+# an absent one, and a symlink that does not resolve fails -e as well as -f,
+# so -L is what sees it at all: either shape would skip a configured source
+# with nothing said and let a lower-precedence value decide. /dev/null is
+# the documented force-defaults handle and stays exempt.
+rg_settings_usable() { # PATH — 0 = readable-shaped or absent; 1 + ::error otherwise
+  [ "$1" != "/dev/null" ] || return 0
+  { [ -e "$1" ] || [ -L "$1" ]; } || return 0
+  [ ! -f "$1" ] || return 0
+  if [ ! -e "$1" ]; then
+    echo "::error::$1: settings source is a symlink that does not resolve (dangling target, cycle, or over-long chain); a source is skipped only when it is absent" >&2
+  else
+    echo "::error::$1: settings source exists but is not a regular file (directory, FIFO, socket or device); a source is skipped only when it is absent" >&2
+  fi
+  return 1
+}
+
 # One read discipline for every settings probe: grep exits 0/1 are
 # measurements, anything else is an unreadable source and fails loud —
 # falling through to a lower-precedence layer would silently change the
@@ -59,21 +77,7 @@ rg_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
     return 0
   fi
   file="${REVIEW_GATE_SETTINGS_FILE:-vstack.settings.toml}"
-  # The fall-back-to-defaults path covers an ABSENT PLAIN FILE only. A path
-  # that EXISTS as something else — directory, FIFO, socket, device — fails
-  # -f exactly like an absent one, so every key would resolve to its
-  # built-in default with nothing said, and an empty default widens the gate
-  # (empty trusted-logins = any non-author). A symlink that does not resolve
-  # fails -e as well as -f, so -L is what sees it at all. /dev/null is the
-  # documented force-defaults handle and stays exempt.
-  if [ "$file" != "/dev/null" ] && { [ -e "$file" ] || [ -L "$file" ]; } && [ ! -f "$file" ]; then
-    if [ ! -e "$file" ]; then
-      echo "::error::$file: settings path is a symlink that does not resolve (dangling target, cycle, or over-long chain); the fall-back to built-in defaults covers an absent plain file only" >&2
-    else
-      echo "::error::$file: settings path exists but is not a regular file (directory, FIFO, socket or device); the fall-back to built-in defaults covers an absent plain file only" >&2
-    fi
-    return 1
-  fi
+  rg_settings_usable "$file" || return 1
   if [ -f "$file" ]; then
     # Key PRESENCE decides, not value non-emptiness: `NAME = ""` is a real
     # assignment ("empty disables" per the settings docs) and must override the

--- a/skills/review-gate/scripts/review-predicate-selftest.sh
+++ b/skills/review-gate/scripts/review-predicate-selftest.sh
@@ -36,23 +36,6 @@ predicate="$here/review-predicate.sh"
 [ -x "$predicate" ] || { echo "not executable: $predicate" >&2; exit 1; }
 . "$here/lib/settings.sh"
 
-# A settings override that is unusable — a directory, FIFO, socket, device,
-# or a symlink that does not resolve — is rg_setting's refusal, for the live
-# engine as much as for this run. What rg_setting cannot see is an EXISTING
-# but UNREADABLE file: its grep presence probe just fails and every key
-# quietly resolves to its built-in default, so this run would green-light
-# settings it never read. A plain absent file keeps the documented
-# fall-back-to-defaults behavior.
-case "${REVIEW_GATE_SETTINGS_FILE:-}" in
-  '' | /dev/null) : ;;
-  *)
-    if [ -f "$REVIEW_GATE_SETTINGS_FILE" ] && [ ! -r "$REVIEW_GATE_SETTINGS_FILE" ]; then
-      echo "FATAL: REVIEW_GATE_SETTINGS_FILE ('$REVIEW_GATE_SETTINGS_FILE') exists but is not readable — refusing to test built-in defaults in its place" >&2
-      exit 1
-    fi
-    ;;
-esac
-
 # ------------------------------------------------------------ active config ---
 # Resolved exactly as the predicate resolves it, from the invoking repo's
 # environment/settings. The configured layer generates its cases from these.

--- a/skills/review-gate/tests/review-predicate-selftest.test.sh
+++ b/skills/review-gate/tests/review-predicate-selftest.test.sh
@@ -403,7 +403,7 @@ replay cyclic "$work/rooted/repo" REVIEW_GATE_SETTINGS_FILE="$work/cyclic/cycle-
 replay dangling "$work/rooted/repo" REVIEW_GATE_SETTINGS_FILE="$work/cyclic/dangling.settings.toml"
 replay nonregular "$work/rooted/repo" REVIEW_GATE_SETTINGS_FILE="$work/cyclic/nonregular.dir"
 # Skipped when the runner can read mode-000 files anyway (privileged CI) —
-# the guard is [ -r ]-based and cannot fire there.
+# the refusal comes from the read itself, which succeeds there.
 unreadable_skip=""
 if [ -r "$work/cyclic/unreadable.settings.toml" ]; then
   unreadable_skip=1
@@ -764,16 +764,16 @@ else
     || note "dangling-override failure does not carry the unresolvable-override diagnostic"
 fi
 
-# An EXISTING but UNREADABLE override must refuse up front too: rg_setting's
-# grep presence probe fails on it and every key silently resolves to its
-# built-in default.
+# An EXISTING but UNREADABLE override must refuse too: -f and -e both pass
+# on it, so only rg_setting's read discipline sees it — without which every
+# key silently resolves to its built-in default.
 if [ -n "$unreadable_skip" ]; then
   echo "skip: unreadable-override fixture (runner reads mode-000 files)"
 elif passed unreadable; then
   note "selftest passed with an UNREADABLE settings override — the silent-defaults guard no longer refuses"
 else
-  grep -q "exists but is not readable" "$work/unreadable.out" \
-    || note "unreadable-override failure does not carry the not-readable diagnostic"
+  grep -q "unreadable while resolving a setting" "$work/unreadable.out" \
+    || note "unreadable-override failure does not carry the unreadable-source diagnostic"
 fi
 
 # An EXISTING NON-REGULAR override (a directory here; a FIFO or socket is

--- a/skills/review-gate/tests/settings-parsing.test.sh
+++ b/skills/review-gate/tests/settings-parsing.test.sh
@@ -124,6 +124,28 @@ OUT=""; RC=0
 OUT="$(unset REVIEW_GATE_TL 2>/dev/null; REVIEW_GATE_SETTINGS_FILE="$TMP/link.settings.toml" rg_setting REVIEW_GATE_TL "dflt" 2>"$TMP/err")" || RC=$?
 [[ "$RC" -eq 0 && "$OUT" == "linked" ]] && ok "a RESOLVING symlink reads its target (control)" || bad "a RESOLVING symlink reads its target (control)" "rc=$RC out=$OUT"
 
+echo "=== an UNREADABLE settings source fails loud, never falls back ==="
+# grep exits 0/1 are measurements; anything else means the source could not
+# be read. -f and -e both pass on a mode-000 file, so only the read itself
+# sees it: falling back would resolve every key to its caller default, and
+# an empty default widens the gate (empty trusted-logins = any non-author).
+if [ "$(id -u)" -eq 0 ]; then
+  echo "  skip  unreadable-source pins need a non-root reader (chmod 000 cannot deny root)"
+else
+  printf 'REVIEW_GATE_TU = "configured"\n' >"$TMP/unreadable.settings.toml"
+  chmod 000 "$TMP/unreadable.settings.toml"
+  RC=0
+  rg_settings_grep "^REVIEW_GATE_TU" "$TMP/unreadable.settings.toml" >/dev/null 2>"$TMP/err" || RC=$?
+  [[ "$RC" -eq 2 ]] && grep -q "unreadable while resolving a setting" "$TMP/err" && ok "the read discipline reports 2 for an unreadable source, never 1 (no match)" || bad "the read discipline reports 2 for an unreadable source" "rc=$RC"
+  OUT=""; RC=0
+  OUT="$(unset REVIEW_GATE_TU 2>/dev/null; REVIEW_GATE_SETTINGS_FILE="$TMP/unreadable.settings.toml" rg_setting REVIEW_GATE_TU "dflt" 2>"$TMP/err")" || RC=$?
+  [[ "$RC" -ne 0 && "$OUT" != "dflt" ]] && grep -q "unreadable.settings.toml: unreadable while resolving a setting" "$TMP/err" && ok "an UNREADABLE settings path is a config error naming the file, not a silent default" || bad "an UNREADABLE settings path is a config error naming the file" "rc=$RC out=$OUT"
+  chmod 600 "$TMP/unreadable.settings.toml"
+  OUT=""; RC=0
+  OUT="$(unset REVIEW_GATE_TU 2>/dev/null; REVIEW_GATE_SETTINGS_FILE="$TMP/unreadable.settings.toml" rg_setting REVIEW_GATE_TU "dflt" 2>"$TMP/err")" || RC=$?
+  [[ "$RC" -eq 0 && "$OUT" == "configured" ]] && ok "control: the same file, readable, resolves its value" || bad "control: the same file, readable, resolves its value" "rc=$RC out=$OUT"
+fi
+
 # Controls: the two shapes that MUST still resolve to the caller default.
 OUT=""; RC=0
 OUT="$(unset REVIEW_GATE_TN 2>/dev/null; REVIEW_GATE_SETTINGS_FILE=/dev/null rg_setting REVIEW_GATE_TN "dflt" 2>"$TMP/err")" || RC=$?

--- a/skills/size-ratchet/README.md
+++ b/skills/size-ratchet/README.md
@@ -100,8 +100,12 @@ src/gen/*.rs	generated bindings
 Each key resolves environment > `.env.local` > `.vstack/settings.toml` > committed `vstack.settings.toml`
 (flat `KEY = "value"` assignment under `[env]`) >
 `.env` > default (env files use `KEY=value` or `export KEY=value`; parsed,
-never sourced). `--baseline` / `--excludes` flags override every source for
-the paths. All relative paths are
+never sourced). Only an ABSENT source is skipped: a source that exists but
+is unusable — unreadable, a directory, FIFO, socket or device, or a symlink
+that does not resolve — is a config error (exit 2), never a fall-through to
+the next layer; `/dev/null` forces the built-in defaults. `--baseline` /
+`--excludes` flags override every source for the paths. All relative paths
+are
 repo-root-relative; the script `cd`s to `git rev-parse --show-toplevel`
 before resolving anything.
 

--- a/skills/size-ratchet/SKILL.md
+++ b/skills/size-ratchet/SKILL.md
@@ -68,7 +68,10 @@ offenders remain.
 Resolution order for every key: explicit environment > `.env.local`
 (personal, untracked) > `.vstack/settings.toml` > the repo's committed
 `vstack.settings.toml` (flat `KEY = "value"` under `[env]`) > `.env` >
-built-in default.
+built-in default. Only an ABSENT source is skipped: a source that exists
+but is unusable — unreadable, a directory, FIFO, socket or device, or a
+symlink that does not resolve — is a config error (exit 2), never a
+fall-through to the next layer. `/dev/null` forces the built-in defaults.
 
 | Key | Default | Meaning |
 |---|---|---|

--- a/skills/size-ratchet/scripts/lib/settings.sh
+++ b/skills/size-ratchet/scripts/lib/settings.sh
@@ -75,6 +75,24 @@ sr_dotenv_value() { # RAW — value on stdout; nonzero on an unsupported shape
   return 1
 }
 
+# A source is skipped only when it is ABSENT. A path that exists as
+# something else — directory, FIFO, socket, device — fails -f exactly like
+# an absent one, and a symlink that does not resolve fails -e as well as -f,
+# so -L is what sees it at all: either shape would skip a configured source
+# with nothing said and let a lower-precedence value decide. /dev/null is
+# the documented force-defaults handle and stays exempt.
+sr_settings_usable() { # PATH — 0 = readable-shaped or absent; 1 + ::error otherwise
+  [ "$1" != "/dev/null" ] || return 0
+  { [ -e "$1" ] || [ -L "$1" ]; } || return 0
+  [ ! -f "$1" ] || return 0
+  if [ ! -e "$1" ]; then
+    echo "::error::$1: settings source is a symlink that does not resolve (dangling target, cycle, or over-long chain); a source is skipped only when it is absent" >&2
+  else
+    echo "::error::$1: settings source exists but is not a regular file (directory, FIFO, socket or device); a source is skipped only when it is absent" >&2
+  fi
+  return 1
+}
+
 # One read discipline for every settings probe: grep exits 0/1 are
 # measurements, anything else is an unreadable source and fails loud —
 # falling through to a lower-precedence layer would silently change the
@@ -110,6 +128,7 @@ sr_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
   # Env-file overrides (standard project layering: .env.local beats the
   # committed settings, .env is the base) — LAST matching KEY= line wins (shell-sourcing semantics),
   # optional surrounding quotes stripped. Parsed, never sourced.
+  sr_settings_usable ".env.local" || return 1
   if [ -f ".env.local" ]; then
     status=0
     matches="$(sr_settings_grep "^[[:space:]]*(export[[:space:]]+)?${name}=" .env.local)" || status=$?
@@ -132,21 +151,7 @@ sr_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
     set -- ".vstack/settings.toml" "vstack.settings.toml"
   fi
   for file in "$@"; do
-  # The fall-back past this file covers an ABSENT PLAIN FILE only. A path
-  # that EXISTS as something else — directory, FIFO, socket, device — fails
-  # -f exactly like an absent one, so the configured settings would be
-  # skipped with nothing said and the built-in default would decide. A
-  # symlink that does not resolve fails -e as well as -f, so -L is what sees
-  # it at all. /dev/null is the documented force-defaults handle and stays
-  # exempt.
-  if [ "$file" != "/dev/null" ] && { [ -e "$file" ] || [ -L "$file" ]; } && [ ! -f "$file" ]; then
-    if [ ! -e "$file" ]; then
-      echo "::error::$file: settings path is a symlink that does not resolve (dangling target, cycle, or over-long chain); the fall-back to built-in defaults covers an absent plain file only" >&2
-    else
-      echo "::error::$file: settings path exists but is not a regular file (directory, FIFO, socket or device); the fall-back to built-in defaults covers an absent plain file only" >&2
-    fi
-    return 1
-  fi
+  sr_settings_usable "$file" || return 1
   if [ -f "$file" ]; then
     # Key PRESENCE decides, not value non-emptiness: `NAME = ""` is a real
     # assignment and must override the built-in default, exactly like a
@@ -184,6 +189,7 @@ sr_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
     fi
   fi
   done
+  sr_settings_usable ".env" || return 1
   if [ -f ".env" ]; then
     status=0
     matches="$(sr_settings_grep "^[[:space:]]*(export[[:space:]]+)?${name}=" .env)" || status=$?

--- a/skills/size-ratchet/scripts/lib/settings.sh
+++ b/skills/size-ratchet/scripts/lib/settings.sh
@@ -75,9 +75,23 @@ sr_dotenv_value() { # RAW — value on stdout; nonzero on an unsupported shape
   return 1
 }
 
+# One read discipline for every settings probe: grep exits 0/1 are
+# measurements, anything else is an unreadable source and fails loud —
+# falling through to a lower-precedence layer would silently change the
+# resolved value.
+sr_settings_grep() { # REGEX FILE — matching lines on stdout; 1 = no match
+  local status=0
+  grep -E -- "$1" "$2" || status=$?
+  if [ "$status" -gt 1 ]; then
+    echo "::error::$2: unreadable while resolving a setting (grep exit $status)" >&2
+    return 2
+  fi
+  return "$status"
+}
+
 sr_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
                # a present-but-unparseable assignment (callers must propagate)
-  local name="$1" default="$2" line val file
+  local name="$1" default="$2" line val file status matches
   # The name is interpolated into ERE patterns below; constrain it to the
   # identifier shape every real key has, so a metacharacter can neither
   # misgrep nor inject pattern syntax.
@@ -97,7 +111,10 @@ sr_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
   # committed settings, .env is the base) — LAST matching KEY= line wins (shell-sourcing semantics),
   # optional surrounding quotes stripped. Parsed, never sourced.
   if [ -f ".env.local" ]; then
-    line="$(grep -E -- "^[[:space:]]*(export[[:space:]]+)?${name}=" .env.local | tail -n 1 || true)"
+    status=0
+    matches="$(sr_settings_grep "^[[:space:]]*(export[[:space:]]+)?${name}=" .env.local)" || status=$?
+    [ "$status" -le 1 ] || return 1
+    line="$(printf '%s\n' "$matches" | tail -n 1)"
     if [ -n "$line" ]; then
       if ! val="$(sr_dotenv_value "${line#*=}")"; then
         echo "::error::.env.local: unsupported syntax for $name (a quoted value must end at its closing quote, optionally followed by a comment)" >&2
@@ -139,16 +156,19 @@ sr_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
     # — anchoring at column one made an indented duplicate bypass the
     # fail-loud guard and an indented sole assignment collapse silently to
     # the built-in default (vstack#1059).
-    if grep -Eq -- "^[[:space:]]*${name}[[:space:]]*=" "$file"; then
+    status=0
+    matches="$(sr_settings_grep "^[[:space:]]*${name}[[:space:]]*=" "$file")" || status=$?
+    [ "$status" -le 1 ] || return 1
+    if [ "$status" -eq 0 ]; then
       # File-wide matching (header contract) makes a re-assigned name
       # ambiguous — e.g. the same key under two tables. Silently taking the
       # first could read an unrelated table's value, so ambiguity is a
       # configuration error.
-      if [ "$(grep -Ec -- "^[[:space:]]*${name}[[:space:]]*=" "$file")" -gt 1 ]; then
+      if [ "$(printf '%s\n' "$matches" | grep -c .)" -gt 1 ]; then
         echo "::error::$file: $name is assigned more than once (keys are matched file-wide regardless of TOML table; each name must be unique in the file)" >&2
         return 1
       fi
-      line="$(grep -E -- "^[[:space:]]*${name}[[:space:]]*=" "$file" | head -n 1)"
+      line="$(printf '%s\n' "$matches" | head -n 1)"
       # A PRESENT assignment this parser cannot read must fail LOUDLY, never
       # collapse to empty. Only the flat single-line basic-string shape is
       # supported — the value is quote-free ([^"]*), which makes the
@@ -165,7 +185,10 @@ sr_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
   fi
   done
   if [ -f ".env" ]; then
-    line="$(grep -E -- "^[[:space:]]*(export[[:space:]]+)?${name}=" .env | tail -n 1 || true)"
+    status=0
+    matches="$(sr_settings_grep "^[[:space:]]*(export[[:space:]]+)?${name}=" .env)" || status=$?
+    [ "$status" -le 1 ] || return 1
+    line="$(printf '%s\n' "$matches" | tail -n 1)"
     if [ -n "$line" ]; then
       if ! val="$(sr_dotenv_value "${line#*=}")"; then
         echo "::error::.env: unsupported syntax for $name (a quoted value must end at its closing quote, optionally followed by a comment)" >&2

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -186,7 +186,8 @@ is_excluded() { # PATH — 0 when some exclusion glob matches the full path
   # Guarded expansion: an empty array is an unbound variable under Bash 3.2
   # with set -u.
   for pat in ${EXCLUDE_PATTERNS[@]+"${EXCLUDE_PATTERNS[@]}"}; do
-    # shellcheck disable=SC2254 -- $pat must expand unquoted to act as a glob
+    # $pat must expand unquoted to act as a glob.
+    # shellcheck disable=SC2254
     case "$path" in
       $pat) return 0 ;;
     esac
@@ -251,6 +252,64 @@ NL='
 '
 checked=0
 : >"$TMP/counts.raw"
+# Worktree reads are batched: one `wc -l` invocation per bounded group of
+# files instead of one per file (a large repo materializes thousands).
+# wc emits its counts in argument order, so every output row is matched to
+# its input BY POSITION — which also places the `total` row a multi-file
+# invocation appends past the last input, where it is never read as a count.
+# A nonzero status, a short read, a non-numeric count or any positional
+# mismatch discards the whole batch (a partial batch is not a measurement)
+# and re-measures it one file at a time, so an unreadable or vanished file
+# still fails loud naming THAT file.
+BATCH_MAX_FILES=256
+BATCH_MAX_CHARS=60000 # ARG_MAX headroom for the assembled command line
+WT_BATCH=()
+WT_BATCH_CHARS=0
+
+flush_batch() { # — appends one "<path><TAB><count>" row per pending file
+  local status=0 idx=0 line count path n f
+  [ "${#WT_BATCH[@]}" -gt 0 ] || return 0
+  : >"$TMP/batch.tsv"
+  wc -l -- "${WT_BATCH[@]}" >"$TMP/wc.out" || status=$?
+  if [ "$status" -eq 0 ]; then
+    while IFS= read -r line; do
+      [ "$idx" -lt "${#WT_BATCH[@]}" ] || break
+      # wc pads counts with leading blanks (BSD wc does); one space then
+      # separates the count from the path, which may hold spaces but never
+      # a newline or tab (both refused above).
+      line="${line#"${line%%[![:space:]]*}"}"
+      count="${line%% *}"
+      path="${line#* }"
+      case "$count" in "" | *[!0-9]*) idx=-1 ;; esac
+      [ "$idx" -ge 0 ] || break
+      [ "$path" = "${WT_BATCH[$idx]}" ] || { idx=-1; break; }
+      printf '%s\t%s\n' "$path" "$count" >>"$TMP/batch.tsv"
+      idx=$((idx + 1))
+    done <"$TMP/wc.out"
+    if [ "$idx" -eq "${#WT_BATCH[@]}" ]; then
+      cat "$TMP/batch.tsv" >>"$TMP/counts.raw"
+      WT_BATCH=()
+      WT_BATCH_CHARS=0
+      return 0
+    fi
+  fi
+  : >"$TMP/batch.tsv"
+  for f in "${WT_BATCH[@]}"; do
+    # Same contract as the index path: a worktree file that exists but
+    # cannot be read (permissions, I/O error) is a collection failure with
+    # its own diagnostic — not a bare set -e death mid-loop.
+    n="$(wc -l <"$f")" || collection_error "cannot read tracked file '$f' — its size is unmeasurable, refusing to skip it"
+    n="${n#"${n%%[![:space:]]*}"}" # strip wc's leading whitespace (BSD wc pads)
+    case "$n" in
+      "" | *[!0-9]*) collection_error "line count for tracked file '$f' came back as '$n', not a number — its size is unmeasurable, refusing to skip it" ;;
+    esac
+    printf '%s\t%s\n' "$f" "$n" >>"$TMP/batch.tsv"
+  done
+  cat "$TMP/batch.tsv" >>"$TMP/counts.raw"
+  WT_BATCH=()
+  WT_BATCH_CHARS=0
+}
+
 while IFS= read -r -d '' rec; do
   # Record shape: "<mode> <sha> <stage>\t<path>".
   mode="${rec%% *}"
@@ -282,16 +341,23 @@ while IFS= read -r -d '' rec; do
     if ! n="$(git show ":$f" | wc -l)"; then
       collection_error "cannot read index blob for tracked file '$f' — its size is unmeasurable, refusing to skip it"
     fi
+    n=$((n)) # strip wc's leading whitespace (BSD wc pads)
+    printf '%s\t%s\n' "$f" "$n" >>"$TMP/counts.raw"
   else
-    # Same contract as the index path: a worktree file that exists but
-    # cannot be read (permissions, I/O error) is a collection failure with
-    # its own diagnostic — not a bare set -e death mid-loop.
-    n="$(wc -l <"$f")" || collection_error "cannot read tracked file '$f' — its size is unmeasurable, refusing to skip it"
+    WT_BATCH+=("$f")
+    WT_BATCH_CHARS=$((WT_BATCH_CHARS + ${#f} + 1))
+    if [ "${#WT_BATCH[@]}" -ge "$BATCH_MAX_FILES" ] || [ "$WT_BATCH_CHARS" -ge "$BATCH_MAX_CHARS" ]; then
+      flush_batch
+    fi
   fi
-  n=$((n)) # strip wc's leading whitespace (BSD wc pads)
-  printf '%s\t%s\n' "$f" "$n" >>"$TMP/counts.raw"
   checked=$((checked + 1))
 done <"$TMP/files.z"
+flush_batch
+# Every selected file must have produced exactly one count row. A shortfall
+# means part of the tracked set went unmeasured, and an unmeasured file can
+# hide an offender — refuse rather than report a verdict over a subset.
+counted="$(count_nonempty_lines "$TMP/counts.raw")"
+[ "$counted" -eq "$checked" ] || collection_error "counted $counted of the $checked tracked file(s) selected for measurement — the collection is incomplete, refusing to report a verdict"
 LC_ALL=C sort "$TMP/counts.raw" >"$TMP/counts.tsv"
 
 # --- evaluate a baseline against the counts ----------------------------------

--- a/skills/size-ratchet/tests/collection-fail-closed.test.sh
+++ b/skills/size-ratchet/tests/collection-fail-closed.test.sh
@@ -8,7 +8,11 @@
 #       execution failure into an empty count and a passing verdict.
 # Every other guarded collection site is pinned the same way: the two
 # baseline-hygiene validations (worktree + index copy), the --update row
-# count, and the worktree read guard (wc failure).
+# count, and the worktree read guard (wc failure). Worktree counts are
+# collected in batched wc invocations, so the batch's own integrity is
+# pinned too: every file across several batches keeps its own count, and a
+# file that cannot be measured still fails loud by name rather than
+# vanishing into a partial batch.
 # Each shim scenario carries a shim-free control first, so a green run is
 # evidence, not a check that cannot fail; the shim's own stderr text is
 # asserted in the failing case to pin the cause to the shim.
@@ -76,9 +80,10 @@ exec "$REAL_GIT" "\$@"
 EOF
 chmod +x "$GIT_SHIM/git"
 
-# grep shim: fail any bare `-c` invocation (the engine's line counts; the
-# settings library only ever uses combined flags like -Ec), pass the rest
-# through to the real grep.
+# grep shim: fail any bare `-c` invocation (the engine's line counts), pass
+# the rest through to the real grep. The fixtures below carry no settings
+# file, so the settings library's own bare-`-c` ambiguity count is never
+# reached under this shim.
 GREP_SHIM="$TMP/grep-shim"
 mkdir -p "$GREP_SHIM"
 cat >"$GREP_SHIM/grep" <<EOF
@@ -120,11 +125,11 @@ exit 1
 EOF
 chmod +x "$WC_SHIM/wc"
 
-# wc shim: pass the first two calls through (the collection loop's counts
-# for the fixture's two tracked files), fail from the third on — which in
-# --update is the recount of the candidate baseline. Exit 7 on purpose: a
-# raw tool status escaping instead of the contract's exit 2 must be
-# visible. Reset $TMP/wc-calls before each run.
+# wc shim: pass the first call through (the collection loop's single
+# batched count for the fixture's two tracked files), fail from the second
+# on — which in --update is the recount of the candidate baseline. Exit 7
+# on purpose: a raw tool status escaping instead of the contract's exit 2
+# must be visible. Reset $TMP/wc-calls before each run.
 WC_RECOUNT_SHIM="$TMP/wc-recount-shim"
 mkdir -p "$WC_RECOUNT_SHIM"
 cat >"$WC_RECOUNT_SHIM/wc" <<EOF
@@ -132,13 +137,25 @@ cat >"$WC_RECOUNT_SHIM/wc" <<EOF
 n="\$(cat "$TMP/wc-calls" 2>/dev/null)" || n=0
 n=\$((n + 1))
 printf '%s\n' "\$n" >"$TMP/wc-calls"
-if [ "\$n" -ge 3 ]; then
+if [ "\$n" -ge 2 ]; then
   echo "wc: simulated recount failure" >&2
   exit 7
 fi
 exec "$REAL_WC" "\$@"
 EOF
 chmod +x "$WC_RECOUNT_SHIM/wc"
+
+# wc shim: succeed while printing nothing. The batch invocation then comes
+# back empty (a shortfall, not a measurement) and each single-file re-read
+# yields no count at all — an empty count arithmetically evaluates to 0,
+# which would file every tracked file as a 0-line file and pass.
+WC_EMPTY_SHIM="$TMP/wc-empty-shim"
+mkdir -p "$WC_EMPTY_SHIM"
+cat >"$WC_EMPTY_SHIM/wc" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$WC_EMPTY_SHIM/wc"
 
 # awk shim: die silently with status 1 on the --update counts scan (its
 # program uniquely contains the yes/no verdict print), delegating every
@@ -317,7 +334,7 @@ run_sr_shimmed "$WC_RECOUNT_SHIM" --update
 [ "$RC" -eq 2 ] && case "$OUT" in *"could not recount the updated baseline tools/size-ratchet-baseline.tsv"*) true ;; *) false ;; esac \
   && ok "a wc failure on the recount is a collection error: exit 2 with the update-aborted diagnostic" \
   || bad "a wc failure on the recount is a collection error, exit 2 (never raw status 7)" "rc=$RC out=$OUT"
-case "$OUT" in *"wc: simulated recount failure"*) ok "the shim fired on the recount call (3rd wc), pinning the cause" ;; *) bad "the shim fired on the recount call" "$OUT" ;; esac
+case "$OUT" in *"wc: simulated recount failure"*) ok "the shim fired on the recount call (2nd wc), pinning the cause" ;; *) bad "the shim fired on the recount call" "$OUT" ;; esac
 row="$(cat "$R/tools/size-ratchet-baseline.tsv")"
 [ "$row" = "$(printf 'big.txt\t20')" ] && ok "the aborted recount leaves the original loose row byte-identical" \
   || bad "the aborted recount leaves the original loose row byte-identical" "row=$row"
@@ -396,6 +413,70 @@ run_sr_shimmed "$WC_SHIM"
   && ok "an unreadable worktree file is a collection error: exit 2, diagnostic names small.txt" \
   || bad "an unreadable worktree file is a collection error naming the file" "rc=$RC out=$OUT"
 case "$OUT" in *"size-ratchet: OK"*) bad "no OK verdict may accompany a worktree read failure" "$OUT" ;; *) ok "no OK verdict accompanies the worktree read failure" ;; esac
+
+echo "=== fail-closed: a wc that succeeds without printing a count is not a measurement ==="
+new_repo wcempty
+mkfile small.txt 5
+git -C "$R" add -A
+run_sr
+[ "$RC" -eq 0 ] && ok "shim-free control: the materialized repo passes" \
+  || bad "shim-free control: the materialized repo passes" "rc=$RC out=$OUT"
+run_sr_shimmed "$WC_EMPTY_SHIM"
+[ "$RC" -eq 2 ] && case "$OUT" in *"line count for tracked file 'small.txt' came back as ''"*) true ;; *) false ;; esac \
+  && ok "an empty count is a collection error naming the file, never arithmetic zero" \
+  || bad "an empty count is a collection error naming the file" "rc=$RC out=$OUT"
+case "$OUT" in *"size-ratchet: OK"*) bad "no OK verdict may accompany an empty count" "$OUT" ;; *) ok "no OK verdict accompanies the empty count" ;; esac
+
+echo "=== batching: every file in every batch keeps its own count ==="
+# The fixture holds more files than one batch carries, so the collection
+# spans several wc invocations: a lost batch, a dropped row or positional
+# drift shows up as a wrong count, a missing offender or a refusal. Names
+# chosen to sit either side of the boundary and to exercise the shapes that
+# make positional parsing load-bearing — a path containing spaces, and a
+# path spelled exactly like the summary row wc appends to every multi-file
+# invocation.
+new_repo batching
+i=0
+while [ "$i" -lt 300 ]; do
+  mkfile "f$i.txt" 2
+  i=$((i + 1))
+done
+mkfile "a file with spaces.txt" 13
+mkfile "aa-offender.txt" 12
+mkfile "total" 14
+mkfile "zz-offender.txt" 11
+git -C "$R" add -A
+run_sr
+[ "$RC" -eq 1 ] && ok "the multi-batch fixture reports violations" || bad "the multi-batch fixture reports violations" "rc=$RC out=$OUT"
+for expect in "a file with spaces.txt — 13 lines" "aa-offender.txt — 12 lines" "total — 14 lines" "zz-offender.txt — 11 lines"; do
+  case "$OUT" in
+    *"new offender: $expect"*) ok "$expect is reported with its own count" ;;
+    *) bad "$expect is reported with its own count" "out=$OUT" ;;
+  esac
+done
+case "$OUT" in *"4 violation(s)"*) ok "exactly the four over-threshold files are violations" ;; *) bad "exactly four violations" "out=$OUT" ;; esac
+OUT=""; RC=0
+OUT="$(cd "$R" && SIZE_RATCHET_THRESHOLD=100 "$SR" 2>&1)" || RC=$?
+[ "$RC" -eq 0 ] && case "$OUT" in *"OK — 304 tracked file(s) checked"*) true ;; *) false ;; esac \
+  && ok "all 304 tracked files are counted — no batch is skipped" \
+  || bad "all 304 tracked files are counted" "rc=$RC out=$OUT"
+
+echo "=== batching: one unreadable file fails loud by ITS name, not by batch ==="
+if [ "$(id -u)" -eq 0 ]; then
+  printf '  skip  unreadable-file pin needs a non-root reader (chmod 000 cannot deny root)\n'
+else
+  chmod 000 "$R/f7.txt"
+  run_sr
+  [ "$RC" -eq 2 ] && case "$OUT" in *"cannot read tracked file 'f7.txt'"*) true ;; *) false ;; esac \
+    && ok "an unreadable file inside a batch is exit 2, diagnostic names f7.txt" \
+    || bad "an unreadable file inside a batch names f7.txt" "rc=$RC out=$OUT"
+  case "$OUT" in *"size-ratchet: OK"*) bad "no OK verdict may accompany an unreadable file" "$OUT" ;; *) ok "no OK verdict accompanies the unreadable file" ;; esac
+  chmod 644 "$R/f7.txt"
+  run_sr
+  [ "$RC" -eq 1 ] && case "$OUT" in *"4 violation(s)"*) true ;; *) false ;; esac \
+    && ok "control: the same file readable, the batch measures the fixture again" \
+    || bad "control: the same file readable, the batch measures again" "rc=$RC out=$OUT"
+fi
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/skills/size-ratchet/tests/settings-and-config.test.sh
+++ b/skills/size-ratchet/tests/settings-and-config.test.sh
@@ -237,6 +237,56 @@ run_raw SIZE_RATCHET_SETTINGS_FILE=absent.settings.toml || true
   && ok "an ABSENT plain file still falls back to the built-in default (control)" \
   || bad "an ABSENT plain file still falls back to the built-in default (control)" "rc=$RC out=$OUT"
 
+echo "=== an UNREADABLE settings source fails loud, never falls through ==="
+# grep exits 0/1 are measurements; anything else means the source could not
+# be read, and continuing to a lower-precedence layer would silently
+# resolve a different value. Every layer carries the same discipline.
+if [ "$(id -u)" -eq 0 ]; then
+  printf '  skip  unreadable-source pins need a non-root reader (chmod 000 cannot deny root)\n'
+else
+  new_repo unreadable
+  mkfile f.txt 20
+  git -C "$R" add -A
+
+  printf '[env]\nSIZE_RATCHET_THRESHOLD = "30"\n' >"$R/vstack.settings.toml"
+  printf 'SIZE_RATCHET_THRESHOLD=15\n' >"$R/.env.local"
+  chmod 000 "$R/.env.local"
+  run_raw || true
+  [ "$RC" -eq 2 ] && case "$OUT" in *".env.local: unreadable while resolving a setting"*) true ;; *) false ;; esac \
+    && ok "an unreadable .env.local is exit 2 (falling through would have read 30 and passed)" \
+    || bad "an unreadable .env.local is exit 2" "rc=$RC out=$OUT"
+  chmod 600 "$R/.env.local"
+  run_raw || true
+  [ "$RC" -eq 1 ] && case "$OUT" in *"threshold 15"*) true ;; *) false ;; esac \
+    && ok "control: the same .env.local, readable, supplies 15 and the 20-line file fails" \
+    || bad "control: readable .env.local supplies the value" "rc=$RC out=$OUT"
+  rm -f "$R/.env.local"
+
+  chmod 000 "$R/vstack.settings.toml"
+  run_raw || true
+  [ "$RC" -eq 2 ] && case "$OUT" in *"vstack.settings.toml: unreadable while resolving a setting"*) true ;; *) false ;; esac \
+    && ok "an unreadable settings file is exit 2 (falling through would have read the built-in 1000)" \
+    || bad "an unreadable settings file is exit 2" "rc=$RC out=$OUT"
+  chmod 600 "$R/vstack.settings.toml"
+  run_raw || true
+  [ "$RC" -eq 0 ] && case "$OUT" in *"threshold 30"*) true ;; *) false ;; esac \
+    && ok "control: the same settings file, readable, supplies 30" \
+    || bad "control: readable settings file supplies the value" "rc=$RC out=$OUT"
+  rm -f "$R/vstack.settings.toml"
+
+  printf 'SIZE_RATCHET_THRESHOLD=12\n' >"$R/.env"
+  chmod 000 "$R/.env"
+  run_raw || true
+  [ "$RC" -eq 2 ] && case "$OUT" in *".env: unreadable while resolving a setting"*) true ;; *) false ;; esac \
+    && ok "an unreadable .env is exit 2 (falling through would have read the built-in 1000)" \
+    || bad "an unreadable .env is exit 2" "rc=$RC out=$OUT"
+  chmod 600 "$R/.env"
+  run_raw || true
+  [ "$RC" -eq 1 ] && case "$OUT" in *"threshold 12"*) true ;; *) false ;; esac \
+    && ok "control: the same .env, readable, supplies 12 and the 20-line file fails" \
+    || bad "control: readable .env supplies the value" "rc=$RC out=$OUT"
+fi
+
 echo "=== option-like configured paths ==="
 new_repo optpath
 mkfile f.txt 20

--- a/skills/size-ratchet/tests/settings-and-config.test.sh
+++ b/skills/size-ratchet/tests/settings-and-config.test.sh
@@ -237,6 +237,34 @@ run_raw SIZE_RATCHET_SETTINGS_FILE=absent.settings.toml || true
   && ok "an ABSENT plain file still falls back to the built-in default (control)" \
   || bad "an ABSENT plain file still falls back to the built-in default (control)" "rc=$RC out=$OUT"
 
+echo "=== an EXISTING non-regular ENV-FILE source never falls through ==="
+# .env.local and .env are probed with -f like the settings file, so a
+# directory or an unresolvable symlink there is skipped exactly like an
+# absent one and a lower-precedence value silently decides.
+new_repo nonregularenv
+mkfile f.txt 20
+git -C "$R" add -A
+printf '[env]\nSIZE_RATCHET_THRESHOLD = "30"\n' >"$R/vstack.settings.toml"
+
+mkdir -p "$R/.env.local"
+run_raw || true
+[ "$RC" -eq 2 ] && case "$OUT" in *".env.local: settings source exists but is not a regular file"*) true ;; *) false ;; esac \
+  && ok "a DIRECTORY at .env.local is exit 2 (falling through would have read 30 and passed)" \
+  || bad "a DIRECTORY at .env.local is exit 2" "rc=$RC out=$OUT"
+rmdir "$R/.env.local"
+
+ln -s missing.env "$R/.env"
+run_raw || true
+[ "$RC" -eq 2 ] && case "$OUT" in *".env: settings source is a symlink that does not resolve"*) true ;; *) false ;; esac \
+  && ok "a DANGLING .env symlink is exit 2, not a silent skip" \
+  || bad "a DANGLING .env symlink is exit 2" "rc=$RC out=$OUT"
+rm -f "$R/.env"
+
+run_raw || true
+[ "$RC" -eq 0 ] && case "$OUT" in *"threshold 30"*) true ;; *) false ;; esac \
+  && ok "control: with both env files absent the settings file still supplies 30" \
+  || bad "control: absent env files fall through to the settings file" "rc=$RC out=$OUT"
+
 echo "=== an UNREADABLE settings source fails loud, never falls through ==="
 # grep exits 0/1 are measurements; anything else means the source could not
 # be read, and continuing to a lower-precedence layer would silently

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -35,7 +35,7 @@ skills/linear/scripts/commands/projects.sh	1364
 skills/orch/scripts/approval-wait	1096
 skills/orch/scripts/queue-wait	1025
 skills/orch/tests/approval_wait.sh	1634
-skills/review-gate/scripts/review-predicate-selftest.sh	2624
+skills/review-gate/scripts/review-predicate-selftest.sh	2607
 skills/review-gate/scripts/review-predicate.sh	1149
 skills/review-gate/tests/pr-watch.test.sh	1158
 skills/second-opinion/scripts/second-opinion	2492


### PR DESCRIPTION
## Summary

Two could-not-measure holes, one per skill.

**Settings reads fail open on an unreadable source.** A settings source that exists but cannot be read passes `-f` and `-e` alike — only the read itself sees it. `grep` failed, the resolver read that as "no match", and resolution walked on to a lower-precedence source or to the built-in default: a configured value silently replaced by a different one, and on the gate a permissive default nobody set (empty trusted-logins = any non-author). growth-guards already carried the discipline; `rg_setting` and `sr_setting` now carry it identically across every probe they have.

**size-ratchet spawned one `wc` per file** — 9,325 processes on the largest consuming tree. Worktree counts are now collected in bounded batches.

## What changed

- `skills/review-gate/scripts/lib/settings.sh` — new `rg_settings_grep`: grep exit 0/1 are measurements, `>= 2` is an unreadable source → `::error` naming the file, return 2; the caller returns 1 and every call site's `|| exit` propagates. The three settings-file probes collapse into one read.
- `skills/size-ratchet/scripts/lib/settings.sh` — the same helper as `sr_settings_grep`, applied to every probe it has: `.env.local`, `.vstack/settings.toml`, `vstack.settings.toml`, `.env`. review-gate has no env-file lanes and gains none. The three vendored libs stay textually aligned outside their documented differences.
- `skills/review-gate/scripts/review-predicate-selftest.sh` — its own unreadable-settings startup guard is deleted. The resolver refuses first and refuses for the live predicate and writer, which the guard never covered; one home per rule. (2624 → 2607 lines; baseline row lowered in this diff.)
- `skills/size-ratchet/scripts/size-ratchet` — batched collection. `wc` emits counts in argument order, so rows are matched to inputs **by position**, which also places the `total` row a multi-file invocation appends past the last input — rather than a name filter that a tracked file called `total` would defeat. A nonzero status, a short read, a non-numeric count or any positional mismatch discards the batch and re-measures it one file at a time, so an unreadable or vanished file still fails loud naming *that* file. The collection then refuses outright unless every selected file produced a count row. Index-blob reads (sparse checkout, unstaged deletion) are unchanged.
- `.env.local` / `.env` lanes (review round): both were probed with a bare `-f`, so a directory, FIFO, socket, device or unresolvable symlink there was skipped exactly like an absent file and a lower-precedence value silently decided — the settings-file half of that rule shipped in #1352, the env half did not. The shape test now sits in one `*_settings_usable` helper per lib and every lane calls it. growth-guards has the same lanes and gets the same fix, keeping the vendored trio aligned.
- Docs: `skills/review-gate/references/settings.md`, both size-ratchet and growth-guards `README.md` + `SKILL.md` state that only an ABSENT source is skipped and that `/dev/null` forces defaults.
- One pre-existing `# shellcheck disable=SC2254 -- reason` directive (SC1072/SC1073 under shellcheck 0.11) is reformatted so the preflight shell lane, which now lints this file, passes.

Consumers vendor review-gate and size-ratchet; the behavior change rides the next vendor mini-train.

## Proof

Local: `tools/validate-changed` green (lanes `always:preflight`, `always:gate-selftest`, `lint:shell`, `skill:growth-guards`, `skill:orch`, `skill:review-gate`, `skill:size-ratchet`, `tools`), `skills/preflight/scripts/preflight --base origin/main` clean, `skills/size-ratchet/scripts/size-ratchet` OK.

**Differential control on real trees** — old and new engines run over two unrelated repositories produce byte-identical output, including a 120-violation report:

| tree | files measured | before | after | verdict |
|---|---|---|---|---|
| 21,050-file repo | 9,325 | 6.34s / 6.21s | 0.79s / 0.80s | identical (OK) |
| this repo | 1,454 | 0.86s / 0.83s / 0.88s | 0.09s ×3 | identical (OK) |
| 2,718-file repo | — | — | — | identical (120 violations, exit 1) |

**Red-once evidence** — every new pin was run against neutered/old behavior first:

1. *Naive batch parse* (status ignored, no positional match, no per-file fallback, `total` dropped by name) → **11 pins red**. The unreadable-file pin loses its attribution (`counted 302 of the 304 … refusing to report a verdict` instead of naming `f7.txt`), the tracked file named `total` is silently dropped (`counted 303 of the 304`), and the four per-file count assertions fail. This is also the must-fail control for the every-file-produced-a-row guard: it fires with its own diagnostic in each case.
2. *Non-numeric-count guard deleted* (fallback kept) → the `wc`-succeeds-silently pin goes red **with a passing verdict**: `size-ratchet: OK — 1 tracked file(s) checked` (empty count → arithmetic 0 → a file measured as 0 lines).
3. *size-ratchet lib reverted to `main`* → the three new unreadable-source pins red at **rc=0**: `grep: .env.local: Permission denied` on stderr while the gate passed on the built-in 1000.
4. *review-gate lib reverted to `main`* → `rg_setting` returns **0 with `dflt`** on a mode-000 settings file; `rg_settings_grep` does not exist (rc=127).
5. *Env lanes without the usable-source guard* (the previous commit's libs) → the directory and dangling-symlink pins red at **rc=0 / the wrong ceiling**: `size-ratchet: OK — 1 tracked file(s) checked, threshold 30` with a directory at `.env.local`, and growth-guards reporting `ceiling 3 KB` where the env source should have decided.
6. *Old lib + the selftest guard already deleted* → the selftest **greens** on an unreadable override and the wrapper notes `selftest passed with an UNREADABLE settings override`. With the resolver discipline in place the same wrapper passes on the resolver's diagnostic, which is what the deletion rests on.

New/changed pins: `skills/size-ratchet/tests/collection-fail-closed.test.sh` (47 pass), `skills/size-ratchet/tests/settings-and-config.test.sh` (41 pass), `skills/growth-guards/tests/byte-ceiling.test.sh` (39 pass), `skills/review-gate/tests/settings-parsing.test.sh` (23 pass), `skills/review-gate/tests/review-predicate-selftest.test.sh` (197 default / 235 configured cases). Each unreadable-source pin carries a readable control and a root skip (chmod 000 cannot deny root). The existing wc-call-ordering shim moves from "fail from the 3rd call" to "fail from the 2nd" — the collection loop is now one batched call, not one per file.

Closes VST-239

https://claude.ai/code/session_01RqdGH7w3Qz8EoYU2yS8z8X
