### PR TITLE
fix(size-ratchet): a batch accounts for wc's summary row, never parses it (VST-239)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,12 @@
 - size-ratchet: the collection loop measures worktree files in batched `wc`
   invocations instead of one process per file — 6.3s -> 0.8s on a tree
   measuring 9,325 files, 0.86s -> 0.09s on one measuring 1,454, with the
-  verdict byte-identical on both. Counts are matched to inputs by position,
-  so a batch that comes back short, out of order or non-numeric is discarded
-  and re-measured one file at a time: an unreadable or vanished file still
-  fails loud naming that file, and a count row is required for every file
-  selected.
+  verdict byte-identical on both. Counts are matched to inputs by position
+  and the summary row a multi-file `wc` appends is counted rather than
+  parsed, so a batch that comes back short, out of order or non-numeric is
+  discarded and re-measured one file at a time: an unreadable or vanished
+  file still fails loud naming that file, and a count row is required for
+  every file selected.
 - second-opinion: a multi-lane review run without `--output` no longer keeps
   its lane reviews in shared system temp (VST-241), and the lane umask no
   longer governs the external model CLI's own files (VST-243). Each lane's

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -267,13 +267,23 @@ WT_BATCH=()
 WT_BATCH_CHARS=0
 
 flush_batch() { # — appends one "<path><TAB><count>" row per pending file
-  local status=0 idx=0 line count path n f
+  local status=0 idx=0 extra=0 want_extra=0 line count path n f
   [ "${#WT_BATCH[@]}" -gt 0 ] || return 0
   : >"$TMP/batch.tsv"
   wc -l -- "${WT_BATCH[@]}" >"$TMP/wc.out" || status=$?
+  # A multi-file invocation appends exactly one summary row and a
+  # single-file one appends none, so the whole output is accounted for:
+  # rows past the last input are counted, never parsed. Without that count
+  # a batch whose LAST row went missing would slide its summary into the
+  # final input's slot — and for an input named `total` the slot would even
+  # match, banking the batch sum as that file's size.
+  if [ "${#WT_BATCH[@]}" -gt 1 ]; then want_extra=1; fi
   if [ "$status" -eq 0 ]; then
     while IFS= read -r line; do
-      [ "$idx" -lt "${#WT_BATCH[@]}" ] || break
+      if [ "$idx" -ge "${#WT_BATCH[@]}" ]; then
+        extra=$((extra + 1))
+        continue
+      fi
       # wc pads counts with leading blanks (BSD wc does); one space then
       # separates the count from the path, which may hold spaces but never
       # a newline or tab (both refused above).
@@ -286,7 +296,7 @@ flush_batch() { # — appends one "<path><TAB><count>" row per pending file
       printf '%s\t%s\n' "$path" "$count" >>"$TMP/batch.tsv"
       idx=$((idx + 1))
     done <"$TMP/wc.out"
-    if [ "$idx" -eq "${#WT_BATCH[@]}" ]; then
+    if [ "$idx" -eq "${#WT_BATCH[@]}" ] && [ "$extra" -eq "$want_extra" ]; then
       cat "$TMP/batch.tsv" >>"$TMP/counts.raw"
       WT_BATCH=()
       WT_BATCH_CHARS=0

--- a/skills/size-ratchet/tests/collection-fail-closed.test.sh
+++ b/skills/size-ratchet/tests/collection-fail-closed.test.sh
@@ -157,6 +157,31 @@ exit 0
 EOF
 chmod +x "$WC_EMPTY_SHIM/wc"
 
+# wc shim: on a multi-file invocation drop the LAST file's row while still
+# printing the summary row and exiting 0 — the shape in which the summary
+# slides into the final input's slot. Single-file reads pass through, so
+# the per-file re-measurement still works.
+WC_DROPLAST_SHIM="$TMP/wc-droplast-shim"
+mkdir -p "$WC_DROPLAST_SHIM"
+cat >"$WC_DROPLAST_SHIM/wc" <<EOF
+#!/usr/bin/env bash
+files=0
+seen_sep=0
+for a in "\$@"; do
+  if [ "\$seen_sep" = 1 ]; then
+    files=\$((files + 1))
+    continue
+  fi
+  if [ "\$a" = "--" ]; then seen_sep=1; fi
+done
+if [ "\$files" -gt 1 ]; then
+  "$REAL_WC" "\$@" | "$REAL_AWK" '{ a[NR] = \$0 } END { for (i = 1; i <= NR; i++) if (i != NR - 1) print a[i] }'
+  exit 0
+fi
+exec "$REAL_WC" "\$@"
+EOF
+chmod +x "$WC_DROPLAST_SHIM/wc"
+
 # awk shim: die silently with status 1 on the --update counts scan (its
 # program uniquely contains the yes/no verdict print), delegating every
 # other awk. Exit 1 on purpose: awk reserves no status for "not found",
@@ -426,6 +451,27 @@ run_sr_shimmed "$WC_EMPTY_SHIM"
   && ok "an empty count is a collection error naming the file, never arithmetic zero" \
   || bad "an empty count is a collection error naming the file" "rc=$RC out=$OUT"
 case "$OUT" in *"size-ratchet: OK"*) bad "no OK verdict may accompany an empty count" "$OUT" ;; *) ok "no OK verdict accompanies the empty count" ;; esac
