### PR TITLE
fix(core): pi move holds stay with pi hooks (KEN-531)

### DIFF
--- a/crates/core/src/engine/detach.rs
+++ b/crates/core/src/engine/detach.rs
@@ -226,9 +226,10 @@ fn edited_items(
 }
 
 /// Whether the user has edited this installation's bytes, for the kinds detach
-/// can lose bytes for. The engine's own check covers skills, agents and
-/// commands; a hook installs an editable script the engine's check skips, so
-/// detach compares it to what apply last wrote and catches an edited hook too.
+/// can lose bytes for. The engine's own check covers skills, agents, commands
+/// and anchored hooks; an anchor-less non-pi hook record holds nothing there,
+/// so the sweep can still clean it up — but detach can lose bytes, so here any
+/// present file of such a record's holds.
 /// (An MCP server is a config entry with no standalone file — its edits are not
 /// detected here, the one gap that remains.)
 fn install_edited(env: &Env, scope: &Scope, entry: &crate::lock::LockEntry) -> bool {

--- a/crates/core/src/engine/item_plan.rs
+++ b/crates/core/src/engine/item_plan.rs
@@ -224,9 +224,10 @@ fn plan_registration(
     let retire = match super::item_record::retire_previous(item, existing) {
         super::item_record::Previous::Settled => None,
         super::item_record::Previous::Retire(path, edit) => Some((path, edit)),
-        // Nothing is written beside entries kendex cannot tell its own
-        // from: this one registration holds, and says which document to
-        // look at.
+        // Only a pi hook answers this way — elsewhere an unsettled
+        // document settles. Nothing is written beside entries pi's pass
+        // cannot tell its own from: this one registration holds, and
+        // says which document to look at.
         super::item_record::Previous::Ambiguous(why) => return Ok(Planned::Conflict(why)),
     };
     let edits: Vec<(PathBuf, ConfigEdit)> =

--- a/crates/core/src/engine/item_record.rs
+++ b/crates/core/src/engine/item_record.rs
@@ -33,6 +33,13 @@ use super::desired::{Artifact, Desired};
 /// entry is looked up by, and one carried more than once is one nothing
 /// here can tell apart.
 ///
+/// An answer short of certainty retires nothing, and outside pi it holds
+/// nothing either: the pass registers under the identity it renders and
+/// leaves the person's entries to them, because all a refresh writes is
+/// its own registration. Pi's reserved-name move is the one consumer
+/// that deletes what it identifies, so for pi an entry the document
+/// cannot settle holds the installation instead.
+///
 /// Nothing is retired where the record names what this pass names anyway,
 /// so a settled installation plans nothing. The edit goes to the file
 /// this pass registers in; one written into a file kendex no longer
@@ -62,6 +69,7 @@ pub(super) fn retire_previous(item: &Desired, existing: Option<&LockEntry>) -> P
     let Some(entry) = existing else {
         return Previous::Settled;
     };
+    let migration = item.harness == crate::model::HarnessId::Pi;
     let previous = match &entry.registration {
         // The record names an entry. Whether it is still there is the
         // document's to say, not the record's: trusting the record here
@@ -73,14 +81,24 @@ pub(super) fn retire_previous(item: &Desired, existing: Option<&LockEntry>) -> P
             recorded.matcher.as_deref(),
             &recorded.command,
         ),
-        // A record too old to name what it registered, over an
-        // installation kendex did make: the command is what there is to
-        // look one up by, and the document says the rest.
+        // A record too old to name what it registered has only the
+        // command to look one up by — a search that reads the person's
+        // own registration of the same command as kendex's leftovers.
+        // Only pi's move, which deletes what it finds, needs it; every
+        // other harness settles and earns the record this pass.
+        None if !migration => return Previous::Settled,
         None => found(&named, None, None, named.command),
     };
     let previous = match previous {
         Found::One(entry) => entry,
         Found::None => return Previous::Settled,
+        // An entry the document cannot settle as kendex's is the
+        // person's to keep. All this pass writes is its own
+        // registration, so it registers under the identity it renders
+        // and leaves theirs where they put it — held instead, the hook
+        // sat in conflict on every refresh with nothing to settle it.
+        // Pi holds: its move deletes bytes, and must not guess whose.
+        Found::Several(_) | Found::Moved(_) if !migration => return Previous::Settled,
         Found::Several(why) | Found::Moved(why) => return Previous::Ambiguous(why),
     };
     if previous.event == named.event

--- a/crates/core/src/engine/plan_pass.rs
+++ b/crates/core/src/engine/plan_pass.rs
@@ -119,10 +119,11 @@ pub(super) fn plan_refusals(
         let mut removals = Vec::new();
         if let Some(entry) = lock.entries.get(&key) {
             // A refused rendering takes its previous installation off disk
-            // — unless the user's edits are in it. Edited bytes are never
-            // an automatic casualty of an upstream change (that is the
-            // exact promise of edit protection), so they hold and the
-            // conflict says why.
+            // — unless the user's edits are in it. Wherever the record can
+            // carry that promise (`edit_holds` names the anchor-less
+            // non-pi hook it cannot vouch for), edited bytes are not an
+            // automatic casualty of an upstream change, so they hold and
+            // the conflict says why.
             // The reserved-name move's hold counts here too: what it is
             // holding is still what runs, and its record is the only
             // thing a later pass can claim it with.

--- a/crates/core/src/engine/removal.rs
+++ b/crates/core/src/engine/removal.rs
@@ -19,10 +19,18 @@ use crate::model::{ItemKind, Scope};
 /// prove anything, so any content present holds. Explicitly asked-for
 /// removals are not gated here: the trash keeps what they take.
 pub fn edit_holds(env: &Env, scope: &Scope, entry: &LockEntry) -> bool {
-    if !matches!(
-        entry.kind,
-        ItemKind::Skill | ItemKind::Agent | ItemKind::Command | ItemKind::Hook
-    ) {
+    // A hook holds only for pi: its reserved-name move derives a new path
+    // the record never wrote, so a file already sitting there has to be
+    // proven before anything of this entry's is taken. Other harnesses'
+    // hook records can carry no anchor at all, and reading "no anchor" as
+    // "hands off" would quietly exempt every older hook install from
+    // every sweep.
+    let anchored = match entry.kind {
+        ItemKind::Skill | ItemKind::Agent | ItemKind::Command => true,
+        ItemKind::Hook => entry.harness == crate::model::HarnessId::Pi,
+        _ => false,
+    };
+    if !anchored {
         return false;
     }
     let Owned { files, .. } = installed(env, scope, entry);

--- a/crates/core/src/engine/removal.rs
+++ b/crates/core/src/engine/removal.rs
@@ -310,8 +310,10 @@ pub(super) fn orphans(
             continue;
         }
         // An automatic removal (a sweep, an unfiltered orphan cleanup)
-        // never takes edited or unprovable bytes; only naming the item —
-        // or asking for edits to be discarded — does.
+        // never takes bytes a record could vouch for and does not —
+        // `edit_holds`' doc draws that line, and names the anchor-less
+        // non-pi hook whose record vouches for nothing; only naming the
+        // item, or asking for edits to be discarded, takes what it holds.
         if !named && !options.overwrite_edited && edit_holds(env, scope, entry) {
             drift.push(DriftRow {
                 kind: entry.kind,

--- a/crates/core/src/engine/removal.rs
+++ b/crates/core/src/engine/removal.rs
@@ -16,21 +16,26 @@ use crate::model::{ItemKind, Scope};
 /// Automatic removals — refusals, sweeps, orphan cleanup nobody named —
 /// only take content they can prove is ours: every content path must hash
 /// to what apply last wrote. A record from before that hash existed cannot
-/// prove anything, so any content present holds. Explicitly asked-for
+/// prove anything, so any content present holds — except a hook's outside
+/// pi, where anchor-less records are the common stock and holding them
+/// would exempt those hooks from cleanup for good. Explicitly asked-for
 /// removals are not gated here: the trash keeps what they take.
 pub fn edit_holds(env: &Env, scope: &Scope, entry: &LockEntry) -> bool {
-    // A hook holds only for pi: its reserved-name move derives a new path
-    // the record never wrote, so a file already sitting there has to be
-    // proven before anything of this entry's is taken. Other harnesses'
-    // hook records can carry no anchor at all, and reading "no anchor" as
+    // A hook's anchor still proves its bytes wherever the record kept
+    // one. What an anchor-less record licenses splits by harness: pi's
+    // reserved-name move derives a new path the record never wrote, so a
+    // file already sitting there has to be proven before anything of
+    // this entry's is taken; everywhere else reading "no anchor" as
     // "hands off" would quietly exempt every older hook install from
     // every sweep.
-    let anchored = match entry.kind {
+    let holdable = match entry.kind {
         ItemKind::Skill | ItemKind::Agent | ItemKind::Command => true,
-        ItemKind::Hook => entry.harness == crate::model::HarnessId::Pi,
+        ItemKind::Hook => {
+            entry.harness == crate::model::HarnessId::Pi || entry.rendered_hash.is_some()
+        }
         _ => false,
     };
-    if !anchored {
+    if !holdable {
         return false;
     }
     let Owned { files, .. } = installed(env, scope, entry);

--- a/crates/core/src/package/updates.rs
+++ b/crates/core/src/package/updates.rs
@@ -201,8 +201,9 @@ fn edited_items(
         // A plan the scope cannot produce (a broken manifest, an
         // unreadable source) must not fail open — reporting nothing edited
         // is exactly when edit detection could not run. Fall back to the
-        // conservative per-entry hold, which holds whatever it cannot prove
-        // is clean.
+        // conservative per-entry hold, which holds whatever a record could
+        // prove clean and cannot — `edit_holds` names the anchor-less
+        // non-pi hook record that can prove nothing and holds nothing.
         Err(_) => lock
             .entries
             .values()

--- a/crates/core/tests/hook_records.rs
+++ b/crates/core/tests/hook_records.rs
@@ -1,10 +1,11 @@
 //! What a record that cannot name the old entry is worth.
 //!
 //! A lock written before kendex kept a registration, or before it kept a
-//! matcher, says less than a later one. Read as "there was nothing", the
-//! entry that is really there stays behind and a second one goes in
-//! beside it; read honestly, the document is asked instead, and what it
-//! says is what comes out.
+//! matcher, says less than a later one — and retires no more than it can
+//! name. Only an entry the record identifies unambiguously comes out;
+//! anything less settles, registers under its own identity, and leaves
+//! the person's entries to them. A refresh never wedges on what the
+//! document holds.
 #![cfg(unix)]
 
 use std::fs;
@@ -24,7 +25,6 @@ struct Fixture {
     env: Env,
     scope: Scope,
     project: PathBuf,
-    catalog: PathBuf,
 }
 
 #[allow(clippy::unwrap_used)]
@@ -54,7 +54,6 @@ fn fixture(declarations: &str) -> Fixture {
             root: project.clone(),
         },
         project,
-        catalog,
         _tmp: tmp,
     }
 }
@@ -108,35 +107,54 @@ fn as_written_by(f: &Fixture, key: &str, keep: &[&str]) {
     fs::write(&path, serde_json::to_string_pretty(&lock).unwrap()).unwrap();
 }
 
-/// A lock from before kendex recorded what it registered, upgraded in the
-/// same refresh that moves the hook. Read as "nothing was registered",
-/// the entry that is really there stays and the new one goes in beside
-/// it: the hook fires twice, and no later pass can find the old one,
-/// because the record it writes describes only the new.
+/// A record that names no registration leaves the document alone. The
+/// command is all such a record could look an entry up by, and the
+/// person's own registration of the same command answers that search
+/// too: read as kendex's leftovers, their entry put the hook in conflict
+/// on every refresh, with nothing to settle it. Only pi's reserved-name
+/// move searches by command, because only it deletes what it finds.
 #[test]
 #[allow(clippy::unwrap_used)]
-fn a_record_that_names_no_registration_still_retires_the_entry_it_left() {
+fn a_record_that_names_no_registration_leaves_their_duplicate_alone() {
     let f = fixture("[hooks.guard]\nsource = \"cat\"\n");
     apply_now(&f);
     assert_eq!(groups(&f), vec![("Bash".to_owned(), 1)]);
     as_written_by(&f, "hook:guard:claude", &[]);
 
+    // Theirs, running the same command under an event of their own.
+    let mut value = settings(&f);
+    let command = value["hooks"]["PreToolUse"][0]["hooks"][0]["command"].clone();
+    value["hooks"]["Stop"] = serde_json::json!([{
+        "matcher": "Edit",
+        "hooks": [{ "type": "command", "command": command }]
+    }]);
     fs::write(
-        f.catalog.join("hooks/guard.sh"),
-        GUARD.replace("# event: PreToolUse", "# event: Stop"),
+        f.project.join(".claude/settings.json"),
+        serde_json::to_string_pretty(&value).unwrap(),
     )
     .unwrap();
-    apply_now(&f);
 
+    let report = audit(&f.env, &f.scope).unwrap();
     assert!(
-        groups(&f).is_empty(),
-        "what it left under the old event comes out: {}",
+        report
+            .drift
+            .iter()
+            .all(|row| !row.detail.contains("more than once")),
+        "their duplicate is not kendex's to wonder about: {:?}",
+        report.drift
+    );
+    apply::execute(&f.env, &report.plan, None).unwrap();
+
+    assert_eq!(
+        groups(&f),
+        vec![("Bash".to_owned(), 1)],
+        "kendex's entry stands where it was: {}",
         settings(&f)
     );
     assert_eq!(
         settings(&f)["hooks"]["Stop"].as_array().unwrap().len(),
         1,
-        "and one entry stands where the catalog now asks"
+        "and theirs where they put it"
     );
     let settled = audit(&f.env, &f.scope).unwrap();
     assert!(settled.plan.ops.is_empty(), "{:?}", settled.plan.ops);
@@ -229,12 +247,14 @@ fn a_first_install_takes_nothing_that_was_already_there() {
 }
 
 /// The other side of the same question: a record that names an entry is
-/// not proof the entry is still there. Moved by hand with its command
-/// unchanged, the record still matches what this pass means to render, so
-/// nothing is retired and the upsert puts a second one in beside theirs.
+/// not proof the entry is still there. Moved by hand, the entry is the
+/// person's own registration of their own command — the refresh registers
+/// under the identity it renders and leaves the moved one to them. Held
+/// instead, the hook sat in conflict on every refresh, and nothing the
+/// refresh could do would ever settle it.
 #[test]
 #[allow(clippy::unwrap_used)]
-fn a_recorded_entry_moved_by_hand_is_never_doubled() {
+fn a_recorded_entry_moved_by_hand_does_not_hold_the_hook() {
     let f = fixture(MINE);
     apply_now(&f);
     assert_eq!(groups(&f), vec![("Bash".to_owned(), 1)]);
@@ -242,23 +262,34 @@ fn a_recorded_entry_moved_by_hand_is_never_doubled() {
     let mut value = settings(&f);
     let group = value["hooks"]["PreToolUse"][0].clone();
     value["hooks"] = serde_json::json!({ "Stop": [group] });
-    let theirs = serde_json::to_string_pretty(&value).unwrap();
-    fs::write(f.project.join(".claude/settings.json"), &theirs).unwrap();
+    fs::write(
+        f.project.join(".claude/settings.json"),
+        serde_json::to_string_pretty(&value).unwrap(),
+    )
+    .unwrap();
 
     let report = audit(&f.env, &f.scope).unwrap();
     assert!(
         report
             .drift
             .iter()
-            .any(|row| row.name == "mine" && row.detail.contains("no longer runs")),
-        "the person is told what is in the way: {:?}",
+            .all(|row| !row.detail.contains("no longer runs")),
+        "what they moved is theirs, not a conflict: {:?}",
         report.drift
     );
     apply::execute(&f.env, &report.plan, None).unwrap();
 
     assert_eq!(
-        fs::read_to_string(f.project.join(".claude/settings.json")).unwrap(),
-        theirs,
-        "and nothing is registered beside what they moved"
+        groups(&f),
+        vec![("Bash".to_owned(), 1)],
+        "kendex's entry is back where the record names it: {}",
+        settings(&f)
     );
+    assert_eq!(
+        settings(&f)["hooks"]["Stop"].as_array().unwrap().len(),
+        1,
+        "and the one they moved stays where they put it"
+    );
+    let settled = audit(&f.env, &f.scope).unwrap();
+    assert!(settled.plan.ops.is_empty(), "{:?}", settled.plan.ops);
 }

--- a/crates/core/tests/hook_records.rs
+++ b/crates/core/tests/hook_records.rs
@@ -4,8 +4,8 @@
 //! matcher, says less than a later one — and retires no more than it can
 //! name. Only an entry the record identifies unambiguously comes out;
 //! anything less settles, registers under its own identity, and leaves
-//! the person's entries to them. A refresh never wedges on what the
-//! document holds.
+//! the person's entries to them. Outside pi, a refresh never wedges on
+//! what the document holds.
 #![cfg(unix)]
 
 use std::fs;
@@ -244,6 +244,93 @@ fn a_first_install_takes_nothing_that_was_already_there() {
         vec![("Bash".to_owned(), 1)],
         "and kendex's goes in beside it: {value}"
     );
+}
+
+/// The same record, and the one entry it could have matched by command
+/// has been moved to another event. A search by command alone would call
+/// the moved entry kendex's and take it; a record that names no
+/// registration takes nothing — the refresh registers under the identity
+/// it renders, the moved entry stays where the person put it, and the
+/// record written this pass settles every refresh after.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_record_that_names_no_registration_leaves_a_moved_entry_alone() {
+    let f = fixture("[hooks.guard]\nsource = \"cat\"\n");
+    apply_now(&f);
+    assert_eq!(groups(&f), vec![("Bash".to_owned(), 1)]);
+    as_written_by(&f, "hook:guard:claude", &[]);
+
+    let mut value = settings(&f);
+    let group = value["hooks"]["PreToolUse"][0].clone();
+    value["hooks"] = serde_json::json!({ "Stop": [group] });
+    fs::write(
+        f.project.join(".claude/settings.json"),
+        serde_json::to_string_pretty(&value).unwrap(),
+    )
+    .unwrap();
+
+    let report = audit(&f.env, &f.scope).unwrap();
+    assert!(
+        report
+            .drift
+            .iter()
+            .all(|row| !row.detail.contains("no longer runs")),
+        "the moved entry is not kendex's to wonder about: {:?}",
+        report.drift
+    );
+    apply::execute(&f.env, &report.plan, None).unwrap();
+
+    assert_eq!(
+        groups(&f),
+        vec![("Bash".to_owned(), 1)],
+        "kendex registers under the identity it renders: {}",
+        settings(&f)
+    );
+    assert_eq!(
+        settings(&f)["hooks"]["Stop"].as_array().unwrap().len(),
+        1,
+        "and the moved entry stays where they put it"
+    );
+    let settled = audit(&f.env, &f.scope).unwrap();
+    assert!(settled.plan.ops.is_empty(), "{:?}", settled.plan.ops);
+}
+
+/// A record that names its registration exactly, duplicated in place: two
+/// entries answer to every field the record kept, and neither can be told
+/// from the other. Retiring by guess would take both, and wedging is a
+/// conflict the person cannot see past — so the refresh settles, and the
+/// duplicate is theirs to keep or to clean up.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn an_exact_duplicate_of_the_recorded_entry_does_not_wedge_the_refresh() {
+    let f = fixture(MINE);
+    apply_now(&f);
+    assert_eq!(groups(&f), vec![("Bash".to_owned(), 1)]);
+
+    let mut value = settings(&f);
+    let handler = value["hooks"]["PreToolUse"][0]["hooks"][0].clone();
+    value["hooks"]["PreToolUse"][0]["hooks"]
+        .as_array_mut()
+        .unwrap()
+        .push(handler);
+    fs::write(
+        f.project.join(".claude/settings.json"),
+        serde_json::to_string_pretty(&value).unwrap(),
+    )
+    .unwrap();
+
+    let report = audit(&f.env, &f.scope).unwrap();
+    assert!(
+        report
+            .drift
+            .iter()
+            .all(|row| !row.detail.contains("more than once")),
+        "an exact duplicate is not a wedge: {:?}",
+        report.drift
+    );
+    apply::execute(&f.env, &report.plan, None).unwrap();
+    let settled = audit(&f.env, &f.scope).unwrap();
+    assert!(settled.plan.ops.is_empty(), "{:?}", settled.plan.ops);
 }
 
 /// The other side of the same question: a record that names an entry is

--- a/crates/core/tests/hook_records.rs
+++ b/crates/core/tests/hook_records.rs
@@ -298,8 +298,9 @@ fn a_record_that_names_no_registration_leaves_a_moved_entry_alone() {
 /// A record that names its registration exactly, duplicated in place: two
 /// entries answer to every field the record kept, and neither can be told
 /// from the other. Retiring by guess would take both, and wedging is a
-/// conflict the person cannot see past — so the refresh settles, and the
-/// duplicate is theirs to keep or to clean up.
+/// conflict the person cannot see past — so the refresh settles without
+/// one, and the byte-identical handler converges back to a single entry
+/// through the idempotent upsert.
 #[test]
 #[allow(clippy::unwrap_used)]
 fn an_exact_duplicate_of_the_recorded_entry_does_not_wedge_the_refresh() {
@@ -329,6 +330,14 @@ fn an_exact_duplicate_of_the_recorded_entry_does_not_wedge_the_refresh() {
         report.drift
     );
     apply::execute(&f.env, &report.plan, None).unwrap();
+    assert_eq!(
+        settings(&f)["hooks"]["PreToolUse"][0]["hooks"]
+            .as_array()
+            .unwrap()
+            .len(),
+        1,
+        "the byte-identical handler converges to one entry"
+    );
     let settled = audit(&f.env, &f.scope).unwrap();
     assert!(settled.plan.ops.is_empty(), "{:?}", settled.plan.ops);
 }

--- a/crates/core/tests/hook_removal.rs
+++ b/crates/core/tests/hook_removal.rs
@@ -117,68 +117,6 @@ fn a_moved_registration_comes_out_with_the_script_it_names() {
     }
 }
 
-/// A record from before hooks carried an anchor names no rendered hash
-/// and no registration. The sweep still takes what that record installed:
-/// only pi's reserved-name move derives paths its record never wrote and
-/// so must prove every byte first, and reading "no anchor" as "hands off"
-/// would quietly exempt every older hook install from cleanup for good.
-#[test]
-#[allow(clippy::unwrap_used)]
-fn the_sweep_takes_a_hook_whose_record_has_no_anchor() {
-    let f = fixture();
-    apply_now(&f);
-    let script = f.project.join(".claude/hooks/guard.sh");
-    assert!(script.is_file());
-
-    // The lock as an older kendex left it: the entry, minus the fields
-    // later versions anchor ownership with.
-    let lock_path = f.project.join(".kendex-lock.json");
-    let mut lock: serde_json::Value =
-        serde_json::from_str(&fs::read_to_string(&lock_path).unwrap()).unwrap();
-    let entry = lock["entries"]["hook:guard:claude"]
-        .as_object_mut()
-        .unwrap();
-    entry.remove("renderedHash");
-    entry.remove("registration");
-    fs::write(&lock_path, serde_json::to_string_pretty(&lock).unwrap()).unwrap();
-
-    // Nothing declares it any more.
-    let manifest = f.project.join("kendex.toml");
-    let text = fs::read_to_string(&manifest).unwrap();
-    let kept: String = text
-        .split_inclusive("\n\n")
-        .filter(|block| !block.starts_with("[hooks."))
-        .collect();
-    fs::write(&manifest, kept).unwrap();
-
-    let report = plan_apply(
-        &f.env,
-        &f.scope,
-        &PlanOptions {
-            remove_orphans: true,
-            sweep_unneeded: true,
-            ..PlanOptions::default()
-        },
-    )
-    .unwrap();
-    assert!(
-        report
-            .drift
-            .iter()
-            .all(|row| !row.detail.contains("edited")),
-        "an anchor-less record is not an edit: {:?}",
-        report.drift
-    );
-    apply::execute(&f.env, &report.plan, None).unwrap();
-
-    assert!(!script.exists(), "the sweep takes the script");
-    let after = fs::read_to_string(f.project.join(".claude/settings.json")).unwrap();
-    assert!(
-        !after.contains("guard.sh"),
-        "and nothing is left registered to run it: {after}"
-    );
-}
-
 /// Switching a hook off is a removal of the entry that is there — which
 /// is not always the entry this pass would write. Change the event in the
 /// same refresh that switches it off and the two part company: the

--- a/crates/core/tests/hook_removal.rs
+++ b/crates/core/tests/hook_removal.rs
@@ -117,6 +117,68 @@ fn a_moved_registration_comes_out_with_the_script_it_names() {
     }
 }
 
+/// A record from before hooks carried an anchor names no rendered hash
+/// and no registration. The sweep still takes what that record installed:
+/// only pi's reserved-name move derives paths its record never wrote and
+/// so must prove every byte first, and reading "no anchor" as "hands off"
+/// would quietly exempt every older hook install from cleanup for good.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn the_sweep_takes_a_hook_whose_record_has_no_anchor() {
+    let f = fixture();
+    apply_now(&f);
+    let script = f.project.join(".claude/hooks/guard.sh");
+    assert!(script.is_file());
+
+    // The lock as an older kendex left it: the entry, minus the fields
+    // later versions anchor ownership with.
+    let lock_path = f.project.join(".kendex-lock.json");
+    let mut lock: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&lock_path).unwrap()).unwrap();
+    let entry = lock["entries"]["hook:guard:claude"]
+        .as_object_mut()
+        .unwrap();
+    entry.remove("renderedHash");
+    entry.remove("registration");
+    fs::write(&lock_path, serde_json::to_string_pretty(&lock).unwrap()).unwrap();
+
+    // Nothing declares it any more.
+    let manifest = f.project.join("kendex.toml");
+    let text = fs::read_to_string(&manifest).unwrap();
+    let kept: String = text
+        .split_inclusive("\n\n")
+        .filter(|block| !block.starts_with("[hooks."))
+        .collect();
+    fs::write(&manifest, kept).unwrap();
+
+    let report = plan_apply(
+        &f.env,
+        &f.scope,
+        &PlanOptions {
+            remove_orphans: true,
+            sweep_unneeded: true,
+            ..PlanOptions::default()
+        },
+    )
+    .unwrap();
+    assert!(
+        report
+            .drift
+            .iter()
+            .all(|row| !row.detail.contains("edited")),
+        "an anchor-less record is not an edit: {:?}",
+        report.drift
+    );
+    apply::execute(&f.env, &report.plan, None).unwrap();
+
+    assert!(!script.exists(), "the sweep takes the script");
+    let after = fs::read_to_string(f.project.join(".claude/settings.json")).unwrap();
+    assert!(
+        !after.contains("guard.sh"),
+        "and nothing is left registered to run it: {after}"
+    );
+}
+
 /// Switching a hook off is a removal of the entry that is there — which
 /// is not always the entry this pass would write. Change the event in the
 /// same refresh that switches it off and the two part company: the

--- a/crates/core/tests/hook_sweep.rs
+++ b/crates/core/tests/hook_sweep.rs
@@ -1,0 +1,177 @@
+//! What the orphan sweep may take of a hook's installation. An anchored
+//! record proves its bytes and holds an edit; a record from before the
+//! anchor proves nothing and, outside pi, holds nothing — reading "no
+//! anchor" as "hands off" would exempt every older install from cleanup
+//! for good.
+#![cfg(unix)]
+
+use std::fs;
+use std::path::PathBuf;
+
+use kendex_core::apply;
+use kendex_core::engine::{PlanOptions, audit, plan_apply};
+use kendex_core::env::{Env, FakeOs};
+use kendex_core::model::Scope;
+
+const GUARD: &str = "#!/usr/bin/env bash\n# ---\n# name: guard\n# event: PreToolUse\n# matcher: Bash\n# description: check shell commands\n# ---\nexit 0\n";
+
+struct Fixture {
+    _tmp: tempfile::TempDir,
+    env: Env,
+    scope: Scope,
+    project: PathBuf,
+}
+
+#[allow(clippy::unwrap_used)]
+fn fixture() -> Fixture {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().to_path_buf();
+    let env = Env::fake(&home, FakeOs::Linux);
+    let project = home.join("dev/app");
+    fs::create_dir_all(project.join(".claude")).unwrap();
+
+    let source = home.join("catalog");
+    fs::create_dir_all(source.join("hooks")).unwrap();
+    fs::write(source.join("hooks/guard.sh"), GUARD).unwrap();
+    fs::write(source.join("kendex.toml"), "is_source_catalog = true\n").unwrap();
+    fs::write(
+        project.join("kendex.toml"),
+        format!(
+            "schema = 5\n\n[sources.cat]\npath = \"{}\"\n\n[install]\nharnesses = [\"claude\"]\nmethod = \"copy\"\n\n[hooks.guard]\nsource = \"cat\"\n",
+            source.display()
+        ),
+    )
+    .unwrap();
+
+    Fixture {
+        env,
+        scope: Scope::Project {
+            root: project.clone(),
+        },
+        project,
+        _tmp: tmp,
+    }
+}
+
+#[allow(clippy::unwrap_used)]
+fn apply_now(f: &Fixture) {
+    let report = audit(&f.env, &f.scope).unwrap();
+    apply::execute(&f.env, &report.plan, None).unwrap();
+}
+
+/// Take the hook's declaration out of the manifest: nothing asks for it
+/// any more, and its record is all that is left of it.
+#[allow(clippy::unwrap_used)]
+fn undeclare(f: &Fixture) {
+    let manifest = f.project.join("kendex.toml");
+    let text = fs::read_to_string(&manifest).unwrap();
+    let kept: String = text
+        .split_inclusive("\n\n")
+        .filter(|block| !block.starts_with("[hooks."))
+        .collect();
+    fs::write(&manifest, kept).unwrap();
+}
+
+#[allow(clippy::unwrap_used)]
+fn sweep(f: &Fixture) -> kendex_core::engine::EngineReport {
+    plan_apply(
+        &f.env,
+        &f.scope,
+        &PlanOptions {
+            remove_orphans: true,
+            sweep_unneeded: true,
+            ..PlanOptions::default()
+        },
+    )
+    .unwrap()
+}
+
+/// An anchored record still proves its bytes before the sweep takes
+/// them: an edited script is the person's work and holds as a conflict,
+/// exactly as an edited skill or agent would, while an untouched one
+/// goes. The anchor-less exemption below is for records that cannot
+/// prove anything, never a license to take what a record disproves.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn the_sweep_proves_an_anchored_hook_before_taking_it() {
+    for state in ["edited", "untouched"] {
+        let f = fixture();
+        apply_now(&f);
+        let script = f.project.join(".claude/hooks/guard.sh");
+        assert!(script.is_file());
+        if state == "edited" {
+            fs::write(&script, GUARD.replace("exit 0", "exit 1")).unwrap();
+        }
+
+        undeclare(&f);
+        let report = sweep(&f);
+        apply::execute(&f.env, &report.plan, None).unwrap();
+
+        match state {
+            "edited" => {
+                assert!(
+                    report.drift.iter().any(|row| row.detail.contains("edited")),
+                    "their edit is a conflict, not a casualty: {:?}",
+                    report.drift
+                );
+                assert!(script.is_file(), "and the edited script stays");
+            }
+            _ => {
+                assert!(
+                    report
+                        .drift
+                        .iter()
+                        .all(|row| !row.detail.contains("edited")),
+                    "untouched bytes are provably ours: {:?}",
+                    report.drift
+                );
+                assert!(!script.exists(), "so the sweep takes them");
+            }
+        }
+    }
+}
+
+/// A record from before hooks carried an anchor names no rendered hash
+/// and no registration. The sweep still takes what that record installed:
+/// only pi's reserved-name move derives paths its record never wrote and
+/// so must prove every byte first, and reading "no anchor" as "hands off"
+/// would quietly exempt every older hook install from cleanup for good.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn the_sweep_takes_a_hook_whose_record_has_no_anchor() {
+    let f = fixture();
+    apply_now(&f);
+    let script = f.project.join(".claude/hooks/guard.sh");
+    assert!(script.is_file());
+
+    // The lock as an older kendex left it: the entry, minus the fields
+    // later versions anchor ownership with.
+    let lock_path = f.project.join(".kendex-lock.json");
+    let mut lock: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&lock_path).unwrap()).unwrap();
+    let entry = lock["entries"]["hook:guard:claude"]
+        .as_object_mut()
+        .unwrap();
+    entry.remove("renderedHash");
+    entry.remove("registration");
+    fs::write(&lock_path, serde_json::to_string_pretty(&lock).unwrap()).unwrap();
+
+    undeclare(&f);
+    let report = sweep(&f);
+    assert!(
+        report
+            .drift
+            .iter()
+            .all(|row| !row.detail.contains("edited")),
+        "an anchor-less record is not an edit: {:?}",
+        report.drift
+    );
+    apply::execute(&f.env, &report.plan, None).unwrap();
+
+    assert!(!script.exists(), "the sweep takes the script");
+    let after = fs::read_to_string(f.project.join(".claude/settings.json")).unwrap();
+    assert!(
+        !after.contains("guard.sh"),
+        "and nothing is left registered to run it: {after}"
+    );
+}

--- a/crates/core/tests/pi_hooks_move/moved_by_hand.rs
+++ b/crates/core/tests/pi_hooks_move/moved_by_hand.rs
@@ -342,3 +342,42 @@ fn an_entry_from_before_the_record_still_holds_over_a_moved_registration() {
         "so what they moved is left where they moved it"
     );
 }
+
+/// The same record, and a copy of kendex's command somebody added under
+/// another listener while kendex's own entry stays put. The record kept
+/// no registration, so nothing can say which of the two is kendex's —
+/// and pi's pass deletes what it identifies, so the installation holds
+/// with the line naming the document, where every other harness settles
+/// and leaves the duplicate to the person.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn an_entry_from_before_the_record_holds_over_a_duplicated_command() {
+    let w = world();
+    apply(&w);
+    let path = w.project.join(".kendex-lock.json");
+    let mut lock: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+    lock["entries"]["hook:guard:pi"]
+        .as_object_mut()
+        .unwrap()
+        .remove("registration");
+    fs::write(&path, serde_json::to_string_pretty(&lock).unwrap()).unwrap();
+
+    let registry = w.dot().join("kendex/hooks.json");
+    let mut value: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&registry).unwrap()).unwrap();
+    let group = value["hooks"]["tool_call"][0].clone();
+    value["hooks"]["turn_end"] = serde_json::json!([group]);
+    fs::write(&registry, serde_json::to_string_pretty(&value).unwrap()).unwrap();
+
+    let report = audit(&w.env, &w.scope()).unwrap();
+    assert!(
+        report.drift.iter().any(|row| {
+            row.name == "guard"
+                && row.state == DriftState::Conflict
+                && row.detail.contains("more than once")
+        }),
+        "two entries the record cannot tell apart hold the installation: {:?}",
+        report.drift
+    );
+}

