### PR TITLE
docs(settings): template comments to one-line intent plus landmines (VST-317)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- settings templates: every key's comment condensed to one-line intent plus
+  landmines (922 → 545 lines across the root and skill templates, zero value
+  changes); refresh's seeded-comment rewrite propagates the terse form to
+  consumer files whose blocks are unedited (VST-317).
+
 - preflight: the code-citation lane leaves installed-artifact subtrees alone
   (`.agents/` and the harness dirs' skills/agents/hooks/rules/instructions/
   packages trees) — a vendored skill's example path is upstream's prose, not

--- a/skills/growth-guards/vstack.settings.toml.example
+++ b/skills/growth-guards/vstack.settings.toml.example
@@ -6,11 +6,8 @@
 # other GROWTH_GUARDS_* key ships a working default; the full list is in the
 # skill's SKILL.md.
 
-# Repo-local check the pre-commit shim runs LAST, after size-ratchet and the
-# growth-guards batch: a repo-root-relative executable, taking no arguments.
-# It follows the family exit contract — 0 clean, 1 violations, anything else
-# "could not complete" — and any nonzero blocks the commit. A value naming a
-# path that is missing or not executable blocks too, rather than passing a
-# commit the repo expected to be checked. Empty (the default) means the shim
-# runs no repo-local check.
+# Repo-local check the pre-commit shim runs LAST: a repo-root-relative
+# executable following the family exit contract (0 clean, 1 violations,
+# else "could not complete"); any nonzero blocks the commit, and so does a
+# missing or non-executable value. Empty = no repo-local check.
 GROWTH_GUARDS_PRE_COMMIT_LOCAL = ""

--- a/skills/linear/vstack.settings.toml.example
+++ b/skills/linear/vstack.settings.toml.example
@@ -5,24 +5,15 @@
 # <project>/vstack.settings.toml (never overwriting existing keys). Full key
 # reference: linear README.md.
 
-# Used by: linear (every command). The team every write targets.
-# There is no built-in default. A team name resolves inside whatever workspace
-# LINEAR_API_KEY reaches, so an unset value means "no target": writes refuse
-# with an actionable error and reads drop the team filter instead of guessing.
-# Set this to the project's own team name, then confirm the target with
-# `linear.sh auth-check --strict`. Only the create actions that take a team
-# (issues, projects, cycles, labels) accept `--team <name>` as a per-call
-# override; every other write needs this key.
+# The team every Linear write targets. No default: an empty value refuses
+# writes instead of guessing inside whatever workspace the API key reaches.
+# Confirm with `linear.sh auth-check --strict`.
 LINEAR_TEAM = ""
 
-# Used by: linear. Issue identifier prefix used in examples (e.g. PROJ-123).
+# Issue identifier prefix used in examples (e.g. PROJ-123).
 LINEAR_TEAM_PREFIX = "PROJ"
 
-# Used by: linear (`issues create`). The project's declared agent-routing
-# label set, comma- or space-separated (e.g. "agent:generalist, agent:rust").
-# When non-empty, `issues create` refuses a create that carries no agent
-# label from this set — an issue without one is invisible to agent routing,
-# while the create prints a URL that looks like success. `--no-agent-label`
-# permits a deliberate bare create (e.g. intake mirroring). Leave empty in
-# projects with no agent-label taxonomy; the guard then stays off.
+# Declared agent-routing label set (e.g. "agent:generalist, agent:rust").
+# Non-empty makes `issues create` refuse a create carrying none of them —
+# such an issue is invisible to agent routing. Empty = guard off.
 LINEAR_AGENT_LABELS = ""

--- a/skills/linear/vstack.settings.toml.example
+++ b/skills/linear/vstack.settings.toml.example
@@ -6,8 +6,9 @@
 # reference: linear README.md.
 
 # The team every Linear write targets. No default: an empty value refuses
-# writes instead of guessing inside whatever workspace the API key reaches.
-# Confirm with `linear.sh auth-check --strict`.
+# writes instead of guessing inside whatever workspace the API key reaches
+# (the create actions still take `--team <name>` per call). Confirm with
+# `linear.sh auth-check --strict`.
 LINEAR_TEAM = ""
 
 # Issue identifier prefix used in examples (e.g. PROJ-123).

--- a/skills/orch/vstack.settings.toml.example
+++ b/skills/orch/vstack.settings.toml.example
@@ -30,7 +30,8 @@ PR_REVIEW_NUDGE = ""
 
 # Check-run/status name a trusted review bot publishes on analyzed heads; a
 # success counts as review-received. SECURITY: matched by NAME and anyone
-# can publish under any name — name only the trusted bot's check.
+# can publish under any name — name only the trusted bot's check. Empty =
+# review objects only.
 PR_REVIEW_CHECK = ""
 
 # Reviewer logins (comma/space separated, ONE line — the loader reads a

--- a/skills/orch/vstack.settings.toml.example
+++ b/skills/orch/vstack.settings.toml.example
@@ -2,128 +2,79 @@
 
 # ORCH — PR review gate, CI waits, reviewer fan-out, and handoff lanes.
 # Project-scope `vstack add` / `vstack refresh` merge these defaults into
-# <project>/vstack.settings.toml (never overwriting existing keys). Full key
-# reference: orch README.md / DEVELOPMENT.md.
+# <project>/vstack.settings.toml (never overwriting existing keys). Comments
+# here are one-line intent + landmines; full key reference: orch README.md /
+# DEVELOPMENT.md.
 
-# Reviewer merge gate mode: "approval" requires a GitHub-native review
-# approval before merge (orch submit-pr/merge-pr); "review" requires a formal
-# review of the current head from a non-author reviewer plus zero unresolved
-# threads — the right mode for review bots that comment but never approve.
-# Set "off" ONLY for repos with no review bots and no reviewer policy — the
-# review wait is skipped entirely. Legacy PR_APPROVAL_GATE ("on"/"off") is
-# still honored when this key is unset.
+# Reviewer merge gate: "approval" needs a GitHub approval; "review" needs a
+# non-author review of the current head plus zero unresolved threads (for
+# bots that comment but never approve); "off" only where no reviewer exists.
 PR_REVIEW_GATE = "approval"
 
-# The review-gate ENGINE's one-switch per-repo gate disable — resolved by
-# approval-wait --resolve-mode ahead of every reviewer-gate key: "off"
-# prints mode off (the wait loop is skipped; the engine keeps the required
-# gate status green with a disabled-by-settings attestation). Only the
-# exact value "off" narrows; anything else leaves PR_REVIEW_GATE
-# authoritative (the engine predicate fails loud on bad values). Listed
-# here because orch consumes it even where the review-gate skill is not
-# installed.
+# The review-gate ENGINE's one-switch disable, consumed by orch even where
+# the review-gate skill is not installed. Only the exact value "off"
+# narrows; anything else leaves PR_REVIEW_GATE authoritative.
 REVIEW_GATE_MODE = "enforce"
 
-# Used by: orch (`approval-wait`). Total review-wait budget in seconds — the
-# per-repo quiet period before the on-timeout policy applies — used when the
-# caller passes no max_wait positional arg (an explicit arg always wins).
+# Total review-wait budget in seconds before the on-timeout policy applies;
+# an explicit max_wait argument always wins.
 PR_REVIEW_WAIT_SECS = "900"
 
-# Used by: orch (`approval-wait`). Seconds without the gate's signal (for the
-# current head) before nudging the reviewer, once per head; a push resets the
-# clock. "0" disables nudging.
+# Seconds of reviewer silence on a head before the one nudge; a push resets
+# the clock. "0" disables.
 PR_REVIEW_NUDGE_SECS = "600"
 
-# Used by: orch (`approval-wait`). Comment body posted as the nudge — set it
-# to whatever summons this repo's review bot (e.g. "@devin review"). Empty =
-# fall back to a GitHub-native re-review request to the PR's reviewers.
+# Comment posted as the nudge — whatever summons this repo's review bot.
+# Empty = GitHub's native re-review request.
 PR_REVIEW_NUDGE = ""
 
-# Used by: orch (`approval-wait`, review mode). Name/context of the trusted
-# reviewer's check-run OR commit status: a success for that exact name on the
-# current head counts as review-received when a clean re-analysis submits no
-# review object (e.g. "Devin Review"). Empty = review objects only. SECURITY:
-# match by name means any app could publish it — name only the trusted bot's
-# check on repos where all publishers are trusted.
+# Check-run/status name a trusted review bot publishes on analyzed heads; a
+# success counts as review-received. SECURITY: matched by NAME and anyone
+# can publish under any name — name only the trusted bot's check.
 PR_REVIEW_CHECK = ""
 
-# Used by: orch (`approval-wait`). Reviewer logins separated by commas or
-# whitespace, on ONE line (the settings loader reads a value per line) — that
-# must EACH have a review pinned to the current head, with zero unresolved
-# threads, before the review gate opens, in either mode. The multi-bot
-# enqueue gate: one bot's pass cannot open the gate while a listed sibling
-# has not yet reacted to this head; findings hold the gate as threads.
-# Empty = off. The wait deadline still bounds it, but PR_REVIEW_ON_TIMEOUT
-# = "proceed" needs EVERY listed reviewer silent: a partial quorum is
-# engagement, so it ends in a timeout rather than proceeding.
+# Reviewer logins (comma/space separated, ONE line — the loader reads a
+# value per line) that must EACH review the current head with zero open
+# threads before the gate opens. Empty = off. On timeout, "proceed" needs
+# EVERY listed reviewer silent — a partial quorum is engagement.
 PR_REVIEW_QUORUM = ""
 
