### PR TITLE
fix(size-ratchet): absorb the seven fixes from drovr's fork (DRO-201)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 ## Unreleased
 
+- size-ratchet: seven fixes absorbed from the forked copy drovr has been
+  running (DRO-201), each with its own regression pin.
+  `--update` converges in ONE run: the baseline's own row is reconciled
+  against the file it is about to become, so a self-referential row no
+  longer contradicts the rewrite that just produced it and fails the very
+  next check.
+  A broken gate exits 2, never 1. The repository `cd`, every scratch-file
+  write, the baseline working copy, the counts sort and the `--update`
+  sort pipeline route through the collection-error path instead of dying
+  under `set -e` with the failing tool's own status — 1 is the code
+  reserved for "a size violation was measured", so a full or read-only
+  TMPDIR reached callers as a failing repository rather than a broken gate.
+  A tracked exclusion list the worktree does not carry is read from the
+  index, as the baseline already was: a sparse or fresh checkout ran with
+  ZERO exclusions and reported violations against the vendored and
+  generated files the tracked policy exempts.
+  Index presence is probed with `git ls-files -s` and its status is
+  checked. `git cat-file -t` exits 128 both for "not in the index" and for
+  a corrupt or unavailable object, so with the status discarded a broken
+  read looked exactly like an untracked file and the gate fell through to
+  an empty baseline — losing every frozen row and any stale row that
+  should have failed the run.
+  A supplied-but-empty `--baseline` / `--excludes` is a config error;
+  automation whose path came out of a bad substitution used to check the
+  repository default and pass.
+  `--update` stages its replacement beside the baseline instead of in
+  `$TMPDIR`, so the final step is a real `rename(2)` rather than a
+  cross-filesystem copy that can leave the tracked baseline truncated
+  mid-write; the replaced file keeps its umask-implied mode.
+  `--` moves before the pattern in the remaining greps (and before the
+  mode in `chmod`) — non-permuting BSD/POSIX option scanning stops at the
+  first operand, so the trailing form failed every invocation on macOS.
+
 - pi-agents-tmux: the idle-stall watchdog skips panes with a pending
   rate-limit retry instead of condemning a merely-throttled agent as a
   post-compaction stall; its synthetic summary no longer asserts a cause it

--- a/skills/size-ratchet/README.md
+++ b/skills/size-ratchet/README.md
@@ -132,7 +132,10 @@ pattern<TAB>reason
 
 The pattern is a shell glob matched against the full repo-relative path
 (`*` crosses `/`). Blank lines and `#` comments are ignored; a pattern
-without a reason is a config error. Typical entries:
+without a reason is a config error. A tracked list the worktree does not
+carry (sparse or partial checkout) is read from the index, like the
+baseline, and gets the same row validation — the exclusions hold on partial
+trees rather than collapsing to none. Typical entries:
 
 ```
 Cargo.lock	lockfile — generated, size is not a design signal
@@ -157,7 +160,9 @@ never sourced). Only an ABSENT source is skipped: a source that exists but
 is unusable — unreadable, a directory, FIFO, socket or device, or a symlink
 that does not resolve — is a config error (exit 2), never a fall-through to
 the next layer; `/dev/null` forces the built-in defaults. `--baseline` /
-`--excludes` flags override every source for the paths. All relative paths
+`--excludes` flags override every source for the paths; supplying one with
+an empty value (`--baseline=`, `--baseline ""`) is a config error, never a
+silent fall back to the default path. All relative paths
 are
 repo-root-relative; the script `cd`s to `git rev-parse --show-toplevel`
 before resolving anything.

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -472,7 +472,9 @@ elif read_index_file_mode "$BASELINE_FILE"; [ -n "$INDEX_FILE_MODE" ]; then
   # The flag means "no worktree copy to rewrite", which is what --update
   # needs to know; staged mode reads the index with the file present too.
   [ -f "$BASELINE_FILE" ] || BASELINE_FROM_INDEX=1
-  git show ":$BASELINE_FILE" >"$TMP/baseline.tsv" || config_error "failed to read tracked baseline from the index: $BASELINE_FILE"
+  # The presence probe above already proved the index entry exists, so a
+  # failing read here is runtime (I/O, corrupt object) — never config.
+  git show ":$BASELINE_FILE" >"$TMP/baseline.tsv" || collection_error "failed to read tracked baseline from the index: $BASELINE_FILE"
   grep_status=0
   bad_rows="$(grep -nEv -- "^[^${TAB}]+${TAB}[1-9][0-9]*\$" "$TMP/baseline.tsv")" || grep_status=$?
   [ "$grep_status" -le 1 ] || collection_error "could not validate $BASELINE_FILE (index copy) (grep exit $grep_status)"
@@ -792,7 +794,11 @@ if [ "$MODE" = "update" ]; then
     # truncated or missing, defeating the atomic-replace intent stated above. A
     # sibling temp is on the destination's own filesystem by construction, so
     # the final step is a real rename(2).
-    STAGED_BASELINE="$(mktemp -- "$(dirname -- "$BASELINE_FILE")/.size-ratchet-baseline.XXXXXX")" || collection_error "could not create a staging file beside $BASELINE_FILE — update aborted, baseline unchanged"
+    case "$BASELINE_FILE" in
+      */*) baseline_dir="${BASELINE_FILE%/*}" ;;
+      *) baseline_dir=. ;;
+    esac
+    STAGED_BASELINE="$(mktemp -- "$baseline_dir/.size-ratchet-baseline.XXXXXX")" || collection_error "could not create a staging file beside $BASELINE_FILE — update aborted, baseline unchanged"
     # rename(2) carries the SOURCE file's mode, and mktemp creates at 0600 — so
     # without this the replace would silently narrow a world-readable tracked
     # file. 0666 masked by the umask is exactly the mode the plain shell

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -90,8 +90,14 @@ collection_error() {
 count_nonempty_lines() { # FILE — count on stdout; loud exit if grep cannot read it
   # grep -c exits 1 on zero matches but still prints 0 — only exit >= 2
   # (execution/read failure) means the count is unknown.
+  #
+  # `--` goes BEFORE the pattern at every grep call site here. Option scanning
+  # stops at the first non-option argument, which for grep is the PATTERN, so a
+  # trailing `--` is read as a literal filename by any non-permuting (BSD/POSIX)
+  # grep and the invocation fails on a clean repo. Leading `--` is valid under
+  # GNU, BSD and POSIX alike.
   local n status=0
-  n="$(grep -c . -- "$1")" || status=$?
+  n="$(grep -c -- . "$1")" || status=$?
   [ "$status" -le 1 ] || collection_error "could not count lines in $1 (grep exit $status)"
   printf '%s\n' "$n"
 }
@@ -99,6 +105,13 @@ count_nonempty_lines() { # FILE — count on stdout; loud exit if grep cannot re
 MODE="check"
 BASELINE_OPT=""
 EXCLUDES_OPT=""
+# Whether the flag was SUPPLIED is tracked apart from its value: testing the
+# value alone made `--baseline=` and `--baseline ""` indistinguishable from an
+# absent flag, so automation passing a path that came out of a bad substitution
+# silently checked the repository default and passed. Supplied-but-empty is a
+# config error below.
+BASELINE_SET=0
+EXCLUDES_SET=0
 while [ $# -gt 0 ]; do
   case "$1" in
     --update)
@@ -113,14 +126,22 @@ while [ $# -gt 0 ]; do
       [ $# -ge 2 ] || config_error "--baseline requires a path"
       shift
       BASELINE_OPT="$1"
+      BASELINE_SET=1
       ;;
-    --baseline=*) BASELINE_OPT="${1#--baseline=}" ;;
+    --baseline=*)
+      BASELINE_OPT="${1#--baseline=}"
+      BASELINE_SET=1
+      ;;
     --excludes)
       [ $# -ge 2 ] || config_error "--excludes requires a path"
       shift
       EXCLUDES_OPT="$1"
+      EXCLUDES_SET=1
       ;;
-    --excludes=*) EXCLUDES_OPT="${1#--excludes=}" ;;
+    --excludes=*)
+      EXCLUDES_OPT="${1#--excludes=}"
+      EXCLUDES_SET=1
+      ;;
     -h | --help)
       usage
       exit 0
@@ -133,10 +154,20 @@ done
 
 # All configured paths (settings file, baseline, excludes) are repo-relative.
 REPO_ROOT="$(git rev-parse --show-toplevel)" || config_error "not inside a git repository"
-cd "$REPO_ROOT"
+# Every collection-path operation below routes its failure through
+# config_error/collection_error. Unguarded, `set -e` killed the script with the
+# failing tool's own status — usually 1, which this script's contract reserves
+# for "a size violation was measured", so a broken environment reached callers
+# as a failing gate rather than a broken one.
+cd "$REPO_ROOT" || config_error "could not enter the repository root $REPO_ROOT"
 
 TMP="$(mktemp -d "${TMPDIR:-/tmp}/size-ratchet.XXXXXX")" || config_error "could not create a temporary directory"
-trap 'rm -rf -- "$TMP"' EXIT
+# STAGED_BASELINE is the --update replacement file, created NEXT TO the baseline
+# (below) so its rename into place is a same-filesystem rename(2). It is cleaned
+# up here because every abort between its creation and the rename must leave no
+# debris in a tracked directory.
+STAGED_BASELINE=""
+trap 'rm -rf -- "$TMP"; [ -z "$STAGED_BASELINE" ] || rm -f -- "$STAGED_BASELINE"' EXIT
 # Not in update mode: it rewrites the worktree policy, and the settings that
 # name WHICH file it rewrites have to come from the same place.
 if [ "$STAGED" -eq 1 ] && [ "$MODE" != "update" ]; then
@@ -201,12 +232,14 @@ while [ -n "$classes_rest" ]; do
 done
 [ "$CLASS_COUNT" -eq 0 ] || CLASSES_NOTE=", classes $CLASSES_NOTE"
 
-if [ -n "$BASELINE_OPT" ]; then
+if [ "$BASELINE_SET" = "1" ]; then
+  [ -n "$BASELINE_OPT" ] || config_error "--baseline was given an empty path; pass a real path or omit the flag to use the configured default"
   BASELINE_FILE="$BASELINE_OPT"
 else
   BASELINE_FILE="$(sr_setting SIZE_RATCHET_BASELINE "tools/size-ratchet-baseline.tsv")" || exit 2
 fi
-if [ -n "$EXCLUDES_OPT" ]; then
+if [ "$EXCLUDES_SET" = "1" ]; then
+  [ -n "$EXCLUDES_OPT" ] || config_error "--excludes was given an empty path; pass a real path or omit the flag to use the configured default"
   EXCLUDES_FILE="$EXCLUDES_OPT"
 else
   EXCLUDES_FILE="$(sr_setting SIZE_RATCHET_EXCLUDES "tools/size-ratchet-excludes")" || exit 2
@@ -263,28 +296,86 @@ staged_policy_state() { # PATH
   # --update REWRITES the worktree policy file, so it must read that copy or
   # the rewrite would drop every unstaged hand-edit from it.
   [ "$MODE" != "update" ] || return 1
-  [ "$(git cat-file -t ":$1" 2>/dev/null)" = "blob" ] && return 0
+  read_index_file_mode "$1"
+  [ -z "$INDEX_FILE_MODE" ] || return 0
   git cat-file -e "HEAD:$1" 2>/dev/null && return 2
   return 1
 }
 
+# Index presence is probed with `git ls-files`, not by comparing `git cat-file
+# -t` output to "blob". cat-file exits 128 BOTH for "not in the index" and for a
+# corrupt or unavailable object, so with its status discarded a broken object
+# read looked exactly like an untracked file and the gate fell through to an
+# empty baseline / zero exclusions and reported OK — the fail-open direction, in
+# which a stale row that should have failed the run simply vanishes. ls-files
+# answers from the index alone and exits 0 whether or not it matches, so a
+# nonzero status here is unambiguously a real failure, and the index MODE it
+# prints also tells us whether the entry is a regular file — which is what
+# cat-file's type check was for. `:(literal)` keeps a path carrying glob
+# metacharacters an exact match.
+#
+# Publishes through INDEX_FILE_MODE rather than stdout, and must be called as a
+# plain command: inside `$(...)` collection_error's `exit 2` would terminate only
+# the subshell, the caller would read an empty mode, and the fall-through to
+# "absent" this guard exists to remove would be right back.
+INDEX_FILE_MODE=""
+read_index_file_mode() { # PATH — sets INDEX_FILE_MODE ("" when untracked)
+  local entry status=0
+  entry="$(git ls-files -s -- ":(literal)$1")" || status=$?
+  [ "$status" -eq 0 ] || collection_error "could not query the index for $1 (git ls-files exit $status) — refusing to treat it as absent"
+  INDEX_FILE_MODE="${entry%% *}"
+  [ -n "$entry" ] || INDEX_FILE_MODE=""
+}
+
+read_policy_from_index() { # PATH — stages the index copy of the list at $TMP/excludes
+  case "$INDEX_FILE_MODE" in
+    100*) ;;
+    *) config_error "$1 is tracked but is not a regular file in the index (mode $INDEX_FILE_MODE); it cannot be read as an exclusion list" ;;
+  esac
+  git show ":$1" >"$TMP/excludes" \
+    || collection_error "could not read the tracked exclusion list from the index: $1 — refusing to run with zero exclusions"
+}
+
 EXCLUDES_SOURCE="$EXCLUDES_FILE"
