### PR TITLE
feat(app): project cards open their library, and scrollbars are the app's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,9 +143,10 @@ changes carry a **Breaking** call-out with their migration note inline.
 - Scrolling surfaces are the app's own colour rather than the desktop's: a
   long list used to end in a stripe of system chrome, and the thumb is now
   drawn from the app's foreground with the track taken away, in light and
-  dark. Each platform keeps its own scrollbar shape and width, so on Linux
-  and macOS — where the bar floats over the list — no list shifts sideways as
-  it grows past the window.
+  dark. Nothing gives up any width for it, so no list shifts sideways as it
+  grows past the window. A system that does not let the app recolour its
+  scrollbar keeps exactly the bar it draws today, and will pick the app's
+  colour up on its own once it supports the setting.
 - The app uses the Geist typeface, with titles and navigation in Geist Mono
   to match the website.
 - **Breaking**: the default Homebrew install is now the app —
@@ -177,6 +178,10 @@ changes carry a **Breaking** call-out with their migration note inline.
   `KENDEX_REAL_HOME=1` — only that exact value opts out. Release builds are
   unaffected, whether you installed one or built it with `--release`.
 
+- "How a marketplace repo works" can be read from the keyboard. The document
+  is longer than the box it opens in, and only a mouse could scroll it, so
+  everything past the first screen was out of reach; `Tab` now reaches the
+  document itself and the keyboard scrolls it.
 - The project-management skill's issue pipeline creates Linear issues
   directly in Backlog instead of the team's Triage default. Pipeline output
   is already fully triaged — project, labels, priority, relations — and a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,7 +133,9 @@ changes carry a **Breaking** call-out with their migration note inline.
 - A project card on Projects opens that project's library. Clicking the
   card — Personal included — shows everything installed there, unfiltered.
   Seeing a whole project used to mean picking a kind you did not want and
-  then clearing the filter.
+  then clearing the filter. A screen reader names the folder each card
+  opens, so two projects whose folders share a name — `/work/client` and
+  `/personal/client` — are told apart by ear as well as on screen.
 - Following a link into My Library starts from a clean filter strip. The
   whole strip — every picker, the search box and where the table is looking —
   is set to exactly what the link asked for, and nothing an earlier visit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,10 +143,10 @@ changes carry a **Breaking** call-out with their migration note inline.
 - Scrolling surfaces are the app's own colour rather than the desktop's: a
   long list used to end in a stripe of system chrome, and the thumb is now
   drawn from the app's foreground with the track taken away, in light and
-  dark. Nothing gives up any width for it, so no list shifts sideways as it
-  grows past the window. A system that does not let the app recolour its
-  scrollbar keeps exactly the bar it draws today, and will pick the app's
-  colour up on its own once it supports the setting.
+  dark. Nothing gives up any width for it, so nothing moves that did not
+  move before. A system that does not let the app recolour its scrollbar
+  keeps exactly the bar it draws today, and will pick the app's colour up on
+  its own once it supports the setting.
 - The app uses the Geist typeface, with titles and navigation in Geist Mono
   to match the website.
 - **Breaking**: the default Homebrew install is now the app —
@@ -179,9 +179,9 @@ changes carry a **Breaking** call-out with their migration note inline.
   unaffected, whether you installed one or built it with `--release`.
 
 - "How a marketplace repo works" can be read from the keyboard. The document
-  is longer than the box it opens in, and only a mouse could scroll it, so
-  everything past the first screen was out of reach; `Tab` now reaches the
-  document itself and the keyboard scrolls it.
+  is longer than the box it opens in and had no tab stop of its own, so the
+  only way in from the keyboard was a link near its end; `Tab` now reaches
+  the document itself and the keyboard scrolls it.
 - The project-management skill's issue pipeline creates Linear issues
   directly in Backlog instead of the team's Triage default. Pipeline output
   is already fully triaged — project, labels, priority, relations — and a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,17 +134,18 @@ changes carry a **Breaking** call-out with their migration note inline.
   card — Personal included — shows everything installed there, unfiltered.
   Seeing a whole project used to mean picking a kind you did not want and
   then clearing the filter.
-- Following a link into My Library starts from a clean filter strip. Type,
-  tool, tag, source, search and location are set to exactly what the link
-  asked for and nothing an earlier visit left narrowed carries over, so a
-  count badge, Home's "Installed" tile and a recently-changed row each land
-  on the list they name rather than on that list narrowed again by whatever
-  was on screen last time.
+- Following a link into My Library starts from a clean filter strip. The
+  whole strip — every picker, the search box and where the table is looking —
+  is set to exactly what the link asked for, and nothing an earlier visit
+  left narrowed carries over, so a count badge, Home's "Installed" tile and a
+  recently-changed row each land on the list they name rather than on that
+  list narrowed again by whatever was on screen last time.
 - Scrolling surfaces are the app's own colour rather than the desktop's: a
   long list used to end in a stripe of system chrome, and the thumb is now
   drawn from the app's foreground with the track taken away, in light and
-  dark. Each platform keeps its own scrollbar shape and width, so no list
-  shifts sideways as it grows past the window.
+  dark. Each platform keeps its own scrollbar shape and width, so on Linux
+  and macOS — where the bar floats over the list — no list shifts sideways as
+  it grows past the window.
 - The app uses the Geist typeface, with titles and navigation in Geist Mono
   to match the website.
 - **Breaking**: the default Homebrew install is now the app —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,14 +131,20 @@ changes carry a **Breaking** call-out with their migration note inline.
   as a different set of problems. Re-accept or re-dismiss from the tokens
   `kendex findings` prints now.
 - A project card on Projects opens that project's library. Clicking the
-  card — Personal included — shows everything installed there, unfiltered;
-  the count badges keep narrowing to one kind, as before. Seeing a whole
-  project used to mean picking a kind you did not want and then clearing
-  the filter.
-- Scrolling surfaces draw the app's own scrollbar rather than the desktop's.
-  A long list used to end in a stripe of system chrome — arrow buttons and
-  a pale track on Linux, something else on macOS and Windows; it is now one
-  quiet thumb, the same on every platform, in light and dark.
+  card — Personal included — shows everything installed there, unfiltered.
+  Seeing a whole project used to mean picking a kind you did not want and
+  then clearing the filter.
+- Following a link into My Library starts from a clean filter strip. Type,
+  tool, tag, source, search and location are set to exactly what the link
+  asked for and nothing an earlier visit left narrowed carries over, so a
+  count badge, Home's "Installed" tile and a recently-changed row each land
+  on the list they name rather than on that list narrowed again by whatever
+  was on screen last time.
+- Scrolling surfaces are the app's own colour rather than the desktop's: a
+  long list used to end in a stripe of system chrome, and the thumb is now
+  drawn from the app's foreground with the track taken away, in light and
+  dark. Each platform keeps its own scrollbar shape and width, so no list
+  shifts sideways as it grows past the window.
 - The app uses the Geist typeface, with titles and navigation in Geist Mono
   to match the website.
 - **Breaking**: the default Homebrew install is now the app —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,15 @@ changes carry a **Breaking** call-out with their migration note inline.
   reported as "the safety rules changed since it was reviewed" rather than
   as a different set of problems. Re-accept or re-dismiss from the tokens
   `kendex findings` prints now.
+- A project card on Projects opens that project's library. Clicking the
+  card — Personal included — shows everything installed there, unfiltered;
+  the count badges keep narrowing to one kind, as before. Seeing a whole
+  project used to mean picking a kind you did not want and then clearing
+  the filter.
+- Scrolling surfaces draw the app's own scrollbar rather than the desktop's.
+  A long list used to end in a stripe of system chrome — arrow buttons and
+  a pale track on Linux, something else on macOS and Windows; it is now one
+  quiet thumb, the same on every platform, in light and dark.
 - The app uses the Geist typeface, with titles and navigation in Geist Mono
   to match the website.
 - **Breaking**: the default Homebrew install is now the app —