-# Used by: orch (`approval-wait`, `submit-pr` / `merge-pr` / `ci-fix`).
-# Deadline behavior when the review gate signal never arrives — the reviewer
-# posted nothing (e.g. its credits are exhausted). "block" (default) reports a
-# "timeout" and the caller prompts or keeps waiting. "proceed" instead reports
-# a distinct "proceeded" verdict and records a reviewer-down override, moving
-# to CI/merge — but ONLY when zero threads are unresolved, so an open thread
-# always blocks (it returns "comments" first) and a real comment is never
-# bypassed. CI and the comment-hygiene gate still apply. On multi-reviewer
-# repos this only fires when EVERY reviewer is silent. Without a configured
-# PR_REVIEW_QUORUM one live review satisfies the gate; with one, a partial
-# response is engagement and ends in a timeout, never a proceed.
+# When the review signal never arrives: "block" reports a timeout;
+# "proceed" records a reviewer-down override and moves on, but only with
+# zero unresolved threads — a real comment is never bypassed.
 PR_REVIEW_ON_TIMEOUT = "block"
 
-# Used by: orch (`ci-wait`). Seconds to keep polling before failing when no CI
-# checks have registered yet. Raise for repos whose CI dispatches only after a
-# review approval (approval-gated jobs / merge queue) with slow dispatch.
+# Seconds ci-wait keeps polling before failing when no CI checks registered
+# yet; raise for approval-gated CI with slow dispatch.
 CI_WAIT_NO_CHECKS_GRACE = "180"
 
-# Used by: orch (`submit-pr` / `merge-pr`). Max automated ci-fix cycles per PR
-# submission or merge recovery before reporting the persistent CI failure back
-# to the user.
+# Max automated ci-fix rounds per PR before a human takes over.
 CI_FIX_MAX_CYCLES = "6"
 
-# Used by: orch (`review-pr` / `review` / `review-codebase`). Total concurrent
-# agent-session budget of the harness runtime, counting the primary session.
-# "0" = unlimited: every reviewer launches up front and persists through
-# fix/re-review cycles. When the reviewer set exceeds the available slots,
-# review workflows run reviewers in bounded sequential waves, retiring each
-# completed session to release its slot. On the Codex collaboration runtime,
-# set the cap that `spawn-adapter slots` reports.
+# Total concurrent agent-session budget, counting the primary; "0" =
+# unlimited. Reviews run in waves when the reviewer set exceeds free slots.
+# On the Codex runtime, set the cap `spawn-adapter slots` reports.
 REVIEWER_SLOT_BUDGET = "0"
 
-# Used by: orch (`dev-fix`). How workflow decision points behave. "ask"
-# (default) presents decision points to the user. Review findings disposition
-# (`review-pr` § 4/§ 7, `review` § 4) is by rule in EVERY mode — no mode
-# presents a selection menu over findings. "auto-recommended" executes the
-# workflow's recommended option and logs "auto-selected: [option] — [reason]"
-# in the round record (workflow-state auto_decisions) — for fleet launchers
-# whose workers would otherwise serialize on one supervisor. Decision-record
-# revisits and scope expansion beyond the issue ALWAYS ask, in every mode;
-# merge is governed by ORCH_MERGE_AUTONOMY.
+# "ask" presents workflow decision points; "auto-recommended" executes the
+# recommended option and logs it. Findings disposition is by rule in every
+# mode; some decisions always ask; merge is governed by ORCH_MERGE_AUTONOMY.
 ORCH_DECISION_MODE = "ask"
 
-# Used by: orch (`start-worktree` § 5.5, `submit-pr` § 6.2). "ask" (default)
-# presents the merge decision; "auto" merges without asking once every merge
-# gate is green. MERGE_READY = false never auto-merges.
+# "ask" presents the merge decision; "auto" merges once every gate is green.
+# MERGE_READY = false never auto-merges.
 ORCH_MERGE_AUTONOMY = "ask"
 
-# Used by: orch (`open-terminal`). Bounded seconds per brief-delivery
-# verification pass on tmux claude handoff lanes (one initial pass plus one
-# after the single re-send). Positive integer; values over 120 are clamped.
+# Seconds per brief-delivery verification pass on tmux handoff lanes.
 ORCH_TMUX_VERIFY_SECS = "15"
 
-# Used by: orch (`lanes`, `open-terminal --lane`). Optional alias overlay for
-# multi-account machines: comma-separated `<config-dir-name>=<alias>` pairs
-# giving discovered lanes meaningful names, usable as `--lane <alias>`. The
-# lane INVENTORY is always discovered (~/.claude plus any ~/.*claude* dir, and
-# ~/.codex), so adding an account needs no edit here — this only renames what
-# discovery already found. ORCH_LANE_DIRS (colon-separated) covers a layout
-# discovery cannot reach.
-# Used by: orch (`review-pr` § 5). Space-separated path globs; a changed file
-# matching one adds the needs-perf-test QA signal to the review's QA routing.
-# QA_PERF_PATHS = "src/hot/* engine/src/*"
-
+# Rename auto-discovered launch lanes (`<config-dir>=<alias>` pairs); the
+# inventory is always discovered — this only renames it. ORCH_LANE_DIRS
+# covers layouts discovery cannot reach.
 # ORCH_LANE_ALIASES = "eclaude=work,mclaude=overflow"
 
-# Used by: orch (`oversee`). Max concurrent lanes the overseer keeps in
-# flight.
+# Path globs that add the needs-perf-test QA signal to review routing.
+# QA_PERF_PATHS = "src/hot/* engine/src/*"
+
+# Max concurrent lanes the overseer keeps in flight.
 ORCH_OVERSEER_LANES = "3"

--- a/skills/orch/vstack.settings.toml.example
+++ b/skills/orch/vstack.settings.toml.example
@@ -28,7 +28,8 @@ PR_REVIEW_NUDGE_SECS = "600"
 # Empty = GitHub's native re-review request.
 PR_REVIEW_NUDGE = ""
 
-# Check-run/status name a trusted review bot publishes on analyzed heads; a
+# Check-run or commit-status name a trusted review bot publishes on
+# analyzed heads; a
 # success counts as review-received. SECURITY: matched by NAME and anyone
 # can publish under any name — name only the trusted bot's check. Empty =
 # review objects only.

--- a/skills/review-gate/vstack.settings.toml.example
+++ b/skills/review-gate/vstack.settings.toml.example
@@ -2,185 +2,96 @@
 
 # REVIEW GATE — shared merge-gate engine (review-gate skill).
 # Project-scope `vstack add` / `vstack refresh` merge these defaults into
-# <project>/vstack.settings.toml (never overwriting existing keys). The
-# scripts resolve each key environment-first, then this file, then the
-# built-in default. List values pack into one string with ';' separators.
-# Full reference: review-gate SKILL.md and references/adoption.md.
+# <project>/vstack.settings.toml (never overwriting existing keys). Keys
+# resolve environment-first, then this file, then the built-in default; list
+# values pack into one string with ';' separators. Full reference:
+# review-gate SKILL.md and references/adoption.md.
 
-# Commit-status context the gate posts on PR heads — the required check name
-# in branch protection. Keep it stable: changing it strands the old required
-# context on open PRs until branch protection is updated to match.
+# Commit-status context the gate posts — the required check name in branch
+# protection. Keep it stable: changing it strands the old required context
+# on open PRs.
 REVIEW_GATE_CONTEXT = "Review gate"
 
-# Clean-analysis evidence: exact names of the trusted reviewer's check-run
-# and/or legacy commit status; a success for a listed name on the current
-# head counts as review evidence (for bots that submit a review object only
-# when they have findings). Both APIs are queried; either counts, and on
-# both the NEWEST row/run per name decides (a newer pending/failed/
-# skip-marked round withdraws the reviewer's own older success). SECURITY:
-# check-runs and statuses are matched by NAME, and any GitHub App or Actions
-# workflow can publish under any name — list only names produced by trusted
-# bots, on repos where every publisher is trusted.
-# Check-runs published by the shared github-actions app are rejected
-# automatically (any PR workflow can mint those; real reviewer bots publish
-# under their own app slug); legacy commit STATUSES still rely on the
-# publisher-trust precondition above.
-# Default is EMPTY (source disabled): trust is opt-in per repo, never a
-# shipped vendor default. Example for a repo whose reviewer posts a
-# check/status under the name "Devin Review":
-# REVIEW_GATE_TRUSTED_STATUS_CONTEXTS = "Devin Review"
+# Check/status names whose success on the current head counts as review
+# evidence (for bots that only file a review object when they have
+# findings). SECURITY: matched by NAME and anyone can publish under any
+# name — list only trusted bots' checks. github-actions-published check-runs
+# are rejected automatically. Empty = source disabled.
 REVIEW_GATE_TRUSTED_STATUS_CONTEXTS = ""
 
-# A trusted "pass" must prove analysis RAN: a success whose check-run
-# output/status description contains one of these case-insensitive
-# substrings (e.g. a reviewer that posts its check as pass with "Review rate
-# limited" after doing nothing) is treated as NOT-EVIDENCE — the same as
-# absent, never a failure. Empty disables the filter (an explicit choice to
-# trust every success blindly).
+# A trusted "pass" whose output contains one of these substrings never ran
+# (e.g. "Review rate limited") and is NOT-EVIDENCE. Empty disables.
 REVIEW_GATE_CHECKRUN_SKIP_PATTERNS = "rate limited;skipped;queued"
 
-# Comment-form reviewers: 'login:binding-pattern' pairs for bots whose clean
-# pass is only an issue comment on the PR conversation (no review object, no
-# check/status). The first ':' splits login from pattern; the pattern is a
-# LITERAL prefix that must precede the bound commit sha in the body (e.g.
-# "chatgpt-codex-connector[bot]:Reviewed commit:"). SECURITY: trust keys on
-# the author LOGIN (only GitHub can set it); the body is read only to bind
-# the evidence to a commit. Empty disables the source.
+# 'login:binding-pattern' pairs for bots whose clean pass is only an issue
+# comment binding a commit sha (e.g. "bot[bot]:Reviewed commit:").
+# SECURITY: trust keys on the author LOGIN. Empty disables.
 REVIEW_GATE_COMMENT_REVIEWERS = ""
 
-# Shortest sha prefix (4–40) a comment-form reviewer may bind evidence to;
-# git's short-sha default. A degenerate prefix must not match every head.
+# Shortest sha prefix (4–40) a comment-form reviewer may bind evidence to.
 REVIEW_GATE_SHA_PREFIX_FLOOR = "7"
 
