### PR TITLE
refactor(skills): frontmatter descriptions to best practice, growth-guards narration out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,17 @@
 - orch PR-comment triage batches fix rounds per fully-reviewed head: a push
   restarts every reviewer, so a round pushed into an open review pass buys
   duplicate findings and unanswered threads.
+- Skill `description:` frontmatter is one or two sentences again across the
+  catalog — what the skill is and when to load it, with the sub-feature
+  enumerations that had grown into ten of them left to the body. The longest
+  fell from 810 characters to 214, and every skill now fits in a loader's
+  index without crowding out its neighbours; `vstack refresh` delivers the
+  shorter text to consumers. The growth-guards skill also lost the narration
+  that accumulated around its checks: duplicated scan machinery now has one
+  home in `lib/common.sh`, SKILL.md carries what every load needs and README
+  the adoption depth. Every verdict, remediation and exit code is unchanged;
+  the only text that moves is two collection-error diagnostics, which now name
+  the lane whose scan failed.
 
 - second-opinion settings example: the `SECOND_OPINION_CURRENT_MODEL` block
   announced "three cases, and only the third makes a project file usable at

--- a/cli/src/git_hooks.rs
+++ b/cli/src/git_hooks.rs
@@ -11,12 +11,8 @@ const HELPER_NAME: &str = "vstack-guards";
 const HOOK_SENTINEL: &str = "# vstack-guards-hook";
 
 /// Install (or repair) the growth-guards git shims after a project-scope
-/// install.
-///
-/// The guard chain has to fire for every tool that commits — agent harnesses,
-/// editors, scripts, a plain shell — so it lives in real `.git/hooks` files,
-/// not in a harness hook. The skill owns the installer and its idempotence;
-/// this is the call site that keeps a consumer's shims current.
+/// install. The skill owns the installer and its idempotence; this is the
+/// call site that keeps a consumer's shims current.
 ///
 /// Returns the one line to surface, or `None` when the skill is not installed
 /// in this project. Never fails the install: an installer that cannot run is
@@ -25,15 +21,11 @@ pub fn install_growth_guards_hooks(project_root: &Path) -> Option<String> {
     run_installer(project_root, &[]).note
 }
 
