### PR TITLE
fix(size-ratchet): --seed probes HEAD; settings resolution fails closed; the /dev/null sentinel honors its docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+- size-ratchet: three fail-closed fixes, each with its own regression pin.
+  `--seed` stays bootstrap-only against the COMMITTED baseline too: its
+  existence probe read the index alone, so staging the baseline's deletion
+  (or a truncation) hid a live ratchet and the mode reseeded every row at
+  today's sizes — growth laundered into a fresh freeze at exit 0. HEAD is
+  probed as well, and a failing index query is a loud exit 2 rather than a
+  green light to reseed.
+  Staged settings resolution fails closed on a broken `git`: the
+  tracked-source probe read EVERY nonzero status as "untracked", so an
+  operational failure silently dropped a committed threshold back to the
+  built-in default and passed staged content the commit does not authorize.
+  Only `--error-unmatch`'s "no such path" now means untracked.
+  `SIZE_RATCHET_SETTINGS_FILE=/dev/null` selects no settings source at all.
+  It named only the settings file, so `.env.local` and `.env` kept deciding
+  and a caller asking for built-in defaults got whatever the repository's
+  env files said; the dotenv layers are skipped with it now, leaving
+  explicit environment variables and the defaults.
+
 - size-ratchet: seven fixes absorbed from the forked copy drovr has been
   running (DRO-201), each with its own regression pin.
   `--update` converges in ONE run: the baseline's own row is reconciled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,20 @@
   env files said; the dotenv layers are skipped with it now, leaving
   explicit environment variables and the defaults.
 
+- growth-guards: the same two settings fixes, which its vendored copy of the
+  loader carried. A hook lane resolving tracked settings from the index no
+  longer reads a broken `git` as "untracked" — a committed commit-type list
+  or ceiling silently reverted to the built-in one and admitted a commit its
+  own configuration rejects — and
+  `GROWTH_GUARDS_SETTINGS_FILE=/dev/null` selects no settings source at all
+  rather than leaving `.env.local` and `.env` deciding.
+
+- review-gate: the `/dev/null` force-defaults handle is answered in
+  `rg_setting`, ahead of every source, rather than through an exemption in
+  the source-shape check. Behavior is unchanged there — the loader has no
+  dotenv layers to leak — and the copies vendored from it now answer the
+  sentinel through the same construct.
+
 - size-ratchet: seven fixes absorbed from the forked copy drovr has been
   running (DRO-201), each with its own regression pin.
   `--update` converges in ONE run: the baseline's own row is reconciled

--- a/skills/growth-guards/README.md
+++ b/skills/growth-guards/README.md
@@ -224,7 +224,10 @@ default (env files use `KEY=value` or `export KEY=value`; parsed, never
 sourced). Only an ABSENT source is skipped: a source that exists but is
 unusable — unreadable, a directory, FIFO, socket or device, or a symlink
 that does not resolve — is a config error (exit 2), never a fall-through to
-the next layer; `/dev/null` forces the built-in defaults. Per-check flags
+the next layer. `GROWTH_GUARDS_SETTINGS_FILE=/dev/null` selects no settings
+source at all — `.env.local`, the settings file and `.env` are all skipped —
+leaving explicit environment variables and the built-in defaults. Per-check
+flags
 (`--excludes`, `--baseline`) override every source for the paths. All
 relative paths are repo-root-relative; the scripts `cd` to
 `git rev-parse --show-toplevel` before resolving anything.

--- a/skills/growth-guards/SKILL.md
+++ b/skills/growth-guards/SKILL.md
@@ -82,7 +82,9 @@ Resolution order for every key: explicit environment > `.env.local` >
 `.vstack/settings.toml` > the repo's committed `vstack.settings.toml` (flat
 `KEY = "value"` under `[env]`) > `.env` > built-in default. Only an ABSENT
 source is skipped: one that exists but is unusable is a config error (exit
-2), never a fall-through. `/dev/null` forces the built-in defaults.
+2), never a fall-through. `GROWTH_GUARDS_SETTINGS_FILE=/dev/null` selects no
+settings source at all (`.env.local`, the settings file and `.env` are all
+skipped), leaving environment variables and the defaults.
 
 **Excludes format** — `pattern<TAB>reason` per line (shell glob against the
 full repo-relative path; `*` crosses `/`); a pattern without a reason is a

--- a/skills/growth-guards/scripts/lib/settings.sh
+++ b/skills/growth-guards/scripts/lib/settings.sh
@@ -96,6 +96,33 @@ gg_settings_usable() { # PATH — 0 = readable-shaped or absent; 1 + ::error oth
   return 1
 }
 
