### PR TITLE
feat(growth-guards): conflict-markers joins the guard family — the marker trio at column 0 fails staged

### DIFF
--- a/skills/growth-guards/DEVELOPMENT.md
+++ b/skills/growth-guards/DEVELOPMENT.md
@@ -7,7 +7,8 @@ docs live in README.md.
 
 - `scripts/growth-guards` — batch dispatcher and single-check router
 - `scripts/todo-ban`, `scripts/byte-ceiling`, `scripts/suppression-ban`,
-  `scripts/commit-msg` — the four checks, each a standalone executable
+  `scripts/conflict-markers`, `scripts/commit-msg` — the five checks, each a
+  standalone executable
 - `scripts/pre-commit` — the chain the git `pre-commit` shim runs
 - `scripts/install-git-hooks` — hook installer and remover
 - `scripts/lib/common.sh`, `scripts/lib/settings.sh` — shared helpers and
@@ -156,7 +157,7 @@ leaving explicit environment variables and the built-in defaults. The
 scripts `cd` to `git rev-parse --show-toplevel` before resolving anything,
 so all relative paths are repo-root-relative.
 
-**Excludes format** (all three lists): `pattern<TAB>reason` per line — shell
+**Excludes format** (all four lists): `pattern<TAB>reason` per line — shell
 glob matched against the full repo-relative path (`*` crosses `/`); blank
 lines and `#` comments ignored; a pattern without a reason is a config
 error. **Baseline format**: `path<TAB>count`, `LC_ALL=C` sorted, unique

--- a/skills/growth-guards/README.md
+++ b/skills/growth-guards/README.md
@@ -1,11 +1,11 @@
 # growth-guards
 
-Four checks that stop quiet repo decay, one family beside `size-ratchet`:
-work markers, oversized additions, blanket lint suppression, and
-non-conventional commit messages. They share one idiom and one exit
-contract: `0` clean, `1` violations, `2` usage/config/collection error. All
-scans read INDEX content; binary files are skipped by the text scans.
-`SKILL.md` is the agent-facing reference; `DEVELOPMENT.md` covers internals.
+Five checks that stop quiet repo decay, one family beside `size-ratchet`:
+work markers, oversized additions, blanket lint suppression, conflict
+markers, and non-conventional commit messages. One idiom, one exit contract:
+`0` clean, `1` violations, `2` usage/config/collection error. All scans read
+INDEX content; binary files are skipped by the text scans. `SKILL.md` is the
+agent-facing reference; `DEVELOPMENT.md` covers internals.
 
 ## Invocation
 
