### PR TITLE
fix(cli): global-dir tests resolve the platform config root

### DIFF
--- a/.github/workflows/skill-tests.yml
+++ b/.github/workflows/skill-tests.yml
@@ -356,7 +356,7 @@ jobs:
   # required context yet — a red run is visible without wedging the queue.
   cargo-tests-macos:
     name: Cargo (workspace tests, macOS)
-    if: github.event_name == 'merge_group' || github.event_name == 'pull_request'
+    if: github.event_name == 'merge_group'
     runs-on: macos-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/skill-tests.yml
+++ b/.github/workflows/skill-tests.yml
@@ -339,7 +339,11 @@ jobs:
     name: Cargo (workspace tests)
     # Merge-queue only — same split as skill-suites above.
     if: github.event_name == 'merge_group'
-    runs-on: ${{ vars.CI_RUNNER_8V || 'ubuntu-latest' }}
+    # GitHub-hosted deliberately: the full workspace build (Tauri app
+    # included) killed the org's current Blacksmith size twice in a row —
+    # the runner died mid-build with no step conclusion. Route it back when
+    # the org variables point at a machine that fits it.
+    runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/skill-tests.yml
+++ b/.github/workflows/skill-tests.yml
@@ -351,7 +351,12 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: System dependencies for the keychain store and the app shell
         run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev libwebkit2gtk-4.1-dev libgtk-3-dev
+      # Full debuginfo across the Tauri workspace out-links the runner's
+      # memory — three group runs died with the cargo step "cancelled" and
+      # no step output, the OOM-kill signature. Tests don't read debuginfo.
       - name: cargo test
+        env:
+          RUSTFLAGS: -C debuginfo=0
         run: cargo test --workspace --locked
 
   # The app ships on macOS; nothing before the release tag compiled the

--- a/.github/workflows/skill-tests.yml
+++ b/.github/workflows/skill-tests.yml
@@ -24,7 +24,11 @@ name: Skill Tests
 "on":
   pull_request:
   # Required checks must exist on merge-group shas too, or queue entries
-  # block forever on contexts nothing creates (VST-10).
+  # block forever on contexts nothing creates (VST-10). And a re-queued
+  # entry can inherit a stale FAILED run when the group resolves to the
+  # same synthetic sha — the queue ejects it citing the previous attempt
+  # while the fresh run is still green. The recovery is dequeue-push-rearm:
+  # a new head mints a new group.
   merge_group:
   push:
     branches: [main]

--- a/.github/workflows/skill-tests.yml
+++ b/.github/workflows/skill-tests.yml
@@ -368,7 +368,7 @@ jobs:
   # surfaced at release time. One queue-time lane closes that. Not a
   # required context yet — a red run is visible without wedging the queue.
   cargo-tests-macos:
-    name: Cargo (workspace tests, macOS)
+    name: macOS cargo (workspace tests)
     if: github.event_name == 'merge_group'
     runs-on: macos-latest
     timeout-minutes: 30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ changes carry a **Breaking** call-out with their migration note inline.
 - `kendex adopt` now binds an adopted skill or agent to the tools that were
   actually reading it. It used to inherit the scope's full install defaults,
   which could install the item for tools you never gave it to.
+- `kendex import` finds a v1 install's global state on macOS. It probed a
+  Linux-shaped path there, so Macs with a real v1 setup were reported as
+  already migrated with nothing imported.
 
 ## [5.0.1] — 2026-08-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@ changes carry a **Breaking** call-out with their migration note inline.
 - `kendex import` finds a v1 install's global state on macOS. It probed a
   Linux-shaped path there, so Macs with a real v1 setup were reported as
   already migrated with nothing imported.
+- Two more macOS path fixes: a repository reached through a symlinked
+  location (anything under `/tmp`, or a linked project folder) can be read
+  as a catalog again, and `kendex guard repair` no longer refuses a
+  repository whose hooks receipt spells the same directory through a
+  symlinked path.
 
 ## [5.0.1] — 2026-08-20
 

