### PR TITLE
feat(review-gate): a tracking claim must name its issue

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,34 @@
+# Code review calibration
+
+This repo's PRs are authored and shepherded by AI agents and re-reviewed on
+every push. Rounds are the scarce resource. Calibrate:
+
+## What to raise
+- Blocking: correctness bugs, security holes, data loss, fail-open paths in
+  gate/CI/guard code — in the changed lines or directly broken by them.
+- One comment per root cause. Name every affected site in that comment
+  instead of one comment per site.
+- Surface everything you have about the current diff in one round; a
+  finding held for the next round costs a full re-review cycle.
+
+## What not to raise
+- Style, wording, naming, and comment-phrasing preferences.
+- Speculative hardening on paths that already fail closed.
+- Test-coverage asks, unless the diff changes behavior that no test now
+  exercises — then say which behavior, in one comment.
+- Scope observations ("this also touches X") when X is listed in the PR
+  body as deliberate.
+- Anything outside the diff and its direct blast radius.
+- A finding class already answered on this PR with `Declined: <reason>` —
+  do not re-raise it unless the relevant code changed since.
+
+## Reply contract (context for reading threads)
+Authors answer findings with exactly one of: `Fixed in <sha>`,
+`Declined: <reason>`, or `Tracked: KEN-<n>`/`#<n>`. A tracking claim
+without an issue id fails this repo's merge gate, so absence of "tracked"
+wording in a decline is deliberate, not evasive.
+
+## Severity honesty
+Mark a finding blocking only if you would stop a human colleague's merge
+for it. Everything else is a suggestion — batch suggestions, and omit them
+entirely on re-review rounds whose diff is a one-line fix.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,17 @@
+# kendex
+
+kendex is a distribution of agent-stack assets: skills (`skills/`, Bash
+scripts plus markdown), agent definitions (`agents/`), hooks (`hooks/`),
+Pi extensions (`pi-extensions/`, TypeScript with committed bundles), a
+Rust engine and CLI (`crates/`), and a Tauri + React app (`crates/app`,
+`ui/`). Consumers vendor the skills and extensions and re-vendor in
+deliberate batches. Path-scoped review rules live in
+`.github/instructions/*.instructions.md`; fleet review economics and
+accepted residual classes in `review-bots.md` — follow both.
+
 # Code review calibration
 
-This repo's PRs are authored and shepherded by AI agents and re-reviewed on
+PRs here are authored and shepherded by AI agents and re-reviewed on
 every push. Rounds are the scarce resource. Calibrate:
 
 ## What to raise

--- a/.github/instructions/crates.instructions.md
+++ b/.github/instructions/crates.instructions.md
@@ -1,0 +1,12 @@
+---
+applyTo: "crates/**"
+---
+
+Rust workspace; repo convention runs `cargo test` and `cargo clippy`. Code
+that writes `kendex.toml` or `kendex.settings.toml` must never reformat
+content inside TOML string values — flag any line-oriented pass over TOML
+text that is not string-state-aware; this has corrupted user config before.
+Inline `#[cfg(test)]` modules deliberately use the OS tempdir
+(`std::env::temp_dir`) with cleanup — the repo's `<worktree>/tmp/` rule
+governs agent working artifacts, not test-runtime fixtures; do not flag
+OS-tempdir use inside test code.

--- a/.github/instructions/hooks.instructions.md
+++ b/.github/instructions/hooks.instructions.md
@@ -1,0 +1,7 @@
+---
+applyTo: "hooks/**"
+---
+
+Security containment here is deliberately fail-closed allowlisting (e.g. the
+connectors-mode PreToolUse hook). The allowlist design is intended — do not
+recommend switching to denylists or loosening the fail-closed posture.

--- a/.github/instructions/pi-extension-bundles.instructions.md
+++ b/.github/instructions/pi-extension-bundles.instructions.md
@@ -1,0 +1,8 @@
+---
+applyTo: "pi-extensions/*/bundle/**"
+---
+
+Files here are committed esbuild artifacts of the extension's `src/`.
+Findings in bundle output are legitimate, but frame each finding against the
+corresponding `src/` file and never propose patching the bundle itself —
+bundles are rebuilt from `src/`, not edited.

--- a/.github/instructions/skills-and-agents.instructions.md
+++ b/.github/instructions/skills-and-agents.instructions.md
@@ -1,0 +1,19 @@
+---
+applyTo: "skills/**,agents/**"
+---
+
+- Skill and agent markdown follows mechanism-over-prose: do not propose
+  defensive caveat paragraphs, history notes, or editorializing in
+  always-loaded content (`SKILL.md`, agent definitions) — propose a concrete
+  mechanism (validation, script, schema) or nothing.
+- Issue-number citations are banned in instruction-flow skill/agent markdown,
+  but `skills/*/schemas/*.md` reference docs carry issue provenance by
+  established convention — do not flag citations there.
+- Shell scripts and tests must stay Bash 3.2-compatible: flag `mapfile`,
+  `declare -A`, `${var,,}` and other Bash 4+ constructs as real defects —
+  unless the skill's own SKILL.md documents a newer-Bash dependency (e.g.
+  `skills/linear` requires Bash 4.0+; its lint tests reflect that). New
+  `tests/*.sh` and `scripts/*` files must carry the executable bit (CI lints
+  this) — sourced `scripts/lib/` libraries are the exception, and non-shell
+  tests (e.g. `.mjs`) need none; flag only those in-scope shapes added
+  without it.