-# Operator override status (v2; the outage attestation generalized beyond
-# outages): commit-status context a trusted operator posts on the head when
-# review evidence is MISSING — a recorded internal-review outcome, or genuine
-# total reviewer silence. Substitutes for MISSING review evidence only —
-# changes-requested and unresolved threads still fail closed, and the status
-# description must carry a REASON, which is ENFORCED: an empty or
-# whitespace-only description is not evidence, and the reason it does carry
-# rides out in the gate status detail. SECURITY: a deliberate, bounded
-# relaxation with the same trusted-publisher model as
-# REVIEW_GATE_TRUSTED_STATUS_CONTEXTS; name it only where every status
-# publisher is trusted. Empty disables. Implemented as an ALIAS over the
-# legacy key REVIEW_GATE_OUTAGE_CONTEXT: when this key is present its value
-# is handed to the predicate as REVIEW_GATE_OUTAGE_CONTEXT (and wins over a
-# file-level assignment of that name); when absent the predicate's own
-# outage-context resolution applies unchanged, so existing repos that still
-# set the legacy key need no edit. Set ONLY this key in new installs.
+# MANUAL operator override status — posted by a human, never automation.
+# Substitutes for MISSING evidence only; the description must carry a
+# reason (enforced). SECURITY: same trusted-publisher model as the
+# contexts above.
+# Alias over legacy REVIEW_GATE_OUTAGE_CONTEXT; set only this key in new
+# installs. Empty disables.
 REVIEW_GATE_OVERRIDE_CONTEXT = "vstack-reviewer-outage"
 
-
-# Status publisher reject-list: creator logins whose commit statuses are
-# never evidence, applied to BOTH the trusted-context and override status
-# reads. SECURITY: on repos whose PR-triggered workflows hold
-# statuses:write, PR content can mint a status under any context through
-# github-actions[bot] — the one publisher identity PR code can wield;
-# listing it closes that mint. Statuses are read from the per-commit
-# statuses LIST endpoint, where every real publisher (GitHub Apps included)
-# carries a creator login; while this list is configured, a status with NO
-# creator login is an anomaly and is not evidence. Default is EMPTY (filter
-# disabled). Recommended "github-actions[bot]" wherever PR workflows hold
-# statuses:write — this requires the operator override to be posted by a
-# non-Actions identity (operator PAT), which is the v2 posture.
+# Creator logins whose commit statuses are never evidence. SECURITY:
+# wherever PR workflows hold statuses:write, PR content can mint statuses
+# through github-actions[bot] — list it; the override must then come from a
+# non-Actions identity. Empty disables.
 REVIEW_GATE_STATUS_PUBLISHER_REJECT = ""
 
-# Review-object trust list: logins whose review objects at the exact head
-# count as evidence. Empty = any non-author (the compatible default; on
-# repos with outside read-access collaborators this means any drive-by
-# COMMENTED review satisfies the gate — set the list to close that).
+# Logins whose review objects at the exact head count as evidence. Empty =
+# any non-author — on repos with outside collaborators, set the list so a
+# drive-by review cannot satisfy the gate.
 REVIEW_GATE_REVIEW_OBJECT_TRUSTED_LOGINS = ""
 
-# Minimum review-object state that counts as evidence: "any" (any
-# non-dismissed row) or "approved" (an APPROVED at head not withdrawn by a
-# LATER CHANGES_REQUESTED from the same login; a trailing COMMENTED never
-# supersedes an approval).
+# "any", or "approved" (an APPROVED at head not withdrawn by a later
+# CHANGES_REQUESTED from the same login).
 REVIEW_GATE_REVIEW_OBJECT_MIN_STATE = "any"
 
-# An errored bot review must prove nothing about the head: the reviews API
-# has no errored state, so an auto-review that ERRORS lands as a normal
-# COMMENTED row whose body is the reviewer's own attestation that the review
-# never ran (e.g. "Copilot encountered an error and was unable to review
-# this pull request."). A row whose body contains one of these
-# case-insensitive substrings is NOT-EVIDENCE — the same as absent, never a
-# failure — and never a carry-forward candidate. A configured value replaces
-# the default list. Empty disables the filter (an explicit choice to count
-# errored rows as evidence).
+# Substrings marking a review row's body as the reviewer's own errored-run
+# attestation — such a row is NOT-EVIDENCE, never a blocker, never carried.
+# Empty disables.
 REVIEW_GATE_REVIEW_OBJECT_ERROR_PATTERNS = "encountered an error and was unable to review"
 
-# Thread term: "enforce" (default) evaluates unresolved review threads
-# CI-side and fails closed on them; "off" skips the reviewThreads GraphQL
-# read entirely and never emits threads-open — for repos whose thread
-# hygiene is a server-side zero-bypass ruleset
-# (required_review_thread_resolution), where the CI-side term is a latency
-# optimization, not the enforcement point of record. Only the thread term is
-# disabled: evidence and changes-requested still fail closed.
+# "enforce" fails closed on unresolved threads CI-side; "off" only where a
+# server-side zero-bypass ruleset already enforces thread hygiene. Evidence
+# and changes-requested still fail closed either way.
 REVIEW_GATE_THREADS = "enforce"
 
-# Bounded retries for the predicate's evidence reads: total attempts per
-# read, and the pause between them. The default single attempt is exactly
-# today's behavior; a read failing through every attempt is still exit 2
-# (no verdict) — retries only let a transient 5xx survive in-process
-# instead of deferring to the next writer pass.
+# Bounded attempts per predicate evidence read, and the pause between them.
+# A read failing every attempt is still exit 2 (no verdict).
 REVIEW_GATE_API_ATTEMPTS = "1"
 REVIEW_GATE_API_RETRY_DELAY_SECONDS = "2"
 
-# Evidence carry-forward across carry-safe deltas: classes ("docs",
-# "comments"; ';' or '|' separated; empty = off, exact-head evidence only).
-# When NO evidence exists at head, a qualifying review object at an ancestor
-# commit N still satisfies the evidence term if the N→head diff classifies
-# ENTIRELY into the enabled classes — docs-only files, or comment-only
-# changes to code files (conservative per-extension comment-token table;
-# unknown extensions refuse) — or the trees are identical (rebase residue).
-# SECURITY: never a waiver — real evidence must exist and only EXTENDS
-# across a delta review would not re-examine; code changes always require
-# fresh evidence, and changes-requested / unresolved threads still fail
-# closed with carried evidence. CAVEAT: the "comments" classifier is
-# line-lexical — it cannot see an enclosing heredoc or multiline string,
-# where a full-line `#`/`//`-prefixed change is data, not a comment. Enable
-# "comments" only on repos where that residual carry risk is acceptable;
-# "docs" has no such caveat.
+# Evidence carry-forward across carry-safe deltas ("docs", "comments";
+# empty = off): ancestor evidence extends to head when the delta is entirely
+# carry-safe. Never a waiver — code changes always need fresh evidence, and
+# changes-requested / threads still fail closed. CAVEAT: "comments" is
+# line-lexical and cannot see heredocs; "docs" has no such caveat.
 REVIEW_GATE_CARRY_FORWARD = ""
 
-# Carry-forward path exclusions: globs (';'-separated, shell-style; '*'
-# matches '/' too) that DISQUALIFY a carry — any file in the ancestor→head
-# delta matching an exclusion forces fresh evidence even when the delta
-# classifies entirely carry-safe. Built for policy-bearing markdown the
-# "docs" class would otherwise carry: AGENTS.md and other agent/reviewer
-# instruction files are docs by extension yet obeyed mechanically, so a
-# push editing them deserves a fresh review (e.g. "*AGENTS.md;.github/*").
-# Surgical: non-matching deltas still carry; identical trees (no delta)
-# are unaffected; inert while REVIEW_GATE_CARRY_FORWARD is empty.
+# Path globs that DISQUALIFY a carry — for policy-bearing markdown obeyed
+# mechanically (e.g. "*AGENTS.md;.github/*"), which deserves fresh review.
+# Inert while REVIEW_GATE_CARRY_FORWARD is empty.
 REVIEW_GATE_CARRY_FORWARD_EXCLUDE = ""
-# Exclusion globs DECLARED to match no tracked path today (";"-separated,
-# exact glob text). The selftest fails an exclusion glob that matches
-# nothing — a typo'd anchor is dead config in the same way a leading-'/'
-# one is — unless it is declared here as deliberately guarding paths that
-# do not exist yet. A declaration that is not an entry of
-# REVIEW_GATE_CARRY_FORWARD_EXCLUDE is an orphan and FAILS the selftest;
-# an EMPTY exclusion list makes every declaration one.
+# Exclusion globs DECLARED to match no tracked path yet, so the selftest
+# accepts them; a declaration not in the exclude list is an orphan and
+# fails the selftest.
 REVIEW_GATE_CARRY_FORWARD_EXCLUDE_PROPHYLACTIC = ""
 
-# The one-switch per-repo gate disable (owner decision 2026-08-08):
-# "enforce" (default) is the full gate; "off" makes the predicate answer
-# approved with an attestation detail ("review gate disabled by settings")
-# before ANY evidence read, so the writer converges the required status to
-# success and merges gate on CI alone. Statuses posted under "off" say the
-# gate is disabled — never that a review happened. Unknown values are a
-# loud config error: a typo cannot disable a merge gate. Orch's submit
-# flow reads the same key and skips its reviewer wait when "off".
+# The one-switch gate disable: "enforce" is the full gate; "off" attests
+# approved before any evidence read and merging gates on CI alone. Unknown
+# values are a loud config error — a typo cannot disable a merge gate.
 REVIEW_GATE_MODE = "enforce"
 