+
+echo "=== batching: the summary row is never read as a file's count ==="
+# A tracked file named exactly like the summary row wc appends, positioned
+# last in its batch: the one arrangement in which a lost final row lands
+# the batch SUM (12) in that file's slot and reports it as an offender.
+new_repo wctotal
+mkfile a.txt 8
+mkfile total 4
+git -C "$R" add -A
+run_sr
+[ "$RC" -eq 0 ] && case "$OUT" in *"OK — 2 tracked file(s) checked"*) true ;; *) false ;; esac \
+  && ok "shim-free control: both files pass at threshold 10" \
+  || bad "shim-free control: both files pass at threshold 10" "rc=$RC out=$OUT"
+run_sr_shimmed "$WC_DROPLAST_SHIM"
+[ "$RC" -eq 0 ] && case "$OUT" in *"OK — 2 tracked file(s) checked"*) true ;; *) false ;; esac \
+  && ok "a batch missing its last row is re-measured per file, never completed with the summary" \
+  || bad "a batch missing its last row is re-measured per file" "rc=$RC out=$OUT"
+case "$OUT" in
+  *"new offender: total"*) bad "the batch sum must never become the count of the file named total" "$OUT" ;;
+  *) ok "the batch sum never becomes the count of the file named total" ;;
+esac
 
 echo "=== batching: every file in every batch keeps its own count ==="
 # The fixture holds more files than one batch carries, so the collection


### PR DESCRIPTION
## Summary

Follow-up to #1365 (same issue, VST-239). The batched `wc` collection matched output rows to inputs by position but left the tail of the output unexamined, so a batch that lost its **last** file row slid the summary row into that input's slot — and for an input named exactly `total` the slot matched, banking the batch **sum** as that file's size. Found by qodo on #1365; the fix was ready before that PR merged but the merge queue got there first, so it lands here.

## What changed

`skills/size-ratchet/scripts/size-ratchet` — a multi-file `wc` invocation appends exactly one summary row and a single-file one appends none, so the expected number of rows past the last input is known. Rows beyond the inputs are now counted, never parsed, and a batch is accepted only when the positional match is complete **and** that count is exactly what the invocation shape predicts. Anything else falls back to per-file measurement, which already fails loud naming its file.

## Proof

Local: `tools/validate-changed` green (lanes `always:preflight`, `always:gate-selftest`, `lint:shell`, `skill:orch`, `skill:size-ratchet`), `skills/preflight/scripts/preflight --base origin/main` clean, `skills/size-ratchet/scripts/size-ratchet` OK.

New pin in `skills/size-ratchet/tests/collection-fail-closed.test.sh` (50 pass) — the one arrangement that can bank a wrong number: a two-file repo `a.txt` (8 lines) and `total` (4 lines) at threshold 10, with a `wc` shim that drops the last file's row on a multi-file invocation while still printing the summary and exiting 0. Single-file reads pass through, so the per-file fallback measures for real. Shim-free control first.

**Red-once**: with the summary accounting removed (`if [ "$idx" -eq "${#WT_BATCH[@]}" ]` alone), the pin fails as `size-ratchet FAIL new offender: total — 12 lines > threshold 10` — the batch sum reported as the file's size. Restored, the same fixture reports `OK — 2 tracked file(s) checked`.

Closes VST-239

https://claude.ai/code/session_01RqdGH7w3Qz8EoYU2yS8z8X
