### PR TITLE
feat(pi): vstack's Pi prompts arrive; the steward skill states its rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,8 @@ docs/reviews/
 /.codex/
 /.cursor/
 /.opencode/
-/.pi/
+/.pi/*
+!/.pi/prompts/
 # Per-checkout install lock (absolute paths and timestamps).
 .kendex-lock.json
 .env.local

--- a/.kendex-local/skills/kendex-issues/SKILL.md
+++ b/.kendex-local/skills/kendex-issues/SKILL.md
@@ -1,254 +1,155 @@
 ---
 name: kendex-issues
 description: >
-  Steward the vanillagreencom/kendex issue queue (Linear team KEN is the poll
-  surface; GitHub stays the PR/code surface) on a self-paced loop: watch open
-  PRs, poll, triage (dedupe; close non-kendex issues and repost project-local
-  ones to their owning repo; fix genuine defects in kendex's
-  skills/agents/hooks/pi-extensions or the Rust CLI), run each fix through the
-  orch skill, merge, propagate via kendex refresh, then reschedule. A thin
-  wrapper: fix cycles belong to orch, PR mechanics to the github skill, PR
-  monitoring to review-gate's pr-watch, Linear ops to the linear skill — this
-  skill carries only the kendex-specific stewardship knowledge. Use when asked
-  to monitor kendex's issues continuously or to run one fix-and-propagate
-  cycle.
+  Steward the vanillagreencom/kendex issue queue on a self-paced loop: watch
+  open PRs, poll Linear (team KEN), triage, fix genuine kendex defects through
+  the orch skill, merge, propagate with kendex refresh, reschedule. A thin
+  wrapper over orch, github, review-gate and linear. Use when asked to monitor
+  kendex's issues continuously or to run one fix-and-propagate cycle.
 ---
-
-> **Never edit this file directly.** To make additions or modifications, edit the appropriate section in the managing project's kendex config — `kendex.toml` at the kendex project root, or `kendex-local.toml` in a source-catalog checkout. Then run `kendex refresh`.
 
 # kendex Issue Steward
 
-Keep the vanillagreencom/kendex issue queue clean and its consumers in sync:
-watch → poll → triage → fix → merge → propagate → repeat. One cycle per turn,
-then reschedule.
+watch → poll → triage → fix → merge → propagate → reschedule. One cycle per
+turn.
 
-**This skill is a thin wrapper.** The mechanics live in four owning skills,
-and every cycle uses them instead of hand-rolling:
+| Concern | Owning skill |
+|---|---|
+| Fix cycle (prepare → delegate → review → submit → merge) | **orch** |
+| PR threads, replies, reviews, merges, CI logs | **github** |
+| Watching open PRs | **review-gate** `pr-watch.sh` |
+| Linear reads and writes | **linear** |
 
-| Concern | Owning skill | Load when |
-|---------|--------------|-----------|
-| Fix cycle (prepare → delegate → review → submit → merge) | **orch** | every fix, before creating the worktree |
-| PR threads / replies / reviews / merges / CI logs | **github** | any PR mutation or read |
-| Watching open PRs across the loop | **review-gate** (`pr-watch.sh`) | first action, every cycle |
-| Linear reads and writes | **linear** | any Linear operation |
-
-A session driven by this skill should load those naturally at each step and
-produce zero hand-rolled PR mechanics (raw `gh api` GraphQL where a
-`github.sh` command exists is the failure smell).
+Hand-rolled PR mechanics (raw `gh api` where a `github.sh` command exists)
+are a defect.
 
 ## Loop (one turn)
 
-1. **PR watch first** — `GH_REPO=vanillagreencom/kendex
-   .agents/skills/review-gate/scripts/pr-watch.sh`. Silence + exit 0 means no
-   open PR needs you. Attention lines (threads-open, changes-requested,
-   gate-stale, disarmed, awaiting-stale) → act through the github skill.
-   NEVER hand-roll a PR monitor: pr-watch is the monitoring primitive for
-   every open-PR concern except queue ejection, which it cannot see — after
-   any gate-green, additionally check `isInMergeQueue` + `autoMergeRequest`
-   (GraphQL; `gh pr view --json` lacks queue membership). Ejection is SILENT
-   and discards the auto-merge arm: re-arm once; a second ejection means a
-   flaky required suite — quarantine/escalate rather than re-arm loops.
-2. **Poll Linear** — creation sync is ONE-WAY GitHub→Linear (owner reverted
-   the 2026-08-09 two-way experiment), so Linear (team KEN) is the only
-   complete queue: Linear-native issues never appear in `gh issue list`.
-   Refresh the cache first, then read open issues:
-   `linear.sh sync --reconcile`, then
+1. **PR watch** — `GH_REPO=vanillagreencom/kendex .agents/skills/review-gate/scripts/pr-watch.sh`.
+   Silence + exit 0 = nothing needs you. Attention lines → act through the
+   github skill. After a gate-green, also check `isInMergeQueue` +
+   `autoMergeRequest` (GraphQL). Queue ejection is silent: re-arm once; a
+   second ejection is a flaky required suite — quarantine, never re-arm loops.
+2. **Poll Linear** — `linear.sh sync --reconcile`, then
    `linear.sh cache issues list --state "Triage,Backlog,Todo,In Progress" --max`.
-   GH-synced issues arrive in **Triage** — omitting it hides the entire
-   synced queue (bit the 2026-08-03 campaign: 14 pending issues invisible).
-   Then cross-check GitHub: `gh issue list --repo vanillagreencom/kendex
-   --state open` — cheap, and history earned it (2026-08-09: nine stray
-   open GH issues over eight "empty" cycles while both a generate-on-merge
-   automation and two-way creation sync were briefly on; both are off now,
-   but pre-revert GH copies of Linear issues still exist and can stick
-   open). An open GH issue whose Linear mirror is DONE is residue — close
-   it with the diagnosis. An open GH issue with NO Linear mirror means the
-   GH→Linear sync broke — triage it from GitHub directly and flag the sync.
-   Zero attention lines and zero open on both surfaces → reschedule, stop.
-3. **Triage** each issue; run the **Fix cycle** for each valid defect.
-   Mutate on the issue's home surface: a GH-mirrored issue (its Linear body
-   links the GitHub issue) is closed/commented on GitHub and sync updates
-   Linear; a Linear-native issue (no GH link) is updated with the linear
-   skill (`issues update` / `comments create` / `issues complete`). PRs,
-   branches, and CI stay on GitHub either way. The PR body carries BOTH
-   references when the issue has a GitHub mirror — `Closes KEN-<n>` for the
-   tracker and `Closes #<n>` for the mirror — so GitHub links the PR on the
-   issue and closes it with that reference at merge; a Linear-native issue
-   gets `Closes KEN-<n>` alone. Never close a mirror by hand without naming
-   the PR in the closing comment.
-4. After any merge, **Propagate + Sync**.
-5. **Schedule the next wakeup** (see Cadence). Stop only if the user asked.
+   Linear is the complete queue (GitHub→Linear sync is one-way); Triage holds
+   the GitHub-synced arrivals. Cross-check `gh issue list --repo vanillagreencom/kendex --state open`:
+   an open GH issue whose Linear mirror is Done is residue — close it naming
+   the PR; one with no mirror means the sync broke — triage it from GitHub
+   and say so. Nothing on either surface → reschedule.
+3. **Triage** each issue (below); run the fix cycle for each valid defect.
+   Mutate on the issue's home surface: GH-mirrored issues (Linear body links
+   the GH issue) are closed/commented on GitHub; Linear-native ones through
+   the linear skill. PR body carries `Closes KEN-<n>` plus `Closes #<n>` when
+   a mirror exists.
+4. After any merge, **propagate**.
+5. **Reschedule** (Cadence). Stop only if the user asked.
 
-## Triage (per issue)
+## Triage
 
-Read body + comments, then classify:
+- **Duplicate** → close, name the canonical issue.
+- **Not a kendex asset** → ownership is the asset's SKILL.md frontmatter
+  (`source: kendex`), never its install path. Close with the reason; repost
+  project-local items to the owning repo, cross-link, notify that repo's
+  overseer (tmux window 1 of `memsira`, `drovr`, `hyprtrade`). Never fix a
+  consuming repo's defect.
+- **Edge case (<1% of users), contrived layout, race between two local
+  processes, or reviewer hypothetical with no report** → cancel with the
+  reason. The bar for a kendex issue is a reported symptom.
+- **Over-built proposal** → cancel; state the simpler approach in one line
+  if one exists.
+- **Genuine kendex defect** (skills/, agents/, hooks/, pi-extensions/,
+  crates/, ui/) → fix cycle.
+- **Unfindable reference** → `git log -S '<name>' --all` first. A name that
+  never existed is a typo: close with the evidence; never ship a shim.
+- **Empty body** → ask for the concrete repro; leave open.
 
-- **Duplicate** → close, referencing the canonical issue.
-- **Not a kendex asset** → verify by grepping the kendex repo; ownership comes
-  from the asset's own SKILL.md frontmatter (`source: kendex`), never from its
-  install location. Close with a specific rationale. Project-local assets:
-  repost to the owning repo, cross-link both ways, and notify that repo's
-  overseer (tmux tab 1: `memsira:1`, `drovr:1`, `hyprtrade:1`) that the fix is
-  theirs. The steward never fixes a consuming repo's own defect, however easy
-  it looks.
-- **Speculative / one-project architecture** → close with reasoning; offer a
-  scoped proposal only if it generalizes.
-- **Genuine kendex defect** (skills/, agents/, hooks/, pi-extensions/, cli/) →
-  Fix cycle. A guidance gap is fixable even when the root trigger is a harness
-  limitation; note the harness part upstream.
-- **Unfindable references** → check history (`git log -S '<name>' --all`)
-  before assuming a rename or regression. A name that never existed in any
-  version is a recorded typo: close with that evidence; never ship a
-  compatibility shim for it.
-- **Empty-body issues** → don't guess the defect from the title. Comment
-  asking for the concrete repro, note what your sweep found, leave open.
+## Fix cycle — load orch
 
-## Fix cycle (per valid defect) — load orch
+orch owns every step. kendex-specific parameters:
 
-The whole cycle is orch's domain: prepare → delegate → review → submit →
-merge. Load the orch skill and follow its workflows; do not re-implement any
-step here. kendex-specific parameters orch can't know:
+- **Delegate to**: `generalist` (shell/docs/skills), `rust` (crates/),
+  `iced` (iced-rs). Tests required; relevant suite green
+  (`bash skills/orch/tests/run-all.sh`, per-skill `tests/*.sh`, `cargo test --workspace`).
+- **Scope is the reported symptom.** Every surface in the diff traces to a
+  line in the issue; anything else is cut or filed. Expect the fix to be
+  about the size of its first commit.
+- **Fix direction**: determinism and tooling first — a deletion, a
+  short-circuit, or a script; added prose last. Skills are instructions,
+  not explanations; `tools/guard` refuses history and reasons in them.
+- **Size ratchet**: split at a seam. `RATCHET_RAISE=1` only when the added
+  lines are the fix itself and no seam exists; never for tests, docs, or
+  review-round additions.
+- **Review must converge** (orch SKILL.md): new defects at round 3 stop
+  per-comment patching. A round that is only scope, test-coverage, or
+  wording asks ends the review: reply, resolve, push nothing, merge through
+  the gate. Never `--admin`.
+- **Review the diff yourself** before submit — the actual root cause, not a
+  plausible one. A stalled delegate: inspect its worktree, nudge once.
+- Coupled real defect found along the way → file it; fix it only if it is
+  in the report's scope.
+- Disjoint files → parallel; same file → sequence or bundle.
+- A required check that cannot be rerun gets a fresh head
+  (`commit --amend --no-edit` + `push --force-with-lease`, never-shared
+  heads only); never a merge past red.
 
-- **Agent fit for delegation**: `generalist` (shell/docs/skills), `rust`
-  (cli/), `iced` (iced-rs). Require tests and the relevant suite green
-  (`bash skills/orch/tests/run-all.sh`, per-skill `tests/*.test.sh`, or
-  `cd cli && cargo test`).
-- **Fix direction rides in every delegation** when the issue touches skills
-  or tooling: determinism and tooling first — a deletion, a short-circuit,
-  or a tool; added prose is the last resort. Skills are instructions, not
-  explanations (AGENTS.md § Rules, "Engineer over patch").
-- **Review the diff yourself** before submit — confirm the actual root
-  cause, not a plausible guess. If a delegate stalls, inspect its worktree
-  and nudge once.
-- A clearly-coupled real defect found along the way → file a tracking issue
-  and fix it too.
-- Disjoint files → run issues in parallel; same file → sequence or bundle.
-- A flaked required check reporting "cannot be rerun" gets a fresh head
-  (`git commit --amend --no-edit` + `push --force-with-lease` — only on
-  never-shared heads; never amend a pushed commit others may have seen),
-  never a force-merge past red.
+## Propagate
 
-PR reads and mutations inside the cycle (threads, replies, resolution,
-merge, CI logs) go through the github skill: `pr-data --actionable`,
-`post-reply`, `resolve-thread`, `pr-merge`, `ci-logs`, `await-mergeable`.
+Only from a change **merged on `origin/main`**. Batch: if open items would
+force another re-vendor soon, hold and run one train; an immediate train is
+for a fail-open defect in a consumer gate or an owner ask.
 
-## Propagate + Sync
+1. `git checkout main && git pull --ff-only`; confirm the source consumers
+   read sits at the `origin/main` tip containing the merge.
+2. Skill/agent/hook changes → `kendex refresh` (all scopes, never
+   `--scope project`; Pi packages are global) + `kendex verify` in each
+   consumer. CLI-only changes → binary rebuild, no skill refresh.
+3. Consumer commits: `git check-ignore -q <path>` first (ignored = nothing to
+   commit). Stage kendex paths only, never `-A`; revert no-op
+   `.kendex-refreshed` and template-default churn. Branch → PR →
+   `gh pr merge --auto`. Reply to and resolve bot threads. Confirm each push
+   landed and carries only kendex files. While propagation PRs are open,
+   `GH_REPO=vanillagreencom/<repo> pr-watch.sh --heal` each cycle.
+4. New skills do not propagate by refresh: `kendex add --skill <name> -y`
+   per consumer, commit its `kendex.toml` entry through that repo's queue.
+5. Bot findings on propagation PRs: a real defect in vendored content is
+   fixed upstream first (issue → fix → merge → refresh on the branch →
+   resolve citing the fix). Nits on the PR's own payload: fix on the branch.
+6. Capability changes consumers must wire into CI/branch protection: ship
+   the spec in the owning skill, coordinate repo-side through each overseer,
+   verify on each consumer's `origin/main`. Security-relevant capabilities
+   need the user's sign-off first.
 
-**BATCH trains (owner directive 2026-08-12): before opening consumer
-refresh PRs, scan the open queue (Todo/Triage/in-flight PRs) for items
-that touch VENDORED assets — if any would force another re-vendor soon,
-HOLD propagation until those land, then run ONE train carrying
-everything.** Per-merge trains cost a review round in every consumer each
-time; the fail-closed direction of vendored fixes makes the wait safe
-(consumers sit at most one train behind, failing loud, never open).
-Exceptions worth an immediate train anyway: a fix for a fail-OPEN defect
-in a consumer-enforced gate, or an owner ask.
+### This skill's home
 
-**Only after the upstream change is MERGED and on `origin/main`.** A PR that
-is approved, queued, or mid-merge-queue has not propagated anything: merges
-can take a while, and refreshing a consumer from an unmerged or mid-queue
-state vendors bytes main may never contain. Before any consumer refresh,
-verify the source being read (the cache, or the recorded remote clone) sits
-at the `origin/main` tip that contains the merge commit — never propagate
-from a feature branch, a local unpushed main, or a stale cache.
-
-After merges:
-
-1. Sync local main (`checkout main && pull --ff-only`) and fast-forward the
-   cache (`git -C ~/.kendex/cache/vanillagreencom_kendex pull --ff-only`) —
-   some consumers source from the cache, and a stale one silently no-ops
-   their refresh. Confirm the cache tip equals `origin/main` tip before
-   refreshing any consumer.
-2. Skill/agent/hook changes → `kendex refresh` (default all scopes) + `kendex
-   verify` in each consumer that vendors the asset. Never narrow to
-   `--scope project`: Pi packages install at global scope, so a
-   project-scoped refresh leaves them drifted and only `kendex verify`
-   catches it (bit the 2026-08-09 batch: pi-task-panel stayed at the old
-   version through a project-scoped refresh in all five consumers).
-   CLI-only changes need a binary rebuild instead, not a skill refresh.
-3. Committing in a consumer:
-   - Probe first: `git check-ignore -q <refreshed path>` → ignored means a
-     local-only install mirror with nothing to commit. The probe is
-     authoritative over any remembered per-repo list.
-   - Stage only kendex paths (scoped `git add`, never `-A`). Revert no-op
-     `.kendex-refreshed` churn and template-default churn on tracked
-     `kendex.settings.toml`/`kendex.toml` unless a key change is the payload.
-   - Merge-queue repos: branch → PR → `gh pr merge --auto` (no strategy
-     flag). Force-merge (`--admin --squash`) is pre-authorized only for
-     kendex-only refresh PRs with `kendex verify` green and the required CI
-     check green or unaffected; it cannot override a failing required check —
-     there, arm `--auto` and let the normal flow merge. Reply to and resolve
-     any bot threads either way.
-   - Confirm each push landed and the commit contains only kendex files.
-   - **While propagation PRs are open, sweep each consumer with
-     `GH_REPO=vanillagreencom/<repo> pr-watch.sh --heal` every cycle** — the
-     writer's event triggers occasionally miss a bot review (observed
-     2026-08-11: hyprtrade-io#43 sat gate-pending ~10 min on a delivered
-     review until the cron floor), and `--heal` converges a stale gate in
-     seconds instead of waiting out the */15 cron (which itself can slip to
-     ~25 min). Same sweep surfaces thread and disarm states on YOUR
-     propagation PRs; other PRs' findings route to that repo's overseer.
-4. **New skills don't propagate via refresh** — refresh reinstalls only locked
-   items. A new skill needs a one-time `kendex add --skill <name> -y` per
-   consumer (always `-y`; the interactive prompt dies in non-interactive
-   shells), and the `kendex.toml` entry it writes committed through the
-   repo's queue where that file is tracked.
-5. **Review-bot findings on propagation PRs**: a real defect in vendored
-   content is fixed upstream first — issue → fix → merge → refresh on the PR
-   branch → resolve threads citing the fix. Stale-doc nits on the PR's own
-   payload may be fixed directly on the branch.
-6. **Capability changes need repo-side wiring.** A change consumers must
-   recognize in their own CI or branch protection is only half-propagated by
-   refresh: ship the spec in the owning skill's docs, coordinate the repo-side
-   change through each overseer, and verify end-to-end on each consumer's
-   origin/main. Security-relevant capabilities need explicit user sign-off
-   before propagation.
-
-### This skill's own home
-
-Canonical copy: `~/dotfiles/.agents/skills/kendex-issues/SKILL.md`, installed
-PROJECT-scoped in `~/dev/kendex` only — never global. Edit the dotfiles copy,
-then run `kendex refresh --scope project` in `~/dev/kendex`. If a stray
-`~/.agents/skills/kendex-issues` symlink ever appears, delete it — it collides
-with the project install.
+Source: `~/dev/kendex/.kendex-local/skills/kendex-issues/SKILL.md`
+(project-scoped, gitignored). Edit it, then `kendex apply` in `~/dev/kendex`.
+A `~/.agents/skills/kendex-issues` link is a collision — delete it.
 
 ## Guardrails
 
