### PR TITLE
feat(size-ratchet): --seed writes the first baseline from the gate's own collector (VST-328)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
 - linear: a truncated `cache issues list` announces itself on stderr with
   both counts instead of returning a bare 75-row array that reads as
   complete; `--max`/`--limit` are documented in SKILL.md (VST-320).
+- size-ratchet: `--seed` writes the FIRST baseline from the gate's own
+  collector (exact counts, class thresholds, excludes, sorted, self-row) and
+  refuses a live one — installing the skill no longer leaves a gate that can
+  never be turned on; the two stale built-in-1000 test messages read 400
+  (VST-328).
 
 - preflight: the code-citation lane leaves installed-artifact subtrees alone
   (`.agents/` and the harness dirs' skills/agents/hooks/rules/instructions/

--- a/skills/size-ratchet/README.md
+++ b/skills/size-ratchet/README.md
@@ -79,11 +79,15 @@ worktree cannot show): materialize it first with
 any path shape; a later `git sparse-checkout reapply` re-hides the file),
 then rerun.
 
-`--update` never adds rows, so the first baseline is created explicitly:
-run the check, and turn each reported `new offender` line (path and count)
-into a `path<TAB>lines` row, `LC_ALL=C` sorted. That the initial freeze is
-a hand-authored, reviewed diff is the point — every frozen offender enters
-the record deliberately.
+`--update` never adds rows, so the first baseline has its own mode:
+`size-ratchet --seed` writes every tracked, non-excluded file over its
+deciding threshold at its current count — collected by the same pass the
+gate itself trusts (index blobs, symlink skipping, tab/newline refusal),
+`LC_ALL=C` sorted, with a self-row when the baseline outgrows its own
+threshold. It refuses a baseline that already has rows: the ratchet is
+live there, and growth stays a reviewed hand-edit. The seeded file lands
+uncommitted, so the initial freeze is still a reviewed diff — every frozen
+offender enters the record deliberately.
 
 ## Path classes
 

--- a/skills/size-ratchet/SKILL.md
+++ b/skills/size-ratchet/SKILL.md
@@ -26,6 +26,7 @@ human editing the row in a reviewed diff.
 .agents/skills/size-ratchet/scripts/size-ratchet            # check (pre-PR / CI)
 .agents/skills/size-ratchet/scripts/size-ratchet --staged   # check what a commit records (git hook)
 .agents/skills/size-ratchet/scripts/size-ratchet --update   # tighten the baseline
