### PR TITLE
fix(growth-guards): index reads fail closed and policy writes land whole

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,8 +104,12 @@
   --update` replaced the baseline with a `mv` from `$TMPDIR`, which degrades to
   copy-then-unlink across filesystems, leaving a truncated RATCHET file that
   silently loosens the gate rather than failing it. Both now write to a temp
-  file beside the destination and rename: the destination carries the complete
-  new bytes or the complete old ones, never a prefix of either.
+  file beside the destination and rename. The staging file is created by
+  `mktemp`, never at a name derived from the pid: it lands in a directory the
+  repository controls, `cp` writes THROUGH a symlink, and a planted
+  `.gg-install.<pid>.<name>` link would therefore redirect the write to any
+  path the user can reach. Either way the destination carries the complete new
+  bytes or the complete old ones, never a prefix of either.
   `suppression-ban` goes through a shared `gg_install_file` helper; the
   settings cache renames inline, because it answers a failure by returning 1
   for its caller to propagate rather than by the family's exit 2, and routing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,10 @@
   over the paths it is about to read and, finding any, exits 2 naming them and
   the only remedy there is: finish or abort the merge. The guard is scoped to
   the lane's own pathspec, so an unmerged path a lane does not scan leaves
-  that scan complete. Same failure class as #1492 — a measurement that could
+  that scan complete. `byte-ceiling`'s index modes refuse too, for a
+  different mechanism with the same shape: an add/add conflict is classified
+  `U`, `--diff-filter=A` drops that record, and the run reported
+  `OK — 0 staged addition(s) checked` — a file of any size past the ceiling. Same failure class as #1492 — a measurement that could
   not be taken must never report as a clean measurement.
 
 - growth-guards: policy reads fail closed on a probe git could not answer, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,48 @@
   dropped key, two drifted unquoted defaults, a stripped SECURITY caveat and
   an absent skill template each fail. Against the previous suite the absent-root
   and unquoted-drift fixtures both exited 0.
+- growth-guards: a `git grep --cached` scan now refuses an UNMERGED index
+  instead of reporting it clean (#1510). `git grep --cached` skips unmerged
+  index entries entirely — no error status, no `error:` line on stderr — so
+  `gg_grep_guard` saw a complete scan and `conflict-markers` printed
+  `OK — no conflict markers in tracked files`, exit 0, over a work tree whose
+  files carried the marker trio. That is the exact state the check exists for,
+  and the state a developer or agent is in when they run a validation command
+  mid-resolution. Every `--cached` scan now asks `git ls-files --unmerged`
+  over the paths it is about to read and, finding any, exits 2 naming them and
+  the only remedy there is: finish or abort the merge. The guard is scoped to
+  the lane's own pathspec, so an unmerged path a lane does not scan leaves
+  that scan complete. Same failure class as #1492 — a measurement that could
+  not be taken must never report as a clean measurement.
+
+- growth-guards: policy reads fail closed on a probe git could not answer, and
+  a configured policy path is matched literally (#1508). `gg_policy_content`
+  discarded the exit status of both its probes, so exit 1 ("no such path") and
+  exit 128 (unreadable index, corrupt object, not a repository) were
+  indistinguishable and both fell through — judging a commit against the
+  unstaged worktree copy of a policy file, or against no file at all, while
+  saying nothing. It now mirrors the classification `gg_settings_source`
+  already applies: exit 1 is the answer, anything else is `gg_collection_error`,
+  and HEAD is probed with `git ls-tree` rather than `cat-file -e`, which cannot
+  tell an absent path from a broken repository. Both probes now pass
+  `:(literal)`, so a policy path spelling a glob matches itself instead of
+  whatever the glob reaches — before, a configured `tools/ex?.tsv` resolved
+  `git show ":tools/ex?.tsv"` as a REVISION and loaded a commit diff as the
+  exclusion list. `suppression-ban`'s baseline read carried the same two
+  defects and gets the same treatment; a ratchet that cannot read its own
+  baseline must not fall through to a looser one.
+
+- growth-guards: policy writes land by same-directory rename (#1502). The
+  settings cache was materialized by redirecting straight onto its final path,
+  so an interrupt left a TRUNCATED cache that the next run read as the
+  complete staged copy — and a key resolving to an empty value means the check
+  it names runs nowhere while the chain still reports OK. `suppression-ban
+  --update` replaced the baseline with a `mv` from `$TMPDIR`, which degrades to
+  copy-then-unlink across filesystems, leaving a truncated RATCHET file that
+  silently loosens the gate rather than failing it. Both now write to a temp
+  file beside the destination and rename, through one shared `gg_install_file`
+  helper: the destination carries the complete new bytes or the complete old
+  ones, never a prefix of either.
 
 - CLI: a lock `source` recorded as a path inside `~/.vstack/cache/` now
   resolves as the remote that cache entry clones, instead of as an ordinary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,7 +86,12 @@
   `git show ":tools/ex?.tsv"` as a REVISION and loaded a commit diff as the
   exclusion list. `suppression-ban`'s baseline read carried the same two
   defects and gets the same treatment; a ratchet that cannot read its own
-  baseline must not fall through to a looser one.
+  baseline must not fall through to a looser one. `gg_load_excludes` now
+  propagates the failure too: it reads the policy through a command
+  substitution, where a `gg_collection_error` dies in the subshell and
+  arrives as a bare status, so an unreadable list was becoming an EMPTY list
+  and the gate then returned a verdict — reporting as a violation the very
+  file the unread policy excluded.
 
 - growth-guards: policy writes land by same-directory rename (#1502). The
   settings cache was materialized by redirecting straight onto its final path,
@@ -96,9 +101,12 @@
   --update` replaced the baseline with a `mv` from `$TMPDIR`, which degrades to
   copy-then-unlink across filesystems, leaving a truncated RATCHET file that
   silently loosens the gate rather than failing it. Both now write to a temp
-  file beside the destination and rename, through one shared `gg_install_file`
-  helper: the destination carries the complete new bytes or the complete old
-  ones, never a prefix of either.
+  file beside the destination and rename: the destination carries the complete
+  new bytes or the complete old ones, never a prefix of either.
+  `suppression-ban` goes through a shared `gg_install_file` helper; the
+  settings cache renames inline, because it answers a failure by returning 1
+  for its caller to propagate rather than by the family's exit 2, and routing
+  it through the helper would change that contract.
 
 - CLI: a lock `source` recorded as a path inside `~/.vstack/cache/` now
   resolves as the remote that cache entry clones, instead of as an ordinary

--- a/skills/growth-guards/SKILL.md
+++ b/skills/growth-guards/SKILL.md
@@ -46,7 +46,9 @@ batch dispatcher exits 2 if any check could not complete.
 
 Scans read INDEX content (`git grep --cached`, staged blobs): what is
 staged is what gets committed, and a sparse checkout cannot hide a tracked
-file from a gate.
+file from a gate. An UNMERGED index cannot be scanned that way — git skips
+unmerged entries and spends no error status doing it — so a scan whose paths
+include one exits 2 naming them: finish or abort the merge, then re-run.
 
 ## Git hooks
 