@@ -16,11 +16,11 @@ scripts/CHECK [ARGS]                # each check is a standalone executable
 ```
 
 The batch runs `GROWTH_GUARDS_CHECKS` (default
-`todo-ban byte-ceiling suppression-ban`) and fails closed: exit 2 if any
-check could not complete, else 1 if any found violations. `commit-msg` reads
-a message, so it never runs in the batch. In an installed project the
-scripts live under `.agents/skills/growth-guards/scripts/`; wire CI at
-whichever grain fits — `byte-ceiling --base origin/main` gates a PR's
+`todo-ban byte-ceiling suppression-ban conflict-markers`) and fails closed:
+exit 2 if any check could not complete, else 1 if any found violations.
+`commit-msg` reads a message, so it never runs in the batch. In an installed
+project the scripts live under `.agents/skills/growth-guards/scripts/`; wire
+CI at whichever grain fits — `byte-ceiling --base origin/main` gates a PR's
 additions, and local commits are covered by the git hooks below.
 
 ## Git hooks
@@ -32,29 +32,26 @@ additions, and local commits are covered by the git hooks below.
 
 The installer writes a helper into the repository's `.git/hooks` plus one
 marked delegating line in `pre-commit` and `commit-msg` — never
-`core.hooksPath`, and an existing hook keeps its content and its own exit
-status. Repeat runs are no-ops, and repairs; `--uninstall` drops the helper
-and our line and leaves the rest of a consumer's own hook untouched. `vstack
-add` and `vstack refresh` run the installer for a project that has the skill
-installed (a non-git project is skipped with a note), and `vstack remove
-growth-guards` runs `--uninstall` first.
+`core.hooksPath`; an existing hook keeps its content and its own exit
+status. Repeat runs are no-ops, and repairs. `--uninstall` drops the helper
+and our line, leaving a consumer's own hook otherwise untouched. `vstack
+add` and `vstack refresh` run the installer (non-git projects are a noted
+skip); `vstack remove growth-guards` runs `--uninstall` first.
 
 `pre-commit` judges ONE commit snapshot: `size-ratchet --staged` and
-`preflight --staged` when those skills are installed beside this one, the
-`growth-guards` batch over the staged content, then the repo-root-relative
-executable named by `GROWTH_GUARDS_PRE_COMMIT_LOCAL` (empty means none).
-`commit-msg` runs this family's message gate on git's message file. Both
-shims BLOCK and fail closed on the family's exit contract — `1` carries the
-check's own remediation text, `2` names a guard that could not run; `git
-commit --no-verify` is the deliberate bypass.
+`preflight --staged` when installed beside this skill, the `growth-guards`
+batch over the staged content, then the repo-root-relative executable named
+by `GROWTH_GUARDS_PRE_COMMIT_LOCAL` (empty means none). `commit-msg` runs
+this family's message gate on git's message file. Both shims BLOCK and fail
+closed on the exit contract — `1` carries the check's remediation text, `2`
+names a guard that could not run; `git commit --no-verify` is the bypass.
 
 ## todo-ban
 
 Flat ban on work markers in first-party tracked files — the words TODO,
 FIXME, HACK, XXX in comment-marker shapes, no baseline. Prose that quotes or
-names a marker does not fire, and matching is case-sensitive. Remediation:
-do the work now, or move it to the tracker and delete the marker.
-Vendored/generated trees go in the excludes list with a reason.
+names a marker does not fire; matching is case-sensitive. Do the work now or
+track it and delete the marker; vendored trees go in excludes with a reason.
 
 ## byte-ceiling
 
@@ -66,29 +63,34 @@ trees go in the excludes list with a reason.
 
 - `--staged` (default) — files added in the staged diff (pre-commit).
 - `--base REF` — files added since the merge-base with REF (CI on a PR).
-- `--all` — every tracked file (audits; pair with excludes rows for known
-  legacy assets).
+- `--all` — every tracked file (audits; pair with excludes rows).
 
 ## suppression-ban
 
 Two gates, both scanned language-scoped by pathspec, so docs and scripts
 that quote a pragma never fire. **Blanket suppressions fail flat** —
 module/crate-wide rust `#![allow(...)]` inner attributes, file-level
-`# ruff: noqa` / `# flake8: noqa`, the bare `/* eslint-disable */` block form
-with no rules named, and `//nolint` with nothing after it or `//nolint:all`.
-A per-line suppression that names its lint and states its reason stays legal
-(`// eslint-disable-next-line rule -- why`, `# noqa: E501`,
-`//nolint:gosec // why`, a per-item rust attribute).
+`# ruff: noqa` / `# flake8: noqa`, the bare `/* eslint-disable */` block
+form, and `//nolint` bare or `:all`. A per-line suppression naming its lint
+with a stated reason stays legal (`// eslint-disable-next-line rule -- why`,
+`# noqa: E501`, `//nolint:gosec // why`, a per-item rust attribute).
 
 **Bare-allow ratchet (Rust)** — reasonless `#[allow(dead_code)]` /
 `#[allow(unused…)]` attributes are counted per file; an attribute carrying
-`reason = "..."` does not count. Repos with legacy counts freeze them in a
-tighten-only baseline: new bare allows, growth past a row, and a baseline
-looser than reality all fail. `--update` lowers/removes rows to current
-reality and re-checks; it never adds a row and never raises a number, so
-deliberate growth — and the first baseline, turned from each reported `new
-bare allow` line (path and count) into an `LC_ALL=C`-sorted `path<TAB>count`
-row — is a hand-edit, visible in review.
+`reason = "..."` does not count. Legacy counts freeze in a tighten-only
+baseline: new bare allows, growth past a row, and a baseline looser than
+reality all fail. `--update` lowers/removes rows and re-checks; it never
+adds a row and never raises one, so deliberate growth — and the first
+baseline, hand-turned from the reported `new bare allow` lines into
+`LC_ALL=C`-sorted `path<TAB>count` rows — is a hand-edit, visible in review.
+
+## conflict-markers
+
+Flat ban on unresolved merge-conflict markers: the open/base/close trio
+(seven `<`, seven vertical bars, seven `>`) at column 0, each followed by a
+space or end of line. Indented or quoted occurrences never fire; neither
+does bare `=======` — a valid Markdown setext underline (a real conflict
+always carries the open and close markers).
 
 ## commit-msg
 
