### PR TITLE
fix(core): apply --replace-unmanaged holds back what it cannot settle (KEN-532)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -246,8 +246,9 @@ changes carry a **Breaking** call-out with their migration note inline.
   used to get "changed while you were deciding" and nothing replaced at
   all. Now every item that can be replaced is, and each held-back item is
   named with why its files stayed. The run fails only when nothing at all
-  could be replaced. Per-item choices in the app are unchanged: they still
-  act on the one row you clicked, whole or not at all.
+  could be replaced, and then says which items it held. Per-item choices
+  in the app are unchanged: they still act on the one row you clicked,
+  whole or not at all.
 
 - Codex now reads the same skill as every other tool. kendex used to cut any
   SKILL.md over 8 KB for Codex — a shortened body plus a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -240,6 +240,15 @@ changes carry a **Breaking** call-out with their migration note inline.
   research deferred as standalone work.
 
 ### Fixed
+- `kendex apply --replace-unmanaged` no longer gives up on the whole scope
+  because one item cannot be settled. A repo arriving on kendex with one
+  odd corner — say, a shortcut somebody set up where a skill installs —
+  used to get "changed while you were deciding" and nothing replaced at
+  all. Now every item that can be replaced is, and each held-back item is
+  named with why its files stayed. The run fails only when nothing at all
+  could be replaced. Per-item choices in the app are unchanged: they still
+  act on the one row you clicked, whole or not at all.
+
 - Codex now reads the same skill as every other tool. kendex used to cut any
   SKILL.md over 8 KB for Codex — a shortened body plus a
   `references/details.md` — on the strength of a limit Codex does not have,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -245,10 +245,12 @@ changes carry a **Breaking** call-out with their migration note inline.
   odd corner — say, a shortcut somebody set up where a skill installs —
   used to get "changed while you were deciding" and nothing replaced at
   all. Now every item that can be replaced is, and each held-back item is
-  named with why its files stayed. The run fails only when nothing at all
-  could be replaced, and then says which items it held. Per-item choices
-  in the app are unchanged: they still act on the one row you clicked,
-  whole or not at all.
+  named with the place that holds it. The run fails only when nothing at
+  all could be replaced, and then names those items and places. A skill
+  installed through links whose every tool is blocked at its link is
+  listed as those conflicts instead, and the run ends with nothing
+  replaced. Per-item choices in the app are unchanged: they still act on
+  the one row you clicked, whole or not at all.
 
 - Codex now reads the same skill as every other tool. kendex used to cut any
   SKILL.md over 8 KB for Codex — a shortened body plus a

--- a/crates/cli/src/commands/blocked.rs
+++ b/crates/cli/src/commands/blocked.rs
@@ -98,20 +98,19 @@ fn exits_under<'a>(env: &Env, rows: &[&'a DriftRow], row: &&'a DriftRow) -> Vec<
 /// — at column 0 it reads as a heading over the plan that follows, which is
 /// the plan that runs without it.
 ///