--- a/skills/growth-guards/scripts/byte-ceiling
+++ b/skills/growth-guards/scripts/byte-ceiling
@@ -105,6 +105,11 @@ emit_candidate() { # SHA PATH
 
 case "$MODE" in
   staged)
+    # An add/add conflict is classified U, which --diff-filter=A drops: the
+    # addition disappears from the record set and the run reports "0 staged
+    # addition(s) checked", so a file of any size passes the ceiling. The
+    # index modes refuse an unresolved merge rather than measure around it.
+    gg_require_merged_index
     git -c diff.renames=true diff --cached --raw --no-abbrev -z --diff-filter=A >"$GG_TMP/raw.z" || gg_collection_error "git diff --cached failed collecting staged additions"
     ;;
   base)
@@ -112,6 +117,9 @@ case "$MODE" in
     git -c diff.renames=true diff --raw --no-abbrev -z --diff-filter=A "$BASE_REF...HEAD" >"$GG_TMP/raw.z" || gg_collection_error "git diff $BASE_REF...HEAD failed collecting added files (no merge base?)"
     ;;
   all)
+    # ls-files -s emits one record per STAGE for an unmerged path, so the
+    # walk below would size two or three rival blobs as separate files.
+    gg_require_merged_index
     git ls-files -sz >"$GG_TMP/files.z" || gg_collection_error "git ls-files failed"
     while IFS= read -r -d '' rec; do
       # Record shape: "<mode> <sha> <stage>\t<path>".

--- a/skills/growth-guards/scripts/lib/common.sh
+++ b/skills/growth-guards/scripts/lib/common.sh
@@ -137,20 +137,63 @@ GG_EXCLUDE_PATTERNS=()
 # tracked file from disk still applies it. A path staged for DELETION governs
 # as ABSENT — the commit carries no such file — which is not the same as a
 # never-tracked path, where the worktree copy is all there is.
+#
+# Each probe reserves one status for its one expected answer and routes every
+# other status through gg_collection_error. A probe git could not answer must
+# not fall through to the worktree copy: that judges the commit against looser
+# policy than the index carries, and says nothing while doing it.
 gg_policy_content() { # FILE — content on stdout; 1 = the commit has no such file
-  local file="$1"
-  if git ls-files --error-unmatch -- "$file" >/dev/null 2>&1; then
-    git show ":$file" || gg_collection_error "could not read the staged copy of $file"
-    return 0
-  fi
-  if git cat-file -e "HEAD:$file" 2>/dev/null; then
-    return 1
-  fi
+  local file="$1" status=0 head_status=0 tree_status=0 entry=""
+  # :(literal) — a path spelling a glob (`*`, `?`, `[`) must match itself in
+  # the index, never whatever the glob happens to reach.
+  git ls-files --error-unmatch -- ":(literal)$file" >/dev/null 2>&1 || status=$?
+  case "$status" in
+    0)
+      git show ":$file" || gg_collection_error "could not read the staged copy of $file"
+      return 0
+      ;;
+    1) ;;
+    *) gg_collection_error "could not query the index for $file (git ls-files exit $status); refusing to treat it as untracked" ;;
+  esac
+  # ls-tree, never `cat-file -e`: with rev:path syntax git answers "no such
+  # path in HEAD" with the same 128 an operational failure returns, so only
+  # ls-tree (exit 0, empty output for an absent path) tells the two apart.
+  # An unborn HEAD carries nothing by definition — rev-parse reserves exit 1.
+  git rev-parse --verify --quiet HEAD >/dev/null 2>&1 || head_status=$?
+  case "$head_status" in
+    0)
+      entry="$(git ls-tree HEAD -- ":(literal)$file" 2>/dev/null)" || tree_status=$?
+      [ "$tree_status" -eq 0 ] \
+        || gg_collection_error "could not probe HEAD for $file (git ls-tree exit $tree_status); refusing to treat it as untracked"
+      # Tracked in HEAD, absent from the index: staged for deletion.
+      if [ -n "$entry" ]; then return 1; fi
+      ;;
+    1) ;;
+    *) gg_collection_error "could not resolve HEAD while reading $file (git rev-parse exit $head_status); refusing to treat it as untracked" ;;
+  esac
   if [ -f "$file" ]; then
     cat -- "$file" || gg_collection_error "could not read $file"
     return 0
   fi
   return 1
+}
+
+# Replace DEST with SRC's bytes through a rename inside DEST's own directory.
+# A direct redirect onto DEST, or a rename that crosses a filesystem (where mv
+# degrades to copy-then-unlink), leaves DEST TRUNCATED behind an interrupt —
+# and a truncated policy file is read as a complete one, which for a ratchet
+# baseline loosens the gate instead of failing it.
+gg_install_file() { # SRC DEST LABEL
+  local src="$1" dest="$2" label="$3" tmp
+  tmp="$(dirname -- "$dest")/.gg-install.$$.$(basename -- "$dest")"
+  if ! cp -- "$src" "$tmp"; then
+    rm -f -- "$tmp"
+    gg_collection_error "could not stage the replacement for $label beside $dest"
+  fi
+  if ! mv -- "$tmp" "$dest"; then
+    rm -f -- "$tmp"
+    gg_collection_error "could not replace $label at $dest — inspect the file before trusting it"
+  fi
 }
 
 # Shell glob matched against the full repo-relative path (`*` crosses `/`);
@@ -192,6 +235,24 @@ gg_is_excluded() { # PATH — 0 when some exclusion glob matches the full path
   return 1
 }
 
+# `git grep --cached` SKIPS an unmerged index entry entirely: it spends no
+# error status and writes no `error:` line doing it, so gg_grep_guard sees a
+# complete scan and the lane reports OK over a work tree whose files carry
+# conflict markers. The index cannot be scanned while a merge is unresolved,
+# so every --cached scan refuses first. The remedy is the only one there is:
+# finish or abort the merge.
+gg_require_merged_index() { # PATHSPEC... — returns only when nothing is unmerged
+  local rows status=0 paths count=0
+  rows="$(git ls-files --unmerged -- "$@")" || status=$?
+  [ "$status" -eq 0 ] \
+    || gg_collection_error "could not read the index for unmerged paths (git ls-files exit $status)"
+  [ -n "$rows" ] || return 0
+  paths="$(printf '%s\n' "$rows" | cut -f2- | LC_ALL=C sort -u)"
+  count="$(printf '%s\n' "$paths" | grep -c .)" || count=0
+  printf '%s\n' "$paths" >&2
+  gg_collection_error "the index carries $count unmerged path(s) (listed above) and a --cached scan skips them silently — finish or abort the merge, then re-run"
+}
+
 # Judge one `git grep` run from its exit status AND captured stderr. The
 # status carries only the MATCH result: a staged blob git cannot read is an
 # `error:` line on stderr while the status still says 1 (nothing matched) or
