### PR TITLE
fix(pi-agents-tmux): launcher version rides the template change

### DIFF
--- a/pi-extensions/pi-agents-tmux/CHANGELOG.md
+++ b/pi-extensions/pi-agents-tmux/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Consumer-impacting changes
 
+### 2.8.8
+
+- `PANE_LAUNCHER_VERSION` bumped 10 → 11: the launcher template changed
+  without the bump that recycles running panes, so live persistent panes
+  recorded at version 10 were still on the older launcher. On upgrade each
+  such pane is killed and relaunched once so it picks up the current
+  template. The pinning test caught this on its first CI run after the
+  suites returned.
+
 ### 2.8.7
 
 - The completion poller no longer re-reads terminal transcripts on every tick (kendex#1453). Transcript fingerprints (size + mtime) were cached only when a usage parse both succeeded and persisted, so any terminal task whose usage failed to persist — or whose summary backfill kept coming up empty — had its whole transcript re-read every 2s for the life of the session; a 17h session with 22 tasks and 70MB of transcripts sat at ~30% CPU and ~20MB/s of reads while idle, with visible TUI input lag. Both poll paths now key the cache on the ATTEMPT: a terminal transcript is parsed once, and again only when its bytes change. The one-shot completion-event and session-restore paths still fingerprint on success, so a transcript whose registry write lost a lock race keeps one poll-loop retry.

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/types.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/types.ts
@@ -16,7 +16,7 @@ export const COLLAPSED_ITEM_COUNT = 10;
 // version, so a stale constant leaves running panes on the previous launcher
 // (kendex#192 shipped the depth-guard/entry exports this way). A pinning test
 // in tests/pi-invocation.test.ts ties this constant to the template text.
-export const PANE_LAUNCHER_VERSION = 10;
+export const PANE_LAUNCHER_VERSION = 11;
 export const SUBAGENT_WIDGET_KEY = "kendex-agents-dashboard";
 export const FIRST_AGENT_COLUMN_ROWS = 3;
 export const NEXT_AGENT_COLUMN_ROWS = 4;

--- a/pi-extensions/pi-agents-tmux/package.json
+++ b/pi-extensions/pi-agents-tmux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vanillagreen/pi-agents-tmux",
-  "version": "2.8.7",
+  "version": "2.8.8",
   "description": "Pi extension for delegating work to project or user agents, including persistent tmux agent panes.",
   "license": "MIT",
   "keywords": [

--- a/pi-extensions/pi-agents-tmux/tests/pi-invocation.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/pi-invocation.test.ts
@@ -447,7 +447,7 @@ describe("persistent pane launcher depth export (kendex#192 / PR #1178 f4)", () 
 		const templateEnd = paneSource.indexOf("`;", templateStart);
 		expect(templateEnd).toBeGreaterThan(templateStart);
 		const templateDigest = createHash("sha256").update(paneSource.slice(templateStart, templateEnd)).digest("hex").slice(0, 16);
-		expect({ version: PANE_LAUNCHER_VERSION, templateDigest }).toEqual({ version: 10, templateDigest: "ed747d117275e537" });
+		expect({ version: PANE_LAUNCHER_VERSION, templateDigest }).toEqual({ version: 11, templateDigest: "38837c68b7dc5b2a" });
 	});
 
 	test("launcher exports the RESOLVED absolute entry when the parent had a relative override (PR #1178 r3)", async () => {


### PR DESCRIPTION
First real run of the restored merge-queue battery caught this: the pane launcher template changed while the suites were out of CI, without the `PANE_LAUNCHER_VERSION` bump that recycles running panes onto the new launcher (current digest 38837c68 vs pinned ed747d11 at version 10). Version 11, digest repinned, suite green (390 tests).

Pre-existing catalog defect surfaced by #1520's coverage restoration — not caused by the rename.

https://claude.ai/code/session_01Jx2yfoaodk4rDpdWDqgoMk