--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -1,0 +1,13 @@
+---
+applyTo: "**/tests/**,**/*.test.sh,**/*.test.ts,**/fixtures/**"
+---
+
+- A fixture path the test built itself (`mktemp -d`, its own sandbox
+  directory) carries no `--`, and its absence is not a finding. The `--`
+  rule covers path values arriving from configuration, argv, or the
+  environment.
+- A `mktemp -d` scratch directory the test removes in its own `trap ... EXIT`
+  is cleaned up — do not report it as a leak or a missing-cleanup finding.
+- `${arr[@]+"${arr[@]}"}` is the quoted empty-array expansion Bash 3.2
+  requires under `set -u`, and is the repo-wide idiom — not an unquoted
+  expansion and not a word-splitting defect.

--- a/.kendex-local/skills/kendex-issues/SKILL.md
+++ b/.kendex-local/skills/kendex-issues/SKILL.md
@@ -80,10 +80,12 @@ orch owns every step. kendex-specific parameters:
 - **Size ratchet**: split at a seam. `RATCHET_RAISE=1` only when the added
   lines are the fix itself and no seam exists; never for tests, docs, or
   review-round additions.
-- **Review must converge** (orch SKILL.md): new defects at round 3 stop
-  per-comment patching. A round that is only scope, test-coverage, or
-  wording asks ends the review: reply, resolve, push nothing, merge through
-  the gate. Never `--admin`.
+- **Review must converge** (orch SKILL.md): a recurring defect class is
+  fixed at its source, never per comment. A round that is only scope,
+  test-coverage, or wording asks ends the review: reply, resolve, push
+  nothing, merge through the gate. Replies are `Fixed in <sha>`,
+  `Declined: <reason>`, or `Tracked: KEN-<n>` (issue created first — the
+  gate rejects a tracking claim naming no issue). Never `--admin`.
 - **Review the diff yourself** before submit — the actual root cause, not a
   plausible one. A stalled delegate: inspect its worktree, nudge once.
 - Coupled real defect found along the way → file it; fix it only if it is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,3 +15,21 @@ Rules the tooling cannot enforce:
 - The CHANGELOG is for consumers (Keep a Changelog): document app, CLI, and package changes; keep engine-internal and maintainer-only details out.
 
 `tools/guard` (the pre-commit hook) enforces the rest — read the script; it is the list.
+
+## Code Review Rules
+
+For automated reviewers (Codex code review, Copilot). Working agents: your
+reply contract is in the orch skill, not here.
+
+- Raise only defects in the changed lines or directly broken by them:
+  correctness, security, data loss, fail-open in gate/guard/CI code.
+- One comment per root cause, naming every affected site. Everything you
+  have about the diff goes in one round.
+- No style, wording, or naming preferences. No speculative hardening on
+  fail-closed paths. No test-coverage asks unless the diff changes behavior
+  no test exercises. Formatting and lint belong to CI, not review.
+- Do not re-raise a finding class answered `Declined: <reason>` on this PR
+  unless the relevant code changed since.
+- Author replies are `Fixed in <sha>`, `Declined: <reason>`, or
+  `Tracked: KEN-<n>` / `#<n>`; the merge gate rejects tracking claims that
+  name no issue.

--- a/kendex-reviews.toml
+++ b/kendex-reviews.toml
@@ -23,9 +23,9 @@ reason = "wrong-call"
 dismissed-at = "2026-08-24T01:55:54Z"
 
 [reviews."skill:review-gate"]
-review-hash = "fb15ec96b953c36e302f0ae90a48da90a7cc9fd199798709351469b95556f058"
+review-hash = "a19f7e03c9937af19968903effe6e1b9955dbc34217937f2582e23fa24e9d134"
 ruleset = 3
 
 [reviews."skill:review-gate".dismissed.b17398253c9f18fc]
 reason = "wrong-call"
-dismissed-at = "2026-08-24T01:49:13Z"
+dismissed-at = "2026-08-24T01:58:49Z"

--- a/kendex-reviews.toml
+++ b/kendex-reviews.toml
@@ -23,9 +23,9 @@ reason = "wrong-call"
 dismissed-at = "2026-08-24T01:55:54Z"
 
 [reviews."skill:review-gate"]
-review-hash = "30848419aaedc451aa2a8d1c693f1a455f4f1b7c24d4a8e27d0e03b301276cc2"
+review-hash = "4cc53bd126dcf7b633be31534c4047dfd3b55dd5fdeb79c3869d25c1368e2e9e"
 ruleset = 3
 
 [reviews."skill:review-gate".dismissed.b17398253c9f18fc]
 reason = "wrong-call"
-dismissed-at = "2026-08-24T02:10:06Z"
+dismissed-at = "2026-08-24T02:26:17Z"

--- a/kendex-reviews.toml
+++ b/kendex-reviews.toml
@@ -15,12 +15,12 @@ reason = "intended"
 dismissed-at = "2026-08-23T17:07:51Z"
 
 [reviews."skill:orch"]
-review-hash = "4e9a5e59f52ab921d4441b5591c881be53493f9e819085039055bd003db8ca97"
+review-hash = "8c2a85c6e5f65266e9e16598238abf3a1ade51f3f2cd693ffe422354b939ed95"
 ruleset = 3
 
 [reviews."skill:orch".dismissed.c8e66ac505c95a7a]
 reason = "wrong-call"
-dismissed-at = "2026-08-24T01:48:56Z"
+dismissed-at = "2026-08-24T01:55:54Z"
 
 [reviews."skill:review-gate"]
 review-hash = "fb15ec96b953c36e302f0ae90a48da90a7cc9fd199798709351469b95556f058"

--- a/kendex-reviews.toml
+++ b/kendex-reviews.toml
@@ -15,17 +15,17 @@ reason = "intended"
 dismissed-at = "2026-08-23T17:07:51Z"
 
 [reviews."skill:orch"]
-review-hash = "92f66a066af1d4d7455cb025003170acc5ad2219627c63dae544ebbf92c6bea1"
+review-hash = "4e9a5e59f52ab921d4441b5591c881be53493f9e819085039055bd003db8ca97"
 ruleset = 3
 
 [reviews."skill:orch".dismissed.c8e66ac505c95a7a]
 reason = "wrong-call"