-# Review-wait quiet period in seconds — SHARED with the orch skill (orch's
-# approval-wait resolves its absent max_wait positional through it). Read
-# here by pr-watch.sh as the awaiting-stale threshold: an un-reviewed head
-# older than this warrants a manual re-review trigger or the caller's
-# on-timeout policy. One key on purpose, so the watcher and the waiter
-# agree on what "reviewer silence has gone on too long" means. Set it HERE
-# (or export it), not in .env/.env.local: review-gate scripts resolve
-# env > this file > default, while orch additionally reads the .env files —
-# a .env-only value reaches the waiter but not the watcher. Must be a
-# non-negative integer of at most 9 digits after leading zeros: pr-watch.sh
-# fails loud (exit 2) on any other value rather than silently falling back
-# to 900.
+# Review-wait quiet period in seconds — SHARED with orch's approval-wait,
+# and pr-watch.sh's awaiting-stale threshold. Set it HERE or export it, not
+# in .env: review-gate scripts do not read the .env files. Must be a
+# non-negative integer (at most 9 digits); anything else fails loud.
 PR_REVIEW_WAIT_SECS = "900"

--- a/skills/second-opinion/vstack.settings.toml.example
+++ b/skills/second-opinion/vstack.settings.toml.example
@@ -1,72 +1,44 @@
 [env]
 
-# SECOND OPINION
-#
-# One reviewer by default: the highest-priority entry in SECOND_OPINION_MODELS
-# that is available and is NOT the model this session runs (a Claude Code
-# session gets codex, a Codex session gets claude). Every mode enforces that;
-# a run with no eligible cross-model target refuses and says why.
+# SECOND OPINION — cross-model review (second-opinion skill).
+# One reviewer by default: the highest-priority roster entry that is NOT the
+# model this session runs. Full semantics: second-opinion SKILL.md.
 
-# Used by: second-opinion. Priority-ordered roster, space/comma separated. Per
-# entry: SECOND_OPINION_<NAME>_CMD (full command; claude and codex have defaults)
-# and SECOND_OPINION_<NAME>_MODEL (identity, when the CLI fronts another model).
-# An entry without a command still names a KNOWN identity, so a session running
-# that model is recognized and excluded.
+# Priority-ordered roster, space/comma separated. Per entry:
+# SECOND_OPINION_<NAME>_CMD (claude and codex have defaults) and
+# SECOND_OPINION_<NAME>_MODEL (identity, when the CLI fronts another model).
 SECOND_OPINION_MODELS = "claude codex"
 
-# Used by: second-opinion (review mode). Opinions to collect; 2+ unions up to
-# that many distinct models on the same diff (a shortfall is reported and
-# stamped as degraded coverage).
+# Opinions a review collects; 2+ unions distinct models on one diff.
 SECOND_OPINION_COUNT = "1"
 
-# Used by: second-opinion. The model THIS session runs. Claude Code and Codex
-# are detected; Pi, OpenCode, Cursor and undetected shells REQUIRE it (the run
-# refuses otherwise). Model ids work, provider prefix included: "opus",
-# "claude-opus-5", "anthropic/claude-opus-4" -> claude; "gpt-5.6-sol",
-# "openai-codex/gpt-5.6-sol", "openai/gpt-5.6-sol" -> codex. "none" declares
-# there is no session model (CI, a plain terminal): every roster entry is then
-# cross-model.
-#
-# SESSION-SCOPED — leave it COMMENTED here and export it in the environment of
-# the sessions that need it. A project file (.env, vstack.settings.toml,
-# .vstack/settings.toml, .env.local) is read by EVERY session in the repo, so a
-# value in one describes no single session:
-#   * Where the harness CANNOT be detected (Pi, OpenCode, Cursor, a plain
-#     shell) the declaration is the only identity there is, and one from a
-#     project file is refused naming the file. Export it in the session.
-#   * A DETECTED Claude Code or Codex session already knows its model and
-#     outranks any declaration: one that AGREES is ignored (it adds nothing),
-#     one that CONTRADICTS is refused naming both values — whatever its source,
-#     since an exported value is inherited by every nested session and so is no
-#     more trustworthy there.
+# The model THIS session runs — needed only where the harness cannot be
+# detected (Pi, OpenCode, Cursor, plain shells); "none" = no session model.
+# SESSION-SCOPED: leave it commented here and export it in the session — a
+# project-file value describes no single session and is refused.
 # SECOND_OPINION_CURRENT_MODEL = "claude"
 
-# Used by: second-opinion. Roster entry claude (identity claude).
+# Roster commands (identities claude / codex).
 SECOND_OPINION_CLAUDE_CMD = "claude -p --no-session-persistence --model opus --effort max --allowedTools Bash(read-only:true),Read,Glob,Grep"
 
-# Used by: second-opinion. Roster entry codex (identity codex).
 SECOND_OPINION_CODEX_CMD = "codex exec -m gpt-5.6-sol -s read-only -c model_reasoning_effort=xhigh --ephemeral"
 
-# Used by: second-opinion. Example of another roster entry: add "pi-deepseek" to
-# SECOND_OPINION_MODELS, give it a command, and declare the model it fronts.
+# Example extra roster entry: add "pi-deepseek" to SECOND_OPINION_MODELS,
+# give it a command, declare the model it fronts.
 # SECOND_OPINION_PI_DEEPSEEK_CMD = "pi -p --model deepseek/deepseek-v4-pro"
 # SECOND_OPINION_PI_DEEPSEEK_MODEL = "deepseek"
 
-# Used by: second-opinion. Seconds to wait for the external CLI.
+# Seconds to wait for the external CLI.
 SECOND_OPINION_TIMEOUT = "300"
 
-# Used by: second-opinion. Home for review/audit records written without
-# --output, relative to --cwd ("~/..." and absolute paths are taken as given).
-# The default is inside the reviewed checkout; the script seeds the directory
-# with a "*" .gitignore on creation so records never dirty the working tree.
+# Home for review/audit records written without --output; seeded with a "*"
+# .gitignore so records never dirty the tree.
 SECOND_OPINION_ARTIFACT_DIR = "tmp/second-opinion"
 
-# Used by: second-opinion (review mode). Glob list of repo instruction files
-# appended to the review prompt (repo-rule adherence lens). Globs resolve
-# inside the reviewed repo (--cwd). Set empty to disable.
+# Repo instruction files appended to the review prompt (repo-rule lens).
+# Empty disables.
 SECOND_OPINION_REVIEW_INSTRUCTIONS = "AGENTS.md review-bots.md .github/instructions/*.instructions.md .github/copilot-instructions.md"
 
-# Used by: second-opinion. Force one target instead of walking the roster. A
-# forced target that runs this session's model is refused. Uncomment only when
-# this project must pin one.
+# Force one target instead of walking the roster; a target running this
+# session's model is refused.
 # SECOND_OPINION_TARGET = "claude"

--- a/skills/second-opinion/vstack.settings.toml.example
+++ b/skills/second-opinion/vstack.settings.toml.example
@@ -1,8 +1,8 @@
 [env]
 
 # SECOND OPINION — cross-model review (second-opinion skill).
-# One reviewer by default: the highest-priority roster entry that is NOT the
-# model this session runs. Full semantics: second-opinion SKILL.md.
+# One reviewer by default: the highest-priority roster entry that is
+# AVAILABLE and is NOT the model this session runs. Full semantics: second-opinion SKILL.md.
 
 # Priority-ordered roster, space/comma separated. Per entry:
 # SECOND_OPINION_<NAME>_CMD (claude and codex have defaults) and

--- a/skills/second-opinion/vstack.settings.toml.example
+++ b/skills/second-opinion/vstack.settings.toml.example
@@ -31,8 +31,9 @@ SECOND_OPINION_CODEX_CMD = "codex exec -m gpt-5.6-sol -s read-only -c model_reas
 # Seconds to wait for the external CLI.
 SECOND_OPINION_TIMEOUT = "300"
 
-# Home for review/audit records written without --output; seeded with a "*"
-# .gitignore so records never dirty the tree.
+# Home for review/audit records written without --output; a directory the
+# script CREATES is seeded with a "*" .gitignore (a pre-existing one is
+# left alone — ignore it yourself).
 SECOND_OPINION_ARTIFACT_DIR = "tmp/second-opinion"
 
 # Repo instruction files appended to the review prompt (repo-rule lens).

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -161,4 +161,3 @@ skills/worktree/scripts/worktree	4077
 skills/worktree/scripts/worktree-session-guard	1194
 skills/worktree/tests/worktree_session_guard.sh	1284
 tools/validate-changed	513
-vstack.settings.toml.example	491

--- a/vstack.settings.toml.example
+++ b/vstack.settings.toml.example
@@ -7,7 +7,7 @@
 
 # WORKTREE / SHARED WORKFLOW PATHS
 
-# Branch new worktrees fork from.
+# Base branch new worktrees fork from.
 WORKTREE_DEFAULT_BRANCH = "main"
 
 # Where worktrees live; default is <parent-of-checkout>/.worktrees/<name>.
@@ -51,7 +51,8 @@ ORCH_OVERSEER_LANES = "3"
 # and some decisions always ask. Full rules: orch skill.
 ORCH_DECISION_MODE = "ask"
 
-# Rename auto-discovered launch lanes for open-terminal/lanes.
+# Rename auto-discovered launch lanes: comma-separated
+# `<config-dir>=<alias>` pairs, usable as `open-terminal --lane <alias>`.
 # ORCH_LANE_ALIASES = "eclaude=work,mclaude=overflow"
 
 # Seconds per brief-delivery verification pass on tmux handoff lanes.

--- a/vstack.settings.toml.example
+++ b/vstack.settings.toml.example
@@ -1,491 +1,293 @@
-# Copy this file to `vstack.settings.toml` and commit it when the values are
-# safe to share with everyone working in the project. Keep secrets in
-# `.env.local`.
-#
-# vstack skill scripts read only the `[env]` table. Keys intentionally match
-# the historical environment variable names so existing scripts and docs remain
-# compatible.
+# Copy to `vstack.settings.toml` and commit it when the values are safe to
+# share. Keep secrets in `.env.local`. Skill scripts read only the `[env]`
+# table. Comments here are one-line intent + landmines; full semantics live in
+# each skill's SKILL.md / references.
 
 [env]
 
 # WORKTREE / SHARED WORKFLOW PATHS
 
+# Branch new worktrees fork from.
 WORKTREE_DEFAULT_BRANCH = "main"
-# Used by: worktree, orch
 