+# Diagnostics name the CONFIGURED path plus where it was read from, so a
+# malformed row in a partial tree still points at the file to fix.
+EXCLUDES_LABEL="$EXCLUDES_FILE"
 excludes_state=0
 staged_policy_state "$EXCLUDES_FILE" || excludes_state=$?
 case "$excludes_state" in
   0)
-    git show ":$EXCLUDES_FILE" >"$TMP/excludes" \
-      || config_error "failed to read tracked excludes from the index: $EXCLUDES_FILE"
+    read_policy_from_index "$EXCLUDES_FILE"
     EXCLUDES_SOURCE="$TMP/excludes"
+    EXCLUDES_LABEL="$EXCLUDES_FILE (index copy)"
+    ;;
+  1)
+    # The worktree copy governs but is not materialized (fresh or sparse
+    # checkout): fall back to the tracked INDEX blob, mirroring the baseline's
+    # fallback below. Running with ZERO exclusions counted the vendored and
+    # generated files the tracked policy excludes and reported violations
+    # against them — "every tracked file minus the exclusion list" held only in
+    # its first half. The list is read-only here, so unlike the baseline there
+    # is no --update interaction to refuse.
+    if [ ! -f "$EXCLUDES_FILE" ]; then
+      read_index_file_mode "$EXCLUDES_FILE"
+      if [ -n "$INDEX_FILE_MODE" ]; then
+        read_policy_from_index "$EXCLUDES_FILE"
+        EXCLUDES_SOURCE="$TMP/excludes"
+        EXCLUDES_LABEL="$EXCLUDES_FILE (index copy)"
+      fi
+    fi
     ;;
   2)
-    : >"$TMP/excludes"
+    : >"$TMP/excludes" || collection_error "could not initialize the excludes scratch file"
     EXCLUDES_SOURCE="$TMP/excludes"
     ;;
 esac
 
 EXCLUDE_PATTERNS=()
 if [ -f "$EXCLUDES_SOURCE" ]; then
+  # The read loop below redirects from this file; an unreadable one would kill
+  # the script on the redirect, with bash's status rather than the contract's.
+  [ -r "$EXCLUDES_SOURCE" ] || config_error "$EXCLUDES_LABEL: exists but cannot be read"
   lineno=0
   while IFS= read -r line || [ -n "$line" ]; do
     lineno=$((lineno + 1))
@@ -294,7 +385,7 @@ if [ -f "$EXCLUDES_SOURCE" ]; then
     pat="${line%%"$TAB"*}"
     reason="${line#*"$TAB"}"
     if [ "$pat" = "$line" ] || [ -z "$pat" ] || [ -z "$reason" ]; then
-      config_error "$EXCLUDES_FILE:$lineno: expected 'pattern<TAB>reason' (every exclusion carries its justification)"
+      config_error "$EXCLUDES_LABEL:$lineno: expected 'pattern<TAB>reason' (every exclusion carries its justification)"
     fi
     EXCLUDE_PATTERNS+=("$pat")
   done <"$EXCLUDES_SOURCE"
@@ -348,12 +439,12 @@ baseline_state=0
 staged_policy_state "$BASELINE_FILE" || baseline_state=$?
 if [ "$baseline_state" -eq 2 ]; then
   # Staged for deletion: the commit freezes nothing, so nothing is frozen.
-  : >"$TMP/baseline.tsv"
+  : >"$TMP/baseline.tsv" || collection_error "could not initialize the empty baseline scratch file"
 elif [ "$baseline_state" -eq 1 ] && [ -f "$BASELINE_FILE" ]; then
   # grep exit 1 = every row well-formed; exit >= 2 = the validation itself
   # broke, which must never read as a clean baseline.
   grep_status=0
-  bad_rows="$(grep -nEv "^[^${TAB}]+${TAB}[1-9][0-9]*\$" -- "$BASELINE_FILE")" || grep_status=$?
+  bad_rows="$(grep -nEv -- "^[^${TAB}]+${TAB}[1-9][0-9]*\$" "$BASELINE_FILE")" || grep_status=$?
   [ "$grep_status" -le 1 ] || collection_error "could not validate $BASELINE_FILE (grep exit $grep_status)"
   if [ -n "$bad_rows" ]; then
     printf '%s\n' "$bad_rows" >&2
@@ -362,13 +453,17 @@ elif [ "$baseline_state" -eq 1 ] && [ -f "$BASELINE_FILE" ]; then
   if ! LC_ALL=C sort -c -- "$BASELINE_FILE" 2>/dev/null; then
     config_error "$BASELINE_FILE: rows must be LC_ALL=C sorted (LC_ALL=C sort -o $BASELINE_FILE $BASELINE_FILE)"
   fi
-  dup_paths="$(cut -f1 -- "$BASELINE_FILE" | LC_ALL=C uniq -d)"
+  dup_paths="$(cut -f1 -- "$BASELINE_FILE" | LC_ALL=C uniq -d)" || collection_error "could not scan $BASELINE_FILE for duplicate paths"
   if [ -n "$dup_paths" ]; then
     printf '%s\n' "$dup_paths" >&2
     config_error "$BASELINE_FILE: duplicate path row(s) above"
   fi
-  cp -- "$BASELINE_FILE" "$TMP/baseline.tsv"
-elif [ "$(git cat-file -t ":$BASELINE_FILE" 2>/dev/null)" = "blob" ]; then
+  cp -- "$BASELINE_FILE" "$TMP/baseline.tsv" || collection_error "could not stage a working copy of $BASELINE_FILE"
+elif read_index_file_mode "$BASELINE_FILE"; [ -n "$INDEX_FILE_MODE" ]; then
+  case "$INDEX_FILE_MODE" in
+    100*) ;;
+    *) config_error "$BASELINE_FILE is tracked but is not a regular file in the index (mode $INDEX_FILE_MODE); it cannot be read as a baseline" ;;
+  esac
   # Staged mode, or a sparse checkout where the accepted baseline is tracked
   # but not materialized: read it from the index rather than degrading to an
   # empty baseline (which would report every frozen offender as new). Full
@@ -379,7 +474,7 @@ elif [ "$(git cat-file -t ":$BASELINE_FILE" 2>/dev/null)" = "blob" ]; then
   [ -f "$BASELINE_FILE" ] || BASELINE_FROM_INDEX=1
   git show ":$BASELINE_FILE" >"$TMP/baseline.tsv" || config_error "failed to read tracked baseline from the index: $BASELINE_FILE"
   grep_status=0
-  bad_rows="$(grep -nEv "^[^${TAB}]+${TAB}[1-9][0-9]*\$" -- "$TMP/baseline.tsv")" || grep_status=$?
+  bad_rows="$(grep -nEv -- "^[^${TAB}]+${TAB}[1-9][0-9]*\$" "$TMP/baseline.tsv")" || grep_status=$?
   [ "$grep_status" -le 1 ] || collection_error "could not validate $BASELINE_FILE (index copy) (grep exit $grep_status)"
   if [ -n "$bad_rows" ]; then
     printf '%s\n' "$bad_rows" >&2
@@ -388,13 +483,13 @@ elif [ "$(git cat-file -t ":$BASELINE_FILE" 2>/dev/null)" = "blob" ]; then
   if ! LC_ALL=C sort -c -- "$TMP/baseline.tsv" 2>/dev/null; then
     config_error "$BASELINE_FILE (index copy): rows must be LC_ALL=C sorted"
   fi
-  dup_paths="$(cut -f1 -- "$TMP/baseline.tsv" | LC_ALL=C uniq -d)"
+  dup_paths="$(cut -f1 -- "$TMP/baseline.tsv" | LC_ALL=C uniq -d)" || collection_error "could not scan $BASELINE_FILE (index copy) for duplicate paths"
   if [ -n "$dup_paths" ]; then
     printf '%s\n' "$dup_paths" >&2
     config_error "$BASELINE_FILE (index copy): duplicate path row(s) above"
   fi
 else