-/// Remove the shims before the skill's own files go away.
-///
-/// Without this a `vstack remove growth-guards` would leave hooks that can no
-/// longer reach their guard — and the shims fail closed, so every subsequent
-/// commit in the repository would be blocked.
+/// Remove the shims before the skill's own files go away: left behind they
+/// fail closed, blocking every subsequent commit in the repository.
 pub fn uninstall_growth_guards_hooks(project_root: &Path) -> Result<Option<String>, String> {
-    // What decides is whether shims exist, not whether the skill or the
-    // repository look healthy: only a helper git could actually reach can
-    // block a commit, and only its absence makes skipping safe.
+    // Whether shims exist decides, not whether the skill or the repository
+    // look healthy: only their absence makes skipping safe.
     let Some(shim) = installed_shim(project_root)
         .map_err(|detail| format!("growth-guards git hooks: {detail}"))?
     else {
@@ -56,13 +48,12 @@ pub fn uninstall_growth_guards_hooks(project_root: &Path) -> Result<Option<Strin
 }
 
 /// Any installed shim: the helper, or a hook still carrying the delegating
-/// line — which fails closed on its own and would block every commit if the
-/// helper went without it.
+/// line — which fails closed on its own.
 ///
-/// The COMMON hooks directory is what the installer writes, and it is what a
-/// later `core.hooksPath` hides rather than moves: shims dormant behind that
-/// setting revive the moment it is unset, so they are still shims. `None`
-/// covers every case where nothing can fire.
+/// The COMMON hooks directory is what the installer writes, and what a later
+/// `core.hooksPath` hides rather than moves: shims dormant behind that setting
+/// revive the moment it is unset, so they are still shims. `None` covers every
+/// case where nothing can fire.
 fn installed_shim(project_root: &Path) -> Result<Option<PathBuf>, String> {
     let output = match Command::new("git")
         .arg("-C")
@@ -90,9 +81,8 @@ fn installed_shim(project_root: &Path) -> Result<Option<PathBuf>, String> {
         return Ok(Some(helper));
     }
     // Read as BYTES: a hook is not required to be UTF-8, and one that failed
-    // to decode would otherwise read as carrying no delegate at all. A hook
-    // that exists but cannot be read is UNKNOWN, and unknown must count as a
-    // shim — removing the skill around a live delegate blocks every commit.
+    // to decode would otherwise read as carrying no delegate. A hook that
+    // exists but cannot be read is UNKNOWN, and unknown counts as a shim.
     // Existence is tested on the LINK, so a dangling symlink counts too: its
     // target can come back carrying a delegate.
     Ok(["pre-commit", "commit-msg"].into_iter().find_map(|hook| {
@@ -161,8 +151,8 @@ fn run_installer(project_root: &Path, extra_args: &[&str]) -> InstallerOutcome {
     if output.status.success() {
         return done(summary.unwrap_or_else(|| "growth-guards git hooks: installed".to_string()));
     }
-    // A failed run must name what happened; the installer's own last warning
-    // is the most specific thing available, its summary next.
+    // Name what happened: the installer's own last warning is the most
+    // specific thing available, its summary next.
     let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
     let detail = last_nonempty_line(&stderr)
         .or(summary)
@@ -170,13 +160,12 @@ fn run_installer(project_root: &Path, extra_args: &[&str]) -> InstallerOutcome {
     failed(format!("growth-guards git hooks: not installed — {detail}"))
 }
 
-/// The installer inside whichever skills directory this project's install
-/// method used: the canonical `.agents/skills` for a symlink install, a
-/// harness skills directory for a copy install.
 /// Every project-scope skills directory a vstack install can write, plus the
-/// source layout vstack itself has. Relative by design: resolution must depend
-/// on the root it is given and never on the process working directory. Keep in
-/// step with the shipped installer's own `SKILL_ROOTS`.
+/// source layout vstack itself has: the canonical `.agents/skills` for a
+/// symlink install, a harness skills directory for a copy install. Relative by
+/// design — resolution depends on the root it is given, never on the process
+/// working directory. Kept in step with the shipped installer's `SKILL_ROOTS`
+/// by a test.
 const SKILL_ROOTS: &[&str] = &[
     ".agents/skills",
     ".claude/skills",

--- a/skills/code-quality/SKILL.md
+++ b/skills/code-quality/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-quality
-description: "Generic code-authoring standards for dev agents: correctness over convenience, no fail-open branches, comment do's/don'ts, over-engineering and cleanup rules, prove-your-guards. Load before writing or modifying code. Per-repo specifics arrive via the project-instructions seam."
+description: "Generic code-authoring standards for dev agents: correctness over convenience, no fail-open branches, comment rules, over-engineering limits, prove-your-guards. Load before writing or modifying code."
 license: MIT
 user-invocable: true
 metadata:

--- a/skills/deep-research/SKILL.md
+++ b/skills/deep-research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deep-research
-description: "Exa-powered deep research for evidence-backed findings reports. Use for research tasks, architectural investigations, vendor/library comparisons, technology choices, and any workflow that needs a findings.md report. In Pi, prefer pi-web-tools web_research when available; in other harnesses, use the bundled script."
+description: "Exa-powered deep research producing an evidence-backed findings.md report. Load for research tasks, architectural investigations, and vendor, library, or technology comparisons."
 license: MIT
 user-invocable: true
 argument-hint: "report [query] --output findings.md"

--- a/skills/dep-radar/SKILL.md
+++ b/skills/dep-radar/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dep-radar
-description: "Sweep every pinned version in the repo (SDKs, pinned runtime binaries, npm/cargo deps, vendored forks, model weights), check upstream, read changelogs, and bias to upgrade — apply bumps (majors included) with their fallout fixed in the same per-surface PR, deferring only on a strong concrete blocker. Reports the narrow owner-decision tier (model-weight swaps, data-scope changes) and new-capability opportunities. Self-maintains a per-repo inventory; run on a schedule/loop or on demand."
+description: "Sweeps every pinned version in the repo — deps, SDKs, vendored forks, model weights — checks upstream, and lands upgrades with their fallout in one PR per surface. Load to run or tune a dependency sweep."
 license: MIT
 user-invocable: true
 dependencies:

--- a/skills/growth-guards/README.md
+++ b/skills/growth-guards/README.md
@@ -46,7 +46,8 @@ Local commits are covered by the git hooks below, not by these calls.
 
 Writes three files into the repository's `.git/hooks` (never
 `core.hooksPath`, which redirects the whole directory and would disable the
-repository's existing hooks):
+repository's existing hooks; where a repo already sets it, the install is a
+reported skip and only removal still runs):
 
 | File | Content |
 |---|---|
@@ -60,13 +61,13 @@ and then falls through to whatever the hook already did — whose own exit
 status still decides.
 
 `pre-commit` runs `scripts/pre-commit`, which judges ONE commit snapshot —
-staged content, and tracked configuration read from the index, so an
-unstaged edit cannot switch a check off for content the commit keeps:
-`size-ratchet --staged` when that skill is installed beside this one, then the `growth-guards` batch over the staged
-content, then the repo-local entry named by `GROWTH_GUARDS_PRE_COMMIT_LOCAL`
-(repo-root-relative executable; empty means none). `commit-msg` runs
-`scripts/commit-msg` on git's message file. Every step runs before the
-verdict, so one attempt reports every blocker.
+staged content, and tracked configuration read from the index, so an unstaged
+edit cannot switch a check off for content the commit keeps: `size-ratchet
+--staged` when that skill is installed beside this one, then the
+`growth-guards` batch over the staged content, then the repo-local entry named
+by `GROWTH_GUARDS_PRE_COMMIT_LOCAL` (repo-root-relative executable; empty
+means none). `commit-msg` runs `scripts/commit-msg` on git's message file.
+Every step runs before the verdict, so one attempt reports every blocker.
 
 The shims BLOCK, and fail closed, on the family's exit contract: `1` for a
 violation, carrying the check's own remediation text, and `2` for a guard
@@ -78,13 +79,13 @@ Repeat runs are no-ops, and repairs. A hook counts as current only when it
 carries the EXACT delegating line on a line of its own — a line that was
 commented out, truncated, or left behind by an older version is rewritten,
 not trusted — and a hook whose executable bit was cleared gets it back,
-because git silently ignores a hook it cannot execute. An
-existing `pre-commit`/`commit-msg` keeps its content and its own exit status;
-a hook that is symlinked, deliberately disabled (not executable), or whose
-shebang names an interpreter that is not a POSIX-compatible shell is left
-alone entirely (reported, and the install exits 1). A file at the helper path that this installer did not write is
-never overwritten. A bare repository is refused — there is no work tree to
-guard.
+because git silently ignores a hook it cannot execute. An existing
+`pre-commit`/`commit-msg` keeps its content and its own exit status; a hook
+that is symlinked, deliberately disabled (not executable), or whose shebang
+names an interpreter that is not a POSIX-compatible shell is left alone
+entirely (reported, and the install exits 1). A file at the helper path that
+this installer did not write is never overwritten. A bare repository is
+refused — there is no work tree to guard.
 
 Linked worktrees share the install, since git resolves their hooks to the
 main checkout's hooks directory. The same sharing governs removal: while any
@@ -211,26 +212,17 @@ type(scope)!: subject        # scope and '!' optional
 
 ## Configuration
 
-| Key | Default | Meaning |
-|---|---|---|
-| `GROWTH_GUARDS_CHECKS` | `todo-ban byte-ceiling suppression-ban` | Batch check list. |
-| `GROWTH_GUARDS_TODO_EXCLUDES` | `tools/todo-ban-excludes` | todo-ban exclusion list. |
-| `GROWTH_GUARDS_BYTE_CEILING_KB` | `200` | Ceiling in KB. |
-| `GROWTH_GUARDS_BYTE_EXCLUDES` | `tools/byte-ceiling-excludes` | byte-ceiling exclusion list. |
-| `GROWTH_GUARDS_SUPPRESSION_EXCLUDES` | `tools/suppression-ban-excludes` | suppression-ban exclusion list. |
-| `GROWTH_GUARDS_SUPPRESSION_BASELINE` | `tools/suppression-baseline.tsv` | Bare-allow baseline. |
-| `GROWTH_GUARDS_COMMIT_TYPES` | `build chore ci docs feat fix perf refactor revert style test` | Accepted types. |
-| `GROWTH_GUARDS_PRE_COMMIT_LOCAL` | *(empty)* | Repo-root-relative executable the pre-commit shim runs last. Empty means none; a configured path that is missing or not executable blocks the commit. |
-
-Each key resolves environment > `.env.local` > `.vstack/settings.toml` >
-committed `vstack.settings.toml` (flat `KEY = "value"` under `[env]`) >
-`.env` > default (env files use `KEY=value` or `export KEY=value`; parsed,
-never sourced). Only an ABSENT source is skipped: a source that exists but
-is unusable — unreadable, a directory, FIFO, socket or device, or a symlink
+Every key, its default and its meaning: [SKILL.md](SKILL.md). Each resolves
+environment > `.env.local` > `.vstack/settings.toml` > committed
+`vstack.settings.toml` (flat `KEY = "value"` under `[env]`) > `.env` >
+default (env files use `KEY=value` or `export KEY=value`; parsed, never
+sourced). Only an ABSENT source is skipped: a source that exists but is
+unusable — unreadable, a directory, FIFO, socket or device, or a symlink
 that does not resolve — is a config error (exit 2), never a fall-through to
 the next layer; `/dev/null` forces the built-in defaults. Per-check flags
-(`--excludes`, `--baseline`) override every source for the paths. All relative paths are repo-root-relative; the
-scripts `cd` to `git rev-parse --show-toplevel` before resolving anything.
+(`--excludes`, `--baseline`) override every source for the paths. All
+relative paths are repo-root-relative; the scripts `cd` to
+`git rev-parse --show-toplevel` before resolving anything.
 
 ```toml
 [env]

--- a/skills/growth-guards/SKILL.md
+++ b/skills/growth-guards/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: growth-guards
-description: "Four repo growth guards beside size-ratchet: todo-ban (flat ban on work markers — the TODO/FIXME/HACK/XXX comment shapes — in first-party tracked files), byte-ceiling (newly added files over N KB fail, default 200; lockfiles and declared asset trees exempt), suppression-ban (blanket lint suppressions fail flat; bare rust allow(dead_code)/allow(unused) attributes ratchet against a tighten-only baseline), and commit-msg (conventional-commit gate that accepts uppercase issue keys and git-generated messages). Also installs the real git pre-commit/commit-msg shims that run the chain for every tool that commits. Load when adding, tuning, or debugging any of these checks, the git hook shims, their exclusion lists, the suppression baseline, or GROWTH_GUARDS_* settings — or when a change trips one of them."
+description: "Four repo growth guards beside size-ratchet — todo-ban, byte-ceiling, suppression-ban, commit-msg — and the git hook shims that run them. Load to add, tune, or debug a check, the hooks, or GROWTH_GUARDS_* settings."
 license: MIT
 user-invocable: true
 metadata:
@@ -15,10 +15,8 @@ metadata:
 
 > **Problem with this skill?** Run `vstack report` — it files to the owning repo automatically. Do not hand-file.
 
-Four checks that stop quiet repo decay, one family beside `size-ratchet`:
-same idiom (language-agnostic where possible, tighten-only baselines only
-where legacy counts exist, every failure names its remediation, exclusion
-rows carry their reasons) and the same exit contract.
+Four checks that stop quiet repo decay, one family beside `size-ratchet`,
+sharing its idiom and its exit contract.
 
 ```bash
 .agents/skills/growth-guards/scripts/growth-guards              # batch: every enabled repo check
@@ -28,33 +26,6 @@ rows carry their reasons) and the same exit contract.
 
 Every check is also independently invocable as `scripts/CHECK` — wire CI at
 whichever grain fits.
-
-## Git hooks
-
-`scripts/install-git-hooks [--repo PATH]` writes real `.git/hooks` shims, so
-the chain fires for every tool that commits — any agent harness, an editor, a
-script, a plain shell. `vstack add` and `vstack refresh` run it for a project
-that has this skill installed, and `vstack remove growth-guards` runs
-`--uninstall` before the files go; a non-git project is skipped with a note.
-
-- `pre-commit` runs `scripts/pre-commit`: `size-ratchet --staged` when that
-  skill is installed beside this one, the batch over staged content, then the
-  repo-root-relative executable named by `GROWTH_GUARDS_PRE_COMMIT_LOCAL`
-  (empty = none).
-- `commit-msg` runs `scripts/commit-msg` on git's message file.
-- The shims BLOCK and fail closed on the family's exit contract: `1` for a
-  violation with its remediation, `2` for a guard that could not run, naming
-  what is missing. `git commit --no-verify` is the deliberate bypass.
-- The line goes first in the hook, not last: content ending in an explicit
-  `exit` would leave an appended guard unreachable.
-- `core.hooksPath` is never set — it would redirect every hook and disable the
-  repository's existing ones. Where a repo already sets it, the install is a
-  reported skip.
-- Existing hooks keep their content and exit status; the install is a no-op
-  only when the exact delegating line is present, and repairs a tampered or
-  stale one and a cleared executable bit. Removal keeps and retargets the
-  shims while another work tree on the same hooks directory still has a
-  separate install. Full behaviour: [README.md](README.md).
 
 ## The checks
 
@@ -75,15 +46,21 @@ Scans read INDEX content (`git grep --cached`, staged blobs): what is
 staged is what gets committed, and a sparse checkout cannot hide a tracked
 file from a gate.
 
-## Configuration
+## Git hooks
 
-Resolution order for every key: explicit environment > `.env.local`
-(personal, untracked) > `.vstack/settings.toml` > the repo's committed
-`vstack.settings.toml` (flat `KEY = "value"` under `[env]`) > `.env` >
-built-in default. Only an ABSENT source is skipped: a source that exists
-but is unusable — unreadable, a directory, FIFO, socket or device, or a
-symlink that does not resolve — is a config error (exit 2), never a
-fall-through to the next layer. `/dev/null` forces the built-in defaults.
+`scripts/install-git-hooks [--repo PATH]` writes real `.git/hooks` shims —
+`pre-commit` runs the chain (`size-ratchet --staged` when that skill is
+installed beside this one, the batch over staged content, then the
+repo-root-relative executable named by `GROWTH_GUARDS_PRE_COMMIT_LOCAL`),
+`commit-msg` runs this family's message gate. They BLOCK on the family's exit
+contract, fail closed on a guard that could not run, and `git commit
+--no-verify` is the deliberate bypass. `vstack add` and `vstack refresh` run
+the installer, `vstack remove growth-guards` runs `--uninstall` first. Repeat
+runs are no-ops and repairs; `core.hooksPath` is never set, existing hooks
+keep their content and their own exit status. Full behaviour, including what
+the installer refuses to touch: [README.md](README.md).
+
+## Configuration
 
 | Key | Default | Meaning |
 |---|---|---|
@@ -96,13 +73,17 @@ fall-through to the next layer. `/dev/null` forces the built-in defaults.
 | `GROWTH_GUARDS_COMMIT_TYPES` | `build chore ci docs feat fix perf refactor revert style test` | Accepted commit types. |
 | `GROWTH_GUARDS_PRE_COMMIT_LOCAL` | *(empty)* | Repo-root-relative executable the pre-commit shim runs last. |
 
-**Excludes format** — `pattern<TAB>reason` per line (shell glob against the
-full repo-relative path; `*` crosses `/`); blank lines and `#` comments are
-ignored, and a pattern without a reason is a config error — every exclusion
-carries its justification (vendored, generated, assets, fixtures).
-**Baseline format** — `path<TAB>count`, `LC_ALL=C` sorted, unique paths,
-positive counts; the only way a number goes up is a human editing the row
-in a reviewed diff.
+Resolution order for every key: explicit environment > `.env.local` >
+`.vstack/settings.toml` > the repo's committed `vstack.settings.toml` (flat
+`KEY = "value"` under `[env]`) > `.env` > built-in default. Only an ABSENT
+source is skipped: one that exists but is unusable is a config error (exit
+2), never a fall-through. `/dev/null` forces the built-in defaults.
 
-Marker shapes, per-language suppression patterns, seeding a first baseline,
-and CI wiring: [README.md](README.md).
+**Excludes format** — `pattern<TAB>reason` per line (shell glob against the
+full repo-relative path; `*` crosses `/`); a pattern without a reason is a
+config error. **Baseline format** — `path<TAB>count`, `LC_ALL=C` sorted,
+unique paths, positive counts.
+
+Marker shapes, per-language suppression patterns, the hook install and
+removal contract, seeding a first baseline, and CI wiring:
+[README.md](README.md).

--- a/skills/growth-guards/scripts/byte-ceiling
+++ b/skills/growth-guards/scripts/byte-ceiling
@@ -1,26 +1,17 @@
 #!/usr/bin/env bash
 # byte-ceiling — newly added tracked files over the byte ceiling fail
-# (default 200 KB). Growth-oriented like size-ratchet: legacy files already
-# in history are not gated by the default modes — only what a change ADDS —
-# so adoption needs no cleanup first. A full sweep over every tracked file
-# is available for audits.
+# (default 200 KB). Growth-oriented like size-ratchet: only what a change
+# ADDS is gated by the default modes, so adoption needs no cleanup first.
 #
 # Modes (mutually exclusive):
 #   --staged (default)  files added in the staged diff (pre-commit shim)
 #   --base REF          files added since merge-base with REF (CI on a PR)
 #   --all               every tracked file (full sweep)
 #
-# Sizes are OBJECT sizes (git cat-file -s of the added blob): the bytes
-# that actually enter history, filters applied, independent of worktree
-# state. Renames are detected (-c diff.renames pinned on), so moving an
-# existing large file is not an "addition"; a copy is one — it duplicates
-# the bytes in the tree, and that growth is what the gate is for. Known
-# lockfile
-# basenames are exempt built-in; asset trees are declared in the excludes
-# list with a reason.
-#
-# Exit codes: 0 clean; 1 violations; 2 usage/config/collection error. A
-# blob whose size cannot be read is a collection error — never a skip.
+# Sizes are OBJECT sizes (git cat-file -s of the added blob): the bytes that
+# enter history, filters applied, independent of worktree state. Renames are
+# detected, so moving an existing large file is not an addition; a copy is
+# one. Exit codes: 0 clean; 1 violations; 2 usage/config/collection error.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -87,16 +78,10 @@ CEILING_KB="$(gg_setting GROWTH_GUARDS_BYTE_CEILING_KB 200)" || exit 2
 gg_positive_int "$CEILING_KB" "GROWTH_GUARDS_BYTE_CEILING_KB"
 CEILING_BYTES=$((CEILING_KB * 1024))
 
-if [ -n "$EXCLUDES_OPT" ]; then
-  EXCLUDES_FILE="$EXCLUDES_OPT"
-else
-  EXCLUDES_FILE="$(gg_setting GROWTH_GUARDS_BYTE_EXCLUDES "tools/byte-ceiling-excludes")" || exit 2
-fi
-EXCLUDES_FILE="$(gg_config_path "$EXCLUDES_FILE" "excludes")" || exit 2
+EXCLUDES_FILE="$(gg_resolve_path "$EXCLUDES_OPT" GROWTH_GUARDS_BYTE_EXCLUDES "tools/byte-ceiling-excludes" excludes)" || exit 2
 gg_load_excludes "$EXCLUDES_FILE"
 
-# Lockfiles are generated whole-file by package managers; their size is not
-# a design signal. Exempt by exact basename.
+# Generated whole-file by package managers: size is not a design signal.
 LOCKFILE_BASENAMES="Cargo.lock package-lock.json npm-shrinkwrap.json yarn.lock pnpm-lock.yaml bun.lock bun.lockb flake.lock poetry.lock uv.lock Pipfile.lock Gemfile.lock composer.lock go.sum gradle.lockfile packages.lock.json Package.resolved"
 
 is_lockfile() { # PATH
@@ -107,29 +92,27 @@ is_lockfile() { # PATH
   return 1
 }
 
-TMP="$(mktemp -d)"
-trap 'rm -rf "$TMP"' EXIT
+gg_tmpdir
 
-# Candidate records land as 'sha<TAB>path' NUL-free per record is
-# impossible for arbitrary paths, so the file holds alternating
-# NUL-terminated fields: sha NUL path NUL. The sha is the added blob
-# itself, so measuring needs no path re-quoting.
-: >"$TMP/candidates.z"
+# Alternating NUL-terminated fields, sha NUL path NUL: no single-record
+# separator survives arbitrary paths. The sha is the added blob itself, so
+# measuring needs no path re-quoting.
+: >"$GG_TMP/candidates.z"
 
 emit_candidate() { # SHA PATH
-  printf '%s\0%s\0' "$1" "$2" >>"$TMP/candidates.z"
+  printf '%s\0%s\0' "$1" "$2" >>"$GG_TMP/candidates.z"
 }
 
 case "$MODE" in
   staged)
-    git -c diff.renames=true diff --cached --raw --no-abbrev -z --diff-filter=A >"$TMP/raw.z" || gg_collection_error "git diff --cached failed collecting staged additions"
+    git -c diff.renames=true diff --cached --raw --no-abbrev -z --diff-filter=A >"$GG_TMP/raw.z" || gg_collection_error "git diff --cached failed collecting staged additions"
     ;;
   base)
     git rev-parse --verify --quiet "$BASE_REF^{commit}" >/dev/null || gg_config_error "--base ref '$BASE_REF' does not name a commit"
-    git -c diff.renames=true diff --raw --no-abbrev -z --diff-filter=A "$BASE_REF...HEAD" >"$TMP/raw.z" || gg_collection_error "git diff $BASE_REF...HEAD failed collecting added files (no merge base?)"
+    git -c diff.renames=true diff --raw --no-abbrev -z --diff-filter=A "$BASE_REF...HEAD" >"$GG_TMP/raw.z" || gg_collection_error "git diff $BASE_REF...HEAD failed collecting added files (no merge base?)"
     ;;
   all)
-    git ls-files -sz >"$TMP/files.z" || gg_collection_error "git ls-files failed"
+    git ls-files -sz >"$GG_TMP/files.z" || gg_collection_error "git ls-files failed"
     while IFS= read -r -d '' rec; do
       # Record shape: "<mode> <sha> <stage>\t<path>".
       mode="${rec%% *}"
@@ -140,7 +123,7 @@ case "$MODE" in
         120000 | 160000) continue ;; # symlink / submodule gitlink — not sized content
       esac
       emit_candidate "$sha" "$f"
-    done <"$TMP/files.z"
+    done <"$GG_TMP/files.z"
     ;;
 esac
 
@@ -160,7 +143,7 @@ if [ "$MODE" != "all" ]; then
       *) gg_collection_error "added file '$f' has no destination blob in the diff record — cannot measure it" ;;
     esac
     emit_candidate "$dstsha" "$f"
-  done <"$TMP/raw.z"
+  done <"$GG_TMP/raw.z"
 fi
 
 checked=0
