### PR TITLE
fix(size-ratchet,growth-guards): the staged-deletion HEAD probes fail closed

### DIFF
--- a/skills/growth-guards/scripts/lib/settings.sh
+++ b/skills/growth-guards/scripts/lib/settings.sh
@@ -130,7 +130,7 @@ gg_settings_normalize_path() { # PATH — normalized path on stdout ("" when it 
 # and parsing that would resolve every key to its built-in default.
 # GG_SETTINGS_INDEX_DIR holds the materialized copies; the caller owns it.
 gg_settings_source() { # FILE — the path to actually read; nonzero + ::error on failure
-  local file="$1" copy="" status=0 entry="" norm=""
+  local file="$1" copy="" status=0 entry="" norm="" head_status=0 cf_status=0
   if [ "${GG_SETTINGS_FROM_INDEX:-0}" != "1" ] || [ -z "${GG_SETTINGS_INDEX_DIR:-}" ]; then
     printf '%s' "$file"
     return 0
@@ -169,10 +169,37 @@ gg_settings_source() { # FILE — the path to actually read; nonzero + ::error o
   case "$status" in
     0) ;;
     1)
-      if git cat-file -e "HEAD:$file" 2>/dev/null; then
-        printf '%s' "$GG_SETTINGS_INDEX_DIR/settings.absent"
-        return 0
-      fi
+      # The HEAD probe is classified like the index probe above: cat-file -e
+      # exits 128 both for "no such path" and for an operational failure, so
+      # a bare probe read a broken git as "never tracked" and let a
+      # recreated worktree copy authorize staged content. An unborn HEAD
+      # carries nothing by definition (rev-parse reserves exit 1 for it).
+      git rev-parse --verify --quiet HEAD >/dev/null 2>&1 || head_status=$?
+      case "$head_status" in
+        0)
+          # ls-tree, never cat-file -e: with rev:path syntax git answers
+          # "no such path in HEAD" with the same 128 an operational failure
+          # returns, so only ls-tree (exit 0, empty output for an absent
+          # path) can tell the two apart.
+          entry="$(git ls-tree HEAD -- ":(literal)$file" 2>/dev/null)" || cf_status=$?
+          if [ "$cf_status" -ne 0 ]; then
+            echo "::error::$file: could not probe HEAD while resolving a setting (git ls-tree exit $cf_status); refusing to treat it as untracked" >&2
+            return 1
+          fi
+          case "${entry:+tracked}" in
+            tracked)
+              printf '%s' "$GG_SETTINGS_INDEX_DIR/settings.absent"
+              return 0
+              ;;
+            *) ;;
+          esac
+          ;;
+        1) ;;
+        *)
+          echo "::error::$file: could not resolve HEAD while resolving a setting (git rev-parse exit $head_status); refusing to treat it as untracked" >&2
+          return 1
+          ;;
+      esac
       printf '%s' "$file"
       return 0
       ;;