-  : >"$TMP/baseline.tsv"
+  : >"$TMP/baseline.tsv" || collection_error "could not initialize the empty baseline scratch file"
 fi
 
 # --- count every tracked, non-excluded, regular file -------------------------
@@ -404,7 +499,7 @@ fi
 # directory, sparse absence) never decides what a path IS — the index does.
 git ls-files -sz >"$TMP/files.z" || config_error "git ls-files failed"
 checked=0
-: >"$TMP/counts.raw"
+: >"$TMP/counts.raw" || collection_error "could not initialize the counts scratch file"
 # Worktree reads are batched: one `wc -l` invocation per bounded group of
 # files instead of one per file (a large repo materializes thousands).
 # wc emits its counts in argument order, so every output row is matched to
@@ -422,7 +517,7 @@ WT_BATCH_CHARS=0
 flush_batch() { # — appends one "<path><TAB><count>" row per pending file
   local status=0 idx=0 extra=0 want_extra=0 line count path n f
   [ "${#WT_BATCH[@]}" -gt 0 ] || return 0
-  : >"$TMP/batch.tsv"
+  : >"$TMP/batch.tsv" || collection_error "could not initialize the batch scratch file"
   wc -l -- "${WT_BATCH[@]}" >"$TMP/wc.out" || status=$?
   # A multi-file invocation appends exactly one summary row and a
   # single-file one appends none, so the whole output is accounted for:
@@ -446,17 +541,17 @@ flush_batch() { # — appends one "<path><TAB><count>" row per pending file
       case "$count" in "" | *[!0-9]*) idx=-1 ;; esac
       [ "$idx" -ge 0 ] || break
       [ "$path" = "${WT_BATCH[$idx]}" ] || { idx=-1; break; }
-      printf '%s\t%s\n' "$path" "$count" >>"$TMP/batch.tsv"
+      printf '%s\t%s\n' "$path" "$count" >>"$TMP/batch.tsv" || collection_error "could not record the batched count for '$path' — the measurement is incomplete, refusing to report a verdict"
       idx=$((idx + 1))
     done <"$TMP/wc.out"
     if [ "$idx" -eq "${#WT_BATCH[@]}" ] && [ "$extra" -eq "$want_extra" ]; then
-      cat "$TMP/batch.tsv" >>"$TMP/counts.raw"
+      cat "$TMP/batch.tsv" >>"$TMP/counts.raw" || collection_error "could not append the batched counts — the measurement is incomplete, refusing to report a verdict"
       WT_BATCH=()
       WT_BATCH_CHARS=0
       return 0
     fi
   fi
-  : >"$TMP/batch.tsv"
+  : >"$TMP/batch.tsv" || collection_error "could not initialize the batch scratch file"
   for f in "${WT_BATCH[@]}"; do
     # Same contract as the index path: a worktree file that exists but
     # cannot be read (permissions, I/O error) is a collection failure with
@@ -466,9 +561,9 @@ flush_batch() { # — appends one "<path><TAB><count>" row per pending file
     case "$n" in
       "" | *[!0-9]*) collection_error "line count for tracked file '$f' came back as '$n', not a number — its size is unmeasurable, refusing to skip it" ;;
     esac
-    printf '%s\t%s\n' "$f" "$n" >>"$TMP/batch.tsv"
+    printf '%s\t%s\n' "$f" "$n" >>"$TMP/batch.tsv" || collection_error "could not record the count for '$f' — the measurement is incomplete, refusing to report a verdict"
   done
-  cat "$TMP/batch.tsv" >>"$TMP/counts.raw"
+  cat "$TMP/batch.tsv" >>"$TMP/counts.raw" || collection_error "could not append the re-measured counts — the measurement is incomplete, refusing to report a verdict"
   WT_BATCH=()
   WT_BATCH_CHARS=0
 }
@@ -509,7 +604,7 @@ while IFS= read -r -d '' rec; do
       collection_error "cannot read index blob for tracked file '$f' — its size is unmeasurable, refusing to skip it"
     fi
     n=$((n)) # strip wc's leading whitespace (BSD wc pads)
-    printf '%s\t%s\n' "$f" "$n" >>"$TMP/counts.raw"
+    printf '%s\t%s\n' "$f" "$n" >>"$TMP/counts.raw" || collection_error "could not record the count for '$f' — the measurement is incomplete, refusing to report a verdict"
   else
     WT_BATCH+=("$f")
     WT_BATCH_CHARS=$((WT_BATCH_CHARS + ${#f} + 1))
@@ -528,14 +623,14 @@ counted="$(count_nonempty_lines "$TMP/counts.raw")"
 # Stamp each measured row with the threshold its path class carries. A pass
 # over the rows, not a step inside collection: counting is batched and the
 # batch writer knows nothing about classes.
-: >"$TMP/counts.classed"
+: >"$TMP/counts.classed" || collection_error "could not initialize the classified-counts scratch file"
 while IFS="$TAB" read -r cf cn; do
   path_threshold "$cf"
-  printf '%s\t%s\t%s\n' "$cf" "$cn" "$PT" >>"$TMP/counts.classed"
+  printf '%s\t%s\t%s\n' "$cf" "$cn" "$PT" >>"$TMP/counts.classed" || collection_error "could not record the threshold for '$cf' — the measurement is incomplete, refusing to report a verdict"
 done <"$TMP/counts.raw"
 classed="$(count_nonempty_lines "$TMP/counts.classed")"
 [ "$classed" -eq "$counted" ] || collection_error "classified $classed of the $counted measured row(s) — refusing to report a verdict over a subset"
-LC_ALL=C sort -- "$TMP/counts.classed" >"$TMP/counts.tsv"
+LC_ALL=C sort -- "$TMP/counts.classed" >"$TMP/counts.tsv" || collection_error "could not sort the collected counts — the measurement is incomplete, refusing to report a verdict"
 
 # --- evaluate a baseline against the counts ----------------------------------
 # Counts rows are `path<TAB>lines<TAB>threshold` — the class resolver already
@@ -619,7 +714,7 @@ if [ "$MODE" = "update" ]; then
         }
       }
     }
-  ' "$TMP/baseline.tsv" "$TMP/counts.tsv" | LC_ALL=C sort >"$TMP/baseline.new"
+  ' "$TMP/baseline.tsv" "$TMP/counts.tsv" | LC_ALL=C sort >"$TMP/baseline.new" || collection_error "could not build the tightened baseline — update aborted, baseline unchanged"
   if [ "$BASELINE_FROM_INDEX" = "1" ]; then
     # printf %q shell-escapes the configured path so the suggested command
     # survives copy-paste. update-index/checkout-index take literal file
@@ -631,6 +726,38 @@ if [ "$MODE" = "update" ]; then
     config_error "--update cannot rewrite an index-only baseline (sparse checkout omits $BASELINE_FILE); materialize it with: git update-index --no-skip-worktree -- $BASELINE_QUOTED && git checkout-index -- $BASELINE_QUOTED, then rerun (a later git sparse-checkout reapply re-hides it; checkout-index without -f refuses to overwrite anything unexpectedly occupying the path)"
   fi
   if [ -f "$BASELINE_FILE" ]; then
+    # Reconcile the baseline's OWN row against the file it is about to become.
+    # The pipeline above wrote that row from the PRE-update counts, so once
+    # other rows were pruned the row disagreed with the file's new length and
+    # the very next check failed — --update contradicting its own one-run
+    # tightening guarantee, and logging "tightened: 50 -> 2" for a file that
+    # ended up 1 line long.
+    #
+    # One pass suffices, no iteration: a row's own file length is the ROW COUNT
+    # of this candidate, and editing a value in place cannot change that count.
+    # Dropping the row lowers the count by one, but only happens when the count
+    # is already at/under the threshold, so the result stays under it. The
+    # deciding threshold is the baseline path's own class, not the base one.
+    path_threshold "$BASELINE_FILE"
+    self_lines="$(wc -l <"$TMP/baseline.new" | tr -d ' ')" || collection_error "could not measure the candidate baseline for its own row — update aborted, baseline unchanged"
+    BASELINE_PATH="$BASELINE_FILE" SELF_LINES="$self_lines" SELF_THR="$PT" awk -F'\t' -v OFS='\t' '
+      BEGIN { p = ENVIRON["BASELINE_PATH"]; n = ENVIRON["SELF_LINES"] + 0; thr = ENVIRON["SELF_THR"] + 0 }
+      $1 != p { print; next }
+      {
+        # The pipeline above already logged this row from the PRE-update counts,
+        # so its verdict is restated here rather than left contradicting reality.
+        if (n <= thr) {
+          printf "removed (the baseline'"'"'s own row: it is now %d line(s), at/under threshold %d): %s\n", n, thr, p > "/dev/stderr"
+          next
+        }
+        v = ($2 + 0 > n ? n : $2 + 0)                     # tighten only, never raise
+        if (v != $2 + 0) {
+          printf "re-tightened (the baseline'"'"'s own row against its new length): %s %d -> %d\n", p, $2 + 0, v > "/dev/stderr"
+        }
+        print p, v
+      }
+    ' "$TMP/baseline.new" >"$TMP/baseline.self" || collection_error "could not reconcile the baseline's own row — update aborted, baseline unchanged"
+    mv "$TMP/baseline.self" "$TMP/baseline.new" || collection_error "could not stage the reconciled baseline — update aborted, baseline unchanged"
     # Every check and recount that can fail runs against the candidate
     # BEFORE it replaces the real baseline, so any collection failure
     # aborts the update with the reviewed baseline byte-identical — and
@@ -658,12 +785,34 @@ if [ "$MODE" = "update" ]; then
       BASELINE_PATH="$BASELINE_FILE" NEW_N="$new_n" awk -F'\t' -v OFS='\t' 'BEGIN { p = ENVIRON["BASELINE_PATH"]; n = ENVIRON["NEW_N"] } $1 == p { print p, n, $3; next } { print }' "$TMP/counts.tsv" >"$TMP/counts.rewrite" || collection_error "could not rewrite the counts row for $BASELINE_FILE — update aborted, baseline unchanged"
       mv "$TMP/counts.rewrite" "$TMP/counts.tsv" || collection_error "could not stage the refreshed counts — update aborted, baseline unchanged"
     fi