@@ -176,7 +159,7 @@ while IFS= read -r -d '' sha && IFS= read -r -d '' f; do
     echo "  remedies: keep big artifacts out of the repo (asset store, Git LFS, build-time generation); a file that genuinely belongs gets a row in $EXCLUDES_FILE with its reason"
     violations=$((violations + 1))
   fi
-done <"$TMP/candidates.z"
+done <"$GG_TMP/candidates.z"
 
 case "$MODE" in
   staged) SCOPE_DESC="staged addition(s)" ;;

--- a/skills/growth-guards/scripts/commit-msg
+++ b/skills/growth-guards/scripts/commit-msg
@@ -1,13 +1,8 @@
 #!/usr/bin/env bash
-# commit-msg — conventional-commit format gate over a commit message,
-# built to sit directly in .git/hooks/commit-msg (it takes the message
-# file git passes, or stdin).
-#
-# The header (first non-blank, non-comment line) must be
-# `type(scope)!: subject` — scope and `!` optional. The scope class
-# accepts uppercase issue keys (fix(ABC-123): ...) and `#`-prefixed issue
-# numbers (fix(#123): ...). Git-generated messages pass unchanged: Merge,
-# Revert, Reapply, fixup!, squash!, amend!.
+# commit-msg — conventional-commit gate over one message, built to sit
+# directly in .git/hooks/commit-msg (it takes the message file git passes, or
+# stdin). The header (first non-blank, non-comment line) must be
+# `type(scope)!: subject`; git-generated messages pass unchanged.
 #
 # Exit codes: 0 pass; 1 violation; 2 usage/config/collection error (an
 # unreadable message file is a collection error, never a pass).
@@ -65,8 +60,7 @@ else
 fi
 
 gg_repo_root_cd
-# Its own hook process, so it turns the mode on for itself: the accepted type
-# list is the one the commit carries, not an unstaged edit to it.
+# The accepted type list is the one the commit carries, not an unstaged edit.
 gg_settings_index_mode
 
 TYPES="$(gg_setting GROWTH_GUARDS_COMMIT_TYPES "build chore ci docs feat fix perf refactor revert style test")" || exit 2

--- a/skills/growth-guards/scripts/growth-guards
+++ b/skills/growth-guards/scripts/growth-guards
@@ -1,19 +1,12 @@
 #!/usr/bin/env bash
-# growth-guards — dispatcher for the check family. One check by name, or
-# the whole enabled batch:
+# growth-guards — dispatcher for the check family:
 #
-#   growth-guards                 run every enabled repo check (same as 'all')
-#   growth-guards all             ditto
+#   growth-guards [all]           run every check named by GROWTH_GUARDS_CHECKS
 #   growth-guards CHECK [ARGS..]  run one check, flags passed through
 #
-# The batch runs the checks named by GROWTH_GUARDS_CHECKS (default:
-# todo-ban byte-ceiling suppression-ban). commit-msg reads a message, so
-# it never runs in the batch — the commit-msg hook invokes it directly.
-#
-# Batch aggregation fails closed: exit 2 if ANY check could not complete
-# (its own exit 2, or any unexpected status), else exit 1 if any check
-# found violations, else 0. Every check also remains independently
-# invocable as scripts/CHECK for pre-commit shims and CI.
+# commit-msg reads a message, so it never runs in the batch — the commit-msg
+# hook invokes it directly. Batch aggregation fails closed: exit 2 if ANY
+# check could not complete, else 1 if any found violations, else 0.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -47,16 +40,16 @@ if [ $# -ge 1 ]; then
       usage
       exit 0
       ;;
+    all) ;;
+    *)
+      CHECK="$1"
+      shift
+      case " $KNOWN_CHECKS " in
+        *" $CHECK "*) exec "$SCRIPT_DIR/$CHECK" "$@" ;;
+      esac
+      gg_config_error "unknown check '$CHECK' (known: $KNOWN_CHECKS)"
+      ;;
   esac
