### PR TITLE
fix(ci): the ejection intake issue is reason-aware

### DIFF
--- a/.github/workflows/merge-queue-ejection-alert.yml
+++ b/.github/workflows/merge-queue-ejection-alert.yml
@@ -191,8 +191,17 @@ jobs:
           # An unidentified ejecting run must not collapse successive
           # ejections into one marker: fall back to this alert run's own id.
           marker="ejection-alert:pr-${PR_NUMBER}:run-${run_id:-alert-${GITHUB_RUN_ID}}"
-          existing="$(gh issue list --search "\"$marker\" in:body" --state open --json number --jq 'length')"
-          if [ "$create_intake_issue" = "1" ] && [ "$existing" = "0" ]; then
+          # The dedupe lookup runs only when an issue could be created: a
+          # transient Issues API failure must not kill a deliberately
+          # non-intake run under set -e.
+          if [ "$create_intake_issue" = "1" ]; then
+            existing="$(gh issue list --search "\"$marker\" in:body" --state open --json number --jq 'length')"
+            if [ "$existing" != "0" ]; then
+              echo "intake issue for $marker already open; skipping create"
+              create_intake_issue=0
+            fi
+          fi
+          if [ "$create_intake_issue" = "1" ]; then
             issue_file="$(mktemp)"
             cat > "$issue_file" <<BODY
           PR #${PR_NUMBER} was ejected from the merge queue (reason: \`${DEQUEUE_REASON}\`); its auto-merge arm is dropped and it will sit unmerged until re-armed.
@@ -209,6 +218,4 @@ jobs:
             gh issue create \
               --title "merge-queue ejection: PR #${PR_NUMBER} — ${run_name:-failing required check}" \
               --body-file "$issue_file"
-          else
-            echo "intake issue for $marker already open; skipping create"
           fi

--- a/.github/workflows/merge-queue-ejection-alert.yml
+++ b/.github/workflows/merge-queue-ejection-alert.yml
@@ -179,18 +179,20 @@ jobs:
 
           # Intake issue (deduped per PR + ejection run), failure-shaped
           # reasons only: a deliberate dequeue or a routine queue
-          # re-evaluation is not triage work.
+          # re-evaluation is not triage work. Guarded by a flag, not an
+          # early exit, so steps appended later still run for every reason.
+          create_intake_issue=1
           case "${DEQUEUE_REASON}" in
             MANUAL|MERGE_CONFLICT)
               echo "reason ${DEQUEUE_REASON}: deliberate dequeue / queue re-evaluation — comment posted, no intake issue"
-              exit 0
+              create_intake_issue=0
               ;;
           esac
           # An unidentified ejecting run must not collapse successive
           # ejections into one marker: fall back to this alert run's own id.
           marker="ejection-alert:pr-${PR_NUMBER}:run-${run_id:-alert-${GITHUB_RUN_ID}}"
           existing="$(gh issue list --search "\"$marker\" in:body" --state open --json number --jq 'length')"
-          if [ "$existing" = "0" ]; then
+          if [ "$create_intake_issue" = "1" ] && [ "$existing" = "0" ]; then
             issue_file="$(mktemp)"
             cat > "$issue_file" <<BODY
           PR #${PR_NUMBER} was ejected from the merge queue (reason: \`${DEQUEUE_REASON}\`); its auto-merge arm is dropped and it will sit unmerged until re-armed.

--- a/.github/workflows/merge-queue-ejection-alert.yml
+++ b/.github/workflows/merge-queue-ejection-alert.yml
@@ -10,6 +10,12 @@
 #      GH→Linear creation sync mirrors it) instead of vanishing.
 # One issue per PR per ejection run id; re-runs and duplicate deliveries
 # de-duplicate against the existing open issue.
+#
+# The intake issue is REASON-AWARE: MANUAL is a deliberate dequeue (the
+# dequeue-push-rearm flow) and MERGE_CONFLICT is routine queue re-evaluation
+# after a sibling merged — both get the PR comment (the dropped arm is still
+# real) but no tracker issue. Only failure-shaped reasons (CI_FAILURE and
+# anything unrecognized, fail-closed) enter the triage queue.
 name: Merge queue ejection alert
 
 # pull_request_target, not pull_request: a fork PR's dequeue would hand a
@@ -171,7 +177,15 @@ jobs:
           BODY
           gh pr comment "$PR_NUMBER" --body-file "$body_file"
 
-          # Intake issue (deduped per PR + ejection run).
+          # Intake issue (deduped per PR + ejection run), failure-shaped
+          # reasons only: a deliberate dequeue or a routine queue
+          # re-evaluation is not triage work.
+          case "${DEQUEUE_REASON}" in
+            MANUAL|MERGE_CONFLICT)
+              echo "reason ${DEQUEUE_REASON}: deliberate dequeue / queue re-evaluation — comment posted, no intake issue"
+              exit 0
+              ;;
+          esac
           # An unidentified ejecting run must not collapse successive
           # ejections into one marker: fall back to this alert run's own id.
           marker="ejection-alert:pr-${PR_NUMBER}:run-${run_id:-alert-${GITHUB_RUN_ID}}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@
   the step, so a fresh worktree in a pnpm workspace no longer starts dirty
   with a stray `package-lock.json`; a failed npm install names its log
   instead of vanishing (VST-340).
+- merge-queue ejection alert: the intake issue is reason-aware — MANUAL
+  (deliberate dequeue) and MERGE_CONFLICT (routine queue re-evaluation) get
+  the PR comment only; failure-shaped reasons (CI_FAILURE, plus anything
+  unrecognized, fail-closed) still file into triage. Cuts ~85% of the
+  ejection-issue noise the GH→Linear sync was mirroring.
 
 - cli: A shared config is read with the parser its OWN harness uses, never the
   one its file extension suggests. OpenCode hands `opencode.json`,


### PR DESCRIPTION
The merge-queue ejection alert filed an intake issue for EVERY non-MERGE dequeue. Today that produced 23 issues, ~85% noise: 13 MANUAL (the deliberate dequeue-push-rearm flow), 6 MERGE_CONFLICT (routine re-evaluation as siblings merged) — each mirrored into Linear by the creation sync. The PR comment (the dropped-arm warning) still posts for every non-MERGE reason; the intake issue now files only for failure-shaped reasons — CI_FAILURE plus anything unrecognized, fail-closed toward filing.

https://claude.ai/code/session_012epxJEzGqT7q3qcFhdZUt5