### PR TITLE
docs(orch): a nits-only round ends the review; merge through the gate

### DIFF
--- a/kendex-reviews.toml
+++ b/kendex-reviews.toml
@@ -15,12 +15,12 @@ reason = "intended"
 dismissed-at = "2026-08-23T17:07:51Z"
 
 [reviews."skill:orch"]
-review-hash = "8def07c07891123cdeda5631ae672c2c980ff0ed06c76eed1e2c3116e6781839"
+review-hash = "4ef5e0d41fa2e0b1ce0e86c30d99927c50e2f2fa3d2c419db42bfae271996d92"
 ruleset = 3
 
 [reviews."skill:orch".dismissed.c8e66ac505c95a7a]
 reason = "wrong-call"
-dismissed-at = "2026-08-23T17:17:26Z"
+dismissed-at = "2026-08-23T17:51:06Z"
 
 [reviews."skill:review-gate"]
 review-hash = "382704b971c779f9b48b7021e7865b4f67c4376138fcee4e76cbb15ca5da9dec"

--- a/skills/orch/SKILL.md
+++ b/skills/orch/SKILL.md
@@ -29,7 +29,7 @@ Get the issue → dev implements → review → dev fixes blockers → re-review
 
 - **Bounded loops.** A fix round addresses blockers only; re-review narrows to the fix diff and the domains it touched; two consecutive rounds with no new blocker end the review.
 - **No edge-case churn.** A finding that cannot affect real usage is declined with a one-line reason — not fixed, not filed. File issues for critical follow-ups only.
-- **Review must converge.** New defects at round 3 stop per-comment patching: cut unrequired surface, fix the recurring class structurally, or split.
+- **Review must converge.** New defects at round 3 stop per-comment patching: cut unrequired surface, fix the recurring class structurally, or split. A round whose only findings are scope, test-coverage, or wording asks ends the review: reply, resolve, push nothing, merge through the gate. Never `--admin`.
 - **Ask the user only about product or experience.** Scope expansion beyond the issue and revisiting a recorded decision always ask, whatever `ORCH_DECISION_MODE` says. Merge asks unless `ORCH_MERGE_AUTONOMY=auto`, which merges without asking only when every merge gate is green.
 - **Acceptance is artifact-based.** A round closes on a validated on-disk artifact plus git/tracker state, never on a return message.
 

--- a/skills/size-ratchet/SKILL.md
+++ b/skills/size-ratchet/SKILL.md
@@ -44,8 +44,13 @@ and fails (exit 1) on any of:
 | **baseline looser than reality** | A row higher than the file's actual count, for a file now at/under its threshold, or for a file that is untracked or excluded. |
 
 Every diagnostic names the file, its count, the baseline row it violated,
-the deciding threshold (class pattern or default), and the remedies: *split
-at a concept seam, or raise the baseline row in this diff with justification*.
+the deciding threshold (class pattern or default), and the remedy: *split
+at a concept seam*.
+
+**Raising a row** is allowed only when the added lines are the fix for the
+reported symptom and the file has no concept seam to split at. Never for
+tests, docs, comments, or lines a review round asked for. Commit with
+`RATCHET_RAISE=1` and name the reason in the commit body.
 
 Exit codes: `0` clean, `1` violations, `2` usage/config/collection error
 (malformed baseline or excludes, bad threshold, a tracked path containing

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -714,11 +714,11 @@ report() { # VIOLATIONS-FILE — human diagnostics on stdout
     case "$kind" in
       NEW)
         echo "size-ratchet FAIL new offender: $path — $n lines > threshold $PT ($why), no baseline row"
-        echo "  remedies: split at a concept seam, or raise the baseline row in this diff with justification"
+        echo "  remedy: split at a concept seam (raise the row only when the added lines are the fix itself and no seam exists: RATCHET_RAISE=1)"
         ;;
       GROW)
         echo "size-ratchet FAIL baselined file grew: $path — $n lines > baseline $b (threshold $PT, $why)"