--- a/skills/growth-guards/scripts/lib/settings.sh
+++ b/skills/growth-guards/scripts/lib/settings.sh
@@ -130,7 +130,7 @@ gg_settings_normalize_path() { # PATH — normalized path on stdout ("" when it 
 # and parsing that would resolve every key to its built-in default.
 # GG_SETTINGS_INDEX_DIR holds the materialized copies; the caller owns it.
 gg_settings_source() { # FILE — the path to actually read; nonzero + ::error on failure
-  local file="$1" copy="" status=0 entry="" norm="" head_status=0 cf_status=0
+  local file="$1" copy="" status=0 entry="" norm="" head_status=0 tree_status=0
   if [ "${GG_SETTINGS_FROM_INDEX:-0}" != "1" ] || [ -z "${GG_SETTINGS_INDEX_DIR:-}" ]; then
     printf '%s' "$file"
     return 0
@@ -181,9 +181,9 @@ gg_settings_source() { # FILE — the path to actually read; nonzero + ::error o
           # "no such path in HEAD" with the same 128 an operational failure
           # returns, so only ls-tree (exit 0, empty output for an absent
           # path) can tell the two apart.
-          entry="$(git ls-tree HEAD -- ":(literal)$file" 2>/dev/null)" || cf_status=$?
-          if [ "$cf_status" -ne 0 ]; then
-            echo "::error::$file: could not probe HEAD while resolving a setting (git ls-tree exit $cf_status); refusing to treat it as untracked" >&2
+          entry="$(git ls-tree HEAD -- ":(literal)$file" 2>/dev/null)" || tree_status=$?
+          if [ "$tree_status" -ne 0 ]; then
+            echo "::error::$file: could not probe HEAD while resolving a setting (git ls-tree exit $tree_status); refusing to treat it as untracked" >&2
             return 1
           fi
           case "${entry:+tracked}" in

--- a/skills/growth-guards/tests/commit-msg.test.sh
+++ b/skills/growth-guards/tests/commit-msg.test.sh
@@ -212,6 +212,7 @@ git -C "$RH" add -A
 git -C "$RH" commit -qm "docs: base" --no-verify
 git -C "$RH" rm -q --cached vstack.settings.toml
 printf '[env]\nGROWTH_GUARDS_COMMIT_TYPES = "feat"\n' >"$RH/vstack.settings.toml"
+REAL_GIT="$(command -v git)"
 GIT_HTREE_SHIM="$TMP/git-htree-shim"
 mkdir -p "$GIT_HTREE_SHIM"
 {

--- a/skills/growth-guards/tests/commit-msg.test.sh
+++ b/skills/growth-guards/tests/commit-msg.test.sh
@@ -197,5 +197,37 @@ OUT="$(cd "$RI" && printf 'feat: not in the outside list\n' | GROWTH_GUARDS_SETT
   || bad "normalized escape stays out-of-repo" "rc=$RC out=$OUT"
 git -C "$RI" checkout -q -- vstack.settings.toml
 
+echo "=== a failing HEAD probe never hands authority to a recreated list ==="
+# Staged deletion + worktree recreation: the commit carries "docs", the
+# deletion is staged, the recreated worktree copy allows "feat". The HEAD
+# probe proves the commit once carried the source; a broken git there must
+# fail closed, never read as "never tracked".
+RH="$TMP/repo-headprobe"
+mkdir -p "$RH"
+git -C "$RH" -c init.defaultBranch=main init -q
+git -C "$RH" config user.email test@example.com
+git -C "$RH" config user.name test
+printf '[env]\nGROWTH_GUARDS_COMMIT_TYPES = "docs"\n' >"$RH/vstack.settings.toml"
+git -C "$RH" add -A
+git -C "$RH" commit -qm "docs: base" --no-verify
+git -C "$RH" rm -q --cached vstack.settings.toml
+printf '[env]\nGROWTH_GUARDS_COMMIT_TYPES = "feat"\n' >"$RH/vstack.settings.toml"
+GIT_HTREE_SHIM="$TMP/git-htree-shim"
+mkdir -p "$GIT_HTREE_SHIM"
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'if [ "${1:-}" = "ls-tree" ]; then\n'
+  printf '  echo "fatal: simulated HEAD-tree failure" >&2\n'
+  printf '  exit 71\n'
+  printf 'fi\n'
+  printf 'exec %s "$@"\n' "$REAL_GIT"
+} >"$GIT_HTREE_SHIM/git"
+chmod +x "$GIT_HTREE_SHIM/git"
+OUT=""; RC=0
+OUT="$(cd "$RH" && printf 'feat: recreated list must not authorize\n' | PATH="$GIT_HTREE_SHIM:$PATH" "$CM" 2>&1)" || RC=$?
+[ "$RC" -eq 2 ] && case "$OUT" in *"(git ls-tree exit 71)"*) true ;; *) false ;; esac \
+  && ok "a failing HEAD probe is exit 2, never authority for the recreated list" \
+  || bad "gg HEAD-probe failure" "rc=$RC out=$OUT"
+
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/skills/size-ratchet/scripts/lib/settings.sh
+++ b/skills/size-ratchet/scripts/lib/settings.sh
@@ -130,7 +130,7 @@ sr_settings_normalize_path() { # PATH — normalized path on stdout ("" when it 
 # (a personal .env.local) is the worktree copy, which is all there is.
 # SR_SETTINGS_INDEX_DIR holds the materialized copies; the caller owns it.
 sr_settings_source() { # FILE — the path to actually read; nonzero + ::error on failure
-  local file="$1" copy="" status=0 entry="" norm=""
+  local file="$1" copy="" status=0 entry="" norm="" head_status=0 cf_status=0
   if [ "${SR_SETTINGS_FROM_INDEX:-0}" != "1" ] || [ -z "${SR_SETTINGS_INDEX_DIR:-}" ]; then
     printf '%s' "$file"
     return 0
@@ -169,13 +169,41 @@ sr_settings_source() { # FILE — the path to actually read; nonzero + ::error o
   case "$status" in
     0) ;;
     1)
-      if git cat-file -e "HEAD:$file" 2>/dev/null; then
-        # Staged for deletion: the commit carries no such source, so it must
-        # govern as ABSENT rather than through a recreated worktree copy. A
-        # path that cannot exist is how the probes below read "not there".
-        printf '%s' "$SR_SETTINGS_INDEX_DIR/settings.absent"
-        return 0
-      fi
+      # The HEAD probe is classified like the index probe above: cat-file -e
+      # exits 128 both for "no such path" and for an operational failure, so
+      # a bare probe read a broken git as "never tracked" and let a
+      # recreated worktree copy authorize staged content. An unborn HEAD
+      # carries nothing by definition (rev-parse reserves exit 1 for it).
+      git rev-parse --verify --quiet HEAD >/dev/null 2>&1 || head_status=$?
+      case "$head_status" in
+        0)
+          # ls-tree, never cat-file -e: with rev:path syntax git answers
+          # "no such path in HEAD" with the same 128 an operational failure
+          # returns, so only ls-tree (exit 0, empty output for an absent
+          # path) can tell the two apart.
+          entry="$(git ls-tree HEAD -- ":(literal)$file" 2>/dev/null)" || cf_status=$?
+          if [ "$cf_status" -ne 0 ]; then
+            echo "::error::$file: could not probe HEAD while resolving a setting (git ls-tree exit $cf_status); refusing to treat it as untracked" >&2
+            return 1
+          fi
+          case "${entry:+tracked}" in
+            tracked)
+              # Staged for deletion: the commit carries no such source, so it
+              # must govern as ABSENT rather than through a recreated worktree
+              # copy. A path that cannot exist is how the probes below read
+              # "not there".
+              printf '%s' "$SR_SETTINGS_INDEX_DIR/settings.absent"
+              return 0
+              ;;
+            *) ;;
+          esac
+          ;;
+        1) ;;
+        *)
+          echo "::error::$file: could not resolve HEAD while resolving a setting (git rev-parse exit $head_status); refusing to treat it as untracked" >&2
+          return 1
+          ;;
+      esac
       printf '%s' "$file"
       return 0
       ;;

