### PR TITLE
chore(orch): drop Ultrathink. from dev delegation blocks [no-changelog]

### DIFF
--- a/skills/orch/workflows/dev-fix.md
+++ b/skills/orch/workflows/dev-fix.md
@@ -101,8 +101,6 @@ Cancel ends the workflow; a selection goes to § 2.
    ⚠ Fill placeholders only ([Format Tags Are Literal](../SKILL.md#format-tags-are-literal)). `Recommendation:` is the technical fix, never procedure steps — the agent owns validate, commit, and return.
 
    <delegation_format>
-   Ultrathink.
-
    Follow workflow: .agents/skills/dev/workflows/dev-fix.md
 
    Source: [SOURCE]

--- a/skills/orch/workflows/dev-start.md
+++ b/skills/orch/workflows/dev-start.md
@@ -82,8 +82,6 @@ After each spawn, persist the session — `"status": "active"` is what reviewer 
 ### Single issue
 
 <delegation_format>
-Ultrathink.
-
 Follow workflow: .agents/skills/dev/workflows/dev-implement.md
 
 Issue: [ISSUE_ID]
@@ -103,8 +101,6 @@ Group pending sub-issues by `agent:[TYPE]` label and order them per [SKILL.md §
 Between groups, read each completed sub-issue's comments for a `Handoff Notes` section and combine them into the next delegation. Re-run all four § 2 stamps immediately before each group's delegation, so every group's round id scopes its own artifact path and a prior group's receipt can never satisfy this group's check, and no group is delegated into a worktree another session has taken.
 
 <delegation_format>
-Ultrathink.
-
 Follow workflow: .agents/skills/dev/workflows/dev-implement.md
 
 Parent: [ISSUE_ID]


### PR DESCRIPTION
Removes the standalone `Ultrathink.` line from the three `<delegation_format>` blocks in the orch dev workflows. Reasoning effort belongs to the spawn parameters, not the delegation message body.

No remaining occurrences repo-wide.

https://claude.ai/code/session_015HxpmCjD4EQGaMc8wouUNC