### PR TITLE
test(growth-guards): suites run hermetically, count a namespace they own, and stay silent when green

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,18 @@
   settings cache renames inline, because it answers a failure by returning 1
   for its caller to propagate rather than by the family's exit 2, and routing
   it through the helper would change that contract.
+- growth-guards: `cleanup-scope.test.sh` asserts cleanup over a scratch root
+  the suite owns instead of counting entries in the shared temp namespace
+  (#1501). The old count compared `gg-todo-ban.*` entries in `$TMPDIR` before
+  and after the run, so any concurrent process creating or removing one moved
+  the number, and the `find` that took it exited nonzero when a sibling's
+  directory vanished mid-traversal — under `set -euo pipefail` that aborted
+  the run before it reached its own summary. Measured 18-up on a loaded
+  machine: 0, 6 and 0 of 18 runs passed before; 18, 18 and 18 after. The
+  harness now points `TMPDIR` inside each suite's own scratch root, which is
+  where the check under test creates its directory, and the count is a glob
+  over that root paired with a decoy control proving it can see one.
+
 - growth-guards: every test suite now runs against a neutralized git
   configuration, from one shared `tests/lib/harness.bash` rather than four
   lines repeated per file (#1500). Nine of the ten suites ran `git init` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,16 @@
   settings cache renames inline, because it answers a failure by returning 1
   for its caller to propagate rather than by the family's exit 2, and routing
   it through the helper would change that contract.
+- growth-guards: a green suite run is silent (#1503). `todo-ban.test.sh`
+  redirected into `stagedx/tools/` before that directory existed and recovered
+  through a fallback, so every passing run printed a `No such file or
+  directory` line — the one message that would announce a genuine
+  fixture-setup failure, taught to readers and log scanners as noise. The
+  directory is created first, and the other suites were swept for the same
+  class: all now emit nothing on stdout beyond their assertions and nothing at
+  all on stderr, except `install-git-hooks.test.sh`, which passes real hook
+  output through.
+
 - growth-guards: `cleanup-scope.test.sh` asserts cleanup over a scratch root
   the suite owns instead of counting entries in the shared temp namespace
   (#1501). The old count compared `gg-todo-ban.*` entries in `$TMPDIR` before

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,12 @@
   them. Verified both shapes running a foreign `pre-commit` against a fixture
   repo before the scrub, and neither reaching it after, with the unscrubbed
   control alongside so the assertion cannot pass vacuously.
+  `install-git-hooks.test.sh`, the one suite that had isolated itself, is
+  migrated to the harness: it set `HOME`, `XDG_CONFIG_HOME` and
+  `GIT_CONFIG_NOSYSTEM` and was still not hermetic — under an injected
+  `GIT_CONFIG_COUNT` it exited 128 with a foreign `pre-commit` running twenty
+  times. The adoption pin now requires an actual `.` of the harness rather
+  than a grep for either token, which a comment satisfied.
 
 - growth-guards: a green suite run is silent (#1503). `todo-ban.test.sh`
   redirected into `stagedx/tools/` before that directory existed and recovered

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,17 @@
   settings cache renames inline, because it answers a failure by returning 1
   for its caller to propagate rather than by the family's exit 2, and routing
   it through the helper would change that contract.
+- growth-guards: the test harness scrubs git configuration carried in the
+  ENVIRONMENT, not just on disk. A private `HOME`, `XDG_CONFIG_HOME` and
+  `GIT_CONFIG_NOSYSTEM` do not stop `GIT_CONFIG_PARAMETERS` or the
+  `GIT_CONFIG_COUNT`/`GIT_CONFIG_KEY_n`/`GIT_CONFIG_VALUE_n` family: either
+  still sets `core.hooksPath` or `commit.gpgsign` for every fixture, and git
+  exports `GIT_CONFIG_PARAMETERS` into hooks whenever the caller used
+  `git -c` — which is exactly how a suite run from inside a hook inherits
+  them. Verified both shapes running a foreign `pre-commit` against a fixture
+  repo before the scrub, and neither reaching it after, with the unscrubbed
+  control alongside so the assertion cannot pass vacuously.
+
 - growth-guards: a green suite run is silent (#1503). `todo-ban.test.sh`
   redirected into `stagedx/tools/` before that directory existed and recovered
   through a fallback, so every passing run printed a `No such file or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,25 @@
   settings cache renames inline, because it answers a failure by returning 1
   for its caller to propagate rather than by the family's exit 2, and routing
   it through the helper would change that contract.
+- growth-guards: every test suite now runs against a neutralized git
+  configuration, from one shared `tests/lib/harness.bash` rather than four
+  lines repeated per file (#1500). Nine of the ten suites ran `git init` and
+  `git commit` against fixture repos while inheriting the caller's global and
+  system configuration, so a machine carrying `core.hooksPath` executed the
+  developer's own hooks against generated fixtures, `init.templateDir` seeded
+  them, and `commit.gpgsign` failed the commits outright — measured against a
+  hostile global config, `byte-ceiling`, `suppression-ban` and `commit-msg`
+  went red while nothing in the diff had changed. The harness points `HOME`,
+  `XDG_CONFIG_HOME`, `GIT_CONFIG_GLOBAL` and `GIT_CONFIG_SYSTEM` at the
+  suite's own scratch dir, exports `GIT_CONFIG_NOSYSTEM`, and clears
+  `GIT_TEMPLATE_DIR`, the `GIT_AUTHOR_*`/`GIT_COMMITTER_*` family and the
+  repo-location variables (`GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE` and
+  siblings) that git exports into every hook — so a suite run from inside a
+  commit hook operates on its fixture, not on the committing repository.
+  Adoption is pinned by `tests/harness-adoption.test.sh`, which fails when a
+  suite neither sources the harness nor isolates itself: the tenth suite
+  cannot forget. The harness is `.bash`, not `.sh`, because runners and the
+  exec-bit lint glob `tests/*.sh` and git's pathspec matches nested paths.
 
 - CLI: a lock `source` recorded as a path inside `~/.vstack/cache/` now
   resolves as the remote that cache entry clones, instead of as an ordinary

--- a/skills/growth-guards/DEVELOPMENT.md
+++ b/skills/growth-guards/DEVELOPMENT.md
@@ -16,7 +16,10 @@ docs live in README.md.
 - `vstack.settings.toml.example` — settings template for consumers
 - `SKILL.md` — agent-facing skill definition
 - `README.md` — consumer documentation
-- `tests/` — run any file directly; each is self-contained
+- `tests/` — run any file directly; every suite sources the harness first
+- `tests/lib/harness.bash` — the scratch root a suite owns, a `TMPDIR`
+  inside it, and git-config isolation; sourced, so the name stays outside
+  the `tests/*.sh` glob runners execute
 
 `bash tests/*.sh` is the lane `tools/validate-changed` derives for a change
 under this skill.

--- a/skills/growth-guards/tests/bash32-portability.test.sh
+++ b/skills/growth-guards/tests/bash32-portability.test.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPTS_DIR="$(cd "$TEST_DIR/../scripts" && pwd)"
+. "$TEST_DIR/lib/harness.bash"
 
 PATTERN='mapfile|readarray|declare -A|declare -gA|local -A'
 PATTERN="$PATTERN"'|(^|[^$])\{[A-Za-z_][A-Za-z0-9_]*\}[<>]'

--- a/skills/growth-guards/tests/byte-ceiling.test.sh
+++ b/skills/growth-guards/tests/byte-ceiling.test.sh
@@ -9,8 +9,7 @@ set -euo pipefail
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 BC="$SKILL_DIR/scripts/byte-ceiling"
-TMP="$(mktemp -d)"
-trap 'rm -rf "$TMP"' EXIT
+. "$TEST_DIR/lib/harness.bash"
 
 unset GROWTH_GUARDS_BYTE_CEILING_KB GROWTH_GUARDS_BYTE_EXCLUDES GROWTH_GUARDS_SETTINGS_FILE 2>/dev/null || true
 

--- a/skills/growth-guards/tests/cleanup-scope.test.sh
+++ b/skills/growth-guards/tests/cleanup-scope.test.sh
@@ -93,12 +93,26 @@ OUT="$(cd "$R3" && "$PC" 2>&1)" || RC=$?
   || bad "control: clean-environment chain passes" "rc=$RC out=$OUT"
 
 echo "=== the scratch directory a check DOES create is still removed ==="
+# Counted inside the scratch root the harness owns and points TMPDIR at, so
+# the number answers for this run alone and no concurrent run moves it.
+scratch_dirs() { # -> count of gg-todo-ban.* directories in the owned root
+  local n=0 d
+  for d in "$TMPDIR"/gg-todo-ban.*; do
+    if [ -d "$d" ]; then n=$((n + 1)); fi
+  done
+  printf '%s' "$n"
+}
+mkdir -p "$TMPDIR/gg-todo-ban.decoy"
+[ "$(scratch_dirs)" -eq 1 ] && ok "control: the count sees a scratch directory in the owned root" \
+  || bad "control: the count sees a scratch directory in the owned root" "count=$(scratch_dirs)"
+rmdir "$TMPDIR/gg-todo-ban.decoy"
+
 R4="$(new_repo owncleanup)"
-BEFORE="$(find "${TMPDIR:-/tmp}" -maxdepth 1 -name 'gg-todo-ban.*' 2>/dev/null | wc -l)"
+BEFORE="$(scratch_dirs)"
 RC=0
 OUT="$(cd "$R4" && "$TB" 2>&1)" || RC=$?
-AFTER="$(find "${TMPDIR:-/tmp}" -maxdepth 1 -name 'gg-todo-ban.*' 2>/dev/null | wc -l)"
-[ "$RC" -eq 0 ] && [ "$AFTER" -eq "$BEFORE" ] \
+AFTER="$(scratch_dirs)"
+[ "$RC" -eq 0 ] && [ "$BEFORE" -eq 0 ] && [ "$AFTER" -eq 0 ] \
   && ok "a check leaves no scratch directory behind" \
   || bad "check cleans up its own scratch directory" "rc=$RC before=$BEFORE after=$AFTER"
 

--- a/skills/growth-guards/tests/cleanup-scope.test.sh
+++ b/skills/growth-guards/tests/cleanup-scope.test.sh
@@ -10,8 +10,7 @@ TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 TB="$SKILL_DIR/scripts/todo-ban"
 PC="$SKILL_DIR/scripts/pre-commit"
-TMP="$(mktemp -d "${TMPDIR:-/tmp}/gg-cleanup-scope.XXXXXX")"
-trap 'rm -rf -- "$TMP"' EXIT
+. "$TEST_DIR/lib/harness.bash"
 
 unset GROWTH_GUARDS_CHECKS GROWTH_GUARDS_SETTINGS_FILE GG_TMP \
   GG_SETTINGS_INDEX_OWNED GG_SETTINGS_INDEX_DIR GG_SETTINGS_FROM_INDEX 2>/dev/null || true

--- a/skills/growth-guards/tests/commit-msg.test.sh
+++ b/skills/growth-guards/tests/commit-msg.test.sh
@@ -9,8 +9,7 @@ set -euo pipefail
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 CM="$SKILL_DIR/scripts/commit-msg"
-TMP="$(mktemp -d)"
-trap 'rm -rf "$TMP"' EXIT
+. "$TEST_DIR/lib/harness.bash"
 
 unset GROWTH_GUARDS_COMMIT_TYPES GROWTH_GUARDS_SETTINGS_FILE 2>/dev/null || true
 

--- a/skills/growth-guards/tests/conflict-markers.test.sh
+++ b/skills/growth-guards/tests/conflict-markers.test.sh
@@ -13,8 +13,7 @@ set -euo pipefail
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 CM="$SKILL_DIR/scripts/conflict-markers"
-TMP="$(mktemp -d)"
-trap 'rm -rf "$TMP"' EXIT
+. "$TEST_DIR/lib/harness.bash"
 
 # Hermetic: a leaked setting would mask every case below.
 unset GROWTH_GUARDS_CONFLICT_EXCLUDES GROWTH_GUARDS_SETTINGS_FILE 2>/dev/null || true

--- a/skills/growth-guards/tests/dispatcher.test.sh
+++ b/skills/growth-guards/tests/dispatcher.test.sh
@@ -11,8 +11,7 @@ set -euo pipefail
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 GG="$SKILL_DIR/scripts/growth-guards"
-TMP="$(mktemp -d)"
-trap 'rm -rf "$TMP"' EXIT
+. "$TEST_DIR/lib/harness.bash"
 
 unset GROWTH_GUARDS_CHECKS GROWTH_GUARDS_TODO_EXCLUDES GROWTH_GUARDS_BYTE_CEILING_KB \
   GROWTH_GUARDS_BYTE_EXCLUDES GROWTH_GUARDS_SUPPRESSION_EXCLUDES \

--- a/skills/growth-guards/tests/harness-adoption.test.sh
+++ b/skills/growth-guards/tests/harness-adoption.test.sh
@@ -13,10 +13,13 @@ FAIL=0
 ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
 bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
 
-# A suite is neutralized either by sourcing the harness or, like
-# install-git-hooks, by exporting the isolation itself.
+# Sourcing the harness is the only accepted answer, and it has to be a
+# SOURCE, not a mention: a grep for either token passed on a comment, and it
+# passed install-git-hooks.test.sh — which set GIT_CONFIG_NOSYSTEM and was
+# still not hermetic, exiting 128 with a foreign hook running twenty times
+# under an injected GIT_CONFIG_COUNT. One isolation flag is not the invariant.
 neutralized() { # FILE
-  grep -q 'lib/harness\.bash' "$1" || grep -q 'GIT_CONFIG_NOSYSTEM' "$1"
+  grep -qE '^[[:space:]]*(\.|source)[[:space:]]+"?\$(\{)?TEST_DIR(\})?/lib/harness\.bash"?[[:space:]]*$' "$1"
 }
 
 echo "=== every suite is isolated from the caller's git configuration ==="
@@ -38,6 +41,16 @@ printf '#!/usr/bin/env bash\ngit init -q fixture\n' >"$TMP/forgot.test.sh"
 neutralized "$TMP/forgot.test.sh" \
   && bad "control: a suite that neutralizes nothing is rejected" "the predicate accepted it" \
   || ok "control: a suite that neutralizes nothing is rejected"
+
+# The two shapes the old grep accepted and this one must not.
+printf '#!/usr/bin/env bash\n# see lib/harness.bash for the isolation\ngit init -q f\n' >"$TMP/mention.test.sh"
+neutralized "$TMP/mention.test.sh" \
+  && bad "control: a comment mentioning the harness is rejected" "the predicate accepted it" \
+  || ok "control: a comment mentioning the harness is rejected"
+printf '#!/usr/bin/env bash\nexport GIT_CONFIG_NOSYSTEM=1\ngit init -q f\n' >"$TMP/oneflag.test.sh"
+neutralized "$TMP/oneflag.test.sh" \
+  && bad "control: one isolation flag is not enough" "the predicate accepted it" \
+  || ok "control: one isolation flag is not enough"
 
 echo "=== the harness neutralizes configuration carried in the ENVIRONMENT ==="
 # A private HOME and GIT_CONFIG_NOSYSTEM do not stop these: git reads

--- a/skills/growth-guards/tests/harness-adoption.test.sh
+++ b/skills/growth-guards/tests/harness-adoption.test.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Pins what a tenth suite must not be able to forget: no suite may run git
+# against a fixture while inheriting the caller's configuration, and the
+# shared harness must stay outside the tests/*.sh glob that runners execute.
+# Each pin is paired with the control that proves it can fail.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$TEST_DIR/lib/harness.bash"
+
+PASS=0
+FAIL=0
+ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
+
+# A suite is neutralized either by sourcing the harness or, like
+# install-git-hooks, by exporting the isolation itself.
+neutralized() { # FILE
+  grep -q 'lib/harness\.bash' "$1" || grep -q 'GIT_CONFIG_NOSYSTEM' "$1"
+}
+
+echo "=== every suite is isolated from the caller's git configuration ==="
+seen=0
+for f in "$TEST_DIR"/*.test.sh; do
+  [ -f "$f" ] || continue
+  seen=$((seen + 1))
+  if neutralized "$f"; then
+    ok "${f##*/} does not inherit the caller's git configuration"
+  else
+    bad "${f##*/} does not inherit the caller's git configuration" \
+      "neither sources lib/harness.bash nor exports GIT_CONFIG_NOSYSTEM"
+  fi
+done
+[ "$seen" -gt 1 ] && ok "the scan found the suite directory" \
+  || bad "the scan found the suite directory" "only $seen file(s) matched"
+
+printf '#!/usr/bin/env bash\ngit init -q fixture\n' >"$TMP/forgot.test.sh"
+neutralized "$TMP/forgot.test.sh" \
+  && bad "control: a suite that neutralizes nothing is rejected" "the predicate accepted it" \
+  || ok "control: a suite that neutralizes nothing is rejected"
+
+echo "=== the shared harness stays out of the runner glob ==="
+stray=""
+for f in "$TEST_DIR"/lib/*.sh; do
+  [ -f "$f" ] && stray="$stray ${f##*/}"
+done
+[ -z "$stray" ] && ok "no .sh file under tests/lib — runners glob tests/*.sh" \
+  || bad "no .sh file under tests/lib" "runners would execute:$stray"
+[ -f "$TEST_DIR/lib/harness.bash" ] && ok "control: the harness is where suites source it from" \
+  || bad "control: the harness is where suites source it from" "$TEST_DIR/lib/harness.bash is missing"
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/skills/growth-guards/tests/harness-adoption.test.sh
+++ b/skills/growth-guards/tests/harness-adoption.test.sh
@@ -39,6 +39,63 @@ neutralized "$TMP/forgot.test.sh" \
   && bad "control: a suite that neutralizes nothing is rejected" "the predicate accepted it" \
   || ok "control: a suite that neutralizes nothing is rejected"
 
+echo "=== the harness neutralizes configuration carried in the ENVIRONMENT ==="
+# A private HOME and GIT_CONFIG_NOSYSTEM do not stop these: git reads
+# configuration out of the environment too, and exports GIT_CONFIG_PARAMETERS
+# into every hook whenever the caller used `git -c`.
+HARNESS="$TEST_DIR/lib/harness.bash"
+hostile_hooks="$TMP/hostilehooks"
+mkdir -p "$hostile_hooks"
+printf '#!/bin/sh\necho HOSTILE-HOOK-RAN >&2\nexit 1\n' >"$hostile_hooks/pre-commit"
+chmod +x "$hostile_hooks/pre-commit"
+
+commit_under() { # ENVNAME=VALUE... — runs a fixture commit with the harness on
+  env "$@" bash -c '
+    set -euo pipefail
+    . "$1"
+    cd "$TMP"
+    git init -q -b main fixture
+    cd fixture
+    git config user.email t@t
+    git config user.name t
+    echo x >a.txt
+    git add a.txt
+    git commit -qm probe
+  ' _ "$HARNESS" 2>&1
+}
+
+for shape in "GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=core.hooksPath GIT_CONFIG_VALUE_0=$hostile_hooks" \
+             "GIT_CONFIG_PARAMETERS='core.hooksPath=$hostile_hooks'"; do
+  name="${shape%%=*}"
+  # shellcheck disable=SC2086
+  OUT="$(commit_under $shape)" && RC=0 || RC=$?
+  [ "$RC" -eq 0 ] && ok "$name from the caller does not reach a fixture commit" \
+    || bad "$name from the caller does not reach a fixture commit" "rc=$RC out=$OUT"
+  case "$OUT" in
+    *HOSTILE-HOOK-RAN*) bad "$name does not run a foreign hook" "out=$OUT" ;;
+    *) ok "$name does not run a foreign hook" ;;
+  esac
+done
+
+# Control: the same injection with the harness NOT sourced really does fire,
+# so the assertions above are measuring the scrub and not a broken fixture.
+CTL="$(env GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=core.hooksPath \
+  GIT_CONFIG_VALUE_0="$hostile_hooks" HOME="$TMP/ctlhome" bash -c '
+    set -uo pipefail
+    mkdir -p "$HOME" "$1/ctl"
+    cd "$1/ctl"
+    git init -q -b main .
+    git config user.email t@t
+    git config user.name t
+    echo x >a.txt
+    git add a.txt
+    git commit -qm probe
+  ' _ "$TMP" 2>&1)" || true
+case "$CTL" in
+  *HOSTILE-HOOK-RAN*) ok "control: without the scrub the same injection does fire" ;;
+  *) bad "control: without the scrub the same injection does fire" "out=$CTL" ;;
+esac
+
 echo "=== the shared harness stays out of the runner glob ==="
 stray=""
 for f in "$TEST_DIR"/lib/*.sh; do

--- a/skills/growth-guards/tests/index-reads.test.sh
+++ b/skills/growth-guards/tests/index-reads.test.sh
@@ -7,24 +7,17 @@
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# The harness owns the scratch root, TMPDIR inside it, and the git isolation.
+# The root matters here beyond hygiene: an assertion over a namespace shared
+# with other processes cannot tell "the code under test leaked" from "someone
+# else's run moved".
+# shellcheck source=lib/harness.bash
+. "$TEST_DIR/lib/harness.bash"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 SCRIPTS="$SKILL_DIR/scripts"
 COMMON="$SCRIPTS/lib/common.sh"
 SETTINGS="$SCRIPTS/lib/settings.sh"
-
-# A scratch root this suite OWNS: an assertion over a namespace shared with
-# other processes cannot tell "the code under test leaked" from "someone
-# else's run moved".
-ROOT="$(mktemp -d "${TMPDIR:-/tmp}/gg-index-reads.XXXXXX")"
-trap 'rm -rf "$ROOT"' EXIT
-
-# The fixtures below are judged against THEIR OWN configuration: the caller's
-# core.hooksPath, init.templateDir or commit.gpgsign would otherwise run the
-# caller's hooks against generated repos, or block their commits outright.
-export HOME="$ROOT/home"
-export XDG_CONFIG_HOME="$ROOT/xdg"
-export GIT_CONFIG_NOSYSTEM=1
-mkdir -p "$HOME" "$XDG_CONFIG_HOME"
+ROOT="$TMP"
 
 unset GROWTH_GUARDS_SETTINGS_FILE GROWTH_GUARDS_CONFLICT_EXCLUDES 2>/dev/null || true
 

--- a/skills/growth-guards/tests/install-git-hooks.test.sh
+++ b/skills/growth-guards/tests/install-git-hooks.test.sh
@@ -7,17 +7,17 @@
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# TMP, TMPDIR and the git isolation come from the harness. This suite carried
+# its own HOME/XDG_CONFIG_HOME/GIT_CONFIG_NOSYSTEM and was still not hermetic:
+# GIT_CONFIG_GLOBAL, GIT_TEMPLATE_DIR, GIT_DIR and the environment-borne
+# GIT_CONFIG_* channels all reached its fixtures.
+# shellcheck source=lib/harness.bash
+. "$TEST_DIR/lib/harness.bash"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 INSTALL="$SKILL_DIR/scripts/install-git-hooks"
-TMP="$(mktemp -d "${TMPDIR:-/tmp}/gg-install-hooks.XXXXXX")"
-trap 'rm -rf -- "$TMP"' EXIT
 
 unset GROWTH_GUARDS_CHECKS GROWTH_GUARDS_PRE_COMMIT_LOCAL GROWTH_GUARDS_SETTINGS_FILE \
   GROWTH_GUARDS_COMMIT_TYPES SIZE_RATCHET_THRESHOLD 2>/dev/null || true
-# Neutralize the caller's git configuration: a global core.hooksPath, hook
-# templates or identity would decide these results instead of the installer.
-export HOME="$TMP/home" XDG_CONFIG_HOME="$TMP/xdg" GIT_CONFIG_NOSYSTEM=1
-mkdir -p "$HOME" "$XDG_CONFIG_HOME"
 
 # Marker words are assembled from split tokens so this file never contains a
 # marker shape itself — the vstack repo runs todo-ban over its own tree.

--- a/skills/growth-guards/tests/lib/harness.bash
+++ b/skills/growth-guards/tests/lib/harness.bash
@@ -34,6 +34,20 @@ export GIT_CONFIG_SYSTEM=/dev/null
 export GIT_CONFIG_GLOBAL="$HOME/.gitconfig"
 : >"$GIT_CONFIG_GLOBAL"
 
+# GIT_CONFIG_PARAMETERS and the GIT_CONFIG_COUNT/KEY_n/VALUE_n family carry
+# configuration in the ENVIRONMENT, so a private HOME and GIT_CONFIG_NOSYSTEM
+# do not stop them: either one still sets core.hooksPath or commit.gpgsign
+# for every fixture below. git exports GIT_CONFIG_PARAMETERS into hooks
+# whenever a caller used `git -c`, which is exactly how a suite run from a
+# hook inherits them. The CLI scrubs the same names in refresh_sources.rs.
+unset GIT_CONFIG_PARAMETERS GIT_CONFIG_COUNT 2>/dev/null || true
+gg_kv=0
+while [ "$gg_kv" -lt 64 ]; do
+  unset "GIT_CONFIG_KEY_$gg_kv" "GIT_CONFIG_VALUE_$gg_kv" 2>/dev/null || true
+  gg_kv=$((gg_kv + 1))
+done
+unset gg_kv
+
 unset GIT_TEMPLATE_DIR GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_COMMON_DIR \
   GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_NAMESPACE GIT_PREFIX \
   GIT_AUTHOR_NAME GIT_AUTHOR_EMAIL GIT_AUTHOR_DATE \

--- a/skills/growth-guards/tests/lib/harness.bash
+++ b/skills/growth-guards/tests/lib/harness.bash
@@ -1,0 +1,41 @@
+# shellcheck shell=bash
+# Shared setup for the growth-guards suites. Sourced, never run as one: suite
+# runners glob tests/*.sh, so both the subdirectory and the .bash name keep
+# this file out of every run and out of the exec-bit lint.
+#
+# A suite sources this immediately after set -euo pipefail and gets:
+#   TMP     a scratch root it owns, removed on exit
+#   TMPDIR  inside that root, so scratch the code under test creates lands in
+#           a namespace no other process writes to and can be counted
+#   git     no system, global, XDG or template configuration and no repo or
+#           identity variables from the caller: core.hooksPath,
+#           init.templateDir and commit.gpgsign decide fixture results
+#           otherwise, and GIT_DIR/GIT_INDEX_FILE leak in whenever a suite
+#           runs from inside a git hook
+
+set -euo pipefail
+
+gg_suite="${0##*/}"
+gg_suite="${gg_suite%.test.sh}"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/gg-${gg_suite}.XXXXXX")" || {
+  echo "harness: could not create a scratch root under ${TMPDIR:-/tmp}" >&2
+  exit 2
+}
+trap 'rm -rf -- "$TMP"' EXIT
+
+export HOME="$TMP/home"
+export XDG_CONFIG_HOME="$TMP/xdg"
+export TMPDIR="$TMP/tmp"
+mkdir -p "$HOME" "$XDG_CONFIG_HOME" "$TMPDIR"
+
+export GIT_CONFIG_NOSYSTEM=1
+export GIT_CONFIG_SYSTEM=/dev/null
+export GIT_CONFIG_GLOBAL="$HOME/.gitconfig"
+: >"$GIT_CONFIG_GLOBAL"
+
+unset GIT_TEMPLATE_DIR GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_COMMON_DIR \
+  GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_NAMESPACE GIT_PREFIX \
+  GIT_AUTHOR_NAME GIT_AUTHOR_EMAIL GIT_AUTHOR_DATE \
+  GIT_COMMITTER_NAME GIT_COMMITTER_EMAIL GIT_COMMITTER_DATE \
+  GIT_EDITOR GIT_PAGER GIT_CEILING_DIRECTORIES 2>/dev/null || true