+# Where worktrees live; default is <parent-of-checkout>/.worktrees/<name>.
+# Never point it inside the repo root — watched build outputs exhaust inotify.
 # WORKTREE_BASE_DIR = "~/dev/.worktrees/myproject"
-# Used by: worktree. Omit to use the default: <parent-of-checkout>/.worktrees/<checkout-name>,
-# an external per-repo dir beside the checkout. Relative paths resolve from the
-# main checkout. Do not point it inside the repo root: worktree build outputs
-# under the repo can exhaust recursive file-watcher (inotify) budgets.
 
+# Paths symlinked into every worktree. Include `.env.local` only when
+# worktrees should share local secrets.
 WORKTREE_SYMLINKS = ".env.local opencode.json .agents .cursor .codex .opencode .pi .claude/settings.json .claude/agents .claude/hooks .claude/skills"
-# Used by: worktree. Include `.env.local` only when worktrees should share local secrets.
 
+# link=target pairs resolved relative to each worktree.
 WORKTREE_RELATIVE_SYMLINKS = ".claude/CLAUDE.md=../AGENTS.md .claude/AGENTS.md=../AGENTS.md"
-# Used by: worktree.
 
+# Files copied (not linked) into new worktrees.
 WORKTREE_COPIES = ".vstack-lock.json"
-# Used by: worktree.
 
+# Gitignored scratch dirs created in new worktrees.
 WORKTREE_MKDIRS = "tmp"
-# Used by: worktree. Intended for gitignored scratch dirs.
 
+# Where orch keeps its per-issue workflow state.
 ORCH_STATE_DIR = "tmp"
-# Used by: orch.
 
+# Seconds ci-wait keeps polling before failing when no CI checks registered
+# yet; raise for approval-gated CI with slow dispatch.
 CI_WAIT_NO_CHECKS_GRACE = "180"
-# Used by: orch (`ci-wait`). Seconds to keep polling before failing when no CI
-# checks have registered yet. Raise for repos whose CI dispatches only after a
-# review approval (approval-gated jobs / merge queue) with slow dispatch.
 
+# Max automated ci-fix rounds per PR before a human takes over.
 CI_FIX_MAX_CYCLES = "6"
-# Used by: orch (`submit-pr` / `merge-pr`). Max automated ci-fix cycles per PR
-# submission or merge recovery before reporting the persistent CI failure back
-# to the user.
 
+# "ask" presents the merge decision; "auto" merges once every gate is green.
 ORCH_MERGE_AUTONOMY = "ask"
-# Used by: orch (`start-worktree` § 5.5, `submit-pr` § 6.2). "ask" (default)
-# presents the merge decision; "auto" merges without asking once every merge
-# gate is green. MERGE_READY = false never auto-merges.
 
+# Max concurrent lanes the overseer keeps in flight.
 ORCH_OVERSEER_LANES = "3"
-# Used by: orch (`oversee`). Max concurrent lanes the overseer keeps in
-# flight.
 
-# Used by: orch (`review-pr` § 5). Space-separated path globs; a changed file
-# matching one adds the needs-perf-test QA signal to the review's QA routing.
+# Path globs that add the needs-perf-test QA signal to review routing.
 # QA_PERF_PATHS = "src/hot/* engine/src/*"
 
+# "ask" presents workflow decision points; "auto-recommended" executes the
+# recommended option and logs it. Merge is governed by ORCH_MERGE_AUTONOMY,
+# and some decisions always ask. Full rules: orch skill.
 ORCH_DECISION_MODE = "ask"
-# Used by: orch (`dev-fix` § 1). How workflow decision points behave. "ask"
-# (default) presents decision points to the user. Review findings disposition
-# (`review-pr` § 4/§ 7, `review` § 4) is by rule in EVERY mode — no mode
-# presents a selection menu over findings. "auto-recommended" executes the
-# workflow's recommended option and logs "auto-selected: [option] — [reason]"
-# in the round record (workflow-state auto_decisions) — for fleet launchers
-# whose workers would otherwise serialize on one supervisor. Decision-record
-# revisits, scope expansion beyond the issue, and anything touching
-# benchmark-host protocol ALWAYS ask, in every mode; merge is governed by
-# ORCH_MERGE_AUTONOMY.
 
+# Rename auto-discovered launch lanes for open-terminal/lanes.
 # ORCH_LANE_ALIASES = "eclaude=work,mclaude=overflow"
-# Used by: orch (`open-terminal`, `lanes`). Renames auto-discovered launch
-# lanes; `open-terminal --lane <alias>` resolves against the same inventory
-# `lanes pick` measures. An alias naming a directory that does not exist is
-# inert. Launch model/effort/permission flags are chosen per task via
-# `--launch-flags`; no setting supplies them.
 
+# Seconds per brief-delivery verification pass on tmux handoff lanes.
 ORCH_TMUX_VERIFY_SECS = "15"
-# Used by: orch (`open-terminal`). Bounded seconds per brief-delivery
-# verification pass on tmux claude handoff lanes (one initial pass plus one
-# after the single re-send). Positive integer; values over 120 are clamped.
 
+# Total concurrent agent-session budget, counting the primary; "0" =
+# unlimited. Reviews run in waves when the reviewer set exceeds free slots.
 REVIEWER_SLOT_BUDGET = "0"
-# Used by: orch (`review-pr` / `review` / `review-codebase`). Total concurrent
-# agent-session budget of the harness runtime, counting the primary
-# orchestrator session. "0" = unlimited: every reviewer launches up front and
-# persists through fix/re-review cycles. When the reviewer set exceeds the
-# available slots (budget minus the primary minus live dev/QA sessions),
-# review workflows run reviewers in bounded sequential waves, retiring each
-# completed session to release its slot. The Codex collaboration runtime's
-# cap is MultiAgentV2's configurable default of 4 total threads including the
-# primary (features.multi_agent_v2.max_concurrent_threads_per_session in
-# ~/.codex/config.toml; the legacy agents.max_threads is silently ignored
-# under V2, and a session must restart to pick up a change) -> set whatever
-# cap the machine config declares ("4" on a default config).
 
-# Reviewer merge gate mode: "approval" requires a GitHub-native review
-# approval before merge (orch submit-pr/merge-pr); "review" requires a formal
-# review of the current head from a non-author reviewer plus zero unresolved
-# threads — the right mode for review bots that comment but never approve.
-# Set "off" ONLY for repos with no review bots and no reviewer policy — the
-# review wait is skipped entirely. Legacy PR_APPROVAL_GATE ("on"/"off") is
-# still honored when this key is unset.
+# Reviewer merge gate: "approval" needs a GitHub approval; "review" needs a
+# non-author review of the current head plus zero unresolved threads (for
+# bots that comment but never approve); "off" only where no reviewer exists.
 PR_REVIEW_GATE = "approval"
-# Used by: orch (`submit-pr` / `merge-pr`).
 
+# Total review-wait budget in seconds before the on-timeout policy applies.
 PR_REVIEW_WAIT_SECS = "900"
-# Used by: orch (`approval-wait`) and review-gate (`pr-watch.sh`). Total
-# review-wait budget in seconds — the per-repo quiet period before the
-# on-timeout policy applies — used when the caller passes no max_wait
-# positional arg (an explicit arg always wins). Must be a non-negative
-# integer of at most 9 digits after leading zeros: pr-watch.sh fails loud
-# (exit 2) on any other value rather than silently falling back to 900.
 
+# Seconds of reviewer silence on a head before the one nudge; "0" disables.
 PR_REVIEW_NUDGE_SECS = "600"
-# Used by: orch (`approval-wait`). Seconds of reviewer silence for the current
-# head before the wait nudges — once per head SHA; a push restarts the clock.
-# "0" disables nudging.
 
+# Comment posted as the nudge — whatever summons this repo's reviewer.
+# Empty = GitHub's native re-review request.
 PR_REVIEW_NUDGE = ""
-# Used by: orch (`approval-wait`). PR comment body posted as the nudge — set
-# it to whatever summons the project's reviewer (e.g. "@your-bot review").
-# Empty = no comment; the nudge falls back to a GitHub-native re-review
-# request to the PR's requested and past reviewers.
 
+# Check-run name a trusted review bot publishes on analyzed heads; a success
+# counts as review evidence. SECURITY: checks match by NAME and anyone can
+# publish under any name — name only the trusted bot's check. Empty = review
+# objects only.
 PR_REVIEW_CHECK = ""
-# Used by: orch (`approval-wait --mode review`). Exact name of the check-run
-# the repo's trusted review bot publishes on analyzed heads (e.g. "Devin
-# Review"). When set, a "success" conclusion of that check on the current
-# head counts as review evidence — for bots that submit a review object only
-# when they have findings, whose clean re-analyses would otherwise never
-# satisfy the review gate. SECURITY: check-runs are matched by NAME, and any
-# GitHub App or Actions workflow can publish a check under any name — name
-# only a check produced by the trusted review bot. Empty = review objects
-# only.
 
-# Used by: orch (`approval-wait`). Reviewer logins separated by commas or
-# whitespace, on ONE line (the settings loader reads a value per line) — that
-# must EACH have a review pinned to the current head, with zero unresolved
-# threads, before the review gate opens, in either mode. The multi-bot
-# enqueue gate: one bot's pass cannot open the gate while a listed sibling
-# has not yet reacted to this head; findings hold the gate as threads.
-# Empty = off. The wait deadline still bounds it, but PR_REVIEW_ON_TIMEOUT
-# = "proceed" needs EVERY listed reviewer silent: a partial quorum is
-# engagement, so it ends in a timeout rather than proceeding.
+# Reviewer logins (comma/space separated, ONE line) that must EACH review the
+# current head with zero open threads before the gate opens. Empty = off.
+# On timeout, "proceed" needs EVERY listed reviewer silent.
 PR_REVIEW_QUORUM = ""
 
+# When the review signal never arrives: "block" reports a timeout; "proceed"
+# records a reviewer-down override and moves on, but only with zero
+# unresolved threads — a real comment is never bypassed.
 PR_REVIEW_ON_TIMEOUT = "block"
