### PR TITLE
ci: serialize the guard CLI test binaries

### DIFF
--- a/.github/workflows/skill-tests.yml
+++ b/.github/workflows/skill-tests.yml
@@ -356,10 +356,29 @@ jobs:
       # Full debuginfo across the Tauri workspace out-links the runner's
       # memory — three group runs died with the cargo step "cancelled" and
       # no step output, the OOM-kill signature. Tests don't read debuginfo.
+      # The guard CLI binaries (guard_hooks, guard_repair, guard_env)
+      # exercise the real binary's git-hook installs through real
+      # commits; with the default parallel test runner the hosted
+      # runner SIGTERMs the whole job within seconds of them starting
+      # (KEN-411 holds the forensics: exit 143 with every completed
+      # suite green, CI-only — the same binaries pass locally and on
+      # the macOS lane). Running just those binaries single-threaded
+      # keeps them enforced here without the kill.
       - name: cargo test
         env:
           RUSTFLAGS: -C debuginfo=0
-        run: cargo test --workspace --locked
+        run: |
+          cargo test --workspace --locked --exclude kendex-cli
+          cargo test -p kendex-cli --locked --lib --bins
+          for t in crates/cli/tests/*.rs; do
+            name=$(basename "$t" .rs)
+            case "$name" in
+              guard_hooks|guard_repair|guard_env)
+                cargo test -p kendex-cli --locked --test "$name" -- --test-threads=1 ;;
+              *)
+                cargo test -p kendex-cli --locked --test "$name" ;;
+            esac
+          done
 
   # The app ships on macOS; nothing before the release tag compiled the
   # workspace there, so a mac-only break (keyring backend, path handling)


### PR DESCRIPTION
The "Cargo (workspace tests)" job on hosted runners dies with an external SIGTERM (~exit 143, "runner has received a shutdown signal") within seconds of the guard-family CLI test binaries starting, with every completed suite green. KEN-411 holds the forensics: the process tree captured seconds before death shows `guard_hooks` with four concurrent `guard install` child processes; compiling that binary out moved the kill to `guard_repair`. The kill is CI-only — the same binaries pass locally and on the macOS lane.

This is the narrowest stopgap that keeps those binaries enforced in CI: the workspace runs as before minus `kendex-cli`, whose test binaries run per-target with `--test-threads=1` on the guard family. If the kill persists even serialized, the fallback (recorded in KEN-411) is skipping the guard binaries on this lane only.

Part of KEN-411.

https://claude.ai/code/session_01Jx2yfoaodk4rDpdWDqgoMk