-/// The flag sweeps up the items it can take over and refuses the whole run
-/// over one it could only half settle, so every item it reaches has to be
-/// wholly replaceable and there has to be one. An unrelated item with no
-/// take-over of its own is never reached by it, and never a reason to
-/// withhold it.
+/// The flag sweeps up the items it can take over, replaces each one it can
+/// settle whole, holds back the ones it could only half settle, and
+/// refuses only when nothing settles — so one wholly replaceable item is
+/// reason enough to print it, and a held-back neighbour is no reason to
+/// withhold it. An unrelated item with no take-over of its own is never
+/// reached by it either way.
 fn say_scope_exit(rows: &[&DriftRow]) {
     let item_of =
         |row: &DriftRow, other: &DriftRow| other.kind == row.kind && other.name == row.name;
-    let swept: Vec<&&DriftRow> = rows
+    let replaceable = rows
         .iter()
         .filter(|row| row.cause.is_some_and(DriftCause::can_replace))
-        .collect();
-    let replaceable = !swept.is_empty()
-        && swept.iter().all(|row| {
+        .any(|row| {
             rows.iter()
                 .filter(|other| item_of(row, other) && other.dead_stop())
                 .all(|other| other.cause.is_some_and(DriftCause::can_replace))

--- a/crates/cli/tests/unmanaged_exits/refusals.rs
+++ b/crates/cli/tests/unmanaged_exits/refusals.rs
@@ -128,12 +128,14 @@ fn a_folder_that_is_not_a_skill_is_not_offered_the_keep() {
     assert_eq!(offer(&planned), "move them somewhere else first");
 }
 
-/// The scope-wide flag reaches every blocked item and refuses the whole run
-/// over one it could only half take over. Printed on the strength of a
-/// single replaceable item, it is a command guaranteed to fail.
+/// The scope-wide flag replaces every item it can take over whole and
+/// holds back one it could only half settle, naming it in the notes — it
+/// refuses only when nothing settles. So one wholly replaceable item makes
+/// the command worth typing, and a held-back neighbour is no reason to
+/// withhold it.
 #[test]
 #[allow(clippy::unwrap_used)]
-fn the_scope_wide_exit_is_not_printed_beside_an_item_it_would_refuse() {
+fn one_wholly_replaceable_item_is_reason_enough_for_the_scope_exit() {
     let tmp = tempfile::tempdir().unwrap();
     let home = tmp.path();
     let project = project_with(home, "[\"claude\", \"codex\"]", "copy");
@@ -166,8 +168,8 @@ fn the_scope_wide_exit_is_not_printed_beside_an_item_it_would_refuse() {
     let planned = plan(home, &project);
     assert!(planned.contains("conflict: skill lint"), "{planned}");
     assert!(
-        !planned.contains("--replace-unmanaged"),
-        "a command that would refuse the whole run was printed: {planned}"
+        planned.contains("--replace-unmanaged"),
+        "the exit the sweep would follow through on was withheld: {planned}"
     );
 }
 

--- a/crates/core/src/engine/item_plan.rs
+++ b/crates/core/src/engine/item_plan.rs
@@ -13,7 +13,8 @@ use super::config_edits::ConfigEditPlan;
 use super::desired::{Artifact, Desired};
 use super::file_plan::{plan_file, plan_written_file};
 use super::item_record::{registration, rendered_hash};
-use super::tree_plan::{Written, plan_tree};
+use super::tree_plan::plan_tree;
+use super::written::Written;
 use crate::configedit::ConfigEdit;
 
 /// Everything one pass over the desired items accumulates.

--- a/crates/core/src/engine/mod.rs
+++ b/crates/core/src/engine/mod.rs
@@ -50,6 +50,7 @@ mod takeover;
 mod targets;
 mod tree_plan;
 mod unmanaged;
+mod written;
 
 pub(crate) use desired_agent::contributes_to_agent;
 pub(crate) use gate::content_hash;
@@ -130,7 +131,7 @@ fn plan_scope_once(
     let mut drift = Vec::new();
     let mut ops: Vec<PlannedOp> = Vec::new();
     let mut new_lock = fresh_lock(manifest, lock, &state);
-    let mut written = tree_plan::Written::default();
+    let mut written = written::Written::default();
     let mut config_edits = config_edits::ConfigEditPlan::default();
 
     plan_manifest_write(env, scope, repo_moved, manifest, &state, &mut ops)?;

--- a/crates/core/src/engine/mod.rs
+++ b/crates/core/src/engine/mod.rs
@@ -73,6 +73,7 @@ pub fn installed_paths(
 }
 
 use desired::desired_state;
+pub use scope_writes::persists_manifest;
 use scope_writes::{
     plan_config_edits, plan_lock_write, plan_repo_move_write, plan_schema_upgrade,
     plan_settings_seed, source_revisions,
@@ -85,9 +86,22 @@ use unmanaged::unmanaged_rows;
 mod report_types;
 pub use report_types::{DriftCause, DriftRow, DriftState, EngineReport, ItemWarning, PlanOptions};
 
-/// Compute drift and the plan that would fix it, in one pass — the Audit
-/// page and `apply` both consume this.
+/// Compute drift and the plan that would fix it — the Audit page and
+/// `apply` both consume this.
 pub fn plan_scope(
+    env: &Env,
+    scope: &Scope,
+    manifest: &Manifest,
+    lock: &Lock,
+    options: &PlanOptions,
+) -> Result<EngineReport> {
+    let report = plan_scope_once(env, scope, manifest, lock, options)?;
+    takeover::hold_back_sweep(options, report, |sweep| {
+        plan_scope_once(env, scope, manifest, lock, sweep)
+    })
+}
+
+fn plan_scope_once(
     env: &Env,
     scope: &Scope,
     manifest: &Manifest,
@@ -283,18 +297,6 @@ fn plan_manifest_write(
         },
     });
     Ok(())
-}
-
-/// Whether a plan already persists the manifest — the full serialized
-/// write, or the repository move's surgical text edit. A caller about to
-/// insert its own save must count both: a second write to the same file
-/// binds to bytes the first one replaces and could never run.
-pub fn persists_manifest(ops: &[PlannedOp]) -> bool {
-    ops.iter().any(|op| {
-        matches!(op.op, Op::WriteManifest { .. })
-            || (op.description == crate::repo_move::MOVE_DESCRIPTION
-                && matches!(op.op, Op::WriteFile { .. }))
-    })
 }
 
 /// A scope still under the old product name renames first: everything

--- a/crates/core/src/engine/plan_pass.rs
+++ b/crates/core/src/engine/plan_pass.rs
@@ -13,7 +13,7 @@ use crate::model::Scope;
 use super::item_plan::plan_item;
 use super::{
     DriftCause, DriftRow, DriftState, PlanOptions, config_edits, desired, holds, item_plan,
-    removal, tree_plan,
+    removal, written,
 };
 
 /// One pass over the desired items, with the two holds that outrank
@@ -32,7 +32,7 @@ pub(super) fn plan_items(
     ops: &mut Vec<PlannedOp>,
     config_edits: &mut config_edits::ConfigEditPlan,
     new_lock: &mut Lock,
-    written: &mut tree_plan::Written,
+    written: &mut written::Written,
 ) -> Result<()> {
     for item in &state.items {
         let mut sink = item_plan::PlanSink {

--- a/crates/core/src/engine/report_types.rs
+++ b/crates/core/src/engine/report_types.rs
@@ -180,9 +180,10 @@ pub struct PlanOptions {
     /// each one moves to the trash and the declared render takes its
     /// place. The opposite direction from adopt, which keeps the files and
     /// rewrites the declaration around them. An item with a place the
-    /// replacement cannot settle — a foreign link, a source clash — is
-    /// held back whole and named in the notes; the plan fails only when
-    /// that holds back every item the sweep reached.
+    /// replacement cannot settle — a foreign link, a source clash — has
+    /// its take-over held back whole and is named in the notes, planned
+    /// otherwise as without the flag; the plan fails only when that holds
+    /// back every item the sweep reached.
     pub replace_unmanaged: bool,
     /// Replace them for these items only, by kind and name — leaving every
     /// other blocked declaration in the scope exactly as it is. The

--- a/crates/core/src/engine/report_types.rs
+++ b/crates/core/src/engine/report_types.rs
@@ -179,7 +179,10 @@ pub struct PlanOptions {
     /// installs. Off, they are a conflict and no write touches them; on,
     /// each one moves to the trash and the declared render takes its
     /// place. The opposite direction from adopt, which keeps the files and
-    /// rewrites the declaration around them.
+    /// rewrites the declaration around them. An item with a place the
+    /// replacement cannot settle — a foreign link, a source clash — is
+    /// held back whole and named in the notes; the plan fails only when
+    /// that holds back every item the sweep reached.
     pub replace_unmanaged: bool,
     /// Replace them for these items only, by kind and name — leaving every
     /// other blocked declaration in the scope exactly as it is. The

--- a/crates/core/src/engine/scope_writes.rs
+++ b/crates/core/src/engine/scope_writes.rs
@@ -15,6 +15,18 @@ use crate::source::SourceState;
 use super::desired::DesiredState;
 use super::{DriftRow, DriftState, config_edits};
 
+/// Whether a plan already persists the manifest — the full serialized
+/// write, or the repository move's surgical text edit. A caller about to
+/// insert its own save must count both: a second write to the same file
+/// binds to bytes the first one replaces and could never run.
+pub fn persists_manifest(ops: &[PlannedOp]) -> bool {
+    ops.iter().any(|op| {
+        matches!(op.op, Op::WriteManifest { .. })
+            || (op.description == crate::repo_move::MOVE_DESCRIPTION
+                && matches!(op.op, Op::WriteFile { .. }))
+    })
+}
+
 /// One mutation per config file, whatever asked for it — a single
 /// precondition can hold; per-edit preconditions against the same original
 /// bytes cannot.

--- a/crates/core/src/engine/takeover.rs
+++ b/crates/core/src/engine/takeover.rs
@@ -48,14 +48,14 @@ pub(crate) fn refuse_unsettled_takeover(
     Ok(())
 }
 
-/// An item the scope-wide sweep cannot settle whole is held back, never a
-/// reason to abort the scope: a repo with one odd item still needs the way
-/// out the flag is. The plan is rebuilt naming only the items that settle,
-/// so nothing staged for a held item survives as half a take-over — and a
-/// sweep that settles nothing at all refuses rather than reporting a
-/// success it did not have. Items a caller named individually are not
-/// exempted from the split: the named check above has already refused any
-/// of them a dead stop reaches.
+/// An item the scope-wide sweep cannot settle whole has its take-over held
+/// back, never a reason to abort the scope: a repo with one odd item still
+/// needs the way out the flag is. The plan is rebuilt naming only the items
+/// that settle, so nothing staged for a held item survives as half a
+/// take-over — and a sweep that settles nothing at all refuses, naming what
+/// it held, rather than reporting a success it did not have. Items a caller
+/// named individually are not exempted from the split: the named check
+/// above has already refused any of them a dead stop reaches.
 pub(crate) fn hold_back_sweep(
     options: &PlanOptions,
     report: super::EngineReport,
@@ -68,19 +68,25 @@ pub(crate) fn hold_back_sweep(
     if held.is_empty() {
         return Ok(report);
     }
+    let held: Vec<String> = held
+        .iter()
+        .map(|(kind, name)| format!("{} {name}", kind.name()))
+        .collect();
     if settled.is_empty() {
-        return Err(crate::error::CoreError::TakeOverAllHeld);
+        return Err(crate::error::CoreError::TakeOverAllHeld { held });
     }
+    // Only the take-over is held: the item is otherwise planned exactly as
+    // a run without the flag plans it, so one of its places with nothing
+    // in the way still gets its install.
     let sweep = PlanOptions {
         replace_unmanaged: false,
         replace_unmanaged_names: Some(settled),
         ..options.clone()
     };
     let mut report = replan(&sweep)?;
-    for (kind, name) in &held {
+    for item in &held {
         report.notes.push(format!(
-            "{} {name} was not replaced: another of its places has a conflict replacing cannot settle, so all its files stay where they are",
-            kind.name()
+            "{item} was not replaced: another of its places has a conflict replacing cannot settle, so the files in its way stay where they are"
         ));
     }
     Ok(report)

--- a/crates/core/src/engine/takeover.rs
+++ b/crates/core/src/engine/takeover.rs
@@ -68,12 +68,13 @@ pub(crate) fn hold_back_sweep(
     if held.is_empty() {
         return Ok(report);
     }
-    let held: Vec<String> = held
-        .iter()
-        .map(|(kind, name)| format!("{} {name}", kind.name()))
-        .collect();
     if settled.is_empty() {
-        return Err(crate::error::CoreError::TakeOverAllHeld { held });
+        return Err(crate::error::CoreError::TakeOverAllHeld {
+            held: held
+                .iter()
+                .map(|(item, why)| format!("{item} — {why}"))
+                .collect(),
+        });
     }
     // Only the take-over is held: the item is otherwise planned exactly as
     // a run without the flag plans it, so one of its places with nothing
@@ -84,34 +85,47 @@ pub(crate) fn hold_back_sweep(
         ..options.clone()
     };
     let mut report = replan(&sweep)?;
-    for item in &held {
+    for (item, why) in &held {
         report.notes.push(format!(
-            "{item} was not replaced: another of its places has a conflict replacing cannot settle, so the files in its way stay where they are"
+            "{item} was not replaced, so the files in its way stay where they are — {why}"
         ));
     }
     Ok(report)
 }
 
 /// The sweep's division of the items it swept up: the ones every row lets
-/// it settle whole, and the ones a dead-stop row beside the files blocks.
+/// it settle whole, and the ones a dead-stop row beside the files blocks —
+/// each held one carried with the place holding it, since under the flag
+/// that row is the only place the dead stop shows: without the flag the
+/// files in the way are refused before the place beside them is looked at.
 type Swept = Vec<(ItemKind, String)>;
-fn split_sweep(drift: &[DriftRow]) -> (Swept, Swept) {
-    let mut settled = Vec::new();
-    let mut held = Vec::new();
+fn split_sweep(drift: &[DriftRow]) -> (Swept, Vec<(String, String)>) {
+    let mut settled: Swept = Vec::new();
+    let mut held: Vec<(String, String)> = Vec::new();
     for row in drift
         .iter()
         .filter(|row| row.detail == super::file_plan::TAKEN_OVER)
     {
-        let item = (row.kind, row.name.clone());
-        let blocked = drift
+        let stop = drift
             .iter()
-            .any(|other| other.kind == row.kind && other.name == row.name && other.dead_stop());
-        let bucket = match blocked {
-            true => &mut held,
-            false => &mut settled,
+            .find(|other| other.kind == row.kind && other.name == row.name && other.dead_stop());
+        let Some(stop) = stop else {
+            let item = (row.kind, row.name.clone());
+            if !settled.contains(&item) {
+                settled.push(item);
+            }
+            continue;
         };
-        if !bucket.contains(&item) {
-            bucket.push(item);
+        let item = format!("{} {}", row.kind.name(), row.name);
+        if !held.iter().any(|(name, _)| *name == item) {
+            held.push((
+                item,
+                format!(
+                    "replacing cannot settle its conflict for {}: {}",
+                    stop.harness.display_name(),
+                    stop.detail
+                ),
+            ));
         }
     }
     (settled, held)

--- a/crates/core/src/engine/takeover.rs
+++ b/crates/core/src/engine/takeover.rs
@@ -1,5 +1,5 @@
-//! What a take-over named per item has to settle before the plan that
-//! carries it out is allowed to run.
+//! What a take-over has to settle before the plan that carries it out is
+//! allowed to run.
 
 use crate::model::ItemKind;
 
@@ -12,25 +12,20 @@ use super::{DriftRow, PlanOptions};
 /// The name has to reach something still in the way, and nothing of that
 /// item may be left in the way afterwards: half an item taken over leaves
 /// the rest blocked with the item no longer theirs.
+///
+/// Only the named form refuses here. The scope-wide sweep holds an
+/// unsettleable item back and replaces the rest (`hold_back_sweep`) —
+/// a refusal there would leave a scope with one odd item no way to take
+/// over any of the others.
 pub(crate) fn refuse_unsettled_takeover(
     options: &PlanOptions,
     drift: &[DriftRow],
 ) -> crate::error::Result<()> {
-    // The scope-wide flag answers for every item it reaches, so it owes
-    // each of them the same whole-item rule the per-item form does.
-    let scope_wide: Vec<(ItemKind, String)> = match options.replace_unmanaged {
-        true => drift
-            .iter()
-            .filter(|row| row.detail == super::file_plan::TAKEN_OVER)
-            .map(|row| (row.kind, row.name.clone()))
-            .collect(),
-        false => Vec::new(),
-    };
     let named = options
         .replace_unmanaged_names
         .as_deref()
         .unwrap_or_default();
-    for (kind, name) in named.iter().chain(scope_wide.iter()) {
+    for (kind, name) in named {
         let rows: Vec<&DriftRow> = drift
             .iter()
             .filter(|row| row.kind == *kind && &row.name == name)
@@ -42,15 +37,76 @@ pub(crate) fn refuse_unsettled_takeover(
         if rows.iter().any(|row| row.dead_stop()) {
             return Err(crate::error::CoreError::TakeOverLeavesSome { name: name.clone() });
         }
-        // A name the reader typed has to reach something; an item the
-        // scope-wide flag swept up was found by its take-over already.
-        if options.replace_unmanaged_names.is_some()
-            && !rows
-                .iter()
-                .any(|row| row.detail == super::file_plan::TAKEN_OVER)
+        // A name the reader typed has to reach something.
+        if !rows
+            .iter()
+            .any(|row| row.detail == super::file_plan::TAKEN_OVER)
         {
             return Err(crate::error::CoreError::TakeOverMatchesNothing { name: name.clone() });
         }
     }
     Ok(())
+}
+
+/// An item the scope-wide sweep cannot settle whole is held back, never a
+/// reason to abort the scope: a repo with one odd item still needs the way
+/// out the flag is. The plan is rebuilt naming only the items that settle,
+/// so nothing staged for a held item survives as half a take-over — and a
+/// sweep that settles nothing at all refuses rather than reporting a
+/// success it did not have. Items a caller named individually are not
+/// exempted from the split: the named check above has already refused any
+/// of them a dead stop reaches.
+pub(crate) fn hold_back_sweep(
+    options: &PlanOptions,
+    report: super::EngineReport,
+    replan: impl FnOnce(&PlanOptions) -> crate::error::Result<super::EngineReport>,
+) -> crate::error::Result<super::EngineReport> {
+    if !options.replace_unmanaged {
+        return Ok(report);
+    }
+    let (settled, held) = split_sweep(&report.drift);
+    if held.is_empty() {
+        return Ok(report);
+    }
+    if settled.is_empty() {
+        return Err(crate::error::CoreError::TakeOverAllHeld);
+    }
+    let sweep = PlanOptions {
+        replace_unmanaged: false,
+        replace_unmanaged_names: Some(settled),
+        ..options.clone()
+    };
+    let mut report = replan(&sweep)?;
+    for (kind, name) in &held {
+        report.notes.push(format!(
+            "{} {name} was not replaced: another of its places has a conflict replacing cannot settle, so all its files stay where they are",
+            kind.name()
+        ));
+    }
+    Ok(report)
+}
+
+/// The sweep's division of the items it swept up: the ones every row lets
+/// it settle whole, and the ones a dead-stop row beside the files blocks.
+type Swept = Vec<(ItemKind, String)>;
+fn split_sweep(drift: &[DriftRow]) -> (Swept, Swept) {
+    let mut settled = Vec::new();
+    let mut held = Vec::new();
+    for row in drift
+        .iter()
+        .filter(|row| row.detail == super::file_plan::TAKEN_OVER)
+    {
+        let item = (row.kind, row.name.clone());
+        let blocked = drift
+            .iter()
+            .any(|other| other.kind == row.kind && other.name == row.name && other.dead_stop());
+        let bucket = match blocked {
+            true => &mut held,
+            false => &mut settled,
+        };
+        if !bucket.contains(&item) {
+            bucket.push(item);
+        }
+    }
+    (settled, held)
 }

--- a/crates/core/src/engine/tree_plan.rs
+++ b/crates/core/src/engine/tree_plan.rs
@@ -11,6 +11,7 @@ use std::path::{Path, PathBuf};
 use super::desired::{Artifact, Desired, artifact_disk_hash};
 use super::file_plan::{TAKEN_OVER, set_aside};
 use super::item_plan::{Planned, unmanaged};
+use super::written::Written;
 use super::{DriftCause, DriftState};
 use crate::apply::{Op, PlannedOp, Pre};
 use crate::env::Env;
@@ -100,7 +101,7 @@ pub(super) fn plan_tree(
     let Some(link) = link else {
         return Ok(result);
     };
-    plan_link(
+    let linked = plan_link(
         env,
         item,
         link,
@@ -109,62 +110,17 @@ pub(super) fn plan_tree(
         owned,
         written,
         ops,
-        result,
-    )
-}
-
-/// Positions this pass has already planned a write for. Two harnesses can
-/// read one physical tree — and, where a global root is pointed at another
-/// tool's, one link — and planning the same write twice fails the second op
-/// and rolls the whole apply back.
-#[derive(Default)]
-pub(super) struct Written {
-    pub(super) canonicals: BTreeSet<PathBuf>,
-    links: BTreeSet<PathBuf>,
-    /// What the item being planned right now claimed. A refusal is reached
-    /// after the tree half has already claimed its position, and a claim
-    /// left standing for an item that plans nothing would silently drop the
-    /// next harness's install of the same tree.
-    claimed: Vec<Claimed>,
-}
-
-enum Claimed {
-    Canonical(PathBuf),
-    Link(PathBuf),
-}
-
-impl Written {
-    /// Start one item's pass. What it claims from here is undone together.
-    pub(super) fn start_item(&mut self) {
-        self.claimed.clear();
-    }
-
-    /// Take back everything the item just claimed — it plans nothing.
-    pub(super) fn undo_item(&mut self) {
-        for claimed in self.claimed.drain(..) {
-            match claimed {
-                Claimed::Canonical(path) => self.canonicals.remove(&path),
-                Claimed::Link(path) => self.links.remove(&path),
-            };
-        }
-    }
-
-    /// Whether this pass is the one that claims the position.
-    fn claim_canonical(&mut self, path: &Path) -> bool {
-        let first = self.canonicals.insert(path.to_path_buf());
-        if first {
-            self.claimed.push(Claimed::Canonical(path.to_path_buf()));
-        }
-        first
-    }
-
-    fn claim_link(&mut self, path: &Path) -> bool {
-        let first = self.links.insert(path.to_path_buf());
-        if first {
-            self.claimed.push(Claimed::Link(path.to_path_buf()));
-        }
-        first
-    }
+        &result,
+    )?;
+    // A take-over staged for the tree is what this item's row has to say:
+    // the sweep reads the row back to know which items it settled, and a
+    // link that merely is not connected yet must not hide the files going
+    // to the trash. A refusal at the link still wins — the item plans
+    // nothing then.
+    Ok(match (&result, &linked) {
+        (Planned::Drift(_, staged), Planned::Drift(..)) if staged == TAKEN_OVER => result,
+        _ => linked,
+    })
 }
 
 /// Files kendex did not write, where a tree goes. Adoption puts a folder
@@ -275,12 +231,12 @@ fn plan_link(
     owned: &BTreeSet<PathBuf>,
     written: &mut Written,
     ops: &mut Vec<PlannedOp>,
-    result: Planned,
+    result: &Planned,
 ) -> Result<Planned> {
     if link.is_symlink() {
         let points_to = std::fs::read_link(link).unwrap_or_default();
         if points_to == canonical {
-            return Ok(result);
+            return Ok(result.clone());
         }
         // A target that is the canonical tree under its pre-rename spelling
         // is our own: only kendex ever pointed links there, so the position

--- a/crates/core/src/engine/written.rs
+++ b/crates/core/src/engine/written.rs
@@ -1,0 +1,57 @@
+//! Positions one planning pass has already planned a write for. Two
+//! harnesses can read one physical tree — and, where a global root is
+//! pointed at another tool's, one link — and planning the same write twice
+//! fails the second op and rolls the whole apply back.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+#[derive(Default)]
+pub(super) struct Written {
+    pub(super) canonicals: BTreeSet<PathBuf>,
+    links: BTreeSet<PathBuf>,
+    /// What the item being planned right now claimed. A refusal is reached
+    /// after the tree half has already claimed its position, and a claim
+    /// left standing for an item that plans nothing would silently drop the
+    /// next harness's install of the same tree.
+    claimed: Vec<Claimed>,
+}
+
+enum Claimed {
+    Canonical(PathBuf),
+    Link(PathBuf),
+}
+
+impl Written {
+    /// Start one item's pass. What it claims from here is undone together.
+    pub(super) fn start_item(&mut self) {
+        self.claimed.clear();
+    }
+
+    /// Take back everything the item just claimed — it plans nothing.
+    pub(super) fn undo_item(&mut self) {
+        for claimed in self.claimed.drain(..) {
+            match claimed {
+                Claimed::Canonical(path) => self.canonicals.remove(&path),
+                Claimed::Link(path) => self.links.remove(&path),
+            };
+        }
+    }
+
+    /// Whether this pass is the one that claims the position.
+    pub(super) fn claim_canonical(&mut self, path: &Path) -> bool {
+        let first = self.canonicals.insert(path.to_path_buf());
+        if first {
+            self.claimed.push(Claimed::Canonical(path.to_path_buf()));
+        }
+        first
+    }
+
+    pub(super) fn claim_link(&mut self, path: &Path) -> bool {
+        let first = self.links.insert(path.to_path_buf());
+        if first {
+            self.claimed.push(Claimed::Link(path.to_path_buf()));
+        }
+        first
+    }
+}

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -110,8 +110,9 @@ pub enum CoreError {
     #[error("{name} changed while you were deciding — nothing was changed")]
     TakeOverLeavesSome { name: String },
 
-    #[error("nothing was replaced: every item in the way also has a conflict to settle first")]
-    TakeOverAllHeld,
+    /// Each held item as `kind name`: no plan survives to carry the notes.
+    #[error("nothing was replaced: every item in the way ({}) also has a conflict to settle first — kendex apply --plan lists them", held.join(", "))]
+    TakeOverAllHeld { held: Vec<String> },
 
     #[error(
         "{name}'s files are different for {first} and {second}. kendex keeps one copy of an item, so move the copy you don't want somewhere else first."

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -110,8 +110,8 @@ pub enum CoreError {
     #[error("{name} changed while you were deciding — nothing was changed")]
     TakeOverLeavesSome { name: String },
 
-    /// Each held item as `kind name`: no plan survives to carry the notes.
-    #[error("nothing was replaced: every item in the way ({}) also has a conflict to settle first — kendex apply --plan lists them", held.join(", "))]
+    /// Each held item as `kind name (why)`: no plan survives to carry the notes.
+    #[error("nothing was replaced: every item in the way also has a conflict to settle first — {}", held.join("; "))]
     TakeOverAllHeld { held: Vec<String> },
 
     #[error(

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -86,11 +86,9 @@ pub enum CoreError {
     // to put it. Two tools holding different files under one name is a
     // choice, not a merge: saying which to keep is the reader's, and
     // picking one for them would put the other in the trash unasked.
-    // A take-over named per item answers for that item whole. The page it
-    // was clicked on can be a minute old, and the apply that carries it out
-    // is the scope's whole plan — so a name that reaches nothing, or an
-    // item with a place the take-over cannot settle, stops the run rather
-    // than applying everything else for a question already gone.
+    // A take-over named per item answers for that item whole: a name that
+    // reaches nothing, or an item with a place the take-over cannot
+    // settle, stops the run rather than answering a question already gone.
     // Adoption takes what kendex did not write; a position it did write is
     // already looked after. Keeping it would move an installation into the
     // local source and rewrite the declaration around it, so a
@@ -111,6 +109,9 @@ pub enum CoreError {
 
     #[error("{name} changed while you were deciding — nothing was changed")]
     TakeOverLeavesSome { name: String },
+
+    #[error("nothing was replaced: every item in the way also has a conflict to settle first")]
+    TakeOverAllHeld,
 
     #[error(
         "{name}'s files are different for {first} and {second}. kendex keeps one copy of an item, so move the copy you don't want somewhere else first."

--- a/crates/core/tests/unmanaged_takeover/held_back.rs
+++ b/crates/core/tests/unmanaged_takeover/held_back.rs
@@ -1,13 +1,24 @@
 //! The scope-wide take-over on a mixed scope: an item with a place nothing
-//! can settle is held back whole, and every other item still gets its way
-//! out — one odd corner must not put the whole repo back where it started.
+//! can settle has its take-over held back whole, and every other item
+//! still gets its way out — one odd corner must not put the whole repo
+//! back where it started.
 
 use std::fs;
 
 use kendex_core::apply;
-use kendex_core::engine::{DriftState, plan_apply};
+use kendex_core::engine::{DriftState, PlanOptions, plan_apply};
+use kendex_core::error::CoreError;
+use kendex_core::model::ItemKind;
 
 use crate::{World, foreign_install, take_over, trashed, world};
+
+/// The app's per-row button: replace exactly this item, whole or not at all.
+fn named(kind: ItemKind, name: &str) -> PlanOptions {
+    PlanOptions {
+        replace_unmanaged_names: Some(vec![(kind, name.into())]),
+        ..PlanOptions::default()
+    }
+}
 
 /// deploy's second place: a link at a folder that is no skill at all —
 /// the conflict neither exit can settle, beside the files the take-over
@@ -22,28 +33,22 @@ fn dead_stop_second_place(w: &World) {
     std::os::unix::fs::symlink(&elsewhere, &position).unwrap();
 }
 
-/// Declare for two tools, keeping the copy method the fixture plans with.
+/// Declare for these tools, keeping the copy method the fixture plans with.
 #[allow(clippy::unwrap_used)]
-fn declare_both_tools(w: &World, skills: &str) {
+fn declare_tools(w: &World, harnesses: &str, skills: &str) {
     fs::write(
         w.home.join("app/kendex.toml"),
         format!(
-            "schema = 5\n\n[sources.cat]\npath = \"{}\"\n\n[install]\nharnesses = [\"claude\", \"codex\"]\nmethod = \"copy\"\n\n{skills}",
+            "schema = 5\n\n[sources.cat]\npath = \"{}\"\n\n[install]\nharnesses = {harnesses}\nmethod = \"copy\"\n\n{skills}",
             w.home.join("catalog").display()
         ),
     )
     .unwrap();
 }
 
-/// One item the sweep cannot settle must not take the way out from every
-/// other item: the flag exists for a repo full of files some earlier tool
-/// wrote, and such a repo arrives with the odd corner nothing can settle.
-/// The odd item is held back whole — half a take-over would leave the rest
-/// blocked with the files no longer theirs — and the plan says so.
-#[test]
+/// A second skill in the catalog, beside deploy.
 #[allow(clippy::unwrap_used)]
-fn a_dead_stop_on_one_item_holds_only_that_item_back() {
-    let w = world();
+fn lint_in_catalog(w: &World) {
     let lint = w.home.join("catalog/skills/lint");
     fs::create_dir_all(&lint).unwrap();
     fs::write(
@@ -51,10 +56,21 @@ fn a_dead_stop_on_one_item_holds_only_that_item_back() {
         "---\nname: lint\ndescription: tidy it\n---\nUpstream.\n",
     )
     .unwrap();
-    declare_both_tools(
-        &w,
-        "[skills.deploy]\nsource = \"cat\"\n\n[skills.lint]\nsource = \"cat\"\n",
-    );
+}
+
+const BOTH_SKILLS: &str = "[skills.deploy]\nsource = \"cat\"\n\n[skills.lint]\nsource = \"cat\"\n";
+
+/// One item the sweep cannot settle must not take the way out from every
+/// other item: the flag exists for a repo full of files some earlier tool
+/// wrote, and such a repo arrives with the odd corner nothing can settle.
+/// The odd item's take-over is held back whole — half of one would leave
+/// the rest blocked with the files no longer theirs — and the plan says so.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_dead_stop_on_one_item_holds_only_that_item_back() {
+    let w = world();
+    lint_in_catalog(&w);
+    declare_tools(&w, "[\"claude\", \"codex\"]", BOTH_SKILLS);
     for name in ["deploy", "lint"] {
         let dir = w.home.join(format!("app/.claude/skills/{name}"));
         fs::create_dir_all(&dir).unwrap();
@@ -96,26 +112,189 @@ fn a_dead_stop_on_one_item_holds_only_that_item_back() {
         report
             .notes
             .iter()
+            .any(|note| note.contains("skill deploy was not replaced")
+                && note.contains("the files in its way stay")),
+        "the plan does not say what it held back: {:?}",
+        report.notes
+    );
+}
+
+/// Held back is the take-over, not the item: a place of the held item
+/// with nothing in the way is installed exactly as a run without the flag
+/// would install it, while the files in its way stay put — so the note
+/// promises only that.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_held_item_s_empty_place_is_still_installed() {
+    let w = world();
+    lint_in_catalog(&w);
+    declare_tools(&w, "[\"claude\", \"codex\", \"opencode\"]", BOTH_SKILLS);
+    let dir = foreign_install(&w);
+    dead_stop_second_place(&w);
+    let lint = w.home.join("app/.agents/skills/lint");
+    fs::create_dir_all(&lint).unwrap();
+    fs::write(lint.join("SKILL.md"), "the tool that came before").unwrap();
+
+    let report = plan_apply(&w.env, &w.scope, &take_over()).unwrap();
+    apply::execute(&w.env, &report.plan, None).unwrap();
+
+    assert!(
+        fs::read_to_string(w.home.join("app/.opencode/skills/deploy/SKILL.md"))
+            .unwrap()
+            .contains("Upstream."),
+        "the held item's empty place was left empty"
+    );
+    assert!(
+        fs::read_to_string(dir.join("SKILL.md"))
+            .unwrap()
+            .contains("came before"),
+        "the files in the held item's way were replaced"
+    );
+    assert!(
+        report
+            .notes
+            .iter()
+            .any(|note| note.contains("skill deploy was not replaced")),
+        "{:?}",
+        report.notes
+    );
+}
+
+/// The same mixed scope in the linking layout. lint's take-over is staged
+/// on its canonical tree and its harness link is planned after it — the
+/// row the sweep reads must still say the item was swept, or the one
+/// settleable item goes unseen and the run refuses over deploy alone.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_linked_item_s_take_over_still_counts_as_settled() {
+    let w = world();
+    lint_in_catalog(&w);
+    for name in ["deploy", "lint"] {
+        let dir = w.home.join(format!("app/.agents/skills/{name}"));
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("SKILL.md"), "the tool that came before").unwrap();
+    }
+    fs::write(
+        w.home.join("app/kendex.toml"),
+        format!(
+            "schema = 5\n\n[sources.cat]\npath = \"{}\"\n\n[install]\nharnesses = [\"claude\"]\nmethod = \"symlink\"\n\n[skills.deploy]\nsource = \"cat\"\nharnesses = [\"claude\", \"codex\"]\n\n[skills.lint]\nsource = \"cat\"\n",
+            w.home.join("catalog").display()
+        ),
+    )
+    .unwrap();
+    // deploy's claude place: a link at a folder that is no skill at all.
+    let elsewhere = w.home.join("documents");
+    fs::create_dir_all(&elsewhere).unwrap();
+    fs::write(elsewhere.join("notes.txt"), "private").unwrap();
+    let link = w.home.join("app/.claude/skills/deploy");
+    fs::create_dir_all(link.parent().unwrap()).unwrap();
+    std::os::unix::fs::symlink(&elsewhere, &link).unwrap();
+
+    let report = plan_apply(&w.env, &w.scope, &take_over()).unwrap();
+    apply::execute(&w.env, &report.plan, None).unwrap();
+
+    assert!(
+        fs::read_to_string(w.home.join("app/.agents/skills/lint/SKILL.md"))
+            .unwrap()
+            .contains("Upstream."),
+        "the linked item's take-over was not carried out"
+    );
+    assert!(
+        w.home.join("app/.claude/skills/lint").is_symlink(),
+        "and its tool is connected to the tree"
+    );
+    assert_eq!(
+        fs::read_to_string(w.home.join("app/.agents/skills/deploy/SKILL.md")).unwrap(),
+        "the tool that came before",
+        "half of the held-back item was taken over"
+    );
+    assert!(link.is_symlink(), "the link is left exactly as it was");
+    assert!(
+        report
+            .notes
+            .iter()
             .any(|note| note.contains("deploy") && note.contains("not replaced")),
         "the plan does not say what it held back: {:?}",
         report.notes
     );
 }
 
+/// The button was clicked on an item one of whose places nothing can
+/// settle: replacing the rest would leave that place blocked with the
+/// item no longer its tool's, so the whole run refuses.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_named_take_over_with_an_unsettleable_place_refuses() {
+    let w = world();
+    declare_tools(
+        &w,
+        "[\"claude\", \"codex\"]",
+        "[skills.deploy]\nsource = \"cat\"\n",
+    );
+    let dir = foreign_install(&w);
+    dead_stop_second_place(&w);
+
+    let refused = plan_apply(&w.env, &w.scope, &named(ItemKind::Skill, "deploy"));
+    assert!(
+        matches!(
+            &refused,
+            Err(CoreError::TakeOverLeavesSome { name }) if name == "deploy"
+        ),
+        "half the item was approved: {refused:?}"
+    );
+    assert!(
+        fs::read_to_string(dir.join("SKILL.md"))
+            .unwrap()
+            .contains("came before"),
+        "and the files in the way stay where they are"
+    );
+}
+
+/// The page a click comes from can be a minute old. A name with nothing
+/// in the way any more answers a question already gone, and running the
+/// scope's whole apply for it would report a success nobody chose.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_name_that_reaches_nothing_refuses() {
+    let w = world();
+
+    let refused = plan_apply(&w.env, &w.scope, &named(ItemKind::Skill, "deploy"));
+    assert!(
+        matches!(
+            &refused,
+            Err(CoreError::TakeOverMatchesNothing { name }) if name == "deploy"
+        ),
+        "a stale choice was carried out: {refused:?}"
+    );
+}
+
 /// With nothing the sweep can settle, replacing nothing and reporting
-/// success would be a lie — the run refuses and changes nothing.
+/// success would be a lie — the run refuses, changes nothing, and names
+/// what it held: with no plan to carry the notes, the error is the only
+/// place the reader learns which items those were.
 #[test]
 #[allow(clippy::unwrap_used)]
 fn a_sweep_that_can_replace_nothing_refuses() {
     let w = world();
-    declare_both_tools(&w, "[skills.deploy]\nsource = \"cat\"\n");
+    declare_tools(
+        &w,
+        "[\"claude\", \"codex\"]",
+        "[skills.deploy]\nsource = \"cat\"\n",
+    );
     let dir = foreign_install(&w);
     dead_stop_second_place(&w);
 
     let refused = plan_apply(&w.env, &w.scope, &take_over());
+    let Err(error) = refused else {
+        panic!("a sweep with nothing to do did not say so: {refused:?}");
+    };
     assert!(
-        matches!(refused, Err(kendex_core::error::CoreError::TakeOverAllHeld)),
-        "a sweep with nothing to do did not say so: {refused:?}"
+        matches!(&error, CoreError::TakeOverAllHeld { held } if held == &["skill deploy"]),
+        "{error:?}"
+    );
+    assert!(
+        error.to_string().contains("skill deploy"),
+        "the refusal names no item: {error}"
     );
     assert!(
         fs::read_to_string(dir.join("SKILL.md"))

--- a/crates/core/tests/unmanaged_takeover/held_back.rs
+++ b/crates/core/tests/unmanaged_takeover/held_back.rs
@@ -219,6 +219,68 @@ fn a_linked_item_s_take_over_still_counts_as_settled() {
     );
 }
 
+/// Under the flag, the row that holds an item back is the only place its
+/// dead stop shows: without it the files in the way are refused before
+/// the link beside them is looked at. So the note, and the refusal when
+/// every item is held, carry the place that holds it — or the reader is
+/// sent round a loop with the cause named nowhere.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_held_item_is_named_with_the_place_that_holds_it() {
+    let w = world();
+    lint_in_catalog(&w);
+    for name in ["deploy", "lint"] {
+        let dir = w.home.join(format!("app/.agents/skills/{name}"));
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("SKILL.md"), "the tool that came before").unwrap();
+    }
+    let declare = |skills: &str| {
+        fs::write(
+            w.home.join("app/kendex.toml"),
+            format!(
+                "schema = 5\n\n[sources.cat]\npath = \"{}\"\n\n[install]\nharnesses = [\"claude\", \"codex\"]\nmethod = \"symlink\"\n\n{skills}",
+                w.home.join("catalog").display()
+            ),
+        )
+        .unwrap();
+    };
+    let elsewhere = w.home.join("documents");
+    fs::create_dir_all(&elsewhere).unwrap();
+    let link = w.home.join("app/.claude/skills/deploy");
+    fs::create_dir_all(link.parent().unwrap()).unwrap();
+    std::os::unix::fs::symlink(&elsewhere, &link).unwrap();
+    let names_the_link =
+        |text: &str| text.contains("Claude") && text.contains(".claude/skills/deploy");
+
+    declare(BOTH_SKILLS);
+    let report = plan_apply(&w.env, &w.scope, &take_over()).unwrap();
+    let note = report
+        .notes
+        .iter()
+        .find(|note| note.contains("skill deploy was not replaced"))
+        .unwrap_or_else(|| panic!("{:?}", report.notes));
+    assert!(
+        names_the_link(note),
+        "the note does not say what holds it: {note}"
+    );
+
+    declare("[skills.deploy]\nsource = \"cat\"\n");
+    let refused = plan_apply(&w.env, &w.scope, &take_over());
+    let Err(error) = refused else {
+        panic!("{refused:?}");
+    };
+    assert!(
+        matches!(&error, CoreError::TakeOverAllHeld { .. }),
+        "{error:?}"
+    );
+    let said = error.to_string();
+    assert!(
+        names_the_link(&said),
+        "the refusal does not say what holds it: {said}"
+    );
+    assert!(!said.contains("--plan"), "sent round the loop: {said}");
+}
+
 /// The button was clicked on an item one of whose places nothing can
 /// settle: replacing the rest would leave that place blocked with the
 /// item no longer its tool's, so the whole run refuses.
@@ -289,7 +351,7 @@ fn a_sweep_that_can_replace_nothing_refuses() {
         panic!("a sweep with nothing to do did not say so: {refused:?}");
     };
     assert!(
-        matches!(&error, CoreError::TakeOverAllHeld { held } if held == &["skill deploy"]),
+        matches!(&error, CoreError::TakeOverAllHeld { held } if held.len() == 1 && held[0].starts_with("skill deploy — ")),
         "{error:?}"
     );
     assert!(

--- a/crates/core/tests/unmanaged_takeover/held_back.rs
+++ b/crates/core/tests/unmanaged_takeover/held_back.rs
@@ -1,0 +1,126 @@
+//! The scope-wide take-over on a mixed scope: an item with a place nothing
+//! can settle is held back whole, and every other item still gets its way
+//! out — one odd corner must not put the whole repo back where it started.
+
+use std::fs;
+
+use kendex_core::apply;
+use kendex_core::engine::{DriftState, plan_apply};
+
+use crate::{World, foreign_install, take_over, trashed, world};
+
+/// deploy's second place: a link at a folder that is no skill at all —
+/// the conflict neither exit can settle, beside the files the take-over
+/// could otherwise replace.
+#[allow(clippy::unwrap_used)]
+fn dead_stop_second_place(w: &World) {
+    let elsewhere = w.home.join("documents");
+    fs::create_dir_all(&elsewhere).unwrap();
+    fs::write(elsewhere.join("notes.txt"), "private").unwrap();
+    let position = w.home.join("app/.agents/skills/deploy");
+    fs::create_dir_all(position.parent().unwrap()).unwrap();
+    std::os::unix::fs::symlink(&elsewhere, &position).unwrap();
+}
+
+/// Declare for two tools, keeping the copy method the fixture plans with.
+#[allow(clippy::unwrap_used)]
+fn declare_both_tools(w: &World, skills: &str) {
+    fs::write(
+        w.home.join("app/kendex.toml"),
+        format!(
+            "schema = 5\n\n[sources.cat]\npath = \"{}\"\n\n[install]\nharnesses = [\"claude\", \"codex\"]\nmethod = \"copy\"\n\n{skills}",
+            w.home.join("catalog").display()
+        ),
+    )
+    .unwrap();
+}
+
+/// One item the sweep cannot settle must not take the way out from every
+/// other item: the flag exists for a repo full of files some earlier tool
+/// wrote, and such a repo arrives with the odd corner nothing can settle.
+/// The odd item is held back whole — half a take-over would leave the rest
+/// blocked with the files no longer theirs — and the plan says so.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_dead_stop_on_one_item_holds_only_that_item_back() {
+    let w = world();
+    let lint = w.home.join("catalog/skills/lint");
+    fs::create_dir_all(&lint).unwrap();
+    fs::write(
+        lint.join("SKILL.md"),
+        "---\nname: lint\ndescription: tidy it\n---\nUpstream.\n",
+    )
+    .unwrap();
+    declare_both_tools(
+        &w,
+        "[skills.deploy]\nsource = \"cat\"\n\n[skills.lint]\nsource = \"cat\"\n",
+    );
+    for name in ["deploy", "lint"] {
+        let dir = w.home.join(format!("app/.claude/skills/{name}"));
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("SKILL.md"), "the tool that came before").unwrap();
+    }
+    dead_stop_second_place(&w);
+
+    let report = plan_apply(&w.env, &w.scope, &take_over()).unwrap();
+    apply::execute(&w.env, &report.plan, None).unwrap();
+
+    assert!(
+        fs::read_to_string(w.home.join("app/.claude/skills/lint/SKILL.md"))
+            .unwrap()
+            .contains("Upstream."),
+        "the item with nothing but files in the way was not replaced"
+    );
+    assert!(
+        trashed(&w.env.trash_dir()),
+        "the files that were in its way are recoverable"
+    );
+    assert_eq!(
+        fs::read_to_string(w.home.join("app/.claude/skills/deploy/SKILL.md")).unwrap(),
+        "the tool that came before",
+        "half of the held-back item was taken over"
+    );
+    assert!(
+        w.home.join("app/.agents/skills/deploy").is_symlink(),
+        "the link is left exactly as it was"
+    );
+    assert!(
+        report
+            .drift
+            .iter()
+            .any(|row| row.name == "deploy" && row.state == DriftState::Conflict),
+        "the held-back item no longer shows why it is blocked: {:?}",
+        report.drift
+    );
+    assert!(
+        report
+            .notes
+            .iter()
+            .any(|note| note.contains("deploy") && note.contains("not replaced")),
+        "the plan does not say what it held back: {:?}",
+        report.notes
+    );
+}
+
+/// With nothing the sweep can settle, replacing nothing and reporting
+/// success would be a lie — the run refuses and changes nothing.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_sweep_that_can_replace_nothing_refuses() {
+    let w = world();
+    declare_both_tools(&w, "[skills.deploy]\nsource = \"cat\"\n");
+    let dir = foreign_install(&w);
+    dead_stop_second_place(&w);
+
+    let refused = plan_apply(&w.env, &w.scope, &take_over());
+    assert!(
+        matches!(refused, Err(kendex_core::error::CoreError::TakeOverAllHeld)),
+        "a sweep with nothing to do did not say so: {refused:?}"
+    );
+    assert!(
+        fs::read_to_string(dir.join("SKILL.md"))
+            .unwrap()
+            .contains("came before"),
+        "and the files in the way stay where they are"
+    );
+}

--- a/crates/core/tests/unmanaged_takeover/main.rs
+++ b/crates/core/tests/unmanaged_takeover/main.rs
@@ -4,6 +4,8 @@
 //! kendex did not create is still never a clobber target (invariant 6).
 #![cfg(unix)]
 
+mod held_back;
+
 use std::fs;
 use std::path::{Path, PathBuf};
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -91,7 +91,11 @@ lives in one capability table read by core and UI.
      per-item `replace_unmanaged_names` a row's button carries) keeps the
      declaration and moves the files to the trash first, bound to the
      bytes the plan read. A link is never its target, nor is a position
-     any install recorded writing.
+     any install recorded writing. A take-over acts on an item whole or
+     not at all: named per item, a place nothing can settle refuses the
+     run; scope-wide, that item is held back whole and named in the notes
+     while every other item is replaced, and the sweep fails only when it
+     can replace nothing.
    The row states which files are in the way and which exits apply; the
    app offers them as buttons, the CLI names the verb and flag. A foreign
    link pointing at a real skill folder several tools read offers keeping

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -88,14 +88,14 @@ lives in one capability table read by core and UI.
      a tool's own position, and only for kinds it can take — not a folder
      where one file goes or vice versa.
    - **Take-over** (`replace_unmanaged` / `--replace-unmanaged`, or the
-     per-item `replace_unmanaged_names` a row's button carries) keeps the
-     declaration and moves the files to the trash first, bound to the
-     bytes the plan read. A link is never its target, nor is a position
-     any install recorded writing. A take-over acts on an item whole or
-     not at all: named per item, a place nothing can settle refuses the
-     run; scope-wide, its take-over is held back — the files in its way
-     stay, the rest of it plans as without the flag — and named in the
-     notes; the sweep fails, naming what it held, only when nothing settles.
+     per-item `replace_unmanaged_names`) keeps the declaration and moves
+     the files to the trash first, bound to the bytes the plan read. A
+     link is never its target, nor is a position any install recorded
+     writing. Whole or not at all: named per item, a place nothing can
+     settle refuses the run; scope-wide it is held back (the files in its
+     way stay) and named in the notes with the place holding it; the sweep
+     fails, naming those, only when nothing settles. One refused at every
+     link is not held: its rows stand, nothing replaced.
    The row states which files are in the way and which exits apply; the
    app offers them as buttons, the CLI names the verb and flag. A foreign
    link pointing at a real skill folder several tools read offers keeping

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -93,9 +93,9 @@ lives in one capability table read by core and UI.
      bytes the plan read. A link is never its target, nor is a position
      any install recorded writing. A take-over acts on an item whole or
      not at all: named per item, a place nothing can settle refuses the
-     run; scope-wide, that item is held back whole and named in the notes
-     while every other item is replaced, and the sweep fails only when it
-     can replace nothing.
+     run; scope-wide, its take-over is held back — the files in its way
+     stay, the rest of it plans as without the flag — and named in the
+     notes; the sweep fails, naming what it held, only when nothing settles.
    The row states which files are in the way and which exits apply; the
    app offers them as buttons, the CLI names the verb and flag. A foreign
    link pointing at a real skill folder several tools read offers keeping

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -1,7 +1,7 @@
 .github/workflows/review-gate-writer.yml	652
 crates/app/gen/schemas/desktop-schema.json	2590
 crates/app/gen/schemas/linux-schema.json	2590
-docs/ARCHITECTURE.md	879
+docs/ARCHITECTURE.md	883
 hooks/block-repo-copy.sh	511
 hooks/pre-commit-check.sh	423
 pi-extensions/pi-agents-tmux/extensions/subagent/browser.ts	650


### PR DESCRIPTION
## Summary
- `apply --replace-unmanaged` no longer aborts the whole scope on one dead-stop item: the sweep replaces every item it can settle, holds an unsettleable item back (its blocking files untouched, named in the plan's notes, conflict rows intact), and refuses only when nothing at all could be replaced — the refusal names each held item with the harness and conflict that holds it.
- The CLI's `--replace-unmanaged` hint now prints whenever at least one swept item is wholly replaceable (it was gated by the old all-or-nothing rule, hiding the way out in exactly the mixed scope this fixes).
- Review found and fixed a coupled defect: a symlink-method skill's take-over row was rewritten by the link pass, so a mixed sweep misclassified it — a take-over staged for the tree now outranks the link's drift row.
- The app's named per-item take-over keeps its strict whole-item refusal; those arms are now pinned by tests proven red against a disabling mutant.

Product note for the owner: a *rerun* of `apply --replace-unmanaged` after a successful partial sweep finds only the held item and exits non-zero (per the issue's "non-zero only when nothing could be applied"), so a scripted or habitual flag fails on every run until the dead stop is hand-fixed. Not a regression (the old code refused both runs); flagged, not changed.

Noted, not filed (refactor beyond scope): the CLI's `say_scope_exit` re-derives core's held/settled rule over drift rows instead of asking core; one shared predicate would keep the hint and the sweep from drifting apart.

Tracked: KEN-553 — in the symlink layout `plan_tree` returns before inspecting the harness link, so a link-position dead stop is in no row (the sweep can exit 0 replacing nothing; the hint can point at a refusing command). This PR carries the first-pass detail into the note and error so the cause is visible; the structural cure is KEN-553.

## Completed Issues
- Closes KEN-532 - apply --replace-unmanaged aborts the whole scope on one dead-stop item

## Test Plan
- `cargo test --workspace` green; unmanaged_takeover suite grew from 8 (mixed scope, all-held, held-item empty place, symlink-method settlement, two per-item refusals, held item named with the place that holds it) — each new test proven red first
- Full guard: fmt, clippy -D warnings, doc, workspace tests, tsc, biome, vitest, preflight, size-ratchet (ARCHITECTURE.md 879→883 for the four lines stating the rule; tree_plan.rs split at a seam into written.rs to stay under the cap)
