### PR TITLE
fix(github): pr-data and review status read every page [no-changelog]

### DIFF
--- a/crates/core/src/engine/adopt/declare.rs
+++ b/crates/core/src/engine/adopt/declare.rs
@@ -6,7 +6,7 @@ use crate::manifest::{self, ItemDecl, LOCAL_SOURCE_NAME};
 use crate::model::{HarnessId, ItemKind};
 
 /// Write the item into the manifest, bound to the tools that had it. Only
-/// when the [install] defaults name exactly that set may the list be left
+/// when the `[install]` defaults name exactly that set may the list be left
 /// off: a wider default would install the item for tools the user never
 /// gave it to.
 pub(super) fn declare(

--- a/skills/github/scripts/commands/pr-data.sh
+++ b/skills/github/scripts/commands/pr-data.sh
@@ -136,6 +136,7 @@ query($owner: String!, $repo: String!, $pr: Int!) {
         nodes { content user { login } }
       }
       reviewThreads(first: 100) {
+        pageInfo { hasNextPage endCursor }
         nodes {
           id
           isResolved
@@ -169,6 +170,51 @@ query($owner: String!, $repo: String!, $pr: Int!) {
 
     local result
     result=$(gh_graphql "$query" -F owner="$owner" -F repo="$repo" -F pr="$pr_num") || exit 1
+
+    # GitHub caps one reviewThreads page at 100; a PR with more threads must
+    # not read as clean because its unresolved ones sit on a later page.
+    local threads_query='
+query($owner: String!, $repo: String!, $pr: Int!, $cursor: String!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $pr) {
+      reviewThreads(first: 100, after: $cursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          isResolved
+          isOutdated
+          path
+          line
+          comments(first: 10) {
+            nodes {
+              author { login }
+              body
+              url
+            }
+          }
+        }
+      }
+    }
+  }
+}'
+    local has_next cursor page_count=0
+    has_next=$(jq -r '.repository.pullRequest.reviewThreads.pageInfo.hasNextPage // false' <<<"$result") || exit 1
+    cursor=$(jq -r '.repository.pullRequest.reviewThreads.pageInfo.endCursor // ""' <<<"$result") || exit 1
+    while [ "$has_next" = "true" ]; do
+        page_count=$((page_count + 1))
+        if [ "$page_count" -gt 1000 ] || [ -z "$cursor" ]; then
+            echo '{"error": "Review thread pagination did not advance"}' >&2
+            exit 1
+        fi
+        local page
+        page=$(gh_graphql "$threads_query" -F owner="$owner" -F repo="$repo" -F pr="$pr_num" -F cursor="$cursor") || exit 1
+        result=$(printf '%s\n%s\n' "$result" "$page" | jq -sc '
+            .[0].repository.pullRequest.reviewThreads.nodes += .[1].repository.pullRequest.reviewThreads.nodes
+            | .[0].repository.pullRequest.reviewThreads.pageInfo = .[1].repository.pullRequest.reviewThreads.pageInfo
+            | .[0]') || exit 1
+        has_next=$(jq -r '.repository.pullRequest.reviewThreads.pageInfo.hasNextPage // false' <<<"$result") || exit 1
+        cursor=$(jq -r '.repository.pullRequest.reviewThreads.pageInfo.endCursor // ""' <<<"$result") || exit 1
+    done
 
     # Apply format
     local output

--- a/skills/github/scripts/lib/github-api.sh
+++ b/skills/github/scripts/lib/github-api.sh
@@ -196,6 +196,17 @@ gh_graphql() {
     done
 }
 
+# Every page of a list endpoint as one array: GitHub returns 30 rows a page
+# by default, so a PR with 300 reviews answered with 30 until this existed.
+# Usage: gh_rest_all "repos/{owner}/{repo}/pulls/123/reviews"
+gh_rest_all() {
+    local endpoint="$1"
+    shift
+    local sep='?'
+    case "$endpoint" in *\?*) sep='&' ;; esac
+    gh_rest "${endpoint}${sep}per_page=100" --paginate --slurp "$@" | jq -c 'add // []'
+}
+
 # Execute REST API call with error handling
 # Usage: gh_rest "repos/{owner}/{repo}/pulls/123"
 gh_rest() {
@@ -705,8 +716,8 @@ bot_review_status() {
 
     local reviews comments body_reactions own_reactions threads first_comment_id
 
-    reviews=$(gh_rest "repos/{owner}/{repo}/pulls/$pr/reviews") || return 1
-    comments=$(gh_rest "repos/{owner}/{repo}/issues/$pr/comments") || return 1
+    reviews=$(gh_rest_all "repos/{owner}/{repo}/pulls/$pr/reviews") || return 1
+    comments=$(gh_rest_all "repos/{owner}/{repo}/issues/$pr/comments") || return 1
     body_reactions=$(gh_rest "repos/{owner}/{repo}/issues/$pr/reactions") || return 1
 
     first_comment_id=$(jq -r --arg u "$reviewer" \
@@ -724,10 +735,11 @@ bot_review_status() {
     owner=$(get_owner "$repo_info")
     repo=$(get_repo "$repo_info")
     local query='
-query($owner: String!, $repo: String!, $pr: Int!) {
+query($owner: String!, $repo: String!, $pr: Int!, $cursor: String) {
   repository(owner: $owner, name: $repo) {
     pullRequest(number: $pr) {
-      reviewThreads(first: 100) {
+      reviewThreads(first: 100, after: $cursor) {
+        pageInfo { hasNextPage endCursor }
         nodes {
           isResolved
           isOutdated
@@ -737,8 +749,22 @@ query($owner: String!, $repo: String!, $pr: Int!) {
     }
   }
 }'
-    threads=$(gh_graphql "$query" -F owner="$owner" -F repo="$repo" -F pr="$pr" \
-        | jq -c '.repository.pullRequest.reviewThreads.nodes // []') || return 1
+    # One page holds 100 threads; the unresolved ones may sit on the next.
+    threads='[]'
+    local cursor="" page has_next
+    while :; do
+        if [ -z "$cursor" ]; then
+            page=$(gh_graphql "$query" -F owner="$owner" -F repo="$repo" -F pr="$pr") || return 1
+        else
+            page=$(gh_graphql "$query" -F owner="$owner" -F repo="$repo" -F pr="$pr" -F cursor="$cursor") || return 1
+        fi
+        threads=$(printf '%s\n%s\n' "$threads" "$page" \
+            | jq -sc '.[0] + (.[1].repository.pullRequest.reviewThreads.nodes // [])') || return 1
+        has_next=$(jq -r '.repository.pullRequest.reviewThreads.pageInfo.hasNextPage // false' <<<"$page")
+        [ "$has_next" = "true" ] || break
+        cursor=$(jq -r '.repository.pullRequest.reviewThreads.pageInfo.endCursor // ""' <<<"$page")
+        [ -n "$cursor" ] || break
+    done
 
     bot_review_status_compute "$reviewer" "$reviews" "$comments" "$body_reactions" "$own_reactions" "$threads"
 }
@@ -776,8 +802,8 @@ detect_bot_reviewers_from_inputs() {
 detect_bot_reviewers() {
     local pr="$1"
     local reviews comments reactions
-    reviews=$(gh_rest "repos/{owner}/{repo}/pulls/$pr/reviews") || return 1
-    comments=$(gh_rest "repos/{owner}/{repo}/issues/$pr/comments") || return 1
+    reviews=$(gh_rest_all "repos/{owner}/{repo}/pulls/$pr/reviews") || return 1
+    comments=$(gh_rest_all "repos/{owner}/{repo}/issues/$pr/comments") || return 1
     reactions=$(gh_rest "repos/{owner}/{repo}/issues/$pr/reactions") || return 1
 
     local reviewers

--- a/skills/github/tests/sticky-comment-cli.test.sh
+++ b/skills/github/tests/sticky-comment-cli.test.sh
@@ -111,6 +111,8 @@ echo
 echo "=== detect_bot_reviewers own-comment reactions ==="
 # shellcheck source=/dev/null
 source "$LIB"
+# The mocks below answer by bare endpoint; the paginating wrapper is one page here.
+gh_rest_all() { gh_rest "$1"; }
 
 gh_rest() {
     case "$1" in


### PR DESCRIPTION
Local review tooling (`github.sh pr-data`, `bot_review_status`) fetched one page of review threads (100) and one REST page of reviews (30). On #1569 (198 threads) it reported 0 unresolved while CI's gate saw 4 — the local-vs-CI disagreement of the last few days. Both now paginate. Also escapes a doc link from #1570 that the cargo-doc gate from #1589 rejects; main could not pass its own commit guard.

Verified live: pr-data on #1569 → 198 threads / 4 unresolved; reviews → 309.

https://claude.ai/code/session_013EDioRsTBmsfaYeAah71hB