-fi
-
-if [ $# -ge 1 ] && [ "$1" != "all" ]; then
-  CHECK="$1"
-  shift
-  case " $KNOWN_CHECKS " in
-    *" $CHECK "*) exec "$SCRIPT_DIR/$CHECK" "$@" ;;
-  esac
-  gg_config_error "unknown check '$CHECK' (known: $KNOWN_CHECKS)"
 fi
 
 [ $# -le 1 ] || gg_config_error "'all' takes no extra arguments; invoke a single check to pass flags"

--- a/skills/growth-guards/scripts/install-git-hooks
+++ b/skills/growth-guards/scripts/install-git-hooks
@@ -1,21 +1,15 @@
 #!/usr/bin/env bash
 # install-git-hooks — real git pre-commit / commit-msg shims, so the guard
-# chain runs for every tool that commits (any agent harness, an editor, a
-# script, a human shell), not only the ones with their own hook system.
+# chain runs for every tool that commits, not only the ones with their own
+# hook system.
 #
-# Layout, mirroring the worktree skill's auto-repair install:
 #   .git/hooks/vstack-guards   helper this installer owns outright and
 #                              rewrites atomically on every run
-#   .git/hooks/pre-commit      one marked delegating line, created or appended
-#   .git/hooks/commit-msg      one marked delegating line, created or appended
+#   .git/hooks/pre-commit      one marked delegating line, created or inserted
+#   .git/hooks/commit-msg      same, passing git's message file through
 #
 # core.hooksPath is deliberately NOT used: it redirects the whole hooks
 # directory and would disable hooks the repo already has.
-#
-# The shims BLOCK. A failing check exits nonzero with its own remediation
-# text; a check that cannot run — missing script, exit 2 — blocks too, naming
-# what is missing. An existing foreign hook keeps its own exit status when our
-# chain passes.
 #
 # Exit codes: 0 shims in place (or deliberately skipped, stated on stdout);
 # 1 one or more shims could not be installed; 2 usage error.
@@ -60,6 +54,19 @@ die() { # usage/config error
   exit 2
 }
 
+warn() { # MESSAGE
+  echo "::warning::install-git-hooks: $*" >&2
+}
+
+FAILED=0
+# Every "this shim is not armed" lane: the run is marked failed, and the
+# caller returns 0 so the other hook is still attempted.
+hook_warn() { # MESSAGE
+  warn "$*"
+  FAILED=1
+  return 0
+}
+
 REPO="."
 MODE="install"
 while [ $# -gt 0 ]; do
@@ -100,18 +107,15 @@ HOOKS_DIR="$COMMON_DIR/hooks"
 
 # Installing under core.hooksPath would write files git never reads. Removal
 # still runs: shims left in .git/hooks reactivate the moment the setting goes
-# away, and they fail closed.
-# PRESENCE decides, not value: core.hooksPath set to the empty string still
-# redirects git away from .git/hooks, and reading it by value alone would let
-# that configuration pass as unset and the install report guards git ignores.
+# away. PRESENCE decides, not value — set to the empty string it still
+# redirects git away from .git/hooks.
 CUSTOM_HOOKS=""
 HOOKS_PATH_SET=0
-if git -C "$REPO_ABS" config --get core.hooksPath >/dev/null 2>&1; then
+if CUSTOM_HOOKS="$(git -C "$REPO_ABS" config --get core.hooksPath 2>/dev/null)"; then
   HOOKS_PATH_SET=1
-  CUSTOM_HOOKS="$(git -C "$REPO_ABS" config --get core.hooksPath 2>/dev/null || true)"
 fi
 if [ "$HOOKS_PATH_SET" -eq 1 ] && [ "$MODE" = "install" ]; then
-  echo "::warning::install-git-hooks: core.hooksPath is set ('$CUSTOM_HOOKS'); git ignores .git/hooks, so the guard shims were NOT installed" >&2
+  warn "core.hooksPath is set ('$CUSTOM_HOOKS'); git ignores .git/hooks, so the guard shims were NOT installed"
   echo "  Have that directory's pre-commit run $SCRIPT_DIR/pre-commit, and its commit-msg run $SCRIPT_DIR/commit-msg \"\$1\"." >&2
   echo "growth-guards git hooks: skipped — core.hooksPath is set ($CUSTOM_HOOKS)"
   exit 0
@@ -119,24 +123,21 @@ fi
 
 mkdir -p -- "$HOOKS_DIR" || die "could not create $HOOKS_DIR"
 
-
-# The helper is POSIX sh and self-contained. It looks for the hook-shaped
-# entry point in this install's own scripts directory first, then rediscovers
-# it from the MAIN checkout (linked worktrees share this hooks directory and
-# may carry no installed skills of their own) so a moved or re-installed
-# checkout repairs itself. Every failure to reach a script blocks the commit —
-# a guard that cannot run must never read as a pass.
+# The helper is POSIX sh and self-contained. It takes this install's own
+# scripts directory first, then rediscovers one from the MAIN checkout (linked
+# worktrees share this hooks directory and may carry no skills of their own),
+# so a moved or re-installed checkout repairs itself.
 write_helper() { # PATH
   local helper="$1" tmp=""
-  # The name is vstack-namespaced, but the non-destructive contract holds even
-  # against a collision: never write through a symlink, never replace a
-  # non-regular file, never overwrite content missing our marker.
+  # Non-destructive even against a name collision: never write through a
+  # symlink, never replace a non-regular file, never overwrite content
+  # missing our marker.
   if [ -L "$helper" ] || { [ -e "$helper" ] && [ ! -f "$helper" ]; }; then
-    echo "::warning::install-git-hooks: $helper exists and is not a regular file; refusing to replace it" >&2
+    warn "$helper exists and is not a regular file; refusing to replace it"
     return 1
   fi
   if [ -f "$helper" ] && ! grep -qF -- "$HELPER_MARKER" "$helper" 2>/dev/null; then
-    echo "::warning::install-git-hooks: $helper exists but was not written by this installer; refusing to overwrite it" >&2
+    warn "$helper exists but was not written by this installer; refusing to overwrite it"
     return 1
   fi
   tmp="$(mktemp "$helper.tmp.XXXXXX")" || return 1
@@ -205,18 +206,16 @@ HELPER
   }
 }
 
-# The delegating line goes FIRST in the hook, right after the shebang: hook
-# content that ends in an explicit `exit` would otherwise leave an appended
-# guard unreachable while the install still reported the hook as armed. Ours
-# runs, blocks on any nonzero, and only then falls through to whatever the
-# hook already did — whose own exit status then decides, unchanged.
+# The delegating line goes FIRST, right after the shebang: hook content ending
+# in an explicit `exit` would leave an appended guard unreachable. Ours runs,
+# blocks on any nonzero, then falls through to whatever the hook already did —
+# whose own exit status still decides.
 call_line() { # HOOK
   local hook="$1" args=""
   [ "$hook" = "pre-commit" ] || args=' "$@"'
   printf '%s' 'vstack_gg_h="$(git rev-parse --git-path hooks 2>/dev/null)/'"$HELPER_NAME"'"; [ -x "$vstack_gg_h" ] || { echo "growth-guards: hook helper $vstack_gg_h is missing or not executable; commit blocked (reinstall: vstack refresh)" >&2; exit 2; }; "$vstack_gg_h" '"$hook$args"' || exit $?; '"$HOOK_SENTINEL"
 }
 
-FAILED=0
 # Line tools terminate their last line, which would permanently add a newline
 # a hook never had. The original EOF state is recorded and re-asserted, so
 # foreign bytes come back exactly as they were.
@@ -241,40 +240,31 @@ strip_final_newline() { # FILE — drop one trailing newline byte if present
 # and cannot be restored is a guard that never runs — never a success.
 ensure_hook_executable() { # HOOK PATH
   local hook="$1" path="$2"
-  if [ -x "$path" ]; then
-    return 0
-  fi
-  if chmod +x -- "$path" 2>/dev/null && [ -x "$path" ]; then
-    return 0
-  fi
-  echo "::warning::install-git-hooks: $path is not executable and could not be made so; git ignores it — the $hook guard is NOT armed" >&2
-  FAILED=1
-  return 0
+  [ -x "$path" ] && return 0
+  chmod +x -- "$path" 2>/dev/null && [ -x "$path" ] && return 0
+  hook_warn "$path is not executable and could not be made so; git ignores it — the $hook guard is NOT armed"
 }
 
 install_hook() { # HOOK
   local hook="$1" path="$HOOKS_DIR/$1" line="" tmp="" rest="" status=0
   line="$(call_line "$hook")"
   # A symlinked hook points at a shared or externally managed target; writing
-  # through it (live) or materializing its target (dangling, which passes
-  # `! -e`) would modify content this install does not own.
+  # through it, or materializing a dangling target (which passes `! -e`),
+  # would modify content this install does not own.
   if [ -L "$path" ]; then
-    echo "::warning::install-git-hooks: $path is a symlink; not modifying its target — the $hook guard is NOT installed" >&2
-    FAILED=1
+    hook_warn "$path is a symlink; not modifying its target — the $hook guard is NOT installed"
     return 0
   fi
   if [ ! -e "$path" ]; then
     printf '#!/bin/sh\n%s\n%s\n' "$line" "$CREATED_MARKER" >"$path" 2>/dev/null || {
-      echo "::warning::install-git-hooks: could not write $path — the $hook guard is NOT installed" >&2
-      FAILED=1
+      hook_warn "could not write $path — the $hook guard is NOT installed"
       return 0
     }
     ensure_hook_executable "$hook" "$path"
     return 0
   fi
   if [ ! -f "$path" ]; then
-    echo "::warning::install-git-hooks: $path exists and is not a regular file — the $hook guard is NOT installed" >&2
-    FAILED=1
+    hook_warn "$path exists and is not a regular file — the $hook guard is NOT installed"
     return 0
   fi
   # Whole interpreter names only: '.*sh' would match #!/usr/bin/fish and let
@@ -282,8 +272,7 @@ install_hook() { # HOOK
   # already-current fast path: our line under an interpreter that cannot run
   # it is not an armed hook, whoever changed the shebang.
   if ! head -n 1 "$path" | grep -qE '^#![[:space:]]*([^[:space:]]*/)?(env[[:space:]]+)?(sh|bash|dash|ksh|zsh)([[:space:]]|$)'; then
-    echo "::warning::install-git-hooks: $path is not a POSIX-shell script; not modifying it — the $hook guard is NOT installed" >&2
-    FAILED=1
+    hook_warn "$path is not a POSIX-shell script; not modifying it — the $hook guard is NOT installed"
     return 0
   fi
   # Idempotence keys on the EXACT delegate AT ITS POSITION — line 2, straight
@@ -295,50 +284,42 @@ install_hook() { # HOOK
     return 0
   fi
   if [ ! -x "$path" ]; then
-    echo "::warning::install-git-hooks: $path exists but is not executable (a disabled hook); not modifying it — the $hook guard is NOT installed" >&2
-    FAILED=1
+    hook_warn "$path exists but is not executable (a disabled hook); not modifying it — the $hook guard is NOT installed"
     return 0
   fi
-  # Ownership is READ before the filter strips the marker along with our line,
-  # and re-asserted below: a repair must not turn a hook we created into one
-  # that looks like a consumer's.
+  # Read before the filter strips the marker with our line, re-asserted below:
+  # a repair must not turn a hook we created into one that looks foreign.
   local created=0
   grep -qF -- "$CREATED_MARKER" "$path" 2>/dev/null && created=1
-  # Everything the hook has apart from its shebang and any stale delegate of
-  # ours, kept in a FILE: a command substitution would strip a missing final
-  # newline, and the foreign bytes must come back exactly as they were.
-  # grep -v exits 1 when it prints nothing; only >= 2 is a read failure.
+  # Everything but the shebang and any stale delegate of ours, kept in a FILE:
+  # a command substitution would strip a missing final newline, and the
+  # foreign bytes must come back exactly as they were. grep -v exits 1 when it
+  # prints nothing; only >= 2 is a read failure.
   rest="$(mktemp "$path.rest.XXXXXX")" || {
-    echo "::warning::install-git-hooks: could not create a temporary file beside $path — the $hook guard is NOT installed" >&2
-    FAILED=1
+    hook_warn "could not create a temporary file beside $path — the $hook guard is NOT installed"
     return 0
   }
   tail -n +2 "$path" | grep -vF -- "$HOOK_SENTINEL" >"$rest" || status=$?
   if [ "$status" -gt 1 ]; then
     rm -f -- "$rest"
-    echo "::warning::install-git-hooks: could not read $path — the $hook guard is NOT installed" >&2
-    FAILED=1
+    hook_warn "could not read $path — the $hook guard is NOT installed"
     return 0
   fi
   if ! ends_with_newline "$path" && ! strip_final_newline "$rest"; then
     rm -f -- "$rest"
-    echo "::warning::install-git-hooks: could not preserve the end of $path — the $hook guard is NOT installed" >&2
-    FAILED=1
+    hook_warn "could not preserve the end of $path — the $hook guard is NOT installed"
     return 0
   fi
   # Written back through the existing file, not renamed over it: the hook keeps
   # its inode, mode, and any links a consumer's tooling holds.
   tmp="$(mktemp "$path.tmp.XXXXXX")" || {
     rm -f -- "$rest"
-    echo "::warning::install-git-hooks: could not create a temporary file beside $path — the $hook guard is NOT installed" >&2
-    FAILED=1
+    hook_warn "could not create a temporary file beside $path — the $hook guard is NOT installed"
     return 0
   }
   # The shebang is re-emitted TERMINATED even when the original file ended at
-  # it: the delegate has to start on its own line or the interpreter path and
-  # the shell code run together. A shebang cannot contain a newline, so the
-  # command substitution is lossless; the body's own EOF state is preserved
-  # above.
+  # it, or the delegate would run onto the interpreter line. A shebang cannot
+  # contain a newline, so the command substitution is lossless.
   local shebang=""
   shebang="$(head -n 1 "$path")"
   if ! cp -p -- "$path" "$tmp" 2>/dev/null || ! {
@@ -350,8 +331,7 @@ install_hook() { # HOOK
     cat -- "$rest"
   } >"$tmp" 2>/dev/null || ! mv -f -- "$tmp" "$path" 2>/dev/null; then
     rm -f -- "$tmp" "$rest"
-    echo "::warning::install-git-hooks: could not rewrite $path — the $hook guard is NOT installed" >&2
-    FAILED=1
+    hook_warn "could not rewrite $path — the $hook guard is NOT installed"
     return 0
   fi
   rm -f -- "$rest"
@@ -368,11 +348,9 @@ uninstall_hook() { # HOOK — drop our line; drop the file when only ours was in
     sentinel_status=0
     grep -qF -- "$HOOK_SENTINEL" "$path" 2>/dev/null || sentinel_status=$?
     if [ "$sentinel_status" -eq 0 ]; then
-      echo "::warning::install-git-hooks: $path is a symlink carrying the guard line; remove it by hand — its target is not ours to edit" >&2
-      FAILED=1
+      hook_warn "$path is a symlink carrying the guard line; remove it by hand — its target is not ours to edit"
     elif [ "$sentinel_status" -gt 1 ]; then
-      echo "::warning::install-git-hooks: $path is a symlink whose target could not be read; it was left in place" >&2
-      FAILED=1
+      hook_warn "$path is a symlink whose target could not be read; it was left in place"
     fi
     return 0
   fi
@@ -383,31 +361,27 @@ uninstall_hook() { # HOOK — drop our line; drop the file when only ours was in
   sentinel_status=0
   grep -qF -- "$HOOK_SENTINEL" "$path" 2>/dev/null || sentinel_status=$?
   if [ "$sentinel_status" -gt 1 ]; then
-    echo "::warning::install-git-hooks: could not read $path to check for the guard line; it was left in place" >&2
-    FAILED=1
+    hook_warn "could not read $path to check for the guard line; it was left in place"
     return 0
   fi
   [ "$sentinel_status" -eq 0 ] || return 0
-  # Ownership is READ before the filter strips the marker with our line.
+  # Read before the filter strips the marker with our line.
   created=0
   grep -qF -- "$CREATED_MARKER" "$path" 2>/dev/null && created=1
   tmp="$(mktemp "$path.tmp.XXXXXX")" || {
-    echo "::warning::install-git-hooks: could not create a temporary file beside $path; its guard line was left in place" >&2
-    FAILED=1
+    hook_warn "could not create a temporary file beside $path; its guard line was left in place"
     return 0
   }
   # grep -v exits 1 when it prints nothing; only >= 2 means the read failed.
   grep -vF -- "$HOOK_SENTINEL" "$path" >"$tmp" || status=$?
   if [ "$status" -gt 1 ]; then
     rm -f -- "$tmp"
-    echo "::warning::install-git-hooks: could not read $path; its guard line was left in place" >&2
-    FAILED=1
+    hook_warn "could not read $path; its guard line was left in place"
     return 0
   fi
   if ! ends_with_newline "$path" && ! strip_final_newline "$tmp"; then
     rm -f -- "$tmp"
-    echo "::warning::install-git-hooks: could not preserve the end of $path; its guard line was left in place" >&2
-    FAILED=1
+    hook_warn "could not preserve the end of $path; its guard line was left in place"
     return 0
   fi
   # Only a hook this installer CREATED goes away outright; a consumer's own
@@ -417,8 +391,7 @@ uninstall_hook() { # HOOK — drop our line; drop the file when only ours was in
   body="$(grep -cvE '^([[:space:]]*|#!.*)$' "$tmp")" || status=$?
   if [ "$status" -gt 1 ]; then
     rm -f -- "$tmp"
-    echo "::warning::install-git-hooks: could not inspect $path; its guard line was left in place" >&2
-    FAILED=1
+    hook_warn "could not inspect $path; its guard line was left in place"
     return 0
   fi
   if [ "$created" -eq 1 ] && [ "$body" -eq 0 ]; then
@@ -432,8 +405,7 @@ uninstall_hook() { # HOOK — drop our line; drop the file when only ours was in
     || ! cat "$tmp" >"$tmp.mode" 2>/dev/null \
     || ! mv -f -- "$tmp.mode" "$path" 2>/dev/null; then
     rm -f -- "$tmp" "$tmp.mode"
-    echo "::warning::install-git-hooks: could not rewrite $path; its guard line was left in place" >&2
-    FAILED=1
+    hook_warn "could not rewrite $path; its guard line was left in place"
     return 0
   fi
   rm -f -- "$tmp"
@@ -442,14 +414,13 @@ uninstall_hook() { # HOOK — drop our line; drop the file when only ours was in
 
 # Every work tree on this common git directory shares one hooks directory, so
 # a checkout that still has the skill installed still needs the shims. Only a
-# SEPARATE install counts: worktree layouts commonly link their skills
-# directory back into the checkout being uninstalled from, and that copy is
-# the one going away, so candidates are compared by physical path.
+# SEPARATE install counts — a worktree whose skills directory links back into
+# the checkout being uninstalled from is the same install — so candidates are
+# compared by physical path.
 #
-# Roots come from the per-worktree `gitdir` files rather than from
-# `worktree list`, whose line-oriented output cannot represent a path
-# containing a newline — one such path would silently shorten a root and
-# hide a survivor. Anything unreadable here is "cannot tell", never "none".
+# Roots come from the per-worktree `gitdir` files, not `worktree list`, whose
+# line-oriented output cannot represent a path containing a newline. Anything
+# unreadable here is "cannot tell", never "none".
 #
 # Returns 0 with the surviving scripts directory on stdout, 1 when there is
 # none, 2 when the question could not be answered.
@@ -550,7 +521,7 @@ if [ "$MODE" = "uninstall" ]; then
   survivor_status=0
   other="$(other_worktree_still_installed)" || survivor_status=$?
   if [ "$survivor_status" -gt 1 ]; then
-    echo "::warning::install-git-hooks: could not enumerate this repository's work trees; the shims were left in place rather than risk disarming one that still needs them" >&2
+    warn "could not enumerate this repository's work trees; the shims were left in place rather than risk disarming one that still needs them"
     echo "growth-guards git hooks: kept — the work-tree list under $COMMON_DIR/worktrees could not be read"
     exit 1
   fi
@@ -575,8 +546,7 @@ if [ "$MODE" = "uninstall" ]; then
     && [ -f "$helper" ] && [ ! -L "$helper" ] \
     && grep -qF -- "$HELPER_MARKER" "$helper" 2>/dev/null; then
     rm -f -- "$helper" || {
-      echo "::warning::install-git-hooks: could not remove $helper" >&2
-      FAILED=1
+      hook_warn "could not remove $helper"
     }
   fi
   if [ "$FAILED" -eq 1 ]; then

--- a/skills/growth-guards/scripts/lib/common.sh
+++ b/skills/growth-guards/scripts/lib/common.sh
@@ -1,31 +1,48 @@
 # shellcheck shell=bash
 # Shared plumbing for the growth-guards check family. Sourced (not executed)
-# by every scripts/* check. Bash 3.2-safe throughout: no Bash 4+ builtins
-# or array kinds, guarded expansion for possibly-empty arrays.
+# by every scripts/* check, which sets GG_CHECK to its own name first so every
+# diagnostic names its producer.
 #
-# Family contract carried here: exit 0 clean, 1 violations, 2
-# usage/config/collection error. The gates distinguish "measured and fine"
-# from "could not measure": any failure to collect (an unreadable file, a
-# git or grep execution failure) goes through gg_collection_error — a loud
-# exit 2, never a silent pass.
+# Family contract: exit 0 clean, 1 violations, 2 usage/config/collection
+# error. A measurement that could not be taken goes through
+# gg_collection_error — a loud exit 2, never a silent pass.
 #
-# Each check sets GG_CHECK to its own name before calling any helper, so
-# every diagnostic names the check that produced it.
+# Bash 3.2-safe throughout: no Bash 4+ builtins or array kinds, guarded
+# expansion for possibly-empty arrays.
 
 set -euo pipefail
 
 GG_TAB="$(printf '\t')"
+GG_VIOLATIONS=0
+# Cleanup state is per-process. An INHERITED value must never decide what a
+# guard deletes on exit: gg_settings_index_mode arms the same trap without
+# creating a scratch directory, and the checks a hook lane runs inherit the
+# exported settings cache their parent is still reading.
+GG_TMP=""
+GG_SETTINGS_INDEX_OWNED=0
 
 gg_config_error() {
   echo "::error::${GG_CHECK:-growth-guards}: $*" >&2
   exit 2
 }
 
-# Same loud exit as a config error, distinct name so call sites read as
-# what they are: a measurement that failed, never a verdict.
-gg_collection_error() {
-  echo "::error::${GG_CHECK:-growth-guards}: $*" >&2
-  exit 2
+# Same loud exit, distinct name so call sites read as what they are: a
+# measurement that failed, never a verdict.
+gg_collection_error() { gg_config_error "$@"; }
+
+# Only what THIS process created: GG_SETTINGS_INDEX_DIR is exported to the
+# checks a hook lane runs, and they must not delete the directory their parent
+# is still resolving settings from.
+gg_cleanup() {
+  [ -z "${GG_TMP:-}" ] || rm -rf -- "$GG_TMP"
+  [ "${GG_SETTINGS_INDEX_OWNED:-0}" = "1" ] && rm -rf -- "$GG_SETTINGS_INDEX_DIR"
+  return 0
+}
+
+gg_tmpdir() { # per-run scratch directory in GG_TMP, removed at exit
+  GG_TMP="$(mktemp -d "${TMPDIR:-/tmp}/gg-${GG_CHECK:-growth-guards}.XXXXXX")" \
+    || gg_config_error "could not create a temporary directory"
+  trap gg_cleanup EXIT
 }
 
 gg_repo_root_cd() { # cd to the repository root; all configured paths are repo-relative
@@ -37,11 +54,12 @@ gg_repo_root_cd() { # cd to the repository root; all configured paths are repo-r
 # A hook lane judges ONE commit, configuration included: tracked settings
 # sources resolve from the index while this is on, so an unstaged edit cannot
 # change the policy a commit is measured against. Call it after cd-ing to the
-# repository root; the temporary directory dies with the process.
+# repository root.
 gg_settings_index_mode() {
   GG_SETTINGS_INDEX_DIR="$(mktemp -d "${TMPDIR:-/tmp}/gg-settings.XXXXXX")" \
     || gg_config_error "could not create a temporary directory"
-  trap 'rm -rf -- "$GG_SETTINGS_INDEX_DIR"' EXIT
+  GG_SETTINGS_INDEX_OWNED=1
+  trap gg_cleanup EXIT
   GG_SETTINGS_FROM_INDEX=1
   export GG_SETTINGS_FROM_INDEX GG_SETTINGS_INDEX_DIR
 }
@@ -103,11 +121,15 @@ gg_config_path() { # RAW LABEL — normalized on stdout; nonzero + ::error on st
   printf '%s' "$norm"
 }
 
+# One resolution order for every configured path: an explicit flag wins, then
+# the setting, then the built-in default — validated and normalized either way.
+gg_resolve_path() { # FLAG-VALUE KEY DEFAULT LABEL — normalized path on stdout
+  local raw="$1"
+  [ -n "$raw" ] || raw="$(gg_setting "$2" "$3")" || return 1
+  gg_config_path "$raw" "$4"
+}
+
 # --- exclusion list: pattern<TAB>reason, reason mandatory --------------------
-# Shell glob matched against the full repo-relative path (`*` crosses `/`);
-# blank lines and `#` comments are ignored; a pattern without a reason is a
-# config error — every exclusion carries its justification. A missing file
-# is an empty list.
 GG_EXCLUDE_PATTERNS=()
 
 # The scans read the INDEX, so policy files come from the index too: staged
@@ -131,6 +153,9 @@ gg_policy_content() { # FILE — content on stdout; 1 = the commit has no such f
   return 1
 }
 
+# Shell glob matched against the full repo-relative path (`*` crosses `/`);
+# blank lines and `#` comments are ignored; a pattern without a reason is a
+# config error. A missing file is an empty list.
 gg_load_excludes() { # FILE — fills GG_EXCLUDE_PATTERNS
   local file="$1" line lineno pat reason content status=0
   GG_EXCLUDE_PATTERNS=()
@@ -165,6 +190,32 @@ gg_is_excluded() { # PATH — 0 when some exclusion glob matches the full path
     esac
   done
   return 1
+}
+
+# One banned shape, scanned over INDEX content in two phases: the offending
+# FILES (-l -z, so a path containing ':' cannot garble parsing), then the
+# numbered hits per file, where the known path prefix strips exactly. Binary
+# files are skipped (-I). The per-file pass is line-oriented, so a path
+# embedding a newline yields no DETAIL lines — the file still fails phase one.
+# Needs GG_TMP (gg_tmpdir) and the excludes already loaded.
+gg_grep_lane() { # LABEL ERE REMEDY PATHSPEC... — numbered violations on stdout
+  local label="$1" ere="$2" remedy="$3" status=0 f hit_status hit
+  shift 3
+  git grep --cached -lIzE "$ere" -- "$@" >"$GG_TMP/lane.z" || status=$?
+  [ "$status" -le 1 ] || gg_collection_error "git grep failed scanning tracked files for $label (exit $status)"
+  while IFS= read -r -d '' f; do
+    gg_is_excluded "$f" && continue
+    hit_status=0
+    git grep --cached -nIE "$ere" -- ":(literal)$f" >"$GG_TMP/lane.hits" || hit_status=$?
+    # This file just listed as containing hits; anything but a clean re-scan
+    # (including "no matches") means the measurement is broken.
+    [ "$hit_status" -eq 0 ] || gg_collection_error "git grep could not detail the $label hits in '$f' (exit $hit_status)"
+    while IFS= read -r hit; do
+      echo "${GG_CHECK:-growth-guards} FAIL $label: $f:${hit#"$f":}"
+      echo "  remedies: $remedy"
+      GG_VIOLATIONS=$((GG_VIOLATIONS + 1))
+    done <"$GG_TMP/lane.hits"
+  done <"$GG_TMP/lane.z"
 }
 
 gg_count_nonempty_lines() { # FILE — count on stdout; loud exit if grep cannot read it

--- a/skills/growth-guards/scripts/lib/settings.sh
+++ b/skills/growth-guards/scripts/lib/settings.sh
@@ -2,10 +2,9 @@
 # Settings resolution for the growth-guards check family. Sourced (not
 # executed) by every scripts/* check.
 #
-# VENDORED from skills/review-gate/scripts/lib/settings.sh (rg_setting),
-# renamed gg_setting: skills are standalone-installable, so a consumer that
-# installs only growth-guards has no review-gate tree to source from. Keep
-# the logic in sync with the original; behavioral fixes belong there first.
+# Standalone by design: a consumer that installs only growth-guards has no
+# review-gate tree to source its settings loader from. This one adds the
+# dotenv layers and the index-scoped resolution the hook lanes need.
 #
 # Resolution order for every key read through gg_setting (the GROWTH_GUARDS_*
 # family):
@@ -23,11 +22,9 @@
 #
 # Keys are matched FILE-WIDE by exact name, with no TOML-table awareness:
 # adopter settings sit under an [env] table, and a table-aware top-level
-# parser would resolve none of them. The consequence is a contract: every
-# key name read through gg_setting is reserved across the whole file — an
-# assignment under an unrelated table would be read as the setting, so
-# callers must keep these names unique file-wide. The one detectable
-# ambiguity, the same name assigned more than once, fails loud below.
+# parser would resolve none of them. So every key name read through
+# gg_setting is reserved across the whole file; the one detectable ambiguity,
+# the same name assigned more than once, fails loud below.
 #
 # The caller cds to the repo root before resolving, so the default settings
 # path is relative.
@@ -95,12 +92,11 @@ gg_settings_usable() { # PATH — 0 = readable-shaped or absent; 1 + ::error oth
   return 1
 }
 
-# The pre-commit chain judges one commit snapshot, policy included: with
-# GG_SETTINGS_FROM_INDEX=1 a TRACKED settings source is read from the INDEX,
-# a source staged for DELETION governs as absent, and an untracked one (a
-# personal .env.local) is the worktree copy, which is all there is. A tracked
-# SYMLINK fails loud: its index blob is the target name, not settings, and
-# parsing that would silently resolve every key to its built-in default.
+# With GG_SETTINGS_FROM_INDEX=1 a TRACKED settings source is read from the
+# INDEX, a source staged for DELETION governs as absent, and an untracked one
+# (a personal .env.local) is the worktree copy, which is all there is. A
+# tracked SYMLINK fails loud: its index blob is the target name, not settings,
+# and parsing that would resolve every key to its built-in default.
 # GG_SETTINGS_INDEX_DIR holds the materialized copies; the caller owns it.
 gg_settings_source() { # FILE — the path to actually read; nonzero + ::error on failure
   local file="$1" copy=""
@@ -151,6 +147,26 @@ gg_settings_grep() { # REGEX FILE — matching lines on stdout; 1 = no match
   return "$status"
 }
 
+# One dotenv layer (.env.local, .env): the LAST matching KEY= line wins
+# (shell-sourcing semantics), optional surrounding quotes stripped. Parsed,
+# never sourced. 0 = value on stdout; 1 = this layer assigns nothing;
+# 2 = the layer is unusable and resolution must fail loud.
+gg_dotenv_layer() { # FILE NAME
+  local file="$1" name="$2" src line val matches status=0
+  src="$(gg_settings_source "$file")" || return 2
+  gg_settings_usable "$src" || return 2
+  [ -f "$src" ] || return 1
+  matches="$(gg_settings_grep "^[[:space:]]*(export[[:space:]]+)?${name}=" "$src")" || status=$?
+  [ "$status" -le 1 ] || return 2
+  line="$(printf '%s\n' "$matches" | tail -n 1)"
+  [ -n "$line" ] || return 1
+  if ! val="$(gg_dotenv_value "${line#*=}")"; then
+    echo "::error::$file: unsupported syntax for $name (a quoted value must end at its closing quote, optionally followed by a comment)" >&2
+    return 2
+  fi
+  printf '%s' "$val"
+}
+
 gg_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
                # a present-but-unparseable assignment (callers must propagate)
   local name="$1" default="$2" line val file status matches
@@ -169,25 +185,14 @@ gg_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
     printf '%s' "${!name}"
     return 0
   fi
-  # Env-file overrides (standard project layering: .env.local beats the
-  # committed settings, .env is the base) — LAST matching KEY= line wins (shell-sourcing semantics),
-  # optional surrounding quotes stripped. Parsed, never sourced.
-  local local_env=""
-  local_env="$(gg_settings_source ".env.local")" || return 1
-  gg_settings_usable "$local_env" || return 1
-  if [ -f "$local_env" ]; then
-    status=0
-    matches="$(gg_settings_grep "^[[:space:]]*(export[[:space:]]+)?${name}=" "$local_env")" || status=$?
-    [ "$status" -le 1 ] || return 1
-    line="$(printf '%s\n' "$matches" | tail -n 1)"
-    if [ -n "$line" ]; then
-      if ! val="$(gg_dotenv_value "${line#*=}")"; then
-        echo "::error::.env.local: unsupported syntax for $name (a quoted value must end at its closing quote, optionally followed by a comment)" >&2
-        return 1
-      fi
-      printf '%s' "$val"
-      return 0
-    fi
+  # Standard project layering: .env.local beats the committed settings, .env
+  # is the base.
+  status=0
+  val="$(gg_dotenv_layer ".env.local" "$name")" || status=$?
+  [ "$status" -ne 2 ] || return 1
+  if [ "$status" -eq 0 ]; then
+    printf '%s' "$val"
+    return 0
   fi
   # Nested project settings override the root file (the standard loader
   # order); an explicit GROWTH_GUARDS_SETTINGS_FILE consults only itself.
@@ -202,30 +207,25 @@ gg_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
   if [ -f "$file" ]; then
     # Key PRESENCE decides, not value non-emptiness: `NAME = ""` is a real
     # assignment and must override the built-in default, exactly like a
-    # set-but-empty env var does above.
-    # Leading whitespace before a key is valid TOML, so matching is
-    # whitespace-tolerant everywhere (presence, ambiguity guard, extraction)
-    # — anchoring at column one made an indented duplicate bypass the
-    # fail-loud guard and an indented sole assignment collapse silently to
-    # the built-in default (vstack#1059).
+    # set-but-empty env var does above. Leading whitespace before a key is
+    # valid TOML, so matching is whitespace-tolerant everywhere — presence,
+    # ambiguity guard and extraction alike.
     status=0
     matches="$(gg_settings_grep "^[[:space:]]*${name}[[:space:]]*=" "$file")" || status=$?
     [ "$status" -le 1 ] || return 1
     if [ "$status" -eq 0 ]; then
-      # File-wide matching (header contract) makes a re-assigned name
-      # ambiguous — e.g. the same key under two tables. Silently taking the
-      # first could read an unrelated table's value, so ambiguity is a
-      # configuration error.
+      # File-wide matching makes a re-assigned name ambiguous — the same key
+      # under two tables. Taking the first could read an unrelated table's
+      # value, so ambiguity is a configuration error.
       if [ "$(printf '%s\n' "$matches" | grep -c .)" -gt 1 ]; then
         echo "::error::$file: $name is assigned more than once (keys are matched file-wide regardless of TOML table; each name must be unique in the file)" >&2
         return 1
       fi
       line="$(printf '%s\n' "$matches" | head -n 1)"
-      # A PRESENT assignment this parser cannot read must fail LOUDLY, never
-      # collapse to empty. Only the flat single-line basic-string shape is
-      # supported — the value is quote-free ([^"]*), which makes the
-      # extraction exact even with a trailing TOML comment (accepted);
-      # anything else is a configuration error.
+      # A PRESENT assignment this parser cannot read fails LOUDLY, never
+      # collapses to empty. Only the flat single-line basic-string shape is
+      # supported: a quote-free value ([^"]*) makes the extraction exact even
+      # with a trailing TOML comment.
       if ! printf '%s\n' "$line" | grep -Eq -- "^[[:space:]]*${name}[[:space:]]*=[[:space:]]*\"[^\"]*\"[[:space:]]*(#.*)?\$"; then
         echo "::error::$file: unsupported syntax for $name (expected a single-line basic string: $name = \"value\")" >&2
         return 1
@@ -236,22 +236,12 @@ gg_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
     fi
   fi
   done
-  local base_env=""
-  base_env="$(gg_settings_source ".env")" || return 1
-  gg_settings_usable "$base_env" || return 1
-  if [ -f "$base_env" ]; then
-    status=0
-    matches="$(gg_settings_grep "^[[:space:]]*(export[[:space:]]+)?${name}=" "$base_env")" || status=$?
-    [ "$status" -le 1 ] || return 1
-    line="$(printf '%s\n' "$matches" | tail -n 1)"
-    if [ -n "$line" ]; then
-      if ! val="$(gg_dotenv_value "${line#*=}")"; then
-        echo "::error::.env: unsupported syntax for $name (a quoted value must end at its closing quote, optionally followed by a comment)" >&2
-        return 1
-      fi
-      printf '%s' "$val"
-      return 0
-    fi
+  status=0
+  val="$(gg_dotenv_layer ".env" "$name")" || status=$?
+  [ "$status" -ne 2 ] || return 1
+  if [ "$status" -eq 0 ]; then
+    printf '%s' "$val"
+    return 0
   fi
   printf '%s' "$default"
 }

--- a/skills/growth-guards/scripts/pre-commit
+++ b/skills/growth-guards/scripts/pre-commit
@@ -1,18 +1,12 @@
 #!/usr/bin/env bash
 # pre-commit — the staged-scope guard chain, shaped for the git pre-commit
-# hook (the installed .git/hooks/vstack-guards shim execs it).
-#
-# Chain, in order:
-#   1. size-ratchet, when the sibling skill is installed beside this one;
-#   2. `growth-guards all` — the batch, staged-scope by default
-#      (todo-ban, byte-ceiling --staged, suppression-ban);
-#   3. the repo-local entry named by GROWTH_GUARDS_PRE_COMMIT_LOCAL
-#      (repo-root-relative executable; empty = none).
+# hook (the installed .git/hooks/vstack-guards shim execs it): size-ratchet
+# when the sibling skill is installed, then `growth-guards all`, then the
+# repo-local entry named by GROWTH_GUARDS_PRE_COMMIT_LOCAL.
 #
 # Every step runs before the verdict, so one commit attempt reports every
-# blocker. Aggregation matches the batch dispatcher and fails CLOSED: exit 2
-# if any step could not complete, else 1 if any step found violations, else 0.
-# Both nonzero verdicts block the commit.
+# blocker. Aggregation fails CLOSED: exit 2 if any step could not complete,
+# else 1 if any found violations, else 0. Both nonzero verdicts block.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -72,19 +66,18 @@ run_step() { # LABEL COMMAND [ARGS...] — runs one step and folds its verdict
   esac
 }
 
-# Sibling-skill resolution, one relative path for both install shapes: a
-# consumer's .agents/skills/<skill>/scripts and vstack's own skills/<skill>/
-# scripts are the same two levels up.
+# One relative path for both install shapes: a consumer's
+# .agents/skills/<skill>/scripts and vstack's own skills/<skill>/scripts are
+# the same two levels up.
 SIZE_RATCHET_SKILL="$SCRIPT_DIR/../../size-ratchet"
 SIZE_RATCHET="$SIZE_RATCHET_SKILL/scripts/size-ratchet"
 # Whether the SKILL is installed decides, not whether its script happens to be
-# runnable: an installed skill whose script is missing, dangling or
-# unexecutable is a broken install, and the chain must never pass by losing a
-# gate. -L catches a dangling symlink, which -e reports as absent.
+# runnable: an installed skill with a missing, dangling or unexecutable script
+# is a broken install, and the chain must never pass by losing a gate. -L
+# catches a dangling symlink, which -e reports as absent.
 if [ -e "$SIZE_RATCHET_SKILL" ] || [ -L "$SIZE_RATCHET_SKILL" ]; then
   [ -x "$SIZE_RATCHET" ] || gg_config_error "the size-ratchet skill is installed at $SIZE_RATCHET_SKILL but $SIZE_RATCHET is missing or not executable — reinstall it"
-  # --staged: the hook must judge the blobs the commit records, not the
-  # worktree copies, which a revert after `git add` would leave clean.
+  # --staged: judge the blobs the commit records, not the worktree copies.
   run_step size-ratchet "$SIZE_RATCHET" --staged
 else
   echo "=== pre-commit: size-ratchet not installed — skipped"
@@ -98,8 +91,8 @@ LOCAL_RAW="$(gg_setting GROWTH_GUARDS_PRE_COMMIT_LOCAL "")" || exit 2
 if [ -n "$LOCAL_RAW" ]; then
   LOCAL_ENTRY="$(gg_config_path "$LOCAL_RAW" GROWTH_GUARDS_PRE_COMMIT_LOCAL)" || exit 2
   [ -x "$LOCAL_ENTRY" ] || gg_config_error "GROWTH_GUARDS_PRE_COMMIT_LOCAL names '$LOCAL_ENTRY', which is missing or not executable"
-  # A repo-local entry follows the family contract: 0 clean, 1 violations,
-  # anything else "could not complete". Every nonzero blocks either way.
+  # The family contract applies: 0 clean, 1 violations, anything else "could
+  # not complete". Every nonzero blocks either way.
   run_step "repo-local: $LOCAL_ENTRY" "./$LOCAL_ENTRY"
 fi
 

--- a/skills/growth-guards/scripts/suppression-ban
+++ b/skills/growth-guards/scripts/suppression-ban
@@ -1,29 +1,17 @@
 #!/usr/bin/env bash
 # suppression-ban — two gates over lint suppression in tracked files:
 #
-# 1. BLANKET suppressions fail flat (no baseline): the file- or
-#    module-wide pragmas that turn a linter off wholesale —
-#      rust        crate/module-wide inner allow attribute  #![allow(...)]
-#      python      file-level directives  ruff: noqa / flake8: noqa
-#      eslint      the bare block form  /* eslint-disable */  (no rules named)
-#      golangci    nolint with no linter named, or nolint:all
-#    A PER-LINE suppression that names its lint and states its reason
-#    stays legal — the ban is on suppressing everything at once.
+# 1. BLANKET suppressions fail flat (no baseline): the file- or module-wide
+#    pragmas that turn a linter off wholesale. A PER-LINE suppression that
+#    names its lint and states its reason stays legal.
+# 2. BARE ALLOW RATCHET (rust): reasonless dead_code/unused allow attributes
+#    are counted per file against a tighten-only baseline TSV
+#    (path<TAB>count). Rows only go down or away; --update lowers and removes
+#    but never adds or raises, so growth is a visible hand-edit in review.
 #
-# 2. BARE ALLOW RATCHET (rust): reasonless per-item attributes for
-#    dead_code / unused lints are counted per file; a repo with legacy
-#    counts freezes them in a tighten-only baseline TSV (path<TAB>count).
-#    Rows only go down or away: new bare allows, growth past a row, and a
-#    baseline looser than reality all fail; --update lowers/removes rows
-#    but never adds or raises one, so deliberate growth is a visible
-#    hand-edit in review. An attribute carrying `reason = "..."` does not
-#    count — stating the reason is the legal form.
-#
-# Scans INDEX content (git grep --cached), language-scoped by pathspec, so
-# documentation and scripts that QUOTE these pragmas never fire. Exit
-# codes: 0 clean; 1 violations; 2 usage/config/collection error; any git
-# or grep execution failure (exit >= 2) is a collection error, never a
-# silent pass.
+# Scans INDEX content, language-scoped by pathspec, so documentation and
+# scripts that QUOTE these pragmas never fire. Exit codes: 0 clean;
+# 1 violations; 2 usage/config/collection error.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -82,70 +70,39 @@ done
 
 gg_repo_root_cd
 
-if [ -n "$BASELINE_OPT" ]; then
-  BASELINE_FILE="$BASELINE_OPT"
-else
-  BASELINE_FILE="$(gg_setting GROWTH_GUARDS_SUPPRESSION_BASELINE "tools/suppression-baseline.tsv")" || exit 2
-fi
-if [ -n "$EXCLUDES_OPT" ]; then
-  EXCLUDES_FILE="$EXCLUDES_OPT"
-else
-  EXCLUDES_FILE="$(gg_setting GROWTH_GUARDS_SUPPRESSION_EXCLUDES "tools/suppression-ban-excludes")" || exit 2
-fi
-BASELINE_FILE="$(gg_config_path "$BASELINE_FILE" "baseline")" || exit 2
-EXCLUDES_FILE="$(gg_config_path "$EXCLUDES_FILE" "excludes")" || exit 2
+BASELINE_FILE="$(gg_resolve_path "$BASELINE_OPT" GROWTH_GUARDS_SUPPRESSION_BASELINE "tools/suppression-baseline.tsv" baseline)" || exit 2
+EXCLUDES_FILE="$(gg_resolve_path "$EXCLUDES_OPT" GROWTH_GUARDS_SUPPRESSION_EXCLUDES "tools/suppression-ban-excludes" excludes)" || exit 2
 gg_load_excludes "$EXCLUDES_FILE"
 
-TMP="$(mktemp -d)"
-trap 'rm -rf "$TMP"' EXIT
+gg_tmpdir
 
 # --- gate 1: blanket suppressions, flat fail ---------------------------------
-BLANKET_VIOLATIONS=0
-
-run_lane() { # LABEL ERE REMEDY PATHSPEC... — numbered violations on stdout
-  local label="$1" ere="$2" remedy="$3" status f hit_status hit
-  shift 3
-  status=0
-  git grep --cached -lIzE "$ere" -- "$@" >"$TMP/lane.z" || status=$?
-  [ "$status" -le 1 ] || gg_collection_error "git grep failed scanning for $label (exit $status)"
-  while IFS= read -r -d '' f; do
-    gg_is_excluded "$f" && continue
-    hit_status=0
-    git grep --cached -nIE "$ere" -- ":(literal)$f" >"$TMP/lane.hits" || hit_status=$?
-    [ "$hit_status" -eq 0 ] || gg_collection_error "git grep could not detail the $label hits in '$f' (exit $hit_status)"
-    while IFS= read -r hit; do
-      echo "suppression-ban FAIL $label: $f:${hit#"$f":}"
-      echo "  remedies: $remedy"
-      BLANKET_VIOLATIONS=$((BLANKET_VIOLATIONS + 1))
-    done <"$TMP/lane.hits"
-  done <"$TMP/lane.z"
-}
-
-run_lane "module-wide rust allow" \
+gg_grep_lane "module-wide rust allow" \
   '^[[:space:]]*#!\[allow\(' \
   "delete the module-wide attribute and fix the findings, or annotate the surviving sites per line with a stated reason; vendored trees belong in $EXCLUDES_FILE with a reason" \
   '*.rs'
 
-run_lane "file-level noqa" \
+gg_grep_lane "file-level noqa" \
   '^[[:space:]]*#[[:space:]]*(ruff|flake8):[[:space:]]*noqa' \
   "drop the file-level directive; a per-line noqa naming its specific codes stays legal" \
   '*.py'
 
-run_lane "blanket eslint-disable" \
+gg_grep_lane "blanket eslint-disable" \
   '/\*[[:space:]]*eslint-disable[[:space:]]*\*/' \
   "name the rules being disabled (and why), or fix the findings; the bare block form turns the linter off wholesale" \
   '*.js' '*.jsx' '*.ts' '*.tsx' '*.mjs' '*.cjs' '*.mts' '*.cts' '*.vue' '*.svelte'
 
-run_lane "blanket nolint" \
+gg_grep_lane "blanket nolint" \
   '//[[:space:]]*nolint([[:space:]]*$|:[[:space:]]*all([^a-z]|$))' \
   "name the linter per line (nolint:lintname with the reason alongside), or fix the finding" \
   '*.go'
 
+BLANKET_VIOLATIONS="$GG_VIOLATIONS"
+
 # --- gate 2: bare-allow ratchet (rust) ---------------------------------------
 # The whole parenthesized span must be lint names (paths like `clippy::x`
 # included), commas, and spaces — a `reason = "…"` component carries `=`
-# and quotes and keeps the attribute out of the bare count, so the reasoned
-# form is the legal one.
+# and quotes, which keeps the attribute out of the bare count.
 BARE_ERE='#\[allow\([[:space:]]*([a-z_:]+[[:space:]]*,[[:space:]]*)*(dead_code|unused(_[a-z_]+)?)([[:space:]]*,[[:space:]]*[a-z_:]+)*[[:space:]]*\)\]'
 
 # Tracked *.rs paths carrying a tab or newline cannot be represented in the
@@ -153,19 +110,19 @@ BARE_ERE='#\[allow\([[:space:]]*([a-z_:]+[[:space:]]*,[[:space:]]*)*(dead_code|u
 # skip the gate) rather than silently splitting into garbage rows.
 NL='
 '
-git ls-files -z -- '*.rs' >"$TMP/rs.z" || gg_collection_error "git ls-files failed enumerating *.rs"
+git ls-files -z -- '*.rs' >"$GG_TMP/rs.z" || gg_collection_error "git ls-files failed enumerating *.rs"
 while IFS= read -r -d '' f; do
   case "$f" in
     *"$NL"*) gg_config_error "tracked path contains a newline, unrepresentable in line-oriented records (exclude it to skip the gate): '$f'" ;;
     *"$GG_TAB"*) gg_config_error "tracked path contains a tab, unrepresentable in the baseline TSV (exclude it to skip the gate): '$f'" ;;
   esac
-done <"$TMP/rs.z"
+done <"$GG_TMP/rs.z"
 
 status=0
-git grep --cached -cIE "$BARE_ERE" -- '*.rs' >"$TMP/bare.raw" || status=$?
+git grep --cached -cIE "$BARE_ERE" -- '*.rs' >"$GG_TMP/bare.raw" || status=$?
 [ "$status" -le 1 ] || gg_collection_error "git grep failed counting bare allows (exit $status)"
 
-: >"$TMP/counts.raw"
+: >"$GG_TMP/counts.raw"
 while IFS= read -r row; do
   cnt="${row##*:}"
   f="${row%:*}"
@@ -173,9 +130,9 @@ while IFS= read -r row; do
     "" | *[!0-9]*) gg_collection_error "unparseable count row from git grep: '$row'" ;;
   esac
   gg_is_excluded "$f" && continue
-  printf '%s\t%s\n' "$f" "$cnt" >>"$TMP/counts.raw"
-done <"$TMP/bare.raw"
-LC_ALL=C sort "$TMP/counts.raw" >"$TMP/counts.tsv"
+  printf '%s\t%s\n' "$f" "$cnt" >>"$GG_TMP/counts.raw"
+done <"$GG_TMP/bare.raw"
+LC_ALL=C sort "$GG_TMP/counts.raw" >"$GG_TMP/counts.tsv"
 
 # Baseline load + hygiene: worktree file first; a tracked-but-absent
 # baseline (sparse checkout) is read from the index so it cannot degrade to
@@ -199,31 +156,27 @@ validate_baseline() { # FILE LABEL
   fi
 }
 
-# The scan is index-scoped, so the baseline it is judged against must be the
-# index copy too: an unstaged row bump would otherwise authorize growth the
-# commit does not carry. Only a never-tracked baseline comes off disk.
-#
-# --update is the exception, because it REWRITES the worktree copy: reading
-# the index there would drop any unstaged hand-edit from the file it then
-# replaces.
+# The scan is index-scoped, so the baseline it is judged against is the index
+# copy too: an unstaged row bump must not authorize growth the commit does not
+# carry. Only a never-tracked baseline, and --update (which rewrites the
+# worktree copy), read from disk.
 BASELINE_FROM_INDEX=0
 if [ "$MODE" = "update" ] && [ -f "$BASELINE_FILE" ]; then
   validate_baseline "$BASELINE_FILE" "$BASELINE_FILE"
-  cp -- "$BASELINE_FILE" "$TMP/baseline.tsv"
+  cp -- "$BASELINE_FILE" "$GG_TMP/baseline.tsv"
 elif git ls-files --error-unmatch -- "$BASELINE_FILE" >/dev/null 2>&1; then
-  # The flag means "no worktree copy to rewrite", which is what --update
-  # needs to know; reading the index is now the norm, not the exception.
+  # No worktree copy to rewrite — what --update needs to know.
   [ -f "$BASELINE_FILE" ] || BASELINE_FROM_INDEX=1
-  git show ":$BASELINE_FILE" >"$TMP/baseline.tsv" || gg_config_error "failed to read tracked baseline from the index: $BASELINE_FILE"
-  validate_baseline "$TMP/baseline.tsv" "$BASELINE_FILE (index copy)"
+  git show ":$BASELINE_FILE" >"$GG_TMP/baseline.tsv" || gg_config_error "failed to read tracked baseline from the index: $BASELINE_FILE"
+  validate_baseline "$GG_TMP/baseline.tsv" "$BASELINE_FILE (index copy)"
 elif git cat-file -e "HEAD:$BASELINE_FILE" 2>/dev/null; then
   # Staged for deletion: the commit freezes nothing.
-  : >"$TMP/baseline.tsv"
+  : >"$GG_TMP/baseline.tsv"
 elif [ -f "$BASELINE_FILE" ]; then
   validate_baseline "$BASELINE_FILE" "$BASELINE_FILE"
-  cp -- "$BASELINE_FILE" "$TMP/baseline.tsv"
+  cp -- "$BASELINE_FILE" "$GG_TMP/baseline.tsv"
 else
-  : >"$TMP/baseline.tsv"
+  : >"$GG_TMP/baseline.tsv"
 fi
 
 evaluate() { # BASELINE-TSV — violations on stdout, one per line, tab-separated
@@ -239,18 +192,17 @@ evaluate() { # BASELINE-TSV — violations on stdout, one per line, tab-separate
       for (i = 1; i <= bn; i++) {
         p = border[i]
         if (p in seen) continue
-        # "-" placeholder, never an empty field: the report loop reads
-        # these rows with tab-IFS, and whitespace IFS collapses
-        # consecutive tabs, shifting columns.
+        # "-" placeholder, never an empty field: the report loop reads these
+        # rows with tab-IFS, which must not see two tabs in a row.
         print "STALE", p, "-", base[p]
       }
     }
-  ' "$1" "$TMP/counts.tsv"
+  ' "$1" "$GG_TMP/counts.tsv"
 }
 
 # --- --update: tighten only ---------------------------------------------------
 if [ "$MODE" = "update" ]; then
-  awk -F'\t' -v OFS='\t' -v basefile="$TMP/baseline.tsv" '
+  awk -F'\t' -v OFS='\t' -v basefile="$GG_TMP/baseline.tsv" '
     FILENAME == basefile { base[$1] = $2 + 0; border[++bn] = $1; next }
     { act[$1] = $2 + 0 }
     END {
@@ -269,19 +221,17 @@ if [ "$MODE" = "update" ]; then
         }
       }
     }
-  ' "$TMP/baseline.tsv" "$TMP/counts.tsv" | LC_ALL=C sort >"$TMP/baseline.new"
+  ' "$GG_TMP/baseline.tsv" "$GG_TMP/counts.tsv" | LC_ALL=C sort >"$GG_TMP/baseline.new"
   if [ "$BASELINE_FROM_INDEX" = "1" ]; then
     BASELINE_QUOTED="$(printf '%q' "$BASELINE_FILE")"
     gg_config_error "--update cannot rewrite an index-only baseline (sparse checkout omits $BASELINE_FILE); materialize it with: git update-index --no-skip-worktree -- $BASELINE_QUOTED && git checkout-index -- $BASELINE_QUOTED, then rerun"
   fi
   if [ -f "$BASELINE_FILE" ]; then
-    # Every recount runs against the candidate BEFORE it replaces the real
-    # baseline, so a collection failure aborts with the reviewed baseline
-    # byte-identical; the replace is the last step, and its own failure
-    # carries honest sidedness.
-    rows="$(gg_count_nonempty_lines "$TMP/baseline.new")"
-    mv -- "$TMP/baseline.new" "$BASELINE_FILE" || gg_collection_error "could not replace the baseline at $BASELINE_FILE (mv failed) — inspect the file before trusting it"
-    cp -- "$BASELINE_FILE" "$TMP/baseline.tsv" || gg_collection_error "could not re-read the replaced baseline at $BASELINE_FILE (cp failed) — the baseline WAS replaced; rerun suppression-ban to verify it"
+    # The replace is the last step: a failure before it leaves the reviewed
+    # baseline byte-identical.
+    rows="$(gg_count_nonempty_lines "$GG_TMP/baseline.new")"
+    mv -- "$GG_TMP/baseline.new" "$BASELINE_FILE" || gg_collection_error "could not replace the baseline at $BASELINE_FILE (mv failed) — inspect the file before trusting it"
+    cp -- "$BASELINE_FILE" "$GG_TMP/baseline.tsv" || gg_collection_error "could not re-read the replaced baseline at $BASELINE_FILE (cp failed) — the baseline WAS replaced; rerun suppression-ban to verify it"
     echo "suppression-ban --update: baseline tightened at $BASELINE_FILE ($rows row(s))"
   else
     echo "suppression-ban --update: no baseline at $BASELINE_FILE and --update never adds rows; nothing written"
@@ -289,8 +239,8 @@ if [ "$MODE" = "update" ]; then
 fi
 
 # --- ratchet verdict ----------------------------------------------------------
-evaluate "$TMP/baseline.tsv" >"$TMP/violations.tsv"
-ratchet_violations="$(gg_count_nonempty_lines "$TMP/violations.tsv")"
+evaluate "$GG_TMP/baseline.tsv" >"$GG_TMP/violations.tsv"
+ratchet_violations="$(gg_count_nonempty_lines "$GG_TMP/violations.tsv")"
 
 while IFS="$GG_TAB" read -r kind path n b; do
   case "$kind" in
@@ -311,7 +261,7 @@ while IFS="$GG_TAB" read -r kind path n b; do
       echo "  remedy: run suppression-ban --update to drop the row"
       ;;
   esac
-done <"$TMP/violations.tsv"
+done <"$GG_TMP/violations.tsv"
 
 total=$((BLANKET_VIOLATIONS + ratchet_violations))
 if [ "$total" -gt 0 ]; then

--- a/skills/growth-guards/scripts/todo-ban
+++ b/skills/growth-guards/scripts/todo-ban
@@ -1,26 +1,9 @@
 #!/usr/bin/env bash
-# todo-ban — flat ban on work markers in first-party tracked files: the
-# words TODO, FIXME, HACK and XXX in comment-marker shapes. No baseline —
-# all consumer repos are at or near zero; vendored, generated and asset
-# trees are excluded with a reason.
+# todo-ban — flat ban on work markers (TODO, FIXME, HACK, XXX in
+# comment-marker shapes) in tracked files, scanned from the index. No
+# baseline; vendored, generated and asset trees are excluded with a reason.
 #
-# A marker is matched only in marker SHAPES, so prose that names or quotes
-# a marker word does not fire:
-#   (a) the word at line start, after whitespace, or after a comment
-#       leader, immediately followed by ':' or '(' — the classic annotated
-#       forms;
-#   (b) the bare word directly after a comment leader (only whitespace
-#       between), followed by whitespace or end of line.
-# Comment leaders: //, #, ;, /*, <!--. A word preceded by a backtick,
-# quote, or other joined text (documentation quoting a marker, a regex
-# that lists the words) matches neither shape.
-#
-# Scans INDEX content (git grep --cached): what is staged is what gets
-# committed, and a sparse checkout cannot hide a tracked file from the
-# gate. Binary files are skipped (-I) — markers are a source-comment
-# concern. Exit codes: 0 clean; 1 violations; 2 usage/config/collection
-# error; any git grep execution failure (exit >= 2) is a collection error,
-# never a silent pass.
+# Exit codes: 0 clean; 1 violations; 2 usage/config/collection error.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -67,47 +50,24 @@ done
 
 gg_repo_root_cd
 
-if [ -n "$EXCLUDES_OPT" ]; then
-  EXCLUDES_FILE="$EXCLUDES_OPT"
-else
-  EXCLUDES_FILE="$(gg_setting GROWTH_GUARDS_TODO_EXCLUDES "tools/todo-ban-excludes")" || exit 2
-fi
-EXCLUDES_FILE="$(gg_config_path "$EXCLUDES_FILE" "excludes")" || exit 2
+EXCLUDES_FILE="$(gg_resolve_path "$EXCLUDES_OPT" GROWTH_GUARDS_TODO_EXCLUDES "tools/todo-ban-excludes" excludes)" || exit 2
 gg_load_excludes "$EXCLUDES_FILE"
+gg_tmpdir
 
-TMP="$(mktemp -d)"
-trap 'rm -rf "$TMP"' EXIT
-
-# A comment leader counts only at line start or after whitespace, so the
-# `//` inside a URL or a path segment is never a boundary.
+# Marker shapes: the word at line start, after whitespace, or after a comment
+# leader, immediately followed by ':' or '(' — and the bare word directly
+# after a comment leader. A leader counts only at line start or after
+# whitespace, so the `//` inside a URL or a path segment is never one, and a
+# marker preceded by a backtick, a quote, or joined text matches neither
+# shape. Case-sensitive: lowercase uses of the words are prose.
 MARKER_ERE='(^|[[:space:]])(TODO|FIXME|HACK|XXX)[:(]|(^|[[:space:]])(//|#|;|<!--|/\*)[[:space:]]*(TODO|FIXME|HACK|XXX)([:(]|[[:space:]]|$)'
 
-# Two phases: first the offending FILES (-l -z, so a path containing ':'
-# cannot garble parsing), then the numbered hits per file, where the known
-# path prefix strips exactly. The per-file pass is line-oriented, so a
-# path embedding a newline is out of scope for the DETAIL lines (the file
-# still fails via phase one).
-status=0
-git grep --cached -lIzE "$MARKER_ERE" -- . >"$TMP/files.z" || status=$?
-[ "$status" -le 1 ] || gg_collection_error "git grep failed scanning tracked files (exit $status)"
+gg_grep_lane "work marker" "$MARKER_ERE" \
+  "do the work now, or move it to the tracker and delete the marker; vendored/generated trees belong in $EXCLUDES_FILE with a reason" \
+  .
 
-violations=0
-while IFS= read -r -d '' f; do
-  gg_is_excluded "$f" && continue
-  hit_status=0
-  git grep --cached -nIE "$MARKER_ERE" -- ":(literal)$f" >"$TMP/hits" || hit_status=$?
-  # This file just listed as containing hits; anything but a clean re-scan
-  # (including "no matches") means the measurement is broken.
-  [ "$hit_status" -eq 0 ] || gg_collection_error "git grep could not detail the hits in '$f' (exit $hit_status)"
-  while IFS= read -r hit; do
-    echo "todo-ban FAIL work marker: $f:${hit#"$f":}"
-    echo "  remedies: do the work now, or move it to the tracker and delete the marker; vendored/generated trees belong in $EXCLUDES_FILE with a reason"
-    violations=$((violations + 1))
-  done <"$TMP/hits"
-done <"$TMP/files.z"
-
-if [ "$violations" -gt 0 ]; then
-  echo "todo-ban: $violations work marker(s) — excludes $EXCLUDES_FILE"
+if [ "$GG_VIOLATIONS" -gt 0 ]; then
+  echo "todo-ban: $GG_VIOLATIONS work marker(s) — excludes $EXCLUDES_FILE"
   exit 1
 fi
 echo "todo-ban: OK — no work markers in tracked files"

--- a/skills/growth-guards/tests/cleanup-scope.test.sh
+++ b/skills/growth-guards/tests/cleanup-scope.test.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Pins for the family's EXIT cleanup: it removes only what THIS process
+# created. An inherited GG_TMP or ownership flag must never decide what a
+# guard deletes, and a check a hook lane runs must not remove the settings
+# cache its parent is still reading. Every hostile-environment pin is paired
+# with the clean-environment control.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
+TB="$SKILL_DIR/scripts/todo-ban"
+PC="$SKILL_DIR/scripts/pre-commit"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/gg-cleanup-scope.XXXXXX")"
+trap 'rm -rf -- "$TMP"' EXIT
+
+unset GROWTH_GUARDS_CHECKS GROWTH_GUARDS_SETTINGS_FILE GG_TMP \
+  GG_SETTINGS_INDEX_OWNED GG_SETTINGS_INDEX_DIR GG_SETTINGS_FROM_INDEX 2>/dev/null || true
+
+PASS=0
+FAIL=0
+ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
+
+new_repo() { # NAME -> repo path on stdout
+  local r="$TMP/$1"
+  mkdir -p "$r"
+  git -C "$r" -c init.defaultBranch=main init -q
+  git -C "$r" config user.email test@example.com
+  git -C "$r" config user.name test
+  printf 'fn main() {}\n' >"$r/ok.rs"
+  # A TRACKED settings source, so the hook lane materializes an index copy
+  # into the cache the children inherit.
+  printf '[env]\nGROWTH_GUARDS_BYTE_CEILING_KB = "200"\n' >"$r/vstack.settings.toml"
+  git -C "$r" add -A
+  printf '%s' "$r"
+}
+
+# A sentinel a correct cleanup never touches: an inherited GG_TMP naming it
+# would be rm -rf'd by the guard's own EXIT trap.
+new_sentinel() { # NAME -> path on stdout
+  local d="$TMP/$1"
+  mkdir -p "$d"
+  printf 'precious\n' >"$d/keep.txt"
+  printf '%s' "$d"
+}
+
+echo "=== a standalone check never deletes an inherited GG_TMP ==="
+R="$(new_repo standalone)"
+S="$(new_sentinel sentinel-standalone)"
+RC=0
+OUT="$(cd "$R" && GG_TMP="$S" "$TB" 2>&1)" || RC=$?
+[ "$RC" -eq 0 ] && ok "control: the check itself still passes with GG_TMP inherited" \
+  || bad "check passes with GG_TMP inherited" "rc=$RC out=$OUT"
+[ -f "$S/keep.txt" ] && ok "the inherited directory survives the check's exit" \
+  || bad "inherited GG_TMP survives todo-ban" "$S/keep.txt is gone"
+
+echo "=== a hook lane never deletes an inherited GG_TMP ==="
+R2="$(new_repo hooklane)"
+S2="$(new_sentinel sentinel-hooklane)"
+RC=0
+OUT="$(cd "$R2" && GG_TMP="$S2" "$PC" 2>&1)" || RC=$?
+[ "$RC" -eq 0 ] && ok "control: the pre-commit chain still passes with GG_TMP inherited" \
+  || bad "pre-commit passes with GG_TMP inherited" "rc=$RC out=$OUT"
+# pre-commit arms the cleanup trap through gg_settings_index_mode, which
+# creates no scratch directory of its own — so an inherited name is the only
+# thing the trap could act on.
+[ -f "$S2/keep.txt" ] && ok "the inherited directory survives the hook lane's exit" \
+  || bad "inherited GG_TMP survives pre-commit" "$S2/keep.txt is gone"
+
+R2B="$(new_repo hooklane-msg)"
+S2B="$(new_sentinel sentinel-hooklane-msg)"
+printf 'feat: a message\n' >"$TMP/msg.txt"
+RC=0
+OUT="$(cd "$R2B" && GG_TMP="$S2B" "$SKILL_DIR/scripts/commit-msg" "$TMP/msg.txt" 2>&1)" || RC=$?
+[ "$RC" -eq 0 ] && ok "control: the commit-msg gate still passes with GG_TMP inherited" \
+  || bad "commit-msg passes with GG_TMP inherited" "rc=$RC out=$OUT"
+[ -f "$S2B/keep.txt" ] && ok "the inherited directory survives the commit-msg lane's exit" \
+  || bad "inherited GG_TMP survives commit-msg" "$S2B/keep.txt is gone"
+
+echo "=== an inherited ownership flag cannot make a child delete the settings cache ==="
+R3="$(new_repo ownership)"
+RC=0
+OUT="$(cd "$R3" && GG_SETTINGS_INDEX_OWNED=1 "$PC" 2>&1)" || RC=$?
+[ "$RC" -eq 0 ] && ok "the chain completes with the ownership flag inherited" \
+  || bad "chain completes with GG_SETTINGS_INDEX_OWNED inherited" "rc=$RC out=$OUT"
+case "$OUT" in
+  *"could not read the staged copy while resolving a setting"* | *"did not complete"*)
+    bad "no check lost the settings cache" "out=$OUT" ;;
+  *) ok "no check lost the settings cache mid-run" ;;
+esac
+RC=0
+OUT="$(cd "$R3" && "$PC" 2>&1)" || RC=$?
+[ "$RC" -eq 0 ] && ok "control: the same chain passes with a clean environment" \
+  || bad "control: clean-environment chain passes" "rc=$RC out=$OUT"
+
+echo "=== the scratch directory a check DOES create is still removed ==="
+R4="$(new_repo owncleanup)"
+BEFORE="$(find "${TMPDIR:-/tmp}" -maxdepth 1 -name 'gg-todo-ban.*' 2>/dev/null | wc -l)"
+RC=0
+OUT="$(cd "$R4" && "$TB" 2>&1)" || RC=$?
+AFTER="$(find "${TMPDIR:-/tmp}" -maxdepth 1 -name 'gg-todo-ban.*' 2>/dev/null | wc -l)"
+[ "$RC" -eq 0 ] && [ "$AFTER" -eq "$BEFORE" ] \
+  && ok "a check leaves no scratch directory behind" \
+  || bad "check cleans up its own scratch directory" "rc=$RC before=$BEFORE after=$AFTER"
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/skills/growth-guards/vstack.settings.toml.example
+++ b/skills/growth-guards/vstack.settings.toml.example
@@ -4,7 +4,7 @@
 # Project-scope `vstack add` / `vstack refresh` merge these defaults into
 # <project>/vstack.settings.toml (never overwriting existing keys). Every
 # other GROWTH_GUARDS_* key ships a working default; the full list is in the
-# skill's SKILL.md and README.md.
+# skill's SKILL.md.
 
 # Repo-local check the pre-commit shim runs LAST, after size-ratchet and the
 # growth-guards batch: a repo-root-relative executable, taking no arguments.

--- a/skills/iced-rs/SKILL.md
+++ b/skills/iced-rs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: iced-rs
-description: "Iced 0.14 GUI framework expert — custom widgets via iced::advanced, overlays, Canvas, Shader, pane_grid, theming, subscriptions, Elm architecture. Load whenever building, modifying, or debugging any Iced UI. Bundled reference library covers the full 0.14 API; bundled examples include all upstream iced examples plus the iced_wgpu renderer source."
+description: "Iced 0.14 GUI expert: custom widgets via iced::advanced, overlays, Canvas, Shader, pane_grid, theming, subscriptions, Elm architecture, with a bundled full-API reference. Load whenever building or debugging an Iced UI."
 license: MIT
 user-invocable: true
 metadata:

--- a/skills/linear/SKILL.md
+++ b/skills/linear/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: linear
-description: "Use for ANY Linear interaction: read, view, list, search, create, edit, update, comment on, label, block, unblock, or activate any Linear issue, project, cycle, milestone, initiative, or label. Bash CLI over Linear's GraphQL API with local cache and mutation syncing."
+description: "Bash CLI over Linear's GraphQL API with a local cache. Load for ANY Linear interaction: reading, searching, creating, or updating an issue, project, cycle, milestone, initiative, or label."
 license: MIT
 user-invocable: true
 metadata:

--- a/skills/preflight/SKILL.md
+++ b/skills/preflight/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: preflight
-description: "Diff-scoped deterministic pre-review checks, fail-only and precision-first: unparseable shell, shellcheck errors, masked return values on added lines, fail-open bash (unchecked mktemp without errexit, new scripts without strict mode, a swallowed exit status on `|| true`), new test suites no runner invokes, scratch directories no EXIT trap removes, docs citing repo paths that do not exist, source files citing docs that do not exist, TODO/FIXME markers with no issue reference, reviewer-bot attributions in durable prose, malformed JSON/TOML, and workflow run: blocks their shell cannot parse. Load when running, tuning, or debugging preflight or wiring it into validation/CI."
+description: "Diff-scoped deterministic pre-review checks: shell parse/shellcheck errors, fail-open bash, unwired test suites, untrapped scratch dirs, dead path citations, TODO markers, bot attributions, malformed JSON/TOML/workflows. Load to run, tune, or debug preflight."
 license: MIT
 user-invocable: true
 metadata:

--- a/skills/review-gate/SKILL.md
+++ b/skills/review-gate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-gate
-description: "Org-wide PR review gate: one predicate answers 'is this exact head reviewed?' (review objects, trusted clean-analysis checks, comment-form passes, operator override) — or, under REVIEW_GATE_MODE 'off', evaluates nothing and attests only that the repo disabled the gate — and one writer posts the answer as a merge-blocking commit status, with an offline decision-table selftest and a live replay harness. Load when wiring, adopting, tuning, or debugging a repo's review gate or its REVIEW_GATE_* settings."
+description: "Org-wide PR review gate: one predicate answers 'is this exact head reviewed?', one writer posts the answer as a merge-blocking commit status. Load to wire, adopt, tune, or debug a repo's gate or its REVIEW_GATE_* settings."
 license: MIT
 user-invocable: true
 metadata:

--- a/skills/reviewer/SKILL.md
+++ b/skills/reviewer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reviewer
-description: "Strict review and QA workflows: shared reviewer ethos, code-review classification, finding JSON schema, and QA-label review lifecycle. Load this skill when reviewing a diff, classifying findings, returning a verdict, or handling a QA-label-triggered review."
+description: "Strict review and QA workflows: reviewer ethos, code-review classification, the finding JSON schema, and the QA-label lifecycle. Load when reviewing a diff, classifying findings, or returning a verdict."
 license: MIT
 user-invocable: true
 dependencies:

--- a/skills/size-ratchet/SKILL.md
+++ b/skills/size-ratchet/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: size-ratchet
-description: "Tighten-only file-size gate: every tracked file over the line threshold (default 1000) must be frozen in a baseline TSV at its current size (--staged counts index blobs, for a pre-commit hook), and the baseline only moves down — new offenders, growth of a baselined file, and a baseline looser than reality all fail; --update lowers/removes rows but never adds or raises one, so deliberate growth is a visible hand-edit in review. Load when adding, tuning, or debugging a repo's file-size ratchet, its baseline, its exclusion list, or SIZE_RATCHET_* settings — or when a change grows files in a repo that has a baseline."
+description: "Tighten-only file-size gate: tracked files over the line threshold are frozen in a baseline TSV that only ever moves down. Load to add, tune, or debug the ratchet, its baseline, or SIZE_RATCHET_* settings."
 license: MIT
 user-invocable: true
 metadata:


### PR DESCRIPTION
A simplification pass over growth-guards and the catalog's SKILL.md frontmatter descriptions. Zero behavior change: all six growth-guards suites, the install-git-hooks suite, and cargo tests are green, and `growth-guards all` on this repo prints byte-identical output before and after.

## Frontmatter descriptions (chars, before → after)

| Skill | Before | After |
|---|---|---|
| growth-guards | 810 | 216 |
| size-ratchet | 622 | 207 |
| preflight | 680 | 259 |
| review-gate | 507 | 224 |
| dep-radar | 491 | 205 |
| iced-rs | 349 | 220 |
| deep-research | 317 | 179 |
| code-quality | 279 | 201 |
| linear | 269 | 190 |
| reviewer | 259 | 204 |

Each keeps the trigger vocabulary a loader matches on; sub-feature enumerations moved to (or already lived in) the body.

## growth-guards bloat pass (lines, before → after)

| File | Before | After |
|---|---|---|
| README.md | 251 | 243 |
| SKILL.md | 108 | 89 |
| scripts/growth-guards | 104 | 97 |
| scripts/todo-ban | 113 | 73 |
| scripts/byte-ceiling | 191 | 174 |
| scripts/suppression-ban | 321 | 271 |
| scripts/commit-msg | 122 | 116 |
| scripts/pre-commit | 114 | 107 |
| scripts/install-git-hooks | 604 | 574 |
| scripts/lib/common.sh | 177 | 228 |
| scripts/lib/settings.sh | 257 | 247 |
| cli/src/git_hooks.rs | 600 | 589 |

Net −154 lines across these files. What went, one line each:

- Review-history and rationale comments whose behavior a test already pins — the test is the record.
- Duplicated regexes and exclusion lists across the four checks — now one home in `lib/common.sh` (which grows so four scripts shrink).
- SKILL.md/README duplication: SKILL.md keeps what every load needs; setup and adoption depth live in README only.
- Over-general branches and repeated defensive checks in `install-git-hooks` and `git_hooks.rs` where an earlier check already holds.

## Defect found by the pre-push second-opinion review, fixed here

The shared EXIT handler trusted an inherited `GG_TMP`, which a hook lane arms without creating a scratch directory of its own — a standalone check invoked from a hook could delete the hook's scratch state. Cleanup state is reset when the library is sourced; `tests/cleanup-scope.test.sh` pins it and ran red 3/8 without the fix.

https://claude.ai/code/session_012epxJEzGqT7q3qcFhdZUt5