-        echo "  remedies: split at a concept seam, or raise the baseline row in this diff with justification"
+        echo "  remedy: split at a concept seam (raise the row only when the added lines are the fix itself and no seam exists: RATCHET_RAISE=1)"
         ;;
       LOOSE)
         echo "size-ratchet FAIL baseline looser than reality: $path — baseline $b > actual $n lines, still over threshold $PT ($why); the ratchet only moves down"

--- a/skills/size-ratchet/tests/ratchet-directions.test.sh
+++ b/skills/size-ratchet/tests/ratchet-directions.test.sh
@@ -19,7 +19,7 @@ FAIL=0
 ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
 bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
 
-REMEDY="split at a concept seam, or raise the baseline row in this diff with justification"
+REMEDY="split at a concept seam (raise the row only when the added lines are the fix itself and no seam exists: RATCHET_RAISE=1)"
 
 new_repo() { # NAME — fresh fixture repo in $R
   R="$TMP/$1"
@@ -58,7 +58,7 @@ run_sr
 [ "$RC" -eq 1 ] && case "$OUT" in *"new offender: big.txt — 11 lines > threshold 10"*) true ;; *) false ;; esac \
   && ok "one line over the threshold fails as a new offender, naming file/count/threshold" \
   || bad "one line over the threshold fails as a new offender" "rc=$RC out=$OUT"
-case "$OUT" in *"$REMEDY"*) ok "new-offender diagnostic carries the two remedies verbatim" ;; *) bad "new-offender diagnostic carries the two remedies verbatim" "$OUT" ;; esac
+case "$OUT" in *"$REMEDY"*) ok "new-offender diagnostic carries the remedy verbatim" ;; *) bad "new-offender diagnostic carries the remedy verbatim" "$OUT" ;; esac
 
 echo "=== a baseline row at the current count freezes the offender ==="
 new_repo frozen
@@ -76,7 +76,7 @@ run_sr
 [ "$RC" -eq 1 ] && case "$OUT" in *"baselined file grew: big.txt — 20 lines > baseline 15"*) true ;; *) false ;; esac \
   && ok "growth past the row fails, naming file/count/baseline" \
   || bad "growth past the row fails" "rc=$RC out=$OUT"
-case "$OUT" in *"$REMEDY"*) ok "growth diagnostic carries the two remedies verbatim" ;; *) bad "growth diagnostic carries the two remedies verbatim" "$OUT" ;; esac
+case "$OUT" in *"$REMEDY"*) ok "growth diagnostic carries the remedy verbatim" ;; *) bad "growth diagnostic carries the remedy verbatim" "$OUT" ;; esac
 
 echo "=== failure direction 3: baseline looser than reality ==="
 printf 'big.txt\t30\n' >"$R/tools/size-ratchet-baseline.tsv"

--- a/tools/guard
+++ b/tools/guard
@@ -85,7 +85,7 @@ done <<<"$prose_files"
 if [ "${RATCHET_RAISE:-}" != "1" ] && git cat-file -e HEAD:tools/size-ratchet-baseline.tsv 2>/dev/null; then
   raised=$(join -t "$(printf '\t')" <(git show HEAD:tools/size-ratchet-baseline.tsv | sort) <(sort tools/size-ratchet-baseline.tsv) |
     awk -F'\t' '$3 > $2 { print "  " $1 ": " $2 " -> " $3 }')
-  [ -n "$raised" ] && say "size-ratchet baseline rows went up — cut the file, or commit with RATCHET_RAISE=1:
+  [ -n "$raised" ] && say "size-ratchet baseline rows went up — split at a seam; RATCHET_RAISE=1 only when the new lines are the fix itself:
 $raised"
 fi
 


### PR DESCRIPTION
Two one-line rules, both owner-requested 2026-08-23, both about when a change may grow:

- orch SKILL.md: when a round's only findings are scope, test-coverage, or wording asks, reply, resolve, push nothing, and merge through the normal gate — never `--admin`.
- size-ratchet: split at a seam; raise a baseline row only when the added lines are the fix itself and no seam exists (`RATCHET_RAISE=1`), never for tests, docs, or review-round additions. Same wording in the script's remedy text and tools/guard.

This PR merges through the gate itself.

https://claude.ai/code/session_013EDioRsTBmsfaYeAah71hB