### PR TITLE
test(pi-tool-renderer): the 43-test suite joins validate-changed and CI

### DIFF
--- a/.github/workflows/skill-tests.yml
+++ b/.github/workflows/skill-tests.yml
@@ -247,6 +247,17 @@ jobs:
         working-directory: pi-extensions/pi-questions
         run: bun test ./extensions/__tests__
 
+      # The renderer imports pi-tui and pi-coding-agent, so unlike pi-questions
+      # its suite needs the 0.84.1 install to resolve at all. pi-ai and
+      # pi-agent-core are pinned alongside them because pi-coding-agent pulls
+      # them transitively and an unpinned resolution mismatches its exports.
+      - name: pi-tool-renderer suite
+        if: matrix.shard == 'node'
+        working-directory: pi-extensions/pi-tool-renderer
+        run: |
+          npm install --no-save --no-package-lock --ignore-scripts --no-audit --no-fund @earendil-works/pi-agent-core@0.84.1 @earendil-works/pi-ai@0.84.1 @earendil-works/pi-coding-agent@0.84.1 @earendil-works/pi-tui@0.84.1
+          bun test ./extensions/__tests__
+
       # The bridge ships ~256 unit tests that nothing in CI ran until now, so
       # "tests pass" on a bridge PR meant "passed on the author's machine".
       # Build first: one suite loads bundle/connector-inventory.js rather than

--- a/pi-extensions/pi-tool-renderer/package.json
+++ b/pi-extensions/pi-tool-renderer/package.json
@@ -20,6 +20,9 @@
     ],
     "image": "https://raw.githubusercontent.com/vanillagreencom/vstack/main/pi-extensions/pi-tool-renderer/assets/tool-batch.png"
   },
+  "scripts": {
+    "test": "bun test ./extensions/__tests__"
+  },
   "vstack": {
     "extensionManager": {
       "displayName": "Tool Renderer",

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -94,7 +94,7 @@ pi-extensions/pi-task-panel/extensions/task-panel.ts	1315
 pi-extensions/pi-tool-renderer/extensions/tool-renderer/diff.ts	1035
 pi-extensions/pi-tool-renderer/extensions/tool-renderer/generic.ts	452
 pi-extensions/pi-tool-renderer/extensions/tool-renderer/messages.ts	530
-pi-extensions/pi-tool-renderer/package.json	588
+pi-extensions/pi-tool-renderer/package.json	591
 pi-extensions/pi-web-tools/src/tools/web-fetch.ts	634
 pi-extensions/pi-web-tools/src/tools/web-research.ts	445
 pi-extensions/pi-web-tools/tests/youtube-video.test.ts	844
@@ -171,4 +171,4 @@ skills/size-ratchet/scripts/size-ratchet	1013
 skills/worktree/scripts/worktree	4148
 skills/worktree/scripts/worktree-session-guard	1194
 skills/worktree/tests/worktree_session_guard.sh	1284
-tools/validate-changed	513
+tools/validate-changed	519

--- a/tools/validate-changed
+++ b/tools/validate-changed
@@ -119,7 +119,7 @@ tr '\0' '\n' <"$RAW_FILE" | LC_ALL=C sort -u >"$CHANGED_FILE"
 # does not depend on path sort order. Indexed (not associative) arrays keep
 # this runnable on bash 3.2.
 LINT_SHELL_DESC="executable bits + \`vstack report\` guidance (shell shard lints)"
-PI_SUITES=(pi-qol pi-output-policy pi-agents-tmux pi-codex-minimal-tools pi-questions pi-claude-bridge)
+PI_SUITES=(pi-qol pi-output-policy pi-agents-tmux pi-codex-minimal-tools pi-questions pi-tool-renderer pi-claude-bridge)
 
 want_lint=0
 want_hooks=0
@@ -293,6 +293,7 @@ for name in "${PI_SUITES[@]}"; do
     pi-agents-tmux) add_lane "pi:pi-agents-tmux" "npm install (pinned pi 0.84.1) && bun test ./tests ./extensions/subagent/__tests__  [pi-extensions/pi-agents-tmux]" ;;
     pi-codex-minimal-tools) add_lane "pi:pi-codex-minimal-tools" "npm install (pinned pi 0.84.1, undici@^7.25.0) && npm test  [pi-extensions/pi-codex-minimal-tools]" ;;
     pi-questions) add_lane "pi:pi-questions" "bun test ./extensions/__tests__  [pi-extensions/pi-questions]" ;;