-dismissed-at = "2026-08-24T00:41:25Z"
+dismissed-at = "2026-08-24T01:48:56Z"
 
 [reviews."skill:review-gate"]
-review-hash = "382704b971c779f9b48b7021e7865b4f67c4376138fcee4e76cbb15ca5da9dec"
+review-hash = "fb15ec96b953c36e302f0ae90a48da90a7cc9fd199798709351469b95556f058"
 ruleset = 3
 
 [reviews."skill:review-gate".dismissed.b17398253c9f18fc]
 reason = "wrong-call"
-dismissed-at = "2026-08-23T17:07:51Z"
+dismissed-at = "2026-08-24T01:49:13Z"

--- a/kendex-reviews.toml
+++ b/kendex-reviews.toml
@@ -23,9 +23,9 @@ reason = "wrong-call"
 dismissed-at = "2026-08-24T01:55:54Z"
 
 [reviews."skill:review-gate"]
-review-hash = "c0358e7d8f4a1edb35ed02b8d1d33c4f02c1d28e4f1226fa1d3a1915a897f9ea"
+review-hash = "30848419aaedc451aa2a8d1c693f1a455f4f1b7c24d4a8e27d0e03b301276cc2"
 ruleset = 3
 
 [reviews."skill:review-gate".dismissed.b17398253c9f18fc]
 reason = "wrong-call"
-dismissed-at = "2026-08-24T02:05:25Z"
+dismissed-at = "2026-08-24T02:10:06Z"

--- a/kendex-reviews.toml
+++ b/kendex-reviews.toml
@@ -23,9 +23,9 @@ reason = "wrong-call"
 dismissed-at = "2026-08-24T01:55:54Z"
 
 [reviews."skill:review-gate"]
-review-hash = "a19f7e03c9937af19968903effe6e1b9955dbc34217937f2582e23fa24e9d134"
+review-hash = "c0358e7d8f4a1edb35ed02b8d1d33c4f02c1d28e4f1226fa1d3a1915a897f9ea"
 ruleset = 3
 
 [reviews."skill:review-gate".dismissed.b17398253c9f18fc]
 reason = "wrong-call"
-dismissed-at = "2026-08-24T01:58:49Z"
+dismissed-at = "2026-08-24T02:05:25Z"

--- a/review-bots.md
+++ b/review-bots.md
@@ -1,0 +1,64 @@
+# Reviewer guidance for GitHub review bots
+
+Instructions for automated PR reviewers (Copilot code review, Codex, and
+any successor). This file is reviewer context only — agent sessions must
+not load it as working instructions (that is why it is not in `AGENTS.md`).
+
+## Review economics
+
+Every push triggers a full re-review by every bot, and PRs here are pushed
+at agent speed — long finding tails are expensive in rounds, not just
+tokens. Calibrate accordingly:
+
+- **Consolidate, don't drip.** Surface everything you have about the
+  current diff in ONE round. A finding you could have raised last round
+  but held back costs a full re-review cycle.
+- **Severity honesty.** Merge-blocking findings are: correctness bugs,
+  fail-open paths in gating/CI code, security holes, data loss. Wording
+  preferences, style nits, and speculative hardening on already-fail-closed
+  paths are suggestions — batch them, mark them non-blocking, or omit them
+  on late rounds.
+- **Do not re-raise declined findings.** When a finding was declined with
+  a documented rationale (a reply on the thread, a settings comment, an
+  engine header comment, or a note in `skills/review-gate/references/`),
+  do not raise the same finding class again on a later round unless the
+  relevant code changed. Repo rules cited by bots live in
+  `.github/instructions/` — check there before asserting a rule.
+
+## Accepted residual classes (decided — do not re-raise)
+
+These are known, deliberate trade-offs. Raising them again is noise:
+
+- **No cross-surface evidence ordering.** Nothing orders evidence *across*
+  the four surfaces (review objects, check runs, commit statuses, trusted
+  comments) — a finding that assumes one surface supersedes another asks
+  for a design that does not exist. Each surface's own resolution
+  semantics are specified in the predicate header
+  (`skills/review-gate/scripts/review-predicate.sh`) — check there before
+  asserting supersession behavior within a surface.
+
+- **Transient windows heal by convergence.** A state change landing
+  between two reads is corrected on the next convergence pass, at most
+  15 minutes later. Do not propose locks for these windows.
+- **A final docs-only push may keep earlier review evidence.** This is
+  deliberate; policy and instruction files are excluded and always get a
+  fresh review. Do not flag it as a gate hole.
+- **A gate success just before a push is not a fail-open.** The next
+  convergence supersedes it, and the merge queue re-checks at admission.
+- **Threads arriving after merge-queue admission are procedural, not a
+  gate defect.** The handling is dequeue → fix → re-arm.
+
+## Trust model (context, not a finding surface)
+
+Review evidence is formal review objects from trusted logins (or the other
+documented evidence forms in `skills/review-gate/references/settings.md`).
+Comment text, emoji reactions, and thumbs-ups are never approval — by
+design. Do not recommend parsing them.
+
+## Reply contract
+
+Author replies to findings are exactly `Fixed in <sha>`, `Declined: <reason>`,
+or `Tracked: <ISSUE-ID>` / `#<n>`. The merge gate turns red on a tracking
+claim naming no issue, so a decline without "tracked" wording is deliberate.
+Do not re-raise a finding class answered `Declined:` unless the relevant
+code changed since.

--- a/skills/orch/SKILL.md
+++ b/skills/orch/SKILL.md
@@ -29,7 +29,7 @@ Get the issue → dev implements → review → dev fixes blockers → re-review
 
 - **Bounded loops.** A fix round addresses blockers only; re-review narrows to the fix diff and the domains it touched; two consecutive rounds with no new blocker end the review.
 - **No edge-case churn.** A finding that cannot affect real usage is declined with a one-line reason — not fixed, not filed. File issues for critical follow-ups only.