-- **Never pipe state-changing or guard commands through `tail`/`head`/`grep`**
-  inside a `&&` chain — the pipe replaces the exit status and masks refusals.
-  Run bare, check the result, then trim. Always read `worktree create`'s full
-  output before cd'ing in; an ownership refusal means another session owns the
-  work — back off and coordinate.
-- **Multi-agent ownership.** Before a fix cycle, check for an existing remote
-  branch, open PR, or foreign local worktree for the issue — other
-  orchestrators work this queue concurrently. Owned elsewhere → hands off —
-  but ownership expires: a kendex PR with unresolved review threads and no
-  pushes or replies for ~2 hours whose authoring session shows no activity
-  (its checkout back on main, no worktree) is ABANDONED — take it over,
-  answer every thread, and shepherd it to merge, noting the takeover in the
-  replies. Hands-off is for active peers, not stalled branches (bit
-  2026-08-09: #1139 sat 16 h with five unanswered bot threads while every
-  poll skipped it as "the other session's work").
-- **Consuming-repo boundary.** The steward's only write lane into consumers is
-  kendex propagation (vendored refreshes and kendex settings keys, through the
-  repo's own review/queue flow) plus hygiene on those PRs. Everything else
-  belongs to that repo's overseer — coordinate over tmux and verify delivery
-  (capture-pane after ~5s). Before pressing Enter on a stuck composer, read
-  its full content — any text that isn't your own just-sent message means
-  don't press Enter; surface the collision instead.
-- **Branch safety.** Never switch or commit on a checkout that's on a
-  non-default branch or mid-work; use a dedicated worktree off origin/main.
-- **Scoped commits, verified pushes.** Inspect diffs for mangling, run
-  `kendex verify`, confirm changes actually landed.
-- **Box load poisons suites.** Sibling sessions load this machine (stress
-  harnesses, ollama); a red bun/bash suite under load is suspect — check
-  uptime, rerun in isolation, A/B against clean HEAD before blaming the
-  change.
-- **Clean up** merged worktrees and stale local branches; keep local and
-  remote main in sync everywhere.
+- Never pipe a state-changing or guard command through `tail`/`head`/`grep`
+  in a `&&` chain. Run bare, read the result, then trim. Read `worktree
+  create`'s full output before entering it; an ownership refusal means
+  another session owns the work.
+- **Ownership.** Before a fix cycle, check for a remote branch, open PR, or
+  foreign worktree for the issue. Active peer → hands off. A PR with
+  unresolved threads and no pushes or replies for ~2 h whose session is idle
+  is abandoned: take it over, answer every thread, note the takeover.
+- **Consumer boundary.** The only write lane into consumers is kendex
+  propagation plus hygiene on those PRs. Coordinate everything else over
+  tmux; verify delivery with capture-pane after ~5 s; read a composer's full
+  content before pressing Enter.
+- **Branch safety.** Never switch or commit on a checkout mid-work; use a
+  worktree off `origin/main`. Never `git stash` in a shared checkout.
+- **Scoped commits, verified pushes.** Inspect diffs, `kendex verify`,
+  confirm it landed.
+- **Box load poisons suites.** A red suite under load: check uptime, rerun
+  in isolation, A/B against clean HEAD.
+- **Clean up** merged worktrees and stale branches; keep local and remote
+  main in sync.
 
 ## Cadence
 
-Self-pace the next wakeup: widen toward ~60 min when the queue has been quiet;
-tighten toward ~15–20 min after a new issue or a burst. Stay in the prompt
-cache when actively watching; go long when idle.
+Widen toward ~60 min when quiet; tighten toward ~15–20 min after a new
+issue or a burst.

--- a/.kendex-local/skills/kendex-issues/SKILL.md
+++ b/.kendex-local/skills/kendex-issues/SKILL.md
@@ -123,7 +123,7 @@ for a fail-open defect in a consumer gate or an owner ask.
 ### This skill's home
 
 Source: `~/dev/kendex/.kendex-local/skills/kendex-issues/SKILL.md`
-(project-scoped, gitignored). Edit it, then `kendex apply` in `~/dev/kendex`.
+(tracked; installed project-scoped only). Edit it, then `kendex apply` in `~/dev/kendex`.
 A `~/.agents/skills/kendex-issues` link is a collision — delete it.
 
 ## Guardrails

--- a/.pi/prompts/gh-release.md
+++ b/.pi/prompts/gh-release.md
@@ -1,0 +1,170 @@
+---
+description: Cut a new kendex GitHub feature release with CLI version/tag sync
+argument-hint: "[patch|minor|major]"
+---
+Cut a new kendex GitHub feature release. Optional bump override: `$ARGUMENTS`.
+
+## Intent
+Review all repository changes since the latest GitHub release, commit safe local work that should ship, ensure docs/tests are current, bump the CLI version, create a matching GitHub release/tag, and leave the local repo clean and pushed.
+
+## Hard rules
+- Never release with dirty or untracked local files after the preflight work-intake step. The release/tag steps require `git status --short` to be empty except for the intentional version bump before its commit.
+- Do not blindly `git add -A`. Inspect dirty and untracked paths, stage only files that are intended to ship, and exclude secrets/private files, ignored build outputs, caches, temp artifacts, local machine config, and generated noise.
+- If any dirty/untracked file is ambiguous, private-looking, ignored, or unrelated to the release, stop and ask before staging it. Do not stash/drop user work silently.
+- Commit safe dirty/untracked release content before the clean/current release preflight. The release preflight starts only after this feature/docs commit is complete and the worktree is clean.
+- Never release from a branch that is behind or diverged from `origin/main`.
+- Keep CLI package version and GitHub release tag exactly in sync:
+  - `crates/Cargo.toml` `[package].version = X.Y.Z`
+  - Git tag/release `vX.Y.Z`
+- Do not bump npm Pi extension package versions as part of this template unless explicitly requested; use `/npm-deploy` for Pi extension npm publishing.
+- Do not move an existing release pointer for a new feature release. Create a new version/tag/release.
+- Stage only intended files in each commit: feature/docs fixes in the work-intake commit; version files in the release-version commit.
+
+## Work-intake: commit safe local changes first
+1. Inspect local state before release preflight:
+   ```bash
+   git status --short --untracked-files=all
+   git diff --stat
+   git diff --name-only
+   ```
+2. Classify every dirty or untracked path:
+   - intended product/docs/test/release content → eligible to stage,
+   - private/secrets/local config (`.env*`, credentials, tokens, local settings) → do not stage; stop and ask,
+   - ignored/build/cache/temp artifacts → do not stage; stop and ask if they must remain,
+   - unrelated user work → do not stage; ask whether to include, commit separately, or stop.
+3. For untracked files, verify they are not ignored before considering them:
+   ```bash
+   git check-ignore -v -- <path> || true
+   ```
+   Ignored files are excluded by default. If an ignored file appears required for the release, ask before forcing it into git.
+4. Stage only safe intended paths explicitly:
+   ```bash
+   git add <intended-file> [<intended-file> ...]
+   git diff --cached --stat
+   git diff --cached --name-only
+   ```
+5. Run validation appropriate for the staged change. At minimum for CLI or TUI changes run:
+   ```bash
+   cargo test --workspace
+   ```
+6. Commit the staged work before release preflight with a descriptive non-version message, for example:
+   ```bash
+   git commit -m "kendex: improve TUI reinstall flow"
+   ```
+7. Re-check local state:
+   ```bash
+   git status --short --untracked-files=all
+   ```
+   If anything remains dirty/untracked, stop and ask unless it is intentionally excluded and safe to leave out of the release. Do not proceed to release preflight until the worktree is clean.
+
+## Preflight: clean and current
+1. Inspect branch and status:
+   ```bash
+   git status --short --branch
+   git fetch origin --tags
+   git rev-parse --abbrev-ref HEAD
+   git rev-list --left-right --count HEAD...origin/main
+   ```
+2. Require:
+   - branch is `main`,
+   - no dirty/untracked files,
+   - no ahead/behind/diverged commits unless they are intentionally pushed before release.
+3. If local commits are ahead, push them before continuing. If behind/diverged, stop and reconcile.
+4. Confirm latest release:
+   ```bash
+   gh release list --limit 10
+   git tag --sort=-v:refname | head
+   ```
+
+## Audit changes since latest release
+1. Identify latest GitHub CLI release tag (normally latest `vX.Y.Z` from `gh release list`, not Pi package tags).
+2. Inspect changes:
+   ```bash
+   git log --oneline <latest-release-tag>..HEAD
+   git diff --stat <latest-release-tag>..HEAD
+   git diff --name-only <latest-release-tag>..HEAD
+   ```
+3. Classify semver:
+   - patch: bug fixes, docs, internal cleanup, non-breaking behavior fixes.
+   - minor: additive CLI commands/options/features, new packages/extensions/agents/skills surfaced to users.
+   - major: breaking CLI behavior, lock/config format break, removed/renamed commands/options, incompatible install behavior.
+4. If the user supplied an explicit bump in `$1`, verify it is not lower than the change classification. Ask before using a lower bump.
+
+## Documentation freshness check
+Compare code changes to docs before bumping:
+- Read affected docs/README files and changed source.
+- Check CLI docs/help examples, AGENTS.md repo layout/rules, README feature lists, Pi extension docs if included, command flags, config keys, release/install commands, and examples.
+- Ensure new commands/options/config fields/user-visible behavior are documented.
+- Ensure removed/renamed/dead behavior is not still documented.
+- Grep for stale old names/versions/config keys if renames happened.
+- If docs are stale, update docs and commit those docs before the version bump, then restart preflight cleanliness/currentness.
+
+## Validation before version bump
+Run required validation for the changed areas:
+- Always run CLI tests:
+  ```bash
+  cargo test --workspace
+  ```
+- If CLI behavior/install paths changed, run the repo integration check, which installs into a throwaway temp project and verifies the printed scope summary:
+  ```bash
+  tools/guard
+  ```
+- If Pi extensions changed in the release range, run each affected package's validation (`npm run check`, or available typecheck/test/build scripts) and consider `/npm-deploy` separately.
+- If docs/examples changed only, run enough checks to confirm examples are still true.
+- Do not release on failing validation unless the user explicitly accepts the risk.
+
+## Bump CLI version
+1. Compute next `X.Y.Z` from latest release and semver classification.
+2. Update `crates/Cargo.toml` `[package].version` to `X.Y.Z`.
+3. If `Cargo.lock` contains the `kendex` package version, update it by running appropriate cargo metadata/build/test command from the workspace root.
+4. Re-run `cargo test --workspace` after the version bump.
+5. Confirm:
+   ```bash
+   grep '^version = ' Cargo.toml
+   git diff -- Cargo.toml Cargo.lock
+   ```
+6. Commit only intended version files:
+   ```bash
+   git add Cargo.toml Cargo.lock
+   git commit -m "kendex: release vX.Y.Z"
+   ```
+
+## Create and push release
+1. Ensure clean status after commit:
+   `git status --short --branch`.
+2. Push main:
+   `git push origin main`.
+3. Create annotated or lightweight tag matching CLI version exactly:
+   `git tag vX.Y.Z`.
+4. Push tag:
+   `git push origin vX.Y.Z`.
+5. Create GitHub release as latest:
+   ```bash
+   gh release create vX.Y.Z --title "kendex X.Y.Z" --generate-notes --latest
+   ```
+   If generated notes omit important highlights, edit the release notes with a concise summary from the audit.
+
+## Final post-release checks
+1. Verify GitHub release/tag:
+   ```bash
+   gh release view vX.Y.Z
+   git ls-remote --tags origin vX.Y.Z
+   ```
+2. Confirm version/tag sync:
+   - `crates/Cargo.toml` version is `X.Y.Z`.
+   - Git tag and release are `vX.Y.Z`.
+3. Confirm clean/current:
+   ```bash
+   git status --short --branch
+   git rev-list --left-right --count HEAD...origin/main
+   ```
+
+## Final report
+Report:
+- latest previous release tag,
+- semver classification and chosen new version,
+- docs freshness findings/changes,
+- validation commands/results,
+- release commit and tag,
+- GitHub release URL,
+- final clean/current git status.

--- a/.pi/prompts/gh-release.md
+++ b/.pi/prompts/gh-release.md
@@ -1,170 +1,39 @@
 ---
-description: Cut a new kendex GitHub feature release with CLI version/tag sync
+description: Cut a kendex release — version bump, tag, draft review — per docs/RELEASING.md
 argument-hint: "[patch|minor|major]"
 ---
-Cut a new kendex GitHub feature release. Optional bump override: `$ARGUMENTS`.
+Cut a kendex release. Optional bump: `$ARGUMENTS` (default: patch; minor when
+CHANGELOG's Unreleased section has an Added entry; major only when asked).
 
-## Intent
-Review all repository changes since the latest GitHub release, commit safe local work that should ship, ensure docs/tests are current, bump the CLI version, create a matching GitHub release/tag, and leave the local repo clean and pushed.
+`docs/RELEASING.md` is the procedure; this prompt only sequences it.
 
-## Hard rules
-- Never release with dirty or untracked local files after the preflight work-intake step. The release/tag steps require `git status --short` to be empty except for the intentional version bump before its commit.
-- Do not blindly `git add -A`. Inspect dirty and untracked paths, stage only files that are intended to ship, and exclude secrets/private files, ignored build outputs, caches, temp artifacts, local machine config, and generated noise.
-- If any dirty/untracked file is ambiguous, private-looking, ignored, or unrelated to the release, stop and ask before staging it. Do not stash/drop user work silently.
-- Commit safe dirty/untracked release content before the clean/current release preflight. The release preflight starts only after this feature/docs commit is complete and the worktree is clean.
-- Never release from a branch that is behind or diverged from `origin/main`.
-- Keep CLI package version and GitHub release tag exactly in sync:
-  - `crates/Cargo.toml` `[package].version = X.Y.Z`
-  - Git tag/release `vX.Y.Z`
-- Do not bump npm Pi extension package versions as part of this template unless explicitly requested; use `/npm-deploy` for Pi extension npm publishing.
-- Do not move an existing release pointer for a new feature release. Create a new version/tag/release.
-- Stage only intended files in each commit: feature/docs fixes in the work-intake commit; version files in the release-version commit.
+## Rules
+- Release from `main`, clean, equal to `origin/main`. Dirty or untracked
+  files: stage only what should ship, commit first, ask about anything
+  ambiguous or private-looking. Never `git add -A`, never stash.
+- One version in three places, equal to the tag minus `v`: `Cargo.toml`
+  `[workspace.package].version`, `crates/app/tauri.conf.json` `version`,
+  and `Cargo.lock` (run `cargo build -q` after the bump).
+- Pi extension npm versions are not touched here (`/npm-deploy`).
+- Never move an existing tag.
 
-## Work-intake: commit safe local changes first
-1. Inspect local state before release preflight:
-   ```bash
-   git status --short --untracked-files=all
-   git diff --stat
-   git diff --name-only
-   ```
-2. Classify every dirty or untracked path:
-   - intended product/docs/test/release content → eligible to stage,
-   - private/secrets/local config (`.env*`, credentials, tokens, local settings) → do not stage; stop and ask,
-   - ignored/build/cache/temp artifacts → do not stage; stop and ask if they must remain,
-   - unrelated user work → do not stage; ask whether to include, commit separately, or stop.
-3. For untracked files, verify they are not ignored before considering them:
-   ```bash
-   git check-ignore -v -- <path> || true
-   ```
-   Ignored files are excluded by default. If an ignored file appears required for the release, ask before forcing it into git.
-4. Stage only safe intended paths explicitly:
-   ```bash
-   git add <intended-file> [<intended-file> ...]
-   git diff --cached --stat
-   git diff --cached --name-only
-   ```
-5. Run validation appropriate for the staged change. At minimum for CLI or TUI changes run:
-   ```bash
-   cargo test --workspace
-   ```
-6. Commit the staged work before release preflight with a descriptive non-version message, for example:
-   ```bash
-   git commit -m "kendex: improve TUI reinstall flow"
-   ```
-7. Re-check local state:
-   ```bash
-   git status --short --untracked-files=all
-   ```
-   If anything remains dirty/untracked, stop and ask unless it is intentionally excluded and safe to leave out of the release. Do not proceed to release preflight until the worktree is clean.
-
-## Preflight: clean and current
-1. Inspect branch and status:
-   ```bash
-   git status --short --branch
-   git fetch origin --tags
-   git rev-parse --abbrev-ref HEAD
-   git rev-list --left-right --count HEAD...origin/main
-   ```
-2. Require:
-   - branch is `main`,
-   - no dirty/untracked files,
-   - no ahead/behind/diverged commits unless they are intentionally pushed before release.
-3. If local commits are ahead, push them before continuing. If behind/diverged, stop and reconcile.
-4. Confirm latest release:
-   ```bash
-   gh release list --limit 10
-   git tag --sort=-v:refname | head
-   ```
-
-## Audit changes since latest release
-1. Identify latest GitHub CLI release tag (normally latest `vX.Y.Z` from `gh release list`, not Pi package tags).
-2. Inspect changes:
-   ```bash
-   git log --oneline <latest-release-tag>..HEAD
-   git diff --stat <latest-release-tag>..HEAD
-   git diff --name-only <latest-release-tag>..HEAD
-   ```
-3. Classify semver:
-   - patch: bug fixes, docs, internal cleanup, non-breaking behavior fixes.
-   - minor: additive CLI commands/options/features, new packages/extensions/agents/skills surfaced to users.
-   - major: breaking CLI behavior, lock/config format break, removed/renamed commands/options, incompatible install behavior.
-4. If the user supplied an explicit bump in `$1`, verify it is not lower than the change classification. Ask before using a lower bump.
-
-## Documentation freshness check
-Compare code changes to docs before bumping:
-- Read affected docs/README files and changed source.
-- Check CLI docs/help examples, AGENTS.md repo layout/rules, README feature lists, Pi extension docs if included, command flags, config keys, release/install commands, and examples.
-- Ensure new commands/options/config fields/user-visible behavior are documented.
-- Ensure removed/renamed/dead behavior is not still documented.
-- Grep for stale old names/versions/config keys if renames happened.
-- If docs are stale, update docs and commit those docs before the version bump, then restart preflight cleanliness/currentness.
-
-## Validation before version bump
-Run required validation for the changed areas:
-- Always run CLI tests:
-  ```bash
-  cargo test --workspace
-  ```
-- If CLI behavior/install paths changed, run the repo integration check, which installs into a throwaway temp project and verifies the printed scope summary:
-  ```bash
-  tools/guard
-  ```
-- If Pi extensions changed in the release range, run each affected package's validation (`npm run check`, or available typecheck/test/build scripts) and consider `/npm-deploy` separately.
-- If docs/examples changed only, run enough checks to confirm examples are still true.
-- Do not release on failing validation unless the user explicitly accepts the risk.
-
-## Bump CLI version
-1. Compute next `X.Y.Z` from latest release and semver classification.
-2. Update `crates/Cargo.toml` `[package].version` to `X.Y.Z`.
-3. If `Cargo.lock` contains the `kendex` package version, update it by running appropriate cargo metadata/build/test command from the workspace root.
-4. Re-run `cargo test --workspace` after the version bump.
-5. Confirm:
-   ```bash
-   grep '^version = ' Cargo.toml
-   git diff -- Cargo.toml Cargo.lock
-   ```
-6. Commit only intended version files:
-   ```bash
-   git add Cargo.toml Cargo.lock
-   git commit -m "kendex: release vX.Y.Z"
-   ```
-
-## Create and push release
-1. Ensure clean status after commit:
-   `git status --short --branch`.
-2. Push main:
-   `git push origin main`.
-3. Create annotated or lightweight tag matching CLI version exactly:
-   `git tag vX.Y.Z`.
-4. Push tag:
-   `git push origin vX.Y.Z`.
-5. Create GitHub release as latest:
-   ```bash
-   gh release create vX.Y.Z --title "kendex X.Y.Z" --generate-notes --latest
-   ```
-   If generated notes omit important highlights, edit the release notes with a concise summary from the audit.
-
-## Final post-release checks
-1. Verify GitHub release/tag:
-   ```bash
-   gh release view vX.Y.Z
-   git ls-remote --tags origin vX.Y.Z
-   ```
-2. Confirm version/tag sync:
-   - `crates/Cargo.toml` version is `X.Y.Z`.
-   - Git tag and release are `vX.Y.Z`.
-3. Confirm clean/current:
-   ```bash
-   git status --short --branch
-   git rev-list --left-right --count HEAD...origin/main
-   ```
-
-## Final report
-Report:
-- latest previous release tag,
-- semver classification and chosen new version,
-- docs freshness findings/changes,
-- validation commands/results,
-- release commit and tag,
-- GitHub release URL,
-- final clean/current git status.
+## Steps
+1. `git fetch origin && git status --short` — must be clean and at
+   `origin/main`. `gh release list --limit 1` — the last tag.
+2. `git log --oneline <last-tag>..HEAD` — confirm there is something to
+   ship; finalize `CHANGELOG.md`: rename `## [Unreleased]` to
+   `## [X.Y.Z] - YYYY-MM-DD` and open a fresh empty `## [Unreleased]`.
+3. Bump the three version sites; `cargo build -q`; `tools/guard`.
+4. Commit `chore(release): vX.Y.Z` with exactly `Cargo.toml Cargo.lock
+   crates/app/tauri.conf.json CHANGELOG.md`; push through the normal PR
+   flow if branch protection requires it, else push `main`.
+5. `git tag vX.Y.Z && git push origin vX.Y.Z`. The tag starts
+   `.github/workflows/release.yml`, which builds every target and creates a
+   **draft** release. Do not call `gh release create`.
+6. `gh run watch` the release workflow. When it finishes, `gh release view
+   vX.Y.Z` — the draft must list one `kendex-<target>` per target, the app
+   bundles, and `feed.json`. Missing asset → fix the workflow, re-tag only
+   after deleting the failed draft and tag.
+7. Publish the draft: `gh release edit vX.Y.Z --draft=false`. Confirm
+   `releases/latest/download/feed.json` serves the new version.
+8. Report: tag, assets, anything skipped.

--- a/.pi/prompts/npm-deploy.md
+++ b/.pi/prompts/npm-deploy.md
@@ -1,0 +1,110 @@
+---
+description: Audit changed Pi extensions, validate, bump, publish to npm, tag, push, refresh, and verify
+argument-hint: "[package-name]"
+---
+Run a complete npm deployment pass for kendex Pi extensions. Optional package filter: `$ARGUMENTS`.
+
+## Intent
+Find every `pi-extensions/*/package.json` package whose source/docs/package contents changed since its last npm deployment tag, then validate, bump, publish, tag, push, refresh, and verify it. Leave no dirty/untracked files.
+
+kendex distribution is independent of npm. `kendex add`/`refresh` copies local source — npm publishing only populates the pi.dev gallery and lets external users run `pi install npm:@vanillagreen/<name>`. Skipping a publish never breaks kendex consumers.
+
+## Hard rules
+- Publish only Pi extension packages that actually need a new npm version.
+- Use scoped npm names from `package.json` (normally `@vanillagreen/<name>`).
+- Per-package release tags use `<unscoped-name>-v<version>` (example: `pi-qol-v1.0.4`).
+- Never publish outside `op run --env-file=../../.env.npm -- npm publish --userconfig=../../.npmrc`.
+- Never write or log npm tokens. `.env.npm` only contains an `op://` reference, never a literal token; never commit `.env.npm` (gitignored).
+- Never use `op run --no-masking` outside one-off auth verification.
+- Stage only intended files. Preserve unrelated user dirty files; if unrelated dirt exists, stop and ask unless the user explicitly included it.
+- Version bump commits are separate from source/docs commits when source/docs changes are not already committed.
+- After any committed Pi package source change, run `kendex refresh`, then `kendex verify -g <changed packages...>`.
+
+## Skip publish for
+- Refactors with no behavior change.
+- Internal cleanup, comment/typo fixes.
+- README/doc edits unless gallery copy needs updating.
+
+Semver bump rules:
+- patch — bug fix, no API change.
+- minor — additive: new tool, new setting, backward-compatible feature.
+- major — breaking: removed/renamed tool, changed setting key, dropped Pi peerDependency support.
+
+## Audit
+1. Inspect `git status --short --branch`.
+2. Enumerate all packages:
+   - `find pi-extensions -maxdepth 2 -name package.json -print | sort`
+   - For each manifest, read `name` and `version`.
+3. For each package, compute:
+   - current npm version: `npm view <name> version`
+   - expected current tag: `<unscoped-name>-v<package.json version>`
+   - source drift since that tag: `git diff --name-only <tag>..HEAD -- <package-dir>` when the tag exists.
+4. Mark a package for deployment if any of these are true:
+   - package files changed since its current version tag,
+   - `package.json` version is greater than npm version,
+   - npm version exists but matching git tag is missing,
+   - user package filter names the package.
+
+## Documentation freshness check
+For each marked package, compare changed code to package docs before publishing:
+- Read its README and package `kendex.extensionManager.settings`.
+- Look for stale setting keys, config examples, commands, shortcuts, tool names, default values, package names, behavior claims, screenshots captions, and install/publish instructions.
+- If new user-visible behavior, settings, commands, tool behavior, critical safety behavior, or workflow changes are missing from docs, update docs first.
+- Also grep all Pi extension READMEs for stale unscoped config examples such as `"pi-web-tools"` under `kendex.extensionManager.config`; current keys should be scoped (`"@vanillagreen/pi-web-tools"`).
+
+## Validation
+For every marked package, run the strongest available validation before publish:
+- If `scripts.check` exists: `npm run check`.
+- Else run available `typecheck`, `test:unit`, `test`, and/or `build` scripts as applicable.
+- If no scripts exist, run lightweight syntax/import checks where practical (for TS-only Pi extensions, use an existing package with `tsx` if available, or explain why live import is not practical due peer deps).
+- For repo-level/CLI changes discovered while auditing, run relevant repo tests too (`cargo test --workspace`).
+- Do not proceed on failing validation unless the user explicitly accepts the risk.
+
+## Commit source/docs before version bumps
+If there are intended source/docs changes not yet committed:
+1. Stage only those intended files.
+2. Commit with a concise package-scoped message.
+3. Re-check status.
+
+## Version bump and publish
+For each marked package that needs publishing:
+1. Choose semver bump:
+   - patch: bug fix, docs packaged with runtime, settings/docs cleanup, UI fix.
+   - minor: additive new command/tool/setting/feature.
+   - major: breaking setting/tool/API behavior.
+2. Bump the package only:
+   ```bash
+   cd pi-extensions/<dir>
+   npm version <patch|minor|major> --no-git-tag-version
+   cd ../..
+   ```
+3. Stage only that package's `package.json` and any lockfile changed by `npm version`.
+4. Commit version bumps. Prefer a single coordinated commit if deploying multiple packages.
+5. Publish each package:
+   ```bash
+   cd pi-extensions/<dir>
+   op run --env-file=../../.env.npm -- npm publish --userconfig=../../.npmrc
+   cd ../..
+   ```
+6. Verify npm reports the new version:
+   `npm view <name> version`.
+7. Create per-package git tags at the version-bump commit:
+   `git tag <unscoped-name>-v<version>`.
+
+## Push, refresh, verify
+1. Push `main` and all new package tags.
+2. Run:
+   ```bash
+   kendex refresh
+   kendex verify -g <changed scoped package names...>
+   ```
+3. Confirm `git status --short --branch` is clean and local `main` matches `origin/main`.
+
+## Final report
+Report:
+- packages audited and deployed,
+- versions published to npm,
+- commits and tags pushed,
+- validation commands/results,
+- refresh/verify result,
+- final git status.

--- a/.pi/prompts/pi-update.md
+++ b/.pi/prompts/pi-update.md
@@ -9,22 +9,20 @@ Pi ships all its packages in lockstep under one monorepo version (e.g. `0.82.0`)
 Do not invent work that isn't supported by a changelog entry; do not skip an entry that touches a surface we own. Earlier releases (at or below the marker version) are assumed already absorbed.
 
 ## Sources (fetch all — do not wait for a paste)
-Authoritative per-package changelogs in `earendil-works/pi` on `main` (older links in the entries may say `pi-mono`; the live repo is `earendil-works/pi`):
+Every per-package changelog in `earendil-works/pi` on `main`. Enumerate them
+each run instead of trusting a list:
 
-| Key | Path |
-|-----|------|
-| `agent` | `packages/agent/CHANGELOG.md` |
-| `ai` | `packages/ai/CHANGELOG.md` |
-| `coding-agent` | `packages/coding-agent/CHANGELOG.md` |
-| `server` | `packages/server/CHANGELOG.md` |
-| `storage` | `packages/storage/sqlite-node/CHANGELOG.md` |
-| `tui` | `packages/tui/CHANGELOG.md` |
+```bash
+gh api repos/earendil-works/pi/git/trees/main?recursive=1 --jq '.tree[].path | select(endswith("/CHANGELOG.md"))'
+```
 
-Curated cross-package release notes (secondary cross-check, not authoritative for per-package detail): <https://pi.dev/news/releases>.
-
-Fetch each changelog with `web_fetch` on its raw URL, e.g.
-`https://raw.githubusercontent.com/earendil-works/pi/main/packages/coding-agent/CHANGELOG.md`
-(fallback: `gh api repos/earendil-works/pi/contents/<path> -H "Accept: application/vnd.github.raw"`). All six share one version line — fetch all six; they will normally list the same new version headers.
+The key for a source is its path with `packages/` and `/CHANGELOG.md`
+stripped. Fetch each with
+`gh api repos/earendil-works/pi/contents/<path> -H "Accept: application/vnd.github.raw"`.
+Record every key fetched in the marker's `sourcesCovered`; a key present
+last run and absent now is reported, never silently dropped. Curated
+cross-package notes (<https://pi.dev/news/releases>) are a secondary
+cross-check only.
 
 Each changelog uses `## [x.y.z] - YYYY-MM-DD` headers with `### New Features / Added / Changed / Fixed / Removed` sub-sections. A leading `## [Unreleased]` block is not a release: scan it for a heads-up only, and never advance the marker to it.
 
@@ -36,13 +34,13 @@ State lives in `pi-extensions/pi-update.state.json` (committed source; not a dis
   "lastDate": "2026-07-24",
   "lastRun": "2026-07-24T18:00:00Z",
   "lastRunHead": "<git sha at run start>",
-  "sourcesCovered": ["agent", "ai", "coding-agent", "server", "storage", "tui", "releases"]
+  "sourcesCovered": ["<every key fetched>", "releases"]
 }
 ```
 
 1. Read the marker. **In scope = every released version header `> lastVersion`** (semver) across all sources, newest processed last. If the top released version equals `lastVersion`, there is nothing to do — say so, still refresh the `lastRun`/`lastRunHead` timestamp, commit the marker, and stop.
 2. **First run (marker absent):** do not silently process the entire history. Detect a candidate baseline (most recent Pi version referenced in `git log`, else the version bundled at `pi-extensions/pi-claude-bridge/node_modules/@earendil-works/pi-coding-agent/CHANGELOG.md`), then use the `question` tool to confirm the baseline version with the user before doing any work. Seed the marker at the confirmed baseline; only versions strictly greater are processed.
-3. **Override:** if the user pastes a changelog or names an explicit version/range after the command, treat that as the authoritative item list, skip fetching, and still update the marker to the highest version covered.
+3. **Override:** a pasted changelog is the authoritative item list and skips fetching. An explicit version or range after the command only constrains which version headers are in scope; every source is still fetched. Either way the marker advances to the highest version covered.
 4. **Update on success (even a no-op):** after the audit — whether or not any fix shipped — rewrite the marker with the newest processed version/date, a fresh `lastRun`, and the run-start `lastRunHead`, and commit it. The marker commit records "audited through vX.Y.Z" so the next run does not re-audit.
 
 ## Hard rules
@@ -95,7 +93,7 @@ Produce a structured summary:
 - **Working tree:** confirm `git status --short` is clean.
 
 ## Notes
-- All six package changelogs currently release in lockstep under one monorepo version, so `lastVersion` tracks the whole release. If a package ever diverges, split the marker to a per-source `{ key: version }` map and gate each source independently.
+- The package changelogs release in lockstep under one monorepo version, so `lastVersion` tracks the whole release. If a package ever diverges, split the marker to a per-source `{ key: version }` map and gate each source independently.
 - Pi `pi update` only reconciles `git:` and `npm:` scheme entries in Pi's `settings.json`. Vstack-installed extensions live as path packages (`./packages/<name>`) so they are out of scope for Pi-side `pi update` git-ref reconcile changes; flag this explicitly when a changelog entry mentions `pi update`.
 - Changes to model/provider config (Bedrock, Copilot, OpenCode Zen routing, `compat.*` flags) do not touch our extension surface unless we override a provider — confirm by grepping for the affected provider id before classifying as Non-impact.
 - Read tool, bash tool, edit tool, write tool, and search/list tool renderers are owned by `pi-tool-renderer` and override Pi defaults. Pi core UX changes to these tools are a UX choice for us, not an automatic must-mirror; ask the user when default behavior diverges.

--- a/.pi/prompts/pi-update.md
+++ b/.pi/prompts/pi-update.md
@@ -1,0 +1,101 @@
+---
+description: Audit kendex Pi extensions against every Pi package changelog since the last run, then apply needed fixes
+---
+Audit `pi-extensions/*` against **every Pi package changelog** for the releases published since this command last ran. Fetch the changelogs yourself — nothing is pasted. Compute the delta from the marker file, classify each new entry, apply the fixes that should ship, and leave the rest documented with reasoning.
+
+## Intent
+Pi ships all its packages in lockstep under one monorepo version (e.g. `0.82.0`). Each release adds entries across several package changelogs. This command finds every release newer than the last one we audited, unions the changelog entries across all packages plus the curated release notes, and decides — per entry — whether our extensions must change.
+
+Do not invent work that isn't supported by a changelog entry; do not skip an entry that touches a surface we own. Earlier releases (at or below the marker version) are assumed already absorbed.
+
+## Sources (fetch all — do not wait for a paste)
+Authoritative per-package changelogs in `earendil-works/pi` on `main` (older links in the entries may say `pi-mono`; the live repo is `earendil-works/pi`):
+
+| Key | Path |
+|-----|------|
+| `agent` | `packages/agent/CHANGELOG.md` |
+| `ai` | `packages/ai/CHANGELOG.md` |
+| `coding-agent` | `packages/coding-agent/CHANGELOG.md` |
+| `server` | `packages/server/CHANGELOG.md` |
+| `storage` | `packages/storage/sqlite-node/CHANGELOG.md` |
+| `tui` | `packages/tui/CHANGELOG.md` |
+
+Curated cross-package release notes (secondary cross-check, not authoritative for per-package detail): <https://pi.dev/news/releases>.
+
+Fetch each changelog with `web_fetch` on its raw URL, e.g.
+`https://raw.githubusercontent.com/earendil-works/pi/main/packages/coding-agent/CHANGELOG.md`
+(fallback: `gh api repos/earendil-works/pi/contents/<path> -H "Accept: application/vnd.github.raw"`). All six share one version line — fetch all six; they will normally list the same new version headers.
+
+Each changelog uses `## [x.y.z] - YYYY-MM-DD` headers with `### New Features / Added / Changed / Fixed / Removed` sub-sections. A leading `## [Unreleased]` block is not a release: scan it for a heads-up only, and never advance the marker to it.
+
+## Delta since last run (marker file)
+State lives in `pi-extensions/pi-update.state.json` (committed source; not a discovered extension — it has no `package.json`, and it sits beside the existing `pi-extensions/package-policy.test.mjs`). It is kept outside `.pi/` on purpose: `.pi/` is broadly gitignored and a marker there cannot be reliably re-included. Schema:
+```json
+{
+  "lastVersion": "0.82.0",
+  "lastDate": "2026-07-24",
+  "lastRun": "2026-07-24T18:00:00Z",
+  "lastRunHead": "<git sha at run start>",
+  "sourcesCovered": ["agent", "ai", "coding-agent", "server", "storage", "tui", "releases"]
+}
+```
+
+1. Read the marker. **In scope = every released version header `> lastVersion`** (semver) across all sources, newest processed last. If the top released version equals `lastVersion`, there is nothing to do — say so, still refresh the `lastRun`/`lastRunHead` timestamp, commit the marker, and stop.
+2. **First run (marker absent):** do not silently process the entire history. Detect a candidate baseline (most recent Pi version referenced in `git log`, else the version bundled at `pi-extensions/pi-claude-bridge/node_modules/@earendil-works/pi-coding-agent/CHANGELOG.md`), then use the `question` tool to confirm the baseline version with the user before doing any work. Seed the marker at the confirmed baseline; only versions strictly greater are processed.
+3. **Override:** if the user pastes a changelog or names an explicit version/range after the command, treat that as the authoritative item list, skip fetching, and still update the marker to the highest version covered.
+4. **Update on success (even a no-op):** after the audit — whether or not any fix shipped — rewrite the marker with the newest processed version/date, a fresh `lastRun`, and the run-start `lastRunHead`, and commit it. The marker commit records "audited through vX.Y.Z" so the next run does not re-audit.
+
+## Hard rules
+- Do not bump any extension package version unless the user explicitly asks. `kendex refresh` ships behavior changes without a version bump.
+- Do not bump the CLI version or cut a release; that is `/gh-release`.
+- Do not npm-publish; that is `/npm-deploy`.
+- Stage only intended files in each commit. Mention unrelated dirty files; stop and ask if anything looks unintentional.
+- After every committed extension change, run `kendex refresh` and report which packages were updated. The Pi extension development workflow in `CLAUDE.md` is binding: commit first, then refresh.
+- Do not claim "fixed" or "shipped" until commit + refresh both completed and reported.
+- If you cannot live-test inside Pi, say so explicitly rather than asserting parity.
+
+## Audit process
+1. **Enumerate extensions.** `ls pi-extensions/` — every subdir with a `package.json` is in scope.
+2. **Triage each new entry by package** (which of our extensions the source most likely touches):
+   - `coding-agent` — tools, hooks, agent runtime, SDK fields, `settings.json`. Highest impact; touches nearly every extension (`pi-tool-renderer`, `pi-hooks`, `pi-agents-tmux`, `pi-task-panel`, `pi-questions`, `pi-qol`, `pi-output-policy`, `pi-skills-manager`, `pi-session-manager`, `pi-web-tools`, `pi-caveman`, `pi-claude-bridge`, `pi-codex-minimal-tools`, `pi-prompt-stash`, `pi-extension-manager`).
+   - `ai` — provider/model SDK (constrained sampling, capability flags, catalogs). Mostly Non-impact unless we override a provider — grep the affected provider id first (see Notes).
+   - `agent` — agent loop/primitives → `pi-agents-tmux`, `pi-session-bridge`.
+   - `server` — RPC/server events → `pi-session-bridge` (RPC surface), `pi-web-tools`.
+   - `storage` — session persistence → `pi-session-manager`, `pi-session-bridge`, `pi-prompt-stash`.
+   - `tui` — terminal UI, rendering, popups → `pi-tool-renderer`, `pi-qol`, `pi-extension-manager`, `pi-skills-manager`.
+3. **Classify each entry** into exactly one bucket:
+   - **Required parity fix** — Pi core changed a behavior we override, mirror, or duplicate (e.g. a tool renderer we replace, a hook event shape, a `settings.json` field we read/write). Off-by-one bugs in helpers we copied count here.
+   - **Optional improvement** — Pi exposed a new SDK field, helper, or event that could simplify our code, but our current code is still correct.
+   - **Non-impact** — Pi core internals, provider/auth fixes, Windows/macOS platform fixes, theme picker UI, or other surfaces outside our extension code.
+4. **For each Required and Optional item:**
+   - Grep our extensions for the affected symbol/field/regex/file pattern. Cite the exact `path:line`.
+   - If a referenced Pi-side field name is unclear, fetch the relevant Pi source file from <https://github.com/earendil-works/pi> to confirm before editing.
+   - Decide: ship now, defer, or skip. Record reasoning.
+5. **For Non-impact items:** one-line justification each — enough that re-reading the audit later confirms it was considered.
+
+## Apply fixes
+For every "ship now" item:
+1. Edit the canonical extension files only — never touch `.pi/`, `.claude/`, `.opencode/`, `.codex/`, `.agents/`, `.cursor/` mirrors. (`pi-extensions/pi-update.state.json` is source state, not an extension — updating it is expected.)
+2. If a fix touches a behavior covered by `hooks/*.sh`, mirror it in `pi-extensions/pi-hooks/extensions/hooks.ts` in the same commit (parity rule in `CLAUDE.md`).
+3. If a fix changes user-visible behavior or settings, update the matching README/SKILL.md/`kendex.toml`/`.env.local.example` payload in the same commit.
+4. Add or extend a unit test where the fix is testable in isolation (favor regression coverage on numeric helpers, parsers, off-by-one bugs).
+5. Run any package-local test suite the fix touches. Document the result (pass/fail, count). If peer-dep imports prevent local execution, link the bundled Pi modules from `/usr/lib/node_modules/pi/node_modules/@earendil-works/*` into a temporary `node_modules/@earendil-works/` (symlinks only), run the tests, then remove the temp `node_modules/` and any generated lockfile so the working tree stays clean.
+6. Group related fixes into one commit per logical change. Multi-package fixes for the same Pi changelog item belong in one commit with a subject listing the affected packages.
+7. After commit(s), run `kendex refresh` and capture the "Pi package(s) updated" line.
+
+## Final report
+Produce a structured summary:
+- **Releases covered:** `lastVersion` → newest processed version, with dates, and the source keys that carried new entries.
+- **Classified entries:** count per bucket (Required / Optional / Non-impact).
+- **Shipped:** commit hash + one-line subject for each commit; affected extensions; tests run with pass count.
+- **Deferred / skipped (with reason):** Optional items not taken, plus the reasoning (e.g. "Pi exposes unified `details.patch` string; our renderer needs `StructuredDiff` tokens for split view, no net simplification").
+- **Non-impact log:** bulleted list of entries with one-line justification.
+- **Marker:** old → new `lastVersion`, and the commit that updated `pi-extensions/pi-update.state.json`.
+- **Refresh result:** packages reported updated by `kendex refresh`.
+- **Working tree:** confirm `git status --short` is clean.
+
+## Notes
+- All six package changelogs currently release in lockstep under one monorepo version, so `lastVersion` tracks the whole release. If a package ever diverges, split the marker to a per-source `{ key: version }` map and gate each source independently.
+- Pi `pi update` only reconciles `git:` and `npm:` scheme entries in Pi's `settings.json`. Vstack-installed extensions live as path packages (`./packages/<name>`) so they are out of scope for Pi-side `pi update` git-ref reconcile changes; flag this explicitly when a changelog entry mentions `pi update`.
+- Changes to model/provider config (Bedrock, Copilot, OpenCode Zen routing, `compat.*` flags) do not touch our extension surface unless we override a provider — confirm by grepping for the affected provider id before classifying as Non-impact.
+- Read tool, bash tool, edit tool, write tool, and search/list tool renderers are owned by `pi-tool-renderer` and override Pi defaults. Pi core UX changes to these tools are a UX choice for us, not an automatic must-mirror; ask the user when default behavior diverges.

--- a/kendex.settings.toml
+++ b/kendex.settings.toml
@@ -228,15 +228,14 @@ SIZE_RATCHET_CLASSES = "*/README.md=120;*/tests/*=800;*/test/*=800;*/__tests__/*
 # paths only: an entry over tracked files makes git refuse writes in that
 # worktree while `git status` still reports clean.
 #
-# The harness directories are named whole (.pi, .codex, .opencode) because
-# nothing under them is tracked. .claude is named child by child instead:
-# it holds tracked files beside the kendex-rendered, gitignored ones, and
-# only the latter may be links.
+# .codex and .opencode are named whole: nothing under them is tracked.
+# .claude and .pi are named child by child: they hold tracked files
+# (.claude/CLAUDE.md, .pi/prompts) beside kendex-rendered, gitignored ones.
 WORKTREE_BASE_DIR = "~/dev/.worktrees/kendex"
 WORKTREE_COPIES = ".kendex-lock.json"
 WORKTREE_DEFAULT_BRANCH = "main"
 WORKTREE_MKDIRS = "tmp"
-WORKTREE_SYMLINKS = ".env.local .agents .cache .codex .opencode .pi .claude/agents .claude/hooks .claude/skills .claude/settings.json"
+WORKTREE_SYMLINKS = ".env.local .agents .cache .codex .opencode .pi/agents .pi/kendex .claude/agents .claude/hooks .claude/skills .claude/settings.json"
 
 # Nothing needs one: .claude/CLAUDE.md is a tracked symlink, so it arrives
 # through git, and naming it here would shadow tracked content.


### PR DESCRIPTION
- `.pi/prompts/{gh-release,npm-deploy,pi-update}.md` ported from vstack (tracked there, missing here), vstack→kendex renames, `cli/` paths → workspace. `.gitignore` un-ignores `.pi/prompts`; `WORKTREE_SYMLINKS` names `.pi/agents .pi/kendex` instead of `.pi` so worktrees never shadow the tracked prompts (the vstack layout).
- `.kendex-local/skills/kendex-issues/SKILL.md`: 2,269 → 1,225 words; adds the scope / convergence / ratchet / no-admin rules; drops dated narration and a `~/dotfiles` home that does not exist.

https://claude.ai/code/session_013EDioRsTBmsfaYeAah71hB