### PR TITLE
feat(packaging): brew installs the app by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ docs/reviews/
 
 # The linear skill's local cache
 .cache/
+
+# Filled-in local working copies of docs (backed up privately, never committed).
+docs/*-local.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@ changes carry a **Breaking** call-out with their migration note inline.
 
 - New ways to install. A one-line installer,
   `curl -fsSL https://kendex.ai/install.sh | sh`, that installs the app and
-  the CLI on Linux and the CLI on macOS; `brew install --cask kendex` and
-  `yay -S kendex-bin`, which install the app and the CLI together; and
-  CLI-only channels `brew install kendex`, `yay -S kendex`, and `kendex-git`.
+  the CLI on Linux and the CLI on macOS;
+  `brew install vanillagreencom/kendex/kendex` and `yay -S kendex-bin`,
+  which install the app and the CLI together; and CLI-only channels
+  `brew install vanillagreencom/kendex/kendex-cli`, `yay -S kendex`, and
+  `kendex-git`.
 - The default catalog now offers curated bundles and tagged packages, so you
   can install a working set in one step: orchestration, code-review,
   research, and commit-guards.
@@ -29,6 +31,11 @@ changes carry a **Breaking** call-out with their migration note inline.
 
 - The app uses the Geist typeface, with titles and navigation in Geist Mono
   to match the website.
+- **Breaking**: the default Homebrew install is now the app —
+  `brew install vanillagreencom/kendex/kendex` installs the desktop app and
+  the CLI together on macOS, and the CLI-only formula was renamed. Anyone
+  on the old `kendex` formula migrates with `brew uninstall kendex &&
+  brew install vanillagreencom/kendex/kendex-cli`.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -62,12 +62,13 @@ curl -fsSL https://kendex.ai/install.sh | sh
 On Linux this installs the app and the `kendex` command. On macOS it installs
 the command; get the app with the cask below.
 
-- macOS: `brew install --cask kendex`
+- macOS: `brew install vanillagreencom/kendex/kendex`
 - Arch: `yay -S kendex-bin`
 - Windows: download the installer from
   [kendex.ai/download](https://kendex.ai/download).
 
-For the CLI on its own: `brew install kendex`, `yay -S kendex`, or the curl
+For the CLI on its own: `brew install vanillagreencom/kendex/kendex-cli`,
+`yay -S kendex`, or the curl
 command on macOS. Every install option is on
 [kendex.ai/download](https://kendex.ai/download).
 

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@
 #   curl -fsSL https://kendex.ai/install.sh | sh
 #
 # On Linux this installs the desktop app and the kendex command. On macOS it
-# installs the kendex command; get the app with `brew install --cask kendex`
+# installs the kendex command; get the app with `brew install vanillagreencom/kendex/kendex`
 # or from https://kendex.ai/download.
 set -euo pipefail
 
@@ -111,7 +111,7 @@ install_cli
 if [ "$kind" = linux ]; then
   install_app_linux
 else
-  echo "Desktop app: brew install --cask kendex, or https://kendex.ai/download"
+  echo "Desktop app: brew install vanillagreencom/kendex/kendex, or https://kendex.ai/download"
 fi
 
 case ":$PATH:" in

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -7,8 +7,8 @@ and the CLI install together; the CLI is also available on its own.
 | Channel | Command | Installs | Recipe |
 |---|---|---|---|
 | curl | `curl -fsSL https://kendex.ai/install.sh \| sh` | app + CLI (Linux), CLI (macOS) | [`/install.sh`](../install.sh) |
-| Homebrew cask | `brew install --cask kendex` | app + CLI | [`homebrew/kendex-cask.rb`](homebrew/kendex-cask.rb) |
-| Homebrew formula | `brew install kendex` | CLI | [`homebrew/kendex.rb`](homebrew/kendex.rb) |
+| Homebrew | `brew install vanillagreencom/kendex/kendex` | app + CLI | [`homebrew/kendex-cask.rb`](homebrew/kendex-cask.rb) |
+| Homebrew (CLI) | `brew install vanillagreencom/kendex/kendex-cli` | CLI | [`homebrew/kendex-cli.rb`](homebrew/kendex-cli.rb) |
 | Arch | `yay -S kendex-bin` | app + CLI | [`arch/kendex-bin/`](arch/kendex-bin/) |
 | Arch (CLI) | `yay -S kendex` | CLI | [`arch/kendex/`](arch/kendex/) |
 | Arch (latest commit) | `yay -S kendex-git` | CLI | [`arch/kendex-git/`](arch/kendex-git/) |
@@ -26,14 +26,16 @@ Each new `vX.Y.Z` changes the artifact checksums. Update, in this repo:
   released `kendex-x86_64-unknown-linux-gnu`).
 - `arch/kendex-bin/PKGBUILD` + `.SRCINFO`: `pkgver` and all three
   `sha256sums` (AppImage, CLI binary, icon).
-- `homebrew/kendex.rb`: `version` and both `sha256` lines.
+- `homebrew/kendex-cli.rb`: `version` and both `sha256` lines.
 - `homebrew/kendex-cask.rb`: `version` and the `.dmg` `sha256`.
 
 Then push the recipes to their channels:
 
-- **Homebrew**: copy `homebrew/kendex.rb` to `Formula/kendex.rb` and
+- **Homebrew**: copy `homebrew/kendex-cli.rb` to `Formula/kendex-cli.rb` and
   `homebrew/kendex-cask.rb` to `Casks/kendex.rb` in the tap repo
-  `vanillagreencom/homebrew-kendex`, and commit.
+  `vanillagreencom/homebrew-kendex`, and commit. The formula deliberately
+  is NOT named `kendex`: brew resolves a formula before a cask, and the
+  plain name must reach the cask so the default install is the app.
 - **Arch**: in each AUR package clone, copy the `PKGBUILD` + `.SRCINFO` and
   `git push` to `ssh://aur@aur.archlinux.org/<name>.git`. Pushing needs the
   AUR account's SSH key.

--- a/packaging/homebrew/kendex-cask.rb
+++ b/packaging/homebrew/kendex-cask.rb
@@ -1,7 +1,9 @@
 # Homebrew cask for the kendex desktop app. Lives in the tap
-# `vanillagreencom/homebrew-kendex` as `Casks/kendex.rb`, installed with:
+# `vanillagreencom/homebrew-kendex` as `Casks/kendex.rb`. The formula is
+# named kendex-cli, so the plain name resolves here and the DEFAULT brew
+# install is the app:
 #
-#   brew install --cask kendex
+#   brew install vanillagreencom/kendex/kendex
 #
 # Installs the app and, through the formula dependency, the kendex command.
 cask "kendex" do
@@ -14,7 +16,7 @@ cask "kendex" do
   homepage "https://kendex.ai"
 
   depends_on arch: :arm64
-  depends_on formula: "vanillagreencom/kendex/kendex"
+  depends_on formula: "vanillagreencom/kendex/kendex-cli"
 
   app "kendex.app"
 

--- a/packaging/homebrew/kendex-cli.rb
+++ b/packaging/homebrew/kendex-cli.rb
@@ -1,10 +1,13 @@
-# Homebrew formula for the kendex CLI. Lives in the tap
-# `vanillagreencom/homebrew-kendex`, installed with:
+# Homebrew formula for the kendex CLI on its own. Lives in the tap
+# `vanillagreencom/homebrew-kendex` as `Formula/kendex-cli.rb`, installed
+# with:
 #
-#   brew install vanillagreencom/kendex/kendex
+#   brew install vanillagreencom/kendex/kendex-cli
 #
-# Installs the prebuilt release binary — no toolchain needed.
-class Kendex < Formula
+# The plain `kendex` name belongs to the cask, so the default install is
+# the app; this formula is the CLI-only channel and what the cask depends
+# on. Installs the prebuilt release binary — no toolchain needed.
+class KendexCli < Formula
   desc "Package manager for agents, skills, and hooks across AI coding tools"
   homepage "https://kendex.ai"
   version "5.0.1"

--- a/tools/guard
+++ b/tools/guard
@@ -83,6 +83,15 @@ hits=$(scan 'allow\((dead_code|unused)' | grep -vE "$guard_impl")
 # catalog path is caught wherever it is added. source/browse/safety.rs is not
 # here on purpose: its one fs read is of kendex's own cache record under the
 # store, never a catalog path, and adding it would flag that legitimate read.
+# The plain Homebrew name must resolve to the cask (the app): brew checks
+# formulas first, so a formula claiming `kendex` silently flips the default
+# install back to CLI-only.
+hits=$(scan 'class Kendex < Formula' '^packaging/homebrew/')
+[ -n "$hits" ] && {
+  echo "$hits"
+  say "a Homebrew formula claims the plain kendex name — the cask owns it; name the formula KendexCli"
+}
+
 hits=$(scan 'std::fs::read|crate::fs::read' '^crates/core/src/(source\.rs|check_catalog\.rs|library\.rs|source/(about|browse|bundles|catalog|config|discover|index|meta|plugin_registry)\.rs|source/browse/preview\.rs|render/skill\.rs|engine/(desired|ops))|^crates/app/src/editor\.rs')
 [ -n "$hits" ] && {
   echo "$hits" | head -5


### PR DESCRIPTION
Owner ask: `brew install` should give Mac users the app by default, with CLI-only as the special case. Homebrew resolves a formula before a cask, so while a formula owned the plain `kendex` name the default install was CLI-only. The formula moves to `kendex-cli` (the cask depends on it and still installs the CLI beside the app), the plain name now reaches the cask, and every doc — README, install.sh's macOS hint, packaging/README — says `brew install vanillagreencom/kendex/kendex` for the app and `…/kendex-cli` for the CLI alone. The packaging README records why the formula must never be named `kendex`.

The tap repo and the kendex.ai download page get the matching updates once this merges; the CHANGELOG carries the migration line for anyone on the old CLI formula.

https://claude.ai/code/session_01Jx2yfoaodk4rDpdWDqgoMk