+    # The replacement is staged NEXT TO the baseline, not in $TMP. `mktemp -d`
+    # honours TMPDIR, so on the common layout where /tmp is a separate
+    # filesystem from the checkout, `mv` could not rename and fell back to
+    # copy-then-remove — an interruption mid-copy left the tracked baseline
+    # truncated or missing, defeating the atomic-replace intent stated above. A
+    # sibling temp is on the destination's own filesystem by construction, so
+    # the final step is a real rename(2).
+    STAGED_BASELINE="$(mktemp -- "$(dirname -- "$BASELINE_FILE")/.size-ratchet-baseline.XXXXXX")" || collection_error "could not create a staging file beside $BASELINE_FILE — update aborted, baseline unchanged"
+    # rename(2) carries the SOURCE file's mode, and mktemp creates at 0600 — so
+    # without this the replace would silently narrow a world-readable tracked
+    # file. 0666 masked by the umask is exactly the mode the plain shell
+    # redirect that writes $TMP/baseline.new produces.
+    #
+    # `--` goes BEFORE the mode, not after it. BSD/macOS chmod parses options
+    # with getopt(3), which stops at the first non-option argument — the mode —
+    # so a trailing `--` is read as a literal filename and chmod fails on the
+    # nonexistent file `--`, aborting every --update on macOS. GNU chmod
+    # permutes and accepts either order, which is why the mistake survives a
+    # Linux-only run.
+    chmod -- "$(printf '%03o' "$((0666 & ~8#$(umask)))")" "$STAGED_BASELINE" || collection_error "could not set the staging file's mode beside $BASELINE_FILE — update aborted, baseline unchanged"
+    cat -- "$TMP/baseline.new" >"$STAGED_BASELINE" || collection_error "could not write the staged baseline beside $BASELINE_FILE — update aborted, baseline unchanged"
     # The replace and the re-read carry the contract too, with honest
     # sidedness: mv failing means the original may not have been replaced
     # cleanly — inspect it; cp failing AFTER a successful mv means the
     # baseline on disk WAS replaced and only the re-read for the
     # post-update check is missing.
-    mv -- "$TMP/baseline.new" "$BASELINE_FILE" || collection_error "could not replace the baseline at $BASELINE_FILE (mv failed) — inspect the file before trusting it"
+    mv -- "$STAGED_BASELINE" "$BASELINE_FILE" || collection_error "could not replace the baseline at $BASELINE_FILE (mv failed) — inspect the file before trusting it"
+    STAGED_BASELINE="" # renamed away; nothing left for the EXIT trap to remove
     cp -- "$BASELINE_FILE" "$TMP/baseline.tsv" || collection_error "could not re-read the replaced baseline at $BASELINE_FILE (cp failed) — the baseline WAS replaced; rerun size-ratchet to verify it"
     echo "size-ratchet --update: baseline tightened at $BASELINE_FILE ($rows row(s))"
   else
@@ -781,9 +930,9 @@ if [ "$MODE" = "seed" ]; then
 fi
 
 # --- verdict -------------------------------------------------------------------
-evaluate "$TMP/baseline.tsv" >"$TMP/violations.tsv"
+evaluate "$TMP/baseline.tsv" >"$TMP/violations.tsv" || collection_error "could not evaluate the baseline against the collected counts"
 violations="$(count_nonempty_lines "$TMP/violations.tsv")"
-report "$TMP/violations.tsv"
+report "$TMP/violations.tsv" || collection_error "could not read the violations scratch file to report them"
 if [ "$violations" -gt 0 ]; then
   echo "size-ratchet: $violations violation(s) — threshold $THRESHOLD$CLASSES_NOTE, baseline $BASELINE_FILE"
   exit 1

--- a/skills/size-ratchet/tests/collection-fail-closed.test.sh
+++ b/skills/size-ratchet/tests/collection-fail-closed.test.sh
@@ -58,6 +58,15 @@ run_sr() { # [args...] — run in $R at threshold 10; sets OUT and RC
   OUT="$(cd "$R" && SIZE_RATCHET_THRESHOLD=10 "$SR" "$@" 2>&1)" || RC=$?
 }
 
+run_wc_failing_from() { # N [args...] — run_sr with the wc shim failing from call N
+  local from="$1"
+  shift
+  rm -f "$TMP/wc-calls"
+  OUT=""
+  RC=0
+  OUT="$(cd "$R" && PATH="$WC_RECOUNT_SHIM:$PATH" SR_WC_FAIL_FROM="$from" SIZE_RATCHET_THRESHOLD=10 "$SR" "$@" 2>&1)" || RC=$?
+}
+
 run_sr_shimmed() { # SHIMDIR [args...] — run_sr with SHIMDIR first on PATH
   local shimdir="$1"
   shift
@@ -125,11 +134,17 @@ exit 1
 EOF
 chmod +x "$WC_SHIM/wc"
 
-# wc shim: pass the first call through (the collection loop's single
-# batched count for the fixture's two tracked files), fail from the second
-# on — which in --update is the recount of the candidate baseline. Exit 7
-# on purpose: a raw tool status escaping instead of the contract's exit 2
-# must be visible. Reset $TMP/wc-calls before each run.
+# wc shim: pass calls through until $SR_WC_FAIL_FROM, then fail. Exit 7 on
+# purpose: a raw tool status escaping instead of the contract's exit 2 must be
+# visible. Reset $TMP/wc-calls before each run.
+#
+# The ordinal is COUPLED to how many times a run measures things, so it is
+# passed in per case rather than hardcoded. For the two-tracked-file fixtures
+# below the collection loop burns call 1 (both files in one batch), then
+# --update measures the candidate TWICE: call 2 reconciles the baseline's own
+# row against the candidate's length, call 3 recounts it afterwards for the
+# counts row. Each of those two sites gets its own case, so adding a third
+# measurement fails a named assertion here instead of silently retargeting one.
 WC_RECOUNT_SHIM="$TMP/wc-recount-shim"
 mkdir -p "$WC_RECOUNT_SHIM"
 cat >"$WC_RECOUNT_SHIM/wc" <<EOF
@@ -137,7 +152,7 @@ cat >"$WC_RECOUNT_SHIM/wc" <<EOF
 n="\$(cat "$TMP/wc-calls" 2>/dev/null)" || n=0
 n=\$((n + 1))
 printf '%s\n' "\$n" >"$TMP/wc-calls"
-if [ "\$n" -ge 2 ]; then
+if [ "\$n" -ge "\${SR_WC_FAIL_FROM:-3}" ]; then
   echo "wc: simulated recount failure" >&2
   exit 7
 fi
@@ -354,12 +369,23 @@ mkfile big.txt 15
 mkdir -p "$R/tools"
 printf 'big.txt\t20\n' >"$R/tools/size-ratchet-baseline.tsv"
 git -C "$R" add -A
-rm -f "$TMP/wc-calls"
-run_sr_shimmed "$WC_RECOUNT_SHIM" --update
+run_wc_failing_from 3 --update
 [ "$RC" -eq 2 ] && case "$OUT" in *"could not recount the updated baseline tools/size-ratchet-baseline.tsv"*) true ;; *) false ;; esac \
   && ok "a wc failure on the recount is a collection error: exit 2 with the update-aborted diagnostic" \
   || bad "a wc failure on the recount is a collection error, exit 2 (never raw status 7)" "rc=$RC out=$OUT"
-case "$OUT" in *"wc: simulated recount failure"*) ok "the shim fired on the recount call (2nd wc), pinning the cause" ;; *) bad "the shim fired on the recount call" "$OUT" ;; esac
+case "$OUT" in *"wc: simulated recount failure"*) ok "the shim fired on the recount call (3rd wc), pinning the cause" ;; *) bad "the shim fired on the recount call" "$OUT" ;; esac
+
+# The OTHER candidate measurement, added with the self-row reconciliation: it
+# runs first, so it needs its own case or a failure there would surface as this
+# one and quietly retarget the assertion above.
+run_wc_failing_from 2 --update
+[ "$RC" -eq 2 ] && case "$OUT" in *"could not measure the candidate baseline for its own row"*) true ;; *) false ;; esac \
+  && ok "a wc failure measuring the candidate for its own row is exit 2 with its own diagnostic" \
+  || bad "a wc failure on the self-row measurement is exit 2 with its own diagnostic" "rc=$RC out=$OUT"
+row_selfmeasure="$(cat "$R/tools/size-ratchet-baseline.tsv")"
+[ "$row_selfmeasure" = "$(printf 'big.txt\t20')" ] \
+  && ok "the aborted self-row measurement leaves the original row byte-identical" \
+  || bad "the aborted self-row measurement leaves the original row byte-identical" "row=$row_selfmeasure"
 row="$(cat "$R/tools/size-ratchet-baseline.tsv")"
 [ "$row" = "$(printf 'big.txt\t20')" ] && ok "the aborted recount leaves the original loose row byte-identical" \
   || bad "the aborted recount leaves the original loose row byte-identical" "row=$row"

