### PR TITLE
fix(install): unwritable system bin dir falls back to sudo again

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -63,7 +63,10 @@ install_cli() {
   echo "Downloading the kendex command ($target)…"
   curl -fSL --proto '=https' -o "$tmp/kendex" "$base/kendex-$target"
   chmod +x "$tmp/kendex"
-  if [ -w "$bindir" ] || mkdir -p "$bindir" 2>/dev/null; then
+  # mkdir -p exits 0 on a directory that already exists, writable or not,
+  # so create-if-missing first and let writability alone pick the branch.
+  [ -d "$bindir" ] || mkdir -p "$bindir" 2>/dev/null || true
+  if [ -w "$bindir" ]; then
     install -m 0755 "$tmp/kendex" "$bindir/kendex"
   else
     echo "Installing to $bindir needs elevated permissions."


### PR DESCRIPTION
**What a user hit:** on a Linux box whose PATH lacks `~/.local/bin`, `curl kendex.ai/install.sh | sh` (no sudo) died with `install: cannot create regular file '/usr/local/bin/kendex': Permission denied` instead of offering the sudo path.

**Why:** the branch test was `[ -w $bindir ] || mkdir -p $bindir` — and `mkdir -p` exits 0 on an existing directory regardless of writability, so the non-sudo branch always won for `/usr/local/bin`.

Reproduced in a sandbox, fixed, re-tested end to end against the published v5.0.1 assets (CLI installs; sudo branch reachable).

https://claude.ai/code/session_01Jx2yfoaodk4rDpdWDqgoMk