### PR TITLE
fix(preflight): the temp-path lane catches bare-root mkdtemp forms

### DIFF
--- a/skills/preflight/scripts/preflight
+++ b/skills/preflight/scripts/preflight
@@ -547,6 +547,11 @@ has_exit_trap() { # FILE
 # real creation sites, and a lane that flags the fixtures is noise that
 # buries the finding.
 TMPPATH_CREATE_RE='(mkdtemp|mkdtempSync|mkdir|mkdirSync|makedirs|create_dir_all)[[:space:]]*\([^,)]*["'\''`]/(var/)?tmp/'
+# The mkdtemp family ALWAYS creates, so a bare quoted temp root anywhere in
+# its arguments is the same leak (tempfile.mkdtemp(dir="/tmp")) — or worse,
+# a root-level sibling (mkdtempSync("/tmp") makes /tmpXXXXXX). Plain mkdir
+# of the bare root stays out: creating /tmp itself is a no-op.
+TMPPATH_CREATE_RE="$TMPPATH_CREATE_RE"'|(mkdtemp|mkdtempSync)[[:space:]]*\([^)]*["'\''`]/(var/)?tmp["'\''`]'
 TMPPATH_CREATE_RE="$TMPPATH_CREATE_RE"'|(^[[:space:]]*|[;|&(`{][[:space:]]*)mkdir[[:space:]]+-p[[:space:]]+["'\'']?/(var/)?tmp/'
 
 # The marker form only: the word immediately followed by a colon or by an
@@ -926,7 +931,7 @@ while IFS= read -r f; do
     # nothing.
     if [ "$is_md" = 0 ]; then
       case "$content" in
-        *"/tmp/"*)
+        *"/tmp"*)
           case "${content#"${content%%[![:space:]]*}"}" in
             '#'* | '//'* | '/*'* | '*'*) ;;
             *)

--- a/skills/preflight/tests/lanes-must-fail.test.sh
+++ b/skills/preflight/tests/lanes-must-fail.test.sh
@@ -121,11 +121,12 @@ fires "an mktemp with no arguments is the same finding" "scripts/scratchfile.sh:
 echo "=== lane hardcoded-temp-path: directory creation at a literal absolute temp path ==="
 seed tmppath
 mkdir -p "$R/src"
-# Trip paths are substituted at run time, so this suite's committed bytes
-# never join a creation call to a temp-path literal.
+# Trip paths are substituted at run time: the generated FIXTURE repo carries
+# the literals by design, while this suite's own committed bytes never join
+# a creation call to one.
 printf '#!/usr/bin/env bash\nset -euo pipefail\nmkdir -p %s/cache\n' /tmp >"$R/scripts/shellmk.sh"
 printf 'const fs = require("fs");\nfs.mkdirSync("%s/out");\nfs.mkdtempSync("%s/app-");\n' /tmp /tmp >"$R/src/mk.js"
-printf 'import os, tempfile\nos.makedirs("%s/state")\ntempfile.mkdtemp(dir="%s/keep")\n' /tmp /tmp >"$R/src/mk.py"
+printf 'import os, tempfile\nos.makedirs("%s/state")\ntempfile.mkdtemp(dir="%s/keep")\ntempfile.mkdtemp(dir="%s")\n' /tmp /tmp /tmp >"$R/src/mk.py"
 printf 'fn main() {\n    std::fs::create_dir_all("%s/rust").unwrap();\n}\n' /tmp >"$R/src/mk.rs"
 printf 'import os\nos.mkdir("%s/persist")\n' /var/tmp >"$R/src/mkvar.py"
 git -C "$R" add -A
@@ -135,6 +136,7 @@ fires "a JS mkdirSync taking the literal fails" "src/mk.js:2: [hardcoded-temp-pa
 fires "a JS mkdtempSync prefix under /tmp is the same finding" "src/mk.js:3: [hardcoded-temp-path]"
 fires "a Python makedirs taking the literal fails" "src/mk.py:2: [hardcoded-temp-path]"
 fires "a Python mkdtemp aimed at /tmp by keyword fails" "src/mk.py:3: [hardcoded-temp-path]"
