### PR TITLE
fix(growth-guards): grep lanes fail closed when git cannot read a staged blob

### DIFF
--- a/skills/growth-guards/scripts/lib/common.sh
+++ b/skills/growth-guards/scripts/lib/common.sh
@@ -192,6 +192,20 @@ gg_is_excluded() { # PATH — 0 when some exclusion glob matches the full path
   return 1
 }
 
+# Judge one `git grep` run from its exit status AND captured stderr. The
+# status carries only the MATCH result: a staged blob git cannot read is an
+# `error:` line on stderr while the status still says 1 (nothing matched) or
+# 0 (something else matched), so status alone can bless a scan that skipped
+# content — and a status-0 run that also errored must not fold as an
+# ordinary violation verdict over a partial scan.
+gg_grep_guard() { # STATUS ERRFILE CONTEXT — returns only when the scan is complete
+  local status="$1" errfile="$2" context="$3" first_err
+  [ ! -s "$errfile" ] || cat -- "$errfile" >&2
+  [ "$status" -le 1 ] || gg_collection_error "git grep failed $context (exit $status)"
+  first_err="$(grep -E '^error:' -- "$errfile" | head -n 1 || true)"
+  [ -z "$first_err" ] || gg_collection_error "git grep could not read staged content while $context ($first_err)"
+}
+
 # One banned shape, scanned over INDEX content in two phases: the offending
 # FILES (-l -z, so a path containing ':' cannot garble parsing), then the
 # numbered hits per file, where the known path prefix strips exactly. Binary