--- a/skills/size-ratchet/tests/fail-closed-routing.test.sh
+++ b/skills/size-ratchet/tests/fail-closed-routing.test.sh
@@ -1,0 +1,422 @@
+#!/usr/bin/env bash
+# Pins for the collection sites whose failure used to escape as the failing
+# tool's OWN status. The contract reserves exit 1 for "a size violation was
+# measured" and exit 2 for "could not measure", so a broken environment
+# leaving through `set -e` with status 1 told every caller the opposite of
+# the truth: the gate reported a failing repository instead of a broken gate.
+# Pinned here: the repository-root cd, the scratch-file writes, the working
+# copy of the baseline, both sorts (check path and --update pipeline), the
+# index-presence probe, and grep's option order.
+#
+# Every case is asserted at exit 2 SPECIFICALLY — nonzero would be satisfied
+# by exactly the value being ruled out — and each carries a shim-free (or
+# disarmed-shim) control first, so a green run is evidence rather than a
+# check that cannot fail.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
+SR="$SKILL_DIR/scripts/size-ratchet"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# Hermetic: a leaked setting would mask every case below.
+unset SIZE_RATCHET_THRESHOLD SIZE_RATCHET_CLASSES SIZE_RATCHET_BASELINE SIZE_RATCHET_EXCLUDES SIZE_RATCHET_SETTINGS_FILE 2>/dev/null || true
+
+PASS=0
+FAIL=0
+ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
+
+REAL_GIT="$(command -v git)"
+REAL_GREP="$(command -v grep)"
+REAL_SORT="$(command -v sort)"
+REAL_CP="$(command -v cp)"
+REAL_MKTEMP="$(command -v mktemp)"
+
+new_repo() { # NAME — fresh fixture repo in $R
+  R="$TMP/$1"
+  mkdir -p "$R"
+  git -C "$R" -c init.defaultBranch=main init -q
+  git -C "$R" config user.email test@example.com
+  git -C "$R" config user.name test
+}
+
+mkfile() { # PATH LINES — file of LINES lines under $R
+  mkdir -p "$R/$(dirname "$1")"
+  awk -v n="$2" 'BEGIN { for (i = 1; i <= n; i++) print "line " i }' >"$R/$1"
+}
+
+run_sr() { # — plain check in $R at threshold 10; sets OUT and RC
+  OUT=""
+  RC=0
+  OUT="$(cd "$R" && SIZE_RATCHET_THRESHOLD=10 "$SR" 2>&1)" || RC=$?
+}
+
+run_sr_shimmed() { # SHIMDIR [args...] — run_sr with SHIMDIR first on PATH
+  local shimdir="$1"
+  shift
+  OUT=""
+  RC=0
+  OUT="$(cd "$R" && PATH="$shimdir:$PATH" SIZE_RATCHET_THRESHOLD=10 "$SR" "$@" 2>&1)" || RC=$?
+}
+
+echo "=== the repository-root cd is a config error, never the violation code ==="
+# `git rev-parse --show-toplevel` answering with a path the process cannot
+# enter (a repository removed mid-run, a permission change) used to kill the
+# script through set -e with cd's own status 1.
+CD_SHIM="$TMP/cd-shim"
+mkdir -p "$CD_SHIM"
+cat >"$CD_SHIM/git" <<EOF
+#!/usr/bin/env bash
+if [ "\${1:-}" = "rev-parse" ] && [ "\${2:-}" = "--show-toplevel" ]; then
+  printf '%s\n' "$TMP/no-such-repository-root"
+  exit 0
+fi
+exec "$REAL_GIT" "\$@"
+EOF
+chmod +x "$CD_SHIM/git"
+
+new_repo cdfail
+mkfile small.txt 5
+git -C "$R" add -A
+run_sr
+[ "$RC" -eq 0 ] && ok "shim-free control: the fixture passes, so a nonzero below is the shim" \
+  || bad "shim-free control: the cd fixture passes" "rc=$RC out=$OUT"
+
+run_sr_shimmed "$CD_SHIM"
+[ "$RC" -eq 2 ] && case "$OUT" in *"could not enter the repository root"*) true ;; *) false ;; esac \
+  && ok "an unenterable repository root exits 2 with its own diagnostic, not 1" \
+  || bad "an unenterable repository root exits 2" "rc=$RC out=$OUT"
+
+echo "=== scratch writes are exit 2, never the violation code ==="
+# mktemp -d succeeding does not make the scratch dir usable. Injected through
+# the filesystem rather than a permission bit so the cases hold for root as
+# well (CI images differ): an unwritable location is one that does not exist,
+# and an unwritable FILE is one that is really a directory.
+BROKEN_TMP_SHIM="$TMP/broken-tmp-shim"
+mkdir -p "$BROKEN_TMP_SHIM"
+cat >"$BROKEN_TMP_SHIM/mktemp" <<EOF
+#!/usr/bin/env bash
+# Hand back a scratch path whose parent was never created: mktemp "succeeds",
+# every subsequent write into it fails with ENOENT.
+for arg in "\$@"; do
+  if [ "\$arg" = "-d" ]; then
+    printf '%s\n' "$TMP/never-created/scratch"
+    exit 0
+  fi
+done
+exec "$REAL_MKTEMP" "\$@"
+EOF
+chmod +x "$BROKEN_TMP_SHIM/mktemp"
+
+new_repo brokentmp
+mkfile small.txt 5
+git -C "$R" add -A
+run_sr
+[ "$RC" -eq 0 ] && ok "shim-free control: the broken-scratch fixture passes" \
+  || bad "shim-free control: the broken-scratch fixture passes" "rc=$RC out=$OUT"
+
+# No baseline in this fixture, so the first scratch write is the empty-baseline
+# initialization.
+run_sr_shimmed "$BROKEN_TMP_SHIM"
+[ "$RC" -eq 2 ] && case "$OUT" in *"could not initialize the empty baseline scratch file"*) true ;; *) false ;; esac \
+  && ok "an unwritable scratch dir is exit 2 at the baseline init, not the violation code 1" \
+  || bad "unwritable scratch dir is exit 2 at the baseline init" "rc=$RC out=$OUT"
+case "$OUT" in
+  *"violation"*) bad "an unwritable scratch dir must not read as a size violation" "$OUT" ;;
+  *) ok "the broken-scratch diagnostic never claims a violation was measured" ;;
+esac
+
+# Same class, next site along: let the baseline write land but make counts.raw
+# unwritable by pre-creating it as a DIRECTORY. This is the only way to reach
+# the counts initialization independently — `: >` and `>>` share one file and
+# one mode, so the per-file append guard cannot be injected separately from it.
+COUNTS_SHIM="$TMP/counts-shim"
+mkdir -p "$COUNTS_SHIM"
+COUNTS_SCRATCH="$TMP/counts-scratch"
+cat >"$COUNTS_SHIM/mktemp" <<EOF
+#!/usr/bin/env bash
+for arg in "\$@"; do
+  if [ "\$arg" = "-d" ]; then
+    rm -rf "$COUNTS_SCRATCH"
+    mkdir -p "$COUNTS_SCRATCH/counts.raw" || exit 1
+    printf '%s\n' "$COUNTS_SCRATCH"
+    exit 0
+  fi
+done
+exec "$REAL_MKTEMP" "\$@"
+EOF
+chmod +x "$COUNTS_SHIM/mktemp"
+
+run_sr_shimmed "$COUNTS_SHIM"
+[ "$RC" -eq 2 ] && case "$OUT" in *"could not initialize the counts scratch file"*) true ;; *) false ;; esac \
+  && ok "an unwritable counts scratch file is exit 2 with its own diagnostic" \
+  || bad "unwritable counts scratch file is exit 2" "rc=$RC out=$OUT"
+
+echo "=== a failed working copy of the baseline is exit 2 ==="
+# The baseline is copied into the scratch dir before anything reads it; that
+# cp's failure used to leave through set -e with status 1.
+CP_STAGE_SHIM="$TMP/cp-stage-shim"
+mkdir -p "$CP_STAGE_SHIM"
+cat >"$CP_STAGE_SHIM/cp" <<EOF
+#!/usr/bin/env bash
+for a in "\$@"; do
+  if [ "\$a" = "tools/size-ratchet-baseline.tsv" ]; then
+    echo "cp: simulated staging failure" >&2
+    exit 1
+  fi
+done
+exec "$REAL_CP" "\$@"
+EOF
+chmod +x "$CP_STAGE_SHIM/cp"
+
+new_repo cpstage
+mkfile big.txt 15
+mkdir -p "$R/tools"
+printf 'big.txt\t15\n' >"$R/tools/size-ratchet-baseline.tsv"
+git -C "$R" add -A
+run_sr
+[ "$RC" -eq 0 ] && ok "shim-free control: the baselined fixture passes" \
+  || bad "shim-free control: the baselined fixture passes" "rc=$RC out=$OUT"
+
+run_sr_shimmed "$CP_STAGE_SHIM"
+[ "$RC" -eq 2 ] && case "$OUT" in *"could not stage a working copy of tools/size-ratchet-baseline.tsv"*) true ;; *) false ;; esac \
+  && ok "a failed baseline staging copy is exit 2 with its own diagnostic" \
+  || bad "a failed baseline staging copy is exit 2" "rc=$RC out=$OUT"
+
+echo "=== a failed sort is exit 2, in both the check and update paths ==="
+# Two distinct sorts: the counts sort on the check path, and the awk-to-sort
+# pipeline that builds the tightened baseline on the update path. The shim
+# targets one at a time so each site is pinned by its own diagnostic.
+SORT_SHIM="$TMP/sort-shim"
+mkdir -p "$SORT_SHIM"
+cat >"$SORT_SHIM/sort" <<EOF
+#!/usr/bin/env bash
+# \$SR_SORT_FAIL picks the invocation to break:
+#   counts   — the one carrying the classified counts as its operand
+#   pipeline — the --update awk|sort, identified by reading STDIN (no file
+#              operand) and not being the -c hygiene check
+has_operand=0
+is_check=0
+for arg in "\$@"; do
+  case "\$arg" in
+    -c) is_check=1 ;;
+    -*) ;;
+    *) has_operand=1 ;;
+  esac
+done
+case "\${SR_SORT_FAIL:-}" in
+  counts)
+    for arg in "\$@"; do
+      case "\$arg" in
+        *counts.classed)
+          echo "sort: simulated counts sort failure" >&2
+          exit 2
+          ;;
+      esac
+    done
+    ;;
+  pipeline)
+    if [ "\$has_operand" -eq 0 ] && [ "\$is_check" -eq 0 ]; then
+      echo "sort: simulated pipeline sort failure" >&2
+      exit 2
+    fi
+    ;;
+esac
+exec "$REAL_SORT" "\$@"
+EOF
+chmod +x "$SORT_SHIM/sort"
+
+run_sort_shimmed() { # WHICH [args...] — run_sr with the sort shim armed
+  local which="$1"
+  shift
+  OUT=""
+  RC=0
+  OUT="$(cd "$R" && PATH="$SORT_SHIM:$PATH" SR_SORT_FAIL="$which" SIZE_RATCHET_THRESHOLD=10 "$SR" "$@" 2>&1)" || RC=$?
+}
+
+new_repo sortfail
+mkfile big.txt 15
+mkdir -p "$R/tools"
+printf 'big.txt\t20\n' >"$R/tools/size-ratchet-baseline.tsv"
+git -C "$R" add -A
+
+# Control with the shim ON PATH but disarmed, so a green result below is the
+# arming and not the shim merely being absent or inert.
+run_sort_shimmed "" --update
+[ "$RC" -eq 0 ] && ok "control: the disarmed sort shim passes the whole run through" \
+  || bad "control: the disarmed sort shim passes through" "rc=$RC out=$OUT"
+
+printf 'big.txt\t20\n' >"$R/tools/size-ratchet-baseline.tsv"
+git -C "$R" add -A
+run_sort_shimmed counts
+[ "$RC" -eq 2 ] && case "$OUT" in *"could not sort the collected counts"*) true ;; *) false ;; esac \
+  && ok "a failed counts sort is a collection error: exit 2, measurement declared incomplete" \
+  || bad "a failed counts sort is exit 2" "rc=$RC out=$OUT"
+case "$OUT" in *"size-ratchet: OK"*) bad "no OK verdict may accompany a failed counts sort" "$OUT" ;; *) ok "no OK verdict accompanies the failed counts sort" ;; esac
+
+run_sort_shimmed pipeline --update
+[ "$RC" -eq 2 ] && case "$OUT" in *"could not build the tightened baseline"*"baseline unchanged"*) true ;; *) false ;; esac \
+  && ok "a failed --update sort pipeline is exit 2 and says the baseline is unchanged" \
+  || bad "a failed --update sort pipeline is exit 2" "rc=$RC out=$OUT"
+row="$(cat "$R/tools/size-ratchet-baseline.tsv")"
+[ "$row" = "$(printf 'big.txt\t20')" ] \
+  && ok "the diagnostic is honest: the baseline really is byte-identical after the aborted update" \
+  || bad "the baseline is unchanged after the aborted update" "row=$row"
+
+echo "=== a broken index probe never reads as 'file absent' ==="
+# The probe used to be `[ "$(git cat-file -t ":$FILE" 2>/dev/null)" = "blob" ]`.
+# cat-file exits 128 for "not in the index" AND for a corrupt or unavailable
+# object, so with its status discarded a broken read compared unequal to "blob"
+# and fell through to "absent" — an EMPTY baseline (every frozen offender
+# forgotten, a stale row silently gone) or ZERO exclusions. Fail-open, in the
+# direction that loses violations.
+#
+# The shim fails the index QUERY the probe now depends on, with a status that is
+# neither 0 nor git's "missing" 128, so nothing can mistake it for absence.
+INDEX_PROBE_SHIM="$TMP/index-probe-shim"
+mkdir -p "$INDEX_PROBE_SHIM"
+cat >"$INDEX_PROBE_SHIM/git" <<EOF
+#!/usr/bin/env bash
+# Break only the single-path index probe (ls-files -s with a pathspec); the
+# collection loop's own "ls-files -sz" listing and everything else pass through.
+if [ "\${1:-}" = "ls-files" ] && [ "\${2:-}" = "-s" ]; then
+  for arg in "\$@"; do
+    case "\$arg" in
+      *"\${SR_PROBE_TARGET:?SR_PROBE_TARGET must name the probe to break}"*)
+        echo "fatal: simulated index query failure" >&2
+        exit 71
+        ;;
+    esac
+  done
+fi
+exec "$REAL_GIT" "\$@"
+EOF
+chmod +x "$INDEX_PROBE_SHIM/git"
+
+run_probe_failing() { # PATH-SUBSTRING — run_sr with only that index probe broken
+  OUT=""
+  RC=0
+  OUT="$(cd "$R" && PATH="$INDEX_PROBE_SHIM:$PATH" SR_PROBE_TARGET="$1" SIZE_RATCHET_THRESHOLD=10 "$SR" 2>&1)" || RC=$?
+}
+
+# --- the baseline probe: a tracked-but-absent baseline holding a STALE row ---
+new_repo idxprobe-baseline
+mkfile small.txt 3
+# A row for a file now under the threshold: a real violation the gate must
+# report. If the probe degrades to "absent", this row disappears and the run
+# reports OK — the exact fail-open being pinned.
+mkdir -p "$R/tools"
+printf 'small.txt\t50\n' >"$R/tools/size-ratchet-baseline.tsv"
+git -C "$R" add -A
+rm "$R/tools/size-ratchet-baseline.tsv" # tracked but not materialized
+
+run_sr
+[ "$RC" -eq 1 ] && case "$OUT" in *"stale baseline row: small.txt"*) true ;; *) false ;; esac \
+  && ok "control: the index baseline is read and its stale row FAILS the run" \
+  || bad "control: the index baseline's stale row fails the run" "rc=$RC out=$OUT"
+
+run_probe_failing size-ratchet-baseline.tsv
+[ "$RC" -eq 2 ] && case "$OUT" in *"could not query the index for tools/size-ratchet-baseline.tsv"*) true ;; *) false ;; esac \
+  && ok "a broken baseline index probe is a collection error: exit 2, refusing to treat it as absent" \
+  || bad "a broken baseline index probe is exit 2" "rc=$RC out=$OUT"
+case "$OUT" in
+  *"size-ratchet: OK"*) bad "a broken index probe must never report OK against an empty baseline" "$OUT" ;;
+  *) ok "no OK verdict accompanies the broken baseline probe" ;;
+esac
+
+# --- the excludes probe: a tracked-but-absent list that exempts an offender ---
+new_repo idxprobe-excludes
+mkfile vendor/big.txt 40
+mkdir -p "$R/tools"
+printf 'vendor/*\tvendored\n' >"$R/tools/size-ratchet-excludes"
+git -C "$R" add -A
+rm "$R/tools/size-ratchet-excludes" # tracked but not materialized
+
+run_sr
+[ "$RC" -eq 0 ] && ok "control: the index exclusion list is read and exempts vendor/big.txt" \
+  || bad "control: the index exclusion list exempts vendor/big.txt" "rc=$RC out=$OUT"
+
+run_probe_failing size-ratchet-excludes
+[ "$RC" -eq 2 ] && case "$OUT" in *"could not query the index for tools/size-ratchet-excludes"*) true ;; *) false ;; esac \
+  && ok "a broken excludes index probe is a collection error: exit 2, never zero exclusions" \
+  || bad "a broken excludes index probe is exit 2" "rc=$RC out=$OUT"
+case "$OUT" in
+  *"new offender: vendor/big.txt"*) bad "a broken excludes probe must not report the excluded path as an offender" "$OUT" ;;
+  *) ok "no violation is reported against the path the unreadable list exempts" ;;
+esac
+
+echo "=== every grep call site survives non-permuting (BSD/POSIX) option parsing ==="
+# Option scanning stops at the first non-option argument, which for grep is the
+# PATTERN — so `grep -c . -- FILE` reads `--` as a literal filename on any
+# non-permuting grep and fails on a clean repo, tripping collection_error
+# universally. GNU greps permute and accept it, so a Linux-only run cannot see
+# it. A CLASS guard, not a site guard: the shim is on PATH for the whole run, so
+# it covers every grep in the script AND in lib/settings.sh at once.
+GREP_ORDER_SHIM="$TMP/grep-order-shim"
+mkdir -p "$GREP_ORDER_SHIM"
+cat >"$GREP_ORDER_SHIM/grep" <<EOF
+#!/usr/bin/env bash
+args=()
+seen_operand=0
+for arg in "\$@"; do
+  if [ "\$seen_operand" -eq 0 ]; then
+    case "\$arg" in
+      # An end-of-options marker seen while still scanning options IS the
+      # terminator. Kept in the forwarded args so the real grep keeps its
+      # protection. (No backticks in this heredoc: it is unquoted for the
+      # REAL_GREP interpolation, so backticks would run as command substitution.)
+      --) seen_operand=1; args+=("\$arg"); continue ;;
+      -*) args+=("\$arg"); continue ;;
+      *) seen_operand=1 ;; # the pattern: scanning stops here
+    esac
+  fi
+  if [ "\$arg" = "--" ]; then
+    echo "grep: --: No such file or directory" >&2
+    exit 2
+  fi
+  args+=("\$arg")
+done
+exec "$REAL_GREP" "\${args[@]}"
+EOF
+chmod +x "$GREP_ORDER_SHIM/grep"
+
+# The shim proven in BOTH directions on a real file first, or a green run below
+# would only mean the shim is a pass-through.
+gprobe="$TMP/grep-order-probe"
+printf 'a\n' >"$gprobe"
+if "$GREP_ORDER_SHIM/grep" -c . -- "$gprobe" >/dev/null 2>&1; then
+  bad "the BSD grep shim models the option-parsing rule" "trailing -- was accepted; the shim is inert"
+else
+  ok "control: the BSD grep shim rejects 'grep -c . -- FILE', the form that breaks on macOS"
+fi
+"$GREP_ORDER_SHIM/grep" -c -- . "$gprobe" >/dev/null 2>&1 \
+  && ok "control: the same shim accepts 'grep -c -- . FILE', so it is not rejecting everything" \
+  || bad "the BSD grep shim accepts the leading -- form" "the shim rejects the correct form too"
+
+# A fixture that drives BOTH shapes: count_nonempty_lines (the violations
+# count) and the baseline-row validation, worktree copy.
+new_repo greporder
+mkfile big.txt 15
+mkdir -p "$R/tools"
+printf 'big.txt\t15\n' >"$R/tools/size-ratchet-baseline.tsv"
+git -C "$R" add -A
+run_sr
+[ "$RC" -eq 0 ] && ok "shim-free control: the grep-order fixture passes" \
+  || bad "shim-free control: the grep-order fixture passes" "rc=$RC out=$OUT"
+
+run_sr_shimmed "$GREP_ORDER_SHIM"
+[ "$RC" -eq 0 ] && case "$OUT" in *"size-ratchet: OK"*) true ;; *) false ;; esac \
+  && ok "the whole run is clean under non-permuting grep option parsing" \
+  || bad "the run is clean under non-permuting grep option parsing" "rc=$RC out=$OUT"
+
+# And the index-copy validation path, which is a separate call site.
+rm "$R/tools/size-ratchet-baseline.tsv" # tracked but absent: read from the index
+run_sr_shimmed "$GREP_ORDER_SHIM"
+[ "$RC" -eq 0 ] \
+  && ok "the index-copy baseline validation also survives non-permuting grep" \
+  || bad "the index-copy baseline validation survives non-permuting grep" "rc=$RC out=$OUT"
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/skills/size-ratchet/tests/ratchet-directions.test.sh
+++ b/skills/size-ratchet/tests/ratchet-directions.test.sh
@@ -117,6 +117,65 @@ run_sr
   && ok "control: the STAGED deletion is stale — only index-listed-but-absent is preserved" \
   || bad "control: the STAGED deletion is stale" "rc=$RC out=$OUT"
 
