### PR TITLE
fix(orch): reconcile-work-items requires a nonempty updatedAt on started rows

### DIFF
--- a/skills/orch/scripts/reconcile-work-items
+++ b/skills/orch/scripts/reconcile-work-items
@@ -53,8 +53,8 @@ jq -e 'type == "array" and all(.[];
     and (.state | type == "object")
     and (.state.name | type == "string")
     and (.state.type | type == "string")
-    and (.state.type != "started" or ((.updatedAt | type == "string") and .updatedAt != "")))' "$CACHE" >/dev/null 2>&1 \
-  || config_error "linear cache at $CACHE is not an array of issue rows with identifier, state.name/state.type, and a nonempty updatedAt on started rows"
+    and (.state.type != "started" or ((.updatedAt | type == "string") and (.updatedAt | test("\\S")))))' "$CACHE" >/dev/null 2>&1 \
+  || config_error "linear cache at $CACHE is not an array of issue rows with identifier, state.name/state.type, and a nonblank updatedAt on started rows"
 
 findings=0
 note() { findings=$((findings + 1)); printf '%s\n' "$1"; }

--- a/skills/orch/scripts/reconcile-work-items
+++ b/skills/orch/scripts/reconcile-work-items
@@ -52,8 +52,9 @@ jq -e 'type == "array" and all(.[];
     and (.identifier | type == "string")
     and (.state | type == "object")
     and (.state.name | type == "string")
-    and (.state.type | type == "string"))' "$CACHE" >/dev/null 2>&1 \
-  || config_error "linear cache at $CACHE is not an array of issue rows with identifier and state.name/state.type"
+    and (.state.type | type == "string")
+    and (.state.type != "started" or ((.updatedAt | type == "string") and .updatedAt != "")))' "$CACHE" >/dev/null 2>&1 \
+  || config_error "linear cache at $CACHE is not an array of issue rows with identifier, state.name/state.type, and a nonempty updatedAt on started rows"
 
 findings=0
 note() { findings=$((findings + 1)); printf '%s\n' "$1"; }

--- a/skills/orch/tests/reconcile-work-items.test.sh
+++ b/skills/orch/tests/reconcile-work-items.test.sh
@@ -117,6 +117,13 @@ OUT=""; RC=0
 OUT="$(cd "$R" && RECONCILE_GH_CLI="$TMP/gh-stub" "$RW" 2>&1)" || RC=$?
 [ "$RC" -eq 2 ] && ok "a row missing state.type is a config error" || bad "missing state.type" "rc=$RC out=$OUT"
 
+# A started row without a usable timestamp must be a config error: GNU date
+# parses an empty field as midnight today, which would quietly read as fresh.
+printf '[{"identifier":"T-1","title":"t","state":{"name":"In Progress","type":"started"},"parent":null,"description":"","updatedAt":""}]' >"$R/.cache/linear/issues.json"
+OUT=""; RC=0
+OUT="$(cd "$R" && RECONCILE_GH_CLI="$TMP/gh-stub" "$RW" 2>&1)" || RC=$?
+[ "$RC" -eq 2 ] && ok "a started row with an empty updatedAt is a config error, never fresh" || bad "empty updatedAt" "rc=$RC out=$OUT"
+
 # Missing cache: loud config error, never a clean pass.
 rm "$R/.cache/linear/issues.json"
 OUT=""; RC=0

--- a/skills/orch/tests/reconcile-work-items.test.sh
+++ b/skills/orch/tests/reconcile-work-items.test.sh
@@ -123,6 +123,14 @@ printf '[{"identifier":"T-1","title":"t","state":{"name":"In Progress","type":"s
 OUT=""; RC=0
 OUT="$(cd "$R" && RECONCILE_GH_CLI="$TMP/gh-stub" "$RW" 2>&1)" || RC=$?
 [ "$RC" -eq 2 ] && ok "a started row with an empty updatedAt is a config error, never fresh" || bad "empty updatedAt" "rc=$RC out=$OUT"
+printf '[{"identifier":"T-1","title":"t","state":{"name":"In Progress","type":"started"},"parent":null,"description":"","updatedAt":"   "}]' >"$R/.cache/linear/issues.json"
+OUT=""; RC=0
+OUT="$(cd "$R" && RECONCILE_GH_CLI="$TMP/gh-stub" "$RW" 2>&1)" || RC=$?
+[ "$RC" -eq 2 ] && ok "a whitespace-only updatedAt is a config error (GNU date parses it as midnight)" || bad "blank updatedAt" "rc=$RC out=$OUT"
+printf '[{"identifier":"T-1","title":"t","state":{"name":"In Progress","type":"started"},"parent":null,"description":""}]' >"$R/.cache/linear/issues.json"
+OUT=""; RC=0
+OUT="$(cd "$R" && RECONCILE_GH_CLI="$TMP/gh-stub" "$RW" 2>&1)" || RC=$?
+[ "$RC" -eq 2 ] && ok "a started row with no updatedAt key at all is a config error" || bad "missing updatedAt key" "rc=$RC out=$OUT"
 
 # Missing cache: loud config error, never a clean pass.
 rm "$R/.cache/linear/issues.json"


### PR DESCRIPTION
Follow-up to #1430 for the one finding deferred past its push budget (thread https://github.com/vanillagreencom/vstack/pull/1430#discussion_r-PRRT_kwDORvss6s6ZzPrj): the structural cache validation now requires a nonempty `updatedAt` on started rows. GNU `date -d ""` parses an empty field as midnight today, so a started row missing its timestamp could quietly read as fresh and let the sweep report clean; BSD date rejected the same row, so behavior also diverged across platforms. Now it is an exit-2 config error on both. One new pin (19 green).

https://claude.ai/code/session_012epxJEzGqT7q3qcFhdZUt5