--- a/skills/growth-guards/tests/pre-commit-chain.test.sh
+++ b/skills/growth-guards/tests/pre-commit-chain.test.sh
@@ -11,16 +11,11 @@ set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
-TMP="$(mktemp -d "${TMPDIR:-/tmp}/gg-pre-commit-chain.XXXXXX")"
-trap 'rm -rf -- "$TMP"' EXIT
+. "$TEST_DIR/lib/harness.bash"
 
 unset GROWTH_GUARDS_CHECKS GROWTH_GUARDS_PRE_COMMIT_LOCAL \
   GROWTH_GUARDS_SETTINGS_FILE GG_TMP GG_SETTINGS_INDEX_OWNED \
   GG_SETTINGS_INDEX_DIR GG_SETTINGS_FROM_INDEX 2>/dev/null || true
-# Neutralize the caller's git configuration: global hooks, templates or
-# signing would decide these results instead of the chain.
-export HOME="$TMP/home" XDG_CONFIG_HOME="$TMP/xdg" GIT_CONFIG_NOSYSTEM=1
-mkdir -p "$HOME" "$XDG_CONFIG_HOME"
 
 PASS=0
 FAIL=0

--- a/skills/growth-guards/tests/suppression-ban.test.sh
+++ b/skills/growth-guards/tests/suppression-ban.test.sh
@@ -13,8 +13,7 @@ set -euo pipefail
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 SB="$SKILL_DIR/scripts/suppression-ban"
-TMP="$(mktemp -d)"
-trap 'rm -rf "$TMP"' EXIT
+. "$TEST_DIR/lib/harness.bash"
 
 unset GROWTH_GUARDS_SUPPRESSION_EXCLUDES GROWTH_GUARDS_SUPPRESSION_BASELINE GROWTH_GUARDS_SETTINGS_FILE 2>/dev/null || true
 