--- a/skills/size-ratchet/scripts/lib/settings.sh
+++ b/skills/size-ratchet/scripts/lib/settings.sh
@@ -130,7 +130,7 @@ sr_settings_normalize_path() { # PATH — normalized path on stdout ("" when it 
 # (a personal .env.local) is the worktree copy, which is all there is.
 # SR_SETTINGS_INDEX_DIR holds the materialized copies; the caller owns it.
 sr_settings_source() { # FILE — the path to actually read; nonzero + ::error on failure
-  local file="$1" copy="" status=0 entry="" norm="" head_status=0 cf_status=0
+  local file="$1" copy="" status=0 entry="" norm="" head_status=0 tree_status=0
   if [ "${SR_SETTINGS_FROM_INDEX:-0}" != "1" ] || [ -z "${SR_SETTINGS_INDEX_DIR:-}" ]; then
     printf '%s' "$file"
     return 0
@@ -181,9 +181,9 @@ sr_settings_source() { # FILE — the path to actually read; nonzero + ::error o
           # "no such path in HEAD" with the same 128 an operational failure
           # returns, so only ls-tree (exit 0, empty output for an absent
           # path) can tell the two apart.
-          entry="$(git ls-tree HEAD -- ":(literal)$file" 2>/dev/null)" || cf_status=$?
-          if [ "$cf_status" -ne 0 ]; then
-            echo "::error::$file: could not probe HEAD while resolving a setting (git ls-tree exit $cf_status); refusing to treat it as untracked" >&2
+          entry="$(git ls-tree HEAD -- ":(literal)$file" 2>/dev/null)" || tree_status=$?
+          if [ "$tree_status" -ne 0 ]; then
+            echo "::error::$file: could not probe HEAD while resolving a setting (git ls-tree exit $tree_status); refusing to treat it as untracked" >&2
             return 1
           fi
           case "${entry:+tracked}" in

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -298,7 +298,12 @@ staged_policy_state() { # PATH
   [ "$MODE" != "update" ] || return 1
   read_index_file_mode "$1"
   [ -z "$INDEX_FILE_MODE" ] || return 0
-  git cat-file -e "HEAD:$1" 2>/dev/null && return 2
+  # The HEAD leg goes through the classified probe: cat-file -e exits 128
+  # both for "HEAD carries no such path" and for an operational failure, so
+  # a bare probe here read a broken git as "never tracked" and let a
+  # recreated worktree policy govern the staged snapshot.
+  read_head_file_mode "$1"
+  [ -z "$HEAD_FILE_MODE" ] || return 2
   return 1
 }
 

--- a/skills/size-ratchet/tests/staged-scope.test.sh
+++ b/skills/size-ratchet/tests/staged-scope.test.sh
@@ -337,5 +337,87 @@ case "$OUT" in
   *) bad "--help documents --staged" "out=$OUT" ;;
 esac
 
+echo "=== a failing HEAD probe cannot hand authority to a recreated source ==="
+# Staged deletion + worktree recreation: the commit carries threshold 100,
+# the deletion is staged, and a recreated worktree copy says 300. The HEAD
+# probe is what proves the commit once carried the source; a broken git
+# there must fail closed, never read as "never tracked" and let the
+# recreated copy authorize the staged 200-line blob.
+new_repo settings-recreated
+mkfile big.txt 200
+printf '[env]\nSIZE_RATCHET_THRESHOLD = "100"\n' >"$R/vstack.settings.toml"
+git -C "$R" add -A
+git -C "$R" commit -q -m seed
+git -C "$R" rm -q --cached vstack.settings.toml
+printf '[env]\nSIZE_RATCHET_THRESHOLD = "300"\n' >"$R/vstack.settings.toml"
+OUT=""; RC=0
+OUT="$(cd "$R" && "$SR" --staged 2>&1)" || RC=$?
+[ "$RC" -eq 0 ] \
+  && ok "control: a staged settings deletion governs as absent (built-in 400 passes the 200-line blob)" \
+  || bad "staged-deletion control" "rc=$RC out=$OUT"
+REAL_GIT="$(command -v git)"
+GIT_HEAD_SHIM="$TMP/git-head-shim"
+mkdir -p "$GIT_HEAD_SHIM"
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'if [ "${1:-}" = "ls-tree" ]; then\n'
+  printf '  echo "fatal: simulated HEAD-tree failure" >&2\n'
+  printf '  exit 71\n'
+  printf 'fi\n'
+  printf 'exec %s "$@"\n' "$REAL_GIT"
+} >"$GIT_HEAD_SHIM/git"
+chmod +x "$GIT_HEAD_SHIM/git"
+OUT=""; RC=0
+OUT="$(cd "$R" && PATH="$GIT_HEAD_SHIM:$PATH" "$SR" --staged 2>&1)" || RC=$?
+[ "$RC" -eq 2 ] && case "$OUT" in *"could not probe HEAD while resolving a setting (git ls-tree"*) true ;; *) false ;; esac \
+  && ok "a failing settings HEAD probe is exit 2, never authority for the recreated copy" \
+  || bad "settings HEAD-probe failure" "rc=$RC out=$OUT"
+
+echo "=== the policy HEAD leg fails closed too ==="
+# Same shape for the baseline: staged deletion + recreated worktree copy.
+# The classified probe (ls-tree) failing must be exit 2; the old bare
+# cat-file read a broken git as "never tracked" and let the recreated
+# baseline absorb staged growth.
+new_repo baseline-recreated
+mkfile big.txt 30
+mkdir -p "$R/tools"
+printf 'big.txt\t15\n' >"$R/tools/size-ratchet-baseline.tsv"
+git -C "$R" add -A
+git -C "$R" commit -q -m seed
+git -C "$R" rm -q --cached tools/size-ratchet-baseline.tsv
+printf 'big.txt\t30\n' >"$R/tools/size-ratchet-baseline.tsv"
+OUT=""; RC=0
+GIT_CATFILE_SHIM="$TMP/git-catfile-shim"
+mkdir -p "$GIT_CATFILE_SHIM"
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'if [ "${1:-}" = "cat-file" ]; then\n'
+  printf '  echo "fatal: simulated HEAD-probe failure" >&2\n'
+  printf '  exit 71\n'
+  printf 'fi\n'
+  printf 'exec %s "$@"\n' "$REAL_GIT"
+} >"$GIT_CATFILE_SHIM/git"
+chmod +x "$GIT_CATFILE_SHIM/git"
+OUT="$(cd "$R" && PATH="$GIT_CATFILE_SHIM:$PATH" SIZE_RATCHET_THRESHOLD=10 "$SR" --staged 2>&1)" || RC=$?
+[ "$RC" -eq 1 ] \
+  && ok "a broken cat-file no longer hands authority to the recreated baseline (the staged snapshot judges without it)" \
+  || bad "recreated baseline under cat-file failure" "rc=$RC out=$OUT"
+GIT_TREE_SHIM="$TMP/git-tree-shim"
+mkdir -p "$GIT_TREE_SHIM"
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'if [ "${1:-}" = "ls-tree" ]; then\n'
+  printf '  echo "fatal: simulated HEAD-tree failure" >&2\n'
+  printf '  exit 71\n'
+  printf 'fi\n'
+  printf 'exec %s "$@"\n' "$REAL_GIT"
+} >"$GIT_TREE_SHIM/git"
+chmod +x "$GIT_TREE_SHIM/git"
+OUT=""; RC=0
+OUT="$(cd "$R" && PATH="$GIT_TREE_SHIM:$PATH" SIZE_RATCHET_THRESHOLD=10 "$SR" --staged 2>&1)" || RC=$?
+[ "$RC" -eq 2 ] && case "$OUT" in *"(git ls-tree exit 71)"*) true ;; *) false ;; esac \
+  && ok "a failing HEAD-tree query is exit 2, never \"never tracked\"" \
+  || bad "policy HEAD-probe failure" "rc=$RC out=$OUT"
+
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -167,7 +167,7 @@ skills/second-opinion/scripts/second-opinion	2506
 skills/second-opinion/tests/cli-failure-gate.test.sh	1211
 skills/second-opinion/tests/lane-scratch-durability.test.sh	999
 skills/second-opinion/tests/review-dual-model.test.sh	1516