+    pi-tool-renderer) add_lane "pi:pi-tool-renderer" "npm install (pinned pi 0.84.1) && bun test ./extensions/__tests__  [pi-extensions/pi-tool-renderer]" ;;
     pi-claude-bridge) add_lane "pi:pi-claude-bridge" "npm ci && npm run build && npm run test:unit && bundle/ matches a fresh build  [pi-extensions/pi-claude-bridge]" ;;
   esac
 done
@@ -471,6 +472,11 @@ run_lane() { # id -> exit status of the lane
       ;;
     pi:pi-questions)
       run_in pi-extensions/pi-questions bun test ./extensions/__tests__
+      ;;
+    pi:pi-tool-renderer)
+      run_in pi-extensions/pi-tool-renderer bash -c '
+        npm install --no-save --no-package-lock --ignore-scripts --no-audit --no-fund @earendil-works/pi-agent-core@0.84.1 @earendil-works/pi-ai@0.84.1 @earendil-works/pi-coding-agent@0.84.1 @earendil-works/pi-tui@0.84.1 &&
+        bun test ./extensions/__tests__'
       ;;
     pi:pi-claude-bridge)
       # The bundle the author is about to commit — the working-tree bytes,

--- a/tools/validate-changed
+++ b/tools/validate-changed
@@ -293,7 +293,7 @@ for name in "${PI_SUITES[@]}"; do
     pi-agents-tmux) add_lane "pi:pi-agents-tmux" "npm install (pinned pi 0.84.1) && bun test ./tests ./extensions/subagent/__tests__  [pi-extensions/pi-agents-tmux]" ;;
     pi-codex-minimal-tools) add_lane "pi:pi-codex-minimal-tools" "npm install (pinned pi 0.84.1, undici@^7.25.0) && npm test  [pi-extensions/pi-codex-minimal-tools]" ;;
     pi-questions) add_lane "pi:pi-questions" "bun test ./extensions/__tests__  [pi-extensions/pi-questions]" ;;
-    pi-tool-renderer) add_lane "pi:pi-tool-renderer" "npm install (pinned pi 0.84.1) && bun test ./extensions/__tests__  [pi-extensions/pi-tool-renderer]" ;;
+    pi-tool-renderer) add_lane "pi:pi-tool-renderer" "npm install (pinned pi 0.84.1 + peer libs) && bun test ./extensions/__tests__  [pi-extensions/pi-tool-renderer]" ;;
     pi-claude-bridge) add_lane "pi:pi-claude-bridge" "npm ci && npm run build && npm run test:unit && bundle/ matches a fresh build  [pi-extensions/pi-claude-bridge]" ;;
   esac
 done


### PR DESCRIPTION
## pi-tool-renderer's 43-test suite joins validate-changed and CI

Found during the README sweep: the suite ran in no automation — absent from both tools/validate-changed's PI_SUITES roster and the workflow's node shard, so a renderer change could ship with it red and nothing would say so.

- package.json gains the sibling-standard test script; the version pin lives in the lane command (npm install pinned pi 0.84.1, --no-save --no-package-lock, same as pi-agents-tmux).
- validate-changed: roster entry + lane case mirroring the sibling shape; a renderer-only change now derives the lane (verified: 3 lanes, all pass).
- skill-tests.yml: a step in the node shard after pi-questions, with a comment noting why this suite needs the install to resolve at all.

Bare run (no install): 10 module-resolution errors — the red control. Under the pinned install from a deleted node_modules: 43/43 green, 136 expect() calls. Guards clean; only the two genuinely grown baseline rows bumped.

https://claude.ai/code/session_01EwxSRv8oy1NxoQm66WKa4J