+echo "=== a tracked-but-absent exclusion list still applies, from the index ==="
+# Same sparse-checkout shape as the baseline case above, for the OTHER tracked
+# policy file. A worktree missing the list used to mean zero exclusions, so a
+# fresh or partial tree reported violations against the vendored and generated
+# files the tracked list excludes — the opposite direction from the baseline
+# fallback (noise, not a smuggled offender), but equally a broken scope
+# contract: "every tracked file minus the exclusion list" held only in its
+# first half.
+new_repo excl-absent
+mkfile vendor/big.txt 40
+git -C "$R" add -A
+
+# Control 1, the failing direction: with no exclusion list, the file IS a
+# violation. Without this the passes below could come from the file being
+# under threshold or uncounted rather than from the exclusion.
+run_sr
+[ "$RC" -eq 1 ] && case "$OUT" in *"vendor/big.txt"*) true ;; *) false ;; esac \
+  && ok "control: with no exclusion list, vendor/big.txt is a new offender" \
+  || bad "control: with no exclusion list, vendor/big.txt is a new offender" "rc=$RC out=$OUT"
+
+mkdir -p "$R/tools"
+printf 'vendor/*\tvendored third-party — size is not a design signal\n' >"$R/tools/size-ratchet-excludes"
+git -C "$R" add -A
+
+# Control 2: the exclusion works when the list is materialized.
+run_sr
+[ "$RC" -eq 0 ] && ok "control: a worktree exclusion list excludes vendor/big.txt" \
+  || bad "control: a worktree exclusion list excludes vendor/big.txt" "rc=$RC out=$OUT"
+
+rm "$R/tools/size-ratchet-excludes" # unstaged: the index still lists it
+run_sr
+[ "$RC" -eq 0 ] && ok "a tracked-but-absent exclusion list is read from the index and still applies" \
+  || bad "a tracked-but-absent exclusion list is read from the index" "rc=$RC out=$OUT"
+case "$OUT" in
+  *"vendor/big.txt"*) bad "the index-read exclusion must keep vendor/big.txt out of the report" "$OUT" ;;
+  *) ok "no violation is reported against the index-excluded path" ;;
+esac
+
+git -C "$R" add -A # stage the deletion: the list truly left the tracked set
+run_sr
+[ "$RC" -eq 1 ] && case "$OUT" in *"vendor/big.txt"*) true ;; *) false ;; esac \
+  && ok "control: a STAGED deletion of the list really removes the exclusions" \
+  || bad "control: a STAGED deletion of the list removes the exclusions" "rc=$RC out=$OUT"
+
+echo "=== the index copy of the exclusion list gets the same validation ==="
+# A malformed row must fail loud from the index exactly as from the worktree —
+# otherwise the fallback would be a hole in the reason-is-mandatory contract —
+# and the diagnostic must say WHICH copy it read.
+new_repo excl-index-bad
+mkfile vendor/big.txt 40
+mkdir -p "$R/tools"
+printf 'vendor/* missing-tab-so-no-reason\n' >"$R/tools/size-ratchet-excludes"
+git -C "$R" add -A
+rm "$R/tools/size-ratchet-excludes"
+run_sr
+[ "$RC" -eq 2 ] && case "$OUT" in *"(index copy):1: expected 'pattern<TAB>reason'"*) true ;; *) false ;; esac \
+  && ok "a malformed index-copy row is a config error naming the copy and the line" \
+  || bad "a malformed index-copy row is a config error" "rc=$RC out=$OUT"
+
 echo "=== newline-containing tracked paths are refused loudly ==="
 new_repo nl
 mkfile ok.txt 3