@@ -201,12 +215,13 @@ gg_is_excluded() { # PATH — 0 when some exclusion glob matches the full path
 gg_grep_lane() { # LABEL ERE REMEDY PATHSPEC... — numbered violations on stdout
   local label="$1" ere="$2" remedy="$3" status=0 f hit_status hit
   shift 3
-  git grep --cached -lIzE "$ere" -- "$@" >"$GG_TMP/lane.z" || status=$?
-  [ "$status" -le 1 ] || gg_collection_error "git grep failed scanning tracked files for $label (exit $status)"
+  git grep --cached -lIzE "$ere" -- "$@" >"$GG_TMP/lane.z" 2>"$GG_TMP/lane.err" || status=$?
+  gg_grep_guard "$status" "$GG_TMP/lane.err" "scanning tracked files for $label"
   while IFS= read -r -d '' f; do
     gg_is_excluded "$f" && continue
     hit_status=0
-    git grep --cached -nIE "$ere" -- ":(literal)$f" >"$GG_TMP/lane.hits" || hit_status=$?
+    git grep --cached -nIE "$ere" -- ":(literal)$f" >"$GG_TMP/lane.hits" 2>"$GG_TMP/lane.err" || hit_status=$?
+    gg_grep_guard "$hit_status" "$GG_TMP/lane.err" "detailing the $label hits in '$f'"
     # This file just listed as containing hits; anything but a clean re-scan
     # (including "no matches") means the measurement is broken.
     [ "$hit_status" -eq 0 ] || gg_collection_error "git grep could not detail the $label hits in '$f' (exit $hit_status)"

--- a/skills/growth-guards/scripts/lib/common.sh
+++ b/skills/growth-guards/scripts/lib/common.sh
@@ -197,7 +197,9 @@ gg_is_excluded() { # PATH — 0 when some exclusion glob matches the full path
 # `error:` line on stderr while the status still says 1 (nothing matched) or
 # 0 (something else matched), so status alone can bless a scan that skipped
 # content — and a status-0 run that also errored must not fold as an
-# ordinary violation verdict over a partial scan.
+# ordinary violation verdict over a partial scan. The `error:` prefix is
+# git's C-locale spelling, so every call feeding this guard runs under
+# LC_ALL=C — a translated prefix would slip past the match.
 gg_grep_guard() { # STATUS ERRFILE CONTEXT — returns only when the scan is complete
   local status="$1" errfile="$2" context="$3" first_err
   [ ! -s "$errfile" ] || cat -- "$errfile" >&2
@@ -215,12 +217,12 @@ gg_grep_guard() { # STATUS ERRFILE CONTEXT — returns only when the scan is com
 gg_grep_lane() { # LABEL ERE REMEDY PATHSPEC... — numbered violations on stdout
   local label="$1" ere="$2" remedy="$3" status=0 f hit_status hit
   shift 3
-  git grep --cached -lIzE "$ere" -- "$@" >"$GG_TMP/lane.z" 2>"$GG_TMP/lane.err" || status=$?
+  LC_ALL=C git grep --cached -lIzE "$ere" -- "$@" >"$GG_TMP/lane.z" 2>"$GG_TMP/lane.err" || status=$?
   gg_grep_guard "$status" "$GG_TMP/lane.err" "scanning tracked files for $label"
   while IFS= read -r -d '' f; do
     gg_is_excluded "$f" && continue
     hit_status=0
-    git grep --cached -nIE "$ere" -- ":(literal)$f" >"$GG_TMP/lane.hits" 2>"$GG_TMP/lane.err" || hit_status=$?
+    LC_ALL=C git grep --cached -nIE "$ere" -- ":(literal)$f" >"$GG_TMP/lane.hits" 2>"$GG_TMP/lane.err" || hit_status=$?
     gg_grep_guard "$hit_status" "$GG_TMP/lane.err" "detailing the $label hits in '$f'"
     # This file just listed as containing hits; anything but a clean re-scan
     # (including "no matches") means the measurement is broken.

--- a/skills/growth-guards/scripts/suppression-ban
+++ b/skills/growth-guards/scripts/suppression-ban
@@ -142,8 +142,8 @@ while IFS= read -r -d '' f; do
 done <"$GG_TMP/rs.z"
 
 status=0
-git grep --cached -cIE "$BARE_ERE" -- '*.rs' >"$GG_TMP/bare.raw" || status=$?
-[ "$status" -le 1 ] || gg_collection_error "git grep failed counting bare allows (exit $status)"
+git grep --cached -cIE "$BARE_ERE" -- '*.rs' >"$GG_TMP/bare.raw" 2>"$GG_TMP/bare.err" || status=$?
+gg_grep_guard "$status" "$GG_TMP/bare.err" "counting bare allows"
 
 : >"$GG_TMP/counts.raw"
 while IFS= read -r row; do

--- a/skills/growth-guards/scripts/suppression-ban
+++ b/skills/growth-guards/scripts/suppression-ban
@@ -142,7 +142,7 @@ while IFS= read -r -d '' f; do
 done <"$GG_TMP/rs.z"
 
 status=0
-git grep --cached -cIE "$BARE_ERE" -- '*.rs' >"$GG_TMP/bare.raw" 2>"$GG_TMP/bare.err" || status=$?
+LC_ALL=C git grep --cached -cIE "$BARE_ERE" -- '*.rs' >"$GG_TMP/bare.raw" 2>"$GG_TMP/bare.err" || status=$?
 gg_grep_guard "$status" "$GG_TMP/bare.err" "counting bare allows"
 
 : >"$GG_TMP/counts.raw"

--- a/skills/growth-guards/tests/conflict-markers.test.sh
+++ b/skills/growth-guards/tests/conflict-markers.test.sh
@@ -195,7 +195,8 @@ run_cm
 [ "$RC" -eq 1 ] && ok "control: the staged marker trips while its blob is readable" \
   || bad "control: readable blob trips" "rc=$RC out=$OUT"
 OID="$(git -C "$R" rev-parse :marker.txt)"
-rm "$R/.git/objects/${OID:0:2}/${OID:2}"
+[ -f "$R/.git/objects/${OID:0:2}/${OID:2}" ] || bad "fixture: the staged blob is not a loose object at the expected path" "$OID"
+rm -f -- "$R/.git/objects/${OID:0:2}/${OID:2}"
 run_cm
 [ "$RC" -eq 2 ] && case "$OUT" in *"error: "*"unable to read"*) true ;; *) false ;; esac \
   && ok "a vanished staged blob is exit 2 carrying git's own error line" \

--- a/skills/growth-guards/tests/conflict-markers.test.sh
+++ b/skills/growth-guards/tests/conflict-markers.test.sh
@@ -187,5 +187,30 @@ OUT="$(cd "$R" && PATH="$GIT_SHIM:$PATH" "$CM" 2>&1)" && RC=0 || RC=$?
   || bad "a git grep execution failure is a collection error" "rc=$RC out=$OUT"
 case "$OUT" in *"conflict-markers: OK"*) bad "no OK verdict may accompany a broken scan" "$OUT" ;; *) ok "no OK verdict accompanies the broken scan" ;; esac
 
+echo "=== fail-closed: an unreadable staged blob is a collection error ==="
+new_repo unreadable
+printf '%s HEAD\n' "$OPEN" >"$R/marker.txt"
+git -C "$R" add -A
+run_cm
+[ "$RC" -eq 1 ] && ok "control: the staged marker trips while its blob is readable" \
+  || bad "control: readable blob trips" "rc=$RC out=$OUT"
+OID="$(git -C "$R" rev-parse :marker.txt)"
+rm "$R/.git/objects/${OID:0:2}/${OID:2}"
+run_cm
+[ "$RC" -eq 2 ] && case "$OUT" in *"error: "*"unable to read"*) true ;; *) false ;; esac \
+  && ok "a vanished staged blob is exit 2 carrying git's own error line" \
+  || bad "vanished blob is exit 2 with git's error line" "rc=$RC out=$OUT"
+case "$OUT" in *"conflict-markers: OK"*) bad "no OK verdict may accompany an unread blob" "$OUT" ;; *) ok "no OK verdict accompanies the unread blob" ;; esac
+
+# Status 0 + stderr error: a second, readable file matches while the first
+# stays unread — a partial scan must not fold as an ordinary violation.
+printf '%s theirs\n' "$CLOSE" >"$R/readable.txt"
+git -C "$R" add readable.txt
+run_cm
+[ "$RC" -eq 2 ] && case "$OUT" in *"unable to read"*) true ;; *) false ;; esac \
+  && ok "a scan that matches one file but cannot read another is exit 2, never a violation verdict" \
+  || bad "match + unreadable blob is exit 2, not 1" "rc=$RC out=$OUT"
+case "$OUT" in *"conflict marker(s) — excludes"*) bad "no violation summary may accompany a partial scan" "$OUT" ;; *) ok "no violation summary accompanies the partial scan" ;; esac
+
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/skills/growth-guards/tests/suppression-ban.test.sh
+++ b/skills/growth-guards/tests/suppression-ban.test.sh
@@ -352,5 +352,48 @@ OUT="$(cd "$R" && PATH="$GIT_SHIM:$PATH" "$SB" 2>&1)" && RC=0 || RC=$?
   || bad "a git grep execution failure is a collection error" "rc=$RC out=$OUT"
 case "$OUT" in *"suppression-ban: OK"*) bad "no OK verdict may accompany a broken scan" "$OUT" ;; *) ok "no OK verdict accompanies the broken scan" ;; esac
 
