### PR TITLE
docs(second-opinion): both settings examples state the rule, not an ordinal into a list (VST-244)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+- second-opinion settings example: the `SECOND_OPINION_CURRENT_MODEL` block
+  announced "three cases, and only the third makes a project file usable at
+  all" over a list of two, neither of which does — and no case does, since a
+  project-file value is refused wherever it would matter. `vstack refresh`
+  copies the file verbatim, so every consuming repo carried the contradiction
+  and flagged it as drift. Both copies (the skill's template and the root
+  `vstack.settings.toml.example` the README points at) now state the rule
+  itself — a project file is read by every session in the repo, so a value in
+  one describes no single session — with no count and no positional reference
+  to maintain.
+
 - orch: `oversee-watch` gains `usage-limit` (the harness is still running but
   its account's limit banner is up — one pass, ahead of `question`, naming the
   config dir when a live lane claim covers the pane it read) and

--- a/skills/second-opinion/vstack.settings.toml.example
+++ b/skills/second-opinion/vstack.settings.toml.example
@@ -28,17 +28,17 @@ SECOND_OPINION_COUNT = "1"
 # cross-model.
 #
 # SESSION-SCOPED — leave it COMMENTED here and export it in the environment of
-# the sessions that need it. Three cases, and only the third makes a project
-# file usable at all:
-#   * A DETECTED Claude Code or Codex session already knows its model. A value
-#     that AGREES is ignored (it adds nothing); one that CONTRADICTS is refused
-#     naming both values — whatever its source, since an exported value is
-#     inherited by every nested session and so is no more trustworthy there.
+# the sessions that need it. A project file (.env, vstack.settings.toml,
+# .vstack/settings.toml, .env.local) is read by EVERY session in the repo, so a
+# value in one describes no single session:
 #   * Where the harness CANNOT be detected (Pi, OpenCode, Cursor, a plain
-#     shell) the declaration is the only identity there is — but every project
-#     file (.env, vstack.settings.toml, .vstack/settings.toml, .env.local) is
-#     read by EVERY session in the repo, so a value in one describes no single
-#     session and is refused naming the file. Export it in the session instead.
+#     shell) the declaration is the only identity there is, and one from a
+#     project file is refused naming the file. Export it in the session.
+#   * A DETECTED Claude Code or Codex session already knows its model and
+#     outranks any declaration: one that AGREES is ignored (it adds nothing),
+#     one that CONTRADICTS is refused naming both values — whatever its source,
+#     since an exported value is inherited by every nested session and so is no
+#     more trustworthy there.
 # SECOND_OPINION_CURRENT_MODEL = "claude"
 
 # Used by: second-opinion. Roster entry claude (identity claude).

--- a/vstack.settings.toml.example
+++ b/vstack.settings.toml.example
@@ -397,17 +397,17 @@ SECOND_OPINION_COUNT = "1"
 # cross-model.
 #
 # SESSION-SCOPED — leave it COMMENTED here and export it in the environment of
-# the sessions that need it. Three cases, and only the third makes a project
-# file usable at all:
-#   * A DETECTED Claude Code or Codex session already knows its model. A value
-#     that AGREES is ignored (it adds nothing); one that CONTRADICTS is refused
-#     naming both values — whatever its source, since an exported value is
-#     inherited by every nested session and so is no more trustworthy there.
+# the sessions that need it. A project file (.env, vstack.settings.toml,
+# .vstack/settings.toml, .env.local) is read by EVERY session in the repo, so a
+# value in one describes no single session:
 #   * Where the harness CANNOT be detected (Pi, OpenCode, Cursor, a plain
-#     shell) the declaration is the only identity there is — but every project
-#     file (.env, vstack.settings.toml, .vstack/settings.toml, .env.local) is
-#     read by EVERY session in the repo, so a value in one describes no single
-#     session and is refused naming the file. Export it in the session instead.
+#     shell) the declaration is the only identity there is, and one from a
+#     project file is refused naming the file. Export it in the session.
+#   * A DETECTED Claude Code or Codex session already knows its model and
+#     outranks any declaration: one that AGREES is ignored (it adds nothing),
+#     one that CONTRADICTS is refused naming both values — whatever its source,
+#     since an exported value is inherited by every nested session and so is no
+#     more trustworthy there.
 
 SECOND_OPINION_CLAUDE_CMD = "claude -p --no-session-persistence --model opus --effort max --allowedTools Bash(read-only:true),Read,Glob,Grep"
 # Used by: second-opinion. Roster entry claude (identity claude).


### PR DESCRIPTION
## Summary

The last item on the VST-244 bundle: a note on the container issue asked for `skills/second-opinion/vstack.settings.toml.example` to be fixed upstream once the bundle landed, because consuming repos flag it as doc drift after `vstack refresh` and the drift is vstack-owned (refresh copies the file verbatim, so a consumer cannot fix it locally — it was declined on that basis in a consumer PR).

## What changed

The `SECOND_OPINION_CURRENT_MODEL` block announced "Three cases, and only the third makes a project file usable at all" and then listed two, neither of which makes a project file usable — and there is no case that does: where detection cannot arbitrate, a value from a project file is refused naming the file, and where it can, the detected harness outranks the declaration whatever its source.

The block now states that rule directly, in the order that matters to someone reading it (the case that requires the variable first, the case that ignores it second), with no count and no positional reference for a future edit to invalidate. The two bullets keep the content they had; what is gone is the sentence pointing past them.

## Proof

`tools/validate-changed` — all 5 lanes pass. `skills/preflight/scripts/preflight --base origin/main` clean. `skills/size-ratchet/scripts/size-ratchet` OK. Comment-only change to a settings template; the wording is checked against `SKILL.md`'s `SECOND_OPINION_CURRENT_MODEL` row, which is the authoritative statement of the same rule.

https://claude.ai/code/session_01RqdGH7w3Qz8EoYU2yS8z8X