--- a/skills/size-ratchet/tests/settings-and-config.test.sh
+++ b/skills/size-ratchet/tests/settings-and-config.test.sh
@@ -329,5 +329,36 @@ git -C "$R" add -A
 run_raw SIZE_RATCHET_BASELINE=-b || true
 if [ "$RC" -eq 2 ]; then ok "option-like baseline path refuses as config (no cut/sort option injection)"; else bad "option-like baseline path" "rc=$RC out=$OUT"; fi
 
+echo "=== a supplied-but-empty path flag is an error, not the default ==="
+# Testing the flag's VALUE alone made `--baseline=` and `--baseline ""`
+# indistinguishable from an absent flag, so automation whose path came out of a
+# bad substitution silently checked the repository's default baseline and
+# passed. Whether the flag was supplied is now tracked apart from its value.
+new_repo emptyflag
+mkfile f.txt 20
+mkfile huge.txt 405
+mkdir -p "$R/tools"
+# The DEFAULT baseline freezes huge.txt, so falling back to it exits 0 — the
+# false pass this case exists to catch. A correct refusal is exit 2.
+printf 'huge.txt\t405\n' >"$R/tools/size-ratchet-baseline.tsv"
+git -C "$R" add -A
+
+run_raw
+[ "$RC" -eq 0 ] \
+  && ok "control: the default baseline is present and passes, so a silent fallback would read as success" \
+  || bad "control: default baseline passes" "rc=$RC out=$OUT"
+
+for flag in --baseline --excludes; do
+  run_raw -- "$flag" "" || true
+  [ "$RC" -eq 2 ] && case "$OUT" in *"was given an empty path"*) true ;; *) false ;; esac \
+    && ok "split form '$flag \"\"' exits 2 instead of falling back to the default" \
+    || bad "split form '$flag \"\"' refuses" "rc=$RC out=$OUT"
+
+  run_raw -- "$flag=" || true
+  [ "$RC" -eq 2 ] && case "$OUT" in *"was given an empty path"*) true ;; *) false ;; esac \
+    && ok "equals form '$flag=' exits 2 instead of falling back to the default" \
+    || bad "equals form '$flag=' refuses" "rc=$RC out=$OUT"
+done
+
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/skills/size-ratchet/tests/update-tightens.test.sh
+++ b/skills/size-ratchet/tests/update-tightens.test.sh
@@ -126,5 +126,214 @@ run_sr --update
   && ok "--update without a baseline writes nothing and the new offender still fails" \
   || bad "--update without a baseline writes nothing" "rc=$RC out=$OUT"
 