@@ -115,5 +117,4 @@ GROWTH_GUARDS_CHECKS = "todo-ban suppression-ban"
 
 ## Requirements
 
-`git`, `awk`, and the usual POSIX userland. Bash 3.2 compatible (macOS
-system bash).
+`git`, `awk`, the usual POSIX userland; Bash 3.2 compatible (macOS bash).

--- a/skills/growth-guards/SKILL.md
+++ b/skills/growth-guards/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: growth-guards
-description: "Four repo growth guards beside size-ratchet — todo-ban, byte-ceiling, suppression-ban, commit-msg — and the git hook shims that run them. Load to add, tune, or debug a check, the hooks, or GROWTH_GUARDS_* settings."
+description: "Five repo growth guards beside size-ratchet — todo-ban, byte-ceiling, suppression-ban, conflict-markers, commit-msg — and the git hook shims that run them. Load to add, tune, or debug a check, the hooks, or GROWTH_GUARDS_* settings."
 license: MIT
 user-invocable: true
 metadata:
@@ -15,7 +15,7 @@ metadata:
 
 > **Problem with this skill?** Run `vstack report` — it files to the owning repo automatically. Do not hand-file.
 
-Four checks that stop quiet repo decay, one family beside `size-ratchet`,
+Five checks that stop quiet repo decay, one family beside `size-ratchet`,
 sharing its idiom and its exit contract.
 
 ```bash
@@ -34,6 +34,7 @@ whichever grain fits.
 | **todo-ban** | Any work marker (the words TODO, FIXME, HACK, XXX in comment-marker shapes) in a tracked, non-excluded file fails. No baseline. Prose that quotes or names a marker word does not fire. |
 | **byte-ceiling** | A newly added tracked file over the ceiling (default 200 KB) fails. `--staged` (default) gates the staged diff, `--base REF` the additions since merge-base, `--all` sweeps every tracked file. Lockfiles are exempt built-in. |
 | **suppression-ban** | Blanket lint suppressions fail flat: module-wide rust `allow` inner attributes, file-level ruff/flake8 noqa, the bare `eslint-disable` block form, bare or `all` nolint. Bare rust `allow(dead_code)`/`allow(unused*)` attributes are counted per file against a tighten-only baseline; `--update` lowers/removes rows, never adds or raises one. A per-line suppression naming its lint with a stated reason stays legal. |
+| **conflict-markers** | An unresolved merge-conflict marker in a tracked, non-excluded file fails: the open/base/close trio (seven `<`, seven vertical bars, seven `>`) at column 0, each followed by a space or end of line. No baseline. Indented or quoted occurrences do not fire; the bare seven-equals separator is deliberately unmatched (a valid Markdown setext underline — a real conflict always carries the open and close markers). |
 | **commit-msg** | Header must be `type(scope)!: subject` (scope and `!` optional). Uppercase issue keys (`fix(ABC-123)`) and `#`-number scopes pass; git-generated messages (Merge/Revert/Reapply, fixup!/squash!/amend!) pass unchanged. Takes the message file or stdin. |
 
 Exit codes everywhere: `0` clean, `1` violations, `2`
@@ -69,12 +70,13 @@ the installer refuses to touch: [DEVELOPMENT.md](DEVELOPMENT.md).
 
 | Key | Default | Meaning |
 |---|---|---|