--- a/crates/core/tests/pi_hooks_move/retirement.rs
+++ b/crates/core/tests/pi_hooks_move/retirement.rs
@@ -344,3 +344,44 @@ fn a_hold_no_discard_can_release_reads_the_same_when_nothing_asks_for_it() {
     );
     assert!(row.cause.is_none(), "nor a cause for one: {:?}", row.cause);
 }
+
+/// The sweep's edit gate with the reserved name long gone: a pi record
+/// that predates the anchor can prove nothing about the file at the new
+/// path, because pi's paths are derived, never recorded — so an
+/// automatic sweep must not take it, and the record survives to claim
+/// it when the person says what they meant.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn an_anchorless_record_holds_the_sweep_at_the_new_path() {
+    let w = super::world();
+    apply(&w);
+    assert!(
+        !w.dot().join("hooks").exists() && !w.dot().join("hooks.json").exists(),
+        "nothing of the old layout is in play"
+    );
+    forget_rendered_hash(&w);
+    undeclare(&w);
+
+    let report = plan_apply(&w.env, &w.scope(), &reconcile()).unwrap();
+    kendex_core::apply::execute(&w.env, &report.plan, None).unwrap();
+
+    assert!(
+        report
+            .drift
+            .iter()
+            .any(|row| row.name == "guard" && row.state == DriftState::Conflict),
+        "what the record cannot prove is a conflict, not a removal: {:?}",
+        report.drift
+    );
+    assert!(
+        w.dot().join("kendex/hooks/guard.sh").exists(),
+        "the copy stays"
+    );
+    let lock: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(w.project.join(".kendex-lock.json")).unwrap())
+            .unwrap();
+    assert!(
+        lock["entries"].get("hook:guard:pi").is_some(),
+        "and the record that can claim it later stays with it: {lock}"
+    );
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -415,15 +415,15 @@ lives in one capability table read by core and UI.
 - **A registration is reconciled, not added to.** What a hook registered
   is recorded (`engine::item_record`); a catalog moving it to another
   event retires the recorded entry where the document still has it,
