### PR TITLE
ci: free runner disk before the cargo job

### DIFF
--- a/.github/workflows/skill-tests.yml
+++ b/.github/workflows/skill-tests.yml
@@ -356,29 +356,27 @@ jobs:
       # Full debuginfo across the Tauri workspace out-links the runner's
       # memory — three group runs died with the cargo step "cancelled" and
       # no step output, the OOM-kill signature. Tests don't read debuginfo.
-      # The guard CLI binaries (guard_hooks, guard_repair, guard_env)
-      # exercise the real binary's git-hook installs through real
-      # commits; with the default parallel test runner the hosted
-      # runner SIGTERMs the whole job within seconds of them starting
-      # (KEN-411 holds the forensics: exit 143 with every completed
-      # suite green, CI-only — the same binaries pass locally and on
-      # the macOS lane). Running just those binaries single-threaded
-      # keeps them enforced here without the kill.
+      # The workspace debug target is far larger than the free disk on a
+      # hosted ubuntu runner. Filling the disk mid-compile does not fail
+      # cargo with ENOSPC — the VM's agent stops the runner service, the
+      # job dies with exit 143 and 'runner has received a shutdown
+      # signal', and every completed suite is green (the KEN runner-kill
+      # issue holds the forensics; the ~3-minute mark is just when the
+      # disk fills). Dropping the image's unused toolchains frees tens of
+      # GB, and non-incremental compilation halves what cargo writes.
+      - name: free disk space
+        run: |
+          df -h /
+          sudo rm -rf /usr/local/lib/android /opt/hostedtoolcache /usr/local/.ghcup /usr/share/dotnet /usr/local/share/powershell
+          df -h /
       - name: cargo test
         env:
           RUSTFLAGS: -C debuginfo=0
-        run: |
-          cargo test --workspace --locked --exclude kendex-cli
-          cargo test -p kendex-cli --locked --lib --bins
-          for t in crates/cli/tests/*.rs; do
-            name=$(basename "$t" .rs)
-            case "$name" in
-              guard_hooks|guard_repair|guard_env)
-                cargo test -p kendex-cli --locked --test "$name" -- --test-threads=1 ;;
-              *)
-                cargo test -p kendex-cli --locked --test "$name" ;;
-            esac
-          done
+          CARGO_INCREMENTAL: '0'
+        run: cargo test --workspace --locked
+      - name: disk after
+        if: always()
+        run: df -h /
 
   # The app ships on macOS; nothing before the release tag compiled the
   # workspace there, so a mac-only break (keyring backend, path handling)


### PR DESCRIPTION
Root cause of the cargo-job kill (KEN-411), corrected: it is **disk exhaustion**, not the guard test binaries. Today's evidence: a main-push run died at the same ~2.5-minute mark during core-library tests, before any guard binary started — while a Blacksmith shard in the same run ran 11 minutes. The workspace debug target is ~24 GB locally; a hosted ubuntu runner has ~14 GB free, and filling the disk mid-compile stops the runner service (exit 143, "runner has received a shutdown signal") instead of failing cargo with ENOSPC. The repeatable ~3-minute mark is how long the disk takes to fill; the guard binaries only ever coincided with it.

This frees tens of GB of unused preinstalled toolchains before the build, disables incremental compilation artifacts (roughly halves what cargo writes), prints df -h before/after for telemetry, and reverts the #1539 guard-serialization stopgap since it addressed the wrong suspect.

Part of KEN-411.

https://claude.ai/code/session_01Jx2yfoaodk4rDpdWDqgoMk
