### PR TITLE
perf(codex): Required Skills load on use, not upfront; waiters run as one blocking call

### DIFF
--- a/cli/src/harness/codex.rs
+++ b/cli/src/harness/codex.rs
@@ -111,7 +111,7 @@ fn required_skills_section(skills: &[(String, String)], global: bool) -> String 
 
     let mut section = String::from("## Required Skills\n\n");
     section.push_str(
-        "These skills govern this agent's workflows. Load a skill's SKILL.md at the moment a task first touches its domain — do not pre-read the list upfront. Prefer the listed local path when it exists; if a path is missing, report the missing install instead of substituting a stale global path.\n\n",
+        "These skills govern this agent's workflows. Open a skill's SKILL.md at the moment a task first touches its domain — do not open every listed SKILL.md at startup. Prefer the listed local path when it exists; if a path is missing, report the missing install instead of substituting a stale global path.\n\n",
     );
     for (name, description) in skills {
         section.push_str(&format!(

--- a/cli/src/harness/codex.rs
+++ b/cli/src/harness/codex.rs
@@ -111,7 +111,7 @@ fn required_skills_section(skills: &[(String, String)], global: bool) -> String 
 
     let mut section = String::from("## Required Skills\n\n");
     section.push_str(
-        "Load these skills before using their workflows. Prefer the listed local path when it exists; if a path is missing, report the missing install instead of substituting a stale global path.\n\n",
+        "These skills govern this agent's workflows. Load a skill's SKILL.md at the moment a task first touches its domain — do not pre-read the list upfront. Prefer the listed local path when it exists; if a path is missing, report the missing install instead of substituting a stale global path.\n\n",
     );
     for (name, description) in skills {
         section.push_str(&format!(

--- a/skills/orch/references/codex-runtime.md
+++ b/skills/orch/references/codex-runtime.md
@@ -14,7 +14,7 @@ rg -n '\x60vstack refresh\x60' skills/
 
 Rewrites:
 
-- Polling loops → the orch waiters `ci-wait`, `approval-wait`, `queue-wait`.
+- Polling loops → the orch waiters `ci-wait`, `approval-wait`, `queue-wait`. Launch a waiter ONCE as a single blocking command and stay on it until it returns — when the harness `exec` yields early, keep issuing `wait` at the harness's maximum duration against the same command rather than re-running the waiter or slicing the wait into short polls; every slice burns a model turn on a state that has not changed.
 - Multi-item sweeps → one simple command per item.
 - Derived values → helper scripts (`git-context`, `workflow-state`), never substitution.
 - File writes → harness file tools or `apply_patch`, never redirection.


### PR DESCRIPTION
## Codex agents stop paying for work they don't use

Root-caused from the orch-drill baseline delta (codex 26m56s vs claude 8m40s on comparable drills; full breakdown in the drill artifacts):

- **Required Skills load on use.** The generated `.codex/agents/*.toml` section said "Load these skills before using their workflows" — Codex has no skill-loading mechanism, so dev agents paged all six listed SKILL.md files by hand at the start of every round (~60s and 8 of 39 exec calls in the measured round; the Claude arm read exactly one doc via its on-demand mechanism). The wording now instructs loading a skill's SKILL.md at the moment a task first touches its domain, never pre-reading the list.
- **Waiters run as one blocking call.** An 82-second `ci-wait` cost the Codex orchestrator six model round-trips of ~11-second exec slices (the Claude arm: one Bash call). The codex runtime reference now pins waiters to a single blocking launch, re-issuing `wait` at the harness's maximum duration instead of slicing.

The third lever from the same investigation — Codex agent `model_reasoning_effort` xhigh → high — is workspace config (`vstack-local.toml` `[agent-frontmatter.codex]`), already applied locally and reaching consumers on their next refresh; no tracked change.

## Verification

`cargo test`: all suites green (973 passed). The wording string has no other reference sites (grep across cli/src, skills/, README, AGENTS.md).

https://claude.ai/code/session_01EwxSRv8oy1NxoQm66WKa4J