-  applies what is rendered, records that. A first install retires
-  nothing, and neither does an answer short of certainty: an entry moved,
+  applies what is rendered, records that. A first install retires nothing,
+  and neither does an answer short of certainty: an entry moved,
   duplicated, or unnamed by the record is the person's to keep, and the
-  pass registers under the identity it renders beside it. Only pi's move,
-  which deletes what it identifies, holds the installation over ambiguity
-  (`engine::pi_hooks_move`). Removal reads the same record; an editor
-  rewrites only what its own registration names; an entry no edit of
-  kendex's can reach is neither reconciled nor retired — proven by
-  applying and reading back.
+  pass registers under the identity it renders beside it. Only a pi hook's
+  ambiguity holds (`engine::item_record::retire_previous`), because pi's
+  move deletes what it identifies (`engine::pi_hooks_move`). Removal reads
+  the same record; an editor rewrites only what its own registration
+  names; an entry no edit of kendex's can reach is neither reconciled nor
+  retired — proven by applying and reading back.
 - **Pi hooks are enforced through the carrier.** The `pi-hooks` extension
   package hosts native listeners; hook content rides in the registry
   kendex renders beside them (`kendex/hooks/<name>.sh` plus

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -415,10 +415,15 @@ lives in one capability table read by core and UI.
 - **A registration is reconciled, not added to.** What a hook registered
   is recorded (`engine::item_record`); a catalog moving it to another
   event retires the recorded entry where the document still has it,
-  applies what is rendered, records that. A first install retires nothing.
-  Removal reads the same record; an editor rewrites only what its own
-  registration names; an entry no edit of kendex's can reach is neither
-  reconciled nor retired — proven by applying and reading back.
+  applies what is rendered, records that. A first install retires
+  nothing, and neither does an answer short of certainty: an entry moved,
+  duplicated, or unnamed by the record is the person's to keep, and the
+  pass registers under the identity it renders beside it. Only pi's move,
+  which deletes what it identifies, holds the installation over ambiguity
+  (`engine::pi_hooks_move`). Removal reads the same record; an editor
+  rewrites only what its own registration names; an entry no edit of
+  kendex's can reach is neither reconciled nor retired — proven by
+  applying and reading back.
 - **Pi hooks are enforced through the carrier.** The `pi-hooks` extension
   package hosts native listeners; hook content rides in the registry
   kendex renders beside them (`kendex/hooks/<name>.sh` plus

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -1,7 +1,7 @@
 .github/workflows/review-gate-writer.yml	652
 crates/app/gen/schemas/desktop-schema.json	2590
 crates/app/gen/schemas/linux-schema.json	2590
-docs/ARCHITECTURE.md	874
+docs/ARCHITECTURE.md	879
 hooks/block-repo-copy.sh	511
 hooks/pre-commit-check.sh	423
 pi-extensions/pi-agents-tmux/extensions/subagent/browser.ts	650


### PR DESCRIPTION
## Summary
- Restores pre-#1559 hook ownership/removal for Claude/Copilot/Codex: the orphan sweep removes anchor-less legacy hook records again, refresh no longer raises `Planned::Conflict` for user-duplicated or hand-moved hook entries, and a hand-moved registration settles instead of holding forever. Pi keeps every hold (its move deletes what it identifies).
- Edit protection stays for anchored hooks: `edit_holds` gates on the anchor (`Pi || rendered_hash.is_some()`), so an edited, anchored non-Pi hook script still holds as an "edited on disk" conflict rather than being swept.
- One regression test per reported bullet plus mutation-proofed guards: five targeted mutations of the new arms each fail exactly one test (independently re-verified), including the Pi presence-hold twin.

Noted, not filed (refactor beyond scope): the "pi's move owns this hook entry" predicate is spelled inline at five engine sites; a shared predicate would centralize it.

## Completed Issues
- Closes KEN-531 - Pi-hooks migration (#1559) changed hook removal and conflicts on every harness

## Test Plan
- `cargo test --workspace` green; touched suites: hook_records 7, hook_removal 4, hook_sweep 2 (new), pi_hooks_move 111
- Every new test proven red first against its mutation or the pre-fix behavior
- fmt, clippy -D warnings, doc, vitest, preflight, size-ratchet (874→879, RATCHET_RAISE justified in commit)
