### PR TITLE
feat(growth-guards): the pre-commit chain runs preflight --staged beside size-ratchet (VST-310)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- growth-guards: the pre-commit shim chain runs `preflight --staged` when
+  that skill is installed beside it — a human committing outside any harness
+  gets the deterministic checks CI would report, first; a repository's first
+  commit skips it with a note (VST-310).
+
 - settings templates: every key's comment condensed to one-line intent plus
   landmines (922 → 545 lines across the root and skill templates, zero value
   changes); refresh's seeded-comment rewrite propagates the terse form to

--- a/skills/growth-guards/README.md
+++ b/skills/growth-guards/README.md
@@ -63,10 +63,11 @@ status still decides.
 `pre-commit` runs `scripts/pre-commit`, which judges ONE commit snapshot —
 staged content, and tracked configuration read from the index, so an unstaged
 edit cannot switch a check off for content the commit keeps: `size-ratchet
---staged` when that skill is installed beside this one, then the
-`growth-guards` batch over the staged content, then the repo-local entry named
-by `GROWTH_GUARDS_PRE_COMMIT_LOCAL` (repo-root-relative executable; empty
-means none). `commit-msg` runs `scripts/commit-msg` on git's message file.
+--staged` and `preflight --staged` when those skills are installed beside
+this one (a repository's first commit skips preflight with a note — nothing
+to diff against), then the `growth-guards` batch over the staged content,
+then the repo-local entry named by `GROWTH_GUARDS_PRE_COMMIT_LOCAL`
+(repo-root-relative executable; empty means none). `commit-msg` runs `scripts/commit-msg` on git's message file.
 Every step runs before the verdict, so one attempt reports every blocker.
 
 The shims BLOCK, and fail closed, on the family's exit contract: `1` for a

--- a/skills/growth-guards/SKILL.md
+++ b/skills/growth-guards/SKILL.md
@@ -49,9 +49,11 @@ file from a gate.
 ## Git hooks
 
 `scripts/install-git-hooks [--repo PATH]` writes real `.git/hooks` shims —
-`pre-commit` runs the chain (`size-ratchet --staged` when that skill is
-installed beside this one, the batch over staged content, then the
-repo-root-relative executable named by `GROWTH_GUARDS_PRE_COMMIT_LOCAL`),
+`pre-commit` runs the chain (`size-ratchet --staged` and `preflight --staged`
+when those skills are installed beside this one — a first commit skips
+preflight with a note, having no base to diff — the batch over staged
+content, then the repo-root-relative executable named by
+`GROWTH_GUARDS_PRE_COMMIT_LOCAL`),
 `commit-msg` runs this family's message gate. They BLOCK on the family's exit
 contract, fail closed on a guard that could not run, and `git commit
 --no-verify` is the deliberate bypass. `vstack add` and `vstack refresh` run

--- a/skills/growth-guards/scripts/pre-commit
+++ b/skills/growth-guards/scripts/pre-commit
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # pre-commit — the staged-scope guard chain, shaped for the git pre-commit
 # hook (the installed .git/hooks/vstack-guards shim execs it): size-ratchet
-# when the sibling skill is installed, then `growth-guards all`, then the
-# repo-local entry named by GROWTH_GUARDS_PRE_COMMIT_LOCAL.
+# and preflight when those sibling skills are installed, then
+# `growth-guards all`, then the repo-local entry named by
+# GROWTH_GUARDS_PRE_COMMIT_LOCAL.
 #
 # Every step runs before the verdict, so one commit attempt reports every
 # blocker. Aggregation fails CLOSED: exit 2 if any step could not complete,
@@ -20,8 +21,9 @@ usage() {
   cat <<'EOF'
 usage: pre-commit
 
-Runs the staged-scope guard chain: size-ratchet (when installed beside this
-skill), the growth-guards batch, then the optional repo-local entry. Takes no
+Runs the staged-scope guard chain: size-ratchet and preflight (each when
+installed beside this skill), the growth-guards batch, then the optional
+repo-local entry. Takes no
 arguments — git passes none to pre-commit. Wire it through the installed shim:
 `install-git-hooks --repo <root>`.
 
@@ -81,6 +83,24 @@ if [ -e "$SIZE_RATCHET_SKILL" ] || [ -L "$SIZE_RATCHET_SKILL" ]; then
   run_step size-ratchet "$SIZE_RATCHET" --staged
 else
   echo "=== pre-commit: size-ratchet not installed — skipped"
+fi
+
+# Same sibling contract for preflight: its --staged lanes judge the same
+# blobs, and a human committing outside any harness gets the deterministic
+# checks CI would otherwise report first.
+PREFLIGHT_SKILL="$SCRIPT_DIR/../../preflight"
+PREFLIGHT="$PREFLIGHT_SKILL/scripts/preflight"
+if [ -e "$PREFLIGHT_SKILL" ] || [ -L "$PREFLIGHT_SKILL" ]; then
+  [ -x "$PREFLIGHT" ] || gg_config_error "the preflight skill is installed at $PREFLIGHT_SKILL but $PREFLIGHT is missing or not executable — reinstall it"
+  if git rev-parse --verify --quiet HEAD >/dev/null; then
+    run_step preflight "$PREFLIGHT" --staged
+  else
+    # The very first commit has nothing to diff --staged against; blocking
+    # a repository's birth is not this chain's job.
+    echo "=== pre-commit: first commit — preflight --staged has no base; skipped"
+  fi
+else
+  echo "=== pre-commit: preflight not installed — skipped"
 fi
 
 BATCH="$SCRIPT_DIR/growth-guards"

--- a/skills/growth-guards/tests/install-git-hooks.test.sh
+++ b/skills/growth-guards/tests/install-git-hooks.test.sh
@@ -919,5 +919,47 @@ OUT=""; RC=0; OUT="$("$INSTALL" --bogus 2>&1)" || RC=$?
 OUT=""; RC=0; OUT="$("$INSTALL" --help 2>&1)" || RC=$?
 [ "$RC" -eq 0 ] && ok "--help is exit 0" || bad "--help is exit 0" "rc=$RC out=$OUT"
 
+echo "=== preflight is in the chain ==="
+R30="$(new_repo preflightchain)"
+ln -s "$SKILL_DIR/../preflight" "$R30/.agents/skills/preflight"
+install_in "$R30"
+printf 'hello\n' >"$R30/ok.txt"
+git -C "$R30" add ok.txt
+commit_in "$R30" "feat: add ok"
+[ "$RC" -eq 0 ] && ok "control: clean staged content commits with preflight installed" || bad "control: preflight clean commit" "rc=$RC out=$OUT"
+case "$OUT" in
+  *"first commit — preflight --staged has no base"*) ok "the first commit states the preflight skip instead of blocking" ;;
+  *) bad "first-commit skip stated" "out=$OUT" ;;
+esac
+printf '#!/usr/bin/env bash\necho hi\n' >"$R30/loose.sh"
+git -C "$R30" add loose.sh
+commit_in "$R30" "feat: add loose"
+[ "$RC" -ne 0 ] && ok "a staged fail-open script blocks through preflight" || bad "preflight blocks" "rc=$RC out=$OUT"
+case "$OUT" in
+  *preflight*) ok "preflight names itself in the blocked output" ;;
+  *) bad "preflight names itself" "out=$OUT" ;;
+esac
+git -C "$R30" rm -q --cached loose.sh
+rm -f "$R30/loose.sh"
+
+echo "=== a broken preflight install blocks, never skips ==="
+printf 'more\n' >"$R30/d.txt"
+git -C "$R30" add d.txt
+rm "$R30/.agents/skills/preflight"
+ln -s "$TMP/no-such-skill" "$R30/.agents/skills/preflight"
+commit_in "$R30" "feat: add d"
+[ "$RC" -ne 0 ] && ok "a dangling preflight install blocks" || bad "dangling preflight blocks" "rc=$RC out=$OUT"
+case "$OUT" in
+  *"preflight skill is installed"*) ok "the broken preflight install is named" ;;
+  *) bad "broken preflight named" "out=$OUT" ;;
+esac
+rm "$R30/.agents/skills/preflight"
+commit_in "$R30" "feat: add d"
+[ "$RC" -eq 0 ] && ok "control: an absent preflight is a stated skip" || bad "absent preflight skips" "rc=$RC out=$OUT"
+case "$OUT" in
+  *"preflight not installed — skipped"*) ok "the skip says preflight is not installed" ;;
+  *) bad "skip states preflight not installed" "out=$OUT" ;;
+esac
+
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -96,7 +96,7 @@ skills/github/scripts/lib/github-api.sh	872
 skills/github/scripts/lib/verify-lib.sh	415
 skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh	2128
 skills/growth-guards/scripts/install-git-hooks	574
-skills/growth-guards/tests/install-git-hooks.test.sh	923
+skills/growth-guards/tests/install-git-hooks.test.sh	965
 skills/iced-rs/examples/changelog/src/changelog.rs	418
 skills/iced-rs/examples/color_palette/src/main.rs	479
 skills/iced-rs/examples/custom_shader/src/scene/pipeline.rs	584


### PR DESCRIPTION
The installer half of the tool-agnostic pre-commit layer landed as VST-216's shims; this ships the runner half: the guard chain runs `preflight --staged` when that skill is installed beside growth-guards — same sibling contract as size-ratchet (installed = runs, broken install = loud config error, absent = stated skip), so a human committing outside any harness gets the deterministic checks CI would report, at the commit. A repository's first commit skips preflight with a note (nothing to diff `--staged` against — blocking a repo's birth is not this chain's job). The repo-owned extension point already exists as GROWTH_GUARDS_PRE_COMMIT_LOCAL. Four pins added to the install suite (blocks-through-preflight, broken-install named, absent-skip stated, first-commit skip stated); 174 green.

Closes VST-310
Closes #1380

https://claude.ai/code/session_012epxJEzGqT7q3qcFhdZUt5