### PR TITLE
fix(guard): review debt from the auto-resolved rounds lands as fixes

### DIFF
--- a/.pi/prompts/gh-release.md
+++ b/.pi/prompts/gh-release.md
@@ -28,8 +28,8 @@ CHANGELOG's Unreleased section has an Added entry; major only when asked).
    crates/app/tauri.conf.json CHANGELOG.md`; push through the normal PR
    flow if branch protection requires it, else push `main`.
 5. Tag the MERGED commit, never the local branch: after the bump is on
-   `origin/main`, run `git checkout main && git pull --ff-only`, confirm
-   `git log -1` is the bump commit, then `git tag vX.Y.Z && git push
+   `origin/main`, run `git fetch origin`, confirm `git log -1 origin/main`
+   is the bump commit, then `git tag vX.Y.Z origin/main && git push
    origin vX.Y.Z`. The tag starts
    `.github/workflows/release.yml`, which builds every target and creates a
    **draft** release. Do not call `gh release create`.

--- a/.pi/prompts/gh-release.md
+++ b/.pi/prompts/gh-release.md
@@ -27,7 +27,10 @@ CHANGELOG's Unreleased section has an Added entry; major only when asked).
 4. Commit `chore(release): vX.Y.Z` with exactly `Cargo.toml Cargo.lock
    crates/app/tauri.conf.json CHANGELOG.md`; push through the normal PR
    flow if branch protection requires it, else push `main`.
-5. `git tag vX.Y.Z && git push origin vX.Y.Z`. The tag starts
+5. Tag the MERGED commit, never the local branch: after the bump is on
+   `origin/main`, run `git checkout main && git pull --ff-only`, confirm
+   `git log -1` is the bump commit, then `git tag vX.Y.Z && git push
+   origin vX.Y.Z`. The tag starts
    `.github/workflows/release.yml`, which builds every target and creates a
    **draft** release. Do not call `gh release create`.
 6. `gh run watch` the release workflow. When it finishes, `gh release view

--- a/.pi/prompts/npm-deploy.md
+++ b/.pi/prompts/npm-deploy.md
@@ -10,7 +10,7 @@ Find every `pi-extensions/*/package.json` package whose source/docs/package cont
 kendex distribution is independent of npm. `kendex add`/`refresh` copies local source — npm publishing only populates the pi.dev gallery and lets external users run `pi install npm:@vanillagreen/<name>`. Skipping a publish never breaks kendex consumers.
 
 ## Hard rules
-- Publish only from `main` equal to `origin/main` (`git fetch && git status -sb` shows no ahead/behind); never from a branch or a dirty tree.
+- Publish only from `main` equal to `origin/main` (`git fetch && git status -sb` shows no ahead/behind); never from a branch or a dirty tree. The version-bump commit is pushed before `npm publish` (step 5 under Version bump and publish) so the rule holds at publish time.
 - Publish only Pi extension packages that actually need a new npm version.
 - Use scoped npm names from `package.json` (normally `@vanillagreen/<name>`).
 - Per-package release tags use `<unscoped-name>-v<version>` (example: `pi-qol-v1.0.4`).
@@ -81,19 +81,25 @@ For each marked package that needs publishing:
    ```
 3. Stage only that package's `package.json` and any lockfile changed by `npm version`.
 4. Commit version bumps. Prefer a single coordinated commit if deploying multiple packages.
-5. Publish each package:
+5. Push `main` and confirm local `main` equals `origin/main` before publishing anything:
+   ```bash
+   git push origin main
+   git fetch origin && git status -sb
+   ```
+   Stop if `git status -sb` shows ahead/behind — the bump commit must be on `origin/main` first.
+6. Publish each package:
    ```bash
    cd pi-extensions/<dir>
    op run --env-file=../../.env.npm -- npm publish --userconfig=../../.npmrc
    cd ../..
    ```
-6. Verify npm reports the new version:
+7. Verify npm reports the new version:
    `npm view <name> version`.
-7. Create per-package git tags at the version-bump commit:
+8. Create per-package git tags at the version-bump commit:
    `git tag <unscoped-name>-v<version>`.
 
-## Push, refresh, verify
-1. Push `main` and all new package tags.
+## Push tags, refresh, verify
+1. Push all new package tags.
 2. Run:
    ```bash
    kendex refresh

--- a/.pi/prompts/npm-deploy.md
+++ b/.pi/prompts/npm-deploy.md
@@ -10,6 +10,7 @@ Find every `pi-extensions/*/package.json` package whose source/docs/package cont
 kendex distribution is independent of npm. `kendex add`/`refresh` copies local source — npm publishing only populates the pi.dev gallery and lets external users run `pi install npm:@vanillagreen/<name>`. Skipping a publish never breaks kendex consumers.
 
 ## Hard rules
+- Publish only from `main` equal to `origin/main` (`git fetch && git status -sb` shows no ahead/behind); never from a branch or a dirty tree.
 - Publish only Pi extension packages that actually need a new npm version.
 - Use scoped npm names from `package.json` (normally `@vanillagreen/<name>`).
 - Per-package release tags use `<unscoped-name>-v<version>` (example: `pi-qol-v1.0.4`).

--- a/kendex-reviews.toml
+++ b/kendex-reviews.toml
@@ -15,12 +15,12 @@ reason = "intended"
 dismissed-at = "2026-08-23T17:07:51Z"
 
 [reviews."skill:orch"]
-review-hash = "8c2a85c6e5f65266e9e16598238abf3a1ade51f3f2cd693ffe422354b939ed95"
+review-hash = "75187756e6647d3e8559317257a769e128c463028cf228144f90bdb25680d4ed"
 ruleset = 3
 
 [reviews."skill:orch".dismissed.c8e66ac505c95a7a]
 reason = "wrong-call"
-dismissed-at = "2026-08-24T01:55:54Z"
+dismissed-at = "2026-08-24T03:29:58Z"
 
 [reviews."skill:review-gate"]
 review-hash = "4cc53bd126dcf7b633be31534c4047dfd3b55dd5fdeb79c3869d25c1368e2e9e"

--- a/skills/orch/workflows/start-worktree.md
+++ b/skills/orch/workflows/start-worktree.md
@@ -32,7 +32,7 @@ The full session from inside a worktree: implement → review → submit → fin
    .agents/skills/worktree/scripts/worktree-session-guard claim [WORKTREE_PATH] --owner [ISSUE_ID]
    ```
 
