### PR TITLE
fix(second-opinion): both consumers report an unusable artifact home the same way (VST-241)

### DIFF
--- a/skills/second-opinion/scripts/second-opinion
+++ b/skills/second-opinion/scripts/second-opinion
@@ -1218,9 +1218,9 @@ artifact_home() {
   ARTIFACT_HOME="$dir"
 }
 
-# The home resolved but will not hold a file — it filled, its permissions
-# changed, or it was never writable and `mkdir -p` said nothing because it
-# already existed. Stated once and then forgotten, so every later allocation
+# The home resolved but will not hold a file — it ran out of space, its
+# permissions changed, or it was never writable and `mkdir -p` said nothing
+# because it already existed. Stated once and then forgotten, so every later allocation
 # goes straight to the fallback rather than retrying the same refusal and
 # repeating the line. One wording for both consumers: an operator reading this
 # has one condition to act on, not two spellings of it.

--- a/skills/second-opinion/scripts/second-opinion
+++ b/skills/second-opinion/scripts/second-opinion
@@ -1218,6 +1218,17 @@ artifact_home() {
   ARTIFACT_HOME="$dir"
 }
 
+# The home resolved but will not hold a file — it filled, its permissions
+# changed, or it was never writable and `mkdir -p` said nothing because it
+# already existed. Stated once and then forgotten, so every later allocation
+# goes straight to the fallback rather than retrying the same refusal and
+# repeating the line. One wording for both consumers: an operator reading this
+# has one condition to act on, not two spellings of it.
+artifact_home_unusable() {
+  echo "→ artifact home unusable, falling back to system temp: $ARTIFACT_HOME" >&2
+  ARTIFACT_HOME=""
+}
+
 artifact_file() {
   local kind="$1"
   artifact_home
@@ -1228,7 +1239,10 @@ artifact_file() {
     # case via the canonicalized $CWD), so the template can never begin with
     # `-`. That also avoids relying on `--` in mktemp, whose support for it is
     # not uniform across the BSD/macOS target.
-    ARTIFACT_PATH=$(mktemp "$ARTIFACT_HOME/${MODE}-${TARGET_CLI}-${kind}.XXXXXX" 2>/dev/null) || ARTIFACT_PATH=""
+    ARTIFACT_PATH=$(mktemp "$ARTIFACT_HOME/${MODE}-${TARGET_CLI}-${kind}.XXXXXX" 2>/dev/null) || {
+      artifact_home_unusable
+      ARTIFACT_PATH=""
+    }
   fi
   if [[ -z "$ARTIFACT_PATH" ]]; then
     # System temp is the last resort, and it can refuse too (a read-only or
@@ -1659,8 +1673,7 @@ if $MULTI_LANE; then
         # already paid for one. Said once — forgetting the home keeps every
         # later lane from retrying it and from repeating the line.
         lane_out=$(mktemp "$ARTIFACT_HOME/${MODE}-lane-${lane}.XXXXXX" 2>/dev/null) || {
-          echo "→ artifact home unusable, lanes fall back to system temp: $ARTIFACT_HOME" >&2
-          ARTIFACT_HOME=""
+          artifact_home_unusable
           lane_out=""
         }
       fi

--- a/skills/second-opinion/tests/cli-failure-gate.test.sh
+++ b/skills/second-opinion/tests/cli-failure-gate.test.sh
@@ -1176,5 +1176,35 @@ assert_file_contains "$s13_err" "$s13_out.failed.json" "the path that refused it
 assert_file_contains "$s13_err" "could not be preserved anywhere" "the loss is still stated"
 assert_file_contains "$s13_err" "hit your usage limit" "the provider cause still reaches stderr"
 
+# --- Scenario 14: a home that exists but will not hold a file ----------------
+# `mkdir -p` succeeds on a directory that already exists and denies writes, so
+# resolving a home is not being able to create in one. The record still has to
+# reach somewhere and keep its exit class, and the operator has to be told the
+# configured home was not the somewhere.
+echo "=== scenario 14: an unwritable artifact home -> temp fallback, cause and class kept ==="
+if $CAN_DENY_BY_MODE; then
+  s14_tmp="$TMP_ROOT/tmpdir14"
+  s14_home="$TMP_ROOT/home14"
+  rm -rf "$s14_tmp" "$s14_home"; mkdir -p "$s14_tmp" "$s14_home"; chmod 0555 "$s14_home"
+  s14_err="$TMP_ROOT/s14.stderr"
+  printf '0' > "$COUNTER"
+  rc14=0
+  set +e
+  PATH="$TMP_ROOT/bin:$PATH" TMPDIR="$s14_tmp" \
+    SECOND_OPINION_TARGET=claude SECOND_OPINION_CLAUDE_CMD="$STUB" STUB_COUNTER="$COUNTER" \
+    SECOND_OPINION_ARTIFACT_DIR="$s14_home" STUB_RC=1 STUB_STDERR="$QUOTA_ERR" \
+    "$SECOND_OPINION" review --range HEAD --cwd "$WORK" >/dev/null 2>"$s14_err"
+  rc14=$?
+  set -e
+  chmod 0700 "$s14_home"
+  assert_eq "$rc14" "5" "an unwritable home keeps EXIT_CLI_FAILED (5)"
+  assert_file_contains "$s14_err" "artifact home unusable" "the home is named as unusable"
+  assert_file_contains "$s14_err" "record kept in system temp instead" "the record still reaches somewhere"
+  assert_file_contains "$s14_err" "hit your usage limit" "the provider cause still reaches stderr"
+  assert_eq "$(ls "$s14_home" | wc -l | tr -d ' ')" "0" "nothing was written into the unwritable home"
+else
+  skip "unwritable artifact home: running as root, a mode-denied directory is still writable"
+fi
+
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/skills/second-opinion/tests/cli-failure-gate.test.sh
+++ b/skills/second-opinion/tests/cli-failure-gate.test.sh
@@ -1178,9 +1178,9 @@ assert_file_contains "$s13_err" "hit your usage limit" "the provider cause still
 
 # --- Scenario 14: a home that exists but will not hold a file ----------------
 # `mkdir -p` succeeds on a directory that already exists and denies writes, so
-# resolving a home is not being able to create in one. The record still has to
-# reach somewhere and keep its exit class, and the operator has to be told the
-# configured home was not the somewhere.
+# resolving a home is not the same as being able to create in it. The record
+# still has to reach somewhere and keep its exit class, and the operator has to
+# be told the configured home was not the somewhere.
 echo "=== scenario 14: an unwritable artifact home -> temp fallback, cause and class kept ==="
 if $CAN_DENY_BY_MODE; then
   s14_tmp="$TMP_ROOT/tmpdir14"
@@ -1201,7 +1201,8 @@ if $CAN_DENY_BY_MODE; then
   assert_file_contains "$s14_err" "artifact home unusable" "the home is named as unusable"
   assert_file_contains "$s14_err" "record kept in system temp instead" "the record still reaches somewhere"
   assert_file_contains "$s14_err" "hit your usage limit" "the provider cause still reaches stderr"
-  assert_eq "$(ls "$s14_home" | wc -l | tr -d ' ')" "0" "nothing was written into the unwritable home"
+  assert_eq "$(find "$s14_home" -mindepth 1 2>/dev/null | head -1)" "" \
+    "nothing was written into the unwritable home"
 else
   skip "unwritable artifact home: running as root, a mode-denied directory is still writable"
 fi

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -38,8 +38,8 @@ skills/orch/tests/approval_wait.sh	1634
 skills/review-gate/scripts/review-predicate-selftest.sh	2607
 skills/review-gate/scripts/review-predicate.sh	1149
 skills/review-gate/tests/pr-watch.test.sh	1158
-skills/second-opinion/scripts/second-opinion	2493
-skills/second-opinion/tests/cli-failure-gate.test.sh	1180
+skills/second-opinion/scripts/second-opinion	2506
+skills/second-opinion/tests/cli-failure-gate.test.sh	1210
 skills/second-opinion/tests/review-dual-model.test.sh	1516
 skills/worktree/scripts/worktree	4077
 skills/worktree/scripts/worktree-session-guard	1194

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -39,7 +39,7 @@ skills/review-gate/scripts/review-predicate-selftest.sh	2607
 skills/review-gate/scripts/review-predicate.sh	1149
 skills/review-gate/tests/pr-watch.test.sh	1158
 skills/second-opinion/scripts/second-opinion	2506
-skills/second-opinion/tests/cli-failure-gate.test.sh	1210
+skills/second-opinion/tests/cli-failure-gate.test.sh	1211
 skills/second-opinion/tests/review-dual-model.test.sh	1516
 skills/worktree/scripts/worktree	4077
 skills/worktree/scripts/worktree-session-guard	1194


### PR DESCRIPTION
## Summary

Follow-up to #1368, which merged while this fix was in flight. Two reviewers raised the same gap on it independently.

Removing the one-time home probe in #1368 left only the multi-lane branch reporting when the configured artifact home refuses a file. The single-lane record path — a `review`/`audit` preserving a failed, rejected or raw response without `--output` — fell back to system temp naming the destination but never the cause, so an operator whose `SECOND_OPINION_ARTIFACT_DIR` had filled or lost write permission saw durable record placement quietly disappear, and every later record retried the same home.

## What changed

- One `artifact_home_unusable` helper carries the wording for both consumers and forgets the home, so the condition is stated once by whichever path meets it and no later allocation retries it. The multi-lane branch now calls it instead of spelling the message itself — an operator has one condition to act on, not two spellings of it.
- `cli-failure-gate.test.sh` scenario 14 pins the single-lane path: an existing `0555` home, a CLI that fails with a quota error, and assertions that the run keeps exit 5, names the home as unusable, still stores the record in system temp, still carries the provider cause, and wrote nothing into the home. Skipped when running as root, where mode bits do not deny.

## Proof

`tools/validate-changed` — all 6 lanes pass. `skills/preflight/scripts/preflight --base origin/main` clean. `skills/size-ratchet/scripts/size-ratchet` OK, with both grown rows hand-raised (`scripts/second-opinion` 2506, `tests/cli-failure-gate.test.sh` 1210).

`cli-failure-gate.test.sh`: 331 pass, 0 fail. Red-once — with `artifact_file`'s allocation failure returned to a bare `|| ARTIFACT_PATH=""`, scenario 14's "the home is named as unusable" goes red on exactly the stderr the reports describe: `record kept in system temp instead: …` with no mention of the configured home.

https://claude.ai/code/session_01RqdGH7w3Qz8EoYU2yS8z8X
