### PR TITLE
feat(KEN-448): Marketplaces: browse any community marketplace, its packages and files in-app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@ changes carry a **Breaking** call-out with their migration note inline.
   opens. It is also the fix for a display set to a fractional scale, which
   GTK rounds to a whole number. If the window cannot take your size, it
   opens at 100% and says so, and the size you chose is kept for next time.
+- Marketplaces › Community: a listed marketplace opens in the app before
+  you subscribe — its packages and bundles, each package's README, files
+  and safety findings, and the About report — on the same pages a
+  subscription gets. Subscribe from any of them and the page carries on as
+  the subscription, Install and all. A Skills.sh hit opens its repository
+  the same way. An unreachable repository says so on the page, with a way
+  to try again.
 - New ways to install. A one-line installer,
   `curl -fsSL https://kendex.ai/install.sh | sh`, that installs the app and
   the CLI on Linux and the CLI on macOS;

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -65,6 +65,7 @@ pub fn specta_builder() -> Builder<tauri::Wry> {
             sources::bundle_install,
             marketplaces::marketplaces_overview,
             marketplaces::marketplace_packages,
+            marketplaces::marketplace_summary,
             marketplaces::marketplace_bundle,
             marketplaces::marketplace_package_preview,
             marketplaces::marketplace_install,

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -68,6 +68,7 @@ pub fn specta_builder() -> Builder<tauri::Wry> {
             marketplaces::marketplace_summary,
             marketplaces::marketplace_bundle,
             marketplaces::marketplace_package_preview,
+            marketplaces::marketplace_package_file,
             marketplaces::marketplace_install,
             marketplaces::marketplace_subscribe,
             unsubscribe::marketplace_unsubscribe_preview,

--- a/crates/app/src/marketplaces.rs
+++ b/crates/app/src/marketplaces.rs
@@ -176,6 +176,20 @@ pub fn marketplace_package_preview(
     Ok(PackageView { preview, safety })
 }
 
+/// One offered file's content before install — the same read an installed
+/// package's file gets, confined to the package inside the catalog.
+#[tauri::command(async)]
+#[specta::specta]
+pub fn marketplace_package_file(
+    catalog: Catalog,
+    kind: ItemKind,
+    name: String,
+    path: String,
+) -> Result<kendex_core::engine::ItemSource, String> {
+    let env = env()?;
+    browse::package_file(&env, &catalog, kind, &name, &path).map_err(|e| e.to_string())
+}
+
 /// One selected package, by the kind and name the catalog offers it under.
 #[derive(Debug, Clone, Deserialize, Type)]
 #[serde(rename_all = "camelCase")]

--- a/crates/app/src/marketplaces.rs
+++ b/crates/app/src/marketplaces.rs
@@ -73,6 +73,9 @@ pub struct MarketplaceRow {
     pub scope: Scope,
     pub name: String,
     pub repo: Option<String>,
+    /// The canonical `owner/repo` a GitHub declaration folds to — what a
+    /// directory row is matched against, however the subscription spells it.
+    pub repo_key: Option<String>,
     pub path: Option<String>,
     pub rev: Option<String>,
     /// The commit the subscription reads right now, when the cache holds one.
@@ -100,6 +103,10 @@ pub fn marketplaces_overview() -> Result<Vec<MarketplaceRow>, String> {
             rows.push(MarketplaceRow {
                 scope: row.scope,
                 name: row.name,
+                repo_key: row
+                    .repo
+                    .as_deref()
+                    .and_then(kendex_core::repo_move::owner_repo),
                 repo: row.repo,
                 path: row.path,
                 rev: row.rev,

--- a/crates/app/src/marketplaces.rs
+++ b/crates/app/src/marketplaces.rs
@@ -1,8 +1,9 @@
 //! The Marketplaces pages' commands: every subscription with what its
-//! catalog says about itself, one subscription's packages and curated sets,
-//! a package's preview beside its safety verdict, installing, subscribing,
-//! and the Library's From column — thin shells over core, like every other
-//! command here.
+//! catalog says about itself, one catalog's packages and curated sets, a
+//! package's preview beside its safety verdict, installing, subscribing, and
+//! the Library's From column — thin shells over core, like every other
+//! command here. Reads take a [`Catalog`]: a subscription, or a repository
+//! opened from the Community tab before subscribing.
 
 use kendex_core::apply;
 use kendex_core::engine::ops::{self as engine_ops, AddRequest};
@@ -11,7 +12,7 @@ use kendex_core::library::{self, ProvenanceRow};
 use kendex_core::manifest::{Manifest, ManifestFile, manifest_path};
 use kendex_core::model::{ItemKind, Scope};
 use kendex_core::source::browse::{
-    self, AvailablePackage, BundleDetail, PackagePreview, PackageSafety,
+    self, AvailablePackage, BundleDetail, Catalog, CatalogSummary, PackagePreview, PackageSafety,
 };
 use kendex_core::source::{CatalogFinding, CatalogMode, MarketplaceMeta, SourceConfig};
 use kendex_core::source_ops;
@@ -118,25 +119,31 @@ pub fn marketplaces_overview() -> Result<Vec<MarketplaceRow>, String> {
     Ok(rows)
 }
 
-/// Every package one subscription offers, across kinds, with installed
-/// state joined in.
+/// Every package one catalog offers, across kinds, with installed state
+/// joined in.
 #[tauri::command(async)]
 #[specta::specta]
-pub fn marketplace_packages(scope: Scope, source: String) -> Result<Vec<AvailablePackage>, String> {
+pub fn marketplace_packages(catalog: Catalog) -> Result<Vec<AvailablePackage>, String> {
     let env = env()?;
-    browse::packages(&env, &scope, &source).map_err(|e| e.to_string())
+    browse::packages(&env, &catalog).map_err(|e| e.to_string())
+}
+
+/// What a catalog says about itself, fetched fresh for a repository nobody
+/// subscribes to — the marketplace page's header, and the subscription to
+/// carry on as when this machine already holds one.
+#[tauri::command(async)]
+#[specta::specta]
+pub fn marketplace_summary(catalog: Catalog) -> Result<CatalogSummary, String> {
+    let env = env()?;
+    browse::summary(&env, &catalog).map_err(|e| e.to_string())
 }
 
 /// One curated set with per-member installed state.
 #[tauri::command(async)]
 #[specta::specta]
-pub fn marketplace_bundle(
-    scope: Scope,
-    source: String,
-    name: String,
-) -> Result<BundleDetail, String> {
+pub fn marketplace_bundle(catalog: Catalog, name: String) -> Result<BundleDetail, String> {
     let env = env()?;
-    browse::bundle(&env, &scope, &source, &name).map_err(|e| e.to_string())
+    browse::bundle(&env, &catalog, &name).map_err(|e| e.to_string())
 }
 
 /// The available-package page's one payload: the preview beside the safety
@@ -151,16 +158,14 @@ pub struct PackageView {
 #[tauri::command(async)]
 #[specta::specta]
 pub fn marketplace_package_preview(
-    scope: Scope,
-    source: String,
+    catalog: Catalog,
     kind: ItemKind,
     name: String,
 ) -> Result<PackageView, String> {
     let env = env()?;
     let preview =
-        browse::package_preview(&env, &scope, &source, kind, &name).map_err(|e| e.to_string())?;
-    let safety =
-        browse::package_safety(&env, &scope, &source, kind, &name).map_err(|e| e.to_string())?;
+        browse::package_preview(&env, &catalog, kind, &name).map_err(|e| e.to_string())?;
+    let safety = browse::package_safety(&env, &catalog, kind, &name).map_err(|e| e.to_string())?;
     Ok(PackageView { preview, safety })
 }
 
@@ -232,7 +237,10 @@ pub fn marketplace_install(
     }
     .map_err(|e| e.to_string())?;
     apply::execute(&env, &report.plan, None).map_err(|e| e.to_string())?;
-    marketplace_packages(target, source)
+    marketplace_packages(Catalog::Subscription {
+        scope: target,
+        source,
+    })
 }
 
 /// What subscribing declared, after the plan ran.
@@ -303,10 +311,9 @@ pub struct AboutView {
 
 #[tauri::command(async)]
 #[specta::specta]
-pub fn marketplace_about(scope: Scope, source: String) -> Result<AboutView, String> {
+pub fn marketplace_about(catalog: Catalog) -> Result<AboutView, String> {
     let env = env()?;
-    let (sealed, config) = open_catalog(&env, &scope, &source)?;
-    let about = kendex_core::source::about(&sealed, &config);
+    let about = browse::about(&env, &catalog).map_err(|e| e.to_string())?;
     Ok(AboutView {
         mode: about.mode,
         found: about

--- a/crates/cli/src/commands/marketplace_browse.rs
+++ b/crates/cli/src/commands/marketplace_browse.rs
@@ -40,7 +40,11 @@ pub fn run_browse(
         for name in names {
             // A subscription that will not open costs its own rows, not the
             // whole listing — the same tolerance the app's overview shows.
-            let Ok(packages) = kendex_core::source::browse::packages(env, &scope, &name) else {
+            let catalog = kendex_core::source::browse::Catalog::Subscription {
+                scope: scope.clone(),
+                source: name.clone(),
+            };
+            let Ok(packages) = kendex_core::source::browse::packages(env, &catalog) else {
                 continue;
             };
             for package in packages {

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -112,6 +112,11 @@ pub enum CoreError {
     #[error("unknown source '{name}' — declare [sources.{name}] first")]
     UnknownSource { name: String },
 
+    #[error(
+        "'{reference}' is not a GitHub repository (owner/repo) — subscribe to it to browse its contents"
+    )]
+    NotBrowsable { reference: String },
+
     #[error("'{reference}': {reason}")]
     SourceRefInvalid { reference: String, reason: String },
 

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -117,6 +117,9 @@ pub enum CoreError {
     )]
     NotBrowsable { reference: String },
 
+    #[error("{repo} could not be fetched: {reason}")]
+    FetchFailed { repo: String, reason: String },
+
     #[error("'{reference}': {reason}")]
     SourceRefInvalid { reference: String, reason: String },
 

--- a/crates/core/src/package/detail.rs
+++ b/crates/core/src/package/detail.rs
@@ -192,25 +192,8 @@ pub fn package_file(
     name: &str,
     rel: &str,
 ) -> Result<ItemSource> {
-    let clean = Path::new(rel);
-    let traversal = clean.is_absolute()
-        || clean
-            .components()
-            .any(|c| !matches!(c, std::path::Component::Normal(_)));
-    if rel.is_empty() || traversal {
-        return Err(CoreError::SourceEscape {
-            path: clean.to_path_buf(),
-            reason: "a package file is named by a plain relative path".to_owned(),
-        });
-    }
     let (sealed, item_path) = effective_item(env, scope, kind, name)?;
-    let target = if sealed.is_dir(&item_path) {
-        item_path.join(clean)
-    } else {
-        item_path.clone()
-    };
-    let bytes = sealed.read(&target)?;
-    Ok(capped(&target, bytes))
+    super::item_file::item_file(&sealed, &item_path, rel)
 }
 
 /// The package's readme, when it ships one at its root: exact `README.md`
@@ -374,7 +357,7 @@ fn catalog_meta(
     })
 }
 
-fn capped(path: &Path, bytes: Vec<u8>) -> ItemSource {
+pub(crate) fn capped(path: &Path, bytes: Vec<u8>) -> ItemSource {
     const MAX: usize = 64 * 1024;
     let taken = {
         let mut at = bytes.len().min(MAX);

--- a/crates/core/src/package/item_file.rs
+++ b/crates/core/src/package/item_file.rs
@@ -1,0 +1,31 @@
+//! One file of a sealed item, read for preview — shared by an installed
+//! package's page and a catalog's offered package.
+
+use std::path::Path;
+
+use crate::engine::ItemSource;
+use crate::error::{CoreError, Result};
+use crate::source_read::SealedSource;
+
+/// The validated read behind [`package_file`], for any sealed item — an
+/// installed package's or a catalog's offered one.
+pub(crate) fn item_file(sealed: &SealedSource, item_path: &Path, rel: &str) -> Result<ItemSource> {
+    let clean = Path::new(rel);
+    let traversal = clean.is_absolute()
+        || clean
+            .components()
+            .any(|c| !matches!(c, std::path::Component::Normal(_)));
+    if rel.is_empty() || traversal {
+        return Err(CoreError::SourceEscape {
+            path: clean.to_path_buf(),
+            reason: "a package file is named by a plain relative path".to_owned(),
+        });
+    }
+    let target = if sealed.is_dir(item_path) {
+        item_path.join(clean)
+    } else {
+        item_path.to_path_buf()
+    };
+    let bytes = sealed.read(&target)?;
+    Ok(super::detail::capped(&target, bytes))
+}

--- a/crates/core/src/package/mod.rs
+++ b/crates/core/src/package/mod.rs
@@ -18,6 +18,7 @@ use crate::source_read::SealedSource;
 
 pub mod detail;
 pub mod diff;
+pub(crate) mod item_file;
 pub mod updates;
 
 /// One declared package bound to its repository coordinates: where its

--- a/crates/core/src/registry/view.rs
+++ b/crates/core/src/registry/view.rs
@@ -26,6 +26,9 @@ pub struct DirectoryView {
 #[serde(rename_all = "camelCase")]
 pub struct DirectoryRow {
     pub repo: String,
+    /// The canonical key a subscription's `repo_key` is compared with, so
+    /// the row can flip to Subscribed from the live subscription list.
+    pub repo_key: Option<String>,
     pub name: String,
     pub description: Option<String>,
     pub tags: Vec<String>,
@@ -46,10 +49,13 @@ pub fn directory(env: &Env, fetch: &dyn Fetch, force_refresh: bool) -> Result<Di
         .into_iter()
         .map(|market| {
             let name = market.name.clone().unwrap_or_else(|| leaf_of(&market.repo));
-            let is_subscribed =
-                repo_move::owner_repo(&market.repo).is_some_and(|key| subscribed.contains(&key));
+            let repo_key = repo_move::owner_repo(&market.repo);
+            let is_subscribed = repo_key
+                .as_ref()
+                .is_some_and(|key| subscribed.contains(key));
             DirectoryRow {
                 repo: market.repo,
+                repo_key,
                 name,
                 description: market.description,
                 tags: market.tags,

--- a/crates/core/src/registry/view.rs
+++ b/crates/core/src/registry/view.rs
@@ -6,7 +6,6 @@
 use crate::clock;
 use crate::env::Env;
 use crate::error::Result;
-use crate::model::Scope;
 use crate::registry::index::{DirectoryBundle, DirectoryPackage};
 use crate::registry::{Fetch, cache};
 use crate::repo_move;
@@ -71,30 +70,12 @@ pub fn directory(env: &Env, fetch: &dyn Fetch, force_refresh: bool) -> Result<Di
 }
 
 /// Every repository any scope subscribes to, spelled the one canonical
-/// way. A scope that cannot be read contributes nothing rather than
-/// blocking the tab.
+/// way.
 fn subscribed_repos(env: &Env) -> BTreeSet<String> {
-    let mut repos = BTreeSet::new();
-    let mut scopes = vec![Scope::Global];
-    if let Ok(settings) = crate::settings::load(env) {
-        scopes.extend(
-            settings
-                .projects
-                .into_iter()
-                .map(|root| Scope::Project { root }),
-        );
-    }
-    for scope in scopes {
-        let Ok(rows) = crate::source_ops::list_subscriptions(env, &scope) else {
-            continue;
-        };
-        for row in rows {
-            if let Some(key) = row.repo.as_deref().and_then(repo_move::owner_repo) {
-                repos.insert(key);
-            }
-        }
-    }
-    repos
+    crate::source_ops::repo_subscriptions(env)
+        .into_iter()
+        .filter_map(|row| row.repo_key)
+        .collect()
 }
 
 fn leaf_of(repo: &str) -> String {

--- a/crates/core/src/remote.rs
+++ b/crates/core/src/remote.rs
@@ -90,7 +90,7 @@ pub fn sync(env: &Env, repo: &str, rev: Option<&str>) -> Result<Resolution> {
     let _guard = store::lock_repo(env, &key)?;
     let fetched = store::ensure_mirror(&mirror, &url).and_then(|()| store::fetch(&mirror));
     stamp_fetch(env, &key, &mirror, &fetched);
-    let warning = match fetched {
+    let warning = match &fetched {
         Ok(()) => None,
         Err(error) => Some(format!("{repo}: using cached version ({error})")),
     };
@@ -98,12 +98,18 @@ pub fn sync(env: &Env, repo: &str, rev: Option<&str>) -> Result<Resolution> {
         // The mirror cannot name this selector: nothing was fetched, or the
         // branch or tag is gone upstream. The pre-2.0 clone is the last
         // thing left that might hold content.
-        return match legacy_resolution(env, repo) {
-            Some(resolution) => Ok(resolution),
-            None => Err(CoreError::PinUnavailable {
+        return match (legacy_resolution(env, repo), fetched) {
+            (Some(resolution), _) => Ok(resolution),
+            // Nothing was ever fetched: the fetch failure is the whole
+            // story, and "pinned" or "cached" would both be untrue.
+            (None, Err(error)) => Err(CoreError::FetchFailed {
+                repo: repo.to_owned(),
+                reason: error.to_string(),
+            }),
+            (None, Ok(())) => Err(CoreError::PinUnavailable {
                 repo: repo.to_owned(),
                 pin: selector.to_owned(),
-                reason: warning.unwrap_or_else(|| "no such branch or tag".to_owned()),
+                reason: "no such branch or tag".to_owned(),
             }),
         };
     };

--- a/crates/core/src/repo_move.rs
+++ b/crates/core/src/repo_move.rs
@@ -24,8 +24,11 @@ pub const MOVE_DESCRIPTION: &str = "Point kendex at its new repository";
 /// The public spelling of the normalization for callers outside this
 /// module — the Community tab matches directory rows against existing
 /// subscriptions by what the string names, never by literal spellings.
+/// The moved default folds to its new key: a scope still declaring the
+/// old repository subscribes to the same catalog the directory lists
+/// under the new one, and every side that matches keys must say so.
 pub fn owner_repo(reference: &str) -> Option<String> {
-    github_owner_repo(reference)
+    github_owner_repo(canonical(reference))
 }
 
 pub(crate) fn github_owner_repo(reference: &str) -> Option<String> {
@@ -156,6 +159,18 @@ mod tests {
         // A substring is a different repository, never a match.
         assert!(!names_old_default("vanillagreencom/vstack-extras"));
         assert!(!names_old_default("vanillagreencom/vstack2"));
+    }
+
+    #[test]
+    fn the_public_key_of_the_moved_default_is_its_new_repository() {
+        assert_eq!(
+            owner_repo("git@github.com:VanillaGreenCom/vstack.git").as_deref(),
+            Some(DEFAULT_SOURCE_REPO)
+        );
+        assert_eq!(
+            owner_repo("someone/vstack").as_deref(),
+            Some("someone/vstack")
+        );
     }
 
     #[test]

--- a/crates/core/src/source/browse.rs
+++ b/crates/core/src/source/browse.rs
@@ -30,7 +30,7 @@ mod safety;
 mod summary;
 pub use catalog::Catalog;
 use catalog::browsable;
-pub use preview::{PackagePreview, package_preview};
+pub use preview::{PackagePreview, package_file, package_preview};
 pub use safety::{PackageSafety, package_safety};
 pub use summary::{CatalogSummary, SubscriptionRef, about, summary};
 

--- a/crates/core/src/source/browse.rs
+++ b/crates/core/src/source/browse.rs
@@ -24,39 +24,15 @@ use crate::quality::Verdict;
 use crate::source_read::SealedSource;
 use crate::tags::Tag;
 
+mod catalog;
 mod preview;
 mod safety;
 mod summary;
+pub use catalog::Catalog;
+use catalog::browsable;
 pub use preview::{PackagePreview, package_preview};
 pub use safety::{PackageSafety, package_safety};
 pub use summary::{CatalogSummary, SubscriptionRef, about, summary};
-
-/// What a browse read addresses: a subscription, or a GitHub repository
-/// browsed before anyone subscribes to it. The second fetches into the same
-/// store a later subscription reads from, so subscribing never downloads
-/// twice and the pages keep working across the switch.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type)]
-#[serde(tag = "by", rename_all = "camelCase")]
-pub enum Catalog {
-    Subscription {
-        scope: Scope,
-        source: String,
-    },
-    /// `owner/repo` on GitHub, as the directory spells it.
-    Repo {
-        repo: String,
-    },
-}
-
-impl Catalog {
-    /// How the catalog is named in an error or a title.
-    pub fn label(&self) -> &str {
-        match self {
-            Catalog::Subscription { source, .. } => source,
-            Catalog::Repo { repo } => repo,
-        }
-    }
-}
 
 /// Whether one offered package exists in this scope.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Type)]
@@ -129,9 +105,7 @@ pub(crate) struct Browsed {
     pub(crate) source: super::ResolvedSource,
     pub(crate) sealed: SealedSource,
     pub(crate) config: super::SourceConfig,
-    /// The subscription's name when there is one. A bare repository is
-    /// subscribed as nothing, so nothing is installed "from here" and every
-    /// declared name is a collision.
+    /// The subscription's name when there is one — see [`Browsed::owned_here`].
     subscription: Option<String>,
 }
 
@@ -151,20 +125,51 @@ fn records(env: &Env, scope: &Scope) -> Result<(Manifest, Lock)> {
 }
 
 pub(crate) fn open(env: &Env, catalog: &Catalog) -> Result<Browsed> {
-    let (manifest, lock, source, subscription) = match catalog {
+    match catalog {
         Catalog::Subscription { scope, source } => {
             let (manifest, lock) = records(env, scope)?;
             let resolved = super::require_ready(env, scope, source, &manifest)?;
-            (manifest, lock, resolved, Some(source.clone()))
+            browsed(manifest, lock, resolved, Some(source.clone()))
         }
         Catalog::Repo { repo } => {
-            // Collisions are judged against the personal scope: that is
-            // where Subscribe lands by default, so the warning shown here
-            // is the refusal an install there would meet.
-            let (manifest, lock) = records(env, &Scope::Global)?;
-            (manifest, lock, resolve_repo(env, repo)?, None)
+            let key = browsable(repo)?;
+            // The store answers without the network when it already holds
+            // the repository; otherwise this is the one fetch.
+            let resolution = match crate::remote::cached(env, &key, None)? {
+                Some(resolution) => resolution,
+                None => crate::remote::sync(env, &key, None)?,
+            };
+            open_repo(env, key, resolution)
         }
+    }
+}
+
+/// A repository nobody subscribes to, at the resolution the caller already
+/// holds — `summary` refreshes first and reads what it fetched.
+pub(super) fn open_repo(
+    env: &Env,
+    key: String,
+    resolution: crate::remote::Resolution,
+) -> Result<Browsed> {
+    // Collisions are judged against the personal scope: that is where
+    // Subscribe lands by default, so the warning shown here is the refusal
+    // an install there would meet.
+    let (manifest, lock) = records(env, &Scope::Global)?;
+    let source = super::ResolvedSource {
+        name: key.clone(),
+        root: resolution.root,
+        provenance: key,
+        commit: Some(resolution.commit),
     };
+    browsed(manifest, lock, source, None)
+}
+
+fn browsed(
+    manifest: Manifest,
+    lock: Lock,
+    source: super::ResolvedSource,
+    subscription: Option<String>,
+) -> Result<Browsed> {
     let sealed = SealedSource::open(&source.root)?;
     let config = super::source_config_for(&sealed, &source.provenance)?;
     Ok(Browsed {
@@ -177,54 +182,33 @@ pub(crate) fn open(env: &Env, catalog: &Catalog) -> Result<Browsed> {
     })
 }
 
-/// The checked-out head of a repository nobody subscribes to. The store
-/// answers without the network when it already holds the repository;
-/// otherwise this is the one fetch, into the store a subscription would
-/// use. Only GitHub's `owner/repo` is browsable this way — that is what the
-/// directory and skills.sh hand over, and anything else is a reference to
-/// subscribe to, not to open blind.
-fn resolve_repo(env: &Env, repo: &str) -> Result<super::ResolvedSource> {
-    if crate::repo_move::owner_repo(repo).is_none() {
-        return Err(CoreError::NotBrowsable {
-            reference: repo.to_owned(),
-        });
-    }
-    // Kept in the directory's spelling: the store keys by it, and Subscribe
-    // is prefilled with the same string, so the two share one download.
-    let repo = repo.trim();
-    let resolution = match crate::remote::cached(env, repo, None)? {
-        Some(resolution) => resolution,
-        None => crate::remote::sync(env, repo, None)?,
-    };
-    Ok(super::ResolvedSource {
-        name: repo.to_owned(),
-        root: resolution.root,
-        provenance: repo.to_owned(),
-        commit: Some(resolution.commit),
-    })
-}
-
 impl Browsed {
+    /// Whether an installation or declaration belongs to this catalog. A
+    /// bare repository is subscribed as nothing, so nothing is installed
+    /// "from here" and every declared name is a collision.
+    fn owned_here(&self, source: &str) -> bool {
+        self.subscription.as_deref() == Some(source)
+    }
+
     fn locked_here(&self, kind: ItemKind, name: &str) -> bool {
-        self.lock.entries.values().any(|entry| {
-            entry.kind == kind
-                && entry.name == name
-                && Some(&entry.source) == self.subscription.as_ref()
-        })
+        self.lock
+            .entries
+            .values()
+            .any(|entry| entry.kind == kind && entry.name == name && self.owned_here(&entry.source))
     }
 
     fn declared_here(&self, kind: ItemKind, name: &str) -> bool {
         self.manifest
             .declared(kind)
             .get(name)
-            .is_some_and(|decl| Some(&decl.source) == self.subscription.as_ref())
+            .is_some_and(|decl| self.owned_here(&decl.source))
     }
 
     fn bundle_declared(&self, name: &str) -> bool {
         self.manifest
             .bundles
             .get(name)
-            .is_some_and(|decl| Some(&decl.source) == self.subscription.as_ref())
+            .is_some_and(|decl| self.owned_here(&decl.source))
     }
 
     /// The lock+manifest join behind every state column. `asked_for` says a
@@ -255,7 +239,7 @@ impl Browsed {
     /// fork counts too — `local` is a source like any other here.
     fn collision(&self, kind: ItemKind, name: &str) -> Option<String> {
         if let Some(decl) = self.manifest.declared(kind).get(name)
-            && Some(&decl.source) != self.subscription.as_ref()
+            && !self.owned_here(&decl.source)
         {
             return Some(decl.source.clone());
         }
@@ -263,9 +247,7 @@ impl Browsed {
             .entries
             .values()
             .find(|entry| {
-                entry.kind == kind
-                    && entry.name == name
-                    && Some(&entry.source) != self.subscription.as_ref()
+                entry.kind == kind && entry.name == name && !self.owned_here(&entry.source)
             })
             .map(|entry| entry.source.clone())
     }
@@ -274,7 +256,7 @@ impl Browsed {
         self.manifest
             .bundles
             .get(name)
-            .filter(|decl| Some(&decl.source) != self.subscription.as_ref())
+            .filter(|decl| !self.owned_here(&decl.source))
             .map(|decl| decl.source.clone())
     }
 }

--- a/crates/core/src/source/browse.rs
+++ b/crates/core/src/source/browse.rs
@@ -1,9 +1,12 @@
-//! Browsing one subscription: every package it offers, its curated sets
-//! with per-member installed state, and a package's preview before install.
+//! Browsing one catalog: every package it offers, its curated sets with
+//! per-member installed state, and a package's preview before install.
 //!
-//! Everything here is read-side. Installed state is a join over the scope's
-//! manifest and lock, never stored — a bundle's partly-installed count is
-//! derived from its members on every call. Every catalog byte comes through
+//! A [`Catalog`] is either a subscription or a bare GitHub repository nobody
+//! has subscribed to yet — the Community tab opens the latter, and both read
+//! through the same functions so the app has one detail surface. Everything
+//! here is read-side. Installed state is a join over the scope's manifest
+//! and lock, never stored — a bundle's partly-installed count is derived
+//! from its members on every call. Every catalog byte comes through
 //! [`SealedSource`], and a catalog's own words are shown, never acted on.
 
 use std::collections::BTreeMap;
@@ -23,8 +26,37 @@ use crate::tags::Tag;
 
 mod preview;
 mod safety;
+mod summary;
 pub use preview::{PackagePreview, package_preview};
 pub use safety::{PackageSafety, package_safety};
+pub use summary::{CatalogSummary, SubscriptionRef, about, summary};
+
+/// What a browse read addresses: a subscription, or a GitHub repository
+/// browsed before anyone subscribes to it. The second fetches into the same
+/// store a later subscription reads from, so subscribing never downloads
+/// twice and the pages keep working across the switch.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type)]
+#[serde(tag = "by", rename_all = "camelCase")]
+pub enum Catalog {
+    Subscription {
+        scope: Scope,
+        source: String,
+    },
+    /// `owner/repo` on GitHub, as the directory spells it.
+    Repo {
+        repo: String,
+    },
+}
+
+impl Catalog {
+    /// How the catalog is named in an error or a title.
+    pub fn label(&self) -> &str {
+        match self {
+            Catalog::Subscription { source, .. } => source,
+            Catalog::Repo { repo } => repo,
+        }
+    }
+}
 
 /// Whether one offered package exists in this scope.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Type)]
@@ -89,7 +121,7 @@ pub struct BundleDetail {
     pub collision: Option<String>,
 }
 
-/// One subscription opened for reading, with the scope records the
+/// One catalog opened for reading, with the scope records the
 /// installed-state join needs.
 pub(crate) struct Browsed {
     pub(crate) manifest: Manifest,
@@ -97,12 +129,16 @@ pub(crate) struct Browsed {
     pub(crate) source: super::ResolvedSource,
     pub(crate) sealed: SealedSource,
     pub(crate) config: super::SourceConfig,
+    /// The subscription's name when there is one. A bare repository is
+    /// subscribed as nothing, so nothing is installed "from here" and every
+    /// declared name is a collision.
+    subscription: Option<String>,
 }
 
-pub(crate) fn open(env: &Env, scope: &Scope, source_name: &str) -> Result<Browsed> {
-    // Browsing observes: a scope whose manifest or lock is still the old
-    // generation reads as empty here rather than blocking the page — the
-    // records only feed the installed-state join.
+/// The scope records the join reads. Browsing observes: a scope whose
+/// manifest or lock is still the old generation reads as empty rather than
+/// blocking the page — the records only feed the installed-state join.
+fn records(env: &Env, scope: &Scope) -> Result<(Manifest, Lock)> {
     let manifest = match crate::manifest::load(&crate::manifest::manifest_path(env, scope))? {
         ManifestFile::Current(manifest) => *manifest,
         _ => Manifest::default(),
@@ -111,7 +147,24 @@ pub(crate) fn open(env: &Env, scope: &Scope, source_name: &str) -> Result<Browse
         LockFile::Current(lock) => lock,
         _ => Lock::default(),
     };
-    let source = super::require_ready(env, scope, source_name, &manifest)?;
+    Ok((manifest, lock))
+}
+
+pub(crate) fn open(env: &Env, catalog: &Catalog) -> Result<Browsed> {
+    let (manifest, lock, source, subscription) = match catalog {
+        Catalog::Subscription { scope, source } => {
+            let (manifest, lock) = records(env, scope)?;
+            let resolved = super::require_ready(env, scope, source, &manifest)?;
+            (manifest, lock, resolved, Some(source.clone()))
+        }
+        Catalog::Repo { repo } => {
+            // Collisions are judged against the personal scope: that is
+            // where Subscribe lands by default, so the warning shown here
+            // is the refusal an install there would meet.
+            let (manifest, lock) = records(env, &Scope::Global)?;
+            (manifest, lock, resolve_repo(env, repo)?, None)
+        }
+    };
     let sealed = SealedSource::open(&source.root)?;
     let config = super::source_config_for(&sealed, &source.provenance)?;
     Ok(Browsed {
@@ -120,13 +173,43 @@ pub(crate) fn open(env: &Env, scope: &Scope, source_name: &str) -> Result<Browse
         source,
         sealed,
         config,
+        subscription,
+    })
+}
+
+/// The checked-out head of a repository nobody subscribes to. The store
+/// answers without the network when it already holds the repository;
+/// otherwise this is the one fetch, into the store a subscription would
+/// use. Only GitHub's `owner/repo` is browsable this way — that is what the
+/// directory and skills.sh hand over, and anything else is a reference to
+/// subscribe to, not to open blind.
+fn resolve_repo(env: &Env, repo: &str) -> Result<super::ResolvedSource> {
+    if crate::repo_move::owner_repo(repo).is_none() {
+        return Err(CoreError::NotBrowsable {
+            reference: repo.to_owned(),
+        });
+    }
+    // Kept in the directory's spelling: the store keys by it, and Subscribe
+    // is prefilled with the same string, so the two share one download.
+    let repo = repo.trim();
+    let resolution = match crate::remote::cached(env, repo, None)? {
+        Some(resolution) => resolution,
+        None => crate::remote::sync(env, repo, None)?,
+    };
+    Ok(super::ResolvedSource {
+        name: repo.to_owned(),
+        root: resolution.root,
+        provenance: repo.to_owned(),
+        commit: Some(resolution.commit),
     })
 }
 
 impl Browsed {
     fn locked_here(&self, kind: ItemKind, name: &str) -> bool {
         self.lock.entries.values().any(|entry| {
-            entry.kind == kind && entry.name == name && entry.source == self.source.name
+            entry.kind == kind
+                && entry.name == name
+                && Some(&entry.source) == self.subscription.as_ref()
         })
     }
 
@@ -134,14 +217,14 @@ impl Browsed {
         self.manifest
             .declared(kind)
             .get(name)
-            .is_some_and(|decl| decl.source == self.source.name)
+            .is_some_and(|decl| Some(&decl.source) == self.subscription.as_ref())
     }
 
     fn bundle_declared(&self, name: &str) -> bool {
         self.manifest
             .bundles
             .get(name)
-            .is_some_and(|decl| decl.source == self.source.name)
+            .is_some_and(|decl| Some(&decl.source) == self.subscription.as_ref())
     }
 
     /// The lock+manifest join behind every state column. `asked_for` says a
@@ -172,7 +255,7 @@ impl Browsed {
     /// fork counts too — `local` is a source like any other here.
     fn collision(&self, kind: ItemKind, name: &str) -> Option<String> {
         if let Some(decl) = self.manifest.declared(kind).get(name)
-            && decl.source != self.source.name
+            && Some(&decl.source) != self.subscription.as_ref()
         {
             return Some(decl.source.clone());
         }
@@ -180,7 +263,9 @@ impl Browsed {
             .entries
             .values()
             .find(|entry| {
-                entry.kind == kind && entry.name == name && entry.source != self.source.name
+                entry.kind == kind
+                    && entry.name == name
+                    && Some(&entry.source) != self.subscription.as_ref()
             })
             .map(|entry| entry.source.clone())
     }
@@ -189,14 +274,14 @@ impl Browsed {
         self.manifest
             .bundles
             .get(name)
-            .filter(|decl| decl.source != self.source.name)
+            .filter(|decl| Some(&decl.source) != self.subscription.as_ref())
             .map(|decl| decl.source.clone())
     }
 }
 
-/// Every package one subscription offers, across kinds.
-pub fn packages(env: &Env, scope: &Scope, source_name: &str) -> Result<Vec<AvailablePackage>> {
-    let browsed = open(env, scope, source_name)?;
+/// Every package one catalog offers, across kinds.
+pub fn packages(env: &Env, catalog: &Catalog) -> Result<Vec<AvailablePackage>> {
+    let browsed = open(env, catalog)?;
     let mut carried: BTreeMap<(ItemKind, String), Vec<String>> = BTreeMap::new();
     for bundle in super::bundles::offered(&browsed.sealed, &browsed.config)? {
         for member in &bundle.members {
@@ -232,17 +317,12 @@ pub fn packages(env: &Env, scope: &Scope, source_name: &str) -> Result<Vec<Avail
 }
 
 /// One curated set with per-member installed state.
-pub fn bundle(
-    env: &Env,
-    scope: &Scope,
-    source_name: &str,
-    bundle_name: &str,
-) -> Result<BundleDetail> {
-    let browsed = open(env, scope, source_name)?;
+pub fn bundle(env: &Env, catalog: &Catalog, bundle_name: &str) -> Result<BundleDetail> {
+    let browsed = open(env, catalog)?;
     let Some(found) = super::bundles::find(&browsed.sealed, &browsed.config, bundle_name)? else {
         return Err(CoreError::NoSuchBundle {
             name: bundle_name.to_owned(),
-            source_name: source_name.to_owned(),
+            source_name: catalog.label().to_owned(),
         });
     };
     let declared = browsed.bundle_declared(bundle_name);

--- a/crates/core/src/source/browse/catalog.rs
+++ b/crates/core/src/source/browse/catalog.rs
@@ -1,0 +1,46 @@
+//! The address a browse read takes, and the one spelling a bare repository
+//! is fetched under.
+
+use serde::{Deserialize, Serialize};
+use specta::Type;
+
+use crate::error::{CoreError, Result};
+use crate::model::Scope;
+
+/// What a browse read addresses: a subscription, or a GitHub repository
+/// browsed before anyone subscribes to it. The second fetches into the same
+/// store a later subscription reads from, so subscribing never downloads
+/// twice and the pages keep working across the switch.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type)]
+#[serde(tag = "by", rename_all = "camelCase")]
+pub enum Catalog {
+    Subscription {
+        scope: Scope,
+        source: String,
+    },
+    /// `owner/repo` on GitHub, as the directory spells it.
+    Repo {
+        repo: String,
+    },
+}
+
+impl Catalog {
+    /// How the catalog is named in an error or a title.
+    pub fn label(&self) -> &str {
+        match self {
+            Catalog::Subscription { source, .. } => source,
+            Catalog::Repo { repo } => repo,
+        }
+    }
+}
+
+/// The one canonical `owner/repo` a blind browse fetches, keys the store
+/// and the safety cache by, and prefills Subscribe with. Only GitHub is
+/// browsable this way — that is what the directory and skills.sh hand over
+/// — and the listing never picks the transport: an `ssh://` or `http://`
+/// spelling is folded to the shorthand, which fetches over https.
+pub(crate) fn browsable(repo: &str) -> Result<String> {
+    crate::repo_move::owner_repo(repo).ok_or_else(|| CoreError::NotBrowsable {
+        reference: repo.to_owned(),
+    })
+}

--- a/crates/core/src/source/browse/catalog.rs
+++ b/crates/core/src/source/browse/catalog.rs
@@ -18,7 +18,8 @@ pub enum Catalog {
         scope: Scope,
         source: String,
     },
-    /// `owner/repo` on GitHub, as the directory spells it.
+    /// A GitHub repository, in any spelling `repo_move::owner_repo` folds
+    /// to the canonical `owner/repo` everything is keyed by.
     Repo {
         repo: String,
     },

--- a/crates/core/src/source/browse/preview.rs
+++ b/crates/core/src/source/browse/preview.rs
@@ -8,12 +8,12 @@ use specta::Type;
 
 use crate::env::Env;
 use crate::error::{CoreError, Result};
-use crate::model::{ItemKind, Scope};
+use crate::model::ItemKind;
 use crate::names;
 use crate::package::detail::PackageFile;
 use crate::tags::Tag;
 
-use super::item_header;
+use super::{Catalog, item_header};
 
 /// What the available-package page shows before anything installs.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Type)]
@@ -35,16 +35,15 @@ pub struct PackagePreview {
 
 pub fn package_preview(
     env: &Env,
-    scope: &Scope,
-    source_name: &str,
+    catalog: &Catalog,
     kind: ItemKind,
     name: &str,
 ) -> Result<PackagePreview> {
-    let browsed = super::open(env, scope, source_name)?;
+    let browsed = super::open(env, catalog)?;
     let Some(path) = crate::source::find_item(&browsed.sealed, &browsed.config, kind, name) else {
         return Err(CoreError::ItemNotInSource {
             name: name.to_owned(),
-            source_name: source_name.to_owned(),
+            source_name: catalog.label().to_owned(),
         });
     };
     let mut files = Vec::new();

--- a/crates/core/src/source/browse/preview.rs
+++ b/crates/core/src/source/browse/preview.rs
@@ -134,3 +134,23 @@ fn file_row(rel: &Path, len: usize) -> PackageFile {
         path,
     }
 }
+
+/// One offered file's content, capped for preview, before anything
+/// installs — the same validated read an installed package's file gets,
+/// confined to the package's own directory inside the sealed catalog.
+pub fn package_file(
+    env: &Env,
+    catalog: &Catalog,
+    kind: ItemKind,
+    name: &str,
+    rel: &str,
+) -> Result<crate::engine::ItemSource> {
+    let browsed = super::open(env, catalog)?;
+    let Some(path) = crate::source::find_item(&browsed.sealed, &browsed.config, kind, name) else {
+        return Err(CoreError::ItemNotInSource {
+            name: name.to_owned(),
+            source_name: catalog.label().to_owned(),
+        });
+    };
+    crate::package::item_file::item_file(&browsed.sealed, &path, rel)
+}

--- a/crates/core/src/source/browse/preview.rs
+++ b/crates/core/src/source/browse/preview.rs
@@ -48,7 +48,9 @@ pub fn package_preview(
     };
     let mut files = Vec::new();
     let readme = if browsed.sealed.is_dir(&path) {
-        for (rel, bytes) in browsed.sealed.collect_tree(&path, &[])? {
+        // The same tree scoring and install read: a repo-root skill's
+        // `.git`, `node_modules` and build output are not its files.
+        for (rel, bytes) in browsed.sealed.collect_skill_tree(&path)? {
             files.push(file_row(&rel, bytes.len()));
         }
         browsed
@@ -152,5 +154,22 @@ pub fn package_file(
             source_name: catalog.label().to_owned(),
         });
     };
+    // Only a file the preview lists is readable: the skill tree scoring
+    // and install use, never the repository around a repo-root skill.
+    let offered = if browsed.sealed.is_dir(&path) {
+        browsed
+            .sealed
+            .collect_skill_tree(&path)?
+            .into_iter()
+            .any(|(tree_rel, _)| file_row(&tree_rel, 0).path == rel)
+    } else {
+        Path::new(rel).file_name() == path.file_name() && !rel.contains('/')
+    };
+    if !offered {
+        return Err(CoreError::SourceEscape {
+            path: Path::new(rel).to_path_buf(),
+            reason: "not one of this package's offered files".to_owned(),
+        });
+    }
     crate::package::item_file::item_file(&browsed.sealed, &path, rel)
 }

--- a/crates/core/src/source/browse/safety.rs
+++ b/crates/core/src/source/browse/safety.rs
@@ -18,14 +18,14 @@ use specta::Type;
 
 use crate::env::Env;
 use crate::error::{CoreError, Result};
-use crate::model::{ItemKind, Scope};
+use crate::model::ItemKind;
 use crate::quality::{
     AuditInput, Content, Finding, QualityScore, RULESET_VERSION, SafetyScore, SkippedRule,
     TreeFile, Verdict,
 };
 use crate::source::DISCOVERY_VERSION;
 
-use super::Browsed;
+use super::{Browsed, Catalog};
 
 /// The shape of one cached record — the scanner/parser half of the cache
 /// key, beside the rule-set and discovery-table versions. Bump it when what
@@ -70,12 +70,11 @@ pub struct PackageSafety {
 
 pub fn package_safety(
     env: &Env,
-    scope: &Scope,
-    source_name: &str,
+    catalog: &Catalog,
     kind: ItemKind,
     name: &str,
 ) -> Result<PackageSafety> {
-    let browsed = super::open(env, scope, source_name)?;
+    let browsed = super::open(env, catalog)?;
     let (score, from_cache) = scored(env, &browsed, kind, name)?;
     let thresholds = crate::settings::load(env)?.safety;
     let (verdict, reasons) = crate::quality::verdict(&score.findings, &score.safety, thresholds);
@@ -155,13 +154,11 @@ fn verified(path: &std::path::Path, content_hash: &str) -> Option<CachedScore> {
 /// Where this item's record lives — beside the commit's receipt in the
 /// store. `None` where there is nothing immutable to key by: a path source
 /// can change under the same identity, so it is scored fresh each time.
+/// Only a remote resolves to a commit, and its provenance is the repository
+/// the store keys by, so a repository browsed before subscribing and the
+/// subscription that follows share one record per commit.
 fn cache_path(env: &Env, browsed: &Browsed, kind: ItemKind, name: &str) -> Option<PathBuf> {
     let commit = browsed.source.commit.as_ref()?;
-    browsed
-        .manifest
-        .sources
-        .get(&browsed.source.name)
-        .filter(|decl| decl.repo.is_some())?;
     let key = crate::remote::cache_key(env, &browsed.source.provenance);
     // The name is flattened for the filesystem; the hash keeps two names
     // one filesystem would fold together from sharing a record.

--- a/crates/core/src/source/browse/summary.rs
+++ b/crates/core/src/source/browse/summary.rs
@@ -42,10 +42,11 @@ pub struct CatalogSummary {
     pub subscription: Option<SubscriptionRef>,
 }
 
-/// One read of what the catalog says about itself. A bare repository is
-/// refreshed here — this is the page's first read, so what follows reads
-/// the head it just fetched — and a failed refresh serves the store with
-/// its warning rather than an empty page.
+/// One read of what the catalog says about itself. A bare repository that
+/// no readable subscription holds is refreshed here — this is the page's
+/// first read, so what follows reads the head it just fetched — and a
+/// failed refresh serves the store with its warning rather than an empty
+/// page.
 pub fn summary(env: &Env, catalog: &Catalog) -> Result<CatalogSummary> {
     let (browsed, warning, subscription) = match catalog {
         Catalog::Subscription { scope, source } => (
@@ -58,14 +59,21 @@ pub fn summary(env: &Env, catalog: &Catalog) -> Result<CatalogSummary> {
         ),
         Catalog::Repo { repo } => {
             let key = super::browsable(repo)?;
-            let resolution = crate::remote::sync(env, &key, None)?;
-            let warning = resolution.warning.clone();
-            let subscription = subscribed_as(env, &key);
-            (
-                super::open_repo(env, key, resolution)?,
-                warning,
-                subscription,
-            )
+            // A readable subscription already holds this repository: the
+            // page carries on as it, from its own store and without the
+            // network — a spelling that keys a different store entry must
+            // not turn an offline open into a failed fetch.
+            if let Some(held) = subscribed_as(env, &key) {
+                let catalog = Catalog::Subscription {
+                    scope: held.scope.clone(),
+                    source: held.source.clone(),
+                };
+                (super::open(env, &catalog)?, None, Some(held))
+            } else {
+                let resolution = crate::remote::sync(env, &key, None)?;
+                let warning = resolution.warning.clone();
+                (super::open_repo(env, key, resolution)?, warning, None)
+            }
         }
     };
     let mut counts = BTreeMap::new();

--- a/crates/core/src/source/browse/summary.rs
+++ b/crates/core/src/source/browse/summary.rs
@@ -28,6 +28,10 @@ pub struct SubscriptionRef {
 pub struct CatalogSummary {
     /// `owner/repo`, a path, or `local` — what the catalog is.
     pub provenance: String,
+    /// The canonical `owner/repo` the provenance folds to on GitHub — what
+    /// a subscription's `repo_key` and a directory row are matched by,
+    /// however the declaration spells it.
+    pub repo_key: Option<String>,
     /// The commit being read, for a remote.
     pub commit: Option<String>,
     /// `[marketplace]` from the catalog's own kendex.toml.
@@ -89,6 +93,7 @@ pub fn summary(env: &Env, catalog: &Catalog) -> Result<CatalogSummary> {
         }
     }
     Ok(CatalogSummary {
+        repo_key: crate::repo_move::owner_repo(&browsed.source.provenance),
         provenance: browsed.source.provenance.clone(),
         commit: browsed.source.commit.clone(),
         meta: browsed.config.marketplace.clone(),

--- a/crates/core/src/source/browse/summary.rs
+++ b/crates/core/src/source/browse/summary.rs
@@ -64,15 +64,17 @@ pub fn summary(env: &Env, catalog: &Catalog) -> Result<CatalogSummary> {
             // network — a spelling that keys a different store entry must
             // not turn an offline open into a failed fetch.
             if let Some(held) = subscribed_as(env, &key) {
-                let catalog = Catalog::Subscription {
-                    scope: held.scope.clone(),
-                    source: held.source.clone(),
-                };
-                (super::open(env, &catalog)?, None, Some(held))
+                (open_held(env, &held)?, None, Some(held))
             } else {
                 let resolution = crate::remote::sync(env, &key, None)?;
                 let warning = resolution.warning.clone();
-                (super::open_repo(env, key, resolution)?, warning, None)
+                // The fetch may be the one a never-fetched subscription
+                // under this spelling was waiting for: it is Ready now, and
+                // the page carries on as it rather than offering Subscribe.
+                match subscribed_as(env, &key) {
+                    Some(held) => (open_held(env, &held)?, warning, Some(held)),
+                    None => (super::open_repo(env, key, resolution)?, warning, None),
+                }
             }
         }
     };
@@ -95,6 +97,17 @@ pub fn summary(env: &Env, catalog: &Catalog) -> Result<CatalogSummary> {
         warning,
         subscription,
     })
+}
+
+/// A held subscription, opened from its own store.
+fn open_held(env: &Env, held: &SubscriptionRef) -> Result<super::Browsed> {
+    super::open(
+        env,
+        &Catalog::Subscription {
+            scope: held.scope.clone(),
+            source: held.source.clone(),
+        },
+    )
 }
 
 /// The About report for any catalog: how its items were decided, what was

--- a/crates/core/src/source/browse/summary.rs
+++ b/crates/core/src/source/browse/summary.rs
@@ -47,8 +47,9 @@ pub struct CatalogSummary {
 /// the head it just fetched — and a failed refresh serves the store with
 /// its warning rather than an empty page.
 pub fn summary(env: &Env, catalog: &Catalog) -> Result<CatalogSummary> {
-    let (warning, subscription) = match catalog {
+    let (browsed, warning, subscription) = match catalog {
         Catalog::Subscription { scope, source } => (
+            super::open(env, catalog)?,
             None,
             Some(SubscriptionRef {
                 scope: scope.clone(),
@@ -56,15 +57,17 @@ pub fn summary(env: &Env, catalog: &Catalog) -> Result<CatalogSummary> {
             }),
         ),
         Catalog::Repo { repo } => {
-            let warning = match crate::repo_move::owner_repo(repo) {
-                Some(_) => crate::remote::sync(env, repo.trim(), None)?.warning,
-                // open() below names the refusal.
-                None => None,
-            };
-            (warning, subscribed_as(env, repo))
+            let key = super::browsable(repo)?;
+            let resolution = crate::remote::sync(env, &key, None)?;
+            let warning = resolution.warning.clone();
+            let subscription = subscribed_as(env, &key);
+            (
+                super::open_repo(env, key, resolution)?,
+                warning,
+                subscription,
+            )
         }
     };
-    let browsed = super::open(env, catalog)?;
     let mut counts = BTreeMap::new();
     for kind in ItemKind::ALL {
         let offered = crate::source::list_items(&browsed.sealed, &browsed.config, kind).len();
@@ -94,31 +97,25 @@ pub fn about(env: &Env, catalog: &Catalog) -> Result<AboutReport> {
 }
 
 /// The first subscription, personal scope first, that points at this
-/// repository however it spells it. A scope that cannot be read holds no
-/// subscription rather than blocking the page.
-fn subscribed_as(env: &Env, repo: &str) -> Option<SubscriptionRef> {
-    let key = crate::repo_move::owner_repo(repo)?;
-    let mut scopes = vec![Scope::Global];
-    if let Ok(settings) = crate::settings::load(env) {
-        scopes.extend(
-            settings
-                .projects
-                .into_iter()
-                .map(|root| Scope::Project { root }),
-        );
-    }
-    scopes.into_iter().find_map(|scope| {
-        let rows = crate::source_ops::list_subscriptions(env, &scope).ok()?;
-        rows.into_iter()
-            .find(|row| {
-                row.repo
-                    .as_deref()
-                    .and_then(crate::repo_move::owner_repo)
-                    .is_some_and(|candidate| candidate == key)
-            })
-            .map(|row| SubscriptionRef {
-                scope,
-                source: row.name,
-            })
-    })
+/// repository however it spells it and can be read right now. One that is
+/// turned off or never fetched is passed over: the page just read the
+/// repository, and switching onto a subscription whose content is
+/// unreachable would trade that for an empty page.
+fn subscribed_as(env: &Env, key: &str) -> Option<SubscriptionRef> {
+    crate::source_ops::repo_subscriptions(env)
+        .into_iter()
+        .filter(|row| row.enabled && row.repo_key.as_deref() == Some(key))
+        .find(|row| {
+            let Ok(Some(manifest)) = crate::source_ops::load_current(env, &row.scope) else {
+                return false;
+            };
+            matches!(
+                crate::source::resolve(env, &row.scope, &row.name, &manifest),
+                Ok(crate::source::SourceState::Ready(_))
+            )
+        })
+        .map(|row| SubscriptionRef {
+            scope: row.scope,
+            source: row.name,
+        })
 }

--- a/crates/core/src/source/browse/summary.rs
+++ b/crates/core/src/source/browse/summary.rs
@@ -1,0 +1,124 @@
+//! A catalog's own account of itself — what the marketplace page's header
+//! and About tab show, for a subscription or a repository browsed before
+//! subscribing.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+use specta::Type;
+
+use crate::env::Env;
+use crate::error::Result;
+use crate::model::{ItemKind, Scope};
+use crate::source::{AboutReport, CatalogMode, MarketplaceMeta};
+
+use super::Catalog;
+
+/// The subscription a browsed repository already has on this machine, so
+/// the page can carry on as that subscription instead of a stranger.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct SubscriptionRef {
+    pub scope: Scope,
+    pub source: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct CatalogSummary {
+    /// `owner/repo`, a path, or `local` — what the catalog is.
+    pub provenance: String,
+    /// The commit being read, for a remote.
+    pub commit: Option<String>,
+    /// `[marketplace]` from the catalog's own kendex.toml.
+    pub meta: Option<MarketplaceMeta>,
+    pub mode: CatalogMode,
+    /// Packages offered, by kind name.
+    pub counts: BTreeMap<String, u32>,
+    /// Set when the catalog is read from the store because a refresh failed.
+    pub warning: Option<String>,
+    /// For a repository: the subscription this machine already holds for
+    /// it, if any. A subscription answers with itself.
+    pub subscription: Option<SubscriptionRef>,
+}
+
+/// One read of what the catalog says about itself. A bare repository is
+/// refreshed here — this is the page's first read, so what follows reads
+/// the head it just fetched — and a failed refresh serves the store with
+/// its warning rather than an empty page.
+pub fn summary(env: &Env, catalog: &Catalog) -> Result<CatalogSummary> {
+    let (warning, subscription) = match catalog {
+        Catalog::Subscription { scope, source } => (
+            None,
+            Some(SubscriptionRef {
+                scope: scope.clone(),
+                source: source.clone(),
+            }),
+        ),
+        Catalog::Repo { repo } => {
+            let warning = match crate::repo_move::owner_repo(repo) {
+                Some(_) => crate::remote::sync(env, repo.trim(), None)?.warning,
+                // open() below names the refusal.
+                None => None,
+            };
+            (warning, subscribed_as(env, repo))
+        }
+    };
+    let browsed = super::open(env, catalog)?;
+    let mut counts = BTreeMap::new();
+    for kind in ItemKind::ALL {
+        let offered = crate::source::list_items(&browsed.sealed, &browsed.config, kind).len();
+        if offered > 0 {
+            counts.insert(
+                kind.name().to_owned(),
+                offered.min(u32::MAX as usize) as u32,
+            );
+        }
+    }
+    Ok(CatalogSummary {
+        provenance: browsed.source.provenance.clone(),
+        commit: browsed.source.commit.clone(),
+        meta: browsed.config.marketplace.clone(),
+        mode: browsed.config.mode,
+        counts,
+        warning,
+        subscription,
+    })
+}
+
+/// The About report for any catalog: how its items were decided, what was
+/// found where, and everything wrong with it.
+pub fn about(env: &Env, catalog: &Catalog) -> Result<AboutReport> {
+    let browsed = super::open(env, catalog)?;
+    Ok(crate::source::about(&browsed.sealed, &browsed.config))
+}
+
+/// The first subscription, personal scope first, that points at this
+/// repository however it spells it. A scope that cannot be read holds no
+/// subscription rather than blocking the page.
+fn subscribed_as(env: &Env, repo: &str) -> Option<SubscriptionRef> {
+    let key = crate::repo_move::owner_repo(repo)?;
+    let mut scopes = vec![Scope::Global];
+    if let Ok(settings) = crate::settings::load(env) {
+        scopes.extend(
+            settings
+                .projects
+                .into_iter()
+                .map(|root| Scope::Project { root }),
+        );
+    }
+    scopes.into_iter().find_map(|scope| {
+        let rows = crate::source_ops::list_subscriptions(env, &scope).ok()?;
+        rows.into_iter()
+            .find(|row| {
+                row.repo
+                    .as_deref()
+                    .and_then(crate::repo_move::owner_repo)
+                    .is_some_and(|candidate| candidate == key)
+            })
+            .map(|row| SubscriptionRef {
+                scope,
+                source: row.name,
+            })
+    })
+}

--- a/crates/core/src/source/browse/summary.rs
+++ b/crates/core/src/source/browse/summary.rs
@@ -98,13 +98,13 @@ pub fn about(env: &Env, catalog: &Catalog) -> Result<AboutReport> {
 
 /// The first subscription, personal scope first, that points at this
 /// repository however it spells it and can be read right now. One that is
-/// turned off or never fetched is passed over: the page just read the
-/// repository, and switching onto a subscription whose content is
-/// unreachable would trade that for an empty page.
+/// turned off or never fetched resolves as not Ready and is passed over:
+/// the page just read the repository, and switching onto a subscription
+/// whose content is unreachable would trade that for an empty page.
 fn subscribed_as(env: &Env, key: &str) -> Option<SubscriptionRef> {
     crate::source_ops::repo_subscriptions(env)
         .into_iter()
-        .filter(|row| row.enabled && row.repo_key.as_deref() == Some(key))
+        .filter(|row| row.repo_key.as_deref() == Some(key))
         .find(|row| {
             let Ok(Some(manifest)) = crate::source_ops::load_current(env, &row.scope) else {
                 return false;

--- a/crates/core/src/source/browse/tests.rs
+++ b/crates/core/src/source/browse/tests.rs
@@ -6,6 +6,7 @@ use crate::env::FakeOs;
 use crate::lock::{Lock, LockEntry};
 use crate::model::HarnessId;
 
+mod repo;
 mod safety_cache;
 
 fn skill(catalog: &Path, dir: &str, name: &str, body: &str) {
@@ -62,6 +63,14 @@ fn save_lock(env: &Env, scope: &Scope, members: &[(ItemKind, &str)]) {
     crate::lock::save(&crate::lock::lock_path(env, scope), &lock).unwrap();
 }
 
+/// The subscription every test here browses.
+fn cat(scope: &Scope) -> Catalog {
+    Catalog::Subscription {
+        scope: scope.clone(),
+        source: "cat".to_owned(),
+    }
+}
+
 fn sources_decl(catalog: &Path) -> String {
     format!(
         "schema = 5\n[sources.cat]\npath = \"{}\"\n",
@@ -77,7 +86,7 @@ fn packages_listed_for_a_plain_discovered_marketplace() {
     skill(&catalog, ".claude/skills", "extra", "body");
     let (env, scope) = project(tmp.path(), &sources_decl(&catalog));
 
-    let rows = packages(&env, &scope, "cat").unwrap();
+    let rows = packages(&env, &cat(&scope)).unwrap();
     let gh = rows.iter().find(|row| row.name == "gh").expect("gh listed");
     assert_eq!(gh.kind, ItemKind::Skill);
     assert_eq!(gh.description.as_deref(), Some("does gh things"));
@@ -106,7 +115,7 @@ fn packages_listed_for_a_plugin_registry_marketplace() {
     .unwrap();
     let (env, scope) = project(tmp.path(), &sources_decl(&catalog));
 
-    let rows = packages(&env, &scope, "cat").unwrap();
+    let rows = packages(&env, &cat(&scope)).unwrap();
     let names: Vec<&str> = rows.iter().map(|row| row.name.as_str()).collect();
     assert!(names.contains(&"tools/eda"), "{names:?}");
     assert!(names.contains(&"tools/helper"), "{names:?}");
@@ -165,7 +174,7 @@ fn bundle_detail_derives_partly_installed_and_full() {
     let (env, scope) = project(tmp.path(), &manifest);
     save_lock(&env, &scope, &SIX[..2]);
 
-    let partly = bundle(&env, &scope, "cat", "starter").unwrap();
+    let partly = bundle(&env, &cat(&scope), "starter").unwrap();
     assert_eq!(partly.total_members, 6);
     assert_eq!(partly.installed_members, 2);
     assert_eq!(partly.description.as_deref(), Some("six things"));
@@ -181,7 +190,7 @@ fn bundle_detail_derives_partly_installed_and_full() {
     assert_eq!(state_of(&partly, "guard"), InstallState::Available);
 
     save_lock(&env, &scope, &SIX);
-    let full = bundle(&env, &scope, "cat", "starter").unwrap();
+    let full = bundle(&env, &cat(&scope), "starter").unwrap();
     assert_eq!(full.installed_members, 6);
     assert!(
         full.members
@@ -210,7 +219,7 @@ fn a_bundle_member_the_catalog_no_longer_carries_is_a_row_not_an_error() {
     );
     let (env, scope) = project(tmp.path(), &manifest);
 
-    let detail = bundle(&env, &scope, "cat", "starter").unwrap();
+    let detail = bundle(&env, &cat(&scope), "starter").unwrap();
     assert_eq!(detail.total_members, 2);
     let state_of = |name: &str| {
         detail
@@ -244,7 +253,7 @@ fn a_member_the_user_removed_shows_removed_by_you() {
     );
     let (env, scope) = project(tmp.path(), &manifest);
 
-    let detail = bundle(&env, &scope, "cat", "starter").unwrap();
+    let detail = bundle(&env, &cat(&scope), "starter").unwrap();
     let state_of = |name: &str| {
         detail
             .members
@@ -274,7 +283,7 @@ fn a_declared_package_the_gate_refuses_shows_held_back() {
     );
     let (env, scope) = project(tmp.path(), &manifest);
 
-    let rows = packages(&env, &scope, "cat").unwrap();
+    let rows = packages(&env, &cat(&scope)).unwrap();
     let state = |name: &str| rows.iter().find(|row| row.name == name).unwrap().state;
     assert_eq!(state("risky"), InstallState::HeldBackBySafety);
     assert_eq!(state("gh"), InstallState::Available);
@@ -294,7 +303,7 @@ fn a_name_taken_by_another_source_is_shown_before_the_click() {
     );
     let (env, scope) = project(tmp.path(), &manifest);
 
-    let rows = packages(&env, &scope, "cat").unwrap();
+    let rows = packages(&env, &cat(&scope)).unwrap();
     let gh = rows.iter().find(|row| row.name == "gh").unwrap();
     assert_eq!(gh.collision.as_deref(), Some("two"));
     assert_eq!(gh.state, InstallState::Available);
@@ -303,7 +312,7 @@ fn a_name_taken_by_another_source_is_shown_before_the_click() {
             .all(|row| row.name == "gh" || row.collision.is_none())
     );
 
-    let detail = bundle(&env, &scope, "cat", "starter").unwrap();
+    let detail = bundle(&env, &cat(&scope), "starter").unwrap();
     assert_eq!(detail.collision.as_deref(), Some("two"));
 }
 
@@ -315,7 +324,7 @@ fn preview_carries_readme_files_tags_and_sets() {
     fs::write(catalog.join("skills/gh/notes.md"), "extra notes\n").unwrap();
     let (env, scope) = project(tmp.path(), &sources_decl(&catalog));
 
-    let preview = package_preview(&env, &scope, "cat", ItemKind::Skill, "gh").unwrap();
+    let preview = package_preview(&env, &cat(&scope), ItemKind::Skill, "gh").unwrap();
     assert_eq!(preview.description.as_deref(), Some("does gh things"));
     assert_eq!(preview.tags, vec![Tag::Review]);
     assert_eq!(preview.readme.as_deref(), Some("body"));
@@ -327,7 +336,7 @@ fn preview_carries_readme_files_tags_and_sets() {
     assert_eq!(paths, ["SKILL.md", "notes.md"]);
     assert_eq!(preview.bundles, vec!["starter".to_owned()]);
 
-    let hook = package_preview(&env, &scope, "cat", ItemKind::Hook, "guard").unwrap();
+    let hook = package_preview(&env, &cat(&scope), ItemKind::Hook, "guard").unwrap();
     assert_eq!(hook.readme.as_deref(), Some("#!/bin/sh\necho ok"));
     assert_eq!(hook.files.len(), 1);
 }
@@ -341,7 +350,7 @@ fn preview_shows_control_characters_instead_of_acting_on_them() {
     skill(&catalog, "skills", "gh", "red \u{1b}[31m text");
     let (env, scope) = project(tmp.path(), &sources_decl(&catalog));
 
-    let preview = package_preview(&env, &scope, "cat", ItemKind::Skill, "gh").unwrap();
+    let preview = package_preview(&env, &cat(&scope), ItemKind::Skill, "gh").unwrap();
     let readme = preview.readme.unwrap();
     assert!(!readme.contains('\u{1b}'), "{readme:?}");
     assert!(readme.contains("\\u{1b}"), "{readme:?}");
@@ -362,9 +371,9 @@ fn preview_reads_only_through_the_sealed_source() {
     let (env, scope) = project(tmp.path(), &sources_decl(&catalog));
 
     assert!(matches!(
-        package_preview(&env, &scope, "cat", ItemKind::Skill, "gh"),
+        package_preview(&env, &cat(&scope), ItemKind::Skill, "gh"),
         Err(CoreError::SourceEscape { .. })
     ));
-    let rows = packages(&env, &scope, "cat").unwrap();
+    let rows = packages(&env, &cat(&scope)).unwrap();
     assert!(!rows.iter().any(|row| row.name == "lnk"));
 }

--- a/crates/core/src/source/browse/tests.rs
+++ b/crates/core/src/source/browse/tests.rs
@@ -7,6 +7,7 @@ use crate::lock::{Lock, LockEntry};
 use crate::model::HarnessId;
 
 mod repo;
+mod root_skill;
 mod safety_cache;
 mod summary;
 

--- a/crates/core/src/source/browse/tests.rs
+++ b/crates/core/src/source/browse/tests.rs
@@ -8,6 +8,7 @@ use crate::model::HarnessId;
 
 mod repo;
 mod safety_cache;
+mod summary;
 
 fn skill(catalog: &Path, dir: &str, name: &str, body: &str) {
     let home = catalog.join(dir).join(name);

--- a/crates/core/src/source/browse/tests/repo.rs
+++ b/crates/core/src/source/browse/tests/repo.rs
@@ -292,3 +292,21 @@ fn a_ready_subscription_under_another_spelling_answers_offline() {
     // The shorthand was never fetched: nothing went to the network.
     assert!(crate::remote::cached(&env, REPO, None).unwrap().is_none());
 }
+
+#[test]
+fn a_never_fetched_subscription_under_the_canonical_spelling_is_found_after_the_fetch() {
+    let (_tmp, env, _upstream) = fixture();
+    let manifest = env.global_manifest_file();
+    fs::create_dir_all(manifest.parent().unwrap()).unwrap();
+    fs::write(
+        &manifest,
+        format!("schema = 5\n[sources.tools]\nrepo = \"{REPO}\"\n"),
+    )
+    .unwrap();
+    assert!(crate::remote::cached(&env, REPO, None).unwrap().is_none());
+
+    // Pending before the read, Ready by the fetch the read itself made.
+    let report = summary(&env, &repo()).unwrap();
+    assert_eq!(report.subscription.unwrap().source, "tools");
+    assert_eq!(report.counts.get("skill"), Some(&1));
+}

--- a/crates/core/src/source/browse/tests/repo.rs
+++ b/crates/core/src/source/browse/tests/repo.rs
@@ -81,21 +81,34 @@ fn the_summary_counts_and_names_the_head_and_knows_no_subscription() {
     assert_eq!(first.provenance, REPO);
     assert!(first.commit.is_some());
     assert_eq!(first.counts.get("skill"), Some(&1));
+    assert_eq!(
+        first.counts.len(),
+        1,
+        "kinds with nothing offered are not rows"
+    );
     assert_eq!(first.subscription, None);
     assert_eq!(first.warning, None);
 }
 
 #[test]
-fn a_subscription_to_the_same_repository_is_found_however_it_is_spelled() {
+fn a_readable_subscription_to_the_same_repository_is_found_and_an_unfetched_one_passed_over() {
     let (_tmp, env, _upstream) = fixture();
     let manifest = env.global_manifest_file();
     fs::create_dir_all(manifest.parent().unwrap()).unwrap();
+    // Spelled as a URL, the declaration keys a different store entry that
+    // nothing has fetched: switching onto it would empty the page.
     fs::write(
         &manifest,
         "schema = 5\n[sources.tools]\nrepo = \"https://github.com/owner/repo.git\"\n",
     )
     .unwrap();
+    assert_eq!(summary(&env, &repo()).unwrap().subscription, None);
 
+    fs::write(
+        &manifest,
+        format!("schema = 5\n[sources.tools]\nrepo = \"{REPO}\"\n"),
+    )
+    .unwrap();
     let found = summary(&env, &repo()).unwrap().subscription.unwrap();
     assert_eq!(found.scope, Scope::Global);
     assert_eq!(found.source, "tools");
@@ -111,10 +124,73 @@ fn a_name_installed_from_anywhere_else_is_a_collision_and_never_installed_here()
         "schema = 5\n[sources.other]\npath = \"/elsewhere\"\n[skills.gh]\nsource = \"other\"\n",
     )
     .unwrap();
+    // Installed too, from that other source: a blind browse owns no
+    // installation, so this is still a clash and never "Installed".
+    let mut lock = crate::lock::Lock {
+        version: crate::lock::LOCK_VERSION,
+        ..Default::default()
+    };
+    lock.entries.insert(
+        crate::lock::entry_key(ItemKind::Skill, "gh", crate::model::HarnessId::Claude),
+        super::lock_entry(ItemKind::Skill, "gh", "other"),
+    );
+    crate::lock::save(&crate::lock::lock_path(&env, &Scope::Global), &lock).unwrap();
 
     let rows = packages(&env, &repo()).unwrap();
     assert_eq!(rows[0].state, InstallState::Available);
     assert_eq!(rows[0].collision.as_deref(), Some("other"));
+}
+
+#[test]
+fn a_subscription_that_is_turned_off_is_passed_over_and_the_repository_still_reads() {
+    let (_tmp, env, _upstream) = fixture();
+    let manifest = env.global_manifest_file();
+    fs::create_dir_all(manifest.parent().unwrap()).unwrap();
+    fs::write(
+        &manifest,
+        format!("schema = 5\n[sources.cat]\nrepo = \"{REPO}\"\nenabled = false\n"),
+    )
+    .unwrap();
+
+    let first = summary(&env, &repo()).unwrap();
+    assert_eq!(first.subscription, None);
+    assert_eq!(packages(&env, &repo()).unwrap().len(), 1);
+}
+
+#[test]
+fn a_listing_never_picks_the_transport() {
+    let (_tmp, env, _upstream) = fixture();
+    let spelled = Catalog::Repo {
+        repo: format!("ssh://git@github.com/{REPO}"),
+    };
+    let first = summary(&env, &spelled).unwrap();
+    // Fetched as the shorthand — over https in production — under the one
+    // key the shorthand, the safety cache and Subscribe all share.
+    assert_eq!(first.provenance, REPO);
+    assert!(crate::remote::cached(&env, REPO, None).unwrap().is_some());
+    assert_ne!(
+        crate::remote::cache_key(&env, &format!("ssh://git@github.com/{REPO}")),
+        crate::remote::cache_key(&env, REPO),
+        "the two spellings would otherwise be two downloads"
+    );
+}
+
+#[test]
+fn a_repository_that_does_not_exist_says_the_fetch_failed_not_a_pin() {
+    let (_tmp, env, _upstream) = fixture();
+    let error = summary(
+        &env,
+        &Catalog::Repo {
+            repo: "owner/missing".to_owned(),
+        },
+    )
+    .unwrap_err();
+    assert!(matches!(error, CoreError::FetchFailed { .. }), "{error}");
+    let text = error.to_string();
+    assert!(
+        !text.contains("pinned") && !text.contains("cached"),
+        "{text}"
+    );
 }
 
 #[test]

--- a/crates/core/src/source/browse/tests/repo.rs
+++ b/crates/core/src/source/browse/tests/repo.rs
@@ -5,7 +5,9 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use super::super::{Catalog, InstallState, package_preview, package_safety, packages, summary};
+use super::super::{
+    Catalog, InstallState, package_file, package_preview, package_safety, packages, summary,
+};
 use crate::env::{Env, FakeOs};
 use crate::error::CoreError;
 use crate::model::{ItemKind, Scope};
@@ -46,6 +48,8 @@ fn fixture() -> (tempfile::TempDir, Env, PathBuf) {
         "---\nname: gh\ndescription: does gh things\n---\nchmod 777 /tmp/x\n",
     )
     .unwrap();
+    fs::write(upstream.join("skills/gh/checklist.md"), "- look twice\n").unwrap();
+    fs::write(upstream.join("secret.txt"), "not offered\n").unwrap();
     git(&upstream, &["init", "--quiet", "-b", "main"]);
     commit(&upstream, "one");
     let base = format!("file://{}", tmp.path().join("base").display());
@@ -222,7 +226,7 @@ fn preview_and_safety_read_the_repository_and_the_score_is_shared_with_a_later_s
         "{:?}",
         preview.readme
     );
-    assert_eq!(preview.files.len(), 1);
+    assert_eq!(preview.files.len(), 2);
 
     let scored = package_safety(&env, &repo(), ItemKind::Skill, "gh").unwrap();
     assert!(!scored.from_cache);
@@ -322,4 +326,20 @@ fn a_never_fetched_subscription_under_the_canonical_spelling_is_found_after_the_
     let report = summary(&env, &repo()).unwrap();
     assert_eq!(report.subscription.unwrap().source, "tools");
     assert_eq!(report.counts.get("skill"), Some(&1));
+}
+
+#[test]
+fn an_offered_file_beyond_the_readme_is_read_and_an_escaping_path_is_refused() {
+    let (_tmp, env, _upstream) = fixture();
+    let file = package_file(&env, &repo(), ItemKind::Skill, "gh", "checklist.md").unwrap();
+    assert_eq!(file.content, "- look twice\n");
+    assert!(!file.truncated);
+
+    for escaping in ["../secret.txt", "/etc/passwd", ""] {
+        let refused = package_file(&env, &repo(), ItemKind::Skill, "gh", escaping).unwrap_err();
+        assert!(
+            matches!(refused, CoreError::SourceEscape { .. }),
+            "{escaping}: {refused}"
+        );
+    }
 }

--- a/crates/core/src/source/browse/tests/repo.rs
+++ b/crates/core/src/source/browse/tests/repo.rs
@@ -1,0 +1,188 @@
+//! Browsing a repository before anyone subscribes to it: the same reads a
+//! subscription gets, off the same store, with the join judged against the
+//! personal scope.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use super::super::{Catalog, InstallState, package_preview, package_safety, packages, summary};
+use crate::env::{Env, FakeOs};
+use crate::error::CoreError;
+use crate::model::{ItemKind, Scope};
+use crate::process::Hardened;
+
+const REPO: &str = "owner/repo";
+
+fn git(dir: &Path, args: &[&str]) {
+    let output = Hardened::git(args, Some(dir)).run().unwrap();
+    assert!(output.status.success(), "git {args:?}");
+}
+
+fn commit(dir: &Path, message: &str) {
+    git(dir, &["add", "-A"]);
+    git(
+        dir,
+        &[
+            "-c",
+            "user.email=t@t",
+            "-c",
+            "user.name=t",
+            "commit",
+            "--quiet",
+            "-m",
+            message,
+        ],
+    );
+}
+
+/// An upstream repository reachable as `owner/repo` that nothing
+/// subscribes to, holding one skill that scores below 100.
+fn fixture() -> (tempfile::TempDir, Env, PathBuf) {
+    let tmp = tempfile::tempdir().unwrap();
+    let upstream = tmp.path().join("base/owner/repo");
+    fs::create_dir_all(upstream.join("skills/gh")).unwrap();
+    fs::write(
+        upstream.join("skills/gh/SKILL.md"),
+        "---\nname: gh\ndescription: does gh things\n---\nchmod 777 /tmp/x\n",
+    )
+    .unwrap();
+    git(&upstream, &["init", "--quiet", "-b", "main"]);
+    commit(&upstream, "one");
+    let base = format!("file://{}", tmp.path().join("base").display());
+    let env = Env::fake(tmp.path(), FakeOs::Linux).with_var("KENDEX_GIT_BASE", &base);
+    (tmp, env, upstream)
+}
+
+fn repo() -> Catalog {
+    Catalog::Repo {
+        repo: REPO.to_owned(),
+    }
+}
+
+#[test]
+fn a_repository_is_browsed_without_a_subscription_and_its_fetch_feeds_the_store() {
+    let (_tmp, env, _upstream) = fixture();
+    assert!(crate::remote::cached(&env, REPO, None).unwrap().is_none());
+
+    let rows = packages(&env, &repo()).unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].name, "gh");
+    assert_eq!(rows[0].state, InstallState::Available);
+    assert_eq!(rows[0].description.as_deref(), Some("does gh things"));
+
+    // The read fetched into the store a subscription would use.
+    assert!(crate::remote::cached(&env, REPO, None).unwrap().is_some());
+}
+
+#[test]
+fn the_summary_counts_and_names_the_head_and_knows_no_subscription() {
+    let (_tmp, env, _upstream) = fixture();
+    let first = summary(&env, &repo()).unwrap();
+    assert_eq!(first.provenance, REPO);
+    assert!(first.commit.is_some());
+    assert_eq!(first.counts.get("skill"), Some(&1));
+    assert_eq!(first.subscription, None);
+    assert_eq!(first.warning, None);
+}
+
+#[test]
+fn a_subscription_to_the_same_repository_is_found_however_it_is_spelled() {
+    let (_tmp, env, _upstream) = fixture();
+    let manifest = env.global_manifest_file();
+    fs::create_dir_all(manifest.parent().unwrap()).unwrap();
+    fs::write(
+        &manifest,
+        "schema = 5\n[sources.tools]\nrepo = \"https://github.com/owner/repo.git\"\n",
+    )
+    .unwrap();
+
+    let found = summary(&env, &repo()).unwrap().subscription.unwrap();
+    assert_eq!(found.scope, Scope::Global);
+    assert_eq!(found.source, "tools");
+}
+
+#[test]
+fn a_name_installed_from_anywhere_else_is_a_collision_and_never_installed_here() {
+    let (_tmp, env, _upstream) = fixture();
+    let manifest = env.global_manifest_file();
+    fs::create_dir_all(manifest.parent().unwrap()).unwrap();
+    fs::write(
+        &manifest,
+        "schema = 5\n[sources.other]\npath = \"/elsewhere\"\n[skills.gh]\nsource = \"other\"\n",
+    )
+    .unwrap();
+
+    let rows = packages(&env, &repo()).unwrap();
+    assert_eq!(rows[0].state, InstallState::Available);
+    assert_eq!(rows[0].collision.as_deref(), Some("other"));
+}
+
+#[test]
+fn only_a_github_repository_is_browsable_blind() {
+    let (_tmp, env, _upstream) = fixture();
+    let refused = packages(
+        &env,
+        &Catalog::Repo {
+            repo: "git@gitlab.com:owner/repo.git".to_owned(),
+        },
+    )
+    .unwrap_err();
+    assert!(
+        matches!(refused, CoreError::NotBrowsable { .. }),
+        "{refused}"
+    );
+}
+
+#[test]
+fn preview_and_safety_read_the_repository_and_the_score_is_shared_with_a_later_subscription() {
+    let (_tmp, env, _upstream) = fixture();
+    let preview = package_preview(&env, &repo(), ItemKind::Skill, "gh").unwrap();
+    assert!(
+        preview
+            .readme
+            .as_deref()
+            .unwrap()
+            .contains("chmod 777 /tmp/x"),
+        "{:?}",
+        preview.readme
+    );
+    assert_eq!(preview.files.len(), 1);
+
+    let scored = package_safety(&env, &repo(), ItemKind::Skill, "gh").unwrap();
+    assert!(!scored.from_cache);
+    assert!(scored.safety.score < 100);
+
+    let manifest = env.global_manifest_file();
+    fs::create_dir_all(manifest.parent().unwrap()).unwrap();
+    fs::write(
+        &manifest,
+        format!("schema = 5\n[sources.cat]\nrepo = \"{REPO}\"\n"),
+    )
+    .unwrap();
+    let subscribed = package_safety(
+        &env,
+        &Catalog::Subscription {
+            scope: Scope::Global,
+            source: "cat".to_owned(),
+        },
+        ItemKind::Skill,
+        "gh",
+    )
+    .unwrap();
+    assert!(subscribed.from_cache);
+    assert_eq!(subscribed.safety, scored.safety);
+}
+
+#[test]
+fn an_unreachable_upstream_serves_the_store_with_a_warning() {
+    let (_tmp, env, upstream) = fixture();
+    summary(&env, &repo()).unwrap();
+    fs::remove_dir_all(&upstream).unwrap();
+
+    let again = summary(&env, &repo()).unwrap();
+    assert_eq!(again.counts.get("skill"), Some(&1));
+    assert!(
+        again.warning.is_some(),
+        "a failed refresh is said, not hidden"
+    );
+}

--- a/crates/core/src/source/browse/tests/repo.rs
+++ b/crates/core/src/source/browse/tests/repo.rs
@@ -315,6 +315,45 @@ fn a_ready_subscription_under_another_spelling_answers_offline() {
 }
 
 #[test]
+fn a_subscription_still_naming_the_moved_default_carries_the_browse_of_its_new_repository() {
+    let tmp = tempfile::tempdir().unwrap();
+    let moved = crate::manifest::DEFAULT_SOURCE_REPO;
+    let upstream = tmp.path().join("base").join(moved);
+    fs::create_dir_all(upstream.join("skills/gh")).unwrap();
+    fs::write(
+        upstream.join("skills/gh/SKILL.md"),
+        "---\nname: gh\ndescription: does gh things\n---\nhello\n",
+    )
+    .unwrap();
+    git(&upstream, &["init", "--quiet", "-b", "main"]);
+    commit(&upstream, "one");
+    let base = format!("file://{}", tmp.path().join("base").display());
+    let env = Env::fake(tmp.path(), FakeOs::Linux).with_var("KENDEX_GIT_BASE", &base);
+    // A manifest written before the move, never upgraded.
+    let manifest = env.global_manifest_file();
+    fs::create_dir_all(manifest.parent().unwrap()).unwrap();
+    fs::write(
+        &manifest,
+        format!(
+            "schema = 5\n[sources.vstack]\nrepo = \"{}\"\n",
+            crate::manifest::LEGACY_SOURCE_REPO
+        ),
+    )
+    .unwrap();
+
+    let report = summary(
+        &env,
+        &Catalog::Repo {
+            repo: moved.to_owned(),
+        },
+    )
+    .unwrap();
+    assert_eq!(report.subscription.unwrap().source, "vstack");
+    assert_eq!(report.repo_key.as_deref(), Some(moved));
+    assert_eq!(report.counts.get("skill"), Some(&1));
+}
+
+#[test]
 fn a_never_fetched_subscription_under_the_canonical_spelling_is_found_after_the_fetch() {
     let (_tmp, env, _upstream) = fixture();
     let manifest = env.global_manifest_file();

--- a/crates/core/src/source/browse/tests/repo.rs
+++ b/crates/core/src/source/browse/tests/repo.rs
@@ -269,8 +269,21 @@ fn a_ready_subscription_under_another_spelling_answers_offline() {
     // Spelled with a capital: the same repository on GitHub, but a
     // different store entry from the shorthand a listing hands over.
     let spelled = "Owner/repo";
-    let owners = upstream.parent().unwrap();
-    std::os::unix::fs::symlink(owners, owners.with_file_name("Owner")).unwrap();
+    // A second copy under the capitalised owner, unless the filesystem
+    // folds case and the path already resolves to the upstream itself.
+    let alias = upstream.parent().unwrap().with_file_name("Owner");
+    if !alias.exists() {
+        fs::create_dir_all(&alias).unwrap();
+        git(
+            &alias,
+            &[
+                "clone",
+                "--quiet",
+                upstream.to_str().unwrap(),
+                alias.join("repo").to_str().unwrap(),
+            ],
+        );
+    }
     assert_ne!(
         crate::remote::cache_key(&env, spelled),
         crate::remote::cache_key(&env, REPO)

--- a/crates/core/src/source/browse/tests/repo.rs
+++ b/crates/core/src/source/browse/tests/repo.rs
@@ -262,3 +262,33 @@ fn an_unreachable_upstream_serves_the_store_with_a_warning() {
         "a failed refresh is said, not hidden"
     );
 }
+
+#[test]
+fn a_ready_subscription_under_another_spelling_answers_offline() {
+    let (_tmp, env, upstream) = fixture();
+    // Spelled with a capital: the same repository on GitHub, but a
+    // different store entry from the shorthand a listing hands over.
+    let spelled = "Owner/repo";
+    let owners = upstream.parent().unwrap();
+    std::os::unix::fs::symlink(owners, owners.with_file_name("Owner")).unwrap();
+    assert_ne!(
+        crate::remote::cache_key(&env, spelled),
+        crate::remote::cache_key(&env, REPO)
+    );
+    let manifest = env.global_manifest_file();
+    fs::create_dir_all(manifest.parent().unwrap()).unwrap();
+    fs::write(
+        &manifest,
+        format!("schema = 5\n[sources.tools]\nrepo = \"{spelled}\"\n"),
+    )
+    .unwrap();
+    crate::remote::sync(&env, spelled, None).unwrap();
+    fs::remove_dir_all(&upstream).unwrap();
+
+    let report = summary(&env, &repo()).unwrap();
+    assert_eq!(report.subscription.unwrap().source, "tools");
+    assert_eq!(report.counts.get("skill"), Some(&1));
+    assert_eq!(report.warning, None);
+    // The shorthand was never fetched: nothing went to the network.
+    assert!(crate::remote::cached(&env, REPO, None).unwrap().is_none());
+}

--- a/crates/core/src/source/browse/tests/repo.rs
+++ b/crates/core/src/source/browse/tests/repo.rs
@@ -15,12 +15,12 @@ use crate::process::Hardened;
 
 const REPO: &str = "owner/repo";
 
-fn git(dir: &Path, args: &[&str]) {
+pub(super) fn git(dir: &Path, args: &[&str]) {
     let output = Hardened::git(args, Some(dir)).run().unwrap();
     assert!(output.status.success(), "git {args:?}");
 }
 
-fn commit(dir: &Path, message: &str) {
+pub(super) fn commit(dir: &Path, message: &str) {
     git(dir, &["add", "-A"]);
     git(
         dir,

--- a/crates/core/src/source/browse/tests/repo.rs
+++ b/crates/core/src/source/browse/tests/repo.rs
@@ -83,6 +83,7 @@ fn the_summary_counts_and_names_the_head_and_knows_no_subscription() {
     let (_tmp, env, _upstream) = fixture();
     let first = summary(&env, &repo()).unwrap();
     assert_eq!(first.provenance, REPO);
+    assert_eq!(first.repo_key.as_deref(), Some(REPO));
     assert!(first.commit.is_some());
     assert_eq!(first.counts.get("skill"), Some(&1));
     assert_eq!(
@@ -171,6 +172,7 @@ fn a_listing_never_picks_the_transport() {
     // Fetched as the shorthand — over https in production — under the one
     // key the shorthand, the safety cache and Subscribe all share.
     assert_eq!(first.provenance, REPO);
+    assert_eq!(first.repo_key.as_deref(), Some(REPO));
     assert!(crate::remote::cached(&env, REPO, None).unwrap().is_some());
     assert_ne!(
         crate::remote::cache_key(&env, &format!("ssh://git@github.com/{REPO}")),
@@ -304,6 +306,8 @@ fn a_ready_subscription_under_another_spelling_answers_offline() {
 
     let report = summary(&env, &repo()).unwrap();
     assert_eq!(report.subscription.unwrap().source, "tools");
+    assert_eq!(report.provenance, spelled);
+    assert_eq!(report.repo_key.as_deref(), Some(REPO));
     assert_eq!(report.counts.get("skill"), Some(&1));
     assert_eq!(report.warning, None);
     // The shorthand was never fetched: nothing went to the network.

--- a/crates/core/src/source/browse/tests/root_skill.rs
+++ b/crates/core/src/source/browse/tests/root_skill.rs
@@ -1,0 +1,67 @@
+//! A skill that is its whole repository: what the preview lists, and the
+//! file read opens, is the skill's tree — never the repository around it.
+
+use std::fs;
+
+use super::super::{Catalog, package_file, package_preview};
+use super::repo::{commit, git};
+use crate::env::{Env, FakeOs};
+use crate::error::CoreError;
+use crate::model::ItemKind;
+
+/// A repository that is one skill at its root, carrying the directories a
+/// repository has and a skill does not.
+fn root_skill_fixture() -> (tempfile::TempDir, Env, Catalog) {
+    let tmp = tempfile::tempdir().unwrap();
+    let upstream = tmp.path().join("base/owner/rootskill");
+    fs::create_dir_all(upstream.join("node_modules/dep")).unwrap();
+    fs::create_dir_all(upstream.join("target")).unwrap();
+    fs::write(
+        upstream.join("SKILL.md"),
+        "---\nname: root\ndescription: lives at the root\n---\nbody\n",
+    )
+    .unwrap();
+    fs::write(upstream.join("notes.md"), "kept\n").unwrap();
+    fs::write(
+        upstream.join("node_modules/dep/index.js"),
+        "module.exports = 1\n",
+    )
+    .unwrap();
+    fs::write(upstream.join("target/out.txt"), "built\n").unwrap();
+    git(&upstream, &["init", "--quiet", "-b", "main"]);
+    commit(&upstream, "one");
+    let base = format!("file://{}", tmp.path().join("base").display());
+    let env = Env::fake(tmp.path(), FakeOs::Linux).with_var("KENDEX_GIT_BASE", &base);
+    let catalog = Catalog::Repo {
+        repo: "owner/rootskill".to_owned(),
+    };
+    (tmp, env, catalog)
+}
+
+#[test]
+fn a_repo_root_skill_lists_and_reads_only_its_own_tree() {
+    let (_tmp, env, catalog) = root_skill_fixture();
+    let preview = package_preview(&env, &catalog, ItemKind::Skill, "root").unwrap();
+    let listed: Vec<&str> = preview.files.iter().map(|f| f.path.as_str()).collect();
+    assert!(listed.contains(&"notes.md"), "{listed:?}");
+    assert!(
+        listed
+            .iter()
+            .all(|p| !p.starts_with("node_modules/") && !p.starts_with("target/")),
+        "{listed:?}"
+    );
+
+    assert_eq!(
+        package_file(&env, &catalog, ItemKind::Skill, "root", "notes.md")
+            .unwrap()
+            .content,
+        "kept\n"
+    );
+    for hidden in ["node_modules/dep/index.js", "target/out.txt", ".git/config"] {
+        let refused = package_file(&env, &catalog, ItemKind::Skill, "root", hidden).unwrap_err();
+        assert!(
+            matches!(refused, CoreError::SourceEscape { .. }),
+            "{hidden}: {refused}"
+        );
+    }
+}

--- a/crates/core/src/source/browse/tests/safety_cache.rs
+++ b/crates/core/src/source/browse/tests/safety_cache.rs
@@ -4,7 +4,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use super::super::{PackageSafety, package_safety};
+use super::super::{Catalog, PackageSafety, package_safety};
 use crate::env::{Env, FakeOs};
 use crate::model::{ItemKind, Scope};
 use crate::process::Hardened;
@@ -73,7 +73,16 @@ fn cache_file(env: &Env) -> PathBuf {
 }
 
 fn score(env: &Env, scope: &Scope) -> PackageSafety {
-    package_safety(env, scope, "cat", ItemKind::Skill, "gh").unwrap()
+    package_safety(
+        env,
+        &Catalog::Subscription {
+            scope: scope.clone(),
+            source: "cat".to_owned(),
+        },
+        ItemKind::Skill,
+        "gh",
+    )
+    .unwrap()
 }
 
 #[test]

--- a/crates/core/src/source/browse/tests/summary.rs
+++ b/crates/core/src/source/browse/tests/summary.rs
@@ -1,0 +1,28 @@
+//! A subscription's own summary: the arm every already-subscribed
+//! marketplace page reads for its header.
+
+use super::super::{SubscriptionRef, summary};
+use super::{cat, project, skill, sources_decl};
+
+#[test]
+fn a_subscription_summary_answers_with_itself_and_counts_its_offer() {
+    let tmp = tempfile::tempdir().unwrap();
+    let catalog = tmp.path().join("catalog");
+    skill(&catalog, "skills", "gh", "body");
+    skill(&catalog, "skills", "extra", "body");
+    let (env, scope) = project(tmp.path(), &sources_decl(&catalog));
+
+    let report = summary(&env, &cat(&scope)).unwrap();
+    assert_eq!(
+        report.subscription,
+        Some(SubscriptionRef {
+            scope: scope.clone(),
+            source: "cat".to_owned(),
+        })
+    );
+    assert_eq!(report.provenance, catalog.display().to_string());
+    assert_eq!(report.commit, None);
+    assert_eq!(report.warning, None);
+    assert_eq!(report.counts.get("skill"), Some(&2));
+    assert_eq!(report.counts.len(), 1);
+}

--- a/crates/core/src/source/browse/tests/summary.rs
+++ b/crates/core/src/source/browse/tests/summary.rs
@@ -21,6 +21,7 @@ fn a_subscription_summary_answers_with_itself_and_counts_its_offer() {
         })
     );
     assert_eq!(report.provenance, catalog.display().to_string());
+    assert_eq!(report.repo_key, None, "a path is no GitHub repository");
     assert_eq!(report.commit, None);
     assert_eq!(report.warning, None);
     assert_eq!(report.counts.get("skill"), Some(&2));

--- a/crates/core/src/source_ops.rs
+++ b/crates/core/src/source_ops.rs
@@ -1,6 +1,9 @@
 use serde::Serialize;
 use specta::Type;
 
+mod repos;
+pub use repos::{RepoSubscription, repo_subscriptions};
+
 use crate::engine::{EngineReport, PlanOptions, plan_scope};
 use crate::env::Env;
 use crate::error::{CoreError, Result};
@@ -22,7 +25,7 @@ pub struct SourceRow {
     pub declared_items: Vec<String>,
 }
 
-fn load_current(env: &Env, scope: &Scope) -> Result<Option<Manifest>> {
+pub(crate) fn load_current(env: &Env, scope: &Scope) -> Result<Option<Manifest>> {
     match manifest::load(&manifest::manifest_path(env, scope))? {
         manifest::ManifestFile::Current(m) => Ok(Some(*m)),
         _ => Ok(None),

--- a/crates/core/src/source_ops/repos.rs
+++ b/crates/core/src/source_ops/repos.rs
@@ -89,4 +89,28 @@ mod tests {
         );
         assert!(rows.iter().all(|row| row.scope == Scope::Global));
     }
+
+    #[test]
+    fn a_scope_still_naming_the_moved_default_subscribes_under_the_new_key() {
+        let tmp = tempfile::tempdir().unwrap();
+        let env = Env::fake(tmp.path(), FakeOs::Linux);
+        let manifest = env.global_manifest_file();
+        fs::create_dir_all(manifest.parent().unwrap()).unwrap();
+        fs::write(
+            &manifest,
+            format!(
+                "schema = 5\n[sources.vstack]\nrepo = \"{}\"\n",
+                crate::manifest::LEGACY_SOURCE_REPO
+            ),
+        )
+        .unwrap();
+
+        let rows = repo_subscriptions(&env);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].name, "vstack");
+        assert_eq!(
+            rows[0].repo_key.as_deref(),
+            Some(crate::manifest::DEFAULT_SOURCE_REPO)
+        );
+    }
 }

--- a/crates/core/src/source_ops/repos.rs
+++ b/crates/core/src/source_ops/repos.rs
@@ -14,7 +14,6 @@ pub struct RepoSubscription {
     /// The declaration's repository, canonical `owner/repo` where it is one
     /// on GitHub — the key the directory and the blind browse match by.
     pub repo_key: Option<String>,
-    pub enabled: bool,
 }
 
 /// Every remote subscription across the personal scope and every project,
@@ -45,9 +44,49 @@ pub fn repo_subscriptions(env: &Env) -> Vec<RepoSubscription> {
                 scope: scope.clone(),
                 name: name.clone(),
                 repo_key: crate::repo_move::owner_repo(repo),
-                enabled: decl.enabled,
             });
         }
     }
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::env::FakeOs;
+    use std::fs;
+
+    #[test]
+    fn every_github_spelling_folds_to_one_key_and_a_path_source_has_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let env = Env::fake(tmp.path(), FakeOs::Linux);
+        let manifest = env.global_manifest_file();
+        fs::create_dir_all(manifest.parent().unwrap()).unwrap();
+        fs::write(
+            &manifest,
+            "schema = 5\n\
+             [sources.https]\nrepo = \"https://github.com/Owner/Repo.git\"\n\
+             [sources.ssh]\nrepo = \"git@github.com:owner/repo.git\"\n\
+             [sources.elsewhere]\nrepo = \"git@gitlab.com:owner/repo.git\"\n\
+             [sources.here]\npath = \"/catalog\"\n",
+        )
+        .unwrap();
+
+        let rows = repo_subscriptions(&env);
+        let key_of = |name: &str| {
+            rows.iter()
+                .find(|row| row.name == name)
+                .expect(name)
+                .repo_key
+                .clone()
+        };
+        assert_eq!(key_of("https").as_deref(), Some("owner/repo"));
+        assert_eq!(key_of("ssh").as_deref(), Some("owner/repo"));
+        assert_eq!(key_of("elsewhere"), None);
+        assert!(
+            rows.iter().all(|row| row.name != "here"),
+            "a path is not a repository"
+        );
+        assert!(rows.iter().all(|row| row.scope == Scope::Global));
+    }
 }

--- a/crates/core/src/source_ops/repos.rs
+++ b/crates/core/src/source_ops/repos.rs
@@ -1,0 +1,53 @@
+//! Which repositories this machine subscribes to, read off the manifests
+//! alone — the one answer the Community tab's Subscribed badge and a blind
+//! browse's "carry on as this subscription" both read.
+
+use crate::env::Env;
+use crate::model::Scope;
+
+/// One declared remote subscription, read off the manifest alone — no
+/// resolve, no catalog open.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RepoSubscription {
+    pub scope: Scope,
+    pub name: String,
+    /// The declaration's repository, canonical `owner/repo` where it is one
+    /// on GitHub — the key the directory and the blind browse match by.
+    pub repo_key: Option<String>,
+    pub enabled: bool,
+}
+
+/// Every remote subscription across the personal scope and every project,
+/// personal first, from the manifests alone. A scope that cannot be read
+/// contributes nothing rather than blocking the caller: the Community
+/// tab's Subscribed badge and the detail page's "carry on as this
+/// subscription" both read this one list, so they cannot disagree.
+pub fn repo_subscriptions(env: &Env) -> Vec<RepoSubscription> {
+    let mut scopes = vec![Scope::Global];
+    if let Ok(settings) = crate::settings::load(env) {
+        scopes.extend(
+            settings
+                .projects
+                .into_iter()
+                .map(|root| Scope::Project { root }),
+        );
+    }
+    let mut out = Vec::new();
+    for scope in scopes {
+        let Ok(Some(manifest)) = super::load_current(env, &scope) else {
+            continue;
+        };
+        for (name, decl) in &manifest.sources {
+            let Some(repo) = &decl.repo else {
+                continue;
+            };
+            out.push(RepoSubscription {
+                scope: scope.clone(),
+                name: name.clone(),
+                repo_key: crate::repo_move::owner_repo(repo),
+                enabled: decl.enabled,
+            });
+        }
+    }
+    out
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -842,15 +842,18 @@ lives in one capability table read by core and UI.
   `Repo { repo }` — so the app has one detail, package and bundle surface
   rather than a parallel set. A bare repository is fetched by
   `remote::sync` into the same store a subscription reads from, keyed by
-  the directory's spelling, so subscribing never downloads twice and the
-  pre-install safety record is shared per commit; only GitHub `owner/repo`
-  is openable blind (`NotBrowsable` for anything else), because that is
-  what the directory and skills.sh hand over. With no subscription the
+  the canonical `owner/repo` every GitHub spelling folds to — the same key
+  Subscribe is prefilled with — so subscribing never downloads twice, the
+  pre-install safety record is shared per commit, and a listing never
+  picks the transport; only GitHub is openable blind (`NotBrowsable` for
+  anything else), because that is what the directory and skills.sh hand
+  over. With no subscription the
   installed-state join answers Available for everything and judges name
   clashes against the personal scope, where Subscribe lands by default.
   `browse::summary` is a repository's first read — it refreshes, reports a
-  failed refresh as a warning over the store's copy, and names the
-  subscription this machine already holds for that repository — and the
+  failed refresh as a warning over the store's copy, and names an enabled
+  subscription this machine already holds for that repository whose
+  content is readable — and the
   UI's `useCatalog` switches the page onto that subscription the moment one
   exists, which is how "subscribe from here" keeps your place. Installing
   still needs a subscription: a repository page's one action is Subscribe.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -836,6 +836,24 @@ lives in one capability table read by core and UI.
   (`KENDEX_SKILLSSH=off`), and a hit is a lead, never an identity —
   installing routes through the same subscribe path as any marketplace.
   Sign-in, collections and deep links arrive with W3/W4.
+- **A listed marketplace is browsable before anyone subscribes to it, on
+  the same pages a subscription gets.** Every browse read in
+  `source/browse` takes a `Catalog` — `Subscription { scope, source }` or
+  `Repo { repo }` — so the app has one detail, package and bundle surface
+  rather than a parallel set. A bare repository is fetched by
+  `remote::sync` into the same store a subscription reads from, keyed by
+  the directory's spelling, so subscribing never downloads twice and the
+  pre-install safety record is shared per commit; only GitHub `owner/repo`
+  is openable blind (`NotBrowsable` for anything else), because that is
+  what the directory and skills.sh hand over. With no subscription the
+  installed-state join answers Available for everything and judges name
+  clashes against the personal scope, where Subscribe lands by default.
+  `browse::summary` is a repository's first read — it refreshes, reports a
+  failed refresh as a warning over the store's copy, and names the
+  subscription this machine already holds for that repository — and the
+  UI's `useCatalog` switches the page onto that subscription the moment one
+  exists, which is how "subscribe from here" keeps your place. Installing
+  still needs a subscription: a repository page's one action is Subscribe.
 - **Intent in the manifest, closure in the plan, edges in the lock.** The
   manifest records choices and never their consequences: the items asked
   for, the bundles installed, which optional dependencies were taken, what

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -594,56 +594,52 @@ lives in one capability table read by core and UI.
   parses as real YAML under the same posture (aliases and duplicate
   keys refused, bounds enforced), and every interpolated value in a
   generated file is quoted so foreign text cannot mint config lines.
-- **The source store is immutable, and revisions are declared.** A
-  downloaded catalog is never a mutable checkout: each commit is
-  materialized once into a directory named after its object id, published
-  by rename, and read unchanged from then on, while fetching touches only
-  a bare mirror beside it. v0.1 hard-reset one checkout per repository on
-  every refresh — two scopes reading different revisions fought over it,
-  and a refresh in one window could shift bytes under a render in
-  another. A source declares which revision it reads: a full commit id is
-  a pin (that commit and no other, and once cached it resolves without
-  any network), a tag or branch is a tracking selector that re-resolves
-  on each refresh and is previewed like any other upstream change. Losing
-  the lock loses no intent either way — the manifest holds what is
-  wanted, the lock only records which commit that came out as. Offline
-  with an uncached pin is a hard error naming the pin; anything already
-  installed keeps working from what is on disk. Materialization runs
-  under a per-repository cache lock; a second resolver waits half a
-  second — enough to ride out a neighbour that is only starting up — and
-  is then told the cache is busy rather than left waiting on someone
-  else's download. A refresh treats that as an error; a read does not —
-  planning degrades to "not fetched yet" for that one source: a neighbour's
-  download must not decide whether the rest of a scope can be planned. The
-  lock's recorded commit is a fallback only for the exact declaration that
-  produced it; a manifest naming another repository or revision is never
-  served the previous one. An item declaration may hold its own `rev`,
-  outranking the source's, always as a full commit id: `kendex pin` and the
-  version picker resolve tags and branches at write time, since a hold a
-  moved tag can move is no hold. Holds flow through derivation — a pinned
-  bundle pins its members, a pinned skill's dependencies read the pinned
-  catalog, and two parents demanding different revisions of one dependency
-  are a conflict that writes nothing: one filesystem identity exists, and a
-  silent winner would install content somebody pinned away from. Updates are
-  a projection over the mirror, never drift: a held item hashes clean
-  against its held tree, and the Updates page asks the mirror (pinned
-  sources too — a pin says what installs, not what exists) what newer
-  content exists; its timeline lists only commits that touched the package's
-  files, tag-decorated, never tag-replaced. Rows are per package per scope;
-  the page folds them by package and expands by place (each is decided per
-  scope), and nothing applies on its own: followers come current on apply or
-  refresh, held ones when their hold moves. Muting a package's
-  update notifications is a machine-local settings entry, not manifest
-  intent: a preference committed to a shared repository would silence a
-  whole team.
-  Reuse is verified against a publish receipt written outside the
-  checkout: a full content hash of the tree, which costs a read of the
-  catalog per plan and is the only check a same-size edit cannot fool.
-  The pre-2.0 clones are read where the new layout has nothing yet, and
-  deleted never. Neither are published commits: the store keeps one tree
-  per commit it has ever resolved, so a tracked branch grows the cache by
-  a catalog per upstream change, and nothing prunes it yet — the cache is
-  rebuildable, so deleting it is the only cleanup there is.
+- **The source store is immutable, and revisions are declared.** A downloaded
+  catalog is never a mutable checkout: each commit is materialized once into a
+  directory named after its object id, published by rename, and read unchanged
+  from then on, while fetching touches only a bare mirror beside it. v0.1
+  hard-reset one checkout per repository on every refresh — two scopes reading
+  different revisions fought over it, and a refresh in one window could shift
+  bytes under a render in another. A source declares which revision it reads:
+  a full commit id is a pin (that commit and no other, and once cached it
+  resolves without any network), a tag or branch is a tracking selector that
+  re-resolves on each refresh and is previewed like any other upstream change.
+  Losing the lock loses no intent either way — the manifest holds what is
+  wanted, the lock only records which commit that came out as. Offline with an
+  uncached pin is a hard error naming the pin; anything already installed
+  keeps working from what is on disk. Materialization runs under a
+  per-repository cache lock; a second resolver waits half a second — enough to
+  ride out a neighbour that is only starting up — and is then told the cache
+  is busy rather than left waiting on someone else's download. A refresh
+  treats that as an error; a read does not — planning degrades to "not fetched
+  yet" for that one source: a neighbour's download must not decide whether the
+  rest of a scope can be planned. The lock's recorded commit is a fallback
+  only for the exact declaration that produced it; a manifest naming another
+  repository or revision is never served the previous one. An item declaration
+  may hold its own `rev`, outranking the source's, always as a full commit id:
+  `kendex pin` and the version picker resolve tags and branches at write time,
+  since a hold a moved tag can move is no hold. Holds flow through derivation
+  — a pinned bundle pins its members, a pinned skill's dependencies read the
+  pinned catalog, and two parents demanding different revisions of one
+  dependency are a conflict that writes nothing: one filesystem identity
+  exists, and a silent winner would install content somebody pinned away from.
+  Updates are a projection over the mirror, never drift: a held item hashes
+  clean against its held tree, and the Updates page asks the mirror (pinned
+  sources too — a pin says what installs, not what exists) what newer content
+  exists; its timeline lists only commits that touched the package's files,
+  tag-decorated, never tag-replaced. Rows are per package per scope; the page
+  folds them by package and expands by place (each is decided per scope), and
+  nothing applies on its own: followers come current on apply or refresh, held
+  ones when their hold moves. Muting a package's update notifications is a
+  machine-local settings entry, not manifest intent: a preference committed to
+  a shared repository would silence a whole team. Reuse is verified against a
+  publish receipt written outside the checkout: a full content hash of the
+  tree, which costs a read of the catalog per plan and is the only check a
+  same-size edit cannot fool. The pre-2.0 clones are read where the new layout
+  has nothing yet, and deleted never. Neither are published commits: the store
+  keeps one tree per commit it has ever resolved, so a tracked branch grows
+  the cache by a catalog per upstream change, and nothing prunes it yet — the
+  cache is rebuildable, so deleting it is the only cleanup there is.
 - **A subscription reference is parsed, never guessed, and one repository
   subscribes once per scope.** Two validators sit side by side in
   `core/source_ref.rs`, one per trust level: the typed one (the Subscribe

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -647,216 +647,198 @@ lives in one capability table read by core and UI.
 - **A subscription reference is parsed, never guessed, and one repository
   subscribes once per scope.** Two validators sit side by side in
   `core/source_ref.rs`, one per trust level: the typed one (the Subscribe
-  dialog, `marketplace subscribe`, `source add`, `add`'s positional
-  source) keeps the full range a person may need — `owner/repo[@rev]`,
-  any-host remote URLs kept as typed (an `ssh://` spelling can be what
-  their auth requires), local paths, GitHub tree URLs, skills.sh package
-  URLs — while the untrusted one (directory rows, collections, deep
-  links) is GitHub-only and normalizes to `owner/repo`. Both refuse a
-  leading `-`, `..` in repository components, and percent-escapes that
-  would smuggle a separator, decoding exactly once. A tree URL always
-  subscribes the whole repository and surfaces the package path as a
-  lead to open, never an identity; its `<ref>` resolves against the
-  mirror's real refs (branch names contain `/`), and two split points
-  both naming refs, or a branch and tag sharing a name, refuse naming
-  every candidate — offline, normalization is a refusal before any
-  write. One repository per scope, compared by canonical identity
+  dialog, `marketplace subscribe`, `source add`, `add`'s positional source)
+  keeps the full range a person may need — `owner/repo[@rev]`, any-host
+  remote URLs kept as typed (an `ssh://` spelling can be what their auth
+  requires), local paths, GitHub tree URLs, skills.sh package URLs — while
+  the untrusted one (directory rows, collections, deep links) is GitHub-only
+  and normalizes to `owner/repo`. Both refuse a leading `-`, `..` in
+  repository components, and percent-escapes that would smuggle a separator,
+  decoding exactly once. A tree URL always subscribes the whole repository
+  and surfaces the package path as a lead to open, never an identity; its
+  `<ref>` resolves against the mirror's real refs (branch names contain
+  `/`), and two split points both naming refs, or a branch and tag sharing a
+  name, refuse naming every candidate — offline, normalization is a refusal
+  before any write. One repository per scope, compared by canonical identity
   (`.git`, case, and redirect spellings are one repo), with the refusal
   naming the existing subscription. The default marketplace is found by
-  repo, never by name and never by sort order: the subscription whose
-  repo is the default repo; two of them prefer the seeded name and
-  otherwise refuse naming both; none is a typed error with no fallback —
-  what the cross-source search catches rather than a guessed install.
-  Installing into a project from a personal subscription copies the
-  declaration into the project in that plan — exactly one scope mutated,
-  the personal manifest read-only, the cache shared by construction.
+  repo, never by name and never by sort order: the subscription whose repo
+  is the default repo; two of them prefer the seeded name and otherwise
+  refuse naming both; none is a typed error with no fallback — what the
+  cross-source search catches rather than a guessed install. Installing into
+  a project from a personal subscription copies the declaration into the
+  project in that plan — exactly one scope mutated, the personal manifest
+  read-only, the cache shared by construction.
 - **A name says where it comes from, or the search does — never a
   fallback.** Every installable kind declares through `add`
   (`engine/ops/add`): agents, skills, hooks, commands, MCP servers; Pi
   extensions are carrier-only and a direct add is a typed refusal. The
-  qualifier is `marketplace::name` (`add/place.rs`) — `::` never appears
-  in an item name, so `/` keeps meaning `plugin/item` or, positionally,
-  `owner/repo` — and it resolves against subscription aliases only,
-  refusing with the subscribed list when nothing matches. A bare name
-  searches every enabled subscription in the scope for its kind: one
-  offer installs, two refuse printing the `::` spellings beside each
-  subscription's canonical repo, and zero is not found with the fix
-  named — the default subscription participates like any other, and
-  `default_source` serves only requests that name no item at all
-  (`--all`, a bare bundle). Installing a whole bundle subsumes, in the
-  same plan, the previously-declared members whose effective options
-  equal what the bundle derives (`add/subsume.rs`) — a member the user
-  shaped keeps its declaration with the preview saying why — and
-  `[bundles.<name>]` stays keyed by bare name, so a second marketplace's
+  qualifier is `marketplace::name` (`add/place.rs`) — `::` never appears in
+  an item name, so `/` keeps meaning `plugin/item` or, positionally,
+  `owner/repo` — and it resolves against subscription aliases only, refusing
+  with the subscribed list when nothing matches. A bare name searches every
+  enabled subscription in the scope for its kind: one offer installs, two
+  refuse printing the `::` spellings beside each subscription's canonical
+  repo, and zero is not found with the fix named — the default subscription
+  participates like any other, and `default_source` serves only requests
+  that name no item at all (`--all`, a bare bundle). Installing a whole
+  bundle subsumes, in the same plan, the previously-declared members whose
+  effective options equal what the bundle derives (`add/subsume.rs`) — a
+  member the user shaped keeps its declaration with the preview saying why —
+  and `[bundles.<name>]` stays keyed by bare name, so a second marketplace's
   same-named bundle is refused naming the first.
-- **A plugin-registry-shaped catalog is recognized, never guessed.** A source
-  is read one plugin deep (`plugins/<name>/{agents,commands,skills}`)
+- **A plugin-registry-shaped catalog is recognized, never guessed.** A
+  source is read one plugin deep (`plugins/<name>/{agents,commands,skills}`)
   exactly when it carries `.claude-plugin/marketplace.json`; a `plugins/`
-  directory on its own is not evidence, and guessing renames every item in
-  a catalog that never asked for it. The registry, not the directory
-  listing, decides what such a catalog offers: an item resolves only under
-  a plugin the registry validated, and only entries pointing at a
-  directory inside the repository are consumed — an entry naming another
-  repository or a URL is skipped with a finding, since fetching it would
-  be a second, unpinned download behind the one the user asked for.
-  Everything the catalog gets wrong is a finding with a fix, cross-file
-  included: a registry that disagrees with a plugin's own manifest about
-  its name or version, a plugin describing parts that live outside itself,
-  and two names one filesystem would fold together. Registry metadata
-  (category, version, author, license, homepage, and the plugin's items as
-  a named group) is read-side only — it feeds browsing and, later,
-  installing a plugin as a unit; the manifest records what the user chose,
-  never what a catalog says about itself.
+  directory on its own is not evidence, and guessing renames every item in a
+  catalog that never asked for it. The registry, not the directory listing,
+  decides what such a catalog offers: an item resolves only under a plugin
+  the registry validated, and only entries pointing at a directory inside
+  the repository are consumed — an entry naming another repository or a URL
+  is skipped with a finding, since fetching it would be a second, unpinned
+  download behind the one the user asked for. Everything the catalog gets
+  wrong is a finding with a fix, cross-file included: a registry that
+  disagrees with a plugin's own manifest about its name or version, a plugin
+  describing parts that live outside itself, and two names one filesystem
+  would fold together. Registry metadata (category, version, author,
+  license, homepage, and the plugin's items as a named group) is read-side
+  only — it feeds browsing and, later, installing a plugin as a unit; the
+  manifest records what the user chose, never what a catalog says about
+  itself.
 - **Any repo holding skills is a marketplace — discovered from a closed
-  table, never guessed wider.** `source/discover.rs` owns a versioned
-  search table (`DISCOVERY_VERSION`, part of the safety-cache key):
-  `skills/` and `skills/.curated`, each harness's project skills dir
-  (pinned to the adapters by test), `<dir>/**/SKILL.md` up to three levels
-  down for category nesting — stopping below a found skill, skipping
-  `.git`, `node_modules` and friends — and a repo-root `SKILL.md` as a
-  one-skill repo named by its validated frontmatter `name`, else by the
-  repository leaf the caller passes, since a store directory is a commit
-  id. The table yields skills only: hooks, MCP servers, commands and
-  agents install from a declared kendex layout, `kendex.toml`, or a
-  plugin registry — executable content is never discovered into
-  existence, so a `hooks/` folder in an undeclared skills repo is
-  repository tooling, not an offer. Precedence is fixed and fail-closed:
-  a `.claude-plugin/marketplace.json` registry wins outright and root
-  dirs are not read; else a parsed control file declares the fixed
-  layout (`[catalog]` overriding which dirs) and the search table stays
-  out — discovery exists for repos that never declared anything; else
-  the search runs. A control file that is present but unreadable, or a
-  wrong-typed `[catalog]` value, makes the source unusable with a
-  finding — presence selects the mode, and breakage never falls through
-  to a different one, because serving defaults would offer a different
-  catalog than the author published. Every probe goes through
+  table, never guessed wider.** `source/discover.rs` owns a versioned search
+  table (`DISCOVERY_VERSION`, part of the safety-cache key): `skills/` and
+  `skills/.curated`, each harness's project skills dir (pinned to the
+  adapters by test), `<dir>/**/SKILL.md` up to three levels down for
+  category nesting — stopping below a found skill, skipping `.git`,
+  `node_modules` and friends — and a repo-root `SKILL.md` as a one-skill
+  repo named by its validated frontmatter `name`, else by the repository
+  leaf the caller passes, since a store directory is a commit id. The table
+  yields skills only: hooks, MCP servers, commands and agents install from a
+  declared kendex layout, `kendex.toml`, or a plugin registry — executable
+  content is never discovered into existence, so a `hooks/` folder in an
+  undeclared skills repo is tooling, not an offer. Precedence is fixed and
+  fail-closed: a `.claude-plugin/marketplace.json` registry wins outright
+  and root dirs are not read; else a parsed control file declares the fixed
+  layout (`[catalog]` overriding which dirs) and the search table stays out
+  — discovery exists for repos that never declared anything; else the search
+  runs. A control file present but unreadable, or a wrong-typed `[catalog]`,
+  makes the source unusable with a finding — presence selects the mode and
+  breakage never falls through to another, since serving defaults would
+  offer a catalog the author never published. Every probe goes through
   `SealedSource` (symlinks skipped, budgets held, hard caps on found
   skills); items dedupe by normalized repository-relative path, never
-  `canonicalize`; two directories that fold to one name are **both**
-  skipped with a finding naming both — unless their bytes are identical, in
-  which case one skill served under two harness layouts is deduplicated by
-  content, not treated as a clash — so which directory the walk reached
-  first can never decide which of two clashing skills installs. A
-  frontmatter `name` disagreeing with its directory is a finding (the
-  directory is the identity), and submodule or LFS pointers under a
-  recognized root are findings, not hydrated. A name that carries an
-  invisible or direction-reversing character is refused (`names::segment_problem`)
-  and shown with it escaped (`names::shown`), so one marketplace's package
-  cannot wear another's name on screen while installing under a different
-  one; a declared-layout catalog lists only names that install, so the
-  Packages table never draws a row `find_item` would refuse. The walk stops
-  at its skill cap rather than reading the rest of a hostile tree, bounding
-  the work, not just the output. `source/about.rs` renders the one typed report — what was
-  found where, plus every finding — that the About tab and `kendex
-  index` consume.
+  `canonicalize`; two directories that fold to one name are **both** skipped
+  with a finding naming both — identical bytes excepted, that being one
+  skill served under two harness layouts — so the walk's order never decides
+  which of two clashing skills installs. A frontmatter `name` disagreeing
+  with its directory is a finding (the directory is the identity), and
+  submodule or LFS pointers under a recognized root are findings, not
+  hydrated. A name carrying an invisible or direction-reversing character is
+  refused (`names::segment_problem`) and shown escaped (`names::shown`), so
+  one marketplace's package cannot wear another's name on screen while
+  installing under a different one; a declared-layout catalog lists only
+  names that install, so the Packages table never draws a row `find_item`
+  would refuse. The walk stops at its skill cap rather than reading the rest
+  of a hostile tree, bounding the work, not just the output.
+  `source/about.rs` renders the one typed report — what was found where,
+  plus every finding — that the About tab and `kendex index` consume.
 - **Browsing is a read-side join, and installed state is derived, never
-  stored.** `source/browse.rs` answers what one catalog offers — every
-  package across kinds, a bundle's members, a package's preview — with each
-  row's state joined from the scope's manifest and lock on every call:
-  installed is a lock entry from this subscription, held-back-by-safety is
-  asked-for content whose catalog bytes the gate's own verdict refuses, and
-  a bundle's "partly installed (2 of 6)" is counted from its members, so no
-  stored flag can drift from the records it summarizes. A name another
-  source already holds is surfaced on the row (`collision`) before the
-  click; the refusal itself stays in the engine (invariant 4). Pre-install
-  safety (`browse/safety.rs`) scores catalog bytes with the same rules an
-  install runs and caches **findings and scores only**, beside the commit's
-  receipt in the immutable store (`<key>/<commit>.safety/…` — never inside
-  the checkout, whose receipt-signed tree must not change), keyed by the
-  item's content hash plus the rule-set, discovery-table and record-format
-  versions, each recomputed and verified before reuse. The warn/block
-  verdict is derived from the current thresholds at read time — thresholds
-  in the key would re-score on every settings change and imply a different
-  analysis where only the judgment moved. Browse is a preview of the
-  verdict, never a second gate. `library.rs` is the same posture for the
-  Library table: one lock+manifest join mapping every installation to its
-  origin — a subscription, the user's own local content (with what a fork
-  replaced), or observed-and-unmanaged.
+  stored.** Every `source/browse.rs` read — packages across kinds, a
+  bundle's members, a package's preview — takes a `Catalog`,
+  `Subscription { scope, source }` or `Repo { repo }`, so a listed
+  marketplace opens before anyone subscribes on the pages a subscription
+  gets, not a parallel set. Each row's state is joined from the scope's
+  manifest and lock on every call — installed is a lock entry from this
+  subscription, held-back-by-safety is asked-for content whose catalog bytes
+  the gate's own verdict refuses, "partly installed (2 of 6)" is counted
+  from a bundle's members — so no stored flag can drift from the records it
+  summarizes; with no subscription the join answers Available and judges
+  name clashes against the personal scope, where Subscribe lands. A name
+  another source holds is surfaced on the row (`collision`) before the
+  click; the refusal stays in the engine (invariant 4). A bare repository is
+  fetched by `remote::sync` into the store a subscription reads from, under
+  the canonical `owner/repo` every GitHub spelling folds to — the key
+  Subscribe is prefilled with — so subscribing never downloads twice and the
+  safety record is shared per commit; only GitHub opens blind
+  (`NotBrowsable` otherwise), and a root skill's file list and file reads
+  are confined to the skill tree scoring and install read, never the
+  repository around it. `browse::summary`, a repository's first read,
+  refreshes (a failure is a warning over the store's copy) and names an
+  enabled, readable subscription this machine already holds for it;
+  `useCatalog` moves the page onto it the moment one exists, so "subscribe
+  from here" keeps your place. Installing still needs a subscription: a
+  repository page's one action is Subscribe. Pre-install safety
+  (`browse/safety.rs`) scores catalog bytes with the rules an install runs
+  and caches **findings and scores only**, beside the commit's receipt in
+  the immutable store (`<key>/<commit>.safety/…`, never inside the
+  receipt-signed checkout), keyed by the item's content hash plus the
+  rule-set, discovery-table and record-format versions, each recomputed and
+  verified before reuse. The warn/block verdict is derived from the current
+  thresholds at read time — thresholds in the key would re-score on every
+  settings change. Browse is a preview of the verdict, never a second gate.
+  `library.rs` is the same join for the Library table, mapping each
+  installation to its origin: a subscription, local content (with what a
+  fork replaced), or observed-and-unmanaged.
 - **A subscription's closure is derived by re-expansion, and unsubscribing
   removes or keeps exactly it.** `engine/detach.rs` computes what leaves
   with a marketplace by expanding the installed set with the source present
   and again with its declarations gone, then diffing — a derived dependency
-  never names the source, so only the difference tells the truth about what
-  its going takes with it. A member another marketplace's bundle still
-  carries is in both expansions, so it stays. The closure refuses while the
-  source cannot be read, rather than infer a wrong one. **Remove** drops the
-  closure's declarations and sweeps their installations (orphan removal
-  filtered to the exact kind+name pairs, so an unrelated same-named orphan is
-  never taken); an edited installation is never swept without `--discard-edits`.
-  **Keep** (`detach/keep.rs`) copies each installation's *source-form* bytes —
-  read through the sealed catalog at the exact commit it installed from, a
-  parent skill excluding any nested child skill — into the scope's local
-  source, flips the declaration to `local` with fork provenance, and removes
-  the subscription; the local writes are ordered before the manifest flip in
-  one plan, so a failed apply rolls the whole conversion back (invariant 11).
-  Keep refuses an edited package (fork or discard first — hooks compared to
-  what apply wrote, so an edited script is caught), and preflights the local
-  target: a symlink, or a case/composition-folding sibling, or different bytes
-  already there is a refusal, never a clobber (invariants 4 and 6). The local
-  source lists a `plugin/item` name beside a plain `plugin`, so a detached
-  plugin-registry package round-trips.
-- **The machine seam reads through the same core installing reads
-  through.** `check_catalog.rs` (core) owns the two authoring passes —
-  structural (would each harness's loader hold this item) and safety (the
-  same rules an install runs) — so `kendex check --catalog [--json]`, the
-  indexer's per-package verdicts, and authoring preflight ask one
-  implementation; the CLI only prints, as lines or as a versioned envelope
-  (`schema`, typed findings, counts, `ok`). `source/index.rs` emits the
-  per-marketplace summary the community directory consumes (`kendex index
-  [<dir>] --json`, schema 1, plain directory, no network): metadata from
-  the catalog's own `[marketplace]` table (`source/meta.rs` — read-only,
-  every string capped and control-char-safe), packages built from
-  `list_items` so what the summary offers is exactly what subscribing
-  finds (pinned by test), safety scores from the check passes, bundles
-  with members, About rows, findings. Field order in both JSON shapes is
-  the schema — serde structs, no maps. `kendex marketplace check` is the
-  alias of `check --catalog --strict`, same exit codes. A maintainer's
-  reviewed findings live in a committed `kendex-reviews.toml` at the
-  catalog root (`check_catalog/dismissals.rs`): the same
-  content-hash-bound dismissal records the install side keeps in a
+  never names the source, so only the difference is true. A member another
+  marketplace's bundle still carries is in both expansions, so it stays. It
+  refuses while the source cannot be read. **Remove** drops the closure's
+  declarations and sweeps their installations (orphan removal filtered to
+  exact kind+name pairs); an edited installation is never swept without
+  `--discard-edits`. **Keep** (`detach/keep.rs`) copies each installation's
+  *source-form* bytes — read through the sealed catalog at the exact commit
+  it installed from, a parent skill excluding any nested child skill — into
+  the scope's local source, flips the declaration to `local` with fork
+  provenance, and removes the subscription; the local writes are ordered
+  before the manifest flip in one plan, so a failed apply rolls the
+  conversion back (invariant 11). Keep refuses an edited package (fork or
+  discard first; hooks are compared to what apply wrote) and preflights the
+  local target: a symlink, a case/composition-folding sibling, or different
+  bytes already there is a refusal, never a clobber (invariants 4 and 6).
+  The local source lists a `plugin/item` name beside a plain `plugin`, so a
+  detached plugin-registry package round-trips.
+- **The machine seam reads through the same core installing reads through.**
+  `check_catalog.rs` (core) owns the two authoring passes — structural
+  (would each harness's loader hold this item) and safety (the rules an
+  install runs) — so `kendex check --catalog [--json]`, the indexer's
+  per-package verdicts, and authoring preflight ask one implementation; the
+  CLI only prints, as lines or as a versioned envelope (`schema`, typed
+  findings, counts, `ok`). `source/index.rs` emits the per-marketplace
+  summary the community directory consumes (`kendex index [<dir>] --json`,
+  schema 1, plain directory, no network): metadata from the catalog's own
+  `[marketplace]` table (`source/meta.rs` — read-only, every string capped
+  and control-char-safe), packages built from `list_items` so the summary
+  offers exactly what subscribing finds (pinned by test), safety scores from
+  the check passes, bundles with members, About rows, findings. Field order
+  in both JSON shapes is the schema — serde structs, no maps.
+  `kendex marketplace check` aliases `check --catalog --strict`, same exit
+  codes. A maintainer's reviewed findings live in a committed
+  `kendex-reviews.toml` at the catalog root (`check_catalog/dismissals.rs`):
+  the same content-hash-bound dismissal records the install side keeps in a
   manifest, keyed `kind:name`, written by `dismiss --catalog` from the
-  tokens `check --catalog` prints. The authoring passes stop counting a
-  dismissed finding (still reported, marked) — and only the authoring
-  passes: a consumer's install never reads a catalog's own reviews, so a
-  catalog cannot pre-approve its content on anyone else's machine. Editing
-  the item stales the record and the hold returns.
-- **The community directory is read like any remote: strictly, capped,
-  and honest about staleness.** `registry/` (core) consumes what
+  tokens `check --catalog` prints. Only the authoring passes stop counting a
+  dismissed finding (still reported, marked); an install never reads a
+  catalog's own reviews, so a catalog cannot pre-approve itself on anyone
+  else's machine. Editing the item stales the record; the hold returns.
+- **The community directory is read like any remote: strictly, capped, and
+  honest about staleness.** `registry/` (core) consumes what
   `source/index.rs` producers feed kendex.ai: `index.rs` re-parses the
-  site's schema-1 payload under the site's own caps (a spoofed or
-  compromised registry cannot grow a row), refusing structural problems
-  whole and dropping only unusable rows; `cache.rs` holds one body and
-  one meta line on disk (`Env::registry_cache_dir`) behind an ETag and a
-  one-hour TTL, and a failed refresh serves the last fetch labeled stale
-  with its real fetch time — the Community tab is never blank. All reads
-  go through the `Fetch` trait (curl via `Hardened`, plain http only when
-  an explicit `KENDEX_API` override asks); tests inject canned
-  transports. `skillssh.rs` is the versioned adapter over their public
-  search: pinned wire schema refused on mismatch, capped, kill-switched
-  (`KENDEX_SKILLSSH=off`), and a hit is a lead, never an identity —
-  installing routes through the same subscribe path as any marketplace.
-  Sign-in, collections and deep links arrive with W3/W4.
-- **A listed marketplace is browsable before anyone subscribes to it, on
-  the same pages a subscription gets.** Every browse read in
-  `source/browse` takes a `Catalog` — `Subscription { scope, source }` or
-  `Repo { repo }` — so the app has one detail, package and bundle surface
-  rather than a parallel set. A bare repository is fetched by
-  `remote::sync` into the same store a subscription reads from, keyed by
-  the canonical `owner/repo` every GitHub spelling folds to — the same key
-  Subscribe is prefilled with — so subscribing never downloads twice, the
-  pre-install safety record is shared per commit, and a listing never
-  picks the transport; only GitHub is openable blind (`NotBrowsable` for
-  anything else), because that is what the directory and skills.sh hand
-  over. With no subscription the
-  installed-state join answers Available for everything and judges name
-  clashes against the personal scope, where Subscribe lands by default.
-  `browse::summary` is a repository's first read — it refreshes, reports a
-  failed refresh as a warning over the store's copy, and names an enabled
-  subscription this machine already holds for that repository whose
-  content is readable — and the
-  UI's `useCatalog` switches the page onto that subscription the moment one
-  exists, which is how "subscribe from here" keeps your place. Installing
-  still needs a subscription: a repository page's one action is Subscribe.
+  site's schema-1 payload under the site's own caps (a spoofed registry
+  cannot grow a row), refusing structural problems whole and dropping only
+  unusable rows; `cache.rs` holds one body and one meta line on disk
+  (`Env::registry_cache_dir`) behind an ETag and a one-hour TTL, and a
+  failed refresh serves the last fetch labeled stale with its real fetch
+  time — the Community tab is never blank. All reads go through the `Fetch`
+  trait (curl via `Hardened`, plain http only when an explicit `KENDEX_API`
+  override asks); tests inject canned transports. `skillssh.rs` is the
+  versioned adapter over their public search: pinned wire schema refused on
+  mismatch, capped, kill-switched (`KENDEX_SKILLSSH=off`); a hit is a lead,
+  never an identity, installing through the same subscribe path as any
+  marketplace. Sign-in, collections and deep links arrive with W3/W4.
 - **Intent in the manifest, closure in the plan, edges in the lock.** The
   manifest records choices and never their consequences: the items asked
   for, the bundles installed, which optional dependencies were taken, what

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -744,42 +744,42 @@ lives in one capability table read by core and UI.
   `source/about.rs` renders the one typed report — what was found where,
   plus every finding — that the About tab and `kendex index` consume.
 - **Browsing is a read-side join, and installed state is derived, never
-  stored.** Every `source/browse.rs` read — packages across kinds, a
-  bundle's members, a package's preview — takes a `Catalog`,
-  `Subscription { scope, source }` or `Repo { repo }`, so a listed
-  marketplace opens before anyone subscribes on the pages a subscription
-  gets, not a parallel set. Each row's state is joined from the scope's
-  manifest and lock on every call — installed is a lock entry from this
-  subscription, held-back-by-safety is asked-for content whose catalog bytes
-  the gate's own verdict refuses, "partly installed (2 of 6)" is counted
+  stored.** Every `source/browse.rs` read — packages across kinds, a bundle's
+  members, a package's preview — takes a `Catalog`, `Subscription { scope,
+  source }` or `Repo { repo }`, so a listed marketplace opens before anyone
+  subscribes on the pages a subscription gets. Each row's state is joined from
+  the scope's manifest and lock on every call — installed is a lock entry from
+  this subscription, held-back-by-safety is asked-for content whose catalog
+  bytes the gate's own verdict refuses, "partly installed (2 of 6)" is counted
   from a bundle's members — so no stored flag can drift from the records it
-  summarizes; with no subscription the join answers Available and judges
-  name clashes against the personal scope, where Subscribe lands. A name
-  another source holds is surfaced on the row (`collision`) before the
-  click; the refusal stays in the engine (invariant 4). A bare repository is
-  fetched by `remote::sync` into the store a subscription reads from, under
-  the canonical `owner/repo` every GitHub spelling folds to — the key
-  Subscribe is prefilled with — so subscribing never downloads twice and the
-  safety record is shared per commit; only GitHub opens blind
-  (`NotBrowsable` otherwise), and a root skill's file list and file reads
-  are confined to the skill tree scoring and install read, never the
-  repository around it. `browse::summary`, a repository's first read,
-  refreshes (a failure is a warning over the store's copy) and names an
-  enabled, readable subscription this machine already holds for it;
-  `useCatalog` moves the page onto it the moment one exists, so "subscribe
-  from here" keeps your place. Installing still needs a subscription: a
-  repository page's one action is Subscribe. Pre-install safety
-  (`browse/safety.rs`) scores catalog bytes with the rules an install runs
-  and caches **findings and scores only**, beside the commit's receipt in
-  the immutable store (`<key>/<commit>.safety/…`, never inside the
-  receipt-signed checkout), keyed by the item's content hash plus the
-  rule-set, discovery-table and record-format versions, each recomputed and
-  verified before reuse. The warn/block verdict is derived from the current
-  thresholds at read time — thresholds in the key would re-score on every
-  settings change. Browse is a preview of the verdict, never a second gate.
-  `library.rs` is the same join for the Library table, mapping each
-  installation to its origin: a subscription, local content (with what a
-  fork replaced), or observed-and-unmanaged.
+  summarizes; with no subscription the join answers Available and judges name
+  clashes against the personal scope, where Subscribe lands. A name another
+  source holds is surfaced on the row (`collision`) before the click; the
+  refusal stays in the engine (invariant 4). A bare repository is fetched by
+  `remote::sync` into the store a subscription reads from, under the canonical
+  `owner/repo` every GitHub spelling folds to — the key Subscribe is prefilled
+  with — so subscribing never downloads twice and the safety record is shared
+  per commit; only GitHub opens blind (`NotBrowsable` otherwise), and a root
+  skill's file list and file reads are confined to the skill tree scoring and
+  install read, never the repository around it. `browse::summary`, a
+  repository's first read, refreshes (a failure is a warning over the store's
+  copy) and names an enabled, readable subscription this machine holds for it;
+  `useCatalog` moves the page onto it at once, so "subscribe from here" keeps
+  your place. Installing still needs a subscription; `RepoAction` offers the
+  one step there: Subscribe when none declares the repository, Turn on when a
+  declared one is off, Refresh when it is declared but unreadable, neutral
+  until the live list has loaded. Pre-install safety (`browse/safety.rs`)
+  scores catalog bytes with the rules an install runs and caches **findings
+  and scores only**, beside the commit's receipt in the immutable store
+  (`<key>/<commit>.safety/…`, never inside the receipt-signed checkout), keyed
+  by the item's content hash plus the rule-set, discovery-table and
+  record-format versions, each recomputed and verified before reuse. The
+  warn/block verdict is derived from the current thresholds at read time —
+  thresholds in the key would re-score on every settings change. Browse is a
+  preview of the verdict, never a second gate. `library.rs` is the same join
+  for the Library table, mapping each installation to its origin: a
+  subscription, local content (with what a fork replaced), or
+  observed-and-unmanaged.
 - **A subscription's closure is derived by re-expansion, and unsubscribing
   removes or keeps exactly it.** `engine/detach.rs` computes what leaves
   with a marketplace by expanding the installed set with the source present

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -750,7 +750,7 @@ lives in one capability table read by core and UI.
   found where, plus every finding — that the About tab and `kendex
   index` consume.
 - **Browsing is a read-side join, and installed state is derived, never
-  stored.** `source/browse.rs` answers what one subscription offers — every
+  stored.** `source/browse.rs` answers what one catalog offers — every
   package across kinds, a bundle's members, a package's preview — with each
   row's state joined from the scope's manifest and lock on every call:
   installed is a lock entry from this subscription, held-back-by-safety is

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -1,7 +1,7 @@
 .github/workflows/review-gate-writer.yml	652
 crates/app/gen/schemas/desktop-schema.json	2590
 crates/app/gen/schemas/linux-schema.json	2590
-docs/ARCHITECTURE.md	1109
+docs/ARCHITECTURE.md	1108
 hooks/block-repo-copy.sh	511
 pi-extensions/pi-agents-tmux/extensions/subagent/browser.ts	650
 pi-extensions/pi-agents-tmux/extensions/subagent/dashboard.ts	431

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -576,7 +576,10 @@ export type CapabilityRow = {
  *  twice and the pages keep working across the switch.
  */
 export type Catalog = { by: "subscription"; scope: Scope; source: string } | 
-/**  `owner/repo` on GitHub, as the directory spells it. */
+/**
+ *  A GitHub repository, in any spelling `repo_move::owner_repo` folds
+ *  to the canonical `owner/repo` everything is keyed by.
+ */
 { by: "repo"; repo: string };
 
 /**  Something wrong with a catalog, said in the catalog author's terms. */

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -192,13 +192,19 @@ export const commands = {
 	 */
 	marketplacesOverview: () => typedError<MarketplaceRow[], string>(__TAURI_INVOKE("marketplaces_overview")),
 	/**
-	 *  Every package one subscription offers, across kinds, with installed
-	 *  state joined in.
+	 *  Every package one catalog offers, across kinds, with installed state
+	 *  joined in.
 	 */
-	marketplacePackages: (scope: Scope, source: string) => typedError<AvailablePackage[], string>(__TAURI_INVOKE("marketplace_packages", { scope, source })),
+	marketplacePackages: (catalog: Catalog) => typedError<AvailablePackage[], string>(__TAURI_INVOKE("marketplace_packages", { catalog })),
+	/**
+	 *  What a catalog says about itself, fetched fresh for a repository nobody
+	 *  subscribes to — the marketplace page's header, and the subscription to
+	 *  carry on as when this machine already holds one.
+	 */
+	marketplaceSummary: (catalog: Catalog) => typedError<CatalogSummary, string>(__TAURI_INVOKE("marketplace_summary", { catalog })),
 	/**  One curated set with per-member installed state. */
-	marketplaceBundle: (scope: Scope, source: string, name: string) => typedError<BundleDetail, string>(__TAURI_INVOKE("marketplace_bundle", { scope, source, name })),
-	marketplacePackagePreview: (scope: Scope, source: string, kind: ItemKind, name: string) => typedError<PackageView, string>(__TAURI_INVOKE("marketplace_package_preview", { scope, source, kind, name })),
+	marketplaceBundle: (catalog: Catalog, name: string) => typedError<BundleDetail, string>(__TAURI_INVOKE("marketplace_bundle", { catalog, name })),
+	marketplacePackagePreview: (catalog: Catalog, kind: ItemKind, name: string) => typedError<PackageView, string>(__TAURI_INVOKE("marketplace_package_preview", { catalog, kind, name })),
 	/**
 	 *  Install packages or a curated set from one subscription. `destination`
 	 *  redirects the install from the scope being browsed into a project: the
@@ -242,7 +248,7 @@ export const commands = {
 	 *  sub-tab when it is not, rather than showing a dead search box.
 	 */
 	communitySkillsshAvailable: () => typedError<boolean, string>(__TAURI_INVOKE("community_skillssh_available")),
-	marketplaceAbout: (scope: Scope, source: string) => typedError<AboutView, string>(__TAURI_INVOKE("marketplace_about", { scope, source })),
+	marketplaceAbout: (catalog: Catalog) => typedError<AboutView, string>(__TAURI_INVOKE("marketplace_about", { catalog })),
 	/**
 	 *  Where every installation came from, across every scope — the Library
 	 *  table's From column in one query.
@@ -563,6 +569,16 @@ export type CapabilityRow = {
 	caps: KindCaps,
 };
 
+/**
+ *  What a browse read addresses: a subscription, or a GitHub repository
+ *  browsed before anyone subscribes to it. The second fetches into the same
+ *  store a later subscription reads from, so subscribing never downloads
+ *  twice and the pages keep working across the switch.
+ */
+export type Catalog = { by: "subscription"; scope: Scope; source: string } | 
+/**  `owner/repo` on GitHub, as the directory spells it. */
+{ by: "repo"; repo: string };
+
 /**  Something wrong with a catalog, said in the catalog author's terms. */
 export type CatalogFinding = {
 	location: string,
@@ -590,6 +606,25 @@ export type CatalogGroupMeta = {
  *  control file makes the source unusable, never a different mode.
  */
 export type CatalogMode = "plugin-registry" | "explicit" | "discovered" | "unusable";
+
+export type CatalogSummary = {
+	/**  `owner/repo`, a path, or `local` — what the catalog is. */
+	provenance: string,
+	/**  The commit being read, for a remote. */
+	commit: string | null,
+	/**  `[marketplace]` from the catalog's own kendex.toml. */
+	meta: MarketplaceMeta | null,
+	mode: CatalogMode,
+	/**  Packages offered, by kind name. */
+	counts: { [key in string]: number },
+	/**  Set when the catalog is read from the store because a refresh failed. */
+	warning: string | null,
+	/**
+	 *  For a repository: the subscription this machine already holds for
+	 *  it, if any. A subscription answers with itself.
+	 */
+	subscription: SubscriptionRef | null,
+};
 
 export type CreateRequest = {
 	/**  Folder and repository name; must be a plain installable spelling. */
@@ -2214,6 +2249,15 @@ export type SubscribeOutcome = {
 	 */
 	lead: string | null,
 	notes: string[],
+};
+
+/**
+ *  The subscription a browsed repository already has on this machine, so
+ *  the page can carry on as that subscription instead of a stranger.
+ */
+export type SubscriptionRef = {
+	scope: Scope,
+	source: string,
 };
 
 /**  The job an item helps with. */

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -807,6 +807,11 @@ export type DirectoryPackage = {
 
 export type DirectoryRow = {
 	repo: string,
+	/**
+	 *  The canonical key a subscription's `repo_key` is compared with, so
+	 *  the row can flip to Subscribed from the live subscription list.
+	 */
+	repoKey: string | null,
 	name: string,
 	description: string | null,
 	tags: string[],
@@ -1700,6 +1705,11 @@ export type MarketplaceRow = {
 	scope: Scope,
 	name: string,
 	repo: string | null,
+	/**
+	 *  The canonical `owner/repo` a GitHub declaration folds to — what a
+	 *  directory row is matched against, however the subscription spells it.
+	 */
+	repoKey: string | null,
 	path: string | null,
 	rev: string | null,
 	/**  The commit the subscription reads right now, when the cache holds one. */

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -206,6 +206,11 @@ export const commands = {
 	marketplaceBundle: (catalog: Catalog, name: string) => typedError<BundleDetail, string>(__TAURI_INVOKE("marketplace_bundle", { catalog, name })),
 	marketplacePackagePreview: (catalog: Catalog, kind: ItemKind, name: string) => typedError<PackageView, string>(__TAURI_INVOKE("marketplace_package_preview", { catalog, kind, name })),
 	/**
+	 *  One offered file's content before install — the same read an installed
+	 *  package's file gets, confined to the package inside the catalog.
+	 */
+	marketplacePackageFile: (catalog: Catalog, kind: ItemKind, name: string, path: string) => typedError<ItemSource, string>(__TAURI_INVOKE("marketplace_package_file", { catalog, kind, name, path })),
+	/**
 	 *  Install packages or a curated set from one subscription. `destination`
 	 *  redirects the install from the scope being browsed into a project: the
 	 *  project gains the personal subscription first (§4.1), then the add runs

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -618,6 +618,12 @@ export type CatalogMode = "plugin-registry" | "explicit" | "discovered" | "unusa
 export type CatalogSummary = {
 	/**  `owner/repo`, a path, or `local` — what the catalog is. */
 	provenance: string,
+	/**
+	 *  The canonical `owner/repo` the provenance folds to on GitHub — what
+	 *  a subscription's `repo_key` and a directory row are matched by,
+	 *  however the declaration spells it.
+	 */
+	repoKey: string | null,
 	/**  The commit being read, for a remote. */
 	commit: string | null,
 	/**  `[marketplace]` from the catalog's own kendex.toml. */

--- a/ui/src/components/marketplaces/about-section.tsx
+++ b/ui/src/components/marketplaces/about-section.tsx
@@ -1,8 +1,8 @@
 import { useEffect } from "react";
-import type { MarketplaceMeta, Scope } from "@/bindings";
+import type { Catalog, MarketplaceMeta } from "@/bindings";
 import { Badge } from "@/components/ui/badge";
 import { kindLabel } from "@/lib/labels";
-import { marketKey, useMarketplacesStore } from "@/stores/marketplaces";
+import { catalogKey, useMarketplacesStore } from "@/stores/marketplaces";
 
 const MODE_COPY: Record<string, string> = {
   "plugin-registry":
@@ -18,23 +18,21 @@ const MODE_COPY: Record<string, string> = {
  * found where, and every finding it carries — the same report `kendex
  * index` prints. */
 export function AboutSection({
-  scope,
-  source,
+  catalog,
   meta,
 }: {
-  scope: Scope;
-  source: string;
+  catalog: Catalog;
   meta: MarketplaceMeta | null;
 }) {
-  const about = useMarketplacesStore((s) => s.about[marketKey(scope, source)]);
+  const about = useMarketplacesStore((s) => s.about[catalogKey(catalog)]);
   const readError = useMarketplacesStore(
-    (s) => s.readErrors[marketKey(scope, source)],
+    (s) => s.readErrors[catalogKey(catalog)],
   );
   const loadAbout = useMarketplacesStore((s) => s.loadAbout);
 
   useEffect(() => {
-    void loadAbout(scope, source);
-  }, [scope, source, loadAbout]);
+    void loadAbout(catalog);
+  }, [catalog, loadAbout]);
 
   if (!about && readError) {
     return (

--- a/ui/src/components/marketplaces/about-section.tsx
+++ b/ui/src/components/marketplaces/about-section.tsx
@@ -1,5 +1,6 @@
-import { useEffect } from "react";
+import { useCallback } from "react";
 import type { Catalog, MarketplaceMeta } from "@/bindings";
+import { useCachedRead } from "@/components/marketplaces/use-catalog";
 import { Badge } from "@/components/ui/badge";
 import { kindLabel } from "@/lib/labels";
 import {
@@ -34,9 +35,8 @@ export function AboutSection({
   );
   const loadAbout = useMarketplacesStore((s) => s.loadAbout);
 
-  useEffect(() => {
-    void loadAbout(catalog);
-  }, [catalog, loadAbout]);
+  const readAbout = useCallback(() => loadAbout(catalog), [loadAbout, catalog]);
+  useCachedRead(about !== undefined, !!readError, true, readAbout);
 
   if (!about && readError) {
     return (

--- a/ui/src/components/marketplaces/about-section.tsx
+++ b/ui/src/components/marketplaces/about-section.tsx
@@ -2,7 +2,11 @@ import { useEffect } from "react";
 import type { Catalog, MarketplaceMeta } from "@/bindings";
 import { Badge } from "@/components/ui/badge";
 import { kindLabel } from "@/lib/labels";
-import { catalogKey, useMarketplacesStore } from "@/stores/marketplaces";
+import {
+  catalogKey,
+  readErrorKey,
+  useMarketplacesStore,
+} from "@/stores/marketplaces";
 
 const MODE_COPY: Record<string, string> = {
   "plugin-registry":
@@ -26,7 +30,7 @@ export function AboutSection({
 }) {
   const about = useMarketplacesStore((s) => s.about[catalogKey(catalog)]);
   const readError = useMarketplacesStore(
-    (s) => s.readErrors[catalogKey(catalog)],
+    (s) => s.readErrors[readErrorKey(catalogKey(catalog), "about")],
   );
   const loadAbout = useMarketplacesStore((s) => s.loadAbout);
 

--- a/ui/src/components/marketplaces/available-aside.tsx
+++ b/ui/src/components/marketplaces/available-aside.tsx
@@ -1,5 +1,5 @@
 import type { Catalog, PackageView } from "@/bindings";
-import { fileSizeLabel } from "@/components/package/file-list";
+import { FileList } from "@/components/package/file-list";
 import { VERDICT_LABELS } from "@/lib/labels";
 import { catalogLabel } from "@/stores/marketplaces";
 
@@ -9,11 +9,16 @@ export function AvailableAside({
   catalog,
   repo,
   view,
+  selectedFile,
+  onSelectFile,
 }: {
   catalog: Catalog;
   /** The repository or path behind the catalog, when known. */
   repo: string | null;
   view: PackageView | null;
+  /** The file open in the main column; null shows the README. */
+  selectedFile: string | null;
+  onSelectFile: (path: string) => void;
 }) {
   return (
     <aside className="space-y-6 text-sm">
@@ -54,19 +59,11 @@ export function AvailableAside({
           <h3 className="mb-1 text-xs font-semibold text-muted-foreground uppercase">
             Files
           </h3>
-          <ul className="space-y-1">
-            {view.preview.files.map((file) => (
-              <li
-                key={file.path}
-                className="flex items-baseline justify-between gap-2"
-              >
-                <span className="truncate font-mono text-xs">{file.path}</span>
-                <span className="shrink-0 text-xs text-muted-foreground">
-                  {fileSizeLabel(file.size)}
-                </span>
-              </li>
-            ))}
-          </ul>
+          <FileList
+            files={view.preview.files}
+            selected={selectedFile}
+            onSelect={onSelectFile}
+          />
         </section>
       ) : null}
       {view?.preview.collision ? (

--- a/ui/src/components/marketplaces/available-aside.tsx
+++ b/ui/src/components/marketplaces/available-aside.tsx
@@ -1,0 +1,80 @@
+import type { Catalog, PackageView } from "@/bindings";
+import { fileSizeLabel } from "@/components/package/file-list";
+import { VERDICT_LABELS } from "@/lib/labels";
+import { catalogLabel } from "@/stores/marketplaces";
+
+/** The available-package page's facts column: where it comes from, its
+ * safety score, the sets that carry it, its files, and a name clash. */
+export function AvailableAside({
+  catalog,
+  repo,
+  view,
+}: {
+  catalog: Catalog;
+  /** The repository or path behind the catalog, when known. */
+  repo: string | null;
+  view: PackageView | null;
+}) {
+  return (
+    <aside className="space-y-6 text-sm">
+      <section>
+        <h3 className="mb-1 text-xs font-semibold text-muted-foreground uppercase">
+          From
+        </h3>
+        <p>
+          {catalogLabel(catalog)}
+          {repo && repo !== catalogLabel(catalog) ? (
+            <span className="block truncate font-mono text-xs text-muted-foreground">
+              {repo}
+            </span>
+          ) : null}
+        </p>
+      </section>
+      {view ? (
+        <section>
+          <h3 className="mb-1 text-xs font-semibold text-muted-foreground uppercase">
+            Safety
+          </h3>
+          <p>
+            {VERDICT_LABELS[view.safety.verdict]} · {view.safety.safety.score}
+            /100
+          </p>
+        </section>
+      ) : null}
+      {view && view.preview.bundles.length > 0 ? (
+        <section>
+          <h3 className="mb-1 text-xs font-semibold text-muted-foreground uppercase">
+            Comes with
+          </h3>
+          <p>{view.preview.bundles.join(", ")}</p>
+        </section>
+      ) : null}
+      {view && view.preview.files.length > 0 ? (
+        <section>
+          <h3 className="mb-1 text-xs font-semibold text-muted-foreground uppercase">
+            Files
+          </h3>
+          <ul className="space-y-1">
+            {view.preview.files.map((file) => (
+              <li
+                key={file.path}
+                className="flex items-baseline justify-between gap-2"
+              >
+                <span className="truncate font-mono text-xs">{file.path}</span>
+                <span className="shrink-0 text-xs text-muted-foreground">
+                  {fileSizeLabel(file.size)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+      {view?.preview.collision ? (
+        <p className="text-xs text-warning">
+          This name is already installed from {view.preview.collision}—
+          installing from {catalogLabel(catalog)} will be refused.
+        </p>
+      ) : null}
+    </aside>
+  );
+}

--- a/ui/src/components/marketplaces/bundle-cards.tsx
+++ b/ui/src/components/marketplaces/bundle-cards.tsx
@@ -4,7 +4,7 @@ import type { AvailablePackage, Catalog, ItemKind } from "@/bindings";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { kindLabel } from "@/lib/labels";
-import { catalogKey, useMarketplacesStore } from "@/stores/marketplaces";
+import { bundleKey, useMarketplacesStore } from "@/stores/marketplaces";
 import { useNavStore } from "@/stores/nav";
 
 /** The curated sets one marketplace offers, as cards: what each carries and
@@ -45,7 +45,7 @@ export function BundleCards({
   return (
     <div className="grid grid-cols-[repeat(auto-fill,minmax(18rem,1fr))] gap-4">
       {names.map((name) => {
-        const detail = bundles[`${catalogKey(catalog)}::${name}`];
+        const detail = bundles[bundleKey(catalog, name)];
         const state = !detail
           ? null
           : detail.installedMembers === detail.totalMembers &&

--- a/ui/src/components/marketplaces/bundle-cards.tsx
+++ b/ui/src/components/marketplaces/bundle-cards.tsx
@@ -1,10 +1,10 @@
 import { Package } from "lucide-react";
 import { useEffect, useMemo } from "react";
-import type { AvailablePackage, ItemKind, Scope } from "@/bindings";
+import type { AvailablePackage, Catalog, ItemKind } from "@/bindings";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { kindLabel } from "@/lib/labels";
-import { marketKey, useMarketplacesStore } from "@/stores/marketplaces";
+import { catalogKey, useMarketplacesStore } from "@/stores/marketplaces";
 import { useNavStore } from "@/stores/nav";
 
 /** The curated sets one marketplace offers, as cards: what each carries and
@@ -12,12 +12,10 @@ import { useNavStore } from "@/stores/nav";
  * every member names its sets — and each card's counts come from its own
  * bundle read. */
 export function BundleCards({
-  scope,
-  source,
+  catalog,
   offered,
 }: {
-  scope: Scope;
-  source: string;
+  catalog: Catalog;
   offered: AvailablePackage[];
 }) {
   const bundles = useMarketplacesStore((s) => s.bundles);
@@ -31,9 +29,9 @@ export function BundleCards({
 
   useEffect(() => {
     for (const name of names) {
-      void loadBundle(scope, source, name);
+      void loadBundle(catalog, name);
     }
-  }, [names, scope, source, loadBundle]);
+  }, [names, catalog, loadBundle]);
 
   if (names.length === 0) {
     return (
@@ -47,7 +45,7 @@ export function BundleCards({
   return (
     <div className="grid grid-cols-[repeat(auto-fill,minmax(18rem,1fr))] gap-4">
       {names.map((name) => {
-        const detail = bundles[`${marketKey(scope, source)}::${name}`];
+        const detail = bundles[`${catalogKey(catalog)}::${name}`];
         const state = !detail
           ? null
           : detail.installedMembers === detail.totalMembers &&
@@ -76,7 +74,7 @@ export function BundleCards({
                 <Button
                   size="sm"
                   variant="outline"
-                  onClick={() => goToBundle({ scope, source, bundle: name })}
+                  onClick={() => goToBundle({ catalog, bundle: name })}
                 >
                   Open
                 </Button>

--- a/ui/src/components/marketplaces/bundle-member-row.tsx
+++ b/ui/src/components/marketplaces/bundle-member-row.tsx
@@ -1,0 +1,83 @@
+import type { BundleMemberRow } from "@/bindings";
+import { StatusDot } from "@/components/status-dot";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { kindIcon } from "@/lib/kind-icon";
+import { kindLabel, packageDisplayName } from "@/lib/labels";
+import { cn } from "@/lib/utils";
+
+export const memberKey = (kind: string, name: string) => `${kind}:${name}`;
+
+/** One member of a curated set: its state here, and — where the set comes
+ * from a subscription — a box to pick it for install. */
+export function BundleMemberLine({
+  member,
+  selectable,
+  selected,
+  busy,
+  onToggle,
+  onRestore,
+}: {
+  member: BundleMemberRow;
+  /** False while the set is browsed from a repository nobody subscribes to. */
+  selectable: boolean;
+  selected: boolean;
+  busy: boolean;
+  onToggle: () => void;
+  onRestore: () => void;
+}) {
+  const Icon = kindIcon(member.kind);
+  const installable = selectable && member.state === "available";
+  const id = `member-${memberKey(member.kind, member.name)}`;
+  return (
+    <label
+      htmlFor={id}
+      className={cn(
+        "flex items-center gap-3 px-4 py-2.5",
+        installable ? "cursor-pointer" : "opacity-80",
+      )}
+    >
+      {selectable ? (
+        <Checkbox
+          id={id}
+          checked={selected}
+          disabled={!installable}
+          onCheckedChange={onToggle}
+        />
+      ) : null}
+      <Icon className="size-4 shrink-0 text-muted-foreground" />
+      <span className="min-w-0 flex-1 truncate font-medium">
+        {packageDisplayName(member)}
+      </span>
+      <span className="w-24 text-xs text-muted-foreground">
+        {kindLabel(member.kind)}
+      </span>
+      <span className="w-32 text-right text-xs">
+        {member.state === "installed" ? (
+          <span className="text-muted-foreground">Installed</span>
+        ) : member.state === "held-back-by-safety" ? (
+          <span className="text-warning">Held back</span>
+        ) : member.state === "not-offered" ? (
+          <span className="text-muted-foreground">No longer offered</span>
+        ) : member.state === "removed-by-you" ? (
+          <span className="inline-flex items-center gap-2">
+            <span className="text-muted-foreground">Removed by you</span>
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={busy}
+              onClick={(e) => {
+                e.preventDefault();
+                onRestore();
+              }}
+            >
+              Restore
+            </Button>
+          </span>
+        ) : (
+          <StatusDot tone="good" className="inline-block" title="Available" />
+        )}
+      </span>
+    </label>
+  );
+}

--- a/ui/src/components/marketplaces/catalog-file-preview.tsx
+++ b/ui/src/components/marketplaces/catalog-file-preview.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  type Catalog,
+  commands,
+  type ItemKind,
+  type ItemSource,
+} from "@/bindings";
+import { FileContent } from "@/components/package/file-preview";
+import { StatusNote } from "@/components/status-note";
+import { Skeleton } from "@/components/ui/skeleton";
+import { latestOnly } from "@/lib/latest";
+
+type State =
+  | { status: "loading" }
+  | { status: "error"; error: string }
+  | ({ status: "ok" } & ItemSource);
+
+/** One offered file of a package nobody has installed yet, rendered the
+ * way the installed package page renders its files. */
+export function CatalogFilePreview({
+  catalog,
+  kind,
+  name,
+  path,
+}: {
+  catalog: Catalog;
+  kind: ItemKind;
+  name: string;
+  path: string;
+}) {
+  const [state, setState] = useState<State>({ status: "loading" });
+  const latest = useRef(latestOnly());
+
+  useEffect(() => {
+    setState({ status: "loading" });
+    void latest
+      .current(commands.marketplacePackageFile(catalog, kind, name, path))
+      .then((response) => {
+        if (!response) return;
+        setState(
+          response.status === "ok"
+            ? { status: "ok", ...response.data }
+            : { status: "error", error: response.error },
+        );
+      });
+  }, [catalog, kind, name, path]);
+
+  if (state.status === "loading") {
+    return (
+      <div className="space-y-2">
+        <Skeleton className="h-3.5 w-3/4" />
+        <Skeleton className="h-3.5 w-full" />
+        <Skeleton className="h-3.5 w-2/3" />
+      </div>
+    );
+  }
+  if (state.status === "error") {
+    return (
+      <StatusNote tone="critical" title="This file couldn't be shown">
+        {state.error}
+      </StatusNote>
+    );
+  }
+  return <FileContent {...state} />;
+}

--- a/ui/src/components/marketplaces/community-tab.tsx
+++ b/ui/src/components/marketplaces/community-tab.tsx
@@ -14,6 +14,7 @@ import {
 import { PAGE_BODY, WIDE_CONTENT_WIDTH } from "@/lib/layout";
 import { cn } from "@/lib/utils";
 import { useCommunityStore } from "@/stores/community";
+import { subscribedKeys, useMarketplacesStore } from "@/stores/marketplaces";
 import { useNavStore } from "@/stores/nav";
 import { agoLabel, DirectoryRowLine, dayOf } from "./directory-row";
 import { SkillsShSearch } from "./skillssh-search";
@@ -31,6 +32,7 @@ export function CommunityTab() {
   const load = useCommunityStore((s) => s.load);
   const goToMarketplaces = useNavStore((s) => s.goToMarketplaces);
   const goToMarketplace = useNavStore((s) => s.goToMarketplace);
+  const subscriptions = useMarketplacesStore((s) => s.rows);
 
   const [section, setSection] = useState<"directory" | "skillssh">("directory");
   const [query, setQuery] = useState("");
@@ -42,6 +44,7 @@ export function CommunityTab() {
     void load(false);
   }, [load]);
 
+  const held = useMemo(() => subscribedKeys(subscriptions), [subscriptions]);
   const tags = useMemo(
     () =>
       [...new Set((directory?.rows ?? []).flatMap((row) => row.tags))].sort(),
@@ -159,6 +162,10 @@ export function CommunityTab() {
                   <DirectoryRowLine
                     key={row.repo}
                     row={row}
+                    subscribed={
+                      row.subscribed ||
+                      (row.repoKey !== null && held.has(row.repoKey))
+                    }
                     onOpen={() =>
                       goToMarketplace({ by: "repo", repo: row.repo })
                     }

--- a/ui/src/components/marketplaces/community-tab.tsx
+++ b/ui/src/components/marketplaces/community-tab.tsx
@@ -37,7 +37,7 @@ export function CommunityTab() {
   const goToMarketplaces = useNavStore((s) => s.goToMarketplaces);
   const goToMarketplace = useNavStore((s) => s.goToMarketplace);
   const subscriptions = useMarketplacesStore((s) => s.rows);
-  const subscriptionsLoaded = useMarketplacesStore((s) => s.loaded);
+  const subscriptionsCurrent = useMarketplacesStore((s) => s.rowsCurrent);
 
   const [section, setSection] = useState<"directory" | "skillssh">("directory");
   const [query, setQuery] = useState("");
@@ -50,8 +50,8 @@ export function CommunityTab() {
   }, [load]);
 
   const held = useMemo(
-    () => (subscriptionsLoaded ? subscribedKeys(subscriptions) : null),
-    [subscriptions, subscriptionsLoaded],
+    () => (subscriptionsCurrent ? subscribedKeys(subscriptions) : null),
+    [subscriptions, subscriptionsCurrent],
   );
   const tags = useMemo(
     () =>

--- a/ui/src/components/marketplaces/community-tab.tsx
+++ b/ui/src/components/marketplaces/community-tab.tsx
@@ -14,7 +14,11 @@ import {
 import { PAGE_BODY, WIDE_CONTENT_WIDTH } from "@/lib/layout";
 import { cn } from "@/lib/utils";
 import { useCommunityStore } from "@/stores/community";
-import { subscribedKeys, useMarketplacesStore } from "@/stores/marketplaces";
+import {
+  rowSubscribed,
+  subscribedKeys,
+  useMarketplacesStore,
+} from "@/stores/marketplaces";
 import { useNavStore } from "@/stores/nav";
 import { agoLabel, DirectoryRowLine, dayOf } from "./directory-row";
 import { SkillsShSearch } from "./skillssh-search";
@@ -33,6 +37,7 @@ export function CommunityTab() {
   const goToMarketplaces = useNavStore((s) => s.goToMarketplaces);
   const goToMarketplace = useNavStore((s) => s.goToMarketplace);
   const subscriptions = useMarketplacesStore((s) => s.rows);
+  const subscriptionsLoaded = useMarketplacesStore((s) => s.loaded);
 
   const [section, setSection] = useState<"directory" | "skillssh">("directory");
   const [query, setQuery] = useState("");
@@ -44,7 +49,10 @@ export function CommunityTab() {
     void load(false);
   }, [load]);
 
-  const held = useMemo(() => subscribedKeys(subscriptions), [subscriptions]);
+  const held = useMemo(
+    () => (subscriptionsLoaded ? subscribedKeys(subscriptions) : null),
+    [subscriptions, subscriptionsLoaded],
+  );
   const tags = useMemo(
     () =>
       [...new Set((directory?.rows ?? []).flatMap((row) => row.tags))].sort(),
@@ -162,10 +170,7 @@ export function CommunityTab() {
                   <DirectoryRowLine
                     key={row.repo}
                     row={row}
-                    subscribed={
-                      row.subscribed ||
-                      (row.repoKey !== null && held.has(row.repoKey))
-                    }
+                    subscribed={rowSubscribed(row, held)}
                     onOpen={() =>
                       goToMarketplace({ by: "repo", repo: row.repo })
                     }

--- a/ui/src/components/marketplaces/community-tab.tsx
+++ b/ui/src/components/marketplaces/community-tab.tsx
@@ -30,6 +30,7 @@ export function CommunityTab() {
   const skillsshAvailable = useCommunityStore((s) => s.skillsshAvailable);
   const load = useCommunityStore((s) => s.load);
   const goToMarketplaces = useNavStore((s) => s.goToMarketplaces);
+  const goToMarketplace = useNavStore((s) => s.goToMarketplace);
 
   const [section, setSection] = useState<"directory" | "skillssh">("directory");
   const [query, setQuery] = useState("");
@@ -81,7 +82,10 @@ export function CommunityTab() {
         </div>
 
         {section === "skillssh" ? (
-          <SkillsShSearch onInstall={(url) => setSubscribeTo(url)} />
+          <SkillsShSearch
+            onOpen={(repo) => goToMarketplace({ by: "repo", repo })}
+            onInstall={(url) => setSubscribeTo(url)}
+          />
         ) : error && !directory ? (
           <EmptyState icon={Globe} title="kendex.ai is not reachable">
             {error}
@@ -155,6 +159,9 @@ export function CommunityTab() {
                   <DirectoryRowLine
                     key={row.repo}
                     row={row}
+                    onOpen={() =>
+                      goToMarketplace({ by: "repo", repo: row.repo })
+                    }
                     onSubscribe={() => setSubscribeTo(row.repo)}
                   />
                 ))}

--- a/ui/src/components/marketplaces/detail-header.tsx
+++ b/ui/src/components/marketplaces/detail-header.tsx
@@ -1,7 +1,7 @@
 import { MoreHorizontal, RefreshCw, Star } from "lucide-react";
 import { type ReactNode, useState } from "react";
 import type { Catalog, CatalogSummary, MarketplaceRow } from "@/bindings";
-import { SubscribeDialog } from "@/components/marketplaces/subscribe-dialog";
+import { SubscribeFromRepo } from "@/components/marketplaces/subscribe-from-repo";
 import { UnsubscribeDialog } from "@/components/marketplaces/unsubscribe-dialog";
 import { PageHeader } from "@/components/page-header";
 import { Badge } from "@/components/ui/badge";
@@ -42,7 +42,6 @@ export function DetailHeader({
       : undefined,
   );
   const [unsubscribeOpen, setUnsubscribeOpen] = useState(false);
-  const [subscribeOpen, setSubscribeOpen] = useState(false);
 
   const meta = row?.meta ?? summary?.meta ?? null;
   const title =
@@ -106,22 +105,7 @@ export function DetailHeader({
       </>
     );
   } else {
-    action = (
-      <>
-        <Button size="sm" onClick={() => setSubscribeOpen(true)}>
-          Subscribe
-        </Button>
-        {/* Keyed so the repository lands in the dialog's initial state. */}
-        {subscribeOpen ? (
-          <SubscribeDialog
-            key={catalog.repo}
-            open
-            onOpenChange={setSubscribeOpen}
-            initialReference={catalog.repo}
-          />
-        ) : null}
-      </>
-    );
+    action = <SubscribeFromRepo repo={catalog.repo} label="Subscribe" />;
   }
 
   return (

--- a/ui/src/components/marketplaces/detail-header.tsx
+++ b/ui/src/components/marketplaces/detail-header.tsx
@@ -105,7 +105,12 @@ export function DetailHeader({
       </>
     );
   } else {
-    action = <SubscribeFromRepo repo={catalog.repo} label="Subscribe" />;
+    action = (
+      <SubscribeFromRepo
+        repo={summary?.provenance ?? catalog.repo}
+        label="Subscribe"
+      />
+    );
   }
 
   return (

--- a/ui/src/components/marketplaces/detail-header.tsx
+++ b/ui/src/components/marketplaces/detail-header.tsx
@@ -1,0 +1,160 @@
+import { MoreHorizontal, RefreshCw, Star } from "lucide-react";
+import { type ReactNode, useState } from "react";
+import type { Catalog, CatalogSummary, MarketplaceRow } from "@/bindings";
+import { SubscribeDialog } from "@/components/marketplaces/subscribe-dialog";
+import { UnsubscribeDialog } from "@/components/marketplaces/unsubscribe-dialog";
+import { PageHeader } from "@/components/page-header";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Switch } from "@/components/ui/switch";
+import { cn } from "@/lib/utils";
+import { useCommunityStore } from "@/stores/community";
+import { useMarketplacesStore } from "@/stores/marketplaces";
+
+/** The marketplace page's header for either kind of catalog: a
+ * subscription's switch, refresh and unsubscribe, or a repository's one
+ * Subscribe button. The words come from the catalog itself where it has
+ * been read, and from the directory's listing until then. */
+export function DetailHeader({
+  requested,
+  catalog,
+  row,
+  summary,
+}: {
+  /** What was opened — a repository keeps its listing's name and tags. */
+  requested: Catalog;
+  catalog: Catalog;
+  row: MarketplaceRow | undefined;
+  summary: CatalogSummary | null;
+}) {
+  const toggle = useMarketplacesStore((s) => s.toggle);
+  const checkForUpdates = useMarketplacesStore((s) => s.checkForUpdates);
+  const busy = useMarketplacesStore((s) => s.busy);
+  const listing = useCommunityStore((s) =>
+    requested.by === "repo"
+      ? s.directory?.rows.find((r) => r.repo === requested.repo)
+      : undefined,
+  );
+  const [unsubscribeOpen, setUnsubscribeOpen] = useState(false);
+  const [subscribeOpen, setSubscribeOpen] = useState(false);
+
+  const meta = row?.meta ?? summary?.meta ?? null;
+  const title =
+    catalog.by === "subscription"
+      ? catalog.source
+      : (listing?.name ?? meta?.name ?? catalog.repo.split("/").at(-1));
+  const description = meta?.description ?? listing?.description ?? null;
+  const commit = row?.commit ?? summary?.commit ?? null;
+  const metaLine = [
+    row?.repo ?? row?.path ?? summary?.provenance ?? listing?.repo,
+    commit ? `@ ${commit.slice(0, 7)}` : null,
+    meta?.license,
+    meta?.author ? `by ${meta.author}` : null,
+  ].filter(Boolean);
+  const tags = [...new Set([...(meta?.tags ?? []), ...(listing?.tags ?? [])])];
+
+  let action: ReactNode;
+  if (catalog.by === "subscription") {
+    const { scope, source } = catalog;
+    action = (
+      <>
+        {row ? (
+          <Switch
+            checked={row.enabled}
+            onCheckedChange={(enabled) => void toggle(scope, source, enabled)}
+            aria-label={row.enabled ? "Turn off" : "Turn on"}
+          />
+        ) : null}
+        <Button
+          size="sm"
+          variant="outline"
+          disabled={busy}
+          onClick={() => void checkForUpdates()}
+        >
+          <RefreshCw className={cn("size-4", busy && "animate-spin")} />
+          Check for updates
+        </Button>
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            render={
+              <Button size="icon-xs" variant="quiet" aria-label="More actions">
+                <MoreHorizontal className="size-4" />
+              </Button>
+            }
+          />
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem
+              className="text-critical"
+              onClick={() => setUnsubscribeOpen(true)}
+            >
+              Unsubscribe…
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+        <UnsubscribeDialog
+          open={unsubscribeOpen}
+          onOpenChange={setUnsubscribeOpen}
+          scope={scope}
+          source={source}
+        />
+      </>
+    );
+  } else {
+    action = (
+      <>
+        <Button size="sm" onClick={() => setSubscribeOpen(true)}>
+          Subscribe
+        </Button>
+        {/* Keyed so the repository lands in the dialog's initial state. */}
+        {subscribeOpen ? (
+          <SubscribeDialog
+            key={catalog.repo}
+            open
+            onOpenChange={setSubscribeOpen}
+            initialReference={catalog.repo}
+          />
+        ) : null}
+      </>
+    );
+  }
+
+  return (
+    <PageHeader
+      wide
+      title={
+        <span className="flex items-center gap-2.5">
+          {title}
+          {listing?.featured ? (
+            <Badge variant="secondary" className="gap-1">
+              <Star className="size-3" /> featured
+            </Badge>
+          ) : null}
+        </span>
+      }
+      subtitle={
+        <>
+          {description ? <p>{description}</p> : null}
+          {metaLine.length > 0 ? (
+            <p className="mt-1 font-mono text-xs">{metaLine.join(" · ")}</p>
+          ) : null}
+          {tags.length > 0 ? (
+            <span className="mt-2 flex flex-wrap gap-1.5">
+              {tags.map((tag) => (
+                <Badge key={tag} variant="secondary">
+                  {tag}
+                </Badge>
+              ))}
+            </span>
+          ) : null}
+        </>
+      }
+      action={action}
+    />
+  );
+}

--- a/ui/src/components/marketplaces/detail-header.tsx
+++ b/ui/src/components/marketplaces/detail-header.tsx
@@ -1,7 +1,7 @@
 import { MoreHorizontal, RefreshCw, Star } from "lucide-react";
 import { type ReactNode, useState } from "react";
 import type { Catalog, CatalogSummary, MarketplaceRow } from "@/bindings";
-import { SubscribeFromRepo } from "@/components/marketplaces/subscribe-from-repo";
+import { RepoAction } from "@/components/marketplaces/repo-action";
 import { UnsubscribeDialog } from "@/components/marketplaces/unsubscribe-dialog";
 import { PageHeader } from "@/components/page-header";
 import { Badge } from "@/components/ui/badge";
@@ -106,9 +106,10 @@ export function DetailHeader({
     );
   } else {
     action = (
-      <SubscribeFromRepo
-        repo={summary?.provenance ?? catalog.repo}
-        label="Subscribe"
+      <RepoAction
+        repo={catalog.repo}
+        summary={summary}
+        subscribeLabel="Subscribe"
       />
     );
   }

--- a/ui/src/components/marketplaces/directory-row.tsx
+++ b/ui/src/components/marketplaces/directory-row.tsx
@@ -3,16 +3,24 @@ import type { DirectoryRow } from "@/bindings";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 
+/** One listed marketplace. The row opens it — what it offers is browsable
+ * before subscribing — and Subscribe stays a separate click. */
 export function DirectoryRowLine({
   row,
+  onOpen,
   onSubscribe,
 }: {
   row: DirectoryRow;
+  onOpen: () => void;
   onSubscribe: () => void;
 }) {
   return (
     <div className="flex items-center gap-3 px-4 py-3">
-      <div className="min-w-0 flex-1">
+      <button
+        type="button"
+        className="min-w-0 flex-1 cursor-pointer text-left"
+        onClick={onOpen}
+      >
         <div className="flex items-center gap-2">
           <span className="truncate text-sm font-medium">{row.name}</span>
           {row.featured ? (
@@ -22,21 +30,16 @@ export function DirectoryRowLine({
           ) : null}
         </div>
         <div className="flex items-center gap-2">
-          <a
-            className="truncate font-mono text-xs text-muted-foreground underline-offset-2 hover:underline"
-            href={`https://github.com/${row.repo}`}
-            target="_blank"
-            rel="noreferrer"
-          >
+          <span className="truncate font-mono text-xs text-muted-foreground">
             {row.repo}
-          </a>
+          </span>
           {row.description ? (
             <span className="truncate text-xs text-muted-foreground">
               {row.description}
             </span>
           ) : null}
         </div>
-      </div>
+      </button>
       <span className="shrink-0 text-xs text-muted-foreground">
         {row.packageCount} {row.packageCount === 1 ? "pkg" : "pkgs"}
         {row.bundleCount > 0 ? ` · ${row.bundleCount} bundles` : ""}

--- a/ui/src/components/marketplaces/directory-row.tsx
+++ b/ui/src/components/marketplaces/directory-row.tsx
@@ -7,10 +7,13 @@ import { Button } from "@/components/ui/button";
  * before subscribing — and Subscribe stays a separate click. */
 export function DirectoryRowLine({
   row,
+  subscribed,
   onOpen,
   onSubscribe,
 }: {
   row: DirectoryRow;
+  /** From the live subscription list, not the directory's snapshot. */
+  subscribed: boolean;
   onOpen: () => void;
   onSubscribe: () => void;
 }) {
@@ -44,7 +47,7 @@ export function DirectoryRowLine({
         {row.packageCount} {row.packageCount === 1 ? "pkg" : "pkgs"}
         {row.bundleCount > 0 ? ` · ${row.bundleCount} bundles` : ""}
       </span>
-      {row.subscribed ? (
+      {subscribed ? (
         <span className="shrink-0 text-xs text-muted-foreground">
           Subscribed ✓
         </span>

--- a/ui/src/components/marketplaces/packages-tab.tsx
+++ b/ui/src/components/marketplaces/packages-tab.tsx
@@ -17,7 +17,11 @@ import { scopeLabel } from "@/lib/derive";
 import { kindLabel, scopeName, TAG_LABELS } from "@/lib/labels";
 import { PAGE_BODY, PAGE_GUTTER, WIDE_CONTENT_WIDTH } from "@/lib/layout";
 import { cn } from "@/lib/utils";
-import { marketKey, useMarketplacesStore } from "@/stores/marketplaces";
+import {
+  marketKey,
+  subscription,
+  useMarketplacesStore,
+} from "@/stores/marketplaces";
 import { useNavStore } from "@/stores/nav";
 
 const KINDS: ItemKind[] = [
@@ -53,7 +57,7 @@ export function PackagesTab() {
     for (const row of rows) {
       if (!row.enabled) continue;
       if (!packages[marketKey(row.scope, row.name)]) {
-        void loadPackages(row.scope, row.name);
+        void loadPackages(subscription(row.scope, row.name));
       }
     }
   }, [rows, packages, loadPackages]);
@@ -79,7 +83,7 @@ export function PackagesTab() {
           !(pkg.description ?? "").toLowerCase().includes(needle)
         )
           continue;
-        out.push({ scope: row.scope, source: row.name, row: pkg });
+        out.push({ catalog: subscription(row.scope, row.name), row: pkg });
       }
     }
     return out;

--- a/ui/src/components/marketplaces/packages-tab.tsx
+++ b/ui/src/components/marketplaces/packages-tab.tsx
@@ -19,6 +19,7 @@ import { PAGE_BODY, PAGE_GUTTER, WIDE_CONTENT_WIDTH } from "@/lib/layout";
 import { cn } from "@/lib/utils";
 import {
   marketKey,
+  readErrorKey,
   subscription,
   useMarketplacesStore,
 } from "@/stores/marketplaces";
@@ -92,7 +93,11 @@ export function PackagesTab() {
   // Subscriptions whose catalog refused to load: named above the table so
   // an empty offer is never mistaken for an empty marketplace.
   const unreadable = rows
-    .filter((row) => row.enabled && readErrors[marketKey(row.scope, row.name)])
+    .filter(
+      (row) =>
+        row.enabled &&
+        readErrors[readErrorKey(marketKey(row.scope, row.name), "packages")],
+    )
     .map((row) => row.name);
   const marketplaceNames = [...new Set(rows.map((row) => row.name))];
   const whereOptions = [

--- a/ui/src/components/marketplaces/packages-table.tsx
+++ b/ui/src/components/marketplaces/packages-table.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import type { AvailablePackage, Scope, Verdict } from "@/bindings";
+import type { AvailablePackage, Catalog, Verdict } from "@/bindings";
 import { StatusDot } from "@/components/status-dot";
 import { TagBadges } from "@/components/tag-badge";
 import { Button } from "@/components/ui/button";
@@ -13,14 +13,17 @@ import {
 } from "@/components/ui/table";
 import { kindIcon } from "@/lib/kind-icon";
 import { kindLabel, packageDisplayName, VERDICT_LABELS } from "@/lib/labels";
-import { marketKey, useMarketplacesStore } from "@/stores/marketplaces";
+import {
+  catalogKey,
+  catalogLabel,
+  useMarketplacesStore,
+} from "@/stores/marketplaces";
 import { useNavStore } from "@/stores/nav";
 import { safetyKey, usePreinstallSafety } from "@/stores/preinstall-safety";
 
-/** One offered package with the subscription it comes from. */
+/** One offered package with the catalog it comes from. */
 export interface PackageEntry {
-  scope: Scope;
-  source: string;
+  catalog: Catalog;
   row: AvailablePackage;
 }
 
@@ -58,7 +61,7 @@ export function PackagesTable({
       <TableBody>
         {entries.map((entry) => (
           <PackageRow
-            key={`${marketKey(entry.scope, entry.source)}:${entry.row.kind}:${entry.row.name}`}
+            key={`${catalogKey(entry.catalog)}:${entry.row.kind}:${entry.row.name}`}
             entry={entry}
             showMarketplace={showMarketplace}
           />
@@ -75,22 +78,22 @@ function PackageRow({
   entry: PackageEntry;
   showMarketplace: boolean;
 }) {
-  const { scope, source, row } = entry;
+  const { catalog, row } = entry;
   const goToAvailablePackage = useNavStore((s) => s.goToAvailablePackage);
   const install = useMarketplacesStore((s) => s.install);
   const busy = useMarketplacesStore((s) => s.busy);
   const want = usePreinstallSafety((s) => s.want);
   const safety = usePreinstallSafety(
-    (s) => s.scores[safetyKey(scope, source, row.kind, row.name)],
+    (s) => s.scores[safetyKey(catalog, row.kind, row.name)],
   );
   const Icon = kindIcon(row.kind);
 
   useEffect(() => {
-    want(scope, source, row.kind, row.name);
-  }, [want, scope, source, row.kind, row.name]);
+    want(catalog, row.kind, row.name);
+  }, [want, catalog, row.kind, row.name]);
 
   const open = () =>
-    goToAvailablePackage({ scope, source, kind: row.kind, name: row.name });
+    goToAvailablePackage({ catalog, kind: row.kind, name: row.name });
 
   return (
     <TableRow className="cursor-pointer" onClick={open}>
@@ -116,7 +119,9 @@ function PackageRow({
         <TagBadges tags={row.tags} />
       </TableCell>
       {showMarketplace ? (
-        <TableCell className="text-muted-foreground">{source}</TableCell>
+        <TableCell className="text-muted-foreground">
+          {catalogLabel(catalog)}
+        </TableCell>
       ) : null}
       <TableCell>
         {safety ? (
@@ -138,6 +143,10 @@ function PackageRow({
           <span className="text-xs text-muted-foreground">
             No longer offered
           </span>
+        ) : catalog.by === "repo" ? (
+          // Installing needs a subscription; the page's Subscribe button
+          // is the one action, so the row only says the package is here.
+          <span className="text-xs text-muted-foreground">Available</span>
         ) : (
           <Button
             size="sm"
@@ -146,8 +155,8 @@ function PackageRow({
             onClick={(e) => {
               e.stopPropagation();
               void install({
-                scope,
-                source,
+                scope: catalog.scope,
+                source: catalog.source,
                 items: [{ kind: row.kind, name: row.name }],
               });
             }}

--- a/ui/src/components/marketplaces/repo-action.tsx
+++ b/ui/src/components/marketplaces/repo-action.tsx
@@ -3,6 +3,7 @@ import type { CatalogSummary } from "@/bindings";
 import { SubscribeFromRepo } from "@/components/marketplaces/subscribe-from-repo";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { useCommunityStore } from "@/stores/community";
 import { repoAction, useMarketplacesStore } from "@/stores/marketplaces";
 
 /** What a page browsing a bare repository offers. Subscribe only when no
@@ -14,7 +15,7 @@ export function RepoAction({
   summary,
   subscribeLabel,
 }: {
-  /** The requested spelling, used until the summary names the canonical key. */
+  /** The requested spelling — a directory row's or a skills.sh hit's. */
   repo: string;
   summary: CatalogSummary | null;
   subscribeLabel: string;
@@ -24,7 +25,12 @@ export function RepoAction({
   const toggle = useMarketplacesStore((s) => s.toggle);
   const checkForUpdates = useMarketplacesStore((s) => s.checkForUpdates);
   const busy = useMarketplacesStore((s) => s.busy);
-  const key = summary?.provenance ?? repo;
+  // The canonical key comes from core — the directory row's from the first
+  // render, or the summary's once it lands — never from the spelling.
+  const listedKey = useCommunityStore(
+    (s) => s.directory?.rows.find((r) => r.repo === repo)?.repoKey ?? null,
+  );
+  const key = summary?.repoKey ?? listedKey;
   const { kind, holder } = repoAction(rows, rowsCurrent, key);
 
   switch (kind) {
@@ -35,7 +41,7 @@ export function RepoAction({
         </Button>
       );
     case "subscribe":
-      return <SubscribeFromRepo repo={key} label={subscribeLabel} />;
+      return <SubscribeFromRepo repo={key ?? repo} label={subscribeLabel} />;
     case "turn-on":
       return (
         <Button

--- a/ui/src/components/marketplaces/repo-action.tsx
+++ b/ui/src/components/marketplaces/repo-action.tsx
@@ -1,0 +1,51 @@
+import { RefreshCw } from "lucide-react";
+import type { CatalogSummary } from "@/bindings";
+import { SubscribeFromRepo } from "@/components/marketplaces/subscribe-from-repo";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { declaredHolder, useMarketplacesStore } from "@/stores/marketplaces";
+
+/** What a page browsing a bare repository offers. Subscribe only when no
+ * subscription declares the repository; a declared one that is turned off
+ * is turned back on from here, and one that is declared but unreadable is
+ * refreshed — either way the page then carries on as it. */
+export function RepoAction({
+  repo,
+  summary,
+  subscribeLabel,
+}: {
+  /** The requested spelling, used until the summary names the canonical key. */
+  repo: string;
+  summary: CatalogSummary | null;
+  subscribeLabel: string;
+}) {
+  const rows = useMarketplacesStore((s) => s.rows);
+  const toggle = useMarketplacesStore((s) => s.toggle);
+  const checkForUpdates = useMarketplacesStore((s) => s.checkForUpdates);
+  const busy = useMarketplacesStore((s) => s.busy);
+  const key = summary?.provenance ?? repo;
+  const held = declaredHolder(rows, key);
+
+  if (!held) return <SubscribeFromRepo repo={key} label={subscribeLabel} />;
+  if (!held.enabled) {
+    return (
+      <Button
+        size="sm"
+        onClick={() => void toggle(held.scope, held.name, true)}
+      >
+        Turn on
+      </Button>
+    );
+  }
+  return (
+    <Button
+      size="sm"
+      variant="outline"
+      disabled={busy}
+      onClick={() => void checkForUpdates()}
+    >
+      <RefreshCw className={cn("size-4", busy && "animate-spin")} />
+      Refresh
+    </Button>
+  );
+}

--- a/ui/src/components/marketplaces/repo-action.tsx
+++ b/ui/src/components/marketplaces/repo-action.tsx
@@ -3,7 +3,7 @@ import type { CatalogSummary } from "@/bindings";
 import { SubscribeFromRepo } from "@/components/marketplaces/subscribe-from-repo";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import { declaredHolder, useMarketplacesStore } from "@/stores/marketplaces";
+import { repoAction, useMarketplacesStore } from "@/stores/marketplaces";
 
 /** What a page browsing a bare repository offers. Subscribe only when no
  * subscription declares the repository; a declared one that is turned off
@@ -20,32 +20,42 @@ export function RepoAction({
   subscribeLabel: string;
 }) {
   const rows = useMarketplacesStore((s) => s.rows);
+  const rowsCurrent = useMarketplacesStore((s) => s.rowsCurrent);
   const toggle = useMarketplacesStore((s) => s.toggle);
   const checkForUpdates = useMarketplacesStore((s) => s.checkForUpdates);
   const busy = useMarketplacesStore((s) => s.busy);
   const key = summary?.provenance ?? repo;
-  const held = declaredHolder(rows, key);
+  const { kind, holder } = repoAction(rows, rowsCurrent, key);
 
-  if (!held) return <SubscribeFromRepo repo={key} label={subscribeLabel} />;
-  if (!held.enabled) {
-    return (
-      <Button
-        size="sm"
-        onClick={() => void toggle(held.scope, held.name, true)}
-      >
-        Turn on
-      </Button>
-    );
+  switch (kind) {
+    case "checking":
+      return (
+        <Button size="sm" variant="outline" disabled>
+          Checking subscriptions…
+        </Button>
+      );
+    case "subscribe":
+      return <SubscribeFromRepo repo={key} label={subscribeLabel} />;
+    case "turn-on":
+      return (
+        <Button
+          size="sm"
+          onClick={() => holder && void toggle(holder.scope, holder.name, true)}
+        >
+          Turn on
+        </Button>
+      );
+    case "refresh":
+      return (
+        <Button
+          size="sm"
+          variant="outline"
+          disabled={busy}
+          onClick={() => void checkForUpdates()}
+        >
+          <RefreshCw className={cn("size-4", busy && "animate-spin")} />
+          Refresh
+        </Button>
+      );
   }
-  return (
-    <Button
-      size="sm"
-      variant="outline"
-      disabled={busy}
-      onClick={() => void checkForUpdates()}
-    >
-      <RefreshCw className={cn("size-4", busy && "animate-spin")} />
-      Refresh
-    </Button>
-  );
 }

--- a/ui/src/components/marketplaces/skillssh-search.tsx
+++ b/ui/src/components/marketplaces/skillssh-search.tsx
@@ -17,8 +17,11 @@ const CHIP_VIEWS: { view: Exclude<SkillsShMode, "search">; label: string }[] = [
  * the skill opens for install, bound to what kendex's own discovery
  * finds there. */
 export function SkillsShSearch({
+  onOpen,
   onInstall,
 }: {
+  /** Open the repository a hit lives in, to browse before installing. */
+  onOpen: (repo: string) => void;
   onInstall: (url: string) => void;
 }) {
   const hits = useCommunityStore((s) => s.skillsshHits);
@@ -95,12 +98,16 @@ export function SkillsShSearch({
               key={`${hit.repo}/${hit.skill}`}
               className="flex items-center gap-3 px-4 py-3"
             >
-              <div className="min-w-0 flex-1">
+              <button
+                type="button"
+                className="min-w-0 flex-1 cursor-pointer text-left"
+                onClick={() => onOpen(hit.repo)}
+              >
                 <p className="truncate text-sm font-medium">{hit.skill}</p>
                 <p className="truncate font-mono text-xs text-muted-foreground">
                   {hit.repo}
                 </p>
-              </div>
+              </button>
               <span className="shrink-0 text-xs text-muted-foreground">
                 {installsLabel(hit.installs)} installs
               </span>

--- a/ui/src/components/marketplaces/subscribe-from-repo.tsx
+++ b/ui/src/components/marketplaces/subscribe-from-repo.tsx
@@ -1,0 +1,33 @@
+import { useState } from "react";
+import { SubscribeDialog } from "@/components/marketplaces/subscribe-dialog";
+import { Button } from "@/components/ui/button";
+
+/** The one action a repository page has before anyone subscribes: open
+ * the Subscribe dialog with this repository filled in. The dialog is
+ * keyed by the repository and mounted only while open, so each opening
+ * starts from the prefilled reference rather than a previous attempt's
+ * edits. */
+export function SubscribeFromRepo({
+  repo,
+  label,
+}: {
+  repo: string;
+  label: string;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button size="sm" onClick={() => setOpen(true)}>
+        {label}
+      </Button>
+      {open ? (
+        <SubscribeDialog
+          key={repo}
+          open
+          onOpenChange={setOpen}
+          initialReference={repo}
+        />
+      ) : null}
+    </>
+  );
+}

--- a/ui/src/components/marketplaces/subscribe-from-repo.tsx
+++ b/ui/src/components/marketplaces/subscribe-from-repo.tsx
@@ -11,6 +11,8 @@ export function SubscribeFromRepo({
   repo,
   label,
 }: {
+  /** The canonical `owner/repo` the page reads, so the subscription keys
+   * the same store entry and the page can carry on as it. */
   repo: string;
   label: string;
 }) {

--- a/ui/src/components/marketplaces/subscribed-row.tsx
+++ b/ui/src/components/marketplaces/subscribed-row.tsx
@@ -10,7 +10,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Switch } from "@/components/ui/switch";
-import { useMarketplacesStore } from "@/stores/marketplaces";
+import { subscription, useMarketplacesStore } from "@/stores/marketplaces";
 import { useNavStore } from "@/stores/nav";
 
 /** How many packages a subscription offers, in one phrase. */
@@ -61,7 +61,7 @@ export function SubscribedRow({ row }: { row: MarketplaceRow }) {
       <Button
         size="sm"
         variant="outline"
-        onClick={() => goToMarketplace({ scope: row.scope, source: row.name })}
+        onClick={() => goToMarketplace(subscription(row.scope, row.name))}
       >
         Open
       </Button>

--- a/ui/src/components/marketplaces/use-catalog.test.ts
+++ b/ui/src/components/marketplaces/use-catalog.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { readDue } from "./use-catalog";
+
+describe("a cached read is due", () => {
+  it("when a mutation has emptied the slot", () => {
+    // Loaded, then dropCatalogCaches ran: present flips false, and with
+    // nothing refusing the read it is asked again.
+    expect(readDue(true, false, true)).toBe(false);
+    expect(readDue(false, false, true)).toBe(true);
+  });
+
+  it("never while a refusal stands or the catalog is not ready", () => {
+    expect(readDue(false, true, true)).toBe(false);
+    expect(readDue(false, false, false)).toBe(false);
+  });
+});

--- a/ui/src/components/marketplaces/use-catalog.ts
+++ b/ui/src/components/marketplaces/use-catalog.ts
@@ -1,0 +1,50 @@
+import { useEffect, useMemo } from "react";
+import type { Catalog, CatalogSummary } from "@/bindings";
+import {
+  catalogKey,
+  subscription,
+  useMarketplacesStore,
+} from "@/stores/marketplaces";
+
+/** The catalog a nested page really reads. A repository opened from the
+ * Community tab is read once for what it says about itself — the read that
+ * fetches it — and when this machine already subscribes to it, or does so
+ * while the page is open, the page carries on as that subscription, Install
+ * and all. Content reads wait for `ready`: a repository's first fetch holds
+ * the store's lock, and a second read racing it would be refused. */
+export function useCatalog(requested: Catalog): {
+  catalog: Catalog;
+  summary: CatalogSummary | null;
+  error: string | null;
+  ready: boolean;
+  retry: () => void;
+} {
+  const key = catalogKey(requested);
+  const summary = useMarketplacesStore((s) => s.summaries[key] ?? null);
+  const error = useMarketplacesStore(
+    (s) => s.readErrors[`${key}::summary`] ?? null,
+  );
+  const loadSummary = useMarketplacesStore((s) => s.loadSummary);
+
+  useEffect(() => {
+    if (requested.by === "repo" && !summary && !error) {
+      void loadSummary(requested);
+    }
+  }, [requested, summary, error, loadSummary]);
+
+  const catalog = useMemo(
+    () =>
+      requested.by === "repo" && summary?.subscription
+        ? subscription(summary.subscription.scope, summary.subscription.source)
+        : requested,
+    [requested, summary],
+  );
+
+  return {
+    catalog,
+    summary,
+    error,
+    ready: requested.by === "subscription" || summary !== null,
+    retry: () => void loadSummary(requested),
+  };
+}

--- a/ui/src/components/marketplaces/use-catalog.ts
+++ b/ui/src/components/marketplaces/use-catalog.ts
@@ -2,6 +2,7 @@ import { useEffect, useMemo } from "react";
 import type { Catalog, CatalogSummary } from "@/bindings";
 import {
   catalogKey,
+  readErrorKey,
   subscription,
   useMarketplacesStore,
 } from "@/stores/marketplaces";
@@ -22,7 +23,7 @@ export function useCatalog(requested: Catalog): {
   const key = catalogKey(requested);
   const summary = useMarketplacesStore((s) => s.summaries[key] ?? null);
   const error = useMarketplacesStore(
-    (s) => s.readErrors[`${key}::summary`] ?? null,
+    (s) => s.readErrors[readErrorKey(key, "summary")] ?? null,
   );
   const loadSummary = useMarketplacesStore((s) => s.loadSummary);
 

--- a/ui/src/components/marketplaces/use-catalog.ts
+++ b/ui/src/components/marketplaces/use-catalog.ts
@@ -49,3 +49,25 @@ export function useCatalog(requested: Catalog): {
     retry: () => void loadSummary(requested),
   };
 }
+
+/** Whether a cached read is due: the slot is empty, nothing has refused
+ * it, and the catalog is ready. A mutation empties the slot without
+ * touching the catalog, so presence is what an effect must watch — the
+ * failure guard keeps a refused read from being asked again and again. */
+export const readDue = (
+  present: boolean,
+  failed: boolean,
+  ready: boolean,
+): boolean => ready && !present && !failed;
+
+/** Issue `read` whenever [readDue] says so. */
+export function useCachedRead(
+  present: boolean,
+  failed: boolean,
+  ready: boolean,
+  read: () => Promise<void>,
+) {
+  useEffect(() => {
+    if (readDue(present, failed, ready)) void read();
+  }, [present, failed, ready, read]);
+}

--- a/ui/src/components/nav-bar.tsx
+++ b/ui/src/components/nav-bar.tsx
@@ -9,6 +9,7 @@ import {
   WIDE_CONTENT_WIDTH,
 } from "@/lib/layout";
 import { cn } from "@/lib/utils";
+import { catalogLabel } from "@/stores/marketplaces";
 import { useNavStore } from "@/stores/nav";
 
 // A quiet strip above the page content — only worth showing at all once a
@@ -58,11 +59,9 @@ export function NavBar() {
               : availableRef
                 ? packageDisplayName(availableRef)
                 : null,
-            marketplaceName:
-              marketplaceRef?.source ??
-              bundleRef?.source ??
-              availableRef?.source ??
-              null,
+            marketplaceName: catalogLabel(
+              marketplaceRef ?? bundleRef?.catalog ?? availableRef?.catalog,
+            ),
             bundleName: bundleRef?.bundle ?? null,
           })}
         </span>

--- a/ui/src/components/package/file-preview.tsx
+++ b/ui/src/components/package/file-preview.tsx
@@ -84,11 +84,25 @@ export function FilePreview({
     );
   }
 
-  const isMarkdown = state.path.toLowerCase().endsWith(".md");
-  const basename = state.path.split("/").pop() ?? state.path;
+  return <FileContent {...state} />;
+}
+
+/** One file, rendered — markdown lightly styled, everything else
+ *  syntax-highlighted — under a bar naming it. */
+export function FileContent({
+  path,
+  content,
+  truncated,
+}: {
+  path: string;
+  content: string;
+  truncated: boolean;
+}) {
+  const isMarkdown = path.toLowerCase().endsWith(".md");
+  const basename = path.split("/").pop() ?? path;
 
   const copyPath = () => {
-    void navigator.clipboard.writeText(state.path).then(() => {
+    void navigator.clipboard.writeText(path).then(() => {
       toast.success("Path copied");
     });
   };
@@ -100,7 +114,7 @@ export function FilePreview({
           {basename}
         </span>
         <span className="flex shrink-0 items-center gap-2">
-          {state.truncated ? (
+          {truncated ? (
             <span className="text-[11px] text-muted-foreground">
               Showing first 64 KB
             </span>
@@ -118,9 +132,9 @@ export function FilePreview({
       </div>
       <div className="p-3">
         {isMarkdown ? (
-          <MarkdownView source={state.content} />
+          <MarkdownView source={content} />
         ) : (
-          <CodeBlock path={state.path} content={state.content} />
+          <CodeBlock path={path} content={content} />
         )}
       </div>
     </div>

--- a/ui/src/components/package/package-meta.tsx
+++ b/ui/src/components/package/package-meta.tsx
@@ -14,6 +14,7 @@ import { groupScopes, type ItemGroup } from "@/lib/derive";
 import { kindLabel, scopeName } from "@/lib/labels";
 import { relativeTime } from "@/lib/relative-time";
 import { versionLabel } from "@/lib/versions";
+import { subscription } from "@/stores/marketplaces";
 import { useNavStore } from "@/stores/nav";
 import {
   originFor,
@@ -85,10 +86,7 @@ export function PackageMetaBlock({
               className="underline underline-offset-2 hover:text-foreground"
               title={originTitle(origin)}
               onClick={() =>
-                goToMarketplace({
-                  scope: primary.scope,
-                  source: origin.source,
-                })
+                goToMarketplace(subscription(primary.scope, origin.source))
               }
             >
               {origin.source}

--- a/ui/src/dev/fixture-marketplaces.ts
+++ b/ui/src/dev/fixture-marketplaces.ts
@@ -103,6 +103,7 @@ export const repoSummaries: Record<
 > = {
   "acme/agent-kit": {
     provenance: "acme/agent-kit",
+    repoKey: "acme/agent-kit",
     commit: "9f3a1c2d4e5f60718293a4b5c6d7e8f901234567",
     meta: {
       description: "Agent kit for TypeScript teams",
@@ -116,6 +117,7 @@ export const repoSummaries: Record<
   },
   "wshobson/agents": {
     provenance: "wshobson/agents",
+    repoKey: "wshobson/agents",
     commit: PLUGINS_HEAD,
     meta: null,
     mode: "plugin-registry",
@@ -125,6 +127,7 @@ export const repoSummaries: Record<
   },
   "vercel-labs/agent-skills": {
     provenance: "vercel-labs/agent-skills",
+    repoKey: "vercel-labs/agent-skills",
     commit: KENDEX_HEAD,
     meta: null,
     mode: "discovered",

--- a/ui/src/dev/fixture-marketplaces.ts
+++ b/ui/src/dev/fixture-marketplaces.ts
@@ -78,6 +78,14 @@ const counts = (offered: Offered[]) => {
   return out;
 };
 
+/** Which subscription fixture backs each listed repository: its packages,
+ * bundle specs and About report are that source's. */
+export const REPO_FIXTURE_SOURCE: Record<string, string> = {
+  "acme/agent-kit": "kendex",
+  "wshobson/agents": "claude-plugins",
+  "vercel-labs/agent-skills": "kendex",
+};
+
 /** What the Community tab's listed repositories offer when opened before
  * subscribing — the kendex catalog's packages, unsubscribed. A listed repo
  * absent here reads as unreachable, so the page's error path is exercised. */

--- a/ui/src/dev/fixture-marketplaces.ts
+++ b/ui/src/dev/fixture-marketplaces.ts
@@ -6,6 +6,7 @@
 import type {
   AboutView,
   AvailablePackage,
+  CatalogSummary,
   MarketplaceRow,
   Scope,
 } from "@/bindings";
@@ -75,6 +76,53 @@ const counts = (offered: Offered[]) => {
     out[pkg.kind] = (out[pkg.kind] ?? 0) + 1;
   }
   return out;
+};
+
+/** What the Community tab's listed repositories offer when opened before
+ * subscribing — the kendex catalog's packages, unsubscribed. A listed repo
+ * absent here reads as unreachable, so the page's error path is exercised. */
+export function repoPackages(): Record<string, AvailablePackage[]> {
+  return {
+    "acme/agent-kit": packageList(KENDEX_OFFERED, []),
+    "wshobson/agents": packageList(PLUGINS_OFFERED, []),
+    "vercel-labs/agent-skills": packageList(KENDEX_OFFERED, []),
+  };
+}
+
+export const repoSummaries: Record<
+  string,
+  Omit<CatalogSummary, "subscription">
+> = {
+  "acme/agent-kit": {
+    provenance: "acme/agent-kit",
+    commit: "9f3a1c2d4e5f60718293a4b5c6d7e8f901234567",
+    meta: {
+      description: "Agent kit for TypeScript teams",
+      author: "Acme",
+      license: "MIT",
+      tags: ["typescript", "agents"],
+    },
+    mode: "explicit",
+    counts: counts(KENDEX_OFFERED),
+    warning: null,
+  },
+  "wshobson/agents": {
+    provenance: "wshobson/agents",
+    commit: PLUGINS_HEAD,
+    meta: null,
+    mode: "plugin-registry",
+    counts: counts(PLUGINS_OFFERED),
+    warning:
+      "wshobson/agents: using cached version (could not reach github.com)",
+  },
+  "vercel-labs/agent-skills": {
+    provenance: "vercel-labs/agent-skills",
+    commit: KENDEX_HEAD,
+    meta: null,
+    mode: "discovered",
+    counts: counts(KENDEX_OFFERED),
+    warning: null,
+  },
 };
 
 export function marketplaces(): MarketplaceRow[] {

--- a/ui/src/dev/fixture-marketplaces.ts
+++ b/ui/src/dev/fixture-marketplaces.ts
@@ -129,6 +129,7 @@ export function marketplaces(): MarketplaceRow[] {
   const kendex = {
     name: "kendex",
     repo: KENDEX_REPO,
+    repoKey: KENDEX_REPO,
     path: null,
     rev: null,
     commit: KENDEX_HEAD,
@@ -151,6 +152,7 @@ export function marketplaces(): MarketplaceRow[] {
       scope: GLOBAL,
       name: "claude-plugins",
       repo: PLUGINS_REPO,
+      repoKey: PLUGINS_REPO,
       path: null,
       rev: null,
       commit: PLUGINS_HEAD,
@@ -164,6 +166,7 @@ export function marketplaces(): MarketplaceRow[] {
       scope: proj(ACME),
       name: "team",
       repo: null,
+      repoKey: null,
       path: "../team-catalog",
       rev: null,
       commit: null,

--- a/ui/src/dev/fixtures.ts
+++ b/ui/src/dev/fixtures.ts
@@ -12,7 +12,11 @@ import type {
   SourceRow,
 } from "@/bindings";
 import { bundles, manifests, sources, views } from "./fixture-declared";
-import { marketplacePackages, marketplaces } from "./fixture-marketplaces";
+import {
+  marketplacePackages,
+  marketplaces,
+  repoPackages,
+} from "./fixture-marketplaces";
 import { harnesses, items } from "./fixture-observed";
 import { provenance } from "./fixture-provenance";
 import { ACME, API } from "./fixture-scopes";
@@ -32,6 +36,8 @@ export interface MockState {
   marketplaces: MarketplaceRow[];
   /// What each readable subscription offers, keyed scope-label::source.
   marketplacePackages: Record<string, AvailablePackage[]>;
+  /// What a listed repository offers when browsed before subscribing.
+  repoPackages: Record<string, AvailablePackage[]>;
   provenance: ProvenanceRow[];
   /// Packages whose update notifications the mock user muted.
   ignored: { kind: ItemKind; name: string }[];
@@ -56,6 +62,7 @@ export function initialState(): MockState {
     bundles: bundles(),
     marketplaces: marketplaces(),
     marketplacePackages: marketplacePackages(),
+    repoPackages: repoPackages(),
     provenance: provenance(),
     ignored: [],
   };

--- a/ui/src/dev/mock-catalog.ts
+++ b/ui/src/dev/mock-catalog.ts
@@ -3,6 +3,7 @@
 import type {
   AvailablePackage,
   BundleDetail,
+  Catalog,
   InstallState,
   ItemKind,
   MarketplaceRow,
@@ -22,11 +23,21 @@ export function marketplaceRow(
 }
 
 /// The readable catalog's packages, or the rejection that says why the
-/// content is unreachable — mirrors core's require_ready errors.
+/// content is unreachable — mirrors core's require_ready errors. A
+/// repository nobody subscribes to reads as the community fixture's listing.
 export function offeredHere(
-  scope: Scope,
-  source: string,
+  catalog: Catalog,
 ): AvailablePackage[] | Promise<never> {
+  if (catalog.by === "repo") {
+    const offered = store.state.repoPackages[catalog.repo];
+    if (!offered) {
+      return Promise.reject(
+        `${catalog.repo}: could not reach github.com (offline in the mock)`,
+      );
+    }
+    return offered;
+  }
+  const { scope, source } = catalog;
   if (!marketplaceRow(scope, source)) {
     return Promise.reject(`unknown source '${source}'`);
   }
@@ -36,6 +47,10 @@ export function offeredHere(
   }
   return offered;
 }
+
+/** The source name a catalog's bundle specs are filed under. */
+export const specSource = (catalog: Catalog): string =>
+  catalog.by === "subscription" ? catalog.source : catalog.repo;
 
 const stateOf = (
   offered: AvailablePackage[],

--- a/ui/src/dev/mock-catalog.ts
+++ b/ui/src/dev/mock-catalog.ts
@@ -10,7 +10,7 @@ import type {
   Scope,
 } from "@/bindings";
 import { BUNDLE_SPECS } from "./fixture-catalog";
-import { packagesKey } from "./fixture-marketplaces";
+import { packagesKey, REPO_FIXTURE_SOURCE } from "./fixture-marketplaces";
 import { same, store } from "./mock-state";
 
 export function marketplaceRow(
@@ -48,9 +48,12 @@ export function offeredHere(
   return offered;
 }
 
-/** The source name a catalog's bundle specs are filed under. */
+/** The source name a catalog's bundle specs and About report are filed
+ * under — a listed repository's is the fixture source backing it. */
 export const specSource = (catalog: Catalog): string =>
-  catalog.by === "subscription" ? catalog.source : catalog.repo;
+  catalog.by === "subscription"
+    ? catalog.source
+    : (REPO_FIXTURE_SOURCE[catalog.repo] ?? catalog.repo);
 
 const stateOf = (
   offered: AvailablePackage[],

--- a/ui/src/dev/mock-community.ts
+++ b/ui/src/dev/mock-community.ts
@@ -8,6 +8,7 @@ const directory: DirectoryView = {
   rows: [
     {
       repo: "acme/agent-kit",
+      repoKey: "acme/agent-kit",
       name: "agent-kit",
       description: "Agent kit for TypeScript teams",
       tags: ["typescript", "agents"],
@@ -20,6 +21,7 @@ const directory: DirectoryView = {
     },
     {
       repo: "wshobson/agents",
+      repoKey: "wshobson/agents",
       name: "agents",
       description: "87 plugins for Claude Code",
       tags: ["plugins"],
@@ -32,6 +34,7 @@ const directory: DirectoryView = {
     },
     {
       repo: "acme/acme-tools",
+      repoKey: "acme/acme-tools",
       name: "acme-tools",
       description: "Rust skills",
       tags: ["rust"],

--- a/ui/src/dev/mock-install.ts
+++ b/ui/src/dev/mock-install.ts
@@ -54,7 +54,7 @@ export const installHandlers: Record<string, Handler> = {
           }));
       }
     }
-    const offered = offeredHere(target, source);
+    const offered = offeredHere({ by: "subscription", scope: target, source });
     if (offered instanceof Promise) return offered;
     const wanted: { kind: ItemKind; name: string }[] = [];
     const takeBundle = (name: string) => {

--- a/ui/src/dev/mock-marketplaces.ts
+++ b/ui/src/dev/mock-marketplaces.ts
@@ -1,10 +1,15 @@
 // Reading marketplaces: the overview, a subscription's packages, a bundle,
 // a package preview with its safety report, and the Library's provenance.
 // Installing and subscribing live in mock-install.ts and mock-subscribe.ts.
-import type { ItemKind, PackageView, Scope } from "@/bindings";
-import { aboutViews } from "./fixture-marketplaces";
+import type {
+  Catalog,
+  CatalogSummary,
+  ItemKind,
+  PackageView,
+} from "@/bindings";
+import { aboutViews, repoSummaries } from "./fixture-marketplaces";
 import { packageSafety } from "./fixture-package-safety";
-import { bundleDetail, offeredHere } from "./mock-catalog";
+import { bundleDetail, offeredHere, specSource } from "./mock-catalog";
 import { installHandlers } from "./mock-install";
 import { type Handler, store } from "./mock-state";
 import { subscribeHandlers } from "./mock-subscribe";
@@ -17,39 +22,64 @@ export const marketplaceHandlers: Record<string, Handler> = {
 
   marketplaces_overview: () => store.state.marketplaces,
 
-  marketplace_packages: ({ scope, source }: { scope: Scope; source: string }) =>
-    offeredHere(scope, source),
+  marketplace_packages: ({ catalog }: { catalog: Catalog }) =>
+    offeredHere(catalog),
+
+  marketplace_summary: ({
+    catalog,
+  }: {
+    catalog: Catalog;
+  }): CatalogSummary | Promise<never> => {
+    const offered = offeredHere(catalog);
+    if (offered instanceof Promise) return offered;
+    if (catalog.by === "subscription") {
+      return {
+        provenance: catalog.source,
+        commit: null,
+        meta: null,
+        mode: "discovered",
+        counts: {},
+        warning: null,
+        subscription: { scope: catalog.scope, source: catalog.source },
+      };
+    }
+    const held = store.state.marketplaces.find(
+      (row) => row.repo === catalog.repo,
+    );
+    return {
+      ...repoSummaries[catalog.repo],
+      subscription: held ? { scope: held.scope, source: held.name } : null,
+    };
+  },
 
   marketplace_bundle: ({
-    scope,
-    source,
+    catalog,
     name,
   }: {
-    scope: Scope;
-    source: string;
+    catalog: Catalog;
     name: string;
   }) => {
-    const offered = offeredHere(scope, source);
+    const offered = offeredHere(catalog);
     if (offered instanceof Promise) return offered;
-    return bundleDetail(offered, source, name);
+    return bundleDetail(offered, specSource(catalog), name);
   },
 
   marketplace_package_preview: ({
-    scope,
-    source,
+    catalog,
     kind,
     name,
   }: {
-    scope: Scope;
-    source: string;
+    catalog: Catalog;
     kind: ItemKind;
     name: string;
   }): PackageView | Promise<never> => {
-    const offered = offeredHere(scope, source);
+    const offered = offeredHere(catalog);
     if (offered instanceof Promise) return offered;
     const pkg = offered.find((p) => p.kind === kind && p.name === name);
     if (!pkg) {
-      return Promise.reject(`'${name}' is not offered by '${source}'`);
+      return Promise.reject(
+        `'${name}' is not offered by '${specSource(catalog)}'`,
+      );
     }
     return {
       preview: {
@@ -82,12 +112,14 @@ export const marketplaceHandlers: Record<string, Handler> = {
     };
   },
 
-  marketplace_about: ({ scope, source }: { scope: Scope; source: string }) => {
-    const offered = offeredHere(scope, source);
+  marketplace_about: ({ catalog }: { catalog: Catalog }) => {
+    const offered = offeredHere(catalog);
     if (offered instanceof Promise) return offered;
-    const about = aboutViews[source];
+    const about = aboutViews[specSource(catalog)];
     if (!about) {
-      return Promise.reject(`source '${source}' is not fetched yet`);
+      return Promise.reject(
+        `source '${specSource(catalog)}' is not fetched yet`,
+      );
     }
     return about;
   },

--- a/ui/src/dev/mock-marketplaces.ts
+++ b/ui/src/dev/mock-marketplaces.ts
@@ -5,6 +5,7 @@ import type {
   Catalog,
   CatalogSummary,
   ItemKind,
+  ItemSource,
   PackageView,
 } from "@/bindings";
 import { aboutViews, repoSummaries } from "./fixture-marketplaces";
@@ -110,6 +111,33 @@ export const marketplaceHandlers: Record<string, Handler> = {
       },
       safety: packageSafety(kind, name),
     };
+  },
+
+  marketplace_package_file: ({
+    catalog,
+    kind,
+    name,
+    path,
+  }: {
+    catalog: Catalog;
+    kind: ItemKind;
+    name: string;
+    path: string;
+  }): ItemSource | Promise<never> => {
+    const offered = offeredHere(catalog);
+    if (offered instanceof Promise) return offered;
+    if (!offered.some((p) => p.kind === kind && p.name === name)) {
+      return Promise.reject(`'${name}' is not offered`);
+    }
+    if (path.startsWith("/") || path.split("/").includes("..") || !path) {
+      return Promise.reject(
+        `${path}: a package file is named by a plain relative path`,
+      );
+    }
+    const content = path.endsWith(".md")
+      ? `# ${path}\n\nWhat **${name}** keeps in ${path}.\n`
+      : `${path} of ${name}\n`;
+    return { path, content, truncated: false };
   },
 
   marketplace_about: ({ catalog }: { catalog: Catalog }) => {

--- a/ui/src/dev/mock-marketplaces.ts
+++ b/ui/src/dev/mock-marketplaces.ts
@@ -12,7 +12,7 @@ import { aboutViews, repoSummaries } from "./fixture-marketplaces";
 import { packageSafety } from "./fixture-package-safety";
 import { bundleDetail, offeredHere, specSource } from "./mock-catalog";
 import { installHandlers } from "./mock-install";
-import { type Handler, store } from "./mock-state";
+import { type Handler, same, store } from "./mock-state";
 import { subscribeHandlers } from "./mock-subscribe";
 import { unsubscribeHandlers } from "./mock-unsubscribe";
 
@@ -36,6 +36,11 @@ export const marketplaceHandlers: Record<string, Handler> = {
     if (catalog.by === "subscription") {
       return {
         provenance: catalog.source,
+        repoKey:
+          store.state.marketplaces.find(
+            (row) =>
+              row.name === catalog.source && same(row.scope, catalog.scope),
+          )?.repoKey ?? null,
         commit: null,
         meta: null,
         mode: "discovered",

--- a/ui/src/dev/mock-subscribe.ts
+++ b/ui/src/dev/mock-subscribe.ts
@@ -2,6 +2,7 @@
 // reference that leads with one package. Nothing is fetched — the mock
 // harness has no network — so the new row carries no content yet.
 import type { Scope, SubscribeOutcome } from "@/bindings";
+import { packagesKey } from "./fixture-marketplaces";
 import { marketplaceRow } from "./mock-catalog";
 import { type Handler, label, same, store } from "./mock-state";
 
@@ -58,6 +59,14 @@ export const subscribeHandlers: Record<string, Handler> = {
         meta: null,
         mode: null,
       });
+      // A listed repository's offer is already in the store: the new
+      // subscription reads it at once, so a page that was browsing the
+      // repository carries on as the subscription with Install available.
+      const browsed = store.state.repoPackages[base];
+      if (browsed) {
+        store.state.marketplacePackages[packagesKey(scope, alias)] =
+          structuredClone(browsed);
+      }
       store.state.sources.push({
         scope,
         name: alias,

--- a/ui/src/dev/mock-subscribe.ts
+++ b/ui/src/dev/mock-subscribe.ts
@@ -49,6 +49,7 @@ export const subscribeHandlers: Record<string, Handler> = {
         scope,
         name: alias,
         repo: isPath ? null : base,
+        repoKey: isPath ? null : base.toLowerCase(),
         path: isPath ? base : null,
         rev,
         commit: null,

--- a/ui/src/lib/latest.test.ts
+++ b/ui/src/lib/latest.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { latestOnly } from "./latest";
+
+describe("latestOnly", () => {
+  it("drops an older answer that arrives after a newer request", async () => {
+    const latest = latestOnly();
+    let settleOld: (value: string) => void = () => {};
+    const old = latest(new Promise<string>((resolve) => (settleOld = resolve)));
+    const fresh = latest(Promise.resolve("pinned"));
+
+    expect(await fresh).toBe("pinned");
+    settleOld("bare HEAD");
+    expect(await old).toBeUndefined();
+  });
+
+  it("passes the newest answer through", async () => {
+    const latest = latestOnly();
+    expect(await latest(Promise.resolve(1))).toBe(1);
+  });
+});

--- a/ui/src/lib/latest.ts
+++ b/ui/src/lib/latest.ts
@@ -1,0 +1,11 @@
+/** Answers from the newest request only. A page whose address changes
+ * while a read is in flight — a repository page carrying on as the
+ * subscription it just gained — must not let the older answer land on top
+ * of the newer one. */
+export function latestOnly() {
+  let generation = 0;
+  return <T>(pending: Promise<T>): Promise<T | undefined> => {
+    const mine = ++generation;
+    return pending.then((value) => (mine === generation ? value : undefined));
+  };
+}

--- a/ui/src/pages/available-package.tsx
+++ b/ui/src/pages/available-package.tsx
@@ -1,24 +1,39 @@
 import { useEffect, useState } from "react";
 import { commands, type PackageView, type Scope } from "@/bindings";
 import { MarkdownView } from "@/components/markdown-view";
+import { AvailableAside } from "@/components/marketplaces/available-aside";
 import { DestinationSelect } from "@/components/marketplaces/destination-select";
-import { fileSizeLabel } from "@/components/package/file-list";
+import { SubscribeDialog } from "@/components/marketplaces/subscribe-dialog";
+import { useCatalog } from "@/components/marketplaces/use-catalog";
 import { PageHeader } from "@/components/page-header";
 import { FindingLine } from "@/components/safety-findings";
 import { TagBadges } from "@/components/tag-badge";
 import { Button } from "@/components/ui/button";
 import { kindIcon } from "@/lib/kind-icon";
-import { kindLabel, packageDisplayName, VERDICT_LABELS } from "@/lib/labels";
+import { kindLabel, packageDisplayName } from "@/lib/labels";
 import { PAGE_BODY, WIDE_CONTENT_WIDTH } from "@/lib/layout";
 import { cn } from "@/lib/utils";
-import { marketKey, useMarketplacesStore } from "@/stores/marketplaces";
-import { useNavStore } from "@/stores/nav";
+import { catalogKey, useMarketplacesStore } from "@/stores/marketplaces";
+import { type AvailableRef, useNavStore } from "@/stores/nav";
 
 /** A package that isn't installed yet: what it is, its own README, its
  * files, and the safety findings its bytes earn before anything lands.
- * Installing turns this same address into the installed package's page. */
+ * From a repository nobody subscribes to yet, the one action is Subscribe;
+ * installing turns this same address into the installed package's page. */
 export function AvailablePackagePage() {
   const availableRef = useNavStore((s) => s.availableRef);
+  if (!availableRef) return null;
+  return <AvailablePackage availableRef={availableRef} />;
+}
+
+function AvailablePackage({ availableRef }: { availableRef: AvailableRef }) {
+  const { kind, name } = availableRef;
+  const {
+    catalog,
+    summary,
+    error: reachError,
+    ready,
+  } = useCatalog(availableRef.catalog);
   const goToPackage = useNavStore((s) => s.goToPackage);
   const rows = useMarketplacesStore((s) => s.rows);
   const install = useMarketplacesStore((s) => s.install);
@@ -26,38 +41,41 @@ export function AvailablePackagePage() {
   const [view, setView] = useState<PackageView | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [destination, setDestination] = useState<Scope | null>(null);
+  const [subscribeOpen, setSubscribeOpen] = useState(false);
 
   useEffect(() => {
-    if (!availableRef) return;
+    if (!ready) return;
     setView(null);
     setError(null);
-    void commands
-      .marketplacePackagePreview(
-        availableRef.scope,
-        availableRef.source,
-        availableRef.kind,
-        availableRef.name,
-      )
-      .then((r) => {
-        if (r.status === "ok") setView(r.data);
-        else setError(r.error);
-      });
-  }, [availableRef]);
+    void commands.marketplacePackagePreview(catalog, kind, name).then((r) => {
+      if (r.status === "ok") setView(r.data);
+      else setError(r.error);
+    });
+  }, [catalog, ready, kind, name]);
 
-  if (!availableRef) return null;
-  const { scope, source, kind, name } = availableRef;
   const Icon = kindIcon(kind);
+  const scope = catalog.by === "subscription" ? catalog.scope : null;
   const target = destination ?? scope;
   // Matched by scope and name both — two scopes can subscribe the same
   // alias to different repositories.
-  const row = rows.find(
-    (r) =>
-      r.name === source &&
-      marketKey(r.scope, r.name) === marketKey(scope, source),
-  );
-  const repo = row?.repo ?? row?.path ?? null;
+  const row =
+    catalog.by === "subscription"
+      ? rows.find(
+          (r) =>
+            r.name === catalog.source &&
+            catalogKey({
+              by: "subscription",
+              scope: r.scope,
+              source: r.name,
+            }) === catalogKey(catalog),
+        )
+      : undefined;
+  const repo = row?.repo ?? row?.path ?? summary?.provenance ?? null;
+  const shownError = reachError ?? error;
 
-  const doInstall = () =>
+  const doInstall = () => {
+    if (catalog.by !== "subscription" || !target) return;
+    const { scope, source } = catalog;
     void install({
       scope,
       source,
@@ -68,6 +86,7 @@ export function AvailablePackagePage() {
       // address gains the scope it landed in.
       if (ok) goToPackage({ kind, name, scope: target });
     });
+  };
 
   return (
     <div className="flex h-full flex-col">
@@ -91,16 +110,32 @@ export function AvailablePackagePage() {
           </>
         }
         action={
-          <>
-            <DestinationSelect
-              browsing={scope}
-              value={target}
-              onChange={setDestination}
-            />
-            <Button disabled={busy || !view} onClick={doInstall}>
-              {busy ? "Installing…" : "Install"}
-            </Button>
-          </>
+          catalog.by === "subscription" && scope && target ? (
+            <>
+              <DestinationSelect
+                browsing={scope}
+                value={target}
+                onChange={setDestination}
+              />
+              <Button disabled={busy || !view} onClick={doInstall}>
+                {busy ? "Installing…" : "Install"}
+              </Button>
+            </>
+          ) : (
+            <>
+              <Button onClick={() => setSubscribeOpen(true)}>
+                Subscribe to install
+              </Button>
+              {subscribeOpen && catalog.by === "repo" ? (
+                <SubscribeDialog
+                  key={catalog.repo}
+                  open
+                  onOpenChange={setSubscribeOpen}
+                  initialReference={catalog.repo}
+                />
+              ) : null}
+            </>
+          )
         }
       />
       <div className="min-h-0 flex-1 overflow-y-auto">
@@ -112,9 +147,9 @@ export function AvailablePackagePage() {
             )}
           >
             <div className="min-w-0 space-y-8">
-              {error ? (
+              {shownError ? (
                 <p className="text-sm text-critical" role="alert">
-                  {error}
+                  {shownError}
                 </p>
               ) : null}
               {view?.preview.readme ? (
@@ -142,68 +177,7 @@ export function AvailablePackagePage() {
                 </section>
               ) : null}
             </div>
-            <aside className="space-y-6 text-sm">
-              <section>
-                <h3 className="mb-1 text-xs font-semibold text-muted-foreground uppercase">
-                  From
-                </h3>
-                <p>
-                  {source}
-                  {repo ? (
-                    <span className="block truncate font-mono text-xs text-muted-foreground">
-                      {repo}
-                    </span>
-                  ) : null}
-                </p>
-              </section>
-              {view ? (
-                <section>
-                  <h3 className="mb-1 text-xs font-semibold text-muted-foreground uppercase">
-                    Safety
-                  </h3>
-                  <p>
-                    {VERDICT_LABELS[view.safety.verdict]} ·{" "}
-                    {view.safety.safety.score}/100
-                  </p>
-                </section>
-              ) : null}
-              {view && view.preview.bundles.length > 0 ? (
-                <section>
-                  <h3 className="mb-1 text-xs font-semibold text-muted-foreground uppercase">
-                    Comes with
-                  </h3>
-                  <p>{view.preview.bundles.join(", ")}</p>
-                </section>
-              ) : null}
-              {view && view.preview.files.length > 0 ? (
-                <section>
-                  <h3 className="mb-1 text-xs font-semibold text-muted-foreground uppercase">
-                    Files
-                  </h3>
-                  <ul className="space-y-1">
-                    {view.preview.files.map((file) => (
-                      <li
-                        key={file.path}
-                        className="flex items-baseline justify-between gap-2"
-                      >
-                        <span className="truncate font-mono text-xs">
-                          {file.path}
-                        </span>
-                        <span className="shrink-0 text-xs text-muted-foreground">
-                          {fileSizeLabel(file.size)}
-                        </span>
-                      </li>
-                    ))}
-                  </ul>
-                </section>
-              ) : null}
-              {view?.preview.collision ? (
-                <p className="text-xs text-warning">
-                  This name is already installed from {view.preview.collision}—
-                  installing from {source} will be refused.
-                </p>
-              ) : null}
-            </aside>
+            <AvailableAside catalog={catalog} repo={repo} view={view} />
           </div>
         </div>
       </div>

--- a/ui/src/pages/available-package.tsx
+++ b/ui/src/pages/available-package.tsx
@@ -3,7 +3,7 @@ import { commands, type PackageView, type Scope } from "@/bindings";
 import { MarkdownView } from "@/components/markdown-view";
 import { AvailableAside } from "@/components/marketplaces/available-aside";
 import { DestinationSelect } from "@/components/marketplaces/destination-select";
-import { SubscribeFromRepo } from "@/components/marketplaces/subscribe-from-repo";
+import { RepoAction } from "@/components/marketplaces/repo-action";
 import { useCatalog } from "@/components/marketplaces/use-catalog";
 import { PageHeader } from "@/components/page-header";
 import { FindingLine } from "@/components/safety-findings";
@@ -110,9 +110,10 @@ function AvailablePackage({ availableRef }: { availableRef: AvailableRef }) {
         }
         action={
           catalog.by === "repo" ? (
-            <SubscribeFromRepo
-              repo={summary?.provenance ?? catalog.repo}
-              label="Subscribe to install"
+            <RepoAction
+              repo={catalog.repo}
+              summary={summary}
+              subscribeLabel="Subscribe to install"
             />
           ) : scope && target ? (
             <>

--- a/ui/src/pages/available-package.tsx
+++ b/ui/src/pages/available-package.tsx
@@ -111,7 +111,7 @@ function AvailablePackage({ availableRef }: { availableRef: AvailableRef }) {
         action={
           catalog.by === "repo" ? (
             <SubscribeFromRepo
-              repo={catalog.repo}
+              repo={summary?.provenance ?? catalog.repo}
               label="Subscribe to install"
             />
           ) : scope && target ? (

--- a/ui/src/pages/available-package.tsx
+++ b/ui/src/pages/available-package.tsx
@@ -3,7 +3,7 @@ import { commands, type PackageView, type Scope } from "@/bindings";
 import { MarkdownView } from "@/components/markdown-view";
 import { AvailableAside } from "@/components/marketplaces/available-aside";
 import { DestinationSelect } from "@/components/marketplaces/destination-select";
-import { SubscribeDialog } from "@/components/marketplaces/subscribe-dialog";
+import { SubscribeFromRepo } from "@/components/marketplaces/subscribe-from-repo";
 import { useCatalog } from "@/components/marketplaces/use-catalog";
 import { PageHeader } from "@/components/page-header";
 import { FindingLine } from "@/components/safety-findings";
@@ -41,7 +41,6 @@ function AvailablePackage({ availableRef }: { availableRef: AvailableRef }) {
   const [view, setView] = useState<PackageView | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [destination, setDestination] = useState<Scope | null>(null);
-  const [subscribeOpen, setSubscribeOpen] = useState(false);
 
   useEffect(() => {
     if (!ready) return;
@@ -110,7 +109,12 @@ function AvailablePackage({ availableRef }: { availableRef: AvailableRef }) {
           </>
         }
         action={
-          catalog.by === "subscription" && scope && target ? (
+          catalog.by === "repo" ? (
+            <SubscribeFromRepo
+              repo={catalog.repo}
+              label="Subscribe to install"
+            />
+          ) : scope && target ? (
             <>
               <DestinationSelect
                 browsing={scope}
@@ -121,21 +125,7 @@ function AvailablePackage({ availableRef }: { availableRef: AvailableRef }) {
                 {busy ? "Installing…" : "Install"}
               </Button>
             </>
-          ) : (
-            <>
-              <Button onClick={() => setSubscribeOpen(true)}>
-                Subscribe to install
-              </Button>
-              {subscribeOpen && catalog.by === "repo" ? (
-                <SubscribeDialog
-                  key={catalog.repo}
-                  open
-                  onOpenChange={setSubscribeOpen}
-                  initialReference={catalog.repo}
-                />
-              ) : null}
-            </>
-          )
+          ) : null
         }
       />
       <div className="min-h-0 flex-1 overflow-y-auto">

--- a/ui/src/pages/available-package.tsx
+++ b/ui/src/pages/available-package.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { commands, type PackageView, type Scope } from "@/bindings";
 import { MarkdownView } from "@/components/markdown-view";
 import { AvailableAside } from "@/components/marketplaces/available-aside";
+import { CatalogFilePreview } from "@/components/marketplaces/catalog-file-preview";
 import { DestinationSelect } from "@/components/marketplaces/destination-select";
 import { RepoAction } from "@/components/marketplaces/repo-action";
 import { useCatalog } from "@/components/marketplaces/use-catalog";
@@ -11,6 +12,7 @@ import { TagBadges } from "@/components/tag-badge";
 import { Button } from "@/components/ui/button";
 import { kindIcon } from "@/lib/kind-icon";
 import { kindLabel, packageDisplayName } from "@/lib/labels";
+import { latestOnly } from "@/lib/latest";
 import { PAGE_BODY, WIDE_CONTENT_WIDTH } from "@/lib/layout";
 import { cn } from "@/lib/utils";
 import { catalogKey, useMarketplacesStore } from "@/stores/marketplaces";
@@ -42,14 +44,24 @@ function AvailablePackage({ availableRef }: { availableRef: AvailableRef }) {
   const [error, setError] = useState<string | null>(null);
   const [destination, setDestination] = useState<Scope | null>(null);
 
+  const [selectedFile, setSelectedFile] = useState<string | null>(null);
+  // The address can change under an in-flight read — a repository page
+  // carrying on as the subscription it just gained — and the older answer
+  // must not land on top of the newer one.
+  const latest = useRef(latestOnly());
+
   useEffect(() => {
     if (!ready) return;
     setView(null);
     setError(null);
-    void commands.marketplacePackagePreview(catalog, kind, name).then((r) => {
-      if (r.status === "ok") setView(r.data);
-      else setError(r.error);
-    });
+    setSelectedFile(null);
+    void latest
+      .current(commands.marketplacePackagePreview(catalog, kind, name))
+      .then((r) => {
+        if (!r) return;
+        if (r.status === "ok") setView(r.data);
+        else setError(r.error);
+      });
   }, [catalog, ready, kind, name]);
 
   const Icon = kindIcon(kind);
@@ -143,7 +155,16 @@ function AvailablePackage({ availableRef }: { availableRef: AvailableRef }) {
                   {shownError}
                 </p>
               ) : null}
-              {view?.preview.readme ? (
+              {view && selectedFile ? (
+                <section>
+                  <CatalogFilePreview
+                    catalog={catalog}
+                    kind={kind}
+                    name={name}
+                    path={selectedFile}
+                  />
+                </section>
+              ) : view?.preview.readme ? (
                 <section>
                   <MarkdownView source={view.preview.readme} />
                 </section>
@@ -168,7 +189,13 @@ function AvailablePackage({ availableRef }: { availableRef: AvailableRef }) {
                 </section>
               ) : null}
             </div>
-            <AvailableAside catalog={catalog} repo={repo} view={view} />
+            <AvailableAside
+              catalog={catalog}
+              repo={repo}
+              view={view}
+              selectedFile={selectedFile}
+              onSelectFile={setSelectedFile}
+            />
           </div>
         </div>
       </div>

--- a/ui/src/pages/bundle-detail.tsx
+++ b/ui/src/pages/bundle-detail.tsx
@@ -5,7 +5,7 @@ import {
   memberKey,
 } from "@/components/marketplaces/bundle-member-row";
 import { DestinationSelect } from "@/components/marketplaces/destination-select";
-import { SubscribeFromRepo } from "@/components/marketplaces/subscribe-from-repo";
+import { RepoAction } from "@/components/marketplaces/repo-action";
 import { useCatalog } from "@/components/marketplaces/use-catalog";
 import { PageHeader } from "@/components/page-header";
 import { Button } from "@/components/ui/button";
@@ -117,9 +117,10 @@ function BundleDetail({ bundleRef }: { bundleRef: BundleRef }) {
               Install all
             </Button>
           ) : catalog.by === "repo" ? (
-            <SubscribeFromRepo
-              repo={summary?.provenance ?? catalog.repo}
-              label="Subscribe to install"
+            <RepoAction
+              repo={catalog.repo}
+              summary={summary}
+              subscribeLabel="Subscribe to install"
             />
           ) : null
         }

--- a/ui/src/pages/bundle-detail.tsx
+++ b/ui/src/pages/bundle-detail.tsx
@@ -5,7 +5,7 @@ import {
   memberKey,
 } from "@/components/marketplaces/bundle-member-row";
 import { DestinationSelect } from "@/components/marketplaces/destination-select";
-import { SubscribeDialog } from "@/components/marketplaces/subscribe-dialog";
+import { SubscribeFromRepo } from "@/components/marketplaces/subscribe-from-repo";
 import { useCatalog } from "@/components/marketplaces/use-catalog";
 import { PageHeader } from "@/components/page-header";
 import { Button } from "@/components/ui/button";
@@ -38,7 +38,6 @@ function BundleDetail({ bundleRef }: { bundleRef: BundleRef }) {
   const busy = useMarketplacesStore((s) => s.busy);
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [destination, setDestination] = useState<Scope | null>(null);
-  const [subscribeOpen, setSubscribeOpen] = useState(false);
 
   useEffect(() => {
     if (ready) void loadBundle(catalog, bundle);
@@ -112,21 +111,12 @@ function BundleDetail({ bundleRef }: { bundleRef: BundleRef }) {
             <Button disabled={busy || !detail} onClick={() => installItems([])}>
               Install all
             </Button>
-          ) : (
-            <>
-              <Button onClick={() => setSubscribeOpen(true)}>
-                Subscribe to install
-              </Button>
-              {subscribeOpen && catalog.by === "repo" ? (
-                <SubscribeDialog
-                  key={catalog.repo}
-                  open
-                  onOpenChange={setSubscribeOpen}
-                  initialReference={catalog.repo}
-                />
-              ) : null}
-            </>
-          )
+          ) : catalog.by === "repo" ? (
+            <SubscribeFromRepo
+              repo={catalog.repo}
+              label="Subscribe to install"
+            />
+          ) : null
         }
       />
       <div className="min-h-0 flex-1 overflow-y-auto">

--- a/ui/src/pages/bundle-detail.tsx
+++ b/ui/src/pages/bundle-detail.tsx
@@ -1,22 +1,36 @@
 import { useEffect, useState } from "react";
-import type { Scope } from "@/bindings";
+import type { ItemKind, Scope } from "@/bindings";
+import {
+  BundleMemberLine,
+  memberKey,
+} from "@/components/marketplaces/bundle-member-row";
 import { DestinationSelect } from "@/components/marketplaces/destination-select";
+import { SubscribeDialog } from "@/components/marketplaces/subscribe-dialog";
+import { useCatalog } from "@/components/marketplaces/use-catalog";
 import { PageHeader } from "@/components/page-header";
-import { StatusDot } from "@/components/status-dot";
 import { Button } from "@/components/ui/button";
-import { Checkbox } from "@/components/ui/checkbox";
-import { kindIcon } from "@/lib/kind-icon";
-import { kindLabel, packageDisplayName } from "@/lib/labels";
 import { CONTENT_WIDTH, PAGE_BODY } from "@/lib/layout";
 import { cn } from "@/lib/utils";
-import { marketKey, useMarketplacesStore } from "@/stores/marketplaces";
-import { useNavStore } from "@/stores/nav";
+import {
+  catalogKey,
+  catalogLabel,
+  useMarketplacesStore,
+} from "@/stores/marketplaces";
+import { type BundleRef, useNavStore } from "@/stores/nav";
 
 /** One curated set: install the whole thing as a set that keeps itself
  * whole, or pick members to install as your own choices. Both go through
- * the normal preview and safety gate. */
+ * the normal preview and safety gate. From a repository nobody subscribes
+ * to yet, the members are listed and Subscribe is the one action. */
 export function BundleDetailPage() {
   const bundleRef = useNavStore((s) => s.bundleRef);
+  if (!bundleRef) return null;
+  return <BundleDetail bundleRef={bundleRef} />;
+}
+
+function BundleDetail({ bundleRef }: { bundleRef: BundleRef }) {
+  const { bundle } = bundleRef;
+  const { catalog, error: reachError, ready } = useCatalog(bundleRef.catalog);
   const bundles = useMarketplacesStore((s) => s.bundles);
   const readErrors = useMarketplacesStore((s) => s.readErrors);
   const loadBundle = useMarketplacesStore((s) => s.loadBundle);
@@ -24,57 +38,54 @@ export function BundleDetailPage() {
   const busy = useMarketplacesStore((s) => s.busy);
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [destination, setDestination] = useState<Scope | null>(null);
+  const [subscribeOpen, setSubscribeOpen] = useState(false);
 
   useEffect(() => {
-    if (!bundleRef) return;
-    void loadBundle(bundleRef.scope, bundleRef.source, bundleRef.bundle);
-  }, [bundleRef, loadBundle]);
+    if (ready) void loadBundle(catalog, bundle);
+  }, [catalog, ready, bundle, loadBundle]);
 
-  if (!bundleRef) return null;
-  const { scope, source, bundle } = bundleRef;
-  const detail = bundles[`${marketKey(scope, source)}::${bundle}`];
-  const readError = readErrors[`${marketKey(scope, source)}::${bundle}`];
+  const key = `${catalogKey(catalog)}::${bundle}`;
+  const detail = bundles[key];
+  const readError = reachError ?? readErrors[key];
+  const subscribed = catalog.by === "subscription" ? catalog : null;
+  const scope = subscribed?.scope ?? null;
   const target = destination ?? scope;
-  const redirected = target !== scope ? target : null;
+  const redirected = target && scope && target !== scope ? target : null;
 
-  const memberKey = (kind: string, name: string) => `${kind}:${name}`;
   const toggleMember = (kind: string, name: string) => {
     setSelected((prev) => {
       const next = new Set(prev);
-      const key = memberKey(kind, name);
-      if (next.has(key)) next.delete(key);
-      else next.add(key);
+      const id = memberKey(kind, name);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
       return next;
     });
   };
 
   // The member list re-reads after any install, so a row flips to
   // Installed the moment it is.
-  const reload = () => loadBundle(scope, source, bundle);
-  const installAll = () =>
+  const reload = () => loadBundle(catalog, bundle);
+  const installItems = (items: { kind: ItemKind; name: string }[]) => {
+    if (!subscribed) return;
     void install({
-      scope,
-      source,
-      items: [],
-      bundle,
+      scope: subscribed.scope,
+      source: subscribed.source,
+      items: items.map((m) => ({ kind: m.kind, name: m.name })),
+      bundle: items.length === 0 ? bundle : null,
       destination: redirected,
     }).then((ok) => {
-      if (ok) void reload();
+      if (ok) {
+        setSelected(new Set());
+        void reload();
+      }
     });
+  };
   const installSelected = () => {
     if (!detail) return;
-    const items = detail.members
-      .filter((m) => selected.has(memberKey(m.kind, m.name)))
-      .map((m) => ({ kind: m.kind, name: m.name }));
-    if (items.length === 0) return;
-    void install({ scope, source, items, destination: redirected }).then(
-      (ok) => {
-        if (ok) {
-          setSelected(new Set());
-          void reload();
-        }
-      },
+    const items = detail.members.filter((m) =>
+      selected.has(memberKey(m.kind, m.name)),
     );
+    if (items.length > 0) installItems(items);
   };
 
   return (
@@ -86,7 +97,10 @@ export function BundleDetailPage() {
             <>
               {detail.description ? <p>{detail.description}</p> : null}
               <p className="mt-1 text-xs">
-                {[detail.version ? `v${detail.version}` : null, source]
+                {[
+                  detail.version ? `v${detail.version}` : null,
+                  catalogLabel(catalog),
+                ]
                   .filter(Boolean)
                   .join(" · ")}
               </p>
@@ -94,9 +108,25 @@ export function BundleDetailPage() {
           ) : null
         }
         action={
-          <Button disabled={busy || !detail} onClick={installAll}>
-            Install all
-          </Button>
+          subscribed ? (
+            <Button disabled={busy || !detail} onClick={() => installItems([])}>
+              Install all
+            </Button>
+          ) : (
+            <>
+              <Button onClick={() => setSubscribeOpen(true)}>
+                Subscribe to install
+              </Button>
+              {subscribeOpen && catalog.by === "repo" ? (
+                <SubscribeDialog
+                  key={catalog.repo}
+                  open
+                  onOpenChange={setSubscribeOpen}
+                  initialReference={catalog.repo}
+                />
+              ) : null}
+            </>
+          )
         }
       />
       <div className="min-h-0 flex-1 overflow-y-auto">
@@ -116,102 +146,36 @@ export function BundleDetailPage() {
             ) : (
               <>
                 <div className="divide-y rounded-lg border">
-                  {detail.members.map((member) => {
-                    const Icon = kindIcon(member.kind);
-                    const installable = member.state === "available";
-                    const id = `member-${memberKey(member.kind, member.name)}`;
-                    return (
-                      <label
-                        key={memberKey(member.kind, member.name)}
-                        htmlFor={id}
-                        className={cn(
-                          "flex items-center gap-3 px-4 py-2.5",
-                          installable ? "cursor-pointer" : "opacity-80",
-                        )}
-                      >
-                        <Checkbox
-                          id={id}
-                          checked={selected.has(
-                            memberKey(member.kind, member.name),
-                          )}
-                          disabled={!installable}
-                          onCheckedChange={() =>
-                            toggleMember(member.kind, member.name)
-                          }
-                        />
-                        <Icon className="size-4 shrink-0 text-muted-foreground" />
-                        <span className="min-w-0 flex-1 truncate font-medium">
-                          {packageDisplayName(member)}
-                        </span>
-                        <span className="w-24 text-xs text-muted-foreground">
-                          {kindLabel(member.kind)}
-                        </span>
-                        <span className="w-32 text-right text-xs">
-                          {member.state === "installed" ? (
-                            <span className="text-muted-foreground">
-                              Installed
-                            </span>
-                          ) : member.state === "held-back-by-safety" ? (
-                            <span className="text-warning">Held back</span>
-                          ) : member.state === "not-offered" ? (
-                            <span className="text-muted-foreground">
-                              No longer offered
-                            </span>
-                          ) : member.state === "removed-by-you" ? (
-                            <span className="inline-flex items-center gap-2">
-                              <span className="text-muted-foreground">
-                                Removed by you
-                              </span>
-                              <Button
-                                size="sm"
-                                variant="outline"
-                                disabled={busy}
-                                onClick={(e) => {
-                                  e.preventDefault();
-                                  void install({
-                                    scope,
-                                    source,
-                                    items: [
-                                      {
-                                        kind: member.kind,
-                                        name: member.name,
-                                      },
-                                    ],
-                                    destination: redirected,
-                                  }).then((ok) => {
-                                    if (ok) void reload();
-                                  });
-                                }}
-                              >
-                                Restore
-                              </Button>
-                            </span>
-                          ) : (
-                            <StatusDot
-                              tone="good"
-                              className="inline-block"
-                              title="Available"
-                            />
-                          )}
-                        </span>
-                      </label>
-                    );
-                  })}
+                  {detail.members.map((member) => (
+                    <BundleMemberLine
+                      key={memberKey(member.kind, member.name)}
+                      member={member}
+                      selectable={subscribed !== null}
+                      selected={selected.has(
+                        memberKey(member.kind, member.name),
+                      )}
+                      busy={busy}
+                      onToggle={() => toggleMember(member.kind, member.name)}
+                      onRestore={() => installItems([member])}
+                    />
+                  ))}
                 </div>
-                <div className="mt-4 flex items-center justify-end gap-2">
-                  <DestinationSelect
-                    browsing={scope}
-                    value={target}
-                    onChange={setDestination}
-                  />
-                  <Button
-                    variant="outline"
-                    disabled={busy || selected.size === 0}
-                    onClick={installSelected}
-                  >
-                    Install {selected.size} selected
-                  </Button>
-                </div>
+                {subscribed && scope && target ? (
+                  <div className="mt-4 flex items-center justify-end gap-2">
+                    <DestinationSelect
+                      browsing={scope}
+                      value={target}
+                      onChange={setDestination}
+                    />
+                    <Button
+                      variant="outline"
+                      disabled={busy || selected.size === 0}
+                      onClick={installSelected}
+                    >
+                      Install {selected.size} selected
+                    </Button>
+                  </div>
+                ) : null}
               </>
             )}
           </div>

--- a/ui/src/pages/bundle-detail.tsx
+++ b/ui/src/pages/bundle-detail.tsx
@@ -12,7 +12,7 @@ import { Button } from "@/components/ui/button";
 import { CONTENT_WIDTH, PAGE_BODY } from "@/lib/layout";
 import { cn } from "@/lib/utils";
 import {
-  catalogKey,
+  bundleKey,
   catalogLabel,
   useMarketplacesStore,
 } from "@/stores/marketplaces";
@@ -30,7 +30,12 @@ export function BundleDetailPage() {
 
 function BundleDetail({ bundleRef }: { bundleRef: BundleRef }) {
   const { bundle } = bundleRef;
-  const { catalog, error: reachError, ready } = useCatalog(bundleRef.catalog);
+  const {
+    catalog,
+    summary,
+    error: reachError,
+    ready,
+  } = useCatalog(bundleRef.catalog);
   const bundles = useMarketplacesStore((s) => s.bundles);
   const readErrors = useMarketplacesStore((s) => s.readErrors);
   const loadBundle = useMarketplacesStore((s) => s.loadBundle);
@@ -43,7 +48,7 @@ function BundleDetail({ bundleRef }: { bundleRef: BundleRef }) {
     if (ready) void loadBundle(catalog, bundle);
   }, [catalog, ready, bundle, loadBundle]);
 
-  const key = `${catalogKey(catalog)}::${bundle}`;
+  const key = bundleKey(catalog, bundle);
   const detail = bundles[key];
   const readError = reachError ?? readErrors[key];
   const subscribed = catalog.by === "subscription" ? catalog : null;
@@ -113,7 +118,7 @@ function BundleDetail({ bundleRef }: { bundleRef: BundleRef }) {
             </Button>
           ) : catalog.by === "repo" ? (
             <SubscribeFromRepo
-              repo={catalog.repo}
+              repo={summary?.provenance ?? catalog.repo}
               label="Subscribe to install"
             />
           ) : null

--- a/ui/src/pages/marketplace-detail.tsx
+++ b/ui/src/pages/marketplace-detail.tsx
@@ -1,10 +1,13 @@
-import { useEffect } from "react";
+import { useCallback, useEffect } from "react";
 import type { Catalog } from "@/bindings";
 import { AboutSection } from "@/components/marketplaces/about-section";
 import { BundleCards } from "@/components/marketplaces/bundle-cards";
 import { DetailHeader } from "@/components/marketplaces/detail-header";
 import { PackagesTable } from "@/components/marketplaces/packages-table";
-import { useCatalog } from "@/components/marketplaces/use-catalog";
+import {
+  useCachedRead,
+  useCatalog,
+} from "@/components/marketplaces/use-catalog";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { PAGE_BODY, PAGE_GUTTER, WIDE_CONTENT_WIDTH } from "@/lib/layout";
@@ -42,7 +45,8 @@ function MarketplaceDetail({ requested }: { requested: Catalog }) {
             marketKey(r.scope, r.name) === catalogKey(catalog),
         )
       : undefined;
-  const offered = packages[catalogKey(catalog)] ?? [];
+  const cached = packages[catalogKey(catalog)];
+  const offered = cached ?? [];
   const packagesError = useMarketplacesStore(
     (s) => s.readErrors[readErrorKey(catalogKey(catalog), "packages")],
   );
@@ -50,9 +54,11 @@ function MarketplaceDetail({ requested }: { requested: Catalog }) {
   useEffect(() => {
     void load();
   }, [load]);
-  useEffect(() => {
-    if (ready) void loadPackages(catalog);
-  }, [catalog, ready, loadPackages]);
+  const readPackages = useCallback(
+    () => loadPackages(catalog),
+    [loadPackages, catalog],
+  );
+  useCachedRead(cached !== undefined, !!packagesError, ready, readPackages);
 
   return (
     <div className="flex h-full flex-col">

--- a/ui/src/pages/marketplace-detail.tsx
+++ b/ui/src/pages/marketplace-detail.tsx
@@ -12,6 +12,7 @@ import { cn } from "@/lib/utils";
 import {
   catalogKey,
   marketKey,
+  readErrorKey,
   useMarketplacesStore,
 } from "@/stores/marketplaces";
 import { useNavStore } from "@/stores/nav";
@@ -42,6 +43,9 @@ function MarketplaceDetail({ requested }: { requested: Catalog }) {
         )
       : undefined;
   const offered = packages[catalogKey(catalog)] ?? [];
+  const packagesError = useMarketplacesStore(
+    (s) => s.readErrors[readErrorKey(catalogKey(catalog), "packages")],
+  );
 
   useEffect(() => {
     void load();
@@ -104,7 +108,14 @@ function MarketplaceDetail({ requested }: { requested: Catalog }) {
                   <BundleCards catalog={catalog} offered={offered} />
                 </TabsContent>
                 <TabsContent value="packages">
-                  {offered.length === 0 ? (
+                  {packagesError ? (
+                    <p
+                      className="py-16 text-center text-sm text-critical"
+                      role="alert"
+                    >
+                      Its packages can't be read right now — {packagesError}
+                    </p>
+                  ) : offered.length === 0 ? (
                     <p className="py-16 text-center text-sm text-muted-foreground">
                       Nothing to list yet — this marketplace hasn't been
                       fetched, or offers no packages.

--- a/ui/src/pages/marketplace-detail.tsx
+++ b/ui/src/pages/marketplace-detail.tsx
@@ -1,178 +1,132 @@
-import { MoreHorizontal, RefreshCw } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
+import type { Catalog } from "@/bindings";
 import { AboutSection } from "@/components/marketplaces/about-section";
 import { BundleCards } from "@/components/marketplaces/bundle-cards";
+import { DetailHeader } from "@/components/marketplaces/detail-header";
 import { PackagesTable } from "@/components/marketplaces/packages-table";
-import { UnsubscribeDialog } from "@/components/marketplaces/unsubscribe-dialog";
-import { PageHeader } from "@/components/page-header";
+import { useCatalog } from "@/components/marketplaces/use-catalog";
 import { Button } from "@/components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { Switch } from "@/components/ui/switch";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { PAGE_BODY, PAGE_GUTTER, WIDE_CONTENT_WIDTH } from "@/lib/layout";
 import { cn } from "@/lib/utils";
-import { marketKey, useMarketplacesStore } from "@/stores/marketplaces";
+import {
+  catalogKey,
+  marketKey,
+  useMarketplacesStore,
+} from "@/stores/marketplaces";
 import { useNavStore } from "@/stores/nav";
 
-/** One subscription's own page: what it offers and what it says about
- * itself. Nested under Marketplaces — the breadcrumb strip above carries
- * the way back. */
+/** One marketplace's own page: what it offers and what it says about
+ * itself — a subscription, or a repository opened from the Community tab
+ * before subscribing, on the same surface. Nested under Marketplaces — the
+ * breadcrumb strip above carries the way back. */
 export function MarketplaceDetailPage() {
   const marketplaceRef = useNavStore((s) => s.marketplaceRef);
+  if (!marketplaceRef) return null;
+  return <MarketplaceDetail requested={marketplaceRef} />;
+}
+
+function MarketplaceDetail({ requested }: { requested: Catalog }) {
+  const { catalog, summary, error, ready, retry } = useCatalog(requested);
   const rows = useMarketplacesStore((s) => s.rows);
   const packages = useMarketplacesStore((s) => s.packages);
   const load = useMarketplacesStore((s) => s.load);
   const loadPackages = useMarketplacesStore((s) => s.loadPackages);
-  const toggle = useMarketplacesStore((s) => s.toggle);
-  const checkForUpdates = useMarketplacesStore((s) => s.checkForUpdates);
-  const busy = useMarketplacesStore((s) => s.busy);
-  const [unsubscribeOpen, setUnsubscribeOpen] = useState(false);
 
-  const key = marketplaceRef
-    ? marketKey(marketplaceRef.scope, marketplaceRef.source)
-    : null;
-  const row = marketplaceRef
-    ? rows.find(
-        (r) =>
-          r.name === marketplaceRef.source &&
-          marketKey(r.scope, r.name) === key,
-      )
-    : undefined;
-  const offered = key ? (packages[key] ?? []) : [];
+  const row =
+    catalog.by === "subscription"
+      ? rows.find(
+          (r) =>
+            r.name === catalog.source &&
+            marketKey(r.scope, r.name) === catalogKey(catalog),
+        )
+      : undefined;
+  const offered = packages[catalogKey(catalog)] ?? [];
 
   useEffect(() => {
     void load();
   }, [load]);
   useEffect(() => {
-    if (!marketplaceRef) return;
-    void loadPackages(marketplaceRef.scope, marketplaceRef.source);
-  }, [marketplaceRef, loadPackages]);
-
-  if (!marketplaceRef) return null;
-  const { scope, source } = marketplaceRef;
-  const meta = row?.meta;
-  const metaLine = [
-    row?.repo ?? row?.path,
-    row?.commit ? `@ ${row.commit.slice(0, 7)}` : null,
-    meta?.license,
-    meta?.author ? `by ${meta.author}` : null,
-  ].filter(Boolean);
+    if (ready) void loadPackages(catalog);
+  }, [catalog, ready, loadPackages]);
 
   return (
     <div className="flex h-full flex-col">
-      <PageHeader
-        wide
-        title={source}
-        subtitle={
-          <>
-            {meta?.description ? <p>{meta.description}</p> : null}
-            {metaLine.length > 0 ? (
-              <p className="mt-1 font-mono text-xs">{metaLine.join(" · ")}</p>
-            ) : null}
-          </>
-        }
-        action={
-          <>
-            {row ? (
-              <Switch
-                checked={row.enabled}
-                onCheckedChange={(enabled) =>
-                  void toggle(scope, source, enabled)
-                }
-                aria-label={row.enabled ? "Turn off" : "Turn on"}
-              />
-            ) : null}
+      <DetailHeader
+        requested={requested}
+        catalog={catalog}
+        row={row}
+        summary={summary}
+      />
+      {error ? (
+        <div className={cn(PAGE_BODY, "pt-0")}>
+          <div className={WIDE_CONTENT_WIDTH}>
+            <p className="text-sm text-critical" role="alert">
+              This marketplace can't be reached right now — {error}
+            </p>
             <Button
+              className="mt-3"
               size="sm"
               variant="outline"
-              disabled={busy}
-              onClick={() => void checkForUpdates()}
+              onClick={retry}
             >
-              <RefreshCw className={cn("size-4", busy && "animate-spin")} />
-              Check for updates
+              Try again
             </Button>
-            <DropdownMenu>
-              <DropdownMenuTrigger
-                render={
-                  <Button
-                    size="icon-xs"
-                    variant="quiet"
-                    aria-label="More actions"
-                  >
-                    <MoreHorizontal className="size-4" />
-                  </Button>
-                }
-              />
-              <DropdownMenuContent align="end">
-                <DropdownMenuItem
-                  className="text-critical"
-                  onClick={() => setUnsubscribeOpen(true)}
-                >
-                  Unsubscribe…
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </>
-        }
-      />
-      <UnsubscribeDialog
-        open={unsubscribeOpen}
-        onOpenChange={setUnsubscribeOpen}
-        scope={scope}
-        source={source}
-      />
-      <Tabs
-        defaultValue="bundles"
-        className="flex min-h-0 flex-1 flex-col gap-0"
-      >
-        <div className={cn("pb-3", PAGE_GUTTER)}>
-          <div className={WIDE_CONTENT_WIDTH}>
-            <TabsList>
-              <TabsTrigger value="bundles">Bundles</TabsTrigger>
-              <TabsTrigger value="packages">Packages</TabsTrigger>
-              <TabsTrigger value="about">About</TabsTrigger>
-            </TabsList>
           </div>
         </div>
-        <div className="min-h-0 flex-1 overflow-y-auto">
-          <div className={cn(PAGE_BODY, "pt-0")}>
+      ) : !ready ? (
+        <p className="py-16 text-center text-sm text-muted-foreground">
+          Reaching {requested.by === "repo" ? requested.repo : ""}…
+        </p>
+      ) : (
+        <Tabs
+          defaultValue="bundles"
+          className="flex min-h-0 flex-1 flex-col gap-0"
+        >
+          <div className={cn("pb-6", PAGE_GUTTER)}>
             <div className={WIDE_CONTENT_WIDTH}>
-              <TabsContent value="bundles">
-                <BundleCards scope={scope} source={source} offered={offered} />
-              </TabsContent>
-              <TabsContent value="packages">
-                {offered.length === 0 ? (
-                  <p className="py-16 text-center text-sm text-muted-foreground">
-                    Nothing to list yet — this marketplace hasn't been fetched,
-                    or offers no packages.
-                  </p>
-                ) : (
-                  <PackagesTable
-                    entries={offered.map((pkg) => ({
-                      scope,
-                      source,
-                      row: pkg,
-                    }))}
-                    showMarketplace={false}
-                  />
-                )}
-              </TabsContent>
-              <TabsContent value="about">
-                <AboutSection
-                  scope={scope}
-                  source={source}
-                  meta={meta ?? null}
-                />
-              </TabsContent>
+              <TabsList>
+                <TabsTrigger value="bundles">Bundles</TabsTrigger>
+                <TabsTrigger value="packages">Packages</TabsTrigger>
+                <TabsTrigger value="about">About</TabsTrigger>
+              </TabsList>
             </div>
           </div>
-        </div>
-      </Tabs>
+          <div className="min-h-0 flex-1 overflow-y-auto">
+            <div className={cn(PAGE_BODY, "pt-0")}>
+              <div className={WIDE_CONTENT_WIDTH}>
+                {summary?.warning ? (
+                  <p className="mb-4 text-xs text-warning">
+                    Shown from the last download — {summary.warning}
+                  </p>
+                ) : null}
+                <TabsContent value="bundles">
+                  <BundleCards catalog={catalog} offered={offered} />
+                </TabsContent>
+                <TabsContent value="packages">
+                  {offered.length === 0 ? (
+                    <p className="py-16 text-center text-sm text-muted-foreground">
+                      Nothing to list yet — this marketplace hasn't been
+                      fetched, or offers no packages.
+                    </p>
+                  ) : (
+                    <PackagesTable
+                      entries={offered.map((pkg) => ({ catalog, row: pkg }))}
+                      showMarketplace={false}
+                    />
+                  )}
+                </TabsContent>
+                <TabsContent value="about">
+                  <AboutSection
+                    catalog={catalog}
+                    meta={row?.meta ?? summary?.meta ?? null}
+                  />
+                </TabsContent>
+              </div>
+            </div>
+          </div>
+        </Tabs>
+      )}
     </div>
   );
 }

--- a/ui/src/pages/marketplaces.tsx
+++ b/ui/src/pages/marketplaces.tsx
@@ -49,7 +49,7 @@ export function MarketplacesPage() {
         onValueChange={(value) => goToMarketplaces(value as MarketplacesTab)}
         className="flex min-h-0 flex-1 flex-col gap-0"
       >
-        <div className={cn("pb-3", PAGE_GUTTER)}>
+        <div className={cn("pb-6", PAGE_GUTTER)}>
           <div className={WIDE_CONTENT_WIDTH}>
             <TabsList>
               <TabsTrigger value="subscribed">Subscribed</TabsTrigger>

--- a/ui/src/stores/marketplaces-reads.test.ts
+++ b/ui/src/stores/marketplaces-reads.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { commands } from "@/bindings";
+import { useMarketplacesStore } from "./marketplaces";
+import {
+  catalogKey,
+  dropCatalogCaches,
+  subscription,
+} from "./marketplaces-shared";
+
+vi.mock("@/bindings", () => ({
+  commands: { marketplacePackages: vi.fn() },
+}));
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), message: vi.fn(), error: vi.fn() },
+}));
+vi.mock("./preinstall-safety", () => ({ resetPreinstallSafety: vi.fn() }));
+
+const catalog = subscription({ scope: "global" }, "kendex");
+const key = catalogKey(catalog);
+const offered = (name: string) => [
+  {
+    kind: "skill" as const,
+    name,
+    description: null,
+    tags: [],
+    bundles: [],
+    state: "available" as const,
+    collision: null,
+  },
+];
+
+describe("a read that outlives a cache drop", () => {
+  beforeEach(() => {
+    useMarketplacesStore.setState({ packages: {}, readErrors: {} });
+    vi.mocked(commands.marketplacePackages).mockReset();
+  });
+
+  it("is not stored, and the slot is read again", async () => {
+    let settleOld: (value: unknown) => void = () => {};
+    vi.mocked(commands.marketplacePackages)
+      .mockImplementationOnce(
+        () => new Promise((resolve) => (settleOld = resolve)) as never,
+      )
+      .mockResolvedValueOnce({ status: "ok", data: offered("after-refresh") });
+
+    const pending = useMarketplacesStore.getState().loadPackages(catalog);
+    // Check for updates lands while the read is still in flight.
+    dropCatalogCaches((partial) => useMarketplacesStore.setState(partial));
+    settleOld({ status: "ok", data: offered("old-checkout") });
+    await pending;
+
+    expect(commands.marketplacePackages).toHaveBeenCalledTimes(2);
+    expect(useMarketplacesStore.getState().packages[key]?.[0]?.name).toBe(
+      "after-refresh",
+    );
+  });
+});

--- a/ui/src/stores/marketplaces-reads.ts
+++ b/ui/src/stores/marketplaces-reads.ts
@@ -1,0 +1,96 @@
+// The marketplaces store's cached reads: each answer lands under its own
+// key, and each failure under its own error key, so a later success
+// elsewhere never erases why a different read produced nothing.
+import type {
+  AboutView,
+  AvailablePackage,
+  BundleDetail,
+  Catalog,
+  CatalogSummary,
+} from "@/bindings";
+import { commands } from "@/bindings";
+import {
+  bundleKey,
+  catalogKey,
+  readErrorKey,
+  without,
+} from "./marketplaces-shared";
+
+/** The slice of the store these reads write. */
+export interface ReadCaches {
+  packages: Record<string, AvailablePackage[]>;
+  summaries: Record<string, CatalogSummary>;
+  about: Record<string, AboutView>;
+  bundles: Record<string, BundleDetail>;
+  readErrors: Record<string, string>;
+}
+
+type Set = (fn: (state: ReadCaches) => Partial<ReadCaches>) => void;
+
+export function catalogReads(set: Set) {
+  return {
+    loadPackages: (catalog: Catalog) => {
+      const key = catalogKey(catalog);
+      return settle(
+        set,
+        "packages",
+        key,
+        readErrorKey(key, "packages"),
+        commands.marketplacePackages(catalog),
+      );
+    },
+    loadSummary: (catalog: Catalog) => {
+      const key = catalogKey(catalog);
+      return settle(
+        set,
+        "summaries",
+        key,
+        readErrorKey(key, "summary"),
+        commands.marketplaceSummary(catalog),
+      );
+    },
+    loadAbout: (catalog: Catalog) => {
+      const key = catalogKey(catalog);
+      return settle(
+        set,
+        "about",
+        key,
+        readErrorKey(key, "about"),
+        commands.marketplaceAbout(catalog),
+      );
+    },
+    loadBundle: (catalog: Catalog, name: string) => {
+      const key = bundleKey(catalog, name);
+      return settle(
+        set,
+        "bundles",
+        key,
+        key,
+        commands.marketplaceBundle(catalog, name),
+      );
+    },
+  };
+}
+
+async function settle<F extends Exclude<keyof ReadCaches, "readErrors">>(
+  set: Set,
+  field: F,
+  key: string,
+  errorKey: string,
+  pending: Promise<
+    | { status: "ok"; data: ReadCaches[F][string] }
+    | { status: "error"; error: string }
+  >,
+) {
+  const response = await pending;
+  if (response.status === "ok") {
+    set((state) => ({
+      [field]: { ...state[field], [key]: response.data },
+      readErrors: without(state.readErrors, errorKey),
+    }));
+  } else {
+    set((state) => ({
+      readErrors: { ...state.readErrors, [errorKey]: response.error },
+    }));
+  }
+}

--- a/ui/src/stores/marketplaces-reads.ts
+++ b/ui/src/stores/marketplaces-reads.ts
@@ -13,6 +13,7 @@ import {
   bundleKey,
   catalogKey,
   readErrorKey,
+  readGeneration,
   without,
 } from "./marketplaces-shared";
 
@@ -31,58 +32,51 @@ export function catalogReads(set: Set) {
   return {
     loadPackages: (catalog: Catalog) => {
       const key = catalogKey(catalog);
-      return settle(
-        set,
-        "packages",
-        key,
-        readErrorKey(key, "packages"),
+      return settle(set, "packages", key, readErrorKey(key, "packages"), () =>
         commands.marketplacePackages(catalog),
       );
     },
     loadSummary: (catalog: Catalog) => {
       const key = catalogKey(catalog);
-      return settle(
-        set,
-        "summaries",
-        key,
-        readErrorKey(key, "summary"),
+      return settle(set, "summaries", key, readErrorKey(key, "summary"), () =>
         commands.marketplaceSummary(catalog),
       );
     },
     loadAbout: (catalog: Catalog) => {
       const key = catalogKey(catalog);
-      return settle(
-        set,
-        "about",
-        key,
-        readErrorKey(key, "about"),
+      return settle(set, "about", key, readErrorKey(key, "about"), () =>
         commands.marketplaceAbout(catalog),
       );
     },
     loadBundle: (catalog: Catalog, name: string) => {
       const key = bundleKey(catalog, name);
-      return settle(
-        set,
-        "bundles",
-        key,
-        key,
+      return settle(set, "bundles", key, key, () =>
         commands.marketplaceBundle(catalog, name),
       );
     },
   };
 }
 
+/** A read lands only if no cache drop happened while it ran: an answer
+ * from before the drop describes a checkout that may no longer be the one
+ * installed from. A stale answer is not stored; the read is asked once
+ * more under the new generation, since the empty slot it would have
+ * filled never changed and nothing else will ask. */
 async function settle<F extends Exclude<keyof ReadCaches, "readErrors">>(
   set: Set,
   field: F,
   key: string,
   errorKey: string,
-  pending: Promise<
+  read: () => Promise<
     | { status: "ok"; data: ReadCaches[F][string] }
     | { status: "error"; error: string }
   >,
-) {
-  const response = await pending;
+): Promise<void> {
+  const began = readGeneration();
+  const response = await read();
+  if (began !== readGeneration()) {
+    return settle(set, field, key, errorKey, read);
+  }
   if (response.status === "ok") {
     set((state) => ({
       [field]: { ...state[field], [key]: response.data },

--- a/ui/src/stores/marketplaces-refresh.test.ts
+++ b/ui/src/stores/marketplaces-refresh.test.ts
@@ -1,0 +1,86 @@
+// A refresh can make a subscription readable that was not; every open
+// repository page then re-asks which subscription to carry on as.
+import { describe, expect, it, vi } from "vitest";
+import { commands, type MarketplaceRow } from "@/bindings";
+import { useMarketplacesStore } from "./marketplaces";
+import { catalogKey } from "./marketplaces-shared";
+
+vi.mock("@/bindings", () => ({
+  commands: {
+    marketplaceSubscribe: vi.fn(),
+    marketplaceUnsubscribe: vi.fn(),
+    marketplaceSummary: vi.fn(),
+    marketplacesOverview: vi.fn(),
+    sourcesRefresh: vi.fn(),
+  },
+}));
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), message: vi.fn(), error: vi.fn() },
+}));
+vi.mock("./audit", () => ({
+  useAuditStore: { getState: () => ({ refresh: vi.fn() }) },
+}));
+vi.mock("./scan", () => ({
+  useScanStore: { getState: () => ({ refresh: vi.fn() }) },
+}));
+
+const row = (repo: string, repoKey: string | null): MarketplaceRow => ({
+  scope: { scope: "global" },
+  name: "kit",
+  repo,
+  repoKey,
+  path: null,
+  rev: null,
+  commit: null,
+  enabled: true,
+  counts: null,
+  meta: null,
+  mode: null,
+});
+
+describe("a repository page whose holder could not be read", () => {
+  it("carries on as the holder once Check for updates made it readable", async () => {
+    const repoKey = catalogKey({ by: "repo", repo: "acme/kit" });
+    const bare = {
+      provenance: "acme/kit",
+      repoKey: "acme/kit",
+      commit: null,
+      meta: null,
+      mode: "discovered" as const,
+      counts: {},
+      warning: null,
+      subscription: null,
+    };
+    useMarketplacesStore.setState({
+      rows: [row("git@github.com:acme/kit.git", "acme/kit")],
+      summaries: { [repoKey]: bare },
+    });
+    vi.mocked(commands.sourcesRefresh).mockResolvedValue({
+      status: "ok",
+      data: [],
+    });
+    vi.mocked(commands.marketplacesOverview).mockResolvedValue({
+      status: "ok",
+      data: [row("git@github.com:acme/kit.git", "acme/kit")],
+    });
+    vi.mocked(commands.marketplaceSummary).mockResolvedValue({
+      status: "ok",
+      data: {
+        ...bare,
+        subscription: { scope: { scope: "global" }, source: "kit" },
+      },
+    });
+
+    await useMarketplacesStore.getState().checkForUpdates();
+    await vi.waitFor(() => {
+      expect(
+        useMarketplacesStore.getState().summaries[repoKey]?.subscription
+          ?.source,
+      ).toBe("kit");
+    });
+    expect(commands.marketplaceSummary).toHaveBeenCalledWith({
+      by: "repo",
+      repo: "acme/kit",
+    });
+  });
+});

--- a/ui/src/stores/marketplaces-shared.test.ts
+++ b/ui/src/stores/marketplaces-shared.test.ts
@@ -17,6 +17,19 @@ describe("catalog addressing", () => {
     );
   });
 
+  it("never lets a project root and alias spell a repository's key", () => {
+    // A project checked out at a relative root named "repo", subscribed to
+    // an alias that reads like a repository reference.
+    const project = subscription(
+      { scope: "project", root: "repo" },
+      "acme/kit",
+    );
+    const repo = { by: "repo" as const, repo: "acme/kit" };
+    expect(catalogKey(project)).not.toBe(catalogKey(repo));
+    expect(isRepoKey(catalogKey(project))).toBe(false);
+    expect(isRepoKey(catalogKey(repo))).toBe(true);
+  });
+
   it("never folds a repository into a subscription of the same name", () => {
     const repo = catalogKey({ by: "repo", repo: "acme/kendex" });
     expect(repo).not.toBe(

--- a/ui/src/stores/marketplaces-shared.test.ts
+++ b/ui/src/stores/marketplaces-shared.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
+  bundleKey,
   catalogKey,
   catalogLabel,
+  isRepoKey,
   marketKey,
+  readErrorKey,
   subscription,
 } from "./marketplaces-shared";
 
@@ -30,5 +33,19 @@ describe("catalog addressing", () => {
       "wshobson/agents",
     );
     expect(catalogLabel(undefined)).toBeNull();
+  });
+
+  it("tells repository keys from subscription keys", () => {
+    expect(isRepoKey(catalogKey({ by: "repo", repo: "acme/kit" }))).toBe(true);
+    expect(
+      isRepoKey(catalogKey(subscription({ scope: "global" }, "repo"))),
+    ).toBe(false);
+  });
+
+  it("keeps a set named like a read off that read's key", () => {
+    const catalog = subscription({ scope: "global" }, "kendex");
+    expect(bundleKey(catalog, "packages")).not.toBe(
+      readErrorKey(catalogKey(catalog), "packages"),
+    );
   });
 });

--- a/ui/src/stores/marketplaces-shared.test.ts
+++ b/ui/src/stores/marketplaces-shared.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import {
+  catalogKey,
+  catalogLabel,
+  marketKey,
+  subscription,
+} from "./marketplaces-shared";
+
+describe("catalog addressing", () => {
+  it("keys a subscription the way its rows were cached", () => {
+    const scope = { scope: "project" as const, root: "/work/acme" };
+    expect(catalogKey(subscription(scope, "kendex"))).toBe(
+      marketKey(scope, "kendex"),
+    );
+  });
+
+  it("never folds a repository into a subscription of the same name", () => {
+    const repo = catalogKey({ by: "repo", repo: "acme/kendex" });
+    expect(repo).not.toBe(
+      catalogKey(subscription({ scope: "global" }, "acme/kendex")),
+    );
+    expect(repo).toBe(catalogKey({ by: "repo", repo: "acme/kendex" }));
+  });
+
+  it("labels a catalog by its alias or its repository", () => {
+    expect(catalogLabel(subscription({ scope: "global" }, "kendex"))).toBe(
+      "kendex",
+    );
+    expect(catalogLabel({ by: "repo", repo: "wshobson/agents" })).toBe(
+      "wshobson/agents",
+    );
+    expect(catalogLabel(undefined)).toBeNull();
+  });
+});

--- a/ui/src/stores/marketplaces-shared.ts
+++ b/ui/src/stores/marketplaces-shared.ts
@@ -56,6 +56,20 @@ export const rowSubscribed = (
 export const isRepoKey = (key: string): boolean =>
   key.startsWith(JSON.stringify(["repo", ""]).slice(0, -3));
 
+/** Every repository catalog with a cached summary — the pages to re-ask
+ * after a refresh may have made a holder readable. The key is the way
+ * back to the catalog, read in place so the old summary stands until the
+ * new one lands. */
+export const cachedRepoCatalogs = (
+  summaries: Record<string, unknown>,
+): Catalog[] =>
+  Object.keys(summaries)
+    .filter(isRepoKey)
+    .map((key) => ({
+      by: "repo",
+      repo: (JSON.parse(key) as [string, string])[1],
+    }));
+
 /** One curated set's cache and error key, in its own namespace so a set
  * named like a read ("packages") can never land on that read's key. */
 export const bundleKey = (catalog: Catalog, name: string): string =>

--- a/ui/src/stores/marketplaces-shared.ts
+++ b/ui/src/stores/marketplaces-shared.ts
@@ -30,6 +30,18 @@ export const catalogKey = (catalog: Catalog): string =>
 export const subscribedKeys = (rows: MarketplaceRow[]): Set<string> =>
   new Set(rows.flatMap((row) => (row.repoKey ? [row.repoKey] : [])));
 
+/** The subscription the live list already declares for a repository the
+ * page is browsing bare — `summary` left it bare because that subscription
+ * is turned off or unreadable, so Subscribe would be refused as a
+ * duplicate. An enabled one outranks a disabled one. */
+export const declaredHolder = (
+  rows: MarketplaceRow[],
+  repoKey: string,
+): MarketplaceRow | null =>
+  rows.find((row) => row.repoKey === repoKey && row.enabled) ??
+  rows.find((row) => row.repoKey === repoKey) ??
+  null;
+
 /** A Community row's Subscribed marker. The directory's own flag is only
  * a stand-in until the live subscription list has loaded; after that the
  * list alone decides, so an unsubscribe clears the marker as surely as a

--- a/ui/src/stores/marketplaces-shared.ts
+++ b/ui/src/stores/marketplaces-shared.ts
@@ -163,17 +163,21 @@ export function dropSummariesHeldBy(
 }
 
 /** What a page browsing a bare repository offers, decided from the live
- * subscription list. Until an overview has succeeded the list is not to
- * be trusted, and Subscribe — which a declared repository would refuse —
- * is not offered on a guess. */
+ * subscription list and the repository's canonical key. Until an overview
+ * has succeeded the list is not to be trusted, and until the key is known
+ * — from the directory's row or the summary, never the requested spelling,
+ * which may differ in case — nothing can be matched: either way Subscribe,
+ * which a declared repository would refuse, is not offered on a guess. */
 export type RepoActionKind = "checking" | "subscribe" | "turn-on" | "refresh";
 
 export function repoAction(
   rows: MarketplaceRow[],
   rowsCurrent: boolean,
-  repoKey: string,
+  repoKey: string | null,
 ): { kind: RepoActionKind; holder: MarketplaceRow | null } {
-  if (!rowsCurrent) return { kind: "checking", holder: null };
+  if (!rowsCurrent || repoKey === null) {
+    return { kind: "checking", holder: null };
+  }
   const holder = declaredHolder(rows, repoKey);
   if (!holder) return { kind: "subscribe", holder: null };
   return { kind: holder.enabled ? "refresh" : "turn-on", holder };

--- a/ui/src/stores/marketplaces-shared.ts
+++ b/ui/src/stores/marketplaces-shared.ts
@@ -116,21 +116,34 @@ export async function openLead(scope: Scope, source: string, lead: string) {
   });
 }
 
-/** Every summary about one repository — however it was requested, and
- * whether or not it is carried by a subscription — so a toggled holder is
- * re-asked in both directions: turned off, the page falls back to the bare
- * repository; turned on, it carries on again. */
-export function dropSummariesForRepo(
+/** Every summary about one subscription's repository — matched by the
+ * canonical key, however the declaration spells the repository, or by the
+ * subscription itself — so a toggled holder is re-asked in both
+ * directions: turned off, the page falls back to the bare repository;
+ * turned on, it carries on again. */
+export function dropSummariesHeldBy(
   set: (
     fn: (state: { summaries: Record<string, CatalogSummary> }) => object,
   ) => void,
-  repoKey: string,
+  rows: MarketplaceRow[],
+  scope: Scope,
+  source: string,
 ) {
+  const held = marketKey(scope, source);
+  const repoKey =
+    rows.find((row) => marketKey(row.scope, row.name) === held)?.repoKey ??
+    null;
   set((state) => ({
     summaries: Object.fromEntries(
-      Object.entries(state.summaries).filter(
-        ([key, summary]) => !isRepoKey(key) || summary.provenance !== repoKey,
-      ),
+      Object.entries(state.summaries).filter(([key, summary]) => {
+        if (!isRepoKey(key)) return true;
+        const sameRepo = repoKey !== null && summary.repoKey === repoKey;
+        const carried =
+          summary.subscription !== null &&
+          marketKey(summary.subscription.scope, summary.subscription.source) ===
+            held;
+        return !sameRepo && !carried;
+      }),
     ),
   }));
 }

--- a/ui/src/stores/marketplaces-shared.ts
+++ b/ui/src/stores/marketplaces-shared.ts
@@ -95,6 +95,7 @@ export function without<T>(
  * kept: it only says which subscription the page carries on as, and
  * dropping it would blank an open page behind a second fetch. */
 export function dropCatalogCaches(set: (partial: object) => void) {
+  generation += 1;
   set({ packages: {}, bundles: {}, about: {}, readErrors: {} });
   resetPreinstallSafety();
 }
@@ -115,27 +116,44 @@ export async function openLead(scope: Scope, source: string, lead: string) {
   });
 }
 
-/** A repository page carried on as this subscription re-asks which
- * subscription to carry on as: turned off, the backend passes it over and
- * the page falls back to the bare repository; turned on, it carries on
- * again. */
-export function dropSummariesCarriedBy(
+/** Every summary about one repository — however it was requested, and
+ * whether or not it is carried by a subscription — so a toggled holder is
+ * re-asked in both directions: turned off, the page falls back to the bare
+ * repository; turned on, it carries on again. */
+export function dropSummariesForRepo(
   set: (
     fn: (state: { summaries: Record<string, CatalogSummary> }) => object,
   ) => void,
-  scope: Scope,
-  source: string,
+  repoKey: string,
 ) {
-  const toggled = marketKey(scope, source);
   set((state) => ({
     summaries: Object.fromEntries(
       Object.entries(state.summaries).filter(
-        ([key, summary]) =>
-          !isRepoKey(key) ||
-          !summary.subscription ||
-          marketKey(summary.subscription.scope, summary.subscription.source) !==
-            toggled,
+        ([key, summary]) => !isRepoKey(key) || summary.provenance !== repoKey,
       ),
     ),
   }));
 }
+
+/** What a page browsing a bare repository offers, decided from the live
+ * subscription list. Until an overview has succeeded the list is not to
+ * be trusted, and Subscribe — which a declared repository would refuse —
+ * is not offered on a guess. */
+export type RepoActionKind = "checking" | "subscribe" | "turn-on" | "refresh";
+
+export function repoAction(
+  rows: MarketplaceRow[],
+  rowsCurrent: boolean,
+  repoKey: string,
+): { kind: RepoActionKind; holder: MarketplaceRow | null } {
+  if (!rowsCurrent) return { kind: "checking", holder: null };
+  const holder = declaredHolder(rows, repoKey);
+  if (!holder) return { kind: "subscribe", holder: null };
+  return { kind: holder.enabled ? "refresh" : "turn-on", holder };
+}
+
+/** Bumped by every cache drop. A read that began under an older generation
+ * describes a checkout that may no longer be the one installed from, and
+ * its answer is discarded rather than stored. */
+let generation = 0;
+export const readGeneration = (): number => generation;

--- a/ui/src/stores/marketplaces-shared.ts
+++ b/ui/src/stores/marketplaces-shared.ts
@@ -1,7 +1,7 @@
 // The cache vocabulary the marketplaces store and its readers share: the
 // collision-free subscription key, and the invalidation every catalog-moving
 // mutation runs.
-import type { Scope } from "@/bindings";
+import type { Catalog, Scope } from "@/bindings";
 import { useAuditStore } from "./audit";
 import { resetPreinstallSafety } from "./preinstall-safety";
 import { useScanStore } from "./scan";
@@ -11,6 +11,27 @@ import { useScanStore } from "./scan";
  * subscription's key. */
 export const marketKey = (scope: Scope, source: string): string =>
   JSON.stringify([scope.scope === "global" ? null : scope.root, source]);
+
+/** Any catalog's cache key — a subscription's is [marketKey], so what a
+ * subscription's rows cached stays found when a page addresses it. */
+export const catalogKey = (catalog: Catalog): string =>
+  catalog.by === "subscription"
+    ? marketKey(catalog.scope, catalog.source)
+    : JSON.stringify(["repo", catalog.repo]);
+
+export const subscription = (scope: Scope, source: string): Catalog => ({
+  by: "subscription",
+  scope,
+  source,
+});
+
+/** What a catalog is called in a title or breadcrumb. */
+export const catalogLabel = (catalog: Catalog | undefined): string | null =>
+  !catalog
+    ? null
+    : catalog.by === "subscription"
+      ? catalog.source
+      : catalog.repo;
 
 /** What lands after any mutation: the tables everywhere else stay current. */
 export async function refreshDownstream() {
@@ -30,7 +51,7 @@ export function without<T>(
  * cache — the pages re-read, and pre-install scores are re-asked, so nothing
  * keeps describing the commit before the change. */
 export function dropCatalogCaches(set: (partial: object) => void) {
-  set({ packages: {}, bundles: {}, about: {}, readErrors: {} });
+  set({ packages: {}, bundles: {}, about: {}, summaries: {}, readErrors: {} });
   resetPreinstallSafety();
 }
 
@@ -39,9 +60,44 @@ export function dropCatalogCaches(set: (partial: object) => void) {
 export async function openLead(scope: Scope, source: string, lead: string) {
   const { useNavStore } = await import("./nav");
   useNavStore.getState().goToAvailablePackage({
-    scope,
-    source,
+    catalog: subscription(scope, source),
     kind: "skill",
     name: lead,
   });
+}
+
+/** One cached read landing: the answer under its key, or why there is
+ * none — `suffix` keeps a summary's failure apart from the packages' under
+ * the same catalog, since the page shows each where it belongs. */
+export async function settle<
+  S extends { readErrors: Record<string, string> },
+  F extends keyof S,
+>(
+  set: (fn: (state: S) => Partial<S>) => void,
+  field: F,
+  key: string,
+  pending: Promise<
+    | { status: "ok"; data: S[F][keyof S[F]] }
+    | { status: "error"; error: string }
+  >,
+  suffix?: string,
+) {
+  const errorKey = suffix ? `${key}::${suffix}` : key;
+  const response = await pending;
+  if (response.status === "ok") {
+    set(
+      (state) =>
+        ({
+          [field]: { ...state[field], [key]: response.data },
+          readErrors: without(state.readErrors, errorKey),
+        }) as Partial<S>,
+    );
+  } else {
+    set(
+      (state) =>
+        ({
+          readErrors: { ...state.readErrors, [errorKey]: response.error },
+        }) as Partial<S>,
+    );
+  }
 }

--- a/ui/src/stores/marketplaces-shared.ts
+++ b/ui/src/stores/marketplaces-shared.ts
@@ -25,6 +25,16 @@ export const catalogKey = (catalog: Catalog): string =>
 export const subscribedKeys = (rows: MarketplaceRow[]): Set<string> =>
   new Set(rows.flatMap((row) => (row.repoKey ? [row.repoKey] : [])));
 
+/** A Community row's Subscribed marker. The directory's own flag is only
+ * a stand-in until the live subscription list has loaded; after that the
+ * list alone decides, so an unsubscribe clears the marker as surely as a
+ * subscribe sets it. */
+export const rowSubscribed = (
+  row: { repoKey: string | null; subscribed: boolean },
+  live: Set<string> | null,
+): boolean =>
+  live ? row.repoKey !== null && live.has(row.repoKey) : row.subscribed;
+
 /** Whether a [catalogKey] names a repository rather than a subscription. */
 export const isRepoKey = (key: string): boolean =>
   key.startsWith(JSON.stringify(["repo", ""]).slice(0, -3));

--- a/ui/src/stores/marketplaces-shared.ts
+++ b/ui/src/stores/marketplaces-shared.ts
@@ -1,9 +1,8 @@
 // The cache vocabulary the marketplaces store and its readers share: the
 // collision-free subscription key, and the invalidation every catalog-moving
 // mutation runs.
-import { type Catalog, commands, type Scope } from "@/bindings";
+import type { Catalog, Scope } from "@/bindings";
 import { useAuditStore } from "./audit";
-import type { MarketplacesState } from "./marketplaces";
 import { resetPreinstallSafety } from "./preinstall-safety";
 import { useScanStore } from "./scan";
 
@@ -19,6 +18,15 @@ export const catalogKey = (catalog: Catalog): string =>
   catalog.by === "subscription"
     ? marketKey(catalog.scope, catalog.source)
     : JSON.stringify(["repo", catalog.repo]);
+
+/** Whether a [catalogKey] names a repository rather than a subscription. */
+export const isRepoKey = (key: string): boolean =>
+  key.startsWith(JSON.stringify(["repo", ""]).slice(0, -3));
+
+/** One curated set's cache and error key, in its own namespace so a set
+ * named like a read ("packages") can never land on that read's key. */
+export const bundleKey = (catalog: Catalog, name: string): string =>
+  `${readErrorKey(catalogKey(catalog), "bundle")}::${name}`;
 
 export const subscription = (scope: Scope, source: string): Catalog => ({
   by: "subscription",
@@ -72,82 +80,4 @@ export async function openLead(scope: Scope, source: string, lead: string) {
     kind: "skill",
     name: lead,
   });
-}
-
-/** One cached read landing: the answer under its key, or why there is
- * none — `suffix` keeps a summary's failure apart from the packages' under
- * the same catalog, since the page shows each where it belongs. */
-export async function settle<
-  S extends { readErrors: Record<string, string> },
-  F extends keyof S,
->(
-  set: (fn: (state: S) => Partial<S>) => void,
-  field: F,
-  key: string,
-  pending: Promise<
-    | { status: "ok"; data: S[F][keyof S[F]] }
-    | { status: "error"; error: string }
-  >,
-  suffix?: string,
-) {
-  const errorKey = suffix ? readErrorKey(key, suffix) : key;
-  const response = await pending;
-  if (response.status === "ok") {
-    set(
-      (state) =>
-        ({
-          [field]: { ...state[field], [key]: response.data },
-          readErrors: without(state.readErrors, errorKey),
-        }) as Partial<S>,
-    );
-  } else {
-    set(
-      (state) =>
-        ({
-          readErrors: { ...state.readErrors, [errorKey]: response.error },
-        }) as Partial<S>,
-    );
-  }
-}
-
-type Set = (
-  fn: (state: MarketplacesState) => Partial<MarketplacesState>,
-) => void;
-
-/** The store's four cached reads, each landing under its own key and
- * failing under its own error key. */
-export function catalogReads(set: Set) {
-  return {
-    loadPackages: (catalog: Catalog) =>
-      settle(
-        set,
-        "packages",
-        catalogKey(catalog),
-        commands.marketplacePackages(catalog),
-        "packages",
-      ),
-    loadSummary: (catalog: Catalog) =>
-      settle(
-        set,
-        "summaries",
-        catalogKey(catalog),
-        commands.marketplaceSummary(catalog),
-        "summary",
-      ),
-    loadAbout: (catalog: Catalog) =>
-      settle(
-        set,
-        "about",
-        catalogKey(catalog),
-        commands.marketplaceAbout(catalog),
-        "about",
-      ),
-    loadBundle: (catalog: Catalog, name: string) =>
-      settle(
-        set,
-        "bundles",
-        `${catalogKey(catalog)}::${name}`,
-        commands.marketplaceBundle(catalog, name),
-      ),
-  };
 }

--- a/ui/src/stores/marketplaces-shared.ts
+++ b/ui/src/stores/marketplaces-shared.ts
@@ -1,8 +1,9 @@
 // The cache vocabulary the marketplaces store and its readers share: the
 // collision-free subscription key, and the invalidation every catalog-moving
 // mutation runs.
-import type { Catalog, Scope } from "@/bindings";
+import { type Catalog, commands, type Scope } from "@/bindings";
 import { useAuditStore } from "./audit";
+import type { MarketplacesState } from "./marketplaces";
 import { resetPreinstallSafety } from "./preinstall-safety";
 import { useScanStore } from "./scan";
 
@@ -49,11 +50,18 @@ export function without<T>(
 
 /** A mutation that can change what any catalog offers empties every derived
  * cache — the pages re-read, and pre-install scores are re-asked, so nothing
- * keeps describing the commit before the change. */
+ * keeps describing the commit before the change. A repository's summary is
+ * kept: it only says which subscription the page carries on as, and
+ * dropping it would blank an open page behind a second fetch. */
 export function dropCatalogCaches(set: (partial: object) => void) {
-  set({ packages: {}, bundles: {}, about: {}, summaries: {}, readErrors: {} });
+  set({ packages: {}, bundles: {}, about: {}, readErrors: {} });
   resetPreinstallSafety();
 }
+
+/** The error key one cached read fails under, kept apart from the other
+ * reads of the same catalog so a later success elsewhere never erases it. */
+export const readErrorKey = (key: string, read: string): string =>
+  `${key}::${read}`;
 
 /** A tree or skills.sh URL was pointing at one package; land on it so
  * Install is the next click, with its safety verdict in view. */
@@ -82,7 +90,7 @@ export async function settle<
   >,
   suffix?: string,
 ) {
-  const errorKey = suffix ? `${key}::${suffix}` : key;
+  const errorKey = suffix ? readErrorKey(key, suffix) : key;
   const response = await pending;
   if (response.status === "ok") {
     set(
@@ -100,4 +108,46 @@ export async function settle<
         }) as Partial<S>,
     );
   }
+}
+
+type Set = (
+  fn: (state: MarketplacesState) => Partial<MarketplacesState>,
+) => void;
+
+/** The store's four cached reads, each landing under its own key and
+ * failing under its own error key. */
+export function catalogReads(set: Set) {
+  return {
+    loadPackages: (catalog: Catalog) =>
+      settle(
+        set,
+        "packages",
+        catalogKey(catalog),
+        commands.marketplacePackages(catalog),
+        "packages",
+      ),
+    loadSummary: (catalog: Catalog) =>
+      settle(
+        set,
+        "summaries",
+        catalogKey(catalog),
+        commands.marketplaceSummary(catalog),
+        "summary",
+      ),
+    loadAbout: (catalog: Catalog) =>
+      settle(
+        set,
+        "about",
+        catalogKey(catalog),
+        commands.marketplaceAbout(catalog),
+        "about",
+      ),
+    loadBundle: (catalog: Catalog, name: string) =>
+      settle(
+        set,
+        "bundles",
+        `${catalogKey(catalog)}::${name}`,
+        commands.marketplaceBundle(catalog, name),
+      ),
+  };
 }

--- a/ui/src/stores/marketplaces-shared.ts
+++ b/ui/src/stores/marketplaces-shared.ts
@@ -1,7 +1,12 @@
 // The cache vocabulary the marketplaces store and its readers share: the
 // collision-free subscription key, and the invalidation every catalog-moving
 // mutation runs.
-import type { Catalog, MarketplaceRow, Scope } from "@/bindings";
+import type {
+  Catalog,
+  CatalogSummary,
+  MarketplaceRow,
+  Scope,
+} from "@/bindings";
 import { useAuditStore } from "./audit";
 import { resetPreinstallSafety } from "./preinstall-safety";
 import { useScanStore } from "./scan";
@@ -96,4 +101,29 @@ export async function openLead(scope: Scope, source: string, lead: string) {
     kind: "skill",
     name: lead,
   });
+}
+
+/** A repository page carried on as this subscription re-asks which
+ * subscription to carry on as: turned off, the backend passes it over and
+ * the page falls back to the bare repository; turned on, it carries on
+ * again. */
+export function dropSummariesCarriedBy(
+  set: (
+    fn: (state: { summaries: Record<string, CatalogSummary> }) => object,
+  ) => void,
+  scope: Scope,
+  source: string,
+) {
+  const toggled = marketKey(scope, source);
+  set((state) => ({
+    summaries: Object.fromEntries(
+      Object.entries(state.summaries).filter(
+        ([key, summary]) =>
+          !isRepoKey(key) ||
+          !summary.subscription ||
+          marketKey(summary.subscription.scope, summary.subscription.source) !==
+            toggled,
+      ),
+    ),
+  }));
 }

--- a/ui/src/stores/marketplaces-shared.ts
+++ b/ui/src/stores/marketplaces-shared.ts
@@ -1,7 +1,7 @@
 // The cache vocabulary the marketplaces store and its readers share: the
 // collision-free subscription key, and the invalidation every catalog-moving
 // mutation runs.
-import type { Catalog, Scope } from "@/bindings";
+import type { Catalog, MarketplaceRow, Scope } from "@/bindings";
 import { useAuditStore } from "./audit";
 import { resetPreinstallSafety } from "./preinstall-safety";
 import { useScanStore } from "./scan";
@@ -18,6 +18,12 @@ export const catalogKey = (catalog: Catalog): string =>
   catalog.by === "subscription"
     ? marketKey(catalog.scope, catalog.source)
     : JSON.stringify(["repo", catalog.repo]);
+
+/** The repositories the live subscription list holds, by canonical key —
+ * what a Community row's Subscribed marker reads, so it flips the moment
+ * a subscription lands or goes, wherever that happened. */
+export const subscribedKeys = (rows: MarketplaceRow[]): Set<string> =>
+  new Set(rows.flatMap((row) => (row.repoKey ? [row.repoKey] : [])));
 
 /** Whether a [catalogKey] names a repository rather than a subscription. */
 export const isRepoKey = (key: string): boolean =>

--- a/ui/src/stores/marketplaces-shared.ts
+++ b/ui/src/stores/marketplaces-shared.ts
@@ -15,10 +15,12 @@ import { useScanStore } from "./scan";
  * a root or alias containing the delimiter can never collide with another
  * subscription's key. */
 export const marketKey = (scope: Scope, source: string): string =>
-  JSON.stringify([scope.scope === "global" ? null : scope.root, source]);
+  JSON.stringify(["sub", scope.scope === "global" ? null : scope.root, source]);
 
 /** Any catalog's cache key — a subscription's is [marketKey], so what a
- * subscription's rows cached stays found when a page addresses it. */
+ * subscription's rows cached stays found when a page addresses it. Each
+ * shape carries its own tag, so a project root and alias can never spell
+ * a repository's key. */
 export const catalogKey = (catalog: Catalog): string =>
   catalog.by === "subscription"
     ? marketKey(catalog.scope, catalog.source)
@@ -54,7 +56,7 @@ export const rowSubscribed = (
 
 /** Whether a [catalogKey] names a repository rather than a subscription. */
 export const isRepoKey = (key: string): boolean =>
-  key.startsWith(JSON.stringify(["repo", ""]).slice(0, -3));
+  (JSON.parse(key) as unknown[])[0] === "repo";
 
 /** Every repository catalog with a cached summary — the pages to re-ask
  * after a refresh may have made a holder readable. The key is the way

--- a/ui/src/stores/marketplaces-subscribed.test.ts
+++ b/ui/src/stores/marketplaces-subscribed.test.ts
@@ -1,10 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { commands, type DirectoryRow, type MarketplaceRow } from "@/bindings";
 import { useMarketplacesStore } from "./marketplaces";
-import { subscribedKeys } from "./marketplaces-shared";
+import { rowSubscribed, subscribedKeys } from "./marketplaces-shared";
 
 vi.mock("@/bindings", () => ({
-  commands: { marketplaceSubscribe: vi.fn(), marketplacesOverview: vi.fn() },
+  commands: {
+    marketplaceSubscribe: vi.fn(),
+    marketplaceUnsubscribe: vi.fn(),
+    marketplacesOverview: vi.fn(),
+  },
 }));
 vi.mock("sonner", () => ({
   toast: { success: vi.fn(), message: vi.fn(), error: vi.fn() },
@@ -80,5 +84,33 @@ describe("a Community row's Subscribed marker", () => {
 
   it("ignores path subscriptions, which are no repository", () => {
     expect(subscribedKeys([row("", null)]).size).toBe(0);
+  });
+
+  it("clears once an unsubscribe lands, whatever the directory snapshot said", async () => {
+    useMarketplacesStore.setState({
+      rows: [row("Acme/Kit", "acme/kit")],
+      loaded: true,
+    });
+    vi.mocked(commands.marketplaceUnsubscribe).mockResolvedValue({
+      status: "ok",
+      data: null,
+    });
+    vi.mocked(commands.marketplacesOverview).mockResolvedValue({
+      status: "ok",
+      data: [],
+    });
+
+    const ok = await useMarketplacesStore
+      .getState()
+      .unsubscribe({ scope: "global" }, "kit", false, false);
+
+    expect(ok).toBe(true);
+    const live = subscribedKeys(useMarketplacesStore.getState().rows);
+    // The snapshot still says subscribed; the live list outranks it.
+    expect(rowSubscribed({ ...listed, subscribed: true }, live)).toBe(false);
+  });
+
+  it("falls back to the snapshot only before the live list has loaded", () => {
+    expect(rowSubscribed({ ...listed, subscribed: true }, null)).toBe(true);
   });
 });

--- a/ui/src/stores/marketplaces-subscribed.test.ts
+++ b/ui/src/stores/marketplaces-subscribed.test.ts
@@ -3,7 +3,6 @@ import { commands, type DirectoryRow, type MarketplaceRow } from "@/bindings";
 import { useMarketplacesStore } from "./marketplaces";
 import {
   catalogKey,
-  declaredHolder,
   rowSubscribed,
   subscribedKeys,
 } from "./marketplaces-shared";
@@ -153,6 +152,7 @@ describe("a repository page carried on as a subscription", () => {
       warning: null,
     };
     useMarketplacesStore.setState({
+      rows: [row("acme/kit", "acme/kit")],
       summaries: {
         [repoKey]: {
           ...summary,
@@ -160,6 +160,7 @@ describe("a repository page carried on as a subscription", () => {
         },
         [otherKey]: {
           ...summary,
+          provenance: "other/repo",
           subscription: { scope: { scope: "global" }, source: "other" },
         },
       },
@@ -181,38 +182,37 @@ describe("a repository page carried on as a subscription", () => {
     expect(summaries[repoKey]).toBeUndefined();
     expect(summaries[otherKey]).toBeDefined();
   });
-});
 
-describe("a bare repository page's action", () => {
-  it("offers Turn on, not Subscribe, once its subscription is turned off", async () => {
-    // Turning the held subscription off: the summary re-reads as bare, and
-    // the live list is what says a (disabled) subscription still holds it.
+  it("re-asks again when the holder is turned back on", async () => {
+    const repoKey = catalogKey({ by: "repo", repo: "Acme/Kit" });
+    // Turned off earlier: the summary reloaded bare, carried by nothing.
+    useMarketplacesStore.setState({
+      rows: [{ ...row("acme/kit", "acme/kit"), enabled: false }],
+      summaries: {
+        [repoKey]: {
+          provenance: "acme/kit",
+          commit: null,
+          meta: null,
+          mode: "discovered",
+          counts: {},
+          warning: null,
+          subscription: null,
+        },
+      },
+    });
     vi.mocked(commands.sourceToggle).mockResolvedValue({
       status: "ok",
       data: [],
     });
     vi.mocked(commands.marketplacesOverview).mockResolvedValue({
       status: "ok",
-      data: [{ ...row("acme/kit", "acme/kit"), enabled: false }],
+      data: [row("acme/kit", "acme/kit")],
     });
+
     await useMarketplacesStore
       .getState()
-      .toggle({ scope: "global" }, "kit", false);
+      .toggle({ scope: "global" }, "kit", true);
 
-    const held = declaredHolder(
-      useMarketplacesStore.getState().rows,
-      "acme/kit",
-    );
-    expect(held?.enabled).toBe(false);
-    expect(held?.name).toBe("kit");
-  });
-
-  it("offers Subscribe only when nothing declares the repository", () => {
-    expect(
-      declaredHolder([row("acme/kit", "acme/kit")], "other/repo"),
-    ).toBeNull();
-    const enabled = row("acme/kit", "acme/kit");
-    const disabled = { ...enabled, name: "old", enabled: false };
-    expect(declaredHolder([disabled, enabled], "acme/kit")?.name).toBe("kit");
+    expect(useMarketplacesStore.getState().summaries[repoKey]).toBeUndefined();
   });
 });

--- a/ui/src/stores/marketplaces-subscribed.test.ts
+++ b/ui/src/stores/marketplaces-subscribed.test.ts
@@ -3,6 +3,7 @@ import { commands, type DirectoryRow, type MarketplaceRow } from "@/bindings";
 import { useMarketplacesStore } from "./marketplaces";
 import {
   catalogKey,
+  declaredHolder,
   rowSubscribed,
   subscribedKeys,
 } from "./marketplaces-shared";
@@ -179,5 +180,39 @@ describe("a repository page carried on as a subscription", () => {
     const summaries = useMarketplacesStore.getState().summaries;
     expect(summaries[repoKey]).toBeUndefined();
     expect(summaries[otherKey]).toBeDefined();
+  });
+});
+
+describe("a bare repository page's action", () => {
+  it("offers Turn on, not Subscribe, once its subscription is turned off", async () => {
+    // Turning the held subscription off: the summary re-reads as bare, and
+    // the live list is what says a (disabled) subscription still holds it.
+    vi.mocked(commands.sourceToggle).mockResolvedValue({
+      status: "ok",
+      data: [],
+    });
+    vi.mocked(commands.marketplacesOverview).mockResolvedValue({
+      status: "ok",
+      data: [{ ...row("acme/kit", "acme/kit"), enabled: false }],
+    });
+    await useMarketplacesStore
+      .getState()
+      .toggle({ scope: "global" }, "kit", false);
+
+    const held = declaredHolder(
+      useMarketplacesStore.getState().rows,
+      "acme/kit",
+    );
+    expect(held?.enabled).toBe(false);
+    expect(held?.name).toBe("kit");
+  });
+
+  it("offers Subscribe only when nothing declares the repository", () => {
+    expect(
+      declaredHolder([row("acme/kit", "acme/kit")], "other/repo"),
+    ).toBeNull();
+    const enabled = row("acme/kit", "acme/kit");
+    const disabled = { ...enabled, name: "old", enabled: false };
+    expect(declaredHolder([disabled, enabled], "acme/kit")?.name).toBe("kit");
   });
 });

--- a/ui/src/stores/marketplaces-subscribed.test.ts
+++ b/ui/src/stores/marketplaces-subscribed.test.ts
@@ -1,11 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { commands, type DirectoryRow, type MarketplaceRow } from "@/bindings";
 import { useMarketplacesStore } from "./marketplaces";
-import {
-  catalogKey,
-  rowSubscribed,
-  subscribedKeys,
-} from "./marketplaces-shared";
+import { rowSubscribed, subscribedKeys } from "./marketplaces-shared";
 
 vi.mock("@/bindings", () => ({
   commands: {
@@ -136,83 +132,5 @@ describe("a Community row's Subscribed marker", () => {
     expect(state.rowsCurrent).toBe(false);
     const live = state.rowsCurrent ? subscribedKeys(state.rows) : null;
     expect(rowSubscribed({ ...listed, subscribed: true }, live)).toBe(true);
-  });
-});
-
-describe("a repository page carried on as a subscription", () => {
-  it("re-asks which subscription to carry on as when that one is toggled", async () => {
-    const repoKey = catalogKey({ by: "repo", repo: "Acme/Kit" });
-    const otherKey = catalogKey({ by: "repo", repo: "other/repo" });
-    const summary = {
-      provenance: "acme/kit",
-      commit: null,
-      meta: null,
-      mode: "discovered" as const,
-      counts: {},
-      warning: null,
-    };
-    useMarketplacesStore.setState({
-      rows: [row("acme/kit", "acme/kit")],
-      summaries: {
-        [repoKey]: {
-          ...summary,
-          subscription: { scope: { scope: "global" }, source: "kit" },
-        },
-        [otherKey]: {
-          ...summary,
-          provenance: "other/repo",
-          subscription: { scope: { scope: "global" }, source: "other" },
-        },
-      },
-    });
-    vi.mocked(commands.sourceToggle).mockResolvedValue({
-      status: "ok",
-      data: [],
-    });
-    vi.mocked(commands.marketplacesOverview).mockResolvedValue({
-      status: "ok",
-      data: [],
-    });
-
-    await useMarketplacesStore
-      .getState()
-      .toggle({ scope: "global" }, "kit", false);
-
-    const summaries = useMarketplacesStore.getState().summaries;
-    expect(summaries[repoKey]).toBeUndefined();
-    expect(summaries[otherKey]).toBeDefined();
-  });
-
-  it("re-asks again when the holder is turned back on", async () => {
-    const repoKey = catalogKey({ by: "repo", repo: "Acme/Kit" });
-    // Turned off earlier: the summary reloaded bare, carried by nothing.
-    useMarketplacesStore.setState({
-      rows: [{ ...row("acme/kit", "acme/kit"), enabled: false }],
-      summaries: {
-        [repoKey]: {
-          provenance: "acme/kit",
-          commit: null,
-          meta: null,
-          mode: "discovered",
-          counts: {},
-          warning: null,
-          subscription: null,
-        },
-      },
-    });
-    vi.mocked(commands.sourceToggle).mockResolvedValue({
-      status: "ok",
-      data: [],
-    });
-    vi.mocked(commands.marketplacesOverview).mockResolvedValue({
-      status: "ok",
-      data: [row("acme/kit", "acme/kit")],
-    });
-
-    await useMarketplacesStore
-      .getState()
-      .toggle({ scope: "global" }, "kit", true);
-
-    expect(useMarketplacesStore.getState().summaries[repoKey]).toBeUndefined();
   });
 });

--- a/ui/src/stores/marketplaces-subscribed.test.ts
+++ b/ui/src/stores/marketplaces-subscribed.test.ts
@@ -1,13 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { commands, type DirectoryRow, type MarketplaceRow } from "@/bindings";
 import { useMarketplacesStore } from "./marketplaces";
-import { rowSubscribed, subscribedKeys } from "./marketplaces-shared";
+import {
+  catalogKey,
+  rowSubscribed,
+  subscribedKeys,
+} from "./marketplaces-shared";
 
 vi.mock("@/bindings", () => ({
   commands: {
     marketplaceSubscribe: vi.fn(),
     marketplaceUnsubscribe: vi.fn(),
     marketplacesOverview: vi.fn(),
+    sourceToggle: vi.fn(),
   },
 }));
 vi.mock("sonner", () => ({
@@ -51,7 +56,11 @@ const row = (repo: string, repoKey: string | null): MarketplaceRow => ({
 
 describe("a Community row's Subscribed marker", () => {
   beforeEach(() => {
-    useMarketplacesStore.setState({ rows: [] });
+    useMarketplacesStore.setState({
+      rows: [],
+      rowsCurrent: false,
+      summaries: {},
+    });
   });
 
   it("flips as soon as a subscribe lands, however the repo was spelled", async () => {
@@ -112,5 +121,63 @@ describe("a Community row's Subscribed marker", () => {
 
   it("falls back to the snapshot only before the live list has loaded", () => {
     expect(rowSubscribed({ ...listed, subscribed: true }, null)).toBe(true);
+  });
+
+  it("keeps the directory snapshot when the live overview cannot be read", async () => {
+    useMarketplacesStore.setState({ rows: [], rowsCurrent: true });
+    vi.mocked(commands.marketplacesOverview).mockResolvedValue({
+      status: "error",
+      error: "settings file is malformed",
+    });
+
+    await useMarketplacesStore.getState().load();
+
+    const state = useMarketplacesStore.getState();
+    expect(state.rowsCurrent).toBe(false);
+    const live = state.rowsCurrent ? subscribedKeys(state.rows) : null;
+    expect(rowSubscribed({ ...listed, subscribed: true }, live)).toBe(true);
+  });
+});
+
+describe("a repository page carried on as a subscription", () => {
+  it("re-asks which subscription to carry on as when that one is toggled", async () => {
+    const repoKey = catalogKey({ by: "repo", repo: "Acme/Kit" });
+    const otherKey = catalogKey({ by: "repo", repo: "other/repo" });
+    const summary = {
+      provenance: "acme/kit",
+      commit: null,
+      meta: null,
+      mode: "discovered" as const,
+      counts: {},
+      warning: null,
+    };
+    useMarketplacesStore.setState({
+      summaries: {
+        [repoKey]: {
+          ...summary,
+          subscription: { scope: { scope: "global" }, source: "kit" },
+        },
+        [otherKey]: {
+          ...summary,
+          subscription: { scope: { scope: "global" }, source: "other" },
+        },
+      },
+    });
+    vi.mocked(commands.sourceToggle).mockResolvedValue({
+      status: "ok",
+      data: [],
+    });
+    vi.mocked(commands.marketplacesOverview).mockResolvedValue({
+      status: "ok",
+      data: [],
+    });
+
+    await useMarketplacesStore
+      .getState()
+      .toggle({ scope: "global" }, "kit", false);
+
+    const summaries = useMarketplacesStore.getState().summaries;
+    expect(summaries[repoKey]).toBeUndefined();
+    expect(summaries[otherKey]).toBeDefined();
   });
 });

--- a/ui/src/stores/marketplaces-subscribed.test.ts
+++ b/ui/src/stores/marketplaces-subscribed.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { commands, type DirectoryRow, type MarketplaceRow } from "@/bindings";
+import { useMarketplacesStore } from "./marketplaces";
+import { subscribedKeys } from "./marketplaces-shared";
+
+vi.mock("@/bindings", () => ({
+  commands: { marketplaceSubscribe: vi.fn(), marketplacesOverview: vi.fn() },
+}));
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), message: vi.fn(), error: vi.fn() },
+}));
+vi.mock("./audit", () => ({
+  useAuditStore: { getState: () => ({ refresh: vi.fn() }) },
+}));
+vi.mock("./scan", () => ({
+  useScanStore: { getState: () => ({ refresh: vi.fn() }) },
+}));
+
+const listed: DirectoryRow = {
+  repo: "Acme/Kit",
+  repoKey: "acme/kit",
+  name: "kit",
+  description: null,
+  tags: [],
+  featured: false,
+  packageCount: 1,
+  bundleCount: 0,
+  // The directory's snapshot, fetched before anyone subscribed.
+  subscribed: false,
+  packages: [],
+  bundles: [],
+};
+
+const row = (repo: string, repoKey: string | null): MarketplaceRow => ({
+  scope: { scope: "global" },
+  name: "kit",
+  repo,
+  repoKey,
+  path: null,
+  rev: null,
+  commit: null,
+  enabled: true,
+  counts: null,
+  meta: null,
+  mode: null,
+});
+
+describe("a Community row's Subscribed marker", () => {
+  beforeEach(() => {
+    useMarketplacesStore.setState({ rows: [] });
+  });
+
+  it("flips as soon as a subscribe lands, however the repo was spelled", async () => {
+    vi.mocked(commands.marketplaceSubscribe).mockResolvedValue({
+      status: "ok",
+      data: {
+        name: "kit",
+        reference: "https://github.com/Acme/Kit.git",
+        rev: null,
+        lead: null,
+        notes: [],
+      },
+    });
+    vi.mocked(commands.marketplacesOverview).mockResolvedValue({
+      status: "ok",
+      data: [row("https://github.com/Acme/Kit.git", "acme/kit")],
+    });
+    expect(
+      subscribedKeys(useMarketplacesStore.getState().rows).has("acme/kit"),
+    ).toBe(false);
+
+    const ok = await useMarketplacesStore
+      .getState()
+      .subscribe({ scope: "global" }, "https://github.com/Acme/Kit.git", null);
+
+    expect(ok).toBe(true);
+    const held = subscribedKeys(useMarketplacesStore.getState().rows);
+    expect(listed.repoKey !== null && held.has(listed.repoKey)).toBe(true);
+  });
+
+  it("ignores path subscriptions, which are no repository", () => {
+    expect(subscribedKeys([row("", null)]).size).toBe(0);
+  });
+});

--- a/ui/src/stores/marketplaces-summary.test.ts
+++ b/ui/src/stores/marketplaces-summary.test.ts
@@ -40,6 +40,7 @@ describe("a repository's summary", () => {
       status: "ok",
       data: {
         provenance: "acme/kit",
+        repoKey: "acme/kit",
         commit: null,
         meta: null,
         mode: "discovered",

--- a/ui/src/stores/marketplaces-summary.test.ts
+++ b/ui/src/stores/marketplaces-summary.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { commands } from "@/bindings";
+import { useMarketplacesStore } from "./marketplaces";
+import { catalogKey, marketKey, readErrorKey } from "./marketplaces-shared";
+
+vi.mock("@/bindings", () => ({
+  commands: { marketplaceSummary: vi.fn() },
+}));
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), message: vi.fn(), error: vi.fn() },
+}));
+
+const repo = { by: "repo" as const, repo: "acme/kit" };
+const key = catalogKey(repo);
+
+describe("a repository's summary", () => {
+  beforeEach(() => {
+    useMarketplacesStore.setState({ summaries: {}, readErrors: {} });
+  });
+
+  it("fails under its own key so the packages table is not hidden", async () => {
+    useMarketplacesStore.setState({ readErrors: { [key]: "packages broke" } });
+    vi.mocked(commands.marketplaceSummary).mockResolvedValue({
+      status: "error",
+      error: "could not reach github.com",
+    });
+
+    await useMarketplacesStore.getState().loadSummary(repo);
+
+    const errors = useMarketplacesStore.getState().readErrors;
+    expect(errors[readErrorKey(key, "summary")]).toBe(
+      "could not reach github.com",
+    );
+    expect(errors[key]).toBe("packages broke");
+  });
+
+  it("names the subscription the page carries on as", async () => {
+    const scope = { scope: "project" as const, root: "/work/acme" };
+    vi.mocked(commands.marketplaceSummary).mockResolvedValue({
+      status: "ok",
+      data: {
+        provenance: "acme/kit",
+        commit: null,
+        meta: null,
+        mode: "discovered",
+        counts: {},
+        warning: null,
+        subscription: { scope, source: "kit" },
+      },
+    });
+
+    await useMarketplacesStore.getState().loadSummary(repo);
+
+    const held = useMarketplacesStore.getState().summaries[key]?.subscription;
+    expect(held).toBeDefined();
+    // What useCatalog derives from it addresses the subscription's own
+    // cache, so rows a subscribed page already loaded are found.
+    expect(
+      catalogKey({
+        by: "subscription",
+        scope: held!.scope,
+        source: held!.source,
+      }),
+    ).toBe(marketKey(scope, "kit"));
+  });
+});

--- a/ui/src/stores/marketplaces-toggle.test.ts
+++ b/ui/src/stores/marketplaces-toggle.test.ts
@@ -76,6 +76,14 @@ describe("a bare repository page's action", () => {
     expect(held?.name).toBe("kit");
   });
 
+  it("stays neutral until the canonical key is known, then matches by it", () => {
+    const disabled = { ...row("acme/kit", "acme/kit"), enabled: false };
+    // The page was opened as "Acme/Kit": before the summary or the directory
+    // row supplies the canonical key, no spelling is compared.
+    expect(repoAction([disabled], true, null).kind).toBe("checking");
+    expect(repoAction([disabled], true, "acme/kit").kind).toBe("turn-on");
+  });
+
   it("offers Subscribe only when nothing declares the repository", () => {
     expect(
       declaredHolder([row("acme/kit", "acme/kit")], "other/repo"),

--- a/ui/src/stores/marketplaces-toggle.test.ts
+++ b/ui/src/stores/marketplaces-toggle.test.ts
@@ -3,7 +3,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { commands, type MarketplaceRow } from "@/bindings";
 import { useMarketplacesStore } from "./marketplaces";
-import { declaredHolder, repoAction } from "./marketplaces-shared";
+import { catalogKey, declaredHolder, repoAction } from "./marketplaces-shared";
 
 vi.mock("@/bindings", () => ({
   commands: {
@@ -83,5 +83,120 @@ describe("a bare repository page's action", () => {
     const enabled = row("acme/kit", "acme/kit");
     const disabled = { ...enabled, name: "old", enabled: false };
     expect(declaredHolder([disabled, enabled], "acme/kit")?.name).toBe("kit");
+  });
+});
+
+describe("a repository page carried on as a subscription", () => {
+  it("re-asks which subscription to carry on as when that one is toggled", async () => {
+    const repoKey = catalogKey({ by: "repo", repo: "Acme/Kit" });
+    const otherKey = catalogKey({ by: "repo", repo: "other/repo" });
+    const summary = {
+      provenance: "acme/kit",
+      repoKey: "acme/kit",
+      commit: null,
+      meta: null,
+      mode: "discovered" as const,
+      counts: {},
+      warning: null,
+    };
+    useMarketplacesStore.setState({
+      rows: [row("acme/kit", "acme/kit")],
+      summaries: {
+        [repoKey]: {
+          ...summary,
+          subscription: { scope: { scope: "global" }, source: "kit" },
+        },
+        [otherKey]: {
+          ...summary,
+          provenance: "other/repo",
+          repoKey: "other/repo",
+          subscription: { scope: { scope: "global" }, source: "other" },
+        },
+      },
+    });
+    vi.mocked(commands.sourceToggle).mockResolvedValue({
+      status: "ok",
+      data: [],
+    });
+    vi.mocked(commands.marketplacesOverview).mockResolvedValue({
+      status: "ok",
+      data: [],
+    });
+
+    await useMarketplacesStore
+      .getState()
+      .toggle({ scope: "global" }, "kit", false);
+
+    const summaries = useMarketplacesStore.getState().summaries;
+    expect(summaries[repoKey]).toBeUndefined();
+    expect(summaries[otherKey]).toBeDefined();
+  });
+
+  it("re-asks a summary whose holder spells the repository another way", async () => {
+    const repoKey = catalogKey({ by: "repo", repo: "acme/kit" });
+    useMarketplacesStore.setState({
+      rows: [row("git@github.com:acme/kit.git", "acme/kit")],
+      summaries: {
+        [repoKey]: {
+          // Carried on as the subscription: provenance is its declaration.
+          provenance: "git@github.com:acme/kit.git",
+          repoKey: "acme/kit",
+          commit: null,
+          meta: null,
+          mode: "discovered",
+          counts: {},
+          warning: null,
+          subscription: { scope: { scope: "global" }, source: "kit" },
+        },
+      },
+    });
+    vi.mocked(commands.sourceToggle).mockResolvedValue({
+      status: "ok",
+      data: [],
+    });
+    vi.mocked(commands.marketplacesOverview).mockResolvedValue({
+      status: "ok",
+      data: [],
+    });
+
+    await useMarketplacesStore
+      .getState()
+      .toggle({ scope: "global" }, "kit", false);
+
+    expect(useMarketplacesStore.getState().summaries[repoKey]).toBeUndefined();
+  });
+
+  it("re-asks again when the holder is turned back on", async () => {
+    const repoKey = catalogKey({ by: "repo", repo: "Acme/Kit" });
+    // Turned off earlier: the summary reloaded bare, carried by nothing.
+    useMarketplacesStore.setState({
+      rows: [{ ...row("acme/kit", "acme/kit"), enabled: false }],
+      summaries: {
+        [repoKey]: {
+          provenance: "acme/kit",
+          repoKey: "acme/kit",
+          commit: null,
+          meta: null,
+          mode: "discovered",
+          counts: {},
+          warning: null,
+          subscription: null,
+        },
+      },
+    });
+    vi.mocked(commands.sourceToggle).mockResolvedValue({
+      status: "ok",
+      data: [],
+    });
+    vi.mocked(commands.marketplacesOverview).mockResolvedValue({
+      status: "ok",
+      data: [row("acme/kit", "acme/kit")],
+    });
+
+    await useMarketplacesStore
+      .getState()
+      .toggle({ scope: "global" }, "kit", true);
+
+    expect(useMarketplacesStore.getState().summaries[repoKey]).toBeUndefined();
   });
 });

--- a/ui/src/stores/marketplaces-toggle.test.ts
+++ b/ui/src/stores/marketplaces-toggle.test.ts
@@ -1,0 +1,87 @@
+// A bare repository page's action and what toggling its holder does to
+// the summaries that decide which subscription the page carries on as.
+import { describe, expect, it, vi } from "vitest";
+import { commands, type MarketplaceRow } from "@/bindings";
+import { useMarketplacesStore } from "./marketplaces";
+import { declaredHolder, repoAction } from "./marketplaces-shared";
+
+vi.mock("@/bindings", () => ({
+  commands: {
+    marketplaceSubscribe: vi.fn(),
+    marketplaceUnsubscribe: vi.fn(),
+    marketplacesOverview: vi.fn(),
+    sourceToggle: vi.fn(),
+  },
+}));
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), message: vi.fn(), error: vi.fn() },
+}));
+vi.mock("./audit", () => ({
+  useAuditStore: { getState: () => ({ refresh: vi.fn() }) },
+}));
+vi.mock("./scan", () => ({
+  useScanStore: { getState: () => ({ refresh: vi.fn() }) },
+}));
+
+const row = (repo: string, repoKey: string | null): MarketplaceRow => ({
+  scope: { scope: "global" },
+  name: "kit",
+  repo,
+  repoKey,
+  path: null,
+  rev: null,
+  commit: null,
+  enabled: true,
+  counts: null,
+  meta: null,
+  mode: null,
+});
+
+describe("a bare repository page's action", () => {
+  it("stays neutral, not Subscribe, while the live list cannot be trusted", async () => {
+    useMarketplacesStore.setState({ rows: [], rowsCurrent: true });
+    vi.mocked(commands.marketplacesOverview).mockResolvedValue({
+      status: "error",
+      error: "settings file is malformed",
+    });
+    await useMarketplacesStore.getState().load();
+
+    const state = useMarketplacesStore.getState();
+    expect(repoAction(state.rows, state.rowsCurrent, "acme/kit").kind).toBe(
+      "checking",
+    );
+    expect(repoAction([], true, "acme/kit").kind).toBe("subscribe");
+  });
+
+  it("offers Turn on, not Subscribe, once its subscription is turned off", async () => {
+    // Turning the held subscription off: the summary re-reads as bare, and
+    // the live list is what says a (disabled) subscription still holds it.
+    vi.mocked(commands.sourceToggle).mockResolvedValue({
+      status: "ok",
+      data: [],
+    });
+    vi.mocked(commands.marketplacesOverview).mockResolvedValue({
+      status: "ok",
+      data: [{ ...row("acme/kit", "acme/kit"), enabled: false }],
+    });
+    await useMarketplacesStore
+      .getState()
+      .toggle({ scope: "global" }, "kit", false);
+
+    const held = declaredHolder(
+      useMarketplacesStore.getState().rows,
+      "acme/kit",
+    );
+    expect(held?.enabled).toBe(false);
+    expect(held?.name).toBe("kit");
+  });
+
+  it("offers Subscribe only when nothing declares the repository", () => {
+    expect(
+      declaredHolder([row("acme/kit", "acme/kit")], "other/repo"),
+    ).toBeNull();
+    const enabled = row("acme/kit", "acme/kit");
+    const disabled = { ...enabled, name: "old", enabled: false };
+    expect(declaredHolder([disabled, enabled], "acme/kit")?.name).toBe("kit");
+  });
+});

--- a/ui/src/stores/marketplaces.ts
+++ b/ui/src/stores/marketplaces.ts
@@ -13,6 +13,7 @@ import {
 } from "@/bindings";
 import { catalogReads } from "./marketplaces-reads";
 import {
+  cachedRepoCatalogs,
   catalogKey,
   dropCatalogCaches,
   dropSummariesHeldBy,
@@ -196,6 +197,9 @@ export const useMarketplacesStore = create<MarketplacesState>((set, get) => ({
         // derived from catalog bytes re-reads.
         dropCatalogCaches(set);
         await get().load();
+        for (const repo of cachedRepoCatalogs(get().summaries)) {
+          void get().loadSummary(repo);
+        }
       } else {
         toast.error(response.error);
       }

--- a/ui/src/stores/marketplaces.ts
+++ b/ui/src/stores/marketplaces.ts
@@ -13,21 +13,23 @@ import {
 } from "@/bindings";
 import {
   catalogKey,
+  catalogReads,
   dropCatalogCaches,
   openLead,
   refreshDownstream,
-  settle,
   subscription,
+  without,
 } from "./marketplaces-shared";
 
 export {
   catalogKey,
   catalogLabel,
   marketKey,
+  readErrorKey,
   subscription,
 } from "./marketplaces-shared";
 
-interface MarketplacesState {
+export interface MarketplacesState {
   rows: MarketplaceRow[];
   /** Each opened catalog's offered packages, by [catalogKey]. */
   packages: Record<string, AvailablePackage[]>;
@@ -91,38 +93,7 @@ export const useMarketplacesStore = create<MarketplacesState>((set, get) => ({
     }
   },
 
-  loadPackages: (catalog) =>
-    settle(
-      set,
-      "packages",
-      catalogKey(catalog),
-      commands.marketplacePackages(catalog),
-    ),
-
-  loadSummary: (catalog) =>
-    settle(
-      set,
-      "summaries",
-      catalogKey(catalog),
-      commands.marketplaceSummary(catalog),
-      "summary",
-    ),
-
-  loadAbout: (catalog) =>
-    settle(
-      set,
-      "about",
-      catalogKey(catalog),
-      commands.marketplaceAbout(catalog),
-    ),
-
-  loadBundle: (catalog, name) =>
-    settle(
-      set,
-      "bundles",
-      `${catalogKey(catalog)}::${name}`,
-      commands.marketplaceBundle(catalog, name),
-    ),
+  ...catalogReads(set),
 
   subscribe: async (scope, reference, name) => {
     set({ busy: true });
@@ -141,6 +112,13 @@ export const useMarketplacesStore = create<MarketplacesState>((set, get) => ({
     toast.success(`Subscribed to '${response.data.name}'`);
     for (const note of response.data.notes) toast.message(note);
     dropCatalogCaches(set);
+    // Only this repository's page has a new subscription to carry on as.
+    set((state) => ({
+      summaries: without(
+        state.summaries,
+        catalogKey({ by: "repo", repo: reference }),
+      ),
+    }));
     await get().load();
     if (response.data.lead) {
       await openLead(scope, response.data.name, response.data.lead);
@@ -172,6 +150,8 @@ export const useMarketplacesStore = create<MarketplacesState>((set, get) => ({
         : `Unsubscribed from '${source}'`,
     );
     dropCatalogCaches(set);
+    // A page carried on as this subscription must stop pointing at it.
+    set({ summaries: {} });
     await get().load();
     await refreshDownstream();
     return true;

--- a/ui/src/stores/marketplaces.ts
+++ b/ui/src/stores/marketplaces.ts
@@ -11,17 +11,18 @@ import {
   type InstallItem,
   type Scope,
 } from "@/bindings";
+import { catalogReads } from "./marketplaces-reads";
 import {
   catalogKey,
-  catalogReads,
   dropCatalogCaches,
+  isRepoKey,
   openLead,
   refreshDownstream,
   subscription,
-  without,
 } from "./marketplaces-shared";
 
 export {
+  bundleKey,
   catalogKey,
   catalogLabel,
   marketKey,
@@ -29,7 +30,7 @@ export {
   subscription,
 } from "./marketplaces-shared";
 
-export interface MarketplacesState {
+interface MarketplacesState {
   rows: MarketplaceRow[];
   /** Each opened catalog's offered packages, by [catalogKey]. */
   packages: Record<string, AvailablePackage[]>;
@@ -112,11 +113,12 @@ export const useMarketplacesStore = create<MarketplacesState>((set, get) => ({
     toast.success(`Subscribed to '${response.data.name}'`);
     for (const note of response.data.notes) toast.message(note);
     dropCatalogCaches(set);
-    // Only this repository's page has a new subscription to carry on as.
+    // A repository page may now have a subscription to carry on as, under
+    // whatever spelling the dialog was submitted with — every repository
+    // summary re-reads, and only one such page can be open.
     set((state) => ({
-      summaries: without(
-        state.summaries,
-        catalogKey({ by: "repo", repo: reference }),
+      summaries: Object.fromEntries(
+        Object.entries(state.summaries).filter(([key]) => !isRepoKey(key)),
       ),
     }));
     await get().load();

--- a/ui/src/stores/marketplaces.ts
+++ b/ui/src/stores/marketplaces.ts
@@ -5,27 +5,38 @@ import {
   type AboutView,
   type AvailablePackage,
   type BundleDetail,
+  type Catalog,
+  type CatalogSummary,
   commands,
   type InstallItem,
   type Scope,
 } from "@/bindings";
 import {
+  catalogKey,
   dropCatalogCaches,
-  marketKey,
   openLead,
   refreshDownstream,
-  without,
+  settle,
+  subscription,
 } from "./marketplaces-shared";
 
-export { marketKey } from "./marketplaces-shared";
+export {
+  catalogKey,
+  catalogLabel,
+  marketKey,
+  subscription,
+} from "./marketplaces-shared";
 
 interface MarketplacesState {
   rows: MarketplaceRow[];
-  /** Each opened subscription's offered packages, by [marketKey]. */
+  /** Each opened catalog's offered packages, by [catalogKey]. */
   packages: Record<string, AvailablePackage[]>;
-  /** Each opened subscription's About report, by [marketKey]. */
+  /** Each opened catalog's About report, by [catalogKey]. */
   about: Record<string, AboutView>;
-  /** Each opened curated set, by [marketKey]::bundle. */
+  /** Each opened catalog's own account of itself, by [catalogKey] — for a
+   * repository this is the read that fetches it. */
+  summaries: Record<string, CatalogSummary>;
+  /** Each opened curated set, by [catalogKey]::bundle. */
   bundles: Record<string, BundleDetail>;
   /** Why a read produced nothing, by the same keys — the page the person is
    * looking at says it instead of loading forever. */
@@ -34,9 +45,10 @@ interface MarketplacesState {
   busy: boolean;
   error: string | null;
   load: () => Promise<void>;
-  loadPackages: (scope: Scope, source: string) => Promise<void>;
-  loadAbout: (scope: Scope, source: string) => Promise<void>;
-  loadBundle: (scope: Scope, source: string, name: string) => Promise<void>;
+  loadPackages: (catalog: Catalog) => Promise<void>;
+  loadSummary: (catalog: Catalog) => Promise<void>;
+  loadAbout: (catalog: Catalog) => Promise<void>;
+  loadBundle: (catalog: Catalog, name: string) => Promise<void>;
   subscribe: (
     scope: Scope,
     reference: string,
@@ -63,6 +75,7 @@ export const useMarketplacesStore = create<MarketplacesState>((set, get) => ({
   rows: [],
   packages: {},
   about: {},
+  summaries: {},
   bundles: {},
   readErrors: {},
   loaded: false,
@@ -78,50 +91,38 @@ export const useMarketplacesStore = create<MarketplacesState>((set, get) => ({
     }
   },
 
-  loadPackages: async (scope, source) => {
-    const key = marketKey(scope, source);
-    const response = await commands.marketplacePackages(scope, source);
-    if (response.status === "ok") {
-      set((state) => ({
-        packages: { ...state.packages, [key]: response.data },
-        readErrors: without(state.readErrors, key),
-      }));
-    } else {
-      set((state) => ({
-        readErrors: { ...state.readErrors, [key]: response.error },
-      }));
-    }
-  },
+  loadPackages: (catalog) =>
+    settle(
+      set,
+      "packages",
+      catalogKey(catalog),
+      commands.marketplacePackages(catalog),
+    ),
 
-  loadAbout: async (scope, source) => {
-    const key = marketKey(scope, source);
-    const response = await commands.marketplaceAbout(scope, source);
-    if (response.status === "ok") {
-      set((state) => ({
-        about: { ...state.about, [key]: response.data },
-        readErrors: without(state.readErrors, key),
-      }));
-    } else {
-      set((state) => ({
-        readErrors: { ...state.readErrors, [key]: response.error },
-      }));
-    }
-  },
+  loadSummary: (catalog) =>
+    settle(
+      set,
+      "summaries",
+      catalogKey(catalog),
+      commands.marketplaceSummary(catalog),
+      "summary",
+    ),
 
-  loadBundle: async (scope, source, name) => {
-    const key = `${marketKey(scope, source)}::${name}`;
-    const response = await commands.marketplaceBundle(scope, source, name);
-    if (response.status === "ok") {
-      set((state) => ({
-        bundles: { ...state.bundles, [key]: response.data },
-        readErrors: without(state.readErrors, key),
-      }));
-    } else {
-      set((state) => ({
-        readErrors: { ...state.readErrors, [key]: response.error },
-      }));
-    }
-  },
+  loadAbout: (catalog) =>
+    settle(
+      set,
+      "about",
+      catalogKey(catalog),
+      commands.marketplaceAbout(catalog),
+    ),
+
+  loadBundle: (catalog, name) =>
+    settle(
+      set,
+      "bundles",
+      `${catalogKey(catalog)}::${name}`,
+      commands.marketplaceBundle(catalog, name),
+    ),
 
   subscribe: async (scope, reference, name) => {
     set({ busy: true });
@@ -226,7 +227,7 @@ export const useMarketplacesStore = create<MarketplacesState>((set, get) => ({
     }
     // The command answers with the refreshed package list for this
     // subscription, so the table flips to Installed without a second query.
-    const key = marketKey(destination ?? scope, source);
+    const key = catalogKey(subscription(destination ?? scope, source));
     set((state) => ({
       packages: { ...state.packages, [key]: response.data },
       // Member states in every open set moved with this install.

--- a/ui/src/stores/marketplaces.ts
+++ b/ui/src/stores/marketplaces.ts
@@ -26,6 +26,7 @@ export {
   bundleKey,
   catalogKey,
   catalogLabel,
+  declaredHolder,
   marketKey,
   readErrorKey,
   rowSubscribed,

--- a/ui/src/stores/marketplaces.ts
+++ b/ui/src/stores/marketplaces.ts
@@ -15,9 +15,8 @@ import { catalogReads } from "./marketplaces-reads";
 import {
   catalogKey,
   dropCatalogCaches,
-  dropSummariesForRepo,
+  dropSummariesHeldBy,
   isRepoKey,
-  marketKey,
   openLead,
   refreshDownstream,
   subscription,
@@ -182,12 +181,7 @@ export const useMarketplacesStore = create<MarketplacesState>((set, get) => ({
       return;
     }
     dropCatalogCaches(set);
-    const toggled = get().rows.find(
-      (row) =>
-        row.name === source &&
-        marketKey(row.scope, row.name) === marketKey(scope, source),
-    );
-    if (toggled?.repoKey) dropSummariesForRepo(set, toggled.repoKey);
+    dropSummariesHeldBy(set, get().rows, scope, source);
     await get().load();
     await refreshDownstream();
   },

--- a/ui/src/stores/marketplaces.ts
+++ b/ui/src/stores/marketplaces.ts
@@ -15,6 +15,7 @@ import { catalogReads } from "./marketplaces-reads";
 import {
   catalogKey,
   dropCatalogCaches,
+  dropSummariesCarriedBy,
   isRepoKey,
   openLead,
   refreshDownstream,
@@ -47,6 +48,10 @@ interface MarketplacesState {
    * looking at says it instead of loading forever. */
   readErrors: Record<string, string>;
   loaded: boolean;
+  /** Whether `rows` is the answer of the last overview read. A failed read
+   * leaves the rows it had, and nothing may treat them as the truth about
+   * what is subscribed until a read succeeds again. */
+  rowsCurrent: boolean;
   busy: boolean;
   error: string | null;
   load: () => Promise<void>;
@@ -84,15 +89,21 @@ export const useMarketplacesStore = create<MarketplacesState>((set, get) => ({
   bundles: {},
   readErrors: {},
   loaded: false,
+  rowsCurrent: false,
   busy: false,
   error: null,
 
   load: async () => {
     const response = await commands.marketplacesOverview();
     if (response.status === "ok") {
-      set({ rows: response.data, loaded: true, error: null });
+      set({
+        rows: response.data,
+        loaded: true,
+        rowsCurrent: true,
+        error: null,
+      });
     } else {
-      set({ loaded: true, error: response.error });
+      set({ loaded: true, rowsCurrent: false, error: response.error });
     }
   },
 
@@ -168,6 +179,7 @@ export const useMarketplacesStore = create<MarketplacesState>((set, get) => ({
       return;
     }
     dropCatalogCaches(set);
+    dropSummariesCarriedBy(set, scope, source);
     await get().load();
     await refreshDownstream();
   },

--- a/ui/src/stores/marketplaces.ts
+++ b/ui/src/stores/marketplaces.ts
@@ -27,6 +27,7 @@ export {
   catalogLabel,
   marketKey,
   readErrorKey,
+  rowSubscribed,
   subscribedKeys,
   subscription,
 } from "./marketplaces-shared";

--- a/ui/src/stores/marketplaces.ts
+++ b/ui/src/stores/marketplaces.ts
@@ -27,6 +27,7 @@ export {
   catalogLabel,
   marketKey,
   readErrorKey,
+  subscribedKeys,
   subscription,
 } from "./marketplaces-shared";
 

--- a/ui/src/stores/marketplaces.ts
+++ b/ui/src/stores/marketplaces.ts
@@ -15,8 +15,9 @@ import { catalogReads } from "./marketplaces-reads";
 import {
   catalogKey,
   dropCatalogCaches,
-  dropSummariesCarriedBy,
+  dropSummariesForRepo,
   isRepoKey,
+  marketKey,
   openLead,
   refreshDownstream,
   subscription,
@@ -29,6 +30,7 @@ export {
   declaredHolder,
   marketKey,
   readErrorKey,
+  repoAction,
   rowSubscribed,
   subscribedKeys,
   subscription,
@@ -180,7 +182,12 @@ export const useMarketplacesStore = create<MarketplacesState>((set, get) => ({
       return;
     }
     dropCatalogCaches(set);
-    dropSummariesCarriedBy(set, scope, source);
+    const toggled = get().rows.find(
+      (row) =>
+        row.name === source &&
+        marketKey(row.scope, row.name) === marketKey(scope, source),
+    );
+    if (toggled?.repoKey) dropSummariesForRepo(set, toggled.repoKey);
     await get().load();
     await refreshDownstream();
   },

--- a/ui/src/stores/nav-marketplaces.test.ts
+++ b/ui/src/stores/nav-marketplaces.test.ts
@@ -52,6 +52,7 @@ describe("nav store — marketplaces", () => {
   it("remembers which Marketplaces tab was open through back", () => {
     useNavStore.getState().goToMarketplaces("packages");
     useNavStore.getState().goToMarketplace({
+      by: "subscription",
       scope: { scope: "global" },
       source: "kendex",
     });
@@ -63,11 +64,15 @@ describe("nav store — marketplaces", () => {
   });
 
   it("opens nested marketplace pages with their refs, cleared on a pick", () => {
-    const ref = { scope: { scope: "global" as const }, source: "kendex" };
+    const ref = {
+      by: "subscription" as const,
+      scope: { scope: "global" as const },
+      source: "kendex",
+    };
     useNavStore.getState().goToMarketplace(ref);
     expect(useNavStore.getState().marketplaceRef).toEqual(ref);
 
-    useNavStore.getState().goToBundle({ ...ref, bundle: "starter" });
+    useNavStore.getState().goToBundle({ catalog: ref, bundle: "starter" });
     expect(useNavStore.getState().page).toBe("bundleDetail");
 
     useNavStore.getState().setPage("home");

--- a/ui/src/stores/nav-types.ts
+++ b/ui/src/stores/nav-types.ts
@@ -1,6 +1,6 @@
 // The vocabulary of places: every page id, the refs that address what a
 // nested page is showing, and the snapshot the back stack keeps.
-import type { HarnessId, ItemKind, Scope } from "@/bindings";
+import type { Catalog, HarnessId, ItemKind, Scope } from "@/bindings";
 
 export type Page =
   | "home"
@@ -45,19 +45,20 @@ export interface PackageRef {
   scope: Scope;
 }
 
-/** One subscription, addressed the way every marketplace query is. */
-export interface MarketplaceRef {
-  scope: Scope;
-  source: string;
-}
+/** One catalog, addressed the way every marketplace query is: a
+ * subscription, or a repository opened from the Community tab before
+ * subscribing. */
+export type MarketplaceRef = Catalog;
 
-/** One curated set inside a subscription. */
-export interface BundleRef extends MarketplaceRef {
+/** One curated set inside a catalog. */
+export interface BundleRef {
+  catalog: Catalog;
   bundle: string;
 }
 
-/** One offered-but-not-installed package inside a subscription. */
-export interface AvailableRef extends MarketplaceRef {
+/** One offered-but-not-installed package inside a catalog. */
+export interface AvailableRef {
+  catalog: Catalog;
   kind: ItemKind;
   name: string;
 }

--- a/ui/src/stores/preinstall-safety.ts
+++ b/ui/src/stores/preinstall-safety.ts
@@ -1,19 +1,18 @@
 import { create } from "zustand";
 import {
+  type Catalog,
   commands,
   type ItemKind,
   type PackageSafety,
-  type Scope,
 } from "@/bindings";
-import { marketKey } from "./marketplaces";
+import { catalogKey } from "./marketplaces-shared";
 
 /** One offered package's identity across every marketplace query. */
 export const safetyKey = (
-  scope: Scope,
-  source: string,
+  catalog: Catalog,
   kind: ItemKind,
   name: string,
-): string => `${marketKey(scope, source)}::${kind}::${name}`;
+): string => `${catalogKey(catalog)}::${kind}::${name}`;
 
 interface PreinstallSafetyState {
   /** Answered scores; a key in flight or failed is simply absent, and the
@@ -22,12 +21,11 @@ interface PreinstallSafetyState {
   /** Queue a package's score. Fetches drain one at a time — a table of
    * forty rows must not fire forty scans at once; the backend caches, so a
    * revisit answers from disk. */
-  want: (scope: Scope, source: string, kind: ItemKind, name: string) => void;
+  want: (catalog: Catalog, kind: ItemKind, name: string) => void;
 }
 
 interface QueueItem {
-  scope: Scope;
-  source: string;
+  catalog: Catalog;
   kind: ItemKind;
   name: string;
   key: string;
@@ -52,11 +50,11 @@ export function resetPreinstallSafety() {
 export const usePreinstallSafety = create<PreinstallSafetyState>(
   (set, get) => ({
     scores: {},
-    want: (scope, source, kind, name) => {
-      const key = safetyKey(scope, source, kind, name);
+    want: (catalog, kind, name) => {
+      const key = safetyKey(catalog, kind, name);
       if (get().scores[key] || queued.has(key)) return;
       queued.add(key);
-      queue.push({ scope, source, kind, name, key });
+      queue.push({ catalog, kind, name, key });
       if (draining) return;
       draining = true;
       void (async () => {
@@ -67,8 +65,7 @@ export const usePreinstallSafety = create<PreinstallSafetyState>(
             const before = generation;
             try {
               const response = await commands.marketplacePackagePreview(
-                item.scope,
-                item.source,
+                item.catalog,
                 item.kind,
                 item.name,
               );


### PR DESCRIPTION
## Summary
- Any marketplace listed on the Community tab (Directory or Skills.sh) can be opened and browsed before subscribing: marketplace page with packages, bundles and About; package page with README, file list and file preview, and safety findings; bundle page with member states. Subscribed and unsubscribed marketplaces share one set of pages.
- Core gained a `Catalog` address (subscription | GitHub repo) that every browse read takes; a blind browse folds any GitHub spelling to the canonical `owner/repo` for fetch, store, safety cache and the Subscribe prefill, so subscribing later downloads nothing new. Subscribe works from any nested page and the page carries on as the subscription; the Community row's Subscribed marker follows live.
- The tab bar on Marketplaces now has room above its first row (`pb-3` → `pb-6`), matching the package page.

## Completed Issues
- Closes KEN-448 - Marketplaces: browse any community marketplace, its packages and files in-app (parity with kendex.ai)

## kendex.ai parity notes (site repo, not changed here)
The app now matches the site's featured badge, tags, author/license and head commit. The app shows, and the site does not yet: an About report (how the catalog is read, catalog findings), a package's file list with sizes, the safety findings themselves (site shows score/verdict only), and bundle member states. Site-only by nature: the `kendex marketplace subscribe` / `kendex add` copy commands.

## QA Metrics
- Internal review: 9 reviewers × 2 cycles, 1 blocker (test gap) + 20 fix suggestions applied, 3 declined; QA (correctness) pass.
- PR review bot (Codex): 21 threads — 19 fixed across 13 follow-up commits (incl. real pre-subscription file preview, skill-tree-scoped file reads, toggle/refresh cache invalidation, tagged cache keys), 2 declined with rationale; every thread resolved.
- reviewer-test mutation: 5/7 → 4/7 killed on the fix diff (survivors non-regressions); browse suite stability 10/10 at 64 threads (safety).
- `cargo test --workspace`, `pnpm check`, vitest 225/225 green on the pushed HEAD.
- Pre-existing flake observed on `main`, untouched by this branch: `source_ops::tests::disable_deactivates_without_drift_and_reenable_restores` failed 1/29 full-suite runs at default threads under concurrent load.

## Test Plan
- Community → click `wshobson/agents`: marketplace page opens with counts, tags, Subscribe; Packages and Bundles tabs list; open a package → README, files with preview, safety findings; Subscribe from that page → page becomes the subscription, Install appears, back on Community the row reads Subscribed.
- Open an unreachable/nonexistent repo from the dev fixtures: the page names the fetch failure with Try again, not a pin/cache message.
- Toggle a subscription or Check for updates while on a Community-opened page: page and tab stay put, no refetch.
- Tab bar spacing on Marketplaces matches the package page.