-# Used by: orch (`approval-wait`, submit-pr / merge-pr / ci-fix). Deadline
-# behavior when the review gate signal never arrives — the reviewer posted
-# nothing (e.g. its credits are exhausted). "block" (default) reports a timeout
-# and the caller prompts or keeps waiting. "proceed" instead records a
-# reviewer-down override and moves to CI/merge, but ONLY when zero threads are
-# unresolved (an open thread always blocks — it returns "comments" first — so a
-# real comment is never bypassed); CI and comment-hygiene gates still apply. On
-# multi-reviewer repos this only fires when EVERY reviewer is silent.
 
-# BOT / COMMIT IDENTITY
+# BOT / COMMIT IDENTITY — all used by worktree; empty = the logged-in user.
 
 BOT_NAME = "automation-bot"
-# Used by: worktree.
 
 BOT_EMAIL = "you+bot@example.com"
-# Used by: worktree.
 
 BOT_REMOTE_NAME = "bot-remote"
-# Used by: worktree.
 
 # DEV
 
+# The project's validation command, run from the worktree root — point it at
+# a diff-scoped validator where one exists. Empty = the documented
+# build/test/lint command.
 DEV_VALIDATE_CMD = ""
-# Used by: dev (`dev-implement` § 5, `dev-fix` § 3). The project's validation
-# command, run from the worktree root after the deterministic gates — point it
-# at a diff-scoped validator where one exists (vstack itself uses
-# "tools/validate-changed") so a one-skill diff does not mirror the whole CI
-# suite. Empty = the project's documented build/test/lint command.
 
 # DECIDER
 
+# Where decision records live; auto-discovered when omitted.
 DECISIONS_DIR = "docs/decisions"
-# Used by: decider. Auto-discovered when omitted.
 
 # LINEAR
 
+# The team every Linear write targets. No default: an empty value refuses
+# writes instead of guessing inside whatever workspace the API key reaches.
+# Confirm with `linear.sh auth-check --strict`.
 LINEAR_TEAM = ""
-# Used by: linear. The team every write targets - set it to this project's own
-# team. No default: a team name resolves inside whatever workspace
-# LINEAR_API_KEY reaches, so an empty value refuses Linear writes instead of
-# guessing a target (reads just drop the team filter). Only the create actions
-# that take a team (issues, projects, cycles, labels) accept `--team <name>` as
-# a per-call override; every other write needs this key. Confirm the resolved
-# target with `linear.sh auth-check --strict`.
 
+# Default output format: safe, table, ids, raw.
 LINEAR_FORMAT = "safe"
-# Used by: linear. Values: safe, table, ids, raw.
 
+# Issue identifier prefix.
 LINEAR_TEAM_PREFIX = "PROJ"
-# Used by: linear.
 
+# Declared agent-routing label set (e.g. "agent:generalist, agent:rust").
+# Non-empty makes `issues create` refuse a create carrying none of them —
+# such an issue is invisible to agent routing. Empty = guard off.
 LINEAR_AGENT_LABELS = ""
-# Used by: linear (`issues create`). The project's declared agent-routing
-# label set, comma- or space-separated (e.g. "agent:generalist, agent:rust").
-# When non-empty, `issues create` refuses a create that carries no agent
-# label from this set - an issue without one is invisible to agent routing,
-# while the create prints a URL that looks like success. `--no-agent-label`
-# permits a deliberate bare create (e.g. intake mirroring). Leave empty in
-# projects with no agent-label taxonomy; the guard then stays off.
 
 # GITHUB
 
+# Bot login the sticky-verdict commands target.
 GH_BOT_USERNAME = "automation[bot]"
-# Used by: github.
 
+# Issue id extracted from branch names.
 GH_ISSUE_PATTERN = "[A-Z]+-[0-9]+"
-# Used by: github, orch.
 
+# Build/test command for `pr-cross-check --verify`.
 GH_VERIFY_CMD = "make verify"
-# Used by: github (`pr-cross-check --verify`).
 
+# Timeouts (seconds) for 1Password token resolution, auth preflight, pr-view.
 VSTACK_GITHUB_OP_TIMEOUT = "10"
-# Used by: github (`pr-view` / bot token 1Password resolution).
 
 VSTACK_GITHUB_AUTH_TIMEOUT = "10"
-# Used by: github (`pr-view` auth preflight).
 
 VSTACK_GITHUB_PR_VIEW_TIMEOUT = "30"
-# Used by: github (`pr-view`).
 
 # REVIEW GATE (shared CI merge-gate engine)
-# The review-gate scripts resolve each key environment-first, then this file,
-# then the built-in default. List values pack into one string with ';'
-# separators. Full reference: review-gate SKILL.md / references/adoption.md.
+# Keys resolve environment-first, then this file, then the built-in default.
+# Full reference: review-gate SKILL.md / references/adoption.md.
 
+# Commit-status context the writer posts — the required check name in branch
+# protection. Keep it stable.
 REVIEW_GATE_CONTEXT = "Review gate"
-# Used by: review-gate (`review-writer.sh`). Commit-status context the
-# writer posts on PR heads — the required check name in branch protection.
-# Keep it stable.
 
+# Check/status names whose success counts as review evidence. SECURITY:
+# matched by NAME — list only trusted bots' checks. github-actions-published
+# check-runs are rejected automatically.
 REVIEW_GATE_TRUSTED_STATUS_CONTEXTS = ""
-# Used by: review-gate (`review-predicate.sh`). Exact names of the trusted
-# reviewer's clean-analysis check-run and/or legacy commit status; a success
-# for a listed name on the current head counts as review evidence. SECURITY:
-# matched by NAME, and any GitHub App or workflow can publish under any name
-# — list only trusted bots' checks, on repos where all publishers are trusted.
-# Check-runs published by the shared github-actions app are rejected
-# automatically (any PR workflow can mint those; real reviewer bots publish
-# under their own app slug); legacy commit STATUSES still rely on the
-# publisher-trust precondition above.
 
+# A trusted "pass" whose output contains one of these substrings is
+# NOT-EVIDENCE (analysis never ran). Empty disables.
 REVIEW_GATE_CHECKRUN_SKIP_PATTERNS = "rate limited;skipped;queued"
-# Used by: review-gate (`review-predicate.sh`). A trusted "pass" must prove
-# analysis RAN: a success whose output/description contains one of these
-# case-insensitive substrings is NOT-EVIDENCE (same as absent, never a
-# failure). Empty disables the filter.
 
+# 'login:binding-pattern' pairs for bots whose clean pass is only an issue
+# comment binding a commit sha. SECURITY: trust keys on the LOGIN. Empty
+# disables.
 REVIEW_GATE_COMMENT_REVIEWERS = ""
-# Used by: review-gate (`review-predicate.sh`). 'login:binding-pattern' pairs
-# for bots whose clean pass is only an issue comment (no review object, no
-# check/status); the first ':' splits, the pattern is a LITERAL prefix that
-# must precede the bound commit sha. SECURITY: trust keys on the author
-# LOGIN; the body is read only to bind evidence to a commit. Empty disables.
 
+# Shortest sha prefix (4–40) a comment-form reviewer may bind evidence to.
 REVIEW_GATE_SHA_PREFIX_FLOOR = "7"
-# Used by: review-gate (`review-predicate.sh`). Shortest sha prefix (4–40) a
-# comment-form reviewer may bind evidence to.
 
+# MANUAL operator override status — posted by a human, never automation;
+# substitutes for MISSING evidence only and must carry a reason in its
+# description. Same trusted-publisher model as the contexts above.
 REVIEW_GATE_OVERRIDE_CONTEXT = "vstack-reviewer-outage"
-# Used by: review-gate (`review-predicate.sh`, so every live gate read
-# honors it). MANUAL operator override status — posted by a human operator,
-# never by automation:
-# substitutes for MISSING review evidence only, and the status description
-# must carry a reason — ENFORCED (an empty or whitespace-only description is
-# not evidence); the reason appears in the gate status detail. SECURITY:
-# same trusted-publisher model as
-# REVIEW_GATE_TRUSTED_STATUS_CONTEXTS. Empty disables. ALIAS over the legacy
-# key REVIEW_GATE_OUTAGE_CONTEXT (still read by the predicate when this key
-# is absent — existing repos need no edit); set ONLY this key in new
-# installs.
 
-
+# Creator logins whose commit statuses are never evidence. Recommended
+# "github-actions[bot]" wherever PR workflows hold statuses:write — PR
+# content can mint statuses through it. Empty disables.
 REVIEW_GATE_STATUS_PUBLISHER_REJECT = ""
-# Used by: review-gate (`review-predicate.sh`). Creator logins whose commit
-# statuses are never evidence — applied to BOTH the trusted-context and
-# override status reads. SECURITY: where PR-triggered workflows hold
-# statuses:write, PR content can mint a status under any context through
-# github-actions[bot]; listing it closes that mint. Statuses are read from
-# the per-commit statuses LIST endpoint, where every real publisher (GitHub
-# Apps included) carries a creator login; while this list is configured, a
-# status with NO creator login is an anomaly and is not evidence. Empty
-# (default) disables. Recommended "github-actions[bot]" wherever PR
-# workflows hold statuses:write — requires the operator override to be
-# posted by a non-Actions identity (operator PAT), the v2 posture.
 
+# Logins whose review objects at the exact head count as evidence. Empty =
+# any non-author.
 REVIEW_GATE_REVIEW_OBJECT_TRUSTED_LOGINS = ""
-# Used by: review-gate (`review-predicate.sh`). Logins whose review objects
-# at the exact head count as evidence. Empty = any non-author (compatible
-# default; set the list to stop drive-by collaborator reviews satisfying the
-# gate).
 
+# "any" or "approved" (an APPROVED at head not withdrawn by a later
+# CHANGES_REQUESTED from the same login).
 REVIEW_GATE_REVIEW_OBJECT_MIN_STATE = "any"
-# Used by: review-gate (`review-predicate.sh`). "any" or "approved"
-# (an APPROVED at head not withdrawn by a LATER CHANGES_REQUESTED from the
-# same login; a trailing COMMENTED never supersedes an approval).
 