-| `GROWTH_GUARDS_CHECKS` | `todo-ban byte-ceiling suppression-ban` | Batch check list (`commit-msg` never batches). |
+| `GROWTH_GUARDS_CHECKS` | `todo-ban byte-ceiling suppression-ban conflict-markers` | Batch check list (`commit-msg` never batches). |
 | `GROWTH_GUARDS_TODO_EXCLUDES` | `tools/todo-ban-excludes` | todo-ban exclusion list. |
 | `GROWTH_GUARDS_BYTE_CEILING_KB` | `200` | Byte ceiling in KB. |
 | `GROWTH_GUARDS_BYTE_EXCLUDES` | `tools/byte-ceiling-excludes` | byte-ceiling exclusion list (declared asset trees). |
 | `GROWTH_GUARDS_SUPPRESSION_EXCLUDES` | `tools/suppression-ban-excludes` | suppression-ban exclusion list. |
 | `GROWTH_GUARDS_SUPPRESSION_BASELINE` | `tools/suppression-baseline.tsv` | Bare-allow ratchet baseline. |
+| `GROWTH_GUARDS_CONFLICT_EXCLUDES` | `tools/conflict-markers-excludes` | conflict-markers exclusion list. |
 | `GROWTH_GUARDS_COMMIT_TYPES` | `build chore ci docs feat fix perf refactor revert style test` | Accepted commit types. |
 | `GROWTH_GUARDS_PRE_COMMIT_LOCAL` | *(empty)* | Repo-root-relative executable the pre-commit shim runs last. |
 

--- a/skills/growth-guards/scripts/conflict-markers
+++ b/skills/growth-guards/scripts/conflict-markers
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# conflict-markers — flat ban on unresolved merge-conflict markers in
+# tracked files, scanned from the index: the open/base/close trio at column
+# 0, each exactly seven characters followed by a space or end of line. The
+# seven-equals separator is deliberately not matched — a real conflict
+# always carries the open and close markers, and a bare seven-equals line
+# is a valid Markdown setext underline.
+#
+# Exit codes: 0 clean; 1 violations; 2 usage/config/collection error.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GG_CHECK="conflict-markers"
+# shellcheck source=lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+# shellcheck source=lib/settings.sh
+source "$SCRIPT_DIR/lib/settings.sh"
+
+usage() {
+  cat <<'EOF'
+usage: conflict-markers [--excludes FILE]
+
+Flat ban on unresolved merge-conflict markers across all tracked files,
+scanned from the index: the open/base/close trio (seven '<', seven '|',
+seven '>') at column 0, each followed by a space or end of line. Indented
+or quoted occurrences do not fire, and neither does the seven-equals
+separator (a valid Markdown setext underline; a real conflict always
+carries the open and close markers).
+
+Configuration (env > .env.local > .vstack/settings.toml >
+vstack.settings.toml [env] > .env > default):
+  GROWTH_GUARDS_CONFLICT_EXCLUDES   exclusion-list path (default tools/conflict-markers-excludes)
+Flag --excludes overrides the path setting.
+
+Exit codes: 0 clean; 1 violations; 2 usage/config/collection error.
+EOF
+}
+
+EXCLUDES_OPT=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --excludes)
+      [ $# -ge 2 ] || gg_config_error "--excludes requires a path"
+      shift
+      EXCLUDES_OPT="$1"
+      ;;
+    --excludes=*) EXCLUDES_OPT="${1#--excludes=}" ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *) gg_config_error "unknown argument '$1' (see --help)" ;;
+  esac
+  shift
+done
+
+gg_repo_root_cd
+
+EXCLUDES_FILE="$(gg_resolve_path "$EXCLUDES_OPT" GROWTH_GUARDS_CONFLICT_EXCLUDES "tools/conflict-markers-excludes" excludes)" || exit 2
+gg_load_excludes "$EXCLUDES_FILE"
+gg_tmpdir
+
+# The trio at column 0, each exactly seven characters followed by a space
+# or end of line — the shape git writes into a file it could not merge.
+# Interval counts keep the literal runs out of this script's own bytes, so
+# the scan never fires on its producer.
+MARKER_ERE='^(<{7}|[|]{7}|>{7})( |$)'
+
+gg_grep_lane "conflict marker" "$MARKER_ERE" \
+  "finish the merge and delete the marker lines; a file that legitimately carries the trio at column 0 belongs in $EXCLUDES_FILE with a reason" \
+  .
+
+if [ "$GG_VIOLATIONS" -gt 0 ]; then
+  echo "conflict-markers: $GG_VIOLATIONS conflict marker(s) — excludes $EXCLUDES_FILE"
+  exit 1
+fi
+echo "conflict-markers: OK — no conflict markers in tracked files"