+.agents/skills/size-ratchet/scripts/size-ratchet --seed     # write the FIRST baseline
 ```
 
 `--staged` judges the commit's snapshot: index blobs, and index policy.
@@ -67,6 +68,14 @@ keeps failing, and a new offender stays a failure. Deliberate growth or a
 new freeze is a hand-edit of the baseline TSV, visible in the diff. After
 the rewrite the check re-runs, so `--update` exits 1 while growth or new
 offenders remain.
+
+## `--seed` — bootstrap only
+
+`--seed` writes the FIRST baseline from the gate's own collector: every
+tracked, non-excluded file over its deciding threshold enters at its
+current count, sorted, with a self-row when the baseline outgrows its own
+threshold. A baseline that already has rows refuses — the ratchet is live
+there, and growth stays a reviewed hand-edit. Commit the seeded file.
 
 ## Configuration
 

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -691,9 +691,10 @@ if [ "$MODE" = "seed" ]; then
   # copy mean the ratchet is live even when the worktree copy was truncated,
   # and a regenerated baseline must be a reviewed hand-edit, never a reseed.
   if git ls-files --error-unmatch -- "$BASELINE_FILE" >/dev/null 2>&1; then
-    rows_index="$(git show ":$BASELINE_FILE" 2>/dev/null | grep -c . || true)"
-    case "$rows_index" in *[!0-9]*) rows_index=0 ;; esac
-    if [ "${rows_index:-0}" -gt 0 ]; then
+    git show ":$BASELINE_FILE" >"$TMP/baseline.index" 2>/dev/null \
+      || collection_error "could not read the index copy of $BASELINE_FILE — seeding cannot prove the ratchet is not live"
+    rows_index="$(count_nonempty_lines "$TMP/baseline.index")"
+    if [ "$rows_index" -gt 0 ]; then
       config_error "--seed refuses: the INDEX copy of $BASELINE_FILE carries $rows_index row(s) — the ratchet is live; restore the file (git checkout -- $BASELINE_FILE) or hand-edit it"
     fi
   fi

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -739,6 +739,11 @@ if [ "$MODE" = "seed" ]; then
       *) config_error "--seed refuses: $BASELINE_FILE resolves outside the repository ($parent_phys) — nothing written" ;;
     esac
   fi
+  # The destination itself must be a plain path: mv onto a symlink or a
+  # directory would deposit the file wherever they point instead.
+  if [ -L "$BASELINE_FILE" ] || { [ -e "$BASELINE_FILE" ] && [ ! -f "$BASELINE_FILE" ]; }; then
+    config_error "--seed refuses: $BASELINE_FILE exists but is not a regular file — the baseline must be a plain file this repository owns"
+  fi
   mv -- "$TMP/baseline.new" "$BASELINE_FILE" || collection_error "could not write the baseline at $BASELINE_FILE (mv failed)"
   cp -- "$BASELINE_FILE" "$TMP/baseline.tsv" || collection_error "could not re-read the seeded baseline at $BASELINE_FILE — the file WAS written; rerun size-ratchet to verify it"
   # The file this mode just wrote is about to be judged by the trailing

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -712,19 +712,33 @@ if [ "$MODE" = "seed" ]; then
   fi
   base_parent="."
   case "$BASELINE_FILE" in
-    */*)
-      base_parent="${BASELINE_FILE%/*}"
-      mkdir -p "$base_parent" || collection_error "could not create the baseline directory for $BASELINE_FILE"
-      ;;
+    */*) base_parent="${BASELINE_FILE%/*}" ;;
   esac
-  # The write stays inside the repository: a symlinked parent physically
-  # resolving elsewhere must not receive the seeded file.
-  parent_phys="$(cd "$base_parent" 2>/dev/null && pwd -P)" || config_error "--seed cannot resolve the baseline directory for $BASELINE_FILE"
+  # Containment BEFORE side effects: the deepest existing ancestor must
+  # physically sit inside the repository before any directory is created —
+  # a symlinked parent resolving elsewhere must receive neither the seeded
+  # file nor the mkdir.
   repo_phys="$(pwd -P)" || collection_error "could not resolve the repository root"
+  probe="$base_parent"
+  while [ ! -d "$probe" ]; do
+    case "$probe" in
+      */*) probe="${probe%/*}" ;;
+      *) probe="." ;;
+    esac
+  done
+  parent_phys="$(cd "$probe" 2>/dev/null && pwd -P)" || config_error "--seed cannot resolve the baseline directory for $BASELINE_FILE"
   case "$parent_phys/" in
     "$repo_phys"/*) ;;
     *) config_error "--seed refuses: $BASELINE_FILE resolves outside the repository ($parent_phys) — nothing written" ;;
   esac
+  if [ "$base_parent" != "." ]; then
+    mkdir -p "$base_parent" || collection_error "could not create the baseline directory for $BASELINE_FILE"
+    parent_phys="$(cd "$base_parent" 2>/dev/null && pwd -P)" || config_error "--seed cannot resolve the baseline directory for $BASELINE_FILE"
+    case "$parent_phys/" in
+      "$repo_phys"/*) ;;
+      *) config_error "--seed refuses: $BASELINE_FILE resolves outside the repository ($parent_phys) — nothing written" ;;
+    esac
+  fi
   mv -- "$TMP/baseline.new" "$BASELINE_FILE" || collection_error "could not write the baseline at $BASELINE_FILE (mv failed)"
   cp -- "$BASELINE_FILE" "$TMP/baseline.tsv" || collection_error "could not re-read the seeded baseline at $BASELINE_FILE — the file WAS written; rerun size-ratchet to verify it"
   # The file this mode just wrote is about to be judged by the trailing

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -696,7 +696,7 @@ if [ "$MODE" = "seed" ]; then
   # counted at the final length, self-row included — so the very next run
   # over the committed file does not open with a new offender.
   path_threshold "$BASELINE_FILE"
-  if [ $((rows + 1)) -gt "$PT" ]; then
+  if [ "$rows" -gt "$PT" ]; then
     printf '%s\t%s\n' "$BASELINE_FILE" $((rows + 1)) >>"$TMP/baseline.new"
     LC_ALL=C sort -o "$TMP/baseline.new" "$TMP/baseline.new" || collection_error "could not sort the seeded baseline — nothing written"
     rows=$((rows + 1))

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -50,7 +50,7 @@ STAGED=0
 
 usage() {
   cat <<'EOF'
-usage: size-ratchet [--staged] [--update] [--baseline FILE] [--excludes FILE]
+usage: size-ratchet [--staged] [--update | --seed] [--baseline FILE] [--excludes FILE]
 
 Tighten-only file-size gate: tracked files over the line threshold must be
 frozen in the baseline at their current size, and the baseline may only
@@ -101,7 +101,14 @@ BASELINE_OPT=""
 EXCLUDES_OPT=""
 while [ $# -gt 0 ]; do
   case "$1" in
-    --update) MODE="update" ;;
+    --update)
+      [ "$MODE" = "check" ] || config_error "--update and --seed are mutually exclusive"
+      MODE="update"
+      ;;
+    --seed)
+      [ "$MODE" = "check" ] || config_error "--update and --seed are mutually exclusive"
+      MODE="seed"
+      ;;
     --baseline)
       [ $# -ge 2 ] || config_error "--baseline requires a path"
       shift
@@ -664,6 +671,53 @@ if [ "$MODE" = "update" ]; then
     # to write; fall through to the plain check.
     echo "size-ratchet --update: no baseline at $BASELINE_FILE and --update never adds rows; nothing written"
   fi
+fi
+
+# --- --seed: write the FIRST baseline -----------------------------------------
+# The steady-state contract (rows never added, never raised) is also the only
+# path to a first baseline, so bootstrap gets its own mode: every tracked,
+# non-excluded file over ITS deciding threshold enters at its current count —
+# collected by the same pass the gate itself trusts — and only onto an empty
+# or absent baseline. A populated baseline is a live ratchet; growth stays a
+# reviewed hand-edit.
+if [ "$MODE" = "seed" ]; then
+  rows_existing="$(count_nonempty_lines "$TMP/baseline.tsv")"
+  if [ "$rows_existing" -gt 0 ]; then
+    config_error "--seed refuses: $BASELINE_FILE already carries $rows_existing row(s) — the ratchet is live and only moves down (--update tightens; growth is a reviewed hand-edit)"
+  fi
+  if [ "$BASELINE_FROM_INDEX" = "1" ]; then
+    BASELINE_QUOTED="$(printf '%q' "$BASELINE_FILE")"
+    config_error "--seed cannot write an index-only baseline (sparse checkout omits $BASELINE_FILE); materialize it with: git update-index --no-skip-worktree -- $BASELINE_QUOTED && git checkout-index -- $BASELINE_QUOTED, then rerun"
+  fi
+  awk -F'\t' -v OFS='\t' '{ if (($2 + 0) > ($3 + 0)) print $1, $2 }' "$TMP/counts.tsv" | LC_ALL=C sort >"$TMP/baseline.new" || collection_error "could not derive the seed rows — nothing written"
+  rows="$(count_nonempty_lines "$TMP/baseline.new")"
+  # The baseline is about to become a tracked file itself; when its own
+  # length will exceed its deciding threshold, it enters with a self-row —
+  # counted at the final length, self-row included — so the very next run
+  # over the committed file does not open with a new offender.
+  path_threshold "$BASELINE_FILE"
+  if [ $((rows + 1)) -gt "$PT" ]; then
+    printf '%s\t%s\n' "$BASELINE_FILE" $((rows + 1)) >>"$TMP/baseline.new"
+    LC_ALL=C sort -o "$TMP/baseline.new" "$TMP/baseline.new" || collection_error "could not sort the seeded baseline — nothing written"
+    rows=$((rows + 1))
+  fi
+  case "$BASELINE_FILE" in
+    */*) mkdir -p "${BASELINE_FILE%/*}" || collection_error "could not create the baseline directory for $BASELINE_FILE" ;;
+  esac
+  mv -- "$TMP/baseline.new" "$BASELINE_FILE" || collection_error "could not write the baseline at $BASELINE_FILE (mv failed)"
+  cp -- "$BASELINE_FILE" "$TMP/baseline.tsv" || collection_error "could not re-read the seeded baseline at $BASELINE_FILE — the file WAS written; rerun size-ratchet to verify it"
+  # The file this mode just wrote is about to be judged by the trailing
+  # verdict; give the counts its row at the written length so the verdict
+  # sees what `git add` is about to make true, replacing any pre-existing
+  # row (a tracked-but-empty baseline is in the counts at length 0).
+  BASELINE_PATH="$BASELINE_FILE" NEW_N="$rows" NEW_T="$PT" awk -F'\t' -v OFS='\t' '
+    BEGIN { p = ENVIRON["BASELINE_PATH"]; n = ENVIRON["NEW_N"]; t = ENVIRON["NEW_T"] }
+    $1 == p { next }
+    { print }
+    END { print p, n, t }
+  ' "$TMP/counts.tsv" >"$TMP/counts.rewrite" || collection_error "could not refresh the counts row for $BASELINE_FILE — the baseline WAS written; rerun size-ratchet to verify it"
+  mv "$TMP/counts.rewrite" "$TMP/counts.tsv" || collection_error "could not stage the refreshed counts — the baseline WAS written; rerun size-ratchet to verify it"
+  echo "size-ratchet --seed: first baseline written at $BASELINE_FILE ($rows row(s)) — commit it; rows only move down from here"
 fi
 
 # --- verdict -------------------------------------------------------------------

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -710,8 +710,20 @@ if [ "$MODE" = "seed" ]; then
     LC_ALL=C sort -o "$TMP/baseline.new" "$TMP/baseline.new" || collection_error "could not sort the seeded baseline — nothing written"
     rows=$((rows + 1))
   fi
+  base_parent="."
   case "$BASELINE_FILE" in
-    */*) mkdir -p "${BASELINE_FILE%/*}" || collection_error "could not create the baseline directory for $BASELINE_FILE" ;;
+    */*)
+      base_parent="${BASELINE_FILE%/*}"
+      mkdir -p "$base_parent" || collection_error "could not create the baseline directory for $BASELINE_FILE"
+      ;;
+  esac
+  # The write stays inside the repository: a symlinked parent physically
+  # resolving elsewhere must not receive the seeded file.
+  parent_phys="$(cd "$base_parent" 2>/dev/null && pwd -P)" || config_error "--seed cannot resolve the baseline directory for $BASELINE_FILE"
+  repo_phys="$(pwd -P)" || collection_error "could not resolve the repository root"
+  case "$parent_phys/" in
+    "$repo_phys"/*) ;;
+    *) config_error "--seed refuses: $BASELINE_FILE resolves outside the repository ($parent_phys) — nothing written" ;;
   esac
   mv -- "$TMP/baseline.new" "$BASELINE_FILE" || collection_error "could not write the baseline at $BASELINE_FILE (mv failed)"
   cp -- "$BASELINE_FILE" "$TMP/baseline.tsv" || collection_error "could not re-read the seeded baseline at $BASELINE_FILE — the file WAS written; rerun size-ratchet to verify it"

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -681,6 +681,9 @@ fi
 # or absent baseline. A populated baseline is a live ratchet; growth stays a
 # reviewed hand-edit.
 if [ "$MODE" = "seed" ]; then
+  if [ "$BASELINE_FILE" = "$EXCLUDES_FILE" ]; then
+    config_error "--seed refuses: the baseline and exclusion list resolve to the same path ($BASELINE_FILE) — seeding would turn every row into an exclusion on the next run"
+  fi
   rows_existing="$(count_nonempty_lines "$TMP/baseline.tsv")"
   if [ "$rows_existing" -gt 0 ]; then
     config_error "--seed refuses: $BASELINE_FILE already carries $rows_existing row(s) — the ratchet is live and only moves down (--update tightens; growth is a reviewed hand-edit)"

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -689,6 +689,15 @@ if [ "$MODE" = "seed" ]; then
     BASELINE_QUOTED="$(printf '%q' "$BASELINE_FILE")"
     config_error "--seed cannot write an index-only baseline (sparse checkout omits $BASELINE_FILE); materialize it with: git update-index --no-skip-worktree -- $BASELINE_QUOTED && git checkout-index -- $BASELINE_QUOTED, then rerun"
   fi
+  # Under --staged the populated-baseline refusal above read the INDEX copy;
+  # unstaged rows in the worktree copy are still content this mode must not
+  # replace.
+  if [ -f "$BASELINE_FILE" ]; then
+    rows_worktree="$(count_nonempty_lines "$BASELINE_FILE")"
+    if [ "$rows_worktree" -gt 0 ]; then
+      config_error "--seed refuses: the worktree copy of $BASELINE_FILE carries $rows_worktree row(s) (unstaged) — stage or remove them first"
+    fi
+  fi
   awk -F'\t' -v OFS='\t' '{ if (($2 + 0) > ($3 + 0)) print $1, $2 }' "$TMP/counts.tsv" | LC_ALL=C sort >"$TMP/baseline.new" || collection_error "could not derive the seed rows — nothing written"
   rows="$(count_nonempty_lines "$TMP/baseline.new")"
   # The baseline is about to become a tracked file itself; when its own
@@ -696,7 +705,7 @@ if [ "$MODE" = "seed" ]; then
   # counted at the final length, self-row included — so the very next run
   # over the committed file does not open with a new offender.
   path_threshold "$BASELINE_FILE"
-  if [ "$rows" -gt "$PT" ]; then
+  if ! is_excluded "$BASELINE_FILE" && [ "$rows" -gt "$PT" ]; then
     printf '%s\t%s\n' "$BASELINE_FILE" $((rows + 1)) >>"$TMP/baseline.new"
     LC_ALL=C sort -o "$TMP/baseline.new" "$TMP/baseline.new" || collection_error "could not sort the seeded baseline — nothing written"
     rows=$((rows + 1))
@@ -709,14 +718,17 @@ if [ "$MODE" = "seed" ]; then
   # The file this mode just wrote is about to be judged by the trailing
   # verdict; give the counts its row at the written length so the verdict
   # sees what `git add` is about to make true, replacing any pre-existing
-  # row (a tracked-but-empty baseline is in the counts at length 0).
-  BASELINE_PATH="$BASELINE_FILE" NEW_N="$rows" NEW_T="$PT" awk -F'\t' -v OFS='\t' '
-    BEGIN { p = ENVIRON["BASELINE_PATH"]; n = ENVIRON["NEW_N"]; t = ENVIRON["NEW_T"] }
-    $1 == p { next }
-    { print }
-    END { print p, n, t }
-  ' "$TMP/counts.tsv" >"$TMP/counts.rewrite" || collection_error "could not refresh the counts row for $BASELINE_FILE — the baseline WAS written; rerun size-ratchet to verify it"
-  mv "$TMP/counts.rewrite" "$TMP/counts.tsv" || collection_error "could not stage the refreshed counts — the baseline WAS written; rerun size-ratchet to verify it"
+  # row (a tracked-but-empty baseline is in the counts at length 0). An
+  # excluded baseline is outside the collector and gets no row.
+  if ! is_excluded "$BASELINE_FILE"; then
+    BASELINE_PATH="$BASELINE_FILE" NEW_N="$rows" NEW_T="$PT" awk -F'\t' -v OFS='\t' '
+      BEGIN { p = ENVIRON["BASELINE_PATH"]; n = ENVIRON["NEW_N"]; t = ENVIRON["NEW_T"] }
+      $1 == p { next }
+      { print }
+      END { print p, n, t }
+    ' "$TMP/counts.tsv" >"$TMP/counts.rewrite" || collection_error "could not refresh the counts row for $BASELINE_FILE — the baseline WAS written; rerun size-ratchet to verify it"
+    mv "$TMP/counts.rewrite" "$TMP/counts.tsv" || collection_error "could not stage the refreshed counts — the baseline WAS written; rerun size-ratchet to verify it"
+  fi
   echo "size-ratchet --seed: first baseline written at $BASELINE_FILE ($rows row(s)) — commit it; rows only move down from here"
 fi
 

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -684,6 +684,19 @@ if [ "$MODE" = "seed" ]; then
   if [ "$BASELINE_FILE" = "$EXCLUDES_FILE" ]; then
     config_error "--seed refuses: the baseline and exclusion list resolve to the same path ($BASELINE_FILE) — seeding would turn every row into an exclusion on the next run"
   fi
+  if [ -e "$BASELINE_FILE" ] && [ -e "$EXCLUDES_FILE" ] && [ "$BASELINE_FILE" -ef "$EXCLUDES_FILE" ]; then
+    config_error "--seed refuses: the baseline and exclusion list are the same file (aliased through a link) — seeding would turn every row into an exclusion on the next run"
+  fi
+  # Bootstrap-only holds against the committed record too: rows in the INDEX
+  # copy mean the ratchet is live even when the worktree copy was truncated,
+  # and a regenerated baseline must be a reviewed hand-edit, never a reseed.
+  if git ls-files --error-unmatch -- "$BASELINE_FILE" >/dev/null 2>&1; then
+    rows_index="$(git show ":$BASELINE_FILE" 2>/dev/null | grep -c . || true)"
+    case "$rows_index" in *[!0-9]*) rows_index=0 ;; esac
+    if [ "${rows_index:-0}" -gt 0 ]; then
+      config_error "--seed refuses: the INDEX copy of $BASELINE_FILE carries $rows_index row(s) — the ratchet is live; restore the file (git checkout -- $BASELINE_FILE) or hand-edit it"
+    fi
+  fi
   rows_existing="$(count_nonempty_lines "$TMP/baseline.tsv")"
   if [ "$rows_existing" -gt 0 ]; then
     config_error "--seed refuses: $BASELINE_FILE already carries $rows_existing row(s) — the ratchet is live and only moves down (--update tightens; growth is a reviewed hand-edit)"

--- a/skills/size-ratchet/tests/seed.test.sh
+++ b/skills/size-ratchet/tests/seed.test.sh
@@ -100,6 +100,40 @@ run_sr --seed
   && ok "--seed on a sparse-hidden baseline is a config error naming the repair" \
   || bad "sparse seed refusal" "rc=$RC out=$OUT"
 
+echo "=== --staged --seed never replaces unstaged worktree rows ==="
+R="$TMP/staged-clobber"
+mkdir -p "$R/tools"
+git -C "$R" -c init.defaultBranch=main init -q
+git -C "$R" config user.email test@example.com
+git -C "$R" config user.name test
+mkfile big.txt 15
+: >"$R/tools/size-ratchet-baseline.tsv"
+git -C "$R" add -A
+printf 'big.txt\t15\n' >"$R/tools/size-ratchet-baseline.tsv" # unstaged rows
+run_sr --staged --seed
+[ "$RC" -eq 2 ] && case "$OUT" in *"unstaged"*) true ;; *) false ;; esac \
+  && ok "--staged --seed refuses while the worktree copy carries unstaged rows" \
+  || bad "staged clobber refusal" "rc=$RC out=$OUT"
+row="$(cat "$R/tools/size-ratchet-baseline.tsv")"
+[ "$row" = "$(printf 'big.txt\t15')" ] && ok "the unstaged rows survive" || bad "unstaged rows" "$row"
+
+echo "=== an excluded baseline gets no self-row ==="
+R="$TMP/excluded-baseline"
+mkdir -p "$R/tools"
+git -C "$R" -c init.defaultBranch=main init -q
+git -C "$R" config user.email test@example.com
+git -C "$R" config user.name test
+for i in $(seq 1 12); do mkfile "off-$i.txt" 15; done
+printf 'tools/*\tpolicy files live outside the gate here\n' >"$R/tools/size-ratchet-excludes"
+git -C "$R" add -A
+run_sr --seed
+[ "$RC" -eq 0 ] && ok "--seed exits 0 with the baseline excluded" || bad "excluded seed exit" "rc=$RC out=$OUT"
+if grep -qF 'tools/size-ratchet-baseline.tsv' "$R/tools/size-ratchet-baseline.tsv"; then
+  bad "excluded self-row" "a self-row was written for an excluded baseline"
+else
+  ok "no self-row for an excluded baseline"
+fi
+
 echo "=== mode exclusivity ==="
 run_sr --seed --update
 [ "$RC" -eq 2 ] && ok "--seed with --update is a config error" || bad "exclusivity" "rc=$RC out=$OUT"

--- a/skills/size-ratchet/tests/seed.test.sh
+++ b/skills/size-ratchet/tests/seed.test.sh
@@ -144,11 +144,11 @@ mkfile big.txt 15
 ln -s "$TMP/outside-target" "$R/policy"
 git -C "$R" add -A
 OUT=""; RC=0
-OUT="$(cd "$R" && SIZE_RATCHET_THRESHOLD=10 "$SR" --seed --baseline policy/base.tsv 2>&1)" || RC=$?
+OUT="$(cd "$R" && SIZE_RATCHET_THRESHOLD=10 "$SR" --seed --baseline policy/new/base.tsv 2>&1)" || RC=$?
 [ "$RC" -eq 2 ] && case "$OUT" in *"outside the repository"*) true ;; *) false ;; esac \
   && ok "--seed refuses a baseline path resolving outside the repo" \
   || bad "containment refusal" "rc=$RC out=$OUT"
-[ ! -e "$TMP/outside-target/base.tsv" ] && ok "nothing was written outside" || bad "outside write" "$(ls "$TMP/outside-target")"
+[ -z "$(ls -A "$TMP/outside-target")" ] && ok "nothing was written or created outside" || bad "outside side effects" "$(ls "$TMP/outside-target")"
 
 echo "=== mode exclusivity ==="
 run_sr --seed --update

--- a/skills/size-ratchet/tests/seed.test.sh
+++ b/skills/size-ratchet/tests/seed.test.sh
@@ -150,6 +150,22 @@ OUT="$(cd "$R" && SIZE_RATCHET_THRESHOLD=10 "$SR" --seed --baseline policy/new/b
   || bad "containment refusal" "rc=$RC out=$OUT"
 [ -z "$(ls -A "$TMP/outside-target")" ] && ok "nothing was written or created outside" || bad "outside side effects" "$(ls "$TMP/outside-target")"
 
+echo "=== a symlinked baseline destination refuses ==="
+R="$TMP/symlink-dest"
+mkdir -p "$R" "$TMP/outside-dest"
+git -C "$R" -c init.defaultBranch=main init -q
+git -C "$R" config user.email test@example.com
+git -C "$R" config user.name test
+mkfile big.txt 15
+ln -s "$TMP/outside-dest" "$R/base-link"
+git -C "$R" add big.txt
+OUT=""; RC=0
+OUT="$(cd "$R" && SIZE_RATCHET_THRESHOLD=10 "$SR" --seed --baseline base-link 2>&1)" || RC=$?
+[ "$RC" -eq 2 ] && case "$OUT" in *"not a regular file"*) true ;; *) false ;; esac \
+  && ok "--seed refuses a symlinked baseline destination" \
+  || bad "symlink destination refusal" "rc=$RC out=$OUT"
+[ -z "$(ls -A "$TMP/outside-dest")" ] && ok "the symlink target stays untouched" || bad "symlink target" "$(ls "$TMP/outside-dest")"
+
 echo "=== mode exclusivity ==="
 run_sr --seed --update
 [ "$RC" -eq 2 ] && ok "--seed with --update is a config error" || bad "exclusivity" "rc=$RC out=$OUT"

--- a/skills/size-ratchet/tests/seed.test.sh
+++ b/skills/size-ratchet/tests/seed.test.sh
@@ -85,6 +85,21 @@ git -C "$R" add -A
 run_sr
 [ "$RC" -eq 0 ] && ok "the committed baseline passes its own gate" || bad "self-row post-check" "rc=$RC out=$OUT"
 
+echo "=== --seed refuses an index-only baseline ==="
+R="$TMP/sparse-seed"
+mkdir -p "$R/tools"
+git -C "$R" -c init.defaultBranch=main init -q
+git -C "$R" config user.email test@example.com
+git -C "$R" config user.name test
+mkfile big.txt 15
+: >"$R/tools/size-ratchet-baseline.tsv"
+git -C "$R" add -A
+rm "$R/tools/size-ratchet-baseline.tsv" # tracked, absent from the worktree
+run_sr --seed
+[ "$RC" -eq 2 ] && case "$OUT" in *"index-only baseline"*) true ;; *) false ;; esac \
+  && ok "--seed on a sparse-hidden baseline is a config error naming the repair" \
+  || bad "sparse seed refusal" "rc=$RC out=$OUT"
+
 echo "=== mode exclusivity ==="
 run_sr --seed --update
 [ "$RC" -eq 2 ] && ok "--seed with --update is a config error" || bad "exclusivity" "rc=$RC out=$OUT"

--- a/skills/size-ratchet/tests/seed.test.sh
+++ b/skills/size-ratchet/tests/seed.test.sh
@@ -181,6 +181,38 @@ OUT="$(cd "$R" && SIZE_RATCHET_THRESHOLD=10 "$SR" --seed --baseline tools/shared
   || bad "alias refusal" "rc=$RC out=$OUT"
 [ ! -e "$R/tools/shared.tsv" ] && ok "the shared path stays unwritten" || bad "alias write" "$(cat "$R/tools/shared.tsv")"
 
+echo "=== a committed ratchet refuses reseeding even with a truncated worktree copy ==="
+R="$TMP/index-rows"
+mkdir -p "$R/tools"
+git -C "$R" -c init.defaultBranch=main init -q
+git -C "$R" config user.email test@example.com
+git -C "$R" config user.name test
+mkfile big.txt 15
+printf 'big.txt\t15\n' >"$R/tools/size-ratchet-baseline.tsv"
+git -C "$R" add -A
+git -C "$R" commit -qm base
+: >"$R/tools/size-ratchet-baseline.tsv" # truncated worktree copy
+run_sr --seed
+[ "$RC" -eq 2 ] && case "$OUT" in *"INDEX copy"*) true ;; *) false ;; esac \
+  && ok "--seed refuses while the index copy carries rows" \
+  || bad "index-rows refusal" "rc=$RC out=$OUT"
+
+echo "=== an exclusion list hard-linked to the baseline refuses ==="
+R="$TMP/hardlink-alias"
+mkdir -p "$R/tools"
+git -C "$R" -c init.defaultBranch=main init -q
+git -C "$R" config user.email test@example.com
+git -C "$R" config user.name test
+mkfile big.txt 15
+: >"$R/tools/size-ratchet-baseline.tsv"
+ln "$R/tools/size-ratchet-baseline.tsv" "$R/tools/alias-excludes"
+git -C "$R" add big.txt
+OUT=""; RC=0
+OUT="$(cd "$R" && SIZE_RATCHET_THRESHOLD=10 "$SR" --seed --excludes tools/alias-excludes 2>&1)" || RC=$?
+[ "$RC" -eq 2 ] && case "$OUT" in *"same file"*) true ;; *) false ;; esac \
+  && ok "--seed refuses an exclusion list aliased to the baseline" \
+  || bad "hardlink alias refusal" "rc=$RC out=$OUT"
+
 echo "=== mode exclusivity ==="
 run_sr --seed --update
 [ "$RC" -eq 2 ] && ok "--seed with --update is a config error" || bad "exclusivity" "rc=$RC out=$OUT"

--- a/skills/size-ratchet/tests/seed.test.sh
+++ b/skills/size-ratchet/tests/seed.test.sh
@@ -134,6 +134,22 @@ else
   ok "no self-row for an excluded baseline"
 fi
 
+echo "=== the seeded write stays inside the repository ==="
+R="$TMP/contained"
+mkdir -p "$R" "$TMP/outside-target"
+git -C "$R" -c init.defaultBranch=main init -q
+git -C "$R" config user.email test@example.com
+git -C "$R" config user.name test
+mkfile big.txt 15
+ln -s "$TMP/outside-target" "$R/policy"
+git -C "$R" add -A
+OUT=""; RC=0
+OUT="$(cd "$R" && SIZE_RATCHET_THRESHOLD=10 "$SR" --seed --baseline policy/base.tsv 2>&1)" || RC=$?
+[ "$RC" -eq 2 ] && case "$OUT" in *"outside the repository"*) true ;; *) false ;; esac \
+  && ok "--seed refuses a baseline path resolving outside the repo" \
+  || bad "containment refusal" "rc=$RC out=$OUT"
+[ ! -e "$TMP/outside-target/base.tsv" ] && ok "nothing was written outside" || bad "outside write" "$(ls "$TMP/outside-target")"
+
 echo "=== mode exclusivity ==="
 run_sr --seed --update
 [ "$RC" -eq 2 ] && ok "--seed with --update is a config error" || bad "exclusivity" "rc=$RC out=$OUT"

--- a/skills/size-ratchet/tests/seed.test.sh
+++ b/skills/size-ratchet/tests/seed.test.sh
@@ -166,6 +166,21 @@ OUT="$(cd "$R" && SIZE_RATCHET_THRESHOLD=10 "$SR" --seed --baseline base-link 2>
   || bad "symlink destination refusal" "rc=$RC out=$OUT"
 [ -z "$(ls -A "$TMP/outside-dest")" ] && ok "the symlink target stays untouched" || bad "symlink target" "$(ls "$TMP/outside-dest")"
 
+echo "=== a baseline aliasing the exclusion list refuses ==="
+R="$TMP/alias"
+mkdir -p "$R/tools"
+git -C "$R" -c init.defaultBranch=main init -q
+git -C "$R" config user.email test@example.com
+git -C "$R" config user.name test
+mkfile big.txt 15
+git -C "$R" add -A
+OUT=""; RC=0
+OUT="$(cd "$R" && SIZE_RATCHET_THRESHOLD=10 "$SR" --seed --baseline tools/shared.tsv --excludes tools/shared.tsv 2>&1)" || RC=$?
+[ "$RC" -eq 2 ] && case "$OUT" in *"same path"*) true ;; *) false ;; esac \
+  && ok "--seed refuses a baseline aliasing the exclusion list" \
+  || bad "alias refusal" "rc=$RC out=$OUT"
+[ ! -e "$R/tools/shared.tsv" ] && ok "the shared path stays unwritten" || bad "alias write" "$(cat "$R/tools/shared.tsv")"
+
 echo "=== mode exclusivity ==="
 run_sr --seed --update
 [ "$RC" -eq 2 ] && ok "--seed with --update is a config error" || bad "exclusivity" "rc=$RC out=$OUT"

--- a/skills/size-ratchet/tests/seed.test.sh
+++ b/skills/size-ratchet/tests/seed.test.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Pins for --seed's bootstrap contract (vstack #1398 / VST-328): the FIRST
+# baseline comes from the gate's own collector — exact counts, class-aware
+# thresholds, excludes honored, LC_ALL=C order, a self-row when the file
+# outgrows its own threshold — and ONLY the first: a baseline with rows
+# refuses, because a live ratchet only moves down.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
+SR="$SKILL_DIR/scripts/size-ratchet"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+unset SIZE_RATCHET_THRESHOLD SIZE_RATCHET_CLASSES SIZE_RATCHET_BASELINE SIZE_RATCHET_EXCLUDES SIZE_RATCHET_SETTINGS_FILE 2>/dev/null || true
+
+PASS=0
+FAIL=0
+ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
+
+mkfile() { # PATH LINES
+  mkdir -p "$R/$(dirname "$1")"
+  awk -v n="$2" 'BEGIN { for (i = 1; i <= n; i++) print "line " i }' >"$R/$1"
+}
+
+run_sr() { # [args...] — run in $R at threshold 10, tests class 20; sets OUT and RC
+  OUT=""
+  RC=0
+  OUT="$(cd "$R" && SIZE_RATCHET_THRESHOLD=10 SIZE_RATCHET_CLASSES='tests/*=20' "$SR" "$@" 2>&1)" || RC=$?
+}
+
+echo "=== --seed writes the first baseline from the collector ==="
+R="$TMP/seed"
+mkdir -p "$R/tools"
+git -C "$R" -c init.defaultBranch=main init -q
+git -C "$R" config user.email test@example.com
+git -C "$R" config user.name test
+mkfile big-b.txt 25
+mkfile big-a.txt 12
+mkfile small.txt 5
+mkfile tests/suite-ok.sh 15
+mkfile tests/suite-big.sh 30
+mkfile skipped.txt 40
+printf 'skipped.txt\tdeliberately unbounded fixture\n' >"$R/tools/size-ratchet-excludes"
+git -C "$R" add -A
+
+run_sr --seed
+[ "$RC" -eq 0 ] && ok "--seed exits 0 on a fresh repo" || bad "--seed exit" "rc=$RC out=$OUT"
+expected="$(printf 'big-a.txt\t12\nbig-b.txt\t25\ntests/suite-big.sh\t30\n')"
+actual="$(cat "$R/tools/size-ratchet-baseline.tsv" 2>/dev/null || echo MISSING)"
+[ "$actual" = "$expected" ] && ok "rows are exact counts, class-aware, excludes honored, sorted" \
+  || bad "seeded rows" "$(printf 'expected:\n%s\ngot:\n%s' "$expected" "$actual")"
+
+git -C "$R" add -A
+run_sr
+[ "$RC" -eq 0 ] && ok "the seeded repo passes the plain check" || bad "post-seed check" "rc=$RC out=$OUT"
+
+echo "=== --seed refuses a live baseline ==="
+before="$(cat "$R/tools/size-ratchet-baseline.tsv")"
+run_sr --seed
+[ "$RC" -eq 2 ] && ok "--seed on a populated baseline is a config error" || bad "refusal rc" "rc=$RC out=$OUT"
+case "$OUT" in
+  *"3 row(s)"*) ok "the refusal names the row count" ;;
+  *) bad "refusal names count" "$OUT" ;;
+esac
+after="$(cat "$R/tools/size-ratchet-baseline.tsv")"
+[ "$before" = "$after" ] && ok "the refused baseline is byte-identical" || bad "refusal wrote" "$after"
+
+echo "=== the baseline that outgrows its own threshold seeds its self-row ==="
+R="$TMP/selfrow"
+mkdir -p "$R/tools"
+git -C "$R" -c init.defaultBranch=main init -q
+git -C "$R" config user.email test@example.com
+git -C "$R" config user.name test
+for i in $(seq 1 12); do mkfile "off-$i.txt" 15; done
+git -C "$R" add -A
+run_sr --seed
+[ "$RC" -eq 0 ] && ok "--seed exits 0 with a self-row fixture" || bad "self-row seed exit" "rc=$RC out=$OUT"
+rows="$(wc -l <"$R/tools/size-ratchet-baseline.tsv" | tr -d ' ')"
+selfrow="$(grep -F 'tools/size-ratchet-baseline.tsv' "$R/tools/size-ratchet-baseline.tsv" || echo MISSING)"
+[ "$selfrow" = "$(printf 'tools/size-ratchet-baseline.tsv\t%s' "$rows")" ] \
+  && ok "the self-row carries the final length ($rows)" || bad "self-row" "rows=$rows selfrow=$selfrow"
+git -C "$R" add -A
+run_sr
+[ "$RC" -eq 0 ] && ok "the committed baseline passes its own gate" || bad "self-row post-check" "rc=$RC out=$OUT"
+
+echo "=== mode exclusivity ==="
+run_sr --seed --update
+[ "$RC" -eq 2 ] && ok "--seed with --update is a config error" || bad "exclusivity" "rc=$RC out=$OUT"
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/skills/size-ratchet/tests/settings-and-config.test.sh
+++ b/skills/size-ratchet/tests/settings-and-config.test.sh
@@ -300,7 +300,7 @@ else
   chmod 000 "$R/vstack.settings.toml"
   run_raw || true
   [ "$RC" -eq 2 ] && case "$OUT" in *"vstack.settings.toml: unreadable while resolving a setting"*) true ;; *) false ;; esac \
-    && ok "an unreadable settings file is exit 2 (falling through would have read the built-in 1000)" \
+    && ok "an unreadable settings file is exit 2 (falling through would have read the built-in 400)" \
     || bad "an unreadable settings file is exit 2" "rc=$RC out=$OUT"
   chmod 600 "$R/vstack.settings.toml"
   run_raw || true
@@ -313,7 +313,7 @@ else
   chmod 000 "$R/.env"
   run_raw || true
   [ "$RC" -eq 2 ] && case "$OUT" in *".env: unreadable while resolving a setting"*) true ;; *) false ;; esac \
-    && ok "an unreadable .env is exit 2 (falling through would have read the built-in 1000)" \
+    && ok "an unreadable .env is exit 2 (falling through would have read the built-in 400)" \
     || bad "an unreadable .env is exit 2" "rc=$RC out=$OUT"
   chmod 600 "$R/.env"
   run_raw || true

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -156,7 +156,7 @@ skills/second-opinion/scripts/second-opinion	2506
 skills/second-opinion/tests/cli-failure-gate.test.sh	1211
 skills/second-opinion/tests/lane-scratch-durability.test.sh	999
 skills/second-opinion/tests/review-dual-model.test.sh	1516
-skills/size-ratchet/scripts/size-ratchet	677
+skills/size-ratchet/scripts/size-ratchet	731
 skills/worktree/scripts/worktree	4077
 skills/worktree/scripts/worktree-session-guard	1194
 skills/worktree/tests/worktree_session_guard.sh	1284

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -156,7 +156,7 @@ skills/second-opinion/scripts/second-opinion	2506
 skills/second-opinion/tests/cli-failure-gate.test.sh	1211
 skills/second-opinion/tests/lane-scratch-durability.test.sh	999
 skills/second-opinion/tests/review-dual-model.test.sh	1516
-skills/size-ratchet/scripts/size-ratchet	774
+skills/size-ratchet/scripts/size-ratchet	777
 skills/worktree/scripts/worktree	4077
 skills/worktree/scripts/worktree-session-guard	1194
 skills/worktree/tests/worktree_session_guard.sh	1284

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -156,7 +156,7 @@ skills/second-opinion/scripts/second-opinion	2506
 skills/second-opinion/tests/cli-failure-gate.test.sh	1211
 skills/second-opinion/tests/lane-scratch-durability.test.sh	999
 skills/second-opinion/tests/review-dual-model.test.sh	1516
-skills/size-ratchet/scripts/size-ratchet	777
+skills/size-ratchet/scripts/size-ratchet	790
 skills/worktree/scripts/worktree	4077
 skills/worktree/scripts/worktree-session-guard	1194
 skills/worktree/tests/worktree_session_guard.sh	1284

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -156,7 +156,7 @@ skills/second-opinion/scripts/second-opinion	2506
 skills/second-opinion/tests/cli-failure-gate.test.sh	1211
 skills/second-opinion/tests/lane-scratch-durability.test.sh	999
 skills/second-opinion/tests/review-dual-model.test.sh	1516
-skills/size-ratchet/scripts/size-ratchet	743
+skills/size-ratchet/scripts/size-ratchet	755
 skills/worktree/scripts/worktree	4077
 skills/worktree/scripts/worktree-session-guard	1194
 skills/worktree/tests/worktree_session_guard.sh	1284

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -156,7 +156,7 @@ skills/second-opinion/scripts/second-opinion	2506
 skills/second-opinion/tests/cli-failure-gate.test.sh	1211
 skills/second-opinion/tests/lane-scratch-durability.test.sh	999
 skills/second-opinion/tests/review-dual-model.test.sh	1516
-skills/size-ratchet/scripts/size-ratchet	755
+skills/size-ratchet/scripts/size-ratchet	769
 skills/worktree/scripts/worktree	4077
 skills/worktree/scripts/worktree-session-guard	1194
 skills/worktree/tests/worktree_session_guard.sh	1284

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -156,7 +156,7 @@ skills/second-opinion/scripts/second-opinion	2506
 skills/second-opinion/tests/cli-failure-gate.test.sh	1211
 skills/second-opinion/tests/lane-scratch-durability.test.sh	999
 skills/second-opinion/tests/review-dual-model.test.sh	1516
-skills/size-ratchet/scripts/size-ratchet	731
+skills/size-ratchet/scripts/size-ratchet	743
 skills/worktree/scripts/worktree	4077
 skills/worktree/scripts/worktree-session-guard	1194
 skills/worktree/tests/worktree_session_guard.sh	1284

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -156,7 +156,7 @@ skills/second-opinion/scripts/second-opinion	2506
 skills/second-opinion/tests/cli-failure-gate.test.sh	1211
 skills/second-opinion/tests/lane-scratch-durability.test.sh	999
 skills/second-opinion/tests/review-dual-model.test.sh	1516
-skills/size-ratchet/scripts/size-ratchet	790
+skills/size-ratchet/scripts/size-ratchet	791
 skills/worktree/scripts/worktree	4077
 skills/worktree/scripts/worktree-session-guard	1194
 skills/worktree/tests/worktree_session_guard.sh	1284

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -156,7 +156,7 @@ skills/second-opinion/scripts/second-opinion	2506
 skills/second-opinion/tests/cli-failure-gate.test.sh	1211
 skills/second-opinion/tests/lane-scratch-durability.test.sh	999
 skills/second-opinion/tests/review-dual-model.test.sh	1516
-skills/size-ratchet/scripts/size-ratchet	769
+skills/size-ratchet/scripts/size-ratchet	774
 skills/worktree/scripts/worktree	4077
 skills/worktree/scripts/worktree-session-guard	1194
 skills/worktree/tests/worktree_session_guard.sh	1284


### PR DESCRIPTION
Installing size-ratchet no longer leaves a gate that can never be turned on: `--seed` writes the FIRST baseline from the same collection pass the gate itself trusts — exact counts, class-aware thresholds, excludes honored, LC_ALL=C order, and a self-row when the baseline outgrows its own threshold (counted at the final length, so the very next run over the committed file is clean). It refuses a baseline that already has rows: the ratchet is live there, and growth stays a reviewed hand-edit. `--seed`/`--update` are mutually exclusive; the sparse-checkout index-only guard applies to both. Ten pins in seed.test.sh, red-first (this train seeded drovr/memsira/hyprtrade by hand — exactly this procedure, now shipped). The two stale built-in-1000 test message strings read 400.

Closes VST-328
Closes #1398

https://claude.ai/code/session_012epxJEzGqT7q3qcFhdZUt5