-- **Review must converge.** New defects at round 3 stop per-comment patching: cut unrequired surface, fix the recurring class structurally, or split. A round whose only findings are scope, test-coverage, or wording asks ends the review: reply, resolve, push nothing, merge through the gate. Never `--admin`.
+- **Review must converge.** A defect class that recurs across rounds is fixed at its source — cut unrequired surface, fix the class structurally, or split — never patched per comment. A round whose only findings are scope, test-coverage, or wording asks ends the review: reply, resolve, push nothing, merge through the gate. Thread replies are exactly `Fixed in <sha>`, `Declined: <reason>`, or `Tracked: KEN-<n>` with the issue created first — the gate rejects a tracking claim naming no issue. Never `--admin`.
 - **Ask the user only about product or experience.** Scope expansion beyond the issue and revisiting a recorded decision always ask, whatever `ORCH_DECISION_MODE` says. Merge asks unless `ORCH_MERGE_AUTONOMY=auto`, which merges without asking only when every merge gate is green.
 - **Acceptance is artifact-based.** A round closes on a validated on-disk artifact plus git/tracker state, never on a return message.
 

--- a/skills/orch/workflows/review-pr-comments.md
+++ b/skills/orch/workflows/review-pr-comments.md
@@ -234,10 +234,13 @@ git -C "[WORKTREE_PATH]" push origin HEAD
 
 | Outcome | Reply body |
 |---------|------------|
-| Applied | `Applied in [COMMIT_SHA]: [SHORT_FIX_SUMMARY]` |
-| Skipped | `Acknowledged — [REASON]` |
-| Blocked → issue | `Tracking in [CREATED_ISSUE_ID]` |
+| Applied | `Fixed in [COMMIT_SHA]: [SHORT_FIX_SUMMARY]` |
+| Skipped / declined | `Declined: [REASON]` |
+| Blocked → issue | `Tracked: [CREATED_ISSUE_ID]` — the issue exists BEFORE the reply; the gate rejects a tracking claim naming no issue |
 | Already fixed | The finding's `draft_response` |
+
+The word "tracked" (any form) in a reply without a `KEN-` or `#` issue id
+turns the gate red (`untracked-claim`). A decline is a decline — say so.
 
 ```bash
 .agents/skills/github/scripts/github.sh post-reply "[THREAD_ID]" "[REPLY_BODY]" --pr "[PR_NUMBER]"

--- a/skills/orch/workflows/review-pr-comments.md
+++ b/skills/orch/workflows/review-pr-comments.md
@@ -287,10 +287,10 @@ A thread is new when its `threads[].id` is not in `known`. No new threads → §
 
 | Outcome | Response |
 |---------|----------|
-| Applied | `Applied in [SHA]` |
-| Skipped (decision) | `Acknowledged — contradicts [DECISION_ID]` |
-| Skipped (not actionable) | `Acknowledged — not actionable` |
-| Blocked or issue created | `Tracking in [ISSUE_ID]` |
+| Applied | `Fixed in [SHA]` |
+| Skipped (decision) | `Declined: contradicts [DECISION_ID]` |
+| Skipped (not actionable) | `Declined: not actionable` |
+| Blocked or issue created | `Tracked: [ISSUE_ID]` (issue exists first) |
 | Question | The finding's `draft_response` |
 
 Use inline `--body` only for plain strings; Markdown with backticks or fences goes to a file and `--body-file` (`post-reply` for threads, `post-comment` for PR-level). Number lists `1.` `2.` `3.`, never `#N`.

--- a/skills/orch/workflows/review-pr.md
+++ b/skills/orch/workflows/review-pr.md
@@ -272,7 +272,7 @@ Omit empty categories. Decline any item that cannot affect real usage with a one
 
 ### Fix Delegation
 