@@ -217,6 +278,7 @@ gg_grep_guard() { # STATUS ERRFILE CONTEXT — returns only when the scan is com
 gg_grep_lane() { # LABEL ERE REMEDY PATHSPEC... — numbered violations on stdout
   local label="$1" ere="$2" remedy="$3" status=0 f hit_status hit
   shift 3
+  gg_require_merged_index "$@"
   LC_ALL=C git grep --cached -lIzE "$ere" -- "$@" >"$GG_TMP/lane.z" 2>"$GG_TMP/lane.err" || status=$?
   gg_grep_guard "$status" "$GG_TMP/lane.err" "scanning tracked files for $label"
   while IFS= read -r -d '' f; do

--- a/skills/growth-guards/scripts/lib/common.sh
+++ b/skills/growth-guards/scripts/lib/common.sh
@@ -20,6 +20,9 @@ GG_VIOLATIONS=0
 # exported settings cache their parent is still reading.
 GG_TMP=""
 GG_SETTINGS_INDEX_OWNED=0
+# In-flight staging file for gg_install_file, so an interrupt between its
+# creation and its rename leaves nothing beside the destination.
+GG_INSTALL_TMP=""
 
 gg_config_error() {
   echo "::error::${GG_CHECK:-growth-guards}: $*" >&2
@@ -34,6 +37,7 @@ gg_collection_error() { gg_config_error "$@"; }
 # checks a hook lane runs, and they must not delete the directory their parent
 # is still resolving settings from.
 gg_cleanup() {
+  [ -z "${GG_INSTALL_TMP:-}" ] || rm -f -- "$GG_INSTALL_TMP"
   [ -z "${GG_TMP:-}" ] || rm -rf -- "$GG_TMP"
   [ "${GG_SETTINGS_INDEX_OWNED:-0}" = "1" ] && rm -rf -- "$GG_SETTINGS_INDEX_DIR"
   return 0
@@ -184,16 +188,25 @@ gg_policy_content() { # FILE — content on stdout; 1 = the commit has no such f
 # and a truncated policy file is read as a complete one, which for a ratchet
 # baseline loosens the gate instead of failing it.
 gg_install_file() { # SRC DEST LABEL
-  local src="$1" dest="$2" label="$3" tmp
-  tmp="$(dirname -- "$dest")/.gg-install.$$.$(basename -- "$dest")"
-  if ! cp -- "$src" "$tmp"; then
-    rm -f -- "$tmp"
+  local src="$1" dest="$2" label="$3"
+  # mktemp, never a name derived from the pid: the staging file lands in a
+  # directory the repository controls, a predictable name can already be
+  # sitting there, and `cp` writes THROUGH a symlink — so a planted
+  # `.gg-install.<pid>.<name>` link would redirect the write anywhere the
+  # user can reach. mktemp creates the file itself, exclusively.
+  GG_INSTALL_TMP="$(mktemp "$dest.gg-install.XXXXXX")" \
+    || gg_collection_error "could not stage the replacement for $label beside $dest"
+  if ! cat -- "$src" >"$GG_INSTALL_TMP"; then
+    rm -f -- "$GG_INSTALL_TMP"
+    GG_INSTALL_TMP=""
     gg_collection_error "could not stage the replacement for $label beside $dest"
   fi
-  if ! mv -- "$tmp" "$dest"; then
-    rm -f -- "$tmp"
+  if ! mv -- "$GG_INSTALL_TMP" "$dest"; then
+    rm -f -- "$GG_INSTALL_TMP"
+    GG_INSTALL_TMP=""
     gg_collection_error "could not replace $label at $dest — inspect the file before trusting it"
   fi
+  GG_INSTALL_TMP=""
 }
 
 # Shell glob matched against the full repo-relative path (`*` crosses `/`);

--- a/skills/growth-guards/scripts/lib/common.sh
+++ b/skills/growth-guards/scripts/lib/common.sh
@@ -202,10 +202,17 @@ gg_install_file() { # SRC DEST LABEL
 gg_load_excludes() { # FILE — fills GG_EXCLUDE_PATTERNS
   local file="$1" line lineno pat reason content status=0
   GG_EXCLUDE_PATTERNS=()
+  # The read runs in a command substitution, so a gg_collection_error inside
+  # it dies in that SUBSHELL and arrives here as a status. Only status 1 is
+  # the answer "the commit has no such file" (an empty list); anything else
+  # is the failed measurement that already named itself on stderr, and
+  # reading it as an empty list would let the gate run on no policy at all.
   content="$(gg_policy_content "$file")" || status=$?
-  if [ "$status" -ne 0 ]; then
-    return 0
-  fi
+  case "$status" in
+    0) ;;
+    1) return 0 ;;
+    *) gg_collection_error "refusing to run on an unread exclusion list: $file (exit $status, cause above)" ;;
+  esac
   lineno=0
   while IFS= read -r line || [ -n "$line" ]; do
     lineno=$((lineno + 1))

--- a/skills/growth-guards/scripts/lib/settings.sh
+++ b/skills/growth-guards/scripts/lib/settings.sh
@@ -130,7 +130,7 @@ gg_settings_normalize_path() { # PATH — normalized path on stdout ("" when it 
 # and parsing that would resolve every key to its built-in default.
 # GG_SETTINGS_INDEX_DIR holds the materialized copies; the caller owns it.
 gg_settings_source() { # FILE — the path to actually read; nonzero + ::error on failure
-  local file="$1" copy="" status=0 entry="" norm="" head_status=0 tree_status=0
+  local file="$1" copy="" status=0 entry="" norm="" head_status=0 tree_status=0 tmp=""
   if [ "${GG_SETTINGS_FROM_INDEX:-0}" != "1" ] || [ -z "${GG_SETTINGS_INDEX_DIR:-}" ]; then
     printf '%s' "$file"
     return 0
@@ -230,9 +230,20 @@ gg_settings_source() { # FILE — the path to actually read; nonzero + ::error o
   # mapping is reversible and collision-free.
   copy="$GG_SETTINGS_INDEX_DIR/settings.$(printf '%s' "$file" | sed -e 's/%/%25/g' -e 's|/|%2F|g' -e 's/[.]/%2E/g')"
   if [ ! -f "$copy" ]; then
-    if ! git show ":$file" >"$copy" 2>/dev/null; then
-      rm -f -- "$copy"
+    # Write-then-rename inside the cache directory. A direct redirect onto
+    # $copy leaves a TRUNCATED cache behind an interrupt, and the next run
+    # reads it as the complete staged copy — resolving keys to wrong or empty
+    # values, which for a key naming a check to run means the check runs
+    # nowhere while the chain still reports OK.
+    tmp="$copy.$$.part"
+    if ! git show ":$file" >"$tmp" 2>/dev/null; then
+      rm -f -- "$tmp"
       echo "::error::$file: could not read the staged copy while resolving a setting" >&2
+      return 1
+    fi
+    if ! mv -- "$tmp" "$copy"; then
+      rm -f -- "$tmp"
+      echo "::error::$file: could not materialize the staged copy while resolving a setting" >&2
       return 1
     fi
   fi

--- a/skills/growth-guards/scripts/suppression-ban
+++ b/skills/growth-guards/scripts/suppression-ban
@@ -142,6 +142,7 @@ while IFS= read -r -d '' f; do
 done <"$GG_TMP/rs.z"
 
 status=0
+gg_require_merged_index '*.rs'
 LC_ALL=C git grep --cached -cIE "$BARE_ERE" -- '*.rs' >"$GG_TMP/bare.raw" 2>"$GG_TMP/bare.err" || status=$?
 gg_grep_guard "$status" "$GG_TMP/bare.err" "counting bare allows"
 
@@ -183,16 +184,45 @@ validate_baseline() { # FILE LABEL
 # copy too: an unstaged row bump must not authorize growth the commit does not
 # carry. Only a never-tracked baseline, and --update (which rewrites the
 # worktree copy), read from disk.
+# Both probes reserve one status for their one expected answer; anything else
+# is git failing to answer, and a ratchet that cannot read its own baseline
+# must not fall through to a looser source than the index carries.
+baseline_in_index() { # 0 = the index has it, 1 = it does not
+  local status=0
+  git ls-files --error-unmatch -- ":(literal)$BASELINE_FILE" >/dev/null 2>&1 || status=$?
+  case "$status" in
+    0) return 0 ;;
+    1) return 1 ;;
+    *) gg_collection_error "could not query the index for $BASELINE_FILE (git ls-files exit $status); refusing to treat it as untracked" ;;
+  esac
+}
+
+baseline_in_head() { # 0 = HEAD has it (so an index miss is a staged deletion)
+  local head_status=0 tree_status=0 entry=""
+  # ls-tree, never `cat-file -e`: with rev:path syntax git answers "no such
+  # path in HEAD" with the same 128 an operational failure returns.
+  git rev-parse --verify --quiet HEAD >/dev/null 2>&1 || head_status=$?
+  case "$head_status" in
+    0) ;;
+    1) return 1 ;;
+    *) gg_collection_error "could not resolve HEAD while reading $BASELINE_FILE (git rev-parse exit $head_status); refusing to treat it as untracked" ;;
+  esac
+  entry="$(git ls-tree HEAD -- ":(literal)$BASELINE_FILE" 2>/dev/null)" || tree_status=$?
+  [ "$tree_status" -eq 0 ] \
+    || gg_collection_error "could not probe HEAD for $BASELINE_FILE (git ls-tree exit $tree_status); refusing to treat it as untracked"
+  [ -n "$entry" ]
+}
+
 BASELINE_FROM_INDEX=0
 if [ "$MODE" = "update" ] && [ -f "$BASELINE_FILE" ]; then
   validate_baseline "$BASELINE_FILE" "$BASELINE_FILE"
   cp -- "$BASELINE_FILE" "$GG_TMP/baseline.tsv"
-elif git ls-files --error-unmatch -- "$BASELINE_FILE" >/dev/null 2>&1; then
+elif baseline_in_index; then
   # No worktree copy to rewrite — what --update needs to know.
   [ -f "$BASELINE_FILE" ] || BASELINE_FROM_INDEX=1
   git show ":$BASELINE_FILE" >"$GG_TMP/baseline.tsv" || gg_config_error "failed to read tracked baseline from the index: $BASELINE_FILE"
   validate_baseline "$GG_TMP/baseline.tsv" "$BASELINE_FILE (index copy)"
-elif git cat-file -e "HEAD:$BASELINE_FILE" 2>/dev/null; then
+elif baseline_in_head; then
   # Staged for deletion: the commit freezes nothing.
   : >"$GG_TMP/baseline.tsv"
 elif [ -f "$BASELINE_FILE" ]; then
@@ -253,7 +283,7 @@ if [ "$MODE" = "update" ]; then
     # The replace is the last step: a failure before it leaves the reviewed
     # baseline byte-identical.
     rows="$(gg_count_nonempty_lines "$GG_TMP/baseline.new")"
-    mv -- "$GG_TMP/baseline.new" "$BASELINE_FILE" || gg_collection_error "could not replace the baseline at $BASELINE_FILE (mv failed) — inspect the file before trusting it"
+    gg_install_file "$GG_TMP/baseline.new" "$BASELINE_FILE" "the baseline"
     cp -- "$BASELINE_FILE" "$GG_TMP/baseline.tsv" || gg_collection_error "could not re-read the replaced baseline at $BASELINE_FILE (cp failed) — the baseline WAS replaced; rerun suppression-ban to verify it"
     echo "suppression-ban --update: baseline tightened at $BASELINE_FILE ($rows row(s))"
   else

--- a/skills/growth-guards/tests/index-reads.test.sh
+++ b/skills/growth-guards/tests/index-reads.test.sh
@@ -1,0 +1,292 @@
+#!/usr/bin/env bash
+# Pins for lib/common.sh's index reads and policy writes: a probe git could
+# not answer never becomes an answer, a configured path is matched literally,
+# a --cached scan refuses an unmerged index, and a policy file is replaced by
+# a same-directory rename or not at all. Every clean assertion is paired with
+# a control that proves it can fail.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
+SCRIPTS="$SKILL_DIR/scripts"
+COMMON="$SCRIPTS/lib/common.sh"
+SETTINGS="$SCRIPTS/lib/settings.sh"
+
+# A scratch root this suite OWNS: an assertion over a namespace shared with
+# other processes cannot tell "the code under test leaked" from "someone
+# else's run moved".
+ROOT="$(mktemp -d "${TMPDIR:-/tmp}/gg-index-reads.XXXXXX")"
+trap 'rm -rf "$ROOT"' EXIT
+
+# The fixtures below are judged against THEIR OWN configuration: the caller's
+# core.hooksPath, init.templateDir or commit.gpgsign would otherwise run the
+# caller's hooks against generated repos, or block their commits outright.
+export HOME="$ROOT/home"
+export XDG_CONFIG_HOME="$ROOT/xdg"
+export GIT_CONFIG_NOSYSTEM=1
+mkdir -p "$HOME" "$XDG_CONFIG_HOME"
+
+unset GROWTH_GUARDS_SETTINGS_FILE GROWTH_GUARDS_CONFLICT_EXCLUDES 2>/dev/null || true
+
+TAB="$(printf '\t')"
+PASS=0
+FAIL=0
+ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
+
+new_repo() { # NAME — fresh fixture repo in $R, cwd unchanged
+  R="$ROOT/$1"
+  mkdir -p "$R"
+  git -C "$R" -c init.defaultBranch=main init -q
+  git -C "$R" config user.email test@example.com
+  git -C "$R" config user.name test
+}
+
+# Run a snippet with common.sh sourced, inside $R. OUT captures stdout+stderr,
+# RC the exit status — a collection error is exit 2 and must be observable.
+call() { # SNIPPET
+  OUT=""
+  RC=0
+  OUT="$(cd "$R" && GG_CHECK=probe bash -c '
+    set -euo pipefail
+    . "$1"
+    shift
+    eval "$1"
+  ' _ "$COMMON" "$1" 2>&1)" || RC=$?
+}
+
+echo "=== gg_policy_content: the index governs, and a probe that failed is not an answer ==="
+
+new_repo staged-wins
+printf 'seed\n' >"$R/seed.txt"
+mkdir -p "$R/tools"
+printf 'INDEX\treason\n' >"$R/tools/ex.tsv"
+git -C "$R" add -A
+git -C "$R" commit -qm base
+printf 'WORKTREE\treason\n' >"$R/tools/ex.tsv"
+call 'gg_policy_content tools/ex.tsv'
+[ "$RC" -eq 0 ] && [ "$OUT" = "INDEX${TAB}reason" ] \
+  && ok "the staged copy governs over an unstaged edit" \
+  || bad "the staged copy governs over an unstaged edit" "rc=$RC out=$OUT"
+
+# Control: the SAME fixture, with the index unreadable. Before this was
+# classified, the failed probe fell through to the worktree copy and the
+# commit was judged against policy it does not carry.
+printf 'not an index\n' >"$ROOT/corrupt.idx"
+call 'GIT_INDEX_FILE="'"$ROOT"'/corrupt.idx" gg_policy_content tools/ex.tsv'
+[ "$RC" -eq 2 ] && case "$OUT" in *"could not query the index"*) true ;; *) false ;; esac \
+  && ok "an unreadable index is a collection error, not a fall-through" \
+  || bad "an unreadable index is a collection error, not a fall-through" "rc=$RC out=$OUT"
+case "$OUT" in
+  *WORKTREE*) bad "the failed probe never emits the worktree copy" "out=$OUT" ;;
+  *) ok "the failed probe never emits the worktree copy" ;;
+esac
+
+new_repo staged-deletion
+mkdir -p "$R/tools"
+printf 'INDEX\treason\n' >"$R/tools/ex.tsv"
+git -C "$R" add -A
+git -C "$R" commit -qm base
+git -C "$R" rm -q --cached tools/ex.tsv
+call 'gg_policy_content tools/ex.tsv'
+[ "$RC" -eq 1 ] && [ -z "$OUT" ] \
+  && ok "a staged deletion governs as absent even with the worktree copy present" \
+  || bad "a staged deletion governs as absent even with the worktree copy present" "rc=$RC out=$OUT"
+
+new_repo never-tracked
+printf 'seed\n' >"$R/seed.txt"
+git -C "$R" add -A
+git -C "$R" commit -qm base
+mkdir -p "$R/tools"
+printf 'ONDISK\treason\n' >"$R/tools/ex.tsv"
+call 'gg_policy_content tools/ex.tsv'
+[ "$RC" -eq 0 ] && case "$OUT" in ONDISK*) true ;; *) false ;; esac \
+  && ok "a never-tracked policy file falls back to the worktree copy" \
+  || bad "a never-tracked policy file falls back to the worktree copy" "rc=$RC out=$OUT"
+
+new_repo unborn-head
+mkdir -p "$R/tools"
+printf 'ONDISK\treason\n' >"$R/tools/ex.tsv"
+call 'gg_policy_content tools/ex.tsv'
+[ "$RC" -eq 0 ] && case "$OUT" in ONDISK*) true ;; *) false ;; esac \
+  && ok "an unborn HEAD carries nothing and does not fail the read" \
+  || bad "an unborn HEAD carries nothing and does not fail the read" "rc=$RC out=$OUT"
+
+echo "=== gg_policy_content: a configured path is a literal path, never a glob ==="
+
+new_repo glob-path
+mkdir -p "$R/tools"
+printf 'REAL\treason\n' >"$R/tools/exA.tsv"
+git -C "$R" add -A
+git -C "$R" commit -qm base
+call "gg_policy_content 'tools/ex?.tsv'"
+[ "$RC" -eq 1 ] && [ -z "$OUT" ] \
+  && ok "a glob-shaped path matches only itself, and it does not exist" \
+  || bad "a glob-shaped path matches only itself, and it does not exist" "rc=$RC out=$OUT"
+case "$OUT" in
+  *REAL* | *"diff --git"*)
+    bad "a glob-shaped path never yields another entry's content" "out=$OUT"
+    ;;
+  *) ok "a glob-shaped path never yields another entry's content" ;;
+esac
+# Control: the literal path this repo does carry still resolves.
+call 'gg_policy_content tools/exA.tsv'
+[ "$RC" -eq 0 ] && case "$OUT" in REAL*) true ;; *) false ;; esac \
+  && ok "the literal path it names still resolves" \
+  || bad "the literal path it names still resolves" "rc=$RC out=$OUT"
+
+echo "=== gg_require_merged_index: a --cached scan refuses an unmerged index ==="
+
+conflicted_repo() { # NAME — fixture left mid-merge, f.txt unmerged
+  new_repo "$1"
+  printf 'line1\nbase\nline3\n' >"$R/f.txt"
+  git -C "$R" add -A
+  git -C "$R" commit -qm base
+  git -C "$R" checkout -q -b other
+  printf 'line1\ntheirs\nline3\n' >"$R/f.txt"
+  git -C "$R" commit -qam other
+  git -C "$R" checkout -q main
+  printf 'line1\nours\nline3\n' >"$R/f.txt"
+  git -C "$R" commit -qam ours
+  git -C "$R" merge other >/dev/null 2>&1 || true
+}
+
+conflicted_repo unmerged
+[ "$(git -C "$R" ls-files -u | wc -l)" -eq 3 ] \
+  && ok "the fixture really is mid-merge (three index stages)" \
+  || bad "the fixture really is mid-merge (three index stages)" "stages=$(git -C "$R" ls-files -u | wc -l)"
+
+call 'gg_require_merged_index'
+[ "$RC" -eq 2 ] && case "$OUT" in *"unmerged path"*"finish or abort the merge"*) true ;; *) false ;; esac \
+  && ok "an unmerged index is a collection error naming the remedy" \
+  || bad "an unmerged index is a collection error naming the remedy" "rc=$RC out=$OUT"
+case "$OUT" in
+  *f.txt*) ok "the refusal names the unmerged path" ;;
+  *) bad "the refusal names the unmerged path" "out=$OUT" ;;
+esac
+
+# Scope: the guard answers for the paths the lane actually scans. An unmerged
+# path outside the pathspec leaves that scan complete.
+call "gg_require_merged_index '*.rs'"
+[ "$RC" -eq 0 ] \
+  && ok "an unmerged path outside the pathspec does not block that scan" \
+  || bad "an unmerged path outside the pathspec does not block that scan" "rc=$RC out=$OUT"
+call "gg_require_merged_index 'f.txt'"
+[ "$RC" -eq 2 ] \
+  && ok "an unmerged path inside the pathspec does block it" \
+  || bad "an unmerged path inside the pathspec does block it" "rc=$RC out=$OUT"
+
+echo "=== end to end: conflict-markers over an unmerged index ==="
+
+conflicted_repo cm-unmerged
+RC=0
+OUT="$(cd "$R" && "$SCRIPTS/conflict-markers" 2>&1)" || RC=$?
+[ "$RC" -eq 2 ] \
+  && ok "conflict-markers refuses rather than reporting OK over an unmerged index" \
+  || bad "conflict-markers refuses rather than reporting OK over an unmerged index" "rc=$RC out=$OUT"
+case "$OUT" in
+  *"OK — no conflict markers"*)
+    bad "the refusal is not dressed as a clean verdict" "out=$OUT"
+    ;;
+  *) ok "the refusal is not dressed as a clean verdict" ;;
+esac
+
+# Control: staging the conflicted content resolves the index, and the SAME
+# bytes then fail as the violation they are — the guard did not replace the
+# measurement, it unblocked it.
+git -C "$R" add f.txt
+RC=0
+OUT="$(cd "$R" && "$SCRIPTS/conflict-markers" 2>&1)" || RC=$?
+[ "$RC" -eq 1 ] && case "$OUT" in *"conflict marker: f.txt:"*) true ;; *) false ;; esac \
+  && ok "once staged, the same markers fail as violations" \
+  || bad "once staged, the same markers fail as violations" "rc=$RC out=$OUT"
+
+# Control: a resolved, marker-free tree passes.
+printf 'line1\nmerged\nline3\n' >"$R/f.txt"
+git -C "$R" add f.txt
+RC=0
+OUT="$(cd "$R" && "$SCRIPTS/conflict-markers" 2>&1)" || RC=$?
+[ "$RC" -eq 0 ] && case "$OUT" in *"conflict-markers: OK"*) true ;; *) false ;; esac \
+  && ok "a resolved tree passes" \
+  || bad "a resolved tree passes" "rc=$RC out=$OUT"
+
+echo "=== gg_install_file: the destination is replaced whole, or not at all ==="
+
+new_repo install-file
+mkdir -p "$R/tools"
+printf 'ORIGINAL\n' >"$R/tools/dest.tsv"
+printf 'REPLACEMENT\n' >"$ROOT/src.tsv"
+call 'gg_install_file "'"$ROOT"'/src.tsv" tools/dest.tsv "the fixture"'
+[ "$RC" -eq 0 ] && [ "$(cat "$R/tools/dest.tsv")" = "REPLACEMENT" ] \
+  && ok "a successful install replaces the destination" \
+  || bad "a successful install replaces the destination" "rc=$RC out=$OUT content=$(cat "$R/tools/dest.tsv")"
+[ -z "$(find "$R/tools" -name '.gg-install*')" ] \
+  && ok "a successful install leaves no residue beside the destination" \
+  || bad "a successful install leaves no residue beside the destination" "$(find "$R/tools" -name '.gg-install*')"
+
+# Control: interrupt the install at the rename. The destination must still
+# carry the reviewed bytes — a truncated ratchet file loosens the gate
+# instead of failing it, so a half-done replace is worse than none.
+new_repo install-fails
+mkdir -p "$R/tools" "$ROOT/stub"
+printf 'ORIGINAL\n' >"$R/tools/dest.tsv"
+printf '#!/bin/sh\nexit 1\n' >"$ROOT/stub/mv"
+chmod +x "$ROOT/stub/mv"
+RC=0
+OUT="$(cd "$R" && PATH="$ROOT/stub:$PATH" GG_CHECK=probe bash -c '
+  set -euo pipefail
+  . "$1"
+  gg_install_file "$2" tools/dest.tsv "the fixture"
+' _ "$COMMON" "$ROOT/src.tsv" 2>&1)" || RC=$?
+[ "$RC" -eq 2 ] && case "$OUT" in *"could not replace the fixture"*) true ;; *) false ;; esac \
+  && ok "a failed rename is a loud collection error" \
+  || bad "a failed rename is a loud collection error" "rc=$RC out=$OUT"
+[ "$(cat "$R/tools/dest.tsv")" = "ORIGINAL" ] \
+  && ok "a failed install leaves the destination byte-identical" \
+  || bad "a failed install leaves the destination byte-identical" "content=$(cat "$R/tools/dest.tsv")"
+
+echo "=== the settings cache is materialized by rename, never by a live redirect ==="
+
+new_repo settings-cache
+printf 'GROWTH_GUARDS_TODO_MAX=7\n' >"$R/vstack.settings.toml"
+git -C "$R" add -A
+git -C "$R" commit -qm base
+RC=0
+OUT="$(cd "$R" && PATH="$ROOT/stub:$PATH" GG_CHECK=probe bash -c '
+  set -euo pipefail
+  . "$1"
+  . "$2"
+  gg_settings_index_mode
+  src="$(gg_settings_source vstack.settings.toml)" || exit 3
+  printf "SRC=%s\n" "$src"
+  ls -A "$GG_SETTINGS_INDEX_DIR"
+' _ "$COMMON" "$SETTINGS" 2>&1)" || RC=$?
+[ "$RC" -eq 3 ] && case "$OUT" in *"could not materialize the staged copy"*) true ;; *) false ;; esac \
+  && ok "a failed rename fails the settings resolve loudly" \
+  || bad "a failed rename fails the settings resolve loudly" "rc=$RC out=$OUT"
+case "$OUT" in
+  *SRC=*) bad "no cache path is handed out when the rename failed" "out=$OUT" ;;
+  *) ok "no cache path is handed out when the rename failed" ;;
+esac
+
+# Control: with mv working, the same resolve materializes a complete cache.
+RC=0
+OUT="$(cd "$R" && GG_CHECK=probe bash -c '
+  set -euo pipefail
+  . "$1"
+  . "$2"
+  gg_settings_index_mode
+  src="$(gg_settings_source vstack.settings.toml)"
+  cat "$src"
+  find "$GG_SETTINGS_INDEX_DIR" -name "*.part" -printf "PART:%p\n"
+' _ "$COMMON" "$SETTINGS" 2>&1)" || RC=$?
+[ "$RC" -eq 0 ] && case "$OUT" in *GROWTH_GUARDS_TODO_MAX=7*) true ;; *) false ;; esac \
+  && ok "the cache resolves the staged value when the rename succeeds" \
+  || bad "the cache resolves the staged value when the rename succeeds" "rc=$RC out=$OUT"
+case "$OUT" in
+  *PART:*) bad "no partial cache file survives the resolve" "out=$OUT" ;;
+  *) ok "no partial cache file survives the resolve" ;;
+esac
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/skills/growth-guards/tests/index-reads.test.sh
+++ b/skills/growth-guards/tests/index-reads.test.sh
@@ -210,6 +210,58 @@ OUT="$(cd "$R" && "$SCRIPTS/conflict-markers" 2>&1)" || RC=$?
   && ok "a resolved tree passes" \
   || bad "a resolved tree passes" "rc=$RC out=$OUT"
 
