### PR TITLE
ci: drop the disk workaround; the queue is back

### DIFF
--- a/.github/workflows/skill-tests.yml
+++ b/.github/workflows/skill-tests.yml
@@ -9,10 +9,11 @@ name: Skill Tests
 # pushes — a PR bills zero heavy runner-minutes through every round of bot
 # review, while the pending "Review gate" status is what actually blocks
 # merge. The full battery runs once per merged result: in the merge queue
-# when it is enabled, and on the push to main while it is not (the queue is
-# currently disabled — it ejects every entry; see the KEN queue-wedge
-# issue — so today the main-push run is the one that tests merged results,
-# after the merge rather than before it). The review gate never conditions
+# before the merge, and again on the push to main as the post-merge record.
+# (The queue was disabled for a stretch when a kill bug in the timed-out
+# process cleanup was taking runners down and ejecting every entry — the
+# KEN runner-kill issue has the story; it is fixed and the queue is back.)
+# The review gate never conditions
 # CI (it answers review-only; see the review-gate skill) — there is no gate
 # job here and nothing reads the predicate.
 #
@@ -356,27 +357,13 @@ jobs:
       # Full debuginfo across the Tauri workspace out-links the runner's
       # memory — three group runs died with the cargo step "cancelled" and
       # no step output, the OOM-kill signature. Tests don't read debuginfo.
-      # The workspace debug target is far larger than the free disk on a
-      # hosted ubuntu runner. Filling the disk mid-compile does not fail
-      # cargo with ENOSPC — the VM's agent stops the runner service, the
-      # job dies with exit 143 and 'runner has received a shutdown
-      # signal', and every completed suite is green (the KEN runner-kill
-      # issue holds the forensics; the ~3-minute mark is just when the
-      # disk fills). Dropping the image's unused toolchains frees tens of
-      # GB, and non-incremental compilation halves what cargo writes.
-      - name: free disk space
-        run: |
-          df -h /
-          sudo rm -rf /usr/local/lib/android /opt/hostedtoolcache /usr/local/.ghcup /usr/share/dotnet /usr/local/share/powershell
-          df -h /
+      # Incremental artifacts are dead weight on a fresh runner and
+      # double what cargo writes.
       - name: cargo test
         env:
           RUSTFLAGS: -C debuginfo=0
           CARGO_INCREMENTAL: '0'
         run: cargo test --workspace --locked
-      - name: disk after
-        if: always()
-        run: df -h /
 
   # The app ships on macOS; nothing before the release tag compiled the
   # workspace there, so a mac-only break (keyring backend, path handling)

--- a/.github/workflows/skill-tests.yml
+++ b/.github/workflows/skill-tests.yml
@@ -10,9 +10,6 @@ name: Skill Tests
 # review, while the pending "Review gate" status is what actually blocks
 # merge. The full battery runs once per merged result: in the merge queue
 # before the merge, and again on the push to main as the post-merge record.
-# (The queue was disabled for a stretch when a kill bug in the timed-out
-# process cleanup was taking runners down and ejecting every entry — the
-# KEN runner-kill issue has the story; it is fixed and the queue is back.)
 # The review gate never conditions
 # CI (it answers review-only; see the review-gate skill) — there is no gate
 # job here and nothing reads the predicate.
@@ -47,9 +44,8 @@ jobs:
       fail-fast: false
       matrix:
         shard: [review-gate, shell, node]
-    # Skipped on PRs (the fast/full split); runs in the queue when enabled
-    # and on the push to main while it is not, so a merged result is always
-    # tested exactly once.
+    # Skipped on PRs (the fast/full split); the merge group proves the
+    # merge and the main push records the merged result.
     if: github.event_name == 'merge_group' || github.event_name == 'push'
     runs-on: ${{ vars.CI_RUNNER_4V || 'ubuntu-latest' }}
     timeout-minutes: 25
@@ -339,13 +335,12 @@ jobs:
 
   cargo-tests:
     name: Cargo (workspace tests)
-    # Same split as skill-suites above: queue when it works, main push
-    # while it is disabled.
+    # Same split as skill-suites above: the merge group proves the merge,
+    # the main push records the merged result.
     if: github.event_name == 'merge_group' || github.event_name == 'push'
     # GitHub-hosted deliberately: the full workspace build (Tauri app
-    # included) killed the org's current Blacksmith size twice in a row —
-    # the runner died mid-build with no step conclusion. Route it back when
-    # the org variables point at a machine that fits it.
+    # included) does not fit the org's current Blacksmith size. Route it
+    # back when the org variables point at a machine that fits it.
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:


### PR DESCRIPTION
With the runner-kill root cause fixed (#1543 — procps kill argv), the disk-cleanup step from #1542 addressed a refuted theory and costs ~90 seconds per battery run; this removes it (CARGO_INCREMENTAL=0 stays — incremental artifacts are dead weight on fresh runners). The workflow header stops describing the merge queue as disabled: the ruleset re-enables the queue, and this PR merges through it as the restoration test.

Part of KEN-409.

https://claude.ai/code/session_01Jx2yfoaodk4rDpdWDqgoMk