-At `cycles` >= 2 on the same diff (a new head resets the count), apply SKILL.md § Review must converge before delegating. Findings that leave `items` are never dropped: declined per [finding-disposition](../references/finding-disposition.md) when a cut removed their surface, recorded in `escalated_items` when a split moved them.
+When a defect class recurs across rounds on the same diff, apply SKILL.md § Review must converge before delegating. Findings that leave `items` are never dropped: declined per [finding-disposition](../references/finding-disposition.md) when a cut removed their surface, recorded in `escalated_items` when a split moved them.
 Never fix as the main agent.
 
 ```bash

--- a/skills/review-gate/scripts/pr-watch.sh
+++ b/skills/review-gate/scripts/pr-watch.sh
@@ -487,6 +487,11 @@ for number in $pr_numbers; do
   case "$verdict" in
     untracked-claim)
       emit "$number" "$head" untracked-claim "$detail$queued"
+      attention=1
+      if [ "$gate_state" = "success" ]; then
+        emit "$number" "$head" gate-stale "an unanchored tracking claim but the newest '$GATE_CONTEXT' row is success — the writer has not converged$queued"
+        heal "$number" "$head"
+      fi
       continue
       ;;
     threads-open)

--- a/skills/review-gate/scripts/pr-watch.sh
+++ b/skills/review-gate/scripts/pr-watch.sh
@@ -463,7 +463,7 @@ for number in $pr_numbers; do
     # The writer validates this same interface; an unknown or empty verdict
     # from a zero-exit predicate is a broken reducer, never a healthy PR.
     case "$verdict" in
-      approved|awaiting|threads-open|changes-requested) ;;
+      approved|awaiting|threads-open|changes-requested|untracked-claim) ;;
       *)
         emit "$number" "$head" error "predicate produced no recognizable verdict (broken output)"
         errored=1
@@ -485,6 +485,10 @@ for number in $pr_numbers; do
   read_gate_state "$number" "$head" || continue
 
   case "$verdict" in
+    untracked-claim)
+      emit "$number" "$head" untracked-claim "$detail$queued"
+      continue
+      ;;
     threads-open)
       # Already reported from the direct read — dedupe the predicate's
       # duplicate verdict. Before stopping, re-check the FRESH gate state:

--- a/skills/review-gate/scripts/review-predicate.sh
+++ b/skills/review-gate/scripts/review-predicate.sh
@@ -1079,7 +1079,7 @@ t_threads_page_jq='if ((.data.repository.pullRequest.reviewThreads.pageInfo.hasN
     + " " + ([.data.repository.pullRequest.reviewThreads.nodes[] | ((.comments.nodes // [])[]
         | select((.author.__typename // "User") != "Bot")
         | select((.body // "") | test("(?i)\\btrack(ed|ing|s)?\\b"))
-        | select(((.body // "") | test("[A-Z][A-Z0-9]+-[0-9]+|#[0-9]+")) | not))] | length | tostring)
+        | select(((.body // "") | test("([A-Z][A-Z0-9]+-[0-9]+|#[0-9]+)\\b")) | not))] | length | tostring)
     + " " + (.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage | tostring)
     + " " + (.data.repository.pullRequest.reviewThreads.pageInfo.endCursor // "END")
   end'

--- a/skills/review-gate/scripts/review-predicate.sh
+++ b/skills/review-gate/scripts/review-predicate.sh
@@ -1068,8 +1068,12 @@ if [ "$THREADS_MODE" = "enforce" ]; then
 # (an ABC-123 tracker id or #123): a tracking claim with nothing behind it is a false
 # disposition, and the gate is where it becomes visible. Bot comments are
 # exempt (they quote each other); a missing comments field reads as none.
+# A thread past 50 comments cannot be fully read in this page shape, so it
+# fails closed as malformed rather than approving a claim it never saw.
 t_threads_page_jq='if ((.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage | type) != "boolean")
     or ([.data.repository.pullRequest.reviewThreads.nodes[] | select((.isResolved | type) != "boolean")] | length) > 0
+  then "malformed"
+  elif ([.data.repository.pullRequest.reviewThreads.nodes[] | select(.comments.pageInfo.hasNextPage == true)] | length) > 0
   then "malformed"
   else ([.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length | tostring)
     + " " + ([.data.repository.pullRequest.reviewThreads.nodes[] | ((.comments.nodes // [])[]
@@ -1089,7 +1093,7 @@ while :; do
   fi
   if [ -n "$t_cursor" ]; then
     t_page="$(gh_read graphql \
-      -f query='query($owner:String!,$repo:String!,$number:Int!,$after:String){repository(owner:$owner,name:$repo){pullRequest(number:$number){reviewThreads(first:100,after:$after){pageInfo{hasNextPage endCursor} nodes{isResolved comments(first:50){nodes{body author{__typename}}}}}}}}' \
+      -f query='query($owner:String!,$repo:String!,$number:Int!,$after:String){repository(owner:$owner,name:$repo){pullRequest(number:$number){reviewThreads(first:100,after:$after){pageInfo{hasNextPage endCursor} nodes{isResolved comments(first:50){pageInfo{hasNextPage} nodes{body author{__typename}}}}}}}}' \
       -F owner="${GH_REPO%/*}" -F repo="${GH_REPO#*/}" -F number="$PR_NUMBER" -f after="$t_cursor" \
       --jq "$t_threads_page_jq")" || {
       echo "::error::could not read review threads" >&2
@@ -1097,7 +1101,7 @@ while :; do
     }
   else
     t_page="$(gh_read graphql \
-      -f query='query($owner:String!,$repo:String!,$number:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$number){reviewThreads(first:100){pageInfo{hasNextPage endCursor} nodes{isResolved comments(first:50){nodes{body author{__typename}}}}}}}}' \
+      -f query='query($owner:String!,$repo:String!,$number:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$number){reviewThreads(first:100){pageInfo{hasNextPage endCursor} nodes{isResolved comments(first:50){pageInfo{hasNextPage} nodes{body author{__typename}}}}}}}}' \
       -F owner="${GH_REPO%/*}" -F repo="${GH_REPO#*/}" -F number="$PR_NUMBER" \
       --jq "$t_threads_page_jq")" || {
       echo "::error::could not read review threads" >&2

--- a/skills/review-gate/scripts/review-predicate.sh
+++ b/skills/review-gate/scripts/review-predicate.sh
@@ -1149,12 +1149,12 @@ echo "PR #$PR_NUMBER head $HEAD_SHA: reviews=$got clean-analysis=$check comment-
 
 if [ "$cr" != "0" ]; then
   echo "verdict=changes-requested detail=standing review changes requested (persists across pushes until re-approval or dismissal)"
+elif [ "$untracked" != "0" ]; then
+  echo "verdict=untracked-claim detail=$untracked tracking claim(s) name no issue — write Declined: <reason>, or add the tracker/#id"
 elif [ "$got" = "0" ] && [ "$check" = "0" ] && [ "$comment_hits" = "0" ] && [ "$outageok" = "0" ] && [ "$carried" = "0" ]; then
   echo "verdict=awaiting detail=awaiting a non-author review for $HEAD_SHA"
 elif [ "$unresolved" != "0" ]; then
   echo "verdict=threads-open detail=$unresolved unresolved review thread(s)"
-elif [ "$untracked" != "0" ]; then
-  echo "verdict=untracked-claim detail=$untracked tracking claim(s) name no issue — write Declined: <reason>, or add the tracker/#id"
 elif [ "$carried" = "1" ]; then
   echo "verdict=approved detail=review evidence at $carry_base carried to head across a $carry_kind"
 elif [ "$outageok" != "0" ] && [ "$got" = "0" ] && [ "$check" = "0" ] && [ "$comment_hits" = "0" ]; then

--- a/skills/review-gate/scripts/review-predicate.sh
+++ b/skills/review-gate/scripts/review-predicate.sh
@@ -1065,7 +1065,7 @@ if [ "$THREADS_MODE" = "enforce" ]; then
 # fail-closed "overflow" posture still applies. Malformed nodes keep
 # failing closed per page exactly as before.
 # A human reply claiming a finding is "tracked" must name the tracker issue
-# (KEN-123 or #123): a tracking claim with nothing behind it is a false
+# (an ABC-123 tracker id or #123): a tracking claim with nothing behind it is a false
 # disposition, and the gate is where it becomes visible. Bot comments are
 # exempt (they quote each other); a missing comments field reads as none.
 t_threads_page_jq='if ((.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage | type) != "boolean")
@@ -1075,7 +1075,7 @@ t_threads_page_jq='if ((.data.repository.pullRequest.reviewThreads.pageInfo.hasN
     + " " + ([.data.repository.pullRequest.reviewThreads.nodes[] | ((.comments.nodes // [])[]
         | select((.author.__typename // "User") != "Bot")
         | select((.body // "") | test("(?i)\\btrack(ed|ing|s)?\\b"))
-        | select(((.body // "") | test("KEN-[0-9]+|#[0-9]+")) | not))] | length | tostring)
+        | select(((.body // "") | test("[A-Z][A-Z0-9]+-[0-9]+|#[0-9]+")) | not))] | length | tostring)
     + " " + (.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage | tostring)
     + " " + (.data.repository.pullRequest.reviewThreads.pageInfo.endCursor // "END")
   end'
@@ -1150,7 +1150,7 @@ elif [ "$got" = "0" ] && [ "$check" = "0" ] && [ "$comment_hits" = "0" ] && [ "$
 elif [ "$unresolved" != "0" ]; then
   echo "verdict=threads-open detail=$unresolved unresolved review thread(s)"
 elif [ "$untracked" != "0" ]; then
-  echo "verdict=untracked-claim detail=$untracked tracking claim(s) name no issue — write Declined: <reason>, or add the KEN-/#id"
+  echo "verdict=untracked-claim detail=$untracked tracking claim(s) name no issue — write Declined: <reason>, or add the tracker/#id"
 elif [ "$carried" = "1" ]; then
   echo "verdict=approved detail=review evidence at $carry_base carried to head across a $carry_kind"
 elif [ "$outageok" != "0" ] && [ "$got" = "0" ] && [ "$check" = "0" ] && [ "$comment_hits" = "0" ]; then

--- a/skills/review-gate/scripts/review-predicate.sh
+++ b/skills/review-gate/scripts/review-predicate.sh
@@ -1055,6 +1055,7 @@ fi
 # only the thread term is disabled; evidence and changes-requested still
 # fail closed exactly as before.
 unresolved=0
+untracked=0
 if [ "$THREADS_MODE" = "enforce" ]; then
 # Threads are counted across PAGES: long-lived PRs accumulate hundreds of
 # resolved threads, and failing closed at the first page's hasNextPage made
@@ -1063,10 +1064,18 @@ if [ "$THREADS_MODE" = "enforce" ]; then
 # past it, and on a truthy hasNextPage with no advancing cursor, the old
 # fail-closed "overflow" posture still applies. Malformed nodes keep
 # failing closed per page exactly as before.
+# A human reply claiming a finding is "tracked" must name the tracker issue
+# (KEN-123 or #123): a tracking claim with nothing behind it is a false
+# disposition, and the gate is where it becomes visible. Bot comments are
+# exempt (they quote each other); a missing comments field reads as none.
 t_threads_page_jq='if ((.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage | type) != "boolean")
     or ([.data.repository.pullRequest.reviewThreads.nodes[] | select((.isResolved | type) != "boolean")] | length) > 0
   then "malformed"
   else ([.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length | tostring)
+    + " " + ([.data.repository.pullRequest.reviewThreads.nodes[] | ((.comments.nodes // [])[]
+        | select((.author.__typename // "User") != "Bot")
+        | select((.body // "") | test("(?i)\\btrack(ed|ing|s)?\\b"))
+        | select(((.body // "") | test("KEN-[0-9]+|#[0-9]+")) | not))] | length | tostring)
     + " " + (.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage | tostring)
     + " " + (.data.repository.pullRequest.reviewThreads.pageInfo.endCursor // "END")
   end'
@@ -1080,7 +1089,7 @@ while :; do
   fi
   if [ -n "$t_cursor" ]; then
     t_page="$(gh_read graphql \
-      -f query='query($owner:String!,$repo:String!,$number:Int!,$after:String){repository(owner:$owner,name:$repo){pullRequest(number:$number){reviewThreads(first:100,after:$after){pageInfo{hasNextPage endCursor} nodes{isResolved}}}}}' \
+      -f query='query($owner:String!,$repo:String!,$number:Int!,$after:String){repository(owner:$owner,name:$repo){pullRequest(number:$number){reviewThreads(first:100,after:$after){pageInfo{hasNextPage endCursor} nodes{isResolved comments(first:50){nodes{body author{__typename}}}}}}}}' \
       -F owner="${GH_REPO%/*}" -F repo="${GH_REPO#*/}" -F number="$PR_NUMBER" -f after="$t_cursor" \
       --jq "$t_threads_page_jq")" || {
       echo "::error::could not read review threads" >&2
@@ -1088,7 +1097,7 @@ while :; do
     }
   else
     t_page="$(gh_read graphql \
-      -f query='query($owner:String!,$repo:String!,$number:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$number){reviewThreads(first:100){pageInfo{hasNextPage endCursor} nodes{isResolved}}}}}' \
+      -f query='query($owner:String!,$repo:String!,$number:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$number){reviewThreads(first:100){pageInfo{hasNextPage endCursor} nodes{isResolved comments(first:50){nodes{body author{__typename}}}}}}}}' \
       -F owner="${GH_REPO%/*}" -F repo="${GH_REPO#*/}" -F number="$PR_NUMBER" \
       --jq "$t_threads_page_jq")" || {
       echo "::error::could not read review threads" >&2
@@ -1108,15 +1117,18 @@ while :; do
   fi
   t_count="${t_page%% *}"
   t_rest="${t_page#* }"
+  t_claim="${t_rest%% *}"
+  t_rest="${t_rest#* }"
   t_next="${t_rest%% *}"
   t_cursor_next="${t_rest#* }"
-  case "$t_count" in
+  case "$t_count$t_claim" in
     '' | *[!0-9]*)
       unresolved="malformed"
       break
       ;;
   esac
   unresolved=$((unresolved + t_count))
+  untracked=$((untracked + t_claim))
   [ "$t_next" = "true" ] || break
   if [ "$t_cursor_next" = "END" ] || [ -z "$t_cursor_next" ] || [ "$t_cursor_next" = "$t_cursor" ]; then
     # hasNextPage with no ADVANCING cursor (missing, or identical to the
@@ -1129,7 +1141,7 @@ while :; do
 done
 fi
 
-echo "PR #$PR_NUMBER head $HEAD_SHA: reviews=$got clean-analysis=$check comment-form=$comment_hits outage-marker=$outageok carried=$carried changes-requested=$cr unresolved-threads=$unresolved (threads=$THREADS_MODE)" >&2
+echo "PR #$PR_NUMBER head $HEAD_SHA: reviews=$got clean-analysis=$check comment-form=$comment_hits outage-marker=$outageok carried=$carried changes-requested=$cr unresolved-threads=$unresolved untracked-claims=$untracked (threads=$THREADS_MODE)" >&2
 
 if [ "$cr" != "0" ]; then
   echo "verdict=changes-requested detail=standing review changes requested (persists across pushes until re-approval or dismissal)"
@@ -1137,6 +1149,8 @@ elif [ "$got" = "0" ] && [ "$check" = "0" ] && [ "$comment_hits" = "0" ] && [ "$
   echo "verdict=awaiting detail=awaiting a non-author review for $HEAD_SHA"
 elif [ "$unresolved" != "0" ]; then
   echo "verdict=threads-open detail=$unresolved unresolved review thread(s)"
+elif [ "$untracked" != "0" ]; then
+  echo "verdict=untracked-claim detail=$untracked tracking claim(s) name no issue — write Declined: <reason>, or add the KEN-/#id"
 elif [ "$carried" = "1" ]; then
   echo "verdict=approved detail=review evidence at $carry_base carried to head across a $carry_kind"
 elif [ "$outageok" != "0" ] && [ "$got" = "0" ] && [ "$check" = "0" ] && [ "$comment_hits" = "0" ]; then

--- a/skills/review-gate/scripts/review-writer.sh
+++ b/skills/review-gate/scripts/review-writer.sh
@@ -194,6 +194,7 @@ case "$verdict" in
   approved)              desired="success" ;;
   changes-requested)     desired="failure" ;;
   awaiting|threads-open) desired="pending" ;;
+  untracked-claim)       desired="failure" ;;
   *)
     echo "::error::unknown verdict '$verdict'"
     exit 1

--- a/skills/review-gate/tests/untracked-claim.test.sh
+++ b/skills/review-gate/tests/untracked-claim.test.sh
@@ -27,6 +27,9 @@ bot()   { printf '{"body":%s,"author":{"__typename":"Bot"}}'  "$(jq -Rn --arg b 
 out=$(page "$(thread true "$(human 'Out of scope for this PR, tracked.')")")
 case "$out" in "0 1 "*) ok "issue-less tracking claim counts";; *) bad "issue-less tracking claim counts" "$out";; esac
 
+out=$(page "$(thread true "$(human 'Tracked: KEN-12oops')"),$(thread true "$(human 'tracked in #34abc')")")
+case "$out" in "0 2 "*) ok "a malformed id does not anchor a claim";; *) bad "a malformed id does not anchor a claim" "$out";; esac
+
 out=$(page "$(thread true "$(human 'Tracked: KEN-536')"),$(thread true "$(human 'Tracked: DRV-12')"),$(thread true "$(human 'Fixed in abc123, tracked as #77')")")
 case "$out" in "0 0 "*) ok "claims naming KEN-/other-prefix/#id pass";; *) bad "claims naming KEN-/other-prefix/#id pass" "$out";; esac
 

--- a/skills/review-gate/tests/untracked-claim.test.sh
+++ b/skills/review-gate/tests/untracked-claim.test.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Behavioral coverage for the untracked-claim term: the predicate's thread
+# jq (extracted from the script, not restated) flags a human tracking claim
+# with no issue id, passes claims carrying any ABC-123 or #123 id, exempts
+# bot comments, and fails closed on a comments page it cannot finish.
+# The writer maps the verdict to a failure status.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PRED="$SCRIPT_DIR/../scripts/review-predicate.sh"
+WRITER="$SCRIPT_DIR/../scripts/review-writer.sh"
+PASS=0 FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ok    $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  FAIL  $1"; echo "        got: $2"; }
+
+prog="$(sed -n "/^t_threads_page_jq='/,/^  end'/p" "$PRED" | sed "s/^t_threads_page_jq='//; s/^  end'\$/  end/")"
+[ -n "$prog" ] || { echo "FAIL: could not extract t_threads_page_jq"; exit 1; }
+
+page() { # page RESOLVED_JSON…  -> jq output
+  jq -r "$prog" <<<"{\"data\":{\"repository\":{\"pullRequest\":{\"reviewThreads\":{\"pageInfo\":{\"hasNextPage\":false,\"endCursor\":null},\"nodes\":[$1]}}}}}"
+}
+thread() { # thread ISRESOLVED COMMENT_JSON… (comma-joined)
+  printf '{"isResolved":%s,"comments":{"pageInfo":{"hasNextPage":%s},"nodes":[%s]}}' "$1" "${3:-false}" "$2"
+}
+human() { printf '{"body":%s,"author":{"__typename":"User"}}' "$(jq -Rn --arg b "$1" '$b')"; }
+bot()   { printf '{"body":%s,"author":{"__typename":"Bot"}}'  "$(jq -Rn --arg b "$1" '$b')"; }
+
+out=$(page "$(thread true "$(human 'Out of scope for this PR, tracked.')")")
+case "$out" in "0 1 "*) ok "issue-less tracking claim counts";; *) bad "issue-less tracking claim counts" "$out";; esac
+
+out=$(page "$(thread true "$(human 'Tracked: KEN-536')"),$(thread true "$(human 'Tracked: DRV-12')"),$(thread true "$(human 'Fixed in abc123, tracked as #77')")")
+case "$out" in "0 0 "*) ok "claims naming KEN-/other-prefix/#id pass";; *) bad "claims naming KEN-/other-prefix/#id pass" "$out";; esac
+
+out=$(page "$(thread true "$(bot 'this should be tracked somewhere')")")
+case "$out" in "0 0 "*) ok "bot comments are exempt";; *) bad "bot comments are exempt" "$out";; esac
+
+out=$(page "$(thread true "$(human 'Declined: probe is intentional')")")
+case "$out" in "0 0 "*) ok "a decline is not a claim";; *) bad "a decline is not a claim" "$out";; esac
+
+out=$(page "$(thread false "$(human 'looking')")")
+case "$out" in "1 0 "*) ok "unresolved counting unchanged";; *) bad "unresolved counting unchanged" "$out";; esac
+
+out=$(page "$(thread true "$(human 'Tracked: KEN-1')" true)")
+case "$out" in malformed) ok "a 50+-comment thread fails closed as malformed";; *) bad "a 50+-comment thread fails closed as malformed" "$out";; esac
+
+grep -q 'untracked-claim)       desired="failure"' "$WRITER" \
+  && ok "writer maps untracked-claim to failure" \
+  || bad "writer maps untracked-claim to failure" "mapping line missing"
+grep -q 'untracked-claim' "$SCRIPT_DIR/../scripts/pr-watch.sh" \
+  && ok "pr-watch accepts and surfaces the verdict" \
+  || bad "pr-watch accepts and surfaces the verdict" "not referenced"
+
+echo "$PASS passed, $FAIL failed"
+[ "$FAIL" = 0 ] || exit 1

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -116,7 +116,7 @@ skills/orch/workflows/review-pr.md	452
 skills/preflight/scripts/preflight	1016
 skills/review-gate/scripts/pr-watch.sh	820
 skills/review-gate/scripts/review-predicate-selftest.sh	2607
-skills/review-gate/scripts/review-predicate.sh	1149
+skills/review-gate/scripts/review-predicate.sh	1163
 skills/review-gate/templates/review-gate-writer.yml	649
 skills/review-gate/tests/e2e-sandbox.sh	898
 skills/review-gate/tests/pr-watch.test.sh	1158

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -114,7 +114,7 @@ skills/orch/tests/oversee_watch.sh	814
 skills/orch/tests/queue_wait.sh	943
 skills/orch/workflows/review-pr.md	452
 skills/preflight/scripts/preflight	1016
-skills/review-gate/scripts/pr-watch.sh	824
+skills/review-gate/scripts/pr-watch.sh	829
 skills/review-gate/scripts/review-predicate-selftest.sh	2607
 skills/review-gate/scripts/review-predicate.sh	1167
 skills/review-gate/templates/review-gate-writer.yml	649

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -114,9 +114,9 @@ skills/orch/tests/oversee_watch.sh	814
 skills/orch/tests/queue_wait.sh	943
 skills/orch/workflows/review-pr.md	452
 skills/preflight/scripts/preflight	1016
-skills/review-gate/scripts/pr-watch.sh	820
+skills/review-gate/scripts/pr-watch.sh	824
 skills/review-gate/scripts/review-predicate-selftest.sh	2607
-skills/review-gate/scripts/review-predicate.sh	1163
+skills/review-gate/scripts/review-predicate.sh	1167
 skills/review-gate/templates/review-gate-writer.yml	649
 skills/review-gate/tests/e2e-sandbox.sh	898
 skills/review-gate/tests/pr-watch.test.sh	1158


### PR DESCRIPTION
Three changes from the owner's review-process decisions:

1. **Checkable dispositions.** The review gate now reads every thread reply on the head: a human comment containing "tracked" without a `KEN-` or `#` issue id turns the gate red (`verdict=untracked-claim`). Audit of #1605/#1607 found every "tracked" reply named no issue; they were really declines. The reply vocabulary is now exactly `Fixed in <sha>` / `Declined: <reason>` / `Tracked: KEN-<n>` (issue created first), stated in orch review-pr-comments.md, the convergence rule, and the steward skill.
2. **Reviewer-bot instructions existed nowhere.** Copilot reads `.github/copilot-instructions.md` (first 4,000 chars); Codex reads AGENTS.md `## Code Review Rules`. Both files now carry the calibration: diff-scoped defects only, one comment per root cause, everything in one round, no style/coverage nits, never re-raise a `Declined:` class on unchanged code.
3. **No round-count rule.** "New defects at round 3" is replaced by the source-based rule: a recurring defect class is fixed structurally, and a nits-only round ends the review — no counter, no blind push-through.

Predicate jq unit-checked (lying reply flagged; `tracked as KEN-536` and bot comments pass); all review-gate and orch suites green.

https://claude.ai/code/session_013EDioRsTBmsfaYeAah71hB