### PR TITLE
fix(cli): --pi-extension counts as an explicit global selection

### DIFF
--- a/crates/cli/src/commands/add.rs
+++ b/crates/cli/src/commands/add.rs
@@ -60,11 +60,20 @@ pub fn run(env: &Env, args: AddArgs) -> CliResult {
     let commands = split(&args.command);
     let mcp_servers = split(&args.mcp_server);
     let bundles = split(&args.bundle);
+    let pi_extensions = split(&args.pi_extension);
     if args.global
         && !args.all
-        && [&agents, &skills, &hooks, &commands, &mcp_servers, &bundles]
-            .iter()
-            .all(|names| names.is_empty())
+        && [
+            &agents,
+            &skills,
+            &hooks,
+            &commands,
+            &mcp_servers,
+            &bundles,
+            &pi_extensions,
+        ]
+        .iter()
+        .all(|names| names.is_empty())
     {
         return Err(
             "global installs need --all or explicit --agent/--skill/--bundle selections".into(),
@@ -87,7 +96,7 @@ pub fn run(env: &Env, args: AddArgs) -> CliResult {
         hooks,
         commands,
         mcp_servers,
-        pi_extensions: split(&args.pi_extension),
+        pi_extensions,
         all: args.all,
         harnesses: if args.harness.is_empty() {
             None

--- a/crates/cli/tests/add_kinds.rs
+++ b/crates/cli/tests/add_kinds.rs
@@ -109,3 +109,23 @@ fn a_pi_extension_flag_is_refused_toward_its_carrier_bundle() {
     let said = String::from_utf8_lossy(&output.stderr).into_owned();
     assert!(said.contains("not installable on its own"), "{said}");
 }
+
+/// The same carrier explanation reaches a global add: `--pi-extension` is
+/// an explicit selection, so the gate lets the engine explain instead of
+/// demanding selections that were already given.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_global_pi_extension_flag_gets_the_carrier_explanation() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path();
+    let project = project_with_catalog(home);
+
+    let output = kendex(
+        home,
+        &project,
+        &["add", "--global", "--pi-extension", "pi-hooks", "-y"],
+    );
+    assert!(!output.status.success());
+    let said = String::from_utf8_lossy(&output.stderr).into_owned();
+    assert!(said.contains("not installable on its own"), "{said}");
+}


### PR DESCRIPTION
`kendex add --global --pi-extension <name>` was refused with "global installs need --all or explicit --agent/--skill/--bundle selections" even though a selection was given — the gate's explicit-selection list omitted Pi extensions. The same command without `--global` reaches the engine and gets the truthful carrier explanation ("not installable on its own … pi-extension support is coming"). Both scopes now refuse with the same reason, and the regression test pins it.

Closes KEN-412.

https://claude.ai/code/session_01Jx2yfoaodk4rDpdWDqgoMk