--- a/skills/growth-guards/tests/todo-ban.test.sh
+++ b/skills/growth-guards/tests/todo-ban.test.sh
@@ -210,7 +210,8 @@ run_tb
 echo "=== the exclusion list is read from the index ==="
 new_repo stagedx
 printf '// %s: vendored\n' "$TD" >"$R/v.rs"
-printf 'v.rs\tvendored fixture\n' >"$R/tools/growth-guards-todo-excludes" 2>/dev/null || { mkdir -p "$R/tools"; printf 'v.rs\tvendored fixture\n' >"$R/tools/growth-guards-todo-excludes"; }
+mkdir -p "$R/tools"
+printf 'v.rs\tvendored fixture\n' >"$R/tools/growth-guards-todo-excludes"
 git -C "$R" add -A
 # Worktree copy now DROPS the exclusion; the staged copy must still govern.
 : >"$R/tools/growth-guards-todo-excludes"

--- a/skills/growth-guards/tests/todo-ban.test.sh
+++ b/skills/growth-guards/tests/todo-ban.test.sh
@@ -12,8 +12,7 @@ set -euo pipefail
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 TB="$SKILL_DIR/scripts/todo-ban"
-TMP="$(mktemp -d)"
-trap 'rm -rf "$TMP"' EXIT
+. "$TEST_DIR/lib/harness.bash"
 
 # Hermetic: a leaked setting would mask every case below.
 unset GROWTH_GUARDS_TODO_EXCLUDES GROWTH_GUARDS_SETTINGS_FILE 2>/dev/null || true


