### PR TITLE
ci: full battery runs on push to main while the queue is down

### DIFF
--- a/.github/workflows/skill-tests.yml
+++ b/.github/workflows/skill-tests.yml
@@ -48,12 +48,10 @@ jobs:
       fail-fast: false
       matrix:
         shard: [review-gate, shell, node]
-    # Merge-queue only (the fast/full split — see the header). A job-level
-    # if:, not workflow-level `paths`/conditions: a SKIPPED job still
-    # reports its context, so the ruleset's required contexts stay satisfied
-    # on PR heads while the pending "Review gate" status blocks merge until
-    # review is done.
-    if: github.event_name == 'merge_group'
+    # Merge-queue only by design; while the queue is disabled (it ejects
+    # every entry — see the KEN queue-wedge issue) the full battery runs on
+    # the push to main instead, so a merged result is still tested once.
+    if: github.event_name == 'merge_group' || github.event_name == 'push'
     runs-on: ${{ vars.CI_RUNNER_4V || 'ubuntu-latest' }}
     timeout-minutes: 25
     steps:
@@ -287,7 +285,7 @@ jobs:
   skill-suites:
     name: Skill suites (shell + node)
     needs: [skill-suites-shard]
-    if: always() && github.event_name == 'merge_group'
+    if: always() && (github.event_name == 'merge_group' || github.event_name == 'push')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -341,8 +339,9 @@ jobs:
 
   cargo-tests:
     name: Cargo (workspace tests)
-    # Merge-queue only — same split as skill-suites above.
-    if: github.event_name == 'merge_group'
+    # Same split as skill-suites above: queue when it works, main push
+    # while it is disabled.
+    if: github.event_name == 'merge_group' || github.event_name == 'push'
     # GitHub-hosted deliberately: the full workspace build (Tauri app
     # included) killed the org's current Blacksmith size twice in a row —
     # the runner died mid-build with no step conclusion. Route it back when
@@ -369,7 +368,7 @@ jobs:
   # required context yet — a red run is visible without wedging the queue.
   cargo-tests-macos:
     name: macOS cargo (workspace tests)
-    if: github.event_name == 'merge_group'
+    if: github.event_name == 'merge_group' || github.event_name == 'push'
     runs-on: macos-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/skill-tests.yml
+++ b/.github/workflows/skill-tests.yml
@@ -5,16 +5,14 @@ name: Skill Tests
 # gating here is what lets consuming repos drop tracked vendoring: quality is
 # proven at the source, not re-proven per consumer.
 #
-# THE FAST/FULL SPLIT: the heavy suite shards and the cargo jobs run ONLY in
-# the merge queue — on PR pushes and main pushes they report `skipped`, which
-# satisfies the ruleset's required contexts while the pending "Review gate"
-# status is what actually blocks merge. A PR bills zero heavy runner-minutes
-# through every round of bot review, and the queue runs the full suite
-# exactly once, on the merged result, after review is done — main-push runs
-# would re-test the exact sha the queue just tested, so they are skipped
-# too. The accepted residual: a bypass-actor merge (gate-repair PRs) skips
-# the queue and lands without a heavy run — the operator runs the suites
-# locally and says so in the merge commit. The review gate never conditions
+# THE FAST/FULL SPLIT: the heavy suite shards and the cargo jobs skip on PR
+# pushes — a PR bills zero heavy runner-minutes through every round of bot
+# review, while the pending "Review gate" status is what actually blocks
+# merge. The full battery runs once per merged result: in the merge queue
+# when it is enabled, and on the push to main while it is not (the queue is
+# currently disabled — it ejects every entry; see the KEN queue-wedge
+# issue — so today the main-push run is the one that tests merged results,
+# after the merge rather than before it). The review gate never conditions
 # CI (it answers review-only; see the review-gate skill) — there is no gate
 # job here and nothing reads the predicate.
 #
@@ -48,9 +46,9 @@ jobs:
       fail-fast: false
       matrix:
         shard: [review-gate, shell, node]
-    # Merge-queue only by design; while the queue is disabled (it ejects
-    # every entry — see the KEN queue-wedge issue) the full battery runs on
-    # the push to main instead, so a merged result is still tested once.
+    # Skipped on PRs (the fast/full split); runs in the queue when enabled
+    # and on the push to main while it is not, so a merged result is always
+    # tested exactly once.
     if: github.event_name == 'merge_group' || github.event_name == 'push'
     runs-on: ${{ vars.CI_RUNNER_4V || 'ubuntu-latest' }}
     timeout-minutes: 25
@@ -277,7 +275,8 @@ jobs:
 
   # AGGREGATOR — this job's name is the ruleset's required context. On PR
   # heads the expression is false and the job reports `skipped`. In a merge
-  # group it runs after every shard and fails unless ALL shards succeeded —
+  # group or a main-push run it runs after every shard and fails unless ALL
+  # shards succeeded —
   # `always()` is required in the expression because skipped/failed needs
   # would otherwise skip this job too, and a skipped required context on a
   # merge group would satisfy the ruleset without any suite having run (the


### PR DESCRIPTION
The merge queue ejects every entry ~3 minutes in: the group's cargo runner receives an external shutdown while all suites are green. Reproduced across 10+ attempts, three PRs, Blacksmith and GitHub-hosted runners, fresh heads, fresh queue branches, and with each other ruleset disabled in isolation — the wedge is in the queue itself (GitHub-side), and it has been there since the rename (this queue has never passed an entry).

Interim posture, all recorded:
- The queue ruleset is replaced by **required checks on the PR** (Review gate) + thread resolution + Copilot review — the enforcement that demonstrably works.
- The **heavy suites run once per merged result on the push to main** (shards, aggregator, both cargo lanes) — post-merge instead of pre-merge, the honest cost of the wedge.
- `merge_group` conditions stay in place for the day the queue returns.

https://claude.ai/code/session_01Jx2yfoaodk4rDpdWDqgoMk