-skills/size-ratchet/scripts/size-ratchet	1013
+skills/size-ratchet/scripts/size-ratchet	1018
 skills/worktree/scripts/worktree	4148
 skills/worktree/scripts/worktree-session-guard	1194
 skills/worktree/tests/worktree_session_guard.sh	1284


### PR DESCRIPTION
## The staged-deletion HEAD probes fail closed

Both reported with reproductions by bot review on vanillagreencom/drovr#559: when a policy file (baseline/excludes) or a tracked settings source is staged for deletion and recreated in the worktree, an operational git failure in the HEAD probe read as "never tracked" and handed authority to the recreated copy — a shimmed exit 71 let staged growth pass against a recreated baseline, and a recreated settings file authorize staged content.

- `staged_policy_state`'s HEAD leg now uses the classified `read_head_file_mode` (ls-tree behind the unborn-HEAD guard) instead of a bare `cat-file -e`.
- Both settings loaders (size-ratchet + growth-guards) probe HEAD with `ls-tree` — with `rev:path` syntax, `cat-file -e` answers absence with the same 128 a broken git returns, so only ls-tree (exit 0, empty output when absent) can distinguish; operational failure is a refusal, unborn HEAD reads as carrying nothing.

## Verification

Red against origin/main: 4 failing pins in staged-scope, 1 in commit-msg (the reviewer's recreated-source scenarios plus fail-closed shims). Green with the fix: staged-scope 44, commit-msg 49; all size-ratchet and growth-guards suites pass; shellcheck clean.

https://claude.ai/code/session_01EwxSRv8oy1NxoQm66WKa4J