+echo "=== fail-closed: an unreadable staged blob is a collection error ==="
+new_repo unreadable
+printf '#[allow(dead_code)]\nfn f() {}\n' >"$R/bare.rs"
+git -C "$R" add -A
+run_sb
+[ "$RC" -eq 1 ] && ok "control: the staged bare allow trips while its blob is readable" \
+  || bad "control: readable blob trips" "rc=$RC out=$OUT"
+OID="$(git -C "$R" rev-parse :bare.rs)"
+rm "$R/.git/objects/${OID:0:2}/${OID:2}"
+run_sb
+[ "$RC" -eq 2 ] && case "$OUT" in *"error: "*"unable to read"*) true ;; *) false ;; esac \
+  && ok "a vanished staged blob is exit 2 carrying git's own error line" \
+  || bad "vanished blob is exit 2 with git's error line" "rc=$RC out=$OUT"
+case "$OUT" in *"suppression-ban: OK"*) bad "no OK verdict may accompany an unread blob" "$OUT" ;; *) ok "no OK verdict accompanies the unread blob" ;; esac
+
+# The bare-allow count call bypasses the shared lane helper; a shim erroring
+# ONLY that call proves its own guard (a real unreadable .rs blob is caught
+# earlier, by the gate-1 lane scan above).
+new_repo countfail
+printf 'fn main() {}\n' >"$R/ok.rs"
+git -C "$R" add -A
+run_sb
+[ "$RC" -eq 0 ] && ok "shim-free control: the countfail fixture passes with the real git" \
+  || bad "shim-free countfail control passes" "rc=$RC out=$OUT"
+COUNT_SHIM="$TMP/git-shim-count"
+mkdir -p "$COUNT_SHIM"
+cat >"$COUNT_SHIM/git" <<EOF
+#!/usr/bin/env bash
+for a in "\$@"; do
+  if [ "\$a" = "-cIE" ]; then
+    echo "error: 'phantom.rs': unable to read 0000000000000000000000000000000000000000" >&2
+    exit 1
+  fi
+done
+exec "$REAL_GIT" "\$@"
+EOF
+chmod +x "$COUNT_SHIM/git"
+OUT="$(cd "$R" && PATH="$COUNT_SHIM:$PATH" "$SB" 2>&1)" && RC=0 || RC=$?
+[ "$RC" -eq 2 ] && case "$OUT" in *"unable to read"*) true ;; *) false ;; esac \
+  && ok "an error-carrying no-match count is exit 2, never a clean zero" \
+  || bad "error-carrying count is exit 2" "rc=$RC out=$OUT"
+case "$OUT" in *"suppression-ban: OK"*) bad "no OK verdict may accompany a broken count" "$OUT" ;; *) ok "no OK verdict accompanies the broken count" ;; esac
+
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/skills/growth-guards/tests/suppression-ban.test.sh
+++ b/skills/growth-guards/tests/suppression-ban.test.sh
@@ -360,7 +360,8 @@ run_sb
 [ "$RC" -eq 1 ] && ok "control: the staged bare allow trips while its blob is readable" \
   || bad "control: readable blob trips" "rc=$RC out=$OUT"
 OID="$(git -C "$R" rev-parse :bare.rs)"