+echo "=== --update stages the replacement on the destination's own filesystem ==="
+# The replacement used to be built under `mktemp -d` (i.e. TMPDIR, commonly a
+# separate filesystem from the checkout), so the final `mv` could not rename and
+# fell back to copy-then-remove — an interruption mid-copy left the tracked
+# baseline truncated or missing, defeating the stated atomic-replace intent.
+#
+# Asserted by WHERE the staging file is created, not by running across a real
+# device boundary: a cross-device run SUCCEEDS under both the old and the new
+# code (mv's copy fallback is correct, just not atomic), so a success assertion
+# would be vacuous for this bug. Same-directory staging is the property that
+# makes the rename atomic, and it is directly observable.
+MKTEMP_SHIM="$TMP/mktemp-shim"
+mkdir -p "$MKTEMP_SHIM"
+REAL_MKTEMP="$(command -v mktemp)"
+MKTEMP_LOG="$TMP/mktemp-templates.log"
+: >"$MKTEMP_LOG"
+cat >"$MKTEMP_SHIM/mktemp" <<EOF
+#!/usr/bin/env bash
+# Record the template of every FILE mktemp (never the -d scratch dir), then
+# defer to the real mktemp so the run behaves normally.
+for arg in "\$@"; do
+  [ "\$arg" = "-d" ] && exec "$REAL_MKTEMP" "\$@"
+done
+for arg in "\$@"; do
+  case "\$arg" in
+    -*) ;;
+    *) printf '%s\n' "\$arg" >>"$MKTEMP_LOG" ;;
+  esac
+done
+exec "$REAL_MKTEMP" "\$@"
+EOF
+chmod +x "$MKTEMP_SHIM/mktemp"
+
+R="$TMP/staging"
+mkdir -p "$R"
+git -C "$R" -c init.defaultBranch=main init -q
+git -C "$R" config user.email test@example.com
+git -C "$R" config user.name test
+mkfile loose.txt 15
+mkdir -p "$R/tools"
+printf 'loose.txt\t30\n' >"$R/tools/size-ratchet-baseline.tsv"
+git -C "$R" add -A
+
+OUT=""
+RC=0
+OUT="$(cd "$R" && umask 022 && PATH="$MKTEMP_SHIM:$PATH" SIZE_RATCHET_THRESHOLD=10 "$SR" --update 2>&1)" || RC=$?
+[ "$RC" -eq 0 ] && [ "$(cat "$R/tools/size-ratchet-baseline.tsv")" = "$(printf 'loose.txt\t15')" ] \
+  && ok "control: the shimmed --update really tightened the baseline (30 -> 15)" \
+  || bad "control: shimmed --update tightens" "rc=$RC out=$OUT"
+
+# Vacuity anchor: an empty log would satisfy every "no template outside tools/"
+# phrasing of the assertion below.
+templates="$(cat "$MKTEMP_LOG")"
+[ -n "$templates" ] \
+  && ok "control: the mktemp shim recorded a file template, so the location assertion has something to read" \
+  || bad "the mktemp shim recorded nothing" "log is empty"
+
+# The property: every staging template sits in the baseline's OWN directory.
+outside="$(printf '%s\n' "$templates" | grep -v '^tools/' || true)"
+[ -z "$outside" ] \
+  && ok "--update stages the replacement inside tools/, the baseline's own directory (rename is same-filesystem)" \
+  || bad "--update stages outside the baseline's directory" "templates outside tools/: $outside"
+
+# rename(2) carries the SOURCE's mode, and mktemp creates at 0600 — so the
+# replaced baseline must not come back private.
+mode="$(ls -l "$R/tools/size-ratchet-baseline.tsv" | cut -c1-10)"
+[ "$mode" = "-rw-r--r--" ] \
+  && ok "the replaced baseline keeps the umask-implied mode (0644), not mktemp's 0600" \
+  || bad "the replaced baseline's mode" "got $mode, want -rw-r--r--"
+
+# Globbed, not `ls | grep`: the staging file is a DOTFILE, so the dot glob is
+# load-bearing — a plain `*` would report "clean" while debris sat right there.
+leftovers=""
+for entry in "$R"/tools/* "$R"/tools/.*; do
+  [ -e "$entry" ] || continue # unmatched glob expands to itself
+  base="${entry##*/}"
+  case "$base" in
+    "." | ".." | "size-ratchet-baseline.tsv") continue ;;
+  esac
+  leftovers="${leftovers:+$leftovers }$base"
+done
+[ -z "$leftovers" ] \
+  && ok "no staging debris is left beside the baseline" \
+  || bad "no staging debris is left beside the baseline" "$leftovers"
+
+echo "=== the staging chmod survives BSD/macOS option parsing ==="
+# BSD chmod parses options with getopt(3), which stops at the first non-option
+# argument — the mode — so `chmod 644 -- FILE` reads `--` as a literal filename
+# and fails on the nonexistent file `--`, aborting every --update on macOS. GNU
+# chmod permutes and accepts either order, so a Linux-only run cannot see it.
+# BSD chmod is not available on this runner, so the RULE is modelled in a shim
+# rather than the binary: options are honoured only until the first operand.
+CHMOD_SHIM="$TMP/chmod-shim"
+mkdir -p "$CHMOD_SHIM"
+REAL_CHMOD="$(command -v chmod)"
+cat >"$CHMOD_SHIM/chmod" <<EOF
+#!/usr/bin/env bash
+args=()
+seen_operand=0
+for arg in "\$@"; do
+  if [ "\$seen_operand" -eq 0 ]; then
+    case "\$arg" in
+      --) seen_operand=1; continue ;; # end-of-options, consumed
+      -*) args+=("\$arg"); continue ;; # an option
+      *) seen_operand=1 ;;             # the mode: BSD stops scanning here
+    esac
+  fi
+  if [ "\$arg" = "--" ]; then
+    echo "chmod: --: No such file or directory" >&2
+    exit 1
+  fi
+  args+=("\$arg")
+done
+exec "$REAL_CHMOD" "\${args[@]}"
+EOF
+chmod +x "$CHMOD_SHIM/chmod"
+
+# The shim proven in the FAILING direction first, on a real file: without this
+# the shim could be a pass-through and the case below would prove nothing.
+probe="$TMP/chmod-probe"
+: >"$probe"
+if "$CHMOD_SHIM/chmod" 644 -- "$probe" 2>/dev/null; then
+  bad "the BSD chmod shim models the option-parsing rule" "trailing -- was accepted; the shim is inert"
+else
+  ok "control: the BSD chmod shim rejects 'chmod MODE -- FILE', the form macOS breaks on"
+fi
+"$CHMOD_SHIM/chmod" -- 644 "$probe" 2>/dev/null \
+  && ok "control: the same shim accepts 'chmod -- MODE FILE', so it is not rejecting everything" \
+  || bad "the BSD chmod shim accepts the leading -- form" "the shim rejects the correct form too"
+
+R="$TMP/bsd-chmod"
+mkdir -p "$R"
+git -C "$R" -c init.defaultBranch=main init -q
+git -C "$R" config user.email test@example.com
+git -C "$R" config user.name test
+mkfile loose.txt 15
+mkdir -p "$R/tools"
+printf 'loose.txt\t30\n' >"$R/tools/size-ratchet-baseline.tsv"
+git -C "$R" add -A
+
+OUT=""
+RC=0
+OUT="$(cd "$R" && umask 022 && PATH="$CHMOD_SHIM:$PATH" SIZE_RATCHET_THRESHOLD=10 "$SR" --update 2>&1)" || RC=$?
+[ "$RC" -eq 0 ] && [ "$(cat "$R/tools/size-ratchet-baseline.tsv")" = "$(printf 'loose.txt\t15')" ] \
+  && ok "--update completes under BSD chmod option parsing (the mode's -- comes first)" \
+  || bad "--update completes under BSD chmod option parsing" "rc=$RC out=$OUT"
+
+echo "=== a self-referential baseline row converges in ONE --update ==="
+# The baseline file is itself tracked, so when it is over its threshold it earns
+# a row — whose correct value is this file's own final length. The pipeline wrote
+# that row from the PRE-update counts, so pruning any other row left the row
+# disagreeing with reality and the very next check failed: --update contradicting
+# its own one-run tightening guarantee, logging "tightened: … 50 -> 2" for a file
+# that ended up 1 line long. Measured before the fix: a baseline holding one
+# to-be-removed row plus a self-referential row needed TWO runs to converge.
+
+# Case A: the candidate lands at/under the threshold, so the row must GO.
+R="$TMP/selfrow-drop"
+mkdir -p "$R/tools"
+git -C "$R" -c init.defaultBranch=main init -q
+git -C "$R" config user.email test@example.com
+git -C "$R" config user.name test
+mkfile shrunk.txt 1
+printf 'shrunk.txt\t50\ntools/size-ratchet-baseline.tsv\t50\n' >"$R/tools/size-ratchet-baseline.tsv"
+git -C "$R" add -A
+OUT=""; RC=0
+OUT="$(cd "$R" && SIZE_RATCHET_THRESHOLD=1 "$SR" --update 2>&1)" || RC=$?
+[ "$RC" -eq 0 ] && ok "one --update converges: no violation remains on the same run" \
+  || bad "one --update converges (self-row dropped)" "rc=$RC out=$OUT"
+# The verdict must be reachable a second time without another rewrite.
+OUT2=""; RC2=0
+OUT2="$(cd "$R" && SIZE_RATCHET_THRESHOLD=1 "$SR" 2>&1)" || RC2=$?
+[ "$RC2" -eq 0 ] && ok "the immediately following CHECK is clean — the fixed point really was reached" \
+  || bad "the immediately following check is clean" "rc=$RC2 out=$OUT2"
+case "$OUT" in
+  *"stale baseline row"*) bad "--update must not leave the stale self-row it just wrote" "$OUT" ;;
+  *) ok "no stale-row violation is reported by the run that wrote the baseline" ;;
+esac
+# The log must not claim a tighten for a row it removed.
+case "$OUT" in
+  *"removed (the baseline's own row"*) ok "the dropped self-row is announced honestly, correcting the earlier line" ;;
+  *) bad "the dropped self-row is announced" "$OUT" ;;
+esac
+
+# Case B: the candidate stays OVER the threshold, so the row is re-tightened to
+# the real length rather than dropped — the other branch of the same fix.
+R="$TMP/selfrow-tighten"
+mkdir -p "$R/tools"
+git -C "$R" -c init.defaultBranch=main init -q
+git -C "$R" config user.email test@example.com
+git -C "$R" config user.name test
+mkfile keep.txt 5
+mkfile shrunk.txt 1
+printf 'keep.txt\t9\nshrunk.txt\t50\ntools/size-ratchet-baseline.tsv\t50\n' >"$R/tools/size-ratchet-baseline.tsv"
+git -C "$R" add -A
+OUT=""; RC=0
+OUT="$(cd "$R" && SIZE_RATCHET_THRESHOLD=1 "$SR" --update 2>&1)" || RC=$?
+[ "$RC" -eq 0 ] && ok "one --update converges when the self-row survives" \
+  || bad "one --update converges (self-row tightened)" "rc=$RC out=$OUT"
+# Two rows survive (keep.txt and the baseline itself), so the self-row must read
+# exactly 2 — the candidate's own line count, not the pre-update 3.
+expected_self="$(printf 'keep.txt\t5\ntools/size-ratchet-baseline.tsv\t2')"
+actual_self="$(cat "$R/tools/size-ratchet-baseline.tsv")"
+[ "$actual_self" = "$expected_self" ] && ok "the surviving self-row equals the file's final length (2), not its pre-update length" \
+  || bad "the surviving self-row equals the final length" "$(printf 'expected:\n%s\ngot:\n%s' "$expected_self" "$actual_self")"
+rows_on_disk="$(wc -l <"$R/tools/size-ratchet-baseline.tsv" | tr -d ' ')"
+[ "$rows_on_disk" = "2" ] && ok "the row and the on-disk line count agree — self-consistent by construction" \
+  || bad "the row and the on-disk line count agree" "on disk: $rows_on_disk"
+
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -167,7 +167,7 @@ skills/second-opinion/scripts/second-opinion	2506
 skills/second-opinion/tests/cli-failure-gate.test.sh	1211
 skills/second-opinion/tests/lane-scratch-durability.test.sh	999
 skills/second-opinion/tests/review-dual-model.test.sh	1516
-skills/size-ratchet/scripts/size-ratchet	940
+skills/size-ratchet/scripts/size-ratchet	946
 skills/worktree/scripts/worktree	4149
 skills/worktree/scripts/worktree-session-guard	1194
 skills/worktree/tests/worktree_session_guard.sh	1284

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -167,7 +167,7 @@ skills/second-opinion/scripts/second-opinion	2506
 skills/second-opinion/tests/cli-failure-gate.test.sh	1211
 skills/second-opinion/tests/lane-scratch-durability.test.sh	999
 skills/second-opinion/tests/review-dual-model.test.sh	1516
-skills/size-ratchet/scripts/size-ratchet	791
+skills/size-ratchet/scripts/size-ratchet	940
 skills/worktree/scripts/worktree	4149
 skills/worktree/scripts/worktree-session-guard	1194
 skills/worktree/tests/worktree_session_guard.sh	1284


### PR DESCRIPTION
## size-ratchet absorbs the seven fixes from drovr's fork (DRO-201)

Drovr's vendored fork of this script accumulated real fixes the standard copy lacked. A verified convergence analysis reproduced each against upstream; this PR absorbs all seven, which clears the way for drovr to retire the fork and rejoin the standard script on config alone (`SIZE_RATCHET_THRESHOLD=1000`).

1. **`--update` converges in one run** — the baseline's own row is reconciled against the candidate's final length (keyed on the baseline path's own class threshold). Previously any baseline file over its threshold made run 1 fail "baseline looser than reality" on its own row and only run 2 settle.
2. **Fail-closed error routing** — `cd`, scratch writes/appends, dup scans, the staging `cp`, both sorts, and the `--update` pipeline now route through `collection_error`. A broken gate exits as a collection error, never as exit 1 ("violations found").
3. **Excludes index fallback** — when the worktree copy of the excludes file is absent, the index copy applies (symmetry with the baseline; diagnostics say `(index copy)`).
4. **Checked index probes** — `git ls-files -s` with status and `100*` regular-file checks replaces the two discarded-status `git cat-file -t` probes.
5. **Supplied-but-empty `--baseline`/`--excludes` is a config error** (exit 2), never a silent fall-through to the default path.
6. **Atomic `--update` staging** — the replacement baseline is written as a chmod'ed sibling temp beside the baseline and renamed into place; a `$TMPDIR` on another filesystem no longer degrades the "atomic replace" to copy-then-unlink. The pin shims `mktemp` to prove the write location structurally (a same-filesystem success assertion proves nothing).
7. **`--` before the pattern** in the three main-script greps (BSD grep permutes otherwise; a non-permuting grep shim now runs a whole suite pass).

## Verification

- Suite: 207 green before, **259 green across 9 suites** after (new `fail-closed-routing.test.sh`, plus pins in four existing suites).
- Red evidence: the new pins run against the unmodified script fail **31 assertions** (routing 12, collection-fail-closed 5, ratchet-directions 3, settings-and-config 4, update-tightens 7) — the cd, scratch writes, and staging `cp` all exited 1 in that run, the exact confusion fix 2 removes.
- `shellcheck -S warning` clean on the script, lib, and all nine suites. Bash 3.2 / BSD-tool compatible throughout.
- Adjacent consumers green: `hooks/tests/pre-commit-check.test.sh` (55), `skills/growth-guards/tests/install-git-hooks.test.sh` (184).
- Real-repo `--update` is byte-identical, baseline stays 0644, no staging debris.

https://claude.ai/code/session_01EwxSRv8oy1NxoQm66WKa4J