--- a/skills/growth-guards/scripts/growth-guards
+++ b/skills/growth-guards/scripts/growth-guards
@@ -16,8 +16,8 @@ source "$SCRIPT_DIR/lib/common.sh"
 # shellcheck source=lib/settings.sh
 source "$SCRIPT_DIR/lib/settings.sh"
 
-KNOWN_CHECKS="todo-ban byte-ceiling suppression-ban commit-msg"
-BATCH_DEFAULT="todo-ban byte-ceiling suppression-ban"
+KNOWN_CHECKS="todo-ban byte-ceiling suppression-ban conflict-markers commit-msg"
+BATCH_DEFAULT="todo-ban byte-ceiling suppression-ban conflict-markers"
 
 usage() {
   cat <<EOF

--- a/skills/growth-guards/tests/conflict-markers.test.sh
+++ b/skills/growth-guards/tests/conflict-markers.test.sh
@@ -72,7 +72,8 @@ run_cm
 printf '%s theirs\n' "$CLOSE" >"$R/a.rs"
 git -C "$R" add -A
 run_cm
-[ "$RC" -eq 1 ] && ok "the close marker with its label fails" \
+[ "$RC" -eq 1 ] && case "$OUT" in *"conflict marker: a.rs:1:"*) true ;; *) false ;; esac \
+  && ok "the close marker with its label fails, naming file:line" \
   || bad "close marker fails" "rc=$RC out=$OUT"
 
 echo "=== indented, quoted, and glued occurrences never fire ==="
@@ -133,6 +134,8 @@ OUT="$(cd "$R" && GROWTH_GUARDS_CONFLICT_EXCLUDES=alt-excludes "$CM" 2>&1)" && R
   || bad "excludes path resolves through the environment key" "rc=$RC out=$OUT"
 run_cm --excludes alt-excludes
 [ "$RC" -eq 0 ] && ok "--excludes flag points at the same list" || bad "--excludes flag" "rc=$RC out=$OUT"
+run_cm --excludes=alt-excludes
+[ "$RC" -eq 0 ] && ok "the equals form of --excludes resolves the same list" || bad "--excludes= equals form" "rc=$RC out=$OUT"
 run_cm
 [ "$RC" -eq 1 ] && ok "control: without either, the fixture marker still fails" \
   || bad "control: default excludes path has no file, marker fails" "rc=$RC out=$OUT"

