### PR TITLE
fix(growth-guards): install corrects a stale shebang in a hook it wrote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,13 @@
 
 ### Fixed
 
+- growth-guards: `install-git-hooks` corrects a stale shebang in a hook it
+  wrote itself rather than refusing it. Older versions emitted
+  `#!/usr/bin/env bash`, which the new trusted-interpreter rule cannot vouch
+  for, so a working install reported `NOT installed` on refresh and drift on
+  `vstack check` while still gating every commit. A hook the CONSUMER wrote is
+  still refused and left untouched.
+
 - cli: a lock `source` inside `~/.vstack/cache/` resolves as the remote that
   entry clones, not as a local checkout. Every freshness mechanism had been
   skipped at once while each command still reported success (#1495).

--- a/skills/growth-guards/scripts/install-git-hooks
+++ b/skills/growth-guards/scripts/install-git-hooks
@@ -305,11 +305,13 @@ install_hook() { # HOOK
     hook_warn "$path is not a POSIX-shell script; not modifying it — the $hook guard is NOT installed"
     return 0
   fi
-  # The SAME predicate --check applies. Installing under a shebang the check
-  # cannot vouch for would report a successful install that the very next
-  # `vstack check` calls unverifiable, so the guard is not inserted at all
-  # and the reason says which interpreter to use.
-  if ! gg_trusted_interpreter "$(head -n 1 "$path")"; then
+  # The SAME predicate --check applies, so an install cannot report success
+  # that the next `vstack check` calls unverifiable. A hook THIS INSTALLER
+  # WROTE is ours to correct rather than refuse: older versions emitted
+  # `#!/usr/bin/env bash`, and refusing there would strand a working install
+  # reporting NOT installed forever. Its shebang is rewritten below.
+  if ! gg_trusted_interpreter "$(head -n 1 "$path")" \
+    && ! grep -qF -- "$CREATED_MARKER" "$path" 2>/dev/null; then
     hook_warn "$path runs under an interpreter that cannot be verified ($(head -n 1 "$path")); not modifying it — the $hook guard is NOT installed. Use a #! naming a shell in /bin or /usr/bin directly."
     return 0
   fi
@@ -317,7 +319,10 @@ install_hook() { # HOOK
   # after the shebang. Content alone is not enough: a line that was commented
   # out, truncated, left by an older version, or moved below hook content that
   # exits is not an install, and each is rewritten rather than trusted.
-  if [ "$(sed -n '2p' "$path")" = "$line" ]; then
+  # The delegate being current is not enough when the SHEBANG is stale: the
+  # fast path would return before the rewrite that corrects it, leaving a
+  # working install reporting unverifiable forever.
+  if [ "$(sed -n '2p' "$path")" = "$line" ] && gg_trusted_interpreter "$(head -n 1 "$path")"; then
     ensure_hook_executable "$hook" "$path"
     return 0
   fi
@@ -358,8 +363,15 @@ install_hook() { # HOOK
   # The shebang is re-emitted TERMINATED even when the original file ended at
   # it, or the delegate would run onto the interpreter line. A shebang cannot
   # contain a newline, so the command substitution is lossless.
+  # A file this installer created carries OUR shebang, so an untrusted one is
+  # a stale spelling from an older version and is corrected here. A file the
+  # consumer wrote keeps its own — it reached this point only by being
+  # trusted already.
   local shebang=""
   shebang="$(head -n 1 "$path")"
+  if [ "$created" -eq 1 ] && ! gg_trusted_interpreter "$shebang"; then
+    shebang="#!/bin/sh"
+  fi
   if ! cp -p -- "$path" "$tmp" 2>/dev/null || ! {
     printf '%s\n' "$shebang"
     printf '%s\n' "$line"

--- a/skills/growth-guards/tests/install-git-hooks.test.sh
+++ b/skills/growth-guards/tests/install-git-hooks.test.sh
@@ -1656,6 +1656,44 @@ check_in "$R38"
 [ "$RC" -eq 1 ] && ok "must-fail: the delegating line without its helper is not armed" \
   || bad "delegating line without helper" "rc=$RC out=$OUT"
 
+echo "=== install corrects a stale shebang in a hook IT wrote ==="
+# Older versions of this installer emitted `#!/usr/bin/env bash`. Refusing
+# there strands a working install reporting NOT installed forever, so a file
+# carrying the created-marker is corrected rather than refused.
+R44="$(new_repo installstaleshebang)"
+install_in "$R44"
+# Exactly the drovr shape: the file this installer wrote, with only its
+# shebang reverted to what an older version emitted.
+{
+  printf '#!/usr/bin/env bash\n'
+  tail -n +2 "$R44/.git/hooks/pre-commit"
+} >"$TMP/stale" && mv "$TMP/stale" "$R44/.git/hooks/pre-commit"
+chmod +x "$R44/.git/hooks/pre-commit"
+grep -qF -- "vstack_gg_h" "$R44/.git/hooks/pre-commit" \
+  && ok "the fixture really carries the guard line under the stale shebang" \
+  || bad "stale fixture carries the guard line" "$(sed -n '2p' "$R44/.git/hooks/pre-commit")"
+check_in "$R44"
+[ "$RC" -eq 2 ] && ok "and it reads as unverifiable before the fix" \
+  || bad "stale fixture unverifiable first" "rc=$RC out=$OUT"
+install_in "$R44"
+[ "$(head -n 1 "$R44/.git/hooks/pre-commit")" = "#!/bin/sh" ] \
+  && ok "a hook this installer wrote has its stale shebang corrected" \
+  || bad "stale shebang corrected" "line1=$(head -n 1 "$R44/.git/hooks/pre-commit")"
+check_in "$R44"
+[ "$RC" -eq 0 ] && ok "and it checks armed afterwards" \
+  || bad "corrected hook checks armed" "rc=$RC out=$OUT"
+
+# Control: a hook the CONSUMER wrote is still refused and left untouched.
+printf '#!/usr/bin/env bash\necho mine\n' >"$R44/.git/hooks/commit-msg"
+chmod +x "$R44/.git/hooks/commit-msg"
+install_in "$R44"
+[ "$(sed -n '2p' "$R44/.git/hooks/commit-msg")" = "echo mine" ] \
+  && ok "control: a consumer's own hook is refused, not rewritten" \
+  || bad "consumer hook untouched" "line2=$(sed -n '2p' "$R44/.git/hooks/commit-msg")"
+[ "$(head -n 1 "$R44/.git/hooks/commit-msg")" = "#!/usr/bin/env bash" ] \
+  && ok "and its shebang is left alone" \
+  || bad "consumer shebang untouched" "line1=$(head -n 1 "$R44/.git/hooks/commit-msg")"
+
 echo "=== install refuses what --check could not vouch for ==="
 # Installing under a shebang the check calls unverifiable would report a
 # successful install that the very next `vstack check` contradicts.

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -106,8 +106,8 @@ skills/github/scripts/lib/gh-auth.sh	479
 skills/github/scripts/lib/github-api.sh	872
 skills/github/scripts/lib/verify-lib.sh	415
 skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh	2128
-skills/growth-guards/scripts/install-git-hooks	1080
-skills/growth-guards/tests/install-git-hooks.test.sh	1861
+skills/growth-guards/scripts/install-git-hooks	1092
+skills/growth-guards/tests/install-git-hooks.test.sh	1899
 skills/iced-rs/examples/README.md	122
 skills/iced-rs/examples/changelog/src/changelog.rs	418
 skills/iced-rs/examples/color_palette/src/main.rs	479


### PR DESCRIPTION
## Summary

Found while rolling #1512 out to consumers: drovr's install now reports itself broken while working perfectly.

vstack#1512 made `--check` refuse an interpreter it cannot vouch for, and made `install` refuse to wire a hook under one, so the two agree. What neither of us checked is that **older versions of this installer emitted `#!/usr/bin/env bash`** — so the hook drovr is running was written by this tool, carries the guard line, gates every commit, and is now unverifiable.

Observed in drovr immediately after `vstack refresh`:

```
+ growth-guards git hooks: not installed — …/pre-commit runs under an interpreter
  that cannot be verified (#!/usr/bin/env bash) … the pre-commit guard is NOT installed
$ install-git-hooks --check   -> exit 2, "could not vouch for"
$ vstack check                 -> exit 1 (drift)
$ git commit  (work-marker violation staged)
  -> blocked. It gates. It has been gating the whole time.
```

## What changed

- A hook carrying this installer's created-marker is CORRECTED rather than refused: its shebang is rewritten to `#!/bin/sh`. A hook the consumer wrote is still refused and left byte-for-byte untouched.
- The already-current fast path now also requires a trusted shebang. Without that it returned before the rewrite — the delegate was current, so nothing looked wrong, and the correction never ran.

## Verification

The second half is the part worth reading. My first fixture built the stale hook by hand and PASSED against the unfixed code, because its guard line differed slightly from the real one and so missed the fast path. Rebuilt to reproduce drovr exactly — install normally, then revert only line 1 — it failed, which is what exposed the fast-path half of the bug.

The fixture now asserts it really carries the guard line and really reads unverifiable before the fix, so it cannot pass vacuously again.

`install-git-hooks.test.sh` 342 passed / 0 failed; all eleven other growth-guards suites green.

## Consumer impact

drovr is the only repo affected — the other four write `#!/bin/sh`. It is gated throughout; only the reported verdict was wrong. One `vstack refresh` after this merges corrects the shebang in place.