-   Do **not** pass `--repo` (`claim` and `refresh` reject it). Exit 75 means another session holds the lease — coordinate with that owner instead of proceeding. Exit 1 with a `flock` message means the host has no `flock`: continue unguarded, but do not assume the tree is protected.
+   Do **not** pass `--repo` (`claim` and `refresh` reject it). Exit 75 means another session holds the lease — coordinate with that owner instead of proceeding. A flock-less host still serializes through the guard's mkdir mutex; exit 1 means the guard itself failed — stop and read its message, never continue unguarded.
 
 4. **Initialize state**:
 

--- a/tools/guard
+++ b/tools/guard
@@ -68,13 +68,14 @@ prose_hits() {
   local out status
   out=$(grep -nEi "$1" "$2")
   status=$?
-  [ "$status" -le 1 ] || { echo "guard: could not read $2"; exit 2; }
+  [ "$status" -le 1 ] || return 1
   printf '%s' "$out"
 }
 while IFS= read -r f; do
   [ -f "$f" ] || continue
-  hits=$(prose_hits "$prose_hist" "$f")
-  case "$f" in docs/*) : ;; *) hits+=$(printf '\n%s' "$(prose_hits "$prose_why" "$f" | grep -vE '["`]rationale["`]')") ;; esac # a quoted key is a schema field, not prose
+  hits=$(prose_hits "$prose_hist" "$f") || { say "$f is unreadable — the prose check could not run"; continue; }
+  case "$f" in docs/*) : ;; *) more=$(prose_hits "$prose_why" "$f") || { say "$f is unreadable — the prose check could not run"; continue; }
+    hits+=$(printf '\n%s' "$(printf '%s' "$more" | grep -vE '["`]rationale["`]')") ;; esac # a quoted key is a schema field, not prose
   hits=$(printf '%s' "$hits" | sed '/^$/d')
   [ -n "$hits" ] && say "$f carries history or rationale — state the rule, delete the story:
 $(printf '%s\n' "$hits" | head -5 | sed 's/^/  /')"
@@ -83,8 +84,10 @@ done <<<"$prose_files"
 # The size-ratchet baseline only tightens. Raising a row is a decision, not
 # a remedy: RATCHET_RAISE=1 on the commit says so out loud.
 if [ "${RATCHET_RAISE:-}" != "1" ] && git cat-file -e HEAD:tools/size-ratchet-baseline.tsv 2>/dev/null; then
-  raised=$(join -t "$(printf '\t')" <(git show HEAD:tools/size-ratchet-baseline.tsv | sort) <(sort tools/size-ratchet-baseline.tsv) |
-    awk -F'\t' '$3 > $2 { print "  " $1 ": " $2 " -> " $3 }')
+  raised=$({ join -t "$(printf '\t')" <(git show HEAD:tools/size-ratchet-baseline.tsv | sort) <(sort tools/size-ratchet-baseline.tsv) |
+    awk -F'\t' '$3 > $2 { print "  " $1 ": " $2 " -> " $3 }';
+    comm -13 <(git show HEAD:tools/size-ratchet-baseline.tsv | cut -f1 | sort) <(cut -f1 tools/size-ratchet-baseline.tsv | sort) |
+    sed 's/^/  new row: /'; })
   [ -n "$raised" ] && say "size-ratchet baseline rows went up — split at a seam; RATCHET_RAISE=1 only when the new lines are the fix itself:
 $raised"
 fi


### PR DESCRIPTION
Audit of the auto-resolved threads on #1601–#1604 found four real findings never acted on and one thrice-promised issue never filed. This PR pays it down:

- `tools/guard`: an unreadable instruction file now fails with its own message (the subshell `exit 2` was dead code); a brand-new baseline row now needs `RATCHET_RAISE=1` exactly like a raise.
- `start-worktree.md`: the flock-less recovery line contradicted the session guard's mkdir-mutex fallback — corrected to never advise continuing unguarded.
- `gh-release` prompt: tags the merged `origin/main` commit, never the local branch (the branch-protection path could tag the wrong commit).
- `npm-deploy` prompt: publishes only from synchronized main.
- KEN-546 filed: the guard test lane promised on #1601 (twice) and #1609.

https://claude.ai/code/session_013EDioRsTBmsfaYeAah71hB