+# Substrings marking a review row's body as the reviewer's own errored-run
+# attestation — such a row is NOT-EVIDENCE, never a blocker.
 REVIEW_GATE_REVIEW_OBJECT_ERROR_PATTERNS = "encountered an error and was unable to review"
-# Used by: review-gate (`review-predicate.sh`). Case-insensitive substrings
-# marking a review row's BODY as the reviewer's own errored-run attestation
-# (the reviews API has no errored state — an errored auto-review is a normal
-# COMMENTED row whose body says the review never ran). Such a row is
-# NOT-EVIDENCE and never a carry candidate, but never a blocker either. A
-# configured value replaces the default list; empty disables the filter.
 
+# "enforce" fails closed on unresolved threads CI-side; "off" only where a
+# server-side zero-bypass ruleset already enforces thread hygiene.
 REVIEW_GATE_THREADS = "enforce"
-# Used by: review-gate (`review-predicate.sh`). "enforce" evaluates
-# unresolved review threads CI-side and fails closed; "off" skips the
-# reviewThreads GraphQL read entirely and never emits threads-open — for
-# repos whose thread hygiene is a server-side zero-bypass ruleset (the
-# CI-side term is a latency optimization there, not the enforcement point).
 
+# Bounded attempts per predicate evidence read, and the pause between them.
 REVIEW_GATE_API_ATTEMPTS = "1"
-# Used by: review-gate (`review-predicate.sh`). Bounded attempts per
-# predicate evidence read. Default = single attempt, today's behavior; a
-# read failing through every attempt is still exit 2.
 
 REVIEW_GATE_API_RETRY_DELAY_SECONDS = "2"
-# Used by: review-gate (`review-predicate.sh`). Pause between retry
-# attempts.
 
+# Carry-safe delta classes ("docs", "comments"; empty = off): ancestor
+# evidence extends to head when the delta is entirely carry-safe. Never a
+# waiver — code changes always need fresh evidence. CAVEAT: "comments" is
+# line-lexical and cannot see heredocs; "docs" has no such caveat.
 REVIEW_GATE_CARRY_FORWARD = ""
-# Used by: review-gate (`review-predicate.sh`). Carry-safe delta classes
-# ("docs", "comments"; ';' or '|' separated; empty = off). Evidence at an
-# ancestor commit extends to head when the delta is entirely docs-only /
-# comment-only (or an identical tree). Never a waiver: code changes always
-# require fresh evidence; changes-requested and threads still fail closed.
-# CAVEAT: the "comments" classifier is line-lexical — it cannot see an
-# enclosing heredoc or multiline string, where a full-line `#`/`//`-prefixed
-# change is data, not a comment. Enable "comments" only on repos where that
-# residual carry risk is acceptable; "docs" has no such caveat.
 
+# Path globs that DISQUALIFY a carry — for policy-bearing markdown obeyed
+# mechanically (e.g. "*AGENTS.md;.github/*"), which deserves fresh review.
 REVIEW_GATE_CARRY_FORWARD_EXCLUDE = ""
-# Used by: review-gate (`review-predicate.sh`). Path globs (';'-separated,
-# shell-style; '*' matches '/' too) that DISQUALIFY a carry: any file in
-# the ancestor→head delta matching an exclusion forces fresh evidence even
-# when the delta classifies entirely carry-safe. Built for policy-bearing
-# markdown the "docs" class would otherwise carry — AGENTS.md and other
-# agent/reviewer instruction files are docs by extension yet obeyed
-# mechanically, so a push editing them deserves a fresh review (e.g.
-# "*AGENTS.md;.github/*"). Surgical: non-matching deltas still carry;
-# identical trees (no delta) are unaffected; inert while
-# REVIEW_GATE_CARRY_FORWARD is empty.
 
+# Exclusion globs DECLARED to match no tracked path yet, so the selftest
+# accepts them; an entry not in the exclude list is an orphan and fails.
 REVIEW_GATE_CARRY_FORWARD_EXCLUDE_PROPHYLACTIC = ""
-# Used by: review-gate (`review-predicate-selftest.sh` only; the live
-# predicate is unchanged). Exclusion globs (';'-separated, exact glob text)
-# DECLARED to match no tracked path today. The selftest fails an exclusion
-# glob that matches nothing — a typo'd anchor is dead config like a
-# leading-'/' one — unless declared here as deliberately guarding paths
-# that do not exist yet. A declaration that is not an entry of
-# REVIEW_GATE_CARRY_FORWARD_EXCLUDE is an orphan and FAILS the selftest;
-# an EMPTY exclusion list makes every declaration one.
 
+# The one-switch gate disable: "enforce" is the full gate; "off" attests
+# approved before any evidence read. A typo is a loud config error.
 REVIEW_GATE_MODE = "enforce"
-# Used by: review-gate (`review-predicate.sh`) and orch (submit flow). The
-# one-switch per-repo gate disable: "enforce" (default) is the full gate;
-# "off" answers approved with an attestation detail before any evidence
-# read — the writer converges the required status to success and merging
-# gates on CI alone; orch skips its reviewer wait. Unknown values are a
-# loud config error: a typo cannot disable a merge gate.
 
 # SECOND OPINION
-#
-# One reviewer by default: the highest-priority entry in SECOND_OPINION_MODELS
-# that is available and is NOT the model this session runs (a Claude Code
-# session gets codex, a Codex session gets claude). Every mode enforces that;
-# a run with no eligible cross-model target refuses and says why.
+# One reviewer by default: the highest-priority roster entry that is NOT the
+# model this session runs. Full semantics: second-opinion SKILL.md.
 
+# Priority-ordered roster. Per entry: SECOND_OPINION_<NAME>_CMD and
+# SECOND_OPINION_<NAME>_MODEL (identity, when the CLI fronts another model).
 SECOND_OPINION_MODELS = "claude codex"
-# Used by: second-opinion. Priority-ordered roster, space/comma separated. Per
-# entry: SECOND_OPINION_<NAME>_CMD (full command; claude and codex have defaults)
-# and SECOND_OPINION_<NAME>_MODEL (identity, when the CLI fronts another model).
-# An entry without a command still names a KNOWN identity, so a session running
-# that model is recognized and excluded.
 
+# Opinions a review collects; 2+ unions distinct models on one diff.
 SECOND_OPINION_COUNT = "1"
-# Used by: second-opinion (review mode). Opinions to collect; 2+ unions up to
-# that many distinct models on the same diff (a shortfall is reported and
-# stamped as degraded coverage).
 
+# The model THIS session runs — needed only where the harness cannot be
+# detected (Pi, OpenCode, Cursor, plain shells). SESSION-SCOPED: leave it
+# commented here and export it in the session; a project-file value describes
+# no single session and is refused.
 # SECOND_OPINION_CURRENT_MODEL = "claude"
-# Used by: second-opinion. The model THIS session runs. Claude Code and Codex
-# are detected; Pi, OpenCode, Cursor and undetected shells REQUIRE it (the run
-# refuses otherwise). Model ids work, provider prefix included: "opus",
-# "claude-opus-5", "anthropic/claude-opus-4" -> claude; "gpt-5.6-sol",
-# "openai-codex/gpt-5.6-sol", "openai/gpt-5.6-sol" -> codex. "none" declares
-# there is no session model (CI, a plain terminal): every roster entry is then
-# cross-model.
-#
-# SESSION-SCOPED — leave it COMMENTED here and export it in the environment of
-# the sessions that need it. A project file (.env, vstack.settings.toml,
-# .vstack/settings.toml, .env.local) is read by EVERY session in the repo, so a
-# value in one describes no single session:
-#   * Where the harness CANNOT be detected (Pi, OpenCode, Cursor, a plain
-#     shell) the declaration is the only identity there is, and one from a
-#     project file is refused naming the file. Export it in the session.
-#   * A DETECTED Claude Code or Codex session already knows its model and
-#     outranks any declaration: one that AGREES is ignored (it adds nothing),
-#     one that CONTRADICTS is refused naming both values — whatever its source,
-#     since an exported value is inherited by every nested session and so is no
-#     more trustworthy there.
 
+# Roster commands (identities claude / codex).
 SECOND_OPINION_CLAUDE_CMD = "claude -p --no-session-persistence --model opus --effort max --allowedTools Bash(read-only:true),Read,Glob,Grep"
-# Used by: second-opinion. Roster entry claude (identity claude).
 
 SECOND_OPINION_CODEX_CMD = "codex exec -m gpt-5.6-sol -s read-only -c model_reasoning_effort=xhigh --ephemeral"
-# Used by: second-opinion. Roster entry codex (identity codex).
 
+# Example extra roster entry: add "pi-deepseek" to SECOND_OPINION_MODELS,
+# give it a command, declare the model it fronts.
 # SECOND_OPINION_PI_DEEPSEEK_CMD = "pi -p --model deepseek/deepseek-v4-pro"
 # SECOND_OPINION_PI_DEEPSEEK_MODEL = "deepseek"
-# Used by: second-opinion. Example of another roster entry: add "pi-deepseek" to
-# SECOND_OPINION_MODELS, give it a command, and declare the model it fronts.
 
+# Seconds to wait for the external CLI.
 SECOND_OPINION_TIMEOUT = "300"
-# Used by: second-opinion. Seconds to wait for the external CLI.
 
+# Home for review/audit records written without --output; seeded with a "*"
+# .gitignore so records never dirty the tree.
 SECOND_OPINION_ARTIFACT_DIR = "tmp/second-opinion"
-# Used by: second-opinion. Home for review/audit records written without
-# --output, relative to --cwd ("~/..." and absolute paths are taken as given).
-# The default is inside the reviewed checkout; the script seeds the directory
-# with a "*" .gitignore on creation so records never dirty the working tree.
 
+# Repo instruction files appended to the review prompt (repo-rule lens).
+# Empty disables.
 SECOND_OPINION_REVIEW_INSTRUCTIONS = "AGENTS.md review-bots.md .github/instructions/*.instructions.md .github/copilot-instructions.md"
-# Used by: second-opinion (review mode). Glob list of repo instruction files
-# appended to the review prompt (repo-rule adherence lens), resolved inside the
-# reviewed repo (--cwd). Set empty to disable.
 
