### PR TITLE
fix(review-gate): two test suites that reported success without measuring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 ## Unreleased
 
+- review-gate: `review-predicate-selftest-teardown.test.sh` no longer fails
+  when a runner launches it in the background — measured 0/4 passing at four
+  concurrent instances, against 4/4 for every other skill (#1506). The cause
+  is signal DISPOSITION, not process groups. A shell without job control
+  gives every async child `SIG_IGN` for SIGINT and SIGQUIT; bash refuses to
+  install a trap for a signal that was ignored when it started, and `SIG_IGN`
+  survives `exec`. So every instance a parallel runner backgrounded ran its
+  `sigquit` variant and its interrupt arm against signals that could never be
+  delivered, and the fixtures reported the undelivered signal as a teardown
+  leak — `expected exit 130, got 99`. The four failures were identical
+  because nothing crossed between instances: ONE instance backgrounded from
+  such a shell fails the same way, and the group signalling the suite proves
+  is already scoped to what it owns, each replay leading its own process
+  group under `set -m` and the leaders read from that instance's own job
+  table. Neither `setsid` nor `set -m` clears an inherited `SIG_IGN`; both
+  were measured.
+
+  The suite now restores the default disposition for INT and QUIT before it
+  measures anything, re-execing itself once through `env --default-signal` or
+  perl, and fails loud naming the cause where neither can restore them rather
+  than running arms that cannot be measured. The once-marker is dropped after
+  the re-exec, so the nested runs re-exec on their own terms. A new arm pins
+  it: the suite is launched by a no-job-control shell that backgrounds it —
+  the shape every parallel runner has — and must still exit 130 on an
+  interrupt. That arm fails on the previous code even in a serial foreground
+  run, so CI catches the defect where the runs are sequential.
+
 - review-gate: `settings-example-sync.test.sh` can no longer report success
   for comparisons it never made (#1507). Its assertion helper ran each
   expression through `eval` in the CURRENT shell, so the absent-root guard —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 ## Unreleased
 
+- review-gate: `settings-example-sync.test.sh` can no longer report success
+  for comparisons it never made (#1507). Its assertion helper ran each
+  expression through `eval` in the CURRENT shell, so the absent-root guard —
+  `[ -f "$ROOT_TEMPLATE" ] || exit 0` — ended the whole SUITE with status 0
+  instead of skipping the one comparison it guarded. In any consumer that
+  vendors the skill without the repo-root template, all 17 REVIEW_GATE
+  key-presence and default-drift comparisons went unmade and the run printed
+  zero bytes, which a CI job wiring the suites in counts as a passing suite.
+  Assertions now run as commands rather than eval'd expression strings, so
+  there is no expression for an `exit` to hide in and no later assertion has
+  to remember the hazard. An absent root template is a counted, printed
+  `  skip  ` per key — the same shape review-gate's other suites already use
+  — the skill-side assertions still run, and every run ends with a
+  `N passed, N failed, N skipped` summary, so an unmeasured run cannot read
+  as a clean one. The absent SKILL template, which ships beside the suite and
+  is a broken checkout rather than a downstream condition, fails loud.
+
+  A second vacuous path went with it: the presence check accepted any
+  assignment while the value reader read only the quoted form, so a key
+  written unquoted in BOTH templates parsed to an empty default on both sides
+  and two different values compared equal. Presence now requires the quoted
+  form the reader actually parses. New `settings-example-sync-controls.test.sh`
+  drives the suite against planted trees and asserts its verdict, counts and
+  skip lines: in-sync passes with `56 passed, 0 failed, 0 skipped`, an absent
+  root reports `22 passed, 0 failed, 17 skipped`, and a drifted default, a
+  dropped key, two drifted unquoted defaults, a stripped SECURITY caveat and
+  an absent skill template each fail. Against the previous suite the absent-root
+  and unquoted-drift fixtures both exited 0.
+
 - CLI: a lock `source` recorded as a path inside `~/.vstack/cache/` now
   resolves as the remote that cache entry clones, instead of as an ordinary
   local checkout (#1495). vstack's cache is its own TTL-managed state, but

--- a/skills/review-gate/tests/review-predicate-selftest-teardown.test.sh
+++ b/skills/review-gate/tests/review-predicate-selftest-teardown.test.sh
@@ -19,6 +19,43 @@ set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WRAPPER="$TEST_DIR/review-predicate-selftest.test.sh"
+SELF_PATH="$TEST_DIR/${BASH_SOURCE[0]##*/}"
+
+# The signal arms below need INT and QUIT DELIVERABLE — to this shell's own
+# traps, to the variants it runs, and to the nested run it interrupts. A
+# shell without job control hands every async child SIG_IGN for both; bash
+# refuses to install a trap for a signal ignored at startup, and SIG_IGN
+# survives exec. So a runner that backgrounds this suite — every parallel
+# one does — would otherwise run those arms against signals that can never
+# be delivered, and the fixtures would report the undelivered signal as a
+# teardown leak. Neither `set -m` nor `setsid` clears an inherited SIG_IGN;
+# only a helper that restores SIG_DFL before exec does. Re-exec through one,
+# once: the guard is idempotent, so the nested runs below pass straight
+# through it.
+sig_ignored_at_startup() {
+  case "$(trap -p "$1")" in
+    *"-- ''"*) return 0 ;;
+  esac
+  return 1
+}
+if sig_ignored_at_startup INT || sig_ignored_at_startup QUIT; then
+  if [ -z "${RG_TEARDOWN_SIGDFL:-}" ]; then
+    export RG_TEARDOWN_SIGDFL=1
+    if env --default-signal=INT,QUIT true 2>/dev/null; then
+      exec env --default-signal=INT,QUIT bash "$SELF_PATH" ${1+"$@"}
+    fi
+    if command -v perl >/dev/null 2>&1; then
+      exec perl -e '$SIG{INT} = "DEFAULT"; $SIG{QUIT} = "DEFAULT"; exec @ARGV or die "exec: $!\n"' \
+        bash "$SELF_PATH" ${1+"$@"}
+    fi
+  fi
+  echo "FAIL: SIGINT/SIGQUIT are ignored and could not be restored to their default disposition — the signal arms measure nothing"
+  exit 1
+fi
+# Restored, or never ignored. The once-marker must not travel any further:
+# the nested run below is launched INTO the ignored state on purpose and has
+# to be able to re-exec out of it exactly as this one did.
+unset RG_TEARDOWN_SIGDFL
 
 fail=0
 note() { echo "FAIL: $1"; fail=1; }
@@ -38,7 +75,6 @@ export RG_TEARDOWN_EXPECT=4
 export RG_TEARDOWN_ZOMBIE_PGID="${RG_TEARDOWN_ZOMBIE_PGID:-$work/zombie.pgid}"
 export RG_TEARDOWN_PROBE_READY="${RG_TEARDOWN_PROBE_READY:-$work/probe.ready}"
 export RG_TEARDOWN_ZOMBIE_KEEPER="${RG_TEARDOWN_ZOMBIE_KEEPER:-$work/zombie.keeper}"
-SELF_PATH="$TEST_DIR/${BASH_SOURCE[0]##*/}"
 : >"$RG_TEARDOWN_PIDS"
 JOBCONTROL_MARK="JOBCONTROL-LEFT-ENABLED"
 
@@ -129,6 +165,7 @@ waiter="$work/bin/$marker-wait"
 stubborn="$work/bin/$marker-stubborn-probe"
 zkeeper="$work/bin/$marker-zombie-keeper"
 zwait="$work/bin/$marker-zombie-wait"
+nojc="$work/bin/$marker-nojobcontrol-launcher"
 
 # The selftest stand-in. Its descendant stands for the gh-shim/jq layer:
 # a child of the selftest, two levels below the job the wrapper signals.
@@ -199,7 +236,19 @@ while [ "$i" -le 200 ]; do
 done
 : >"$RG_TEARDOWN_TIMEOUT"
 ZWAIT
-chmod +x "$probe" "$descendant" "$waiter" "$stubborn" "$zkeeper" "$zwait"
+# A launcher with NO job control that backgrounds its argument — the shape
+# every parallel test runner has, and the one that hands the child SIG_IGN
+# for INT and QUIT.
+cat >"$nojc" <<'NOJC'
+#!/usr/bin/env bash
+"$@" &
+p=$!
+echo "$p" >"$RG_TEARDOWN_BGPID"
+rc=0
+wait "$p" || rc=$?
+exit "$rc"
+NOJC
+chmod +x "$probe" "$descendant" "$waiter" "$stubborn" "$zkeeper" "$zwait" "$nojc"
 
 # The exact wrapper lines each edit rewrites. A miss is not silent: awk
 # records how many times each fired and the counts are asserted per variant.
@@ -441,6 +490,38 @@ if [ "$fail" -eq 0 ]; then
     wait "$probe_pid" 2>/dev/null || prc=$?
     if [ "$prc" -ne 130 ]; then
       note "an interrupted run exited $prc rather than 130 — the interrupt never reached cleanup"
+    fi
+  fi
+
+  # (a2) and the interrupt has to arrive when this suite is launched the way
+  # a parallel runner launches it: as a background job of a shell with no job
+  # control, which is what hands an async child SIG_IGN for INT and QUIT.
+  # Without the disposition guard at the top of this file the nested run
+  # cannot trap the interrupt at all, sails past it, and every signal arm
+  # above reports an undeliverable signal as a teardown leak.
+  rm -f "$probe_ready"
+  bgpid="$work/bg.pid"
+  RG_TEARDOWN_BGPID="$bgpid" \
+  RG_TEARDOWN_LEAK_PROBE=1 RG_TEARDOWN_PROBE_READY="$probe_ready" \
+    "$nojc" bash "$SELF_PATH" >"$work/nojc.out" 2>&1 &
+  nojc_pid=$!
+  i=0
+  while { [ ! -e "$probe_ready" ] || [ ! -s "$bgpid" ]; } && [ "$i" -lt 200 ]; do
+    i=$((i + 1))
+    sleep 0.05
+  done
+  if [ ! -e "$probe_ready" ] || [ ! -s "$bgpid" ]; then
+    cat "$work/nojc.out"
+    note "the background-launched run never signalled readiness, so it proves nothing about a runner that backgrounds this suite"
+    kill -KILL "$nojc_pid" 2>/dev/null || true
+    kill -KILL "$(cat "$bgpid" 2>/dev/null || echo 0)" 2>/dev/null || true
+  else
+    kill -INT "$(cat "$bgpid")" 2>/dev/null || true
+    nrc=0
+    wait "$nojc_pid" 2>/dev/null || nrc=$?
+    if [ "$nrc" -ne 130 ]; then
+      cat "$work/nojc.out"
+      note "a run backgrounded by a shell without job control exited $nrc rather than 130 — INT was ignored at startup and its traps never installed"
     fi
   fi
 

--- a/skills/review-gate/tests/settings-example-sync-controls.test.sh
+++ b/skills/review-gate/tests/settings-example-sync-controls.test.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# settings-example-sync.test.sh is the only review-gate suite whose entire
+# body is cross-file comparison, so a run that made no comparison at all
+# still exits 0. These are its controls: the suite is driven against planted
+# fixtures and its verdict, its counts and its skip lines are asserted, so a
+# green run can never be confused with an unmeasured one.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SUITE="$TEST_DIR/settings-example-sync.test.sh"
+SKILL_TEMPLATE="$TEST_DIR/../vstack.settings.toml.example"
+ROOT_TEMPLATE="$TEST_DIR/../../../vstack.settings.toml.example"
+
+fail=0
+note() { echo "FAIL: $1"; fail=1; }
+ok() { echo "  ok    $1"; }
+
+for f in "$SUITE" "$SKILL_TEMPLATE" "$ROOT_TEMPLATE"; do
+  [ -f "$f" ] || { echo "FAIL: fixture source missing: $f"; exit 1; }
+done
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+# fixture NAME — a tree the suite resolves exactly as it resolves the real
+# one: <root>/skills/review-gate/tests/<suite> beside the skill template,
+# three levels under the root template. Echoes the tree's root.
+fixture() {
+  local fx="$work/$1"
+  rm -rf "$fx"
+  mkdir -p "$fx/skills/review-gate/tests"
+  cp "$SUITE" "$fx/skills/review-gate/tests/"
+  cp "$SKILL_TEMPLATE" "$fx/skills/review-gate/"
+  cp "$ROOT_TEMPLATE" "$fx/"
+  echo "$fx"
+}
+
+# run_fixture ROOT — the suite under ROOT; stdout+stderr to $ROOT.out, exit
+# status echoed.
+run_fixture() {
+  local rc=0
+  bash "$1/skills/review-gate/tests/settings-example-sync.test.sh" >"$1.out" 2>&1 || rc=$?
+  echo "$rc"
+}
+
+expect_rc() {
+  [ "$2" = "$3" ] || note "$1: expected exit $3, got $2"
+}
+
+expect_out() {
+  grep -qF "$3" "$1.out" || {
+    cat "$1.out"
+    note "$(basename "$1"): expected output to contain '$3' ($2)"
+  }
+}
+
+expect_no_out() {
+  if grep -qF "$3" "$1.out"; then
+    cat "$1.out"
+    note "$(basename "$1"): output must NOT contain '$3' ($2)"
+  fi
+}
+
+# --- control: in sync, everything present -> pass, with counts ------------
+fx="$(fixture insync)"
+rc="$(run_fixture "$fx")"
+expect_rc insync "$rc" 0
+expect_out "$fx" "the verdict" "pass: settings-example-sync"
+expect_out "$fx" "every comparison ran" "56 passed, 0 failed, 0 skipped"
+ok "in-sync templates pass, and the run reports the count it measured"
+
+# --- must-fail control: root template ABSENT ------------------------------
+# The defect this file exists for: the absent-root guard used to end the RUN
+# with status 0, printing nothing, while all 17 key comparisons went
+# unmade. An absent root is skippable downstream, so the verdict may stay
+# green — but only as counted, printed skips, and only with the skill-side
+# assertions still measured.
+fx="$(fixture noroot)"
+rm -f "$fx/vstack.settings.toml.example"
+rc="$(run_fixture "$fx")"
+expect_rc noroot "$rc" 0
+expect_out "$fx" "skips are printed" "  skip  REVIEW_GATE_MODE cross-template comparison"
+expect_out "$fx" "skips are counted, skill side still measured" "22 passed, 0 failed, 17 skipped"
+expect_no_out "$fx" "an unmeasured run must never report a clean one" "0 skipped"
+[ -s "$fx.out" ] || note "noroot: the suite produced no output at all"
+ok "an absent root template is a counted, printed skip — never a silent green run"
+
+# --- must-fail control: root present but DRIFTED --------------------------
+fx="$(fixture drift)"
+sed -i.bak 's/^REVIEW_GATE_MODE = "enforce"$/REVIEW_GATE_MODE = "warn"/' "$fx/vstack.settings.toml.example"
+rm -f "$fx/vstack.settings.toml.example.bak"
+rc="$(run_fixture "$fx")"
+expect_rc drift "$rc" 1
+expect_out "$fx" "the drift is named" "REVIEW_GATE_MODE default drift: skill='enforce' root='warn'"
+expect_out "$fx" "the verdict" "settings-example-sync: FAIL"
+ok "a drifted default in the root template fails the suite"
+
+# --- must-fail control: root present but MISSING a key --------------------
+fx="$(fixture missingkey)"
+sed -i.bak '/^REVIEW_GATE_THREADS = /d' "$fx/vstack.settings.toml.example"
+rm -f "$fx/vstack.settings.toml.example.bak"
+rc="$(run_fixture "$fx")"
+expect_rc missingkey "$rc" 1
+expect_out "$fx" "the absent key is named" "REVIEW_GATE_THREADS present in root template"
+ok "a key dropped from the root template fails the suite"
+
+# --- must-fail control: drifted UNQUOTED values in both templates ---------
+# Both sides parse to an empty default under a value reader that only reads
+# the quoted form, so a presence check that accepts any assignment lets two
+# different values agree.
+fx="$(fixture unquoted)"
+sed -i.bak 's/^REVIEW_GATE_MODE = "enforce"$/REVIEW_GATE_MODE = enforce/' "$fx/skills/review-gate/vstack.settings.toml.example"
+sed -i.bak 's/^REVIEW_GATE_MODE = "enforce"$/REVIEW_GATE_MODE = warn/' "$fx/vstack.settings.toml.example"
+rm -f "$fx/skills/review-gate/vstack.settings.toml.example.bak" "$fx/vstack.settings.toml.example.bak"
+rc="$(run_fixture "$fx")"
+expect_rc unquoted "$rc" 1
+expect_out "$fx" "the unquoted skill-side assignment is named" "REVIEW_GATE_MODE present in skill template"
+expect_out "$fx" "the unquoted root-side assignment is named" "REVIEW_GATE_MODE present in root template"
+ok "two drifted UNQUOTED defaults fail rather than agreeing as empty"
+
+# --- must-fail control: the SECURITY caveat check can fail ----------------
+fx="$(fixture nocaveat)"
+sed -i.bak 's/SECURITY/NOTE/g' "$fx/skills/review-gate/vstack.settings.toml.example"
+rm -f "$fx/skills/review-gate/vstack.settings.toml.example.bak"
+rc="$(run_fixture "$fx")"
+expect_rc nocaveat "$rc" 1
+expect_out "$fx" "the caveat-less key is named" "carries the SECURITY caveat in the skill template"
+ok "a key that lost its SECURITY caveat fails the suite"
+
+# --- must-fail control: the SKILL template absent is a hard failure -------
+# It ships beside the suite, so its absence is a broken checkout rather than
+# a downstream condition, and nothing below it is measurable.
+fx="$(fixture noskill)"
+rm -f "$fx/skills/review-gate/vstack.settings.toml.example"
+rc="$(run_fixture "$fx")"
+expect_rc noskill "$rc" 1
+expect_out "$fx" "the missing template is named" "review-gate skill template missing"
+ok "an absent skill template fails loud"
+
+if [ "$fail" -ne 0 ]; then
+  echo "settings-example-sync-controls: FAIL"
+  exit 1
+fi
+echo "pass: settings-example-sync-controls"

--- a/skills/review-gate/tests/settings-example-sync.test.sh
+++ b/skills/review-gate/tests/settings-example-sync.test.sh
@@ -15,44 +15,97 @@ ROOT_TEMPLATE="$SCRIPT_DIR/../../../vstack.settings.toml.example"
 # vars-documented test enforces the legacy key's absence).
 GATE_KEYS="REVIEW_GATE_CONTEXT REVIEW_GATE_TRUSTED_STATUS_CONTEXTS REVIEW_GATE_CHECKRUN_SKIP_PATTERNS REVIEW_GATE_COMMENT_REVIEWERS REVIEW_GATE_SHA_PREFIX_FLOOR REVIEW_GATE_OVERRIDE_CONTEXT REVIEW_GATE_STATUS_PUBLISHER_REJECT REVIEW_GATE_REVIEW_OBJECT_TRUSTED_LOGINS REVIEW_GATE_REVIEW_OBJECT_MIN_STATE REVIEW_GATE_REVIEW_OBJECT_ERROR_PATTERNS REVIEW_GATE_THREADS REVIEW_GATE_API_ATTEMPTS REVIEW_GATE_API_RETRY_DELAY_SECONDS REVIEW_GATE_CARRY_FORWARD REVIEW_GATE_CARRY_FORWARD_EXCLUDE REVIEW_GATE_CARRY_FORWARD_EXCLUDE_PROPHYLACTIC REVIEW_GATE_MODE"
 
-fail=0
+passed=0
+failed=0
+skipped=0
 
+# check DESC CMD... — CMD is run as a command, never eval'd. An assertion
+# that could `exit` would end the RUN rather than itself, and the summary
+# below would then report a green verdict for every comparison it never
+# reached; there is no expression string here for one to hide in.
 check() {
-  if ! eval "$2"; then
-    echo "FAIL: $1"
-    fail=1
+  local desc="$1"
+  shift
+  if "$@"; then
+    passed=$((passed + 1))
+  else
+    echo "FAIL: $desc"
+    failed=$((failed + 1))
   fi
 }
 
-value_of() {
-  # First uncommented assignment of key $2 in file $1, value only.
-  sed -n "s/^$2 = \"\(.*\)\"$/\1/p" "$1" | head -1
+# skip REASON — a comparison this run cannot make. Counted, printed, and
+# reported in the summary, so an unmeasured run never reads as a clean one.
+skip() {
+  echo "  skip  $1"
+  skipped=$((skipped + 1))
 }
 
-check "review-gate skill template exists" "[ -f \"\$SKILL_TEMPLATE\" ]"
-check "root template exists (skip-safe in downstream installs)" "[ -f \"\$ROOT_TEMPLATE\" ] || exit 0"
+summary() {
+  echo "settings-example-sync: $passed passed, $failed failed, $skipped skipped"
+}
 
-check "skill template declares [env]" "grep -q '^\[env\]' \"\$SKILL_TEMPLATE\""
+# has_key FILE KEY — KEY carries a QUOTED default in FILE. The quotes are
+# part of the contract: value_of reads that form and nothing else, so a key
+# written any other way would compare as an empty default against a real one
+# and two drifted unquoted values would agree.
+has_key() {
+  grep -q "^$2 = \"" "$1"
+}
+
+# has_caveat FILE KEY — a SECURITY caveat sits within the 12 lines above KEY.
+has_caveat() {
+  grep -B12 "^$2 = \"" "$1" | grep -qi 'SECURITY'
+}
+
+# value_of FILE KEY — first uncommented assignment of KEY in FILE, value
+# only. One sed, no pipeline: a SIGPIPE from a `| head -1` would fail the
+# command substitution and, under `set -e`, end the run mid-comparison.
+value_of() {
+  sed -n "/^$2 = \"/{s/^$2 = \"\(.*\)\"\$/\1/p;q;}" "$1"
+}
+
+# The skill template ships beside this test; its absence is a broken
+# checkout, not a downstream condition, and every comparison below reads it.
+if [ ! -f "$SKILL_TEMPLATE" ]; then
+  echo "FAIL: review-gate skill template missing: $SKILL_TEMPLATE"
+  failed=1
+  summary
+  exit 1
+fi
+
+# The root template exists only in the vstack source tree. A downstream
+# install that vendors the skill alone skips the cross-file comparisons —
+# one counted skip per key — and still runs every skill-side assertion.
+root_present=1
+if [ ! -f "$ROOT_TEMPLATE" ]; then
+  root_present=""
+fi
+
+check "skill template declares [env]" grep -q '^\[env\]' "$SKILL_TEMPLATE"
 
 for key in $GATE_KEYS; do
+  check "$key present in skill template" has_key "$SKILL_TEMPLATE" "$key"
+  if [ -z "$root_present" ]; then
+    skip "$key cross-template comparison: root template absent ($ROOT_TEMPLATE)"
+    continue
+  fi
+  check "$key present in root template" has_key "$ROOT_TEMPLATE" "$key"
   skill_val="$(value_of "$SKILL_TEMPLATE" "$key")"
   root_val="$(value_of "$ROOT_TEMPLATE" "$key")"
-  check "$key present in skill template" "grep -q \"^$key = \" \"\$SKILL_TEMPLATE\""
-  check "$key present in root template" "grep -q \"^$key = \" \"\$ROOT_TEMPLATE\""
-  if [ "$skill_val" != "$root_val" ]; then
-    echo "FAIL: $key default drift: skill='$skill_val' root='$root_val'"
-    fail=1
-  fi
+  check "$key default drift: skill='$skill_val' root='$root_val'" \
+    test "$skill_val" = "$root_val"
 done
 
 # The security caveats must travel with the keys that need them: name-matched
 # evidence trust and the publisher reject-list.
 for caveat_key in REVIEW_GATE_TRUSTED_STATUS_CONTEXTS REVIEW_GATE_COMMENT_REVIEWERS REVIEW_GATE_OVERRIDE_CONTEXT REVIEW_GATE_STATUS_PUBLISHER_REJECT; do
   check "$caveat_key carries the SECURITY caveat in the skill template" \
-    "grep -B12 \"^$caveat_key = \" \"\$SKILL_TEMPLATE\" | grep -qi 'SECURITY'"
+    has_caveat "$SKILL_TEMPLATE" "$caveat_key"
 done
 
-if [ "$fail" -ne 0 ]; then
+summary
+if [ "$failed" -ne 0 ]; then
   echo "settings-example-sync: FAIL"
   exit 1
 fi


### PR DESCRIPTION
## Summary

Two review-gate test suites that reported success without measuring anything.

`settings-example-sync.test.sh` ended the whole run with status 0, printing zero bytes, whenever the repo-root template was absent — all 17 key comparisons unmade. `review-predicate-selftest-teardown.test.sh` failed in every instance a parallel runner backgrounded, because its INT/QUIT arms were measuring signals that could never be delivered.

Closes VST-390
Closes #1507
Closes VST-389
Closes #1506

## What changed

### #1507 — the suite must fail when it cannot measure

`check` ran each assertion through `eval` in the CURRENT shell, so `[ -f "$ROOT_TEMPLATE" ] || exit 0` ended the SUITE rather than skipping the one comparison it guarded.

- Assertions now run as commands, not eval'd expression strings — there is no expression for an `exit` to hide in, and no later assertion has to remember the hazard.
- An absent root template is a counted, printed `  skip  ` per key, matching the skip line review-gate's other suites already use. The skill-side assertions still run.
- Every run ends with a `N passed, N failed, N skipped` summary, so an unmeasured run cannot read as a clean one.
- An absent SKILL template ships beside the suite, so it is a broken checkout rather than a downstream condition: it fails loud.

**Second vacuous path found in the same file.** The presence check accepted any assignment (`^KEY = `) while `value_of` read only the quoted form, so a key written unquoted in BOTH templates parsed to an empty default on both sides and two different values compared equal. Presence now requires the quoted form the reader parses. Verified against the pre-fix suite: a fixture with `REVIEW_GATE_MODE = enforce` in the skill template and `REVIEW_GATE_MODE = warn` in the root template exited 0.

New `settings-example-sync-controls.test.sh` drives the suite against planted trees and asserts its verdict, its counts and its skip lines.

### #1506 — the suite must only measure what it can receive

The reported cause was process groups. It is not: **one** instance backgrounded from a shell without job control fails identically, with no second instance to interfere with.

A shell without job control gives every async child `SIG_IGN` for SIGINT and SIGQUIT. Bash refuses to install a trap for a signal ignored at startup (`trap -p QUIT` reports `trap -- '' SIGQUIT`), and `SIG_IGN` survives `exec`. The `sigquit` variant's `kill -QUIT $$` and the interrupt arm's `kill -INT` therefore hit signals that could never be delivered, and the fixtures reported that as a teardown leak (`expected exit 130, got 99`).

Measured: neither `setsid` nor `set -m` clears an inherited `SIG_IGN`; `env --default-signal=INT,QUIT` and `perl` with `$SIG{...} = "DEFAULT"` both do.

- The suite restores the default disposition for INT and QUIT before it measures anything, re-execing itself once through `env --default-signal` or perl.
- Where neither is available it fails loud naming the cause, rather than running arms it cannot measure.
- The once-marker is dropped after the re-exec, so the nested runs re-exec on their own terms.
- New arm: the suite is launched by a no-job-control shell that backgrounds it — the shape every parallel runner has — and must still exit 130 on an interrupt.

The group signalling itself was left as designed. It is already scoped to what the instance owns: each replay leads its own process group under `set -m` in `replay()`, and `sweep_replays` signals only leaders read from that instance's own `jobs -pr`. Narrowing it would break the suite's `perpid` control, which exists to prove the group kill is what reaches the descendants.

## Verification

### Concurrency, `review-predicate-selftest-teardown.test.sh`

Four instances launched as async children of a shell **without** job control (each with its own private `TMPDIR`) — the condition the issue reports. A launcher **with** job control gives each instance its own process group and passed 4/4 even before the fix, which is why the failure needs the no-job-control shape to reproduce.

| trial | before | after |
| --- | --- | --- |
| 1 | 0/4 | 4/4 |
| 2 | 0/4 | 4/4 |
| 3 | 0/4 | 4/4 |
| 4 | not run | 4/4 |
| 5 | not run | 4/4 |

Same launcher at N=1 (one instance, nothing to interfere with): before 0/1, after 1/1 — the measurement that falsifies the process-group diagnosis.

Full review-gate suite set, 4 concurrent instances, private `TMPDIR` each: 4/4 instances fully green on each of 3 trials (machine load average 60–107 throughout).

The new background-launch arm is a must-fail control: against the pre-fix file it fails in a **serial foreground** run —

```
FAIL: a run backgrounded by a shell without job control exited 0 rather than 130 — INT was ignored at startup and its traps never installed
```

### Serial, every review-gate suite

| suite | result |
| --- | --- |
| `bash32-portability.test.sh` | pass |
| `pr-watch.test.sh` | pass: 175 fail: 0 |
| `review-predicate-selftest-teardown.test.sh` | pass |
| `review-predicate-selftest.test.sh` | pass (197 default / 235 configured cases) |
| `review-writer-template.test.sh` | pass: 505 fail: 0 |
| `review-writer.test.sh` | pass: 100 fail: 0 |
| `settings-example-sync-controls.test.sh` | pass (7 controls) |
| `settings-example-sync.test.sh` | 56 passed, 0 failed, 0 skipped |
| `settings-parsing.test.sh` | 26 passed, 0 failed |
| `settings-vars-documented.test.sh` | pass |

### `settings-example-sync` controls, and what each proves against the pre-fix suite

| fixture | required verdict | pre-fix suite |
| --- | --- | --- |
| in sync | pass, `56 passed, 0 failed, 0 skipped` | pass |
| root template absent | exit 0, `22 passed, 0 failed, 17 skipped`, skip lines printed | **exit 0, zero bytes of output** |
| root default drifted | FAIL, drift named | FAIL |
| key dropped from root | FAIL, key named | FAIL |
| same key unquoted in both, different values | FAIL, both sides named | **pass** |
| SECURITY caveat stripped | FAIL | FAIL |
| skill template absent | FAIL, loud | (suite aborts under `set -e`) |

`bash -n` and `shellcheck -S warning` clean on every edited and added file. The pre-commit chain (size-ratchet, preflight, growth-guards) ran clean on both commits.

https://claude.ai/code/session_01Gg9szjD5ozRjAV6BMe7Eyx