+echo "=== a failed policy read stops the gate, it does not become an empty list ==="
+
+# gg_policy_content runs inside a command substitution, so its exit 2 dies in
+# that subshell and reaches gg_load_excludes as a bare status. This shim fails
+# ONLY the index probe, so nothing later in the run can mask the propagation.
+mkdir -p "$ROOT/gitstub"
+cat >"$ROOT/gitstub/git" <<'STUB'
+#!/usr/bin/env bash
+for a in "$@"; do
+  [ "$a" = "--error-unmatch" ] || continue
+  echo "fatal: simulated index failure" >&2
+  exit 128
+done
+exec "$GG_REAL_GIT" "$@"
+STUB
+chmod +x "$ROOT/gitstub/git"
+GG_REAL_GIT="$(command -v git)"
+export GG_REAL_GIT
+
+new_repo excludes-unread
+printf 'seed\n' >"$R/seed.txt"
+mkdir -p "$R/tools"
+printf '# notes\n\nTODO: an unlinked work marker\n' >"$R/bad.md"
+printf 'bad.md\tallowed to carry markers\n' >"$R/tools/todo-ban-excludes"
+git -C "$R" add -A
+git -C "$R" commit -qm base
+
+RC=0
+OUT="$(cd "$R" && "$SCRIPTS/todo-ban" 2>&1)" || RC=$?
+[ "$RC" -eq 0 ] && case "$OUT" in *"todo-ban: OK"*) true ;; *) false ;; esac \
+  && ok "control: with the excludes readable, the excluded marker passes" \
+  || bad "control: with the excludes readable, the excluded marker passes" "rc=$RC out=$OUT"
+
+RC=0
+OUT="$(cd "$R" && PATH="$ROOT/gitstub:$PATH" "$SCRIPTS/todo-ban" 2>&1)" || RC=$?
+[ "$RC" -eq 2 ] \
+  && ok "an unreadable exclusion list stops the run at exit 2" \
+  || bad "an unreadable exclusion list stops the run at exit 2" "rc=$RC out=$OUT"
+case "$OUT" in
+  *"refusing to run on an unread exclusion list"*)
+    ok "the refusal names the unread exclusion list"
+    ;;
+  *) bad "the refusal names the unread exclusion list" "out=$OUT" ;;
+esac
+# The failure mode this closes: an empty list is not "no exclusions apply".
+case "$OUT" in
+  *"work marker(s)"* | *"todo-ban: OK"*)
+    bad "the failed read never produces a verdict" "out=$OUT"
+    ;;
+  *) ok "the failed read never produces a verdict" ;;
+esac
+
 echo "=== gg_install_file: the destination is replaced whole, or not at all ==="
 
 new_repo install-file
