### PR TITLE
fix(cli): update-pi resolves catalog dirs by package name

### DIFF
--- a/crates/cli/src/commands/update_pi.rs
+++ b/crates/cli/src/commands/update_pi.rs
@@ -221,7 +221,7 @@ fn declared_sources(
                 let dir = base.join(name);
                 if dir.join("package.json").is_file() {
                     found.insert(name.clone(), dir);
-                } else if let Some(dir) = dir_by_package_name(&base, name) {
+                } else if let Some(dir) = pi_ext::find_by_package_name(&base, name) {
                     found.insert(name.clone(), dir);
                 } else {
                     notes.push(format!(
@@ -234,24 +234,6 @@ fn declared_sources(
         }
     }
     found
-}
-
-/// A catalog is free to shelve a package under a directory spelled
-/// differently from the name its package.json registers — kendex's own
-/// catalog keeps short directories for scoped names. The name in the
-/// manifest is the package's, so when no directory matches it literally,
-/// the package.json names decide.
-fn dir_by_package_name(base: &Path, name: &str) -> Option<PathBuf> {
-    for entry in std::fs::read_dir(base).ok()?.flatten() {
-        let dir = entry.path();
-        if !dir.join("package.json").is_file() {
-            continue;
-        }
-        if pi_ext::read(&dir).is_ok_and(|package| package.name == name) {
-            return Some(dir);
-        }
-    }
-    None
 }
 
 fn installed_version(root: &Path, name: &str) -> Option<String> {

--- a/crates/cli/src/commands/update_pi.rs
+++ b/crates/cli/src/commands/update_pi.rs
@@ -217,8 +217,11 @@ fn declared_sources(
     for (name, decl) in &manifest.pi_extensions {
         match source::require_ready(env, scope, &decl.source, &manifest) {
             Ok(ready) => {
-                let dir = ready.root.join("pi-extensions").join(name);
+                let base = ready.root.join("pi-extensions");
+                let dir = base.join(name);
                 if dir.join("package.json").is_file() {
+                    found.insert(name.clone(), dir);
+                } else if let Some(dir) = dir_by_package_name(&base, name) {
                     found.insert(name.clone(), dir);
                 } else {
                     notes.push(format!(
@@ -231,6 +234,24 @@ fn declared_sources(
         }
     }
     found
+}
+
+/// A catalog is free to shelve a package under a directory spelled
+/// differently from the name its package.json registers — kendex's own
+/// catalog keeps short directories for scoped names. The name in the
+/// manifest is the package's, so when no directory matches it literally,
+/// the package.json names decide.
+fn dir_by_package_name(base: &Path, name: &str) -> Option<PathBuf> {
+    for entry in std::fs::read_dir(base).ok()?.flatten() {
+        let dir = entry.path();
+        if !dir.join("package.json").is_file() {
+            continue;
+        }
+        if pi_ext::read(&dir).is_ok_and(|package| package.name == name) {
+            return Some(dir);
+        }
+    }
+    None
 }
 
 fn installed_version(root: &Path, name: &str) -> Option<String> {

--- a/crates/cli/src/commands/update_pi.rs
+++ b/crates/cli/src/commands/update_pi.rs
@@ -217,12 +217,18 @@ fn declared_sources(
     for (name, decl) in &manifest.pi_extensions {
         match source::require_ready(env, scope, &decl.source, &manifest) {
             Ok(ready) => {
-                let base = ready.root.join("pi-extensions");
-                let dir = base.join(name);
-                if dir.join("package.json").is_file() {
+                let sealed = match kendex_core::source_read::SealedSource::open(&ready.root) {
+                    Ok(sealed) => sealed,
+                    Err(error) => {
+                        notes.push(format!("{name}: {error}"));
+                        continue;
+                    }
+                };
+                let dir = sealed.root().join("pi-extensions").join(name);
+                if sealed.is_file(&dir.join("package.json")) {
                     found.insert(name.clone(), dir);
                 } else {
-                    match pi_ext::find_by_package_name(&base, name) {
+                    match pi_ext::find_by_package_name(&sealed, name) {
                         Ok(Some(dir)) => {
                             found.insert(name.clone(), dir);
                         }

--- a/crates/cli/src/commands/update_pi.rs
+++ b/crates/cli/src/commands/update_pi.rs
@@ -221,13 +221,17 @@ fn declared_sources(
                 let dir = base.join(name);
                 if dir.join("package.json").is_file() {
                     found.insert(name.clone(), dir);
-                } else if let Some(dir) = pi_ext::find_by_package_name(&base, name) {
-                    found.insert(name.clone(), dir);
                 } else {
-                    notes.push(format!(
-                        "{name}: source '{}' no longer ships pi-extensions/{name}",
-                        decl.source
-                    ));
+                    match pi_ext::find_by_package_name(&base, name) {
+                        Ok(Some(dir)) => {
+                            found.insert(name.clone(), dir);
+                        }
+                        Ok(None) => notes.push(format!(
+                            "{name}: source '{}' no longer ships pi-extensions/{name}",
+                            decl.source
+                        )),
+                        Err(error) => notes.push(format!("{name}: {error}")),
+                    }
                 }
             }
             Err(error) => notes.push(format!("{name}: {error}")),

--- a/crates/cli/tests/update_pi.rs
+++ b/crates/cli/tests/update_pi.rs
@@ -200,3 +200,44 @@ fn a_package_no_source_declares_is_reported_not_updated() {
     let notes = String::from_utf8_lossy(&output.stderr);
     assert!(notes.contains("no longer ships pi-extensions"), "{notes}");
 }
+
+/// The kendex catalog shelves scoped packages under short directories —
+/// `pi-extensions/pi-hooks/` registering `@vanillagreen/pi-hooks`. The
+/// declaration names the package, so the resolver falls back to the
+/// package.json names when no directory matches the declared name.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_scoped_name_resolves_a_short_directory_by_package_name() {
+    let tmp = tempfile::tempdir().unwrap();
+    let project = tmp.path().join("dev/app");
+    write(
+        &project.join("kendex.toml"),
+        "schema = 5\n\n[sources.cat]\npath = \"catalog\"\n\n[pi-extensions.\"@vanillagreen/pi-hooks\"]\nsource = \"cat\"\n",
+    );
+    write(
+        &project.join("catalog/pi-extensions/pi-hooks/package.json"),
+        "{\"name\": \"@vanillagreen/pi-hooks\", \"version\": \"1.1.0\"}\n",
+    );
+    write(
+        &project.join(".pi/packages/@vanillagreen/pi-hooks/package.json"),
+        "{\"name\": \"@vanillagreen/pi-hooks\", \"version\": \"1.0.0\"}\n",
+    );
+
+    let output = kendex(tmp.path(), &project, &["update-pi", "--check"]);
+    assert!(output.status.success());
+    let plan = String::from_utf8_lossy(&output.stdout);
+    assert!(!plan.contains("no declared source"), "{plan}");
+    assert!(!plan.contains("no longer ships"), "{plan}");
+    assert!(plan.contains("stale"), "{plan}");
+
+    let output = kendex(tmp.path(), &project, &["update-pi"]);
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let updated =
+        fs::read_to_string(project.join(".pi/packages/@vanillagreen/pi-hooks/package.json"))
+            .unwrap();
+    assert!(updated.contains("1.1.0"), "{updated}");
+}

--- a/crates/core/src/pi_ext/mod.rs
+++ b/crates/core/src/pi_ext/mod.rs
@@ -121,20 +121,22 @@ pub fn read(package_dir: &Path) -> Result<PiPackage> {
 /// scoped names in short directories. The walk stays inside the sealed
 /// reader: catalog content is adversarial input, so symlinked or
 /// oversized metadata is skipped, never followed. One nested level
-/// covers npm-style `@scope/name` layouts.
-pub fn find_by_package_name(base: &Path, name: &str) -> Option<PathBuf> {
-    let sealed = crate::source_read::SealedSource::open(base).ok()?;
-    let mut candidates = sealed.list_dir(sealed.root()).ok()?;
+/// covers npm-style `@scope/name` layouts. Two directories registering
+/// the same name is an error, not a coin toss over which bytes install.
+pub fn find_by_package_name(base: &Path, name: &str) -> Result<Option<PathBuf>> {
+    let sealed = crate::source_read::SealedSource::open(base)?;
+    let mut candidates = sealed.list_dir(sealed.root())?;
     for dir in std::mem::take(&mut candidates) {
         if dir
             .file_name()
             .is_some_and(|n| n.to_string_lossy().starts_with('@'))
         {
-            candidates.extend(sealed.list_dir(&dir).ok().unwrap_or_default());
+            candidates.extend(sealed.list_dir(&dir).unwrap_or_default());
         } else {
             candidates.push(dir);
         }
     }
+    let mut matches = Vec::new();
     for dir in candidates {
         let manifest = dir.join("package.json");
         if !sealed.is_file(&manifest) {
@@ -144,10 +146,21 @@ pub fn find_by_package_name(base: &Path, name: &str) -> Option<PathBuf> {
             continue;
         };
         if serde_json::from_str::<RawPackage>(&text).is_ok_and(|raw| raw.name == name) {
-            return Some(dir);
+            matches.push(dir);
         }
     }
-    None
+    match matches.len() {
+        0 => Ok(None),
+        1 => Ok(matches.pop()),
+        _ => Err(CoreError::PiPackage {
+            name: name.to_owned(),
+            message: format!(
+                "{} directories under {} register this package name — refusing to pick one",
+                matches.len(),
+                base.display()
+            ),
+        }),
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/core/src/pi_ext/mod.rs
+++ b/crates/core/src/pi_ext/mod.rs
@@ -116,6 +116,40 @@ pub fn read(package_dir: &Path) -> Result<PiPackage> {
     })
 }
 
+/// Where a package whose registered name differs from its directory
+/// lives under a catalog's package folder — kendex's own catalog shelves
+/// scoped names in short directories. The walk stays inside the sealed
+/// reader: catalog content is adversarial input, so symlinked or
+/// oversized metadata is skipped, never followed. One nested level
+/// covers npm-style `@scope/name` layouts.
+pub fn find_by_package_name(base: &Path, name: &str) -> Option<PathBuf> {
+    let sealed = crate::source_read::SealedSource::open(base).ok()?;
+    let mut candidates = sealed.list_dir(sealed.root()).ok()?;
+    for dir in std::mem::take(&mut candidates) {
+        if dir
+            .file_name()
+            .is_some_and(|n| n.to_string_lossy().starts_with('@'))
+        {
+            candidates.extend(sealed.list_dir(&dir).ok().unwrap_or_default());
+        } else {
+            candidates.push(dir);
+        }
+    }
+    for dir in candidates {
+        let manifest = dir.join("package.json");
+        if !sealed.is_file(&manifest) {
+            continue;
+        }
+        let Ok(text) = sealed.read_to_string(&manifest) else {
+            continue;
+        };
+        if serde_json::from_str::<RawPackage>(&text).is_ok_and(|raw| raw.name == name) {
+            return Some(dir);
+        }
+    }
+    None
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InstallOutcome {
     pub name: String,

--- a/crates/core/src/pi_ext/mod.rs
+++ b/crates/core/src/pi_ext/mod.rs
@@ -117,15 +117,23 @@ pub fn read(package_dir: &Path) -> Result<PiPackage> {
 }
 
 /// Where a package whose registered name differs from its directory
-/// lives under a catalog's package folder — kendex's own catalog shelves
-/// scoped names in short directories. The walk stays inside the sealed
-/// reader: catalog content is adversarial input, so symlinked or
-/// oversized metadata is skipped, never followed. One nested level
-/// covers npm-style `@scope/name` layouts. Two directories registering
-/// the same name is an error, not a coin toss over which bytes install.
-pub fn find_by_package_name(base: &Path, name: &str) -> Result<Option<PathBuf>> {
-    let sealed = crate::source_read::SealedSource::open(base)?;
-    let mut candidates = sealed.list_dir(sealed.root())?;
+/// lives under a catalog's `pi-extensions/` folder — kendex's own catalog
+/// shelves scoped names in short directories. `sealed` is the CATALOG
+/// root, and the folder is traversed beneath it: sealing the folder
+/// itself would canonicalize a symlinked `pi-extensions` into a trusted
+/// root and launder an escape. Symlinked or oversized metadata is
+/// skipped, never followed. One nested level covers npm-style
+/// `@scope/name` layouts. Two directories registering the same name is
+/// an error, not a coin toss over which bytes install.
+pub fn find_by_package_name(
+    sealed: &crate::source_read::SealedSource,
+    name: &str,
+) -> Result<Option<PathBuf>> {
+    let base = sealed.root().join("pi-extensions");
+    if !sealed.is_dir(&base) {
+        return Ok(None);
+    }
+    let mut candidates = sealed.list_dir(&base)?;
     for dir in std::mem::take(&mut candidates) {
         if dir
             .file_name()

--- a/crates/core/src/pi_ext/mod.rs
+++ b/crates/core/src/pi_ext/mod.rs
@@ -133,6 +133,10 @@ pub fn find_by_package_name(
     if !sealed.is_dir(&base) {
         return Ok(None);
     }
+    // One aggregate budget across both levels: per-directory caps alone
+    // would let thousands of @scope directories multiply into millions of
+    // candidates.
+    const MAX_CANDIDATES: usize = 4096;
     let mut candidates = sealed.list_dir(&base)?;
     for dir in std::mem::take(&mut candidates) {
         if dir
@@ -142,6 +146,15 @@ pub fn find_by_package_name(
             candidates.extend(sealed.list_dir(&dir).unwrap_or_default());
         } else {
             candidates.push(dir);
+        }
+        if candidates.len() > MAX_CANDIDATES {
+            return Err(CoreError::PiPackage {
+                name: name.to_owned(),
+                message: format!(
+                    "more than {MAX_CANDIDATES} package directories under {} — refusing to scan them all",
+                    base.display()
+                ),
+            });
         }
     }
     let mut matches = Vec::new();

--- a/crates/core/src/pi_ext/tests.rs
+++ b/crates/core/src/pi_ext/tests.rs
@@ -332,3 +332,20 @@ fn find_by_package_name_refuses_a_symlinked_extensions_folder() {
     let sealed = crate::source_read::SealedSource::open(&catalog).unwrap();
     assert_eq!(find_by_package_name(&sealed, "@vg/pi-hooks").unwrap(), None);
 }
+
+/// The scan carries one aggregate budget across both levels — thousands
+/// of scope directories must not multiply into millions of candidates.
+#[test]
+fn find_by_package_name_bounds_the_aggregate_scan() {
+    let tmp = tempfile::tempdir().unwrap();
+    let catalog = tmp.path().canonicalize().unwrap().join("catalog");
+    let base = catalog.join("pi-extensions");
+    for scope in 0..3 {
+        for pkg in 0..2000 {
+            std::fs::create_dir_all(base.join(format!("@s{scope}/p{pkg}"))).unwrap();
+        }
+    }
+    let sealed = crate::source_read::SealedSource::open(&catalog).unwrap();
+    let error = find_by_package_name(&sealed, "@vg/pi-hooks").unwrap_err();
+    assert!(error.to_string().contains("refusing to scan"), "{error}");
+}

--- a/crates/core/src/pi_ext/tests.rs
+++ b/crates/core/src/pi_ext/tests.rs
@@ -257,6 +257,7 @@ fn a_package_without_an_append_system_file_writes_no_block() {
 }
 
 #[test]
+#[cfg(unix)]
 fn find_by_package_name_reads_sealed_and_skips_symlinked_metadata() {
     let tmp = tempfile::tempdir().unwrap();
     let base = tmp.path().canonicalize().unwrap().join("pi-extensions");
@@ -282,12 +283,29 @@ fn find_by_package_name_reads_sealed_and_skips_symlinked_metadata() {
     .unwrap();
 
     assert_eq!(
-        find_by_package_name(&base, "@vg/pi-hooks"),
+        find_by_package_name(&base, "@vg/pi-hooks").unwrap(),
         Some(base.join("pi-hooks"))
     );
     assert_eq!(
-        find_by_package_name(&base, "@scope/pi-deep"),
+        find_by_package_name(&base, "@scope/pi-deep").unwrap(),
         Some(base.join("@scope/pi-deep"))
     );
-    assert_eq!(find_by_package_name(&base, "@vg/pi-evil"), None);
+    assert_eq!(find_by_package_name(&base, "@vg/pi-evil").unwrap(), None);
+}
+
+#[test]
+fn find_by_package_name_refuses_an_ambiguous_registration() {
+    let tmp = tempfile::tempdir().unwrap();
+    let base = tmp.path().canonicalize().unwrap().join("pi-extensions");
+    for dir in ["first", "second"] {
+        write(
+            &base.join(dir).join("package.json"),
+            "{\"name\": \"@vg/pi-hooks\", \"version\": \"1.0.0\"}",
+        );
+    }
+    let error = find_by_package_name(&base, "@vg/pi-hooks").unwrap_err();
+    assert!(
+        error.to_string().contains("refusing to pick one"),
+        "{error}"
+    );
 }

--- a/crates/core/src/pi_ext/tests.rs
+++ b/crates/core/src/pi_ext/tests.rs
@@ -282,15 +282,16 @@ fn find_by_package_name_reads_sealed_and_skips_symlinked_metadata() {
     )
     .unwrap();
 
+    let sealed = crate::source_read::SealedSource::open(base.parent().unwrap()).unwrap();
     assert_eq!(
-        find_by_package_name(&base, "@vg/pi-hooks").unwrap(),
+        find_by_package_name(&sealed, "@vg/pi-hooks").unwrap(),
         Some(base.join("pi-hooks"))
     );
     assert_eq!(
-        find_by_package_name(&base, "@scope/pi-deep").unwrap(),
+        find_by_package_name(&sealed, "@scope/pi-deep").unwrap(),
         Some(base.join("@scope/pi-deep"))
     );
-    assert_eq!(find_by_package_name(&base, "@vg/pi-evil").unwrap(), None);
+    assert_eq!(find_by_package_name(&sealed, "@vg/pi-evil").unwrap(), None);
 }
 
 #[test]
@@ -303,9 +304,31 @@ fn find_by_package_name_refuses_an_ambiguous_registration() {
             "{\"name\": \"@vg/pi-hooks\", \"version\": \"1.0.0\"}",
         );
     }
-    let error = find_by_package_name(&base, "@vg/pi-hooks").unwrap_err();
+    let sealed = crate::source_read::SealedSource::open(base.parent().unwrap()).unwrap();
+    let error = find_by_package_name(&sealed, "@vg/pi-hooks").unwrap_err();
     assert!(
         error.to_string().contains("refusing to pick one"),
         "{error}"
     );
+}
+
+/// A catalog whose `pi-extensions` is itself a symlink out of the catalog
+/// must not have the escape laundered by sealing the folder as a root —
+/// the traversal stays beneath the catalog's own seal and refuses the
+/// link.
+#[test]
+#[cfg(unix)]
+fn find_by_package_name_refuses_a_symlinked_extensions_folder() {
+    let tmp = tempfile::tempdir().unwrap();
+    let outside = tmp.path().canonicalize().unwrap().join("outside");
+    write(
+        &outside.join("pi-hooks/package.json"),
+        "{\"name\": \"@vg/pi-hooks\", \"version\": \"9.9.9\"}",
+    );
+    let catalog = tmp.path().canonicalize().unwrap().join("catalog");
+    std::fs::create_dir_all(&catalog).unwrap();
+    std::os::unix::fs::symlink(&outside, catalog.join("pi-extensions")).unwrap();
+
+    let sealed = crate::source_read::SealedSource::open(&catalog).unwrap();
+    assert_eq!(find_by_package_name(&sealed, "@vg/pi-hooks").unwrap(), None);
 }

--- a/crates/core/src/pi_ext/tests.rs
+++ b/crates/core/src/pi_ext/tests.rs
@@ -255,3 +255,39 @@ fn a_package_without_an_append_system_file_writes_no_block() {
     install(&f.env, &f.scope, &source).unwrap();
     assert!(!append_system_path(&f.scope).exists());
 }
+
+#[test]
+fn find_by_package_name_reads_sealed_and_skips_symlinked_metadata() {
+    let tmp = tempfile::tempdir().unwrap();
+    let base = tmp.path().canonicalize().unwrap().join("pi-extensions");
+    write(
+        &base.join("pi-hooks/package.json"),
+        "{\"name\": \"@vg/pi-hooks\", \"version\": \"1.0.0\"}",
+    );
+    write(
+        &base.join("@scope/pi-deep/package.json"),
+        "{\"name\": \"@scope/pi-deep\", \"version\": \"1.0.0\"}",
+    );
+    // A hostile catalog linking metadata at host files must be skipped,
+    // not followed.
+    write(
+        &tmp.path().join("outside.json"),
+        "{\"name\": \"@vg/pi-evil\", \"version\": \"9.9.9\"}",
+    );
+    std::fs::create_dir_all(base.join("pi-evil")).unwrap();
+    std::os::unix::fs::symlink(
+        tmp.path().join("outside.json"),
+        base.join("pi-evil/package.json"),
+    )
+    .unwrap();
+
+    assert_eq!(
+        find_by_package_name(&base, "@vg/pi-hooks"),
+        Some(base.join("pi-hooks"))
+    );
+    assert_eq!(
+        find_by_package_name(&base, "@scope/pi-deep"),
+        Some(base.join("@scope/pi-deep"))
+    );
+    assert_eq!(find_by_package_name(&base, "@vg/pi-evil"), None);
+}

--- a/crates/core/src/source/config.rs
+++ b/crates/core/src/source/config.rs
@@ -318,7 +318,7 @@ pub fn find_item(
             if sealed.is_file(&literal.join("package.json")) {
                 return Some(literal);
             }
-            crate::pi_ext::find_by_package_name(&base, name)
+            crate::pi_ext::find_by_package_name(sealed, name)
                 .ok()
                 .flatten()
         }

--- a/crates/core/src/source/config.rs
+++ b/crates/core/src/source/config.rs
@@ -307,7 +307,22 @@ pub fn find_item(
             catalog_file(sealed, dir, &format!("{name}.{ext}"))
         }
         ItemKind::Hook | ItemKind::Command | ItemKind::McpServer => None,
-        ItemKind::Plugin | ItemKind::PiExtension => None,
+        // A declared Pi package resolves like update-pi resolves it: the
+        // literal directory, else whichever directory's package.json
+        // registers the name — kendex's own catalog shelves scoped names
+        // in short directories. Without this, every declared Pi package
+        // reads as "no longer offered" the moment it is declared.
+        ItemKind::PiExtension => {
+            let base = root.join("pi-extensions");
+            let literal = base.join(name);
+            if sealed.is_file(&literal.join("package.json")) {
+                return Some(literal);
+            }
+            crate::pi_ext::find_by_package_name(&base, name)
+                .ok()
+                .flatten()
+        }
+        ItemKind::Plugin => None,
     }
 }
 

--- a/crates/core/src/source/tests.rs
+++ b/crates/core/src/source/tests.rs
@@ -323,3 +323,33 @@ fn a_local_source_left_under_the_old_name_still_reads() {
         project.join(".kendex-local")
     );
 }
+
+/// A declared Pi package is on offer wherever its package.json registers
+/// the name — the literal directory, or a short directory shelving a
+/// scoped name the way kendex's own catalog does.
+#[test]
+fn a_pi_extension_is_found_literal_or_by_registered_name() {
+    let tmp = tempfile::tempdir().unwrap();
+    let catalog = tmp.path().join("catalog");
+    std::fs::create_dir_all(catalog.join("pi-extensions/pi-hooks")).unwrap();
+    std::fs::write(
+        catalog.join("pi-extensions/pi-hooks/package.json"),
+        "{\"name\": \"@vg/pi-hooks\", \"version\": \"1.0.0\"}",
+    )
+    .unwrap();
+
+    let sealed = SealedSource::open(&catalog).unwrap();
+    let config = source_config(&sealed, "catalog").unwrap();
+    assert_eq!(
+        find_item(&sealed, &config, ItemKind::PiExtension, "pi-hooks"),
+        Some(sealed.root().join("pi-extensions/pi-hooks"))
+    );
+    assert_eq!(
+        find_item(&sealed, &config, ItemKind::PiExtension, "@vg/pi-hooks"),
+        Some(sealed.root().join("pi-extensions/pi-hooks"))
+    );
+    assert_eq!(
+        find_item(&sealed, &config, ItemKind::PiExtension, "@vg/pi-ghost"),
+        None
+    );
+}


### PR DESCRIPTION
`kendex update-pi` resolved a declared package's source bytes only at `pi-extensions/<declared name>`, so the kendex catalog's own packages — short directories (`pi-extensions/pi-hooks/`) registering scoped names (`@vanillagreen/pi-hooks`) — could never be sourced: every declaration reported "source no longer ships…" and stale installs were unreachable by any update path. Live consequence: the owner's machine still runs a pi-hooks whose settings walk-up predates the rename (the KEN-410 marker fix has been on main since the consolidation commit but had no vehicle to reach installs).

When no directory matches the declared name literally, the resolver now decides by the package.json `name` fields across `pi-extensions/*`. The regression test covers the real layout (short dir, scoped name): the stale install is detected and updated in place.

Closes KEN-413.

https://claude.ai/code/session_01Jx2yfoaodk4rDpdWDqgoMk
