### PR TITLE
fix(orch): a failed re-enumeration keeps the snapshot it could not improve on (VST-296)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@
   sides of an in-place rewrite of one line and, across a release rotation,
   lands a rebased bullet under the new heading: read the Unreleased list after
   a rebase, and rotate a release only with no PR open.
+- orch: pruning a lane claim re-enumerates the tmux server once per pass
+  before deleting a same-server miss, and keeps the snapshot it already had
+  when that re-enumeration fails — a claim another launcher wrote after the
+  first `list-panes` looked dead on this server and was deleted, handing a
+  running account straight back out (VST-296).
 - review-gate/size-ratchet: settings resolution fails closed on a source it
   cannot read. `-f` and `-e` both pass on an existing mode-000 file, so only
   the read itself sees it: `grep` failed, the resolver read that as "no

--- a/skills/orch/scripts/lib/lane-claims.sh
+++ b/skills/orch/scripts/lib/lane-claims.sh
@@ -48,7 +48,7 @@ lane_claims_canon() {
 # the caller knows whether it is deciding or reporting.
 lane_claims_read() {
   local dir="$1" live this_server f server pane cfg window created rc=0
-  local rechecked=0 live_now fresh
+  local rechecked=0 recheck_ok=1 live_now fresh
   # Absent is genuinely empty; anything else that is not a directory is a
   # misconfiguration, and an unreadable store is not an empty one. Reporting
   # no claims for either would report every busy account as free.
@@ -95,13 +95,21 @@ lane_claims_read() {
       # every same-server miss in this pass.
       if [[ "$rechecked" -eq 0 ]]; then
         rechecked=1
-        # A re-enumeration that FAILS says nothing; replacing the snapshot with
-        # its empty output would then prune every remaining live claim.
+        # A re-enumeration that FAILS says nothing: it neither replaces the
+        # snapshot nor settles the record that provoked it.
         if fresh="$(tmux list-panes -a -F '#{pid} #{pane_id}' 2>/dev/null)"; then
           live="$fresh"
+        else
+          recheck_ok=0
         fi
       fi
-      if grep -qxF -- "$server $pane" <<<"$live"; then live_now=1; fi
+      if [[ "$recheck_ok" -eq 0 ]]; then
+        # Only a snapshot taken after this record was written can call it
+        # dead, and none is available: unknown, and an unknown claim is kept.
+        live_now=1
+      elif grep -qxF -- "$server $pane" <<<"$live"; then
+        live_now=1
+      fi
     elif kill -0 "$server" 2>/dev/null; then
       # A server this process cannot enumerate, still running.
       live_now=1

--- a/skills/orch/scripts/lib/lane-claims.sh
+++ b/skills/orch/scripts/lib/lane-claims.sh
@@ -48,7 +48,7 @@ lane_claims_canon() {
 # the caller knows whether it is deciding or reporting.
 lane_claims_read() {
   local dir="$1" live this_server f server pane cfg window created rc=0
-  local rechecked=0 live_now
+  local rechecked=0 live_now fresh
   # Absent is genuinely empty; anything else that is not a directory is a
   # misconfiguration, and an unreadable store is not an empty one. Reporting
   # no claims for either would report every busy account as free.
@@ -95,7 +95,11 @@ lane_claims_read() {
       # every same-server miss in this pass.
       if [[ "$rechecked" -eq 0 ]]; then
         rechecked=1
-        live="$(tmux list-panes -a -F '#{pid} #{pane_id}' 2>/dev/null)" || live=""
+        # A re-enumeration that FAILS says nothing; replacing the snapshot with
+        # its empty output would then prune every remaining live claim.
+        if fresh="$(tmux list-panes -a -F '#{pid} #{pane_id}' 2>/dev/null)"; then
+          live="$fresh"
+        fi
       fi
       if grep -qxF -- "$server $pane" <<<"$live"; then live_now=1; fi
     elif kill -0 "$server" 2>/dev/null; then

--- a/skills/orch/tests/lanes.sh
+++ b/skills/orch/tests/lanes.sh
@@ -248,8 +248,10 @@ cat > "$CLAIM_BIN/tmux" <<'STUBEOF'
 n=0; [[ -f "${TMUX_PANES_FILE:-}.calls" ]] && n="$(cat "$TMUX_PANES_FILE.calls")"
 n=$((n + 1)); [[ -z "${TMUX_PANES_FILE:-}" ]] || printf '%s' "$n" > "$TMUX_PANES_FILE.calls"
 src="$TMUX_PANES_FILE.$n"; [[ -f "$src" ]] || src="$TMUX_PANES_FILE"
-[[ -f "$src" ]] && cat "$src"
-exit 0
+[[ -f "$src" ]] || exit 0
+# cat's status is the stub's: an unreadable file is a failed enumeration, the
+# way a dead tmux server is, not an empty one.
+cat "$src"
 STUBEOF
 chmod +x "$CLAIM_BIN/tmux"
 
@@ -427,6 +429,22 @@ assert_eq "$(jq -r '.[] | select(.alias=="claude") | .claims' <<<"$RACED")" "1" 
   "a claim written after the pane snapshot is not pruned by it"
 assert_eq "$([[ -f "$CLAIM_STATE/claims/racer.claim" ]] && echo yes || echo no)" "yes" \
   "the raced claim file survives"
+
+# ...and a re-enumeration that FAILS says nothing: the claims the first
+# snapshot proved live must survive it.
+rm -f "$CLAIM_STATE"/claims/*.claim "$PANES.calls"
+printf '%s %%1\n%s %%4\n' "$LIVE_PID" "$LIVE_PID" > "$PANES.1"
+: > "$PANES.2"; chmod 000 "$PANES.2"           # the second enumeration fails
+printf '%s %%1\n' "$LIVE_PID" > "$PANES"
+write_claim live4 "$LIVE_PID" "%4" "$H/.claude" "vst-10"
+write_claim gone5 "$LIVE_PID" "%5" "$H/.eclaude" "vst-11"
+KEPT2="$(run_lanes_claims list --harness claude --json)"
+chmod 644 "$PANES.2"; rm -f "$PANES.1" "$PANES.2" "$PANES.calls"
+assert_eq "$(jq -r '.[] | select(.alias=="claude") | .claims' <<<"$KEPT2")" "1" \
+  "a failed re-enumeration does not prune what the first snapshot proved live"
+assert_eq "$([[ -f "$CLAIM_STATE/claims/live4.claim" ]] && echo yes || echo no)" "yes" \
+  "the claim the snapshot covered survives a failed re-check"
+rm -f "$CLAIM_STATE"/claims/*.claim
 
 # A config dir carrying a backslash is a real path, and the count must see it:
 # `awk -v` would expand the escape and match nothing.

--- a/skills/orch/tests/lanes.sh
+++ b/skills/orch/tests/lanes.sh
@@ -433,17 +433,23 @@ assert_eq "$([[ -f "$CLAIM_STATE/claims/racer.claim" ]] && echo yes || echo no)"
 # ...and a re-enumeration that FAILS says nothing: the claims the first
 # snapshot proved live must survive it.
 rm -f "$CLAIM_STATE"/claims/*.claim "$PANES.calls"
-printf '%s %%1\n%s %%4\n' "$LIVE_PID" "$LIVE_PID" > "$PANES.1"
-: > "$PANES.2"; chmod 000 "$PANES.2"           # the second enumeration fails
-printf '%s %%1\n' "$LIVE_PID" > "$PANES"
-write_claim live4 "$LIVE_PID" "%4" "$H/.claude" "vst-10"
-write_claim gone5 "$LIVE_PID" "%5" "$H/.eclaude" "vst-11"
-KEPT2="$(run_lanes_claims list --harness claude --json)"
-chmod 644 "$PANES.2"; rm -f "$PANES.1" "$PANES.2" "$PANES.calls"
-assert_eq "$(jq -r '.[] | select(.alias=="claude") | .claims' <<<"$KEPT2")" "1" \
-  "a failed re-enumeration does not prune what the first snapshot proved live"
-assert_eq "$([[ -f "$CLAIM_STATE/claims/live4.claim" ]] && echo yes || echo no)" "yes" \
-  "the claim the snapshot covered survives a failed re-check"
+if [[ "$(id -u)" -eq 0 ]]; then
+  # Root reads a mode-000 file, so the second enumeration would SUCCEED and
+  # the case would assert the retention path without ever failing a re-check.
+  printf '  skip  failed re-enumeration (running as root)\n'
+else
+  printf '%s %%1\n%s %%4\n' "$LIVE_PID" "$LIVE_PID" > "$PANES.1"
+  : > "$PANES.2"; chmod 000 "$PANES.2"           # the second enumeration fails
+  printf '%s %%1\n' "$LIVE_PID" > "$PANES"
+  write_claim live4 "$LIVE_PID" "%4" "$H/.claude" "vst-10"
+  write_claim gone5 "$LIVE_PID" "%5" "$H/.eclaude" "vst-11"
+  KEPT2="$(run_lanes_claims list --harness claude --json)"
+  chmod 644 "$PANES.2"; rm -f "$PANES.1" "$PANES.2" "$PANES.calls"
+  assert_eq "$(jq -r '.[] | select(.alias=="claude") | .claims' <<<"$KEPT2")" "1" \
+    "a failed re-enumeration does not prune what the first snapshot proved live"
+  assert_eq "$([[ -f "$CLAIM_STATE/claims/live4.claim" ]] && echo yes || echo no)" "yes" \
+    "the claim the snapshot covered survives a failed re-check"
+fi
 rm -f "$CLAIM_STATE"/claims/*.claim
 
 # A config dir carrying a backslash is a real path, and the count must see it:

--- a/skills/orch/tests/lanes.sh
+++ b/skills/orch/tests/lanes.sh
@@ -449,6 +449,12 @@ else
     "a failed re-enumeration does not prune what the first snapshot proved live"
   assert_eq "$([[ -f "$CLAIM_STATE/claims/live4.claim" ]] && echo yes || echo no)" "yes" \
     "the claim the snapshot covered survives a failed re-check"
+  # The record that PROVOKED the re-check is the one a stale snapshot cannot
+  # settle: without a fresh enumeration it is unknown, and kept.
+  assert_eq "$(jq -r '.[] | select(.alias=="eclaude") | .claims' <<<"$KEPT2")" "1" \
+    "the record that provoked the failed re-check is kept, not pruned by the stale snapshot"
+  assert_eq "$([[ -f "$CLAIM_STATE/claims/gone5.claim" ]] && echo yes || echo no)" "yes" \
+    "no claim is deleted on a snapshot that predates it"
 fi
 rm -f "$CLAIM_STATE"/claims/*.claim
 


### PR DESCRIPTION
## Summary

Follow-up to #1355, which merged while this fix was in flight. The same-server re-check that #1355 added to lane-claim pruning replaced the pane snapshot with the output of its second `list-panes` **even when that call failed** — an empty result then pruned every remaining live claim on that server, the opposite of what the re-check exists for.

## What changed

The snapshot is replaced only by a **successful** enumeration; a failed one leaves what the first `list-panes` already proved. One line, plus the test stub now propagates a failed enumeration (`cat`'s status is the stub's) instead of reporting an unreadable pane list as an empty one.

## Proof

`tools/validate-changed` — all 6 lanes green (`always:preflight`, `always:gate-selftest`, `lint:shell`, `skill:github`, `skill:orch` 36/36 files, `skill:reviewer`). `preflight --base origin/main` clean.

Red-once: both new assertions — `a failed re-enumeration does not prune what the first snapshot proved live` and `the claim the snapshot covered survives a failed re-check` — run RED against `origin/main`'s `lane-claims.sh` and green with the fix (`lanes.sh` 127 → 129 assertions).

Found by the Codex reviewer on #1355 after its merge; the finding is real and this is the fix rather than a decline.

Closes VST-296

https://claude.ai/code/session_01RqdGH7w3Qz8EoYU2yS8z8X