@@ -278,7 +330,7 @@ OUT="$(cd "$R" && GG_CHECK=probe bash -c '
   gg_settings_index_mode
   src="$(gg_settings_source vstack.settings.toml)"
   cat "$src"
-  find "$GG_SETTINGS_INDEX_DIR" -name "*.part" -printf "PART:%p\n"
+  find "$GG_SETTINGS_INDEX_DIR" -name "*.part" -print | sed "s/^/PART:/"
 ' _ "$COMMON" "$SETTINGS" 2>&1)" || RC=$?
 [ "$RC" -eq 0 ] && case "$OUT" in *GROWTH_GUARDS_TODO_MAX=7*) true ;; *) false ;; esac \
   && ok "the cache resolves the staged value when the rename succeeds" \

--- a/skills/growth-guards/tests/index-reads.test.sh
+++ b/skills/growth-guards/tests/index-reads.test.sh
@@ -210,6 +210,69 @@ OUT="$(cd "$R" && "$SCRIPTS/conflict-markers" 2>&1)" || RC=$?
   && ok "a resolved tree passes" \
   || bad "a resolved tree passes" "rc=$RC out=$OUT"
 
+echo "=== byte-ceiling: an add/add conflict is not a zero-addition diff ==="
+
+# An add/add conflict is status U, which --diff-filter=A drops entirely: the
+# addition vanishes from the record set and the ceiling measures nothing.
+new_repo bc-addadd
+printf 'seed\n' >"$R/seed.txt"
+git -C "$R" add -A
+git -C "$R" commit -qm base
+git -C "$R" checkout -q -b other
+head -c 400000 /dev/zero | tr '\0' 'b' >"$R/big.txt"
+git -C "$R" add -A
+git -C "$R" commit -qm other
+git -C "$R" checkout -q main
+head -c 400000 /dev/zero | tr '\0' 'a' >"$R/big.txt"
+git -C "$R" add -A
+git -C "$R" commit -qm ours
+git -C "$R" merge other >/dev/null 2>&1 || true
+[ "$(git -C "$R" diff --cached --raw --diff-filter=A | wc -l)" -eq 0 ] \
+  && ok "the fixture really does hide the addition from --diff-filter=A" \
+  || bad "the fixture really does hide the addition from --diff-filter=A" "$(git -C "$R" diff --cached --raw --diff-filter=A)"
+
+RC=0
+OUT="$(cd "$R" && "$SCRIPTS/byte-ceiling" 2>&1)" || RC=$?
+[ "$RC" -eq 2 ] \
+  && ok "byte-ceiling refuses the unmerged index instead of measuring around it" \
+  || bad "byte-ceiling refuses the unmerged index instead of measuring around it" "rc=$RC out=$OUT"
+case "$OUT" in
+  *"0 staged addition(s) checked"* | *"byte-ceiling: OK"*)
+    bad "the refusal is not dressed as a clean measurement" "out=$OUT"
+    ;;
+  *) ok "the refusal is not dressed as a clean measurement" ;;
+esac
+
+RC=0
+OUT="$(cd "$R" && "$SCRIPTS/byte-ceiling" --all 2>&1)" || RC=$?
+[ "$RC" -eq 2 ] \
+  && ok "--all refuses it too, where ls-files emits one record per stage" \
+  || bad "--all refuses it too, where ls-files emits one record per stage" "rc=$RC out=$OUT"
+
+# Control: the guard did not replace the measurement. A merged index with a
+# genuinely new oversized file still fails the ceiling, and a merged index
+# with nothing oversized still passes.
+new_repo bc-merged
+printf 'seed\n' >"$R/seed.txt"
+git -C "$R" add -A
+git -C "$R" commit -qm base
+head -c 400000 /dev/zero | tr '\0' 'a' >"$R/big.txt"
+git -C "$R" add -A
+RC=0
+OUT="$(cd "$R" && "$SCRIPTS/byte-ceiling" 2>&1)" || RC=$?
+[ "$RC" -eq 1 ] && case "$OUT" in *big.txt*) true ;; *) false ;; esac \
+  && ok "a merged index still fails an oversized addition" \
+  || bad "a merged index still fails an oversized addition" "rc=$RC out=$OUT"
+git -C "$R" rm -q --cached big.txt
+rm -f "$R/big.txt"
+printf 'small\n' >"$R/small.txt"
+git -C "$R" add -A
+RC=0
+OUT="$(cd "$R" && "$SCRIPTS/byte-ceiling" 2>&1)" || RC=$?
+[ "$RC" -eq 0 ] && case "$OUT" in *"byte-ceiling: OK"*) true ;; *) false ;; esac \
+  && ok "a merged index with nothing oversized still passes" \
+  || bad "a merged index with nothing oversized still passes" "rc=$RC out=$OUT"
+
 echo "=== a failed policy read stops the gate, it does not become an empty list ==="
 
 # gg_policy_content runs inside a command substitution, so its exit 2 dies in