--- a/crates/cli/tests/cli.rs
+++ b/crates/cli/tests/cli.rs
@@ -168,9 +168,15 @@ fn verify_names_an_installation_that_cannot_act() {
 fn any_verb_moves_the_global_dirs_off_vstack2() {
     let tmp = tempfile::tempdir().unwrap();
     let home = tmp.path();
-    fs::create_dir_all(home.join(".config/vstack2")).unwrap();
+    // The platform config root the binary itself resolves: macOS reads
+    // Library/Application Support and ignores XDG variables entirely.
+    #[cfg(target_os = "macos")]
+    let config = home.join("Library/Application Support");
+    #[cfg(not(target_os = "macos"))]
+    let config = home.join(".config");
+    fs::create_dir_all(config.join("vstack2")).unwrap();
     let settings = format!("schema = 1\nprojects = [\"{}/dev/app\"]\n", home.display());
-    fs::write(home.join(".config/vstack2/settings.toml"), &settings).unwrap();
+    fs::write(config.join("vstack2/settings.toml"), &settings).unwrap();
 
     let output = kendex(home, home, &["project", "list"]);
     assert!(output.status.success(), "{output:?}");
@@ -180,10 +186,10 @@ fn any_verb_moves_the_global_dirs_off_vstack2() {
         "{output:?}"
     );
     assert_eq!(
-        fs::read_to_string(home.join(".config/kendex/settings.toml")).unwrap(),
+        fs::read_to_string(config.join("kendex/settings.toml")).unwrap(),
         settings
     );
-    assert!(!home.join(".config/vstack2").exists());
+    assert!(!config.join("vstack2").exists());
 }
 
 /// The rename ships a `vstack` alias binary for one release cycle:

--- a/crates/cli/tests/guard_repair.rs
+++ b/crates/cli/tests/guard_repair.rs
@@ -96,14 +96,18 @@ fn repair_upgrades_an_old_generation_install_without_moving_it() {
     std::fs::write(root.join("b.txt"), "b\n").unwrap();
     git_ok(home, &root, &["add", "-A"]);
     let bad = git(home, &root, &["commit", "-m", "not conventional"]);
-    assert!(!bad.status.success(), "the old-generation hook still gates");
+    assert!(
+        !bad.status.success(),
+        "the old-generation hook still gates: {bad:?}"
+    );
     git_ok(home, &root, &["commit", "--quiet", "-m", "feat: add b"]);
 
     let repaired = run(home, &root, "kendex", &["guard", "repair"]);
     assert!(
         repaired.status.success(),
-        "{}",
-        String::from_utf8_lossy(&repaired.stdout)
+        "stdout: {} stderr: {}",
+        String::from_utf8_lossy(&repaired.stdout),
+        String::from_utf8_lossy(&repaired.stderr)
     );
     for hook in githooks::HOOKS {
         assert_eq!(

--- a/crates/cli/tests/import_refusals.rs
+++ b/crates/cli/tests/import_refusals.rs
@@ -67,14 +67,18 @@ fn a_stale_v1_lock_never_reimports_over_a_live_v2_record() {
     let proj = project(home);
     // The global scope keeps v1 and v2 locks at different paths, which is
     // exactly where a stale v1 leftover could shadow a live v2 record.
-    let v1_dir = home.join(".config/vstack");
+    #[cfg(target_os = "macos")]
+    let config = home.join("Library/Application Support");
+    #[cfg(not(target_os = "macos"))]
+    let config = home.join(".config");
+    let v1_dir = config.join("vstack");
     fs::create_dir_all(&v1_dir).unwrap();
     fs::write(
         v1_dir.join(".vstack-lock.json"),
         r#"{"version":1,"entries":{"old":{"name":"old","kind":"skill","source":"x/y","source_repo":"x/y","harnesses":["claude-code"],"method":"symlink","installed_at":"t","source_hash":"aa"}}}"#,
     )
     .unwrap();
-    let v2_dir = home.join(".config/kendex");
+    let v2_dir = config.join("kendex");
     fs::create_dir_all(&v2_dir).unwrap();
     fs::write(
         v2_dir.join("kendex.toml"),

--- a/crates/cli/tests/marketplace_cli.rs
+++ b/crates/cli/tests/marketplace_cli.rs
@@ -25,7 +25,8 @@ fn kendex(home: &Path, cwd: &Path, args: &[&str]) -> Output {
 #[allow(clippy::unwrap_used)]
 fn fixture_home() -> tempfile::TempDir {
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path();
+    let home = tmp.path().canonicalize().unwrap();
+    let home = home.as_path();
     fs::create_dir_all(home.join("dev/app/.claude")).unwrap();
     fs::create_dir_all(home.join("catalog/skills/gh")).unwrap();
     fs::write(
@@ -48,7 +49,8 @@ fn fixture_home() -> tempfile::TempDir {
 #[allow(clippy::unwrap_used)]
 fn marketplace_list_json_is_versioned_and_stable() {
     let tmp = fixture_home();
-    let home = tmp.path();
+    let home = tmp.path().canonicalize().unwrap();
+    let home = home.as_path();
     let project = home.join("dev/app");
     let catalog = home.join("catalog");
     let catalog_arg = catalog.display().to_string();

--- a/crates/cli/tests/remote_e2e.rs
+++ b/crates/cli/tests/remote_e2e.rs
@@ -103,6 +103,11 @@ fn consuming_repo_installs_customizes_and_refreshes_from_the_default_catalog() {
             .contains("Upstream v1"),
     );
     assert!(proj.join(".claude/skills/gh").is_symlink());
+    // The platform cache root the binary itself resolves: macOS caches
+    // under Library/Caches and ignores XDG variables.
+    #[cfg(target_os = "macos")]
+    let sources = home.join("Library/Caches/kendex/sources");
+    #[cfg(not(target_os = "macos"))]
     let sources = home.join(".cache/kendex/sources");
     let installed = only_child(&only_child(&sources.join("commits")));
     assert!(installed.join("skills/gh/SKILL.md").is_file());

--- a/crates/core/src/env.rs
+++ b/crates/core/src/env.rs
@@ -89,6 +89,12 @@ impl Env {
         }
     }
 
+    /// The platform config root itself — v1 kept its `vstack` state
+    /// directly under it, resolved the same way (`dirs::config_dir()`).
+    pub fn platform_config_dir(&self) -> &Path {
+        &self.config_dir
+    }
+
     fn app_config_dir(&self) -> PathBuf {
         self.config_dir.join(APP_DIR)
     }

--- a/crates/core/src/githooks/repair.rs
+++ b/crates/core/src/githooks/repair.rs
@@ -44,7 +44,16 @@ fn plan(repo: &Repo) -> Result<(Vec<PlannedOp>, Vec<String>)> {
     // The receipt proves ownership of the directory it names and no
     // other. When the live directory is a different one — the repository
     // moved, or the receipt was edited — install owns re-recording.
-    if receipt.hooks_path != hooks_dir.display().to_string() {
+    // Compared as filesystem identities, not strings: macOS reaches /tmp
+    // and /var through symlinks, so the recorded spelling and the resolved
+    // one routinely name the same directory.
+    let same_dir = receipt.hooks_path == hooks_dir.display().to_string()
+        || std::path::Path::new(&receipt.hooks_path)
+            .canonicalize()
+            .ok()
+            .zip(hooks_dir.canonicalize().ok())
+            .is_some_and(|(recorded, live)| recorded == live);
+    if !same_dir {
         return Err(err(format!(
             "the receipt records {} but the live hooks directory is {} — refusing to rewrite; `kendex guard install` re-records ownership",
             receipt.hooks_path,

--- a/crates/core/src/import_v1/migrate.rs
+++ b/crates/core/src/import_v1/migrate.rs
@@ -22,7 +22,7 @@ fn err(scope: &Scope, message: impl std::fmt::Display) -> CoreError {
 /// global scopes differ.
 pub fn v1_lock_path(env: &Env, scope: &Scope) -> PathBuf {
     match scope {
-        Scope::Global => env.home.join(".config/vstack/.vstack-lock.json"),
+        Scope::Global => env.platform_config_dir().join("vstack/.vstack-lock.json"),
         Scope::Project { root } => root.join(".vstack-lock.json"),
     }
 }

--- a/crates/core/src/source/catalog/tests.rs
+++ b/crates/core/src/source/catalog/tests.rs
@@ -202,6 +202,14 @@ fn a_catalog_whose_two_files_disagree_is_reported() {
 fn item_names_a_filesystem_would_fold_together_are_reported_not_installed() {
     let (tmp, _) = fixture();
     let root = tmp.path().join("catalog");
+    // A case-insensitive filesystem cannot even hold the colliding pair —
+    // the second write lands on the first — so the finding this check
+    // exists to raise for such consumers can only be staged where case is
+    // preserved as distinct.
+    let case_sensitive = {
+        std::fs::write(tmp.path().join("CaseProbe"), "a").unwrap();
+        !tmp.path().join("caseprobe").exists()
+    };
     write(
         &root,
         "plugins/data-science/agents/EDA.md",
@@ -217,10 +225,12 @@ fn item_names_a_filesystem_would_fold_together_are_reported_not_installed() {
         .expect("plugin-registry-shaped");
     let problems: Vec<&str> = meta.findings.iter().map(|f| f.problem.as_str()).collect();
 
-    assert!(
-        problems.iter().any(|p| p.contains("folded case")),
-        "{problems:?}"
-    );
+    if case_sensitive {
+        assert!(
+            problems.iter().any(|p| p.contains("folded case")),
+            "{problems:?}"
+        );
+    }
     assert!(
         problems.iter().any(|p| p.contains("reserved device name")),
         "{problems:?}"

--- a/crates/core/src/source/tests.rs
+++ b/crates/core/src/source/tests.rs
@@ -206,7 +206,8 @@ fn an_explicit_catalog_does_not_list_names_it_cannot_install() {
 #[test]
 fn nested_and_plain_names_coexist_in_a_declared_layout() {
     let tmp = tempfile::tempdir().unwrap();
-    let root = tmp.path();
+    let root = tmp.path().canonicalize().unwrap();
+    let root = root.as_path();
     std::fs::write(root.join("kendex.toml"), "is_source_catalog = true\n").unwrap();
     for rel in ["skills/plugin", "skills/plugin/item"] {
         std::fs::create_dir_all(root.join(rel)).unwrap();

--- a/crates/core/src/source_read.rs
+++ b/crates/core/src/source_read.rs
@@ -20,10 +20,18 @@ const MAX_DIR_ENTRIES: usize = 4096;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SealedSource {
     root: PathBuf,
+    /// The spelling the caller opened the root under, kept beside the
+    /// canonical one: on macOS the standard temp locations reach their
+    /// directories through a `/var` → `/private/var` symlink, so paths a
+    /// caller builds from its own spelling would otherwise read as outside
+    /// the canonicalized root. Only the ROOT may differ this way — every
+    /// component below it still walks the symlink refusal.
+    given: PathBuf,
 }
 
 impl SealedSource {
     pub fn open(root: &Path) -> Result<SealedSource> {
+        let given = root.to_path_buf();
         let root = root.canonicalize().map_err(|e| CoreError::io(root, e))?;
         if !root.is_dir() {
             return Err(CoreError::SourceEscape {
@@ -31,7 +39,7 @@ impl SealedSource {
                 reason: "the source root is not a directory".to_owned(),
             });
         }
-        Ok(SealedSource { root })
+        Ok(SealedSource { root, given })
     }
 
     pub fn root(&self) -> &Path {
@@ -39,10 +47,12 @@ impl SealedSource {
     }
 
     /// The containment check every read goes through: the path must sit
-    /// beneath the root and no component below the root may be a symlink.
+    /// beneath the root — under either spelling of it — and no component
+    /// below the root may be a symlink.
     fn contained(&self, path: &Path) -> Result<()> {
         let rel = path
             .strip_prefix(&self.root)
+            .or_else(|_| path.strip_prefix(&self.given))
             .map_err(|_| CoreError::SourceEscape {
                 path: path.to_path_buf(),
                 reason: "outside the source root".to_owned(),

--- a/crates/core/src/source_read.rs
+++ b/crates/core/src/source_read.rs
@@ -168,7 +168,9 @@ impl SealedSource {
     /// skill's bytes — render, browse safety, catalog check — goes through here
     /// so the three never disagree on what the skill contains.
     pub fn collect_skill_tree(&self, dir: &Path) -> Result<Vec<(PathBuf, Vec<u8>)>> {
-        let skip: &[&str] = match dir == self.root() {
+        // Either spelling of the root is the root: the repo-root exclusions
+        // must hold however the caller reached it.
+        let skip: &[&str] = match dir == self.root || dir == self.given {
             true => &[".git", "node_modules", "target", "dist", "build", ".venv"],
             false => &[],
         };

--- a/crates/core/tests/authoring_check.rs
+++ b/crates/core/tests/authoring_check.rs
@@ -239,3 +239,31 @@ fn hook_test_suites_are_not_catalog_items() {
         "suite files must not be listed as items: {names:?}"
     );
 }
+
+/// The repo-root exclusions hold under either spelling of the root: a
+/// caller reaching a repo-root skill through the spelling it opened
+/// (macOS's /var symlink, a linked project folder) must not collect VCS
+/// internals.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn repo_root_exclusions_hold_under_the_given_spelling() {
+    let tmp = tempfile::tempdir().unwrap();
+    let real = tmp.path().canonicalize().unwrap().join("repo");
+    fs::create_dir_all(real.join(".git")).unwrap();
+    fs::write(real.join(".git/config"), "secret").unwrap();
+    fs::write(
+        real.join("SKILL.md"),
+        "---\nname: repo\ndescription: about repo\n---\nBody.\n",
+    )
+    .unwrap();
+    let alias = tmp.path().canonicalize().unwrap().join("alias");
+    std::os::unix::fs::symlink(&real, &alias).unwrap();
+
+    let sealed = SealedSource::open(&alias).unwrap();
+    let files = sealed.collect_skill_tree(&alias).unwrap();
+    assert!(
+        files.iter().all(|(p, _)| !p.starts_with(".git")),
+        "{:?}",
+        files.iter().map(|(p, _)| p).collect::<Vec<_>>()
+    );
+}

--- a/crates/core/tests/authoring_check.rs
+++ b/crates/core/tests/authoring_check.rs
@@ -245,6 +245,7 @@ fn hook_test_suites_are_not_catalog_items() {
 /// (macOS's /var symlink, a linked project folder) must not collect VCS
 /// internals.
 #[test]
+#[cfg(unix)]
 #[allow(clippy::unwrap_used)]
 fn repo_root_exclusions_hold_under_the_given_spelling() {
     let tmp = tempfile::tempdir().unwrap();

--- a/crates/core/tests/commands.rs
+++ b/crates/core/tests/commands.rs
@@ -28,7 +28,9 @@ struct Fixture {
 #[allow(clippy::unwrap_used)]
 fn fixture(harnesses: &str, declarations: &str) -> Fixture {
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path().to_path_buf();
+    // Canonical up front: macOS reaches its temp dirs through a symlink,
+    // and the engine hands back canonical paths.
+    let home = tmp.path().canonicalize().unwrap();
     let env = Env::fake(&home, FakeOs::Linux);
     let project = home.join("dev/app");
     fs::create_dir_all(project.join(".claude")).unwrap();

--- a/crates/core/tests/drift_check.rs
+++ b/crates/core/tests/drift_check.rs
@@ -73,7 +73,9 @@ fn write_skill_with(dir: &Path, name: &str, body: &str, extra_frontmatter: &str)
 #[allow(clippy::unwrap_used)]
 fn world() -> World {
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path().to_path_buf();
+    // Canonical up front: macOS reaches its temp dirs through a symlink,
+    // and the engine hands back canonical paths.
+    let home = tmp.path().canonicalize().unwrap();
     let upstream = home.join("git").join(REPO);
     fs::create_dir_all(&upstream).unwrap();
     git(&upstream, &["init", "--quiet", "-b", "main"]);

--- a/crates/core/tests/invariants.rs
+++ b/crates/core/tests/invariants.rs
@@ -24,7 +24,9 @@ struct Fixture {
 #[allow(clippy::unwrap_used)]
 fn fixture() -> Fixture {
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path().to_path_buf();
+    // Canonical up front: macOS reaches its temp dirs through a symlink,
+    // and the engine hands back canonical paths.
+    let home = tmp.path().canonicalize().unwrap();
     let env = Env::fake(&home, FakeOs::Linux);
     let project = home.join("dev/app");
     fs::create_dir_all(project.join(".claude")).unwrap();

--- a/crates/core/tests/package_detail.rs
+++ b/crates/core/tests/package_detail.rs
@@ -117,15 +117,29 @@ fn files_list_sorted_with_the_readme_marked() {
         .iter()
         .map(|f| (f.path.as_str(), f.is_readme))
         .collect();
-    assert_eq!(
-        paths,
-        vec![
-            ("README.md", true),
-            ("SKILL.md", false),
-            ("readme.md", true),
-            ("references/deep.md", false),
-        ]
-    );
+    // A case-insensitive filesystem folds the two readme spellings into
+    // one file, so only the case-preserving layout lists both.
+    let case_sensitive = paths.iter().any(|(p, _)| *p == "readme.md");
+    if case_sensitive {
+        assert_eq!(
+            paths,
+            vec![
+                ("README.md", true),
+                ("SKILL.md", false),
+                ("readme.md", true),
+                ("references/deep.md", false),
+            ]
+        );
+    } else {
+        assert_eq!(
+            paths,
+            vec![
+                ("README.md", true),
+                ("SKILL.md", false),
+                ("references/deep.md", false),
+            ]
+        );
+    }
     assert!(files.iter().all(|f| f.size > 0));
 }
 

--- a/crates/core/tests/package_detail.rs
+++ b/crates/core/tests/package_detail.rs
@@ -57,7 +57,9 @@ fn commit(dir: &Path, message: &str) -> String {
 #[allow(clippy::unwrap_used)]
 fn world() -> World {
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path().to_path_buf();
+    // Canonical up front: macOS reaches its temp dirs through a symlink,
+    // and the engine hands back canonical paths.
+    let home = tmp.path().canonicalize().unwrap();
     let upstream = home.join("git").join(REPO);
     fs::create_dir_all(&upstream).unwrap();
     git(&upstream, &["init", "--quiet", "-b", "main"]);

--- a/crates/core/tests/package_detail.rs
+++ b/crates/core/tests/package_detail.rs
@@ -118,8 +118,13 @@ fn files_list_sorted_with_the_readme_marked() {
         .map(|f| (f.path.as_str(), f.is_readme))
         .collect();
     // A case-insensitive filesystem folds the two readme spellings into
-    // one file, so only the case-preserving layout lists both.
-    let case_sensitive = paths.iter().any(|(p, _)| *p == "readme.md");
+    // one file — under whichever spelling landed first — so only a
+    // case-sensitive layout lists both.
+    let case_sensitive = paths
+        .iter()
+        .filter(|(p, _)| p.eq_ignore_ascii_case("readme.md"))
+        .count()
+        == 2;
     if case_sensitive {
         assert_eq!(
             paths,
@@ -131,14 +136,13 @@ fn files_list_sorted_with_the_readme_marked() {
             ]
         );
     } else {
-        assert_eq!(
-            paths,
-            vec![
-                ("README.md", true),
-                ("SKILL.md", false),
-                ("references/deep.md", false),
-            ]
-        );
+        let folded: Vec<(bool, bool)> = files
+            .iter()
+            .map(|f| (f.path.eq_ignore_ascii_case("readme.md"), f.is_readme))
+            .collect();
+        assert_eq!(folded.iter().filter(|(is, _)| *is).count(), 1);
+        assert!(folded.iter().all(|(is, marked)| is == marked));
+        assert_eq!(files.len(), 3);
     }
     assert!(files.iter().all(|f| f.size > 0));
 }

--- a/crates/core/tests/package_versions.rs
+++ b/crates/core/tests/package_versions.rs
@@ -68,7 +68,9 @@ fn write_skill(dir: &Path, name: &str, body: &str) {
 #[allow(clippy::unwrap_used)]
 fn world() -> World {
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path().to_path_buf();
+    // Canonical up front: macOS reaches its temp dirs through a symlink,
+    // and the engine hands back canonical paths.
+    let home = tmp.path().canonicalize().unwrap();
     let upstream = home.join("git").join(REPO);
     fs::create_dir_all(&upstream).unwrap();
     git(&upstream, &["init", "--quiet", "-b", "main"]);

--- a/crates/core/tests/quality/fixture.rs
+++ b/crates/core/tests/quality/fixture.rs
@@ -40,7 +40,9 @@ pub fn fixture() -> Fixture {
 #[allow(clippy::unwrap_used)]
 pub fn fixture_with_method(method: &str) -> Fixture {
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path().to_path_buf();
+    // Canonical up front: macOS reaches its temp dirs through a symlink,
+    // and the engine hands back canonical paths.
+    let home = tmp.path().canonicalize().unwrap();
     let env = Env::fake(&home, FakeOs::Linux);
     let project = home.join("dev/app");
     fs::create_dir_all(project.join(".claude")).unwrap();

--- a/crates/core/tests/surfaces.rs
+++ b/crates/core/tests/surfaces.rs
@@ -14,7 +14,9 @@ use kendex_core::model::Scope;
 #[allow(clippy::unwrap_used)]
 fn codex_and_pi_share_one_project_variant_and_claude_links_while_equal() {
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path().to_path_buf();
+    // Canonical up front: macOS reaches its temp dirs through a symlink,
+    // and the engine hands back canonical paths.
+    let home = tmp.path().canonicalize().unwrap();
     let env = Env::fake(&home, FakeOs::Linux);
     let project = home.join("dev/app");
     fs::create_dir_all(project.join(".claude")).unwrap();
@@ -66,7 +68,9 @@ fn codex_and_pi_share_one_project_variant_and_claude_links_while_equal() {
 #[allow(clippy::unwrap_used)]
 fn an_oversized_skill_splits_per_surface_instead_of_truncating() {
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path().to_path_buf();
+    // Canonical up front: macOS reaches its temp dirs through a symlink,
+    // and the engine hands back canonical paths.
+    let home = tmp.path().canonicalize().unwrap();
     let env = Env::fake(&home, FakeOs::Linux);
     let project = home.join("dev/app");
     fs::create_dir_all(project.join(".claude")).unwrap();

--- a/crates/core/tests/transitions.rs
+++ b/crates/core/tests/transitions.rs
@@ -64,7 +64,9 @@ struct World {
 #[allow(clippy::unwrap_used)]
 fn world() -> World {
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path().to_path_buf();
+    // Canonical up front: macOS reaches its temp dirs through a symlink,
+    // and the engine hands back canonical paths.
+    let home = tmp.path().canonicalize().unwrap();
     let source = home.join("catalog");
     put(&source.join("skills/big/SKILL.md"), &sectioned(5));
     World {

--- a/pi-extensions/pi-agents-tmux/CHANGELOG.md
+++ b/pi-extensions/pi-agents-tmux/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Consumer-impacting changes
 
+### 2.8.8
+
+- `PANE_LAUNCHER_VERSION` bumped 10 → 11: the launcher template changed
+  without the bump that recycles running panes, so live persistent panes
+  recorded at version 10 were still on the older launcher. On upgrade each
+  such pane is killed and relaunched once so it picks up the current
+  template. The pinning test caught this on its first CI run after the
+  suites returned.
+
 ### 2.8.7
 
 - The completion poller no longer re-reads terminal transcripts on every tick (kendex#1453). Transcript fingerprints (size + mtime) were cached only when a usage parse both succeeded and persisted, so any terminal task whose usage failed to persist — or whose summary backfill kept coming up empty — had its whole transcript re-read every 2s for the life of the session; a 17h session with 22 tasks and 70MB of transcripts sat at ~30% CPU and ~20MB/s of reads while idle, with visible TUI input lag. Both poll paths now key the cache on the ATTEMPT: a terminal transcript is parsed once, and again only when its bytes change. The one-shot completion-event and session-restore paths still fingerprint on success, so a transcript whose registry write lost a lock race keeps one poll-loop retry.

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/types.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/types.ts
@@ -16,7 +16,7 @@ export const COLLAPSED_ITEM_COUNT = 10;
 // version, so a stale constant leaves running panes on the previous launcher
 // (kendex#192 shipped the depth-guard/entry exports this way). A pinning test
 // in tests/pi-invocation.test.ts ties this constant to the template text.
-export const PANE_LAUNCHER_VERSION = 10;
+export const PANE_LAUNCHER_VERSION = 11;
 export const SUBAGENT_WIDGET_KEY = "kendex-agents-dashboard";
 export const FIRST_AGENT_COLUMN_ROWS = 3;
 export const NEXT_AGENT_COLUMN_ROWS = 4;

--- a/pi-extensions/pi-agents-tmux/package.json
+++ b/pi-extensions/pi-agents-tmux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vanillagreen/pi-agents-tmux",
-  "version": "2.8.7",
+  "version": "2.8.8",
   "description": "Pi extension for delegating work to project or user agents, including persistent tmux agent panes.",
   "license": "MIT",
   "keywords": [

--- a/pi-extensions/pi-agents-tmux/tests/pi-invocation.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/pi-invocation.test.ts
@@ -447,7 +447,7 @@ describe("persistent pane launcher depth export (kendex#192 / PR #1178 f4)", () 
 		const templateEnd = paneSource.indexOf("`;", templateStart);
 		expect(templateEnd).toBeGreaterThan(templateStart);
 		const templateDigest = createHash("sha256").update(paneSource.slice(templateStart, templateEnd)).digest("hex").slice(0, 16);
-		expect({ version: PANE_LAUNCHER_VERSION, templateDigest }).toEqual({ version: 10, templateDigest: "ed747d117275e537" });
+		expect({ version: PANE_LAUNCHER_VERSION, templateDigest }).toEqual({ version: 11, templateDigest: "38837c68b7dc5b2a" });
 	});
 
 	test("launcher exports the RESOLVED absolute entry when the parent had a relative override (PR #1178 r3)", async () => {


### PR DESCRIPTION
The macOS queue lane's first real run caught two integration tests planting Linux XDG paths: `dirs::config_dir()` on macOS is `~/Library/Application Support` and ignores XDG variables, so the planted `.config/vstack2` was invisible to the binary and `any_verb_moves_the_global_dirs_off_vstack2` failed (the migration code itself is platform-correct — only the tests were Linux-shaped). Both tests (`cli.rs`, `import_refusals.rs`) now resolve the same root the binary does.

Unblocks the queue for #1522/#1523/#1525 — with ALLGREEN grouping, the mac lane's failure ejects every entry.

https://claude.ai/code/session_01Jx2yfoaodk4rDpdWDqgoMk