### PR TITLE
fix(size-ratchet): the index-blob count validates as numeric; a fixture commit failure fails its suite

### DIFF
--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -605,7 +605,7 @@ while IFS= read -r -d '' rec; do
     if ! n="$(git show ":$f" | wc -l)"; then
       collection_error "cannot read index blob for tracked file '$f' — its size is unmeasurable, refusing to skip it"
     fi
-    n="${n//[[:space:]]/}" # strip wc's padding (BSD wc pads)
+    n="${n#"${n%%[![:space:]]*}"}" # strip wc's leading whitespace (BSD wc pads)
     case "$n" in
       "" | *[!0-9]*) collection_error "line count for index blob of '$f' came back as '$n', not a number — its size is unmeasurable, refusing to skip it" ;;
     esac

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -605,7 +605,10 @@ while IFS= read -r -d '' rec; do
     if ! n="$(git show ":$f" | wc -l)"; then
       collection_error "cannot read index blob for tracked file '$f' — its size is unmeasurable, refusing to skip it"
     fi
-    n=$((n)) # strip wc's leading whitespace (BSD wc pads)
+    n="${n//[[:space:]]/}" # strip wc's padding (BSD wc pads)
+    case "$n" in
+      "" | *[!0-9]*) collection_error "line count for index blob of '$f' came back as '$n', not a number — its size is unmeasurable, refusing to skip it" ;;
+    esac
     printf '%s\t%s\n' "$f" "$n" >>"$TMP/counts.raw" || collection_error "could not record the count for '$f' — the measurement is incomplete, refusing to report a verdict"
   else
     WT_BATCH+=("$f")

--- a/skills/size-ratchet/tests/staged-scope.test.sh
+++ b/skills/size-ratchet/tests/staged-scope.test.sh
@@ -114,7 +114,7 @@ mkdir -p "$R/tools"
 mkfile big.txt 30
 printf '# nothing excluded\n' >"$R/tools/size-ratchet-excludes"
 git -C "$R" add -A
-git -C "$R" commit -q -m seed 2>/dev/null || true
+git -C "$R" commit -q -m seed
 printf 'big.txt\tunstaged exclusion\n' >"$R/tools/size-ratchet-excludes"
 run_sr --staged
 [ "$RC" -eq 1 ] && ok "an unstaged exclusion does not silence the staged blob" \

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -167,7 +167,7 @@ skills/second-opinion/scripts/second-opinion	2506
 skills/second-opinion/tests/cli-failure-gate.test.sh	1211
 skills/second-opinion/tests/lane-scratch-durability.test.sh	999
 skills/second-opinion/tests/review-dual-model.test.sh	1516
-skills/size-ratchet/scripts/size-ratchet	946
+skills/size-ratchet/scripts/size-ratchet	949
 skills/worktree/scripts/worktree	4148
 skills/worktree/scripts/worktree-session-guard	1194
 skills/worktree/tests/worktree_session_guard.sh	1284


### PR DESCRIPTION
## Two review findings from drovr's convergence PR, fixed upstream

Both surfaced by bot review on vanillagreencom/drovr#559 against the vendored copies; upstream is the fix site so the vendored copy stays byte-identical.

- The index-blob count path now validates its `wc` output as numeric before arithmetic — the same `"" | *[!0-9]*` → `collection_error` shape the worktree batch path already had (a shimmed/broken `wc` produced exit 1, the violations code, instead of a collection error).
- `staged-scope.test.sh` no longer swallows a fixture `git commit` failure with `|| true` — a fixture that cannot be constructed fails its suite instead of running later pins against a repo with no valid HEAD.

All nine suites green; shellcheck clean.

https://claude.ai/code/session_01EwxSRv8oy1NxoQm66WKa4J