--- a/skills/growth-guards/tests/index-reads.test.sh
+++ b/skills/growth-guards/tests/index-reads.test.sh
@@ -339,6 +339,49 @@ call 'gg_install_file "'"$ROOT"'/src.tsv" tools/dest.tsv "the fixture"'
   && ok "a successful install leaves no residue beside the destination" \
   || bad "a successful install leaves no residue beside the destination" "$(find "$R/tools" -name '.gg-install*')"
 
+# A planted staging file must not redirect the write. cp writes THROUGH a
+# symlink, so a staging name the repository can predict is an arbitrary-file
+# overwrite waiting for the next --update. The writer publishes its own pid
+# and waits, so the symlink is planted at the EXACT name a pid-derived
+# scheme would choose — the control is aimed, not a guess.
+new_repo install-symlink
+mkdir -p "$R/tools"
+printf 'ORIGINAL\n' >"$R/tools/dest.tsv"
+printf 'VICTIM\n' >"$ROOT/victim.txt"
+pidfile="$ROOT/writer.pid"
+gofile="$ROOT/writer.go"
+rm -f "$pidfile" "$gofile"
+(
+  cd "$R" && GG_CHECK=probe bash -c '
+    set -euo pipefail
+    echo "$$" >"$2"
+    i=0
+    while [ ! -e "$3" ] && [ "$i" -lt 200 ]; do i=$((i + 1)); sleep 0.05; done
+    . "$1"
+    gg_install_file "$4" tools/dest.tsv "the fixture"
+  ' _ "$COMMON" "$pidfile" "$gofile" "$ROOT/src.tsv"
+) >"$ROOT/writer.out" 2>&1 &
+writer=$!
+i=0
+while [ ! -s "$pidfile" ] && [ "$i" -lt 200 ]; do i=$((i + 1)); sleep 0.05; done
+if [ -s "$pidfile" ]; then
+  ln -s "$ROOT/victim.txt" "$R/tools/.gg-install.$(cat "$pidfile").dest.tsv"
+  ok "the control is aimed at the pid the writer actually uses"
+else
+  bad "the control is aimed at the pid the writer actually uses" "no pid published"
+fi
+: >"$gofile"
+wait "$writer" || true
+[ "$(cat "$ROOT/victim.txt")" = "VICTIM" ] \
+  && ok "a planted staging symlink does not redirect the write" \
+  || bad "a planted staging symlink does not redirect the write" "victim=$(cat "$ROOT/victim.txt")"
+[ "$(cat "$R/tools/dest.tsv")" = "REPLACEMENT" ] \
+  && ok "the install still lands on its real destination" \
+  || bad "the install still lands on its real destination" "content=$(cat "$R/tools/dest.tsv") out=$(cat "$ROOT/writer.out")"
+[ -z "$(find "$R/tools" -name '.gg-install.*.XXXXXX' -o -name '*.gg-install.??????')" ] \
+  && ok "no staging file is left behind beside the destination" \
+  || bad "no staging file is left behind beside the destination" "$(find "$R/tools" -name '*gg-install*')"
+
 # Control: interrupt the install at the rename. The destination must still
 # carry the reviewed bytes — a truncated ratchet file loosens the gate
 # instead of failing it, so a half-done replace is worse than none.