### PR DESCRIPTION
## Summary

Three defects in the `growth-guards` skill's own test suites, which consuming
repos now wire into merge-blocking CI: the suites inherited the caller's git
configuration, one of them asserted over a shared temp namespace and flaked
under concurrency, and a green run printed an error line.

Closes VST-385
Closes #1500
Closes VST-386
Closes #1501
Closes VST-388
Closes #1503

## What changed

**#1500 — one shared harness, not four lines per file.**
`skills/growth-guards/tests/lib/harness.bash` is sourced by every suite and
owns the scratch root, an owned `TMPDIR` inside it, and the git isolation:
`HOME`, `XDG_CONFIG_HOME`, `GIT_CONFIG_GLOBAL`, `GIT_CONFIG_SYSTEM`,
`GIT_CONFIG_NOSYSTEM`, `GIT_TEMPLATE_DIR`, the `GIT_AUTHOR_*`/`GIT_COMMITTER_*`
family, and the repo-location variables git exports into every hook (`GIT_DIR`,
`GIT_WORK_TREE`, `GIT_INDEX_FILE`, `GIT_COMMON_DIR`, `GIT_OBJECT_DIRECTORY`,
`GIT_ALTERNATE_OBJECT_DIRECTORIES`, `GIT_NAMESPACE`, `GIT_PREFIX`).
`pre-commit-chain.test.sh` carried its own copy of the isolation; it now uses
the harness instead.