+# Lexically normalize a repo-relative path: drop empty and `.` segments, and
+# let `..` pop the segment before it. Pure string surgery — no symlink
+# resolution, Bash 3.2-safe. The index records canonical paths, so a source
+# named `sub/../vstack.settings.toml` is the same entry as
+# `vstack.settings.toml` and has to probe, and materialize, as that one. A
+# `..` with nothing left to pop ACCUMULATES rather than vanishing, so a path
+# that really does leave the repository stays visible as one to the caller.
+gg_settings_normalize_path() { # PATH — normalized path on stdout ("" when it cancels out)
+  local rest="$1" out="" seg
+  while [ -n "$rest" ]; do
+    seg="${rest%%/*}"
+    if [ "$seg" = "$rest" ]; then rest=""; else rest="${rest#*/}"; fi
+    case "$seg" in
+      "" | ".") ;;
+      "..")
+        case "$out" in
+          "" | ".." | */..) out="${out:+$out/}.." ;;
+          */*) out="${out%/*}" ;;
+          *) out="" ;;
+        esac
+        ;;
+      *) out="${out:+$out/}$seg" ;;
+    esac
+  done
+  printf '%s' "$out"
+}
+
 # With GG_SETTINGS_FROM_INDEX=1 a TRACKED settings source is read from the
 # INDEX, a source staged for DELETION governs as absent, and an untracked one
 # (a personal .env.local) is the worktree copy, which is all there is. A
@@ -103,21 +130,35 @@ gg_settings_usable() { # PATH — 0 = readable-shaped or absent; 1 + ::error oth
 # and parsing that would resolve every key to its built-in default.
 # GG_SETTINGS_INDEX_DIR holds the materialized copies; the caller owns it.
 gg_settings_source() { # FILE — the path to actually read; nonzero + ::error on failure
-  local file="$1" copy="" status=0 entry=""
+  local file="$1" copy="" status=0 entry="" norm=""
   if [ "${GG_SETTINGS_FROM_INDEX:-0}" != "1" ] || [ -z "${GG_SETTINGS_INDEX_DIR:-}" ]; then
     printf '%s' "$file"
     return 0
   fi
-  # A path that cannot BE an index entry — absolute, or escaping the root
-  # through a `..` segment — makes git refuse with the same 128 an operational
-  # failure returns, so it is answered before the probes below: the worktree
-  # copy is all such a source ever has.
+  # An ABSOLUTE path is never an index entry, and git refuses such a pathspec
+  # with the same 128 an operational failure returns — so it is answered here,
+  # before the probes below: the worktree copy is all it ever has.
   case "$file" in
-    /* | "../"* | *"/../"* | *"/..")
+    /*)
       printf '%s' "$file"
       return 0
       ;;
   esac
+  # Everything else is judged by what it NORMALIZES to, not by whether it
+  # spells a `..`: `sub/../vstack.settings.toml` is the committed settings
+  # file, and treating any `..` as an escape read it from the worktree — the
+  # unstaged-edit bypass the hook lane exists to close. Only a path that still
+  # leaves the repository once normalized (or cancels out to nothing) keeps
+  # the worktree copy, and it keeps the ORIGINAL spelling, which is what the
+  # caller's own file tests and diagnostics name.
+  norm="$(gg_settings_normalize_path "$file")"
+  case "$norm" in
+    "" | ".." | "../"*)
+      printf '%s' "$file"
+      return 0
+      ;;
+  esac
+  file="$norm"
   # --error-unmatch reserves exit 1 for the one expected answer, "the index
   # has no such path"; every other nonzero status is a FAILING git, not a
   # measurement. Reading them alike let an operational failure pass for

--- a/skills/growth-guards/scripts/lib/settings.sh
+++ b/skills/growth-guards/scripts/lib/settings.sh
@@ -124,7 +124,7 @@ gg_settings_source() { # FILE — the path to actually read; nonzero + ::error o
   # "untracked", which resolved the key from the worktree copy or the
   # built-in default — a committed policy silently swapped for a looser one,
   # admitting a commit its own configuration rejects.
-  git ls-files --error-unmatch -- "$file" >/dev/null 2>&1 || status=$?
+  git ls-files --error-unmatch -- ":(literal)$file" >/dev/null 2>&1 || status=$?
   case "$status" in
     0) ;;
     1)
@@ -145,7 +145,7 @@ gg_settings_source() { # FILE — the path to actually read; nonzero + ::error o
   # let the symlink shape below through to the silent resolve-to-default it
   # exists to prevent.
   status=0
-  entry="$(git ls-files -s -- "$file" 2>/dev/null)" || status=$?
+  entry="$(git ls-files -s -- ":(literal)$file" 2>/dev/null)" || status=$?
   if [ "$status" -ne 0 ]; then
     echo "::error::$file: could not read its index mode while resolving a setting (git ls-files exit $status)" >&2
     return 1

--- a/skills/growth-guards/scripts/lib/settings.sh
+++ b/skills/growth-guards/scripts/lib/settings.sh
@@ -13,9 +13,13 @@
 #   2. .env.local (KEY=value, quotes optional — parsed, never sourced);
 #   3. .vstack/settings.toml, then the repo's committed vstack.settings.toml
 #      (sole uncommented `KEY = "value"` assignment; an explicit
-#      GROWTH_GUARDS_SETTINGS_FILE consults only itself, e.g. /dev/null);
+#      GROWTH_GUARDS_SETTINGS_FILE consults only itself);
 #   4. .env (same shape);
 #   5. the built-in default passed by the caller.
+#
+# GROWTH_GUARDS_SETTINGS_FILE=/dev/null is the force-defaults handle and means
+# NO settings source at all: layers 2-4 are skipped whole, leaving explicit
+# environment variables and the built-in defaults.
 #
 # The parser reads flat single-line basic-string TOML assignments only —
 # exactly the shape vstack.settings.toml [env] blocks use.
@@ -78,10 +82,10 @@ gg_dotenv_value() { # RAW — value on stdout; nonzero on an unsupported shape
 # something else — directory, FIFO, socket, device — fails -f exactly like
 # an absent one, and a symlink that does not resolve fails -e as well as -f,
 # so -L is what sees it at all: either shape would skip a configured source
-# with nothing said and let a lower-precedence value decide. /dev/null is
-# the documented force-defaults handle and stays exempt.
+# with nothing said and let a lower-precedence value decide. The /dev/null
+# force-defaults handle never reaches here — gg_setting answers it before any
+# source is consulted.
 gg_settings_usable() { # PATH — 0 = readable-shaped or absent; 1 + ::error otherwise
-  [ "$1" != "/dev/null" ] || return 0
   { [ -e "$1" ] || [ -L "$1" ]; } || return 0
   [ ! -f "$1" ] || return 0
   if [ ! -e "$1" ]; then
@@ -99,20 +103,54 @@ gg_settings_usable() { # PATH — 0 = readable-shaped or absent; 1 + ::error oth
 # and parsing that would resolve every key to its built-in default.
 # GG_SETTINGS_INDEX_DIR holds the materialized copies; the caller owns it.
 gg_settings_source() { # FILE — the path to actually read; nonzero + ::error on failure
-  local file="$1" copy=""
+  local file="$1" copy="" status=0 entry=""
   if [ "${GG_SETTINGS_FROM_INDEX:-0}" != "1" ] || [ -z "${GG_SETTINGS_INDEX_DIR:-}" ]; then
     printf '%s' "$file"
     return 0
   fi
-  if ! git ls-files --error-unmatch -- "$file" >/dev/null 2>&1; then
-    if git cat-file -e "HEAD:$file" 2>/dev/null; then
-      printf '%s' "$GG_SETTINGS_INDEX_DIR/settings.absent"
+  # A path that cannot BE an index entry — absolute, or escaping the root
+  # through a `..` segment — makes git refuse with the same 128 an operational
+  # failure returns, so it is answered before the probes below: the worktree
+  # copy is all such a source ever has.
+  case "$file" in
+    /* | "../"* | *"/../"* | *"/..")
+      printf '%s' "$file"
       return 0
-    fi
-    printf '%s' "$file"
-    return 0
+      ;;
+  esac
+  # --error-unmatch reserves exit 1 for the one expected answer, "the index
+  # has no such path"; every other nonzero status is a FAILING git, not a
+  # measurement. Reading them alike let an operational failure pass for
+  # "untracked", which resolved the key from the worktree copy or the
+  # built-in default — a committed policy silently swapped for a looser one,
+  # admitting a commit its own configuration rejects.
+  git ls-files --error-unmatch -- "$file" >/dev/null 2>&1 || status=$?
+  case "$status" in
+    0) ;;
+    1)
+      if git cat-file -e "HEAD:$file" 2>/dev/null; then
+        printf '%s' "$GG_SETTINGS_INDEX_DIR/settings.absent"
+        return 0
+      fi
+      printf '%s' "$file"
+      return 0
+      ;;
+    *)
+      echo "::error::$file: could not query the index while resolving a setting (git ls-files exit $status); refusing to treat it as untracked" >&2
+      return 1
+      ;;
+  esac
+  # `ls-files -s` exits 0 whether or not the path matches, so a nonzero status
+  # is a failing invocation and gets the same refusal — an unread mode would
+  # let the symlink shape below through to the silent resolve-to-default it
+  # exists to prevent.
+  status=0
+  entry="$(git ls-files -s -- "$file" 2>/dev/null)" || status=$?
+  if [ "$status" -ne 0 ]; then
+    echo "::error::$file: could not read its index mode while resolving a setting (git ls-files exit $status)" >&2
+    return 1
   fi
-  case "$(git ls-files -s -- "$file" 2>/dev/null | cut -d' ' -f1)" in
+  case "${entry%% *}" in
     120000)
       echo "::error::$file: tracked as a symlink; staged settings resolution cannot read through it" >&2
       return 1
@@ -183,6 +221,15 @@ gg_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
   # ${!name+x} tests set-ness of the variable NAMED by $name (Bash 3.2-safe).
   if [ -n "${!name+x}" ]; then
     printf '%s' "${!name}"
+    return 0
+  fi
+  # /dev/null is the force-defaults handle: it selects NO settings source at
+  # all, so the dotenv layers around the settings file are skipped with it.
+  # Skipping only the TOML layer left .env.local and .env still deciding, so
+  # a caller asking for built-in defaults got whatever the repository's env
+  # files happened to say.
+  if [ "${GROWTH_GUARDS_SETTINGS_FILE:-}" = "/dev/null" ]; then
+    printf '%s' "$default"
     return 0
   fi
   # Standard project layering: .env.local beats the committed settings, .env

--- a/skills/growth-guards/tests/commit-msg.test.sh
+++ b/skills/growth-guards/tests/commit-msg.test.sh
@@ -103,5 +103,74 @@ run_stdin 'feat: settings-rejected type'
   || bad "control: settings-restricted list rejects" "rc=$RC out=$OUT"
 rm "$R/vstack.settings.toml"
 
+echo "=== the /dev/null sentinel selects NO settings source, dotenv layers included ==="
+# It named only the settings file, so .env.local (read before it) and .env
+# (read after it) kept deciding: a caller asking for built-in defaults got
+# whatever the repository's env files said.
+printf 'GROWTH_GUARDS_COMMIT_TYPES=docs\n' >"$R/.env"
+run_stdin 'feat: base type'
+[ "$RC" -eq 1 ] && ok "control: without the sentinel .env restricts the list to docs" \
+  || bad "sentinel control (.env)" "rc=$RC out=$OUT"
+run_stdin 'feat: base type' "GROWTH_GUARDS_SETTINGS_FILE=/dev/null"
+[ "$RC" -eq 0 ] && ok "the sentinel skips .env (read AFTER the settings file) and the built-in list decides" \
+  || bad "sentinel skips .env" "rc=$RC out=$OUT"
+
+printf 'GROWTH_GUARDS_COMMIT_TYPES=chore\n' >"$R/.env.local"
+run_stdin 'feat: base type'
+[ "$RC" -eq 1 ] && ok "control: without the sentinel .env.local restricts the list to chore" \
+  || bad "sentinel control (.env.local)" "rc=$RC out=$OUT"
+run_stdin 'feat: base type' "GROWTH_GUARDS_SETTINGS_FILE=/dev/null"
+[ "$RC" -eq 0 ] && ok "the sentinel skips .env.local (read BEFORE the settings file) too" \
+  || bad "sentinel skips .env.local" "rc=$RC out=$OUT"
+rm -f "$R/.env" "$R/.env.local"
+
+echo "=== a failing index probe never loosens the committed type list ==="
+# The hook lane resolves tracked settings from the INDEX so a commit is judged
+# by its own configuration. `--error-unmatch` reserves exit 1 for "no such
+# path"; reading EVERY nonzero status as "untracked" let a broken git drop the
+# committed list back to the built-in one and admit a type it rejects.
+RI="$TMP/repo-index"
+mkdir -p "$RI"
+git -C "$RI" -c init.defaultBranch=main init -q
+git -C "$RI" config user.email test@example.com
+git -C "$RI" config user.name test
+printf '[env]\nGROWTH_GUARDS_COMMIT_TYPES = "docs"\n' >"$RI/vstack.settings.toml"
+git -C "$RI" add -A
+git -C "$RI" commit -qm "docs: base" --no-verify
+OUT=""; RC=0
+OUT="$(cd "$RI" && printf 'feat: not in the committed list\n' | "$CM" 2>&1)" || RC=$?
+[ "$RC" -eq 1 ] && ok "control: the committed list rejects the header" \
+  || bad "committed list rejects (probe control)" "rc=$RC out=$OUT"
+
+REAL_GIT="$(command -v git)"
+GIT_TRACKED_SHIM="$TMP/git-tracked-shim"
+mkdir -p "$GIT_TRACKED_SHIM"
+cat >"$GIT_TRACKED_SHIM/git" <<EOF
+#!/usr/bin/env bash
+if [ "\${1:-}" = "ls-files" ] && [ "\${2:-}" = "--error-unmatch" ]; then
+  echo "fatal: simulated index-probe failure" >&2
+  exit 71
+fi
+exec "$REAL_GIT" "\$@"
+EOF
+chmod +x "$GIT_TRACKED_SHIM/git"
+OUT=""; RC=0
+OUT="$(cd "$RI" && printf 'feat: not in the committed list\n' | PATH="$GIT_TRACKED_SHIM:$PATH" "$CM" 2>&1)" || RC=$?
+[ "$RC" -eq 2 ] && case "$OUT" in *"could not query the index while resolving a setting"*) true ;; *) false ;; esac \
+  && ok "a failing tracked-source probe is exit 2, never a silent fall back to the built-in list" \
+  || bad "settings probe failure" "rc=$RC out=$OUT"
+
+# A settings source that cannot be an index entry — absolute, or escaping the
+# root — draws git's "outside repository" refusal, which carries the same 128
+# an operational failure does. It is answered before the probe, so such a
+# source still reads from the worktree instead of failing the run.
+printf '[env]\nGROWTH_GUARDS_COMMIT_TYPES = "docs"\n' >"$TMP/outside-settings.toml"
+for path in "$TMP/outside-settings.toml" "../outside-settings.toml"; do
+  OUT=""; RC=0
+  OUT="$(cd "$RI" && printf 'feat: not in the outside list\n' | GROWTH_GUARDS_SETTINGS_FILE="$path" "$CM" 2>&1)" || RC=$?
+  [ "$RC" -eq 1 ] && ok "an out-of-repo settings source still reads in the hook lane ($path)" \
+    || bad "out-of-repo settings source" "path=$path rc=$RC out=$OUT"
+done
+
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/skills/growth-guards/tests/commit-msg.test.sh
+++ b/skills/growth-guards/tests/commit-msg.test.sh
@@ -172,5 +172,30 @@ for path in "$TMP/outside-settings.toml" "../outside-settings.toml"; do
     || bad "out-of-repo settings source" "path=$path rc=$RC out=$OUT"
 done
 
+echo "=== a '..' that normalizes back inside is an ordinary index entry ==="
+# The answer-before-probe shortcut for out-of-repo paths must not swallow
+# sub/../vstack.settings.toml, which IS the committed settings file: reading
+# the worktree copy there handed an unstaged edit exactly the authority the
+# hook lane removes.
+mkdir -p "$RI/sub"
+echo keep >"$RI/sub/keep.txt"
+git -C "$RI" add -A
+git -C "$RI" commit -qm "docs: subdir" --no-verify
+# Loosened on disk only: the commit still carries the docs-only list.
+printf '[env]\nGROWTH_GUARDS_COMMIT_TYPES = "docs feat"\n' >"$RI/vstack.settings.toml"
+for path in "vstack.settings.toml" "sub/../vstack.settings.toml" "./vstack.settings.toml" "a/b/../../vstack.settings.toml"; do
+  OUT=""; RC=0
+  OUT="$(cd "$RI" && printf 'feat: not in the committed list\n' | GROWTH_GUARDS_SETTINGS_FILE="$path" "$CM" 2>&1)" || RC=$?
+  [ "$RC" -eq 1 ] && ok "the committed type list governs a path spelled '$path'" \
+    || bad "dot-dot settings path resolves to the index" "path=$path rc=$RC out=$OUT"
+done
+# Control: still escaping once normalized, so it reads the out-of-repo file
+# (docs-only, written above) instead of anything in the index.
+OUT=""; RC=0
+OUT="$(cd "$RI" && printf 'feat: not in the outside list\n' | GROWTH_GUARDS_SETTINGS_FILE="sub/../../outside-settings.toml" "$CM" 2>&1)" || RC=$?
+[ "$RC" -eq 1 ] && ok "control: a path that still escapes once normalized reads the out-of-repo file" \
+  || bad "normalized escape stays out-of-repo" "rc=$RC out=$OUT"
+git -C "$RI" checkout -q -- vstack.settings.toml
+
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/skills/review-gate/scripts/lib/settings.sh
+++ b/skills/review-gate/scripts/lib/settings.sh
@@ -8,8 +8,12 @@
 #      string, so a caller (or the selftest) can force "explicitly empty";
 #   2. the repo's committed vstack.settings.toml (the file's sole uncommented
 #      `KEY = "value"` assignment; the file path can be overridden with
-#      REVIEW_GATE_SETTINGS_FILE, e.g. /dev/null to force built-in defaults);
+#      REVIEW_GATE_SETTINGS_FILE);
 #   3. the built-in default passed by the caller.
+#
+# REVIEW_GATE_SETTINGS_FILE=/dev/null is the force-defaults handle and means
+# NO settings source at all: layer 2 is skipped whole, leaving explicit
+# environment variables and the built-in defaults.
 #
 # The parser reads flat single-line basic-string TOML assignments only —
 # exactly the shape vstack.settings.toml [env] blocks use. List-valued keys
@@ -30,10 +34,10 @@
 # something else — directory, FIFO, socket, device — fails -f exactly like
 # an absent one, and a symlink that does not resolve fails -e as well as -f,
 # so -L is what sees it at all: either shape would skip a configured source
-# with nothing said and let a lower-precedence value decide. /dev/null is
-# the documented force-defaults handle and stays exempt.
+# with nothing said and let a lower-precedence value decide. The /dev/null
+# force-defaults handle never reaches here — rg_setting answers it before any
+# source is consulted.
 rg_settings_usable() { # PATH — 0 = readable-shaped or absent; 1 + ::error otherwise
-  [ "$1" != "/dev/null" ] || return 0
   { [ -e "$1" ] || [ -L "$1" ]; } || return 0
   [ ! -f "$1" ] || return 0
   if [ ! -e "$1" ]; then
@@ -74,6 +78,15 @@ rg_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
   # ${!name+x} tests set-ness of the variable NAMED by $name (Bash 3.2-safe).
   if [ -n "${!name+x}" ]; then
     printf '%s' "${!name}"
+    return 0
+  fi
+  # /dev/null is the force-defaults handle: it selects NO settings source at
+  # all. Keeping that in one place — here, ahead of every source — is what
+  # keeps this loader and the copies vendored from it (size-ratchet,
+  # growth-guards, which layer dotenv sources around this one) answering the
+  # sentinel identically.
+  if [ "${REVIEW_GATE_SETTINGS_FILE:-}" = "/dev/null" ]; then
+    printf '%s' "$default"
     return 0
   fi
   file="${REVIEW_GATE_SETTINGS_FILE:-vstack.settings.toml}"

--- a/skills/review-gate/tests/settings-parsing.test.sh
+++ b/skills/review-gate/tests/settings-parsing.test.sh
@@ -155,5 +155,25 @@ OUT=""; RC=0
 OUT="$(unset REVIEW_GATE_TN 2>/dev/null; REVIEW_GATE_SETTINGS_FILE="$TMP/absent.settings.toml" rg_setting REVIEW_GATE_TN "dflt" 2>"$TMP/err")" || RC=$?
 [[ "$RC" -eq 0 && "$OUT" == "dflt" ]] && ok "an ABSENT plain file still falls back to the default (control)" || bad "an ABSENT plain file still falls back to the default (control)" "rc=$RC out=$OUT"
 
+echo "=== the /dev/null sentinel selects NO settings source ==="
+# The handle means "no source at all", so it must beat a populated settings
+# file sitting at the default path, and lose only to an explicit environment
+# variable. The copies vendored from this loader layer dotenv sources around
+# it and answer the sentinel the same way, so the contract is pinned here
+# where the shared logic lives.
+mkdir -p "$TMP/sentinel"
+printf '[env]\nREVIEW_GATE_TS = "fromfile"\n' >"$TMP/sentinel/vstack.settings.toml"
+OUT=""; RC=0
+OUT="$(cd "$TMP/sentinel" && unset REVIEW_GATE_TS REVIEW_GATE_SETTINGS_FILE 2>/dev/null; rg_setting REVIEW_GATE_TS "dflt" 2>"$TMP/err")" || RC=$?
+[[ "$RC" -eq 0 && "$OUT" == "fromfile" ]] && ok "control: without the sentinel the settings file at the default path supplies the value" || bad "sentinel control" "rc=$RC out=$OUT"
+
+OUT=""; RC=0
+OUT="$(cd "$TMP/sentinel" && unset REVIEW_GATE_TS 2>/dev/null; REVIEW_GATE_SETTINGS_FILE=/dev/null rg_setting REVIEW_GATE_TS "dflt" 2>"$TMP/err")" || RC=$?
+[[ "$RC" -eq 0 && "$OUT" == "dflt" ]] && ok "the sentinel skips a populated settings file and the built-in default decides" || bad "sentinel skips the settings file" "rc=$RC out=$OUT"
+
+OUT=""; RC=0
+OUT="$(cd "$TMP/sentinel" && REVIEW_GATE_TS="fromenv" REVIEW_GATE_SETTINGS_FILE=/dev/null rg_setting REVIEW_GATE_TS "dflt" 2>"$TMP/err")" || RC=$?
+[[ "$RC" -eq 0 && "$OUT" == "fromenv" ]] && ok "an explicit environment variable still wins over the sentinel" || bad "sentinel vs environment" "rc=$RC out=$OUT"
+
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/skills/size-ratchet/README.md
+++ b/skills/size-ratchet/README.md
@@ -84,8 +84,10 @@ then rerun.
 deciding threshold at its current count — collected by the same pass the
 gate itself trusts (index blobs, symlink skipping, tab/newline refusal),
 `LC_ALL=C` sorted, with a self-row when the baseline outgrows its own
-threshold. It refuses a baseline that already has rows: the ratchet is
-live there, and growth stays a reviewed hand-edit. The seeded file lands
+threshold. It refuses a baseline that already has rows in the worktree, the
+index **or** `HEAD`: the ratchet is live there, and growth stays a reviewed
+hand-edit — staging the baseline's deletion or truncation is not a reseed
+ticket. The seeded file lands
 uncommitted, so the initial freeze is still a reviewed diff — every frozen
 offender enters the record deliberately.
 
@@ -159,7 +161,10 @@ Each key resolves environment > `.env.local` > `.vstack/settings.toml` > committ
 never sourced). Only an ABSENT source is skipped: a source that exists but
 is unusable — unreadable, a directory, FIFO, socket or device, or a symlink
 that does not resolve — is a config error (exit 2), never a fall-through to
-the next layer; `/dev/null` forces the built-in defaults. `--baseline` /
+the next layer. `SIZE_RATCHET_SETTINGS_FILE=/dev/null` selects no settings
+source at all — `.env.local`, the settings file and `.env` are all skipped —
+leaving explicit environment variables and the built-in defaults.
+`--baseline` /
 `--excludes` flags override every source for the paths; supplying one with
 an empty value (`--baseline=`, `--baseline ""`) is a config error, never a
 silent fall back to the default path. All relative paths

--- a/skills/size-ratchet/SKILL.md
+++ b/skills/size-ratchet/SKILL.md
@@ -74,8 +74,9 @@ offenders remain.
 `--seed` writes the FIRST baseline from the gate's own collector: every
 tracked, non-excluded file over its deciding threshold enters at its
 current count, sorted, with a self-row when the baseline outgrows its own
-threshold. A baseline that already has rows refuses — the ratchet is live
-there, and growth stays a reviewed hand-edit. Commit the seeded file.
+threshold. A baseline that already has rows in the worktree, the index or
+`HEAD` refuses — the ratchet is live there, and growth stays a reviewed
+hand-edit. Commit the seeded file.
 
 ## Configuration
 
@@ -85,7 +86,9 @@ Resolution order for every key: explicit environment > `.env.local`
 built-in default. Only an ABSENT source is skipped: a source that exists
 but is unusable — unreadable, a directory, FIFO, socket or device, or a
 symlink that does not resolve — is a config error (exit 2), never a
-fall-through to the next layer. `/dev/null` forces the built-in defaults.
+fall-through to the next layer. `SIZE_RATCHET_SETTINGS_FILE=/dev/null`
+selects no settings source at all (`.env.local`, the settings file and
+`.env` are all skipped), leaving environment variables and the defaults.
 
 | Key | Default | Meaning |
 |---|---|---|

--- a/skills/size-ratchet/scripts/lib/settings.sh
+++ b/skills/size-ratchet/scripts/lib/settings.sh
@@ -124,7 +124,7 @@ sr_settings_source() { # FILE — the path to actually read; nonzero + ::error o
   # "untracked", which resolved the key from the worktree copy or the
   # built-in default — a committed threshold silently swapped for a looser
   # one, admitting staged content the commit does not authorize.
-  git ls-files --error-unmatch -- "$file" >/dev/null 2>&1 || status=$?
+  git ls-files --error-unmatch -- ":(literal)$file" >/dev/null 2>&1 || status=$?
   case "$status" in
     0) ;;
     1)
@@ -149,7 +149,7 @@ sr_settings_source() { # FILE — the path to actually read; nonzero + ::error o
   # failing invocation and gets the same refusal — an unread mode would let
   # the symlink shape through to exactly that silent resolution.
   status=0
-  entry="$(git ls-files -s -- "$file" 2>/dev/null)" || status=$?
+  entry="$(git ls-files -s -- ":(literal)$file" 2>/dev/null)" || status=$?
   if [ "$status" -ne 0 ]; then
     echo "::error::$file: could not read its index mode while resolving a setting (git ls-files exit $status)" >&2
     return 1

--- a/skills/size-ratchet/scripts/lib/settings.sh
+++ b/skills/size-ratchet/scripts/lib/settings.sh
@@ -97,27 +97,68 @@ sr_settings_usable() { # PATH — 0 = readable-shaped or absent; 1 + ::error oth
   return 1
 }
 
+# Lexically normalize a repo-relative path: drop empty and `.` segments, and
+# let `..` pop the segment before it. Pure string surgery — no symlink
+# resolution, Bash 3.2-safe. The index records canonical paths, so a source
+# named `sub/../vstack.settings.toml` is the same entry as
+# `vstack.settings.toml` and has to probe, and materialize, as that one. A
+# `..` with nothing left to pop ACCUMULATES rather than vanishing, so a path
+# that really does leave the repository stays visible as one to the caller.
+sr_settings_normalize_path() { # PATH — normalized path on stdout ("" when it cancels out)
+  local rest="$1" out="" seg
+  while [ -n "$rest" ]; do
+    seg="${rest%%/*}"
+    if [ "$seg" = "$rest" ]; then rest=""; else rest="${rest#*/}"; fi
+    case "$seg" in
+      "" | ".") ;;
+      "..")
+        case "$out" in
+          "" | ".." | */..) out="${out:+$out/}.." ;;
+          */*) out="${out%/*}" ;;
+          *) out="" ;;
+        esac
+        ;;
+      *) out="${out:+$out/}$seg" ;;
+    esac
+  done
+  printf '%s' "$out"
+}
+
 # In staged mode a TRACKED settings source is read from the INDEX: the commit
 # must satisfy its OWN configuration, and an unstaged threshold or path edit
 # must not authorize content the commit does not carry. An untracked source
 # (a personal .env.local) is the worktree copy, which is all there is.
 # SR_SETTINGS_INDEX_DIR holds the materialized copies; the caller owns it.
 sr_settings_source() { # FILE — the path to actually read; nonzero + ::error on failure
-  local file="$1" copy="" status=0 entry=""
+  local file="$1" copy="" status=0 entry="" norm=""
   if [ "${SR_SETTINGS_FROM_INDEX:-0}" != "1" ] || [ -z "${SR_SETTINGS_INDEX_DIR:-}" ]; then
     printf '%s' "$file"
     return 0
   fi
-  # A path that cannot BE an index entry — absolute, or escaping the root
-  # through a `..` segment — makes git refuse with the same 128 an operational
-  # failure returns, so it is answered before the probes below: the worktree
-  # copy is all such a source ever has.
+  # An ABSOLUTE path is never an index entry, and git refuses such a pathspec
+  # with the same 128 an operational failure returns — so it is answered here,
+  # before the probes below: the worktree copy is all it ever has.
   case "$file" in
-    /* | "../"* | *"/../"* | *"/..")
+    /*)
       printf '%s' "$file"
       return 0
       ;;
   esac
+  # Everything else is judged by what it NORMALIZES to, not by whether it
+  # spells a `..`: `sub/../vstack.settings.toml` is the committed settings
+  # file, and treating any `..` as an escape read it from the worktree — the
+  # unstaged-edit bypass staged mode exists to close. Only a path that still
+  # leaves the repository once normalized (or cancels out to nothing) keeps
+  # the worktree copy, and it keeps the ORIGINAL spelling, which is what the
+  # caller's own file tests and diagnostics name.
+  norm="$(sr_settings_normalize_path "$file")"
+  case "$norm" in
+    "" | ".." | "../"*)
+      printf '%s' "$file"
+      return 0
+      ;;
+  esac
+  file="$norm"
   # --error-unmatch reserves exit 1 for the one expected answer, "the index
   # has no such path"; every other nonzero status is a FAILING git, not a
   # measurement. Reading them alike let an operational failure pass for

--- a/skills/size-ratchet/scripts/lib/settings.sh
+++ b/skills/size-ratchet/scripts/lib/settings.sh
@@ -14,9 +14,13 @@
 #   2. .env.local (KEY=value, quotes optional — parsed, never sourced);
 #   3. .vstack/settings.toml, then the repo's committed vstack.settings.toml
 #      (sole uncommented `KEY = "value"` assignment; an explicit
-#      SIZE_RATCHET_SETTINGS_FILE consults only itself, e.g. /dev/null);
+#      SIZE_RATCHET_SETTINGS_FILE consults only itself);
 #   4. .env (same shape);
 #   5. the built-in default passed by the caller.
+#
+# SIZE_RATCHET_SETTINGS_FILE=/dev/null is the force-defaults handle and means
+# NO settings source at all: layers 2-4 are skipped whole, leaving explicit
+# environment variables and the built-in defaults.
 #
 # The parser reads flat single-line basic-string TOML assignments only —
 # exactly the shape vstack.settings.toml [env] blocks use.
@@ -79,10 +83,10 @@ sr_dotenv_value() { # RAW — value on stdout; nonzero on an unsupported shape
 # something else — directory, FIFO, socket, device — fails -f exactly like
 # an absent one, and a symlink that does not resolve fails -e as well as -f,
 # so -L is what sees it at all: either shape would skip a configured source
-# with nothing said and let a lower-precedence value decide. /dev/null is
-# the documented force-defaults handle and stays exempt.
+# with nothing said and let a lower-precedence value decide. The /dev/null
+# force-defaults handle never reaches here — sr_setting answers it before any
+# source is consulted.
 sr_settings_usable() { # PATH — 0 = readable-shaped or absent; 1 + ::error otherwise
-  [ "$1" != "/dev/null" ] || return 0
   { [ -e "$1" ] || [ -L "$1" ]; } || return 0
   [ ! -f "$1" ] || return 0
   if [ ! -e "$1" ]; then
@@ -99,25 +103,58 @@ sr_settings_usable() { # PATH — 0 = readable-shaped or absent; 1 + ::error oth
 # (a personal .env.local) is the worktree copy, which is all there is.
 # SR_SETTINGS_INDEX_DIR holds the materialized copies; the caller owns it.
 sr_settings_source() { # FILE — the path to actually read; nonzero + ::error on failure
-  local file="$1" copy=""
+  local file="$1" copy="" status=0 entry=""
   if [ "${SR_SETTINGS_FROM_INDEX:-0}" != "1" ] || [ -z "${SR_SETTINGS_INDEX_DIR:-}" ]; then
     printf '%s' "$file"
     return 0
   fi
-  if ! git ls-files --error-unmatch -- "$file" >/dev/null 2>&1; then
-    if git cat-file -e "HEAD:$file" 2>/dev/null; then
-      # Staged for deletion: the commit carries no such source, so it must
-      # govern as ABSENT rather than through a recreated worktree copy. A
-      # path that cannot exist is how the probes below read "not there".
-      printf '%s' "$SR_SETTINGS_INDEX_DIR/settings.absent"
+  # A path that cannot BE an index entry — absolute, or escaping the root
+  # through a `..` segment — makes git refuse with the same 128 an operational
+  # failure returns, so it is answered before the probes below: the worktree
+  # copy is all such a source ever has.
+  case "$file" in
+    /* | "../"* | *"/../"* | *"/..")
+      printf '%s' "$file"
       return 0
-    fi
-    printf '%s' "$file"
-    return 0
-  fi
+      ;;
+  esac
+  # --error-unmatch reserves exit 1 for the one expected answer, "the index
+  # has no such path"; every other nonzero status is a FAILING git, not a
+  # measurement. Reading them alike let an operational failure pass for
+  # "untracked", which resolved the key from the worktree copy or the
+  # built-in default — a committed threshold silently swapped for a looser
+  # one, admitting staged content the commit does not authorize.
+  git ls-files --error-unmatch -- "$file" >/dev/null 2>&1 || status=$?
+  case "$status" in
+    0) ;;
+    1)
+      if git cat-file -e "HEAD:$file" 2>/dev/null; then
+        # Staged for deletion: the commit carries no such source, so it must
+        # govern as ABSENT rather than through a recreated worktree copy. A
+        # path that cannot exist is how the probes below read "not there".
+        printf '%s' "$SR_SETTINGS_INDEX_DIR/settings.absent"
+        return 0
+      fi
+      printf '%s' "$file"
+      return 0
+      ;;
+    *)
+      echo "::error::$file: could not query the index while resolving a setting (git ls-files exit $status); refusing to treat it as untracked" >&2
+      return 1
+      ;;
+  esac
   # A symlink's index blob is its TARGET NAME, not settings content: parsing
-  # it would silently resolve every key to its built-in default.
-  case "$(git ls-files -s -- "$file" 2>/dev/null | cut -d' ' -f1)" in
+  # it would silently resolve every key to its built-in default. `ls-files -s`
+  # exits 0 whether or not the path matches, so a nonzero status here is a
+  # failing invocation and gets the same refusal — an unread mode would let
+  # the symlink shape through to exactly that silent resolution.
+  status=0
+  entry="$(git ls-files -s -- "$file" 2>/dev/null)" || status=$?
+  if [ "$status" -ne 0 ]; then
+    echo "::error::$file: could not read its index mode while resolving a setting (git ls-files exit $status)" >&2
+    return 1
+  fi
+  case "${entry%% *}" in
     120000)
       echo "::error::$file: tracked as a symlink; staged settings resolution cannot read through it" >&2
       return 1
@@ -168,6 +205,15 @@ sr_setting() { # NAME DEFAULT — resolved value on stdout; nonzero + ::error on
   # ${!name+x} tests set-ness of the variable NAMED by $name (Bash 3.2-safe).
   if [ -n "${!name+x}" ]; then
     printf '%s' "${!name}"
+    return 0
+  fi
+  # /dev/null is the force-defaults handle: it selects NO settings source at
+  # all, so the dotenv layers around the settings file are skipped with it.
+  # Skipping only the TOML layer left .env.local and .env still deciding, so
+  # a caller asking for built-in defaults got whatever the repository's env
+  # files happened to say.
+  if [ "${SIZE_RATCHET_SETTINGS_FILE:-}" = "/dev/null" ]; then
+    printf '%s' "$default"
     return 0
   fi
   # Env-file overrides (standard project layering: .env.local beats the

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -327,6 +327,31 @@ read_index_file_mode() { # PATH — sets INDEX_FILE_MODE ("" when untracked)
   [ -n "$entry" ] || INDEX_FILE_MODE=""
 }
 
+# The same probe against the COMMITTED tree, for the one state the index
+# cannot answer: a path whose DELETION is staged is gone from the index, so an
+# index-only look reads a committed file as "never there". `git ls-tree` reads
+# the named tree and exits 0 whether or not the path matches — printing the
+# entry only when it does — so, exactly as above, a nonzero status is a real
+# failure and never "not there". An UNBORN HEAD carries nothing by definition
+# (a repository before its first commit, which is where a bootstrap runs);
+# rev-parse reserves exit 1 for that, and any other status is a failure too.
+# Same call discipline as read_index_file_mode: a plain command, never `$(...)`.
+HEAD_FILE_MODE=""
+read_head_file_mode() { # PATH — sets HEAD_FILE_MODE ("" when HEAD carries no such path)
+  local entry status=0 head_status=0
+  HEAD_FILE_MODE=""
+  git rev-parse --verify --quiet HEAD >/dev/null 2>&1 || head_status=$?
+  case "$head_status" in
+    0) ;;
+    1) return 0 ;;
+    *) collection_error "could not resolve HEAD while probing for $1 (git rev-parse exit $head_status) — refusing to treat it as absent" ;;
+  esac
+  entry="$(git ls-tree HEAD -- ":(literal)$1")" || status=$?
+  [ "$status" -eq 0 ] || collection_error "could not query HEAD for $1 (git ls-tree exit $status) — refusing to treat it as absent"
+  HEAD_FILE_MODE="${entry%% *}"
+  [ -n "$entry" ] || HEAD_FILE_MODE=""
+}
+
 read_policy_from_index() { # PATH — stages the index copy of the list at $TMP/excludes
   case "$INDEX_FILE_MODE" in
     100*) ;;
@@ -845,15 +870,40 @@ if [ "$MODE" = "seed" ]; then
   if [ -e "$BASELINE_FILE" ] && [ -e "$EXCLUDES_FILE" ] && [ "$BASELINE_FILE" -ef "$EXCLUDES_FILE" ]; then
     config_error "--seed refuses: the baseline and exclusion list are the same file (aliased through a link) — seeding would turn every row into an exclusion on the next run"
   fi
-  # Bootstrap-only holds against the committed record too: rows in the INDEX
+  # Bootstrap-only holds against the recorded copies too: rows in the INDEX
   # copy mean the ratchet is live even when the worktree copy was truncated,
   # and a regenerated baseline must be a reviewed hand-edit, never a reseed.
-  if git ls-files --error-unmatch -- "$BASELINE_FILE" >/dev/null 2>&1; then
+  # The probe is the collector's own, so a failing git terminates here rather
+  # than reading as "no such path" and clearing the way for a reseed.
+  read_index_file_mode "$BASELINE_FILE"
+  if [ -n "$INDEX_FILE_MODE" ]; then
+    case "$INDEX_FILE_MODE" in
+      100*) ;;
+      *) config_error "--seed refuses: the index carries $BASELINE_FILE as a non-regular entry (mode $INDEX_FILE_MODE); seeding cannot read it to prove the ratchet is not live" ;;
+    esac
     git show ":$BASELINE_FILE" >"$TMP/baseline.index" 2>/dev/null \
       || collection_error "could not read the index copy of $BASELINE_FILE — seeding cannot prove the ratchet is not live"
     rows_index="$(count_nonempty_lines "$TMP/baseline.index")"
     if [ "$rows_index" -gt 0 ]; then
       config_error "--seed refuses: the INDEX copy of $BASELINE_FILE carries $rows_index row(s) — the ratchet is live; restore the file (git checkout -- $BASELINE_FILE) or hand-edit it"
+    fi
+  fi
+  # …and against the COMMITTED copy, which is what the index probe above
+  # cannot see: staging the baseline's DELETION (or a truncation) empties it
+  # from the index, and an index-only look then reads a live ratchet as "no
+  # baseline" and reseeds every row at today's sizes — laundering growth into
+  # a fresh freeze with nothing said.
+  read_head_file_mode "$BASELINE_FILE"
+  if [ -n "$HEAD_FILE_MODE" ]; then
+    case "$HEAD_FILE_MODE" in
+      100*) ;;
+      *) config_error "--seed refuses: HEAD carries $BASELINE_FILE as a non-regular entry (mode $HEAD_FILE_MODE); seeding cannot read it to prove the ratchet is not live" ;;
+    esac
+    git show "HEAD:$BASELINE_FILE" >"$TMP/baseline.head" 2>/dev/null \
+      || collection_error "could not read the committed copy of $BASELINE_FILE — seeding cannot prove the ratchet is not live"
+    rows_head="$(count_nonempty_lines "$TMP/baseline.head")"
+    if [ "$rows_head" -gt 0 ]; then
+      config_error "--seed refuses: the COMMITTED copy of $BASELINE_FILE carries $rows_head row(s) — the ratchet is live even though the worktree and index copies no longer carry them; restore the file (git checkout HEAD -- $BASELINE_FILE) or hand-edit it"
     fi
   fi
   rows_existing="$(count_nonempty_lines "$TMP/baseline.tsv")"

--- a/skills/size-ratchet/tests/seed.test.sh
+++ b/skills/size-ratchet/tests/seed.test.sh
@@ -197,6 +197,114 @@ run_sr --seed
   && ok "--seed refuses while the index copy carries rows" \
   || bad "index-rows refusal" "rc=$RC out=$OUT"
 
+echo "=== a committed ratchet refuses reseeding when its deletion or truncation is STAGED ==="
+# The index probe above cannot see this: staging the baseline's deletion drops
+# it from the index, so an index-only look read a live ratchet as "no baseline
+# yet" and reseeded every row at today's size — laundering growth into a fresh
+# freeze at exit 0.
+R="$TMP/staged-delete"
+mkdir -p "$R/tools"
+git -C "$R" -c init.defaultBranch=main init -q
+git -C "$R" config user.email test@example.com
+git -C "$R" config user.name test
+mkfile big.txt 15
+printf 'big.txt\t15\n' >"$R/tools/size-ratchet-baseline.tsv"
+git -C "$R" add -A
+git -C "$R" commit -qm base
+mkfile big.txt 30 # the growth a reseed would freeze at its new size
+git -C "$R" add big.txt
+git -C "$R" rm -q --cached tools/size-ratchet-baseline.tsv
+rm "$R/tools/size-ratchet-baseline.tsv"
+run_sr --seed
+[ "$RC" -eq 2 ] && case "$OUT" in *"COMMITTED copy"*) true ;; *) false ;; esac \
+  && ok "--seed refuses while HEAD carries rows the staged deletion hid" \
+  || bad "staged-deletion refusal" "rc=$RC out=$OUT"
+[ ! -e "$R/tools/size-ratchet-baseline.tsv" ] && ok "and no baseline was written" \
+  || bad "staged-deletion wrote a baseline" "$(cat "$R/tools/size-ratchet-baseline.tsv")"
+
+# Same bypass one shape over: an emptied baseline staged as the new content.
+R="$TMP/staged-truncate"
+mkdir -p "$R/tools"
+git -C "$R" -c init.defaultBranch=main init -q
+git -C "$R" config user.email test@example.com
+git -C "$R" config user.name test
+mkfile big.txt 15
+printf 'big.txt\t15\n' >"$R/tools/size-ratchet-baseline.tsv"
+git -C "$R" add -A
+git -C "$R" commit -qm base
+mkfile big.txt 30
+: >"$R/tools/size-ratchet-baseline.tsv"
+git -C "$R" add -A
+run_sr --seed
+[ "$RC" -eq 2 ] && case "$OUT" in *"COMMITTED copy"*) true ;; *) false ;; esac \
+  && ok "--seed refuses while HEAD carries rows a staged truncation hid" \
+  || bad "staged-truncation refusal" "rc=$RC out=$OUT"
+[ ! -s "$R/tools/size-ratchet-baseline.tsv" ] && ok "and the emptied file stays empty" \
+  || bad "staged-truncation wrote rows" "$(cat "$R/tools/size-ratchet-baseline.tsv")"
+
+# Control: with the deletion COMMITTED there is no live ratchet anywhere, and
+# the bootstrap this mode exists for must still run.
+R="$TMP/committed-delete"
+mkdir -p "$R/tools"
+git -C "$R" -c init.defaultBranch=main init -q
+git -C "$R" config user.email test@example.com
+git -C "$R" config user.name test
+mkfile big.txt 15
+printf 'big.txt\t15\n' >"$R/tools/size-ratchet-baseline.tsv"
+git -C "$R" add -A
+git -C "$R" commit -qm base
+git -C "$R" rm -q tools/size-ratchet-baseline.tsv
+git -C "$R" commit -qm drop
+run_sr --seed
+[ "$RC" -eq 0 ] && [ "$(cat "$R/tools/size-ratchet-baseline.tsv")" = "$(printf 'big.txt\t15')" ] \
+  && ok "control: a committed deletion leaves nothing live and --seed writes the first baseline" \
+  || bad "committed-deletion control" "rc=$RC out=$OUT"
+
+echo "=== a failing index probe never clears the way for a reseed ==="
+# The probe that decides whether the index carries a baseline must fail LOUD:
+# a nonzero status read as "no such path" let an operational failure pass for
+# "no baseline yet" and the mode reseeded over live rows. Only the BASELINE's
+# own index query is shimmed, so the refusal has to come from this probe
+# rather than from another fail-closed read on the way in.
+REAL_GIT="$(command -v git)"
+GIT_PROBE_SHIM="$TMP/git-probe-shim"
+mkdir -p "$GIT_PROBE_SHIM"
+cat >"$GIT_PROBE_SHIM/git" <<EOF
+#!/usr/bin/env bash
+if [ "\${1:-}" = "ls-files" ]; then
+  for a in "\$@"; do
+    case "\$a" in
+      *tools/size-ratchet-baseline.tsv)
+        echo "fatal: simulated index-probe failure" >&2
+        exit 71
+        ;;
+    esac
+  done
+fi
+exec "$REAL_GIT" "\$@"
+EOF
+chmod +x "$GIT_PROBE_SHIM/git"
+R="$TMP/probe-failure"
+mkdir -p "$R/tools"
+git -C "$R" -c init.defaultBranch=main init -q
+git -C "$R" config user.email test@example.com
+git -C "$R" config user.name test
+mkfile big.txt 30
+printf 'big.txt\t15\n' >"$R/tools/size-ratchet-baseline.tsv"
+git -C "$R" add -A
+: >"$R/tools/size-ratchet-baseline.tsv" # rows live in the index only
+OUT=""; RC=0
+OUT="$(cd "$R" && PATH="$GIT_PROBE_SHIM:$PATH" SIZE_RATCHET_THRESHOLD=10 "$SR" --seed 2>&1)" || RC=$?
+[ "$RC" -eq 2 ] && case "$OUT" in *"refusing to treat it as absent"*) true ;; *) false ;; esac \
+  && ok "a nonzero index probe is exit 2, not a green light to reseed" \
+  || bad "index probe failure" "rc=$RC out=$OUT"
+[ ! -s "$R/tools/size-ratchet-baseline.tsv" ] && ok "and nothing was written over the baseline" \
+  || bad "probe failure wrote rows" "$(cat "$R/tools/size-ratchet-baseline.tsv")"
+run_sr --seed
+[ "$RC" -eq 2 ] && case "$OUT" in *"INDEX copy"*) true ;; *) false ;; esac \
+  && ok "control: unshimmed, the same tree refuses on the index rows it can read" \
+  || bad "index probe control" "rc=$RC out=$OUT"
+
 echo "=== an exclusion list hard-linked to the baseline refuses ==="
 R="$TMP/hardlink-alias"
 mkdir -p "$R/tools"

--- a/skills/size-ratchet/tests/settings-and-config.test.sh
+++ b/skills/size-ratchet/tests/settings-and-config.test.sh
@@ -244,6 +244,38 @@ run_raw SIZE_RATCHET_SETTINGS_FILE=absent.settings.toml || true
   && ok "an ABSENT plain file still falls back to the built-in default (control)" \
   || bad "an ABSENT plain file still falls back to the built-in default (control)" "rc=$RC out=$OUT"
 
+echo "=== the /dev/null sentinel selects NO settings source, dotenv layers included ==="
+# It named only the settings file, so .env.local (read before it) and .env
+# (read after it) kept deciding: a caller asking for built-in defaults got
+# whatever the repository's env files said.
+new_repo devnull
+mkfile f.txt 10
+git -C "$R" add -A
+printf 'SIZE_RATCHET_THRESHOLD=5\n' >"$R/.env"
+run_raw || true
+[ "$RC" -eq 1 ] && case "$OUT" in *"threshold 5"*) true ;; *) false ;; esac \
+  && ok "control: without the sentinel .env supplies 5 and the 10-line file fails" \
+  || bad "devnull control (.env)" "rc=$RC out=$OUT"
+run_raw SIZE_RATCHET_SETTINGS_FILE=/dev/null || true
+[ "$RC" -eq 0 ] && case "$OUT" in *"threshold 400"*) true ;; *) false ;; esac \
+  && ok "the sentinel skips .env (read AFTER the settings file) and the built-in 400 decides" \
+  || bad "sentinel skips .env" "rc=$RC out=$OUT"
+
+printf 'SIZE_RATCHET_THRESHOLD=6\n' >"$R/.env.local"
+run_raw || true
+[ "$RC" -eq 1 ] && case "$OUT" in *"threshold 6"*) true ;; *) false ;; esac \
+  && ok "control: without the sentinel .env.local supplies 6" \
+  || bad "devnull control (.env.local)" "rc=$RC out=$OUT"
+run_raw SIZE_RATCHET_SETTINGS_FILE=/dev/null || true
+[ "$RC" -eq 0 ] && case "$OUT" in *"threshold 400"*) true ;; *) false ;; esac \
+  && ok "the sentinel skips .env.local (read BEFORE the settings file) too" \
+  || bad "sentinel skips .env.local" "rc=$RC out=$OUT"
+
+run_raw SIZE_RATCHET_SETTINGS_FILE=/dev/null SIZE_RATCHET_THRESHOLD=5 || true
+[ "$RC" -eq 1 ] && case "$OUT" in *"threshold 5"*) true ;; *) false ;; esac \
+  && ok "an explicit environment variable still wins over the sentinel" \
+  || bad "sentinel vs environment" "rc=$RC out=$OUT"
+
 echo "=== an EXISTING non-regular ENV-FILE source never falls through ==="
 # .env.local and .env are probed with -f like the settings file, so a
 # directory or an unresolvable symlink there is skipped exactly like an

--- a/skills/size-ratchet/tests/staged-scope.test.sh
+++ b/skills/size-ratchet/tests/staged-scope.test.sh
@@ -164,6 +164,50 @@ OUT=""; RC=0
 OUT="$(cd "$R" && SIZE_RATCHET_THRESHOLD=10 "$SR" --staged 2>&1)" || RC=$?
 [ "$RC" -eq 0 ] && ok "an explicit environment override still wins" || bad "env override wins" "rc=$RC out=$OUT"
 
+new_repo settings-probe-failure
+mkfile big.txt 200
+printf '[env]\nSIZE_RATCHET_THRESHOLD = "100"\n' >"$R/vstack.settings.toml"
+git -C "$R" add -A
+git -C "$R" commit -q -m seed
+OUT=""; RC=0
+OUT="$(cd "$R" && "$SR" --staged 2>&1)" || RC=$?
+[ "$RC" -eq 1 ] && case "$OUT" in *"threshold 100"*) true ;; *) false ;; esac \
+  && ok "control: the committed threshold of 100 rejects the 200-line blob" \
+  || bad "committed threshold rejects (probe control)" "rc=$RC out=$OUT"
+# The staged-source probe asks the index whether a settings file is tracked.
+# `--error-unmatch` reserves exit 1 for "no such path"; reading EVERY nonzero
+# status as "untracked" let a broken git drop the committed threshold back to
+# the built-in 400 and pass the 200-line offender.
+REAL_GIT="$(command -v git)"
+GIT_TRACKED_SHIM="$TMP/git-tracked-shim"
+mkdir -p "$GIT_TRACKED_SHIM"
+cat >"$GIT_TRACKED_SHIM/git" <<EOF
+#!/usr/bin/env bash
+if [ "\${1:-}" = "ls-files" ] && [ "\${2:-}" = "--error-unmatch" ]; then
+  echo "fatal: simulated index-probe failure" >&2
+  exit 71
+fi
+exec "$REAL_GIT" "\$@"
+EOF
+chmod +x "$GIT_TRACKED_SHIM/git"
+OUT=""; RC=0
+OUT="$(cd "$R" && PATH="$GIT_TRACKED_SHIM:$PATH" "$SR" --staged 2>&1)" || RC=$?
+[ "$RC" -eq 2 ] && case "$OUT" in *"could not query the index while resolving a setting"*) true ;; *) false ;; esac \
+  && ok "a failing tracked-source probe is exit 2, never a silent fall back to the built-in threshold" \
+  || bad "settings probe failure" "rc=$RC out=$OUT"
+# A settings source that cannot be an index entry — absolute, or escaping the
+# root — draws git's "outside repository" refusal, which carries the same 128
+# an operational failure does. It is answered before the probe, so such a
+# source still reads from the worktree instead of failing the run.
+printf '[env]\nSIZE_RATCHET_THRESHOLD = "5"\n' >"$TMP/outside-settings.toml"
+for path in "$TMP/outside-settings.toml" "../outside-settings.toml"; do
+  OUT=""; RC=0
+  OUT="$(cd "$R" && SIZE_RATCHET_SETTINGS_FILE="$path" "$SR" --staged 2>&1)" || RC=$?
+  [ "$RC" -eq 1 ] && case "$OUT" in *"threshold 5"*) true ;; *) false ;; esac \
+    && ok "an out-of-repo settings source still reads under --staged ($path)" \
+    || bad "out-of-repo settings source" "path=$path rc=$RC out=$OUT"
+done
+
 new_repo settings-deleted
 mkfile big.txt 8
 printf '[env]\nSIZE_RATCHET_THRESHOLD = "10"\n' >"$R/vstack.settings.toml"

--- a/skills/size-ratchet/tests/staged-scope.test.sh
+++ b/skills/size-ratchet/tests/staged-scope.test.sh
@@ -208,6 +208,36 @@ for path in "$TMP/outside-settings.toml" "../outside-settings.toml"; do
     || bad "out-of-repo settings source" "path=$path rc=$RC out=$OUT"
 done
 
+# …but a `..` that NORMALIZES back inside is an ordinary index entry, and the
+# answer-before-probe shortcut must not swallow it: sub/../vstack.settings.toml
+# IS the committed settings file, so reading the worktree copy there handed
+# the unstaged threshold bump exactly the authority --staged removes.
+new_repo settings-dotdot
+mkdir -p "$R/sub"
+mkfile big.txt 200
+mkfile sub/keep.txt 1
+printf '[env]\nSIZE_RATCHET_THRESHOLD = "100"\n' >"$R/vstack.settings.toml"
+git -C "$R" add -A
+git -C "$R" commit -q -m seed
+# Raised on disk only: the commit still carries 100, so the 200-line blob
+# fails however the settings path is spelled.
+printf '[env]\nSIZE_RATCHET_THRESHOLD = "300"\n' >"$R/vstack.settings.toml"
+for path in "vstack.settings.toml" "sub/../vstack.settings.toml" "./vstack.settings.toml" "a/b/../../vstack.settings.toml"; do
+  OUT=""; RC=0
+  OUT="$(cd "$R" && SIZE_RATCHET_SETTINGS_FILE="$path" "$SR" --staged 2>&1)" || RC=$?
+  [ "$RC" -eq 1 ] && case "$OUT" in *"threshold 100"*) true ;; *) false ;; esac \
+    && ok "the committed threshold governs a path spelled '$path'" \
+    || bad "dot-dot settings path resolves to the index" "path=$path rc=$RC out=$OUT"
+done
+# Control: a path that STILL escapes once normalized keeps the worktree lane
+# — it reads the out-of-repo file ($TMP/outside-settings.toml, threshold 5,
+# written above) rather than resolving to anything in the index.
+OUT=""; RC=0
+OUT="$(cd "$R" && SIZE_RATCHET_SETTINGS_FILE="sub/../../outside-settings.toml" "$SR" --staged 2>&1)" || RC=$?
+[ "$RC" -eq 1 ] && case "$OUT" in *"threshold 5"*) true ;; *) false ;; esac \
+  && ok "control: a path that still escapes once normalized reads the out-of-repo file" \
+  || bad "normalized escape stays out-of-repo" "rc=$RC out=$OUT"
+
 new_repo settings-deleted
 mkfile big.txt 8
 printf '[env]\nSIZE_RATCHET_THRESHOLD = "10"\n' >"$R/vstack.settings.toml"

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -167,7 +167,7 @@ skills/second-opinion/scripts/second-opinion	2506
 skills/second-opinion/tests/cli-failure-gate.test.sh	1211
 skills/second-opinion/tests/lane-scratch-durability.test.sh	999
 skills/second-opinion/tests/review-dual-model.test.sh	1516
-skills/size-ratchet/scripts/size-ratchet	949
+skills/size-ratchet/scripts/size-ratchet	999
 skills/worktree/scripts/worktree	4148
 skills/worktree/scripts/worktree-session-guard	1194
 skills/worktree/tests/worktree_session_guard.sh	1284


### PR DESCRIPTION
## Three verified defects from the drovr convergence review, fixed at the source

All three were reported with reproductions by bot review on vanillagreencom/drovr#559 against the vendored size-ratchet copy; upstream is the fix site so the vendored copy stays byte-identical.

1. **(P1) `--seed` refuses a live ratchet even when the baseline's deletion is staged.** The bootstrap-only probe consulted the index alone, so staging the baseline's deletion let `--seed` recreate enlarged rows and exit 0. The existence probe now also consults HEAD (status-checked, fail-closed); a baseline in HEAD, the index, or the worktree refuses the seed. Pinned by 6 new seed assertions (staged deletion, staged truncation, probe failure — each with a no-write control).
2. **(P2) Staged settings resolution fails closed on a git error.** `sr_settings_source` classified every nonzero `ls-files --error-unmatch` as "not tracked", so an operational git failure silently dropped a committed threshold back to the built-in default. Status 1 (documented not-a-path) proceeds; anything else is exit 2. The adjacent symlink-mode probe is hardened the same way, and an out-of-repo settings path is answered before the probes (it can never be an index entry) — two controls pin that behavior preservation.
3. **(P2) The `/dev/null` sentinel now does what the docs claim.** `SIZE_RATCHET_SETTINGS_FILE=/dev/null` short-circuits in `sr_setting` after the explicit-environment layer: `.env.local`, the settings file, and `.env` are all skipped; env vars still win. Nothing depended on the old layering (the only repo uses are the suite's own fixtures). README/SKILL.md updated.

The same loader is vendored in growth-guards and review-gate: growth-guards had both gaps (fixed, 3 red pins in its commit-msg suite); review-gate's `rg_setting` has no dotenv layers so the sentinel already behaved — it moves to the same explicit short-circuit construct (divergence fix, controls only, stated plainly: those pins cannot go red).

## Verification

- Red runs against unmodified code: size-ratchet 9 failing pins (seed 6, settings 2, staged 1), growth-guards 3; every pre-existing assertion green in the same runs.
- All suites green: size-ratchet 9 suites / 276 assertions; growth-guards 8 suites (incl. install-git-hooks 184); review-gate full shard (pr-watch 175, writer-template 505, predicate selftests 197/235, settings-parsing 26).
- `shellcheck -S warning` clean on all touched files. Bash 3.2 / BSD throughout.

https://claude.ai/code/session_01EwxSRv8oy1NxoQm66WKa4J
