### PR TITLE
fix(preflight): vendored mirrors are exempt from every authoring lane, not just the citation one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,25 @@
   past: silently reaching the next source installed from one the project never
   chose and failed with an error naming it.
 
+- preflight: installed-artifact subtrees are now out of scope for every lane
+  that judges how a file is AUTHORED, not just `docs-cited-paths`. The
+  `vendored_mirror` classification already knew those paths are upstream
+  bytes a `vstack refresh` rewrites wholesale, but only the citation lane
+  read it, so `mktemp-trap`, `fail-open`, `unwired-suite` and
+  `masked-returns` still judged them — and a consumer repo that TRACKS a
+  vendored skill had no way out: preflight reads no settings file, has no
+  exclusion list, no lane selector and no inline suppression, and editing
+  the vendored file is reverted by the next refresh. The live case was
+  `growth-guards/scripts/install-git-hooks`, whose four `mktemp` sites clean
+  up per branch with `rm -f` instead of `trap … EXIT`: a required check red
+  on an upstream authoring choice the consumer cannot change. Lanes that
+  judge what those bytes DO to the repo carrying them are unchanged and
+  still fire inside a mirror — `shell-syntax`, `shellcheck-errors`,
+  `data-syntax`, `workflow-run-syntax`, `hardcoded-temp-path`, `todo-links`,
+  `reviewer-attribution` — because a mirror is no reason a broken parse, a
+  malformed config, a leaked temp directory or an unreferenced work marker
+  becomes invisible. Both directions are pinned in `precision.test.sh`, per
+  guard. (#1498)
 - preflight: new `hardcoded-temp-path` lane — an added directory-creating
   call taking a literal `/tmp/…` or `/var/tmp/…` as (part of) its first
   argument fails. A literal absolute temp path escapes TMPDIR redirection

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,7 @@
   malformed config, a leaked temp directory or an unreferenced work marker
   becomes invisible. Both directions are pinned in `precision.test.sh`, per
   guard. (#1498)
+
 - preflight: new `hardcoded-temp-path` lane — an added directory-creating
   call taking a literal `/tmp/…` or `/var/tmp/…` as (part of) its first
   argument fails. A literal absolute temp path escapes TMPDIR redirection

--- a/skills/preflight/SKILL.md
+++ b/skills/preflight/SKILL.md
@@ -51,7 +51,21 @@ clean empty diff.
 Shell files are `*.sh`, `*.bash`, or anything with a `sh`/`bash` shebang.
 Deleted files, and files under `tests/` or `fixtures/`, are out of scope
 for the lanes that judge whole files — `unwired-suite`, whose subject is
-the suite itself, is the exception. A lane whose tool is missing skips
+the suite itself, is the exception.
+
+Installed-artifact subtrees (`.agents/` and the harness dirs'
+skills/agents/hooks/rules/instructions/packages trees) hold vendored
+tooling a refresh rewrites wholesale, so the lanes judging how a file is
+AUTHORED — `masked-returns`, `fail-open`, `unwired-suite`, `mktemp-trap`,
+`docs-cited-paths` — are out of scope there: the finding names an upstream
+authoring choice this repo cannot fix, and an edit is reverted by the next
+refresh. The lanes judging what those bytes DO to this repo stay on —
+`shell-syntax`, `shellcheck-errors`, `hardcoded-temp-path`, `todo-links`,
+`reviewer-attribution`, `data-syntax`, `workflow-run-syntax`. A file
+authored elsewhere under a harness dir (a `prompts/` or `commands/` tree)
+keeps every lane, and markdown inside a mirror needs no exemption of its
+own: a mirror-internal token is dot-leading and a foreign one fails the
+subtree guard. A lane whose tool is missing skips
 silently — an absent shellcheck never fails a run and never passes one.
 
 Exit codes: `0` clean, `1` findings, `2` usage/environment error (bad flag,

--- a/skills/preflight/scripts/preflight
+++ b/skills/preflight/scripts/preflight
@@ -780,11 +780,11 @@ while IFS= read -r f; do
   is_new=0
   if [ "$MODE" = "all" ] || grep -qxF -- "$f" "$TMP/newfiles.list"; then is_new=1; fi
   # Installed-artifact subtrees hold vendored tooling a refresh rewrites
-  # wholesale: their text is the upstream project's prose, not this repo's
-  # claims, so the code-citation lane leaves them alone. Authored files
-  # elsewhere under the harness dirs (a prompts/ or commands/ tree) keep the
-  # lane. Markdown inside a mirror needs no gate — a mirror-internal token
-  # is dot-leading and a foreign one fails the subtree guard.
+  # wholesale: the prose is upstream's claims and the code its authoring
+  # choices, so the citation lane and the lanes judging how a file is
+  # written skip them — what those bytes DO here still fails. Authored
+  # files elsewhere under the harness dirs keep every lane; a mirror's
+  # markdown needs no gate (its own tokens are dot-leading).
   vendored_mirror=0
   case "$f" in
     .agents/* | .claude/skills/* | .claude/agents/* | .claude/hooks/* | \
@@ -848,7 +848,7 @@ while IFS= read -r f; do
         parse_gcc "$raw" "$cpath"
         if [ "$GCC_SEV" = "error" ]; then
           emit "$f" "$GCC_LINE" shellcheck-errors "$GCC_MSG"
-        elif [ "$GCC_LINE" != 0 ] && is_masked_code "$GCC_CODE"; then
+        elif [ "$GCC_LINE" != 0 ] && [ "$vendored_mirror" = 0 ] && is_masked_code "$GCC_CODE"; then
           if [ "$MODE" = "all" ] || grep -qxF -- "$GCC_LINE" "$(added_lines_of "$IDX")"; then
             emit "$f" "$GCC_LINE" masked-returns "$GCC_MSG"
           fi
@@ -859,14 +859,14 @@ while IFS= read -r f; do
     # A brand-new script that never turns on errexit, nounset and pipefail
     # fails open at its first unchecked command. Test trees and fixtures set
     # their own rules.
-    if [ "$own_rules" = 0 ] && [ "$is_new" = 1 ]; then
+    if [ "$own_rules" = 0 ] && [ "$vendored_mirror" = 0 ] && [ "$is_new" = 1 ]; then
       if [ "$has_ee" = 0 ] || ! file_matches "$cpath" "$NOUNSET_RE" || ! file_matches "$cpath" "$PIPEFAIL_RE"; then
         emit "$f" 0 fail-open "new shell file without strict mode (set -euo pipefail)"
       fi
     fi
   fi
 
-  if [ "$is_new" = 1 ] && is_suite_path "$f" && ! suite_is_wired "$f"; then
+  if [ "$is_new" = 1 ] && [ "$vendored_mirror" = 0 ] && is_suite_path "$f" && ! suite_is_wired "$f"; then
     emit "$f" 0 unwired-suite "new suite is not invoked by any runner"
   fi
 
@@ -907,13 +907,13 @@ while IFS= read -r f; do
     n="${rec%%"$TAB"*}"
     content="${rec#*"$TAB"}"
 
-    if [ "$is_sh" = 1 ] && [ "$has_ee" = 0 ] && printf '%s' "$content" | grep -Eq -- "$MKTEMP_ASSIGN"; then
+    if [ "$is_sh" = 1 ] && [ "$vendored_mirror" = 0 ] && [ "$has_ee" = 0 ] && printf '%s' "$content" | grep -Eq -- "$MKTEMP_ASSIGN"; then
       emit "$f" "$n" fail-open "unchecked mktemp in a file without errexit — a failed mktemp leaves the variable empty and the script runs on"
     fi
 
     # The literal prefilters keep the regex passes off the lines that cannot
     # carry either shape — most of them.
-    if [ "$is_sh" = 1 ] && [ "$own_rules" = 0 ] && [ "$is_new" = 1 ] && [ "$has_trap" = 0 ] && [ "$mktemp_reported" = 0 ]; then
+    if [ "$is_sh" = 1 ] && [ "$own_rules" = 0 ] && [ "$vendored_mirror" = 0 ] && [ "$is_new" = 1 ] && [ "$has_trap" = 0 ] && [ "$mktemp_reported" = 0 ]; then
       case "$content" in
         *mktemp*)
           if ! is_comment_line "$content" && printf '%s' "$content" | grep -Eq -- "$MKTEMP_CALL_RE"; then
@@ -944,7 +944,7 @@ while IFS= read -r f; do
       esac
     fi
 
-    if [ "$is_sh" = 1 ] && [ "$own_rules" = 0 ] && [ "$is_testname" = 0 ]; then
+    if [ "$is_sh" = 1 ] && [ "$own_rules" = 0 ] && [ "$vendored_mirror" = 0 ] && [ "$is_testname" = 0 ]; then
       case "$content" in
         *"||"*)
           if ! is_comment_line "$content"; then

--- a/skills/preflight/tests/precision.test.sh
+++ b/skills/preflight/tests/precision.test.sh
@@ -23,6 +23,7 @@ bad() {
   FAIL=$((FAIL + 1))
   printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"
 }
+skipped() { printf '  skip  %s (%s)\n' "$1" "$2"; }
 
 seed() { # NAME — fixture in $R: committed baseline, origin/main, feature branch
   R="$TMP/$1"
@@ -332,6 +333,65 @@ mkdir -p "$R/.pi/prompts"
 printf '#!/usr/bin/env bash\nset -euo pipefail\n# See docs/gone.md for background.\necho prompt\n' >"$R/.pi/prompts/release.sh"
 run_pf
 fires "an authored file under a harness dir keeps the lane" ".pi/prompts/release.sh:3: [docs-cited-paths] cites a path that does not exist: docs/gone.md"
+
+echo "=== a mirror's authoring choices are the upstream project's, not this repo's ==="
+seed mirrorlanes
+mkdir -p "$R/.github/workflows"
+printf 'name: ci\non: push\njobs:\n  t:\n    runs-on: ubuntu-latest\n    steps:\n      - run: bash tests/other.test.sh\n' >"$R/.github/workflows/ci.yml"
+git -C "$R" add -A
+git -C "$R" commit -qm "a runner set complete enough to prove a suite unwired"
+mkdir -p "$R/.agents/skills/foo/scripts" "$R/.agents/skills/foo/tests"
+# Every authoring-lane shape at once, in bytes the next refresh rewrites: no
+# strict mode, an unchecked and untrapped mktemp, a masking local-and-assign,
+# a swallowed grep status, and a suite this repo's runners never name.
+cat >"$R/.agents/skills/foo/scripts/run" <<'EOF'
+#!/usr/bin/env bash
+D="$(mktemp -d)"
+f() {
+  local d="$(mktemp -d)"
+  echo "$d"
+}
+grep -q x -- "$D" || true
+f
+EOF
+printf '#!/usr/bin/env bash\nset -euo pipefail\necho vendored\n' >"$R/.agents/skills/foo/tests/foo.test.sh"
+run_pf
+clean "a vendored skill's strict mode, scratch cleanup, masked returns and suite wiring are upstream's to fix"
+
+echo "=== control: the same bytes this repo authors itself still fail ==="
+cp "$R/.agents/skills/foo/scripts/run" "$R/scripts/run.sh"
+cp "$R/.agents/skills/foo/tests/foo.test.sh" "$R/tests/foo.test.sh"
+run_pf
+fires "an authored script without strict mode still fails" "scripts/run.sh:0: [fail-open] new shell file without strict mode"
+fires "an authored unchecked mktemp still fails" "scripts/run.sh:2: [fail-open] unchecked mktemp"
+fires "an authored untrapped mktemp still fails" "scripts/run.sh:2: [mktemp-trap]"
+fires "an authored swallowed status still fails" "scripts/run.sh:7: [fail-open] grep || true swallows exit 2"
+fires "an authored unwired suite still fails" "tests/foo.test.sh:0: [unwired-suite]"
+if command -v shellcheck >/dev/null 2>&1; then
+  fires "an authored masking local-and-assign still fails" "scripts/run.sh:4: [masked-returns] SC2155"
+else
+  skipped "an authored masking local-and-assign still fails" "shellcheck not on PATH"
+fi
+
+echo "=== what vendored bytes DO to this repo is still this repo's problem ==="
+seed mirrorkeep
+mkdir -p "$R/.agents/skills/foo/scripts"
+printf '#!/usr/bin/env bash\nif [ 1 -eq 1 ]\necho broken\n' >"$R/.agents/skills/foo/scripts/broken"
+printf '#!/usr/bin/env bash\nset -euo pipefail\nexit 300\n' >"$R/.agents/skills/foo/scripts/exitcode"
+printf 'import os\nos.makedirs("%s/vendored-leak")\n' /tmp >"$R/.agents/skills/foo/scripts/leak.py"
+printf '{\n  "a":\n}\n' >"$R/.agents/skills/foo/data.json"
+printf '# Notes\n\nTODO: no issue behind it.\n\nHardened per qodo review.\n' >"$R/.agents/skills/foo/NOTES.md"
+run_pf
+fires "a vendored script bash cannot parse still fails" ".agents/skills/foo/scripts/broken:4: [shell-syntax]"
+fires "a vendored creation at a literal temp path still fails" ".agents/skills/foo/scripts/leak.py:2: [hardcoded-temp-path]"
+fires "vendored malformed JSON still fails" ".agents/skills/foo/data.json:3: [data-syntax]"
+fires "a vendored work marker still fails" ".agents/skills/foo/NOTES.md:3: [todo-links]"
+fires "a vendored reviewer credit still fails" ".agents/skills/foo/NOTES.md:5: [reviewer-attribution]"
+if command -v shellcheck >/dev/null 2>&1; then
+  fires "a vendored shellcheck error still fails" ".agents/skills/foo/scripts/exitcode:3: [shellcheck-errors] SC2242"
+else
+  skipped "a vendored shellcheck error still fails" "shellcheck not on PATH"
+fi
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/skills/preflight/tests/precision.test.sh
+++ b/skills/preflight/tests/precision.test.sh
@@ -15,6 +15,7 @@ trap 'rm -rf "$TMP"' EXIT
 
 PASS=0
 FAIL=0
+SKIP=0
 ok() {
   PASS=$((PASS + 1))
   printf '  ok    %s\n' "$1"
@@ -23,7 +24,10 @@ bad() {
   FAIL=$((FAIL + 1))
   printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"
 }
-skipped() { printf '  skip  %s (%s)\n' "$1" "$2"; }
+skipped() {
+  SKIP=$((SKIP + 1))
+  printf '  skip  %s (%s)\n' "$1" "$2"
+}
 
 seed() { # NAME — fixture in $R: committed baseline, origin/main, feature branch
   R="$TMP/$1"
@@ -393,5 +397,5 @@ else
   skipped "a vendored shellcheck error still fails" "shellcheck not on PATH"
 fi
 
-printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+printf '\n%s passed, %s failed, %s skipped\n' "$PASS" "$FAIL" "$SKIP"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## The false positive

`preflight` already classifies installed-artifact subtrees — `.agents/*`, `.claude/skills|agents|hooks/*`, `.cursor/rules/*`, `.opencode/*`, `.codex/*`, `.pi/*` — as `vendored_mirror`: upstream bytes a `vstack refresh` rewrites wholesale. Only ONE lane read that classification (`docs-cited-paths`). Every other whole-file and line lane still judged vendored bytes.

Live blocker: a consumer repo tracking the vendored `growth-guards` skill gets

```
.agents/skills/growth-guards/scripts/install-git-hooks:161: [mktemp-trap] mktemp without an EXIT trap
```

on a required check. It is a false positive — the installer cleans up per branch (`rm -f -- "$tmp"` on every early return, all four `mktemp` sites) instead of `trap … EXIT`, which the heuristic cannot see. And it is unsuppressable: preflight reads no settings file, has no exclusion list, no lane selector, no inline suppression, and `own_rules` covers only `*/tests/*` and `*/fixtures/*`. Editing the vendored file is reverted by the next refresh.

## The class fix

The guard the classification already computes is now read by the lanes that judge **how a file is authored**. One-line guards at six emit sites; no new classification, no new configuration surface.

### Exempted in a mirror — the lane judges upstream's authoring choices

| Lane | Why |
|---|---|
| `mktemp-trap` | Whether scratch is removed by a trap or per-branch `rm -f` is upstream's style call; the consumer cannot change it. |
| `fail-open` (all three shapes: new-file strict mode, unchecked `mktemp`, `… \|\| true`) | Same class — how upstream writes its bash. Named in the issue. |
| `unwired-suite` | A vendored suite is wired by the UPSTREAM project's runner; this repo's runner set can never prove it wired, so the lane is structurally undecidable here — exactly the "a lane that cannot decide says nothing" rule in preflight's own header. |
| `masked-returns` | SC2155/SC2311 on an added line is an authoring-style judgment of the same family as `fail-open`; consistency argues it moves with it. |
| `docs-cited-paths` | Already exempt (unchanged). |

### Deliberately left ON in a mirror — the finding is about what those bytes DO to the repo carrying them

| Lane | Why |
|---|---|
| `shell-syntax` | A script the shell cannot parse fails at runtime *here*, whoever wrote it. |
| `shellcheck-errors` | Error severity is breakage, not style. |
| `data-syntax` (JSON/TOML) | A malformed config in the tree is a malformed config. |
| `workflow-run-syntax` | A vendored workflow runs in THIS repo's CI. |
| `hardcoded-temp-path` | The leak happens on the machine running the vendored tool — the defect is the runtime effect, not the authoring. |
| `todo-links` | Boundary case, kept on deliberately: a work marker is a fact about what this repo now ships, and `growth-guards`' `todo-ban` already offers a reasoned exclusion list for vendored trees, so silencing preflight here would only split the verdict between two gates on the same bytes. |
| `reviewer-attribution` | Bot attribution is provenance pollution in the tree regardless of authorship. |

## Verification

`skills/preflight/tests/precision.test.sh` gains three sections; the existing mirror section is untouched.

- **Exempt direction.** One mirror fixture carries every exempt shape at once — no strict mode, an unchecked and untrapped `mktemp`, a masking `local`-and-assign, a swallowed `grep` status, and a new suite in a repo whose runner set is complete enough to prove a suite unwired — and the whole run is clean.
- **Control.** The identical bytes copied to `scripts/run.sh` and `tests/foo.test.sh` still fail each of the five lanes, at named lines.
- **Still-on direction.** A second mirror fixture plants an unparseable script, an SC2242 shellcheck error, a `/tmp` creation, malformed JSON, an unreferenced TODO and a reviewer credit — all six still fire, inside `.agents/skills/foo/`.

### Mutation evidence

| Mutation | Result |
|---|---|
| Fix fully reverted (`git show main:` script) | 40 passed, **1 failed** — the clean assertion reds, naming all five lanes |
| Each of the six guards removed individually (6 runs) | 40 passed, **1 failed** each — every guard is separately pinned |
| Over-broad direction: the exemption also applied to `todo-links`, `reviewer-attribution` and `hardcoded-temp-path` | 38 passed, **3 failed** — the still-on assertions red |
| Fix in place | **41 passed, 0 failed** |

### Suite results (this branch)

| Suite | Result |
|---|---|
| `precision.test.sh` | 41 passed, 0 failed (was 28) |
| `lanes-must-fail.test.sh` | 45 passed, 0 failed |
| `modes.test.sh` | 21 passed, 0 failed |
| `bash32-portability.test.sh` | pass |
| `tools/validate-changed` | all 5 lanes passed |

### End-to-end on the reporting repo

The consumer worktree with `growth-guards` staged (32 changed files):

```
before: .agents/skills/growth-guards/scripts/install-git-hooks:161: [mktemp-trap] …
        preflight: 1 finding(s) across 32 changed file(s)
after:  preflight: clean (32 changed file(s))
```

No finding disappeared other than the false positive, and none appeared.

The fix is already vendored and green in that consumer: it now tracks these exact bytes as its installed preflight, its CI-shape preflight run is clean across 35 changed files, and all four vendored preflight suites pass there (lanes-must-fail 45, modes 21, precision 41, bash32).

`skills/preflight/scripts/preflight` stays at exactly 1009 lines — this repo's frozen `size-ratchet` baseline row for it, unchanged.

Refs vanillagreencom/kendex#1498