+fires "a bare-root mkdtemp keyword (dir=/tmp, no trailing slash) fails" "src/mk.py:4: [hardcoded-temp-path]"
 fires "a Rust create_dir_all taking the literal fails" "src/mk.rs:2: [hardcoded-temp-path]"
 fires "/var/tmp is the same literal" "src/mkvar.py:2: [hardcoded-temp-path]"
 

--- a/skills/preflight/tests/lanes-must-fail.test.sh
+++ b/skills/preflight/tests/lanes-must-fail.test.sh
@@ -125,7 +125,7 @@ mkdir -p "$R/src"
 # the literals by design, while this suite's own committed bytes never join
 # a creation call to one.
 printf '#!/usr/bin/env bash\nset -euo pipefail\nmkdir -p %s/cache\n' /tmp >"$R/scripts/shellmk.sh"
-printf 'const fs = require("fs");\nfs.mkdirSync("%s/out");\nfs.mkdtempSync("%s/app-");\n' /tmp /tmp >"$R/src/mk.js"
+printf 'const fs = require("fs");\nfs.mkdirSync("%s/out");\nfs.mkdtempSync("%s/app-");\nfs.mkdtempSync("%s");\n' /tmp /tmp /tmp >"$R/src/mk.js"
 printf 'import os, tempfile\nos.makedirs("%s/state")\ntempfile.mkdtemp(dir="%s/keep")\ntempfile.mkdtemp(dir="%s")\n' /tmp /tmp /tmp >"$R/src/mk.py"
 printf 'fn main() {\n    std::fs::create_dir_all("%s/rust").unwrap();\n}\n' /tmp >"$R/src/mk.rs"
 printf 'import os\nos.mkdir("%s/persist")\n' /var/tmp >"$R/src/mkvar.py"
@@ -137,6 +137,7 @@ fires "a JS mkdtempSync prefix under /tmp is the same finding" "src/mk.js:3: [ha
 fires "a Python makedirs taking the literal fails" "src/mk.py:2: [hardcoded-temp-path]"
 fires "a Python mkdtemp aimed at /tmp by keyword fails" "src/mk.py:3: [hardcoded-temp-path]"
 fires "a bare-root mkdtemp keyword (dir=/tmp, no trailing slash) fails" "src/mk.py:4: [hardcoded-temp-path]"
+fires "the JS bare-root prefix form (mkdtempSync(/tmp) making a /tmpXXXXXX sibling) fails" "src/mk.js:4: [hardcoded-temp-path]"
 fires "a Rust create_dir_all taking the literal fails" "src/mk.rs:2: [hardcoded-temp-path]"
 fires "/var/tmp is the same literal" "src/mkvar.py:2: [hardcoded-temp-path]"
 

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -156,7 +156,7 @@ skills/orch/tests/lanes.sh	890
 skills/orch/tests/oversee_watch.sh	814
 skills/orch/tests/queue_wait.sh	943
 skills/orch/workflows/review-pr.md	450
-skills/preflight/scripts/preflight	1004
+skills/preflight/scripts/preflight	1009
 skills/review-gate/scripts/pr-watch.sh	820
 skills/review-gate/scripts/review-predicate-selftest.sh	2607
 skills/review-gate/scripts/review-predicate.sh	1149


### PR DESCRIPTION
Follow-up from the drovr#570 re-vendor review (the one finding that survived triage): `tempfile.mkdtemp(dir="/tmp")` — and any mkdtemp-family call carrying a bare quoted temp root — creates a fresh subdirectory under the literal root (or a root-level `/tmpXXXXXX` sibling for the prefix form), which is exactly the leak shape the lane exists for, and the trailing-slash requirement missed it.

The mkdtemp family always creates, so a new alternation matches `mkdtemp`/`mkdtempSync` with a bare quoted `/tmp` or `/var/tmp` anywhere in the arguments; plain `mkdir` of the bare root stays excluded (creating `/tmp` itself is a no-op — the pinned decision from #1483's review). The line fast-path widens from `/tmp/` to `/tmp` accordingly. Also rewords the fixture comment the same review flagged as ambiguous.

Tests: new must-fire pin for the keyword form; all four preflight suites pass; size-ratchet row bumped in-diff.

https://claude.ai/code/session_01SgCfsq4oKxc45iq25VcPhG