### PR DESCRIPTION
## Summary

Three defects in the growth-guards check family, all in the same direction: a gate that could not read its own inputs answered anyway, and a gate that rewrote its own policy could leave half of it behind.

The family contract in `lib/common.sh` already says what should have happened — "a measurement that could not be taken goes through `gg_collection_error` — a loud exit 2, never a silent pass." Three paths escaped it.

## What changed

**An unmerged index is no longer scanned as if it were clean (#1510).** `git grep --cached` skips unmerged index entries entirely: no error status, no `error:` line, nothing for `gg_grep_guard` to catch. `conflict-markers` therefore printed `OK — no conflict markers in tracked files` and exited 0 in a work tree mid-conflict — the exact state the check exists for. Every `--cached` scan now runs `gg_require_merged_index` over the paths it is about to read first, and exits 2 naming them. The guard is scoped to the lane's own pathspec, so an unmerged path a lane does not scan leaves that scan complete.

**Policy probes fail closed, and policy paths are literal (#1508).** `gg_policy_content` discarded both probes' exit status, so exit 1 ("no such path") and exit 128 (unreadable index, corrupt object, not a repository) fell through alike — judging the commit against the unstaged worktree copy, or against nothing. It now mirrors the classification `gg_settings_source` already applies, and probes HEAD with `git ls-tree` rather than `cat-file -e`, which cannot distinguish an absent path from a broken repository. Both probes pass `:(literal)`. `suppression-ban`'s baseline read carried the same two defects and gets the same treatment.

The `:(literal)` half turned out to be worse than the issue's note suggested — see the table below.

**Policy writes land by same-directory rename (#1502).** The settings cache was written by redirecting onto its final path; `suppression-ban --update` replaced the baseline by `mv` from `$TMPDIR`, which degrades to copy-then-unlink across filesystems. Both now write beside the destination and rename, through one shared `gg_install_file`. The destination carries the complete new bytes or the complete old ones, never a prefix of either.

## Verification

New suite `skills/growth-guards/tests/index-reads.test.sh`, 26 assertions. Run against the **pre-fix** scripts it is **13 passed, 13 failed** — every new contract has a real must-fail control, and the surviving 13 are the regression guards for behavior that was already correct.

| Case | Before | After |
| -- | -- | -- |
| `conflict-markers` over a 3-stage unmerged index | `OK — no conflict markers`, exit 0 | exit 2 naming `f.txt` and the remedy |
| the same tree once staged | exit 1 (markers found) | exit 1 — unchanged, the guard unblocked the measurement rather than replacing it |
| `gg_policy_content` with an unreadable index, file staged-not-committed | exit 0, **emits the unstaged worktree copy** | exit 2, `could not query the index … refusing to treat it as untracked` |
| `gg_policy_content 'tools/ex?.tsv'`, index holds `tools/exA.tsv` | exit 0, **emits a commit diff** — git resolved `:tools/ex?.tsv` as a REVISION and `git show` printed the whole commit, which then parses as the exclusion list | exit 1, no such path |
| `gg_install_file` with the rename failing | n/a (direct `mv`, truncation possible) | exit 2, destination byte-identical, no residue |
| settings cache with the rename failing | hands out a cache path anyway | exit nonzero, no cache path handed out, no `.part` file survives |

Every growth-guards suite green on this branch:

```
bash32-portability  pass          index-reads          26 passed, 0 failed
byte-ceiling        39 passed     install-git-hooks   205 passed, 0 failed
cleanup-scope       10 passed     pre-commit-chain     27 passed, 0 failed
commit-msg          49 passed     suppression-ban      56 passed, 0 failed
conflict-markers    26 passed     todo-ban             29 passed, 0 failed
dispatcher          15 passed
```

`bash -n` and `shellcheck` clean on all four changed scripts (only the pre-existing SC1091/SC2034/SC2015 notes the suite already carries). The scripts stay Bash 3.2-safe — `bash32-portability.test.sh` covers the new code.

Closes VST-393
Closes #1510
Closes VST-391
Closes #1508
Closes VST-387
Closes #1502
