### PR TITLE
chore(repo): CHANGELOG.md merges with the union driver — concurrent Unreleased bullets stop conflicting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# CHANGELOG.md is append-at-top: two branches each adding a bullet under
+# Unreleased conflict on every rebase; the union driver keeps both.
+CHANGELOG.md merge=union

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
 # CHANGELOG.md is append-at-top: two branches each adding a bullet under
-# Unreleased conflict on every rebase; the union driver keeps both.
-CHANGELOG.md merge=union
+# Unreleased conflict on every rebase; the union driver keeps both. It also
+# keeps both sides of an in-place rewrite and, across a release rotation,
+# lands a rebased bullet under the new heading — read the Unreleased list
+# after a rebase, and rotate a release with no PR open.
+/CHANGELOG.md merge=union

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
   store that exists but cannot be read — consumers delegating lane selection
   see a misconfigured `OVERSEE_WATCH_STATE_DIR` as a launch failure instead
   of a fleet stacked on one account (VST-296).
+- repo: `CHANGELOG.md` merges with git's `union` driver (`.gitattributes`) —
+  two branches each adding a bullet under Unreleased no longer conflict on
+  rebase; both bullets are kept.
 - review-gate/size-ratchet: settings resolution fails closed on a source it
   cannot read. `-f` and `-e` both pass on an existing mode-000 file, so only
   the read itself sees it: `grep` failed, the resolver read that as "no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,12 @@
   store that exists but cannot be read — consumers delegating lane selection
   see a misconfigured `OVERSEE_WATCH_STATE_DIR` as a launch failure instead
   of a fleet stacked on one account (VST-296).
-- repo: `CHANGELOG.md` merges with git's `union` driver (`.gitattributes`) —
-  two branches each adding a bullet under Unreleased no longer conflict on
-  rebase; both bullets are kept.
+- repo: the root `CHANGELOG.md` merges with git's `union` driver
+  (`.gitattributes`) — two branches each adding a bullet under Unreleased no
+  longer conflict on rebase; both bullets are kept. The driver also keeps both
+  sides of an in-place rewrite of one line and, across a release rotation,
+  lands a rebased bullet under the new heading: read the Unreleased list after
+  a rebase, and rotate a release only with no PR open.
 - review-gate/size-ratchet: settings resolution fails closed on a source it
   cannot read. `-f` and `-e` both pass on an existing mode-000 file, so only
   the read itself sees it: `grep` failed, the resolver read that as "no


### PR DESCRIPTION
Every merge into main today dirtied every open PR (six at a time) on the CHANGELOG.md Unreleased top-insert. `.gitattributes` sets `CHANGELOG.md merge=union`: git keeps both sides' bullets, so a rebase over a sibling's merge resolves by itself (proved on a scratch repo: A and B both inserting at the top rebase clean, both bullets kept, base retained). Whether GitHub's own mergeability check honors the driver will show on the next sibling merge; the local rebase is automatic either way.

https://claude.ai/code/session_01RqdGH7w3Qz8EoYU2yS8z8X