+# Force one target instead of walking the roster; a target running this
+# session's model is refused.
 # SECOND_OPINION_TARGET = "claude"
-# Used by: second-opinion. Force one target instead of walking the roster. A
-# forced target that runs this session's model is refused. Uncomment only when
-# this project must pin one.
 
 # SIZE RATCHET
 
+# Line threshold for paths matching no class below. Files already over it
+# are frozen in the baseline TSV and may only shrink.
 # SIZE_RATCHET_THRESHOLD = "400"
-# Used by: size-ratchet. Line threshold for every path that matches no class
-# below. Files already over it are frozen in tools/size-ratchet-baseline.tsv at
-# their current counts and may only shrink. Raising this number is a policy
-# change; lowering it adds baseline rows (see the skill README's Migration).
 
+# Per-path-class thresholds, `pattern=threshold` entries `;`-separated, FIRST
+# match wins. Globs cross `/`; a directory name needs both `tests/*` and
+# `*/tests/*`. A malformed entry is a config error, never a silent fallback.
 # SIZE_RATCHET_CLASSES = "tests/*=800;*/tests/*=800;*.test.*=800"
-# Used by: size-ratchet. Per-path-class thresholds: `pattern=threshold` entries
-# separated by `;`, FIRST match wins, unmatched paths take
-# SIZE_RATCHET_THRESHOLD. Patterns are the exclusion list's shell globs against
-# the full repo-relative path (`*` crosses `/`). This is the two-tier shape —
-# implementation 400, test paths 800 — and the patterns above are a starting
-# point: match them to the test layouts this repo actually has. A directory
-# name needs BOTH forms, as above: `*/tests/*` requires a slash-delimited
-# prefix, so a root-level `tests/` needs `tests/*` too. A malformed entry is a
-# config error, not a silent fall back to the base threshold.
 
+# Relocate the baseline TSV / exclusion list (repo-root-relative).
 # SIZE_RATCHET_BASELINE = "tools/size-ratchet-baseline.tsv"
 # SIZE_RATCHET_EXCLUDES = "tools/size-ratchet-excludes"
-# Used by: size-ratchet. Relocate the baseline TSV / exclusion list. Both are
-# repo-root-relative; the --baseline / --excludes flags override them.
 
 # PRE-COMMIT HOOK
 
+# Clippy lane for staged Rust files: unset = per-crate `cargo clippy
+# --all-targets -- -D warnings`; "off" skips the lane; any other value runs
+# verbatim as the check. The environment variable outranks this file.
 # VSTACK_PRE_COMMIT_RUST_CLIPPY = "off"
-# Used by: hooks/pre-commit-check.sh (the Clippy lane for staged Rust files).
-# Three tiers:
-#   unset (default) — the hook runs `cargo clippy --all-targets -- -D warnings`
-#     once per crate manifest owning a staged .rs file (`--manifest-path`, so
-#     workspace-excluded crates lint against their own manifest), falling back
-#     to `--workspace` when no owning manifest resolves.
-#   "off" — skip the hook's Clippy lane entirely. Use when repo-owned
-#     validation (feature-matrix lanes, a project validator) is authoritative
-#     and the hook's default-feature lane could flag pre-existing warnings the
-#     staged change didn't introduce.
-#   any other value — run it verbatim via `bash -c` from the repo root as the
-#     Clippy check; its exit status decides. Use to pin the hook to the repo's
-#     canonical lint command, e.g. "cargo clippy --workspace --all-features
-#     --all-targets -- -D warnings" or "tools/validate --clippy".
-# The environment variable takes precedence over this file.
 
 # DEBUG / OVERRIDE HOOKS
 
 WORKTREE_CLI = ".agents/skills/worktree/scripts/worktree"
-# Used by: orch (`open-terminal`).
 
 GIT_HOST_CLI = ".agents/skills/github/scripts/github.sh"
-# Used by: orch (`ci-wait`).

--- a/vstack.settings.toml.example
+++ b/vstack.settings.toml.example
@@ -229,8 +229,8 @@ REVIEW_GATE_CARRY_FORWARD_EXCLUDE_PROPHYLACTIC = ""
 REVIEW_GATE_MODE = "enforce"
 
 # SECOND OPINION
-# One reviewer by default: the highest-priority roster entry that is NOT the
-# model this session runs. Full semantics: second-opinion SKILL.md.
+# One reviewer by default: the highest-priority roster entry that is
+# AVAILABLE and is NOT the model this session runs. Full semantics: second-opinion SKILL.md.
 
 # Priority-ordered roster. Per entry: SECOND_OPINION_<NAME>_CMD and
 # SECOND_OPINION_<NAME>_MODEL (identity, when the CLI fronts another model).

--- a/vstack.settings.toml.example
+++ b/vstack.settings.toml.example
@@ -18,7 +18,8 @@ WORKTREE_DEFAULT_BRANCH = "main"
 # worktrees should share local secrets.
 WORKTREE_SYMLINKS = ".env.local opencode.json .agents .cursor .codex .opencode .pi .claude/settings.json .claude/agents .claude/hooks .claude/skills"
 
-# link=target pairs resolved relative to each worktree.
+# link=target pairs; each target resolves from the LINK's own directory
+# (`.claude/CLAUDE.md=../AGENTS.md` reaches the worktree root's AGENTS.md).
 WORKTREE_RELATIVE_SYMLINKS = ".claude/CLAUDE.md=../AGENTS.md .claude/AGENTS.md=../AGENTS.md"
 
 # Files copied (not linked) into new worktrees.
@@ -93,7 +94,9 @@ PR_REVIEW_QUORUM = ""
 # unresolved threads — a real comment is never bypassed.
 PR_REVIEW_ON_TIMEOUT = "block"
 
-# BOT / COMMIT IDENTITY — all used by worktree; empty = the logged-in user.
+# BOT / COMMIT IDENTITY — used by worktree. Leave ALL of them empty to act
+# as the logged-in user; the fallback is not per-key (a partly-empty set
+# writes the empty values verbatim).
 
 BOT_NAME = "automation-bot"
 

--- a/vstack.settings.toml.example
+++ b/vstack.settings.toml.example
@@ -94,9 +94,9 @@ PR_REVIEW_QUORUM = ""
 # unresolved threads — a real comment is never bypassed.
 PR_REVIEW_ON_TIMEOUT = "block"
 
-# BOT / COMMIT IDENTITY — used by worktree. Leave ALL of them empty to act
-# as the logged-in user; the fallback is not per-key (a partly-empty set
-# writes the empty values verbatim).
+# BOT / COMMIT IDENTITY — used by worktree. BOT_NAME is the gate: empty
+# BOT_NAME = the logged-in user, and the other keys are ignored; once it is
+# set the rest are written verbatim, empty values included.
 
 BOT_NAME = "automation-bot"
 

--- a/vstack.settings.toml.example
+++ b/vstack.settings.toml.example
@@ -78,8 +78,8 @@ PR_REVIEW_NUDGE_SECS = "600"
 # Empty = GitHub's native re-review request.
 PR_REVIEW_NUDGE = ""
 
-# Check-run name a trusted review bot publishes on analyzed heads; a success
-# counts as review evidence. SECURITY: checks match by NAME and anyone can
+# Check-run or commit-status name a trusted review bot publishes on
+# analyzed heads; a success counts as review evidence. SECURITY: checks match by NAME and anyone can
 # publish under any name — name only the trusted bot's check. Empty = review
 # objects only.
 PR_REVIEW_CHECK = ""
@@ -94,9 +94,10 @@ PR_REVIEW_QUORUM = ""
 # unresolved threads — a real comment is never bypassed.
 PR_REVIEW_ON_TIMEOUT = "block"
 
-# BOT / COMMIT IDENTITY — used by worktree. BOT_NAME is the gate: empty
-# BOT_NAME = the logged-in user, and the other keys are ignored; once it is
-# set the rest are written verbatim, empty values included.
+# BOT / COMMIT IDENTITY — used by worktree. BOT_NAME gates the identity:
+# empty = the logged-in user (BOT_EMAIL then ignored); set = name and email
+# written verbatim, empty values included. BOT_REMOTE_NAME independently
+# selects the push remote (empty = origin).
 
 BOT_NAME = "automation-bot"
 
@@ -119,8 +120,9 @@ DECISIONS_DIR = "docs/decisions"
 # LINEAR
 
 # The team every Linear write targets. No default: an empty value refuses
-# writes instead of guessing inside whatever workspace the API key reaches.
-# Confirm with `linear.sh auth-check --strict`.
+# writes instead of guessing inside whatever workspace the API key reaches
+# (the create actions still take `--team <name>` per call). Confirm with
+# `linear.sh auth-check --strict`.
 LINEAR_TEAM = ""
 
 # Default output format: safe, table, ids, raw.
@@ -256,8 +258,9 @@ SECOND_OPINION_CODEX_CMD = "codex exec -m gpt-5.6-sol -s read-only -c model_reas
 # Seconds to wait for the external CLI.
 SECOND_OPINION_TIMEOUT = "300"
 
-# Home for review/audit records written without --output; seeded with a "*"
-# .gitignore so records never dirty the tree.
+# Home for review/audit records written without --output; a directory the
+# script CREATES is seeded with a "*" .gitignore (a pre-existing one is
+# left alone — ignore it yourself).
 SECOND_OPINION_ARTIFACT_DIR = "tmp/second-opinion"
 
 # Repo instruction files appended to the review prompt (repo-rule lens).


### PR DESCRIPTION
Every settings-template key's comment condensed to the drovr worked-example register (drovr#511): one-line intent plus genuine landmines, full semantics pointed at the skills — 922 → 545 lines across the root and five skill templates, zero key or value changes (asserted mechanically). The refresh's seeded-comment rewrite propagates the terse form to consumer files whose blocks are unedited, which also delivers the issue's secondary ask (terse seeding) with no new flag. The security caveats travel with the four trust keys, pinned by settings-example-sync.

Closes VST-317
Closes #1387

https://claude.ai/code/session_012epxJEzGqT7q3qcFhdZUt5