-rm "$R/.git/objects/${OID:0:2}/${OID:2}"
+[ -f "$R/.git/objects/${OID:0:2}/${OID:2}" ] || bad "fixture: the staged blob is not a loose object at the expected path" "$OID"
+rm -f -- "$R/.git/objects/${OID:0:2}/${OID:2}"
 run_sb
 [ "$RC" -eq 2 ] && case "$OUT" in *"error: "*"unable to read"*) true ;; *) false ;; esac \
   && ok "a vanished staged blob is exit 2 carrying git's own error line" \

--- a/skills/growth-guards/tests/todo-ban.test.sh
+++ b/skills/growth-guards/tests/todo-ban.test.sh
@@ -186,7 +186,8 @@ run_tb
 [ "$RC" -eq 1 ] && ok "control: the staged marker trips while its blob is readable" \
   || bad "control: readable blob trips" "rc=$RC out=$OUT"
 OID="$(git -C "$R" rev-parse :a.rs)"
-rm "$R/.git/objects/${OID:0:2}/${OID:2}"
+[ -f "$R/.git/objects/${OID:0:2}/${OID:2}" ] || bad "fixture: the staged blob is not a loose object at the expected path" "$OID"
+rm -f -- "$R/.git/objects/${OID:0:2}/${OID:2}"
 run_tb
 [ "$RC" -eq 2 ] && case "$OUT" in *"error: "*"unable to read"*) true ;; *) false ;; esac \
   && ok "a vanished staged blob is exit 2 carrying git's own error line" \