--- a/ui/src/components/harnesses/project-card.tsx
+++ b/ui/src/components/harnesses/project-card.tsx
@@ -15,6 +15,7 @@ export function ProjectCard({
   name,
   subtitle,
   counts,
+  onOpen,
   onKindClick,
   emptyLabel,
   badge,
@@ -23,6 +24,10 @@ export function ProjectCard({
   name: string;
   subtitle: string;
   counts: [ItemKind, number][];
+  /** Open this project's whole library. The card is the target for it —
+   * a count badge narrows to one kind, and there was no way to ask for
+   * everything without picking a kind first. */
+  onOpen: () => void;
   onKindClick: (kind: ItemKind) => void;
   emptyLabel: string;
   /** A state worth flagging beside the name, e.g. a missing folder. */
@@ -30,7 +35,25 @@ export function ProjectCard({
   action?: ReactNode;
 }) {
   return (
-    <Card className="gap-3 py-4">
+    <Card
+      role="button"
+      tabIndex={0}
+      aria-label={`Show everything in ${name}`}
+      // The controls inside the card mean their own thing, not "open the
+      // project" — a click that lands on one has already been answered, and
+      // a key pressed there belongs to whatever has focus.
+      onClick={(e) => {
+        if ((e.target as HTMLElement).closest("button")) return;
+        onOpen();
+      }}
+      onKeyDown={(e) => {
+        if (e.target !== e.currentTarget) return;
+        if (e.key !== "Enter" && e.key !== " ") return;
+        e.preventDefault();
+        onOpen();
+      }}
+      className="gap-3 py-4 hover:bg-accent/40 focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-none"
+    >
       <div className="flex items-start justify-between gap-3 px-4">
         <div className="min-w-0">
           <div className="flex flex-wrap items-center gap-2">

--- a/ui/src/components/harnesses/project-card.tsx
+++ b/ui/src/components/harnesses/project-card.tsx
@@ -3,6 +3,7 @@ import type { ItemKind } from "@/bindings";
 import { KindCountBadges } from "@/components/kind-count-badges";
 import { Badge } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
+import { showEverythingLabel } from "@/lib/project-card-label";
 
 /**
  * One place a setup applies — Personal, or a project folder. Personal and a
@@ -14,6 +15,7 @@ import { Card } from "@/components/ui/card";
 export function ProjectCard({
   name,
   subtitle,
+  path,
   counts,
   onOpen,
   onKindClick,
@@ -23,6 +25,10 @@ export function ProjectCard({
 }: {
   name: string;
   subtitle: string;
+  /** The folder this card is for, where it has one. The name is only that
+   * folder's last segment, which two projects can share, so it is what a
+   * label says to name one card apart from another. */
+  path?: string;
   counts: [ItemKind, number][];
   /** Show everything installed here — what the project's name is a button
    * for. A count badge narrows to one kind, and there was no way to ask for
@@ -54,7 +60,7 @@ export function ProjectCard({
             <button
               type="button"
               onClick={onOpen}
-              aria-label={`Show everything in ${name}`}
+              aria-label={showEverythingLabel(name, path)}
               className="truncate text-sm font-medium hover:underline"
             >
               {name}

--- a/ui/src/components/harnesses/project-card.tsx
+++ b/ui/src/components/harnesses/project-card.tsx
@@ -24,8 +24,8 @@ export function ProjectCard({
   name: string;
   subtitle: string;
   counts: [ItemKind, number][];
-  /** Open this project's whole library. The card is the target for it —
-   * a count badge narrows to one kind, and there was no way to ask for
+  /** Show everything installed here — what the project's name is a button
+   * for. A count badge narrows to one kind, and there was no way to ask for
    * everything without picking a kind first. */
   onOpen: () => void;
   onKindClick: (kind: ItemKind) => void;
@@ -36,28 +36,29 @@ export function ProjectCard({
 }) {
   return (
     <Card
-      role="button"
-      tabIndex={0}
-      aria-label={`Show everything in ${name}`}
-      // The controls inside the card mean their own thing, not "open the
-      // project" — a click that lands on one has already been answered, and
-      // a key pressed there belongs to whatever has focus.
-      onClick={(e) => {
-        if ((e.target as HTMLElement).closest("button")) return;
+      // A shortcut for the mouse, on top of the name's own button: the card
+      // reads as one target, so clicking its empty space should do what the
+      // card is for. Every control inside it means something else and has
+      // already answered the click; a drag that ends here was someone
+      // keeping the path, not asking to leave the page.
+      onClick={(event) => {
+        if ((event.target as HTMLElement).closest("button")) return;
+        if (window.getSelection()?.isCollapsed === false) return;
         onOpen();
       }}
-      onKeyDown={(e) => {
-        if (e.target !== e.currentTarget) return;
-        if (e.key !== "Enter" && e.key !== " ") return;
-        e.preventDefault();
-        onOpen();
-      }}
-      className="gap-3 py-4 hover:bg-accent/40 focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-none"
+      className="cursor-pointer gap-3 py-4 hover:bg-accent/40"
     >
       <div className="flex items-start justify-between gap-3 px-4">
         <div className="min-w-0">
           <div className="flex flex-wrap items-center gap-2">
-            <span className="truncate text-sm font-medium">{name}</span>
+            <button
+              type="button"
+              onClick={onOpen}
+              aria-label={`Show everything in ${name}`}
+              className="truncate text-sm font-medium hover:underline"
+            >
+              {name}
+            </button>
             {badge ? <Badge variant="destructive">{badge}</Badge> : null}
           </div>
           <p className="truncate text-[13px] text-muted-foreground">

--- a/ui/src/components/harnesses/project-list.tsx
+++ b/ui/src/components/harnesses/project-list.tsx
@@ -15,7 +15,6 @@ import { useSettingsStore } from "@/stores/settings";
 /** "Projects": personal plus every registered project, one card each. */
 export function ProjectList() {
   const result = useScanStore((s) => s.result);
-  const setLibraryScope = useNavStore((s) => s.setLibraryScope);
   const goToLibrary = useNavStore((s) => s.goToLibrary);
   const { settings, registerProject, unregisterProject, discoverProjects } =
     useSettingsStore();
@@ -45,14 +44,8 @@ export function ProjectList() {
           subtitle="Works in every project on this computer"
           counts={[...countByKind(globalItems).entries()]}
           emptyLabel="Nothing from kendex yet."
-          onOpen={() => {
-            setLibraryScope("global");
-            goToLibrary();
-          }}
-          onKindClick={(kind) => {
-            setLibraryScope("global");
-            goToLibrary({ kind });
-          }}
+          onOpen={() => goToLibrary({ scope: "global" })}
+          onKindClick={(kind) => goToLibrary({ kind, scope: "global" })}
         />
 
         {projects.length === 0 ? (
@@ -78,14 +71,10 @@ export function ProjectList() {
                     ? "Folder not found"
                     : undefined
                 }
-                onOpen={() => {
-                  setLibraryScope({ project: root });
-                  goToLibrary();
-                }}
-                onKindClick={(kind) => {
-                  setLibraryScope({ project: root });
-                  goToLibrary({ kind });
-                }}
+                onOpen={() => goToLibrary({ scope: { project: root } })}
+                onKindClick={(kind) =>
+                  goToLibrary({ kind, scope: { project: root } })
+                }
                 action={
                   <Button
                     variant="ghost"

--- a/ui/src/components/harnesses/project-list.tsx
+++ b/ui/src/components/harnesses/project-list.tsx
@@ -45,6 +45,10 @@ export function ProjectList() {
           subtitle="Works in every project on this computer"
           counts={[...countByKind(globalItems).entries()]}
           emptyLabel="Nothing from kendex yet."
+          onOpen={() => {
+            setLibraryScope("global");
+            goToLibrary();
+          }}
           onKindClick={(kind) => {
             setLibraryScope("global");
             goToLibrary({ kind });
@@ -74,6 +78,10 @@ export function ProjectList() {
                     ? "Folder not found"
                     : undefined
                 }
+                onOpen={() => {
+                  setLibraryScope({ project: root });
+                  goToLibrary();
+                }}
                 onKindClick={(kind) => {
                   setLibraryScope({ project: root });
                   goToLibrary({ kind });

--- a/ui/src/components/harnesses/project-list.tsx
+++ b/ui/src/components/harnesses/project-list.tsx
@@ -64,6 +64,7 @@ export function ProjectList() {
                 key={root}
                 name={name}
                 subtitle={root}
+                path={root}
                 counts={[...countByKind(items).entries()]}
                 emptyLabel="Nothing from kendex yet."
                 badge={

--- a/ui/src/components/library/apply-library-view.test.ts
+++ b/ui/src/components/library/apply-library-view.test.ts
@@ -1,12 +1,12 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { UNFILTERED } from "@/lib/library-handoff";
-import { NO_FILTERS, useLibraryViewStore } from "@/stores/library-view";
+import { useLibraryViewStore } from "@/stores/library-view";
 import { useNavStore } from "@/stores/nav";
 import { applyLibraryView } from "./use-filter-handoff";
 
 describe("applyLibraryView", () => {
   beforeEach(() => {
-    useLibraryViewStore.setState({ ...NO_FILTERS, scrollTop: 0 });
+    useLibraryViewStore.setState(useLibraryViewStore.getInitialState(), true);
     useNavStore.setState({ search: "", libraryScope: "all" });
   });
 

--- a/ui/src/components/library/apply-library-view.test.ts
+++ b/ui/src/components/library/apply-library-view.test.ts
@@ -5,9 +5,16 @@ import { useNavStore } from "@/stores/nav";
 import { applyLibraryView } from "./use-filter-handoff";
 
 describe("applyLibraryView", () => {
+  // Both halves start from the one definition of an unfiltered view, so a
+  // change to what unfiltered means reaches this suite. Only the two fields
+  // the view owns are touched: the nav store also holds the page, its history
+  // and refs, which this suite has no business resetting.
   beforeEach(() => {
     useLibraryViewStore.setState(useLibraryViewStore.getInitialState(), true);
-    useNavStore.setState({ search: "", libraryScope: "all" });
+    useNavStore.setState({
+      search: UNFILTERED.search,
+      libraryScope: UNFILTERED.scope,
+    });
   });
 
   it("puts every part of a view where that part is kept", () => {
@@ -33,7 +40,7 @@ describe("applyLibraryView", () => {
     const view = useLibraryViewStore.getState();
     expect(view.kind).toBe("any");
     expect(view.tag).toBe("any");
-    expect(useNavStore.getState().search).toBe("");
-    expect(useNavStore.getState().libraryScope).toBe("all");
+    expect(useNavStore.getState().search).toBe(UNFILTERED.search);
+    expect(useNavStore.getState().libraryScope).toBe(UNFILTERED.scope);
   });
 });

--- a/ui/src/components/library/apply-library-view.test.ts
+++ b/ui/src/components/library/apply-library-view.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { UNFILTERED } from "@/lib/library-handoff";
+import { NO_FILTERS, useLibraryViewStore } from "@/stores/library-view";
+import { useNavStore } from "@/stores/nav";
+import { applyLibraryView } from "./use-filter-handoff";
+
+describe("applyLibraryView", () => {
+  beforeEach(() => {
+    useLibraryViewStore.setState({ ...NO_FILTERS, scrollTop: 0 });
+    useNavStore.setState({ search: "", libraryScope: "all" });
+  });
+
+  it("puts every part of a view where that part is kept", () => {
+    applyLibraryView({
+      filters: { kind: "hook", harness: "claude", tag: "any", from: "any" },
+      search: "deploy",
+      scope: { project: "/x" },
+    });
+
+    const view = useLibraryViewStore.getState();
+    expect(view.kind).toBe("hook");
+    expect(view.harness).toBe("claude");
+    expect(useNavStore.getState().search).toBe("deploy");
+    expect(useNavStore.getState().libraryScope).toEqual({ project: "/x" });
+  });
+
+  it("clears what an earlier view left behind", () => {
+    useLibraryViewStore.setState({ kind: "skill", tag: "review" });
+    useNavStore.setState({ search: "old", libraryScope: "global" });
+
+    applyLibraryView(UNFILTERED);
+
+    const view = useLibraryViewStore.getState();
+    expect(view.kind).toBe("any");
+    expect(view.tag).toBe("any");
+    expect(useNavStore.getState().search).toBe("");
+    expect(useNavStore.getState().libraryScope).toBe("all");
+  });
+});

--- a/ui/src/components/library/installed-view.tsx
+++ b/ui/src/components/library/installed-view.tsx
@@ -6,7 +6,10 @@ import { LibraryFilters } from "@/components/library/library-filters";
 import { LibraryLegend } from "@/components/library/library-legend";
 import { NotManagedPanel } from "@/components/library/not-managed";
 import { TableEmptyRow } from "@/components/library/table-empty";
-import { useFilterHandoff } from "@/components/library/use-filter-handoff";
+import {
+  applyLibraryView,
+  useFilterHandoff,
+} from "@/components/library/use-filter-handoff";
 import {
   Table,
   TableBody,
@@ -23,6 +26,7 @@ import {
   scopeChoices,
 } from "@/lib/derive";
 import { PAGE_GUTTER, WIDE_CONTENT_WIDTH } from "@/lib/layout";
+import { isNarrowed, UNFILTERED } from "@/lib/library-handoff";
 import { scopeKey } from "@/lib/scope";
 import { cn } from "@/lib/utils";
 import { useEditorStore } from "@/stores/editor";
@@ -54,7 +58,6 @@ export function InstalledView() {
     setTag,
     setFrom,
     setScrollTop,
-    clearFilters: clearViewFilters,
   } = useLibraryViewStore();
   const provenance = useProvenanceStore((s) => s.rows);
   const loadProvenance = useProvenanceStore((s) => s.load);
@@ -92,16 +95,17 @@ export function InstalledView() {
       customizedKeys.has(`${scopeKey(scope)}|${group.kind}:${group.name}`),
     );
 
-  useFilterHandoff();
+  const replaced = useFilterHandoff();
 
   // Pick up where the table was last scrolled to, and record it again on the
-  // way out. A link that replaced the view has already reset that to the top.
+  // way out — unless a link replaced the list, in which case that offset
+  // belongs to something no longer on screen.
   useEffect(() => {
     const node = scroller.current;
     if (!node) return;
-    node.scrollTop = useLibraryViewStore.getState().scrollTop;
+    node.scrollTop = replaced ? 0 : useLibraryViewStore.getState().scrollTop;
     return () => setScrollTop(node.scrollTop);
-  }, [setScrollTop]);
+  }, [replaced, setScrollTop]);
 
   const groups = useMemo(() => {
     if (!result) return [];
@@ -137,19 +141,13 @@ export function InstalledView() {
   // Nothing has been counted yet — distinct from "counted, found nothing".
   const scanning = result === null;
   const hasAnyItems = (result?.items.length ?? 0) > 0;
-  const filtered =
-    search !== "" ||
-    kind !== "any" ||
-    harness !== "any" ||
-    tag !== "any" ||
-    from !== "any" ||
-    scope !== "all";
+  const filtered = isNarrowed({
+    filters: { kind, harness, tag, from },
+    search,
+    scope,
+  });
 
-  const clearFilters = () => {
-    clearViewFilters();
-    setSearch("");
-    setScope("all");
-  };
+  const clearFilters = () => applyLibraryView(UNFILTERED);
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">

--- a/ui/src/components/library/installed-view.tsx
+++ b/ui/src/components/library/installed-view.tsx
@@ -6,6 +6,7 @@ import { LibraryFilters } from "@/components/library/library-filters";
 import { LibraryLegend } from "@/components/library/library-legend";
 import { NotManagedPanel } from "@/components/library/not-managed";
 import { TableEmptyRow } from "@/components/library/table-empty";
+import { useFilterHandoff } from "@/components/library/use-filter-handoff";
 import {
   Table,
   TableBody,
@@ -43,7 +44,6 @@ export function InstalledView() {
   const setScope = useNavStore((s) => s.setLibraryScope);
   const goToMarketplaces = useNavStore((s) => s.goToMarketplaces);
   const goToPackage = useNavStore((s) => s.goToPackage);
-  const clearLibraryFilter = useNavStore((s) => s.clearLibraryFilter);
   const {
     kind,
     harness,
@@ -92,17 +92,7 @@ export function InstalledView() {
       customizedKeys.has(`${scopeKey(scope)}|${group.kind}:${group.name}`),
     );
 
-  // The filter is a one-time handoff from wherever the link was clicked
-  // (Harnesses, Projects); once applied, further tab visits start from the
-  // stored view again rather than reapplying a stale filter.
-  useEffect(() => {
-    const handoff = useNavStore.getState().libraryFilter;
-    if (handoff) {
-      setKind(handoff.kind ?? "any");
-      setHarness(handoff.harness ?? "any");
-    }
-    clearLibraryFilter();
-  }, [clearLibraryFilter, setKind, setHarness]);
+  useFilterHandoff();
 
   // Restore where the table was scrolled to when it last unmounted, and
   // record it again on the way out.

--- a/ui/src/components/library/installed-view.tsx
+++ b/ui/src/components/library/installed-view.tsx
@@ -30,7 +30,10 @@ import { isNarrowed, UNFILTERED } from "@/lib/library-handoff";
 import { scopeKey } from "@/lib/scope";
 import { cn } from "@/lib/utils";
 import { useEditorStore } from "@/stores/editor";
-import { useLibraryViewStore } from "@/stores/library-view";
+import {
+  type FilterSelection,
+  useLibraryViewStore,
+} from "@/stores/library-view";
 import { useNavStore } from "@/stores/nav";
 import {
   originFor,
@@ -141,11 +144,8 @@ export function InstalledView() {
   // Nothing has been counted yet — distinct from "counted, found nothing".
   const scanning = result === null;
   const hasAnyItems = (result?.items.length ?? 0) > 0;
-  const filtered = isNarrowed({
-    filters: { kind, harness, tag, from },
-    search,
-    scope,
-  });
+  const filters: FilterSelection = { kind, harness, tag, from };
+  const filtered = isNarrowed({ filters, search, scope });
 
   const clearFilters = () => applyLibraryView(UNFILTERED);
 

--- a/ui/src/components/library/installed-view.tsx
+++ b/ui/src/components/library/installed-view.tsx
@@ -20,7 +20,7 @@ import {
   filterItems,
   groupItems,
   groupScopes,
-  projectScopes,
+  scopeChoices,
 } from "@/lib/derive";
 import { PAGE_GUTTER, WIDE_CONTENT_WIDTH } from "@/lib/layout";
 import { scopeKey } from "@/lib/scope";
@@ -62,7 +62,7 @@ export function InstalledView() {
   // back lands on the same narrowed table.
   const search = useNavStore((s) => s.search);
   const setSearch = useNavStore((s) => s.setSearch);
-  const projects = result ? projectScopes(result) : [];
+  const projects = scopeChoices(result, scope);
   const scroller = useRef<HTMLDivElement | null>(null);
   // Every scope's manifest, so a row can say whether you have changed the
   // package wherever it is installed — not only in the scope last edited.
@@ -94,8 +94,8 @@ export function InstalledView() {
 
   useFilterHandoff();
 
-  // Restore where the table was scrolled to when it last unmounted, and
-  // record it again on the way out.
+  // Pick up where the table was last scrolled to, and record it again on the
+  // way out. A link that replaced the view has already reset that to the top.
   useEffect(() => {
     const node = scroller.current;
     if (!node) return;

--- a/ui/src/components/library/library-filters.tsx
+++ b/ui/src/components/library/library-filters.tsx
@@ -157,9 +157,11 @@ export function LibraryFilters({
           />
         </div>
         <div className="flex flex-wrap items-center justify-between gap-x-6 gap-y-3">
-          {projects.length > 0 ? (
-            // With no projects there is nothing to choose between — the pills
-            // would offer two buttons that show the same list.
+          {projects.length > 0 || scope !== "all" ? (
+            // With no projects and nowhere picked there is nothing to choose
+            // between — the pills would offer two buttons showing the same
+            // list. Once somewhere is picked they always show, so where the
+            // table is looking is never a narrowing with no cause on screen.
             <ScopePills
               scope={scope}
               onScopeChange={onScopeChange}

--- a/ui/src/components/library/scope-pills.tsx
+++ b/ui/src/components/library/scope-pills.tsx
@@ -11,7 +11,8 @@ export function ScopePills({
 }: {
   scope: ScopeSelection;
   onScopeChange: (scope: ScopeSelection) => void;
-  /** Project roots that currently have at least one item. */
+  /** Project roots to offer: the ones holding something, and the one being
+   * looked at. */
   projects: string[];
 }) {
   return (

--- a/ui/src/components/library/scope-pills.tsx
+++ b/ui/src/components/library/scope-pills.tsx
@@ -2,8 +2,9 @@ import { Pill } from "@/components/pill";
 import type { ScopeSelection } from "@/lib/derive";
 import { scopeName } from "@/lib/labels";
 
-/** Where the table is looking: the same app-wide scope the sidebar sets, so
- *  the two can never disagree about which project is on screen. */
+/** Where the table is looking. The Library's own location filter — no other
+ *  page narrows by location, they state it on each row — and a link into the
+ *  Library can name one on the way in. */
 export function ScopePills({
   scope,
   onScopeChange,

--- a/ui/src/components/library/use-filter-handoff.ts
+++ b/ui/src/components/library/use-filter-handoff.ts
@@ -1,0 +1,32 @@
+import { useEffect } from "react";
+import { useLibraryViewStore } from "@/stores/library-view";
+import { useNavStore } from "@/stores/nav";
+
+/**
+ * Apply the filter a link into the Library asked for, once, on arrival.
+ *
+ * The handoff comes from wherever the link was clicked — Harnesses,
+ * Projects, Home — and a link states the whole narrowing it wants, so
+ * whatever an earlier visit left behind goes first: otherwise "everything
+ * in this project" arrives still narrowed to the last kind looked at.
+ * Where to look is not part of it — the caller sets the scope on the way
+ * here. Arriving with no link at all leaves the stored view standing.
+ */
+export function useFilterHandoff() {
+  const clearLibraryFilter = useNavStore((s) => s.clearLibraryFilter);
+  const setSearch = useNavStore((s) => s.setSearch);
+  const setKind = useLibraryViewStore((s) => s.setKind);
+  const setHarness = useLibraryViewStore((s) => s.setHarness);
+  const clearViewFilters = useLibraryViewStore((s) => s.clearFilters);
+
+  useEffect(() => {
+    const handoff = useNavStore.getState().libraryFilter;
+    if (handoff) {
+      clearViewFilters();
+      setSearch("");
+      setKind(handoff.kind ?? "any");
+      setHarness(handoff.harness ?? "any");
+    }
+    clearLibraryFilter();
+  }, [clearLibraryFilter, clearViewFilters, setSearch, setKind, setHarness]);
+}

--- a/ui/src/components/library/use-filter-handoff.ts
+++ b/ui/src/components/library/use-filter-handoff.ts
@@ -1,29 +1,42 @@
-import { useEffect } from "react";
-import { libraryViewFromHandoff } from "@/lib/library-handoff";
+import { useLayoutEffect, useState } from "react";
+import {
+  type LibraryView,
+  libraryViewFromHandoff,
+} from "@/lib/library-handoff";
 import { useLibraryViewStore } from "@/stores/library-view";
 import { useNavStore } from "@/stores/nav";
 
+/** Show a view: write each part of it to the store that holds that part. */
+export function applyLibraryView(view: LibraryView): void {
+  useLibraryViewStore.getState().setFilters(view.filters);
+  const nav = useNavStore.getState();
+  nav.setSearch(view.search);
+  nav.setLibraryScope(view.scope);
+}
+
 /**
- * Adopt the view a link into the Library asked for, once, on arrival.
+ * Adopt the view a link into the Library asked for, once, on arrival, and
+ * say whether one did. A caller that has its own idea of where the table
+ * should be — the scroll position — needs that answer: the offset a previous
+ * visit left belongs to the list a link has just replaced.
  *
  * The handoff comes from wherever the link was clicked — Harnesses, Projects,
- * Home. What it means is {@link libraryViewFromHandoff}'s to decide; this
- * writes that answer to the stores holding each part of the view, then
- * consumes the handoff so a later visit starts from the stored view again.
+ * Home. What it means is {@link libraryViewFromHandoff}'s to decide; consuming
+ * it here is what makes a later visit start from the stored view again.
  */
-export function useFilterHandoff() {
+export function useFilterHandoff(): boolean {
   const clearLibraryFilter = useNavStore((s) => s.clearLibraryFilter);
-  const setSearch = useNavStore((s) => s.setSearch);
-  const setScope = useNavStore((s) => s.setLibraryScope);
-  const setView = useLibraryViewStore((s) => s.setView);
-
-  useEffect(() => {
-    const view = libraryViewFromHandoff(useNavStore.getState().libraryFilter);
-    if (view) {
-      setView(view);
-      setSearch(view.search);
-      setScope(view.scope);
-    }
+  // Read while the handoff is still there. Consuming it below empties it, and
+  // a later render must not read that emptiness as "no link opened the page".
+  const [view] = useState(() =>
+    libraryViewFromHandoff(useNavStore.getState().libraryFilter),
+  );
+  // Layout rather than passive: where the table looks decides which rows it
+  // has at all, so writing the link's view after the first paint would put
+  // the list being replaced on screen before the one that was asked for.
+  useLayoutEffect(() => {
+    if (view) applyLibraryView(view);
     clearLibraryFilter();
-  }, [clearLibraryFilter, setSearch, setScope, setView]);
+  }, [view, clearLibraryFilter]);
+  return view !== null;
 }

--- a/ui/src/components/library/use-filter-handoff.ts
+++ b/ui/src/components/library/use-filter-handoff.ts
@@ -1,32 +1,29 @@
 import { useEffect } from "react";
+import { libraryViewFromHandoff } from "@/lib/library-handoff";
 import { useLibraryViewStore } from "@/stores/library-view";
 import { useNavStore } from "@/stores/nav";
 
 /**
- * Apply the filter a link into the Library asked for, once, on arrival.
+ * Adopt the view a link into the Library asked for, once, on arrival.
  *
- * The handoff comes from wherever the link was clicked — Harnesses,
- * Projects, Home — and a link states the whole narrowing it wants, so
- * whatever an earlier visit left behind goes first: otherwise "everything
- * in this project" arrives still narrowed to the last kind looked at.
- * Where to look is not part of it — the caller sets the scope on the way
- * here. Arriving with no link at all leaves the stored view standing.
+ * The handoff comes from wherever the link was clicked — Harnesses, Projects,
+ * Home. What it means is {@link libraryViewFromHandoff}'s to decide; this
+ * writes that answer to the stores holding each part of the view, then
+ * consumes the handoff so a later visit starts from the stored view again.
  */
 export function useFilterHandoff() {
   const clearLibraryFilter = useNavStore((s) => s.clearLibraryFilter);
   const setSearch = useNavStore((s) => s.setSearch);
-  const setKind = useLibraryViewStore((s) => s.setKind);
-  const setHarness = useLibraryViewStore((s) => s.setHarness);
-  const clearViewFilters = useLibraryViewStore((s) => s.clearFilters);
+  const setScope = useNavStore((s) => s.setLibraryScope);
+  const setView = useLibraryViewStore((s) => s.setView);
 
   useEffect(() => {
-    const handoff = useNavStore.getState().libraryFilter;
-    if (handoff) {
-      clearViewFilters();
-      setSearch("");
-      setKind(handoff.kind ?? "any");
-      setHarness(handoff.harness ?? "any");
+    const view = libraryViewFromHandoff(useNavStore.getState().libraryFilter);
+    if (view) {
+      setView(view);
+      setSearch(view.search);
+      setScope(view.scope);
     }
     clearLibraryFilter();
-  }, [clearLibraryFilter, clearViewFilters, setSearch, setKind, setHarness]);
+  }, [clearLibraryFilter, setSearch, setScope, setView]);
 }

--- a/ui/src/components/marketplaces/mine-tab.tsx
+++ b/ui/src/components/marketplaces/mine-tab.tsx
@@ -134,13 +134,27 @@ export function MineTab() {
           <DialogHeader>
             <DialogTitle>How a marketplace repo works</DialogTitle>
           </DialogHeader>
-          <div className="max-h-[70vh] overflow-y-auto pr-3">
+          {/* biome-ignore-start lint/a11y/noNoninteractiveTabindex: the
+              document is longer than the dialog and carries almost no links,
+              so without a tab stop of its own everything past the first
+              screen needs a mouse — WKWebView and WebKitGTK, two of the three
+              engines the app ships on, do not focus an overflowing container
+              by themselves. Reaching a scrollable region by keyboard is what
+              the WCAG scrollable-region-focusable rule asks for, and what
+              this rule would take away. */}
+          <section
+            tabIndex={0}
+            aria-label="How a marketplace repo works"
+            className="max-h-[70vh] overflow-y-auto pr-3 outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
+          >
             {doc === null ? (
               <TextBar width="w-64" />
             ) : (
               <MarkdownView source={doc} />
             )}
-          </div>
+          </section>
+          {/* biome-ignore-end lint/a11y/noNoninteractiveTabindex: the rule
+              stands for everything else here. */}
         </DialogContent>
       </Dialog>
       <MineSubmitDialog

--- a/ui/src/components/marketplaces/mine-tab.tsx
+++ b/ui/src/components/marketplaces/mine-tab.tsx
@@ -11,7 +11,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import { useAccountStore } from "@/stores/account";
 import { useMineStore } from "@/stores/mine";
 import { MineCreateDialog } from "./mine-create-dialog";
@@ -135,13 +134,13 @@ export function MineTab() {
           <DialogHeader>
             <DialogTitle>How a marketplace repo works</DialogTitle>
           </DialogHeader>
-          <ScrollArea className="max-h-[70vh] pr-3">
+          <div className="max-h-[70vh] overflow-y-auto pr-3">
             {doc === null ? (
               <TextBar width="w-64" />
             ) : (
               <MarkdownView source={doc} />
             )}
-          </ScrollArea>
+          </div>
         </DialogContent>
       </Dialog>
       <MineSubmitDialog

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -184,32 +184,18 @@
   ) {
     cursor: pointer;
   }
-  /* The platform scrollbar is a different width, shape and colour on every
-     desktop kendex runs on, so a long list ended in a stripe of someone
-     else's chrome. One thumb, drawn from the app's own foreground, reads the
-     same on all of them. Sized to match the space the layout already
-     reserves via scrollbar-gutter, so nothing reflows. */
-  ::-webkit-scrollbar {
-    width: 10px;
-    height: 10px;
-  }
-  ::-webkit-scrollbar-track,
-  ::-webkit-scrollbar-corner {
-    background: transparent;
-  }
-  ::-webkit-scrollbar-thumb {
-    /* The border is transparent and clipped to the padding box: it insets the
-       thumb without shrinking the grab target. */
-    background-color: color-mix(in oklab, var(--foreground) 20%, transparent);
-    background-clip: padding-box;
-    border: 3px solid transparent;
-    border-radius: 9999px;
-  }
-  ::-webkit-scrollbar-thumb:hover {
-    background-color: color-mix(in oklab, var(--foreground) 35%, transparent);
-  }
-  ::-webkit-scrollbar-thumb:active {
-    background-color: color-mix(in oklab, var(--foreground) 45%, transparent);
+  /* The desktop's own scrollbar ends a long list in a pale stripe of someone
+     else's chrome, so the thumb is drawn from the app's foreground and the
+     track is taken away. Colour only — each platform keeps its own scrollbar
+     shape and width, which is what stops a list from jumping sideways as it
+     starts and stops overflowing: on WebKitGTK 2.52, the Linux runtime, the
+     bar is a zero-width overlay and scrollbar-gutter reserves nothing, so a
+     width set here would be content width taken away the moment a list
+     overflows and handed back when it stops. Inherited, so every scroller in
+     the app is covered without naming any of them. */
+  html {
+    scrollbar-color: color-mix(in oklab, var(--foreground) 30%, transparent)
+      transparent;
   }
 }
 

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -184,6 +184,33 @@
   ) {
     cursor: pointer;
   }
+  /* The platform scrollbar is a different width, shape and colour on every
+     desktop kendex runs on, so a long list ended in a stripe of someone
+     else's chrome. One thumb, drawn from the app's own foreground, reads the
+     same on all of them. Sized to match the space the layout already
+     reserves via scrollbar-gutter, so nothing reflows. */
+  ::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+  }
+  ::-webkit-scrollbar-track,
+  ::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+  ::-webkit-scrollbar-thumb {
+    /* The border is transparent and clipped to the padding box: it insets the
+       thumb without shrinking the grab target. */
+    background-color: color-mix(in oklab, var(--foreground) 20%, transparent);
+    background-clip: padding-box;
+    border: 3px solid transparent;
+    border-radius: 9999px;
+  }
+  ::-webkit-scrollbar-thumb:hover {
+    background-color: color-mix(in oklab, var(--foreground) 35%, transparent);
+  }
+  ::-webkit-scrollbar-thumb:active {
+    background-color: color-mix(in oklab, var(--foreground) 45%, transparent);
+  }
 }
 
 /* Rendered-markdown preview (SKILL.md etc.) — no typography plugin in this

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -186,16 +186,46 @@
   }
   /* The desktop's own scrollbar ends a long list in a pale stripe of someone
      else's chrome, so the thumb is drawn from the app's foreground and the
-     track is taken away. Colour only — each platform keeps its own scrollbar
-     shape and width, which is what stops a list from jumping sideways as it
-     starts and stops overflowing: on WebKitGTK 2.52, the Linux runtime, the
-     bar is a zero-width overlay and scrollbar-gutter reserves nothing, so a
-     width set here would be content width taken away the moment a list
-     overflows and handed back when it stops. Inherited, so every scroller in
-     the app is covered without naming any of them. */
+     track is taken away. Said twice because no one property reaches every
+     runtime this app ships on: WebKit honours scrollbar-color only from
+     26.2, so the Mac would otherwise keep the system bar, and the
+     pseudo-element is the recolour it has always understood.
+
+     Where both are honoured the modern property wins outright, which is what
+     makes stating both safe. Measured on WebKitGTK 2.52.5, the Linux runtime,
+     as offsetWidth minus clientWidth in both overflow states and both themes:
+     scrollbar-color alone reserves nothing, the pseudo-element alone reserves
+     10px the moment a list overflows and hands it back when it stops — a
+     sideways jump — and the two together reserve nothing and paint the same
+     pixels as scrollbar-color alone. Widths belong to the platform for that
+     reason: an overlay bar on Linux takes no content width, a classic one on
+     Windows does. Inherited and unscoped, so every scroller in the app is
+     covered without naming any of them. */
   html {
     scrollbar-color: color-mix(in oklab, var(--foreground) 30%, transparent)
       transparent;
+  }
+  ::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+  }
+  ::-webkit-scrollbar-track,
+  ::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+  ::-webkit-scrollbar-thumb {
+    /* The border is transparent and clipped to the padding box: it insets the
+       thumb without shrinking the grab target. */
+    background-color: color-mix(in oklab, var(--foreground) 20%, transparent);
+    background-clip: padding-box;
+    border: 3px solid transparent;
+    border-radius: 9999px;
+  }
+  ::-webkit-scrollbar-thumb:hover {
+    background-color: color-mix(in oklab, var(--foreground) 35%, transparent);
+  }
+  ::-webkit-scrollbar-thumb:active {
+    background-color: color-mix(in oklab, var(--foreground) 45%, transparent);
   }
 }
 

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -186,46 +186,21 @@
   }
   /* The desktop's own scrollbar ends a long list in a pale stripe of someone
      else's chrome, so the thumb is drawn from the app's foreground and the
-     track is taken away. Said twice because no one property reaches every
-     runtime this app ships on: WebKit honours scrollbar-color only from
-     26.2, so the Mac would otherwise keep the system bar, and the
-     pseudo-element is the recolour it has always understood.
+     track is taken away. Inherited and unscoped, so every scroller in the app
+     is covered without naming any of them.
 
-     Where both are honoured the modern property wins outright, which is what
-     makes stating both safe. Measured on WebKitGTK 2.52.5, the Linux runtime,
-     as offsetWidth minus clientWidth in both overflow states and both themes:
-     scrollbar-color alone reserves nothing, the pseudo-element alone reserves
-     10px the moment a list overflows and hands it back when it stops — a
-     sideways jump — and the two together reserve nothing and paint the same
-     pixels as scrollbar-color alone. Widths belong to the platform for that
-     reason: an overlay bar on Linux takes no content width, a classic one on
-     Windows does. Inherited and unscoped, so every scroller in the app is
-     covered without naming any of them. */
+     This property and nothing else. The ::-webkit-scrollbar pseudo-element
+     recolours the same bars, but measured on WebKitGTK 2.52.5 as offsetWidth
+     minus clientWidth, in both overflow states and both themes, it takes 10px
+     of content width the moment a list overflows and hands it back when it
+     stops — every list jumping sideways as it crosses that line — where
+     scrollbar-color takes nothing in either state. A runtime that does not
+     honour scrollbar-color keeps the scrollbar it already draws, at the width
+     and shape that runtime chose, and picks the colour up if it gains
+     support. */
   html {
     scrollbar-color: color-mix(in oklab, var(--foreground) 30%, transparent)
       transparent;
-  }
-  ::-webkit-scrollbar {
-    width: 10px;
-    height: 10px;
-  }
-  ::-webkit-scrollbar-track,
-  ::-webkit-scrollbar-corner {
-    background: transparent;
-  }
-  ::-webkit-scrollbar-thumb {
-    /* The border is transparent and clipped to the padding box: it insets the
-       thumb without shrinking the grab target. */
-    background-color: color-mix(in oklab, var(--foreground) 20%, transparent);
-    background-clip: padding-box;
-    border: 3px solid transparent;
-    border-radius: 9999px;
-  }
-  ::-webkit-scrollbar-thumb:hover {
-    background-color: color-mix(in oklab, var(--foreground) 35%, transparent);
-  }
-  ::-webkit-scrollbar-thumb:active {
-    background-color: color-mix(in oklab, var(--foreground) 45%, transparent);
   }
 }
 

--- a/ui/src/lib/derive-scopes.test.ts
+++ b/ui/src/lib/derive-scopes.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import type { ObservedItem, ScanResult } from "@/bindings";
+import { scopeChoices } from "./derive";
+
+function result(roots: string[]): ScanResult {
+  const items: ObservedItem[] = roots.map((root) => ({
+    kind: "skill",
+    name: "deploy",
+    harness: "claude",
+    scope: { scope: "project", root },
+    path: `${root}/.claude/skills/deploy`,
+    fileState: { state: "dir" },
+    enabled: true,
+    origin: null,
+    description: null,
+    tags: [],
+    modifiedAt: null,
+    vendor: null,
+  }));
+  return { harnesses: [], items, missingProjects: [], warnings: [] };
+}
+
+describe("scopeChoices", () => {
+  it("offers every project holding something", () => {
+    expect(scopeChoices(result(["/b", "/a", "/a"]), "all")).toEqual([
+      "/a",
+      "/b",
+    ]);
+  });
+
+  it("offers the project being looked at even when it holds nothing", () => {
+    // Picked last, listed in its place: the pills read the same however the
+    // project came to be one of them.
+    expect(scopeChoices(result(["/z"]), { project: "/empty" })).toEqual([
+      "/empty",
+      "/z",
+    ]);
+    expect(scopeChoices(null, { project: "/empty" })).toEqual(["/empty"]);
+  });
+
+  it("names the picked project once when it holds something too", () => {
+    expect(scopeChoices(result(["/a"]), { project: "/a" })).toEqual(["/a"]);
+  });
+});

--- a/ui/src/lib/derive.test.ts
+++ b/ui/src/lib/derive.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { AuditView, ObservedItem } from "@/bindings";
+import type { ObservedItem } from "@/bindings";
 import {
   bundleSummary,
   countByKind,
@@ -9,7 +9,6 @@ import {
   groupVendor,
   recentItems,
   scopeMatches,
-  viewsInScope,
 } from "./derive";
 
 function item(overrides: Partial<ObservedItem>): ObservedItem {
@@ -197,32 +196,6 @@ describe("bundleSummary", () => {
 
   it("says so when a bundle carries nothing", () => {
     expect(bundleSummary([])).toBe("Carries nothing yet");
-  });
-});
-
-describe("viewsInScope", () => {
-  const view = (scope: AuditView["scope"]): AuditView => ({
-    scope,
-    drift: [],
-    plan: [],
-    notes: [],
-    warnings: [],
-    safety: [],
-    heldBack: [],
-    queued: [],
-  });
-  const all = [
-    view({ scope: "global" }),
-    view({ scope: "project", root: "/a" }),
-    view({ scope: "project", root: "/b" }),
-  ];
-
-  it("narrows to the picked scope and nothing else", () => {
-    expect(viewsInScope(all, "all")).toHaveLength(3);
-    expect(viewsInScope(all, "global").map((v) => v.scope.scope)).toEqual([
-      "global",
-    ]);
-    expect(viewsInScope(all, { project: "/b" })).toEqual([all[2]]);
   });
 });
 

--- a/ui/src/lib/derive.ts
+++ b/ui/src/lib/derive.ts
@@ -171,6 +171,22 @@ export function projectScopes(result: ScanResult): string[] {
   return [...roots].sort();
 }
 
+/** The places the Library offers to look: every project with something
+ * installed, plus the one being looked at. A project can be picked before it
+ * holds anything — from its card on Projects, or by emptying it while the
+ * table is open — and a place with no pill would leave an empty table with
+ * nothing on screen saying where it is looking. */
+export function scopeChoices(
+  result: ScanResult | null,
+  selection: ScopeSelection,
+): string[] {
+  const roots = new Set(result ? projectScopes(result) : []);
+  if (selection !== "all" && selection !== "global") {
+    roots.add(selection.project);
+  }
+  return [...roots].sort();
+}
+
 // An item whose findings someone read and accepted is installed and staying,
 // so calling it held back would be the opposite of the truth. Only a block
 // with no live acceptance behind it is held back.

--- a/ui/src/lib/derive.ts
+++ b/ui/src/lib/derive.ts
@@ -1,5 +1,4 @@
 import type {
-  AuditView,
   ItemKind,
   ItemSafety,
   ObservedItem,
@@ -23,23 +22,6 @@ export function scopeMatches(
   return (
     item.scope.scope === "project" && item.scope.root === selection.project
   );
-}
-
-/** The audit views the app-wide scope picker leaves in view. The Review
- *  page, the sidebar badge and the footer all read this, so a picked project
- *  narrows every number on screen to the same set — a badge counting the
- *  whole machine beside a page showing one project would be two answers. */
-export function viewsInScope(
-  views: AuditView[],
-  selection: ScopeSelection,
-): AuditView[] {
-  return views.filter((view) => {
-    if (selection === "all") return true;
-    if (selection === "global") return view.scope.scope === "global";
-    return (
-      view.scope.scope === "project" && view.scope.root === selection.project
-    );
-  });
 }
 
 export interface ItemFilter {

--- a/ui/src/lib/library-handoff.test.ts
+++ b/ui/src/lib/library-handoff.test.ts
@@ -1,53 +1,72 @@
 import { describe, expect, it } from "vitest";
-import { libraryViewFromHandoff } from "./library-handoff";
+import {
+  isNarrowed,
+  type LibraryView,
+  libraryViewFromHandoff,
+  UNFILTERED,
+} from "./library-handoff";
+
+const EVERYTHING: LibraryView = {
+  filters: { kind: "any", harness: "any", tag: "any", from: "any" },
+  search: "",
+  scope: "all",
+};
 
 describe("libraryViewFromHandoff", () => {
   it("asks for everything when the link names nothing", () => {
-    expect(libraryViewFromHandoff({})).toEqual({
-      kind: "any",
-      harness: "any",
-      tag: "any",
-      from: "any",
-      search: "",
-      scope: "all",
-      scrollTop: 0,
-    });
+    expect(libraryViewFromHandoff({})).toEqual(EVERYTHING);
+    expect(UNFILTERED).toEqual(EVERYTHING);
   });
 
   it("keeps only the narrowing the link named", () => {
     expect(libraryViewFromHandoff({ kind: "hook" })).toEqual({
-      kind: "hook",
-      harness: "any",
-      tag: "any",
-      from: "any",
-      search: "",
-      scope: "all",
-      scrollTop: 0,
+      ...EVERYTHING,
+      filters: { ...EVERYTHING.filters, kind: "hook" },
     });
     expect(libraryViewFromHandoff({ harness: "claude" })).toEqual({
-      kind: "any",
-      harness: "claude",
-      tag: "any",
-      from: "any",
-      search: "",
-      scope: "all",
-      scrollTop: 0,
+      ...EVERYTHING,
+      filters: { ...EVERYTHING.filters, harness: "claude" },
     });
   });
 
   it("looks where the link asked", () => {
     expect(libraryViewFromHandoff({ scope: { project: "/x" } })).toEqual({
-      kind: "any",
-      harness: "any",
-      tag: "any",
-      from: "any",
-      search: "",
+      ...EVERYTHING,
       scope: { project: "/x" },
-      scrollTop: 0,
+    });
+  });
+
+  it("looks at the personal setup alone when the link asked for that", () => {
+    expect(libraryViewFromHandoff({ scope: "global" })).toEqual({
+      ...EVERYTHING,
+      scope: "global",
     });
   });
 
   it("leaves the stored view standing when no link opened the page", () => {
     expect(libraryViewFromHandoff(null)).toBeNull();
+  });
+});
+
+describe("isNarrowed", () => {
+  it("says a view showing everything is holding nothing back", () => {
+    expect(isNarrowed(EVERYTHING)).toBe(false);
+  });
+
+  it("counts every picker on the strip", () => {
+    for (const name of ["kind", "harness", "tag", "from"] as const) {
+      expect(
+        isNarrowed({
+          ...EVERYTHING,
+          filters: { ...EVERYTHING.filters, [name]: "something" },
+        }),
+      ).toBe(true);
+    }
+  });
+
+  it("counts the search box and where the table is looking", () => {
+    expect(isNarrowed({ ...EVERYTHING, search: "deploy" })).toBe(true);
+    expect(isNarrowed({ ...EVERYTHING, scope: "global" })).toBe(true);
+    expect(isNarrowed({ ...EVERYTHING, scope: { project: "/x" } })).toBe(true);
   });
 });

--- a/ui/src/lib/library-handoff.test.ts
+++ b/ui/src/lib/library-handoff.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { libraryViewFromHandoff } from "./library-handoff";
+
+describe("libraryViewFromHandoff", () => {
+  it("asks for everything when the link names nothing", () => {
+    expect(libraryViewFromHandoff({})).toEqual({
+      kind: "any",
+      harness: "any",
+      tag: "any",
+      from: "any",
+      search: "",
+      scope: "all",
+      scrollTop: 0,
+    });
+  });
+
+  it("keeps only the narrowing the link named", () => {
+    expect(libraryViewFromHandoff({ kind: "hook" })).toEqual({
+      kind: "hook",
+      harness: "any",
+      tag: "any",
+      from: "any",
+      search: "",
+      scope: "all",
+      scrollTop: 0,
+    });
+    expect(libraryViewFromHandoff({ harness: "claude" })).toEqual({
+      kind: "any",
+      harness: "claude",
+      tag: "any",
+      from: "any",
+      search: "",
+      scope: "all",
+      scrollTop: 0,
+    });
+  });
+
+  it("looks where the link asked", () => {
+    expect(libraryViewFromHandoff({ scope: { project: "/x" } })).toEqual({
+      kind: "any",
+      harness: "any",
+      tag: "any",
+      from: "any",
+      search: "",
+      scope: { project: "/x" },
+      scrollTop: 0,
+    });
+  });
+
+  it("leaves the stored view standing when no link opened the page", () => {
+    expect(libraryViewFromHandoff(null)).toBeNull();
+  });
+});

--- a/ui/src/lib/library-handoff.ts
+++ b/ui/src/lib/library-handoff.ts
@@ -1,5 +1,5 @@
 import type { ScopeSelection } from "@/lib/derive";
-import { type LibraryFilters, NO_FILTERS } from "@/stores/library-view";
+import { type FilterSelection, NO_FILTERS } from "@/stores/library-view";
 import type { LibraryFilter } from "@/stores/nav-types";
 
 /** Everything the Library's table is showing: the narrowing its filter strip
@@ -7,7 +7,7 @@ import type { LibraryFilter } from "@/stores/nav-types";
  * fields stay grouped as the store defines them rather than being restated
  * here, so a filter added to the strip is part of the view by construction. */
 export interface LibraryView {
-  filters: LibraryFilters;
+  filters: FilterSelection;
   search: string;
   scope: ScopeSelection;
 }
@@ -27,7 +27,7 @@ export function isNarrowed(view: LibraryView): boolean {
   if (view.search !== UNFILTERED.search || view.scope !== UNFILTERED.scope) {
     return true;
   }
-  const names = Object.keys(NO_FILTERS) as (keyof LibraryFilters)[];
+  const names = Object.keys(NO_FILTERS) as (keyof FilterSelection)[];
   return names.some((name) => view.filters[name] !== NO_FILTERS[name]);
 }
 

--- a/ui/src/lib/library-handoff.ts
+++ b/ui/src/lib/library-handoff.ts
@@ -1,16 +1,34 @@
 import type { ScopeSelection } from "@/lib/derive";
+import { type LibraryFilters, NO_FILTERS } from "@/stores/library-view";
 import type { LibraryFilter } from "@/stores/nav-types";
 
-/** Everything the Library's table is showing: the filter strip, the search
- * box, where it is looking, and where it is scrolled to. */
+/** Everything the Library's table is showing: the narrowing its filter strip
+ * holds, what the search box holds, and where it is looking. The strip's own
+ * fields stay grouped as the store defines them rather than being restated
+ * here, so a filter added to the strip is part of the view by construction. */
 export interface LibraryView {
-  kind: string;
-  harness: string;
-  tag: string;
-  from: string;
+  filters: LibraryFilters;
   search: string;
   scope: ScopeSelection;
-  scrollTop: number;
+}
+
+/** Everything, everywhere: nothing narrowed, nothing searched for, every
+ * location in view. */
+export const UNFILTERED: LibraryView = {
+  filters: NO_FILTERS,
+  search: "",
+  scope: "all",
+};
+
+/** Whether a view is holding anything back, which is what makes offering to
+ * clear it worth doing. Compared against {@link UNFILTERED} rather than
+ * tested field by field, so a filter added to the strip counts here too. */
+export function isNarrowed(view: LibraryView): boolean {
+  if (view.search !== UNFILTERED.search || view.scope !== UNFILTERED.scope) {
+    return true;
+  }
+  const names = Object.keys(NO_FILTERS) as (keyof LibraryFilters)[];
+  return names.some((name) => view.filters[name] !== NO_FILTERS[name]);
 }
 
 /**
@@ -20,20 +38,19 @@ export interface LibraryView {
  * A link states the whole view it wants, so everything it does not name goes
  * back to unfiltered rather than carrying over: otherwise "everything in this
  * project" arrives still narrowed to the last kind, tag or search an earlier
- * visit left behind. The table also starts at the top — the offset a previous
- * visit left belongs to a list this one has just replaced.
+ * visit left behind.
  */
 export function libraryViewFromHandoff(
   handoff: LibraryFilter | null,
 ): LibraryView | null {
   if (!handoff) return null;
   return {
-    kind: handoff.kind ?? "any",
-    harness: handoff.harness ?? "any",
-    tag: "any",
-    from: "any",
-    search: "",
-    scope: handoff.scope ?? "all",
-    scrollTop: 0,
+    filters: {
+      ...NO_FILTERS,
+      kind: handoff.kind ?? NO_FILTERS.kind,
+      harness: handoff.harness ?? NO_FILTERS.harness,
+    },
+    search: UNFILTERED.search,
+    scope: handoff.scope ?? UNFILTERED.scope,
   };
 }

--- a/ui/src/lib/library-handoff.ts
+++ b/ui/src/lib/library-handoff.ts
@@ -1,0 +1,39 @@
+import type { ScopeSelection } from "@/lib/derive";
+import type { LibraryFilter } from "@/stores/nav-types";
+
+/** Everything the Library's table is showing: the filter strip, the search
+ * box, where it is looking, and where it is scrolled to. */
+export interface LibraryView {
+  kind: string;
+  harness: string;
+  tag: string;
+  from: string;
+  search: string;
+  scope: ScopeSelection;
+  scrollTop: number;
+}
+
+/**
+ * The view the Library should adopt for a link that just opened it, or null
+ * when it was opened some other way and the stored view stands.
+ *
+ * A link states the whole view it wants, so everything it does not name goes
+ * back to unfiltered rather than carrying over: otherwise "everything in this
+ * project" arrives still narrowed to the last kind, tag or search an earlier
+ * visit left behind. The table also starts at the top — the offset a previous
+ * visit left belongs to a list this one has just replaced.
+ */
+export function libraryViewFromHandoff(
+  handoff: LibraryFilter | null,
+): LibraryView | null {
+  if (!handoff) return null;
+  return {
+    kind: handoff.kind ?? "any",
+    harness: handoff.harness ?? "any",
+    tag: "any",
+    from: "any",
+    search: "",
+    scope: handoff.scope ?? "all",
+    scrollTop: 0,
+  };
+}

--- a/ui/src/lib/project-card-label.test.ts
+++ b/ui/src/lib/project-card-label.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { showEverythingLabel } from "./project-card-label";
+
+describe("showEverythingLabel", () => {
+  it("separates two projects whose folders share a name", () => {
+    expect(showEverythingLabel("client", "/work/client")).not.toBe(
+      showEverythingLabel("client", "/personal/client"),
+    );
+  });
+
+  it("names the folder a card opens", () => {
+    expect(showEverythingLabel("client", "/work/client")).toBe(
+      "Show everything in client, /work/client",
+    );
+  });
+
+  it("keeps the name a reader sees inside the label", () => {
+    expect(showEverythingLabel("client", "/work/client")).toContain("client");
+  });
+
+  it("says only the name where there is no folder", () => {
+    expect(showEverythingLabel("Personal")).toBe("Show everything in Personal");
+    expect(showEverythingLabel("Personal", "")).toBe(
+      "Show everything in Personal",
+    );
+  });
+});

--- a/ui/src/lib/project-card-label.ts
+++ b/ui/src/lib/project-card-label.ts
@@ -1,0 +1,15 @@
+/**
+ * A project card shows the folder's last segment as its name, so two
+ * registered folders can put the same word on two cards — /work/client and
+ * /personal/client are both "client". What separates them on screen is the
+ * full path printed under the name, which a button's own label leaves out.
+ * This is that label with the path in it, so each card's button announces
+ * the place it opens instead of a word another card also answers to.
+ *
+ * Personal is one card with no folder, and its name already stands alone.
+ */
+export function showEverythingLabel(name: string, path?: string): string {
+  return path
+    ? `Show everything in ${name}, ${path}`
+    : `Show everything in ${name}`;
+}

--- a/ui/src/pages/overview.tsx
+++ b/ui/src/pages/overview.tsx
@@ -81,7 +81,7 @@ export function OverviewPage() {
                   scope: first.scope,
                 }),
             }
-          : { label: "Library", onClick: () => setPage("library") },
+          : { label: "Library", onClick: () => goToLibrary() },
     });
   }
   if (blocked > 0) {

--- a/ui/src/stores/library-view.test.ts
+++ b/ui/src/stores/library-view.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { NO_FILTERS, useLibraryViewStore } from "./library-view";
+
+describe("library view store", () => {
+  beforeEach(() => {
+    useLibraryViewStore.setState({ ...NO_FILTERS, scrollTop: 0 });
+  });
+
+  it("opens narrowed by nothing", () => {
+    const state = useLibraryViewStore.getState();
+    expect(state.kind).toBe("any");
+    expect(state.harness).toBe("any");
+    expect(state.tag).toBe("any");
+    expect(state.from).toBe("any");
+  });
+
+  it("adopts every picker of a whole narrowing, stale values included", () => {
+    useLibraryViewStore.setState({
+      kind: "skill",
+      harness: "codex",
+      tag: "review",
+      from: "some marketplace",
+    });
+
+    useLibraryViewStore.getState().setFilters({
+      kind: "hook",
+      harness: "claude",
+      tag: "any",
+      from: "any",
+    });
+
+    const state = useLibraryViewStore.getState();
+    expect(state.kind).toBe("hook");
+    expect(state.harness).toBe("claude");
+    expect(state.tag).toBe("any");
+    expect(state.from).toBe("any");
+  });
+
+  it("leaves the scroll offset to whoever owns it", () => {
+    useLibraryViewStore.setState({ scrollTop: 480 });
+
+    useLibraryViewStore.getState().setFilters(NO_FILTERS);
+
+    expect(useLibraryViewStore.getState().scrollTop).toBe(480);
+  });
+
+  it("changes one picker at a time without disturbing the rest", () => {
+    useLibraryViewStore.getState().setKind("agent");
+    useLibraryViewStore.getState().setTag("deploy");
+
+    const state = useLibraryViewStore.getState();
+    expect(state.kind).toBe("agent");
+    expect(state.tag).toBe("deploy");
+    expect(state.harness).toBe("any");
+    expect(state.from).toBe("any");
+  });
+});

--- a/ui/src/stores/library-view.test.ts
+++ b/ui/src/stores/library-view.test.ts
@@ -2,16 +2,18 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { NO_FILTERS, useLibraryViewStore } from "./library-view";
 
 describe("library view store", () => {
+  // Reset to what the store was created with rather than to a restatement of
+  // it, so a filter added to the strip is reset here without anyone editing
+  // this line — and so the opening state below is the store's own answer.
   beforeEach(() => {
-    useLibraryViewStore.setState({ ...NO_FILTERS, scrollTop: 0 });
+    useLibraryViewStore.setState(useLibraryViewStore.getInitialState(), true);
   });
 
-  it("opens narrowed by nothing", () => {
-    const state = useLibraryViewStore.getState();
-    expect(state.kind).toBe("any");
-    expect(state.harness).toBe("any");
-    expect(state.tag).toBe("any");
-    expect(state.from).toBe("any");
+  it("opens narrowed by nothing, at the top", () => {
+    expect(useLibraryViewStore.getInitialState()).toMatchObject({
+      ...NO_FILTERS,
+      scrollTop: 0,
+    });
   });
 
   it("adopts every picker of a whole narrowing, stale values included", () => {

--- a/ui/src/stores/library-view.test.ts
+++ b/ui/src/stores/library-view.test.ts
@@ -50,10 +50,27 @@ describe("library view store", () => {
     useLibraryViewStore.getState().setKind("agent");
     useLibraryViewStore.getState().setTag("deploy");
 
-    const state = useLibraryViewStore.getState();
-    expect(state.kind).toBe("agent");
-    expect(state.tag).toBe("deploy");
-    expect(state.harness).toBe("any");
-    expect(state.from).toBe("any");
+    expect(useLibraryViewStore.getState()).toMatchObject({
+      kind: "agent",
+      tag: "deploy",
+      harness: "any",
+      from: "any",
+    });
+
+    useLibraryViewStore.getState().setHarness("codex");
+    useLibraryViewStore.getState().setFrom("some marketplace");
+
+    expect(useLibraryViewStore.getState()).toMatchObject({
+      kind: "agent",
+      tag: "deploy",
+      harness: "codex",
+      from: "some marketplace",
+    });
+  });
+
+  it("remembers where the table was scrolled to", () => {
+    useLibraryViewStore.getState().setScrollTop(320);
+
+    expect(useLibraryViewStore.getState().scrollTop).toBe(320);
   });
 });

--- a/ui/src/stores/library-view.ts
+++ b/ui/src/stores/library-view.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import type { LibraryView } from "@/lib/library-handoff";
 
 /** The Installed table's view state, kept outside the component so opening
  * a package (a real page, which unmounts the table) and coming back lands
@@ -20,6 +21,9 @@ interface LibraryViewState {
   setTag: (tag: string) => void;
   setFrom: (from: string) => void;
   setScrollTop: (scrollTop: number) => void;
+  /** Adopt the whole view a link into the Library asked for — the parts of
+   * it this store owns. */
+  setView: (view: LibraryView) => void;
   clearFilters: () => void;
 }
 
@@ -34,6 +38,8 @@ export const useLibraryViewStore = create<LibraryViewState>((set) => ({
   setTag: (tag) => set({ tag }),
   setFrom: (from) => set({ from }),
   setScrollTop: (scrollTop) => set({ scrollTop }),
+  setView: ({ kind, harness, tag, from, scrollTop }) =>
+    set({ kind, harness, tag, from, scrollTop }),
   clearFilters: () =>
     set({ kind: "any", harness: "any", tag: "any", from: "any" }),
 }));

--- a/ui/src/stores/library-view.ts
+++ b/ui/src/stores/library-view.ts
@@ -1,5 +1,23 @@
 import { create } from "zustand";
-import type { LibraryView } from "@/lib/library-handoff";
+
+/** What the Installed table's filter strip is narrowing by. Values use the
+ * strip's own vocabulary: "any" means unfiltered. */
+export interface LibraryFilters {
+  kind: string;
+  harness: string;
+  tag: string;
+  from: string;
+}
+
+/** Narrowed by nothing. The one definition of an unfiltered strip, so the
+ * table's opening state, its Clear affordance and a link asking for
+ * everything can never drift apart on what "everything" means. */
+export const NO_FILTERS: LibraryFilters = {
+  kind: "any",
+  harness: "any",
+  tag: "any",
+  from: "any",
+};
 
 /** The Installed table's view state, kept outside the component so opening
  * a package (a real page, which unmounts the table) and coming back lands
@@ -7,13 +25,8 @@ import type { LibraryView } from "@/lib/library-handoff";
  * not here — that is the app-wide scope, so the table and the rest of the
  * app can never disagree about which project is being looked at.
  * Session-lifetime only — a fresh launch starts clean, like every other
- * filter in the app. Values use the filter strip's own vocabulary: "any"
- * means unfiltered. */
-interface LibraryViewState {
-  kind: string;
-  harness: string;
-  tag: string;
-  from: string;
+ * filter in the app. */
+interface LibraryViewState extends LibraryFilters {
   /** The table's scroll offset when it last unmounted. */
   scrollTop: number;
   setKind: (kind: string) => void;
@@ -21,25 +34,19 @@ interface LibraryViewState {
   setTag: (tag: string) => void;
   setFrom: (from: string) => void;
   setScrollTop: (scrollTop: number) => void;
-  /** Adopt the whole view a link into the Library asked for — the parts of
-   * it this store owns. */
-  setView: (view: LibraryView) => void;
-  clearFilters: () => void;
+  /** Adopt a whole narrowing at once — a link's, or the empty one behind
+   * Clear. Taken as one object rather than field by field, so a filter added
+   * to the strip is applied without anyone having to remember it here. */
+  setFilters: (filters: LibraryFilters) => void;
 }
 
 export const useLibraryViewStore = create<LibraryViewState>((set) => ({
-  kind: "any",
-  harness: "any",
-  tag: "any",
-  from: "any",
+  ...NO_FILTERS,
   scrollTop: 0,
   setKind: (kind) => set({ kind }),
   setHarness: (harness) => set({ harness }),
   setTag: (tag) => set({ tag }),
   setFrom: (from) => set({ from }),
   setScrollTop: (scrollTop) => set({ scrollTop }),
-  setView: ({ kind, harness, tag, from, scrollTop }) =>
-    set({ kind, harness, tag, from, scrollTop }),
-  clearFilters: () =>
-    set({ kind: "any", harness: "any", tag: "any", from: "any" }),
+  setFilters: (filters) => set(filters),
 }));

--- a/ui/src/stores/library-view.ts
+++ b/ui/src/stores/library-view.ts
@@ -2,7 +2,7 @@ import { create } from "zustand";
 
 /** What the Installed table's filter strip is narrowing by. Values use the
  * strip's own vocabulary: "any" means unfiltered. */
-export interface LibraryFilters {
+export interface FilterSelection {
   kind: string;
   harness: string;
   tag: string;
@@ -12,7 +12,7 @@ export interface LibraryFilters {
 /** Narrowed by nothing. The one definition of an unfiltered strip, so the
  * table's opening state, its Clear affordance and a link asking for
  * everything can never drift apart on what "everything" means. */
-export const NO_FILTERS: LibraryFilters = {
+export const NO_FILTERS: FilterSelection = {
   kind: "any",
   harness: "any",
   tag: "any",
@@ -21,12 +21,11 @@ export const NO_FILTERS: LibraryFilters = {
 
 /** The Installed table's view state, kept outside the component so opening
  * a package (a real page, which unmounts the table) and coming back lands
- * on the same filters and the same scroll position. Where an item lives is
- * not here — that is the app-wide scope, so the table and the rest of the
- * app can never disagree about which project is being looked at.
+ * on the same filters and the same scroll position. Where the table is
+ * looking is kept in the nav store, which outlives that same trip.
  * Session-lifetime only — a fresh launch starts clean, like every other
  * filter in the app. */
-interface LibraryViewState extends LibraryFilters {
+interface LibraryViewState extends FilterSelection {
   /** The table's scroll offset when it last unmounted. */
   scrollTop: number;
   setKind: (kind: string) => void;
@@ -37,7 +36,7 @@ interface LibraryViewState extends LibraryFilters {
   /** Adopt a whole narrowing at once — a link's, or the empty one behind
    * Clear. Taken as one object rather than field by field, so a filter added
    * to the strip is applied without anyone having to remember it here. */
-  setFilters: (filters: LibraryFilters) => void;
+  setFilters: (filters: FilterSelection) => void;
 }
 
 export const useLibraryViewStore = create<LibraryViewState>((set) => ({

--- a/ui/src/stores/nav-types.ts
+++ b/ui/src/stores/nav-types.ts
@@ -1,6 +1,7 @@
 // The vocabulary of places: every page id, the refs that address what a
 // nested page is showing, and the snapshot the back stack keeps.
 import type { Catalog, HarnessId, ItemKind, Scope } from "@/bindings";
+import type { ScopeSelection } from "@/lib/derive";
 
 export type Page =
   | "home"
@@ -31,10 +32,14 @@ export type Page =
 /** Which of the Marketplaces page's four tabs is showing. */
 export type MarketplacesTab = "subscribed" | "packages" | "community" | "mine";
 
-/** What Library's table should filter to when it first opens. */
+/** What a link into the Library is asking to see — every narrowing it wants,
+ * where to look included. A link states the whole thing, so a field it leaves
+ * out is a narrowing it does not want, and an all-empty filter asks for
+ * everything. */
 export interface LibraryFilter {
   harness?: HarnessId;
   kind?: ItemKind;
+  scope?: ScopeSelection;
 }
 
 /** The package a package page is showing — everything a backend query

--- a/ui/src/stores/nav.test.ts
+++ b/ui/src/stores/nav.test.ts
@@ -121,6 +121,19 @@ describe("nav store", () => {
     expect(useNavStore.getState().libraryFilter).toBeNull();
   });
 
+  it("hands off an empty filter when a link asks for everything", () => {
+    useNavStore.getState().goToLibrary({ kind: "hook" });
+    useNavStore.getState().clearLibraryFilter();
+
+    // A link naming no filter still hands off, so the Library knows to drop
+    // what an earlier visit left narrowed rather than keeping "hook".
+    useNavStore.getState().goToLibrary();
+    expect(useNavStore.getState().libraryFilter).toEqual({
+      harness: undefined,
+      kind: undefined,
+    });
+  });
+
   it("pushes the prior page onto history on a cross-page nav", () => {
     useNavStore.getState().goToLibrary();
 

--- a/ui/src/stores/nav.test.ts
+++ b/ui/src/stores/nav.test.ts
@@ -122,15 +122,16 @@ describe("nav store", () => {
   });
 
   it("hands off an empty filter when a link asks for everything", () => {
-    useNavStore.getState().goToLibrary({ kind: "hook" });
-    useNavStore.getState().clearLibraryFilter();
-
-    // A link naming no filter still hands off, so the Library knows to drop
-    // what an earlier visit left narrowed rather than keeping "hook".
     useNavStore.getState().goToLibrary();
-    expect(useNavStore.getState().libraryFilter).toEqual({
-      harness: undefined,
-      kind: undefined,
+
+    expect(useNavStore.getState().libraryFilter).not.toBeNull();
+  });
+
+  it("hands off where a link asks the Library to look", () => {
+    useNavStore.getState().goToLibrary({ scope: { project: "/x" } });
+
+    expect(useNavStore.getState().libraryFilter?.scope).toEqual({
+      project: "/x",
     });
   });
 

--- a/ui/src/stores/nav.test.ts
+++ b/ui/src/stores/nav.test.ts
@@ -135,6 +135,12 @@ describe("nav store", () => {
     });
   });
 
+  it("hands off a link asking for the personal setup alone", () => {
+    useNavStore.getState().goToLibrary({ scope: "global" });
+
+    expect(useNavStore.getState().libraryFilter?.scope).toBe("global");
+  });
+
   it("pushes the prior page onto history on a cross-page nav", () => {
     useNavStore.getState().goToLibrary();
 

--- a/ui/src/stores/nav.ts
+++ b/ui/src/stores/nav.ts
@@ -32,7 +32,9 @@ interface NavState {
    *  is ever hidden behind a filter set somewhere else. */
   libraryScope: ScopeSelection;
   /** What the Library's search box holds, kept here so leaving the page and
-   * coming back keeps the table narrowed the same way. */
+   * coming back — by the sidebar, by back, or from a package page — keeps the
+   * table narrowed the same way. A link into the Library states the whole
+   * view it wants instead, so following one clears it. */
   search: string;
   /** Bumped whenever something asks for the search box. The mounted box
    * focuses itself on every change, so the "/" shortcut reaches whichever
@@ -119,10 +121,10 @@ export const useNavStore = create<NavState>((set) => ({
   // Always a handoff, even an empty one: a link that names no filter is
   // asking for everything, and the Library has to be able to tell that
   // apart from arriving with no link at all, where the stored view stands.
-  goToLibrary: ({ harness, kind } = {}) =>
+  goToLibrary: ({ harness, kind, scope } = {}) =>
     set((state) => ({
       page: "library",
-      libraryFilter: { harness, kind },
+      libraryFilter: { harness, kind, scope },
       history: pushHistory(state, "library"),
       future: [],
     })),

--- a/ui/src/stores/nav.ts
+++ b/ui/src/stores/nav.ts
@@ -116,10 +116,13 @@ export const useNavStore = create<NavState>((set) => ({
           }),
       searchFocus: state.searchFocus + 1,
     })),
+  // Always a handoff, even an empty one: a link that names no filter is
+  // asking for everything, and the Library has to be able to tell that
+  // apart from arriving with no link at all, where the stored view stands.
   goToLibrary: ({ harness, kind } = {}) =>
     set((state) => ({
       page: "library",
-      libraryFilter: harness || kind ? { harness, kind } : null,
+      libraryFilter: { harness, kind },
       history: pushHistory(state, "library"),
       future: [],
     })),


### PR DESCRIPTION
## What changed

**A project card opens its library.** Each card on Projects names a place a setup applies — Personal, or a project folder — but only its count badges were reachable, so seeing everything in a project meant picking a kind you did not want and then clearing the filter. The card is the target for the whole project now: the project name is a real button, the whole card stays clickable with the mouse, the badges keep narrowing to one kind, and the stop-tracking control still means only itself. Dragging across the project path to copy it no longer navigates.

**A link into the Library lands on exactly what it names.** Arriving "unfiltered" was not unfiltered — the Library kept whatever an earlier visit left narrowed, so a link asking for everything opened on the last kind looked at. Every link now hands off the whole view it wants, including where to look, and the Library adopts it before its first paint: type, use, harness, origin, search and location all come from the link. Arriving with no link — the sidebar, back, or returning from a package page — still keeps the view you left. A scope that is picked always has a pill, so the table can never be narrowed with the cause off screen, and the list starts at the top rather than at the previous visit's scroll position.

**Scrollbars are the app's colour, at no cost to layout.** Every scrolling surface drew the host desktop's scrollbar. The app now states its own colour through the standard property, so the platform keeps its own scrollbar shape and width and nothing gives up content width. Measured on WebKitGTK 2.52.5, the Linux runtime: 0px reserved in both overflow states, in light and dark, against a system thumb before the change. A runtime that does not yet honour the property — WebKit before 26.2, which is the shipped Mac — keeps the bar it already draws and picks the colour up later. That trade was a deliberate product decision: the alternative reached the Mac but turned its floating overlay bar into a permanent one and shifted every list sideways as it grew past the window.

## Review

Four review cycles, six reviewers each (correctness, quality, architecture, docs, tests, plus a cross-model external pass), and four fix rounds. Twenty-six findings were applied; one was declined with evidence. Findings that surfaced along the way and are filed as separate work rather than fixed here: the Library's own table rows need the same keyboard path and drag guard the card just got, the Library's view still lives across two stores, Home's Installed tile counts a different unit than the Library, and the UI test suite does not run in GitHub CI.

## Verification

- `tsc --noEmit` and `biome check` clean; 364 tests pass (62 files). The two biome warnings are pre-existing on `main` in a file this branch does not touch.
- The behaviour was driven in the real pages against the mock IPC bridge, not reasoned about: card click from a Library left narrowed, searched and scrolled lands on that project with a clean strip at the top of the list; a count badge still narrows to its kind within the project; stop-tracking opens its dialog without navigating; the project name is in the tab order with a visible focus ring; a project with nothing installed gets its own pill rather than stranding the table.
- Every new assertion was proved able to fail: reviewers planted mutants for the decision layer, the applying layer, the store setters and the opening state, including a control confirming an earlier version of one test could not fail at all.

Closes KEN-463