--- a/skills/growth-guards/tests/conflict-markers.test.sh
+++ b/skills/growth-guards/tests/conflict-markers.test.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# Pins for scripts/conflict-markers: each of the open/base/close trio at
+# column 0 fires, indented/quoted/glued occurrences and the seven-equals
+# separator do not, excludes need reasons, the check's own source never
+# trips it, and a broken scan is a collection error — never a pass. Every
+# green assertion is paired with a control that proves it can fail.
+#
+# Marker runs are assembled with printf throughout so this test file never
+# contains a marker shape itself — the vstack repo runs conflict-markers
+# over its own tree, tests included.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
+CM="$SKILL_DIR/scripts/conflict-markers"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# Hermetic: a leaked setting would mask every case below.
+unset GROWTH_GUARDS_CONFLICT_EXCLUDES GROWTH_GUARDS_SETTINGS_FILE 2>/dev/null || true
+
+mk7() { printf '%s%s%s%s%s%s%s' "$1" "$1" "$1" "$1" "$1" "$1" "$1"; }
+OPEN="$(mk7 '<')"
+BASE="$(mk7 '|')"
+CLOSE="$(mk7 '>')"
+SEP="$(mk7 '=')"
+
+PASS=0
+FAIL=0
+ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
+
+new_repo() { # NAME — fresh fixture repo in $R
+  R="$TMP/$1"
+  mkdir -p "$R"
+  git -C "$R" -c init.defaultBranch=main init -q
+  git -C "$R" config user.email test@example.com
+  git -C "$R" config user.name test
+}
+
+run_cm() { # [args...] — run in $R; sets OUT and RC
+  OUT=""
+  RC=0
+  OUT="$(cd "$R" && "$CM" "$@" 2>&1)" || RC=$?
+}
+
+echo "=== control: a clean repo passes ==="
+new_repo clean
+printf 'fn main() {}\n' >"$R/ok.rs"
+git -C "$R" add -A
+run_cm
+[ "$RC" -eq 0 ] && case "$OUT" in *"conflict-markers: OK"*) true ;; *) false ;; esac \
+  && ok "clean repo passes" || bad "clean repo passes" "rc=$RC out=$OUT"
+
+echo "=== each marker of the trio at column 0 fails, naming the file ==="
+new_repo trio
+printf '%s HEAD\n' "$OPEN" >"$R/a.rs"
+git -C "$R" add -A
+run_cm
+[ "$RC" -eq 1 ] && case "$OUT" in *"conflict marker: a.rs:1:"*) true ;; *) false ;; esac \
+  && ok "the open marker with its label fails, naming file:line" \
+  || bad "open marker fails" "rc=$RC out=$OUT"
+case "$OUT" in *"finish the merge and delete the marker lines"*) ok "diagnostic carries the remediation" ;; *) bad "diagnostic carries the remediation" "$OUT" ;; esac
+
+printf '%s\n' "$BASE" >"$R/a.rs"
+git -C "$R" add -A
+run_cm
+[ "$RC" -eq 1 ] && case "$OUT" in *"conflict marker: a.rs:1:"*) true ;; *) false ;; esac \
+  && ok "the bare base marker (end of line, no label) fails" \
+  || bad "base marker fails" "rc=$RC out=$OUT"
+
+printf '%s theirs\n' "$CLOSE" >"$R/a.rs"
+git -C "$R" add -A
+run_cm
+[ "$RC" -eq 1 ] && ok "the close marker with its label fails" \
+  || bad "close marker fails" "rc=$RC out=$OUT"
+
+echo "=== indented, quoted, and glued occurrences never fire ==="
+{
+  printf ' %s HEAD\n' "$OPEN"
+  printf '\t%s theirs\n' "$CLOSE"
+  printf 'the %s run mid-prose\n' "$BASE"
+  printf 'quoted: "%s ours"\n' "$OPEN"
+  printf '%sx glued to text\n' "$OPEN"
+} >"$R/a.rs"
+git -C "$R" add -A
+run_cm
+[ "$RC" -eq 0 ] && ok "space/tab-indented, quoted, mid-prose and glued runs all pass" \
+  || bad "non-column-0 and glued runs pass" "rc=$RC out=$OUT"
+
+printf '%s%s eight then a space\n' "$OPEN" '<' >"$R/a.rs"
+git -C "$R" add -A
+run_cm
+[ "$RC" -eq 0 ] && ok "an eight-character run is not the seven-character marker" \
+  || bad "eight-character run passes" "rc=$RC out=$OUT"
+
+echo "=== the seven-equals separator alone never fires ==="
+printf 'Title\n%s\n' "$SEP" >"$R/a.md"
+printf 'fn main() {}\n' >"$R/a.rs"
+git -C "$R" add -A
+run_cm
+[ "$RC" -eq 0 ] && ok "a setext H2 underline at column 0 passes (separator is deliberately unmatched)" \
+  || bad "seven-equals separator passes" "rc=$RC out=$OUT"
+
+echo "=== excludes: a declared path is exempt WITH a reason ==="
+new_repo exc
+mkdir -p "$R/fixtures" "$R/tools"
+printf '%s HEAD\nours\n%s theirs\n' "$OPEN" "$CLOSE" >"$R/fixtures/merge.txt"
+git -C "$R" add -A
+run_cm
+[ "$RC" -eq 1 ] && ok "control: the fixture marker fails without an excludes row" \
+  || bad "control: fixture marker fails without excludes" "rc=$RC out=$OUT"
+
+printf 'fixtures/*\tmerge-conflict fixture data\n' >"$R/tools/conflict-markers-excludes"
+git -C "$R" add -A
+run_cm
+[ "$RC" -eq 0 ] && ok "the excludes row silences exactly the declared path" \
+  || bad "excludes row silences the declared path" "rc=$RC out=$OUT"
+
+printf 'fixtures/*\n' >"$R/tools/conflict-markers-excludes"
+git -C "$R" add -A
+run_cm
+[ "$RC" -eq 2 ] && case "$OUT" in *"pattern<TAB>reason"*) true ;; *) false ;; esac \
+  && ok "a pattern without a tab-separated reason is exit 2" \
+  || bad "a pattern without a reason is exit 2" "rc=$RC out=$OUT"
+
+echo "=== configuration: GROWTH_GUARDS_CONFLICT_EXCLUDES and --excludes ==="
+printf 'fixtures/*\tmerge-conflict fixture data\n' >"$R/alt-excludes"
+rm "$R/tools/conflict-markers-excludes"
+git -C "$R" add -A
+OUT="$(cd "$R" && GROWTH_GUARDS_CONFLICT_EXCLUDES=alt-excludes "$CM" 2>&1)" && RC=0 || RC=$?
+[ "$RC" -eq 0 ] && ok "excludes path resolves through the environment key" \
+  || bad "excludes path resolves through the environment key" "rc=$RC out=$OUT"
+run_cm --excludes alt-excludes
+[ "$RC" -eq 0 ] && ok "--excludes flag points at the same list" || bad "--excludes flag" "rc=$RC out=$OUT"
+run_cm
+[ "$RC" -eq 1 ] && ok "control: without either, the fixture marker still fails" \
+  || bad "control: default excludes path has no file, marker fails" "rc=$RC out=$OUT"
+
+run_cm --no-such-flag
+[ "$RC" -eq 2 ] && ok "unknown flag is exit 2" || bad "unknown flag is exit 2" "rc=$RC out=$OUT"
+
+echo "=== the check's own source does not trip it ==="
+new_repo self
+mkdir -p "$R/scripts"
+cp "$CM" "$R/scripts/conflict-markers"
+git -C "$R" add -A
+run_cm
+[ "$RC" -eq 0 ] && ok "the shipped script, tracked, scans clean (interval-built patterns)" \
+  || bad "the shipped script scans clean" "rc=$RC out=$OUT"
+# Control: the scan still fires in this repo when a real marker appears.
+printf '%s HEAD\n' "$OPEN" >"$R/planted.txt"
+git -C "$R" add -A
+run_cm
+[ "$RC" -eq 1 ] && case "$OUT" in *"planted.txt:1:"*"scripts/conflict-markers"*) false ;; *"planted.txt:1:"*) true ;; *) false ;; esac \
+  && ok "control: a planted marker fails while the script stays unnamed" \
+  || bad "control: planted marker fails, script unnamed" "rc=$RC out=$OUT"
+
+echo "=== fail-closed: a broken scan terminates, never passes ==="
+new_repo grepfail
+printf 'clean file\n' >"$R/ok.txt"
+git -C "$R" add -A
+run_cm
+[ "$RC" -eq 0 ] && ok "shim-free control: the fixture passes with the real git" \
+  || bad "shim-free control passes" "rc=$RC out=$OUT"
+
+REAL_GIT="$(command -v git)"
+GIT_SHIM="$TMP/git-shim"
+mkdir -p "$GIT_SHIM"
+cat >"$GIT_SHIM/git" <<EOF
+#!/usr/bin/env bash
+for a in "\$@"; do
+  if [ "\$a" = "grep" ]; then
+    echo "git grep: simulated execution failure" >&2
+    exit 128
+  fi
+done
+exec "$REAL_GIT" "\$@"
+EOF
+chmod +x "$GIT_SHIM/git"
+OUT="$(cd "$R" && PATH="$GIT_SHIM:$PATH" "$CM" 2>&1)" && RC=0 || RC=$?
+[ "$RC" -eq 2 ] && case "$OUT" in *"git grep failed scanning tracked files"*) true ;; *) false ;; esac \
+  && ok "a git grep execution failure is a collection error: exit 2, never OK" \
+  || bad "a git grep execution failure is a collection error" "rc=$RC out=$OUT"
+case "$OUT" in *"conflict-markers: OK"*) bad "no OK verdict may accompany a broken scan" "$OUT" ;; *) ok "no OK verdict accompanies the broken scan" ;; esac
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/skills/growth-guards/tests/dispatcher.test.sh
+++ b/skills/growth-guards/tests/dispatcher.test.sh
@@ -16,8 +16,8 @@ trap 'rm -rf "$TMP"' EXIT
 
 unset GROWTH_GUARDS_CHECKS GROWTH_GUARDS_TODO_EXCLUDES GROWTH_GUARDS_BYTE_CEILING_KB \
   GROWTH_GUARDS_BYTE_EXCLUDES GROWTH_GUARDS_SUPPRESSION_EXCLUDES \