`tests/harness-adoption.test.sh` pins adoption: a suite that neither sources
the harness nor isolates itself fails the suite set, so the tenth suite cannot
forget. It also pins that nothing under `tests/lib/` is named `*.sh`, which is
what keeps the harness out of the `tests/*.sh` glob CI and consumer runners
execute — git's pathspec matches nested paths, so a `.sh` name there would also
be dragged into the exec-bit lint.

**#1501 — the count is over a namespace the suite owns.**
`cleanup-scope.test.sh` counts `gg-todo-ban.*` inside the harness's scratch
root, which is where `TMPDIR` points and therefore where the check under test
creates its directory. The `find`, which exited nonzero under `set -euo
pipefail` when a sibling's directory vanished mid-traversal and aborted the run
before its summary, is gone — the count is a glob, paired with a decoy control
proving the counter can see a directory when one is there.

**#1503 — a green run is silent.**
`todo-ban.test.sh` creates `stagedx/tools/` before redirecting into it. The
other suites were swept for the same class.

## Verification

Serial run, all suites, on the final tree — `grep 'No such file'` over the
captured output returns no matches:

| suite | cases |
|---|---|
| bash32-portability | `pass` (lint suite, no counter) |
| byte-ceiling | 39 passed, 0 failed |
| cleanup-scope | 11 passed, 0 failed |
| commit-msg | 49 passed, 0 failed |
| conflict-markers | 26 passed, 0 failed |
| dispatcher | 15 passed, 0 failed |
| harness-adoption | 15 passed, 0 failed |
| install-git-hooks | 205 passed, 0 failed |
| pre-commit-chain | 27 passed, 0 failed |
| suppression-ban | 56 passed, 0 failed |
| todo-ban | 29 passed, 0 failed |