--- a/skills/growth-guards/tests/todo-ban.test.sh
+++ b/skills/growth-guards/tests/todo-ban.test.sh
@@ -178,6 +178,20 @@ OUT="$(cd "$R" && PATH="$GIT_SHIM:$PATH" "$TB" 2>&1)" && RC=0 || RC=$?
   || bad "a git grep execution failure is a collection error" "rc=$RC out=$OUT"
 case "$OUT" in *"todo-ban: OK"*) bad "no OK verdict may accompany a broken scan" "$OUT" ;; *) ok "no OK verdict accompanies the broken scan" ;; esac
 
+echo "=== fail-closed: an unreadable staged blob is a collection error ==="
+new_repo unreadable
+printf '// %s: stranded work\n' "$TD" >"$R/a.rs"
+git -C "$R" add -A
+run_tb
+[ "$RC" -eq 1 ] && ok "control: the staged marker trips while its blob is readable" \
+  || bad "control: readable blob trips" "rc=$RC out=$OUT"
+OID="$(git -C "$R" rev-parse :a.rs)"
+rm "$R/.git/objects/${OID:0:2}/${OID:2}"
+run_tb
+[ "$RC" -eq 2 ] && case "$OUT" in *"error: "*"unable to read"*) true ;; *) false ;; esac \
+  && ok "a vanished staged blob is exit 2 carrying git's own error line" \
+  || bad "vanished blob is exit 2 with git's error line" "rc=$RC out=$OUT"
+case "$OUT" in *"todo-ban: OK"*) bad "no OK verdict may accompany an unread blob" "$OUT" ;; *) ok "no OK verdict accompanies the unread blob" ;; esac
 
 echo "=== a URL is not a comment leader ==="
 new_repo url


### PR DESCRIPTION
Closes #1492.

**Defect (owner repro):** the shared lane helper guarded `git grep`'s exit STATUS but not stderr — and git spends the status on the MATCH result (1 no-match, 0 when something else matched), reporting an unreadable staged blob only as an `error:` stderr line. A lane printed git's diagnostic and then exited 0 over content it never scanned; the one failure mode CI cannot backstop (a fresh clone can't reproduce a missing local object).

**Fix (the issue's three-way fold, at the shared helper):** new `gg_grep_guard STATUS ERRFILE CONTEXT` — status ≥2 keeps the hard-failure path; status 0 or 1 with a `^error:` stderr line raises `gg_collection_error` (exit 2) embedding git's first error line, the status-0 branch included so a scan that matches one file but cannot read another never folds as an ordinary violation over a partial scan. Applied to both helper phases (list-files and per-file detail) covering conflict-markers/todo-ban/suppression-ban, plus suppression-ban's direct bare-allow count (the one call bypassing the helper). Full call-site audit in the commit's test coverage: `ls-files` (index-only) and `git show` (status-guarded) call sites have no hole.

**Tests:** unreadable-blob fixtures (loose-object deletion per the repro) with readable controls in all three lane suites, the status-0 partial-scan branch, and a shimmed direct-count case — every firing pin red-proofed fail-open against the unmodified scripts (rc 0 "OK" → rc 2 with git's error line). Family suite green: conflict-markers 26, todo-ban 29, suppression-ban 56, install-git-hooks 205, pre-commit-chain 27, dispatcher 15, commit-msg 49, byte-ceiling 39, cleanup-scope 10, bash32. The issue's exact repro now exits 2 naming the unreadable blob.

Implementation by a delegated dev agent; reviewed and shepherded by the steward session.

https://claude.ai/code/session_01SgCfsq4oKxc45iq25VcPhG