-  GROWTH_GUARDS_SUPPRESSION_BASELINE GROWTH_GUARDS_COMMIT_TYPES \
-  GROWTH_GUARDS_SETTINGS_FILE 2>/dev/null || true
+  GROWTH_GUARDS_SUPPRESSION_BASELINE GROWTH_GUARDS_CONFLICT_EXCLUDES \
+  GROWTH_GUARDS_COMMIT_TYPES GROWTH_GUARDS_SETTINGS_FILE 2>/dev/null || true
 
 TD="TO""DO"
 
@@ -58,9 +58,9 @@ printf 'fn main() {}\n' >"$R/ok.rs"
 git -C "$R" add -A
 run_gg
 [ "$RC" -eq 0 ] \
-  && case "$OUT" in *"growth-guards: todo-ban"*"growth-guards: byte-ceiling"*"growth-guards: suppression-ban"*"growth-guards: OK"*) true ;; *) false ;; esac \
-  && ok "the batch runs todo-ban, byte-ceiling, suppression-ban and reports OK" \
-  || bad "batch runs the three default checks" "rc=$RC out=$OUT"
+  && case "$OUT" in *"growth-guards: todo-ban"*"growth-guards: byte-ceiling"*"growth-guards: suppression-ban"*"growth-guards: conflict-markers"*"growth-guards: OK"*) true ;; *) false ;; esac \
+  && ok "the batch runs todo-ban, byte-ceiling, suppression-ban, conflict-markers and reports OK" \
+  || bad "batch runs the four default checks" "rc=$RC out=$OUT"
 run_gg -- all
 [ "$RC" -eq 0 ] && ok "'all' is the same batch" || bad "'all' is the same batch" "rc=$RC out=$OUT"
 