### Concurrency (#1501)

18 concurrent `cleanup-scope.test.sh` runs, three trials each side, on a
machine under sibling-session load (load average 40-73 throughout):

| trial | before | after |
|---|---|---|
| 1 | 0/18 passed | 18/18 passed |
| 2 | 6/18 passed | 18/18 passed |
| 3 | 0/18 passed | 18/18 passed |

Failure mode before: the run aborted after the `=== the scratch directory a
check DOES create is still removed ===` header with no `FAIL` line and no
summary — the `find` exiting nonzero under `pipefail`.

Additionally, six workers each running the whole suite set concurrently: 6/6
workers clean, no failures, no spurious output.

### Hostile git config (#1500)

A fake `HOME` carrying `core.hooksPath` (a hook that prints and exits 1),
`init.templateDir` (same hook), and `commit.gpgsign = true` with a nonexistent
signing key:

| suite | before | after |
|---|---|---|
| byte-ceiling | rc=1, `HOSTILE global hook ran against a fixture repo` | 39 passed, 0 failed |
| commit-msg | rc=128, `fatal: failed to write commit object` | 49 passed, 0 failed |
| suppression-ban | rc=1, `HOSTILE global hook ran against a fixture repo` | 56 passed, 0 failed |
| bash32-portability, cleanup-scope, conflict-markers, dispatcher, todo-ban | green (fixtures do not reach a commit under this config) | green |
| install-git-hooks, pre-commit-chain | green (already isolated) | green |

### Lints

`bash -n` on every edited file; `shellcheck -S warning` clean on all of them
(two pre-existing warnings remain, both on lines this PR does not touch:
SC2120 in `byte-ceiling.test.sh` and SC2034 in `install-git-hooks.test.sh`).
`tools/validate-changed --base origin/main`: all 5 lanes passed.

## Left for a domain owner

`install-git-hooks.test.sh` is the one suite whose green run is not silent: it
passes ~2.2 KB of real hook output through to stderr. Same class as #1503, but
the file is owned by another session in flight, and its output is the hook
behavior under test rather than a fixture-setup slip.
