### PR TITLE
fix(core): the group kill passes -- before the negative pid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,12 @@ changes carry a **Breaking** call-out with their migration note inline.
 
 ### Fixed
 
+- On Linux, a helper command that ran past its time limit could take
+  unrelated processes down with it: Ubuntu's `kill` misreads the negative
+  process-group argument kendex passed, and for some process ids that
+  meant signalling everything the user runs. The cleanup now spells the
+  argument unambiguously, and the timed-out command's own processes are
+  the only ones ended.
 - Accepting a held-back update now actually installs it. `kendex findings`
   printed the accept flag for the copy already on disk rather than for the
   update being held back, so typing the instruction back did nothing; the

--- a/crates/core/src/process/mod.rs
+++ b/crates/core/src/process/mod.rs
@@ -288,15 +288,19 @@ fn ssh_command(inherited: Option<&str>) -> String {
 /// own group, so the group is what goes: a chance to end cleanly, then not.
 #[cfg(unix)]
 fn end_tree(child: &mut std::process::Child) {
+    // The `--` is load-bearing: procps kill (Ubuntu) without it folds a
+    // negative pid to its leading digits — `kill -TERM -1234` becomes
+    // kill(-1, SIGTERM), every process the user owns, the CI runner
+    // included. util-linux and BSD kill accept the same spelling.
     let group = format!("-{}", child.id());
-    for signal in ["-TERM", "-KILL"] {
+    for signal in ["TERM", "KILL"] {
         let _ = Command::new("kill")
-            .args([signal, &group])
+            .args(["-s", signal, "--", &group])
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .status();
-        if signal == "-TERM" {
+        if signal == "TERM" {
             std::thread::sleep(GROUP_GRACE);
         }
     }


### PR DESCRIPTION
Root cause of the runner kill, found and proven with strace: procps `kill` (Ubuntu's `/usr/bin/kill`) without a `--` separator folds a negative process-group argument to its leading digit(s) — `kill -TERM -1234` executes **kill(-1, SIGTERM)**, signalling every process the user owns. kendex's `end_tree` (the timeout cleanup for hardened child processes) used exactly that spelling, so on CI any timed-out test child whose pid began with 1 SIGTERM'd the runner service itself: "The runner has received a shutdown signal", exit 143, every completed suite green. The repeatable ~3-minute mark was the pid counter crossing 10000 during compilation; the earlier guard-binary and disk theories were both this effect observed at different moments (KEN-411 has the full forensic trail, including a probe where `ps` confirms the child leads its own group, both kills return status 0, and the process survives SIGKILL — because kill(-5, …) went nowhere).

The same bug explains the merge-queue ejections (KEN-409): the queue's cargo job died the same way and the ejection blamed the run its own dequeue cancelled.

Fix: `kill -s TERM -- -<pgid>` — unambiguous on procps, util-linux, and BSD kill. The existing timeout tests are the regression tests: on Ubuntu they fail without this (they assert a kill procps was quietly not delivering) and pass with it.

Closes KEN-411.

https://claude.ai/code/session_01Jx2yfoaodk4rDpdWDqgoMk