### PR DESCRIPTION
Closes #1479.

New `conflict-markers` check in the growth-guards family, exactly the issue's shape: index-scoped (`git grep --cached` via the shared lane helper), fails the open/base/close trio at column 0 (each exactly seven characters, then space or EOL; an 8-char run does not match — pinned by test), deliberately not the seven-equals separator (setext-underline false-positive; open+close always accompany a real conflict). Family idiom throughout: `pattern<TAB>reason` excludes (default `tools/conflict-markers-excludes`, env `GROWTH_GUARDS_CONFLICT_EXCLUDES`, flag override), exit 0/1/2 with git-grep errors routed to collection-error (never clean), dispatcher batch + single-name routing, pre-commit chain pickup automatic.

Self-trip avoidance: the pattern is built with ERE interval counts (`^(<{7}|[|]{7}|>{7})( |$)`) so no literal 7-char marker run exists in the script's bytes; tests build runs at runtime.

Tests: new 20-case suite (per-marker firing with file:line, precision controls, excludes with fail-first control, config errors, broken-grep exit 2, self-scan control); full family green (bash32, byte-ceiling 39, cleanup-scope 10, commit-msg 49, dispatcher 15, install-git-hooks 184, suppression-ban 38, todo-ban 26); the new check runs clean over vstack's own 1557-file tree; `validate-changed` all 5 lanes; README held exactly at its 120-line class bound by tightening, no claims dropped.

The issue's demand side: at least one consumer carries two local implementations of this rule — both retire against this check on the next train.

Implementation by a delegated dev agent; reviewed and shepherded by the steward session.

https://claude.ai/code/session_01SgCfsq4oKxc45iq25VcPhG