### PR TITLE
feat(reviewers): correctness reviewer gains plausible-by-default, removed-behavior, and wrapper-routing angles

### DIFF
--- a/agents/reviewer-correctness.md
+++ b/agents/reviewer-correctness.md
@@ -37,6 +37,21 @@ For each changed predicate, parser, or guard, mentally execute:
 - **Teardown symmetry** — for every install/enable/claim path, walk uninstall/disable/release under: another worktree still installed, the helper already missing, a partially applied prior run, and a foreign tool owning the same file.
 - **Staged vs worktree** — a `--staged` or index-reading mode reads its policy inputs (baseline, excludes, settings) from the index too, never from the worktree.
 
+## Removed Behavior
+
+For every line the diff deletes or replaces, name the invariant or behavior it enforced, then find where the new code re-establishes it. Not re-established → a finding: a removed guard, a dropped error path, a narrowed validation, a deleted test that covered a real case.
+
+## Wrapper Routing
+
+When a change adds or modifies a type wrapping another (cache, proxy, decorator, adapter):
+
+- **Delegation target** — every method routes to the wrapped instance, never back through a registry, session, or global (`delegate.get(...)`, not `session.get(...)` — re-entry/recursion hazard).
+- **Forwarding coverage** — the wrapper forwards every method its callers actually use.
+
+## Plausible by Default
+
+Never refute a finding as "speculative" or "depends on runtime state" when the state is realistic: a concurrency race; nil/undefined on a rare-but-reachable path (error handler, cold cache, missing optional field); a falsy zero treated as missing; an off-by-one on a boundary the code does not exclude; retry storms and partial failures; a regex or allowlist that lost an anchor. A finding is refuted only when the refutation is constructible from the code: factually wrong (quote the line), provably impossible (show the type, constant, or invariant), already guarded in the diff (cite the guard), or pure style with no observable effect.
+
 ## Output
 
 Regressions, boundary defects, compatibility/contract breaks, feature leaks, state/migration issues → `blockers[]`. Non-blocking risks and follow-up hardening → `suggestions[]`.


### PR DESCRIPTION
Closes #1468.

Adopts the three review angles the issue specifies from the bundled /code-review skill, as directives in `agents/reviewer-correctness.md` (+15 lines, no other changes):

- **Plausible by Default** — a finding is never refuted as speculative when the state is realistic (races, rare-but-reachable nil paths, falsy zero, boundary off-by-ones, retry storms, lost anchors); refutation must be constructible from the code (quote the line / show the invariant / cite the in-diff guard / pure style).
- **Removed Behavior** — every deleted or replaced line's invariant must be found re-established in the new code, else it's a finding.
- **Wrapper Routing** — wrappers route to their wrapped instance (never back through a registry/session/global) and forward every method callers use.

Verified per the issue's bar: three seeded fixture diffs (rare-path nil in an error handler; a deleted length-validation guard; a wrapper `delete` re-entering itself via a registry) each caught by the letter of the added text — mapping in the fixtures dir, summarized in the commit.

No coverage overlap with existing sections (the falsy-zero mention in Boundary Probes is a code-shape probe; the new one is a verdict-filtering rule).

https://claude.ai/code/session_01SgCfsq4oKxc45iq25VcPhG